### PR TITLE
Add Codex Desktop orchestration backend boundary

### DIFF
--- a/.agents/skills/no-mistakes/SKILL.md
+++ b/.agents/skills/no-mistakes/SKILL.md
@@ -132,11 +132,13 @@ Run the pipeline and decide on its findings as they come up:
    - `checks-passed` - the change is validated and CI is green, but the PR is
      not merged yet. **You are done driving the pipeline.** Do not wait for the
      merge: before telling the user or a maintainer that the PR is ready, run
-     the `pr-readiness` skill if this repo has it. It refreshes live GitHub/base
+     the `pr-readiness` skill if this repo has it.
+     It refreshes live GitHub/base
      facts, checks mergeability and overlap with current base, verifies public
      PR text, and blocks stale, conflicting, unverified, or overly broad PRs.
      If that audit passes, tell the user the PR is ready and ask them to review
-     and merge it (the PR link is in the `help` line). no-mistakes keeps
+     and merge it (the PR link is in the `help` line).
+     no-mistakes keeps
      monitoring the PR in the background, so a human can watch it in the TUI.
    - `passed` - the changes cleared the gate and the PR was merged or closed.
    - `failed` or `cancelled` - they did not; read the output and address it.

--- a/.agents/skills/no-mistakes/SKILL.md
+++ b/.agents/skills/no-mistakes/SKILL.md
@@ -131,9 +131,13 @@ Run the pipeline and decide on its findings as they come up:
    outcomes are:
    - `checks-passed` - the change is validated and CI is green, but the PR is
      not merged yet. **You are done driving the pipeline.** Do not wait for the
