### PR TITLE
feat: add opencode server backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,15 @@ jobs:
       - uses: actions/checkout@v6
       - run: shellcheck bin/*.sh
 
+  tests:
+    name: Backend contract tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: bash -n bin/*.sh test/*.test.sh
+      - run: node --check bin/fm-codex-app
+      - run: for t in test/*.test.sh; do "$t"; done
+
   invariants:
     name: Repo invariants
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,6 @@ data/
 .lavish/
 .DS_Store
 .env
+config/backend
+config/backend.env
 config/crew-harness

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ Hard rules, in priority order:
    You must not edit, commit to, or run state-changing commands in anything under `projects/` or in any worktree.
    You read projects to understand them; crewmates change them.
    Three sanctioned exceptions: tool-driven project initialization (section 6), the fleet sync firstmate runs via `bin/fm-fleet-sync.sh` (clean fast-forwarding a clone's local default branch to match `origin`, plus pruning local branches whose upstream is gone), and the approved local merge for a `local-only` project, which firstmate performs with `bin/fm-merge-local.sh` once the captain approves (section 7).
-   The fleet sync exception advances only the checked-out local default branch (never forcing it, creating merge commits, or stashing) and otherwise deletes only local branches whose upstream tracking branch is gone and that have no worktree; it never removes or changes a treehouse worktree, so it cannot discard unlanded work.
+   The fleet sync exception advances only the checked-out local default branch (never forcing it, creating merge commits, or stashing) and otherwise deletes only local branches whose upstream tracking branch is gone and that have no worktree; it never removes or changes a backend-created worktree, so it cannot discard unlanded work.
    Project `AGENTS.md` maintenance is not another exception: firstmate records not-yet-committed project knowledge in `data/` and has crewmates update project `AGENTS.md` through normal worktree delivery (section 6).
 2. **Never merge a PR without the captain's explicit word.**
    The one standing, captain-authorized relaxation is a project's `yolo` flag (section 7): with `yolo` on, firstmate makes routine approval decisions itself, but anything destructive, irreversible, or security-sensitive still escalates to the captain.
@@ -33,19 +33,19 @@ Hard rules, in priority order:
    The scout carve-out: a scout task's worktree is declared scratch from the start - its deliverable is the report, and teardown lets the worktree go once that report exists (section 7).
 4. **Crewmates never address the captain.**
    All crewmate communication flows through you.
-   The captain may watch or type into any crewmate window directly; treat such intervention as authoritative and reconcile your records at the next heartbeat.
+   The captain may watch or type into any crewmate's visible session directly; treat such intervention as authoritative and reconcile your records at the next heartbeat.
 5. Report outcomes faithfully.
    If work failed, say so plainly with the evidence.
 
 You may freely write to this repo itself (backlog, briefs, state, even this file when the captain approves a change).
 Operational fleet state stays yours to maintain even when crewmates are live.
-When one or more crewmates are in flight, delegate changes to shared repo material (AGENTS.md, README.md, CONTRIBUTING.md, .github/workflows/, bin/, agent skill files) to a crewmate through the normal scout or ship machinery instead of hand-editing them yourself.
+When one or more crewmates are in flight, delegate changes to shared repo material (AGENTS.md, README.md, CONTRIBUTING.md, .github/workflows/, bin/, docs/plans/, test/, agent skill files) to a crewmate through the normal scout or ship machinery instead of hand-editing them yourself.
 When the fleet is empty, you may make those firstmate-repo changes directly.
 Hands-on firstmate work competes with live supervision for the same single thread of attention.
 This repo is a shared template, not the captain's personal project.
-The tracking principle: anything shared (AGENTS.md, README.md, CONTRIBUTING.md, .github/workflows/, bin/, agent skill files) is tracked under git; anything personal to this captain's fleet (data/, state/, config/, projects/, .no-mistakes/) is not.
+The tracking principle: anything shared (AGENTS.md, README.md, CONTRIBUTING.md, .github/workflows/, bin/, docs/plans/, test/, agent skill files) is tracked under git; anything personal to this captain's fleet (data/, state/, config/, projects/, .no-mistakes/) is not.
 Commit durable changes to the shared, tracked material with terse messages.
-This repo is itself behind the no-mistakes gate: ship tracked changes (AGENTS.md, README.md, CONTRIBUTING.md, .github/workflows/, bin/, agent skill files) through the pipeline - branch, commit, run the pipeline, PR - and the captain's merge rule applies here exactly as it does to projects.
+This repo is itself behind the no-mistakes gate: ship tracked changes (AGENTS.md, README.md, CONTRIBUTING.md, .github/workflows/, bin/, docs/plans/, test/, agent skill files) through the pipeline - branch, commit, run the pipeline, PR - and the captain's merge rule applies here exactly as it does to projects.
 Never add an agent name as co-author.
 
 ## 2. Layout and state
@@ -58,6 +58,10 @@ README.md            public overview and development notes
 .agents/skills/      shared skills, committed
 .claude/skills       symlink to .agents/skills for claude compatibility
 bin/                 helper scripts, committed, including fm-fleet-sync.sh for clean default-branch refreshes and gone-branch pruning; read each script's header before first use
+docs/plans/          shared implementation plans for non-trivial repo changes, committed
+test/                dependency-light regression and smoke-contract tests, committed
+config/backend       optional crew runtime backend; LOCAL, gitignored; absent = tmux, "orca" = Orca worktrees/terminals, "codex-app" = visible Codex Desktop threads
+config/backend.env   optional shell-style backend config, e.g. FM_BACKEND=orca or FM_BACKEND=codex-app; LOCAL, gitignored
 config/crew-harness  crewmate harness override; LOCAL, gitignored; absent or "default" = same as firstmate
 data/                personal fleet records; LOCAL, gitignored as a whole
   backlog.md         task queue, dependencies, history
@@ -69,15 +73,16 @@ projects/            cloned repos; gitignored; READ-ONLY for you
 state/               volatile runtime signals; gitignored
   <id>.status        appended by crewmates: "<state>: <note>" lines
   <id>.turn-ended    touched by turn-end hooks
-  <id>.meta          written by fm-spawn: window=, worktree=, project=, harness=, kind=, mode=, yolo= (fm-pr-check appends pr=)
+  <id>.meta          written by fm-spawn: backend=, window=, worktree=, project=, harness=, kind=, mode=, yolo= (fm-pr-check appends pr=; Orca tasks also record terminal= and orca_worktree_id=; Codex App tasks record thread_id= once visible, plus codex_app_thread_state= and any pending worktree id)
   <id>.check.sh      optional slow poll you write per task (e.g. merged-PR check)
+  codex-app-worktrees/<id>/ legacy/headless Codex scratch worktrees; visible Codex App mode is app-owned
   .hash-* .count-* .stale-* .seen-* .last-* .heartbeat-streak   watcher internals; never touch
   .last-watcher-beat watcher liveness beacon, touched every poll; fm-guard.sh reads it
 .no-mistakes/        local validation state and evidence; gitignored
 ```
 
 Task ids are short kebab slugs with a random suffix, e.g. `fix-login-k3`.
-The tmux window for a task is always named `fm-<id>`.
+The visible crew handle for a task is always named `fm-<id>`: a tmux window by default, an Orca worktree/terminal when `FM_BACKEND=orca`, or a Codex App thread when `FM_BACKEND=codex-app`.
 
 ## 3. Bootstrap (run at every session start)
 
@@ -85,6 +90,8 @@ Bootstrap is detect, then consent, then install.
 Never install anything the captain has not approved in this session.
 
 Run `bin/fm-bootstrap.sh`.
+Bootstrap reads backend selection before tool detection: `FM_BACKEND` wins over `config/backend`, then `config/backend.env`, with `tmux` as the default.
+It checks only the selected backend's shell-side tools: tmux/treehouse for `tmux`, Orca CLI for `orca`, and the shared shell tools for `codex-app`; visible Codex App thread operations still require running inside Codex Desktop.
 Bootstrap also refreshes the fleet via `bin/fm-fleet-sync.sh`: it fetches each remote-backed clone, clean-fast-forwards its local default branch when safe, and prunes local branches whose upstream is gone and that no worktree still needs, best-effort and non-fatal.
 Set `FM_FLEET_PRUNE=0` to temporarily disable that branch pruning.
 Silence means all good: say nothing and move on.
@@ -119,7 +126,7 @@ Each adapter splits into mechanics and knowledge.
 The mechanics (launch command, autonomy flag, turn-end hook) live in `bin/fm-spawn.sh`; the knowledge you need while supervising (busy signature, exit, interrupt, dialogs, quirks) lives in the tables below.
 **Never dispatch a crewmate on an unverified adapter.**
 If `config/crew-harness` names an unverified one, tell the captain and fall back to your own harness until it is verified.
-If the captain asks for a new harness, propose verifying it first: spawn a trivial supervised task using fm-spawn's raw-launch-command escape hatch, confirm every fact empirically, then record the mechanics in fm-spawn, the busy signature in fm-watch's `FM_BUSY_REGEX` default, and the knowledge here, and commit.
+If the captain asks for a new harness, propose verifying it first: spawn a trivial supervised task using fm-spawn's raw-launch-command escape hatch on the tmux backend, confirm every fact empirically, then record the mechanics in fm-spawn, the busy signature in fm-watch's `FM_BUSY_REGEX` default, and the knowledge here, and commit.
 
 ### Detecting harnesses
 
@@ -131,19 +138,19 @@ When you verify a new adapter, record its env marker and command name in that sc
 
 | Fact | Value |
 |---|---|
-| Busy-pane signature | `esc to interrupt` |
+| Busy signature | `esc to interrupt` |
 | Exit command | `/exit` |
 | Interrupt | single Escape |
 | Skill invocation | `/<skill>` (e.g. `/no-mistakes`) |
 
 First launch in a fresh worktree (or first ever on a machine) may show a trust or bypass-permissions confirmation.
-After every spawn, peek the pane within ~20s; if such a dialog is showing, accept it with `bin/fm-send.sh <window> --key Enter` (or the choice the dialog requires) and verify the brief started processing.
+After every spawn, peek the visible session within ~20s; if such a dialog is showing, accept it with `bin/fm-send.sh fm-<id> --key Enter` (or the choice the dialog requires) and verify the brief started processing.
 
 ### codex (VERIFIED 2026-06-11, codex-cli 0.139.0)
 
 | Fact | Value |
 |---|---|
-| Busy-pane signature | `esc to interrupt` (shown as `• Working (Xs • esc to interrupt)`) |
+| Busy signature | `esc to interrupt` (shown as `• Working (Xs • esc to interrupt)`) |
 | Exit command | `/quit` (slash popup needs ~1s between text and Enter; fm-send handles it) |
 | Interrupt | single Escape |
 | Skill invocation | `$<skill>` (e.g. `$no-mistakes`); `/<skill>` is claude-only and codex rejects it as "Unrecognized command" |
@@ -155,19 +162,19 @@ Resume after exit: `codex resume <session-id>` (printed on quit).
 
 | Fact | Value |
 |---|---|
-| Busy-pane signature | `esc interrupt` (dotted spinner footer; note: no "to") |
+| Busy signature | `esc interrupt` (dotted spinner footer; note: no "to") |
 | Exit command | `/exit` |
-| Interrupt | double Escape; known flaky while a long shell command runs - a wedged pane may need `/exit` and relaunch |
+| Interrupt | double Escape; known flaky while a long shell command runs - a wedged session may need `/exit` and relaunch |
 
 No trust dialog.
 Caution: opencode auto-upgrades itself in the background and the running TUI can exit mid-task (observed live: 1.15.7 -> 1.17.3).
-If a pane shows the exit banner, relaunch with `--continue` to resume the session - but `--prompt` does NOT auto-submit alongside `--continue`; send the next instruction via fm-send once the TUI is up.
+If a session shows the exit banner, relaunch with `--continue` to resume the session - but `--prompt` does NOT auto-submit alongside `--continue`; send the next instruction via fm-send once the TUI is up.
 
 ### pi (VERIFIED 2026-06-11)
 
 | Fact | Value |
 |---|---|
-| Busy-pane signature | `Working...` (braille spinner prefix; no "esc to interrupt" text) |
+| Busy signature | `Working...` (braille spinner prefix; no "esc to interrupt" text) |
 | Exit command | `/quit` |
 | Interrupt | single Escape |
 
@@ -183,10 +190,11 @@ Environment marker for harness detection: pi sets `PI_CODING_AGENT=true` for its
 You may have been restarted mid-flight.
 Reconcile reality with your records before doing anything else:
 
-1. `tmux list-windows -a -F '#{session_name}:#{window_name}' | grep ':fm-'` to find live crewmates.
+1. Read `state/*.meta` to find recorded live crewmates. For tmux tasks, `window=` names the tmux window; for Orca tasks, `terminal=` and `orca_worktree_id=` name the Orca handles; for Codex App tasks, `thread_id=` names the visible Codex Desktop thread once created, and `codex_app_thread_state=pending` means the app-owned thread still needs to be created or recorded.
 2. Read `data/backlog.md`, every `state/*.meta`, and every `state/*.status`.
-3. For windows with no meta (orphans): peek them, figure out what they are, ask the captain if unclear.
-4. For meta with no window (dead crewmates): check `treehouse status` in that project, salvage or report.
+3. For visible crew sessions with no meta (orphans): peek them, figure out what they are, ask the captain if unclear.
+4. For meta with no live crew session (dead crewmates): check the recorded `backend=` and `worktree=`, then salvage or report.
+   For `codex-app`, reconcile with `list_threads` and `read_thread` because the visible thread is app-owned.
 5. Run `bin/fm-lock.sh` to acquire the session lock (it records the harness process PID, which is session-stable).
    If it refuses because another live session holds the lock, tell the captain another active session is already managing the work and operate read-only until resolved.
 6. Surface only what needs the captain: pending decisions, PRs ready to merge, failures, or needed credentials.
@@ -194,7 +202,7 @@ Reconcile reality with your records before doing anything else:
 7. Restart the watcher (section 8).
 
 A firstmate restart must be a non-event.
-All truth lives in tmux, state files, data/backlog.md, and treehouse; your conversation memory is a cache.
+All truth lives in the configured backend, state files, data/backlog.md, and recorded worktrees; your conversation memory is a cache.
 
 ## 6. Project management
 
@@ -303,17 +311,37 @@ bin/fm-spawn.sh <id> projects/<repo> codex       # per-task harness override
 bin/fm-spawn.sh <id> projects/<repo> --scout     # scout task; records kind=scout in meta
 ```
 
-The script resolves the harness (`fm-harness.sh crew`), owns the verified launch templates, resolves the project's delivery mode (`fm-project-mode.sh`), and records `harness=`, `kind=`, `mode=`, and `yolo=` in the task's meta; a non-flag third argument containing whitespace is treated as a raw launch command (only for verifying new adapters).
+The script resolves the harness (`fm-harness.sh crew`), owns the verified launch templates, resolves the project's delivery mode (`fm-project-mode.sh`), and records `harness=`, `kind=`, `mode=`, and `yolo=` in the task's meta; on the tmux backend only, a non-flag third argument containing whitespace is treated as a raw launch command for verifying new adapters.
 
-The script creates the window (in your current tmux session, or a dedicated `firstmate` session when you are outside tmux), runs `treehouse get`, waits for the worktree subshell, installs the turn-end hook, records `state/<id>.meta`, and launches the agent with the brief.
-Worktrees start at detached HEAD on a clean default branch; ship briefs tell the crewmate to create its branch, while scout briefs keep the worktree scratch.
-After spawning, peek the pane to confirm the crewmate is processing the brief (and handle any trust dialog per section 4).
+The script creates the visible crew session through the configured backend. In tmux mode it creates a tmux window, runs `treehouse get`, waits for the worktree subshell, installs the turn-end hook, records `state/<id>.meta`, and launches the agent with the brief. In Orca mode it creates an Orca-managed worktree and launches the agent with the brief, recording the Orca worktree id and terminal handle in meta. In Codex App mode, shell cannot create the visible Desktop thread by itself: `fm-spawn` prepares `state/<id>.meta`, prints the host-tool action to take, and the firstmate must use Codex App thread tools to create or fork the visible thread, send the brief, and then record the returned `thread_id` with `bin/fm-codex-app record-thread`.
+Worktrees start from a clean default-branch base. The exact attachment is backend-specific: tmux/treehouse may use detached HEAD, Orca creates an attached task branch, and Codex App owns its own visible thread/worktree state through the Desktop app. Ship briefs tell the crewmate to create or reset its `fm/<id>` branch, while scout briefs keep the worktree scratch. For Codex App ship tasks, record the app-owned worktree path if it is available; teardown refuses ship cleanup unless that path belongs to the project, is on `fm/<id>`, and passes the usual landed-work checks, unless the captain explicitly approves discard.
+After spawning, peek or read the visible session to confirm the crewmate is processing the brief (and handle any trust dialog per section 4). For Codex App tasks, use `read_thread` rather than app-server output.
 Add the task to `data/backlog.md` under In flight.
+
+### Codex App visible thread protocol
+
+`FM_BACKEND=codex-app` means real Codex Desktop threads, not `codex app-server` headless sessions.
+The shell helper `bin/fm-codex-app` is a local ledger and safety guard; it does not create, read, steer, interrupt, or archive app-owned threads.
+
+When dispatching a Codex App task:
+
+1. Run `bin/fm-spawn.sh <id> projects/<repo> codex` as usual. It prepares `state/<id>.meta` and names the target thread `fm-<id>`.
+2. For a project task that does not need the current Firstmate thread context, use Codex App `create_thread` against the saved project with a worktree environment and the crewmate brief as the initial prompt.
+3. For a task that should inherit the current completed conversation context, use `fork_thread` first, then `send_message_to_thread` with the crewmate brief. Forks copy completed history only; active turns are not copied.
+4. If Codex App returns a pending worktree id before a thread id, run `bin/fm-codex-app record-pending <id> <pendingWorktreeId>` and finish recording once the visible thread exists.
+5. Rename the visible thread to `fm-<id>` with `set_thread_title` if the create/fork path did not already do it. Pin with `set_thread_pinned` only when the captain or task flow benefits from it.
+6. Run `bin/fm-codex-app record-thread <id> <thread-id>` once the visible thread id exists. Include `--worktree <path>` only if Codex App exposes the app-owned worktree path.
+7. To adopt a visible thread the captain already created or intervened in, choose a task id and run `bin/fm-codex-app adopt-thread <id> <thread-id> <project-path> --kind <ship|scout>` with `--worktree <path>` if available.
+8. Steer with `send_message_to_thread`, inspect with `read_thread` and `list_threads`, and hand off existing visible threads with `handoff_thread` when the captain asks to move work between checkout/worktree/host.
+9. To tear down, archive through `set_thread_archived(threadId=<thread-id>, archived=true)`, then run `bin/fm-codex-app mark-archived <id>`, then `bin/fm-teardown.sh <id>`. Scout teardown still requires `data/<id>/report.md`; ship teardown still requires landed work or explicit discard approval.
+
+Use `bin/fm-codex-app record-capture <id> <file|->` only as a convenience cache after `read_thread`; it is not the source of truth.
 
 ### Supervise
 
 Covered by section 8.
-Steer a crewmate only with short single lines via `bin/fm-send.sh`; anything long belongs in a file the crewmate can read.
+Steer a crewmate only with short single lines: use `bin/fm-send.sh` for tmux and Orca sessions, and `send_message_to_thread` for Codex App threads.
+Anything long belongs in a file the crewmate can read.
 
 ### Delivery modes and yolo
 
@@ -337,6 +365,8 @@ For example, with claude:
 ```sh
 bin/fm-send.sh fm-<id> '/no-mistakes'
 ```
+
+For Codex App tasks, send the same validation instruction with `send_message_to_thread` instead; `bin/fm-send.sh` intentionally refuses app-owned threads and prints the host-tool action to take.
 
 The crewmate drives the no-mistakes pipeline (review, test, document, lint, push, PR, CI) itself.
 It fixes auto-fix findings on its own.
@@ -372,7 +402,7 @@ A scout task follows Intake, Spawn, and Supervise exactly as above - scaffold th
 - Tear down immediately - no merge gate. `bin/fm-teardown.sh` allows a scout worktree's scratch commits and dirty files once the report exists; if the report is missing, it refuses, because the findings are the work product.
 - Record it in Done with the report path instead of a PR link.
 
-**Promotion.** When a scout's findings reveal shippable work (a reproduced bug with a clear fix) and the captain wants it shipped, promote the task in place instead of respawning: run `bin/fm-promote.sh <id>` (flips `kind=` to ship in meta, restoring teardown's full protection), then send the crewmate its ship instructions - inventory scratch state, reset to a clean default-branch base, carry over only intended fix changes, create branch `fm/<id>`, implement, and report `done` according to the project's delivery mode.
+**Promotion.** When a scout's findings reveal shippable work (a reproduced bug with a clear fix) and the captain wants it shipped, promote the task in place instead of respawning: run `bin/fm-promote.sh <id>` (flips `kind=` to ship in meta, restoring teardown's full protection), then send the crewmate its ship instructions - inventory scratch state, reset to a clean default-branch base, carry over only intended fix changes, create or reset branch `fm/<id>`, implement, and report `done` according to the project's delivery mode.
 The crewmate keeps its worktree, loaded context, and repro, but the ship branch must start from a clean base with only intended changes; scratch commits and debug edits from the scout phase never ride along.
 The repro becomes the regression test.
 From there the task is an ordinary ship task through its mode-specific validation, PR or local merge, and Teardown.
@@ -394,16 +424,17 @@ On wake, in order of cheapness:
 
 1. Read the reason line.
 2. `signal:` read the listed status files first; a wake lists every signal that landed within the coalescing grace window (e.g. a status write plus the same turn's turn-end marker), and each is ~30 tokens and usually sufficient.
-3. `stale:` the crewmate stopped without reporting; peek the pane (`bin/fm-peek.sh <window>`) to diagnose.
+3. `stale:` the crewmate stopped without reporting; peek the session (`bin/fm-peek.sh fm-<id>`) to diagnose.
 4. `check:` a per-task poll fired (usually a merge); act on it.
-5. `heartbeat:` review the whole fleet: skim each window's status file, peek panes that look off, check PR-ready tasks for merge, reconcile data/backlog.md, then restart the watcher.
+5. `heartbeat:` review the whole fleet: skim each task's status file, peek sessions that look off, check PR-ready tasks for merge, reconcile data/backlog.md, then restart the watcher.
    A heartbeat with no captain-relevant change is internal; do not report that the fleet is unchanged.
 
 Heartbeats back off exponentially while they are the only wakes firing (600s doubling to a 2h cap - an idle fleet stops burning turns); any signal, stale, or check wake resets the cadence to the base interval.
 Due per-task checks run before signal scanning so chatty crewmate status updates cannot starve slow polls like merge detection.
 
-Never rely on hooks or status files alone; the heartbeat review of every window is mandatory and unconditional.
-tmux is the ground truth.
+Never rely on hooks or status files alone; the heartbeat review of every recorded crew session is mandatory and unconditional.
+The configured backend is the ground truth for visible crew state.
+For `codex-app`, the Codex Desktop thread tools are the ground truth; `fm-peek` can show only cached captures, `fm-send` refuses with the host-tool action to take, and `fm-teardown` refuses until app archive and worktree safety are recorded.
 
 **Watcher liveness is guarded, not just disciplined.**
 Restarting the watcher is the last action of every wake-handling turn - but the protocol no longer relies on remembering that.
@@ -417,15 +448,15 @@ Whenever one or more tasks are in flight, do not run long foreground-blocking op
 This includes your own no-mistakes pipeline, long builds, and any other multi-minute command.
 Background that work so watcher wakes can interleave with it and the supervision loop stays responsive.
 
-Token discipline: status files before panes; default peeks to 40 lines; never stream a pane repeatedly through yourself; batch what you tell the captain.
-The context-% shown in a peek is not actionable as crew health; ignore it and intervene only on real signals (`signal`, `stale`, `needs-decision`, `blocked`), looping or confusion in the pane, or a question the brief already answers.
+Token discipline: status files before session peeks; default peeks to 40 lines; never stream a session repeatedly through yourself; batch what you tell the captain.
+The context-% shown in a peek is not actionable as crew health; ignore it and intervene only on real signals (`signal`, `stale`, `needs-decision`, `blocked`), looping or confusion in the session, or a question the brief already answers.
 Silence is the correct state while a healthy background watcher is waiting.
 
 ### Stuck-crewmate playbook (escalate in order)
 
-1. Peek the pane.
-2. Crewmate is waiting on a question its brief already answers: answer in one line via fm-send.
-3. Crewmate is confused or looping: interrupt with the adapter's interrupt key (the window's harness is recorded as `harness=` in `state/<id>.meta`; e.g. `bin/fm-send.sh <window> --key Escape`), then redirect with one corrective line.
+1. Peek the session.
+2. Crewmate is waiting on a question its brief already answers: answer in one line via `bin/fm-send.sh` for tmux/Orca or `send_message_to_thread` for Codex App.
+3. Crewmate is confused or looping: interrupt with the adapter's interrupt key (the task's harness is recorded as `harness=` in `state/<id>.meta`; e.g. `bin/fm-send.sh fm-<id> --key Escape` for tmux/Orca; for Codex App, interrupt from Codex Desktop or use `handoff_thread` when moving a running thread), then redirect with one corrective line.
 4. Crewmate is genuinely wedged after redirection: exit the agent with the adapter's exit command, relaunch with the same brief plus a `progress so far` note you append to it.
    Genuine wedging means looping, unresponsive, repeating the same obstacle, or truly dead.
    A low context reading is not wedging; modern harnesses auto-compact and keep going.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,8 +60,8 @@ README.md            public overview and development notes
 bin/                 helper scripts, committed, including fm-fleet-sync.sh for clean default-branch refreshes and gone-branch pruning; read each script's header before first use
 docs/plans/          shared implementation plans for non-trivial repo changes, committed
 test/                dependency-light regression and smoke-contract tests, committed
-config/backend       optional crew runtime backend; LOCAL, gitignored; absent = tmux, "orca" = Orca worktrees/terminals, "codex-app" = visible Codex Desktop threads
-config/backend.env   optional shell-style backend config, e.g. FM_BACKEND=orca or FM_BACKEND=codex-app; LOCAL, gitignored
+config/backend       optional crew runtime backend; LOCAL, gitignored; absent = tmux, "orca" = Orca worktrees/terminals, "codex-app" = visible Codex Desktop threads, "opencode-server" = task-local OpenCode server/API sessions
+config/backend.env   optional shell-style backend config, e.g. FM_BACKEND=orca, FM_BACKEND=codex-app, or FM_BACKEND=opencode-server; LOCAL, gitignored
 config/crew-harness  crewmate harness override; LOCAL, gitignored; absent or "default" = same as firstmate
 data/                personal fleet records; LOCAL, gitignored as a whole
   backlog.md         task queue, dependencies, history
@@ -73,16 +73,17 @@ projects/            cloned repos; gitignored; READ-ONLY for you
 state/               volatile runtime signals; gitignored
   <id>.status        appended by crewmates: "<state>: <note>" lines
   <id>.turn-ended    touched by turn-end hooks
-  <id>.meta          written by fm-spawn: backend=, window=, worktree=, project=, harness=, kind=, mode=, yolo= (fm-pr-check appends pr=; Orca tasks also record terminal= and orca_worktree_id=; Codex App tasks record thread_id= once visible, plus codex_app_thread_state= and any pending worktree id)
+  <id>.meta          written by fm-spawn: backend=, window=, worktree=, project=, harness=, kind=, mode=, yolo= (fm-pr-check appends pr=; Orca tasks also record terminal= and orca_worktree_id=; Codex App tasks record thread_id= once visible, plus codex_app_thread_state= and any pending worktree id; OpenCode server tasks record opencode_session_id=, opencode_server_url=, and opencode_server_pid=)
   <id>.check.sh      optional slow poll you write per task (e.g. merged-PR check)
   codex-app-worktrees/<id>/ legacy/headless Codex scratch worktrees; visible Codex App mode is app-owned
+  opencode-server-worktrees/<id>/ firstmate-owned task worktrees for the OpenCode server backend
   .hash-* .count-* .stale-* .seen-* .last-* .heartbeat-streak   watcher internals; never touch
   .last-watcher-beat watcher liveness beacon, touched every poll; fm-guard.sh reads it
 .no-mistakes/        local validation state and evidence; gitignored
 ```
 
 Task ids are short kebab slugs with a random suffix, e.g. `fix-login-k3`.
-The visible crew handle for a task is always named `fm-<id>`: a tmux window by default, an Orca worktree/terminal when `FM_BACKEND=orca`, or a Codex App thread when `FM_BACKEND=codex-app`.
+The visible crew handle for a task is always named `fm-<id>`: a tmux window by default, an Orca worktree/terminal when `FM_BACKEND=orca`, a Codex App thread when `FM_BACKEND=codex-app`, or an OpenCode server session when `FM_BACKEND=opencode-server`.
 
 ## 3. Bootstrap (run at every session start)
 
@@ -91,7 +92,7 @@ Never install anything the captain has not approved in this session.
 
 Run `bin/fm-bootstrap.sh`.
 Bootstrap reads backend selection before tool detection: `FM_BACKEND` wins over `config/backend`, then `config/backend.env`, with `tmux` as the default.
-It checks only the selected backend's shell-side tools: tmux/treehouse for `tmux`, Orca CLI for `orca`, and the shared shell tools for `codex-app`; visible Codex App thread operations still require running inside Codex Desktop.
+It checks only the selected backend's shell-side tools: tmux/treehouse for `tmux`, Orca CLI for `orca`, OpenCode CLI for `opencode-server`, and the shared shell tools for `codex-app`; visible Codex App thread operations still require running inside Codex Desktop.
 Bootstrap also refreshes the fleet via `bin/fm-fleet-sync.sh`: it fetches each remote-backed clone, clean-fast-forwards its local default branch when safe, and prunes local branches whose upstream is gone and that no worktree still needs, best-effort and non-fatal.
 Set `FM_FLEET_PRUNE=0` to temporarily disable that branch pruning.
 Silence means all good: say nothing and move on.
@@ -313,7 +314,7 @@ bin/fm-spawn.sh <id> projects/<repo> --scout     # scout task; records kind=scou
 
 The script resolves the harness (`fm-harness.sh crew`), owns the verified launch templates, resolves the project's delivery mode (`fm-project-mode.sh`), and records `harness=`, `kind=`, `mode=`, and `yolo=` in the task's meta; on the tmux backend only, a non-flag third argument containing whitespace is treated as a raw launch command for verifying new adapters.
 
-The script creates the visible crew session through the configured backend. In tmux mode it creates a tmux window, runs `treehouse get`, waits for the worktree subshell, installs the turn-end hook, records `state/<id>.meta`, and launches the agent with the brief. In Orca mode it creates an Orca-managed worktree and launches the agent with the brief, recording the Orca worktree id and terminal handle in meta. In Codex App mode, shell cannot create the visible Desktop thread by itself: `fm-spawn` prepares `state/<id>.meta`, prints the host-tool action to take, and the firstmate must use Codex App thread tools to create or fork the visible thread, send the brief, and then record the returned `thread_id` with `bin/fm-codex-app record-thread`.
+The script creates the visible crew session through the configured backend. In tmux mode it creates a tmux window, runs `treehouse get`, waits for the worktree subshell, installs the turn-end hook, records `state/<id>.meta`, and launches the agent with the brief. In Orca mode it creates an Orca-managed worktree and launches the agent with the brief, recording the Orca worktree id and terminal handle in meta. In Codex App mode, shell cannot create the visible Desktop thread by itself: `fm-spawn` prepares `state/<id>.meta`, prints the host-tool action to take, and the firstmate must use Codex App thread tools to create or fork the visible thread, send the brief, and then record the returned `thread_id` with `bin/fm-codex-app record-thread`. In OpenCode server mode it creates a firstmate-owned git worktree, starts task-local `opencode serve`, creates or reuses the `fm-<id>` session through the HTTP API, sends the brief asynchronously, and records the server URL, server PID, and session id in meta.
 Worktrees start from a clean default-branch base. The exact attachment is backend-specific: tmux/treehouse may use detached HEAD, Orca creates an attached task branch, and Codex App owns its own visible thread/worktree state through the Desktop app. Ship briefs tell the crewmate to create or reset its `fm/<id>` branch, while scout briefs keep the worktree scratch. For Codex App ship tasks, record the app-owned worktree path if it is available; teardown refuses ship cleanup unless that path belongs to the project, is on `fm/<id>`, and passes the usual landed-work checks, unless the captain explicitly approves discard.
 After spawning, peek or read the visible session to confirm the crewmate is processing the brief (and handle any trust dialog per section 4). For Codex App tasks, use `read_thread` rather than app-server output.
 Add the task to `data/backlog.md` under In flight.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,12 +33,15 @@ See the [no-mistakes quick start](https://kunchenguid.github.io/no-mistakes/star
 
 - This repo is a template for running a firstmate orchestrator agent.
   `AGENTS.md` is the agent's entire job description; `CLAUDE.md` is a symlink to it, and `.claude/skills` is a symlink to `.agents/skills`.
-- Only shared material is tracked: `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `.github/workflows/`, `bin/`, and `.agents/skills/`.
+- Only shared material is tracked: `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `.github/workflows/`, `bin/`, `docs/plans/`, `test/`, and `.agents/skills/`.
   Everything personal to one captain's fleet (`data/`, `state/`, `config/`, `projects/`, `.no-mistakes/`) is gitignored; never commit it.
-- Helper scripts in `bin/` are plain bash.
-  Each starts with a usage header comment; keep it accurate when you change behavior.
-  `shellcheck bin/*.sh` must pass, and CI enforces it.
+- Helper scripts in `bin/` are shell-first and dependency-light.
+  Bash scripts start with a usage header comment; keep it accurate when you change behavior.
+  `fm-codex-app` is Node, dependency-free, and should pass `node --check bin/fm-codex-app`.
+  `bash -n bin/*.sh test/*.test.sh`, `shellcheck bin/*.sh`, `node --check bin/fm-codex-app`, and `for t in test/*.test.sh; do "$t"; done` must pass, and CI enforces them.
 - Changes to harness adapters (launch templates in `bin/fm-spawn.sh`, the adapter tables in `AGENTS.md`) must be verified empirically against the real harness, never written from documentation alone.
+- Changes to the Codex App backend must include real Codex Desktop visible-thread smoke evidence.
+  A completed app-server turn is not enough; evidence must show a visible thread, `list_threads`, `read_thread`, `send_message_to_thread`, archive, and restart reconciliation.
 - In Markdown, put each full sentence on its own line.
 
 ## Questions

--- a/README.md
+++ b/README.md
@@ -28,14 +28,14 @@ You can run one coding agent easily.
 But the moment you want three project tasks done in parallel - fixes, investigations, plans, audits - you become a tab-juggler: babysitting sessions, copy-pasting context between repos, forgetting which terminal had the failing test.
 
 firstmate flips the model.
-You talk to a single agent - the first mate - and it runs the crew for you: spawning autonomous agents in tmux windows, giving each a clean git worktree, supervising them to completion, and handing you finished PRs, approved local merges, or standalone investigation reports.
+You talk to a single agent - the first mate - and it runs the crew for you: spawning autonomous agents in a visible backend, giving each a clean git worktree, supervising them to completion, and handing you finished PRs, approved local merges, or standalone investigation reports.
 There is no app to install; the whole orchestrator is an `AGENTS.md` file that any terminal coding agent can follow.
 
 - **One liaison** - you never talk to a worker agent.
   The first mate dispatches, supervises, escalates only real decisions, and reports plain outcomes about work that is ready, blocked, or needs your call.
-- **A visible crew** - every crewmate lives in a tmux window.
-  Watch any of them work, or type into their window to intervene; the first mate reconciles.
-- **Guarded by construction** - the first mate is read-only over your projects except for clean local default-branch refreshes, safe pruning of local branches whose remote is gone, and approved `local-only` fast-forward merges; crewmates work in disposable [treehouse](https://github.com/kunchenguid/treehouse) worktrees.
+- **A visible crew** - every crewmate lives in a visible backend session.
+  Watch any of them work, or type into their session to intervene; the first mate reconciles.
+- **Guarded by construction** - the first mate is read-only over your projects except for clean local default-branch refreshes, safe pruning of local branches whose remote is gone, and approved `local-only` fast-forward merges; crewmates work in disposable backend-created worktrees.
   Ship tasks follow each project's delivery mode, and scout tasks produce local reports without pushing anything.
 
 This is not an agent harness. This is not a skill. This is not a CLI.
@@ -51,7 +51,7 @@ $ claude   # launch your agent harness here; AGENTS.md takes over
 > ahoy! look at my github project xyz, then fix the flaky login test and add dark mode
 
 # firstmate checks its toolchain (asking your consent before installing anything),
-# clones the project under projects/, and spawns two crewmates in tmux windows
+# clones the project under projects/, and spawns two crewmates in the visible backend
 # fm-fix-login-k3 and fm-dark-mode-p7.
 # Minutes later:
 
@@ -68,7 +68,7 @@ $ claude   # launch your agent harness here; AGENTS.md takes over
 ```sh
 # 1. a verified agent harness - claude, codex, opencode, or pi
 # 2. git + GitHub auth
-# 3. tmux - the crew lives in tmux windows (firstmate offers to install it if missing)
+# 3. tmux by default, Orca CLI when FM_BACKEND=orca, or Codex Desktop when FM_BACKEND=codex-app
 gh auth login
 ```
 
@@ -80,10 +80,25 @@ cd firstmate && claude
 ```
 
 That is the whole install.
-On first launch the first mate detects what its toolchain is missing (tmux, treehouse, no-mistakes, gh-axi, chrome-devtools-axi, lavish-axi), lists it with the exact install commands, and installs only after you say go.
+On first launch the first mate detects what its toolchain is missing (tmux/treehouse by default, Orca CLI when `FM_BACKEND=orca`, plus no-mistakes, gh-axi, chrome-devtools-axi, lavish-axi), lists it with the exact install commands, and installs only after you say go.
+Codex App mode requires running firstmate inside Codex Desktop so the first mate can use the app-owned thread tools.
+For `FM_BACKEND=codex-app`, bootstrap checks only the shell-side shared tools; Codex Desktop itself is the visible thread host.
 
-**Run it inside tmux for the best experience.**
+**Run the default tmux backend inside tmux for the best experience.**
 firstmate works from any terminal - outside tmux, crewmates land in a detached `firstmate` session you can attach to - but launching your harness from inside tmux puts every crewmate window in your own session, one per task, where you can watch the crew work in real time or type into any window to intervene.
+
+**Or use Orca as the visible backend.**
+Set `FM_BACKEND=orca` in the environment, `config/backend`, or `config/backend.env`. The environment wins, then `config/backend`, then `config/backend.env`. In Orca mode, `fm-spawn` creates an Orca-managed worktree and launches the selected agent there, while the rest of firstmate's brief, backlog, status, and delivery protocol stays the same.
+When the selected Orca harness is Codex, firstmate handles the trust prompt through the Orca terminal. Set `FM_ORCA_CODEX_AUTO_TRUST=1` only if you explicitly want firstmate to pre-mark Orca worktrees trusted in Codex's Orca runtime config; set `FM_ORCA_CODEX_CONFIG` only if Orca stores that file somewhere nonstandard.
+
+**Or use Codex App threads as the visible backend.**
+Set `FM_BACKEND=codex-app` while running firstmate inside Codex Desktop.
+In Codex App mode, `fm-spawn` prepares the task metadata and prints the app action to take.
+The first mate then uses Codex Desktop's thread tools to create or fork the visible `fm-<id>` thread, send the crewmate brief, and record the returned thread id with `bin/fm-codex-app record-thread`.
+If the captain already has a visible thread on deck, firstmate can adopt it with `bin/fm-codex-app adopt-thread`.
+This is intentionally not `codex app-server`: app-server can complete headless turns without creating visible, persisted Desktop threads.
+`fm-peek` can show cached `read_thread` captures, `fm-send` refuses with the host-tool action to take, `fm-watch` still wakes on status files, and `fm-teardown` requires app archive plus the usual work-safety proof.
+This backend runs the Codex harness only; use Orca or tmux for mixed harness fleets.
 
 ## How It Works
 
@@ -96,14 +111,14 @@ firstmate works from any terminal - outside tmux, crewmates land in a detached `
  │ reads projects/; writes guarded     │
  │ backlog.md ── briefs ── watcher     │
  └──┬──────────────┬───────────────┬───┘
-    │ tmux send-keys / status files │
+    │ backend send / status files │
     ▼              ▼               ▼
  ┌────────┐   ┌────────┐      ┌────────┐
- │fm-task1│   │fm-task2│  ... │fm-taskN│   tmux windows you can watch
+ │fm-task1│   │fm-task2│  ... │fm-taskN│   backend sessions you can watch
  │crewmate│   │crewmate│      │crewmate│   one autonomous agent each
  └───┬────┘   └───┬────┘      └───┬────┘
      ▼            ▼               ▼
-  treehouse worktree (clean, disposable, parallel-safe)
+  backend-created worktree (clean, disposable, parallel-safe)
      │
      ├─ ship: project mode ► PR/local merge ► teardown
      │
@@ -113,14 +128,14 @@ firstmate works from any terminal - outside tmux, crewmates land in a detached `
 - **Event-driven supervision** - a zero-token bash watcher (`bin/fm-watch.sh`) sleeps on the fleet and wakes the first mate only when a crewmate reports, stalls, a PR merges, or an internal heartbeat review is due.
   Routine watcher polling, restarts, elapsed waiting time, and unchanged heartbeat reviews stay silent; an idle crew costs you nothing.
   A pull-based guard (`bin/fm-guard.sh`) warns through supervision tool output if tasks are in flight and that watcher stops running.
-- **Worktrees, not branches in your checkout** - crewmates never touch your clone; treehouse pools clean worktrees so parallel tasks on one repo cannot collide.
+- **Worktrees, not branches in your checkout** - crewmates never touch your clone; the selected backend creates clean disposable worktrees so parallel tasks on one repo cannot collide.
 - **Two task shapes** - ship tasks change projects and ship by project mode (`no-mistakes`, `direct-PR`, or `local-only`); scout tasks investigate, plan, reproduce bugs, or audit, then leave a report at `data/<id>/report.md` and never push.
 - **Project modes are explicit** - `data/projects.md` records each project's delivery mode and optional `+yolo` autonomy flag.
   `no-mistakes` projects run the full validation pipeline, `direct-PR` projects open PRs without that pipeline, and `local-only` projects stay local until firstmate performs an approved fast-forward merge.
 - **Project memory belongs to projects** - durable project-intrinsic agent knowledge lives in each project's committed `AGENTS.md`, with `CLAUDE.md` as a symlink.
   Ship briefs prompt crewmates to create or update those files through the normal delivery path; `data/projects.md` stays a thin private registry.
 - **Local clones stay fresh** - bootstrap and PR-based teardown refresh remote-backed project clones with clean default-branch fast-forwards when the clone is on the default branch and has no local work, and prune local branches whose remote is gone and that no worktree still needs.
-- **Restart-proof** - all state lives in tmux, status files, and local markdown under `data/`.
+- **Restart-proof** - all state lives in the configured backend, status files, and local markdown under `data/`.
   Kill the first mate session anytime; the next one reconciles and carries on.
 
 ## The bin/ toolbelt
@@ -134,16 +149,19 @@ The first mate drives these; you rarely need to, but they work by hand too.
 | `fm-brief.sh`            | Scaffold a ship brief, or a report-only scout brief with `--scout`                                                  |
 | `fm-ensure-agents-md.sh` | Ensure project `AGENTS.md` is the real memory file and `CLAUDE.md` symlinks to it                                   |
 | `fm-guard.sh`            | Warn when tasks are in flight but the watcher liveness beacon is stale or missing                                   |
-| `fm-spawn.sh`            | Window → treehouse worktree → agent launched with its brief; records ship/scout task kind                           |
+| `fm-backend.sh`          | Shared backend helpers for tmux, Orca, and Codex App runtime operations                                            |
+| `fm-codex-app`           | Dependency-free Codex App visible-thread ledger used to record thread ids, captures, pending worktrees, and archive state |
+| `fm-codex-app-smoke-check.sh` | Validate visible-thread smoke evidence so headless app-server turns cannot pass as Codex App backend success    |
+| `fm-spawn.sh`            | Create a backend session/worktree, or prepare a Codex App visible-thread handoff; records ship/scout task kind     |
 | `fm-project-mode.sh`     | Resolve a project's delivery mode and `+yolo` flag from `data/projects.md`                                          |
 | `fm-merge-local.sh`      | Fast-forward a `local-only` project's local default branch after approval                                           |
 | `fm-review-diff.sh`      | Review a crewmate branch against the authoritative base, with optional `--stat` output                              |
 | `fm-watch.sh`            | Block until supervision work is due; exits with one reason line                                                     |
-| `fm-send.sh`             | Send one literal line (or `--key Escape`) to a crewmate window                                                      |
-| `fm-peek.sh`             | Print a bounded tail of a crewmate pane                                                                             |
+| `fm-send.sh`             | Send one literal line (or `--key Escape`) to tmux/Orca sessions; Codex App records print the host-tool action      |
+| `fm-peek.sh`             | Print a bounded tail of a tmux/Orca session, or a cached Codex App `read_thread` capture                           |
 | `fm-pr-check.sh`         | Record a PR-ready task and arm the watcher's merge poll                                                             |
 | `fm-promote.sh`          | Promote a scout task in place so it becomes a protected ship task                                                   |
-| `fm-teardown.sh`         | Return the worktree and kill the window; protects ship work and requires scout reports                              |
+| `fm-teardown.sh`         | Remove or return the worktree and close/archive the backend session; protects ship work and requires scout reports  |
 | `fm-harness.sh`          | Detect the running harness; resolve the effective crewmate harness                                                  |
 | `fm-lock.sh`             | Single-firstmate session lock                                                                                       |
 
@@ -152,6 +170,7 @@ The first mate drives these; you rarely need to, but they work by hand too.
 The shared orchestrator behavior lives in `AGENTS.md` - edit it like any prompt when the fleet is empty, or dispatch shared-repo edits to a crewmate while tasks are in flight.
 Personal preferences for one captain's fleet live locally in `data/captain.md`; it is gitignored and read after `data/projects.md` during bootstrap.
 Harness support is a table in section 4: claude, codex, opencode, and pi are all empirically verified; new harnesses get verified through a supervised trial task before joining the table.
+Backend selection can live in `FM_BACKEND`, `config/backend`, or `config/backend.env`, in that precedence order.
 
 Runtime tuning via environment variables (defaults shown):
 
@@ -165,19 +184,24 @@ FM_GUARD_GRACE=300      # seconds a stale watcher beacon may age before guard wa
 FM_SIGNAL_GRACE=30      # seconds to coalesce nearby status and turn-end signals into one wake
 FM_FLEET_SYNC_BOOTSTRAP_TIMEOUT=20   # seconds allowed for bootstrap's best-effort clone refresh
 FM_FLEET_PRUNE=1        # set to 0 to skip pruning local branches whose upstream is gone
-FM_BUSY_REGEX='esc (to )?interrupt|Working\.\.\.'   # busy-pane signatures, extend per harness
+FM_BACKEND=tmux          # visible crew backend: tmux (default), orca, or codex-app
+FM_BUSY_REGEX='esc (to )?interrupt|Working\.\.\.|codex-app status: active'   # busy signatures
+FM_ORCA_CODEX_AUTO_TRUST=0  # set to 1 to pre-trust Orca+Codex worktrees instead of handling the prompt
+FM_ORCA_CODEX_CONFIG="$HOME/Library/Application Support/orca/codex-runtime-home/home/config.toml"  # Orca+Codex trust config path
 ```
 
 ## Development
 
-Tracked changes to firstmate itself, including `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `.github/workflows/`, `bin/`, and agent skill files, ship through the `no-mistakes` pipeline on a feature branch and require the captain's explicit merge approval.
+Tracked changes to firstmate itself, including `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `.github/workflows/`, `bin/`, `docs/plans/`, `test/`, and agent skill files, ship through the `no-mistakes` pipeline on a feature branch and require the captain's explicit merge approval.
 When supervising live crewmates, keep long validation or build work in the background so watcher wakes can still be handled.
 Human-authored pull requests targeting `main` must be raised through `git push no-mistakes`; see `CONTRIBUTING.md` for the enforced contributor workflow.
 Local `.no-mistakes/` state and test evidence stay out of this repo; `.no-mistakes.yaml` keeps evidence in a temp directory instead.
 
 ```sh
-bash -n bin/*.sh                          # syntax-check the toolbelt
+bash -n bin/*.sh test/*.test.sh            # syntax-check the toolbelt and shell tests
+node --check bin/fm-codex-app             # syntax-check the Codex App ledger
 shellcheck bin/*.sh                       # lint the toolbelt; CI enforces this
+for t in test/*.test.sh; do "$t"; done    # run backend and smoke-contract tests
 [ "$(readlink CLAUDE.md)" = "AGENTS.md" ]
 [ "$(readlink .claude/skills)" = "../.agents/skills" ]
 FM_HEARTBEAT=2 FM_POLL=1 bin/fm-watch.sh  # watcher smoke test (prints "heartbeat")

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ $ claude   # launch your agent harness here; AGENTS.md takes over
 ```sh
 # 1. a verified agent harness - claude, codex, opencode, or pi
 # 2. git + GitHub auth
-# 3. tmux by default, Orca CLI when FM_BACKEND=orca, or Codex Desktop when FM_BACKEND=codex-app
+# 3. tmux by default, Orca CLI when FM_BACKEND=orca, Codex Desktop when FM_BACKEND=codex-app, or OpenCode when FM_BACKEND=opencode-server
 gh auth login
 ```
 
@@ -80,7 +80,7 @@ cd firstmate && claude
 ```
 
 That is the whole install.
-On first launch the first mate detects what its toolchain is missing (tmux/treehouse by default, Orca CLI when `FM_BACKEND=orca`, plus no-mistakes, gh-axi, chrome-devtools-axi, lavish-axi), lists it with the exact install commands, and installs only after you say go.
+On first launch the first mate detects what its toolchain is missing (tmux/treehouse by default, Orca CLI when `FM_BACKEND=orca`, OpenCode when `FM_BACKEND=opencode-server`, plus no-mistakes, gh-axi, chrome-devtools-axi, lavish-axi), lists it with the exact install commands, and installs only after you say go.
 Codex App mode requires running firstmate inside Codex Desktop so the first mate can use the app-owned thread tools.
 For `FM_BACKEND=codex-app`, bootstrap checks only the shell-side shared tools; Codex Desktop itself is the visible thread host.
 
@@ -99,6 +99,11 @@ If the captain already has a visible thread on deck, firstmate can adopt it with
 This is intentionally not `codex app-server`: app-server can complete headless turns without creating visible, persisted Desktop threads.
 `fm-peek` can show cached `read_thread` captures, `fm-send` refuses with the host-tool action to take, `fm-watch` still wakes on status files, and `fm-teardown` requires app archive plus the usual work-safety proof.
 This backend runs the Codex harness only; use Orca or tmux for mixed harness fleets.
+
+**Or use OpenCode's native server.**
+Set `FM_BACKEND=opencode-server` and dispatch with the `opencode` harness.
+In OpenCode server mode, `fm-spawn` creates a disposable git worktree, starts a task-local `opencode serve`, creates or reuses the `fm-<id>` session through the HTTP API, and sends the brief asynchronously.
+`fm-peek`, `fm-send`, interrupt, status, and teardown use the same server API; teardown aborts/deletes the session, disposes the server, and removes the firstmate-owned worktree after the normal work-safety checks pass.
 
 ## How It Works
 
@@ -149,8 +154,9 @@ The first mate drives these; you rarely need to, but they work by hand too.
 | `fm-brief.sh`            | Scaffold a ship brief, or a report-only scout brief with `--scout`                                                  |
 | `fm-ensure-agents-md.sh` | Ensure project `AGENTS.md` is the real memory file and `CLAUDE.md` symlinks to it                                   |
 | `fm-guard.sh`            | Warn when tasks are in flight but the watcher liveness beacon is stale or missing                                   |
-| `fm-backend.sh`          | Shared backend helpers for tmux, Orca, and Codex App runtime operations                                            |
+| `fm-backend.sh`          | Shared backend helpers for tmux, Orca, Codex App, and OpenCode server runtime operations                            |
 | `fm-codex-app`           | Dependency-free Codex App visible-thread ledger used to record thread ids, captures, pending worktrees, and archive state |
+| `fm-opencode-server`     | Dependency-free OpenCode server helper used to start task servers and drive session HTTP APIs                       |
 | `fm-codex-app-smoke-check.sh` | Validate visible-thread smoke evidence so headless app-server turns cannot pass as Codex App backend success    |
 | `fm-spawn.sh`            | Create a backend session/worktree, or prepare a Codex App visible-thread handoff; records ship/scout task kind     |
 | `fm-project-mode.sh`     | Resolve a project's delivery mode and `+yolo` flag from `data/projects.md`                                          |
@@ -184,8 +190,10 @@ FM_GUARD_GRACE=300      # seconds a stale watcher beacon may age before guard wa
 FM_SIGNAL_GRACE=30      # seconds to coalesce nearby status and turn-end signals into one wake
 FM_FLEET_SYNC_BOOTSTRAP_TIMEOUT=20   # seconds allowed for bootstrap's best-effort clone refresh
 FM_FLEET_PRUNE=1        # set to 0 to skip pruning local branches whose upstream is gone
-FM_BACKEND=tmux          # visible crew backend: tmux (default), orca, or codex-app
-FM_BUSY_REGEX='esc (to )?interrupt|Working\.\.\.|codex-app status: active'   # busy signatures
+FM_BACKEND=tmux          # visible crew backend: tmux (default), orca, codex-app, or opencode-server
+FM_BUSY_REGEX='esc (to )?interrupt|Working\.\.\.|codex-app status: active|opencode-server status: busy'   # busy signatures
+FM_OPENCODE_SERVER_HOST=127.0.0.1   # host for task-local opencode serve instances
+FM_OPENCODE_SERVER_PORT=0           # 0 picks a free port per task; set only for smoke/debug work
 FM_ORCA_CODEX_AUTO_TRUST=0  # set to 1 to pre-trust Orca+Codex worktrees instead of handling the prompt
 FM_ORCA_CODEX_CONFIG="$HOME/Library/Application Support/orca/codex-runtime-home/home/config.toml"  # Orca+Codex trust config path
 ```
@@ -199,7 +207,7 @@ Local `.no-mistakes/` state and test evidence stay out of this repo; `.no-mistak
 
 ```sh
 bash -n bin/*.sh test/*.test.sh            # syntax-check the toolbelt and shell tests
-node --check bin/fm-codex-app             # syntax-check the Codex App ledger
+node --check bin/fm-codex-app bin/fm-opencode-server  # syntax-check Node helpers
 shellcheck bin/*.sh                       # lint the toolbelt; CI enforces this
 for t in test/*.test.sh; do "$t"; done    # run backend and smoke-contract tests
 [ "$(readlink CLAUDE.md)" = "AGENTS.md" ]

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+# Backend helpers for firstmate's visible crew runtime.
+# Default backend is tmux. Set FM_BACKEND=orca or codex-app via
+# config/backend(.env) to use another visible crew backend.
+
+fm_backend_root() {
+  cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd
+}
+
+fm_backend_name() {
+  local root=${FM_ROOT:-$(fm_backend_root)} cfg line
+  if [ -n "${FM_BACKEND:-}" ]; then
+    echo "$FM_BACKEND"
+    return 0
+  fi
+  if [ -f "$root/config/backend" ]; then
+    cfg=$(tr -d '[:space:]' < "$root/config/backend" || true)
+    [ -n "$cfg" ] && { echo "$cfg"; return 0; }
+  fi
+  if [ -f "$root/config/backend.env" ]; then
+    line=$(grep -E '^[[:space:]]*FM_BACKEND=' "$root/config/backend.env" 2>/dev/null | tail -1 || true)
+    line=${line#*=}
+    line=${line%\"}
+    line=${line#\"}
+    line=${line%\'}
+    line=${line#\'}
+    line=$(printf '%s' "$line" | tr -d '[:space:]')
+    [ -n "$line" ] && { echo "$line"; return 0; }
+  fi
+  echo tmux
+}
+
+fm_meta_get() {
+  local key=$1 file=$2
+  grep "^$key=" "$file" 2>/dev/null | tail -1 | cut -d= -f2-
+}
+
+fm_backend_json_get() {
+  local expr=$1
+  node -e '
+const fs = require("fs");
+const input = fs.readFileSync(0, "utf8");
+const data = input.trim() ? JSON.parse(input) : {};
+const expr = process.argv[1].split(".");
+let cur = data;
+for (const part of expr) {
+  if (cur == null) break;
+  cur = cur[part];
+}
+if (cur != null) process.stdout.write(String(cur));
+' "$expr"
+}
+
+fm_backend_first_terminal() {
+  node -e '
+const fs = require("fs");
+const data = JSON.parse(fs.readFileSync(0, "utf8"));
+const terms = data.result && data.result.terminals || [];
+if (terms[0] && terms[0].handle) process.stdout.write(terms[0].handle);
+'
+}
+
+fm_backend_parse_worktree_create() {
+  # shellcheck disable=SC2016 # Node reads this script literally; shell expansion is not wanted.
+  node -e '
+const fs = require("fs");
+const data = JSON.parse(fs.readFileSync(0, "utf8"));
+let found = { id: "", path: "", terminal: "" };
+function walk(v) {
+  if (!v || typeof v !== "object") return;
+  if (!found.id && typeof v.worktreeId === "string") found.id = v.worktreeId;
+  if (!found.id && typeof v.id === "string" && v.id.includes("::")) found.id = v.id;
+  if (!found.path && typeof v.path === "string" && v.path.startsWith("/")) found.path = v.path;
+  if (!found.terminal && typeof v.handle === "string" && v.handle.startsWith("term_")) found.terminal = v.handle;
+  for (const value of Object.values(v)) walk(value);
+}
+walk(data.result || data);
+process.stdout.write(`${found.id}\t${found.path}\t${found.terminal}`);
+'
+}
+
+fm_backend_codex_config_path() {
+  if [ -n "${FM_ORCA_CODEX_CONFIG:-}" ]; then
+    echo "$FM_ORCA_CODEX_CONFIG"
+    return 0
+  fi
+  echo "$HOME/Library/Application Support/orca/codex-runtime-home/home/config.toml"
+}
+
+fm_backend_trust_codex_project() {
+  local project_path=$1 config_path
+  config_path=$(fm_backend_codex_config_path)
+  mkdir -p "$(dirname "$config_path")"
+  PROJECT_PATH="$project_path" CONFIG_PATH="$config_path" node <<'NODE'
+const fs = require("fs");
+
+const configPath = process.env.CONFIG_PATH;
+const projectPath = process.env.PROJECT_PATH;
+const key = projectPath.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+const header = `[projects."${key}"]`;
+
+let content = "";
+try {
+  content = fs.readFileSync(configPath, "utf8");
+} catch (error) {
+  if (error.code !== "ENOENT") throw error;
+}
+
+if (!content.includes(header)) {
+  const prefix = content.length && !content.endsWith("\n") ? "\n" : "";
+  fs.appendFileSync(configPath, `${prefix}\n${header}\ntrust_level = "trusted"\n`);
+}
+NODE
+}
+
+fm_backend_meta_for_selector() {
+  local selector=$1 root=${FM_ROOT:-$(fm_backend_root)} state meta base win thread_id
+  state="$root/state"
+  base=${selector#fm-}
+  if [ -f "$state/$base.meta" ]; then
+    echo "$state/$base.meta"
+    return 0
+  fi
+  for meta in "$state"/*.meta; do
+    [ -e "$meta" ] || continue
+    win=$(fm_meta_get window "$meta")
+    thread_id=$(fm_meta_get thread_id "$meta")
+    case "$selector" in
+      "$win"|fm-"$(basename "$meta" .meta)") echo "$meta"; return 0 ;;
+      "$thread_id") echo "$meta"; return 0 ;;
+      *) case "$win" in *:"$selector"|"$selector") echo "$meta"; return 0 ;; esac ;;
+    esac
+  done
+  return 1
+}
+
+fm_backend_tmux_resolve() {
+  case "$1" in
+    *:*) echo "$1" ;;
+    *) tmux list-windows -a -F '#{session_name}:#{window_name}' | grep -m1 ":$1\$" \
+       || { echo "error: no window named $1" >&2; return 1; } ;;
+  esac
+}
+
+fm_backend_capture() {
+  local meta=$1 lines=${2:-40} backend target terminal thread_id
+  backend=$(fm_meta_get backend "$meta")
+  [ -n "$backend" ] || backend=tmux
+  case "$backend" in
+    tmux)
+      target=$(fm_meta_get window "$meta")
+      tmux capture-pane -p -t "$target" -S -"$lines"
+      ;;
+    orca)
+      terminal=$(fm_meta_get terminal "$meta")
+      [ -n "$terminal" ] || { echo "error: no terminal= in $meta" >&2; return 1; }
+      orca terminal read --terminal "$terminal" --limit "$lines" --json \
+        | node -e '
+const fs = require("fs");
+const data = JSON.parse(fs.readFileSync(0, "utf8"));
+const r = data.result || {};
+if (r.terminal && Array.isArray(r.terminal.tail)) {
+  process.stdout.write(r.terminal.tail.join("\n"));
+} else {
+  process.stdout.write(r.text || r.output || r.content || r.preview || "");
+}
+'
+      ;;
+    codex-app)
+      thread_id=$(fm_meta_get thread_id "$meta")
+      [ -n "$thread_id" ] || { echo "error: no thread_id= in $meta" >&2; return 1; }
+      "${FM_ROOT:-$(fm_backend_root)}/bin/fm-codex-app" capture "$thread_id" "$lines"
+      ;;
+    *) echo "error: unknown backend '$backend'" >&2; return 1 ;;
+  esac
+}
+
+fm_backend_orca_terminal_text() {
+  local terminal=$1 lines=${2:-40}
+  orca terminal read --terminal "$terminal" --limit "$lines" --json \
+    | node -e '
+const fs = require("fs");
+const data = JSON.parse(fs.readFileSync(0, "utf8"));
+const r = data.result || {};
+if (r.terminal && Array.isArray(r.terminal.tail)) {
+  process.stdout.write(r.terminal.tail.join("\n"));
+} else {
+  process.stdout.write(r.text || r.output || r.content || r.preview || "");
+}
+'
+}
+
+fm_backend_send_text() {
+  local meta=$1 text=$2 backend target terminal thread_id root
+  backend=$(fm_meta_get backend "$meta")
+  [ -n "$backend" ] || backend=tmux
+  case "$backend" in
+    tmux)
+      target=$(fm_meta_get window "$meta")
+      tmux send-keys -t "$target" -l "$text"
+      case "$text" in /*) sleep 1.2 ;; *) sleep 0.3 ;; esac
+      tmux send-keys -t "$target" Enter
+      ;;
+    orca)
+      terminal=$(fm_meta_get terminal "$meta")
+      [ -n "$terminal" ] || { echo "error: no terminal= in $meta" >&2; return 1; }
+      orca terminal send --terminal "$terminal" --text "$text" --enter --json >/dev/null
+      ;;
+    codex-app)
+      root=${FM_ROOT:-$(fm_backend_root)}
+      thread_id=$(fm_meta_get thread_id "$meta")
+      [ -n "$thread_id" ] || { echo "error: no thread_id= in $meta" >&2; return 1; }
+      "$root/bin/fm-codex-app" send "$thread_id" "$text"
+      ;;
+    *) echo "error: unknown backend '$backend'" >&2; return 1 ;;
+  esac
+}
+
+fm_backend_send_key() {
+  local meta=$1 key=$2 backend target terminal thread_id
+  backend=$(fm_meta_get backend "$meta")
+  [ -n "$backend" ] || backend=tmux
+  case "$backend" in
+    tmux)
+      target=$(fm_meta_get window "$meta")
+      tmux send-keys -t "$target" "$key"
+      ;;
+    orca)
+      terminal=$(fm_meta_get terminal "$meta")
+      [ -n "$terminal" ] || { echo "error: no terminal= in $meta" >&2; return 1; }
+      case "$key" in
+        Escape|C-c) orca terminal send --terminal "$terminal" --interrupt --json >/dev/null ;;
+        Enter) orca terminal send --terminal "$terminal" --text "" --enter --json >/dev/null ;;
+        *) echo "error: unsupported Orca key '$key'" >&2; return 1 ;;
+      esac
+      ;;
+    codex-app)
+      thread_id=$(fm_meta_get thread_id "$meta")
+      [ -n "$thread_id" ] || { echo "error: no thread_id= in $meta" >&2; return 1; }
+      case "$key" in
+        Escape|C-c) "${FM_ROOT:-$(fm_backend_root)}/bin/fm-codex-app" interrupt "$thread_id" >/dev/null ;;
+        Enter) "${FM_ROOT:-$(fm_backend_root)}/bin/fm-codex-app" send "$thread_id" "" ;;
+        *) echo "error: unsupported Codex App key '$key'" >&2; return 1 ;;
+      esac
+      ;;
+    *) echo "error: unknown backend '$backend'" >&2; return 1 ;;
+  esac
+}

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Backend helpers for firstmate's visible crew runtime.
-# Default backend is tmux. Set FM_BACKEND=orca or codex-app via
+# Default backend is tmux. Set FM_BACKEND=orca, codex-app, or opencode-server via
 # config/backend(.env) to use another visible crew backend.
 
 fm_backend_root() {
@@ -114,7 +114,7 @@ NODE
 }
 
 fm_backend_meta_for_selector() {
-  local selector=$1 root=${FM_ROOT:-$(fm_backend_root)} state meta base win thread_id
+  local selector=$1 root=${FM_ROOT:-$(fm_backend_root)} state meta base win thread_id opencode_session_id
   state="$root/state"
   base=${selector#fm-}
   if [ -f "$state/$base.meta" ]; then
@@ -125,9 +125,11 @@ fm_backend_meta_for_selector() {
     [ -e "$meta" ] || continue
     win=$(fm_meta_get window "$meta")
     thread_id=$(fm_meta_get thread_id "$meta")
+    opencode_session_id=$(fm_meta_get opencode_session_id "$meta")
     case "$selector" in
       "$win"|fm-"$(basename "$meta" .meta)") echo "$meta"; return 0 ;;
       "$thread_id") echo "$meta"; return 0 ;;
+      "$opencode_session_id") echo "$meta"; return 0 ;;
       *) case "$win" in *:"$selector"|"$selector") echo "$meta"; return 0 ;; esac ;;
     esac
   done
@@ -143,7 +145,7 @@ fm_backend_tmux_resolve() {
 }
 
 fm_backend_capture() {
-  local meta=$1 lines=${2:-40} backend target terminal thread_id
+  local meta=$1 lines=${2:-40} backend target terminal thread_id server_url opencode_session_id
   backend=$(fm_meta_get backend "$meta")
   [ -n "$backend" ] || backend=tmux
   case "$backend" in
@@ -171,6 +173,13 @@ if (r.terminal && Array.isArray(r.terminal.tail)) {
       [ -n "$thread_id" ] || { echo "error: no thread_id= in $meta" >&2; return 1; }
       "${FM_ROOT:-$(fm_backend_root)}/bin/fm-codex-app" capture "$thread_id" "$lines"
       ;;
+    opencode-server)
+      server_url=$(fm_meta_get opencode_server_url "$meta")
+      opencode_session_id=$(fm_meta_get opencode_session_id "$meta")
+      [ -n "$server_url" ] || { echo "error: no opencode_server_url= in $meta" >&2; return 1; }
+      [ -n "$opencode_session_id" ] || { echo "error: no opencode_session_id= in $meta" >&2; return 1; }
+      "${FM_ROOT:-$(fm_backend_root)}/bin/fm-opencode-server" capture "$server_url" "$opencode_session_id" "$lines"
+      ;;
     *) echo "error: unknown backend '$backend'" >&2; return 1 ;;
   esac
 }
@@ -191,7 +200,7 @@ if (r.terminal && Array.isArray(r.terminal.tail)) {
 }
 
 fm_backend_send_text() {
-  local meta=$1 text=$2 backend target terminal thread_id root
+  local meta=$1 text=$2 backend target terminal thread_id root server_url opencode_session_id
   backend=$(fm_meta_get backend "$meta")
   [ -n "$backend" ] || backend=tmux
   case "$backend" in
@@ -212,12 +221,20 @@ fm_backend_send_text() {
       [ -n "$thread_id" ] || { echo "error: no thread_id= in $meta" >&2; return 1; }
       "$root/bin/fm-codex-app" send "$thread_id" "$text"
       ;;
+    opencode-server)
+      root=${FM_ROOT:-$(fm_backend_root)}
+      server_url=$(fm_meta_get opencode_server_url "$meta")
+      opencode_session_id=$(fm_meta_get opencode_session_id "$meta")
+      [ -n "$server_url" ] || { echo "error: no opencode_server_url= in $meta" >&2; return 1; }
+      [ -n "$opencode_session_id" ] || { echo "error: no opencode_session_id= in $meta" >&2; return 1; }
+      "$root/bin/fm-opencode-server" send "$server_url" "$opencode_session_id" "$text" >/dev/null
+      ;;
     *) echo "error: unknown backend '$backend'" >&2; return 1 ;;
   esac
 }
 
 fm_backend_send_key() {
-  local meta=$1 key=$2 backend target terminal thread_id
+  local meta=$1 key=$2 backend target terminal thread_id server_url opencode_session_id root
   backend=$(fm_meta_get backend "$meta")
   [ -n "$backend" ] || backend=tmux
   case "$backend" in
@@ -242,6 +259,50 @@ fm_backend_send_key() {
         Enter) "${FM_ROOT:-$(fm_backend_root)}/bin/fm-codex-app" send "$thread_id" "" ;;
         *) echo "error: unsupported Codex App key '$key'" >&2; return 1 ;;
       esac
+      ;;
+    opencode-server)
+      root=${FM_ROOT:-$(fm_backend_root)}
+      server_url=$(fm_meta_get opencode_server_url "$meta")
+      opencode_session_id=$(fm_meta_get opencode_session_id "$meta")
+      [ -n "$server_url" ] || { echo "error: no opencode_server_url= in $meta" >&2; return 1; }
+      [ -n "$opencode_session_id" ] || { echo "error: no opencode_session_id= in $meta" >&2; return 1; }
+      case "$key" in
+        Escape|C-c) "$root/bin/fm-opencode-server" interrupt "$server_url" "$opencode_session_id" >/dev/null ;;
+        Enter) "$root/bin/fm-opencode-server" send "$server_url" "$opencode_session_id" "" >/dev/null ;;
+        *) echo "error: unsupported OpenCode server key '$key'" >&2; return 1 ;;
+      esac
+      ;;
+    *) echo "error: unknown backend '$backend'" >&2; return 1 ;;
+  esac
+}
+
+fm_backend_status() {
+  local meta=$1 backend target terminal thread_id server_url opencode_session_id root
+  backend=$(fm_meta_get backend "$meta")
+  [ -n "$backend" ] || backend=tmux
+  case "$backend" in
+    tmux)
+      target=$(fm_meta_get window "$meta")
+      if tmux display-message -p -t "$target" '#{pane_pid}' >/dev/null 2>&1; then echo status=present; else echo status=missing; fi
+      ;;
+    orca)
+      terminal=$(fm_meta_get terminal "$meta")
+      [ -n "$terminal" ] || { echo "error: no terminal= in $meta" >&2; return 1; }
+      if orca terminal read --terminal "$terminal" --limit 1 --json >/dev/null 2>&1; then echo status=present; else echo status=missing; fi
+      ;;
+    codex-app)
+      root=${FM_ROOT:-$(fm_backend_root)}
+      thread_id=$(fm_meta_get thread_id "$meta")
+      [ -n "$thread_id" ] || { echo "error: no thread_id= in $meta" >&2; return 1; }
+      "$root/bin/fm-codex-app" status "$thread_id"
+      ;;
+    opencode-server)
+      root=${FM_ROOT:-$(fm_backend_root)}
+      server_url=$(fm_meta_get opencode_server_url "$meta")
+      opencode_session_id=$(fm_meta_get opencode_session_id "$meta")
+      [ -n "$server_url" ] || { echo "error: no opencode_server_url= in $meta" >&2; return 1; }
+      [ -n "$opencode_session_id" ] || { echo "error: no opencode_session_id= in $meta" >&2; return 1; }
+      "$root/bin/fm-opencode-server" status "$server_url" "$opencode_session_id"
       ;;
     *) echo "error: unknown backend '$backend'" >&2; return 1 ;;
   esac

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -4,6 +4,7 @@
 #          Detect: prints one line per problem and exits 0. Silent = all good.
 #          Lines: "MISSING: <tool> (install: <command>)", "NEEDS_GH_AUTH",
 #                 "CREW_HARNESS_OVERRIDE: <name>", "FLEET_SYNC: <repo>: skipped: <reason>".
+#          Tool detection is backend-specific from FM_BACKEND/config/backend(.env).
 #          Fleet sync fetches, fast-forwards, and prunes gone local branches;
 #          it is bounded by FM_FLEET_SYNC_BOOTSTRAP_TIMEOUT, default 20s.
 #          Set FM_FLEET_PRUNE=0 to skip branch pruning during that refresh.
@@ -12,6 +13,8 @@
 set -u
 
 FM_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=bin/fm-backend.sh
+. "$FM_ROOT/bin/fm-backend.sh"
 
 fleet_sync() {
   [ -x "$FM_ROOT/bin/fm-fleet-sync.sh" ] || return 0
@@ -53,7 +56,8 @@ fleet_sync() {
 
 install_cmd() {
   case "$1" in
-    tmux|node|gh) echo "brew install $1  # or the platform's package manager" ;;
+    tmux|node|gh|orca) echo "brew install $1  # or the platform's package manager" ;;
+    codex) echo "curl -fsSL https://chatgpt.com/codex/install.sh | sh" ;;
     treehouse) echo "curl -fsSL https://kunchenguid.github.io/treehouse/install.sh | sh" ;;
     no-mistakes) echo "curl -fsSL https://raw.githubusercontent.com/kunchenguid/no-mistakes/main/docs/install.sh | sh" ;;
     gh-axi|chrome-devtools-axi|lavish-axi) echo "npm install -g $1 && $1 setup hooks" ;;
@@ -61,7 +65,13 @@ install_cmd() {
   esac
 }
 
-TOOLS="tmux node gh treehouse no-mistakes gh-axi chrome-devtools-axi lavish-axi"
+BACKEND=$(fm_backend_name)
+case "$BACKEND" in
+  tmux) TOOLS="tmux node gh treehouse no-mistakes gh-axi chrome-devtools-axi lavish-axi" ;;
+  orca) TOOLS="orca node gh no-mistakes gh-axi chrome-devtools-axi lavish-axi" ;;
+  codex-app) TOOLS="node gh no-mistakes gh-axi chrome-devtools-axi lavish-axi" ;;
+  *) TOOLS="node gh no-mistakes gh-axi chrome-devtools-axi lavish-axi" ;;
+esac
 
 if [ "${1:-}" = "install" ]; then
   shift

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -58,6 +58,7 @@ install_cmd() {
   case "$1" in
     tmux|node|gh|orca) echo "brew install $1  # or the platform's package manager" ;;
     codex) echo "curl -fsSL https://chatgpt.com/codex/install.sh | sh" ;;
+    opencode) echo "npm install -g opencode-ai" ;;
     treehouse) echo "curl -fsSL https://kunchenguid.github.io/treehouse/install.sh | sh" ;;
     no-mistakes) echo "curl -fsSL https://raw.githubusercontent.com/kunchenguid/no-mistakes/main/docs/install.sh | sh" ;;
     gh-axi|chrome-devtools-axi|lavish-axi) echo "npm install -g $1 && $1 setup hooks" ;;
@@ -70,6 +71,7 @@ case "$BACKEND" in
   tmux) TOOLS="tmux node gh treehouse no-mistakes gh-axi chrome-devtools-axi lavish-axi" ;;
   orca) TOOLS="orca node gh no-mistakes gh-axi chrome-devtools-axi lavish-axi" ;;
   codex-app) TOOLS="node gh no-mistakes gh-axi chrome-devtools-axi lavish-axi" ;;
+  opencode-server) TOOLS="opencode node gh no-mistakes gh-axi chrome-devtools-axi lavish-axi" ;;
   *) TOOLS="node gh no-mistakes gh-axi chrome-devtools-axi lavish-axi" ;;
 esac
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -43,7 +43,7 @@ You are a crewmate: an autonomous worker agent managed by firstmate. Work on you
 {TASK}
 
 # Setup
-You are in a disposable git worktree of $REPO, at a detached HEAD on a clean default branch.
+You are in a disposable git worktree of $REPO, created from a clean default-branch base.
 This is a SCOUT task: the deliverable is a written report, not a PR.
 The worktree is your laboratory - install, run, edit, and make scratch commits freely; all of it is discarded at teardown.
 The report is the only thing that survives, so anything worth keeping must be in it.
@@ -57,7 +57,7 @@ The report is the only thing that survives, so anything worth keeping must be in
    States: working, needs-decision, blocked, done, failed.
    Each append wakes firstmate, so report sparingly: only phase changes a supervisor
    would act on and the needs-decision/blocked/done/failed states. No step-by-step
-   FYI progress lines; firstmate reads your pane for that.
+   FYI progress lines; firstmate reads your visible session for that.
 5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
 6. If a decision belongs to a human (product choices, destructive actions),
    append \`needs-decision: {summary of options}\` and stop. Firstmate will reply with the decision.
@@ -127,8 +127,8 @@ You are a crewmate: an autonomous worker agent managed by firstmate. Work on you
 {TASK}
 
 # Setup
-You are in a disposable git worktree of $REPO, at a detached HEAD on a clean default branch.
-1. First action: create your branch: \`git checkout -b fm/$ID\`$SETUP2
+You are in a disposable git worktree of $REPO, created from a clean default-branch base.
+1. First action: create or switch to your task branch: \`git checkout -B fm/$ID\`$SETUP2
 
 # Rules
 $RULE1
@@ -140,7 +140,7 @@ $RULE1
    Each append wakes firstmate, so report sparingly: only phase changes a supervisor
    would act on (setup done, bug reproduced, fix implemented, validation passed) and the
    needs-decision/blocked/done/failed states. No step-by-step FYI progress lines;
-   firstmate reads your pane for that.
+   firstmate reads your visible session for that.
 5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
 6. If a decision belongs to a human (product choices, destructive actions, ask-user findings),
    append \`needs-decision: {summary of options}\` and stop. Firstmate will reply with the decision.

--- a/bin/fm-codex-app
+++ b/bin/fm-codex-app
@@ -1,0 +1,319 @@
+#!/usr/bin/env node
+// Firstmate Codex App visible-thread ledger.
+// Visible Codex App threads are owned by the Codex Desktop host. This helper
+// records local task state and refuses to masquerade as the host thread API.
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const ROOT = process.env.FM_ROOT || path.resolve(__dirname, "..");
+const STATE = path.join(ROOT, "state");
+
+function usage() {
+  console.error(`usage:
+  fm-codex-app prepare <task-id> <thread-name> <brief-file>
+  fm-codex-app record-thread <task-id> <thread-id> [--turn-id <id>] [--worktree <path>] [--pending-worktree-id <id>]
+  fm-codex-app adopt-thread <task-id> <thread-id> <project-path> --kind <ship|scout> [--thread-name <name>] [--mode <mode>] [--yolo <on|off>] [--worktree <path>] [--turn-id <id>] [--pending-worktree-id <id>] [--brief <path>]
+  fm-codex-app record-pending <task-id> <pending-worktree-id>
+  fm-codex-app record-capture <task-id> <capture-file|->
+  fm-codex-app mark-archived <task-id>
+  fm-codex-app capture <thread-id> [lines]
+  fm-codex-app send <thread-id> <text>
+  fm-codex-app interrupt <thread-id>
+  fm-codex-app archive <thread-id>
+  fm-codex-app status <thread-id>`);
+  process.exit(2);
+}
+
+function ensureState() {
+  fs.mkdirSync(STATE, { recursive: true });
+}
+
+function metaPath(taskId) {
+  return path.join(STATE, `${taskId}.meta`);
+}
+
+function parseMeta(content) {
+  const values = {};
+  for (const line of content.split(/\r?\n/)) {
+    if (!line || line.startsWith("#")) continue;
+    const idx = line.indexOf("=");
+    if (idx === -1) continue;
+    values[line.slice(0, idx)] = line.slice(idx + 1);
+  }
+  return values;
+}
+
+function readMeta(taskId) {
+  const file = metaPath(taskId);
+  try {
+    return parseMeta(fs.readFileSync(file, "utf8"));
+  } catch (error) {
+    if (error.code === "ENOENT") throw new Error(`no meta for task ${taskId} at ${file}`);
+    throw error;
+  }
+}
+
+function ensureMetaExists(taskId, action) {
+  if (!fs.existsSync(metaPath(taskId))) {
+    throw new Error(`${action} requires existing meta for task ${taskId}; run prepare or adopt-thread first`);
+  }
+}
+
+function writeMeta(taskId, values) {
+  ensureState();
+  const file = metaPath(taskId);
+  let current = {};
+  try {
+    current = parseMeta(fs.readFileSync(file, "utf8"));
+  } catch (error) {
+    if (error.code !== "ENOENT") throw error;
+  }
+  const next = Object.fromEntries(Object.entries(values).filter(([, value]) => value !== undefined && value !== null));
+  const merged = { ...current, ...next };
+  const body = Object.entries(merged)
+    .filter(([, value]) => value !== undefined && value !== null)
+    .map(([key, value]) => `${key}=${value}`)
+    .join("\n");
+  fs.writeFileSync(file, `${body}\n`);
+}
+
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function resolveProjectMode(projectPath) {
+  const projectName = path.basename(String(projectPath || "").replace(/\/+$/, ""));
+  const fallback = { mode: "no-mistakes", yolo: "off" };
+  if (!projectName) return fallback;
+
+  const registry = path.join(ROOT, "data", "projects.md");
+  let content;
+  try {
+    content = fs.readFileSync(registry, "utf8");
+  } catch (error) {
+    if (error.code !== "ENOENT") throw error;
+    return fallback;
+  }
+
+  const linePattern = new RegExp(`^-\\s+${escapeRegex(projectName)}(?:\\s+\\[([^\\]]+)\\])?\\s+-\\s+`);
+  for (const line of content.split(/\r?\n/)) {
+    const match = line.match(linePattern);
+    if (!match) continue;
+    const tokens = String(match[1] || "").trim().split(/\s+/).filter(Boolean);
+    let mode = "no-mistakes";
+    let yolo = "off";
+    if (tokens[0] && tokens[0] !== "+yolo") mode = tokens[0];
+    if (tokens.includes("+yolo")) yolo = "on";
+    if (!["no-mistakes", "direct-PR", "local-only"].includes(mode)) return fallback;
+    return { mode, yolo };
+  }
+  return fallback;
+}
+
+function taskForThread(threadId) {
+  let matches = [];
+  try {
+    matches = fs.readdirSync(STATE).filter((name) => name.endsWith(".meta"));
+  } catch (error) {
+    if (error.code === "ENOENT") return null;
+    throw error;
+  }
+  for (const name of matches) {
+    const taskId = name.slice(0, -5);
+    const meta = readMeta(taskId);
+    if (meta.thread_id === threadId) return { taskId, meta };
+  }
+  return null;
+}
+
+function parseFlags(args) {
+  const flags = {};
+  for (let i = 0; i < args.length; i += 1) {
+    const key = args[i];
+    if (!key.startsWith("--")) throw new Error(`unexpected argument '${key}'`);
+    const value = args[i + 1];
+    if (!value || value.startsWith("--")) throw new Error(`missing value for ${key}`);
+    flags[key.slice(2).replace(/-/g, "_")] = value;
+    i += 1;
+  }
+  return flags;
+}
+
+function lastLines(text, limit) {
+  const lines = String(text || "").replace(/\r?\n$/, "").split(/\r?\n/);
+  return lines.slice(Math.max(0, lines.length - limit)).join("\n");
+}
+
+function hostToolMessage(action, threadId, taskId) {
+  const suffix = taskId ? ` for task ${taskId}` : "";
+  switch (action) {
+    case "capture":
+      return `Codex App thread ${threadId}${suffix} is app-owned. Use read_thread in Codex Desktop, then optionally cache the text with: bin/fm-codex-app record-capture ${taskId || "<task-id>"} <file|->`;
+    case "send":
+      return `Codex App thread ${threadId}${suffix} is app-owned. Use send_message_to_thread(threadId=${threadId}, prompt=...) in Codex Desktop.`;
+    case "interrupt":
+      return `Codex App thread ${threadId}${suffix} is app-owned. Interrupt it from Codex Desktop, or use handoff_thread when moving a running thread.`;
+    case "archive":
+      return `Codex App thread ${threadId}${suffix} is app-owned. Use set_thread_archived(threadId=${threadId}, archived=true), then run: bin/fm-codex-app mark-archived ${taskId || "<task-id>"}`;
+    default:
+      return `Codex App thread ${threadId}${suffix} is app-owned. Use the Codex Desktop thread tools.`;
+  }
+}
+
+async function main() {
+  const [cmd, ...args] = process.argv.slice(2);
+  if (!cmd) usage();
+
+  if (cmd === "prepare") {
+    const [taskId, threadName, briefFile] = args;
+    if (!taskId || !threadName || !briefFile) usage();
+    if (!fs.existsSync(briefFile)) throw new Error(`brief not found: ${briefFile}`);
+    writeMeta(taskId, {
+      backend: "codex-app",
+      window: threadName,
+      harness: "codex",
+      codex_app_thread_state: "pending",
+      codex_app_pending_action: "create_thread_or_fork_thread",
+      codex_app_brief: briefFile,
+      codex_app_transport: "visible-thread",
+    });
+    console.log(`prepared_thread_name=${threadName}`);
+    console.log(`brief=${briefFile}`);
+    console.log("next=create_thread_or_fork_thread");
+    return;
+  }
+
+  if (cmd === "record-thread") {
+    const [taskId, threadId, ...rest] = args;
+    if (!taskId || !threadId) usage();
+    ensureMetaExists(taskId, "record-thread");
+    const flags = parseFlags(rest);
+    const existing = taskForThread(threadId);
+    if (existing && existing.taskId !== taskId) {
+      throw new Error(`thread ${threadId} is already recorded for task ${existing.taskId}`);
+    }
+    writeMeta(taskId, {
+      thread_id: threadId,
+      turn_id: flags.turn_id,
+      worktree: flags.worktree,
+      codex_app_pending_worktree_id: flags.pending_worktree_id,
+      codex_app_thread_state: "visible",
+      codex_app_pending_action: "none",
+      codex_app_transport: "visible-thread",
+    });
+    console.log(`recorded_thread_id=${threadId}`);
+    return;
+  }
+
+  if (cmd === "adopt-thread") {
+    const [taskId, threadId, projectPath, ...rest] = args;
+    if (!taskId || !threadId || !projectPath) usage();
+    const flags = parseFlags(rest);
+    if (fs.existsSync(metaPath(taskId))) throw new Error(`task ${taskId} already has meta at ${metaPath(taskId)}`);
+    const existing = taskForThread(threadId);
+    if (existing) throw new Error(`thread ${threadId} is already recorded for task ${existing.taskId}`);
+    const kind = flags.kind;
+    if (kind !== "ship" && kind !== "scout") throw new Error("adopt-thread requires --kind ship or --kind scout");
+    const projectMode = resolveProjectMode(projectPath);
+    writeMeta(taskId, {
+      backend: "codex-app",
+      window: flags.thread_name || `fm-${taskId}`,
+      worktree: flags.worktree || "",
+      project: projectPath,
+      harness: flags.harness || "codex",
+      kind,
+      mode: flags.mode || projectMode.mode,
+      yolo: flags.yolo || projectMode.yolo,
+      thread_id: threadId,
+      turn_id: flags.turn_id,
+      codex_app_pending_worktree_id: flags.pending_worktree_id,
+      codex_app_thread_state: "visible",
+      codex_app_pending_action: "none",
+      codex_app_transport: "visible-thread",
+      codex_app_brief: flags.brief,
+    });
+    console.log(`adopted_thread_id=${threadId}`);
+    return;
+  }
+
+  if (cmd === "record-pending") {
+    const [taskId, pendingWorktreeId] = args;
+    if (!taskId || !pendingWorktreeId) usage();
+    ensureMetaExists(taskId, "record-pending");
+    writeMeta(taskId, {
+      codex_app_pending_worktree_id: pendingWorktreeId,
+      codex_app_thread_state: "pending-worktree",
+      codex_app_pending_action: "await_thread_id",
+      codex_app_transport: "visible-thread",
+    });
+    console.log(`recorded_pending_worktree_id=${pendingWorktreeId}`);
+    return;
+  }
+
+  if (cmd === "record-capture") {
+    const [taskId, captureFile] = args;
+    if (!taskId || !captureFile) usage();
+    ensureMetaExists(taskId, "record-capture");
+    const text = captureFile === "-" ? fs.readFileSync(0, "utf8") : fs.readFileSync(captureFile, "utf8");
+    ensureState();
+    fs.writeFileSync(path.join(STATE, `${taskId}.codex-app.capture`), text);
+    writeMeta(taskId, { codex_app_last_capture: new Date().toISOString() });
+    console.log(`recorded_capture_task=${taskId}`);
+    return;
+  }
+
+  if (cmd === "mark-archived") {
+    const [taskId] = args;
+    if (!taskId) usage();
+    ensureMetaExists(taskId, "mark-archived");
+    writeMeta(taskId, {
+      codex_app_archived: "1",
+      codex_app_thread_state: "archived",
+      codex_app_pending_action: "none",
+    });
+    console.log(`marked_archived_task=${taskId}`);
+    return;
+  }
+
+  if (cmd === "capture") {
+    const [threadId, linesArg] = args;
+    if (!threadId) usage();
+    const found = taskForThread(threadId);
+    const limit = Number(linesArg || 40);
+    if (found) {
+      const file = path.join(STATE, `${found.taskId}.codex-app.capture`);
+      if (fs.existsSync(file)) {
+        console.log(lastLines(fs.readFileSync(file, "utf8"), Number.isFinite(limit) && limit > 0 ? limit : 40));
+        return;
+      }
+    }
+    console.error(`error: ${hostToolMessage("capture", threadId, found?.taskId)}`);
+    process.exit(2);
+  }
+
+  if (cmd === "status") {
+    const [threadId] = args;
+    if (!threadId) usage();
+    const found = taskForThread(threadId);
+    if (!found) throw new Error(`thread ${threadId} is not recorded in ${STATE}`);
+    console.log(`status=${found.meta.codex_app_thread_state || "visible"}`);
+    if (found.meta.turn_id) console.log(`turn_id=${found.meta.turn_id}`);
+    return;
+  }
+
+  if (cmd === "send" || cmd === "interrupt" || cmd === "archive") {
+    const [threadId] = args;
+    if (!threadId) usage();
+    const found = taskForThread(threadId);
+    console.error(`error: ${hostToolMessage(cmd, threadId, found?.taskId)}`);
+    process.exit(2);
+  }
+
+  usage();
+}
+
+main().catch((error) => {
+  console.error(`error: ${error.message}`);
+  process.exit(1);
+});

--- a/bin/fm-codex-app-smoke-check.sh
+++ b/bin/fm-codex-app-smoke-check.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Validate a Codex App visible-thread smoke evidence transcript.
+# Usage: fm-codex-app-smoke-check.sh <transcript-file>
+# The transcript is intentionally simple key-value evidence, so humans can paste
+# it into reports and CI can reject headless app-server "success" as insufficient.
+set -eu
+
+FILE=${1:-}
+[ -n "$FILE" ] && [ -f "$FILE" ] || { echo "usage: fm-codex-app-smoke-check.sh <transcript-file>" >&2; exit 2; }
+
+require() {
+  local key=$1
+  if ! grep -Eq "^$key=(ok|yes|true|1)$" "$FILE"; then
+    echo "FAIL: missing $key=ok" >&2
+    exit 1
+  fi
+}
+
+if grep -Eq '^(app_server_only|headless_only)=(ok|yes|true|1)$' "$FILE"; then
+  echo "FAIL: app-server/headless-only evidence is not a visible Codex App smoke" >&2
+  exit 1
+fi
+
+require visible_thread
+require list_threads
+require read_thread
+require send_message_to_thread
+require archive
+require restart_reconcile
+
+echo "codex-app visible smoke: passed"

--- a/bin/fm-opencode-server
+++ b/bin/fm-opencode-server
@@ -1,0 +1,430 @@
+#!/usr/bin/env node
+// Firstmate OpenCode server backend helper.
+// Owns one headless OpenCode server per task worktree and talks to its HTTP API.
+
+const fs = require("node:fs");
+const http = require("node:http");
+const https = require("node:https");
+const net = require("node:net");
+const path = require("node:path");
+const { spawn, spawnSync } = require("node:child_process");
+
+const ROOT = process.env.FM_ROOT || path.resolve(__dirname, "..");
+const STATE = path.join(ROOT, "state");
+const MOCK = process.env.FM_OPENCODE_SERVER_MOCK === "1";
+let HYBRID_OPENCODE;
+
+function usage() {
+  console.error(`usage:
+  fm-opencode-server start <task-id> <session-title> <worktree> <brief-file>
+  fm-opencode-server capture <server-url> <session-id> [lines]
+  fm-opencode-server send <server-url> <session-id> <text>
+  fm-opencode-server interrupt <server-url> <session-id>
+  fm-opencode-server status <server-url> <session-id>
+  fm-opencode-server close <server-url> <session-id> [server-pid]`);
+  process.exit(2);
+}
+
+function ensureState() {
+  fs.mkdirSync(STATE, { recursive: true });
+}
+
+function isWindows() {
+  return process.platform === "win32";
+}
+
+function requireOpenCode() {
+  const result = spawnSync("opencode", ["--version"], {
+    stdio: "ignore",
+    shell: isWindows(),
+    windowsHide: true,
+  });
+  if (result.error && result.error.code === "ENOENT") {
+    throw new Error("FM_BACKEND=opencode-server but opencode is not installed");
+  }
+  if (result.error) throw result.error;
+  if (result.status !== 0) throw new Error("FM_BACKEND=opencode-server but opencode --version failed");
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function findFreePort(host) {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.on("error", reject);
+    server.listen(0, host, () => {
+      const address = server.address();
+      server.close(() => resolve(address.port));
+    });
+  });
+}
+
+function commandPath(command) {
+  if (process.platform === "win32") {
+    const result = spawnSync("where", [command], { encoding: "utf8", windowsHide: true });
+    return result.status === 0 ? result.stdout.split(/\r?\n/)[0].trim() : "";
+  }
+  const result = spawnSync("sh", ["-lc", `command -v ${command}`], { encoding: "utf8" });
+  return result.status === 0 ? result.stdout.trim().split(/\r?\n/)[0] : "";
+}
+
+function isWslWindowsOpenCode() {
+  if (HYBRID_OPENCODE !== undefined) return HYBRID_OPENCODE;
+  HYBRID_OPENCODE = false;
+  if (process.platform !== "linux") return false;
+  const opencodePath = commandPath("opencode");
+  if (!opencodePath.startsWith("/mnt/")) return false;
+  try {
+    HYBRID_OPENCODE = fs.readFileSync(opencodePath, "utf8").includes("opencode.exe");
+  } catch {
+    HYBRID_OPENCODE = false;
+  }
+  return HYBRID_OPENCODE;
+}
+
+function windowsEnv(name) {
+  if (!isWslWindowsOpenCode()) return "";
+  const result = spawnSync("cmd.exe", ["/d", "/s", "/c", `set ${name}`], { encoding: "utf8", windowsHide: true });
+  if (result.status !== 0) return "";
+  const prefix = `${name}=`;
+  const line = result.stdout.split(/\r?\n/).find((entry) => entry.startsWith(prefix));
+  return line ? line.slice(prefix.length) : "";
+}
+
+function wslGatewayAddress() {
+  try {
+    const route = fs.readFileSync("/proc/net/route", "utf8").split(/\r?\n/);
+    for (const line of route.slice(1)) {
+      const fields = line.trim().split(/\s+/);
+      if (fields[1] !== "00000000" || !fields[2]) continue;
+      const hex = fields[2].match(/../g);
+      if (!hex) continue;
+      return hex.reverse().map((part) => parseInt(part, 16)).join(".");
+    }
+  } catch {
+    // Fall through to localhost below.
+  }
+  return "127.0.0.1";
+}
+
+function serverHosts(hybrid = isWslWindowsOpenCode()) {
+  if (process.env.FM_OPENCODE_SERVER_HOST) {
+    return { bind: process.env.FM_OPENCODE_SERVER_HOST, connect: process.env.FM_OPENCODE_SERVER_HOST };
+  }
+  if (hybrid) {
+    return { bind: "0.0.0.0", connect: wslGatewayAddress() };
+  }
+  return { bind: "127.0.0.1", connect: "127.0.0.1" };
+}
+
+function authHeaders(headers = {}) {
+  const password = process.env.OPENCODE_SERVER_PASSWORD || windowsEnv("OPENCODE_SERVER_PASSWORD");
+  if (!password) return headers;
+  const username = process.env.OPENCODE_SERVER_USERNAME || windowsEnv("OPENCODE_SERVER_USERNAME") || "opencode";
+  return {
+    ...headers,
+    Authorization: `Basic ${Buffer.from(`${username}:${password}`).toString("base64")}`,
+  };
+}
+
+function request(method, serverUrl, route, body, ok = [200]) {
+  const url = new URL(route, serverUrl.endsWith("/") ? serverUrl : `${serverUrl}/`);
+  const transport = url.protocol === "https:" ? https : http;
+  const payload = body === undefined ? undefined : JSON.stringify(body);
+  const headers = authHeaders(payload ? { "Content-Type": "application/json", "Content-Length": Buffer.byteLength(payload) } : {});
+
+  return new Promise((resolve, reject) => {
+    const req = transport.request(
+      url,
+      {
+        method,
+        headers,
+        timeout: Number(process.env.FM_OPENCODE_SERVER_HTTP_TIMEOUT_MS || 10000),
+      },
+      (res) => {
+        const chunks = [];
+        res.on("data", (chunk) => chunks.push(chunk));
+        res.on("end", () => {
+          const text = Buffer.concat(chunks).toString("utf8");
+          if (!ok.includes(res.statusCode)) {
+            reject(new Error(`${method} ${route} failed with HTTP ${res.statusCode}: ${text}`));
+            return;
+          }
+          if (!text.trim()) {
+            resolve(undefined);
+            return;
+          }
+          try {
+            resolve(JSON.parse(text));
+          } catch {
+            resolve(text);
+          }
+        });
+      },
+    );
+    req.on("timeout", () => req.destroy(new Error(`${method} ${route} timed out`)));
+    req.on("error", reject);
+    if (payload) req.write(payload);
+    req.end();
+  });
+}
+
+async function waitForHealth(serverUrl, child) {
+  const deadline = Date.now() + Number(process.env.FM_OPENCODE_SERVER_START_TIMEOUT_MS || 30000);
+  let exit = null;
+  let lastError = "";
+  child.once("exit", (code, signal) => {
+    exit = signal || String(code);
+  });
+  while (Date.now() < deadline) {
+    if (exit !== null) throw new Error(`opencode serve exited before becoming healthy (${exit})`);
+    try {
+      const health = await request("GET", serverUrl, "/global/health", undefined, [200]);
+      if (health && health.healthy) return health;
+    } catch (error) {
+      lastError = error.message;
+      // Keep polling until the startup deadline.
+    }
+    await sleep(250);
+  }
+  throw new Error(`opencode serve did not become healthy at ${serverUrl}${lastError ? ` (${lastError})` : ""}`);
+}
+
+function sessionRoute(sessionId, suffix = "") {
+  return `/session/${encodeURIComponent(sessionId)}${suffix}`;
+}
+
+function promptBody(text) {
+  return {
+    agent: "build",
+    parts: [{ type: "text", text }],
+  };
+}
+
+async function ensureSession(serverUrl, title) {
+  const sessions = await request("GET", serverUrl, "/session", undefined, [200]);
+  const existing = Array.isArray(sessions) ? sessions.find((session) => session.title === title) : undefined;
+  if (existing && existing.id) return existing;
+  const created = await request("POST", serverUrl, "/session", { title }, [200]);
+  if (!created || !created.id) throw new Error("opencode server did not return a session id");
+  return created;
+}
+
+async function sendPrompt(serverUrl, sessionId, text) {
+  await request("POST", serverUrl, sessionRoute(sessionId, "/prompt_async"), promptBody(text), [200, 204]);
+}
+
+function killPid(pid) {
+  const parsed = Number(pid || 0);
+  if (!Number.isFinite(parsed) || parsed <= 0) return;
+  if (isWindows()) {
+    spawnSync("taskkill", ["/PID", String(parsed), "/T", "/F"], { stdio: "ignore", windowsHide: true });
+    return;
+  }
+  try {
+    process.kill(-parsed, "SIGTERM");
+  } catch {
+    try {
+      process.kill(parsed, "SIGTERM");
+    } catch {
+      return;
+    }
+  }
+}
+
+async function closeServer(serverUrl, sessionId, pid) {
+  if (MOCK) {
+    console.log(`closed_session_id=${sessionId}`);
+    return;
+  }
+  if (serverUrl && sessionId) {
+    await request("POST", serverUrl, sessionRoute(sessionId, "/abort"), undefined, [200, 404]).catch(() => undefined);
+    await request("DELETE", serverUrl, sessionRoute(sessionId), undefined, [200, 404]).catch(() => undefined);
+  }
+  if (serverUrl) {
+    await request("POST", serverUrl, "/instance/dispose", undefined, [200, 404]).catch(() => undefined);
+  }
+  await sleep(500);
+  killPid(pid);
+}
+
+function partText(part) {
+  if (!part || typeof part !== "object") return "";
+  if (part.type === "text" || part.type === "reasoning") return part.text || "";
+  if (part.type === "tool") {
+    const state = part.state && part.state.status ? part.state.status : "unknown";
+    const title = part.state && part.state.title ? ` ${part.state.title}` : "";
+    return `[tool:${part.tool} ${state}${title}]`;
+  }
+  if (part.type === "step-finish") return `[step-finish:${part.reason}]`;
+  if (part.type === "file") return `[file:${part.filename || part.url || "attachment"}]`;
+  if (part.type === "agent") return `[agent:${part.name}]`;
+  return `[${part.type || "part"}]`;
+}
+
+function lastLines(text, limit) {
+  const lines = String(text || "").replace(/\r?\n$/, "").split(/\r?\n/);
+  return lines.slice(Math.max(0, lines.length - limit)).join("\n");
+}
+
+async function statusLine(serverUrl, sessionId) {
+  const statuses = await request("GET", serverUrl, "/session/status", undefined, [200]);
+  const status = statuses && statuses[sessionId] ? statuses[sessionId] : { type: "unknown" };
+  return `opencode-server status: ${status.type || "unknown"}`;
+}
+
+async function capture(serverUrl, sessionId, linesArg) {
+  const limit = Number(linesArg || 40);
+  if (MOCK) {
+    console.log(lastLines(`opencode-server status: idle\nsession=${sessionId}`, Number.isFinite(limit) && limit > 0 ? limit : 40));
+    return;
+  }
+  const messageLimit = Math.max(10, Math.min(100, Number.isFinite(limit) && limit > 0 ? limit : 40));
+  const status = await statusLine(serverUrl, sessionId).catch((error) => `opencode-server status: unknown (${error.message})`);
+  const messages = await request("GET", serverUrl, `${sessionRoute(sessionId, "/message")}?limit=${messageLimit}`, undefined, [200]);
+  const out = [status];
+  for (const message of Array.isArray(messages) ? messages : []) {
+    const role = message.info && message.info.role ? message.info.role : "message";
+    const id = message.info && message.info.id ? message.info.id : "unknown";
+    out.push(`[${role} ${id}]`);
+    for (const part of message.parts || []) {
+      const text = partText(part);
+      if (text) out.push(text);
+    }
+  }
+  console.log(lastLines(out.join("\n"), Number.isFinite(limit) && limit > 0 ? limit : 40));
+}
+
+async function start(taskId, title, worktree, briefFile) {
+  requireOpenCode();
+  if (!fs.existsSync(worktree)) throw new Error(`worktree not found: ${worktree}`);
+  if (!fs.existsSync(briefFile)) throw new Error(`brief not found: ${briefFile}`);
+  ensureState();
+  const logFile = path.join(STATE, `${taskId}.opencode-server.log`);
+
+  if (MOCK) {
+    fs.writeFileSync(logFile, `mock opencode-server start ${title}\n`);
+    console.log("opencode_server_url=http://127.0.0.1:0");
+    console.log("opencode_server_pid=0");
+    console.log(`opencode_server_log=${logFile}`);
+    console.log(`opencode_session_id=mock-${taskId}`);
+    console.log(`opencode_session_title=${title}`);
+    console.log("opencode_session_state=active");
+    return;
+  }
+
+  const hybrid = isWslWindowsOpenCode();
+  const hosts = serverHosts(hybrid);
+  const port = Number(process.env.FM_OPENCODE_SERVER_PORT || 0) || (await findFreePort(hosts.connect === "127.0.0.1" ? hosts.connect : "127.0.0.1"));
+  const serverUrl = `http://${hosts.connect}:${port}`;
+  const fd = fs.openSync(logFile, "a");
+  const env = {
+    ...process.env,
+    OPENCODE_CONFIG_CONTENT: process.env.OPENCODE_CONFIG_CONTENT || '{"permission":{"*":"allow"}}',
+    OPENCODE_DISABLE_AUTOUPDATE: process.env.OPENCODE_DISABLE_AUTOUPDATE || "1",
+  };
+  if (hybrid && !process.env.OPENCODE_SERVER_PASSWORD) {
+    env.OPENCODE_SERVER_PASSWORD = "";
+    env.OPENCODE_SERVER_USERNAME = "";
+  }
+  const child = spawn("opencode", ["serve", "--hostname", hosts.bind, "--port", String(port)], {
+    cwd: worktree,
+    env,
+    detached: true,
+    shell: isWindows(),
+    stdio: ["ignore", fd, fd],
+    windowsHide: true,
+  });
+  fs.closeSync(fd);
+
+  let sessionId = "";
+  try {
+    await waitForHealth(serverUrl, child);
+    const session = await ensureSession(serverUrl, title);
+    sessionId = session.id;
+    await sendPrompt(serverUrl, sessionId, fs.readFileSync(briefFile, "utf8"));
+  } catch (error) {
+    await closeServer(serverUrl, sessionId, child.pid).catch(() => undefined);
+    throw error;
+  }
+
+  child.unref();
+  console.log(`opencode_server_url=${serverUrl}`);
+  console.log(`opencode_server_pid=${child.pid}`);
+  console.log(`opencode_server_log=${logFile}`);
+  console.log(`opencode_session_id=${sessionId}`);
+  console.log(`opencode_session_title=${title}`);
+  console.log("opencode_session_state=active");
+}
+
+async function main() {
+  const [cmd, ...args] = process.argv.slice(2);
+  if (!cmd) usage();
+
+  if (cmd === "start") {
+    const [taskId, title, worktree, briefFile] = args;
+    if (!taskId || !title || !worktree || !briefFile) usage();
+    await start(taskId, title, worktree, briefFile);
+    return;
+  }
+
+  if (cmd === "capture") {
+    const [serverUrl, sessionId, lines] = args;
+    if (!serverUrl || !sessionId) usage();
+    await capture(serverUrl, sessionId, lines);
+    return;
+  }
+
+  if (cmd === "send") {
+    const [serverUrl, sessionId, ...textParts] = args;
+    if (!serverUrl || !sessionId) usage();
+    const text = textParts.join(" ");
+    if (MOCK) {
+      console.log(`sent_session_id=${sessionId}`);
+      return;
+    }
+    await sendPrompt(serverUrl, sessionId, text);
+    console.log(`sent_session_id=${sessionId}`);
+    return;
+  }
+
+  if (cmd === "interrupt") {
+    const [serverUrl, sessionId] = args;
+    if (!serverUrl || !sessionId) usage();
+    if (MOCK) {
+      console.log(`aborted_session_id=${sessionId}`);
+      return;
+    }
+    await request("POST", serverUrl, sessionRoute(sessionId, "/abort"), undefined, [200]);
+    console.log(`aborted_session_id=${sessionId}`);
+    return;
+  }
+
+  if (cmd === "status") {
+    const [serverUrl, sessionId] = args;
+    if (!serverUrl || !sessionId) usage();
+    if (MOCK) {
+      console.log("status=idle");
+      return;
+    }
+    const line = await statusLine(serverUrl, sessionId);
+    console.log(`status=${line.replace(/^opencode-server status: /, "")}`);
+    return;
+  }
+
+  if (cmd === "close") {
+    const [serverUrl, sessionId, pid] = args;
+    if (!serverUrl || !sessionId) usage();
+    await closeServer(serverUrl, sessionId, pid);
+    return;
+  }
+
+  usage();
+}
+
+main().catch((error) => {
+  console.error(`error: ${error.message}`);
+  process.exit(1);
+});

--- a/bin/fm-peek.sh
+++ b/bin/fm-peek.sh
@@ -1,19 +1,23 @@
 #!/usr/bin/env bash
-# Print the tail of a crewmate pane (bounded, for cheap diagnosis).
-# Usage: fm-peek.sh <window> [lines=40]
-#   <window> may be a bare window name (fm-xyz) or session:window.
+# Print the tail of a crewmate backend session (bounded, for cheap diagnosis).
+# Usage: fm-peek.sh <selector> [lines=40]
+#   <selector> may be fm-xyz, a tmux session:window, or a backend thread id.
+#   Codex App threads are app-owned: this prints only a cached read_thread capture,
+#   and otherwise refuses with the host-tool action to take.
 set -eu
 
-"$(dirname "${BASH_SOURCE[0]}")/fm-guard.sh" || true
+FM_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=bin/fm-backend.sh
+. "$FM_ROOT/bin/fm-backend.sh"
+"$FM_ROOT/bin/fm-guard.sh" || true
 
-resolve() {
-  case "$1" in
-    *:*) echo "$1" ;;
-    *) tmux list-windows -a -F '#{session_name}:#{window_name}' | grep -m1 ":$1\$" \
-         || { echo "error: no window named $1" >&2; exit 1; } ;;
-  esac
-}
-
-T=$(resolve "$1")
+META=$(fm_backend_meta_for_selector "$1" || true)
+if [ -z "$META" ]; then
+  # Backward-compatible tmux fallback for ad hoc windows with no meta.
+  T=$(fm_backend_tmux_resolve "$1")
+  tmp=$(mktemp "${TMPDIR:-/tmp}/fm-peek-meta.XXXXXX")
+  printf 'backend=tmux\nwindow=%s\n' "$T" > "$tmp"
+  META=$tmp
+fi
 N=${2:-40}
-tmux capture-pane -p -t "$T" -S -"$N"
+fm_backend_capture "$META" "$N"

--- a/bin/fm-promote.sh
+++ b/bin/fm-promote.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
-# Promote a scout task to a ship task in place: the crewmate keeps its window,
-# worktree, and loaded context; only the contract changes. Flips kind= to ship in
+# Promote a scout task to a ship task in place: the crewmate keeps its visible
+# session, worktree, and loaded context; only the contract changes. Flips kind= to ship in
 # state/<task-id>.meta so fm-teardown.sh applies the full unpushed-work protection
 # again. After promoting, send the crewmate its ship instructions via fm-send.sh
 # (inventory scratch state, reset to a clean default-branch base, carry over only
-# intended fix changes, create branch fm/<task-id>, implement, then report done
+# intended fix changes, create or reset branch fm/<task-id>, implement, then report done
 # according to the project's delivery mode).
 # Usage: fm-promote.sh <task-id>
 set -eu
@@ -22,4 +22,4 @@ echo "kind=ship" >> "$TMP"
 mv "$TMP" "$META"
 
 echo "promoted $ID to ship (teardown protection restored)"
-echo "next: bin/fm-send.sh fm-$ID '<ship instructions: review scratch state with git status and git log; reset to a clean default-branch base; carry over only intended fix changes; create branch fm/$ID; implement; report done>'"
+echo "next: bin/fm-send.sh fm-$ID '<ship instructions: review scratch state with git status and git log; reset to a clean default-branch base; carry over only intended fix changes; create or reset branch fm/$ID; implement; report done>'"

--- a/bin/fm-send.sh
+++ b/bin/fm-send.sh
@@ -1,29 +1,29 @@
 #!/usr/bin/env bash
-# Send one line of literal text to a crewmate window, then Enter.
-# Usage: fm-send.sh <window> <text...>
-#   <window> may be a bare window name (fm-xyz) or session:window.
-# Special keys instead of text: fm-send.sh <window> --key Escape   (or Enter, C-c, ...)
+# Send one line of literal text to a crewmate backend session.
+# Usage: fm-send.sh <selector> <text...>
+#   <selector> may be fm-xyz, a tmux session:window, or a backend thread id.
+# Special keys instead of text: fm-send.sh <selector> --key Escape   (or Enter, C-c, ...)
+#   Codex App threads are app-owned: this refuses and prints the Codex Desktop
+#   host-tool action instead of sending from shell.
 set -eu
 
-"$(dirname "${BASH_SOURCE[0]}")/fm-guard.sh" || true
+FM_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=bin/fm-backend.sh
+. "$FM_ROOT/bin/fm-backend.sh"
+"$FM_ROOT/bin/fm-guard.sh" || true
 
-resolve() {
-  case "$1" in
-    *:*) echo "$1" ;;
-    *) tmux list-windows -a -F '#{session_name}:#{window_name}' | grep -m1 ":$1\$" \
-         || { echo "error: no window named $1" >&2; exit 1; } ;;
-  esac
-}
-
-T=$(resolve "$1")
+META=$(fm_backend_meta_for_selector "$1" || true)
+if [ -z "$META" ]; then
+  # Backward-compatible tmux fallback for ad hoc windows with no meta.
+  T=$(fm_backend_tmux_resolve "$1")
+  tmp=$(mktemp "${TMPDIR:-/tmp}/fm-send-meta.XXXXXX")
+  printf 'backend=tmux\nwindow=%s\n' "$T" > "$tmp"
+  META=$tmp
+fi
 shift
 
 if [ "${1:-}" = "--key" ]; then
-  tmux send-keys -t "$T" "$2"
+  fm_backend_send_key "$META" "$2"
 else
-  tmux send-keys -t "$T" -l "$*"
-  # Slash commands open a completion popup in some TUIs (verified on codex);
-  # submitting too fast selects nothing. Give popups time to settle.
-  case "$*" in /*) sleep 1.2 ;; *) sleep 0.3 ;; esac
-  tmux send-keys -t "$T" Enter
+  fm_backend_send_text "$META" "$*"
 fi

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1,10 +1,14 @@
 #!/usr/bin/env bash
-# Spawn a crewmate: tmux window -> treehouse worktree subshell -> agent launched with its brief.
+# Spawn a crewmate or prepare a visible Codex App thread handoff.
 # Usage: fm-spawn.sh <task-id> <project-dir> [harness|launch-command] [--scout]
 #   With no harness arg, the harness comes from fm-harness.sh crew (config/crew-harness,
 #   falling back to firstmate's own harness). A bare adapter name (claude|codex|
-#   opencode|pi) overrides it for this spawn. A non-flag string containing whitespace
-#   is treated as a RAW launch command - the escape hatch for verifying new adapters.
+#   opencode|pi) overrides it for this spawn. On the tmux backend only, a
+#   non-flag string containing whitespace is treated as a RAW launch command -
+#   the escape hatch for verifying new adapters.
+#   FM_BACKEND=codex-app supports only the codex harness and prepares app-owned
+#   visible thread metadata; the firstmate must create/fork/send through Codex
+#   Desktop host tools, then record the returned thread id.
 #   --scout records kind=scout in the task's meta (report deliverable, scratch worktree;
 #   see AGENTS.md section 7); the default is kind=ship.
 #   Launch templates live in launch_template() below; placeholders replaced before launch:
@@ -14,11 +18,14 @@
 #     __PIEXT__    absolute path to state/<task-id>.pi-ext.ts (pi turn-end extension,
 #                  written by this script; outside the worktree to avoid pi's trust gate)
 # Per-harness turn-end hooks are installed automatically; some live outside the worktree.
-# On success prints: spawned <id> harness=<name> kind=<ship|scout> mode=<mode> yolo=<on|off> window=<session:window> worktree=<path>
+# On success prints either spawned <id> ... worktree=<path>, or prepared <id> ...
+# with the Codex App host-tool action needed to create/fork the visible thread.
 # mode/yolo are resolved per-project from data/projects.md via fm-project-mode.sh.
 set -eu
 
 FM_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=bin/fm-backend.sh
+. "$FM_ROOT/bin/fm-backend.sh"
 "$FM_ROOT/bin/fm-guard.sh" || true
 KIND=ship
 POS=()
@@ -35,7 +42,7 @@ ARG3=${POS[2]:-}
 # The verified launch command per adapter. The knowledge half of each adapter
 # (busy signature, exit command, dialogs, quirks) lives in AGENTS.md section 4.
 launch_template() {
-  # shellcheck disable=SC2016  # single quotes are deliberate: $(cat ...) expands in the crewmate pane, not here
+  # shellcheck disable=SC2016  # single quotes are deliberate: $(cat ...) expands in the crewmate shell, not here
   case "$1" in
     claude) printf '%s' 'claude --dangerously-skip-permissions "$(cat __BRIEF__)"' ;;
     codex) printf '%s' 'codex --dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch __TURNEND__\"]" "$(cat __BRIEF__)"' ;;
@@ -66,44 +73,113 @@ esac
 BRIEF="$FM_ROOT/data/$ID/brief.md"
 [ -f "$BRIEF" ] || { echo "error: no brief at $BRIEF" >&2; exit 1; }
 PROJ_ABS="$(cd "$PROJ" && pwd)"
-
-# Same session when firstmate already runs inside tmux; dedicated session otherwise.
-if [ -n "${TMUX:-}" ]; then
-  SES=$(tmux display-message -p '#S')
-else
-  tmux has-session -t firstmate 2>/dev/null || tmux new-session -d -s firstmate
-  SES=firstmate
-fi
+BACKEND=$(fm_backend_name)
 
 W="fm-$ID"
-T="$SES:$W"
-if tmux list-windows -t "$SES" -F '#{window_name}' | grep -qx "$W"; then
-  echo "error: window $T already exists" >&2
-  exit 1
-fi
-
-tmux new-window -d -t "$SES" -n "$W" -c "$PROJ_ABS"
-tmux send-keys -t "$T" 'treehouse get' Enter
-
-# Wait for the treehouse subshell: the pane's cwd moves from the project to the worktree.
+T=""
 WT=""
-for _ in $(seq 1 60); do
-  p=$(tmux display-message -p -t "$T" '#{pane_current_path}' 2>/dev/null || true)
-  if [ -n "$p" ] && [ "$p" != "$PROJ_ABS" ]; then
-    WT="$p"
-    break
+ORCA_WORKTREE_ID=""
+ORCA_TERMINAL=""
+CODEX_APP_THREAD_ID=""
+CODEX_APP_TURN_ID=""
+CODEX_APP_PENDING_ACTION=""
+TURNEND="$FM_ROOT/state/$ID.turn-ended"
+PIEXT="$FM_ROOT/state/$ID.pi-ext.ts"
+
+git_worktree_base() {
+  local repo=$1 ref branch
+  ref=$(git -C "$repo" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)
+  if [ -n "$ref" ]; then
+    echo "$ref"
+    return 0
   fi
-  sleep 1
-done
-if [ -z "$WT" ]; then
-  echo "error: treehouse get did not enter a worktree within 60s; inspect window $T" >&2
-  exit 1
-fi
+  for branch in main master; do
+    if git -C "$repo" show-ref --verify --quiet "refs/remotes/origin/$branch"; then
+      echo "origin/$branch"
+      return 0
+    fi
+    if git -C "$repo" show-ref --verify --quiet "refs/heads/$branch"; then
+      echo "$branch"
+      return 0
+    fi
+  done
+  git -C "$repo" rev-parse --verify HEAD 2>/dev/null
+}
+
+case "$BACKEND" in
+  tmux)
+    # Same session when firstmate already runs inside tmux; dedicated session otherwise.
+    if [ -n "${TMUX:-}" ]; then
+      SES=$(tmux display-message -p '#S')
+    else
+      tmux has-session -t firstmate 2>/dev/null || tmux new-session -d -s firstmate
+      SES=firstmate
+    fi
+
+    T="$SES:$W"
+    if tmux list-windows -t "$SES" -F '#{window_name}' | grep -qx "$W"; then
+      echo "error: window $T already exists" >&2
+      exit 1
+    fi
+
+    tmux new-window -d -t "$SES" -n "$W" -c "$PROJ_ABS"
+    tmux send-keys -t "$T" 'treehouse get' Enter
+
+    # Wait for the treehouse subshell: the pane's cwd moves from the project to the worktree.
+    for _ in $(seq 1 60); do
+      p=$(tmux display-message -p -t "$T" '#{pane_current_path}' 2>/dev/null || true)
+      if [ -n "$p" ] && [ "$p" != "$PROJ_ABS" ]; then
+        WT="$p"
+        break
+      fi
+      sleep 1
+    done
+    if [ -z "$WT" ]; then
+      echo "error: treehouse get did not enter a worktree within 60s; inspect window $T" >&2
+      exit 1
+    fi
+    ;;
+  orca)
+    command -v orca >/dev/null || { echo "error: FM_BACKEND=orca but orca is not installed" >&2; exit 1; }
+    case "$ARG3" in
+      *' '*) echo "error: FM_BACKEND=orca does not support raw launch commands yet; use a verified harness name" >&2; exit 1 ;;
+    esac
+    orca repo add --path "$PROJ_ABS" --json >/dev/null 2>&1 || true
+    create_json=$(mktemp "${TMPDIR:-/tmp}/fm-orca-create.XXXXXX")
+    if ! orca worktree create --repo "path:$PROJ_ABS" --name "$W" --setup skip --no-parent --json > "$create_json"; then
+      cat "$create_json" >&2
+      rm -f "$create_json"
+      exit 1
+    fi
+    IFS=$(printf '\t') read -r ORCA_WORKTREE_ID WT ORCA_TERMINAL <<EOF
+$(fm_backend_parse_worktree_create < "$create_json")
+EOF
+    rm -f "$create_json"
+    [ -n "$ORCA_WORKTREE_ID" ] || { echo "error: Orca did not return a worktree id" >&2; exit 1; }
+    if [ -z "$WT" ]; then
+      WT=$(orca worktree show --worktree "id:$ORCA_WORKTREE_ID" --json | fm_backend_json_get result.worktree.path)
+    fi
+    [ -n "$WT" ] || { echo "error: Orca did not return a worktree path" >&2; exit 1; }
+    T="$W"
+    ;;
+  codex-app)
+    case "$ARG3" in
+      *' '*) echo "error: FM_BACKEND=codex-app does not support raw launch commands; use the codex harness" >&2; exit 1 ;;
+    esac
+    case "$HARNESS" in
+      codex*) ;;
+      *) echo "error: FM_BACKEND=codex-app supports only the codex harness (got '$HARNESS')" >&2; exit 1 ;;
+    esac
+    T="$W"
+    WT=""
+    CODEX_APP_PENDING_ACTION=create_thread_or_fork_thread
+    ;;
+  *) echo "error: unknown FM_BACKEND '$BACKEND' (expected tmux, orca, or codex-app)" >&2; exit 1 ;;
+esac
 
 # Per-harness turn-end hook: a file that touches state/<id>.turn-ended when the
 # agent finishes a turn. Worktree-resident hooks are kept out of git's view so
 # they never block teardown's dirty check or leak into a commit.
-TURNEND="$FM_ROOT/state/$ID.turn-ended"
 exclude_path() {
   local rel=$1 EXCL
   EXCL=$(git -C "$WT" rev-parse --git-path info/exclude 2>/dev/null || true)
@@ -134,7 +210,7 @@ EOF
     # Written OUTSIDE the worktree: pi's project-trust gate fires on any extension
     # loaded from inside the project (verified live), but an explicit -e path
     # elsewhere loads without a dialog. Lives in state/, cleaned by teardown.
-    cat > "$FM_ROOT/state/$ID.pi-ext.ts" <<EOF
+    cat > "$PIEXT" <<EOF
 // Firstmate turn-end signal; written by fm-spawn.
 // Use "turn_end" (fires after each turn the agent finishes), not "agent_end"
 // (fires once, only when the whole run exits): the watcher needs a signal at
@@ -150,6 +226,38 @@ EOF
     ;;
 esac
 
+LAUNCH=${LAUNCH//__BRIEF__/$BRIEF}
+LAUNCH=${LAUNCH//__TURNEND__/$TURNEND}
+LAUNCH=${LAUNCH//__PIEXT__/$PIEXT}
+
+if [ "$BACKEND" = orca ]; then
+  case "$HARNESS" in
+    codex*)
+      if [ "${FM_ORCA_CODEX_AUTO_TRUST:-0}" = 1 ]; then
+        fm_backend_trust_codex_project "$WT"
+      fi
+      ;;
+  esac
+  terminal_json=$(mktemp "${TMPDIR:-/tmp}/fm-orca-terminal.XXXXXX")
+  if ! orca terminal create --worktree "id:$ORCA_WORKTREE_ID" --title "$W" --json > "$terminal_json"; then
+    cat "$terminal_json" >&2
+    rm -f "$terminal_json"
+    exit 1
+  fi
+  IFS=$(printf '\t') read -r _unused_id _unused_path ORCA_TERMINAL <<EOF
+$(fm_backend_parse_worktree_create < "$terminal_json")
+EOF
+  rm -f "$terminal_json"
+  if [ -z "$ORCA_TERMINAL" ]; then
+    for _ in $(seq 1 30); do
+      ORCA_TERMINAL=$(orca terminal list --worktree "id:$ORCA_WORKTREE_ID" --json | fm_backend_first_terminal)
+      [ -n "$ORCA_TERMINAL" ] && break
+      sleep 1
+    done
+  fi
+  [ -n "$ORCA_TERMINAL" ] || { echo "error: Orca did not return a terminal handle" >&2; exit 1; }
+fi
+
 # Per-project delivery mode + yolo flag (bin/fm-project-mode.sh; AGENTS.md sections 6-7).
 # Recorded in meta so fm-teardown's safety check and the validate/merge stages can
 # branch on them. Mode governs ship tasks; a scout's deliverable is a report, not a
@@ -161,6 +269,7 @@ EOF
 
 mkdir -p "$FM_ROOT/state"
 {
+  echo "backend=$BACKEND"
   echo "window=$T"
   echo "worktree=$WT"
   echo "project=$PROJ_ABS"
@@ -168,13 +277,45 @@ mkdir -p "$FM_ROOT/state"
   echo "kind=$KIND"
   echo "mode=$MODE"
   echo "yolo=$YOLO"
+  [ -n "$ORCA_WORKTREE_ID" ] && echo "orca_worktree_id=$ORCA_WORKTREE_ID"
+  [ -n "$ORCA_TERMINAL" ] && echo "terminal=$ORCA_TERMINAL"
+  [ -n "$CODEX_APP_THREAD_ID" ] && echo "thread_id=$CODEX_APP_THREAD_ID"
+  [ -n "$CODEX_APP_TURN_ID" ] && echo "turn_id=$CODEX_APP_TURN_ID"
+  [ "$BACKEND" = codex-app ] && echo "codex_app_thread_state=pending"
+  [ "$BACKEND" = codex-app ] && echo "codex_app_pending_action=$CODEX_APP_PENDING_ACTION"
+  [ "$BACKEND" = codex-app ] && echo "codex_app_transport=visible-thread"
+  [ "$BACKEND" = codex-app ] && echo "codex_app_brief=$BRIEF"
 } > "$FM_ROOT/state/$ID.meta"
 
-LAUNCH=${LAUNCH//__BRIEF__/$BRIEF}
-LAUNCH=${LAUNCH//__TURNEND__/$TURNEND}
-LAUNCH=${LAUNCH//__PIEXT__/$FM_ROOT/state/$ID.pi-ext.ts}
-tmux send-keys -t "$T" -l "$LAUNCH"
-sleep 0.3
-tmux send-keys -t "$T" Enter
+if [ "$BACKEND" = tmux ]; then
+  tmux send-keys -t "$T" -l "$LAUNCH"
+  sleep 0.3
+  tmux send-keys -t "$T" Enter
+elif [ "$BACKEND" = orca ]; then
+  orca terminal send --terminal "$ORCA_TERMINAL" --text "$LAUNCH" --enter --json >/dev/null
+  case "$HARNESS" in
+    codex*)
+      for _ in $(seq 1 20); do
+        tail=$(fm_backend_orca_terminal_text "$ORCA_TERMINAL" 30 || true)
+        if printf '%s\n' "$tail" | grep -q 'Hooks need review' \
+          && printf '%s\n' "$tail" | grep -q 'Trust.*continue'; then
+          orca terminal send --terminal "$ORCA_TERMINAL" --text "2" --enter --json >/dev/null
+          break
+        fi
+        if printf '%s\n' "$tail" | grep -q 'esc to interrupt'; then
+          break
+        fi
+        sleep 1
+      done
+      ;;
+  esac
+fi
 
-echo "spawned $ID harness=$HARNESS kind=$KIND mode=$MODE yolo=$YOLO window=$T worktree=$WT"
+if [ "$BACKEND" = codex-app ]; then
+  "$FM_ROOT/bin/fm-codex-app" prepare "$ID" "$W" "$BRIEF" >/dev/null
+  echo "prepared $ID backend=$BACKEND harness=$HARNESS kind=$KIND mode=$MODE yolo=$YOLO window=$T"
+  echo "next: use Codex App create_thread or fork_thread for $W, send the brief at $BRIEF, then run:"
+  echo "      bin/fm-codex-app record-thread $ID <thread-id> [--worktree <path>] [--pending-worktree-id <id>]"
+else
+  echo "spawned $ID backend=$BACKEND harness=$HARNESS kind=$KIND mode=$MODE yolo=$YOLO window=$T worktree=$WT"
+fi

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -9,6 +9,8 @@
 #   FM_BACKEND=codex-app supports only the codex harness and prepares app-owned
 #   visible thread metadata; the firstmate must create/fork/send through Codex
 #   Desktop host tools, then record the returned thread id.
+#   FM_BACKEND=opencode-server supports only the opencode harness and starts one
+#   headless OpenCode server per task worktree.
 #   --scout records kind=scout in the task's meta (report deliverable, scratch worktree;
 #   see AGENTS.md section 7); the default is kind=ship.
 #   Launch templates live in launch_template() below; placeholders replaced before launch:
@@ -83,6 +85,12 @@ ORCA_TERMINAL=""
 CODEX_APP_THREAD_ID=""
 CODEX_APP_TURN_ID=""
 CODEX_APP_PENDING_ACTION=""
+OPENCODE_SERVER_URL=""
+OPENCODE_SERVER_PID=""
+OPENCODE_SERVER_LOG=""
+OPENCODE_SESSION_ID=""
+OPENCODE_SESSION_TITLE=""
+OPENCODE_SESSION_STATE=""
 TURNEND="$FM_ROOT/state/$ID.turn-ended"
 PIEXT="$FM_ROOT/state/$ID.pi-ext.ts"
 
@@ -174,7 +182,23 @@ EOF
     WT=""
     CODEX_APP_PENDING_ACTION=create_thread_or_fork_thread
     ;;
-  *) echo "error: unknown FM_BACKEND '$BACKEND' (expected tmux, orca, or codex-app)" >&2; exit 1 ;;
+  opencode-server)
+    command -v opencode >/dev/null || { echo "error: FM_BACKEND=opencode-server but opencode is not installed" >&2; exit 1; }
+    case "$ARG3" in
+      *' '*) echo "error: FM_BACKEND=opencode-server does not support raw launch commands; use the opencode harness" >&2; exit 1 ;;
+    esac
+    case "$HARNESS" in
+      opencode*) ;;
+      *) echo "error: FM_BACKEND=opencode-server supports only the opencode harness (got '$HARNESS')" >&2; exit 1 ;;
+    esac
+    mkdir -p "$FM_ROOT/state/opencode-server-worktrees"
+    WT="$FM_ROOT/state/opencode-server-worktrees/$ID"
+    [ ! -e "$WT" ] || { echo "error: OpenCode server worktree already exists: $WT" >&2; exit 1; }
+    BASE=$(git_worktree_base "$PROJ_ABS")
+    git -C "$PROJ_ABS" worktree add --detach "$WT" "$BASE" >/dev/null
+    T="$W"
+    ;;
+  *) echo "error: unknown FM_BACKEND '$BACKEND' (expected tmux, orca, codex-app, or opencode-server)" >&2; exit 1 ;;
 esac
 
 # Per-harness turn-end hook: a file that touches state/<id>.turn-ended when the
@@ -196,15 +220,17 @@ EOF
     exclude_path '.claude/settings.local.json'
     ;;
   opencode*)
-    mkdir -p "$WT/.opencode/plugins"
-    cat > "$WT/.opencode/plugins/fm-turn-end.js" <<EOF
+    if [ "$BACKEND" != opencode-server ]; then
+      mkdir -p "$WT/.opencode/plugins"
+      cat > "$WT/.opencode/plugins/fm-turn-end.js" <<EOF
 export const FmTurnEnd = async ({ \$ }) => ({
   event: async ({ event }) => {
     if (event.type === "session.idle") await \$\`touch $TURNEND\`
   },
 })
 EOF
-    exclude_path '.opencode/plugins/fm-turn-end.js'
+      exclude_path '.opencode/plugins/fm-turn-end.js'
+    fi
     ;;
   pi*)
     # Written OUTSIDE the worktree: pi's project-trust gate fires on any extension
@@ -258,6 +284,22 @@ EOF
   [ -n "$ORCA_TERMINAL" ] || { echo "error: Orca did not return a terminal handle" >&2; exit 1; }
 fi
 
+if [ "$BACKEND" = opencode-server ]; then
+  if ! opencode_start=$("$FM_ROOT/bin/fm-opencode-server" start "$ID" "$W" "$WT" "$BRIEF"); then
+    git -C "$PROJ_ABS" worktree remove --force "$WT" >/dev/null 2>&1 || true
+    exit 1
+  fi
+  opencode_value() { printf '%s\n' "$opencode_start" | grep "^$1=" | tail -1 | cut -d= -f2-; }
+  OPENCODE_SERVER_URL=$(opencode_value opencode_server_url)
+  OPENCODE_SERVER_PID=$(opencode_value opencode_server_pid)
+  OPENCODE_SERVER_LOG=$(opencode_value opencode_server_log)
+  OPENCODE_SESSION_ID=$(opencode_value opencode_session_id)
+  OPENCODE_SESSION_TITLE=$(opencode_value opencode_session_title)
+  OPENCODE_SESSION_STATE=$(opencode_value opencode_session_state)
+  [ -n "$OPENCODE_SERVER_URL" ] || { echo "error: OpenCode server helper did not return opencode_server_url" >&2; exit 1; }
+  [ -n "$OPENCODE_SESSION_ID" ] || { echo "error: OpenCode server helper did not return opencode_session_id" >&2; exit 1; }
+fi
+
 # Per-project delivery mode + yolo flag (bin/fm-project-mode.sh; AGENTS.md sections 6-7).
 # Recorded in meta so fm-teardown's safety check and the validate/merge stages can
 # branch on them. Mode governs ship tasks; a scout's deliverable is a report, not a
@@ -285,6 +327,12 @@ mkdir -p "$FM_ROOT/state"
   [ "$BACKEND" = codex-app ] && echo "codex_app_pending_action=$CODEX_APP_PENDING_ACTION"
   [ "$BACKEND" = codex-app ] && echo "codex_app_transport=visible-thread"
   [ "$BACKEND" = codex-app ] && echo "codex_app_brief=$BRIEF"
+  [ -n "$OPENCODE_SERVER_URL" ] && echo "opencode_server_url=$OPENCODE_SERVER_URL"
+  [ -n "$OPENCODE_SERVER_PID" ] && echo "opencode_server_pid=$OPENCODE_SERVER_PID"
+  [ -n "$OPENCODE_SERVER_LOG" ] && echo "opencode_server_log=$OPENCODE_SERVER_LOG"
+  [ -n "$OPENCODE_SESSION_ID" ] && echo "opencode_session_id=$OPENCODE_SESSION_ID"
+  [ -n "$OPENCODE_SESSION_TITLE" ] && echo "opencode_session_title=$OPENCODE_SESSION_TITLE"
+  [ -n "$OPENCODE_SESSION_STATE" ] && echo "opencode_session_state=$OPENCODE_SESSION_STATE"
 } > "$FM_ROOT/state/$ID.meta"
 
 if [ "$BACKEND" = tmux ]; then
@@ -316,6 +364,8 @@ if [ "$BACKEND" = codex-app ]; then
   echo "prepared $ID backend=$BACKEND harness=$HARNESS kind=$KIND mode=$MODE yolo=$YOLO window=$T"
   echo "next: use Codex App create_thread or fork_thread for $W, send the brief at $BRIEF, then run:"
   echo "      bin/fm-codex-app record-thread $ID <thread-id> [--worktree <path>] [--pending-worktree-id <id>]"
+elif [ "$BACKEND" = opencode-server ]; then
+  echo "spawned $ID backend=$BACKEND harness=$HARNESS kind=$KIND mode=$MODE yolo=$YOLO window=$T worktree=$WT session=$OPENCODE_SESSION_ID server=$OPENCODE_SERVER_URL"
 else
   echo "spawned $ID backend=$BACKEND harness=$HARNESS kind=$KIND mode=$MODE yolo=$YOLO window=$T worktree=$WT"
 fi

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1,17 +1,20 @@
 #!/usr/bin/env bash
-# Tear down a finished task: return the treehouse worktree, kill the tmux window,
-# clear volatile state, then refresh/prune the project's clone for PR-based ship tasks.
-# REFUSES if the worktree holds work not on any remote, because treehouse return
-# hard-resets the worktree and kills its processes.
+# Tear down a finished task: close the backend session, remove/return the
+# worktree, clear volatile state, then refresh/prune the project's clone for
+# PR-based ship tasks.
+# REFUSES if the worktree holds work not on any remote, because teardown removes
+# the disposable worktree and kills/archives its backend session.
 # Scout tasks (kind=scout in meta) carve out of that check: their worktree is
 # declared scratch and the report at data/<task-id>/report.md is the work
 # product - teardown proceeds once the report exists, and refuses without it.
 # Usage: fm-teardown.sh <task-id> [--force]
-#   --force skips the unpushed-work check. Only use it when the captain has
-#   explicitly said to discard the work.
+#   --force skips teardown safety checks, including Codex App archive/worktree
+#   proof. Only use it when the captain has explicitly said to discard the work.
 set -eu
 
 FM_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=bin/fm-backend.sh
+. "$FM_ROOT/bin/fm-backend.sh"
 "$FM_ROOT/bin/fm-guard.sh" || true
 STATE="$FM_ROOT/state"
 ID=$1
@@ -22,6 +25,12 @@ META="$STATE/$ID.meta"
 WT=$(grep '^worktree=' "$META" | cut -d= -f2-)
 T=$(grep '^window=' "$META" | cut -d= -f2-)
 PROJ=$(grep '^project=' "$META" | cut -d= -f2-)
+BACKEND=$(grep '^backend=' "$META" | cut -d= -f2- || true)
+[ -n "$BACKEND" ] || BACKEND=tmux
+ORCA_WORKTREE_ID=$(grep '^orca_worktree_id=' "$META" | cut -d= -f2- || true)
+ORCA_TERMINAL=$(grep '^terminal=' "$META" | cut -d= -f2- || true)
+CODEX_APP_THREAD_ID=$(grep '^thread_id=' "$META" | cut -d= -f2- || true)
+CODEX_APP_ARCHIVED=$(grep '^codex_app_archived=' "$META" | cut -d= -f2- || true)
 
 KIND=$(grep '^kind=' "$META" | cut -d= -f2- || true)
 [ -n "$KIND" ] || KIND=ship
@@ -43,6 +52,59 @@ default_branch() {
   done
   return 1
 }
+
+git_common_dir() {
+  git -C "$1" rev-parse --path-format=absolute --git-common-dir 2>/dev/null
+}
+
+git_origin_url() {
+  git -C "$1" remote get-url origin 2>/dev/null || true
+}
+
+same_project_repo() {
+  local a=$1 b=$2 a_common b_common a_origin b_origin
+  a_common=$(git_common_dir "$a" || true)
+  b_common=$(git_common_dir "$b" || true)
+  if [ -n "$a_common" ] && [ "$a_common" = "$b_common" ]; then
+    return 0
+  fi
+  a_origin=$(git_origin_url "$a")
+  b_origin=$(git_origin_url "$b")
+  [ -n "$a_origin" ] && [ "$a_origin" = "$b_origin" ]
+}
+
+if [ "$BACKEND" = codex-app ] && [ "$KIND" != scout ] && [ "$FORCE" != "--force" ]; then
+  if [ -z "$WT" ]; then
+    echo "REFUSED: Codex App ship task $ID has no known worktree path." >&2
+    echo "Firstmate cannot prove the work is landed or safe to discard. Record the app-owned worktree path, merge/ship the work, or get the captain's explicit OK to discard, then --force." >&2
+    exit 1
+  fi
+  if [ ! -d "$WT" ] || ! git -C "$WT" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "REFUSED: Codex App ship task $ID has invalid worktree path: $WT" >&2
+    echo "Firstmate cannot prove the work is landed or safe to discard. Record a real app-owned git worktree path, merge/ship the work, or get the captain's explicit OK to discard, then --force." >&2
+    exit 1
+  fi
+  if ! same_project_repo "$WT" "$PROJ"; then
+    echo "REFUSED: Codex App ship task $ID worktree does not belong to project $PROJ: $WT" >&2
+    echo "Record the app-owned worktree for this project, merge/ship the work, or get the captain's explicit OK to discard, then --force." >&2
+    exit 1
+  fi
+  branch=$(git -C "$WT" rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+  if [ "$branch" != "fm/$ID" ]; then
+    echo "REFUSED: Codex App ship task $ID expected worktree branch fm/$ID, got ${branch:-unknown}." >&2
+    echo "Record the app-owned task worktree, merge/ship the work, or get the captain's explicit OK to discard, then --force." >&2
+    exit 1
+  fi
+fi
+
+if [ "$BACKEND" = codex-app ] && [ "$KIND" = scout ] && [ "$FORCE" != "--force" ]; then
+  REPORT="$FM_ROOT/data/$ID/report.md"
+  if [ ! -f "$REPORT" ]; then
+    echo "REFUSED: scout task $ID has no report at $REPORT." >&2
+    echo "The report is the work product. Have the crewmate write it (or get the captain's explicit OK to discard, then --force)." >&2
+    exit 1
+  fi
+fi
 
 if [ -d "$WT" ] && [ "$FORCE" != "--force" ]; then
   if [ "$KIND" = scout ]; then
@@ -81,6 +143,12 @@ if [ -d "$WT" ] && [ "$FORCE" != "--force" ]; then
   fi
 fi
 
+if [ "$BACKEND" = codex-app ] && [ -n "$CODEX_APP_THREAD_ID" ] && [ "$CODEX_APP_ARCHIVED" != 1 ] && [ "$FORCE" != "--force" ]; then
+  echo "REFUSED: Codex App thread $CODEX_APP_THREAD_ID is not marked archived." >&2
+  echo "Use set_thread_archived(threadId=$CODEX_APP_THREAD_ID, archived=true), then run: bin/fm-codex-app mark-archived $ID" >&2
+  exit 1
+fi
+
 # Best-effort: drop the local task branch so the shared repo does not accumulate refs.
 if [ -d "$WT" ]; then
   branch=$(git -C "$WT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo HEAD)
@@ -91,15 +159,39 @@ if [ -d "$WT" ]; then
   fi
   # Remove our hook file so a reused pool worktree cannot fire signals for a dead task.
   rm -f "$WT/.claude/settings.local.json" "$WT/.opencode/plugins/fm-turn-end.js"
-  # Kills remaining processes in the worktree (including the agent), resets, returns
-  # to pool. treehouse resolves the pool from the working directory, so run it from
-  # the project.
-  ( cd "$PROJ" && treehouse return --force "$WT" )
+  case "$BACKEND" in
+    tmux)
+      # Kills remaining processes in the worktree (including the agent), resets, returns
+      # to pool. treehouse resolves the pool from the working directory, so run it from
+      # the project.
+      ( cd "$PROJ" && treehouse return --force "$WT" )
+      ;;
+    orca)
+      if [ -n "$ORCA_TERMINAL" ]; then
+        orca terminal close --terminal "$ORCA_TERMINAL" --json >/dev/null 2>&1 || true
+      fi
+      if [ -n "$ORCA_WORKTREE_ID" ]; then
+        orca worktree rm --worktree "id:$ORCA_WORKTREE_ID" --force --json >/dev/null
+      else
+        orca worktree rm --worktree "path:$WT" --force --json >/dev/null
+      fi
+      ;;
+    codex-app)
+      case "$WT" in
+        "$FM_ROOT/state/codex-app-worktrees/"*) git -C "$PROJ" worktree remove --force "$WT" >/dev/null ;;
+        *) : ;; # App-owned worktrees are managed by Codex App, not this shell helper.
+      esac
+      ;;
+    *) echo "REFUSED: unknown backend '$BACKEND' for task $ID." >&2; exit 1 ;;
+  esac
 fi
 
-tmux kill-window -t "$T" 2>/dev/null || true
-rm -f "$STATE/$ID.status" "$STATE/$ID.turn-ended" "$STATE/$ID.check.sh" "$STATE/$ID.meta" "$STATE/$ID.pi-ext.ts"
+if [ "$BACKEND" = tmux ]; then
+  tmux kill-window -t "$T" 2>/dev/null || true
+fi
+rm -f "$STATE/$ID.status" "$STATE/$ID.turn-ended" "$STATE/$ID.check.sh" "$STATE/$ID.meta" "$STATE/$ID.pi-ext.ts" \
+  "$STATE/$ID.codex-app.env" "$STATE/$ID.codex-app.log" "$STATE/$ID.codex-app.capture" "$STATE/$ID.codex-app-send."*
 if [ "$KIND" != scout ] && [ "$MODE" != local-only ]; then
   "$FM_ROOT/bin/fm-fleet-sync.sh" "$PROJ" || true
 fi
-echo "teardown $ID complete (window $T, worktree $WT)"
+echo "teardown $ID complete (backend $BACKEND, window $T, worktree $WT)"

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -31,6 +31,10 @@ ORCA_WORKTREE_ID=$(grep '^orca_worktree_id=' "$META" | cut -d= -f2- || true)
 ORCA_TERMINAL=$(grep '^terminal=' "$META" | cut -d= -f2- || true)
 CODEX_APP_THREAD_ID=$(grep '^thread_id=' "$META" | cut -d= -f2- || true)
 CODEX_APP_ARCHIVED=$(grep '^codex_app_archived=' "$META" | cut -d= -f2- || true)
+OPENCODE_SERVER_URL=$(grep '^opencode_server_url=' "$META" | cut -d= -f2- || true)
+OPENCODE_SERVER_PID=$(grep '^opencode_server_pid=' "$META" | cut -d= -f2- || true)
+OPENCODE_SESSION_ID=$(grep '^opencode_session_id=' "$META" | cut -d= -f2- || true)
+OPENCODE_CLOSED=0
 
 KIND=$(grep '^kind=' "$META" | cut -d= -f2- || true)
 [ -n "$KIND" ] || KIND=ship
@@ -120,7 +124,7 @@ if [ -d "$WT" ] && [ "$FORCE" != "--force" ]; then
     # The work is safe once it is merged into the local default branch (firstmate
     # does that merge on the captain's approval). Refuse until then.
     DEFAULT=$(default_branch) || { echo "REFUSED: cannot determine default branch for $PROJ; expected origin/HEAD, main, or master." >&2; exit 1; }
-    dirty=$(git -C "$WT" status --porcelain 2>/dev/null | grep -vE '^\?\? \.claude/' | head -1 || true)
+    dirty=$(git -C "$WT" status --porcelain 2>/dev/null | grep -vE '^\?\? (\.claude/|\.opencode/plugins/fm-turn-end\.js$)' | head -1 || true)
     unmerged=$(git -C "$WT" log --oneline HEAD --not "$DEFAULT" -- 2>/dev/null | head -5 || true)
     if [ -n "$dirty" ] || [ -n "$unmerged" ]; then
       echo "REFUSED: local-only worktree $WT has work not yet merged into $DEFAULT." >&2
@@ -131,7 +135,7 @@ if [ -d "$WT" ] && [ "$FORCE" != "--force" ]; then
     fi
   else
     # The fm-spawn hook file is ours, never work product; ignore it in the dirty check.
-    dirty=$(git -C "$WT" status --porcelain 2>/dev/null | grep -vE '^\?\? \.claude/' | head -1 || true)
+    dirty=$(git -C "$WT" status --porcelain 2>/dev/null | grep -vE '^\?\? (\.claude/|\.opencode/plugins/fm-turn-end\.js$)' | head -1 || true)
     unpushed=$(git -C "$WT" log --oneline HEAD --not --remotes -- 2>/dev/null | head -5 || true)
     if [ -n "$dirty" ] || [ -n "$unpushed" ]; then
       echo "REFUSED: worktree $WT has work not on any remote." >&2
@@ -182,6 +186,16 @@ if [ -d "$WT" ]; then
         *) : ;; # App-owned worktrees are managed by Codex App, not this shell helper.
       esac
       ;;
+    opencode-server)
+      if [ -n "$OPENCODE_SERVER_URL" ] && [ -n "$OPENCODE_SESSION_ID" ]; then
+        "$FM_ROOT/bin/fm-opencode-server" close "$OPENCODE_SERVER_URL" "$OPENCODE_SESSION_ID" "$OPENCODE_SERVER_PID" >/dev/null 2>&1 || true
+        OPENCODE_CLOSED=1
+      fi
+      case "$WT" in
+        "$FM_ROOT/state/opencode-server-worktrees/"*) git -C "$PROJ" worktree remove --force "$WT" >/dev/null ;;
+        *) echo "REFUSED: OpenCode server worktree is not firstmate-owned: $WT" >&2; exit 1 ;;
+      esac
+      ;;
     *) echo "REFUSED: unknown backend '$BACKEND' for task $ID." >&2; exit 1 ;;
   esac
 fi
@@ -189,8 +203,12 @@ fi
 if [ "$BACKEND" = tmux ]; then
   tmux kill-window -t "$T" 2>/dev/null || true
 fi
+if [ "$BACKEND" = opencode-server ] && [ "$OPENCODE_CLOSED" != 1 ] && [ ! -d "$WT" ] && [ -n "$OPENCODE_SERVER_URL" ] && [ -n "$OPENCODE_SESSION_ID" ]; then
+  "$FM_ROOT/bin/fm-opencode-server" close "$OPENCODE_SERVER_URL" "$OPENCODE_SESSION_ID" "$OPENCODE_SERVER_PID" >/dev/null 2>&1 || true
+fi
 rm -f "$STATE/$ID.status" "$STATE/$ID.turn-ended" "$STATE/$ID.check.sh" "$STATE/$ID.meta" "$STATE/$ID.pi-ext.ts" \
-  "$STATE/$ID.codex-app.env" "$STATE/$ID.codex-app.log" "$STATE/$ID.codex-app.capture" "$STATE/$ID.codex-app-send."*
+  "$STATE/$ID.codex-app.env" "$STATE/$ID.codex-app.log" "$STATE/$ID.codex-app.capture" "$STATE/$ID.codex-app-send."* \
+  "$STATE/$ID.opencode-server.log" "$STATE/$ID.opencode-server.capture"
 if [ "$KIND" != scout ] && [ "$MODE" != local-only ]; then
   "$FM_ROOT/bin/fm-fleet-sync.sh" "$PROJ" || true
 fi

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -3,13 +3,15 @@
 # Blocks until supervision work is due, then exits printing one reason line:
 #   signal: <file>...     a crewmate wrote a status line or a turn-end hook fired; signals
 #                         landing within FM_SIGNAL_GRACE of each other coalesce into one wake
-#   stale: <window>       a crewmate pane stopped changing and shows no busy signature
+#   stale: <session>      a crewmate session stopped changing and shows no busy signature
 #   check: <script>: <out> a per-task check script (e.g. merged-PR poll) produced output
 #   heartbeat              fleet review due; starts at FM_HEARTBEAT and backs off to FM_HEARTBEAT_MAX
 # Run as a background task. Restart it after handling each wake.
 set -u
 
 FM_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=bin/fm-backend.sh
+. "$FM_ROOT/bin/fm-backend.sh"
 STATE="$FM_ROOT/state"
 mkdir -p "$STATE"
 
@@ -22,8 +24,9 @@ SIGNAL_GRACE=${FM_SIGNAL_GRACE:-30}   # seconds to linger after a signal so trai
                                       # signals (a status write, then the same turn's
                                       # turn-end hook) coalesce into one wake
 # Busy signatures per harness, OR-ed. Extend via env when new adapters are verified.
-# claude/codex: "esc to interrupt"; opencode: "esc interrupt"; pi: "Working..."
-BUSY_REGEX=${FM_BUSY_REGEX:-'esc (to )?interrupt|Working\.\.\.'}
+# claude/codex: "esc to interrupt"; opencode: "esc interrupt"; pi: "Working...";
+# optional Codex App cached captures may include "codex-app status: active".
+BUSY_REGEX=${FM_BUSY_REGEX:-'esc (to )?interrupt|Working\.\.\.|codex-app status: active'}
 
 hash_pane() {
   if command -v md5 >/dev/null 2>&1; then md5 -q; else md5sum | cut -d' ' -f1; fi
@@ -127,11 +130,14 @@ EOF
     wake "signal:$files"
   fi
 
-  # Layer 1 backbone: pane staleness. Two consecutive identical hashes with no busy
+  # Layer 1 backbone: terminal staleness. Two consecutive identical hashes with no busy
   # signature means the crewmate finished, is waiting, or is wedged. Each distinct
   # stale state is reported once (.stale-* remembers the hash already reported).
-  while IFS= read -r w; do
-    tail40=$(tmux capture-pane -p -t "$w" -S -40 2>/dev/null) || continue
+  for meta in "$STATE"/*.meta; do
+    [ -e "$meta" ] || continue
+    w=$(fm_meta_get window "$meta")
+    [ -n "$w" ] || w=$(basename "$meta" .meta)
+    tail40=$(fm_backend_capture "$meta" 40 2>/dev/null) || continue
     h=$(printf '%s' "$tail40" | hash_pane)
     key=$(printf '%s' "$w" | tr ':/.' '___')
     hf="$STATE/.hash-$key"
@@ -154,7 +160,7 @@ EOF
       printf '%s' "$h" > "$hf"
       echo 0 > "$cf"
     fi
-  done < <(tmux list-windows -a -F '#{session_name}:#{window_name}' 2>/dev/null | grep ':fm-' || true)
+  done
 
   # Heartbeat: firstmate reviews the whole fleet at a regular cadence no matter
   # what. Time-based via .last-heartbeat mtime; interval doubles per consecutive

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -25,8 +25,8 @@ SIGNAL_GRACE=${FM_SIGNAL_GRACE:-30}   # seconds to linger after a signal so trai
                                       # turn-end hook) coalesce into one wake
 # Busy signatures per harness, OR-ed. Extend via env when new adapters are verified.
 # claude/codex: "esc to interrupt"; opencode: "esc interrupt"; pi: "Working...";
-# optional Codex App cached captures may include "codex-app status: active".
-BUSY_REGEX=${FM_BUSY_REGEX:-'esc (to )?interrupt|Working\.\.\.|codex-app status: active'}
+# API-backed captures may include backend-specific status lines.
+BUSY_REGEX=${FM_BUSY_REGEX:-'esc (to )?interrupt|Working\.\.\.|codex-app status: active|opencode-server status: busy'}
 
 hash_pane() {
   if command -v md5 >/dev/null 2>&1; then md5 -q; else md5sum | cut -d' ' -f1; fi

--- a/docs/plans/2026-06-21-001-feat-codex-app-visible-threads-plan.md
+++ b/docs/plans/2026-06-21-001-feat-codex-app-visible-threads-plan.md
@@ -1,0 +1,327 @@
+---
+title: "feat: Rework Codex App backend for visible threads"
+type: feat
+date: 2026-06-21
+---
+
+# feat: Rework Codex App backend for visible threads
+
+## Summary
+
+Rework Firstmate's Codex App backend so `FM_BACKEND=codex-app` creates and supervises real Codex Desktop threads visible in the sidebar.
+Keep tmux and Orca behavior unchanged, and ensure the former `codex app-server` path cannot pass as a visible backend.
+
+---
+
+## Problem Frame
+
+Firstmate promises a visible crew: every crewmate should live somewhere the captain can watch, interrupt, and type into.
+The earlier Codex App branch used `codex app-server --stdio --enable remote_control` through `bin/fm-codex-app`.
+Live smoke tests showed that path can complete turns, but its threads do not reliably materialize in Codex Desktop's visible, persisted thread list.
+
+That is the wrong contract for this backend.
+`FM_BACKEND=codex-app` should map to the same app-owned primitives Codex Desktop uses for ordinary thread creation, fork, send, handoff, title, pin, read, and archive.
+Shell scripts can maintain Firstmate state, but they cannot pretend to be the Codex App host.
+
+---
+
+## Requirements
+
+**Visible Thread Contract**
+
+- R1. `FM_BACKEND=codex-app` starts a Codex Desktop thread that is visible in the sidebar with the `fm-<id>` handle.
+- R2. A spawned Codex App crewmate receives the same brief contract as tmux and Orca crewmates, including status-file reporting and delivery-mode rules.
+- R3. Firstmate records enough Codex App metadata to reconcile after restart, including `thread_id`, task kind, project, mode, yolo posture, and any pending worktree handle.
+- R4. A completed or active Codex App task can be read and steered through Codex App thread tools, not through the headless app-server transport.
+
+**Handoff and Context**
+
+- R5. Firstmate supports the normal Codex App handoff shape: fork a completed context when the captain wants a new thread to inherit context, send a follow-up prompt to continue work, and hand off existing visible threads when the captain asks to move them.
+- R6. Project task spawn and current-thread context fork are separate flows, because forking the Firstmate thread is not the same as opening a project-scoped crewmate.
+- R7. Firstmate can adopt an existing visible Codex App thread into `state/<id>.meta` when the captain has already spawned or intervened manually.
+
+**Compatibility and Safety**
+
+- R8. The tmux and Orca backends keep their current command paths, metadata fields, and teardown behavior.
+- R9. The existing app-server implementation is not advertised as the visible Codex App backend unless a smoke test proves sidebar visibility, resume, read, steer, and archive.
+- R10. Ship teardown for Codex App tasks refuses to discard unlanded work unless Firstmate can inspect the app-owned worktree or the captain explicitly approves discard.
+
+**Verification**
+
+- R11. The acceptance smoke for Codex App requires sidebar visibility, `list_threads` discoverability, `read_thread` access, `send_message_to_thread` steering, optional `handoff_thread`, archive, and restart reconciliation.
+- R12. CI keeps enforcing shell syntax, ShellCheck, Node syntax for any retained Node helper, symlink invariants, and no tracked personal fleet paths.
+
+---
+
+## Key Technical Decisions
+
+- KTD1. `codex-app` means visible app-owned threads.
+  The captain asked for Codex App operation, and the existing smoke results showed app-server threads are headless in practice.
+  A backend named `codex-app` that does not show visible threads is worse than no backend because it trains Firstmate to lose the captain's intervention surface.
+
+- KTD2. Split shell-owned state from app-owned thread actions.
+  Firstmate's shell scripts should continue to own briefs, local metadata, safety checks, and backend-neutral helpers.
+  Codex App thread creation, fork, send, handoff, read, title, pin, and archive must be done through Codex App host tools while running inside Codex Desktop.
+
+- KTD3. Treat app-server as headless until proven otherwise.
+  The previous `bin/fm-codex-app` helper spoke app-server JSON-RPC directly.
+  If a non-visible app-server helper returns later, name it separately so it never satisfies visible backend acceptance criteria.
+  Do not let it satisfy the visible backend acceptance criteria.
+
+- KTD4. Add an adoption path for existing visible threads.
+  The captain can spawn, fork, or type into Codex App threads directly.
+  Firstmate should reconcile that reality by recording a visible thread as a managed task instead of insisting every task originate from `fm-spawn.sh`.
+
+- KTD5. Preserve backend independence.
+  The Orca backend already works through Orca worktree and terminal handles.
+  The Codex App pivot should branch only where host-tool mediation is required, leaving tmux and Orca code paths covered by regression checks.
+
+---
+
+## High-Level Technical Design
+
+### Backend Responsibility Split
+
+```mermaid
+flowchart TB
+  Captain["Captain request"] --> Firstmate["Firstmate protocol in AGENTS.md"]
+  Firstmate --> State["Shell state helpers: briefs, meta, backlog, checks"]
+  Firstmate --> Backend{"FM_BACKEND"}
+  Backend --> Tmux["tmux/treehouse path"]
+  Backend --> Orca["Orca worktree + terminal path"]
+  Backend --> CodexVisible["Codex App visible-thread path"]
+  CodexVisible --> AppTools["Codex App host tools"]
+  AppTools --> Thread["Sidebar-visible fm-<id> thread"]
+  Thread --> Status["status/report files wake watcher"]
+  State --> Meta["state/<id>.meta"]
+  Status --> Firstmate
+  Meta --> Firstmate
+```
+
+### Codex App Spawn and Adoption Lifecycle
+
+```mermaid
+stateDiagram-v2
+  [*] --> Prepared: brief and task id exist
+  Prepared --> PendingThread: create or fork requested
+  PendingThread --> VisibleThread: thread id returned
+  VisibleThread --> InFlight: brief/follow-up sent
+  InFlight --> Waiting: status, stale read, or heartbeat
+  Waiting --> InFlight: steer follow-up
+  Waiting --> Ready: report, PR, or local branch ready
+  Ready --> Archived: safe teardown and archive
+  PendingThread --> Failed: app worktree creation failed
+  VisibleThread --> Adopted: captain-created thread recorded
+  Adopted --> InFlight
+```
+
+### Spawn Flow Choice
+
+```mermaid
+flowchart TB
+  Start["Need Codex App crewmate"] --> Context{"Need current thread context?"}
+  Context -->|yes| Fork["fork_thread from completed current context"]
+  Context -->|no| Project{"Project is available to Codex App?"}
+  Project -->|yes| Create["create_thread against project worktree"]
+  Project -->|no| Block["block with saved-project setup/adoption instruction"]
+  Fork --> Send["send_message_to_thread with crewmate brief"]
+  Create --> Title["set title to fm-<id> and optionally pin"]
+  Send --> Record["record state/<id>.meta"]
+  Title --> Record
+  Record --> Supervise["supervise through status files and read_thread"]
+```
+
+---
+
+## Scope Boundaries
+
+### In Scope
+
+- Rework Firstmate's Codex App backend contract around visible Codex Desktop threads.
+- Update AGENTS.md and README.md so they stop implying the app-server path is a visible Codex App backend.
+- Add helper support for recording, adopting, reconciling, and tearing down app-owned thread metadata.
+- Add tests and smoke criteria that protect tmux, Orca, and the new Codex App path.
+
+### Deferred to Follow-Up Work
+
+- Fully automated shell-only Codex App thread creation.
+  That requires an app-exposed CLI or bridge that can invoke host thread tools outside the model tool surface.
+- Mixed-harness Codex App fleets.
+  The Codex App backend should run Codex threads only; tmux and Orca remain the mixed-harness paths.
+- Cloud handoff support beyond the local host and already connected Codex App hosts.
+
+### Out of Scope
+
+- Changing the captain's upstream remote ownership.
+  Work stays on the captain fork and local no-mistakes remote; upstream push remains disabled.
+- Reworking Firstmate's delivery modes.
+  `no-mistakes`, `direct-PR`, and `local-only` behavior stay as they are.
+
+---
+
+## System-Wide Impact
+
+This change affects Firstmate's core supervision model, not just one helper script.
+The watcher remains shell-based, but Codex App visibility and thread status become app-owned state that Firstmate must read through host tools.
+That weakens any assumption that every backend operation can be expressed as one shell command.
+
+The biggest operational consequence is restart recovery.
+For tmux and Orca, `state/<id>.meta` names a terminal-like handle Firstmate can inspect from shell.
+For Codex App, `state/<id>.meta` names a thread handle that only Codex Desktop can read.
+AGENTS.md must make that distinction impossible to miss.
+
+---
+
+## Implementation Units
+
+### U1. Reclassify the Previous App-Server Path
+
+- **Goal:** Prevent the previous app-server helper from being mistaken for the visible Codex App backend.
+- **Requirements:** R1, R4, R9, R11.
+- **Dependencies:** None.
+- **Files:** `bin/fm-codex-app`, `bin/fm-spawn.sh`, `bin/fm-backend.sh`, `bin/fm-watch.sh`, `README.md`, `AGENTS.md`, `test/fm-codex-app-headless.test.sh`.
+- **Approach:** Demote the app-server transport so `FM_BACKEND=codex-app` no longer defaults to a path that live smoke proved headless.
+  Keep the dependency-free Node helper as a visible-thread ledger and make the name and docs honest.
+- **Patterns to follow:** Existing backend switch structure in `bin/fm-backend.sh`; dependency-light helper style in `bin/fm-codex-app`; documentation wording in `README.md`.
+- **Test scenarios:**
+  - With the visible backend selected and no shell host-tool bridge available, spawn stops at preparation with a clear visible-thread action instead of silently using app-server.
+  - The helper syntax-checks as a ledger and contains no app-server transport path.
+  - Documentation no longer describes app-server completion as a successful visible backend smoke.
+- **Verification:** A reader cannot confuse headless app-server completion with a visible Codex App thread, and existing Node syntax checks still pass for any retained helper.
+
+### U2. Add Codex App Visible Thread State Helpers
+
+- **Goal:** Give Firstmate a local state contract for app-owned visible threads without pretending shell owns the app thread.
+- **Requirements:** R1, R3, R4, R7, R10.
+- **Dependencies:** U1.
+- **Files:** `bin/fm-codex-app`, `bin/fm-spawn.sh`, `bin/fm-teardown.sh`, `bin/fm-peek.sh`, `bin/fm-send.sh`, `test/fm-codex-app-state.test.sh`.
+- **Approach:** Refactor the helper around local state operations: prepare spawn metadata, record returned `thread_id` or pending worktree handle, adopt an existing thread, mark archive intent, and expose actionable errors when a shell command needs an app host tool.
+  The shell helper should be a ledger and validator, not the thread transport.
+- **Patterns to follow:** `state/<id>.meta` field style from `fm-spawn.sh`; backend selector helpers in `fm-backend.sh`; teardown refusal language in `fm-teardown.sh`.
+- **Test scenarios:**
+  - Recording a visible thread writes backend, window, project, harness, kind, mode, yolo, and thread id without disturbing Orca-specific fields.
+  - Adoption refuses duplicate task ids and duplicate thread ids.
+  - A pending worktree record survives restart reconciliation and is distinguishable from a completed visible thread record.
+  - Shell send/peek commands for visible Codex App threads fail with host-tool instructions when no app bridge result is provided.
+- **Verification:** Firstmate can reconstruct task identity from meta alone, and shell-only attempts cannot accidentally talk to app-server.
+
+### U3. Teach AGENTS.md the Host-Tool Codex App Protocol
+
+- **Goal:** Make Codex App mode executable by a Firstmate agent running inside Codex Desktop.
+- **Requirements:** R1, R2, R4, R5, R6, R7, R11.
+- **Dependencies:** U2.
+- **Files:** `AGENTS.md`, `README.md`, `test/fm-doc-codex-app-protocol.test.sh`.
+- **Approach:** Add a Codex App backend subsection that says when to use `create_thread`, `fork_thread`, `send_message_to_thread`, `handoff_thread`, `read_thread`, `list_threads`, `set_thread_title`, `set_thread_pinned`, and `set_thread_archived`.
+  The protocol should distinguish project task spawn from current-thread handoff, because they preserve different context.
+- **Patterns to follow:** Existing adapter verification tables in AGENTS.md; backend lifecycle prose in AGENTS.md section 7; "visible crew" language in README.md.
+- **Test scenarios:**
+  - The docs state that Codex App host tools are required for visible mode and that shell app-server is not equivalent.
+  - Project spawn instructions use project-scoped thread creation rather than forking the Firstmate repo by habit.
+  - Current-thread context handoff instructions use fork/send semantics and warn that only completed history is copied.
+  - Existing Orca instructions remain present and unchanged in meaning.
+- **Verification:** A fresh Codex App Firstmate session can follow AGENTS.md to spawn, steer, adopt, and archive a visible thread without reading prior chat.
+
+### U4. Update Spawn, Send, Peek, Watch, and Teardown Semantics
+
+- **Goal:** Make backend-neutral commands safe around visible Codex App metadata while keeping tmux and Orca behavior intact.
+- **Requirements:** R3, R4, R8, R10, R11.
+- **Dependencies:** U2, U3.
+- **Files:** `bin/fm-spawn.sh`, `bin/fm-backend.sh`, `bin/fm-send.sh`, `bin/fm-peek.sh`, `bin/fm-watch.sh`, `bin/fm-teardown.sh`, `test/fm-backend-regression.test.sh`, `test/fm-codex-app-state.test.sh`, `test/fm-codex-app-teardown.test.sh`.
+- **Approach:** Keep tmux and Orca command execution as-is.
+  For visible Codex App records, shell commands either update local state from an app-tool result or print a precise host-tool action requirement.
+  Teardown must archive the visible thread through Codex App only after the worktree safety check is satisfied or the captain explicitly approves discard.
+- **Patterns to follow:** Existing backend case statements; refusal-first safety posture in `fm-teardown.sh`; watcher signal coalescing in `fm-watch.sh`.
+- **Test scenarios:**
+  - tmux backend selection and fallback behavior are unchanged.
+  - Orca metadata, terminal send, peek, and teardown branches still parse and route exactly as before.
+  - Codex App meta with a visible thread id is selectable by `fm-<id>` and by raw thread id.
+  - Codex App teardown refuses ship work when worktree safety cannot be proven.
+  - Scout teardown allows archive only after `data/<id>/report.md` exists.
+- **Verification:** ShellCheck passes, backend regression tests pass, and Codex App visible records never fall back to tmux or app-server by accident.
+
+### U5. Add Visible-Thread Smoke Contract
+
+- **Goal:** Replace the weak "turn completed" smoke with acceptance criteria that prove the captain can operate through Codex Desktop.
+- **Requirements:** R1, R4, R5, R7, R8, R11, R12.
+- **Dependencies:** U3, U4.
+- **Files:** `README.md`, `AGENTS.md`, `CONTRIBUTING.md`, `.github/workflows/ci.yml`, `test/fm-codex-app-smoke-contract.test.sh`.
+- **Approach:** Document and automate what can be automated locally, then leave the live Desktop smoke as an explicit manual verification item when host tools are required.
+  The smoke contract should require visibility, list/read discovery, steering, handoff or fork behavior, status-file wake, restart recovery, and archive.
+- **Patterns to follow:** Development checks in README.md; empirical-verification rule for harness adapters in CONTRIBUTING.md; CI's dependency-light style.
+- **Test scenarios:**
+  - A fake visible-thread transcript that lacks `list_threads` discoverability fails the contract.
+  - A fake transcript that completes a turn but cannot be read after runner exit fails the contract.
+  - A fake transcript with create/read/send/archive evidence passes the non-interactive contract parser.
+  - CI runs the new shell tests without tracking personal fleet paths.
+- **Verification:** The same failure mode captured in local smoke reports cannot be reported as green again.
+
+### U6. Run the Real Desktop Smoke Before PR Merge
+
+- **Goal:** Prove the redesigned backend works on the actual Codex Desktop surface before the captain merges it.
+- **Requirements:** R1, R2, R4, R5, R7, R8, R10, R11.
+- **Dependencies:** U1, U2, U3, U4, U5.
+- **Files:** `data/<smoke-id>/brief.md`, `data/<smoke-id>/report.md`, `state/<smoke-id>.meta`, `README.md`.
+- **Approach:** Use a throwaway scout task in Codex App mode.
+  Verify the thread appears in the sidebar as `fm-<id>`, can be found through `list_threads`, can be read through `read_thread`, accepts a follow-up through `send_message_to_thread`, and can be archived after the report exists.
+  Then run an Orca regression smoke or equivalent command-path check to confirm that backend still works.
+- **Patterns to follow:** Existing scout task contract in `bin/fm-brief.sh`; local smoke report style under `data/codex-app-live-smoke-*/report.md`.
+- **Test scenarios:**
+  - The Codex App scout writes `data/<id>/report.md` and `state/<id>.status`.
+  - The thread remains visible and readable after the first turn completes.
+  - A follow-up message reaches the same visible thread.
+  - Teardown archives the thread and removes local state only after safety checks pass.
+  - Orca backend smoke still creates a worktree and terminal handle or reports a precise environment blocker.
+- **Verification:** The PR body includes the visible-thread smoke result, the Orca preservation result, and any remaining manual caveats.
+
+---
+
+## Acceptance Examples
+
+- AE1. Given `FM_BACKEND=codex-app` and a saved Codex App project, when Firstmate spawns `fm-demo`, then the captain sees an `fm-demo` thread in Codex Desktop and Firstmate records its thread id.
+- AE2. Given a visible Codex App crewmate has finished its first turn, when Firstmate sends a follow-up, then the same thread receives the prompt and the new turn is readable.
+- AE3. Given a headless app-server turn completes but never appears in `list_threads`, when the smoke contract is evaluated, then the backend is rejected as not visible.
+- AE4. Given Orca remains selected, when Firstmate spawns a task, then it still uses Orca worktree and terminal handles rather than any Codex App path.
+- AE5. Given a Codex App ship task has unpushed or unmerged work, when teardown runs, then Firstmate refuses unless the captain explicitly approves discard.
+
+---
+
+## Risks & Dependencies
+
+- **Host-tool availability:** Codex App visible mode depends on app tools that are available to Codex Desktop agents, not ordinary shell scripts.
+  If those tools are unavailable, the backend must block with a clear message rather than falling back to app-server.
+- **Worktree path discoverability:** Teardown safety depends on knowing where the app-owned worktree lives or proving that work has landed elsewhere.
+  Ship tasks should remain blocked until the implementation can prove that safety path.
+- **Watcher limitations:** The shell watcher cannot poll Codex App host tools by itself.
+  Codex App crewmates must write status files, and Firstmate must use `read_thread` during status, stale, and heartbeat handling.
+- **PR confusion:** At planning time, the captain fork had an open PR for the headless implementation.
+  That PR should be revised or replaced before merge; merging it as-is would codify the wrong backend contract.
+
+---
+
+## Open Questions
+
+- OQ1. Does the current Codex App thread read/list surface expose the app-owned worktree path reliably enough for ship-task teardown safety?
+  If not, visible Codex App mode should start with scout/adoption support and keep ship teardown blocked until a safe path exists.
+- OQ2. Is there an installable Codex App bridge that lets Firstmate scripts invoke host thread tools directly?
+  Without that bridge, Codex App visible mode is an in-app Firstmate protocol plus shell state helpers, not a pure shell backend.
+
+---
+
+## Documentation / Operational Notes
+
+- README.md should say `codex-app` requires running Firstmate inside Codex Desktop because visible thread operations are app-owned.
+- AGENTS.md should make `create_thread` versus `fork_thread` a first-class decision.
+  Project work should use project-scoped creation; current-context handoff should use fork/send.
+- CONTRIBUTING.md should require empirical Codex Desktop smoke evidence for any future changes to the Codex App backend, the same way harness adapters require live verification.
+
+---
+
+## Sources & Research
+
+- The previous `bin/fm-codex-app` path started `codex app-server --stdio --enable remote_control` and called thread JSON-RPC directly.
+- The previous `bin/fm-spawn.sh` path mapped `FM_BACKEND=codex-app` to a local git worktree plus the app-server helper.
+- `bin/fm-backend.sh`, `bin/fm-send.sh`, `bin/fm-peek.sh`, `bin/fm-watch.sh`, and `bin/fm-teardown.sh` now preserve tmux and Orca behavior through backend switch points.
+- `README.md` and `AGENTS.md` now describe Codex App mode as a visible-thread protocol rather than app-server completion.
+- Local smoke reports under `data/codex-app-live-smoke-*/report.md` show completed or interrupted app-server turns that were not visible or persisted in Codex Desktop thread discovery.
+- Codex Desktop currently exposes visible-thread host tools for project thread creation, thread fork, follow-up send, handoff, read, list, title, pin, and archive.
+- At planning time, the captain fork PR for the headless implementation was open at `https://github.com/SSBrouhard/firstmate/pull/1`; upstream push remained disabled.

