### PR TITLE
feat: add optional tasks-axi groundwork

### DIFF
--- a/.tasks.toml
+++ b/.tasks.toml
@@ -1,0 +1,6 @@
+backend = "markdown"
+
+[markdown]
+path = "data/backlog.md"
+archive = "data/done-archive.md"
+done_keep = 10

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,13 +103,16 @@ Run `bin/fm-bootstrap.sh`.
 Bootstrap also refreshes the fleet via `bin/fm-fleet-sync.sh`: it fetches each remote-backed clone, clean-fast-forwards its local default branch when safe, and prunes local branches whose upstream is gone and that no worktree still needs, best-effort and non-fatal.
 Set `FM_FLEET_PRUNE=0` to temporarily disable that branch pruning.
 Silence means all good: say nothing and move on.
-Otherwise it prints one line per problem; handle each:
+Otherwise it prints one line per problem or capability fact; handle each:
 
 - `MISSING: <tool> (install: <command>)` - list the missing tools to the captain with a one-line purpose each plus the printed install commands, wait for consent (one approval may cover the list), then run `bin/fm-bootstrap.sh install <approved tools...>`.
   For `treehouse`, this also covers an installed version whose `treehouse get` lacks `--lease`; treat it as an upgrade request.
 - `NEEDS_GH_AUTH` - ask the captain to run `! gh auth login` (interactive; you cannot run it for them).
 - `CREW_HARNESS_OVERRIDE: <name>` - record and use the override silently; surface a harness fact only if it actually blocks work or the captain asks.
 - `FLEET_SYNC: <repo>: skipped: <reason>` - bootstrap continued; investigate only if the dirty, diverged, or offline clone blocks work.
+- `TASKS_AXI: available` - an optional capability fact, not a problem; record it silently and never surface it to the captain.
+  Firstmate does not route backlog mutations through `tasks-axi` yet (deferred pending format compatibility, section 10), so keep hand-editing `data/backlog.md` exactly as section 10 describes.
+  Its presence and its absence are equally a no-op here, never a missing tool to install.
 
 Bootstrap's fleet refresh is bounded by `FM_FLEET_SYNC_BOOTSTRAP_TIMEOUT` seconds, default 20; a timeout is reported as a `FLEET_SYNC` skip and does not block startup.
 
@@ -630,6 +633,8 @@ Re-evaluate Queued on every teardown and every heartbeat: anything whose blocker
 
 Keep Done to the 10 most recent entries; prune older ones whenever you add to the section.
 Every finished PR-based ship task lives on as its GitHub PR, every local-only ship task lives on in local `main`, and every scout task lives on as its report file, so pruning loses nothing; the retained tail exists only as cheap recent context for recovery and heartbeats.
+
+A tracked `.tasks.toml` at this repo root pins the `tasks-axi` markdown backend to `data/backlog.md`, but adopting `tasks-axi` for backlog mutations is deferred pending a release whose format is compatible with the In-flight (`- [ ] <id>`) and `blocked-by: <id> - <reason>` shapes above; until then, every firstmate home (main and each secondmate) keeps hand-editing `data/backlog.md` exactly as this section describes.
 
 ## 11. Crewmate briefs
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ Hard rules, in priority order:
 
 You may freely write to this repo itself (backlog, briefs, state, even this file when the captain approves a change).
 Operational fleet state stays yours to maintain even when crewmates are live.
-Shared, tracked material means `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `.github/workflows/`, `bin/`, and agent skill files.
+Shared, tracked material means `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `.tasks.toml`, `.github/workflows/`, `bin/`, and agent skill files.
 When one or more crewmates are in flight, delegate changes to shared, tracked material to a crewmate through the normal scout or ship machinery instead of hand-editing them yourself.
 When the fleet is empty, you may make those firstmate-repo changes directly.
 Hands-on firstmate work competes with live supervision for the same single thread of attention.
@@ -65,6 +65,7 @@ AGENTS.md            this file (CLAUDE.md is a symlink to it)
 CONTRIBUTING.md      contributor workflow and repo conventions
 README.md            public overview and development notes
 .github/workflows/   shared CI and PR enforcement, committed
