### PR TITLE
feat(spawn): support batch task dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - run: tests/fm-wake-queue.test.sh
+      - run: |
+          set -eu
+          for test_script in tests/*.test.sh; do
+            "$test_script"
+          done
 
   invariants:
     name: Repo invariants

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -304,7 +304,10 @@ Write the brief per section 11.
 bin/fm-spawn.sh <id> projects/<repo>             # uses the active crewmate harness
 bin/fm-spawn.sh <id> projects/<repo> codex       # per-task harness override
 bin/fm-spawn.sh <id> projects/<repo> --scout     # scout task; records kind=scout in meta
+bin/fm-spawn.sh <id1>=projects/<repo1> <id2>=projects/<repo2> [--scout]   # batch: one call, several tasks
 ```
+
+Dispatch several tasks in one call by passing `id=repo` pairs instead of a single `<id> <project>`; each pair is spawned through the same single-task path, a shared `--scout` applies to all, and the looping happens inside the script so you never hand-write a multi-task shell loop.
 
 The script resolves the harness (`fm-harness.sh crew`), owns the verified launch templates, resolves the project's delivery mode (`fm-project-mode.sh`), and records `harness=`, `kind=`, `mode=`, and `yolo=` in the task's meta; a non-flag third argument containing whitespace is treated as a raw launch command (only for verifying new adapters).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -308,6 +308,7 @@ bin/fm-spawn.sh <id1>=projects/<repo1> <id2>=projects/<repo2> [--scout]   # batc
 ```
 
 Dispatch several tasks in one call by passing `id=repo` pairs instead of a single `<id> <project>`; each pair is spawned through the same single-task path, a shared `--scout` applies to all, and the looping happens inside the script so you never hand-write a multi-task shell loop.
+If one pair fails, the rest still run and the batch exits non-zero.
 
 The script resolves the harness (`fm-harness.sh crew`), owns the verified launch templates, resolves the project's delivery mode (`fm-project-mode.sh`), and records `harness=`, `kind=`, `mode=`, and `yolo=` in the task's meta; a non-flag third argument containing whitespace is treated as a raw launch command (only for verifying new adapters).
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ The first mate drives these; you rarely need to, but they work by hand too.
 | `fm-brief.sh`            | Scaffold a ship brief, or a report-only scout brief with `--scout`                                                  |
 | `fm-ensure-agents-md.sh` | Ensure project `AGENTS.md` is the real memory file and `CLAUDE.md` symlinks to it                                   |
 | `fm-guard.sh`            | Warn when tasks are in flight but queued wakes are pending or the watcher liveness beacon is stale or missing      |
-| `fm-spawn.sh`            | Window → treehouse worktree → agent launched with its brief; records ship/scout task kind                           |
+| `fm-spawn.sh`            | Spawn one task, or several `id=repo` pairs in one batch; records ship/scout task kind                                |
 | `fm-project-mode.sh`     | Resolve a project's delivery mode and `+yolo` flag from `data/projects.md`                                          |
 | `fm-merge-local.sh`      | Fast-forward a `local-only` project's local default branch after approval                                           |
 | `fm-review-diff.sh`      | Review a crewmate branch against the authoritative base, with optional `--stat` output                              |
@@ -182,7 +182,7 @@ The persistent detector daemon and blocking waiter split are deferred follow-up 
 ```sh
 bash -n bin/*.sh                          # syntax-check the toolbelt
 shellcheck bin/*.sh tests/*.sh            # lint the toolbelt and behavior tests; CI enforces this
-tests/fm-wake-queue.test.sh               # durable wake queue and singleton behavior tests
+for test_script in tests/*.test.sh; do "$test_script"; done   # behavior tests, matching CI
 [ "$(readlink CLAUDE.md)" = "AGENTS.md" ]
 [ "$(readlink .claude/skills)" = "../.agents/skills" ]
 FM_HEARTBEAT=2 FM_POLL=1 bin/fm-watch.sh  # watcher smoke test (prints "heartbeat")

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -7,6 +7,12 @@
 #   is treated as a RAW launch command - the escape hatch for verifying new adapters.
 #   --scout records kind=scout in the task's meta (report deliverable, scratch worktree;
 #   see AGENTS.md section 7); the default is kind=ship.
+# Batch dispatch: pass one or more `id=repo` pairs instead of a single <id> <project>, e.g.
+#     fm-spawn.sh fix-a-k3=projects/foo add-b-q7=projects/bar [--scout]
+#   Each pair re-execs this script in single-task mode, so the single path stays the only
+#   source of truth; a shared --scout applies to every pair. The loop lives here, in bash,
+#   so callers never hand-write a multi-task shell loop (the tool shell is zsh, which does
+#   not word-split unquoted $vars and silently breaks ad-hoc `for ... in $pairs` loops).
 #   Launch templates live in launch_template() below; placeholders replaced before launch:
 #     __BRIEF__    absolute path to data/<task-id>/brief.md
 #     __TURNEND__  absolute path to state/<task-id>.turn-ended (for harnesses whose
@@ -19,7 +25,9 @@
 set -eu
 
 FM_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-"$FM_ROOT/bin/fm-guard.sh" || true
+# Skip the watcher guard when re-exec'd for one pair of a batch (FM_SPAWN_NO_GUARD is
+# set by the batch loop below), so the guard runs once for the batch, not once per pair.
+[ -n "${FM_SPAWN_NO_GUARD:-}" ] || "$FM_ROOT/bin/fm-guard.sh" || true
 KIND=ship
 POS=()
 for a in "$@"; do
@@ -28,6 +36,30 @@ for a in "$@"; do
     *) POS+=("$a") ;;
   esac
 done
+
+# Batch dispatch (see header): when the first positional is an `id=repo` pair, treat every
+# positional as one and spawn each by re-execing this script in single-task mode. We use
+# the FM_ROOT path (not $0) so it works whatever cwd or relative path invoked us, and reuse
+# the single path verbatim. A failed pair is reported and skipped; the rest still launch;
+# exit is non-zero if any pair failed. Single-task invocations never carry an '=' in arg
+# one (task ids are bare slugs), so they fall straight through to the logic below.
+idpart=${POS[0]:-}
+idpart=${idpart%%=*}
+if [ "${#POS[@]}" -gt 0 ] && [ "${POS[0]}" != "$idpart" ] && case "$idpart" in */*) false ;; *) true ;; esac; then
+  rc=0
+  for pair in "${POS[@]}"; do
+    case "$pair" in
+      *=*) : ;;
+      *) echo "error: batch dispatch expects every argument as id=repo; got '$pair'" >&2; rc=2; continue ;;
+    esac
+    if [ "$KIND" = scout ]; then
+      if FM_SPAWN_NO_GUARD=1 "$FM_ROOT/bin/fm-spawn.sh" "${pair%%=*}" "${pair#*=}" --scout; then :; else echo "batch: FAILED to spawn ${pair%%=*} (${pair#*=})" >&2; rc=1; fi
+    else
+      if FM_SPAWN_NO_GUARD=1 "$FM_ROOT/bin/fm-spawn.sh" "${pair%%=*}" "${pair#*=}"; then :; else echo "batch: FAILED to spawn ${pair%%=*} (${pair#*=})" >&2; rc=1; fi
+    fi
+  done
+  exit "$rc"
+fi
 ID=${POS[0]}
 PROJ=${POS[1]}
 ARG3=${POS[2]:-}

