### PR TITLE
feat(bin): recurring automated review sweep across the fleet

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -467,7 +467,7 @@ Failing-CI PRs are **kept** (not skipped): their review brief adds an instructio
 
 The `review-rectify-pi` skill already deletes its prior `Review Findings - Rectification Status` comment and posts the fresh one (Phase 9); the sweep relies on that and does not re-implement comment deletion. After each review lands its comment, the sweep parses the recommendation: on a **clean APPROVE** (not CONDITIONAL APPROVE), it transitions the PR's linked Jira ticket (the `MILE-\d+` key from the title/body) to "In Review" via `jira issue move` — composing with the standing Jira rule. Status-only; it never merges.
 
-`--dry-run` enumerates, filters, and prints the plan without dispatching. `FM_SWEEP_CONCURRENCY` and `FM_SWEEP_TASK_TIMEOUT` (default 1800s) tune the run. Because it dispatches headlessly, it depends on `fm-spawn`'s headless-launch reliability - `--approve` to clear pi's project-trust gate, stable-worktree detection, and a post-launch verify that the harness binary is actually running (section 4).
+`--dry-run` enumerates, filters, and prints the plan without dispatching; `--one <owner>/<name>` restricts the run to a single fleet repo (for testing). `FM_SWEEP_CONCURRENCY` and `FM_SWEEP_TASK_TIMEOUT` (default 1800s) tune the run; a review that overruns the timeout is abandoned and left for inspection (window `fm-sweep-*`, worktree, meta) rather than torn down, so an unattended overrun may need manual cleanup. Because it dispatches headlessly, it depends on `fm-spawn`'s headless-launch reliability - `--approve` to clear pi's project-trust gate, stable-worktree detection, and a post-launch verify that the harness binary is actually running (section 4).
 
 ## 9. Escalation and captain etiquette
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,9 @@ state/               volatile runtime signals; gitignored
   .watch.lock .wake-queue.lock watcher singleton and queue serialization locks
   .hash-* .count-* .stale-* .seen-* .last-* .heartbeat-streak   watcher internals; never touch
   .last-watcher-beat watcher liveness beacon, touched every poll; fm-guard.sh reads it
+  sweep.log          recurring review sweep run log (cron appends here; section 8)
+  sweep/             per-run scratch for the review sweep (transient plan files)
+  .sweep.lock        flock guard so two review sweeps never overlap
 .no-mistakes/        local validation state and evidence; gitignored
 ```
 
@@ -175,7 +178,8 @@ If a pane shows the exit banner, relaunch with `--continue` to resume the sessio
 
 pi has no permission system - crewmates are always autonomous.
 Keep the brief as ONE positional argument - multiple positional args become separate queued messages (fm-spawn's template does this correctly).
-Project trust dialog can appear on the first pi run in any not-yet-trusted directory (observed even on clean worktrees); accept with Enter - the decision persists per path in `~/.pi/agent/trust.json`, so later spawns in the same worktree slot skip it.
+The launch template passes `--approve`, so pi trusts project-local files for each run and a spawned crewmate never blocks on pi's project-trust dialog - this is what lets the unattended review sweep dispatch pi headlessly.
+A pi you launch by hand still shows that dialog on the first run in a not-yet-trusted directory (observed even on clean worktrees); accept with Enter - the decision persists per path in `~/.pi/agent/trust.json`, so later manual runs in the same path skip it.
 fm-spawn keeps the turn-end extension in `state/`, outside the worktree, because project-local extension files make the trust gate strictly worse (and pollute the project).
 The extension must listen for pi's `turn_end` event, not `agent_end`, so the watcher wakes after each completed turn instead of only when the whole agent run exits.
 Environment marker for harness detection: pi sets `PI_CODING_AGENT=true` for its children.
@@ -463,7 +467,7 @@ Failing-CI PRs are **kept** (not skipped): their review brief adds an instructio
 
 The `review-rectify-pi` skill already deletes its prior `Review Findings - Rectification Status` comment and posts the fresh one (Phase 9); the sweep relies on that and does not re-implement comment deletion. After each review lands its comment, the sweep parses the recommendation: on a **clean APPROVE** (not CONDITIONAL APPROVE), it transitions the PR's linked Jira ticket (the `MILE-\d+` key from the title/body) to "In Review" via `jira issue move` — composing with the standing Jira rule. Status-only; it never merges.
 
-`--dry-run` enumerates, filters, and prints the plan without dispatching. `FM_SWEEP_CONCURRENCY` and `FM_SWEEP_TASK_TIMEOUT` (default 1800s) tune the run. Because it dispatches headlessly, it depends on `fm-spawn`'s headless-launch reliability (detection + post-launch verify).
+`--dry-run` enumerates, filters, and prints the plan without dispatching. `FM_SWEEP_CONCURRENCY` and `FM_SWEEP_TASK_TIMEOUT` (default 1800s) tune the run. Because it dispatches headlessly, it depends on `fm-spawn`'s headless-launch reliability - `--approve` to clear pi's project-trust gate, stable-worktree detection, and a post-launch verify that the harness binary is actually running (section 4).
 
 ## 9. Escalation and captain etiquette
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -448,6 +448,23 @@ Silence is the correct state while a healthy background watcher is waiting.
    The worktree and commits persist; this is cheap.
 5. Second relaunch fails too: write `failed` to backlog, tell the captain with evidence.
 
+### Recurring review sweep (cron)
+
+`bin/fm-review-sweep.sh` is a standalone, unattended sweep that reviews every open fleet PR on a fixed cadence, independent of the live supervisor. It is designed to run from cron (no firstmate session is required to be live):
+
+```sh
+0 */8 * * * /home/boks/Projects/firstmate/bin/fm-review-sweep.sh >> /home/boks/Projects/firstmate/state/sweep.log 2>&1
+```
+Firstmate installs the crontab line after merge; the script never installs it itself.
+
+Each run: enumerate every open PR across the fleet repos (resolved from `data/projects.md`), exclude drafts and already-approved PRs (`reviewDecision=APPROVED`), fetch CI status per PR, and dispatch a `review-rectify-pi` review in `--push` mode — **review-only, no code edits or fixes** — to each kept PR as a crewmate via `bin/fm-spawn.sh`, bounded to `FM_SWEEP_CONCURRENCY` (default **3**) concurrent reviews. The sweep is flock-guarded (no overlapping runs), best-effort per PR (a single PR's failure never aborts the run; `set -uo pipefail`, no `-e`), and logs a run summary to `state/sweep.log`.
+
+Failing-CI PRs are **kept** (not skipped): their review brief adds an instruction to investigate the CI failure root cause and include a `## CI Failure` section in the posted comment naming the failing job and error.
+
+The `review-rectify-pi` skill already deletes its prior `Review Findings - Rectification Status` comment and posts the fresh one (Phase 9); the sweep relies on that and does not re-implement comment deletion. After each review lands its comment, the sweep parses the recommendation: on a **clean APPROVE** (not CONDITIONAL APPROVE), it transitions the PR's linked Jira ticket (the `MILE-\d+` key from the title/body) to "In Review" via `jira issue move` — composing with the standing Jira rule. Status-only; it never merges.
+
+`--dry-run` enumerates, filters, and prints the plan without dispatching. `FM_SWEEP_CONCURRENCY` and `FM_SWEEP_TASK_TIMEOUT` (default 1800s) tune the run. Because it dispatches headlessly, it depends on `fm-spawn`'s headless-launch reliability (detection + post-launch verify).
+
 ## 9. Escalation and captain etiquette
 
 **Talk in outcomes, not mechanics.**

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ The first mate drives these; you rarely need to, but they work by hand too.
 | `fm-project-mode.sh`     | Resolve a project's delivery mode and `+yolo` flag from `data/projects.md`                                          |
 | `fm-merge-local.sh`      | Fast-forward a `local-only` project's local default branch after approval                                           |
 | `fm-review-diff.sh`      | Review a crewmate branch against the authoritative base, with optional `--stat` output                              |
+| `fm-review-sweep.sh`     | Unattended cron sweep: review every open fleet PR (review-rectify-pi `--push`, review-only), bounded concurrency, Jira tie-in |
 | `fm-watch.sh`            | Singleton-safe one-shot watcher; blocks until supervision work is due, queues it durably, then exits with one reason line |
 | `fm-wake-drain.sh`       | Atomically drain queued watcher wakes before handling supervision work                                              |
 | `fm-send.sh`             | Send one literal line (or `--key Escape`) to a crewmate window                                                      |
@@ -168,6 +169,8 @@ FM_SIGNAL_GRACE=30      # seconds to coalesce nearby status and turn-end signals
 FM_FLEET_SYNC_BOOTSTRAP_TIMEOUT=20   # seconds allowed for bootstrap's best-effort clone refresh
 FM_FLEET_PRUNE=1        # set to 0 to skip pruning local branches whose upstream is gone
 FM_BUSY_REGEX='esc (to )?interrupt|Working\.\.\.'   # busy-pane signatures, extend per harness
