### PR TITLE
fix(brief): slim no-mistakes contract behind version floor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,7 @@ Otherwise it prints one line per problem or capability fact; handle each:
 
 - `MISSING: <tool> (install: <command>)` - list the missing tools to the captain with a one-line purpose each plus the printed install commands, wait for consent (one approval may cover the list), then run `bin/fm-bootstrap.sh install <approved tools...>`.
   For `treehouse`, this also covers an installed version whose `treehouse get` lacks `--lease`; treat it as an upgrade request.
+  For `no-mistakes`, this also covers an installed version older than 1.31.2, because crewmate validation briefs delegate gate mechanics to no-mistakes' version-matched guidance.
 - `NEEDS_GH_AUTH` - ask the captain to run `! gh auth login` (interactive; you cannot run it for them).
 - `TANGLE: <remediation>` - the firstmate primary checkout (the repo root, `FM_ROOT`) is stranded on a feature branch instead of its default branch: a crewmate working firstmate-on-itself branched/committed in the primary instead of its own isolated worktree (section 8). The work is safe on that branch ref; restore the primary to its default branch with the printed `git -C <root> checkout <default>`, then re-validate that branch in a proper worktree. This is the only sanctioned firstmate-initiated git write to the primary, and it is a non-destructive branch switch that strands nothing.
 - `CREW_HARNESS_OVERRIDE: <name>` - record and use the override silently; surface a harness fact only if it actually blocks work or the captain asks.
@@ -371,17 +372,17 @@ For `no-mistakes`-mode ship tasks, when a crewmate's status says `done`, trigger
 Load `harness-adapters` for the target harness's skill invocation form; natural language also works if uncertain.
 
 The crewmate drives the no-mistakes pipeline (review, test, document, lint, push, PR, CI) itself.
-The no-mistakes pipeline owns every validation fix on the crewmate's branch in its own worktree; the crewmate advances each gate with `no-mistakes axi respond`, and must never hand-edit, commit, reset, checkout, abort, or re-run while a run is active.
-When it reports `needs-decision` (ask-user findings), relay the findings to the captain unless `yolo=on` permits routine approval on your judgment, then send the decision back as a short instruction (the crewmate responds via `no-mistakes axi respond`).
+The ship brief intentionally does not restate no-mistakes gate mechanics; it points the crewmate to the version-matched SKILL.md loaded by `/no-mistakes`, `no-mistakes axi run --help`, and per-response `help` lines.
+Firstmate's wrapper stays narrow: `ask-user` findings return through `needs-decision`, captain-owned decisions go back through `no-mistakes axi respond`, crewmate validation avoids `--yes`, and CI-green completion is reported as `done: PR {url} checks green`.
 Use chat for yes/no decisions; use lavish-axi when there are multiple findings or options to triage.
 
 Judge a validating crewmate by the run's step status, never by whether its shell is still running; read it cheaply with `no-mistakes axi status`.
 
 - `running`/`fixing`/`ci` - the pipeline is working (a fix round, a test, or CI monitoring); these run for many minutes and quiet is normal, so leave it alone.
 - `awaiting_approval`/`fix_review` - the run is parked waiting on the agent, surfaced as a top-level `awaiting_agent: parked <duration>` line right after `status:` in `axi status`.
-  The crewmate owes a `respond`; if it is idle-waiting for the run to advance on its own, steer it to drive the gate, because a parked gate never self-resolves.
+  The crewmate owes a response; if it is idle-waiting for the run to advance on its own, steer it to follow no-mistakes' active-gate help.
 - Red flag - self-fix duplication: a validating crewmate making fresh hand-commits, aborting the run, or re-running it mid-validation is re-doing work the pipeline already owns.
-  Steer it back to respond-only: the pipeline applies every fix on the branch from `axi respond`, including the fix for a real bug the review found in the crewmate's own code, and hand-fixing forces a full re-validation.
+  Steer it back to no-mistakes' respond flow; the pipeline, not the crewmate, applies validation fixes.
 
 ### PR ready
 
