### PR TITLE
fix(supervision): treat NBSP as whitespace in composer detection

### DIFF
--- a/bin/fm-tmux-lib.sh
+++ b/bin/fm-tmux-lib.sh
@@ -127,6 +127,13 @@ fm_tmux_composer_state() {  # <target> -> empty|pending|unknown
   stripped=${line//│/}      # U+2502 light vertical (claude)
   stripped=${stripped//┃/}  # U+2503 heavy vertical
   stripped=${stripped//|/}  # ASCII pipe
+  # Normalize the non-breaking space (U+00A0) the claude composer pads its prompt
+  # with into an ASCII space. The trim below uses POSIX [:space:], which does NOT
+  # match U+00A0, so without this an idle "❯<NBSP>" prompt survives the trim, never
+  # matches the bare-prompt "empty" case, and reads as pending input — wedging the
+  # away-mode daemon (it deferred 100% of escalations) and tripping fm-send's
+  # swallowed-Enter check on every idle pane.
+  stripped=${stripped//$'\xc2\xa0'/ }  # U+00A0 NBSP -> ASCII space
   # Trim surrounding whitespace.
   stripped="${stripped#"${stripped%%[![:space:]]*}"}"
   stripped="${stripped%"${stripped##*[![:space:]]}"}"


### PR DESCRIPTION
## Problem

The composer-state detector (`fm_tmux_composer_state` in `bin/fm-tmux-lib.sh`) misclassifies an **idle** Claude composer as holding pending input. Two consequences:

- The away-mode sub-supervisor's composer guard defers every escalation, so `/afk` silently delivers nothing for the entire away period (the durable queue preserves it, but the proactive notify path is dead). This is the `afk-invx-i5` failure mode reopening after a TUI rendering change.
- `fm-send.sh` shares the detector, so it reports a false "Enter swallowed; text left in composer" on every steer into an idle pane, even when the message submitted fine.

## Root cause

The current Claude TUI pads its prompt with a **non-breaking space (U+00A0)** rather than an ASCII space, rendering the idle composer row as `❯<U+00A0>`. The detector strips the box-border glyphs and then trims whitespace with POSIX `[:space:]`, which does **not** match U+00A0. The trailing NBSP survives the trim, so `stripped` is `❯<U+00A0>` rather than a bare `❯`, never matches the bare-prompt "empty" case, and falls through to `pending`.

Reproduced live: `fm_tmux_composer_state` returns `pending` for known-idle Claude panes; the stripped value's hex is `e2 9d af c2 a0` (`❯` + U+00A0).

## Fix

Normalize U+00A0 to an ASCII space before the trim, alongside the existing border-glyph strips. After the fix, the same idle panes classify `empty`.

Minimal and harness-generic; does not affect busy detection or genuine pending input.
