### PR TITLE
feat: add capabilities and problems registries with captain skills

### DIFF
--- a/.agents/skills/propose-tool/SKILL.md
+++ b/.agents/skills/propose-tool/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: propose-tool
+description: Record a captain's proposal for a better alternative tool. Use when the captain invokes /propose-tool or proposes swapping or adding a tool (e.g. "propose we use X instead of Y", "there's a better tool for this"). Appends a structured proposed-tool entry (tool, what it replaces, why it is better) to CAPABILITIES.md and queues an evaluation, so the proposal is named and tracked instead of lost in chat.
+user-invocable: true
+---
+
+# propose-tool
+
+The captain has a better tool in mind for something firstmate already does.
+This skill captures that proposal as a structured entry in the capabilities manifest and queues firstmate to evaluate it, closing one end of the capabilities loop: proposal recorded -> candidate evaluated -> capability added -> [`CAPABILITIES.md`](../../../CAPABILITIES.md) and the relevant playbook updated.
+
+Do not edit `CAPABILITIES.md` by hand for this; the helper guarantees the exact, consistent schema.
+
+## What it does
+
+1. **Gather the three required fields** from the captain's message (ask one concise question only if a field is genuinely missing):
+   - **tool** - the proposed tool and, if known, where to get it.
+   - **replaces** - the current capability or tool it would replace or augment.
+   - **why** - the concrete advantage: faster, more correct, fewer failures, lower cost.
+   - Optionally **notes** - any extra context.
+
+2. **Record the proposal** by running the helper from the firstmate repo root:
+   ```sh
+   bin/fm-registry.sh propose-tool \
+     --tool "<tool>" \
+     --replaces "<what it replaces>" \
+     --why "<why it is better>" \
+     [--notes "<optional context>"]
+   ```
+   This appends a `### T-<timestamp>-<slug>` entry to the "Proposed tools" section of `CAPABILITIES.md` with status `proposed`, and appends a line to the fleet-local evaluation queue (`data/evaluation-queue.md`).
+
+3. **Confirm to the captain** in plain outcome language: the proposal is recorded and queued for evaluation, naming the tool and what it would replace. Do not expose internal mechanics.
+
+## Closing the loop
+
+The proposal now waits in the evaluation queue.
+When firstmate evaluates it (often via a scout task that benchmarks the candidate against the incumbent), advance the entry's **Status** (`proposed` -> `evaluating` -> `adopted` | `rejected`).
+On adoption, graduate the entry into the relevant category of `CAPABILITIES.md` with its version and known limits, remove it from "Proposed tools", and update any playbook that should now use it.
+
+## Notes
+
+- This is a firstmate-repo change. When the fleet has crewmates in flight, ship shared, tracked changes to `CAPABILITIES.md` through the normal pipeline; when the fleet is empty, firstmate may record directly. Either way the helper performs the append.
+- If the captain is reporting a problem rather than proposing a tool, use `report-problem` instead; a proposed tool is often the candidate fix for a recorded problem.

--- a/.agents/skills/report-problem/SKILL.md
+++ b/.agents/skills/report-problem/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: report-problem
+description: Record a captain-flagged recurring problem. Use when the captain invokes /report-problem or flags something that keeps going wrong (e.g. "this keeps failing", "X is too slow", "report a problem with Y"). Appends a structured entry (problem, symptom, impact, suspected root cause) to PROBLEMS.md and queues an evaluation, so the problem is named and tracked instead of fixes chasing symptoms.
+user-invocable: true
+---
+
+# report-problem
+
+The captain has hit a recurring problem - something slow, wrong, or repeatedly failing.
+This skill names that problem in the registry before anyone fixes it, so the fix targets the cause rather than the symptom.
+It closes one end of the capabilities loop: problem reported -> named in [`PROBLEMS.md`](../../../PROBLEMS.md) -> candidate fix/tool evaluated -> capability added to [`CAPABILITIES.md`](../../../CAPABILITIES.md) -> manifest and playbook updated.
+
+Do not edit `PROBLEMS.md` by hand for this; the helper guarantees the exact, consistent schema.
+
+## What it does
+
+1. **Gather the four required fields** from the captain's message (ask one concise question only if a field is genuinely missing):
+   - **problem** - a one-line title naming the problem, not the symptom.
+   - **symptom** - what is actually observed (the failure, error, or degraded behavior).
+   - **impact** - who or what it costs, and how much.
+   - **cause** - the best current hypothesis for the root cause.
+   - Optionally **fix** - a candidate remedy or tool, if one is already apparent.
+
+2. **Record the problem** by running the helper from the firstmate repo root:
+   ```sh
+   bin/fm-registry.sh report-problem \
+     --problem "<one-line title>" \
+     --symptom "<what is observed>" \
+     --impact "<cost>" \
+     --cause "<suspected root cause>" \
+     [--fix "<candidate fix or tool>"]
+   ```
+   This appends a `### P-<timestamp>-<slug>` entry to the "Registry" section of `PROBLEMS.md` with status `reported`, and appends a line to the fleet-local evaluation queue (`data/evaluation-queue.md`).
+
+3. **Confirm to the captain** in plain outcome language: the problem is recorded and queued for evaluation, restated in one line. Do not expose internal mechanics.
+
+## Scope: tracked taxonomy vs fleet-local incident
+
+`PROBLEMS.md` holds the **general taxonomy** - problems any firstmate fleet can hit.
+If the captain's report is a one-off, captain-specific incident with private context, record it in `data/` (fleet-local) instead, and only promote a sanitized, general version into `PROBLEMS.md` if it recurs across the fleet.
+When in doubt, file it to `PROBLEMS.md` if it is general and to `data/` if it is specific to this captain's projects.
+
+## Closing the loop
+
+The problem now waits in the evaluation queue.
+When firstmate evaluates it, advance the entry's **Status** (`reported` -> `triaging` -> `evaluating` -> `fix-identified` -> `resolved` | `wontfix`).
+A `propose-tool` proposal is frequently the candidate fix; on resolution, record the landing change and update `CAPABILITIES.md` if the fix added or changed a capability.
+
+## Notes
+
+- This is a firstmate-repo change. When the fleet has crewmates in flight, ship shared, tracked changes to `PROBLEMS.md` through the normal pipeline; when the fleet is empty, firstmate may record directly. Either way the helper performs the append.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -614,3 +614,19 @@ These skills are not captain-invocable; they are conditional operating reference
 - `harness-adapters` - load before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter.
 - `stuck-crewmate-recovery` - load after a stale wake, looping pane, repeated confusion, an answered-by-brief question, an unresponsive crewmate, or a failed steer.
 - `secondmate-provisioning` - load before creating, seeding, validating, recovering, handing backlog to, or retiring a secondmate home, and before editing `data/secondmates.md`.
+
+The two captain-invocable registry skills (`propose-tool`, `report-problem`) are not in the agent-only list above; they are described with the registries in section 14.
+
+## 14. Capabilities and problem registries
+
+Firstmate keeps a living record of what it can do and what keeps going wrong, so improvements start by naming the underlying problem rather than chasing symptoms.
+
+- [`CAPABILITIES.md`](CAPABILITIES.md) - the living manifest of every tool, MCP server, skill, and quality gate this firstmate uses, with current capabilities and known limits. Keep it current in the same change whenever a capability is added, removed, upgraded, or hits a new limit.
+- [`PROBLEMS.md`](PROBLEMS.md) - the registry of recurring problems with an explicit schema (problem, symptom, impact, suspected root cause, candidate fix/tool, status). The tracked file is the general taxonomy; fleet-specific incidents stay local in `data/`.
+
+Two captain-invocable skills feed the loop, each appending a structured entry via `bin/fm-registry.sh` and queuing an evaluation:
+
+- `propose-tool` - the captain proposes a better alternative tool (tool, what it replaces, why it is better); recorded in `CAPABILITIES.md`.
+- `report-problem` - the captain flags a problem (problem, symptom, impact, suspected root cause); recorded in `PROBLEMS.md`.
+
+The loop they close: problem reported -> named in the registry -> candidate tool/fix evaluated -> capability added -> manifest and playbook updated.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ Hard rules, in priority order:
 
 You may freely write to this repo itself (backlog, briefs, state, even this file when the captain approves a change).
 Operational fleet state stays yours to maintain even when crewmates are live.
