### PR TITLE
fix: guard firstmate against primary worktree tangles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,7 @@ Otherwise it prints one line per problem or capability fact; handle each:
 - `MISSING: <tool> (install: <command>)` - list the missing tools to the captain with a one-line purpose each plus the printed install commands, wait for consent (one approval may cover the list), then run `bin/fm-bootstrap.sh install <approved tools...>`.
   For `treehouse`, this also covers an installed version whose `treehouse get` lacks `--lease`; treat it as an upgrade request.
 - `NEEDS_GH_AUTH` - ask the captain to run `! gh auth login` (interactive; you cannot run it for them).
+- `TANGLE: <remediation>` - the firstmate primary checkout (the repo root, `FM_ROOT`) is stranded on a feature branch instead of its default branch: a crewmate working firstmate-on-itself branched/committed in the primary instead of its own isolated worktree (section 8). The work is safe on that branch ref; restore the primary to its default branch with the printed `git -C <root> checkout <default>`, then re-validate that branch in a proper worktree. This is the only sanctioned firstmate-initiated git write to the primary, and it is a non-destructive branch switch that strands nothing.
 - `CREW_HARNESS_OVERRIDE: <name>` - record and use the override silently; surface a harness fact only if it actually blocks work or the captain asks.
 - `FLEET_SYNC: <repo>: skipped: <reason>` - bootstrap continued; investigate only if the dirty, diverged, or offline clone blocks work.
 - `TASKS_AXI: available` - an optional capability fact, not a problem; record it silently and use section 10 for backlog mutations.
@@ -320,7 +321,7 @@ If one pair fails, the rest still run and the batch exits non-zero.
 The script resolves the harness (`fm-harness.sh crew`), owns the verified launch templates, resolves the project's delivery mode (`fm-project-mode.sh`) for ship/scout tasks, and records `harness=`, `kind=`, `mode=`, and `yolo=` in the task's meta; a non-flag third argument containing whitespace is treated as a raw launch command (only for verifying new adapters).
 For `kind=secondmate`, the same script launches in the registered or explicit firstmate home instead of running `treehouse get` for a project, records `home=` and `projects=`, and uses the charter brief as the launch prompt.
 
-For ship and scout tasks, the script creates the window (in your current tmux session, or a dedicated `firstmate` session when you are outside tmux), runs `treehouse get`, waits for the worktree subshell, installs the turn-end hook, records `state/<id>.meta`, and launches the agent with the brief.
+For ship and scout tasks, the script creates the window (in your current tmux session, or a dedicated `firstmate` session when you are outside tmux), runs `treehouse get`, waits for the worktree subshell, asserts the resolved worktree is a genuine isolated worktree distinct from the primary checkout (aborting the spawn otherwise, to prevent the worktree tangle of section 8), installs the turn-end hook, records `state/<id>.meta`, and launches the agent with the brief.
 For `kind=secondmate`, the script creates the same kind of window but starts directly in the persistent home.
 Project worktrees start at detached HEAD on a clean default branch; ship briefs tell the crewmate to create its branch, while scout briefs keep the worktree scratch.
 After spawning, peek the pane to confirm the crewmate is processing the brief and handle any trust dialog with `harness-adapters`.
@@ -458,6 +459,13 @@ So the next time you touch the fleet with queued wakes or no watcher alive, the 
 The grace window keeps normal handling (watcher briefly down between a wake and its re-arm) silent.
 If a guard warning says queued wakes are pending, drain them before doing anything else.
 If a guard warning says watcher liveness is stale, arm `bin/fm-watch-arm.sh` after draining any queued wakes.
+
+`fm-guard.sh` carries a second, independent alarm in the same bordered ●-marked style: the **worktree-tangle** guard.
+Firstmate is a treehouse-pooled git repo of itself - the primary checkout (the repo root, `FM_ROOT`) and every crewmate worktree and secondmate home are linked worktrees of one repo - and the primary must stay on its default branch.
+If a crewmate sent to work firstmate-on-itself branches or commits in the primary instead of its own isolated worktree, the primary is stranded on a feature branch (the failure this guards against); the guard names the offending branch and prints the non-destructive restore (`git -C <root> checkout <default>`), so the tangle surfaces on the very next fleet action.
+The check is scoped precisely to the primary: detached HEAD (the legitimate resting state of crewmate worktrees and secondmate homes on the default branch) and the default branch itself never alarm; only a named non-default branch checked out in the primary does.
+The same assertion runs at session start as the bootstrap `TANGLE:` line (section 3).
+Two further guards prevent the tangle upstream: `fm-spawn` refuses to launch unless `treehouse get` yields a genuine isolated worktree distinct from the primary checkout, and every ship brief's first instruction has the crewmate verify it is in its own worktree before branching (section 11).
 Watcher liveness is not enough if you are foreground-blocked.
 Whenever one or more tasks are in flight, do not run long foreground-blocking operations in your own session.
 This is about firstmate's own session: it includes a no-mistakes pipeline firstmate runs for this repo, long builds, and any other multi-minute command.
@@ -555,6 +563,7 @@ Map firstmate's real backlog operations to the approved commands:
 ## 11. Crewmate briefs
 
 Scaffold with `bin/fm-brief.sh <id> <repo-name>` - it writes `data/<id>/brief.md` with the standard contract (branch setup, status-reporting protocol, push/merge rules, definition of done) and all paths filled in.
+The ship-brief Setup opens with a worktree-isolation assertion ahead of the branch step: the crewmate confirms it is in its own treehouse worktree, not the primary checkout, and stops with `blocked: launched in primary checkout, not an isolated worktree` if not - the upstream half of the worktree-tangle guard (section 8).
 For a ship task the definition of done is shaped by the project's delivery mode (section 6): `no-mistakes` ends in the harness-appropriate no-mistakes validation pipeline, `direct-PR` has the crewmate push and open the PR itself, `local-only` has it stop at "ready in branch" for firstmate to review and merge locally.
 The scaffold reads the mode via `fm-project-mode.sh`, so you do not pass it.
 Ship briefs also include the project-memory contract: run `bin/fm-ensure-agents-md.sh` when the project already has agent-memory files or when the task produced durable project-intrinsic knowledge, then record proportionate learnings in `AGENTS.md`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,7 @@ tests/fm-wake-daemon-lifecycle-e2e.test.sh # watcher + daemon lifecycle e2e: res
 tests/fm-composer-ghost.test.sh           # dim-ghost stripping, ghost-only composer detection, and escape-free peek tests
 tests/fm-afk-inject-e2e.test.sh           # private-socket end-to-end test of the afk injection path (partial-input deferral, swallowed-Enter retry)
 tests/fm-bootstrap.test.sh                # bootstrap dependency and feature-probe tests
+tests/fm-tangle-guard.test.sh             # primary-checkout tangle detection and spawn/brief isolation tests
 tests/fm-spawn-batch.test.sh              # batch dispatch and FM_HOME project-path scoping tests
 tests/fm-update.test.sh                   # fast-forward-only self-update, reread, nudge, dedup, and skip-safety tests
 tests/fm-secondmate-lifecycle-e2e.test.sh # persistent secondmate routing, seeding, backlog handoff, spawn, recovery, teardown, and FM_HOME flow tests