+FM_SWEEP_CONCURRENCY=3  # max concurrent reviews in the recurring review sweep
+FM_SWEEP_TASK_TIMEOUT=1800  # seconds allowed per review in the recurring review sweep
 ```
 
 ## Development

--- a/bin/fm-review-sweep.sh
+++ b/bin/fm-review-sweep.sh
@@ -219,7 +219,19 @@ spawn_review() {
         "$FM_ROOT/bin/fm-spawn.sh" "$id" "$FM_ROOT/$proj" 2>&1) || spawn_rc=$?
   if [ "$spawn_rc" -ne 0 ]; then
     log "  error   $repo#$num fm-spawn failed (rc=$spawn_rc): $(printf '%s' "$spawn_out" | tail -1)"
-    rm -f "$FM_ROOT/state/$id.meta" "$status_file"; rm -rf "$FM_ROOT/data/$id"
+    # fm-spawn may already have created the window and/or worktree before failing;
+    # reclaim both so repeated sweep runs do not leak them.
+    tmux kill-window -t "fm-$id" 2>/dev/null || true
+    local fmeta="$FM_ROOT/state/$id.meta" fwt fproj
+    if [ -f "$fmeta" ]; then
+      fwt=$(grep '^worktree=' "$fmeta" 2>/dev/null | cut -d= -f2-)
+      fproj=$(grep '^project=' "$fmeta" 2>/dev/null | cut -d= -f2-)
+      if [ -n "$fwt" ] && [ -n "$fproj" ]; then
+        ( cd "$fproj" && treehouse return --force "$fwt" ) >/dev/null 2>&1 || true
+      fi
+    fi
+    rm -f "$fmeta" "$status_file" "$FM_ROOT/state/$id.turn-ended" "$FM_ROOT/state/$id.pi-ext.ts"
+    rm -rf "$FM_ROOT/data/$id"
     return 1
   fi
   log "  spawn   $repo#$num -> $id (cifail=$cifail)"
@@ -278,16 +290,26 @@ maybe_transition_jira() {
 # ---- teardown a sweep crewmate (best-effort) -------------------------------
 teardown_task() {
   local id=$1
-  local window="fm-$id"
+  local meta="$FM_ROOT/state/$id.meta"
+  local window="fm-$id" wt="" proj=""
+  if [ -f "$meta" ]; then
+    window=$(grep '^window=' "$meta" 2>/dev/null | cut -d= -f2-)
+    wt=$(grep '^worktree=' "$meta" 2>/dev/null | cut -d= -f2-)
+    proj=$(grep '^project=' "$meta" 2>/dev/null | cut -d= -f2-)
+  fi
+  [ -n "$window" ] || window="fm-$id"
   # Tell pi to quit, then exit the treehouse subshell, then kill the window.
   tmux send-keys -t "$window" '/quit' Enter 2>/dev/null || true
   sleep 2
   tmux send-keys -t "$window" 'exit' Enter 2>/dev/null || true
   sleep 1
   tmux kill-window -t "$window" 2>/dev/null || true
-  # return the worktree to the pool if treehouse still holds it
-  treehouse prune --yes >/dev/null 2>&1 || true
-  rm -f "$FM_ROOT/state/$id.meta" "$FM_ROOT/state/$id.turn-ended" \
+  # return THIS task's worktree to the pool (deterministic; a global prune could
+  # reap another live task's worktree when the sweep runs alongside a session).
+  if [ -n "$wt" ] && [ -n "$proj" ]; then
+    ( cd "$proj" && treehouse return --force "$wt" ) >/dev/null 2>&1 || true
+  fi
+  rm -f "$meta" "$FM_ROOT/state/$id.turn-ended" \
         "$FM_ROOT/state/$id.pi-ext.ts" "$FM_ROOT/state/$id.status"
   rm -rf "$FM_ROOT/data/$id"
 }
@@ -299,7 +321,10 @@ main() {
 while [ $# -gt 0 ]; do
   case "$1" in
     --dry-run) DRY_RUN=1; shift ;;
-    --one) ONLY_REPO="${2:-}"; shift 2 ;;
+    --one)
+      [ $# -ge 2 ] || { echo "error: --one requires a repo argument" >&2; exit 2; }
+      ONLY_REPO="$2"; shift 2
+      ;;
     -h|--help)
       sed -n '2,40p' "$0"; exit 0 ;;
     *) echo "error: unknown arg '$1'" >&2; exit 2 ;;
@@ -353,7 +378,7 @@ if [ "$DRY_RUN" -eq 1 ]; then
   if [ "$total" -eq 0 ]; then
     say "(no candidate PRs after filters)"
   else
-    printf 'repo\t#cifail\ttitle\turl\n' 
+    printf 'repo\t#num\tcifail\ttitle\n' 
     while IFS=$'\t' read -r repo num cifail title url head proj; do
       printf '%s\t#%s\t%s\t%s\n' "$repo" "$num" "$cifail" "$title"
     done < "$PLAN_FILE"
@@ -404,7 +429,12 @@ try_reap() {
   log "  result  $repo#$num status='$last' recommendation='${decision}'"
   say "sweep: $repo#$num -> recommendation=${decision:-unknown} ($last)"
   if [ -n "$decision" ]; then maybe_transition_jira "$repo" "$num" "$decision"; fi
-  teardown_task "$id"
+  if [ "$last" != "timeout" ]; then
+    teardown_task "$id"
+  else
+    # Leave the window + worktree intact so an unattended overrun can be inspected.
+    log "  inspect  $repo#$num ($id) left for inspection: window fm-$id, meta state/$id.meta"
+  fi
   reviewed=$((reviewed + 1))
   # compact: move last element into slot i, then pop (order does not matter).
   local last_idx=$((${#A_ID[@]} - 1))

--- a/bin/fm-review-sweep.sh
+++ b/bin/fm-review-sweep.sh
@@ -217,14 +217,13 @@ spawn_review() {
   : > "$status_file"
   # Spawn headlessly (cron has no TMUX). FM_SPAWN_NO_GUARD: no watcher to guard.
   local spawn_out spawn_rc=0
-  if ! spawn_out=$(env -u TMUX FM_SPAWN_NO_GUARD=1 \
-        "$FM_ROOT/bin/fm-spawn.sh" "$id" "$FM_ROOT/$proj" 2>&1); then
-    spawn_rc=$?
+  spawn_out=$(env -u TMUX FM_SPAWN_NO_GUARD=1 \
+        "$FM_ROOT/bin/fm-spawn.sh" "$id" "$FM_ROOT/$proj" 2>&1) || spawn_rc=$?
+  if [ "$spawn_rc" -ne 0 ]; then
     log "  error   $repo#$num fm-spawn failed (rc=$spawn_rc): $(printf '%s' "$spawn_out" | tail -1)"
     rm -f "$FM_ROOT/state/$id.meta" "$status_file"; rm -rf "$FM_ROOT/data/$id"
     return 1
   fi
-  printf '%s\n' "$id" >> "$SWEEP_RUN_DIR/.active"
   log "  spawn   $repo#$num -> $id (cifail=$cifail)"
   SPAWN_ID="$id"
 }
@@ -240,7 +239,6 @@ parse_recommendation() {
   comments=$(gh api "repos/$repo/issues/$num/comments" --jq '.[].body' 2>/dev/null) || { echo ""; return; }
   # Find the recommendation line in the review-rectify comment block.
   line=$(printf '%s\n' "$comments" | grep -iE '^[# ]*Recommendation:' | tail -1)
-  [ -n "$line" ] || line=$(printf '%s\n' "$comments" | grep -iE 'Recommendation:' | tail -1)
   [ -n "$line" ] || { echo ""; return; }
   # strip up to the colon, take the first decision word, uppercase
   local decision
@@ -337,6 +335,7 @@ FLEET=$(resolve_fleet)
 # Collect candidate PRs into a plan.
 PLAN_FILE="$SWEEP_RUN_DIR/$$.plan"
 : > "$PLAN_FILE"
+trap 'rm -f "$PLAN_FILE"' EXIT
 considered=0
 while IFS=$'\t' read -r repo proj; do
   [ -n "$repo" ] || continue
@@ -385,9 +384,10 @@ try_reap() {
   id=${A_ID[i]}; repo=${A_REPO[i]}; num=${A_NUM[i]}; dl=${A_DEADLINE[i]}
   now=$(date +%s)
   last=$(tail -1 "$FM_ROOT/state/$id.status" 2>/dev/null || true)
-  local finished=0
+  local finished=0 review_posted=0
   case "$last" in
-    done:*|failed:*|blocked:*|needs-decision:*) finished=1 ;;
+    done:*) finished=1; review_posted=1 ;;
+    failed:*|blocked:*|needs-decision:*) finished=1 ;;
   esac
   if [ "$finished" -ne 1 ]; then
     # window gone? crewmate exited without terminal status.
@@ -402,7 +402,7 @@ try_reap() {
   [ "$finished" -eq 1 ] || return 1
   # Collect result.
   local decision=""
-  decision=$(parse_recommendation "$repo" "$num")
+  [ "$review_posted" -eq 1 ] && decision=$(parse_recommendation "$repo" "$num")
   log "  result  $repo#$num status='$last' recommendation='${decision}'"
   say "sweep: $repo#$num -> recommendation=${decision:-unknown} ($last)"
   if [ -n "$decision" ]; then maybe_transition_jira "$repo" "$num" "$decision"; fi

--- a/bin/fm-review-sweep.sh
+++ b/bin/fm-review-sweep.sh
@@ -1,0 +1,474 @@
+#!/usr/bin/env bash
+# fm-review-sweep.sh — recurring, automated review sweep across the whole fleet.
+#
+# Every run: enumerate every OPEN PR across the fleet repos, drop drafts and
+# already-approved PRs (GitHub reviewDecision=APPROVED), fetch CI status per PR,
+# and dispatch a review-rectify-pi review (in --push mode, REVIEW-ONLY: no code
+# edits, no fixes) to each kept PR as a firstmate crewmate via bin/fm-spawn.sh,
+# bounded to FM_SWEEP_CONCURRENCY (3) concurrent reviews. After each review lands
+# its PR comment, parse the recommendation; on a clean APPROVE, transition the
+# PR's linked Jira ticket (MILE-\d+) to "In Review". A single PR's failure never
+# aborts the sweep. Designed to run unattended from cron (no live firstmate).
+#
+# Usage:
+#   fm-review-sweep.sh             # run the sweep (dispatch + review + jira)
+#   fm-review-sweep.sh --dry-run   # enumerate + filter + print the plan, dispatch nothing
+#   fm-review-sweep.sh --one REPO  # run only one repo (full name owner/name) — for testing
+#
+# Cron (every 8 hours; firstmate installs this after merge — do NOT auto-install):
+#   0 */8 * * * /home/boks/Projects/firstmate/bin/fm-review-sweep.sh >> /home/boks/Projects/firstmate/state/sweep.log 2>&1
+#
+# Concurrency: FM_SWEEP_CONCURRENCY (default 3). Bounded by gating the dispatch
+# loop on the count of running sweep crewmates.
+# Per-review timeout: FM_SWEEP_TASK_TIMEOUT (default 1800s = 30min). A review that
+# overruns is abandoned (window left for inspection) so the sweep always progresses.
+# Fleet repos: parsed from data/projects.md (the github.com/<owner>/<name> URLs).
+# Log: state/sweep.log (timestamped run summary: considered/filtered/reviewed,
+# per-PR recommendation, Jira moves, failures).
+#
+# Review-only contract: the dispatched crewmate runs review-rectify-pi --push and
+# POSTS/REPLACES the single "Review Findings - Rectification Status" comment
+# (the skill's Phase 9 already deletes its prior comment — we do not re-implement
+# that). It never edits code or pushes fixes. For failing-CI PRs the brief adds an
+# "investigate the CI failure root cause and include a ## CI Failure section"
+# instruction so the posted review names the failing job + the error.
+set -uo pipefail   # NOT -e: a single PR's failure must not abort the whole sweep.
+
+FM_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+STATE_DIR="$FM_ROOT/state"
+PROJECTS_MD="$FM_ROOT/data/projects.md"
+SWEEP_LOG="$STATE_DIR/sweep.log"
+SWEEP_RUN_DIR="$STATE_DIR/sweep"          # per-run scratch (task ids, briefs live under data/)
+mkdir -p "$STATE_DIR" "$SWEEP_RUN_DIR"
+
+CONCURRENCY="${FM_SWEEP_CONCURRENCY:-3}"
+TASK_TIMEOUT="${FM_SWEEP_TASK_TIMEOUT:-1800}"
+DRY_RUN=0
+ONLY_REPO=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dry-run) DRY_RUN=1; shift ;;
+    --one) ONLY_REPO="${2:-}"; shift 2 ;;
+    -h|--help)
+      sed -n '2,40p' "$0"; exit 0 ;;
+    *) echo "error: unknown arg '$1'" >&2; exit 2 ;;
+  esac
+done
+
+log() { printf '%s\n' "$*" >> "$SWEEP_LOG"; }
+say() { printf '%s\n' "$*"; }   # stdout (cron redirects both to sweep.log via >>2>&1)
+
+# ---- flock: never overlap two sweeps ---------------------------------------
+LOCK_FD=9
+exec 9>>"$STATE_DIR/.sweep.lock"
+if ! flock -n "$LOCK_FD"; then
+  say "sweep: another run holds the lock; exiting"
+  exit 0
+fi
+
+ts() { date -u +"%Y-%m-%dT%H:%M:%SZ"; }
+RUN_TS="$(ts)"
+log ""
+log "==== sweep start $RUN_TS (dry-run=$DRY_RUN, concurrency=$CONCURRENCY) ===="
+
+# ---- prerequisites ----------------------------------------------------------
+need() { command -v "$1" >/dev/null 2>&1 || { say "error: missing required tool '$1'"; exit 1; }; }
+need gh
+need tmux
+need jq
+need git
+# jira is optional (only the transition needs it); checked lazily where used.
+
+# ---- resolve fleet repos from data/projects.md -----------------------------
+# Each registry line carries a github.com/<owner>/<name> URL. Emit
+# "<owner>/<name>\t<local-clone-path>" per repo. The local clone path is needed
+# so fm-spawn can `treehouse get` a worktree of that repo.
+resolve_fleet() {
+  [ -f "$PROJECTS_MD" ] || { say "error: no fleet registry at $PROJECTS_MD"; exit 1; }
+  local line url owner name proj
+  # project name is the first token of each "- <name> [...]" bullet; the local
+  # clone lives at projects/<name>. The github URL is the github.com/<o>/<n> token.
+  while IFS= read -r line; do
+    case "$line" in
+      *github.com/*)
+        url=$(printf '%s' "$line" | grep -oE 'github.com/[^ )"]+' | head -1 | sed 's#github.com/##')
+        proj=$(printf '%s' "$line" | grep -oE '^- [A-Za-z0-9_-]+' | sed 's/^- //')
+        [ -n "$url" ] && [ -n "$proj" ] || continue
+        # strip a trailing .git if present
+        url="${url%.git}"
+        printf '%s\t%s\n' "$url" "projects/$proj"
+        ;;
+    esac
+  done < "$PROJECTS_MD"
+}
+
+# ---- CI status for a PR: returns "fail" | "pass" | "unknown" ----------------
+# gh pr checks --json state values: SUCCESS, FAILURE, STARTED, PENDING, SKIPPED,
+# CANCELLED, TIMED_OUT, etc. We treat a PR as CI-failing only if at least one
+# check is in a hard-failure state; pending/running/missing checks are not fails.
+ci_status() {
+  local repo=$1 num=$2 states out
+  if ! out=$(gh pr checks "$num" --repo "$repo" --json state -q '[.[].state]' 2>/dev/null); then
+    echo unknown; return
+  fi
+  states=$(printf '%s' "$out" | tr -d ' \n[]"')
+  [ -z "$states" ] && { echo unknown; return; }
+  # hard failures
+  case "$states" in
+    *FAILURE*|*TIMED_OUT*|*CANCELLED*|*ACTION_REQUIRED*) echo fail; return ;;
+  esac
+  echo pass
+}
+
+# ---- enumerate candidate PRs for one repo ----------------------------------
+# Emits TSV rows: repo<TAB>num<TAB>cifail<TAB>title<TAB>url<TAB>headRefOid
+# Drafts and APPROVED PRs are excluded here.
+emit_repo_prs() {
+  local repo=$1 proj=$2 prs json num draft dec cifail title url head
+  prs=$(gh pr list --repo "$repo" --state open --limit 100 \
+        --json number,isDraft,reviewDecision,title,url,headRefOid 2>/dev/null) || return 0
+  [ -n "$prs" ] || return 0
+  while IFS=$'\t' read -r num draft dec title url head; do
+    [ -n "$num" ] || continue
+    # filter: exclude drafts
+    [ "$draft" = "true" ] && { log "  filter  $repo#$num draft"; continue; }
+    # filter: exclude already-approved (reviewDecision=APPROVED)
+    [ "$dec" = "APPROVED" ] && { log "  filter  $repo#$num approved"; continue; }
+    cifail=$(ci_status "$repo" "$num")
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' "$repo" "$num" "$cifail" "$title" "$url" "$head" "$proj"
+  done < <(printf '%s' "$prs" | jq -r '.[] | [.number, (.isDraft|tostring), (.reviewDecision // ""), .title, .url, .headRefOid] | @tsv')
+}
+
+# ---- build a per-PR review brief -------------------------------------------
+# Review-only: check out the PR head, run review-rectify-pi --push, report done.
+# For failing-CI PRs, add the "investigate root cause + ## CI Failure section" rule.
+write_brief() {
+  local id=$1 repo=$2 num=$3 cifail=$4 proj=$5
+  local brief_dir="$FM_ROOT/data/$id"
+  mkdir -p "$brief_dir"
+  local status_file="$FM_ROOT/state/$id.status"
+  local repo_dir="$FM_ROOT/$proj"
+  local cifail_rule=""
+  if [ "$cifail" = "fail" ]; then
+    cifail_rule=$(
+      cat <<'EOF'
+
+## CI failure (this PR's CI is RED — investigate before reviewing)
+This PR's GitHub checks are FAILING. As part of this review you MUST investigate
+the ROOT CAUSE of the CI failure and include a `## CI Failure` section in the
+posted review comment. Steps:
+- `gh pr checks <NUM> --repo <REPO>` to list the checks; identify the FAILING job(s).
+- Open the failing job's log: `gh run view <run-id> --repo <REPO> --log-failed`
+  (or the job URL from `gh pr checks`). Read the actual error.
+- Name the failing job and quote the error in the `## CI Failure` section, with a
+  one-line root-cause assessment (compile error, test failure, lint, env, flake?).
+The review-rectify-pi recommendation may still be APPROVE if the code is sound
+and CI fails for an unrelated/env reason — but the failure MUST be documented.
+EOF
+    )
+    cifail_rule=${cifail_rule//<NUM>/$num}
+    cifail_rule=${cifail_rule//<REPO>/$repo}
+  fi
+
+  cat > "$brief_dir/brief.md" <<EOF
+You are a crewmate dispatched by the automated review sweep. Work autonomously; do not wait for a human.
+
+# Task
+Run a **fresh code review** of PR **$repo#$num** and post it as the PR's review
+comment. This is **REVIEW-ONLY**: review and post — do NOT edit any code, do NOT
+push any fix, do NOT change the branch beyond checking out the PR to review it.
+
+# Engine
+Use the **review-rectify-pi** skill in **\`--push\`** mode. Invoke it so it runs
+its full pipeline (existing-comment rectification + fresh code review + merged
+findings table + recommendation) and posts/replaces the single
+"Review Findings - Rectification Status" comment on the PR.
+
+# Setup
+You are in a treehouse worktree of \`$repo\` (clone at \`$repo_dir\`) on a detached
+HEAD of the default branch. To review THIS PR, check out its head commit IN THIS
+WORKTREE (never touch the pooled clone — review here, in your disposable worktree):
+1. \`gh pr checkout $num --repo $repo\`  — run this from your worktree; it fetches
+   the PR head and checks it out locally. If it refuses (shared worktree / branch
+   exists), fall back to a detached checkout of the head:
+   \`git fetch origin pull/$num/head && git checkout --detach FETCH_HEAD\`.
+2. Confirm you are on the PR head: \`git rev-parse HEAD\` should equal the PR's
+   head SHA (\`gh pr view $num --repo $repo --json headRefOid -q .headRefOid\`).
+$cifail_rule
+
+# How to run the review
+- Invoke review-rectify-pi with **\`--push\`** so it posts the comment to GitHub.
+- The skill already deletes its prior "Review Findings - Rectification Status"
+  comment and posts the fresh one (Phase 9) — do NOT manually delete comments.
+- Scope the review to the PR's diff. The skill computes diff scope itself; make
+  sure you are on the PR head (step above) so \`git diff main...HEAD\` is correct.
+- Pre-push validation (Phase 8.5) runs the project's lint/typecheck/test. If that
+  fails because of the RED CI, that is expected for failing-CI PRs — still post
+  the review with the \`## CI Failure\` section; do not block on Phase 8.5.
+
+# Rules
+1. REVIEW-ONLY. Never edit project code, never commit, never push, never open or
+   merge a PR. The only GitHub write you do is the review comment (via the skill).
+2. Stay inside this worktree; the only files you may write outside it are the
+   status file below.
+3. Use gh / gh-axi for GitHub operations.
+4. Report status by appending one line:
+   \`echo "{state}: {one short line}" >> $status_file\`
+   States: working, needs-decision, blocked, done, failed.
+5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop.
+6. If a decision belongs to a human, append \`needs-decision: {summary}\` and stop.
+
+# Definition of done
+The review comment is posted to $repo#$num. When posted, append
+\`done: posted review to $repo#$num\` to the status file and STOP (exit pi with
+\`/quit\`). Do not attempt to fix anything the review found.
+EOF
+  echo "$brief_dir/brief.md"
+}
+
+# ---- spawn one review (non-blocking) -------------------------------------
+# Writes the brief and spawns the crewmate via fm-spawn. Returns 0 and sets
+# SPAWN_ID on success; the caller then owns waiting for that task. fm-spawn
+# itself blocks until the harness is confirmed running (its post-launch verify),
+# so when this returns the crewmate is live and processing the brief — but the
+# review is NOT done yet. Best-effort: never aborts the caller.
+spawn_review() {
+  local repo=$1 num=$2 cifail=$3 proj=$4
+  local id="sweep-$(printf '%s' "$repo" | tr '/.' '--')-${num}-$$"
+  local status_file="$FM_ROOT/state/$id.status"
+  local brief
+  brief=$(write_brief "$id" "$repo" "$num" "$cifail" "$proj") || { log "  error   $repo#$num brief write failed"; return 1; }
+  : > "$status_file"
+  # Spawn headlessly (cron has no TMUX). FM_SPAWN_NO_GUARD: no watcher to guard.
+  local spawn_out spawn_rc=0
+  if ! spawn_out=$(env -u TMUX FM_SPAWN_NO_GUARD=1 \
+        "$FM_ROOT/bin/fm-spawn.sh" "$id" "$FM_ROOT/$proj" 2>&1); then
+    spawn_rc=$?
+    log "  error   $repo#$num fm-spawn failed (rc=$spawn_rc): $(printf '%s' "$spawn_out" | tail -1)"
+    rm -f "$FM_ROOT/state/$id.meta" "$status_file"; rm -rf "$FM_ROOT/data/$id"
+    return 1
+  fi
+  printf '%s\n' "$id" >> "$SWEEP_RUN_DIR/.active"
+  log "  spawn   $repo#$num -> $id (cifail=$cifail)"
+  SPAWN_ID="$id"
+}
+
+# ---- wait for one task to finish (blocking) -------------------------------
+# Polls the task's status file (and window liveness) until a terminal status or
+# timeout. Sets WAIT_STATUS. Used by the concurrent pool reaper.
+wait_review() {
+  local id=$1 window="fm-$id"
+  local status_file="$FM_ROOT/state/$id.status"
+  local deadline=$(( $(date +%s) + TASK_TIMEOUT ))
+  local last=""
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    last=$(tail -1 "$status_file" 2>/dev/null || true)
+    case "$last" in
+      done:*|failed:*|blocked:*|needs-decision:*) break ;;
+    esac
+    # Fallback: window gone means the crewmate exited without a terminal status.
+    if ! tmux list-windows -a -F '#{window_name}' 2>/dev/null | grep -qx "$window"; then
+      [ -n "$last" ] || { echo "done: window-exited" >> "$status_file"; last="done: window-exited"; }
+      break
+    fi
+    sleep 15
+  done
+  if [ "$(date +%s)" -ge "$deadline" ]; then
+    case "$last" in
+      done:*|failed:*|blocked:*|needs-decision:*) : ;;
+      *) last="timeout"; log "  timeout $id after ${TASK_TIMEOUT}s" ;;
+    esac
+  fi
+  WAIT_STATUS="$last"
+}
+
+# ---- parse the recommendation from the posted PR comment -------------------
+# review-rectify-pi posts a comment whose closing section contains a line:
+#   ### Recommendation: APPROVE    (or BLOCK / REQUEST CHANGES / CAUTION /
+#                                   CONDITIONAL APPROVE)
+# We must detect a CLEAN APPROVE only (not CONDITIONAL APPROVE). Returns the
+# bare decision word (uppercased) or "" if not found.
+parse_recommendation() {
+  local repo=$1 num=$2 comments line
+  comments=$(gh api "repos/$repo/issues/$num/comments" --jq '.[].body' 2>/dev/null) || { echo ""; return; }
+  # Find the recommendation line in the review-rectify comment block.
+  line=$(printf '%s\n' "$comments" | grep -iE '^[# ]*Recommendation:' | tail -1)
+  [ -n "$line" ] || line=$(printf '%s\n' "$comments" | grep -iE 'Recommendation:' | tail -1)
+  [ -n "$line" ] || { echo ""; return; }
+  # strip up to the colon, take the first decision word, uppercase
+  local decision
+  decision=$(printf '%s' "$line" | sed -E 's/.*[Rr]ecommendation:[[:space:]]*//' | awk '{print toupper($1)}')
+  # CONDITIONAL APPROVE: the first word is CONDITIONAL — surface it distinctly.
+  printf '%s\n' "$decision"
+}
+
+# ---- Jira tie-in: on clean APPROVE, move MILE-<key> to "In Review" ---------
+jira_key_for() {
+  local repo=$1 num=$2 key
+  # Firstmate's records (brief/backlog) are the preferred source, but the sweep
+  # is self-contained: parse MILE-\d+ from the PR title/body.
+  key=$(gh pr view "$num" --repo "$repo" --json title,body -q '.title + "\n" + .body' 2>/dev/null \
+        | grep -oE 'MILE-[0-9]+' | head -1)
+  printf '%s\n' "$key"
+}
+
+maybe_transition_jira() {
+  local repo=$1 num=$2 decision=$3 key out
+  [ "$decision" = "APPROVE" ] || return 0
+  key=$(jira_key_for "$repo" "$num")
+  if [ -z "$key" ]; then
+    log "  jira    $repo#$num APPROVE but no MILE- key in title/body; skipping transition"
+    return 0
+  fi
+  if ! command -v jira >/dev/null 2>&1; then
+    log "  jira    $repo#$num APPROVE ($key) but 'jira' CLI not found; skipping transition"
+    return 0
+  fi
+  if out=$(jira issue move "$key" "In Review" 2>&1); then
+    log "  jira    $repo#$num APPROVE -> moved $key to In Review"
+    say "jira: moved $key to In Review ($repo#$num approved by sweep)"
+  else
+    log "  jira    $repo#$num APPROVE -> FAILED to move $key: $(printf '%s' "$out" | tail -1)"
+  fi
+}
+
+# ---- teardown a sweep crewmate (best-effort) -------------------------------
+teardown_task() {
+  local id=$1 window="fm-$id"
+  # Tell pi to quit, then exit the treehouse subshell, then kill the window.
+  tmux send-keys -t "$window" '/quit' Enter 2>/dev/null || true
+  sleep 2
+  tmux send-keys -t "$window" 'exit' Enter 2>/dev/null || true
+  sleep 1
+  tmux kill-window -t "$window" 2>/dev/null || true
+  # return the worktree to the pool if treehouse still holds it
+  treehouse prune --yes >/dev/null 2>&1 || true
+  rm -f "$FM_ROOT/state/$id.meta" "$FM_ROOT/state/$id.turn-ended" \
+        "$FM_ROOT/state/$id.pi-ext.ts" "$FM_ROOT/state/$id.status"
+  rm -rf "$FM_ROOT/data/$id"
+}
+
+# ============================================================================
+# Main
+# ============================================================================
+say "sweep: enumerating fleet PRs..."
+FLEET=$(resolve_fleet)
+[ -n "$FLEET" ] || { say "sweep: no fleet repos resolved; nothing to do"; log "==== sweep end (no repos) ===="; exit 0; }
+
+# Collect candidate PRs into a plan.
+PLAN_FILE="$SWEEP_RUN_DIR/$$.plan"
+: > "$PLAN_FILE"
+considered=0
+while IFS=$'\t' read -r repo proj; do
+  [ -n "$repo" ] || continue
+  if [ -n "$ONLY_REPO" ] && [ "$repo" != "$ONLY_REPO" ]; then continue; fi
+  say "  repo $repo ($proj)"
+  emit_repo_prs "$repo" "$proj" >> "$PLAN_FILE" 2> >(log)
+  considered=$((considered + 1))
+done < <(printf '%s\n' "$FLEET")
+
+total=$(wc -l < "$PLAN_FILE" | tr -d ' ')
+log "  plan    $total candidate PR(s) across $considered repo(s) (after draft+approved filters)"
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  say ""
+  say "==== DRY RUN PLAN ===="
+  say "concurrency=$CONCURRENCY  task_timeout=${TASK_TIMEOUT}s"
+  if [ "$total" -eq 0 ]; then
+    say "(no candidate PRs after filters)"
+  else
+    printf 'repo\t#cifail\ttitle\turl\n' 
+    while IFS=$'\t' read -r repo num cifail title url head proj; do
+      printf '%s\t#%s\t%s\t%s\n' "$repo" "$num" "$cifail" "$title"
+    done < "$PLAN_FILE"
+  fi
+  say "==== END DRY RUN (dispatched nothing) ===="
+  log "==== sweep end (dry-run, $total candidates) ===="
+  exit 0
+fi
+
+# Dispatch with TRUE bounded concurrency: spawn up to CONCURRENCY reviews at
+# once, then reap finished ones and refill slots. Each task is polled
+# round-robin (non-blocking status check) rather than blocking on one at a time.
+reviewed=0
+failures=0
+# Active pool, held as parallel arrays indexed identically:
+#   A_ID[i] A_REPO[i] A_NUM[i] A_DEADLINE[i]
+A_ID=(); A_REPO=(); A_NUM=(); A_DEADLINE=()
+
+# helper: current length of the active pool
+pool_size() { echo "${#A_ID[@]}"; }
+
+# helper: reap one finished task at index i (parse rec, jira, teardown), then
+# compact it out of the arrays. Returns 0 if it reaped one, 1 if still running.
+try_reap() {
+  local i=$1 id repo num dl now last
+  id=${A_ID[i]}; repo=${A_REPO[i]}; num=${A_NUM[i]}; dl=${A_DEADLINE[i]}
+  now=$(date +%s)
+  last=$(tail -1 "$FM_ROOT/state/$id.status" 2>/dev/null || true)
+  local finished=0
+  case "$last" in
+    done:*|failed:*|blocked:*|needs-decision:*) finished=1 ;;
+  esac
+  if [ "$finished" -ne 1 ]; then
+    # window gone? crewmate exited without terminal status.
+    if ! tmux list-windows -a -F '#{window_name}' 2>/dev/null | grep -qx "fm-$id"; then
+      [ -n "$last" ] || { last="done: window-exited"; echo "$last" >> "$FM_ROOT/state/$id.status"; }
+      finished=1
+    elif [ "$now" -ge "$dl" ]; then
+      last="timeout"; finished=1
+      log "  timeout $repo#$num ($id) after ${TASK_TIMEOUT}s"
+    fi
+  fi
+  [ "$finished" -eq 1 ] || return 1
+  # Collect result.
+  local decision=""
+  decision=$(parse_recommendation "$repo" "$num")
+  log "  result  $repo#$num status='$last' recommendation='${decision}'"
+  say "sweep: $repo#$num -> recommendation=${decision:-unknown} ($last)"
+  if [ -n "$decision" ]; then maybe_transition_jira "$repo" "$num" "$decision"; fi
+  teardown_task "$id"
+  reviewed=$((reviewed + 1))
+  # compact: move last element into slot i, then pop (order does not matter).
+  local last_idx=$((${#A_ID[@]} - 1))
+  if [ "$i" -lt "$last_idx" ]; then
+    A_ID[i]=${A_ID[last_idx]}; A_REPO[i]=${A_REPO[last_idx]}
+    A_NUM[i]=${A_NUM[last_idx]}; A_DEADLINE[i]=${A_DEADLINE[last_idx]}
+  fi
+  unset 'A_ID[last_idx]' 'A_REPO[last_idx]' 'A_NUM[last_idx]' 'A_DEADLINE[last_idx]'
+  return 0
+}
+
+while IFS=$'\t' read -r repo num cifail title url head proj; do
+  [ -n "$repo" ] || continue
+  # Concurrency gate: if the pool is full, reap until a slot opens.
+  while [ "$(pool_size)" -ge "$CONCURRENCY" ]; do
+    reaped=0
+    for ((i=0; i<${#A_ID[@]}; i++)); do
+      if try_reap "$i"; then reaped=1; break; fi
+    done
+    [ "$reaped" -eq 1 ] || sleep 15   # all still running; wait and retry
+  done
+  say "sweep: reviewing $repo#$num (cifail=$cifail)"
+  SPAWN_ID=""
+  if spawn_review "$repo" "$num" "$cifail" "$proj"; then
+    A_ID+=("$SPAWN_ID"); A_REPO+=("$repo"); A_NUM+=("$num")
+    A_DEADLINE+=($(( $(date +%s) + TASK_TIMEOUT )))
+  else
+    failures=$((failures + 1))
+    log "  result  $repo#$num FAILED to spawn"
+  fi
+done < "$PLAN_FILE"
+
+# Drain the remaining pool: reap everything still active until empty.
+while [ "$(pool_size)" -gt 0 ]; do
+  reaped=0
+  for ((i=0; i<${#A_ID[@]}; i++)); do
+    if try_reap "$i"; then reaped=1; break; fi
+  done
+  [ "$reaped" -eq 1 ] || sleep 15
+done
+
+log "==== sweep end $RUN_TS: considered=$considered candidates=$total reviewed=$reviewed failures=$failures ===="
+say "sweep done: reviewed=$reviewed failures=$failures (see state/sweep.log)"

--- a/bin/fm-review-sweep.sh
+++ b/bin/fm-review-sweep.sh
@@ -81,9 +81,7 @@ resolve_fleet() {
 # check is in a hard-failure state; pending/running/missing checks are not fails.
 ci_status() {
   local repo=$1 num=$2 states out
-  if ! out=$(gh pr checks "$num" --repo "$repo" --json state -q '[.[].state]' 2>/dev/null); then
-    echo unknown; return
-  fi
+  out=$(gh pr checks "$num" --repo "$repo" --json state -q '[.[].state]' 2>/dev/null || true)
   states=$(printf '%s' "$out" | tr -d ' \n[]"')
   [ -z "$states" ] && { echo unknown; return; }
   # hard failures

--- a/bin/fm-review-sweep.sh
+++ b/bin/fm-review-sweep.sh
@@ -39,46 +39,17 @@ STATE_DIR="$FM_ROOT/state"
 PROJECTS_MD="$FM_ROOT/data/projects.md"
 SWEEP_LOG="$STATE_DIR/sweep.log"
 SWEEP_RUN_DIR="$STATE_DIR/sweep"          # per-run scratch (task ids, briefs live under data/)
-mkdir -p "$STATE_DIR" "$SWEEP_RUN_DIR"
 
 CONCURRENCY="${FM_SWEEP_CONCURRENCY:-3}"
 TASK_TIMEOUT="${FM_SWEEP_TASK_TIMEOUT:-1800}"
 DRY_RUN=0
 ONLY_REPO=""
 
-while [ $# -gt 0 ]; do
-  case "$1" in
-    --dry-run) DRY_RUN=1; shift ;;
-    --one) ONLY_REPO="${2:-}"; shift 2 ;;
-    -h|--help)
-      sed -n '2,40p' "$0"; exit 0 ;;
-    *) echo "error: unknown arg '$1'" >&2; exit 2 ;;
-  esac
-done
-
 log() { printf '%s\n' "$*" >> "$SWEEP_LOG"; }
 say() { printf '%s\n' "$*"; }   # stdout (cron redirects both to sweep.log via >>2>&1)
-
-# ---- flock: never overlap two sweeps ---------------------------------------
-LOCK_FD=9
-exec 9>>"$STATE_DIR/.sweep.lock"
-if ! flock -n "$LOCK_FD"; then
-  say "sweep: another run holds the lock; exiting"
-  exit 0
-fi
-
 ts() { date -u +"%Y-%m-%dT%H:%M:%SZ"; }
-RUN_TS="$(ts)"
-log ""
-log "==== sweep start $RUN_TS (dry-run=$DRY_RUN, concurrency=$CONCURRENCY) ===="
-
-# ---- prerequisites ----------------------------------------------------------
+# prerequisite helper (used inside main)
 need() { command -v "$1" >/dev/null 2>&1 || { say "error: missing required tool '$1'"; exit 1; }; }
-need gh
-need tmux
-need jq
-need git
-# jira is optional (only the transition needs it); checked lazily where used.
 
 # ---- resolve fleet repos from data/projects.md -----------------------------
 # Each registry line carries a github.com/<owner>/<name> URL. Emit
@@ -86,7 +57,7 @@ need git
 # so fm-spawn can `treehouse get` a worktree of that repo.
 resolve_fleet() {
   [ -f "$PROJECTS_MD" ] || { say "error: no fleet registry at $PROJECTS_MD"; exit 1; }
-  local line url owner name proj
+  local line url proj
   # project name is the first token of each "- <name> [...]" bullet; the local
   # clone lives at projects/<name>. The github URL is the github.com/<o>/<n> token.
   while IFS= read -r line; do
@@ -94,10 +65,11 @@ resolve_fleet() {
       *github.com/*)
         url=$(printf '%s' "$line" | grep -oE 'github.com/[^ )"]+' | head -1 | sed 's#github.com/##')
         proj=$(printf '%s' "$line" | grep -oE '^- [A-Za-z0-9_-]+' | sed 's/^- //')
-        [ -n "$url" ] && [ -n "$proj" ] || continue
         # strip a trailing .git if present
         url="${url%.git}"
-        printf '%s\t%s\n' "$url" "projects/$proj"
+        if [ -n "$url" ] && [ -n "$proj" ]; then
+          printf '%s\t%s\n' "$url" "projects/$proj"
+        fi
         ;;
     esac
   done < "$PROJECTS_MD"
@@ -125,7 +97,7 @@ ci_status() {
 # Emits TSV rows: repo<TAB>num<TAB>cifail<TAB>title<TAB>url<TAB>headRefOid
 # Drafts and APPROVED PRs are excluded here.
 emit_repo_prs() {
-  local repo=$1 proj=$2 prs json num draft dec cifail title url head
+  local repo=$1 proj=$2 prs num draft dec cifail title url head
   prs=$(gh pr list --repo "$repo" --state open --limit 100 \
         --json number,isDraft,reviewDecision,title,url,headRefOid 2>/dev/null) || return 0
   [ -n "$prs" ] || return 0
@@ -235,10 +207,13 @@ EOF
 # review is NOT done yet. Best-effort: never aborts the caller.
 spawn_review() {
   local repo=$1 num=$2 cifail=$3 proj=$4
-  local id="sweep-$(printf '%s' "$repo" | tr '/.' '--')-${num}-$$"
-  local status_file="$FM_ROOT/state/$id.status"
-  local brief
-  brief=$(write_brief "$id" "$repo" "$num" "$cifail" "$proj") || { log "  error   $repo#$num brief write failed"; return 1; }
+  local id status_file
+  id="sweep-$(printf '%s' "$repo" | tr '/.' '--')-${num}-$$"
+  status_file="$FM_ROOT/state/$id.status"
+  if ! write_brief "$id" "$repo" "$num" "$cifail" "$proj"; then
+    log "  error   $repo#$num brief write failed"
+    return 1
+  fi
   : > "$status_file"
   # Spawn headlessly (cron has no TMUX). FM_SPAWN_NO_GUARD: no watcher to guard.
   local spawn_out spawn_rc=0
@@ -252,35 +227,6 @@ spawn_review() {
   printf '%s\n' "$id" >> "$SWEEP_RUN_DIR/.active"
   log "  spawn   $repo#$num -> $id (cifail=$cifail)"
   SPAWN_ID="$id"
-}
-
-# ---- wait for one task to finish (blocking) -------------------------------
-# Polls the task's status file (and window liveness) until a terminal status or
-# timeout. Sets WAIT_STATUS. Used by the concurrent pool reaper.
-wait_review() {
-  local id=$1 window="fm-$id"
-  local status_file="$FM_ROOT/state/$id.status"
-  local deadline=$(( $(date +%s) + TASK_TIMEOUT ))
-  local last=""
-  while [ "$(date +%s)" -lt "$deadline" ]; do
-    last=$(tail -1 "$status_file" 2>/dev/null || true)
-    case "$last" in
-      done:*|failed:*|blocked:*|needs-decision:*) break ;;
-    esac
-    # Fallback: window gone means the crewmate exited without a terminal status.
-    if ! tmux list-windows -a -F '#{window_name}' 2>/dev/null | grep -qx "$window"; then
-      [ -n "$last" ] || { echo "done: window-exited" >> "$status_file"; last="done: window-exited"; }
-      break
-    fi
-    sleep 15
-  done
-  if [ "$(date +%s)" -ge "$deadline" ]; then
-    case "$last" in
-      done:*|failed:*|blocked:*|needs-decision:*) : ;;
-      *) last="timeout"; log "  timeout $id after ${TASK_TIMEOUT}s" ;;
-    esac
-  fi
-  WAIT_STATUS="$last"
 }
 
 # ---- parse the recommendation from the posted PR comment -------------------
@@ -335,7 +281,8 @@ maybe_transition_jira() {
 
 # ---- teardown a sweep crewmate (best-effort) -------------------------------
 teardown_task() {
-  local id=$1 window="fm-$id"
+  local id=$1
+  local window="fm-$id"
   # Tell pi to quit, then exit the treehouse subshell, then kill the window.
   tmux send-keys -t "$window" '/quit' Enter 2>/dev/null || true
   sleep 2
@@ -350,8 +297,39 @@ teardown_task() {
 }
 
 # ============================================================================
-# Main
+# Main (guarded so the helper functions above can be sourced by tests)
 # ============================================================================
+main() {
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dry-run) DRY_RUN=1; shift ;;
+    --one) ONLY_REPO="${2:-}"; shift 2 ;;
+    -h|--help)
+      sed -n '2,40p' "$0"; exit 0 ;;
+    *) echo "error: unknown arg '$1'" >&2; exit 2 ;;
+  esac
+done
+
+mkdir -p "$STATE_DIR" "$SWEEP_RUN_DIR"
+
+# ---- flock: never overlap two sweeps ---------------------------------------
+exec 9>>"$STATE_DIR/.sweep.lock"
+if ! flock -n 9; then
+  say "sweep: another run holds the lock; exiting"
+  exit 0
+fi
+
+RUN_TS="$(ts)"
+log ""
+log "==== sweep start $RUN_TS (dry-run=$DRY_RUN, concurrency=$CONCURRENCY) ===="
+
+# ---- prerequisites ----------------------------------------------------------
+need gh
+need tmux
+need jq
+need git
+# jira is optional (only the transition needs it); checked lazily where used.
+
 say "sweep: enumerating fleet PRs..."
 FLEET=$(resolve_fleet)
 [ -n "$FLEET" ] || { say "sweep: no fleet repos resolved; nothing to do"; log "==== sweep end (no repos) ===="; exit 0; }
@@ -472,3 +450,7 @@ done
 
 log "==== sweep end $RUN_TS: considered=$considered candidates=$total reviewed=$reviewed failures=$failures ===="
 say "sweep done: reviewed=$reviewed failures=$failures (see state/sweep.log)"
+}
+
+# Run main only when executed, not when sourced (e.g. by tests).
+[ "${BASH_SOURCE[0]:-$0}" = "$0" ] && main "$@"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -72,7 +72,7 @@ launch_template() {
     claude) printf '%s' 'claude --dangerously-skip-permissions "$(cat __BRIEF__)"' ;;
     codex) printf '%s' 'codex --dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch __TURNEND__\"]" "$(cat __BRIEF__)"' ;;
     opencode) printf '%s' 'OPENCODE_CONFIG_CONTENT='\''{"permission":{"*":"allow"}}'\'' opencode --prompt "$(cat __BRIEF__)"' ;;
-    pi) printf '%s' 'pi -e __PIEXT__ "$(cat __BRIEF__)"' ;;
+    pi) printf '%s' 'pi --approve -e __PIEXT__ "$(cat __BRIEF__)"' ;;
     *) return 1 ;;
   esac
 }
@@ -117,18 +117,51 @@ fi
 tmux new-window -d -t "$SES" -n "$W" -c "$PROJ_ABS"
 tmux send-keys -t "$T" 'treehouse get' Enter
 
-# Wait for the treehouse subshell: the pane's cwd moves from the project to the worktree.
+# Wait for the treehouse subshell to be ready before sending the launch command.
+# Two race conditions to defeat (verified live on this host, default shell fish):
+#  1. PATH TRANSIENT: for ~100ms after `new-window -c PROJ_ABS`, tmux reports
+#     pane_current_path as $HOME (e.g. /home/boks) before fish's slow startup
+#     (conda+fnm+omf+direnv) applies the requested -c directory. A naive
+#     "path != PROJ_ABS" check breaks on that transient and captures $HOME.
+#  2. FOREGROUND RACE: while `treehouse get` runs it is the foreground process
+#     (cwd = PROJ_ABS); the worktree subshell (fish) is its child. A launch
+#     command sent while treehouse is still foreground lands in the wrong
+#     context and is dropped, so the agent never starts.
+# Fix: only accept a path that is a real treehouse worktree AND whose foreground
+# process is the interactive shell (the subshell is up and ready to receive).
+is_treehouse_path() {
+  # treehouse worktrees live under ~/.treehouse/<repo>-<rand>/<n>/<branch>
+  case "$1" in *.treehouse/*) return 0 ;; *) return 1 ;; esac
+}
+# Interactive shells treehouse may open as the subshell (shell-of-record is fish
+# here, but accept the common set so this stays portable across hosts).
+is_interactive_shell() {
+  case "$(basename "$1")" in fish|bash|zsh|sh|dash) return 0 ;; *) return 1 ;; esac
+}
 WT=""
-for _ in $(seq 1 60); do
+prev=""
+for _ in $(seq 1 90); do
   p=$(tmux display-message -p -t "$T" '#{pane_current_path}' 2>/dev/null || true)
-  if [ -n "$p" ] && [ "$p" != "$PROJ_ABS" ]; then
-    WT="$p"
-    break
+  c=$(tmux display-message -p -t "$T" '#{pane_current_command}' 2>/dev/null || true)
+  # Accept only a real treehouse worktree path that is NOT the project dir we
+  # launched from, with an interactive shell foreground (subshell is ready), AND
+  # stable across two consecutive polls — so a one-shot transient (the ~100ms
+  # $HOME blip, or an intermediate worktree path as treehouse selects one) is
+  # never captured. prev holds the previous valid candidate; matching it twice
+  # means the subshell has settled on a single worktree.
+  if [ -n "$p" ] && [ "$p" != "$PROJ_ABS" ] && is_treehouse_path "$p" && is_interactive_shell "$c"; then
+    if [ "$p" = "$prev" ]; then
+      WT="$p"
+      break
+    fi
+    prev="$p"
+  else
+    prev=""
   fi
   sleep 1
 done
 if [ -z "$WT" ]; then
-  echo "error: treehouse get did not enter a worktree within 60s; inspect window $T" >&2
+  echo "error: treehouse get did not reach an interactive shell in a worktree within 90s; inspect window $T (last: cmd='${c:-}' path='${p:-}')" >&2
   exit 1
 fi
 
@@ -205,8 +238,46 @@ mkdir -p "$FM_ROOT/state"
 LAUNCH=${LAUNCH//__BRIEF__/$BRIEF}
 LAUNCH=${LAUNCH//__TURNEND__/$TURNEND}
 LAUNCH=${LAUNCH//__PIEXT__/$FM_ROOT/state/$ID.pi-ext.ts}
-tmux send-keys -t "$T" -l "$LAUNCH"
-sleep 0.3
-tmux send-keys -t "$T" Enter
+
+# What pane_current_command reports once the harness is actually running, used by
+# the post-launch verify below. For the verified adapters the binary name is the
+# harness name (pi/claude/codex/opencode); the raw-launch escape hatch derived
+# HARNESS from the command basename, so it works there too.
+EXPECTED_CMD=$(basename "$HARNESS")
+
+# Send the launch command and VERIFY the harness actually started. A headless
+# dispatch (cron sweep, or any spawn without a live supervisor watching the pane)
+# cannot tolerate a silent drop: if the keystrokes land while the shell is still
+# mid-startup the launch can be swallowed and the pane is left at a shell prompt
+# with no agent process. So confirm pane_current_command flips to the harness
+# binary within a grace window; if it does not, resend once and re-check.
+send_launch() {
+  tmux send-keys -t "$T" -l "$LAUNCH"
+  sleep 0.4
+  tmux send-keys -t "$T" Enter
+}
+harness_running() {
+  case "$(basename "$(tmux display-message -p -t "$T" '#{pane_current_command}' 2>/dev/null || true)")" in
+    "$EXPECTED_CMD"|node*) return 0 ;; *) return 1 ;;
+  esac
+}
+send_launch
+verified=0
+for _ in $(seq 1 40); do   # ~40s grace for slow agent startup (pi/claude cold start)
+  if harness_running; then verified=1; break; fi
+  sleep 1
+done
+if [ "$verified" -ne 1 ]; then
+  echo "warn: harness '$HARNESS' not detected as foreground within 40s; resending launch once" >&2
+  send_launch
+  for _ in $(seq 1 40); do
+    if harness_running; then verified=1; break; fi
+    sleep 1
+  done
+fi
+if [ "$verified" -ne 1 ]; then
+  echo "error: harness '$HARNESS' failed to start in window $T after retry; pane left for inspection" >&2
+  exit 1
+fi
 
 echo "spawned $ID harness=$HARNESS kind=$KIND mode=$MODE yolo=$YOLO window=$T worktree=$WT"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -268,8 +268,13 @@ for _ in $(seq 1 40); do   # ~40s grace for slow agent startup (pi/claude cold s
   sleep 1
 done
 if [ "$verified" -ne 1 ]; then
-  echo "warn: harness '$HARNESS' not detected as foreground within 40s; resending launch once" >&2
-  send_launch
+  fg_cmd="$(tmux display-message -p -t "$T" '#{pane_current_command}' 2>/dev/null || true)"
+  if is_interactive_shell "$fg_cmd"; then
+    echo "warn: harness '$HARNESS' not detected within 40s; pane at interactive shell ('$fg_cmd'); resending launch once" >&2
+    send_launch
+  else
+    echo "warn: harness '$HARNESS' not detected within 40s; foreground '$fg_cmd' is not a known shell — not resending (would risk injecting into a running process), continuing to poll" >&2
+  fi
   for _ in $(seq 1 40); do
     if harness_running; then verified=1; break; fi
     sleep 1

--- a/tests/fm-review-sweep.test.sh
+++ b/tests/fm-review-sweep.test.sh
@@ -66,13 +66,13 @@ EOF
 # ---- ci_status: FAILURE in any check => fail; otherwise pass ---------------
 # Stub gh to emit a given JSON array of states.
 stub_gh() {
-  local states_json="$1"
+  local states_json="$1" exit_code="${2:-0}"
   mkdir -p "$TMP/bin"
   cat > "$TMP/bin/gh" <<EOF
 #!/usr/bin/env bash
 # test stub
 case "\$*" in
-  *pr*checks*) printf '%s' "$states_json" ;;
+  *pr*checks*) printf '%s' "$states_json"; exit $exit_code ;;
 esac
 EOF
   chmod +x "$TMP/bin/gh"
@@ -80,9 +80,11 @@ EOF
 }
 
 test_ci_status_failure_is_fail() {
-  stub_gh '["SUCCESS","FAILURE","SUCCESS"]'
-  [ "$(ci_status owner/name 1)" = "fail" ] || fail "FAILURE should make ci_status return fail"
-  pass "ci_status returns fail when any check is FAILURE"
+  # Real `gh pr checks` exits 1 when any check FAILED. The stub mirrors that;
+  # ci_status must classify from the check content, NOT the non-zero exit code.
+  stub_gh '["SUCCESS","FAILURE","SUCCESS"]' 1
+  [ "$(ci_status owner/name 1)" = "fail" ] || fail "FAILURE should make ci_status return fail even when gh exits 1"
+  pass "ci_status returns fail when any check is FAILURE (gh exit 1)"
 }
 
 test_ci_status_all_success_is_pass() {
@@ -92,10 +94,11 @@ test_ci_status_all_success_is_pass() {
 }
 
 test_ci_status_pending_is_not_fail() {
-  # PENDING/STARTED are running states, not hard failures.
-  stub_gh '["STARTED","PENDING"]'
+  # PENDING/STARTED are running states, not hard failures. Real `gh pr checks`
+  # exits 8 while checks are pending; the stub mirrors that.
+  stub_gh '["STARTED","PENDING"]' 8
   [ "$(ci_status owner/name 1)" = "pass" ] || fail "pending/running should not count as fail"
-  pass "ci_status treats PENDING/STARTED as non-failure"
+  pass "ci_status treats PENDING/STARTED as non-failure (gh exit 8)"
 }
 
 test_ci_status_empty_is_unknown() {

--- a/tests/fm-review-sweep.test.sh
+++ b/tests/fm-review-sweep.test.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# Behavior tests for fm-review-sweep.sh pure helpers.
+# Sources the script's functions (the main() guard keeps sourcing side-effect-free)
+# and exercises the side-effect-free logic: fleet resolution from data/projects.md,
+# the CI-fail decision, the recommendation parser (clean APPROVE vs CONDITIONAL
+# APPROVE), and the Jira MILE-key extraction. gh is stubbed on PATH so no network.
+# shellcheck disable=SC2034  # PROJECTS_MD / FM_ROOT are read by sourced functions
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SWEEP="$ROOT/bin/fm-review-sweep.sh"
+
+fail() { printf 'not ok - %s\n' "$1" >&2; exit 1; }
+pass() { printf 'ok - %s\n' "$1"; }
+
+# A scratch dir that stands in for FM_ROOT; the sweep writes nothing here for
+# these tests (we never call main), but the path vars must resolve.
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+# Set up the global env the sourced functions read. FM_ROOT drives STATE_DIR etc.
+export FM_ROOT="$TMP"
+# shellcheck disable=SC1090
+# Source the functions only (the main() guard at the bottom prevents execution).
+. "$SWEEP"
+
+# ---- resolve_fleet: parse registry lines into owner/name<TAB>clone-path ----
+test_resolve_fleet_parses_registry() {
+  local reg="$TMP/projects.md"
+  cat > "$reg" <<'EOF'
+# Fleet registry
+
+## project-racgoon (racgoon umbrella)
+
+- racgoon-be [no-mistakes] - Backend Go service — github.com/veridianlab/racgoon (added 2026-06-22)
+- racgoon-fe [no-mistakes] - Frontend React/TS app — github.com/veridianlab/raccoon-fe (added 2026-06-22)
+- racgoon-infra [no-mistakes] - Terraform IaC — github.com/veridianlab/infra (added 2026-06-22)
+EOF
+  PROJECTS_MD="$reg"
+  local out
+  out=$(resolve_fleet)
+  echo "$out" | grep -qx $'veridianlab/racgoon\tprojects/racgoon-be' \
+    || fail "resolve_fleet did not emit racgoon-be -> veridianlab/racgoon"
+  echo "$out" | grep -qx $'veridianlab/raccoon-fe\tprojects/racgoon-fe' \
+    || fail "resolve_fleet did not strip to owner/name for raccoon-fe"
+  echo "$out" | grep -qx $'veridianlab/infra\tprojects/racgoon-infra' \
+    || fail "resolve_fleet did not map racgoon-infra to infra repo"
+  # lines without a github.com URL are skipped (e.g. the header/section lines)
+  [ "$(echo "$out" | wc -l)" -eq 3 ] || fail "resolve_fleet emitted wrong line count"
+  pass "resolve_fleet parses owner/name and clone path from registry bullets"
+}
+
+test_resolve_fleet_strips_trailing_dot_git() {
+  local reg="$TMP/projects2.md"
+  cat > "$reg" <<'EOF'
+- lynx-be [no-mistakes] - Backend — github.com/veridianlab/lynx-haven.git (added 2026-06-22)
+EOF
+  PROJECTS_MD="$reg"
+  local out
+  out=$(resolve_fleet)
+  echo "$out" | grep -qx $'veridianlab/lynx-haven\tprojects/lynx-be' \
+    || fail "resolve_fleet did not strip trailing .git"
+  pass "resolve_fleet strips a trailing .git from the repo URL"
+}
+
+# ---- ci_status: FAILURE in any check => fail; otherwise pass ---------------
+# Stub gh to emit a given JSON array of states.
+stub_gh() {
+  local states_json="$1"
+  mkdir -p "$TMP/bin"
+  cat > "$TMP/bin/gh" <<EOF
+#!/usr/bin/env bash
+# test stub
+case "\$*" in
+  *pr*checks*) printf '%s' "$states_json" ;;
+esac
+EOF
+  chmod +x "$TMP/bin/gh"
+  export PATH="$TMP/bin:$PATH"
+}
+
+test_ci_status_failure_is_fail() {
+  stub_gh '["SUCCESS","FAILURE","SUCCESS"]'
+  [ "$(ci_status owner/name 1)" = "fail" ] || fail "FAILURE should make ci_status return fail"
+  pass "ci_status returns fail when any check is FAILURE"
+}
+
+test_ci_status_all_success_is_pass() {
+  stub_gh '["SUCCESS","SUCCESS","SKIPPED"]'
+  [ "$(ci_status owner/name 1)" = "pass" ] || fail "all-success should be pass"
+  pass "ci_status returns pass when all checks are SUCCESS/SKIPPED"
+}
+
+test_ci_status_pending_is_not_fail() {
+  # PENDING/STARTED are running states, not hard failures.
+  stub_gh '["STARTED","PENDING"]'
+  [ "$(ci_status owner/name 1)" = "pass" ] || fail "pending/running should not count as fail"
+  pass "ci_status treats PENDING/STARTED as non-failure"
+}
+
+test_ci_status_empty_is_unknown() {
+  stub_gh '[]'
+  [ "$(ci_status owner/name 1)" = "unknown" ] || fail "empty checks should be unknown"
+  pass "ci_status returns unknown when there are no checks"
+}
+
+# ---- parse_recommendation: clean APPROVE vs CONDITIONAL APPROVE -----------
+# Stub gh api to return one comment body.
+stub_gh_comment() {
+  local body="$1"
+  mkdir -p "$TMP/bin"
+  cat > "$TMP/bin/gh" <<EOF
+#!/usr/bin/env bash
+# test stub
+printf '%s' $(printf '%q' "$body")
+EOF
+  chmod +x "$TMP/bin/gh"
+  export PATH="$TMP/bin:$PATH"
+}
+
+test_parse_clean_approve() {
+  stub_gh_comment $'Some findings table.\n### Recommendation: APPROVE\nAll clear.'
+  [ "$(parse_recommendation owner/name 1)" = "APPROVE" ] || fail "clean APPROVE not parsed"
+  pass "parse_recommendation returns APPROVE for a clean approval"
+}
+
+test_parse_conditional_approve_is_not_clean_approve() {
+  # CONDITIONAL APPROVE must surface as CONDITIONAL, never APPROVE, so the Jira
+  # tie-in (which keys on == APPROVE) does not fire.
+  stub_gh_comment $'### Recommendation: CONDITIONAL APPROVE\nRationale.'
+  [ "$(parse_recommendation owner/name 1)" = "CONDITIONAL" ] \
+    || fail "CONDITIONAL APPROVE should parse to CONDITIONAL, not APPROVE"
+  pass "parse_recommendation returns CONDITIONAL for CONDITIONAL APPROVE"
+}
+
+test_parse_other_decisions() {
+  for dec in BLOCK "REQUEST CHANGES" CAUTION; do
+    stub_gh_comment "### Recommendation: $dec"
+    local got
+    got=$(parse_recommendation owner/name 1)
+    # first word uppercased
+    [ "$got" = "$(echo "$dec" | awk '{print toupper($1)}')" ] \
+      || fail "recommendation '$dec' parsed as '$got'"
+  done
+  pass "parse_recommendation returns the decision word for BLOCK/REQUEST/CAUTION"
+}
+
+# ---- jira_key_for: extract MILE-\d+ from PR title/body ---------------------
+# Reuses the gh comment stub to emit a title+body blob (jira_key_for greps it).
+test_jira_key_from_title() {
+  stub_gh_comment $'feat: Status Flow Config API & Permissions (MILE-1027)\n\nbody text'
+  [ "$(jira_key_for owner/name 1)" = "MILE-1027" ] || fail "MILE key not extracted from title"
+  pass "jira_key_for extracts the MILE- key from the PR title"
+}
+
+test_jira_key_from_body() {
+  stub_gh_comment $'feat: no key in title\n\nLinked ticket: MILE-1132.'
+  [ "$(jira_key_for owner/name 1)" = "MILE-1132" ] || fail "MILE key not extracted from body"
+  pass "jira_key_for extracts the MILE- key from the PR body when title lacks one"
+}
+
+test_jira_key_none() {
+  stub_gh_comment $'chore: no ticket here\n\nnothing'
+  [ -z "$(jira_key_for owner/name 1)" ] || fail "should return empty when no MILE key"
+  pass "jira_key_for returns empty when no MILE- key is present"
+}
+
+test_resolve_fleet_parses_registry
+test_resolve_fleet_strips_trailing_dot_git
+test_ci_status_failure_is_fail
+test_ci_status_all_success_is_pass
+test_ci_status_pending_is_not_fail
+test_ci_status_empty_is_unknown
+test_parse_clean_approve
+test_parse_conditional_approve_is_not_clean_approve
+test_parse_other_decisions
+test_jira_key_from_title
+test_jira_key_from_body
+test_jira_key_none


### PR DESCRIPTION
## Intent

Build a recurring, automated review sweep for firstmate (cron, every 8h) that
reviews every open fleet PR with review-rectify-pi --push (review-only), excluding
drafts and already-approved PRs, keeping failing-CI PRs (with a ## CI Failure
investigation), bounded to 3 concurrent, with a clean-APPROVE -> Jira In-Review
tie-in. Includes bin/fm-review-sweep.sh, the headless fm-spawn.sh launch fix
(stable worktree detection + post-launch verify + --approve), AGENTS.md/README.md
docs, and behavior tests. This re-run pushes via the meisbokai/firstmate fork
(contributor has no push access to kunchenguid/firstmate; CONTRIBUTING.md fork
workflow). Branch HEAD already passed review/test/lint in the prior run; only the
push failed on permissions, now resolved by the fork.

## What Changed
- Adds `bin/fm-review-sweep.sh`, a cron-driven sweep that enumerates every open fleet PR, drops drafts and already-approved PRs (`reviewDecision=APPROVED`), keeps failing-CI PRs (adding a CI-failure investigation to the review), and dispatches `review-rectify-pi` in review-only `--push` mode bounded to `FM_SWEEP_CONCURRENCY` (3); on a clean APPROVE it moves the PR's linked `MILE-\d+` Jira ticket to "In Review".
- Reworks headless launch in `bin/fm-spawn.sh`: adds `--approve` to the pi launch template, replaces the naive cwd check with treehouse-path + interactive-shell + two-poll stability detection (defeats the `$HOME` path transient and the `treehouse get` foreground race), and adds a post-launch verify that resends once if the harness binary isn't seen within 40s.
- Adds behavior tests for the sweep helpers in `tests/fm-review-sweep.test.sh` and documents the sweep, its state files, and the headless-launch reliability in `AGENTS.md` and `README.md`.

## Risk Assessment

✅ Low: This is a focused fix-up commit that correctly resolves all 5 prior findings with minimal, targeted changes consistent with existing firstmate conventions, and introduces no new material risks.

## Testing

Exercised the review sweep's real cron code path (enumerate→filter→CI-classify→plan→brief→Jira→flock) against a stubbed-gh fleet via the real main() with redirected paths, and verified the headless fm-spawn.sh detection/verify logic against scripted tmux sequences that replay the documented race conditions. All 25 sweep e2e checks, all 9 spawn-logic checks, and the project's 12 behavior tests pass; the dry-run plan, sweep.log, and both briefs are captured as artifacts showing the intended review-only + failing-CI-kept + clean-APPROVE→Jira behavior. One coverage gap (not a defect): a fully live headless spawn (real treehouse pool + real pi/claude binary) was not run because warming the pool and launching real harnesses would write worktrees/processes outside the worktree boundary and risk interfering with the no-mistakes gate's own treehouse machinery; the spawn fix's per-step logic is instead proven via verbatim-copied predicates driven by scripted pane outputs.

<details>
<summary>Evidence: Sweep --dry-run plan (what cron prints: candidates with CI flags; draft #2 &amp; approved #3 filtered)</summary>

<code>==== DRY RUN PLAN ====&#10;concurrency=3 task_timeout=1800s&#10;repo #num cifail title&#10;veridianlab/racgoon #1 pass https://github.com/veridianlab/racgoon/pull/1&#10;veridianlab/racgoon #4 fail https://github.com/veridianlab/racgoon/pull/4&#10;veridianlab/infra #10 pass https://github.com/veridianlab/infra/pull/10&#10;==== END DRY RUN (dispatched nothing) ====</code>

```text
sweep: enumerating fleet PRs...
  repo veridianlab/racgoon (projects/racgoon)
  repo veridianlab/infra (projects/racgoon-infra)

==== DRY RUN PLAN ====
concurrency=3  task_timeout=1800s
repo	#num	cifail	title
veridianlab/racgoon	#1	pass	https://github.com/veridianlab/racgoon/pull/1
veridianlab/racgoon	#4	fail	https://github.com/veridianlab/racgoon/pull/4
veridianlab/infra	#10	pass	https://github.com/veridianlab/infra/pull/10
==== END DRY RUN (dispatched nothing) ====
```
</details>
<details>
<summary>Evidence: state/sweep.log cron run log (filter reasons, plan count, Jira moves + no-key composition)</summary>

<code>==== sweep start 2026-06-22T12:49:43Z (dry-run=1, concurrency=3) ====&#10;filter veridianlab/racgoon#2 draft&#10;filter veridianlab/racgoon#3 approved&#10;plan 3 candidate PR(s) across 2 repo(s) (after draft+approved filters)&#10;==== sweep end (dry-run, 3 candidates) ====&#10;jira veridianlab/racgoon#1 APPROVE -&gt; moved MILE-1001 to In Review&#10;jira veridianlab/racgoon#99 APPROVE but no MILE- key in title/body; skipping transition</code>

```text

==== sweep start 2026-06-22T12:49:43Z (dry-run=1, concurrency=3) ====

  filter  veridianlab/racgoon#2 draft
  filter  veridianlab/racgoon#3 approved

  plan    3 candidate PR(s) across 2 repo(s) (after draft+approved filters)
==== sweep end (dry-run, 3 candidates) ====
  jira    veridianlab/racgoon#1 APPROVE -> moved MILE-1001 to In Review
  jira    veridianlab/racgoon#99 APPROVE but no MILE- key in title/body; skipping transition

==== sweep start 2026-06-22T12:49:46Z (dry-run=1, concurrency=3) ====

  plan    1 candidate PR(s) across 1 repo(s) (after draft+approved filters)
==== sweep end (dry-run, 1 candidates) ====
```
</details>
<details>
<summary>Evidence: Red-PR review brief: dedicated ## CI failure root-cause investigation section (gh pr checks / gh run view --log-failed)</summary>

```text
You are a crewmate dispatched by the automated review sweep. Work autonomously; do not wait for a human.

# Task
Run a **fresh code review** of PR **veridianlab/racgoon#4** and post it as the PR's review
comment. This is **REVIEW-ONLY**: review and post — do NOT edit any code, do NOT
push any fix, do NOT change the branch beyond checking out the PR to review it.

# Engine
Use the **review-rectify-pi** skill in **`--push`** mode. Invoke it so it runs
its full pipeline (existing-comment rectification + fresh code review + merged
findings table + recommendation) and posts/replaces the single
"Review Findings - Rectification Status" comment on the PR.

# Setup
You are in a treehouse worktree of `veridianlab/racgoon` (clone at `/tmp/tmp.nkr9mgwbHh/projects/racgoon`) on a detached
HEAD of the default branch. To review THIS PR, check out its head commit IN THIS
WORKTREE (never touch the pooled clone — review here, in your disposable worktree):
1. `gh pr checkout 4 --repo veridianlab/racgoon`  — run this from your worktree; it fetches
   the PR head and checks it out locally. If it refuses (shared worktree / branch
   exists), fall back to a detached checkout of the head:
   `git fetch origin pull/4/head && git checkout --detach FETCH_HEAD`.
2. Confirm you are on the PR head: `git rev-parse HEAD` should equal the PR's
   head SHA (`gh pr view 4 --repo veridianlab/racgoon --json headRefOid -q .headRefOid`).

## CI failure (this PR's CI is RED — investigate before reviewing)
This PR's GitHub checks are FAILING. As part of this review you MUST investigate
the ROOT CAUSE of the CI failure and include a `## CI Failure` section in the
posted review comment. Steps:
- `gh pr checks 4 --repo veridianlab/racgoon` to list the checks; identify the FAILING job(s).
- Open the failing job's log: `gh run view <run-id> --repo veridianlab/racgoon --log-failed`
  (or the job URL from `gh pr checks`). Read the actual error.
- Name the failing job and quote the error in the `## CI Failure` section, with a
  one-line root-cause assessment (compile error, test failure, lint, env, flake?).
The review-rectify-pi recommendation may still be APPROVE if the code is sound
and CI fails for an unrelated/env reason — but the failure MUST be documented.

# How to run the review
- Invoke review-rectify-pi with **`--push`** so it posts the comment to GitHub.
- The skill already deletes its prior "Review Findings - Rectification Status"
  comment and posts the fresh one (Phase 9) — do NOT manually delete comments.
- Scope the review to the PR's diff. The skill computes diff scope itself; make
  sure you are on the PR head (step above) so `git diff main...HEAD` is correct.
- Pre-push validation (Phase 8.5) runs the project's lint/typecheck/test. If that
  fails because of the RED CI, that is expected for failing-CI PRs — still post
  the review with the `## CI Failure` section; do not block on Phase 8.5.

# Rules
1. REVIEW-ONLY. Never edit project code, never commit, never push, never open or
   merge a PR. The only GitHub write you do is the review comment (via the skill).
2. Stay inside this worktree; the only files you may write outside it are the
   status file below.
3. Use gh / gh-axi for GitHub operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> /tmp/tmp.nkr9mgwbHh/state/sweep-test-fail.status`
   States: working, needs-decision, blocked, done, failed.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop.
6. If a decision belongs to a human, append `needs-decision: {summary}` and stop.

# Definition of done
The review comment is posted to veridianlab/racgoon#4. When posted, append
`done: posted review to veridianlab/racgoon#4` to the status file and STOP (exit pi with
`/quit`). Do not attempt to fix anything the review found.
```
</details>
<details>
<summary>Evidence: Green-PR review brief: REVIEW-ONLY contract (review-rectify-pi --push; never edit/commit/push/merge)</summary>

```text
You are a crewmate dispatched by the automated review sweep. Work autonomously; do not wait for a human.

# Task
Run a **fresh code review** of PR **veridianlab/racgoon#1** and post it as the PR's review
comment. This is **REVIEW-ONLY**: review and post — do NOT edit any code, do NOT
push any fix, do NOT change the branch beyond checking out the PR to review it.

# Engine
Use the **review-rectify-pi** skill in **`--push`** mode. Invoke it so it runs
its full pipeline (existing-comment rectification + fresh code review + merged
findings table + recommendation) and posts/replaces the single
"Review Findings - Rectification Status" comment on the PR.

# Setup
You are in a treehouse worktree of `veridianlab/racgoon` (clone at `/tmp/tmp.nkr9mgwbHh/projects/racgoon`) on a detached
HEAD of the default branch. To review THIS PR, check out its head commit IN THIS
WORKTREE (never touch the pooled clone — review here, in your disposable worktree):
1. `gh pr checkout 1 --repo veridianlab/racgoon`  — run this from your worktree; it fetches
   the PR head and checks it out locally. If it refuses (shared worktree / branch
   exists), fall back to a detached checkout of the head:
   `git fetch origin pull/1/head && git checkout --detach FETCH_HEAD`.
2. Confirm you are on the PR head: `git rev-parse HEAD` should equal the PR's
   head SHA (`gh pr view 1 --repo veridianlab/racgoon --json headRefOid -q .headRefOid`).


# How to run the review
- Invoke review-rectify-pi with **`--push`** so it posts the comment to GitHub.
- The skill already deletes its prior "Review Findings - Rectification Status"
  comment and posts the fresh one (Phase 9) — do NOT manually delete comments.
- Scope the review to the PR's diff. The skill computes diff scope itself; make
  sure you are on the PR head (step above) so `git diff main...HEAD` is correct.
- Pre-push validation (Phase 8.5) runs the project's lint/typecheck/test. If that
  fails because of the RED CI, that is expected for failing-CI PRs — still post
  the review with the `## CI Failure` section; do not block on Phase 8.5.

# Rules
1. REVIEW-ONLY. Never edit project code, never commit, never push, never open or
   merge a PR. The only GitHub write you do is the review comment (via the skill).
2. Stay inside this worktree; the only files you may write outside it are the
   status file below.
3. Use gh / gh-axi for GitHub operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> /tmp/tmp.nkr9mgwbHh/state/sweep-test-pass.status`
   States: working, needs-decision, blocked, done, failed.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop.
6. If a decision belongs to a human, append `needs-decision: {summary}` and stop.

# Definition of done
The review comment is posted to veridianlab/racgoon#1. When posted, append
`done: posted review to veridianlab/racgoon#1` to the status file and STOP (exit pi with
`/quit`). Do not attempt to fix anything the review found.
```
</details>
<details>
<summary>Evidence: --one REPO run: sweep restricted to a single repo</summary>

<code>sweep: enumerating fleet PRs...&#10;repo veridianlab/infra (projects/racgoon-infra)&#10;==== DRY RUN PLAN ====&#10;repo #num cifail title&#10;veridianlab/infra #10 pass https://github.com/veridianlab/infra/pull/10&#10;==== END DRY RUN (dispatched nothing) ====</code>

```text
sweep: enumerating fleet PRs...
  repo veridianlab/infra (projects/racgoon-infra)

