### PR TITLE
feat: adopt tasks-axi backlog mutations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ AGENTS.md            this file (CLAUDE.md is a symlink to it)
 CONTRIBUTING.md      contributor workflow and repo conventions
 README.md            public overview and development notes
 .github/workflows/   shared CI and PR enforcement, committed
-.tasks.toml          tracked optional tasks-axi markdown backend config, currently inert
+.tasks.toml          tracked tasks-axi markdown backend config; drives backlog mutations when tasks-axi is on PATH (section 10), otherwise inert
 .agents/skills/      shared skills, committed
 .claude/skills       symlink to .agents/skills for claude compatibility
 bin/                 helper scripts, committed, including fm-fleet-sync.sh for clean default-branch refreshes and gone-branch pruning; read each script's header before first use
@@ -112,8 +112,9 @@ Otherwise it prints one line per problem or capability fact; handle each:
 - `CREW_HARNESS_OVERRIDE: <name>` - record and use the override silently; surface a harness fact only if it actually blocks work or the captain asks.
 - `FLEET_SYNC: <repo>: skipped: <reason>` - bootstrap continued; investigate only if the dirty, diverged, or offline clone blocks work.
 - `TASKS_AXI: available` - an optional capability fact, not a problem; record it silently and never surface it to the captain.
-  Firstmate does not route backlog mutations through `tasks-axi` yet (deferred pending format compatibility, section 10), so keep hand-editing `data/backlog.md` exactly as section 10 describes.
-  Its presence and its absence are equally a no-op here, never a missing tool to install.
+  When `tasks-axi` is on PATH, firstmate routes every `data/backlog.md` mutation through its verbs instead of hand-editing the file, exactly as section 10 describes.
+  When `tasks-axi` is absent, firstmate hand-edits `data/backlog.md` exactly as before, so the silent guarantee that backlog bookkeeping keeps working holds either way.
+  It is never a missing tool to install: its absence only falls back to hand-editing and never blocks work.
 
 Bootstrap's fleet refresh is bounded by `FM_FLEET_SYNC_BOOTSTRAP_TIMEOUT` seconds, default 20; a timeout is reported as a `FLEET_SYNC` skip and does not block startup.
 
@@ -654,7 +655,22 @@ Re-evaluate Queued on every teardown and every heartbeat: anything whose blocker
 Keep Done to the 10 most recent entries; prune older ones whenever you add to the section.
 Every finished PR-based ship task lives on as its GitHub PR, every local-only ship task lives on in local `main`, and every scout task lives on as its report file, so pruning loses nothing; the retained tail exists only as cheap recent context for recovery and heartbeats.
 
-A tracked `.tasks.toml` at this repo root pins the `tasks-axi` markdown backend to `data/backlog.md`, but adopting `tasks-axi` for backlog mutations is deferred pending a release whose format is compatible with the In-flight (`- [ ] <id>`) and `blocked-by: <id> - <reason>` shapes above; until then, every firstmate home (main and each secondmate) keeps hand-editing `data/backlog.md` exactly as this section describes.
+A tracked `.tasks.toml` at this repo root pins the `tasks-axi` markdown backend to `data/backlog.md`, with `done_keep = 10` and an archive at `data/done-archive.md`.
+When `tasks-axi` is on PATH, firstmate mutates the backlog through its verbs instead of hand-editing.
+The `## In flight` / `## Queued` / `## Done` format above stays the contract: the verbs edit `data/backlog.md` in place, byte-exact, preserving whatever item forms the file already uses - the bold in-flight `- **<id>**` form, the `- [ ]`/`- [x]` queued and done forms, and `blocked-by: <id> - <reason>` - rather than reformatting them.
+Map firstmate's real backlog operations to the verbs:
+
+- File an item: `tasks-axi add <id> "<one line>" --kind <ship|scout> --repo <name>`, plus `--start` for immediate dispatch (In flight) or the default queue placement, and `--blocked-by <id>` (repeatable) when it waits on another task.
+- Move a finished task to Done: `tasks-axi done <id> --pr <url>` for a PR-based ship, `--report <path>` for a scout, or `--note "local main"` for a local-only merge.
+- Append a status note: `tasks-axi update <id> --append "<note>"`; replace fields with `--title`, `--body`, or `--body-file <path>`.
+- Manage dependencies: `tasks-axi block <id> --by <other>` and `tasks-axi unblock <id> --by <other>`, then `tasks-axi ready` to list the queued work that is dispatchable right now.
+- Read an item's full notes: `tasks-axi show <id> --full`.
+- Hand a task off to a secondmate home: `tasks-axi mv <id> --to <path>`, the verb form of moving the line into the secondmate's `data/backlog.md`.
+- Normalize the file: `tasks-axi render` rewrites every id'd task in canonical form and leaves free-form lines untouched.
+
+`tasks-axi done` auto-prunes Done to `done_keep = 10` and archives the pruned entries to `data/done-archive.md`, which supersedes the manual "keep Done to the 10 most recent" pruning above: when `tasks-axi` is present you do not hand-prune Done, and nothing is lost because pruned entries are archived rather than deleted.
+When `tasks-axi` is absent, every firstmate home (main and each secondmate) hand-edits `data/backlog.md` exactly as this section describes, including the manual Done pruning.
+Secondmates inherit this automatically: each secondmate home carries the same `AGENTS.md` and its own `.tasks.toml`, so the same present-or-absent rule applies in every home with no separate setup.
 
 ## 11. Crewmate briefs
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,7 +112,7 @@ Otherwise it prints one line per problem or capability fact; handle each:
 - `CREW_HARNESS_OVERRIDE: <name>` - record and use the override silently; surface a harness fact only if it actually blocks work or the captain asks.
 - `FLEET_SYNC: <repo>: skipped: <reason>` - bootstrap continued; investigate only if the dirty, diverged, or offline clone blocks work.
 - `TASKS_AXI: available` - an optional capability fact, not a problem; record it silently and never surface it to the captain.
-  When `tasks-axi` is on PATH, firstmate routes every `data/backlog.md` mutation through its verbs instead of hand-editing the file, exactly as section 10 describes.
+  When `tasks-axi` is on PATH, firstmate routes routine `data/backlog.md` mutations through its verbs instead of hand-editing the file, exactly as section 10 describes.
   When `tasks-axi` is absent, firstmate hand-edits `data/backlog.md` exactly as before, so the silent guarantee that backlog bookkeeping keeps working holds either way.
   It is never a missing tool to install: its absence only falls back to hand-editing and never blocks work.
 
@@ -656,16 +656,17 @@ Keep Done to the 10 most recent entries; prune older ones whenever you add to th
 Every finished PR-based ship task lives on as its GitHub PR, every local-only ship task lives on in local `main`, and every scout task lives on as its report file, so pruning loses nothing; the retained tail exists only as cheap recent context for recovery and heartbeats.
 
 A tracked `.tasks.toml` at this repo root pins the `tasks-axi` markdown backend to `data/backlog.md`, with `done_keep = 10` and an archive at `data/done-archive.md`.
-When `tasks-axi` is on PATH, firstmate mutates the backlog through its verbs instead of hand-editing.
+When `tasks-axi` is on PATH, firstmate mutates the backlog through its verbs instead of hand-editing, with secondmate handoffs still going through the validated helper described in section 6.
 The `## In flight` / `## Queued` / `## Done` format above stays the contract: the verbs edit `data/backlog.md` in place, byte-exact, preserving whatever item forms the file already uses - the bold in-flight `- **<id>**` form, the `- [ ]`/`- [x]` queued and done forms, and `blocked-by: <id> - <reason>` - rather than reformatting them.
-Map firstmate's real backlog operations to the verbs:
+Map firstmate's real backlog operations to the approved commands:
 
 - File an item: `tasks-axi add <id> "<one line>" --kind <ship|scout> --repo <name>`, plus `--start` for immediate dispatch (In flight) or the default queue placement, and `--blocked-by <id>` (repeatable) when it waits on another task.
+- Start an existing queued item: `tasks-axi start <id>` before dispatching unblocked or date-due work from Queued.
 - Move a finished task to Done: `tasks-axi done <id> --pr <url>` for a PR-based ship, `--report <path>` for a scout, or `--note "local main"` for a local-only merge.
 - Append a status note: `tasks-axi update <id> --append "<note>"`; replace fields with `--title`, `--body`, or `--body-file <path>`.
 - Manage dependencies: `tasks-axi block <id> --by <other>` and `tasks-axi unblock <id> --by <other>`, then `tasks-axi ready` to list the queued work that is dispatchable right now.
 - Read an item's full notes: `tasks-axi show <id> --full`.
-- Hand a task off to a secondmate home: `tasks-axi mv <id> --to <path>`, the verb form of moving the line into the secondmate's `data/backlog.md`.
+- Hand a task off to a secondmate home: keep using `bin/fm-backlog-handoff.sh <secondmate-id> <item-key>...`; do not call bare `tasks-axi mv` for this path, because the helper resolves and validates the secondmate home before moving anything.
 - Normalize the file: `tasks-axi render` rewrites every id'd task in canonical form and leaves free-form lines untouched.
 
 `tasks-axi done` auto-prunes Done to `done_keep = 10` and archives the pruned entries to `data/done-archive.md`, which supersedes the manual "keep Done to the 10 most recent" pruning above: when `tasks-axi` is present you do not hand-prune Done, and nothing is lost because pruned entries are archived rather than deleted.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ AGENTS.md            this file (CLAUDE.md is a symlink to it)
 CONTRIBUTING.md      contributor workflow and repo conventions
 README.md            public overview and development notes
 .github/workflows/   shared CI and PR enforcement, committed
-.tasks.toml          tracked tasks-axi markdown backend config; drives backlog mutations when tasks-axi is on PATH (section 10), otherwise inert
+.tasks.toml          tracked tasks-axi markdown backend config; drives backlog mutations when a compatible tasks-axi is on PATH (section 10), otherwise inert
 .agents/skills/      shared skills, committed
 .claude/skills       symlink to .agents/skills for claude compatibility
 bin/                 helper scripts, committed, including fm-fleet-sync.sh for clean default-branch refreshes and gone-branch pruning; read each script's header before first use
