### PR TITLE
feat(bin): add BDD acceptance-scenarios block to ship brief scaffold

### DIFF
--- a/.agents/skills/bdd-scenarios/SKILL.md
+++ b/.agents/skills/bdd-scenarios/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: bdd-scenarios
+description: Agent-only reference for defining Behavior-Driven Development acceptance scenarios when delegating work. Use before running a design phase for a behavior-shaped ship task, before filling the acceptance-scenarios block in a brief, or when judging whether a task warrants scenarios at all. Covers the discovery/formulation/automation flow, Given/When/Then semantics, scenario best practices and anti-patterns, proportionality, and the executable-vs-prose decision.
+user-invocable: false
+---
+
+# bdd-scenarios
+
+Use this reference when a behavior-shaped ship task needs its intent pinned down before a crewmate builds it: to run the design phase with the captain, to author the Given/When/Then scenarios that go into the brief's acceptance-scenarios block, and to decide whether a task warrants scenarios at all.
+
+Keep the always-inline rules in `AGENTS.md` authoritative: behavior-shaped ship tasks get captain-approved acceptance scenarios in the brief; trivial mechanical and non-behavioral changes do not; scout tasks never do.
+
+## 1. What BDD is — and the trap
+
+BDD (Dan North, 2006) is a reframing of TDD around *behaviour* instead of *tests*. The load-bearing fact, which every authoritative source insists on, is:
+
+> **BDD is a collaboration and specification practice, not a testing tool.** The tests are a byproduct; the value is the shared understanding that stops you building the wrong thing.
+
+Cucumber's three practices, applied in order:
+
+1. **Discovery** — a conversation about a concrete upcoming change, surfacing real examples from the user's perspective ("what it *could* do"). This is where the value is: the examples nobody thought of.
+2. **Formulation** — writing the agreed examples in language both humans and machines can read ("what it *should* do").
+3. **Automation** — turning each example into a test that drives the code, exactly like TDD ("what it *actually does*").
+
+The trap is adopting only Automation. Scenarios written by one person *after* the design is settled are "just test automation" — you pay the ceremony cost without the shared-understanding benefit. Discovery and Formulation are where the payoff lives.
+
+## 2. Firstmate's adaptation
+
+Firstmate has no literal "Three Amigos" room, but the three perspectives map cleanly:
+
+- **Captain = the business voice.** What is valuable, what "correct" means.
+- **Firstmate = the analyst / facilitator.** Runs the design phase, asks the skeptical and edge-case questions, formulates the scenarios.
+- **Crewmate = the implementer.** Turns the agreed scenarios into code and tests.
+
+This preserves BDD's core: the scenarios are shaped in a conversation between the captain and firstmate, **not** authored by firstmate alone and dispatched. The flow:
+
+1. **Discovery + Formulation (design phase).** For a behavior-shaped ship task, draft Given/When/Then scenarios and review them with the captain in Lavish *before any code exists* — when changing direction is free. Use the `plan` / `input` Lavish playbooks; the captain annotates, corrects, and approves. Their approval is the green light to dispatch.
+2. **Into the brief.** The approved scenarios fill the `{SCENARIOS}` placeholder in the ship brief's `# Acceptance scenarios` section. They are now the crewmate's definition of "correct."
+3. **Automation (crewmate).** The crewmate implements the change so every scenario holds and covers each with a passing test (see §7 for how). A scenario with no passing test is not done. This generalizes the existing rule that a reproduced bug's repro becomes its regression test.
+
+A lightweight design phase (one or two scenarios, an obvious feature) can happen in a couple of chat exchanges rather than a full Lavish surface — match the ceremony to the stakes.
+
+## 3. When to use scenarios — proportionality and fit
+
+BDD scenarios are **required for behavior-shaped ship tasks** and **omitted elsewhere**. Judge by whether the change has observable behaviour a stakeholder could have an opinion about.
+
+**Use scenarios** — features, bug fixes with observable symptoms, changed business rules, anything user-facing or with an observable contract.
+
+**Skip scenarios** (write `N/A` in the brief block, with a one-line reason):
+- Trivial mechanical changes: typo, dependency bump, rename, formatting.
+- Pure refactors and internal-only changes with no behaviour change.
+- Performance tuning and low-level algorithmic work where no stakeholder reads the spec — ordinary unit/benchmark tests fit better.
+- All scout tasks (their deliverable is a report, not a change).
+
+The authoritative proportionality test: scenarios pay off only when they capture behaviour someone other than the implementer cares to validate. If the captain would have no opinion about the scenario, it is ceremony — skip it and let the project's normal tests carry the change.
+
+## 4. How to define a scenario — Given/When/Then semantics
+
+The semantics are strict; getting them right is most of the skill.
+
+- **Given** = context / preconditions. Puts the system into a known state. Describes *state*, not actions. **No actions, no assertions in a Given.**
+- **When** = the single action or event under test. **Exactly one `When` per scenario** — this is the cardinal rule. More than one `When`/`Then` pair means more than one behaviour; split it.
+- **Then** = the observable, verifiable outcome. **Assertions only** — never an action or a state change.
+
+Mnemonic: Given = past context, When = present action, Then = future outcome.
+
+Shape: `As a <role>, I want <capability>, so that <value>` frames the feature; each scenario is one concrete example under it.
+
+## 5. Best practices
+
+1. **Declarative, not imperative — the central rule.** Describe the behaviour, not the UI mechanics. The litmus test: *"Will this wording need to change if the implementation changes?"* If yes, it is too low-level.
+2. **One behaviour per scenario.** One `When`/`Then` pair.
+3. **Business / domain language.** No CSS selectors, endpoints, table names, or "click the button." Use the ubiquitous language the captain and the domain use.
+4. **Concrete but not incidental.** Use real, specific values, but include only what matters to the behaviour. Avoid both vagueness ("some money") and noise (irrelevant fields).
+5. **Independent and order-independent.** Each scenario provisions its own state and passes regardless of run order.
+6. **Named actor, consistent voice.** Pick an actor and a tense and keep them; do not mix first and third person.
+7. **No conjunctions inside a step.** Split "and" into separate steps.
+8. **Group by rule.** When several scenarios illustrate one business rule, say so; one rule with too many examples is a sign the rule is too complex.
+
+Example — the same behaviour, badly and well:
+
+```
+# BAD (imperative; breaks on any UI change; mixes setup mechanics into the behaviour)
+Given I visit "/login"
+When I enter "Bob" in the "username" field
+And I enter "tester" in the "password" field
+And I press the "login" button
+Then I should see the "welcome" page
+
+# GOOD (declarative; survives implementation change; states the behaviour)
+Given "Bob" is a registered user
+When "Bob" logs in with valid credentials
+Then he sees his dashboard
+```
+
+## 6. Anti-patterns (reject these in review)
+
+- **Imperative UI script** — step-by-step field entry and button presses. Collapse to the behaviour (`When "Bob" logs in`).
+- **DOM/implementation coupling** — selectors, URLs, DB tables in steps. Couples the spec to the implementation; breaks on refactor.
+- **Conjunction step** — `Given I have shades and a brand new Mustang`. Split into two steps.
+- **Multiple behaviours** — more than one `When`/`Then` pair. Split into separate scenarios.
+- **Wrong step type** — an assertion in a `Given`, or an action in a `Then`.
+- **Vague scenario** — "When I withdraw some money / Then the balance is reduced." Use concrete values.
+- **Scenario-outline bloat** — a row per near-duplicate case. Keep one row per genuine equivalence class.
+
+## 7. Automation: executable vs prose — match the repo
+
+**You do not need Gherkin or Cucumber to do BDD.** Given/When/Then works equally as plain-language acceptance criteria turned into ordinary tests (Fowler: GWT "is the same as Arrange-Act-Assert; you don't need Cucumber"). Decide per repo — never impose a new runner on a repo that has none:
+
+- **Repo already has a BDD/Gherkin runner** → add the scenarios as feature files in that runner's idiom and wire step definitions. Detect by looking for `*.feature` files, a `features/` dir, or the framework in the dependency manifest.
+- **Repo has no BDD runner (the common case)** → the scenarios become ordinary unit/integration tests, named to mirror each scenario's Given/When/Then. This is the default; it preserves behaviour-first specification with zero new tooling, regex glue, or step-definition maintenance.
+
+The brief instructs the crewmate to make this choice; the skill is here so firstmate can sanity-check it during review.
+
+Runner notes by ecosystem (current as of 2026), for when a repo does use one:
+- **Ruby / JS / JVM** — Cucumber / Cucumber-JS / Cucumber-JVM. Serenity BDD adds living-documentation reporting on top.
+- **Python** — `behave` (stakeholder-readable, no native parallelism) or `pytest-bdd` (rides the pytest ecosystem: xdist parallelism, reporting). Prefer `pytest-bdd` when the repo already uses pytest.
+- **.NET** — **Reqnroll**, not SpecFlow. SpecFlow reached end-of-life on 2024-12-31; Reqnroll is its maintained successor.
+- **Go** — Godog (official Cucumber for Go; runs alongside `go test`).
+- **JS/TS, browser** — `playwright-bdd` generates native Playwright tests from feature files; `jest-cucumber` runs Gherkin as ordinary Jest tests.
+
+Keep BDD/E2E at the thin top of the test pyramid — test at the appropriate level, as close to the code as possible. Browser-level scenarios are the icing, not the cake.
+
+## 8. Procedure (end to end)
+
+1. Classify the task. Behavior-shaped ship task → continue. Trivial/non-behavioral → write `N/A` with a reason in the brief block, skip the rest. Scout → no scenarios.
+2. Run the design phase with the captain: draft Given/When/Then scenarios, review in Lavish (or briefly in chat for small changes), iterate, get approval. Capture rules and the examples that illustrate them; record open questions rather than guessing.
+3. Apply §4–§6: declarative, one behaviour each, business language, concrete values, no anti-patterns.
+4. Fill the `{SCENARIOS}` block in the ship brief with the approved scenarios; spawn as normal.
+5. On `done`, sanity-check that each scenario is covered by a passing test and that the crewmate matched the repo's testing reality (§7) before relaying to the captain.
+
+## Sources
+
+- Dan North, "Introducing BDD" — https://dannorth.net/blog/introducing-bdd/
+- Cucumber, "BDD" (three practices) — https://cucumber.io/docs/bdd/
+- Cucumber, "BDD is not test automation" — https://cucumber.io/blog/bdd/bdd-is-not-test-automation/
+- Cucumber, "Where should you use BDD?" — https://cucumber.io/blog/bdd/where_should_you_use_bdd/
+- Cucumber, "Writing better Gherkin" — https://cucumber.io/docs/bdd/better-gherkin/
+- Cucumber, "Gherkin Reference" — https://cucumber.io/docs/gherkin/reference/
+- Matt Wynne, "Introducing Example Mapping" — https://cucumber.io/docs/bdd/example-mapping/
+- Martin Fowler, "GivenWhenThen" — https://martinfowler.com/bliki/GivenWhenThen.html
+- Gojko Adzic, "Specification by Example" — https://gojko.net/books/specification-by-example/
+- Liz Keogh, "What is BDD?" — https://lizkeogh.com/2015/03/27/what-is-bdd/
+- Reqnroll, "SpecFlow end-of-life" — https://reqnroll.net/news/2025/01/specflow-end-of-life-has-been-announced/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -300,6 +300,11 @@ Then classify readiness:
 Keep dependency judgment coarse: same repo plus overlapping area means serialize; everything else runs parallel.
 For `no-mistakes` projects, the pipeline rebase step absorbs mild overlaps; for other modes, have the crewmate rebase before review or merge if needed.
 
