### PR TITLE
fix: reduce crewmate status wake noise

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -346,5 +346,6 @@ Every finished task lives on as its GitHub PR, so pruning loses nothing; the ret
 ## 11. Crewmate briefs
 
 Scaffold with `bin/fm-brief.sh <id> <repo-name>` - it writes `data/<id>/brief.md` with the standard contract (branch setup, status-reporting protocol, never-push-to-default rules, the no-mistakes definition of done) and all paths filled in.
+The status-reporting protocol is intentionally sparse: crewmates append status only for supervisor-actionable phase changes or `needs-decision`/`blocked`/`done`/`failed`, because every append wakes firstmate.
 Then replace the `{TASK}` placeholder with a clear task description, acceptance criteria, and any constraints or context the crewmate needs.
 Adjust the other sections only when the task genuinely deviates from the standard ship-a-new-PR shape (e.g. fixing an existing external PR); the scaffold is the contract, not a suggestion.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -31,9 +31,13 @@ You are in a disposable git worktree of $REPO, at a detached HEAD on a clean def
 1. Never push to the default branch. Never merge a PR.
 2. Stay inside this worktree; modify nothing outside it.
 3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
-4. Report status after every meaningful state change by appending one line:
+4. Report status by appending one line:
    \`echo "{state}: {one short line}" >> $FM_ROOT/state/$ID.status\`
    States: working, needs-decision, blocked, done, failed.
+   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
+   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
+   needs-decision/blocked/done/failed states. No step-by-step FYI progress lines;
+   firstmate reads your pane for that.
 5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
 6. If a decision belongs to a human (product choices, destructive actions, ask-user findings),
    append \`needs-decision: {summary of options}\` and stop. Firstmate will reply with the decision.


### PR DESCRIPTION
## Intent

Reduce firstmate wake noise from crewmate status reporting. The captain observed that crewmates write FYI-ish status lines (e.g. 'installed dependencies', 'attached chrome-devtools-axi') that each wake the supervising firstmate agent for no actionable reason. Tighten the brief scaffold's reporting rule (rule 4 in bin/fm-brief.sh) so crewmates append status lines only on real phase changes a supervisor would act on (setup done, bug reproduced, fix implemented, validation passed) plus the needs-decision/blocked/done/failed states, and explicitly not step-by-step progress - firstmate peeks the tmux pane for that. Deliberate decisions: keep the same status file mechanism and state vocabulary unchanged; the change is wording-only in the scaffold heredoc, no behavior change to any script logic; the rationale sentence 'Each append wakes firstmate' is intentionally included so crewmate agents understand why sparse reporting matters.

## What Changed
- Tightened the `fm-brief.sh` scaffold so crewmates report only supervisor-actionable phase changes plus `needs-decision`/`blocked`/`done`/`failed` states.
- Added brief wording that each status append wakes firstmate and that step-by-step FYI progress should stay out of status files.
- Documented the sparse crewmate status cadence in `AGENTS.md`.

## Risk Assessment

✅ Low: The branch only tightens wording in the brief scaffold without changing script behavior, and the new guidance matches the watcher/status-file contract.

## Testing

Exercised the actual brief-scaffolding CLI path and captured the generated crewmate-facing markdown; no automated test suite exists for this repo, no lint/static analysis was run, the transient worktree fixture was removed, and the generated brief directly demonstrates the intended sparse status-reporting rule.

<details>
<summary>Evidence: Generated crewmate brief showing sparse status cadence rule</summary>

<code>Lines 17-21 show: `States: working, needs-decision, blocked, done, failed.` followed by `Each append wakes firstmate, so report sparingly: only phase changes a supervisor would act on (setup done, bug reproduced, fix implemented, validation passed) and the needs-decision/blocked/done/failed states. No step-by-step FYI progress lines; firstmate reads your pane for that.`</code>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Setup
You are in a disposable git worktree of demo-repo, at a detached HEAD on a clean default branch.
1. First action: create your branch: `git checkout -b fm/status-cadence-e2e-01kty`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KTYFNG7DD7NG5V3S3TFVC493/state/status-cadence-e2e-01kty.status`
   States: working, needs-decision, blocked, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs to a human (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.

# Definition of done
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
During validation, fix auto-fix findings yourself; escalate ask-user findings per rule 6.
After /no-mistakes reports CI green, append `done: PR {url} checks green` and stop. You are finished.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected the target diff with `git diff --stat 683b8cf2ab701edca9209656812b61c9f5ff2656..ad561356880e2df9df9a9ffb4c78b7f78d127e7b`.</code>
- `Confirmed there are no repository test files or package test scripts via file discovery.`
- <code>Ran the end-user CLI path: `bin/fm-brief.sh status-cadence-e2e-01kty demo-repo`.</code>
- <code>Verified the generated `data/status-cadence-e2e-01kty/brief.md` includes the unchanged state vocabulary, the `Each append wakes firstmate` rationale, the allowed phase-change examples, and the `No step-by-step FYI progress lines` instruction.</code>
- <code>Copied the generated brief to `/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KTYFNG7DD7NG5V3S3TFVC493/generated-brief-status-cadence.md`.</code>
- <code>Removed the transient generated worktree fixture with `rm -rf data/status-cadence-e2e-01kty` and verified `git status --short` was clean.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