--- a/test/fm-backend-regression.test.sh
+++ b/test/fm-backend-regression.test.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -eu
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP=$(mktemp -d "${TMPDIR:-/tmp}/fm-backend-regression.XXXXXX")
+ID=codex-app-test-$$
+cleanup() {
+  rm -rf "$TMP" "$ROOT/data/$ID" "$ROOT/state/$ID.meta" "$ROOT/state/$ID.turn-ended" "$ROOT/state/$ID.codex-app.capture"
+}
+trap cleanup EXIT
+
+backend_name() {
+  FM_ROOT="$TMP" bash -c '. "$1/bin/fm-backend.sh"; fm_backend_name' bash "$ROOT"
+}
+
+[ "$(backend_name)" = tmux ]
+mkdir -p "$TMP/config"
+printf 'orca\n' > "$TMP/config/backend"
+[ "$(backend_name)" = orca ]
+printf 'FM_BACKEND="codex-app"\n' > "$TMP/config/backend.env"
+[ "$(backend_name)" = orca ]
+FM_BACKEND=codex-app FM_ROOT="$TMP" bash -c '. "$1/bin/fm-backend.sh"; fm_backend_name' bash "$ROOT" | grep -qx codex-app
+
+mkdir -p "$ROOT/data/$ID" "$ROOT/state" "$TMP/project"
+printf 'brief\n' > "$ROOT/data/$ID/brief.md"
+OUT=$(FM_BACKEND=codex-app "$ROOT/bin/fm-spawn.sh" "$ID" "$TMP/project" codex)
+printf '%s\n' "$OUT" | grep -q '^prepared '
+printf '%s\n' "$OUT" | grep -q 'create_thread or fork_thread'
+META="$ROOT/state/$ID.meta"
+grep -qx 'backend=codex-app' "$META"
+grep -qx 'window=fm-'"$ID" "$META"
+grep -qx 'codex_app_thread_state=pending' "$META"
+grep -qx 'codex_app_pending_action=create_thread_or_fork_thread' "$META"
+! grep -q '^thread_id=' "$META"
+! grep -q '^codex_app_runner_pid=' "$META"
+! grep -q '^codex_app_state=' "$META"
+printf 'thread_id=thread-enter\n' >> "$META"
+if FM_ROOT="$ROOT" bash -c '. "$1/bin/fm-backend.sh"; fm_backend_send_key "$2" Enter' bash "$ROOT" "$META" 2>"$TMP/enter.err"; then
+  echo "expected Codex App Enter key send to fail through host-tool refusal" >&2
+  exit 1
+fi
+grep -q 'send_message_to_thread' "$TMP/enter.err"
+
+meta_line=$(grep -n '> "$FM_ROOT/state/$ID.meta"' "$ROOT/bin/fm-spawn.sh" | cut -d: -f1)
+orca_launch_line=$(grep -n 'orca terminal send --terminal "$ORCA_TERMINAL" --text "$LAUNCH"' "$ROOT/bin/fm-spawn.sh" | cut -d: -f1)
+[ "$meta_line" -lt "$orca_launch_line" ]
+
+grep -q 'FM_ORCA_CODEX_AUTO_TRUST' "$ROOT/bin/fm-spawn.sh"
+if grep -q 'codex\\*) fm_backend_trust_codex_project "$WT"' "$ROOT/bin/fm-spawn.sh"; then
+  echo "Orca+Codex trust must be explicit opt-in" >&2
+  exit 1
+fi