+For a behavior-shaped ship task, run a short BDD design phase before writing the brief: with the captain, agree the intended behaviour as Given/When/Then acceptance scenarios (review them in Lavish, or briefly in chat for a small change), and treat the captain's approval as the go-ahead to dispatch.
+Those approved scenarios become the brief's acceptance-scenarios block, and the crewmate covers each with a passing test.
+Trivial mechanical or non-behavioural changes (typo, dependency bump, rename, pure refactor, internal-only) skip this, and scout tasks never use it.
+Load `bdd-scenarios` for the proportionality call and for how to define good scenarios.
+
 Write the brief per section 11.
 
 ### Spawn
@@ -566,6 +571,9 @@ Scaffold with `bin/fm-brief.sh <id> <repo-name>` - it writes `data/<id>/brief.md
 The ship-brief Setup opens with a worktree-isolation assertion ahead of the branch step: the crewmate confirms it is in its own treehouse worktree, not the primary checkout, and stops with `blocked: launched in primary checkout, not an isolated worktree` if not - the upstream half of the worktree-tangle guard (section 8).
 For a ship task the definition of done is shaped by the project's delivery mode (section 6): `no-mistakes` ends in the harness-appropriate no-mistakes validation pipeline, `direct-PR` has the crewmate push and open the PR itself, `local-only` has it stop at "ready in branch" for firstmate to review and merge locally.
 The scaffold reads the mode via `fm-project-mode.sh`, so you do not pass it.
+Ship briefs also carry an acceptance-scenarios block: replace its `{SCENARIOS}` placeholder with the captain-approved Given/When/Then scenarios from the design phase (section 7), or with `N/A` plus a one-line reason for a non-behavioural change.
+The brief tells the crewmate to cover each scenario with a passing test - as feature files where the repo already has a BDD runner, otherwise as ordinary tests mirroring the scenarios.
+Load `bdd-scenarios` before authoring scenarios or making the proportionality call.
 Ship briefs also include the project-memory contract: run `bin/fm-ensure-agents-md.sh` when the project already has agent-memory files or when the task produced durable project-intrinsic knowledge, then record proportionate learnings in `AGENTS.md`.
 For scout tasks add `--scout`: the scaffold swaps the definition of done for the report contract (findings to `data/<id>/report.md`, no branch, no push, no PR) and declares the worktree scratch; scout is mode-agnostic.
 Scout briefs do not include the project-memory step, because their deliverable is a report rather than a committed project change.
@@ -592,3 +600,4 @@ These skills are not captain-invocable; they are conditional operating reference
 - `harness-adapters` - load before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter.
 - `stuck-crewmate-recovery` - load after a stale wake, looping pane, repeated confusion, an answered-by-brief question, an unresponsive crewmate, or a failed steer.
 - `secondmate-provisioning` - load before creating, seeding, validating, recovering, handing backlog to, or retiring a secondmate home, and before editing `data/secondmates.md`.
+- `bdd-scenarios` - load before running a design phase for a behavior-shaped ship task, before filling a brief's acceptance-scenarios block, or when deciding whether a task warrants scenarios at all.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -6,6 +6,10 @@
 # description, acceptance criteria, and context, and may adjust other sections
 # when the task genuinely deviates (e.g. working an existing external PR instead
 # of shipping a new one).
+# Ship briefs also carry an Acceptance scenarios section: firstmate replaces the
+# {SCENARIOS} placeholder with the captain-approved Given/When/Then scenarios for
+# a behavior-shaped task, or "N/A" with a reason for a non-behavioral one. See the
+# bdd-scenarios skill and AGENTS.md task lifecycle / crewmate briefs.
 # Usage: fm-brief.sh <task-id> <repo-name> [--scout]
 #        fm-brief.sh <task-id> --secondmate <project>...
 #   --scout writes the scout contract instead: the deliverable is a report at
@@ -212,6 +216,12 @@ You are a crewmate: an autonomous worker agent managed by firstmate. Work on you
 # Task
 {TASK}
 
+# Acceptance scenarios
+If this section lists Given/When/Then scenarios, they are the captain-approved behaviour for this task - the definition of "correct". Implement the change so every scenario holds, and cover each one with an automated test: if this repo already uses a BDD/Gherkin runner (a \`features/\` dir, \`*.feature\` files, or a Cucumber-family/behave/pytest-bdd/Reqnroll/Godog dependency), add the scenarios in that runner's idiom; otherwise write ordinary unit/integration tests named to mirror each scenario's Given/When/Then. A listed scenario with no passing test is not done. If a scenario proves wrong or ambiguous while implementing, append \`needs-decision:\` and stop rather than guessing.
+If this section says "N/A", this is a non-behavioural change (refactor, mechanical edit, internal-only); no scenario tests are required, though the project's normal tests still apply.
+
+{SCENARIOS}
+
 # Setup
 You are in a disposable git worktree of $REPO, at a detached HEAD on a clean default branch.
 
@@ -243,4 +253,4 @@ Keep it proportionate: skip \`AGENTS.md\` edits for trivial tasks that produced 
 
 $DOD
 EOF
-echo "scaffolded: $BRIEF (ship, mode=$MODE; replace {TASK})"
+echo "scaffolded: $BRIEF (ship, mode=$MODE; replace {TASK} and {SCENARIOS})"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -39,6 +39,10 @@ Ship briefs also tell the crewmate to verify `pwd -P` and `git rev-parse --show-
 
 Ship tasks change projects and ship by project mode (`no-mistakes`, `direct-PR`, or `local-only`); scout tasks investigate, plan, reproduce bugs, or audit, then leave a report at `data/<id>/report.md` and never push.
 
