### PR TITLE
fix(watch): assert watcher liveness during wake drain

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -438,13 +438,22 @@ It costs zero tokens while running and exits with one reason line when something
 It also writes each detected wake to the durable queue at `state/.wake-queue` before advancing suppression markers such as `.seen-*`, `.stale-*`, `.last-check`, or `.last-heartbeat`.
 At the start of every wake-handling turn and every recovery turn, run `bin/fm-wake-drain.sh` before peeking panes, reading status files beyond the reason line, or starting new work.
 The printed one-shot reason line is still useful, but the drained queue is the lossless backlog.
-After handling drained wakes, re-arm the watcher before you end the turn by running `bin/fm-watch-arm.sh` as a background task.
-Arm or re-arm the watcher only through the harness's own tracked background mechanism - the one that survives the call and notifies you when the process exits - so the re-arm actually persists and the next wake reaches you.
+**Keep exactly one live cycle.**
+The arm chain IS the supervision: while any task is in flight, keep exactly one live `bin/fm-watch-arm.sh` background task at all times, because if no cycle is live firstmate is blind.
+Each cycle is one harness-tracked background task that blocks until a wake is due, fires with one reason line, and ends, so the chain survives only when firstmate starts the next cycle after each fire.
+After handling the drained wakes, re-arm before you end the turn by running `bin/fm-watch-arm.sh` as its own background task.
+Arm or re-arm the watcher only through the harness's own tracked background mechanism - the one that survives the call and notifies you when the process exits - so the cycle actually persists and the next wake reaches you.
 Never fire-and-forget the watcher with a shell `&` inside another call: that backgrounded child is reaped when the call returns, so supervision silently stops, and worse, the dying process reports a false "already running" that hides the gap.
+**Standalone, never bundled.**
+Run `bin/fm-watch-arm.sh` as its OWN background task with nothing else in that bash, never tacked onto the tail of a multi-command call: bundled, its self-verifying status line is buried in unrelated output and it can silently no-op as a side effect of those other commands, so no fresh cycle gets established and supervision lapses unnoticed.
 `bin/fm-watch-arm.sh` is self-verifying: it confirms a genuinely live watcher with a fresh beacon and prints exactly one honest status line - `watcher: started ...`, `watcher: healthy ...`, or `watcher: FAILED - no live watcher with a fresh beacon` (which exits non-zero) - so treat that line, not a process count or an unverified "already running", as the source of truth for watcher state.
+**Re-arm after each FIRE; do not churn on a no-op.**
+Read that line to know whether a cycle is already live: `started` (this arm just launched the live cycle, now blocking for the next wake) and `healthy` (a live cycle already held the lock) both mean a cycle is live, so do NOT start another - re-running it while one is healthy only churns no-op tasks and never establishes a fresh cycle; `FAILED` means no live cycle, so arm one now after draining any queued wakes.
+A cycle is down only when its background task completes carrying a WAKE REASON (`signal`/`stale`/`check`/`heartbeat`): that is the watcher firing, and that is the one moment to handle the wake and then start exactly one fresh cycle.
 The watcher is singleton-safe: acquisition is race-proof, so under any number of concurrent arms at most one watcher ever holds this home's lock, and a duplicate that somehow starts self-evicts within one poll once it sees the lock no longer names it.
 If one is already alive with a fresh liveness beacon, another invocation exits cleanly instead of creating a duplicate watcher; if the live holder's beacon is stale, the new invocation exits with an actionable failure.