==== DRY RUN PLAN ====
concurrency=3  task_timeout=1800s
repo	#num	cifail	title
veridianlab/infra	#10	pass	https://github.com/veridianlab/infra/pull/10
==== END DRY RUN (dispatched nothing) ====
```
</details>
<details>
<summary>Evidence: Sweep e2e results (25/25 checks pass)</summary>

<code>PASS :: candidate #1 (pass CI) kept in plan&#10;PASS :: candidate #4 (fail CI) kept in plan&#10;PASS :: candidate infra#10 (pending CI -&gt; pass) kept&#10;PASS :: draft #2 filtered out&#10;PASS :: already-approved #3 filtered out&#10;PASS :: FAILING-CI #4 is KEPT, not skipped&#10;PASS :: second run refused with the lock message&#10;PASS :: green brief states REVIEW-ONLY&#10;PASS :: green brief uses review-rectify-pi&#10;PASS :: green brief runs --push&#10;PASS :: green brief has never-push rule&#10;PASS :: no red-only CI-investigation section on a green PR&#10;PASS :: red brief has dedicated ## CI Failure section&#10;PASS :: red brief mandates investigate root-cause&#10;PASS :: red brief instructs reading the failing job log&#10;PASS :: red brief instructs listing the checks&#10;PASS :: exactly one Jira transition (APPROVE fired, CONDITIONAL suppressed)&#10;PASS :: transition targets MILE-1001 -&gt; In Review&#10;PASS :: no transition when PR has no MILE key&#10;PASS :: no-key case logged (composes with standing rule)&#10;PASS :: APPROVE parses to APPROVE&#10;PASS :: CONDITIONAL APPROVE parses to CONDITIONAL (not APPROVE)&#10;PASS :: BLOCK parses to BLOCK&#10;PASS :: --one ran only the named repo&#10;PASS :: --one excluded the other repo&#10;-- totals: 25 passed, 0 failed --&#10;ALL E2E CHECKS PASSED</code>

```text
PASS :: candidate #1 (pass CI) kept in plan
PASS :: candidate #4 (fail CI) kept in plan
PASS :: candidate infra#10 (pending CI -> pass) kept
PASS :: draft #2 filtered out
PASS :: already-approved #3 filtered out
PASS :: FAILING-CI #4 is KEPT, not skipped
PASS :: second run refused with the lock message
PASS :: green brief states REVIEW-ONLY
PASS :: green brief uses review-rectify-pi
PASS :: green brief runs --push
PASS :: green brief has never-push rule
PASS :: no red-only CI-investigation section on a green PR
PASS :: red brief has dedicated ## CI Failure section
PASS :: red brief mandates investigate root-cause
PASS :: red brief instructs reading the failing job log
PASS :: red brief instructs listing the checks
PASS :: exactly one Jira transition (APPROVE fired, CONDITIONAL suppressed)
PASS :: transition targets MILE-1001 -> In Review
PASS :: no transition when PR has no MILE key
PASS :: no-key case logged (composes with standing rule)
PASS :: APPROVE parses to APPROVE
PASS :: CONDITIONAL APPROVE parses to CONDITIONAL (not APPROVE)
PASS :: BLOCK parses to BLOCK
PASS :: --one ran only the named repo
PASS :: --one excluded the other repo
```
</details>
<details>
<summary>Evidence: Headless spawn-logic results (9/9: detection + verify + --approve)</summary>

<code>PASS :: transient HOME is skipped, worktree captured after it settles&#10;PASS :: captured path is the real treehouse worktree (not HOME)&#10;PASS :: waits past the treehouse-foreground race, then captures the subshell&#10;PASS :: no launch keystrokes sent during the foreground race&#10;PASS :: empty WT when only HOME is ever reported (would trigger the error+exit)&#10;PASS :: harness detected once pane_current_command flips to the harness binary&#10;PASS :: first 40 polls at a shell do NOT falsely verify (resend-once path engages)&#10;PASS :: pi launch template passes --approve (clears project-trust gate for headless dispatch)&#10;PASS :: brief still passed as the single positional argument</code>

```text
PASS :: transient HOME is skipped, worktree captured after it settles
PASS :: captured path is the real treehouse worktree (not HOME)
PASS :: waits past the treehouse-foreground race, then captures the subshell
PASS :: no launch keystrokes sent during the foreground race
PASS :: empty WT when only HOME is ever reported (would trigger the error+exit)
PASS :: harness detected once pane_current_command flips to the harness binary
PASS :: first 40 polls at a shell do NOT falsely verify (resend-once path engages)
PASS :: pi launch template passes --approve (clears project-trust gate for headless dispatch)
PASS :: brief still passed as the single positional argument
```
</details>
<details>
<summary>Evidence: End-to-end sweep harness script (reproducible: stubs gh/jira, runs real main())</summary>

```text
#!/usr/bin/env bash
# End-to-end exercise of fm-review-sweep.sh decision pipeline (cron sweep logic).
# Stubs `gh`/`jira` with a realistic fleet; SOURCES the sweep (main guard prevents
# execution on source) and calls the REAL main() with redirected globals — same
# code path cron runs, with paths pointed at a temp FM_ROOT. No network/PRs.
set -u

