### PR TITLE
feat(bin): guard watcher liveness across supervision scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,7 @@ state/               volatile runtime signals; gitignored
   <id>.meta          written by fm-spawn: window=, worktree=, project=, harness=, kind= (fm-pr-check appends pr=)
   <id>.check.sh      optional slow poll you write per task (e.g. merged-PR check)
   .hash-* .count-* .stale-* .seen-* .last-* .heartbeat-streak   watcher internals; never touch
+  .last-watcher-beat watcher liveness beacon, touched every poll; fm-guard.sh reads it
 .no-mistakes/        local validation state and evidence; gitignored
 ```
 
@@ -318,6 +319,14 @@ Heartbeats back off exponentially while they are the only wakes firing (600s dou
 
 Never rely on hooks or status files alone; the heartbeat review of every window is mandatory and unconditional.
 tmux is the ground truth.
+
+**Watcher liveness is guarded, not just disciplined.**
+Restarting the watcher is the last action of every wake-handling turn - but the protocol no longer relies on remembering that.
+While running, `fm-watch.sh` touches `state/.last-watcher-beat` every poll cycle.
+The supervision scripts (`fm-peek`, `fm-send`, `fm-spawn`, `fm-teardown`, `fm-pr-check`, `fm-promote`) call `bin/fm-guard.sh` first, which warns to stderr when any task is in flight (`state/*.meta` exists) but that beacon is missing or older than `FM_GUARD_GRACE` (default 300s).
+So the next time you touch the fleet with no watcher alive, the tool output itself tells you to restart it - a pull-based guard that works on any harness, since it rides the script output you already read rather than a harness-specific hook.
+The grace window keeps normal handling (watcher briefly down between a wake and its restart) silent.
+If a guard warning fires, restart the watcher before doing anything else.
 
 Token discipline: status files before panes; default peeks to 40 lines; never stream a pane repeatedly through yourself; batch what you tell the captain.
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ firstmate works from any terminal - outside tmux, crewmates land in a detached `
      └─ scout: report at data/<id>/report.md ► relay findings ► teardown
 ```
 
-- **Event-driven supervision** — a zero-token bash watcher (`bin/fm-watch.sh`) sleeps on the fleet and wakes the first mate only when a crewmate reports, stalls, or a PR merges. An idle crew costs you nothing.
+- **Event-driven supervision** — a zero-token bash watcher (`bin/fm-watch.sh`) sleeps on the fleet and wakes the first mate only when a crewmate reports, stalls, or a PR merges. A pull-based guard (`bin/fm-guard.sh`) warns through supervision tool output if tasks are in flight and that watcher stops running. An idle crew costs you nothing.
 - **Worktrees, not branches in your checkout** — crewmates never touch your clone; treehouse pools clean worktrees so parallel tasks on one repo cannot collide.
 - **Two task shapes** — ship tasks change projects and end in a validated PR; scout tasks investigate, plan, reproduce bugs, or audit, then leave a report at `data/<id>/report.md` and never push.
 - **Validation is non-negotiable for shipping** — every project gets `no-mistakes init`; every ship task ends with its pipeline. Human-judgment findings escalate to you through the first mate.
@@ -121,6 +121,7 @@ The first mate drives these; you rarely need to, but they work by hand too.
 | ----------------- | ------------------------------------------------------------------------------------------- |
 | `fm-bootstrap.sh` | Detect missing toolchain pieces; install them only after consent                            |
 | `fm-brief.sh`     | Scaffold a ship brief, or a report-only scout brief with `--scout`                          |
+| `fm-guard.sh`     | Warn when tasks are in flight but the watcher liveness beacon is stale or missing           |
 | `fm-spawn.sh`     | Window → treehouse worktree → agent launched with its brief; records ship/scout task kind   |
 | `fm-watch.sh`     | Block until a crewmate needs attention; exits with one reason line                          |
 | `fm-send.sh`      | Send one literal line (or `--key Escape`) to a crewmate window                              |
@@ -143,6 +144,7 @@ FM_POLL=15              # seconds between watcher cycles
 FM_HEARTBEAT=600        # base seconds between fleet reviews; backs off exponentially while idle
 FM_HEARTBEAT_MAX=7200   # heartbeat backoff cap
 FM_CHECK_INTERVAL=300   # seconds between slow checks (merged-PR polls)
+FM_GUARD_GRACE=300      # seconds a stale watcher beacon may age before guard warnings
 FM_SIGNAL_GRACE=30      # seconds to coalesce nearby status and turn-end signals into one wake
 FM_BUSY_REGEX='esc (to )?interrupt|Working\.\.\.'   # busy-pane signatures, extend per harness
 ```

--- a/bin/fm-guard.sh
+++ b/bin/fm-guard.sh
@@ -13,7 +13,13 @@ FM_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 STATE="$FM_ROOT/state"
 GRACE=${FM_GUARD_GRACE:-300}
 
-ls "$STATE"/*.meta >/dev/null 2>&1 || exit 0
+has_meta=false
+for meta in "$STATE"/*.meta; do
+  [ -e "$meta" ] || continue
+  has_meta=true
+  break
+done
+"$has_meta" || exit 0
 
 BEAT="$STATE/.last-watcher-beat"
 if [ -e "$BEAT" ]; then

--- a/bin/fm-guard.sh
+++ b/bin/fm-guard.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Watcher liveness guard, called at the top of the supervision scripts.
+# If any task is in flight (a state/<id>.meta exists) and the watcher's
+# liveness beacon (state/.last-watcher-beat, touched every poll cycle) is
+# missing or older than FM_GUARD_GRACE seconds, prints a loud warning so the
+# agent sees it in the tool output of whatever it was doing - the one channel
+# every harness has. Normal wake handling (watcher briefly down between a wake
+# and its restart) stays inside the grace window and stays silent.
+# Always exits 0: the guard warns, it never blocks.
+set -u
+
+FM_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+STATE="$FM_ROOT/state"
+GRACE=${FM_GUARD_GRACE:-300}
+
+ls "$STATE"/*.meta >/dev/null 2>&1 || exit 0
+
+BEAT="$STATE/.last-watcher-beat"
+if [ -e "$BEAT" ]; then
+  m=$(stat -f %m "$BEAT" 2>/dev/null || stat -c %Y "$BEAT" 2>/dev/null) || exit 0
+  age=$(( $(date +%s) - m ))
+  [ "$age" -lt "$GRACE" ] && exit 0
+  echo "WARNING: tasks are in flight but no watcher has been alive for ${age}s (>${GRACE}s)." >&2
+else
+  echo "WARNING: tasks are in flight but no watcher has ever run (no liveness beacon)." >&2
+fi
+echo "Restart it NOW, before anything else: run bin/fm-watch.sh as a background task." >&2
+exit 0

--- a/bin/fm-peek.sh
+++ b/bin/fm-peek.sh
@@ -4,6 +4,8 @@
 #   <window> may be a bare window name (fm-xyz) or session:window.
 set -eu
 
+"$(dirname "${BASH_SOURCE[0]}")/fm-guard.sh" || true
+
 resolve() {
   case "$1" in
     *:*) echo "$1" ;;

--- a/bin/fm-pr-check.sh
+++ b/bin/fm-pr-check.sh
@@ -7,6 +7,7 @@
 set -eu
 
 FM_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+"$FM_ROOT/bin/fm-guard.sh" || true
 ID=$1
 URL=$2
 

--- a/bin/fm-pr-check.sh
+++ b/bin/fm-pr-check.sh
@@ -17,7 +17,7 @@ if [ -f "$META" ] && ! grep -qxF "pr=$URL" "$META"; then
 fi
 
 cat > "$FM_ROOT/state/$ID.check.sh" <<EOF
-state=\$(gh pr view $URL --json state -q .state 2>/dev/null)
+state=\$(gh pr view "$URL" --json state -q .state 2>/dev/null)
 [ "\$state" = "MERGED" ] && echo "merged"
 EOF
 echo "armed: state/$ID.check.sh polls $URL"

--- a/bin/fm-promote.sh
+++ b/bin/fm-promote.sh
@@ -10,6 +10,7 @@
 set -eu
 
 FM_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+"$FM_ROOT/bin/fm-guard.sh" || true
 ID=$1
 META="$FM_ROOT/state/$ID.meta"
 [ -f "$META" ] || { echo "error: no meta for task $ID at $META" >&2; exit 1; }

--- a/bin/fm-send.sh
+++ b/bin/fm-send.sh
@@ -5,6 +5,8 @@
 # Special keys instead of text: fm-send.sh <window> --key Escape   (or Enter, C-c, ...)
 set -eu
 
+"$(dirname "${BASH_SOURCE[0]}")/fm-guard.sh" || true
+
 resolve() {
   case "$1" in
     *:*) echo "$1" ;;

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -18,6 +18,7 @@
 set -eu
 
 FM_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+"$FM_ROOT/bin/fm-guard.sh" || true
 KIND=ship
 POS=()
 for a in "$@"; do

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -11,6 +11,7 @@
 set -eu
 
 FM_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+"$FM_ROOT/bin/fm-guard.sh" || true
 STATE="$FM_ROOT/state"
 ID=$1
 FORCE=${2:-}

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -72,6 +72,10 @@ scan_signals() {
 }
 
 while :; do
+  # Liveness beacon for fm-guard.sh: a fresh mtime here means a watcher is
+  # alive. Supervision scripts warn when this goes stale with tasks in flight.
+  touch "$STATE/.last-watcher-beat"
+
   # On the first changed signal, linger one grace period and re-scan before
   # waking: a crewmate's final status write and the same turn's turn-end hook
   # land seconds apart, and reporting them as separate wakes costs a full


### PR DESCRIPTION
## Intent

Make firstmate's watcher-liveness robust across ALL crewmate harnesses, not just Claude Code. Context: this session firstmate twice ended a turn without restarting the background watcher (fm-watch.sh), so a crewmate's 'done' signal went unnoticed for minutes. Earlier-considered fixes (Claude Code Stop hooks, persistent monitors) were rejected because the firstmate template must work on codex/opencode/pi too. The harness-agnostic channel chosen is tool output, which firstmate reads constantly while supervising. Changes: (1) fm-watch.sh touches state/.last-watcher-beat every poll cycle as a liveness beacon (no PIDs, works everywhere); (2) new bin/fm-guard.sh: if any state/*.meta exists (task in flight) and the beacon is missing or older than FM_GUARD_GRACE (default 300s), it prints a loud restart warning to STDERR and always exits 0 (warn, never block); the 300s grace keeps normal wake handling - watcher briefly down between a wake and its restart - silent; (3) the supervision scripts fm-peek, fm-send, fm-spawn, fm-teardown, fm-pr-check, fm-promote call fm-guard.sh first so the warning rides whatever output firstmate was already reading; fm-brief is deliberately NOT guarded because it only scaffolds a file and often runs before any task exists; (4) AGENTS.md section 8 documents the beacon+guard as a pull-based guard replacing pure discipline, section 2 lists the new state file. Deliberate decisions: guard writes to stderr to avoid polluting fm-peek's parseable stdout (pane capture); guard is pull-based by design - it cannot fire if firstmate ends a turn and never touches the fleet again, with the next captain message as the recovery point, because closing that last gap would require a per-harness push channel which is the exact dependency we are avoiding; absent kind= in older meta defaults to ship. All branches smoke-tested locally (silent with fresh beacon, warns with stale/missing beacon and a live task, all scripts pass bash -n).

## What Changed
- Added `fm-guard.sh` to warn on stderr when tasks are in flight and the watcher heartbeat beacon is missing or stale, without blocking supervision commands.
- Updated `fm-watch.sh` to refresh `state/.last-watcher-beat` every poll cycle and wired the guard into the supervision entrypoints.
- Documented the watcher beacon, guard behavior, and new state file in `AGENTS.md` and `README.md`.

## Risk Assessment

✅ Low: The change is limited to a non-blocking watcher-liveness beacon and guard wiring around existing supervision scripts, with no material correctness issues found in the reviewed diff.

## Testing

Exercised the watcher-guard flow end-to-end as a firstmate would experience it through CLI output: guard silence with no task or fresh beacon, loud stderr warnings for missing and stale watcher beacons with in-flight metadata, warning propagation through a guarded supervision script, and `fm-watch.sh` creating the liveness beacon; no automated test suite was present, the CLI transcript was captured as evidence, and the worktree was clean after removing transient state.

<details>
<summary>Evidence: Watcher guard CLI transcript</summary>

<code>Shows no-task silence, missing-beacon warning, stale-beacon warning, fresh-beacon silence, guarded supervision-script warning propagation, and `fm-watch.sh` creating `state/.last-watcher-beat`.</code>

```text
## no-task
command: ./bin/fm-guard.sh
exit: 0
stdout:
  <empty>
stderr:
  <empty>

## missing-beacon
command: ./bin/fm-guard.sh
exit: 0
stdout:
  <empty>
stderr:
  WARNING: tasks are in flight but no watcher has ever run (no liveness beacon).
  Restart it NOW, before anything else: run bin/fm-watch.sh as a background task.

## stale-beacon
command: env FM_GUARD_GRACE=300 ./bin/fm-guard.sh
exit: 0
stdout:
  <empty>
stderr:
  WARNING: tasks are in flight but no watcher has been alive for 203432772s (>300s).
  Restart it NOW, before anything else: run bin/fm-watch.sh as a background task.

## fresh-beacon
command: env FM_GUARD_GRACE=300 ./bin/fm-guard.sh
exit: 0
stdout:
  <empty>
stderr:
  <empty>

## supervised-script-warning
command: ./bin/fm-promote.sh demo
exit: 1
stdout:
  <empty>
stderr:
  WARNING: tasks are in flight but no watcher has ever run (no liveness beacon).
  Restart it NOW, before anything else: run bin/fm-watch.sh as a background task.
  error: task demo is not a scout task (kind=scout not in meta)

## watcher-beacon
command: ./bin/fm-watch.sh (started in background for 1s, then stopped)
state/.last-watcher-beat: present
stdout:
  <empty>
stderr:
  <empty>
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected target diff from `d3f8a1c18ffec95e2c3c27ca47835970ee84d68c..44499023f2e3e7fd2d3835f107800698eccd71ac` to identify watcher-liveness intent and affected scripts.</code>
- <code>Created an isolated `state/` fixture and ran `./bin/fm-guard.sh` with no `*.meta` task files to confirm it exits 0 and stays silent when no task is in flight.</code>
- <code>Created `state/demo.meta` with no `state/.last-watcher-beat` and ran `./bin/fm-guard.sh` to confirm it warns on stderr, leaves stdout empty, and exits 0.</code>
- <code>Touched an old `state/.last-watcher-beat` and ran `env FM_GUARD_GRACE=300 ./bin/fm-guard.sh` to confirm stale watcher detection warns on stderr without blocking.</code>
- <code>Touched a fresh `state/.last-watcher-beat` and ran `env FM_GUARD_GRACE=300 ./bin/fm-guard.sh` to confirm the grace-window path stays silent.</code>
- <code>Ran guarded supervision entrypoint `./bin/fm-promote.sh demo` against the fixture to confirm the watcher warning rides a supervision script&#39;s stderr before that script&#39;s own task error.</code>
- <code>Started `./bin/fm-watch.sh` in the background for 1 second, then stopped it, confirming it created `state/.last-watcher-beat`.</code>
- <code>Searched for existing tests with `Glob` patterns `**/*test*`, `**/package.json`, and `**/Makefile`; none were present.</code>
- <code>Removed the transient `state/` fixture and verified cleanup with `git status --short`.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
