### PR TITLE
feat: add treehouse setup hook and manual PR validation flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,8 @@ Hands-on firstmate work competes with live supervision for the same single threa
 This repo is a shared template, not the captain's personal project.
 The tracking principle: shared, tracked material is tracked under git; anything personal to this captain's fleet (data/, state/, config/, projects/, .no-mistakes/) is not.
 Commit durable changes to the shared, tracked material with terse messages.
-This repo is itself behind the no-mistakes gate: ship shared, tracked material through the pipeline - branch, commit, run the pipeline, PR - and the captain's merge rule applies here exactly as it does to projects.
+This repo is itself behind the no-mistakes gate: ship shared, tracked material by branching, committing, running the no-mistakes validation pipeline with `--skip=pr,ci`, and opening the PR manually afterward.
+The captain's merge rule applies here exactly as it does to projects.
 Never add an agent name as co-author.
 
 ## 2. Layout and state
@@ -295,7 +296,7 @@ Do not eagerly backfill every project.
 
 **Delivery mode (choose at add).** `<mode>` is how a finished change reaches `main`, picked per project when you add it and recorded in the registry line (`fm-project-mode.sh` parses it; `fm-spawn` records it into each task's meta):
 
-- `no-mistakes` (default; `[...]` may be omitted) - full pipeline -> PR -> captain merge. Highest assurance.
+- `no-mistakes` (default; `[...]` may be omitted) - validation pipeline through branch push with `--skip=pr,ci` -> manual PR -> captain merge. Highest assurance.
 - `direct-PR` - push + open a PR via `gh-axi`, no pipeline -> captain merge.
 - `local-only` - local branch, no remote, no PR; firstmate reviews the diff, the captain approves, firstmate merges to local `main` (section 7).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,7 @@ README.md            public overview and development notes
 .github/workflows/   shared CI and PR enforcement, committed
 .agents/skills/      shared skills, committed
 .claude/skills       symlink to .agents/skills for claude compatibility
-bin/                 helper scripts, committed, including fm-fleet-sync.sh for clean default-branch refreshes and gone-branch pruning; read each script's header before first use
+bin/                 helper scripts, committed, including fm-fleet-sync.sh for clean default-branch refreshes and gone-branch pruning and fm-treehouse-post-create.sh for per-project worktree setup; read each script's header before first use
 config/crew-harness  crewmate harness override; LOCAL, gitignored; absent or "default" = same as firstmate
 data/                personal fleet records; LOCAL, gitignored as a whole
   backlog.md         task queue, dependencies, history
@@ -88,6 +88,7 @@ state/               volatile runtime signals; gitignored
   .hash-* .count-* .stale-* .seen-* .last-* .heartbeat-streak   watcher internals; never touch
   .last-watcher-beat watcher liveness beacon, touched every poll; fm-guard.sh reads it
   .subsuper-* .supervise-daemon.*   sub-supervisor internals (stale markers, escalation buffer, seen-status dedup, log, lock, pid); never touch
+  treehouse-setup-<project>.log      latest per-project treehouse post_create setup output
 .no-mistakes/        local validation state and evidence; gitignored
 ```
 
@@ -105,8 +106,8 @@ Set `FM_FLEET_PRUNE=0` to temporarily disable that branch pruning.
 Silence means all good: say nothing and move on.
 Otherwise it prints one line per problem; handle each:
 
-- `MISSING: <tool> (install: <command>)` - list the missing tools to the captain with a one-line purpose each plus the printed install commands, wait for consent (one approval may cover the list), then run `bin/fm-bootstrap.sh install <approved tools...>`.
-  For `treehouse`, this also covers an installed version whose `treehouse get` lacks `--lease`; treat it as an upgrade request.
+- `MISSING: <tool> (install: <command>)` - list the missing tools or setup steps to the captain with a one-line purpose each plus the printed install commands, wait for consent (one approval may cover the list), then run `bin/fm-bootstrap.sh install <approved tools...>`.
+  For `treehouse`, this also covers an installed version whose `treehouse get` lacks `--lease` or whose version lacks `post_create` hooks; treat it as an upgrade request. For `treehouse-post-create-hook`, this wires firstmate's global Treehouse hook into the Treehouse user config.
 - `NEEDS_GH_AUTH` - ask the captain to run `! gh auth login` (interactive; you cannot run it for them).
 - `CREW_HARNESS_OVERRIDE: <name>` - record and use the override silently; surface a harness fact only if it actually blocks work or the captain asks.
 - `FLEET_SYNC: <repo>: skipped: <reason>` - bootstrap continued; investigate only if the dirty, diverged, or offline clone blocks work.
@@ -379,11 +380,20 @@ If one pair fails, the rest still run and the batch exits non-zero.
 The script resolves the harness (`fm-harness.sh crew`), owns the verified launch templates, resolves the project's delivery mode (`fm-project-mode.sh`) for ship/scout tasks, and records `harness=`, `kind=`, `mode=`, and `yolo=` in the task's meta; a non-flag third argument containing whitespace is treated as a raw launch command (only for verifying new adapters).
 For `kind=secondmate`, the same script launches in the registered or explicit firstmate home instead of running `treehouse get` for a project, records `home=` and `projects=`, and uses the charter brief as the launch prompt.
 
-For ship and scout tasks, the script creates the window (in your current tmux session, or a dedicated `firstmate` session when you are outside tmux), runs `treehouse get`, waits for the worktree subshell, installs the turn-end hook, records `state/<id>.meta`, and launches the agent with the brief.
+For ship and scout tasks, the script creates the window (in your current tmux session, or a dedicated `firstmate` session when you are outside tmux), runs `treehouse get`, waits up to `FM_TREEHOUSE_GET_TIMEOUT` seconds (default 300) for the worktree subshell, installs the turn-end hook, records `state/<id>.meta`, and launches the agent with the brief.
 For `kind=secondmate`, the script creates the same kind of window but starts directly in the persistent home.
 Project worktrees start at detached HEAD on a clean default branch; ship briefs tell the crewmate to create its branch, while scout briefs keep the worktree scratch.
 After spawning, peek the pane to confirm the crewmate is processing the brief (and handle any trust dialog per section 4).
 Add the task to `data/backlog.md` under In flight.
+
+Per-project worktree setup runs via a treehouse `post_create` hook (`bin/fm-treehouse-post-create.sh`), not inside fm-spawn: treehouse >= v1.8.0 fires the hook in the worktree right before handing it over, which is earlier and simpler than waiting inside fm-spawn.
+The hook is a single global script wired in the Treehouse user config (`${TREEHOUSE_CONFIG:-${XDG_CONFIG_HOME:-$HOME/.config}/treehouse/config.toml}`) as a shell command string such as `post_create = ["'<abs path>/bin/fm-treehouse-post-create.sh'"]`; bootstrap reports `MISSING: treehouse-post-create-hook` until that wiring exists, and `bin/fm-bootstrap.sh install treehouse-post-create-hook` adds the shell-quoted form after approval.
+`fm-spawn` passes the active `FM_HOME` and operational override variables through `treehouse get`, so the hook can locate the same firstmate home, `data/`, `projects/`, and `state/` that the spawning firstmate is using.
+The hook verifies the current worktree belongs to the matching clone under `${FM_PROJECTS_OVERRIDE:-$FM_HOME/projects}` and runs `${FM_DATA_OVERRIDE:-$FM_HOME/data}/<project>-setup.sh` if it exists (project name = worktree directory basename, matching the `data/projects.md` convention).
+Output is logged to `${FM_STATE_OVERRIDE:-$FM_HOME/state}/treehouse-setup-<project>.log`.
+A failing setup script is non-fatal (treehouse continues on hook failure by design); the hook exits with the setup script's code so the failure surfaces in treehouse's own logs.
+Secondmates have no project worktree, so the hook is irrelevant to them.
+Any project can get a `data/<name>-setup.sh` and the hook picks it up automatically.
 
 ### Supervise
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -406,7 +406,7 @@ Its charter retargets escalation to the main firstmate's status file, so routine
 
 A ship task's path from `done` to landed on `main` is set by the project's `mode` (recorded in meta; section 6); `yolo` decides who approves. The Validate / PR ready / Ship teardown stages below are written for the `no-mistakes` path; the other modes diverge:
 
-- **no-mistakes** - the stages below as written: no-mistakes validation pipeline through lint with `--skip=push,pr,ci` -> captain pushes and opens the PR manually -> captain merge.
+- **no-mistakes** - the stages below as written: no-mistakes validation pipeline through push with `--skip=pr,ci` -> captain opens the PR manually -> captain merge.
 - **direct-PR** - no pipeline. The crewmate pushes and opens the PR itself (its brief says so) and reports `done: PR <url>`. Skip the Validate step and go straight to PR ready (run `fm-pr-check`, relay the PR). Teardown uses the normal pushed-branch check.
 - **local-only** - no remote, no PR. The crewmate stops at `done: ready in branch fm/<id>`. Review the diff with `bin/fm-review-diff.sh <id>`, relay a one-paragraph summary to the captain, and on approval run `bin/fm-merge-local.sh <id>` to fast-forward local `main` (it refuses anything but a clean fast-forward - if it does, have the crewmate rebase). No `fm-pr-check`. Then teardown, whose safety check requires the branch already merged into local `main`, OR the work pushed to any remote (a fork counts - relevant for upstream-contribution PRs on a local-only-registered project).
 
@@ -418,23 +418,23 @@ Pooled clones keep their local default refs frozen at clone time and can lag `or
 ### Validate
 
 For `no-mistakes`-mode ship tasks, when a crewmate's status says `done`, trigger validation using the crew's harness from `state/<id>.meta`.
-Every instruction to a crewmate to run the no-mistakes pipeline must include `--skip=push,pr,ci`.
-Use `/no-mistakes --skip=push,pr,ci` for claude, `$no-mistakes --skip=push,pr,ci` for codex; natural language also works if it explicitly includes `--skip=push,pr,ci`.
+Every instruction to a crewmate to run the no-mistakes pipeline must include `--skip=pr,ci`.
+Use `/no-mistakes --skip=pr,ci` for claude, `$no-mistakes --skip=pr,ci` for codex; natural language also works if it explicitly includes `--skip=pr,ci`.
 For example, with claude:
 
 ```sh
-bin/fm-send.sh fm-<id> '/no-mistakes --skip=push,pr,ci'
+bin/fm-send.sh fm-<id> '/no-mistakes --skip=pr,ci'
 ```
 
-The crewmate drives the no-mistakes pipeline through local validation itself (review, test, document, lint), while no-mistakes skips branch push, PR creation, and PR-based CI monitoring.
+The crewmate drives the no-mistakes pipeline through branch push itself (review, test, document, lint, push), while no-mistakes skips PR creation and PR-based CI monitoring.
 It fixes auto-fix findings on its own.
 When it reports `needs-decision` (ask-user findings), relay the findings to the captain unless `yolo=on` permits routine approval on your judgment, then send the decision back as a short instruction (the crewmate responds via `no-mistakes axi respond`).
 Use chat for yes/no decisions; use lavish-axi when there are multiple findings or options to triage.
 
 ### PR ready
 
-For PR-based ship tasks, the ready signal depends on mode: `no-mistakes` reports `done: validated with --skip=push,pr,ci; branch ready for captain/manual push+PR` after local validation, while `direct-PR` reports `done: PR <url>` after opening the PR.
-For `no-mistakes`, tell the captain the branch is locally validated and ready for them to push and open the PR manually. If this repo's required workflow checks look for a no-mistakes marker in the PR body, preserve that marker in the manual PR body or the workflow may fail.
+For PR-based ship tasks, the ready signal depends on mode: `no-mistakes` reports `done: validated with --skip=pr,ci; branch pushed and ready for captain/manual PR` after validation, while `direct-PR` reports `done: PR <url>` after opening the PR.
+For `no-mistakes`, tell the captain the branch is validated, pushed, and ready for them to open the PR manually. If this repo's required workflow checks look for a no-mistakes marker in the PR body, preserve that marker in the manual PR body or the workflow may fail.
 Once a PR URL exists, run `bin/fm-pr-check.sh <id> <PR url>` - it records `pr=` in the task's meta and arms the watcher's merge poll.
 Tell the captain: the PR's full URL (always the complete `https://...` link, never a bare `#number` - the captain's terminal makes a full URL clickable), a one-paragraph summary, and, for `no-mistakes`, the risk level it emitted.
 (The check contract, for any custom `state/<id>.check.sh` you write yourself: print one line only when firstmate should wake, print nothing otherwise, and finish before `FM_CHECK_TIMEOUT`.)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -406,7 +406,7 @@ Its charter retargets escalation to the main firstmate's status file, so routine
 
 A ship task's path from `done` to landed on `main` is set by the project's `mode` (recorded in meta; section 6); `yolo` decides who approves. The Validate / PR ready / Ship teardown stages below are written for the `no-mistakes` path; the other modes diverge:
 
-- **no-mistakes** - the stages below as written: no-mistakes validation pipeline -> PR -> captain merge.
+- **no-mistakes** - the stages below as written: no-mistakes validation pipeline through lint with `--skip=push,pr,ci` -> captain pushes and opens the PR manually -> captain merge.
 - **direct-PR** - no pipeline. The crewmate pushes and opens the PR itself (its brief says so) and reports `done: PR <url>`. Skip the Validate step and go straight to PR ready (run `fm-pr-check`, relay the PR). Teardown uses the normal pushed-branch check.
 - **local-only** - no remote, no PR. The crewmate stops at `done: ready in branch fm/<id>`. Review the diff with `bin/fm-review-diff.sh <id>`, relay a one-paragraph summary to the captain, and on approval run `bin/fm-merge-local.sh <id>` to fast-forward local `main` (it refuses anything but a clean fast-forward - if it does, have the crewmate rebase). No `fm-pr-check`. Then teardown, whose safety check requires the branch already merged into local `main`, OR the work pushed to any remote (a fork counts - relevant for upstream-contribution PRs on a local-only-registered project).
 