@@ -603,7 +604,8 @@ Map firstmate's real backlog operations to the approved commands:
 
 Scaffold with `bin/fm-brief.sh <id> <repo-name>` - it writes `data/<id>/brief.md` with the standard contract (branch setup, status-reporting protocol, push/merge rules, definition of done) and all paths filled in.
 The ship-brief Setup opens with a worktree-isolation assertion ahead of the branch step: the crewmate confirms it is in its own treehouse worktree, not the primary checkout, and stops with `blocked: launched in primary checkout, not an isolated worktree` if not - the upstream half of the worktree-tangle guard (section 8).
-For a ship task the definition of done is shaped by the project's delivery mode (section 6): `no-mistakes` ends in the harness-appropriate no-mistakes validation pipeline, `direct-PR` has the crewmate push and open the PR itself, `local-only` has it stop at "ready in branch" for firstmate to review and merge locally.
+For a ship task the definition of done is shaped by the project's delivery mode (section 6): `no-mistakes` stops after the implementation commit, then firstmate triggers the harness-appropriate no-mistakes validation pipeline; `direct-PR` has the crewmate push and open the PR itself, and `local-only` has it stop at "ready in branch" for firstmate to review and merge locally.
+The no-mistakes brief points to no-mistakes' version-matched guidance and keeps only firstmate-specific wrapper rules for `ask-user` escalation, `--yes` avoidance, and the CI-green done line.
 The scaffold reads the mode via `fm-project-mode.sh`, so you do not pass it.
 Ship briefs also include the project-memory contract: run `bin/fm-ensure-agents-md.sh` when the project already has agent-memory files or when the task produced durable project-intrinsic knowledge, then record proportionate learnings in `AGENTS.md`.
 For scout tasks add `--scout`: the scaffold swaps the definition of done for the report contract (findings to `data/<id>/report.md`, no branch, no push, no PR) and declares the worktree scratch; scout is mode-agnostic.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Dependency bots are exempt so their automation keeps working, but regular contri
 
 1. Fork the repo, then clone the parent repo or set your local `origin` back to the parent (`git@github.com:kunchenguid/firstmate.git`).
 2. Create a branch and make your changes.
-3. Initialize the gate with your fork as the push target: `no-mistakes init --fork-url git@github.com:<you>/firstmate.git` (fork routing requires **no-mistakes v1.30.1+**; without a fork, plain `no-mistakes init` still works for maintainers with push access).
+3. Initialize the gate with your fork as the push target: `no-mistakes init --fork-url git@github.com:<you>/firstmate.git` (firstmate expects **no-mistakes v1.31.2+**; without a fork, plain `no-mistakes init` still works for maintainers with push access).
 4. Commit your changes.
 5. Push through the gate instead of pushing to `origin`:
 
@@ -25,7 +25,7 @@ Dependency bots are exempt so their automation keeps working, but regular contri
    ```
 
 6. Run `no-mistakes` to attach to the pipeline, watch findings, authorize auto-fixes, and review ask-user findings as needed.
-   While a run is active, let the pipeline apply authorized fixes instead of editing or committing them by hand.
+   Follow the installed no-mistakes version's SKILL.md and live `axi` help for gate mechanics.
 7. Once the pipeline passes, it pushes the branch to your fork and opens the PR against the parent repo for you.
 
 See the [no-mistakes quick start](https://kunchenguid.github.io/no-mistakes/start-here/quick-start/) for the full first-run walkthrough.
@@ -49,9 +49,8 @@ See the [no-mistakes quick start](https://kunchenguid.github.io/no-mistakes/star
 
 Tracked changes to firstmate itself - `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `.tasks.toml`, `.github/workflows/`, `bin/`, and agent skill files - ship through the `no-mistakes` pipeline on a feature branch and require an explicit merge approval.
 When supervising live crewmates, keep firstmate's own long validation or build commands in the background so watcher wakes can still be handled.
