### PR TITLE
ci: enforce contributor guardrails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint shell scripts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: shellcheck bin/*.sh
+
+  invariants:
+    name: Repo invariants
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Symlinks must stay intact
+        run: |
+          set -eu
+          [ "$(readlink CLAUDE.md)" = "AGENTS.md" ] || { echo "::error::CLAUDE.md must be a symlink to AGENTS.md"; exit 1; }
+          [ "$(readlink .claude/skills)" = "../.agents/skills" ] || { echo "::error::.claude/skills must be a symlink to ../.agents/skills"; exit 1; }
+      - name: Personal fleet paths must not be tracked
+        run: |
+          set -eu
+          tracked=$(git ls-files -- data state config projects .no-mistakes)
+          if [ -n "$tracked" ]; then
+            echo "::error::Personal fleet paths are tracked in git:"
+            printf '%s\n' "$tracked"
+            exit 1
+          fi

--- a/.github/workflows/no-mistakes-required.yml
+++ b/.github/workflows/no-mistakes-required.yml
@@ -1,0 +1,49 @@
+name: Require no-mistakes
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: no-mistakes-required-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: PR must be raised via no-mistakes
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.pull_request.user.login != 'github-actions[bot]' &&
+      github.event.pull_request.user.login != 'dependabot[bot]'
+    steps:
+      - name: Verify no-mistakes signature in PR body
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -eu
+          marker='Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)'
+          if printf '%s' "${PR_BODY:-}" | grep -qF -- "$marker"; then
+            echo "Found no-mistakes signature in PR #${PR_NUMBER} body."
+            exit 0
+          fi
+          {
+            echo "::error::This PR was not raised through no-mistakes."
+            echo
+            echo "Contributions to this repository must be submitted via 'git push no-mistakes'."
+            echo "That pipeline runs the required review/test/lint/CI steps and writes a"
+            echo "deterministic '## Pipeline' section into the PR body containing:"
+            echo
+            echo "    $marker"
+            echo
+            echo "See CONTRIBUTING.md for setup and the full workflow."
+            echo
+            echo "PR author: ${PR_AUTHOR}"
+          } >&2
+          exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,15 +30,18 @@ Hard rules, in priority order:
 
 You may freely write to this repo itself (backlog, briefs, state, even this file when the captain approves a change).
 This repo is a shared template, not the captain's personal project.
-The tracking principle: anything shared (AGENTS.md, bin/, agent skill files) is tracked under git; anything personal to this captain's fleet (data/, state/, config/, projects/) is not.
+The tracking principle: anything shared (AGENTS.md, README.md, CONTRIBUTING.md, .github/workflows/, bin/, agent skill files) is tracked under git; anything personal to this captain's fleet (data/, state/, config/, projects/, .no-mistakes/) is not.
 Commit durable changes to the shared, tracked material with terse messages.
-This repo is itself behind the no-mistakes gate: ship tracked changes (AGENTS.md, bin/, agent skill files) through the pipeline yourself - branch, commit, run the pipeline, PR - and the captain's merge rule applies here exactly as it does to projects.
+This repo is itself behind the no-mistakes gate: ship tracked changes (AGENTS.md, README.md, CONTRIBUTING.md, .github/workflows/, bin/, agent skill files) through the pipeline yourself - branch, commit, run the pipeline, PR - and the captain's merge rule applies here exactly as it does to projects.
 Never add an agent name as co-author.
 
 ## 2. Layout and state
 
 ```
 AGENTS.md            this file (CLAUDE.md is a symlink to it)
+CONTRIBUTING.md      contributor workflow and repo conventions
+README.md            public overview and development notes
+.github/workflows/   shared CI and PR enforcement, committed
 .agents/skills/      shared skills, committed
 .claude/skills       symlink to .agents/skills for claude compatibility
 bin/                 helper scripts, committed; read each script's header before first use

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+# Contributing
+
+Thanks for wanting to contribute.
+One rule up front:
+
+**Human-authored pull requests targeting `main` must be raised through [`no-mistakes`](https://github.com/kunchenguid/no-mistakes).**
+We require this to reduce the maintainer's burden of reviewing and merging contributions.
+
+`no-mistakes` puts a local git proxy in front of your real remote.
+Pushing through it runs an AI-driven review/test/lint pipeline in an isolated worktree, forwards the push upstream only after every check passes, and opens a clean PR automatically.
+
+A GitHub Actions check (`Require no-mistakes`) runs on PRs targeting `main` and fails if the body is missing the deterministic signature that no-mistakes writes.
+Dependency bots are exempt so their automation keeps working, but regular contributor PRs without the signature will not be reviewed or merged.
+
+## Workflow
+
+1. Fork the repo and clone your fork.
+2. Create a branch and make your changes.
+3. Initialize the gate in the repo once: `no-mistakes init`.
+4. Commit your changes.
+5. Push through the gate instead of pushing to `origin`:
+
+   ```sh
+   git push no-mistakes
+   ```
+
+6. Run `no-mistakes` to attach to the pipeline, watch findings, and auto-fix or review as needed.
+7. Once the pipeline passes, it forwards the push upstream and opens the PR for you.
+
+See the [no-mistakes quick start](https://kunchenguid.github.io/no-mistakes/start-here/quick-start/) for the full first-run walkthrough.
+
+## Repo conventions
+
+- This repo is a template for running a firstmate orchestrator agent.
+  `AGENTS.md` is the agent's entire job description; `CLAUDE.md` is a symlink to it, and `.claude/skills` is a symlink to `.agents/skills`.
+- Only shared material is tracked: `AGENTS.md`, `README.md`, `bin/`, and `.agents/skills/`.
+  Everything personal to one captain's fleet (`data/`, `state/`, `config/`, `projects/`, `.no-mistakes/`) is gitignored; never commit it.
+- Helper scripts in `bin/` are plain bash.
+  Each starts with a usage header comment; keep it accurate when you change behavior.
+  `shellcheck bin/*.sh` must pass, and CI enforces it.
+- Changes to harness adapters (launch templates in `bin/fm-spawn.sh`, the adapter tables in `AGENTS.md`) must be verified empirically against the real harness, never written from documentation alone.
+- In Markdown, put each full sentence on its own line.
+
+## Questions
+
+Open an issue, or talk to me on [Discord](https://discord.gg/Wsy2NpnZDu).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ See the [no-mistakes quick start](https://kunchenguid.github.io/no-mistakes/star
 
 - This repo is a template for running a firstmate orchestrator agent.
   `AGENTS.md` is the agent's entire job description; `CLAUDE.md` is a symlink to it, and `.claude/skills` is a symlink to `.agents/skills`.
-- Only shared material is tracked: `AGENTS.md`, `README.md`, `bin/`, and `.agents/skills/`.
+- Only shared material is tracked: `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `.github/workflows/`, `bin/`, and `.agents/skills/`.
   Everything personal to one captain's fleet (`data/`, `state/`, `config/`, `projects/`, `.no-mistakes/`) is gitignored; never commit it.
 - Helper scripts in `bin/` are plain bash.
   Each starts with a usage header comment; keep it accurate when you change behavior.

--- a/README.md
+++ b/README.md
@@ -149,10 +149,14 @@ FM_BUSY_REGEX='esc (to )?interrupt|Working\.\.\.'   # busy-pane signatures, exte
 
 ## Development
 
-Tracked changes to firstmate itself, including `AGENTS.md`, `bin/`, and agent skill files, ship through the `no-mistakes` pipeline on a feature branch and require the captain's explicit merge approval.
+Tracked changes to firstmate itself, including `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `.github/workflows/`, `bin/`, and agent skill files, ship through the `no-mistakes` pipeline on a feature branch and require the captain's explicit merge approval.
+Human-authored pull requests targeting `main` must be raised through `git push no-mistakes`; see `CONTRIBUTING.md` for the enforced contributor workflow.
 Local `.no-mistakes/` state and test evidence stay out of this repo; `.no-mistakes.yaml` keeps evidence in a temp directory instead.
 
 ```sh
 bash -n bin/*.sh                          # syntax-check the toolbelt
+shellcheck bin/*.sh                       # lint the toolbelt; CI enforces this
+[ "$(readlink CLAUDE.md)" = "AGENTS.md" ]
+[ "$(readlink .claude/skills)" = "../.agents/skills" ]
 FM_HEARTBEAT=2 FM_POLL=1 bin/fm-watch.sh  # watcher smoke test (prints "heartbeat")
 ```

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -38,6 +38,6 @@ for t in $TOOLS; do
   command -v "$t" >/dev/null || echo "MISSING: $t (install: $(install_cmd "$t"))"
 done
 gh auth status >/dev/null 2>&1 || echo "NEEDS_GH_AUTH"
-crew=$(cat "$FM_ROOT/config/crew-harness" 2>/dev/null | tr -d '[:space:]')
+crew=$(tr -d '[:space:]' < "$FM_ROOT/config/crew-harness" 2>/dev/null || true)
 [ -n "$crew" ] && [ "$crew" != "default" ] && echo "CREW_HARNESS_OVERRIDE: $crew"
 exit 0

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -33,13 +33,15 @@ detect_own() {
         esac ;;
     esac
     pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
-    [ -n "$pid" ] && [ "$pid" -gt 1 ] || break
+    if [ -z "$pid" ] || [ "$pid" -le 1 ]; then
+      break
+    fi
   done
   echo unknown
 }
 
 if [ "${1:-}" = "crew" ]; then
-  crew=$(cat "$FM_ROOT/config/crew-harness" 2>/dev/null | tr -d '[:space:]')
+  crew=$(tr -d '[:space:]' < "$FM_ROOT/config/crew-harness" 2>/dev/null || true)
   if [ -z "$crew" ] || [ "$crew" = "default" ]; then detect_own; else echo "$crew"; fi
 else
   detect_own

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -23,6 +23,7 @@ ARG3=${3:-}
 # The verified launch command per adapter. The knowledge half of each adapter
 # (busy signature, exit command, dialogs, quirks) lives in AGENTS.md section 4.
 launch_template() {
+  # shellcheck disable=SC2016  # single quotes are deliberate: $(cat ...) expands in the crewmate pane, not here
   case "$1" in
     claude) printf '%s' 'claude --dangerously-skip-permissions "$(cat __BRIEF__)"' ;;
     codex) printf '%s' 'codex --dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch __TURNEND__\"]" "$(cat __BRIEF__)"' ;;

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -35,7 +35,9 @@ fi
 if [ -d "$WT" ]; then
   branch=$(git -C "$WT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo HEAD)
   if [ "$branch" != "HEAD" ]; then
-    git -C "$WT" checkout --detach -q 2>/dev/null && git -C "$WT" branch -D "$branch" >/dev/null 2>&1 || true
+    if git -C "$WT" checkout --detach -q 2>/dev/null; then
+      git -C "$WT" branch -D "$branch" >/dev/null 2>&1 || true
+    fi
   fi
   # Remove our hook file so a reused pool worktree cannot fire signals for a dead task.
   rm -f "$WT/.claude/settings.local.json" "$WT/.opencode/plugins/fm-turn-end.js"


### PR DESCRIPTION
## Intent

The captain wants firstmate to have the same contributor guardrails as his other repos (lavish-axi, gh-axi, trial-by-combat, etc.): a CONTRIBUTING.md guide plus GitHub Actions enforcement for PRs. Adapted from the standard set: (1) CONTRIBUTING.md documenting the mandatory git-push-no-mistakes flow and firstmate-specific repo conventions (template repo, AGENTS.md is the contract, CLAUDE.md/.claude/skills symlinks, tracked-vs-local split, bash + shellcheck, one sentence per line in Markdown); (2) no-mistakes-required.yml copied from lavish-axi minus the release-please bot exemption since this repo has no releases; (3) ci.yml that shellchecks bin/*.sh and checks repo invariants (symlinks intact, personal fleet paths like data/ state/ config/ projects/ untracked). guard-generated-files.yml was deliberately NOT ported because firstmate has no release-please or generated files. The SC2016 shellcheck directive added in bin/fm-spawn.sh is deliberate: the single-quoted launch templates defer expansion to the crewmate tmux pane, and the directive makes shellcheck pass clean so CI can enforce it. All CI steps were verified to pass locally before commit.

## What Changed

- Added GitHub Actions checks for shell scripts, repository invariants, and PR bodies signed by the no-mistakes flow.
- Added a `CONTRIBUTING.md` guide covering the required no-mistakes workflow and firstmate repository conventions.
- Updated firstmate docs and spawn script shellcheck annotations so the new CI guardrails match the repo layout and launch-template behavior.

## Risk Assessment

⚠️ Medium: The change is small and mostly documentation/CI guardrails, but the central enforcement workflow can be trivially bypassed if treated as a mandatory policy gate.

## Testing

Bootstrap was clean; I exercised the PR enforcement script end-to-end for signed and unsigned human PR bodies, exercised the CI repo invariant checks, confirmed the omitted generated-file guard and lack of release-please exemption, and left the worktree clean. I did not run the shellcheck CI step because this testing prompt explicitly forbids linters/static analysis.

<details>
<summary>Evidence: PR signature enforcement transcript</summary>

<code>Scenario: human PR created by no-mistakes with signature&#10;Found no-mistakes signature in PR #42 body.&#10;Result: accepted&#10;&#10;Scenario: human PR without no-mistakes signature&#10;::error::This PR was not raised through no-mistakes.&#10;&#10;Contributions to this repository must be submitted via &#39;git push no-mistakes&#39;.&#10;That pipeline runs the required review/test/lint/CI steps and writes a&#10;deterministic &#39;## Pipeline&#39; section into the PR body containing:&#10;&#10;Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)&#10;&#10;See CONTRIBUTING.md for setup and the full workflow.&#10;&#10;PR author: octocat&#10;Result: rejected</code>

```text
Scenario: human PR created by no-mistakes with signature
Found no-mistakes signature in PR #42 body.
Result: accepted

Scenario: human PR without no-mistakes signature
::error::This PR was not raised through no-mistakes.

Contributions to this repository must be submitted via 'git push no-mistakes'.
That pipeline runs the required review/test/lint/CI steps and writes a
deterministic '## Pipeline' section into the PR body containing:

    Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

See CONTRIBUTING.md for setup and the full workflow.

PR author: octocat
Result: rejected
```
</details>
<details>
<summary>Evidence: Repo invariant transcript</summary>

<code>Scenario: CI symlink invariants&#10;CLAUDE.md -&gt; AGENTS.md&#10;.claude/skills -&gt; ../.agents/skills&#10;&#10;Scenario: CI personal fleet path invariant&#10;No tracked files under data/, state/, config/, projects/, or .no-mistakes/.&#10;&#10;Scenario: generated-file guard deliberately absent&#10;No .github/workflows/guard-generated-files.yml tracked.</code>

```text
Scenario: CI symlink invariants
CLAUDE.md -> AGENTS.md
.claude/skills -> ../.agents/skills

Scenario: CI personal fleet path invariant
No tracked files under data/, state/, config/, projects/, or .no-mistakes/.

Scenario: generated-file guard deliberately absent
No .github/workflows/guard-generated-files.yml tracked.
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (2m8s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 warning</summary>

- ⚠️ `.github/workflows/no-mistakes-required.yml:31` - The required check accepts any PR body containing this public marker, so a manually opened PR can paste the string and pass without ever going through no-mistakes. If this is meant to enforce the gate rather than serve as an advisory convention, validate a non-forgeable signal from the no-mistakes run or document the limitation explicitly.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ `.github/workflows/ci.yml:18` - I did not run `shellcheck bin/*.sh`, so I could not directly demonstrate the new CI lint job passes. This validation prompt explicitly forbids linters/static analysis, and shellcheck is a linter.
- `bin/fm-bootstrap.sh`
- <code>Simulated `.github/workflows/no-mistakes-required.yml` PR-body check with a no-mistakes-signed human PR body and a manual human PR body, recording `/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KTX6NK7HKCCY4H1Y4NF0X775/no-mistakes-required-transcript.txt`</code>
- <code>Executed `.github/workflows/ci.yml` repo invariant commands for `CLAUDE.md`, `.claude/skills`, and personal fleet paths, plus verified `guard-generated-files.yml` is not tracked, recording `/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KTX6NK7HKCCY4H1Y4NF0X775/repo-invariants-transcript.txt`</code>
- <code>Searched workflows for `release-please`, `github-actions[bot]`, `dependabot[bot]`, and `guard-generated-files` to confirm only the intended bot exemptions are present and the generated-file guard was not ported</code>
- <code>Searched `bin/*.sh` for the deliberate `SC2016` directive documenting deferred crewmate-pane expansion</code>
- `git status --short`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
