### PR TITLE
fix: harden watcher singleton locking

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -556,7 +556,7 @@ The `/afk` skill is the explicit trigger: invoking it sets a durable away-mode f
 **Entering afk.** Invoke the `/afk` skill.
 It sets `state/.afk` (durable — recovery re-enters afk if the flag survives a restart), ensures the daemon is running (`nohup bin/fm-supervise-daemon.sh &` if the pid is dead or absent), and acknowledges.
 With afk active:
-- **Do not separately arm `fm-watch.sh`.** The daemon manages the watcher; the singleton lock no-ops a stray arm harmlessly, but the daemon is the single owner.
+- **Do not separately arm the watcher with `fm-watch-arm.sh` or `fm-watch.sh`.** The daemon manages the watcher; the singleton lock no-ops a stray arm harmlessly, but the daemon is the single owner.
 - **`fm-wake-drain.sh` still runs at the start of every escalated firstmate turn** - it is the lossless backstop. The daemon routes; the queue guarantees nothing is lost. The two are complementary, not redundant.
 
 **In-band sentinel marker (the load-bearing detail).** The daemon injects into the same pane the captain types into, so an escalation would otherwise look like a user message and cancel afk the moment it fired.
@@ -599,7 +599,7 @@ This is why fewer, cheaper firstmate turns handle the same fleet.
   That empty composer is the acknowledgement that the submit landed, using the same dim-ghost-aware and border-aware detector so a ghost-only or bordered-empty claude composer counts as submitted rather than a false "swallowed Enter".
   `fm-send.sh` shares this primitive and exits non-zero on a positively-confirmed swallow, so firstmate learns a steer did not land instead of leaving it unsubmitted.
 - **Marker strip** - `strip_injection_marker` removes the sentinel prefix before classification/relay, so the digest text firstmate sees is clean.
-- **Portable singleton lock** - the daemon uses the repo's mkdir-based lock helper (`fm-wake-lib.sh`) instead of `flock`, which is absent on macOS.
+- **Portable singleton lock** - the daemon uses the repo's portable lock helper (`fm-wake-lib.sh`) instead of `flock`, which is absent on macOS.
 - **Dedupe across signal/stale/scan** - `classify_signal` and `classify_stale` both check the seen-status marker before escalating, so a status escalated by one path is not re-escalated by another in the same digest.
 - **Auto-discovered supervisor pane** - the daemon resolves its injection target from `FM_SUPERVISOR_TARGET`, then `$TMUX_PANE` (inherited from the pane that launched it), then a `firstmate:0` fallback with a warning; the resolution source is logged at startup so a wrong-but-resolving fallback is detectable.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -488,9 +488,12 @@ It costs zero tokens while running and exits with one reason line when something
 It also writes each detected wake to the durable queue at `state/.wake-queue` before advancing suppression markers such as `.seen-*`, `.stale-*`, `.last-check`, or `.last-heartbeat`.
 At the start of every wake-handling turn and every recovery turn, run `bin/fm-wake-drain.sh` before peeking panes, reading status files beyond the reason line, or starting new work.
 The printed one-shot reason line is still useful, but the drained queue is the lossless backlog.
-After handling drained wakes, re-arm `bin/fm-watch.sh` before you end the turn.
-The watcher is singleton-safe: if one is already alive with a fresh liveness beacon, another invocation exits cleanly instead of creating a duplicate watcher; if the live holder's beacon is stale, the new invocation exits with an actionable failure.
-Do not pkill-and-restart the watcher as a routine operation; just arm it, and let the singleton lock no-op when appropriate.
+After handling drained wakes, re-arm the watcher before you end the turn by running `bin/fm-watch-arm.sh` as a background task.
+The watcher is singleton-safe: acquisition is race-proof, so under any number of concurrent arms at most one watcher ever holds this home's lock, and a duplicate that somehow starts self-evicts within one poll once it sees the lock no longer names it.
+If one is already alive with a fresh liveness beacon, another invocation exits cleanly instead of creating a duplicate watcher; if the live holder's beacon is stale, the new invocation exits with an actionable failure.
+Re-arming is the primary model: just run `bin/fm-watch-arm.sh` and let the singleton lock no-op when a healthy watcher is already alive.
+If a forced restart is ever genuinely needed, use `bin/fm-watch-arm.sh --restart`, which stops only THIS home's watcher (the pid recorded in this home's `state/.watch.lock`) and starts a fresh one.
+Never `pkill -f bin/fm-watch.sh`: that pattern matches every firstmate home's watcher, including secondmate homes that run the same script, so a broad pkill from one home kills sibling homes' watchers.
 P2 of the watcher reliability design - proactive routing of wakes into supervisor turns for chat-mode / walk-away supervision - is provided by the optional sub-supervisor (`bin/fm-supervise-daemon.sh`, below), which is presence-gated via the `/afk` skill.
 P3, a blocking-waiter split, remains deferred; the one-shot restart model is otherwise preserved.
 Waiting on the watcher is intentionally silent.
@@ -498,8 +501,10 @@ After arming it, do not send idle progress updates to the captain; wait until it
 Empty polls, elapsed waiting time, and "still no change" are tool bookkeeping, not conversational progress.
 
 ```sh
-bin/fm-watch.sh   # run in background; exits with: signal|stale|check|heartbeat
-bin/fm-wake-drain.sh   # drain queued wake records at turn start
+bin/fm-watch-arm.sh        # safe re-arm; run in background; no-ops if a healthy watcher is alive
+bin/fm-watch-arm.sh --restart  # home-scoped forced restart; never a broad pkill
+bin/fm-watch.sh            # the watcher itself; exits with: signal|stale|check|heartbeat
+bin/fm-wake-drain.sh       # drain queued wake records at turn start
 ```
 
 On wake, in order of cheapness:
