### PR TITLE
fix: persist watcher wakes across supervision gaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - run: shellcheck bin/*.sh
+      - run: shellcheck bin/*.sh tests/*.sh
+
+  tests:
+    name: Behavior tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: tests/fm-wake-queue.test.sh
 
   invariants:
     name: Repo invariants

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,8 @@ state/               volatile runtime signals; gitignored
   <id>.turn-ended    touched by turn-end hooks
   <id>.meta          written by fm-spawn: window=, worktree=, project=, harness=, kind=, mode=, yolo= (fm-pr-check appends pr=)
   <id>.check.sh      optional slow poll you write per task (e.g. merged-PR check)
+  .wake-queue        durable queued wakes: epoch<TAB>seq<TAB>kind<TAB>key<TAB>payload
+  .watch.lock .wake-queue.lock watcher singleton and queue serialization locks
   .hash-* .count-* .stale-* .seen-* .last-* .heartbeat-streak   watcher internals; never touch
   .last-watcher-beat watcher liveness beacon, touched every poll; fm-guard.sh reads it
 .no-mistakes/        local validation state and evidence; gitignored
@@ -191,7 +193,7 @@ Reconcile reality with your records before doing anything else:
    If it refuses because another live session holds the lock, tell the captain another active session is already managing the work and operate read-only until resolved.
 6. Surface only what needs the captain: pending decisions, PRs ready to merge, failures, or needed credentials.
    If there is nothing that needs them, say nothing and resume.
-7. Restart the watcher (section 8).
+7. Drain queued wakes with `bin/fm-wake-drain.sh`, handle anything pending, then arm the watcher (section 8).
 
 A firstmate restart must be a non-event.
 All truth lives in tmux, state files, data/backlog.md, and treehouse; your conversation memory is a cache.
@@ -381,22 +383,30 @@ From there the task is an ordinary ship task through its mode-specific validatio
 
 The watcher is the backbone.
 Whenever at least one task is in flight, `bin/fm-watch.sh` must be running as a background task.
-It costs zero tokens while running and exits with one reason line when something needs you; restart it after handling every wake, and before you end any turn.
+It costs zero tokens while running and exits with one reason line when something needs you.
+It also writes each detected wake to the durable queue at `state/.wake-queue` before advancing suppression markers such as `.seen-*`, `.stale-*`, `.last-check`, or `.last-heartbeat`.
+At the start of every wake-handling turn and every recovery turn, run `bin/fm-wake-drain.sh` before peeking panes, reading status files beyond the reason line, or starting new work.
+The printed one-shot reason line is still useful, but the drained queue is the lossless backlog.
+After handling drained wakes, re-arm `bin/fm-watch.sh` before you end the turn.
+The watcher is singleton-safe: if one is already alive, another invocation exits cleanly instead of creating a duplicate watcher.
+Do not pkill-and-restart the watcher as a routine operation; just arm it, and let the singleton lock no-op when appropriate.
+P2/P3 of the watcher reliability design - a persistent detector daemon and blocking waiter split - are deferred; this phase intentionally preserves the current one-shot restart model.
 Waiting on the watcher is intentionally silent.
-After starting or restarting it, do not send idle progress updates to the captain; wait until it returns `signal`, `stale`, `check`, or `heartbeat`, unless the captain asks for status.
+After arming it, do not send idle progress updates to the captain; wait until it returns `signal`, `stale`, `check`, or `heartbeat`, unless the captain asks for status.
 Empty polls, elapsed waiting time, and "still no change" are tool bookkeeping, not conversational progress.
 
 ```sh
 bin/fm-watch.sh   # run in background; exits with: signal|stale|check|heartbeat
+bin/fm-wake-drain.sh   # drain queued wake records at turn start
 ```
 
 On wake, in order of cheapness:
 
-1. Read the reason line.
+1. Read the reason line and drain queued wake records with `bin/fm-wake-drain.sh`.
 2. `signal:` read the listed status files first; a wake lists every signal that landed within the coalescing grace window (e.g. a status write plus the same turn's turn-end marker), and each is ~30 tokens and usually sufficient.
 3. `stale:` the crewmate stopped without reporting; peek the pane (`bin/fm-peek.sh <window>`) to diagnose.
 4. `check:` a per-task poll fired (usually a merge); act on it.
-5. `heartbeat:` review the whole fleet: skim each window's status file, peek panes that look off, check PR-ready tasks for merge, reconcile data/backlog.md, then restart the watcher.
+5. `heartbeat:` review the whole fleet: skim each window's status file, peek panes that look off, check PR-ready tasks for merge, reconcile data/backlog.md, then re-arm the watcher.
    A heartbeat with no captain-relevant change is internal; do not report that the fleet is unchanged.
 
 Heartbeats back off exponentially while they are the only wakes firing (600s doubling to a 2h cap - an idle fleet stops burning turns); any signal, stale, or check wake resets the cadence to the base interval.
@@ -406,12 +416,13 @@ Never rely on hooks or status files alone; the heartbeat review of every window 
 tmux is the ground truth.
 
 **Watcher liveness is guarded, not just disciplined.**
-Restarting the watcher is the last action of every wake-handling turn - but the protocol no longer relies on remembering that.
+Arming the watcher is the last action of every wake-handling turn - but the protocol no longer relies on remembering that.
 While running, `fm-watch.sh` touches `state/.last-watcher-beat` every poll cycle.
-The supervision scripts (`fm-peek`, `fm-send`, `fm-spawn`, `fm-teardown`, `fm-pr-check`, `fm-promote`, `fm-review-diff`, `fm-fleet-sync`) call `bin/fm-guard.sh` first, which warns to stderr when any task is in flight (`state/*.meta` exists) but that beacon is missing or older than `FM_GUARD_GRACE` (default 300s).
-So the next time you touch the fleet with no watcher alive, the tool output itself tells you to restart it - a pull-based guard that works on any harness, since it rides the script output you already read rather than a harness-specific hook.
-The grace window keeps normal handling (watcher briefly down between a wake and its restart) silent.
-If a guard warning fires, restart the watcher before doing anything else.
+The supervision scripts (`fm-peek`, `fm-send`, `fm-spawn`, `fm-teardown`, `fm-pr-check`, `fm-promote`, `fm-review-diff`, `fm-fleet-sync`) call `bin/fm-guard.sh` first, which warns to stderr when any task is in flight (`state/*.meta` exists) but queued wakes are pending, or that beacon is missing or older than `FM_GUARD_GRACE` (default 300s).
+So the next time you touch the fleet with queued wakes or no watcher alive, the tool output itself tells you what to do - a pull-based guard that works on any harness, since it rides the script output you already read rather than a harness-specific hook.
+The grace window keeps normal handling (watcher briefly down between a wake and its re-arm) silent.
+If a guard warning says queued wakes are pending, drain them before doing anything else.
+If a guard warning says watcher liveness is stale, arm `bin/fm-watch.sh` after draining any queued wakes.
 Watcher liveness is not enough if you are foreground-blocked.
 Whenever one or more tasks are in flight, do not run long foreground-blocking operations in your own session.
 This includes your own no-mistakes pipeline, long builds, and any other multi-minute command.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,15 +185,16 @@ Environment marker for harness detection: pi sets `PI_CODING_AGENT=true` for its
 You may have been restarted mid-flight.
 Reconcile reality with your records before doing anything else:
 
-1. `tmux list-windows -a -F '#{session_name}:#{window_name}' | grep ':fm-'` to find live crewmates.
-2. Read `data/backlog.md`, every `state/*.meta`, and every `state/*.status`.
-3. For windows with no meta (orphans): peek them, figure out what they are, ask the captain if unclear.
-4. For meta with no window (dead crewmates): check `treehouse status` in that project, salvage or report.
-5. Run `bin/fm-lock.sh` to acquire the session lock (it records the harness process PID, which is session-stable).
+1. Drain queued wakes with `bin/fm-wake-drain.sh` and keep the printed records as the first work queue for this recovery turn.
+2. `tmux list-windows -a -F '#{session_name}:#{window_name}' | grep ':fm-'` to find live crewmates.
+3. Read `data/backlog.md`, every `state/*.meta`, and every `state/*.status`.
+4. For windows with no meta (orphans): peek them, figure out what they are, ask the captain if unclear.
+5. For meta with no window (dead crewmates): check `treehouse status` in that project, salvage or report.
+6. Run `bin/fm-lock.sh` to acquire the session lock (it records the harness process PID, which is session-stable).
    If it refuses because another live session holds the lock, tell the captain another active session is already managing the work and operate read-only until resolved.
-6. Surface only what needs the captain: pending decisions, PRs ready to merge, failures, or needed credentials.
+7. Surface only what needs the captain: pending decisions, PRs ready to merge, failures, or needed credentials.
    If there is nothing that needs them, say nothing and resume.
-7. Drain queued wakes with `bin/fm-wake-drain.sh`, handle anything pending, then arm the watcher (section 8).
+8. Handle drained wakes, then arm the watcher (section 8).
 
 A firstmate restart must be a non-event.
 All truth lives in tmux, state files, data/backlog.md, and treehouse; your conversation memory is a cache.
@@ -388,7 +389,7 @@ It also writes each detected wake to the durable queue at `state/.wake-queue` be
 At the start of every wake-handling turn and every recovery turn, run `bin/fm-wake-drain.sh` before peeking panes, reading status files beyond the reason line, or starting new work.
 The printed one-shot reason line is still useful, but the drained queue is the lossless backlog.
 After handling drained wakes, re-arm `bin/fm-watch.sh` before you end the turn.
-The watcher is singleton-safe: if one is already alive, another invocation exits cleanly instead of creating a duplicate watcher.
+The watcher is singleton-safe: if one is already alive with a fresh liveness beacon, another invocation exits cleanly instead of creating a duplicate watcher; if the live holder's beacon is stale, the new invocation exits with an actionable failure.
 Do not pkill-and-restart the watcher as a routine operation; just arm it, and let the singleton lock no-op when appropriate.
 P2/P3 of the watcher reliability design - a persistent detector daemon and blocking waiter split - are deferred; this phase intentionally preserves the current one-shot restart model.
 Waiting on the watcher is intentionally silent.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,13 +185,13 @@ Environment marker for harness detection: pi sets `PI_CODING_AGENT=true` for its
 You may have been restarted mid-flight.
 Reconcile reality with your records before doing anything else:
 
-1. Drain queued wakes with `bin/fm-wake-drain.sh` and keep the printed records as the first work queue for this recovery turn.
-2. `tmux list-windows -a -F '#{session_name}:#{window_name}' | grep ':fm-'` to find live crewmates.
-3. Read `data/backlog.md`, every `state/*.meta`, and every `state/*.status`.
-4. For windows with no meta (orphans): peek them, figure out what they are, ask the captain if unclear.
-5. For meta with no window (dead crewmates): check `treehouse status` in that project, salvage or report.
-6. Run `bin/fm-lock.sh` to acquire the session lock (it records the harness process PID, which is session-stable).
+1. Run `bin/fm-lock.sh` to acquire the session lock (it records the harness process PID, which is session-stable).
    If it refuses because another live session holds the lock, tell the captain another active session is already managing the work and operate read-only until resolved.
+2. Drain queued wakes with `bin/fm-wake-drain.sh` and keep the printed records as the first work queue for this recovery turn.
+3. `tmux list-windows -a -F '#{session_name}:#{window_name}' | grep ':fm-'` to find live crewmates.
+4. Read `data/backlog.md`, every `state/*.meta`, and every `state/*.status`.
+5. For windows with no meta (orphans): peek them, figure out what they are, ask the captain if unclear.
+6. For meta with no window (dead crewmates): check `treehouse status` in that project, salvage or report.
 7. Surface only what needs the captain: pending decisions, PRs ready to merge, failures, or needed credentials.
    If there is nothing that needs them, say nothing and resume.
 8. Handle drained wakes, then arm the watcher (section 8).

--- a/README.md
+++ b/README.md
@@ -111,8 +111,9 @@ firstmate works from any terminal - outside tmux, crewmates land in a detached `
 ```
 
 - **Event-driven supervision** - a zero-token bash watcher (`bin/fm-watch.sh`) sleeps on the fleet and wakes the first mate only when a crewmate reports, stalls, a PR merges, or an internal heartbeat review is due.
+  Detected wakes are also written to a durable local queue (`state/.wake-queue`) before detector state advances, so a missed one-shot process exit can be recovered by draining the queue.
   Routine watcher polling, restarts, elapsed waiting time, and unchanged heartbeat reviews stay silent; an idle crew costs you nothing.
-  A pull-based guard (`bin/fm-guard.sh`) warns through supervision tool output if tasks are in flight and that watcher stops running.
+  A pull-based guard (`bin/fm-guard.sh`) warns through supervision tool output if tasks are in flight and that watcher stops running or queued wakes are waiting to be drained.
 - **Worktrees, not branches in your checkout** - crewmates never touch your clone; treehouse pools clean worktrees so parallel tasks on one repo cannot collide.
 - **Two task shapes** - ship tasks change projects and ship by project mode (`no-mistakes`, `direct-PR`, or `local-only`); scout tasks investigate, plan, reproduce bugs, or audit, then leave a report at `data/<id>/report.md` and never push.
 - **Project modes are explicit** - `data/projects.md` records each project's delivery mode and optional `+yolo` autonomy flag.
@@ -133,12 +134,13 @@ The first mate drives these; you rarely need to, but they work by hand too.
 | `fm-fleet-sync.sh`       | Fetch clones, clean-fast-forward their checked-out default branches, and safely prune branches whose remote is gone |
 | `fm-brief.sh`            | Scaffold a ship brief, or a report-only scout brief with `--scout`                                                  |
 | `fm-ensure-agents-md.sh` | Ensure project `AGENTS.md` is the real memory file and `CLAUDE.md` symlinks to it                                   |
-| `fm-guard.sh`            | Warn when tasks are in flight but the watcher liveness beacon is stale or missing                                   |
+| `fm-guard.sh`            | Warn when tasks are in flight but queued wakes are pending or the watcher liveness beacon is stale or missing      |
 | `fm-spawn.sh`            | Window → treehouse worktree → agent launched with its brief; records ship/scout task kind                           |
 | `fm-project-mode.sh`     | Resolve a project's delivery mode and `+yolo` flag from `data/projects.md`                                          |
 | `fm-merge-local.sh`      | Fast-forward a `local-only` project's local default branch after approval                                           |
 | `fm-review-diff.sh`      | Review a crewmate branch against the authoritative base, with optional `--stat` output                              |
-| `fm-watch.sh`            | Block until supervision work is due; exits with one reason line                                                     |
+| `fm-watch.sh`            | Singleton-safe one-shot watcher; blocks until supervision work is due, queues it durably, then exits with one reason line |
+| `fm-wake-drain.sh`       | Atomically drain queued watcher wakes before handling supervision work                                              |
 | `fm-send.sh`             | Send one literal line (or `--key Escape`) to a crewmate window                                                      |
 | `fm-peek.sh`             | Print a bounded tail of a crewmate pane                                                                             |
 | `fm-pr-check.sh`         | Record a PR-ready task and arm the watcher's merge poll                                                             |
@@ -174,10 +176,13 @@ Tracked changes to firstmate itself, including `AGENTS.md`, `README.md`, `CONTRI
 When supervising live crewmates, keep long validation or build work in the background so watcher wakes can still be handled.
 Human-authored pull requests targeting `main` must be raised through `git push no-mistakes`; see `CONTRIBUTING.md` for the enforced contributor workflow.
 Local `.no-mistakes/` state and test evidence stay out of this repo; `.no-mistakes.yaml` keeps evidence in a temp directory instead.
+The current watcher reliability work keeps the one-shot process model and adds a durable queue plus singleton lock.
+The persistent detector daemon and blocking waiter split are deferred follow-up phases.
 
 ```sh
 bash -n bin/*.sh                          # syntax-check the toolbelt
-shellcheck bin/*.sh                       # lint the toolbelt; CI enforces this
+shellcheck bin/*.sh tests/*.sh            # lint the toolbelt and behavior tests; CI enforces this
+tests/fm-wake-queue.test.sh               # durable wake queue and singleton behavior tests
 [ "$(readlink CLAUDE.md)" = "AGENTS.md" ]
 [ "$(readlink .claude/skills)" = "../.agents/skills" ]
 FM_HEARTBEAT=2 FM_POLL=1 bin/fm-watch.sh  # watcher smoke test (prints "heartbeat")

--- a/bin/fm-guard.sh
+++ b/bin/fm-guard.sh
@@ -13,6 +13,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 STATE="${FM_STATE_OVERRIDE:-$FM_ROOT/state}"
 GRACE=${FM_GUARD_GRACE:-300}
+queue_pending=false
 
 # shellcheck source=bin/fm-wake-lib.sh
 . "$SCRIPT_DIR/fm-wake-lib.sh"
@@ -33,6 +34,7 @@ done
 "$has_meta" || exit 0
 
 if [ -s "$FM_WAKE_QUEUE" ]; then
+  queue_pending=true
   echo "WARNING: queued wakes pending - drain them with bin/fm-wake-drain.sh before anything else." >&2
 fi
 
@@ -45,5 +47,9 @@ if [ -e "$BEAT" ]; then
 else
   echo "WARNING: tasks are in flight but no watcher has ever run (no liveness beacon)." >&2
 fi
-echo "Restart it NOW, before anything else: run bin/fm-watch.sh as a background task." >&2
+if "$queue_pending"; then
+  echo "After draining queued wakes, re-arm the watcher: run bin/fm-watch.sh as a background task." >&2
+else
+  echo "Restart it NOW, before anything else: run bin/fm-watch.sh as a background task." >&2
+fi
 exit 0

--- a/bin/fm-guard.sh
+++ b/bin/fm-guard.sh
@@ -9,9 +9,13 @@
 # Always exits 0: the guard warns, it never blocks.
 set -u
 
-FM_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-STATE="$FM_ROOT/state"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+STATE="${FM_STATE_OVERRIDE:-$FM_ROOT/state}"
 GRACE=${FM_GUARD_GRACE:-300}
+
+# shellcheck source=bin/fm-wake-lib.sh
+. "$SCRIPT_DIR/fm-wake-lib.sh"
 
 # Portable mtime; see fm-watch.sh for why the `stat -f || stat -c` fallback breaks on Linux.
 if [ "$(uname)" = Darwin ]; then
@@ -27,6 +31,10 @@ for meta in "$STATE"/*.meta; do
   break
 done
 "$has_meta" || exit 0
+
+if [ -s "$FM_WAKE_QUEUE" ]; then
+  echo "WARNING: queued wakes pending - drain them with bin/fm-wake-drain.sh before anything else." >&2
+fi
 
 BEAT="$STATE/.last-watcher-beat"
 if [ -e "$BEAT" ]; then

--- a/bin/fm-wake-drain.sh
+++ b/bin/fm-wake-drain.sh
@@ -9,7 +9,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DRAIN_TMP=
 DRAIN_LOCK_HELD=false
 
-# shellcheck disable=SC2329 # Invoked by trap handlers below.
+# shellcheck disable=SC2317,SC2329 # Invoked by trap handlers below.
 cleanup() {
   local status=$?
   if [ "$status" -ne 0 ] && [ "$DRAIN_LOCK_HELD" = true ] && [ -n "$DRAIN_TMP" ] && [ -e "$DRAIN_TMP" ]; then

--- a/bin/fm-wake-drain.sh
+++ b/bin/fm-wake-drain.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Atomically drain durable watcher wake records.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=bin/fm-wake-lib.sh
+. "$SCRIPT_DIR/fm-wake-lib.sh"
+
+DRAIN_TMP=
+DRAIN_LOCK_HELD=false
+
+# shellcheck disable=SC2329 # Invoked by trap handlers below.
+cleanup() {
+  local status=$?
+  if [ "$status" -ne 0 ] && [ "$DRAIN_LOCK_HELD" = true ] && [ -n "$DRAIN_TMP" ] && [ -e "$DRAIN_TMP" ]; then
+    fm_wake_restore_queue "$DRAIN_TMP" || true
+  fi
+  if [ "$DRAIN_LOCK_HELD" = true ]; then
+    fm_lock_release "$FM_WAKE_QUEUE_LOCK"
+  fi
+  exit "$status"
+}
+
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+fm_lock_acquire_wait "$FM_WAKE_QUEUE_LOCK"
+DRAIN_LOCK_HELD=true
+
+if [ ! -s "$FM_WAKE_QUEUE" ]; then
+  : > "$FM_WAKE_QUEUE"
+  exit 0
+fi
+
+DRAIN_TMP="$STATE/.wake-queue.drain.$(fm_current_pid)"
+rm -f "$DRAIN_TMP"
+mv "$FM_WAKE_QUEUE" "$DRAIN_TMP" || exit 1
+: > "$FM_WAKE_QUEUE" || exit 1
+
+fm_wake_print_deduped "$DRAIN_TMP" || exit "$?"
+rm -f "$DRAIN_TMP"
+DRAIN_TMP=
+exit 0

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# Shared durable wake queue and portable lock helpers.
+
+FM_WAKE_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_WAKE_DEFAULT_ROOT="$(cd "$FM_WAKE_LIB_DIR/.." && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-${FM_ROOT:-$FM_WAKE_DEFAULT_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-${STATE:-$FM_ROOT/state}}"
+FM_WAKE_QUEUE="${FM_WAKE_QUEUE:-$STATE/.wake-queue}"
+FM_WAKE_QUEUE_LOCK="${FM_WAKE_QUEUE_LOCK:-$STATE/.wake-queue.lock}"
+FM_LOCK_STALE_AFTER="${FM_LOCK_STALE_AFTER:-2}"
+mkdir -p "$STATE"
+
+fm_current_pid() {
+  printf '%s\n' "${BASHPID:-$$}"
+}
+
+fm_pid_alive() {
+  local pid=$1
+  case "$pid" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+  kill -0 "$pid" 2>/dev/null
+}
+
+fm_path_mtime() {
+  if [ "$(uname)" = Darwin ]; then
+    stat -f %m "$1" 2>/dev/null
+  else
+    stat -c %Y "$1" 2>/dev/null
+  fi
+}
+
+fm_path_age() {
+  local path=$1 m
+  m=$(fm_path_mtime "$path") || { echo 999999; return; }
+  echo $(( $(date +%s) - m ))
+}
+
+fm_lock_remove_stale() {
+  local lockdir=$1 expected_pid=$2 current_pid
+  current_pid=$(cat "$lockdir/pid" 2>/dev/null || true)
+  [ "$current_pid" = "$expected_pid" ] || return 1
+  if fm_pid_alive "$current_pid"; then
+    return 1
+  fi
+  case "$current_pid" in
+    ''|*[!0-9]*)
+      [ "$(fm_path_age "$lockdir")" -ge "$FM_LOCK_STALE_AFTER" ] || return 1
+      ;;
+  esac
+  rm -f "$lockdir/pid" 2>/dev/null || return 1
+  rmdir "$lockdir" 2>/dev/null
+}
+
+fm_lock_try_acquire() {
+  local lockdir=$1 pid
+  FM_LOCK_HELD_PID=
+  if mkdir "$lockdir" 2>/dev/null; then
+    if { fm_current_pid > "$lockdir/pid"; } 2>/dev/null; then
+      return 0
+    fi
+    rm -f "$lockdir/pid" 2>/dev/null || true
+    rmdir "$lockdir" 2>/dev/null || true
+    return 1
+  fi
+
+  pid=$(cat "$lockdir/pid" 2>/dev/null || true)
+  if fm_pid_alive "$pid"; then
+    FM_LOCK_HELD_PID=$pid
+    return 1
+  fi
+  case "$pid" in
+    ''|*[!0-9]*)
+      if [ "$(fm_path_age "$lockdir")" -lt "$FM_LOCK_STALE_AFTER" ]; then
+        FM_LOCK_HELD_PID=$pid
+        return 1
+      fi
+      ;;
+  esac
+
+  fm_lock_remove_stale "$lockdir" "$pid" || true
+  if mkdir "$lockdir" 2>/dev/null; then
+    if { fm_current_pid > "$lockdir/pid"; } 2>/dev/null; then
+      return 0
+    fi
+    rm -f "$lockdir/pid" 2>/dev/null || true
+    rmdir "$lockdir" 2>/dev/null || true
+    return 1
+  fi
+
+  pid=$(cat "$lockdir/pid" 2>/dev/null || true)
+  # shellcheck disable=SC2034 # Read by callers after fm_lock_try_acquire returns.
+  FM_LOCK_HELD_PID=$pid
+  return 1
+}
+
+fm_lock_acquire_wait() {
+  local lockdir=$1
+  while ! fm_lock_try_acquire "$lockdir"; do
+    sleep 0.1
+  done
+}
+
+fm_lock_release() {
+  local lockdir=$1 pid current
+  current=${BASHPID:-$$}
+  pid=$(cat "$lockdir/pid" 2>/dev/null || true)
+  [ "$pid" = "$current" ] || return 0
+  rm -f "$lockdir/pid" 2>/dev/null || true
+  rmdir "$lockdir" 2>/dev/null || true
+}
+
+fm_wake_clean_field() {
+  LC_ALL=C tr '\t\r\n' '   '
+}
+
+fm_wake_append() {
+  local kind=$1 key=$2 payload=$3 clean_key clean_payload epoch seq seq_file status
+  case "$kind" in
+    signal|stale|check|heartbeat) ;;
+    *) printf 'fm_wake_append: invalid wake kind: %s\n' "$kind" >&2; return 2 ;;
+  esac
+
+  clean_key=$(printf '%s' "$key" | fm_wake_clean_field)
+  clean_payload=$(printf '%s' "$payload" | fm_wake_clean_field)
+  epoch=$(date +%s)
+  seq_file="$STATE/.wake-queue.seq"
+  status=0
+
+  fm_lock_acquire_wait "$FM_WAKE_QUEUE_LOCK"
+  seq=$(cat "$seq_file" 2>/dev/null || echo 0)
+  case "$seq" in
+    ''|*[!0-9]*) seq=0 ;;
+  esac
+  seq=$((seq + 1))
+  printf '%s\n' "$seq" > "$seq_file" || status=$?
+  if [ "$status" -eq 0 ]; then
+    printf '%s\t%s\t%s\t%s\t%s\n' "$epoch" "$seq" "$kind" "$clean_key" "$clean_payload" >> "$FM_WAKE_QUEUE" || status=$?
+  fi
+  fm_lock_release "$FM_WAKE_QUEUE_LOCK"
+  return "$status"
+}
+
+fm_wake_restore_queue() {
+  local drained=$1 restore
+  restore="$STATE/.wake-queue.restore.$(fm_current_pid)"
+  if [ -e "$FM_WAKE_QUEUE" ]; then
+    cat "$drained" "$FM_WAKE_QUEUE" > "$restore" && mv "$restore" "$FM_WAKE_QUEUE"
+  else
+    mv "$drained" "$FM_WAKE_QUEUE"
+  fi
+}
+
+fm_wake_print_deduped() {
+  local file=$1
+  awk -F '\t' '
+    NF >= 5 {
+      dedupe = $3 SUBSEP $4
+      if ($3 == "heartbeat") {
+        dedupe = "heartbeat"
+      }
+      if (!(dedupe in seen)) {
+        order[++count] = dedupe
+        seen[dedupe] = 1
+      }
+      line[dedupe] = $0
+    }
+    END {
+      for (i = 1; i <= count; i++) {
+        print line[order[i]]
+      }
+    }
+  ' "$file"
+}

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -19,8 +19,20 @@ mkdir -p "$STATE"
 . "$SCRIPT_DIR/fm-wake-lib.sh"
 
 WATCH_LOCK="$STATE/.watch.lock"
+WATCHER_STALE_GRACE=${FM_WATCHER_STALE_GRACE:-${FM_GUARD_GRACE:-300}}
 if ! fm_lock_try_acquire "$WATCH_LOCK"; then
+  BEAT="$STATE/.last-watcher-beat"
   if [ -n "${FM_LOCK_HELD_PID:-}" ]; then
+    if [ -e "$BEAT" ]; then
+      beat_age=$(fm_path_age "$BEAT")
+      if [ "$beat_age" -ge "$WATCHER_STALE_GRACE" ]; then
+        echo "watcher: lock held by live pid $FM_LOCK_HELD_PID but heartbeat is stale for ${beat_age}s (>${WATCHER_STALE_GRACE}s); inspect or stop that watcher before re-arming." >&2
+        exit 1
+      fi
+    elif [ "$(fm_path_age "$WATCH_LOCK")" -ge "$WATCHER_STALE_GRACE" ]; then
+      echo "watcher: lock held by live pid $FM_LOCK_HELD_PID but no heartbeat exists; inspect or stop that watcher before re-arming." >&2
+      exit 1
+    fi
     echo "watcher: already running pid $FM_LOCK_HELD_PID"
   else
     echo "watcher: already running"

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -6,12 +6,28 @@
 #   stale: <window>       a crewmate pane stopped changing and shows no busy signature
 #   check: <script>: <out> a per-task check script (e.g. merged-PR poll) produced output
 #   heartbeat              fleet review due; starts at FM_HEARTBEAT and backs off to FM_HEARTBEAT_MAX
-# Run as a background task. Restart it after handling each wake.
+# Run as a background task. Re-arm it after handling each wake; duplicate
+# invocations no-op through the watcher singleton lock.
 set -u
 
-FM_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-STATE="$FM_ROOT/state"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+STATE="${FM_STATE_OVERRIDE:-$FM_ROOT/state}"
 mkdir -p "$STATE"
+
+# shellcheck source=bin/fm-wake-lib.sh
+. "$SCRIPT_DIR/fm-wake-lib.sh"
+
+WATCH_LOCK="$STATE/.watch.lock"
+if ! fm_lock_try_acquire "$WATCH_LOCK"; then
+  if [ -n "${FM_LOCK_HELD_PID:-}" ]; then
+    echo "watcher: already running pid $FM_LOCK_HELD_PID"
+  else
+    echo "watcher: already running"
+  fi
+  exit 0
+fi
+trap 'fm_lock_release "$WATCH_LOCK"' EXIT
 
 # Portable stat. macOS (BSD) stat uses `-f <fmt>`; Linux (GNU) stat uses `-c <fmt>`.
 # Do NOT use the `stat -f <fmt> ... || stat -c <fmt> ...` fallback form: on Linux
@@ -112,14 +128,17 @@ while :; do
   # never run until the fleet went quiet. Checks are due only every
   # CHECK_INTERVAL, so most cycles skip this block and fall straight through.
   if [ "$(age_of "$STATE/.last-check")" -ge "$CHECK_INTERVAL" ]; then
-    touch "$STATE/.last-check"
     for c in "$STATE"/*.check.sh; do
       [ -e "$c" ] || continue
       out=$(run_check "$c")
       if [ -n "$out" ]; then
-        wake "check: $c: $out"
+        reason="check: $c: $out"
+        fm_wake_append check "$c" "$reason" || exit 1
+        touch "$STATE/.last-check"
+        wake "$reason"
       fi
     done
+    touch "$STATE/.last-check"
   fi
 
   # On the first changed signal, linger one grace period and re-scan before
@@ -134,12 +153,24 @@ while :; do
     files=""
     while IFS=$(printf '\t') read -r sf sig f; do
       [ -n "$sf" ] || continue
-      printf '%s' "$sig" > "$sf"
       case " $files " in *" $f "*) ;; *) files="$files $f" ;; esac
     done <<EOF
 $pending
 EOF
-    wake "signal:$files"
+    reason="signal:$files"
+    while IFS=$(printf '\t') read -r sf sig f; do
+      [ -n "$sf" ] || continue
+      fm_wake_append signal "$(basename "$f")" "$reason" || exit 1
+    done <<EOF
+$pending
+EOF
+    while IFS=$(printf '\t') read -r sf sig f; do
+      [ -n "$sf" ] || continue
+      printf '%s' "$sig" > "$sf"
+    done <<EOF
+$pending
+EOF
+    wake "$reason"
   fi
 
   # Layer 1 backbone: pane staleness. Two consecutive identical hashes with no busy
@@ -161,6 +192,7 @@ EOF
       # strings in displayed content cannot suppress stale detection.
       if [ "$n" -ge 2 ] && ! printf '%s' "$tail40" | grep -v '^[[:space:]]*$' | tail -6 | grep -qiE "$BUSY_REGEX"; then
         if [ "$(cat "$sf" 2>/dev/null || true)" != "$h" ]; then
+          fm_wake_append stale "$w" "stale: $w" || exit 1
           printf '%s' "$h" > "$sf"
           wake "stale: $w"
         fi
@@ -179,6 +211,7 @@ EOF
   hb=$(( HEARTBEAT * (1 << streak) ))
   [ "$hb" -gt "$HEARTBEAT_MAX" ] && hb=$HEARTBEAT_MAX
   if [ "$(age_of "$STATE/.last-heartbeat")" -ge "$hb" ]; then
+    fm_wake_append heartbeat heartbeat heartbeat || exit 1
     touch "$STATE/.last-heartbeat"
     wake "heartbeat"
   fi

--- a/tests/fm-wake-queue.test.sh
+++ b/tests/fm-wake-queue.test.sh
@@ -1,0 +1,305 @@
+#!/usr/bin/env bash
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WATCH="$ROOT/bin/fm-watch.sh"
+DRAIN="$ROOT/bin/fm-wake-drain.sh"
+LIB="$ROOT/bin/fm-wake-lib.sh"
+TMP_ROOT=
+
+fail() {
+  printf 'not ok - %s\n' "$1" >&2
+  exit 1
+}
+
+pass() {
+  printf 'ok - %s\n' "$1"
+}
+
+cleanup() {
+  if [ -n "${TMP_ROOT:-}" ]; then
+    rm -rf "$TMP_ROOT"
+  fi
+}
+
+trap cleanup EXIT
+
+TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/fm-wake-tests.XXXXXX")
+
+make_case() {
+  local name=$1 dir fakebin
+  dir="$TMP_ROOT/$name"
+  fakebin="$dir/fakebin"
+  mkdir -p "$dir/state" "$fakebin"
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+if [ "${1:-}" = "list-windows" ]; then
+  if [ -n "${FM_FAKE_TMUX_WINDOW:-}" ]; then
+    printf '%s\n' "$FM_FAKE_TMUX_WINDOW"
+  fi
+  exit 0
+fi
+if [ "${1:-}" = "capture-pane" ]; then
+  if [ -n "${FM_FAKE_TMUX_CAPTURE:-}" ]; then
+    cat "$FM_FAKE_TMUX_CAPTURE"
+  fi
+  exit 0
+fi
+exit 1
+SH
+  chmod +x "$fakebin/tmux"
+  printf '%s\n' "$dir"
+}
+
+append_wake() {
+  local state=$1 kind=$2 key=$3 payload=$4
+  (
+    export FM_STATE_OVERRIDE="$state"
+    # shellcheck disable=SC1090
+    . "$LIB"
+    fm_wake_append "$kind" "$key" "$payload"
+  )
+}
+
+wait_for_exit() {
+  local pid=$1 limit=${2:-50} i=0
+  while [ "$i" -lt "$limit" ]; do
+    if ! kill -0 "$pid" 2>/dev/null; then
+      wait "$pid"
+      return "$?"
+    fi
+    sleep 0.1
+    i=$((i + 1))
+  done
+  kill "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+  return 124
+}
+
+is_live_non_zombie() {
+  local pid=$1 stat
+  kill -0 "$pid" 2>/dev/null || return 1
+  stat=$(ps -p "$pid" -o stat= 2>/dev/null || true)
+  case "$stat" in
+    Z*) return 1 ;;
+  esac
+  return 0
+}
+
+hash_text() {
+  if command -v md5 >/dev/null 2>&1; then
+    printf '%s' "$1" | md5 -q
+  else
+    printf '%s' "$1" | md5sum | cut -d' ' -f1
+  fi
+}
+
+test_concurrent_append_and_drain() {
+  local dir state out1 out2 all pids i pid count unique malformed
+  dir=$(make_case concurrent)
+  state="$dir/state"
+  out1="$dir/drain-one.out"
+  out2="$dir/drain-two.out"
+  all="$dir/all.out"
+  pids=
+  i=1
+  while [ "$i" -le 40 ]; do
+    append_wake "$state" signal "status-$i" "signal: $state/status-$i.status" &
+    pids="$pids $!"
+    i=$((i + 1))
+  done
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$out1" &
+  pids="$pids $!"
+  for pid in $pids; do
+    wait "$pid" || fail "concurrent append/drain subprocess failed"
+  done
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$out2" || fail "final drain failed"
+  cat "$out1" "$out2" > "$all"
+  count=$(awk 'NF { count++ } END { print count + 0 }' "$all")
+  [ "$count" -eq 40 ] || fail "expected 40 drained records, got $count"
+  malformed=$(awk -F '\t' 'NF != 5 { bad++ } END { print bad + 0 }' "$all")
+  [ "$malformed" -eq 0 ] || fail "drained records had malformed fields"
+  unique=$(awk -F '\t' '{ keys[$4] = 1 } END { for (k in keys) count++; print count + 0 }' "$all")
+  [ "$unique" -eq 40 ] || fail "expected 40 unique keys, got $unique"
+  pass "concurrent append plus drain preserves queue records"
+}
+
+test_signal_catchup_without_running_watcher() {
+  local dir state fakebin out drain_out status_file
+  dir=$(make_case signal)
+  state="$dir/state"
+  fakebin="$dir/fakebin"
+  out="$dir/watch.out"
+  drain_out="$dir/drain.out"
+  status_file="$state/task.status"
+  printf 'working: first\n' > "$status_file"
+  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  wait_for_exit "$!" 40 || fail "watcher did not exit for first signal"
+  grep -F "signal: $status_file" "$out" >/dev/null || fail "watcher did not print first signal"
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$drain_out" || fail "drain after first signal failed"
+  grep "$(printf '\tsignal\t')" "$drain_out" | grep -F "$status_file" >/dev/null || fail "first signal was not queued"
+
+  printf 'done: second\n' >> "$status_file"
+  : > "$out"
+  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  wait_for_exit "$!" 40 || fail "watcher did not exit for second signal"
+  grep -F "signal: $status_file" "$out" >/dev/null || fail "signal written with no watcher was not caught"
+  pass "signal written while no watcher runs is caught on next run"
+}
+
+test_stale_enqueue_before_suppressor() {
+  local dir state fakebin out drain_out capture_file window key pane_hash
+  dir=$(make_case stale)
+  state="$dir/state"
+  fakebin="$dir/fakebin"
+  out="$dir/watch.out"
+  drain_out="$dir/drain.out"
+  capture_file="$dir/pane.txt"
+  window="test:fm-stale"
+  printf 'idle prompt' > "$capture_file"
+  key=$(printf '%s' "$window" | tr ':/.' '___')
+  pane_hash=$(hash_text "idle prompt")
+  printf '%s' "$pane_hash" > "$state/.hash-$key"
+  printf '1\n' > "$state/.count-$key"
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" FM_STATE_OVERRIDE="$state" FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  wait_for_exit "$!" 40 || fail "watcher did not exit for stale pane"
+  grep -Fx "stale: $window" "$out" >/dev/null || fail "watcher did not print stale wake"
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$drain_out" || fail "drain after stale wake failed"
+  grep "$(printf '\tstale\t')" "$drain_out" | grep -F "$window" >/dev/null || fail "stale wake was not queued"
+  [ "$(cat "$state/.stale-$key" 2>/dev/null || true)" = "$pane_hash" ] || fail "stale suppressor was not written"
+  pass "stale wake is queued before suppressor state is advanced"
+}
+
+test_check_output_is_queued() {
+  local dir state fakebin out drain_out check_file
+  dir=$(make_case check)
+  state="$dir/state"
+  fakebin="$dir/fakebin"
+  out="$dir/watch.out"
+  drain_out="$dir/drain.out"
+  check_file="$state/task.check.sh"
+  cat > "$check_file" <<'SH'
+#!/usr/bin/env bash
+printf 'merged: https://example.test/pr/1\n'
+SH
+  chmod +x "$check_file"
+  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=0 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  wait_for_exit "$!" 40 || fail "watcher did not exit for check output"
+  grep -F "check: $check_file: merged: https://example.test/pr/1" "$out" >/dev/null || fail "watcher did not print check wake"
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$drain_out" || fail "drain after check wake failed"
+  grep "$(printf '\tcheck\t')" "$drain_out" | grep -F "$check_file" | grep -F 'merged: https://example.test/pr/1' >/dev/null || fail "check wake was not queued"
+  [ -e "$state/.last-check" ] || fail "check cadence marker was not written after queue append"
+  pass "check output is queued before cadence suppression"
+}
+
+test_singleton_start() {
+  local dir state fakebin out1 out2 pid1 pid2 live
+  dir=$(make_case singleton)
+  state="$dir/state"
+  fakebin="$dir/fakebin"
+  out1="$dir/watch-one.out"
+  out2="$dir/watch-two.out"
+  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out1" &
+  pid1=$!
+  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out2" &
+  pid2=$!
+  sleep 0.5
+  live=0
+  is_live_non_zombie "$pid1" && live=$((live + 1))
+  is_live_non_zombie "$pid2" && live=$((live + 1))
+  [ "$live" -eq 1 ] || fail "expected exactly one live watcher, got $live"
+  grep -h 'watcher: already running pid ' "$out1" "$out2" >/dev/null || fail "second watcher did not report existing singleton"
+  kill "$pid1" "$pid2" 2>/dev/null || true
+  wait "$pid1" 2>/dev/null || true
+  wait "$pid2" 2>/dev/null || true
+  pass "simultaneous watcher starts leave exactly one live process"
+}
+
+test_atomic_double_drain() {
+  local dir state out1 out2 all count leftover
+  dir=$(make_case double-drain)
+  state="$dir/state"
+  out1="$dir/drain-one.out"
+  out2="$dir/drain-two.out"
+  all="$dir/all.out"
+  append_wake "$state" heartbeat heartbeat heartbeat || fail "heartbeat append failed"
+  append_wake "$state" signal task "signal: $state/task.status" || fail "signal append failed"
+  append_wake "$state" stale 's:fm-task' 'stale: s:fm-task' || fail "stale append failed"
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$out1" &
+  pid1=$!
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$out2" &
+  pid2=$!
+  wait "$pid1" || fail "first drain failed"
+  wait "$pid2" || fail "second drain failed"
+  cat "$out1" "$out2" > "$all"
+  count=$(awk 'NF { count++ } END { print count + 0 }' "$all")
+  [ "$count" -eq 3 ] || fail "two drains consumed records more than once or lost records; got $count"
+  leftover=$(FM_STATE_OVERRIDE="$state" "$DRAIN" | awk 'NF { count++ } END { print count + 0 }')
+  [ "$leftover" -eq 0 ] || fail "queue was not empty after double drain"
+  pass "two atomic drains cannot consume the same records twice"
+}
+
+test_drain_dedupes_obvious_duplicates() {
+  local dir state out count
+  dir=$(make_case dedupe)
+  state="$dir/state"
+  out="$dir/drain.out"
+  append_wake "$state" heartbeat heartbeat heartbeat || fail "first heartbeat append failed"
+  append_wake "$state" signal task.status "signal: $state/task.status" || fail "first signal append failed"
+  append_wake "$state" heartbeat heartbeat heartbeat || fail "second heartbeat append failed"
+  append_wake "$state" signal task.status "signal: $state/task.status $state/task.turn-ended" || fail "second signal append failed"
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$out" || fail "dedupe drain failed"
+  count=$(awk 'NF { count++ } END { print count + 0 }' "$out")
+  [ "$count" -eq 2 ] || fail "expected 2 deduped records, got $count"
+  grep "$(printf '\theartbeat\theartbeat\theartbeat')" "$out" >/dev/null || fail "heartbeat was not preserved"
+  grep "$(printf '\tsignal\ttask.status\t')" "$out" | grep -F "$state/task.turn-ended" >/dev/null || fail "latest signal payload was not preserved"
+  pass "drain collapses obvious duplicate heartbeat and signal records"
+}
+
+test_stale_watch_lock_reclaimed() {
+  local dir state fakebin out dead_pid pid live lock_pid
+  dir=$(make_case stale-lock)
+  state="$dir/state"
+  fakebin="$dir/fakebin"
+  out="$dir/watch.out"
+  dead_pid=999999
+  while kill -0 "$dead_pid" 2>/dev/null; do
+    dead_pid=$((dead_pid + 1))
+  done
+  mkdir "$state/.watch.lock"
+  printf '%s\n' "$dead_pid" > "$state/.watch.lock/pid"
+  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  sleep 0.5
+  live=0
+  is_live_non_zombie "$pid" && live=1
+  [ "$live" -eq 1 ] || fail "watcher did not reclaim stale lock and stay alive"
+  lock_pid=$(cat "$state/.watch.lock/pid" 2>/dev/null || true)
+  [ "$lock_pid" != "$dead_pid" ] || fail "stale watch lock pid was not replaced"
+  kill "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+  pass "killed watcher stale lock is reclaimed"
+}
+
+test_guard_warns_on_pending_queue() {
+  local dir state err
+  dir=$(make_case guard)
+  state="$dir/state"
+  err="$dir/guard.err"
+  printf 'project=x\n' > "$state/task.meta"
+  append_wake "$state" heartbeat heartbeat heartbeat || fail "guard heartbeat append failed"
+  FM_STATE_OVERRIDE="$state" FM_GUARD_GRACE=999999 "$ROOT/bin/fm-guard.sh" 2> "$err" >/dev/null || fail "guard failed"
+  grep -F 'queued wakes pending - drain them' "$err" >/dev/null || fail "guard did not warn about pending queue"
+  pass "guard warns when queued wakes are pending"
+}
+
+test_concurrent_append_and_drain
+test_signal_catchup_without_running_watcher
+test_stale_enqueue_before_suppressor
+test_check_output_is_queued
+test_singleton_start
+test_atomic_double_drain
+test_drain_dedupes_obvious_duplicates
+test_stale_watch_lock_reclaimed
+test_guard_warns_on_pending_queue

--- a/tests/fm-wake-queue.test.sh
+++ b/tests/fm-wake-queue.test.sh
@@ -311,6 +311,20 @@ test_guard_warns_on_pending_queue() {
   pass "guard warns when queued wakes are pending"
 }
 
+test_guard_rearms_after_draining_pending_queue() {
+  local dir state err
+  dir=$(make_case guard-order)
+  state="$dir/state"
+  err="$dir/guard.err"
+  printf 'project=x\n' > "$state/task.meta"
+  append_wake "$state" heartbeat heartbeat heartbeat || fail "guard heartbeat append failed"
+  FM_STATE_OVERRIDE="$state" FM_GUARD_GRACE=1 "$ROOT/bin/fm-guard.sh" 2> "$err" >/dev/null || fail "guard failed"
+  grep -F 'queued wakes pending - drain them' "$err" >/dev/null || fail "guard did not warn about pending queue"
+  grep -F 'After draining queued wakes, re-arm the watcher' "$err" >/dev/null || fail "guard did not order re-arm after drain"
+  ! grep -F 'Restart it NOW, before anything else' "$err" >/dev/null || fail "guard still gave conflicting restart-first instruction"
+  pass "guard orders watcher re-arm after queued wake drain"
+}
+
 test_concurrent_append_and_drain
 test_signal_catchup_without_running_watcher
 test_stale_enqueue_before_suppressor
@@ -321,3 +335,4 @@ test_drain_dedupes_obvious_duplicates
 test_stale_watch_lock_reclaimed
 test_live_stale_watch_lock_is_actionable
 test_guard_warns_on_pending_queue
+test_guard_rearms_after_draining_pending_queue

--- a/tests/fm-wake-queue.test.sh
+++ b/tests/fm-wake-queue.test.sh
@@ -282,6 +282,23 @@ test_stale_watch_lock_reclaimed() {
   pass "killed watcher stale lock is reclaimed"
 }
 
+test_live_stale_watch_lock_is_actionable() {
+  local dir state fakebin out err status
+  dir=$(make_case live-stale-lock)
+  state="$dir/state"
+  fakebin="$dir/fakebin"
+  out="$dir/watch.out"
+  err="$dir/watch.err"
+  mkdir "$state/.watch.lock"
+  printf '%s\n' "$$" > "$state/.watch.lock/pid"
+  touch -t 200001010000 "$state/.last-watcher-beat"
+  status=0
+  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_GUARD_GRACE=1 FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" 2> "$err" || status=$?
+  [ "$status" -ne 0 ] || fail "watcher silently no-opped behind a live stale holder"
+  grep -F 'heartbeat is stale' "$err" >/dev/null || fail "watcher did not explain the stale live lock"
+  pass "live watcher lock with stale heartbeat is actionable"
+}
+
 test_guard_warns_on_pending_queue() {
   local dir state err
   dir=$(make_case guard)
@@ -302,4 +319,5 @@ test_singleton_start
 test_atomic_double_drain
 test_drain_dedupes_obvious_duplicates
 test_stale_watch_lock_reclaimed
+test_live_stale_watch_lock_is_actionable
 test_guard_warns_on_pending_queue


### PR DESCRIPTION
## Intent

Implement Phase 1 of GitHub issue kunchenguid/firstmate#27 for firstmate supervision reliability. Preserve the current one-shot watcher model while adding a durable tab-separated state/.wake-queue, atomic fm-wake-drain.sh, portable mkdir-based watcher singleton and queue locks, enqueue-before-suppress semantics for signal/stale/check/heartbeat wake paths, guard warnings for pending queued wakes, and minimal AGENTS.md/README documentation noting P2/P3 are deferred. Add fast behavior tests using temp state roots for concurrent append/drain safety, catch-up signals, stale enqueue ordering, singleton enforcement, atomic drain dedupe, stale lock reclaim, guard warning behavior, plus CI coverage for those tests.

## What Changed

- Added a durable tab-separated `state/.wake-queue` with locked enqueue/drain helpers so watcher wakes are recorded before suppression markers advance and can be recovered atomically after interruptions.
- Hardened watcher and guard behavior around singleton locks, stale heartbeat recovery, queued wake warnings, and recovery ordering so operators drain pending wakes before re-arming supervision.
- Documented the queued wake recovery flow and added focused shell tests plus CI coverage for queue safety, watcher catch-up paths, stale lock handling, and guard warnings.

## Risk Assessment

✅ Low: Captain, the change is well-bounded to watcher queueing and documentation, and I did not identify material correctness or recovery regressions in the diff.

## Testing

Inspected the watcher, guard, drain, CI, and docs changes, ran the focused wake-queue behavior suite via both shell and exact CI-style invocation, and produced a manual CLI transcript showing catch-up signal detection, durable queue persistence, guard warning, drain dedupe, and empty queue after drain; all checks passed.

<details>
<summary>Evidence: Behavior test output</summary>

```text
ok - concurrent append plus drain preserves queue records
ok - signal written while no watcher runs is caught on next run
ok - stale wake is queued before suppressor state is advanced
ok - check output is queued before cadence suppression
ok - simultaneous watcher starts leave exactly one live process
ok - two atomic drains cannot consume the same records twice
ok - drain collapses obvious duplicate heartbeat and signal records
ok - killed watcher stale lock is reclaimed
ok - live watcher lock with stale heartbeat is actionable
ok - guard warns when queued wakes are pending
ok - guard orders watcher re-arm after queued wake drain
```
</details>
<details>
<summary>Evidence: Manual wake-queue CLI transcript</summary>

```text
Manual durable wake queue CLI verification
State root: /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVJ1ZJZWJWZZ3RN96XFWP4JF/wakequeue-signal-e2e/state

$ printf status > state/task.status  # done while no watcher process is running
status: done: queued while no watcher process was running

$ PATH=<fake tmux> FM_STATE_OVERRIDE=<state> bin/fm-watch.sh
watcher stdout: signal: /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVJ1ZJZWJWZZ3RN96XFWP4JF/wakequeue-signal-e2e/state/task.status

$ cat state/.wake-queue  # before drain
queue-before: 1781944964	1	signal	task.status	signal: /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVJ1ZJZWJWZZ3RN96XFWP4JF/wakequeue-signal-e2e/state/task.status
queue-before: 1781944964	2	signal	task.status	signal: /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVJ1ZJZWJWZZ3RN96XFWP4JF/wakequeue-signal-e2e/state/task.status

$ FM_STATE_OVERRIDE=<state> FM_GUARD_GRACE=999999 bin/fm-guard.sh 2>&1
guard stderr: WARNING: queued wakes pending - drain them with bin/fm-wake-drain.sh before anything else.

$ FM_STATE_OVERRIDE=<state> bin/fm-wake-drain.sh
drain stdout: 1781944964	2	signal	task.status	signal: /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVJ1ZJZWJWZZ3RN96XFWP4JF/wakequeue-signal-e2e/state/task.status

$ test ! -s state/.wake-queue && printf "queue empty"
queue empty
```
</details>
<details>
<summary>Evidence: Queued signal before drain</summary>

```text
1781944964	1	signal	task.status	signal: /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVJ1ZJZWJWZZ3RN96XFWP4JF/wakequeue-signal-e2e/state/task.status
1781944964	2	signal	task.status	signal: /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVJ1ZJZWJWZZ3RN96XFWP4JF/wakequeue-signal-e2e/state/task.status
```
</details>
<details>
<summary>Evidence: Drain output after dedupe</summary>

```text
1781944964	2	signal	task.status	signal: /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVJ1ZJZWJWZZ3RN96XFWP4JF/wakequeue-signal-e2e/state/task.status
```
</details>
<details>
<summary>Evidence: Guard pending-queue warning</summary>

```text
WARNING: queued wakes pending - drain them with bin/fm-wake-drain.sh before anything else.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (2) ✅</summary>

- ⚠️ `bin/fm-watch.sh:22` - The singleton path trusts any live PID in `.watch.lock` and exits before checking whether the watcher heartbeat is stale. If the current watcher is alive but wedged, the guard will tell the operator to re-arm the watcher, but every re-arm attempt just prints `already running`, leaving supervision without a working watcher. Reclaim based on a stale heartbeat or return an actionable failure instead of silently no-oping.
- ⚠️ `AGENTS.md:196` - The recovery checklist drains queued wakes only after reading status files, peeking orphan panes, and surfacing decisions. That conflicts with the new section 8 rule that recovery must drain the durable queue first, so a restarted agent can still consume state out of order. Move `fm-wake-drain.sh` ahead of the status/pane reads in this checklist.

🔧 Fix: Captain, harden watcher recovery flow
2 warnings still open:
- ⚠️ `bin/fm-guard.sh:36` - When queued wakes exist and the watcher beacon is also stale or missing, the guard now prints both &#34;drain them ... before anything else&#34; and the old final &#34;Restart it NOW, before anything else&#34; instruction. That is the main missed-wake recovery path, so the tool gives contradictory ordering and can steer the operator to re-arm before draining the durable queue. Make the liveness instruction conditional, for example: drain queued wakes first, then re-arm the watcher.
- ⚠️ `AGENTS.md:188` - The recovery checklist drains and removes queued wake records before acquiring the single-firstmate session lock. If a restarted or secondary firstmate session runs this while another live session holds `state/.lock`, it can consume that session&#39;s wake queue and only then discover it must operate read-only. Acquire the session lock before the destructive drain, while still draining before pane/status inspection.

🔧 Fix: Captain, fix queued wake recovery ordering
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-wake-queue.test.sh`
- `tests/fm-wake-queue.test.sh`
- <code>Manual CLI scenario with `FM_STATE_OVERRIDE=/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVJ1ZJZWJWZZ3RN96XFWP4JF/wakequeue-signal-e2e/state`: created `task.status` while no watcher was running, ran `bin/fm-watch.sh`, inspected `state/.wake-queue`, ran `bin/fm-guard.sh`, drained with `bin/fm-wake-drain.sh`, and verified the queue was empty</code>
- <code>`git status --short --ignored` to confirm testing left no transient files in the worktree</code>

</details>

<details>
<summary>⚠️ **Document** - 1 error</summary>

- 🚨 Captain, I’m blocked by conflicting instructions: AGENTS.md says I must not edit worktrees directly and must delegate project-specific work, while this task explicitly requires documentation-only edits in the current worktree. Please confirm whether I should make the docs edits here or stop without modifying the worktree.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