--- a/test/fm-backend-regression.test.sh
+++ b/test/fm-backend-regression.test.sh
@@ -20,6 +20,8 @@ printf 'orca\n' > "$TMP/config/backend"
 printf 'FM_BACKEND="codex-app"\n' > "$TMP/config/backend.env"
 [ "$(backend_name)" = orca ]
 FM_BACKEND=codex-app FM_ROOT="$TMP" bash -c '. "$1/bin/fm-backend.sh"; fm_backend_name' bash "$ROOT" | grep -qx codex-app
+printf 'opencode-server\n' > "$TMP/config/backend"
+[ "$(backend_name)" = opencode-server ]
 
 mkdir -p "$ROOT/data/$ID" "$ROOT/state" "$TMP/project"
 printf 'brief\n' > "$ROOT/data/$ID/brief.md"

--- a/test/fm-codex-app-headless.test.sh
+++ b/test/fm-codex-app-headless.test.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -eu
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP=$(mktemp -d "${TMPDIR:-/tmp}/fm-codex-app-headless.XXXXXX")
+trap 'rm -rf "$TMP"' EXIT
+
+if grep -q 'app-server' "$ROOT/bin/fm-codex-app"; then
+  echo "fm-codex-app must not start codex app-server in visible-thread mode" >&2
+  exit 1
+fi
+
+if FM_ROOT="$TMP" "$ROOT/bin/fm-codex-app" send thread-1 hello 2>"$TMP/send.err"; then
+  echo "expected shell send to visible Codex App thread to fail" >&2
+  exit 1
+fi
+grep -q 'send_message_to_thread' "$TMP/send.err"
+
+if FM_ROOT="$TMP" "$ROOT/bin/fm-codex-app" archive thread-1 2>"$TMP/archive.err"; then
+  echo "expected shell archive to visible Codex App thread to fail" >&2
+  exit 1
+fi
+grep -q 'set_thread_archived' "$TMP/archive.err"