-Shared, tracked material means `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `.tasks.toml`, `.github/workflows/`, `bin/`, and agent skill files.
+Shared, tracked material means `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `CAPABILITIES.md`, `PROBLEMS.md`, `.tasks.toml`, `.github/workflows/`, `bin/`, and agent skill files.
 When one or more crewmates are in flight, delegate changes to shared, tracked material to a crewmate through the normal scout or ship machinery instead of hand-editing them yourself.
 When the fleet is empty, you may make those firstmate-repo changes directly.
 Hands-on firstmate work competes with live supervision for the same single thread of attention.
@@ -65,6 +65,8 @@ Each secondmate gets its own persistent `FM_HOME`, so its local state, backlog, 
 AGENTS.md            this file (CLAUDE.md is a symlink to it)
 CONTRIBUTING.md      contributor workflow and repo conventions
 README.md            public overview and development notes
+CAPABILITIES.md      living manifest of tools, MCP servers, skills, and quality gates with known limits (section 14)
+PROBLEMS.md          registry of recurring problems with an explicit schema (section 14)
 .github/workflows/   shared CI and PR enforcement, committed
 .tasks.toml          tracked tasks-axi markdown backend config; drives backlog mutations when a compatible tasks-axi is on PATH (section 10), otherwise inert
 .agents/skills/      shared skills, committed