-     merge: tell the user the PR is ready and ask them to review and merge it
-     (the PR link is in the `help` line). no-mistakes keeps monitoring the PR
-     in the background, so a human can watch it in the TUI.
+     merge: before telling the user or a maintainer that the PR is ready, run
+     the `pr-readiness` skill if this repo has it. It refreshes live GitHub/base
+     facts, checks mergeability and overlap with current base, verifies public
+     PR text, and blocks stale, conflicting, unverified, or overly broad PRs.
+     If that audit passes, tell the user the PR is ready and ask them to review
+     and merge it (the PR link is in the `help` line). no-mistakes keeps
+     monitoring the PR in the background, so a human can watch it in the TUI.
    - `passed` - the changes cleared the gate and the PR was merged or closed.
    - `failed` or `cancelled` - they did not; read the output and address it.
      Fix whatever the output points at (a failing test, a lint error, a finding

--- a/.agents/skills/pr-readiness/SKILL.md
+++ b/.agents/skills/pr-readiness/SKILL.md
@@ -14,23 +14,25 @@ missing research, internal transcript language, or weak validation.
 
 1. Refresh the base and PR facts.
    ```sh
-   git fetch origin main
    gh-axi pr view <number> --json number,title,author,mergeStateStatus,statusCheckRollup,changedFiles,additions,deletions,url
    gh-axi api repos/<owner>/<repo>/pulls/<number> --jq '{mergeable,mergeable_state,rebaseable,head:{repo:.head.repo.full_name,ref:.head.ref,sha:.head.sha},base:{ref:.base.ref,sha:.base.sha}}'
+   BASE_REF="$(gh-axi api repos/<owner>/<repo>/pulls/<number> --jq '.base.ref')"
+   BASE_REMOTE="origin/${BASE_REF}"
+   git fetch origin "refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
    ```
    Use `gh-axi`, not raw `gh`, in this repo.
 
 2. Compare against current base, not the branch's old base.
    ```sh
-   git log --oneline --cherry-pick --right-only origin/main...HEAD
-   git diff --name-status origin/main...HEAD
-   git merge-tree "$(git merge-base origin/main HEAD)" origin/main HEAD
+   git log --oneline --cherry-pick --right-only "${BASE_REMOTE}"...HEAD
+   git diff --name-status "${BASE_REMOTE}"...HEAD
+   git merge-tree "$(git merge-base "${BASE_REMOTE}" HEAD)" "${BASE_REMOTE}" HEAD
    ```
    If the branch is dirty/conflicting, rebase or rebuild before asking anyone to
    review or merge it.
 
 3. Check overlap and supersession.
-   - Inspect recently merged commits on `origin/main`.
+   - Inspect recently merged commits on `${BASE_REMOTE}`.
    - Inspect adjacent open PRs that touch the same files or subsystem.
    - Decide whether the change is still needed, partly superseded, or should be
      split into smaller PRs.
@@ -82,7 +84,7 @@ For replacement PRs from a fork, also state what happened to the original PR:
 
 ```markdown
 This is a rebased/reworked replacement for #<old>. I kept <specific useful
-part>, dropped <superseded part>, and retested against current `main`.
+part>, dropped <superseded part>, and retested against current base.
 ```
 
 ## Stop conditions

--- a/.agents/skills/pr-readiness/SKILL.md
+++ b/.agents/skills/pr-readiness/SKILL.md
@@ -12,13 +12,32 @@ missing research, internal transcript language, or weak validation.
 
 ## Required checks
 
-1. Refresh the base and PR facts.
+1. Refresh the base facts for the actual action.
+
+   For an existing PR, capture both the base branch and the base repository
+   before comparing or fetching:
    ```sh
    gh-axi pr view <number> --json number,title,author,mergeStateStatus,statusCheckRollup,changedFiles,additions,deletions,url
-   gh-axi api repos/<owner>/<repo>/pulls/<number> --jq '{mergeable,mergeable_state,rebaseable,head:{repo:.head.repo.full_name,ref:.head.ref,sha:.head.sha},base:{ref:.base.ref,sha:.base.sha}}'
+   gh-axi api repos/<owner>/<repo>/pulls/<number> --jq '{mergeable,mergeable_state,rebaseable,head:{repo:.head.repo.full_name,ref:.head.ref,sha:.head.sha},base:{repo:.base.repo.full_name,ref:.base.ref,sha:.base.sha}}'
+   BASE_REPO="$(gh-axi api repos/<owner>/<repo>/pulls/<number> --jq '.base.repo.full_name')"
    BASE_REF="$(gh-axi api repos/<owner>/<repo>/pulls/<number> --jq '.base.ref')"
-   BASE_REMOTE="origin/${BASE_REF}"
-   git fetch origin "refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+   BASE_REMOTE="refs/remotes/pr-base/${BASE_REF}"
+   git fetch "https://github.com/${BASE_REPO}.git" "refs/heads/${BASE_REF}:${BASE_REMOTE}"
+   ```
+
+   Before a PR exists, derive the intended base from the local branch and fetch
+   that base directly. For fork or replacement workflows, set
+   `TARGET_BASE_REPO` to the intended upstream repository rather than assuming
+   `origin`.
+   ```sh
+   BRANCH="$(git branch --show-current)"
+   BASE_REPO="${TARGET_BASE_REPO:-$(gh-axi repo view --json nameWithOwner --jq '.nameWithOwner')}"
+   BASE_REF="${TARGET_BASE_REF:-$(git config "branch.${BRANCH}.gh-merge-base" || true)}"
+   BASE_REF="${BASE_REF:-$(gh-axi repo view "${BASE_REPO}" --json defaultBranchRef --jq '.defaultBranchRef.name')}"
+   BASE_REMOTE="refs/remotes/pr-base/${BASE_REF}"
+   git fetch "https://github.com/${BASE_REPO}.git" "refs/heads/${BASE_REF}:${BASE_REMOTE}"
+   git status --short
+   git branch -vv
    ```
    Use `gh-axi`, not raw `gh`, in this repo.
 

--- a/.agents/skills/pr-readiness/SKILL.md
+++ b/.agents/skills/pr-readiness/SKILL.md
@@ -1,13 +1,19 @@
 ---
 name: pr-readiness
-description: Prepare, audit, or rewrite a pull request before it is opened, updated, commented on, or presented to a maintainer. Use when a user asks to create a PR, ask someone to merge a PR, replace an upstream PR from a fork, comment on a PR, publish branch work, or make sure a PR is maintainer-ready.
+description: >-
+  Prepare, audit, or rewrite a pull request before it is opened, updated,
+  commented on, or presented to a maintainer.
+  Use when a user asks to create a PR, ask someone to merge a PR, replace an
+  upstream PR from a fork, comment on a PR, publish branch work, or make sure a
+  PR is maintainer-ready.
 ---
 
 # pr-readiness
 
 Use this before any public PR action: opening a PR, updating a PR body, asking a
 maintainer to merge, commenting with a replacement branch, or presenting a PR as
-ready. The goal is to avoid wasting maintainer attention with stale branches,
+ready.
+The goal is to avoid wasting maintainer attention with stale branches,
 missing research, internal transcript language, or weak validation.
 
 ## Required checks
@@ -26,7 +32,8 @@ missing research, internal transcript language, or weak validation.
    ```
 
    Before a PR exists, derive the intended base from the local branch and fetch
-   that base directly. For fork or replacement workflows, set
+   that base directly.
+   For fork or replacement workflows, set
    `TARGET_BASE_REPO` to the intended upstream repository rather than assuming
    `origin`.
    ```sh
@@ -102,8 +109,8 @@ Compatibility, risk, or follow-up work if relevant.
 For replacement PRs from a fork, also state what happened to the original PR:
 
 ```markdown
-This is a rebased/reworked replacement for #<old>. I kept <specific useful
-part>, dropped <superseded part>, and retested against current base.
+This is a rebased/reworked replacement for #<old>.
+I kept <specific useful part>, dropped <superseded part>, and retested against current base.
 ```
 
 ## Stop conditions

--- a/.agents/skills/pr-readiness/SKILL.md
+++ b/.agents/skills/pr-readiness/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: pr-readiness
+description: Prepare, audit, or rewrite a pull request before it is opened, updated, commented on, or presented to a maintainer. Use when a user asks to create a PR, ask someone to merge a PR, replace an upstream PR from a fork, comment on a PR, publish branch work, or make sure a PR is maintainer-ready.
+---
+
+# pr-readiness
+
+Use this before any public PR action: opening a PR, updating a PR body, asking a
+maintainer to merge, commenting with a replacement branch, or presenting a PR as
+ready. The goal is to avoid wasting maintainer attention with stale branches,
+missing research, internal transcript language, or weak validation.
+
+## Required checks
+
+1. Refresh the base and PR facts.
+   ```sh
+   git fetch origin main
+   gh-axi pr view <number> --json number,title,author,mergeStateStatus,statusCheckRollup,changedFiles,additions,deletions,url
+   gh-axi api repos/<owner>/<repo>/pulls/<number> --jq '{mergeable,mergeable_state,rebaseable,head:{repo:.head.repo.full_name,ref:.head.ref,sha:.head.sha},base:{ref:.base.ref,sha:.base.sha}}'
+   ```
+   Use `gh-axi`, not raw `gh`, in this repo.
+
+2. Compare against current base, not the branch's old base.
+   ```sh
+   git log --oneline --cherry-pick --right-only origin/main...HEAD
+   git diff --name-status origin/main...HEAD
+   git merge-tree "$(git merge-base origin/main HEAD)" origin/main HEAD
+   ```
+   If the branch is dirty/conflicting, rebase or rebuild before asking anyone to
+   review or merge it.
+
+3. Check overlap and supersession.
+   - Inspect recently merged commits on `origin/main`.
+   - Inspect adjacent open PRs that touch the same files or subsystem.
+   - Decide whether the change is still needed, partly superseded, or should be
+     split into smaller PRs.
+
+4. Verify the change.
+   - Run focused tests for the changed behavior.
+   - Run lint/syntax checks for touched languages.
+   - For code changes in firstmate, run the no-mistakes gate once the work is
+     committed unless the user explicitly chooses a lighter path.
+   - Do not claim GitHub CI passed unless GitHub actually shows passing checks.
+
+5. Inspect public text.
+   Remove local/internal language before opening, updating, or commenting:
+   - no "Captain" address;
+   - no local transcript/intake details;
+   - no firstmate operational chatter unless it is relevant to the upstream repo;
+   - no "validated locally" claim without the exact commands and outcome;
+   - no request to merge a conflicting, stale, or unverified branch.
+
+## Maintainer-facing format
+
+Prefer this structure:
+
+```markdown
+## What
+
+One short paragraph describing the bug or capability.
+
+## Why
+
+The concrete failure mode or maintainer-relevant motivation.
+
+## Changes
+
+- Specific implementation points.
+- Any deliberate scope limits.
+
+## Validation
+
+- `command` - outcome
+- GitHub checks: passed / unavailable with reason
+
+## Notes
+
+Compatibility, risk, or follow-up work if relevant.
+```
+
+For replacement PRs from a fork, also state what happened to the original PR:
+
+```markdown
+This is a rebased/reworked replacement for #<old>. I kept <specific useful
+part>, dropped <superseded part>, and retested against current `main`.
+```
+
+## Stop conditions
+
+Do not proceed publicly without telling the captain if any of these are true:
+
+- GitHub reports `mergeable=false`, `mergeable_state=dirty`, or not rebaseable.
+- The PR has no GitHub checks and the repo normally expects checks.
+- The PR body still contains internal transcript language.
+- The branch includes unrelated fixes that should be split.
+- Recent upstream commits may have already solved the same problem.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -394,8 +394,8 @@ bin/fm-spawn.sh <id1>=projects/<repo1> <id2>=projects/<repo2> [--scout]   # batc
 Dispatch several tasks in one call by passing `id=repo` pairs instead of a single `<id> <project>`; each pair is spawned through the same single-task path, a shared `--scout` applies to all, and the looping happens inside the script so you never hand-write a multi-task shell loop.
 If one pair fails, the rest still run and the batch exits non-zero.
 
-The script resolves the harness (`fm-harness.sh crew`), owns the verified launch templates, resolves the project's delivery mode (`fm-project-mode.sh`) for ship/scout tasks, and records `backend=tmux-treehouse`, `worker_id=`, `worker_project_path=`, `environment=`, `harness=`, `kind=`, `mode=`, and `yolo=` in the task's meta; a non-flag third argument containing whitespace is treated as a raw launch command (only for verifying new adapters).
-The backend fields are the integration seam for Codex Desktop-native workers: future Desktop project-thread spawns should use `backend=codex-desktop` plus thread/project identifiers, while missing `backend=` in older metadata means the legacy tmux/treehouse backend.
+The script resolves the harness (`fm-harness.sh crew`), owns the verified launch templates, resolves the project's delivery mode (`fm-project-mode.sh`) for ship/scout tasks, and records `backend=tmux-treehouse`, `worker_id=`, `worker_project_path=`, `environment=`, `harness=`, `kind=`, `mode=`, and `yolo=` in the task's meta for the currently implemented worker path; a non-flag third argument containing whitespace is treated as a raw launch command (only for verifying new adapters).
+The backend fields are the integration seam for Codex Desktop-native workers: future Desktop project-thread spawns should use `backend=codex-desktop` plus thread/project identifiers, while missing `backend=` in older metadata is interpreted as `tmux-treehouse` for compatibility during the migration.
 Do not fake Codex Desktop project or thread creation in shell scripts; add that backend only when a real callable Desktop API exists.
 For `kind=secondmate`, the same script launches in the registered or explicit firstmate home instead of running `treehouse get` for a project, records `home=` and `projects=`, and uses the charter brief as the launch prompt.
 
@@ -436,7 +436,7 @@ Pooled clones keep their local default refs frozen at clone time and can lag `or
 
 For ordinary ship tasks, validate with Fast Gate: focused relevant checks for the touched area, lint/typecheck only when relevant and cheap, diff review, committed result, and a risk summary listing checks run and checks skipped.
 Escalate to full no-mistakes when the change is security-sensitive, release/deploy-related, a dependency upgrade, a broad refactor, spans multiple subsystems, or the captain explicitly asks.
-Fast Gate is lighter on validation breadth, not workspace safety: ship work still runs in an isolated Codex Worktree mode in the future or the legacy treehouse worktree today.
+Fast Gate is lighter on validation breadth, not workspace safety: ship work still runs in an isolated Codex Worktree mode in the future or the current treehouse worktree implementation today.
 
 For a full no-mistakes escalation, trigger validation using the crew's harness from `state/<id>.meta`.
 Use `/no-mistakes` for claude, `$no-mistakes` for codex; natural language also works.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,7 +82,7 @@ projects/            cloned repos; gitignored; READ-ONLY for you
 state/               volatile runtime signals; gitignored
   <id>.status        appended by crewmates: "<state>: <note>" lines
   <id>.turn-ended    touched by turn-end hooks
-  <id>.meta          written by fm-spawn: window=, worktree=, project=, harness=, kind=, mode=, yolo=; kind=secondmate also records home= and projects= (fm-pr-check appends pr=)
+  <id>.meta          written by fm-spawn: backend=, worker_id=, worker_project_path=, environment=, window=, worktree=, project=, harness=, kind=, mode=, yolo=; kind=secondmate also records home= and projects= (fm-pr-check appends pr=)
   <id>.check.sh      optional slow poll you write per task (e.g. merged-PR check)
   .wake-queue        durable queued wakes: epoch<TAB>seq<TAB>kind<TAB>key<TAB>payload
   .afk               durable away-mode flag; present = sub-supervisor may inject escalations (set by /afk, cleared on user return)
@@ -252,6 +252,10 @@ The registry line records the project name, delivery mode, optional `+yolo` post
 Add the line when you clone or create a project, keep the description useful for identifying the project, and drop the line if a project is ever removed from `projects/`.
 Do not turn the registry into a knowledge dump.
 Durable descriptive detail belongs in the project's own `AGENTS.md`.
+Treat this registry as a work-destination registry, not a list of every tool involved in the fleet.
+Work repos are valid task destinations.
+Tooling repos, including Kun tooling repos such as firstmate, treehouse, no-mistakes, gh-axi, chrome-devtools-axi, and lavish-axi, are dependencies/orchestration tools unless the task explicitly edits that tooling repo.
+Do not route ordinary product/app work into a tooling repo merely because the request mentions that tool.
 
 `data/secondmates.md` is the secondmate routing table.
 Every persistent secondmate has one line:
@@ -306,11 +310,11 @@ Create a project's `AGENTS.md` lazily on first need.
 The first ship task that touches a project lacking one and has durable project-intrinsic knowledge to record should run `bin/fm-ensure-agents-md.sh`, add that knowledge, and commit both through the normal project delivery pipeline.
 Do not eagerly backfill every project.
 
-**Delivery mode (choose at add).** `<mode>` is how a finished change reaches `main`, picked per project when you add it and recorded in the registry line (`fm-project-mode.sh` parses it; `fm-spawn` records it into each task's meta):
+**Delivery mode (choose at add).** `<mode>` is how a finished change reaches `main`, picked per project when you add it and recorded in the registry line (`fm-project-mode.sh` parses it; `fm-spawn` records it into each task's meta). Delivery mode is separate from validation gate: Fast Gate is the default for ordinary ship work; full no-mistakes is reserved for high-risk, release/deploy, security-sensitive, dependency, broad-refactor, multi-subsystem, or explicitly requested work.
 
-- `no-mistakes` (default; `[...]` may be omitted) - full pipeline -> PR -> captain merge. Highest assurance.
-- `direct-PR` - run `pr-readiness`, push + open a PR via `gh-axi`, no pipeline -> captain merge.
-- `local-only` - local branch, no remote, no PR; firstmate reviews the diff, the captain approves, firstmate merges to local `main` (section 7).
+- `no-mistakes` (default; `[...]` may be omitted) - PR-capable mode; ordinary work starts with Fast Gate, and full no-mistakes remains the high-assurance escalation/fallback.
+- `direct-PR` - Fast Gate, run `pr-readiness`, push + open a PR via `gh-axi`, no full pipeline -> captain merge.
+- `local-only` - Fast Gate on a local branch, no remote, no PR; firstmate reviews the diff, the captain approves, firstmate merges to local `main` (section 7).
 
 Orthogonal to mode is an optional `+yolo` flag (`[direct-PR +yolo]`), default off and **not recommended**: with `yolo` on, firstmate makes the approval decisions itself instead of asking the captain (section 7). When the captain adds a project without saying, default to `no-mistakes` with yolo off; only set a faster mode or `+yolo` on the captain's explicit say-so.
 
@@ -363,7 +367,7 @@ When you create a new secondmate, hand its in-scope queued items off from the ma
 
 Then classify the shape:
 
-- **Ship** (the default): the deliverable is a change to the project. It ships through the project's delivery mode: `no-mistakes`, `direct-PR`, or `local-only`.
+- **Ship** (the default): the deliverable is a change to the project. Ordinary ship work validates through Fast Gate and lands through the project's delivery mode: `no-mistakes`, `direct-PR`, or `local-only`. Escalate to full no-mistakes for high-risk, release/deploy, security-sensitive, dependency, broad-refactor, multi-subsystem, or explicitly requested work.
 - **Scout:** the deliverable is knowledge - an investigation, a plan, a bug reproduction, an audit. It ends in a report at `data/<id>/report.md`, never a PR. When the captain asks "what's wrong", "how would we", or "find out why" about a project, that is a scout task; dispatch it instead of doing the digging yourself.
 
 Then classify readiness:
@@ -390,7 +394,9 @@ bin/fm-spawn.sh <id1>=projects/<repo1> <id2>=projects/<repo2> [--scout]   # batc
 Dispatch several tasks in one call by passing `id=repo` pairs instead of a single `<id> <project>`; each pair is spawned through the same single-task path, a shared `--scout` applies to all, and the looping happens inside the script so you never hand-write a multi-task shell loop.
 If one pair fails, the rest still run and the batch exits non-zero.
 
-The script resolves the harness (`fm-harness.sh crew`), owns the verified launch templates, resolves the project's delivery mode (`fm-project-mode.sh`) for ship/scout tasks, and records `harness=`, `kind=`, `mode=`, and `yolo=` in the task's meta; a non-flag third argument containing whitespace is treated as a raw launch command (only for verifying new adapters).
+The script resolves the harness (`fm-harness.sh crew`), owns the verified launch templates, resolves the project's delivery mode (`fm-project-mode.sh`) for ship/scout tasks, and records `backend=tmux-treehouse`, `worker_id=`, `worker_project_path=`, `environment=`, `harness=`, `kind=`, `mode=`, and `yolo=` in the task's meta; a non-flag third argument containing whitespace is treated as a raw launch command (only for verifying new adapters).
+The backend fields are the integration seam for Codex Desktop-native workers: future Desktop project-thread spawns should use `backend=codex-desktop` plus thread/project identifiers, while missing `backend=` in older metadata means the legacy tmux/treehouse backend.
+Do not fake Codex Desktop project or thread creation in shell scripts; add that backend only when a real callable Desktop API exists.
 For `kind=secondmate`, the same script launches in the registered or explicit firstmate home instead of running `treehouse get` for a project, records `home=` and `projects=`, and uses the charter brief as the launch prompt.
 
 For ship and scout tasks, the script creates the window (in your current tmux session, or a dedicated `firstmate` session when you are outside tmux), runs `treehouse get`, waits for the worktree subshell, installs the turn-end hook, records `state/<id>.meta`, and launches the agent with the brief.
@@ -408,12 +414,12 @@ Its charter retargets escalation to the main firstmate's status file, so routine
 
 ### Delivery modes and yolo
 
-A ship task's path from `done` to landed on `main` is set by the project's `mode` (recorded in meta; section 6); `yolo` decides who approves. The Validate / PR ready / Ship teardown stages below are written for the `no-mistakes` path; the other modes diverge:
+A ship task's path from `done` to landed on `main` is set by the project's `mode` (recorded in meta; section 6); `yolo` decides who approves. Validation is Fast Gate by default, with full no-mistakes as the high-assurance escalation path. The PR ready / Ship teardown stages below remain mode-specific:
 
-- **no-mistakes** - the stages below as written: no-mistakes validation pipeline -> PR -> captain merge.
-- **direct-PR** - no pipeline.
+- **no-mistakes** - Fast Gate for ordinary work; escalate to full no-mistakes when risk, repo policy, or captain instruction requires it.
+- **direct-PR** - no full pipeline.
   The crewmate runs the `pr-readiness` audit, then pushes and opens the PR itself (its brief says so) and reports `done: PR <url>`.
-  Skip the Validate step and go straight to PR ready (run the same readiness audit on the opened PR if facts may have changed, then `fm-pr-check`, then relay the PR).
+  Fast Gate happens before push; then go straight to PR ready (run the same readiness audit on the opened PR if facts may have changed, then `fm-pr-check`, then relay the PR).
   Teardown uses the normal pushed-branch check.
 - **local-only** - no remote, no PR.
   The crewmate stops at `done: ready in branch fm/<id>`.
@@ -428,7 +434,11 @@ Pooled clones keep their local default refs frozen at clone time and can lag `or
 
 ### Validate
 
-For `no-mistakes`-mode ship tasks, when a crewmate's status says `done`, trigger validation using the crew's harness from `state/<id>.meta`.
+For ordinary ship tasks, validate with Fast Gate: focused relevant checks for the touched area, lint/typecheck only when relevant and cheap, diff review, committed result, and a risk summary listing checks run and checks skipped.
+Escalate to full no-mistakes when the change is security-sensitive, release/deploy-related, a dependency upgrade, a broad refactor, spans multiple subsystems, or the captain explicitly asks.
+Fast Gate is lighter on validation breadth, not workspace safety: ship work still runs in an isolated Codex Worktree mode in the future or the legacy treehouse worktree today.
+
+For a full no-mistakes escalation, trigger validation using the crew's harness from `state/<id>.meta`.
 Use `/no-mistakes` for claude, `$no-mistakes` for codex; natural language also works.
 For example, with claude:
 
@@ -443,7 +453,7 @@ Use chat for yes/no decisions; use lavish-axi when there are multiple findings o
 
 ### PR ready
 
-For PR-based ship tasks, the ready signal depends on mode: `no-mistakes` reports `done: PR <url> checks green` after CI is green, while `direct-PR` reports `done: PR <url>` after opening the PR.
+For PR-based ship tasks, the ready signal depends on validation and mode: full no-mistakes reports `done: PR <url> checks green` after CI is green, while Fast Gate work reports a committed branch or PR with checks and risk summary.
 Before telling the captain the PR is ready, asking a maintainer to review or merge, updating PR public text, or commenting with a replacement branch, use the `pr-readiness` skill to audit live GitHub/base facts, mergeability, current-base overlap, validation, and maintainer-facing text.
 If that audit finds stale base, conflicts, missing checks, internal transcript language, or broad unrelated scope, stop and resolve it before any public PR action.
 Run `bin/fm-pr-check.sh <id> <PR url>` - it records `pr=` in the task's meta and arms the watcher's merge poll.
@@ -691,7 +701,7 @@ Secondmates inherit this automatically: each secondmate home carries the same `A
 ## 11. Crewmate briefs
 
 Scaffold with `bin/fm-brief.sh <id> <repo-name>` - it writes `data/<id>/brief.md` with the standard contract (branch setup, status-reporting protocol, push/merge rules, definition of done) and all paths filled in.
-For a ship task the definition of done is shaped by the project's delivery mode (section 6): `no-mistakes` ends in the harness-appropriate no-mistakes validation pipeline, `direct-PR` has the crewmate run `pr-readiness` before pushing and opening the PR itself, `local-only` has it stop at "ready in branch" for firstmate to review and merge locally.
+For a ship task, Fast Gate is the default definition of done unless the project or task escalates to full no-mistakes: focused relevant checks, cheap relevant lint/typecheck, diff review, commit, and risk summary. Delivery mode still decides PR/local merge mechanics: `direct-PR` has the crewmate run `pr-readiness` before pushing and opening the PR itself, `local-only` has it stop at "ready in branch" for firstmate to review and merge locally, and `no-mistakes` remains the high-assurance escalation/fallback.
 The scaffold reads the mode via `fm-project-mode.sh`, so you do not pass it.
 Ship briefs also include the project-memory contract: run `bin/fm-ensure-agents-md.sh` when the project already has agent-memory files or when the task produced durable project-intrinsic knowledge, then record proportionate learnings in `AGENTS.md`.
 For scout tasks add `--scout`: the scaffold swaps the definition of done for the report contract (findings to `data/<id>/report.md`, no branch, no push, no PR) and declares the worktree scratch; scout is mode-agnostic.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -309,7 +309,7 @@ Do not eagerly backfill every project.
 **Delivery mode (choose at add).** `<mode>` is how a finished change reaches `main`, picked per project when you add it and recorded in the registry line (`fm-project-mode.sh` parses it; `fm-spawn` records it into each task's meta):
 
 - `no-mistakes` (default; `[...]` may be omitted) - full pipeline -> PR -> captain merge. Highest assurance.
-- `direct-PR` - push + open a PR via `gh-axi`, no pipeline -> captain merge.
+- `direct-PR` - run `pr-readiness`, push + open a PR via `gh-axi`, no pipeline -> captain merge.
 - `local-only` - local branch, no remote, no PR; firstmate reviews the diff, the captain approves, firstmate merges to local `main` (section 7).
 
 Orthogonal to mode is an optional `+yolo` flag (`[direct-PR +yolo]`), default off and **not recommended**: with `yolo` on, firstmate makes the approval decisions itself instead of asking the captain (section 7). When the captain adds a project without saying, default to `no-mistakes` with yolo off; only set a faster mode or `+yolo` on the captain's explicit say-so.
@@ -411,7 +411,7 @@ Its charter retargets escalation to the main firstmate's status file, so routine
 A ship task's path from `done` to landed on `main` is set by the project's `mode` (recorded in meta; section 6); `yolo` decides who approves. The Validate / PR ready / Ship teardown stages below are written for the `no-mistakes` path; the other modes diverge:
 
 - **no-mistakes** - the stages below as written: no-mistakes validation pipeline -> PR -> captain merge.
-- **direct-PR** - no pipeline. The crewmate pushes and opens the PR itself (its brief says so) and reports `done: PR <url>`. Skip the Validate step and go straight to PR ready (run `fm-pr-check`, relay the PR). Teardown uses the normal pushed-branch check.
+- **direct-PR** - no pipeline. The crewmate runs the `pr-readiness` audit, then pushes and opens the PR itself (its brief says so) and reports `done: PR <url>`. Skip the Validate step and go straight to PR ready (run the same readiness audit on the opened PR if facts may have changed, then `fm-pr-check`, then relay the PR). Teardown uses the normal pushed-branch check.
 - **local-only** - no remote, no PR. The crewmate stops at `done: ready in branch fm/<id>`. Review the diff with `bin/fm-review-diff.sh <id>`, relay a one-paragraph summary to the captain, and on approval run `bin/fm-merge-local.sh <id>` to fast-forward local `main` (it refuses anything but a clean fast-forward - if it does, have the crewmate rebase). No `fm-pr-check`. Then teardown, whose safety check requires the branch already merged into local `main`, OR the work pushed to any remote (a fork counts - relevant for upstream-contribution PRs on a local-only-registered project).
 
 When reviewing any crewmate branch diff, use `bin/fm-review-diff.sh <id>` rather than `git diff <default>...branch` directly.
@@ -437,11 +437,14 @@ Use chat for yes/no decisions; use lavish-axi when there are multiple findings o
 ### PR ready
 
 For PR-based ship tasks, the ready signal depends on mode: `no-mistakes` reports `done: PR <url> checks green` after CI is green, while `direct-PR` reports `done: PR <url>` after opening the PR.
+Before telling the captain the PR is ready, asking a maintainer to review or merge, updating PR public text, or commenting with a replacement branch, use the `pr-readiness` skill to audit live GitHub/base facts, mergeability, current-base overlap, validation, and maintainer-facing text.
+If that audit finds stale base, conflicts, missing checks, internal transcript language, or broad unrelated scope, stop and resolve it before any public PR action.
 Run `bin/fm-pr-check.sh <id> <PR url>` - it records `pr=` in the task's meta and arms the watcher's merge poll.
 Tell the captain: the PR's full URL (always the complete `https://...` link, never a bare `#number` - the captain's terminal makes a full URL clickable), a one-paragraph summary, and, for `no-mistakes`, the risk level it emitted.
 (The check contract, for any custom `state/<id>.check.sh` you write yourself: print one line only when firstmate should wake, print nothing otherwise, and finish before `FM_CHECK_TIMEOUT`.)
 
-If the captain says "merge it", run `gh-axi pr merge` yourself; that instruction is the explicit approval. If `yolo=on`, merge a green/approved PR yourself and post the required FYI.
+If the captain says "merge it", run the `pr-readiness` audit again if the ready facts may be stale, then run `gh-axi pr merge` yourself; that instruction is the explicit approval.
+If `yolo=on`, merge a green/approved PR yourself only after the same readiness audit passes, then post the required FYI.
 
 ### Ship teardown (only after merge is confirmed)
 
@@ -681,7 +684,7 @@ Secondmates inherit this automatically: each secondmate home carries the same `A
 ## 11. Crewmate briefs
 
 Scaffold with `bin/fm-brief.sh <id> <repo-name>` - it writes `data/<id>/brief.md` with the standard contract (branch setup, status-reporting protocol, push/merge rules, definition of done) and all paths filled in.
-For a ship task the definition of done is shaped by the project's delivery mode (section 6): `no-mistakes` ends in the harness-appropriate no-mistakes validation pipeline, `direct-PR` has the crewmate push and open the PR itself, `local-only` has it stop at "ready in branch" for firstmate to review and merge locally.
+For a ship task the definition of done is shaped by the project's delivery mode (section 6): `no-mistakes` ends in the harness-appropriate no-mistakes validation pipeline, `direct-PR` has the crewmate run `pr-readiness` before pushing and opening the PR itself, `local-only` has it stop at "ready in branch" for firstmate to review and merge locally.
 The scaffold reads the mode via `fm-project-mode.sh`, so you do not pass it.
 Ship briefs also include the project-memory contract: run `bin/fm-ensure-agents-md.sh` when the project already has agent-memory files or when the task produced durable project-intrinsic knowledge, then record proportionate learnings in `AGENTS.md`.
 For scout tasks add `--scout`: the scaffold swaps the definition of done for the report contract (findings to `data/<id>/report.md`, no branch, no push, no PR) and declares the worktree scratch; scout is mode-agnostic.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -411,8 +411,15 @@ Its charter retargets escalation to the main firstmate's status file, so routine
 A ship task's path from `done` to landed on `main` is set by the project's `mode` (recorded in meta; section 6); `yolo` decides who approves. The Validate / PR ready / Ship teardown stages below are written for the `no-mistakes` path; the other modes diverge:
 
 - **no-mistakes** - the stages below as written: no-mistakes validation pipeline -> PR -> captain merge.
-- **direct-PR** - no pipeline. The crewmate runs the `pr-readiness` audit, then pushes and opens the PR itself (its brief says so) and reports `done: PR <url>`. Skip the Validate step and go straight to PR ready (run the same readiness audit on the opened PR if facts may have changed, then `fm-pr-check`, then relay the PR). Teardown uses the normal pushed-branch check.
-- **local-only** - no remote, no PR. The crewmate stops at `done: ready in branch fm/<id>`. Review the diff with `bin/fm-review-diff.sh <id>`, relay a one-paragraph summary to the captain, and on approval run `bin/fm-merge-local.sh <id>` to fast-forward local `main` (it refuses anything but a clean fast-forward - if it does, have the crewmate rebase). No `fm-pr-check`. Then teardown, whose safety check requires the branch already merged into local `main`, OR the work pushed to any remote (a fork counts - relevant for upstream-contribution PRs on a local-only-registered project).
+- **direct-PR** - no pipeline.
+  The crewmate runs the `pr-readiness` audit, then pushes and opens the PR itself (its brief says so) and reports `done: PR <url>`.
+  Skip the Validate step and go straight to PR ready (run the same readiness audit on the opened PR if facts may have changed, then `fm-pr-check`, then relay the PR).
+  Teardown uses the normal pushed-branch check.
+- **local-only** - no remote, no PR.
+  The crewmate stops at `done: ready in branch fm/<id>`.
+  Review the diff with `bin/fm-review-diff.sh <id>`, relay a one-paragraph summary to the captain, and on approval run `bin/fm-merge-local.sh <id>` to fast-forward local `main` (it refuses anything but a clean fast-forward - if it does, have the crewmate rebase).
+  No `fm-pr-check`.
+  Then teardown, whose safety check requires the branch already merged into local `main`, OR the work pushed to any remote (a fork counts - relevant for upstream-contribution PRs on a local-only-registered project).
 
 When reviewing any crewmate branch diff, use `bin/fm-review-diff.sh <id>` rather than `git diff <default>...branch` directly.
 Pooled clones keep their local default refs frozen at clone time and can lag `origin`; the helper always compares against the authoritative base.

--- a/README.md
+++ b/README.md
@@ -120,8 +120,8 @@ firstmate works from any terminal - outside tmux, crewmates land in a detached `
   A pull-based guard (`bin/fm-guard.sh`) warns through supervision tool output if tasks are in flight and that watcher stops running or queued wakes are waiting to be drained.
   A presence-gated sub-supervisor (`bin/fm-supervise-daemon.sh`) extends this for walk-away supervision: the `/afk` skill activates it, after which it self-handles routine wakes in bash and escalates only captain-relevant events as one batched, single-line digest (prefixed with an in-band sentinel marker so firstmate can tell daemon injections apart from real messages).
   Its injection path shares `bin/fm-tmux-lib.sh` with `fm-send.sh`, so dim-ghost-aware and border-aware composer detection plus verified submit retry stay consistent; stalled escalation delivery raises `state/.subsuper-inject-wedged` after `FM_MAX_DEFER_SECS` instead of silently deferring forever.
-- **Worker backend is explicit** - current workers use the legacy `tmux-treehouse` backend: a tmux window plus a treehouse worktree, recorded in `state/<id>.meta`.
-  That metadata is the migration seam for future Codex Desktop project-thread workers; missing `backend=` still means the legacy path.
+- **Worker backend is explicit** - current workers use the implemented `tmux-treehouse` backend: a tmux window plus a treehouse worktree, recorded in `state/<id>.meta`.
+  That metadata is the migration seam for Codex Desktop project-thread workers; older metadata without `backend=` is interpreted as `tmux-treehouse` for compatibility during the migration.
 - **Worktrees, not branches in your checkout** - crewmates never touch your clone; treehouse pools clean worktrees so parallel tasks on one repo cannot collide.
 - **Two task shapes** - ship tasks change projects and ship by project mode (`no-mistakes`, `direct-PR`, or `local-only`); ordinary ship work uses Fast Gate by default: isolated worktree, focused checks, diff review, commit, and risk summary.
   Full no-mistakes is reserved for high-risk, release/deploy, security-sensitive, dependency, broad-refactor, multi-subsystem, or explicitly requested work.

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ firstmate works from any terminal - outside tmux, crewmates land in a detached `
   After seeding a secondmate, `fm-backlog-handoff.sh` moves already-judged in-scope queued items from the main backlog into that secondmate home so the domain queue starts in the right place.
   Idle secondmate panes are healthy; teardown is explicit and refuses while the secondmate home has in-flight work unless the captain has approved discard with `--force`.
 - **Project modes are explicit** - `data/projects.md` records each project's delivery mode and optional `+yolo` autonomy flag.
-  `no-mistakes` projects run the full validation pipeline, `direct-PR` projects open PRs without that pipeline, and `local-only` projects stay local until firstmate performs an approved fast-forward merge.
+  `no-mistakes` projects run the full validation pipeline, `direct-PR` projects run the PR-readiness audit before opening PRs without that pipeline, and `local-only` projects stay local until firstmate performs an approved fast-forward merge.
 - **Project memory belongs to projects** - durable project-intrinsic agent knowledge lives in each project's committed `AGENTS.md`, with `CLAUDE.md` as a symlink.
   Ship briefs prompt crewmates to create or update those files through the normal delivery path; `data/projects.md` stays a thin private registry.
 - **Local clones stay fresh** - bootstrap and PR-based teardown refresh remote-backed project clones with clean default-branch fast-forwards when the clone is on the default branch and has no local work, and prune local branches whose remote is gone and that no worktree still needs.
@@ -231,6 +231,7 @@ Human-authored pull requests targeting `main` must be raised through `git push n
 Local `.no-mistakes/` state and test evidence stay out of this repo; `.no-mistakes.yaml` keeps evidence in a temp directory instead.
 The current watcher reliability work keeps the one-shot process model and adds a durable queue plus singleton lock.
 The presence-gated sub-supervisor (`bin/fm-supervise-daemon.sh`) provides proactive wake routing for walk-away supervision via the `/afk` skill; a blocking-waiter split remains a deferred follow-up phase.
+The `pr-readiness` skill audits live GitHub/base facts, current-base overlap, validation, and public PR text before firstmate opens, updates, comments on, presents, or asks maintainers to merge a PR.
 
 ```sh
 bash -n bin/*.sh                          # syntax-check the toolbelt

--- a/README.md
+++ b/README.md
@@ -120,8 +120,12 @@ firstmate works from any terminal - outside tmux, crewmates land in a detached `
   A pull-based guard (`bin/fm-guard.sh`) warns through supervision tool output if tasks are in flight and that watcher stops running or queued wakes are waiting to be drained.
   A presence-gated sub-supervisor (`bin/fm-supervise-daemon.sh`) extends this for walk-away supervision: the `/afk` skill activates it, after which it self-handles routine wakes in bash and escalates only captain-relevant events as one batched, single-line digest (prefixed with an in-band sentinel marker so firstmate can tell daemon injections apart from real messages).
   Its injection path shares `bin/fm-tmux-lib.sh` with `fm-send.sh`, so dim-ghost-aware and border-aware composer detection plus verified submit retry stay consistent; stalled escalation delivery raises `state/.subsuper-inject-wedged` after `FM_MAX_DEFER_SECS` instead of silently deferring forever.
+- **Worker backend is explicit** - current workers use the legacy `tmux-treehouse` backend: a tmux window plus a treehouse worktree, recorded in `state/<id>.meta`.
+  That metadata is the migration seam for future Codex Desktop project-thread workers; missing `backend=` still means the legacy path.
 - **Worktrees, not branches in your checkout** - crewmates never touch your clone; treehouse pools clean worktrees so parallel tasks on one repo cannot collide.
-- **Two task shapes** - ship tasks change projects and ship by project mode (`no-mistakes`, `direct-PR`, or `local-only`); scout tasks investigate, plan, reproduce bugs, or audit, then leave a report at `data/<id>/report.md` and never push.
+- **Two task shapes** - ship tasks change projects and ship by project mode (`no-mistakes`, `direct-PR`, or `local-only`); ordinary ship work uses Fast Gate by default: isolated worktree, focused checks, diff review, commit, and risk summary.
+  Full no-mistakes is reserved for high-risk, release/deploy, security-sensitive, dependency, broad-refactor, multi-subsystem, or explicitly requested work.
+  Scout tasks investigate, plan, reproduce bugs, or audit, then leave a report at `data/<id>/report.md` and never push.
 - **Optional secondmates** - `data/secondmates.md` records persistent domain supervisors with natural-language scopes, project clone lists, and home paths.
   `fm-home-seed.sh` provisions the isolated home, clones the listed PR-based projects into it, initializes newly cloned `no-mistakes` projects, copies the charter to `data/charter.md`, and `fm-spawn.sh --secondmate` launches it through the same tmux and status-file path as any direct report.
   When seeded with `-`, the home is a durable treehouse lease under the secondmate id, so it survives with no live process and is not recycled by later `treehouse get` or pruning.
@@ -133,8 +137,9 @@ firstmate works from any terminal - outside tmux, crewmates land in a detached `
   Secondmates are idle by default: after startup recovery reconciles only work already in their own home, an empty queue waits silently for routed tasks, and they never self-initiate surveys or audits.
   After seeding a secondmate, `fm-backlog-handoff.sh` moves already-judged in-scope queued items from the main backlog into that secondmate home so the domain queue starts in the right place.
   Idle secondmate panes are healthy; teardown is explicit and refuses while the secondmate home has in-flight work unless the captain has approved discard with `--force`.
-- **Project modes are explicit** - `data/projects.md` records each project's delivery mode and optional `+yolo` autonomy flag.
-  `no-mistakes` projects run the full validation pipeline, `direct-PR` projects run the PR-readiness audit before opening PRs without that pipeline, and `local-only` projects stay local until firstmate performs an approved fast-forward merge.
+- **Project modes are explicit** - `data/projects.md` records each work repo's delivery mode and optional `+yolo` autonomy flag.
+  Tooling repos are not ordinary work destinations unless the task edits that tool repo.
+  `no-mistakes` remains the high-assurance escalation/fallback, `direct-PR` projects run the PR-readiness audit before opening PRs without the full pipeline, and `local-only` projects stay local until firstmate performs an approved fast-forward merge.
 - **Project memory belongs to projects** - durable project-intrinsic agent knowledge lives in each project's committed `AGENTS.md`, with `CLAUDE.md` as a symlink.
   Ship briefs prompt crewmates to create or update those files through the normal delivery path; `data/projects.md` stays a thin private registry.
 - **Local clones stay fresh** - bootstrap and PR-based teardown refresh remote-backed project clones with clean default-branch fast-forwards when the clone is on the default branch and has no local work, and prune local branches whose remote is gone and that no worktree still needs.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -16,10 +16,12 @@
 #   only captain-relevant escalations append to this home's status file.
 #   Set FM_SECONDMATE_CHARTER='<charter>' to fill the charter text.
 #   Set FM_SECONDMATE_SCOPE='<scope>' to write a routing scope distinct from the charter text.
-# For ship tasks, the definition of done is shaped by the project's delivery mode
-# (data/projects.md via fm-project-mode.sh; see AGENTS.md sections 6-7):
-#   no-mistakes  implement -> /no-mistakes pipeline -> PR -> captain merge (default)
-#   direct-PR    implement -> push + open PR via gh-axi (no pipeline) -> captain merge
+# For ship tasks, validation defaults to Fast Gate (isolated worktree, focused
+# checks, diff review, commit, risk summary). The project's delivery mode still
+# controls PR/local merge mechanics (data/projects.md via fm-project-mode.sh;
+# see AGENTS.md sections 6-7):
+#   no-mistakes  Fast Gate by default; full no-mistakes only for high assurance
+#   direct-PR    Fast Gate -> push + open PR via gh-axi -> captain merge
 #   local-only   implement on branch, stop and report "ready in branch" (no push/PR);
 #                firstmate reviews, captain approves, firstmate merges to local main
 # Scout tasks ignore mode - their deliverable is a report, not a merge.
@@ -162,9 +164,9 @@ case "$MODE" in
     RULE1='1. Never push to the default branch (push only your `fm/'"$ID"'` branch). Never merge a PR.'
     DOD=$(cat <<EOF
 # Definition of done
-This project ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
-The task is complete only when committed on your branch.
-When it is implemented and committed, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\` to the status file and stop.
+This project ships **direct-PR**: you raise the PR yourself after Fast Gate, without the full no-mistakes pipeline.
+Fast Gate means: run focused relevant checks for the files/behavior you changed; run lint/typecheck only when relevant and cheap; review your diff; commit the finished change; write a short risk summary with checks run and checks skipped.
+When it is implemented, checked, diff-reviewed, and committed, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}; checks {summary}; risk {low|medium|high}\` to the status file and stop.
 Do NOT run /no-mistakes. The captain reviews and merges the PR; firstmate relays it.
 EOF
 )
@@ -174,25 +176,24 @@ EOF
     RULE1="1. Never push to any remote and never open a PR. Work only on your \`fm/$ID\` branch; firstmate handles the merge into local \`main\`."
     DOD=$(cat <<EOF
 # Definition of done
-This project ships **local-only**: no remote, no PR, no pipeline.
-The task is complete only when committed on your branch \`fm/$ID\`. Do NOT push, do NOT open a PR, do NOT merge.
+This project ships **local-only**: no remote, no PR, no full no-mistakes pipeline.
+Fast Gate means: run focused relevant checks for the files/behavior you changed; run lint/typecheck only when relevant and cheap; review your diff; commit the finished change; write a short risk summary with checks run and checks skipped.
+The task is complete only when Fast Gate is done and the change is committed on your branch \`fm/$ID\`. Do NOT push, do NOT open a PR, do NOT merge.
 Keep your branch a clean fast-forward onto the current default branch - if \`main\` has advanced, rebase onto it so the eventual merge stays a fast-forward.
-When it is implemented and committed, append \`done: ready in branch fm/$ID\` to the status file and stop.
+When it is implemented, checked, diff-reviewed, and committed, append \`done: ready in branch fm/$ID; checks {summary}; risk {low|medium|high}\` to the status file and stop.
 Firstmate then reviews your branch diff, the captain approves, and firstmate merges it into local \`main\`.
 EOF
 )
     ;;
-  *)  # no-mistakes (default)
-    SETUP2="
-2. Run \`no-mistakes doctor\`; if it reports the repo is not initialized here, run \`no-mistakes init\`."
+  *)  # no-mistakes delivery mode; Fast Gate is the ordinary-work default.
+    SETUP2=""
     RULE1='1. Never push to the default branch. Never merge a PR.'
     DOD=$(cat <<EOF
 # Definition of done
-The task is complete only when committed on your branch.
-When you believe it is complete, append \`done: {summary}\` to the status file and stop.
-Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
-During validation, fix auto-fix findings yourself; escalate ask-user findings per rule 6.
-After /no-mistakes reports CI green, append \`done: PR {url} checks green\` and stop. You are finished.
+Fast Gate is the default for ordinary ship work: run focused relevant checks for the files/behavior you changed; run lint/typecheck only when relevant and cheap; review your diff; commit the finished change; write a short risk summary with checks run and checks skipped.
+Escalate before final status if the work is security-sensitive, release/deploy-related, a dependency upgrade, a broad refactor, spans multiple subsystems, or the task explicitly requests full no-mistakes.
+When Fast Gate is done and the change is committed, append \`done: {summary}; checks {summary}; risk {low|medium|high}\` to the status file and stop.
+If firstmate escalates this task to full no-mistakes, run the harness-appropriate no-mistakes flow then append \`done: PR {url} checks green\` after CI is green. You are finished.
 EOF
 )
     ;;

--- a/bin/fm-project-mode.sh
+++ b/bin/fm-project-mode.sh
@@ -9,15 +9,16 @@
 #   - <name> [<mode> +yolo] - <desc> (added <date>)    -> <mode> on
 #
 # mode = how a finished change reaches main:
-#   no-mistakes  full pipeline -> PR -> captain merge (default)
-#   direct-PR    push + PR via gh-axi, no pipeline -> captain merge
+#   no-mistakes  PR-capable legacy default; full pipeline only for high assurance
+#   direct-PR    push + PR via gh-axi, no full pipeline -> captain merge
 #   local-only   local branch, no remote/PR -> firstmate review -> captain approve -> local merge
 # yolo (orthogonal) = when on, firstmate makes approval decisions itself (PR merges,
 #   ask-user findings, local-only merge approval) without checking the captain - except
 #   anything destructive/irreversible/security-sensitive, which still escalates.
 #
 # An unknown/missing project or unknown mode falls back to "no-mistakes off" and warns
-# to stderr, so a typo never silently drops the gate.
+# to stderr, so a typo never silently drops the legacy fallback while work/tooling
+# registry split and Codex Desktop project resolution mature.
 # Usage: fm-project-mode.sh <project-name>
 set -eu
 

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -26,8 +26,8 @@
 # On success prints: spawned <id> backend=<backend> harness=<name> kind=<ship|scout|secondmate> mode=<mode> yolo=<on|off> window=<session:window> worktree=<path>
 # mode/yolo are resolved per-project from data/projects.md for ship/scout tasks;
 # secondmate spawns record mode=secondmate, yolo=off, home=, and projects=.
-# backend=tmux-treehouse is the legacy worker backend. Future Codex Desktop
-# workers should add their own backend value without removing these fields.
+# backend=tmux-treehouse is the current implemented worker backend. Future Codex
+# Desktop workers should add their own backend value without removing these fields.
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -23,9 +23,11 @@
 #     __PIEXT__    absolute path to state/<task-id>.pi-ext.ts (pi turn-end extension,
 #                  written by this script; outside the worktree to avoid pi's trust gate)
 # Per-harness turn-end hooks are installed automatically; some live outside the worktree.
-# On success prints: spawned <id> harness=<name> kind=<ship|scout|secondmate> mode=<mode> yolo=<on|off> window=<session:window> worktree=<path>
+# On success prints: spawned <id> backend=<backend> harness=<name> kind=<ship|scout|secondmate> mode=<mode> yolo=<on|off> window=<session:window> worktree=<path>
 # mode/yolo are resolved per-project from data/projects.md for ship/scout tasks;
 # secondmate spawns record mode=secondmate, yolo=off, home=, and projects=.
+# backend=tmux-treehouse is the legacy worker backend. Future Codex Desktop
+# workers should add their own backend value without removing these fields.
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -402,6 +404,7 @@ fi
 # Recorded in meta so fm-teardown's safety check and the validate/merge stages can
 # branch on them. Mode governs ship tasks; a scout's deliverable is a report, not a
 # merge, so scout teardown ignores mode.
+BACKEND=tmux-treehouse
 SECONDMATE_PROJECTS=
 if [ "$KIND" = secondmate ]; then
   MODE=secondmate
@@ -416,6 +419,14 @@ fi
 
 mkdir -p "$STATE"
 {
+  echo "backend=$BACKEND"
+  echo "worker_id=$T"
+  echo "worker_project_path=$PROJ_ABS"
+  if [ "$KIND" = secondmate ]; then
+    echo "environment=firstmate-home"
+  else
+    echo "environment=treehouse"
+  fi
   echo "window=$T"
   echo "worktree=$WT"
   echo "project=$PROJ_ABS"
@@ -443,4 +454,4 @@ tmux send-keys -t "$T" -l "$LAUNCH"
 sleep 0.3
 tmux send-keys -t "$T" Enter
 
-echo "spawned $ID harness=$HARNESS kind=$KIND mode=$MODE yolo=$YOLO window=$T worktree=$WT"
+echo "spawned $ID backend=$BACKEND harness=$HARNESS kind=$KIND mode=$MODE yolo=$YOLO window=$T worktree=$WT"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -27,7 +27,8 @@
 # mode/yolo are resolved per-project from data/projects.md for ship/scout tasks;
 # secondmate spawns record mode=secondmate, yolo=off, home=, and projects=.
 # backend=tmux-treehouse is the current implemented worker backend. Future Codex
-# Desktop workers should add their own backend value without removing these fields.
+# Desktop workers should add their own backend value only when a real project/thread
+# API exists, without removing these fields.
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -140,6 +141,64 @@ launch_template() {
   esac
 }
 
+current_worker_backend() {
+  printf '%s\n' "${FM_WORKER_BACKEND:-tmux-treehouse}"
+}
+
+require_supported_worker_backend() {
+  local backend=$1
+  case "$backend" in
+    tmux-treehouse) ;;
+    codex-desktop)
+      echo "error: worker backend codex-desktop is not implemented; no callable Codex Desktop project/thread API exists yet" >&2
+      return 1
+      ;;
+    *)
+      echo "error: unsupported worker backend '$backend'" >&2
+      return 1
+      ;;
+  esac
+}
+
+worker_environment() {
+  if [ "$KIND" = secondmate ]; then
+    printf '%s\n' firstmate-home
+  else
+    printf '%s\n' treehouse
+  fi
+}
+
+worker_id() {
+  printf '%s\n' "$T"
+}
+
+worker_project_path() {
+  printf '%s\n' "$PROJ_ABS"
+}
+
+write_spawn_meta() {
+  local environment
+  environment=$(worker_environment)
+  mkdir -p "$STATE"
+  {
+    echo "backend=$BACKEND"
+    echo "worker_id=$(worker_id)"
+    echo "worker_project_path=$(worker_project_path)"
+    echo "environment=$environment"
+    echo "window=$T"
+    echo "worktree=$WT"
+    echo "project=$PROJ_ABS"
+    echo "harness=$HARNESS"
+    echo "kind=$KIND"
+    echo "mode=$MODE"
+    echo "yolo=$YOLO"
+    if [ "$KIND" = secondmate ]; then
+      echo "home=$PROJ_ABS"
+      echo "projects=$SECONDMATE_PROJECTS"
+    fi
+  } > "$STATE/$ID.meta"
+}
+
 case "$ARG3" in
   *' '*)  # raw launch command (unverified-adapter escape hatch)
     LAUNCH=$ARG3
@@ -157,6 +216,9 @@ case "$ARG3" in
     LAUNCH=$(launch_template "$HARNESS" "$KIND") || { echo "error: unknown harness '$HARNESS'; pass a raw launch command to use an unverified adapter" >&2; exit 1; }
     ;;
 esac
+
+BACKEND=$(current_worker_backend)
+require_supported_worker_backend "$BACKEND" || exit 1
 
 secondmate_registry_value() {
   local id=$1 key=$2 reg line value
@@ -404,7 +466,6 @@ fi
 # Recorded in meta so fm-teardown's safety check and the validate/merge stages can
 # branch on them. Mode governs ship tasks; a scout's deliverable is a report, not a
 # merge, so scout teardown ignores mode.
-BACKEND=tmux-treehouse
 SECONDMATE_PROJECTS=
 if [ "$KIND" = secondmate ]; then
   MODE=secondmate
@@ -417,28 +478,7 @@ $("$FM_ROOT/bin/fm-project-mode.sh" "$PROJ_NAME")
 EOF
 fi
 
-mkdir -p "$STATE"
-{
-  echo "backend=$BACKEND"
-  echo "worker_id=$T"
-  echo "worker_project_path=$PROJ_ABS"
-  if [ "$KIND" = secondmate ]; then
-    echo "environment=firstmate-home"
-  else
-    echo "environment=treehouse"
-  fi
-  echo "window=$T"
-  echo "worktree=$WT"
-  echo "project=$PROJ_ABS"
-  echo "harness=$HARNESS"
-  echo "kind=$KIND"
-  echo "mode=$MODE"
-  echo "yolo=$YOLO"
-  if [ "$KIND" = secondmate ]; then
-    echo "home=$PROJ_ABS"
-    echo "projects=$SECONDMATE_PROJECTS"
-  fi
-} > "$STATE/$ID.meta"
+write_spawn_meta
 
 sq_brief=$(shell_quote "$BRIEF")
 sq_turnend=$(shell_quote "$TURNEND")

--- a/tests/fm-secondmate.test.sh
+++ b/tests/fm-secondmate.test.sh
@@ -1081,7 +1081,7 @@ test_secondmate_spawn_records_home_meta() {
     || fail "secondmate spawn failed"
 
   meta="$home/state/spawn-sub.meta"
-  grep -Fx 'backend=tmux-treehouse' "$meta" >/dev/null || fail "meta did not record legacy worker backend"
+  grep -Fx 'backend=tmux-treehouse' "$meta" >/dev/null || fail "meta did not record implemented worker backend"
   grep -Fx 'worker_id=firstmate:fm-spawn-sub' "$meta" >/dev/null || fail "meta did not record worker id"
   grep -Fx "worker_project_path=$subhome_abs" "$meta" >/dev/null || fail "meta did not record worker project path"
   grep -Fx 'environment=firstmate-home' "$meta" >/dev/null || fail "meta did not record worker environment"

--- a/tests/fm-secondmate.test.sh
+++ b/tests/fm-secondmate.test.sh
@@ -221,6 +221,12 @@ test_fm_home_parameterization() {
   brief="$home_one/data/task-a/brief.md"
   [ -f "$brief" ] || fail "brief was not written under FM_HOME/data"
   grep -F ">> '$home_one/state/task-a.status'" "$brief" >/dev/null || fail "brief did not shell-quote FM_HOME state path"
+  grep -F 'Fast Gate means: run focused relevant checks' "$brief" >/dev/null || fail "local-only ship brief did not include Fast Gate"
+
+  FM_HOME="$home_one" "$ROOT/bin/fm-brief.sh" task-fast fallback-app >/dev/null 2>/dev/null || fail "default ship brief scaffold failed under FM_HOME"
+  brief="$home_one/data/task-fast/brief.md"
+  grep -F 'Fast Gate is the default for ordinary ship work' "$brief" >/dev/null || fail "default ship brief did not make Fast Gate default"
+  grep -F 'no-mistakes doctor' "$brief" >/dev/null && fail "default ship brief still forces no-mistakes setup"
 
   FM_HOME="$home_one" "$ROOT/bin/fm-brief.sh" task-b app --scout >/dev/null || fail "scout brief scaffold failed under FM_HOME"
   brief="$home_one/data/task-b/brief.md"
@@ -1057,7 +1063,7 @@ test_home_seed_refuses_symlinked_leaf_files() {
 }
 
 test_secondmate_spawn_records_home_meta() {
-  local home subhome subhome_abs fakebin log meta
+  local home subhome subhome_abs fakebin log meta out
   home="$TMP_ROOT/spawn home"
   subhome="$TMP_ROOT/spawn subhome"
   mkdir -p "$home/data/spawn-sub" "$home/state" "$subhome/data"
@@ -1070,14 +1076,19 @@ test_secondmate_spawn_records_home_meta() {
   fakebin=$(make_fake_tmux "$TMP_ROOT/spawn-fake")
   log="$TMP_ROOT/spawn-fake/tmux.log"
 
-  PATH="$fakebin:$PATH" FM_HOME="$home" FM_CONFIG_OVERRIDE="$home/parent-config" FM_FAKE_TMUX_LOG="$log" FM_FAKE_TMUX_CAPTURE="$TMP_ROOT/spawn-fake/pane.txt" \
-    "$ROOT/bin/fm-spawn.sh" spawn-sub "$subhome" codex --secondmate >/dev/null \
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_CONFIG_OVERRIDE="$home/parent-config" FM_FAKE_TMUX_LOG="$log" FM_FAKE_TMUX_CAPTURE="$TMP_ROOT/spawn-fake/pane.txt" \
+    "$ROOT/bin/fm-spawn.sh" spawn-sub "$subhome" codex --secondmate) \
     || fail "secondmate spawn failed"
 
   meta="$home/state/spawn-sub.meta"
+  grep -Fx 'backend=tmux-treehouse' "$meta" >/dev/null || fail "meta did not record legacy worker backend"
+  grep -Fx 'worker_id=firstmate:fm-spawn-sub' "$meta" >/dev/null || fail "meta did not record worker id"
+  grep -Fx "worker_project_path=$subhome_abs" "$meta" >/dev/null || fail "meta did not record worker project path"
+  grep -Fx 'environment=firstmate-home' "$meta" >/dev/null || fail "meta did not record worker environment"
   grep -Fx 'kind=secondmate' "$meta" >/dev/null || fail "meta did not record kind=secondmate"
   grep -Fx "home=$subhome_abs" "$meta" >/dev/null || fail "meta did not record subhome"
   grep -Fx 'projects=alpha, beta' "$meta" >/dev/null || fail "meta did not record project clone list"
+  printf '%s\n' "$out" | grep -F 'spawned spawn-sub backend=tmux-treehouse' >/dev/null || fail "spawn output did not include backend"
   grep -F 'treehouse get' "$log" >/dev/null && fail "secondmate spawn should not run project treehouse get"
   grep -F "FM_HOME='$subhome_abs'" "$log" >/dev/null || fail "secondmate launch did not set FM_HOME to subhome"
   grep -F 'FM_ROOT_OVERRIDE= FM_STATE_OVERRIDE= FM_DATA_OVERRIDE= FM_PROJECTS_OVERRIDE=' "$log" >/dev/null || fail "secondmate launch did not clear operational overrides"

--- a/tests/fm-spawn-backend.test.sh
+++ b/tests/fm-spawn-backend.test.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# Behavior tests for fm-spawn.sh worker backend metadata and tmux-treehouse path.
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SPAWN="$ROOT/bin/fm-spawn.sh"
+TMP_ROOT=
+
+fail() {
+  printf 'not ok - %s\n' "$1" >&2
+  exit 1
+}
+
+pass() {
+  printf 'ok - %s\n' "$1"
+}
+
+cleanup() {
+  if [ -n "${TMP_ROOT:-}" ]; then
+    rm -rf "$TMP_ROOT"
+  fi
+}
+
+trap cleanup EXIT
+
+TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/fm-spawn-backend.XXXXXX")
+
+make_fake_tmux() {
+  local dir=$1 fakebin log
+  fakebin="$dir/fakebin"
+  log="$dir/tmux.log"
+  mkdir -p "$fakebin"
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "${1:-}" in
+  has-session|new-session|new-window|send-keys)
+    printf '%s\n' "$*" >> "$FM_FAKE_TMUX_LOG"
+    exit 0
+    ;;
+  list-windows)
+    if [ -n "${FM_FAKE_TMUX_WINDOW:-}" ]; then
+      printf '%s\n' "$FM_FAKE_TMUX_WINDOW"
+    fi
+    exit 0
+    ;;
+  display-message)
+    case " $* " in
+      *'#{pane_current_path}'*) printf '%s\n' "$FM_FAKE_TMUX_PANE_PATH" ;;
+      *) printf 'firstmate\n' ;;
+    esac
+    exit 0
+    ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/tmux"
+  : > "$log"
+  printf '%s\n' "$fakebin"
+}
+
+make_home_with_project() {
+  local home=$1 project=$2 mode=${3:-direct-PR} yolo=${4-+yolo}
+  mkdir -p "$home/data" "$home/projects/$project"
+  cat > "$home/data/projects.md" <<EOF
+# Projects
+
+- $project [$mode $yolo] - backend spawn test project (added 2026-06-24)
+EOF
+}
+
+test_ship_spawn_records_backend_metadata() {
+  local home project wt fakebin log out meta project_abs wt_abs
+  home="$TMP_ROOT/ship-home"
+  project=alpha
+  wt="$TMP_ROOT/ship-worktree"
+  mkdir -p "$wt"
+  make_home_with_project "$home" "$project"
+  mkdir -p "$home/data/backend-ship"
+  printf 'ship brief\n' > "$home/data/backend-ship/brief.md"
+  project_abs=$(cd "$home/projects/$project" && pwd)
+  wt_abs=$(cd "$wt" && pwd)
+  fakebin=$(make_fake_tmux "$TMP_ROOT/ship-fake")
+  log="$TMP_ROOT/ship-fake/tmux.log"
+
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SPAWN_NO_GUARD=1 \
+    FM_FAKE_TMUX_LOG="$log" FM_FAKE_TMUX_PANE_PATH="$wt_abs" \
+    "$SPAWN" backend-ship "projects/$project" codex 2>&1) \
+    || fail "ship spawn failed: $out"
+
+  meta="$home/state/backend-ship.meta"
+  grep -Fx 'backend=tmux-treehouse' "$meta" >/dev/null || fail "meta did not record backend"
+  grep -Fx 'worker_id=firstmate:fm-backend-ship' "$meta" >/dev/null || fail "meta did not record worker id"
+  grep -Fx "worker_project_path=$project_abs" "$meta" >/dev/null || fail "meta did not record project path"
+  grep -Fx 'environment=treehouse' "$meta" >/dev/null || fail "meta did not record treehouse environment"
+  grep -Fx 'window=firstmate:fm-backend-ship' "$meta" >/dev/null || fail "meta did not record tmux window"
+  grep -Fx "worktree=$wt_abs" "$meta" >/dev/null || fail "meta did not record worktree"
+  grep -Fx "project=$project_abs" "$meta" >/dev/null || fail "meta did not record project"
+  grep -Fx 'harness=codex' "$meta" >/dev/null || fail "meta did not record harness"
+  grep -Fx 'kind=ship' "$meta" >/dev/null || fail "meta did not record ship kind"
+  grep -Fx 'mode=direct-PR' "$meta" >/dev/null || fail "meta did not record project mode"
+  grep -Fx 'yolo=on' "$meta" >/dev/null || fail "meta did not record yolo"
+  printf '%s\n' "$out" | grep -F "spawned backend-ship backend=tmux-treehouse harness=codex kind=ship mode=direct-PR yolo=on window=firstmate:fm-backend-ship worktree=$wt_abs" >/dev/null \
+    || fail "spawn output did not preserve backend summary"
+  grep -F "new-window -d -t firstmate -n fm-backend-ship -c $project_abs" "$log" >/dev/null \
+    || fail "spawn did not create tmux window in project"
+  grep -F 'send-keys -t firstmate:fm-backend-ship treehouse get Enter' "$log" >/dev/null \
+    || fail "spawn did not keep treehouse get launch path"
+  grep -F 'codex --dangerously-bypass-approvals-and-sandbox -c "notify=' "$log" >/dev/null \
+    || fail "spawn did not send codex launch command"
+  pass "ship spawn records explicit tmux-treehouse backend metadata"
+}
+
+test_scout_spawn_uses_same_backend_boundary() {
+  local home project wt fakebin log out meta wt_abs
+  home="$TMP_ROOT/scout-home"
+  project=bravo
+  wt="$TMP_ROOT/scout-worktree"
+  mkdir -p "$wt"
+  make_home_with_project "$home" "$project" local-only ''
+  mkdir -p "$home/data/backend-scout"
+  printf 'scout brief\n' > "$home/data/backend-scout/brief.md"
+  wt_abs=$(cd "$wt" && pwd)
+  fakebin=$(make_fake_tmux "$TMP_ROOT/scout-fake")
+  log="$TMP_ROOT/scout-fake/tmux.log"
+
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SPAWN_NO_GUARD=1 \
+    FM_FAKE_TMUX_LOG="$log" FM_FAKE_TMUX_PANE_PATH="$wt_abs" \
+    "$SPAWN" backend-scout "projects/$project" codex --scout 2>&1) \
+    || fail "scout spawn failed: $out"
+
+  meta="$home/state/backend-scout.meta"
+  grep -Fx 'backend=tmux-treehouse' "$meta" >/dev/null || fail "scout meta did not record backend"
+  grep -Fx 'environment=treehouse' "$meta" >/dev/null || fail "scout meta did not record environment"
+  grep -Fx 'kind=scout' "$meta" >/dev/null || fail "scout meta did not record scout kind"
+  grep -Fx 'mode=local-only' "$meta" >/dev/null || fail "scout meta did not keep project mode"
+  grep -Fx 'yolo=off' "$meta" >/dev/null || fail "scout meta did not record yolo off"
+  printf '%s\n' "$out" | grep -F "spawned backend-scout backend=tmux-treehouse harness=codex kind=scout mode=local-only yolo=off window=firstmate:fm-backend-scout worktree=$wt_abs" >/dev/null \
+    || fail "scout output did not preserve backend summary"
+  grep -F 'send-keys -t firstmate:fm-backend-scout treehouse get Enter' "$log" >/dev/null \
+    || fail "scout spawn did not keep treehouse get launch path"
+  pass "scout spawn uses the same explicit backend metadata"
+}
+
+test_codex_desktop_backend_fails_closed_until_real_api_exists() {
+  local home project wt fakebin log out status
+  home="$TMP_ROOT/unsupported-home"
+  project=charlie
+  wt="$TMP_ROOT/unsupported-worktree"
+  mkdir -p "$wt"
+  make_home_with_project "$home" "$project"
+  mkdir -p "$home/data/backend-unsupported"
+  printf 'brief\n' > "$home/data/backend-unsupported/brief.md"
+  fakebin=$(make_fake_tmux "$TMP_ROOT/unsupported-fake")
+  log="$TMP_ROOT/unsupported-fake/tmux.log"
+
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SPAWN_NO_GUARD=1 \
+    FM_WORKER_BACKEND=codex-desktop FM_FAKE_TMUX_LOG="$log" FM_FAKE_TMUX_PANE_PATH="$wt" \
+    "$SPAWN" backend-unsupported "projects/$project" codex 2>&1)
+  status=$?
+  [ "$status" -ne 0 ] || fail "codex-desktop backend should fail until implemented"
+  printf '%s\n' "$out" | grep -F 'worker backend codex-desktop is not implemented' >/dev/null \
+    || fail "codex-desktop refusal did not explain missing real API"
+  [ ! -s "$log" ] || fail "unsupported backend reached tmux side effects"
+  [ ! -e "$home/state/backend-unsupported.meta" ] || fail "unsupported backend wrote metadata"
+  pass "codex-desktop backend fails closed before tmux side effects"
+}
+
+test_ship_spawn_records_backend_metadata
+test_scout_spawn_uses_same_backend_boundary
+test_codex_desktop_backend_fails_closed_until_real_api_exists


### PR DESCRIPTION
## What

Adds Codex Desktop orchestration groundwork while preserving the current tmux-treehouse worker behavior.

## Why

Firstmate needs an explicit worker backend seam before native Codex Desktop project/thread workers can be introduced. The current implementation remains tmux plus treehouse until a real Desktop API is available.

## Changes

- Clarifies Fast Gate, PR-readiness, and worker backend metadata guidance for the orchestration migration.
- Records current worker metadata for tmux-treehouse spawns.
- Adds a minimal `fm-spawn.sh` backend boundary that selects `tmux-treehouse` by default and fails closed for `codex-desktop` until a real API exists.
- Adds spawn backend behavior tests for ship/scout metadata, output, and unsupported Desktop backend side effects.

## Validation

- `bash -n bin/*.sh tests/*.sh` - passed
- `shellcheck bin/*.sh tests/*.sh` - passed
- `for test_script in tests/*.test.sh; do "$test_script"; done` - passed
- Independent read-only review gate - APPROVE across requirements, tests, security/secrets, and repo patterns
- GitHub checks: unavailable before PR creation

## Notes

The current implemented worker backend remains `tmux-treehouse`. This does not fake Codex Desktop project or thread creation.