### PR TITLE
feat(supervise): make watcher liveness daemon-owned and always-on

### DIFF
--- a/.agents/skills/afk/SKILL.md
+++ b/.agents/skills/afk/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: afk
-description: Enter away-mode supervision. Use when the user invokes /afk (e.g. "/afk", "/afk back in an hour", "going afk"). Sets a durable away-mode flag so the sub-supervisor daemon can self-handle routine wakes and escalate only captain-relevant events as one batched digest, cutting supervision token cost during walk-away stretches. Exit is automatic; any real (unmarked) message returns to full per-wake responsiveness.
+description: Enter away-mode supervision. Use when the user invokes /afk (e.g. "/afk", "/afk back in an hour", "going afk"). Sets a durable away-mode flag so the always-on supervisor daemon switches to away mode, self-handles routine wakes, and escalates only captain-relevant events as one batched digest, cutting supervision token cost during walk-away stretches. Exit is automatic; any real (unmarked) message returns to full per-wake responsiveness.
 user-invocable: true
 ---
 

--- a/.agents/skills/afk/SKILL.md
+++ b/.agents/skills/afk/SKILL.md
@@ -6,11 +6,21 @@ user-invocable: true
 
 # afk
 
-Away-mode supervision. When invoked, `/afk` makes the daemon's token-saving
-tradeoff **consented** and **explicit**: the captain is stepping away, so the
-sub-supervisor may triage routine wakes in bash instead of waking firstmate's
-LLM for each one. Escalations still reach the captain, but as one pre-read,
-batched digest rather than per-wake injections.
+Away-mode supervision. The supervisor daemon **already runs always** (started at
+bootstrap and recovery as the per-home liveness guardian, section 8). `/afk` does
+not start a daemon; it flips that one long-lived process's injection **policy**
+from present to away, and makes the token-saving tradeoff **consented** and
+**explicit**: the captain is stepping away, so the daemon may triage routine wakes
+in bash instead of waking firstmate's LLM for each one, and escalations reach the
+captain as one pre-read, batched digest rather than per-wake injections.
+
+The daemon's two modes (one process, `state/.afk` is the toggle):
+
+- **Present (afk off):** liveness guardian only - it does not own the watcher or
+  process wakes; it restores a lapsed watcher and nudges firstmate once, and
+  never injects a routine wake.
+- **Away (afk on):** it owns the watcher, self-handles routine wakes, and
+  escalates a batched captain-relevant digest.
 
 ## What it does
 
@@ -19,22 +29,20 @@ batched digest rather than per-wake injections.
    date '+%s' > state/.afk
    ```
    This file survives a firstmate restart: recovery re-enters afk if the
-   flag is present.
+   flag is present. The running daemon picks up the flag on its next cycle and
+   transitions to away mode in-process (it takes watcher ownership), with no
+   restart.
 
-2. **Ensure the sub-supervisor daemon is running.** Check the pid file; start
-   the daemon only if it is dead or absent:
+2. **Ensure the daemon is running** (it should already be, from bootstrap):
    ```sh
-   if [ -f state/.supervise-daemon.pid ] && kill -0 "$(cat state/.supervise-daemon.pid)" 2>/dev/null; then
-     : # daemon already alive - it picks up the flag on its next cycle
-   else
-     nohup bin/fm-supervise-daemon.sh >/dev/null 2>&1 &
-   fi
+   bin/fm-guardian-arm.sh   # singleton-safe: no-op if a live daemon already holds this home
    ```
-   The daemon is **presence-gated**: it injects escalations only while
-   `state/.afk` exists, and stays quiet otherwise.
+   The away-mode escalation injection is **presence-gated** by `state/.afk`; the
+   present-mode liveness nudge is the only thing the daemon injects while afk is
+   off.
 
-3. **Do not separately arm `fm-watch.sh`.** The daemon manages the watcher as
-   its child; the singleton lock no-ops a stray arm harmlessly.
+3. **Do not separately arm `fm-watch.sh`.** In away mode the daemon owns the
+   watcher; the singleton lock no-ops a stray arm harmlessly.
 
 4. **Acknowledge** to the captain that away-mode is active: the daemon will
    self-handle routine wakes, escalate only captain-relevant events, and the
@@ -45,13 +53,16 @@ batched digest rather than per-wake injections.
 No `/back` is needed. The first genuine message is the return signal:
 
 - A message **without** the sentinel marker and **not** starting with `/afk`
-  -> the captain is back. Clear `state/.afk`, stop the daemon, flush one
-  distilled "while you were out" catch-up (drain `state/.wake-queue`, summarize
-  any pending escalations from `state/.subsuper-escalations` and any
+  -> the captain is back. Clear `state/.afk` - this is enough: the daemon
+  transitions back to present/liveness-guardian mode on its own and keeps
+  guaranteeing watcher liveness, so **do not stop it**. Flush one distilled
+  "while you were out" catch-up (drain `state/.wake-queue`, summarize any pending
+  escalations from `state/.subsuper-escalations` and any
   `state/.subsuper-inject-wedged` marker), and resume full per-wake
   responsiveness (arm `bin/fm-watch-arm.sh`).
 - A message **with** the sentinel marker (`FM_INJECT_MARK`, ASCII 0x1f) -> it
-  is a daemon escalation; stay afk and process it.
+  is a daemon escalation (away mode) or a liveness nudge (present mode); stay in
+  the current mode and process it.
 - Re-invoking `/afk` while already away -> stay afk (refresh the flag); this
   does **not** trigger an exit.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,11 +85,11 @@ state/               volatile runtime signals; gitignored
   <id>.meta          written by fm-spawn: window=, worktree=, project=, harness=, kind=, mode=, yolo=; kind=secondmate also records home= and projects= (fm-pr-check appends pr= and verified pr_head= when available)
   <id>.check.sh      optional slow poll you write per task (e.g. merged-PR check)
   .wake-queue        durable queued wakes: epoch<TAB>seq<TAB>kind<TAB>key<TAB>payload
-  .afk               durable away-mode flag; present = sub-supervisor may inject escalations (set by /afk, cleared on user return)
+  .afk               durable away-mode flag; in-process policy toggle for the always-on daemon (present=on -> away/own-watcher+escalate, absent=off -> present/liveness-guardian); set by /afk, cleared on user return; never starts/stops the daemon
   .watch.lock .wake-queue.lock watcher singleton and queue serialization locks
   .hash-* .count-* .stale-* .seen-* .last-* .heartbeat-streak   watcher internals; never touch
-  .last-watcher-beat watcher liveness beacon, touched every poll; fm-guard.sh reads it
-  .subsuper-* .supervise-daemon.*   sub-supervisor internals; never touch
+  .last-watcher-beat watcher liveness beacon, touched every poll; the always-on daemon's liveness guardian and fm-guard.sh both read it
+  .subsuper-* .supervise-daemon.* .guardian-*   always-on supervisor daemon internals; never touch
 .no-mistakes/        local validation state and evidence; gitignored
 ```
 
@@ -102,6 +102,7 @@ Bootstrap is detect, then consent, then install.
 Never install anything the captain has not approved in this session.
 
 Run `bin/fm-bootstrap.sh`.
+Bootstrap also starts the always-on supervisor daemon for this home via `bin/fm-guardian-arm.sh` (best-effort, quiet, singleton-safe: a no-op if a live daemon already holds this home), so watcher liveness is daemon-guaranteed from session start rather than dependent on per-turn re-arm discipline (section 8).
 Bootstrap also refreshes the fleet via `bin/fm-fleet-sync.sh`, best-effort and non-fatal, under the hard-rule exception in section 1.
 Set `FM_FLEET_PRUNE=0` to temporarily disable that branch pruning.
 Bootstrap also sweeps every live secondmate home, fast-forwarding each one's worktree to firstmate's own current default-branch commit so the fleet stays converged on whatever version firstmate is on.
@@ -170,10 +171,10 @@ Reconcile reality with your records before doing anything else:
 7. Do not reconstruct a secondmate's whole tree from the main home.
    The main firstmate reconciles only direct reports.
    Each secondmate is a firstmate in its own home, so it reconciles only work that is already its own and then idles; it never creates new work during recovery.
-8. If `state/.afk` is present, load `/afk`, ensure the daemon is running, do not arm the one-shot watcher because the daemon owns it, and resume away-mode supervision.
+8. Ensure the always-on supervisor daemon is running for this home with `bin/fm-guardian-arm.sh` (singleton-safe; it may well have survived the restart, since it is detached and independent of your process - in which case this no-ops and it already covered the restart gap). If `state/.afk` is present, load `/afk`, and because the daemon is in away mode and owns the watcher, do not arm the one-shot watcher; resume away-mode supervision. If `state/.afk` is absent, the daemon is the present-mode liveness guardian and you re-arm the watcher as normal (section 8).
 9. Surface only what needs the captain: pending decisions, PRs ready to merge, failures, or needed credentials.
    If there is nothing that needs them, say nothing and resume.
-10. Handle drained wakes, then follow the section 8 watcher checklist; if `state/.afk` exists, the daemon owns the watcher.
+10. Handle drained wakes, then follow the section 8 watcher checklist; if `state/.afk` exists, the daemon owns the watcher, otherwise re-arm it yourself with the guardian as the backstop.
 
 A firstmate restart must be a non-event.
 All truth lives in tmux, state files, data/backlog.md, data/secondmates.md, persistent secondmate homes, and treehouse; your conversation memory is a cache.
@@ -424,27 +425,37 @@ From there the task is an ordinary ship task through its mode-specific validatio
 
 ## 8. Supervision protocol
 
-The watcher is the backbone.
-Whenever at least one task is in flight, keep `bin/fm-watch.sh` running through a harness-tracked `bin/fm-watch-arm.sh` background task.
+The watcher is the backbone, and a per-home supervisor daemon guarantees it stays alive.
+Whenever at least one task is in flight, the watcher (`bin/fm-watch.sh`) must be running.
 It costs zero tokens while running and exits with one reason line when something needs you.
 It also writes each detected wake to the durable queue at `state/.wake-queue` before advancing suppression markers such as `.seen-*`, `.stale-*`, `.last-check`, or `.last-heartbeat`.
 At the start of every wake-handling turn and every recovery turn, run `bin/fm-wake-drain.sh` before peeking panes, reading status files beyond the reason line, or starting new work.
 The printed one-shot reason line is still useful, but the drained queue is the lossless backlog.
-After handling drained wakes, re-arm the watcher before you end the turn by running `bin/fm-watch-arm.sh` as a background task.
+
+**Liveness is daemon-guaranteed, not discipline-dependent.**
+The supervisor daemon (`bin/fm-supervise-daemon.sh`) runs always - started at bootstrap and recovery via `bin/fm-guardian-arm.sh`, not only by `/afk` - as a long-lived, per-home liveness guardian with two modes that `state/.afk` toggles in-process:
+
+- **Present (afk off, the default):** the daemon does **not** own the watcher and does not process wakes - your own re-arm is primary. Every guardian tick it checks one thing: is work in flight **and** is the liveness beacon (`state/.last-watcher-beat`) missing or older than `FM_GUARD_GRACE`? If so, your per-turn re-arm has genuinely lapsed (not a brief sub-grace gap), so the guardian restores the watcher itself via the singleton-safe path **and** injects exactly one nudge so you drain the wake-queue and resume. It never injects for a routine wake - only a detected liveness lapse. So a missed re-arm self-heals within a tick instead of silently stopping supervision indefinitely (the failure that once cost ~69 minutes).
+- **Away (afk on):** the daemon owns the watcher, self-handles routine wakes, and escalates a batched captain-relevant digest, exactly as before. `/afk` only flips this injection policy; it never starts or stops the daemon.
+
+So re-arming the watcher each turn is now a redundant backstop, not the single load-bearing step.
+You still re-arm - it keeps the present-mode watcher healthy and the guardian idle - but a forgotten re-arm no longer takes supervision down.
+After handling drained wakes, re-arm the watcher before you end the turn by running `bin/fm-watch-arm.sh` as a harness-tracked background task.
 Arm or re-arm the watcher only through the harness's own tracked background mechanism - the one that survives the call and notifies you when the process exits - so the re-arm actually persists and the next wake reaches you.
-Never fire-and-forget the watcher with a shell `&` inside another call: that backgrounded child is reaped when the call returns, so supervision silently stops, and worse, the dying process reports a false "already running" that hides the gap.
+Never fire-and-forget the watcher with a shell `&` inside another call: that backgrounded child is reaped when the call returns; the guardian would restore it within a tick, but you would lose the harness notification on its next wake.
 `bin/fm-watch-arm.sh` is self-verifying: it confirms a genuinely live watcher with a fresh beacon and prints exactly one honest status line - `watcher: started ...`, `watcher: healthy ...`, or `watcher: FAILED - no live watcher with a fresh beacon` (which exits non-zero) - so treat that line, not a process count or an unverified "already running", as the source of truth for watcher state.
-The watcher is singleton-safe: acquisition is race-proof, so under any number of concurrent arms at most one watcher ever holds this home's lock, and a duplicate that somehow starts self-evicts within one poll once it sees the lock no longer names it.
+The watcher is singleton-safe: acquisition is race-proof, so under any number of concurrent arms - including the guardian restoring it at the same moment you re-arm - at most one watcher ever holds this home's lock, and a duplicate that somehow starts self-evicts within one poll once it sees the lock no longer names it.
 If one is already alive with a fresh liveness beacon, another invocation exits cleanly instead of creating a duplicate watcher; if the live holder's beacon is stale, the new invocation exits with an actionable failure.
 Re-arming is the primary model: just run `bin/fm-watch-arm.sh` and let the singleton lock no-op when a healthy watcher is already alive.
 If a forced restart is ever genuinely needed, use `bin/fm-watch-arm.sh --restart`, which stops only this home's watcher (the pid recorded in this home's `state/.watch.lock`) and starts a fresh one.
