### PR TITLE
fix: keep idle watcher supervision silent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -306,6 +306,9 @@ From there the task is an ordinary ship task through PR ready and Teardown.
 The watcher is the backbone.
 Whenever at least one task is in flight, `bin/fm-watch.sh` must be running as a background task.
 It costs zero tokens while running and exits with one reason line when something needs you; restart it after handling every wake, and before you end any turn.
+Waiting on the watcher is intentionally silent.
+After starting or restarting it, do not send idle progress updates to the captain; wait until it returns `signal`, `stale`, `check`, or `heartbeat`, unless the captain asks for status.
+Empty polls, elapsed waiting time, and "still no change" are tool bookkeeping, not conversational progress.
 
 ```sh
 bin/fm-watch.sh   # run in background; exits with: signal|stale|check|heartbeat
@@ -318,6 +321,7 @@ On wake, in order of cheapness:
 3. `stale:` the crewmate stopped without reporting; peek the pane (`bin/fm-peek.sh <window>`) to diagnose.
 4. `check:` a per-task poll fired (usually a merge); act on it.
 5. `heartbeat:` review the whole fleet: skim each window's status file, peek panes that look off, check PR-ready tasks for merge, reconcile data/backlog.md, then restart the watcher.
+   A heartbeat with no captain-relevant change is internal; do not report that the fleet is unchanged.
 
 Heartbeats back off exponentially while they are the only wakes firing (600s doubling to a 2h cap - an idle fleet stops burning turns); any signal, stale, or check wake resets the cadence to the base interval.
 
@@ -337,6 +341,7 @@ This includes your own no-mistakes pipeline, long builds, and any other multi-mi
 Background that work so watcher wakes can interleave with it and the supervision loop stays responsive.
 
 Token discipline: status files before panes; default peeks to 40 lines; never stream a pane repeatedly through yourself; batch what you tell the captain.
+Silence is the correct state while a healthy background watcher is waiting.
 
 ### Stuck-crewmate playbook (escalate in order)
 
@@ -358,6 +363,7 @@ Reaches the captain immediately:
 - A needed credential or login.
 
 Does not reach the captain: auto-fixes, retries, routine progress, watcher mechanics.
+Routine watcher mechanics include restarting the watcher, polling a waiting watcher, and confirming that no status changed.
 Batch non-urgent updates into your next natural reply.
 Use lavish-axi for multi-option decisions and fleet reports worth a visual; plain chat for yes/no.
 As a courtesy, mention cost when the fleet grows unusually large (more than ~8 concurrent crewmates); never block on it.

--- a/README.md
+++ b/README.md
@@ -107,7 +107,9 @@ firstmate works from any terminal - outside tmux, crewmates land in a detached `
      └─ scout: report at data/<id>/report.md ► relay findings ► teardown
 ```
 
-- **Event-driven supervision** — a zero-token bash watcher (`bin/fm-watch.sh`) sleeps on the fleet and wakes the first mate only when a crewmate reports, stalls, or a PR merges. A pull-based guard (`bin/fm-guard.sh`) warns through supervision tool output if tasks are in flight and that watcher stops running. An idle crew costs you nothing.
+- **Event-driven supervision** — a zero-token bash watcher (`bin/fm-watch.sh`) sleeps on the fleet and wakes the first mate only when a crewmate reports, stalls, a PR merges, or an internal heartbeat review is due.
+  Routine watcher polling, restarts, elapsed waiting time, and unchanged heartbeat reviews stay silent; an idle crew costs you nothing.
+  A pull-based guard (`bin/fm-guard.sh`) warns through supervision tool output if tasks are in flight and that watcher stops running.
 - **Worktrees, not branches in your checkout** — crewmates never touch your clone; treehouse pools clean worktrees so parallel tasks on one repo cannot collide.
 - **Two task shapes** — ship tasks change projects and end in a validated PR; scout tasks investigate, plan, reproduce bugs, or audit, then leave a report at `data/<id>/report.md` and never push.
 - **Validation is non-negotiable for shipping** — every project gets `no-mistakes init`; every ship task ends with its pipeline. Human-judgment findings escalate to you through the first mate.
@@ -123,7 +125,7 @@ The first mate drives these; you rarely need to, but they work by hand too.
 | `fm-brief.sh`     | Scaffold a ship brief, or a report-only scout brief with `--scout`                          |
 | `fm-guard.sh`     | Warn when tasks are in flight but the watcher liveness beacon is stale or missing           |
 | `fm-spawn.sh`     | Window → treehouse worktree → agent launched with its brief; records ship/scout task kind   |
-| `fm-watch.sh`     | Block until a crewmate needs attention; exits with one reason line                          |
+| `fm-watch.sh`     | Block until supervision work is due; exits with one reason line                             |
 | `fm-send.sh`      | Send one literal line (or `--key Escape`) to a crewmate window                              |
 | `fm-peek.sh`      | Print a bounded tail of a crewmate pane                                                     |
 | `fm-pr-check.sh`  | Record a PR-ready task and arm the watcher's merge poll                                     |

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Firstmate watcher.
-# Blocks until any managed crewmate needs attention, then exits printing one reason line:
+# Blocks until supervision work is due, then exits printing one reason line:
 #   signal: <file>...     a crewmate wrote a status line or a turn-end hook fired; signals
 #                         landing within FM_SIGNAL_GRACE of each other coalesce into one wake
 #   stale: <window>       a crewmate pane stopped changing and shows no busy signature


### PR DESCRIPTION
## Intent

The captain asked me to update firstmate's own instructions so future supervision through bin/fm-watch.sh does not waste user-facing turns with idle status messages. The change should clarify that waiting on the watcher is intentionally silent, empty polls and elapsed waiting time are internal tool bookkeeping, unchanged heartbeat reviews should not be reported, and watcher mechanics such as restart/poll/no-change confirmations do not reach the captain unless they reveal a captain-relevant issue.

## What Changed
- Clarifies firstmate supervision instructions so waiting on `bin/fm-watch.sh`, empty polls, elapsed waiting time, and no-change heartbeat reviews remain internal instead of user-facing updates.
- Updates the README and watcher script wording to describe `fm-watch.sh` as waking when supervision work is due, including heartbeat reviews, not only when a crewmate needs attention.
- Documents that routine watcher mechanics such as polling, restarting, and confirming no status changed should not reach the captain unless they surface a relevant issue.

## Risk Assessment

✅ Low: The change only clarifies documentation for watcher communication behavior and does not alter executable code or operational mechanics.

## Testing

I verified the documentation-only behavior change by inspecting the changed AGENTS.md supervision flow and producing an evidence transcript showing every intended watcher-silence rule present; no source tests were applicable, and the working tree remained clean.

<details>
<summary>Evidence: Watcher-silence instruction evidence</summary>

<code>309:Waiting on the watcher is intentionally silent.&#10;310:After starting or restarting it, do not send idle progress updates to the captain; wait until it returns `signal`, `stale`, `check`, or `heartbeat`, unless the captain asks for status.&#10;311:Empty polls, elapsed waiting time, and &#34;still no change&#34; are tool bookkeeping, not conversational progress.&#10;324: A heartbeat with no captain-relevant change is internal; do not report that the fleet is unchanged.&#10;344:Silence is the correct state while a healthy background watcher is waiting.&#10;366:Routine watcher mechanics include restarting the watcher, polling a waiting watcher, and confirming that no status changed.</code>

```text
Changed watcher-silence instructions in AGENTS.md:

309:Waiting on the watcher is intentionally silent.
310:After starting or restarting it, do not send idle progress updates to the captain; wait until it returns `signal`, `stale`, `check`, or `heartbeat`, unless the captain asks for status.
311:Empty polls, elapsed waiting time, and "still no change" are tool bookkeeping, not conversational progress.
324:   A heartbeat with no captain-relevant change is internal; do not report that the fleet is unchanged.
344:Silence is the correct state while a healthy background watcher is waiting.
366:Routine watcher mechanics include restarting the watcher, polling a waiting watcher, and confirming that no status changed.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Reviewed `git diff f3958097383870fbc9be46365016a5252a73beff..HEAD -- AGENTS.md` to confirm the change scope is limited to watcher-silence instructions.</code>
- <code>Read `AGENTS.md` section 8 and section 9 around lines 304-366 to evaluate the end-user supervision instructions in context.</code>
- <code>Ran `rg -n &#39;Waiting on the watcher|idle progress|Empty polls|heartbeat.*captain-relevant|Silence is the correct state|Routine watcher mechanics&#39; AGENTS.md` and saved the matching instruction lines as evidence.</code>
- <code>Ran `git status --short` after testing to confirm no working-tree artifacts were created.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
