### PR TITLE
fix: remind supervisors to refresh backlog after teardown

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -364,7 +364,7 @@ bin/fm-teardown.sh <id>
 The script refuses if the worktree holds unpushed work; treat a refusal as a stop-and-investigate, not an obstacle.
 Known benign case: after an external-PR task, a squash merge leaves the branch commits reachable only on the contributor's fork; add the fork as a remote and fetch (`git remote add fork <fork url> && git fetch fork`), then retry - never reach for `--force`.
 After a successful PR-based teardown, it also runs `bin/fm-fleet-sync.sh` for that project, best-effort, so the clone's local default catches up to the merge and the just-merged branch, now gone on the remote and free of its worktree, is pruned immediately.
-Then move the task to Done in `data/backlog.md` (with the full `https://...` PR URL or local merge note and date), re-evaluate the queue, and dispatch anything that was blocked on this task.
+Then move the task to Done in `data/backlog.md` (with the full `https://...` PR URL or local merge note and date), keep Done to the 10 most recent, re-evaluate the queue, and dispatch anything that was blocked on this task or is now time/date-due.
 
 ### Scout tasks (report instead of PR)
 
@@ -373,7 +373,7 @@ A scout task follows Intake, Spawn, and Supervise exactly as above - scaffold th
 - There is no Validate or PR-ready stage. When the crewmate's status says `done`, read `data/<id>/report.md`.
 - Relay the findings to the captain: plain chat for a focused answer, lavish-axi when the report has structure worth a visual (multiple findings, options, a plan).
 - Tear down immediately - no merge gate. `bin/fm-teardown.sh` allows a scout worktree's scratch commits and dirty files once the report exists; if the report is missing, it refuses, because the findings are the work product.