-Re-arming is the primary model: just run `bin/fm-watch-arm.sh` and let the singleton lock no-op when a healthy watcher is already alive.
+**No turn ends blind, holds included.**
+Never end a turn while any task is in flight without a live cycle running: a text-only "holding" or "waiting" reply with crewmates live and no live cycle is a bug, and because such a turn runs no supervision script it is exactly the blind gap the script-only guard (`fm-guard.sh`, below) cannot catch, so this discipline must.
 If a forced restart is ever genuinely needed, use `bin/fm-watch-arm.sh --restart`, which stops only this home's watcher (the pid recorded in this home's `state/.watch.lock`) and starts a fresh one.
 Never `pkill -f bin/fm-watch.sh`: that pattern matches every firstmate home's watcher, including secondmate homes that run the same script, so a broad pkill from one home kills sibling homes' watchers.
 Away-mode supervision is provided by the `/afk` skill and its daemon; while `state/.afk` exists, the daemon owns the watcher.
@@ -483,6 +492,7 @@ This exception is narrow: ordinary crewmates still trip stale detection when the
 Arming the watcher is the last action of every wake-handling turn - but the protocol no longer relies on remembering that.
 While running, `fm-watch.sh` touches `state/.last-watcher-beat` every poll cycle.
 The supervision scripts (`fm-peek`, `fm-send`, `fm-spawn`, `fm-teardown`, `fm-pr-check`, `fm-promote`, `fm-review-diff`, `fm-fleet-sync`, `fm-update`) call `bin/fm-guard.sh` first, which warns to stderr when any task is in flight (`state/*.meta` exists) but queued wakes are pending, or that beacon is missing or older than `FM_GUARD_GRACE` (default 300s).
+`bin/fm-wake-drain.sh` runs the same guard after it drains, so the liveness check also fires on a drain-and-handle turn that runs no other supervision script, narrowing the window in which a lapsed chain can hide; the grace beacon keeps it silent right after a normal fire and it warns only on a genuine stale-beyond-grace lapse.
 The no-watcher case leads with a prominent, bordered ●-marked banner (in-flight count, beacon age, and the exact one-line re-arm command) so it reads as an alarm rather than a buried stderr line you can skim past.
 So the next time you touch the fleet with queued wakes or no watcher alive, the tool output itself tells you what to do - a pull-based guard that works on any harness, since it rides the script output you already read rather than a harness-specific hook.
 The grace window keeps normal handling (watcher briefly down between a wake and its re-arm) silent.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -465,7 +465,7 @@ Empty polls, elapsed waiting time, and "still no change" are tool bookkeeping, n
 bin/fm-watch-arm.sh        # safe verified re-arm; run as harness-tracked background; no-ops if healthy
 bin/fm-watch-arm.sh --restart  # home-scoped forced restart; never a broad pkill
 bin/fm-watch.sh            # the watcher itself; exits with: signal|stale|check|heartbeat