+A behavior-shaped ship task gets a short BDD design phase first: firstmate and the captain agree the intended behaviour as captain-approved Given/When/Then acceptance scenarios (reviewed in Lavish, or briefly in chat), which then fill the brief's acceptance-scenarios block and become the crewmate's definition of "correct", each covered by a passing test.
+Trivial mechanical or non-behavioural changes and scout tasks skip this.
+The scenario practice itself is owned by the agent-only [`bdd-scenarios`](../.agents/skills/bdd-scenarios/SKILL.md) skill.
+
 ## Optional secondmates
 
 `data/secondmates.md` records persistent domain supervisors with natural-language scopes, project clone lists, and home paths.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -9,7 +9,7 @@ Each file also starts with a short header comment.
 | `fm-fleet-sync.sh`       | Fetch clones, clean-fast-forward their checked-out default branches, and safely prune branches whose remote is gone |
 | `fm-update.sh`           | Self-update the running firstmate repo and registered secondmate homes with fast-forward-only pulls from origin     |
 | `fm-backlog-handoff.sh`  | Move already-judged in-scope queued backlog items from the main home into a seeded secondmate home                 |
-| `fm-brief.sh`            | Scaffold a ship brief with a worktree-isolation assertion, a report-only scout brief with `--scout`, or a secondmate charter with `--secondmate` |
+| `fm-brief.sh`            | Scaffold a ship brief with a worktree-isolation assertion and a `{SCENARIOS}` acceptance-scenarios block, a report-only scout brief with `--scout`, or a secondmate charter with `--secondmate` |
 | `fm-ensure-agents-md.sh` | Ensure project `AGENTS.md` is the real memory file and `CLAUDE.md` symlinks to it                                   |
 | `fm-guard.sh`            | Warn when the primary checkout is tangled, when queued wakes are pending, or when a stale or missing watcher needs a prominent banner |
 | `fm-home-seed.sh`        | Lease/provision a secondmate home transactionally, clone projects, initialize gates, and maintain `data/secondmates.md` |


