### PR TITLE
fix(watcher): preserve PR-check wakes before suppression

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -425,7 +425,7 @@ Use chat for yes/no decisions; use lavish-axi when there are multiple findings o
 For PR-based ship tasks, the ready signal depends on mode: `no-mistakes` reports `done: PR <url> checks green` after CI is green, while `direct-PR` reports `done: PR <url>` after opening the PR.
 Run `bin/fm-pr-check.sh <id> <PR url>` - it records `pr=` in the task's meta and arms the watcher's merge poll.
 Tell the captain: the PR's full URL (always the complete `https://...` link, never a bare `#number` - the captain's terminal makes a full URL clickable), a one-paragraph summary, and, for `no-mistakes`, the risk level it emitted.
-(The check contract, for any custom `state/<id>.check.sh` you write yourself: print one line only when firstmate should wake, print nothing otherwise, and finish before `FM_CHECK_TIMEOUT`.)
+(The check contract, for any custom `state/<id>.check.sh` you write yourself: **print the current state every run** (idempotent), e.g. `echo "merged"` while merged. The watcher dedups against `.seen-check-<name>` and enqueues to the durable queue *before* advancing that marker, so a lost stdout or a crashed watcher can never swallow a wake - the same lossless guarantee signals enjoy. Edge-triggered checks that self-suppress via their own `.babysit-*.seen` are tolerated (empty stdout = no wake), but a swallowed transition is only recovered by the watcher's catch-all backstop, so prefer the stateless "always print current state" form. Finish before `FM_CHECK_TIMEOUT`.)
 
 If the captain says "merge it", run `gh-axi pr merge` yourself; that instruction is the explicit approval. If `yolo=on`, merge a green/approved PR yourself and post the required FYI.
 
@@ -470,7 +470,7 @@ From there the task is an ordinary ship task through its mode-specific validatio
 The watcher is the backbone.
 Whenever at least one task is in flight, `bin/fm-watch.sh` must be running as a background task.
 It costs zero tokens while running and exits with one reason line when something needs you.
-It also writes each detected wake to the durable queue at `state/.wake-queue` before advancing suppression markers such as `.seen-*`, `.stale-*`, `.last-check`, or `.last-heartbeat`.
+It also writes each detected wake to the durable queue at `state/.wake-queue` before advancing suppression markers such as `.seen-*`, `.stale-*`, `.seen-check-*`, `.escalated-*`, `.last-check`, or `.last-heartbeat`.
 At the start of every wake-handling turn and every recovery turn, run `bin/fm-wake-drain.sh` before peeking panes, reading status files beyond the reason line, or starting new work.
 The printed one-shot reason line is still useful, but the drained queue is the lossless backlog.
 After handling drained wakes, re-arm `bin/fm-watch.sh` before you end the turn.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,7 +85,7 @@ state/               volatile runtime signals; gitignored
   .wake-queue        durable queued wakes: epoch<TAB>seq<TAB>kind<TAB>key<TAB>payload
   .afk               durable away-mode flag; present = sub-supervisor may inject escalations (set by /afk, cleared on user return)
   .watch.lock .wake-queue.lock watcher singleton and queue serialization locks
-  .hash-* .count-* .stale-* .seen-* .last-* .heartbeat-streak   watcher internals; never touch
+  .hash-* .count-* .stale-* .seen-* .babysit-* .escalated-* .last-* .heartbeat-streak   watcher internals; never touch
   .last-watcher-beat watcher liveness beacon, touched every poll; fm-guard.sh reads it
   .subsuper-* .supervise-daemon.*   sub-supervisor internals (stale markers, escalation buffer, seen-status dedup, log, lock, pid); never touch
 .no-mistakes/        local validation state and evidence; gitignored

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ firstmate works from any terminal - outside tmux, crewmates land in a detached `
 
 - **Event-driven supervision** - a zero-token bash watcher (`bin/fm-watch.sh`) sleeps on the fleet and wakes the first mate only when a crewmate reports, stalls, a PR merges, or an internal heartbeat review is due.
   Detected wakes are also written to a durable local queue (`state/.wake-queue`) before detector state advances, so a missed one-shot process exit can be recovered by draining the queue.
+  Custom slow checks should print their current state idempotently; the watcher dedups repeated output and keeps a catch-all backstop for legacy self-suppressing `.babysit-*.seen` checks.
   Routine watcher polling, restarts, elapsed waiting time, and unchanged heartbeat reviews stay silent; an idle crew costs you nothing.
   A pull-based guard (`bin/fm-guard.sh`) warns through supervision tool output if tasks are in flight and that watcher stops running or queued wakes are waiting to be drained.
   A presence-gated sub-supervisor (`bin/fm-supervise-daemon.sh`) extends this for walk-away supervision: the `/afk` skill activates it, after which it self-handles routine wakes in bash and escalates only captain-relevant events as one batched, single-line digest (prefixed with an in-band sentinel marker so firstmate can tell daemon injections apart from real messages).

--- a/bin/fm-pr-check.sh
+++ b/bin/fm-pr-check.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # Record a PR-ready task: appends pr=<url> to state/<id>.meta and arms the
-# watcher's merge poll by writing state/<id>.check.sh, which prints one line iff
-# the PR is merged (the watcher's check contract: output = wake firstmate,
-# silence = keep sleeping).
+# watcher's merge poll by writing state/<id>.check.sh. Once the PR is merged,
+# the check prints the current terminal state every run; the watcher dedups the
+# repeated output and enqueues the first delta before advancing suppression.
+# Silence means "no current terminal state; keep sleeping."
 # Usage: fm-pr-check.sh <task-id> <pr-url>
 set -eu
 

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -69,6 +69,23 @@ meta_value() {
   grep "^$key=" "$meta" | cut -d= -f2- || true
 }
 
+sanitize_state_name() { printf '%s' "$1" | LC_ALL=C tr -c 'A-Za-z0-9._-' '_'; }
+
+cleanup_task_state() {
+  local state=$1 id=$2 check_name sidecar_name
+  check_name=$(sanitize_state_name "$id.check.sh")
+  sidecar_name=$(sanitize_state_name ".babysit-$id.seen")
+  rm -f \
+    "$state/$id.status" \
+    "$state/$id.turn-ended" \
+    "$state/$id.check.sh" \
+    "$state/$id.meta" \
+    "$state/$id.pi-ext.ts" \
+    "$state/.seen-check-$check_name" \
+    "$state/.babysit-$id.seen" \
+    "$state/.escalated-$sidecar_name"
+}
+
 registry_home_for_line() {
   sed -n 's/^[^(]*(home: \([^;)]*\);.*/\1/p'
 }
@@ -346,7 +363,7 @@ cleanup_firstmate_home_children() {
         safe_rm_rf_child_worktree "$child_wt" "$child_proj"
       fi
     fi
-    rm -f "$sub_state/$child_id.status" "$sub_state/$child_id.turn-ended" "$sub_state/$child_id.check.sh" "$sub_state/$child_id.meta" "$sub_state/$child_id.pi-ext.ts"
+    cleanup_task_state "$sub_state" "$child_id"
   done
 }
 
@@ -446,7 +463,7 @@ if [ "$KIND" = secondmate ]; then
   remove_firstmate_home "$HOME_PATH" "secondmate home" "$ID"
   remove_secondmate_registry_entry "$ID"
 fi
-rm -f "$STATE/$ID.status" "$STATE/$ID.turn-ended" "$STATE/$ID.check.sh" "$STATE/$ID.meta" "$STATE/$ID.pi-ext.ts"
+cleanup_task_state "$STATE" "$ID"
 if [ "$KIND" != scout ] && [ "$KIND" != secondmate ] && [ "$MODE" != local-only ]; then
   "$FM_ROOT/bin/fm-fleet-sync.sh" "$PROJ" || true
 fi

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -4,7 +4,9 @@
 #   signal: <file>...     a crewmate wrote a status line or a turn-end hook fired; signals
 #                         landing within FM_SIGNAL_GRACE of each other coalesce into one wake
 #   stale: <window>       a crewmate pane stopped changing and shows no busy signature
-#   check: <script>: <out> a per-task check script (e.g. merged-PR poll) produced output
+#   check: <script>: <out> a per-task check produced output (deduped by the watcher;
+#                         enqueued before suppression so the wake is lossless), or the
+#                         catch-all force-escalated a swallowed terminal transition
 #   heartbeat              fleet review due; starts at FM_HEARTBEAT and backs off to FM_HEARTBEAT_MAX
 # Run as a background task. Re-arm it after handling each wake; duplicate
 # invocations no-op through the watcher singleton lock.
@@ -101,6 +103,10 @@ recorded_windows() {
   done
 }
 
+# Collapse a check/sidecar basename into a safe suffix for watcher-side state
+# files (.seen-check-*, .escalated-*). LC_ALL=C so the complement is byte-stable.
+sanitize_name() { printf '%s' "$1" | LC_ALL=C tr -c 'A-Za-z0-9._-' '_'; }
+
 # Exit reporting a wake. Consecutive heartbeats with no other wake in between
 # mean an idle fleet, so the heartbeat interval backs off exponentially
 # (base * 2^streak, capped at HEARTBEAT_MAX); any real wake resets the cadence.
@@ -168,17 +174,65 @@ while :; do
   # keeps producing signals - the slow poll (e.g. merge detection) would then
   # never run until the fleet went quiet. Checks are due only every
   # CHECK_INTERVAL, so most cycles skip this block and fall straight through.
+  #
+  # LOSSLESS CHECK WAKES (the #29 invariant, ported to checks). Checks were the
+  # sole wake source whose suppression lived inside an opaque script: an
+  # edge-triggered check advanced its own .babysit-*.seen marker BEFORE the
+  # print could become a wake, so a lost stdout (timeout / concurrent run /
+  # crash) permanently swallowed the transition - the root cause of the missed
+  # PR #3095 merge. Suppression now lives HERE, in the watcher, with
+  # enqueue-before-suppress - exactly the pattern scan_signals uses:
+  #   * the check always prints its current state (idempotent); the watcher
+  #     dedups against .seen-check-<name> and only wakes on a delta;
+  #   * fm_wake_append (durable queue) happens BEFORE the .seen-check marker
+  #     advances, so a crash between detect and suppress leaves the wake in the
+  #     queue (recovered next turn) and the marker un-advanced (re-detected
+  #     next cycle). A lost check wake is now impossible.
+  # Backward-compatible with old edge-triggered checks: empty stdout never
+  # produces a wake, so they keep their quiet behavior. Any transition they
+  # swallow is caught by the catch-all scan at the end of this block.
   if [ "$(age_of "$STATE/.last-check")" -ge "$CHECK_INTERVAL" ]; then
     for c in "$STATE"/*.check.sh; do
       [ -e "$c" ] || continue
       out=$(run_check "$c")
-      if [ -n "$out" ]; then
+      [ -n "$out" ] || continue
+      sf="$STATE/.seen-check-$(sanitize_name "$(basename "$c")")"
+      if [ "$out" != "$(cat "$sf" 2>/dev/null || true)" ]; then
         reason="check: $c: $out"
         fm_wake_append check "$c" "$reason" || exit 1
+        # Test-only hook: prove the wake is durable by simulating a crash
+        # between enqueue and suppress. Never set outside the test suite.
+        [ -n "${FM_WATCH_BREAK_AFTER_CHECK_ENQUEUE:-}" ] && exit 99
+        printf '%s' "$out" > "$sf"
         touch "$STATE/.last-check"
         wake "$reason"
       fi
     done
+
+    # Catch-all backstop: force-escalate any edge-triggered check whose own
+    # .babysit-*.seen sidecar shows a terminal state the watcher never
+    # delivered a wake for. This catches a swallowed transition (sidecar
+    # advanced inside the script but stdout lost) within one sweep - the
+    # belt-and-suspenders safety net for checks that have not migrated to the
+    # lossless "always print current state" contract. Deduped via
+    # .escalated-<sidecar> so each terminal transition fires at most once.
+    for sf in "$STATE"/.babysit-*.seen; do
+      [ -e "$sf" ] || continue
+      terminal=$(cat "$sf" 2>/dev/null || true)
+      state=${terminal%%|*}
+      case "$state" in
+        MERGED|CLOSED) ;;
+        *) continue ;;
+      esac
+      ec="$STATE/.escalated-$(sanitize_name "$(basename "$sf")")"
+      [ "$terminal" = "$(cat "$ec" 2>/dev/null || true)" ] && continue
+      reason="check: catch-all: $sf: $state"
+      fm_wake_append check "$sf" "$reason" || exit 1
+      printf '%s' "$terminal" > "$ec"
+      touch "$STATE/.last-check"
+      wake "$reason"
+    done
+
     touch "$STATE/.last-check"
   fi
 

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -240,9 +240,35 @@ test_local_only_force_overrides_unpushed() {
   pass "local-only worktree with unpushed work is torn down under --force (escape hatch)"
 }
 
+test_teardown_removes_check_dedup_state() {
+  local case_dir rc
+  case_dir=$(make_case check-dedup-cleanup)
+  write_meta "$case_dir" no-mistakes ship
+  wt_commit "$case_dir" "shippable work"
+  git -C "$case_dir/wt" push -q origin fm/task-x1
+  git -C "$case_dir/project" fetch -q origin
+  printf '#!/usr/bin/env bash\nprintf merged\\n\n' > "$case_dir/state/task-x1.check.sh"
+  printf 'merged\n' > "$case_dir/state/.seen-check-task-x1.check.sh"
+  printf 'MERGED|https://example.test/pr/1\n' > "$case_dir/state/.babysit-task-x1.seen"
+  printf 'MERGED|https://example.test/pr/1\n' > "$case_dir/state/.escalated-.babysit-task-x1.seen"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "check-cleanup: teardown should succeed"
+  [ ! -e "$case_dir/state/task-x1.check.sh" ] || fail "check-cleanup: check script remained"
+  [ ! -e "$case_dir/state/.seen-check-task-x1.check.sh" ] || fail "check-cleanup: seen-check marker remained"
+  [ ! -e "$case_dir/state/.babysit-task-x1.seen" ] || fail "check-cleanup: babysit sidecar remained"
+  [ ! -e "$case_dir/state/.escalated-.babysit-task-x1.seen" ] || fail "check-cleanup: escalated marker remained"
+  pass "teardown removes watcher check dedup state"
+}
+
 test_local_only_fork_remote_allows
 test_local_only_truly_unpushed_refuses
 test_local_only_merged_to_local_main_allows
 test_no_mistakes_origin_remote_allows
 test_no_mistakes_truly_unpushed_refuses
 test_local_only_force_overrides_unpushed
+test_teardown_removes_check_dedup_state

--- a/tests/fm-wake-queue.test.sh
+++ b/tests/fm-wake-queue.test.sh
@@ -358,7 +358,7 @@ SH
 
 # Catch-all backstop: an old edge-triggered check that swallowed its own
 # transition (advanced .babysit-*.seen inside the script but lost stdout) is
-# force-escalated within one sweep by the heartbeat catch-all scanning the
+# force-escalated within one sweep by the watcher's catch-all scanning the
 # sidecar. This is the belt-and-suspenders safety net that would have surfaced
 # PR #3095 within one scan even without the lossless primary path.
 test_catch_all_escalates_swallowed_transition() {

--- a/tests/fm-wake-queue.test.sh
+++ b/tests/fm-wake-queue.test.sh
@@ -280,6 +280,126 @@ SH
   pass "check output is queued before cadence suppression"
 }
 
+# Regression for the missed PR #3095 merge: a check wake must survive a
+# crash/race between enqueue and suppress. The watcher enqueues to the durable
+# queue BEFORE advancing the .seen-check marker, so even if the marker is never
+# advanced (simulated here via FM_WATCH_BREAK_AFTER_CHECK_ENQUEUE), the wake is
+# already in the queue and is re-detected next cycle.
+test_check_wake_survives_lost_delivery() {
+  local dir state fakebin out drain_out check_file seen_check
+  dir=$(make_case check-lossless)
+  state="$dir/state"
+  fakebin="$dir/fakebin"
+  out="$dir/watch.out"
+  drain_out="$dir/drain.out"
+  check_file="$state/pr-3095.check.sh"
+  seen_check="$state/.seen-check-pr-3095.check.sh"
+  cat > "$check_file" <<'SH'
+#!/usr/bin/env bash
+printf 'merged: https://example.test/pr/3095\n'
+SH
+  chmod +x "$check_file"
+  # Cycle 1: enqueue, then simulate a crash before the suppression marker
+  # advances. The wake is already durable; the marker is still absent.
+  PATH="$fakebin:$PATH" FM_WATCH_BREAK_AFTER_CHECK_ENQUEUE=1 FM_STATE_OVERRIDE="$state" FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=0 FM_HEARTBEAT=999999 "$WATCH" > "$out" 2>/dev/null &
+  wait_for_exit "$!" 40
+  local crash_status=$?
+  [ "$crash_status" -eq 99 ] || fail "crashing watcher did not simulate the post-enqueue crash (exit $crash_status)"
+  [ ! -e "$seen_check" ] || fail "suppression marker advanced before the wake was durable (enqueue-before-suppress broken)"
+  # The wake survived the crash in the durable queue.
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$drain_out" || fail "drain after crash failed"
+  grep "$(printf '\tcheck\t')" "$drain_out" | grep -F "$check_file" | grep -F 'pr/3095' >/dev/null || fail "check wake was lost when delivery failed (the #3095 regression)"
+  # Cycle 2: re-run normally. The un-advanced marker means the delta is
+  # re-detected, enqueued again (deduped downstream), and now suppressed.
+  : > "$out"
+  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=0 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  wait_for_exit "$!" 40 || fail "watcher did not exit on re-detection"
+  grep -F "check: $check_file: merged: https://example.test/pr/3095" "$out" >/dev/null || fail "watcher did not re-detect the delta after the crash"
+  [ -e "$seen_check" ] || fail "suppression marker was not advanced after a clean delivery"
+  pass "check wake is enqueued before suppression so a lost delivery is recovered"
+}
+
+# Dedup: a stateless check that always prints the same state must wake exactly
+# once; subsequent identical output is suppressed by the watcher's .seen-check.
+test_check_dedup_suppresses_repeats() {
+  local dir state fakebin out drain_out check_file count
+  dir=$(make_case check-dedup)
+  state="$dir/state"
+  fakebin="$dir/fakebin"
+  out="$dir/watch.out"
+  drain_out="$dir/drain.out"
+  check_file="$state/steady.check.sh"
+  cat > "$check_file" <<'SH'
+#!/usr/bin/env bash
+printf 'merged\n'
+SH
+  chmod +x "$check_file"
+  # Cycle 1: empty -> "merged" is a delta -> wake.
+  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=0 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  wait_for_exit "$!" 40 || fail "watcher did not exit for first check wake"
+  grep -Fx "check: $check_file: merged" "$out" >/dev/null || fail "watcher did not wake on first check output"
+  # Cycle 2: same output -> no delta -> no wake (watcher loops until the
+  # timeout kills it; the background poll is what lets wait_for_exit return).
+  : > "$out"
+  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=0 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  local pid=$!
+  sleep 2
+  if ! kill -0 "$pid" 2>/dev/null; then
+    fail "watcher woke on a duplicate check output (dedup broken)"
+  fi
+  kill "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+  # Only the first wake should be in the queue.
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$drain_out" || fail "drain failed"
+  count=$(grep -c "$(printf '\tcheck\t')" "$drain_out" || true)
+  [ "$count" -eq 1 ] || fail "expected 1 deduped check wake, got $count"
+  pass "watcher-side .seen-check dedup suppresses repeated identical check output"
+}
+
+# Catch-all backstop: an old edge-triggered check that swallowed its own
+# transition (advanced .babysit-*.seen inside the script but lost stdout) is
+# force-escalated within one sweep by the heartbeat catch-all scanning the
+# sidecar. This is the belt-and-suspenders safety net that would have surfaced
+# PR #3095 within one scan even without the lossless primary path.
+test_catch_all_escalates_swallowed_transition() {
+  local dir state fakebin out drain_out check_file sidecar escalated
+  dir=$(make_case check-catchall)
+  state="$dir/state"
+  fakebin="$dir/fakebin"
+  out="$dir/watch.out"
+  drain_out="$dir/drain.out"
+  check_file="$state/legacy-pr.check.sh"
+  sidecar="$state/.babysit-legacy-pr.seen"
+  escalated="$state/.escalated-.babysit-legacy-pr.seen"
+  # The check already self-suppressed: its sidecar says MERGED, but the script
+  # prints nothing (the transition's stdout was lost - exactly the #3095 mode).
+  printf 'MERGED|comment-a comment-b\n' > "$sidecar"
+  cat > "$check_file" <<'SH'
+#!/usr/bin/env bash
+# Edge-triggered babysit that already advanced its own .seen; prints nothing.
+exit 0
+SH
+  chmod +x "$check_file"
+  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=0 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  wait_for_exit "$!" 40 || fail "watcher did not exit for catch-all escalation"
+  grep -F "catch-all" "$out" >/dev/null || fail "catch-all did not force-escalate the swallowed transition"
+  grep -F "MERGED" "$out" >/dev/null || fail "catch-all wake did not report the terminal state"
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$drain_out" || fail "drain after catch-all failed"
+  grep "$(printf '\tcheck\t')" "$drain_out" | grep -F "$sidecar" >/dev/null || fail "catch-all wake was not queued"
+  [ -e "$escalated" ] || fail "catch-all did not record its dedup marker"
+  # A second sweep must NOT re-escalate (deduped by .escalated-*).
+  : > "$out"
+  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=0 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  local pid=$!
+  sleep 2
+  if ! kill -0 "$pid" 2>/dev/null; then
+    fail "catch-all re-escalated an already-handled terminal state (dedup broken)"
+  fi
+  kill "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+  pass "catch-all force-escalates a swallowed terminal transition within one sweep"
+}
+
 test_singleton_start() {
   local dir state fakebin out1 out2 pid1 pid2 live
   dir=$(make_case singleton)
@@ -966,6 +1086,9 @@ test_concurrent_append_and_drain
 test_signal_catchup_without_running_watcher
 test_stale_enqueue_before_suppressor
 test_check_output_is_queued
+test_check_wake_survives_lost_delivery
+test_check_dedup_suppresses_repeats
+test_catch_all_escalates_swallowed_transition
 test_singleton_start
 test_atomic_double_drain
 test_drain_dedupes_obvious_duplicates


### PR DESCRIPTION
## Intent

The transcript is mostly omitted, but the visible context indicates the developer wanted work continued on PR or issue #34 by restoring its fixed branch and running it through a fork-aware no-mistakes validation flow. They expected the agent to operate under Firstmate rules: avoid direct project writes, use delegated work where appropriate, preserve unlanded work, and validate through the configured pipeline before reporting readiness.

## What Changed

- Move PR-check wake suppression into the watcher so merged-check notifications are enqueued before suppress markers are recorded, preserving lossless wake delivery while still preventing duplicates.
- Clean stale check suppression markers during teardown so completed tasks do not leave behind watcher state.
- Update watcher check documentation and add coverage for lossless PR-check wakes and teardown cleanup.

## Risk Assessment

✅ Low: Captain, the change is well-bounded to watcher check wake dedup/catch-all cleanup behavior, with matching teardown cleanup and focused regression coverage; I did not find material merge-blocking risks.

## Testing

Exercised the CLI-facing PR-check watcher flow end to end plus the targeted shell suites for crash recovery, enqueue-before-suppress, repeat deduping, catch-all escalation, and teardown marker cleanup; all checks passed and the final worktree status was clean.

<details>
<summary>Evidence: fm-wake-queue targeted test transcript</summary>

```text
ok - supervise daemon state root is scoped by FM_HOME
ok - concurrent append plus drain preserves queue records
ok - signal written while no watcher runs is caught on next run
ok - stale wake is queued before suppressor state is advanced
ok - check output is queued before cadence suppression
ok - check wake is enqueued before suppression so a lost delivery is recovered
ok - watcher-side .seen-check dedup suppresses repeated identical check output
ok - catch-all force-escalates a swallowed terminal transition within one sweep
ok - simultaneous watcher starts leave exactly one live process
ok - two atomic drains cannot consume the same records twice
ok - drain collapses obvious duplicate heartbeat and signal records
ok - killed watcher stale lock is reclaimed
ok - live watcher lock with stale heartbeat is actionable
ok - guard warns when queued wakes are pending
ok - guard orders watcher re-arm after queued wake drain
ok - routine signal self-handles
ok - captain-relevant status verbs escalate
ok - check + unknown escalate; heartbeat self-handles
ok - transient stale self-handles and records a persistence marker
ok - stale + terminal status escalates immediately
ok - persistent stale escalates after threshold and clears its marker
ok - resumed (busy) stale clears its marker without escalating
ok - multiple escalations flush as a single batched digest
ok - batch flush measures max-delay from the first append, not the last
ok - catch-all scan escalates a missed terminal once, not twice
ok - handle_wake routes routine->self and captain->escalate
ok - INJECT_SKIP forces self-handle, bypassing captain-relevant classification
ok - is_wake_reason distinguishes watcher wake reasons from singleton-status stdout
ok - terminal-stale escalate removes its marker so housekeeping does not re-escalate
ok - captain signal escalate marks seen so the catch-all scan does not re-fire
ok - _collapse_newlines replaces newlines with literal separator
ok - afk flag absent: daemon does not inject, buffer preserved
ok - afk flag present: daemon injects with sentinel marker prefix
ok - injected digest is single-line (no embedded newlines)
ok - busy-guard defers injection when supervisor pane is busy
ok - marker detection: marker -> stay afk, no marker -> exit afk
ok - /afk invocation is exempt from afk exit (no self-cancel)
ok - should_exit_afk returns false when afk is not active
ok - strip_injection_marker removes the sentinel marker cleanly
ok - pane_input_pending detects partial input on the cursor line
ok - pane_input_pending: blank cursor line is not pending
ok - pane_input_pending: bare prompts are not pending (idle)
ok - composer guard defers injection when pane has pending input
ok - swallowed Enter: type-once + Enter-retry, no concatenation
ok - normal inject: exactly one digest, one Enter, no duplicates
ok - classify_signal dedupes against the catch-all scan seen marker
ok - classify_stale dedupes against the signal path seen marker
```
</details>
<details>
<summary>Evidence: fm-teardown targeted test transcript</summary>

```text
ok - local-only worktree with HEAD on a fork remote is torn down (fix holds)
ok - local-only worktree with truly unpushed work is refused (safety preserved)
ok - local-only worktree with work merged into local main is torn down (no regression)
ok - no-mistakes worktree with HEAD on origin is torn down (no regression)
ok - no-mistakes worktree with truly unpushed work is refused (no regression)
ok - local-only worktree with unpushed work is torn down under --force (escape hatch)
ok - teardown removes watcher check dedup state
```
</details>
<details>
<summary>Evidence: manual PR-check/watch/drain transcript</summary>

```text
$ FM_STATE_OVERRIDE=$MANUAL/state bin/fm-pr-check.sh task-pr https://example.test/pull/3095
armed: state/task-pr.check.sh polls https://example.test/pull/3095

$ sed -n 1,5p $MANUAL/state/task-pr.check.sh
state=$(gh pr view "https://example.test/pull/3095" --json state -q .state 2>/dev/null)
[ "$state" = "MERGED" ] && echo "merged"

$ PATH=$MANUAL/fakebin:$PATH FM_STATE_OVERRIDE=$MANUAL/state FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=0 FM_HEARTBEAT=999999 bin/fm-watch.sh
check: /var/folders/kg/vqcvwwlx3xs4wblm4wpvpkz00000gn/T/no-mistakes-evidence/01KVTN33M520MFG54DMN8E78EB/manual-pr-check-lossless/state/task-pr.check.sh: merged

$ FM_STATE_OVERRIDE=$MANUAL/state bin/fm-wake-drain.sh
1782232451	1	check	/var/folders/kg/vqcvwwlx3xs4wblm4wpvpkz00000gn/T/no-mistakes-evidence/01KVTN33M520MFG54DMN8E78EB/manual-pr-check-lossless/state/task-pr.check.sh	check: /var/folders/kg/vqcvwwlx3xs4wblm4wpvpkz00000gn/T/no-mistakes-evidence/01KVTN33M520MFG54DMN8E78EB/manual-pr-check-lossless/state/task-pr.check.sh: merged

$ repeat same terminal state: watcher should stay asleep and queue should stay empty
duplicate check output suppressed: watcher still sleeping after 2s

$ FM_STATE_OVERRIDE=$MANUAL/state bin/fm-wake-drain.sh (after duplicate)
queue empty after duplicate check output
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-wake-queue.test.sh 2>&1 | tee /var/folders/kg/vqcvwwlx3xs4wblm4wpvpkz00000gn/T/no-mistakes-evidence/01KVTN33M520MFG54DMN8E78EB/fm-wake-queue.test.log`
- `bash tests/fm-teardown.test.sh 2>&1 | tee /var/folders/kg/vqcvwwlx3xs4wblm4wpvpkz00000gn/T/no-mistakes-evidence/01KVTN33M520MFG54DMN8E78EB/fm-teardown.test.log`
- <code>Manual end-to-end smoke with fake `gh pr view` returning `MERGED`: ran `bin/fm-pr-check.sh`, `bin/fm-watch.sh`, `bin/fm-wake-drain.sh`, then reran the watcher on the same terminal state to verify no duplicate wake was queued; transcript at `/var/folders/kg/vqcvwwlx3xs4wblm4wpvpkz00000gn/T/no-mistakes-evidence/01KVTN33M520MFG54DMN8E78EB/manual-pr-check-lossless.transcript`.</code>
- `git status --short`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
