### PR TITLE
docs: clarify no-mistakes init setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,11 +210,9 @@ For `local-only`, create the local repo under `projects/<name>` and skip GitHub 
 cd projects/<name> && no-mistakes init && no-mistakes doctor
 ```
 
-`no-mistakes init` writes skill files into the project (`.claude/skills/`, `.agents/skills/`).
-Crewmates spawn from committed state, so these files must be committed and pushed before the first task.
-This is one of the two sanctioned exceptions to the never-write rule (section 1): you may commit and push the tool-generated init files yourself, on a `chore/no-mistakes-init` branch with a PR, or directly to the default branch if the captain okays it.
-Touch nothing else in the project.
-`direct-PR` and `local-only` projects skip init entirely - they do not run the pipeline.
+`no-mistakes init` sets up the local gate: a bare repo plus post-receive hook, the `no-mistakes` git remote, and a database record for the repo (it needs an `origin` remote). It does **not** vendor any skill into the project - the no-mistakes skill is user-level now, available to every crewmate without a per-project copy.
+So init produces nothing to commit; it is a sanctioned exception to the never-write rule (section 1) only in that it runs git remote/config setup inside the project. Touch nothing else.
+`direct-PR` and `local-only` projects skip init entirely - they do not run the pipeline (`local-only` has no remote at all).
 
 If `no-mistakes doctor` reports problems, fix the environment (auth, daemon) before dispatching work to that project.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,8 +210,10 @@ For `local-only`, create the local repo under `projects/<name>` and skip GitHub 
 cd projects/<name> && no-mistakes init && no-mistakes doctor
 ```
 
-`no-mistakes init` sets up the local gate: a bare repo plus post-receive hook, the `no-mistakes` git remote, and a database record for the repo (it needs an `origin` remote). It does **not** vendor any skill into the project - the no-mistakes skill is user-level now, available to every crewmate without a per-project copy.
-So init produces nothing to commit; it is a sanctioned exception to the never-write rule (section 1) only in that it runs git remote/config setup inside the project. Touch nothing else.
+`no-mistakes init` sets up the local gate: a bare repo plus post-receive hook, the `no-mistakes` git remote, and a database record for the repo (it needs an `origin` remote).
+It does **not** vendor any skill into the project - the no-mistakes skill is user-level now, available to every crewmate without a per-project copy.
+So init produces nothing to commit; it is a sanctioned exception to the never-write rule (section 1) only in that it runs git remote/config setup inside the project.
+Touch nothing else.
 `direct-PR` and `local-only` projects skip init entirely - they do not run the pipeline (`local-only` has no remote at all).
 
 If `no-mistakes doctor` reports problems, fix the environment (auth, daemon) before dispatching work to that project.


### PR DESCRIPTION
## Intent

Update firstmate AGENTS.md section 6 to reflect that the no-mistakes skill is now user-level. Previously the Initialize step said 'no-mistakes init writes skill files into the project (.claude/skills/, .agents/skills/)' that crewmates needed committed - that is no longer true. Per 'no-mistakes init --help', init now sets up the local gate (a bare repo + post-receive hook, the no-mistakes git remote, and a DB record; needs an origin remote) and vendors no skill. This is part (a) of the nm-skill-devendor work; part (b) (removing the already-vendored skills from the 6 fleet projects) already shipped as separate per-project PRs. Docs-only change to AGENTS.md section 6.

## What Changed
- Updates `AGENTS.md` project initialization guidance to state that `no-mistakes init` configures the local gate, `no-mistakes` remote, hook, and database record instead of vendoring skill files.
- Removes the instruction to commit generated skill files after init and clarifies that init produces nothing to commit because the no-mistakes skill is now user-level.
- Notes that `local-only` projects skip the pipeline and have no remote.

## Risk Assessment

✅ Low: The change is a narrow documentation update to AGENTS.md that aligns the initialization instructions with the user-level no-mistakes skill model and does not alter executable behavior.

## Testing

Confirmed the range diff removes the old vendored-skill commit workflow, verified the new AGENTS.md initialize instructions match `no-mistakes init --help`, searched for stale vendoring language, captured a rendered documentation excerpt as evidence, and confirmed the working tree was left clean.

