### PR TITLE
fix(spawn): set per-task GOTMPDIR so interrupted Go builds don't leak /tmp

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,7 +85,7 @@ state/               volatile runtime signals; gitignored
   <id>.status        appended by crewmates: "<state>: <note>" wake-event lines, not current-state truth
   <id>.turn-ended    touched by turn-end hooks
   <id>.grok-turnend-token   firstmate-owned grok hook registry token for the task; removed by teardown
-  <id>.meta          written by fm-spawn: window=, worktree=, project=, harness=, kind=, mode=, yolo=; kind=secondmate also records home= and projects= (fm-pr-check appends pr= and verified pr_head= when available; fm-x-link appends x_request= and x_request_ts= for an X-mention-originated task, section 14)
+  <id>.meta          written by fm-spawn: window=, worktree=, project=, harness=, kind=, mode=, yolo=, tasktmp=; kind=secondmate also records home= and projects= (fm-pr-check appends pr= and verified pr_head= when available; fm-x-link appends x_request= and x_request_ts= for an X-mention-originated task, section 14)
   <id>.check.sh      optional slow poll you write per task (e.g. merged-PR check)
   x-watch.check.sh   generated X-mode relay poll shim; present only when opted in (section 14)
   x-inbox/           generated X-mode pending mention payloads; fmx-respond drains it (section 14)

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -411,6 +411,14 @@ if [ "$KIND" != secondmate ]; then
   fi
 fi
 
+# Per-task temp root: /tmp/fm-<id>/ with Go's build temp nested at gotmp/. Go won't
+# create GOTMPDIR, so mkdir before it is used; fm-teardown removes the whole root.
+# Nested (not a bare /tmp/fm-<id>/gotmp) so other per-task temp can live alongside
+# later, and teardown cleans one deterministic path. GOTMPDIR (not TMPDIR) is the
+# targeted knob: TMPDIR is too broad (affects every program's temp, not just Go's).
+TASK_TMP="/tmp/fm-$ID"
+mkdir -p "$TASK_TMP/gotmp"
+
 # Per-harness turn-end hook: a file that touches state/<id>.turn-ended when the
 # agent finishes a turn. Worktree-resident hooks are kept out of git's view so
 # they never block teardown's dirty check or leak into a commit.
@@ -538,6 +546,7 @@ fi
   echo "kind=$KIND"
   echo "mode=$MODE"
   echo "yolo=$YOLO"
+  echo "tasktmp=$TASK_TMP"
   if [ "$KIND" = secondmate ]; then
     echo "home=$PROJ_ABS"
     echo "projects=$SECONDMATE_PROJECTS"
@@ -554,6 +563,11 @@ if [ "$KIND" = secondmate ]; then
   sq_home=$(shell_quote "$PROJ_ABS")
   LAUNCH="FM_ROOT_OVERRIDE= FM_STATE_OVERRIDE= FM_DATA_OVERRIDE= FM_PROJECTS_OVERRIDE= FM_CONFIG_OVERRIDE= FM_HOME=$sq_home $LAUNCH"
 fi
+# Export GOTMPDIR into the crewmate's pane shell so the agent and every child
+# process (go build, go test, ...) inherit it. Sent before the launch command so
+# the env is set when the agent starts; the brief sleep lets the export land.
+tmux send-keys -t "$T" "export GOTMPDIR=$TASK_TMP/gotmp" Enter
+sleep 0.3
 tmux send-keys -t "$T" -l "$LAUNCH"
 sleep 0.3
 tmux send-keys -t "$T" Enter

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -54,6 +54,9 @@ T=$(grep '^window=' "$META" | cut -d= -f2-)
 PROJ=$(grep '^project=' "$META" | cut -d= -f2-)
 HOME_PATH=$(grep '^home=' "$META" | cut -d= -f2- || true)
 PR_URL=$(grep '^pr=' "$META" | tail -1 | cut -d= -f2- || true)