--- a/CAPABILITIES.md
+++ b/CAPABILITIES.md
@@ -1,0 +1,144 @@
+# Capabilities manifest
+
+This is the living manifest of every tool, MCP server, skill, and quality gate this firstmate actually uses, plus what each one does and its known limits.
+It exists because a fleet that keeps no record of what it can do cannot reason about what it is missing, and improvements that are not anchored to a named capability chase symptoms.
+
+This manifest is one half of a loop; [`PROBLEMS.md`](PROBLEMS.md) is the other.
+The loop: a problem is reported and named in the registry, a candidate tool or fix is evaluated, the capability is added here, and the manifest plus the relevant playbook are updated.
+The captain feeds both ends of that loop with two skills: `report-problem` names a recurring problem, and `propose-tool` proposes a better alternative tool.
+
+**Keep it living.**
+When a tool, MCP, skill, or gate is added, removed, upgraded, or hits a new limit, update the matching row here in the same change.
+Versions below are the ones observed in this environment; treat them as a snapshot, not a pin, and refresh a row when you notice it has moved.
+New capabilities usually arrive through the loop: a proposal in the "Proposed tools" section at the bottom is evaluated and, if adopted, graduates into the relevant category above with its limits recorded.
+
+## Crewmate harnesses
+
+The agent runtimes firstmate dispatches crewmates and secondmates on.
+The active crewmate harness is `config/crew-harness` (absent or `default` mirrors firstmate's own); per-task overrides are allowed.
+Never dispatch on an unverified adapter - see the `harness-adapters` skill for the verified set and the mechanics.
+
+| Harness | Status here | Notes |
+| --- | --- | --- |
+| claude | installed, active | firstmate's own harness and the default for crewmates. |
+| codex | installed | per-task override; also runs the optional pre-PR review pass (`codex` CLI). |
+| opencode | adapter verified, not installed | launch via `harness-adapters`; install before dispatch. |
+| pi | adapter verified, not installed | launch via `harness-adapters`; install before dispatch. |
+
+Known limits: only adapters verified in `harness-adapters` may be dispatched; an unverified `config/crew-harness` falls back to firstmate's own harness.
+
+## Agent-ergonomic CLIs (the `*-axi` wrappers)
+
+Ergonomic wrappers preferred over the raw underlying tools; each carries session hooks and `--help` as the source of truth for flags.
+
+| Tool | Version | What it does | Known limits |
+| --- | --- | --- | --- |
+| gh-axi | 0.1.21 | all GitHub operations (issues, PRs, runs, releases, repos, labels). | needs `gh auth login` once; a `#number` is not a clickable link, always relay full PR URLs. |
+| chrome-devtools-axi | 0.1.24 | all browser / DevTools automation. | drives a real Chrome session; needs the browser available. |
+| lavish-axi | 0.1.31 | rich, annotatable HTML review surfaces for captain decisions and structured reports. | `poll` long-polls and must be left running (re-run if killed); only native controls and `[data-lavish-action]` stay clickable, nested iframes are not injected. |
+
+## Quality gate
+
+| Gate | Version | What it does | Known limits |
+| --- | --- | --- | --- |
+| no-mistakes | v1.30.1 | the validation pipeline a crewmate drives to ship: review, test, document, lint, push, PR, CI. The pipeline owns every fix (in its own worktree); the crewmate only advances gates with `no-mistakes axi respond`. | serializes per repo - one run per repo at a time, holding the slot until its PR is merged or aborted, so concurrent ship tasks on one repo must be sequenced. `axi run`/`axi respond` block synchronously for many minutes. |
+
+`no-mistakes` is the gate for `no-mistakes`-mode projects (including this repo); `direct-PR` and `local-only` projects skip it.
+
+## Worktree and fleet management
+
+| Tool | Version | What it does | Known limits |
+| --- | --- | --- | --- |
+| treehouse | v1.8.0 | pooled, isolated git worktrees - one clean worktree per crewmate. | use `--lease` for a non-interactive, durable acquire; pooled clones keep frozen local default refs, so diff against the authoritative base via `bin/fm-review-diff.sh`. |
+| git | 2.50.1 | underlying VCS for every clone, worktree, and the firstmate repo itself. | firstmate's primary checkout must stay on its default branch (worktree-tangle guard in `bin/fm-guard.sh`). |
+
+## Backlog
+
+| Tool | Version | What it does | Known limits |
+| --- | --- | --- | --- |
+| tasks-axi | 0.1.1 | markdown backlog backend pinned by `.tasks.toml` to `data/backlog.md`; mutate the backlog through its verbs when present. | compatible only at 0.1.1+; when absent or incompatible, hand-edit `data/backlog.md` in the documented format. Secondmate handoffs always go through `bin/fm-backlog-handoff.sh`, never bare `tasks-axi mv`. |
+
+## MCP servers
+
+Model-context servers reachable from firstmate and its crewmates (schemas load on demand).
+
+| Server | What it provides | Notes |
+| --- | --- | --- |
+| claude-in-chrome | browser automation (navigate, click, read, screenshot, console/network). | prefer `chrome-devtools-axi` first; avoid triggering blocking JS dialogs. |
+| context7 | live library / framework / SDK / CLI documentation. | prefer over web search and over memory for library docs. |
+| open-design | local-first design workspace (OD): artifacts, files, runs. | drive same-project iteration via the `od` CLI to avoid the start_run prompt-drop. |
+| xcodebuild | Apple platform build / simulator / device / UI automation. | only simulator workflow tools enabled by default; verify session defaults before first build. |
+| mobbin | mobile app design reference search (flows, screens, sections). | reference only. |
+| refero | design reference search (screens, flows, styles, similar screens). | reference only. |
+| socialcrawl | social-platform data (endpoints, monitors, requests). | metered; check balance. |
+| vercel | deploys, runtime logs, project/domain ops, docs. | outward-facing actions need captain consent. |
+
+## Mobile / iOS
+
+| Tool | Version | What it does | Known limits |
+| --- | --- | --- | --- |
+| baguette | 0.1.75 | iOS simulator control, including custom named device sets so parallel crews get isolated sims. | a custom `fm-sim` device-set is invisible to the xcodebuild MCP, so give each parallel iOS crew its own DEFAULT-set named sim. |
+| fm-sim | not built | planned iOS v2 helper (`fm-sim.sh`) for per-crew simulator management. | **not yet on PATH** - tracked as a gap in the iOS v2 plan; do not assume it exists. |
+
+## Skills
+
+Skills are invocable capabilities; firstmate's own live under `.agents/skills/` (`.claude/skills` symlinks to it).
+
+**Captain-invocable** (the captain runs these by name):
+
+| Skill | What it does |
+| --- | --- |
+| afk | enters away-mode supervision: the sub-supervisor daemon self-handles routine wakes and batches escalations. |
+| updatefirstmate | fast-forward self-update of firstmate and every secondmate home, then re-read and nudge. |
+| propose-tool | records a structured proposed-tool entry (tool, what it replaces, why better) in this manifest and queues an evaluation. |
+| report-problem | records a structured problem entry (problem, symptom, impact, suspected root cause) in `PROBLEMS.md` and queues an evaluation. |
+
+Harness built-ins are also captain-invocable (for example `no-mistakes` to validate, `code-review`, `security-review`); they are not firstmate-owned and live in the harness, not `.agents/skills/`.
+
+**Agent-only references** (firstmate loads these at the trigger points in AGENTS.md section 13, never the captain):
+
+| Skill | Load before |
+| --- | --- |
+| harness-adapters | spawning/recovering a crewmate or secondmate, trust dialogs, harness-specific skill calls, interrupt/exit/resume, verifying a new adapter. |
+| stuck-crewmate-recovery | a stale wake, looping pane, repeated confusion, answered-by-brief question, unresponsive crewmate, or failed steer. |
+| secondmate-provisioning | creating, seeding, validating, recovering, handing backlog to, or retiring a secondmate home, or editing `data/secondmates.md`. |
+
+## firstmate helper scripts (`bin/`)
+
+The committed toolkit firstmate drives the fleet with; read each script's header before first use.
+
+| Area | Scripts |
+| --- | --- |
+| startup & recovery | `fm-bootstrap.sh`, `fm-lock.sh`, `fm-wake-drain.sh`, `fm-harness.sh` |
+| task lifecycle | `fm-spawn.sh`, `fm-brief.sh`, `fm-peek.sh`, `fm-send.sh`, `fm-teardown.sh`, `fm-promote.sh`, `fm-project-mode.sh` |
+| delivery & review | `fm-pr-check.sh`, `fm-review-diff.sh`, `fm-merge-local.sh`, `fm-ensure-agents-md.sh` |
+| supervision | `fm-watch.sh`, `fm-watch-arm.sh`, `fm-guard.sh`, `fm-supervise-daemon.sh` |
+| fleet & sync | `fm-fleet-sync.sh`, `fm-home-seed.sh`, `fm-update.sh`, `fm-backlog-handoff.sh` |
+| registries | `fm-registry.sh` (backs `propose-tool` and `report-problem`) |
+| shared libraries | `fm-ff-lib.sh`, `fm-marker-lib.sh`, `fm-tangle-lib.sh`, `fm-tasks-axi-lib.sh`, `fm-tmux-lib.sh`, `fm-wake-lib.sh` |
+
+## Known limits and gaps (cross-cutting)
+
+These are the standing constraints worth remembering across categories; recurring ones are tracked with full schema in [`PROBLEMS.md`](PROBLEMS.md).
+
+- no-mistakes serializes per repo, so concurrent ship tasks on one repo must be sequenced.
+- The watcher (`fm-watch.sh`) is one-shot and must be re-armed every wake/recovery turn via `fm-watch-arm.sh`; the durable wake queue and `fm-guard.sh` are the backstops.
+- Long sessions grow context and can degrade the harness; see `PROBLEMS.md`.
+- `fm-sim` is planned but not yet built; iOS sim isolation today relies on baguette named device sets.
+
+## Proposed tools (pending evaluation)
+
+Candidate tools the captain has proposed but firstmate has not yet evaluated.
+The `propose-tool` skill appends entries here through `bin/fm-registry.sh propose-tool`; an adopted proposal graduates into the relevant category above and is removed from this section.
+
+Each entry uses this schema:
+
+- **Tool:** the proposed tool and where to get it.
+- **Replaces:** the current capability or tool it would replace or augment.
+- **Why better:** the concrete advantage (speed, correctness, fewer failures, lower cost).
+- **Notes:** optional extra context.
+- **Status:** `proposed` -> `evaluating` -> `adopted` | `rejected`.
+- **Proposed:** the date it was filed.
+
+<!-- propose-tool entries are appended below this line by bin/fm-registry.sh; none yet -->
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ See the [no-mistakes quick start](https://kunchenguid.github.io/no-mistakes/star
 
 - This repo is a template for running a firstmate orchestrator agent.
   `AGENTS.md` is the agent's main job description and names when to load bundled skills; `CLAUDE.md` is a symlink to it, and `.claude/skills` is a symlink to `.agents/skills`.
-- Only shared material is tracked: `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `.tasks.toml`, `.github/workflows/`, `bin/`, and `.agents/skills/`.
+- Only shared material is tracked: `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `CAPABILITIES.md`, `PROBLEMS.md`, `.tasks.toml`, `.github/workflows/`, `bin/`, and `.agents/skills/`.
   Everything personal to one captain's fleet (`data/`, `state/`, `config/`, `projects/`, `.no-mistakes/`) is gitignored; never commit it.
   The root `.tasks.toml` is tracked `tasks-axi` config for `data/backlog.md`; compatible `tasks-axi` uses it for routine backlog mutations.
   It does not make `data/` tracked.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ See the [no-mistakes quick start](https://kunchenguid.github.io/no-mistakes/star
 
 ## Development
 
-Tracked changes to firstmate itself - `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `.tasks.toml`, `.github/workflows/`, `bin/`, and agent skill files - ship through the `no-mistakes` pipeline on a feature branch and require an explicit merge approval.
+Tracked changes to firstmate itself - `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `CAPABILITIES.md`, `PROBLEMS.md`, `.tasks.toml`, `.github/workflows/`, `bin/`, and agent skill files - ship through the `no-mistakes` pipeline on a feature branch and require an explicit merge approval.
 When supervising live crewmates, keep firstmate's own long validation or build commands in the background so watcher wakes can still be handled.
 A crewmate driving its own `no-mistakes` validation does the opposite: it runs the gate in the foreground and lets each synchronous `no-mistakes axi run` or `no-mistakes axi respond` call return.
 The pipeline owns auto-fix changes; the crewmate authorizes them with `no-mistakes axi respond --action fix --findings <ids>` instead of editing or committing while the run is active.

--- a/PROBLEMS.md
+++ b/PROBLEMS.md
@@ -9,7 +9,7 @@ The captain feeds the loop with the `report-problem` skill (names a problem) and
 
 ## Entry schema
 
-Every entry uses exactly these fields, in this order, so the registry stays scannable and machine-appendable:
+Every entry uses these fields, in this order, so the registry stays scannable and machine-appendable:
 
 - **Problem:** a one-line title naming the problem (not the symptom).
 - **Symptom:** what is actually observed - the failure, error, or degraded behavior.
@@ -17,7 +17,10 @@ Every entry uses exactly these fields, in this order, so the registry stays scan
 - **Suspected root cause:** the best current hypothesis for why it happens.
 - **Candidate fix / tool:** the proposed remedy - a tool, a script, a process change - or `TBD - to be evaluated`.
 - **Status:** one value from the vocabulary below.
-- **Reported / Resolved:** the date filed, and the date resolved once it is.
+- **Reported:** the date the entry was filed.
+- **Resolved:** the date it was resolved; optional, added only when **Status** becomes `resolved` (or `wontfix`).
+
+The `report-problem` skill emits every field except **Resolved**, which firstmate appends by hand when the entry closes.
 
 Each entry is a `### <id> - <problem title>` heading followed by those fields as a bullet list.
 Hand-authored seed entries below use readable ids; entries the `report-problem` skill appends use a timestamped id (`P-<YYYYMMDD-HHMMSS>-<slug>`) for uniqueness.

--- a/PROBLEMS.md
+++ b/PROBLEMS.md
@@ -1,0 +1,103 @@
+# Problem registry
+
+This is the registry of recurring problems firstmate hits, named before they are fixed.
+We name the underlying problem first - slow execution, bad output, repeated failures - so that fixes target the cause instead of chasing symptoms.
+
+This registry is one half of a loop; [`CAPABILITIES.md`](CAPABILITIES.md) is the other.
+The loop: a problem is reported and named here, a candidate tool or fix is evaluated, the capability is added to the manifest, and the manifest plus the relevant playbook are updated.
+The captain feeds the loop with the `report-problem` skill (names a problem) and `propose-tool` (proposes a candidate tool); firstmate then evaluates and closes it.
+
+## Entry schema
+
+Every entry uses exactly these fields, in this order, so the registry stays scannable and machine-appendable:
+
+- **Problem:** a one-line title naming the problem (not the symptom).
+- **Symptom:** what is actually observed - the failure, error, or degraded behavior.
+- **Impact:** who or what it costs, and how much (wasted turns, blocked work, lost messages, wrong output).
+- **Suspected root cause:** the best current hypothesis for why it happens.
+- **Candidate fix / tool:** the proposed remedy - a tool, a script, a process change - or `TBD - to be evaluated`.
+- **Status:** one value from the vocabulary below.
+- **Reported / Resolved:** the date filed, and the date resolved once it is.
+
+Each entry is a `### <id> - <problem title>` heading followed by those fields as a bullet list.
+Hand-authored seed entries below use readable ids; entries the `report-problem` skill appends use a timestamped id (`P-<YYYYMMDD-HHMMSS>-<slug>`) for uniqueness.
+
+## Status vocabulary
+
+`reported` -> `triaging` -> `evaluating` -> `fix-identified` -> `resolved` | `wontfix`
+
+- **reported** - filed, not yet looked at.
+- **triaging** - being reproduced and scoped.
+- **evaluating** - a candidate fix or tool is under evaluation.
+- **fix-identified** - the fix is known and queued or in flight.
+- **resolved** - fixed and verified; record the landing PR or change.
+- **wontfix** - acknowledged but intentionally not addressed; record why.
+
+## Scope: tracked taxonomy vs fleet-local incidents
+
+This tracked file is the **general taxonomy**: problems any firstmate fleet can hit, plus the schema above.
+**Fleet-specific incidents** - this captain's one-off breakages, project quirks, and private context - stay local in `data/` (gitignored), not here.
+When a fleet-local incident turns out to be general, promote a sanitized version into this file.
+
+## How entries get added
+
+The captain files entries with the captain-invocable skills, which call `bin/fm-registry.sh`:
+
+- `report-problem` -> `bin/fm-registry.sh report-problem --problem ... --symptom ... --impact ... --cause ... [--fix ...]` appends an entry below, status `reported`, and queues an evaluation in the fleet-local queue.
+- `propose-tool` files a candidate tool against a capability in `CAPABILITIES.md` (and is often the candidate fix for an entry here).
+
+firstmate then evaluates the queued item, advances the entry's **Status**, and on resolution updates `CAPABILITIES.md`.
+
+## Registry
+
+Seed entries are the general firstmate taxonomy; the `report-problem` skill appends new `###` entries below them.
+
+### P-seed-watcher-rearm-gap - Supervision stops when the watcher is not re-armed
+
+- **Problem:** the one-shot watcher silently stops supervising the fleet.
+- **Symptom:** crewmate signals, stale panes, and merge checks stop waking firstmate; long gaps with no fleet action despite in-flight work.
+- **Impact:** in-flight tasks go unsupervised for extended periods; decisions and ready PRs are missed.
+- **Suspected root cause:** `fm-watch.sh` is one-shot and a turn ended without re-arming it via `fm-watch-arm.sh`, or it was fire-and-forgotten with a shell `&` and reaped.
+- **Candidate fix / tool:** always re-arm through the harness's tracked background mechanism every wake/recovery turn; the durable wake queue, `fm-guard.sh` liveness banner, and the `/afk` daemon are the backstops.
+- **Status:** fix-identified
+- **Reported:** 2026-06-27
+
+### P-seed-nomistakes-repo-serialization - no-mistakes serializes per repo
+
+- **Problem:** only one no-mistakes validation pipeline can run per repo at a time.
+- **Symptom:** a second ship task's run on the same repo blocks until the first run's PR is merged or aborted.
+- **Impact:** concurrent ship tasks on one repo stall; a finished-but-unmerged run holds the slot indefinitely.
+- **Suspected root cause:** the pipeline holds a per-repo slot for the lifetime of a run, by design, to keep validation coherent.
+- **Candidate fix / tool:** sequence concurrent ship tasks on the same repo; abort finished-unmerged runs to release the slot; keep cross-repo work parallel.
+- **Status:** wontfix
+- **Reported:** 2026-06-27
+
+### P-seed-worktree-tangle - Primary checkout stranded on a feature branch
+
+- **Problem:** firstmate-on-itself work lands in the primary checkout instead of an isolated worktree.
+- **Symptom:** the firstmate primary (`FM_ROOT`) is on a named non-default branch; `fm-guard.sh` raises the worktree-tangle banner and bootstrap prints a `TANGLE:` line.
+- **Impact:** the primary is off its default branch, which can confuse later fleet actions and other crewmates.
+- **Suspected root cause:** a crewmate sent to work on firstmate itself branched or committed in the primary rather than its own treehouse worktree.
+- **Candidate fix / tool:** the non-destructive restore `git -C <root> checkout <default>`, then re-validate in a real worktree; prevented upstream by `fm-spawn` isolation assertion and the ship-brief first step.
+- **Status:** fix-identified
+- **Reported:** 2026-06-27
+
+### P-seed-long-session-context-growth - Long-session context degrades the harness
+
+- **Problem:** very long sessions grow context until the harness misbehaves.
+- **Symptom:** on Opus, a tool-call decoder-flip can leak malformed tool calls to the captain (tracked as firstmate issue #95).
+- **Impact:** garbled captain-facing output and unreliable tool calls late in long sessions.
+- **Suspected root cause:** unbounded context growth crossing a threshold the decoder handles poorly.
+- **Candidate fix / tool:** context-threshold session breaking; until then, keep sessions bounded and lean on durable state (backlog, status files, meta) so a restart is a non-event.
+- **Status:** triaging
+- **Reported:** 2026-06-27
+
+### P-seed-stale-crewmate - Crewmate stalls without reporting
+
+- **Problem:** a crewmate stops making progress without appending a status line.
+- **Symptom:** a `stale` wake; the pane is waiting, looping, confused, or unresponsive.
+- **Impact:** the task stops silently; without intervention it never completes.
+- **Suspected root cause:** the crewmate hit an obstacle it cannot self-resolve, a trust/interrupt dialog, or a question already answered by its brief.
+- **Candidate fix / tool:** the `stuck-crewmate-recovery` playbook - peek, one-line steer, harness interrupt, relaunch with a progress note, then `failed` with evidence.
+- **Status:** fix-identified
+- **Reported:** 2026-06-27

--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ Claude uses the slash form shown here; codex uses the same names with `$`, such 
 | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
 | `/afk`             | Enter away-mode supervision: the sub-supervisor self-handles routine wakes in bash and escalates only captain-relevant events as one batched digest, cutting supervision cost while you step away |
 | `/updatefirstmate` | Self-update the running firstmate and its secondmates to the latest from origin with fast-forward-only pulls, then re-read instructions and nudge secondmates |
+| `/propose-tool`    | Record a proposal for a better alternative tool (what it replaces, why it is better) as a structured entry in the capabilities manifest ([`CAPABILITIES.md`](CAPABILITIES.md)) and queue it for evaluation |
+| `/report-problem`  | Record a recurring problem (symptom, impact, suspected cause) as a structured entry in the problem registry ([`PROBLEMS.md`](PROBLEMS.md)) and queue it for evaluation |
 
 Agent-only reference skills live under `.agents/skills/` and are loaded by firstmate at the trigger points named in [`AGENTS.md`](AGENTS.md).
 
@@ -132,6 +134,8 @@ Agent-only reference skills live under `.agents/skills/` and are loaded by first
 - [docs/architecture.md](docs/architecture.md) - how the crew, supervision, worktrees, secondmates, and project modes work.
 - [docs/configuration.md](docs/configuration.md) - environment variables, `FM_HOME`, the files you set, and harness support.
 - [docs/scripts.md](docs/scripts.md) - the `bin/` toolbelt reference.
+- [`CAPABILITIES.md`](CAPABILITIES.md) - the living manifest of every tool, MCP server, skill, and quality gate firstmate uses, with their known limits.
+- [`PROBLEMS.md`](PROBLEMS.md) - the registry of recurring problems, named so fixes target causes instead of symptoms.
 - [`AGENTS.md`](AGENTS.md) - firstmate's full operating manual for the orchestrator agent.
 - [CONTRIBUTING.md](CONTRIBUTING.md) - how to contribute, including the dev/test commands.
 

--- a/bin/fm-registry.sh
+++ b/bin/fm-registry.sh
@@ -30,8 +30,25 @@ stamp="$(date '+%Y%m%d-%H%M%S')"
 die() { echo "fm-registry: $*" >&2; exit 1; }
 
 slug() {
-  printf '%s' "$1" | tr '[:upper:]' '[:lower:]' \
-    | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//' | cut -c1-32 | sed -E 's/-+$//'
+  local s
+  s=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]' \
+    | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//' | cut -c1-32 | sed -E 's/-+$//')
+  # A title that is entirely punctuation or non-ASCII slugifies to empty; keep
+  # the id well-formed with a stable fallback rather than emitting a trailing dash.
+  [ -n "$s" ] || s=entry
+  printf '%s' "$s"
+}
+
+# Resolve a collision-free id by appending -2, -3, ... when a heading with the
+# same base id already exists in the target registry, so two submissions in the
+# same second (the timestamp resolution) cannot overwrite or duplicate an id.
+unique_id() {
+  local base=$1 file=$2 id=$1 n=1
+  while [ -f "$file" ] && grep -qF "### $id - " "$file"; do
+    n=$((n + 1))
+    id="$base-$n"
+  done
+  printf '%s' "$id"
 }
 
 ensure_queue() {
@@ -67,7 +84,11 @@ case "$cmd" in
     [ -n "$replaces" ] || die "missing required --replaces"
     [ -n "$why" ]      || die "missing required --why"
     [ -f "$CAP" ]      || die "registry not found: $CAP"
-    id="T-$stamp-$(slug "$tool")"
+    id="$(unique_id "T-$stamp-$(slug "$tool")" "$CAP")"
+    # Preflight the queue first: if data/ cannot be created we die here, before
+    # the tracked registry is mutated, so we never leave a recorded entry with no
+    # queued evaluation.
+    ensure_queue
     {
       echo
       echo "### $id - $tool"
@@ -78,7 +99,6 @@ case "$cmd" in
       echo "- **Status:** proposed"
       echo "- **Proposed:** $today"
     } >> "$CAP"
-    ensure_queue
     echo "- [ ] evaluate tool proposal $id ($tool, replaces $replaces) -> CAPABILITIES.md (filed $today)" >> "$QUEUE"
     echo "recorded $id in CAPABILITIES.md and queued its evaluation in $QUEUE"
     ;;
@@ -99,7 +119,11 @@ case "$cmd" in
     [ -n "$impact" ]  || die "missing required --impact"
     [ -n "$cause" ]   || die "missing required --cause"
     [ -f "$PROB" ]    || die "registry not found: $PROB"
-    id="P-$stamp-$(slug "$problem")"
+    id="$(unique_id "P-$stamp-$(slug "$problem")" "$PROB")"
+    # Preflight the queue first: if data/ cannot be created we die here, before
+    # the tracked registry is mutated, so we never leave a recorded entry with no
+    # queued evaluation.
+    ensure_queue
     {
       echo
       echo "### $id - $problem"
@@ -111,7 +135,6 @@ case "$cmd" in
       echo "- **Status:** reported"
       echo "- **Reported:** $today"
     } >> "$PROB"
-    ensure_queue
     echo "- [ ] evaluate problem $id ($problem) -> PROBLEMS.md (filed $today)" >> "$QUEUE"
     echo "recorded $id in PROBLEMS.md and queued its evaluation in $QUEUE"
     ;;

--- a/bin/fm-registry.sh
+++ b/bin/fm-registry.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Append a structured entry to a firstmate registry and queue an evaluation.
+# Backs the captain-invocable propose-tool and report-problem skills so every
+# entry lands in the tracked registry with the exact, consistent schema instead
+# of being hand-written (and drifting) per submission.
+#   propose-tool  -> appends a "Proposed tools" entry to CAPABILITIES.md
+#   report-problem -> appends a problem entry to PROBLEMS.md
+# Both also append a line to the fleet-local evaluation queue (data/, gitignored)
+# so firstmate later dispatches the evaluation that closes the loop: problem or
+# proposal recorded -> candidate evaluated -> capability added -> manifest +
+# playbook updated. The tracked registries are repo files (FM_ROOT); the queue is
+# operational (FM_HOME/data), matching the rest of bin/.
+# Usage:
+#   fm-registry.sh propose-tool   --tool NAME --replaces WHAT --why TEXT [--notes TEXT]
+#   fm-registry.sh report-problem --problem TITLE --symptom TEXT --impact TEXT --cause TEXT [--fix TEXT]
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
+
+CAP="$FM_ROOT/CAPABILITIES.md"
+PROB="$FM_ROOT/PROBLEMS.md"
+QUEUE="$DATA/evaluation-queue.md"
+
+today="$(date '+%Y-%m-%d')"
+stamp="$(date '+%Y%m%d-%H%M%S')"
+
+die() { echo "fm-registry: $*" >&2; exit 1; }
+
+slug() {
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]' \
+    | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//' | cut -c1-32 | sed -E 's/-+$//'
+}
+
+ensure_queue() {
+  [ -d "$DATA" ] || mkdir -p "$DATA"
+  if [ ! -f "$QUEUE" ]; then
+    {
+      echo "# Evaluation queue (fleet-local)"
+      echo
+      echo "Proposals and problems filed by the propose-tool and report-problem skills, awaiting firstmate evaluation."
+      echo "Each line names the tracked-registry entry it came from; resolve one by dispatching a scout or ship task, then update that entry's Status in CAPABILITIES.md / PROBLEMS.md."
+      echo "This file is fleet-local (under data/, gitignored); the registries it points at are tracked."
+      echo
+    } > "$QUEUE"
+  fi
+}
+
+cmd="${1:-}"
+[ $# -gt 0 ] && shift || true
+
+case "$cmd" in
+  propose-tool)
+    tool=""; replaces=""; why=""; notes=""
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --tool)     [ $# -ge 2 ] || die "--tool needs a value";     tool="$2";     shift 2;;
+        --replaces) [ $# -ge 2 ] || die "--replaces needs a value"; replaces="$2"; shift 2;;
+        --why)      [ $# -ge 2 ] || die "--why needs a value";      why="$2";      shift 2;;
+        --notes)    [ $# -ge 2 ] || die "--notes needs a value";    notes="$2";    shift 2;;
+        *) die "unknown flag: $1";;
+      esac
+    done
+    [ -n "$tool" ]     || die "missing required --tool"
+    [ -n "$replaces" ] || die "missing required --replaces"
+    [ -n "$why" ]      || die "missing required --why"
+    [ -f "$CAP" ]      || die "registry not found: $CAP"
+    id="T-$stamp-$(slug "$tool")"
+    {
+      echo
+      echo "### $id - $tool"
+      echo "- **Tool:** $tool"
+      echo "- **Replaces:** $replaces"
+      echo "- **Why better:** $why"
+      [ -n "$notes" ] && echo "- **Notes:** $notes"
+      echo "- **Status:** proposed"
+      echo "- **Proposed:** $today"
+    } >> "$CAP"
+    ensure_queue
+    echo "- [ ] evaluate tool proposal $id ($tool, replaces $replaces) -> CAPABILITIES.md (filed $today)" >> "$QUEUE"
+    echo "recorded $id in CAPABILITIES.md and queued its evaluation in $QUEUE"
+    ;;
+  report-problem)
+    problem=""; symptom=""; impact=""; cause=""; fix=""
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --problem) [ $# -ge 2 ] || die "--problem needs a value"; problem="$2"; shift 2;;
+        --symptom) [ $# -ge 2 ] || die "--symptom needs a value"; symptom="$2"; shift 2;;
+        --impact)  [ $# -ge 2 ] || die "--impact needs a value";  impact="$2";  shift 2;;
+        --cause)   [ $# -ge 2 ] || die "--cause needs a value";   cause="$2";   shift 2;;
+        --fix)     [ $# -ge 2 ] || die "--fix needs a value";     fix="$2";     shift 2;;
+        *) die "unknown flag: $1";;
+      esac
+    done
+    [ -n "$problem" ] || die "missing required --problem"
+    [ -n "$symptom" ] || die "missing required --symptom"
+    [ -n "$impact" ]  || die "missing required --impact"
+    [ -n "$cause" ]   || die "missing required --cause"
+    [ -f "$PROB" ]    || die "registry not found: $PROB"
+    id="P-$stamp-$(slug "$problem")"
+    {
+      echo
+      echo "### $id - $problem"
+      echo "- **Problem:** $problem"
+      echo "- **Symptom:** $symptom"
+      echo "- **Impact:** $impact"
+      echo "- **Suspected root cause:** $cause"
+      echo "- **Candidate fix / tool:** ${fix:-TBD - to be evaluated}"
+      echo "- **Status:** reported"
+      echo "- **Reported:** $today"
+    } >> "$PROB"
+    ensure_queue
+    echo "- [ ] evaluate problem $id ($problem) -> PROBLEMS.md (filed $today)" >> "$QUEUE"
+    echo "recorded $id in PROBLEMS.md and queued its evaluation in $QUEUE"
+    ;;
+  ""|-h|--help)
+    sed -n '13,15p' "$0" | sed 's/^# \{0,1\}//'
+    ;;
+  *)
+    die "unknown subcommand: $cmd (expected propose-tool or report-problem)"
+    ;;
+esac

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -34,3 +34,4 @@ Each file also starts with a short header comment.
 | `fm-teardown.sh`         | Return a clean, landed ship worktree or retire/release a secondmate home; requires scout reports, checks child work, and prints the backlog reminder |
 | `fm-harness.sh`          | Detect the running harness; resolve the effective crewmate harness                                                  |
 | `fm-lock.sh`             | Per-home firstmate session lock                                                                                     |