-bin/fm-wake-drain.sh       # drain queued wake records at turn start
+bin/fm-wake-drain.sh       # drain queued wake records at turn start; asserts guard after draining
 ```
 
 On wake, in order of cheapness:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ Check and test the toolbelt before pushing:
 bash -n bin/*.sh                          # syntax-check the toolbelt
 shellcheck bin/*.sh tests/*.sh            # lint the toolbelt and behavior tests; CI enforces this
 for test_script in tests/*.test.sh; do "$test_script"; done   # behavior tests, matching CI
-tests/fm-wake-queue.test.sh               # durable wake queue losslessness, catch-up, double-drain, and duplicate-collapse tests
+tests/fm-wake-queue.test.sh               # durable wake queue losslessness, catch-up, double-drain, duplicate-collapse, and drain liveness guard tests
 tests/fm-watcher-lock.test.sh             # watcher singleton, lock-race, watch-arm liveness, and guard-warning tests
 tests/fm-daemon.test.sh                   # sub-supervisor classifier, /afk presence-gating, max-defer, composer, and fm-send submit tests
 tests/fm-send-settle.test.sh              # fm-send post-submit settle pause, tuning, disable, and --key bypass tests

--- a/bin/fm-guard.sh
+++ b/bin/fm-guard.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Watcher liveness and worktree-tangle guard, called at the top of the
-# supervision scripts.
+# Watcher liveness and worktree-tangle guard, called by supervision scripts and
+# by fm-wake-drain.sh after it empties queued wakes.
 # First, always warn if the firstmate primary checkout (FM_ROOT) is on a named
 # non-default branch, because that means firstmate-on-itself work landed in the
 # primary instead of an isolated worktree.

--- a/bin/fm-wake-drain.sh
+++ b/bin/fm-wake-drain.sh
@@ -9,6 +9,21 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DRAIN_TMP=
 DRAIN_LOCK_HELD=false
 
+# Defense in depth for the watcher re-arm chain: this script runs at the top of
+# every wake-handling and recovery turn, so assert watcher liveness here too. A
+# lapsed supervision chain then surfaces on a plain drain-and-handle turn, not
+# only when a guarded supervision script (fm-peek/fm-send/...) happens to run.
+# Reuse fm-guard.sh's existing graced, beacon-based banner (FM_GUARD_GRACE) - do
+# not duplicate the beacon math. Because the watcher touches its beacon every
+# poll cycle, a normal fire leaves a recent beacon well inside grace and stays
+# silent; only a genuine stale-beyond-grace lapse with work in flight warns. Call
+# after the queue is emptied so guard never re-prints its own queued-wakes notice
+# for the records this run just drained, and never let a guard hiccup change the
+# drain's exit status.
+assert_watcher_liveness() {
+  "$SCRIPT_DIR/fm-guard.sh" || true
+}
+
 # shellcheck disable=SC2317,SC2329 # Invoked by trap handlers below.
 cleanup() {
   local status=$?
@@ -30,6 +45,7 @@ DRAIN_LOCK_HELD=true
 
 if [ ! -s "$FM_WAKE_QUEUE" ]; then
   : > "$FM_WAKE_QUEUE"
+  assert_watcher_liveness
   exit 0
 fi
 
@@ -41,4 +57,5 @@ mv "$FM_WAKE_QUEUE" "$DRAIN_TMP" || exit 1
 fm_wake_print_deduped "$DRAIN_TMP" || exit "$?"
 rm -f "$DRAIN_TMP"
 DRAIN_TMP=
+assert_watcher_liveness
 exit 0

--- a/bin/fm-wake-drain.sh
+++ b/bin/fm-wake-drain.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Atomically drain durable watcher wake records.
+# Atomically drain durable watcher wake records, then assert watcher liveness.
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/bin/fm-watch-arm.sh
+++ b/bin/fm-watch-arm.sh
@@ -4,11 +4,12 @@
 # The watcher (bin/fm-watch.sh) is one-shot: it blocks until a wake is due, prints
 # one reason line, and exits. Reliability depends on re-arming through a mechanism
 # that SURVIVES the call and NOTIFIES on exit, so firstmate must run this script as
-# the harness's own tracked background task (e.g. run_in_background). NEVER fire it
-# and forget with a shell `&` inside another call: that backgrounded child is
-# reaped when the call returns, leaving NO watcher running and - worse - a false
-# "already running" off the dying process. That exact mistake silently took
-# supervision down for ~30 minutes.
+# the harness's own tracked background task (e.g. run_in_background). Run it as
+# its own standalone background task, never bundled onto the tail of another
+# command. NEVER fire it and forget with a shell `&` inside another call: that
+# backgrounded child is reaped when the call returns, leaving NO watcher running
+# and a false "already running" off the dying process. That exact mistake
+# silently took supervision down for ~30 minutes.
 #
 # This script forks the watcher as a tracked child, then VERIFIES the outcome
 # before it settles in. It confirms a watcher process is genuinely alive AND the
@@ -22,7 +23,8 @@
 # stale-beacon or dead-pid holder either self-heals (the fresh child steals the
 # dead lock per the singleton self-eviction/steal path and is confirmed) or this
 # returns the FAILED line. On started/healthy it exits zero; on FAILED it exits
-# non-zero so the failure is loud and a caller can react.
+# non-zero so the failure is loud and a caller can react. A healthy line means a
+# live cycle already exists; do not churn extra no-op arms until that cycle fires.
 #
 # --restart: stop ONLY this FM_HOME's watcher (the pid recorded in THIS home's
 # state/.watch.lock) and start a fresh one. It resolves and signals exactly that

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,11 +10,13 @@ firstmate's full operating manual for the orchestrator agent itself is [`AGENTS.
 
 A zero-token bash watcher (`bin/fm-watch.sh`) sleeps on the fleet and wakes the first mate only when a crewmate reports, stalls, a PR merges, or an internal heartbeat review is due.
 Detected wakes are also written to a durable local queue (`state/.wake-queue`) before detector state advances, so a missed one-shot process exit can be recovered by draining the queue.