-Unlike firstmate, a crewmate owns its own validation gate loop: it processes every `no-mistakes axi run` or `no-mistakes axi respond` return, responds to gates, and never waits for a parked gate to self-resolve.
-The pipeline owns every validation fix, including auto-fix findings and fixes for real bugs found in the crewmate's own code; the crewmate authorizes or answers with `no-mistakes axi respond` instead of editing, committing, aborting, or re-running while the run is active.
-Do not use `--yes` for crewmate validation because it silently resolves `ask-user` findings without escalation.
+Crewmate validation follows the installed no-mistakes version's SKILL.md and live `axi` help instead of duplicating gate mechanics in firstmate docs.
+Firstmate's wrapper still matters: `ask-user` findings route to the captain through firstmate, and crewmates avoid `--yes` because it silently resolves captain-owned decisions without escalation.
 Local `.no-mistakes/` state and test evidence stay out of this repo; `.no-mistakes.yaml` keeps evidence in a temp directory instead.
 
 Check and test the toolbelt before pushing:

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -20,6 +20,8 @@
 #          landed in the primary instead of its own worktree; restore it per the line.
 #          treehouse is also MISSING when its installed version lacks
 #          "treehouse get --lease" support.
+#          no-mistakes is also MISSING when its installed version is older than
+#          1.31.2.
 #          tasks-axi is an OPTIONAL backlog-management capability reported only
 #          when tasks-axi --version is 0.1.1 or newer. It is never a MISSING
 #          line and never prompts an install.
@@ -128,9 +130,34 @@ install_cmd() {
 }
 
 TOOLS="tmux node gh treehouse no-mistakes gh-axi chrome-devtools-axi lavish-axi"
