### PR TITLE
fix: settle after fm-send text submits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,7 @@ for test_script in tests/*.test.sh; do "$test_script"; done   # behavior tests, 
 tests/fm-wake-queue.test.sh               # durable wake queue losslessness, catch-up, double-drain, and duplicate-collapse tests
 tests/fm-watcher-lock.test.sh             # watcher singleton, lock-race, watch-arm liveness, and guard-warning tests
 tests/fm-daemon.test.sh                   # sub-supervisor classifier, /afk presence-gating, max-defer, composer, and fm-send submit tests
+tests/fm-send-settle.test.sh              # fm-send post-submit settle pause, tuning, disable, and --key bypass tests
 tests/fm-wake-daemon-lifecycle-e2e.test.sh # watcher + daemon lifecycle e2e: restart catch-up, batching, dedupe, stale-pane routing, and digest injection
 tests/fm-composer-ghost.test.sh           # dim-ghost stripping, ghost-only composer detection, and escape-free peek tests
 tests/fm-afk-inject-e2e.test.sh           # private-socket end-to-end test of the afk injection path (partial-input deferral, swallowed-Enter retry)

--- a/bin/fm-send.sh
+++ b/bin/fm-send.sh
@@ -12,6 +12,12 @@
 # instead of silently leaving an unsubmitted instruction (incident afk-invx-i5).
 # The composer/submit logic is shared with the away-mode daemon via
 # bin/fm-tmux-lib.sh. Tune with FM_SEND_RETRIES (default 3) / FM_SEND_SLEEP (0.4).
+# After a successful text submit fm-send pauses FM_SEND_SETTLE seconds (default 1,
+# 0 disables) before returning: a cleared composer only proves the text was
+# submitted, but the harness needs a beat to spin up the turn before its busy
+# footer appears, so an immediate peek would otherwise see the stale idle pane.
+# The pause is fm-send-only; the shared submit core (used by the away-mode daemon,
+# which only needs "submitted") does not pay it, and the --key path is unaffected.
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -66,4 +72,10 @@ else
       exit 1
       ;;
   esac
+  # Submit landed (verdict was not pending/send-failed). The cleared composer only
+  # proves the text was submitted; the harness still needs a beat to spin up the
+  # turn before its busy footer shows. Pause so an immediate peek catches the
+  # crewmate actually working instead of the stale idle pane. FM_SEND_SETTLE=0
+  # disables it. Scoped to this path only, never the shared submit core.
+  [ "${FM_SEND_SETTLE:-1}" = 0 ] || sleep "${FM_SEND_SETTLE:-1}"
 fi

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,6 +19,7 @@ It leads with prominent bordered banners for the tangle and no-watcher cases so 
 
 A presence-gated sub-supervisor (`bin/fm-supervise-daemon.sh`) extends this for walk-away supervision: the `/afk` skill activates it, after which it self-handles routine wakes in bash and escalates only captain-relevant events as one batched, single-line digest (prefixed with an in-band sentinel marker so firstmate can tell daemon injections apart from real messages).
 Its injection path shares `bin/fm-tmux-lib.sh` with `fm-send.sh`, so dim-ghost-aware and border-aware composer detection plus verified submit retry stay consistent; stalled escalation delivery raises `state/.subsuper-inject-wedged` after `FM_MAX_DEFER_SECS` instead of silently deferring forever.
+`fm-send.sh` adds its own `FM_SEND_SETTLE` pause after successful text sends so immediate peeks catch the receiving turn starting; the sub-supervisor uses only the shared submit core and does not pay that pause.
 
 ## Worktrees, not branches in your checkout
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -76,6 +76,7 @@ FM_BUSY_REGEX='esc (to )?interrupt|Working\.\.\.'   # busy-pane signatures, shar
 FM_COMPOSER_IDLE_RE=    # optional empty-composer regex, applied after dim-ghost and border stripping
 FM_SEND_RETRIES=3       # fm-send Enter-retry attempts after typing the line once
 FM_SEND_SLEEP=0.4       # seconds between fm-send submit checks
+FM_SEND_SETTLE=1        # seconds fm-send waits after a successful text submit; 0 disables
 # sub-supervisor (bin/fm-supervise-daemon.sh); presence-gated via /afk
 FM_SUPERVISOR_TARGET=firstmate:0   # supervisor tmux target (override; auto-discovers from $TMUX_PANE)
 FM_INJECT_SKIP=heartbeat           # |-prefixes force-self-handled bypassing classification; empty disables

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -24,7 +24,7 @@ Each file also starts with a short header comment.
 | `fm-tasks-axi-lib.sh`    | Shared `tasks-axi` compatibility probe sourced by bootstrap and teardown                                            |
 | `fm-wake-drain.sh`       | Atomically drain queued watcher wakes before handling supervision work                                              |
 | `fm-wake-lib.sh`         | Shared durable wake queue and portable lock helpers sourced by the watcher, drain, arm, guard, and daemon          |
-| `fm-send.sh`             | Send one verified literal line (or `--key Escape`) to a crewmate window; exits non-zero when Enter is positively swallowed |
+| `fm-send.sh`             | Send one verified literal line (or `--key Escape`) to a crewmate window; exits non-zero when Enter is positively swallowed; text sends pause `FM_SEND_SETTLE` seconds after success |
 | `fm-tmux-lib.sh`         | Shared tmux pane primitives for busy detection, dim-ghost-aware and border-aware composer detection, and verified submit retry |
 | `fm-peek.sh`             | Print a bounded tail of a crewmate pane                                                                             |
 | `fm-pr-check.sh`         | Record a PR-ready task and arm the watcher's merge poll                                                             |

--- a/tests/fm-send-settle.test.sh
+++ b/tests/fm-send-settle.test.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# fm-send post-submit settle pause (FM_SEND_SETTLE).
+#
+# fm-send's success only proves the composer cleared - the Enter landed and the
+# text was submitted. The harness then takes a beat to spin up the turn before its
+# busy footer appears, so an immediate peek after fm-send returns would see the
+# stale idle pane. fm-send therefore pauses FM_SEND_SETTLE seconds (default 1, 0
+# disables) after a successful text submit, so the receiving turn has time to
+# visibly start. These tests pin that behavior hermetically (stubbed tmux + sleep,
+# no real agent):
+#   1. A successful text send pauses for the FM_SEND_SETTLE value (default 1).
+#   2. FM_SEND_SETTLE=0 produces no pause at all (sleep is never invoked for it).
+#   3. The pause is tunable (FM_SEND_SETTLE=7 pauses 7).
+#   4. The --key path never pauses (it bypasses the submit/settle path entirely).
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SEND="$ROOT/bin/fm-send.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-send-settle)
+
+# A fake tmux that lets fm-send's submit path reach a clean "empty" verdict, plus a
+# fake sleep that records every requested duration (one per line) instead of
+# sleeping. send-keys always succeeds; display-message yields a numeric cursor_y;
+# capture-pane returns an empty bordered composer so fm_tmux_composer_state reads
+# "empty" (submit landed) on the first Enter. The sleep log path comes from
+# FM_SLEEP_LOG.
+make_stubs() {  # <dir> -> echoes fakebin dir
+  local dir=$1 fb="$1/fakebin"
+  mkdir -p "$fb"
+  cat > "$fb/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "${1:-}" in
+  send-keys) exit 0 ;;
+  display-message)
+    for a in "$@"; do case "$a" in *cursor_y*) printf '0\n'; exit 0 ;; esac; done
+    printf 'fakepane\n'; exit 0 ;;
+  capture-pane) printf '\xe2\x94\x82 \xe2\x94\x82\n'; exit 0 ;;
+  list-windows) exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fb/tmux"
+  cat > "$fb/sleep" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "${1:-}" >> "$FM_SLEEP_LOG"
+exit 0
+SH
+  chmod +x "$fb/sleep"
+  printf '%s\n' "$fb"
+}
+
+# run_send <fakebin> <sleep-log> [env-assignments...] -- <fm-send args...>
+# Runs fm-send.sh with the stubs on PATH. FM_ROOT_OVERRIDE points at a non-repo
+# temp dir so fm-guard's tangle check stays silent, and FM_HOME at an empty home so
+# no in-flight task is seen; guard noise goes to stderr (discarded). Echoes nothing;
+# returns fm-send's exit code.
+run_send() {
+  local fb=$1 log=$2 home; shift 2
+  home="$TMP_ROOT/home-$RANDOM"; mkdir -p "$home/state"
+  : > "$log"
+  env "$@" PATH="$fb:$PATH" \
+    FM_ROOT_OVERRIDE="$home" FM_HOME="$home" FM_SLEEP_LOG="$log" \
+    "$SEND" "sess:win" "hello captain" 2>/dev/null
+}
+
+test_default_send_pauses_one_second() {
+  local dir fb log rc last
+  dir="$TMP_ROOT/default"; mkdir -p "$dir"
+  fb=$(make_stubs "$dir"); log="$dir/sleep.log"
+  run_send "$fb" "$log"; rc=$?
+  expect_code 0 "$rc" "default send should succeed"
+  last=$(tail -1 "$log")
+  [ "$last" = 1 ] || fail "default send: expected a trailing 1s settle pause, got '$last'"$'\n'"--- sleeps ---"$'\n'"$(cat "$log")"
+  pass "fm-send: a successful text send pauses the default 1s after submit"
+}
+
+test_zero_disables_pause() {
+  local dir fb log rc
+  dir="$TMP_ROOT/zero"; mkdir -p "$dir"
+  fb=$(make_stubs "$dir"); log="$dir/sleep.log"
+  run_send "$fb" "$log" FM_SEND_SETTLE=0; rc=$?
+  expect_code 0 "$rc" "FM_SEND_SETTLE=0 send should succeed"
+  # The disable path must not invoke sleep with 0 at all - the only sleeps left are
+  # the submit core's own settle/enter waits, none of which is "0".
+  if grep -qx '0' "$log"; then
+    fail "FM_SEND_SETTLE=0 still paused (a sleep 0 was recorded)"$'\n'"--- sleeps ---"$'\n'"$(cat "$log")"
+  fi
+  pass "fm-send: FM_SEND_SETTLE=0 produces no settle pause"
+}
+
+test_pause_is_tunable() {
+  local dir fb log rc last
+  dir="$TMP_ROOT/tunable"; mkdir -p "$dir"
+  fb=$(make_stubs "$dir"); log="$dir/sleep.log"
+  run_send "$fb" "$log" FM_SEND_SETTLE=7; rc=$?
+  expect_code 0 "$rc" "FM_SEND_SETTLE=7 send should succeed"
+  last=$(tail -1 "$log")
+  [ "$last" = 7 ] || fail "FM_SEND_SETTLE=7: expected a trailing 7s settle pause, got '$last'"$'\n'"--- sleeps ---"$'\n'"$(cat "$log")"
+  pass "fm-send: the settle pause is tunable via FM_SEND_SETTLE"
+}
+
+test_key_path_never_pauses() {
+  local dir fb log rc home
+  dir="$TMP_ROOT/key"; mkdir -p "$dir"
+  fb=$(make_stubs "$dir"); log="$dir/sleep.log"
+  home="$dir/home"; mkdir -p "$home/state"
+  : > "$log"
+  env PATH="$fb:$PATH" FM_ROOT_OVERRIDE="$home" FM_HOME="$home" FM_SLEEP_LOG="$log" \
+    "$SEND" "sess:win" --key Escape 2>/dev/null; rc=$?
+  expect_code 0 "$rc" "--key send should succeed"
+  [ ! -s "$log" ] || fail "--key path paused but must not"$'\n'"--- sleeps ---"$'\n'"$(cat "$log")"
+  pass "fm-send: the --key path never pauses (settle scoped to text submit)"
+}
+
+test_default_send_pauses_one_second
+test_zero_disables_pause
+test_pause_is_tunable
+test_key_path_never_pauses


### PR DESCRIPTION
## Intent

Add a tunable fixed pause to bin/fm-send.sh after a text message is successfully submitted, so the receiving crewmate's turn has time to visibly start before fm-send returns.

The bug: fm-send's success only proves the composer cleared - the Enter landed and the text was submitted - but the harness then takes a beat to spin up the turn before its busy footer appears. So an immediate peek after fm-send returns sees the stale 'before' (idle) pane, and firstmate has to peek a second time to catch the crewmate actually working. A small fixed pause after submit covers this in the common case.

The fix is deliberately a fixed pause, NOT a busy-poll. On the successful text-submit path only (after fm_tmux_submit_core returns and the verdict is NOT pending/send-failed), it runs: [ "${FM_SEND_SETTLE:-1}" = 0 ] || sleep "${FM_SEND_SETTLE:-1}". Default is 1 second; FM_SEND_SETTLE=0 disables the pause entirely (sleep is never invoked, so the disable is exact).

Deliberate scoping decisions (intentional, not oversights): the pause is confined to fm-send.sh's text-message submit path only. It is intentionally NOT added to the --key path, and intentionally NOT added to the shared fm_tmux_submit_core / bin/fm-tmux-lib.sh, because the away-mode daemon (fm-supervise-daemon.sh) sources that lib and only needs 'submitted' - it must not pay the pause. The change is purely additive: existing submit/verify logic and exit codes are unchanged.

FM_SEND_SETTLE is documented in the fm-send.sh header comment alongside FM_SEND_RETRIES/FM_SEND_SLEEP, with a one-line note on why it exists. A new hermetic test, tests/fm-send-settle.test.sh, stubs tmux and sleep (no real agent) to verify: a successful send pauses for the FM_SEND_SETTLE value (default 1), FM_SEND_SETTLE=0 produces no pause, the pause is tunable, and the --key path never pauses.

Hard constraint: the hardened supervision backbone (bin/fm-watch.sh, bin/fm-watch-arm.sh, bin/fm-wake-lib.sh, bin/fm-supervise-daemon.sh, bin/fm-tmux-lib.sh, and the afk skill) must remain untouched by this change.

## What Changed

- Captain, adds a configurable `FM_SEND_SETTLE` pause after successful `fm-send` text-message submits so immediate follow-up peeks can observe the receiving turn starting.
- Keeps the pause out of `--key` sends and shared tmux submit helpers, preserving existing submit verdicts and exit behavior.
- Documents the new setting and adds hermetic coverage for the default, disabled, tuned, and key-send paths.

## Risk Assessment

✅ Low: Captain, the change is narrow, scoped to fm-send's successful text-submit path, leaves the shared tmux submit core untouched, and the added test coverage matches the intended behavior well enough for a low-risk merge.

## Testing

No prior baseline command was provided; I inspected the two-file diff, ran the targeted settle test and the existing daemon/shared-submit regression test, generated a CLI transcript showing recorded sleep calls, and confirmed the worktree stayed clean. All exercised behavior passed; no UI screenshot was applicable because this is a shell CLI change.

<details>
<summary>Evidence: fm-send settle behavior transcript</summary>

```text
fm-send settle behavior transcript
worktree: /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KW1003XGF0HPZWQS331XEGYD
changed files under test:
  bin/fm-send.sh
  tests/fm-send-settle.test.sh

case: default-text
command: /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KW1003XGF0HPZWQS331XEGYD/bin/fm-send.sh sess:win hello captain
exit: 0
recorded sleep calls:
  0.3
  0.4
  1

case: disabled-zero
command: env FM_SEND_SETTLE=0 /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KW1003XGF0HPZWQS331XEGYD/bin/fm-send.sh sess:win hello captain
exit: 0
recorded sleep calls:
  0.3
  0.4

case: tunable-two
command: env FM_SEND_SETTLE=2 /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KW1003XGF0HPZWQS331XEGYD/bin/fm-send.sh sess:win hello captain
exit: 0
recorded sleep calls:
  0.3
  0.4
  2

case: key-path
command: /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KW1003XGF0HPZWQS331XEGYD/bin/fm-send.sh sess:win --key Escape
exit: 0
recorded sleep calls:
  <none>

interpretation:
  default-text ends with sleep 1 after submit.
  disabled-zero records no sleep 0, so the disable path is exact.
  tunable-two ends with sleep 2 after submit.
  key-path records no sleep calls, so --key does not pay the settle pause.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --name-only 10850ad9430ecf12d7b6b556867beda7007985e8..a7fcb1dfebc45538c148d9c73e9892f4016f16f3`
- `bash tests/fm-send-settle.test.sh`
- `bash tests/fm-daemon.test.sh`
- <code>Manual hermetic CLI check with fake `tmux` and fake `sleep`: `bin/fm-send.sh sess:win &#39;hello captain&#39;`, `FM_SEND_SETTLE=0 bin/fm-send.sh sess:win &#39;hello captain&#39;`, `FM_SEND_SETTLE=2 bin/fm-send.sh sess:win &#39;hello captain&#39;`, and `bin/fm-send.sh sess:win --key Escape`, recorded in the evidence transcript.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
