### PR TITLE
docs: document local captain preferences

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,7 @@ bin/                 helper scripts, committed, including fm-fleet-sync.sh for c
 config/crew-harness  crewmate harness override; LOCAL, gitignored; absent or "default" = same as firstmate
 data/                personal fleet records; LOCAL, gitignored as a whole
   backlog.md         task queue, dependencies, history
+  captain.md         captain's curated personal preferences and working style - approval posture, communication style, release habits; LOCAL, gitignored; compact rewrite-and-prune counterpart to shared AGENTS.md; canonical harness-portable home, even if harness memory mirrors it as a recall cache
   projects.md        fleet registry: one line per project under projects/ with a short description and its delivery mode - "- <name> [<mode>] - <desc>", optional "+yolo" (e.g. "[direct-PR +yolo]"); no "[...]" = no-mistakes. fm-project-mode.sh parses it (section 6)
   <id>/brief.md      per-task crewmate brief
   <id>/report.md     scout task deliverable, written by the crewmate; survives teardown
@@ -93,6 +94,9 @@ Bootstrap's fleet refresh is bounded by `FM_FLEET_SYNC_BOOTSTRAP_TIMEOUT` second
 
 Then read `data/projects.md`, the fleet registry, to load what each project is.
 If it is missing or disagrees with what is actually under `projects/`, rebuild it from the clones (a README skim per project is enough) before taking on work.
+Then read `data/captain.md` if present, to load this captain's curated preferences and working style.
+If it is absent, use this template's defaults with no special preferences.
+Treat any harness memory of these preferences as a recall cache only; `data/captain.md` is the canonical, harness-portable home.
 
 Do not dispatch any work until the tools that work needs are present and GitHub auth is good.
 Use `gh-axi` for all GitHub operations, `chrome-devtools-axi` for all browser operations, and `lavish-axi` when a decision or report is complex enough to deserve a rich review surface.

--- a/README.md
+++ b/README.md
@@ -146,7 +146,8 @@ The first mate drives these; you rarely need to, but they work by hand too.
 
 ## Configuration
 
-The orchestrator's behavior lives in `AGENTS.md` - edit it like any prompt when the fleet is empty, or dispatch shared-repo edits to a crewmate while tasks are in flight.
+The shared orchestrator behavior lives in `AGENTS.md` - edit it like any prompt when the fleet is empty, or dispatch shared-repo edits to a crewmate while tasks are in flight.
+Personal preferences for one captain's fleet live locally in `data/captain.md`; it is gitignored and read after `data/projects.md` during bootstrap.
 Harness support is a table in section 4: claude, codex, opencode, and pi are all empirically verified; new harnesses get verified through a supervised trial task before joining the table.
 
 Watcher tuning via environment variables (defaults shown):


### PR DESCRIPTION
## Intent

Give firstmate a dedicated, intentional local home for this captain's personal preferences by documenting data/captain.md in the shared AGENTS.md template and reading it during bootstrap. The tracked change should be AGENTS.md only: Section 2 must describe data/captain.md as the local, gitignored, compact rewrite-and-prune counterpart to AGENTS.md for curated preferences such as approval posture, communication style, and release habits; Section 3 must read data/captain.md if present after bootstrap checks and data/projects.md, treat absence as template defaults, and clarify that harness memory is only a recall cache while data/captain.md is canonical. I audited AGENTS.md conservatively for personalization and found no material captain-specific behavior to relocate beyond adding the generic pointer, so the existing system mechanisms and doctrine remain unchanged.

## What Changed
- Documented `data/captain.md` as the local, gitignored home for a captain's curated preferences and working style.
- Updated bootstrap guidance to read `data/captain.md` after `data/projects.md`, using template defaults when it is absent and treating harness memory as a recall cache.
- Clarified README configuration docs to distinguish shared orchestrator behavior in `AGENTS.md` from per-captain local preferences.

## Risk Assessment

✅ Low: The change is limited to documenting a local preferences file and adding bootstrap reading guidance in AGENTS.md, with no executable code or behavioral complexity introduced.

## Testing

I inspected the target diff, verified the tracked change is AGENTS.md only, asserted the new data/captain.md layout and bootstrap instructions including read order and canonical-source wording, confirmed personal fleet paths remain untracked, and captured an AGENTS.md excerpt as reviewer-visible evidence; all checks passed.

<details>
<summary>Evidence: AGENTS.md captain preferences excerpt</summary>

`Excerpt from AGENTS.md lines 47-104 showing data/captain.md in Section 2 and the bootstrap read instructions in Section 3.`