--- a/test/fm-codex-app-smoke-contract.test.sh
+++ b/test/fm-codex-app-smoke-contract.test.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -eu
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP=$(mktemp -d "${TMPDIR:-/tmp}/fm-codex-app-smoke.XXXXXX")
+trap 'rm -rf "$TMP"' EXIT
+
+cat > "$TMP/pass.txt" <<EOF
+visible_thread=ok
+list_threads=ok
+read_thread=ok
+send_message_to_thread=ok
+archive=ok
+restart_reconcile=ok
+EOF
+"$ROOT/bin/fm-codex-app-smoke-check.sh" "$TMP/pass.txt" | grep -qx 'codex-app visible smoke: passed'
+
+cat > "$TMP/no-list.txt" <<EOF
+visible_thread=ok
+read_thread=ok
+send_message_to_thread=ok
+archive=ok
+restart_reconcile=ok
+EOF
+if "$ROOT/bin/fm-codex-app-smoke-check.sh" "$TMP/no-list.txt" 2>"$TMP/no-list.err"; then
+  echo "expected missing list_threads evidence to fail" >&2
+  exit 1
+fi
+grep -q 'missing list_threads=ok' "$TMP/no-list.err"
+
+cat > "$TMP/headless.txt" <<EOF
+app_server_only=1
+visible_thread=ok
+list_threads=ok
+read_thread=ok
+send_message_to_thread=ok
+archive=ok
+restart_reconcile=ok
+EOF
+if "$ROOT/bin/fm-codex-app-smoke-check.sh" "$TMP/headless.txt" 2>"$TMP/headless.err"; then
+  echo "expected headless-only evidence to fail" >&2
+  exit 1
+fi
+grep -q 'headless-only evidence' "$TMP/headless.err"