@@ -112,9 +112,10 @@ Otherwise it prints one line per problem or capability fact; handle each:
 - `CREW_HARNESS_OVERRIDE: <name>` - record and use the override silently; surface a harness fact only if it actually blocks work or the captain asks.
 - `FLEET_SYNC: <repo>: skipped: <reason>` - bootstrap continued; investigate only if the dirty, diverged, or offline clone blocks work.
 - `TASKS_AXI: available` - an optional capability fact, not a problem; record it silently and never surface it to the captain.
-  When `tasks-axi` is on PATH, firstmate routes routine `data/backlog.md` mutations through its verbs instead of hand-editing the file, exactly as section 10 describes.
-  When `tasks-axi` is absent, firstmate hand-edits `data/backlog.md` exactly as before, so the silent guarantee that backlog bookkeeping keeps working holds either way.
-  It is never a missing tool to install: its absence only falls back to hand-editing and never blocks work.
+  Bootstrap prints this only after the `tasks-axi` compatibility probe passes for version 0.1.1 or newer.
+  When a compatible `tasks-axi` is on PATH, firstmate routes routine `data/backlog.md` mutations through its verbs instead of hand-editing the file, exactly as section 10 describes.
+  When `tasks-axi` is absent or fails the compatibility probe, firstmate hand-edits `data/backlog.md` exactly as before, so the silent guarantee that backlog bookkeeping keeps working holds either way.
+  It is never a missing tool to install: its absence or incompatibility only falls back to hand-editing and never blocks work.
 
 Bootstrap's fleet refresh is bounded by `FM_FLEET_SYNC_BOOTSTRAP_TIMEOUT` seconds, default 20; a timeout is reported as a `FLEET_SYNC` skip and does not block startup.
 
@@ -450,7 +451,8 @@ bin/fm-teardown.sh <id>
 The script refuses if the worktree holds unpushed work; treat a refusal as a stop-and-investigate, not an obstacle.
 Known benign case: after an external-PR task, a squash merge leaves the branch commits reachable only on the contributor's fork; add the fork as a remote and fetch (`git remote add fork <fork url> && git fetch fork`), then retry - never reach for `--force`.
 After a successful PR-based teardown, it also runs `bin/fm-fleet-sync.sh` for that project, best-effort, so the clone's local default catches up to the merge and the just-merged branch, now gone on the remote and free of its worktree, is pruned immediately.
-Then move the task to Done in `data/backlog.md` (with the full `https://...` PR URL or local merge note and date), keep Done to the 10 most recent, re-evaluate the queue, and dispatch anything that was blocked on this task or is now time/date-due.
+Then update the backlog using the teardown reminder: run `tasks-axi done` when the compatible tool is available, otherwise move the task to Done in `data/backlog.md` manually with the full `https://...` PR URL or local merge note and date and keep Done to the 10 most recent.
+Re-evaluate the queue and dispatch anything that was blocked on this task or is now time/date-due.
 
 ### Secondmate teardown (explicit only)
 
@@ -470,7 +472,7 @@ A scout task follows Intake, Spawn, and Supervise exactly as above - scaffold th
 - There is no Validate or PR-ready stage. When the crewmate's status says `done`, read `data/<id>/report.md`.
 - Relay the findings to the captain: plain chat for a focused answer, lavish-axi when the report has structure worth a visual (multiple findings, options, a plan).
 - Tear down immediately - no merge gate. `bin/fm-teardown.sh` allows a scout worktree's scratch commits and dirty files once the report exists; if the report is missing, it refuses, because the findings are the work product.
-- Record it in Done with the report path instead of a PR link, keep Done to the 10 most recent, then re-evaluate the queue and dispatch anything unblocked or now time/date-due.
+- Record it in Done with the report path instead of a PR link using `tasks-axi done` when compatible tasks-axi is available, otherwise hand-edit `data/backlog.md` and keep Done to the 10 most recent, then re-evaluate the queue and dispatch anything unblocked or now time/date-due.
 
 **Promotion.** When a scout's findings reveal shippable work (a reproduced bug with a clear fix) and the captain wants it shipped, promote the task in place instead of respawning: run `bin/fm-promote.sh <id>` (flips `kind=` to ship in meta, restoring teardown's full protection), then send the crewmate its ship instructions - inventory scratch state, reset to a clean default-branch base, carry over only intended fix changes, create branch `fm/<id>`, implement, and report `done` according to the project's delivery mode.
 The crewmate keeps its worktree, loaded context, and repro, but the ship branch must start from a clean base with only intended changes; scratch commits and debug edits from the scout phase never ride along.
@@ -656,7 +658,8 @@ Keep Done to the 10 most recent entries; prune older ones whenever you add to th
 Every finished PR-based ship task lives on as its GitHub PR, every local-only ship task lives on in local `main`, and every scout task lives on as its report file, so pruning loses nothing; the retained tail exists only as cheap recent context for recovery and heartbeats.
 
 A tracked `.tasks.toml` at this repo root pins the `tasks-axi` markdown backend to `data/backlog.md`, with `done_keep = 10` and an archive at `data/done-archive.md`.
-When `tasks-axi` is on PATH, firstmate mutates the backlog through its verbs instead of hand-editing, with secondmate handoffs still going through the validated helper described in section 6.
+When a compatible `tasks-axi` is on PATH, firstmate mutates the backlog through its verbs instead of hand-editing, with secondmate handoffs still going through the validated helper described in section 6.
+Compatible means the shared bootstrap probe accepts `tasks-axi --version` as 0.1.1 or newer.
 The `## In flight` / `## Queued` / `## Done` format above stays the contract: the verbs edit `data/backlog.md` in place, byte-exact, preserving whatever item forms the file already uses - the bold in-flight `- **<id>**` form, the `- [ ]`/`- [x]` queued and done forms, and `blocked-by: <id> - <reason>` - rather than reformatting them.
 Map firstmate's real backlog operations to the approved commands:
 
@@ -669,8 +672,8 @@ Map firstmate's real backlog operations to the approved commands:
 - Hand a task off to a secondmate home: keep using `bin/fm-backlog-handoff.sh <secondmate-id> <item-key>...`; do not call bare `tasks-axi mv` for this path, because the helper resolves and validates the secondmate home before moving anything.
 - Normalize the file: `tasks-axi render` rewrites every id'd task in canonical form and leaves free-form lines untouched.
 
-`tasks-axi done` auto-prunes Done to `done_keep = 10` and archives the pruned entries to `data/done-archive.md`, which supersedes the manual "keep Done to the 10 most recent" pruning above: when `tasks-axi` is present you do not hand-prune Done, and nothing is lost because pruned entries are archived rather than deleted.
-When `tasks-axi` is absent, every firstmate home (main and each secondmate) hand-edits `data/backlog.md` exactly as this section describes, including the manual Done pruning.
+`tasks-axi done` auto-prunes Done to `done_keep = 10` and archives the pruned entries to `data/done-archive.md`, which supersedes the manual "keep Done to the 10 most recent" pruning above: when compatible `tasks-axi` is present you do not hand-prune Done, and nothing is lost because pruned entries are archived rather than deleted.
+When `tasks-axi` is absent or fails the compatibility probe, every firstmate home (main and each secondmate) hand-edits `data/backlog.md` exactly as this section describes, including the manual Done pruning.
 Secondmates inherit this automatically: each secondmate home carries the same `AGENTS.md` and its own `.tasks.toml`, so the same present-or-absent rule applies in every home with no separate setup.
 
 ## 11. Crewmate briefs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -452,7 +452,7 @@ The script refuses if the worktree holds unpushed work; treat a refusal as a sto
 Known benign case: after an external-PR task, a squash merge leaves the branch commits reachable only on the contributor's fork; add the fork as a remote and fetch (`git remote add fork <fork url> && git fetch fork`), then retry - never reach for `--force`.
 After a successful PR-based teardown, it also runs `bin/fm-fleet-sync.sh` for that project, best-effort, so the clone's local default catches up to the merge and the just-merged branch, now gone on the remote and free of its worktree, is pruned immediately.
 Then update the backlog using the teardown reminder: run `tasks-axi done` when the compatible tool is available, otherwise move the task to Done in `data/backlog.md` manually with the full `https://...` PR URL or local merge note and date and keep Done to the 10 most recent.
-Re-evaluate the queue and dispatch anything that was blocked on this task or is now time/date-due.
+Re-evaluate the queue and dispatch only queued work whose blockers are gone and whose time/date gate, if any, has arrived.
 
 ### Secondmate teardown (explicit only)
 
@@ -472,7 +472,7 @@ A scout task follows Intake, Spawn, and Supervise exactly as above - scaffold th
 - There is no Validate or PR-ready stage. When the crewmate's status says `done`, read `data/<id>/report.md`.
 - Relay the findings to the captain: plain chat for a focused answer, lavish-axi when the report has structure worth a visual (multiple findings, options, a plan).
 - Tear down immediately - no merge gate. `bin/fm-teardown.sh` allows a scout worktree's scratch commits and dirty files once the report exists; if the report is missing, it refuses, because the findings are the work product.
-- Record it in Done with the report path instead of a PR link using `tasks-axi done` when compatible tasks-axi is available, otherwise hand-edit `data/backlog.md` and keep Done to the 10 most recent, then re-evaluate the queue and dispatch anything unblocked or now time/date-due.
+- Record it in Done with the report path instead of a PR link using `tasks-axi done` when compatible tasks-axi is available, otherwise hand-edit `data/backlog.md` and keep Done to the 10 most recent, then re-evaluate the queue and dispatch only queued work whose blockers are gone and whose time/date gate, if any, has arrived.
 
 **Promotion.** When a scout's findings reveal shippable work (a reproduced bug with a clear fix) and the captain wants it shipped, promote the task in place instead of respawning: run `bin/fm-promote.sh <id>` (flips `kind=` to ship in meta, restoring teardown's full protection), then send the crewmate its ship instructions - inventory scratch state, reset to a clean default-branch base, carry over only intended fix changes, create branch `fm/<id>`, implement, and report `done` according to the project's delivery mode.
 The crewmate keeps its worktree, loaded context, and repro, but the ship branch must start from a clean base with only intended changes; scratch commits and debug edits from the scout phase never ride along.