```text
 47: ## 2. Layout and state
 48: 
 49: `` `
 50: AGENTS.md            this file (CLAUDE.md is a symlink to it)
 51: CONTRIBUTING.md      contributor workflow and repo conventions
 52: README.md            public overview and development notes
 53: .github/workflows/   shared CI and PR enforcement, committed
 54: .agents/skills/      shared skills, committed
 55: .claude/skills       symlink to .agents/skills for claude compatibility
 56: bin/                 helper scripts, committed, including fm-fleet-sync.sh for clean default-branch refreshes; read each script's header before first use
 57: config/crew-harness  crewmate harness override; LOCAL, gitignored; absent or "default" = same as firstmate
 58: data/                personal fleet records; LOCAL, gitignored as a whole
 59:   backlog.md         task queue, dependencies, history
 60:   captain.md         captain's curated personal preferences and working style - approval posture, communication style, release habits; LOCAL, gitignored; compact rewrite-and-prune counterpart to shared AGENTS.md; canonical harness-portable home, even if harness memory mirrors it as a recall cache
 61:   projects.md        fleet registry: one line per project under projects/ with a short description and its delivery mode - "- <name> [<mode>] - <desc>", optional "+yolo" (e.g. "[direct-PR +yolo]"); no "[...]" = no-mistakes. fm-project-mode.sh parses it (section 6)
 62:   <id>/brief.md      per-task crewmate brief
 63:   <id>/report.md     scout task deliverable, written by the crewmate; survives teardown
 64: projects/            cloned repos; gitignored; READ-ONLY for you
 65: state/               volatile runtime signals; gitignored
 66:   <id>.status        appended by crewmates: "<state>: <note>" lines
 67:   <id>.turn-ended    touched by turn-end hooks
 68:   <id>.meta          written by fm-spawn: window=, worktree=, project=, harness=, kind=, mode=, yolo= (fm-pr-check appends pr=)
 69:   <id>.check.sh      optional slow poll you write per task (e.g. merged-PR check)
 70:   .hash-* .count-* .stale-* .seen-* .last-* .heartbeat-streak   watcher internals; never touch
 71:   .last-watcher-beat watcher liveness beacon, touched every poll; fm-guard.sh reads it
 72: .no-mistakes/        local validation state and evidence; gitignored
 73: `` `
 74: 
 75: Task ids are short kebab slugs with a random suffix, e.g. `fix-login-k3`.
 76: The tmux window for a task is always named `fm-<id>`.
 77: 
 78: ## 3. Bootstrap (run at every session start)
 79: 
 80: Bootstrap is detect, then consent, then install.
 81: Never install anything the captain has not approved in this session.
 82: 
 83: Run `bin/fm-bootstrap.sh`.
 84: Bootstrap also refreshes the fleet via `bin/fm-fleet-sync.sh`: it fetches each remote-backed clone and clean-fast-forwards its local default branch when safe, best-effort and non-fatal.
 85: Silence means all good: say nothing and move on.
 86: Otherwise it prints one line per problem; handle each:
 87: 
 88: - `MISSING: <tool> (install: <command>)` - list the missing tools to the captain with a one-line purpose each plus the printed install commands, wait for consent (one approval may cover the list), then run `bin/fm-bootstrap.sh install <approved tools...>`.
 89: - `NEEDS_GH_AUTH` - ask the captain to run `! gh auth login` (interactive; you cannot run it for them).
 90: - `CREW_HARNESS_OVERRIDE: <name>` - record and use the override silently; surface a harness fact only if it actually blocks work or the captain asks.
 91: - `FLEET_SYNC: <repo>: skipped: <reason>` - bootstrap continued; investigate only if the dirty, diverged, or offline clone blocks work.
 92: 
 93: Bootstrap's fleet refresh is bounded by `FM_FLEET_SYNC_BOOTSTRAP_TIMEOUT` seconds, default 20; a timeout is reported as a `FLEET_SYNC` skip and does not block startup.
 94: 
 95: Then read `data/projects.md`, the fleet registry, to load what each project is.
 96: If it is missing or disagrees with what is actually under `projects/`, rebuild it from the clones (a README skim per project is enough) before taking on work.
 97: Then read `data/captain.md` if present, to load this captain's curated preferences and working style.
 98: If it is absent, use this template's defaults with no special preferences.
 99: Treat any harness memory of these preferences as a recall cache only; `data/captain.md` is the canonical, harness-portable home.
100: 
101: Do not dispatch any work until the tools that work needs are present and GitHub auth is good.
102: Use `gh-axi` for all GitHub operations, `chrome-devtools-axi` for all browser operations, and `lavish-axi` when a decision or report is complex enough to deserve a rich review surface.
103: Do not memorize their flags; their session hooks and `--help` are the source of truth.
104: If the captain names a different crewmate harness at bootstrap or later, write it to `config/crew-harness` (local, gitignored); that is the whole switch.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --stat 539f3a3131c0e07cfe1cd940b23c9cf5c1c4e2ab..29007ba0409264d1dbc7c7a5acccddcfe53120ea`
- `git diff --name-only 539f3a3131c0e07cfe1cd940b23c9cf5c1c4e2ab..29007ba0409264d1dbc7c7a5acccddcfe53120ea`
- <code>`ruby -e &#39;changed = `git diff --name-only 539f3a3131c0e07cfe1cd940b23c9cf5c1c4e2ab..29007ba0409264d1dbc7c7a5acccddcfe53120ea`.lines.map(&amp;:chomp); abort(&#34;unexpected changed files: #{changed.inspect}&#34;) unless changed == [&#34;AGENTS.md&#34;]; puts &#34;tracked change scope ok: AGENTS.md only&#34;&#39;`</code>
- <code>`ruby -e &#39;tracked = `git ls-files -- data state config projects .no-mistakes`; abort(&#34;personal fleet paths are tracked:\n#{tracked}&#34;) unless tracked.empty?; puts &#34;personal fleet paths remain untracked&#34;&#39;`</code>
- <code>`ruby -e &#39;text = File.read(&#34;AGENTS.md&#34;); checks = { ... }; checks.each { |name, needle| abort(&#34;missing #{name}&#34;) unless text.include?(needle) }; abort(&#34;data/captain.md read must follow data/projects.md&#34;) unless text.index(&#34;Then read `data/projects.md`, the fleet registry&#34;) &lt; text.index(&#34;Then read `data/captain.md` if present&#34;); puts &#34;AGENTS.md documents captain preferences home and bootstrap read order&#34;&#39;`</code>
- `ruby -e 'lines = File.readlines("AGENTS.md"); File.write("/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KV449Q3NDH57CJ5SJJ4CGJEW/captain-preferences-agents-excerpt.txt", lines.each_with_index.select { |_, i| (47..104).cover?(i + 1) }.map { |line, i| "%3d: %s" % [i + 1, line] }.join)'`
- `git status --short`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
