### PR TITLE
fix: preserve watcher check wakes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,7 @@ state/               volatile runtime signals; gitignored
   .wake-queue        durable queued wakes: epoch<TAB>seq<TAB>kind<TAB>key<TAB>payload
   .afk               durable away-mode flag; present = sub-supervisor may inject escalations (set by /afk, cleared on user return)
   .watch.lock .wake-queue.lock watcher singleton and queue serialization locks
-  .hash-* .count-* .stale-* .seen-* .last-* .heartbeat-streak   watcher internals; never touch
+  .hash-* .count-* .stale-* .seen-* .babysit-* .escalated-* .last-* .heartbeat-streak   watcher internals; never touch
   .last-watcher-beat watcher liveness beacon, touched every poll; fm-guard.sh reads it
   .subsuper-* .supervise-daemon.*   sub-supervisor internals (stale markers, escalation buffer, inject-wedged marker, seen-status dedup, log, lock, pid); never touch
 .no-mistakes/        local validation state and evidence; gitignored
@@ -439,7 +439,7 @@ Use chat for yes/no decisions; use lavish-axi when there are multiple findings o
 For PR-based ship tasks, the ready signal depends on mode: `no-mistakes` reports `done: PR <url> checks green` after CI is green, while `direct-PR` reports `done: PR <url>` after opening the PR.
 Run `bin/fm-pr-check.sh <id> <PR url>` - it records `pr=` in the task's meta and arms the watcher's merge poll.
 Tell the captain: the PR's full URL (always the complete `https://...` link, never a bare `#number` - the captain's terminal makes a full URL clickable), a one-paragraph summary, and, for `no-mistakes`, the risk level it emitted.
-(The check contract, for any custom `state/<id>.check.sh` you write yourself: print one line only when firstmate should wake, print nothing otherwise, and finish before `FM_CHECK_TIMEOUT`.)
+(The check contract, for any custom `state/<id>.check.sh` you write yourself: prefer printing the current terminal state every run, such as `echo "merged"` while merged. The watcher dedups repeated output with `.seen-check-<name>` and enqueues to the durable queue before advancing that marker, so a lost stdout or crashed watcher cannot swallow a wake. Edge-triggered checks that self-suppress with `.babysit-*.seen` still work, but a swallowed terminal transition then relies on the watcher catch-all backstop. Finish before `FM_CHECK_TIMEOUT`.)
 
 If the captain says "merge it", run `gh-axi pr merge` yourself; that instruction is the explicit approval. If `yolo=on`, merge a green/approved PR yourself and post the required FYI.
 
@@ -485,7 +485,7 @@ From there the task is an ordinary ship task through its mode-specific validatio
 The watcher is the backbone.
 Whenever at least one task is in flight, `bin/fm-watch.sh` must be running as a background task.
 It costs zero tokens while running and exits with one reason line when something needs you.
-It also writes each detected wake to the durable queue at `state/.wake-queue` before advancing suppression markers such as `.seen-*`, `.stale-*`, `.last-check`, or `.last-heartbeat`.
+It also writes each detected wake to the durable queue at `state/.wake-queue` before advancing suppression markers such as `.seen-*`, `.stale-*`, `.seen-check-*`, `.escalated-*`, `.last-check`, or `.last-heartbeat`.
 At the start of every wake-handling turn and every recovery turn, run `bin/fm-wake-drain.sh` before peeking panes, reading status files beyond the reason line, or starting new work.
 The printed one-shot reason line is still useful, but the drained queue is the lossless backlog.
 After handling drained wakes, re-arm `bin/fm-watch.sh` before you end the turn.