-Never `pkill -f bin/fm-watch.sh`: that pattern matches every firstmate home's watcher, including secondmate homes that run the same script, so a broad pkill from one home kills sibling homes' watchers.
-Away-mode supervision is provided by the `/afk` skill and its daemon; while `state/.afk` exists, the daemon owns the watcher.
+The guardian is home-scoped the same way: it restores and stops only this home's watcher and signals only pids the lock proves are this home's, never a broad `pkill`.
+Never `pkill -f bin/fm-watch.sh` or `pkill -f fm-supervise-daemon`: those patterns match every firstmate home's watcher and daemon, including secondmate homes that run the same scripts, so a broad pkill from one home kills sibling homes' supervision.
 Waiting on the watcher is intentionally silent.
 After arming it, do not send idle progress updates to the captain; wait until it returns `signal`, `stale`, `check`, or `heartbeat`, unless the captain asks for status.
 Empty polls, elapsed waiting time, and "still no change" are tool bookkeeping, not conversational progress.
 
 ```sh
+bin/fm-guardian-arm.sh     # start the always-on supervisor daemon (liveness guardian) if not running; no-ops if alive
 bin/fm-watch-arm.sh        # safe verified re-arm; run as harness-tracked background; no-ops if healthy
 bin/fm-watch-arm.sh --restart  # home-scoped forced restart; never a broad pkill
 bin/fm-watch.sh            # the watcher itself; exits with: signal|stale|check|heartbeat
@@ -471,15 +482,16 @@ A secondmate may be sitting on its own watcher with no visible pane changes, so 
 `fm-watch.sh` therefore skips stale-pane wakes for windows whose meta records `kind=secondmate`.
 This exception is narrow: ordinary crewmates still trip stale detection when their pane stops changing without a busy signature.
 
-**Watcher liveness is guarded, not just disciplined.**
-Arming the watcher is the last action of every wake-handling turn - but the protocol no longer relies on remembering that.
+**Watcher liveness is guaranteed by the daemon, then guarded as defense in depth.**
+The always-on supervisor daemon is the structural guarantee: while present it restores a lapsed watcher within a tick and nudges you once, so a forgotten re-arm self-heals rather than stranding supervision.
+The pull-based guard is the second, independent layer in case the daemon itself is somehow down.
 While running, `fm-watch.sh` touches `state/.last-watcher-beat` every poll cycle.
 The supervision scripts (`fm-peek`, `fm-send`, `fm-spawn`, `fm-teardown`, `fm-pr-check`, `fm-promote`, `fm-review-diff`, `fm-fleet-sync`, `fm-update`) call `bin/fm-guard.sh` first, which warns to stderr when any task is in flight (`state/*.meta` exists) but queued wakes are pending, or that beacon is missing or older than `FM_GUARD_GRACE` (default 300s).
 The no-watcher case leads with a prominent, bordered ●-marked banner (in-flight count, beacon age, and the exact one-line re-arm command) so it reads as an alarm rather than a buried stderr line you can skim past.
-So the next time you touch the fleet with queued wakes or no watcher alive, the tool output itself tells you what to do - a pull-based guard that works on any harness, since it rides the script output you already read rather than a harness-specific hook.
+So even if both the daemon and your re-arm have lapsed, the next time you touch the fleet with queued wakes or no watcher alive, the tool output itself tells you what to do - a pull-based guard that works on any harness, since it rides the script output you already read rather than a harness-specific hook.
 The grace window keeps normal handling (watcher briefly down between a wake and its re-arm) silent.
 If a guard warning says queued wakes are pending, drain them before doing anything else.
-If a guard warning says watcher liveness is stale, arm `bin/fm-watch-arm.sh` after draining any queued wakes.
+If a guard warning says watcher liveness is stale, arm `bin/fm-watch-arm.sh` after draining any queued wakes; if it persists, confirm the daemon is up with `bin/fm-guardian-arm.sh`.
 
 `fm-guard.sh` carries a second, independent alarm in the same bordered ●-marked style: the **worktree-tangle** guard.
 Firstmate is a treehouse-pooled git repo of itself - the primary checkout (the repo root, `FM_ROOT`) and every crewmate worktree and secondmate home are linked worktrees of one repo - and the primary must stay on its default branch.
@@ -503,11 +515,12 @@ Invoke the `/afk` skill when the captain says `/afk`, says they are going afk, `
 The skill owns the full daemon procedure: classification policy, batching, injection hardening, max-defer, verified submit, marker stripping, portable lock, dedupe, target discovery, reliability properties, and `FM_INJECT_SKIP`.
 Inline facts that must survive without a loaded skill:
 
-- Every daemon injection is prefixed with `FM_INJECT_MARK`, ASCII unit separator `0x1f`, so internal escalations are distinguishable from a captain message.
-- While `state/.afk` exists, the daemon owns the watcher; do not separately arm `fm-watch-arm.sh` or `fm-watch.sh`.
-- If firstmate receives a marked message while afk is active, it is an internal escalation: stay afk and process it.
+- The supervisor daemon runs **always** (started at bootstrap and recovery via `bin/fm-guardian-arm.sh`), not only under `/afk`. `state/.afk` is a policy toggle inside that one process: on = away (own the watcher, self-handle, escalate digests); off = present (liveness guardian only - restore a lapsed watcher and nudge once, never inject a routine wake). `/afk` and its exit only flip this policy; they never start or stop the daemon.
+- Every daemon injection is prefixed with `FM_INJECT_MARK`, ASCII unit separator `0x1f`, so an internal escalation or a present-mode liveness nudge is distinguishable from a captain message.
+- While `state/.afk` exists, the daemon owns the watcher; do not separately arm `fm-watch-arm.sh` or `fm-watch.sh`. While afk is off, you re-arm the watcher as normal - the daemon only steps in on a detected liveness lapse.
+- If firstmate receives a marked message while afk is active, it is an internal escalation: stay afk and process it. A marked present-mode liveness nudge ("supervision liveness lapsed ...") means drain `state/.wake-queue`, handle, and re-arm; it does not change afk state.
 - If the message starts with `/afk`, stay afk and refresh the flag.
-- Any other unmarked message means the captain is back: clear `state/.afk`, stop the daemon, flush catch-up from `state/.wake-queue`, `state/.subsuper-escalations`, and `state/.subsuper-inject-wedged`, then re-arm normal watcher supervision.
+- Any other unmarked message means the captain is back: clear `state/.afk` (the daemon transitions back to present/liveness-guardian mode on its own - do **not** stop it), flush catch-up from `state/.wake-queue`, `state/.subsuper-escalations`, and `state/.subsuper-inject-wedged`, then re-arm normal watcher supervision.
 - Afk never changes approval authority; PR merges, ask-user findings, destructive actions, irreversible actions, and security-sensitive choices still require the same approval they required before.
 - Bias ambiguous cases toward exit because a present captain beats token savings and a false exit is self-correcting.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,9 @@ shellcheck bin/*.sh tests/*.sh            # lint the toolbelt and behavior tests
 for test_script in tests/*.test.sh; do "$test_script"; done   # behavior tests, matching CI
 tests/fm-wake-queue.test.sh               # durable wake queue losslessness, catch-up, double-drain, and duplicate-collapse tests
 tests/fm-watcher-lock.test.sh             # watcher singleton, lock-race, watch-arm liveness, and guard-warning tests
-tests/fm-daemon.test.sh                   # sub-supervisor classifier, /afk presence-gating, max-defer, composer, and fm-send submit tests
+tests/fm-daemon.test.sh                   # away-mode classifier, /afk presence-gating, max-defer, composer, and fm-send submit tests
+tests/fm-guardian.test.sh                 # always-on daemon present-mode liveness-guardian units: lapse decision, single-nudge cooldown, singleton-safe watcher restore, no routine-wake injection, and home-scoping
+tests/fm-guardian-present-e2e.test.sh     # present-mode (afk off) liveness guardian end to end: lapse, restore the watcher, nudge once, stay quiet, plus clean signal shutdown
 tests/fm-send-settle.test.sh              # fm-send post-submit settle pause, tuning, disable, and --key bypass tests
 tests/fm-send-secondmate-marker.test.sh   # fm-send from-firstmate marker for kind=secondmate targets: marked vs crewmate/explicit/--key, and the exact marker byte sequence
 tests/fm-wake-daemon-lifecycle-e2e.test.sh # watcher + daemon lifecycle e2e: restart catch-up, batching, dedupe, stale-pane routing, and digest injection

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ You chat with the first mate.
 It routes each request to a crewmate in its own tmux window and git worktree, supervises the fleet with a zero-token event-driven watcher, and brings you finished PRs, approved local merges, or investigation reports.
 Persistent secondmate homes are linked firstmate worktrees; startup syncs live ones and secondmate launch syncs the target home to the primary default-branch commit without fetching from origin when it is safe.
 When a routed request goes to a secondmate, firstmate marks it so the answer returns through status or a document pointer; direct typing into that secondmate window stays conversational.
-A presence-gated sub-supervisor (`/afk`) can self-handle routine events and batch only what matters while you step away.
+An always-on, per-home supervisor daemon keeps watcher liveness self-healing in the background, and `/afk` flips it to away mode to self-handle routine events and batch only what matters while you step away.
 When firstmate works on itself, spawn-time isolation checks and a primary-checkout tangle alarm keep the operating checkout on its default branch and stop a crewmate that did not land in a separate worktree.
 
 Full architecture - the supervision engine, worktree isolation, secondmates, project modes, fleet sync, and self-update - is in [docs/architecture.md](docs/architecture.md).
@@ -122,7 +122,7 @@ Claude uses the slash form shown here; codex uses the same names with `$`, such 
 
 | Skill              | What it does                                                                                                                                  |
 | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| `/afk`             | Enter away-mode supervision: the sub-supervisor self-handles routine wakes in bash and escalates only captain-relevant events as one batched digest, cutting supervision cost while you step away |
+| `/afk`             | Flip the always-on supervisor daemon to away mode: it self-handles routine wakes in bash and escalates only captain-relevant events as one batched digest, cutting supervision cost while you step away |
 | `/updatefirstmate` | Self-update the running firstmate and its secondmates to the latest from origin with fast-forward-only pulls, then re-read instructions and nudge secondmates |
 
 Agent-only reference skills live under `.agents/skills/` and are loaded by firstmate at the trigger points named in [`AGENTS.md`](AGENTS.md).

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -117,6 +117,16 @@ secondmate_sync() {
   return 0
 }
 
+guardian_arm() {
+  # Start the always-on supervisor daemon (liveness guardian) for this home if it
+  # is not already running. Best-effort and quiet: watcher liveness is then
+  # daemon-guaranteed from session start, not dependent on per-turn re-arm
+  # discipline. Output is infra, not a firstmate-actionable detection line, so it
+  # is suppressed; the daemon logs details to state/.supervise-daemon.log.
+  [ -x "$FM_ROOT/bin/fm-guardian-arm.sh" ] || return 0
+  "$FM_ROOT/bin/fm-guardian-arm.sh" >/dev/null 2>&1 || true
+}
+
 install_cmd() {
   case "$1" in
     tmux|node|gh) echo "brew install $1  # or the platform's package manager" ;;
@@ -164,6 +174,7 @@ crew=
 [ -f "$CONFIG/crew-harness" ] && crew=$(tr -d '[:space:]' < "$CONFIG/crew-harness" || true)
 [ -n "$crew" ] && [ "$crew" != "default" ] && echo "CREW_HARNESS_OVERRIDE: $crew"
 fm_tasks_axi_compatible && echo "TASKS_AXI: available"
+guardian_arm
 secondmate_sync
 fleet_sync
 exit 0

--- a/bin/fm-guardian-arm.sh
+++ b/bin/fm-guardian-arm.sh
@@ -28,13 +28,26 @@ mkdir -p "$STATE"
 
 [ -x "$DAEMON" ] || { echo "guardian: FAILED - daemon not executable: $DAEMON" >&2; exit 1; }
 
-daemon_alive() {  # 0 if a live daemon already runs for this home
-  local pid
+daemon_alive() {  # 0 only if the pidfile names a LIVE, GENUINE daemon for this home
+  local pid cmd
   pid=$(cat "$PIDFILE" 2>/dev/null || true)
   case "$pid" in
     ''|*[!0-9]*) return 1 ;;
   esac
-  kill -0 "$pid" 2>/dev/null
+  kill -0 "$pid" 2>/dev/null || return 1
+  # Liveness alone is not enough. An unclean daemon death (kill -9 / OOM) leaves a
+  # stale pidfile, and the OS may later recycle that pid to an unrelated process;
+  # trusting kill -0 alone would then falsely conclude the daemon is up and no-op,
+  # leaving this home with no guardian for as long as that process lives. Mirror
+  # the daemon's own lock identity check: require the pid to actually be an
+  # fm-supervise-daemon process. ps -o command= is portable on BSD and GNU. A
+  # false-negative here is safe — the daemon's portable singleton lock makes a
+  # redundant start a no-op — while the false-positive this closes is not.
+  cmd=$(ps -p "$pid" -o command= 2>/dev/null) || return 1
+  case "$cmd" in
+    *fm-supervise-daemon*) return 0 ;;
+    *) return 1 ;;
+  esac
 }
 
 # Already running for this home: no-op. The daemon also self-singletons via its

--- a/bin/fm-guardian-arm.sh
+++ b/bin/fm-guardian-arm.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Start the always-on supervisor daemon (liveness guardian) for THIS home if it
+# is not already running. Singleton-safe: a no-op when a live daemon already
+# holds this home's lock.
+#
+# The watcher (bin/fm-watch.sh) is one-shot; on its own, liveness rode entirely on
+# firstmate re-arming it every turn, so a single missed re-arm silently stopped
+# supervision (the ~69-minute gap). The supervisor daemon
+# (bin/fm-supervise-daemon.sh) now runs ALWAYS — not only under /afk — as a
+# liveness guardian: while present (afk off) it does not own the watcher or
+# process wakes, but every tick it restores a lapsed watcher and nudges firstmate
+# once. Bootstrap and recovery call this script so that guarantee is in place from
+# session start, independent of re-arm discipline. /afk no longer starts the
+# daemon; it only flips the in-process injection policy.
+#
+# Detaches the daemon (setsid/nohup) so it survives this script's exit and any
+# firstmate restart, and inherits this pane's TMUX_PANE so the daemon discovers
+# the right supervisor target. Best-effort and non-fatal: it never blocks startup.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+DAEMON="$SCRIPT_DIR/fm-supervise-daemon.sh"
+PIDFILE="$STATE/.supervise-daemon.pid"
+mkdir -p "$STATE"
+
+[ -x "$DAEMON" ] || { echo "guardian: FAILED - daemon not executable: $DAEMON" >&2; exit 1; }
+
+daemon_alive() {  # 0 if a live daemon already runs for this home
+  local pid
+  pid=$(cat "$PIDFILE" 2>/dev/null || true)
+  case "$pid" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+  kill -0 "$pid" 2>/dev/null
+}
+
+# Already running for this home: no-op. The daemon also self-singletons via its
+# own portable lock, so even a racing duplicate start can never double-run.
+if daemon_alive; then
+  echo "guardian: already running pid=$(cat "$PIDFILE" 2>/dev/null)"
+  exit 0
+fi
+
+# Start detached so the daemon outlives this script and any firstmate restart.
+# Pass FM_HOME explicitly; the daemon inherits TMUX_PANE from this pane for target
+# discovery.
+if command -v setsid >/dev/null 2>&1; then
+  FM_HOME="$FM_HOME" setsid "$DAEMON" >/dev/null 2>&1 </dev/null &
+else
+  FM_HOME="$FM_HOME" nohup "$DAEMON" >/dev/null 2>&1 </dev/null &
+fi
+disown 2>/dev/null || true
+
+# Brief, bounded confirm: the daemon writes its pidfile only after acquiring its
+# singleton lock. If another daemon won a concurrent race, ITS pidfile is what we
+# observe alive — still the correct end state (exactly one daemon).
+i=0
+while [ "$i" -lt 25 ]; do
+  if daemon_alive; then
+    echo "guardian: started pid=$(cat "$PIDFILE" 2>/dev/null)"
+    exit 0
+  fi
+  sleep 0.2
+  i=$((i + 1))
+done
+
+# Could not confirm within the window. Non-fatal: the pull-based fm-guard.sh
+# banner and firstmate's own fm-watch-arm.sh remain as backstops. Report and exit
+# zero so a transient start hiccup never blocks bootstrap or recovery.
+echo "guardian: could not confirm daemon start within 5s (continuing; guard banner + re-arm remain as backstops)" >&2
+exit 0

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -10,15 +10,34 @@
 # check-output events reach the LLM, and even then as one pre-read digest per
 # batch window.
 #
-# PRESENCE-GATING (the /afk contract). The daemon is the away-mode engine: it
-# injects ONLY when the durable away-mode flag state/.afk is present. Invoking
-# the /afk skill sets that flag and starts this daemon; any real (unmarked)
-# user message clears it and firstmate resumes full per-wake responsiveness.
-# When afk is off, the daemon stays quiet — it self-handles routine wakes and
-# buffers escalations without injecting, so the base one-shot fm-watch.sh
-# protocol is the active mechanism. Escalations that arrive while afk is off
-# survive in state/.subsuper-escalations and are flushed on the next
-# "while you were out" catch-up or when afk is re-entered.
+# ALWAYS-ON, TWO MODES. This daemon is a per-home, long-lived liveness guardian
+# that runs whenever firstmate is up (started at bootstrap and recovery via
+# bin/fm-guardian-arm.sh, not only by /afk). The durable away-mode flag
+# state/.afk is now a POLICY TOGGLE inside the one process, never daemon
+# existence:
+#
+#   Mode A — afk ON (away): own the watcher as a child, classify each wake, and
+#     SELF-HANDLE the routine majority in bash or ESCALATE a batched, distilled
+#     digest to firstmate's pane on captain-relevant events. Injection is
+#     presence-gated by state/.afk (unchanged from the prior always-inject
+#     replacement).
+#
+#   Mode B — afk OFF (present): the daemon does NOT own the watcher and does NOT
+#     process wakes — firstmate's own run_in_background fm-watch-arm.sh is
+#     primary. The daemon's only job is to GUARANTEE watcher liveness: every
+#     FM_GUARDIAN_TICK it checks whether work is in flight AND the liveness
+#     beacon (state/.last-watcher-beat) is missing or older than FM_GUARD_GRACE.
+#     If so, firstmate's per-turn re-arm has lapsed: the guardian restores the
+#     watcher itself (singleton-safe fork) AND injects exactly ONE minimal nudge
+#     so firstmate drains the wake-queue and resumes. It never injects for a
+#     routine wake — only a detected liveness lapse. This makes the ~69-minute
+#     "missed re-arm => supervision silently off" failure mode impossible while
+#     keeping present-mode firstmate's normal per-turn flow untouched.
+#
+# afk flips the mode in-process: ON => Mode A injection policy, OFF => Mode B
+# lapse-only nudge, with no daemon restart and no change to approval authority.
+# Escalations buffered in Mode A survive in state/.subsuper-escalations and are
+# flushed on the next "while you were out" catch-up if afk turns off mid-batch.
 #
 # IN-BAND SENTINEL MARKER. Every daemon injection is prefixed with
 # FM_INJECT_MARK (ASCII unit separator, 0x1f) — a byte a human would never type
@@ -132,6 +151,25 @@ CRASH_BACKOFF_DEFAULT=60
 CRASH_NORMAL_SLEEP_DEFAULT=5
 LOG_MAX_BYTES_DEFAULT=1048576
 LOG_KEEP_LINES_DEFAULT=2000
+
+# --- Mode B (present) liveness-guardian tunables ----------------------------
+# How often the present-mode guardian checks watcher liveness. 30-60s keeps the
+# check cheap while bounding restore latency to one tick past the grace window.
+GUARDIAN_TICK_DEFAULT=45
+# A watcher is "lapsed" when its beacon is missing or older than this. Reuses the
+# guard's threshold so liveness has ONE definition across fm-watch.sh,
+# fm-watch-arm.sh, fm-guard.sh, and the guardian. Crucially, this tolerance is
+# what keeps the guardian SILENT during a normal sub-grace gap (the watcher is
+# briefly down between a wake and firstmate's re-arm): only a true lapse — a beacon
+# stale past the grace, i.e. firstmate stopped re-arming entirely — ever nudges,
+# so a routine wake never produces an injection (acceptance criterion 3).
+GUARD_GRACE_DEFAULT=300
+# After a lapse nudge, suppress further nudges for this long so a single lapse
+# produces exactly ONE re-arm/drain nudge, never a stream. Defaults to the grace.
+GUARDIAN_NUDGE_COOLDOWN_DEFAULT=$GUARD_GRACE_DEFAULT
+# The single, minimal lapse nudge. Marker-prefixed at injection like every daemon
+# message, so firstmate recognizes it as internal (not a captain message).
+GUARDIAN_NUDGE_MSG='supervision liveness lapsed - draining the wake-queue and resuming'
 
 # --- presence-gating + sentinel marker --------------------------------------
 # The in-band sentinel: ASCII unit separator (0x1f). Invisible and untypable on
@@ -584,22 +622,24 @@ window_for_task() {  # <task-key>
 #     after dim/faint ghost text and borders are ignored (a human's half-typed
 #     line, or a previous injection's unsent text), defer entirely - injecting
 #     would merge with the human's text.
-inject_msg() {  # <message> [state]
-  local msg=$1 state target retries sleep_s verdict
-  state="${2:-$(_state_root)}"
-  # (1) Presence-gate: inject ONLY when afk is active. When afk is off, the
-  # daemon self-handles and stays quiet; firstmate drives the base one-shot
-  # watcher. Escalations buffer and survive for the next catch-up flush.
-  afk_active "$state" || { log "inject deferred: afk inactive"; return 1; }
-  # (2) Single-line digest: collapse any embedded newlines so submission via
+# _inject_marked: the shared, hardened injection core (no presence gate). Used by
+# inject_msg (Mode A escalations, afk-gated by its caller) and inject_nudge (Mode
+# B liveness nudge, NOT gated). Collapses to one line, prepends the sentinel
+# marker, busy/pending-guards the supervisor pane, then types ONCE and submits
+# Enter (retry Enter only) via the shared primitive. Returns 0 only on a confirmed
+# empty composer; an unconfirmed/busy/pending pane returns non-zero so the caller
+# preserves whatever it was trying to deliver.
+_inject_marked() {  # <message> <state>
+  local msg=$1 state=$2 target retries sleep_s verdict
+  # (1) Single-line digest: collapse any embedded newlines so submission via
   # send-keys + Enter is unambiguous regardless of how the TUI composer treats
-  # them. Then prepend the sentinel marker — firstmate's afk-exit contract
-  # keys off its presence at the start of the message.
+  # them. Then prepend the sentinel marker — firstmate keys off its presence to
+  # tell an internal daemon message from a real captain message.
   msg=$(_collapse_newlines "$msg")
   msg="${FM_INJECT_MARK}${msg}"
   target="${FM_SUPERVISOR_TARGET:-$FM_SUPERVISOR_TARGET_DEFAULT}"
   tmux display-message -p -t "$target" '#{pane_id}' >/dev/null 2>&1 || return 1
-  # (3) Busy-guard: never inject into an in-use pane. Two checks:
+  # (2) Busy-guard: never inject into an in-use pane. Two checks:
   #   a) pane_is_busy: the harness shows a busy footer (agent mid-turn).
   #   b) pane_input_pending: the cursor line has real unsubmitted text after
   #      dim/faint ghost text and borders are ignored (a human's half-typed line,
@@ -612,10 +652,10 @@ inject_msg() {  # <message> [state]
     log "inject deferred: supervisor pane has pending input (non-empty composer)"
     return 1
   fi
-  # (4) Type the digest ONCE, then submit with Enter (retry Enter only, never
+  # (3) Type the message ONCE, then submit with Enter (retry Enter only, never
   # retype) via the shared submit primitive. Success = the composer is confirmed
   # EMPTY afterward (the text was consumed). An unconfirmed/unknown pane does NOT
-  # count as delivered, so the buffer is preserved (strict) rather than cleared.
+  # count as delivered, so the caller preserves (strict) rather than clears.
   retries=${FM_INJECT_CONFIRM_RETRIES:-$INJECT_CONFIRM_RETRIES_DEFAULT}
   sleep_s=${FM_INJECT_CONFIRM_SLEEP:-$INJECT_CONFIRM_SLEEP_DEFAULT}
   verdict=$(fm_tmux_submit_core "$target" "$msg" "$retries" "$sleep_s" "$sleep_s")
@@ -624,6 +664,96 @@ inject_msg() {  # <message> [state]
   fi
   log "inject failed: submit unconfirmed after $retries retries (verdict=$verdict, text may be in composer)"
   return 1
+}
+
+# inject_msg: Mode A escalation injection. Presence-gated — injects ONLY when afk
+# is active. When afk is off, the daemon self-handles and stays quiet; escalations
+# buffer and survive for the next catch-up flush. This gate is unchanged.
+inject_msg() {  # <message> [state]
+  local msg=$1 state
+  state="${2:-$(_state_root)}"
+  afk_active "$state" || { log "inject deferred: afk inactive"; return 1; }
+  _inject_marked "$msg" "$state"
+}
+
+# inject_nudge: Mode B liveness nudge injection. NOT presence-gated — it fires
+# while afk is OFF (present), because its whole job is to wake a present firstmate
+# whose watcher re-arm has lapsed. It reuses the same marker + busy-guard +
+# verified submit hardening as inject_msg, so a present captain's half-typed line
+# is never clobbered and the nudge is recognized as internal, not a captain
+# message. Returns 0 only on a confirmed submit.
+inject_nudge() {  # <message> [state]
+  local msg=$1 state
+  state="${2:-$(_state_root)}"
+  _inject_marked "$msg" "$state"
+}
+
+# --- Mode B liveness guardian (present; PURE-ish, testable) ------------------
+# guardian_lapsed: 0 when watcher liveness has lapsed AND there is work to guard —
+# i.e. some state/*.meta exists (a task in flight) AND state/.last-watcher-beat is
+# missing or older than FM_GUARD_GRACE. With no work in flight there is nothing to
+# supervise, so it is never a lapse. The grace tolerance is what makes a normal
+# sub-grace gap (watcher briefly down between a wake and firstmate's re-arm) NOT a
+# lapse, so routine wakes never trigger a nudge.
+guardian_lapsed() {  # <state>
+  local state=$1 m in_flight=0 age
+  for m in "$state"/*.meta; do
+    [ -e "$m" ] && { in_flight=1; break; }
+  done
+  [ "$in_flight" = 1 ] || return 1
+  age=$(_file_age "$state/.last-watcher-beat")
+  [ "$age" -ge "${FM_GUARD_GRACE:-$GUARD_GRACE_DEFAULT}" ]
+}
+
+# guardian_nudge_due: 0 when the lapse nudge cooldown has elapsed, so a single
+# lapse yields exactly ONE nudge rather than a stream. Keyed off the
+# state/.guardian-last-nudge marker's mtime.
+guardian_nudge_due() {  # <state>
+  local state=$1 cooldown
+  # Default the cooldown to the live grace (so a small test grace shrinks it too),
+  # falling back to the compile-time default when neither is set.
+  cooldown=${FM_GUARDIAN_NUDGE_COOLDOWN:-${FM_GUARD_GRACE:-$GUARDIAN_NUDGE_COOLDOWN_DEFAULT}}
+  [ "$(_file_age "$state/.guardian-last-nudge")" -ge "$cooldown" ]
+}
+
+# guardian_restore_watcher: fork a watcher via the singleton-safe path so a lapsed
+# beacon goes fresh again within a tick. The fork can never double-arm: the
+# watcher's own singleton lock makes a redundant fork stand down. We track and
+# opportunistically reap our forked child (GUARDIAN_WATCHER_PID) to avoid zombies
+# and to avoid stacking forks while one is already alive. FM_WATCH_CMD/FM_WATCH_ERR
+# default to fm_super_main's WATCH/WATCH_ERR (dynamic scope); a test injects them.
+guardian_restore_watcher() {
+  local watch="${FM_WATCH_CMD:-${WATCH:-}}" err="${FM_WATCH_ERR:-${WATCH_ERR:-/dev/null}}"
+  [ -n "$watch" ] || return 1
+  if [ -n "${GUARDIAN_WATCHER_PID:-}" ] && ! kill -0 "$GUARDIAN_WATCHER_PID" 2>/dev/null; then
+    wait "$GUARDIAN_WATCHER_PID" 2>/dev/null || true
+    GUARDIAN_WATCHER_PID=""
+  fi
+  [ -z "${GUARDIAN_WATCHER_PID:-}" ] || return 0
+  "$watch" >/dev/null 2>>"$err" &
+  GUARDIAN_WATCHER_PID=$!
+}
+
+# guardian_step: one present-mode liveness check. On a detected lapse it restores
+# the watcher itself AND nudges firstmate exactly once (cooldown-guarded). It never
+# processes wakes — firstmate does, draining the durable queue after the nudge.
+# A non-lapsed tick is a no-op, so routine wakes produce no nudge.
+guardian_step() {  # <state>
+  local state=$1
+  guardian_lapsed "$state" || return 0
+  guardian_restore_watcher
+  if guardian_nudge_due "$state"; then
+    _now > "$state/.guardian-last-nudge"
+    if inject_nudge "$GUARDIAN_NUDGE_MSG" "$state"; then
+      log "guardian: liveness lapse — restored watcher and nudged firstmate"
+    else
+      # Pane busy/pending: firstmate is mid-turn and will see the guard banner and
+      # the durable queue itself. The watcher is already restored; nothing lost.
+      log "guardian: liveness lapse — restored watcher, nudge deferred (pane busy/pending)"
+    fi
+  else
+    log "guardian: liveness lapse — restored watcher, nudge suppressed (cooldown)"
+  fi
 }
 
 # --- INJECT_SKIP prefix match (literal prefixes, no regex) ------------------
@@ -720,10 +850,17 @@ fm_super_main() {
   FM_STATE_OVERRIDE="$STATE" . "$FM_DAEMON_DIR/fm-wake-lib.sh"
 
   local WATCH="$FM_DAEMON_DIR/fm-watch.sh"
+  local WATCH_LOCK="$STATE/.watch.lock"
   local LOG="$STATE/.supervise-daemon.log"
   local WATCH_ERR="$STATE/.supervise-daemon.watcher.err"
   local LOCK="$STATE/.supervise-daemon.lock"
   local PIDFILE="$STATE/.supervise-daemon.pid"
+  local GUARDIAN_TICK=${FM_GUARDIAN_TICK:-$GUARDIAN_TICK_DEFAULT}
+  # GUARDIAN_WATCHER_PID tracks the watcher the Mode B guardian forks on a lapse,
+  # so it is reaped (no zombie) and never double-forked. WATCH/WATCH_ERR reach
+  # guardian_restore_watcher via dynamic scope from here; a unit test injects
+  # FM_WATCH_CMD/FM_WATCH_ERR instead.
+  local GUARDIAN_WATCHER_PID=""
   local INJECT_FAIL_SLEEP=${FM_INJECT_FAIL_SLEEP:-$INJECT_FAIL_SLEEP_DEFAULT}
   local CRASH_THRESHOLD=${FM_CRASH_THRESHOLD:-$CRASH_THRESHOLD_DEFAULT}
   local CRASH_WINDOW=${FM_CRASH_WINDOW:-$CRASH_WINDOW_DEFAULT}
@@ -776,17 +913,26 @@ fm_super_main() {
 
   local afk_status="off"
   afk_active "$STATE" && afk_status="on"
-  log "daemon starting (pid $$); target=$TARGET; target_source=$target_source; afk=$afk_status; inject_skip='${FM_INJECT_SKIP:-$INJECT_SKIP_DEFAULT}'; stale_escalate=${FM_STALE_ESCALATE_SECS:-$STALE_ESCALATE_SECS_DEFAULT}s; batch=${FM_ESCALATE_BATCH_SECS:-$ESCALATE_BATCH_SECS_DEFAULT}s"
+  log "daemon starting (pid $$); always-on, two-mode; target=$TARGET; target_source=$target_source; afk=$afk_status (afk on=away/own+escalate, off=present/liveness-guardian); guardian_tick=${FM_GUARDIAN_TICK:-$GUARDIAN_TICK_DEFAULT}s; guard_grace=${FM_GUARD_GRACE:-$GUARD_GRACE_DEFAULT}s; inject_skip='${FM_INJECT_SKIP:-$INJECT_SKIP_DEFAULT}'; stale_escalate=${FM_STALE_ESCALATE_SECS:-$STALE_ESCALATE_SECS_DEFAULT}s; batch=${FM_ESCALATE_BATCH_SECS:-$ESCALATE_BATCH_SECS_DEFAULT}s"
 
-  # --- shutdown: flush buffered escalations, reap child, release lock -------
+  # --- shutdown: flush buffered escalations, reap children, release lock -----
   local WATCHER_PID="" CUR_TMP=""
   cleanup() {
     trap - TERM INT
+    # Flush any buffered Mode A escalation; and if a present-mode liveness lapse
+    # is still open, fire its single nudge now so it is not lost on shutdown.
     escalate_flush "$STATE" 2>/dev/null || true
-    if [ -n "${WATCHER_PID:-}" ]; then
-      kill "$WATCHER_PID" 2>/dev/null || true
-      wait "$WATCHER_PID" 2>/dev/null || true
+    if ! afk_active "$STATE" && guardian_lapsed "$STATE" && guardian_nudge_due "$STATE"; then
+      _now > "$STATE/.guardian-last-nudge"
+      inject_nudge "$GUARDIAN_NUDGE_MSG" "$STATE" 2>/dev/null || true
     fi
+    local p
+    for p in "${WATCHER_PID:-}" "${GUARDIAN_WATCHER_PID:-}"; do
+      if [ -n "$p" ]; then
+        kill "$p" 2>/dev/null || true
+        wait "$p" 2>/dev/null || true
+      fi
+    done
     if [ -n "${CUR_TMP:-}" ]; then
       rm -f "$CUR_TMP" 2>/dev/null || true
     fi
@@ -823,8 +969,101 @@ fm_super_main() {
     WATCHER_PID=$!
   }
 
-  local rc reason
+  # daemon_watch_lock_is_genuine: 0 iff the watch lock names <pid> as a real
+  # watcher of THIS home (fm-home + watcher-path + a matching pid-identity). The
+  # identity check guards against a recycled/reused pid. Mirrors
+  # fm-watch-arm.sh's watch_lock_matches_pid so a B->A takeover never signals an
+  # unrelated process or another home's watcher (home isolation).
+  daemon_watch_lock_is_genuine() {  # <pid>
+    local pid=$1 lock_home lock_path lock_identity current_identity
+    lock_home=$(cat "$WATCH_LOCK/fm-home" 2>/dev/null || true)
+    lock_path=$(cat "$WATCH_LOCK/watcher-path" 2>/dev/null || true)
+    lock_identity=$(cat "$WATCH_LOCK/pid-identity" 2>/dev/null || true)
+    [ "$lock_home" = "$FM_HOME" ] || return 1
+    [ "$lock_path" = "$WATCH" ] || return 1
+    [ -n "$lock_identity" ] || return 1
+    current_identity=$(fm_pid_identity "$pid") || return 1
+    [ "$current_identity" = "$lock_identity" ]
+  }
+
+  # daemon_stop_home_watcher: home-scoped stop of the watcher recorded in THIS
+  # home's lock, used when the daemon takes watcher ownership on B->A. It signals
+  # ONLY a pid the lock proves is this home's genuine watcher, then waits for it to
+  # exit so the fresh daemon-owned watcher takes a released (or now-dead) lock
+  # rather than colliding with a live holder. Never a broad pkill.
+  daemon_stop_home_watcher() {
+    local lock_pid i=0
+    lock_pid=$(cat "$WATCH_LOCK/pid" 2>/dev/null || true)
+    fm_pid_alive "$lock_pid" || return 0
+    daemon_watch_lock_is_genuine "$lock_pid" || return 0
+    kill -TERM "$lock_pid" 2>/dev/null || true
+    while [ "$i" -lt 50 ] && fm_pid_alive "$lock_pid"; do
+      sleep 0.1
+      i=$((i + 1))
+    done
+  }
+
+  # enter_mode_a (afk turned ON / away): take watcher ownership so the daemon can
+  # self-handle and escalate. firstmate's present-mode arm may still hold the
+  # watcher, so stop it (home-scoped) and start a fresh daemon-owned child. The
+  # singleton lock makes this safe even under a race: at most one watcher survives.
+  enter_mode_a() {
+    if [ -n "${GUARDIAN_WATCHER_PID:-}" ]; then
+      kill "$GUARDIAN_WATCHER_PID" 2>/dev/null || true
+      wait "$GUARDIAN_WATCHER_PID" 2>/dev/null || true
+      GUARDIAN_WATCHER_PID=""
+    fi
+    daemon_stop_home_watcher
+    start_watcher
+    log "afk on: took watcher ownership (away mode: self-handle + escalate)"
+  }
+
+  # enter_mode_b (afk turned OFF / present): release watcher ownership so
+  # firstmate's run_in_background arm is primary again. Killing our owned child
+  # leaves the beacon fresh (it beat moments ago), so the guardian's grace window
+  # covers firstmate re-arming without a spurious nudge. Delay the first guardian
+  # check by one tick so a just-returned firstmate has room to arm.
+  enter_mode_b() {
+    if [ -n "${WATCHER_PID:-}" ]; then
+      kill "$WATCHER_PID" 2>/dev/null || true
+      wait "$WATCHER_PID" 2>/dev/null || true
+      WATCHER_PID=""
+    fi
+    if [ -n "${CUR_TMP:-}" ]; then
+      rm -f "$CUR_TMP" 2>/dev/null || true
+      CUR_TMP=""
+    fi
+    _now > "$STATE/.guardian-last-check"
+    log "afk off: released watcher ownership (present mode: liveness guardian only)"
+  }
+
+  local rc reason mode MODE_PREV=""
   while true; do
+    # afk is a POLICY TOGGLE inside this one process, checked every second so a
+    # transition is acted on promptly: ON => Mode A (own watcher, self-handle /
+    # escalate), OFF => Mode B (present; liveness guardian only).
+    if afk_active "$STATE"; then mode=A; else mode=B; fi
+    if [ "$mode" != "$MODE_PREV" ]; then
+      if [ "$mode" = A ]; then enter_mode_a; else enter_mode_b; fi
+      MODE_PREV=$mode
+    fi
+
+    if [ "$mode" = B ]; then
+      # --- Mode B (present): liveness guardian ONLY --------------------------
+      # The daemon does not own the watcher or process wakes here — firstmate's
+      # own arm is primary. Every GUARDIAN_TICK, restore a lapsed watcher and nudge
+      # firstmate exactly once. A non-lapsed tick is a no-op, so routine wakes never
+      # produce a nudge. The pane-gone case is handled inside the guardian path
+      # (inject just defers); no separate backoff is needed when present.
+      if [ "$(_file_age "$STATE/.guardian-last-check")" -ge "$GUARDIAN_TICK" ]; then
+        _now > "$STATE/.guardian-last-check"
+        guardian_step "$STATE"
+      fi
+      sleep 1
+      continue
+    fi
+
+    # --- Mode A (away): own the watcher, self-handle / escalate (UNCHANGED) ---
     # --- pane-gone guard (preserved) ---------------------------------------
     # With the #29 watcher's enqueue-before-suppress, a wake is no longer
     # swallowed by running the watcher with no injection target. We still back

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,7 +23,7 @@ So a forgotten re-arm self-heals within a tick instead of silently stopping supe
 While away (afk on, activated by the `/afk` skill) the same process owns the watcher, self-handles routine wakes in bash, and escalates only captain-relevant events as one batched, single-line digest (prefixed with an in-band sentinel marker so firstmate can tell daemon injections apart from real messages).
 The daemon's watcher restore and away-mode takeover are home-scoped the same way `--restart` is: they touch only this home's watcher, never a broad `pkill`, so the singleton lock guarantees at most one watcher per home even when the guardian restores it at the same moment firstmate re-arms.
 Its injection path shares `bin/fm-tmux-lib.sh` with `fm-send.sh`, so dim-ghost-aware and border-aware composer detection plus verified submit retry stay consistent; stalled escalation delivery raises `state/.subsuper-inject-wedged` after `FM_MAX_DEFER_SECS` instead of silently deferring forever.
-`fm-send.sh` adds its own `FM_SEND_SETTLE` pause after successful text sends so immediate peeks catch the receiving turn starting; the sub-supervisor uses only the shared submit core and does not pay that pause.
+`fm-send.sh` adds its own `FM_SEND_SETTLE` pause after successful text sends so immediate peeks catch the receiving turn starting; the daemon uses only the shared submit core and does not pay that pause.
 
 ## Worktrees, not branches in your checkout
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,7 +17,11 @@ Its `--restart` mode signals only the watcher recorded in the current home's `st
 A pull-based guard (`bin/fm-guard.sh`) warns through supervision tool output if the primary checkout is tangled, or if tasks are in flight and that watcher stops running or queued wakes are waiting to be drained.
 It leads with prominent bordered banners for the tangle and no-watcher cases so they cannot be skimmed past.
 
-A presence-gated sub-supervisor (`bin/fm-supervise-daemon.sh`) extends this for walk-away supervision: the `/afk` skill activates it, after which it self-handles routine wakes in bash and escalates only captain-relevant events as one batched, single-line digest (prefixed with an in-band sentinel marker so firstmate can tell daemon injections apart from real messages).
+An always-on, per-home supervisor daemon (`bin/fm-supervise-daemon.sh`) makes watcher liveness structural rather than discipline-dependent: it is started at bootstrap and recovery via `bin/fm-guardian-arm.sh` and runs in two modes that the durable `state/.afk` flag toggles in-process.
+While present (afk off, the default) it is a liveness guardian: it does not own the watcher, but every tick it checks whether work is in flight and the liveness beacon has gone stale past `FM_GUARD_GRACE`, and if so restores the watcher via the singleton-safe path and injects exactly one re-arm/drain nudge - never for a routine wake.
+So a forgotten re-arm self-heals within a tick instead of silently stopping supervision.
+While away (afk on, activated by the `/afk` skill) the same process owns the watcher, self-handles routine wakes in bash, and escalates only captain-relevant events as one batched, single-line digest (prefixed with an in-band sentinel marker so firstmate can tell daemon injections apart from real messages).
+The daemon's watcher restore and away-mode takeover are home-scoped the same way `--restart` is: they touch only this home's watcher, never a broad `pkill`, so the singleton lock guarantees at most one watcher per home even when the guardian restores it at the same moment firstmate re-arms.
 Its injection path shares `bin/fm-tmux-lib.sh` with `fm-send.sh`, so dim-ghost-aware and border-aware composer detection plus verified submit retry stay consistent; stalled escalation delivery raises `state/.subsuper-inject-wedged` after `FM_MAX_DEFER_SECS` instead of silently deferring forever.
 `fm-send.sh` adds its own `FM_SEND_SETTLE` pause after successful text sends so immediate peeks catch the receiving turn starting; the sub-supervisor uses only the shared submit core and does not pay that pause.
 
@@ -97,4 +101,4 @@ Kill the first mate session anytime; the next one reconciles and carries on.
 ## Development notes
 
 The current watcher reliability work keeps the one-shot process model and adds a durable queue, race-proof singleton lock, duplicate self-eviction, and a self-verifying tracked-child arm wrapper.
-The presence-gated sub-supervisor (`bin/fm-supervise-daemon.sh`) provides proactive wake routing for walk-away supervision via the `/afk` skill; a blocking-waiter split remains a deferred follow-up phase.
+The always-on supervisor daemon (`bin/fm-supervise-daemon.sh`) makes liveness daemon-owned in both modes: a present-mode liveness guardian that restores a lapsed watcher and nudges once, and the `/afk` away mode that adds proactive wake routing and batched escalation. `state/.afk` toggles the policy in one long-lived process; it never starts or stops the daemon.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -68,7 +68,7 @@ FM_HEARTBEAT_MAX=7200   # heartbeat backoff cap
 FM_CHECK_INTERVAL=300   # seconds between slow checks (merged-PR polls)
 FM_CHECK_TIMEOUT=30     # seconds allowed per slow check script
 FM_LOCK_STALE_AFTER=2   # seconds before dead-pid lock records can be reclaimed; mid-acquire locks keep at least 2s grace
-FM_GUARD_GRACE=300      # seconds before guard warnings and arm health checks treat a watcher beacon as stale
+FM_GUARD_GRACE=300      # seconds before guard warnings, arm health checks, and the present-mode liveness guardian treat a watcher beacon as stale
 FM_ARM_CONFIRM_TIMEOUT=10   # seconds fm-watch-arm waits to confirm a fresh watcher before reporting FAILED
 FM_WATCHER_STALE_GRACE=300   # defaults to FM_GUARD_GRACE; seconds a live watcher lock may have a stale beacon before re-arm errors
 FM_SIGNAL_GRACE=30      # seconds to coalesce nearby status and turn-end signals into one wake
@@ -79,7 +79,9 @@ FM_COMPOSER_IDLE_RE=    # optional empty-composer regex, applied after dim-ghost
 FM_SEND_RETRIES=3       # fm-send Enter-retry attempts after typing the line once
 FM_SEND_SLEEP=0.4       # seconds between fm-send submit checks
 FM_SEND_SETTLE=1        # seconds fm-send waits after a successful text submit; 0 disables
-# sub-supervisor (bin/fm-supervise-daemon.sh); presence-gated via /afk
+# always-on supervisor daemon (bin/fm-supervise-daemon.sh); state/.afk toggles away/present mode
+FM_GUARDIAN_TICK=45                 # present-mode seconds between watcher-liveness guardian checks
+FM_GUARDIAN_NUDGE_COOLDOWN=        # defaults to FM_GUARD_GRACE; min seconds between present-mode lapse nudges so one lapse yields one nudge
 FM_SUPERVISOR_TARGET=firstmate:0   # supervisor tmux target (override; auto-discovers from $TMUX_PANE)
 FM_INJECT_SKIP=heartbeat           # |-prefixes force-self-handled bypassing classification; empty disables
 FM_CAPTAIN_RE='done:|needs-decision:|blocked:|failed:|PR ready|checks green|ready in branch|merged'   # status regex that escalates daemon signal/stale/scan output

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -18,9 +18,10 @@ Each file also starts with a short header comment.
 | `fm-merge-local.sh`      | Fast-forward a `local-only` project's local default branch after approval                                           |
 | `fm-review-diff.sh`      | Review a crewmate branch against the authoritative base, with optional `--stat` output                              |
 | `fm-marker-lib.sh`       | Shared from-firstmate request marker and detector sourced by `fm-send.sh`, `fm-brief.sh`, and tests                 |
+| `fm-guardian-arm.sh`     | Start the always-on, per-home supervisor daemon (liveness guardian) if it is not already running; singleton-safe no-op when a live daemon already holds this home |
 | `fm-watch-arm.sh`        | Verified per-home watcher re-arm; reports `started`, `healthy`, or `FAILED`; `--restart` relaunches only this home's watcher |
 | `fm-watch.sh`            | Singleton-safe one-shot watcher; blocks until supervision work is due, queues it durably, then exits with one reason line |
-| `fm-supervise-daemon.sh` | Presence-gated sub-supervisor for walk-away (`/afk`) supervision: wraps `fm-watch.sh`, self-handles routine wakes in bash, and escalates only captain-relevant events as one verified, batched, single-line digest prefixed with a sentinel marker |
+| `fm-supervise-daemon.sh` | Always-on, per-home supervisor daemon with two `state/.afk`-toggled modes: a present-mode liveness guardian that restores a lapsed watcher and nudges firstmate once, and the `/afk` away mode that owns the watcher, self-handles routine wakes, and escalates only captain-relevant events as one verified, batched, single-line digest prefixed with a sentinel marker |
 | `fm-tangle-lib.sh`       | Shared default-branch resolution and primary-checkout tangle classification sourced by bootstrap and guard         |
 | `fm-ff-lib.sh`           | Shared guarded fast-forward helper for `/updatefirstmate` origin pulls and no-fetch local secondmate syncs         |
 | `fm-tasks-axi-lib.sh`    | Shared `tasks-axi` compatibility probe sourced by bootstrap and teardown                                            |

--- a/tests/fm-afk-inject-e2e.test.sh
+++ b/tests/fm-afk-inject-e2e.test.sh
@@ -91,6 +91,17 @@ _buf=
 redraw() {
   printf '\r\033[K%s' "$_buf"
 }
+# Byte-accurate hex without depending on a PATH `od`: a user's Open Design `od`
+# shim (in ~/.local/bin) can shadow coreutils octal-dump, and the pane's login
+# shell re-prepends it, so bare `od` would emit CLI usage instead of bytes. Prefer
+# coreutils od at a known absolute path, then hexdump, then xxd; all lowercase, no
+# spaces. On CI (no shim) this still resolves to coreutils od.
+_hex_bytes() {
+  if [ -x /usr/bin/od ]; then /usr/bin/od -An -tx1
+  elif command -v hexdump >/dev/null 2>&1; then hexdump -v -e '/1 "%02x"'
+  else xxd -p
+  fi
+}
 submit_line() {
   local _line=$_buf _c _hex
   if [ "${_line:0:1}" = "$MARK" ]; then
@@ -98,7 +109,7 @@ submit_line() {
   else
     _c="user"
   fi
-  _hex=$(printf '%s' "$_line" | od -An -tx1 | tr -d ' \n')
+  _hex=$(printf '%s' "$_line" | _hex_bytes | tr -d ' \n')
   printf '%s\t%s\t%s\n' "$_hex" "$_line" "$_c" >> "$LOG"
   _buf=
   printf '\r\033[K\n'

--- a/tests/fm-guardian-present-e2e.test.sh
+++ b/tests/fm-guardian-present-e2e.test.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# tests/fm-guardian-present-e2e.test.sh - the always-on supervisor daemon's
+# PRESENT-mode (afk OFF) liveness guardian, end to end through the real
+# fm_super_main loop on a private tmux socket. This is the operator-visible proof
+# of the structural fix: with work in flight and no watcher, the running daemon
+# restores the watcher itself and nudges firstmate exactly once, then keeps quiet.
+#
+# Covers:
+#   criterion 1  a missing beacon (firstmate's re-arm lapsed) is restored within a
+#                tick AND firstmate gets exactly one re-arm/drain nudge.
+#   criterion 3  no routine-wake injection: after the single lapse nudge, the
+#                guardian stays silent while the restored watcher beats.
+#   criterion 6  clean signal shutdown: SIGTERM removes the pidfile, releases the
+#                lock, and tears down the forked watcher (no leak).
+#
+# Mode A (afk ON) injection behavior is covered by fm-afk-inject-e2e; the
+# deterministic decision/cooldown/singleton units are in fm-guardian.test.sh.
+#
+# Isolation: a dedicated tmux socket (tmux -L) + a shim that redirects the
+# daemon's bare `tmux` to it. Nothing touches the live fleet.
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DAEMON="$ROOT/bin/fm-supervise-daemon.sh"
+
+command -v tmux >/dev/null 2>&1 || { echo "skip: tmux not found"; exit 0; }
+
+REAL_TMUX=$(command -v tmux)
+SOCKET="fm-guardian-e2e-$$"
+STATE_DIR=
+TMUX_SHIM_DIR=
+LOG_FILE=
+DAEMON_PID=
+SUPERVISOR_PANE=
+LOOP_SCRIPT=
+
+fail() { printf 'not ok - %s\n' "$1" >&2; cleanup_all; exit 1; }
+pass() { printf 'ok - %s\n' "$1"; }
+
+cleanup_all() {
+  if [ -n "${DAEMON_PID:-}" ]; then
+    kill "$DAEMON_PID" 2>/dev/null || true
+    wait "$DAEMON_PID" 2>/dev/null || true
+  fi
+  # Kill any watcher the guardian forked into this throwaway state.
+  if [ -n "${STATE_DIR:-}" ] && [ -f "$STATE_DIR/.watch.lock/pid" ]; then
+    kill "$(cat "$STATE_DIR/.watch.lock/pid" 2>/dev/null || true)" 2>/dev/null || true
+  fi
+  if [ -n "${SOCKET:-}" ] && [ -n "${REAL_TMUX:-}" ]; then
+    "$REAL_TMUX" -L "$SOCKET" kill-server 2>/dev/null || true
+  fi
+  rm -rf "${TMUX_SHIM_DIR:-}" "${STATE_DIR:-}" 2>/dev/null || true
+}
+trap cleanup_all EXIT
+
+STATE_DIR=$(mktemp -d "${TMPDIR:-/tmp}/fm-guardian-e2e.XXXXXX")
+LOG_FILE="$STATE_DIR/submitted.log"
+: > "$LOG_FILE"
+
+# Private tmux server + a supervisor pane that logs each submitted line verbatim,
+# classifying a sentinel-marked (0x1f) line as an injection. Same approach as
+# fm-afk-inject-e2e; the hex is computed without a PATH `od` (an Open Design `od`
+# shim can shadow coreutils octal-dump).
+"$REAL_TMUX" -L "$SOCKET" new-session -d -s supervisor -x 200 -y 50
+SUPERVISOR_PANE=$("$REAL_TMUX" -L "$SOCKET" display-message -p -t supervisor '#{pane_id}')
+
+LOOP_SCRIPT="$STATE_DIR/supervisor-loop.sh"
+cat > "$LOOP_SCRIPT" <<'LOOP'
+#!/usr/bin/env bash
+MARK=$'\x1f'
+LOG="$1"
+OLD_STTY=$(stty -g 2>/dev/null || true)
+[ -z "$OLD_STTY" ] || stty -echo -icanon min 1 time 0 2>/dev/null || true
+cleanup() { [ -z "$OLD_STTY" ] || stty "$OLD_STTY" 2>/dev/null || true; }
+trap cleanup EXIT INT TERM
+_hex_bytes() {
+  if [ -x /usr/bin/od ]; then /usr/bin/od -An -tx1
+  elif command -v hexdump >/dev/null 2>&1; then hexdump -v -e '/1 "%02x"'
+  else xxd -p
+  fi
+}
+_buf=
+redraw() { printf '\r\033[K%s' "$_buf"; }
+submit_line() {
+  local _line=$_buf _c _hex
+  if [ "${_line:0:1}" = "$MARK" ]; then _c="injection"; else _c="user"; fi
+  _hex=$(printf '%s' "$_line" | _hex_bytes | tr -d ' \n')
+  printf '%s\t%s\t%s\n' "$_hex" "$_line" "$_c" >> "$LOG"
+  _buf=
+  printf '\r\033[K\n'
+  redraw
+}
+redraw
+while IFS= read -r -n 1 _ch; do
+  if [ -z "$_ch" ]; then submit_line; continue; fi
+  case "$_ch" in
+    $'\r'|$'\n') submit_line ;;
+    $'\177'|$'\b') _buf=${_buf%?}; redraw ;;
+    *) _buf="${_buf}${_ch}"; redraw ;;
+  esac
+done
+LOOP
+chmod +x "$LOOP_SCRIPT"
+"$REAL_TMUX" -L "$SOCKET" send-keys -t "$SUPERVISOR_PANE" "bash '$LOOP_SCRIPT' '$LOG_FILE'" Enter
+sleep 1
+
+TMUX_SHIM_DIR=$(mktemp -d "${TMPDIR:-/tmp}/fm-guardian-shim.XXXXXX")
+cat > "$TMUX_SHIM_DIR/tmux" <<SHIM
+#!/usr/bin/env bash
+exec "$REAL_TMUX" -L "$SOCKET" "\$@"
+SHIM
+chmod +x "$TMUX_SHIM_DIR/tmux"
+
+nudge_count() { grep -c 'supervision liveness lapsed' "$LOG_FILE" 2>/dev/null || true; }
+
+start_daemon_present() {
+  # afk deliberately NOT set: the daemon runs in Mode B (present, liveness
+  # guardian). Small tick + grace so a missing beacon is an immediate lapse; a
+  # long nudge cooldown so exactly-one-nudge is the logic, not test timing.
+  PATH="$TMUX_SHIM_DIR:$PATH" \
+  FM_STATE_OVERRIDE="$STATE_DIR" \
+  FM_SUPERVISOR_TARGET="$SUPERVISOR_PANE" \
+  FM_GUARDIAN_TICK=2 \
+  FM_GUARD_GRACE=2 \
+  FM_GUARDIAN_NUDGE_COOLDOWN=9999 \
+  FM_POLL=1 \
+  FM_SIGNAL_GRACE=1 \
+  FM_HEARTBEAT=999999 \
+  FM_CHECK_INTERVAL=999999 \
+  FM_INJECT_CONFIRM_SLEEP=0.2 \
+  FM_INJECT_CONFIRM_RETRIES=5 \
+  nohup "$DAEMON" >"$STATE_DIR/daemon.out" 2>"$STATE_DIR/daemon.err" &
+  DAEMON_PID=$!
+  local i=0
+  while [ "$i" -lt 30 ]; do
+    [ -f "$STATE_DIR/.supervise-daemon.pid" ] && break
+    sleep 0.2; i=$((i + 1))
+  done
+  [ -f "$STATE_DIR/.supervise-daemon.pid" ] || {
+    echo "daemon stderr:" >&2; cat "$STATE_DIR/daemon.err" >&2
+    fail "daemon did not start (no pid file)"
+  }
+}
+
+test_present_lapse_restores_and_nudges_once() {
+  # Work in flight, no watcher, no beacon: firstmate's present-mode re-arm has
+  # lapsed. The running daemon must restore the watcher and nudge exactly once.
+  printf 'project=x\nkind=ship\n' > "$STATE_DIR/task-c1.meta"
+  rm -f "$STATE_DIR/.last-watcher-beat"
+
+  start_daemon_present
+
+  # Within a couple guardian ticks: the beacon comes back (watcher restored) and
+  # exactly one liveness nudge is submitted.
+  local i=0
+  while [ "$i" -lt 40 ]; do
+    [ -e "$STATE_DIR/.last-watcher-beat" ] && [ "$(nudge_count)" -ge 1 ] && break
+    sleep 0.5; i=$((i + 1))
+  done
+  [ -e "$STATE_DIR/.last-watcher-beat" ] \
+    || fail "guardian did not restore the watcher beacon while present"
+  [ "$(nudge_count)" -eq 1 ] \
+    || fail "expected exactly one liveness nudge, got $(nudge_count)"
+
+  # The nudge is sentinel-marked (classified injection), not a captain message.
+  grep 'supervision liveness lapsed' "$LOG_FILE" | grep -q 'injection$' \
+    || fail "liveness nudge was not a sentinel-marked injection"
+
+  # criterion 3: no routine spam. The restored watcher keeps beating; over the
+  # next several seconds the guardian must NOT nudge again.
+  sleep 6
+  [ "$(nudge_count)" -eq 1 ] \
+    || fail "guardian re-nudged while the watcher was healthy (routine injection - criterion 3), count=$(nudge_count)"
+  # And no spurious captain-message (user) line was ever submitted.
+  [ "$(grep -c $'\tuser$' "$LOG_FILE" 2>/dev/null || true)" -eq 0 ] \
+    || fail "guardian submitted a non-injection line while present"
+
+  pass "present: a liveness lapse restores the watcher and nudges exactly once, then stays silent (criteria 1, 3)"
+}
+
+test_clean_shutdown_releases_and_reaps() {
+  # criterion 6: SIGTERM the running daemon -> clean exit. The pidfile is removed,
+  # the singleton lock is released, and the forked watcher is torn down.
+  local watcher_pid
+  watcher_pid=$(cat "$STATE_DIR/.watch.lock/pid" 2>/dev/null || true)
+  kill -TERM "$DAEMON_PID" 2>/dev/null || true
+  local i=0
+  while [ "$i" -lt 60 ] && kill -0 "$DAEMON_PID" 2>/dev/null; do sleep 0.1; i=$((i + 1)); done
+  kill -0 "$DAEMON_PID" 2>/dev/null && fail "daemon did not exit on SIGTERM"
+  wait "$DAEMON_PID" 2>/dev/null || true
+  DAEMON_PID=""
+  [ ! -e "$STATE_DIR/.supervise-daemon.pid" ] || fail "daemon left its pidfile behind after shutdown"
+  [ ! -e "$STATE_DIR/.supervise-daemon.lock" ] || fail "daemon left its singleton lock behind after shutdown"
+  # The forked watcher should be gone too (cleanup kills the guardian's child).
+  if [ -n "$watcher_pid" ]; then
+    i=0
+    while [ "$i" -lt 40 ] && kill -0 "$watcher_pid" 2>/dev/null; do sleep 0.1; i=$((i + 1)); done
+    kill -0 "$watcher_pid" 2>/dev/null && fail "guardian-forked watcher leaked after daemon shutdown"
+  fi
+  pass "clean shutdown: SIGTERM removes the pidfile + lock and reaps the forked watcher (criterion 6)"
+}
+
+test_present_lapse_restores_and_nudges_once
+test_clean_shutdown_releases_and_reaps
+
+echo "all present-mode guardian e2e tests passed"

--- a/tests/fm-guardian-present-e2e.test.sh
+++ b/tests/fm-guardian-present-e2e.test.sh
@@ -123,6 +123,8 @@ start_daemon_present() {
   FM_GUARDIAN_TICK=2 \
   FM_GUARD_GRACE=2 \
   FM_GUARDIAN_NUDGE_COOLDOWN=9999 \
+  FM_ESCALATE_BATCH_SECS=0 \
+  FM_STALE_ESCALATE_SECS=999999 \
   FM_POLL=1 \
   FM_SIGNAL_GRACE=1 \
   FM_HEARTBEAT=999999 \
@@ -178,6 +180,35 @@ test_present_lapse_restores_and_nudges_once() {
   pass "present: a liveness lapse restores the watcher and nudges exactly once, then stays silent (criteria 1, 3)"
 }
 
+# criterion 4: afk is a policy toggle inside the ONE running process. Turning afk
+# on must transition the live daemon to away mode (own the watcher, self-handle +
+# escalate); turning it back off must return it to present/liveness-guardian.
+test_afk_toggle_in_one_process() {
+  : > "$LOG_FILE"                                   # clear the lapse nudge
+  # B -> A: afk on. The same daemon takes watcher ownership and self-handles.
+  date +%s > "$STATE_DIR/.afk"
+  sleep 3                                           # let the 1s poll notice + take over
+  echo "done: PR https://example.test/pr/777 checks green" > "$STATE_DIR/task-c1.status"
+  local i=0
+  while [ "$i" -lt 40 ]; do
+    grep -q 'Supervisor escalate' "$LOG_FILE" && break
+    sleep 0.5; i=$((i + 1))
+  done
+  grep -q 'Supervisor escalate' "$LOG_FILE" \
+    || fail "B->A: daemon did not escalate a captain status after afk turned on (transition or away mode broke)"
+
+  # A -> B: afk off. The same process returns to present mode and must NOT escalate
+  # a routine status (present mode never injects a routine wake).
+  rm -f "$STATE_DIR/.afk"
+  sleep 3
+  : > "$LOG_FILE"
+  echo "working: still compiling" > "$STATE_DIR/task-c1.status"
+  sleep 5
+  grep -q 'Supervisor escalate' "$LOG_FILE" \
+    && fail "A->B: daemon escalated while present (afk off) - did not return to liveness-guardian mode"
+  pass "afk toggles mode in one running process: B->A self-handles+escalates, A->B returns to present (criterion 4)"
+}
+
 test_clean_shutdown_releases_and_reaps() {
   # criterion 6: SIGTERM the running daemon -> clean exit. The pidfile is removed,
   # the singleton lock is released, and the forked watcher is torn down.
@@ -201,6 +232,7 @@ test_clean_shutdown_releases_and_reaps() {
 }
 
 test_present_lapse_restores_and_nudges_once
+test_afk_toggle_in_one_process
 test_clean_shutdown_releases_and_reaps
 
 echo "all present-mode guardian e2e tests passed"

--- a/tests/fm-guardian.test.sh
+++ b/tests/fm-guardian.test.sh
@@ -1,0 +1,334 @@
+#!/usr/bin/env bash
+# tests/fm-guardian.test.sh - the always-on supervisor daemon's Mode B (present)
+# liveness guardian: the structural fix that makes a missed watcher re-arm
+# self-heal instead of silently stopping supervision. These are the deterministic
+# units + real-process singleton checks behind the acceptance criteria; the full
+# operator-visible lapse->restore->nudge->shutdown flow through a real daemon lives
+# in fm-guardian-present-e2e.test.sh.
+#
+# Mapping to the spec's acceptance criteria:
+#   1 (restore + exactly one nudge)  test_guardian_restores_watcher_and_nudges_once
+#   2 (no double watcher)            test_guardian_restore_is_singleton_safe
+#   3 (no routine-wake injection)    test_guardian_no_nudge_when_beacon_fresh,
+#                                    test_guardian_lapsed_matrix
+#   4 (afk unchanged)                covered by fm-afk-inject-e2e + fm-daemon units
+#   5 (home isolation, no broad kill) test_no_broad_pkill_in_sources
+#   6 (self-heal, clean shutdown)    fm-guardian-present-e2e + test_restore_does_not_stack
+#   7 (guard banner still fires)     test_guard_banner_still_fires_with_daemon_model
+set -u
+
+# shellcheck source=tests/wake-helpers.sh
+. "$(dirname "${BASH_SOURCE[0]}")/wake-helpers.sh"
+
+DAEMON="$ROOT/bin/fm-supervise-daemon.sh"
+WATCH="$ROOT/bin/fm-watch.sh"
+GUARDIAN_ARM="$ROOT/bin/fm-guardian-arm.sh"
+
+# Source the daemon's pure functions once (its main loop is BASH_SOURCE-guarded).
+if [ -z "${FM_TEST_DAEMON_SOURCED:-}" ]; then
+  export FM_TEST_DAEMON_SOURCED=1
+  # shellcheck source=bin/fm-supervise-daemon.sh
+  . "$DAEMON"
+fi
+
+TMP_ROOT=$(fm_test_tmproot fm-guardian-tests)
+
+# A deterministic stub "watcher": it makes the liveness beacon fresh (like the
+# real watcher's per-poll touch) and stays alive, so a guardian restore is
+# observable without the real watcher's lock machinery. FM_WATCH_CMD points the
+# guardian at it.
+make_stub_watcher() {  # <dir>
+  local dir=$1 stub="$1/stub-watcher.sh"
+  cat > "$stub" <<'SH'
+#!/usr/bin/env bash
+touch "${FM_STATE_OVERRIDE:?}/.last-watcher-beat"
+exec sleep 30
+SH
+  chmod +x "$stub"
+  printf '%s\n' "$stub"
+}
+
+reap_guardian_watcher() {
+  if [ -n "${GUARDIAN_WATCHER_PID:-}" ]; then
+    kill "$GUARDIAN_WATCHER_PID" 2>/dev/null || true
+    wait "$GUARDIAN_WATCHER_PID" 2>/dev/null || true
+  fi
+  GUARDIAN_WATCHER_PID=""
+}
+
+# --- guardian_lapsed: the detection contract (criterion 3 boundary) ----------
+test_guardian_lapsed_matrix() {
+  local dir state
+  dir=$(make_supercase guardian-lapsed)
+  state="$dir/state"
+
+  # No work in flight -> never a lapse, even with no beacon at all.
+  rm -f "$state"/*.meta 2>/dev/null || true
+  rm -f "$state/.last-watcher-beat"
+  if FM_GUARD_GRACE=2 guardian_lapsed "$state"; then
+    fail "guardian_lapsed true with no work in flight"
+  fi
+
+  # Work in flight + fresh beacon -> NOT a lapse (a live watcher is beating).
+  printf 'project=x\n' > "$state/task.meta"
+  touch "$state/.last-watcher-beat"
+  if FM_GUARD_GRACE=300 guardian_lapsed "$state"; then
+    fail "guardian_lapsed true while the beacon is fresh (routine, not a lapse)"
+  fi
+
+  # Work in flight + missing beacon -> lapse.
+  rm -f "$state/.last-watcher-beat"
+  FM_GUARD_GRACE=300 guardian_lapsed "$state" || fail "missing beacon with work in flight is not a lapse"
+
+  # Work in flight + stale beacon -> lapse.
+  touch -t 200001010000 "$state/.last-watcher-beat"
+  FM_GUARD_GRACE=300 guardian_lapsed "$state" || fail "stale beacon with work in flight is not a lapse"
+
+  pass "guardian_lapsed: lapse only when work is in flight AND the beacon is missing/stale"
+}
+
+# --- guardian_nudge_due: exactly-one-nudge cooldown (criterion 1) ------------
+test_guardian_nudge_due_cooldown() {
+  local dir state
+  dir=$(make_supercase guardian-cooldown)
+  state="$dir/state"
+  # The cooldown keys off the marker's MTIME (via _file_age), not its content.
+  rm -f "$state/.guardian-last-nudge"
+  FM_GUARD_GRACE=300 guardian_nudge_due "$state" || fail "first nudge should be due (no marker)"
+  touch "$state/.guardian-last-nudge"                       # mtime = now -> within cooldown
+  if FM_GUARD_GRACE=300 guardian_nudge_due "$state"; then
+    fail "a fresh nudge marker should suppress a second nudge (cooldown)"
+  fi
+  touch -t 200001010000 "$state/.guardian-last-nudge"       # mtime far in the past -> aged out
+  FM_GUARD_GRACE=300 guardian_nudge_due "$state" || fail "an aged nudge marker should allow a new nudge"
+  pass "guardian_nudge_due: one nudge per cooldown window, re-armed after it elapses"
+}
+
+# --- criterion 3: a fresh beacon (routine) produces NO injection -------------
+test_guardian_no_nudge_when_beacon_fresh() {
+  local dir state sent
+  dir=$(make_supercase guardian-fresh-noop)
+  state="$dir/state"
+  sent="$dir/sent.log"; : > "$sent"
+  printf 'project=x\n' > "$state/task.meta"
+  touch "$state/.last-watcher-beat"          # a live watcher is beating
+  rm -f "$state/.guardian-last-nudge"
+  PATH="$dir/fakebin:$PATH" FM_FAKE_TMUX_PANE_ALIVE=1 FM_FAKE_TMUX_SENT="$sent" \
+    FM_FAKE_TMUX_CAPTURE="$dir/pane.txt" FM_STATE_OVERRIDE="$state" FM_GUARD_GRACE=300 \
+    guardian_step "$state"
+  [ ! -s "$sent" ] || fail "guardian injected on a routine tick (fresh beacon) - criterion 3 violated"
+  [ ! -e "$state/.guardian-last-nudge" ] || fail "guardian recorded a nudge with a fresh beacon"
+  [ -z "${GUARDIAN_WATCHER_PID:-}" ] || fail "guardian forked a watcher with a fresh beacon"
+  pass "guardian: a fresh beacon is a no-op - no watcher fork, no nudge (criterion 3)"
+}
+
+test_guardian_no_action_without_work() {
+  local dir state sent
+  dir=$(make_supercase guardian-nowork)
+  state="$dir/state"
+  sent="$dir/sent.log"; : > "$sent"
+  rm -f "$state"/*.meta 2>/dev/null || true
+  rm -f "$state/.last-watcher-beat"          # no beacon, but also no work
+  PATH="$dir/fakebin:$PATH" FM_FAKE_TMUX_PANE_ALIVE=1 FM_FAKE_TMUX_SENT="$sent" \
+    FM_FAKE_TMUX_CAPTURE="$dir/pane.txt" FM_STATE_OVERRIDE="$state" FM_GUARD_GRACE=2 \
+    guardian_step "$state"
+  [ ! -s "$sent" ] || fail "guardian injected with no work in flight"
+  [ -z "${GUARDIAN_WATCHER_PID:-}" ] || fail "guardian forked a watcher with no work in flight"
+  pass "guardian: no work in flight is a no-op even with a missing beacon"
+}
+
+# --- criterion 1: lapse -> restore liveness + exactly ONE nudge --------------
+test_guardian_restores_watcher_and_nudges_once() {
+  local dir state sent stub i
+  dir=$(make_supercase guardian-restore)
+  state="$dir/state"
+  sent="$dir/sent.log"; : > "$sent"
+  : > "$dir/pane.txt"
+  stub=$(make_stub_watcher "$dir")
+  printf 'project=x\n' > "$state/task.meta"   # work in flight
+  rm -f "$state/.last-watcher-beat"           # watcher killed: lapse
+  rm -f "$state/.guardian-last-nudge"
+  GUARDIAN_WATCHER_PID=""
+
+  # First guardian tick on a detected lapse: restore the watcher + nudge once.
+  # Small grace so the missing beacon is an immediate lapse; a long nudge cooldown
+  # so "exactly one nudge" is a property of the logic, not of test timing.
+  PATH="$dir/fakebin:$PATH" FM_FAKE_TMUX_PANE_ALIVE=1 FM_FAKE_TMUX_SENT="$sent" \
+    FM_FAKE_TMUX_CAPTURE="$dir/pane.txt" FM_STATE_OVERRIDE="$state" FM_WATCH_CMD="$stub" \
+    FM_WATCH_ERR="$dir/watch.err" FM_GUARD_GRACE=2 FM_GUARDIAN_NUDGE_COOLDOWN=9999 \
+    FM_INJECT_CONFIRM_SLEEP=0.05 guardian_step "$state"
+
+  # The beacon goes fresh again (liveness restored) within a beat.
+  i=0
+  while [ "$i" -lt 50 ] && [ ! -e "$state/.last-watcher-beat" ]; do sleep 0.1; i=$((i + 1)); done
+  [ -e "$state/.last-watcher-beat" ] || { reap_guardian_watcher; fail "guardian did not restore the watcher beacon"; }
+  if [ -z "${GUARDIAN_WATCHER_PID:-}" ] || ! kill -0 "$GUARDIAN_WATCHER_PID" 2>/dev/null; then
+    reap_guardian_watcher
+    fail "guardian did not keep a restored watcher alive"
+  fi
+
+  # Exactly one nudge was submitted, and it is the liveness-lapse nudge.
+  [ "$(grep -c 'supervision liveness lapsed' "$sent")" -eq 1 ] \
+    || { reap_guardian_watcher; fail "expected exactly one liveness nudge, got $(grep -c 'supervision liveness lapsed' "$sent")"; }
+  [ "$(grep -c '\[ENTER\]' "$sent")" -eq 1 ] \
+    || { reap_guardian_watcher; fail "nudge was not submitted exactly once"; }
+
+  # A second tick within the cooldown must NOT nudge again (exactly one). The
+  # restored stub keeps the beacon fresh, so this is also a no-lapse no-op.
+  PATH="$dir/fakebin:$PATH" FM_FAKE_TMUX_PANE_ALIVE=1 FM_FAKE_TMUX_SENT="$sent" \
+    FM_FAKE_TMUX_CAPTURE="$dir/pane.txt" FM_STATE_OVERRIDE="$state" FM_WATCH_CMD="$stub" \
+    FM_WATCH_ERR="$dir/watch.err" FM_GUARD_GRACE=2 FM_GUARDIAN_NUDGE_COOLDOWN=9999 \
+    FM_INJECT_CONFIRM_SLEEP=0.05 guardian_step "$state"
+  [ "$(grep -c 'supervision liveness lapsed' "$sent")" -eq 1 ] \
+    || { reap_guardian_watcher; fail "guardian re-nudged within the cooldown (criterion 1: exactly one)"; }
+
+  reap_guardian_watcher
+  pass "guardian: a detected lapse restores the watcher and nudges firstmate exactly once (criterion 1)"
+}
+
+# The nudge must carry the sentinel marker so a PRESENT firstmate tells it from a
+# captain message, and inject_nudge must NOT be afk-gated (it fires while present).
+test_inject_nudge_marked_and_not_afk_gated() {
+  local dir state sent nudge_line
+  dir=$(make_supercase guardian-nudge-marker)
+  state="$dir/state"
+  sent="$dir/sent.log"; : > "$sent"
+  : > "$dir/pane.txt"
+  # afk deliberately NOT set (present). inject_msg would defer here; inject_nudge must not.
+  PATH="$dir/fakebin:$PATH" FM_FAKE_TMUX_PANE_ALIVE=1 FM_FAKE_TMUX_SENT="$sent" \
+    FM_FAKE_TMUX_CAPTURE="$dir/pane.txt" FM_INJECT_CONFIRM_SLEEP=0.05 \
+    inject_nudge "supervision liveness lapsed - draining the wake-queue and resuming" "$state" \
+    || fail "inject_nudge did not deliver while afk was off (it must not be presence-gated)"
+  grep -F 'supervision liveness lapsed' "$sent" >/dev/null || fail "nudge text was not submitted"
+  # The submitted line starts with the sentinel marker byte (0x1f). Pure-bash
+  # first-char check against FM_INJECT_MARK (no `od`, which a PATH shim can shadow).
+  nudge_line=$(grep -F 'supervision liveness lapsed' "$sent" | head -1)
+  [ "${nudge_line:0:1}" = "$FM_INJECT_MARK" ] || fail "nudge is not sentinel-marked (first char not 0x1f)"
+  # Contrast: inject_msg (Mode A) stays presence-gated and defers while afk is off.
+  : > "$sent"
+  if PATH="$dir/fakebin:$PATH" FM_FAKE_TMUX_PANE_ALIVE=1 FM_FAKE_TMUX_SENT="$sent" \
+    FM_FAKE_TMUX_CAPTURE="$dir/pane.txt" inject_msg "an escalation" "$state"; then
+    fail "inject_msg delivered while afk inactive (it must stay presence-gated)"
+  fi
+  [ ! -s "$sent" ] || fail "inject_msg injected while afk inactive"
+  pass "inject_nudge is sentinel-marked and fires while present; inject_msg stays afk-gated"
+}
+
+# --- criterion 2: the guardian restore can never double-arm the watcher ------
+test_guardian_restore_is_singleton_safe() {
+  local dir state i a_pid
+  dir=$(make_case guardian-singleton)   # make_case gives a list/capture tmux shim
+  state="$dir/state"
+
+  # "firstmate's" watcher: a real fm-watch.sh holding the singleton + beating.
+  PATH="$dir/fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_POLL=5 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" >/dev/null 2>&1 &
+  a_pid=$!
+  i=0
+  while [ "$i" -lt 60 ]; do
+    [ "$(cat "$state/.watch.lock/pid" 2>/dev/null || true)" = "$a_pid" ] && break
+    sleep 0.1; i=$((i + 1))
+  done
+  [ "$(cat "$state/.watch.lock/pid" 2>/dev/null || true)" = "$a_pid" ] \
+    || { kill "$a_pid" 2>/dev/null; fail "seed watcher did not take the singleton lock"; }
+
+  # The guardian forks a watcher via the singleton-safe path: it must stand down
+  # rather than become a second live watcher.
+  GUARDIAN_WATCHER_PID=""
+  PATH="$dir/fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_POLL=5 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 FM_WATCH_CMD="$WATCH" \
+    FM_WATCH_ERR="$dir/watch.err" guardian_restore_watcher
+  local b_pid=$GUARDIAN_WATCHER_PID
+  [ -n "$b_pid" ] || { kill "$a_pid" 2>/dev/null; fail "guardian did not fork a watcher"; }
+  wait_for_exit "$b_pid" 60 || true   # the redundant fork exits ("already running")
+
+  is_live_non_zombie "$a_pid" || { kill "$a_pid" "$b_pid" 2>/dev/null; fail "the original watcher died - guardian fork stole the singleton"; }
+  is_live_non_zombie "$b_pid" && { kill "$a_pid" "$b_pid" 2>/dev/null; fail "two live watchers after a guardian restore (double-arm) - criterion 2 violated"; }
+  [ "$(cat "$state/.watch.lock/pid" 2>/dev/null || true)" = "$a_pid" ] \
+    || { kill "$a_pid" "$b_pid" 2>/dev/null; fail "guardian fork disturbed the live watcher's lock"; }
+
+  kill "$a_pid" "$b_pid" 2>/dev/null || true
+  wait "$a_pid" 2>/dev/null || true
+  GUARDIAN_WATCHER_PID=""
+  pass "guardian restore is singleton-safe: a redundant fork stands down, exactly one watcher survives (criterion 2)"
+}
+
+# guardian_restore_watcher must not stack forks: while one forked watcher is still
+# alive, a second call is a no-op (no crash-spin of watcher processes; criterion 6).
+test_restore_does_not_stack() {
+  local dir stub first second
+  dir=$(make_supercase guardian-nostack)
+  stub=$(make_stub_watcher "$dir")
+  GUARDIAN_WATCHER_PID=""
+  FM_STATE_OVERRIDE="$dir/state" FM_WATCH_CMD="$stub" FM_WATCH_ERR="$dir/watch.err" \
+    guardian_restore_watcher
+  first=$GUARDIAN_WATCHER_PID
+  [ -n "$first" ] || fail "first restore did not fork a watcher"
+  FM_STATE_OVERRIDE="$dir/state" FM_WATCH_CMD="$stub" FM_WATCH_ERR="$dir/watch.err" \
+    guardian_restore_watcher
+  second=$GUARDIAN_WATCHER_PID
+  [ "$first" = "$second" ] || { kill "$first" "$second" 2>/dev/null; fail "restore stacked a second watcher fork while one was alive"; }
+  reap_guardian_watcher
+  pass "guardian_restore_watcher does not stack forks while one is alive (criterion 6)"
+}
+
+# --- criterion 5: home isolation - never a broad pkill -----------------------
+test_no_broad_pkill_in_sources() {
+  local f
+  for f in "$DAEMON" "$GUARDIAN_ARM"; do
+    # Strip comments first: a "Never a broad pkill" caution is fine; an actual
+    # pkill invocation is not (it would match sibling/secondmate homes).
+    if sed 's/#.*//' "$f" | grep -nE 'pkill' >/dev/null 2>&1; then
+      fail "pkill invocation found in $(basename "$f") - would match sibling/secondmate homes (criterion 5)"
+    fi
+  done
+  # The daemon's takeover stops only a pid the lock proves is THIS home's watcher.
+  grep -F 'daemon_watch_lock_is_genuine' "$DAEMON" >/dev/null \
+    || fail "daemon takeover lost its identity-checked, home-scoped stop"
+  pass "no pkill invocation in the daemon or guardian-arm; takeover is home-scoped + identity-checked (criterion 5)"
+}
+
+# --- criterion 7: the pull-based guard banner still fires on a real lapse -----
+# Defense in depth: even with the daemon model, fm-guard.sh must still alarm on a
+# stale beacon with work in flight, so a human touching the fleet sees it.
+test_guard_banner_still_fires_with_daemon_model() {
+  local dir state err
+  dir=$(make_case guardian-guard-banner)
+  state="$dir/state"
+  err="$dir/guard.err"
+  printf 'project=x\n' > "$state/task.meta"
+  # No beacon -> watcher down. Non-git FM_ROOT keeps the tangle guard inert.
+  FM_ROOT_OVERRIDE="$dir" FM_STATE_OVERRIDE="$state" FM_GUARD_GRACE=1 \
+    "$ROOT/bin/fm-guard.sh" 2> "$err" >/dev/null || fail "guard exited non-zero"
+  grep -F 'WATCHER DOWN - SUPERVISION IS OFF' "$err" >/dev/null \
+    || fail "guard banner did not fire on a stale beacon with work in flight (criterion 7)"
+  pass "fm-guard.sh still fires its stale-beacon banner under the daemon model (criterion 7)"
+}
+
+# --- guardian-arm is singleton-safe (no-op when a live daemon already runs) ---
+test_guardian_arm_no_ops_when_daemon_alive() {
+  local dir state out
+  dir=$(make_case guardian-arm-noop)
+  state="$dir/state"
+  # A live "daemon": any live pid recorded in the pidfile.
+  sleep 30 &
+  local fake=$!
+  printf '%s\n' "$fake" > "$state/.supervise-daemon.pid"
+  out=$(FM_STATE_OVERRIDE="$state" FM_HOME="$dir" "$GUARDIAN_ARM" 2>&1) || fail "guardian-arm exited non-zero with a live daemon"
+  grep -F "already running pid=$fake" <<<"$out" >/dev/null || fail "guardian-arm did not no-op for a live daemon: $out"
+  kill "$fake" 2>/dev/null || true
+  wait "$fake" 2>/dev/null || true
+  pass "guardian-arm no-ops when a live daemon already holds this home"
+}
+
+test_guardian_lapsed_matrix
+test_guardian_nudge_due_cooldown
+test_guardian_no_nudge_when_beacon_fresh
+test_guardian_no_action_without_work
+test_guardian_restores_watcher_and_nudges_once
+test_inject_nudge_marked_and_not_afk_gated
+test_guardian_restore_is_singleton_safe
+test_restore_does_not_stack
+test_no_broad_pkill_in_sources
+test_guard_banner_still_fires_with_daemon_model
+test_guardian_arm_no_ops_when_daemon_alive

