### PR TITLE
fix(teardown): allow teardown when work is on any remote (incl. fork), not just local main

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ Hard rules, in priority order:
    The one standing, captain-authorized relaxation is a project's `yolo` flag (section 7): with `yolo` on, firstmate makes routine approval decisions itself, but anything destructive, irreversible, or security-sensitive still escalates to the captain.
 3. **Never tear down a worktree that holds unlanded work.**
    `bin/fm-teardown.sh` enforces this; never bypass it with `--force` unless the captain explicitly said to discard the work.
-   For PR-based ship tasks, the work must be on a remote; for `local-only` ship tasks, it must be merged into the local default branch.
+   The work is "landed" once `HEAD` is reachable from any remote-tracking branch (a fork counts as a remote - upstream-contribution PRs pushed to a fork satisfy this in any mode); for `local-only` ship tasks with no remote at all, the work may instead be merged into the local default branch.
    The scout carve-out: a scout task's worktree is declared scratch from the start - its deliverable is the report, and teardown lets the worktree go once that report exists (section 7).
 4. **Crewmates never address the captain.**
    All crewmate communication flows through you.
@@ -381,7 +381,7 @@ A ship task's path from `done` to landed on `main` is set by the project's `mode
 
 - **no-mistakes** - the stages below as written: no-mistakes validation pipeline -> PR -> captain merge.
 - **direct-PR** - no pipeline. The crewmate pushes and opens the PR itself (its brief says so) and reports `done: PR <url>`. Skip the Validate step and go straight to PR ready (run `fm-pr-check`, relay the PR). Teardown uses the normal pushed-branch check.
-- **local-only** - no remote, no PR. The crewmate stops at `done: ready in branch fm/<id>`. Review the diff with `bin/fm-review-diff.sh <id>`, relay a one-paragraph summary to the captain, and on approval run `bin/fm-merge-local.sh <id>` to fast-forward local `main` (it refuses anything but a clean fast-forward - if it does, have the crewmate rebase). No `fm-pr-check`. Then teardown, whose safety check requires the branch already merged into local `main`.
+- **local-only** - no remote, no PR. The crewmate stops at `done: ready in branch fm/<id>`. Review the diff with `bin/fm-review-diff.sh <id>`, relay a one-paragraph summary to the captain, and on approval run `bin/fm-merge-local.sh <id>` to fast-forward local `main` (it refuses anything but a clean fast-forward - if it does, have the crewmate rebase). No `fm-pr-check`. Then teardown, whose safety check requires the branch already merged into local `main`, OR the work pushed to any remote (a fork counts - relevant for upstream-contribution PRs on a local-only-registered project).
 
 When reviewing any crewmate branch diff, use `bin/fm-review-diff.sh <id>` rather than `git diff <default>...branch` directly.
 Pooled clones keep their local default refs frozen at clone time and can lag `origin`; the helper always compares against the authoritative base.

--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ for test_script in tests/*.test.sh; do "$test_script"; done   # behavior tests, 
 tests/fm-wake-queue.test.sh               # durable wake queue, singleton behavior, sub-supervisor classifier, and /afk presence-gating tests
 tests/fm-afk-inject-e2e.test.sh           # private-socket end-to-end test of the afk injection path (partial-input deferral, swallowed-Enter retry)
 tests/fm-secondmate.test.sh               # persistent secondmate routing, seeding, spawn, recovery, teardown, and FM_HOME tests
+tests/fm-teardown.test.sh                 # fm-teardown.sh unpushed-work safety check: local-only fork-remote allow, truly-unpushed refuse, merged-to-main allow, no-mistakes regression, --force override
 [ "$(readlink CLAUDE.md)" = "AGENTS.md" ]
 [ "$(readlink .claude/skills)" = "../.agents/skills" ]
 FM_HEARTBEAT=2 FM_POLL=1 bin/fm-watch.sh  # watcher smoke test (prints "heartbeat")

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -4,7 +4,11 @@
 # the project's clone for PR-based ship tasks, then print a backlog-refresh
 # reminder.
 # REFUSES if the worktree holds work not on any remote, because treehouse return
-# hard-resets the worktree and kills its processes.
+# hard-resets the worktree and kills its processes. A fork counts as a remote,
+# so upstream-contribution PRs pushed to a fork satisfy this in any mode.
+# local-only projects additionally accept work merged into the local default
+# branch (firstmate performs that merge on the captain's approval) as a fallback
+# for the common case where there is no remote at all.
 # Scout tasks (kind=scout in meta) carve out of that check: their worktree is
 # declared scratch and the report at data/<task-id>/report.md is the work
 # product - teardown proceeds once the report exists, and refuses without it.
@@ -374,25 +378,28 @@ if [ -d "$WT" ] && [ "$FORCE" != "--force" ]; then
       echo "The report is the work product. Have the crewmate write it (or get the captain's explicit OK to discard, then --force)." >&2
       exit 1
     fi
-  elif [ "$MODE" = local-only ]; then
-    # local-only ships have no remote, so the "on a remote" test never passes.
-    # The work is safe once it is merged into the local default branch (firstmate
-    # does that merge on the captain's approval). Refuse until then.
-    DEFAULT=$(default_branch) || { echo "REFUSED: cannot determine default branch for $PROJ; expected origin/HEAD, main, or master." >&2; exit 1; }
-    dirty=$(git -C "$WT" status --porcelain 2>/dev/null | grep -vE '^\?\? \.claude/' | head -1 || true)
-    unmerged=$(git -C "$WT" log --oneline HEAD --not "$DEFAULT" -- 2>/dev/null | head -5 || true)
-    if [ -n "$dirty" ] || [ -n "$unmerged" ]; then
-      echo "REFUSED: local-only worktree $WT has work not yet merged into $DEFAULT." >&2
-      [ -n "$dirty" ] && echo "uncommitted changes present" >&2
-      [ -n "$unmerged" ] && printf 'commits not yet on %s:\n%s\n' "$DEFAULT" "$unmerged" >&2
-      echo "Merge the branch into local $DEFAULT first (bin/fm-merge-local.sh after the captain approves), or get the captain's explicit OK to discard, then --force." >&2
-      exit 1
-    fi
   else
     # The fm-spawn hook file is ours, never work product; ignore it in the dirty check.
     dirty=$(git -C "$WT" status --porcelain 2>/dev/null | grep -vE '^\?\? \.claude/' | head -1 || true)
+    # A worktree's work is "safely on a remote" once HEAD is reachable from ANY
+    # remote-tracking branch (empty result here). A fork is a remote too, so
+    # upstream-contribution PRs pushed to a fork satisfy this regardless of mode.
     unpushed=$(git -C "$WT" log --oneline HEAD --not --remotes -- 2>/dev/null | head -5 || true)
-    if [ -n "$dirty" ] || [ -n "$unpushed" ]; then
+    if [ -n "$unpushed" ] && [ "$MODE" = local-only ]; then
+      # local-only ships have no remote in the common case, so the "on a remote"
+      # test above is expected to be non-empty. The work is safe once it is merged
+      # into the local default branch (firstmate does that merge on the captain's
+      # approval). Refuse until then.
+      DEFAULT=$(default_branch) || { echo "REFUSED: cannot determine default branch for $PROJ; expected origin/HEAD, main, or master." >&2; exit 1; }
+      unmerged=$(git -C "$WT" log --oneline HEAD --not "$DEFAULT" -- 2>/dev/null | head -5 || true)
+      if [ -n "$dirty" ] || [ -n "$unmerged" ]; then
+        echo "REFUSED: local-only worktree $WT has work not yet merged into $DEFAULT and not on any remote." >&2
+        [ -n "$dirty" ] && echo "uncommitted changes present" >&2
+        [ -n "$unmerged" ] && printf 'commits not yet on %s:\n%s\n' "$DEFAULT" "$unmerged" >&2
+        echo "Merge the branch into local $DEFAULT first (bin/fm-merge-local.sh after the captain approves), or push to a fork/remote, or get the captain's explicit OK to discard, then --force." >&2
+        exit 1
+      fi
+    elif [ -n "$dirty" ] || [ -n "$unpushed" ]; then
       echo "REFUSED: worktree $WT has work not on any remote." >&2
       [ -n "$dirty" ] && echo "uncommitted changes present" >&2
       [ -n "$unpushed" ] && printf 'unpushed commits:\n%s\n' "$unpushed" >&2

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+# Tests for bin/fm-teardown.sh's unpushed-work safety check.
+#
+# Covers the local-only fork-remote fix: a local-only-registered project whose
+# task pushes its work to a fork (upstream-contribution PRs) must be teardown-
+# eligible because a fork IS a remote. The pre-fix code short-circuited to a
+# strict local-main check and false-refused legitimate fork-pushed work.
+#
+# Matrix:
+#   (a) local-only + HEAD on a fork remote-tracking branch     -> ALLOW  (the fix)
+#   (b) local-only + truly unpushed work (no remote, not main) -> REFUSE (safety)
+#   (c) local-only + merged into local main, no remote         -> ALLOW  (no regression)
+#   (d) no-mistakes  + HEAD on origin remote-tracking branch   -> ALLOW  (no regression)
+#   (e) no-mistakes  + truly unpushed work                     -> REFUSE (no regression)
+#   (f) local-only + truly unpushed + --force                  -> ALLOW  (escape hatch)
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TEARDOWN="$ROOT/bin/fm-teardown.sh"
+TMP_ROOT=
+
+fail() {
+  printf 'not ok - %s\n' "$1" >&2
+  exit 1
+}
+
+pass() {
+  printf 'ok - %s\n' "$1"
+}
+
+cleanup() {
+  if [ -n "${TMP_ROOT:-}" ]; then
+    rm -rf "$TMP_ROOT"
+  fi
+}
+
+trap cleanup EXIT
+
+TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/fm-teardown-tests.XXXXXX")
+
+# Build a fresh sandbox for one test case. Sets up:
+#   $CASE/state/        - firstmate state dir (with a fresh watcher beacon)
+#   $CASE/fakebin/      - mocks for treehouse, tmux (PATH-prepended by caller)
+#   $CASE/origin.git/   - bare upstream repo (so the project clone has origin)
+#   $CASE/project/      - clone of origin; acts as the firstmate project dir
+#   $CASE/wt/           - a worktree of the project (the task worktree)
+# Echoes the case dir.
+make_case() {
+  local name=$1 case_dir fakebin
+  case_dir="$TMP_ROOT/$name"
+  fakebin="$case_dir/fakebin"
+  mkdir -p "$case_dir/state" "$fakebin"
+
+  # Mocks for the post-check teardown steps. Refuse logic exits before these
+  # run; the ALLOW cases need them so the script can complete cleanly.
+  cat > "$fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+# `treehouse return --force <wt>`: succeed silently.
+exit 0
+SH
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+# tmux kill-window etc.: succeed silently.
+exit 0
+SH
+  chmod +x "$fakebin/treehouse" "$fakebin/tmux"
+
+  # Bare origin so the clone has an `origin` remote and origin/HEAD.
+  git init -q --bare "$case_dir/origin.git"
+  git -C "$case_dir/origin.git" symbolic-ref HEAD refs/heads/main
+  # Seed origin with one commit BEFORE cloning so the clone is not empty.
+  git clone -q "$case_dir/origin.git" "$case_dir/_seed" 2>/dev/null
+  git -C "$case_dir/_seed" -c user.email=t@t -c user.name=t \
+    commit -q --allow-empty -m "origin baseline"
+  git -C "$case_dir/_seed" push -q origin main
+  rm -rf "$case_dir/_seed"
+  # Clone as the project; give it a `main` branch and an origin/HEAD.
+  git clone -q "$case_dir/origin.git" "$case_dir/project"
+  git -C "$case_dir/project" remote set-head origin main 2>/dev/null || true
+  # Add a worktree on a fresh task branch; that branch is where the crewmate commits.
+  git -C "$case_dir/project" worktree add -q -b fm/task-x1 "$case_dir/wt" main
+
+  # Fresh watcher beacon so fm-guard stays quiet.
+  touch "$case_dir/state/.last-watcher-beat"
+
+  printf '%s\n' "$case_dir"
+}
+
+# Write a meta file for the task. Args: case_dir mode kind
+write_meta() {
+  local case_dir=$1 mode=$2 kind=$3
+  cat > "$case_dir/state/task-x1.meta" <<EOF
+window=fm-task-x1
+worktree=$case_dir/wt
+project=$case_dir/project
+kind=$kind
+mode=$mode
+EOF
+}
+
+# Commit something on the worktree's task branch. Args: case_dir [message]
+wt_commit() {
+  local case_dir=$1 msg=${2:-wt work}
+  git -C "$case_dir/wt" -c user.email=t@t -c user.name=t \
+    commit -q --allow-empty -m "$msg"
+}
+
+# Add a fork bare repo and register it as a remote on the project, then push
+# the worktree's task branch to it and fetch into the project so the worktree
+# sees the remote-tracking ref. Args: case_dir
+add_fork_with_pushed_branch() {
+  local case_dir=$1
+  git init -q --bare "$case_dir/fork.git"
+  git -C "$case_dir/project" remote add fork "$case_dir/fork.git"
+  # Push the task branch from the worktree to the fork, then fetch into project
+  # so refs/remotes/fork/fm-task-x1 is visible from the worktree (shared object db).
+  git -C "$case_dir/wt" push -q fork fm/task-x1
+  git -C "$case_dir/project" fetch -q fork
+}
+
+# Run teardown with PATH mocking. Args: case_dir [extra args...]
+run_teardown() {
+  local case_dir=$1; shift
+  FM_ROOT_OVERRIDE="$ROOT" \
+  FM_STATE_OVERRIDE="$case_dir/state" \
+  PATH="$case_dir/fakebin:$PATH" \
+    "$TEARDOWN" task-x1 "$@"
+}
+
+# Exit code expectation. Args: expected actual label
+expect_code() {
+  local expected=$1 actual=$2 label=$3
+  [ "$actual" = "$expected" ] || fail "$label: expected exit $expected, got $actual"
+}
+
+test_local_only_fork_remote_allows() {
+  local case_dir rc
+  case_dir=$(make_case fork-allow)
+  write_meta "$case_dir" local-only ship
+  wt_commit "$case_dir" "fix the thing"
+  add_fork_with_pushed_branch "$case_dir"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "fork-allow: teardown should succeed when HEAD is on a fork remote"
+  ! grep -q REFUSED "$case_dir/stderr" || fail "fork-allow: teardown printed a REFUSED line"
+  pass "local-only worktree with HEAD on a fork remote is torn down (fix holds)"
+}
+
+test_local_only_truly_unpushed_refuses() {
+  local case_dir rc
+  case_dir=$(make_case truly-unpushed)
+  write_meta "$case_dir" local-only ship
+  wt_commit "$case_dir" "unpushed work"
+  # No fork, no push to origin, not merged into main.
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "truly-unpushed: teardown should refuse"
+  grep -q REFUSED "$case_dir/stderr" || fail "truly-unpushed: no REFUSED line in stderr"
+  pass "local-only worktree with truly unpushed work is refused (safety preserved)"
+}
+
+test_local_only_merged_to_local_main_allows() {
+  local case_dir rc
+  case_dir=$(make_case merged-main)
+  write_meta "$case_dir" local-only ship
+  wt_commit "$case_dir" "merged work"
+  # Fast-forward the project's main to the worktree's HEAD commit so HEAD is
+  # reachable from main. update-ref works whether or not main is checked out,
+  # and the worktree shares the project's object db so the commit is visible.
+  local wt_head
+  wt_head=$(git -C "$case_dir/wt" rev-parse HEAD)
+  git -C "$case_dir/project" update-ref refs/heads/main "$wt_head"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "merged-main: teardown should succeed when work is merged into local main"
+  ! grep -q REFUSED "$case_dir/stderr" || fail "merged-main: teardown printed a REFUSED line"
+  pass "local-only worktree with work merged into local main is torn down (no regression)"
+}
+
+test_no_mistakes_origin_remote_allows() {
+  local case_dir rc
+  case_dir=$(make_case nm-origin)
+  write_meta "$case_dir" no-mistakes ship
+  wt_commit "$case_dir" "shippable work"
+  # Push the task branch to origin and fetch so the worktree sees it.
+  git -C "$case_dir/wt" push -q origin fm/task-x1
+  git -C "$case_dir/project" fetch -q origin
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "nm-origin: teardown should succeed when HEAD is on origin"
+  ! grep -q REFUSED "$case_dir/stderr" || fail "nm-origin: teardown printed a REFUSED line"
+  pass "no-mistakes worktree with HEAD on origin is torn down (no regression)"
+}
+
+test_no_mistakes_truly_unpushed_refuses() {
+  local case_dir rc
+  case_dir=$(make_case nm-unpushed)
+  write_meta "$case_dir" no-mistakes ship
+  wt_commit "$case_dir" "unpushed work"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "nm-unpushed: teardown should refuse"
+  grep -q REFUSED "$case_dir/stderr" || fail "nm-unpushed: no REFUSED line in stderr"
+  pass "no-mistakes worktree with truly unpushed work is refused (no regression)"
+}
+
+test_local_only_force_overrides_unpushed() {
+  local case_dir rc
+  case_dir=$(make_case force-override)
+  write_meta "$case_dir" local-only ship
+  wt_commit "$case_dir" "unpushed work"
+
+  set +e
+  run_teardown "$case_dir" --force > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "force-override: --force should bypass the unpushed-work check"
+  ! grep -q REFUSED "$case_dir/stderr" || fail "force-override: REFUSED printed despite --force"
+  pass "local-only worktree with unpushed work is torn down under --force (escape hatch)"
+}
+
+test_local_only_fork_remote_allows
+test_local_only_truly_unpushed_refuses
+test_local_only_merged_to_local_main_allows
+test_no_mistakes_origin_remote_allows
+test_no_mistakes_truly_unpushed_refuses
+test_local_only_force_overrides_unpushed


### PR DESCRIPTION
## What

Fixes `bin/fm-teardown.sh`'s local-only false-refuse: when a project is registered `[local-only]` but a task pushes its work to a **fork** (upstream-contribution PRs), teardown refused with "work not on main" even though the work IS safely on the fork remote. The local-only branch short-circuited to a strict local-main check before the `git log HEAD --not --remotes` check ran, so legitimate fork-pushed work looked unlanded.

## Motivation

This bug bit us **3× this session**:
- `no-mistakes` teardown false-refused **twice** during this session's 8-PR upstream-contribution batch (projects registered `local-only` whose work was shipped via fork PRs to upstream).
- A **treehouse orphan** got stuck behind the same false refuse.

In each case the work was safely on a fork remote, but teardown demanded a local-main merge that does not exist for upstream-contribution workflows.

## The fix

Unify the safety check across modes. `git log HEAD --not --remotes` (empty == `HEAD` reachable from any remote-tracking branch) becomes the **primary** gate for **every** mode — and a fork IS a remote. The local-main check now runs **only as a fallback** for `local-only` projects whose work is genuinely on no remote at all.

Safety properties preserved:
- Truly unpushed work (on no remote at all) is still REFUSED.
- `--force` escape hatch is unchanged (still requires the captain's explicit discard word).
- `no-mistakes` and `direct-PR` mode behavior is unchanged (they always used the `--remotes` check).

Files:
- `bin/fm-teardown.sh` — the fix; also teaches the script to honor `FM_ROOT_OVERRIDE` / `FM_STATE_OVERRIDE` like its siblings (`fm-guard.sh`, `fm-watch.sh`), which is what makes it testable in isolation.
- `tests/fm-teardown.test.sh` — new. Covers all six cases (fork-remote allow, truly-unpushed refuse, merged-to-main allow, `no-mistakes` origin allow, `no-mistakes` unpushed refuse, `--force` override). Wired into `.github/workflows/ci.yml`.
- `.github/workflows/ci.yml` — runs `tests/fm-teardown.test.sh` in the Behavior tests job alongside `tests/fm-wake-queue.test.sh`.
- `README.md` — lists `tests/fm-teardown.test.sh` in the behavior-test index.
- `AGENTS.md` — rule #3 and the local-only delivery-mode section both reflect that a fork counts as a remote in any mode.

## Verification

- `bash tests/fm-teardown.test.sh` — 6/6 ok
- `bash tests/fm-wake-queue.test.sh` — 26/26 ok (no regression)
- `shellcheck bin/fm-teardown.sh tests/fm-teardown.test.sh` — clean

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

> Note: the no-mistakes pipeline ran the full intent/rebase/review/test/document/lint gates on this change (all green; one review fix round applied by the no-mistakes agents is commit `79a8d44`, which wired the new test into CI and README after captain approval). The no-mistakes **push/pr** steps could not complete in this environment because no-mistakes is hard-bound to its recorded remote `kunchenguid/firstmate` (403 for the `e-jung` contributor) and cannot drive a fork→upstream cross-repo PR, so the branch was pushed to the `e-jung/firstmate` fork and this PR opened manually. The change is no-mistakes-validated; the CI gates below (Require no-mistakes, CI lint/tests/invariants) re-verify it on the PR.

AI disclosure: Human-reviewed. The fix design, the safety-property analysis, the test matrix, and the AGENTS.md wording were authored by the captain's crewmate; the CI/README wiring was applied by the no-mistakes pipeline under explicit captain approval.