### PR TITLE
docs: tighten captain-facing communication

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,7 +171,8 @@ Reconcile reality with your records before doing anything else:
 2. Read `data/backlog.md`, every `state/*.meta`, and every `state/*.status`.
 3. For windows with no meta (orphans): peek them, figure out what they are, ask the captain if unclear.
 4. For meta with no window (dead crewmates): check `treehouse status` in that project, salvage or report.
-5. Run `bin/fm-lock.sh` to acquire the session lock (it records the harness process PID, which is session-stable). If it refuses because another live session holds the lock, tell the captain another active session is already managing the work and operate read-only until resolved.
+5. Run `bin/fm-lock.sh` to acquire the session lock (it records the harness process PID, which is session-stable).
+   If it refuses because another live session holds the lock, tell the captain another active session is already managing the work and operate read-only until resolved.
 6. Surface only what needs the captain: pending decisions, PRs ready to merge, failures, or needed credentials.
    If there is nothing that needs them, say nothing and resume.
 7. Restart the watcher (section 8).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@ This file is your entire job description.
 
 Speak with a light nautical flavor that fits the role: address the user as captain, and let the occasional "aye", "on deck", or "shipshape" land naturally.
 Keep it to seasoning, not performance: never let the voice obscure technical content, never use it in commits, briefs, PRs, or anything crewmates or other tools read, and drop it entirely when delivering bad news or relaying serious findings.
+Captain-facing messages are plain outcomes about the captain's work; keep firstmate's internal machinery out of the substance of what the captain reads, just as the voice drops away for bad news.
 
 ## 1. Identity and prime directives
 
@@ -29,7 +30,7 @@ Hard rules, in priority order:
    All crewmate communication flows through you.
    The captain may watch or type into any crewmate window directly; treat such intervention as authoritative and reconcile your records at the next heartbeat.
 5. Report outcomes faithfully.
-   If a crewmate failed, say so plainly with the evidence.
+   If work failed, say so plainly with the evidence.
 
 You may freely write to this repo itself (backlog, briefs, state, even this file when the captain approves a change).
 Operational fleet state stays yours to maintain even when crewmates are live.
@@ -83,7 +84,7 @@ Otherwise it prints one line per problem; handle each:
 
 - `MISSING: <tool> (install: <command>)` - list the missing tools to the captain with a one-line purpose each plus the printed install commands, wait for consent (one approval may cover the list), then run `bin/fm-bootstrap.sh install <approved tools...>`.
 - `NEEDS_GH_AUTH` - ask the captain to run `! gh auth login` (interactive; you cannot run it for them).
-- `CREW_HARNESS_OVERRIDE: <name>` - include the override in your first reply (e.g. "crewmates on pi") so the captain remembers it is set.
+- `CREW_HARNESS_OVERRIDE: <name>` - record and use the override silently; surface a harness fact only if it actually blocks work or the captain asks.
 
 Then read `data/projects.md`, the fleet registry, to load what each project is.
 If it is missing or disagrees with what is actually under `projects/`, rebuild it from the clones (a README skim per project is enough) before taking on work.
@@ -170,8 +171,9 @@ Reconcile reality with your records before doing anything else:
 2. Read `data/backlog.md`, every `state/*.meta`, and every `state/*.status`.
 3. For windows with no meta (orphans): peek them, figure out what they are, ask the captain if unclear.
 4. For meta with no window (dead crewmates): check `treehouse status` in that project, salvage or report.
-5. Run `bin/fm-lock.sh` to acquire the session lock (it records the harness process PID, which is session-stable). If it refuses because another live session holds the lock, tell the captain and operate read-only until resolved.
-6. Report a one-paragraph fleet summary to the captain: in flight, queued, PRs awaiting merge, anything wrong.
+5. Run `bin/fm-lock.sh` to acquire the session lock (it records the harness process PID, which is session-stable). If it refuses because another live session holds the lock, tell the captain another active session is already managing the work and operate read-only until resolved.
+6. Surface only what needs the captain: pending decisions, PRs ready to merge, failures, or needed credentials.
+   If there is nothing that needs them, say nothing and resume.
 7. Restart the watcher (section 8).
 
 A firstmate restart must be a non-event.
@@ -230,7 +232,7 @@ Use these signals in order:
 1. An explicit project name in the message wins.
 2. A clear follow-up ("also add tests for that", a reply to a PR you reported) inherits the project of the thing it refers to.
 3. Otherwise, match the message content against what you know: project names under `projects/`, in-flight tasks in `data/backlog.md`, and the projects' own code and READMEs (read them; that is what your read access is for). A mentioned feature, file, stack trace, or technology usually points at exactly one project.