--- a/tests/fm-guardian.test.sh
+++ b/tests/fm-guardian.test.sh
@@ -56,6 +56,23 @@ reap_guardian_watcher() {
   GUARDIAN_WATCHER_PID=""
 }
 
+# A stand-in for the real daemon: a long-lived bash process whose argv contains
+# "fm-supervise-daemon", so guardian-arm's identity check recognizes it as a
+# genuine daemon (the real daemon is likewise a non-exec'd bash process running a
+# script of that name). No exec, so ps -o command= keeps reporting this script's
+# path rather than sleep; the TERM trap reaps the sleep child so nothing orphans.
+write_daemon_stub() {  # <dir> -> prints stub path
+  local dir=$1 stub="$1/fm-supervise-daemon-stub.sh"
+  cat > "$stub" <<'SH'
+#!/usr/bin/env bash
+trap 'kill "${child:-}" 2>/dev/null; exit 0' TERM INT
+sleep 30 & child=$!
+wait "$child"
+SH
+  chmod +x "$stub"
+  printf '%s\n' "$stub"
+}
+
 # --- guardian_lapsed: the detection contract (criterion 3 boundary) ----------
 test_guardian_lapsed_matrix() {
   local dir state
@@ -307,18 +324,55 @@ test_guard_banner_still_fires_with_daemon_model() {
 
 # --- guardian-arm is singleton-safe (no-op when a live daemon already runs) ---
 test_guardian_arm_no_ops_when_daemon_alive() {
-  local dir state out
+  local dir state out stub daemon_pid
   dir=$(make_case guardian-arm-noop)
   state="$dir/state"
-  # A live "daemon": any live pid recorded in the pidfile.
+  # A live, GENUINE daemon: a stub whose argv contains fm-supervise-daemon so the
+  # identity check recognizes it. Liveness alone is not the contract — a bare
+  # 'sleep 30' must NOT pass (asserted by the recycled-pid test below).
+  stub=$(write_daemon_stub "$dir")
+  "$stub" &
+  daemon_pid=$!
+  printf '%s\n' "$daemon_pid" > "$state/.supervise-daemon.pid"
+  out=$(FM_STATE_OVERRIDE="$state" FM_HOME="$dir" "$GUARDIAN_ARM" 2>&1) \
+    || { kill "$daemon_pid" 2>/dev/null; wait "$daemon_pid" 2>/dev/null; fail "guardian-arm exited non-zero with a live daemon"; }
+  grep -F "already running pid=$daemon_pid" <<<"$out" >/dev/null \
+    || { kill "$daemon_pid" 2>/dev/null; wait "$daemon_pid" 2>/dev/null; fail "guardian-arm did not no-op for a live daemon: $out"; }
+  kill "$daemon_pid" 2>/dev/null || true
+  wait "$daemon_pid" 2>/dev/null || true
+  pass "guardian-arm no-ops when a live, genuine daemon already holds this home"
+}
+
+# --- guardian-arm does NOT trust a recycled non-daemon pid (the finding) ------
+# After an unclean daemon death the pidfile is stale; if that pid is recycled to an
+# unrelated live process, a liveness-only check would falsely no-op and start no
+# guardian. The identity check closes that: a live pid that is NOT a daemon must
+# make guardian-arm proceed to start rather than print "already running".
+test_guardian_arm_starts_for_recycled_non_daemon_pid() {
+  local dir state out fake daemon_pid
+  dir=$(make_case guardian-arm-recycled)
+  state="$dir/state"
+  # A live but UNRELATED pid: a plain sleep, whose argv is not the daemon.
   sleep 30 &
-  local fake=$!
+  fake=$!
   printf '%s\n' "$fake" > "$state/.supervise-daemon.pid"
-  out=$(FM_STATE_OVERRIDE="$state" FM_HOME="$dir" "$GUARDIAN_ARM" 2>&1) || fail "guardian-arm exited non-zero with a live daemon"
-  grep -F "already running pid=$fake" <<<"$out" >/dev/null || fail "guardian-arm did not no-op for a live daemon: $out"
+  # The fakebin tmux (make_case) fails display-message, so the daemon guardian-arm
+  # launches fails target validation and self-terminates immediately — the start
+  # path runs without leaving a real daemon behind.
+  out=$(PATH="$dir/fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_HOME="$dir" "$GUARDIAN_ARM" 2>&1) || true
+  if grep -F "already running" <<<"$out" >/dev/null; then
+    kill "$fake" 2>/dev/null; wait "$fake" 2>/dev/null
+    fail "guardian-arm falsely no-opped on a recycled non-daemon pid (identity check missing): $out"
+  fi
+  # Best-effort cleanup of any daemon the start path may have spawned before exit.
+  daemon_pid=$(cat "$state/.supervise-daemon.pid" 2>/dev/null || true)
+  case "$daemon_pid" in
+    ''|*[!0-9]*) : ;;
+    *) [ "$daemon_pid" != "$fake" ] && { kill "$daemon_pid" 2>/dev/null || true; wait "$daemon_pid" 2>/dev/null || true; } ;;
+  esac
   kill "$fake" 2>/dev/null || true
   wait "$fake" 2>/dev/null || true
-  pass "guardian-arm no-ops when a live daemon already holds this home"
+  pass "guardian-arm starts (no false no-op) when the pidfile names a live NON-daemon pid"
 }
 
 test_guardian_lapsed_matrix
@@ -332,3 +386,4 @@ test_restore_does_not_stack
 test_no_broad_pkill_in_sources
 test_guard_banner_still_fires_with_daemon_model
 test_guardian_arm_no_ops_when_daemon_alive
+test_guardian_arm_starts_for_recycled_non_daemon_pid

--- a/tests/fm-send-secondmate-marker.test.sh
+++ b/tests/fm-send-secondmate-marker.test.sh
@@ -152,16 +152,15 @@ test_key_path_is_not_marked() {
 }
 
 test_marker_is_label_plus_unit_separator() {
-  local us hex
+  local us
   us=$(printf '\037')
   [ "$FM_FROMFIRST_MARK" = "[fm-from-firstmate]$us" ] \
-    || fail "marker is not the expected label + 0x1f sequence"$'\n'"--- bytes ---"$'\n'"$(printf '%s' "$FM_FROMFIRST_MARK" | od -An -c)"
+    || fail "marker is not the expected label + 0x1f sequence"
   # The last byte must be ASCII unit separator 0x1f, the untypable guarantee.
-  hex=$(printf '%s' "$FM_FROMFIRST_MARK" | od -An -tx1 | tr -d ' \n')
-  case "$hex" in
-    *1f) : ;;
-    *) fail "marker does not end in a 0x1f byte; bytes were: $hex" ;;
-  esac
+  # Pure-bash last-char check (no `od`, which a PATH shim can shadow to a
+  # same-named tool, e.g. the Open Design `od` CLI).
+  [ "${FM_FROMFIRST_MARK: -1}" = "$us" ] \
+    || fail "marker does not end in a 0x1f byte"
   # The detector keys on that exact untypable sequence.
   fm_message_from_firstmate "${FM_FROMFIRST_MARK}do the work" \
     || fail "detector should recognize a marked message"


