### PR TITLE
feat(secondmate): keep secondmates idle and hand off scoped backlog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,6 +213,7 @@ Reconcile reality with your records before doing anything else:
 7. Do not reconstruct a secondmate's whole tree from the main home.
    The main firstmate reconciles only direct reports.
    Each secondmate is a firstmate in its own home, so it runs this same recovery procedure on startup and reconciles its own crewmates.
+   A secondmate's recovery reconciles only work that is already its own; on finding no assigned or in-flight work it goes idle and waits for the main firstmate to route it a task, never initiating a survey or audit of its own (section 6).
 8. If `state/.afk` is present (away-mode was active before the restart): re-enter afk - ensure the daemon is running, do not arm the one-shot watcher (the daemon owns it), and resume away-mode supervision.
 9. Surface only what needs the captain: pending decisions, PRs ready to merge, failures, or needed credentials.
    If there is nothing that needs them, say nothing and resume.
@@ -251,6 +252,18 @@ Seeding is transactional: if validation, cloning, no-mistakes initialization, or
 `bin/fm-home-seed.sh validate` refuses duplicate ids, duplicate homes, and nested or overlapping homes.
 Secondmate project lists may include `no-mistakes` and `direct-PR` projects only; `local-only` projects stay with the main firstmate.
 For `no-mistakes` projects, seeding initializes only projects newly cloned into a secondmate home and refuses to mutate a preexisting clone that is not already initialized.