--- a/README.md
+++ b/README.md
@@ -109,8 +109,9 @@ Outside tmux, crewmates land in a detached `firstmate` session you can attach to
 You chat with the first mate.
 It routes each request to a crewmate in its own tmux window and git worktree, supervises the fleet with a zero-token event-driven watcher, and brings you finished PRs, approved local merges, or investigation reports.
 A presence-gated sub-supervisor (`/afk`) can self-handle routine events and batch only what matters while you step away.
+When firstmate works on itself, spawn-time isolation checks and a primary-checkout tangle alarm keep the operating checkout on its default branch and stop a crewmate that did not land in a separate worktree.
 
-Full architecture - the supervision engine, secondmates, project modes, fleet sync, and self-update - is in [docs/architecture.md](docs/architecture.md).
+Full architecture - the supervision engine, worktree isolation, secondmates, project modes, fleet sync, and self-update - is in [docs/architecture.md](docs/architecture.md).
 
 ## Built-in skills
 

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -5,7 +5,10 @@
 #          Silent = all good.
 #          Lines: "MISSING: <tool> (install: <command>)", "NEEDS_GH_AUTH",
 #                 "CREW_HARNESS_OVERRIDE: <name>", "FLEET_SYNC: <repo>: skipped: <reason>",
-#                 "TASKS_AXI: available".
+#                 "TASKS_AXI: available", "TANGLE: <remediation>".
+#          A TANGLE line means the firstmate primary checkout (FM_ROOT) is stranded
+#          on a feature branch instead of its default branch - a crewmate's work
+#          landed in the primary instead of its own worktree; restore it per the line.
 #          treehouse is also MISSING when its installed version lacks
 #          "treehouse get --lease" support.
 #          tasks-axi is an OPTIONAL backlog-management capability reported only
@@ -25,6 +28,8 @@ PROJECTS="${FM_PROJECTS_OVERRIDE:-$FM_HOME/projects}"
 CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
 # shellcheck source=bin/fm-tasks-axi-lib.sh
 . "$SCRIPT_DIR/fm-tasks-axi-lib.sh"