<details>
<summary>Evidence: Rendered AGENTS.md section 6 evidence</summary>

<code>Rendered excerpt shows line 213: `no-mistakes init` sets up the local gate and does not vendor any skill into the project; line 214 says init produces nothing to commit.</code>

```text
<!doctype html><html><head><meta charset="utf-8"><title>AGENTS.md Section 6 Evidence</title><style>body{font-family:-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif;margin:40px;line-height:1.5;color:#172033;background:#f7f8fb}main{max-width:980px;margin:auto;background:white;border:1px solid #d8deea;border-radius:14px;padding:28px;box-shadow:0 8px 30px #1b2a4a14}h1{margin-top:0} .ok{border-left:5px solid #238636;background:#eef8f0;padding:14px 16px;border-radius:8px;margin:18px 0}table{border-collapse:collapse;width:100%;font-size:14px}td{border-top:1px solid #e6e9f0;padding:7px 10px;vertical-align:top}td:first-child{width:52px;color:#667085;text-align:right;background:#fafbff}code{white-space:pre-wrap;font-family:ui-monospace,SFMono-Regular,Menlo,monospace}</style></head><body><main><h1>Rendered Evidence: AGENTS.md Section 6</h1><p>This excerpt demonstrates that the initialize instructions now describe <code>no-mistakes init</code> as local gate setup only, explicitly stating that it does not vendor a skill and produces nothing to commit.</p><div class="ok"><strong>Intent check:</strong> The old project-vendored skill workflow is absent from the Initialize section, and the user-level skill behavior is visible in the rendered documentation.</div><table><tr><td>206</td><td><code></code></td></tr>
<tr><td>207</td><td><code>**Initialize (`no-mistakes` mode only):**</code></td></tr>
<tr><td>208</td><td><code></code></td></tr>
<tr><td>209</td><td><code>`` `sh</code></td></tr>
<tr><td>210</td><td><code>cd projects/&lt;name&gt; &amp;&amp; no-mistakes init &amp;&amp; no-mistakes doctor</code></td></tr>
<tr><td>211</td><td><code>`` `</code></td></tr>
<tr><td>212</td><td><code></code></td></tr>
<tr><td>213</td><td><code>`no-mistakes init` sets up the local gate: a bare repo plus post-receive hook, the `no-mistakes` git remote, and a database record for the repo (it needs an `origin` remote). It does **not** vendor any skill into the project - the no-mistakes skill is user-level now, available to every crewmate without a per-project copy.</code></td></tr>
<tr><td>214</td><td><code>So init produces nothing to commit; it is a sanctioned exception to the never-write rule (section 1) only in that it runs git remote/config setup inside the project. Touch nothing else.</code></td></tr>
<tr><td>215</td><td><code>`direct-PR` and `local-only` projects skip init entirely - they do not run the pipeline (`local-only` has no remote at all).</code></td></tr>
<tr><td>216</td><td><code></code></td></tr>
<tr><td>217</td><td><code>If `no-mistakes doctor` reports problems, fix the environment (auth, daemon) before dispatching work to that project.</code></td></tr></table></main></body></html>
```
</details>
<details>
<summary>Evidence: no-mistakes init help contract</summary>

```text
Sets up or refreshes a local bare repo as a gate, installs a post-receive hook, best-effort isolates the gate hook path from shared local git config writes when Git supports `config --worktree`, adds or repairs the "no-mistakes" git remote, and records the repo in the database.

Run this from inside a git repository that has an "origin" remote.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `Read AGENTS.md section 6 lines 207-217 to verify the rendered instructions state init does not vendor skills and produces nothing to commit.`
- `git diff bed9bc27f79db039c6ea8066d3299218c339e30b..05b3d2d7ecdde96161a8979e6a1ab70298dd8eea -- AGENTS.md`
- `no-mistakes init --help`
- <code>Searched Markdown for stale instructions with `writes skill|vendor|vendored|\.claude/skills|\.agents/skills|no-mistakes skill`.</code>
- <code>Generated rendered HTML evidence at `/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KV26TCRKJKWRKNMPATPXKSE5/agents-section-6-rendered.html`.</code>
- `git status --short`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