@@ -528,7 +533,7 @@ The supervision scripts (`fm-peek`, `fm-send`, `fm-spawn`, `fm-teardown`, `fm-pr
 So the next time you touch the fleet with queued wakes or no watcher alive, the tool output itself tells you what to do - a pull-based guard that works on any harness, since it rides the script output you already read rather than a harness-specific hook.
 The grace window keeps normal handling (watcher briefly down between a wake and its re-arm) silent.
 If a guard warning says queued wakes are pending, drain them before doing anything else.
-If a guard warning says watcher liveness is stale, arm `bin/fm-watch.sh` after draining any queued wakes.
+If a guard warning says watcher liveness is stale, arm `bin/fm-watch-arm.sh` after draining any queued wakes.
 Watcher liveness is not enough if you are foreground-blocked.
 Whenever one or more tasks are in flight, do not run long foreground-blocking operations in your own session.
 This includes your own no-mistakes pipeline, long builds, and any other multi-minute command.
@@ -561,7 +566,7 @@ The marker travels with the message text; it does not rely on harness-level type
 **Exiting afk (the captain's contract).** When firstmate receives a message while afk is active:
 - Leading marker present → **internal escalation**. Stay afk, process it.
 - Message starts with `/afk` → **afk re-invocation**. Stay afk (refresh the flag); do not treat as a return.
-- Anything else → **the captain is back.** Clear `state/.afk`, stop the daemon, flush one distilled "while you were out" catch-up (drain `state/.wake-queue` + summarize any pending `state/.subsuper-escalations` and `state/.subsuper-inject-wedged` marker), and resume full per-wake responsiveness (arm `bin/fm-watch.sh`).
+- Anything else → **the captain is back.** Clear `state/.afk`, stop the daemon, flush one distilled "while you were out" catch-up (drain `state/.wake-queue` + summarize any pending `state/.subsuper-escalations` and `state/.subsuper-inject-wedged` marker), and resume full per-wake responsiveness (arm `bin/fm-watch-arm.sh`).
 **Bias ambiguous cases toward exit** (a present captain beats token savings; a false exit is self-correcting).
 
 **Orthogonal to yolo.** afk changes how aggressively firstmate surfaces things, not who approves what. "Away" never means "approves more" — a PR, a needs-decision finding, or anything destructive still waits for the captain's explicit word.

--- a/README.md
+++ b/README.md
@@ -116,7 +116,9 @@ firstmate works from any terminal - outside tmux, crewmates land in a detached `
 
 - **Event-driven supervision** - a zero-token bash watcher (`bin/fm-watch.sh`) sleeps on the fleet and wakes the first mate only when a crewmate reports, stalls, a PR merges, or an internal heartbeat review is due.
   Detected wakes are also written to a durable local queue (`state/.wake-queue`) before detector state advances, so a missed one-shot process exit can be recovered by draining the queue.
-  Routine watcher polling, restarts, elapsed waiting time, and unchanged heartbeat reviews stay silent; an idle crew costs you nothing.
+  Routine watcher polling, re-arm no-ops, elapsed waiting time, and unchanged heartbeat reviews stay silent; an idle crew costs you nothing.
+  Routine re-arms go through `bin/fm-watch-arm.sh`, whose default path either execs the watcher or no-ops behind the per-home singleton.
+  Its `--restart` mode signals only the watcher recorded in the current home's `state/.watch.lock`, so restarting one home cannot kill sibling secondmate watchers.
   A pull-based guard (`bin/fm-guard.sh`) warns through supervision tool output if tasks are in flight and that watcher stops running or queued wakes are waiting to be drained.
   A presence-gated sub-supervisor (`bin/fm-supervise-daemon.sh`) extends this for walk-away supervision: the `/afk` skill activates it, after which it self-handles routine wakes in bash and escalates only captain-relevant events as one batched, single-line digest (prefixed with an in-band sentinel marker so firstmate can tell daemon injections apart from real messages).
   Its injection path shares `bin/fm-tmux-lib.sh` with `fm-send.sh`, so dim-ghost-aware and border-aware composer detection plus verified submit retry stay consistent; stalled escalation delivery raises `state/.subsuper-inject-wedged` after `FM_MAX_DEFER_SECS` instead of silently deferring forever.
@@ -161,6 +163,7 @@ The first mate drives these; you rarely need to, but they work by hand too.
 | `fm-project-mode.sh`     | Resolve a project's delivery mode and `+yolo` flag from `data/projects.md`                                          |
 | `fm-merge-local.sh`      | Fast-forward a `local-only` project's local default branch after approval                                           |
 | `fm-review-diff.sh`      | Review a crewmate branch against the authoritative base, with optional `--stat` output                              |
+| `fm-watch-arm.sh`        | Safe per-home watcher re-arm; `--restart` stops only this home's recorded watcher before relaunching               |
 | `fm-watch.sh`            | Singleton-safe one-shot watcher; blocks until supervision work is due, queues it durably, then exits with one reason line |
 | `fm-supervise-daemon.sh` | Presence-gated sub-supervisor for walk-away (`/afk`) supervision: wraps `fm-watch.sh`, self-handles routine wakes in bash, and escalates only captain-relevant events as one verified, batched, single-line digest prefixed with a sentinel marker |
 | `fm-wake-drain.sh`       | Atomically drain queued watcher wakes before handling supervision work                                              |
@@ -203,7 +206,9 @@ FM_HEARTBEAT=600        # base seconds between fleet reviews; backs off exponent
 FM_HEARTBEAT_MAX=7200   # heartbeat backoff cap
 FM_CHECK_INTERVAL=300   # seconds between slow checks (merged-PR polls)
 FM_CHECK_TIMEOUT=30     # seconds allowed per slow check script
+FM_LOCK_STALE_AFTER=2   # seconds before dead-pid lock records can be reclaimed; mid-acquire locks keep at least 2s grace
 FM_GUARD_GRACE=300      # seconds a stale watcher beacon may age before guard warnings
+FM_WATCHER_STALE_GRACE=300   # defaults to FM_GUARD_GRACE; seconds a live watcher lock may have a stale beacon before re-arm errors
 FM_SIGNAL_GRACE=30      # seconds to coalesce nearby status and turn-end signals into one wake
 FM_FLEET_SYNC_BOOTSTRAP_TIMEOUT=20   # seconds allowed for bootstrap's best-effort clone refresh
 FM_FLEET_PRUNE=1        # set to 0 to skip pruning local branches whose upstream is gone
@@ -229,14 +234,14 @@ Tracked changes to firstmate itself, including `AGENTS.md`, `README.md`, `CONTRI
 When supervising live crewmates, keep long validation or build work in the background so watcher wakes can still be handled.
 Human-authored pull requests targeting `main` must be raised through `git push no-mistakes`; see `CONTRIBUTING.md` for the enforced contributor workflow.
 Local `.no-mistakes/` state and test evidence stay out of this repo; `.no-mistakes.yaml` keeps evidence in a temp directory instead.
-The current watcher reliability work keeps the one-shot process model and adds a durable queue plus singleton lock.
+The current watcher reliability work keeps the one-shot process model and adds a durable queue, race-proof singleton lock, duplicate self-eviction, and home-scoped arm wrapper.
 The presence-gated sub-supervisor (`bin/fm-supervise-daemon.sh`) provides proactive wake routing for walk-away supervision via the `/afk` skill; a blocking-waiter split remains a deferred follow-up phase.
 
 ```sh
 bash -n bin/*.sh                          # syntax-check the toolbelt
 shellcheck bin/*.sh tests/*.sh            # lint the toolbelt and behavior tests; CI enforces this
 for test_script in tests/*.test.sh; do "$test_script"; done   # behavior tests, matching CI
-tests/fm-wake-queue.test.sh               # durable wake queue, singleton behavior, sub-supervisor classifier, /afk presence-gating, border-aware composer, max-defer, and fm-send submit tests
+tests/fm-wake-queue.test.sh               # durable wake queue, race-proof locks, watcher singleton/re-arm behavior, sub-supervisor classifier, /afk presence-gating, border-aware composer, max-defer, and fm-send submit tests
 tests/fm-composer-ghost.test.sh           # dim-ghost stripping, ghost-only composer detection, and escape-free peek tests
 tests/fm-afk-inject-e2e.test.sh           # private-socket end-to-end test of the afk injection path (partial-input deferral, swallowed-Enter retry)
 tests/fm-bootstrap.test.sh                # bootstrap dependency and feature-probe tests
@@ -245,5 +250,5 @@ tests/fm-secondmate.test.sh               # persistent secondmate routing, seedi
 tests/fm-teardown.test.sh                 # fm-teardown.sh safety and reminder checks: local-only fork-remote allow, truly-unpushed refuse, merged-to-main allow, no-mistakes regression, tasks-axi reminder, --force override
 [ "$(readlink CLAUDE.md)" = "AGENTS.md" ]
 [ "$(readlink .claude/skills)" = "../.agents/skills" ]
-FM_HEARTBEAT=2 FM_POLL=1 bin/fm-watch.sh  # watcher smoke test (prints "heartbeat")
+FM_HEARTBEAT=2 FM_POLL=1 bin/fm-watch-arm.sh  # watcher re-arm smoke test (prints "heartbeat")
 ```

--- a/bin/fm-guard.sh
+++ b/bin/fm-guard.sh
@@ -5,7 +5,7 @@
 # missing or older than FM_GUARD_GRACE seconds, prints a loud warning so the
 # agent sees it in the tool output of whatever it was doing - the one channel
 # every harness has. Normal wake handling (watcher briefly down between a wake
-# and its restart) stays inside the grace window and stays silent.
+# and its re-arm) stays inside the grace window and stays silent.
 # Always exits 0: the guard warns, it never blocks.
 set -u
 

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -48,7 +48,7 @@
 #     have missed (e.g. a status verb outside CAPTAIN_RE) and escalates it.
 #
 # The robustness shell from the prior always-inject version is preserved:
-# single-instance lock (portable mkdir-based, no flock dependency), crash-loop
+# single-instance lock (portable helper, no flock dependency), crash-loop
 # backoff, pane-gone guard, and a signal-trapped shutdown that flushes buffered
 # escalations before exit.
 #
@@ -92,7 +92,7 @@
 #          FM_LOG_MAX_BYTES / FM_LOG_KEEP_LINES / FM_CRASH_*  log + crash guards
 #          FM_STATE_OVERRIDE        alternate state dir (testing)
 #          Logs each wake to state/.supervise-daemon.log (size-capped). Single
-#          instance via portable mkdir lock on state/.supervise-daemon.lock. Trapped
+#          instance via portable lock on state/.supervise-daemon.lock. Trapped
 #          SIGTERM/SIGINT shut down within ~1s, flush escalations, release the
 #          lock. A crashing fm-watch.sh is logged and restarted, never killing
 #          the daemon; a tight crash-restart spin is detected and backed off.
@@ -714,8 +714,8 @@ fm_super_main() {
   STATE="$(_state_root)"
   mkdir -p "$STATE"
 
-  # Source the portable lock helpers (mkdir-based, works on macOS where flock
-  # is absent). Export FM_STATE_OVERRIDE so the lib resolves the same state dir.
+  # Source the portable lock helpers (works on macOS where flock is absent).
+  # Export FM_STATE_OVERRIDE so the lib resolves the same state dir.
   # shellcheck source=bin/fm-wake-lib.sh
   FM_STATE_OVERRIDE="$STATE" . "$FM_DAEMON_DIR/fm-wake-lib.sh"
 
@@ -732,7 +732,7 @@ fm_super_main() {
 
   [ -x "$WATCH" ] || { echo "error: watcher not found or not executable: $WATCH" >&2; exit 1; }
 
-  # --- single instance (portable mkdir-based lock, no flock dependency) ------
+  # --- single instance (portable lock, no flock dependency) ------------------
   if ! fm_lock_try_acquire "$LOCK"; then
     if [ -n "${FM_LOCK_HELD_PID:-}" ]; then
       echo "error: another fm-supervise-daemon is already running (pid $FM_LOCK_HELD_PID, lock $LOCK held)" >&2

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -120,6 +120,7 @@ fm_lock_claim() {
 
 fm_lock_try_create() {
   local lockdir=$1 ownerdir
+  FM_LOCK_OWNER_DIR=
   ownerdir=$(fm_lock_owner_dir "$lockdir") || return 1
   if [ -e "$lockdir" ] || [ -L "$lockdir" ]; then
     fm_lock_discard_owner "$ownerdir"
@@ -127,6 +128,7 @@ fm_lock_try_create() {
   fi
   if ln -s "$ownerdir" "$lockdir" 2>/dev/null && fm_lock_points_to_owner "$lockdir" "$ownerdir"; then
     if fm_lock_claim "$lockdir" "$ownerdir"; then
+      FM_LOCK_OWNER_DIR=$ownerdir
       return 0
     fi
     if fm_lock_points_to_owner "$lockdir" "$ownerdir"; then
@@ -165,8 +167,9 @@ fm_lock_mid_acquire_is_fresh() {
 }
 
 fm_lock_try_acquire() {
-  local lockdir=$1 pid steal cur rc steal_stale
+  local lockdir=$1 pid steal cur rc steal_owner
   FM_LOCK_HELD_PID=
+  FM_LOCK_OWNER_DIR=
 
   if fm_lock_try_create "$lockdir"; then
     return 0
@@ -182,28 +185,31 @@ fm_lock_try_acquire() {
     return 1
   fi
 
-  steal_stale=$FM_LOCK_STALE_AFTER
-  [ "$steal_stale" -lt 2 ] && steal_stale=2
   steal="$lockdir.steal"
-  if ! mkdir "$steal" 2>/dev/null; then
-    if [ "$(fm_path_age "$steal")" -ge "$steal_stale" ]; then
-      rmdir "$steal" 2>/dev/null || true
-    fi
-    if ! mkdir "$steal" 2>/dev/null; then
-      FM_LOCK_HELD_PID=$(cat "$lockdir/pid" 2>/dev/null || true)
-      return 1
-    fi
+  if ! fm_lock_try_acquire "$steal"; then
+    FM_LOCK_HELD_PID=$(cat "$lockdir/pid" 2>/dev/null || true)
+    FM_LOCK_OWNER_DIR=
+    return 1
   fi
+  steal_owner=${FM_LOCK_OWNER_DIR:-}
 
   cur=$(cat "$lockdir/pid" 2>/dev/null || true)
   if fm_pid_alive "$cur"; then
-    rmdir "$steal" 2>/dev/null || true
+    fm_lock_release "$steal"
     FM_LOCK_HELD_PID=$cur
+    FM_LOCK_OWNER_DIR=
     return 1
   fi
   if fm_lock_mid_acquire_is_fresh "$lockdir" "$cur"; then
-    rmdir "$steal" 2>/dev/null || true
+    fm_lock_release "$steal"
     FM_LOCK_HELD_PID=$cur
+    FM_LOCK_OWNER_DIR=
+    return 1
+  fi
+  if ! fm_lock_points_to_owner "$steal" "$steal_owner"; then
+    fm_lock_release "$steal"
+    FM_LOCK_HELD_PID=$(cat "$lockdir/pid" 2>/dev/null || true)
+    FM_LOCK_OWNER_DIR=
     return 1
   fi
 
@@ -215,8 +221,9 @@ fm_lock_try_acquire() {
   if [ "$rc" -ne 0 ]; then
     # shellcheck disable=SC2034 # Read by callers after fm_lock_try_acquire returns.
     FM_LOCK_HELD_PID=$(cat "$lockdir/pid" 2>/dev/null || true)
+    FM_LOCK_OWNER_DIR=
   fi
-  rmdir "$steal" 2>/dev/null || true
+  fm_lock_release "$steal"
   return "$rc"
 }
 

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -23,6 +23,16 @@ fm_pid_alive() {
   kill -0 "$pid" 2>/dev/null
 }
 
+fm_pid_identity() {
+  local pid=$1 out
+  case "$pid" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+  out=$(ps -p "$pid" -o lstart= -o command= 2>/dev/null) || return 1
+  [ -n "$out" ] || return 1
+  printf '%s\n' "$out" | sed 's/^[[:space:]]*//'
+}
+
 fm_path_mtime() {
   if [ "$(uname)" = Darwin ]; then
     stat -f %m "$1" 2>/dev/null
@@ -35,6 +45,16 @@ fm_path_age() {
   local path=$1 m
   m=$(fm_path_mtime "$path") || { echo 999999; return; }
   echo $(( $(date +%s) - m ))
+}
+
+fm_lock_clean_known_files() {
+  local lockdir=$1
+  rm -f \
+    "$lockdir/pid" \
+    "$lockdir/fm-home" \
+    "$lockdir/pid-identity" \
+    "$lockdir/watcher-path" \
+    2>/dev/null || true
 }
 
 # Claim a freshly-created (or freshly-reclaimed) lock dir: write our pid, then
@@ -70,7 +90,7 @@ fm_lock_claim() {
 # back, no concurrent acquirer can evict it, so under any number of concurrent
 # fm_lock_try_acquire calls on one lockdir AT MOST ONE returns 0.
 fm_lock_try_acquire() {
-  local lockdir=$1 pid steal cur rc steal_stale
+  local lockdir=$1 pid steal cur rc steal_stale mid_acquire_stale
   FM_LOCK_HELD_PID=
 
   # Fast path: create the lock dir atomically and claim it.
@@ -89,7 +109,9 @@ fm_lock_try_acquire() {
   # written yet). Respect a grace window before treating that as abandoned.
   case "$pid" in
     ''|*[!0-9]*)
-      if [ "$(fm_path_age "$lockdir")" -lt "$FM_LOCK_STALE_AFTER" ]; then
+      mid_acquire_stale=$FM_LOCK_STALE_AFTER
+      [ "$mid_acquire_stale" -lt 2 ] && mid_acquire_stale=2
+      if [ "$(fm_path_age "$lockdir")" -lt "$mid_acquire_stale" ]; then
         FM_LOCK_HELD_PID=$pid
         return 1
       fi
@@ -129,7 +151,7 @@ fm_lock_try_acquire() {
 
   # Evict the stale dir and reclaim. The recreate mkdir still competes with any
   # fresh fast-path contender; mkdir is atomic, so only one of us creates it.
-  rm -f "$lockdir/pid" 2>/dev/null || true
+  fm_lock_clean_known_files "$lockdir"
   rmdir "$lockdir" 2>/dev/null || true
   rc=1
   if mkdir "$lockdir" 2>/dev/null; then
@@ -154,7 +176,7 @@ fm_lock_release() {
   current=${BASHPID:-$$}
   pid=$(cat "$lockdir/pid" 2>/dev/null || true)
   [ "$pid" = "$current" ] || return 0
-  rm -f "$lockdir/pid" 2>/dev/null || true
+  fm_lock_clean_known_files "$lockdir"
   rmdir "$lockdir" 2>/dev/null || true
 }
 

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -71,6 +71,14 @@ fm_lock_owner_dir() {
   mktemp -d "${lock_abs}.owner.XXXXXX" 2>/dev/null
 }
 
+fm_lock_prepare_owner() {
+  local ownerdir=$1 mypid back
+  mypid=${BASHPID:-$$}
+  printf '%s\n' "$mypid" > "$ownerdir/pid" 2>/dev/null || return 1
+  back=$(cat "$ownerdir/pid" 2>/dev/null || true)
+  [ "$back" = "$mypid" ]
+}
+
 fm_lock_link_owner() {
   local lockdir=$1 owner
   owner=$(readlink "$lockdir" 2>/dev/null) || return 1
@@ -102,16 +110,36 @@ fm_lock_remove_stray_owner_link() {
   fi
 }
 
+fm_lock_claim_blocked_by_steal() {
+  local lockdir=$1 allowed_steal_owner=${2:-} steal
+  steal="$lockdir.steal"
+  [ -e "$steal" ] || [ -L "$steal" ] || return 1
+  if [ -n "$allowed_steal_owner" ] && fm_lock_points_to_owner "$steal" "$allowed_steal_owner"; then
+    return 1
+  fi
+  return 0
+}
+
 fm_lock_claim() {
-  local lockdir=$1 ownerdir=$2 mypid back
+  local lockdir=$1 ownerdir=$2 allowed_steal_owner=${3:-} mypid back
   mypid=${BASHPID:-$$}
   if ! { printf '%s\n' "$mypid" > "$ownerdir/pid"; } 2>/dev/null; then
     fm_lock_discard_owner "$ownerdir"
     return 1
   fi
   back=$(cat "$ownerdir/pid" 2>/dev/null || true)
-  [ "$back" = "$mypid" ] || return 1
+  if [ "$back" != "$mypid" ]; then
+    fm_lock_discard_owner "$ownerdir"
+    return 1
+  fi
   if ! fm_lock_points_to_owner "$lockdir" "$ownerdir"; then
+    fm_lock_discard_owner "$ownerdir"
+    return 1
+  fi
+  if fm_lock_claim_blocked_by_steal "$lockdir" "$allowed_steal_owner"; then
+    if fm_lock_points_to_owner "$lockdir" "$ownerdir"; then
+      rm -f "$lockdir" 2>/dev/null || true
+    fi
     fm_lock_discard_owner "$ownerdir"
     return 1
   fi
@@ -119,15 +147,19 @@ fm_lock_claim() {
 }
 
 fm_lock_try_create() {
-  local lockdir=$1 ownerdir
+  local lockdir=$1 allowed_steal_owner=${2:-} ownerdir
   FM_LOCK_OWNER_DIR=
   ownerdir=$(fm_lock_owner_dir "$lockdir") || return 1
   if [ -e "$lockdir" ] || [ -L "$lockdir" ]; then
     fm_lock_discard_owner "$ownerdir"
     return 1
   fi
+  if ! fm_lock_prepare_owner "$ownerdir"; then
+    fm_lock_discard_owner "$ownerdir"
+    return 1
+  fi
   if ln -s "$ownerdir" "$lockdir" 2>/dev/null && fm_lock_points_to_owner "$lockdir" "$ownerdir"; then
-    if fm_lock_claim "$lockdir" "$ownerdir"; then
+    if fm_lock_claim "$lockdir" "$ownerdir" "$allowed_steal_owner"; then
       FM_LOCK_OWNER_DIR=$ownerdir
       return 0
     fi
@@ -166,8 +198,26 @@ fm_lock_mid_acquire_is_fresh() {
   return 1
 }
 
+fm_lock_recheck_stale_owner() {
+  local lockdir=$1 expected_owner=$2 expected_pid=$3 actual_pid
+  if [ -n "$expected_owner" ]; then
+    fm_lock_points_to_owner "$lockdir" "$expected_owner" || return 1
+  elif [ -e "$lockdir" ] || [ -L "$lockdir" ]; then
+    [ -d "$lockdir" ] && [ ! -L "$lockdir" ] || return 1
+  fi
+  actual_pid=$(cat "$lockdir/pid" 2>/dev/null || true)
+  [ "$actual_pid" = "$expected_pid" ] || return 1
+  if fm_pid_alive "$actual_pid"; then
+    return 1
+  fi
+  if fm_lock_mid_acquire_is_fresh "$lockdir" "$actual_pid"; then
+    return 1
+  fi
+  return 0
+}
+
 fm_lock_try_acquire() {
-  local lockdir=$1 pid steal cur rc steal_owner
+  local lockdir=$1 pid steal cur rc steal_owner primary_owner
   FM_LOCK_HELD_PID=
   FM_LOCK_OWNER_DIR=
 
@@ -213,9 +263,21 @@ fm_lock_try_acquire() {
     return 1
   fi
 
+  primary_owner=
+  if [ -L "$lockdir" ]; then
+    primary_owner=$(fm_lock_link_owner "$lockdir" 2>/dev/null || true)
+  fi
+  cur=$(cat "$lockdir/pid" 2>/dev/null || true)
+  if ! fm_lock_recheck_stale_owner "$lockdir" "$primary_owner" "$cur"; then
+    fm_lock_release "$steal"
+    FM_LOCK_HELD_PID=$(cat "$lockdir/pid" 2>/dev/null || true)
+    FM_LOCK_OWNER_DIR=
+    return 1
+  fi
+
   fm_lock_remove_path "$lockdir" || true
   rc=1
-  if fm_lock_try_create "$lockdir"; then
+  if fm_lock_try_create "$lockdir" "$steal_owner"; then
     rc=0
   fi
   if [ "$rc" -ne 0 ]; then

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -37,39 +37,56 @@ fm_path_age() {
   echo $(( $(date +%s) - m ))
 }
 
-fm_lock_remove_stale() {
-  local lockdir=$1 expected_pid=$2 current_pid
-  current_pid=$(cat "$lockdir/pid" 2>/dev/null || true)
-  [ "$current_pid" = "$expected_pid" ] || return 1
-  if fm_pid_alive "$current_pid"; then
-    return 1
-  fi
-  case "$current_pid" in
-    ''|*[!0-9]*)
-      [ "$(fm_path_age "$lockdir")" -ge "$FM_LOCK_STALE_AFTER" ] || return 1
-      ;;
-  esac
-  rm -f "$lockdir/pid" 2>/dev/null || return 1
-  rmdir "$lockdir" 2>/dev/null
-}
-
-fm_lock_try_acquire() {
-  local lockdir=$1 pid
-  FM_LOCK_HELD_PID=
-  if mkdir "$lockdir" 2>/dev/null; then
-    if { fm_current_pid > "$lockdir/pid"; } 2>/dev/null; then
-      return 0
-    fi
-    rm -f "$lockdir/pid" 2>/dev/null || true
+# Claim a freshly-created (or freshly-reclaimed) lock dir: write our pid, then
+# read it straight back and confirm it is still ours. The read-back is the race
+# arbiter - if a competitor stomped the pid file in between, we lost and must
+# not act as the holder. Returns 0 only when the lock provably names us.
+#
+# mypid is read as ${BASHPID:-$$} directly in this function's (caller's) shell,
+# NOT via $(fm_current_pid): a command substitution forks a subshell whose
+# BASHPID differs, which would record a dead pid and mismatch fm_lock_release's
+# own ${BASHPID:-$$} comparison. This matches the holder pid the caller's shell
+# is identified by.
+fm_lock_claim() {
+  local lockdir=$1 mypid back
+  mypid=${BASHPID:-$$}
+  if ! { printf '%s\n' "$mypid" > "$lockdir/pid"; } 2>/dev/null; then
     rmdir "$lockdir" 2>/dev/null || true
     return 1
   fi
+  back=$(cat "$lockdir/pid" 2>/dev/null || true)
+  [ "$back" = "$mypid" ]
+}
 
+# Single-winner lock acquire, portable (mkdir/rmdir only; no flock).
+#
+# Correctness rests on two facts:
+#   1. `mkdir "$lockdir"` is atomic: between any two successful mkdirs of the
+#      same path the dir must have been removed in between.
+#   2. A live holder's lock dir is never removed - reclaim only ever evicts a
+#      lock whose recorded pid is dead, and re-verifies that deadness while
+#      holding a serialized steal mutex immediately before the rmdir.
+# Together these mean: once an acquirer writes its own (live) pid and reads it
+# back, no concurrent acquirer can evict it, so under any number of concurrent
+# fm_lock_try_acquire calls on one lockdir AT MOST ONE returns 0.
+fm_lock_try_acquire() {
+  local lockdir=$1 pid steal cur rc steal_stale
+  FM_LOCK_HELD_PID=
+
+  # Fast path: create the lock dir atomically and claim it.
+  if mkdir "$lockdir" 2>/dev/null; then
+    fm_lock_claim "$lockdir" && return 0
+    return 1
+  fi
+
+  # Dir exists - someone holds (or held) it.
   pid=$(cat "$lockdir/pid" 2>/dev/null || true)
   if fm_pid_alive "$pid"; then
     FM_LOCK_HELD_PID=$pid
     return 1
   fi
+  # Empty / non-numeric pid means a holder is mid-acquire (mkdir done, pid not
+  # written yet). Respect a grace window before treating that as abandoned.
   case "$pid" in
     ''|*[!0-9]*)
       if [ "$(fm_path_age "$lockdir")" -lt "$FM_LOCK_STALE_AFTER" ]; then
@@ -79,20 +96,50 @@ fm_lock_try_acquire() {
       ;;
   esac
 
-  fm_lock_remove_stale "$lockdir" "$pid" || true
-  if mkdir "$lockdir" 2>/dev/null; then
-    if { fm_current_pid > "$lockdir/pid"; } 2>/dev/null; then
-      return 0
+  # Stale lock (dead pid, or empty/non-numeric past the grace). Serialize the
+  # destroy-and-recreate through a sibling steal mutex so two stealers can never
+  # evict-and-recreate concurrently - that serialization is what guarantees a
+  # single winner. The steal critical section is a few syscalls, so a steal
+  # mutex older than steal_stale can only belong to a crashed stealer and is
+  # safe to clear. Its threshold is INDEPENDENT of FM_LOCK_STALE_AFTER and never
+  # below 2s: tying it to that knob (which may be tuned to 0) would let a live
+  # stealer's mutex be force-cleared, breaking serialization and re-admitting
+  # the double-winner race.
+  steal_stale=$FM_LOCK_STALE_AFTER
+  [ "$steal_stale" -lt 2 ] && steal_stale=2
+  steal="$lockdir.steal"
+  if ! mkdir "$steal" 2>/dev/null; then
+    if [ "$(fm_path_age "$steal")" -ge "$steal_stale" ]; then
+      rmdir "$steal" 2>/dev/null || true
     fi
-    rm -f "$lockdir/pid" 2>/dev/null || true
-    rmdir "$lockdir" 2>/dev/null || true
+    if ! mkdir "$steal" 2>/dev/null; then
+      FM_LOCK_HELD_PID=$(cat "$lockdir/pid" 2>/dev/null || true)
+      return 1
+    fi
+  fi
+
+  # Sole stealer now. Re-read the holder pid immediately before evicting: a
+  # racer may have refreshed it to a live pid since our first read above.
+  cur=$(cat "$lockdir/pid" 2>/dev/null || true)
+  if fm_pid_alive "$cur"; then
+    rmdir "$steal" 2>/dev/null || true
+    FM_LOCK_HELD_PID=$cur
     return 1
   fi
 
-  pid=$(cat "$lockdir/pid" 2>/dev/null || true)
-  # shellcheck disable=SC2034 # Read by callers after fm_lock_try_acquire returns.
-  FM_LOCK_HELD_PID=$pid
-  return 1
+  # Evict the stale dir and reclaim. The recreate mkdir still competes with any
+  # fresh fast-path contender; mkdir is atomic, so only one of us creates it.
+  rm -f "$lockdir/pid" 2>/dev/null || true
+  rmdir "$lockdir" 2>/dev/null || true
+  rc=1
+  if mkdir "$lockdir" 2>/dev/null; then
+    fm_lock_claim "$lockdir" && rc=0
+  else
+    # shellcheck disable=SC2034 # Read by callers after fm_lock_try_acquire returns.
+    FM_LOCK_HELD_PID=$(cat "$lockdir/pid" 2>/dev/null || true)
+  fi
+  rmdir "$steal" 2>/dev/null || true
+  return "$rc"
 }
 
 fm_lock_acquire_wait() {

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -57,76 +57,131 @@ fm_lock_clean_known_files() {
     2>/dev/null || true
 }
 
-# Claim a freshly-created (or freshly-reclaimed) lock dir: write our pid, then
-# read it straight back and confirm it is still ours. The read-back is the race
-# arbiter - if a competitor stomped the pid file in between, we lost and must
-# not act as the holder. Returns 0 only when the lock provably names us.
-#
-# mypid is read as ${BASHPID:-$$} directly in this function's (caller's) shell,
-# NOT via $(fm_current_pid): a command substitution forks a subshell whose
-# BASHPID differs, which would record a dead pid and mismatch fm_lock_release's
-# own ${BASHPID:-$$} comparison. This matches the holder pid the caller's shell
-# is identified by.
-fm_lock_claim() {
-  local lockdir=$1 mypid back
-  mypid=${BASHPID:-$$}
-  if ! { printf '%s\n' "$mypid" > "$lockdir/pid"; } 2>/dev/null; then
-    rmdir "$lockdir" 2>/dev/null || true
-    return 1
-  fi
-  back=$(cat "$lockdir/pid" 2>/dev/null || true)
-  [ "$back" = "$mypid" ]
+fm_lock_abs_path() {
+  local path=$1 dir base
+  dir=$(dirname "$path")
+  base=$(basename "$path")
+  dir=$(cd "$dir" 2>/dev/null && pwd -P) || return 1
+  printf '%s/%s\n' "$dir" "$base"
 }
 
-# Single-winner lock acquire, portable (mkdir/rmdir only; no flock).
-#
-# Correctness rests on two facts:
-#   1. `mkdir "$lockdir"` is atomic: between any two successful mkdirs of the
-#      same path the dir must have been removed in between.
-#   2. A live holder's lock dir is never removed - reclaim only ever evicts a
-#      lock whose recorded pid is dead, and re-verifies that deadness while
-#      holding a serialized steal mutex immediately before the rmdir.
-# Together these mean: once an acquirer writes its own (live) pid and reads it
-# back, no concurrent acquirer can evict it, so under any number of concurrent
-# fm_lock_try_acquire calls on one lockdir AT MOST ONE returns 0.
-fm_lock_try_acquire() {
-  local lockdir=$1 pid steal cur rc steal_stale mid_acquire_stale
-  FM_LOCK_HELD_PID=
+fm_lock_owner_dir() {
+  local lockdir=$1 lock_abs
+  lock_abs=$(fm_lock_abs_path "$lockdir") || return 1
+  mktemp -d "${lock_abs}.owner.XXXXXX" 2>/dev/null
+}
 
-  # Fast path: create the lock dir atomically and claim it.
-  if mkdir "$lockdir" 2>/dev/null; then
-    fm_lock_claim "$lockdir" && return 0
+fm_lock_link_owner() {
+  local lockdir=$1 owner
+  owner=$(readlink "$lockdir" 2>/dev/null) || return 1
+  [ -n "$owner" ] || return 1
+  case "$owner" in
+    /*) printf '%s\n' "$owner" ;;
+    *) printf '%s/%s\n' "$(dirname "$lockdir")" "$owner" ;;
+  esac
+}
+
+fm_lock_points_to_owner() {
+  local lockdir=$1 ownerdir=$2 actual
+  actual=$(readlink "$lockdir" 2>/dev/null) || return 1
+  [ "$actual" = "$ownerdir" ]
+}
+
+fm_lock_discard_owner() {
+  local ownerdir=$1
+  [ -n "$ownerdir" ] || return 0
+  fm_lock_clean_known_files "$ownerdir"
+  rmdir "$ownerdir" 2>/dev/null || true
+}
+
+fm_lock_remove_stray_owner_link() {
+  local lockdir=$1 ownerdir=$2 stray
+  stray="$lockdir/$(basename "$ownerdir")"
+  if [ -L "$stray" ] && [ "$(readlink "$stray" 2>/dev/null || true)" = "$ownerdir" ]; then
+    rm -f "$stray" 2>/dev/null || true
+  fi
+}
+
+fm_lock_claim() {
+  local lockdir=$1 ownerdir=$2 mypid back
+  mypid=${BASHPID:-$$}
+  if ! { printf '%s\n' "$mypid" > "$ownerdir/pid"; } 2>/dev/null; then
+    fm_lock_discard_owner "$ownerdir"
     return 1
   fi
+  back=$(cat "$ownerdir/pid" 2>/dev/null || true)
+  [ "$back" = "$mypid" ] || return 1
+  if ! fm_lock_points_to_owner "$lockdir" "$ownerdir"; then
+    fm_lock_discard_owner "$ownerdir"
+    return 1
+  fi
+  return 0
+}
 
-  # Dir exists - someone holds (or held) it.
+fm_lock_try_create() {
+  local lockdir=$1 ownerdir
+  ownerdir=$(fm_lock_owner_dir "$lockdir") || return 1
+  if [ -e "$lockdir" ] || [ -L "$lockdir" ]; then
+    fm_lock_discard_owner "$ownerdir"
+    return 1
+  fi
+  if ln -s "$ownerdir" "$lockdir" 2>/dev/null && fm_lock_points_to_owner "$lockdir" "$ownerdir"; then
+    if fm_lock_claim "$lockdir" "$ownerdir"; then
+      return 0
+    fi
+    if fm_lock_points_to_owner "$lockdir" "$ownerdir"; then
+      rm -f "$lockdir" 2>/dev/null || true
+    fi
+  else
+    fm_lock_remove_stray_owner_link "$lockdir" "$ownerdir"
+  fi
+  fm_lock_discard_owner "$ownerdir"
+  return 1
+}
+
+fm_lock_remove_path() {
+  local lockdir=$1 ownerdir
+  if [ -L "$lockdir" ]; then
+    ownerdir=$(fm_lock_link_owner "$lockdir" 2>/dev/null || true)
+    rm -f "$lockdir" 2>/dev/null || return 1
+    [ -n "$ownerdir" ] && fm_lock_discard_owner "$ownerdir"
+    return 0
+  fi
+  fm_lock_clean_known_files "$lockdir"
+  rmdir "$lockdir" 2>/dev/null
+}
+
+fm_lock_mid_acquire_is_fresh() {
+  local lockdir=$1 pid=$2 mid_acquire_stale
+  case "$pid" in
+    ''|*[!0-9]*)
+      mid_acquire_stale=$FM_LOCK_STALE_AFTER
+      [ "$mid_acquire_stale" -lt 2 ] && mid_acquire_stale=2
+      [ "$(fm_path_age "$lockdir")" -lt "$mid_acquire_stale" ]
+      return
+      ;;
+  esac
+  return 1
+}
+
+fm_lock_try_acquire() {
+  local lockdir=$1 pid steal cur rc steal_stale
+  FM_LOCK_HELD_PID=
+
+  if fm_lock_try_create "$lockdir"; then
+    return 0
+  fi
+
   pid=$(cat "$lockdir/pid" 2>/dev/null || true)
   if fm_pid_alive "$pid"; then
     FM_LOCK_HELD_PID=$pid
     return 1
   fi
-  # Empty / non-numeric pid means a holder is mid-acquire (mkdir done, pid not
-  # written yet). Respect a grace window before treating that as abandoned.
-  case "$pid" in
-    ''|*[!0-9]*)
-      mid_acquire_stale=$FM_LOCK_STALE_AFTER
-      [ "$mid_acquire_stale" -lt 2 ] && mid_acquire_stale=2
-      if [ "$(fm_path_age "$lockdir")" -lt "$mid_acquire_stale" ]; then
-        FM_LOCK_HELD_PID=$pid
-        return 1
-      fi
-      ;;
-  esac
+  if fm_lock_mid_acquire_is_fresh "$lockdir" "$pid"; then
+    FM_LOCK_HELD_PID=$pid
+    return 1
+  fi
 
-  # Stale lock (dead pid, or empty/non-numeric past the grace). Serialize the
-  # destroy-and-recreate through a sibling steal mutex so two stealers can never
-  # evict-and-recreate concurrently - that serialization is what guarantees a
-  # single winner. The steal critical section is a few syscalls, so a steal
-  # mutex older than steal_stale can only belong to a crashed stealer and is
-  # safe to clear. Its threshold is INDEPENDENT of FM_LOCK_STALE_AFTER and never
-  # below 2s: tying it to that knob (which may be tuned to 0) would let a live
-  # stealer's mutex be force-cleared, breaking serialization and re-admitting
-  # the double-winner race.
   steal_stale=$FM_LOCK_STALE_AFTER
   [ "$steal_stale" -lt 2 ] && steal_stale=2
   steal="$lockdir.steal"
@@ -140,23 +195,24 @@ fm_lock_try_acquire() {
     fi
   fi
 
-  # Sole stealer now. Re-read the holder pid immediately before evicting: a
-  # racer may have refreshed it to a live pid since our first read above.
   cur=$(cat "$lockdir/pid" 2>/dev/null || true)
   if fm_pid_alive "$cur"; then
     rmdir "$steal" 2>/dev/null || true
     FM_LOCK_HELD_PID=$cur
     return 1
   fi
+  if fm_lock_mid_acquire_is_fresh "$lockdir" "$cur"; then
+    rmdir "$steal" 2>/dev/null || true
+    FM_LOCK_HELD_PID=$cur
+    return 1
+  fi
 
-  # Evict the stale dir and reclaim. The recreate mkdir still competes with any
-  # fresh fast-path contender; mkdir is atomic, so only one of us creates it.
-  fm_lock_clean_known_files "$lockdir"
-  rmdir "$lockdir" 2>/dev/null || true
+  fm_lock_remove_path "$lockdir" || true
   rc=1
-  if mkdir "$lockdir" 2>/dev/null; then
-    fm_lock_claim "$lockdir" && rc=0
-  else
+  if fm_lock_try_create "$lockdir"; then
+    rc=0
+  fi
+  if [ "$rc" -ne 0 ]; then
     # shellcheck disable=SC2034 # Read by callers after fm_lock_try_acquire returns.
     FM_LOCK_HELD_PID=$(cat "$lockdir/pid" 2>/dev/null || true)
   fi
@@ -172,8 +228,18 @@ fm_lock_acquire_wait() {
 }
 
 fm_lock_release() {
-  local lockdir=$1 pid current
+  local lockdir=$1 pid current ownerdir
   current=${BASHPID:-$$}
+  if [ -L "$lockdir" ]; then
+    ownerdir=$(fm_lock_link_owner "$lockdir" 2>/dev/null || true)
+    [ -n "$ownerdir" ] || return 0
+    pid=$(cat "$ownerdir/pid" 2>/dev/null || true)
+    [ "$pid" = "$current" ] || return 0
+    fm_lock_points_to_owner "$lockdir" "$ownerdir" || return 0
+    rm -f "$lockdir" 2>/dev/null || return 0
+    fm_lock_discard_owner "$ownerdir"
+    return 0
+  fi
   pid=$(cat "$lockdir/pid" 2>/dev/null || true)
   [ "$pid" = "$current" ] || return 0
   fm_lock_clean_known_files "$lockdir"

--- a/bin/fm-watch-arm.sh
+++ b/bin/fm-watch-arm.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Safe, home-scoped (re-)arm of the firstmate watcher.
+#
+# Default (no args): start bin/fm-watch.sh. The watcher is a singleton per
+# FM_HOME, so a second arm no-ops harmlessly when one is already alive. This is
+# the primary re-arm model - just arm, never kill, and let the singleton lock
+# decide.
+#
+# --restart: stop ONLY this FM_HOME's watcher and start a fresh one. It resolves
+# the pid from THIS home's state/.watch.lock and signals exactly that pid, so it
+# can never touch another home's watcher. NEVER use `pkill -f bin/fm-watch.sh`:
+# that pattern matches every firstmate home's watcher (secondmate homes run the
+# same script) and would kill siblings.
+#
+# Run this exactly like bin/fm-watch.sh - as a background task. It execs the
+# watcher in the foreground, so the harness backgrounds the whole invocation.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=bin/fm-wake-lib.sh
+. "$SCRIPT_DIR/fm-wake-lib.sh"
+
+WATCH="$SCRIPT_DIR/fm-watch.sh"
+WATCH_LOCK="$STATE/.watch.lock"
+
+mode=arm
+case "${1:-}" in
+  ''|arm|--arm) mode=arm ;;
+  --restart) mode=restart ;;
+  *) echo "usage: $(basename "$0") [--restart]" >&2; exit 2 ;;
+esac
+
+if [ "$mode" = restart ]; then
+  # Home-scoped stop: only the watcher pid recorded in THIS home's lock.
+  lock_pid=$(cat "$WATCH_LOCK/pid" 2>/dev/null || true)
+  if fm_pid_alive "$lock_pid"; then
+    kill -TERM "$lock_pid" 2>/dev/null || true
+    # Wait for it to actually exit before relaunching, so the fresh watcher
+    # either takes a released lock or reclaims a now-dead-pid stale lock instead
+    # of seeing the dying one as a live holder and no-opping.
+    i=0
+    while [ "$i" -lt 50 ] && fm_pid_alive "$lock_pid"; do
+      sleep 0.1
+      i=$((i + 1))
+    done
+  fi
+fi
+
+exec "$WATCH"

--- a/bin/fm-watch-arm.sh
+++ b/bin/fm-watch-arm.sh
@@ -23,6 +23,30 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WATCH="$SCRIPT_DIR/fm-watch.sh"
 WATCH_LOCK="$STATE/.watch.lock"
 
+watch_lock_matches_pid() {
+  local pid=$1 lock_home lock_path lock_identity current_identity
+  lock_home=$(cat "$WATCH_LOCK/fm-home" 2>/dev/null || true)
+  lock_path=$(cat "$WATCH_LOCK/watcher-path" 2>/dev/null || true)
+  lock_identity=$(cat "$WATCH_LOCK/pid-identity" 2>/dev/null || true)
+  [ "$lock_home" = "$FM_HOME" ] || return 1
+  [ "$lock_path" = "$WATCH" ] || return 1
+  [ -n "$lock_identity" ] || return 1
+  current_identity=$(fm_pid_identity "$pid") || return 1
+  [ "$current_identity" = "$lock_identity" ]
+}
+
+clear_stale_recorded_watcher_lock() {
+  local lock_home lock_path lock_identity
+  lock_home=$(cat "$WATCH_LOCK/fm-home" 2>/dev/null || true)
+  lock_path=$(cat "$WATCH_LOCK/watcher-path" 2>/dev/null || true)
+  lock_identity=$(cat "$WATCH_LOCK/pid-identity" 2>/dev/null || true)
+  [ "$lock_home" = "$FM_HOME" ] || return 0
+  [ "$lock_path" = "$WATCH" ] || return 0
+  [ -n "$lock_identity" ] || return 0
+  fm_lock_clean_known_files "$WATCH_LOCK"
+  rmdir "$WATCH_LOCK" 2>/dev/null || true
+}
+
 mode=arm
 case "${1:-}" in
   ''|arm|--arm) mode=arm ;;
@@ -34,15 +58,19 @@ if [ "$mode" = restart ]; then
   # Home-scoped stop: only the watcher pid recorded in THIS home's lock.
   lock_pid=$(cat "$WATCH_LOCK/pid" 2>/dev/null || true)
   if fm_pid_alive "$lock_pid"; then
-    kill -TERM "$lock_pid" 2>/dev/null || true
-    # Wait for it to actually exit before relaunching, so the fresh watcher
-    # either takes a released lock or reclaims a now-dead-pid stale lock instead
-    # of seeing the dying one as a live holder and no-opping.
-    i=0
-    while [ "$i" -lt 50 ] && fm_pid_alive "$lock_pid"; do
-      sleep 0.1
-      i=$((i + 1))
-    done
+    if watch_lock_matches_pid "$lock_pid"; then
+      kill -TERM "$lock_pid" 2>/dev/null || true
+      # Wait for it to actually exit before relaunching, so the fresh watcher
+      # either takes a released lock or reclaims a now-dead-pid stale lock instead
+      # of seeing the dying one as a live holder and no-opping.
+      i=0
+      while [ "$i" -lt 50 ] && fm_pid_alive "$lock_pid"; do
+        sleep 0.1
+        i=$((i + 1))
+      done
+    else
+      clear_stale_recorded_watcher_lock
+    fi
   fi
 fi
 

--- a/bin/fm-watch-arm.sh
+++ b/bin/fm-watch-arm.sh
@@ -43,8 +43,7 @@ clear_stale_recorded_watcher_lock() {
   [ "$lock_home" = "$FM_HOME" ] || return 0
   [ "$lock_path" = "$WATCH" ] || return 0
   [ -n "$lock_identity" ] || return 0
-  fm_lock_clean_known_files "$WATCH_LOCK"
-  rmdir "$WATCH_LOCK" 2>/dev/null || true
+  fm_lock_remove_path "$WATCH_LOCK" || true
 }
 
 mode=arm

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -6,8 +6,8 @@
 #   stale: <window>       a crewmate pane stopped changing and shows no busy signature
 #   check: <script>: <out> a per-task check script (e.g. merged-PR poll) produced output
 #   heartbeat              fleet review due; starts at FM_HEARTBEAT and backs off to FM_HEARTBEAT_MAX
-# Run as a background task. Re-arm it after handling each wake; duplicate
-# invocations no-op through the watcher singleton lock.
+# Run as a background task. Re-arm after each wake through bin/fm-watch-arm.sh;
+# direct duplicate invocations still no-op through the watcher singleton lock.
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -20,6 +20,7 @@ mkdir -p "$STATE"
 . "$SCRIPT_DIR/fm-wake-lib.sh"
 
 WATCH_LOCK="$STATE/.watch.lock"
+WATCH_PATH="$SCRIPT_DIR/fm-watch.sh"
 WATCHER_STALE_GRACE=${FM_WATCHER_STALE_GRACE:-${FM_GUARD_GRACE:-300}}
 if ! fm_lock_try_acquire "$WATCH_LOCK"; then
   BEAT="$STATE/.last-watcher-beat"
@@ -45,6 +46,9 @@ trap 'fm_lock_release "$WATCH_LOCK"' EXIT
 # ${BASHPID:-$$} from this same main shell). Read directly, never via a command
 # substitution, so it matches the stored holder pid for the self-eviction check.
 WATCHER_PID=${BASHPID:-$$}
+printf '%s\n' "$FM_HOME" > "$WATCH_LOCK/fm-home" || true
+printf '%s\n' "$WATCH_PATH" > "$WATCH_LOCK/watcher-path" || true
+fm_pid_identity "$WATCHER_PID" > "$WATCH_LOCK/pid-identity" 2>/dev/null || true
 
 # Portable stat. macOS (BSD) stat uses `-f <fmt>`; Linux (GNU) stat uses `-c <fmt>`.
 # Do NOT use the `stat -f <fmt> ... || stat -c <fmt> ...` fallback form: on Linux

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -41,6 +41,10 @@ if ! fm_lock_try_acquire "$WATCH_LOCK"; then
   exit 0
 fi
 trap 'fm_lock_release "$WATCH_LOCK"' EXIT
+# This watcher's own pid, as recorded in the lock by fm_lock_claim (which writes
+# ${BASHPID:-$$} from this same main shell). Read directly, never via a command
+# substitution, so it matches the stored holder pid for the self-eviction check.
+WATCHER_PID=${BASHPID:-$$}
 
 # Portable stat. macOS (BSD) stat uses `-f <fmt>`; Linux (GNU) stat uses `-c <fmt>`.
 # Do NOT use the `stat -f <fmt> ... || stat -c <fmt> ...` fallback form: on Linux
@@ -157,6 +161,16 @@ run_check() {
 }
 
 while :; do
+  # Self-eviction: if the singleton lock no longer names this process, a second
+  # watcher has taken over (e.g. a transient duplicate from a racy arm). Stand
+  # down so the rightful singleton continues alone. The EXIT trap's release
+  # no-ops because the lock pid is not ours, so the survivor's lock is untouched.
+  # This makes any duplicate self-resolve within one poll instead of persisting
+  # and doubling every wake.
+  if [ "$(cat "$WATCH_LOCK/pid" 2>/dev/null || true)" != "$WATCHER_PID" ]; then
+    exit 0
+  fi
+
   # Liveness beacon for fm-guard.sh: a fresh mtime here means a watcher is
   # alive. Supervision scripts warn when this goes stale with tasks in flight.
   touch "$STATE/.last-watcher-beat"

--- a/tests/fm-wake-queue.test.sh
+++ b/tests/fm-wake-queue.test.sh
@@ -1271,6 +1271,128 @@ test_fm_send_exits_nonzero_on_initial_send_failure() {
   pass "fm-send exits non-zero when initial text send fails"
 }
 
+# A pid that is guaranteed dead: walk up from a high number until kill -0 fails.
+dead_pid() {
+  local p=999999
+  while kill -0 "$p" 2>/dev/null; do
+    p=$((p + 1))
+  done
+  printf '%s\n' "$p"
+}
+
+# fm_lock_try_acquire is single-winner: N processes racing on one lockdir, each
+# writing its own (live) pid and holding it for the contention window, must
+# yield exactly one success. This is the core race-proofing guarantee. Each
+# contender runs in its own `bash -c` with FM_STATE_OVERRIDE as a command-scoped
+# env prefix (not a subshell var modification), keeping the dataflow clean.
+test_lock_single_winner_under_concurrency() {
+  local dir state lockdir marker i pids pid wins
+  dir=$(make_case lock-concurrency)
+  state="$dir/state"
+  lockdir="$state/.contend.lock"
+  marker="$dir/wins"
+  : > "$marker"
+  pids=
+  i=1
+  while [ "$i" -le 40 ]; do
+    FM_STATE_OVERRIDE="$state" bash -c '
+      . "$1"
+      if fm_lock_try_acquire "$2"; then
+        printf "%s\n" "$$" >> "$3"
+        # Stay alive so the held lock names a live pid for the whole window;
+        # otherwise a late contender could legitimately reclaim a dead-pid lock.
+        sleep 1
+      fi
+    ' _ "$LIB" "$lockdir" "$marker" &
+    pids="$pids $!"
+    i=$((i + 1))
+  done
+  for pid in $pids; do
+    wait "$pid" 2>/dev/null || true
+  done
+  wins=$(awk 'NF { c++ } END { print c + 0 }' "$marker")
+  [ "$wins" -eq 1 ] || fail "expected exactly one lock winner under concurrency, got $wins"
+  pass "concurrent fm_lock_try_acquire yields exactly one winner"
+}
+
+# A genuinely-dead-pid stale lock is reclaimed by a single acquirer.
+test_lock_steals_dead_pid_lock() {
+  local dir state lockdir dead rc newpid
+  dir=$(make_case lock-dead-steal)
+  state="$dir/state"
+  lockdir="$state/.contend.lock"
+  dead=$(dead_pid)
+  mkdir "$lockdir"
+  printf '%s\n' "$dead" > "$lockdir/pid"
+  rc=0
+  newpid=$(FM_STATE_OVERRIDE="$state" bash -c '
+    . "$1"
+    if fm_lock_try_acquire "$2"; then cat "$2/pid"; else exit 7; fi
+  ' _ "$LIB" "$lockdir") || rc=$?
+  [ "$rc" -eq 0 ] || fail "acquirer failed to steal a dead-pid stale lock (rc=$rc)"
+  [ "$newpid" != "$dead" ] || fail "stale dead-pid lock was not replaced (still $dead)"
+  [ -n "$newpid" ] || fail "reclaimed lock has no pid recorded"
+  pass "dead-pid stale lock is reclaimed by a single acquirer"
+}
+
+# A lock held by a LIVE pid is never stolen; acquire is a no-op that reports the
+# live holder via FM_LOCK_HELD_PID and leaves the pid file untouched.
+test_lock_does_not_steal_live_lock() {
+  local dir state lockdir live out lockpid
+  dir=$(make_case lock-live-noop)
+  state="$dir/state"
+  lockdir="$state/.contend.lock"
+  sleep 300 &
+  live=$!
+  mkdir "$lockdir"
+  printf '%s\n' "$live" > "$lockdir/pid"
+  out=$(FM_STATE_OVERRIDE="$state" bash -c '
+    . "$1"
+    if fm_lock_try_acquire "$2"; then rc=0; else rc=1; fi
+    printf "rc=%s held=%s\n" "$rc" "${FM_LOCK_HELD_PID:-}"
+  ' _ "$LIB" "$lockdir")
+  kill "$live" 2>/dev/null || true
+  wait "$live" 2>/dev/null || true
+  case "$out" in
+    *"rc=1"*) ;;
+    *) fail "live-held lock was acquired instead of refused: $out" ;;
+  esac
+  case "$out" in
+    *"held=$live"*) ;;
+    *) fail "live holder pid not reported via FM_LOCK_HELD_PID: $out" ;;
+  esac
+  lockpid=$(cat "$lockdir/pid" 2>/dev/null || true)
+  [ "$lockpid" = "$live" ] || fail "live holder's lock pid was clobbered (got '$lockpid')"
+  pass "live-held lock is not stolen"
+}
+
+# The watcher self-evicts within one poll when the lock pid stops naming it
+# (a second watcher took over the singleton), and leaves the new holder's lock
+# intact rather than clobbering it on the way out.
+test_watcher_self_evicts_on_lock_takeover() {
+  local dir state fakebin out pid i lock_pid
+  dir=$(make_case self-evict)
+  state="$dir/state"
+  fakebin="$dir/fakebin"
+  out="$dir/watch.out"
+  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  i=0
+  while [ "$i" -lt 50 ]; do
+    [ "$(cat "$state/.watch.lock/pid" 2>/dev/null || true)" = "$pid" ] && break
+    sleep 0.1
+    i=$((i + 1))
+  done
+  [ "$(cat "$state/.watch.lock/pid" 2>/dev/null || true)" = "$pid" ] || fail "watcher did not record its own pid in the lock"
+  # Simulate a second watcher taking over the singleton lock. $$ (the test
+  # runner) is a live pid that is not the watcher.
+  printf '%s\n' "$$" > "$state/.watch.lock/pid"
+  wait_for_exit "$pid" 60 || fail "watcher did not self-evict after lock takeover"
+  lock_pid=$(cat "$state/.watch.lock/pid" 2>/dev/null || true)
+  [ "$lock_pid" = "$$" ] || fail "self-evicting watcher clobbered the new holder's lock (got '$lock_pid')"
+  pass "watcher self-evicts when the lock pid no longer names it"
+}
+
 test_daemon_state_root_uses_fm_home
 test_concurrent_append_and_drain
 test_signal_catchup_without_running_watcher
@@ -1281,6 +1403,10 @@ test_atomic_double_drain
 test_drain_dedupes_obvious_duplicates
 test_stale_watch_lock_reclaimed
 test_live_stale_watch_lock_is_actionable
+test_lock_single_winner_under_concurrency
+test_lock_steals_dead_pid_lock
+test_lock_does_not_steal_live_lock
+test_watcher_self_evicts_on_lock_takeover
 test_guard_warns_on_pending_queue
 test_guard_rearms_after_draining_pending_queue
 # Sub-supervisor (fm-supervise-daemon.sh) classifier + batching + housekeeping.

--- a/tests/fm-wake-queue.test.sh
+++ b/tests/fm-wake-queue.test.sh
@@ -3,6 +3,7 @@ set -u
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 WATCH="$ROOT/bin/fm-watch.sh"
+WATCH_ARM="$ROOT/bin/fm-watch-arm.sh"
 DRAIN="$ROOT/bin/fm-wake-drain.sh"
 LIB="$ROOT/bin/fm-wake-lib.sh"
 DAEMON="$ROOT/bin/fm-supervise-daemon.sh"
@@ -1366,9 +1367,57 @@ test_lock_does_not_steal_live_lock() {
   pass "live-held lock is not stolen"
 }
 
-# The watcher self-evicts within one poll when the lock pid stops naming it
-# (a second watcher took over the singleton), and leaves the new holder's lock
-# intact rather than clobbering it on the way out.
+test_lock_empty_pid_uses_minimum_grace() {
+  local dir state lockdir out
+  dir=$(make_case lock-empty-grace)
+  state="$dir/state"
+  lockdir="$state/.contend.lock"
+  mkdir "$lockdir"
+  out=$(FM_LOCK_STALE_AFTER=0 FM_STATE_OVERRIDE="$state" bash -c '
+    . "$1"
+    if fm_lock_try_acquire "$2"; then rc=0; else rc=1; fi
+    printf "rc=%s held=%s\n" "$rc" "${FM_LOCK_HELD_PID:-}"
+  ' _ "$LIB" "$lockdir")
+  case "$out" in
+    *"rc=1"*) ;;
+    *) fail "empty mid-acquire lock was stolen with zero stale threshold: $out" ;;
+  esac
+  [ -d "$lockdir" ] || fail "empty mid-acquire lock dir was removed during grace"
+  [ ! -e "$lockdir/pid" ] || fail "empty mid-acquire lock gained a pid during grace"
+  pass "empty mid-acquire lock keeps a minimum grace"
+}
+
+test_watch_restart_rejects_reused_pid() {
+  local dir state fakebin out live pid i lock_pid
+  dir=$(make_case restart-reused-pid)
+  state="$dir/state"
+  fakebin="$dir/fakebin"
+  out="$dir/restart.out"
+  sleep 300 &
+  live=$!
+  mkdir "$state/.watch.lock"
+  printf '%s\n' "$live" > "$state/.watch.lock/pid"
+  printf '%s\n' "$dir" > "$state/.watch.lock/fm-home"
+  printf '%s\n' "$WATCH" > "$state/.watch.lock/watcher-path"
+  printf '%s\n' "stale watcher identity" > "$state/.watch.lock/pid-identity"
+  PATH="$fakebin:$PATH" FM_HOME="$dir" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH_ARM" --restart > "$out" &
+  pid=$!
+  i=0
+  while [ "$i" -lt 50 ]; do
+    lock_pid=$(cat "$state/.watch.lock/pid" 2>/dev/null || true)
+    [ "$lock_pid" = "$pid" ] && break
+    sleep 0.1
+    i=$((i + 1))
+  done
+  lock_pid=$(cat "$state/.watch.lock/pid" 2>/dev/null || true)
+  [ "$lock_pid" = "$pid" ] || fail "restart did not replace stale reused-pid lock (got '$lock_pid')"
+  is_live_non_zombie "$live" || fail "restart killed a reused unrelated pid"
+  kill "$pid" "$live" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+  wait "$live" 2>/dev/null || true
+  pass "watch restart refuses to signal a reused pid"
+}
+
 test_watcher_self_evicts_on_lock_takeover() {
   local dir state fakebin out pid i lock_pid
   dir=$(make_case self-evict)
@@ -1406,6 +1455,8 @@ test_live_stale_watch_lock_is_actionable
 test_lock_single_winner_under_concurrency
 test_lock_steals_dead_pid_lock
 test_lock_does_not_steal_live_lock
+test_lock_empty_pid_uses_minimum_grace
+test_watch_restart_rejects_reused_pid
 test_watcher_self_evicts_on_lock_takeover
 test_guard_warns_on_pending_queue
 test_guard_rearms_after_draining_pending_queue

--- a/tests/fm-wake-queue.test.sh
+++ b/tests/fm-wake-queue.test.sh
@@ -1367,6 +1367,46 @@ test_lock_stale_steal_single_winner_under_concurrency() {
   pass "concurrent stale-lock steal yields exactly one winner"
 }
 
+test_lock_live_steal_mutex_is_not_reclaimed() {
+  local dir state lockdir dead holder_file holder out i lockpid stealpid
+  dir=$(make_case lock-live-stealer)
+  state="$dir/state"
+  lockdir="$state/.contend.lock"
+  holder_file="$dir/holder"
+  dead=$(dead_pid)
+  mkdir "$lockdir"
+  printf '%s\n' "$dead" > "$lockdir/pid"
+  FM_STATE_OVERRIDE="$state" bash -c '
+    . "$1"
+    fm_lock_try_acquire "$2.steal" || exit 7
+    printf "%s\n" "${BASHPID:-$$}" > "$3"
+    sleep 2
+    fm_lock_release "$2.steal"
+  ' _ "$LIB" "$lockdir" "$holder_file" &
+  holder=$!
+  i=0
+  while [ "$i" -lt 50 ] && [ ! -s "$holder_file" ]; do
+    sleep 0.1
+    i=$((i + 1))
+  done
+  [ -s "$holder_file" ] || fail "live steal mutex holder did not start"
+  out=$(FM_LOCK_STALE_AFTER=0 FM_STATE_OVERRIDE="$state" bash -c '
+    . "$1"
+    if fm_lock_try_acquire "$2"; then rc=0; else rc=1; fi
+    printf "rc=%s held=%s lockpid=%s stealpid=%s\n" "$rc" "${FM_LOCK_HELD_PID:-}" "$(cat "$2/pid" 2>/dev/null || true)" "$(cat "$2.steal/pid" 2>/dev/null || true)"
+  ' _ "$LIB" "$lockdir")
+  wait "$holder" || fail "live steal mutex holder failed"
+  case "$out" in
+    *"rc=1"*) ;;
+    *) fail "stale lock was stolen while a live stealer held the mutex: $out" ;;
+  esac
+  lockpid=${out#*lockpid=}; lockpid=${lockpid%% *}
+  stealpid=${out#*stealpid=}; stealpid=${stealpid%% *}
+  [ "$lockpid" = "$dead" ] || fail "primary lock changed while live steal mutex was held: $out"
+  [ "$stealpid" = "$(cat "$holder_file")" ] || fail "live steal mutex owner changed: $out"
+  pass "live steal mutex is not reclaimed"
+}
+
 # A lock held by a LIVE pid is never stolen; acquire is a no-op that reports the
 # live holder via FM_LOCK_HELD_PID and leaves the pid file untouched.
 test_lock_does_not_steal_live_lock() {
@@ -1518,6 +1558,7 @@ test_live_stale_watch_lock_is_actionable
 test_lock_single_winner_under_concurrency
 test_lock_steals_dead_pid_lock
 test_lock_stale_steal_single_winner_under_concurrency
+test_lock_live_steal_mutex_is_not_reclaimed
 test_lock_does_not_steal_live_lock
 test_lock_empty_pid_uses_minimum_grace
 test_lock_late_claim_loses_after_recreate

--- a/tests/fm-wake-queue.test.sh
+++ b/tests/fm-wake-queue.test.sh
@@ -1490,6 +1490,35 @@ test_lock_late_claim_loses_after_recreate() {
   pass "late original claimant cannot claim a recreated lock"
 }
 
+test_lock_paused_mid_acquire_claim_fails_during_steal() {
+  local dir state lockdir out pid
+  dir=$(make_case lock-paused-claim-steal)
+  state="$dir/state"
+  lockdir="$state/.contend.lock"
+  out=$(FM_LOCK_STALE_AFTER=0 FM_STATE_OVERRIDE="$state" bash -c '
+    . "$1"
+    owner=$(fm_lock_owner_dir "$2") || exit 20
+    ln -s "$owner" "$2" || exit 21
+    fm_lock_try_acquire "$2.steal" || exit 22
+    steal_owner=${FM_LOCK_OWNER_DIR:-}
+    if fm_lock_claim "$2" "$owner"; then late=won; else late=lost; fi
+    if fm_lock_try_create "$2" "$steal_owner"; then stealer=won; else stealer=lost; fi
+    pid=$(cat "$2/pid" 2>/dev/null || true)
+    printf "late=%s stealer=%s pid=%s\n" "$late" "$stealer" "$pid"
+  ' _ "$LIB" "$lockdir")
+  case "$out" in
+    *"late=lost"*) ;;
+    *) fail "paused claimant succeeded while steal mutex was held: $out" ;;
+  esac
+  case "$out" in
+    *"stealer=won"*) ;;
+    *) fail "stealer could not claim after paused claimant backed off: $out" ;;
+  esac
+  pid=${out#*pid=}; pid=${pid%% *}
+  [ -n "$pid" ] || fail "stealer claim did not record a pid: $out"
+  pass "paused mid-acquire claimant backs off to active stealer"
+}
+
 test_watch_restart_rejects_reused_pid() {
   local dir state fakebin out live pid i lock_pid
   dir=$(make_case restart-reused-pid)
@@ -1562,6 +1591,7 @@ test_lock_live_steal_mutex_is_not_reclaimed
 test_lock_does_not_steal_live_lock
 test_lock_empty_pid_uses_minimum_grace
 test_lock_late_claim_loses_after_recreate
+test_lock_paused_mid_acquire_claim_fails_during_steal
 test_watch_restart_rejects_reused_pid
 test_watcher_self_evicts_on_lock_takeover
 test_guard_warns_on_pending_queue

--- a/tests/fm-wake-queue.test.sh
+++ b/tests/fm-wake-queue.test.sh
@@ -1336,6 +1336,37 @@ test_lock_steals_dead_pid_lock() {
   pass "dead-pid stale lock is reclaimed by a single acquirer"
 }
 
+test_lock_stale_steal_single_winner_under_concurrency() {
+  local dir state lockdir dead marker i pids pid wins
+  dir=$(make_case lock-stale-concurrency)
+  state="$dir/state"
+  lockdir="$state/.contend.lock"
+  marker="$dir/wins"
+  dead=$(dead_pid)
+  mkdir "$lockdir"
+  printf '%s\n' "$dead" > "$lockdir/pid"
+  : > "$marker"
+  pids=
+  i=1
+  while [ "$i" -le 40 ]; do
+    FM_STATE_OVERRIDE="$state" bash -c '
+      . "$1"
+      if fm_lock_try_acquire "$2"; then
+        printf "%s\n" "${BASHPID:-$$}" >> "$3"
+        sleep 1
+      fi
+    ' _ "$LIB" "$lockdir" "$marker" &
+    pids="$pids $!"
+    i=$((i + 1))
+  done
+  for pid in $pids; do
+    wait "$pid" 2>/dev/null || true
+  done
+  wins=$(awk 'NF { c++ } END { print c + 0 }' "$marker")
+  [ "$wins" -eq 1 ] || fail "expected exactly one stale-lock stealer, got $wins"
+  pass "concurrent stale-lock steal yields exactly one winner"
+}
+
 # A lock held by a LIVE pid is never stolen; acquire is a no-op that reports the
 # live holder via FM_LOCK_HELD_PID and leaves the pid file untouched.
 test_lock_does_not_steal_live_lock() {
@@ -1385,6 +1416,38 @@ test_lock_empty_pid_uses_minimum_grace() {
   [ -d "$lockdir" ] || fail "empty mid-acquire lock dir was removed during grace"
   [ ! -e "$lockdir/pid" ] || fail "empty mid-acquire lock gained a pid during grace"
   pass "empty mid-acquire lock keeps a minimum grace"
+}
+
+test_lock_late_claim_loses_after_recreate() {
+  local dir state lockdir out
+  dir=$(make_case lock-late-claim)
+  state="$dir/state"
+  lockdir="$state/.contend.lock"
+  out=$(FM_LOCK_STALE_AFTER=0 FM_STATE_OVERRIDE="$state" bash -c '
+    . "$1"
+    owner1=$(fm_lock_owner_dir "$2") || exit 20
+    ln -s "$owner1" "$2" || exit 21
+    touch -h -t 200001010000 "$2" 2>/dev/null || sleep 2
+    if ! fm_lock_try_acquire "$2"; then exit 22; fi
+    before=$(cat "$2/pid" 2>/dev/null || true)
+    if fm_lock_claim "$2" "$owner1"; then late=won; else late=lost; fi
+    after=$(cat "$2/pid" 2>/dev/null || true)
+    current_owner=$(readlink "$2" 2>/dev/null || true)
+    printf "late=%s before=%s after=%s owner_changed=%s\n" "$late" "$before" "$after" "$([ "$current_owner" != "$owner1" ] && echo yes || echo no)"
+  ' _ "$LIB" "$lockdir")
+  case "$out" in
+    *"late=lost"*) ;;
+    *) fail "late original claimant succeeded after lock recreation: $out" ;;
+  esac
+  case "$out" in
+    *"owner_changed=yes"*) ;;
+    *) fail "stale owner was not replaced before late claim: $out" ;;
+  esac
+  before=${out#*before=}; before=${before%% *}
+  after=${out#*after=}; after=${after%% *}
+  [ -n "$before" ] || fail "recreated lock did not record a pid: $out"
+  [ "$before" = "$after" ] || fail "late claim changed the recreated lock pid: $out"
+  pass "late original claimant cannot claim a recreated lock"
 }
 
 test_watch_restart_rejects_reused_pid() {
@@ -1454,8 +1517,10 @@ test_stale_watch_lock_reclaimed
 test_live_stale_watch_lock_is_actionable
 test_lock_single_winner_under_concurrency
 test_lock_steals_dead_pid_lock
+test_lock_stale_steal_single_winner_under_concurrency
 test_lock_does_not_steal_live_lock
 test_lock_empty_pid_uses_minimum_grace
+test_lock_late_claim_loses_after_recreate
 test_watch_restart_rejects_reused_pid
 test_watcher_self_evicts_on_lock_takeover
 test_guard_warns_on_pending_queue


### PR DESCRIPTION
## Intent

Make the firstmate watcher singleton race-proof so two fm-watch.sh watchers can never run in one home, and make re-arm safe across homes. Root cause: fm_lock_try_acquire's stale-steal path in bin/fm-wake-lib.sh destroyed and recreated the lock dir without serialization, so two racers seeing the same dead pid could both reclaim it (observed: two watchers in one home doubling every wake); and the supervision pattern of re-arming via 'pkill -f bin/fm-watch.sh' matched every home's watcher, killing secondmate homes' watchers.

Changes and the deliberate decisions behind them:
- bin/fm-wake-lib.sh: rewrote fm_lock_try_acquire to be single-winner. Reclaim of a stale lock is now serialized through a sibling '.steal' mkdir mutex so two stealers can never destroy-and-recreate concurrently; the holder pid is re-verified dead immediately before the rmdir; and a new fm_lock_claim helper writes the pid then reads it back so a stomped pid means we lost. mkdir is the atomic winner-selector, so at most one acquirer returns 0. Deliberate: the steal-mutex abandonment threshold (steal_stale) is DECOUPLED from FM_LOCK_STALE_AFTER and floored at 2s on purpose - tying it to that knob (which can be tuned to 0) would force-clear a live stealer's mutex and re-admit the double-winner race. Deliberate: fm_lock_claim reads its pid as ${BASHPID:-$$} directly rather than via $(fm_current_pid), because a command substitution forks a subshell whose pid would be recorded dead; this also keeps it consistent with fm_lock_release's own ${BASHPID:-$$} comparison. Removed the now-unused fm_lock_remove_stale (only ever called internally).
- bin/fm-watch.sh: added per-poll self-eviction - each cycle the watcher verifies the lock pid still names it (compared against WATCHER_PID captured once at startup) and exits cleanly if another pid took over, so any transient duplicate self-resolves within one poll. The EXIT-trap release intentionally no-ops for a foreign pid so the survivor's lock is untouched.
- bin/fm-watch-arm.sh (new): safe home-scoped re-arm. Default execs the watcher and relies on the singleton no-op; --restart signals ONLY this home's recorded watcher pid (from this home's state/.watch.lock) and waits for it to exit before relaunching - never a broad pkill.
- AGENTS.md section 8: routes re-arm through bin/fm-watch-arm.sh, documents --restart as the home-scoped forced restart, and explicitly warns that 'pkill -f bin/fm-watch.sh' kills sibling homes' watchers since secondmate homes run the same script.
- tests/fm-wake-queue.test.sh: added four hermetic tests - concurrency single-winner (40 contenders, exactly one wins), dead-pid stale lock stolen by a single acquirer, live-holder lock not stolen (no-op reporting FM_LOCK_HELD_PID), and watcher self-eviction on lock takeover.

Constraints honored: portable bash/POSIX, macOS (BSD) + Linux (GNU) compatible, no flock; all existing env knobs preserved (FM_LOCK_STALE_AFTER, FM_WATCHER_STALE_GRACE, FM_GUARD_GRACE) and the watcher's exit/reason contract (signal/stale/check/heartbeat), durable wake queue, and heartbeat backoff unchanged. Verified locally: shellcheck clean (CI-style across bin/*.sh tests/*.sh), all 165 tests across 8 files pass, and a stress harness yields exactly one winner across 1000+ concurrent steal attempts even at FM_LOCK_STALE_AFTER=0.

## What Changed
- Hardened wake lock acquisition so stale lock stealing is serialized, ownership is revalidated before takeover, and only one claimant can enter a protected section.
- Added `fm-watch-arm.sh` for home-scoped watcher arming and restart behavior, with watcher self-eviction when another process takes over its lock.
- Updated watcher documentation and added shell tests for lock contention, stale lock recovery, live-holder refusal, and watcher takeover handling.

## Risk Assessment

⚠️ Medium: Captain, the final patch has no substantiated merge-blocking findings, but it rewrites a central shared lock primitive with subtle scheduler and stale-state behavior, so residual concurrency risk remains higher than a routine change.

## Testing

Captain, I exercised the focused watcher/wake-queue suite, the full CI behavior-test loop, and a reviewer-visible CLI transcript for the intended race and re-arm behavior; all checks passed and the working tree stayed clean.

<details>
<summary>Evidence: manual watcher singleton and re-arm transcript</summary>

`Key lines: winner_count=1; second_arm_output=watcher: already running pid 33072; home_b_still_alive=yes; original_watcher_alive_after_poll=no.`

```text
Manual evidence for watcher singleton and home-scoped re-arm
repo=/Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KVXEQH3C9PT9ARAKSMFE59J4

1. Stale lock steal race with 40 concurrent contenders
dead_pid_before=999999
winner_count=1
winner_record=winner pid=31788
final_lock_pid=31788
PASS: exactly one contender reclaimed the stale lock.

2. Live holder lock is not stolen
rc=1 held=33046 pid_after=33046
PASS: live holder was reported and its pid file was preserved.

3. Duplicate watcher arm in one home no-ops
first_watcher_pid=33072
lock_pid=33072
first_watcher_alive_after_second_arm=yes
second_arm_output=watcher: already running pid 33072
PASS: second arm exited and reported the existing singleton.

4. --restart is scoped to the selected FM_HOME
home_a_old_pid=33172
home_a_new_pid=33287
home_a_lock_after_restart=33287
home_a_old_exited=yes
home_b_pid_before_and_after=33229/33229
home_a_new_alive=yes
home_b_still_alive=yes
PASS: restarting home A replaced only home A watcher; home B stayed alive.

5. Watcher self-evicts when its lock pid is taken over
original_watcher_pid=33403
takeover_pid=33495
original_watcher_alive_after_poll=no
lock_pid_after_self_eviction=33495
takeover_pid_alive=yes
PASS: displaced watcher exited and did not remove the survivor lock.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (4) ✅</summary>

- 🚨 `bin/fm-wake-lib.sh:92` - When FM_LOCK_STALE_AFTER=0, a just-created lock dir with no pid is immediately treated as stale. The mkdir winner can be preempted before fm_lock_claim, another process can remove and recreate the lock dir and return success, then the original winner can resume, write its pid into the recreated dir, and also return success. Give the mid-acquire empty/non-numeric pid case a nonzero minimum grace or another unstealable claim token.
- ⚠️ `bin/fm-watch-arm.sh:36` - --restart sends TERM to any live pid found in state/.watch.lock/pid. If the lock is stale and that pid has been reused, this can kill an unrelated process while trying to restart the watcher. Verify that the pid still belongs to this home&#39;s fm-watch.sh instance before signalling it, or store enough owner identity in the lock to reject reused pids.

🔧 Fix: Harden watcher lock ownership
1 error still open:
- 🚨 `bin/fm-wake-lib.sh:73` - A process that wins `mkdir &#34;$lockdir&#34;` can still be paused longer than `mid_acquire_stale` before this write, letting another process reclaim the empty lock, write its pid, and return success. When the original process resumes, it writes into the newly-created lockdir, reads back its own pid, and also returns success, so the new single-winner guarantee is still breakable even with the 2s floor. Bind the claim to an unstealable owner token, or otherwise make a stale original winner unable to claim a recreated directory.

🔧 Fix: Captain, harden watcher lock claims
1 error still open:
- 🚨 `bin/fm-wake-lib.sh:189` - The stale-steal mutex can be force-cleared after 2s without proving the stealer is dead. If stealer A creates `$lockdir.steal`, reads a dead `cur`, then is paused past `steal_stale`, stealer B can remove the mutex, remove/recreate the lock, and return success; when A resumes it can remove B&#39;s live lock at `fm_lock_remove_path`, recreate it, and also return success. Make the steal mutex itself owned/unstealable, or revalidate the exact lock owner immediately before removal so a live slow stealer cannot be displaced.

🔧 Fix: Captain, harden lock steal mutex ownership
1 error still open:
- 🚨 `bin/fm-wake-lib.sh:216` - A paused mid-acquire owner can still win after the stale stealer has checked the empty pid but before this removal. In that interleaving, the original claimant writes its pid and returns success, then the stealer removes that now-live lock, creates a new one, and also returns success, so two callers can enter the protected section. Revalidate the exact primary owner/pid immediately at removal time, or make `fm_lock_claim` fail while the steal lock is held.

🔧 Fix: Captain, harden steal-aware lock claims
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `FM_FLEET_SYNC_BOOTSTRAP_TIMEOUT=1 bin/fm-bootstrap.sh`
- `bash tests/fm-wake-queue.test.sh`
- `set -eu; for test_script in tests/*.test.sh; do "$test_script"; done`
- <code>Manual shell harness wrote `/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVXEQH3C9PT9ARAKSMFE59J4/watcher-singleton-rearm-transcript.txt` exercising stale-lock contention, live-holder refusal, duplicate arm no-op, home-scoped restart, and lock-takeover self-eviction.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