-- Record it in Done with the report path instead of a PR link.
+- Record it in Done with the report path instead of a PR link, keep Done to the 10 most recent, then re-evaluate the queue and dispatch anything unblocked or now time/date-due.
 
 **Promotion.** When a scout's findings reveal shippable work (a reproduced bug with a clear fix) and the captain wants it shipped, promote the task in place instead of respawning: run `bin/fm-promote.sh <id>` (flips `kind=` to ship in meta, restoring teardown's full protection), then send the crewmate its ship instructions - inventory scratch state, reset to a clean default-branch base, carry over only intended fix changes, create branch `fm/<id>`, implement, and report `done` according to the project's delivery mode.
 The crewmate keeps its worktree, loaded context, and repro, but the ship branch must start from a clean base with only intended changes; scratch commits and debug edits from the scout phase never ride along.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -486,7 +486,7 @@ Update it on every dispatch, completion, and decision.
 - [x] <id> - <one line> - data/<id>/report.md (reported <date>)
 ```
 
-Re-evaluate Queued on every teardown and every heartbeat: anything whose blocker is gone gets dispatched.
+Re-evaluate Queued on every teardown and every heartbeat: anything whose blocker is gone gets dispatched, and time/date-gated items whose date has arrived get dispatched too.
 
 Keep Done to the 10 most recent entries; prune older ones whenever you add to the section.
 Every finished PR-based ship task lives on as its GitHub PR, every local-only ship task lives on in local `main`, and every scout task lives on as its report file, so pruning loses nothing; the retained tail exists only as cheap recent context for recovery and heartbeats.

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ The first mate drives these; you rarely need to, but they work by hand too.
 | `fm-peek.sh`             | Print a bounded tail of a crewmate pane                                                                             |
 | `fm-pr-check.sh`         | Record a PR-ready task and arm the watcher's merge poll                                                             |
 | `fm-promote.sh`          | Promote a scout task in place so it becomes a protected ship task                                                   |
-| `fm-teardown.sh`         | Return the worktree and kill the window; protects ship work and requires scout reports                              |
+| `fm-teardown.sh`         | Return the worktree and kill the window; protects ship work, requires scout reports, and reminds backlog refresh    |
 | `fm-harness.sh`          | Detect the running harness; resolve the effective crewmate harness                                                  |
 | `fm-lock.sh`             | Single-firstmate session lock                                                                                       |
 

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -103,3 +103,4 @@ if [ "$KIND" != scout ] && [ "$MODE" != local-only ]; then
   "$FM_ROOT/bin/fm-fleet-sync.sh" "$PROJ" || true
 fi
 echo "teardown $ID complete (window $T, worktree $WT)"
+printf '%s\n' "🌱 Backlog: $ID just finished. Update data/backlog.md - move $ID to Done (keep Done to the 10 most recent), then re-scan Queued for items now unblocked (a \"blocked-by: $ID\" may have just cleared) or now time-due, and dispatch what's ready."

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Tear down a finished task: return the treehouse worktree, kill the tmux window,
-# clear volatile state, then refresh/prune the project's clone for PR-based ship tasks.
+# clear volatile state, refresh/prune the project's clone for PR-based ship tasks,
+# then print a backlog-refresh reminder.
 # REFUSES if the worktree holds work not on any remote, because treehouse return
 # hard-resets the worktree and kills its processes.
 # Scout tasks (kind=scout in meta) carve out of that check: their worktree is


### PR DESCRIPTION
## Intent

Add a plain backlog-refresh reminder to firstmate so queued-item readiness stops going stale. The requested scope is intentionally minimal: after successful fm-teardown.sh completion, print a plain stdout reminder telling the supervisor to update data/backlog.md, move the finished id to Done, keep Done to the 10 most recent, re-scan Queued for items unblocked by the finished id or now time-due, and dispatch ready work. Also tighten one AGENTS.md backlog/supervision line to explicitly include time/date-gated queued items whose date has arrived. Do not add grep or auto-scan logic, structured ready-when or blocked-by machine fields, cron jobs, or new scripts.

## What Changed

- Updates `bin/fm-teardown.sh` to print a post-teardown reminder to refresh `data/backlog.md`, prune Done entries, re-scan queued work, and dispatch anything ready.
- Tightens firstmate supervision docs in `AGENTS.md` to call out time/date-gated queued items whose date has arrived.
- Keeps the README teardown guidance aligned with the new backlog-refresh reminder.

## Risk Assessment

✅ Low: Captain, the change is a narrow reminder/documentation update that runs only after the existing teardown path succeeds and does not alter teardown safety logic.

## Testing

Captain, I inspected the intent, ran the existing shell behavior tests, then exercised the successful `fm-teardown.sh` path with reviewer-visible stdout evidence; stderr was empty, transient worktree fixtures were removed, and the working tree was clean afterward.

<details>
<summary>Evidence: fm-teardown reminder transcript</summary>

<code>$ bin/fm-teardown.sh test-backlog-r3&#10;teardown test-backlog-r3 complete ...&#10;🌱 Backlog: test-backlog-r3 just finished. Update data/backlog.md - move test-backlog-r3 to Done (keep Done to the 10 most recent), then re-scan Queued for items now unblocked ... or now time-due, and dispatch what&#39;s ready.</code>

```text
$ bin/fm-teardown.sh test-backlog-r3
teardown test-backlog-r3 complete (window fm-test-backlog-r3, worktree /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KVNPEVJAYB1NBBC5A3KT98YG/.test-tmp/test-backlog-r3/worktree)
🌱 Backlog: test-backlog-r3 just finished. Update data/backlog.md - move test-backlog-r3 to Done (keep Done to the 10 most recent), then re-scan Queued for items now unblocked (a "blocked-by: test-backlog-r3" may have just cleared) or now time-due, and dispatch what's ready.
$ test ! -e state/test-backlog-r3.meta && echo "state cleanup: meta removed"
state cleanup: meta removed
$ cat .test-tmp/test-backlog-r3/treehouse-call.log
treehouse return --force /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KVNPEVJAYB1NBBC5A3KT98YG/.test-tmp/test-backlog-r3/worktree
```
</details>
<details>
<summary>Evidence: AGENTS backlog instruction snippet</summary>

`AGENTS.md line 489: Re-evaluate Queued on every teardown and every heartbeat: anything whose blocker is gone gets dispatched, and time/date-gated items whose date has arrived get dispatched too.`

```text
   473	`data/backlog.md` is the durable queue.
   474	Update it on every dispatch, completion, and decision.
   475	
   476	`` `markdown
   477	## In flight
   478	- [ ] <id> - <one line> (repo: <name>, since <date>)
   479	
   480	## Queued
   481	- [ ] <id> - <one line> (repo: <name>) blocked-by: <id> - <reason>
   482	
   483	## Done
   484	- [x] <id> - <one line> - <https://github.com/owner/repo/pull/number> (merged <date>)
   485	- [x] <id> - <one line> - local main (merged <date>)
   486	- [x] <id> - <one line> - data/<id>/report.md (reported <date>)
   487	`` `
   488	
   489	Re-evaluate Queued on every teardown and every heartbeat: anything whose blocker is gone gets dispatched, and time/date-gated items whose date has arrived get dispatched too.
   490	
   491	Keep Done to the 10 most recent entries; prune older ones whenever you add to the section.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `tests/fm-wake-queue.test.sh`
- <code>Created a temporary scout-style teardown fixture for `test-backlog-r3`, ran `bin/fm-teardown.sh test-backlog-r3` with a fake `treehouse return --force` on `PATH`, captured stdout/stderr, and grepped stdout for the completion line plus the Done pruning, `blocked-by`, time-due, and dispatch reminder text.</code>
- <code>`nl -ba AGENTS.md | sed -n &#39;473,491p&#39; &gt; /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVNPEVJAYB1NBBC5A3KT98YG/agents-backlog-instruction.txt` plus a targeted `grep -F` for the time/date-gated queued-item instruction.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
