### PR TITLE
fix(bin): keep fleet clones cleanly synced

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,8 @@ Hard rules, in priority order:
 1. **Never write to a project.**
    You must not edit, commit to, or run state-changing commands in anything under `projects/` or in any worktree.
    You read projects to understand them; crewmates change them.
-   Two sanctioned exceptions: tool-driven project initialization (section 6), and the approved local merge for a `local-only` project, which firstmate performs with `bin/fm-merge-local.sh` once the captain approves (section 7).
+   Three sanctioned exceptions: tool-driven project initialization (section 6), clean fast-forwarding a clone's local default branch to match `origin` via `bin/fm-fleet-sync.sh`, and the approved local merge for a `local-only` project, which firstmate performs with `bin/fm-merge-local.sh` once the captain approves (section 7).
+   The fleet sync exception advances only the checked-out local default branch and never forces, creates merge commits, stashes, or changes treehouse worktrees.
 2. **Never merge a PR without the captain's explicit word.**
    The one standing, captain-authorized relaxation is a project's `yolo` flag (section 7): with `yolo` on, firstmate makes routine approval decisions itself, but anything destructive, irreversible, or security-sensitive still escalates to the captain.
 3. **Never tear down a worktree that holds unlanded work.**
@@ -52,7 +53,7 @@ README.md            public overview and development notes
 .github/workflows/   shared CI and PR enforcement, committed
 .agents/skills/      shared skills, committed
 .claude/skills       symlink to .agents/skills for claude compatibility
-bin/                 helper scripts, committed; read each script's header before first use
+bin/                 helper scripts, committed, including fm-fleet-sync.sh for clean default-branch refreshes; read each script's header before first use
 config/crew-harness  crewmate harness override; LOCAL, gitignored; absent or "default" = same as firstmate
 data/                personal fleet records; LOCAL, gitignored as a whole
   backlog.md         task queue, dependencies, history
@@ -79,12 +80,14 @@ Bootstrap is detect, then consent, then install.
 Never install anything the captain has not approved in this session.
 
 Run `bin/fm-bootstrap.sh`.
+Bootstrap also refreshes the fleet via `bin/fm-fleet-sync.sh`: it fetches each remote-backed clone and clean-fast-forwards its local default branch when safe, best-effort and non-fatal.
 Silence means all good: say nothing and move on.
 Otherwise it prints one line per problem; handle each:
 
 - `MISSING: <tool> (install: <command>)` - list the missing tools to the captain with a one-line purpose each plus the printed install commands, wait for consent (one approval may cover the list), then run `bin/fm-bootstrap.sh install <approved tools...>`.
 - `NEEDS_GH_AUTH` - ask the captain to run `! gh auth login` (interactive; you cannot run it for them).
 - `CREW_HARNESS_OVERRIDE: <name>` - record and use the override silently; surface a harness fact only if it actually blocks work or the captain asks.
+- `FLEET_SYNC: <repo>: skipped: <reason>` - bootstrap continued; investigate only if the dirty, diverged, or offline clone blocks work.
 
 Then read `data/projects.md`, the fleet registry, to load what each project is.
 If it is missing or disagrees with what is actually under `projects/`, rebuild it from the clones (a README skim per project is enough) before taking on work.
@@ -314,6 +317,7 @@ bin/fm-teardown.sh <id>
 
 The script refuses if the worktree holds unpushed work; treat a refusal as a stop-and-investigate, not an obstacle.
 Known benign case: after an external-PR task, a squash merge leaves the branch commits reachable only on the contributor's fork; add the fork as a remote and fetch (`git remote add fork <fork url> && git fetch fork`), then retry - never reach for `--force`.
+After a successful PR-based teardown, it also runs `bin/fm-fleet-sync.sh` for that project, best-effort, so the clone's local default catches up to the merge immediately.
 Then move the task to Done in `data/backlog.md` (with the full `https://...` PR URL or local merge note and date), re-evaluate the queue, and dispatch anything that was blocked on this task.
 
 ### Scout tasks (report instead of PR)
@@ -361,7 +365,7 @@ tmux is the ground truth.
 **Watcher liveness is guarded, not just disciplined.**
 Restarting the watcher is the last action of every wake-handling turn - but the protocol no longer relies on remembering that.
 While running, `fm-watch.sh` touches `state/.last-watcher-beat` every poll cycle.
-The supervision scripts (`fm-peek`, `fm-send`, `fm-spawn`, `fm-teardown`, `fm-pr-check`, `fm-promote`, `fm-review-diff`) call `bin/fm-guard.sh` first, which warns to stderr when any task is in flight (`state/*.meta` exists) but that beacon is missing or older than `FM_GUARD_GRACE` (default 300s).
+The supervision scripts (`fm-peek`, `fm-send`, `fm-spawn`, `fm-teardown`, `fm-pr-check`, `fm-promote`, `fm-review-diff`, `fm-fleet-sync`) call `bin/fm-guard.sh` first, which warns to stderr when any task is in flight (`state/*.meta` exists) but that beacon is missing or older than `FM_GUARD_GRACE` (default 300s).
 So the next time you touch the fleet with no watcher alive, the tool output itself tells you to restart it - a pull-based guard that works on any harness, since it rides the script output you already read rather than a harness-specific hook.
 The grace window keeps normal handling (watcher briefly down between a wake and its restart) silent.
 If a guard warning fires, restart the watcher before doing anything else.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,8 @@ Otherwise it prints one line per problem; handle each:
 - `CREW_HARNESS_OVERRIDE: <name>` - record and use the override silently; surface a harness fact only if it actually blocks work or the captain asks.
 - `FLEET_SYNC: <repo>: skipped: <reason>` - bootstrap continued; investigate only if the dirty, diverged, or offline clone blocks work.
 