### PR DESCRIPTION
## Intent

The developer was working on the firstmate agent-supervision system and needed to fix a structural flaw where the watcher process (bin/fm-watch.sh) was one-shot and relied entirely on firstmate re-arming it every turn, so a skipped re-arm silently stopped supervision (which had already caused a ~69-minute gap). Their goal was to promote the supervisor daemon (bin/fm-supervise-daemon.sh) from afk-only to an always-on, per-home liveness guardian with two modes in one long-lived process: afk-on behavior unchanged, and a new present/afk-off mode that only restores the watcher and injects exactly one nudge when it detects a genuine liveness lapse (work in flight plus a missing or stale beacon). They imposed strict constraints: maintain exactly one watcher and one lock owner with no double-arming under any race, keep everything home-scoped with no broad pkill that could kill sibling or secondmate homes, start the daemon at bootstrap and recovery (not just /afk), and never inject for routine wakes. Required deliverables included a guardian-arm script, rewrites of AGENTS.md sections 8/5/3/2 and the afk SKILL.md, and tests covering all seven acceptance criteria. They also mandated exactly one Codex review pass over the committed diff (focused on the double-watcher race, home-scoping, and the inject-when-present rule) before running the no-mistakes validation pipeline, treating an external spec file as authoritative while keeping the present-mode change minimal and validating hard since this is the live fleet's supervision backbone.