--- a/tests/fm-spawn-batch.test.sh
+++ b/tests/fm-spawn-batch.test.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Behavior tests for fm-spawn.sh batch dispatch (`id=repo` pairs).
+# These exercise argument routing only: each spawn attempt fails fast at the missing-brief
+# check, which is reached before any tmux/treehouse side effect, so the tests create no
+# windows or worktrees. FM_SPAWN_NO_GUARD=1 keeps them off the live watcher guard / state.
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SPAWN="$ROOT/bin/fm-spawn.sh"
+
+fail() {
+  printf 'not ok - %s\n' "$1" >&2
+  exit 1
+}
+
+pass() {
+  printf 'ok - %s\n' "$1"
+}
+
+# Run fm-spawn with the guard suppressed; capture combined output and exit status.
+run_spawn() {
+  FM_SPAWN_NO_GUARD=1 "$SPAWN" "$@" 2>&1
+}
+
+test_batch_dispatches_each_pair() {
+  local out status
+  out=$(run_spawn nope-batch-a-z1=projects/none-a nope-batch-b-z2=projects/none-b)
+  status=$?
+  [ "$status" -ne 0 ] || fail "batch with missing briefs should exit non-zero"
+  printf '%s\n' "$out" | grep -F 'batch: FAILED to spawn nope-batch-a-z1 (projects/none-a)' >/dev/null \
+    || fail "first pair was not dispatched/reported"
+  printf '%s\n' "$out" | grep -F 'batch: FAILED to spawn nope-batch-b-z2 (projects/none-b)' >/dev/null \
+    || fail "second pair was not dispatched/reported (loop stopped early?)"
+  pass "batch dispatch re-execs and reports every id=repo pair"
+}
+
+test_single_pair_is_batch() {
+  local out status
+  out=$(run_spawn nope-batch-solo-z3=projects/none-solo)
+  status=$?
+  [ "$status" -ne 0 ] || fail "single missing-brief pair should exit non-zero"
+  printf '%s\n' "$out" | grep -F 'batch: FAILED to spawn nope-batch-solo-z3 (projects/none-solo)' >/dev/null \
+    || fail "single id=repo pair was not treated as batch"
+  pass "a single id=repo pair routes through batch dispatch"
+}
+
+test_single_mode_unaffected() {
+  local out status
+  out=$(run_spawn nope-single-z4 projects/none-single)
+  status=$?
+  [ "$status" -ne 0 ] || fail "single-task spawn with missing brief should exit non-zero"
+  if printf '%s\n' "$out" | grep -F 'batch:' >/dev/null; then
+    fail "plain '<id> <repo>' invocation wrongly entered batch dispatch"
+  fi
+  pass "single-task invocation (no '=') is untouched by batch detection"
+}
+
+test_batch_rejects_non_pair_argument() {
+  local out status
+  out=$(run_spawn nope-batch-mix-z5=projects/none-mix bogus-no-equals)
+  status=$?
+  [ "$status" -ne 0 ] || fail "batch with a non-pair argument should exit non-zero"
+  printf '%s\n' "$out" | grep -F "batch dispatch expects every argument as id=repo; got 'bogus-no-equals'" >/dev/null \
+    || fail "non-pair argument in batch mode was not rejected"
+  pass "batch dispatch rejects an argument that is not id=repo"
+}
+
+test_id_with_slash_is_not_batch() {
+  local out status
+  # A first arg whose pre-'=' part contains '/' is not a bare task id, so it must NOT be
+  # treated as a batch pair (it falls through to single-task handling).
+  out=$(run_spawn weird/id-z6=projects/none projects/none)
+  status=$?
+  [ "$status" -ne 0 ] || fail "malformed single-task spawn should exit non-zero"
+  if printf '%s\n' "$out" | grep -F 'batch:' >/dev/null; then
+    fail "first arg with '/' before '=' wrongly entered batch dispatch"
+  fi
+  pass "an arg whose id part contains '/' is not treated as a batch pair"
+}
+
+test_batch_dispatches_each_pair
+test_single_pair_is_batch
+test_single_mode_unaffected
+test_batch_rejects_non_pair_argument
+test_id_with_slash_is_not_batch


