### PR TITLE
docs: align tmux and harness guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ $ claude   # launch your agent harness here; AGENTS.md takes over
 **Prerequisites** (the first mate detects everything else and offers to install it):
 
 ```sh
-# 1. an agent harness - claude code is the verified one today
+# 1. a verified agent harness - claude, codex, opencode, or pi
 # 2. git + GitHub auth
 # 3. tmux - the crew lives in tmux windows (firstmate offers to install it if missing)
 gh auth login

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ You talk to a single agent - the first mate - and it runs the crew for you: spaw
 There is no app to install; the whole orchestrator is an `AGENTS.md` file that any terminal coding agent can follow.
 
 - **One liaison** — you never talk to a worker agent. The first mate dispatches, supervises, escalates only real decisions, and reports when PRs are ready.
-- **A visible crew** — every crewmate lives in a tmux window in your session. Watch any of them work, or type into their window to intervene; the first mate reconciles.
+- **A visible crew** — every crewmate lives in a tmux window. Watch any of them work, or type into their window to intervene; the first mate reconciles.
 - **Guarded by construction** — the first mate is read-only over your projects; crewmates work in disposable [treehouse](https://github.com/kunchenguid/treehouse) worktrees and ship through the [no-mistakes](https://github.com/kunchenguid/no-mistakes) validation pipeline. Nothing lands without a PR you merge.
 
 This is not an agent harness. This is not a skill. This is not a CLI.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ There is no app to install; the whole orchestrator is an `AGENTS.md` file that a
 - **A visible crew** — every crewmate lives in a tmux window in your session. Watch any of them work, or type into their window to intervene; the first mate reconciles.
 - **Guarded by construction** — the first mate is read-only over your projects; crewmates work in disposable [treehouse](https://github.com/kunchenguid/treehouse) worktrees and ship through the [no-mistakes](https://github.com/kunchenguid/no-mistakes) validation pipeline. Nothing lands without a PR you merge.
 
+This is not an agent harness. This is not a skill. This is not a CLI.
+
+This is.. a directory that turns any agent into your firstmate, and you the captain.
+
 ## Quick Start
 
 ```sh
@@ -61,6 +65,7 @@ $ claude   # launch your agent harness here; AGENTS.md takes over
 ```sh
 # 1. an agent harness - claude code is the verified one today
 # 2. git + GitHub auth
+# 3. tmux - the crew lives in tmux windows (firstmate offers to install it if missing)
 gh auth login
 ```
 
@@ -73,6 +78,9 @@ cd firstmate && claude
 
 That is the whole install.
 On first launch the first mate detects what its toolchain is missing (tmux, treehouse, no-mistakes, gh-axi, chrome-devtools-axi, lavish-axi), lists it with the exact install commands, and installs only after you say go.
+
+**Run it inside tmux for the best experience.**
+firstmate works from any terminal - outside tmux, crewmates land in a detached `firstmate` session you can attach to - but launching your harness from inside tmux puts every crewmate window in your own session, one per task, where you can watch the crew work in real time or type into any window to intervene.
 
 ## How It Works
 
