### PR TITLE
feat: add scout task lifecycle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Keep it to seasoning, not performance: never let the voice obscure technical con
 
 You are the captain's only point of contact for all software work across all of their projects.
 You do not do the work yourself.
-You delegate every coding task to a crewmate agent that you spawn, supervise, and tear down.
+You delegate every piece of project-specific work - coding, investigation, planning, bug reproduction, audits - to a crewmate agent that you spawn, supervise, and tear down.
 
 Hard rules, in priority order:
 
@@ -22,6 +22,7 @@ Hard rules, in priority order:
 2. **Never merge a PR without the captain's explicit word.**
 3. **Never tear down a worktree that holds work not on a remote.**
    `bin/fm-teardown.sh` enforces this; never bypass it with `--force` unless the captain explicitly said to discard the work.
+   The one carve-out: a scout task's worktree is declared scratch from the start - its deliverable is the report, and teardown lets the worktree go once that report exists (section 7).
 4. **Crewmates never address the captain.**
    All crewmate communication flows through you.
    The captain may watch or type into any crewmate window directly; treat such intervention as authoritative and reconcile your records at the next heartbeat.
@@ -50,11 +51,12 @@ data/                personal fleet records; LOCAL, gitignored as a whole
   backlog.md         task queue, dependencies, history
   projects.md        fleet registry: one line per project under projects/ with a short description
   <id>/brief.md      per-task crewmate brief
+  <id>/report.md     scout task deliverable, written by the crewmate; survives teardown
 projects/            cloned repos; gitignored; READ-ONLY for you
 state/               volatile runtime signals; gitignored
   <id>.status        appended by crewmates: "<state>: <note>" lines
   <id>.turn-ended    touched by turn-end hooks
-  <id>.meta          written by fm-spawn: window=, worktree=, project=, harness= (fm-pr-check appends pr=)
+  <id>.meta          written by fm-spawn: window=, worktree=, project=, harness=, kind= (fm-pr-check appends pr=)
   <id>.check.sh      optional slow poll you write per task (e.g. merged-PR check)
   .hash-* .count-* .stale-* .seen-* .last-* .heartbeat-streak   watcher internals; never touch
 .no-mistakes/        local validation state and evidence; gitignored
@@ -213,10 +215,15 @@ Use these signals in order:
 4. One confident match: proceed, but state the assumption in your reply ("dispatching to `yourapp`") so a wrong guess costs one correction instead of a crewmate's wasted run.
 5. More than one plausible match, or none: ask a one-line question. A misdirected dispatch is recoverable (everything ships as a PR) but expensive; a question is cheap.
 
-Then classify the work:
+Then classify the shape:
+
+- **Ship** (the default): the deliverable is a change to the project. It ends in a PR through the no-mistakes pipeline.
+- **Scout:** the deliverable is knowledge - an investigation, a plan, a bug reproduction, an audit. It ends in a report at `data/<id>/report.md`, never a PR. When the captain asks "what's wrong", "how would we", or "find out why" about a project, that is a scout task; dispatch it instead of doing the digging yourself.
+
+Then classify readiness:
 
 - **Dispatchable:** no overlap with in-flight tasks. Dispatch immediately. There is no concurrency cap.
-- **Blocked:** touches the same files or subsystem as an in-flight task, or explicitly depends on an unmerged PR. Record it in `data/backlog.md` with `blocked-by: <id>` and tell the captain why it is queued.
+- **Blocked:** touches the same files or subsystem as an in-flight task, or explicitly depends on an unmerged PR. Record it in `data/backlog.md` with `blocked-by: <id>` and tell the captain why it is queued. Scout tasks are read-mostly and almost never block on anything.
 
 Keep dependency judgment coarse: same repo plus overlapping area means serialize; everything else runs parallel.
 The no-mistakes rebase step absorbs mild overlaps.
@@ -228,9 +235,10 @@ Write the brief per section 11.
 ```sh
 bin/fm-spawn.sh <id> projects/<repo>             # uses the active crewmate harness
 bin/fm-spawn.sh <id> projects/<repo> codex       # per-task harness override
+bin/fm-spawn.sh <id> projects/<repo> --scout     # scout task; records kind=scout in meta
 ```
 
-The script resolves the harness (`fm-harness.sh crew`), owns the verified launch templates, and records `harness=` in the task's meta; a third argument containing whitespace is treated as a raw launch command (only for verifying new adapters).
+The script resolves the harness (`fm-harness.sh crew`), owns the verified launch templates, and records `harness=` and `kind=` in the task's meta; a non-flag third argument containing whitespace is treated as a raw launch command (only for verifying new adapters).
 
 The script creates the window (in your current tmux session, or a dedicated `firstmate` session when you are outside tmux), runs `treehouse get`, waits for the worktree subshell, installs the turn-end hook, records `state/<id>.meta`, and launches the agent with the brief.
 Worktrees start at detached HEAD on a clean default branch; the brief's first instruction makes the crewmate create its branch.