## What Changed

- Promoted the supervisor daemon (`bin/fm-supervise-daemon.sh`) from afk-only to an always-on, per-home liveness guardian: one long-lived process now runs two modes toggled in-process by `state/.afk`. Present mode (afk off) does not own the watcher and only restores a lapsed watcher plus injects exactly one nudge when it detects a genuine liveness lapse (work in flight with a missing or stale beacon); away mode behavior is unchanged. Restore and signaling stay home-scoped via the lock-recorded pid, never a broad `pkill`.
- Added `bin/fm-guardian-arm.sh`, a singleton-safe starter that no-ops when a live daemon already holds the home (with a pid-identity check on the pidfile so a recycled pid is not mistaken for the daemon), and wired `bin/fm-bootstrap.sh` to arm it at session start so the watcher is guaranteed alive without depending on per-turn re-arm discipline.
- Rewrote the relevant `AGENTS.md` sections and `afk/SKILL.md`, refreshed `docs/`, `README.md`, and `CONTRIBUTING.md`, and added `tests/fm-guardian.test.sh` and `tests/fm-guardian-present-e2e.test.sh` covering all seven acceptance criteria (lapse detection, exactly-one-nudge cooldown, fresh-beacon/no-work no-ops, singleton-safe restore with no fork stacking, home-scoped takeover, and the afk B->A->B transition).

