### PR TITLE
docs: add operator-seat orchestration guide

### DIFF
--- a/docs/operator-seat.md
+++ b/docs/operator-seat.md
@@ -1,0 +1,104 @@
+# The Operator's Seat — Intent-Governed Orchestration
+
+*A firstmate pattern for directing an autonomous crew against high-stakes systems, from outside the codebase.*
+
+## Who this is for
+
+firstmate is usually described for engineers: a developer running a crew of coding agents in parallel.
+This doc is about a second seat — the **operator**.
+Someone accountable for outcomes (a P&L, a function, a business) who *also* builds the software that function runs on, and who directs the crew at the level of intent and judgment rather than the diff.
+
+firstmate's nautical naming earns its keep here, and it points at two duties worth keeping distinct.
+The operator is the **captain**, who sets the course; the crew does the work; firstmate carries the two duties in between.
+As the **mate**, it oversees the crew — dispatch, supervise, gate, tear down.
+As the **helmsman** — held to a committed intent — its one job is keeping every action on the course the captain set: never drifting off the heading, never changing course without an order.
+firstmate wears both hats today — but the operator seat forces them apart.
+The moment "off-course" is a *business* event and not a failed test, holding the heading stops being a side effect of crew management and becomes a component that has to exist on its own.
+In this stack it does: a dedicated enforcement layer — runway-guard — whose only job is to hold the crew to the heading and hard-stop on drift.
+And it didn't come from the metaphor; it came from a failure with a number on it: an eight-hour overnight build — fully planned, pre-vetted, the crew staged and ready — that stopped eight minutes in, leaving the helm idling the other seven hours and fifty-two on a single needless question.
+It was built as enforcement, for a functional reason, *before* anyone called it a helmsman — the metaphor mapped on afterward.
+That's the real test of the seam: not "did two people both reach for the word *helmsman*" — the shared frame could do that — but "would you build a separate course-holder having never heard the word."
+I did, from a burned runway; firstmate's own design, I'd argue, leans the same way — parallelism and isolation push toward a separate course-holder — two unrelated failure-pressures, zero coordination, and one of them named for the function rather than the figure.
+A separation you can rederive from first principles without the metaphor isn't a metaphor anymore; it's an architecture.
+The course the helmsman holds is **intent** — so the operator-seat problem reduces to: how do you give the helmsman a heading precise enough to hold, and a rule for when to call the captain?
+
+That seat is becoming common.
+As agents get capable enough to do the building, the binding constraint moves from "can we write it" to "can the person accountable for the result safely command it."
+firstmate's core already serves this well — the orchestrator conducts but never codes, escalates only judgment, keeps the human's final say.
+This doc adds the layer the operator seat specifically needs.
+
+## Why the operator seat changes the requirements
+
+Three things differ from the engineer-captain case:
+
+1. **The blast radius is the business, not the build.**
+   A crew working an operator's repos can touch real systems — finance, customers, compliance, production.
+   A bad turn isn't a failed test; it's a business event.
+   The cost of "the agent did something wrong" is categorically higher.
+
+2. **Control happens at intent, not implementation.**
+   The operator reasons in *why* and *is this in bounds* — not line-by-line review.
+   "Escalate only judgment" stops being a convenience and becomes the entire control surface.
+   If the operator can't trust the crew to stay inside the intent *without* watching the code, the seat doesn't work.
+
+3. **Scrutiny is asymmetric and unforgiving.**
+   A leaked secret, a sensitive number committed to the wrong place, an irreversible action against a system of record — these don't recover the way a bad commit does.
+   The operator needs *structural* guarantees, not careful intentions.
+
+The engineer-captain has the diff as a backstop.
+The operator needs something else.
+
+## The pattern: CAPTAINS-INTENT
+
+Give every repo a committed `CAPTAINS-INTENT.md` — the durable **why**, kept separate from the `AGENTS.md` **how**:
+
+- **A north star** — the one sentence the repo steers by.
+  The name is earnest, not decorative: it's the fixed point sailors actually steered by, the reference that holds the heading no matter the weather.
+- **The 5 Whys** — the north star drilled to the root.
+  Borrowed straight from Toyota's root-cause method: ask *why this exists*, then ask it of the answer, five layers down.
+  This is what keeps intent from being a one-line slogan you can't actually test against — the edges that make the tie-back test meaningful only appear once the reasoning is layered down to the root.
+  (Fitting, maybe, that a discipline from the factory floor turns out to govern the agent floor.)
+- **The heart** — what must stay true even when the code, tools, and structure all change.
+- **Boundaries** — in scope, out of scope, and what *always* escalates.
+- **A tie-back test** — the single question every change must answer: *does this serve the north star, inside the boundaries?*
+  A change that can't trace back isn't done; it's escalated.
+
+With the why committed, the orchestrator operates *against intent*, not just against tickets:
+
+- the committable intent **rides into every crewmate brief**, so the crew is intent-aware from its first turn;
+- anything **off-heading** — off-intent, irreversible, or beyond one repo's blast radius — is a wall: hold up and call the captain, never change course alone;
+- the operator reviews **intent and outcomes**, not implementation — the diff is the crew's concern, the *why* is the operator's.
+
+This is what turns "use good judgment" into something testable: the crew isn't trusted on discretion, it's held to a boundary.
+
+Straight talk on where this stands, since the operator seat is exactly where overselling gets you hurt: the wall on *blast radius and reversibility* is real today — it's what stops a crew before an irreversible or out-of-scope move.
+Gating a change against its repo's *committed* intent is the part I'm still wiring in.
+I trust the pattern because I've watched the gap bite — which is also why the security lessons below are this specific.
+
+## The scrutiny layer (where it gets real)
+
+For the operator seat, intent isn't only a steering tool — it's a security surface.
+Two lessons, learned the hard way, that the pattern should bake in:
+
+1. **Review weighs *visibility*, not just content.**
+   "Safe to commit to a private product repo" and "safe to commit to a public template" are different bars.
+   A review that judges sensitivity without knowing where the file lands will miss leaks that only matter because the destination is public.
+   Visibility is part of the review, not an afterthought.
+
+2. **Security-clear is not intent-correct.**
+   Confirming nothing sensitive leaked is a *different lens* from confirming the intent is actually right.
+   Conflate them and you ship wrong-but-clean content.
+   Both gate the commit; neither substitutes for the other.
+
+The strongest version separates authorship from delivery entirely.
+An independent authority — the operator's own knowledge base, a reviewer, a "second brain" — owns what is *allowed* to be committable, and firstmate owns only delivery: it never authors the sensitive strategy, and it cannot commit what hasn't been cleared.
+Sensitive material stays in the operator's sovereign store and simply never crosses into a repo.
+**Nothing handed over is nothing to leak** — a stronger guarantee than any wall around content that has already moved.
+
+## Why it matters
+
+The operator seat is, I'd argue, the path more people are about to arrive at: not engineers adopting agents, but people accountable for real outcomes who become technical enough to command them.
+That seat needs more than parallelism — it needs **governable autonomy**: a crew that moves fast *and* stays provably inside an intent the operator can defend.
+
+firstmate already gets the hard parts right — isolation, validate-before-you-fan-out, reliability as the whole game.
+CAPTAINS-INTENT is the smallest layer I've found that lets someone steer all of that who is accountable for more than the code: a captain who sets the heading, and a helmsman trusted to hold it.