+After each drain, `fm-wake-drain.sh` runs the same liveness guard as the supervision scripts, so a lapsed watcher chain surfaces even on a turn that only drains and handles queued wakes.
 Routine watcher polling, re-arm no-ops, elapsed waiting time, and unchanged heartbeat reviews stay silent; an idle crew costs you nothing.
 
 Routine re-arms go through `bin/fm-watch-arm.sh`, which forks the watcher as a tracked child, verifies it is genuinely alive with a fresh liveness beacon, and prints exactly one honest status line (`started` / `healthy` / `FAILED`, the last exiting non-zero) - never a false `already running` off a dying process.
 Its `--restart` mode signals only the watcher recorded in the current home's `state/.watch.lock`, so restarting one home cannot kill sibling secondmate watchers.
 A pull-based guard (`bin/fm-guard.sh`) warns through supervision tool output if the primary checkout is tangled, or if tasks are in flight and that watcher stops running or queued wakes are waiting to be drained.
+The drain script calls that guard after emptying the queue, which avoids repeating the queued-wakes warning for records it just consumed while still warning on stale watcher liveness.
 It leads with prominent bordered banners for the tangle and no-watcher cases so they cannot be skimmed past.
 
 A presence-gated sub-supervisor (`bin/fm-supervise-daemon.sh`) extends this for walk-away supervision: the `/afk` skill activates it, after which it self-handles routine wakes in bash and escalates only captain-relevant events as one batched, single-line digest (prefixed with an in-band sentinel marker so firstmate can tell daemon injections apart from real messages).
@@ -96,5 +98,5 @@ Kill the first mate session anytime; the next one reconciles and carries on.
 
 ## Development notes
 
-The current watcher reliability work keeps the one-shot process model and adds a durable queue, race-proof singleton lock, duplicate self-eviction, and a self-verifying tracked-child arm wrapper.
+The current watcher reliability work keeps the one-shot process model and adds a durable queue, race-proof singleton lock, duplicate self-eviction, drain-time liveness assertion, and a self-verifying tracked-child arm wrapper.
 The presence-gated sub-supervisor (`bin/fm-supervise-daemon.sh`) provides proactive wake routing for walk-away supervision via the `/afk` skill; a blocking-waiter split remains a deferred follow-up phase.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -24,7 +24,7 @@ Each file also starts with a short header comment.
 | `fm-tangle-lib.sh`       | Shared default-branch resolution and primary-checkout tangle classification sourced by bootstrap and guard         |
 | `fm-ff-lib.sh`           | Shared guarded fast-forward helper for `/updatefirstmate` origin pulls and no-fetch local secondmate syncs         |
 | `fm-tasks-axi-lib.sh`    | Shared `tasks-axi` compatibility probe sourced by bootstrap and teardown                                            |
-| `fm-wake-drain.sh`       | Atomically drain queued watcher wakes before handling supervision work                                              |
+| `fm-wake-drain.sh`       | Atomically drain queued watcher wakes before handling supervision work, then run the watcher-liveness guard         |
 | `fm-wake-lib.sh`         | Shared durable wake queue and portable lock helpers sourced by the watcher, drain, arm, guard, and daemon          |
 | `fm-send.sh`             | Send one verified literal line (or `--key Escape`) to a direct-report window; exits non-zero on confirmed swallowed Enter; bare `kind=secondmate` targets are marked as from-firstmate; text sends pause `FM_SEND_SETTLE` seconds after success |
 | `fm-tmux-lib.sh`         | Shared tmux pane primitives for busy detection, dim-ghost-aware and border-aware composer detection, and verified submit retry |