+NO_MISTAKES_MIN_MAJOR=1
+NO_MISTAKES_MIN_MINOR=31
+NO_MISTAKES_MIN_PATCH=2
 
 treehouse_supports_lease() {
   treehouse get --help 2>&1 | grep -Eq '(^|[^[:alnum:]_-])--lease([^[:alnum:]_-]|$)'
+}
+
+no_mistakes_version_parts() {
+  local output
+  command -v no-mistakes >/dev/null 2>&1 || return 1
+  output=$(no-mistakes --version 2>/dev/null) || return 1
+  printf '%s\n' "$output" | sed -nE 's/.*[vV]?([0-9]+)\.([0-9]+)\.([0-9]+).*/\1 \2 \3/p' | head -n 1
+}
+
+no_mistakes_compatible() {
+  local parts major minor patch
+  parts=$(no_mistakes_version_parts) || return 1
+  set -- $parts
+  [ $# -eq 3 ] || return 1
+  major=$1
+  minor=$2
+  patch=$3
+  [ "$major" -gt "$NO_MISTAKES_MIN_MAJOR" ] && return 0
+  [ "$major" -eq "$NO_MISTAKES_MIN_MAJOR" ] || return 1
+  [ "$minor" -gt "$NO_MISTAKES_MIN_MINOR" ] && return 0
+  [ "$minor" -eq "$NO_MISTAKES_MIN_MINOR" ] || return 1
+  [ "$patch" -ge "$NO_MISTAKES_MIN_PATCH" ]
 }
 
 if [ "${1:-}" = "install" ]; then
@@ -150,6 +177,9 @@ for t in $TOOLS; do
 done
 if command -v treehouse >/dev/null 2>&1 && ! treehouse_supports_lease; then
   echo "MISSING: treehouse (install: $(install_cmd treehouse))"
+fi
+if command -v no-mistakes >/dev/null 2>&1 && ! no_mistakes_compatible; then
+  echo "MISSING: no-mistakes (install: $(install_cmd no-mistakes))"
 fi
 gh auth status >/dev/null 2>&1 || echo "NEEDS_GH_AUTH"
 # Worktree-tangle check: the firstmate primary checkout (FM_ROOT) must sit on its

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -146,13 +146,10 @@ no_mistakes_version_parts() {
 }
 
 no_mistakes_compatible() {
-  local parts major minor patch
+  local parts major minor patch extra
   parts=$(no_mistakes_version_parts) || return 1
-  set -- $parts
-  [ $# -eq 3 ] || return 1
-  major=$1
-  minor=$2
-  patch=$3
+  IFS=' ' read -r major minor patch extra <<< "$parts"
+  [ -n "$major" ] && [ -n "$minor" ] && [ -n "$patch" ] && [ -z "$extra" ] || return 1
   [ "$major" -gt "$NO_MISTAKES_MIN_MAJOR" ] && return 0
   [ "$major" -eq "$NO_MISTAKES_MIN_MAJOR" ] || return 1
   [ "$minor" -gt "$NO_MISTAKES_MIN_MINOR" ] && return 0

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -207,24 +207,14 @@ The task is complete only when committed on your branch.
 When you believe it is complete, append \`done: {summary}\` to the status file and stop.
 Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
 
-During validation the pipeline owns every fix; you only drive the gates.
-Once a run is active, every fix - both auto-fix findings and the fix for a real bug the review finds in your own code - is applied by the pipeline on your branch, in its own worktree.
-Never hand-edit, \`git commit\`, \`git reset\`/\`git checkout\`, abort, or re-run while a run is active: doing so duplicates the pipeline's work and forces a full re-validation.
-You advance the work only by responding to gates:
-- Process every return; never idle-wait.
-  \`no-mistakes axi run\` / \`axi respond\` return either at a gate (a \`gate:\` object) or at a terminal or CI-ready outcome (no \`gate:\`).
-  A run legitimately runs long - test, CI, and each fix round take many minutes - so a quiet call is working, not stalled.
-  Backgrounding the call is fine; idle-waiting for the run to advance on its own is not, because it never advances past a gate by itself.
-  Read every return: on a \`gate:\`, respond, and loop until you reach an outcome.
-- Auto-fix findings: advance the gate with \`no-mistakes axi respond --action fix --findings <ids>\`; the pipeline applies the fix on your branch and re-reviews.
-  You never apply it yourself.
-- Review findings always gate.
-  Review auto-fix is disabled, so every actionable review finding parks for your response instead of being self-fixed - drive it like any other gate.
-- ask-user findings: escalate to firstmate (rule 6) and stop.
-  When the decision comes back, feed it to the gate with \`no-mistakes axi respond\` (the \`--action\`/answer the decision implies) and let the pipeline apply it.
-  Even when it is a real bug in your own code, do NOT implement the decided fix yourself and do NOT abort to go fix it - the pipeline applies it from your \`respond\`.
-- Avoid \`--yes\`: it silently auto-resolves every finding, including \`ask-user\`, with zero escalation, so a decision the captain should make gets resolved without them.
-  Drive gates manually and escalate \`ask-user\` findings.
+You drive no-mistakes by responding to its gates, not by implementing fixes.
+Follow no-mistakes' own guidance for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.
+Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.
+
+Two firstmate-specific rules layer on top of that guidance:
+- ask-user findings are not yours to answer: escalate to firstmate (rule 6) and stop.
+  When the decision comes back, feed it to the gate with \`no-mistakes axi respond\` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
+- Avoid \`--yes\`: the captain, not you, owns the ask-user decisions it would silently auto-resolve.
 
 After /no-mistakes reports CI green, append \`done: PR {url} checks green\` and stop. You are finished.
 EOF

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -45,7 +45,7 @@ Launch mechanics, including the verified command templates, live in [`bin/fm-spa
 
 ## Toolchain
 
-On first launch the first mate detects what its required toolchain is missing or too old (tmux, node, gh, treehouse with durable lease support, no-mistakes, gh-axi, chrome-devtools-axi, lavish-axi), lists it with the exact install commands, and installs only after you say go.
+On first launch the first mate detects what its required toolchain is missing or too old (tmux, node, gh, treehouse with durable lease support, no-mistakes v1.31.2 or newer, gh-axi, chrome-devtools-axi, lavish-axi), lists it with the exact install commands, and installs only after you say go.
 If compatible `tasks-axi` is already on `PATH`, bootstrap records it as an optional capability fact and firstmate uses its verbs for routine backlog mutations; when it is absent or incompatible, firstmate keeps hand-editing `data/backlog.md` exactly as before.
 Bootstrap also reports a `TANGLE:` line when `FM_ROOT` is on a named non-default branch; follow the printed checkout remediation rather than treating it as an installable tool problem.
 Bootstrap also runs the guarded local secondmate sync for recorded live secondmate homes.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -5,7 +5,7 @@ Each file also starts with a short header comment.
 
 | Script                   | Description                                                                                                         |
 | ------------------------ | ------------------------------------------------------------------------------------------------------------------- |
-| `fm-bootstrap.sh`        | Detect required toolchain problems, optional capability facts, and primary-checkout `TANGLE:` problems; locally sync live secondmate homes; refresh clones best-effort; install tools only after consent |
+| `fm-bootstrap.sh`        | Detect required toolchain and version problems, optional capability facts, and primary-checkout `TANGLE:` problems; locally sync live secondmate homes; refresh clones best-effort; install tools only after consent |
 | `fm-fleet-sync.sh`       | Fetch clones, clean-fast-forward their checked-out default branches, and safely prune branches whose remote is gone |
 | `fm-update.sh`           | Self-update the running firstmate repo and registered secondmate homes with fast-forward-only pulls from origin     |
 | `fm-backlog-handoff.sh`  | Move already-judged in-scope queued backlog items from the main home into a seeded secondmate home                 |

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -4,8 +4,9 @@
 # Bootstrap prints one line per problem or capability fact and is silent when all
 # is well. firstmate consumes the exact 'MISSING: treehouse (install: ...)' and
 # 'TASKS_AXI: available' lines, so those contracts are pinned verbatim. The cases
-# are table-driven over the two inputs that vary: whether `treehouse get --help`
-# advertises --lease, and which (if any) tasks-axi version is on PATH.
+# are table-driven over the inputs that vary: whether `treehouse get --help`
+# advertises --lease, which (if any) tasks-axi version is on PATH, and which
+# no-mistakes version is on PATH.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -19,7 +20,7 @@ TMP_ROOT=$(fm_test_tmproot fm-bootstrap-tests)
 make_fake_toolchain() {
   local dir=$1 fakebin
   fakebin=$(fm_fakebin "$dir")
-  fm_fake_exit0 "$fakebin" tmux node no-mistakes gh-axi chrome-devtools-axi lavish-axi
+  fm_fake_exit0 "$fakebin" tmux node gh-axi chrome-devtools-axi lavish-axi
   cat > "$fakebin/gh" <<'SH'
 #!/usr/bin/env bash
 if [ "${1:-}" = auth ] && [ "${2:-}" = status ]; then
@@ -41,6 +42,15 @@ fi
 exit 0
 SH
   chmod +x "$fakebin/treehouse"
+  cat > "$fakebin/no-mistakes" <<'SH'
+#!/usr/bin/env bash
+if [ "${1:-}" = --version ]; then
+  printf '%s\n' "${FM_FAKE_NO_MISTAKES_VERSION:-no-mistakes version v1.31.2 (fake) 2026-06-27T00:02:18Z}"
+  exit 0
+fi
+exit 0
+SH
+  chmod +x "$fakebin/no-mistakes"
   printf '%s\n' "$fakebin"
 }
 
@@ -97,4 +107,33 @@ ROWS
   pass "bootstrap reports treehouse lease + tasks-axi compatibility contracts"
 }
 
+test_no_mistakes_min_version() {
+  local label version mode case_dir fakebin out missing n
+  missing='MISSING: no-mistakes (install: curl -fsSL https://raw.githubusercontent.com/kunchenguid/no-mistakes/main/docs/install.sh | sh)'
+  n=0
+  while IFS='^' read -r label version mode; do
+    [ -n "$label" ] || continue
+    n=$((n + 1))
+    case_dir="$TMP_ROOT/no-mistakes-$n"
+    mkdir -p "$case_dir/home"
+    fakebin=$(make_fake_toolchain "$case_dir")
+    out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+      FM_FAKE_TREEHOUSE_LEASE_HELP=1 FM_FAKE_NO_MISTAKES_VERSION="$version" "$ROOT/bin/fm-bootstrap.sh")
+    case "$mode" in
+      empty)
+        [ -z "$out" ] || fail "$label: expected silence, got: $out" ;;
+      missing)
+        [ "$out" = "$missing" ] || fail "$label: expected '$missing', got: $out" ;;
+    esac
+  done <<'ROWS'
+minimum no-mistakes version is accepted^no-mistakes version v1.31.2 (fake)^empty
+newer no-mistakes minor is accepted^no-mistakes version v1.32.0 (fake)^empty
+newer no-mistakes major is accepted^no-mistakes version v2.0.0 (fake)^empty
+older no-mistakes patch reports an upgrade^no-mistakes version v1.31.1 (fake)^missing
+unparseable no-mistakes version reports an upgrade^no-mistakes development build^missing
+ROWS
+  pass "bootstrap enforces no-mistakes minimum version"
+}
+
 test_bootstrap_reporting
