### PR TITLE
docs: require full PR URLs in captain reports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -285,7 +285,7 @@ bin/fm-teardown.sh <id>
 
 The script refuses if the worktree holds unpushed work; treat a refusal as a stop-and-investigate, not an obstacle.
 Known benign case: after an external-PR task, a squash merge leaves the branch commits reachable only on the contributor's fork; add the fork as a remote and fetch (`git remote add fork <fork url> && git fetch fork`), then retry - never reach for `--force`.
-Then move the task to Done in `data/backlog.md` (with PR link and date), re-evaluate the queue, and dispatch anything that was blocked on this task.
+Then move the task to Done in `data/backlog.md` (with the full `https://...` PR URL and date), re-evaluate the queue, and dispatch anything that was blocked on this task.
 
 ### Scout tasks (report instead of PR)
 
@@ -382,7 +382,7 @@ Update it on every dispatch, completion, and decision.
 - [ ] <id> - <one line> (repo: <name>) blocked-by: <id> - <reason>
 
 ## Done
-- [x] <id> - <one line> - <PR url> (merged <date>)
+- [x] <id> - <one line> - <https://github.com/owner/repo/pull/number> (merged <date>)
 - [x] <id> - <one line> - data/<id>/report.md (reported <date>)
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -272,7 +272,7 @@ Use chat for yes/no decisions; use lavish-axi when there are multiple findings o
 
 For ship tasks, when the pipeline reaches CI-green, the crewmate reports `done: PR <url> checks green`.
 Run `bin/fm-pr-check.sh <id> <PR url>` - it records `pr=` in the task's meta and arms the watcher's merge poll.
-Tell the captain: PR link, one-paragraph summary, and the risk level no-mistakes emitted.
+Tell the captain: the PR's full URL (always the complete `https://...` link, never a bare `#number` - the captain's terminal makes a full URL clickable), a one-paragraph summary, and the risk level no-mistakes emitted.
 (The check contract, for any custom `state/<id>.check.sh` you write yourself: print one line only when firstmate should wake, print nothing otherwise.)
 
 If the captain says "merge it", run `gh-axi pr merge` yourself; that instruction is the explicit approval.
@@ -366,6 +366,7 @@ Does not reach the captain: auto-fixes, retries, routine progress, watcher mecha
 Routine watcher mechanics include restarting the watcher, polling a waiting watcher, and confirming that no status changed.
 Batch non-urgent updates into your next natural reply.
 Use lavish-axi for multi-option decisions and fleet reports worth a visual; plain chat for yes/no.
+Whenever you reference a PR to the captain - PR-ready, status updates, backlog lines you quote - give its full `https://...` URL, never a bare `#number`: the captain's terminal makes a full URL clickable. A shorthand `#number` is fine only as a back-reference after the full URL has already appeared in the same message.
 As a courtesy, mention cost when the fleet grows unusually large (more than ~8 concurrent crewmates); never block on it.
 
 ## 10. Backlog format

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -366,7 +366,8 @@ Does not reach the captain: auto-fixes, retries, routine progress, watcher mecha
 Routine watcher mechanics include restarting the watcher, polling a waiting watcher, and confirming that no status changed.
 Batch non-urgent updates into your next natural reply.
 Use lavish-axi for multi-option decisions and fleet reports worth a visual; plain chat for yes/no.
-Whenever you reference a PR to the captain - PR-ready, status updates, backlog lines you quote - give its full `https://...` URL, never a bare `#number`: the captain's terminal makes a full URL clickable. A shorthand `#number` is fine only as a back-reference after the full URL has already appeared in the same message.
+Whenever you reference a PR to the captain - PR-ready, status updates, backlog lines you quote - give its full `https://...` URL, never a bare `#number`: the captain's terminal makes a full URL clickable.
+A shorthand `#number` is fine only as a back-reference after the full URL has already appeared in the same message.
 As a courtesy, mention cost when the fleet grows unusually large (more than ~8 concurrent crewmates); never block on it.
 
 ## 10. Backlog format


### PR DESCRIPTION
## Intent

Document a firstmate reporting convention the captain requested: when reporting a PR to the captain, always give the PR's full https URL, never a bare #number, because the captain's terminal makes full URLs clickable. Docs-only change to AGENTS.md - §7 (PR-ready: the crewmate report to the captain) and §9 (captain etiquette). No code, no behavior change; purely a communication-style rule for firstmate.

## What Changed