@@ -652,7 +652,7 @@ Update it on every dispatch, completion, and decision.
 - [x] <id> - <one line> - data/<id>/report.md (reported <date>)
 ```
 
-Re-evaluate Queued on every teardown and every heartbeat: anything whose blocker is gone gets dispatched, and time/date-gated items whose date has arrived get dispatched too.
+Re-evaluate Queued on every teardown and every heartbeat: anything whose blocker is gone and whose time/date gate, if any, has arrived gets dispatched.
 
 Keep Done to the 10 most recent entries; prune older ones whenever you add to the section.
 Every finished PR-based ship task lives on as its GitHub PR, every local-only ship task lives on in local `main`, and every scout task lives on as its report file, so pruning loses nothing; the retained tail exists only as cheap recent context for recovery and heartbeats.
@@ -664,10 +664,11 @@ The `## In flight` / `## Queued` / `## Done` format above stays the contract: th
 Map firstmate's real backlog operations to the approved commands:
 
 - File an item: `tasks-axi add <id> "<one line>" --kind <ship|scout> --repo <name>`, plus `--start` for immediate dispatch (In flight) or the default queue placement, and `--blocked-by <id>` (repeatable) when it waits on another task.
-- Start an existing queued item: `tasks-axi start <id>` before dispatching unblocked or date-due work from Queued.
+- Start an existing queued item: `tasks-axi start <id>` before dispatching work from Queued, after checking that blockers are gone and any time/date gate has arrived.
 - Move a finished task to Done: `tasks-axi done <id> --pr <url>` for a PR-based ship, `--report <path>` for a scout, or `--note "local main"` for a local-only merge.
 - Append a status note: `tasks-axi update <id> --append "<note>"`; replace fields with `--title`, `--body`, or `--body-file <path>`.
-- Manage dependencies: `tasks-axi block <id> --by <other>` and `tasks-axi unblock <id> --by <other>`, then `tasks-axi ready` to list the queued work that is dispatchable right now.
+- Manage dependencies: `tasks-axi block <id> --by <other>` and `tasks-axi unblock <id> --by <other>`, then `tasks-axi ready` to list queued work with no unresolved blockers.
+  This is a dependency check only; future-dated items still stay queued until their date arrives.
 - Read an item's full notes: `tasks-axi show <id> --full`.
 - Hand a task off to a secondmate home: keep using `bin/fm-backlog-handoff.sh <secondmate-id> <item-key>...`; do not call bare `tasks-axi mv` for this path, because the helper resolves and validates the secondmate home before moving anything.
 - Normalize the file: `tasks-axi render` rewrites every id'd task in canonical form and leaves free-form lines untouched.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,8 @@ See the [no-mistakes quick start](https://kunchenguid.github.io/no-mistakes/star
   `AGENTS.md` is the agent's entire job description; `CLAUDE.md` is a symlink to it, and `.claude/skills` is a symlink to `.agents/skills`.
 - Only shared material is tracked: `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `.tasks.toml`, `.github/workflows/`, `bin/`, and `.agents/skills/`.
   Everything personal to one captain's fleet (`data/`, `state/`, `config/`, `projects/`, `.no-mistakes/`) is gitignored; never commit it.
-  The root `.tasks.toml` is tracked optional `tasks-axi` config; it does not make `data/` tracked.
+  The root `.tasks.toml` is tracked `tasks-axi` config for `data/backlog.md`; compatible `tasks-axi` uses it for routine backlog mutations.
+  It does not make `data/` tracked.
 - Helper scripts in `bin/` are plain bash.
   Each starts with a usage header comment; keep it accurate when you change behavior.
   `shellcheck bin/*.sh` must pass, and CI enforces it.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ cd firstmate && claude
 
 That is the whole install.
 On first launch the first mate detects what its required toolchain is missing or too old (tmux, node, gh, treehouse with durable lease support, no-mistakes, gh-axi, chrome-devtools-axi, lavish-axi), lists it with the exact install commands, and installs only after you say go.
-If `tasks-axi` is already on `PATH`, bootstrap records it as an optional capability fact, but firstmate still hand-edits `data/backlog.md` until that tool can parse firstmate's backlog format.
+If `tasks-axi` is already on `PATH`, bootstrap records it as an optional capability fact and firstmate uses its verbs for routine backlog mutations; when it is absent, firstmate keeps hand-editing `data/backlog.md` exactly as before.
 
 **Run it inside tmux for the best experience.**
 firstmate works from any terminal - outside tmux, crewmates land in a detached `firstmate` session you can attach to - but launching your harness from inside tmux puts every crewmate window in your own session, one per task, where you can watch the crew work in real time or type into any window to intervene.
@@ -173,7 +173,8 @@ The first mate drives these; you rarely need to, but they work by hand too.
 ## Configuration
 
 The shared orchestrator behavior lives in `AGENTS.md` - edit it like any prompt when the fleet is empty, or dispatch shared-repo edits to a crewmate while tasks are in flight.
-The tracked `.tasks.toml` pins the optional `tasks-axi` markdown backend to `data/backlog.md`, but current backlog mutations remain manual until `tasks-axi` can parse firstmate's backlog format.
+The tracked `.tasks.toml` pins the optional `tasks-axi` markdown backend to `data/backlog.md`, with `done_keep = 10` and an archive at `data/done-archive.md`.
+When `tasks-axi` is on `PATH`, firstmate uses its verbs for routine backlog mutations and keeps secondmate transfers behind `fm-backlog-handoff.sh` validation; without it, backlog bookkeeping remains manual.
 Personal preferences for one captain's fleet live locally in `data/captain.md`; it is gitignored and read after `data/projects.md` and optional `data/secondmates.md` during bootstrap.
 Persistent secondmate routes live locally in `data/secondmates.md`.
 Each line records the secondmate id, charter summary, absolute home path, natural-language scope, project clone list, and added date; `fm-home-seed.sh validate` refuses duplicate ids, duplicate homes, and nested or overlapping homes.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ cd firstmate && claude
 
 That is the whole install.
 On first launch the first mate detects what its required toolchain is missing or too old (tmux, node, gh, treehouse with durable lease support, no-mistakes, gh-axi, chrome-devtools-axi, lavish-axi), lists it with the exact install commands, and installs only after you say go.
-If `tasks-axi` is already on `PATH`, bootstrap records it as an optional capability fact and firstmate uses its verbs for routine backlog mutations; when it is absent, firstmate keeps hand-editing `data/backlog.md` exactly as before.
+If compatible `tasks-axi` is already on `PATH`, bootstrap records it as an optional capability fact and firstmate uses its verbs for routine backlog mutations; when it is absent or incompatible, firstmate keeps hand-editing `data/backlog.md` exactly as before.
 
 **Run it inside tmux for the best experience.**
 firstmate works from any terminal - outside tmux, crewmates land in a detached `firstmate` session you can attach to - but launching your harness from inside tmux puts every crewmate window in your own session, one per task, where you can watch the crew work in real time or type into any window to intervene.
@@ -174,7 +174,8 @@ The first mate drives these; you rarely need to, but they work by hand too.
 
 The shared orchestrator behavior lives in `AGENTS.md` - edit it like any prompt when the fleet is empty, or dispatch shared-repo edits to a crewmate while tasks are in flight.
 The tracked `.tasks.toml` pins the optional `tasks-axi` markdown backend to `data/backlog.md`, with `done_keep = 10` and an archive at `data/done-archive.md`.
-When `tasks-axi` is on `PATH`, firstmate uses its verbs for routine backlog mutations and keeps secondmate transfers behind `fm-backlog-handoff.sh` validation; without it, backlog bookkeeping remains manual.
+When compatible `tasks-axi` is on `PATH`, firstmate uses its verbs for routine backlog mutations and keeps secondmate transfers behind `fm-backlog-handoff.sh` validation; without it, backlog bookkeeping remains manual.
+Compatible means the shared bootstrap probe accepts `tasks-axi --version` as 0.1.1 or newer.
 Personal preferences for one captain's fleet live locally in `data/captain.md`; it is gitignored and read after `data/projects.md` and optional `data/secondmates.md` during bootstrap.
 Persistent secondmate routes live locally in `data/secondmates.md`.
 Each line records the secondmate id, charter summary, absolute home path, natural-language scope, project clone list, and added date; `fm-home-seed.sh validate` refuses duplicate ids, duplicate homes, and nested or overlapping homes.

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ The first mate drives these; you rarely need to, but they work by hand too.
 | `fm-peek.sh`             | Print a bounded tail of a crewmate pane                                                                             |
 | `fm-pr-check.sh`         | Record a PR-ready task and arm the watcher's merge poll                                                             |
 | `fm-promote.sh`          | Promote a scout task in place so it becomes a protected ship task                                                   |
-| `fm-teardown.sh`         | Return the worktree or retire/release a secondmate home; protects ship work, requires scout reports, and checks child work |
+| `fm-teardown.sh`         | Return the worktree or retire/release a secondmate home; protects ship work, requires scout reports, checks child work, and prints the backlog reminder |
 | `fm-harness.sh`          | Detect the running harness; resolve the effective crewmate harness                                                  |
 | `fm-lock.sh`             | Per-home firstmate session lock                                                                                     |
 
@@ -238,7 +238,7 @@ tests/fm-composer-ghost.test.sh           # dim-ghost stripping, ghost-only comp
 tests/fm-afk-inject-e2e.test.sh           # private-socket end-to-end test of the afk injection path (partial-input deferral, swallowed-Enter retry)
 tests/fm-bootstrap.test.sh                # bootstrap dependency and feature-probe tests
 tests/fm-secondmate.test.sh               # persistent secondmate routing, seeding, idle charter, backlog handoff, spawn, recovery, teardown, and FM_HOME tests
-tests/fm-teardown.test.sh                 # fm-teardown.sh unpushed-work safety check: local-only fork-remote allow, truly-unpushed refuse, merged-to-main allow, no-mistakes regression, --force override
+tests/fm-teardown.test.sh                 # fm-teardown.sh safety and reminder checks: local-only fork-remote allow, truly-unpushed refuse, merged-to-main allow, no-mistakes regression, tasks-axi reminder, --force override
 [ "$(readlink CLAUDE.md)" = "AGENTS.md" ]
 [ "$(readlink .claude/skills)" = "../.agents/skills" ]
 FM_HEARTBEAT=2 FM_POLL=1 bin/fm-watch.sh  # watcher smoke test (prints "heartbeat")

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -8,8 +8,9 @@
 #                 "TASKS_AXI: available".
 #          treehouse is also MISSING when its installed version lacks
 #          "treehouse get --lease" support.
-#          tasks-axi is an OPTIONAL backlog-management capability, never a
-#          required tool: it is never a MISSING line and never prompts an install.
+#          tasks-axi is an OPTIONAL backlog-management capability reported only
+#          when tasks-axi --version is 0.1.1 or newer. It is never a MISSING
+#          line and never prompts an install.
 #          Fleet sync fetches, fast-forwards, and prunes gone local branches;
 #          it is bounded by FM_FLEET_SYNC_BOOTSTRAP_TIMEOUT, default 20s.
 #          Set FM_FLEET_PRUNE=0 to skip branch pruning during that refresh.

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -23,6 +23,7 @@ FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 PROJECTS="${FM_PROJECTS_OVERRIDE:-$FM_HOME/projects}"
 CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
+# shellcheck source=bin/fm-tasks-axi-lib.sh
 . "$SCRIPT_DIR/fm-tasks-axi-lib.sh"
 
 fleet_sync() {

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -22,6 +22,7 @@ FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 PROJECTS="${FM_PROJECTS_OVERRIDE:-$FM_HOME/projects}"
 CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
+. "$SCRIPT_DIR/fm-tasks-axi-lib.sh"
 
 fleet_sync() {
   [ -x "$FM_ROOT/bin/fm-fleet-sync.sh" ] || return 0
@@ -99,8 +100,6 @@ gh auth status >/dev/null 2>&1 || echo "NEEDS_GH_AUTH"
 crew=
 [ -f "$CONFIG/crew-harness" ] && crew=$(tr -d '[:space:]' < "$CONFIG/crew-harness" || true)
 [ -n "$crew" ] && [ "$crew" != "default" ] && echo "CREW_HARNESS_OVERRIDE: $crew"
-# Optional capability, not a required tool: detected on PATH so it is never a
-# MISSING line and never prompts an install. Absent => silent, behavior unchanged.
-command -v tasks-axi >/dev/null 2>&1 && echo "TASKS_AXI: available"
+fm_tasks_axi_compatible && echo "TASKS_AXI: available"
 fleet_sync
 exit 0

--- a/bin/fm-tasks-axi-lib.sh
+++ b/bin/fm-tasks-axi-lib.sh
@@ -1,0 +1,23 @@
+fm_tasks_axi_version_parts() {
+  local output
+  command -v tasks-axi >/dev/null 2>&1 || return 1
+  output=$(tasks-axi --version 2>/dev/null) || return 1
+  printf '%s\n' "$output" |
+    sed -n 's/.*\([0-9][0-9]*\)\.\([0-9][0-9]*\)\.\([0-9][0-9]*\).*/\1 \2 \3/p' |
+    head -1
+}
+
+fm_tasks_axi_compatible() {
+  local parts major minor patch
+  parts=$(fm_tasks_axi_version_parts) || return 1
+  [ -n "$parts" ] || return 1
+  set -- $parts
+  major=$1
+  minor=$2
+  patch=$3
+
+  [ "$major" -gt 0 ] && return 0
+  [ "$major" -eq 0 ] && [ "$minor" -gt 1 ] && return 0
+  [ "$major" -eq 0 ] && [ "$minor" -eq 1 ] && [ "$patch" -ge 1 ] && return 0
+  return 1
+}

