### PR TITLE
fix(send): settle codex skill popups before submit

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -71,6 +71,12 @@ That styled capture is internal to the boolean detector only.
 | Interrupt | single Escape |
 | Skill invocation | `$<skill>` (e.g. `$no-mistakes`); `/<skill>` is claude-only and codex rejects it as "Unrecognized command" |
 
+A `$<skill>` invocation opens a `$`-autocomplete (skill) popup, the same hazard as the `/` slash popup: submitting too fast lets the popup swallow the Enter, so the invocation never lands.
+`fm-send` handles it the same way it handles `/` - it gives the popup a longer settle (1.2s) between typing and the first Enter, with `fm_tmux_submit_core`'s retried Enter as the safety net - but the `$` settle is scoped to `harness=codex`, read from the target's `state/<id>.meta`.
+That scope matters because, unlike `/`, a leading `$` commonly starts ordinary text (`$5/month`, `$HOME`), so a universal `$` rule would needlessly slow plain steers to claude/opencode/pi; only a codex target receiving a `$...` message gets the popup-settle.
+An explicit `session:window` target has no meta, so its harness is unknown and treated as non-codex (the safe fast-path default).
+This is why the validation trigger (`$no-mistakes`) to a codex crew now lands on the first Enter instead of biting the popup.
+
 Directory trust dialog on first run per repo root: "Do you trust the contents of this directory?"
 Accept with Enter.
 The decision persists for the repo, so later worktrees of the same project skip it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,7 @@ tests/fm-wake-queue.test.sh               # durable wake queue losslessness, cat
 tests/fm-watcher-lock.test.sh             # watcher singleton, lock-race, watch-arm liveness, and guard-warning tests
 tests/fm-daemon.test.sh                   # sub-supervisor classifier, /afk presence-gating, max-defer, composer, and fm-send submit tests
 tests/fm-send-settle.test.sh              # fm-send post-submit settle pause, tuning, disable, and --key bypass tests
+tests/fm-send-popup-settle.test.sh        # fm-send pre-Enter popup-settle selection for slash commands and codex $skill invocations
 tests/fm-send-secondmate-marker.test.sh   # fm-send from-firstmate marker for kind=secondmate targets: marked vs crewmate/explicit/--key, and the exact marker byte sequence
 tests/fm-wake-daemon-lifecycle-e2e.test.sh # watcher + daemon lifecycle e2e: restart catch-up, batching, dedupe, stale-pane routing, and digest injection
 tests/fm-composer-ghost.test.sh           # dim-ghost stripping, ghost-only composer detection, and escape-free peek tests

--- a/bin/fm-send.sh
+++ b/bin/fm-send.sh
@@ -12,6 +12,8 @@
 # instead of silently leaving an unsubmitted instruction (incident afk-invx-i5).
 # The composer/submit logic is shared with the away-mode daemon via
 # bin/fm-tmux-lib.sh. Tune with FM_SEND_RETRIES (default 3) / FM_SEND_SLEEP (0.4).
+# Slash commands, and codex `$...` skill invocations resolved through harness
+# meta, get a longer pre-Enter settle so completion popups do not swallow Enter.
 #
 # From-firstmate marker: when the resolved target is a bare `fm-<id>` whose meta
 # records kind=secondmate, the text is prefixed with the from-firstmate marker

--- a/bin/fm-send.sh
+++ b/bin/fm-send.sh
@@ -76,12 +76,38 @@ case "$RAW_TARGET" in
     ;;
 esac
 
+# Resolve the target's harness from its meta (recorded by fm-spawn), used only to
+# scope the codex `$<skill>` popup-settle below. A bare fm-<id> target carries
+# meta; an explicit session:window escape-hatch target has none, so its harness is
+# unknown and treated as non-codex (the safe default that keeps the fast path).
+TARGET_HARNESS=""
+case "$RAW_TARGET" in
+  fm-*)
+    meta="$STATE/${RAW_TARGET#fm-}.meta"
+    if [ -f "$meta" ]; then
+      TARGET_HARNESS=$(grep '^harness=' "$meta" 2>/dev/null | tail -1 | cut -d= -f2- || true)
+    fi
+    ;;
+esac
+
 if [ "${1:-}" = "--key" ]; then
   tmux send-keys -t "$T" "$2"
 else
   # Slash commands open a completion popup in some TUIs (verified on codex);