WORK="$1"            # repo worktree (has bin/fm-review-sweep.sh)
SWEEP="$WORK/bin/fm-review-sweep.sh"
EVIDENCE="$2"
mkdir -p "$EVIDENCE"

ROOT=$(mktemp -d)            # stands in for FM_ROOT
mkdir -p "$ROOT/bin" "$ROOT/state" "$ROOT/data"

# ---- realistic fleet registry --------------------------------------------
cat > "$ROOT/projects.md" <<'EOF'
# Fleet registry
- racgoon [no-mistakes] - Backend Go service — github.com/veridianlab/racgoon (added 2026-06-22)
- racgoon-infra [no-mistakes] - Terraform IaC — github.com/veridianlab/infra (added 2026-06-22)
EOF

# ---- robust stub `gh`: dispatch on subcommand + parse --repo --------------
cat > "$ROOT/bin/gh" <<'GHSTUB'
#!/usr/bin/env bash
set -u
repof() { printf '%s' "$*" | grep -oE -- '--repo [^ ]+' | sed 's/--repo //'; }
case "$1 $2" in
  "pr list")
    repo="$(repof "$*")"
    case "$repo" in
      veridianlab/racgoon) cat <<'JSON'
[{"number":1,"isDraft":false,"reviewDecision":null,"title":"feat: auth flow (MILE-1001)","url":"https://github.com/veridianlab/racgoon/pull/1","headRefOid":"aaa111"},{"number":2,"isDraft":true,"reviewDecision":null,"title":"wip: draft","url":"https://github.com/veridianlab/racgoon/pull/2","headRefOid":"bbb222"},{"number":3,"isDraft":false,"reviewDecision":"APPROVED","title":"already approved","url":"https://github.com/veridianlab/racgoon/pull/3","headRefOid":"ccc333"},{"number":4,"isDraft":false,"reviewDecision":null,"title":"feat: payments (MILE-1004) - CI red","url":"https://github.com/veridianlab/racgoon/pull/4","headRefOid":"ddd444"}]
JSON
        ;;
      veridianlab/infra) cat <<'JSON'
