### PR TITLE
fix(watcher): make check wakes lossless via watcher-side suppression

### DIFF
--- a/.agents/skills/afk/SKILL.md
+++ b/.agents/skills/afk/SKILL.md
@@ -141,7 +141,7 @@ Classify each wake this way:
   -> self-handle. Captain-relevant verb -> escalate.
 - `signal` or `stale` for a declared `paused:` external wait -> self-handle and track the pause rather than a wedge.
   If it remains declared and idle past `FM_PAUSE_RESURFACE_SECS` (default 3600s), housekeeping sends one awaiting-external recheck and resets the pause window.
-- `check` -> always escalate. Check scripts print only when firstmate should wake.
+- `check` -> always escalate. The watcher emits a check wake only for a genuine state change (deduped steady-state output) or a swallowed terminal transition (catch-all), so it is always actionable.
 - `stale` with a terminal status -> escalate. Non-terminal stale is transient:
   record a marker and self-handle. If the pane is still idle past
   `FM_STALE_ESCALATE_SECS` (default 240s), housekeeping escalates it as a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -497,7 +497,7 @@ During the `ci` monitor phase, `bin/fm-crew-state.sh` also reads the ci step log
 For PR-based ship tasks, the ready signal depends on mode: `no-mistakes` reports `done: PR <url> checks green` after CI is green, while `direct-PR` reports `done: PR <url>` after opening the PR.
 Run `bin/fm-pr-check.sh <id> <PR url>` - it records `pr=` and GitHub's `pr_head=` when available in the task's meta and arms the watcher's merge poll.
 Tell the captain: the PR's full URL (always the complete `https://...` link, never a bare `#number` - the captain's terminal makes a full URL clickable), a one-paragraph summary, and, for `no-mistakes`, the risk level it emitted.