@@ -274,6 +282,19 @@ The script refuses if the worktree holds unpushed work; treat a refusal as a sto
 Known benign case: after an external-PR task, a squash merge leaves the branch commits reachable only on the contributor's fork; add the fork as a remote and fetch (`git remote add fork <fork url> && git fetch fork`), then retry - never reach for `--force`.
 Then move the task to Done in `data/backlog.md` (with PR link and date), re-evaluate the queue, and dispatch anything that was blocked on this task.
 
+### Scout tasks (report instead of PR)
+
+A scout task follows Intake, Spawn, and Supervise exactly as above - scaffold the brief with `bin/fm-brief.sh <id> <repo> --scout`, spawn with `--scout` - then diverges after the work:
+
+- There is no Validate or PR-ready stage. When the crewmate's status says `done`, read `data/<id>/report.md`.
+- Relay the findings to the captain: plain chat for a focused answer, lavish-axi when the report has structure worth a visual (multiple findings, options, a plan).
+- Tear down immediately - no merge gate. `bin/fm-teardown.sh` allows a scout worktree's scratch commits and dirty files once the report exists; if the report is missing, it refuses, because the findings are the work product.
+- Record it in Done with the report path instead of a PR link.
+
+**Promotion.** When a scout's findings reveal shippable work (a reproduced bug with a clear fix) and the captain wants it shipped, promote the task in place instead of respawning: run `bin/fm-promote.sh <id>` (flips `kind=` to ship in meta, restoring teardown's full unpushed-work protection), then send the crewmate its ship instructions - create branch `fm/<id>`, implement, report `done`, then `/no-mistakes` per the Validate stage.
+The crewmate keeps its worktree, loaded context, and repro; the repro becomes the regression test.
+From there the task is an ordinary ship task through PR ready and Teardown.
+
 ## 8. Supervision protocol
 
 The watcher is the backbone.
@@ -312,6 +333,7 @@ Token discipline: status files before panes; default peeks to 40 lines; never st
 Reaches the captain immediately:
 
 - PR ready for review.