--- a/test/fm-codex-app-state.test.sh
+++ b/test/fm-codex-app-state.test.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -eu
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP=$(mktemp -d "${TMPDIR:-/tmp}/fm-codex-app-state.XXXXXX")
+trap 'rm -rf "$TMP"' EXIT
+
+mkdir -p "$TMP/state"
+ID=state-test
+META="$TMP/state/$ID.meta"
+cat > "$META" <<EOF
+backend=codex-app
+window=fm-$ID
+project=/tmp/example
+harness=codex
+kind=scout
+mode=no-mistakes
+yolo=off
+EOF
+
+FM_ROOT="$TMP" "$ROOT/bin/fm-codex-app" record-thread "$ID" thread-1 --turn-id turn-1 --pending-worktree-id pending-1 >/dev/null
+grep -qx 'thread_id=thread-1' "$META"
+grep -qx 'turn_id=turn-1' "$META"
+grep -qx 'codex_app_pending_worktree_id=pending-1' "$META"
+grep -qx 'codex_app_thread_state=visible' "$META"
+grep -qx 'codex_app_transport=visible-thread' "$META"
+
+PENDING_ID=pending-loss
+PENDING_META="$TMP/state/$PENDING_ID.meta"
+cat > "$PENDING_META" <<EOF
+backend=codex-app
+window=fm-$PENDING_ID
+project=/tmp/example
+harness=codex
+kind=scout
+mode=no-mistakes
+yolo=off
+EOF
+FM_ROOT="$TMP" "$ROOT/bin/fm-codex-app" record-pending "$PENDING_ID" pending-2 >/dev/null
+FM_ROOT="$TMP" "$ROOT/bin/fm-codex-app" record-thread "$PENDING_ID" thread-pending >/dev/null
+grep -qx 'codex_app_pending_worktree_id=pending-2' "$PENDING_META"
+
+printf 'first\nsecond\nthird\n' | FM_ROOT="$TMP" "$ROOT/bin/fm-codex-app" record-capture "$ID" - >/dev/null
+[ "$(FM_ROOT="$TMP" "$ROOT/bin/fm-codex-app" capture thread-1 2)" = "$(printf 'second\nthird')" ]
+
+FM_ROOT="$TMP" "$ROOT/bin/fm-codex-app" mark-archived "$ID" >/dev/null
+grep -qx 'codex_app_archived=1' "$META"
+grep -qx 'codex_app_thread_state=archived' "$META"
+
+cat > "$TMP/state/other.meta" <<EOF
+backend=codex-app
+window=fm-other
+thread_id=thread-1
+EOF
+cat > "$TMP/state/third.meta" <<EOF
+backend=codex-app
+window=fm-third
+project=/tmp/example
+harness=codex
+kind=scout
+mode=no-mistakes
+yolo=off
+EOF
+if FM_ROOT="$TMP" "$ROOT/bin/fm-codex-app" record-thread third thread-1 2>"$TMP/duplicate.err"; then
+  echo "expected duplicate thread record to fail" >&2
+  exit 1
+fi
+grep -q 'already recorded' "$TMP/duplicate.err"
+
+if FM_ROOT="$TMP" "$ROOT/bin/fm-codex-app" record-thread missing thread-missing 2>"$TMP/missing-meta.err"; then
+  echo "expected record-thread without prepared meta to fail" >&2
+  exit 1
+fi
+grep -q 'requires existing meta' "$TMP/missing-meta.err"
+
+mkdir -p "$TMP/data"
+cat > "$TMP/data/projects.md" <<EOF
+- example [direct-PR +yolo] - Example project (added 2026-06-21)
+EOF
+FM_ROOT="$TMP" "$ROOT/bin/fm-codex-app" adopt-thread adopted thread-2 /tmp/example --kind scout --thread-name fm-adopted --worktree /tmp/wt >/dev/null
+ADOPTED_META="$TMP/state/adopted.meta"
+grep -qx 'backend=codex-app' "$ADOPTED_META"
+grep -qx 'window=fm-adopted' "$ADOPTED_META"
+grep -qx 'worktree=/tmp/wt' "$ADOPTED_META"
+grep -qx 'project=/tmp/example' "$ADOPTED_META"
+grep -qx 'harness=codex' "$ADOPTED_META"
+grep -qx 'kind=scout' "$ADOPTED_META"
+grep -qx 'mode=direct-PR' "$ADOPTED_META"
+grep -qx 'yolo=on' "$ADOPTED_META"
+grep -qx 'thread_id=thread-2' "$ADOPTED_META"
+grep -qx 'codex_app_thread_state=visible' "$ADOPTED_META"
+grep -qx 'codex_app_pending_action=none' "$ADOPTED_META"
+
+if FM_ROOT="$TMP" "$ROOT/bin/fm-codex-app" adopt-thread adopted thread-3 /tmp/example --kind scout 2>"$TMP/duplicate-task.err"; then
+  echo "expected duplicate task adoption to fail" >&2
+  exit 1
+fi
+grep -q 'already has meta' "$TMP/duplicate-task.err"
+
+if FM_ROOT="$TMP" "$ROOT/bin/fm-codex-app" adopt-thread adopted-other thread-2 /tmp/example --kind scout 2>"$TMP/duplicate-thread.err"; then
+  echo "expected duplicate thread adoption to fail" >&2
+  exit 1
+fi
+grep -q 'already recorded' "$TMP/duplicate-thread.err"

