### PR TITLE
test(secondmate): trim redundant spawn ordering assertions

### DIFF
--- a/tests/fm-secondmate.test.sh
+++ b/tests/fm-secondmate.test.sh
@@ -1123,18 +1123,18 @@ SH
     fail "secondmate spawn accepted an unseeded home"
   fi
   grep -F 'not a seeded secondmate home' "$err" >/dev/null || fail "spawn did not explain missing seed marker"
-  grep -F 'new-window' "$log" >/dev/null && fail "spawn created a window before seed marker validation"
+  # Canonical ordering proof: validation runs before any tmux side-effect. Every rejection
+  # reason below shares this one linear pre-launch path, so they each assert only their own
+  # refusal message rather than re-proving "no window created before validation" each time.
+  grep -F 'new-window' "$log" >/dev/null && fail "spawn created a window before validation"
 
-  : > "$log"
   printf 'other\n' > "$wronghome/.fm-secondmate-home"
   if PATH="$fakebin:$PATH" FM_HOME="$home" FM_FAKE_TMUX_LOG="$log" FM_FAKE_TMUX_CAPTURE="$TMP_ROOT/spawn-validate-fake/pane.txt" \
     "$ROOT/bin/fm-spawn.sh" domain "$wronghome" codex --secondmate >/dev/null 2>"$err"; then
     fail "secondmate spawn accepted a home marked for another secondmate"
   fi
   grep -F 'marked for secondmate other, expected domain' "$err" >/dev/null || fail "spawn did not explain marker mismatch"
-  grep -F 'new-window' "$log" >/dev/null && fail "spawn created a window before marker mismatch validation"
 
-  : > "$log"
   printf 'domain\n' > "$marker_only/.fm-secondmate-home"
   printf 'charter\n' > "$marker_only/data/charter.md"
   if PATH="$fakebin:$PATH" FM_HOME="$home" FM_FAKE_TMUX_LOG="$log" FM_FAKE_TMUX_CAPTURE="$TMP_ROOT/spawn-validate-fake/pane.txt" \
@@ -1142,35 +1142,27 @@ SH
     fail "secondmate spawn accepted a marked home missing AGENTS.md"
   fi
   grep -F 'not a firstmate home (missing AGENTS.md)' "$err" >/dev/null || fail "spawn did not explain missing AGENTS.md"
-  grep -F 'new-window' "$log" >/dev/null && fail "spawn created a window before AGENTS.md validation"
 
-  : > "$log"
   printf '# Firstmate\n' > "$marker_only/AGENTS.md"
   if PATH="$fakebin:$PATH" FM_HOME="$home" FM_FAKE_TMUX_LOG="$log" FM_FAKE_TMUX_CAPTURE="$TMP_ROOT/spawn-validate-fake/pane.txt" \
     "$ROOT/bin/fm-spawn.sh" domain "$marker_only" codex --secondmate >/dev/null 2>"$err"; then
     fail "secondmate spawn accepted a marked home missing bin"
   fi
   grep -F 'not a firstmate home (missing bin/)' "$err" >/dev/null || fail "spawn did not explain missing bin"
-  grep -F 'new-window' "$log" >/dev/null && fail "spawn created a window before bin validation"
 
-  : > "$log"
   printf 'domain\n' > "$home/.fm-secondmate-home"
   if PATH="$fakebin:$PATH" FM_HOME="$home" FM_FAKE_TMUX_LOG="$log" FM_FAKE_TMUX_CAPTURE="$TMP_ROOT/spawn-validate-fake/pane.txt" \
     "$ROOT/bin/fm-spawn.sh" domain "$home" codex --secondmate >/dev/null 2>"$err"; then
     fail "secondmate spawn accepted the active home"
   fi
   grep -F 'secondmate home cannot be the active firstmate home' "$err" >/dev/null || fail "spawn did not reject active home"
-  grep -F 'new-window' "$log" >/dev/null && fail "spawn created a window before active-home validation"
 