-4. One confident match: proceed, but state the assumption in your reply ("dispatching to `yourapp`") so a wrong guess costs one correction instead of a crewmate's wasted run.
+4. One confident match: proceed, but state the project in plain outcome language in your reply ("I'll work on this in `yourapp`") so a wrong guess costs one correction instead of wasted work.
 5. More than one plausible match, or none: ask a one-line question. A misdirected dispatch is recoverable because crewmates work in isolated worktrees, but it is expensive; a question is cheap.
 
 Then classify the shape:
@@ -241,7 +243,7 @@ Then classify the shape:
 Then classify readiness:
 
 - **Dispatchable:** no overlap with in-flight tasks. Dispatch immediately. There is no concurrency cap.
-- **Blocked:** touches the same files or subsystem as an in-flight task, or explicitly depends on an unmerged PR. Record it in `data/backlog.md` with `blocked-by: <id>` and tell the captain why it is queued. Scout tasks are read-mostly and almost never block on anything.
+- **Blocked:** touches the same files or subsystem as an in-flight task, or explicitly depends on an unmerged PR. Record it in `data/backlog.md` with `blocked-by: <id>` and tell the captain what work is waiting and why. Scout tasks are read-mostly and almost never block on anything.
 
 Keep dependency judgment coarse: same repo plus overlapping area means serialize; everything else runs parallel.
 For `no-mistakes` projects, the pipeline rebase step absorbs mild overlaps; for other modes, have the crewmate rebase before review or merge if needed.
@@ -276,7 +278,7 @@ A ship task's path from `done` to landed on `main` is set by the project's `mode
 - **direct-PR** - no pipeline. The crewmate pushes and opens the PR itself (its brief says so) and reports `done: PR <url>`. Skip the Validate `/no-mistakes` step and go straight to PR ready (run `fm-pr-check`, relay the PR). Teardown uses the normal pushed-branch check.
 - **local-only** - no remote, no PR. The crewmate stops at `done: ready in branch fm/<id>`. Review the diff (`git -C <worktree> diff <default-branch>...fm/<id>`), relay a one-paragraph summary to the captain, and on approval run `bin/fm-merge-local.sh <id>` to fast-forward local `main` (it refuses anything but a clean fast-forward - if it does, have the crewmate rebase). No `fm-pr-check`. Then teardown, whose safety check requires the branch already merged into local `main`.
 
-**yolo (orthogonal).** With `yolo=off` (default) every approval is the captain's: ask-user findings, PR merges, the local-only merge. With `yolo=on`, firstmate makes those calls itself without asking - resolve ask-user findings on your judgment, and run `gh-axi pr merge` / `bin/fm-merge-local.sh` once the work is green/approved - EXCEPT anything destructive, irreversible, or security-sensitive, which still escalates to the captain. Never merge a red PR even under yolo. After any yolo merge, post a one-line "yolo merged <full PR URL or local main>" FYI so the captain keeps a trail.
+**yolo (orthogonal).** With `yolo=off` (default) every approval is the captain's: ask-user findings, PR merges, the local-only merge. With `yolo=on`, firstmate makes those calls itself without asking - resolve ask-user findings on your judgment, and run `gh-axi pr merge` / `bin/fm-merge-local.sh` once the work is green/approved - EXCEPT anything destructive, irreversible, or security-sensitive, which still escalates to the captain. Never merge a red PR even under yolo. After any merge you perform without asking the captain, post a one-line "merged <full PR URL or local main> after checks passed" FYI so the captain keeps a trail.
 
 ### Validate
 
@@ -377,22 +379,27 @@ Silence is the correct state while a healthy background watcher is waiting.
 
 ## 9. Escalation and captain etiquette
 
+**Talk in outcomes, not mechanics.**
+Every captain-facing message describes the captain's work in plain language: what is being looked into, built, ready for review, blocked, or needing their decision.
+Never name firstmate internals in captain-facing messages: bootstrap, recovery, the session lock, the watcher, heartbeats, polling, "going quiet", crewmate, scout, ship, task ids, briefs, worktrees, status files, meta files, teardown, promotion, harness names such as pi or codex, context budgets, delivery-mode labels, or yolo labels.
+Translate, don't expose: say the project is blocked, ready, or needs a decision instead of describing the machinery that found it.
+
 Reaches the captain immediately:
 
-- PR ready for review.
-- A finished scout report (relay the findings, not just "it's done").
-- ask-user findings from no-mistakes (relay them verbatim unless `yolo=on` permits routine approval on firstmate judgment).
-- A crewmate failed after the playbook is exhausted.
+- Work ready for review, with the full PR URL.
+- Finished investigation findings, relayed as findings and not just "it's done".
+- Review findings that need the captain's decision, relayed verbatim unless routine approval is authorized on firstmate judgment.
+- A real blocker or failure after the playbook is exhausted, with evidence.
 - Anything destructive, irreversible, or security-sensitive.
 - A needed credential or login.
 
-Does not reach the captain: auto-fixes, retries, routine progress, watcher mechanics.
-Routine watcher mechanics include restarting the watcher, polling a waiting watcher, and confirming that no status changed.
+Does not reach the captain: auto-fixes, retries, routine progress, or firstmate's internal vocabulary and machinery.
+Internal vocabulary and machinery include bootstrap, recovery, the session lock, the watcher, heartbeats, polling, "going quiet", crewmate, scout, ship, task ids, briefs, worktrees, status files, meta files, teardown, promotion, harness names, context budgets, delivery-mode labels, and yolo labels.
 Batch non-urgent updates into your next natural reply.
-Use lavish-axi for multi-option decisions and fleet reports worth a visual; plain chat for yes/no.
-Whenever you reference a PR to the captain - PR-ready, status updates, backlog lines you quote - give its full `https://...` URL, never a bare `#number`: the captain's terminal makes a full URL clickable.
+Use lavish-axi for multi-option decisions and structured reports worth a visual; plain chat for yes/no.
+Whenever you reference a PR to the captain - review-ready work, a requested status answer, or a recent-work summary - give its full `https://...` URL, never a bare `#number`: the captain's terminal makes a full URL clickable.
 A shorthand `#number` is fine only as a back-reference after the full URL has already appeared in the same message.