+# shellcheck source=bin/fm-tangle-lib.sh
+. "$SCRIPT_DIR/fm-tangle-lib.sh"
 
 fleet_sync() {
   [ -x "$FM_ROOT/bin/fm-fleet-sync.sh" ] || return 0
@@ -99,6 +104,14 @@ if command -v treehouse >/dev/null 2>&1 && ! treehouse_supports_lease; then
   echo "MISSING: treehouse (install: $(install_cmd treehouse))"
 fi
 gh auth status >/dev/null 2>&1 || echo "NEEDS_GH_AUTH"
+# Worktree-tangle check: the firstmate primary checkout (FM_ROOT) must sit on its
+# default branch, not a feature branch (see fm-tangle-lib.sh). Scoped to the
+# primary only; detached-HEAD worktrees and secondmate homes never trip it.
+tangle_branch=$(fm_primary_tangle_branch "$FM_ROOT" 2>/dev/null || true)
+if [ -n "$tangle_branch" ]; then
+  tangle_default=$(fm_default_branch "$FM_ROOT" 2>/dev/null || echo main)
+  echo "TANGLE: primary checkout on feature branch '$tangle_branch' (expected '$tangle_default'); the work is safe on that ref - restore the primary with: git -C $FM_ROOT checkout $tangle_default, then re-validate the branch in a proper worktree"
+fi
 crew=
 [ -f "$CONFIG/crew-harness" ] && crew=$(tr -d '[:space:]' < "$CONFIG/crew-harness" || true)
 [ -n "$crew" ] && [ "$crew" != "default" ] && echo "CREW_HARNESS_OVERRIDE: $crew"

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -23,6 +23,7 @@
 #   direct-PR    implement -> push + open PR via gh-axi (no pipeline) -> captain merge
 #   local-only   implement on branch, stop and report "ready in branch" (no push/PR);
 #                firstmate reviews, captain approves, firstmate merges to local main
+# Ship briefs begin with a worktree-isolation assertion before the branch step.
 # Scout tasks ignore mode - their deliverable is a report, not a merge.
 # Ship tasks include a project-memory section so durable project-intrinsic
 # learnings can be committed to AGENTS.md through the project's delivery path.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -213,6 +213,9 @@ You are a crewmate: an autonomous worker agent managed by firstmate. Work on you
 
 # Setup
 You are in a disposable git worktree of $REPO, at a detached HEAD on a clean default branch.
+
+**Verify isolation before anything else.** Confirm you are in your own disposable worktree, NOT the primary checkout firstmate operates from. Run \`git rev-parse --show-toplevel\` and confirm it resolves to the treehouse worktree you were launched in (a path under a \`.treehouse/\` pool), not the repo root. A reliable test that you are in a linked worktree: \`git rev-parse --git-dir\` and \`git rev-parse --git-common-dir\` resolve to DIFFERENT paths (they are identical in the primary checkout). If it resolves to the primary checkout, STOP - do not branch or commit here - append \`blocked: launched in primary checkout, not an isolated worktree\` to the status file and stop.
+
 1. First action: create your branch: \`git checkout -b fm/$ID\`$SETUP2
 
 # Rules

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -214,7 +214,9 @@ You are a crewmate: an autonomous worker agent managed by firstmate. Work on you
 # Setup
 You are in a disposable git worktree of $REPO, at a detached HEAD on a clean default branch.
 
-**Verify isolation before anything else.** Confirm you are in your own disposable worktree, NOT the primary checkout firstmate operates from. Run \`git rev-parse --show-toplevel\` and confirm it resolves to the treehouse worktree you were launched in (a path under a \`.treehouse/\` pool), not the repo root. A reliable test that you are in a linked worktree: \`git rev-parse --git-dir\` and \`git rev-parse --git-common-dir\` resolve to DIFFERENT paths (they are identical in the primary checkout). If it resolves to the primary checkout, STOP - do not branch or commit here - append \`blocked: launched in primary checkout, not an isolated worktree\` to the status file and stop.
+**Verify isolation before anything else.** Run \`pwd -P\` and \`git rev-parse --show-toplevel\`; both must resolve to the disposable treehouse worktree you were launched in, typically a path under a \`.treehouse/\` pool, not the primary checkout firstmate operates from.
+The path check is authoritative: \`git rev-parse --git-dir\` and \`git rev-parse --git-common-dir\` can help inspect the repo, but they do not prove you are outside the primary checkout.
+If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append \`blocked: launched in primary checkout, not an isolated worktree\` to the status file and stop.
 
 1. First action: create your branch: \`git checkout -b fm/$ID\`$SETUP2
 

--- a/bin/fm-guard.sh
+++ b/bin/fm-guard.sh
@@ -18,6 +18,30 @@ queue_pending=false
 
 # shellcheck source=bin/fm-wake-lib.sh
 . "$SCRIPT_DIR/fm-wake-lib.sh"
+# shellcheck source=bin/fm-tangle-lib.sh
+. "$SCRIPT_DIR/fm-tangle-lib.sh"
+
+# Worktree-tangle alarm, checked FIRST and independent of in-flight tasks: the
+# firstmate PRIMARY checkout (FM_ROOT) must stay on its default branch. If a
+# crewmate's branch/commits landed here instead of in its own isolated worktree,
+# the primary is stranded on a feature branch - surface it loudly on the very next
+# fleet action, the same way the watcher-down banner does. Scoped to the primary
+# only: detached HEAD (linked worktrees, secondmate homes) never trips this.
+tangle_branch=$(fm_primary_tangle_branch "$FM_ROOT" || true)
+if [ -n "$tangle_branch" ]; then
+  tangle_default=$(fm_default_branch "$FM_ROOT" 2>/dev/null || echo main)
+  trule='━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'
+  {
+    printf '●%s\n' "$trule"
+    printf '●  WORKTREE TANGLE - PRIMARY CHECKOUT IS ON A FEATURE BRANCH\n'
+    printf "●  %s is on '%s', not its default branch '%s'.\n" "$FM_ROOT" "$tangle_branch" "$tangle_default"
+    printf '●  A crewmate likely branched/committed in the primary instead of its own worktree.\n'
+    printf "●  The work is SAFE on the '%s' ref. Restore the primary to '%s':\n" "$tangle_branch" "$tangle_default"
+    printf '●      git -C %s checkout %s\n' "$FM_ROOT" "$tangle_default"
+    printf "●  then re-validate '%s' in a proper isolated worktree.\n" "$tangle_branch"
+    printf '●%s\n' "$trule"
+  } >&2
+fi
 
 # Portable mtime; see fm-watch.sh for why the `stat -f || stat -c` fallback breaks on Linux.
 if [ "$(uname)" = Darwin ]; then

--- a/bin/fm-guard.sh
+++ b/bin/fm-guard.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
-# Watcher liveness guard, called at the top of the supervision scripts.
-# If any task is in flight (a state/<id>.meta exists) and the watcher's
+# Watcher liveness and worktree-tangle guard, called at the top of the
+# supervision scripts.
+# First, always warn if the firstmate primary checkout (FM_ROOT) is on a named
+# non-default branch, because that means firstmate-on-itself work landed in the
+# primary instead of an isolated worktree.
+# Then, if any task is in flight (a state/<id>.meta exists) and the watcher's
 # liveness beacon (state/.last-watcher-beat, touched every poll cycle) is
 # missing or older than FM_GUARD_GRACE seconds, prints a loud, clearly delimited
 # banner so the agent cannot skim past it in the tool output of whatever it was

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -354,10 +354,19 @@ if [ "$KIND" != secondmate ]; then
   # checkout; branching/committing there would tangle the primary onto a feature
   # branch (see fm-tangle-lib.sh). The wait loop above only proves the pane left
   # PROJ_ABS's exact path; this proves it landed in a true, separate worktree.
-  wt_real=$(cd "$WT" 2>/dev/null && pwd -P || true)
-  proj_real=$(cd "$PROJ_ABS" 2>/dev/null && pwd -P || true)
+  wt_real=
+  if ! wt_real=$(cd "$WT" 2>/dev/null && pwd -P); then
+    wt_real=
+  fi
+  proj_real=
+  if ! proj_real=$(cd "$PROJ_ABS" 2>/dev/null && pwd -P); then
+    proj_real=
+  fi
   wt_top=$(git -C "$WT" rev-parse --show-toplevel 2>/dev/null || true)
-  wt_top_real=$(cd "$wt_top" 2>/dev/null && pwd -P || true)
+  wt_top_real=
+  if ! wt_top_real=$(cd "$wt_top" 2>/dev/null && pwd -P); then
+    wt_top_real=
+  fi
   if [ -z "$wt_real" ] || [ -z "$wt_top_real" ] || [ "$wt_real" != "$wt_top_real" ] || [ "$wt_real" = "$proj_real" ]; then
     echo "error: treehouse get did not yield an isolated worktree (resolved '$WT'; worktree root '${wt_top:-none}'; primary '$PROJ_ABS'); refusing to launch to avoid tangling the primary checkout. Inspect window $T" >&2
     exit 1

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -10,6 +10,8 @@
 #   --scout records kind=scout in the task's meta (report deliverable, scratch worktree;
 #   see AGENTS.md task lifecycle); --secondmate records kind=secondmate and launches in a
 #   provisioned firstmate home; the default is kind=ship.
+#   Ship/scout spawns refuse to launch after treehouse get unless the resolved pane
+#   path is a real git worktree root distinct from the primary project checkout.
 # Batch dispatch: pass one or more `id=repo` pairs instead of a single <id> <project>, e.g.
 #     fm-spawn.sh fix-a-k3=projects/foo add-b-q7=projects/bar [--scout]
 #   Each pair re-execs this script in single-task mode, so the single path stays the only

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -344,6 +344,22 @@ if [ "$KIND" != secondmate ]; then
     echo "error: treehouse get did not enter a worktree within 60s; inspect window $T" >&2
     exit 1
   fi
+
+  # Isolation guard: refuse to launch unless WT is a genuine, ISOLATED worktree -
+  # a real git worktree root, distinct from the project's primary checkout
+  # (PROJ_ABS). Firstmate is a treehouse-pooled repo of itself, so a treehouse-get
+  # misfire can leave the pane in (or in a subdir of, or a symlink to) the primary
+  # checkout; branching/committing there would tangle the primary onto a feature
+  # branch (see fm-tangle-lib.sh). The wait loop above only proves the pane left
+  # PROJ_ABS's exact path; this proves it landed in a true, separate worktree.
+  wt_real=$(cd "$WT" 2>/dev/null && pwd -P || true)
+  proj_real=$(cd "$PROJ_ABS" 2>/dev/null && pwd -P || true)
+  wt_top=$(git -C "$WT" rev-parse --show-toplevel 2>/dev/null || true)
+  wt_top_real=$(cd "$wt_top" 2>/dev/null && pwd -P || true)
+  if [ -z "$wt_real" ] || [ -z "$wt_top_real" ] || [ "$wt_real" != "$wt_top_real" ] || [ "$wt_real" = "$proj_real" ]; then
+    echo "error: treehouse get did not yield an isolated worktree (resolved '$WT'; worktree root '${wt_top:-none}'; primary '$PROJ_ABS'); refusing to launch to avoid tangling the primary checkout. Inspect window $T" >&2
+    exit 1
+  fi
 fi
 
 # Per-harness turn-end hook: a file that touches state/<id>.turn-ended when the

--- a/bin/fm-tangle-lib.sh
+++ b/bin/fm-tangle-lib.sh
@@ -1,0 +1,53 @@
+# shellcheck shell=bash
+# Shared worktree-tangle guard for the firstmate-on-itself case.
+# Usage: . bin/fm-tangle-lib.sh
+#
+# Firstmate is a treehouse-pooled git repo of itself: crewmate worktrees and
+# secondmate homes are all linked `git worktree`s of the same repo, while the
+# PRIMARY checkout (the repo root firstmate operates from) is a normal checkout
+# on a real branch - normally the default branch, main. The "worktree tangle"
+# failure mode is a crewmate spawned to work on firstmate ITSELF branching and
+# committing in the primary checkout instead of its own disposable worktree,
+# stranding the primary on a feature branch (e.g. fm/readme-restructure-d3).
+#
+# fm_primary_tangle_branch detects exactly that and nothing else: a NAMED,
+# non-default branch checked out in the given root. It is deliberately silent for
+# every legitimate state - the primary on its default branch, and detached HEAD,
+# which is how every linked worktree and secondmate home legitimately sits on the
+# default branch. Detached HEAD on the default is fine; a feature branch in a
+# primary checkout is the alarm.
+
+# Resolve the default branch name of the git repo at <dir>: prefer origin/HEAD,
+# then fall back to a local main/master. Echoes the name, or returns 1.
+fm_default_branch() {
+  local dir=$1 ref branch
+  ref=$(git -C "$dir" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)
+  if [ -n "$ref" ]; then
+    printf '%s\n' "${ref#origin/}"
+    return 0
+  fi
+  for branch in main master; do
+    if git -C "$dir" show-ref --verify --quiet "refs/heads/$branch"; then
+      printf '%s\n' "$branch"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# If the git checkout at <root> is tangled - on a NAMED branch that is not its
+# default branch - echo the offending branch name and return 0. For every healthy
+# state (not a git work tree, detached HEAD, or already on the default branch)
+# echo nothing and return 1. Detached HEAD is how linked worktrees and secondmate
+# homes legitimately sit, so they never trip this; only a feature branch checked
+# out in a primary checkout does.
+fm_primary_tangle_branch() {
+  local root=$1 cur default
+  git -C "$root" rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 1
+  cur=$(git -C "$root" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
+  [ -n "$cur" ] || return 1
+  default=$(fm_default_branch "$root") || return 1
+  [ "$cur" = "$default" ] && return 1
+  printf '%s\n' "$cur"
+  return 0
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,14 +14,25 @@ Routine watcher polling, re-arm no-ops, elapsed waiting time, and unchanged hear
 
 Routine re-arms go through `bin/fm-watch-arm.sh`, which forks the watcher as a tracked child, verifies it is genuinely alive with a fresh liveness beacon, and prints exactly one honest status line (`started` / `healthy` / `FAILED`, the last exiting non-zero) - never a false `already running` off a dying process.
 Its `--restart` mode signals only the watcher recorded in the current home's `state/.watch.lock`, so restarting one home cannot kill sibling secondmate watchers.
-A pull-based guard (`bin/fm-guard.sh`) warns through supervision tool output if tasks are in flight and that watcher stops running or queued wakes are waiting to be drained, leading with a prominent bordered banner for the no-watcher case so it cannot be skimmed past.
+A pull-based guard (`bin/fm-guard.sh`) warns through supervision tool output if the primary checkout is tangled, or if tasks are in flight and that watcher stops running or queued wakes are waiting to be drained.
+It leads with prominent bordered banners for the tangle and no-watcher cases so they cannot be skimmed past.
 
 A presence-gated sub-supervisor (`bin/fm-supervise-daemon.sh`) extends this for walk-away supervision: the `/afk` skill activates it, after which it self-handles routine wakes in bash and escalates only captain-relevant events as one batched, single-line digest (prefixed with an in-band sentinel marker so firstmate can tell daemon injections apart from real messages).
 Its injection path shares `bin/fm-tmux-lib.sh` with `fm-send.sh`, so dim-ghost-aware and border-aware composer detection plus verified submit retry stay consistent; stalled escalation delivery raises `state/.subsuper-inject-wedged` after `FM_MAX_DEFER_SECS` instead of silently deferring forever.
 
 ## Worktrees, not branches in your checkout
 
-Crewmates never touch your clone; [treehouse](https://github.com/kunchenguid/treehouse) pools clean worktrees so parallel tasks on one repo cannot collide.
+Crewmates never intentionally touch your project clone; [treehouse](https://github.com/kunchenguid/treehouse) pools clean worktrees so parallel tasks on one repo cannot collide.
+For ship and scout work, `fm-spawn.sh` waits for `treehouse get` and then refuses to launch unless the pane resolves to a real git worktree root that is distinct from the project primary checkout.
+
+The firstmate repo has one extra exposure because it can dispatch crewmates to work on itself.
+Its operating checkout (`FM_ROOT`) and the disposable crewmate worktrees are all linked git worktrees of the same repository, so the valid discriminator is branch state, not whether the checkout is linked.
+The primary checkout is healthy on its default branch, and linked worktrees or secondmate homes are healthy at detached HEAD.
+Only a named non-default branch checked out in `FM_ROOT` is a worktree tangle.
+
+`fm-tangle-lib.sh` resolves the default branch from `origin/HEAD`, then local `main` or `master`, and classifies that named non-default primary branch as the tangle.
+`fm-guard.sh` prints the repair command on the next fleet action, while `fm-bootstrap.sh` reports the same condition as a `TANGLE:` line at session start.
+Ship briefs also tell the crewmate to verify `pwd -P` and `git rev-parse --show-toplevel` before creating `fm/<id>`, then stop with a blocked status if it landed in the primary checkout.
 
 ## Two task shapes
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,7 +33,8 @@ Set `FM_SECONDMATE_CHARTER` to seed from inline charter text when no filled char
 
 `FM_HOME` selects the operational home for one firstmate instance.
 When it is unset, the repo root is the home; when it is set, scripts still run from this repo's `bin/`, but `state/`, `data/`, `config/`, and `projects/` come from `$FM_HOME`.
-`FM_ROOT_OVERRIDE` remains supported as the old whole-root override when `FM_HOME` is unset.
+`FM_ROOT_OVERRIDE` overrides the firstmate repo root used by scripts, including the primary checkout watched by the worktree-tangle guard.
+When `FM_HOME` is unset, it also behaves as the old whole-root override.
 `FM_STATE_OVERRIDE`, `FM_DATA_OVERRIDE`, `FM_PROJECTS_OVERRIDE`, and `FM_CONFIG_OVERRIDE` override individual operational directories for tests and specialized harness setup.
 
 ## Harness support
@@ -46,6 +47,7 @@ Launch mechanics, including the verified command templates, live in [`bin/fm-spa
 
 On first launch the first mate detects what its required toolchain is missing or too old (tmux, node, gh, treehouse with durable lease support, no-mistakes, gh-axi, chrome-devtools-axi, lavish-axi), lists it with the exact install commands, and installs only after you say go.
 If compatible `tasks-axi` is already on `PATH`, bootstrap records it as an optional capability fact and firstmate uses its verbs for routine backlog mutations; when it is absent or incompatible, firstmate keeps hand-editing `data/backlog.md` exactly as before.
+Bootstrap also reports a `TANGLE:` line when `FM_ROOT` is on a named non-default branch; follow the printed checkout remediation rather than treating it as an installable tool problem.
 
 ## Environment variables
 
@@ -53,7 +55,7 @@ Runtime tuning via environment variables (defaults shown):
 
 ```sh
 FM_HOME=                 # optional operational home; unset means this repo root
-FM_ROOT_OVERRIDE=        # legacy whole-root override when FM_HOME is unset
+FM_ROOT_OVERRIDE=        # override firstmate repo root and tangle-guard target; also legacy whole-root override when FM_HOME is unset
 FM_STATE_OVERRIDE=       # alternate state dir, mainly for tests
 FM_DATA_OVERRIDE=        # alternate data dir, mainly for tests
 FM_PROJECTS_OVERRIDE=    # alternate projects dir, mainly for tests

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -5,22 +5,23 @@ Each file also starts with a short header comment.
 
 | Script                   | Description                                                                                                         |
 | ------------------------ | ------------------------------------------------------------------------------------------------------------------- |
-| `fm-bootstrap.sh`        | Detect required toolchain problems and optional capability facts; refresh clones best-effort; install tools only after consent |
+| `fm-bootstrap.sh`        | Detect required toolchain problems, optional capability facts, and primary-checkout `TANGLE:` problems; refresh clones best-effort; install tools only after consent |
 | `fm-fleet-sync.sh`       | Fetch clones, clean-fast-forward their checked-out default branches, and safely prune branches whose remote is gone |
 | `fm-update.sh`           | Self-update the running firstmate repo and registered secondmate homes with fast-forward-only pulls from origin     |
 | `fm-backlog-handoff.sh`  | Move already-judged in-scope queued backlog items from the main home into a seeded secondmate home                 |
-| `fm-brief.sh`            | Scaffold a ship brief, a report-only scout brief with `--scout`, or a secondmate charter with `--secondmate`      |
+| `fm-brief.sh`            | Scaffold a ship brief with a worktree-isolation assertion, a report-only scout brief with `--scout`, or a secondmate charter with `--secondmate` |
 | `fm-ensure-agents-md.sh` | Ensure project `AGENTS.md` is the real memory file and `CLAUDE.md` symlinks to it                                   |
-| `fm-guard.sh`            | Warn when tasks are in flight but queued wakes are pending; lead stale or missing watcher cases with a prominent banner |
+| `fm-guard.sh`            | Warn when the primary checkout is tangled, when queued wakes are pending, or when a stale or missing watcher needs a prominent banner |
 | `fm-home-seed.sh`        | Lease/provision a secondmate home transactionally, clone projects, initialize gates, and maintain `data/secondmates.md` |
-| `fm-spawn.sh`            | Spawn one task, several `id=repo` pairs, or a persistent secondmate with `--secondmate`                            |
+| `fm-spawn.sh`            | Spawn one task, several `id=repo` pairs, or a persistent secondmate with `--secondmate`; ship/scout spawns require an isolated treehouse worktree |
 | `fm-project-mode.sh`     | Resolve a project's delivery mode and `+yolo` flag from `data/projects.md`                                          |
 | `fm-merge-local.sh`      | Fast-forward a `local-only` project's local default branch after approval                                           |
 | `fm-review-diff.sh`      | Review a crewmate branch against the authoritative base, with optional `--stat` output                              |
 | `fm-watch-arm.sh`        | Verified per-home watcher re-arm; reports `started`, `healthy`, or `FAILED`; `--restart` relaunches only this home's watcher |
 | `fm-watch.sh`            | Singleton-safe one-shot watcher; blocks until supervision work is due, queues it durably, then exits with one reason line |
 | `fm-supervise-daemon.sh` | Presence-gated sub-supervisor for walk-away (`/afk`) supervision: wraps `fm-watch.sh`, self-handles routine wakes in bash, and escalates only captain-relevant events as one verified, batched, single-line digest prefixed with a sentinel marker |
-| `fm-tasks-axi-lib.sh`  | Shared `tasks-axi` compatibility probe sourced by bootstrap and teardown                                            |
+| `fm-tangle-lib.sh`       | Shared default-branch resolution and primary-checkout tangle classification sourced by bootstrap and guard         |
+| `fm-tasks-axi-lib.sh`    | Shared `tasks-axi` compatibility probe sourced by bootstrap and teardown                                            |
 | `fm-wake-drain.sh`       | Atomically drain queued watcher wakes before handling supervision work                                              |
 | `fm-wake-lib.sh`         | Shared durable wake queue and portable lock helpers sourced by the watcher, drain, arm, guard, and daemon          |
 | `fm-send.sh`             | Send one verified literal line (or `--key Escape`) to a crewmate window; exits non-zero when Enter is positively swallowed |

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -71,7 +71,10 @@ test_bootstrap_reporting() {
     mkdir -p "$case_dir/home"
     fakebin=$(make_fake_toolchain "$case_dir")
     [ "$tasks" = "-" ] || add_tasks_axi "$fakebin" "$tasks"
-    out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" \
+    # FM_ROOT_OVERRIDE points the worktree-tangle check at the non-git home dir so
+    # it stays inert: this suite pins tool detection, not the tangle guard, and the
+    # ambient checkout (CI runs on a feature branch) must not leak a TANGLE line in.
+    out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
       FM_FAKE_TREEHOUSE_LEASE_HELP="$lease" "$ROOT/bin/fm-bootstrap.sh")
     case "$mode" in
       empty)

--- a/tests/fm-tangle-guard.test.sh
+++ b/tests/fm-tangle-guard.test.sh
@@ -22,7 +22,7 @@ set -u
 . "$ROOT/bin/fm-tangle-lib.sh"
 
 TMP_ROOT=$(fm_test_tmproot fm-tangle-guard)
-fm_git_identity
+fm_git_identity fmtest fmtest@example.invalid
 
 # A fresh git repo on `main` with one commit. Echoes its path.
 make_repo() {
@@ -132,7 +132,9 @@ test_brief_assertion_precedes_branch() {
     "brief must not claim the primary checkout has identical git dirs"
   iso=$(grep -n 'launched in primary checkout, not an isolated worktree' "$brief" | head -1 | cut -d: -f1)
   br=$(grep -n 'git checkout -b fm/' "$brief" | head -1 | cut -d: -f1)
-  [ -n "$iso" ] && [ -n "$br" ] || fail "brief missing assertion ($iso) or branch step ($br)"
+  if [ -z "$iso" ] || [ -z "$br" ]; then
+    fail "brief missing assertion ($iso) or branch step ($br)"
+  fi
   [ "$iso" -lt "$br" ] || fail "isolation assertion (line $iso) must precede the branch step (line $br)"
   pass "fm-brief: ship brief asserts worktree isolation before the branch step"
 }

--- a/tests/fm-tangle-guard.test.sh
+++ b/tests/fm-tangle-guard.test.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# Behavior tests for the worktree-tangle guards.
+#
+# Firstmate is a treehouse-pooled git repo of itself: linked worktrees and
+# secondmate homes all sit at a detached HEAD on the default branch, while the
+# PRIMARY checkout (FM_ROOT) is a normal checkout on a real branch. The "tangle"
+# is a crewmate branching/committing in the primary instead of its own worktree,
+# stranding the primary on a feature branch. Two guards cover it:
+#   GUARD 1 (prevention) - the brief asserts isolation before its branch step, and
+#            fm-spawn refuses to launch unless the resolved worktree is isolated.
+#   GUARD 2 (detection)  - fm-guard and fm-bootstrap alarm when the primary is on
+#            a feature branch, and stay silent on the default branch or detached.
+# These cases pin: the shared lib's branch classification, the fm-guard banner,
+# the fm-bootstrap problem line, the brief assertion ordering, and the fm-spawn
+# abort - all hermetic over temp git repos and fakebins.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+# shellcheck source=bin/fm-tangle-lib.sh
+. "$ROOT/bin/fm-tangle-lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-tangle-guard)
+fm_git_identity
+
+# A fresh git repo on `main` with one commit. Echoes its path.
+make_repo() {
+  local dir=$1
+  git init -q -b main "$dir"
+  git -C "$dir" commit -q --allow-empty -m init
+  printf '%s\n' "$dir"
+}
+
+# --- shared lib: branch classification --------------------------------------
+
+# fm_primary_tangle_branch is the whole scoping decision: a NAMED non-default
+# branch is the tangle; the default branch and detached HEAD are healthy.
+test_lib_classification() {
+  local repo n=0 label state branch expect out
+  repo=$(make_repo "$TMP_ROOT/lib-repo")
+  while IFS='|' read -r label state branch expect; do
+    [ -n "$label" ] || continue
+    n=$((n + 1))
+    case "$state" in
+      default)  git -C "$repo" checkout -q main ;;
+      feature)  git -C "$repo" checkout -q -B "$branch" ;;
+      detached) git -C "$repo" checkout -q main; git -C "$repo" checkout -q --detach ;;
+    esac
+    out=$(fm_primary_tangle_branch "$repo" || true)
+    [ "$out" = "$expect" ] || fail "$label: expected tangle='$expect', got '$out'"
+  done <<'ROWS'
+on the default branch is healthy|default||
+on a feature branch is the tangle|feature|fm/readme-restructure-d3|fm/readme-restructure-d3
+detached HEAD on default is healthy (worktrees, secondmate homes)|detached||
+ROWS
+  # A non-git directory is not a tangle and must not error.
+  out=$(fm_primary_tangle_branch "$TMP_ROOT" || true)
+  [ -z "$out" ] || fail "non-git dir wrongly reported a tangle: '$out'"
+  pass "fm_primary_tangle_branch: feature branch alarms; default/detached/non-git stay silent"
+}
+
+# --- GUARD 2a: fm-guard banner ----------------------------------------------
+
+run_guard() {
+  # Scope the guard to a temp repo as the primary checkout; state lives under it.
+  FM_ROOT_OVERRIDE="$1" FM_HOME="$1" "$ROOT/bin/fm-guard.sh" 2>&1
+}
+
+test_guard_banner() {
+  local repo out
+  repo=$(make_repo "$TMP_ROOT/guard-repo")
+
+  out=$(run_guard "$repo")
+  assert_not_contains "$out" "WORKTREE TANGLE" "guard alarmed while primary was on main"
+
+  git -C "$repo" checkout -q --detach
+  out=$(run_guard "$repo")
+  assert_not_contains "$out" "WORKTREE TANGLE" "guard alarmed on a detached HEAD (legitimate worktree state)"
+
+  git -C "$repo" checkout -q -B fm/tangle-aa1
+  out=$(run_guard "$repo")
+  assert_contains "$out" "WORKTREE TANGLE" "guard did not alarm on a feature branch in the primary"
+  assert_contains "$out" "fm/tangle-aa1" "guard banner did not name the offending branch"
+  assert_contains "$out" "checkout main" "guard banner did not print the restore remediation"
+  pass "fm-guard: bordered tangle banner fires only for a feature branch in the primary"
+}
+
+# --- GUARD 2b: fm-bootstrap problem line ------------------------------------
+
+run_bootstrap() {
+  # No projects/ under the home keeps fleet sync inert; grep isolates the line.
+  FM_ROOT_OVERRIDE="$1" FM_HOME="$1" "$ROOT/bin/fm-bootstrap.sh" 2>/dev/null
+}
+
+test_bootstrap_line() {
+  local repo out
+  repo=$(make_repo "$TMP_ROOT/bootstrap-repo")
+
+  out=$(run_bootstrap "$repo" | grep '^TANGLE:' || true)
+  [ -z "$out" ] || fail "bootstrap emitted a TANGLE line while on main: $out"
+
+  git -C "$repo" checkout -q --detach
+  out=$(run_bootstrap "$repo" | grep '^TANGLE:' || true)
+  [ -z "$out" ] || fail "bootstrap emitted a TANGLE line on a detached HEAD: $out"
+
+  git -C "$repo" checkout -q -B fm/tangle-bb2
+  out=$(run_bootstrap "$repo" | grep '^TANGLE:' || true)
+  assert_contains "$out" "fm/tangle-bb2" "bootstrap did not report the tangled branch"
+  assert_contains "$out" "checkout main" "bootstrap TANGLE line lacked the restore remediation"
+  pass "fm-bootstrap: TANGLE problem line fires only for a feature branch in the primary"
+}
+
+# --- GUARD 1a: brief isolation assertion ------------------------------------
+
+# The generated ship brief must carry the isolation assertion AHEAD of the
+# `git checkout -b` step, so the crewmate verifies its worktree before branching.
+test_brief_assertion_precedes_branch() {
+  local home brief iso br
+  home="$TMP_ROOT/brief-home"
+  mkdir -p "$home/data"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" tangle-brief-cc3 alpha >/dev/null 2>&1
+  brief="$home/data/tangle-brief-cc3/brief.md"
+  assert_present "$brief" "brief was not scaffolded"
+  assert_grep "blocked: launched in primary checkout, not an isolated worktree" "$brief" \
+    "brief is missing the isolation blocked-status contract"
+  iso=$(grep -n 'launched in primary checkout, not an isolated worktree' "$brief" | head -1 | cut -d: -f1)
+  br=$(grep -n 'git checkout -b fm/' "$brief" | head -1 | cut -d: -f1)
+  [ -n "$iso" ] && [ -n "$br" ] || fail "brief missing assertion ($iso) or branch step ($br)"
+  [ "$iso" -lt "$br" ] || fail "isolation assertion (line $iso) must precede the branch step (line $br)"
+  pass "fm-brief: ship brief asserts worktree isolation before the branch step"
+}
+
+# --- GUARD 1b: fm-spawn isolation abort -------------------------------------
+
+# A fake tmux that reports FM_FAKE_PANE_PATH as the post-`treehouse get` pane cwd
+# (so the spawn's worktree-resolution loop resolves to a path we control), names
+# the session on '#S', and swallows window ops. Echoes the fakebin dir.
+make_spawn_fakebin() {
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+esac
+case "${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+  list-windows) exit 0 ;;
+  has-session|new-session|new-window|send-keys) exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" treehouse
+  printf '%s\n' "$fakebin"
+}
+
+run_spawn() {
+  local home=$1 id=$2 proj=$3 pane=$4 fakebin=$5
+  mkdir -p "$home/data/$id"
+  printf 'brief\n' > "$home/data/$id/brief.md"
+  FM_ROOT_OVERRIDE='' FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
+    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$pane" TMUX="fake,1,0" \
+    PATH="$fakebin:$PATH" \
+    "$ROOT/bin/fm-spawn.sh" "$id" "$proj" codex 2>&1
+}
+
+test_spawn_isolation_abort() {
+  local home proj fakebin out status
+  home="$TMP_ROOT/spawn-home"
+  mkdir -p "$home/data"
+  proj=$(make_repo "$TMP_ROOT/spawn-proj")
+  fakebin=$(make_spawn_fakebin "$TMP_ROOT/spawn-fake")
+  # A genuine isolated linked worktree of the project, detached on the default.
+  git -C "$proj" worktree add -q --detach "$TMP_ROOT/spawn-wt" >/dev/null 2>&1
+  mkdir -p "$TMP_ROOT/spawn-notgit" "$proj/sub"
+
+  # Abort: the pane resolves to a plain non-git directory (not a worktree at all).
+  out=$(run_spawn "$home" abort-notgit-dd4 "$proj" "$TMP_ROOT/spawn-notgit" "$fakebin"); status=$?
+  expect_code 1 "$status" "spawn into a non-worktree dir should abort"
+  assert_contains "$out" "did not yield an isolated worktree" "non-worktree spawn lacked the isolation error"
+  assert_absent "$home/state/abort-notgit-dd4.meta" "aborted spawn must not record meta"
+
+  # Abort: the pane resolves INTO the primary checkout (a subdir of PROJ_ABS).
+  out=$(run_spawn "$home" abort-primary-ee5 "$proj" "$proj/sub" "$fakebin"); status=$?
+  expect_code 1 "$status" "spawn landing inside the primary checkout should abort"
+  assert_contains "$out" "did not yield an isolated worktree" "primary-checkout spawn lacked the isolation error"
+
+  # Proceed: the pane resolves to a genuine, isolated worktree.
+  out=$(run_spawn "$home" ok-isolated-ff6 "$proj" "$TMP_ROOT/spawn-wt" "$fakebin"); status=$?
+  expect_code 0 "$status" "spawn into a genuine isolated worktree should succeed"
+  assert_contains "$out" "spawned ok-isolated-ff6" "isolated spawn did not report success"
+  assert_not_contains "$out" "did not yield an isolated worktree" "isolated spawn wrongly tripped the guard"
+  pass "fm-spawn: aborts unless the resolved worktree is a genuine, isolated worktree"
+}
+
+test_lib_classification
+test_guard_banner
+test_bootstrap_line
+test_brief_assertion_precedes_branch
+test_spawn_isolation_abort

--- a/tests/fm-tangle-guard.test.sh
+++ b/tests/fm-tangle-guard.test.sh
@@ -124,6 +124,12 @@ test_brief_assertion_precedes_branch() {
   assert_present "$brief" "brief was not scaffolded"
   assert_grep "blocked: launched in primary checkout, not an isolated worktree" "$brief" \
     "brief is missing the isolation blocked-status contract"
+  assert_grep "The path check is authoritative" "$brief" \
+    "brief must make the path check authoritative"
+  assert_no_grep "A reliable test that you are in a linked worktree" "$brief" \
+    "brief must not present git-dir/common-dir as decisive"
+  assert_no_grep "they are identical in the primary checkout" "$brief" \
+    "brief must not claim the primary checkout has identical git dirs"
   iso=$(grep -n 'launched in primary checkout, not an isolated worktree' "$brief" | head -1 | cut -d: -f1)
   br=$(grep -n 'git checkout -b fm/' "$brief" | head -1 | cut -d: -f1)
   [ -n "$iso" ] && [ -n "$br" ] || fail "brief missing assertion ($iso) or branch step ($br)"

--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -95,10 +95,12 @@ test_guard_warnings() {
   err="$dir/guard.err"
 
   # (1) watcher down (no beacon) + two in-flight tasks + a queued wake.
+  # FM_ROOT_OVERRIDE points the worktree-tangle check at a non-git dir so it stays
+  # inert here; this case is about the watcher-down banner, not the tangle guard.
   printf 'project=x\n' > "$state/task.meta"
   printf 'project=y\n' > "$state/task2.meta"
   append_wake "$state" heartbeat heartbeat heartbeat || fail "guard heartbeat append failed"
-  FM_STATE_OVERRIDE="$state" FM_GUARD_GRACE=1 "$ROOT/bin/fm-guard.sh" 2> "$err" >/dev/null || fail "guard failed"
+  FM_ROOT_OVERRIDE="$dir" FM_STATE_OVERRIDE="$state" FM_GUARD_GRACE=1 "$ROOT/bin/fm-guard.sh" 2> "$err" >/dev/null || fail "guard failed"
   first=$(grep -v '^[[:space:]]*$' "$err" | head -1)
   case "$first" in
     '●'*) ;;
@@ -121,7 +123,9 @@ test_guard_warnings() {
   err="$dir/guard.err"
   printf 'project=x\n' > "$state/task.meta"
   touch "$state/.last-watcher-beat"
-  FM_STATE_OVERRIDE="$state" FM_GUARD_GRACE=300 "$ROOT/bin/fm-guard.sh" 2> "$err" >/dev/null || fail "guard failed"
+  # Non-git FM_ROOT keeps the worktree-tangle check inert so "fresh watcher ->
+  # total silence" stays a pure assertion about watcher state.
+  FM_ROOT_OVERRIDE="$dir" FM_STATE_OVERRIDE="$state" FM_GUARD_GRACE=300 "$ROOT/bin/fm-guard.sh" 2> "$err" >/dev/null || fail "guard failed"
   [ ! -s "$err" ] || fail "guard warned with a fresh watcher and no queued wakes: $(cat "$err")"
   pass "guard banner leads when down with pending wakes (re-arm-after-drain) and stays silent when fresh"
 }


### PR DESCRIPTION
## Intent

Add two guards to firstmate that prevent and immediately detect a 'worktree tangle': the failure mode where a crewmate spawned to work on the firstmate repo itself branches/commits in the PRIMARY firstmate checkout (the repo root firstmate operates from) instead of its assigned disposable treehouse worktree, stranding the primary on a feature branch. This targets only the firstmate-on-itself case (projects have no such exposure).

Architecture insight that shapes the design: firstmate is a treehouse-pooled git repo of itself - the primary checkout AND every crewmate worktree / secondmate home are all linked git worktrees of one repo, and the primary is itself a writable linked worktree normally on the default branch (main). Therefore BRANCH NAME is the only valid discriminator: a named non-default branch checked out in the primary is the tangle; the default branch and detached HEAD (the legitimate resting state of worktrees and secondmate homes) are healthy. A 'linked-worktree vs main-worktree' test would be WRONG here because it would exempt the primary itself, so it was deliberately not used. The default branch name is resolved (origin/HEAD then main/master), not hardcoded.

GUARD 1 (prevention, spawn-time): (a) bin/fm-brief.sh - the ship-brief Setup opens with a worktree-isolation assertion ahead of the 'git checkout -b' step; the crewmate confirms via git rev-parse --show-toplevel (and a git-dir != git-common-dir linked-worktree test) it is in its own treehouse worktree, and if it resolves to the primary it STOPS and reports 'blocked: launched in primary checkout, not an isolated worktree'. (b) bin/fm-spawn.sh - after treehouse get resolves the worktree (WT), it asserts WT is a genuine isolated worktree distinct from the primary checkout (PROJ_ABS) with git -C WT rev-parse --show-toplevel canonicalizing to WT; otherwise aborts the spawn.

GUARD 2 (detection, immediate): new shared bin/fm-tangle-lib.sh provides fm_default_branch and fm_primary_tangle_branch. bin/fm-guard.sh emits a bordered alarm (like the watcher-down banner) when the primary (FM_ROOT) is on a feature branch, placed before the in-flight early-exit so it fires on the next fleet action; bin/fm-bootstrap.sh prints the same as a 'TANGLE:' problem line at session start.

Tests: new tests/fm-tangle-guard.test.sh covers lib classification, the guard banner, the bootstrap line, brief assertion ordering, and the spawn abort, hermetic over temp git repos/fakebins. tests/fm-bootstrap.test.sh and tests/fm-watcher-lock.test.sh now pin FM_ROOT so the new alarm stays inert there (the ambient checkout runs on a feature branch in CI).

Docs: AGENTS.md sections 3, 7, 8, 11 document both guards. Deliberately did NOT touch README.md, docs/, or CONTRIBUTING.md (a separate restructure is in flight there; changes are disjoint). Scope is firstmate-repo tooling only.

Note: a prior run was aborted; the only delta is a shell-lint fix - relocating '|| true' outside the $(cd && pwd -P) substitutions in fm-spawn.sh and converting an 'A && B || fail' and a bare fm_git_identity call in the new test to SC2015/SC2119-clean forms - so the repo CI shellcheck (stricter than the pipeline lint) passes. No behavior change; full local suite (13/13) green.

## What Changed
- Added shared tangle detection helpers plus bootstrap and guard alarms when the firstmate primary checkout is stranded on a non-default branch.
- Hardened ship dispatch by asserting crewmates are launched in isolated treehouse worktrees, with brief instructions that stop before branching if the primary checkout is detected.
- Added hermetic tangle guard coverage and updated related bootstrap and watcher-lock tests and docs.

## Risk Assessment

✅ Low: Captain, the change is narrowly scoped to spawn/bootstrap/guard shell paths with focused coverage, and I found no material risks in the diff.

## Testing

Captain, I exercised the new tangle guard tests, the adjacent bootstrap and watcher-lock suites, and a manual E2E transcript showing silent healthy states, the guard banner, the bootstrap TANGLE line, brief ordering, spawn refusal in the primary checkout, and allowed spawn into an isolated worktree; the worktree was clean afterward.

<details>
<summary>Evidence: Tangle guard E2E CLI transcript</summary>

```text
Firstmate worktree-tangle guard E2E evidence
repo under test: /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KVZY23DPJ2R136369KQ4FQGH

== Setup: hermetic primary checkout on main ==
primary=/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVZY23DPJ2R136369KQ4FQGH/manual-e2e/primary
branch=main

== Detection stays silent on default branch ==
fm-guard output: <silent>

== Detection stays silent on detached HEAD ==
fm-guard output: <silent>

== Detection alarms when primary is stranded on a feature branch ==
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
●  WORKTREE TANGLE - PRIMARY CHECKOUT IS ON A FEATURE BRANCH
●  /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVZY23DPJ2R136369KQ4FQGH/manual-e2e/primary is on 'fm/tangle-evidence', not its default branch 'main'.
●  A crewmate likely branched/committed in the primary instead of its own worktree.
●  The work is SAFE on the 'fm/tangle-evidence' ref. Restore the primary to 'main':
●      git -C /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVZY23DPJ2R136369KQ4FQGH/manual-e2e/primary checkout main
●  then re-validate 'fm/tangle-evidence' in a proper isolated worktree.
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

== Bootstrap reports the same TANGLE remediation line ==
TANGLE: primary checkout on feature branch 'fm/tangle-evidence' (expected 'main'); the work is safe on that ref - restore the primary with: git -C /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVZY23DPJ2R136369KQ4FQGH/manual-e2e/primary checkout main, then re-validate the branch in a proper worktree

== Ship brief puts isolation assertion before branch creation ==
isolation_assertion_line=11
branch_creation_line=13
You are in a disposable git worktree of alpha, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable treehouse worktree you were launched in, typically a path under a `.treehouse/` pool, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/tangle-brief-e2e`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

== Spawn prevention refuses a pane that resolves inside the primary checkout ==
exit_code=1
error: treehouse get did not yield an isolated worktree (resolved '/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVZY23DPJ2R136369KQ4FQGH/manual-e2e/spawn-project/sub'; worktree root '/private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVZY23DPJ2R136369KQ4FQGH/manual-e2e/spawn-project'; primary '/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVZY23DPJ2R136369KQ4FQGH/manual-e2e/spawn-project'); refusing to launch to avoid tangling the primary checkout. Inspect window firstmate:fm-abort-primary-e2e
meta_file=absent

== Spawn prevention allows a genuine isolated linked worktree ==
warn: no registry at /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVZY23DPJ2R136369KQ4FQGH/manual-e2e/spawn-home/data/projects.md; defaulting spawn-project to no-mistakes off
spawned ok-isolated-e2e harness=codex kind=ship mode=no-mistakes yolo=off window=firstmate:fm-ok-isolated-e2e worktree=/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVZY23DPJ2R136369KQ4FQGH/manual-e2e/spawn-worktree
created_meta:
window=firstmate:fm-ok-isolated-e2e
worktree=/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVZY23DPJ2R136369KQ4FQGH/manual-e2e/spawn-worktree
project=/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVZY23DPJ2R136369KQ4FQGH/manual-e2e/spawn-project
harness=codex
kind=ship
mode=no-mistakes
yolo=off
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Rebase** - 3 issues found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-brief.sh` - merge conflict rebasing onto origin/fm/tangle-guard-g5
- ⚠️ `bin/fm-spawn.sh` - merge conflict rebasing onto origin/fm/tangle-guard-g5
- ⚠️ `tests/fm-tangle-guard.test.sh` - merge conflict rebasing onto origin/fm/tangle-guard-g5

🔧 Fix applied.
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `TMPDIR=/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVZY23DPJ2R136369KQ4FQGH/tmp bash tests/fm-tangle-guard.test.sh`
- `TMPDIR=/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVZY23DPJ2R136369KQ4FQGH/tmp bash tests/fm-bootstrap.test.sh`
- `TMPDIR=/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVZY23DPJ2R136369KQ4FQGH/tmp bash tests/fm-watcher-lock.test.sh`
- `/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVZY23DPJ2R136369KQ4FQGH/run-tangle-guard-e2e.sh /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KVZY23DPJ2R136369KQ4FQGH /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KVZY23DPJ2R136369KQ4FQGH`
- `git status --short`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