### PR DESCRIPTION
## Intent

The developer (acting as the captain of the firstmate fleet-supervision tool) first asked clarifying questions about how firstmate works: whether it would follow a no-mistakes pipeline if set up in a repo, and a detailed explanation of how it delegates work, interacts with repos, and the fundamental value it provides, which they wanted illustrated as a Lavish design doc. They then proposed driving crewmate tasks with BDD (Given/When/Then) specs as the intent, reviewed in Lavish during the design phase, and decided to implement two pieces: (1) the contract change adding an acceptance-scenarios block to the brief scaffold (bin/fm-brief.sh) and documenting when BDD applies in AGENTS.md, and (2) a new agent-only bdd-scenarios reference skill. They explicitly required an extensive investigation into how BDD works, its semantics, and best practices to ground both pieces. They approved shipping the change through firstmate's own no-mistakes gate via a PR (not a direct merge), and authorized creating a personal fork (henrylaih41/firstmate) to push the branch and open a PR against the read-only upstream.

## What Changed

- `bin/fm-brief.sh` now injects an acceptance-scenarios block with a `{SCENARIOS}` placeholder into ship briefs (no-mistakes, direct-PR, and local-only modes), instructing the crewmate to cover each Given/When/Then scenario with a passing test; scout and secondmate briefs deliberately omit the block.
- Added a new agent-only `bdd-scenarios` reference skill covering the discovery/formulation/automation flow, Given/When/Then semantics, scenario best practices and anti-patterns, the proportionality call, and the executable-vs-prose decision.
- Documented the BDD acceptance-scenarios contract in `AGENTS.md` (intake design phase and brief contract) and updated `docs/architecture.md` and `docs/scripts.md` to reference it.