+| `fm-registry.sh`         | Append a structured `propose-tool` or `report-problem` entry to the tracked `CAPABILITIES.md` / `PROBLEMS.md` registry and queue its evaluation in the fleet-local queue |

--- a/tests/fm-registry.test.sh
+++ b/tests/fm-registry.test.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# Behavior tests for bin/fm-registry.sh - the helper backing the captain-invocable
+# propose-tool and report-problem skills.
+#
+# The helper's whole job is to append a schema-consistent entry to the right
+# tracked registry (CAPABILITIES.md / PROBLEMS.md) AND queue an evaluation in the
+# fleet-local queue, so proposals and problems are named and tracked instead of
+# hand-written (and drifting) per submission. These cases pin:
+#   - propose-tool appends the documented Tool/Replaces/Why better/Notes/Status/
+#     Proposed schema to CAPABILITIES.md and a pointer line to the queue.
+#   - report-problem appends the documented Problem/Symptom/Impact/Suspected root
+#     cause/Candidate fix/tool/Status/Reported schema to PROBLEMS.md and a queue line.
+#   - the queue file is created with its header on first use.
+#   - duplicate ids in the same timestamp second get a -N suffix (no overwrite).
+#   - a punctuation/non-ASCII-only title slugifies to the `entry` fallback.
+#   - report-problem without --fix records the documented TBD placeholder.
+#   - missing required flags / unknown subcommand fail non-zero with a message.
+#   - queue preflight: if data/ cannot be created, the tracked registry is NOT
+#     mutated (no recorded entry without a queued evaluation).
+# All hermetic over copies of the real registries under a temp FM_ROOT.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+REG="$ROOT/bin/fm-registry.sh"
+TMP_ROOT=$(fm_test_tmproot fm-registry)
+
+# A fresh sandbox FM_ROOT seeded with copies of the real tracked registries, so
+# appends land against the real document structure. Echoes the sandbox path.
+make_sandbox() {
+  local dir=$1
+  mkdir -p "$dir"
+  cp "$ROOT/CAPABILITIES.md" "$dir/CAPABILITIES.md"
+  cp "$ROOT/PROBLEMS.md" "$dir/PROBLEMS.md"
+  printf '%s\n' "$dir"
+}
+
+# Run the helper with the sandbox as FM_ROOT/FM_HOME (so the queue lands under
+# <sandbox>/data). Caller captures $? for exit-code assertions.
+run_registry() {
+  local home=$1
+  shift
+  FM_ROOT_OVERRIDE="$home" FM_HOME="$home" "$REG" "$@" 2>&1
+}
+
+# --- propose-tool: schema + queue -------------------------------------------
+
+test_propose_tool_records_and_queues() {
+  local home out cap queue entry
+  home=$(make_sandbox "$TMP_ROOT/propose")
+  cap="$home/CAPABILITIES.md"
+  queue="$home/data/evaluation-queue.md"
+
+  out=$(run_registry "$home" propose-tool \
+    --tool "ripgrep" \
+    --replaces "grep for fleet-wide search" \
+    --why "much faster on large clones" \
+    --notes "install via brew"); status=$?
+  expect_code 0 "$status" "propose-tool should succeed"
+  assert_contains "$out" "recorded" "propose-tool did not confirm the recording"
+  assert_contains "$out" "CAPABILITIES.md" "propose-tool did not name the registry"
+  assert_contains "$out" "evaluation-queue.md" "propose-tool did not name the queue"
+
+  # The appended entry carries every documented field, in order, with values.
+  entry=$(awk '/^### T-.*ripgrep/{p=1} p{print} p&&/Proposed:/{exit}' "$cap")
+  assert_contains "$entry" "### T-" "appended id is not the timestamped T- form"
+  assert_contains "$entry" "- **Tool:** ripgrep" "missing Tool field"
+  assert_contains "$entry" "- **Replaces:** grep for fleet-wide search" "missing Replaces field"
+  assert_contains "$entry" "- **Why better:** much faster on large clones" "missing Why better field"
+  assert_contains "$entry" "- **Notes:** install via brew" "missing Notes field"
+  assert_contains "$entry" "- **Status:** proposed" "missing/!proposed Status field"
+  assert_contains "$entry" "- **Proposed:**" "missing Proposed date field"
+
+  # The queue was created with its header and a pointer line naming the entry.
+  assert_present "$queue" "evaluation queue was not created"
+  assert_grep "# Evaluation queue (fleet-local)" "$queue" "queue is missing its header"
+  assert_grep "evaluate tool proposal" "$queue" "queue is missing the proposal pointer line"
+  assert_grep "-> CAPABILITIES.md" "$queue" "queue line does not point at CAPABILITIES.md"
+  pass "propose-tool: appends the documented schema to CAPABILITIES.md and queues an evaluation"
+}
+
+# --- report-problem: schema + queue + optional --fix default ----------------
+
+test_report_problem_records_and_queues() {
+  local home out prob queue entry
+  home=$(make_sandbox "$TMP_ROOT/report")
+  prob="$home/PROBLEMS.md"
+  queue="$home/data/evaluation-queue.md"
+
+  out=$(run_registry "$home" report-problem \
+    --problem "Steers get dropped mid-turn" \
+    --symptom "a sent line never reaches the crewmate" \
+    --impact "wasted turns re-sending" \
+    --cause "send raced the busy signature" \
+    --fix "settle before send"); status=$?
+  expect_code 0 "$status" "report-problem should succeed"
+  assert_contains "$out" "PROBLEMS.md" "report-problem did not name the registry"
+
+  entry=$(awk '/^### P-.*Steers/{p=1} p{print} p&&/Reported:/{exit}' "$prob")
+  assert_contains "$entry" "### P-" "appended id is not the timestamped P- form"
+  assert_contains "$entry" "- **Problem:** Steers get dropped mid-turn" "missing Problem field"
+  assert_contains "$entry" "- **Symptom:** a sent line never reaches the crewmate" "missing Symptom field"
+  assert_contains "$entry" "- **Impact:** wasted turns re-sending" "missing Impact field"
+  assert_contains "$entry" "- **Suspected root cause:** send raced the busy signature" "missing Suspected root cause field"
+  assert_contains "$entry" "- **Candidate fix / tool:** settle before send" "missing Candidate fix / tool field"
+  assert_contains "$entry" "- **Status:** reported" "missing/!reported Status field"
+  assert_contains "$entry" "- **Reported:**" "missing Reported date field"
+
+  assert_grep "evaluate problem" "$queue" "queue is missing the problem pointer line"
+  assert_grep "-> PROBLEMS.md" "$queue" "queue line does not point at PROBLEMS.md"
+
+  # Optional --fix omitted -> the documented TBD placeholder, not an empty field.
+  out=$(run_registry "$home" report-problem \
+    --problem "No-fix case" \
+    --symptom "s" --impact "i" --cause "c"); status=$?
+  expect_code 0 "$status" "report-problem without --fix should still succeed"
+  entry=$(awk '/^### P-.*No-fix case/{p=1} p{print} p&&/Reported:/{exit}' "$prob")
+  assert_contains "$entry" "- **Candidate fix / tool:** TBD - to be evaluated" \
+    "omitted --fix did not record the TBD placeholder"
+  pass "report-problem: appends the documented schema (and TBD default) to PROBLEMS.md and queues an evaluation"
+}
+
+# --- id collision: same-second submissions never overwrite ------------------
+
+test_unique_id_suffix() {
+  local home cap n
+  home=$(make_sandbox "$TMP_ROOT/collide")
+  cap="$home/CAPABILITIES.md"
+  run_registry "$home" propose-tool --tool "dupe" --replaces "x" --why "y" >/dev/null
+  run_registry "$home" propose-tool --tool "dupe" --replaces "x" --why "y" >/dev/null
+  # Two distinct headings for the same tool, the second carrying a -N suffix.
+  n=$(grep -cE '^### T-[0-9]{8}-[0-9]{6}-dupe(-[0-9]+)? - dupe$' "$cap")
+  [ "$n" -ge 2 ] || fail "expected >=2 distinct dupe ids, got $n"
+  assert_grep "-dupe-2 - dupe" "$cap" "collision did not produce a -2 suffixed id"
+  pass "propose-tool: a colliding id is suffixed -N instead of overwriting"
+}
+
+# --- slug fallback: a title with no slug characters -------------------------
+
+test_slug_fallback() {
+  local home prob
+  home=$(make_sandbox "$TMP_ROOT/slug")
+  prob="$home/PROBLEMS.md"
+  run_registry "$home" report-problem --problem "??? !!!" --symptom s --impact i --cause c >/dev/null
+  assert_grep "-entry - ??? !!!" "$prob" "punctuation-only title did not fall back to the 'entry' slug"
+  assert_no_grep "-- - ??? !!!" "$prob" "fallback id has a malformed empty slug"
+  pass "fm-registry: a no-slug title gets the stable 'entry' id fallback"
+}
+
+# --- input validation -------------------------------------------------------
+
+test_validation() {
+  local home out
+  home=$(make_sandbox "$TMP_ROOT/validate")
+
+  out=$(run_registry "$home" propose-tool --tool "only-tool"); status=$?
+  expect_code 1 "$status" "missing required flag should fail"
+  assert_contains "$out" "missing required --replaces" "missing-flag error did not name the field"
+
+  out=$(run_registry "$home" frobnicate); status=$?
+  expect_code 1 "$status" "unknown subcommand should fail"
+  assert_contains "$out" "unknown subcommand" "unknown subcommand lacked an error"
+
+  out=$(run_registry "$home" report-problem --bogus x); status=$?
+  expect_code 1 "$status" "unknown flag should fail"
+  assert_contains "$out" "unknown flag" "unknown flag lacked an error"
+  pass "fm-registry: missing flags, unknown subcommand, and unknown flags fail non-zero with a message"
+}
+
+# --- preflight: no registry mutation when the queue cannot be created --------
+
+test_queue_preflight_guards_registry() {
+  local home cap before after out
+  home=$(make_sandbox "$TMP_ROOT/preflight")
+  cap="$home/CAPABILITIES.md"
+  before=$(grep -c '^### T-' "$cap")
+  # Force the queue dir uncreatable by rooting it under a regular file, so
+  # ensure_queue's mkdir -p fails before any registry append happens.
+  printf 'i am a file\n' > "$home/blocker"
+  out=$(FM_ROOT_OVERRIDE="$home" FM_HOME="$home" FM_DATA_OVERRIDE="$home/blocker/data" \
+    "$REG" propose-tool --tool "should-not-land" --replaces x --why y 2>&1); status=$?
+  expect_code 1 "$status" "an uncreatable queue dir should fail the run"
+  after=$(grep -c '^### T-' "$cap")
+  [ "$before" = "$after" ] || fail "tracked registry was mutated despite the queue failing ($before -> $after)"
+  assert_no_grep "should-not-land" "$cap" "an entry leaked into the registry without a queued evaluation"
+  pass "fm-registry: a failed queue preflight leaves the tracked registry untouched"
+}
+
+test_propose_tool_records_and_queues
+test_report_problem_records_and_queues
+test_unique_id_suffix
+test_slug_fallback
+test_validation
+test_queue_preflight_guards_registry