--- a/bin/fm-tasks-axi-lib.sh
+++ b/bin/fm-tasks-axi-lib.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # Shared tasks-axi compatibility probe for bootstrap and teardown.
 # Usage: . bin/fm-tasks-axi-lib.sh
 # Compatible means tasks-axi --version reports 0.1.1 or newer.
@@ -12,13 +13,13 @@ fm_tasks_axi_version_parts() {
 }
 
 fm_tasks_axi_compatible() {
-  local parts major minor patch
+  local parts major minor patch rest
   parts=$(fm_tasks_axi_version_parts) || return 1
   [ -n "$parts" ] || return 1
-  set -- $parts
-  major=$1
-  minor=$2
-  patch=$3
+  major=${parts%% *}
+  rest=${parts#* }
+  minor=${rest%% *}
+  patch=${rest##* }
 
   [ "$major" -gt 0 ] && return 0
   [ "$major" -eq 0 ] && [ "$minor" -gt 1 ] && return 0

--- a/bin/fm-tasks-axi-lib.sh
+++ b/bin/fm-tasks-axi-lib.sh
@@ -1,3 +1,7 @@
+# Shared tasks-axi compatibility probe for bootstrap and teardown.
+# Usage: . bin/fm-tasks-axi-lib.sh
+# Compatible means tasks-axi --version reports 0.1.1 or newer.
+
 fm_tasks_axi_version_parts() {
   local output
   command -v tasks-axi >/dev/null 2>&1 || return 1

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -32,6 +32,7 @@ STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 SECONDMATE_REG="$DATA/secondmates.md"
 SUB_HOME_MARKER=".fm-secondmate-home"
+. "$SCRIPT_DIR/fm-tasks-axi-lib.sh"
 "$FM_ROOT/bin/fm-guard.sh" || true
 ID=$1
 FORCE=${2:-}
@@ -42,6 +43,7 @@ WT=$(grep '^worktree=' "$META" | cut -d= -f2-)
 T=$(grep '^window=' "$META" | cut -d= -f2-)
 PROJ=$(grep '^project=' "$META" | cut -d= -f2-)
 HOME_PATH=$(grep '^home=' "$META" | cut -d= -f2- || true)
+PR_URL=$(grep '^pr=' "$META" | tail -1 | cut -d= -f2- || true)
 
 KIND=$(grep '^kind=' "$META" | cut -d= -f2- || true)
 [ -n "$KIND" ] || KIND=ship
@@ -67,6 +69,36 @@ default_branch() {
 meta_value() {
   local meta=$1 key=$2
   grep "^$key=" "$meta" | cut -d= -f2- || true
+}
+
+backlog_refresh_reminder() {
+  local pr done_cmd report_path
+  if fm_tasks_axi_compatible; then
+    case "$KIND" in
+      scout)
+        report_path="data/$ID/report.md"
+        done_cmd="tasks-axi done $ID --report $report_path"
+        ;;
+      secondmate)
+        done_cmd="tasks-axi done $ID --note \"retired\""
+        ;;
+      *)
+        if [ "$MODE" = local-only ]; then
+          done_cmd="tasks-axi done $ID --note \"local main\""
+        else
+          pr=$PR_URL
+          if [ -n "$pr" ]; then
+            done_cmd="tasks-axi done $ID --pr $pr"
+          else
+            done_cmd="tasks-axi done $ID --pr PR_URL"
+          fi
+        fi
+        ;;
+    esac
+    printf '%s\n' "Backlog: $ID just finished. Run $done_cmd, then run tasks-axi ready and dispatch work now unblocked or time-due."
+  else
+    printf '%s\n' "Backlog: $ID just finished. Update data/backlog.md - move $ID to Done, keep Done to the 10 most recent, then re-scan Queued for items now unblocked (a \"blocked-by: $ID\" may have just cleared) or now time-due, and dispatch what's ready."
+  fi
 }
 
 registry_home_for_line() {
@@ -451,4 +483,4 @@ if [ "$KIND" != scout ] && [ "$KIND" != secondmate ] && [ "$MODE" != local-only 
   "$FM_ROOT/bin/fm-fleet-sync.sh" "$PROJ" || true
 fi
 echo "teardown $ID complete (window $T, worktree $WT)"
-printf '%s\n' "🌱 Backlog: $ID just finished. Update data/backlog.md - move $ID to Done (keep Done to the 10 most recent), then re-scan Queued for items now unblocked (a \"blocked-by: $ID\" may have just cleared) or now time-due, and dispatch what's ready."
+backlog_refresh_reminder

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -32,6 +32,7 @@ STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 SECONDMATE_REG="$DATA/secondmates.md"
 SUB_HOME_MARKER=".fm-secondmate-home"
+# shellcheck source=bin/fm-tasks-axi-lib.sh
 . "$SCRIPT_DIR/fm-tasks-axi-lib.sh"
 "$FM_ROOT/bin/fm-guard.sh" || true
 ID=$1

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -95,9 +95,9 @@ backlog_refresh_reminder() {
         fi
         ;;
     esac
-    printf '%s\n' "Backlog: $ID just finished. Run $done_cmd, then run tasks-axi ready and dispatch work now unblocked or time-due."
+    printf '%s\n' "Backlog: $ID just finished. Run $done_cmd, then run tasks-axi ready for dependency-cleared candidates, check date gates, and dispatch only work whose blockers are gone and date is due."
   else
-    printf '%s\n' "Backlog: $ID just finished. Update data/backlog.md - move $ID to Done, keep Done to the 10 most recent, then re-scan Queued for items now unblocked (a \"blocked-by: $ID\" may have just cleared) or now time-due, and dispatch what's ready."
+    printf '%s\n' "Backlog: $ID just finished. Update data/backlog.md - move $ID to Done, keep Done to the 10 most recent, then re-scan Queued and dispatch only work whose blockers are gone and date is due."
   fi
 }
 

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -95,15 +95,38 @@ test_bootstrap_reports_tasks_axi_when_available() {
   fakebin=$(make_fake_toolchain "$case_dir")
   cat > "$fakebin/tasks-axi" <<'SH'
 #!/usr/bin/env bash
+if [ "${1:-}" = --version ]; then
+  printf '%s\n' '0.1.1'
+fi
 exit 0
 SH
   chmod +x "$fakebin/tasks-axi"
 
   out=$(FM_FAKE_TREEHOUSE_LEASE_HELP=1 run_bootstrap "$case_dir/home" "$fakebin")
   [ "$out" = 'TASKS_AXI: available' ] || fail "bootstrap did not report tasks-axi availability: $out"
-  pass "bootstrap reports optional tasks-axi availability"
+  pass "bootstrap reports compatible optional tasks-axi availability"
+}
+
+test_bootstrap_ignores_incompatible_tasks_axi() {
+  local case_dir fakebin out
+  case_dir="$TMP_ROOT/tasks-axi-incompatible"
+  mkdir -p "$case_dir/home"
+  fakebin=$(make_fake_toolchain "$case_dir")
+  cat > "$fakebin/tasks-axi" <<'SH'
+#!/usr/bin/env bash
+if [ "${1:-}" = --version ]; then
+  printf '%s\n' '0.1.0'
+fi
+exit 0
+SH
+  chmod +x "$fakebin/tasks-axi"
+
+  out=$(FM_FAKE_TREEHOUSE_LEASE_HELP=1 run_bootstrap "$case_dir/home" "$fakebin")
+  [ -z "$out" ] || fail "bootstrap reported incompatible tasks-axi as available: $out"
+  pass "bootstrap ignores incompatible optional tasks-axi"
 }
 
 test_bootstrap_accepts_treehouse_lease_support
 test_bootstrap_reports_treehouse_without_lease_support
 test_bootstrap_reports_tasks_axi_when_available
+test_bootstrap_ignores_incompatible_tasks_axi

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -174,6 +174,8 @@ test_teardown_prompts_tasks_axi_done_when_compatible() {
     || fail "teardown did not prompt tasks-axi done: $out"
   printf '%s\n' "$out" | grep -F 'tasks-axi ready' >/dev/null \
     || fail "teardown did not prompt tasks-axi ready: $out"
+  printf '%s\n' "$out" | grep -F 'check date gates' >/dev/null \
+    || fail "teardown did not preserve date-gate check: $out"
   printf '%s\n' "$out" | grep -F 'keep Done to the 10 most recent' >/dev/null \
     && fail "teardown kept manual Done pruning in compatible tasks-axi prompt: $out"
   pass "teardown prompts tasks-axi backlog refresh when compatible"
@@ -234,6 +236,8 @@ test_no_mistakes_origin_remote_allows() {
 
   expect_code 0 "$rc" "nm-origin: teardown should succeed when HEAD is on origin"
   ! grep -q REFUSED "$case_dir/stderr" || fail "nm-origin: teardown printed a REFUSED line"
+  grep -F 'blockers are gone and date is due' "$case_dir/stdout" >/dev/null \
+    || fail "nm-origin: teardown manual prompt did not preserve date-gate check"
   pass "no-mistakes worktree with HEAD on origin is torn down (no regression)"
 }
 

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -86,6 +86,18 @@ SH
   printf '%s\n' "$case_dir"
 }
 
+add_compatible_tasks_axi() {
+  local case_dir=$1
+  cat > "$case_dir/fakebin/tasks-axi" <<'SH'
+#!/usr/bin/env bash
+if [ "${1:-}" = --version ]; then
+  printf '%s\n' '0.1.1'
+fi
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/tasks-axi"
+}
+
 # Write a meta file for the task. Args: case_dir mode kind
 write_meta() {
   local case_dir=$1 mode=$2 kind=$3
@@ -148,6 +160,23 @@ test_local_only_fork_remote_allows() {
   expect_code 0 "$rc" "fork-allow: teardown should succeed when HEAD is on a fork remote"
   ! grep -q REFUSED "$case_dir/stderr" || fail "fork-allow: teardown printed a REFUSED line"
   pass "local-only worktree with HEAD on a fork remote is torn down (fix holds)"
+}
+
+test_teardown_prompts_tasks_axi_done_when_compatible() {
+  local case_dir out
+  case_dir=$(make_case tasks-axi-reminder)
+  write_meta "$case_dir" no-mistakes ship
+  printf '%s\n' 'pr=https://github.com/example/repo/pull/7' >> "$case_dir/state/task-x1.meta"
+  add_compatible_tasks_axi "$case_dir"
+
+  out=$(run_teardown "$case_dir") || fail "teardown failed with compatible tasks-axi"
+  printf '%s\n' "$out" | grep -F 'tasks-axi done task-x1 --pr https://github.com/example/repo/pull/7' >/dev/null \
+    || fail "teardown did not prompt tasks-axi done: $out"
+  printf '%s\n' "$out" | grep -F 'tasks-axi ready' >/dev/null \
+    || fail "teardown did not prompt tasks-axi ready: $out"
+  printf '%s\n' "$out" | grep -F 'keep Done to the 10 most recent' >/dev/null \
+    && fail "teardown kept manual Done pruning in compatible tasks-axi prompt: $out"
+  pass "teardown prompts tasks-axi backlog refresh when compatible"
 }
 
 test_local_only_truly_unpushed_refuses() {
@@ -241,6 +270,7 @@ test_local_only_force_overrides_unpushed() {
 }
 
 test_local_only_fork_remote_allows
+test_teardown_prompts_tasks_axi_done_when_compatible
 test_local_only_truly_unpushed_refuses
 test_local_only_merged_to_local_main_allows
 test_no_mistakes_origin_remote_allows


### PR DESCRIPTION
## Intent

Flip ON full tasks-axi backlog mutation-adoption in firstmate's AGENTS.md (CLAUDE.md is a symlink to it). tasks-axi 0.1.1 is published and empirically verified to round-trip data/backlog.md byte-safely. The prior PR #55 shipped detection-only and AGENTS.md said mutation-adoption was DEFERRED; this change activates it. Specifically: (1) Section 3 TASKS_AXI bootstrap note now says WHEN tasks-axi is on PATH firstmate mutates data/backlog.md via its verbs instead of hand-editing, WHEN absent it hand-edits exactly as before with the silent guarantee intact. (2) Section 10 replaces the deferred paragraph with the ACTIVE policy plus a verb mapping of firstmate's real ops (add/done/update/block/unblock/ready/show/mv/render, all verified against tasks-axi 0.1.1 --help), notes tasks-axi auto-prunes Done to done_keep=10 and archives to data/done-archive.md which SUPERSEDES the manual prune convention when present, and keeps the In flight/Queued/Done format spec block intact since the verbs edit in place byte-exact. (3) The WHEN-ABSENT path stays the unchanged hand-edit behavior. (4) Secondmates inherit automatically via the same AGENTS.md + .tasks.toml. Deliberate scope decisions: this is purely a docs/policy change - tasks-axi itself was NOT changed, and data/backlog.md was NOT reformatted or migrated (it is gitignored/local and tasks-axi handles it in place). I also fixed one internal-consistency line in the section 2 layout that still called .tasks.toml 'currently inert', since that contradicts the flip. Prose follows the repo convention of one full sentence per physical line and plain '-' dashes (no em dashes).

## What Changed

- Captain, activates `tasks-axi` as the preferred `data/backlog.md` mutation path when a compatible 0.1.1+ install is detected, while preserving manual edits as the fallback when unavailable.
- Adds `fm-tasks-axi-lib.sh` feature probing and wires bootstrap diagnostics so incompatible `tasks-axi` versions do not silently enter the active mutation policy.
- Updates teardown guidance and tests to align Done pruning, handoff safety, date-gated queue handling, and shellcheck-clean behavior with the new active policy.

## Risk Assessment

✅ Low: Captain, the remaining change is well-bounded to tasks-axi policy docs plus a small compatibility probe and teardown reminder, with no material merge-blocking issues found.

## Testing

Captain, I inspected the base-to-target diff, ran the two relevant automated shell tests, verified the installed `tasks-axi` is version 0.1.1, checked the documented command help surface, and ran a disposable firstmate-style backlog fixture that used `tasks-axi` to add, start, update, block, unblock, show, complete, render, prune Done to 10, and archive older entries. All checks passed, evidence was written under the requested evidence directory, and the worktree was clean afterward.

<details>
<summary>Evidence: policy excerpts</summary>

```text
$ readlink CLAUDE.md
AGENTS.md

$ cat .tasks.toml
backend = "markdown"

[markdown]
path = "data/backlog.md"
archive = "data/done-archive.md"
done_keep = 10

$ sed -n "112,120p" AGENTS.md
- `CREW_HARNESS_OVERRIDE: <name>` - record and use the override silently; surface a harness fact only if it actually blocks work or the captain asks.
- `FLEET_SYNC: <repo>: skipped: <reason>` - bootstrap continued; investigate only if the dirty, diverged, or offline clone blocks work.
- `TASKS_AXI: available` - an optional capability fact, not a problem; record it silently and never surface it to the captain.
  Bootstrap prints this only after the `tasks-axi` compatibility probe passes for version 0.1.1 or newer.
  When a compatible `tasks-axi` is on PATH, firstmate routes routine `data/backlog.md` mutations through its verbs instead of hand-editing the file, exactly as section 10 describes.
  When `tasks-axi` is absent or fails the compatibility probe, firstmate hand-edits `data/backlog.md` exactly as before, so the silent guarantee that backlog bookkeeping keeps working holds either way.
  It is never a missing tool to install: its absence or incompatibility only falls back to hand-editing and never blocks work.

Bootstrap's fleet refresh is bounded by `FM_FLEET_SYNC_BOOTSTRAP_TIMEOUT` seconds, default 20; a timeout is reported as a `FLEET_SYNC` skip and does not block startup.

$ sed -n "652,685p" AGENTS.md
- [x] <id> - <one line> - data/<id>/report.md (reported <date>)
`` `

Re-evaluate Queued on every teardown and every heartbeat: anything whose blocker is gone and whose time/date gate, if any, has arrived gets dispatched.

Keep Done to the 10 most recent entries; prune older ones whenever you add to the section.
Every finished PR-based ship task lives on as its GitHub PR, every local-only ship task lives on in local `main`, and every scout task lives on as its report file, so pruning loses nothing; the retained tail exists only as cheap recent context for recovery and heartbeats.

A tracked `.tasks.toml` at this repo root pins the `tasks-axi` markdown backend to `data/backlog.md`, with `done_keep = 10` and an archive at `data/done-archive.md`.
When a compatible `tasks-axi` is on PATH, firstmate mutates the backlog through its verbs instead of hand-editing, with secondmate handoffs still going through the validated helper described in section 6.
Compatible means the shared bootstrap probe accepts `tasks-axi --version` as 0.1.1 or newer.
The `## In flight` / `## Queued` / `## Done` format above stays the contract: the verbs edit `data/backlog.md` in place, byte-exact, preserving whatever item forms the file already uses - the bold in-flight `- **<id>**` form, the `- [ ]`/`- [x]` queued and done forms, and `blocked-by: <id> - <reason>` - rather than reformatting them.
Map firstmate's real backlog operations to the approved commands:

- File an item: `tasks-axi add <id> "<one line>" --kind <ship|scout> --repo <name>`, plus `--start` for immediate dispatch (In flight) or the default queue placement, and `--blocked-by <id>` (repeatable) when it waits on another task.
- Start an existing queued item: `tasks-axi start <id>` before dispatching work from Queued, after checking that blockers are gone and any time/date gate has arrived.
- Move a finished task to Done: `tasks-axi done <id> --pr <url>` for a PR-based ship, `--report <path>` for a scout, or `--note "local main"` for a local-only merge.
- Append a status note: `tasks-axi update <id> --append "<note>"`; replace fields with `--title`, `--body`, or `--body-file <path>`.
- Manage dependencies: `tasks-axi block <id> --by <other>` and `tasks-axi unblock <id> --by <other>`, then `tasks-axi ready` to list queued work with no unresolved blockers.
  This is a dependency check only; future-dated items still stay queued until their date arrives.
- Read an item's full notes: `tasks-axi show <id> --full`.
- Hand a task off to a secondmate home: keep using `bin/fm-backlog-handoff.sh <secondmate-id> <item-key>...`; do not call bare `tasks-axi mv` for this path, because the helper resolves and validates the secondmate home before moving anything.
- Normalize the file: `tasks-axi render` rewrites every id'd task in canonical form and leaves free-form lines untouched.

`tasks-axi done` auto-prunes Done to `done_keep = 10` and archives the pruned entries to `data/done-archive.md`, which supersedes the manual "keep Done to the 10 most recent" pruning above: when compatible `tasks-axi` is present you do not hand-prune Done, and nothing is lost because pruned entries are archived rather than deleted.
When `tasks-axi` is absent or fails the compatibility probe, every firstmate home (main and each secondmate) hand-edits `data/backlog.md` exactly as this section describes, including the manual Done pruning.
Secondmates inherit this automatically: each secondmate home carries the same `AGENTS.md` and its own `.tasks.toml`, so the same present-or-absent rule applies in every home with no separate setup.

## 11. Crewmate briefs

Scaffold with `bin/fm-brief.sh <id> <repo-name>` - it writes `data/<id>/brief.md` with the standard contract (branch setup, status-reporting protocol, push/merge rules, definition of done) and all paths filled in.
For a ship task the definition of done is shaped by the project's delivery mode (section 6): `no-mistakes` ends in the harness-appropriate no-mistakes validation pipeline, `direct-PR` has the crewmate push and open the PR itself, `local-only` has it stop at "ready in branch" for firstmate to review and merge locally.
The scaffold reads the mode via `fm-project-mode.sh`, so you do not pass it.
Ship briefs also include the project-memory contract: run `bin/fm-ensure-agents-md.sh` when the project already has agent-memory files or when the task produced durable project-intrinsic knowledge, then record proportionate learnings in `AGENTS.md`.
```
</details>
<details>
<summary>Evidence: tasks-axi help surface</summary>

```text
$ tasks-axi add --help
usage: tasks-axi add <id> "<title>" [flags]
aliases: create
flags:
  --kind <ship|scout|docs|...>, --repo <name>, --body <text> or --body-file <path>
  --start (place in In flight) | --queue (place in Queued, default)
  --blocked-by <id> (repeatable, must exist), --pr <url>, --report <path>, --priority <0-4>
  --mint [--prefix <p>]   mint a slug-xx id from the title instead of passing one
examples:
  tasks-axi add lavish-foo-q9 "fix summary toggle" --kind ship --repo lavish-axi --start
  tasks-axi add fm-x "adopt lease" --blocked-by treehouse-lease-t4
  tasks-axi add "quick note" --mint
$ tasks-axi start --help
usage: tasks-axi start <id>
Move a task to In flight (idempotent).
examples:
  tasks-axi start firstmate-treehouse-lease-adopt
$ tasks-axi done --help
usage: tasks-axi done <id> [flags]
aliases: close
Re-running on an already Done task backfills links/notes without changing the close date.
flags:
  --pr <url>, --report <path>, --note "<text>"
  --keep <n> (default from config), --no-prune
examples:
  tasks-axi done sm-idle-handoff-q8 --pr https://github.com/o/r/pull/42
  tasks-axi done pr31-review-r6 --report data/pr31-review-r6/report.md
$ tasks-axi update --help
usage: tasks-axi update <id> [flags]
aliases: edit
flags:
  --title <text>, --body <text> or --body-file <path>, --append "<note>"
  --repo <name>, --kind <name>, --priority <0-4>, --pr <url>, --report <path>
examples:
  tasks-axi update nm-release-validation --append "step 3 in progress on lavish #87"
  tasks-axi update fm-x --repo firstmate --kind ship
$ tasks-axi block --help
usage: tasks-axi block <id> --by <other>
Record a blocked-by dependency edge (idempotent).
The blocker named by --by must already exist.
examples:
  tasks-axi block firstmate-treehouse-lease-adopt --by treehouse-lease-t4
$ tasks-axi unblock --help
usage: tasks-axi unblock <id> --by <other>
Clear a blocked-by dependency edge (idempotent).
$ tasks-axi ready --help
usage: tasks-axi ready [--repo <name>]
List unblocked queued work - the tasks dispatchable right now.
$ tasks-axi show --help
usage: tasks-axi show <id> [--full]
aliases: view
examples:
  tasks-axi show homemux-h7
  tasks-axi show homemux-h7 --full
$ tasks-axi mv --help
usage: tasks-axi mv <id> --to <path-or-dir>
Move a task to another backlog file (generalizes a hand-rolled line move).
Fails while active tasks still block on this id.
examples:
  tasks-axi mv hibit-cert-cleanup --to ../homemux/data/backlog.md
$ tasks-axi render --help
usage: tasks-axi render
Normalize the backlog file: rewrite every id'd task in canonical form.
Free-form lines are left untouched.
```
</details>
<details>
<summary>Evidence: tasks-axi end-to-end transcript</summary>

```text
$ tasks-axi --version
0.1.1

$ cat .tasks.toml
backend = "markdown"

[markdown]
path = "data/backlog.md"
archive = "data/done-archive.md"
done_keep = 10

$ tasks-axi add prereq-a1 "ship prerequisite" --kind ship --repo firstmate
task:
  id: prereq-a1
  title: ship prerequisite
  state: queued
  blocked: no
  blocked_by: none
  kind: ship
  repo: firstmate
  priority: "-"
  created: 2026-06-23
  closed: "-"
  deps: none
  links: none
  body: ""
help[2]:
  - Run `tasks-axi start prereq-a1` to move it to in flight
  - Run `tasks-axi block prereq-a1 --by <other>` to record a dependency

$ tasks-axi add dependent-a1 "adopt tasks-axi mutations" --kind docs --repo firstmate --blocked-by prereq-a1
task:
  id: dependent-a1
  title: adopt tasks-axi mutations
  state: queued
  blocked: yes
  blocked_by: prereq-a1
  kind: docs
  repo: firstmate
  priority: "-"
  created: 2026-06-23
  closed: "-"
  deps: "blocked-by:prereq-a1"
  links: none
  body: ""
help[2]:
  - Run `tasks-axi start dependent-a1` to move it to in flight
  - Run `tasks-axi block dependent-a1 --by <other>` to record a dependency

$ tasks-axi ready
count: 1
ready[1]{id,state,kind,repo,title}:
  prereq-a1,queued,ship,firstmate,ship prerequisite
help[1]:
  - Run `tasks-axi start <id>` to dispatch one of these

$ tasks-axi start prereq-a1
start:
  id: prereq-a1
  state: in_flight
help[1]:
  - Run `tasks-axi done prereq-a1 --pr <url>` when it ships

$ tasks-axi update prereq-a1 --append "Validated compatible tasks-axi mutation path."
task:
  id: prereq-a1
  title: ship prerequisite
  state: in_flight
  blocked: no
  blocked_by: none
  kind: ship
  repo: firstmate
  priority: "-"
  created: 2026-06-23
  closed: "-"
  deps: none
  links: none
  body: Validated compatible tasks-axi mutation path.
help[1]:
  - Run `tasks-axi show prereq-a1 --full` to see the result

$ tasks-axi show prereq-a1 --full
task:
  id: prereq-a1
  title: ship prerequisite
  state: in_flight
  blocked: no
  blocked_by: none
  kind: ship
  repo: firstmate
  priority: "-"
  created: 2026-06-23
  closed: "-"
  deps: none
  links: none
  body: Validated compatible tasks-axi mutation path.

$ tasks-axi done prereq-a1 --pr https://github.com/kunchenguid/firstmate/pull/58
done:
  id: prereq-a1
  state: done
  pruned: 0
help[1]:
  - Run `tasks-axi ready` to dispatch work unblocked by this

$ tasks-axi ready
count: 1
ready[1]{id,state,kind,repo,title}:
  dependent-a1,queued,docs,firstmate,adopt tasks-axi mutations
help[1]:
  - Run `tasks-axi start <id>` to dispatch one of these

$ tasks-axi add manual-blocker-a1 "manual blocker" --kind ship --repo firstmate
task:
  id: manual-blocker-a1
  title: manual blocker
  state: queued
  blocked: no
  blocked_by: none
  kind: ship
  repo: firstmate
  priority: "-"
  created: 2026-06-23
  closed: "-"
  deps: none
  links: none
  body: ""
help[2]:
  - Run `tasks-axi start manual-blocker-a1` to move it to in flight
  - Run `tasks-axi block manual-blocker-a1 --by <other>` to record a dependency

$ tasks-axi block dependent-a1 --by manual-blocker-a1
block:
  id: dependent-a1
  blocked_by: manual-blocker-a1
help[2]:
  - Run `tasks-axi unblock dependent-a1 --by <other>` to clear it
  - Run `tasks-axi ready` to see what is still dispatchable

$ tasks-axi ready
count: 1
ready[1]{id,state,kind,repo,title}:
  manual-blocker-a1,queued,ship,firstmate,manual blocker
help[1]:
  - Run `tasks-axi start <id>` to dispatch one of these

$ tasks-axi unblock dependent-a1 --by manual-blocker-a1
unblock:
  id: dependent-a1
  blocked_by: manual-blocker-a1
help[1]:
  - Run `tasks-axi ready` to see newly unblocked work

$ tasks-axi start dependent-a1
start:
  id: dependent-a1
  state: in_flight
help[1]:
  - Run `tasks-axi done dependent-a1 --pr <url>` when it ships

$ tasks-axi done dependent-a1 --pr https://github.com/kunchenguid/firstmate/pull/58
done:
  id: dependent-a1
  state: done
  pruned: 0
help[1]:
  - Run `tasks-axi ready` to dispatch work unblocked by this

$ tasks-axi add archive-sample-01 "completed backlog sample 01" --kind ship --repo firstmate --start
task:
  id: archive-sample-01
  title: completed backlog sample 01
  state: in_flight
  blocked: no
  blocked_by: none
  kind: ship
  repo: firstmate
  priority: "-"
  created: 2026-06-23
  closed: "-"
  deps: none
  links: none
  body: ""
help[2]:
  - Run `tasks-axi start archive-sample-01` to move it to in flight
  - Run `tasks-axi block archive-sample-01 --by <other>` to record a dependency

$ tasks-axi done archive-sample-01 --note "fixture complete"
done:
  id: archive-sample-01
  state: done
  pruned: 0
help[1]:
  - Run `tasks-axi ready` to dispatch work unblocked by this

$ tasks-axi add archive-sample-02 "completed backlog sample 02" --kind ship --repo firstmate --start
task:
  id: archive-sample-02
  title: completed backlog sample 02
  state: in_flight
  blocked: no
  blocked_by: none
  kind: ship
  repo: firstmate
  priority: "-"
  created: 2026-06-23
  closed: "-"
  deps: none
  links: none
  body: ""
help[2]:
  - Run `tasks-axi start archive-sample-02` to move it to in flight
  - Run `tasks-axi block archive-sample-02 --by <other>` to record a dependency

$ tasks-axi done archive-sample-02 --note "fixture complete"
done:
  id: archive-sample-02
  state: done
  pruned: 0
help[1]:
  - Run `tasks-axi ready` to dispatch work unblocked by this

$ tasks-axi add archive-sample-03 "completed backlog sample 03" --kind ship --repo firstmate --start
task:
  id: archive-sample-03
  title: completed backlog sample 03
  state: in_flight
  blocked: no
  blocked_by: none
  kind: ship
  repo: firstmate
  priority: "-"
  created: 2026-06-23
  closed: "-"
  deps: none
  links: none
  body: ""
help[2]:
  - Run `tasks-axi start archive-sample-03` to move it to in flight
  - Run `tasks-axi block archive-sample-03 --by <other>` to record a dependency

$ tasks-axi done archive-sample-03 --note "fixture complete"
done:
  id: archive-sample-03
  state: done
  pruned: 0
help[1]:
  - Run `tasks-axi ready` to dispatch work unblocked by this

$ tasks-axi add archive-sample-04 "completed backlog sample 04" --kind ship --repo firstmate --start
task:
  id: archive-sample-04
  title: completed backlog sample 04
  state: in_flight
  blocked: no
  blocked_by: none
  kind: ship
  repo: firstmate
  priority: "-"
  created: 2026-06-23
  closed: "-"
  deps: none
  links: none
  body: ""
help[2]:
  - Run `tasks-axi start archive-sample-04` to move it to in flight
  - Run `tasks-axi block archive-sample-04 --by <other>` to record a dependency

$ tasks-axi done archive-sample-04 --note "fixture complete"
done:
  id: archive-sample-04
  state: done
  pruned: 0
help[1]:
  - Run `tasks-axi ready` to dispatch work unblocked by this

$ tasks-axi add archive-sample-05 "completed backlog sample 05" --kind ship --repo firstmate --start
task:
  id: archive-sample-05
  title: completed backlog sample 05
  state: in_flight
  blocked: no
  blocked_by: none
  kind: ship
  repo: firstmate
  priority: "-"
  created: 2026-06-23
  closed: "-"
  deps: none
  links: none
  body: ""
help[2]:
  - Run `tasks-axi start archive-sample-05` to move it to in flight
  - Run `tasks-axi block archive-sample-05 --by <other>` to record a dependency

$ tasks-axi done archive-sample-05 --note "fixture complete"
done:
  id: archive-sample-05
  state: done
  pruned: 0
help[1]:
  - Run `tasks-axi ready` to dispatch work unblocked by this

$ tasks-axi add archive-sample-06 "completed backlog sample 06" --kind ship --repo firstmate --start
task:
  id: archive-sample-06
  title: completed backlog sample 06
  state: in_flight
  blocked: no
  blocked_by: none
  kind: ship
  repo: firstmate
  priority: "-"
  created: 2026-06-23
  closed: "-"
  deps: none
  links: none
  body: ""
help[2]:
  - Run `tasks-axi start archive-sample-06` to move it to in flight
  - Run `tasks-axi block archive-sample-06 --by <other>` to record a dependency

$ tasks-axi done archive-sample-06 --note "fixture complete"
done:
  id: archive-sample-06
  state: done
  pruned: 0
help[1]:
  - Run `tasks-axi ready` to dispatch work unblocked by this

$ tasks-axi add archive-sample-07 "completed backlog sample 07" --kind ship --repo firstmate --start
task:
  id: archive-sample-07
  title: completed backlog sample 07
  state: in_flight
  blocked: no
  blocked_by: none
  kind: ship
  repo: firstmate
  priority: "-"
  created: 2026-06-23
  closed: "-"
  deps: none
  links: none
  body: ""
help[2]:
  - Run `tasks-axi start archive-sample-07` to move it to in flight
  - Run `tasks-axi block archive-sample-07 --by <other>` to record a dependency

$ tasks-axi done archive-sample-07 --note "fixture complete"
done:
  id: archive-sample-07
  state: done
  pruned: 0
help[1]:
  - Run `tasks-axi ready` to dispatch work unblocked by this

$ tasks-axi add archive-sample-08 "completed backlog sample 08" --kind ship --repo firstmate --start
task:
  id: archive-sample-08
  title: completed backlog sample 08
  state: in_flight
  blocked: no
  blocked_by: none
  kind: ship
  repo: firstmate
  priority: "-"
  created: 2026-06-23
  closed: "-"
  deps: none
  links: none
  body: ""
help[2]:
  - Run `tasks-axi start archive-sample-08` to move it to in flight
  - Run `tasks-axi block archive-sample-08 --by <other>` to record a dependency

$ tasks-axi done archive-sample-08 --note "fixture complete"
done:
  id: archive-sample-08
  state: done
  pruned: 0
help[1]:
  - Run `tasks-axi ready` to dispatch work unblocked by this

$ tasks-axi add archive-sample-09 "completed backlog sample 09" --kind ship --repo firstmate --start
task:
  id: archive-sample-09
  title: completed backlog sample 09
  state: in_flight
  blocked: no
  blocked_by: none
  kind: ship
  repo: firstmate
  priority: "-"
  created: 2026-06-23
  closed: "-"
  deps: none
  links: none
  body: ""
help[2]:
  - Run `tasks-axi start archive-sample-09` to move it to in flight
  - Run `tasks-axi block archive-sample-09 --by <other>` to record a dependency

$ tasks-axi done archive-sample-09 --note "fixture complete"
done:
  id: archive-sample-09
  state: done
  pruned: 1
help[1]:
  - Run `tasks-axi ready` to dispatch work unblocked by this

$ tasks-axi add archive-sample-10 "completed backlog sample 10" --kind ship --repo firstmate --start
task:
  id: archive-sample-10
  title: completed backlog sample 10
  state: in_flight
  blocked: no
  blocked_by: none
  kind: ship
  repo: firstmate
  priority: "-"
  created: 2026-06-23
  closed: "-"
  deps: none
  links: none
  body: ""
help[2]:
  - Run `tasks-axi start archive-sample-10` to move it to in flight
  - Run `tasks-axi block archive-sample-10 --by <other>` to record a dependency

$ tasks-axi done archive-sample-10 --note "fixture complete"
done:
  id: archive-sample-10
  state: done
  pruned: 1
help[1]:
  - Run `tasks-axi ready` to dispatch work unblocked by this

$ tasks-axi add archive-sample-11 "completed backlog sample 11" --kind ship --repo firstmate --start
task:
  id: archive-sample-11
  title: completed backlog sample 11
  state: in_flight
  blocked: no
  blocked_by: none
  kind: ship
  repo: firstmate
  priority: "-"
  created: 2026-06-23
  closed: "-"
  deps: none
  links: none
  body: ""
help[2]:
  - Run `tasks-axi start archive-sample-11` to move it to in flight
  - Run `tasks-axi block archive-sample-11 --by <other>` to record a dependency

$ tasks-axi done archive-sample-11 --note "fixture complete"
done:
  id: archive-sample-11
  state: done
  pruned: 1
help[1]:
  - Run `tasks-axi ready` to dispatch work unblocked by this

$ tasks-axi render
render:
  normalized: 11

$ tasks-axi show archive-sample-11 --full
task:
  id: archive-sample-11
  title: completed backlog sample 11
  state: done
  blocked: no
  blocked_by: none
  kind: ship
  repo: firstmate
  priority: "-"
  created: "-"
  closed: 2026-06-23
  deps: none
  links: none
  body: fixture complete

$ tasks-axi ready
count: 1
ready[1]{id,state,kind,repo,title}:
  manual-blocker-a1,queued,ship,firstmate,manual blocker
help[1]:
  - Run `tasks-axi start <id>` to dispatch one of these

$ sed -n "1,220p" data/backlog.md
# Backlog

## In flight
## Queued
- [ ] manual-blocker-a1 - manual blocker (repo: firstmate) (kind: ship) (since 2026-06-23)
## Done
- [x] archive-sample-11 - completed backlog sample 11 (repo: firstmate) (kind: ship) (done 2026-06-23)
  fixture complete
- [x] archive-sample-10 - completed backlog sample 10 (repo: firstmate) (kind: ship) (done 2026-06-23)
  fixture complete
- [x] archive-sample-09 - completed backlog sample 09 (repo: firstmate) (kind: ship) (done 2026-06-23)
  fixture complete
- [x] archive-sample-08 - completed backlog sample 08 (repo: firstmate) (kind: ship) (done 2026-06-23)
  fixture complete
- [x] archive-sample-07 - completed backlog sample 07 (repo: firstmate) (kind: ship) (done 2026-06-23)
  fixture complete
- [x] archive-sample-06 - completed backlog sample 06 (repo: firstmate) (kind: ship) (done 2026-06-23)
  fixture complete
- [x] archive-sample-05 - completed backlog sample 05 (repo: firstmate) (kind: ship) (done 2026-06-23)
  fixture complete
- [x] archive-sample-04 - completed backlog sample 04 (repo: firstmate) (kind: ship) (done 2026-06-23)
  fixture complete
- [x] archive-sample-03 - completed backlog sample 03 (repo: firstmate) (kind: ship) (done 2026-06-23)
  fixture complete
- [x] archive-sample-02 - completed backlog sample 02 (repo: firstmate) (kind: ship) (done 2026-06-23)
  fixture complete

$ sed -n "1,220p" data/done-archive.md

## Archived 2026-06-23
- [x] prereq-a1 - ship prerequisite https://github.com/kunchenguid/firstmate/pull/58 (repo: firstmate) (kind: ship) (merged 2026-06-23)
  Validated compatible tasks-axi mutation path.

## Archived 2026-06-23
- [x] dependent-a1 - adopt tasks-axi mutations https://github.com/kunchenguid/firstmate/pull/58 blocked-by: prereq-a1 (repo: firstmate) (kind: docs) (merged 2026-06-23)

## Archived 2026-06-23
- [x] archive-sample-01 - completed backlog sample 01 (repo: firstmate) (kind: ship) (done 2026-06-23)
  fixture complete
```
</details>
<details>
<summary>Evidence: fixture backlog after tasks-axi render</summary>

```text
# Backlog

## In flight
## Queued
- [ ] manual-blocker-a1 - manual blocker (repo: firstmate) (kind: ship) (since 2026-06-23)
## Done
- [x] archive-sample-11 - completed backlog sample 11 (repo: firstmate) (kind: ship) (done 2026-06-23)
  fixture complete
- [x] archive-sample-10 - completed backlog sample 10 (repo: firstmate) (kind: ship) (done 2026-06-23)
  fixture complete
- [x] archive-sample-09 - completed backlog sample 09 (repo: firstmate) (kind: ship) (done 2026-06-23)
  fixture complete
- [x] archive-sample-08 - completed backlog sample 08 (repo: firstmate) (kind: ship) (done 2026-06-23)
  fixture complete
- [x] archive-sample-07 - completed backlog sample 07 (repo: firstmate) (kind: ship) (done 2026-06-23)
  fixture complete
- [x] archive-sample-06 - completed backlog sample 06 (repo: firstmate) (kind: ship) (done 2026-06-23)
  fixture complete
- [x] archive-sample-05 - completed backlog sample 05 (repo: firstmate) (kind: ship) (done 2026-06-23)
  fixture complete
- [x] archive-sample-04 - completed backlog sample 04 (repo: firstmate) (kind: ship) (done 2026-06-23)
  fixture complete
- [x] archive-sample-03 - completed backlog sample 03 (repo: firstmate) (kind: ship) (done 2026-06-23)
  fixture complete
- [x] archive-sample-02 - completed backlog sample 02 (repo: firstmate) (kind: ship) (done 2026-06-23)
  fixture complete
```
</details>
<details>
<summary>Evidence: fixture done archive</summary>

```text

## Archived 2026-06-23
- [x] prereq-a1 - ship prerequisite https://github.com/kunchenguid/firstmate/pull/58 (repo: firstmate) (kind: ship) (merged 2026-06-23)
  Validated compatible tasks-axi mutation path.

## Archived 2026-06-23
- [x] dependent-a1 - adopt tasks-axi mutations https://github.com/kunchenguid/firstmate/pull/58 blocked-by: prereq-a1 (repo: firstmate) (kind: docs) (merged 2026-06-23)

## Archived 2026-06-23
- [x] archive-sample-01 - completed backlog sample 01 (repo: firstmate) (kind: ship) (done 2026-06-23)
  fixture complete
```
</details>
<details>
<summary>Evidence: bootstrap test transcript</summary>

```text
ok - bootstrap accepts treehouse get --lease support
ok - bootstrap reports treehouse without get --lease support
ok - bootstrap reports compatible optional tasks-axi availability
ok - bootstrap ignores incompatible optional tasks-axi
```
</details>
<details>
<summary>Evidence: teardown test transcript</summary>

```text
ok - local-only worktree with HEAD on a fork remote is torn down (fix holds)
ok - teardown prompts tasks-axi backlog refresh when compatible
ok - local-only worktree with truly unpushed work is refused (safety preserved)
ok - local-only worktree with work merged into local main is torn down (no regression)
ok - no-mistakes worktree with HEAD on origin is torn down (no regression)
ok - no-mistakes worktree with truly unpushed work is refused (no regression)
ok - local-only worktree with unpushed work is torn down under --force (escape hatch)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed (3) ✅</summary>

- 🚨 `AGENTS.md:663` - The active tasks-axi policy omits the dispatch path for an existing queued task. Section 7 still requires re-evaluating Queued and dispatching unblocked or date-due work, but under the new &#39;no hand-editing when tasks-axi is present&#39; rule the documented verb list only covers `add --start` for new immediate dispatch and never tells firstmate to run `tasks-axi start &lt;id&gt;` for an already-queued item. That can leave launched work recorded as Queued, making recovery or heartbeat dispatch it again.
- ⚠️ `AGENTS.md:668` - This new mapping tells firstmate to hand off secondmate work with bare `tasks-axi mv`, but the rest of AGENTS.md still directs handoffs through `bin/fm-backlog-handoff.sh`. That helper resolves the registered secondmate home, validates the `.fm-secondmate-home` marker, refuses in-flight items, and provides idempotent all-or-nothing moves. The new policy either conflicts with those existing instructions or bypasses their firstmate-specific safety checks, so the handoff path should be reconciled before enabling mandatory tasks-axi mutations.
- ⚠️ `AGENTS.md:659` - The README still says tasks-axi is detection-only and backlog mutations remain manual, contradicting the new active policy here. Since README is the public operator overview, merge would leave two repo-level sources giving opposite instructions about whether firstmate should use tasks-axi.

🔧 Fix: Captain, document tasks-axi start and handoff policy
2 warnings still open:
- ⚠️ `AGENTS.md:115` - The new policy activates tasks-axi for any executable on PATH, but bootstrap still detects it with a bare command-v check while section 10 relies on 0.1.1-specific verbs, flags, pruning, and format compatibility. An older incompatible tasks-axi install would now be treated as safe and could fail or mutate the durable backlog incorrectly. Gate adoption on a version or feature probe, or explicitly fall back to manual edits when the probe fails.
- ⚠️ `AGENTS.md:672` - This says tasks-axi done supersedes manual Done pruning, but the operational teardown path still tells firstmate to move the task to Done and keep Done to 10 manually, including the printed prompt in bin/fm-teardown.sh. Since that prompt appears at the exact moment the backlog must be updated, it can steer agents around tasks-axi done and skip archive-backed pruning. Update the teardown instructions or prompt to use tasks-axi done when available.

🔧 Fix: Gate tasks-axi adoption and teardown prompts
1 warning still open:
- ⚠️ `AGENTS.md:670` - `tasks-axi ready` only reports queued tasks without unresolved blockers, but the existing protocol also treats future date-gated queued items as not dispatchable until their date arrives. This line now describes `ready` as a complete &#39;dispatchable right now&#39; list, so a firstmate following the new policy can start future-dated work early. Clarify that `ready` is dependency-only and that date gates still need the existing manual check before `tasks-axi start`.

🔧 Fix: Clarify tasks-axi date gates
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff 3718fd0cd010a0a2668493d8c11eeb6331904d7d..f33ebc40e8dfd68183348e5e415585af30f6e54f -- AGENTS.md README.md bin/fm-bootstrap.sh bin/fm-tasks-axi-lib.sh bin/fm-teardown.sh tests/fm-bootstrap.test.sh tests/fm-teardown.test.sh`
- `tests/fm-bootstrap.test.sh > /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVV986B2GZC3950RQ7CS223X/fm-bootstrap.test.log 2>&1`
- `tests/fm-teardown.test.sh > /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVV986B2GZC3950RQ7CS223X/fm-teardown.test.log 2>&1`
- <code>`command -v tasks-axi` and `tasks-axi --version`</code>
- <code>`tasks-axi --help`, `tasks-axi add --help`, `tasks-axi done --help`, and `tasks-axi ready --help`</code>
- `for cmd in add start done update block unblock ready show mv render; do tasks-axi "$cmd" --help; done > /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVV986B2GZC3950RQ7CS223X/tasks-axi-help-surface.log`
- <code>`./run-e2e.sh &gt; /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVV986B2GZC3950RQ7CS223X/tasks-axi-e2e.log 2&gt;&amp;1` from the evidence fixture</code>
- <code>`readlink CLAUDE.md`, `cat .tasks.toml`, and targeted `sed` excerpts from `AGENTS.md` into `policy-excerpts.txt`</code>
- <code>`git status --short` after testing to confirm no worktree artifacts were left behind</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