## Risk Assessment

✅ Low: The change is confined to documentation and a brief-template heredoc addition with correctly escaped backticks and no shell-injection or behavioral risk, all consistent with the existing brief-scaffolding conventions.

## Testing

No existing test covered fm-brief.sh's brief output, so I drove the scaffold directly: in an isolated firstmate home I generated briefs for all three ship modes plus a scout and a secondmate, and captured the rendered markdown as reviewer-visible artifacts. The new Acceptance scenarios section and {SCENARIOS} placeholder appear in every ship-mode brief and are correctly absent from scout and secondmate briefs; a simulated firstmate fill replaced the placeholder with real Given/When/Then scenarios leaving none behind. The two existing tests that invoke fm-brief.sh both pass, so the change is isolated. This is a CLI/scaffold change with no UI surface, so the evidence is the rendered brief markdown files rather than screenshots. Overall result: the BDD acceptance-scenarios contract works as intended.

<details>
<summary>Evidence: Ship brief (no-mistakes mode) — rendered Acceptance scenarios section a crewmate reads</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Acceptance scenarios
If this section lists Given/When/Then scenarios, they are the captain-approved behaviour for this task - the definition of "correct". Implement the change so every scenario holds, and cover each one with an automated test: if this repo already uses a BDD/Gherkin runner (a `features/` dir, `*.feature` files, or a Cucumber-family/behave/pytest-bdd/Reqnroll/Godog dependency), add the scenarios in that runner's idiom; otherwise write ordinary unit/integration tests named to mirror each scenario's Given/When/Then. A listed scenario with no passing test is not done. If a scenario proves wrong or ambiguous while implementing, append `needs-decision:` and stop rather than guessing.
If this section says "N/A", this is a non-behavioural change (refactor, mechanical edit, internal-only); no scenario tests are required, though the project's normal tests still apply.