--- a/tests/fm-wake-queue.test.sh
+++ b/tests/fm-wake-queue.test.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 # tests/fm-wake-queue.test.sh - wake-queue losslessness (the queue safety matrix):
 # concurrent append/drain, signal catch-up while no watcher runs, stale/check
-# enqueue-before-suppressor ordering, atomic double-drain, and duplicate collapse.
-# Nothing is lost and nothing is double-consumed. Watcher/lock liveness lives in
-# fm-watcher-lock.test.sh; daemon classification/injection in fm-daemon.test.sh.
+# enqueue-before-suppressor ordering, atomic double-drain, duplicate collapse,
+# and the drain-time watcher-liveness assertion.
+# Nothing is lost and nothing is double-consumed. General watcher/lock liveness
+# lives in fm-watcher-lock.test.sh; daemon classification/injection in
+# fm-daemon.test.sh.
 set -u
 
 # shellcheck source=tests/wake-helpers.sh

--- a/tests/fm-wake-queue.test.sh
+++ b/tests/fm-wake-queue.test.sh
@@ -155,9 +155,32 @@ test_drain_dedupes_obvious_duplicates() {
   pass "drain collapses obvious duplicate heartbeat and signal records"
 }
 
+# The drain runs at the top of every wake-handling turn, so it also asserts
+# watcher liveness via fm-guard.sh: a lapsed re-arm chain then surfaces even on a
+# plain drain-and-handle turn that runs no other supervision script. It must warn
+# when work is in flight with no live watcher, and stay silent right after a
+# normal fire (a fresh beacon within grace), so it never false-alarms every wake.
+test_drain_asserts_watcher_liveness() {
+  local dir state err
+  dir=$(make_case drain-liveness)
+  state="$dir/state"
+  err="$dir/drain.err"
+  printf 'window=test:fm-x\nkind=ship\n' > "$state/x.meta"
+  FM_STATE_OVERRIDE="$state" "$DRAIN" >/dev/null 2> "$err" || fail "drain failed while asserting liveness"
+  grep -F 'WATCHER DOWN' "$err" >/dev/null || fail "drain did not surface the watcher-down banner with work in flight and no live watcher"
+  : > "$err"
+  touch "$state/.last-watcher-beat"
+  FM_STATE_OVERRIDE="$state" FM_GUARD_GRACE=300 "$DRAIN" >/dev/null 2> "$err" || fail "drain failed with a fresh beacon"
+  if grep -F 'WATCHER DOWN' "$err" >/dev/null; then
+    fail "drain false-alarmed right after a normal fire (fresh beacon within grace)"
+  fi
+  pass "drain asserts watcher liveness: warns on a lapse, stays silent right after a fire"
+}
+
 test_concurrent_append_and_drain
 test_signal_catchup_without_running_watcher
 test_stale_enqueue_before_suppressor
 test_check_output_is_queued
 test_atomic_double_drain
 test_drain_dedupes_obvious_duplicates
+test_drain_asserts_watcher_liveness