--- a/test/fm-codex-app-teardown.test.sh
+++ b/test/fm-codex-app-teardown.test.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+set -eu
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ID=codex-app-teardown-$$
+SCOUT_ID=codex-app-scout-teardown-$$
+OTHER_ID=codex-app-other-worktree-$$
+DIRTY_ID=codex-app-dirty-worktree-$$
+TMP=$(mktemp -d "${TMPDIR:-/tmp}/fm-codex-app-teardown.XXXXXX")
+META="$ROOT/state/$ID.meta"
+SCOUT_META="$ROOT/state/$SCOUT_ID.meta"
+SCOUT_CAPTURE="$ROOT/state/$SCOUT_ID.codex-app.capture"
+OTHER_META="$ROOT/state/$OTHER_ID.meta"
+DIRTY_META="$ROOT/state/$DIRTY_ID.meta"
+cleanup() {
+  rm -rf "$TMP"
+  rm -rf "$ROOT/data/$SCOUT_ID"
+  rm -f "$META" "$SCOUT_META" "$SCOUT_CAPTURE" "$OTHER_META" "$DIRTY_META" "$ROOT/state/$OTHER_ID.err" "$ROOT/state/$DIRTY_ID.err"
+}
+trap cleanup EXIT
+
+mkdir -p "$ROOT/state"
+cat > "$META" <<EOF
+backend=codex-app
+window=fm-$ID
+worktree=/tmp/firstmate-missing-codex-app-worktree-$ID
+project=$ROOT
+harness=codex
+kind=ship
+mode=no-mistakes
+yolo=off
+thread_id=thread-$ID
+codex_app_archived=1
+EOF
+
+if "$ROOT/bin/fm-teardown.sh" "$ID" 2>"$ROOT/state/$ID.err"; then
+  echo "expected teardown with invalid Codex App ship worktree to fail" >&2
+  rm -f "$ROOT/state/$ID.err"
+  exit 1
+fi
+grep -q 'invalid worktree path' "$ROOT/state/$ID.err"
+rm -f "$ROOT/state/$ID.err"
+
+git init "$TMP/project" >/dev/null
+git -C "$TMP/project" config user.email firstmate-test@example.com
+git -C "$TMP/project" config user.name Firstmate
+printf 'project\n' > "$TMP/project/README.md"
+git -C "$TMP/project" add README.md
+git -C "$TMP/project" commit -m init >/dev/null
+
+git init "$TMP/other" >/dev/null
+git -C "$TMP/other" config user.email firstmate-test@example.com
+git -C "$TMP/other" config user.name Firstmate
+printf 'other\n' > "$TMP/other/README.md"
+git -C "$TMP/other" add README.md
+git -C "$TMP/other" commit -m init >/dev/null
+git -C "$TMP/other" checkout -b "fm/$OTHER_ID" >/dev/null 2>&1
+cat > "$OTHER_META" <<EOF
+backend=codex-app
+window=fm-$OTHER_ID
+worktree=$TMP/other
+project=$TMP/project
+harness=codex
+kind=ship
+mode=no-mistakes
+yolo=off
+thread_id=thread-$OTHER_ID
+codex_app_archived=1
+EOF
+if "$ROOT/bin/fm-teardown.sh" "$OTHER_ID" 2>"$ROOT/state/$OTHER_ID.err"; then
+  echo "expected teardown with unrelated Codex App worktree to fail" >&2
+  exit 1
+fi
+grep -q 'worktree does not belong to project' "$ROOT/state/$OTHER_ID.err"
+
+git -C "$TMP/project" checkout -b "fm/$DIRTY_ID" >/dev/null 2>&1
+printf 'dirty\n' > "$TMP/project/dirty.txt"
+cat > "$DIRTY_META" <<EOF
+backend=codex-app
+window=fm-$DIRTY_ID
+worktree=$TMP/project
+project=$TMP/project
+harness=codex
+kind=ship
+mode=no-mistakes
+yolo=off
+thread_id=thread-$DIRTY_ID
+EOF
+if "$ROOT/bin/fm-teardown.sh" "$DIRTY_ID" 2>"$ROOT/state/$DIRTY_ID.err"; then
+  echo "expected teardown with unlanded Codex App worktree to fail" >&2
+  exit 1
+fi
+grep -q 'has work not on any remote' "$ROOT/state/$DIRTY_ID.err"
+if grep -q 'not marked archived' "$ROOT/state/$DIRTY_ID.err"; then
+  echo "expected work safety refusal before archive refusal" >&2
+  exit 1
+fi
+
+mkdir -p "$ROOT/data/$SCOUT_ID"
+printf 'report\n' > "$ROOT/data/$SCOUT_ID/report.md"
+printf 'cached transcript\n' > "$SCOUT_CAPTURE"
+cat > "$SCOUT_META" <<EOF
+backend=codex-app
+window=fm-$SCOUT_ID
+worktree=
+project=$ROOT
+harness=codex
+kind=scout
+mode=no-mistakes
+yolo=off
+thread_id=thread-$SCOUT_ID
+codex_app_archived=1
+EOF
+
+"$ROOT/bin/fm-teardown.sh" "$SCOUT_ID" >/dev/null
+[ ! -e "$SCOUT_META" ]
+[ ! -e "$SCOUT_CAPTURE" ]