### PR DESCRIPTION
## Intent

The developer (acting as captain managing the firstmate orchestration system) directed a crewmate to build a capabilities and problems registry for firstmate-on-itself, working from a written spec at .lavish/firstmate-ios/capabilities-registry-spec.md. The goal was three artifacts: a tracked CAPABILITIES.md living manifest accurately surveying the real environment's tools, MCPs, skills, and quality gates with their limits; a tracked PROBLEMS.md registry using an explicit consistent schema (problem, symptom, impact, suspected root cause, candidate fix/tool, status); and two captain-invocable skills, propose-tool and report-problem, each appending a structured entry to the right registry and queuing an evaluation. They required a minimal AGENTS.md edit (kept in its own section to rebase cleanly against a concurrent watcher fix touching sections 3/5/8) pointing to the manifest and both skills. They explicitly mandated exactly one Codex CLI review pass over the committed diff (checking schema consistency and that skills append valid entries), with real fixes applied and committed but no second pass, before validating through the no-mistakes pipeline.

## What Changed

- Added two tracked registries at the repo root: `CAPABILITIES.md`, a living manifest of tools, MCP servers, skills, and quality gates with their known limits, and `PROBLEMS.md`, a recurring-problem registry with an explicit schema (problem, symptom, impact, suspected root cause, candidate fix/tool, status).
- Added the captain-invocable `propose-tool` and `report-problem` skills plus the shared `bin/fm-registry.sh` helper they call, which appends a schema-exact entry to the matching registry and queues an evaluation pointer; covered by the new hermetic `tests/fm-registry.test.sh` suite.
- Wired the new artifacts into the docs: a new AGENTS.md section 14 pointing to both registries and skills, and updates to `CONTRIBUTING.md`, `README.md`, and `docs/scripts.md`, including a Document-gate sync of the tracked-file lists to include the two new registries.