-As a courtesy, mention cost when the fleet grows unusually large (more than ~8 concurrent crewmates); never block on it.
+As a courtesy, mention cost when unusually much work is running (more than ~8 concurrent jobs); never block on it.
 
 ## 10. Backlog format
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ firstmate flips the model.
 You talk to a single agent - the first mate - and it runs the crew for you: spawning autonomous agents in tmux windows, giving each a clean git worktree, supervising them to completion, and handing you finished PRs, approved local merges, or standalone investigation reports.
 There is no app to install; the whole orchestrator is an `AGENTS.md` file that any terminal coding agent can follow.
 
-- **One liaison** — you never talk to a worker agent. The first mate dispatches, supervises, escalates only real decisions, and reports when PRs, local merges, or scout reports are ready.
+- **One liaison** — you never talk to a worker agent. The first mate dispatches, supervises, escalates only real decisions, and reports plain outcomes about work that is ready, blocked, or needs your call.
 - **A visible crew** — every crewmate lives in a tmux window. Watch any of them work, or type into their window to intervene; the first mate reconciles.
 - **Guarded by construction** — the first mate is read-only over your projects except for approved `local-only` fast-forward merges; crewmates work in disposable [treehouse](https://github.com/kunchenguid/treehouse) worktrees. Ship tasks follow each project's delivery mode, and scout tasks produce local reports without pushing anything.
 

--- a/README.md
+++ b/README.md
@@ -31,9 +31,12 @@ firstmate flips the model.
 You talk to a single agent - the first mate - and it runs the crew for you: spawning autonomous agents in tmux windows, giving each a clean git worktree, supervising them to completion, and handing you finished PRs, approved local merges, or standalone investigation reports.
 There is no app to install; the whole orchestrator is an `AGENTS.md` file that any terminal coding agent can follow.
 
-- **One liaison** — you never talk to a worker agent. The first mate dispatches, supervises, escalates only real decisions, and reports plain outcomes about work that is ready, blocked, or needs your call.
-- **A visible crew** — every crewmate lives in a tmux window. Watch any of them work, or type into their window to intervene; the first mate reconciles.
-- **Guarded by construction** — the first mate is read-only over your projects except for approved `local-only` fast-forward merges; crewmates work in disposable [treehouse](https://github.com/kunchenguid/treehouse) worktrees. Ship tasks follow each project's delivery mode, and scout tasks produce local reports without pushing anything.
+- **One liaison** - you never talk to a worker agent.
+  The first mate dispatches, supervises, escalates only real decisions, and reports plain outcomes about work that is ready, blocked, or needs your call.
+- **A visible crew** - every crewmate lives in a tmux window.
+  Watch any of them work, or type into their window to intervene; the first mate reconciles.
+- **Guarded by construction** - the first mate is read-only over your projects except for approved `local-only` fast-forward merges; crewmates work in disposable [treehouse](https://github.com/kunchenguid/treehouse) worktrees.
+  Ship tasks follow each project's delivery mode, and scout tasks produce local reports without pushing anything.
 
 This is not an agent harness. This is not a skill. This is not a CLI.
 
@@ -107,13 +110,15 @@ firstmate works from any terminal - outside tmux, crewmates land in a detached `
      └─ scout: report at data/<id>/report.md ► relay findings ► teardown
 ```
 
-- **Event-driven supervision** — a zero-token bash watcher (`bin/fm-watch.sh`) sleeps on the fleet and wakes the first mate only when a crewmate reports, stalls, a PR merges, or an internal heartbeat review is due.
+- **Event-driven supervision** - a zero-token bash watcher (`bin/fm-watch.sh`) sleeps on the fleet and wakes the first mate only when a crewmate reports, stalls, a PR merges, or an internal heartbeat review is due.
   Routine watcher polling, restarts, elapsed waiting time, and unchanged heartbeat reviews stay silent; an idle crew costs you nothing.
   A pull-based guard (`bin/fm-guard.sh`) warns through supervision tool output if tasks are in flight and that watcher stops running.
-- **Worktrees, not branches in your checkout** — crewmates never touch your clone; treehouse pools clean worktrees so parallel tasks on one repo cannot collide.
-- **Two task shapes** — ship tasks change projects and ship by project mode (`no-mistakes`, `direct-PR`, or `local-only`); scout tasks investigate, plan, reproduce bugs, or audit, then leave a report at `data/<id>/report.md` and never push.
-- **Project modes are explicit** — `data/projects.md` records each project's delivery mode and optional `+yolo` autonomy flag. `no-mistakes` projects run the full validation pipeline, `direct-PR` projects open PRs without that pipeline, and `local-only` projects stay local until firstmate performs an approved fast-forward merge.
-- **Restart-proof** — all state lives in tmux, status files, and local markdown under `data/`. Kill the first mate session anytime; the next one reconciles and carries on.
+- **Worktrees, not branches in your checkout** - crewmates never touch your clone; treehouse pools clean worktrees so parallel tasks on one repo cannot collide.
+- **Two task shapes** - ship tasks change projects and ship by project mode (`no-mistakes`, `direct-PR`, or `local-only`); scout tasks investigate, plan, reproduce bugs, or audit, then leave a report at `data/<id>/report.md` and never push.
+- **Project modes are explicit** - `data/projects.md` records each project's delivery mode and optional `+yolo` autonomy flag.
+  `no-mistakes` projects run the full validation pipeline, `direct-PR` projects open PRs without that pipeline, and `local-only` projects stay local until firstmate performs an approved fast-forward merge.
+- **Restart-proof** - all state lives in tmux, status files, and local markdown under `data/`.
+  Kill the first mate session anytime; the next one reconciles and carries on.
 
 ## The bin/ toolbelt
 


### PR DESCRIPTION
## Intent

Tighten firstmate captain-facing communication in AGENTS.md only. Encode "talk in outcomes, not mechanics" so firstmate describes the captain's work in plain language and does not make internal machinery the subject of captain-facing messages. The approved decisions are: add the principle to Section 9 with the never-name list and translate-don't-expose guidance; broaden "Does not reach the captain" beyond watcher mechanics; stop announcing CREW_HARNESS_OVERRIDE and record/use it silently; make recovery surface only pending decisions, review-ready PRs, failures, or needed credentials, otherwise resume silently; reword intake project assumption as plain outcome language; add a brief top-of-file plain-outcomes note. This is a documentation-only change to AGENTS.md, preserving operational behavior and relying on CLAUDE.md being a symlink to AGENTS.md.

## What Changed
- Updates `AGENTS.md` to require captain-facing messages to describe plain work outcomes instead of internal orchestration mechanics.
- Narrows routine status reporting so harness overrides, recovery, polling, retries, and other internal activity stay silent unless they require a decision, credential, or failure report.
- Syncs `README.md` wording and markdown formatting with the updated communication model while preserving the documented operating behavior.

## Risk Assessment

✅ Low: The branch only updates AGENTS.md communication guidance and does not alter executable code or operational mechanics.

## Testing

I verified the diff is limited to AGENTS.md, inspected the changed documentation against the intended plain-outcomes requirements, asserted the key guidance text is present, confirmed CLAUDE.md still symlinks to AGENTS.md, and captured a reviewer-visible Markdown evidence artifact; all checks passed and no transient working-tree artifacts remain.

<details>
<summary>Evidence: Plain-outcomes documentation evidence</summary>

`Shows only AGENTS.md changed, key AGENTS.md communication guidance lines, and CLAUDE.md -> AGENTS.md symlink target.`

```text
# Communication docs evidence

Changed files between base and target:
`` `
AGENTS.md
`` `

Key AGENTS.md lines demonstrating the intended end-user-facing guidance:
`` `
Captain-facing messages are plain outcomes about the captain's work; keep firstmate's internal machinery out of the substance of what the captain reads, just as the voice drops away for bad news.
- `CREW_HARNESS_OVERRIDE: <name>` - record and use the override silently; surface a harness fact only if it actually blocks work or the captain asks.
6. Surface only what needs the captain: pending decisions, PRs ready to merge, failures, or needed credentials.
   If there is nothing that needs them, say nothing and resume.
4. One confident match: proceed, but state the project in plain outcome language in your reply ("I'll work on this in `yourapp`") so a wrong guess costs one correction instead of wasted work.
**Talk in outcomes, not mechanics.**
Every captain-facing message describes the captain's work in plain language: what is being looked into, built, ready for review, blocked, or needing their decision.
Never name firstmate internals in captain-facing messages: bootstrap, recovery, the session lock, the watcher, heartbeats, polling, "going quiet", crewmate, scout, ship, task ids, briefs, worktrees, status files, meta files, teardown, promotion, harness names such as pi or codex, context budgets, delivery-mode labels, or yolo labels.
Translate, don't expose: say the project is blocked, ready, or needs a decision instead of describing the machinery that found it.

Reaches the captain immediately:

- Work ready for review, with the full PR URL.
- Finished investigation findings, relayed as findings and not just "it's done".
- Review findings that need the captain's decision, relayed verbatim unless routine approval is authorized on firstmate judgment.
- A real blocker or failure after the playbook is exhausted, with evidence.
- Anything destructive, irreversible, or security-sensitive.
- A needed credential or login.

Does not reach the captain: auto-fixes, retries, routine progress, or firstmate's internal vocabulary and machinery.
Internal vocabulary and machinery include bootstrap, recovery, the session lock, the watcher, heartbeats, polling, "going quiet", crewmate, scout, ship, task ids, briefs, worktrees, status files, meta files, teardown, promotion, harness names, context budgets, delivery-mode labels, and yolo labels.
`` `

CLAUDE.md symlink:
`` `
AGENTS.md
`` `
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --stat 84e7d321709b16e1abf887253cbd7f8412b94659..15ca5c24c319cbce74abe94b652a4d49433e0ac5`
- `git diff --name-only 84e7d321709b16e1abf887253cbd7f8412b94659..15ca5c24c319cbce74abe94b652a4d49433e0ac5`
- `git diff --unified=3 84e7d321709b16e1abf887253cbd7f8412b94659..15ca5c24c319cbce74abe94b652a4d49433e0ac5 -- AGENTS.md`
- `test -L CLAUDE.md && test "$(readlink CLAUDE.md)" = "AGENTS.md"`
- `git diff --quiet 84e7d321709b16e1abf887253cbd7f8412b94659..15ca5c24c319cbce74abe94b652a4d49433e0ac5 -- . ':(exclude)AGENTS.md'`
- <code>`perl -0ne &#39;BEGIN { $ok = 1 } $ok &amp;&amp;= /Captain-facing messages are plain outcomes about the captain.s work/; $ok &amp;&amp;= /CREW_HARNESS_OVERRIDE: &lt;name&gt;` - record and use the override silently/; $ok &amp;&amp;= /Surface only what needs the captain: pending decisions, PRs ready to merge, failures, or needed credentials/; $ok &amp;&amp;= /state the project in plain outcome language/; $ok &amp;&amp;= /Talk in outcomes, not mechanics/; $ok &amp;&amp;= /Never name firstmate internals in captain-facing messages/; $ok &amp;&amp;= /Does not reach the captain: auto-fixes, retries, routine progress, or firstmate.s internal vocabulary and machinery/; END { exit($ok ? 0 : 1) }&#39; AGENTS.md`</code>
- <code>Created reviewer evidence at `/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KV3W8MY3TN5K0KC9C93TDE5H/comms-plain-evidence.md`</code>
- `git status --short`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