[{"number":10,"isDraft":false,"reviewDecision":null,"title":"chore: bump provider","url":"https://github.com/veridianlab/infra/pull/10","headRefOid":"eee555"}]
JSON
        ;;
    esac
    exit 0 ;;
  "pr checks")
    num="$3"; repo="$(repof "$*")"
    case "${repo}#${num}" in
      "veridianlab/racgoon#1") printf '%s' '["SUCCESS","SUCCESS"]'; exit 0 ;;
      "veridianlab/racgoon#4") printf '%s' '["SUCCESS","FAILURE"]'; exit 1 ;;  # gh exits 1 on FAILURE
      "veridianlab/infra#10")  printf '%s' '["STARTED","PENDING"]'; exit 8 ;;  # gh exits 8 while pending
    esac
    printf '%s' '[]'; exit 0 ;;
  "pr view")
    num="$3"
    case "$num" in
      1) printf '%s' 'feat: auth flow (MILE-1001)' ;;
      4) printf '%s' 'feat: payments (MILE-1004) - CI red' ;;
      *) printf '%s' 'no ticket here' ;;
    esac
    exit 0 ;;
  api\ repos*)
    # gh api repos/.../comments : $2 is the full path, so prefix-match.
    printf '### Recommendation: %s\n' "${SWEEP_RECO:-APPROVE}"
    exit 0 ;;