-  : > "$log"
   if PATH="$fakebin:$PATH" FM_HOME="$home" FM_FAKE_TMUX_LOG="$log" FM_FAKE_TMUX_CAPTURE="$TMP_ROOT/spawn-validate-fake/pane.txt" \
     "$ROOT/bin/fm-spawn.sh" domain "$ROOT" codex --secondmate >/dev/null 2>"$err"; then
     fail "secondmate spawn accepted the firstmate repo root"
   fi
   grep -F 'secondmate home cannot be the firstmate repo' "$err" >/dev/null || fail "spawn did not reject firstmate repo root"
-  grep -F 'new-window' "$log" >/dev/null && fail "spawn created a window before root validation"
 
-  : > "$log"
   printf 'domain\n' > "$active_descendant/.fm-secondmate-home"
   printf 'charter\n' > "$active_descendant/data/charter.md"
   if PATH="$fakebin:$PATH" FM_HOME="$home" FM_FAKE_TMUX_LOG="$log" FM_FAKE_TMUX_CAPTURE="$TMP_ROOT/spawn-validate-fake/pane.txt" \
@@ -1178,9 +1170,7 @@ SH
     fail "secondmate spawn accepted a home inside the active firstmate home"
   fi
   grep -F 'secondmate home cannot be inside the active firstmate home' "$err" >/dev/null || fail "spawn did not reject active home descendant"
-  grep -F 'new-window' "$log" >/dev/null && fail "spawn created a window before active descendant validation"
 
-  : > "$log"
   printf 'domain\n' > "$active_ancestor/.fm-secondmate-home"
   printf 'charter\n' > "$active_ancestor/data/charter.md"
   if PATH="$fakebin:$PATH" FM_HOME="$ancestor_active_home" FM_FAKE_TMUX_LOG="$log" FM_FAKE_TMUX_CAPTURE="$TMP_ROOT/spawn-validate-fake/pane.txt" \
@@ -1188,9 +1178,7 @@ SH
     fail "secondmate spawn accepted a home containing the active firstmate home"
   fi
   grep -F 'secondmate home cannot be an ancestor of the active firstmate home' "$err" >/dev/null || fail "spawn did not reject active home ancestor"
-  grep -F 'new-window' "$log" >/dev/null && fail "spawn created a window before active ancestor validation"
 
-  : > "$log"
   printf 'domain\n' > "$root_descendant/.fm-secondmate-home"
   printf 'charter\n' > "$root_descendant/data/charter.md"
   if PATH="$fakebin:$PATH" FM_ROOT_OVERRIDE="$fakeroot" FM_HOME="$home" FM_FAKE_TMUX_LOG="$log" FM_FAKE_TMUX_CAPTURE="$TMP_ROOT/spawn-validate-fake/pane.txt" \
@@ -1198,9 +1186,7 @@ SH
     fail "secondmate spawn accepted a home inside the firstmate repo"
   fi
   grep -F 'secondmate home cannot be inside the firstmate repo' "$err" >/dev/null || fail "spawn did not reject repo root descendant"
-  grep -F 'new-window' "$log" >/dev/null && fail "spawn created a window before repo descendant validation"
 
-  : > "$log"
   printf 'domain\n' > "$root_ancestor/.fm-secondmate-home"
   printf 'charter\n' > "$root_ancestor/data/charter.md"
   if PATH="$fakebin:$PATH" FM_ROOT_OVERRIDE="$root_inside" FM_HOME="$home" FM_FAKE_TMUX_LOG="$log" FM_FAKE_TMUX_CAPTURE="$TMP_ROOT/spawn-validate-fake/pane.txt" \
@@ -1208,7 +1194,6 @@ SH
     fail "secondmate spawn accepted a home containing the firstmate repo"
   fi
   grep -F 'secondmate home cannot be an ancestor of the firstmate repo' "$err" >/dev/null || fail "spawn did not reject repo ancestor"
-  grep -F 'new-window' "$log" >/dev/null && fail "spawn created a window before repo ancestor validation"
 
   pass "secondmate spawn validates homes before launch"
 }


### PR DESCRIPTION
## Intent