@@ -418,26 +418,28 @@ Pooled clones keep their local default refs frozen at clone time and can lag `or
 ### Validate
 
 For `no-mistakes`-mode ship tasks, when a crewmate's status says `done`, trigger validation using the crew's harness from `state/<id>.meta`.
-Use `/no-mistakes` for claude, `$no-mistakes` for codex; natural language also works.
+Every instruction to a crewmate to run the no-mistakes pipeline must include `--skip=push,pr,ci`.
+Use `/no-mistakes --skip=push,pr,ci` for claude, `$no-mistakes --skip=push,pr,ci` for codex; natural language also works if it explicitly includes `--skip=push,pr,ci`.
 For example, with claude:
 
 ```sh
-bin/fm-send.sh fm-<id> '/no-mistakes'
+bin/fm-send.sh fm-<id> '/no-mistakes --skip=push,pr,ci'
 ```
 
-The crewmate drives the no-mistakes pipeline (review, test, document, lint, push, PR, CI) itself.
+The crewmate drives the no-mistakes pipeline through local validation itself (review, test, document, lint), while no-mistakes skips branch push, PR creation, and PR-based CI monitoring.
 It fixes auto-fix findings on its own.
 When it reports `needs-decision` (ask-user findings), relay the findings to the captain unless `yolo=on` permits routine approval on your judgment, then send the decision back as a short instruction (the crewmate responds via `no-mistakes axi respond`).
 Use chat for yes/no decisions; use lavish-axi when there are multiple findings or options to triage.
 
 ### PR ready
 
-For PR-based ship tasks, the ready signal depends on mode: `no-mistakes` reports `done: PR <url> checks green` after CI is green, while `direct-PR` reports `done: PR <url>` after opening the PR.
-Run `bin/fm-pr-check.sh <id> <PR url>` - it records `pr=` in the task's meta and arms the watcher's merge poll.
+For PR-based ship tasks, the ready signal depends on mode: `no-mistakes` reports `done: validated with --skip=push,pr,ci; branch ready for captain/manual push+PR` after local validation, while `direct-PR` reports `done: PR <url>` after opening the PR.
+For `no-mistakes`, tell the captain the branch is locally validated and ready for them to push and open the PR manually. If this repo's required workflow checks look for a no-mistakes marker in the PR body, preserve that marker in the manual PR body or the workflow may fail.
+Once a PR URL exists, run `bin/fm-pr-check.sh <id> <PR url>` - it records `pr=` in the task's meta and arms the watcher's merge poll.
 Tell the captain: the PR's full URL (always the complete `https://...` link, never a bare `#number` - the captain's terminal makes a full URL clickable), a one-paragraph summary, and, for `no-mistakes`, the risk level it emitted.
 (The check contract, for any custom `state/<id>.check.sh` you write yourself: print one line only when firstmate should wake, print nothing otherwise, and finish before `FM_CHECK_TIMEOUT`.)
 
-If the captain says "merge it", run `gh-axi pr merge` yourself; that instruction is the explicit approval. If `yolo=on`, merge a green/approved PR yourself and post the required FYI.
+If the captain says "merge it", run `gh-axi pr merge` yourself; that instruction is the explicit approval. Manual PR creation does not weaken the review or merge gates. If `yolo=on`, merge a green/approved PR yourself and post the required FYI.
 
 ### Ship teardown (only after merge is confirmed)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,13 +3,14 @@
 Thanks for wanting to contribute.
 One rule up front:
 