@@ -104,32 +112,38 @@ On first launch the first mate detects what its toolchain is missing (tmux, tree
 - **Event-driven supervision** — a zero-token bash watcher (`bin/fm-watch.sh`) sleeps on the fleet and wakes the first mate only when a crewmate reports, stalls, or a PR merges. An idle crew costs you nothing.
 - **Worktrees, not branches in your checkout** — crewmates never touch your clone; treehouse pools clean worktrees so parallel tasks on one repo cannot collide.
 - **Validation is non-negotiable** — every project gets `no-mistakes init`; every task ends with its pipeline. Human-judgment findings escalate to you through the first mate.
-- **Restart-proof** — all state lives in tmux, status files, and committed markdown. Kill the first mate session anytime; the next one reconciles and carries on.
+- **Restart-proof** — all state lives in tmux, status files, and local markdown under `data/`. Kill the first mate session anytime; the next one reconciles and carries on.
 
 ## The bin/ toolbelt
 
 The first mate drives these; you rarely need to, but they work by hand too.
 
-| Script           | Description                                                                 |
-| ---------------- | --------------------------------------------------------------------------- |
-| `fm-spawn.sh`    | Window → treehouse worktree → agent launched with its brief                 |
-| `fm-watch.sh`    | Block until a crewmate needs attention; exits with one reason line          |
-| `fm-send.sh`     | Send one literal line (or `--key Escape`) to a crewmate window              |
-| `fm-peek.sh`     | Print a bounded tail of a crewmate pane                                     |
-| `fm-teardown.sh` | Return the worktree and kill the window; refuses if work is not on a remote |
+| Script            | Description                                                                  |
+| ----------------- | ---------------------------------------------------------------------------- |
+| `fm-bootstrap.sh` | Detect missing toolchain pieces; install them only after consent             |
+| `fm-brief.sh`     | Scaffold a crewmate brief with the standard contract filled in               |
+| `fm-spawn.sh`     | Window → treehouse worktree → agent launched with its brief                  |
+| `fm-watch.sh`     | Block until a crewmate needs attention; exits with one reason line           |
+| `fm-send.sh`      | Send one literal line (or `--key Escape`) to a crewmate window               |
+| `fm-peek.sh`      | Print a bounded tail of a crewmate pane                                      |
+| `fm-pr-check.sh`  | Record a PR-ready task and arm the watcher's merge poll                      |
+| `fm-teardown.sh`  | Return the worktree and kill the window; refuses if work is not on a remote  |
+| `fm-harness.sh`   | Detect the running harness; resolve the effective crewmate harness           |
+| `fm-lock.sh`      | Single-firstmate session lock                                                |
 
 ## Configuration
 
 The orchestrator's behavior lives in `AGENTS.md` - edit it like any prompt.
-Harness support is a table in section 4 (claude is verified; codex/opencode/pi are stubs awaiting empirical verification).
+Harness support is a table in section 4: claude, codex, opencode, and pi are all empirically verified; new harnesses get verified through a supervised trial task before joining the table.
 
-Watcher tuning via environment variables:
+Watcher tuning via environment variables (defaults shown):
 
 ```sh
-FM_POLL=15          # seconds between watcher cycles
-FM_HEARTBEAT=600    # max seconds before a mandatory fleet review
-FM_CHECK_EVERY=20   # cycles between slow checks (merged-PR polls)
-FM_BUSY_REGEX='esc to interrupt'   # busy-pane signatures, extend per harness
+FM_POLL=15              # seconds between watcher cycles
+FM_HEARTBEAT=600        # base seconds between fleet reviews; backs off exponentially while idle
+FM_HEARTBEAT_MAX=7200   # heartbeat backoff cap
+FM_CHECK_INTERVAL=300   # seconds between slow checks (merged-PR polls)
+FM_BUSY_REGEX='esc (to )?interrupt|Working\.\.\.'   # busy-pane signatures, extend per harness
 ```
 
 ## Development

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -10,7 +10,7 @@ set -u
 FM_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 detect_own() {
-  # Layer 1: environment markers (claude VERIFIED; pi source-verified).
+  # Layer 1: environment markers for verified harnesses.
   [ "${CLAUDECODE:-}" = "1" ] && { echo claude; return; }
   [ "${PI_CODING_AGENT:-}" = "true" ] && { echo pi; return; }
   # Layer 2: walk the parent chain and match the command name.

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -11,7 +11,7 @@
 #                  turn-end signal rides the launch command, e.g. codex -c notify=[...])
 #     __PIEXT__    absolute path to state/<task-id>.pi-ext.ts (pi turn-end extension,
 #                  written by this script; outside the worktree to avoid pi's trust gate)
-# Per-harness turn-end hook files are installed into the worktree automatically.
+# Per-harness turn-end hooks are installed automatically; some live outside the worktree.
 # On success prints: spawned <id> harness=<name> window=<session:window> worktree=<path>
 set -eu
 

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -4,7 +4,7 @@
 #   signal: <file>        a crewmate wrote a status line or a turn-end hook fired
 #   stale: <window>       a crewmate pane stopped changing and shows no busy signature
 #   check: <script>: <out> a per-task check script (e.g. merged-PR poll) produced output
-#   heartbeat              nothing happened for FM_HEARTBEAT seconds; review the fleet
+#   heartbeat              fleet review due; starts at FM_HEARTBEAT and backs off to FM_HEARTBEAT_MAX
 # Run as a background task. Restart it after handling each wake.
 set -u
 


### PR DESCRIPTION
## Intent

README accuracy pass: state tmux as a prerequisite and recommend running firstmate inside tmux so the captain can watch crewmate windows; fix stale claims - all four harness adapters are now verified, watcher env vars match fm-watch.sh (FM_CHECK_INTERVAL replaced FM_CHECK_EVERY, heartbeat backs off exponentially to FM_HEARTBEAT_MAX, new busy-regex default), restart state is local not committed markdown, toolbelt table lists all ten scripts; also includes the captain's own manifesto paragraph edit

## What Changed
- Updates the README install and usage guidance to make tmux visibility explicit, recommend running firstmate inside tmux, and clarify restart state under local `data/`.
- Refreshes documented harness support, watcher environment variables, heartbeat behavior, busy signatures, and the full `bin/` toolbelt table.
- Aligns script comments with the verified harness and watcher behavior now described in the README.

## Risk Assessment

✅ Low: The change is limited to README documentation updates and aligns with the referenced scripts and AGENTS.md guidance, with no material merge-blocking risks found.

## Testing

Reviewed the README diff against the actual scripts, exercised the watcher heartbeat and `FM_CHECK_INTERVAL` slow-check paths end to end, asserted the README documents tmux guidance, verified harnesses, current watcher env vars, and all 10 `bin/` scripts, captured rendered README evidence, removed transient watcher state, and confirmed the worktree was clean afterward.

- Evidence: Rendered README screenshot showing tmux guidance, verified harnesses, toolbelt table, and watcher env vars (local file: <code>/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KTX01X6W39ETXRZJR6C61JB6/readme-render.png</code>)
<details>
<summary>Evidence: Rendered README evidence page</summary>

```text
<!doctype html><html><head><meta charset="utf-8"><title>firstmate README evidence</title><style>
body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;max-width:1040px;margin:0 auto;padding:36px;background:#f6f8fa;color:#24292f;line-height:1.55}.card{background:white;border:1px solid #d0d7de;border-radius:14px;padding:28px;margin:22px 0;box-shadow:0 8px 26px rgba(31,35,40,.06)}h1{text-align:center;margin:0 0 8px}h2{border-bottom:1px solid #d8dee4;padding-bottom:8px;margin-top:0}h3{margin-bottom:6px}.subtitle{text-align:center;color:#57606a}.banner{width:100%;border-radius:12px;margin:18px 0}.badge{display:inline-block;background:#0969da;color:white;border-radius:999px;padding:4px 10px;margin:3px;font-size:12px}code,pre{background:#f6f8fa;border-radius:6px}code{padding:2px 5px}pre{padding:14px;overflow:auto;border:1px solid #d0d7de}.bullet{padding-left:18px;position:relative}.bullet:before{content:'•';position:absolute;left:0}table{border-collapse:collapse;width:100%;font-size:14px}th,td{border:1px solid #d0d7de;padding:8px;text-align:left}th{background:#f6f8fa}.callout{border-left:4px solid #1a7f37;padding-left:14px;color:#1a7f37;font-weight:600}</style></head><body>
<h1>firstmate</h1><p class="subtitle">The only agent you need to talk to.</p><img class="banner" src="banner.jpg" alt="firstmate banner">
<div class="card"><span class="badge">tmux prerequisite</span><span class="badge">4 verified harnesses</span><span class="badge">watcher env vars current</span><span class="badge">10 toolbelt scripts</span><p>You can run one coding agent well.</p><p>But the moment you want three things done in parallel, you become a tab-juggler: babysitting sessions, copy-pasting context between repos, forgetting which terminal had the failing test.</p><p>firstmate flips the model.</p><p>You talk to a single agent - the first mate - and it runs the crew for you: spawning autonomous agents in tmux windows, giving each a clean git worktree, supervising them to completion, and handing you finished PRs to merge.</p><p>There is no app to install; the whole orchestrator is an <code>AGENTS.md</code> file that any terminal coding agent can follow.</p><p class="bullet"><strong>One liaison</strong> — you never talk to a worker agent. The first mate dispatches, supervises, escalates only real decisions, and reports when PRs are ready.</p><p class="bullet"><strong>A visible crew</strong> — every crewmate lives in a tmux window in your session. Watch any of them work, or type into their window to intervene; the first mate reconciles.</p><p class="bullet"><strong>Guarded by construction</strong> — the first mate is read-only over your projects; crewmates work in disposable <a href="https://github.com/kunchenguid/treehouse">treehouse</a> worktrees and ship through the <a href="https://github.com/kunchenguid/no-mistakes">no-mistakes</a> validation pipeline. Nothing lands without a PR you merge.</p><p>This is not an agent harness. This is not a skill. This is not a CLI.</p><p>This is.. a directory that turns any agent into your firstmate, and you the captain.</p></div>
<div class="card"><h2>Install</h2><p><strong>Prerequisites</strong> (the first mate detects everything else and offers to install it):</p><pre><code># 1. a verified agent harness - claude, codex, opencode, or pi
# 2. git + GitHub auth
# 3. tmux - the crew lives in tmux windows (firstmate offers to install it if missing)
gh auth login</code></pre><h3>Get firstmate:</h3><pre><code>git clone https://github.com/kunchenguid/firstmate
cd firstmate &amp;&amp; claude</code></pre><p>That is the whole install.</p><p>On first launch the first mate detects what its toolchain is missing (tmux, treehouse, no-mistakes, gh-axi, chrome-devtools-axi, lavish-axi), lists it with the exact install commands, and installs only after you say go.</p><h3>Run it inside tmux for the best experience.</h3><p>firstmate works from any terminal - outside tmux, crewmates land in a detached <code>firstmate</code> session you can attach to - but launching your harness from inside tmux puts every crewmate window in your own session, one per task, where you can watch the crew work in real time or type into any window to intervene.</p><p class="callout">Visual check: README now recommends launching inside tmux so crewmate windows are visible in the captain's own session.</p></div>
<div class="card"><h2>The bin/ toolbelt</h2><p>The first mate drives these; you rarely need to, but they work by hand too.</p><table><thead><tr><th>Script</th><th>Description</th></tr></thead><tbody><tr><td><code>fm-bootstrap.sh</code></td><td>Detect missing toolchain pieces; install them only after consent</td></tr><tr><td><code>fm-brief.sh</code></td><td>Scaffold a crewmate brief with the standard contract filled in</td></tr><tr><td><code>fm-spawn.sh</code></td><td>Window → treehouse worktree → agent launched with its brief</td></tr><tr><td><code>fm-watch.sh</code></td><td>Block until a crewmate needs attention; exits with one reason line</td></tr><tr><td><code>fm-send.sh</code></td><td>Send one literal line (or <code>--key Escape</code>) to a crewmate window</td></tr><tr><td><code>fm-peek.sh</code></td><td>Print a bounded tail of a crewmate pane</td></tr><tr><td><code>fm-pr-check.sh</code></td><td>Record a PR-ready task and arm the watcher's merge poll</td></tr><tr><td><code>fm-teardown.sh</code></td><td>Return the worktree and kill the window; refuses if work is not on a remote</td></tr><tr><td><code>fm-harness.sh</code></td><td>Detect the running harness; resolve the effective crewmate harness</td></tr><tr><td><code>fm-lock.sh</code></td><td>Single-firstmate session lock</td></tr></tbody></table></div>
<div class="card"><h2>Configuration</h2><p>The orchestrator's behavior lives in <code>AGENTS.md</code> - edit it like any prompt.</p><p>Harness support is a table in section 4: claude, codex, opencode, and pi are all empirically verified; new harnesses get verified through a supervised trial task before joining the table.</p><p>Watcher tuning via environment variables (defaults shown):</p><pre><code>FM_POLL=15              # seconds between watcher cycles
FM_HEARTBEAT=600        # base seconds between fleet reviews; backs off exponentially while idle
FM_HEARTBEAT_MAX=7200   # heartbeat backoff cap
FM_CHECK_INTERVAL=300   # seconds between slow checks (merged-PR polls)
FM_BUSY_REGEX='esc (to )?interrupt|Working\.\.\.'   # busy-pane signatures, extend per harness</code></pre></div>
</body></html>
```
</details>
<details>
<summary>Evidence: Watcher heartbeat smoke output</summary>

```text
heartbeat
```
</details>
<details>
<summary>Evidence: Watcher slow-check interval output</summary>

```text
check: /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KTX01X6W39ETXRZJR6C61JB6/state/no-mistakes-readme-test.check.sh: slow-check-ready
```
</details>
<details>
<summary>Evidence: README accuracy assertion output</summary>

```text
README accuracy assertions passed: tmux guidance, verified harnesses, watcher env vars, and all 10 bin scripts are documented.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `README.md:137` - The new statement that claude, codex, opencode, and pi are all verified conflicts with the Install prerequisite at line 66, which still says &#34;claude code is the verified one today&#34;. Update the prerequisite wording so the README does not give users contradictory harness support guidance.

🔧 Fix: Align README harness prerequisites
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --unified=80 f62d3e4776413043816990a6c11acfa46c8783dc..06dfd26dad0978361c46e44e15fab6603a93cb46 -- README.md`
- `FM_HEARTBEAT=0 FM_HEARTBEAT_MAX=2 FM_POLL=1 FM_CHECK_INTERVAL=999 bin/fm-watch.sh`
- `printf ... > state/no-mistakes-readme-test.check.sh && chmod +x state/no-mistakes-readme-test.check.sh && FM_HEARTBEAT=999 FM_POLL=1 FM_CHECK_INTERVAL=0 bin/fm-watch.sh`
- `node <<'NODE' ... README accuracy assertions ... NODE`
- `chrome-devtools-axi open file:///var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KTX01X6W39ETXRZJR6C61JB6/readme-render.html && chrome-devtools-axi screenshot /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KTX01X6W39ETXRZJR6C61JB6/readme-render.png`
- `rm -rf state`
- `git status --short`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