-(The check contract, for any custom `state/<id>.check.sh` you write yourself: print one line only when firstmate should wake, print nothing otherwise, and finish before `FM_CHECK_TIMEOUT`.)
+(The check contract, for any custom `state/<id>.check.sh` you write yourself: **print the current state every run** (idempotent), e.g. `echo "merged"` while merged. The watcher dedups against `.seen-check-<name>` and enqueues to the durable queue *before* advancing that marker, so a lost stdout or a crashed watcher can never swallow a wake - the same lossless guarantee signals enjoy. Edge-triggered checks that self-suppress via their own `.babysit-*.seen` are tolerated (empty stdout = no wake), but a swallowed transition is only recovered by the watcher's catch-all backstop, so prefer the stateless "always print current state" form. Finish before `FM_CHECK_TIMEOUT`.)
 
 If the captain says "merge it", run `bin/fm-pr-merge.sh <id> <full GitHub PR URL>` yourself; that instruction is the explicit approval.
 If `yolo=on`, merge a green/approved PR yourself the same way and post the required FYI.
@@ -554,6 +554,7 @@ Repeated provably-working stale escalations on one unchanged pane eventually add
 At the start of every wake-handling turn, run `bin/fm-wake-drain.sh` before peeking panes, reading status files beyond the reason line, or starting new work.
 Session-start recovery is the exception: `bin/fm-session-start.sh` already drained the queue when locked, or deliberately skipped the drain when read-only because another session owns it.
 The printed reason line is still useful, but the drained queue is the lossless backlog.
+Each detected wake is written to the durable queue at `state/.wake-queue` before any suppression marker advances (`.seen-*`, `.stale-*`, `.seen-check-*`, `.escalated-*`, `.last-check`, or `.last-heartbeat`), so a crash between detect and suppress never loses a wake - the same enqueue-before-suppress invariant signal and stale wakes already enjoy, now extended to check wakes.
 **Keep exactly one live cycle.**
 The live cycle is the supervision: while any task is in flight, the active harness protocol must maintain one wait that can wake this primary when `bin/fm-watch.sh` reports an actionable reason.
 After handling drained wakes, resume the emitted harness protocol before ending the turn.

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -1013,14 +1013,29 @@ secondmate_current_json() {  # <parent-tasks-json>
       esac
     fi
     if [ -z "$reason" ]; then
-      if ! validate_secondmate_home "$id" "$home" 2>/dev/null; then
-        reason="invalid home: $VALIDATION_ERROR"
+      validate_out=$(FM_HOME="$FM_HOME" FM_ROOT="$FM_ROOT" run_timed \
+        "$FM_SNAPSHOT_SECONDMATE_TIMEOUT" bash -c '
+          . "$1"
+          if validate_secondmate_home "$2" "$3"; then
+            printf "%s" "$VALIDATED_HOME"
+            exit 0
+          fi
+          printf "%s" "$VALIDATION_ERROR"
+          exit 1
+        ' validate-secondmate "$SCRIPT_DIR/fm-ff-lib.sh" "$id" "$home" 2>/dev/null)
+      validate_rc=$?
+      if [ "$validate_rc" -eq 124 ]; then
+        reason="invalid home: validation timed out"
+      elif [ "$validate_rc" -ne 0 ]; then
+        reason="invalid home: ${validate_out:-validation failed}"
       else
-        home=$VALIDATED_HOME
-        case " $seen_homes " in
-          *" $home "*) reason="invalid home: duplicate resolved home route" ;;
-          *) seen_homes="$seen_homes $home" ;;
-        esac
+        home=$validate_out
+        VALIDATED_HOME=$home
+        if [ -n "$seen_homes" ] && printf '%s\n' "$seen_homes" | grep -qxF -- "$home"; then
+          reason="invalid home: duplicate resolved home route"
+        else
+          seen_homes=$(printf '%s\n%s' "$seen_homes" "$home")
+        fi
       fi
     fi
     if [ -z "$reason" ]; then

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -1013,6 +1013,7 @@ secondmate_current_json() {  # <parent-tasks-json>
       esac
     fi
     if [ -z "$reason" ]; then
+      # shellcheck disable=SC2016 # Positional parameters expand inside the child bash, not here.
       validate_out=$(FM_HOME="$FM_HOME" FM_ROOT="$FM_ROOT" run_timed \
         "$FM_SNAPSHOT_SECONDMATE_TIMEOUT" bash -c '
           . "$1"

--- a/bin/fm-pr-check.sh
+++ b/bin/fm-pr-check.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Record a PR-ready task: appends pr=<url> and GitHub's pr_head=<sha> to
 # state/<id>.meta when available, then arms the watcher's merge poll by writing
-# state/<id>.check.sh, which prints one line iff the PR is merged (the watcher's
-# check contract: output = wake firstmate, silence = keep sleeping).
+# state/<id>.check.sh, an idempotent check that prints "merged" once the PR is
+# merged; the watcher dedups steady-state output so it wakes once on the merge.
 # Usage: fm-pr-check.sh <task-id> <pr-url>
 set -eu
 

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -381,7 +381,7 @@ classify_stale() {  # <window> <state>
   printf 'self|transient stale (%s): %s' "$win" "${last:-no status}"
 }
 
-classify_check() {  # <full reason>  — check scripts print only when firstmate should wake
+classify_check() {  # <full reason>  — the watcher emits a check wake only for a real change or swallowed transition
   printf 'escalate|%s' "$1"
 }
 

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -31,7 +31,10 @@
 #                          wake payload itself, not just repetition, forces a
 #                          closer look instead of another routine supervision
 #                          resume. Unless afk is active.
-#   check: <script>: <out> per-task check output, always actionable
+#   check: <script>: <out> per-task check output (deduped by the watcher against
+#                          .seen-check-<name> and enqueued before suppression so the
+#                          wake is lossless), or the catch-all force-escalated a
+#                          swallowed terminal transition; always actionable
 #   heartbeat              fleet-scan backstop found an unsurfaced captain-relevant
 #                          status, unless afk is active
 # For normal supervision, resume the session-start primary-harness protocol
@@ -237,6 +240,10 @@ recorded_windows() {
     printf '%s\n' "$w"
   done
 }
+
+# Collapse a check/sidecar basename into a safe suffix for watcher-side state
+# files (.seen-check-*, .escalated-*). LC_ALL=C so the complement is byte-stable.
+sanitize_name() { printf '%s' "$1" | LC_ALL=C tr -c 'A-Za-z0-9._-' '_'; }
 
 # Exit reporting a wake. Consecutive heartbeats with no other wake in between
 # mean an idle fleet, so the heartbeat interval backs off exponentially
@@ -633,17 +640,65 @@ while :; do
   # keeps producing signals - the slow poll (e.g. merge detection) would then
   # never run until the fleet went quiet. Checks are due only every
   # CHECK_INTERVAL, so most cycles skip this block and fall straight through.
+  #
+  # LOSSLESS CHECK WAKES (the #29 invariant, ported to checks). Checks were the
+  # sole wake source whose suppression lived inside an opaque script: an
+  # edge-triggered check advanced its own .babysit-*.seen marker BEFORE the
+  # print could become a wake, so a lost stdout (timeout / concurrent run /
+  # crash) permanently swallowed the transition - the root cause of the missed
+  # PR #3095 merge. Suppression now lives HERE, in the watcher, with
+  # enqueue-before-suppress - exactly the pattern scan_signals uses:
+  #   * the check always prints its current state (idempotent); the watcher
+  #     dedups against .seen-check-<name> and only wakes on a delta;
+  #   * fm_wake_append (durable queue) happens BEFORE the .seen-check marker
+  #     advances, so a crash between detect and suppress leaves the wake in the
+  #     queue (recovered next turn) and the marker un-advanced (re-detected
+  #     next cycle). A lost check wake is now impossible.
+  # Backward-compatible with old edge-triggered checks: empty stdout never
+  # produces a wake, so they keep their quiet behavior. Any transition they
+  # swallow is caught by the catch-all scan at the end of this block.
   if [ "$(age_of "$STATE/.last-check")" -ge "$CHECK_INTERVAL" ]; then
     for c in "$STATE"/*.check.sh; do
       [ -e "$c" ] || continue
       out=$(run_check "$c")
-      if [ -n "$out" ]; then
+      [ -n "$out" ] || continue
+      sf="$STATE/.seen-check-$(sanitize_name "$(basename "$c")")"
+      if [ "$out" != "$(cat "$sf" 2>/dev/null || true)" ]; then
         reason="check: $c: $out"
         fm_wake_append check "$c" "$reason" || exit 1
+        # Test-only hook: prove the wake is durable by simulating a crash
+        # between enqueue and suppress. Never set outside the test suite.
+        [ -n "${FM_WATCH_BREAK_AFTER_CHECK_ENQUEUE:-}" ] && exit 99
+        printf '%s' "$out" > "$sf"
         touch "$STATE/.last-check"
         wake "$reason"
       fi
     done
+
+    # Catch-all backstop: force-escalate any edge-triggered check whose own
+    # .babysit-*.seen sidecar shows a terminal state the watcher never
+    # delivered a wake for. This catches a swallowed transition (sidecar
+    # advanced inside the script but stdout lost) within one sweep - the
+    # belt-and-suspenders safety net for checks that have not migrated to the
+    # lossless "always print current state" contract. Deduped via
+    # .escalated-<sidecar> so each terminal transition fires at most once.
+    for sf in "$STATE"/.babysit-*.seen; do
+      [ -e "$sf" ] || continue
+      terminal=$(cat "$sf" 2>/dev/null || true)
+      state=${terminal%%|*}
+      case "$state" in
+        MERGED|CLOSED) ;;
+        *) continue ;;
+      esac
+      ec="$STATE/.escalated-$(sanitize_name "$(basename "$sf")")"
+      [ "$terminal" = "$(cat "$ec" 2>/dev/null || true)" ] && continue
+      reason="check: catch-all: $sf: $state"
+      fm_wake_append check "$sf" "$reason" || exit 1
+      printf '%s' "$terminal" > "$ec"
+      touch "$STATE/.last-check"
+      wake "$reason"
+    done
+
     touch "$STATE/.last-check"
   fi
 

--- a/bin/fm-x-poll.sh
+++ b/bin/fm-x-poll.sh
@@ -3,9 +3,9 @@
 #
 # Inert by default: a HARD no-op (exit 0, no output) unless X mode is configured
 # via a non-empty FMX_PAIRING_TOKEN (from the home's .env or the environment).
-# This script is the body of the watcher check shim state/x-watch.check.sh, where
-# the contract is "output => wake firstmate, silence => keep sleeping", so the
-# no-op keeps the watcher behaving exactly as today until a user opts in.
+# This script is the body of the watcher check shim state/x-watch.check.sh, so
+# the hard no-op keeps the watcher behaving exactly as today until a user opts
+# in: a check that prints nothing never produces a wake.
 #
 # Behavior when X mode is on:
 #   HTTP 204 / empty / missing text              -> print nothing, exit 0 (no wake)

--- a/tests/fm-wake-queue.test.sh
+++ b/tests/fm-wake-queue.test.sh
@@ -166,6 +166,126 @@ SH
   pass "check output is queued before cadence suppression"
 }
 
+# Regression for the missed PR #3095 merge: a check wake must survive a
+# crash/race between enqueue and suppress. The watcher enqueues to the durable
+# queue BEFORE advancing the .seen-check marker, so even if the marker is never
+# advanced (simulated here via FM_WATCH_BREAK_AFTER_CHECK_ENQUEUE), the wake is
+# already in the queue and is re-detected next cycle.
+test_check_wake_survives_lost_delivery() {
+  local dir state fakebin out drain_out check_file seen_check
+  dir=$(make_case check-lossless)
+  state="$dir/state"
+  fakebin="$dir/fakebin"
+  out="$dir/watch.out"
+  drain_out="$dir/drain.out"
+  check_file="$state/pr-3095.check.sh"
+  seen_check="$state/.seen-check-pr-3095.check.sh"
+  cat > "$check_file" <<'SH'
+#!/usr/bin/env bash
+printf 'merged: https://example.test/pr/3095\n'
+SH
+  chmod +x "$check_file"
+  # Cycle 1: enqueue, then simulate a crash before the suppression marker
+  # advances. The wake is already durable; the marker is still absent.
+  PATH="$fakebin:$PATH" FM_WATCH_BREAK_AFTER_CHECK_ENQUEUE=1 FM_STATE_OVERRIDE="$state" FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=0 FM_HEARTBEAT=999999 "$WATCH" > "$out" 2>/dev/null &
+  wait_for_exit "$!" 40
+  local crash_status=$?
+  [ "$crash_status" -eq 99 ] || fail "crashing watcher did not simulate the post-enqueue crash (exit $crash_status)"
+  [ ! -e "$seen_check" ] || fail "suppression marker advanced before the wake was durable (enqueue-before-suppress broken)"
+  # The wake survived the crash in the durable queue.
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$drain_out" || fail "drain after crash failed"
+  grep "$(printf '\tcheck\t')" "$drain_out" | grep -F "$check_file" | grep -F 'pr/3095' >/dev/null || fail "check wake was lost when delivery failed (the #3095 regression)"
+  # Cycle 2: re-run normally. The un-advanced marker means the delta is
+  # re-detected, enqueued again (deduped downstream), and now suppressed.
+  : > "$out"
+  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=0 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  wait_for_exit "$!" 40 || fail "watcher did not exit on re-detection"
+  grep -F "check: $check_file: merged: https://example.test/pr/3095" "$out" >/dev/null || fail "watcher did not re-detect the delta after the crash"
+  [ -e "$seen_check" ] || fail "suppression marker was not advanced after a clean delivery"
+  pass "check wake is enqueued before suppression so a lost delivery is recovered"
+}
+
+# Dedup: a stateless check that always prints the same state must wake exactly
+# once; subsequent identical output is suppressed by the watcher's .seen-check.
+test_check_dedup_suppresses_repeats() {
+  local dir state fakebin out drain_out check_file count
+  dir=$(make_case check-dedup)
+  state="$dir/state"
+  fakebin="$dir/fakebin"
+  out="$dir/watch.out"
+  drain_out="$dir/drain.out"
+  check_file="$state/steady.check.sh"
+  cat > "$check_file" <<'SH'
+#!/usr/bin/env bash
+printf 'merged\n'
+SH
+  chmod +x "$check_file"
+  # Cycle 1: empty -> "merged" is a delta -> wake.
+  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=0 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  wait_for_exit "$!" 40 || fail "watcher did not exit for first check wake"
+  grep -Fx "check: $check_file: merged" "$out" >/dev/null || fail "watcher did not wake on first check output"
+  # Cycle 2: same output -> no delta -> no wake (watcher loops until the
+  # timeout kills it; the background poll is what lets wait_for_exit return).
+  : > "$out"
+  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=0 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  local pid=$!
+  sleep 2
+  if ! kill -0 "$pid" 2>/dev/null; then
+    fail "watcher woke on a duplicate check output (dedup broken)"
+  fi
+  kill "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+  # Only the first wake should be in the queue.
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$drain_out" || fail "drain failed"
+  count=$(grep -c "$(printf '\tcheck\t')" "$drain_out" || true)
+  [ "$count" -eq 1 ] || fail "expected 1 deduped check wake, got $count"
+  pass "watcher-side .seen-check dedup suppresses repeated identical check output"
+}
+
+# Catch-all backstop: an old edge-triggered check that swallowed its own
+# transition (advanced .babysit-*.seen inside the script but lost stdout) is
+# force-escalated within one sweep by the heartbeat catch-all scanning the
+# sidecar. This is the belt-and-suspenders safety net that would have surfaced
+# PR #3095 within one scan even without the lossless primary path.
+test_catch_all_escalates_swallowed_transition() {
+  local dir state fakebin out drain_out check_file sidecar escalated
+  dir=$(make_case check-catchall)
+  state="$dir/state"
+  fakebin="$dir/fakebin"
+  out="$dir/watch.out"
+  drain_out="$dir/drain.out"
+  check_file="$state/legacy-pr.check.sh"
+  sidecar="$state/.babysit-legacy-pr.seen"
+  escalated="$state/.escalated-.babysit-legacy-pr.seen"
+  # The check already self-suppressed: its sidecar says MERGED, but the script
+  # prints nothing (the transition's stdout was lost - exactly the #3095 mode).
+  printf 'MERGED|comment-a comment-b\n' > "$sidecar"
+  cat > "$check_file" <<'SH'
+#!/usr/bin/env bash
+# Edge-triggered babysit that already advanced its own .seen; prints nothing.
+exit 0
+SH
+  chmod +x "$check_file"
+  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=0 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  wait_for_exit "$!" 40 || fail "watcher did not exit for catch-all escalation"
+  grep -F "catch-all" "$out" >/dev/null || fail "catch-all did not force-escalate the swallowed transition"
+  grep -F "MERGED" "$out" >/dev/null || fail "catch-all wake did not report the terminal state"
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$drain_out" || fail "drain after catch-all failed"
+  grep "$(printf '\tcheck\t')" "$drain_out" | grep -F "$sidecar" >/dev/null || fail "catch-all wake was not queued"
+  [ -e "$escalated" ] || fail "catch-all did not record its dedup marker"
+  # A second sweep must NOT re-escalate (deduped by .escalated-*).
+  : > "$out"
+  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=0 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  local pid=$!
+  sleep 2
+  if ! kill -0 "$pid" 2>/dev/null; then
+    fail "catch-all re-escalated an already-handled terminal state (dedup broken)"
+  fi
+  kill "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+  pass "catch-all force-escalates a swallowed terminal transition within one sweep"
+}
+
 test_atomic_double_drain() {
   local dir state out1 out2 all count leftover
   dir=$(make_case double-drain)
@@ -234,6 +354,9 @@ test_signal_catchup_without_running_watcher
 test_stale_enqueue_before_suppressor
 test_not_working_stale_enqueue_before_suppressor
 test_check_output_is_queued
+test_check_wake_survives_lost_delivery
+test_check_dedup_suppresses_repeats
+test_catch_all_escalates_swallowed_transition
 test_atomic_double_drain
 test_drain_dedupes_obvious_duplicates
 test_drain_asserts_watcher_liveness

--- a/tests/fm-wake-queue.test.sh
+++ b/tests/fm-wake-queue.test.sh
@@ -244,7 +244,7 @@ SH
 
 # Catch-all backstop: an old edge-triggered check that swallowed its own
 # transition (advanced .babysit-*.seen inside the script but lost stdout) is
-# force-escalated within one sweep by the heartbeat catch-all scanning the
+# force-escalated within one sweep by the watcher's catch-all scanning the
 # sidecar. This is the belt-and-suspenders safety net that would have surfaced
 # PR #3095 within one scan even without the lossless primary path.
 test_catch_all_escalates_swallowed_transition() {


### PR DESCRIPTION
## What Changed
- Moved check-wake suppression from opaque check scripts into the watcher: checks now print their current state idempotently, and the watcher dedups against `.seen-check-<name>` and enqueues to the durable queue *before* advancing that marker, so a crashed watcher or lost stdout can no longer swallow a check wake.
- Added a catch-all backstop that scans `.babysit-*.seen` sidecars and force-escalates a swallowed terminal (MERGED/CLOSED) transition within one sweep, deduped via `.escalated-<sidecar>`, as a safety net for legacy edge-triggered checks.
- Hardened `fm-fleet-snapshot.sh`: bounded secondmate-home validation with `run_timed` (a hung NFS/automount mount can no longer block the parent snapshot) and switched the seen-homes dedup from space-substring to newline-exact matching.

## Risk Assessment

✅ Low: The incremental fix commit correctly resolves both prior warnings — validate_secondmate_home is now bounded by run_timed (with correct globals-via-stdout and rc 124/non-zero/zero handling, safe under set -u, no injection) and the seen_homes dedup now uses exact newline-delimited line matching (verified empirically: distinct homes and the space-prefix case are added, only genuine duplicates are caught) — and it introduces no new issues; the only remaining branch item is the acknowledged no-op watcher catch-all tradeoff from the prior round, requiring no action.

## Testing

Completed 1 recorded test check.

- Outcome: ⚠️ 1 error across 1 run (19m21s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Rebase** - 1 warning</summary>

- ⚠️ `.agents/skills/bearings/SKILL.md` - branch carries 1 commit(s) that exist on your local main branch but were never pushed to origin/main; rebasing would bundle this unrelated work (11 file(s)) into the PR:
- 8934c17 fix: derive bearings from authoritative secondmate state (#555)

Push main to origin, or rebase your branch onto origin/main, before gating.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-fleet-snapshot.sh:1016` - validate_secondmate_home is called directly (line 1016) without a run_timed wrapper, unlike every other cross-home read in this same commit (registry line ~430, parent-activity ~517, terminal ~546, summary ~1027). validate_secondmate_home (fm-ff-lib.sh:122-189) does ~8 stat/cd+pwd/cat syscalls against the home and its data/state/config/projects subdirs. A registered secondmate home on a stale NFS/automount path or hung mount blocks the parent snapshot for the mount timeout (60s+) with no recourse, directly violating the file&#39;s stated invariant at lines 62-63 (&#39;one broken or unexpectedly large home cannot hang the parent snapshot&#39;). Fix: route through run_timed and treat 124 as a validation failure; note validate_secondmate_home sets globals (VALIDATED_HOME/VALIDATION_ERROR) the caller reads, so the wrap must capture the result rather than run in a bare subshell.
- ⚠️ `bin/fm-fleet-snapshot.sh:1020` - The seen_homes dedup uses a space-delimited substring match: `case &#34; $seen_homes &#34; in *&#34; $home &#34;*)`. If one validated secondmate home&#39;s canonical path is a space-prefixed prefix of another&#39;s (e.g. /a/foo registered before /a/foo bar, verified empirically: &#39; /a/foo &#39; matches inside &#39; /a/foo bar &#39;), the second home is wrongly flagged &#39;invalid home: duplicate resolved home route&#39; and its structured state is silently dropped from the snapshot. Unlikely for canonical secondmate paths but legal, and the fix is mechanical: use a newline-delimited set with exact per-line equality instead of substring matching.
- ℹ️ `bin/fm-watch.sh:685` - The new catch-all backstop (lines 685-700) dedups only against its own .escalated-&lt;sidecar&gt; marker, which is decoupled from the regular check path&#39;s .seen-check-&lt;name&gt; marker. For a check that both prints a terminal state idempotently AND carries a .babysit-*.seen sidecar (a hybrid/transitional check, or a migrated check with a leftover stale sidecar), the regular path wakes on sweep N and the catch-all emits one additional &#39;check: catch-all&#39; wake on sweep N+1 for the same transition; the two records carry different wake keys (script path vs sidecar path) so drain does not collapse them. Bounded to once per terminal value (.escalated is then set), self-healing, and consistent with the stated lossless/belt-and-suspenders intent, but worth knowing since either path can change independently.

🔧 Fix: bound secondmate home validation and dedup exactly
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Test** - 1 error</summary>

- 🚨 tests failed with exit code 1
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `AGENTS.md:108` - The state/ inventory line (`.hash-* .count-* .stale-* ... .seen-* .hb-surfaced-* .last-* .heartbeat-streak   watcher internals; never touch`) does not enumerate the new `.escalated-*` watcher-internal marker this change introduced (written by the catch-all backstop). `.seen-check-*` is already covered by the existing `.seen-*` glob, but `.escalated-*` matches no glob on that line. This is not a falsehood — the line is an illustrative category label that already omits the pre-existing `.babysit-*.seen` marker, and the change authoritatively documents `.escalated-*` as a suppression marker in AGENTS.md:557. Adding only `.escalated-*` (without `.babysit-*.seen`) would make the inventory inconsistent; both-or-neither is the consistent choice, and `.babysit-*.seen` is out of scope for this change. Left as-is.

</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: suppress SC2016 on intentional bash -c eval string
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