### PR DESCRIPTION
## Intent

The captain asked to make bin/fm-spawn.sh support spawning several tasks in one call by accepting multiple id=repo pairs, removing the recurring need to hand-write multi-task dispatch loops in the tool shell. Motivation: the interactive tool shell is zsh, which (unlike bash) does not word-split an unquoted $var, so ad-hoc 'for ... in $pairs' / 'set -- $pair' loops silently mangled arguments and repeatedly broke multi-task dispatch. Decisions/tradeoffs: (1) chose unambiguous id=repo pair syntax so single-task invocations (<id> <project> [harness|--scout|raw-cmd]) are detected as NOT batch and stay byte-for-byte unchanged - detection requires the first positional to contain '=' with a slash-free id part; (2) implemented batch as a re-exec of this same script in single-task mode per pair (via the FM_ROOT path, not $0) so the single-task path stays the one source of truth instead of duplicating spawn logic; (3) a shared --scout applies to every pair; (4) continue-on-failure - a failed pair is reported ('batch: FAILED to spawn ...') and skipped while the rest still launch, non-zero exit if any failed; (5) the watcher guard runs once per batch (not per pair) via an FM_SPAWN_NO_GUARD env flag on the re-execed children. Scope deliberately limited to this batch helper: the captain explicitly chose NOT to add a broader zsh word-splitting convention note elsewhere. Added tests/fm-spawn-batch.test.sh (behavior tests exercising arg routing only - each spawn fails fast at the missing-brief check before any tmux/treehouse side effect, so no real worktrees/windows are created) and documented the batch form in AGENTS.md section 7.