esac
exit 0
GHSTUB
chmod +x "$ROOT/bin/gh"

# ---- stub `jira` (records transitions; never real) -----------------------
JLOG="$ROOT/jira-calls.log"; : > "$JLOG"
cat > "$ROOT/bin/jira" <<EOF
#!/usr/bin/env bash
echo "jira: \$*" >> "$JLOG"
exit 0
EOF
chmod +x "$ROOT/bin/jira"

export PATH="$ROOT/bin:$PATH"

# results accumulator on disk (subshell-safe)
RESULTS="$ROOT/results.txt"; : > "$RESULTS"
chk() { if eval "$1"; then echo "PASS :: $2" >> "$RESULTS"; else echo "FAIL :: $2" >> "$RESULTS"; fi; }

# helper: source sweep and redirect ALL derived globals to $ROOT
sourced() {
  . "$SWEEP"
  FM_ROOT="$ROOT"
  STATE_DIR="$ROOT/state"; PROJECTS_MD="$ROOT/projects.md"
  SWEEP_LOG="$ROOT/state/sweep.log"; SWEEP_RUN_DIR="$ROOT/state/sweep"
  export FM_ROOT
}

echo "########## 1) DRY-RUN: full enumerate -> filter -> CI-classify -> plan"
( sourced; main --dry-run ) > "$ROOT/dryrun.out" 2>&1
echo "rc=$?"
cat "$ROOT/dryrun.out"

