### PR TITLE
feat: add per-project delivery modes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,9 +21,10 @@ Hard rules, in priority order:
    Two sanctioned exceptions: tool-driven project initialization (section 6), and the approved local merge for a `local-only` project, which firstmate performs with `bin/fm-merge-local.sh` once the captain approves (section 7).
 2. **Never merge a PR without the captain's explicit word.**
    The one standing, captain-authorized relaxation is a project's `yolo` flag (section 7): with `yolo` on, firstmate makes routine approval decisions itself, but anything destructive, irreversible, or security-sensitive still escalates to the captain.
-3. **Never tear down a worktree that holds work not on a remote.**
+3. **Never tear down a worktree that holds unlanded work.**
    `bin/fm-teardown.sh` enforces this; never bypass it with `--force` unless the captain explicitly said to discard the work.
-   The one carve-out: a scout task's worktree is declared scratch from the start - its deliverable is the report, and teardown lets the worktree go once that report exists (section 7).
+   For PR-based ship tasks, the work must be on a remote; for `local-only` ship tasks, it must be merged into the local default branch.
+   The scout carve-out: a scout task's worktree is declared scratch from the start - its deliverable is the report, and teardown lets the worktree go once that report exists (section 7).
 4. **Crewmates never address the captain.**
    All crewmate communication flows through you.
    The captain may watch or type into any crewmate window directly; treat such intervention as authoritative and reconcile your records at the next heartbeat.
@@ -196,11 +197,12 @@ Add the line when you clone or create a project, keep the description current as
 
 Orthogonal to mode is an optional `+yolo` flag (`[direct-PR +yolo]`), default off and **not recommended**: with `yolo` on, firstmate makes the approval decisions itself instead of asking the captain (section 7). When the captain adds a project without saying, default to `no-mistakes` with yolo off; only set a faster mode or `+yolo` on the captain's explicit say-so.
 
-**Clone existing:** `git clone <url> projects/<name>`, then initialize.
+**Clone existing:** `git clone <url> projects/<name>`, add its registry line with the chosen mode, then initialize only if the mode is `no-mistakes`.
 
 **Create new:** for `no-mistakes` and `direct-PR` modes a new project needs a GitHub repo first (they push to an `origin` remote); a `local-only` project needs no remote at all - a purely local git repo is fine.
-Creating a GitHub repo is outward-facing, so get the captain's consent before touching GitHub: propose the repo name, owner/org, and visibility (default private), and create with `gh-axi` only after the captain confirms.
-Then clone it into `projects/<name>` and initialize.
+Creating a GitHub repo is outward-facing, so get the captain's consent before touching GitHub: propose the repo name, owner/org, visibility (default private), and delivery mode, and create with `gh-axi` only after the captain confirms.
+Then clone it into `projects/<name>` and initialize only if the mode is `no-mistakes`.
+For `local-only`, create the local repo under `projects/<name>` and skip GitHub entirely.
 
 **Initialize (`no-mistakes` mode only):**
 
@@ -233,7 +235,7 @@ Use these signals in order:
 
 Then classify the shape:
 
-- **Ship** (the default): the deliverable is a change to the project. It ends in a PR through the no-mistakes pipeline.
+- **Ship** (the default): the deliverable is a change to the project. It ships through the project's delivery mode: `no-mistakes`, `direct-PR`, or `local-only`.
 - **Scout:** the deliverable is knowledge - an investigation, a plan, a bug reproduction, an audit. It ends in a report at `data/<id>/report.md`, never a PR. When the captain asks "what's wrong", "how would we", or "find out why" about a project, that is a scout task; dispatch it instead of doing the digging yourself.
 
 Then classify readiness:
@@ -242,7 +244,7 @@ Then classify readiness:
 - **Blocked:** touches the same files or subsystem as an in-flight task, or explicitly depends on an unmerged PR. Record it in `data/backlog.md` with `blocked-by: <id>` and tell the captain why it is queued. Scout tasks are read-mostly and almost never block on anything.
 
 Keep dependency judgment coarse: same repo plus overlapping area means serialize; everything else runs parallel.
-The no-mistakes rebase step absorbs mild overlaps.
+For `no-mistakes` projects, the pipeline rebase step absorbs mild overlaps; for other modes, have the crewmate rebase before review or merge if needed.
 
 Write the brief per section 11.
 
@@ -286,17 +288,17 @@ bin/fm-send.sh fm-<id> '/no-mistakes'
 
 The crewmate drives the no-mistakes pipeline (review, test, document, lint, push, PR, CI) itself.
 It fixes auto-fix findings on its own.
-When it reports `needs-decision` (ask-user findings), relay the findings to the captain, get the decision, and send it back as a short instruction (the crewmate responds via `no-mistakes axi respond`).
+When it reports `needs-decision` (ask-user findings), relay the findings to the captain unless `yolo=on` permits routine approval on your judgment, then send the decision back as a short instruction (the crewmate responds via `no-mistakes axi respond`).
 Use chat for yes/no decisions; use lavish-axi when there are multiple findings or options to triage.
 
 ### PR ready
 
-For ship tasks, when the pipeline reaches CI-green, the crewmate reports `done: PR <url> checks green`.
+For PR-based ship tasks, the ready signal depends on mode: `no-mistakes` reports `done: PR <url> checks green` after CI is green, while `direct-PR` reports `done: PR <url>` after opening the PR.
 Run `bin/fm-pr-check.sh <id> <PR url>` - it records `pr=` in the task's meta and arms the watcher's merge poll.
-Tell the captain: the PR's full URL (always the complete `https://...` link, never a bare `#number` - the captain's terminal makes a full URL clickable), a one-paragraph summary, and the risk level no-mistakes emitted.
+Tell the captain: the PR's full URL (always the complete `https://...` link, never a bare `#number` - the captain's terminal makes a full URL clickable), a one-paragraph summary, and, for `no-mistakes`, the risk level it emitted.
 (The check contract, for any custom `state/<id>.check.sh` you write yourself: print one line only when firstmate should wake, print nothing otherwise, and finish before `FM_CHECK_TIMEOUT`.)
 
-If the captain says "merge it", run `gh-axi pr merge` yourself; that instruction is the explicit approval.
+If the captain says "merge it", run `gh-axi pr merge` yourself; that instruction is the explicit approval. If `yolo=on`, merge a green/approved PR yourself and post the required FYI.
 
 ### Ship teardown (only after merge is confirmed)
 
@@ -306,7 +308,7 @@ bin/fm-teardown.sh <id>
 
 The script refuses if the worktree holds unpushed work; treat a refusal as a stop-and-investigate, not an obstacle.
 Known benign case: after an external-PR task, a squash merge leaves the branch commits reachable only on the contributor's fork; add the fork as a remote and fetch (`git remote add fork <fork url> && git fetch fork`), then retry - never reach for `--force`.
-Then move the task to Done in `data/backlog.md` (with the full `https://...` PR URL and date), re-evaluate the queue, and dispatch anything that was blocked on this task.
+Then move the task to Done in `data/backlog.md` (with the full `https://...` PR URL or local merge note and date), re-evaluate the queue, and dispatch anything that was blocked on this task.
 
 ### Scout tasks (report instead of PR)
 
@@ -317,10 +319,10 @@ A scout task follows Intake, Spawn, and Supervise exactly as above - scaffold th
 - Tear down immediately - no merge gate. `bin/fm-teardown.sh` allows a scout worktree's scratch commits and dirty files once the report exists; if the report is missing, it refuses, because the findings are the work product.
 - Record it in Done with the report path instead of a PR link.
 
