### PR TITLE
feat: lease secondmate homes with treehouse

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -246,7 +246,8 @@ Every persistent secondmate has one line:
 ```
 
 The `scope:` field is used during intake; the `projects:` field is a non-exclusive clone list, not ownership.
-Use `bin/fm-home-seed.sh <id> <home|-> <project>...` after scaffolding the charter to provision the persistent home and registry entry; `-` asks `treehouse get` for the home.
+Use `bin/fm-home-seed.sh <id> <home|-> <project>...` after scaffolding the charter to provision the persistent home and registry entry; `-` durably leases a fresh firstmate worktree via `treehouse get --lease` under the secondmate id.
+A leased home survives with no live process and is never recycled by a later `treehouse get` or `prune`, so the secondmate's slot stays reserved across restarts until the lease is released; that release happens only on explicit retirement or seed rollback, never on a routine restart or recovery.
 The charter must be filled before seeding; direct seed without a preexisting brief requires `FM_SECONDMATE_CHARTER`.
 Seeding is transactional: if validation, cloning, no-mistakes initialization, or registry update fails, generated briefs, new homes, new project clones, and registry edits are rolled back.
 `bin/fm-home-seed.sh validate` refuses duplicate ids, duplicate homes, and nested or overlapping homes.
@@ -445,7 +446,8 @@ An empty queue is healthy and does not trigger teardown.
 Run `bin/fm-teardown.sh <id>` for `kind=secondmate` only when the captain or main firstmate explicitly decides to retire that persistent supervisor.
 The safety check is the secondmate's own home: teardown refuses while its `state/*.meta` contains in-flight work.
 When it is safe, teardown kills the direct tmux window, removes the `data/secondmates.md` route, clears the main home metadata, and removes the retired secondmate home.
-With `--force`, teardown is the explicit discard path: it kills child windows, discards child work and state inside the secondmate home, removes the route, and removes the retired secondmate home.
+Removing a leased home releases its durable treehouse lease (via `treehouse return`) so the pool slot is freed for reuse rather than left leased forever; a plain-clone home with no pool slot is simply removed.
+With `--force`, teardown is the explicit discard path: it kills child windows, discards child work and state inside the secondmate home, removes the route, releases the lease, and removes the retired secondmate home.
 
 ### Scout tasks (report instead of PR)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,7 @@ Silence means all good: say nothing and move on.
 Otherwise it prints one line per problem; handle each:
 
 - `MISSING: <tool> (install: <command>)` - list the missing tools to the captain with a one-line purpose each plus the printed install commands, wait for consent (one approval may cover the list), then run `bin/fm-bootstrap.sh install <approved tools...>`.
+  For `treehouse`, this also covers an installed version whose `treehouse get` lacks `--lease`; treat it as an upgrade request.
 - `NEEDS_GH_AUTH` - ask the captain to run `! gh auth login` (interactive; you cannot run it for them).
 - `CREW_HARNESS_OVERRIDE: <name>` - record and use the override silently; surface a harness fact only if it actually blocks work or the captain asks.
 - `FLEET_SYNC: <repo>: skipped: <reason>` - bootstrap continued; investigate only if the dirty, diverged, or offline clone blocks work.
@@ -447,6 +448,7 @@ Run `bin/fm-teardown.sh <id>` for `kind=secondmate` only when the captain or mai
 The safety check is the secondmate's own home: teardown refuses while its `state/*.meta` contains in-flight work.
 When it is safe, teardown kills the direct tmux window, removes the `data/secondmates.md` route, clears the main home metadata, and removes the retired secondmate home.
 Removing a leased home releases its durable treehouse lease (via `treehouse return`) so the pool slot is freed for reuse rather than left leased forever; a plain-clone home with no pool slot is simply removed.
+If `treehouse return` fails for a leased home, teardown stops with state intact rather than raw-removing the directory and hiding a held lease.
 With `--force`, teardown is the explicit discard path: it kills child windows, discards child work and state inside the secondmate home, removes the route, releases the lease, and removes the retired secondmate home.
 
 ### Scout tasks (report instead of PR)

--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ shellcheck bin/*.sh tests/*.sh            # lint the toolbelt and behavior tests
 for test_script in tests/*.test.sh; do "$test_script"; done   # behavior tests, matching CI
 tests/fm-wake-queue.test.sh               # durable wake queue, singleton behavior, sub-supervisor classifier, and /afk presence-gating tests
 tests/fm-afk-inject-e2e.test.sh           # private-socket end-to-end test of the afk injection path (partial-input deferral, swallowed-Enter retry)
+tests/fm-bootstrap.test.sh                # bootstrap dependency and feature-probe tests
 tests/fm-secondmate.test.sh               # persistent secondmate routing, seeding, idle charter, backlog handoff, spawn, recovery, teardown, and FM_HOME tests
 tests/fm-teardown.test.sh                 # fm-teardown.sh unpushed-work safety check: local-only fork-remote allow, truly-unpushed refuse, merged-to-main allow, no-mistakes regression, --force override
 [ "$(readlink CLAUDE.md)" = "AGENTS.md" ]

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ cd firstmate && claude
 ```
 
 That is the whole install.
-On first launch the first mate detects what its toolchain is missing (tmux, treehouse, no-mistakes, gh-axi, chrome-devtools-axi, lavish-axi), lists it with the exact install commands, and installs only after you say go.
+On first launch the first mate detects what its toolchain is missing or too old (tmux, node, gh, treehouse with durable lease support, no-mistakes, gh-axi, chrome-devtools-axi, lavish-axi), lists it with the exact install commands, and installs only after you say go.
 
 **Run it inside tmux for the best experience.**
 firstmate works from any terminal - outside tmux, crewmates land in a detached `firstmate` session you can attach to - but launching your harness from inside tmux puts every crewmate window in your own session, one per task, where you can watch the crew work in real time or type into any window to intervene.
@@ -122,6 +122,9 @@ firstmate works from any terminal - outside tmux, crewmates land in a detached `
 - **Two task shapes** - ship tasks change projects and ship by project mode (`no-mistakes`, `direct-PR`, or `local-only`); scout tasks investigate, plan, reproduce bugs, or audit, then leave a report at `data/<id>/report.md` and never push.
 - **Optional secondmates** - `data/secondmates.md` records persistent domain supervisors with natural-language scopes, project clone lists, and home paths.
   `fm-home-seed.sh` provisions the isolated home, clones the listed PR-based projects into it, initializes newly cloned `no-mistakes` projects, copies the charter to `data/charter.md`, and `fm-spawn.sh --secondmate` launches it through the same tmux and status-file path as any direct report.
+  When seeded with `-`, the home is a durable treehouse lease under the secondmate id, so it survives with no live process and is not recycled by later `treehouse get` or pruning.
+  Retirement or seed rollback returns the leased home; normal restart/recovery keeps it leased.
+  If returning the lease fails during teardown, firstmate leaves the route and home intact instead of hiding a still-held lease.
   Seeding is transactional: if validation, cloning, initialization, or registry update fails, generated briefs, new homes, new project clones, and registry edits are rolled back.
   `local-only` projects stay with the main first mate because they merge into the main local checkout instead of a remote-backed PR path.
   The same project may appear in multiple secondmate homes when their scopes differ, such as issue triage versus feature development.
@@ -142,13 +145,13 @@ The first mate drives these; you rarely need to, but they work by hand too.
 
 | Script                   | Description                                                                                                         |
 | ------------------------ | ------------------------------------------------------------------------------------------------------------------- |
-| `fm-bootstrap.sh`        | Detect missing toolchain pieces; refresh clones best-effort; install tools only after consent                       |
+| `fm-bootstrap.sh`        | Detect missing or outdated toolchain pieces; refresh clones best-effort; install tools only after consent           |
 | `fm-fleet-sync.sh`       | Fetch clones, clean-fast-forward their checked-out default branches, and safely prune branches whose remote is gone |
 | `fm-backlog-handoff.sh`  | Move already-judged in-scope queued backlog items from the main home into a seeded secondmate home                 |
 | `fm-brief.sh`            | Scaffold a ship brief, a report-only scout brief with `--scout`, or a secondmate charter with `--secondmate`      |
 | `fm-ensure-agents-md.sh` | Ensure project `AGENTS.md` is the real memory file and `CLAUDE.md` symlinks to it                                   |
 | `fm-guard.sh`            | Warn when tasks are in flight but queued wakes are pending or the watcher liveness beacon is stale or missing      |
-| `fm-home-seed.sh`        | Provision a secondmate home transactionally, clone projects, initialize gates, and maintain `data/secondmates.md`  |
+| `fm-home-seed.sh`        | Lease/provision a secondmate home transactionally, clone projects, initialize gates, and maintain `data/secondmates.md` |
 | `fm-spawn.sh`            | Spawn one task, several `id=repo` pairs, or a persistent secondmate with `--secondmate`                            |
 | `fm-project-mode.sh`     | Resolve a project's delivery mode and `+yolo` flag from `data/projects.md`                                          |
 | `fm-merge-local.sh`      | Fast-forward a `local-only` project's local default branch after approval                                           |
@@ -160,7 +163,7 @@ The first mate drives these; you rarely need to, but they work by hand too.
 | `fm-peek.sh`             | Print a bounded tail of a crewmate pane                                                                             |
 | `fm-pr-check.sh`         | Record a PR-ready task and arm the watcher's merge poll                                                             |
 | `fm-promote.sh`          | Promote a scout task in place so it becomes a protected ship task                                                   |
-| `fm-teardown.sh`         | Return the worktree or retire a secondmate home; protects ship work, requires scout reports, and checks child work |
+| `fm-teardown.sh`         | Return the worktree or retire/release a secondmate home; protects ship work, requires scout reports, and checks child work |
 | `fm-harness.sh`          | Detect the running harness; resolve the effective crewmate harness                                                  |
 | `fm-lock.sh`             | Per-home firstmate session lock                                                                                     |
 
@@ -171,6 +174,9 @@ Personal preferences for one captain's fleet live locally in `data/captain.md`; 
 Persistent secondmate routes live locally in `data/secondmates.md`.
 Each line records the secondmate id, charter summary, absolute home path, natural-language scope, project clone list, and added date; `fm-home-seed.sh validate` refuses duplicate ids, duplicate homes, and nested or overlapping homes.
 The main first mate routes by reading those scopes with judgment; the project list is provisioning data, not exclusive ownership.
+Use `fm-home-seed.sh <id> - <project>...` to lease a fresh firstmate worktree for the secondmate home.
+The lease is held under the secondmate id until explicit retirement or seed rollback returns it, so normal restarts do not free or recycle the home.
+Teardown of a leased home fails closed if `treehouse return` cannot release the lease; plain-clone homes with no treehouse pool slot are removed directly.
 Secondmate routes cover `no-mistakes` and `direct-PR` projects; `local-only` projects remain main-firstmate work.
 For `no-mistakes` projects, seeding initializes only projects newly cloned into a secondmate home and refuses to mutate a preexisting clone that is not already initialized.
 After creating a secondmate, move existing main-backlog items that you have judged in-scope with `fm-backlog-handoff.sh <secondmate-id> <item-key>...`; it is idempotent and refuses in-flight items or non-secondmate homes.

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -4,6 +4,8 @@
 #          Detect: prints one line per problem and exits 0. Silent = all good.
 #          Lines: "MISSING: <tool> (install: <command>)", "NEEDS_GH_AUTH",
 #                 "CREW_HARNESS_OVERRIDE: <name>", "FLEET_SYNC: <repo>: skipped: <reason>".
+#          treehouse is also MISSING when its installed version lacks
+#          "treehouse get --lease" support.
 #          Fleet sync fetches, fast-forwards, and prunes gone local branches;
 #          it is bounded by FM_FLEET_SYNC_BOOTSTRAP_TIMEOUT, default 20s.
 #          Set FM_FLEET_PRUNE=0 to skip branch pruning during that refresh.

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -67,6 +67,10 @@ install_cmd() {
 
 TOOLS="tmux node gh treehouse no-mistakes gh-axi chrome-devtools-axi lavish-axi"
 
+treehouse_supports_lease() {
+  treehouse get --help 2>&1 | grep -Eq '(^|[^[:alnum:]_-])--lease([^[:alnum:]_-]|$)'
+}
+
 if [ "${1:-}" = "install" ]; then
   shift
   [ $# -gt 0 ] || { echo "usage: fm-bootstrap.sh install <tool>..." >&2; exit 1; }
@@ -82,6 +86,9 @@ fi
 for t in $TOOLS; do
   command -v "$t" >/dev/null || echo "MISSING: $t (install: $(install_cmd "$t"))"
 done
+if command -v treehouse >/dev/null 2>&1 && ! treehouse_supports_lease; then
+  echo "MISSING: treehouse (install: $(install_cmd treehouse))"
+fi
 gh auth status >/dev/null 2>&1 || echo "NEEDS_GH_AUTH"
 crew=
 [ -f "$CONFIG/crew-harness" ] && crew=$(tr -d '[:space:]' < "$CONFIG/crew-harness" || true)

--- a/bin/fm-home-seed.sh
+++ b/bin/fm-home-seed.sh
@@ -16,7 +16,7 @@
 #       Seeding is transactional: on validation, clone, init, or registry failure,
 #       generated briefs, new homes, new project clones, and registry edits are
 #       rolled back. Treehouse-acquired homes are returned only when the rollback
-#       target is safe.
+#       target is safe; a failed return warns because the lease may still be held.
 #       Set FM_SECONDMATE_CHARTER='<charter>' to seed from inline charter text
 #       when no filled charter brief exists. Set FM_SECONDMATE_SCOPE='<scope>'
 #       to override the registry routing scope. Otherwise the registry summary

--- a/bin/fm-home-seed.sh
+++ b/bin/fm-home-seed.sh
@@ -635,7 +635,14 @@ seed_rollback_target() {
 seed_return_treehouse_home() {
   local home=$1 abs_home
   abs_home=$(seed_rollback_target "$home" "treehouse-acquired home") || return 0
-  ( cd "$FM_ROOT" && treehouse return --force "$abs_home" ) >/dev/null 2>&1 || true
+  if ! command -v treehouse >/dev/null 2>&1; then
+    echo "warning: failed to return treehouse-acquired home $abs_home during seed rollback; treehouse command not found" >&2
+    return 0
+  fi
+  ( cd "$FM_ROOT" && treehouse return --force "$abs_home" >/dev/null ) || {
+    echo "warning: failed to return treehouse-acquired home $abs_home during seed rollback; lease may still be held" >&2
+    return 0
+  }
 }
 
 seed_remove_created_home() {

--- a/bin/fm-home-seed.sh
+++ b/bin/fm-home-seed.sh
@@ -4,7 +4,10 @@
 # Usage:
 #   fm-home-seed.sh <id> <home|-> <project>...
 #       Provision <home> as an isolated firstmate home. If <home> is "-", acquire
-#       a fresh firstmate worktree via treehouse get. Projects are cloned
+#       a fresh firstmate worktree via "treehouse get --lease", which durably
+#       leases the worktree under the secondmate <id> so the home survives with
+#       no live process and is never recycled until the lease is released with
+#       "treehouse return". Projects are cloned
 #       from the active home into the secondmate home's projects/ directory.
 #       That project list is non-exclusive provisioning data. The charter brief
 #       is copied to data/charter.md, newly cloned no-mistakes projects are
@@ -457,26 +460,23 @@ seeded_origin_url() {
 }
 
 acquire_treehouse_home() {
-  local tmp runner home
-  tmp=$(mktemp "${TMPDIR:-/tmp}/fm-home-path.XXXXXX")
-  runner=$(mktemp "${TMPDIR:-/tmp}/fm-home-shell.XXXXXX")
-  cat > "$runner" <<'SH'
-#!/usr/bin/env bash
-printf '%s\n' "$PWD" > "$FM_HOME_SEED_PATH_FILE"
-exit 0
-SH
-  chmod +x "$runner"
-  (cd "$FM_ROOT" && FM_HOME_SEED_PATH_FILE="$tmp" SHELL="$runner" treehouse get >/dev/null)
-  home=$(cat "$tmp" 2>/dev/null || true)
-  rm -f "$tmp" "$runner"
-  [ -n "$home" ] || { echo "error: treehouse get did not report a firstmate home" >&2; return 1; }
+  local id=$1 home
+  # Durably lease a firstmate worktree from the pool. The lease persists with no
+  # live process and is skipped by later get/prune, so the home survives restarts
+  # until teardown or rollback returns it. treehouse prints only the worktree path
+  # to stdout (banners go to stderr), so command substitution captures the path.
+  home=$(cd "$FM_ROOT" && treehouse get --lease --lease-holder "$id") || {
+    echo "error: treehouse get --lease failed to lease a firstmate home" >&2
+    return 1
+  }
+  [ -n "$home" ] || { echo "error: treehouse get --lease did not report a firstmate home" >&2; return 1; }
   printf '%s\n' "$home"
 }
 
 ensure_home() {
-  local requested=$1 home
+  local id=$1 requested=$2 home
   if [ "$requested" = "-" ]; then
-    home=$(acquire_treehouse_home)
+    home=$(acquire_treehouse_home "$id")
     verify_firstmate_home "$home"
     return
   fi
@@ -829,7 +829,7 @@ seed_home() {
 
   if [ "$requested_home" = "-" ]; then
     SEED_HOME_ACQUIRED=1
-    home=$(acquire_treehouse_home)
+    home=$(acquire_treehouse_home "$id")
     SEED_HOME="$home"
     home=$(verify_firstmate_home "$home")
   else
@@ -838,7 +838,7 @@ seed_home() {
     validate_home_assignment "$id" "$requested_abs" || return 1
     SEED_HOME="$requested_abs"
     [ -e "$requested_abs" ] || SEED_HOME_CREATED=1
-    home=$(ensure_home "$requested_abs")
+    home=$(ensure_home "$id" "$requested_abs")
   fi
   SEED_HOME="$home"
   validate_registry_home_text "$home" || return 1

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -15,7 +15,9 @@
 # Secondmates (kind=secondmate in meta) are retired explicitly. Normal
 # teardown refuses while their home has in-flight crewmate meta files; --force
 # is the approved discard path that prevalidates child removal targets, discards
-# child work, kills child windows, and removes the retired home.
+# child work, kills child windows, and removes the retired home. Removing a
+# leased home releases its durable treehouse lease so the pool slot is freed,
+# never left leased forever.
 # Usage: fm-teardown.sh <task-id> [--force]
 #   --force skips the unpushed-work check for ordinary tasks and discards
 #   secondmate child work for kind=secondmate. Only use it when the captain has
@@ -271,6 +273,10 @@ remove_firstmate_home() {
   [ -e "$home" ] || return 0
   abs_home_path=$(validate_firstmate_home_for_removal "$home" "$label" "$expected_id") || return 1
   [ -n "$abs_home_path" ] || return 0
+  # Retiring a leased secondmate home: treehouse return releases the durable lease
+  # and frees the pool slot for reuse. treehouse resolves the pool from the home
+  # path, so run it from FM_ROOT. A plain-clone home (no pool slot) falls back to
+  # safe removal.
   if command -v treehouse >/dev/null 2>&1; then
     ( cd "$FM_ROOT" && treehouse return --force "$abs_home_path" ) || safe_rm_rf "$abs_home_path" "$label"
   else

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -112,6 +112,11 @@ EOF
   return 1
 }
 
+firstmate_home_has_treehouse_slot() {
+  local home=$1
+  worktree_registered_for_project "$FM_ROOT" "$home"
+}
+
 validate_removal_target() {
   local target=$1 label=$2 abs_target abs_home abs_root
   [ -n "$target" ] || return 0
@@ -273,15 +278,18 @@ remove_firstmate_home() {
   [ -e "$home" ] || return 0
   abs_home_path=$(validate_firstmate_home_for_removal "$home" "$label" "$expected_id") || return 1
   [ -n "$abs_home_path" ] || return 0
-  # Retiring a leased secondmate home: treehouse return releases the durable lease
-  # and frees the pool slot for reuse. treehouse resolves the pool from the home
-  # path, so run it from FM_ROOT. A plain-clone home (no pool slot) falls back to
-  # safe removal.
-  if command -v treehouse >/dev/null 2>&1; then
-    ( cd "$FM_ROOT" && treehouse return --force "$abs_home_path" ) || safe_rm_rf "$abs_home_path" "$label"
-  else
-    safe_rm_rf "$abs_home_path" "$label"
+  if firstmate_home_has_treehouse_slot "$abs_home_path"; then
+    command -v treehouse >/dev/null 2>&1 || {
+      echo "error: treehouse command not found; cannot return $label $abs_home_path" >&2
+      return 1
+    }
+    ( cd "$FM_ROOT" && treehouse return --force "$abs_home_path" ) || {
+      echo "error: treehouse return failed for $label $abs_home_path; lease may still be held" >&2
+      return 1
+    }
+    return 0
   fi
+  safe_rm_rf "$abs_home_path" "$label"
 }
 
 validate_firstmate_home_children_removal() {

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -17,7 +17,8 @@
 # is the approved discard path that prevalidates child removal targets, discards
 # child work, kills child windows, and removes the retired home. Removing a
 # leased home releases its durable treehouse lease so the pool slot is freed,
-# never left leased forever.
+# never left leased forever. If the treehouse return fails, teardown leaves the
+# leased home and state in place instead of hiding a still-held lease.
 # Usage: fm-teardown.sh <task-id> [--force]
 #   --force skips the unpushed-work check for ordinary tasks and discards
 #   secondmate child work for kind=secondmate. Only use it when the captain has

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_ROOT=
+
+fail() {
+  printf 'not ok - %s\n' "$1" >&2
+  exit 1
+}
+
+pass() {
+  printf 'ok - %s\n' "$1"
+}
+
+cleanup() {
+  if [ -n "${TMP_ROOT:-}" ]; then
+    rm -rf "$TMP_ROOT"
+  fi
+}
+
+trap cleanup EXIT
+
+TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/fm-bootstrap-tests.XXXXXX")
+
+make_fake_toolchain() {
+  local dir=$1 fakebin tool
+  fakebin="$dir/fakebin"
+  mkdir -p "$fakebin"
+  for tool in tmux node no-mistakes gh-axi chrome-devtools-axi lavish-axi; do
+    cat > "$fakebin/$tool" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+    chmod +x "$fakebin/$tool"
+  done
+  cat > "$fakebin/gh" <<'SH'
+#!/usr/bin/env bash
+if [ "${1:-}" = auth ] && [ "${2:-}" = status ]; then
+  exit 0
+fi
+exit 0
+SH
+  chmod +x "$fakebin/gh"
+  cat > "$fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+if [ "${1:-}" = get ] && [ "${2:-}" = --help ]; then
+  if [ "${FM_FAKE_TREEHOUSE_LEASE_HELP:-}" = 1 ]; then
+    printf '%s\n' 'Usage: treehouse get [--lease] [--lease-holder <holder>]'
+  else
+    printf '%s\n' 'Usage: treehouse get'
+  fi
+  exit 0
+fi
+exit 0
+SH
+  chmod +x "$fakebin/treehouse"
+  printf '%s\n' "$fakebin"
+}
+
+run_bootstrap() {
+  local home=$1 fakebin=$2
+  PATH="$fakebin:$PATH" FM_HOME="$home" "$ROOT/bin/fm-bootstrap.sh"
+}
+
+test_bootstrap_accepts_treehouse_lease_support() {
+  local case_dir fakebin out
+  case_dir="$TMP_ROOT/lease-supported"
+  mkdir -p "$case_dir/home"
+  fakebin=$(make_fake_toolchain "$case_dir")
+
+  out=$(FM_FAKE_TREEHOUSE_LEASE_HELP=1 run_bootstrap "$case_dir/home" "$fakebin")
+  [ -z "$out" ] || fail "bootstrap reported problems despite treehouse lease support: $out"
+  pass "bootstrap accepts treehouse get --lease support"
+}
+
+test_bootstrap_reports_treehouse_without_lease_support() {
+  local case_dir fakebin out
+  case_dir="$TMP_ROOT/lease-missing"
+  mkdir -p "$case_dir/home"
+  fakebin=$(make_fake_toolchain "$case_dir")
+
+  out=$(FM_FAKE_TREEHOUSE_LEASE_HELP=0 run_bootstrap "$case_dir/home" "$fakebin")
+  printf '%s\n' "$out" | grep -Fx 'MISSING: treehouse (install: curl -fsSL https://kunchenguid.github.io/treehouse/install.sh | sh)' >/dev/null \
+    || fail "bootstrap did not report treehouse upgrade instruction"
+  printf '%s\n' "$out" | grep -F 'NEEDS_GH_AUTH' >/dev/null && fail "bootstrap reported gh auth despite fake authenticated gh"
+  pass "bootstrap reports treehouse without get --lease support"
+}
+
+test_bootstrap_accepts_treehouse_lease_support
+test_bootstrap_reports_treehouse_without_lease_support

--- a/tests/fm-secondmate.test.sh
+++ b/tests/fm-secondmate.test.sh
@@ -95,14 +95,44 @@ SH
 #!/usr/bin/env bash
 set -u
 printf 'treehouse %s\n' "$*" >> "${FM_FAKE_TMUX_LOG:-/dev/null}"
-if [ "${1:-}" = get ] && [ -n "${FM_FAKE_TREEHOUSE_HOME:-}" ]; then
-  mkdir -p "$FM_FAKE_TREEHOUSE_HOME"
-  ( cd "$FM_FAKE_TREEHOUSE_HOME" && "$SHELL" )
-  exit $?
-fi
-if [ "${1:-}" = return ] && [ "${2:-}" = --force ] && [ -n "${3:-}" ]; then
-  rm -rf -- "$3"
-fi
+case "${1:-}" in
+  get)
+    # Durable lease: print only the worktree path to stdout (banners to stderr),
+    # and record the lease holder so tests can assert it is set and later cleared.
+    shift
+    holder=
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --lease) ;;
+        --lease-holder) shift; holder=${1:-} ;;
+        --lease-holder=*) holder=${1#--lease-holder=} ;;
+      esac
+      shift
+    done
+    if [ -n "${FM_FAKE_TREEHOUSE_HOME:-}" ]; then
+      mkdir -p "$FM_FAKE_TREEHOUSE_HOME"
+      [ -n "${FM_FAKE_TREEHOUSE_LEASE_FILE:-}" ] && printf '%s\n' "$holder" > "$FM_FAKE_TREEHOUSE_LEASE_FILE"
+      printf 'leased worktree for %s\n' "${holder:-unknown}" >&2
+      printf '%s\n' "$FM_FAKE_TREEHOUSE_HOME"
+    fi
+    exit 0
+    ;;
+  return)
+    # Release the lease and return/remove the worktree slot the home occupied.
+    shift
+    target=
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --force) ;;
+        *) target=$1 ;;
+      esac
+      shift
+    done
+    [ -n "${FM_FAKE_TREEHOUSE_LEASE_FILE:-}" ] && rm -f "$FM_FAKE_TREEHOUSE_LEASE_FILE"
+    [ -n "$target" ] && rm -rf -- "$target"
+    exit 0
+    ;;
+esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
@@ -355,7 +385,7 @@ EOF
 }
 
 test_home_seed_uses_treehouse_acquired_home() {
-  local home acquired acquired_abs fakebin log out
+  local home acquired acquired_abs fakebin log lease out
   home="$TMP_ROOT/dash-home"
   acquired="$TMP_ROOT/dash-acquired-home"
   mkdir -p "$home/projects" "$home/data" "$home/state"
@@ -365,19 +395,23 @@ test_home_seed_uses_treehouse_acquired_home() {
   git clone --quiet "$ROOT" "$acquired"
   fakebin=$(make_fake_tmux "$TMP_ROOT/dash-fake")
   log="$TMP_ROOT/dash-fake/tmux.log"
+  lease="$TMP_ROOT/dash-fake/lease"
 
   out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_FAKE_TREEHOUSE_HOME="$acquired" FM_FAKE_TMUX_LOG="$log" \
+    FM_FAKE_TREEHOUSE_LEASE_FILE="$lease" \
     FM_SECONDMATE_CHARTER='dash acquired scope' FM_SECONDMATE_SCOPE='dash acquired scope' \
     "$ROOT/bin/fm-home-seed.sh" dash - alpha) \
     || fail "seed failed for a treehouse-acquired home"
   acquired_abs=$(cd "$acquired" && pwd -P)
   printf '%s\n' "$out" | grep -F "home=$acquired_abs" >/dev/null || fail "seed did not report acquired home"
-  grep -F 'treehouse get' "$log" >/dev/null || fail "seed did not ask treehouse for a home"
+  grep -F 'treehouse get --lease --lease-holder dash' "$log" >/dev/null || fail "seed did not durably lease a home under the secondmate id"
+  [ -f "$lease" ] || fail "seed did not record a treehouse lease"
+  [ "$(cat "$lease")" = dash ] || fail "seed did not set the lease holder to the secondmate id"
   [ -f "$acquired/.fm-secondmate-home" ] || fail "seed did not mark acquired home"
   [ "$(cat "$acquired/.fm-secondmate-home")" = dash ] || fail "seed wrote wrong acquired-home marker"
   [ -d "$acquired/projects/alpha/.git" ] || fail "seed did not clone project into acquired home"
   grep -F "home: $acquired_abs" "$home/data/secondmates.md" >/dev/null || fail "registry did not record acquired home"
-  pass "home seeding accepts treehouse-acquired dash homes"
+  pass "home seeding durably leases treehouse-acquired dash homes under the secondmate id"
 }
 
 test_home_seed_returns_treehouse_acquired_home_on_assignment_failure() {
@@ -1224,11 +1258,12 @@ test_recovery_respawn_uses_persistent_home() {
 }
 
 test_secondmate_teardown_retires_empty_home() {
-  local home subhome fakebin
+  local home subhome subhome_abs fakebin log lease
   home="$TMP_ROOT/teardown-home"
   subhome="$TMP_ROOT/teardown-subhome"
   mkdir -p "$home/state" "$home/data" "$subhome/state"
   printf 'domain\n' > "$subhome/.fm-secondmate-home"
+  subhome_abs=$(cd "$subhome" && pwd -P)
   cat > "$home/state/domain.meta" <<EOF
 window=firstmate:fm-domain
 worktree=$subhome
@@ -1242,9 +1277,15 @@ projects=alpha
 EOF
   printf '%s\n' '- domain - design domain (home: '"$subhome"'; scope: design domain; projects: alpha; added 2026-06-22)' > "$home/data/secondmates.md"
   fakebin=$(make_fake_tmux "$TMP_ROOT/teardown-fake")
-  PATH="$fakebin:$PATH" FM_HOME="$home" FM_FAKE_TMUX_LOG="$TMP_ROOT/teardown-fake/tmux.log" FM_FAKE_TMUX_CAPTURE="$TMP_ROOT/teardown-fake/pane.txt" \
+  log="$TMP_ROOT/teardown-fake/tmux.log"
+  lease="$TMP_ROOT/teardown-fake/lease"
+  printf 'domain\n' > "$lease"
+  PATH="$fakebin:$PATH" FM_HOME="$home" FM_FAKE_TMUX_LOG="$log" FM_FAKE_TMUX_CAPTURE="$TMP_ROOT/teardown-fake/pane.txt" \
+    FM_FAKE_TREEHOUSE_LEASE_FILE="$lease" \
     "$ROOT/bin/fm-teardown.sh" domain >/dev/null 2>/dev/null \
     || fail "teardown failed for empty secondmate home"
+  grep -F "treehouse return --force $subhome_abs" "$log" >/dev/null || fail "teardown did not release the secondmate home lease via treehouse return"
+  [ ! -e "$lease" ] || fail "teardown left the secondmate home lease held after retirement"
   [ ! -d "$subhome" ] || fail "teardown did not remove the retired secondmate home"
   [ ! -e "$home/state/domain.meta" ] || fail "teardown did not clear parent meta"
   grep -F -- '- domain ' "$home/data/secondmates.md" >/dev/null && fail "teardown did not remove secondmate registry route"

--- a/tests/fm-secondmate.test.sh
+++ b/tests/fm-secondmate.test.sh
@@ -58,6 +58,20 @@ mark_firstmate_home() {
   printf '# Firstmate\n' > "$home/AGENTS.md"
 }
 
+make_firstmate_git_root() {
+  local home=$1
+  mkdir -p "$home/bin"
+  printf '# Firstmate\n' > "$home/AGENTS.md"
+  cat > "$home/bin/fm-guard.sh" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  chmod +x "$home/bin/fm-guard.sh"
+  git -C "$home" init -q
+  git -C "$home" add AGENTS.md bin/fm-guard.sh
+  git -C "$home" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm initial
+}
+
 make_fake_tmux() {
   local dir=$1 fakebin log capture
   fakebin="$dir/fakebin"
@@ -118,7 +132,6 @@ case "${1:-}" in
     exit 0
     ;;
   return)
-    # Release the lease and return/remove the worktree slot the home occupied.
     shift
     target=
     while [ $# -gt 0 ]; do
@@ -128,6 +141,7 @@ case "${1:-}" in
       esac
       shift
     done
+    [ -z "${FM_FAKE_TREEHOUSE_RETURN_FAIL:-}" ] || exit 17
     [ -n "${FM_FAKE_TREEHOUSE_LEASE_FILE:-}" ] && rm -f "$FM_FAKE_TREEHOUSE_LEASE_FILE"
     [ -n "$target" ] && rm -rf -- "$target"
     exit 0
@@ -441,6 +455,37 @@ test_home_seed_returns_treehouse_acquired_home_on_assignment_failure() {
     fail "failed acquired seed left a registry route"
   fi
   pass "home seeding returns rejected acquired homes through treehouse"
+}
+
+test_home_seed_warns_when_acquired_home_return_fails() {
+  local home acquired acquired_abs fakebin log err lease
+  home="$TMP_ROOT/dash-return-fail-home"
+  acquired="$TMP_ROOT/dash-return-fail-acquired-home"
+  err="$TMP_ROOT/dash-return-fail.err"
+  mkdir -p "$home/projects" "$home/data" "$home/state"
+  make_git_project "$home/projects/alpha"
+  add_file_origin "$home/projects/alpha" "$TMP_ROOT/remotes/dash-return-fail-alpha.git"
+  printf '%s\n' '- alpha [direct-PR] - alpha project (added 2026-06-22)' > "$home/data/projects.md"
+  git clone --quiet "$ROOT" "$acquired"
+  acquired_abs=$(cd "$acquired" && pwd -P)
+  printf 'other\n' > "$acquired/.fm-secondmate-home"
+  fakebin=$(make_fake_tmux "$TMP_ROOT/dash-return-fail-fake")
+  log="$TMP_ROOT/dash-return-fail-fake/tmux.log"
+  lease="$TMP_ROOT/dash-return-fail-fake/lease"
+
+  if PATH="$fakebin:$PATH" FM_HOME="$home" FM_FAKE_TREEHOUSE_HOME="$acquired" FM_FAKE_TMUX_LOG="$log" \
+    FM_FAKE_TREEHOUSE_LEASE_FILE="$lease" FM_FAKE_TREEHOUSE_RETURN_FAIL=1 \
+    FM_SECONDMATE_CHARTER='dash acquired scope' FM_SECONDMATE_SCOPE='dash acquired scope' \
+    "$ROOT/bin/fm-home-seed.sh" dash - alpha >/dev/null 2>"$err"; then
+    fail "seed reused an acquired home after return failure setup"
+  fi
+  grep -F 'already marked for other' "$err" >/dev/null || fail "seed did not report original acquired-home rejection"
+  grep -F "warning: failed to return treehouse-acquired home $acquired_abs during seed rollback" "$err" >/dev/null \
+    || fail "seed rollback did not warn when treehouse return failed"
+  [ -f "$lease" ] || fail "failed rollback return did not preserve lease evidence"
+  grep -F "treehouse return --force $acquired_abs" "$log" >/dev/null \
+    || fail "failed rollback did not attempt to return the acquired home"
+  pass "home seed rollback warns when treehouse-acquired return fails"
 }
 
 test_home_seed_does_not_return_unsafe_acquired_home() {
@@ -1258,9 +1303,12 @@ test_recovery_respawn_uses_persistent_home() {
 }
 
 test_secondmate_teardown_retires_empty_home() {
-  local home subhome subhome_abs fakebin log lease
+  local home subhome subhome_abs fakebin log lease fmroot
   home="$TMP_ROOT/teardown-home"
   subhome="$TMP_ROOT/teardown-subhome"
+  fmroot="$TMP_ROOT/teardown-fmroot"
+  make_firstmate_git_root "$fmroot"
+  git -C "$fmroot" worktree add --quiet --detach "$subhome" HEAD
   mkdir -p "$home/state" "$home/data" "$subhome/state"
   printf 'domain\n' > "$subhome/.fm-secondmate-home"
   subhome_abs=$(cd "$subhome" && pwd -P)
@@ -1280,7 +1328,7 @@ EOF
   log="$TMP_ROOT/teardown-fake/tmux.log"
   lease="$TMP_ROOT/teardown-fake/lease"
   printf 'domain\n' > "$lease"
-  PATH="$fakebin:$PATH" FM_HOME="$home" FM_FAKE_TMUX_LOG="$log" FM_FAKE_TMUX_CAPTURE="$TMP_ROOT/teardown-fake/pane.txt" \
+  PATH="$fakebin:$PATH" FM_ROOT_OVERRIDE="$fmroot" FM_HOME="$home" FM_FAKE_TMUX_LOG="$log" FM_FAKE_TMUX_CAPTURE="$TMP_ROOT/teardown-fake/pane.txt" \
     FM_FAKE_TREEHOUSE_LEASE_FILE="$lease" \
     "$ROOT/bin/fm-teardown.sh" domain >/dev/null 2>/dev/null \
     || fail "teardown failed for empty secondmate home"
@@ -1290,6 +1338,82 @@ EOF
   [ ! -e "$home/state/domain.meta" ] || fail "teardown did not clear parent meta"
   grep -F -- '- domain ' "$home/data/secondmates.md" >/dev/null && fail "teardown did not remove secondmate registry route"
   pass "secondmate teardown retires empty homes and releases routing"
+}
+
+test_secondmate_teardown_refuses_failed_leased_home_return() {
+  local home subhome subhome_abs fakebin log fmroot err rc
+  home="$TMP_ROOT/teardown-return-fail-home"
+  subhome="$TMP_ROOT/teardown-return-fail-subhome"
+  fmroot="$TMP_ROOT/teardown-return-fail-fmroot"
+  err="$TMP_ROOT/teardown-return-fail.err"
+  make_firstmate_git_root "$fmroot"
+  git -C "$fmroot" worktree add --quiet --detach "$subhome" HEAD
+  mkdir -p "$home/state" "$home/data" "$subhome/state"
+  printf 'domain\n' > "$subhome/.fm-secondmate-home"
+  subhome_abs=$(cd "$subhome" && pwd -P)
+  cat > "$home/state/domain.meta" <<EOF
+window=firstmate:fm-domain
+worktree=$subhome
+project=$subhome
+harness=echo
+kind=secondmate
+mode=secondmate
+yolo=off
+home=$subhome
+projects=alpha
+EOF
+  printf '%s\n' '- domain - design domain (home: '"$subhome"'; scope: design domain; projects: alpha; added 2026-06-22)' > "$home/data/secondmates.md"
+  fakebin=$(make_fake_tmux "$TMP_ROOT/teardown-return-fail-fake")
+  log="$TMP_ROOT/teardown-return-fail-fake/tmux.log"
+
+  set +e
+  PATH="$fakebin:$PATH" FM_ROOT_OVERRIDE="$fmroot" FM_HOME="$home" FM_FAKE_TMUX_LOG="$log" FM_FAKE_TMUX_CAPTURE="$TMP_ROOT/teardown-return-fail-fake/pane.txt" \
+    FM_FAKE_TREEHOUSE_RETURN_FAIL=1 \
+    "$ROOT/bin/fm-teardown.sh" domain >/dev/null 2>"$err"
+  rc=$?
+  set -e
+
+  [ "$rc" -ne 0 ] || fail "teardown succeeded despite failed treehouse return"
+  grep -F "treehouse return --force $subhome_abs" "$log" >/dev/null || fail "teardown did not try to return the leased home"
+  grep -F 'treehouse return failed for secondmate home' "$err" >/dev/null || fail "teardown did not report failed leased home return"
+  [ -d "$subhome" ] || fail "teardown removed a leased home after return failed"
+  [ -e "$home/state/domain.meta" ] || fail "teardown cleared meta after leased home return failed"
+  grep -F -- '- domain ' "$home/data/secondmates.md" >/dev/null || fail "teardown removed registry route after leased home return failed"
+  pass "secondmate teardown refuses to hide failed leased-home return"
+}
+
+test_secondmate_teardown_removes_plain_clone_home_without_treehouse_return() {
+  local home subhome subhome_abs fakebin log
+  home="$TMP_ROOT/plain-clone-teardown-home"
+  subhome="$TMP_ROOT/plain-clone-teardown-subhome"
+  mkdir -p "$home/state" "$home/data" "$subhome/state"
+  mark_firstmate_home "$subhome"
+  printf 'domain\n' > "$subhome/.fm-secondmate-home"
+  subhome_abs=$(cd "$subhome" && pwd -P)
+  cat > "$home/state/domain.meta" <<EOF
+window=firstmate:fm-domain
+worktree=$subhome
+project=$subhome
+harness=echo
+kind=secondmate
+mode=secondmate
+yolo=off
+home=$subhome
+projects=alpha
+EOF
+  printf '%s\n' '- domain - design domain (home: '"$subhome"'; scope: design domain; projects: alpha; added 2026-06-22)' > "$home/data/secondmates.md"
+  fakebin=$(make_fake_tmux "$TMP_ROOT/plain-clone-teardown-fake")
+  log="$TMP_ROOT/plain-clone-teardown-fake/tmux.log"
+
+  PATH="$fakebin:$PATH" FM_HOME="$home" FM_FAKE_TMUX_LOG="$log" FM_FAKE_TMUX_CAPTURE="$TMP_ROOT/plain-clone-teardown-fake/pane.txt" \
+    FM_FAKE_TREEHOUSE_RETURN_FAIL=1 \
+    "$ROOT/bin/fm-teardown.sh" domain >/dev/null 2>/dev/null \
+    || fail "teardown failed for plain-clone secondmate home"
+  grep -F "treehouse return --force $subhome_abs" "$log" >/dev/null && fail "teardown tried to return a plain-clone home through treehouse"
+  [ ! -d "$subhome" ] || fail "teardown did not remove the plain-clone secondmate home"
+  [ ! -e "$home/state/domain.meta" ] || fail "teardown did not clear parent meta for plain-clone home"
+  grep -F -- '- domain ' "$home/data/secondmates.md" >/dev/null && fail "teardown did not remove plain-clone registry route"
+  pass "secondmate teardown raw-removes plain-clone homes"
 }
 
 test_secondmate_force_teardown_discards_child_work() {
@@ -2014,6 +2138,7 @@ test_home_seed_validate_rejects_duplicate_ids
 test_home_seed_validate_rejects_nested_homes
 test_home_seed_uses_treehouse_acquired_home
 test_home_seed_returns_treehouse_acquired_home_on_assignment_failure
+test_home_seed_warns_when_acquired_home_return_fails
 test_home_seed_does_not_return_unsafe_acquired_home
 test_home_seed_rolls_back_failed_clone
 test_home_seed_refuses_missing_filled_charter
@@ -2040,6 +2165,8 @@ test_secondmate_spawn_refuses_operational_dirs_outside_subhome
 test_fm_send_resolves_bare_firstmate_window_from_home_meta
 test_recovery_respawn_uses_persistent_home
 test_secondmate_teardown_retires_empty_home
+test_secondmate_teardown_refuses_failed_leased_home_return
+test_secondmate_teardown_removes_plain_clone_home_without_treehouse_return
 test_secondmate_force_teardown_discards_child_work
 test_secondmate_force_teardown_allows_operational_dir_symlinks_inside_home
 test_secondmate_force_teardown_refuses_operational_dir_symlink_outside_home


### PR DESCRIPTION
## Intent

Adopt treehouse v1.8.0's durable worktree lease in firstmate's secondmate-home lifecycle, replacing the fragile process-based hold plus path-capture hack.

Background: a secondmate's home is a treehouse worktree of the firstmate repo acquired at seeding. The old acquire_treehouse_home() ran 'treehouse get' with a throwaway custom SHELL runner ONLY to capture the worktree path from the subshell's PWD, then let the subshell exit - which returned the worktree to the pool, so the home only persisted because a live process happened to keep it in use. treehouse v1.8.0 adds a real durable lease.

Changes made:
1. bin/fm-home-seed.sh acquire_treehouse_home(): replaced the mktemp SHELL-runner path-capture with 'treehouse get --lease --lease-holder <id>', reading the path from stdout (treehouse prints only the path to stdout, banners to stderr, so command substitution captures a clean path). Threaded the secondmate id from seed_home through ensure_home into acquire so the lease holder label is the secondmate id.
2. Lease release on retirement: seed rollback (seed_return_treehouse_home) and secondmate teardown (remove_firstmate_home in fm-teardown.sh) already call 'treehouse return --force', which releases the lease in v1.8.0. Confirmed both and added clarifying comments documenting that this now frees the leased pool slot. Deliberately did NOT release the lease on a normal restart/recovery - the home must stay leased across restarts, which is the whole point; release happens only on explicit retirement or rollback.
3. AGENTS.md: updated section 6 (seeding) and section 7 (secondmate teardown) prose to describe the lease semantics, each full sentence on its own line per repo convention.
4. tests/fm-secondmate.test.sh: updated the treehouse mock to support 'get --lease [--lease-holder]' (prints path to stdout, records holder in an optional lease file) and 'return <path>' (clears the lease file, removes the slot). Added assertions that the lease holder is set to the secondmate id on acquire and that retirement releases the lease via treehouse return. Kept all existing security/path-escape and --force child-safety guards green.

Deliberate scope choice: existing process-held homes (e.g. live secondmate homemux-h7, acquired before v1.8.0) are intentionally NOT retroactively leased - only new provisioning uses the lease; they keep the old hold until reprovisioned. This is noted for the PR.

Validation done locally: all 5 test scripts pass (110 assertions) and shellcheck bin/*.sh tests/*.sh is clean, matching CI.

## What Changed
- Adopted durable `treehouse get --lease --lease-holder` provisioning for secondmate homes, with retirement and rollback paths releasing leased slots through `treehouse return --force`.
- Added bootstrap detection for the required treehouse lease capability and hardened teardown/rollback behavior so lease release failures are surfaced instead of silently removing homes.
- Updated secondmate lifecycle docs and expanded shell tests around lease acquisition, holder tracking, retirement cleanup, and bootstrap compatibility.

## Risk Assessment

✅ Low: Captain, the changes are narrowly scoped to the secondmate lease lifecycle, add bootstrap coverage for the required treehouse feature, and preserve failure paths without introducing a material merge risk.

## Testing

Inspected the lease-related diff and docs, ran all six shell behavior test scripts, then captured a focused end-to-end CLI transcript proving seed acquires a durable secondmate lease and teardown releases it. All checks passed, the worktree stayed clean, and I did not run linters or static analysis per the prompt.

<details>
<summary>Evidence: Focused CLI lease seed and teardown transcript</summary>

```text
E2E: secondmate home durable treehouse lease
workspace=/Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KVRW18PP6HKJ5779PP3318PE
tmp=/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T//fm-lease-e2e.6arc6r

$ FM_HOME=<main-home> fm-home-seed.sh dash - alpha
leased worktree for dash
home=/private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/fm-lease-e2e.6arc6r/leased-home
lease-holder-after-seed=dash
seeded-marker=dash
seeded-project-origin=file:///var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T//fm-lease-e2e.6arc6r/remotes/alpha.git
registry-route=- dash - dash acquired scope (home: /private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/fm-lease-e2e.6arc6r/leased-home; scope: dash acquired scope; projects: alpha; added 2026-06-22)
treehouse-log-after-seed:
treehouse get --lease --lease-holder dash

$ FM_HOME=<main-home> fm-teardown.sh dash
teardown dash complete (window firstmate:fm-dash, worktree /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T//fm-lease-e2e.6arc6r/leased-home)
🌱 Backlog: dash just finished. Update data/backlog.md - move dash to Done (keep Done to the 10 most recent), then re-scan Queued for items now unblocked (a "blocked-by: dash" may have just cleared) or now time-due, and dispatch what's ready.
treehouse-log-after-teardown:
treehouse get --lease --lease-holder dash
treehouse return --force /private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/fm-lease-e2e.6arc6r/leased-home
lease-file-after-teardown=absent
home-after-teardown=absent
registry-route-after-teardown=absent
meta-after-teardown=absent
```
</details>
<details>
<summary>Evidence: Secondmate lifecycle behavior test log</summary>

```text
ok - FM_HOME parameterizes data and state paths
ok - fm-lock status is scoped per home
ok - secondmates registry records scopes and allows overlapping project clone lists
ok - home seeding records routing scope from filled charter briefs
ok - home seed validation rejects duplicate home routes
ok - home seed validation rejects duplicate id routes
ok - home seed validation rejects nested home routes
leased worktree for dash
ok - home seeding durably leases treehouse-acquired dash homes under the secondmate id
ok - home seeding returns rejected acquired homes through treehouse
ok - home seed rollback warns when treehouse-acquired return fails
ok - home seeding leaves unsafe acquired active homes untouched
ok - home seeding rolls back failed clone attempts without residue
ok - home seeding refuses direct seed without filled charter text
ok - home seeding refuses unfilled placeholder charters
ok - home seeding refuses empty normalized charter fields
ok - home seeding refuses local-only projects
ok - home seeding refuses registry delimiter home paths
ok - home seeding refuses active home and repo root
ok - home seeding refuses homes marked for another id
ok - home seeding refuses homes registered to another id
ok - home seeding refuses same-id reassignment to a different home
ok - home seeding refuses registered home overlaps
ok - remote-backed subhome seeding requires a source origin
ok - remote-backed subhome seeding validates existing destination origins
ok - home seeding resolves relative source origins against the source project
ok - home seeding skips initialized existing no-mistakes clones
ok - home seeding refuses uninitialized existing no-mistakes clones
ok - home seeding refuses project destinations outside the subhome
ok - home seeding refuses operational directories outside the subhome
ok - home seeding refuses symlinked leaf files
ok - kind=secondmate spawn launches in the home and records routing meta
ok - secondmate spawn validates homes before launch
ok - secondmate spawn refuses operational directories outside the subhome
ok - fm-send resolves bare firstmate windows through this home
ok - restart recovery can respawn a secondmate from durable registry and charter
ok - secondmate teardown retires empty homes and releases routing
ok - secondmate teardown refuses to hide failed leased-home return
ok - secondmate teardown raw-removes plain-clone homes
ok - secondmate force teardown discards child work
ok - force teardown allows operational directory symlinks inside the subhome
ok - force teardown refuses operational directory symlinks outside the subhome
ok - secondmate teardown requires seeded home marker
ok - secondmate teardown refuses homes containing registered nested homes
ok - secondmate teardown refuses nested homes from the child registry
ok - force teardown validates subhome before child cleanup
ok - force teardown refuses child worktrees inside the active home
ok - force teardown refuses child worktrees inside the firstmate repo
ok - force teardown refuses unregistered child worktree paths
ok - secondmate teardown refuses ancestor homes
ok - secondmate teardown refuses descendant homes
ok - idle kind=secondmate pane is healthy and not stale
ok - secondmate charter brief is idle by default and does not self-initiate work
ok - fm-backlog-handoff moves in-scope items, is idempotent, and aborts safely
ok - fm-backlog-handoff creates absent sections and refuses unsafe homes
```
</details>
<details>
<summary>Evidence: Bootstrap feature-probe behavior test log</summary>

```text
ok - bootstrap accepts treehouse get --lease support
ok - bootstrap reports treehouse without get --lease support
```
</details>
<details>
<summary>Evidence: Teardown regression behavior test log</summary>

```text
ok - local-only worktree with HEAD on a fork remote is torn down (fix holds)
ok - local-only worktree with truly unpushed work is refused (safety preserved)
ok - local-only worktree with work merged into local main is torn down (no regression)
ok - no-mistakes worktree with HEAD on origin is torn down (no regression)
ok - no-mistakes worktree with truly unpushed work is refused (no regression)
ok - local-only worktree with unpushed work is torn down under --force (escape hatch)
```
</details>
- Evidence: Remaining shell behavior test logs (local file: <code>/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVRW18PP6HKJ5779PP3318PE</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-home-seed.sh:468` - `acquire_treehouse_home` now requires the v1.8.0 `treehouse get --lease` flag, but bootstrap still only checks that some `treehouse` binary exists. A pre-1.8 install will pass startup and fail later during secondmate seeding, so add a bootstrap feature/version probe for `get --lease` and surface the normal install/upgrade instruction there.
- ⚠️ `bin/fm-teardown.sh:281` - On secondmate retirement, falling back to `safe_rm_rf` after `treehouse return` fails can remove a leased worktree directory while leaving the durable lease recorded in treehouse state, then the script clears meta and registry as if release succeeded. For homes registered as firstmate treehouse worktrees, teardown should fail unless `treehouse return --force` succeeds; reserve raw removal for plain-clone homes with no treehouse pool slot.
- ⚠️ `bin/fm-home-seed.sh:638` - Rollback suppresses `treehouse return` failures for newly leased homes, so a failed seed can leave the durable lease held with no visible cleanup warning. Since the registry is never written in that path, make release failure visible at least, and preferably preserve enough evidence for manual cleanup instead of silently swallowing it.

🔧 Fix: Captain, harden treehouse lease lifecycle
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git status --short --branch`
- `git diff --stat ef1107d41c7ef710bdb2e27aa64bebdf94f2e027..bf195ee8ab8dbd8fe3e7e8e553c0776ab50e7062`
- `git diff --unified=80 ef1107d41c7ef710bdb2e27aa64bebdf94f2e027..bf195ee8ab8dbd8fe3e7e8e553c0776ab50e7062 -- bin/fm-home-seed.sh`
- `git diff --unified=80 ef1107d41c7ef710bdb2e27aa64bebdf94f2e027..bf195ee8ab8dbd8fe3e7e8e553c0776ab50e7062 -- bin/fm-teardown.sh`
- `git diff --unified=60 ef1107d41c7ef710bdb2e27aa64bebdf94f2e027..bf195ee8ab8dbd8fe3e7e8e553c0776ab50e7062 -- tests/fm-secondmate.test.sh`
- `git diff --unified=60 ef1107d41c7ef710bdb2e27aa64bebdf94f2e027..bf195ee8ab8dbd8fe3e7e8e553c0776ab50e7062 -- tests/fm-bootstrap.test.sh README.md AGENTS.md`
- `tests/fm-bootstrap.test.sh > /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVRW18PP6HKJ5779PP3318PE/fm-bootstrap.test.log 2>&1`
- `tests/fm-secondmate.test.sh > /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVRW18PP6HKJ5779PP3318PE/fm-secondmate.test.log 2>&1`
- `tests/fm-teardown.test.sh > /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVRW18PP6HKJ5779PP3318PE/fm-teardown.test.log 2>&1`
- `tests/fm-spawn-batch.test.sh > /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVRW18PP6HKJ5779PP3318PE/fm-spawn-batch.test.log 2>&1`
- `tests/fm-wake-queue.test.sh > /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVRW18PP6HKJ5779PP3318PE/fm-wake-queue.test.log 2>&1`
- `tests/fm-afk-inject-e2e.test.sh > /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVRW18PP6HKJ5779PP3318PE/fm-afk-inject-e2e.test.log 2>&1`
- <code>Focused manual CLI check captured in `lease-e2e.transcript`: seeded a secondmate with `home=-`, verified the lease holder, marker, project clone, and registry route, then retired it and verified `treehouse return --force`, lease removal, home removal, registry cleanup, and meta cleanup.</code>
- `git status --short`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
