### PR TITLE
docs: clarify context supervision signal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -418,6 +418,7 @@ This includes your own no-mistakes pipeline, long builds, and any other multi-mi
 Background that work so watcher wakes can interleave with it and the supervision loop stays responsive.
 
 Token discipline: status files before panes; default peeks to 40 lines; never stream a pane repeatedly through yourself; batch what you tell the captain.
+The context-% shown in a peek is not actionable as crew health; ignore it and intervene only on real signals (`signal`, `stale`, `needs-decision`, `blocked`), looping or confusion in the pane, or a question the brief already answers.
 Silence is the correct state while a healthy background watcher is waiting.
 
 ### Stuck-crewmate playbook (escalate in order)
@@ -425,7 +426,10 @@ Silence is the correct state while a healthy background watcher is waiting.
 1. Peek the pane.
 2. Crewmate is waiting on a question its brief already answers: answer in one line via fm-send.
 3. Crewmate is confused or looping: interrupt with the adapter's interrupt key (the window's harness is recorded as `harness=` in `state/<id>.meta`; e.g. `bin/fm-send.sh <window> --key Escape`), then redirect with one corrective line.
-4. Crewmate is context-exhausted or wedged: exit the agent with the adapter's exit command, relaunch with the same brief plus a `progress so far` note you append to it. The worktree and commits persist; this is cheap.
+4. Crewmate is genuinely wedged after redirection: exit the agent with the adapter's exit command, relaunch with the same brief plus a `progress so far` note you append to it.
+   Genuine wedging means looping, unresponsive, repeating the same obstacle, or truly dead.
+   A low context reading is not wedging; modern harnesses auto-compact and keep going.
+   The worktree and commits persist; this is cheap.
 5. Second relaunch fails too: write `failed` to backlog, tell the captain with evidence.
 
 ## 9. Escalation and captain etiquette


### PR DESCRIPTION
## Intent

Bake into firstmate's shared AGENTS.md supervision instructions that firstmate must not intervene in a crewmate merely because the pane shows low context remaining. Modern agent harnesses manage their own context windows by auto-compacting or summarizing as needed and keep going. The change must be general to harnesses, not codex-specific. Keep it scoped to Section 8 only: reframe the stuck-crewmate playbook so exit/relaunch is for genuine wedging such as looping, unresponsive, repeating the same obstacle, or truly dead, and add token-discipline guidance that context percentage shown in a peek is not actionable as a crew-health metric. Match the existing terse declarative voice, edit AGENTS.md directly, do not touch the CLAUDE.md symlink, and do not add a co-author.

## What Changed
- Clarifies that low context percentage in supervision peeks is not actionable crew-health signal.
- Reframes relaunch guidance around genuine wedging after redirection, such as looping, unresponsiveness, repeated obstacles, or a dead pane.
- Notes that modern harnesses auto-compact and continue, so low context alone should not trigger intervention.

## Risk Assessment

✅ Low: The change is limited to Section 8 documentation in AGENTS.md and aligns with the requested supervision behavior without introducing executable-code risk.

## Testing

Exercised the documentation change as an end user would review it: inspected the changed supervision instructions, verified the diff is scoped to `AGENTS.md` Section 8 with `CLAUDE.md` untouched, checked the required low-context and genuine-wedging guidance is present and harness-general, saved the exact reviewer-visible diff artifact, and confirmed the worktree stayed clean.

<details>
<summary>Evidence: Reviewer-visible AGENTS.md Section 8 diff</summary>

<code>Diff shows `context-% shown in a peek is not actionable as crew health` added under token discipline and the stuck-crewmate playbook changed from `context-exhausted or wedged` to genuine wedging only, with examples and auto-compaction guidance.</code>

```text
diff --git a/AGENTS.md b/AGENTS.md
index 3c973ca..51b5621 100644
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -418,6 +418,7 @@ This includes your own no-mistakes pipeline, long builds, and any other multi-mi
 Background that work so watcher wakes can interleave with it and the supervision loop stays responsive.
 
 Token discipline: status files before panes; default peeks to 40 lines; never stream a pane repeatedly through yourself; batch what you tell the captain.
+The context-% shown in a peek is not actionable as crew health; ignore it and intervene only on real signals (`signal`, `stale`, `needs-decision`, `blocked`), looping or confusion in the pane, or a question the brief already answers.
 Silence is the correct state while a healthy background watcher is waiting.
 
 ### Stuck-crewmate playbook (escalate in order)
@@ -425,7 +426,10 @@ Silence is the correct state while a healthy background watcher is waiting.
 1. Peek the pane.
 2. Crewmate is waiting on a question its brief already answers: answer in one line via fm-send.
 3. Crewmate is confused or looping: interrupt with the adapter's interrupt key (the window's harness is recorded as `harness=` in `state/<id>.meta`; e.g. `bin/fm-send.sh <window> --key Escape`), then redirect with one corrective line.
-4. Crewmate is context-exhausted or wedged: exit the agent with the adapter's exit command, relaunch with the same brief plus a `progress so far` note you append to it. The worktree and commits persist; this is cheap.
+4. Crewmate is genuinely wedged after redirection: exit the agent with the adapter's exit command, relaunch with the same brief plus a `progress so far` note you append to it.
+   Genuine wedging means looping, unresponsive, repeating the same obstacle, or truly dead.
+   A low context reading is not wedging; modern harnesses auto-compact and keep going.
+   The worktree and commits persist; this is cheap.
 5. Second relaunch fails too: write `failed` to backlog, tell the captain with evidence.
 
 ## 9. Escalation and captain etiquette
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Reviewed `AGENTS.md` Section 8 lines 420-431 to confirm low-context guidance is general to harnesses and wedging is limited to real stuck states.</code>
- <code>Ran `git diff --name-status 8216d04800ae8120a28c386717e3a9c9bd0dc026...5f7a3b668eb0bc848c087827528b368fcd1fc03d` to confirm only `AGENTS.md` changed.</code>
- <code>Ran `git diff --quiet 8216d04800ae8120a28c386717e3a9c9bd0dc026...5f7a3b668eb0bc848c087827528b368fcd1fc03d -- . &#39;:!AGENTS.md&#39;` and `git diff --quiet ... -- CLAUDE.md` to confirm no out-of-scope files or symlink changes.</code>
- <code>Ran focused `rg -q` acceptance checks for the required phrases: context-% is not actionable, low context is not wedging, modern harnesses auto-compact, and genuine wedging examples.</code>
- <code>Generated reviewer evidence with `git diff --output=/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVEVGJV56BMNNDR5RBQTX9WM/agents-section8-low-context.diff 8216d04800ae8120a28c386717e3a9c9bd0dc026...5f7a3b668eb0bc848c087827528b368fcd1fc03d -- AGENTS.md`.</code>
- <code>Ran `git status --short` after testing to confirm no transient working-tree artifacts remained.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