+Bootstrap's fleet refresh is bounded by `FM_FLEET_SYNC_BOOTSTRAP_TIMEOUT` seconds, default 20; a timeout is reported as a `FLEET_SYNC` skip and does not block startup.
+
 Then read `data/projects.md`, the fleet registry, to load what each project is.
 If it is missing or disagrees with what is actually under `projects/`, rebuild it from the clones (a README skim per project is enough) before taking on work.
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ There is no app to install; the whole orchestrator is an `AGENTS.md` file that a
   The first mate dispatches, supervises, escalates only real decisions, and reports plain outcomes about work that is ready, blocked, or needs your call.
 - **A visible crew** - every crewmate lives in a tmux window.
   Watch any of them work, or type into their window to intervene; the first mate reconciles.
-- **Guarded by construction** - the first mate is read-only over your projects except for approved `local-only` fast-forward merges; crewmates work in disposable [treehouse](https://github.com/kunchenguid/treehouse) worktrees.
+- **Guarded by construction** - the first mate is read-only over your projects except for clean local default-branch refreshes and approved `local-only` fast-forward merges; crewmates work in disposable [treehouse](https://github.com/kunchenguid/treehouse) worktrees.
   Ship tasks follow each project's delivery mode, and scout tasks produce local reports without pushing anything.
 
 This is not an agent harness. This is not a skill. This is not a CLI.
@@ -126,7 +126,8 @@ The first mate drives these; you rarely need to, but they work by hand too.
 
 | Script            | Description                                                                                 |
 | ----------------- | ------------------------------------------------------------------------------------------- |
-| `fm-bootstrap.sh` | Detect missing toolchain pieces; install them only after consent                            |
+| `fm-bootstrap.sh` | Detect missing toolchain pieces; refresh clones best-effort; install tools only after consent |
+| `fm-fleet-sync.sh` | Fetch clones and clean-fast-forward their checked-out local default branches when safe       |
 | `fm-brief.sh`     | Scaffold a ship brief, or a report-only scout brief with `--scout`                          |
 | `fm-guard.sh`     | Warn when tasks are in flight but the watcher liveness beacon is stale or missing           |
 | `fm-spawn.sh`     | Window → treehouse worktree → agent launched with its brief; records ship/scout task kind   |

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ firstmate works from any terminal - outside tmux, crewmates land in a detached `
                   ▼
  ┌─────────────────────────────────────┐
  │ firstmate            (this repo)    │
- │ reads projects/; writes only gated  │
+ │ reads projects/; writes guarded     │
  │ backlog.md ── briefs ── watcher     │
  └──┬──────────────┬───────────────┬───┘
     │ tmux send-keys / status files │
@@ -117,6 +117,7 @@ firstmate works from any terminal - outside tmux, crewmates land in a detached `
 - **Two task shapes** - ship tasks change projects and ship by project mode (`no-mistakes`, `direct-PR`, or `local-only`); scout tasks investigate, plan, reproduce bugs, or audit, then leave a report at `data/<id>/report.md` and never push.
 - **Project modes are explicit** - `data/projects.md` records each project's delivery mode and optional `+yolo` autonomy flag.
   `no-mistakes` projects run the full validation pipeline, `direct-PR` projects open PRs without that pipeline, and `local-only` projects stay local until firstmate performs an approved fast-forward merge.
+- **Local clones stay fresh** - bootstrap and PR-based teardown refresh remote-backed project clones with clean default-branch fast-forwards when the clone is on the default branch and has no local work.
 - **Restart-proof** - all state lives in tmux, status files, and local markdown under `data/`.
   Kill the first mate session anytime; the next one reconciles and carries on.
 
@@ -158,6 +159,7 @@ FM_CHECK_INTERVAL=300   # seconds between slow checks (merged-PR polls)
 FM_CHECK_TIMEOUT=30     # seconds allowed per slow check script
 FM_GUARD_GRACE=300      # seconds a stale watcher beacon may age before guard warnings
 FM_SIGNAL_GRACE=30      # seconds to coalesce nearby status and turn-end signals into one wake
+FM_FLEET_SYNC_BOOTSTRAP_TIMEOUT=20   # seconds allowed for bootstrap's best-effort clone refresh
 FM_BUSY_REGEX='esc (to )?interrupt|Working\.\.\.'   # busy-pane signatures, extend per harness
 ```
 

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -4,6 +4,7 @@
 #          Detect: prints one line per problem and exits 0. Silent = all good.
 #          Lines: "MISSING: <tool> (install: <command>)", "NEEDS_GH_AUTH",
 #                 "CREW_HARNESS_OVERRIDE: <name>", "FLEET_SYNC: <repo>: skipped: <reason>".
+#          The fleet refresh is bounded by FM_FLEET_SYNC_BOOTSTRAP_TIMEOUT, default 20s.
 #        fm-bootstrap.sh install <tool>...
 #          Install the named tools (only ones the captain approved).
 set -u

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -1,14 +1,50 @@
 #!/usr/bin/env bash
-# Bootstrap detection and installs.
+# Bootstrap detection, best-effort fleet refresh, and installs.
 # Usage: fm-bootstrap.sh
 #          Detect: prints one line per problem and exits 0. Silent = all good.
 #          Lines: "MISSING: <tool> (install: <command>)", "NEEDS_GH_AUTH",
-#                 "CREW_HARNESS_OVERRIDE: <name>".
+#                 "CREW_HARNESS_OVERRIDE: <name>", "FLEET_SYNC: <repo>: skipped: <reason>".
 #        fm-bootstrap.sh install <tool>...
 #          Install the named tools (only ones the captain approved).
 set -u
 
 FM_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+fleet_sync() {
+  [ -x "$FM_ROOT/bin/fm-fleet-sync.sh" ] || return 0
+  [ -d "$FM_ROOT/projects" ] || return 0
+
+  tmp=$(mktemp "${TMPDIR:-/tmp}/fm-fleet-sync.XXXXXX" 2>/dev/null) || return 0
+  done_file="$tmp.done"
+  (
+    "$FM_ROOT/bin/fm-fleet-sync.sh" >"$tmp" 2>/dev/null || true
+    : > "$done_file"
+  ) &
+  pid=$!
+
+  timeout=${FM_FLEET_SYNC_BOOTSTRAP_TIMEOUT:-20}
+  case "$timeout" in ''|*[!0-9]*) timeout=20 ;; esac
+  start=$SECONDS
+  while [ ! -e "$done_file" ]; do
+    if [ $((SECONDS - start)) -ge "$timeout" ]; then
+      kill "$pid" 2>/dev/null || true
+      wait "$pid" 2>/dev/null || true
+      echo "FLEET_SYNC: fleet: skipped: bootstrap refresh timed out"
+      rm -f "$tmp" "$done_file"
+      return 0
+    fi
+    sleep 1
+  done
+  wait "$pid" 2>/dev/null || true
+
+  while IFS= read -r line; do
+    case "$line" in
+      *': skipped: no origin remote') ;;
+      *': skipped:'*) echo "FLEET_SYNC: $line" ;;
+    esac
+  done < "$tmp"
+  rm -f "$tmp" "$done_file"
+}
 
 install_cmd() {
   case "$1" in
@@ -41,4 +77,5 @@ gh auth status >/dev/null 2>&1 || echo "NEEDS_GH_AUTH"
 crew=
 [ -f "$FM_ROOT/config/crew-harness" ] && crew=$(tr -d '[:space:]' < "$FM_ROOT/config/crew-harness" || true)
 [ -n "$crew" ] && [ "$crew" != "default" ] && echo "CREW_HARNESS_OVERRIDE: $crew"
+fleet_sync
 exit 0

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -15,27 +15,28 @@ fleet_sync() {
   [ -d "$FM_ROOT/projects" ] || return 0
 
   tmp=$(mktemp "${TMPDIR:-/tmp}/fm-fleet-sync.XXXXXX" 2>/dev/null) || return 0
-  done_file="$tmp.done"
-  (
-    "$FM_ROOT/bin/fm-fleet-sync.sh" >"$tmp" 2>/dev/null || true
-    : > "$done_file"
-  ) &
+  monitor_was_on=0
+  case $- in *m*) monitor_was_on=1 ;; esac
+  set -m 2>/dev/null || true
+  "$FM_ROOT/bin/fm-fleet-sync.sh" >"$tmp" 2>/dev/null &
   pid=$!
 
   timeout=${FM_FLEET_SYNC_BOOTSTRAP_TIMEOUT:-20}
   case "$timeout" in ''|*[!0-9]*) timeout=20 ;; esac
   start=$SECONDS
-  while [ ! -e "$done_file" ]; do
+  while jobs -r -p | grep -qx "$pid"; do
     if [ $((SECONDS - start)) -ge "$timeout" ]; then
-      kill "$pid" 2>/dev/null || true
+      kill -TERM "-$pid" 2>/dev/null || kill "$pid" 2>/dev/null || true
       wait "$pid" 2>/dev/null || true
+      [ "$monitor_was_on" -eq 1 ] || set +m 2>/dev/null || true
       echo "FLEET_SYNC: fleet: skipped: bootstrap refresh timed out"
-      rm -f "$tmp" "$done_file"
+      rm -f "$tmp"
       return 0
     fi
     sleep 1
   done
   wait "$pid" 2>/dev/null || true
+  [ "$monitor_was_on" -eq 1 ] || set +m 2>/dev/null || true
 
   while IFS= read -r line; do
     case "$line" in
@@ -43,7 +44,7 @@ fleet_sync() {
       *': skipped:'*) echo "FLEET_SYNC: $line" ;;
     esac
   done < "$tmp"
-  rm -f "$tmp" "$done_file"
+  rm -f "$tmp"
 }
 
 install_cmd() {

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -40,6 +40,7 @@ fleet_sync() {
 
   while IFS= read -r line; do
     case "$line" in
+      *': skipped: local-only project') ;;
       *': skipped: no origin remote') ;;
       *': skipped:'*) echo "FLEET_SYNC: $line" ;;
     esac

--- a/bin/fm-fleet-sync.sh
+++ b/bin/fm-fleet-sync.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # Refresh project clones by fast-forwarding their checked-out local default branch
 # to origin/<default> when it is safe to do so.
+# Skips local-only/no-origin projects, dirty clones, non-default checkouts,
+# diverged branches, and fetch/fast-forward failures without forcing or stashing.
 # Usage: fm-fleet-sync.sh [<project-dir>]
 set -eu
 

--- a/bin/fm-fleet-sync.sh
+++ b/bin/fm-fleet-sync.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Refresh project clones by fast-forwarding their checked-out local default branch
+# to origin/<default> when it is safe to do so.
+# Usage: fm-fleet-sync.sh [<project-dir>]
+set -eu
+
+FM_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+"$FM_ROOT/bin/fm-guard.sh" || true
+
+usage() {
+  echo "usage: fm-fleet-sync.sh [<project-dir>]" >&2
+}
+
+if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
+  usage
+  exit 0
+fi
+[ $# -le 1 ] || { usage; exit 1; }
+
+project_label() {
+  case "$PROJ" in
+    "$FM_ROOT"/projects/*) basename "$PROJ" ;;
+    *) printf '%s\n' "$PROJ" ;;
+  esac
+}
+
+default_branch() {
+  local ref branch
+  ref=$(git -C "$PROJ" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)
+  if [ -n "$ref" ]; then
+    echo "${ref#origin/}"
+    return 0
+  fi
+  for branch in main master; do
+    if git -C "$PROJ" show-ref --verify --quiet "refs/heads/$branch"; then
+      echo "$branch"
+      return 0
+    fi
+  done
+  return 1
+}
+
+first_line() {
+  printf '%s\n' "$1" | sed -n '1s/[[:space:]]\{1,\}/ /g;1p'
+}
+
+sync_project() {
+  PROJ=$1
+  label=$(project_label)
+
+  if [ ! -d "$PROJ" ]; then
+    echo "$label: skipped: not a directory"
+    return 0
+  fi
+  if ! git -C "$PROJ" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "$label: skipped: not a git repo"
+    return 0
+  fi
+  if ! git -C "$PROJ" remote get-url origin >/dev/null 2>&1; then
+    echo "$label: skipped: no origin remote"
+    return 0
+  fi
+
+  if ! fetch_output=$(git -C "$PROJ" fetch origin --quiet 2>&1); then
+    reason="fetch failed"
+    if [ -n "$fetch_output" ]; then
+      reason="$reason: $(first_line "$fetch_output")"
+    fi
+    echo "$label: skipped: $reason"
+    return 0
+  fi
+
+  DEFAULT=$(default_branch) || {
+    echo "$label: skipped: cannot determine default branch"
+    return 0
+  }
+  BASE="origin/$DEFAULT"
+  if ! git -C "$PROJ" rev-parse --verify --quiet "$BASE^{commit}" >/dev/null; then
+    echo "$label: skipped: $BASE does not exist"
+    return 0
+  fi
+
+  cur=$(git -C "$PROJ" symbolic-ref --short HEAD 2>/dev/null || echo "")
+  if [ "$cur" != "$DEFAULT" ]; then
+    [ -n "$cur" ] || cur="detached HEAD"
+    echo "$label: skipped: on $cur, expected $DEFAULT"
+    return 0
+  fi
+  if [ -n "$(git -C "$PROJ" status --porcelain 2>/dev/null | head -1)" ]; then
+    echo "$label: skipped: dirty working tree"
+    return 0
+  fi
+  if ! git -C "$PROJ" rev-parse --verify --quiet "$DEFAULT^{commit}" >/dev/null; then
+    echo "$label: skipped: local $DEFAULT does not exist"
+    return 0
+  fi
+
+  local_rev=$(git -C "$PROJ" rev-parse "$DEFAULT") || {
+    echo "$label: skipped: cannot read local $DEFAULT"
+    return 0
+  }
+  remote_rev=$(git -C "$PROJ" rev-parse "$BASE") || {
+    echo "$label: skipped: cannot read $BASE"
+    return 0
+  }
+  if [ "$local_rev" = "$remote_rev" ]; then
+    echo "$label: already current"
+    return 0
+  fi
+  if ! git -C "$PROJ" merge-base --is-ancestor "$DEFAULT" "$BASE"; then
+    echo "$label: skipped: local $DEFAULT has diverged from $BASE"
+    return 0
+  fi
+
+  before=$(git -C "$PROJ" rev-parse --short "$DEFAULT") || {
+    echo "$label: skipped: cannot read local $DEFAULT"
+    return 0
+  }
+  if ! merge_output=$(git -C "$PROJ" merge --ff-only "$BASE" 2>&1); then
+    reason="fast-forward failed"
+    if [ -n "$merge_output" ]; then
+      reason="$reason: $(first_line "$merge_output")"
+    fi
+    echo "$label: skipped: $reason"
+    return 0
+  fi
+  after=$(git -C "$PROJ" rev-parse --short "$DEFAULT") || {
+    echo "$label: skipped: fast-forward completed but cannot read local $DEFAULT"
+    return 0
+  }
+  echo "$label: synced $before..$after"
+  return 0
+}
+
+if [ $# -eq 1 ]; then
+  sync_project "$1"
+  exit 0
+fi
+
+PROJECTS="$FM_ROOT/projects"
+[ -d "$PROJECTS" ] || exit 0
+for proj in "$PROJECTS"/*; do
+  [ -e "$proj" ] || continue
+  [ -d "$proj" ] || continue
+  sync_project "$proj"
+done

--- a/bin/fm-fleet-sync.sh
+++ b/bin/fm-fleet-sync.sh
@@ -20,6 +20,7 @@ fi
 project_label() {
   case "$PROJ" in
     "$FM_ROOT"/projects/*) basename "$PROJ" ;;
+    projects/*) basename "$PROJ" ;;
     *) printf '%s\n' "$PROJ" ;;
   esac
 }
@@ -54,6 +55,12 @@ sync_project() {
   fi
   if ! git -C "$PROJ" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
     echo "$label: skipped: not a git repo"
+    return 0
+  fi
+  mode_line=$("$FM_ROOT/bin/fm-project-mode.sh" "$label" 2>/dev/null || echo "no-mistakes off")
+  mode=${mode_line%% *}
+  if [ "$mode" = "local-only" ]; then
+    echo "$label: skipped: local-only project"
     return 0
   fi
   if ! git -C "$PROJ" remote get-url origin >/dev/null 2>&1; then

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -98,4 +98,7 @@ fi
 
 tmux kill-window -t "$T" 2>/dev/null || true
 rm -f "$STATE/$ID.status" "$STATE/$ID.turn-ended" "$STATE/$ID.check.sh" "$STATE/$ID.meta" "$STATE/$ID.pi-ext.ts"
+if [ "$KIND" != scout ] && [ "$MODE" != local-only ]; then
+  "$FM_ROOT/bin/fm-fleet-sync.sh" "$PROJ" || true
+fi
 echo "teardown $ID complete (window $T, worktree $WT)"

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # Tear down a finished task: return the treehouse worktree, kill the tmux window,
-# clear volatile state. REFUSES if the worktree holds work not on any remote,
-# because treehouse return hard-resets the worktree and kills its processes.
+# clear volatile state, then refresh the project's clone for PR-based ship tasks.
+# REFUSES if the worktree holds work not on any remote, because treehouse return
+# hard-resets the worktree and kills its processes.
 # Scout tasks (kind=scout in meta) carve out of that check: their worktree is
 # declared scratch and the report at data/<task-id>/report.md is the work
 # product - teardown proceeds once the report exists, and refuses without it.


### PR DESCRIPTION
## Intent

Fix firstmate's pooled project clones drifting behind their remote defaults by adding a guarded fleet-sync helper that fetches origin and clean-fast-forwards each clone's checked-out default branch only when safe. The helper must skip local-only/no-origin projects, dirty clones, clones not on default, and diverged/non-fast-forward cases with concise one-line reasons, never force, stash, merge, or touch treehouse worktrees, and continue best-effort across all repos. Bootstrap should run the fleet refresh best-effort and stay quiet unless a repo could not sync, and successful PR-based teardown should refresh that project's clone after merge confirmation. Documentation in AGENTS.md must record the narrow write exception and bootstrap/teardown behavior, with CLAUDE.md tracking through the symlink; README should stay consistent with the toolbelt.

## What Changed

- Added `bin/fm-fleet-sync.sh` to fetch `origin` and clean-fast-forward checked-out default branches only when safe, skipping local-only, no-origin, dirty, non-default, and diverged clones with concise reasons.
- Wired best-effort fleet refresh into bootstrap and successful PR-based teardown, including timeout cleanup and suppression of expected local-only bootstrap noise.
- Updated `AGENTS.md` and `README.md` to document the narrow fleet-sync write exception and the new bootstrap/teardown refresh behavior.

## Risk Assessment

✅ Low: The change is narrowly scoped to guarded clone refresh behavior, with safety checks for local-only, dirty, non-default, and non-fast-forward cases and no material review findings.

## Testing

Exercised the user-facing shell workflow with real git repositories: the helper fast-forwarded only a clean default-branch clone, skipped dirty/non-default/diverged/local-only/no-origin cases safely, bootstrap suppressed expected local-only/no-origin noise while surfacing real skipped syncs, teardown refreshed the project clone after a simulated merge, and the worktree was clean afterward.

<details>
<summary>Evidence: Fleet sync and bootstrap CLI transcript</summary>

<code>Shows `sync-safe: synced 98b7d1b..73e2118`, unsafe clones skipped with concise reasons, and bootstrap emitting only dirty/diverged/non-default `FLEET_SYNC:` lines while suppressing local-only/no-origin skips.</code>

```text
Fleet sync CLI verification transcript
root=/Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KV3Z0WTQ2KF9QW4DWFN9GY9M
evidence=/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KV3Z0WTQ2KF9QW4DWFN9GY9M/fleet-sync-cli-transcript.txt

$ git init --bare /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KV3Z0WTQ2KF9QW4DWFN9GY9M/fleet-sync-lab/remote.git
Initialized empty Git repository in /private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KV3Z0WTQ2KF9QW4DWFN9GY9M/fleet-sync-lab/remote.git/

$ git -C /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KV3Z0WTQ2KF9QW4DWFN9GY9M/fleet-sync-lab/remote.git symbolic-ref HEAD refs/heads/main

$ git init -b main /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KV3Z0WTQ2KF9QW4DWFN9GY9M/fleet-sync-lab/seed
Initialized empty Git repository in /private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KV3Z0WTQ2KF9QW4DWFN9GY9M/fleet-sync-lab/seed/.git/

$ git -C /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KV3Z0WTQ2KF9QW4DWFN9GY9M/fleet-sync-lab/seed config user.email test@example.com

$ git -C /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KV3Z0WTQ2KF9QW4DWFN9GY9M/fleet-sync-lab/seed config user.name Test User

$ git -C /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KV3Z0WTQ2KF9QW4DWFN9GY9M/fleet-sync-lab/seed add app.txt

$ git -C /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KV3Z0WTQ2KF9QW4DWFN9GY9M/fleet-sync-lab/seed commit -m initial
[main (root-commit) 98b7d1b] initial
 1 file changed, 1 insertion(+)
 create mode 100644 app.txt

$ git -C /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KV3Z0WTQ2KF9QW4DWFN9GY9M/fleet-sync-lab/seed remote add origin /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KV3Z0WTQ2KF9QW4DWFN9GY9M/fleet-sync-lab/remote.git

$ git -C /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KV3Z0WTQ2KF9QW4DWFN9GY9M/fleet-sync-lab/seed push -u origin main
To /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KV3Z0WTQ2KF9QW4DWFN9GY9M/fleet-sync-lab/remote.git
 * [new branch]      main -> main
branch 'main' set up to track 'origin/main'.

$ git clone /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KV3Z0WTQ2KF9QW4DWFN9GY9M/fleet-sync-lab/remote.git /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KV3Z0WTQ2KF9QW4DWFN9GY9M/projects/sync-safe
Cloning into '/Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KV3Z0WTQ2KF9QW4DWFN9GY9M/projects/sync-safe'...
done.

$ git -C /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KV3Z0WTQ2KF9QW4DWFN9GY9M/projects/sync-safe config user.email test@example.com

$ git -C /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KV3Z0WTQ2KF9QW4DWFN9GY9M/projects/sync-safe config user.name Test User

$ git clone /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KV3Z0WTQ2KF9QW4DWFN9GY9M/fleet-sync-lab/remote.git /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KV3Z0WTQ2KF9QW4DWFN9GY9M/projects/dirty
Cloning into '/Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KV3Z0WTQ2KF9QW4DWFN9GY9M/projects/dirty'...
done.

$ git -C /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KV3Z0WTQ2KF9QW4DWFN9GY9M/projects/dirty config user.email test@example.com

$ git -C /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KV3Z0WTQ2KF9QW4DWFN9GY9M/projects/dirty config user.name Test User

$ git clone /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KV3Z0WTQ2KF9QW4DWFN9GY9M/fleet-sync-lab/remote.git /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KV3Z0WTQ2KF9QW4DWFN9GY9M/projects/feature
Cloning into '/Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KV3Z0WTQ2KF9QW4DWFN9GY9M/projects/feature'...
done.

$ git -C /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KV3Z0WTQ2KF9QW4DWFN9GY9M/projects/feature config user.email test@example.com

$ git -C /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KV3Z0WTQ2KF9QW4DWFN9GY9M/projects/feature config user.name Test User

$ git clone /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KV3Z0WTQ2KF9QW4DWFN9GY9M/fleet-sync-lab/remote.git /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KV3Z0WTQ2KF9QW4DWFN9GY9M/projects/diverged
Cloning into '/Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KV3Z0WTQ2KF9QW4DWFN9GY9M/projects/diverged'...
done.

$ git -C /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KV3Z0WTQ2KF9QW4DWFN9GY9M/projects/diverged config user.email test@example.com

$ git -C /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KV3Z0WTQ2KF9QW4DWFN9GY9M/projects/diverged config user.name Test User

$ git -C /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KV3Z0WTQ2KF9QW4DWFN9GY9M/projects/feature checkout -b feature
Switched to a new branch 'feature'

$ git -C /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KV3Z0WTQ2KF9QW4DWFN9GY9M/projects/diverged add app.txt

$ git -C /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KV3Z0WTQ2KF9QW4DWFN9GY9M/projects/diverged commit -m local-diverge
[main 6892bd9] local-diverge
 1 file changed, 1 insertion(+)

$ git init -b main /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KV3Z0WTQ2KF9QW4DWFN9GY9M/projects/noorigin
Initialized empty Git repository in /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KV3Z0WTQ2KF9QW4DWFN9GY9M/projects/noorigin/.git/

$ git -C /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KV3Z0WTQ2KF9QW4DWFN9GY9M/projects/noorigin config user.email test@example.com

$ git -C /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KV3Z0WTQ2KF9QW4DWFN9GY9M/projects/noorigin config user.name Test User

$ git -C /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KV3Z0WTQ2KF9QW4DWFN9GY9M/projects/noorigin add local.txt

$ git -C /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KV3Z0WTQ2KF9QW4DWFN9GY9M/projects/noorigin commit -m local-only
[main (root-commit) 6837759] local-only
 1 file changed, 1 insertion(+)
 create mode 100644 local.txt

$ git init -b main /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KV3Z0WTQ2KF9QW4DWFN9GY9M/projects/localonly
Initialized empty Git repository in /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KV3Z0WTQ2KF9QW4DWFN9GY9M/projects/localonly/.git/

$ git -C /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KV3Z0WTQ2KF9QW4DWFN9GY9M/projects/localonly config user.email test@example.com

$ git -C /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KV3Z0WTQ2KF9QW4DWFN9GY9M/projects/localonly config user.name Test User

$ git -C /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KV3Z0WTQ2KF9QW4DWFN9GY9M/projects/localonly add local.txt

$ git -C /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KV3Z0WTQ2KF9QW4DWFN9GY9M/projects/localonly commit -m registered-local-only
[main (root-commit) f19d16b] registered-local-only
 1 file changed, 1 insertion(+)
 create mode 100644 local.txt

Advancing origin/main to create drift in pooled clones.

$ git -C /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KV3Z0WTQ2KF9QW4DWFN9GY9M/fleet-sync-lab/seed add app.txt

$ git -C /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KV3Z0WTQ2KF9QW4DWFN9GY9M/fleet-sync-lab/seed commit -m remote-advance
[main 73e2118] remote-advance
 1 file changed, 1 insertion(+)

$ git -C /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KV3Z0WTQ2KF9QW4DWFN9GY9M/fleet-sync-lab/seed push origin main
To /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KV3Z0WTQ2KF9QW4DWFN9GY9M/fleet-sync-lab/remote.git
   98b7d1b..73e2118  main -> main

Remote main after advance: 73e2118
sync-safe before sync: 98b7d1b
dirty before sync: 98b7d1b
feature before sync: 98b7d1b
diverged before sync: 6892bd9

Fleet sync across all registered project clones:

$ /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KV3Z0WTQ2KF9QW4DWFN9GY9M/bin/fm-fleet-sync.sh
dirty: skipped: dirty working tree
diverged: skipped: local main has diverged from origin/main
feature: skipped: on feature, expected main
localonly: skipped: local-only project
noorigin: skipped: no origin remote
sync-safe: synced 98b7d1b..73e2118
sync-safe after sync: 73e2118
dirty after sync: 98b7d1b
feature after sync: 98b7d1b
diverged after sync: 6892bd9
sync-safe matches origin: yes
dirty unchanged: yes
feature branch unchanged: yes
diverged unchanged: yes

Bootstrap user-visible fleet-sync lines (expected local-only/no-origin skips suppressed):
FLEET_SYNC: dirty: skipped: dirty working tree
FLEET_SYNC: diverged: skipped: local main has diverged from origin/main
FLEET_SYNC: feature: skipped: on feature, expected main

Done.
```
</details>
<details>
<summary>Evidence: Teardown refresh CLI transcript</summary>

<code>Shows `teardown-sync: synced 468a96e..4b26696` and `teardown refreshed project to origin: yes` after a simulated PR merge.</code>

```text
Teardown post-merge fleet refresh transcript
root=/Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KV3Z0WTQ2KF9QW4DWFN9GY9M
evidence=/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KV3Z0WTQ2KF9QW4DWFN9GY9M/teardown-sync-cli-transcript.txt

$ git init --bare /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KV3Z0WTQ2KF9QW4DWFN9GY9M/teardown-sync-lab/remote.git
Initialized empty Git repository in /private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KV3Z0WTQ2KF9QW4DWFN9GY9M/teardown-sync-lab/remote.git/

$ git -C /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KV3Z0WTQ2KF9QW4DWFN9GY9M/teardown-sync-lab/remote.git symbolic-ref HEAD refs/heads/main

$ git init -b main /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KV3Z0WTQ2KF9QW4DWFN9GY9M/teardown-sync-lab/seed
Initialized empty Git repository in /private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KV3Z0WTQ2KF9QW4DWFN9GY9M/teardown-sync-lab/seed/.git/

$ git -C /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KV3Z0WTQ2KF9QW4DWFN9GY9M/teardown-sync-lab/seed config user.email test@example.com

$ git -C /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KV3Z0WTQ2KF9QW4DWFN9GY9M/teardown-sync-lab/seed config user.name Test User

$ git -C /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KV3Z0WTQ2KF9QW4DWFN9GY9M/teardown-sync-lab/seed add app.txt

$ git -C /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KV3Z0WTQ2KF9QW4DWFN9GY9M/teardown-sync-lab/seed commit -m initial
[main (root-commit) 468a96e] initial
 1 file changed, 1 insertion(+)
 create mode 100644 app.txt

$ git -C /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KV3Z0WTQ2KF9QW4DWFN9GY9M/teardown-sync-lab/seed remote add origin /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KV3Z0WTQ2KF9QW4DWFN9GY9M/teardown-sync-lab/remote.git

$ git -C /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KV3Z0WTQ2KF9QW4DWFN9GY9M/teardown-sync-lab/seed push -u origin main
To /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KV3Z0WTQ2KF9QW4DWFN9GY9M/teardown-sync-lab/remote.git
 * [new branch]      main -> main
branch 'main' set up to track 'origin/main'.

$ git clone /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KV3Z0WTQ2KF9QW4DWFN9GY9M/teardown-sync-lab/remote.git /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KV3Z0WTQ2KF9QW4DWFN9GY9M/projects/teardown-sync
Cloning into '/Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KV3Z0WTQ2KF9QW4DWFN9GY9M/projects/teardown-sync'...
done.

$ git clone /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KV3Z0WTQ2KF9QW4DWFN9GY9M/teardown-sync-lab/remote.git /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KV3Z0WTQ2KF9QW4DWFN9GY9M/teardown-sync-lab/task-worktree
Cloning into '/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KV3Z0WTQ2KF9QW4DWFN9GY9M/teardown-sync-lab/task-worktree'...
done.

$ git -C /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KV3Z0WTQ2KF9QW4DWFN9GY9M/teardown-sync-lab/seed add app.txt

$ git -C /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KV3Z0WTQ2KF9QW4DWFN9GY9M/teardown-sync-lab/seed commit -m merged-pr-advance
[main 4b26696] merged-pr-advance
 1 file changed, 1 insertion(+)

$ git -C /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KV3Z0WTQ2KF9QW4DWFN9GY9M/teardown-sync-lab/seed push origin main
To /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KV3Z0WTQ2KF9QW4DWFN9GY9M/teardown-sync-lab/remote.git
   468a96e..4b26696  main -> main
project before teardown refresh: 468a96e
origin after simulated merge: 4b26696

$ /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KV3Z0WTQ2KF9QW4DWFN9GY9M/bin/fm-teardown.sh teardown-sync
WARNING: tasks are in flight but no watcher has ever run (no liveness beacon).
Restart it NOW, before anything else: run bin/fm-watch.sh as a background task.
treehouse stub: 
tmux stub: 
teardown-sync: synced 468a96e..4b26696
teardown teardown-sync complete (window fm-teardown-sync, worktree /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KV3Z0WTQ2KF9QW4DWFN9GY9M/teardown-sync-lab/task-worktree)
project after teardown refresh: 4b26696
teardown refreshed project to origin: yes

Done.
```
</details>
- Outcome: 🔧 1 issue found → auto-fixed ✅ across 2 runs (7m10s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (2) ✅</summary>

- ⚠️ `bin/fm-fleet-sync.sh:59` - `fm-fleet-sync.sh` only skips projects without an `origin` remote and never checks `data/projects.md` for `local-only` mode. A project registered as `local-only` but still carrying an `origin` remote would be fetched and potentially fast-forwarded, violating the intended local-only/no-remote write boundary; skip mode=`local-only` before fetching or merging.

🔧 Fix: Skip local-only projects during fleet sync
1 warning still open:
- ⚠️ `bin/fm-bootstrap.sh:30` - The bootstrap timeout only kills the wrapper subshell, not the `fm-fleet-sync.sh` process it launched, so a slow fetch/sync can continue fast-forwarding project clones after bootstrap has reported `FLEET_SYNC: fleet: skipped: bootstrap refresh timed out` and deleted its temp files. Run the sync process in a killable process group or avoid claiming the refresh was stopped until the actual sync process has exited.

🔧 Fix: Fix bootstrap sync timeout cleanup
✅ Re-checked - no issues remain.

</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `bin/fm-bootstrap.sh:43` - Bootstrap reports a registered local-only project as `FLEET_SYNC: ... skipped: local-only project`, even though local-only projects are expected to have no remote and the intended behavior says bootstrap should stay quiet for expected skips unless a repo could not sync.
- <code>`bin/fm-fleet-sync.sh &lt;fixture-clone&gt;` against throwaway Git repos covering clean fast-forward, already-current, non-default branch, dirty working tree, diverged local branch, and no-origin repository</code>
- <code>`FM_FLEET_SYNC_BOOTSTRAP_TIMEOUT=10 bin/fm-bootstrap.sh` with a temporary registered `[local-only]` project under `projects/` and `data/projects.md`</code>
- <code>`git status --short` after cleanup to verify no working-tree artifacts remained</code>

🔧 Fix: Suppress local-only bootstrap sync noise
✅ Re-checked - no issues remain.
- <code>Inspected the target diff from `363fa89f80a5e48147b15764e0ebcf1fe9c368ce...d7b8cd37c3b585fd9b881b8edc17da9954eb187c` to identify the intended behavior and changed scripts/docs.</code>
- <code>Ran an end-to-end CLI harness that created real temporary git remotes/clones, drifted `origin/main`, and executed `bin/fm-fleet-sync.sh` across safe, dirty, non-default-branch, diverged, local-only, and no-origin project clones.</code>
- <code>Ran `FM_FLEET_SYNC_BOOTSTRAP_TIMEOUT=20 bin/fm-bootstrap.sh` with temporary registered projects and filtered its user-visible `FLEET_SYNC:` output to verify expected local-only/no-origin skips stay quiet while unsafe skipped syncs are surfaced.</code>
- <code>Ran `bin/fm-teardown.sh teardown-sync` with temporary git repos plus stubbed `treehouse` and `tmux` commands to verify a completed PR-style teardown invokes `fm-fleet-sync.sh` and fast-forwards the project clone after the simulated merge.</code>
- <code>Ran `git status --short` after cleanup to verify transient worktree test projects/state were removed.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
