### PR TITLE
fix: wake pi crewmates after each turn

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,6 +156,7 @@ pi has no permission system - crewmates are always autonomous.
 Keep the brief as ONE positional argument - multiple positional args become separate queued messages (fm-spawn's template does this correctly).
 Project trust dialog can appear on the first pi run in any not-yet-trusted directory (observed even on clean worktrees); accept with Enter - the decision persists per path in `~/.pi/agent/trust.json`, so later spawns in the same worktree slot skip it.
 fm-spawn keeps the turn-end extension in `state/`, outside the worktree, because project-local extension files make the trust gate strictly worse (and pollute the project).
+The extension must listen for pi's `turn_end` event, not `agent_end`, so the watcher wakes after each completed turn instead of only when the whole agent run exits.
 Environment marker for harness detection: pi sets `PI_CODING_AGENT=true` for its children.
 
 ## 5. Recovery (run at every session start, after bootstrap)

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -135,9 +135,12 @@ EOF
     # elsewhere loads without a dialog. Lives in state/, cleaned by teardown.
     cat > "$FM_ROOT/state/$ID.pi-ext.ts" <<EOF
 // Firstmate turn-end signal; written by fm-spawn.
+// Use "turn_end" (fires after each turn the agent finishes), not "agent_end"
+// (fires once, only when the whole run exits): the watcher needs a signal at
+// every turn boundary so an idle crewmate is surfaced, not just at shutdown.
 import { execFile } from "node:child_process";
 export default function (pi: any) {
-  pi.on("agent_end", () => execFile("touch", ["$TURNEND"]));
+  pi.on("turn_end", () => execFile("touch", ["$TURNEND"]));
 }
 EOF
     ;;


### PR DESCRIPTION
## Intent

Fix firstmate's pi crewmate turn-end hook. fm-spawn's generated pi extension listened on pi's 'agent_end' event, which (per pi 0.79.1 type docs) fires only once when the whole agent run exits - so the turn-end backstop never fired at per-turn boundaries for pi crewmates, leaving firstmate reliant on crewmate status appends alone and blind to an idle crewmate that stopped without writing status. Change the hook to 'turn_end', which fires after each turn the agent finishes, matching how the claude/codex/opencode adapters behave. One-line change to the pi-ext template in bin/fm-spawn.sh plus an explanatory comment; no other behavior change.

## What Changed
- Updated the pi harness extension generated by `bin/fm-spawn.sh` to listen for `turn_end` instead of `agent_end`, so firstmate receives a turn-ended signal after each completed pi turn rather than only when the whole agent run exits.
- Added an inline comment explaining why the pi hook must use `turn_end` for per-turn idle detection.
- Documented the pi adapter requirement in `AGENTS.md` so future harness changes preserve the same watcher behavior.

## Risk Assessment

✅ Low: The branch is a narrow one-line event-name correction plus explanatory generated-code comments, with no broader control-flow or API surface changes.

## Testing

Baseline bootstrap could not run due missing local firstmate config state, but the focused end-to-end spawn path was exercised: `fm-spawn.sh` generated and launched a pi extension using `turn_end`; live pi execution stopped at the trust prompt, which I did not accept because it would change user-level trust outside the worktree boundary, so I supplemented it with a mocked extension event simulation proving the generated hook would touch the turn-ended sentinel. All focused checks passed and temporary worktree test scaffolding was removed.

<details>
<summary>Evidence: Generated pi extension evidence</summary>

<code>The emitted extension registers `pi.on(&#34;turn_end&#34;, ...)` and touches `state/pi-hook-e2e.turn-ended`; it contains no `pi.on(&#34;agent_end&#34;, ...)` registration.</code>

```text
// Firstmate turn-end signal; written by fm-spawn.
// Use "turn_end" (fires after each turn the agent finishes), not "agent_end"
// (fires once, only when the whole run exits): the watcher needs a signal at
// every turn boundary so an idle crewmate is surfaced, not just at shutdown.
import { execFile } from "node:child_process";
export default function (pi: any) {
  pi.on("turn_end", () => execFile("touch", ["/Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KV18PMDX505TN87957JNNXTT/state/pi-hook-e2e.turn-ended"]));
}
```
</details>
<details>
<summary>Evidence: Pi spawn pane transcript</summary>

<code>Shows the real spawn command launching `pi -e /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KV18PMDX505TN87957JNNXTT/state/pi-hook-e2e.pi-ext.ts ...` before pi displayed its project trust prompt.</code>

```text
treehouse get
01KV18PMDX505TN87957JNNXTT HEAD
❯ treehouse get
🌳 Setting up worktree...
🌳 Entered worktree at ~/.treehouse/01KV18PMDX505TN87957JNNXTT-b8697d/1/01KV18PMDX505TN87957JNNXTT. Type 'exit' to return.
01KV18PMDX505TN87957JNNXTT HEAD
❯ pi -e /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KV18PMDX505TN87957JNNXTT/state/pi-hook-e2e.pi-ext.ts "$(cat /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KV18PMDX505TN87957JNNXTT/data/pi-hook-e2e/brief.md)"
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

 Trust project folder?
 /Users/kunchen/.treehouse/01KV18PMDX505TN87957JNNXTT-b8697d/1/01KV18PMDX505TN87957JNNXTT

 This allows pi to load .pi settings and resources, install missing project packages, and execute project extensions.

 → Trust
   Trust parent folder (/Users/kunchen/.treehouse/01KV18PMDX505TN87957JNNXTT-b8697d/1)
   Trust (this session only)
   Do not trust
   Do not trust (this session only)

 ↑↓ navigate  enter select  escape/ctrl+c cancel

───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
```
</details>
<details>
<summary>Evidence: Generated extension event simulation</summary>

<code>registered_event=turn_end&#10;execFile_command=touch&#10;execFile_arg=/Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KV18PMDX505TN87957JNNXTT/state/pi-hook-e2e.turn-ended</code>

```text
registered_event=turn_end
execFile_command=touch
execFile_arg=/Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KV18PMDX505TN87957JNNXTT/state/pi-hook-e2e.turn-ended
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bin/fm-bootstrap.sh` - attempted baseline bootstrap; it failed because this isolated worktree lacks `config/crew-harness` parent state, so validation continued without creating persistent config.</code>
- <code>Created temporary `data/pi-hook-e2e/brief.md` and `state/`, then ran `bin/fm-spawn.sh pi-hook-e2e . pi --scout` to exercise the real pi spawn path.</code>
- <code>Captured `state/pi-hook-e2e.pi-ext.ts` and the tmux pane transcript into `/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KV18PMDX505TN87957JNNXTT`.</code>
- <code>`node -e &#39;...&#39;` asserted the generated pi extension contains `pi.on(&#34;turn_end&#34;...)` and does not register `pi.on(&#34;agent_end&#34;...)`.</code>
- <code>`node -e &#39;...&#39;` asserted the captured spawn transcript launched `pi -e .../state/pi-hook-e2e.pi-ext.ts`.</code>
- <code>`node &lt;&lt;&#39;NODE&#39; ... NODE` loaded the generated extension text with a mocked pi event emitter and verified triggering the registered callback calls `touch` on `state/pi-hook-e2e.turn-ended`.</code>
- <code>`bin/fm-teardown.sh pi-hook-e2e` tore down the spawned scout task; `git status --short` confirmed no temporary worktree scaffolding remained.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