--- a/test/fm-doc-codex-app-protocol.test.sh
+++ b/test/fm-doc-codex-app-protocol.test.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -eu
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+grep -q 'visible Codex Desktop threads' "$ROOT/AGENTS.md"
+grep -q 'create_thread' "$ROOT/AGENTS.md"
+grep -q 'fork_thread' "$ROOT/AGENTS.md"
+grep -q 'send_message_to_thread' "$ROOT/AGENTS.md"
+grep -q 'set_thread_archived' "$ROOT/AGENTS.md"
+grep -q 'adopt-thread' "$ROOT/AGENTS.md"
+grep -q 'app-server.*headless' "$ROOT/README.md"
+grep -q 'A completed app-server turn is not enough' "$ROOT/CONTRIBUTING.md"
+
+if grep -q 'Codex CLI when FM_BACKEND=codex-app' "$ROOT/README.md"; then
+  echo "README must not describe Codex App visible mode as Codex CLI app-server mode" >&2
+  exit 1
+fi

--- a/test/fm-opencode-server-state.test.sh
+++ b/test/fm-opencode-server-state.test.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -eu
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP=$(mktemp -d "${TMPDIR:-/tmp}/fm-opencode-server.XXXXXX")
+ID=opencode-server-test-$$
+META="$ROOT/state/$ID.meta"
+
+cleanup() {
+  PATH="$TMP/bin:$PATH" FM_OPENCODE_SERVER_MOCK=1 "$ROOT/bin/fm-teardown.sh" "$ID" --force >/dev/null 2>&1 || true
+  rm -rf "$TMP" "$ROOT/data/$ID"
+  rm -f "$META" "$ROOT/state/$ID.status" "$ROOT/state/$ID.turn-ended" "$ROOT/state/$ID.opencode-server.log"
+}
+trap cleanup EXIT
+
+mkdir -p "$TMP/bin" "$ROOT/data/$ID" "$ROOT/state"
+cat > "$TMP/bin/opencode" <<'EOF'
+#!/usr/bin/env bash
+case "${1:-}" in
+  --version) echo "opencode 0-test" ;;
+  *) exit 0 ;;
+esac
+EOF
+chmod +x "$TMP/bin/opencode"
+printf '@echo off\r\nif "%%1"=="--version" echo opencode 0-test\r\nexit /b 0\r\n' > "$TMP/bin/opencode.cmd"
+
+git init --bare "$TMP/origin.git" >/dev/null
+git init "$TMP/project" >/dev/null
+git -C "$TMP/project" config user.email firstmate-test@example.com
+git -C "$TMP/project" config user.name Firstmate
+git -C "$TMP/project" config core.autocrlf false
+git -C "$TMP/project" config core.eol lf
+git -C "$TMP/project" config core.filemode false
+printf 'project\n' > "$TMP/project/README.md"
+git -C "$TMP/project" add README.md
+git -C "$TMP/project" commit -m init >/dev/null
+git -C "$TMP/project" branch -M main
+git -C "$TMP/project" remote add origin "$TMP/origin.git"
+git -C "$TMP/project" push -u origin main >/dev/null 2>&1
+
+printf 'brief\n' > "$ROOT/data/$ID/brief.md"
+OUT=$(PATH="$TMP/bin:$PATH" FM_BACKEND=opencode-server FM_OPENCODE_SERVER_MOCK=1 "$ROOT/bin/fm-spawn.sh" "$ID" "$TMP/project" opencode)
+printf '%s\n' "$OUT" | grep -q '^spawned '
+printf '%s\n' "$OUT" | grep -q 'backend=opencode-server'
+printf '%s\n' "$OUT" | grep -q 'session=mock-'
+
+grep -qx 'backend=opencode-server' "$META"
+grep -qx "window=fm-$ID" "$META"
+grep -qx 'harness=opencode' "$META"
+grep -qx 'kind=ship' "$META"
+grep -qx 'mode=no-mistakes' "$META"
+grep -qx 'yolo=off' "$META"
+grep -qx 'opencode_server_url=http://127.0.0.1:0' "$META"
+grep -qx 'opencode_server_pid=0' "$META"
+grep -qx "opencode_session_id=mock-$ID" "$META"
+grep -qx "opencode_session_title=fm-$ID" "$META"
+grep -qx 'opencode_session_state=active' "$META"
+
+WT=$(grep '^worktree=' "$META" | cut -d= -f2-)
+case "$WT" in
+  "$ROOT/state/opencode-server-worktrees/$ID") ;;
+  *) echo "unexpected worktree path: $WT" >&2; exit 1 ;;
+esac
+[ -d "$WT" ]
+git -C "$WT" rev-parse --is-inside-work-tree >/dev/null
+
+CAPTURE=$(FM_ROOT="$ROOT" FM_OPENCODE_SERVER_MOCK=1 bash -c '. "$1/bin/fm-backend.sh"; fm_backend_capture "$2" 5' bash "$ROOT" "$META")
+printf '%s\n' "$CAPTURE" | grep -q 'opencode-server status: idle'
+STATUS=$(FM_ROOT="$ROOT" FM_OPENCODE_SERVER_MOCK=1 bash -c '. "$1/bin/fm-backend.sh"; fm_backend_status "$2"' bash "$ROOT" "$META")
+[ "$STATUS" = status=idle ]
+FM_ROOT="$ROOT" FM_OPENCODE_SERVER_MOCK=1 bash -c '. "$1/bin/fm-backend.sh"; fm_backend_send_text "$2" "hello"' bash "$ROOT" "$META"
+FM_ROOT="$ROOT" FM_OPENCODE_SERVER_MOCK=1 bash -c '. "$1/bin/fm-backend.sh"; fm_backend_send_key "$2" Escape' bash "$ROOT" "$META"
+
+if ! PATH="$TMP/bin:$PATH" FM_OPENCODE_SERVER_MOCK=1 "$ROOT/bin/fm-teardown.sh" "$ID" >"$TMP/teardown.out" 2>"$TMP/teardown.err"; then
+  git -C "$WT" status --porcelain >&2 || true
+  cat "$TMP/teardown.err" >&2
+  exit 1
+fi
+[ ! -e "$META" ]
+[ ! -d "$WT" ]


### PR DESCRIPTION
## Summary
- add an opencode-server backend that drives task-local OpenCode serve sessions through the HTTP API
- wire capture, send, interrupt/status, spawn metadata, teardown, bootstrap checks, docs, and watcher busy detection
- add regression coverage for opencode-server metadata/state behavior without requiring a live server

## Testing
- node --check bin/fm-codex-app bin/fm-opencode-server
- shell syntax checks via LF-normalized temp copies
- full test/*.test.sh suite via LF-normalized temp copy
- live FM_BACKEND=opencode-server fm-spawn smoke against a disposable git repo, with prompt capture and cleanup