Trim tests/fm-secondmate.test.sh to remove over-defensive/redundant test cases without losing any distinct behavior coverage. The suite grew during a defensive review-hardening pass. After a thorough audit (including the production code structure and two independent reviews), I found the suite is overwhelmingly load-bearing: the three scripts fm-home-seed.sh, fm-spawn.sh, fm-teardown.sh each INDEPENDENTLY re-implement their own home path-escape/symlink/nested-home validation (no shared library), so testing the same scenario through seed AND spawn AND teardown is legitimate separate coverage, not redundancy. I deliberately kept ALL security guards intact (symlink-escape, path-escape, nested/overlapping-home rejection, and the --force teardown safety tests). The ONLY genuine over-defensive redundancy I removed is in test_secondmate_spawn_requires_seeded_matching_home: it re-proved 'no tmux window was created before validation' for all 10 rejection reasons, but all spawn validation runs inside validate_firstmate_home_for_spawn which returns before the caller reaches 'tmux new-window' (verified at fm-spawn.sh line 292 vs 321), so a per-reason ordering regression is structurally impossible. I consolidated those 9 repeats to one canonical ordering proof (kept on the first sub-case, with an explanatory comment so the repeats are not re-added) plus removed 9 now-dead ': > $log' resets, while keeping every per-reason rejection-message assertion. I intentionally did NOT trim the one-per-function ordering checks in the teardown tests because those are self-contained per-scenario coverage, not intra-function repetition, and they sit in the protected categories. Net change is 4 insertions, 19 deletions in one file; no production scripts changed; all 54 test cases still pass. This is a test-suite-only cleanup.

## What Changed
- Removed repeated `new-window` ordering assertions from secondmate spawn rejection sub-cases, captain, keeping one canonical pre-validation side-effect check.
- Added a short comment explaining why the remaining rejection cases assert only their specific refusal messages.
- Left the per-reason rejection-message coverage intact in `tests/fm-secondmate.test.sh`.

## Risk Assessment

✅ Low: Captain, risk is low because this is a narrow test-only cleanup that preserves the per-reason rejection assertions plus one fresh-log ordering check before launch.

## Testing

Exercised the changed secondmate shell behavior suite and a focused end-to-end spawn-validation CLI transcript; no baseline run was provided, no UI surface was involved, and all verification completed without findings.

<details>
<summary>Evidence: fm-secondmate behavior test transcript</summary>

```text
ok - FM_HOME parameterizes data and state paths
ok - fm-lock status is scoped per home
ok - secondmates registry records scopes and allows overlapping project clone lists
ok - home seeding records routing scope from filled charter briefs
ok - home seed validation rejects duplicate home routes
ok - home seed validation rejects duplicate id routes
ok - home seed validation rejects nested home routes
leased worktree for dash
ok - home seeding durably leases treehouse-acquired dash homes under the secondmate id
ok - home seeding returns rejected acquired homes through treehouse
ok - home seed rollback warns when treehouse-acquired return fails
ok - home seeding leaves unsafe acquired active homes untouched
ok - home seeding rolls back failed clone attempts without residue
ok - home seeding refuses direct seed without filled charter text
ok - home seeding refuses unfilled placeholder charters
ok - home seeding refuses empty normalized charter fields
ok - home seeding refuses local-only projects
ok - home seeding refuses registry delimiter home paths
ok - home seeding refuses active home and repo root
ok - home seeding refuses homes marked for another id
ok - home seeding refuses homes registered to another id
ok - home seeding refuses same-id reassignment to a different home
ok - home seeding refuses registered home overlaps
ok - remote-backed subhome seeding requires a source origin
ok - remote-backed subhome seeding validates existing destination origins
ok - home seeding resolves relative source origins against the source project
ok - home seeding skips initialized existing no-mistakes clones
ok - home seeding refuses uninitialized existing no-mistakes clones
ok - home seeding refuses project destinations outside the subhome
ok - home seeding refuses operational directories outside the subhome
ok - home seeding refuses symlinked leaf files
ok - kind=secondmate spawn launches in the home and records routing meta
ok - secondmate spawn validates homes before launch
ok - secondmate spawn refuses operational directories outside the subhome
ok - fm-send resolves bare firstmate windows through this home
ok - restart recovery can respawn a secondmate from durable registry and charter
ok - secondmate teardown retires empty homes and releases routing
ok - secondmate teardown refuses to hide failed leased-home return
ok - secondmate teardown raw-removes plain-clone homes
ok - secondmate force teardown discards child work
ok - force teardown allows operational directory symlinks inside the subhome
ok - force teardown refuses operational directory symlinks outside the subhome
ok - secondmate teardown requires seeded home marker
ok - secondmate teardown refuses homes containing registered nested homes
ok - secondmate teardown refuses nested homes from the child registry
ok - force teardown validates subhome before child cleanup
ok - force teardown refuses child worktrees inside the active home
ok - force teardown refuses child worktrees inside the firstmate repo
ok - force teardown refuses unregistered child worktree paths
ok - secondmate teardown refuses ancestor homes
ok - secondmate teardown refuses descendant homes
ok - idle kind=secondmate pane is healthy and not stale
ok - secondmate charter brief is idle by default and does not self-initiate work
ok - fm-backlog-handoff moves in-scope items, is idempotent, and aborts safely
ok - fm-backlog-handoff creates absent sections and refuses unsafe homes
```
</details>
<details>
<summary>Evidence: spawn validation CLI transcript</summary>