echo
echo "########## 2) sweep.log (the cron run log the captain inspects)"
cat "$ROOT/state/sweep.log"

echo
echo "########## 3) filtering invariants from the plan"
chk 'grep -q "veridianlab/racgoon	#1	pass" "$ROOT/dryrun.out"' "candidate #1 (pass CI) kept in plan"
chk 'grep -q "veridianlab/racgoon	#4	fail" "$ROOT/dryrun.out"' "candidate #4 (fail CI) kept in plan"
chk 'grep -q "veridianlab/infra	#10	pass" "$ROOT/dryrun.out"' "candidate infra#10 (pending CI -> pass) kept"
chk '! grep -q "#2" "$ROOT/dryrun.out"' "draft #2 filtered out"
chk '! grep -q "#3" "$ROOT/dryrun.out"' "already-approved #3 filtered out"
chk 'grep -q "#4" "$ROOT/dryrun.out"' "FAILING-CI #4 is KEPT, not skipped"

echo
echo "########## 4) flock guard: a second concurrent run is refused gracefully"
(
  exec 9>>"$ROOT/state/.sweep.lock"
  flock -n 9 || exit 1
  echo "fixture-holds-lock" > "$ROOT/lock-held"
  sleep 3
) &
FX=$!
sleep 0.6
( sourced; main --dry-run ) > "$ROOT/second.out" 2>&1
rc=$?
echo "second run rc=$rc  (expected 0 — refused, not crashed)"
cat "$ROOT/second.out"
chk 'grep -q "another run holds the lock" "$ROOT/second.out"' "second run refused with the lock message"
wait $FX 2>/dev/null

echo
echo "########## 5) write_brief: REVIEW-ONLY contract (green PR)"
( sourced
  write_brief "sweep-test-pass" "veridianlab/racgoon" 1 "pass" "projects/racgoon" >/dev/null
  echo "brief: $ROOT/data/sweep-test-pass/brief.md"
  grep -qi "REVIEW-ONLY" "$ROOT/data/sweep-test-pass/brief.md" && echo "  yes: states REVIEW-ONLY"
  grep -qi "review-rectify-pi" "$ROOT/data/sweep-test-pass/brief.md" && echo "  yes: uses review-rectify-pi"
  grep -qi -- "--push" "$ROOT/data/sweep-test-pass/brief.md" && echo "  yes: --push mode"
  grep -qi "do NOT push" "$ROOT/data/sweep-test-pass/brief.md" && echo "  yes: never-push rule"
  chk 'grep -qi "REVIEW-ONLY" "$ROOT/data/sweep-test-pass/brief.md"' "green brief states REVIEW-ONLY"
  chk 'grep -qi "review-rectify-pi" "$ROOT/data/sweep-test-pass/brief.md"' "green brief uses review-rectify-pi"
  chk 'grep -qi -- "--push" "$ROOT/data/sweep-test-pass/brief.md"' "green brief runs --push"
  chk 'grep -qi "never push" "$ROOT/data/sweep-test-pass/brief.md"' "green brief has never-push rule"
  chk '! grep -qi "CI failure (this PR" "$ROOT/data/sweep-test-pass/brief.md"' "no red-only CI-investigation section on a green PR"
)

echo
echo "########## 6) write_brief: RED PR adds the ## CI Failure investigation section"
( sourced
  write_brief "sweep-test-fail" "veridianlab/racgoon" 4 "fail" "projects/racgoon" >/dev/null
  echo "brief: $ROOT/data/sweep-test-fail/brief.md"
  grep -qi "CI failure (this PR" "$ROOT/data/sweep-test-fail/brief.md" && echo "  yes: dedicated CI Failure section"
  grep -qi "investigate" "$ROOT/data/sweep-test-fail/brief.md" && echo "  yes: investigate mandate"
  grep -qi "gh run view" "$ROOT/data/sweep-test-fail/brief.md" && echo "  yes: read failing job log"
  chk 'grep -qi "CI failure (this PR" "$ROOT/data/sweep-test-fail/brief.md"' "red brief has dedicated ## CI Failure section"
  chk 'grep -qi "investigate" "$ROOT/data/sweep-test-fail/brief.md"' "red brief mandates investigate root-cause"
  chk 'grep -qi "gh run view" "$ROOT/data/sweep-test-fail/brief.md"' "red brief instructs reading the failing job log"
  chk 'grep -qi "gh pr checks" "$ROOT/data/sweep-test-fail/brief.md"' "red brief instructs listing the checks"
)

echo
echo "########## 7) Jira tie-in: clean APPROVE moves; CONDITIONAL does not"
: > "$JLOG"
( sourced
  maybe_transition_jira "veridianlab/racgoon" 1 "APPROVE"
  maybe_transition_jira "veridianlab/racgoon" 1 "CONDITIONAL"
)
echo "-- jira invocations recorded (expect exactly one 'issue move ... In Review') --"
cat "$JLOG"
chk '[ "$(grep -c "issue move" "$JLOG")" -eq 1 ]' "exactly one Jira transition (APPROVE fired, CONDITIONAL suppressed)"
chk 'grep -q "issue move MILE-1001 In Review" "$JLOG"' "transition targets MILE-1001 -> In Review"
: > "$JLOG"
( sourced
  maybe_transition_jira "veridianlab/racgoon" 99 "APPROVE"  # PR 99 has no MILE key
)
chk '[ "$(grep -c "issue move" "$JLOG")" -eq 0 ]' "no transition when PR has no MILE key"
chk 'grep -q "no MILE- key" "$ROOT/state/sweep.log"' "no-key case logged (composes with standing rule)"

echo
echo "########## 8) parse_recommendation across decision words"
( sourced
  for dec in APPROVE "CONDITIONAL APPROVE" BLOCK "REQUEST CHANGES" CAUTION; do
    r=$(SWEEP_RECO="$dec" parse_recommendation veridianlab/racgoon 1)
    printf 'recommendation %-22s -> parsed=[%s]\n' "[$dec]" "$r"
  done
  chk '[ "$(SWEEP_RECO=APPROVE parse_recommendation veridianlab/racgoon 1)" = "APPROVE" ]' "APPROVE parses to APPROVE"
  chk '[ "$(SWEEP_RECO="CONDITIONAL APPROVE" parse_recommendation veridianlab/racgoon 1)" = "CONDITIONAL" ]' "CONDITIONAL APPROVE parses to CONDITIONAL (not APPROVE)"
  chk '[ "$(SWEEP_RECO=BLOCK parse_recommendation veridianlab/racgoon 1)" = "BLOCK" ]' "BLOCK parses to BLOCK"
)

echo
echo "########## 9) --one REPO restricts the sweep to a single repo"
( sourced; main --one veridianlab/infra --dry-run ) > "$ROOT/one.out" 2>&1
echo "rc=$?"
cat "$ROOT/one.out"
chk 'grep -q "infra	#10" "$ROOT/one.out"' "--one ran only the named repo"
chk '! grep -q "racgoon	#1" "$ROOT/one.out"' "--one excluded the other repo"