## Risk Assessment

✅ Low: The change is well-bounded, extensively tested (12 units + 3 e2e covering all seven acceptance criteria), home-scoped and singleton-safe with real-process verification, docs consistent with code, and the round-1 fix correctly applied; the only remaining items are well-mitigated info-level tradeoffs.

## Testing

Ran the two new guardian suites and four adjacent suites under the repo's CI command on macOS bash 3.2 with tmux 3.6b; all passed. Beyond the passing tests, I drove the real supervisor daemon through the exact failure mode the change targets (a missed watcher re-arm) and captured the operator-visible result: the daemon restored the watcher itself and delivered exactly one sentinel-marked liveness nudge to firstmate's pane, produced no routine-wake spam, and shut down cleanly. No screenshot/GIF artifact applies because this is a backend tmux-supervision daemon with no rendered UI; the equivalent product-level evidence is the captured supervisor-pane transcript and daemon log, both saved to the evidence dir.

<details>
<summary>Evidence: Real-daemon lapse-&gt;restore-&gt;single-nudge-&gt;clean-shutdown transcript</summary>

<code>### SETUP: ship task in flight, watcher re-arm lapsed (no beacon)&#10;beacon present before daemon: NO&#10;### daemon started in PRESENT mode (afk OFF), pid 45073&#10;beacon restored by daemon: YES watcher lock pid now held: 45155&#10;### firstmate&#39;s pane received:&#10;INJECTION supervision liveness lapsed - draining the wake-queue and resuming&#10;nudge count: 1&#10;### no routine spam: nudges before idle window: 1 after 6s healthy: 1&#10;### clean shutdown: pidfile removed YES; singleton lock removed YES; forked watcher reaped YES</code>