<code>Focused CLI transcript covers 10 spawn rejection cases and ends with `tmux new-window observed: no`.</code>

```text
case: unseeded home
exit: 1
stderr: error: firstmate home /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T//fm-spawn-validation.Cqb1SO/unseeded-subhome is not a seeded secondmate home

case: marker belongs to another secondmate
exit: 1
stderr: error: firstmate home /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T//fm-spawn-validation.Cqb1SO/wrong-marker-home is marked for secondmate other, expected domain

case: missing AGENTS.md
exit: 1
stderr: error: /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T//fm-spawn-validation.Cqb1SO/marker-only-home is not a firstmate home (missing AGENTS.md)

case: missing bin directory
exit: 1
stderr: error: /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T//fm-spawn-validation.Cqb1SO/marker-only-home is not a firstmate home (missing bin/)

case: active home rejected
exit: 1
stderr: error: secondmate home cannot be the active firstmate home: /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T//fm-spawn-validation.Cqb1SO/active-home

case: repo root rejected
exit: 1
stderr: error: secondmate home cannot be the firstmate repo: /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KVV2KCZHCT72JPJ4MDBS6M9X

case: inside active home rejected
exit: 1
stderr: error: secondmate home cannot be inside the active firstmate home: /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T//fm-spawn-validation.Cqb1SO/active-home/data/spawn-descendant-home

case: ancestor of active home rejected
exit: 1
stderr: error: secondmate home cannot be an ancestor of the active firstmate home: /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T//fm-spawn-validation.Cqb1SO/spawn-active-ancestor

case: inside firstmate repo rejected
exit: 1
stderr: error: secondmate home cannot be inside the firstmate repo: /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T//fm-spawn-validation.Cqb1SO/spawn-validate-root/tmp/spawn-descendant-home

case: ancestor of firstmate repo rejected
exit: 1
stderr: error: secondmate home cannot be an ancestor of the firstmate repo: /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T//fm-spawn-validation.Cqb1SO/spawn-root-ancestor

tmux new-window observed: no
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected the target diff with `git diff --find-renames 7651a3c08341e065d582881b2360d44f7f3abd41..1ea4359963876316e98fca0039e274803caedf97 -- tests/fm-secondmate.test.sh`.</code>
- <code>Verified the production ordering path with `rg -n &#34;validate_firstmate_home_for_spawn|new-window|secondmate home&#34; bin/fm-spawn.sh` and `sed -n &#39;250,340p&#39; bin/fm-spawn.sh`.</code>
- <code>Ran `tests/fm-secondmate.test.sh &gt; /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVV2KCZHCT72JPJ4MDBS6M9X/fm-secondmate-test-output.txt 2&gt;&amp;1`.</code>
- <code>Ran a focused inline `bash` CLI scenario that invoked `bin/fm-spawn.sh domain &lt;home&gt; codex --secondmate` against the seeded-home rejection cases and wrote `/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVV2KCZHCT72JPJ4MDBS6M9X/spawn-validation-cli-transcript.txt`.</code>
- <code>Checked cleanup with `git status --short`; the working tree remained clean.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