-  # submitting too fast selects nothing. Give popups time to settle.
-  case "$*" in /*) settle=1.2 ;; *) settle=0.3 ;; esac
+  # submitting too fast selects nothing, so give the popup time to settle before
+  # the (retried) Enter. Codex opens the same kind of popup for a `$<skill>`
+  # invocation, so a `$...` message to a codex target gets the same settle. That
+  # `$` case is scoped to codex on purpose: unlike `/`, a leading `$` commonly
+  # starts ordinary text ("$5/month", "$HOME"), so a universal `$` rule would
+  # needlessly slow plain text to claude/opencode/pi. The retried Enter in
+  # fm_tmux_submit_core still backs the settle up either way.
+  case "$*" in
+    /*) settle=1.2 ;;
+    \$*)
+      if [ "$TARGET_HARNESS" = codex ]; then settle=1.2; else settle=0.3; fi
+      ;;
+    *) settle=0.3 ;;
+  esac
   retries=${FM_SEND_RETRIES:-3}
   sleep_s=${FM_SEND_SLEEP:-0.4}
   # Type once, submit, verify. Lenient: only a positively-confirmed swallow

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,7 +21,7 @@ It leads with prominent bordered banners for the tangle and no-watcher cases so 
 
 A presence-gated sub-supervisor (`bin/fm-supervise-daemon.sh`) extends this for walk-away supervision: the `/afk` skill activates it, after which it self-handles routine wakes in bash and escalates only captain-relevant events as one batched, single-line digest (prefixed with an in-band sentinel marker so firstmate can tell daemon injections apart from real messages).
 Its injection path shares `bin/fm-tmux-lib.sh` with `fm-send.sh`, so dim-ghost-aware and border-aware composer detection plus verified submit retry stay consistent; stalled escalation delivery raises `state/.subsuper-inject-wedged` after `FM_MAX_DEFER_SECS` instead of silently deferring forever.
-`fm-send.sh` adds its own `FM_SEND_SETTLE` pause after successful text sends so immediate peeks catch the receiving turn starting; the sub-supervisor uses only the shared submit core and does not pay that pause.
+`fm-send.sh` selects a pre-Enter popup-settle for slash commands and for codex `$...` skill invocations using the target's recorded `harness=` meta, then adds its own `FM_SEND_SETTLE` pause after successful text sends so immediate peeks catch the receiving turn starting; the sub-supervisor uses only the shared submit core and does not pay that post-submit pause.
 
 ## Worktrees, not branches in your checkout
 

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -26,7 +26,7 @@ Each file also starts with a short header comment.
 | `fm-tasks-axi-lib.sh`    | Shared `tasks-axi` compatibility probe sourced by bootstrap and teardown                                            |
 | `fm-wake-drain.sh`       | Atomically drain queued watcher wakes before handling supervision work, then run the watcher-liveness guard         |
 | `fm-wake-lib.sh`         | Shared durable wake queue and portable lock helpers sourced by the watcher, drain, arm, guard, and daemon          |
-| `fm-send.sh`             | Send one verified literal line (or `--key Escape`) to a direct-report window; exits non-zero on confirmed swallowed Enter; bare `kind=secondmate` targets are marked as from-firstmate; text sends pause `FM_SEND_SETTLE` seconds after success |
+| `fm-send.sh`             | Send one verified literal line (or `--key Escape`) to a direct-report window; exits non-zero on confirmed swallowed Enter; bare `kind=secondmate` targets are marked as from-firstmate; slash commands and codex `$...` skill invocations get popup-settle before Enter; text sends pause `FM_SEND_SETTLE` seconds after success |
 | `fm-tmux-lib.sh`         | Shared tmux pane primitives for busy detection, dim-ghost-aware and border-aware composer detection, and verified submit retry |
 | `fm-peek.sh`             | Print a bounded tail of a crewmate pane                                                                             |
 | `fm-pr-check.sh`         | Record `pr=` and a verified `pr_head=` when available for a PR-ready task, then arm the watcher's merge poll        |

--- a/tests/fm-send-popup-settle.test.sh
+++ b/tests/fm-send-popup-settle.test.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# fm-send pre-submit popup-settle selection (the codex `$<skill>` fix).
+#
+# Some TUIs open a completion popup when the composer's first character triggers
+# it: codex (and others) for a leading `/` slash command, and codex specifically
+# for a leading `$<skill>` invocation (e.g. `$no-mistakes`). Submitting before the
+# popup settles lets it swallow the Enter, so the line never submits. fm-send
+# absorbs this by pausing `settle` seconds AFTER typing and BEFORE the (retried)
+# Enter - the first sleep fm_tmux_submit_core makes. These tests pin the
+# settle-SELECTION matrix hermetically (stubbed tmux + sleep, no real agent):
+#
+#   /...            -> 1.2  (universal; `/` only starts a command, never plain text)
+#   $... to codex   -> 1.2  (scoped: codex opens a `$<skill>` popup)
+#   $... to claude  -> 0.3  (NOT codex: `$` commonly starts plain text "$5", "$HOME")
+#   $... explicit   -> 0.3  (session:window target has no meta -> harness unknown
+#                            -> non-codex safe default)
+#   plain text      -> 0.3  (fast path)
+#
+# The popup-settle is the FIRST sleep recorded: fm_tmux_submit_core types the text,
+# then `sleep "$settle"`, then the Enter-retry loop (sleep 0.4 each) and finally
+# fm-send's own post-submit FM_SEND_SETTLE pause. So tail-vs-head matters: this
+# suite asserts on the HEAD sleep, distinct from fm-send-settle.test.sh which pins
+# the TAIL (post-submit) pause. The retried Enter in fm_tmux_submit_core remains the
+# real safety net; this settle is only the optimization that lets the popup clear so
+# the first Enter lands.
+#
+# Every case below passes a LITERAL `$<skill>` / `$price` message in single quotes
+# on purpose - the whole point is to send an unexpanded `$...` line to the agent -
+# so SC2016 (which flags single-quoted `$` as a probably-forgotten expansion) is a
+# false positive here and is disabled file-wide.
+# shellcheck disable=SC2016
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SEND="$ROOT/bin/fm-send.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-send-popup-settle)
+
+# Same stub shape as fm-send-settle.test.sh: a fake tmux that drives the submit
+# path to a clean "empty" verdict on the first Enter, and a fake sleep that records
+# every requested duration (one per line) into FM_SLEEP_LOG instead of sleeping.
+make_stubs() {  # <dir> -> echoes fakebin dir
+  local dir=$1 fb="$1/fakebin"
+  mkdir -p "$fb"
+  cat > "$fb/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "${1:-}" in
+  send-keys) exit 0 ;;
+  display-message)
+    for a in "$@"; do case "$a" in *cursor_y*) printf '0\n'; exit 0 ;; esac; done
+    printf 'fakepane\n'; exit 0 ;;
+  capture-pane) printf '\xe2\x94\x82 \xe2\x94\x82\n'; exit 0 ;;
+  list-windows) exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fb/tmux"
+  cat > "$fb/sleep" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "${1:-}" >> "$FM_SLEEP_LOG"
+exit 0
+SH
+  chmod +x "$fb/sleep"
+  printf '%s\n' "$fb"
+}
+
+# first_settle <expected> <label> <harness|--explicit> <message>: build a fresh
+# home, send <message> to a target whose meta records <harness> (or to a bare
+# session:window with NO meta when --explicit), and assert the FIRST recorded sleep
+# (the popup-settle) equals <expected>. FM_SEND_SETTLE=0 strips the trailing
+# post-submit pause so the log holds only the popup-settle plus the 0.4 Enter wait,
+# keeping the head assertion crisp. FM_ROOT_OVERRIDE points at a non-repo dir so
+# fm-guard's tangle check stays silent; its watcher-liveness note goes to stderr
+# (discarded).
+first_settle() {  # <expected> <label> <harness|--explicit> <message>
+  local expected=$1 label=$2 harness=$3 msg=$4
+  local dir fb log home target rc first
+  dir="$TMP_ROOT/case-$RANDOM"; mkdir -p "$dir/state"
+  fb=$(make_stubs "$dir"); log="$dir/sleep.log"; home="$dir"
+  if [ "$harness" = --explicit ]; then
+    target="sess:win"
+  else
+    target="fm-popupcase"
+    fm_write_meta "$home/state/popupcase.meta" "window=sess:win" "harness=$harness"
+  fi
+  : > "$log"
+  env FM_SEND_SETTLE=0 PATH="$fb:$PATH" \
+    FM_ROOT_OVERRIDE="$home" FM_HOME="$home" FM_SLEEP_LOG="$log" \
+    "$SEND" "$target" "$msg" 2>/dev/null; rc=$?
+  expect_code 0 "$rc" "$label: send should succeed"
+  first=$(head -1 "$log")
+  [ "$first" = "$expected" ] || fail "$label: expected popup-settle $expected, got '$first'"$'\n'"--- sleeps ---"$'\n'"$(cat "$log")"
+  pass "fm-send popup-settle: $label -> ${expected}s"
+}
+
+# Codex `$<skill>` gets the long settle so its `$` popup clears (the fix).
+first_settle 1.2 'codex $skill -> long settle' codex '$no-mistakes'
+
+# Same `$` message to claude keeps the fast path: `$` is ordinary text there.
+first_settle 0.3 'claude $-message -> fast path' claude '$no-mistakes'
+
+# `$`-prefixed plain text to claude (a price) must NOT popup-settle - the regression
+# the codex scoping exists to prevent.
+first_settle 0.3 'claude "$5/month" -> fast path' claude '$5/month is cheap'
+
+# An explicit session:window target has no meta, so the harness is unknown and
+# treated as non-codex: the safe default keeps the fast path even for a `$` message.
+first_settle 0.3 'explicit target $message -> fast path (unknown harness)' --explicit '$no-mistakes'
+
+# The `/` slash case stays universal and unchanged: long settle regardless of
+# harness (here a non-codex claude target).
+first_settle 1.2 'claude /command -> long settle (slash unchanged)' claude '/no-mistakes'
+
+# A `/` to codex is likewise still the long settle (slash path untouched).
+first_settle 1.2 'codex /command -> long settle (slash unchanged)' codex '/help'
+
+# Plain text to codex takes the fast path - the codex scope is `$`-prefixed only.
+first_settle 0.3 'codex plain text -> fast path' codex 'just a normal steer'


### PR DESCRIPTION
## Intent

Fix: fm-send.sh must reliably submit codex $skill invocations (e.g. $no-mistakes). On a codex crew, a $-prefixed message opens codex's $-autocomplete (skill) popup; submitting too fast lets the popup swallow the Enter, so the invocation never lands - this bit every pipeline-validation trigger to a codex crew/secondmate. fm-send already handles the analogous '/' slash popup by giving it a longer 1.2s settle before the (retried) Enter (fm_tmux_submit_core's retried-Enter is the safety net). The chosen fix mirrors that for '$' but SCOPED TO codex: I added a TARGET_HARNESS resolution block that reads harness= from the target's state/<id>.meta (the same meta fm-spawn records and the marker/window logic already reads), and extended the settle-selection case to: '/*' -> 1.2 (unchanged, universal-benign); else if harness=codex AND message starts with '$' -> 1.2 (new); else -> 0.3. The scoping to codex is deliberate and important: unlike '/', a leading '$' commonly starts ordinary text ('$5/month', '$HOME', a price), so a universal '$' rule would needlessly popup-settle plain steers sent to claude/opencode/pi. An explicit session:window target has no meta, so its harness is unknown and is treated as non-codex (the safe fast-path default). Deliberate constraints I held to: the existing '/' case, the --key path, the from-firstmate secondmate marker logic, and the meta-resolution contract are all left byte-for-byte unchanged; the retried-Enter safety net is kept as-is (the settle is only the optimization that lets the popup clear so the first Enter lands). The settle selection checks the user's message $* (not the marker-prefixed text), matching the existing '/' check, so the marker path is unaffected. The durable codex-popup knowledge was recorded in the harness-adapters skill (.agents/skills/harness-adapters/SKILL.md, codex section) NOT in AGENTS.md, because a concurrent task owns AGENTS.md - so AGENTS.md is intentionally untouched here. Verification: a new deterministic per-harness test tests/fm-send-popup-settle.test.sh (7 cases) asserts the exact settle value passed to the submit core (codex $ ->1.2, claude $ ->0.3, claude $-price ->0.3, explicit-target $ ->0.3, claude / ->1.2, codex / ->1.2, codex plain ->0.3); it intentionally sends single-quoted literal $ text so a file-wide 'shellcheck disable=SC2016' documents that intent. I also ran a real-tmux end-to-end timing check (real fm-send.sh + real sleep + real meta) confirming codex $ lands in ~1.70s vs claude $ in ~0.80s, every submit landing on the first Enter. Full suite 17/17 files pass; shellcheck clean via the CI invocation 'shellcheck bin/*.sh tests/*.sh'.

## What Changed

- Updates `bin/fm-send.sh` to detect codex targets from recorded task metadata and give `$`-prefixed messages the longer popup settle before submitting.
- Documents the codex `$skill` popup behavior in harness adapter and script docs.
- Adds deterministic popup-settle coverage for codex, claude, slash-prefixed messages, explicit targets, and plain text cases.

## Risk Assessment

✅ Low: Captain, the change is narrow, meta-scoped, and covered by a focused hermetic test for the new settle-selection behavior.

## Testing

Reviewed the diff and intent, ran the focused fm-send popup-settle and adjacent send behavior tests, reran the real-tmux evidence check after discarding a flawed temporary receiver, then ran the full shell test suite. The final transcript shows `$no-mistakes` landing in real tmux panes with codex taking the longer settle path than claude; all tests passed, no linters/static analysis were run, the temporary manual-test home was removed, and the worktree remained clean.

<details>
<summary>Evidence: real-tmux-dollar-send-transcript</summary>

<code>CASE codexdollar: harness=codex message=$no-mistakes elapsed_ms=1965, pane showed RECEIVED:codexdollar:$no-mistakes&#10;CASE claudedollar: harness=claude message=$no-mistakes elapsed_ms=882, pane showed RECEIVED:claudedollar:$no-mistakes</code>

```text
fm-send real tmux evidence
purpose: show codex $-prefixed send waits longer but still submits the literal line; non-codex $ stays fast and also submits.

CASE codexdollar
target=fm-codexcase harness=codex message=$no-mistakes elapsed_ms=1965
READY:codexdollar
$no-mistakes
RECEIVED:codexdollar:$no-mistakes

CASE claudedollar
target=fm-claudecase harness=claude message=$no-mistakes elapsed_ms=882
READY:claudedollar
$no-mistakes
RECEIVED:claudedollar:$no-mistakes

SUMMARY
codexdollar 1965
claudedollar 882
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git status --short --branch && git rev-parse HEAD && git diff --name-status 362fb54e02156f02d65f9f19d48269dbeb85ceb6...0e2e0bc800cc424a383718f30d0abc8c35e11094`
- `git diff --no-ext-diff 362fb54e02156f02d65f9f19d48269dbeb85ceb6...HEAD -- bin/fm-send.sh tests/fm-send-popup-settle.test.sh .agents/skills/harness-adapters/SKILL.md`
- `bash tests/fm-send-popup-settle.test.sh`
- `bash tests/fm-send-settle.test.sh`
- `bash tests/fm-send-secondmate-marker.test.sh`
- <code>Manual real-tmux evidence check: created codex and claude target metadata, sent literal `$no-mistakes` through `bin/fm-send.sh`, captured submitted pane output and elapsed timing in `/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KW3J2D7PZ1KDXV186BZZ6115/fm-send-codex-dollar-real-tmux-transcript.txt`</code>
- `for t in tests/*.test.sh; do bash "$t"; done`
- <code>`git status --short` and `tmux list-sessions -F &#39;#{session_name}&#39; | rg &#39;^fm-send-dollar-e2e-&#39; || true` after cleanup</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