```text
### SETUP: a ship task is in flight, but the watcher re-arm has lapsed (no beacon)
beacon present before daemon: NO

### Starting the always-on supervisor daemon in PRESENT mode (afk OFF)...
daemon pid: 45073

### Waiting for the guardian to detect the lapse, restore the watcher, and nudge once...
beacon restored by daemon: YES
watcher lock pid now held: 45155

### What firstmate's pane received (INJECTION = sentinel-marked internal message):
----------------------------------------------------------------------
INJECTION	supervision liveness lapsed - draining the wake-queue and resuming
----------------------------------------------------------------------
nudge count: 1

### Confirming NO routine spam: watcher healthy, 6s of silence expected...
nudges before idle window: 1   after 6s healthy: 1   (must stay 1)

### Relevant daemon log lines:

### Clean shutdown on SIGTERM...
pidfile removed:       YES
singleton lock removed: YES
forked watcher reaped: YES

### Artifacts written to /var/folders/cs/7fdvl2j92sd9x9t5l763vn_c0000gn/T/no-mistakes-evidence/01KW2XVRE176FSJJNNSMN8ZBZM
```
</details>
<details>
<summary>Evidence: Supervisor pane content firstmate actually received (sentinel-marked injection)</summary>

`INJECTION supervision liveness lapsed - draining the wake-queue and resuming`

