### PR TITLE
fix: make composer detection ignore Claude ghost text

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,6 +160,13 @@ When you verify a new adapter, record its env marker and command name in that sc
 First launch in a fresh worktree (or first ever on a machine) may show a trust or bypass-permissions confirmation.
 After every spawn, peek the pane within ~20s; if such a dialog is showing, accept it with `bin/fm-send.sh <window> --key Enter` (or the choice the dialog requires) and verify the brief started processing.
 
+Ghost text (prompt suggestions): claude renders a predicted-next-prompt suggestion as dim/faint text inside an otherwise-empty composer after a turn completes.
+A plain `tmux capture-pane` cannot tell that ghost text apart from text a human typed, so left unhandled it makes firstmate misread an idle composer as holding pending input.
+Firstmate launches every claude crewmate and secondmate with `CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false` (a per-launch env prefix in `bin/fm-spawn.sh`, scoped to firstmate-launched agents - it never touches the captain's global config), which disables the interactive ghost text at the source.
+The CLI's `--prompt-suggestions` flag is print/SDK-mode only and does NOT suppress the interactive composer ghost text (verified empirically on v2.1.186), so the env var is the correct control.
+As defense in depth for any pane that flag cannot reach (such as the captain's own firstmate composer the away-mode daemon reads), the pane reader in `bin/fm-tmux-lib.sh` captures only the composer line with ANSI styling, drops dim/faint (SGR 2) runs, and ignores them, so only normal-intensity typed text counts as pending input.
+That styled capture is internal to the boolean detector only; `fm-peek` and every other human/LLM-facing capture path stay plain `tmux capture-pane` with no escape codes.
+
 ### codex (VERIFIED 2026-06-11, codex-cli 0.139.0)
 
 | Fact | Value |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -578,16 +578,16 @@ This is why fewer, cheaper firstmate turns handle the same fleet.
 - **Composer guard on the supervisor pane** - before injecting, the daemon checks both `pane_is_busy` (harness busy footer = agent mid-turn) and `pane_input_pending` (real unsubmitted text on the cursor line = human mid-typing or previous injection with swallowed Enter).
   Either condition **defers** the injection (buffer preserved for retry).
   This is the human-in-the-pane safety property: the daemon never merges its digest into the captain's half-typed line.
-  The composer detector (shared with `fm-send.sh` in `bin/fm-tmux-lib.sh`) **strips the harness's composer box borders first**, so an idle *bordered* composer (claude draws `│ > … │`) reads as empty, not pending.
-  Without this, every idle claude pane looked like pending input and the daemon deferred 100% of escalations (incident afk-invx-i5).
-  `FM_COMPOSER_IDLE_RE` still overrides empty-composer matching after border stripping, and `FM_BUSY_REGEX` overrides busy footers.
+  The composer detector (shared with `fm-send.sh` in `bin/fm-tmux-lib.sh`) drops dim/faint ghost text, then strips the harness's composer box borders, so a ghost-only or idle *bordered* composer (claude draws `│ > … │`) reads as empty, not pending.
+  Without these filters, idle bordered composers and dim ghost suggestions can look like pending input and stall supervision (incidents afk-invx-i5 and composer-robust).
+  `FM_COMPOSER_IDLE_RE` still overrides empty-composer matching after dim-ghost and border stripping, and `FM_BUSY_REGEX` overrides busy footers.
 - **Max-defer escape** - the daemon must never silently wedge.
   If anything stays buffered past `FM_MAX_DEFER_SECS` (default 300s), the daemon attempts one normal flush, which still requires an idle pane and empty composer.
   If that cannot confirm a submit, it raises a loud, rate-limited wedge alarm (ERROR log + durable `state/.subsuper-inject-wedged` marker + a status-line flash).
   A composer false-positive is then surfaced as a visible stall, never an unbounded silent no-op.
 - **Verified type-once submit model** - the digest is typed once via `send-keys -l`, then submitted with Enter and **verified**.
   Enter is retried, Enter only and never a retype, until the composer is confirmed empty.
-  That empty composer is the acknowledgement that the submit landed, using the same border-aware detector so a bordered-empty claude composer counts as submitted rather than a false "swallowed Enter".
+  That empty composer is the acknowledgement that the submit landed, using the same dim-ghost-aware and border-aware detector so a ghost-only or bordered-empty claude composer counts as submitted rather than a false "swallowed Enter".
   `fm-send.sh` shares this primitive and exits non-zero on a positively-confirmed swallow, so firstmate learns a steer did not land instead of leaving it unsubmitted.
 - **Marker strip** - `strip_injection_marker` removes the sentinel prefix before classification/relay, so the digest text firstmate sees is clean.
 - **Portable singleton lock** - the daemon uses the repo's mkdir-based lock helper (`fm-wake-lib.sh`) instead of `flock`, which is absent on macOS.

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ firstmate works from any terminal - outside tmux, crewmates land in a detached `
   Routine watcher polling, restarts, elapsed waiting time, and unchanged heartbeat reviews stay silent; an idle crew costs you nothing.
   A pull-based guard (`bin/fm-guard.sh`) warns through supervision tool output if tasks are in flight and that watcher stops running or queued wakes are waiting to be drained.
   A presence-gated sub-supervisor (`bin/fm-supervise-daemon.sh`) extends this for walk-away supervision: the `/afk` skill activates it, after which it self-handles routine wakes in bash and escalates only captain-relevant events as one batched, single-line digest (prefixed with an in-band sentinel marker so firstmate can tell daemon injections apart from real messages).
-  Its injection path shares `bin/fm-tmux-lib.sh` with `fm-send.sh`, so border-aware composer detection and verified submit retry stay consistent; stalled escalation delivery raises `state/.subsuper-inject-wedged` after `FM_MAX_DEFER_SECS` instead of silently deferring forever.
+  Its injection path shares `bin/fm-tmux-lib.sh` with `fm-send.sh`, so dim-ghost-aware and border-aware composer detection plus verified submit retry stay consistent; stalled escalation delivery raises `state/.subsuper-inject-wedged` after `FM_MAX_DEFER_SECS` instead of silently deferring forever.
 - **Worktrees, not branches in your checkout** - crewmates never touch your clone; treehouse pools clean worktrees so parallel tasks on one repo cannot collide.
 - **Two task shapes** - ship tasks change projects and ship by project mode (`no-mistakes`, `direct-PR`, or `local-only`); scout tasks investigate, plan, reproduce bugs, or audit, then leave a report at `data/<id>/report.md` and never push.
 - **Optional secondmates** - `data/secondmates.md` records persistent domain supervisors with natural-language scopes, project clone lists, and home paths.
@@ -162,7 +162,7 @@ The first mate drives these; you rarely need to, but they work by hand too.
 | `fm-supervise-daemon.sh` | Presence-gated sub-supervisor for walk-away (`/afk`) supervision: wraps `fm-watch.sh`, self-handles routine wakes in bash, and escalates only captain-relevant events as one verified, batched, single-line digest prefixed with a sentinel marker |
 | `fm-wake-drain.sh`       | Atomically drain queued watcher wakes before handling supervision work                                              |
 | `fm-send.sh`             | Send one verified literal line (or `--key Escape`) to a crewmate window; exits non-zero when Enter is positively swallowed |
-| `fm-tmux-lib.sh`         | Shared tmux pane primitives for busy detection, border-aware composer detection, and verified submit retry          |
+| `fm-tmux-lib.sh`         | Shared tmux pane primitives for busy detection, dim-ghost-aware and border-aware composer detection, and verified submit retry |
 | `fm-peek.sh`             | Print a bounded tail of a crewmate pane                                                                             |
 | `fm-pr-check.sh`         | Record a PR-ready task and arm the watcher's merge poll                                                             |
 | `fm-promote.sh`          | Promote a scout task in place so it becomes a protected ship task                                                   |
@@ -203,7 +203,7 @@ FM_SIGNAL_GRACE=30      # seconds to coalesce nearby status and turn-end signals
 FM_FLEET_SYNC_BOOTSTRAP_TIMEOUT=20   # seconds allowed for bootstrap's best-effort clone refresh
 FM_FLEET_PRUNE=1        # set to 0 to skip pruning local branches whose upstream is gone
 FM_BUSY_REGEX='esc (to )?interrupt|Working\.\.\.'   # busy-pane signatures, shared by watcher and tmux helper
-FM_COMPOSER_IDLE_RE=    # optional empty-composer regex, applied after border stripping
+FM_COMPOSER_IDLE_RE=    # optional empty-composer regex, applied after dim-ghost and border stripping
 FM_SEND_RETRIES=3       # fm-send Enter-retry attempts after typing the line once
 FM_SEND_SLEEP=0.4       # seconds between fm-send submit checks
 # sub-supervisor (bin/fm-supervise-daemon.sh); presence-gated via /afk
@@ -232,6 +232,7 @@ bash -n bin/*.sh                          # syntax-check the toolbelt
 shellcheck bin/*.sh tests/*.sh            # lint the toolbelt and behavior tests; CI enforces this
 for test_script in tests/*.test.sh; do "$test_script"; done   # behavior tests, matching CI
 tests/fm-wake-queue.test.sh               # durable wake queue, singleton behavior, sub-supervisor classifier, /afk presence-gating, border-aware composer, max-defer, and fm-send submit tests
+tests/fm-composer-ghost.test.sh           # dim-ghost stripping, ghost-only composer detection, and escape-free peek tests
 tests/fm-afk-inject-e2e.test.sh           # private-socket end-to-end test of the afk injection path (partial-input deferral, swallowed-Enter retry)
 tests/fm-bootstrap.test.sh                # bootstrap dependency and feature-probe tests
 tests/fm-secondmate.test.sh               # persistent secondmate routing, seeding, idle charter, backlog handoff, spawn, recovery, teardown, and FM_HOME tests

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -109,7 +109,16 @@ launch_template() {
   local harness=$1 kind=${2:-ship}
   # shellcheck disable=SC2016  # single quotes are deliberate: $(cat ...) expands in the crewmate pane, not here
   case "$harness" in
-    claude) printf '%s' 'claude --dangerously-skip-permissions "$(cat __BRIEF__)"' ;;
+    # CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false disables claude's interactive
+    # predicted-next-prompt ghost text, which renders as dim/faint text inside an
+    # otherwise-empty composer and would otherwise read like real typed input when
+    # firstmate captures the pane (see AGENTS.md section 4). It is a per-launch env
+    # prefix scoped to this firstmate-launched agent; it never touches the captain's
+    # global config. The CLI's --prompt-suggestions flag is print/SDK-mode only and
+    # does NOT suppress the interactive ghost text (verified empirically), so the env
+    # var is the correct control. The dim-aware composer reader in fm-tmux-lib.sh is
+    # the defense-in-depth backstop for any pane this flag cannot reach.
+    claude) printf '%s' 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions "$(cat __BRIEF__)"' ;;
     codex)
       if [ "$kind" = secondmate ]; then
         printf '%s' 'codex --dangerously-bypass-approvals-and-sandbox "$(cat __BRIEF__)"'

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -72,9 +72,9 @@
 #          FM_HOUSEKEEPING_TICK     seconds between housekeeping passes while
 #                                   the watcher is mid-cycle (default 15)
 #          FM_BUSY_REGEX            OR-ed busy signatures (mirrors fm-watch.sh)
-#          FM_COMPOSER_IDLE_RE      empty-composer regex applied after structural
-#                                   border stripping (default: bare prompt
-#                                   glyphs plus busy footers)
+#          FM_COMPOSER_IDLE_RE      empty-composer regex applied after dim-ghost
+#                                   and structural border stripping (default:
+#                                   bare prompt glyphs plus busy footers)
 #          FM_MAX_DEFER_SECS        max seconds a buffered escalation may sit
 #                                   undelivered before one normal flush attempt;
 #                                   if that cannot confirm a submit, a wedge
@@ -82,10 +82,11 @@
 #          FM_INJECT_CONFIRM_RETRIES Enter-retry attempts on a swallowed Enter
 #                                   (default 3); the digest is typed once, only
 #                                   Enter is retried. Composer-empty detection is
-#                                   structural (bin/fm-tmux-lib.sh): it strips the
+#                                   structural and style-aware (bin/fm-tmux-lib.sh):
+#                                   it drops dim/faint ghost text and strips the
 #                                   harness's box borders before deciding, so a
-#                                   bordered-but-empty composer is not misread as
-#                                   pending input.
+#                                   ghost-only or bordered-but-empty composer is
+#                                   not misread as pending input.
 #          FM_INJECT_CONFIRM_SLEEP  seconds between daemon submit checks
 #                                   (default 0.5)
 #          FM_LOG_MAX_BYTES / FM_LOG_KEEP_LINES / FM_CRASH_*  log + crash guards
@@ -404,10 +405,11 @@ mark_escalated_seen() {  # <kind> <arg> <state>
 # call sites and the unit tests stable.
 #
 # pane_input_pending returns 0 (pending) when the cursor line holds real
-# unsubmitted text — a human's half-typed line (the return race) or a previous
-# injection whose Enter was swallowed. The detector strips the harness's composer
-# box borders first, so an idle bordered claude composer ("│ > … │") is correctly
-# read as empty, not pending (incident afk-invx-i5).
+# unsubmitted text - a human's half-typed line (the return race) or a previous
+# injection whose Enter was swallowed. The detector drops dim/faint ghost text and
+# strips the harness's composer box borders, so a ghost-only or idle bordered
+# claude composer ("│ > … │") is correctly read as empty, not pending (incidents
+# afk-invx-i5 and composer-robust).
 pane_is_busy() { fm_pane_is_busy "$@"; }        # <window>
 pane_input_pending() { fm_pane_input_pending "$@"; }  # <target>
 
@@ -574,12 +576,14 @@ window_for_task() {  # <task-key>
 #   - TYPE ONCE, then submit with Enter. Never retype the digest: a swallowed
 #     Enter leaves our text in the composer, and retyping would concatenate two
 #     sentinel-prefixed digests into one corrupted turn.
-#   - SUBMIT ACK = the border-aware composer detector reports empty after Enter.
+#   - SUBMIT ACK = the dim-ghost-aware and border-aware composer detector reports
+#     empty after Enter.
 #     Empty means the text was consumed; pending means Enter was swallowed; unknown
 #     is treated as undelivered by this strict daemon path.
-#   - COMPOSER GUARD before typing: if the cursor line already has content (a
-#     human's half-typed line, or a previous injection's unsent text), defer
-#     entirely - injecting would merge with the human's text.
+#   - COMPOSER GUARD before typing: if the cursor line already has real content
+#     after dim/faint ghost text and borders are ignored (a human's half-typed
+#     line, or a previous injection's unsent text), defer entirely - injecting
+#     would merge with the human's text.
 inject_msg() {  # <message> [state]
   local msg=$1 state target retries sleep_s verdict
   state="${2:-$(_state_root)}"
@@ -597,8 +601,9 @@ inject_msg() {  # <message> [state]
   tmux display-message -p -t "$target" '#{pane_id}' >/dev/null 2>&1 || return 1
   # (3) Busy-guard: never inject into an in-use pane. Two checks:
   #   a) pane_is_busy: the harness shows a busy footer (agent mid-turn).
-  #   b) pane_input_pending: the cursor line has real unsubmitted text (a human's
-  #      half-typed line, or a previous injection whose Enter was swallowed).
+  #   b) pane_input_pending: the cursor line has real unsubmitted text after
+  #      dim/faint ghost text and borders are ignored (a human's half-typed line,
+  #      or a previous injection whose Enter was swallowed).
   if pane_is_busy "$target"; then
     log "inject deferred: supervisor pane busy (agent mid-turn)"
     return 1

--- a/bin/fm-tmux-lib.sh
+++ b/bin/fm-tmux-lib.sh
@@ -67,7 +67,12 @@ fm_tmux_strip_ghost() {
               k = split(params, a, ";")
               for (p = 1; p <= k; p++) {
                 v = a[p]; if (v == "") v = "0"
-                if (v == "2") dim = 1
+                if (v == "38" || v == "48") {
+                  mode = a[p + 1]
+                  if (mode == "5") p += 2
+                  else if (mode == "2") p += 4
+                  else if (mode != "") p += 1
+                } else if (v == "2") dim = 1
                 else if (v == "0" || v == "22") dim = 0
               }
             }

--- a/bin/fm-tmux-lib.sh
+++ b/bin/fm-tmux-lib.sh
@@ -28,8 +28,8 @@
 # is harness-generic: any harness that dims placeholder/ghost text benefits.
 #
 # Per-harness override: FM_COMPOSER_IDLE_RE matches an empty composer after
-# structural border stripping. FM_BUSY_REGEX overrides the busy footer set
-# (mirrors fm-watch.sh / the daemon).
+# dim-ghost and structural border stripping. FM_BUSY_REGEX overrides the busy
+# footer set (mirrors fm-watch.sh / the daemon).
 #
 # All functions are `set -u` and `set -e` safe (guarded tmux calls, explicit
 # returns) so they can be sourced into either context.

--- a/bin/fm-tmux-lib.sh
+++ b/bin/fm-tmux-lib.sh
@@ -15,6 +15,18 @@
 # corrected detector backs the submit acknowledgement (a submit "landed" iff the
 # composer is empty afterward), fixing the parallel false "Enter swallowed".
 #
+# Ghost text (incident composer-robust): claude renders a predicted-next-prompt
+# "suggestion" as dim/faint text inside an otherwise-empty composer. A plain
+# capture cannot tell it apart from text a human typed, so the old reader saw an
+# idle pane as holding pending input and the daemon deferred injection / firstmate
+# misjudged the pane. The composer reader now captures just the cursor line WITH
+# ANSI styling (tmux capture-pane -e), drops dim/faint (SGR 2) runs, and decides on
+# what is left, so ghost/placeholder text never counts as real input. The styled
+# capture is consumed internally and parsed into a boolean here; it is NEVER
+# surfaced (fm-peek and every human/LLM-facing path stay plain), and only the
+# single composer row is captured, so no escape-laden pane bulk is produced. This
+# is harness-generic: any harness that dims placeholder/ghost text benefits.
+#
 # Per-harness override: FM_COMPOSER_IDLE_RE matches an empty composer after
 # structural border stripping. FM_BUSY_REGEX overrides the busy footer set
 # (mirrors fm-watch.sh / the daemon).
@@ -26,23 +38,72 @@
 # interrupt"; opencode: "esc interrupt"; pi: "Working...".
 FM_TMUX_BUSY_REGEX_DEFAULT='esc (to )?interrupt|Working\.\.\.'
 
+# fm_tmux_strip_ghost: remove dim/faint (ANSI SGR 2) styled runs from one captured
+# composer line, then drop any remaining escape sequences, leaving only the plain,
+# normal-intensity text, the text a human actually typed. Dim/faint runs are
+# ghost/placeholder text (e.g. claude's predicted-next-prompt suggestion) that
+# fills an otherwise-empty composer and must never read as pending input. Reads the
+# styled line on stdin (from `tmux capture-pane -e`) and prints plain text on
+# stdout. LC_ALL=C makes awk walk bytes, so multibyte glyphs (e.g. ❯) and dim runs
+# alike pass through or drop intact without locale-dependent character classes.
+# A reset (SGR 0) or normal-intensity (SGR 22) ends a dim run; codes are processed
+# left to right within a sequence so "ESC[0;2m" (reset then dim) reads as dim.
+fm_tmux_strip_ghost() {
+  LC_ALL=C awk '
+    {
+      line = $0; out = ""; dim = 0; n = length(line); i = 1
+      while (i <= n) {
+        c = substr(line, i, 1)
+        if (c == "\033") {            # ESC: consume a CSI ... final-byte sequence
+          j = i + 1
+          if (substr(line, j, 1) == "[") {
+            j++; params = ""
+            while (j <= n) {
+              cc = substr(line, j, 1)
+              if (cc ~ /[0-9;]/) { params = params cc; j++ } else break
+            }
+            if (substr(line, j, 1) == "m") {   # SGR: update dim/faint state
+              if (params == "") params = "0"
+              k = split(params, a, ";")
+              for (p = 1; p <= k; p++) {
+                v = a[p]; if (v == "") v = "0"
+                if (v == "2") dim = 1
+                else if (v == "0" || v == "22") dim = 0
+              }
+            }
+            i = j + 1; continue
+          }
+          i = i + 1; continue          # lone/other ESC: drop the ESC byte only
+        }
+        if (dim == 0) out = out c        # keep only normal-intensity bytes
+        i++
+      }
+      print out
+    }
+  '
+}
+
 # fm_tmux_composer_state: classify the cursor/composer line of <target> as
-#   empty   — no pending input (blank, a bare prompt, or a busy footer). Safe to
-#             inject; also the positive acknowledgement that a submit landed.
-#   pending — real, unsubmitted text on the cursor line (a human mid-typing, or a
+#   empty   - no pending input (blank, a bare prompt, a busy footer, or only dim
+#             ghost/placeholder text). Safe to inject; also the positive
+#             acknowledgement that a submit landed.
+#   pending - real, unsubmitted text on the cursor line (a human mid-typing, or a
 #             previous injection whose Enter was swallowed). Defer / retry.
-#   unknown — the pane could not be read (tmux error). The caller decides.
+#   unknown - the pane could not be read (tmux error). The caller decides.
 #
-# The detector strips the harness's box-drawing composer borders ("│ … │", heavy
-# "┃", or a plain ASCII "|") from the cursor line FIRST, using literal-string
+# The cursor line is captured WITH ANSI styling (capture-pane -e) and bounded to
+# the single composer row (-S/-E), then run through fm_tmux_strip_ghost so dim/faint
+# ghost text drops out before classification. The styled capture is internal only,
+# never surfaced. The detector then strips the harness's box-drawing composer
+# borders ("│ … │", heavy "┃", or a plain ASCII "|") using literal-string
 # substitution (bash 3.2 safe, locale-independent — no \u escapes, no multibyte
-# character classes), then asks whether anything real is left.
+# character classes), and asks whether anything real is left.
 fm_tmux_composer_state() {  # <target> -> empty|pending|unknown
-  local target=$1 cy pane_out line stripped
+  local target=$1 cy raw line stripped
   cy=$(tmux display-message -p -t "$target" '#{cursor_y}' 2>/dev/null) || { printf 'unknown'; return 0; }
   case "$cy" in ''|*[!0-9]*) printf 'unknown'; return 0 ;; esac
-  pane_out=$(tmux capture-pane -p -t "$target" 2>/dev/null) || { printf 'unknown'; return 0; }
-  line=$(printf '%s\n' "$pane_out" | sed -n "$((cy + 1))p")
+  raw=$(tmux capture-pane -e -p -t "$target" -S "$cy" -E "$cy" 2>/dev/null) || { printf 'unknown'; return 0; }
+  line=$(printf '%s\n' "$raw" | fm_tmux_strip_ghost)
   # Strip the composer box borders (literal glyphs — no character classes).
   stripped=${line//│/}      # U+2502 light vertical (claude)
   stripped=${stripped//┃/}  # U+2503 heavy vertical

--- a/bin/fm-tmux-lib.sh
+++ b/bin/fm-tmux-lib.sh
@@ -50,6 +50,22 @@ FM_TMUX_BUSY_REGEX_DEFAULT='esc (to )?interrupt|Working\.\.\.'
 # left to right within a sequence so "ESC[0;2m" (reset then dim) reads as dim.
 fm_tmux_strip_ghost() {
   LC_ALL=C awk '
+    function sgr_code(v, b) {
+      b = v
+      sub(/:.*/, "", b)
+      if (b == "") b = "0"
+      return b
+    }
+    function skip_color_payload(a, p, k, mode, code) {
+      if (index(a[p], ":") > 0) return p
+      if (p >= k) return p
+      mode = a[p + 1]
+      code = sgr_code(mode)
+      if (index(mode, ":") > 0) return p + 1
+      if (code == "5") return p + 2
+      if (code == "2") return p + 4
+      return p + 1
+    }
     {
       line = $0; out = ""; dim = 0; n = length(line); i = 1
       while (i <= n) {
@@ -60,23 +76,21 @@ fm_tmux_strip_ghost() {
             j++; params = ""
             while (j <= n) {
               cc = substr(line, j, 1)
-              if (cc ~ /[0-9;]/) { params = params cc; j++ } else break
+              if (cc ~ /[@-~]/) break
+              params = params cc; j++
             }
-            if (substr(line, j, 1) == "m") {   # SGR: update dim/faint state
+            if (j <= n && substr(line, j, 1) == "m") {   # SGR: update dim/faint state
               if (params == "") params = "0"
               k = split(params, a, ";")
               for (p = 1; p <= k; p++) {
-                v = a[p]; if (v == "") v = "0"
-                if (v == "38" || v == "48") {
-                  mode = a[p + 1]
-                  if (mode == "5") p += 2
-                  else if (mode == "2") p += 4
-                  else if (mode != "") p += 1
-                } else if (v == "2") dim = 1
-                else if (v == "0" || v == "22") dim = 0
+                v = a[p]; code = sgr_code(v)
+                if (code == "38" || code == "48" || code == "58") {
+                  p = skip_color_payload(a, p, k)
+                } else if (code == "2") dim = 1
+                else if (code == "0" || code == "22") dim = 0
               }
             }
-            i = j + 1; continue
+            if (j <= n) { i = j + 1; continue }
           }
           i = i + 1; continue          # lone/other ESC: drop the ESC byte only
         }

--- a/tests/fm-composer-ghost.test.sh
+++ b/tests/fm-composer-ghost.test.sh
@@ -101,6 +101,14 @@ test_strip_ghost_keeps_colored_text_with_2_payloads() {
   [ "$out" = "truecolor typed" ] || fail "truecolor payload 2 was treated as dim: '$out'"
   out=$(printf '\033[48;2;4;5;6mbackground typed\033[0m\n' | fm_tmux_strip_ghost)
   [ "$out" = "background typed" ] || fail "background truecolor payload was treated as dim: '$out'"
+  out=$(printf '\033[58;5;2munderline-color typed\033[0m\n' | fm_tmux_strip_ghost)
+  [ "$out" = "underline-color typed" ] || fail "underline color payload 2 was treated as dim: '$out'"
+  out=$(printf '\033[38:2::1:2:3mcolon truecolor typed\033[0m\n' | fm_tmux_strip_ghost)
+  [ "$out" = "colon truecolor typed" ] || fail "colon truecolor payload 2 was treated as dim: '$out'"
+  out=$(printf '\033[58::5::2mcolon underline typed\033[0m\n' | fm_tmux_strip_ghost)
+  [ "$out" = "colon underline typed" ] || fail "colon underline SGR leaked or dimmed text: '$out'"
+  out=$(printf '\033[4:2mnot dim underline\033[0m\n' | fm_tmux_strip_ghost)
+  [ "$out" = "not dim underline" ] || fail "colon subparameter 2 was treated as dim: '$out'"
   pass "fm_tmux_strip_ghost keeps colored text with 2 payloads"
 }
 
@@ -160,6 +168,14 @@ test_colored_text_with_2_payload_still_pending() {
   PATH="$fb:$PATH" FM_FAKE_STYLED="$capture" FM_FAKE_CY=0 \
     fm_pane_input_pending "fakepane" \
     || fail "truecolor typed text was not detected as pending"
+  printf '\xe2\x9d\xaf \033[58;5;2munderline-color typed\033[0m\n' > "$capture"
+  PATH="$fb:$PATH" FM_FAKE_STYLED="$capture" FM_FAKE_CY=0 \
+    fm_pane_input_pending "fakepane" \
+    || fail "underline-colored typed text was not detected as pending"
+  printf '\xe2\x9d\xaf \033[58::5::2mcolon underline typed\033[0m\n' > "$capture"
+  PATH="$fb:$PATH" FM_FAKE_STYLED="$capture" FM_FAKE_CY=0 \
+    fm_pane_input_pending "fakepane" \
+    || fail "colon underline typed text was not detected as pending"
   pass "fm_pane_input_pending: colored text with 2 payloads is still pending"
 }
 

--- a/tests/fm-composer-ghost.test.sh
+++ b/tests/fm-composer-ghost.test.sh
@@ -93,6 +93,17 @@ test_strip_ghost_handles_combined_and_boundary_codes() {
   pass "fm_tmux_strip_ghost handles combined SGR, ESC[22m, and reset-then-dim"
 }
 
+test_strip_ghost_keeps_colored_text_with_2_payloads() {
+  local out
+  out=$(printf '\033[38;5;2mgreen typed\033[0m\n' | fm_tmux_strip_ghost)
+  [ "$out" = "green typed" ] || fail "8-bit color payload 2 was treated as dim: '$out'"
+  out=$(printf '\033[38;2;1;2;3mtruecolor typed\033[0m\n' | fm_tmux_strip_ghost)
+  [ "$out" = "truecolor typed" ] || fail "truecolor payload 2 was treated as dim: '$out'"
+  out=$(printf '\033[48;2;4;5;6mbackground typed\033[0m\n' | fm_tmux_strip_ghost)
+  [ "$out" = "background typed" ] || fail "background truecolor payload was treated as dim: '$out'"
+  pass "fm_tmux_strip_ghost keeps colored text with 2 payloads"
+}
+
 # --- fm_pane_input_pending: dim ghost is not pending ------------------------
 
 test_dim_ghost_only_composer_is_not_pending() {
@@ -134,6 +145,22 @@ test_normal_text_still_pending() {
     fm_pane_input_pending "fakepane" \
     || fail "real typed text was not detected as pending"
   pass "fm_pane_input_pending: normal-intensity typed text is still pending"
+}
+
+test_colored_text_with_2_payload_still_pending() {
+  local dir fb capture
+  dir="$TMP_ROOT/colored-text"; mkdir -p "$dir"
+  fb=$(make_fake_tmux "$dir")
+  capture="$dir/styled.txt"
+  printf '\xe2\x9d\xaf \033[38;5;2mgreen typed\033[0m\n' > "$capture"
+  PATH="$fb:$PATH" FM_FAKE_STYLED="$capture" FM_FAKE_CY=0 \
+    fm_pane_input_pending "fakepane" \
+    || fail "8-bit colored typed text was not detected as pending"
+  printf '\xe2\x9d\xaf \033[38;2;1;2;3mtruecolor typed\033[0m\n' > "$capture"
+  PATH="$fb:$PATH" FM_FAKE_STYLED="$capture" FM_FAKE_CY=0 \
+    fm_pane_input_pending "fakepane" \
+    || fail "truecolor typed text was not detected as pending"
+  pass "fm_pane_input_pending: colored text with 2 payloads is still pending"
 }
 
 test_real_text_with_trailing_ghost_is_pending() {
@@ -178,8 +205,10 @@ test_peek_output_is_escape_free() {
 
 test_strip_ghost_drops_dim_keeps_normal
 test_strip_ghost_handles_combined_and_boundary_codes
+test_strip_ghost_keeps_colored_text_with_2_payloads
 test_dim_ghost_only_composer_is_not_pending
 test_dim_ghost_inside_bordered_composer_is_not_pending
 test_normal_text_still_pending
+test_colored_text_with_2_payload_still_pending
 test_real_text_with_trailing_ghost_is_pending
 test_peek_output_is_escape_free

--- a/tests/fm-composer-ghost.test.sh
+++ b/tests/fm-composer-ghost.test.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# Ghost-text robustness (incident composer-robust).
+#
+# claude renders a predicted-next-prompt "suggestion" as DIM/FAINT (ANSI SGR 2)
+# text inside an otherwise-empty composer. A plain pane capture cannot tell that
+# ghost text apart from text a human typed, which made the composer reader see an
+# idle pane as holding pending input. These tests pin two guarantees:
+#   1. fm_tmux_strip_ghost drops dim/faint runs and keeps normal-intensity text.
+#   2. fm_pane_input_pending reads a dim-ghost-only composer as NOT pending, while
+#      still treating real (normal-intensity) text as pending.
+#   3. The human/LLM-facing capture path (fm-peek.sh) stays PLAIN - no escape codes
+#      ever reach firstmate's context.
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LIB="$ROOT/bin/fm-tmux-lib.sh"
+PEEK="$ROOT/bin/fm-peek.sh"
+
+# shellcheck source=bin/fm-tmux-lib.sh
+. "$LIB"
+
+TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/fm-ghost-tests.XXXXXX")
+cleanup() { [ -n "${TMP_ROOT:-}" ] && rm -rf "$TMP_ROOT"; }
+trap cleanup EXIT
+
+fail() { printf 'not ok - %s\n' "$1" >&2; exit 1; }
+pass() { printf 'ok - %s\n' "$1"; }
+
+# ESC byte for building styled fixtures and asserting escape-free output.
+ESC=$(printf '\033')
+
+# A fake tmux that serves a styled composer line for the dim-aware reader and an
+# escape-free line for the plain (peek) path. capture-pane returns the styled
+# fixture verbatim WITH -e (mirrors `tmux capture-pane -e`), and the same content
+# with SGR sequences stripped WITHOUT -e (mirrors a plain capture). cursor_y comes
+# from FM_FAKE_CY.
+make_fake_tmux() {  # <dir>
+  local dir=$1 fb="$1/fakebin"
+  mkdir -p "$fb"
+  cat > "$fb/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "${1:-}" in
+  display-message)
+    for a in "$@"; do case "$a" in *cursor_y*) printf '%s\n' "${FM_FAKE_CY:-0}"; exit 0 ;; esac; done
+    printf 'fakepane\n'; exit 0 ;;
+  capture-pane)
+    has_e=0
+    for a in "$@"; do [ "$a" = "-e" ] && has_e=1; done
+    f="${FM_FAKE_STYLED:-/dev/null}"
+    if [ "$has_e" = 1 ]; then
+      cat "$f" 2>/dev/null
+    else
+      # Plain capture: drop SGR sequences, as real `tmux capture-pane -p` does.
+      LC_ALL=C awk '{gsub(/\033\[[0-9;]*m/, ""); print}' "$f" 2>/dev/null
+    fi
+    exit 0 ;;
+  list-windows) exit 0 ;;
+esac
+exit 1
+SH
+  chmod +x "$fb/tmux"
+  printf '%s\n' "$fb"
+}
+
+# --- fm_tmux_strip_ghost (pure) ---------------------------------------------
+
+test_strip_ghost_drops_dim_keeps_normal() {
+  local out
+  # Dim run between ESC[2m and ESC[0m is dropped; the prompt glyph survives.
+  out=$(printf '\xe2\x9d\xaf \033[2mWhat is the largest country by area?\033[0m\n' | fm_tmux_strip_ghost)
+  [ "$out" = "$(printf '\xe2\x9d\xaf ')" ] || fail "dim run not dropped: '$out'"
+  # Normal-intensity text is kept verbatim (no styling at all).
+  out=$(printf '\xe2\x9d\xaf real human text\n' | fm_tmux_strip_ghost)
+  [ "$out" = "$(printf '\xe2\x9d\xaf real human text')" ] || fail "normal text changed: '$out'"
+  # Bold (SGR 1) is normal-intensity, NOT dim - must be kept.
+  out=$(printf '\033[1mbold typed\033[0m\n' | fm_tmux_strip_ghost)
+  [ "$out" = "bold typed" ] || fail "bold text wrongly dropped: '$out'"
+  pass "fm_tmux_strip_ghost drops dim/faint runs, keeps normal and bold text"
+}
+
+test_strip_ghost_handles_combined_and_boundary_codes() {
+  local out
+  # Dim combined with a color in one sequence (ESC[2;37m) is still a dim run.
+  out=$(printf '\xe2\x9d\xaf \033[2;37mpredicted\033[0m\n' | fm_tmux_strip_ghost)
+  [ "$out" = "$(printf '\xe2\x9d\xaf ')" ] || fail "combined dim+color not dropped: '$out'"
+  # ESC[22m (normal intensity) ends a dim run mid-line; the tail is kept.
+  out=$(printf '\033[2mghost\033[22mREALTAIL\n' | fm_tmux_strip_ghost)
+  [ "$out" = "REALTAIL" ] || fail "ESC[22m did not end the dim run: '$out'"
+  # ESC[0;2m (reset then dim) reads as dim (left-to-right within the sequence).
+  out=$(printf 'keep\033[0;2mdrop\033[0m\n' | fm_tmux_strip_ghost)
+  [ "$out" = "keep" ] || fail "reset-then-dim not treated as dim: '$out'"
+  pass "fm_tmux_strip_ghost handles combined SGR, ESC[22m, and reset-then-dim"
+}
+
+# --- fm_pane_input_pending: dim ghost is not pending ------------------------
+
+test_dim_ghost_only_composer_is_not_pending() {
+  local dir fb capture
+  dir="$TMP_ROOT/ghost-only"; mkdir -p "$dir"
+  fb=$(make_fake_tmux "$dir")
+  capture="$dir/styled.txt"
+  # The exact rendering claude emits: a normal prompt glyph + a DIM predicted prompt.
+  printf '\xe2\x9d\xaf \033[2mWhat is the largest country by area?\033[0m\n' > "$capture"
+  if PATH="$fb:$PATH" FM_FAKE_STYLED="$capture" FM_FAKE_CY=0 \
+     fm_pane_input_pending "fakepane"; then
+    fail "dim ghost-only composer falsely read as pending"
+  fi
+  pass "fm_pane_input_pending: a dim ghost-only composer is NOT pending"
+}
+
+test_dim_ghost_inside_bordered_composer_is_not_pending() {
+  local dir fb capture
+  dir="$TMP_ROOT/ghost-bordered"; mkdir -p "$dir"
+  fb=$(make_fake_tmux "$dir")
+  capture="$dir/styled.txt"
+  # Bordered composer (claude box) holding only dim ghost text.
+  printf '\xe2\x94\x82 \033[2mtry the other approach instead\033[0m \xe2\x94\x82\n' > "$capture"
+  if PATH="$fb:$PATH" FM_FAKE_STYLED="$capture" FM_FAKE_CY=0 \
+     fm_pane_input_pending "fakepane"; then
+    fail "dim ghost in a bordered composer falsely read as pending"
+  fi
+  pass "fm_pane_input_pending: dim ghost inside a bordered composer is NOT pending"
+}
+
+test_normal_text_still_pending() {
+  local dir fb capture
+  dir="$TMP_ROOT/real-text"; mkdir -p "$dir"
+  fb=$(make_fake_tmux "$dir")
+  capture="$dir/styled.txt"
+  # Real human text, normal intensity - must still read as pending.
+  printf '\xe2\x9d\xaf fix findings 1 and 3, skip 2\n' > "$capture"
+  PATH="$fb:$PATH" FM_FAKE_STYLED="$capture" FM_FAKE_CY=0 \
+    fm_pane_input_pending "fakepane" \
+    || fail "real typed text was not detected as pending"
+  pass "fm_pane_input_pending: normal-intensity typed text is still pending"
+}
+
+test_real_text_with_trailing_ghost_is_pending() {
+  local dir fb capture
+  dir="$TMP_ROOT/mixed"; mkdir -p "$dir"
+  fb=$(make_fake_tmux "$dir")
+  capture="$dir/styled.txt"
+  # A human typed "deploy" and claude appended a dim ghost completion. The real
+  # text must win - the composer is pending.
+  printf '\xe2\x9d\xaf deploy\033[2m the staging environment now\033[0m\n' > "$capture"
+  PATH="$fb:$PATH" FM_FAKE_STYLED="$capture" FM_FAKE_CY=0 \
+    fm_pane_input_pending "fakepane" \
+    || fail "real text with a trailing ghost completion was not detected as pending"
+  pass "fm_pane_input_pending: real text plus a trailing ghost run is still pending"
+}
+
+# --- fm-peek.sh stays escape-free (LLM-facing path) -------------------------
+
+test_peek_output_is_escape_free() {
+  local dir fb capture home out
+  dir="$TMP_ROOT/peek"; mkdir -p "$dir"
+  fb=$(make_fake_tmux "$dir")
+  capture="$dir/styled.txt"
+  # A pane full of styling, including dim ghost text. The plain peek path must
+  # surface NONE of these escape codes into firstmate's context.
+  printf 'normal output line\n\xe2\x9d\xaf \033[2mpredicted next prompt\033[0m\n' > "$capture"
+  # Empty FM_HOME so fm-guard.sh finds no in-flight task and stays silent.
+  home="$dir/home"; mkdir -p "$home/state"
+  # Pass an explicit session:window so resolution needs no metadata.
+  out=$(PATH="$fb:$PATH" FM_HOME="$home" FM_FAKE_STYLED="$capture" \
+        "$PEEK" "sess:win" 2>/dev/null)
+  case "$out" in
+    *"$ESC"*) fail "fm-peek surfaced ANSI escape codes into LLM-facing output" ;;
+  esac
+  # And it should still carry the real content.
+  case "$out" in
+    *"predicted next prompt"*) : ;;
+    *) fail "fm-peek dropped pane content (expected the ghost text body as plain text)" ;;
+  esac
+  pass "fm-peek output is escape-free (no raw -e bytes reach firstmate context)"
+}
+
+test_strip_ghost_drops_dim_keeps_normal
+test_strip_ghost_handles_combined_and_boundary_codes
+test_dim_ghost_only_composer_is_not_pending
+test_dim_ghost_inside_bordered_composer_is_not_pending
+test_normal_text_still_pending
+test_real_text_with_trailing_ghost_is_pending
+test_peek_output_is_escape_free

--- a/tests/fm-wake-queue.test.sh
+++ b/tests/fm-wake-queue.test.sh
@@ -88,7 +88,27 @@ case "${1:-}" in
     [ -n "${FM_FAKE_TMUX_WINDOW:-}" ] && printf '%s\n' "$FM_FAKE_TMUX_WINDOW"
     exit 0 ;;
   capture-pane)
-    [ -n "${FM_FAKE_TMUX_CAPTURE:-}" ] && cat "$FM_FAKE_TMUX_CAPTURE" 2>/dev/null
+    # Honor a single-line band capture (-S N -E M, both non-negative) the way the
+    # composer reader now bounds its capture to the cursor row; otherwise (e.g.
+    # fm_pane_is_busy's "-S -40" tail) return the whole capture. -e is accepted and
+    # ignored: this fake emits plain text, which the dim-stripper passes through.
+    _S=""; _E=""; shift
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        -S) _S="${2:-}"; shift 2; continue ;;
+        -E) _E="${2:-}"; shift 2; continue ;;
+        *) shift ;;
+      esac
+    done
+    [ -n "${FM_FAKE_TMUX_CAPTURE:-}" ] || exit 0
+    if [ -n "$_S" ] && [ -n "$_E" ]; then
+      case "$_S$_E" in
+        *[!0-9]*) cat "$FM_FAKE_TMUX_CAPTURE" 2>/dev/null ;;
+        *) sed -n "$((_S + 1)),$((_E + 1))p" "$FM_FAKE_TMUX_CAPTURE" 2>/dev/null ;;
+      esac
+    else
+      cat "$FM_FAKE_TMUX_CAPTURE" 2>/dev/null
+    fi
     exit 0 ;;
   send-keys)
     while [ "$#" -gt 0 ]; do


### PR DESCRIPTION
## Intent

Make firstmate's crewmate/secondmate launches and pane-reading robust to Claude Code's autocomplete 'ghost text'. claude renders a predicted-next-prompt suggestion as dim/faint (ANSI SGR 2) text inside an otherwise-empty composer; a plain tmux capture cannot tell it apart from human-typed text, so firstmate misread an idle composer as holding pending input and could fire phantom Enter keys / misjudge crewmate state.

Two prongs, both intentional:

1. Disable at the source. The claude launch template in bin/fm-spawn.sh now prefixes CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false, covering every firstmate-launched claude crewmate AND secondmate (both use launch_template('claude',...)). Deliberate decision: I empirically verified on Claude Code v2.1.186 that the documented --prompt-suggestions CLI flag does NOT suppress the INTERACTIVE composer ghost text (it is print/SDK-mode only - it still rendered a dim prediction with the flag set), whereas the env var CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false reliably suppresses it (verified clean across many turns). So I intentionally used the env var instead of the CLI flag the task text suggested. It is a per-launch env prefix scoped to firstmate-launched agents only and never touches the captain's global config (constraint).

2. Make pane-reading ghost-text-aware (defense in depth, any harness). bin/fm-tmux-lib.sh gains fm_tmux_strip_ghost: it captures only the composer cursor line WITH ANSI styling (tmux capture-pane -e, bounded to a single row via -S/-E), drops dim/faint (SGR 2) runs, then strips remaining escapes, leaving only normal-intensity text. fm_tmux_composer_state now runs the captured line through it before the existing border/glyph/whitespace classification, so a composer holding only dim ghost text reads as empty/not-pending while normal-intensity typed text (incl. bold) still reads as pending. Deliberate token-safety design (captain constraint): capture-pane -e is INTERNAL to this boolean detector only and bounded to one line; raw escape bytes are never surfaced or logged; fm-peek and every other human/LLM-facing capture path stay plain capture-pane.

3. Docs: AGENTS.md section 4 (claude adapter) documents both the launch env var and the dim-aware reader, each sentence on its own line.

Tests: new tests/fm-composer-ghost.test.sh (dim-stripper unit cases incl. combined SGR / ESC[22m boundary / reset-then-dim; dim-ghost-only composer not-pending incl. bordered; normal text still pending; real-text-plus-trailing-ghost still pending; an escape-free fm-peek assertion). tests/fm-wake-queue.test.sh's fake tmux was updated to honor the new single-line band capture (-S N -E M) so existing composer tests still index by cursor_y. All tests pass and shellcheck is clean. Also verified end-to-end against real tmux + a live claude: the dim-aware reader returns empty/not-pending on a genuine ghost composer and pending on real typed text.

No em dashes per the captain's style preference.

## What Changed

- Disable Claude Code interactive prompt suggestions for firstmate-launched Claude crewmates and secondmates via a per-launch environment prefix.
- Make composer pending-input detection strip dim/faint SGR ghost text while preserving normal styled typed input, including color payload edge cases.
- Document the Claude ghost-text behavior and add focused shell tests plus fake-tmux coverage for styled single-line composer captures.

## Risk Assessment

✅ Low: Captain, the change is narrow, the earlier SGR parsing regressions are addressed, and I did not find material correctness or safety issues in the diff or shared call paths.

## Testing

Captain, I ran the bootstrap check, targeted ghost/composer/spawn/supervisor/secondmate tests, then captured real tmux pane evidence and claude launch-command evidence; everything passed, the worktree stayed clean, and no transient worktree artifacts were left behind.

<details>
<summary>Evidence: Real tmux ghost composer evidence</summary>

```text
case: dim ghost-only prompt
expected: empty, not pending
state: empty
pending: no
styled cursor line (escaped for review): ❯ \033[2mWhat is the largest country by area?\033[0m$
plain cursor line (escaped for review): ❯ What is the largest country by area?$

case: normal typed prompt
expected: pending
state: pending
pending: yes
styled cursor line (escaped for review): ❯ fix findings 1 and 3, skip 2$
plain cursor line (escaped for review): ❯ fix findings 1 and 3, skip 2$

case: bordered dim ghost composer
expected: empty, not pending
state: empty
pending: no
styled cursor line (escaped for review): │ \033[2mtry the other approach instead\033[0m │$
plain cursor line (escaped for review): │ try the other approach instead │$

case: real typed text with trailing ghost
expected: pending
state: pending
pending: yes
styled cursor line (escaped for review): ❯ deploy\033[2m staging environment now\033[0m$
plain cursor line (escaped for review): ❯ deploy staging environment now$
```
</details>
<details>
<summary>Evidence: Claude launch template evidence</summary>

```text
ship spawn exit: 0
ship launch contains CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false: yes
ship launch line: tmux send-keys -t firstmate:fm-ship-ghost -l CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions "$(cat '/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVV6D6TQMQRYEZ22PXW2YVHZ/claude-launch-template/main-home/data/ship-ghost/brief.md')"

secondmate spawn exit: 0
secondmate launch contains CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false: yes
secondmate launch line: tmux send-keys -t firstmate:fm-second-ghost -l FM_ROOT_OVERRIDE= FM_STATE_OVERRIDE= FM_DATA_OVERRIDE= FM_PROJECTS_OVERRIDE= FM_CONFIG_OVERRIDE= FM_HOME='/private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVV6D6TQMQRYEZ22PXW2YVHZ/claude-launch-template/second-home' CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions "$(cat '/private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVV6D6TQMQRYEZ22PXW2YVHZ/claude-launch-template/second-home/data/charter.md')"

ship stdout: warn: no registry at /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVV6D6TQMQRYEZ22PXW2YVHZ/claude-launch-template/main-home/data/projects.md; defaulting app to no-mistakes off
spawned ship-ghost harness=claude kind=ship mode=no-mistakes yolo=off window=firstmate:fm-ship-ghost worktree=/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVV6D6TQMQRYEZ22PXW2YVHZ/claude-launch-template/worktree
secondmate stdout: spawned second-ghost harness=claude kind=secondmate mode=secondmate yolo=off window=firstmate:fm-second-ghost worktree=/private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVV6D6TQMQRYEZ22PXW2YVHZ/claude-launch-template/second-home
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (2) ✅</summary>

- 🚨 `bin/fm-tmux-lib.sh:70` - Captain, this treats any SGR parameter equal to `2` as faint, but `2` also appears inside normal color sequences like `ESC[38;5;2m` and truecolor `ESC[38;2;...m`. A colored composer line can therefore set `dim=1` and strip real typed input until reset, causing `fm_pane_input_pending` to report empty and allowing injection or Enter over user text. Parse SGR parameters with 38/48 color payloads skipped before applying intensity codes.

🔧 Fix: Captain, preserve SGR-colored typed input
1 warning still open:
- ⚠️ `bin/fm-tmux-lib.sh:63` - Captain, the SGR scanner still only consumes digits and semicolons, and the color-payload skip only covers 38/48. Valid styled output with colon subparameters or underline color, such as `ESC[58::5::2m` or `ESC[58;5;2m`, can either leak `:5::2m` into the composer text or treat the payload `2` as faint. That can make an idle styled composer look pending, or strip real typed input in the semicolon form. Consume CSI parameters through the final byte and skip 38/48/58 color payload forms before applying intensity codes.

🔧 Fix: Captain, harden SGR color parsing
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `FM_FLEET_PRUNE=0 bin/fm-bootstrap.sh`
- `tests/fm-composer-ghost.test.sh`
- `tests/fm-spawn-batch.test.sh`
- `tests/fm-wake-queue.test.sh`
- `tests/fm-afk-inject-e2e.test.sh`
- `tests/fm-secondmate.test.sh`
- <code>Manual evidence capture: real tmux panes with dim SGR ghost text, normal typed text, bordered ghost text, and mixed real-plus-ghost text classified through `fm_tmux_composer_state` and `fm_pane_input_pending`.</code>
- <code>Manual evidence capture: `fm-spawn.sh` with fake tmux verified both ship and secondmate claude launch commands include `CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false`.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