--- a/README.md
+++ b/README.md
@@ -230,20 +230,20 @@ Tracked changes to firstmate itself, including `AGENTS.md`, `README.md`, `CONTRI
 When supervising live crewmates, keep long validation or build work in the background so watcher wakes can still be handled.
 Human-authored pull requests targeting `main` must be raised through `git push no-mistakes`; see `CONTRIBUTING.md` for the enforced contributor workflow.
 Local `.no-mistakes/` state and test evidence stay out of this repo; `.no-mistakes.yaml` keeps evidence in a temp directory instead.
-The current watcher reliability work keeps the one-shot process model and adds a durable queue plus singleton lock.
+The current watcher reliability work keeps the one-shot process model and adds a durable queue, singleton lock, and lossless check-output dedup.
 The presence-gated sub-supervisor (`bin/fm-supervise-daemon.sh`) provides proactive wake routing for walk-away supervision via the `/afk` skill; a blocking-waiter split remains a deferred follow-up phase.
 
 ```sh
 bash -n bin/*.sh                          # syntax-check the toolbelt
 shellcheck bin/*.sh tests/*.sh            # lint the toolbelt and behavior tests; CI enforces this
 for test_script in tests/*.test.sh; do "$test_script"; done   # behavior tests, matching CI
-tests/fm-wake-queue.test.sh               # durable wake queue, singleton behavior, sub-supervisor classifier, /afk presence-gating, border-aware composer, max-defer, and fm-send submit tests
+tests/fm-wake-queue.test.sh               # durable wake queue, lossless check dedup, singleton behavior, sub-supervisor classifier, /afk presence-gating, border-aware composer, max-defer, and fm-send submit tests
 tests/fm-composer-ghost.test.sh           # dim-ghost stripping, ghost-only composer detection, and escape-free peek tests
 tests/fm-afk-inject-e2e.test.sh           # private-socket end-to-end test of the afk injection path (partial-input deferral, swallowed-Enter retry)
 tests/fm-bootstrap.test.sh                # bootstrap dependency and feature-probe tests
 tests/fm-update.test.sh                   # fast-forward-only self-update, reread, nudge, dedup, and skip-safety tests
 tests/fm-secondmate.test.sh               # persistent secondmate routing, seeding, idle charter, backlog handoff, spawn, recovery, teardown, and FM_HOME tests
-tests/fm-teardown.test.sh                 # fm-teardown.sh safety and reminder checks: local-only fork-remote allow, truly-unpushed refuse, merged-to-main allow, no-mistakes regression, tasks-axi reminder, --force override
+tests/fm-teardown.test.sh                 # fm-teardown.sh safety and reminder checks: local-only fork-remote allow, truly-unpushed refuse, merged-to-main allow, no-mistakes regression, tasks-axi reminder, check-dedup cleanup, --force override
 [ "$(readlink CLAUDE.md)" = "AGENTS.md" ]
 [ "$(readlink .claude/skills)" = "../.agents/skills" ]
 FM_HEARTBEAT=2 FM_POLL=1 bin/fm-watch.sh  # watcher smoke test (prints "heartbeat")

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ firstmate works from any terminal - outside tmux, crewmates land in a detached `
 
 - **Event-driven supervision** - a zero-token bash watcher (`bin/fm-watch.sh`) sleeps on the fleet and wakes the first mate only when a crewmate reports, stalls, a PR merges, or an internal heartbeat review is due.
   Detected wakes are also written to a durable local queue (`state/.wake-queue`) before detector state advances, so a missed one-shot process exit can be recovered by draining the queue.
+  Custom slow checks should print their current terminal state idempotently; the watcher dedups repeated output and keeps a catch-all backstop for legacy self-suppressing `.babysit-*.seen` checks.
   Routine watcher polling, restarts, elapsed waiting time, and unchanged heartbeat reviews stay silent; an idle crew costs you nothing.
   A pull-based guard (`bin/fm-guard.sh`) warns through supervision tool output if tasks are in flight and that watcher stops running or queued wakes are waiting to be drained.
   A presence-gated sub-supervisor (`bin/fm-supervise-daemon.sh`) extends this for walk-away supervision: the `/afk` skill activates it, after which it self-handles routine wakes in bash and escalates only captain-relevant events as one batched, single-line digest (prefixed with an in-band sentinel marker so firstmate can tell daemon injections apart from real messages).

--- a/bin/fm-pr-check.sh
+++ b/bin/fm-pr-check.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # Record a PR-ready task: appends pr=<url> to state/<id>.meta and arms the
-# watcher's merge poll by writing state/<id>.check.sh, which prints one line iff
-# the PR is merged (the watcher's check contract: output = wake firstmate,
-# silence = keep sleeping).
+# watcher's merge poll by writing state/<id>.check.sh. Once the PR is merged,
+# the check prints the current terminal state every run; the watcher dedups the
+# repeated output and enqueues the first delta before advancing suppression.
+# Silence means "no current terminal state; keep sleeping."
 # Usage: fm-pr-check.sh <task-id> <pr-url>
 set -eu
 

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -72,6 +72,23 @@ meta_value() {
   grep "^$key=" "$meta" | cut -d= -f2- || true
 }
 
+sanitize_state_name() { printf '%s' "$1" | LC_ALL=C tr -c 'A-Za-z0-9._-' '_'; }
+
+cleanup_task_state() {
+  local state=$1 id=$2 check_name sidecar_name
+  check_name=$(sanitize_state_name "$id.check.sh")
+  sidecar_name=$(sanitize_state_name ".babysit-$id.seen")
+  rm -f \
+    "$state/$id.status" \
+    "$state/$id.turn-ended" \
+    "$state/$id.check.sh" \
+    "$state/$id.meta" \
+    "$state/$id.pi-ext.ts" \
+    "$state/.seen-check-$check_name" \
+    "$state/.babysit-$id.seen" \
+    "$state/.escalated-$sidecar_name"
+}
+
 backlog_refresh_reminder() {
   local pr done_cmd report_path
   if fm_tasks_axi_compatible; then
@@ -479,7 +496,7 @@ if [ "$KIND" = secondmate ]; then
   remove_firstmate_home "$HOME_PATH" "secondmate home" "$ID"
   remove_secondmate_registry_entry "$ID"
 fi
-rm -f "$STATE/$ID.status" "$STATE/$ID.turn-ended" "$STATE/$ID.check.sh" "$STATE/$ID.meta" "$STATE/$ID.pi-ext.ts"
+cleanup_task_state "$STATE" "$ID"
 if [ "$KIND" != scout ] && [ "$KIND" != secondmate ] && [ "$MODE" != local-only ]; then
   "$FM_ROOT/bin/fm-fleet-sync.sh" "$PROJ" || true
 fi

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -107,6 +107,25 @@ recorded_windows() {
 # files (.seen-check-*, .escalated-*). LC_ALL=C keeps the mapping byte-stable.
 sanitize_name() { printf '%s' "$1" | LC_ALL=C tr -c 'A-Za-z0-9._-' '_'; }
 
+mark_matching_babysit_escalated() {
+  local c=$1 base id sidecar terminal state ec
+  base=$(basename "$c")
+  case "$base" in
+    *.check.sh) id=${base%.check.sh} ;;
+    *) return 0 ;;
+  esac
+  sidecar="$STATE/.babysit-$id.seen"
+  [ -e "$sidecar" ] || return 0
+  terminal=$(cat "$sidecar" 2>/dev/null || true)
+  state=${terminal%%|*}
+  case "$state" in
+    MERGED|CLOSED) ;;
+    *) return 0 ;;
+  esac
+  ec="$STATE/.escalated-$(sanitize_name "$(basename "$sidecar")")"
+  printf '%s' "$terminal" > "$ec"
+}
+
 # Exit reporting a wake. Consecutive heartbeats with no other wake in between
 # mean an idle fleet, so the heartbeat interval backs off exponentially
 # (base * 2^streak, capped at HEARTBEAT_MAX); any real wake resets the cadence.
@@ -194,6 +213,7 @@ while :; do
         # Test-only hook: prove the wake is durable by simulating a crash
         # between enqueue and suppress. Never set outside the test suite.
         [ -n "${FM_WATCH_BREAK_AFTER_CHECK_ENQUEUE:-}" ] && exit 99
+        mark_matching_babysit_escalated "$c"
         printf '%s' "$out" > "$sf"
         touch "$STATE/.last-check"
         wake "$reason"

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -4,7 +4,9 @@
 #   signal: <file>...     a crewmate wrote a status line or a turn-end hook fired; signals
 #                         landing within FM_SIGNAL_GRACE of each other coalesce into one wake
 #   stale: <window>       a crewmate pane stopped changing and shows no busy signature
-#   check: <script>: <out> a per-task check script (e.g. merged-PR poll) produced output
+#   check: <script>: <out> a per-task check produced output (deduped by the watcher;
+#                         enqueued before suppression so the wake is lossless), or the
+#                         catch-all force-escalated a swallowed terminal transition
 #   heartbeat              fleet review due; starts at FM_HEARTBEAT and backs off to FM_HEARTBEAT_MAX
 # Run as a background task. Re-arm it after handling each wake; duplicate
 # invocations no-op through the watcher singleton lock.
@@ -101,6 +103,10 @@ recorded_windows() {
   done
 }
 
+# Collapse a check/sidecar basename into a safe suffix for watcher-side state
+# files (.seen-check-*, .escalated-*). LC_ALL=C keeps the mapping byte-stable.
+sanitize_name() { printf '%s' "$1" | LC_ALL=C tr -c 'A-Za-z0-9._-' '_'; }
+
 # Exit reporting a wake. Consecutive heartbeats with no other wake in between
 # mean an idle fleet, so the heartbeat interval backs off exponentially
 # (base * 2^streak, capped at HEARTBEAT_MAX); any real wake resets the cadence.
@@ -168,16 +174,47 @@ while :; do
   # keeps producing signals - the slow poll (e.g. merge detection) would then
   # never run until the fleet went quiet. Checks are due only every
   # CHECK_INTERVAL, so most cycles skip this block and fall straight through.
+  #
+  # Lossless check wakes: checks used to be the sole wake source whose
+  # suppression could live inside an opaque script. If an edge-triggered check
+  # advanced its own .babysit-*.seen marker before stdout became a delivered
+  # wake, a timeout, crash, or concurrent run could permanently swallow the
+  # transition. Suppression now lives in the watcher for stateless checks:
+  # enqueue first, then advance .seen-check-<name>. Old self-suppressing checks
+  # still work, and the catch-all below force-escalates terminal sidecars.
   if [ "$(age_of "$STATE/.last-check")" -ge "$CHECK_INTERVAL" ]; then
     for c in "$STATE"/*.check.sh; do
       [ -e "$c" ] || continue
       out=$(run_check "$c")
-      if [ -n "$out" ]; then
+      [ -n "$out" ] || continue
+      sf="$STATE/.seen-check-$(sanitize_name "$(basename "$c")")"
+      if [ "$out" != "$(cat "$sf" 2>/dev/null || true)" ]; then
         reason="check: $c: $out"
         fm_wake_append check "$c" "$reason" || exit 1
+        # Test-only hook: prove the wake is durable by simulating a crash
+        # between enqueue and suppress. Never set outside the test suite.
+        [ -n "${FM_WATCH_BREAK_AFTER_CHECK_ENQUEUE:-}" ] && exit 99
+        printf '%s' "$out" > "$sf"
         touch "$STATE/.last-check"
         wake "$reason"
       fi
+    done
+
+    for sf in "$STATE"/.babysit-*.seen; do
+      [ -e "$sf" ] || continue
+      terminal=$(cat "$sf" 2>/dev/null || true)
+      state=${terminal%%|*}
+      case "$state" in
+        MERGED|CLOSED) ;;
+        *) continue ;;
+      esac
+      ec="$STATE/.escalated-$(sanitize_name "$(basename "$sf")")"
+      [ "$terminal" = "$(cat "$ec" 2>/dev/null || true)" ] && continue
+      reason="check: catch-all: $sf: $state"
+      fm_wake_append check "$sf" "$reason" || exit 1
+      printf '%s' "$terminal" > "$ec"
+      touch "$STATE/.last-check"
+      wake "$reason"
     done
     touch "$STATE/.last-check"
   fi

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -273,6 +273,31 @@ test_local_only_force_overrides_unpushed() {
   pass "local-only worktree with unpushed work is torn down under --force (escape hatch)"
 }
 
+test_teardown_removes_check_dedup_state() {
+  local case_dir rc
+  case_dir=$(make_case check-dedup-cleanup)
+  write_meta "$case_dir" no-mistakes ship
+  wt_commit "$case_dir" "shippable work"
+  git -C "$case_dir/wt" push -q origin fm/task-x1
+  git -C "$case_dir/project" fetch -q origin
+  printf '#!/usr/bin/env bash\nprintf merged\\n\n' > "$case_dir/state/task-x1.check.sh"
+  printf 'merged\n' > "$case_dir/state/.seen-check-task-x1.check.sh"
+  printf 'MERGED|https://example.test/pr/1\n' > "$case_dir/state/.babysit-task-x1.seen"
+  printf 'MERGED|https://example.test/pr/1\n' > "$case_dir/state/.escalated-.babysit-task-x1.seen"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "check-cleanup: teardown should succeed"
+  [ ! -e "$case_dir/state/task-x1.check.sh" ] || fail "check-cleanup: check script remained"
+  [ ! -e "$case_dir/state/.seen-check-task-x1.check.sh" ] || fail "check-cleanup: seen-check marker remained"
+  [ ! -e "$case_dir/state/.babysit-task-x1.seen" ] || fail "check-cleanup: babysit sidecar remained"
+  [ ! -e "$case_dir/state/.escalated-.babysit-task-x1.seen" ] || fail "check-cleanup: escalated marker remained"
+  pass "teardown removes watcher check dedup state"
+}
+
 test_local_only_fork_remote_allows
 test_teardown_prompts_tasks_axi_done_when_compatible
 test_local_only_truly_unpushed_refuses
@@ -280,3 +305,4 @@ test_local_only_merged_to_local_main_allows
 test_no_mistakes_origin_remote_allows
 test_no_mistakes_truly_unpushed_refuses
 test_local_only_force_overrides_unpushed
+test_teardown_removes_check_dedup_state

--- a/tests/fm-wake-queue.test.sh
+++ b/tests/fm-wake-queue.test.sh
@@ -395,6 +395,42 @@ SH
   pass "catch-all force-escalates a swallowed terminal check transition"
 }
 
+test_normal_check_marks_matching_legacy_sidecar_escalated() {
+  local dir state fakebin out drain_out check_file sidecar escalated count pid
+  dir=$(make_case check-sidecar-dedup)
+  state="$dir/state"
+  fakebin="$dir/fakebin"
+  out="$dir/watch.out"
+  drain_out="$dir/drain.out"
+  check_file="$state/legacy-pr.check.sh"
+  sidecar="$state/.babysit-legacy-pr.seen"
+  escalated="$state/.escalated-.babysit-legacy-pr.seen"
+  printf 'MERGED|comment-a comment-b\n' > "$sidecar"
+  cat > "$check_file" <<'SH'
+#!/usr/bin/env bash
+printf 'merged\n'
+SH
+  chmod +x "$check_file"
+
+  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=0 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  wait_for_exit "$!" 40 || fail "watcher did not exit for normal legacy check"
+  grep -F "check: $check_file: merged" "$out" >/dev/null || fail "normal check wake did not print"
+  [ "$(cat "$escalated" 2>/dev/null || true)" = "MERGED|comment-a comment-b" ] \
+    || fail "normal check did not mark matching sidecar escalated"
+
+  : > "$out"
+  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=0 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  wait_for_exit "$pid" 3 && fail "watcher emitted duplicate catch-all wake"
+  kill "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$drain_out" || fail "drain after normal legacy check failed"
+  count=$(grep -c "$(printf '\tcheck\t')" "$drain_out" || true)
+  [ "$count" -eq 1 ] || fail "expected 1 check wake after legacy sidecar dedup, got $count"
+  pass "normal check wake marks matching legacy sidecar escalated"
+}
+
 test_singleton_start() {
   local dir state fakebin out1 out2 pid1 pid2 live
   dir=$(make_case singleton)
@@ -1371,6 +1407,7 @@ test_check_output_is_queued
 test_check_wake_survives_lost_delivery
 test_check_dedup_suppresses_repeats
 test_catch_all_escalates_swallowed_transition
+test_normal_check_marks_matching_legacy_sidecar_escalated
 test_singleton_start
 test_atomic_double_drain
 test_drain_dedupes_obvious_duplicates

--- a/tests/fm-wake-queue.test.sh
+++ b/tests/fm-wake-queue.test.sh
@@ -303,6 +303,98 @@ SH
   pass "check output is queued before cadence suppression"
 }
 
+# Regression for a missed PR merge wake: a check wake must survive a crash
+# between durable enqueue and suppression-marker advance.
+test_check_wake_survives_lost_delivery() {
+  local dir state fakebin out drain_out check_file seen_check crash_status
+  dir=$(make_case check-lossless)
+  state="$dir/state"
+  fakebin="$dir/fakebin"
+  out="$dir/watch.out"
+  drain_out="$dir/drain.out"
+  check_file="$state/pr-3095.check.sh"
+  seen_check="$state/.seen-check-pr-3095.check.sh"
+  cat > "$check_file" <<'SH'
+#!/usr/bin/env bash
+printf 'merged: https://example.test/pr/3095\n'
+SH
+  chmod +x "$check_file"
+
+  PATH="$fakebin:$PATH" FM_WATCH_BREAK_AFTER_CHECK_ENQUEUE=1 FM_STATE_OVERRIDE="$state" FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=0 FM_HEARTBEAT=999999 "$WATCH" > "$out" 2>/dev/null &
+  wait_for_exit "$!" 40
+  crash_status=$?
+  [ "$crash_status" -eq 99 ] || fail "crashing watcher did not simulate post-enqueue crash (exit $crash_status)"
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$drain_out" || fail "drain after simulated crash failed"
+  grep "$(printf '\tcheck\t')" "$drain_out" | grep -F "$check_file" | grep -F 'merged: https://example.test/pr/3095' >/dev/null \
+    || fail "check wake was not durable before suppression"
+  [ ! -e "$seen_check" ] || fail "seen-check marker advanced before simulated crash"
+
+  : > "$out"
+  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=0 FM_HEARTBEAT=999999 "$WATCH" > "$out" 2>/dev/null &
+  wait_for_exit "$!" 40 || fail "watcher did not re-detect unsuppressed check wake"
+  grep -F "check: $check_file: merged: https://example.test/pr/3095" "$out" >/dev/null \
+    || fail "check wake was not re-detected after failed suppression"
+  [ "$(cat "$seen_check" 2>/dev/null || true)" = "merged: https://example.test/pr/3095" ] \
+    || fail "seen-check marker was not advanced after successful wake"
+  pass "check wake is enqueued before suppression so lost delivery is recovered"
+}
+
+test_check_dedup_suppresses_repeats() {
+  local dir state fakebin out drain_out check_file count
+  dir=$(make_case check-dedup)
+  state="$dir/state"
+  fakebin="$dir/fakebin"
+  out="$dir/watch.out"
+  drain_out="$dir/drain.out"
+  check_file="$state/repeating.check.sh"
+  cat > "$check_file" <<'SH'
+#!/usr/bin/env bash
+printf 'merged\n'
+SH
+  chmod +x "$check_file"
+
+  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=0 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  wait_for_exit "$!" 40 || fail "watcher did not exit for first repeated check"
+  : > "$out"
+  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=0 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  wait_for_exit "$!" 3 && fail "watcher emitted a duplicate check wake"
+  kill "$!" 2>/dev/null || true
+  wait "$!" 2>/dev/null || true
+
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$drain_out" || fail "drain after repeated check failed"
+  count=$(grep -c "$(printf '\tcheck\t')" "$drain_out" || true)
+  [ "$count" -eq 1 ] || fail "expected 1 deduped check wake, got $count"
+  pass "watcher-side .seen-check dedup suppresses repeated identical check output"
+}
+
+test_catch_all_escalates_swallowed_transition() {
+  local dir state fakebin out drain_out check_file sidecar escalated
+  dir=$(make_case check-catchall)
+  state="$dir/state"
+  fakebin="$dir/fakebin"
+  out="$dir/watch.out"
+  drain_out="$dir/drain.out"
+  check_file="$state/legacy-pr.check.sh"
+  sidecar="$state/.babysit-legacy-pr.seen"
+  escalated="$state/.escalated-.babysit-legacy-pr.seen"
+  printf 'MERGED|comment-a comment-b\n' > "$sidecar"
+  cat > "$check_file" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  chmod +x "$check_file"
+
+  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=0 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  wait_for_exit "$!" 40 || fail "watcher did not exit for catch-all check"
+  grep -F "check: catch-all: $sidecar: MERGED" "$out" >/dev/null || fail "catch-all did not print swallowed terminal transition"
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$drain_out" || fail "drain after catch-all failed"
+  grep "$(printf '\tcheck\t')" "$drain_out" | grep -F "$sidecar" | grep -F 'MERGED' >/dev/null \
+    || fail "catch-all check wake was not queued"
+  [ "$(cat "$escalated" 2>/dev/null || true)" = "MERGED|comment-a comment-b" ] \
+    || fail "catch-all escalation marker was not written"
+  pass "catch-all force-escalates a swallowed terminal check transition"
+}
+
 test_singleton_start() {
   local dir state fakebin out1 out2 pid1 pid2 live
   dir=$(make_case singleton)
@@ -1276,6 +1368,9 @@ test_concurrent_append_and_drain
 test_signal_catchup_without_running_watcher
 test_stale_enqueue_before_suppressor
 test_check_output_is_queued
+test_check_wake_survives_lost_delivery
+test_check_dedup_suppresses_repeats
+test_catch_all_escalates_swallowed_transition
 test_singleton_start
 test_atomic_double_drain
 test_drain_dedupes_obvious_duplicates


### PR DESCRIPTION
## What

Reworked replacement for #52, rebased onto current `main`.

This makes watcher PR/check wakes lossless by moving repeated-output suppression into `fm-watch.sh`: check output is written to the durable wake queue before the watcher advances its `.seen-check-*` marker.

## Why

`state/*.check.sh` was the remaining wake source whose suppression could happen inside an opaque check script. A legacy edge-triggered check could advance its own `.babysit-*.seen` marker before its stdout became a delivered watcher wake; if that stdout was lost by a timeout, crash, or concurrent watcher run, the terminal transition could be swallowed permanently.

That violates the durable wake invariant used by status and stale-pane signals: enqueue first, suppress second.

## Changes

- Adds watcher-owned dedupe for stateless check output via `.seen-check-*`.
- Enqueues check wakes before advancing the dedupe marker.
- Keeps a catch-all for legacy `.babysit-*.seen` sidecars that already self-suppressed a terminal `MERGED` or `CLOSED` state.
- Marks matching legacy sidecars as already escalated when a normal check wake is delivered, avoiding duplicate catch-all wakes.
- Cleans check-related watcher state during teardown.
- Updates the PR-check contract docs and adds focused regression coverage.

## Validation

- `tests/fm-wake-queue.test.sh` - passed
- `tests/fm-teardown.test.sh` - passed
- `for test_script in tests/*.test.sh; do "$test_script"; done` - passed
- `bash -n bin/*.sh tests/*.sh` - passed
- `shellcheck -x bin/*.sh tests/*.sh` - passed
- `no-mistakes` run `01KVWAJEV4K1D91FS6J8Q400ZX` - `checks-passed`

The no-mistakes review found and fixed one issue in this branch before final validation: the legacy catch-all could duplicate a check wake after a normal check output had already delivered. The final branch includes that fix.

GitHub currently reports no status checks configured for this fork PR, so the validation evidence is the local/no-mistakes run above.