## What Changed
- Added batch dispatch support to `bin/fm-spawn.sh` using `id=repo` pairs, with shared `--scout`, continue-on-failure behavior, and a single watcher guard for the batch.
- Documented the new batch spawn form in `AGENTS.md` and `README.md`.
- Added batch spawn behavior coverage and wired all shell behavior tests into CI.

## Risk Assessment

✅ Low: Captain, the change is narrow, keeps single-task spawning as the source of truth, and the earlier CI coverage gap is now addressed.

## Testing

Inspected the changed files, ran the targeted batch-spawn test and full behavior-test loop without lint/static analysis, captured CLI success and failure transcripts in the evidence directory, cleaned temporary `data`, `state`, and `projects` fixtures from the worktree, and ended with no actionable test failures.

<details>
<summary>Evidence: Targeted batch-spawn test output</summary>

<code>ok - batch dispatch re-execs and reports every id=repo pair&#10;ok - a single id=repo pair routes through batch dispatch&#10;ok - single-task invocation (no &#39;=&#39;) is untouched by batch detection&#10;ok - batch dispatch rejects an argument that is not id=repo&#10;ok - an arg whose id part contains &#39;/&#39; is not treated as a batch pair</code>

```text
ok - batch dispatch re-execs and reports every id=repo pair
ok - a single id=repo pair routes through batch dispatch
ok - single-task invocation (no '=') is untouched by batch detection
ok - batch dispatch rejects an argument that is not id=repo
ok - an arg whose id part contains '/' is not treated as a batch pair
```
</details>
<details>
<summary>Evidence: All behavior tests output</summary>

`Behavior test loop covering batch spawn and wake queue tests passed.`

```text
ok - batch dispatch re-execs and reports every id=repo pair
ok - a single id=repo pair routes through batch dispatch
ok - single-task invocation (no '=') is untouched by batch detection
ok - batch dispatch rejects an argument that is not id=repo
ok - an arg whose id part contains '/' is not treated as a batch pair
ok - concurrent append plus drain preserves queue records
ok - signal written while no watcher runs is caught on next run
ok - stale wake is queued before suppressor state is advanced
ok - check output is queued before cadence suppression
ok - simultaneous watcher starts leave exactly one live process
ok - two atomic drains cannot consume the same records twice
ok - drain collapses obvious duplicate heartbeat and signal records
ok - killed watcher stale lock is reclaimed
ok - live watcher lock with stale heartbeat is actionable
ok - guard warns when queued wakes are pending
ok - guard orders watcher re-arm after queued wake drain
```
</details>
<details>
<summary>Evidence: CLI batch spawn success transcript</summary>

<code>$ PATH=&lt;fake-tmux&gt;:$PATH bin/fm-spawn.sh batch-a=projects/demo-a batch-b=projects/demo-b --scout&#10;spawned batch-a harness=codex kind=scout mode=direct-PR yolo=off window=firstmate:fm-batch-a worktree=/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVNX6QWGFN889JRHRQTH6A1Z/fake-worktrees/firstmate_fm-batch-a&#10;spawned batch-b harness=codex kind=scout mode=local-only yolo=on window=firstmate:fm-batch-b worktree=/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVNX6QWGFN889JRHRQTH6A1Z/fake-worktrees/firstmate_fm-batch-b&#10;exit=0</code>