## Risk Assessment

✅ Low: Additive change of documentation registries plus one well-guarded append helper whose substantive issues were already fixed in a prior review pass; schemas are consistent and only minor latent fragilities remain.

## Testing

Baseline checks (bash -n, --help) passed, then I drove the helper that backs both captain skills end-to-end in a sandboxed FM_ROOT and confirmed propose-tool/report-problem append entries whose fields match the declared registry schemas byte-for-byte and queue a corresponding evaluation line, including all Codex-review hardening paths (collision suffixing, slug fallback, --fix default, input validation, and the queue-preflight guard that prevents an orphaned registry entry). I also reviewed the three docs/skills artifacts and the contained AGENTS.md section 14 for correctness and link resolution. No existing test covered this script, so I added a hermetic `tests/fm-registry.test.sh` (matching the repo's tests/lib.sh convention and CI discovery) that locks in the schema-consistency, queue, and safety behaviors; it passes 6/6. This is a CLI/markdown change with no rendered UI surface, so the reviewer-visible evidence is a CLI transcript plus the generated registry/queue markdown rather than a screenshot. All testing wrote to the evidence dir and temp sandboxes only; the change under test is untouched and the sole working-tree addition is the intentional new test file.

<details>
<summary>Evidence: End-to-end CLI transcript: captain runs /propose-tool and /report-problem (commands, confirmations, generated CAPABILITIES.md/PROBLEMS.md entries, and queued evaluations)</summary>

```text
# fm-registry end-to-end transcript (captain skill flow)

Exercised `bin/fm-registry.sh` (the helper backing /propose-tool and /report-problem)
against copies of the real tracked registries via FM_ROOT_OVERRIDE.

## 1. Captain runs /propose-tool
`` `
$ bin/fm-registry.sh propose-tool --tool "ripgrep (rg)" \
    --replaces "grep for fleet-wide code search" \
    --why "10-50x faster on large clones, respects .gitignore by default, fewer false hits" \
    --notes "already a common dependency; install via brew"
recorded T-20260627-030509-ripgrep-rg in CAPABILITIES.md and queued its evaluation in .../data/evaluation-queue.md
`` `

### -> appended to CAPABILITIES.md "Proposed tools" section
`` `
### T-20260627-030509-ripgrep-rg - ripgrep (rg)
- **Tool:** ripgrep (rg)
- **Replaces:** grep for fleet-wide code search
- **Why better:** 10-50x faster on large clones, respects .gitignore by default, fewer false hits
- **Notes:** already a common dependency; install via brew
- **Status:** proposed
- **Proposed:** 2026-06-27
`` `

## 2. Captain runs /report-problem
`` `
$ bin/fm-registry.sh report-problem --problem "Peeking panes too often burns context budget" \
    --symptom "repeated full-pane peeks during supervision inflate token use late in a session" \
    --impact "faster context growth, earlier decoder-flip risk on long sessions" \
    --cause "defaulting to pane peeks instead of reading the ~30-token status file first" \
    --fix "status-file-first discipline; cap peeks at 40 lines"
recorded P-20260627-030509-peeking-panes-too-often-burns-co in PROBLEMS.md and queued its evaluation in .../data/evaluation-queue.md
`` `

### -> appended to PROBLEMS.md "Registry" section
`` `
### P-20260627-030509-peeking-panes-too-often-burns-co - Peeking panes too often burns context budget
- **Problem:** Peeking panes too often burns context budget
- **Symptom:** repeated full-pane peeks during supervision inflate token use late in a session
- **Impact:** faster context growth, earlier decoder-flip risk on long sessions
- **Suspected root cause:** defaulting to pane peeks instead of reading the ~30-token status file first
- **Candidate fix / tool:** status-file-first discipline; cap peeks at 40 lines
- **Status:** reported
- **Reported:** 2026-06-27
`` `

## 3. Both queued an evaluation (fleet-local data/evaluation-queue.md)
`` `
- [ ] evaluate tool proposal T-20260627-030509-ripgrep-rg (ripgrep (rg), replaces grep for fleet-wide code search) -> CAPABILITIES.md (filed 2026-06-27)
- [ ] evaluate problem P-20260627-030509-peeking-panes-too-often-burns-co (Peeking panes too often burns context budget) -> PROBLEMS.md (filed 2026-06-27)
- [ ] evaluate tool proposal T-20260627-030536-dupe (dupe, replaces x) -> CAPABILITIES.md (filed 2026-06-27)
- [ ] evaluate tool proposal T-20260627-030536-dupe-2 (dupe, replaces x) -> CAPABILITIES.md (filed 2026-06-27)
- [ ] evaluate problem P-20260627-030536-entry (??? 上海 !!!) -> PROBLEMS.md (filed 2026-06-27)
- [ ] evaluate problem P-20260627-030536-nofix-case (nofix case) -> PROBLEMS.md (filed 2026-06-27)
`` `
```
</details>
<details>
<summary>Evidence: Generated proposed-tool entry appended to CAPABILITIES.md (schema-exact)</summary>

```text
### T-20260627-030509-ripgrep-rg - ripgrep (rg)
- **Tool:** ripgrep (rg)
- **Replaces:** grep for fleet-wide code search
- **Why better:** 10-50x faster on large clones, respects .gitignore by default, fewer false hits
- **Notes:** already a common dependency; install via brew
- **Status:** proposed
- **Proposed:** 2026-06-27
```
</details>
<details>
<summary>Evidence: Generated problem entry appended to PROBLEMS.md (schema-exact) + queued evaluations</summary>

```text
### P-20260627-030509-peeking-panes-too-often-burns-co - Peeking panes too often burns context budget
- **Problem:** Peeking panes too often burns context budget
- **Symptom:** repeated full-pane peeks during supervision inflate token use late in a session
- **Impact:** faster context growth, earlier decoder-flip risk on long sessions
- **Suspected root cause:** defaulting to pane peeks instead of reading the ~30-token status file first
- **Candidate fix / tool:** status-file-first discipline; cap peeks at 40 lines
- **Status:** reported
- **Reported:** 2026-06-27

# evaluation-queue.md:
- [ ] evaluate tool proposal T-20260627-030509-ripgrep-rg (ripgrep (rg), replaces grep for fleet-wide code search) -> CAPABILITIES.md (filed 2026-06-27)
- [ ] evaluate problem P-20260627-030509-peeking-panes-too-often-burns-co (Peeking panes too often burns context budget) -> PROBLEMS.md (filed 2026-06-27)
```
</details>
<details>
<summary>Evidence: New hermetic regression test (added, 6/6 pass)</summary>

Source: [New hermetic regression test (added, 6/6 pass)](https://github.com/kunchenguid/firstmate/blob/3aba48b57a4abae65a747ee39e3760a25d092707/tests/fm-registry.test.sh)

```text
ok - propose-tool: appends the documented schema to CAPABILITIES.md and queues an evaluation
ok - report-problem: appends the documented schema (and TBD default) to PROBLEMS.md and queues an evaluation
ok - propose-tool: a colliding id is suffixed -N instead of overwriting
ok - fm-registry: a no-slug title gets the stable 'entry' id fallback
ok - fm-registry: missing flags, unknown subcommand, and unknown flags fail non-zero with a message
ok - fm-registry: a failed queue preflight leaves the tracked registry untouched
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ℹ️ `bin/fm-registry.sh:101` - fm-registry.sh appends new entries to the end of the file (`&gt;&gt; &#34;$CAP&#34;` / `&gt;&gt; &#34;$PROB&#34;`), relying on &#34;## Proposed tools&#34; and &#34;## Registry&#34; each being the last section. The CAPABILITIES.md anchor marker (&#34;propose-tool entries are appended below this line&#34;) is decorative - the script never seeks to it. If any section is ever added below these, generated entries will silently land in the wrong section. Consider inserting at the anchor marker (or asserting the target section is last) to make the contract robust.
- ℹ️ `bin/fm-registry.sh:142` - The help/usage output is produced by `sed -n &#39;13,15p&#39; &#34;$0&#34;`, hard-coding the line range of the usage comment block. Editing the header comment shifts those lines and silently corrupts `--help` output. A heredoc usage() or matching the `# Usage:` anchor would be self-maintaining.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash -n bin/fm-registry.sh` and `bin/fm-registry.sh --help` (parse + usage)</code>
- <code>End-to-end captain flow in a sandboxed FM_ROOT (copies of real registries): `bin/fm-registry.sh propose-tool --tool ... --replaces ... --why ... --notes ...` and `bin/fm-registry.sh report-problem --problem ... --symptom ... --impact ... --cause ... --fix ...` -&gt; verified schema-exact entries appended to CAPABILITIES.md / PROBLEMS.md and pointer lines added to data/evaluation-queue.md</code>
- <code>Robustness: id-collision suffixing (same-second dupe -&gt; `-2`), slug fallback (`??? 上海 !!!` -&gt; `entry`), omitted `--fix` -&gt; `TBD - to be evaluated`, missing required flag / unknown subcommand / unknown flag all exit 1 with a message</code>
- `Safety invariant: forced data/ creation failure (FM_DATA_OVERRIDE under a regular file) -> script exits 1 and the tracked registry is NOT mutated (no orphaned entry)`
- <code>Programmatic label comparison: report-problem/propose-tool emitted `**Field:**` labels vs the schemas declared in PROBLEMS.md/CAPABILITIES.md headers (exact match; only optional Resolved omitted by design); skill doc relative links resolve to repo-root registries</code>
- <code>Added and ran `tests/fm-registry.test.sh` (hermetic, matches existing tests/lib.sh convention, picked up by CI&#39;s `tests/*.test.sh` loop) - 6/6 cases pass</code>

</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed ✅</summary>

- ℹ️ `AGENTS.md:46` - AGENTS.md section 1&#39;s &#39;Shared, tracked material means ...&#39; enumeration (line 46) and the section 2 layout tree both omit the two new tracked top-level files CAPABILITIES.md and PROBLEMS.md. Left unchanged because the change deliberately isolated its AGENTS.md edit to a single new section (14) for clean rebasing against a concurrent watcher fix; folding the two files into those enumerations is a judgment call about prioritizing accuracy over that isolation. The parallel list in CONTRIBUTING.md was updated since it carries no such constraint.

🔧 Fix: sync tracked-file lists with new registries
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
