### PR TITLE
fix: prevent watcher check starvation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -274,7 +274,7 @@ Use chat for yes/no decisions; use lavish-axi when there are multiple findings o
 For ship tasks, when the pipeline reaches CI-green, the crewmate reports `done: PR <url> checks green`.
 Run `bin/fm-pr-check.sh <id> <PR url>` - it records `pr=` in the task's meta and arms the watcher's merge poll.
 Tell the captain: the PR's full URL (always the complete `https://...` link, never a bare `#number` - the captain's terminal makes a full URL clickable), a one-paragraph summary, and the risk level no-mistakes emitted.
-(The check contract, for any custom `state/<id>.check.sh` you write yourself: print one line only when firstmate should wake, print nothing otherwise.)
+(The check contract, for any custom `state/<id>.check.sh` you write yourself: print one line only when firstmate should wake, print nothing otherwise, and finish before `FM_CHECK_TIMEOUT`.)
 
 If the captain says "merge it", run `gh-axi pr merge` yourself; that instruction is the explicit approval.
 
@@ -325,6 +325,7 @@ On wake, in order of cheapness:
    A heartbeat with no captain-relevant change is internal; do not report that the fleet is unchanged.
 
 Heartbeats back off exponentially while they are the only wakes firing (600s doubling to a 2h cap - an idle fleet stops burning turns); any signal, stale, or check wake resets the cadence to the base interval.
+Due per-task checks run before signal scanning so chatty crewmate status updates cannot starve slow polls like merge detection.
 
 Never rely on hooks or status files alone; the heartbeat review of every window is mandatory and unconditional.
 tmux is the ground truth.

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ FM_POLL=15              # seconds between watcher cycles
 FM_HEARTBEAT=600        # base seconds between fleet reviews; backs off exponentially while idle
 FM_HEARTBEAT_MAX=7200   # heartbeat backoff cap
 FM_CHECK_INTERVAL=300   # seconds between slow checks (merged-PR polls)
+FM_CHECK_TIMEOUT=30     # seconds allowed per slow check script
 FM_GUARD_GRACE=300      # seconds a stale watcher beacon may age before guard warnings
 FM_SIGNAL_GRACE=30      # seconds to coalesce nearby status and turn-end signals into one wake
 FM_BUSY_REGEX='esc (to )?interrupt|Working\.\.\.'   # busy-pane signatures, extend per harness

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -17,6 +17,7 @@ POLL=${FM_POLL:-15}                   # seconds between cycles
 HEARTBEAT=${FM_HEARTBEAT:-600}        # base seconds between heartbeat wakes
 HEARTBEAT_MAX=${FM_HEARTBEAT_MAX:-7200}  # heartbeat backoff cap
 CHECK_INTERVAL=${FM_CHECK_INTERVAL:-300}  # seconds between *.check.sh sweeps
+CHECK_TIMEOUT=${FM_CHECK_TIMEOUT:-30}     # seconds allowed per *.check.sh
 SIGNAL_GRACE=${FM_SIGNAL_GRACE:-30}   # seconds to linger after a signal so trailing
                                       # signals (a status write, then the same turn's
                                       # turn-end hook) coalesce into one wake
@@ -71,6 +72,17 @@ scan_signals() {
   return 0
 }
 
+run_check() {
+  local c=$1
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$CHECK_TIMEOUT" bash "$c" 2>/dev/null || true
+  elif command -v gtimeout >/dev/null 2>&1; then
+    gtimeout "$CHECK_TIMEOUT" bash "$c" 2>/dev/null || true
+  else
+    perl -e 'my $t = shift; my $pid = fork; die "fork failed" unless defined $pid; if (!$pid) { setpgrp(0, 0); exec @ARGV } local $SIG{ALRM} = sub { kill "TERM", -$pid; select undef, undef, undef, 0.2; kill "KILL", -$pid; exit 124 }; alarm $t; waitpid $pid, 0; exit($? >> 8)' "$CHECK_TIMEOUT" bash "$c" 2>/dev/null || true
+  fi
+}
+
 while :; do
   # Liveness beacon for fm-guard.sh: a fresh mtime here means a watcher is
   # alive. Supervision scripts warn when this goes stale with tasks in flight.