+- A finished scout report (relay the findings, not just "it's done").
 - ask-user findings from no-mistakes (relay them verbatim; never approve in the captain's place).
 - A crewmate failed after the playbook is exhausted.
 - Anything destructive, irreversible, or security-sensitive.
@@ -336,16 +358,18 @@ Update it on every dispatch, completion, and decision.
 
 ## Done
 - [x] <id> - <one line> - <PR url> (merged <date>)
+- [x] <id> - <one line> - data/<id>/report.md (reported <date>)
 ```
 
 Re-evaluate Queued on every teardown and every heartbeat: anything whose blocker is gone gets dispatched.
 
 Keep Done to the 10 most recent entries; prune older ones whenever you add to the section.
-Every finished task lives on as its GitHub PR, so pruning loses nothing; the retained tail exists only as cheap recent context for recovery and heartbeats.
+Every finished ship task lives on as its GitHub PR and every scout task as its report file, so pruning loses nothing; the retained tail exists only as cheap recent context for recovery and heartbeats.
 
 ## 11. Crewmate briefs
 
 Scaffold with `bin/fm-brief.sh <id> <repo-name>` - it writes `data/<id>/brief.md` with the standard contract (branch setup, status-reporting protocol, never-push-to-default rules, the no-mistakes definition of done) and all paths filled in.
+For scout tasks add `--scout`: the scaffold swaps the definition of done for the report contract (findings to `data/<id>/report.md`, no branch, no push, no PR) and declares the worktree scratch.
 The status-reporting protocol is intentionally sparse: crewmates append status only for supervisor-actionable phase changes or `needs-decision`/`blocked`/`done`/`failed`, because every append wakes firstmate.
 Then replace the `{TASK}` placeholder with a clear task description, acceptance criteria, and any constraints or context the crewmate needs.
 Adjust the other sections only when the task genuinely deviates from the standard ship-a-new-PR shape (e.g. fixing an existing external PR); the scaffold is the contract, not a suggestion.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,7 +213,7 @@ Use these signals in order:
 2. A clear follow-up ("also add tests for that", a reply to a PR you reported) inherits the project of the thing it refers to.
 3. Otherwise, match the message content against what you know: project names under `projects/`, in-flight tasks in `data/backlog.md`, and the projects' own code and READMEs (read them; that is what your read access is for). A mentioned feature, file, stack trace, or technology usually points at exactly one project.
 4. One confident match: proceed, but state the assumption in your reply ("dispatching to `yourapp`") so a wrong guess costs one correction instead of a crewmate's wasted run.
-5. More than one plausible match, or none: ask a one-line question. A misdirected dispatch is recoverable (everything ships as a PR) but expensive; a question is cheap.
+5. More than one plausible match, or none: ask a one-line question. A misdirected dispatch is recoverable because crewmates work in isolated worktrees, but it is expensive; a question is cheap.
 
 Then classify the shape:
 
@@ -241,7 +241,7 @@ bin/fm-spawn.sh <id> projects/<repo> --scout     # scout task; records kind=scou
 The script resolves the harness (`fm-harness.sh crew`), owns the verified launch templates, and records `harness=` and `kind=` in the task's meta; a non-flag third argument containing whitespace is treated as a raw launch command (only for verifying new adapters).
 
 The script creates the window (in your current tmux session, or a dedicated `firstmate` session when you are outside tmux), runs `treehouse get`, waits for the worktree subshell, installs the turn-end hook, records `state/<id>.meta`, and launches the agent with the brief.
-Worktrees start at detached HEAD on a clean default branch; the brief's first instruction makes the crewmate create its branch.
+Worktrees start at detached HEAD on a clean default branch; ship briefs tell the crewmate to create its branch, while scout briefs keep the worktree scratch.
 After spawning, peek the pane to confirm the crewmate is processing the brief (and handle any trust dialog per section 4).
 Add the task to `data/backlog.md` under In flight.
 
@@ -252,7 +252,7 @@ Steer a crewmate only with short single lines via `bin/fm-send.sh`; anything lon
 
 ### Validate
 
-When a crewmate's status says `done`:
+For ship tasks, when a crewmate's status says `done`:
 
 ```sh
 bin/fm-send.sh fm-<id> '/no-mistakes'
@@ -265,14 +265,14 @@ Use chat for yes/no decisions; use lavish-axi when there are multiple findings o
 
 ### PR ready
 
-When the pipeline reaches CI-green, the crewmate reports `done: PR <url> checks green`.
+For ship tasks, when the pipeline reaches CI-green, the crewmate reports `done: PR <url> checks green`.
 Run `bin/fm-pr-check.sh <id> <PR url>` - it records `pr=` in the task's meta and arms the watcher's merge poll.
 Tell the captain: PR link, one-paragraph summary, and the risk level no-mistakes emitted.
 (The check contract, for any custom `state/<id>.check.sh` you write yourself: print one line only when firstmate should wake, print nothing otherwise.)
 
 If the captain says "merge it", run `gh-axi pr merge` yourself; that instruction is the explicit approval.
 
-### Teardown (only after merge is confirmed)
+### Ship teardown (only after merge is confirmed)
 
 ```sh
 bin/fm-teardown.sh <id>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -291,8 +291,9 @@ A scout task follows Intake, Spawn, and Supervise exactly as above - scaffold th
 - Tear down immediately - no merge gate. `bin/fm-teardown.sh` allows a scout worktree's scratch commits and dirty files once the report exists; if the report is missing, it refuses, because the findings are the work product.
 - Record it in Done with the report path instead of a PR link.
 
-**Promotion.** When a scout's findings reveal shippable work (a reproduced bug with a clear fix) and the captain wants it shipped, promote the task in place instead of respawning: run `bin/fm-promote.sh <id>` (flips `kind=` to ship in meta, restoring teardown's full unpushed-work protection), then send the crewmate its ship instructions - create branch `fm/<id>`, implement, report `done`, then `/no-mistakes` per the Validate stage.
-The crewmate keeps its worktree, loaded context, and repro; the repro becomes the regression test.
+**Promotion.** When a scout's findings reveal shippable work (a reproduced bug with a clear fix) and the captain wants it shipped, promote the task in place instead of respawning: run `bin/fm-promote.sh <id>` (flips `kind=` to ship in meta, restoring teardown's full unpushed-work protection), then send the crewmate its ship instructions - inventory scratch state, reset to a clean default-branch base, carry over only intended fix changes, create branch `fm/<id>`, implement, report `done`, then `/no-mistakes` per the Validate stage.
+The crewmate keeps its worktree, loaded context, and repro, but the ship branch must start from a clean base with only intended changes; scratch commits and debug edits from the scout phase never ride along.
+The repro becomes the regression test.
 From there the task is an ordinary ship task through PR ready and Teardown.
 
 ## 8. Supervision protocol

--- a/README.md
+++ b/README.md
@@ -25,15 +25,15 @@
 </p>
 
 You can run one coding agent well.
-But the moment you want three things done in parallel, you become a tab-juggler: babysitting sessions, copy-pasting context between repos, forgetting which terminal had the failing test.
+But the moment you want three project tasks done in parallel - fixes, investigations, plans, audits - you become a tab-juggler: babysitting sessions, copy-pasting context between repos, forgetting which terminal had the failing test.
 
 firstmate flips the model.
-You talk to a single agent - the first mate - and it runs the crew for you: spawning autonomous agents in tmux windows, giving each a clean git worktree, supervising them to completion, and handing you finished PRs to merge.
+You talk to a single agent - the first mate - and it runs the crew for you: spawning autonomous agents in tmux windows, giving each a clean git worktree, supervising them to completion, and handing you finished PRs or standalone investigation reports.
 There is no app to install; the whole orchestrator is an `AGENTS.md` file that any terminal coding agent can follow.
 
-- **One liaison** — you never talk to a worker agent. The first mate dispatches, supervises, escalates only real decisions, and reports when PRs are ready.
+- **One liaison** — you never talk to a worker agent. The first mate dispatches, supervises, escalates only real decisions, and reports when PRs or scout reports are ready.
 - **A visible crew** — every crewmate lives in a tmux window. Watch any of them work, or type into their window to intervene; the first mate reconciles.
-- **Guarded by construction** — the first mate is read-only over your projects; crewmates work in disposable [treehouse](https://github.com/kunchenguid/treehouse) worktrees and ship through the [no-mistakes](https://github.com/kunchenguid/no-mistakes) validation pipeline. Nothing lands without a PR you merge.
+- **Guarded by construction** — the first mate is read-only over your projects; crewmates work in disposable [treehouse](https://github.com/kunchenguid/treehouse) worktrees. Ship tasks go through the [no-mistakes](https://github.com/kunchenguid/no-mistakes) validation pipeline, and scout tasks produce local reports without pushing anything.
 
 This is not an agent harness. This is not a skill. This is not a CLI.
 
@@ -102,34 +102,34 @@ firstmate works from any terminal - outside tmux, crewmates land in a detached `
      ▼            ▼               ▼
   treehouse worktree (clean, disposable, parallel-safe)
      │
-     ▼
-  /no-mistakes pipeline: review ► test ► lint ► push ► PR ► CI green
+     ├─ ship: /no-mistakes ► PR for the captain ► merge ► teardown
      │
-     ▼
-  PR for the captain ── merged ── worktree returned, window closed
+     └─ scout: report at data/<id>/report.md ► relay findings ► teardown
 ```
 
 - **Event-driven supervision** — a zero-token bash watcher (`bin/fm-watch.sh`) sleeps on the fleet and wakes the first mate only when a crewmate reports, stalls, or a PR merges. An idle crew costs you nothing.
 - **Worktrees, not branches in your checkout** — crewmates never touch your clone; treehouse pools clean worktrees so parallel tasks on one repo cannot collide.
-- **Validation is non-negotiable** — every project gets `no-mistakes init`; every task ends with its pipeline. Human-judgment findings escalate to you through the first mate.
+- **Two task shapes** — ship tasks change projects and end in a validated PR; scout tasks investigate, plan, reproduce bugs, or audit, then leave a report at `data/<id>/report.md` and never push.
+- **Validation is non-negotiable for shipping** — every project gets `no-mistakes init`; every ship task ends with its pipeline. Human-judgment findings escalate to you through the first mate.
 - **Restart-proof** — all state lives in tmux, status files, and local markdown under `data/`. Kill the first mate session anytime; the next one reconciles and carries on.
 
 ## The bin/ toolbelt
 
 The first mate drives these; you rarely need to, but they work by hand too.
 
-| Script            | Description                                                                  |
-| ----------------- | ---------------------------------------------------------------------------- |
-| `fm-bootstrap.sh` | Detect missing toolchain pieces; install them only after consent             |
-| `fm-brief.sh`     | Scaffold a crewmate brief with the standard contract filled in               |
-| `fm-spawn.sh`     | Window → treehouse worktree → agent launched with its brief                  |
-| `fm-watch.sh`     | Block until a crewmate needs attention; exits with one reason line           |
-| `fm-send.sh`      | Send one literal line (or `--key Escape`) to a crewmate window               |
-| `fm-peek.sh`      | Print a bounded tail of a crewmate pane                                      |
-| `fm-pr-check.sh`  | Record a PR-ready task and arm the watcher's merge poll                      |
-| `fm-teardown.sh`  | Return the worktree and kill the window; refuses if work is not on a remote  |
-| `fm-harness.sh`   | Detect the running harness; resolve the effective crewmate harness           |
-| `fm-lock.sh`      | Single-firstmate session lock                                                |
+| Script            | Description                                                                                 |
+| ----------------- | ------------------------------------------------------------------------------------------- |
+| `fm-bootstrap.sh` | Detect missing toolchain pieces; install them only after consent                            |
+| `fm-brief.sh`     | Scaffold a ship brief, or a report-only scout brief with `--scout`                          |
+| `fm-spawn.sh`     | Window → treehouse worktree → agent launched with its brief; records ship/scout task kind   |
+| `fm-watch.sh`     | Block until a crewmate needs attention; exits with one reason line                          |
+| `fm-send.sh`      | Send one literal line (or `--key Escape`) to a crewmate window                              |
+| `fm-peek.sh`      | Print a bounded tail of a crewmate pane                                                     |
+| `fm-pr-check.sh`  | Record a PR-ready task and arm the watcher's merge poll                                     |
+| `fm-promote.sh`   | Promote a scout task in place so it becomes a protected ship task                           |
+| `fm-teardown.sh`  | Return the worktree and kill the window; protects ship work and requires scout reports      |
+| `fm-harness.sh`   | Detect the running harness; resolve the effective crewmate harness                          |
+| `fm-lock.sh`      | Single-firstmate session lock                                                               |
 
 ## Configuration
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -4,18 +4,62 @@
 # {TASK} placeholder with the task description, acceptance criteria, and context,
 # and may adjust other sections when the task genuinely deviates (e.g. working an
 # existing external PR instead of shipping a new one).
-# Usage: fm-brief.sh <task-id> <repo-name>
+# Usage: fm-brief.sh <task-id> <repo-name> [--scout]
+#   --scout writes the scout contract instead: the deliverable is a report at
+#   data/<task-id>/report.md (no branch, no push, no PR) and the worktree is scratch.
 # Refuses to overwrite an existing brief.
 set -eu
 
 FM_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-ID=$1
-REPO=$2
+KIND=ship
+POS=()
+for a in "$@"; do
+  case "$a" in
+    --scout) KIND=scout ;;
+    *) POS+=("$a") ;;
+  esac
+done
+ID=${POS[0]}
+REPO=${POS[1]}
 
 BRIEF="$FM_ROOT/data/$ID/brief.md"
 [ -e "$BRIEF" ] && { echo "error: $BRIEF already exists" >&2; exit 1; }
 mkdir -p "$FM_ROOT/data/$ID"
 
+if [ "$KIND" = scout ]; then
+cat > "$BRIEF" <<EOF
+You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
+
+# Task
+{TASK}
+
+# Setup
+You are in a disposable git worktree of $REPO, at a detached HEAD on a clean default branch.
+This is a SCOUT task: the deliverable is a written report, not a PR.
+The worktree is your laboratory - install, run, edit, and make scratch commits freely; all of it is discarded at teardown.
+The report is the only thing that survives, so anything worth keeping must be in it.
+
+# Rules
+1. Never push to any remote and never open a PR.
+2. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
+3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
+4. Report status by appending one line:
+   \`echo "{state}: {one short line}" >> $FM_ROOT/state/$ID.status\`
+   States: working, needs-decision, blocked, done, failed.
+   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
+   would act on and the needs-decision/blocked/done/failed states. No step-by-step
+   FYI progress lines; firstmate reads your pane for that.
+5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
+6. If a decision belongs to a human (product choices, destructive actions),
+   append \`needs-decision: {summary of options}\` and stop. Firstmate will reply with the decision.
+
+# Definition of done
+Write your findings to \`$FM_ROOT/data/$ID/report.md\`.
+The report must stand alone: what you did, what you found, the evidence (commands run, output, file:line references), and what you recommend.
+When the report is complete, append \`done: {one-line conclusion}\` to the status file and stop.
+If your findings reveal work that should ship (e.g. you reproduced a bug and the fix is clear), say so in the report; firstmate may promote this task in place, and you would then receive ship instructions (branch, implement, /no-mistakes) as a follow-up message.
+EOF
+else
 cat > "$BRIEF" <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
 
@@ -49,4 +93,5 @@ Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
 During validation, fix auto-fix findings yourself; escalate ask-user findings per rule 6.
 After /no-mistakes reports CI green, append \`done: PR {url} checks green\` and stop. You are finished.
 EOF
-echo "scaffolded: $BRIEF (replace {TASK})"
+fi
+echo "scaffolded: $BRIEF ($KIND; replace {TASK})"

--- a/bin/fm-promote.sh
+++ b/bin/fm-promote.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Promote a scout task to a ship task in place: the crewmate keeps its window,
+# worktree, and loaded context; only the contract changes. Flips kind= to ship in
+# state/<task-id>.meta so fm-teardown.sh applies the full unpushed-work protection
+# again. After promoting, send the crewmate its ship instructions via fm-send.sh
+# (create branch fm/<task-id>, implement, report done, then /no-mistakes).
+# Usage: fm-promote.sh <task-id>
+set -eu
+
+FM_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ID=$1
+META="$FM_ROOT/state/$ID.meta"
+[ -f "$META" ] || { echo "error: no meta for task $ID at $META" >&2; exit 1; }
+grep -qx 'kind=scout' "$META" || { echo "error: task $ID is not a scout task (kind=scout not in meta)" >&2; exit 1; }
+
+TMP="$META.tmp"
+grep -v '^kind=' "$META" > "$TMP"
+echo "kind=ship" >> "$TMP"
+mv "$TMP" "$META"
+
+echo "promoted $ID to ship (teardown protection restored)"
+echo "next: bin/fm-send.sh fm-$ID '<ship instructions: create branch fm/$ID, implement, report done>'"

--- a/bin/fm-promote.sh
+++ b/bin/fm-promote.sh
@@ -3,7 +3,9 @@
 # worktree, and loaded context; only the contract changes. Flips kind= to ship in
 # state/<task-id>.meta so fm-teardown.sh applies the full unpushed-work protection
 # again. After promoting, send the crewmate its ship instructions via fm-send.sh
-# (create branch fm/<task-id>, implement, report done, then /no-mistakes).
+# (inventory scratch state, reset to a clean default-branch base, carry over only
+# intended fix changes, create branch fm/<task-id>, implement, report done, then
+# /no-mistakes).
 # Usage: fm-promote.sh <task-id>
 set -eu
 
@@ -19,4 +21,4 @@ echo "kind=ship" >> "$TMP"
 mv "$TMP" "$META"
 
 echo "promoted $ID to ship (teardown protection restored)"
-echo "next: bin/fm-send.sh fm-$ID '<ship instructions: create branch fm/$ID, implement, report done>'"
+echo "next: bin/fm-send.sh fm-$ID '<ship instructions: review scratch state with git status and git log; reset to a clean default-branch base; carry over only intended fix changes; create branch fm/$ID; implement; report done>'"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 # Spawn a crewmate: tmux window -> treehouse worktree subshell -> agent launched with its brief.
-# Usage: fm-spawn.sh <task-id> <project-dir> [harness|launch-command]
-#   With no third arg, the harness comes from fm-harness.sh crew (config/crew-harness,
+# Usage: fm-spawn.sh <task-id> <project-dir> [harness|launch-command] [--scout]
+#   With no harness arg, the harness comes from fm-harness.sh crew (config/crew-harness,
 #   falling back to firstmate's own harness). A bare adapter name (claude|codex|
-#   opencode|pi) overrides it for this spawn. A string containing whitespace is
-#   treated as a RAW launch command - the escape hatch for verifying new adapters.
+#   opencode|pi) overrides it for this spawn. A non-flag string containing whitespace
+#   is treated as a RAW launch command - the escape hatch for verifying new adapters.
+#   --scout records kind=scout in the task's meta (report deliverable, scratch worktree;
+#   see AGENTS.md section 7); the default is kind=ship.
 #   Launch templates live in launch_template() below; placeholders replaced before launch:
 #     __BRIEF__    absolute path to data/<task-id>/brief.md
 #     __TURNEND__  absolute path to state/<task-id>.turn-ended (for harnesses whose
@@ -12,13 +14,21 @@
 #     __PIEXT__    absolute path to state/<task-id>.pi-ext.ts (pi turn-end extension,
 #                  written by this script; outside the worktree to avoid pi's trust gate)
 # Per-harness turn-end hooks are installed automatically; some live outside the worktree.
-# On success prints: spawned <id> harness=<name> window=<session:window> worktree=<path>
+# On success prints: spawned <id> harness=<name> kind=<ship|scout> window=<session:window> worktree=<path>
 set -eu
 
 FM_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-ID=$1
-PROJ=$2
-ARG3=${3:-}
+KIND=ship
+POS=()
+for a in "$@"; do
+  case "$a" in
+    --scout) KIND=scout ;;
+    *) POS+=("$a") ;;
+  esac
+done
+ID=${POS[0]}
+PROJ=${POS[1]}
+ARG3=${POS[2]:-}
 
 # The verified launch command per adapter. The knowledge half of each adapter
 # (busy signature, exit command, dialogs, quirks) lives in AGENTS.md section 4.
@@ -141,6 +151,7 @@ mkdir -p "$FM_ROOT/state"
   echo "worktree=$WT"
   echo "project=$PROJ_ABS"
   echo "harness=$HARNESS"
+  echo "kind=$KIND"
 } > "$FM_ROOT/state/$ID.meta"
 
 LAUNCH=${LAUNCH//__BRIEF__/$BRIEF}
@@ -150,4 +161,4 @@ tmux send-keys -t "$T" -l "$LAUNCH"
 sleep 0.3
 tmux send-keys -t "$T" Enter
 
-echo "spawned $ID harness=$HARNESS window=$T worktree=$WT"
+echo "spawned $ID harness=$HARNESS kind=$KIND window=$T worktree=$WT"

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -2,6 +2,9 @@
 # Tear down a finished task: return the treehouse worktree, kill the tmux window,
 # clear volatile state. REFUSES if the worktree holds work not on any remote,
 # because treehouse return hard-resets the worktree and kills its processes.
+# Scout tasks (kind=scout in meta) carve out of that check: their worktree is
+# declared scratch and the report at data/<task-id>/report.md is the work
+# product - teardown proceeds once the report exists, and refuses without it.
 # Usage: fm-teardown.sh <task-id> [--force]
 #   --force skips the unpushed-work check. Only use it when the captain has
 #   explicitly said to discard the work.
@@ -18,16 +21,29 @@ WT=$(grep '^worktree=' "$META" | cut -d= -f2-)
 T=$(grep '^window=' "$META" | cut -d= -f2-)
 PROJ=$(grep '^project=' "$META" | cut -d= -f2-)
 
+KIND=$(grep '^kind=' "$META" | cut -d= -f2- || true)
+[ -n "$KIND" ] || KIND=ship
+
 if [ -d "$WT" ] && [ "$FORCE" != "--force" ]; then
-  # The fm-spawn hook file is ours, never work product; ignore it in the dirty check.
-  dirty=$(git -C "$WT" status --porcelain 2>/dev/null | grep -vE '^\?\? \.claude/' | head -1 || true)
-  unpushed=$(git -C "$WT" log --oneline HEAD --not --remotes -- 2>/dev/null | head -5 || true)
-  if [ -n "$dirty" ] || [ -n "$unpushed" ]; then
-    echo "REFUSED: worktree $WT has work not on any remote." >&2
-    [ -n "$dirty" ] && echo "uncommitted changes present" >&2
-    [ -n "$unpushed" ] && printf 'unpushed commits:\n%s\n' "$unpushed" >&2
-    echo "Push the branch (or get the captain's explicit OK to discard, then --force)." >&2
-    exit 1
+  if [ "$KIND" = scout ]; then
+    # Scout worktrees are scratch by contract, but only once the deliverable exists.
+    REPORT="$FM_ROOT/data/$ID/report.md"
+    if [ ! -f "$REPORT" ]; then
+      echo "REFUSED: scout task $ID has no report at $REPORT." >&2
+      echo "The report is the work product. Have the crewmate write it (or get the captain's explicit OK to discard, then --force)." >&2
+      exit 1
+    fi
+  else
+    # The fm-spawn hook file is ours, never work product; ignore it in the dirty check.
+    dirty=$(git -C "$WT" status --porcelain 2>/dev/null | grep -vE '^\?\? \.claude/' | head -1 || true)
+    unpushed=$(git -C "$WT" log --oneline HEAD --not --remotes -- 2>/dev/null | head -5 || true)
+    if [ -n "$dirty" ] || [ -n "$unpushed" ]; then
+      echo "REFUSED: worktree $WT has work not on any remote." >&2
+      [ -n "$dirty" ] && echo "uncommitted changes present" >&2
+      [ -n "$unpushed" ] && printf 'unpushed commits:\n%s\n' "$unpushed" >&2
+      echo "Push the branch (or get the captain's explicit OK to discard, then --force)." >&2
+      exit 1
+    fi
   fi
 fi
 


### PR DESCRIPTION
## Intent

Extend firstmate so crewmates handle ALL project-specific work, not just coding that ends in a PR. The captain asked for this and approved the proposed design including the rule-3 carve-out and promotion. New task shape 'scout' (investigations, planning, bug reproductions, audits): deliverable is a standalone report at data/<id>/report.md instead of a PR; the worktree is declared scratch from the start. Changes: (1) AGENTS.md - identity broadened from coding tasks to all project work, intake now classifies shape (ship vs scout) before readiness, scout flow documented (no validate/PR/merge stages; report -> relay to captain -> immediate teardown), promotion documented, hard rule 3 gets the deliberate scout carve-out, backlog format gains a report-link Done variant, brief section mentions --scout; (2) bin/fm-brief.sh - --scout flag writes a scout contract scaffold (never push, report definition of done, worktree-is-scratch framing); (3) bin/fm-spawn.sh - --scout flag records kind=scout in the task meta, default kind=ship for backward compatibility (absent kind in old meta files is treated as ship by teardown); (4) bin/fm-teardown.sh - scout tasks skip the unpushed-work refusal once data/<id>/report.md exists, refuse with a clear message when the report is missing, ship tasks keep the full protection unchanged; (5) new bin/fm-promote.sh - flips kind=scout to ship in meta so a scout crewmate can be promoted in place (keeping worktree and context) when its findings reveal shippable work, restoring full teardown protection. Deliberate decisions: --scout flags are parsed positionally-tolerant (filtered from args) on both fm-brief and fm-spawn; scout briefs forbid pushing to ANY remote (stronger than ship's never-push-to-default) because nothing from a scout worktree should ever leave the machine; the report-missing teardown refusal deliberately mirrors the existing refusal wording style; all scripts were smoke-tested locally (both scaffolds, promote happy/error paths, teardown refusal and carve-out paths).

## What Changed
- Added a scout task shape for investigations, plans, reproductions, and audits, with report-based completion at `data/<id>/report.md` instead of PR validation.
- Extended task scaffolding and spawning with `--scout`, persisted task `kind` metadata, and documented scout intake, supervision, teardown, and Done backlog entries.
- Added in-place scout promotion via `bin/fm-promote.sh` and updated teardown protections so scout scratch work can only be discarded after a report exists while ship tasks retain unpushed-work safeguards.

## Risk Assessment

✅ Low: The change is well-bounded to firstmate task orchestration scripts and documentation, and the previously flagged promotion handoff risk is addressed with explicit cleanup-before-branch guidance.

## Testing

Exercised the scout flow through the actual firstmate shell scripts and treehouse-backed spawn/teardown path, captured reviewer-visible CLI transcripts, verified documented edge cases, and confirmed no transient test files remained in the working tree; all tested behavior passed.

<details>
<summary>Evidence: Scout lifecycle transcript</summary>

<code>Shows scout brief scaffolding, `fm-spawn` recording `kind=scout`, teardown refusing before `data/e2e-scout/report.md`, teardown succeeding after the report despite an unpushed scratch commit, and `fm-promote` changing meta to `kind=ship` with ship teardown protection restored.</code>

```text
## Scout lifecycle end-to-end transcript
workspace=/Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KTYK46X0ZFACSPFS8HBDMCKP

### Scaffold scout brief
scaffolded: /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KTYK46X0ZFACSPFS8HBDMCKP/data/e2e-scout/brief.md (scout; replace {TASK})
brief contains scout contract: yes

### Spawn scout with raw inert crewmate command
spawned e2e-scout harness=sh kind=scout window=firstmate:fm-e2e-scout worktree=/Users/kunchen/.treehouse/project-9d4b21/1/project

meta after spawn:
window=firstmate:fm-e2e-scout
worktree=/Users/kunchen/.treehouse/project-9d4b21/1/project
project=/Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KTYK46X0ZFACSPFS8HBDMCKP/.tmp-scout-lifecycle/project
harness=sh
kind=scout

worktree path=/Users/kunchen/.treehouse/project-9d4b21/1/project

### Add scratch work that would block ship teardown
scratch status after commit:
unpushed commit visible: f97b47b scratch scout work

### Teardown refuses when report is missing
REFUSED: scout task e2e-scout has no report at /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KTYK46X0ZFACSPFS8HBDMCKP/data/e2e-scout/report.md.
The report is the work product. Have the crewmate write it (or get the captain's explicit OK to discard, then --force).
missing-report refusal observed

### Report unlocks scout teardown despite unpushed scratch commit
🌳 Terminated lingering processes: zsh (19087), sleep (19317)
🌳 Worktree returned to pool.
teardown e2e-scout complete (window firstmate:fm-e2e-scout, worktree /Users/kunchen/.treehouse/project-9d4b21/1/project)
meta removed after teardown: yes
report preserved after teardown: yes

### Promotion restores ship protection
promoted e2e-promote to ship (teardown protection restored)
next: bin/fm-send.sh fm-e2e-promote '<ship instructions: review scratch state with git status and git log; reset to a clean default-branch base; carry over only intended fix changes; create branch fm/e2e-promote; implement; report done>'
meta after promote:
window=firstmate:fm-e2e-promote
worktree=/Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KTYK46X0ZFACSPFS8HBDMCKP/.tmp-scout-lifecycle/promote-wt
project=/Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KTYK46X0ZFACSPFS8HBDMCKP/.tmp-scout-lifecycle/promote-project
harness=raw
kind=ship
ship teardown now refuses unpushed local commit: REFUSED: worktree /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KTYK46X0ZFACSPFS8HBDMCKP/.tmp-scout-lifecycle/promote-wt has work not on any remote.
unpushed commits:
996cb0f base
Push the branch (or get the captain's explicit OK to discard, then --force).
yes

cleanup complete
```
</details>
<details>
<summary>Evidence: Scout edge-case transcript</summary>

<code>Shows `fm-brief.sh` accepting `--scout` before positional args and `fm-teardown.sh` treating legacy meta without `kind=` as ship-protected.</code>

```text
## Scout edge cases transcript

### fm-brief parses --scout before positional args
scaffolded: /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KTYK46X0ZFACSPFS8HBDMCKP/data/e2e-edge-brief/brief.md (scout; replace {TASK})
scout brief created with front-position flag: yes

### legacy meta without kind= defaults to ship protection
legacy meta contents:
window=firstmate:fm-e2e-legacy
worktree=/Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KTYK46X0ZFACSPFS8HBDMCKP/.tmp-scout-edge-cases/project
project=/Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KTYK46X0ZFACSPFS8HBDMCKP/.tmp-scout-edge-cases/project
harness=raw
legacy teardown refuses unpushed commit: REFUSED: worktree /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KTYK46X0ZFACSPFS8HBDMCKP/.tmp-scout-edge-cases/project has work not on any remote.
unpushed commits:
4d07e57 base
Push the branch (or get the captain's explicit OK to discard, then --force).
yes

cleanup complete
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-promote.sh:22` - The promoted task instructions tell firstmate to have the crewmate create `fm/&lt;id&gt;` from the current scout worktree state. Scout briefs explicitly allow arbitrary scratch edits and commits, so this can put exploratory work on the shipping branch unless promotion first requires an inventory/cleanup step or a reset/cherry-pick of only intended changes.

🔧 Fix: Require clean promotion handoff
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected changed files with `git diff --name-only 8b6f11ad5518e345fd84e022d4caa0dbbabcbdee..45d4b1666643557641983374db58d046cad1c248` and read `AGENTS.md`, `bin/fm-brief.sh`, `bin/fm-spawn.sh`, `bin/fm-teardown.sh`, and `bin/fm-promote.sh`.</code>
- <code>Ran an end-to-end scout lifecycle smoke using `./bin/fm-brief.sh e2e-scout .tmp-scout-lifecycle/project --scout`, `./bin/fm-spawn.sh e2e-scout .tmp-scout-lifecycle/project &#34;sh -c &#39;sleep 300&#39;&#34; --scout`, scratch commit creation in the treehouse worktree, missing-report teardown refusal, report creation, successful scout teardown, and `./bin/fm-promote.sh e2e-promote`.</code>
- <code>Ran edge-case smoke checks for `./bin/fm-brief.sh --scout e2e-edge-brief .tmp-scout-edge-cases/project` and `./bin/fm-teardown.sh e2e-legacy` with a legacy meta file lacking `kind=`.</code>
- <code>Checked for leftover working-tree artifacts with `git status --short` plus glob checks for `.tmp-scout-*`, `data/e2e-*`, and `state/e2e-*`.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