+
+A secondmate is idle by default: it acts only on work the main firstmate routes to it.
+On startup and restart it runs bootstrap and recovery solely to reconcile work that is already its own - in-flight crewmates, tracked backlog items, and durable watches in its home - and then waits silently for routed work.
+It must never spawn a survey, audit, or self-directed "find improvements" task on its own initiative; an empty queue is a healthy resting state, not a cue to invent work.
+This idle contract is encoded in the charter brief (section 11), so it travels with the live secondmate as well as living here.
+
+**Hand off in-scope backlog on creation.**
+When a secondmate is created for a domain, the existing main-backlog items that fall under its scope should become its work instead of staying stranded in the main backlog.
+Scope-matching is firstmate's judgment against the secondmate's natural-language scope, not a keyword rule: read `data/backlog.md`, pick the queued items that fit the new scope, and move them with `bin/fm-backlog-handoff.sh <secondmate-id> <item-key>...`.
+The helper resolves the secondmate home from `data/secondmates.md` and mechanically moves each named item from the main `data/backlog.md` into the secondmate home's `data/backlog.md`, preserving the line and its section, so the item is neither duplicated nor lost.
+It is idempotent (an item already in the secondmate backlog is skipped) and refuses any destination that is not a genuine seeded secondmate home (it checks the home's `.fm-secondmate-home` marker), so a move can never land in a project.
+Do not hand off `local-only` items: that work stays with the main firstmate (section 7).
 
 ### Project memory ownership
 
@@ -329,6 +342,7 @@ If a secondmate's scope fits, steer that secondmate with one concise instruction
 The bare `fm-<id>` target resolves through this home's `state/<id>.meta`; pass `session:window` only when intentionally targeting a window outside this firstmate home.
 Do not spawn a direct crewmate for work that belongs to a secondmate scope unless the secondmate is blocked or the captain explicitly redirects it.
 If no secondmate scope fits, proceed in the main firstmate or create a new secondmate with the captain when that domain should become persistent.
+When you create a new secondmate, hand its in-scope queued items off from the main backlog into its home with `bin/fm-backlog-handoff.sh` so it owns its domain's queue from day one (section 6).
 
 Then classify the shape:
 
@@ -625,7 +639,9 @@ The scaffold writes a charter brief instead of a task brief.
 Set `FM_SECONDMATE_CHARTER='<charter>'` to fill the charter text and `FM_SECONDMATE_SCOPE='<scope>'` when the routing scope differs.
 If you scaffold without `FM_SECONDMATE_CHARTER`, replace the `{TASK}` placeholder before seeding.
 Keep the charter focused on the persistent responsibility, available project clones, and escalation back to the main firstmate status file.
+The scaffold's definition of done encodes the idle-by-default contract (section 6): on startup the secondmate reconciles only its own in-flight work and then waits for routed tasks, never self-initiating a survey or audit; preserve that wording when filling the charter.
 `bin/fm-home-seed.sh` copies the charter into the secondmate home as `data/charter.md`; `bin/fm-spawn.sh --secondmate` launches it through the same launch-template path.
+After seeding, hand the new secondmate's in-scope queued items off from the main backlog with `bin/fm-backlog-handoff.sh` (section 6).
 `bin/fm-home-seed.sh` refuses to copy a missing or placeholder charter.
 The status-reporting protocol is intentionally sparse: crewmates append status only for supervisor-actionable phase changes or `needs-decision`/`blocked`/`done`/`failed`, because every append wakes firstmate.
 For any generated brief that still contains `{TASK}`, replace it with a clear task description, acceptance criteria, and any constraints or context the crewmate needs before spawning or seeding.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -262,7 +262,8 @@ This idle contract is encoded in the charter brief (section 11), so it travels w
 When a secondmate is created for a domain, the existing main-backlog items that fall under its scope should become its work instead of staying stranded in the main backlog.
 Scope-matching is firstmate's judgment against the secondmate's natural-language scope, not a keyword rule: read `data/backlog.md`, pick the queued items that fit the new scope, and move them with `bin/fm-backlog-handoff.sh <secondmate-id> <item-key>...`.
 The helper resolves the secondmate home from `data/secondmates.md` and mechanically moves each named item from the main `data/backlog.md` into the secondmate home's `data/backlog.md`, preserving the line and its section, so the item is neither duplicated nor lost.
-It is idempotent (an item already in the secondmate backlog is skipped) and refuses any destination that is not a genuine seeded secondmate home (it checks the home's `.fm-secondmate-home` marker), so a move can never land in a project.
+It refuses `## In flight` entries because active task ownership also lives in tmux and `state/`.
+It is idempotent (an item already in the secondmate backlog is skipped) and refuses any destination that is not a genuine seeded firstmate home with safe operational directories and a matching `.fm-secondmate-home` marker, so a move can never land in a project.
 Do not hand off `local-only` items: that work stays with the main firstmate (section 7).
 
 ### Project memory ownership

--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ firstmate works from any terminal - outside tmux, crewmates land in a detached `
   Seeding is transactional: if validation, cloning, initialization, or registry update fails, generated briefs, new homes, new project clones, and registry edits are rolled back.
   `local-only` projects stay with the main first mate because they merge into the main local checkout instead of a remote-backed PR path.
   The same project may appear in multiple secondmate homes when their scopes differ, such as issue triage versus feature development.
+  Secondmates are idle by default: after startup recovery reconciles only work already in their own home, an empty queue waits silently for routed tasks, and they never self-initiate surveys or audits.
+  After seeding a secondmate, `fm-backlog-handoff.sh` moves already-judged in-scope queued items from the main backlog into that secondmate home so the domain queue starts in the right place.
   Idle secondmate panes are healthy; teardown is explicit and refuses while the secondmate home has in-flight work unless the captain has approved discard with `--force`.
 - **Project modes are explicit** - `data/projects.md` records each project's delivery mode and optional `+yolo` autonomy flag.
   `no-mistakes` projects run the full validation pipeline, `direct-PR` projects open PRs without that pipeline, and `local-only` projects stay local until firstmate performs an approved fast-forward merge.
@@ -142,6 +144,7 @@ The first mate drives these; you rarely need to, but they work by hand too.
 | ------------------------ | ------------------------------------------------------------------------------------------------------------------- |
 | `fm-bootstrap.sh`        | Detect missing toolchain pieces; refresh clones best-effort; install tools only after consent                       |
 | `fm-fleet-sync.sh`       | Fetch clones, clean-fast-forward their checked-out default branches, and safely prune branches whose remote is gone |
+| `fm-backlog-handoff.sh`  | Move already-judged in-scope queued backlog items from the main home into a seeded secondmate home                 |
 | `fm-brief.sh`            | Scaffold a ship brief, a report-only scout brief with `--scout`, or a secondmate charter with `--secondmate`      |
 | `fm-ensure-agents-md.sh` | Ensure project `AGENTS.md` is the real memory file and `CLAUDE.md` symlinks to it                                   |
 | `fm-guard.sh`            | Warn when tasks are in flight but queued wakes are pending or the watcher liveness beacon is stale or missing      |
@@ -170,6 +173,7 @@ Each line records the secondmate id, charter summary, absolute home path, natura
 The main first mate routes by reading those scopes with judgment; the project list is provisioning data, not exclusive ownership.
 Secondmate routes cover `no-mistakes` and `direct-PR` projects; `local-only` projects remain main-firstmate work.
 For `no-mistakes` projects, seeding initializes only projects newly cloned into a secondmate home and refuses to mutate a preexisting clone that is not already initialized.
+After creating a secondmate, move existing main-backlog items that you have judged in-scope with `fm-backlog-handoff.sh <secondmate-id> <item-key>...`; it is idempotent and refuses in-flight items or non-secondmate homes.
 Set `FM_SECONDMATE_CHARTER` to seed from inline charter text when no filled charter brief exists; set `FM_SECONDMATE_SCOPE` when the routing scope should differ from the charter text.
 `FM_HOME` selects the operational home for one firstmate instance.
 When it is unset, the repo root is the home; when it is set, scripts still run from this repo's `bin/`, but `state/`, `data/`, `config/`, and `projects/` come from `$FM_HOME`.
@@ -213,7 +217,7 @@ shellcheck bin/*.sh tests/*.sh            # lint the toolbelt and behavior tests
 for test_script in tests/*.test.sh; do "$test_script"; done   # behavior tests, matching CI
 tests/fm-wake-queue.test.sh               # durable wake queue, singleton behavior, sub-supervisor classifier, and /afk presence-gating tests
 tests/fm-afk-inject-e2e.test.sh           # private-socket end-to-end test of the afk injection path (partial-input deferral, swallowed-Enter retry)
-tests/fm-secondmate.test.sh               # persistent secondmate routing, seeding, spawn, recovery, teardown, and FM_HOME tests
+tests/fm-secondmate.test.sh               # persistent secondmate routing, seeding, idle charter, backlog handoff, spawn, recovery, teardown, and FM_HOME tests
 tests/fm-teardown.test.sh                 # fm-teardown.sh unpushed-work safety check: local-only fork-remote allow, truly-unpushed refuse, merged-to-main allow, no-mistakes regression, --force override
 [ "$(readlink CLAUDE.md)" = "AGENTS.md" ]
 [ "$(readlink .claude/skills)" = "../.agents/skills" ]

--- a/bin/fm-backlog-handoff.sh
+++ b/bin/fm-backlog-handoff.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# Hand already-identified, in-scope backlog items off from the main firstmate
+# backlog to a secondmate's own home backlog. Use this when a secondmate is
+# created (or whenever an existing queued item should become its domain's work)
+# so the secondmate owns its queue from day one instead of the item staying
+# stranded in the main backlog.
+#
+# Scope-matching is firstmate's JUDGMENT: you pass the task-id keys you have
+# already judged in-scope for the secondmate. This script performs only the
+# mechanical move - it removes each matched line from data/backlog.md under the
+# active firstmate home and appends it, under the same section heading, to the
+# secondmate home's data/backlog.md (home resolved from data/secondmates.md). It
+# never changes a line's text, never writes into a project (it refuses a home
+# that is not a firstmate home), and is idempotent: a key already present in the
+# secondmate backlog is reported and skipped, so re-running converges. If any key
+# matches neither backlog, nothing is moved. See AGENTS.md sections 6-7.
+# Usage: fm-backlog-handoff.sh <secondmate-id> <item-key>...
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
+REG="$DATA/secondmates.md"
+MAIN_BACKLOG="$DATA/backlog.md"
+
+[ $# -ge 2 ] || { echo "usage: fm-backlog-handoff.sh <secondmate-id> <item-key>..." >&2; exit 1; }
+ID=$1
+shift
+
+secondmate_home() {
+  local id=$1 line
+  [ -f "$REG" ] || { echo "error: no secondmate registry at $REG" >&2; return 1; }
+  line=$(grep -E "^- $id( |$)" "$REG" | tail -1 || true)
+  [ -n "$line" ] || { echo "error: secondmate $id is not registered in $REG" >&2; return 1; }
+  printf '%s\n' "$line" | sed -n 's/^[^(]*(home: \([^;)]*\);.*/\1/p'
+}
+
+# A backlog task line is "- [ ] <id> - ..." or "- [x] <id> - ..."; the key is the
+# first whitespace-delimited token after the checkbox.
+backlog_has_key() {
+  local file=$1 key=$2
+  [ -f "$file" ] || return 1
+  awk -v key="$key" '
+    /^- \[[ x]\] / {
+      rest = $0
+      sub(/^- \[[ x]\] +/, "", rest)
+      id = rest
+      sub(/[ \t].*/, "", id)
+      if (id == key) { found = 1; exit }
+    }
+    END { exit found ? 0 : 1 }
+  ' "$file"
+}
+
+RAW_HOME=$(secondmate_home "$ID") || exit 1
+[ -n "$RAW_HOME" ] || { echo "error: secondmate $ID has no home in $REG" >&2; exit 1; }
+[ -d "$RAW_HOME" ] || { echo "error: secondmate home does not exist or is not a directory: $RAW_HOME" >&2; exit 1; }
+SUB_HOME=$(cd "$RAW_HOME" && pwd -P)
+# A move may only land in a genuine seeded secondmate home. The .fm-secondmate-home
+# marker is that home's authoritative signal (projects never carry it), and its id
+# must match, so a move can never write into a project or the wrong home.
+SUB_MARKER="$SUB_HOME/.fm-secondmate-home"
+[ -f "$SUB_MARKER" ] || { echo "error: $SUB_HOME is not a seeded secondmate home (missing .fm-secondmate-home marker); refusing to write its backlog" >&2; exit 1; }
+MARKER_ID=$(cat "$SUB_MARKER" 2>/dev/null || true)
+[ "$MARKER_ID" = "$ID" ] || { echo "error: $SUB_HOME is marked for secondmate '${MARKER_ID:-unknown}', not '$ID'; refusing to write its backlog" >&2; exit 1; }
+SUB_BACKLOG="$SUB_HOME/data/backlog.md"
+
+# Classify every key before changing anything: move-from-main, already-in-sub, or
+# missing. Abort with no changes if any key matches neither backlog.
+TO_MOVE=()
+ALREADY=()
+MISSING=()
+for key in "$@"; do
+  if backlog_has_key "$SUB_BACKLOG" "$key"; then
+    ALREADY+=("$key")
+  elif backlog_has_key "$MAIN_BACKLOG" "$key"; then
+    TO_MOVE+=("$key")
+  else
+    MISSING+=("$key")
+  fi
+done
+
+if [ "${#MISSING[@]}" -gt 0 ]; then
+  echo "error: no backlog item matched these keys in $MAIN_BACKLOG: ${MISSING[*]}" >&2
+  echo "       nothing was moved." >&2
+  exit 1
+fi
+
+if [ "${#TO_MOVE[@]}" -eq 0 ]; then
+  echo "nothing to move: ${ALREADY[*]:-no keys} already present in $SUB_BACKLOG"
+  exit 0
+fi
+
+mkdir -p "$SUB_HOME/data"
+if [ ! -f "$SUB_BACKLOG" ]; then
+  printf '## In flight\n\n## Queued\n\n## Done\n' > "$SUB_BACKLOG"
+fi
+
+KEYS_FILE=$(mktemp "${TMPDIR:-/tmp}/fm-handoff-keys.XXXXXX")
+MOVED_FILE=$(mktemp "${TMPDIR:-/tmp}/fm-handoff-moved.XXXXXX")
+KEPT_FILE=$(mktemp "${TMPDIR:-/tmp}/fm-handoff-kept.XXXXXX")
+SUB_TMP=$(mktemp "${TMPDIR:-/tmp}/fm-handoff-sub.XXXXXX")
+cleanup() { rm -f "$KEYS_FILE" "$MOVED_FILE" "$KEPT_FILE" "$SUB_TMP"; }
+trap cleanup EXIT
+printf '%s\n' "${TO_MOVE[@]}" > "$KEYS_FILE"
+
+# Pass 1: drop the matched lines from the main backlog, capturing each removed
+# line tagged with the "## " section heading it lived under.
+: > "$MOVED_FILE"
+awk -v keysfile="$KEYS_FILE" -v movedfile="$MOVED_FILE" '
+  BEGIN {
+    while ((getline k < keysfile) > 0) { if (k != "") want[k] = 1 }
+    section = "## Queued"
+  }
+  /^## / { section = $0; print; next }
+  /^- \[[ x]\] / {
+    rest = $0
+    sub(/^- \[[ x]\] +/, "", rest)
+    id = rest
+    sub(/[ \t].*/, "", id)
+    if (id in want) { print section "\t" $0 > movedfile; next }
+  }
+  { print }
+' "$MAIN_BACKLOG" > "$KEPT_FILE"
+
+# Pass 2: insert each moved line at the end of its section in the sub backlog,
+# creating the section heading if the sub backlog lacks it.
+awk -v movedfile="$MOVED_FILE" '
+  function flush(sec) {
+    if (sec != "" && (sec in items) && !(sec in flushed)) {
+      printf "%s", items[sec]
+      flushed[sec] = 1
+    }
+  }
+  BEGIN {
+    nsec = 0
+    while ((getline rec < movedfile) > 0) {
+      tab = index(rec, "\t")
+      if (tab == 0) continue
+      sec = substr(rec, 1, tab - 1)
+      line = substr(rec, tab + 1)
+      if (!(sec in items)) { order[++nsec] = sec }
+      items[sec] = items[sec] line "\n"
+    }
+    cur = ""
+  }
+  /^## / { flush(cur); cur = $0; print; next }
+  { print }
+  END {
+    flush(cur)
+    for (i = 1; i <= nsec; i++) {
+      s = order[i]
+      if (!(s in flushed)) {
+        print ""
+        print s
+        printf "%s", items[s]
+        flushed[s] = 1
+      }
+    }
+  }
+' "$SUB_BACKLOG" > "$SUB_TMP"
+
+mv "$KEPT_FILE" "$MAIN_BACKLOG"
+mv "$SUB_TMP" "$SUB_BACKLOG"
+
+echo "handed off ${#TO_MOVE[@]} item(s) to $ID: ${TO_MOVE[*]}"
+echo "  into $SUB_BACKLOG"
+if [ "${#ALREADY[@]}" -gt 0 ]; then
+  echo "  already present (skipped): ${ALREADY[*]}"
+fi

--- a/bin/fm-backlog-handoff.sh
+++ b/bin/fm-backlog-handoff.sh
@@ -36,18 +36,132 @@ secondmate_home() {
   printf '%s\n' "$line" | sed -n 's/^[^(]*(home: \([^;)]*\);.*/\1/p'
 }
 
-# A backlog task line is "- [ ] <id> - ..." or "- [x] <id> - ..."; the key is the
-# first whitespace-delimited token after the checkbox.
-backlog_has_key() {
+path_is_ancestor_of() {
+  local ancestor=$1 path=$2
+  [ -n "$ancestor" ] || return 1
+  [ -n "$path" ] || return 1
+  [ "$ancestor" != "$path" ] || return 1
+  case "$path" in
+    "$ancestor"/*) return 0 ;;
+  esac
+  return 1
+}
+
+resolved_existing_dir() {
+  local path=$1
+  [ -d "$path" ] || { echo "error: firstmate home does not exist or is not a directory: $path" >&2; return 1; }
+  cd "$path" && pwd -P
+}
+
+validate_operational_dirs() {
+  local abs_home=$1 abs_active_home=$2 abs_root=$3 name dir abs_dir
+  for name in data state config projects; do
+    dir="$abs_home/$name"
+    if [ -L "$dir" ] && [ ! -e "$dir" ]; then
+      echo "error: secondmate $name directory must resolve inside the secondmate home: $dir" >&2
+      return 1
+    fi
+    if [ -d "$dir" ]; then
+      abs_dir=$(cd "$dir" && pwd -P)
+    elif [ -e "$dir" ]; then
+      echo "error: secondmate $name path is not a directory: $dir" >&2
+      return 1
+    else
+      abs_dir="$abs_home/$name"
+    fi
+    if ! path_is_ancestor_of "$abs_home" "$abs_dir"; then
+      echo "error: secondmate $name directory must resolve inside the secondmate home: $dir" >&2
+      return 1
+    fi
+    if [ "$abs_dir" = "$abs_active_home" ] || path_is_ancestor_of "$abs_active_home" "$abs_dir"; then
+      echo "error: secondmate $name directory cannot be inside the active firstmate home: $dir" >&2
+      return 1
+    fi
+    if [ "$abs_dir" = "$abs_root" ] || path_is_ancestor_of "$abs_root" "$abs_dir"; then
+      echo "error: secondmate $name directory cannot be inside the firstmate repo: $dir" >&2
+      return 1
+    fi
+  done
+}
+
+validate_secondmate_home() {
+  local id=$1 home=$2 abs_home abs_active_home abs_root marker_id
+  abs_home=$(resolved_existing_dir "$home") || return 1
+  abs_active_home=$(resolved_existing_dir "$FM_HOME")
+  abs_root=$(resolved_existing_dir "$FM_ROOT")
+  if [ "$abs_home" = "/" ]; then
+    echo "error: secondmate home cannot be the filesystem root: $home" >&2
+    return 1
+  fi
+  if [ "$abs_home" = "$abs_active_home" ]; then
+    echo "error: secondmate home cannot be the active firstmate home: $home" >&2
+    return 1
+  fi
+  if [ "$abs_home" = "$abs_root" ]; then
+    echo "error: secondmate home cannot be the firstmate repo: $home" >&2
+    return 1
+  fi
+  if path_is_ancestor_of "$abs_active_home" "$abs_home"; then
+    echo "error: secondmate home cannot be inside the active firstmate home: $home" >&2
+    return 1
+  fi
+  if path_is_ancestor_of "$abs_root" "$abs_home"; then
+    echo "error: secondmate home cannot be inside the firstmate repo: $home" >&2
+    return 1
+  fi
+  if path_is_ancestor_of "$abs_home" "$abs_active_home"; then
+    echo "error: secondmate home cannot be an ancestor of the active firstmate home: $home" >&2
+    return 1
+  fi
+  if path_is_ancestor_of "$abs_home" "$abs_root"; then
+    echo "error: secondmate home cannot be an ancestor of the firstmate repo: $home" >&2
+    return 1
+  fi
+  validate_operational_dirs "$abs_home" "$abs_active_home" "$abs_root" || return 1
+  if [ ! -f "$abs_home/.fm-secondmate-home" ]; then
+    echo "error: firstmate home $home is not a seeded secondmate home" >&2
+    return 1
+  fi
+  marker_id=$(cat "$abs_home/.fm-secondmate-home" 2>/dev/null || true)
+  if [ "$marker_id" != "$id" ]; then
+    echo "error: firstmate home $home is marked for secondmate ${marker_id:-unknown}, expected $id" >&2
+    return 1
+  fi
+  if [ ! -f "$abs_home/AGENTS.md" ]; then
+    echo "error: $home is not a firstmate home (missing AGENTS.md)" >&2
+    return 1
+  fi
+  if [ ! -d "$abs_home/bin" ]; then
+    echo "error: $home is not a firstmate home (missing bin/)" >&2
+    return 1
+  fi
+  printf '%s\n' "$abs_home"
+}
+
+validate_backlog_file() {
+  local label=$1 path=$2
+  if [ -L "$path" ]; then
+    echo "error: $label must not be a symlink: $path" >&2
+    return 1
+  fi
+  if [ -e "$path" ] && [ ! -f "$path" ]; then
+    echo "error: $label is not a regular file: $path" >&2
+    return 1
+  fi
+}
+
+backlog_key_section() {
   local file=$1 key=$2
   [ -f "$file" ] || return 1
   awk -v key="$key" '
+    BEGIN { section = "## Queued" }
+    /^## / { section = $0; next }
     /^- \[[ x]\] / {
       rest = $0
       sub(/^- \[[ x]\] +/, "", rest)
       id = rest
       sub(/[ \t].*/, "", id)
-      if (id == key) { found = 1; exit }
+      if (id == key) { print section; found = 1; exit }
     }
     END { exit found ? 0 : 1 }
   ' "$file"
@@ -55,34 +169,41 @@ backlog_has_key() {
 
 RAW_HOME=$(secondmate_home "$ID") || exit 1
 [ -n "$RAW_HOME" ] || { echo "error: secondmate $ID has no home in $REG" >&2; exit 1; }
-[ -d "$RAW_HOME" ] || { echo "error: secondmate home does not exist or is not a directory: $RAW_HOME" >&2; exit 1; }
-SUB_HOME=$(cd "$RAW_HOME" && pwd -P)
-# A move may only land in a genuine seeded secondmate home. The .fm-secondmate-home
-# marker is that home's authoritative signal (projects never carry it), and its id
-# must match, so a move can never write into a project or the wrong home.
-SUB_MARKER="$SUB_HOME/.fm-secondmate-home"
-[ -f "$SUB_MARKER" ] || { echo "error: $SUB_HOME is not a seeded secondmate home (missing .fm-secondmate-home marker); refusing to write its backlog" >&2; exit 1; }
-MARKER_ID=$(cat "$SUB_MARKER" 2>/dev/null || true)
-[ "$MARKER_ID" = "$ID" ] || { echo "error: $SUB_HOME is marked for secondmate '${MARKER_ID:-unknown}', not '$ID'; refusing to write its backlog" >&2; exit 1; }
+SUB_HOME=$(validate_secondmate_home "$ID" "$RAW_HOME") || exit 1
 SUB_BACKLOG="$SUB_HOME/data/backlog.md"
+validate_backlog_file "main backlog" "$MAIN_BACKLOG" || exit 1
+validate_backlog_file "secondmate backlog" "$SUB_BACKLOG" || exit 1
 
 # Classify every key before changing anything: move-from-main, already-in-sub, or
 # missing. Abort with no changes if any key matches neither backlog.
 TO_MOVE=()
 ALREADY=()
 MISSING=()
+IN_FLIGHT=()
 for key in "$@"; do
-  if backlog_has_key "$SUB_BACKLOG" "$key"; then
+  if backlog_key_section "$SUB_BACKLOG" "$key" >/dev/null; then
     ALREADY+=("$key")
-  elif backlog_has_key "$MAIN_BACKLOG" "$key"; then
-    TO_MOVE+=("$key")
+  elif section=$(backlog_key_section "$MAIN_BACKLOG" "$key"); then
+    if [ "$section" = "## In flight" ]; then
+      IN_FLIGHT+=("$key")
+    else
+      TO_MOVE+=("$key")
+    fi
   else
     MISSING+=("$key")
   fi
 done
 
+FAILED=0
+if [ "${#IN_FLIGHT[@]}" -gt 0 ]; then
+  echo "error: refusing to hand off in-flight backlog items: ${IN_FLIGHT[*]}" >&2
+  FAILED=1
+fi
 if [ "${#MISSING[@]}" -gt 0 ]; then
   echo "error: no backlog item matched these keys in $MAIN_BACKLOG: ${MISSING[*]}" >&2
+  FAILED=1
+fi
+if [ "$FAILED" -ne 0 ]; then
   echo "       nothing was moved." >&2
   exit 1
 fi
@@ -93,17 +214,40 @@ if [ "${#TO_MOVE[@]}" -eq 0 ]; then
 fi
 
 mkdir -p "$SUB_HOME/data"
+SUB_EXISTED=0
 if [ ! -f "$SUB_BACKLOG" ]; then
   printf '## In flight\n\n## Queued\n\n## Done\n' > "$SUB_BACKLOG"
+else
+  SUB_EXISTED=1
 fi
 
-KEYS_FILE=$(mktemp "${TMPDIR:-/tmp}/fm-handoff-keys.XXXXXX")
-MOVED_FILE=$(mktemp "${TMPDIR:-/tmp}/fm-handoff-moved.XXXXXX")
-KEPT_FILE=$(mktemp "${TMPDIR:-/tmp}/fm-handoff-kept.XXXXXX")
-SUB_TMP=$(mktemp "${TMPDIR:-/tmp}/fm-handoff-sub.XXXXXX")
-cleanup() { rm -f "$KEYS_FILE" "$MOVED_FILE" "$KEPT_FILE" "$SUB_TMP"; }
+MAIN_DIR=$(dirname "$MAIN_BACKLOG")
+SUB_DIR=$(dirname "$SUB_BACKLOG")
+KEYS_FILE=$(mktemp "$MAIN_DIR/.fm-handoff-keys.XXXXXX")
+MOVED_FILE=$(mktemp "$MAIN_DIR/.fm-handoff-moved.XXXXXX")
+KEPT_FILE=$(mktemp "$MAIN_DIR/.fm-handoff-kept.XXXXXX")
+SUB_TMP=$(mktemp "$SUB_DIR/.fm-handoff-sub.XXXXXX")
+MAIN_BAK=$(mktemp "$MAIN_DIR/.fm-handoff-main-bak.XXXXXX")
+SUB_BAK=$(mktemp "$SUB_DIR/.fm-handoff-sub-bak.XXXXXX")
+CHANGES_STARTED=0
+COMMITTED=0
+cleanup() {
+  if [ "$CHANGES_STARTED" -eq 1 ] && [ "$COMMITTED" -eq 0 ]; then
+    cp "$MAIN_BAK" "$MAIN_BACKLOG" 2>/dev/null || true
+    if [ "$SUB_EXISTED" -eq 1 ]; then
+      cp "$SUB_BAK" "$SUB_BACKLOG" 2>/dev/null || true
+    else
+      rm -f "$SUB_BACKLOG"
+    fi
+  fi
+  rm -f "$KEYS_FILE" "$MOVED_FILE" "$KEPT_FILE" "$SUB_TMP" "$MAIN_BAK" "$SUB_BAK"
+}
 trap cleanup EXIT
 printf '%s\n' "${TO_MOVE[@]}" > "$KEYS_FILE"
+cp "$MAIN_BACKLOG" "$MAIN_BAK"
+if [ "$SUB_EXISTED" -eq 1 ]; then
+  cp "$SUB_BACKLOG" "$SUB_BAK"
+fi
 
 # Pass 1: drop the matched lines from the main backlog, capturing each removed
 # line tagged with the "## " section heading it lived under.
@@ -161,8 +305,10 @@ awk -v movedfile="$MOVED_FILE" '
   }
 ' "$SUB_BACKLOG" > "$SUB_TMP"
 
-mv "$KEPT_FILE" "$MAIN_BACKLOG"
+CHANGES_STARTED=1
 mv "$SUB_TMP" "$SUB_BACKLOG"
+mv "$KEPT_FILE" "$MAIN_BACKLOG"
+COMMITTED=1
 
 echo "handed off ${#TO_MOVE[@]} item(s) to $ID: ${TO_MOVE[*]}"
 echo "  into $SUB_BACKLOG"

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -84,6 +84,9 @@ You are in an isolated firstmate home. The local \`AGENTS.md\` is your job descr
 The projects above are local clones for work you supervise; they are not an exclusive ownership claim.
 Delegate project work to your own crewmates with the normal firstmate lifecycle: brief, spawn, status, watcher, steer, teardown, and recovery.
 Do not invent a second delegation system.
+You do not generate your own work.
+Act only on tasks the main firstmate routes to you.
+Never start a survey, audit, or "find improvements" sweep on your own initiative; that is not your job and it is unwanted.
 
 # Escalation to main firstmate
 Handle routine work yourself.
@@ -95,7 +98,9 @@ Routine internal supervision, heartbeats, retries, and crewmate churn stay insid
 
 # Definition of done
 You are persistent by default. Do not exit just because your queue is empty.
-On startup and restart, run normal firstmate bootstrap and recovery for your own home, then supervise work that matches your scope.
+On startup and restart, run normal firstmate bootstrap and recovery for your own home, but only to RECONCILE work that is already yours: in-flight crewmates, tracked backlog items, and durable watches recorded in this home.
+When you have no assigned or in-flight work after that reconciliation, go idle and wait silently for the main firstmate to route you a task.
+An empty queue is a healthy resting state, not a cue to invent work: never spawn a survey, audit, or any self-directed "find work" task on your own initiative.
 If this charter cannot be carried out, append \`blocked: {why}\` or \`failed: {why}\` to the main status file and stop.
 EOF
 if [ "$SECONDMATE_CHARTER" = "{TASK}" ]; then

--- a/tests/fm-secondmate.test.sh
+++ b/tests/fm-secondmate.test.sh
@@ -1790,6 +1790,139 @@ EOF
   pass "idle kind=secondmate pane is healthy and not stale"
 }
 
+seed_secondmate_home_marker() {
+  # Make a directory look like a genuine seeded secondmate home for handoff tests.
+  local home=$1 id=$2
+  mark_firstmate_home "$home"
+  mkdir -p "$home/data"
+  printf '%s\n' "$id" > "$home/.fm-secondmate-home"
+}
+
+test_secondmate_charter_brief_is_idle_by_default() {
+  local home brief
+  home="$TMP_ROOT/idle-charter-home"
+  mkdir -p "$home/data" "$home/state"
+  scaffold_secondmate_charter "$home" idle-sm 'feature work for alpha' alpha
+  brief="$home/data/idle-sm/brief.md"
+  [ -f "$brief" ] || fail "secondmate charter brief was not scaffolded"
+  # Idle contract: waits for routed work, never self-initiates.
+  grep -F 'go idle and wait silently for the main firstmate' "$brief" >/dev/null \
+    || fail "charter brief does not tell the secondmate to go idle and wait for routed work"
+  grep -F 'Act only on tasks the main firstmate routes to you' "$brief" >/dev/null \
+    || fail "charter brief does not restrict work to routed tasks"
+  grep -F 'never spawn a survey, audit, or any self-directed' "$brief" >/dev/null \
+    || fail "charter brief does not forbid self-initiated survey/audit work"
+  # Reconcile-on-startup must remain: bootstrap and recovery still run, scoped to own work.
+  grep -F 'run normal firstmate bootstrap and recovery' "$brief" >/dev/null \
+    || fail "charter brief dropped the bootstrap/recovery reconciliation step"
+  grep -F 'only to RECONCILE work that is already yours' "$brief" >/dev/null \
+    || fail "charter brief does not scope startup work to reconciling existing work"
+  # Regression guard: the over-broad phrasing that got misread as "go find work" is gone.
+  if grep -F 'then supervise work that matches your scope' "$brief" >/dev/null; then
+    fail "charter brief still uses the over-broad 'supervise work that matches your scope' phrasing"
+  fi
+  pass "secondmate charter brief is idle by default and does not self-initiate work"
+}
+
+test_backlog_handoff_moves_in_scope_items() {
+  local home subhome subhome_abs out before
+  home="$TMP_ROOT/handoff-main"
+  subhome="$TMP_ROOT/handoff-sub"
+  mkdir -p "$home/data" "$home/state"
+  seed_secondmate_home_marker "$subhome" design
+  subhome_abs=$(cd "$subhome" && pwd -P)
+  printf -- '- design - feature work (home: %s; scope: feature work; projects: alpha; added 2026-06-22)\n' "$subhome_abs" > "$home/data/secondmates.md"
+  cat > "$home/data/backlog.md" <<'EOF'
+## In flight
+- [ ] live-task - active work (repo: alpha, since 2026-06-20)
+
+## Queued
+- [ ] feat-x - add feature x (repo: alpha)
+- [ ] feat-y - add feature y (repo: beta) blocked-by: feat-x - waits
+- [ ] bug-z - fix bug z (repo: gamma)
+
+## Done
+- [x] old-task - shipped thing - local main (merged 2026-06-19)
+EOF
+
+  out=$(FM_HOME="$home" "$ROOT/bin/fm-backlog-handoff.sh" design feat-x feat-y) \
+    || fail "handoff failed for in-scope items"
+  printf '%s\n' "$out" | grep -F 'handed off 2 item(s) to design' >/dev/null \
+    || fail "handoff did not report the moved items"
+
+  # Moved items leave the main backlog; untouched items stay.
+  grep -F 'feat-x' "$home/data/backlog.md" >/dev/null && fail "feat-x was not removed from the main backlog"
+  grep -F 'feat-y' "$home/data/backlog.md" >/dev/null && fail "feat-y was not removed from the main backlog"
+  grep -F 'bug-z' "$home/data/backlog.md" >/dev/null || fail "out-of-scope bug-z was wrongly removed from the main backlog"
+  grep -F 'live-task' "$home/data/backlog.md" >/dev/null || fail "in-flight item was wrongly removed from the main backlog"
+
+  # Moved items arrive in the secondmate backlog, verbatim and under their section.
+  grep -F -- '- [ ] feat-x - add feature x (repo: alpha)' "$subhome/data/backlog.md" >/dev/null \
+    || fail "feat-x did not arrive verbatim in the secondmate backlog"
+  grep -F -- '- [ ] feat-y - add feature y (repo: beta) blocked-by: feat-x - waits' "$subhome/data/backlog.md" >/dev/null \
+    || fail "feat-y line was not preserved verbatim in the secondmate backlog"
+  awk '/^## Queued/{q=1;next} /^## /{q=0} q && /feat-x/{found=1} END{exit found?0:1}' "$subhome/data/backlog.md" \
+    || fail "feat-x did not land under the Queued section in the secondmate backlog"
+
+  # Idempotent re-run: no error, no duplication, main untouched.
+  before=$(cat "$home/data/backlog.md")
+  FM_HOME="$home" "$ROOT/bin/fm-backlog-handoff.sh" design feat-x feat-y >/dev/null 2>&1 \
+    || fail "idempotent re-run failed"
+  [ "$(grep -cF -- '- [ ] feat-x - add feature x (repo: alpha)' "$subhome/data/backlog.md")" -eq 1 ] \
+    || fail "idempotent re-run duplicated feat-x in the secondmate backlog"
+  [ "$before" = "$(cat "$home/data/backlog.md")" ] || fail "idempotent re-run mutated the main backlog"
+
+  # A key matching neither backlog aborts atomically: nothing moves.
+  before=$(cat "$home/data/backlog.md")
+  if FM_HOME="$home" "$ROOT/bin/fm-backlog-handoff.sh" design bug-z no-such-key >/dev/null 2>&1; then
+    fail "handoff succeeded despite an unmatched key"
+  fi
+  [ "$before" = "$(cat "$home/data/backlog.md")" ] || fail "handoff with an unmatched key still mutated the main backlog"
+  grep -F 'bug-z' "$home/data/backlog.md" >/dev/null || fail "atomic abort lost the valid bug-z item from the main backlog"
+
+  # An unregistered secondmate is refused.
+  if FM_HOME="$home" "$ROOT/bin/fm-backlog-handoff.sh" ghost bug-z >/dev/null 2>&1; then
+    fail "handoff accepted an unregistered secondmate id"
+  fi
+  pass "fm-backlog-handoff moves in-scope items, is idempotent, and aborts safely"
+}
+
+test_backlog_handoff_creates_absent_section_and_refuses_non_secondmate_home() {
+  local home subhome subhome_abs projhome projhome_abs
+  home="$TMP_ROOT/handoff-safety-main"
+  subhome="$TMP_ROOT/handoff-safety-sub"
+  projhome="$TMP_ROOT/handoff-safety-proj"
+  mkdir -p "$home/data" "$home/state"
+
+  # A Done item handed into a secondmate backlog lacking a Done section gets one.
+  seed_secondmate_home_marker "$subhome" archive
+  subhome_abs=$(cd "$subhome" && pwd -P)
+  printf '## Queued\n- [ ] keep-me - stays (repo: alpha)\n' > "$subhome/data/backlog.md"
+  printf -- '- archive - archival (home: %s; scope: archival; projects: alpha; added 2026-06-22)\n' "$subhome_abs" > "$home/data/secondmates.md"
+  cat > "$home/data/backlog.md" <<'EOF'
+## Done
+- [x] shipped-task - shipped thing - local main (merged 2026-06-19)
+EOF
+  FM_HOME="$home" "$ROOT/bin/fm-backlog-handoff.sh" archive shipped-task >/dev/null \
+    || fail "handoff of a Done item failed"
+  grep -F '## Done' "$subhome/data/backlog.md" >/dev/null \
+    || fail "handoff did not create the missing Done section in the secondmate backlog"
+  awk '/^## Done/{d=1;next} /^## /{d=0} d && /shipped-task/{found=1} END{exit found?0:1}' "$subhome/data/backlog.md" \
+    || fail "Done item did not land under the created Done section"
+  grep -F 'keep-me' "$subhome/data/backlog.md" >/dev/null || fail "handoff clobbered the existing secondmate backlog content"
+
+  # A registered home that is not a seeded secondmate home (e.g. a project clone)
+  # is refused, and nothing is written into it.
+  make_git_project "$projhome"
+  projhome_abs=$(cd "$projhome" && pwd -P)
+  printf -- '- proj-sm - bogus (home: %s; scope: bogus; projects: alpha; added 2026-06-22)\n' "$projhome_abs" >> "$home/data/secondmates.md"
+  if FM_HOME="$home" "$ROOT/bin/fm-backlog-handoff.sh" proj-sm shipped-task >/dev/null 2>&1; then
+    fail "handoff wrote into a destination that is not a seeded secondmate home"
+  fi
+  [ ! -e "$projhome/data/backlog.md" ] || fail "handoff created a backlog inside a non-secondmate home"
+  pass "fm-backlog-handoff creates absent sections and refuses non-secondmate homes"
+}
+
 test_fm_home_parameterization
 test_lock_status_is_per_home
 test_home_seed_registry_scope_and_overlapping_projects
@@ -1838,3 +1971,6 @@ test_secondmate_force_teardown_refuses_unregistered_child_worktree
 test_secondmate_teardown_refuses_home_ancestor
 test_secondmate_teardown_refuses_home_descendants
 test_secondmate_idle_pane_is_not_stale
+test_secondmate_charter_brief_is_idle_by_default
+test_backlog_handoff_moves_in_scope_items
+test_backlog_handoff_creates_absent_section_and_refuses_non_secondmate_home

--- a/tests/fm-secondmate.test.sh
+++ b/tests/fm-secondmate.test.sh
@@ -1880,6 +1880,14 @@ EOF
   [ "$before" = "$(cat "$home/data/backlog.md")" ] || fail "handoff with an unmatched key still mutated the main backlog"
   grep -F 'bug-z' "$home/data/backlog.md" >/dev/null || fail "atomic abort lost the valid bug-z item from the main backlog"
 
+  before=$(cat "$home/data/backlog.md")
+  if FM_HOME="$home" "$ROOT/bin/fm-backlog-handoff.sh" design live-task >/dev/null 2>&1; then
+    fail "handoff accepted an in-flight backlog item"
+  fi
+  [ "$before" = "$(cat "$home/data/backlog.md")" ] || fail "handoff with an in-flight key mutated the main backlog"
+  grep -F 'live-task' "$home/data/backlog.md" >/dev/null || fail "in-flight refusal lost the live task"
+  grep -F 'live-task' "$subhome/data/backlog.md" >/dev/null && fail "in-flight refusal copied the live task"
+
   # An unregistered secondmate is refused.
   if FM_HOME="$home" "$ROOT/bin/fm-backlog-handoff.sh" ghost bug-z >/dev/null 2>&1; then
     fail "handoff accepted an unregistered secondmate id"
@@ -1888,10 +1896,13 @@ EOF
 }
 
 test_backlog_handoff_creates_absent_section_and_refuses_non_secondmate_home() {
-  local home subhome subhome_abs projhome projhome_abs
+  local home subhome subhome_abs projhome projhome_abs markerhome markerhome_abs symlinkhome symlinkhome_abs outside
   home="$TMP_ROOT/handoff-safety-main"
   subhome="$TMP_ROOT/handoff-safety-sub"
   projhome="$TMP_ROOT/handoff-safety-proj"
+  markerhome="$TMP_ROOT/handoff-safety-marker"
+  symlinkhome="$TMP_ROOT/handoff-safety-symlink"
+  outside="$TMP_ROOT/handoff-safety-outside"
   mkdir -p "$home/data" "$home/state"
 
   # A Done item handed into a secondmate backlog lacking a Done section gets one.
@@ -1920,7 +1931,37 @@ EOF
     fail "handoff wrote into a destination that is not a seeded secondmate home"
   fi
   [ ! -e "$projhome/data/backlog.md" ] || fail "handoff created a backlog inside a non-secondmate home"
-  pass "fm-backlog-handoff creates absent sections and refuses non-secondmate homes"
+
+  mkdir -p "$markerhome/data"
+  markerhome_abs=$(cd "$markerhome" && pwd -P)
+  printf 'marker-sm\n' > "$markerhome/.fm-secondmate-home"
+  printf -- '- marker-sm - bogus (home: %s; scope: bogus; projects: alpha; added 2026-06-22)\n' "$markerhome_abs" >> "$home/data/secondmates.md"
+  cat > "$home/data/backlog.md" <<'EOF'
+## Queued
+- [ ] marker-task - should not move (repo: alpha)
+EOF
+  if FM_HOME="$home" "$ROOT/bin/fm-backlog-handoff.sh" marker-sm marker-task >/dev/null 2>&1; then
+    fail "handoff accepted a marker-only directory as a secondmate home"
+  fi
+  [ ! -e "$markerhome/data/backlog.md" ] || fail "handoff wrote into a marker-only directory"
+  grep -F 'marker-task' "$home/data/backlog.md" >/dev/null || fail "marker-only refusal lost the main backlog item"
+
+  seed_secondmate_home_marker "$symlinkhome" symlink-sm
+  symlinkhome_abs=$(cd "$symlinkhome" && pwd -P)
+  mkdir -p "$outside"
+  rm -rf "$symlinkhome/data"
+  ln -s "$outside" "$symlinkhome/data"
+  printf -- '- symlink-sm - bogus (home: %s; scope: bogus; projects: alpha; added 2026-06-22)\n' "$symlinkhome_abs" >> "$home/data/secondmates.md"
+  cat > "$home/data/backlog.md" <<'EOF'
+## Queued
+- [ ] symlink-task - should not move (repo: alpha)
+EOF
+  if FM_HOME="$home" "$ROOT/bin/fm-backlog-handoff.sh" symlink-sm symlink-task >/dev/null 2>&1; then
+    fail "handoff accepted a secondmate home with data outside the home"
+  fi
+  [ ! -e "$outside/backlog.md" ] || fail "handoff wrote through a symlinked secondmate data directory"
+  grep -F 'symlink-task' "$home/data/backlog.md" >/dev/null || fail "symlink refusal lost the main backlog item"
+  pass "fm-backlog-handoff creates absent sections and refuses unsafe homes"
 }
 
 test_fm_home_parameterization


### PR DESCRIPTION
## Intent

Fix two secondmate spin-up behaviors in the firstmate repo, both from live captain observations.

(1) Idle-by-default startup: a freshly created secondmate with an empty queue was running its own bootstrap/recovery and then spawning a survey/audit crewmate to 'find work', which is expensive and unwanted. Rewrite the --secondmate charter brief template in bin/fm-brief.sh (operating model + definition of done) so a secondmate runs bootstrap/recovery ONLY to reconcile work that is already its own (in-flight crewmates, tracked backlog, durable watches) - that reconciliation MUST stay - and then goes idle and waits silently for the main firstmate to route it a task, never self-initiating surveys/audits/'find improvements' sweeps. The old phrase 'then supervise work that matches your scope' was what got over-interpreted, so it is deliberately removed. Mirror the contract in AGENTS.md sections 5 (recovery), 6 (secondmate description), and 11 (briefs).

(2) Backlog handoff on creation: when a secondmate is created for a domain, existing main-firstmate backlog items that fall under its scope should move into the new secondmate's own home backlog so it owns its queue from day one. Scope-matching is deliberately left as firstmate (agent) JUDGMENT - NOT automated keyword matching, per the task constraint. I chose to add a small mechanical helper bin/fm-backlog-handoff.sh <secondmate-id> <item-key>... because the safe move (resolve the correct home from data/secondmates.md, atomic + idempotent + section-preserving transfer between two data/backlog.md files without duplicating or losing a line) is genuinely fiddly and safety-sensitive to do by hand. The helper refuses any destination lacking the .fm-secondmate-home marker so a move can never land in a project (respecting prime directive #1), honors FM_HOME resolution, and only moves keys the agent already judged in-scope. Documented the handoff step in AGENTS.md sections 6, 7, and 11.

Tests: extended tests/fm-secondmate.test.sh with three tests (idle charter contract incl. a regression guard on the removed phrasing; handoff move/idempotency/atomic-abort/unregistered-id refusal; absent-section creation + non-secondmate-home refusal). All 4 test suites pass (104 ok) and shellcheck is clean. AGENTS.md sentences kept one-per-line and no em dashes per repo conventions; CLAUDE.md is a symlink to AGENTS.md. This repo is itself behind the no-mistakes gate.

## What Changed
- Updated secondmate startup and charter guidance so persistent secondmates reconcile only their own existing work, then remain idle until routed work arrives.
- Added `bin/fm-backlog-handoff.sh` to safely move judged in-scope queued backlog items from the main firstmate home into a seeded secondmate home, with idempotency and destination safeguards.
- Extended secondmate tests and README/AGENTS documentation to cover idle startup, handoff behavior, refusal cases, and the new creation workflow.

## Risk Assessment

✅ Low: Captain, the change is well-bounded and the current commit addresses the prior handoff safety issues without introducing a material correctness risk I could substantiate.

## Testing

Captain, I exercised the focused secondmate tests, the remaining shell behavior suites, and a manual CLI-level scenario that shows the idle charter text, backlog move, idempotent re-run, and unsafe-home refusal; all tests and checks passed, and the worktree ended clean.

<details>
<summary>Evidence: Manual CLI transcript</summary>

```text
$ FM_HOME=$DEMO/main-home FM_SECONDMATE_CHARTER="Own UX design work routed by main firstmate." FM_SECONDMATE_SCOPE="UX and product design backlog" bin/fm-brief.sh design --secondmate alpha
scaffolded: /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVRQS9P63EFKW86VVT9CKCW2/secondmate-idle-handoff-evidence/main-home/data/design/brief.md (secondmate charter)

$ grep -E "Act only|go idle|never spawn|supervise work" generated brief
Act only on tasks the main firstmate routes to you.
When you have no assigned or in-flight work after that reconciliation, go idle and wait silently for the main firstmate to route you a task.
An empty queue is a healthy resting state, not a cue to invent work: never spawn a survey, audit, or any self-directed "find work" task on your own initiative.
charter regression check: old over-broad phrase absent

$ FM_HOME=$DEMO/main-home bin/fm-backlog-handoff.sh design ux-copy ux-flow
handed off 2 item(s) to design: ux-copy ux-flow
  into /private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVRQS9P63EFKW86VVT9CKCW2/secondmate-idle-handoff-evidence/design-home/data/backlog.md

$ FM_HOME=$DEMO/main-home bin/fm-backlog-handoff.sh design ux-copy ux-flow  # idempotent re-run
nothing to move: ux-copy ux-flow already present in /private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVRQS9P63EFKW86VVT9CKCW2/secondmate-idle-handoff-evidence/design-home/data/backlog.md

$ FM_HOME=$DEMO/main-home bin/fm-backlog-handoff.sh unsafe-sm api-cleanup  # refuses unseeded destination
error: firstmate home /private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVRQS9P63EFKW86VVT9CKCW2/secondmate-idle-handoff-evidence/project-home is not a seeded secondmate home
unsafe-home exit code: 1
unsafe-home check: no project backlog was created
```
</details>
<details>
<summary>Evidence: Generated secondmate charter</summary>

```text
You are a secondmate: a persistent domain supervisor managed by the main firstmate. Work on your own; do not wait for a human.

# Charter
Own UX design work routed by main firstmate.

# Routing scope
UX and product design backlog

# Project clones
- alpha

# Operating model
You are in an isolated firstmate home. The local `AGENTS.md` is your job description, and your local `data/`, `state/`, `config/`, and `projects/` dirs are yours to operate.
The projects above are local clones for work you supervise; they are not an exclusive ownership claim.
Delegate project work to your own crewmates with the normal firstmate lifecycle: brief, spawn, status, watcher, steer, teardown, and recovery.
Do not invent a second delegation system.
You do not generate your own work.
Act only on tasks the main firstmate routes to you.
Never start a survey, audit, or "find improvements" sweep on your own initiative; that is not your job and it is unwanted.

# Escalation to main firstmate
Handle routine work yourself.
Escalate only true captain-relevant outcomes by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVRQS9P63EFKW86VVT9CKCW2/secondmate-idle-handoff-evidence/main-home/state/design.status'`
States: working, needs-decision, blocked, done, failed.
Use this only for material phase changes, a captain decision, a real blocker, a failure, or work ready for review.
Routine internal supervision, heartbeats, retries, and crewmate churn stay inside your own home and must not touch that status file.

# Definition of done
You are persistent by default. Do not exit just because your queue is empty.
On startup and restart, run normal firstmate bootstrap and recovery for your own home, but only to RECONCILE work that is already yours: in-flight crewmates, tracked backlog items, and durable watches recorded in this home.
When you have no assigned or in-flight work after that reconciliation, go idle and wait silently for the main firstmate to route you a task.
An empty queue is a healthy resting state, not a cue to invent work: never spawn a survey, audit, or any self-directed "find work" task on your own initiative.
If this charter cannot be carried out, append `blocked: {why}` or `failed: {why}` to the main status file and stop.
```
</details>
<details>
<summary>Evidence: Main backlog after handoff</summary>

```text
## In flight
- [ ] active-launch - ongoing launch fix (repo: alpha, since 2026-06-21)

## Queued
- [ ] api-cleanup - simplify webhook payload (repo: alpha)

## Done
- [x] shipped-theme - updated color tokens - PR merged 2026-06-20
```
</details>
<details>
<summary>Evidence: Secondmate backlog after handoff</summary>

```text
## In flight

## Queued

- [ ] ux-copy - tighten onboarding copy (repo: alpha)
- [ ] ux-flow - redesign invite flow (repo: alpha) blocked-by: active-launch - waits for launch fix
## Done
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-backlog-handoff.sh:122` - The helper will hand off any matching backlog line regardless of section, including `## In flight`; moving an active task line without also transferring its `state/*.meta`, status file, tmux window, and supervisor ownership can leave the main firstmate unable to track live work. Refuse In flight entries here unless the helper also performs the full state handoff.
- ⚠️ `bin/fm-backlog-handoff.sh:164` - The first destructive replacement updates the main backlog before the secondmate backlog replacement is known to have succeeded. If the second `mv` fails, the moved items have already been removed from the main backlog and may be lost; add rollback or another recoverable two-file update sequence.
- ⚠️ `bin/fm-backlog-handoff.sh:95` - The destination check only verifies `.fm-secondmate-home`, then writes through `$SUB_HOME/data`; it does not verify that the home is still a firstmate home or that `data/` resolves inside it. A stale registry entry, accidental marker, or symlinked `data` directory could make this write land outside the secondmate home. Reuse the existing home and operational-dir validation before writing.

🔧 Fix: Harden secondmate backlog handoff safety
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `tests/fm-secondmate.test.sh`
- `tests/fm-wake-queue.test.sh`
- `tests/fm-spawn-batch.test.sh`
- `tests/fm-afk-inject-e2e.test.sh`
- <code>Manual evidence scenario: generated a secondmate charter with `FM_HOME=... FM_SECONDMATE_CHARTER=... bin/fm-brief.sh design --secondmate alpha`.</code>
- <code>Manual evidence scenario: moved judged in-scope backlog items with `FM_HOME=... bin/fm-backlog-handoff.sh design ux-copy ux-flow`.</code>
- `Manual evidence scenario: re-ran the same handoff to verify idempotency.`
- <code>Manual evidence scenario: ran `FM_HOME=... bin/fm-backlog-handoff.sh unsafe-sm api-cleanup` and verified it refused an unseeded destination without creating a project backlog.</code>
- `git status --short`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