{SCENARIOS}

# Setup
You are in a disposable git worktree of webapp, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable treehouse worktree you were launched in, typically a path under a `.treehouse/` pool, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/feat-login`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/kh/0yfhkcx94t1710yvpx1cg_b80000gn/T/tmp.Fk1HYs4uph/state/feat-login.status'`
   States: working, needs-decision, blocked, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs to a human (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/Users/hlaih/.no-mistakes/worktrees/d3b0d9f85f4a/01KW13B4V6889PSCDP0VPJ0F98/bin/fm-ensure-agents-md.sh .` in the worktree.
If this task produced durable project-intrinsic knowledge, record it in `AGENTS.md` as part of your change.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

During validation you drive the gates while the pipeline owns the fixes. Run it in the foreground and follow this contract:
- Never edit or `git commit` code yourself while a run is active; the pipeline applies every fix in its own worktree.
- When a gate shows auto-fix findings, advance it with `no-mistakes axi respond --action fix --findings <ids>` (the pipeline applies the fix and re-reviews). Escalate ask-user findings per rule 6.
- `no-mistakes axi run` and `axi respond` block synchronously for many minutes (test and CI especially); the pipeline often fixes findings itself with no gate, so when a call returns no `gate:` object that is normal - just let it return.
- Never cancel, abort, re-run, or background the run, and never idle-wait for a background notification: the call is in the foreground and returns on its own.

After /no-mistakes reports CI green, append `done: PR {url} checks green` and stop. You are finished.
```
</details>
<details>
<summary>Evidence: Ship brief (direct-PR mode)</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Acceptance scenarios
If this section lists Given/When/Then scenarios, they are the captain-approved behaviour for this task - the definition of "correct". Implement the change so every scenario holds, and cover each one with an automated test: if this repo already uses a BDD/Gherkin runner (a `features/` dir, `*.feature` files, or a Cucumber-family/behave/pytest-bdd/Reqnroll/Godog dependency), add the scenarios in that runner's idiom; otherwise write ordinary unit/integration tests named to mirror each scenario's Given/When/Then. A listed scenario with no passing test is not done. If a scenario proves wrong or ambiguous while implementing, append `needs-decision:` and stop rather than guessing.
If this section says "N/A", this is a non-behavioural change (refactor, mechanical edit, internal-only); no scenario tests are required, though the project's normal tests still apply.

{SCENARIOS}

# Setup
You are in a disposable git worktree of toolkit, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable treehouse worktree you were launched in, typically a path under a `.treehouse/` pool, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/feat-flag`

# Rules
1. Never push to the default branch (push only your `fm/feat-flag` branch). Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/kh/0yfhkcx94t1710yvpx1cg_b80000gn/T/tmp.Fk1HYs4uph/state/feat-flag.status'`
   States: working, needs-decision, blocked, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs to a human (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/Users/hlaih/.no-mistakes/worktrees/d3b0d9f85f4a/01KW13B4V6889PSCDP0VPJ0F98/bin/fm-ensure-agents-md.sh .` in the worktree.
If this task produced durable project-intrinsic knowledge, record it in `AGENTS.md` as part of your change.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
This project ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
The task is complete only when committed on your branch.
When it is implemented and committed, push your branch and open a PR with `gh-axi`, then append `done: PR {url}` to the status file and stop.
Do NOT run /no-mistakes. The captain reviews and merges the PR; firstmate relays it.
```
</details>
<details>
<summary>Evidence: Ship brief (local-only mode)</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Acceptance scenarios
If this section lists Given/When/Then scenarios, they are the captain-approved behaviour for this task - the definition of "correct". Implement the change so every scenario holds, and cover each one with an automated test: if this repo already uses a BDD/Gherkin runner (a `features/` dir, `*.feature` files, or a Cucumber-family/behave/pytest-bdd/Reqnroll/Godog dependency), add the scenarios in that runner's idiom; otherwise write ordinary unit/integration tests named to mirror each scenario's Given/When/Then. A listed scenario with no passing test is not done. If a scenario proves wrong or ambiguous while implementing, append `needs-decision:` and stop rather than guessing.
If this section says "N/A", this is a non-behavioural change (refactor, mechanical edit, internal-only); no scenario tests are required, though the project's normal tests still apply.

{SCENARIOS}

# Setup
You are in a disposable git worktree of notes, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable treehouse worktree you were launched in, typically a path under a `.treehouse/` pool, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/feat-tag`

# Rules
1. Never push to any remote and never open a PR. Work only on your `fm/feat-tag` branch; firstmate handles the merge into local `main`.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/kh/0yfhkcx94t1710yvpx1cg_b80000gn/T/tmp.Fk1HYs4uph/state/feat-tag.status'`
   States: working, needs-decision, blocked, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs to a human (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/Users/hlaih/.no-mistakes/worktrees/d3b0d9f85f4a/01KW13B4V6889PSCDP0VPJ0F98/bin/fm-ensure-agents-md.sh .` in the worktree.
If this task produced durable project-intrinsic knowledge, record it in `AGENTS.md` as part of your change.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
This project ships **local-only**: no remote, no PR, no pipeline.
The task is complete only when committed on your branch `fm/feat-tag`. Do NOT push, do NOT open a PR, do NOT merge.
Keep your branch a clean fast-forward onto the current default branch - if `main` has advanced, rebase onto it so the eventual merge stays a fast-forward.
When it is implemented and committed, append `done: ready in branch fm/feat-tag` to the status file and stop.
Firstmate then reviews your branch diff, the captain approves, and firstmate merges it into local `main`.
```
</details>
<details>
<summary>Evidence: Scout brief — no Acceptance scenarios block (negative case)</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Setup
You are in a disposable git worktree of webapp, at a detached HEAD on a clean default branch.
This is a SCOUT task: the deliverable is a written report, not a PR.
The worktree is your laboratory - install, run, edit, and make scratch commits freely; all of it is discarded at teardown.
The report is the only thing that survives, so anything worth keeping must be in it.

# Rules
1. Never push to any remote and never open a PR.
2. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/kh/0yfhkcx94t1710yvpx1cg_b80000gn/T/tmp.Fk1HYs4uph/state/why-slow.status'`
   States: working, needs-decision, blocked, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on and the needs-decision/blocked/done/failed states. No step-by-step
   FYI progress lines; firstmate reads your pane for that.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs to a human (product choices, destructive actions),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.

# Definition of done
Write your findings to `/var/folders/kh/0yfhkcx94t1710yvpx1cg_b80000gn/T/tmp.Fk1HYs4uph/data/why-slow/report.md`.
The report must stand alone: what you did, what you found, the evidence (commands run, output, file:line references), and what you recommend.
When the report is complete, append `done: {one-line conclusion}` to the status file and stop.
If your findings reveal work that should ship (e.g. you reproduced a bug and the fix is clear), say so in the report; firstmate may promote this task in place, and you would then receive mode-specific ship instructions as a follow-up message.
```
</details>
<details>
<summary>Evidence: Secondmate charter — no Acceptance scenarios block (negative case)</summary>

```text
You are a secondmate: a persistent domain supervisor managed by the main firstmate. Work on your own; do not wait for a human.

# Charter
Own triage for webapp

# Routing scope
Own triage for webapp

# Project clones
- webapp

# Operating model
You are in an isolated firstmate home. The local `AGENTS.md` is your job description, and your local `data/`, `state/`, `config/`, and `projects/` dirs are yours to operate.
The projects above are local clones for work you supervise; they are not an exclusive ownership claim.
Delegate project work to your own crewmates with the normal firstmate lifecycle: brief, spawn, status, watcher, steer, teardown, and recovery.
Do not invent a second delegation system.
You do not generate your own work.
Act only on tasks the main firstmate routes to you.
Never start a survey, audit, or "find improvements" sweep on your own initiative; that is not your job and it is unwanted.

# Escalation to main firstmate
Handle routine work yourself.
Escalate only true captain-relevant outcomes by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/kh/0yfhkcx94t1710yvpx1cg_b80000gn/T/tmp.Fk1HYs4uph/state/triage-sm.status'`
States: working, needs-decision, blocked, done, failed.
Use this only for material phase changes, a captain decision, a real blocker, a failure, or work ready for review.
Routine internal supervision, heartbeats, retries, and crewmate churn stay inside your own home and must not touch that status file.

# Definition of done
You are persistent by default. Do not exit just because your queue is empty.
On startup and restart, run normal firstmate bootstrap and recovery for your own home, but only to RECONCILE work that is already yours: in-flight crewmates, tracked backlog items, and durable watches recorded in this home.
When you have no assigned or in-flight work after that reconciliation, go idle and wait silently for the main firstmate to route you a task.
An empty queue is a healthy resting state, not a cue to invent work: never spawn a survey, audit, or any self-directed "find work" task on your own initiative.
If this charter cannot be carried out, append `blocked: {why}` or `failed: {why}` to the main status file and stop.
```
</details>
<details>
<summary>Evidence: Filled ship brief — placeholders replaced with real captain-approved GWT scenarios</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
Add username/password login to the web app.

# Acceptance scenarios
If this section lists Given/When/Then scenarios, they are the captain-approved behaviour for this task - the definition of "correct". Implement the change so every scenario holds, and cover each one with an automated test: if this repo already uses a BDD/Gherkin runner (a `features/` dir, `*.feature` files, or a Cucumber-family/behave/pytest-bdd/Reqnroll/Godog dependency), add the scenarios in that runner's idiom; otherwise write ordinary unit/integration tests named to mirror each scenario's Given/When/Then. A listed scenario with no passing test is not done. If a scenario proves wrong or ambiguous while implementing, append `needs-decision:` and stop rather than guessing.
If this section says "N/A", this is a non-behavioural change (refactor, mechanical edit, internal-only); no scenario tests are required, though the project's normal tests still apply.

Scenario: Returning user signs in
  Given "Bob" is a registered user
  When "Bob" logs in with valid credentials
  Then he sees his dashboard

Scenario: Wrong password is rejected
  Given "Bob" is a registered user
  When "Bob" logs in with an incorrect password
  Then he is told the credentials are invalid
  And he is not signed in

# Setup
You are in a disposable git worktree of webapp, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable treehouse worktree you were launched in, typically a path under a `.treehouse/` pool, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/feat-login`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/kh/0yfhkcx94t1710yvpx1cg_b80000gn/T/tmp.Fk1HYs4uph/state/feat-login.status'`
   States: working, needs-decision, blocked, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs to a human (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/Users/hlaih/.no-mistakes/worktrees/d3b0d9f85f4a/01KW13B4V6889PSCDP0VPJ0F98/bin/fm-ensure-agents-md.sh .` in the worktree.
If this task produced durable project-intrinsic knowledge, record it in `AGENTS.md` as part of your change.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

During validation you drive the gates while the pipeline owns the fixes. Run it in the foreground and follow this contract:
- Never edit or `git commit` code yourself while a run is active; the pipeline applies every fix in its own worktree.
- When a gate shows auto-fix findings, advance it with `no-mistakes axi respond --action fix --findings <ids>` (the pipeline applies the fix and re-reviews). Escalate ask-user findings per rule 6.
- `no-mistakes axi run` and `axi respond` block synchronously for many minutes (test and CI especially); the pipeline often fixes findings itself with no gate, so when a call returns no `gate:` object that is normal - just let it return.
- Never cancel, abort, re-run, or background the run, and never idle-wait for a background notification: the call is in the foreground and returns on its own.

After /no-mistakes reports CI green, append `done: PR {url} checks green` and stop. You are finished.
```
</details>
<details>
<summary>Evidence: Contract assertion run (15/15 pass)</summary>

```text
PASS: ship-no-mistakes has '# Acceptance scenarios' heading
PASS: ship-no-mistakes has {SCENARIOS} placeholder
PASS: ship-no-mistakes explains GWT + per-scenario test
PASS: ship-no-mistakes explains N/A path
... (direct-pr, local-only same) ...
PASS: scout brief has NO Acceptance scenarios section
PASS: scout brief has NO {SCENARIOS} placeholder
PASS: secondmate charter has NO Acceptance scenarios
passed=15 failed=0
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bin/fm-brief.sh feat-login webapp` (no-mistakes ship) — brief contains `# Acceptance scenarios` + `{SCENARIOS}`</code>
- <code>`bin/fm-brief.sh feat-flag toolkit` (direct-PR ship) — scenarios block present</code>
- <code>`bin/fm-brief.sh feat-tag notes` (local-only ship) — scenarios block present</code>
- <code>`bin/fm-brief.sh why-slow webapp --scout` — confirmed NO scenarios block/placeholder</code>
- <code>`FM_SECONDMATE_CHARTER=... bin/fm-brief.sh triage-sm --secondmate webapp` — confirmed NO scenarios block</code>
- `15-assertion contract check across all generated briefs (heading, placeholder, GWT text, N/A path; negative checks for scout/secondmate) — all pass`
- <code>End-to-end placeholder fill with real Given/When/Then scenarios via Python — no `{TASK}`/`{SCENARIOS}` left in final brief</code>
- <code>`tests/fm-secondmate-safety.test.sh` — pass</code>
- <code>`tests/fm-tangle-guard.test.sh` — pass (includes &#39;fm-brief: ship brief asserts worktree isolation&#39;)</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
