### PR TITLE
docs(contributing): document fork-based contributions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,9 +14,9 @@ Dependency bots are exempt so their automation keeps working, but regular contri
 
 ## Workflow
 
-1. Fork the repo and clone your fork.
+1. Fork the repo, then clone the parent repo or set your local `origin` back to the parent (`git@github.com:kunchenguid/firstmate.git`).
 2. Create a branch and make your changes.
-3. Initialize the gate in the repo once: `no-mistakes init`.
+3. Initialize the gate with your fork as the push target: `no-mistakes init --fork-url git@github.com:<you>/firstmate.git` (fork routing requires **no-mistakes v1.30.1+**; without a fork, plain `no-mistakes init` still works for maintainers with push access).
 4. Commit your changes.
 5. Push through the gate instead of pushing to `origin`:
 
@@ -25,7 +25,7 @@ Dependency bots are exempt so their automation keeps working, but regular contri
    ```
 
 6. Run `no-mistakes` to attach to the pipeline, watch findings, and auto-fix or review as needed.
-7. Once the pipeline passes, it forwards the push upstream and opens the PR for you.
+7. Once the pipeline passes, it pushes the branch to your fork and opens the PR against the parent repo for you.
 
 See the [no-mistakes quick start](https://kunchenguid.github.io/no-mistakes/start-here/quick-start/) for the full first-run walkthrough.
 


### PR DESCRIPTION
Document fork-based contributions now that no-mistakes **v1.30.1** supports fork routing: clone the parent (or set `origin` back to it), run `no-mistakes init --fork-url <your fork>`, and the gate pushes to your fork and opens the PR against the parent. Docs-only; raised as a direct PR (no pipeline).