-**Human-authored pull requests targeting `main` must be raised through [`no-mistakes`](https://github.com/kunchenguid/no-mistakes).**
+**Human-authored pull requests targeting `main` must be validated through [`no-mistakes`](https://github.com/kunchenguid/no-mistakes).**
 We require this to reduce the maintainer's burden of reviewing and merging contributions.
 
 `no-mistakes` puts a local git proxy in front of your real remote.
-Pushing through it runs an AI-driven review/test/lint pipeline in an isolated worktree, forwards the push upstream only after every check passes, and opens a clean PR automatically.
+For this repo, run the review/test/lint pipeline through branch push with `--skip=pr,ci`, then open the GitHub PR manually.
 
 A GitHub Actions check (`Require no-mistakes`) runs on PRs targeting `main` and fails if the body is missing the deterministic signature that no-mistakes writes.
+When you open the PR manually, preserve the no-mistakes marker or copy the generated pipeline section into the PR body.
 Dependency bots are exempt so their automation keeps working, but regular contributor PRs without the signature will not be reviewed or merged.
 
 ## Workflow
@@ -18,14 +19,15 @@ Dependency bots are exempt so their automation keeps working, but regular contri
 2. Create a branch and make your changes.
 3. Initialize the gate with your fork as the push target: `no-mistakes init --fork-url git@github.com:<you>/firstmate.git` (fork routing requires **no-mistakes v1.30.1+**; without a fork, plain `no-mistakes init` still works for maintainers with push access).
 4. Commit your changes.
-5. Push through the gate instead of pushing to `origin`:
+5. Run the validation pipeline through branch push, but skip automatic PR creation and PR-based CI monitoring:
 
    ```sh
-   git push no-mistakes
+   no-mistakes --skip=pr,ci
    ```
 
-6. Run `no-mistakes` to attach to the pipeline, watch findings, and auto-fix or review as needed.
-7. Once the pipeline passes, it pushes the branch to your fork and opens the PR against the parent repo for you.
+6. Watch findings, and auto-fix or review as needed.
+7. Once the pipeline passes and pushes the branch to your fork, open the PR against the parent repo manually.
+   Preserve the no-mistakes marker in the PR body so the required workflow can verify the run.
 
 See the [no-mistakes quick start](https://kunchenguid.github.io/no-mistakes/start-here/quick-start/) for the full first-run walkthrough.
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You can run one coding agent easily.
 But the moment you want three project tasks done in parallel - fixes, investigations, plans, audits - you become a tab-juggler: babysitting sessions, copy-pasting context between repos, forgetting which terminal had the failing test.
 
 firstmate flips the model.
-You talk to a single agent - the first mate - and it runs the crew for you: spawning autonomous agents in tmux windows, giving each a clean git worktree, supervising them to completion, and handing you finished PRs, approved local merges, or standalone investigation reports.
+You talk to a single agent - the first mate - and it runs the crew for you: spawning autonomous agents in tmux windows, giving each a clean git worktree, supervising them to completion, and handing you PR-ready branches or finished PRs, approved local merges, or standalone investigation reports.
 For larger fleets, you can opt in to persistent secondmates: domain supervisors that are still ordinary direct reports, but run from their own isolated firstmate homes.
 There is no app to install; the whole orchestrator is an `AGENTS.md` file that any terminal coding agent can follow.
 
@@ -58,8 +58,12 @@ $ claude   # launch your agent harness here; AGENTS.md takes over
 # fm-fix-login-k3 and fm-dark-mode-p7.
 # Minutes later:
 
+  Branch validated and pushed, captain.
+  Open the PR manually with the no-mistakes marker in the body.
+
+> PR is https://github.com/you/xyz/pull/42
+
   PR ready for review, captain: https://github.com/you/xyz/pull/42
-  (fix flaky login test - risk: low - CI green)
 
 > alright merge it
 ```
@@ -133,7 +137,7 @@ firstmate works from any terminal - outside tmux, crewmates land in a detached `
   After seeding a secondmate, `fm-backlog-handoff.sh` moves already-judged in-scope queued items from the main backlog into that secondmate home so the domain queue starts in the right place.
   Idle secondmate panes are healthy; teardown is explicit and refuses while the secondmate home has in-flight work unless the captain has approved discard with `--force`.
 - **Project modes are explicit** - `data/projects.md` records each project's delivery mode and optional `+yolo` autonomy flag.
-  `no-mistakes` projects run the full validation pipeline, `direct-PR` projects open PRs without that pipeline, and `local-only` projects stay local until firstmate performs an approved fast-forward merge.
+  `no-mistakes` projects run validation through branch push with `--skip=pr,ci`, then the captain opens the PR manually; `direct-PR` projects open PRs without that pipeline, and `local-only` projects stay local until firstmate performs an approved fast-forward merge.
 - **Project memory belongs to projects** - durable project-intrinsic agent knowledge lives in each project's committed `AGENTS.md`, with `CLAUDE.md` as a symlink.
   Ship briefs prompt crewmates to create or update those files through the normal delivery path; `data/projects.md` stays a thin private registry.
 - **Local clones stay fresh** - bootstrap and PR-based teardown refresh remote-backed project clones with clean default-branch fast-forwards when the clone is on the default branch and has no local work, and prune local branches whose remote is gone and that no worktree still needs.
@@ -217,9 +221,9 @@ FM_HOUSEKEEPING_TICK=15            # seconds between batch-flush, stale-recheck,
 
 ## Development
 
-Tracked changes to firstmate itself, including `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `.github/workflows/`, `bin/`, and agent skill files, ship through the `no-mistakes` pipeline on a feature branch and require the captain's explicit merge approval.
+Tracked changes to firstmate itself, including `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `.github/workflows/`, `bin/`, and agent skill files, ship through the `no-mistakes` validation pipeline on a feature branch with `--skip=pr,ci`, then through a manual PR, and require the captain's explicit merge approval.
 When supervising live crewmates, keep long validation or build work in the background so watcher wakes can still be handled.
-Human-authored pull requests targeting `main` must be raised through `git push no-mistakes`; see `CONTRIBUTING.md` for the enforced contributor workflow.
+Human-authored pull requests targeting `main` must be validated through `no-mistakes` and include the no-mistakes marker in the manual PR body; see `CONTRIBUTING.md` for the enforced contributor workflow.
 Local `.no-mistakes/` state and test evidence stay out of this repo; `.no-mistakes.yaml` keeps evidence in a temp directory instead.
 The current watcher reliability work keeps the one-shot process model and adds a durable queue plus singleton lock.
 The presence-gated sub-supervisor (`bin/fm-supervise-daemon.sh`) provides proactive wake routing for walk-away supervision via the `/afk` skill; a blocking-waiter split remains a deferred follow-up phase.

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ cd firstmate && claude
 ```
 
 That is the whole install.
-On first launch the first mate detects what its toolchain is missing or too old (tmux, node, gh, treehouse with durable lease support, no-mistakes, gh-axi, chrome-devtools-axi, lavish-axi), lists it with the exact install commands, and installs only after you say go.
+On first launch the first mate detects what its toolchain is missing or too old (tmux, node, gh, treehouse with durable lease and post-create hook support, Treehouse hook wiring, no-mistakes, gh-axi, chrome-devtools-axi, lavish-axi), lists it with the exact install commands, and installs only after you say go.
 
 **Run it inside tmux for the best experience.**
 firstmate works from any terminal - outside tmux, crewmates land in a detached `firstmate` session you can attach to - but launching your harness from inside tmux puts every crewmate window in your own session, one per task, where you can watch the crew work in real time or type into any window to intervene.
@@ -119,6 +119,7 @@ firstmate works from any terminal - outside tmux, crewmates land in a detached `
   A pull-based guard (`bin/fm-guard.sh`) warns through supervision tool output if tasks are in flight and that watcher stops running or queued wakes are waiting to be drained.
   A presence-gated sub-supervisor (`bin/fm-supervise-daemon.sh`) extends this for walk-away supervision: the `/afk` skill activates it, after which it self-handles routine wakes in bash and escalates only captain-relevant events as one batched, single-line digest (prefixed with an in-band sentinel marker so firstmate can tell daemon injections apart from real messages).
 - **Worktrees, not branches in your checkout** - crewmates never touch your clone; treehouse pools clean worktrees so parallel tasks on one repo cannot collide.
+  A Treehouse `post_create` hook can run local `data/<project>-setup.sh` scripts as each worktree is provisioned, so per-project dependency installs, builds, or env-file copies happen before the crewmate launches.
 - **Two task shapes** - ship tasks change projects and ship by project mode (`no-mistakes`, `direct-PR`, or `local-only`); scout tasks investigate, plan, reproduce bugs, or audit, then leave a report at `data/<id>/report.md` and never push.
 - **Optional secondmates** - `data/secondmates.md` records persistent domain supervisors with natural-language scopes, project clone lists, and home paths.
   `fm-home-seed.sh` provisions the isolated home, clones the listed PR-based projects into it, initializes newly cloned `no-mistakes` projects, copies the charter to `data/charter.md`, and `fm-spawn.sh --secondmate` launches it through the same tmux and status-file path as any direct report.
@@ -153,6 +154,7 @@ The first mate drives these; you rarely need to, but they work by hand too.
 | `fm-guard.sh`            | Warn when tasks are in flight but queued wakes are pending or the watcher liveness beacon is stale or missing      |
 | `fm-home-seed.sh`        | Lease/provision a secondmate home transactionally, clone projects, initialize gates, and maintain `data/secondmates.md` |
 | `fm-spawn.sh`            | Spawn one task, several `id=repo` pairs, or a persistent secondmate with `--secondmate`                            |
+| `fm-treehouse-post-create.sh` | Treehouse `post_create` hook that runs local `data/<project>-setup.sh` scripts in matching project worktrees |
 | `fm-project-mode.sh`     | Resolve a project's delivery mode and `+yolo` flag from `data/projects.md`                                          |
 | `fm-merge-local.sh`      | Fast-forward a `local-only` project's local default branch after approval                                           |
 | `fm-review-diff.sh`      | Review a crewmate branch against the authoritative base, with optional `--stat` output                              |
@@ -184,6 +186,9 @@ Set `FM_SECONDMATE_CHARTER` to seed from inline charter text when no filled char
 `FM_HOME` selects the operational home for one firstmate instance.
 When it is unset, the repo root is the home; when it is set, scripts still run from this repo's `bin/`, but `state/`, `data/`, `config/`, and `projects/` come from `$FM_HOME`.
 Harness support is a table in section 4: claude, codex, opencode, and pi are all empirically verified; new harnesses get verified through a supervised trial task before joining the table.
+Optional per-project worktree setup scripts live locally as `data/<project>-setup.sh`.
+After bootstrap wires the Treehouse `post_create` hook into the Treehouse user config, `treehouse get` runs the matching setup script in each new or reset worktree, logs output to `state/treehouse-setup-<project>.log`, and continues even if the setup exits non-zero.
+Bootstrap writes the hook as a shell-quoted command string, so firstmate paths containing spaces still work.
 
 Runtime tuning via environment variables (defaults shown):
 
@@ -194,6 +199,8 @@ FM_HEARTBEAT=600        # base seconds between fleet reviews; backs off exponent
 FM_HEARTBEAT_MAX=7200   # heartbeat backoff cap
 FM_CHECK_INTERVAL=300   # seconds between slow checks (merged-PR polls)
 FM_CHECK_TIMEOUT=30     # seconds allowed per slow check script
+FM_TREEHOUSE_GET_TIMEOUT=300   # seconds allowed for treehouse get to enter a worktree
+TREEHOUSE_CONFIG=       # optional Treehouse config path for hook wiring
 FM_GUARD_GRACE=300      # seconds a stale watcher beacon may age before guard warnings
 FM_SIGNAL_GRACE=30      # seconds to coalesce nearby status and turn-end signals into one wake
 FM_FLEET_SYNC_BOOTSTRAP_TIMEOUT=20   # seconds allowed for bootstrap's best-effort clone refresh
@@ -224,6 +231,8 @@ for test_script in tests/*.test.sh; do "$test_script"; done   # behavior tests, 
 tests/fm-wake-queue.test.sh               # durable wake queue, singleton behavior, sub-supervisor classifier, and /afk presence-gating tests
 tests/fm-afk-inject-e2e.test.sh           # private-socket end-to-end test of the afk injection path (partial-input deferral, swallowed-Enter retry)
 tests/fm-bootstrap.test.sh                # bootstrap dependency and feature-probe tests
+tests/fm-spawn-treehouse-env.test.sh      # spawn passes active firstmate home/override context into treehouse get
+tests/fm-treehouse-post-create.test.sh    # treehouse post_create per-project setup hook behavior
 tests/fm-secondmate.test.sh               # persistent secondmate routing, seeding, idle charter, backlog handoff, spawn, recovery, teardown, and FM_HOME tests
 tests/fm-teardown.test.sh                 # fm-teardown.sh unpushed-work safety check: local-only fork-remote allow, truly-unpushed refuse, merged-to-main allow, no-mistakes regression, --force override
 [ "$(readlink CLAUDE.md)" = "AGENTS.md" ]

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -5,7 +5,13 @@
 #          Lines: "MISSING: <tool> (install: <command>)", "NEEDS_GH_AUTH",
 #                 "CREW_HARNESS_OVERRIDE: <name>", "FLEET_SYNC: <repo>: skipped: <reason>".
 #          treehouse is also MISSING when its installed version lacks
-#          "treehouse get --lease" support.
+#          "treehouse get --lease" support or post_create hook support.
+#          treehouse-post-create-hook is MISSING when Treehouse is not wired
+#          to firstmate's global post_create hook.
+#          Installing treehouse-post-create-hook edits the Treehouse user
+#          config and stores the hook path as a shell-quoted command string.
+#          That config path follows TREEHOUSE_CONFIG, then XDG_CONFIG_HOME,
+#          then ~/.config/treehouse/config.toml.
 #          Fleet sync fetches, fast-forwards, and prunes gone local branches;
 #          it is bounded by FM_FLEET_SYNC_BOOTSTRAP_TIMEOUT, default 20s.
 #          Set FM_FLEET_PRUNE=0 to skip branch pruning during that refresh.
@@ -61,6 +67,7 @@ install_cmd() {
   case "$1" in
     tmux|node|gh) echo "brew install $1  # or the platform's package manager" ;;
     treehouse) echo "curl -fsSL https://kunchenguid.github.io/treehouse/install.sh | sh" ;;
+    treehouse-post-create-hook) printf '%q install treehouse-post-create-hook\n' "$FM_ROOT/bin/fm-bootstrap.sh" ;;
     no-mistakes) echo "curl -fsSL https://raw.githubusercontent.com/kunchenguid/no-mistakes/main/docs/install.sh | sh" ;;
     gh-axi|chrome-devtools-axi|lavish-axi) echo "npm install -g $1 && $1 setup hooks" ;;
     *) return 1 ;;
@@ -73,11 +80,445 @@ treehouse_supports_lease() {
   treehouse get --help 2>&1 | grep -Eq '(^|[^[:alnum:]_-])--lease([^[:alnum:]_-]|$)'
 }
 
+treehouse_supports_post_create() {
+  version=$(treehouse --version 2>/dev/null) || return 1
+  version=${version#treehouse }
+  version=${version#v}
+  case "$version" in
+    [0-9]*.[0-9]*.[0-9]*)
+      major=${version%%.*}
+      rest=${version#*.}
+      minor=${rest%%.*}
+      patch=${rest#*.}
+      patch=${patch%%[!0-9]*}
+      [ -n "$patch" ] || patch=0
+      [ "$major" -gt 1 ] || { [ "$major" -eq 1 ] && [ "$minor" -gt 8 ]; } || { [ "$major" -eq 1 ] && [ "$minor" -eq 8 ] && [ "$patch" -ge 0 ]; }
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+treehouse_config_path() {
+  printf '%s\n' "${TREEHOUSE_CONFIG:-${XDG_CONFIG_HOME:-$HOME/.config}/treehouse/config.toml}"
+}
+
+treehouse_hook_path() {
+  cd "$FM_ROOT/bin" 2>/dev/null && printf '%s/fm-treehouse-post-create.sh\n' "$(pwd -P)"
+}
+
+shell_quote() {
+  printf "'"
+  printf '%s' "$1" | sed "s/'/'\\\\''/g"
+  printf "'"
+}
+
+toml_basic_escape() {
+  printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+
+treehouse_hook_command_usable() {
+  command=$1
+  case "$command" in
+    *fm-treehouse-post-create.sh*) ;;
+    *) return 1 ;;
+  esac
+  hook_path=$(printf '%s\n' "$command" | awk '
+    function trim(s) { sub(/^[[:space:]]+/, "", s); sub(/[[:space:]]+$/, "", s); return s }
+    function shell_safe(s) {
+      return s !~ /[^A-Za-z0-9_\/:.,@%+=~=-]/
+    }
+    function emit_word() {
+      word = trim(word)
+      if (word == "") {
+        word_quoted = 0
+        return
+      }
+      if (word ~ /^[A-Za-z_][A-Za-z0-9_]*=/) {
+        word = ""
+        word_quoted = 0
+        return
+      }
+      if (word ~ /^\/.*\/fm-treehouse-post-create\.sh$/ && (word_quoted || shell_safe(word))) {
+        print word
+      }
+      exit
+    }
+    {
+      line = trim($0)
+      quote = ""
+      word = ""
+      word_quoted = 0
+      for (i = 1; i <= length(line); i++) {
+        c = substr(line, i, 1)
+        if (quote == "" && c ~ /[[:space:]]/) {
+          emit_word()
+          continue
+        }
+        if (c == "\\" && i < length(line)) {
+          word = word substr(line, i + 1, 1)
+          word_quoted = 1
+          i++
+          continue
+        }
+        if (c == "\"" || c == "'\''") {
+          if (quote == "") {
+            quote = c
+            word_quoted = 1
+            continue
+          }
+          if (quote == c) {
+            quote = ""
+            continue
+          }
+        }
+        word = word c
+      }
+      if (quote != "") {
+        exit
+      }
+      emit_word()
+    }
+  ')
+  [ -n "$hook_path" ] || return 1
+  case "$hook_path" in
+    /*) ;;
+    *) return 1 ;;
+  esac
+  [ -x "$hook_path" ]
+}
+
+treehouse_post_create_hook_configured() {
+  config=$(treehouse_config_path)
+  [ -f "$config" ] || return 1
+  while IFS= read -r command; do
+    treehouse_hook_command_usable "$command" && return 0
+  done < <(awk '
+    function strip_comment(line,    i, c, prev, quote, out) {
+      quote = ""
+      out = ""
+      for (i = 1; i <= length(line); i++) {
+        c = substr(line, i, 1)
+        prev = i > 1 ? substr(line, i - 1, 1) : ""
+        if (quote == "" && c == "#") {
+          break
+        }
+        out = out c
+        if ((c == "\"" || c == "'\''") && prev != "\\") {
+          if (quote == "") {
+            quote = c
+          } else if (quote == c) {
+            quote = ""
+          }
+        }
+      }
+      return out
+    }
+    function unescape_basic_string(value,    i, c, n, out) {
+      out = ""
+      for (i = 1; i <= length(value); i++) {
+        c = substr(value, i, 1)
+        if (c == "\\" && i < length(value)) {
+          n = substr(value, i + 1, 1)
+          if (n == "n") {
+            out = out "\n"
+          } else if (n == "t") {
+            out = out "\t"
+          } else if (n == "r") {
+            out = out "\r"
+          } else {
+            out = out n
+          }
+          i++
+          continue
+        }
+        out = out c
+      }
+      return out
+    }
+    function emit_strings(line,    i, c, prev, quote, value) {
+      quote = ""
+      value = ""
+      for (i = 1; i <= length(line); i++) {
+        c = substr(line, i, 1)
+        prev = i > 1 ? substr(line, i - 1, 1) : ""
+        if ((c == "\"" || c == "'\''") && prev != "\\") {
+          if (quote == "") {
+            quote = c
+            value = ""
+            continue
+          }
+          if (quote == c) {
+            print (quote == "\"" ? unescape_basic_string(value) : value)
+            quote = ""
+            value = ""
+            continue
+          }
+        }
+        if (quote != "") {
+          value = value c
+        }
+      }
+    }
+    {
+      clean = strip_comment($0)
+      if (clean ~ /^[[:space:]]*\[[^]]+\][[:space:]]*$/) {
+        in_hooks = (clean ~ /^[[:space:]]*\[hooks\][[:space:]]*$/)
+        in_post_create = 0
+      }
+      post_create_line = 0
+      if (in_hooks && clean ~ /^[[:space:]]*post_create[[:space:]]*=/) {
+        in_post_create = 1
+        post_create_line = 1
+      }
+      if (in_hooks && in_post_create) {
+        emit_strings(clean)
+      }
+      if (in_hooks && in_post_create && (clean ~ /\]/ || (post_create_line && clean !~ /\[/))) {
+        in_post_create = 0
+      }
+    }
+  ' "$config")
+  return 1
+}
+
+treehouse_config_has_hooks_section() {
+  awk '
+    function strip_comment(line,    i, c, prev, quote, out) {
+      quote = ""
+      out = ""
+      for (i = 1; i <= length(line); i++) {
+        c = substr(line, i, 1)
+        prev = i > 1 ? substr(line, i - 1, 1) : ""
+        if (quote == "" && c == "#") {
+          break
+        }
+        out = out c
+        if ((c == "\"" || c == "'\''") && prev != "\\") {
+          if (quote == "") {
+            quote = c
+          } else if (quote == c) {
+            quote = ""
+          }
+        }
+      }
+      return out
+    }
+    { clean = strip_comment($0) }
+    clean ~ /^[[:space:]]*\[hooks\][[:space:]]*$/ { found = 1 }
+    END { exit found ? 0 : 1 }
+  ' "$1"
+}
+
+treehouse_config_has_post_create() {
+  awk '
+    function strip_comment(line,    i, c, prev, quote, out) {
+      quote = ""
+      out = ""
+      for (i = 1; i <= length(line); i++) {
+        c = substr(line, i, 1)
+        prev = i > 1 ? substr(line, i - 1, 1) : ""
+        if (quote == "" && c == "#") {
+          break
+        }
+        out = out c
+        if ((c == "\"" || c == "'\''") && prev != "\\") {
+          if (quote == "") {
+            quote = c
+          } else if (quote == c) {
+            quote = ""
+          }
+        }
+      }
+      return out
+    }
+    {
+      clean = strip_comment($0)
+      if (clean ~ /^[[:space:]]*\[[^]]+\][[:space:]]*$/) {
+        in_hooks = (clean ~ /^[[:space:]]*\[hooks\][[:space:]]*$/)
+      }
+      if (in_hooks && clean ~ /^[[:space:]]*post_create[[:space:]]*=/) {
+        found = 1
+      }
+    }
+    END { exit found ? 0 : 1 }
+  ' "$1"
+}
+
+append_treehouse_post_create_hook() {
+  config=$1
+  hook=$2
+  tmp=$(mktemp "${TMPDIR:-/tmp}/fm-treehouse-config.XXXXXX") || return 1
+  if awk -v hook="$hook" '
+    function trim(s) { sub(/^[[:space:]]+/, "", s); sub(/[[:space:]]+$/, "", s); return s }
+    function strip_comment(line,    i, c, prev, quote, out) {
+      quote = ""
+      out = ""
+      for (i = 1; i <= length(line); i++) {
+        c = substr(line, i, 1)
+        prev = i > 1 ? substr(line, i - 1, 1) : ""
+        if (quote == "" && c == "#") {
+          break
+        }
+        out = out c
+        if ((c == "\"" || c == "'\''") && prev != "\\") {
+          if (quote == "") {
+            quote = c
+          } else if (quote == c) {
+            quote = ""
+          }
+        }
+      }
+      return out
+    }
+    function append_to_single_line(line, hook,    open, rel_close, close_pos, inside, prefix, suffix) {
+      open = index(line, "[")
+      rel_close = index(substr(line, open + 1), "]")
+      if (!open || !rel_close) {
+        return line
+      }
+      close_pos = open + rel_close
+      inside = trim(substr(line, open + 1, close_pos - open - 1))
+      prefix = substr(line, 1, close_pos - 1)
+      suffix = substr(line, close_pos)
+      if (inside == "") {
+        return prefix "\"" hook "\"" suffix
+      }
+      return prefix ", \"" hook "\"" suffix
+    }
+    function add_comma_before_comment(line,    hash, body, comment) {
+      hash = index(line, "#")
+      if (hash) {
+        body = substr(line, 1, hash - 1)
+        comment = substr(line, hash)
+      } else {
+        body = line
+        comment = ""
+      }
+      if (body ~ /,[[:space:]]*$/) {
+        return line
+      }
+      sub(/[[:space:]]*$/, "", body)
+      return body "," (comment == "" ? "" : " " comment)
+    }
+    {
+      lines[NR] = $0
+      clean = strip_comment($0)
+      if (clean ~ /^[[:space:]]*\[[^]]+\][[:space:]]*$/) {
+        in_hooks = (clean ~ /^[[:space:]]*\[hooks\][[:space:]]*$/)
+        if (in_post_create && !pc_end) {
+          pc_end = NR - 1
+        }
+        in_post_create = 0
+      }
+      if (in_hooks && clean ~ /^[[:space:]]*post_create[[:space:]]*=/) {
+        pc_start = NR
+        in_post_create = 1
+      }
+      if (in_post_create && clean ~ /\]/) {
+        pc_end = NR
+        in_post_create = 0
+      }
+    }
+    END {
+      if (!pc_start || !pc_end) {
+        exit 1
+      }
+      if (pc_start == pc_end) {
+        lines[pc_start] = append_to_single_line(lines[pc_start], hook)
+      } else {
+        last_value = 0
+        for (i = pc_start + 1; i < pc_end; i++) {
+          candidate = lines[i]
+          sub(/[[:space:]]*#.*/, "", candidate)
+          if (trim(candidate) != "") {
+            last_value = i
+          }
+        }
+        if (last_value) {
+          lines[last_value] = add_comma_before_comment(lines[last_value])
+        }
+      }
+      for (i = 1; i <= NR; i++) {
+        if (i == pc_end && pc_start != pc_end) {
+          indent = lines[pc_end]
+          sub(/[^[:space:]].*$/, "", indent)
+          printf "%s\"%s\"\n", indent "  ", hook
+        }
+        print lines[i]
+      }
+    }
+  ' "$config" >"$tmp" && mv "$tmp" "$config"; then
+    rm -f "$tmp"
+    return 0
+  fi
+  rm -f "$tmp"
+  return 1
+}
+
+install_treehouse_hook() {
+  config=$(treehouse_config_path)
+  hook=$(treehouse_hook_path) || return 1
+  hook=$(toml_basic_escape "$(shell_quote "$hook")")
+  if treehouse_post_create_hook_configured; then
+    return 0
+  fi
+  mkdir -p "$(dirname "$config")"
+  if [ ! -f "$config" ]; then
+    printf '[hooks]\npost_create = ["%s"]\n' "$hook" >"$config"
+    return 0
+  fi
+  if ! treehouse_config_has_hooks_section "$config"; then
+    printf '\n[hooks]\npost_create = ["%s"]\n' "$hook" >>"$config"
+    return 0
+  fi
+  if ! treehouse_config_has_post_create "$config"; then
+    tmp=$(mktemp "${TMPDIR:-/tmp}/fm-treehouse-config.XXXXXX") || return 1
+    if awk -v hook="$hook" '
+      function strip_comment(line,    i, c, prev, quote, out) {
+        quote = ""
+        out = ""
+        for (i = 1; i <= length(line); i++) {
+          c = substr(line, i, 1)
+          prev = i > 1 ? substr(line, i - 1, 1) : ""
+          if (quote == "" && c == "#") {
+            break
+          }
+          out = out c
+          if ((c == "\"" || c == "'\''") && prev != "\\") {
+            if (quote == "") {
+              quote = c
+            } else if (quote == c) {
+              quote = ""
+            }
+          }
+        }
+        return out
+      }
+      { print }
+      !inserted && strip_comment($0) ~ /^[[:space:]]*\[hooks\][[:space:]]*$/ {
+        printf "post_create = [\"%s\"]\n", hook
+        inserted = 1
+      }
+    ' "$config" >"$tmp" && mv "$tmp" "$config"; then
+      rm -f "$tmp"
+      return 0
+    fi
+    rm -f "$tmp"
+    return 1
+  fi
+  append_treehouse_post_create_hook "$config" "$hook"
+}
+
 if [ "${1:-}" = "install" ]; then
   shift
   [ $# -gt 0 ] || { echo "usage: fm-bootstrap.sh install <tool>..." >&2; exit 1; }
   for t in "$@"; do
     cmd=$(install_cmd "$t") || { echo "error: unknown tool $t" >&2; exit 1; }
+    if [ "$t" = treehouse-post-create-hook ]; then
+      echo "installing $t: $cmd"
+      install_treehouse_hook || exit 1
+      continue
+    fi
     cmd=${cmd%%  #*}
     echo "installing $t: $cmd"
     eval "$cmd"
@@ -88,8 +529,11 @@ fi
 for t in $TOOLS; do
   command -v "$t" >/dev/null || echo "MISSING: $t (install: $(install_cmd "$t"))"
 done
-if command -v treehouse >/dev/null 2>&1 && ! treehouse_supports_lease; then
+if command -v treehouse >/dev/null 2>&1 && { ! treehouse_supports_lease || ! treehouse_supports_post_create; }; then
   echo "MISSING: treehouse (install: $(install_cmd treehouse))"
+fi
+if command -v treehouse >/dev/null 2>&1 && treehouse_supports_lease && treehouse_supports_post_create && ! treehouse_post_create_hook_configured; then
+  echo "MISSING: treehouse-post-create-hook (install: $(install_cmd treehouse-post-create-hook))"
 fi
 gh auth status >/dev/null 2>&1 || echo "NEEDS_GH_AUTH"
 crew=

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -18,7 +18,7 @@
 #   Set FM_SECONDMATE_SCOPE='<scope>' to write a routing scope distinct from the charter text.
 # For ship tasks, the definition of done is shaped by the project's delivery mode
 # (data/projects.md via fm-project-mode.sh; see AGENTS.md sections 6-7):
-#   no-mistakes  implement -> /no-mistakes pipeline -> PR -> captain merge (default)
+#   no-mistakes  implement -> /no-mistakes --skip=pr,ci -> manual PR -> captain merge (default)
 #   direct-PR    implement -> push + open PR via gh-axi (no pipeline) -> captain merge
 #   local-only   implement on branch, stop and report "ready in branch" (no push/PR);
 #                firstmate reviews, captain approves, firstmate merges to local main

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -185,14 +185,15 @@ EOF
   *)  # no-mistakes (default)
     SETUP2="
 2. Run \`no-mistakes doctor\`; if it reports the repo is not initialized here, run \`no-mistakes init\`."
-    RULE1='1. Never push to the default branch. Never merge a PR.'
+    RULE1='1. Never push to any remote. Never open or merge a PR.'
     DOD=$(cat <<EOF
 # Definition of done
 The task is complete only when committed on your branch.
 When you believe it is complete, append \`done: {summary}\` to the status file and stop.
-Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
+Firstmate will then instruct you to run the no-mistakes validation pipeline with \`--skip=push,pr,ci\`.
 During validation, fix auto-fix findings yourself; escalate ask-user findings per rule 6.
-After /no-mistakes reports CI green, append \`done: PR {url} checks green\` and stop. You are finished.
+No-mistakes does not push, open a PR, or monitor CI in this workflow.
+After no-mistakes finishes local validation, append \`done: validated with --skip=push,pr,ci; branch ready for captain/manual push+PR\` and stop. You are finished.
 EOF
 )
     ;;

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -185,15 +185,15 @@ EOF
   *)  # no-mistakes (default)
     SETUP2="
 2. Run \`no-mistakes doctor\`; if it reports the repo is not initialized here, run \`no-mistakes init\`."
-    RULE1='1. Never push to any remote. Never open or merge a PR.'
+    RULE1='1. Never push to the default branch. Never open or merge a PR. Push only your `fm/'"$ID"'` branch, and only as part of the no-mistakes validation pipeline.'
     DOD=$(cat <<EOF
 # Definition of done
 The task is complete only when committed on your branch.
 When you believe it is complete, append \`done: {summary}\` to the status file and stop.
-Firstmate will then instruct you to run the no-mistakes validation pipeline with \`--skip=push,pr,ci\`.
+Firstmate will then instruct you to run the no-mistakes validation pipeline with \`--skip=pr,ci\`.
 During validation, fix auto-fix findings yourself; escalate ask-user findings per rule 6.
-No-mistakes does not push, open a PR, or monitor CI in this workflow.
-After no-mistakes finishes local validation, append \`done: validated with --skip=push,pr,ci; branch ready for captain/manual push+PR\` and stop. You are finished.
+No-mistakes may push your branch, but does not open a PR or monitor CI in this workflow.
+After no-mistakes finishes validation and branch push, append \`done: validated with --skip=pr,ci; branch pushed and ready for captain/manual PR\` and stop. You are finished.
 EOF
 )
     ;;

--- a/bin/fm-project-mode.sh
+++ b/bin/fm-project-mode.sh
@@ -9,7 +9,7 @@
 #   - <name> [<mode> +yolo] - <desc> (added <date>)    -> <mode> on
 #
 # mode = how a finished change reaches main:
-#   no-mistakes  full pipeline -> PR -> captain merge (default)
+#   no-mistakes  validation pipeline + branch push with --skip=pr,ci -> manual PR -> captain merge (default)
 #   direct-PR    push + PR via gh-axi, no pipeline -> captain merge
 #   local-only   local branch, no remote/PR -> firstmate review -> captain approve -> local merge
 # yolo (orthogonal) = when on, firstmate makes approval decisions itself (PR merges,

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -23,6 +23,10 @@
 #     __PIEXT__    absolute path to state/<task-id>.pi-ext.ts (pi turn-end extension,
 #                  written by this script; outside the worktree to avoid pi's trust gate)
 # Per-harness turn-end hooks are installed automatically; some live outside the worktree.
+# Ship/scout spawns run treehouse get with the active FM_HOME and operational
+# override variables so Treehouse post_create hooks see the same firstmate home.
+# FM_TREEHOUSE_GET_TIMEOUT controls how long spawn waits for treehouse get to
+# enter a worktree; default 300 seconds.
 # On success prints: spawned <id> harness=<name> kind=<ship|scout|secondmate> mode=<mode> yolo=<on|off> window=<session:window> worktree=<path>
 # mode/yolo are resolved per-project from data/projects.md for ship/scout tasks;
 # secondmate spawns record mode=secondmate, yolo=off, home=, and projects=.
@@ -320,10 +324,16 @@ fi
 
 tmux new-window -d -t "$SES" -n "$W" -c "$PROJ_ABS"
 if [ "$KIND" != secondmate ]; then
-  tmux send-keys -t "$T" 'treehouse get' Enter
+  TREEHOUSE_LAUNCH="FM_ROOT_OVERRIDE=$(shell_quote "${FM_ROOT_OVERRIDE:-}") FM_STATE_OVERRIDE=$(shell_quote "${FM_STATE_OVERRIDE:-}") FM_DATA_OVERRIDE=$(shell_quote "${FM_DATA_OVERRIDE:-}") FM_PROJECTS_OVERRIDE=$(shell_quote "${FM_PROJECTS_OVERRIDE:-}") FM_CONFIG_OVERRIDE=$(shell_quote "${FM_CONFIG_OVERRIDE:-}") FM_HOME=$(shell_quote "$FM_HOME") treehouse get"
+  tmux send-keys -t "$T" -l "$TREEHOUSE_LAUNCH"
+  tmux send-keys -t "$T" Enter
 
   # Wait for the treehouse subshell: the pane's cwd moves from the project to the worktree.
-  for _ in $(seq 1 60); do
+  TREEHOUSE_GET_TIMEOUT=${FM_TREEHOUSE_GET_TIMEOUT:-300}
+  case "$TREEHOUSE_GET_TIMEOUT" in ''|*[!0-9]*) TREEHOUSE_GET_TIMEOUT=300 ;; esac
+  [ "$TREEHOUSE_GET_TIMEOUT" -gt 0 ] || TREEHOUSE_GET_TIMEOUT=300
+  start=$SECONDS
+  while [ $((SECONDS - start)) -lt "$TREEHOUSE_GET_TIMEOUT" ]; do
     p=$(tmux display-message -p -t "$T" '#{pane_current_path}' 2>/dev/null || true)
     if [ -n "$p" ] && [ "$p" != "$PROJ_ABS" ]; then
       WT="$p"
@@ -332,7 +342,7 @@ if [ "$KIND" != secondmate ]; then
     sleep 1
   done
   if [ -z "$WT" ]; then
-    echo "error: treehouse get did not enter a worktree within 60s; inspect window $T" >&2
+    echo "error: treehouse get did not enter a worktree within ${TREEHOUSE_GET_TIMEOUT}s; inspect window $T" >&2
     exit 1
   fi
 fi

--- a/bin/fm-treehouse-post-create.sh
+++ b/bin/fm-treehouse-post-create.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Treehouse post_create hook: run a firstmate per-project worktree setup
+# script (data/<project>-setup.sh) when a worktree is provisioned or reset.
+# Usage: fm-treehouse-post-create.sh
+#   Invoked by Treehouse from the new worktree directory, not by hand during
+#   normal firstmate operation.
+#
+# Treehouse >= v1.8.0 fires post_create in the worktree directory, right
+# before `treehouse get` hands the worktree over. That is the natural place
+# to install dependencies, build, or copy env files so a crewmate agent
+# launches into a ready worktree. Treehouse itself knows nothing about
+# firstmate; this hook bridges the two by locating firstmate's operational
+# directories from its own location (it lives in firstmate's bin/).
+#
+# Wiring (machine-level, one-time): add to the Treehouse user config
+# (${TREEHOUSE_CONFIG:-${XDG_CONFIG_HOME:-$HOME/.config}/treehouse/config.toml})
+#   [hooks]
+#   post_create = ["'<absolute path to this script>'"]
+# Treehouse treats hook entries as shell command strings, so keep the script
+# path shell-quoted; bootstrap writes this form automatically.
+# Treehouse ignores repo-level treehouse.toml hooks for safety, so the user
+# config is the only place this can live.
+#
+# Behavior:
+#   - project name = basename of the worktree directory, which matches the
+#     repo basename and the data/projects.md registry convention (projects
+#     are cloned as projects/<repo-basename>). Before running setup, the hook
+#     verifies this worktree belongs to the matching firstmate project clone
+#     under ${FM_PROJECTS_OVERRIDE:-$FM_HOME/projects}.
+#   - firstmate home = $FM_HOME if set, else derived from this script's
+#     location (../ from bin/). Secondmates never use treehouse worktrees,
+#     so the main firstmate home is the only relevant one.
+#   - runs ${FM_DATA_OVERRIDE:-$FM_HOME/data}/<project>-setup.sh
+#     synchronously if it exists.
+#   - non-fatal: a failing setup script is logged but does not block the
+#     worktree handoff. Treehouse continues on hook failure by design, so
+#     this script exits with the setup script's code to surface the failure
+#     in treehouse's own logs without aborting the get.
+#   - output is logged to
+#     ${FM_STATE_OVERRIDE:-$FM_HOME/state}/treehouse-setup-<project>.log so
+#     firstmate can inspect it. The log is worktree-keyed (not task-keyed)
+#     because post_create fires at worktree creation time, before any task is
+#     assigned to the worktree; a reused worktree's log is overwritten on each
+#     reset, which is the right freshness behavior.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
+PROJECTS="${FM_PROJECTS_OVERRIDE:-$FM_HOME/projects}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+
+PROJECT=$(basename "$(pwd)")
+SETUP="$DATA/$PROJECT-setup.sh"
+
+# No setup script for this project: quiet no-op.
+[ -f "$SETUP" ] || exit 0
+
+git_common_dir() {
+  repo=$1
+  common=$(git -C "$repo" rev-parse --git-common-dir 2>/dev/null) || return 1
+  case "$common" in
+    /*) ;;
+    *) common="$repo/$common" ;;
+  esac
+  cd "$common" 2>/dev/null && pwd -P
+}
+
+PROJECT_CLONE="$PROJECTS/$PROJECT"
+[ -d "$PROJECT_CLONE" ] || exit 0
+WORKTREE_COMMON=$(git_common_dir "$(pwd)") || exit 0
+PROJECT_COMMON=$(git_common_dir "$PROJECT_CLONE") || exit 0
+[ "$WORKTREE_COMMON" = "$PROJECT_COMMON" ] || exit 0
+
+mkdir -p "$STATE"
+LOG="$STATE/treehouse-setup-$PROJECT.log"
+# Capture the exit code explicitly: `if cmd; then ...; fi` without `else`
+# returns 0 on a false condition (POSIX), so `$?` after `fi` is useless here.
+set +e
+bash "$SETUP" >"$LOG" 2>&1
+rc=$?
+set -e
+if [ "$rc" -ne 0 ]; then
+  echo "fm-treehouse-post-create: setup script exited $rc for $PROJECT; see $LOG" >&2
+fi
+exit "$rc"

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -52,6 +52,10 @@ if [ "${1:-}" = get ] && [ "${2:-}" = --help ]; then
   fi
   exit 0
 fi
+if [ "${1:-}" = --version ]; then
+  printf '%s\n' "${FM_FAKE_TREEHOUSE_VERSION:-v1.8.0}"
+  exit 0
+fi
 exit 0
 SH
   chmod +x "$fakebin/treehouse"
@@ -60,18 +64,186 @@ SH
 
 run_bootstrap() {
   local home=$1 fakebin=$2
-  PATH="$fakebin:$PATH" FM_HOME="$home" "$ROOT/bin/fm-bootstrap.sh"
+  PATH="$fakebin:$PATH" FM_ROOT_OVERRIDE="${FM_ROOT_OVERRIDE:-}" FM_HOME="$home" XDG_CONFIG_HOME="$home/xdg" "$ROOT/bin/fm-bootstrap.sh"
 }
 
-test_bootstrap_accepts_treehouse_lease_support() {
+install_bootstrap_tool() {
+  local home=$1 fakebin=$2 tool=$3
+  PATH="$fakebin:$PATH" FM_ROOT_OVERRIDE="${FM_ROOT_OVERRIDE:-}" FM_HOME="$home" XDG_CONFIG_HOME="$home/xdg" "$ROOT/bin/fm-bootstrap.sh" install "$tool"
+}
+
+write_treehouse_hook_config() {
+  local home=$1 root=${2:-$ROOT}
+  mkdir -p "$home/xdg/treehouse"
+  printf '[hooks]\npost_create = ["%s/bin/fm-treehouse-post-create.sh"]\n' "$root" >"$home/xdg/treehouse/config.toml"
+}
+
+write_treehouse_quoted_hook_config() {
+  local home=$1 root=${2:-$ROOT}
+  mkdir -p "$home/xdg/treehouse"
+  printf '[hooks]\npost_create = ["'\''%s/bin/fm-treehouse-post-create.sh'\''"]\n' "$root" >"$home/xdg/treehouse/config.toml"
+}
+
+test_bootstrap_accepts_treehouse_lease_and_hook_support() {
   local case_dir fakebin out
   case_dir="$TMP_ROOT/lease-supported"
   mkdir -p "$case_dir/home"
   fakebin=$(make_fake_toolchain "$case_dir")
+  write_treehouse_hook_config "$case_dir/home"
 
-  out=$(FM_FAKE_TREEHOUSE_LEASE_HELP=1 run_bootstrap "$case_dir/home" "$fakebin")
-  [ -z "$out" ] || fail "bootstrap reported problems despite treehouse lease support: $out"
-  pass "bootstrap accepts treehouse get --lease support"
+  out=$(FM_FAKE_TREEHOUSE_LEASE_HELP=1 FM_FAKE_TREEHOUSE_VERSION=v1.8.0 run_bootstrap "$case_dir/home" "$fakebin")
+  [ -z "$out" ] || fail "bootstrap reported problems despite treehouse lease, post_create, and hook support: $out"
+  pass "bootstrap accepts treehouse get --lease, post_create, and configured hook support"
+}
+
+test_bootstrap_accepts_treehouse_hook_from_another_firstmate_root() {
+  local case_dir fakebin out other_root
+  case_dir="$TMP_ROOT/other-root-hook"
+  other_root="$case_dir/other-firstmate"
+  mkdir -p "$case_dir/home" "$other_root/bin"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$other_root/bin/fm-treehouse-post-create.sh"
+  chmod +x "$other_root/bin/fm-treehouse-post-create.sh"
+  fakebin=$(make_fake_toolchain "$case_dir")
+  write_treehouse_hook_config "$case_dir/home" "$other_root"
+
+  out=$(FM_FAKE_TREEHOUSE_LEASE_HELP=1 FM_FAKE_TREEHOUSE_VERSION=v1.8.0 run_bootstrap "$case_dir/home" "$fakebin")
+  [ -z "$out" ] || fail "bootstrap rejected configured treehouse hook from another firstmate root: $out"
+  pass "bootstrap accepts treehouse hook from another firstmate root"
+}
+
+test_bootstrap_accepts_treehouse_hook_path_with_spaces() {
+  local case_dir fakebin out other_root
+  case_dir="$TMP_ROOT/spaced-hook"
+  other_root="$case_dir/other firstmate"
+  mkdir -p "$case_dir/home" "$other_root/bin"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$other_root/bin/fm-treehouse-post-create.sh"
+  chmod +x "$other_root/bin/fm-treehouse-post-create.sh"
+  fakebin=$(make_fake_toolchain "$case_dir")
+  write_treehouse_quoted_hook_config "$case_dir/home" "$other_root"
+
+  out=$(FM_FAKE_TREEHOUSE_LEASE_HELP=1 FM_FAKE_TREEHOUSE_VERSION=v1.8.0 run_bootstrap "$case_dir/home" "$fakebin")
+  [ -z "$out" ] || fail "bootstrap rejected configured treehouse hook path with spaces: $out"
+  pass "bootstrap accepts treehouse hook path with spaces"
+}
+
+test_bootstrap_rejects_unquoted_treehouse_hook_path_with_spaces() {
+  local case_dir fakebin out other_root expected
+  case_dir="$TMP_ROOT/unquoted-spaced-hook"
+  other_root="$case_dir/other firstmate"
+  mkdir -p "$case_dir/home" "$other_root/bin"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$other_root/bin/fm-treehouse-post-create.sh"
+  chmod +x "$other_root/bin/fm-treehouse-post-create.sh"
+  fakebin=$(make_fake_toolchain "$case_dir")
+  write_treehouse_hook_config "$case_dir/home" "$other_root"
+
+  out=$(FM_FAKE_TREEHOUSE_LEASE_HELP=1 FM_FAKE_TREEHOUSE_VERSION=v1.8.0 run_bootstrap "$case_dir/home" "$fakebin")
+  expected="MISSING: treehouse-post-create-hook (install: $ROOT/bin/fm-bootstrap.sh install treehouse-post-create-hook)"
+  printf '%s\n' "$out" | grep -Fx "$expected" >/dev/null \
+    || fail "bootstrap accepted unquoted treehouse hook path with spaces: $out"
+  pass "bootstrap rejects unquoted treehouse hook path with spaces"
+}
+
+test_bootstrap_rejects_unquoted_treehouse_hook_path_with_shell_metachar() {
+  local case_dir fakebin out other_root expected
+  case_dir="$TMP_ROOT/unquoted-metachar-hook"
+  other_root="$case_dir/other;firstmate"
+  mkdir -p "$case_dir/home" "$other_root/bin"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$other_root/bin/fm-treehouse-post-create.sh"
+  chmod +x "$other_root/bin/fm-treehouse-post-create.sh"
+  fakebin=$(make_fake_toolchain "$case_dir")
+  write_treehouse_hook_config "$case_dir/home" "$other_root"
+
+  out=$(FM_FAKE_TREEHOUSE_LEASE_HELP=1 FM_FAKE_TREEHOUSE_VERSION=v1.8.0 run_bootstrap "$case_dir/home" "$fakebin")
+  expected="MISSING: treehouse-post-create-hook (install: $ROOT/bin/fm-bootstrap.sh install treehouse-post-create-hook)"
+  printf '%s\n' "$out" | grep -Fx "$expected" >/dev/null \
+    || fail "bootstrap accepted unquoted treehouse hook path with shell metacharacter: $out"
+  pass "bootstrap rejects unquoted treehouse hook path with shell metacharacter"
+}
+
+test_bootstrap_accepts_hooks_section_inline_comment() {
+  local case_dir fakebin out expected_config
+  case_dir="$TMP_ROOT/hooks-inline-comment"
+  mkdir -p "$case_dir/home/xdg/treehouse"
+  fakebin=$(make_fake_toolchain "$case_dir")
+  expected_config="$case_dir/home/xdg/treehouse/config.toml"
+  printf '[hooks] # local hooks\npost_create = ["%s/bin/fm-treehouse-post-create.sh"]\n' "$ROOT" >"$expected_config"
+
+  out=$(FM_FAKE_TREEHOUSE_LEASE_HELP=1 FM_FAKE_TREEHOUSE_VERSION=v1.8.0 run_bootstrap "$case_dir/home" "$fakebin")
+  [ -z "$out" ] || fail "bootstrap rejected treehouse hook under inline-commented hooks section: $out"
+  pass "bootstrap accepts inline-commented hooks section"
+}
+
+test_bootstrap_ignores_commented_treehouse_hook_config() {
+  local case_dir fakebin out expected_config expected
+  case_dir="$TMP_ROOT/commented-hook"
+  mkdir -p "$case_dir/home/xdg/treehouse"
+  fakebin=$(make_fake_toolchain "$case_dir")
+  expected_config="$case_dir/home/xdg/treehouse/config.toml"
+  printf '[hooks]\n# post_create = ["%s/bin/fm-treehouse-post-create.sh"]\n' "$ROOT" >"$expected_config"
+
+  out=$(FM_FAKE_TREEHOUSE_LEASE_HELP=1 FM_FAKE_TREEHOUSE_VERSION=v1.8.0 run_bootstrap "$case_dir/home" "$fakebin")
+  expected="MISSING: treehouse-post-create-hook (install: $ROOT/bin/fm-bootstrap.sh install treehouse-post-create-hook)"
+  printf '%s\n' "$out" | grep -Fx "$expected" >/dev/null \
+    || fail "bootstrap accepted commented treehouse hook config: $out"
+  pass "bootstrap ignores commented treehouse hook config"
+}
+
+test_bootstrap_ignores_stale_treehouse_hook_config() {
+  local case_dir fakebin out expected_config expected
+  case_dir="$TMP_ROOT/stale-hook"
+  mkdir -p "$case_dir/home/xdg/treehouse"
+  fakebin=$(make_fake_toolchain "$case_dir")
+  expected_config="$case_dir/home/xdg/treehouse/config.toml"
+  printf '[hooks]\npost_create = ["%s/missing/bin/fm-treehouse-post-create.sh"]\n' "$case_dir" >"$expected_config"
+
+  out=$(FM_FAKE_TREEHOUSE_LEASE_HELP=1 FM_FAKE_TREEHOUSE_VERSION=v1.8.0 run_bootstrap "$case_dir/home" "$fakebin")
+  expected="MISSING: treehouse-post-create-hook (install: $ROOT/bin/fm-bootstrap.sh install treehouse-post-create-hook)"
+  printf '%s\n' "$out" | grep -Fx "$expected" >/dev/null \
+    || fail "bootstrap accepted stale treehouse hook config: $out"
+  pass "bootstrap ignores stale treehouse hook config"
+}
+
+test_bootstrap_does_not_match_other_hook_commands() {
+  local case_dir fakebin out expected_config expected
+  case_dir="$TMP_ROOT/other-hook-command"
+  mkdir -p "$case_dir/home/xdg/treehouse"
+  fakebin=$(make_fake_toolchain "$case_dir")
+  expected_config="$case_dir/home/xdg/treehouse/config.toml"
+  printf '[hooks]\npost_create = ["existing-hook"]\npre_create = ["%s/bin/fm-treehouse-post-create.sh"]\n' "$ROOT" >"$expected_config"
+
+  out=$(FM_FAKE_TREEHOUSE_LEASE_HELP=1 FM_FAKE_TREEHOUSE_VERSION=v1.8.0 run_bootstrap "$case_dir/home" "$fakebin")
+  expected="MISSING: treehouse-post-create-hook (install: $ROOT/bin/fm-bootstrap.sh install treehouse-post-create-hook)"
+  printf '%s\n' "$out" | grep -Fx "$expected" >/dev/null \
+    || fail "bootstrap matched a non-post_create treehouse hook command: $out"
+  pass "bootstrap does not match other hook commands"
+}
+
+test_bootstrap_rejects_hook_path_as_shell_argument() {
+  local case_dir fakebin out expected_config expected
+  case_dir="$TMP_ROOT/hook-path-as-arg"
+  mkdir -p "$case_dir/home/xdg/treehouse"
+  fakebin=$(make_fake_toolchain "$case_dir")
+  expected_config="$case_dir/home/xdg/treehouse/config.toml"
+  printf '[hooks]\npost_create = ["echo %s/bin/fm-treehouse-post-create.sh"]\n' "$ROOT" >"$expected_config"
+
+  out=$(FM_FAKE_TREEHOUSE_LEASE_HELP=1 FM_FAKE_TREEHOUSE_VERSION=v1.8.0 run_bootstrap "$case_dir/home" "$fakebin")
+  expected="MISSING: treehouse-post-create-hook (install: $ROOT/bin/fm-bootstrap.sh install treehouse-post-create-hook)"
+  printf '%s\n' "$out" | grep -Fx "$expected" >/dev/null \
+    || fail "bootstrap accepted treehouse hook path as a shell argument: $out"
+  pass "bootstrap rejects treehouse hook path as shell argument"
+}
+
+test_bootstrap_accepts_hook_after_env_assignment() {
+  local case_dir fakebin out expected_config
+  case_dir="$TMP_ROOT/hook-after-env-assignment"
+  mkdir -p "$case_dir/home/xdg/treehouse"
+  fakebin=$(make_fake_toolchain "$case_dir")
+  expected_config="$case_dir/home/xdg/treehouse/config.toml"
+  printf '[hooks]\npost_create = ["FM_HOME=%s/home %s/bin/fm-treehouse-post-create.sh"]\n' "$case_dir" "$ROOT" >"$expected_config"
+
+  out=$(FM_FAKE_TREEHOUSE_LEASE_HELP=1 FM_FAKE_TREEHOUSE_VERSION=v1.8.0 run_bootstrap "$case_dir/home" "$fakebin")
+  [ -z "$out" ] || fail "bootstrap rejected treehouse hook command after env assignment: $out"
+  pass "bootstrap accepts treehouse hook after env assignment"
 }
 
 test_bootstrap_reports_treehouse_without_lease_support() {
@@ -87,5 +259,138 @@ test_bootstrap_reports_treehouse_without_lease_support() {
   pass "bootstrap reports treehouse without get --lease support"
 }
 
-test_bootstrap_accepts_treehouse_lease_support
+test_bootstrap_reports_treehouse_without_post_create_support() {
+  local case_dir fakebin out
+  case_dir="$TMP_ROOT/post-create-missing"
+  mkdir -p "$case_dir/home"
+  fakebin=$(make_fake_toolchain "$case_dir")
+
+  out=$(FM_FAKE_TREEHOUSE_LEASE_HELP=1 FM_FAKE_TREEHOUSE_VERSION=v1.7.9 run_bootstrap "$case_dir/home" "$fakebin")
+  printf '%s\n' "$out" | grep -Fx 'MISSING: treehouse (install: curl -fsSL https://kunchenguid.github.io/treehouse/install.sh | sh)' >/dev/null \
+    || fail "bootstrap did not report treehouse upgrade instruction for missing post_create support"
+  pass "bootstrap reports treehouse without post_create support"
+}
+
+test_bootstrap_reports_treehouse_without_post_create_hook_config() {
+  local case_dir fakebin out expected
+  case_dir="$TMP_ROOT/hook-missing"
+  mkdir -p "$case_dir/home"
+  fakebin=$(make_fake_toolchain "$case_dir")
+
+  out=$(FM_FAKE_TREEHOUSE_LEASE_HELP=1 FM_FAKE_TREEHOUSE_VERSION=v1.8.0 run_bootstrap "$case_dir/home" "$fakebin")
+  expected="MISSING: treehouse-post-create-hook (install: $ROOT/bin/fm-bootstrap.sh install treehouse-post-create-hook)"
+  printf '%s\n' "$out" | grep -Fx "$expected" >/dev/null \
+    || fail "bootstrap did not report missing treehouse post_create hook config: $out"
+  pass "bootstrap reports treehouse without post_create hook config"
+}
+
+test_bootstrap_installs_treehouse_post_create_hook_config() {
+  local case_dir fakebin out expected_config
+  case_dir="$TMP_ROOT/hook-install"
+  mkdir -p "$case_dir/home"
+  fakebin=$(make_fake_toolchain "$case_dir")
+
+  install_bootstrap_tool "$case_dir/home" "$fakebin" treehouse-post-create-hook >/dev/null \
+    || fail "bootstrap install treehouse-post-create-hook failed"
+  expected_config="$case_dir/home/xdg/treehouse/config.toml"
+  grep -Fx "post_create = [\"'$ROOT/bin/fm-treehouse-post-create.sh'\"]" "$expected_config" >/dev/null \
+    || fail "bootstrap did not install treehouse post_create hook config"
+  out=$(FM_FAKE_TREEHOUSE_LEASE_HELP=1 FM_FAKE_TREEHOUSE_VERSION=v1.8.0 run_bootstrap "$case_dir/home" "$fakebin")
+  [ -z "$out" ] || fail "bootstrap reported problems after installing treehouse hook: $out"
+  pass "bootstrap installs treehouse post_create hook config"
+}
+
+test_bootstrap_appends_treehouse_post_create_hook_config() {
+  local case_dir fakebin expected_config out
+  case_dir="$TMP_ROOT/hook-append"
+  mkdir -p "$case_dir/home/xdg/treehouse"
+  fakebin=$(make_fake_toolchain "$case_dir")
+  expected_config="$case_dir/home/xdg/treehouse/config.toml"
+  printf '[hooks]\npost_create = ["existing-hook"]\n' >"$expected_config"
+
+  install_bootstrap_tool "$case_dir/home" "$fakebin" treehouse-post-create-hook >/dev/null \
+    || fail "bootstrap install treehouse-post-create-hook failed with existing post_create"
+  grep -Fx "post_create = [\"existing-hook\", \"'$ROOT/bin/fm-treehouse-post-create.sh'\"]" "$expected_config" >/dev/null \
+    || fail "bootstrap did not append treehouse post_create hook config"
+  out=$(FM_FAKE_TREEHOUSE_LEASE_HELP=1 FM_FAKE_TREEHOUSE_VERSION=v1.8.0 run_bootstrap "$case_dir/home" "$fakebin")
+  [ -z "$out" ] || fail "bootstrap reported problems after appending treehouse hook: $out"
+  pass "bootstrap appends treehouse post_create hook config"
+}
+
+test_bootstrap_installs_quoted_treehouse_hook_path_with_spaces() {
+  local case_dir fakebin expected_config out other_root expected_root
+  case_dir="$TMP_ROOT/hook-install-spaced"
+  other_root="$case_dir/first mate"
+  mkdir -p "$case_dir/home" "$other_root/bin"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$other_root/bin/fm-treehouse-post-create.sh"
+  chmod +x "$other_root/bin/fm-treehouse-post-create.sh"
+  expected_root=$(cd "$other_root" && pwd -P)
+  fakebin=$(make_fake_toolchain "$case_dir")
+
+  FM_ROOT_OVERRIDE="$other_root" install_bootstrap_tool "$case_dir/home" "$fakebin" treehouse-post-create-hook >/dev/null \
+    || fail "bootstrap install treehouse-post-create-hook failed with spaced root"
+  expected_config="$case_dir/home/xdg/treehouse/config.toml"
+  grep -Fx "post_create = [\"'$expected_root/bin/fm-treehouse-post-create.sh'\"]" "$expected_config" >/dev/null \
+    || fail "bootstrap did not quote treehouse post_create hook path with spaces"
+  out=$(FM_ROOT_OVERRIDE="$other_root" FM_FAKE_TREEHOUSE_LEASE_HELP=1 FM_FAKE_TREEHOUSE_VERSION=v1.8.0 run_bootstrap "$case_dir/home" "$fakebin")
+  [ -z "$out" ] || fail "bootstrap reported problems after installing spaced treehouse hook: $out"
+  pass "bootstrap installs quoted treehouse hook path with spaces"
+}
+
+test_bootstrap_installs_quoted_treehouse_hook_path_with_single_quote() {
+  local case_dir fakebin expected_config out other_root
+  case_dir="$TMP_ROOT/hook-install-single-quote"
+  other_root="$case_dir/first'mate"
+  mkdir -p "$case_dir/home" "$other_root/bin"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$other_root/bin/fm-treehouse-post-create.sh"
+  chmod +x "$other_root/bin/fm-treehouse-post-create.sh"
+  fakebin=$(make_fake_toolchain "$case_dir")
+
+  FM_ROOT_OVERRIDE="$other_root" install_bootstrap_tool "$case_dir/home" "$fakebin" treehouse-post-create-hook >/dev/null \
+    || fail "bootstrap install treehouse-post-create-hook failed with single-quote root"
+  expected_config="$case_dir/home/xdg/treehouse/config.toml"
+  grep -F "\\\\''" "$expected_config" >/dev/null \
+    || fail "bootstrap did not TOML-escape shell quoting for single-quote path"
+  out=$(FM_ROOT_OVERRIDE="$other_root" FM_FAKE_TREEHOUSE_LEASE_HELP=1 FM_FAKE_TREEHOUSE_VERSION=v1.8.0 run_bootstrap "$case_dir/home" "$fakebin")
+  [ -z "$out" ] || fail "bootstrap reported problems after installing single-quote treehouse hook: $out"
+  pass "bootstrap installs quoted treehouse hook path with single quote"
+}
+
+test_bootstrap_installs_into_hooks_section_with_inline_comment() {
+  local case_dir fakebin expected_config out hook_count
+  case_dir="$TMP_ROOT/hook-install-inline-comment"
+  mkdir -p "$case_dir/home/xdg/treehouse"
+  fakebin=$(make_fake_toolchain "$case_dir")
+  expected_config="$case_dir/home/xdg/treehouse/config.toml"
+  printf '[hooks] # local hooks\npre_create = ["existing-hook"]\n' >"$expected_config"
+
+  install_bootstrap_tool "$case_dir/home" "$fakebin" treehouse-post-create-hook >/dev/null \
+    || fail "bootstrap install treehouse-post-create-hook failed with inline-commented hooks section"
+  hook_count=$(grep -Ec '^[[:space:]]*\[hooks\]' "$expected_config")
+  [ "$hook_count" -eq 1 ] || fail "bootstrap duplicated inline-commented hooks section"
+  grep -Fx "post_create = [\"'$ROOT/bin/fm-treehouse-post-create.sh'\"]" "$expected_config" >/dev/null \
+    || fail "bootstrap did not insert treehouse post_create under inline-commented hooks section"
+  out=$(FM_FAKE_TREEHOUSE_LEASE_HELP=1 FM_FAKE_TREEHOUSE_VERSION=v1.8.0 run_bootstrap "$case_dir/home" "$fakebin")
+  [ -z "$out" ] || fail "bootstrap reported problems after inline-commented hooks install: $out"
+  pass "bootstrap installs into inline-commented hooks section"
+}
+
+test_bootstrap_accepts_treehouse_lease_and_hook_support
+test_bootstrap_accepts_treehouse_hook_from_another_firstmate_root
+test_bootstrap_accepts_treehouse_hook_path_with_spaces
+test_bootstrap_rejects_unquoted_treehouse_hook_path_with_spaces
+test_bootstrap_rejects_unquoted_treehouse_hook_path_with_shell_metachar
+test_bootstrap_accepts_hooks_section_inline_comment
+test_bootstrap_ignores_commented_treehouse_hook_config
+test_bootstrap_ignores_stale_treehouse_hook_config
+test_bootstrap_does_not_match_other_hook_commands
+test_bootstrap_rejects_hook_path_as_shell_argument
+test_bootstrap_accepts_hook_after_env_assignment
 test_bootstrap_reports_treehouse_without_lease_support
+test_bootstrap_reports_treehouse_without_post_create_support
+test_bootstrap_reports_treehouse_without_post_create_hook_config
+test_bootstrap_installs_treehouse_post_create_hook_config
+test_bootstrap_appends_treehouse_post_create_hook_config
+test_bootstrap_installs_quoted_treehouse_hook_path_with_spaces
+test_bootstrap_installs_quoted_treehouse_hook_path_with_single_quote
+test_bootstrap_installs_into_hooks_section_with_inline_comment

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -33,9 +33,9 @@ test_no_mistakes_brief_uses_manual_pr_validation_contract() {
     || fail "brief scaffold failed"
   brief="$home/data/ship-test/brief.md"
 
-  grep -F 'Never push to the default branch. Never open or merge a PR. Push only your `fm/ship-test` branch, and only as part of the no-mistakes validation pipeline.' "$brief" >/dev/null \
+  grep -F "Never push to the default branch. Never open or merge a PR. Push only your \`fm/ship-test\` branch, and only as part of the no-mistakes validation pipeline." "$brief" >/dev/null \
     || fail "no-mistakes brief permits unsafe push or PR creation"
-  grep -F 'no-mistakes validation pipeline with `--skip=pr,ci`' "$brief" >/dev/null \
+  grep -F "no-mistakes validation pipeline with \`--skip=pr,ci\`" "$brief" >/dev/null \
     || fail "no-mistakes brief omits skip flags"
   grep -F 'No-mistakes may push your branch, but does not open a PR or monitor CI in this workflow.' "$brief" >/dev/null \
     || fail "no-mistakes brief omits manual workflow boundary"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_ROOT=
+
+fail() {
+  printf 'not ok - %s\n' "$1" >&2
+  exit 1
+}
+
+pass() {
+  printf 'ok - %s\n' "$1"
+}
+
+cleanup() {
+  if [ -n "${TMP_ROOT:-}" ]; then
+    rm -rf "$TMP_ROOT"
+  fi
+}
+
+trap cleanup EXIT
+
+TMP_ROOT=$(mktemp -d "$ROOT/.tmp.fm-brief-tests.XXXXXX")
+
+test_no_mistakes_brief_uses_manual_pr_validation_contract() {
+  local home brief
+  home="$TMP_ROOT/home"
+  mkdir -p "$home/data" "$home/state"
+  printf '%s\n' '- app [no-mistakes] - test project (added 2026-06-23)' > "$home/data/projects.md"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" ship-test app >/dev/null \
+    || fail "brief scaffold failed"
+  brief="$home/data/ship-test/brief.md"
+
+  grep -F 'Never push to any remote. Never open or merge a PR.' "$brief" >/dev/null \
+    || fail "no-mistakes brief permits push or PR creation"
+  grep -F 'no-mistakes validation pipeline with `--skip=push,pr,ci`' "$brief" >/dev/null \
+    || fail "no-mistakes brief omits skip flags"
+  grep -F 'No-mistakes does not push, open a PR, or monitor CI in this workflow.' "$brief" >/dev/null \
+    || fail "no-mistakes brief omits manual workflow boundary"
+  grep -F 'done: validated with --skip=push,pr,ci; branch ready for captain/manual push+PR' "$brief" >/dev/null \
+    || fail "no-mistakes brief omits manual PR-ready status"
+
+  if grep -F 'validate and ship a PR' "$brief" >/dev/null; then
+    fail "no-mistakes brief still says validation ships a PR"
+  fi
+  if grep -F 'reports CI green' "$brief" >/dev/null; then
+    fail "no-mistakes brief still waits for CI green"
+  fi
+  if grep -F 'done: PR {url} checks green' "$brief" >/dev/null; then
+    fail "no-mistakes brief still reports old PR completion"
+  fi
+
+  pass "no-mistakes brief uses manual PR validation contract"
+}
+
+test_no_mistakes_brief_uses_manual_pr_validation_contract

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -33,14 +33,18 @@ test_no_mistakes_brief_uses_manual_pr_validation_contract() {
     || fail "brief scaffold failed"
   brief="$home/data/ship-test/brief.md"
 
-  grep -F 'Never push to any remote. Never open or merge a PR.' "$brief" >/dev/null \
-    || fail "no-mistakes brief permits push or PR creation"
-  grep -F 'no-mistakes validation pipeline with `--skip=push,pr,ci`' "$brief" >/dev/null \
+  grep -F 'Never push to the default branch. Never open or merge a PR. Push only your `fm/ship-test` branch, and only as part of the no-mistakes validation pipeline.' "$brief" >/dev/null \
+    || fail "no-mistakes brief permits unsafe push or PR creation"
+  grep -F 'no-mistakes validation pipeline with `--skip=pr,ci`' "$brief" >/dev/null \
     || fail "no-mistakes brief omits skip flags"
-  grep -F 'No-mistakes does not push, open a PR, or monitor CI in this workflow.' "$brief" >/dev/null \
+  grep -F 'No-mistakes may push your branch, but does not open a PR or monitor CI in this workflow.' "$brief" >/dev/null \
     || fail "no-mistakes brief omits manual workflow boundary"
-  grep -F 'done: validated with --skip=push,pr,ci; branch ready for captain/manual push+PR' "$brief" >/dev/null \
+  grep -F 'done: validated with --skip=pr,ci; branch pushed and ready for captain/manual PR' "$brief" >/dev/null \
     || fail "no-mistakes brief omits manual PR-ready status"
+
+  if grep -F -- '--skip=push,pr,ci' "$brief" >/dev/null; then
+    fail "no-mistakes brief still skips branch push"
+  fi
 
   if grep -F 'validate and ship a PR' "$brief" >/dev/null; then
     fail "no-mistakes brief still says validation ships a PR"

--- a/tests/fm-spawn-treehouse-env.test.sh
+++ b/tests/fm-spawn-treehouse-env.test.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_ROOT=
+
+fail() {
+  printf 'not ok - %s\n' "$1" >&2
+  exit 1
+}
+
+pass() {
+  printf 'ok - %s\n' "$1"
+}
+
+cleanup() {
+  if [ -n "${TMP_ROOT:-}" ]; then
+    rm -rf "$TMP_ROOT"
+  fi
+}
+
+trap cleanup EXIT
+
+TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/fm-spawn-treehouse-env.XXXXXX")
+
+make_fake_tmux() {
+  local fakebin=$1
+  mkdir -p "$fakebin"
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "${1:-}" in
+  has-session|new-session|new-window|send-keys)
+    printf '%s\n' "$*" >> "$FM_FAKE_TMUX_LOG"
+    exit 0
+    ;;
+  list-windows)
+    exit 0
+    ;;
+  display-message)
+    printf '%s\n' "$FM_FAKE_WORKTREE"
+    exit 0
+    ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/tmux"
+}
+
+test_spawn_passes_home_context_to_treehouse_get() {
+  local case_dir fakebin home data state projects config project worktree id log
+  case_dir="$TMP_ROOT/home context"
+  fakebin="$case_dir/fakebin"
+  home="$case_dir/home"
+  data="$case_dir/data override"
+  state="$case_dir/state override"
+  projects="$case_dir/projects override"
+  config="$case_dir/config override"
+  project="$projects/app"
+  worktree="$case_dir/worktree app"
+  id=env-z1
+  log="$case_dir/tmux.log"
+
+  make_fake_tmux "$fakebin"
+  mkdir -p "$data/$id" "$state" "$config" "$project" "$worktree"
+  printf 'brief\n' > "$data/$id/brief.md"
+  mkdir -p "$data"
+  printf '%s\n' '- app [direct-PR] - test app (added 2026-06-23)' > "$data/projects.md"
+
+  PATH="$fakebin:$PATH" \
+    FM_HOME="$home" \
+    FM_DATA_OVERRIDE="$data" \
+    FM_STATE_OVERRIDE="$state" \
+    FM_PROJECTS_OVERRIDE="$projects" \
+    FM_CONFIG_OVERRIDE="$config" \
+    FM_FAKE_TMUX_LOG="$log" \
+    FM_FAKE_WORKTREE="$worktree" \
+    FM_SPAWN_NO_GUARD=1 \
+    "$ROOT/bin/fm-spawn.sh" "$id" projects/app codex >/dev/null \
+    || fail "spawn failed"
+
+  grep -F "send-keys -t firstmate:fm-$id -l FM_ROOT_OVERRIDE='' FM_STATE_OVERRIDE='$state' FM_DATA_OVERRIDE='$data' FM_PROJECTS_OVERRIDE='$projects' FM_CONFIG_OVERRIDE='$config' FM_HOME='$home' treehouse get" "$log" >/dev/null \
+    || fail "spawn did not pass active firstmate context to treehouse get"
+  pass "spawn passes active home context to treehouse get"
+}
+
+test_spawn_uses_configurable_treehouse_get_timeout() {
+  local case_dir fakebin home data state projects config project project_abs id log err rc
+  case_dir="$TMP_ROOT/treehouse timeout"
+  fakebin="$case_dir/fakebin"
+  home="$case_dir/home"
+  data="$case_dir/data"
+  state="$case_dir/state"
+  projects="$case_dir/projects"
+  config="$case_dir/config"
+  project="$projects/app"
+  id=timeout-z1
+  log="$case_dir/tmux.log"
+  err="$case_dir/stderr.log"
+
+  make_fake_tmux "$fakebin"
+  mkdir -p "$data/$id" "$state" "$config" "$project"
+  project_abs="$(cd "$project" && pwd)"
+  printf 'brief\n' > "$data/$id/brief.md"
+  printf '%s\n' '- app [direct-PR] - test app (added 2026-06-23)' > "$data/projects.md"
+
+  set +e
+  PATH="$fakebin:$PATH" \
+    FM_HOME="$home" \
+    FM_DATA_OVERRIDE="$data" \
+    FM_STATE_OVERRIDE="$state" \
+    FM_PROJECTS_OVERRIDE="$projects" \
+    FM_CONFIG_OVERRIDE="$config" \
+    FM_FAKE_TMUX_LOG="$log" \
+    FM_FAKE_WORKTREE="$project_abs" \
+    FM_TREEHOUSE_GET_TIMEOUT=1 \
+    FM_SPAWN_NO_GUARD=1 \
+    "$ROOT/bin/fm-spawn.sh" "$id" projects/app codex >/dev/null 2>"$err"
+  rc=$?
+
+  [ "$rc" -ne 0 ] || fail "spawn succeeded despite treehouse cwd never changing"
+  grep -F "treehouse get did not enter a worktree within 1s" "$err" >/dev/null \
+    || fail "spawn did not use configured treehouse timeout: $(cat "$err")"
+  pass "spawn uses configurable treehouse get timeout"
+}
+
+test_spawn_passes_home_context_to_treehouse_get
+test_spawn_uses_configurable_treehouse_get_timeout

--- a/tests/fm-treehouse-post-create.test.sh
+++ b/tests/fm-treehouse-post-create.test.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_ROOT=
+
+fail() {
+  printf 'not ok - %s\n' "$1" >&2
+  exit 1
+}
+
+pass() {
+  printf 'ok - %s\n' "$1"
+}
+
+cleanup() {
+  if [ -n "${TMP_ROOT:-}" ]; then
+    rm -rf "$TMP_ROOT"
+  fi
+}
+
+trap cleanup EXIT
+
+TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/fm-treehouse-post-create-tests.XXXXXX")
+
+create_project() {
+  local home=$1 project=$2 clone
+  clone="$home/projects/$project"
+  mkdir -p "$home/projects" "$home/data" "$home/state"
+  git init -q "$clone"
+  git -C "$clone" config user.email test@example.com
+  git -C "$clone" config user.name Test
+  printf '%s\n' initial >"$clone/file.txt"
+  git -C "$clone" add file.txt
+  git -C "$clone" commit -q -m initial
+  printf '%s\n' "$clone"
+}
+
+create_worktree() {
+  local clone=$1 path=$2
+  git -C "$clone" worktree add -q --detach "$path" HEAD
+}
+
+write_setup() {
+  local data=$1 project=$2 marker=$3
+  cat >"$data/$project-setup.sh" <<SH
+#!/usr/bin/env bash
+printf '%s\n' "\$(pwd)" >"$marker"
+SH
+  chmod +x "$data/$project-setup.sh"
+}
+
+test_hook_runs_for_matching_project_worktree() {
+  local home clone worktree marker expected
+  home="$TMP_ROOT/matching/home"
+  clone=$(create_project "$home" app)
+  worktree="$TMP_ROOT/matching/app"
+  create_worktree "$clone" "$worktree"
+  marker="$TMP_ROOT/matching/ran"
+  write_setup "$home/data" app "$marker"
+
+  (cd "$worktree" && FM_HOME="$home" "$ROOT/bin/fm-treehouse-post-create.sh") \
+    || fail "hook failed for matching worktree"
+  expected=$(cd "$worktree" && pwd)
+  [ "$(cat "$marker" 2>/dev/null)" = "$expected" ] \
+    || fail "hook did not run setup in matching worktree"
+  [ -f "$home/state/treehouse-setup-app.log" ] \
+    || fail "hook did not write matching setup log"
+  pass "hook runs setup for matching project worktree"
+}
+
+test_hook_skips_same_basename_different_repo() {
+  local home clone unrelated worktree marker
+  home="$TMP_ROOT/collision/home"
+  clone=$(create_project "$home" app)
+  unrelated="$TMP_ROOT/collision/unrelated-source"
+  git init -q "$unrelated"
+  git -C "$unrelated" config user.email test@example.com
+  git -C "$unrelated" config user.name Test
+  printf '%s\n' unrelated >"$unrelated/file.txt"
+  git -C "$unrelated" add file.txt
+  git -C "$unrelated" commit -q -m initial
+  worktree="$TMP_ROOT/collision/app"
+  create_worktree "$unrelated" "$worktree"
+  marker="$TMP_ROOT/collision/ran"
+  write_setup "$home/data" app "$marker"
+  [ -d "$clone" ] || fail "test project clone missing"
+
+  (cd "$worktree" && FM_HOME="$home" "$ROOT/bin/fm-treehouse-post-create.sh") \
+    || fail "hook failed while skipping colliding worktree"
+  [ ! -e "$marker" ] || fail "hook ran setup for colliding basename"
+  pass "hook skips same-basename worktree from a different repo"
+}
+
+test_hook_uses_data_override() {
+  local home data clone worktree marker expected
+  home="$TMP_ROOT/data-override/home"
+  data="$TMP_ROOT/data-override/data"
+  clone=$(create_project "$home" app)
+  mkdir -p "$data"
+  worktree="$TMP_ROOT/data-override/app"
+  create_worktree "$clone" "$worktree"
+  marker="$TMP_ROOT/data-override/ran"
+  write_setup "$data" app "$marker"
+
+  (cd "$worktree" && FM_HOME="$home" FM_DATA_OVERRIDE="$data" "$ROOT/bin/fm-treehouse-post-create.sh") \
+    || fail "hook failed with data override"
+  expected=$(cd "$worktree" && pwd)
+  [ "$(cat "$marker" 2>/dev/null)" = "$expected" ] \
+    || fail "hook did not run setup from data override"
+  pass "hook uses FM_DATA_OVERRIDE"
+}
+
+test_hook_runs_for_matching_project_worktree
+test_hook_skips_same_basename_different_repo
+test_hook_uses_data_override


### PR DESCRIPTION
## Intent

Captain, the developer wanted AGENTS.md updated so all firstmate instructions to crewmates for running the no-mistakes pipeline use the manual-PR workflow with --skip=pr,ci. They wanted validation to run through push without no-mistakes opening a GitHub PR, leaving the captain to open the PR manually afterward, while preserving the explicit rule that firstmate must not merge without approval. They asked for the change to be tightly scoped to the no-mistakes validation and PR-ready instructions, with a caveat that manual PR bodies may need to preserve the no-mistakes marker required by the current workflow checks. They also required creating branch fm/nomistakes-skip-pr-ci-v5, committing the change, staying inside the worktree, not pushing to origin or GitHub, and using only the local no-mistakes remote/bare gate if needed to start validation with push/pr/ci steps skipped.

## What Changed

- Adds Treehouse post-create setup support in bootstrap/spawn, including hook installation, environment propagation, and a dedicated `fm-treehouse-post-create.sh` helper.
- Updates firstmate no-mistakes guidance and generated crewmate briefs so validation runs through branch push with `--skip=pr,ci`, leaving PR creation/manual merge approval outside the pipeline.
- Expands shell tests for bootstrap hook handling, generated brief wording, spawn Treehouse environment behavior, and post-create setup execution.

## Risk Assessment

⚠️ Medium: Captain, no new material issues were found beyond the previously ignored Treehouse TOML edge case, but the branch changes bootstrap/spawn behavior and global Treehouse hook wiring with nontrivial shell parsing.

## Testing

Captain, I inspected the branch diff and no-mistakes instructions, ran the focused changed-area tests, generated an actual crewmate brief as end-user evidence, verified it contains the manual-PR workflow and not the old push-skipping wording, ran the full shell test suite, and confirmed the working tree was left clean.

<details>
<summary>Evidence: Manual PR generated brief excerpt</summary>

<code>Generated brief excerpt shows: `--skip=pr,ci`, branch push through no-mistakes, no PR/CI monitoring, and manual PR-ready status.</code>

```text
Generated brief: /var/folders/t0/dws_m6l52lj97dkt9f4hd_sh0000gn/T/no-mistakes-evidence/01KVTKFHBWBD1CHR7ZPTDJ1T17/manual-pr-home/data/ship-evidence-prci/brief.md

# Definition of done
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run the no-mistakes validation pipeline with `--skip=pr,ci`.
During validation, fix auto-fix findings yourself; escalate ask-user findings per rule 6.
No-mistakes may push your branch, but does not open a PR or monitor CI in this workflow.
After no-mistakes finishes validation and branch push, append `done: validated with --skip=pr,ci; branch pushed and ready for captain/manual PR` and stop. You are finished.
```
</details>
<details>
<summary>Evidence: Full generated crewmate brief</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Setup
You are in a disposable git worktree of app, at a detached HEAD on a clean default branch.
1. First action: create your branch: `git checkout -b fm/ship-evidence-prci`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never open or merge a PR. Push only your `fm/ship-evidence-prci` branch, and only as part of the no-mistakes validation pipeline.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/t0/dws_m6l52lj97dkt9f4hd_sh0000gn/T/no-mistakes-evidence/01KVTKFHBWBD1CHR7ZPTDJ1T17/manual-pr-home/state/ship-evidence-prci.status'`
   States: working, needs-decision, blocked, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs to a human (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/Users/michael/.no-mistakes/worktrees/458d9fed4d70/01KVTKFHBWBD1CHR7ZPTDJ1T17/bin/fm-ensure-agents-md.sh .` in the worktree.
If this task produced durable project-intrinsic knowledge, record it in `AGENTS.md` as part of your change.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run the no-mistakes validation pipeline with `--skip=pr,ci`.
During validation, fix auto-fix findings yourself; escalate ask-user findings per rule 6.
No-mistakes may push your branch, but does not open a PR or monitor CI in this workflow.
After no-mistakes finishes validation and branch push, append `done: validated with --skip=pr,ci; branch pushed and ready for captain/manual PR` and stop. You are finished.
```
</details>
<details>
<summary>Evidence: Evidence transcript</summary>

```text
Generated by: FM_HOME=/var/folders/t0/dws_m6l52lj97dkt9f4hd_sh0000gn/T/no-mistakes-evidence/01KVTKFHBWBD1CHR7ZPTDJ1T17/manual-pr-home bin/fm-brief.sh ship-evidence-prci app
Generated brief: /var/folders/t0/dws_m6l52lj97dkt9f4hd_sh0000gn/T/no-mistakes-evidence/01KVTKFHBWBD1CHR7ZPTDJ1T17/manual-pr-home/data/ship-evidence-prci/brief.md

# Rules
1. Never push to the default branch. Never open or merge a PR. Push only your `fm/ship-evidence-prci` branch, and only as part of the no-mistakes validation pipeline.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/t0/dws_m6l52lj97dkt9f4hd_sh0000gn/T/no-mistakes-evidence/01KVTKFHBWBD1CHR7ZPTDJ1T17/manual-pr-home/state/ship-evidence-prci.status'`
   States: working, needs-decision, blocked, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs to a human (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/Users/michael/.no-mistakes/worktrees/458d9fed4d70/01KVTKFHBWBD1CHR7ZPTDJ1T17/bin/fm-ensure-agents-md.sh .` in the worktree.
If this task produced durable project-intrinsic knowledge, record it in `AGENTS.md` as part of your change.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run the no-mistakes validation pipeline with `--skip=pr,ci`.
During validation, fix auto-fix findings yourself; escalate ask-user findings per rule 6.
No-mistakes may push your branch, but does not open a PR or monitor CI in this workflow.
After no-mistakes finishes validation and branch push, append `done: validated with --skip=pr,ci; branch pushed and ready for captain/manual PR` and stop. You are finished.
```
</details>
- Outcome: 🔧 1 issue found → auto-fixed ✅ across 2 runs (13m40s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- 🚨 `AGENTS.md:421` - The new rule requires every no-mistakes instruction to include `--skip=push,pr,ci`, but generated no-mistakes briefs still say firstmate will run `/no-mistakes` to ship a PR and that the crewmate should report `done: PR {url} checks green` after CI. New tasks will get conflicting instructions and may still push/open PRs despite this workflow change; update `bin/fm-brief.sh`&#39;s no-mistakes definition of done to match the manual PR flow.
- ⚠️ `bin/fm-bootstrap.sh:386` - Appending to a valid single-line TOML array with a trailing comma, such as `post_create = [&#34;existing&#34;,]`, produces `post_create = [&#34;existing&#34;,, &#34;&lt;hook&gt;&#34;]`, corrupting the Treehouse config. Strip an existing trailing comma before inserting, or rewrite the array through a safer parser path.

🔧 Fix: Align generated no-mistakes brief contract
✅ Re-checked - no issues remain.

</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `AGENTS.md:421` - Captain, the implemented no-mistakes instructions skip the push step too: AGENTS.md requires `--skip=push,pr,ci` and says no-mistakes skips branch push. The generated crewmate brief mirrors that by telling the crewmate never to push and to stop before manual push+PR. That does not demonstrate the stated intent of validation running through push while only PR/CI are skipped with `--skip=pr,ci`.
- `git diff 2a2fe0566e63b883ec53dc3e34dc14306689f989..0b9ac82dd25e61de49e59221918dce3dbab2f965 -- AGENTS.md bin/fm-brief.sh tests/fm-brief.test.sh README.md .github/workflows/no-mistakes-required.yml`
- `tests/fm-brief.test.sh`
- `FM_HOME=/var/folders/t0/dws_m6l52lj97dkt9f4hd_sh0000gn/T/no-mistakes-evidence/01KVTKFHBWBD1CHR7ZPTDJ1T17/home bin/fm-brief.sh ship-test app`
- <code>`nl -ba AGENTS.md | sed -n &#39;406,440p&#39;` and `nl -ba bin/fm-brief.sh | sed -n &#39;184,198p&#39;`</code>
- `git status --short`

🔧 Fix: Captain, allow no-mistakes push before manual PR
✅ Re-checked - no issues remain.
- `sed -n '1,220p' /Users/michael/.agents/skills/no-mistakes/SKILL.md`
- <code>`pwd`; `git status --short`; `git rev-parse --show-toplevel`; `git log --oneline --decorate -5`</code>
- <code>`git diff --stat 2a2fe0566e63b883ec53dc3e34dc14306689f989..HEAD`; `git diff --name-only 2a2fe0566e63b883ec53dc3e34dc14306689f989..HEAD`</code>
- <code>`sed -n &#39;380,445p&#39; AGENTS.md`; `sed -n &#39;170,205p&#39; bin/fm-brief.sh`; `sed -n &#39;1,260p&#39; tests/fm-brief.test.sh`</code>
- `tests/fm-brief.test.sh && tests/fm-bootstrap.test.sh && tests/fm-spawn-treehouse-env.test.sh && tests/fm-treehouse-post-create.test.sh`
- `for t in tests/*.test.sh; do echo "== $t =="; "$t" || exit $?; done`
- `FM_HOME=/var/folders/t0/dws_m6l52lj97dkt9f4hd_sh0000gn/T/no-mistakes-evidence/01KVTKFHBWBD1CHR7ZPTDJ1T17/manual-pr-home bin/fm-brief.sh ship-evidence-prci app`
- <code>`grep` checks on the generated brief for `--skip=pr,ci`, branch-push wording, manual PR-ready status, and absence of `--skip=push,pr,ci` / old PR+CI status wording</code>
- `git status --short && find . -maxdepth 1 -type d -name '.tmp.*' -print`

</details>

<details>
<summary>⏭️ **Document** - skipped</summary>

- ⚠️ `.github/workflows/no-mistakes-required.yml:18` - Workflow UI/error text still says PRs must be raised through `git push no-mistakes` and that the pipeline writes the PR body. I left it unchanged because it is executable workflow configuration, not a documentation file or doc comment.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