+.tasks.toml          tracked optional tasks-axi markdown backend config, currently inert
 .agents/skills/      shared skills, committed
 .claude/skills       symlink to .agents/skills for claude compatibility
 bin/                 helper scripts, committed, including fm-fleet-sync.sh for clean default-branch refreshes and gone-branch pruning; read each script's header before first use

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,8 +33,9 @@ See the [no-mistakes quick start](https://kunchenguid.github.io/no-mistakes/star
 
 - This repo is a template for running a firstmate orchestrator agent.
   `AGENTS.md` is the agent's entire job description; `CLAUDE.md` is a symlink to it, and `.claude/skills` is a symlink to `.agents/skills`.
-- Only shared material is tracked: `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `.github/workflows/`, `bin/`, and `.agents/skills/`.
+- Only shared material is tracked: `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `.tasks.toml`, `.github/workflows/`, `bin/`, and `.agents/skills/`.
   Everything personal to one captain's fleet (`data/`, `state/`, `config/`, `projects/`, `.no-mistakes/`) is gitignored; never commit it.
+  The root `.tasks.toml` is tracked optional `tasks-axi` config; it does not make `data/` tracked.
 - Helper scripts in `bin/` are plain bash.
   Each starts with a usage header comment; keep it accurate when you change behavior.
   `shellcheck bin/*.sh` must pass, and CI enforces it.

--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ cd firstmate && claude
 ```
 
 That is the whole install.
-On first launch the first mate detects what its toolchain is missing or too old (tmux, node, gh, treehouse with durable lease support, no-mistakes, gh-axi, chrome-devtools-axi, lavish-axi), lists it with the exact install commands, and installs only after you say go.
+On first launch the first mate detects what its required toolchain is missing or too old (tmux, node, gh, treehouse with durable lease support, no-mistakes, gh-axi, chrome-devtools-axi, lavish-axi), lists it with the exact install commands, and installs only after you say go.
+If `tasks-axi` is already on `PATH`, bootstrap records it as an optional capability fact, but firstmate still hand-edits `data/backlog.md` until that tool can parse firstmate's backlog format.
 
 **Run it inside tmux for the best experience.**
 firstmate works from any terminal - outside tmux, crewmates land in a detached `firstmate` session you can attach to - but launching your harness from inside tmux puts every crewmate window in your own session, one per task, where you can watch the crew work in real time or type into any window to intervene.
@@ -145,7 +146,7 @@ The first mate drives these; you rarely need to, but they work by hand too.
 
 | Script                   | Description                                                                                                         |
 | ------------------------ | ------------------------------------------------------------------------------------------------------------------- |
-| `fm-bootstrap.sh`        | Detect missing or outdated toolchain pieces; refresh clones best-effort; install tools only after consent           |
+| `fm-bootstrap.sh`        | Detect required toolchain problems and optional capability facts; refresh clones best-effort; install tools only after consent |
 | `fm-fleet-sync.sh`       | Fetch clones, clean-fast-forward their checked-out default branches, and safely prune branches whose remote is gone |
 | `fm-backlog-handoff.sh`  | Move already-judged in-scope queued backlog items from the main home into a seeded secondmate home                 |
 | `fm-brief.sh`            | Scaffold a ship brief, a report-only scout brief with `--scout`, or a secondmate charter with `--secondmate`      |
@@ -170,6 +171,7 @@ The first mate drives these; you rarely need to, but they work by hand too.
 ## Configuration
 
 The shared orchestrator behavior lives in `AGENTS.md` - edit it like any prompt when the fleet is empty, or dispatch shared-repo edits to a crewmate while tasks are in flight.
+The tracked `.tasks.toml` pins the optional `tasks-axi` markdown backend to `data/backlog.md`, but current backlog mutations remain manual until `tasks-axi` can parse firstmate's backlog format.
 Personal preferences for one captain's fleet live locally in `data/captain.md`; it is gitignored and read after `data/projects.md` and optional `data/secondmates.md` during bootstrap.
 Persistent secondmate routes live locally in `data/secondmates.md`.
 Each line records the secondmate id, charter summary, absolute home path, natural-language scope, project clone list, and added date; `fm-home-seed.sh validate` refuses duplicate ids, duplicate homes, and nested or overlapping homes.
@@ -210,7 +212,7 @@ FM_HOUSEKEEPING_TICK=15            # seconds between batch-flush, stale-recheck,
 
 ## Development
 
-Tracked changes to firstmate itself, including `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `.github/workflows/`, `bin/`, and agent skill files, ship through the `no-mistakes` pipeline on a feature branch and require the captain's explicit merge approval.
+Tracked changes to firstmate itself, including `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `.tasks.toml`, `.github/workflows/`, `bin/`, and agent skill files, ship through the `no-mistakes` pipeline on a feature branch and require the captain's explicit merge approval.
 When supervising live crewmates, keep long validation or build work in the background so watcher wakes can still be handled.
 Human-authored pull requests targeting `main` must be raised through `git push no-mistakes`; see `CONTRIBUTING.md` for the enforced contributor workflow.
 Local `.no-mistakes/` state and test evidence stay out of this repo; `.no-mistakes.yaml` keeps evidence in a temp directory instead.

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -1,11 +1,15 @@
 #!/usr/bin/env bash
 # Bootstrap detection, best-effort fleet refresh/prune, and installs.
 # Usage: fm-bootstrap.sh
-#          Detect: prints one line per problem and exits 0. Silent = all good.
+#          Detect: prints one line per problem or capability fact and exits 0.
+#          Silent = all good.
 #          Lines: "MISSING: <tool> (install: <command>)", "NEEDS_GH_AUTH",
-#                 "CREW_HARNESS_OVERRIDE: <name>", "FLEET_SYNC: <repo>: skipped: <reason>".
+#                 "CREW_HARNESS_OVERRIDE: <name>", "FLEET_SYNC: <repo>: skipped: <reason>",
+#                 "TASKS_AXI: available".
 #          treehouse is also MISSING when its installed version lacks
 #          "treehouse get --lease" support.
+#          tasks-axi is an OPTIONAL backlog-management capability, never a
+#          required tool: it is never a MISSING line and never prompts an install.
 #          Fleet sync fetches, fast-forwards, and prunes gone local branches;
 #          it is bounded by FM_FLEET_SYNC_BOOTSTRAP_TIMEOUT, default 20s.
 #          Set FM_FLEET_PRUNE=0 to skip branch pruning during that refresh.
@@ -95,5 +99,8 @@ gh auth status >/dev/null 2>&1 || echo "NEEDS_GH_AUTH"
 crew=
 [ -f "$CONFIG/crew-harness" ] && crew=$(tr -d '[:space:]' < "$CONFIG/crew-harness" || true)
 [ -n "$crew" ] && [ "$crew" != "default" ] && echo "CREW_HARNESS_OVERRIDE: $crew"
+# Optional capability, not a required tool: detected on PATH so it is never a
+# MISSING line and never prompts an install. Absent => silent, behavior unchanged.
+command -v tasks-axi >/dev/null 2>&1 && echo "TASKS_AXI: available"
 fleet_sync
 exit 0

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -3,6 +3,7 @@ set -u
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TMP_ROOT=
+BASE_PATH=${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin}
 
 fail() {
   printf 'not ok - %s\n' "$1" >&2
@@ -60,7 +61,7 @@ SH
 
 run_bootstrap() {
   local home=$1 fakebin=$2
-  PATH="$fakebin:$PATH" FM_HOME="$home" "$ROOT/bin/fm-bootstrap.sh"
+  PATH="$fakebin:$BASE_PATH" FM_HOME="$home" "$ROOT/bin/fm-bootstrap.sh"
 }
 
 test_bootstrap_accepts_treehouse_lease_support() {
@@ -87,5 +88,22 @@ test_bootstrap_reports_treehouse_without_lease_support() {
   pass "bootstrap reports treehouse without get --lease support"
 }
 
+test_bootstrap_reports_tasks_axi_when_available() {
+  local case_dir fakebin out
+  case_dir="$TMP_ROOT/tasks-axi-available"
+  mkdir -p "$case_dir/home"
+  fakebin=$(make_fake_toolchain "$case_dir")
+  cat > "$fakebin/tasks-axi" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  chmod +x "$fakebin/tasks-axi"
+
+  out=$(FM_FAKE_TREEHOUSE_LEASE_HELP=1 run_bootstrap "$case_dir/home" "$fakebin")
+  [ "$out" = 'TASKS_AXI: available' ] || fail "bootstrap did not report tasks-axi availability: $out"
+  pass "bootstrap reports optional tasks-axi availability"
+}
+
 test_bootstrap_accepts_treehouse_lease_support
 test_bootstrap_reports_treehouse_without_lease_support
+test_bootstrap_reports_tasks_axi_when_available


### PR DESCRIPTION
## Intent

Land ONLY the inert, no-op groundwork for adopting the published tasks-axi CLI in firstmate's backlog management; explicitly DEFER routing any backlog mutations through tasks-axi.

Background and decision: an earlier wider version of this change also instructed firstmate to perform backlog mutations via tasks-axi verbs. Review correctly flagged (and I empirically confirmed) that tasks-axi v0.1.0 is NOT format-compatible with firstmate's backlog: (a) In-flight lines use '- [ ] <id> - ...' (firstmate docs AND the bin/fm-backlog-handoff.sh awk matcher), but tasks-axi only reads/writes '- **<id>** - ...', so existing in-flight items are invisible to tasks-axi (NOT_FOUND) and tasks-axi-written items are unmatched by the helper; (b) firstmate's 'blocked-by: <id> - <reason>' form is not parsed by tasks-axi, which swallows it into the title and reports the item as ready, risking premature dispatch of blocked work. The captain reviewed these findings and chose to ship only the inert pieces now and defer mutation-adoption until a tasks-axi release parses firstmate's format.

What this change deliberately does:
- fm-bootstrap.sh: detect tasks-axi on PATH as an OPTIONAL capability that prints a single 'TASKS_AXI: available' fact line. It is intentionally NOT in the required TOOLS list, so it can never be a 'MISSING:' line and never prompts an install; absent => prints nothing (strict no-op via a single '&&' short-circuit). Header comment documents it as optional, never required.
- Add a tracked .tasks.toml at repo root pinning the markdown backend to data/backlog.md (archive data/done-archive.md, done_keep 10). data/ is gitignored but .tasks.toml at root is tracked and intentionally applies to every firstmate home (main + secondmates), which all use data/backlog.md. This file is INERT right now - nothing is instructed to run tasks-axi mutations.
- AGENTS.md (CLAUDE.md is a symlink to it): section 3 gains a 'TASKS_AXI: available' handling bullet that records the capability silently and EXPLICITLY states firstmate does NOT route mutations through tasks-axi yet (deferred), so it keeps hand-editing data/backlog.md exactly as today; section 10 keeps its existing backlog format spec block byte-intact and gains ONE deferred-adoption note sentence. There is intentionally NO instruction anywhere to use tasks-axi for mutations.

Deliberately OUT of scope (do not flag as omissions): no tasks-axi verb adoption (intentionally removed per the captain's decision); no migration or reformatting of backlog content; no change to the backlog FORMAT or section structure; no auto-install or making tasks-axi required. The net behavior change when tasks-axi is absent is zero, and when present is only the inert detection line plus a tracked config file that nothing yet consumes.

## What Changed
- Adds inert `tasks-axi` groundwork by tracking `.tasks.toml` for the existing `data/backlog.md` markdown backend.
- Updates bootstrap to report `TASKS_AXI: available` only when the optional CLI is present, without making it a required dependency or prompting install.
- Documents, captain, that backlog mutations remain hand-edited for now and that `tasks-axi` mutation adoption is deferred until format compatibility is resolved.

## Risk Assessment

✅ Low: Captain, the change is narrow, documented as inert, and the prior PATH-leak test risk has been addressed without adding new material runtime risk.

## Testing

Captain, I ran the targeted bootstrap test, manually exercised the end-user bootstrap command with `tasks-axi` absent and present, verified the required-tool list and deferred-adoption docs, captured the CLI transcript as evidence, and confirmed the worktree stayed clean.

<details>
<summary>Evidence: Optional tasks-axi bootstrap transcript</summary>

<code>Manual bootstrap evidence shows no output when `tasks-axi` is absent, `TASKS_AXI: available` when present, and `.tasks.toml` points at `data/backlog.md`.</code>

```text
Manual bootstrap evidence for optional tasks-axi detection

Case 1: all required tools available, tasks-axi absent
$ PATH=<fake required tools> FM_HOME=<empty firstmate home> ./bin/fm-bootstrap.sh
<no output>

Case 2: same environment, tasks-axi present on PATH
$ PATH=<fake required tools plus tasks-axi> FM_HOME=<empty firstmate home> ./bin/fm-bootstrap.sh
TASKS_AXI: available

Tracked tasks-axi config
$ sed -n '1,80p' .tasks.toml
backend = "markdown"

[markdown]
path = "data/backlog.md"
archive = "data/done-archive.md"
done_keep = 10
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `bin/fm-bootstrap.sh:104` - Line 104 now emits `TASKS_AXI: available` whenever `tasks-axi` is anywhere on PATH, but `tests/fm-bootstrap.test.sh` prepends its fake toolchain while preserving the real PATH and still asserts empty bootstrap output for the all-good case. Captain, on machines with `tasks-axi` installed, that test will fail even though the feature is behaving as intended; shim/hide `tasks-axi` in the test or allow the optional capability line.

🔧 Fix: Captain, isolate optional tasks-axi bootstrap tests
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-bootstrap.test.sh`
- <code>Controlled-PATH manual check: `PATH=&lt;fake required tools&gt; FM_HOME=&lt;empty firstmate home&gt; ./bin/fm-bootstrap.sh` with `tasks-axi` absent produced no output.</code>
- <code>Controlled-PATH manual check: `PATH=&lt;fake required tools plus tasks-axi&gt; FM_HOME=&lt;empty firstmate home&gt; ./bin/fm-bootstrap.sh` produced exactly `TASKS_AXI: available`.</code>
- <code>`awk &#39;/^TOOLS=/{print; exit}&#39; bin/fm-bootstrap.sh` plus targeted `rg` checks verified `tasks-axi` is not required and AGENTS.md says mutation adoption is deferred.</code>
- <code>`git status --short` verified testing left no transient worktree files.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