+test_no_mistakes_min_version

--- a/tests/fm-secondmate-sync.test.sh
+++ b/tests/fm-secondmate-sync.test.sh
@@ -264,7 +264,7 @@ make_fake_toolchain() {
   local dir=$1 fakebin
   fakebin="$dir/fakebin"
   mkdir -p "$fakebin"
-  fm_fake_exit0 "$fakebin" tmux node no-mistakes gh-axi chrome-devtools-axi lavish-axi
+  fm_fake_exit0 "$fakebin" tmux node gh-axi chrome-devtools-axi lavish-axi
   cat > "$fakebin/gh" <<'SH'
 #!/usr/bin/env bash
 exit 0
@@ -278,6 +278,15 @@ fi
 exit 0
 SH
   chmod +x "$fakebin/treehouse"
+  cat > "$fakebin/no-mistakes" <<'SH'
+#!/usr/bin/env bash
+if [ "${1:-}" = --version ]; then
+  printf '%s\n' 'no-mistakes version v1.31.2 (fake)'
+  exit 0
+fi
+exit 0
+SH
+  chmod +x "$fakebin/no-mistakes"
   printf '%s\n' "$fakebin"
 }
 


### PR DESCRIPTION
## Intent

Slim firstmate's no-mistakes validation contract in bin/fm-brief.sh down to a short pointer plus the firstmate-specific wrapper, because no-mistakes now self-documents the validation mechanics in its own SKILL.md (refreshed from the binary on init) and live axi help output as of v1.31.2. The brief's no-mistakes-mode Definition of done was restating those mechanics verbatim-in-spirit, which is a drift hazard since the brief lives in firstmate's repo while the authoritative, version-matched guidance lives in no-mistakes' SKILL.md.