--- a/tests/wake-helpers.sh
+++ b/tests/wake-helpers.sh
@@ -7,6 +7,19 @@
 # shellcheck source=tests/lib.sh
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
+# fm-wake-drain.sh now calls fm-guard.sh to assert watcher liveness on every
+# drain. fm-guard.sh's first check warns when the firstmate PRIMARY checkout
+# (FM_ROOT) sits on a feature branch; with no override FM_ROOT resolves to the
+# test runner's own checkout, which during validation is on a feature branch, so
+# each drain would emit a spurious worktree-tangle banner. Point the tangle check
+# at a fresh non-git dir to keep it inert across these suites - the same trick the
+# direct fm-guard.sh tests use. A per-call FM_ROOT_OVERRIDE still wins where a
+# suite sets its own (e.g. the watcher-lock guard-banner cases).
+if [ -z "${FM_ROOT_OVERRIDE:-}" ]; then
+  FM_ROOT_OVERRIDE="$(fm_test_tmproot fm-wake-tangle-root)"
+  export FM_ROOT_OVERRIDE
+fi
+
 # append_wake <state> <kind> <key> <payload>: append a wake record to the durable
 # queue in a subshell scoped to <state>, using the production wake library.
 append_wake() {


### PR DESCRIPTION
## Intent

Tighten firstmate's watcher re-arm discipline (AGENTS.md section 8) and add a wake-drain liveness assertion so the watcher supervision chain cannot silently lapse. Motivating incident: the watcher (bin/fm-watch.sh, armed via bin/fm-watch-arm.sh as a harness-tracked background task) died ~12 min undetected because re-arms were bundled at the tail of multi-command bashes (where fm-watch-arm silently no-ops when a cycle is briefly still alive, so no fresh cycle got established) and because text-only 'holding' turns ran no supervision script, so fm-guard.sh's liveness banner (which only fires when a supervision script runs) never triggered.

Three deliberate changes:
1. AGENTS.md section 8: reworded the re-arm discipline into four unambiguous bold-led rules - keep exactly one live cycle while work is in flight; re-arm after each FIRE (a completed arm task carrying a wake reason signal/stale/check/heartbeat) and do NOT churn on a healthy/started no-op; run fm-watch-arm standalone, never bundled in a multi-command bash; never end a turn blind, holds included. This intentionally REPLACES the old misleading 'Re-arming is the primary model: just run fm-watch-arm and let the singleton lock no-op' line that encouraged the churn. Existing correct material (singleton lock, beacon, guard banner, afk-daemon-owns-watcher exception) is preserved verbatim - a tightening, not a rewrite. Also added one line noting fm-wake-drain.sh now runs the same guard.

2. bin/fm-wake-drain.sh: added an assert_watcher_liveness() helper that REUSES fm-guard.sh's existing graced, beacon-based banner (no duplicated beacon math, per the task constraint) and called it on both success-exit paths. Deliberately called AFTER the queue is emptied so the guard never re-prints its own 'queued wakes pending' notice for the records this run just drained, and wrapped with '|| true' so a guard hiccup never changes the drain's exit status. Because the watcher touches its beacon every poll cycle, a normal fire leaves a recent beacon well inside FM_GUARD_GRACE so the drain stays silent right after a fire; it warns only on a genuine stale-beyond-grace lapse with work in flight. The watcher core (fm-watch.sh, the singleton lock, the beacon-touch, the wake-queue) is deliberately UNTOUCHED.

3. Tests: the drain's new guard call would otherwise emit a spurious WORKTREE TANGLE banner across the drain-invoking suites because FM_ROOT resolves to the feature-branch test checkout during validation, so tests/wake-helpers.sh now sets a default FM_ROOT_OVERRIDE to a fresh non-git dir to keep the tangle check inert (the same trick the direct fm-guard.sh tests already use); a per-call FM_ROOT_OVERRIDE still wins. Added a regression test (test_drain_asserts_watcher_liveness in tests/fm-wake-queue.test.sh) asserting the drain warns on a lapse and stays silent right after a fire. Verified locally: shellcheck clean, all behavior suites green, and a negative control confirmed the new test genuinely fails if the assertion is removed.

## What Changed

- Tightened watcher supervision rules in `AGENTS.md` and related docs so captain-facing instructions require one live cycle, standalone re-arms after fired wakes, and supervision before ending holding turns.
- Added a drain-time watcher liveness assertion to `bin/fm-wake-drain.sh` by reusing `fm-guard.sh` after queue drains without changing the drain exit status.
- Updated wake queue test helpers and regression coverage so drain liveness warnings are exercised without unrelated guard tangle noise.

## Risk Assessment

✅ Low: Captain, the change is narrowly scoped to documentation, a successful-drain guard call that reuses existing liveness logic, and focused regression coverage; I did not find material risks in the changed paths.

## Testing

I inspected the target diff, ran the focused wake-drain/watcher/daemon suites, ran the full behavior-test loop, captured a manual CLI transcript showing the WATCHER DOWN banner and fresh-beacon silence, verified the AGENTS.md re-arm rules and old line removal, and confirmed the worktree stayed clean with no transient build/test directories left behind.

<details>
<summary>Evidence: Manual fm-wake-drain liveness transcript</summary>

```text
$ FM_STATE_OVERRIDE=/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KW31M8H57RN64KXEMCME7WZP/drain-liveness-case/state FM_ROOT_OVERRIDE=/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KW31M8H57RN64KXEMCME7WZP/drain-liveness-case/non-git-root bin/fm-wake-drain.sh >/tmp/no-beacon.out 2>/tmp/no-beacon.err
# stderr (no beacon, work in flight)
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
●  WATCHER DOWN - SUPERVISION IS OFF
●  1 task(s) in flight, but no watcher has a fresh beacon (last beat: never, grace 300s).
●  Trust bin/fm-watch-arm.sh for the true state: it confirms a live watcher and a fresh beacon, or fails loudly.
●  Re-arm it NOW: run bin/fm-watch-arm.sh as the harness-tracked background task (never a shell & that gets reaped).
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
# stdout (no beacon, work in flight)

$ touch /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KW31M8H57RN64KXEMCME7WZP/drain-liveness-case/state/.last-watcher-beat
$ FM_STATE_OVERRIDE=/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KW31M8H57RN64KXEMCME7WZP/drain-liveness-case/state FM_ROOT_OVERRIDE=/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KW31M8H57RN64KXEMCME7WZP/drain-liveness-case/non-git-root FM_GUARD_GRACE=300 bin/fm-wake-drain.sh >/tmp/fresh.out 2>/tmp/fresh.err
# stderr bytes (fresh beacon)
       0
# stdout bytes (fresh beacon)
       0

# Final queue file bytes
       0
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git status --short --branch`
- `git diff --stat fe3c867788fe389bbcaddbf9500c27cceb99504a..eb6897bb28b25df74b6dc2ab7d966904c16b9b25`
- `git diff --name-only fe3c867788fe389bbcaddbf9500c27cceb99504a..eb6897bb28b25df74b6dc2ab7d966904c16b9b25`
- <code>Reviewed base-to-target diffs for `AGENTS.md`, `bin/fm-wake-drain.sh`, `tests/fm-wake-queue.test.sh`, and `tests/wake-helpers.sh`.</code>
- `tests/fm-wake-queue.test.sh`
- `tests/fm-watcher-lock.test.sh`
- `tests/fm-daemon.test.sh`
- `tests/fm-wake-daemon-lifecycle-e2e.test.sh`
- `for test_script in tests/*.test.sh; do "$test_script"; done`
- <code>Manual `bin/fm-wake-drain.sh` check with an in-flight meta file and no watcher beacon, then with a fresh `.last-watcher-beat`, writing evidence to `/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KW31M8H57RN64KXEMCME7WZP`.</code>
- `rg -n "Keep exactly one live cycle|Standalone, never bundled|Re-arm after each FIRE|No turn ends blind|fm-wake-drain.sh.*same guard" AGENTS.md`
- `if rg -q "Re-arming is the primary model" AGENTS.md; then printf 'old misleading re-arm line still present\n' >&2; exit 1; fi`
- `git status --short`
- `find . -maxdepth 2 -type d \( -name '.pytest_cache' -o -name 'node_modules' -o -name 'coverage' -o -name 'dist' -o -name 'build' \) -print`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