echo
echo "########## RESULT SUMMARY"
echo "-- checks --"
cat "$RESULTS"
F=$(grep -c '^FAIL' "$RESULTS" || true)
P=$(grep -c '^PASS' "$RESULTS" || true)
echo "-- totals: $P passed, $F failed --"
[ "$F" -eq 0 ] && echo "########## ALL E2E CHECKS PASSED" || echo "########## SOME E2E CHECKS FAILED"

cp "$RESULTS" "$EVIDENCE/sweep-e2e-results.txt"
cp "$ROOT/dryrun.out" "$EVIDENCE/sweep-dryrun-output.txt"
cp "$ROOT/state/sweep.log" "$EVIDENCE/sweep-cron-log.txt"
cp "$ROOT/data/sweep-test-fail/brief.md" "$EVIDENCE/sweep-brief-failing-ci.md"
cp "$ROOT/data/sweep-test-pass/brief.md" "$EVIDENCE/sweep-brief-green.md"
cp "$ROOT/one.out" "$EVIDENCE/sweep-one-repo-output.txt"
echo "evidence copied to $EVIDENCE"
```
</details>
<details>
<summary>Evidence: Spawn-logic harness script (verbatim predicates driven by scripted tmux)</summary>

```text
#!/usr/bin/env bash
# Verifies the fm-spawn.sh headless-launch detection LOGIC against scripted tmux
# pane sequences that replay the exact race conditions the fix documents.
# The predicate functions (is_treehouse_path, is_interactive_shell) and the
# detection/verify loop bodies are copied VERBATIM from bin/fm-spawn.sh so this
# exercises the real logic; only `tmux` and `sleep` are stubbed (no real tmux /
# treehouse / harness processes are spawned — keeps the test inside the worktree
# boundary and deterministic).
set -u

WORK="$1"; SPAWN="$WORK/bin/fm-spawn.sh"; EVIDENCE="$2"; mkdir -p "$EVIDENCE"
ROOT=$(mktemp -d); mkdir -p "$ROOT/bin"
RESULTS="$ROOT/results.txt"; : > "$RESULTS"
chk() { if eval "$1"; then echo "PASS :: $2" >> "$RESULTS"; else echo "FAIL :: $2" >> "$RESULTS"; fi; }

# ---- VERBATIM predicate copies from bin/fm-spawn.sh (lines 132-141) --------
is_treehouse_path() {
  case "$1" in *.treehouse/*) return 0 ;; *) return 1 ;; esac
}
is_interactive_shell() {
  case "$(basename "$1")" in fish|bash|zsh|sh|dash) return 0 ;; *) return 1 ;; esac
}

# ---- stub tmux: pops scripted (path<TAB>cmd) pairs per display-message call -
# A global SCRIPT array holds "path|cmd" frames; each tmux display-message for
# pane_current_path returns the path of the current frame, for pane_current_command
# the cmd. advance() moves to the next frame. send-keys / new-window are recorded.
TMUXLOG="$ROOT/tmux.log"; : > "$TMUXLOG"
NEXT=0
SCRIPT=()
advance() { NEXT=$((NEXT+1)); }
tmux() {
  local arg rest
  case "$1" in
    new-window|send-keys|has-session|new-session|list-windows)
      echo "tmux $*" >> "$TMUXLOG"; return 0 ;;
    display-message)
      rest="$*"
      if printf '%s' "$rest" | grep -q 'pane_current_path'; then
        printf '%s' "${SCRIPT[$NEXT]:-EOF}" | cut -d'|' -f1
      elif printf '%s' "$rest" | grep -q 'pane_current_command'; then
        printf '%s' "${SCRIPT[$NEXT]:-EOF}" | cut -d'|' -f2
      fi ;;
  esac
}
# fast sleep
sleep() { :; }

PROJ_ABS="/home/captain/projects/acme"   # the project we launched from
T="t:fm-x"
HARNESS="pi"; EXPECTED_CMD="pi"

# ---- VERBATIM worktree-detection loop (lines 145-167), with `advance()` to  --
# step the scripted tmux each poll instead of real time ----------------------
detect_worktree() {
WT=""
prev=""
for _ in $(seq 1 90); do
  p=$(tmux display-message -p -t "$T" '#{pane_current_path}' 2>/dev/null || true)
  c=$(tmux display-message -p -t "$T" '#{pane_current_command}' 2>/dev/null || true)
  if [ -n "$p" ] && [ "$p" != "$PROJ_ABS" ] && is_treehouse_path "$p" && is_interactive_shell "$c"; then
    if [ "$p" = "$prev" ]; then
      WT="$p"; break
    fi
    prev="$p"
  else
    prev=""
  fi
  advance
  sleep 1
done
}

echo "########## A) PATH TRANSIENT then SETTLE (the documented ~100ms HOME blip)"
# poll0: HOME transient; poll1: real worktree; poll2: same -> captured
NEXT=0
SCRIPT=("/home/captain|fish" "/home/captain/.treehouse/acme-x1/1/main|fish" "/home/captain/.treehouse/acme-x1/1/main|fish")
detect_worktree
echo "WT=$WT"
chk '[ -n "$WT" ]' "transient HOME is skipped, worktree captured after it settles"
chk 'case "$WT" in *.treehouse/acme-x1/1/main) true;; *) false;; esac' "captured path is the real treehouse worktree (not HOME)"

echo
echo "########## B) FOREGROUND RACE: treehouse still running when we'd capture"
# poll0: treehouse is foreground in PROJ_ABS; poll1: worktree+fish; poll2: same
NEXT=0
SCRIPT=("$PROJ_ABS|treehouse" "/home/captain/.treehouse/acme-x1/2/main|fish" "/home/captain/.treehouse/acme-x1/2/main|fish")
detect_worktree
chk '[ -n "$WT" ]' "waits past the treehouse-foreground race, then captures the subshell"
chk '! grep -q "send-keys" "$TMUXLOG"' "no launch keystrokes sent during the foreground race"

echo
echo "########## C) never reaches a worktree within the window -> error path"
NEXT=0
SCRIPT=("/home/captain|fish" "/home/captain|fish" "/home/captain|fish")
detect_worktree
chk '[ -z "$WT" ]' "empty WT when only HOME is ever reported (would trigger the error+exit)"

echo
echo "########## D) post-launch VERIFY: harness flips to running quickly"
# VERBATIM verify loop (lines 261-289), driven by scripted tmux command frames.
EXPECTED_CMD="pi"
harness_running() {
  case "$(basename "$(tmux display-message -p -t "$T" '#{pane_current_command}' 2>/dev/null || true)")" in
    "$EXPECTED_CMD"|node*) return 0 ;; *) return 1 ;;
  esac
}
verify_harness() {
  : > "$TMUXLOG"
  verified=0
  for _ in $(seq 1 40); do
    if harness_running; then verified=1; break; fi
    advance
  done
  echo "$verified"
}
NEXT=0
SCRIPT=("fish" "pi")   # poll0 still shell, poll1 harness up
v=$(verify_harness)
echo "verified=$v"
chk '[ "$v" = "1" ]' "harness detected once pane_current_command flips to the harness binary"

echo
echo "########## E) post-launch VERIFY: stays at shell -> resend path"
# 40 polls of 'fish' then the resend; we simulate resend succeeding on 2nd pass.
NEXT=0
# first 40 polls fish (never detected), then after resend we'd re-poll; script 41 fish then pi
SCRIPT=()
for i in $(seq 1 41); do SCRIPT+=("fish"); done
SCRIPT+=("pi")
v=$(verify_harness)   # this models the first pass only (40 polls)
echo "first-pass verified=$v (expect 0 -> triggers the 40s resend-once path)"
chk '[ "$v" = "0" ]' "first 40 polls at a shell do NOT falsely verify (resend-once path engages)"

echo
echo "########## F) launch template carries --approve (headless trust gate fix)"
# pull the real template from the file (don't trust the copy)
tpl=$(awk '/launch_template\(\)/{f=1} f&&/pi\) printf/{print; exit}' "$SPAWN")
echo "template: $tpl"
chk 'printf "%s" "$tpl" | grep -q -- "--approve"' "pi launch template passes --approve (clears project-trust gate for headless dispatch)"
# also confirm other adapters unchanged shape (still single positional brief)
chk 'printf "%s" "$tpl" | grep -q "cat __BRIEF__"' "brief still passed as the single positional argument"

echo
echo "########## RESULT SUMMARY"
cat "$RESULTS"
F=$(grep -c '^FAIL' "$RESULTS" || true); P=$(grep -c '^PASS' "$RESULTS" || true)
echo "-- totals: $P passed, $F failed --"
[ "$F" -eq 0 ] && echo "ALL SPAWN-LOGIC CHECKS PASSED" || echo "SOME SPAWN-LOGIC CHECKS FAILED"
cp "$RESULTS" "$EVIDENCE/spawn-logic-results.txt"
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 5 issues found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-review-sweep.sh:301` - `--one` without a following repo argument hangs forever. `ONLY_REPO=&#34;${2:-}&#34;` tolerates the missing arg, but `shift 2` fails when only one arg remains (returns non-zero, does not shift) and `set -e` is deliberately off, so `$1` stays `--one` and the `while [ $# -gt 0 ]` loop re-matches it indefinitely. Verified: `fm-review-sweep.sh --one` loops without progress. Fix: guard with `shift 2 || { echo &#39;error: --one requires a repo argument&#39; &gt;&amp;2; exit 2; }` (or check `$# -ge 2`).
- ⚠️ `bin/fm-review-sweep.sh:24` - The header doc (line 24) promises an overrun review is &#39;abandoned (window left for inspection)&#39;, but on timeout `try_reap` (line ~411) calls `teardown_task`, which sends `/quit`, `kill-window` (line 287), and `treehouse prune` (line 289). The window and worktree are destroyed, so nothing is left for inspection — defeating post-mortem debugging of an unattended cron run. Either the doc or the behavior is wrong; preserving the pane/worktree on timeout (or at least skipping the kill) better matches the stated intent.
- ⚠️ `bin/fm-review-sweep.sh:221` - When `fm-spawn.sh` returns non-zero, the failure cleanup only `rm -f`s the meta/status and `rm -rf`s data (`rm -f &#34;$FM_ROOT/state/$id.meta&#34; &#34;$status_file&#34;; rm -rf &#34;$FM_ROOT/data/$id&#34;`), but fm-spawn may already have created the tmux window `fm-$id` (it creates the window before the worktree-detection and post-launch-verify waits that can fail). The window is never killed, so it leaks. Over repeated sweep runs these accumulate. Add `tmux kill-window -t &#34;fm-$id&#34; 2&gt;/dev/null || true` to the failure path.
- ℹ️ `bin/fm-review-sweep.sh:289` - `teardown_task` calls `treehouse prune --yes`, a GLOBAL prune of all orphaned worktrees, whereas the established `bin/fm-teardown.sh` returns the specific worktree with `treehouse return --force &#34;$WT&#34;` (reading `worktree=` from meta). The sweep never reads its task&#39;s worktree path, so it falls back to the imprecise global prune. `prune` is safe if treehouse only targets truly-orphaned worktrees, but running it from cron while a live firstmate session has active crewmates relies on treehouse correctly distinguishing active vs orphaned worktrees. Returning the specific worktree (like fm-teardown) would be deterministic and consistent.
- ℹ️ `bin/fm-review-sweep.sh:356` - The dry-run header `printf &#39;repo\t#cifail\ttitle\turl\n&#39;` does not match the data rows `printf &#39;%s\t#%s\t%s\t%s\n&#39; &#34;$repo&#34; &#34;$num&#34; &#34;$cifail&#34; &#34;$title&#34;`. The header shows a nonsensical `#cifail` column and lists `url`, while the data prints `repo`, `#&lt;num&gt;`, `&lt;cifail&gt;`, `&lt;title&gt;` — so the columns are mislabeled and `url` is promised but never printed. The header should be `printf &#39;repo\t#num\tcifail\ttitle\n&#39;`.

🔧 Fix: fix sweep --one loop, timeout inspection, spawn-fail window leak, precise worktree return, dry-run header
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-review-sweep.test.sh` (project&#39;s own behavior tests: resolve_fleet, ci_status, parse_recommendation clean-vs-CONDITIONAL, jira_key_for — 12/12 pass)</code>
- <code>`e2e_sweep.sh`: sourced the real main() and ran `main --dry-run` against a stubbed gh fleet of 5 PRs across 2 repos — verified draft #2 and approved #3 are filtered, candidates #1/#4/#10 kept, failing-CI #4 KEPT, and the dry-run plan + sweep.log show it</code>
- <code>`e2e_sweep.sh` §4: held the flock from a background fixture then ran `main --dry-run` again — verified graceful refusal with exit 0 and the lock message</code>
- <code>`e2e_sweep.sh` §5-6: called `write_brief` for a green PR and a red PR — verified the review-only contract (review-rectify-pi/--push/never-push) and that only the red PR brief contains the dedicated `## CI failure (this PR&#39;s CI is RED)` root-cause investigation section (gh pr checks / gh run view --log-failed)</code>
- <code>`e2e_sweep.sh` §7: called `maybe_transition_jira` with APPROVE then CONDITIONAL against a stubbed jira CLI — verified exactly one `issue move MILE-1001 In Review` (CONDITIONAL suppressed), plus the no-MILE-key suppression+log path</code>
- <code>`e2e_sweep.sh` §8: called `parse_recommendation` for APPROVE/CONDITIONAL APPROVE/BLOCK/REQUEST CHANGES/CAUTION — verified clean APPROVE→APPROVE and CONDITIONAL APPROVE→CONDITIONAL</code>
- <code>`e2e_sweep.sh` §9: ran `main --one veridianlab/infra --dry-run` — verified it ran only the named repo and excluded the other</code>
- <code>`e2e_spawn_logic.sh`: drove verbatim-copied is_treehouse_path/is_interactive_shell + the worktree-detection loop with a scripted tmux replaying the documented ~100ms $HOME path transient (skipped), the treehouse foreground race (waits, no keystrokes sent), and a never-settling pane (empty WT→error path)</code>
- <code>`e2e_spawn_logic.sh` §D-E: drove the verbatim post-launch verify loop — harness detected when pane_current_command flips to the harness binary; 40 polls at a shell do NOT falsely verify (engages the resend-once path)</code>
- <code>`e2e_spawn_logic.sh` §F: extracted the live pi launch_template from bin/fm-spawn.sh — verified it carries `--approve` and still passes the brief as a single positional arg</code>
- <code>`bash -n bin/fm-review-sweep.sh bin/fm-spawn.sh tests/fm-review-sweep.test.sh` (syntax)</code>
- `Worktree cleanliness verified before/after (git status clean; removed transient state/sweep.log + state/sweep created by an early subprocess run)`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