The deliberate change: in the no-mistakes (default) branch of the DOD heredoc, replace the ~18-line duplicated mechanics block (the 'During validation the pipeline owns every fix...' bullets covering process-every-return, gate/outcome return model, long-run-is-normal, backgrounding-vs-idle-wait, auto-fix respond mechanics, review-always-gates, and the abort/rerun-mid-run warning) with a 3-line pointer that tells the crewmate it drives gates by responding (not implementing fixes) and to follow no-mistakes' own version-matched guidance (SKILL.md loaded on /no-mistakes invocation, plus 'no-mistakes axi run --help' and the per-response help lines).

Deliberately KEEP only the firstmate-specific wrapper that no-mistakes cannot know: the done handshake (commit -> append 'done: {summary}' -> firstmate then instructs /no-mistakes), ask-user routing to FIRSTMATE via rule 6 / the status file rather than 'the user' with the decision fed back through axi respond, the --yes stance that the captain (not the crewmate) owns those decisions, and the post-CI-green 'done: PR {url} checks green' reporting line.

Constraints honored: edited ONLY the no-mistakes-contract section of the DOD heredoc; the direct-PR and local-only branches and every other part of fm-brief.sh are untouched. The orienting sentence intentionally stays in the brief because the crewmate reads the brief before it ever invokes /no-mistakes, so SKILL.md is not yet in its context at planning time. Verified before removal that the installed no-mistakes v1.31.2 SKILL.md carries the three dropped facts (review-auto-fix-disabled, no-abort/rerun-mid-run, never-idle-wait/backgrounding-ok), so none of them now live nowhere. A freshly-scaffolded brief was confirmed to read coherently and rule 6 still resolves for the ask-user cross-reference. This is a fresh retry after the prior run died with a transient 'daemon crashed during execution' at the test step (review had already passed with 0 findings); no code changed between runs.

## What Changed

- Slimmed the no-mistakes-mode brief contract so crewmates follow no-mistakes' version-matched guidance instead of duplicated validation mechanics, while keeping firstmate-specific handoff, decision-routing, and PR-ready reporting rules.
- Added bootstrap enforcement for the no-mistakes v1.31.2 minimum, including robust version parsing and coverage for older or missing installs.
- Synced firstmate docs and tests around the slimmer brief contract, bootstrap version floor, and secondmate sync behavior.

## Risk Assessment

✅ Low: Captain, the diff is narrow and the added no-mistakes version floor directly addresses the prior regression risk without widening runtime behavior beyond bootstrap detection.

