### PR TITLE
fix(bin): make watcher + guard stat portable across macOS and Linux

### DIFF
--- a/bin/fm-guard.sh
+++ b/bin/fm-guard.sh
@@ -13,6 +13,13 @@ FM_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 STATE="$FM_ROOT/state"
 GRACE=${FM_GUARD_GRACE:-300}
 
+# Portable mtime; see fm-watch.sh for why the `stat -f || stat -c` fallback breaks on Linux.
+if [ "$(uname)" = Darwin ]; then
+  stat_mtime() { stat -f %m "$1" 2>/dev/null; }
+else
+  stat_mtime() { stat -c %Y "$1" 2>/dev/null; }
+fi
+
 has_meta=false
 for meta in "$STATE"/*.meta; do
   [ -e "$meta" ] || continue
@@ -23,7 +30,7 @@ done
 
 BEAT="$STATE/.last-watcher-beat"
 if [ -e "$BEAT" ]; then
-  m=$(stat -f %m "$BEAT" 2>/dev/null || stat -c %Y "$BEAT" 2>/dev/null) || exit 0
+  m=$(stat_mtime "$BEAT") || exit 0
   age=$(( $(date +%s) - m ))
   [ "$age" -lt "$GRACE" ] && exit 0
   echo "WARNING: tasks are in flight but no watcher has been alive for ${age}s (>${GRACE}s)." >&2

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -13,6 +13,21 @@ FM_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 STATE="$FM_ROOT/state"
 mkdir -p "$STATE"
 
+# Portable stat. macOS (BSD) stat uses `-f <fmt>`; Linux (GNU) stat uses `-c <fmt>`.
+# Do NOT use the `stat -f <fmt> ... || stat -c <fmt> ...` fallback form: on Linux
+# `stat -f` is *filesystem* stat and writes a partial filesystem dump ("File: ...",
+# "Blocks: ...") to stdout before failing, so the fallback's correct output gets
+# appended to that garbage. Arithmetic under `set -u` then aborts on the stray
+# token (e.g. the word "File" read as an unset variable), which silently kills the
+# watcher mid-cycle. Detect the platform once and pick the right form.
+if [ "$(uname)" = Darwin ]; then
+  stat_mtime() { stat -f %m "$1" 2>/dev/null; }        # epoch seconds of mtime
+  stat_sig()   { stat -f '%z:%Fm' "$1" 2>/dev/null; }   # size:mtime signature
+else
+  stat_mtime() { stat -c %Y "$1" 2>/dev/null; }
+  stat_sig()   { stat -c '%s:%Y' "$1" 2>/dev/null; }
+fi
+
 POLL=${FM_POLL:-15}                   # seconds between cycles
 HEARTBEAT=${FM_HEARTBEAT:-600}        # base seconds between heartbeat wakes
 HEARTBEAT_MAX=${FM_HEARTBEAT_MAX:-7200}  # heartbeat backoff cap
@@ -46,7 +61,7 @@ wake() {
 # a busy fleet. Persist the schedule as file mtimes instead.
 age_of() {  # seconds since file mtime; "due immediately" if missing
   local f=$1 m
-  m=$(stat -f %m "$f" 2>/dev/null || stat -c %Y "$f" 2>/dev/null) || { echo 999999; return; }
+  m=$(stat_mtime "$f") || { echo 999999; return; }
   echo $(( $(date +%s) - m ))
 }
 
@@ -63,7 +78,7 @@ scan_signals() {
   local f sig sf
   for f in "$STATE"/*.status "$STATE"/*.turn-ended; do
     [ -e "$f" ] || continue
-    sig=$(stat -f '%z:%Fm' "$f" 2>/dev/null || stat -c '%s:%Y' "$f" 2>/dev/null) || continue
+    sig=$(stat_sig "$f") || continue
     sf="$STATE/.seen-$(basename "$f" | tr '.' '_')"
     if [ "$sig" != "$(cat "$sf" 2>/dev/null)" ]; then
       printf '%s\t%s\t%s\n' "$sf" "$sig" "$f"


### PR DESCRIPTION
## Fixes #26

### Root cause

`bin/fm-watch.sh` and `bin/fm-guard.sh` used a macOS-first `stat -f %m ... || stat -c %Y ...` fallback to read file mtimes. On Linux (GNU `stat`), `stat -f` is **filesystem stat** — it writes a partial filesystem dump (`File: ...`, `Blocks: ...`) to **stdout** before failing. The `2>/dev/null` only suppresses stderr, so the fallback's correct output gets appended to that garbage. The subsequent arithmetic under `set -u` then evaluates the stray token (e.g. the word `File`) as an unset variable and aborts, silently killing the watcher mid-cycle. The liveness beacon goes stale and every supervision wake (signal/stale/check/heartbeat) is missed. `fm-guard.sh` had the same flaw at its beacon-age line, so its warning was broken too.

### Fix

Detect the platform once (`uname`) and define `stat_mtime` / `stat_sig` helpers with the correct BSD (`-f`) or GNU (`-c`) form, then call those helpers everywhere. The macOS format strings (`%m`, `%z:%Fm`) are preserved unchanged; only the Linux path changes.

### Verification

- **Bug reproduced**: the exact `File: unbound variable` (exit 1) crash confirmed under `set -u` on the original code path.
- **Fix verified**: the helpers produce clean mtime/signature output on Linux; a multi-cycle relaunch loop (exercising the previously-fatal `age_of()` and `scan_signals()` paths) shows **zero unbound-variable deaths**.
- `shellcheck bin/*.sh` passes clean.
- Watcher runs clean under `set -u`; liveness beacon stays fresh.

---

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

> **Opened manually** because no-mistakes' push step still targets the parent repo despite `fork_url` being correctly configured (follow-up to kunchenguid/no-mistakes#293); the change passed no-mistakes review/test/lint.