+# tasktmp is recorded by fm-spawn for tasks that set up a per-task temp root
+# (/tmp/fm-<id>/); absent for tasks spawned before that change, so tolerate empty.
+TASK_TMP=$(grep '^tasktmp=' "$META" | cut -d= -f2- || true)
 
 KIND=$(grep '^kind=' "$META" | cut -d= -f2- || true)
 [ -n "$KIND" ] || KIND=ship
@@ -590,6 +593,9 @@ if [ "$KIND" = secondmate ]; then
   remove_secondmate_registry_entry "$ID"
 fi
 remove_grok_turnend_auth "$STATE" "$ID"
+# Remove the per-task temp root (/tmp/fm-<id>/, incl. its gotmp/) recorded by spawn.
+# Read before the state-file rm below; empty (pre-fix tasks without tasktmp=) is a no-op.
+[ -n "$TASK_TMP" ] && rm -rf "$TASK_TMP"
 rm -f "$STATE/$ID.status" "$STATE/$ID.turn-ended" "$STATE/$ID.check.sh" "$STATE/$ID.meta" "$STATE/$ID.pi-ext.ts" "$STATE/$ID.grok-turnend-token"
 if [ "$KIND" != scout ] && [ "$KIND" != secondmate ] && [ "$MODE" != local-only ]; then
   "$FM_ROOT/bin/fm-fleet-sync.sh" "$PROJ" || true