@@ -87,7 +99,7 @@ while :; do
     touch "$STATE/.last-check"
     for c in "$STATE"/*.check.sh; do
       [ -e "$c" ] || continue
-      out=$(bash "$c" 2>/dev/null || true)
+      out=$(run_check "$c")
       if [ -n "$out" ]; then
         wake "check: $c: $out"
       fi

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -79,6 +79,7 @@ run_check() {
   elif command -v gtimeout >/dev/null 2>&1; then
     gtimeout "$CHECK_TIMEOUT" bash "$c" 2>/dev/null || true
   else
+    # shellcheck disable=SC2016  # single quotes are deliberate: Perl expands its own variables.
     perl -e 'my $t = shift; my $pid = fork; die "fork failed" unless defined $pid; if (!$pid) { setpgrp(0, 0); exec @ARGV } local $SIG{ALRM} = sub { kill "TERM", -$pid; select undef, undef, undef, 0.2; kill "KILL", -$pid; exit 124 }; alarm $t; waitpid $pid, 0; exit($? >> 8)' "$CHECK_TIMEOUT" bash "$c" 2>/dev/null || true
   fi
 }

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -76,6 +76,24 @@ while :; do
   # alive. Supervision scripts warn when this goes stale with tasks in flight.
   touch "$STATE/.last-watcher-beat"
 
+  # Slow per-task checks (firstmate writes these, e.g. a merged-PR poll).
+  # Time-based via .last-check mtime so the cadence survives watcher restarts.
+  # Evaluated BEFORE the signal scan: wake() exits the cycle, so a check placed
+  # after the signal scan would be starved whenever a chatty sibling crewmate
+  # keeps producing signals - the slow poll (e.g. merge detection) would then
+  # never run until the fleet went quiet. Checks are due only every
+  # CHECK_INTERVAL, so most cycles skip this block and fall straight through.
+  if [ "$(age_of "$STATE/.last-check")" -ge "$CHECK_INTERVAL" ]; then
+    touch "$STATE/.last-check"
+    for c in "$STATE"/*.check.sh; do
+      [ -e "$c" ] || continue
+      out=$(bash "$c" 2>/dev/null || true)
+      if [ -n "$out" ]; then
+        wake "check: $c: $out"
+      fi
+    done
+  fi
+
   # On the first changed signal, linger one grace period and re-scan before
   # waking: a crewmate's final status write and the same turn's turn-end hook
   # land seconds apart, and reporting them as separate wakes costs a full
@@ -124,19 +142,6 @@ EOF
       echo 0 > "$cf"
     fi
   done < <(tmux list-windows -a -F '#{session_name}:#{window_name}' 2>/dev/null | grep ':fm-' || true)
-
-  # Slow per-task checks (firstmate writes these, e.g. a merged-PR poll).
-  # Time-based via .last-check mtime so the cadence survives watcher restarts.
-  if [ "$(age_of "$STATE/.last-check")" -ge "$CHECK_INTERVAL" ]; then
-    touch "$STATE/.last-check"
-    for c in "$STATE"/*.check.sh; do
-      [ -e "$c" ] || continue
-      out=$(bash "$c" 2>/dev/null || true)
-      if [ -n "$out" ]; then
-        wake "check: $c: $out"
-      fi
-    done
-  fi
 
   # Heartbeat: firstmate reviews the whole fleet at a regular cadence no matter
   # what. Time-based via .last-heartbeat mtime; interval doubles per consecutive


### PR DESCRIPTION
## Intent

Fix merge-poll starvation in firstmate's watcher (bin/fm-watch.sh). The poll loop evaluated conditions in order signals -> stale -> check-sweep -> heartbeat, and wake() exits the cycle on the first hit. So when a chatty sibling crewmate kept producing status/turn-end signals, every cycle exited on the signal before reaching the check sweep, and the slow per-task polls (e.g. merged-PR detection) were starved indefinitely - observed live: a merged PR went unsurfaced while a sibling task was active. Fix: move the due-check sweep to run right after the liveness beacon, before the signal scan, so due checks run before signals can preempt them. Checks are due only every CHECK_INTERVAL (300s), so most cycles skip the block and fall straight through to the signal scan as before; signals are never lost (persisted .seen-* signatures catch any that land while the watcher is between cycles). Pure reordering of existing blocks plus an explanatory comment; no new behavior.

## What Changed

- Run due watcher check scripts before signal scanning so chatty crewmate status updates cannot indefinitely preempt merge-poll checks.
- Add `FM_CHECK_TIMEOUT` and bounded check execution so slow or hung check scripts cannot block later watcher signals.
- Document the new check ordering and timeout contract in `AGENTS.md` and `README.md`.

## Risk Assessment

✅ Low: The change is narrowly scoped to watcher check scheduling and bounded check execution, with no material correctness issues found in the reviewed diff.

## Testing

Exercised the actual watcher entry point in a controlled merge-poll-starvation scenario, captured the CLI transcript as reviewer-visible evidence, confirmed due checks preempt chatty signals while signals persist for the next cycle, and cleaned up transient `state/` files afterward.

<details>
<summary>Evidence: Watcher check-before-signal transcript</summary>

<code>Output 1: check: .../state/merge-poll.check.sh: merged-pr-detected&#10;Output 2: signal: .../state/chatty.status</code>

```text
Scenario: due merge-poll check and pending chatty status signal both exist before watcher starts.
Command 1: FM_POLL=1 FM_CHECK_INTERVAL=0 FM_CHECK_TIMEOUT=5 FM_SIGNAL_GRACE=0 FM_HEARTBEAT=999999 bin/fm-watch.sh
Output 1: check: /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KV1957JM706HH26XY4EFQ1YM/state/merge-poll.check.sh: merged-pr-detected
Command 2: FM_POLL=1 FM_CHECK_INTERVAL=300 FM_CHECK_TIMEOUT=5 FM_SIGNAL_GRACE=0 FM_HEARTBEAT=999999 bin/fm-watch.sh
Output 2: signal: /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KV1957JM706HH26XY4EFQ1YM/state/chatty.status
Interpretation: Output 1 proves due checks preempt signals; Output 2 proves the pending signal was not lost.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-watch.sh:90` - Due checks now run before the signal scan, but each check script is executed synchronously with no timeout. A hung or very slow poll, such as a network-backed PR check, can now block pending crewmate status/turn-end signals from being surfaced until the command returns; add a bounded timeout around each check invocation so fixing check starvation does not create signal starvation.

🔧 Fix: Bound watcher check execution
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected the target diff with `git diff a5ffb9f4b5d0ed57d5918fa6f508617007a4bb2f...289a229011f5e500129ca023ef479e7c4fc32cc1 -- bin/fm-watch.sh`.</code>
- <code>Ran an end-to-end watcher scenario: created `state/merge-poll.check.sh` and `state/chatty.status`, then ran `FM_POLL=1 FM_CHECK_INTERVAL=0 FM_CHECK_TIMEOUT=5 FM_SIGNAL_GRACE=0 FM_HEARTBEAT=999999 bin/fm-watch.sh` and observed a `check:` wake before any signal wake.</code>
- <code>Ran the follow-up persisted-signal check after removing the check script: `FM_POLL=1 FM_CHECK_INTERVAL=300 FM_CHECK_TIMEOUT=5 FM_SIGNAL_GRACE=0 FM_HEARTBEAT=999999 bin/fm-watch.sh` and observed the pending `signal:` wake.</code>
- <code>Verified transient working-tree test state was removed with `git status --short`.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