### PR DESCRIPTION
Hi — I adopted firstmate a while back and it's become the backbone of how I run a fleet of repos.
This doc is a small bit back.

Where I'm coming from, since it's the angle: I'm a Navy veteran and the GM of a manufacturing company — I own a P&L, and I also build the software the business runs on (CS/Math undergrad, MBA).
So I use firstmate from a seat that isn't the usual one: not an engineer managing parallel projects, but an operator commanding agents against systems where a mistake is a *business* event, not a failed test.

`docs/operator-seat.md` writes that seat up.
It builds *on* your design, not over it — the core (orchestrator conducts not codes, escalate only judgment, isolation, reliability-as-the-whole-game) is yours, and I think you nailed it.
The doc adds (1) the operator lens and why it raises the scrutiny bar, and (2) the **CAPTAINS-INTENT** pattern: a committed `CAPTAINS-INTENT.md` per repo — north star, a Toyota-style 5 Whys, boundaries, a tie-back test — that turns "use good judgment" into something testable, plus two security lessons that seat taught me the hard way (review must weigh repo *visibility*; security-clear ≠ intent-correct).

Aside: you and I seem to have derived a lot of the same principles independently — I was sold enough by your execution to adopt yours rather than keep building my own.
Hopefully a useful addition from the operator end.
Happy to revise to fit the project's voice.