```text
$ PATH=<fake-tmux>:$PATH bin/fm-spawn.sh batch-a=projects/demo-a batch-b=projects/demo-b --scout
spawned batch-a harness=codex kind=scout mode=direct-PR yolo=off window=firstmate:fm-batch-a worktree=/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVNX6QWGFN889JRHRQTH6A1Z/fake-worktrees/firstmate_fm-batch-a
spawned batch-b harness=codex kind=scout mode=local-only yolo=on window=firstmate:fm-batch-b worktree=/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVNX6QWGFN889JRHRQTH6A1Z/fake-worktrees/firstmate_fm-batch-b
exit=0

$ sed -n "1,20p" state/batch-a.meta state/batch-b.meta
window=firstmate:fm-batch-a
worktree=/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVNX6QWGFN889JRHRQTH6A1Z/fake-worktrees/firstmate_fm-batch-a
project=/Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KVNX6QWGFN889JRHRQTH6A1Z/projects/demo-a
harness=codex
kind=scout
mode=direct-PR
yolo=off
window=firstmate:fm-batch-b
worktree=/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVNX6QWGFN889JRHRQTH6A1Z/fake-worktrees/firstmate_fm-batch-b
project=/Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KVNX6QWGFN889JRHRQTH6A1Z/projects/demo-b
harness=codex
kind=scout
mode=local-only
yolo=on

$ cat fake-tmux-calls.log
tmux has-session -t firstmate
tmux list-windows -t firstmate -F \#\{window_name\}
tmux new-window -d -t firstmate -n fm-batch-a -c /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KVNX6QWGFN889JRHRQTH6A1Z/projects/demo-a
tmux send-keys -t firstmate:fm-batch-a treehouse\ get Enter
tmux display-message -p -t firstmate:fm-batch-a \#\{pane_current_path\}
tmux send-keys -t firstmate:fm-batch-a -l codex\ --dangerously-bypass-approvals-and-sandbox\ -c\ \"notify=\[\\\"bash\\\"\,\\\"-c\\\"\,\\\"touch\ /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KVNX6QWGFN889JRHRQTH6A1Z/state/batch-a.turn-ended\\\"\]\"\ \"\$\(cat\ /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KVNX6QWGFN889JRHRQTH6A1Z/data/batch-a/brief.md\)\"
tmux send-keys -t firstmate:fm-batch-a Enter
tmux has-session -t firstmate
tmux list-windows -t firstmate -F \#\{window_name\}
tmux new-window -d -t firstmate -n fm-batch-b -c /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KVNX6QWGFN889JRHRQTH6A1Z/projects/demo-b
tmux send-keys -t firstmate:fm-batch-b treehouse\ get Enter
tmux display-message -p -t firstmate:fm-batch-b \#\{pane_current_path\}
tmux send-keys -t firstmate:fm-batch-b -l codex\ --dangerously-bypass-approvals-and-sandbox\ -c\ \"notify=\[\\\"bash\\\"\,\\\"-c\\\"\,\\\"touch\ /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KVNX6QWGFN889JRHRQTH6A1Z/state/batch-b.turn-ended\\\"\]\"\ \"\$\(cat\ /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KVNX6QWGFN889JRHRQTH6A1Z/data/batch-b/brief.md\)\"
tmux send-keys -t firstmate:fm-batch-b Enter
```
</details>
<details>
<summary>Evidence: CLI batch failure transcript</summary>

<code>$ FM_SPAWN_NO_GUARD=1 bin/fm-spawn.sh missing-a=projects/no-a missing-b=projects/no-b&#10;error: no brief at /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KVNX6QWGFN889JRHRQTH6A1Z/data/missing-a/brief.md&#10;batch: FAILED to spawn missing-a (projects/no-a)&#10;error: no brief at /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KVNX6QWGFN889JRHRQTH6A1Z/data/missing-b/brief.md&#10;batch: FAILED to spawn missing-b (projects/no-b)&#10;exit=1</code>