--- a/tests/fm-gotmp.test.sh
+++ b/tests/fm-gotmp.test.sh
@@ -81,8 +81,10 @@ META
 test_spawn_contract_and_mkdir_pattern() {
   # Structural: fm-spawn must create the gotmp dir, record tasktmp in meta, and export
   # GOTMPDIR into the pane. Assert the contract lines are present in the source.
+  # shellcheck disable=SC2016  # single quotes are deliberate: these are literal source strings
   grep -F 'mkdir -p "$TASK_TMP/gotmp"' "$SPAWN" >/dev/null \
     || fail "fm-spawn missing: mkdir of gotmp under TASK_TMP"
+  # shellcheck disable=SC2016  # single quotes are deliberate: literal source string
   grep -F 'echo "tasktmp=$TASK_TMP"' "$SPAWN" >/dev/null \
     || fail "fm-spawn missing: tasktmp= line in meta write"
   grep -F 'export GOTMPDIR=' "$SPAWN" >/dev/null \

--- a/tests/fm-gotmp.test.sh
+++ b/tests/fm-gotmp.test.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# Behavior tests for per-task GOTMPDIR support (fm-gotmp).
+#
+# fm-spawn gives each task a temp root /tmp/fm-<id>/ with Go's build temp nested at
+# gotmp/, exports GOTMPDIR into the crewmate pane, and records tasktmp= in the task's
+# meta. fm-teardown reads tasktmp= and removes the whole root on cleanup.
+#
+# These tests exercise behavior directly: fm-teardown is run as a subprocess against a
+# fake FM_ROOT (built so the real script resolves into it), with stub helper scripts.
+# Nothing is sourced. The fm-spawn side is verified both structurally (the source has
+# the contract lines) and behaviorally (the mkdir + meta-write pattern it uses).
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SPAWN="$ROOT/bin/fm-spawn.sh"
+TEARDOWN="$ROOT/bin/fm-teardown.sh"
+
+fail() {
+  printf 'not ok - %s\n' "$1" >&2
+  exit 1
+}
+
+pass() {
+  printf 'ok - %s\n' "$1"
+}
+
+TMP_ROOT=
+
+cleanup() {
+  if [ -n "${TMP_ROOT:-}" ]; then
+    rm -rf "$TMP_ROOT"
+  fi
+}
+trap cleanup EXIT
+
+TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/fm-gotmp-tests.XXXXXX")
+
+# Build a fake FM_ROOT so the real fm-teardown.sh (symlinked in) resolves FM_ROOT to
+# it via its BASH_SOURCE computation. Stub the helper scripts fm-teardown calls so no
+# live tmux/treehouse/fleet state is touched. A nonexistent worktree path makes both
+# `if [ -d "$WT" ]` guards skip, so teardown runs straight to the cleanup + state rm.
+make_fake_root() {
+  local id=$1 tasktmp=$2
+  local fake="$TMP_ROOT/$id"
+  mkdir -p "$fake/bin" "$fake/state"
+  # Symlink the REAL teardown so the test exercises actual code, not a copy.
+  ln -s "$TEARDOWN" "$fake/bin/fm-teardown.sh"
+  # fm-guard.sh: stub (teardown calls it with `|| true`).
+  cat > "$fake/bin/fm-guard.sh" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  chmod +x "$fake/bin/fm-guard.sh"
+  # fm-fleet-sync.sh: stub (called for non-scout/non-local-only teardowns).
+  cat > "$fake/bin/fm-fleet-sync.sh" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  chmod +x "$fake/bin/fm-fleet-sync.sh"
+  # fm-tasks-axi-lib.sh: stub (teardown sources it). Report not-compatible so
+  # backlog_refresh_reminder takes the plain-message path; no tasks-axi here.
+  cat > "$fake/bin/fm-tasks-axi-lib.sh" <<'SH'
+fm_tasks_axi_compatible() { return 1; }
+SH
+  # Meta with a nonexistent worktree so the dirty/treehouse blocks skip.
+  cat > "$fake/state/$id.meta" <<META
+window=fakeses:fm-$id
+worktree=$TMP_ROOT/nonexistent-worktree-$id
+project=$TMP_ROOT/nonexistent-project-$id
+harness=claude
+kind=ship
+mode=no-mistakes
+yolo=off
+tasktmp=$tasktmp
+META
+  printf '%s' "$fake"
+}
+
+# --- fm-spawn side ---
+
+test_spawn_contract_and_mkdir_pattern() {
+  # Structural: fm-spawn must create the gotmp dir, record tasktmp in meta, and export
+  # GOTMPDIR into the pane. Assert the contract lines are present in the source.
+  grep -F 'mkdir -p "$TASK_TMP/gotmp"' "$SPAWN" >/dev/null \
+    || fail "fm-spawn missing: mkdir of gotmp under TASK_TMP"
+  grep -F 'echo "tasktmp=$TASK_TMP"' "$SPAWN" >/dev/null \
+    || fail "fm-spawn missing: tasktmp= line in meta write"
+  grep -F 'export GOTMPDIR=' "$SPAWN" >/dev/null \
+    || fail "fm-spawn missing: GOTMPDIR export into pane"
+  # Behavioral: the mkdir + meta-write pattern spawn uses must produce a gotmp dir and
+  # a meta line whose value the teardown grep (tasktmp=, cut -d= -f2-) reads back whole.
+  local id=spawn-sim-z1
+  local sim_root="$TMP_ROOT/$id-root"
+  local task_tmp="$sim_root/tmp/fm-$id"
+  mkdir -p "$sim_root/state"
+  # Replicate spawn's exact mkdir + meta-write lines.
+  TASK_TMP="$task_tmp"
+  mkdir -p "$TASK_TMP/gotmp"
+  {
+    echo "tasktmp=$TASK_TMP"
+  } > "$sim_root/state/$id.meta"
+  [ -d "$task_tmp/gotmp" ] || fail "simulated spawn did not create gotmp dir"
+  # Teardown reads tasktmp= with `grep '^tasktmp=' | cut -d= -f2-`; round-trip it.
+  local read_back
+  read_back=$(grep '^tasktmp=' "$sim_root/state/$id.meta" | cut -d= -f2-)
+  [ "$read_back" = "$task_tmp" ] \
+    || fail "tasktmp value not round-tripped by teardown's grep|cut (got '$read_back')"
+  pass "fm-spawn creates gotmp dir and records tasktmp in meta"
+}
+
+# --- fm-teardown side (real subprocess) ---
+
+test_teardown_removes_tasktmp_dir() {
+  local id=td-rm-z2
+  local task_tmp="$TMP_ROOT/fm-$id"
+  mkdir -p "$task_tmp/gotmp"
+  printf 'leftover\n' > "$task_tmp/gotmp/build-artifact"
+  local fake
+  fake=$(make_fake_root "$id" "$task_tmp")
+  # Sanity: dir + contents exist before teardown.
+  [ -d "$task_tmp/gotmp" ] || fail "precondition: gotmp missing before teardown"
+  # Run the REAL teardown against the fake root.
+  bash "$fake/bin/fm-teardown.sh" "$id" >/dev/null 2>&1 \
+    || fail "teardown exited non-zero with a valid tasktmp"
+  [ ! -e "$task_tmp" ] \
+    || fail "teardown did not remove the tasktmp dir ($task_tmp still exists)"
+  pass "fm-teardown removes the dir pointed to by tasktmp= in meta"
+}
+
+test_teardown_skips_gracefully_without_tasktmp() {
+  # Backward compat: a meta from a pre-fix task has no tasktmp= line. Teardown must
+  # not error and must not remove anything.
+  local id=td-absent-z3
+  local fake="$TMP_ROOT/$id-root"
+  mkdir -p "$fake/bin" "$fake/state"
+  ln -s "$TEARDOWN" "$fake/bin/fm-teardown.sh"
+  cat > "$fake/bin/fm-guard.sh" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  chmod +x "$fake/bin/fm-guard.sh"
+  cat > "$fake/bin/fm-fleet-sync.sh" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  chmod +x "$fake/bin/fm-fleet-sync.sh"
+  cat > "$fake/bin/fm-tasks-axi-lib.sh" <<'SH'
+fm_tasks_axi_compatible() { return 1; }
+SH
+  # No tasktmp= line at all.
+  cat > "$fake/state/$id.meta" <<META
+window=fakeses:fm-$id
+worktree=$TMP_ROOT/nonexistent-wt-$id
+project=$TMP_ROOT/nonexistent-proj-$id
+harness=claude
+kind=ship
+mode=no-mistakes
+yolo=off
+META
+  bash "$fake/bin/fm-teardown.sh" "$id" >/dev/null 2>&1 \
+    || fail "teardown exited non-zero when tasktmp= was absent"
+  pass "fm-teardown skips gracefully when tasktmp= is absent (backward compat)"
+}
+
+test_teardown_skips_gracefully_when_dir_missing() {
+  # tasktmp= points to a path that does not exist. Teardown must not error.
+  local id=td-missing-z4
+  local task_tmp="$TMP_ROOT/never-created-fm-$id"
+  # Intentionally do NOT create $task_tmp.
+  [ ! -e "$task_tmp" ] || fail "precondition: task_tmp should not exist yet"
+  local fake
+  fake=$(make_fake_root "$id" "$task_tmp")
+  bash "$fake/bin/fm-teardown.sh" "$id" >/dev/null 2>&1 \
+    || fail "teardown exited non-zero when tasktmp dir was missing"
+  [ ! -e "$task_tmp" ] || fail "teardown created/left the tasktmp dir unexpectedly"
+  pass "fm-teardown skips gracefully when tasktmp= points to a nonexistent dir"
+}
+
+test_spawn_contract_and_mkdir_pattern
+test_teardown_removes_tasktmp_dir
+test_teardown_skips_gracefully_without_tasktmp
+test_teardown_skips_gracefully_when_dir_missing


### PR DESCRIPTION
## Intent

The developer wanted to stop interrupted Go builds from leaking /tmp/go-build* temp directories that accumulate and fill the disk. The fix gives each task its own Go temp root at /tmp/fm-<id>/ with GOTMPDIR set to /tmp/fm-<id>/gotmp/ in the crewmate pane, recorded as tasktmp= in the task meta, and cleaned up deterministically by fm-teardown.sh. They specified changes to bin/fm-spawn.sh (create the dir, write tasktmp= to meta, export GOTMPDIR before launch) and bin/fm-teardown.sh (read tasktmp= and rm -rf the dir), required backward compatibility so pre-fix tasks without tasktmp= tear down gracefully, and kept the existing daily cron as a safety net. They also required new TAP-style tests in tests/fm-gotmp.test.sh covering creation, teardown, missing tasktmp, and non-existent dir, with all existing tests still passing. The change was to be shipped as a cross-repo PR to kunchenguid/firstmate from the e-jung fork, with the specified title and body, no merge, and AI disclosure marked Human-reviewed.

## What Changed
- Each spawned task now gets a private temp root at `/tmp/fm-<id>/gotmp/`: `fm-spawn.sh` creates it, records `tasktmp=/tmp/fm-<id>` in the task meta, and exports `GOTMPDIR` into the crewmate pane before launch, so interrupted `go build`/`go test` runs drop their temp dirs there instead of polluting `/tmp`.
- `fm-teardown.sh` reads `tasktmp=` and removes the whole per-task temp root on cleanup; tasks spawned before this change (no `tasktmp=` line) tear down unchanged.
- Adds `tests/fm-gotmp.test.sh` covering creation, teardown cleanup, missing `tasktmp=`, and a non-existent dir, and documents the new `tasktmp=` meta field in `AGENTS.md`.

## Risk Assessment

✅ Low: Small, well-bounded change (mkdir + env export + teardown rm) with thorough isolated tests and backward-compatible empty/absent tasktmp handling; no correctness, security, or performance concerns found.

## Testing

`Demonstrated the full user intent end-to-end: Go's build WORK temp (the dir that leaks on interrupt) lands under the per-task GOTMPDIR with zero /tmp/go-build* leakage; fm-spawn creates /tmp/fm-<id>/gotmp/ and records tasktmp=; the export reaches a real tmux pane and is inherited by child go processes; the real fm-teardown.sh removes the tasktmp dir including leaked go-build content; and pre-fix metas without tasktmp= tear down gracefully. The project's own tests/fm-gotmp.test.sh passes 4/4. Worktree left clean; all evidence in the dedicated evidence directory.`

<details>
<summary>Evidence: Definitive proof: Go build WORK temp lands under GOTMPDIR</summary>

```text
$ go build -work -x with GOTMPDIR=$GOTMPDIR
WORK=/tmp/fm-work.cPvZ02/gotmp/go-build3237883459
$ ls $GOTMPDIR -> go-build3237883459/ (62 entries kept by -work)
$ /tmp/go-build* count after build: 0
=> An interrupted build leaks under the task's GOTMPDIR (removed by teardown), not into shared /tmp.
```
</details>
<details>
<summary>Evidence: Real tmux pane inherits GOTMPDIR (fm-spawn.sh:220-224 replicated)</summary>

```text
tmux send-keys -t pane "export GOTMPDIR=$TASK_TMP/gotmp" Enter; sleep 0.3
pane $GOTMPDIR = /tmp/fm-pane.1yAQs5/fm-pane-demo-q2/gotmp
go env GOTMPDIR = /tmp/fm-pane.1yAQs5/fm-pane-demo-q2/gotmp
Go build in pane -> 0 /tmp/go-build* dirs. PASS
```
</details>
<details>
<summary>Evidence: Real fm-teardown removes tasktmp dir (with leaked go-build content)</summary>

```text
bash $fake/bin/fm-teardown.sh e2e-td-m4 -> teardown exit: 0
after teardown: /tmp/fm-e2e.WRuAo2/fm-e2e-td-m4 exists = no
PASS: removed the tasktmp root and its leaked go-build content
```
</details>
<details>
<summary>Evidence: Project test suite: tests/fm-gotmp.test.sh</summary>

```text
ok - fm-spawn creates gotmp dir and records tasktmp in meta
ok - fm-teardown removes the dir pointed to by tasktmp= in meta
ok - fm-teardown skips gracefully when tasktmp= is absent (backward compat)
ok - fm-teardown skips gracefully when tasktmp= points to a nonexistent dir
GOTMP_TEST_EXIT=0
```
</details>
<details>
<summary>Evidence: Consolidated verification transcript</summary>

```text
============================================================================
GOTMPDIR feature end-to-end verification
Branch: set-gotmpdir-per-task-c7
Intent: stop interrupted Go builds from leaking /tmp/go-build* temp dirs.
Mechanism: per-task /tmp/fm-<id>/ with GOTMPDIR=/tmp/fm-<id>/gotmp in the
crewmate pane, recorded as tasktmp= in meta, removed by fm-teardown.sh.
============================================================================

[1] CORE MECHANISM — Go places its build temp UNDER GOTMPDIR, not /tmp
    Command: go build -work -x with GOTMPDIR set
    Result:  WORK=$GOTMPDIR/go-build3237883459   (the dir that leaks on interrupt)
             /tmp/go-build* count after build: 0
    => An interrupted build now leaks under the task's GOTMPDIR, which teardown
       removes deterministically, instead of into shared /tmp.

[2] fm-spawn contract (bin/fm-spawn.sh:140-141,211,220)
    - mkdir -p "$TASK_TMP/gotmp"   => creates /tmp/fm-<id>/gotmp/
    - echo "tasktmp=$TASK_TMP"     => recorded in state/<id>.meta
    - export GOTMPDIR into pane    => inherited by the agent and go children
    Behavioral sim of spawn's exact lines: gotmp dir created, tasktmp round-trips
    through teardown's `grep '^tasktmp=' | cut -d= -f2-`.  PASS

[3] REAL fm-teardown (bin/fm-teardown.sh:107) removes tasktmp dir
    Ran the real fm-teardown.sh as a subprocess against a fake FM_ROOT with a
    tasktmp= pointing at a dir containing a simulated leaked go-build artifact.
    Result: exit 0, dir removed (including the leaked content).  PASS

[4] Backward compatibility — pre-fix meta without tasktmp=
    Ran real fm-teardown.sh against a meta with NO tasktmp= line.
    Result: exit 0, no error, nothing removed.  PASS

[5] GOTMPDIR export reaches a real tmux pane (bin/fm-spawn.sh:220-224)
    Replicated spawn's exact `tmux send-keys "export GOTMPDIR=..." Enter; sleep`
    against a live pane, then read the pane back.
    Result: pane $GOTMPDIR = /tmp/fm-<id>/gotmp; go env GOTMPDIR inherited the
    same value; a Go build in that pane produced 0 /tmp/go-build* dirs.  PASS

[6] Project's own test suite: tests/fm-gotmp.test.sh — 4/4 ok, exit 0.

OVERALL: All behaviors demonstrated. No /tmp/go-build* leakage under the fix.
============================================================================
```
</details>
<details>
<summary>Evidence: E2E results (Parts 1-4)</summary>

```text
=== Part 1: Go uses GOTMPDIR for its build temp dir ===
baseline /tmp/go-build* dirs before build: 0
build exit: 0
go env GOTMPDIR (with env set): /tmp/fm-e2e.WRuAo2/gotmp
go env GOTMPDIR (unset default): 
baseline /tmp/go-build* dirs after build: 0 (unchanged => no leak to /tmp)
binary output: hello
PASS: Go honors GOTMPDIR; build temp stays out of /tmp
=== Part 2: spawn creates /tmp/fm-<id>/gotmp/ and records tasktmp= ===
created: /tmp/fm-e2e.WRuAo2/fm-e2e-sim-k9/gotmp/
meta round-trips: '/tmp/fm-e2e.WRuAo2/fm-e2e-sim-k9'
PASS: spawn pattern produces gotmp dir + round-trippable tasktmp=
=== Part 3: REAL fm-teardown removes the tasktmp dir ===
before teardown: /tmp/fm-e2e.WRuAo2/fm-e2e-td-m4 exists = yes
  with simulated leaked go-build content under gotmp/
teardown bin exists: lrwxrwxrwx 1 ubuntu ubuntu 94 Jun 29 22:06 /tmp/fm-e2e.WRuAo2/e2e-td-m4/bin/fm-teardown.sh -> /home/ubuntu/.no-mistakes/worktrees/507cc8072d97/01KWAP4GW4E6GS44ZKHYDEPSAH/bin/fm-teardown.sh
teardown e2e-td-m4 complete (window fakeses:fm-e2e-td-m4, worktree /tmp/fm-e2e.WRuAo2/nonexistent-wt-e2e-td-m4)
🌱 Backlog: e2e-td-m4 just finished. Update data/backlog.md - move e2e-td-m4 to Done (keep Done to the 10 most recent), then re-scan Queued for items now unblocked (a "blocked-by: e2e-td-m4" may have just cleared) or now time-due, and dispatch what's ready.
teardown exit: 0
after teardown: /tmp/fm-e2e.WRuAo2/fm-e2e-td-m4 exists = no
PASS: teardown removed the tasktmp root and its leaked go-build content
=== Part 4: backward compat — meta with no tasktmp= ===
teardown e2e-bc-n2 complete (window fakeses:fm-e2e-bc-n2, worktree /tmp/fm-e2e.WRuAo2/nonexistent-wt-e2e-bc-n2)
🌱 Backlog: e2e-bc-n2 just finished. Update data/backlog.md - move e2e-bc-n2 to Done (keep Done to the 10 most recent), then re-scan Queued for items now unblocked (a "blocked-by: e2e-bc-n2" may have just cleared) or now time-due, and dispatch what's ready.
PASS: pre-fix meta (no tasktmp=) tears down with exit 0
=== OVERALL: ALL-PASS ===
```
</details>
<details>
<summary>Evidence: Pane-export results (Part 5)</summary>

```text
=== Part 5: GOTMPDIR export lands in a real tmux pane (replicating fm-spawn.sh:217-224) ===
pane output:
PANE_GOTMPDIR=/tmp/fm-pane.1yAQs5/fm-pane-demo-q2/gotmp
GO_SEES=/tmp/fm-pane.1yAQs5/fm-pane-demo-q2/gotmp
  pane $GOTMPDIR = [/tmp/fm-pane.1yAQs5/fm-pane-demo-q2/gotmp]
  go env GOTMPDIR = [/tmp/fm-pane.1yAQs5/fm-pane-demo-q2/gotmp]
PASS: export landed in the pane AND Go (a child process) inherited GOTMPDIR
pane build result:  -o /tmp/fm-pane.1yAQs5/leakdemo . && echo BUILD_OK
new /tmp/go-build* dirs from pane build: 0
PASS: pane Go build succeeded with zero /tmp/go-build* leakage
=== Part 5 OVERALL: PASS ===
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`go build -work -x` with GOTMPDIR set — proved Go places its build WORK temp at $GOTMPDIR/go-build3237883459 and produces 0 /tmp/go-build* dirs</code>
- `bash tests/fm-gotmp.test.sh — the project's own suite (4/4 ok, exit 0)`
- `fm-gotmp-e2e.sh Part 1: Go respects GOTMPDIR; build temp stays out of /tmp`
- <code>fm-gotmp-e2e.sh Part 2: replicated fm-spawn.sh:140-141,211 mkdir + meta-write lines; gotmp dir created and tasktmp round-trips through teardown&#39;s `grep &#39;^tasktmp=&#39; | cut -d= -f2-`</code>
- `fm-gotmp-e2e.sh Part 3: ran real bin/fm-teardown.sh as subprocess against fake FM_ROOT with tasktmp= pointing at a dir holding a simulated leaked go-build artifact — exit 0, dir removed`
- `fm-gotmp-e2e.sh Part 4: ran real fm-teardown.sh against a meta with NO tasktmp= line — exit 0, no error (backward compat)`
- <code>fm-gotmp-pane.sh Part 5: replicated fm-spawn.sh:220-224 `tmux send-keys &#34;export GOTMPDIR=...&#34; Enter; sleep` against a live tmux pane — pane $GOTMPDIR and `go env GOTMPDIR` both inherited the value; a Go build in that pane produced 0 /tmp/go-build* dirs</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