## Testing

Inspected the target diff, ran the focused bootstrap, secondmate sync, and brief-related behavior tests, then captured reviewer-visible artifacts showing the generated crewmate brief now contains the slim no-mistakes pointer and firstmate-specific wrapper, and that bootstrap enforces the v1.31.2 no-mistakes floor; all checks passed and no working-tree artifacts were left behind.

<details>
<summary>Evidence: Generated no-mistakes-mode crewmate brief</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Setup
You are in a disposable git worktree of alpha, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable treehouse worktree you were launched in, typically a path under a `.treehouse/` pool, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/slim-contract-b5`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KW3AQWJRMEKKDXSV8P10FN0D/brief-home/state/slim-contract-b5.status'`
   States: working, needs-decision, blocked, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs to a human (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KW3AQWJRMEKKDXSV8P10FN0D/bin/fm-ensure-agents-md.sh .` in the worktree.
If this task produced durable project-intrinsic knowledge, record it in `AGENTS.md` as part of your change.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow no-mistakes' own guidance for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are not yours to answer: escalate to firstmate (rule 6) and stop.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: the captain, not you, owns the ask-user decisions it would silently auto-resolve.

After /no-mistakes reports CI green, append `done: PR {url} checks green` and stop. You are finished.
```
</details>
<details>
<summary>Evidence: Brief contract check transcript</summary>

```text
Generated brief: /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KW3AQWJRMEKKDXSV8P10FN0D/generated-no-mistakes-brief.md

Required slim contract lines:
You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow no-mistakes' own guidance for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.
- ask-user findings are not yours to answer: escalate to firstmate (rule 6) and stop.
- Avoid `--yes`: the captain, not you, owns the ask-user decisions it would silently auto-resolve.
After /no-mistakes reports CI green, append `done: PR {url} checks green` and stop. You are finished.

Removed duplicated mechanics absent:
absent: Process every return; never idle-wait.
absent: Review auto-fix is disabled
absent: Backgrounding the call is fine
absent: Never hand-edit, `git commit`, `git reset`/`git checkout`, abort, or re-run while a run is active
```
</details>
<details>
<summary>Evidence: Bootstrap no-mistakes version probe transcript</summary>

```text
$ fm-bootstrap.sh with no-mistakes v1.31.1
MISSING: no-mistakes (install: curl -fsSL https://raw.githubusercontent.com/kunchenguid/no-mistakes/main/docs/install.sh | sh)

$ fm-bootstrap.sh with no-mistakes v1.31.2
<no output>
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-brief.sh:211` - The slimmed brief now delegates the removed validation mechanics to the installed no-mistakes guidance, but bootstrap only checks that `no-mistakes` exists and does not enforce the v1.31.2+ capability that carries those details. Existing fleets with an older binary will scaffold briefs that no longer include the no-idle-wait/no-abort gate-loop safety rules, so validation can regress silently. Add a minimum version/capability check, or keep a fallback in the brief until that dependency is enforced.

🔧 Fix: Enforce no-mistakes bootstrap version floor
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected target diff with `git diff --stat 9391e901001e13428a61f7de34e04f65a2bdaae1..c6058ca39a34e465947634929a27bd4aa5bd8711` and focused file diffs for `bin/fm-brief.sh`, `bin/fm-bootstrap.sh`, `tests/fm-bootstrap.test.sh`, and `tests/fm-secondmate-sync.test.sh`.</code>
- <code>Ran `tests/fm-bootstrap.test.sh`.</code>
- <code>Ran `tests/fm-secondmate-sync.test.sh`.</code>
- <code>Ran `tests/fm-tangle-guard.test.sh`.</code>
- <code>Generated a real no-mistakes-mode ship brief with `FM_HOME=/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KW3AQWJRMEKKDXSV8P10FN0D/brief-home bin/fm-brief.sh slim-contract-b5 alpha` and checked required slim-contract lines plus removed duplicated mechanics phrases.</code>
- <code>Ran a fake-toolchain `fm-bootstrap.sh` evidence probe showing no-mistakes `v1.31.1` reports `MISSING: no-mistakes` while `v1.31.2` is accepted silently.</code>
- <code>Verified the working tree stayed clean with `git status --short`.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