- Updated firstmate PR-ready instructions to require complete `https://...` PR URLs instead of bare `#number` references when reporting to the captain.
- Clarified ship teardown and backlog examples to record full GitHub PR URLs.
- Added captain-etiquette guidance allowing shorthand PR numbers only after the full URL appears in the same message.

## Risk Assessment

✅ Low: The change is docs-only, narrowly scoped to firstmate PR reporting guidance, and introduces no behavior or code-path risk.

## Testing

For this docs-only change, I verified the target commit changes only AGENTS.md, inspected the two requested documentation sections, confirmed the end-user-facing firstmate convention now requires complete https PR URLs instead of bare #numbers, and saved a focused diff artifact as reviewer evidence; no runtime tests were applicable.

<details>
<summary>Evidence: Focused AGENTS.md diff showing full PR URL convention</summary>

<code>diff --git a/AGENTS.md b/AGENTS.md&#10;@@ -272,7 +272,7 @@&#10;For ship tasks, when the pipeline reaches CI-green, the crewmate reports `done: PR &lt;url&gt; checks green`.&#10;Run `bin/fm-pr-check.sh &lt;id&gt; &lt;PR url&gt;` - it records `pr=` in the task&#39;s meta and arms the watcher&#39;s merge poll.&#10;-Tell the captain: PR link, one-paragraph summary, and the risk level no-mistakes emitted.&#10;+Tell the captain: the PR&#39;s full URL (always the complete `https://...` link, never a bare `#number` - the captain&#39;s terminal makes a full URL clickable), a one-paragraph summary, and the risk level no-mistakes emitted.&#10;@@ -366,6 +366,7 @@&#10;Routine watcher mechanics include restarting the watcher, polling a waiting watcher, and confirming that no status changed.&#10;Batch non-urgent updates into your next natural reply.&#10;Use lavish-axi for multi-option decisions and fleet reports worth a visual; plain chat for yes/no.&#10;+Whenever you reference a PR to the captain - PR-ready, status updates, backlog lines you quote - give its full `https://...` URL, never a bare `#number`: the captain&#39;s terminal makes a full URL clickable. A shorthand `#number` is fine only as a back-reference after the full URL has already appeared in the same message.</code>

```text
diff --git a/AGENTS.md b/AGENTS.md
index ad58f84..f6b38dc 100644
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -272,7 +272,7 @@ Use chat for yes/no decisions; use lavish-axi when there are multiple findings o
 
 For ship tasks, when the pipeline reaches CI-green, the crewmate reports `done: PR <url> checks green`.
 Run `bin/fm-pr-check.sh <id> <PR url>` - it records `pr=` in the task's meta and arms the watcher's merge poll.
-Tell the captain: PR link, one-paragraph summary, and the risk level no-mistakes emitted.
+Tell the captain: the PR's full URL (always the complete `https://...` link, never a bare `#number` - the captain's terminal makes a full URL clickable), a one-paragraph summary, and the risk level no-mistakes emitted.
 (The check contract, for any custom `state/<id>.check.sh` you write yourself: print one line only when firstmate should wake, print nothing otherwise.)
 
 If the captain says "merge it", run `gh-axi pr merge` yourself; that instruction is the explicit approval.
@@ -366,6 +366,7 @@ Does not reach the captain: auto-fixes, retries, routine progress, watcher mecha
 Routine watcher mechanics include restarting the watcher, polling a waiting watcher, and confirming that no status changed.
 Batch non-urgent updates into your next natural reply.
 Use lavish-axi for multi-option decisions and fleet reports worth a visual; plain chat for yes/no.
+Whenever you reference a PR to the captain - PR-ready, status updates, backlog lines you quote - give its full `https://...` URL, never a bare `#number`: the captain's terminal makes a full URL clickable. A shorthand `#number` is fine only as a back-reference after the full URL has already appeared in the same message.
 As a courtesy, mention cost when the fleet grows unusually large (more than ~8 concurrent crewmates); never block on it.
 
 ## 10. Backlog format
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --stat a5ffb9f4b5d0ed57d5918fa6f508617007a4bb2f..b22d446d5613e79150a0bc3308a1287f6e22b289`
- <code>`grep` search in `AGENTS.md` for full URL / bare #number wording</code>
- <code>Manual review of `AGENTS.md:271-275` and `AGENTS.md:365-369`</code>
- `git diff a5ffb9f4b5d0ed57d5918fa6f508617007a4bb2f..b22d446d5613e79150a0bc3308a1287f6e22b289 -- AGENTS.md > /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KV18CD7W7MXC6ZFTBYKR8W3M/full-pr-url-doc-diff.patch`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
