### PR TITLE
feat: add authoritative review diff helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -277,7 +277,10 @@ A ship task's path from `done` to landed on `main` is set by the project's `mode
 
 - **no-mistakes** - the stages below as written: `/no-mistakes` pipeline -> PR -> captain merge.
 - **direct-PR** - no pipeline. The crewmate pushes and opens the PR itself (its brief says so) and reports `done: PR <url>`. Skip the Validate `/no-mistakes` step and go straight to PR ready (run `fm-pr-check`, relay the PR). Teardown uses the normal pushed-branch check.
-- **local-only** - no remote, no PR. The crewmate stops at `done: ready in branch fm/<id>`. Review the diff (`git -C <worktree> diff <default-branch>...fm/<id>`), relay a one-paragraph summary to the captain, and on approval run `bin/fm-merge-local.sh <id>` to fast-forward local `main` (it refuses anything but a clean fast-forward - if it does, have the crewmate rebase). No `fm-pr-check`. Then teardown, whose safety check requires the branch already merged into local `main`.
+- **local-only** - no remote, no PR. The crewmate stops at `done: ready in branch fm/<id>`. Review the diff with `bin/fm-review-diff.sh <id>`, relay a one-paragraph summary to the captain, and on approval run `bin/fm-merge-local.sh <id>` to fast-forward local `main` (it refuses anything but a clean fast-forward - if it does, have the crewmate rebase). No `fm-pr-check`. Then teardown, whose safety check requires the branch already merged into local `main`.
+
+When reviewing any crewmate branch diff, use `bin/fm-review-diff.sh <id>` rather than `git diff <default>...branch` directly.
+Pooled clones keep their local default refs frozen at clone time and can lag `origin`; the helper always compares against the authoritative base.
 
 **yolo (orthogonal).** With `yolo=off` (default) every approval is the captain's: ask-user findings, PR merges, the local-only merge. With `yolo=on`, firstmate makes those calls itself without asking - resolve ask-user findings on your judgment, and run `gh-axi pr merge` / `bin/fm-merge-local.sh` once the work is green/approved - EXCEPT anything destructive, irreversible, or security-sensitive, which still escalates to the captain. Never merge a red PR even under yolo. After any merge you perform without asking the captain, post a one-line "merged <full PR URL or local main> after checks passed" FYI so the captain keeps a trail.
 
@@ -358,7 +361,7 @@ tmux is the ground truth.
 **Watcher liveness is guarded, not just disciplined.**
 Restarting the watcher is the last action of every wake-handling turn - but the protocol no longer relies on remembering that.
 While running, `fm-watch.sh` touches `state/.last-watcher-beat` every poll cycle.
-The supervision scripts (`fm-peek`, `fm-send`, `fm-spawn`, `fm-teardown`, `fm-pr-check`, `fm-promote`) call `bin/fm-guard.sh` first, which warns to stderr when any task is in flight (`state/*.meta` exists) but that beacon is missing or older than `FM_GUARD_GRACE` (default 300s).
+The supervision scripts (`fm-peek`, `fm-send`, `fm-spawn`, `fm-teardown`, `fm-pr-check`, `fm-promote`, `fm-review-diff`) call `bin/fm-guard.sh` first, which warns to stderr when any task is in flight (`state/*.meta` exists) but that beacon is missing or older than `FM_GUARD_GRACE` (default 300s).
 So the next time you touch the fleet with no watcher alive, the tool output itself tells you to restart it - a pull-based guard that works on any harness, since it rides the script output you already read rather than a harness-specific hook.
 The grace window keeps normal handling (watcher briefly down between a wake and its restart) silent.
 If a guard warning fires, restart the watcher before doing anything else.

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ The first mate drives these; you rarely need to, but they work by hand too.
 | `fm-spawn.sh`     | Window → treehouse worktree → agent launched with its brief; records ship/scout task kind   |
 | `fm-project-mode.sh` | Resolve a project's delivery mode and `+yolo` flag from `data/projects.md`               |
 | `fm-merge-local.sh` | Fast-forward a `local-only` project's local default branch after approval                  |
+| `fm-review-diff.sh` | Review a crewmate branch against the authoritative base, with optional `--stat` output    |
 | `fm-watch.sh`     | Block until supervision work is due; exits with one reason line                             |
 | `fm-send.sh`      | Send one literal line (or `--key Escape`) to a crewmate window                              |
 | `fm-peek.sh`      | Print a bounded tail of a crewmate pane                                                     |

--- a/bin/fm-review-diff.sh
+++ b/bin/fm-review-diff.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Review a crewmate branch against the authoritative base.
+#
+# Pooled project clones do not keep their local default branch current, so this
+# helper compares remote-backed projects against origin/<default> after fetching
+# the default branch, and local-only projects against the local default branch.
+# Usage: fm-review-diff.sh <task-id> [--stat]
+#   --stat prints only the stat summary; default prints stat summary plus full diff.
+set -eu
+
+FM_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+"$FM_ROOT/bin/fm-guard.sh" || true
+
+usage() {
+  echo "usage: fm-review-diff.sh <task-id> [--stat]" >&2
+}
+
+if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
+  usage
+  exit 0
+fi
+
+ID=${1:-}
+[ -n "$ID" ] || { usage; exit 1; }
+STAT_ONLY=false
+case "${2:-}" in
+  '') ;;
+  --stat) STAT_ONLY=true ;;
+  *) usage; exit 1 ;;
+esac
+[ $# -le 2 ] || { usage; exit 1; }
+
+META="$FM_ROOT/state/$ID.meta"
+[ -f "$META" ] || { echo "error: no meta for task $ID at $META" >&2; exit 1; }
+
+WT=$(grep '^worktree=' "$META" | cut -d= -f2-)
+PROJ=$(grep '^project=' "$META" | cut -d= -f2-)
+[ -n "$WT" ] || { echo "error: meta for task $ID is missing worktree=" >&2; exit 1; }
+[ -n "$PROJ" ] || { echo "error: meta for task $ID is missing project=" >&2; exit 1; }
+[ -d "$WT" ] || { echo "error: worktree for task $ID is missing: $WT" >&2; exit 1; }
+[ -d "$PROJ" ] || { echo "error: project for task $ID is missing: $PROJ" >&2; exit 1; }
+
+default_branch() {
+  local ref branch
+  ref=$(git -C "$PROJ" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)
+  if [ -n "$ref" ]; then
+    echo "${ref#origin/}"
+    return 0
+  fi
+  for branch in main master; do
+    if git -C "$PROJ" show-ref --verify --quiet "refs/heads/$branch"; then
+      echo "$branch"
+      return 0
+    fi
+  done
+  return 1
+}
+
+DEFAULT=$(default_branch) || { echo "error: cannot determine default branch for $PROJ; expected origin/HEAD, main, or master" >&2; exit 1; }
+
+BRANCH="fm/$ID"
+if ! git -C "$WT" rev-parse --verify --quiet "refs/heads/$BRANCH" >/dev/null; then
+  BRANCH=$(git -C "$WT" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
+  [ -n "$BRANCH" ] || { echo "error: branch fm/$ID does not exist and worktree $WT is detached" >&2; exit 1; }
+  git -C "$WT" rev-parse --verify --quiet "refs/heads/$BRANCH" >/dev/null || { echo "error: branch $BRANCH does not exist in $WT" >&2; exit 1; }
+fi
+
+if git -C "$PROJ" remote get-url origin >/dev/null 2>&1; then
+  # Update the remote-tracking ref itself; a bare single-branch fetch can leave
+  # origin/<default> stale on some Git versions and only refresh FETCH_HEAD.
+  git -C "$WT" fetch origin "+refs/heads/$DEFAULT:refs/remotes/origin/$DEFAULT" --quiet
+  BASE="origin/$DEFAULT"
+else
+  BASE="$DEFAULT"
+fi
+
+git -C "$WT" rev-parse --verify --quiet "$BASE^{commit}" >/dev/null || { echo "error: base $BASE does not exist in $WT" >&2; exit 1; }
+git -C "$WT" rev-parse --verify --quiet "$BRANCH^{commit}" >/dev/null || { echo "error: branch $BRANCH does not resolve in $WT" >&2; exit 1; }
+
+echo "diff base: $BASE"
+if git -C "$WT" diff --quiet "$BASE...$BRANCH" --; then
+  echo "no changes vs $BASE"
+  exit 0
+fi
+
+git -C "$WT" diff --stat "$BASE...$BRANCH" --
+if ! "$STAT_ONLY"; then
+  echo
+  git -C "$WT" diff "$BASE...$BRANCH" --
+fi


### PR DESCRIPTION
## Intent

Add a read-only bin/fm-review-diff.sh helper so firstmate reviews crewmate branches against the authoritative base instead of a stale pooled clone local default ref. The helper should resolve worktree and project from state/<id>.meta, detect the default branch with the same origin/HEAD then main/master fallback used by fm-merge-local.sh and fm-teardown.sh, verify fm/<id> or fall back to the worktree current branch, fetch only origin/<default> for remote-backed projects, use the local default branch for local-only projects, print a header naming the base, support --stat mode, show no changes gracefully, and avoid pulls, merges, or working-tree mutation. Update AGENTS.md so local-only review and general branch diff review use the helper, with a concise stale-local-ref note, while matching existing bin script conventions.

## What Changed

- Adds `bin/fm-review-diff.sh`, a read-only helper that resolves a task worktree from `state/<id>.meta`, compares `fm/<id>` or the current branch against the authoritative default branch, and supports full patch or `--stat` output.
- Handles remote-backed projects by fetching only `origin/<default>`, handles local-only projects against the local default branch, and reports unchanged branches gracefully.
- Updates firstmate documentation to use the helper for local-only and general branch diff reviews so stale pooled-clone default refs do not skew review diffs.

## Risk Assessment

✅ Low: The change is a small, bounded read-only review helper plus documentation updates, and it follows the existing default-branch and guard conventions without introducing material risks.

## Testing

Baseline inspection confirmed only `AGENTS.md` and `bin/fm-review-diff.sh` changed; end-to-end CLI fixtures exercised remote-backed stale-base fetching, local-only review, no-change output, current-branch fallback, `--stat`, default full diff, and `master` fallback successfully, with temporary working-tree artifacts cleaned up afterward.

<details>
<summary>Evidence: fm-review-diff end-to-end CLI transcript</summary>

<code>Transcript shows stale `origin/main` before helper, updated `origin/main` after helper, correct diff bases for remote/local/master, no-change handling, current-branch fallback, stat output, and full patch output. Guard warnings appear because the isolated test created fake task metadata without running the normal supervisor loop; they did not affect helper behavior.</code>

```text
== Remote-backed project fetches authoritative default branch ==
origin/main before helper: 7d5b9658301e3630064a852a71dc980c791fdcd2
remote main: 28c618f892ceb6fd21b9019f10c8dfffc9c4b3d0
WARNING: tasks are in flight but no watcher has ever run (no liveness beacon).
Restart it NOW, before anything else: run bin/fm-watch.sh as a background task.
diff base: origin/main
 feature.txt | 1 +
 1 file changed, 1 insertion(+)
origin/main after helper: 28c618f892ceb6fd21b9019f10c8dfffc9c4b3d0

== No changes are reported gracefully ==
WARNING: tasks are in flight but no watcher has ever run (no liveness beacon).
Restart it NOW, before anything else: run bin/fm-watch.sh as a background task.
diff base: origin/main
no changes vs origin/main

== Local-only project uses local default branch ==
WARNING: tasks are in flight but no watcher has ever run (no liveness beacon).
Restart it NOW, before anything else: run bin/fm-watch.sh as a background task.
diff base: main
 local-feature.txt | 1 +
 1 file changed, 1 insertion(+)

== Missing fm/<id> falls back to current branch ==
WARNING: tasks are in flight but no watcher has ever run (no liveness beacon).
Restart it NOW, before anything else: run bin/fm-watch.sh as a background task.
diff base: main
 fallback.txt | 1 +
 1 file changed, 1 insertion(+)

All fm-review-diff behavior checks passed.

== Default output prints stat plus full diff and master fallback ==
WARNING: tasks are in flight but no watcher has ever run (no liveness beacon).
Restart it NOW, before anything else: run bin/fm-watch.sh as a background task.
diff base: master
 readme.txt | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

diff --git a/readme.txt b/readme.txt
index 90be1f3..294186e 100644
--- a/readme.txt
+++ b/readme.txt
@@ -1 +1 @@
-before
+after

Additional full-diff behavior check passed.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git status --short && git diff --stat 1d1db259114a47af8a7190f051dc8de94bec4905..21fb0fde44252c8059811df0e587090fe8c551d1`
- <code>Temporary remote-backed git fixture: created a stale local `origin/main`, ran `./bin/fm-review-diff.sh remote-stale --stat`, and verified the helper fetched only the authoritative default branch before diffing `fm/remote-stale`.</code>
- <code>Temporary remote-backed no-change fixture: ran `./bin/fm-review-diff.sh no-change` and verified it printed `no changes vs origin/main` gracefully.</code>
- <code>Temporary local-only fixture: ran `./bin/fm-review-diff.sh local-only --stat` and verified it used local `main` as the base without a remote fetch.</code>
- <code>Temporary fallback fixture: ran `./bin/fm-review-diff.sh fallback --stat` with no `fm/fallback` branch and verified it diffed the current branch against `main`.</code>
- <code>Temporary `master` fallback/full-output fixture: ran `./bin/fm-review-diff.sh master-full` and verified default output included both stat and full patch against `master`.</code>
- <code>`git status --short` after testing to verify transient working-tree artifacts were removed.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