-**Promotion.** When a scout's findings reveal shippable work (a reproduced bug with a clear fix) and the captain wants it shipped, promote the task in place instead of respawning: run `bin/fm-promote.sh <id>` (flips `kind=` to ship in meta, restoring teardown's full unpushed-work protection), then send the crewmate its ship instructions - inventory scratch state, reset to a clean default-branch base, carry over only intended fix changes, create branch `fm/<id>`, implement, report `done`, then `/no-mistakes` per the Validate stage.
+**Promotion.** When a scout's findings reveal shippable work (a reproduced bug with a clear fix) and the captain wants it shipped, promote the task in place instead of respawning: run `bin/fm-promote.sh <id>` (flips `kind=` to ship in meta, restoring teardown's full protection), then send the crewmate its ship instructions - inventory scratch state, reset to a clean default-branch base, carry over only intended fix changes, create branch `fm/<id>`, implement, and report `done` according to the project's delivery mode.
 The crewmate keeps its worktree, loaded context, and repro, but the ship branch must start from a clean base with only intended changes; scratch commits and debug edits from the scout phase never ride along.
 The repro becomes the regression test.
-From there the task is an ordinary ship task through PR ready and Teardown.
+From there the task is an ordinary ship task through its mode-specific validation, PR or local merge, and Teardown.
 
 ## 8. Supervision protocol
 
@@ -379,7 +381,7 @@ Reaches the captain immediately:
 
 - PR ready for review.
 - A finished scout report (relay the findings, not just "it's done").
