### PR TITLE
fix(bin): coalesce watcher signals into one wake

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -284,7 +284,7 @@ bin/fm-watch.sh   # run in background; exits with: signal|stale|check|heartbeat
 On wake, in order of cheapness:
 
 1. Read the reason line.
-2. `signal:` read that status file first; it is ~30 tokens and usually sufficient.
+2. `signal:` read the listed status files first; a wake lists every signal that landed within the coalescing grace window (e.g. a status write plus the same turn's turn-end marker), and each is ~30 tokens and usually sufficient.
 3. `stale:` the crewmate stopped without reporting; peek the pane (`bin/fm-peek.sh <window>`) to diagnose.
 4. `check:` a per-task poll fired (usually a merge); act on it.
 5. `heartbeat:` review the whole fleet: skim each window's status file, peek panes that look off, check PR-ready tasks for merge, reconcile data/backlog.md, then restart the watcher.

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ FM_POLL=15              # seconds between watcher cycles
 FM_HEARTBEAT=600        # base seconds between fleet reviews; backs off exponentially while idle
 FM_HEARTBEAT_MAX=7200   # heartbeat backoff cap
 FM_CHECK_INTERVAL=300   # seconds between slow checks (merged-PR polls)
+FM_SIGNAL_GRACE=30      # seconds to coalesce nearby status and turn-end signals into one wake
 FM_BUSY_REGEX='esc (to )?interrupt|Working\.\.\.'   # busy-pane signatures, extend per harness
 ```
 

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # Firstmate watcher.
 # Blocks until any managed crewmate needs attention, then exits printing one reason line:
-#   signal: <file>        a crewmate wrote a status line or a turn-end hook fired
+#   signal: <file>...     a crewmate wrote a status line or a turn-end hook fired; signals
+#                         landing within FM_SIGNAL_GRACE of each other coalesce into one wake
 #   stale: <window>       a crewmate pane stopped changing and shows no busy signature
 #   check: <script>: <out> a per-task check script (e.g. merged-PR poll) produced output
 #   heartbeat              fleet review due; starts at FM_HEARTBEAT and backs off to FM_HEARTBEAT_MAX
@@ -16,6 +17,9 @@ POLL=${FM_POLL:-15}                   # seconds between cycles
 HEARTBEAT=${FM_HEARTBEAT:-600}        # base seconds between heartbeat wakes
 HEARTBEAT_MAX=${FM_HEARTBEAT_MAX:-7200}  # heartbeat backoff cap
 CHECK_INTERVAL=${FM_CHECK_INTERVAL:-300}  # seconds between *.check.sh sweeps
+SIGNAL_GRACE=${FM_SIGNAL_GRACE:-30}   # seconds to linger after a signal so trailing
+                                      # signals (a status write, then the same turn's
+                                      # turn-end hook) coalesce into one wake
 # Busy signatures per harness, OR-ed. Extend via env when new adapters are verified.
 # claude/codex: "esc to interrupt"; opencode: "esc interrupt"; pi: "Working..."
 BUSY_REGEX=${FM_BUSY_REGEX:-'esc (to )?interrupt|Working\.\.\.'}
@@ -47,21 +51,46 @@ age_of() {  # seconds since file mtime; "due immediately" if missing
 
 [ -e "$STATE/.last-heartbeat" ] || touch "$STATE/.last-heartbeat"
 
-while :; do
-  # Layer 2 + 3 signals: status files and turn-end markers. Each file is
-  # compared against a persisted size:mtime signature (.seen-*) rather than
-  # mtime-vs-a-startup-touch, so signals that land while no watcher is running
-  # are caught by the next one, and same-second writes cannot slip through a
-  # strict -nt comparison.
+# Layer 2 + 3 signal scan: status files and turn-end markers. Each file is
+# compared against a persisted size:mtime signature (.seen-*) rather than
+# mtime-vs-a-startup-touch, so signals that land while no watcher is running
+# are caught by the next one, and same-second writes cannot slip through a
+# strict -nt comparison. Pure read: prints one "<seen-file>\t<sig>\t<file>"
+# line per changed file; .seen-* is updated only when a wake is reported, so
+# a watcher killed mid-cycle never swallows a signal.
+scan_signals() {
+  local f sig sf
   for f in "$STATE"/*.status "$STATE"/*.turn-ended; do
     [ -e "$f" ] || continue
     sig=$(stat -f '%z:%Fm' "$f" 2>/dev/null || stat -c '%s:%Y' "$f" 2>/dev/null) || continue
     sf="$STATE/.seen-$(basename "$f" | tr '.' '_')"
     if [ "$sig" != "$(cat "$sf" 2>/dev/null)" ]; then
-      printf '%s' "$sig" > "$sf"
-      wake "signal: $f"
+      printf '%s\t%s\t%s\n' "$sf" "$sig" "$f"
     fi
   done
+  return 0
+}
+
+while :; do
+  # On the first changed signal, linger one grace period and re-scan before
+  # waking: a crewmate's final status write and the same turn's turn-end hook
+  # land seconds apart, and reporting them as separate wakes costs a full
+  # firstmate turn each. The re-scan also picks up a newer signature for an
+  # already-pending file (last write wins below).
+  pending=$(scan_signals)
+  if [ -n "$pending" ]; then
+    sleep "$SIGNAL_GRACE"
+    pending=$(printf '%s\n%s' "$pending" "$(scan_signals)")
+    files=""
+    while IFS=$(printf '\t') read -r sf sig f; do
+      [ -n "$sf" ] || continue
+      printf '%s' "$sig" > "$sf"
+      case " $files " in *" $f "*) ;; *) files="$files $f" ;; esac
+    done <<EOF
+$pending
+EOF
+    wake "signal:$files"
+  fi
 
   # Layer 1 backbone: pane staleness. Two consecutive identical hashes with no busy
   # signature means the crewmate finished, is waiting, or is wedged. Each distinct


### PR DESCRIPTION
## Intent

The firstmate watcher (bin/fm-watch.sh) produced duplicate wakes: a crewmate's final status-file write and the same turn's turn-end hook land seconds apart (observed 15s), and since the watcher exits on the first changed signal file and is restarted between wakes, one logical event (crewmate finished its turn) cost two full firstmate turns. The user asked to patch this duplicate-signal behavior. Change: the signal scan is now a pure read collecting all changed files; on the first detection the watcher lingers FM_SIGNAL_GRACE (default 30s, deliberately chosen to cover the observed 15s status-to-turn-end gap), re-scans, dedupes by file, and reports everything in one 'signal: <file>...' wake line. Seen-signatures are deliberately written only at wake time now, so a watcher killed mid-grace cannot mark a signal seen without reporting it (the old code wrote seen before waking). AGENTS.md section 8 wording updated to match the multi-file wake format. Single-signal wake format is unchanged ('signal: <file>'), keeping existing wake-handling instructions valid. Tested end-to-end in a sandbox: coalescing of two signals 3s apart into one wake, no duplicate wake after restart, and solo-signal wake all verified. The added wake latency (one grace period) is an accepted tradeoff; crewmate tasks run minutes to hours.

## What Changed
- Updated `bin/fm-watch.sh` to collect changed signal files, wait through a configurable `FM_SIGNAL_GRACE` window, and emit one deduped `signal: <file>...` wake for near-simultaneous status and turn-end signals.
- Delayed writing seen-signal markers until the coalesced wake is reported, so watcher restarts during the grace period do not silently consume pending signals.
- Documented the multi-file signal wake behavior in `AGENTS.md` and noted the default signal grace window in `README.md`.

## Risk Assessment

✅ Low: The change is narrowly scoped to watcher signal coalescing and documentation, preserves the single-signal output shape, and I found no material correctness or operational risks in the changed code.

## Testing

Exercised the actual `bin/fm-watch.sh` end-to-end with synthetic watcher state: coalesced status plus turn-end signals, verified no duplicate wake after restart, verified kill-during-grace does not swallow a signal, verified solo-signal output shape, captured a transcript artifact, and removed transient in-worktree state afterward.

<details>
<summary>Evidence: fm-watch coalescing transcript</summary>

`Shows one wake containing both coalesced signal files, no duplicate wake after restart, preserved pending signal after kill during grace, and unchanged solo-signal wake format.`

```text
fm-watch signal coalescing end-to-end transcript
worktree: /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KTX4RWRT72G8HZECAEST4FR8
test isolation: PATH prepends fake tmux returning no fm-* windows, avoiding unrelated stale wakes from live sessions.

Scenario 1: status write and turn-end marker 1s apart coalesce into one wake.
wake: signal: /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KTX4RWRT72G8HZECAEST4FR8/state/demo.status /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KTX4RWRT72G8HZECAEST4FR8/state/demo.turn-ended 
result: PASS - one wake contained both changed signal files.

Scenario 2: restarting after the coalesced wake does not produce a duplicate signal wake.
wake: <none within 3s>
result: PASS - seen signatures suppressed duplicate wake after restart.

Scenario 3: a watcher killed during the grace period does not mark a signal seen before reporting it.
wake after restart: signal: /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KTX4RWRT72G8HZECAEST4FR8/state/grace.status 
result: PASS - killed watcher did not swallow the pending signal.

Scenario 4: a solo status signal keeps the original single-file wake shape.
wake: signal: /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KTX4RWRT72G8HZECAEST4FR8/state/solo.status 
result: PASS - solo signal reported as one signal wake with one file.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`FM_SIGNAL_GRACE=2 FM_POLL=1 FM_HEARTBEAT=9999 FM_HEARTBEAT_MAX=9999 FM_CHECK_INTERVAL=9999 bin/fm-watch.sh` with a status write followed by a turn-end marker 1s later, isolated from live tmux windows by a fake `tmux` on `PATH`</code>
- <code>`FM_SIGNAL_GRACE=1 FM_POLL=1 FM_HEARTBEAT=9999 FM_HEARTBEAT_MAX=9999 FM_CHECK_INTERVAL=9999 bin/fm-watch.sh` restarted after the coalesced wake and observed for 3s to confirm no duplicate signal wake</code>
- <code>`FM_SIGNAL_GRACE=5 ... bin/fm-watch.sh` killed during the grace period, followed by a restart with `FM_SIGNAL_GRACE=1`, to confirm pending signals are not marked seen before a wake is reported</code>
- <code>`FM_SIGNAL_GRACE=1 ... bin/fm-watch.sh` with a single status-file signal to confirm the original single-file `signal: &lt;file&gt;` wake shape remains intact</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
