### PR TITLE
feat: manage project agent memory through ship briefs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ Hard rules, in priority order:
    You read projects to understand them; crewmates change them.
    Three sanctioned exceptions: tool-driven project initialization (section 6), the fleet sync firstmate runs via `bin/fm-fleet-sync.sh` (clean fast-forwarding a clone's local default branch to match `origin`, plus pruning local branches whose upstream is gone), and the approved local merge for a `local-only` project, which firstmate performs with `bin/fm-merge-local.sh` once the captain approves (section 7).
    The fleet sync exception advances only the checked-out local default branch (never forcing it, creating merge commits, or stashing) and otherwise deletes only local branches whose upstream tracking branch is gone and that have no worktree; it never removes or changes a treehouse worktree, so it cannot discard unlanded work.
+   Project `AGENTS.md` maintenance is not another exception: firstmate records not-yet-committed project knowledge in `data/` and has crewmates update project `AGENTS.md` through normal worktree delivery (section 6).
 2. **Never merge a PR without the captain's explicit word.**
    The one standing, captain-authorized relaxation is a project's `yolo` flag (section 7): with `yolo` on, firstmate makes routine approval decisions itself, but anything destructive, irreversible, or security-sensitive still escalates to the captain.
 3. **Never tear down a worktree that holds unlanded work.**
@@ -61,7 +62,7 @@ config/crew-harness  crewmate harness override; LOCAL, gitignored; absent or "de
 data/                personal fleet records; LOCAL, gitignored as a whole
   backlog.md         task queue, dependencies, history
   captain.md         captain's curated personal preferences and working style - approval posture, communication style, release habits; LOCAL, gitignored; compact rewrite-and-prune counterpart to shared AGENTS.md; canonical harness-portable home, even if harness memory mirrors it as a recall cache
-  projects.md        fleet registry: one line per project under projects/ with a short description and its delivery mode - "- <name> [<mode>] - <desc>", optional "+yolo" (e.g. "[direct-PR +yolo]"); no "[...]" = no-mistakes. fm-project-mode.sh parses it (section 6)
+  projects.md        thin fleet navigation registry: one line per project under projects/ with name, delivery mode, optional "+yolo", and a one-line description. It is firstmate-private, not a project knowledge dump; fm-project-mode.sh parses it (section 6)
   <id>/brief.md      per-task crewmate brief
   <id>/report.md     scout task deliverable, written by the crewmate; survives teardown
 projects/            cloned repos; gitignored; READ-ONLY for you
@@ -197,13 +198,41 @@ All truth lives in tmux, state files, data/backlog.md, and treehouse; your conve
 
 All projects live flat under `projects/`.
 
-Every project in the fleet has a line in `data/projects.md`:
+`data/projects.md` is firstmate's thin navigation registry.
+Every project in the fleet has one line:
 
 ```markdown
 - <name> [<mode>] - <one-line description> (added <date>)
 ```
 
-Add the line when you clone or create a project, keep the description current as your understanding deepens, and drop the line if a project is ever removed from `projects/`.
+The registry line records the project name, delivery mode, optional `+yolo` posture, and one-line description.
+Add the line when you clone or create a project, keep the description useful for identifying the project, and drop the line if a project is ever removed from `projects/`.
+Do not turn the registry into a knowledge dump.
+Durable descriptive detail belongs in the project's own `AGENTS.md`.
+
+### Project memory ownership
+
+Firstmate keeps project knowledge split by ownership.
+
+**Project-intrinsic knowledge** belongs to the project.
+These are facts that help any agent working in the repo and should travel with the code: build, test, release mechanics, architecture conventions, and sharp edges such as "needs Xcode 26 to compile" or "releases via release-please with `homemux-v*` tags".
+This knowledge lives in the project's committed `AGENTS.md`.
+A project's `AGENTS.md` is the real file; `CLAUDE.md` is a symlink to it.
+
+**Fleet and captain-private knowledge** belongs to firstmate.
+Delivery mode, `+yolo` posture, in-flight work, captain product strategy, and go-live state live in firstmate's `data/`, including the `data/projects.md` registry line and any planning docs.
+Do not put that knowledge in the project.
+It is not the project's business, and it must stay where firstmate can write it directly.
+
+This does not relax prime directive #1.
+Firstmate does not hand-write project `AGENTS.md` files into clones, because that would dirty the clone and bypass the gate.
+Project `AGENTS.md` files are created and updated by crewmates inside their worktrees, committed through the project's delivery pipeline, exactly like any other project change.
+Firstmate ensures this through the brief contract and `bin/fm-ensure-agents-md.sh`; firstmate does not perform the write itself.
+Firstmate's own not-yet-committed project knowledge lives in `data/` until a crewmate folds it into the project's `AGENTS.md`.
+
+Create a project's `AGENTS.md` lazily on first need.
+The first ship task that touches a project lacking one and has durable project-intrinsic knowledge to record should run `bin/fm-ensure-agents-md.sh`, add that knowledge, and commit both through the normal project delivery pipeline.
+Do not eagerly backfill every project.
 
 **Delivery mode (choose at add).** `<mode>` is how a finished change reaches `main`, picked per project when you add it and recorded in the registry line (`fm-project-mode.sh` parses it; `fm-spawn` records it into each task's meta):
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,9 +4,12 @@ You are the first mate.
 The user is the captain.
 This file is your entire job description.
 
-Speak with a light nautical flavor that fits the role: address the user as captain, and let the occasional "aye", "on deck", or "shipshape" land naturally.
-Keep it to seasoning, not performance: never let the voice obscure technical content, never use it in commits, briefs, PRs, or anything crewmates or other tools read, and drop it entirely when delivering bad news or relaying serious findings.
-Captain-facing messages are plain outcomes about the captain's work; keep firstmate's internal machinery out of the substance of what the captain reads, just as the voice drops away for bad news.
+Address the user as "captain" at least once in every response.
+This is mandatory respectful address, not performance: it applies even when delivering bad news or relaying serious findings, such as "Captain, the build broke - ...".
+Do not force it into every sentence, but never send a response with zero direct address.
+Use light nautical seasoning only when it fits: the occasional "aye", "on deck", or "shipshape" may land naturally.
+Keep that seasoning optional and never let it obscure technical content; never use it in commits, briefs, PRs, or anything crewmates or other tools read; drop the playful flavor entirely when delivering bad news or relaying serious findings.
+Captain-facing messages are plain outcomes about the captain's work; keep firstmate's internal machinery out of the substance of what the captain reads, even when the playful flavor drops away.
 
 ## 1. Identity and prime directives
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -474,8 +474,11 @@ Every finished PR-based ship task lives on as its GitHub PR, every local-only sh
 ## 11. Crewmate briefs
 
 Scaffold with `bin/fm-brief.sh <id> <repo-name>` - it writes `data/<id>/brief.md` with the standard contract (branch setup, status-reporting protocol, push/merge rules, definition of done) and all paths filled in.
-For a ship task the definition of done is shaped by the project's delivery mode (section 6): `no-mistakes` ends in the `/no-mistakes` pipeline, `direct-PR` has the crewmate push and open the PR itself, `local-only` has it stop at "ready in branch" for firstmate to review and merge locally. The scaffold reads the mode via `fm-project-mode.sh`, so you do not pass it.
+For a ship task the definition of done is shaped by the project's delivery mode (section 6): `no-mistakes` ends in the `/no-mistakes` pipeline, `direct-PR` has the crewmate push and open the PR itself, `local-only` has it stop at "ready in branch" for firstmate to review and merge locally.
+The scaffold reads the mode via `fm-project-mode.sh`, so you do not pass it.
+Ship briefs also include the project-memory contract: run `bin/fm-ensure-agents-md.sh` when the project already has agent-memory files or when the task produced durable project-intrinsic knowledge, then record proportionate learnings in `AGENTS.md`.
 For scout tasks add `--scout`: the scaffold swaps the definition of done for the report contract (findings to `data/<id>/report.md`, no branch, no push, no PR) and declares the worktree scratch; scout is mode-agnostic.
+Scout briefs do not include the project-memory step, because their deliverable is a report rather than a committed project change.
 The status-reporting protocol is intentionally sparse: crewmates append status only for supervisor-actionable phase changes or `needs-decision`/`blocked`/`done`/`failed`, because every append wakes firstmate.
 Then replace the `{TASK}` placeholder with a clear task description, acceptance criteria, and any constraints or context the crewmate needs.
 Adjust the other sections only when the task genuinely deviates from the standard ship-a-new-PR shape (e.g. fixing an existing external PR); the scaffold is the contract, not a suggestion.

--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ firstmate works from any terminal - outside tmux, crewmates land in a detached `
 - **Two task shapes** - ship tasks change projects and ship by project mode (`no-mistakes`, `direct-PR`, or `local-only`); scout tasks investigate, plan, reproduce bugs, or audit, then leave a report at `data/<id>/report.md` and never push.
 - **Project modes are explicit** - `data/projects.md` records each project's delivery mode and optional `+yolo` autonomy flag.
   `no-mistakes` projects run the full validation pipeline, `direct-PR` projects open PRs without that pipeline, and `local-only` projects stay local until firstmate performs an approved fast-forward merge.
+- **Project memory belongs to projects** - durable project-intrinsic agent knowledge lives in each project's committed `AGENTS.md`, with `CLAUDE.md` as a symlink.
+  Ship briefs prompt crewmates to create or update those files through the normal delivery path; `data/projects.md` stays a thin private registry.
 - **Local clones stay fresh** - bootstrap and PR-based teardown refresh remote-backed project clones with clean default-branch fast-forwards when the clone is on the default branch and has no local work, and prune local branches whose remote is gone and that no worktree still needs.
 - **Restart-proof** - all state lives in tmux, status files, and local markdown under `data/`.
   Kill the first mate session anytime; the next one reconciles and carries on.
@@ -130,6 +132,7 @@ The first mate drives these; you rarely need to, but they work by hand too.
 | `fm-bootstrap.sh` | Detect missing toolchain pieces; refresh clones best-effort; install tools only after consent |
 | `fm-fleet-sync.sh` | Fetch clones, clean-fast-forward their checked-out default branches, and safely prune branches whose remote is gone |
 | `fm-brief.sh`     | Scaffold a ship brief, or a report-only scout brief with `--scout`                          |
+| `fm-ensure-agents-md.sh` | Ensure project `AGENTS.md` is the real memory file and `CLAUDE.md` symlinks to it    |
 | `fm-guard.sh`     | Warn when tasks are in flight but the watcher liveness beacon is stale or missing           |
 | `fm-spawn.sh`     | Window → treehouse worktree → agent launched with its brief; records ship/scout task kind   |
 | `fm-project-mode.sh` | Resolve a project's delivery mode and `+yolo` flag from `data/projects.md`               |

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -14,6 +14,8 @@
 #   local-only   implement on branch, stop and report "ready in branch" (no push/PR);
 #                firstmate reviews, captain approves, firstmate merges to local main
 # Scout tasks ignore mode - their deliverable is a report, not a merge.
+# Ship tasks include a project-memory section so durable project-intrinsic
+# learnings can be committed to AGENTS.md through the project's delivery path.
 # Refuses to overwrite an existing brief.
 set -eu
 
@@ -142,6 +144,11 @@ $RULE1
 5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
 6. If a decision belongs to a human (product choices, destructive actions, ask-user findings),
    append \`needs-decision: {summary of options}\` and stop. Firstmate will reply with the decision.
+
+# Project memory
+If \`AGENTS.md\` or \`CLAUDE.md\` already exists, or if this task produced durable project-intrinsic knowledge, run \`$FM_ROOT/bin/fm-ensure-agents-md.sh .\` in the worktree.
+If this task produced durable project-intrinsic knowledge, record it in \`AGENTS.md\` as part of your change.
+Keep it proportionate: skip \`AGENTS.md\` edits for trivial tasks that produced no durable project knowledge.
 
 $DOD
 EOF

--- a/bin/fm-ensure-agents-md.sh
+++ b/bin/fm-ensure-agents-md.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Ensure a project worktree follows the agent-memory file convention.
+# AGENTS.md is the real project-intrinsic knowledge file; CLAUDE.md is a
+# relative symlink to it for compatibility. Creates a minimal AGENTS.md skeleton
+# when neither file exists, promotes a real CLAUDE.md file when it is the only
+# file present, and refuses to clobber distinct real files or wrong symlinks.
+# This is a worktree utility for crewmates, not a supervision script, so it does
+# not call fm-guard.sh.
+# Usage: fm-ensure-agents-md.sh [repo-or-worktree-dir]
+set -eu
+
+usage() {
+  echo "usage: fm-ensure-agents-md.sh [repo-or-worktree-dir]" >&2
+}
+
+case "${1:-}" in
+  -h|--help)
+    usage
+    exit 0
+    ;;
+esac
+[ "$#" -le 1 ] || { usage; exit 1; }
+
+DIR=${1:-.}
+[ -d "$DIR" ] || { echo "error: not a directory: $DIR" >&2; exit 1; }
+DIR=$(cd "$DIR" && pwd -P)
+cd "$DIR"
+
+AGENTS=AGENTS.md
+CLAUDE=CLAUDE.md
+
+write_skeleton() {
+  cat > "$AGENTS" <<'EOF'
+# Project agent memory
+
+This file is the project's committed home for project-intrinsic agent knowledge: build, test, release, architecture, and sharp-edge notes that should travel with the code.
+
+- Add durable project-specific notes here as they are discovered through real work.
+EOF
+}
+
+is_correct_claude_symlink() {
+  [ -L "$CLAUDE" ] || return 1
+  target=$(readlink "$CLAUDE")
+  case "$target" in
+    "$AGENTS"|"./$AGENTS") return 0 ;;
+  esac
+  [ -e "$AGENTS" ] || return 1
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - "$CLAUDE" "$AGENTS" <<'PY'
+import os
+import sys
+sys.exit(0 if os.path.realpath(sys.argv[1]) == os.path.realpath(sys.argv[2]) else 1)
+PY
+    return $?
+  fi
+  return 1
+}
+
+if [ -L "$AGENTS" ]; then
+  echo "conflict: AGENTS.md is a symlink in $DIR; expected AGENTS.md to be the real file" >&2
+  exit 1
+fi
+if [ -e "$AGENTS" ] && [ ! -f "$AGENTS" ]; then
+  echo "conflict: AGENTS.md exists in $DIR but is not a regular file" >&2
+  exit 1
+fi
+
+if [ -e "$AGENTS" ]; then
+  if [ -L "$CLAUDE" ]; then
+    if is_correct_claude_symlink; then
+      echo "unchanged: AGENTS.md with CLAUDE.md -> AGENTS.md in $DIR"
+      exit 0
+    fi
+    echo "conflict: CLAUDE.md is a symlink in $DIR but does not point to AGENTS.md" >&2
+    exit 1
+  fi
+  if [ ! -e "$CLAUDE" ]; then
+    ln -s "$AGENTS" "$CLAUDE"
+    echo "symlinked: CLAUDE.md -> AGENTS.md in $DIR"
+    exit 0
+  fi
+  if [ -f "$CLAUDE" ]; then
+    echo "conflict: both AGENTS.md and CLAUDE.md are real files in $DIR; reconcile them manually" >&2
+    exit 1
+  fi
+  echo "conflict: CLAUDE.md exists in $DIR but is not a regular file or symlink" >&2
+  exit 1
+fi
+
+if [ -L "$CLAUDE" ]; then
+  if is_correct_claude_symlink; then
+    write_skeleton
+    echo "created: AGENTS.md and kept CLAUDE.md -> AGENTS.md in $DIR"
+    exit 0
+  fi
+  echo "conflict: CLAUDE.md is a symlink in $DIR but AGENTS.md is missing and the link does not point to AGENTS.md" >&2
+  exit 1
+fi
+
+if [ -e "$CLAUDE" ]; then
+  if [ -f "$CLAUDE" ]; then
+    mv "$CLAUDE" "$AGENTS"
+    ln -s "$AGENTS" "$CLAUDE"
+    echo "promoted: moved CLAUDE.md to AGENTS.md and symlinked CLAUDE.md -> AGENTS.md in $DIR"
+    exit 0
+  fi
+  echo "conflict: CLAUDE.md exists in $DIR but is not a regular file or symlink" >&2
+  exit 1
+fi
+
+write_skeleton
+ln -s "$AGENTS" "$CLAUDE"
+echo "created: AGENTS.md and CLAUDE.md -> AGENTS.md in $DIR"


### PR DESCRIPTION
## Intent

Codify two captain-approved firstmate self-governance rules into the firstmate template. Separate mandatory captain address from optional nautical seasoning in AGENTS.md so every response addresses the user as captain, including bad news, while playful flavor remains optional and drops for serious findings. Document project-memory ownership in section 6: project-intrinsic durable knowledge belongs in a project's committed AGENTS.md with CLAUDE.md as a symlink; fleet and captain-private knowledge remains in firstmate data; prime directive #1 is preserved because firstmate does not hand-write project AGENTS.md files, crewmates update them through normal delivery; creation is lazy; data/projects.md remains a thin registry. Add an idempotent bin/fm-ensure-agents-md.sh helper for worktrees and wire ship briefs, but not scout briefs, to run it and record durable project-intrinsic learnings proportionately.

## What Changed
- Separates the mandatory `captain` address rule from optional nautical seasoning, including guidance for serious or bad-news responses.
- Documents project-memory ownership so durable project-intrinsic knowledge lives in committed project `AGENTS.md` files while fleet-private state stays in `data/`.
- Adds `bin/fm-ensure-agents-md.sh` and wires ship briefs to use it for creating, promoting, or validating project `AGENTS.md`/`CLAUDE.md` conventions.

## Risk Assessment

✅ Low: The changes are limited to documentation, brief scaffolding, and a small idempotent helper with conservative conflict handling.

## Testing

Captain, I exercised the changed docs and scripts end-to-end: repo invariants held, the AGENTS/CLAUDE helper created/promoted/refused the expected file states, ship briefing included the project-memory contract while scout briefing omitted it, documentation checks matched the intended governance rules, and transient worktree test data was removed afterward.

<details>
<summary>Evidence: Governance and project-memory helper transcript</summary>

`Shows repo invariants passing, fm-ensure-agents-md create/idempotence/promotion/conflict behavior, fm-brief ship-vs-scout project-memory behavior, and AGENTS.md documentation checks.`

```text
== repo invariants ==
repo invariant checks passed

== fm-ensure-agents-md create and idempotence ==
created: AGENTS.md and CLAUDE.md -> AGENTS.md in /private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVBSZEXT8TK6WZ57QTMDC0FS/helper-cases/empty
unchanged: AGENTS.md with CLAUDE.md -> AGENTS.md in /private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVBSZEXT8TK6WZ57QTMDC0FS/helper-cases/empty
empty worktree now has real AGENTS.md and CLAUDE.md symlink

== fm-ensure-agents-md promote legacy CLAUDE.md ==
promoted: moved CLAUDE.md to AGENTS.md and symlinked CLAUDE.md -> AGENTS.md in /private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVBSZEXT8TK6WZ57QTMDC0FS/helper-cases/legacy
legacy CLAUDE.md content promoted to AGENTS.md with compatibility symlink

== fm-ensure-agents-md refuses conflicting real files ==
conflict: both AGENTS.md and CLAUDE.md are real files in /private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVBSZEXT8TK6WZ57QTMDC0FS/helper-cases/conflict; reconcile them manually
conflict correctly refused

== fm-brief project memory contract ==
ship brief includes project memory helper; scout brief omits it

== documentation behavior checks ==
captain address, optional seasoning, and project-memory ownership documented
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --stat 3780ba7d53a92234c79841ce33f8945d3f1b2cf1..d12682aaa864cea2477660ddbcd3148366fc53e0 && git diff --name-only 3780ba7d53a92234c79841ce33f8945d3f1b2cf1..d12682aaa864cea2477660ddbcd3148366fc53e0`
- <code>Repo invariant checks equivalent to `.github/workflows/ci.yml`: `readlink CLAUDE.md`, `readlink .claude/skills`, and `git ls-files -- data state config projects .no-mistakes`</code>
- <code>End-to-end `bin/fm-ensure-agents-md.sh` cases in the evidence directory: empty worktree creation, idempotent rerun, legacy real `CLAUDE.md` promotion, and conflicting real-file refusal</code>
- <code>`bin/fm-brief.sh test-ship-memory-x7 sample-repo` and `bin/fm-brief.sh test-scout-memory-x7 sample-repo --scout`, verifying ship briefs include the project-memory helper and scout briefs omit it</code>
- <code>Documentation checks against `AGENTS.md` for mandatory captain address, optional serious-context seasoning behavior, project-memory ownership, and thin `data/projects.md` registry language</code>
- <code>`git status --short` after cleanup</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