-- ask-user findings from no-mistakes (relay them verbatim; never approve in the captain's place).
+- ask-user findings from no-mistakes (relay them verbatim unless `yolo=on` permits routine approval on firstmate judgment).
 - A crewmate failed after the playbook is exhausted.
 - Anything destructive, irreversible, or security-sensitive.
 - A needed credential or login.
@@ -406,13 +408,14 @@ Update it on every dispatch, completion, and decision.
 
 ## Done
 - [x] <id> - <one line> - <https://github.com/owner/repo/pull/number> (merged <date>)
+- [x] <id> - <one line> - local main (merged <date>)
 - [x] <id> - <one line> - data/<id>/report.md (reported <date>)
 ```
 
 Re-evaluate Queued on every teardown and every heartbeat: anything whose blocker is gone gets dispatched.
 
 Keep Done to the 10 most recent entries; prune older ones whenever you add to the section.
-Every finished ship task lives on as its GitHub PR and every scout task as its report file, so pruning loses nothing; the retained tail exists only as cheap recent context for recovery and heartbeats.
+Every finished PR-based ship task lives on as its GitHub PR, every local-only ship task lives on in local `main`, and every scout task lives on as its report file, so pruning loses nothing; the retained tail exists only as cheap recent context for recovery and heartbeats.
 
 ## 11. Crewmate briefs
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,8 +18,9 @@ Hard rules, in priority order:
 1. **Never write to a project.**
    You must not edit, commit to, or run state-changing commands in anything under `projects/` or in any worktree.
    You read projects to understand them; crewmates change them.
-   The single exception is tool-driven project initialization (section 6).
+   Two sanctioned exceptions: tool-driven project initialization (section 6), and the approved local merge for a `local-only` project, which firstmate performs with `bin/fm-merge-local.sh` once the captain approves (section 7).
 2. **Never merge a PR without the captain's explicit word.**
+   The one standing, captain-authorized relaxation is a project's `yolo` flag (section 7): with `yolo` on, firstmate makes routine approval decisions itself, but anything destructive, irreversible, or security-sensitive still escalates to the captain.
 3. **Never tear down a worktree that holds work not on a remote.**
    `bin/fm-teardown.sh` enforces this; never bypass it with `--force` unless the captain explicitly said to discard the work.
    The one carve-out: a scout task's worktree is declared scratch from the start - its deliverable is the report, and teardown lets the worktree go once that report exists (section 7).
@@ -53,14 +54,14 @@ bin/                 helper scripts, committed; read each script's header before
 config/crew-harness  crewmate harness override; LOCAL, gitignored; absent or "default" = same as firstmate
 data/                personal fleet records; LOCAL, gitignored as a whole
   backlog.md         task queue, dependencies, history
-  projects.md        fleet registry: one line per project under projects/ with a short description
+  projects.md        fleet registry: one line per project under projects/ with a short description and its delivery mode - "- <name> [<mode>] - <desc>", optional "+yolo" (e.g. "[direct-PR +yolo]"); no "[...]" = no-mistakes. fm-project-mode.sh parses it (section 6)
   <id>/brief.md      per-task crewmate brief
   <id>/report.md     scout task deliverable, written by the crewmate; survives teardown
 projects/            cloned repos; gitignored; READ-ONLY for you
 state/               volatile runtime signals; gitignored
   <id>.status        appended by crewmates: "<state>: <note>" lines
   <id>.turn-ended    touched by turn-end hooks
-  <id>.meta          written by fm-spawn: window=, worktree=, project=, harness=, kind= (fm-pr-check appends pr=)
+  <id>.meta          written by fm-spawn: window=, worktree=, project=, harness=, kind=, mode=, yolo= (fm-pr-check appends pr=)
   <id>.check.sh      optional slow poll you write per task (e.g. merged-PR check)
   .hash-* .count-* .stale-* .seen-* .last-* .heartbeat-streak   watcher internals; never touch
   .last-watcher-beat watcher liveness beacon, touched every poll; fm-guard.sh reads it
@@ -182,18 +183,26 @@ All projects live flat under `projects/`.
 Every project in the fleet has a line in `data/projects.md`:
 
 ```markdown
-- <name> - <one-line description> (added <date>)
+- <name> [<mode>] - <one-line description> (added <date>)
 ```
 
 Add the line when you clone or create a project, keep the description current as your understanding deepens, and drop the line if a project is ever removed from `projects/`.
 
+**Delivery mode (choose at add).** `<mode>` is how a finished change reaches `main`, picked per project when you add it and recorded in the registry line (`fm-project-mode.sh` parses it; `fm-spawn` records it into each task's meta):
+
+- `no-mistakes` (default; `[...]` may be omitted) - full pipeline -> PR -> captain merge. Highest assurance.
+- `direct-PR` - push + open a PR via `gh-axi`, no pipeline -> captain merge.
+- `local-only` - local branch, no remote, no PR; firstmate reviews the diff, the captain approves, firstmate merges to local `main` (section 7).
+
+Orthogonal to mode is an optional `+yolo` flag (`[direct-PR +yolo]`), default off and **not recommended**: with `yolo` on, firstmate makes the approval decisions itself instead of asking the captain (section 7). When the captain adds a project without saying, default to `no-mistakes` with yolo off; only set a faster mode or `+yolo` on the captain's explicit say-so.
+
 **Clone existing:** `git clone <url> projects/<name>`, then initialize.
 
-**Create new:** a new project needs a GitHub repo first (no-mistakes requires an `origin` remote).
-Creating one is outward-facing, so get the captain's consent before touching GitHub: propose the repo name, owner/org, and visibility (default private), and create with `gh-axi` only after the captain confirms.
+**Create new:** for `no-mistakes` and `direct-PR` modes a new project needs a GitHub repo first (they push to an `origin` remote); a `local-only` project needs no remote at all - a purely local git repo is fine.
+Creating a GitHub repo is outward-facing, so get the captain's consent before touching GitHub: propose the repo name, owner/org, and visibility (default private), and create with `gh-axi` only after the captain confirms.
 Then clone it into `projects/<name>` and initialize.
 
-**Initialize (mandatory for every project, no exceptions):**
+**Initialize (`no-mistakes` mode only):**
 
 ```sh
 cd projects/<name> && no-mistakes init && no-mistakes doctor
@@ -201,8 +210,9 @@ cd projects/<name> && no-mistakes init && no-mistakes doctor
 
 `no-mistakes init` writes skill files into the project (`.claude/skills/`, `.agents/skills/`).
 Crewmates spawn from committed state, so these files must be committed and pushed before the first task.
-This is the single exception to the never-write rule: you may commit and push the tool-generated init files yourself, on a `chore/no-mistakes-init` branch with a PR, or directly to the default branch if the captain okays it.
+This is one of the two sanctioned exceptions to the never-write rule (section 1): you may commit and push the tool-generated init files yourself, on a `chore/no-mistakes-init` branch with a PR, or directly to the default branch if the captain okays it.
 Touch nothing else in the project.
+`direct-PR` and `local-only` projects skip init entirely - they do not run the pipeline.
 
 If `no-mistakes doctor` reports problems, fix the environment (auth, daemon) before dispatching work to that project.
 
@@ -244,7 +254,7 @@ bin/fm-spawn.sh <id> projects/<repo> codex       # per-task harness override
 bin/fm-spawn.sh <id> projects/<repo> --scout     # scout task; records kind=scout in meta
 ```
 
-The script resolves the harness (`fm-harness.sh crew`), owns the verified launch templates, and records `harness=` and `kind=` in the task's meta; a non-flag third argument containing whitespace is treated as a raw launch command (only for verifying new adapters).
+The script resolves the harness (`fm-harness.sh crew`), owns the verified launch templates, resolves the project's delivery mode (`fm-project-mode.sh`), and records `harness=`, `kind=`, `mode=`, and `yolo=` in the task's meta; a non-flag third argument containing whitespace is treated as a raw launch command (only for verifying new adapters).
 
 The script creates the window (in your current tmux session, or a dedicated `firstmate` session when you are outside tmux), runs `treehouse get`, waits for the worktree subshell, installs the turn-end hook, records `state/<id>.meta`, and launches the agent with the brief.
 Worktrees start at detached HEAD on a clean default branch; ship briefs tell the crewmate to create its branch, while scout briefs keep the worktree scratch.
@@ -256,9 +266,19 @@ Add the task to `data/backlog.md` under In flight.
 Covered by section 8.
 Steer a crewmate only with short single lines via `bin/fm-send.sh`; anything long belongs in a file the crewmate can read.
 
+### Delivery modes and yolo
+
+A ship task's path from `done` to landed on `main` is set by the project's `mode` (recorded in meta; section 6); `yolo` decides who approves. The Validate / PR ready / Ship teardown stages below are written for the `no-mistakes` path; the other modes diverge:
+
+- **no-mistakes** - the stages below as written: `/no-mistakes` pipeline -> PR -> captain merge.
+- **direct-PR** - no pipeline. The crewmate pushes and opens the PR itself (its brief says so) and reports `done: PR <url>`. Skip the Validate `/no-mistakes` step and go straight to PR ready (run `fm-pr-check`, relay the PR). Teardown uses the normal pushed-branch check.
+- **local-only** - no remote, no PR. The crewmate stops at `done: ready in branch fm/<id>`. Review the diff (`git -C <worktree> diff <default-branch>...fm/<id>`), relay a one-paragraph summary to the captain, and on approval run `bin/fm-merge-local.sh <id>` to fast-forward local `main` (it refuses anything but a clean fast-forward - if it does, have the crewmate rebase). No `fm-pr-check`. Then teardown, whose safety check requires the branch already merged into local `main`.
+
+**yolo (orthogonal).** With `yolo=off` (default) every approval is the captain's: ask-user findings, PR merges, the local-only merge. With `yolo=on`, firstmate makes those calls itself without asking - resolve ask-user findings on your judgment, and run `gh-axi pr merge` / `bin/fm-merge-local.sh` once the work is green/approved - EXCEPT anything destructive, irreversible, or security-sensitive, which still escalates to the captain. Never merge a red PR even under yolo. After any yolo merge, post a one-line "yolo merged <full PR URL or local main>" FYI so the captain keeps a trail.
+
 ### Validate
 
-For ship tasks, when a crewmate's status says `done`:
+For `no-mistakes`-mode ship tasks, when a crewmate's status says `done`:
 
 ```sh
 bin/fm-send.sh fm-<id> '/no-mistakes'
@@ -396,8 +416,9 @@ Every finished ship task lives on as its GitHub PR and every scout task as its r
 
 ## 11. Crewmate briefs
 
-Scaffold with `bin/fm-brief.sh <id> <repo-name>` - it writes `data/<id>/brief.md` with the standard contract (branch setup, status-reporting protocol, never-push-to-default rules, the no-mistakes definition of done) and all paths filled in.
-For scout tasks add `--scout`: the scaffold swaps the definition of done for the report contract (findings to `data/<id>/report.md`, no branch, no push, no PR) and declares the worktree scratch.
+Scaffold with `bin/fm-brief.sh <id> <repo-name>` - it writes `data/<id>/brief.md` with the standard contract (branch setup, status-reporting protocol, push/merge rules, definition of done) and all paths filled in.
+For a ship task the definition of done is shaped by the project's delivery mode (section 6): `no-mistakes` ends in the `/no-mistakes` pipeline, `direct-PR` has the crewmate push and open the PR itself, `local-only` has it stop at "ready in branch" for firstmate to review and merge locally. The scaffold reads the mode via `fm-project-mode.sh`, so you do not pass it.
+For scout tasks add `--scout`: the scaffold swaps the definition of done for the report contract (findings to `data/<id>/report.md`, no branch, no push, no PR) and declares the worktree scratch; scout is mode-agnostic.
 The status-reporting protocol is intentionally sparse: crewmates append status only for supervisor-actionable phase changes or `needs-decision`/`blocked`/`done`/`failed`, because every append wakes firstmate.
 Then replace the `{TASK}` placeholder with a clear task description, acceptance criteria, and any constraints or context the crewmate needs.
 Adjust the other sections only when the task genuinely deviates from the standard ship-a-new-PR shape (e.g. fixing an existing external PR); the scaffold is the contract, not a suggestion.

--- a/README.md
+++ b/README.md
@@ -28,12 +28,12 @@ You can run one coding agent well.
 But the moment you want three project tasks done in parallel - fixes, investigations, plans, audits - you become a tab-juggler: babysitting sessions, copy-pasting context between repos, forgetting which terminal had the failing test.
 
 firstmate flips the model.
-You talk to a single agent - the first mate - and it runs the crew for you: spawning autonomous agents in tmux windows, giving each a clean git worktree, supervising them to completion, and handing you finished PRs or standalone investigation reports.
+You talk to a single agent - the first mate - and it runs the crew for you: spawning autonomous agents in tmux windows, giving each a clean git worktree, supervising them to completion, and handing you finished PRs, approved local merges, or standalone investigation reports.
 There is no app to install; the whole orchestrator is an `AGENTS.md` file that any terminal coding agent can follow.
 
-- **One liaison** — you never talk to a worker agent. The first mate dispatches, supervises, escalates only real decisions, and reports when PRs or scout reports are ready.
+- **One liaison** — you never talk to a worker agent. The first mate dispatches, supervises, escalates only real decisions, and reports when PRs, local merges, or scout reports are ready.
 - **A visible crew** — every crewmate lives in a tmux window. Watch any of them work, or type into their window to intervene; the first mate reconciles.
-- **Guarded by construction** — the first mate is read-only over your projects; crewmates work in disposable [treehouse](https://github.com/kunchenguid/treehouse) worktrees. Ship tasks go through the [no-mistakes](https://github.com/kunchenguid/no-mistakes) validation pipeline, and scout tasks produce local reports without pushing anything.
+- **Guarded by construction** — the first mate is read-only over your projects except for approved `local-only` fast-forward merges; crewmates work in disposable [treehouse](https://github.com/kunchenguid/treehouse) worktrees. Ship tasks follow each project's delivery mode, and scout tasks produce local reports without pushing anything.
 
 This is not an agent harness. This is not a skill. This is not a CLI.
 
@@ -90,7 +90,7 @@ firstmate works from any terminal - outside tmux, crewmates land in a detached `
                   ▼
  ┌─────────────────────────────────────┐
  │ firstmate            (this repo)    │
- │ reads projects/, never writes them  │
+ │ reads projects/; writes only gated  │
  │ backlog.md ── briefs ── watcher     │
  └──┬──────────────┬───────────────┬───┘
     │ tmux send-keys / status files │
@@ -102,7 +102,7 @@ firstmate works from any terminal - outside tmux, crewmates land in a detached `
      ▼            ▼               ▼
   treehouse worktree (clean, disposable, parallel-safe)
      │
-     ├─ ship: /no-mistakes ► PR for the captain ► merge ► teardown
+     ├─ ship: project mode ► PR/local merge ► teardown
      │
      └─ scout: report at data/<id>/report.md ► relay findings ► teardown
 ```
@@ -111,8 +111,8 @@ firstmate works from any terminal - outside tmux, crewmates land in a detached `
   Routine watcher polling, restarts, elapsed waiting time, and unchanged heartbeat reviews stay silent; an idle crew costs you nothing.
   A pull-based guard (`bin/fm-guard.sh`) warns through supervision tool output if tasks are in flight and that watcher stops running.
 - **Worktrees, not branches in your checkout** — crewmates never touch your clone; treehouse pools clean worktrees so parallel tasks on one repo cannot collide.
-- **Two task shapes** — ship tasks change projects and end in a validated PR; scout tasks investigate, plan, reproduce bugs, or audit, then leave a report at `data/<id>/report.md` and never push.
-- **Validation is non-negotiable for shipping** — every project gets `no-mistakes init`; every ship task ends with its pipeline. Human-judgment findings escalate to you through the first mate.
+- **Two task shapes** — ship tasks change projects and ship by project mode (`no-mistakes`, `direct-PR`, or `local-only`); scout tasks investigate, plan, reproduce bugs, or audit, then leave a report at `data/<id>/report.md` and never push.
+- **Project modes are explicit** — `data/projects.md` records each project's delivery mode and optional `+yolo` autonomy flag. `no-mistakes` projects run the full validation pipeline, `direct-PR` projects open PRs without that pipeline, and `local-only` projects stay local until firstmate performs an approved fast-forward merge.
 - **Restart-proof** — all state lives in tmux, status files, and local markdown under `data/`. Kill the first mate session anytime; the next one reconciles and carries on.
 
 ## The bin/ toolbelt
@@ -125,6 +125,8 @@ The first mate drives these; you rarely need to, but they work by hand too.
 | `fm-brief.sh`     | Scaffold a ship brief, or a report-only scout brief with `--scout`                          |
 | `fm-guard.sh`     | Warn when tasks are in flight but the watcher liveness beacon is stale or missing           |
 | `fm-spawn.sh`     | Window → treehouse worktree → agent launched with its brief; records ship/scout task kind   |
+| `fm-project-mode.sh` | Resolve a project's delivery mode and `+yolo` flag from `data/projects.md`               |
+| `fm-merge-local.sh` | Fast-forward a `local-only` project's local default branch after approval                  |
 | `fm-watch.sh`     | Block until supervision work is due; exits with one reason line                             |
 | `fm-send.sh`      | Send one literal line (or `--key Escape`) to a crewmate window                              |
 | `fm-peek.sh`      | Print a bounded tail of a crewmate pane                                                     |

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -38,6 +38,7 @@ for t in $TOOLS; do
   command -v "$t" >/dev/null || echo "MISSING: $t (install: $(install_cmd "$t"))"
 done
 gh auth status >/dev/null 2>&1 || echo "NEEDS_GH_AUTH"
-crew=$(tr -d '[:space:]' < "$FM_ROOT/config/crew-harness" 2>/dev/null || true)
+crew=
+[ -f "$FM_ROOT/config/crew-harness" ] && crew=$(tr -d '[:space:]' < "$FM_ROOT/config/crew-harness" || true)
 [ -n "$crew" ] && [ "$crew" != "default" ] && echo "CREW_HARNESS_OVERRIDE: $crew"
 exit 0

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -7,6 +7,13 @@
 # Usage: fm-brief.sh <task-id> <repo-name> [--scout]
 #   --scout writes the scout contract instead: the deliverable is a report at
 #   data/<task-id>/report.md (no branch, no push, no PR) and the worktree is scratch.
+# For ship tasks, the definition of done is shaped by the project's delivery mode
+# (data/projects.md via fm-project-mode.sh; see AGENTS.md sections 6-7):
+#   no-mistakes  implement -> /no-mistakes pipeline -> PR -> captain merge (default)
+#   direct-PR    implement -> push + open PR via gh-axi (no pipeline) -> captain merge
+#   local-only   implement on branch, stop and report "ready in branch" (no push/PR);
+#                firstmate reviews, captain approves, firstmate merges to local main
+# Scout tasks ignore mode - their deliverable is a report, not a merge.
 # Refuses to overwrite an existing brief.
 set -eu
 
@@ -59,7 +66,58 @@ The report must stand alone: what you did, what you found, the evidence (command
 When the report is complete, append \`done: {one-line conclusion}\` to the status file and stop.
 If your findings reveal work that should ship (e.g. you reproduced a bug and the fix is clear), say so in the report; firstmate may promote this task in place, and you would then receive ship instructions (branch, implement, /no-mistakes) as a follow-up message.
 EOF
-else
+echo "scaffolded: $BRIEF (scout; replace {TASK})"
+exit 0
+fi
+
+# Ship task: shape Setup / Rule 1 / Definition of done by the project's delivery mode.
+# yolo does not affect the brief (it governs firstmate's approval behaviour), so discard it.
+read -r MODE _ <<EOF
+$("$FM_ROOT/bin/fm-project-mode.sh" "$REPO")
+EOF
+
+case "$MODE" in
+  direct-PR)
+    SETUP2=""
+    RULE1='1. Never push to the default branch (push only your `fm/'"$ID"'` branch). Never merge a PR.'
+    DOD=$(cat <<EOF
+# Definition of done
+This project ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
+The task is complete only when committed on your branch.
+When it is implemented and committed, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\` to the status file and stop.
+Do NOT run /no-mistakes. The captain reviews and merges the PR; firstmate relays it.
+EOF
+)
+    ;;
+  local-only)
+    SETUP2=""
+    RULE1='1. Never push to any remote and never open a PR. Work only on your `fm/'"$ID"'` branch; firstmate handles the merge into local `main`.'
+    DOD=$(cat <<EOF
+# Definition of done
+This project ships **local-only**: no remote, no PR, no pipeline.
+The task is complete only when committed on your branch \`fm/$ID\`. Do NOT push, do NOT open a PR, do NOT merge.
+Keep your branch a clean fast-forward onto the current default branch - if \`main\` has advanced, rebase onto it so the eventual merge stays a fast-forward.
+When it is implemented and committed, append \`done: ready in branch fm/$ID\` to the status file and stop.
+Firstmate then reviews your branch diff, the captain approves, and firstmate merges it into local \`main\`.
+EOF
+)
+    ;;
+  *)  # no-mistakes (default)
+    SETUP2='
+2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.'
+    RULE1='1. Never push to the default branch. Never merge a PR.'
+    DOD=$(cat <<EOF
+# Definition of done
+The task is complete only when committed on your branch.
+When you believe it is complete, append \`done: {summary}\` to the status file and stop.
+Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
+During validation, fix auto-fix findings yourself; escalate ask-user findings per rule 6.
+After /no-mistakes reports CI green, append \`done: PR {url} checks green\` and stop. You are finished.
+EOF
+)
+    ;;
+esac
+
 cat > "$BRIEF" <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
 
@@ -68,11 +126,10 @@ You are a crewmate: an autonomous worker agent managed by firstmate. Work on you
 
 # Setup
 You are in a disposable git worktree of $REPO, at a detached HEAD on a clean default branch.
-1. First action: create your branch: \`git checkout -b fm/$ID\`
-2. Run \`no-mistakes doctor\`; if it reports the repo is not initialized here, run \`no-mistakes init\`.
+1. First action: create your branch: \`git checkout -b fm/$ID\`$SETUP2
 
 # Rules
-1. Never push to the default branch. Never merge a PR.
+$RULE1
 2. Stay inside this worktree; modify nothing outside it.
 3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
 4. Report status by appending one line:
@@ -86,12 +143,6 @@ You are in a disposable git worktree of $REPO, at a detached HEAD on a clean def
 6. If a decision belongs to a human (product choices, destructive actions, ask-user findings),
    append \`needs-decision: {summary of options}\` and stop. Firstmate will reply with the decision.
 
-# Definition of done
-The task is complete only when committed on your branch.
-When you believe it is complete, append \`done: {summary}\` to the status file and stop.
-Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
-During validation, fix auto-fix findings yourself; escalate ask-user findings per rule 6.
-After /no-mistakes reports CI green, append \`done: PR {url} checks green\` and stop. You are finished.
+$DOD
 EOF
-fi
-echo "scaffolded: $BRIEF ($KIND; replace {TASK})"
+echo "scaffolded: $BRIEF (ship, mode=$MODE; replace {TASK})"

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -91,7 +91,7 @@ EOF
     ;;
   local-only)
     SETUP2=""
-    RULE1='1. Never push to any remote and never open a PR. Work only on your `fm/'"$ID"'` branch; firstmate handles the merge into local `main`.'
+    RULE1="1. Never push to any remote and never open a PR. Work only on your \`fm/$ID\` branch; firstmate handles the merge into local \`main\`."
     DOD=$(cat <<EOF
 # Definition of done
 This project ships **local-only**: no remote, no PR, no pipeline.
@@ -103,8 +103,8 @@ EOF
 )
     ;;
   *)  # no-mistakes (default)
-    SETUP2='
-2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.'
+    SETUP2="
+2. Run \`no-mistakes doctor\`; if it reports the repo is not initialized here, run \`no-mistakes init\`."
     RULE1='1. Never push to the default branch. Never merge a PR.'
     DOD=$(cat <<EOF
 # Definition of done

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -64,7 +64,7 @@ The report is the only thing that survives, so anything worth keeping must be in
 Write your findings to \`$FM_ROOT/data/$ID/report.md\`.
 The report must stand alone: what you did, what you found, the evidence (commands run, output, file:line references), and what you recommend.
 When the report is complete, append \`done: {one-line conclusion}\` to the status file and stop.
-If your findings reveal work that should ship (e.g. you reproduced a bug and the fix is clear), say so in the report; firstmate may promote this task in place, and you would then receive ship instructions (branch, implement, /no-mistakes) as a follow-up message.
+If your findings reveal work that should ship (e.g. you reproduced a bug and the fix is clear), say so in the report; firstmate may promote this task in place, and you would then receive mode-specific ship instructions as a follow-up message.
 EOF
 echo "scaffolded: $BRIEF (scout; replace {TASK})"
 exit 0

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -41,7 +41,8 @@ detect_own() {
 }
 
 if [ "${1:-}" = "crew" ]; then
-  crew=$(tr -d '[:space:]' < "$FM_ROOT/config/crew-harness" 2>/dev/null || true)
+  crew=
+  [ -f "$FM_ROOT/config/crew-harness" ] && crew=$(tr -d '[:space:]' < "$FM_ROOT/config/crew-harness" || true)
   if [ -z "$crew" ] || [ "$crew" = "default" ]; then detect_own; else echo "$crew"; fi
 else
   detect_own

--- a/bin/fm-merge-local.sh
+++ b/bin/fm-merge-local.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Perform the approved local merge for a local-only ship task: fast-forward the
+# project's default branch to the crewmate's fm/<id> branch.
+#
+# This is firstmate's merge gate-action (the captain's merge authority applied
+# locally instead of via a GitHub PR). It is the one sanctioned exception to hard
+# rule #1 "never run state-changing git in projects/", and it is narrow: it only
+# runs for mode=local-only tasks, only after the captain approves (or yolo=on
+# auto-approves), and only as a clean fast-forward - it refuses a diverged branch
+# and tells you to have the crewmate rebase. See AGENTS.md sections 1, 6, 7.
+# Usage: fm-merge-local.sh <task-id>
+set -eu
+
+FM_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+"$FM_ROOT/bin/fm-guard.sh" || true
+ID=${1:?usage: fm-merge-local.sh <task-id>}
+META="$FM_ROOT/state/$ID.meta"
+[ -f "$META" ] || { echo "error: no meta for task $ID at $META" >&2; exit 1; }
+
+PROJ=$(grep '^project=' "$META" | cut -d= -f2-)
+MODE=$(grep '^mode=' "$META" | cut -d= -f2- || true)
+[ "$MODE" = local-only ] || { echo "error: task $ID is mode=$MODE, not local-only; merge it the normal way (gh-axi pr merge / captain)" >&2; exit 1; }
+
+BRANCH="fm/$ID"
+git -C "$PROJ" rev-parse --verify --quiet "refs/heads/$BRANCH" >/dev/null || { echo "error: branch $BRANCH does not exist in $PROJ" >&2; exit 1; }
+
+DEFAULT=$(git -C "$PROJ" symbolic-ref --short HEAD 2>/dev/null || echo main)
+
+# The project's main checkout must be on its default branch and clean, so the
+# fast-forward lands predictably (firstmate never writes here otherwise).
+cur=$(git -C "$PROJ" symbolic-ref --short HEAD 2>/dev/null || echo "")
+[ "$cur" = "$DEFAULT" ] || { echo "error: $PROJ is on '$cur', expected default branch '$DEFAULT'; cannot merge safely" >&2; exit 1; }
+if [ -n "$(git -C "$PROJ" status --porcelain 2>/dev/null | head -1)" ]; then
+  echo "error: $PROJ has a dirty working tree; refusing to merge into it" >&2
+  exit 1
+fi
+
+# Clean fast-forward only: DEFAULT must be an ancestor of BRANCH.
+if ! git -C "$PROJ" merge-base --is-ancestor "$DEFAULT" "$BRANCH"; then
+  echo "REFUSED: $BRANCH is not a fast-forward of $DEFAULT (it has diverged)." >&2
+  echo "Have the crewmate rebase $BRANCH onto $DEFAULT, then retry." >&2
+  exit 1
+fi
+
+before=$(git -C "$PROJ" rev-parse --short "$DEFAULT")
+git -C "$PROJ" merge --ff-only "$BRANCH" >/dev/null
+after=$(git -C "$PROJ" rev-parse --short "$DEFAULT")
+echo "merged $BRANCH into local $DEFAULT ($before -> $after) in $PROJ"

--- a/bin/fm-merge-local.sh
+++ b/bin/fm-merge-local.sh
@@ -21,10 +21,26 @@ PROJ=$(grep '^project=' "$META" | cut -d= -f2-)
 MODE=$(grep '^mode=' "$META" | cut -d= -f2- || true)
 [ "$MODE" = local-only ] || { echo "error: task $ID is mode=$MODE, not local-only; merge it the normal way (gh-axi pr merge / captain)" >&2; exit 1; }
 
+default_branch() {
+  local ref branch
+  ref=$(git -C "$PROJ" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)
+  if [ -n "$ref" ]; then
+    echo "${ref#origin/}"
+    return 0
+  fi
+  for branch in main master; do
+    if git -C "$PROJ" show-ref --verify --quiet "refs/heads/$branch"; then
+      echo "$branch"
+      return 0
+    fi
+  done
+  return 1
+}
+
 BRANCH="fm/$ID"
 git -C "$PROJ" rev-parse --verify --quiet "refs/heads/$BRANCH" >/dev/null || { echo "error: branch $BRANCH does not exist in $PROJ" >&2; exit 1; }
 
-DEFAULT=$(git -C "$PROJ" symbolic-ref --short HEAD 2>/dev/null || echo main)
+DEFAULT=$(default_branch) || { echo "error: cannot determine default branch for $PROJ; expected origin/HEAD, main, or master" >&2; exit 1; }
 
 # The project's main checkout must be on its default branch and clean, so the
 # fast-forward lands predictably (firstmate never writes here otherwise).

--- a/bin/fm-project-mode.sh
+++ b/bin/fm-project-mode.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Resolve a project's delivery mode and yolo flag from the data/projects.md registry.
+# Prints two words to stdout: "<mode> <yolo>" where mode is one of
+# no-mistakes|direct-PR|local-only and yolo is on|off.
+#
+# Registry line format (data/projects.md):
+#   - <name> - <desc> (added <date>)                  -> no-mistakes off  (legacy default)
+#   - <name> [<mode>] - <desc> (added <date>)          -> <mode> off
+#   - <name> [<mode> +yolo] - <desc> (added <date>)    -> <mode> on
+#
+# mode = how a finished change reaches main:
+#   no-mistakes  full pipeline -> PR -> captain merge (default)
+#   direct-PR    push + PR via gh-axi, no pipeline -> captain merge
+#   local-only   local branch, no remote/PR -> firstmate review -> captain approve -> local merge
+# yolo (orthogonal) = when on, firstmate makes approval decisions itself (PR merges,
+#   ask-user findings, local-only merge approval) without checking the captain - except
+#   anything destructive/irreversible/security-sensitive, which still escalates.
+#
+# An unknown/missing project or unknown mode falls back to "no-mistakes off" and warns
+# to stderr, so a typo never silently drops the gate.
+# Usage: fm-project-mode.sh <project-name>
+set -eu
+
+FM_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REG="$FM_ROOT/data/projects.md"
+NAME=${1:?usage: fm-project-mode.sh <project-name>}
+
+if [ ! -f "$REG" ]; then
+  echo "warn: no registry at $REG; defaulting $NAME to no-mistakes off" >&2
+  echo "no-mistakes off"
+  exit 0
+fi
+
+# awk emits "<mode> <yolo>" (one line) or nothing if the project is absent.
+parsed=$(awk -v n="$NAME" '
+  $1=="-" && $2==n {
+    mode="no-mistakes"; yolo="off";
+    if ($3 ~ /^\[/) {
+      s="";
+      for (i=3; i<=NF; i++) { s = s (s==""?"":" ") $i; if ($i ~ /\]$/) break }
+      gsub(/^\[|\]$/, "", s);           # strip the surrounding brackets
+      k = split(s, a, " ");
+      if (a[1] != "" && a[1] != "+yolo") mode = a[1];
+      for (j=1; j<=k; j++) if (a[j]=="+yolo") yolo="on";
+    }
+    print mode, yolo; exit
+  }
+' "$REG")
+
+if [ -z "$parsed" ]; then
+  echo "warn: project \"$NAME\" not in registry; defaulting to no-mistakes off" >&2
+  echo "no-mistakes off"
+  exit 0
+fi
+
+mode=${parsed%% *}
+yolo=${parsed##* }
+case "$mode" in
+  no-mistakes|direct-PR|local-only) ;;
+  *) echo "warn: unknown mode \"$mode\" for $NAME; defaulting to no-mistakes" >&2; mode=no-mistakes ;;
+esac
+case "$yolo" in on|off) ;; *) yolo=off ;; esac
+echo "$mode $yolo"

--- a/bin/fm-project-mode.sh
+++ b/bin/fm-project-mode.sh
@@ -57,7 +57,7 @@ mode=${parsed%% *}
 yolo=${parsed##* }
 case "$mode" in
   no-mistakes|direct-PR|local-only) ;;
-  *) echo "warn: unknown mode \"$mode\" for $NAME; defaulting to no-mistakes" >&2; mode=no-mistakes ;;
+  *) echo "warn: unknown mode \"$mode\" for $NAME; defaulting to no-mistakes off" >&2; mode=no-mistakes; yolo=off ;;
 esac
 case "$yolo" in on|off) ;; *) yolo=off ;; esac
 echo "$mode $yolo"

--- a/bin/fm-promote.sh
+++ b/bin/fm-promote.sh
@@ -4,8 +4,8 @@
 # state/<task-id>.meta so fm-teardown.sh applies the full unpushed-work protection
 # again. After promoting, send the crewmate its ship instructions via fm-send.sh
 # (inventory scratch state, reset to a clean default-branch base, carry over only
-# intended fix changes, create branch fm/<task-id>, implement, report done, then
-# /no-mistakes).
+# intended fix changes, create branch fm/<task-id>, implement, then report done
+# according to the project's delivery mode).
 # Usage: fm-promote.sh <task-id>
 set -eu
 

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -14,7 +14,8 @@
 #     __PIEXT__    absolute path to state/<task-id>.pi-ext.ts (pi turn-end extension,
 #                  written by this script; outside the worktree to avoid pi's trust gate)
 # Per-harness turn-end hooks are installed automatically; some live outside the worktree.
-# On success prints: spawned <id> harness=<name> kind=<ship|scout> window=<session:window> worktree=<path>
+# On success prints: spawned <id> harness=<name> kind=<ship|scout> mode=<mode> yolo=<on|off> window=<session:window> worktree=<path>
+# mode/yolo are resolved per-project from data/projects.md via fm-project-mode.sh.
 set -eu
 
 FM_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -149,6 +150,15 @@ EOF
     ;;
 esac
 
+# Per-project delivery mode + yolo flag (bin/fm-project-mode.sh; AGENTS.md sections 6-7).
+# Recorded in meta so fm-teardown's safety check and the validate/merge stages can
+# branch on them. Mode governs ship tasks; a scout's deliverable is a report, not a
+# merge, so scout teardown ignores mode.
+PROJ_NAME=$(basename "$PROJ_ABS")
+read -r MODE YOLO <<EOF
+$("$FM_ROOT/bin/fm-project-mode.sh" "$PROJ_NAME")
+EOF
+
 mkdir -p "$FM_ROOT/state"
 {
   echo "window=$T"
@@ -156,6 +166,8 @@ mkdir -p "$FM_ROOT/state"
   echo "project=$PROJ_ABS"
   echo "harness=$HARNESS"
   echo "kind=$KIND"
+  echo "mode=$MODE"
+  echo "yolo=$YOLO"
 } > "$FM_ROOT/state/$ID.meta"
 
 LAUNCH=${LAUNCH//__BRIEF__/$BRIEF}
@@ -165,4 +177,4 @@ tmux send-keys -t "$T" -l "$LAUNCH"
 sleep 0.3
 tmux send-keys -t "$T" Enter
 
-echo "spawned $ID harness=$HARNESS kind=$KIND window=$T worktree=$WT"
+echo "spawned $ID harness=$HARNESS kind=$KIND mode=$MODE yolo=$YOLO window=$T worktree=$WT"

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -27,6 +27,22 @@ KIND=$(grep '^kind=' "$META" | cut -d= -f2- || true)
 MODE=$(grep '^mode=' "$META" | cut -d= -f2- || true)
 [ -n "$MODE" ] || MODE=no-mistakes
 
+default_branch() {
+  local ref branch
+  ref=$(git -C "$PROJ" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)
+  if [ -n "$ref" ]; then
+    echo "${ref#origin/}"
+    return 0
+  fi
+  for branch in main master; do
+    if git -C "$PROJ" show-ref --verify --quiet "refs/heads/$branch"; then
+      echo "$branch"
+      return 0
+    fi
+  done
+  return 1
+}
+
 if [ -d "$WT" ] && [ "$FORCE" != "--force" ]; then
   if [ "$KIND" = scout ]; then
     # Scout worktrees are scratch by contract, but only once the deliverable exists.
@@ -40,7 +56,7 @@ if [ -d "$WT" ] && [ "$FORCE" != "--force" ]; then
     # local-only ships have no remote, so the "on a remote" test never passes.
     # The work is safe once it is merged into the local default branch (firstmate
     # does that merge on the captain's approval). Refuse until then.
-    DEFAULT=$(git -C "$PROJ" symbolic-ref --short HEAD 2>/dev/null || echo main)
+    DEFAULT=$(default_branch) || { echo "REFUSED: cannot determine default branch for $PROJ; expected origin/HEAD, main, or master." >&2; exit 1; }
     dirty=$(git -C "$WT" status --porcelain 2>/dev/null | grep -vE '^\?\? \.claude/' | head -1 || true)
     unmerged=$(git -C "$WT" log --oneline HEAD --not "$DEFAULT" -- 2>/dev/null | head -5 || true)
     if [ -n "$dirty" ] || [ -n "$unmerged" ]; then

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -24,6 +24,8 @@ PROJ=$(grep '^project=' "$META" | cut -d= -f2-)
 
 KIND=$(grep '^kind=' "$META" | cut -d= -f2- || true)
 [ -n "$KIND" ] || KIND=ship
+MODE=$(grep '^mode=' "$META" | cut -d= -f2- || true)
+[ -n "$MODE" ] || MODE=no-mistakes
 
 if [ -d "$WT" ] && [ "$FORCE" != "--force" ]; then
   if [ "$KIND" = scout ]; then
@@ -32,6 +34,20 @@ if [ -d "$WT" ] && [ "$FORCE" != "--force" ]; then
     if [ ! -f "$REPORT" ]; then
       echo "REFUSED: scout task $ID has no report at $REPORT." >&2
       echo "The report is the work product. Have the crewmate write it (or get the captain's explicit OK to discard, then --force)." >&2
+      exit 1
+    fi
+  elif [ "$MODE" = local-only ]; then
+    # local-only ships have no remote, so the "on a remote" test never passes.
+    # The work is safe once it is merged into the local default branch (firstmate
+    # does that merge on the captain's approval). Refuse until then.
+    DEFAULT=$(git -C "$PROJ" symbolic-ref --short HEAD 2>/dev/null || echo main)
+    dirty=$(git -C "$WT" status --porcelain 2>/dev/null | grep -vE '^\?\? \.claude/' | head -1 || true)
+    unmerged=$(git -C "$WT" log --oneline HEAD --not "$DEFAULT" -- 2>/dev/null | head -5 || true)
+    if [ -n "$dirty" ] || [ -n "$unmerged" ]; then
+      echo "REFUSED: local-only worktree $WT has work not yet merged into $DEFAULT." >&2
+      [ -n "$dirty" ] && echo "uncommitted changes present" >&2
+      [ -n "$unmerged" ] && printf 'commits not yet on %s:\n%s\n' "$DEFAULT" "$unmerged" >&2
+      echo "Merge the branch into local $DEFAULT first (bin/fm-merge-local.sh after the captain approves), or get the captain's explicit OK to discard, then --force." >&2
       exit 1
     fi
   else


### PR DESCRIPTION
## Intent

Add a per-project delivery mode plus an orthogonal yolo autonomy flag to firstmate, per the captain-approved plan at data/project-modes-p2/plan.md. Each project in data/projects.md gets a mode - no-mistakes (default), direct-PR, or local-only - chosen at project-add and recorded as '- <name> [<mode>] - <desc>' with optional '+yolo'. A new reader bin/fm-project-mode.sh parses it (legacy un-annotated lines and unknown modes/projects default safely to 'no-mistakes off' with a stderr warning). fm-spawn resolves and records mode= and yolo= into state/<id>.meta alongside harness=/kind=. fm-brief shapes the ship definition-of-done by mode: no-mistakes -> /no-mistakes pipeline; direct-PR -> crewmate pushes + opens PR via gh-axi, no pipeline; local-only -> crewmate stops at 'ready in branch', firstmate reviews and merges to local main. fm-teardown gains a local-only carve-out: since local-only has no remote, the safety check requires the branch merged into the local default branch instead of 'on a remote'. New bin/fm-merge-local.sh performs the approved local-only merge as a clean fast-forward only (firstmate's merge gate-action; a deliberate, documented, narrowly-scoped exception to hard rule #1, only after captain/yolo approval). AGENTS.md sections 1, 2, 6, 7, 11 document the modes, the meta/registry format, conditional init (direct-PR/local-only skip no-mistakes init; local-only needs no remote), the per-mode lifecycle, and the yolo approval matrix (yolo on = firstmate approves routine decisions itself but still escalates destructive/irreversible/security-sensitive ones, never merges a red PR, and posts a post-hoc FYI). Deliberate decisions the captain made: yolo is orthogonal to mode (not a 4th mode) and offered-but-not-recommended; for local-only, firstmate (not the crewmate) performs the merge, hence the rule-#1 carve-out. Shell-only change; no test suite in this repo.

## What Changed

- Added per-project delivery mode parsing with safe defaults, including optional `+yolo` autonomy, and records `mode=`/`yolo=` in task metadata during spawn.
- Updated task briefs and lifecycle handling for `no-mistakes`, `direct-PR`, and `local-only` delivery paths, including local-only teardown safety.
- Added the approved local-only fast-forward merge helper and documented the registry format, mode behavior, initialization rules, and yolo approval matrix.

## Risk Assessment

✅ Low: The remaining changes are bounded to documented delivery-mode handling and fail closed in the local-only merge/teardown paths, with no material merge-blocking issues found.

## Testing

Bootstrap was silent, no automated test suite was present, and manual CLI-level validation showed registry parsing, brief shaping, spawn metadata, local-only merge safety, and local-only teardown behavior working as intended; all transient worktree fixtures were removed and the worktree ended clean.

<details>
<summary>Evidence: Clean project-mode CLI transcript</summary>

```text
# fm-project-mode end-user outputs
legacyapp => no-mistakes off
gateapp => no-mistakes off
directapp => direct-PR on
localapp => local-only off
typoapp => warn: unknown mode "fast-lane" for typoapp; defaulting to no-mistakes off
no-mistakes off
missingapp => warn: project "missingapp" not in registry; defaulting to no-mistakes off
no-mistakes off

# fm-brief definitions of done by mode

## gateapp
# Definition of done
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
During validation, fix auto-fix findings yourself; escalate ask-user findings per rule 6.
After /no-mistakes reports CI green, append `done: PR {url} checks green` and stop. You are finished.

## directapp
# Definition of done
This project ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
The task is complete only when committed on your branch.
When it is implemented and committed, push your branch and open a PR with `gh-axi`, then append `done: PR {url}` to the status file and stop.
Do NOT run /no-mistakes. The captain reviews and merges the PR; firstmate relays it.

## localapp
# Definition of done
This project ships **local-only**: no remote, no PR, no pipeline.
The task is complete only when committed on your branch `fm/brief-localapp`. Do NOT push, do NOT open a PR, do NOT merge.
Keep your branch a clean fast-forward onto the current default branch - if `main` has advanced, rebase onto it so the eventual merge stays a fast-forward.
When it is implemented and committed, append `done: ready in branch fm/brief-localapp` to the status file and stop.
Firstmate then reviews your branch diff, the captain approves, and firstmate merges it into local `main`.

# fm-spawn records project mode metadata
spawned spawn-task harness=sh kind=scout mode=direct-PR yolo=on window=firstmate:fm-spawn-task worktree=/Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KV1B7XFB3K3TYGKSPSE9QFR4/projects/directapp-wt
worktree=/Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KV1B7XFB3K3TYGKSPSE9QFR4/projects/directapp-wt
project=/Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KV1B7XFB3K3TYGKSPSE9QFR4/projects/directapp
kind=scout
mode=direct-PR
yolo=on

# local-only merge and teardown gate
WARNING: tasks are in flight but no watcher has ever run (no liveness beacon).
Restart it NOW, before anything else: run bin/fm-watch.sh as a background task.
REFUSED: local-only worktree /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KV1B7XFB3K3TYGKSPSE9QFR4/projects/localapp-wt has work not yet merged into main.
commits not yet on main:
d6c37cb local task change
Merge the branch into local main first (bin/fm-merge-local.sh after the captain approves), or get the captain's explicit OK to discard, then --force.
teardown refused before merge as expected
WARNING: tasks are in flight but no watcher has ever run (no liveness beacon).
Restart it NOW, before anything else: run bin/fm-watch.sh as a background task.
merged fm/local-task into local main (175cdaf -> d6c37cb) in /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KV1B7XFB3K3TYGKSPSE9QFR4/projects/localapp
WARNING: tasks are in flight but no watcher has ever run (no liveness beacon).
Restart it NOW, before anything else: run bin/fm-watch.sh as a background task.
treehouse return --force /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KV1B7XFB3K3TYGKSPSE9QFR4/projects/localapp-wt
teardown local-task complete (window firstmate:fm-local-task, worktree /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KV1B7XFB3K3TYGKSPSE9QFR4/projects/localapp-wt)

# bootstrap optional config check
bootstrap silent success

worktree transient fixtures cleaned
```
</details>
- Outcome: 🔧 1 issue found → auto-fixed ✅ across 2 runs (9m24s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed ✅</summary>

- 🚨 `bin/fm-project-mode.sh:60` - Unknown modes do not fully fall back to the documented safe default: a registry entry like `[typo +yolo]` becomes `no-mistakes on`, enabling autonomous approvals even though the comment and requirements say unknown modes/projects default to `no-mistakes off`. Reset `yolo=off` in this fallback path.
- 🚨 `bin/fm-merge-local.sh:27` - `DEFAULT` is derived from the project checkout&#39;s current branch, so `fm-merge-local.sh` will fast-forward whatever branch happens to be checked out instead of verifying and merging into the real default branch/main. If `projects/&lt;repo&gt;` is on a feature branch, this silently lands the local-only task in the wrong place.
- 🚨 `bin/fm-teardown.sh:43` - The local-only teardown safety check also treats the project checkout&#39;s current branch as the default branch, so it can allow teardown after commits are merged into an arbitrary checked-out branch rather than local main/default. Resolve the actual default branch and fail closed if that ref cannot be determined.

🔧 Fix: Fix local-only safety defaults
✅ Re-checked - no issues remain.

</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `bin/fm-bootstrap.sh:41` - Running the documented bootstrap command in a fresh worktree where `config/crew-harness` is absent prints `/config/crew-harness: No such file or directory` instead of staying silent. `AGENTS.md` documents the file as optional, so first-time users hit an erroneous bootstrap warning before any project-mode work can be dispatched.
- <code>`bin/fm-bootstrap.sh` in the checked-out worktree with no `config/crew-harness` file present</code>
- <code>With temporary `data/projects.md` fixtures: `bin/fm-project-mode.sh nmproj`, `bin/fm-project-mode.sh directproj`, `bin/fm-project-mode.sh localproj`, `bin/fm-project-mode.sh missingproj`, and `bin/fm-project-mode.sh badproj`</code>
- <code>With temporary registry fixtures: `bin/fm-brief.sh brief-nm nmproj`, `bin/fm-brief.sh brief-direct directproj`, and `bin/fm-brief.sh brief-local localproj`, then verified the generated user-facing brief text for each delivery mode</code>
- <code>With a temporary git project and harmless raw launcher: `bin/fm-spawn.sh spawntask projects/spawnproj &#34;printf crewmate-spawned&#34;`, then verified `state/spawntask.meta` recorded `mode=direct-PR` and `yolo=on`</code>
- <code>With a temporary local git project and sibling worktree: `bin/fm-teardown.sh localtask` before merge, `bin/fm-merge-local.sh localtask`, then `bin/fm-teardown.sh localtask` after merge using a fake `treehouse` shim</code>
- <code>`git status --short` after cleanup to confirm transient worktree fixtures were removed</code>

🔧 Fix: Guard optional harness config reads
✅ Re-checked - no issues remain.
- `bin/fm-bootstrap.sh`
- <code>Created a temporary `data/projects.md` registry and ran `bin/fm-project-mode.sh legacyapp gateapp directapp localapp typoapp missingapp` to verify defaults, direct-PR +yolo, local-only, unknown-mode fallback, and missing-project fallback.</code>
- <code>Ran `bin/fm-brief.sh &lt;id&gt; &lt;repo&gt;` for `no-mistakes`, `direct-PR`, and `local-only` registry entries and inspected the generated Definition of done sections.</code>
- <code>Ran `bin/fm-spawn.sh spawn-task projects/directapp &#39;sh -c sleep&#39; --scout` with worktree-local fake `tmux` to verify `mode=direct-PR` and `yolo=on` are recorded in task meta.</code>
- <code>Created a temporary local git repo and worktree, ran `bin/fm-teardown.sh local-task` before merge to verify local-only teardown refusal, then ran `bin/fm-merge-local.sh local-task` and reran `bin/fm-teardown.sh local-task` with worktree-local fake `treehouse` to verify fast-forward merge then successful teardown.</code>
- <code>Searched for existing test runner/test files with `Glob **/*test*`, `Glob Makefile`, and `Glob package.json`; none were present.</code>
- `git status --short`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