## What Changed

- Adds `docs/operator-seat.md` (+104 lines), a conceptual essay describing the "operator's seat" — intent-governed orchestration for someone accountable for business outcomes who also commands a crew of coding agents.
- Introduces the `CAPTAINS-INTENT.md` pattern (north star, Toyota-style 5 Whys, heart, boundaries, tie-back test) and the firstmate/helmsman duty split, with a runway-guard enforcement layer that hard-stops on drift.
- The doc is new and currently unlinked from README or any docs index; surfacing it is left as a maintainer decision.

## Risk Assessment

✅ Low: The change adds a single standalone documentation file with no code, scripts, or shared-machinery impact, and it explicitly distinguishes aspirational concepts from what is built today.

## Testing

There is no automated test surface for this documentation-only change, so I validated it the way a reviewer would: I audited the prose against every element of the author's intent (all present and consistent), confirmed the file is valid GitHub-flavored markdown by rendering it with pandoc (no warnings), and captured a full-page screenshot of the rendered document to show it displays correctly — title, all five sections, lists, inline code, and emphasis all render as intended. Worktree left clean.

- Evidence: Rendered operator-seat.md (full-page screenshot) (local file: <code>/var/folders/l8/htqy6t0j6hd9y084y1jqmqbr0000gn/T/no-mistakes-evidence/01KVV3MYX3XB14JQG30FCDP1KA/operator-seat-rendered.png</code>)
- Evidence: Rendered operator-seat.md (HTML) (local file: <code>/var/folders/l8/htqy6t0j6hd9y084y1jqmqbr0000gn/T/no-mistakes-evidence/01KVV3MYX3XB14JQG30FCDP1KA/operator-seat.html</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git show --stat HEAD` — confirmed the change is one new file, docs/operator-seat.md (+104 lines), no code</code>
- <code>`grep` keyword audit of docs/operator-seat.md — confirmed presence of CAPTAINS-INTENT, 5 Whys, helmsman, runway-guard, eight-hour/eight minutes origin, north star, tie-back test, blast radius, and the &#39;Straight talk&#39; built-vs-target section</code>
- <code>Verified markdown structure: title + 5 well-formed `##` sections, numbered/bulleted lists, inline code, bold/italic emphasis</code>
- <code>`pandoc docs/operator-seat.md -f gfm -s` — rendered to HTML with no warnings, confirming valid GFM</code>
- `Opened the rendered HTML in Chrome and captured a full-page screenshot to confirm the document displays cleanly end-to-end`
- <code>`git status --short` — worktree clean, no transient artifacts left behind</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `docs/operator-seat.md` - docs/operator-seat.md is added with no inbound link from README.md, CONTRIBUTING.md, or any docs index (none exists). It is not factually out of sync with the code, but it is currently undiscoverable. Whether to link it — and where — is a judgment call: README is a curated overview and this is a first-person conceptual essay, so surfacing it should be the maintainer&#39;s decision rather than an automatic edit.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

