### PR TITLE
feat: add Droid harness support

### DIFF
--- a/.agents/skills/afk/SKILL.md
+++ b/.agents/skills/afk/SKILL.md
@@ -72,7 +72,7 @@ separator, 0x1f) — invisible and untypable. This is how firstmate tells a
 daemon escalation apart from a real message in the same pane. The marker
 travels with the message text; it does not rely on harness-level
 typed-vs-injected detection (which is not portable across claude, codex,
-opencode, and pi).
+opencode, pi, and droid).
 
 ## Busy-guard and composer guard
 
@@ -82,12 +82,15 @@ injection (shared with `fm-send.sh` via `bin/fm-tmux-lib.sh`):
 - **`pane_is_busy`** — the harness shows a busy footer (agent mid-turn).
 - **`pane_input_pending`** — the cursor line holds real unsubmitted text (a
   human's half-typed line, or a previous injection whose Enter was swallowed).
-  The detector **strips the harness's composer box borders first**, so an idle
-  *bordered* composer (claude draws `│ > … │`) is correctly read as empty, not
-  pending. Without this, every idle claude pane looked like pending input and
+  The detector **drops dim/faint ghost text and strips the harness's composer
+  box borders first**, so an idle *bordered* composer (claude draws `│ > … │`)
+  or ghost-only composer is correctly read as empty, not pending.
+  Without border stripping, every idle claude pane looked like pending input and
   the daemon deferred 100% of escalations (incident afk-invx-i5).
-  `FM_COMPOSER_IDLE_RE` still overrides empty-composer matching after border
-  stripping.
+  Without dim/faint stripping, ghost suggestions can look like real typed text
+  and stall delivery (incident composer-robust).
+  `FM_COMPOSER_IDLE_RE` still overrides empty-composer matching after
+  dim-ghost and border stripping.
 
 Either condition defers the injection; the buffered escalation survives in
 `state/.subsuper-escalations` and is retried on the next housekeeping tick. In
@@ -110,9 +113,10 @@ The digest is typed **once** via `send-keys -l`, then submitted with Enter and
 **verified**: Enter is retried (Enter only, never a retype) until the composer
 clears.
 A submit "landed" only when the composer is confirmed empty afterward, using
-the same corrected, border-aware detector as the composer guard.
-A bordered-empty claude composer is recognized as submitted rather than
-mistaken for a swallowed Enter.
+the same corrected, dim-ghost-aware and border-aware detector as the composer
+guard.
+A ghost-only or bordered-empty claude composer is recognized as submitted
+rather than mistaken for a swallowed Enter.
 `fm-send.sh` uses the same primitive and exits non-zero
 when a steer's Enter is positively swallowed, so firstmate learns an instruction
 did not land instead of leaving it unsubmitted.

--- a/.agents/skills/updatefirstmate/SKILL.md
+++ b/.agents/skills/updatefirstmate/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: updatefirstmate
-description: Self-update a running firstmate and its secondmates to the latest from origin. Use when the captain invokes /updatefirstmate (e.g. "/updatefirstmate", "update firstmate", "pull the latest firstmate"). Fast-forwards this firstmate repo's default branch and every secondmate home from origin (fast-forward only, never forced, never disruptive), then re-reads AGENTS.md and nudges each updated secondmate to do the same, so the whole tree runs the latest bin/ and instructions.
+description: Self-update a running firstmate and its secondmates to the latest from origin. Use when the captain invokes /updatefirstmate (e.g. "/updatefirstmate", "update firstmate", "pull the latest firstmate"). Fast-forwards this firstmate repo's default branch and every secondmate home from origin (fast-forward only, never forced, never disruptive), then re-reads AGENTS.md and nudges each updated secondmate to do the same, so the whole tree runs the latest bin/, skills, compatibility symlinks, and instructions.
 user-invocable: true
 ---
 
 # updatefirstmate
 
 Self-update firstmate in place.
-Firstmate is its own repo, behind the same no-mistakes gate as any project, so new tracked material (AGENTS.md, bin/, skills) reaches `main` and then sits there until each running firstmate pulls it.
+Firstmate is its own repo, behind the same no-mistakes gate as any project, so new tracked material (AGENTS.md, bin/, skills, and tracked skill compatibility symlinks) reaches `main` and then sits there until each running firstmate pulls it.
 This skill performs that pull for the running main firstmate and every secondmate, without disturbing any in-flight work.
 
 The update is **fast-forward only** - the same sanctioned self-write as the fleet sync firstmate already runs.
@@ -27,7 +27,7 @@ This touches only the firstmate repo and its own worktrees, never anything under
    - `nudge-secondmates: <window-targets...>|none`
 
 2. **Re-read AGENTS.md if your own instructions changed.**
-   When the updater printed `reread-firstmate: yes`, the tracked instruction surface (AGENTS.md, bin/, or skills) just advanced under you.
+   When the updater printed `reread-firstmate: yes`, the tracked instruction surface (AGENTS.md, bin/, skills, or tracked skill compatibility symlinks) just advanced under you.
    **Read `AGENTS.md` now** (CLAUDE.md is a symlink to it) to refresh your operating instructions before doing anything else, so you are acting on the new instructions rather than the stale ones you were started with.
    When it printed `reread-firstmate: no`, nothing changed for you - skip the re-read.
 

--- a/.factory/skills
+++ b/.factory/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,7 @@ README.md            public overview and development notes
 .tasks.toml          tracked tasks-axi markdown backend config; drives backlog mutations when a compatible tasks-axi is on PATH (section 10), otherwise inert
 .agents/skills/      shared skills, committed
 .claude/skills       symlink to .agents/skills for claude compatibility
+.factory/skills      symlink to .agents/skills for droid compatibility
 bin/                 helper scripts, committed, including fm-fleet-sync.sh for clean default-branch refreshes and gone-branch pruning, and fm-update.sh for fast-forward-only self-updates; read each script's header before first use
 config/crew-harness  crewmate harness override; LOCAL, gitignored; absent or "default" = same as firstmate
 data/                personal fleet records; LOCAL, gitignored as a whole
@@ -208,6 +209,23 @@ Project trust dialog can appear on the first pi run in any not-yet-trusted direc
 fm-spawn keeps the turn-end extension in `state/`, outside the worktree, because project-local extension files make the trust gate strictly worse (and pollute the project).
 The extension must listen for pi's `turn_end` event, not `agent_end`, so the watcher wakes after each completed turn instead of only when the whole agent run exits.
 Environment marker for harness detection: pi sets `PI_CODING_AGENT=true` for its children.
+
+### droid (VERIFIED 2026-06-24, Droid CLI 0.157.1)
+
+| Fact | Value |
+|---|---|
+| Busy-pane signature | `Streaming... (Press ESC to stop)` or `Thinking... (Press ESC to stop)` |
+| Exit command | `/quit` |
+| Interrupt | single Escape |
+| Skill invocation | `/<skill>` when the skill is discoverable; otherwise steer with natural language |
+
+No trust dialog was observed in a fresh temporary directory.
+Launch with `--auto high` for autonomous crewmates; do not use `--skip-permissions-unsafe` for normal firstmate dispatch because Droid's high autonomy preserves its safety checks.
+For ship and scout tasks, fm-spawn writes a runtime-only `state/<id>.droid-settings.json` and launches Droid with `--settings` so a Stop hook touches `state/<id>.turn-ended` after each response.
+Secondmate launches omit the parent turn-end hook, the same as the other adapters.
+Droid discovers project skills from `.factory/skills`, so this repo tracks `.factory/skills` as a symlink to `.agents/skills`; `.claude/skills` remains the Claude compatibility symlink.
+Harness detection uses process ancestry (`droid` or a node wrapper whose args contain `droid`); no stable Droid-specific environment marker was observed.
+Resume after exit: `droid --resume [sessionId]` resumes the most recent or named session.
 
 ## 5. Recovery (run at every session start, after bootstrap)
 
@@ -422,7 +440,7 @@ Pooled clones keep their local default refs frozen at clone time and can lag `or
 ### Validate
 
 For `no-mistakes`-mode ship tasks, when a crewmate's status says `done`, trigger validation using the crew's harness from `state/<id>.meta`.
-Use `/no-mistakes` for claude, `$no-mistakes` for codex; natural language also works.
+Use `/no-mistakes` for claude and droid when the skill is discoverable, `$no-mistakes` for codex, and natural language for any harness where the slash skill is unavailable.
 For example, with claude:
 
 ```sh
@@ -556,7 +574,7 @@ With afk active:
 
 **In-band sentinel marker (the load-bearing detail).** The daemon injects into the same pane the captain types into, so an escalation would otherwise look like a user message and cancel afk the moment it fired.
 Every daemon injection is prefixed with `FM_INJECT_MARK` (ASCII unit separator, 0x1f) — a byte a human would never type at the start of a message.
-The marker travels with the message text; it does not rely on harness-level typed-vs-injected detection (not portable across claude, codex, opencode, pi).
+The marker travels with the message text; it does not rely on harness-level typed-vs-injected detection (not portable across claude, codex, opencode, pi, droid).
 
 **Exiting afk (the captain's contract).** When firstmate receives a message while afk is active:
 - Leading marker present → **internal escalation**. Stay afk, process it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,7 +221,7 @@ Environment marker for harness detection: pi sets `PI_CODING_AGENT=true` for its
 
 No trust dialog was observed in a fresh temporary directory.
 Launch with `--auto high` for autonomous crewmates; do not use `--skip-permissions-unsafe` for normal firstmate dispatch because Droid's high autonomy preserves its safety checks.
-For ship and scout tasks, fm-spawn writes a runtime-only `state/<id>.droid-settings.json` and launches Droid with `--settings` so a Stop hook touches `state/<id>.turn-ended` after each response.
+For ship and scout tasks, fm-spawn writes a runtime-only `state/<id>.droid-settings.json` and launches Droid with `--settings` so a Stop hook touches `state/<id>.turn-ended` after each response and Droid co-author trailers stay disabled.
 Secondmate launches omit the parent turn-end hook, the same as the other adapters.
 Droid discovers project skills from `.factory/skills`, so this repo tracks `.factory/skills` as a symlink to `.agents/skills`; `.claude/skills` remains the Claude compatibility symlink.
 Harness detection uses process ancestry (`droid` or a node wrapper whose args contain `droid`); no stable Droid-specific environment marker was observed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -719,7 +719,7 @@ Adjust the other sections only when the task genuinely deviates from the standar
 
 ## 12. Self-update
 
-firstmate is its own repo behind the no-mistakes gate, so improvements to `AGENTS.md`, `bin/`, and skills reach `main` and then wait for each running firstmate to pull them.
+firstmate is its own repo behind the no-mistakes gate, so improvements to `AGENTS.md`, `bin/`, skills, and tracked skill compatibility symlinks reach `main` and then wait for each running firstmate to pull them.
 The `/updatefirstmate` skill performs that pull in place for the running main firstmate and every secondmate.
 It runs `bin/fm-update.sh`, which fast-forwards this firstmate repo's default branch from origin and then fast-forwards every registered secondmate home (resolved from `state/*.meta` and `data/secondmates.md`) the same way.
 The mechanics mirror `bin/fm-fleet-sync.sh` exactly: fast-forward only, never forcing, never creating a merge commit, never stashing, and skipping with a reported reason anything dirty, diverged, offline, or on a non-default branch, so prime directive #3 holds and no unlanded work is ever discarded.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,8 +32,8 @@ See the [no-mistakes quick start](https://kunchenguid.github.io/no-mistakes/star
 ## Repo conventions
 
 - This repo is a template for running a firstmate orchestrator agent.
-  `AGENTS.md` is the agent's entire job description; `CLAUDE.md` is a symlink to it, and `.claude/skills` is a symlink to `.agents/skills`.
-- Only shared material is tracked: `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `.tasks.toml`, `.github/workflows/`, `bin/`, and `.agents/skills/`.
+  `AGENTS.md` is the agent's entire job description; `CLAUDE.md` is a symlink to it, `.claude/skills` is a symlink to `.agents/skills`, and `.factory/skills` is the Droid compatibility symlink.
+- Only shared material is tracked: `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `.tasks.toml`, `.github/workflows/`, `bin/`, `.agents/skills/`, and compatibility symlinks to those skills.
   Everything personal to one captain's fleet (`data/`, `state/`, `config/`, `projects/`, `.no-mistakes/`) is gitignored; never commit it.
   The root `.tasks.toml` is tracked `tasks-axi` config for `data/backlog.md`; compatible `tasks-axi` uses it for routine backlog mutations.
   It does not make `data/` tracked.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ $ claude   # launch your agent harness here; AGENTS.md takes over
 **Prerequisites** (the first mate detects everything else and offers to install it):
 
 ```sh
-# 1. a verified agent harness - claude, codex, opencode, or pi
+# 1. a verified agent harness - claude, codex, opencode, pi, or droid
 # 2. git + GitHub auth
 # 3. tmux - the crew lives in tmux windows (firstmate offers to install it if missing)
 gh auth login
@@ -192,7 +192,7 @@ After creating a secondmate, move existing main-backlog items that you have judg
 Set `FM_SECONDMATE_CHARTER` to seed from inline charter text when no filled charter brief exists; set `FM_SECONDMATE_SCOPE` when the routing scope should differ from the charter text.
 `FM_HOME` selects the operational home for one firstmate instance.
 When it is unset, the repo root is the home; when it is set, scripts still run from this repo's `bin/`, but `state/`, `data/`, `config/`, and `projects/` come from `$FM_HOME`.
-Harness support is a table in section 4: claude, codex, opencode, and pi are all empirically verified; new harnesses get verified through a supervised trial task before joining the table.
+Harness support is a table in section 4: claude, codex, opencode, pi, and droid are all empirically verified; new harnesses get verified through a supervised trial task before joining the table.
 
 Runtime tuning via environment variables (defaults shown):
 
@@ -207,7 +207,7 @@ FM_GUARD_GRACE=300      # seconds a stale watcher beacon may age before guard wa
 FM_SIGNAL_GRACE=30      # seconds to coalesce nearby status and turn-end signals into one wake
 FM_FLEET_SYNC_BOOTSTRAP_TIMEOUT=20   # seconds allowed for bootstrap's best-effort clone refresh
 FM_FLEET_PRUNE=1        # set to 0 to skip pruning local branches whose upstream is gone
-FM_BUSY_REGEX='esc (to )?interrupt|Working\.\.\.'   # busy-pane signatures, shared by watcher and tmux helper
+FM_BUSY_REGEX='esc (to )?interrupt|Working\.\.\.|(Streaming|Thinking)\.\.\..*Press ESC to stop'   # busy-pane signatures, shared by watcher and tmux helper
 FM_COMPOSER_IDLE_RE=    # optional empty-composer regex, applied after dim-ghost and border stripping
 FM_SEND_RETRIES=3       # fm-send Enter-retry attempts after typing the line once
 FM_SEND_SLEEP=0.4       # seconds between fm-send submit checks
@@ -245,5 +245,6 @@ tests/fm-secondmate.test.sh               # persistent secondmate routing, seedi
 tests/fm-teardown.test.sh                 # fm-teardown.sh safety and reminder checks: local-only fork-remote allow, truly-unpushed refuse, merged-to-main allow, no-mistakes regression, tasks-axi reminder, --force override
 [ "$(readlink CLAUDE.md)" = "AGENTS.md" ]
 [ "$(readlink .claude/skills)" = "../.agents/skills" ]
+[ "$(readlink .factory/skills)" = "../.agents/skills" ]
 FM_HEARTBEAT=2 FM_POLL=1 bin/fm-watch.sh  # watcher smoke test (prints "heartbeat")
 ```

--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ tests/fm-wake-queue.test.sh               # durable wake queue, singleton behavi
 tests/fm-composer-ghost.test.sh           # dim-ghost stripping, ghost-only composer detection, and escape-free peek tests
 tests/fm-afk-inject-e2e.test.sh           # private-socket end-to-end test of the afk injection path (partial-input deferral, swallowed-Enter retry)
 tests/fm-bootstrap.test.sh                # bootstrap dependency and feature-probe tests
+tests/fm-droid-harness.test.sh            # Droid launch templates, runtime Stop hook settings, and secondmate behavior tests
 tests/fm-update.test.sh                   # fast-forward-only self-update, reread, nudge, dedup, and skip-safety tests
 tests/fm-secondmate.test.sh               # persistent secondmate routing, seeding, idle charter, backlog handoff, spawn, recovery, teardown, and FM_HOME tests
 tests/fm-teardown.test.sh                 # fm-teardown.sh safety and reminder checks: local-only fork-remote allow, truly-unpushed refuse, merged-to-main allow, no-mistakes regression, tasks-axi reminder, --force override

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ firstmate works from any terminal - outside tmux, crewmates land in a detached `
 - **Project memory belongs to projects** - durable project-intrinsic agent knowledge lives in each project's committed `AGENTS.md`, with `CLAUDE.md` as a symlink.
   Ship briefs prompt crewmates to create or update those files through the normal delivery path; `data/projects.md` stays a thin private registry.
 - **Local clones stay fresh** - bootstrap and PR-based teardown refresh remote-backed project clones with clean default-branch fast-forwards when the clone is on the default branch and has no local work, and prune local branches whose remote is gone and that no worktree still needs.
-- **Self-updates stay safe** - `/updatefirstmate` fast-forwards the running firstmate repo and registered secondmate homes from `origin`, then re-reads updated instructions and nudges updated secondmates without touching project clones.
+- **Self-updates stay safe** - `/updatefirstmate` fast-forwards the running firstmate repo and registered secondmate homes from `origin`, then re-reads updated instructions, tooling, skills, and tracked skill compatibility symlinks and nudges updated secondmates without touching project clones.
   The update is fast-forward only: dirty, diverged, offline, and off-default targets are reported and left untouched.
 - **Restart-proof** - all state lives in tmux, status files, local markdown under `data/`, `data/secondmates.md`, and persistent secondmate homes.
   Kill the first mate session anytime; the next one reconciles and carries on.

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Detect the agent harness this process tree runs on.
-# Usage: fm-harness.sh         print own harness: claude|codex|opencode|pi|unknown
+# Usage: fm-harness.sh         print own harness: claude|codex|opencode|pi|droid|unknown
 #        fm-harness.sh crew    print the effective crewmate harness
 #                              (config/crew-harness; "default" resolves to own)
 # Detection layers: verified environment markers first, then process ancestry.
@@ -17,13 +17,15 @@ detect_own() {
   [ "${CLAUDECODE:-}" = "1" ] && { echo claude; return; }
   [ "${PI_CODING_AGENT:-}" = "true" ] && { echo pi; return; }
   # Layer 2: walk the parent chain and match the command name.
-  local pid=$$ comm args
+  local pid=$$ comm base args
   for _ in 1 2 3 4 5 6 7 8; do
     comm=$(ps -o comm= -p "$pid" 2>/dev/null) || break
-    case "$(basename "$comm")" in
+    base=${comm##*/}
+    case "$base" in
       *claude*) echo claude; return ;;
       *codex*) echo codex; return ;;
       *opencode*) echo opencode; return ;;
+      *droid*) echo droid; return ;;
       pi) echo pi; return ;;
       node*|python*)
         # Bare interpreter: match the harness name in its script path.
@@ -32,6 +34,7 @@ detect_own() {
           *claude*) echo claude; return ;;
           *codex*) echo codex; return ;;
           *opencode*) echo opencode; return ;;
+          *droid*) echo droid; return ;;
           *" pi "*|*/pi) echo pi; return ;;
         esac ;;
     esac

--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -15,14 +15,15 @@ LOCK="$STATE/.lock"
 mkdir -p "$STATE"
 
 # Known harness command names; extend when a new adapter is verified.
-HARNESS_RE='claude|codex|opencode|^pi$'
+HARNESS_RE='claude|codex|opencode|droid|^pi$'
 
 harness_pid() {
-  local pid=$$ comm args
+  local pid=$$ comm base args
   for _ in 1 2 3 4 5 6 7 8; do
     comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
     args=$(ps -o args= -p "$pid" 2>/dev/null)
-    if printf '%s' "$(basename "$comm")" | grep -qE "$HARNESS_RE"; then
+    base=${comm##*/}
+    if printf '%s' "$base" | grep -qE "$HARNESS_RE"; then
       echo "$pid"; return 0
     fi
     # Bare interpreter (e.g. node): match the harness name in its script path.
@@ -36,10 +37,11 @@ harness_pid() {
 }
 
 holder_alive() {  # true if $1 is a live process that looks like a harness
-  local pid=$1 comm
+  local pid=$1 comm base
   kill -0 "$pid" 2>/dev/null || return 1
   comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
-  printf '%s' "$(basename "$comm") $(ps -o args= -p "$pid" 2>/dev/null)" | grep -qE "$HARNESS_RE"
+  base=${comm##*/}
+  printf '%s' "$base $(ps -o args= -p "$pid" 2>/dev/null)" | grep -qE "$HARNESS_RE"
 }
 
 if [ "${1:-}" = "status" ]; then

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -5,7 +5,7 @@
 #        fm-spawn.sh <task-id> [<firstmate-home>] [harness|launch-command] --secondmate
 #   With no harness arg, the harness comes from fm-harness.sh crew (config/crew-harness,
 #   falling back to firstmate's own harness). A bare adapter name (claude|codex|
-#   opencode|pi) overrides it for this spawn. A non-flag string containing whitespace
+#   opencode|pi|droid) overrides it for this spawn. A non-flag string containing whitespace
 #   is treated as a RAW launch command - the escape hatch for verifying new adapters.
 #   --scout records kind=scout in the task's meta (report deliverable, scratch worktree;
 #   see AGENTS.md section 7); --secondmate records kind=secondmate and launches in a
@@ -22,6 +22,8 @@
 #                  turn-end signal rides the launch command, e.g. codex -c notify=[...])
 #     __PIEXT__    absolute path to state/<task-id>.pi-ext.ts (pi turn-end extension,
 #                  written by this script; outside the worktree to avoid pi's trust gate)
+#     __DROIDSETTINGS__ absolute path to state/<task-id>.droid-settings.json
+#                  (Droid runtime settings with a task-local Stop hook)
 # Per-harness turn-end hooks are installed automatically; some live outside the worktree.
 # On success prints: spawned <id> harness=<name> kind=<ship|scout|secondmate> mode=<mode> yolo=<on|off> window=<session:window> worktree=<path>
 # mode/yolo are resolved per-project from data/projects.md for ship/scout tasks;
@@ -82,7 +84,7 @@ FIRSTMATE_HOME=
 
 if [ "$KIND" = secondmate ]; then
   case "${POS[1]:-}" in
-    ''|claude|codex|opencode|pi)
+    ''|claude|codex|opencode|pi|droid)
       ARG3=${POS[1]:-}
       ;;
     *' '*)
@@ -132,6 +134,13 @@ launch_template() {
         printf '%s' 'pi "$(cat __BRIEF__)"'
       else
         printf '%s' 'pi -e __PIEXT__ "$(cat __BRIEF__)"'
+      fi
+      ;;
+    droid)
+      if [ "$kind" = secondmate ]; then
+        printf '%s' 'droid --auto high "$(cat __BRIEF__)"'
+      else
+        printf '%s' 'droid --settings __DROIDSETTINGS__ --auto high "$(cat __BRIEF__)"'
       fi
       ;;
     *) return 1 ;;
@@ -395,6 +404,11 @@ EOF
     codex*)
       # codex: turn-end rides the launch command via -c notify=[...] and __TURNEND__.
       ;;
+    droid*)
+      cat > "$STATE/$ID.droid-settings.json" <<EOF
+{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"touch '$TURNEND'"}]}]}}
+EOF
+      ;;
   esac
 fi
 
@@ -432,9 +446,11 @@ mkdir -p "$STATE"
 sq_brief=$(shell_quote "$BRIEF")
 sq_turnend=$(shell_quote "$TURNEND")
 sq_piext=$(shell_quote "$STATE/$ID.pi-ext.ts")
+sq_droidsettings=$(shell_quote "$STATE/$ID.droid-settings.json")
 LAUNCH=${LAUNCH//__BRIEF__/$sq_brief}
 LAUNCH=${LAUNCH//__TURNEND__/$sq_turnend}
 LAUNCH=${LAUNCH//__PIEXT__/$sq_piext}
+LAUNCH=${LAUNCH//__DROIDSETTINGS__/$sq_droidsettings}
 if [ "$KIND" = secondmate ]; then
   sq_home=$(shell_quote "$PROJ_ABS")
   LAUNCH="FM_ROOT_OVERRIDE= FM_STATE_OVERRIDE= FM_DATA_OVERRIDE= FM_PROJECTS_OVERRIDE= FM_CONFIG_OVERRIDE= FM_HOME=$sq_home $LAUNCH"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -23,7 +23,8 @@
 #     __PIEXT__    absolute path to state/<task-id>.pi-ext.ts (pi turn-end extension,
 #                  written by this script; outside the worktree to avoid pi's trust gate)
 #     __DROIDSETTINGS__ absolute path to state/<task-id>.droid-settings.json
-#                  (Droid runtime settings with a task-local Stop hook)
+#                  (Droid runtime settings with a task-local Stop hook and
+#                  disabled co-author trailers)
 # Per-harness turn-end hooks are installed automatically; some live outside the worktree.
 # On success prints: spawned <id> harness=<name> kind=<ship|scout|secondmate> mode=<mode> yolo=<on|off> window=<session:window> worktree=<path>
 # mode/yolo are resolved per-project from data/projects.md for ship/scout tasks;

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -406,7 +406,7 @@ EOF
       ;;
     droid*)
       cat > "$STATE/$ID.droid-settings.json" <<EOF
-{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"touch '$TURNEND'"}]}]}}
+{"includeCoAuthoredByDroid":false,"hooks":{"Stop":[{"hooks":[{"type":"command","command":"touch '$TURNEND'"}]}]}}
 EOF
       ;;
   esac

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -379,7 +379,7 @@ cleanup_firstmate_home_children() {
         safe_rm_rf_child_worktree "$child_wt" "$child_proj"
       fi
     fi
-    rm -f "$sub_state/$child_id.status" "$sub_state/$child_id.turn-ended" "$sub_state/$child_id.check.sh" "$sub_state/$child_id.meta" "$sub_state/$child_id.pi-ext.ts"
+    rm -f "$sub_state/$child_id.status" "$sub_state/$child_id.turn-ended" "$sub_state/$child_id.check.sh" "$sub_state/$child_id.meta" "$sub_state/$child_id.pi-ext.ts" "$sub_state/$child_id.droid-settings.json"
   done
 }
 
@@ -479,7 +479,7 @@ if [ "$KIND" = secondmate ]; then
   remove_firstmate_home "$HOME_PATH" "secondmate home" "$ID"
   remove_secondmate_registry_entry "$ID"
 fi
-rm -f "$STATE/$ID.status" "$STATE/$ID.turn-ended" "$STATE/$ID.check.sh" "$STATE/$ID.meta" "$STATE/$ID.pi-ext.ts"
+rm -f "$STATE/$ID.status" "$STATE/$ID.turn-ended" "$STATE/$ID.check.sh" "$STATE/$ID.meta" "$STATE/$ID.pi-ext.ts" "$STATE/$ID.droid-settings.json"
 if [ "$KIND" != scout ] && [ "$KIND" != secondmate ] && [ "$MODE" != local-only ]; then
   "$FM_ROOT/bin/fm-fleet-sync.sh" "$PROJ" || true
 fi

--- a/bin/fm-tmux-lib.sh
+++ b/bin/fm-tmux-lib.sh
@@ -35,8 +35,9 @@
 # returns) so they can be sourced into either context.
 
 # Busy footers per harness (mirror fm-watch.sh). claude/codex: "esc to
-# interrupt"; opencode: "esc interrupt"; pi: "Working...".
-FM_TMUX_BUSY_REGEX_DEFAULT='esc (to )?interrupt|Working\.\.\.'
+# interrupt"; opencode: "esc interrupt"; pi: "Working..."; droid:
+# "Streaming... (Press ESC to stop)" or "Thinking... (Press ESC to stop)".
+FM_TMUX_BUSY_REGEX_DEFAULT='esc (to )?interrupt|Working\.\.\.|(Streaming|Thinking)\.\.\..*Press ESC to stop'
 
 # fm_tmux_strip_ghost: remove dim/faint (ANSI SGR 2) styled runs from one captured
 # composer line, then drop any remaining escape sequences, leaving only the plain,

--- a/bin/fm-update.sh
+++ b/bin/fm-update.sh
@@ -216,7 +216,7 @@ fetch_once() {
 # (AGENTS.md, which CLAUDE.md symlinks), its skills, and its tooling (bin/).
 changed_instr() {
   local dir=$1 base=$2 p out=""
-  for p in AGENTS.md bin .agents/skills; do
+  for p in AGENTS.md bin .agents/skills .factory/skills; do
     if ! git -C "$dir" diff --quiet HEAD "$base" -- "$p" 2>/dev/null; then
       out="$out${out:+, }$p"
     fi

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -66,8 +66,9 @@ SIGNAL_GRACE=${FM_SIGNAL_GRACE:-30}   # seconds to linger after a signal so trai
                                       # signals (a status write, then the same turn's
                                       # turn-end hook) coalesce into one wake
 # Busy signatures per harness, OR-ed. Extend via env when new adapters are verified.
-# claude/codex: "esc to interrupt"; opencode: "esc interrupt"; pi: "Working..."
-BUSY_REGEX=${FM_BUSY_REGEX:-'esc (to )?interrupt|Working\.\.\.'}
+# claude/codex: "esc to interrupt"; opencode: "esc interrupt"; pi: "Working...";
+# droid: "Streaming... (Press ESC to stop)" or "Thinking... (Press ESC to stop)".
+BUSY_REGEX=${FM_BUSY_REGEX:-'esc (to )?interrupt|Working\.\.\.|(Streaming|Thinking)\.\.\..*Press ESC to stop'}
 
 hash_pane() {
   if command -v md5 >/dev/null 2>&1; then md5 -q; else md5sum | cut -d' ' -f1; fi

--- a/tests/fm-droid-harness.test.sh
+++ b/tests/fm-droid-harness.test.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Behavior tests for the verified Droid harness adapter.
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SPAWN="$ROOT/bin/fm-spawn.sh"
+TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/fm-droid-harness.XXXXXX")
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+fail() {
+  printf 'not ok - %s\n' "$1" >&2
+  exit 1
+}
+
+pass() {
+  printf 'ok - %s\n' "$1"
+}
+
+make_fake_tmux() {
+  local dir=$1 fakebin
+  fakebin="$dir/fakebin"
+  mkdir -p "$fakebin"
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "${1:-}" in
+  display-message)
+    for a in "$@"; do
+      case "$a" in
+        '#S') printf 'testsession\n'; exit 0 ;;
+        '#{pane_current_path}') printf '%s\n' "${FM_FAKE_WORKTREE:-/tmp/fm-droid-worktree}"; exit 0 ;;
+      esac
+    done
+    printf 'testsession\n'
+    exit 0
+    ;;
+  list-windows)
+    exit 0
+    ;;
+  has-session|new-session|new-window|send-keys|kill-window)
+    {
+      printf '%s' "$1"
+      shift
+      for arg in "$@"; do
+        printf '\t%s' "$arg"
+      done
+      printf '\n'
+    } >> "$FM_FAKE_TMUX_LOG"
+    exit 0
+    ;;
+  capture-pane)
+    printf 'idle prompt\n'
+    exit 0
+    ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/tmux"
+  printf '%s\n' "$fakebin"
+}
+
+test_droid_ship_launch_uses_runtime_stop_hook() {
+  local dir home project worktree fakebin log id settings meta
+  dir="$TMP_ROOT/ship"
+  home="$dir/home"
+  project="$dir/project"
+  worktree="$dir/worktree"
+  fakebin=$(make_fake_tmux "$dir")
+  log="$dir/tmux.log"
+  id=droid-ship-a1
+  settings="$home/state/$id.droid-settings.json"
+  meta="$home/state/$id.meta"
+  mkdir -p "$home/data/$id" "$home/state" "$project" "$worktree"
+  printf 'do the task\n' > "$home/data/$id/brief.md"
+  : > "$log"
+
+  PATH="$fakebin:$PATH" TMUX=1 FM_HOME="$home" FM_SPAWN_NO_GUARD=1 \
+    FM_FAKE_TMUX_LOG="$log" FM_FAKE_WORKTREE="$worktree" \
+    "$SPAWN" "$id" "$project" droid >/dev/null \
+    || fail "droid ship spawn failed"
+
+  [ -f "$settings" ] || fail "droid runtime settings file was not written"
+  grep -F "touch '$home/state/$id.turn-ended'" "$settings" >/dev/null \
+    || fail "droid Stop hook does not touch the task turn-ended marker"
+  grep -F "droid --settings '$settings' --auto high" "$log" >/dev/null \
+    || fail "droid launch did not use --settings and --auto high"
+  grep -F "$home/data/$id/brief.md" "$log" >/dev/null \
+    || fail "droid launch did not pass the task brief"
+  grep -Fx 'harness=droid' "$meta" >/dev/null || fail "meta did not record harness=droid"
+  pass "droid ship launch uses a runtime Stop hook and records harness metadata"
+}
+
+test_droid_secondmate_launch_omits_parent_hook() {
+  local dir home subhome subhome_abs fakebin log id settings
+  dir="$TMP_ROOT/secondmate"
+  home="$dir/home"
+  subhome="$dir/subhome"
+  fakebin=$(make_fake_tmux "$dir")
+  log="$dir/tmux.log"
+  id=droid-sub-b2
+  settings="$home/state/$id.droid-settings.json"
+  mkdir -p "$home/data/$id" "$home/state" "$subhome/data" "$subhome/bin"
+  subhome_abs=$(cd "$subhome" && pwd -P)
+  printf '%s\n' "$id" > "$subhome/.fm-secondmate-home"
+  printf '# Firstmate\n' > "$subhome/AGENTS.md"
+  printf 'charter\n' > "$subhome/data/charter.md"
+  printf '%s\n' "- $id - droid secondmate (home: $subhome_abs; scope: droid secondmate; projects: alpha; added 2026-06-24)" > "$home/data/secondmates.md"
+  : > "$log"
+
+  PATH="$fakebin:$PATH" TMUX=1 FM_HOME="$home" FM_SPAWN_NO_GUARD=1 \
+    FM_FAKE_TMUX_LOG="$log" \
+    "$SPAWN" "$id" "$subhome" droid --secondmate >/dev/null \
+    || fail "droid secondmate spawn failed"
+
+  [ ! -e "$settings" ] || fail "droid secondmate launch wrote a parent Stop hook"
+  grep -F "droid --auto high" "$log" >/dev/null \
+    || fail "droid secondmate launch did not use --auto high"
+  grep -F -- "--settings" "$log" >/dev/null \
+    && fail "droid secondmate launch should not use parent runtime settings"
+  grep -F "$subhome_abs/data/charter.md" "$log" >/dev/null \
+    || fail "droid secondmate launch did not pass persistent charter"
+  pass "droid secondmate launch omits parent turn-end hook"
+}
+
+test_droid_ship_launch_uses_runtime_stop_hook
+test_droid_secondmate_launch_omits_parent_hook

--- a/tests/fm-droid-harness.test.sh
+++ b/tests/fm-droid-harness.test.sh
@@ -80,6 +80,8 @@ test_droid_ship_launch_uses_runtime_stop_hook() {
     || fail "droid ship spawn failed"
 
   [ -f "$settings" ] || fail "droid runtime settings file was not written"
+  grep -F '"includeCoAuthoredByDroid":false' "$settings" >/dev/null \
+    || fail "droid runtime settings did not disable Droid co-author trailers"
   grep -F "touch '$home/state/$id.turn-ended'" "$settings" >/dev/null \
     || fail "droid Stop hook does not touch the task turn-ended marker"
   grep -F "droid --settings '$settings' --auto high" "$log" >/dev/null \

--- a/tests/fm-spawn-batch.test.sh
+++ b/tests/fm-spawn-batch.test.sh
@@ -123,6 +123,22 @@ test_fm_projects_override_scopes_projects_path() {
   pass "FM_PROJECTS_OVERRIDE scopes projects/ paths for single-task spawn"
 }
 
+test_explicit_droid_adapter_is_verified() {
+  local home out status expected
+  home="$TMP_ROOT/droid home"
+  mkdir -p "$home/data" "$home/projects/alpha"
+  out=$(FM_ROOT_OVERRIDE='' FM_STATE_OVERRIDE='' FM_DATA_OVERRIDE='' FM_PROJECTS_OVERRIDE='' FM_CONFIG_OVERRIDE='' \
+    FM_HOME="$home" FM_SPAWN_NO_GUARD=1 "$SPAWN" nope-droid-z9 projects/alpha droid 2>&1)
+  status=$?
+  [ "$status" -ne 0 ] || fail "spawn with missing brief should fail"
+  expected="error: no brief at $home/data/nope-droid-z9/brief.md"
+  printf '%s\n' "$out" | grep -F "$expected" >/dev/null \
+    || fail "explicit droid adapter did not reach the normal missing-brief check"
+  printf '%s\n' "$out" | grep -F "unknown harness 'droid'" >/dev/null \
+    && fail "explicit droid adapter was treated as unverified"
+  pass "explicit droid adapter is accepted as verified"
+}
+
 test_batch_dispatches_each_pair
 test_single_pair_is_batch
 test_single_mode_unaffected
@@ -130,3 +146,4 @@ test_batch_rejects_non_pair_argument
 test_id_with_slash_is_not_batch
 test_fm_home_scopes_projects_path
 test_fm_projects_override_scopes_projects_path
+test_explicit_droid_adapter_is_verified

--- a/tests/fm-wake-queue.test.sh
+++ b/tests/fm-wake-queue.test.sh
@@ -528,6 +528,23 @@ test_housekeeping_resumed_stale_cleared() {
   pass "resumed (busy) stale clears its marker without escalating"
 }
 
+test_droid_busy_footer_is_recognized() {
+  local dir state fakebin pane
+  dir=$(make_supercase droid-busy)
+  state="$dir/state"
+  fakebin="$dir/fakebin"
+  pane="$dir/pane.txt"
+  printf 'user prompt\n ⠋ Streaming...  (Press ESC to stop)\n' > "$pane"
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_CAPTURE="$pane" FM_STATE_OVERRIDE="$state" \
+    fm_pane_is_busy "fakepane" \
+    || fail "Droid Streaming busy footer was not recognized"
+  printf 'user prompt\n ⠇ Thinking...  (Press ESC to stop)\n' > "$pane"
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_CAPTURE="$pane" FM_STATE_OVERRIDE="$state" \
+    fm_pane_is_busy "fakepane" \
+    || fail "Droid Thinking busy footer was not recognized"
+  pass "Droid busy footers are recognized"
+}
+
 test_escalate_batches_into_one_digest() {
   local dir state fakebin sent capture n
   dir=$(make_supercase batch)
@@ -1291,6 +1308,7 @@ test_stale_transient_self_records_marker
 test_stale_terminal_escalates
 test_housekeeping_persistent_stale_escalates
 test_housekeeping_resumed_stale_cleared
+test_droid_busy_footer_is_recognized
 test_escalate_batches_into_one_digest
 test_escalate_batch_age_uses_first_append
 test_heartbeat_scan_dedup


### PR DESCRIPTION
## Intent

Make Factory Droid CLI a first-class verified Firstmate harness, functionally equivalent to the existing Claude, Codex, OpenCode, and Pi harnesses. The implementation should support Droid in harness detection and session locking, spawning ship/scout tasks and secondmates, turn-end signaling via Droid Stop hooks, busy-pane detection, teardown cleanup, skill discovery through Factory's .factory/skills path, self-update instruction-surface tracking, and project documentation. It should preserve Firstmate's safety posture by using Droid --auto high rather than unsafe permission bypass, keep runtime hook settings in state rather than project worktrees, ensure Droid sessions do not add agent co-author trailers, and include behavior tests for Droid launch templates, secondmate behavior, adapter acceptance, and busy-footer detection.

## What Changed

- Adds Droid as a verified Firstmate harness for detection, spawning, session locking, busy-pane handling, teardown cleanup, and runtime turn-end Stop hooks using `--auto high`.
- Exposes Factory skill discovery through `.factory/skills` and updates Firstmate docs and skills to describe Droid behavior, co-author suppression, and instruction-surface handling.
- Adds behavior coverage for Droid launch templates, secondmate launch behavior, adapter acceptance, and Droid busy-footer recognition.

## Risk Assessment

✅ Low: Captain, the changes are well-bounded harness-adapter additions with matching cleanup, detection, documentation, and focused behavior coverage, and I did not identify material merge-blocking risks.

## Testing

Inspected the Droid harness change scope, ran focused behavior tests covering Droid ship and secondmate launch templates, verified adapter acceptance, busy-footer detection, wake handling, update instruction-surface tracking, and manually demonstrated Droid harness detection plus lock recognition; the relevant tests and checks passed, the working tree remained clean, and the only broad-suite attempt timed out before replacing it with focused validation.

<details>
<summary>Evidence: Focused Droid harness behavior test transcript</summary>

```text
warn: no registry at /var/folders/cp/jmq_5jjx6t3bzrtt05d5_chm0000gn/T/tmp.1JeMeZG0VK/fm-droid-harness.nakBEA/ship/home/data/projects.md; defaulting project to no-mistakes off
ok - droid ship launch uses a runtime Stop hook and records harness metadata
ok - droid secondmate launch omits parent turn-end hook
ok - batch dispatch re-execs and reports every id=repo pair
ok - a single id=repo pair routes through batch dispatch
ok - single-task invocation (no '=') is untouched by batch detection
ok - batch dispatch rejects an argument that is not id=repo
ok - an arg whose id part contains '/' is not treated as a batch pair
ok - FM_HOME scopes projects/ paths for single-task spawn
ok - FM_PROJECTS_OVERRIDE scopes projects/ paths for single-task spawn
ok - explicit droid adapter is accepted as verified
ok - supervise daemon state root is scoped by FM_HOME
ok - concurrent append plus drain preserves queue records
ok - signal written while no watcher runs is caught on next run
ok - stale wake is queued before suppressor state is advanced
ok - check output is queued before cadence suppression
ok - simultaneous watcher starts leave exactly one live process
ok - two atomic drains cannot consume the same records twice
ok - drain collapses obvious duplicate heartbeat and signal records
ok - killed watcher stale lock is reclaimed
ok - live watcher lock with stale heartbeat is actionable
ok - guard warns when queued wakes are pending
ok - guard orders watcher re-arm after queued wake drain
ok - routine signal self-handles
ok - captain-relevant status verbs escalate
ok - check + unknown escalate; heartbeat self-handles
ok - transient stale self-handles and records a persistence marker
ok - stale + terminal status escalates immediately
ok - persistent stale escalates after threshold and clears its marker
ok - resumed (busy) stale clears its marker without escalating
ok - Droid busy footers are recognized
ok - multiple escalations flush as a single batched digest
ok - batch flush measures max-delay from the first append, not the last
ok - catch-all scan escalates a missed terminal once, not twice
ok - handle_wake routes routine->self and captain->escalate
ok - INJECT_SKIP forces self-handle, bypassing captain-relevant classification
ok - is_wake_reason distinguishes watcher wake reasons from singleton-status stdout
ok - terminal-stale escalate removes its marker so housekeeping does not re-escalate
ok - captain signal escalate marks seen so the catch-all scan does not re-fire
ok - _collapse_newlines replaces newlines with literal separator
ok - afk flag absent: daemon does not inject, buffer preserved
ok - afk flag present: daemon injects with sentinel marker prefix
ok - injected digest is single-line (no embedded newlines)
ok - busy-guard defers injection when supervisor pane is busy
ok - marker detection: marker -> stay afk, no marker -> exit afk
ok - /afk invocation is exempt from afk exit (no self-cancel)
ok - should_exit_afk returns false when afk is not active
ok - strip_injection_marker removes the sentinel marker cleanly
ok - pane_input_pending detects partial input on the cursor line
ok - pane_input_pending: blank cursor line is not pending
ok - pane_input_pending: bare prompts are not pending (idle)
ok - pane_input_pending honors FM_COMPOSER_IDLE_RE after border stripping
ok - composer guard defers injection when pane has pending input
ok - swallowed Enter: type-once + Enter-retry, no concatenation
ok - normal inject: exactly one digest, one Enter, no duplicates
ok - classify_signal dedupes against the catch-all scan seen marker
ok - classify_stale dedupes against the signal path seen marker
ok - pane_input_pending: an idle bordered composer is NOT pending (afk-invx-i5)
ok - pane_input_pending: text inside a bordered composer is still pending
ok - submit-ACK confirms a submit when the composer returns to a bordered-empty box
ok - submit-ACK reports pending on a persistently swallowed Enter (type-once)
ok - max-defer on an empty stuck pane types once, alarms, and preserves the buffer
ok - max-defer flushes and clears the buffer on an empty bordered pane
ok - max-defer on a pending composer alarms without typing
ok - normal flush clears a stale wedge marker
ok - below MAX_DEFER: no inject, no alarm, buffer preserved
ok - max-defer does not flush or alarm while afk is inactive
ok - fm-send exits non-zero on a confirmed swallow, zero on a clean submit
ok - fm-send exits non-zero when initial text send fails
```
</details>
<details>
<summary>Evidence: Self-update instruction-surface test transcript</summary>

```text
ok - T1 main + secondmate fast-forward, reread + nudge signalled
ok - T2 advance is a fast-forward, not a merge commit
ok - T3 reread gates on instruction surface, nudge on advancement
ok - T4 dirty secondmate skipped, local edit preserved
ok - T5 diverged secondmate skipped, local commit preserved
ok - T6 idempotent: a second run is a no-op
ok - T7 secondmate resolved from registry without inventing a window
ok - T8 deduped homes and excluded the firstmate repo itself
ok - T9 firstmate off its default branch is skipped, not forced
ok - T10 firstmate detached HEAD is skipped
ok - T11 unsafe secondmate home is not fast-forwarded
# all fm-update tests passed
```
</details>
<details>
<summary>Evidence: Droid harness detection evidence</summary>

`droid`

```text
droid
```
</details>
<details>
<summary>Evidence: Droid session-lock recognition evidence</summary>

`lock: held by live harness pid 57396`

```text
lock: held by live harness pid 57396
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git status --porcelain` and `git diff --stat e2e730f8e7139e385a6eee3352eea1db9da6adeb..151c1516779ac4d0e5b9344d6f9a17ef7f5eae0d`</code>
- `./tests/fm-droid-harness.test.sh; ./tests/fm-spawn-batch.test.sh; ./tests/fm-wake-queue.test.sh`
- `./tests/fm-update.test.sh`
- <code>Manual harness detection check using a `droid`-named shell wrapper around `./bin/fm-harness.sh`</code>
- <code>Manual session-lock status check using a live `droid`-named process recorded in `.lock`</code>
- <code>Attempted broad `for t in ./tests/*.test.sh; do &#34;$t&#34;; done`, which timed out in the long afk e2e test before useful full-suite coverage was produced</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