```text
INJECTION	supervision liveness lapsed - draining the wake-queue and resuming
```
</details>
<details>
<summary>Evidence: Daemon log: always-on two-mode startup + present-mode liveness restore</summary>

<code>daemon starting; always-on, two-mode; afk=off (afk on=away/own+escalate, off=present/liveness-guardian); guardian_tick=2s; guard_grace=2s&#10;afk off: released watcher ownership (present mode: liveness guardian only)&#10;guardian: liveness lapse — restored watcher and nudged firstmate&#10;daemon shutting down</code>

```text
[2026-06-27T03:50:29+0530] daemon starting (pid 47096); always-on, two-mode; target=%0; target_source=FM_SUPERVISOR_TARGET; afk=off (afk on=away/own+escalate, off=present/liveness-guardian); guardian_tick=2s; guard_grace=2s; inject_skip='heartbeat'; stale_escalate=999999s; batch=0s
[2026-06-27T03:50:29+0530] afk off: released watcher ownership (present mode: liveness guardian only)
[2026-06-27T03:50:32+0530] guardian: liveness lapse — restored watcher and nudged firstmate
[2026-06-27T03:50:38+0530] daemon shutting down
```
</details>
<details>
<summary>Evidence: Present-mode e2e suite output (criteria 1,3,4,6)</summary>

<code>ok - present: a liveness lapse restores the watcher and nudges exactly once, then stays silent (criteria 1, 3)&#10;ok - afk toggles mode in one running process: B-&gt;A self-handles+escalates, A-&gt;B returns to present (criterion 4)&#10;ok - clean shutdown: SIGTERM removes the pidfile + lock and reaps the forked watcher (criterion 6)&#10;all present-mode guardian e2e tests passed</code>

```text
ok - present: a liveness lapse restores the watcher and nudges exactly once, then stays silent (criteria 1, 3)
ok - afk toggles mode in one running process: B->A self-handles+escalates, A->B returns to present (criterion 4)
ok - clean shutdown: SIGTERM removes the pidfile + lock and reaps the forked watcher (criterion 6)
all present-mode guardian e2e tests passed
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ℹ️ `bin/fm-supervise-daemon.sh:902` - The daemon&#39;s supervisor target (FM_SUPERVISOR_TARGET) is discovered once at startup from TMUX_PANE and never refreshed in the loop. Because the daemon is now always-on and deliberately survives firstmate restarts (bootstrap/recovery&#39;s guardian-arm no-ops for a live daemon), a firstmate that restarts in a different/reused tmux pane leaves the daemon holding a stale target. Blast radius is small and well-mitigated: the core guarantee (restoring the watcher) does not depend on the pane, and _inject_marked defers when the pane is gone, with fm-guard.sh&#39;s banner as the human-visible backstop; only nudge *delivery* degrades (deferred if the pane is gone, or mis-delivered in the rare reused-pane case). There is also no documented daemon-restart path to force a target refresh. Noting as a deliberate tradeoff of the survive-restart design.
- ℹ️ `bin/fm-guardian-arm.sh:37` - daemon_alive() trusts the pidfile&#39;s pid with only a kill -0 liveness check, no identity verification (unlike the daemon&#39;s own portable lock, which checks pid-identity). After an unclean daemon death (kill -9 / OOM, which leaves a stale pidfile), if that pid is later recycled to an unrelated live process, guardian-arm will falsely conclude the daemon is running and no-op, so no liveness guardian gets started for as long as that recycled process lives. The daemon&#39;s lock protects against double-running but not against this false no-op. Impact is bounded: liveness then falls back to firstmate&#39;s own re-arm plus the fm-guard.sh banner (pre-change behavior), so supervision degrades rather than goes silent. A cheap hardening would be to confirm the pid is actually a fm-supervise-daemon process before trusting the pidfile.

🔧 Fix: harden guardian-arm daemon_alive with pid-identity check
2 infos still open:
- ℹ️ `bin/fm-supervise-daemon.sh:728` - guardian_restore_watcher decides reap+re-fork via `! kill -0 &#34;$GUARDIAN_WATCHER_PID&#34;`. Verified on this macOS host that kill -0 returns failure for an unreaped zombie child, so the path works on the target platform. On Linux, kill -0 returns success for an unreaped zombie, so a guardian-forked watcher that exited but is not yet reaped would be treated as alive and never re-forked, weakening the guardian&#39;s self-restore. Mirrors the preexisting Mode A idiom at line 1082 and is well-mitigated: firstmate&#39;s nudged re-arm and the cooldown-gated re-nudge still recover supervision. Latent cross-platform robustness point, not a regression.
- ℹ️ `bin/fm-supervise-daemon.sh:744` - guardian_step restores the guardian&#39;s own untracked watcher fork BEFORE nudging firstmate (line 744 then 747). firstmate&#39;s post-nudge re-arm (fm-watch-arm.sh:133-136) then no-ops against the guardian&#39;s now-healthy watcher, so firstmate never reclaims a harness-tracked watcher. An idle present-mode firstmate would receive subsequent wakes only via the durable wake-queue plus the guardian&#39;s next ~FM_GUARD_GRACE-latency re-nudge instead of its fast harness notification, until it happens to re-arm during a watcher-down window. Bounded and strictly better than the prior silent-gap behavior, but a latency tradeoff in the post-lapse recovery path worth confirming is intended; nudging before restoring would let firstmate reclaim its fast path immediately.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`./tests/fm-guardian.test.sh` - 12 deterministic units mapping to all 7 acceptance criteria (lapse detection, exactly-one-nudge cooldown, fresh-beacon no-op, no-work no-op, restore+single-nudge, sentinel-marked &amp; not-afk-gated nudge, singleton-safe restore, no fork stacking, no broad pkill / home-scoped takeover, guard banner still fires, guardian-arm no-op vs recycled-pid identity check)</code>
- <code>`./tests/fm-guardian-present-e2e.test.sh` - real daemon on a private tmux socket: present-mode lapse restores watcher + nudges exactly once then stays silent (criteria 1,3); afk B-&gt;A-&gt;B mode toggle in one process (criterion 4); SIGTERM clean shutdown removes pidfile+lock and reaps forked watcher (criterion 6)</code>
- <code>Manual evidence harness driving the real `bin/fm-supervise-daemon.sh` in present mode: captured the supervisor pane content firstmate receives, the restored beacon/lock, and the daemon log (lapse -&gt; restore -&gt; single marked nudge -&gt; 6s silence -&gt; clean shutdown)</code>
- <code>Regression run: `./tests/fm-afk-inject-e2e.test.sh`, `./tests/fm-daemon.test.sh`, `./tests/fm-send-secondmate-marker.test.sh`, `./tests/fm-bootstrap.test.sh`, `./tests/fm-watcher-lock.test.sh` - all exit 0</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