```text
$ FM_SPAWN_NO_GUARD=1 bin/fm-spawn.sh missing-a=projects/no-a missing-b=projects/no-b
error: no brief at /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KVNX6QWGFN889JRHRQTH6A1Z/data/missing-a/brief.md
batch: FAILED to spawn missing-a (projects/no-a)
error: no brief at /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KVNX6QWGFN889JRHRQTH6A1Z/data/missing-b/brief.md
batch: FAILED to spawn missing-b (projects/no-b)
exit=1

$ FM_SPAWN_NO_GUARD=1 bin/fm-spawn.sh mixed-a=projects/no-a bogus-no-equals
error: no brief at /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KVNX6QWGFN889JRHRQTH6A1Z/data/mixed-a/brief.md
batch: FAILED to spawn mixed-a (projects/no-a)
error: batch dispatch expects every argument as id=repo; got 'bogus-no-equals'
exit=2
```
</details>
<details>
<summary>Evidence: Fake tmux calls from CLI success check</summary>

<code>Fake tmux call log showing two batch children created windows, sent `treehouse get`, and launched codex from the normal single-spawn path.</code>

```text
tmux has-session -t firstmate
tmux list-windows -t firstmate -F \#\{window_name\}
tmux new-window -d -t firstmate -n fm-batch-a -c /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KVNX6QWGFN889JRHRQTH6A1Z/projects/demo-a
tmux send-keys -t firstmate:fm-batch-a treehouse\ get Enter
tmux display-message -p -t firstmate:fm-batch-a \#\{pane_current_path\}
tmux send-keys -t firstmate:fm-batch-a -l codex\ --dangerously-bypass-approvals-and-sandbox\ -c\ \"notify=\[\\\"bash\\\"\,\\\"-c\\\"\,\\\"touch\ /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KVNX6QWGFN889JRHRQTH6A1Z/state/batch-a.turn-ended\\\"\]\"\ \"\$\(cat\ /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KVNX6QWGFN889JRHRQTH6A1Z/data/batch-a/brief.md\)\"
tmux send-keys -t firstmate:fm-batch-a Enter
tmux has-session -t firstmate
tmux list-windows -t firstmate -F \#\{window_name\}
tmux new-window -d -t firstmate -n fm-batch-b -c /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KVNX6QWGFN889JRHRQTH6A1Z/projects/demo-b
tmux send-keys -t firstmate:fm-batch-b treehouse\ get Enter
tmux display-message -p -t firstmate:fm-batch-b \#\{pane_current_path\}
tmux send-keys -t firstmate:fm-batch-b -l codex\ --dangerously-bypass-approvals-and-sandbox\ -c\ \"notify=\[\\\"bash\\\"\,\\\"-c\\\"\,\\\"touch\ /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KVNX6QWGFN889JRHRQTH6A1Z/state/batch-b.turn-ended\\\"\]\"\ \"\$\(cat\ /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KVNX6QWGFN889JRHRQTH6A1Z/data/batch-b/brief.md\)\"
tmux send-keys -t firstmate:fm-batch-b Enter
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `tests/fm-spawn-batch.test.sh:1` - The new batch-dispatch behavior test is not wired into the existing Behavior tests job, which still only runs `tests/fm-wake-queue.test.sh`; this means the branch&#39;s main regression coverage will be skipped by CI and can silently rot. Add `tests/fm-spawn-batch.test.sh` to the CI test step, or change the job to run all intended behavior tests.

🔧 Fix: Wire batch behavior tests into CI
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `tests/fm-spawn-batch.test.sh`
- `for test_script in tests/*.test.sh; do "$test_script"; done`
- `bin/fm-harness.sh crew`
- <code>`PATH=&lt;fake-tmux&gt;:$PATH bin/fm-spawn.sh batch-a=projects/demo-a batch-b=projects/demo-b --scout` with temporary briefs/projects and captured `state/*.meta` plus fake tmux calls</code>
- `FM_SPAWN_NO_GUARD=1 bin/fm-spawn.sh missing-a=projects/no-a missing-b=projects/no-b`
- `FM_SPAWN_NO_GUARD=1 bin/fm-spawn.sh mixed-a=projects/no-a bogus-no-equals`
- `git status --short && find data state projects config -maxdepth 1 -type e 2>/dev/null | sort`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ `.github/workflows/ci.yml:18` - Configured ShellCheck lint could not be run because shellcheck is not installed in PATH or common local locations; unresolved ShellCheck findings may remain.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
