### PR TITLE
feat(supervise): add deterministic crew state helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -376,7 +376,11 @@ The ship brief intentionally does not restate no-mistakes gate mechanics; it poi
 Firstmate's wrapper stays narrow: `ask-user` findings return through `needs-decision`, captain-owned decisions go back through `no-mistakes axi respond`, crewmate validation avoids `--yes`, and CI-green completion is reported as `done: PR {url} checks green`.
 Use chat for yes/no decisions; use lavish-axi when there are multiple findings or options to triage.
 
-Judge a validating crewmate by the run's step status, never by whether its shell is still running; read it cheaply with `no-mistakes axi status`.
+Judge a validating crewmate by the run's step status, never by whether its shell is still running.
+Read its current state with `bin/fm-crew-state.sh <id>`: a deterministic, token-tight one-line read that takes the active no-mistakes run-step as the source of truth and reconciles it against the crewmate's `state/<id>.status` log.
+That log is an append-only wake-*event* log, not a current-state field, and it goes stale the moment a resolved gate lets the run resume: after you answer a `needs-decision`/`blocked` and the crewmate silently resumes (responds to the gate, the pipeline fixes, it re-validates), the log's last line still reads `needs-decision`/`blocked` while the run-step has moved on.
+So never infer current state from a `tail` of that log; `bin/fm-crew-state.sh` reports the live run-step state and explicitly flags the stale log line superseded, where a raw `tail` would mislead you into re-escalating settled work.
+The status verbs below name the run-step states it reads from `no-mistakes axi status`; run that command directly when you want the full gate findings.
 
 - `running`/`fixing`/`ci` - the pipeline is working (a fix round, a test, or CI monitoring); these run for many minutes and quiet is normal, so leave it alone.
 - `awaiting_approval`/`fix_review` - the run is parked waiting on the agent, surfaced as a top-level `awaiting_agent: parked <duration>` line right after `status:` in `axi status`.
@@ -473,10 +477,11 @@ On wake, in order of cheapness:
 
 1. Read the reason line and drain queued wake records with `bin/fm-wake-drain.sh`.
 2. `signal:` read the listed status files first; a wake lists every signal that landed within the coalescing grace window (e.g. a status write plus the same turn's turn-end marker), and each is ~30 tokens and usually sufficient.
+   A status line is the wake *event*, not the crewmate's current state; when you need the live state - especially to confirm a `needs-decision`/`blocked` is still real and not already resolved-and-resumed - read it with `bin/fm-crew-state.sh <id>`, which reconciles the authoritative run-step over the possibly-stale log line, and never `tail` the status log as the current-state source.
 3. `stale:` the crewmate stopped without reporting; peek the pane (`bin/fm-peek.sh <window>`) to diagnose.
    If the pane is waiting, looping, confused, or unresponsive, load `stuck-crewmate-recovery`.
 4. `check:` a per-task poll fired (usually a merge); act on it.
-5. `heartbeat:` review the whole fleet: skim each window's status file, peek panes that look off, check PR-ready tasks for merge, reconcile data/backlog.md, then re-arm the watcher.
+5. `heartbeat:` review the whole fleet: read each crewmate's current state with `bin/fm-crew-state.sh <id>` (the cheap first read - it reconciles the authoritative run-step over a possibly-stale status-log line, so a crewmate whose gate you already resolved no longer reads as still parked), peek panes that look off, check PR-ready tasks for merge, reconcile data/backlog.md, then re-arm the watcher.
    A heartbeat with no captain-relevant change is internal; do not report that the fleet is unchanged.
 
 Heartbeats back off exponentially while they are the only wakes firing (600s doubling to a 2h cap - an idle fleet stops burning turns); any signal, stale, or check wake resets the cadence to the base interval.
@@ -512,7 +517,7 @@ This is about firstmate's own session: it includes a no-mistakes pipeline firstm
 Background that work so watcher wakes can interleave with it and the supervision loop stays responsive.
 A crewmate driving its own `no-mistakes` validation does the opposite: it drives that gate loop synchronously and processes every return, never idle-waiting for its own validation run to advance on its own.
 
-Token discipline: status files before panes; default peeks to 40 lines; never stream a pane repeatedly through yourself; batch what you tell the captain.
+Token discipline: for a crewmate's current state prefer `bin/fm-crew-state.sh <id>`, which reads the run-step, then the pane, then the log in that cheap-first order and treats the status log's last line as a wake event rather than the current state; default peeks to 40 lines; never stream a pane repeatedly through yourself; batch what you tell the captain.
 The context-% shown in a peek is not actionable as crew health; ignore it and intervene only on real signals (`signal`, `stale`, `needs-decision`, `blocked`), looping or confusion in the pane, or a question the brief already answers.
 Silence is the correct state while a healthy background watcher is waiting.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,6 +162,7 @@ Reconcile reality with your records before doing anything else:
    If it refuses because another live session holds the lock, tell the captain another active session is already managing the work and operate read-only until resolved.
 2. Drain queued wakes with `bin/fm-wake-drain.sh` and keep the printed records as the first work queue for this recovery turn.
 3. Read `data/backlog.md`, `data/secondmates.md` if present, every `state/*.meta`, and every `state/*.status`.
+   Treat status files as wake-event history; when you need a live current-state read for a recorded direct report, use `bin/fm-crew-state.sh <id>` instead of inferring from the last status line.
 4. Use the `window=` values from this home's `state/*.meta` files as the live direct-report set, then check those tmux panes.
    Do not sweep every `fm-*` tmux window across all sessions during recovery; another firstmate home's child panes may share that namespace and are not this home's orphans.
 5. If a recorded direct-report window is missing, reconcile it through its meta as described below.
@@ -377,14 +378,17 @@ Firstmate's wrapper stays narrow: `ask-user` findings return through `needs-deci
 Use chat for yes/no decisions; use lavish-axi when there are multiple findings or options to triage.
 
 Judge a validating crewmate by the run's step status, never by whether its shell is still running.
-Read its current state with `bin/fm-crew-state.sh <id>`: a deterministic, token-tight one-line read that takes the active no-mistakes run-step as the source of truth and reconciles it against the crewmate's `state/<id>.status` log.
+Read its current state with `bin/fm-crew-state.sh <id>`: a deterministic, token-tight one-line read that takes the matching no-mistakes run-step as the source of truth and reconciles it against the crewmate's `state/<id>.status` log.
+Because the run-step is authoritative before pane liveness, a crewmate whose window closed after or during validation can still report `done` or `working` from its run; a missing pane becomes `unknown` only when no matching run exists.
 That log is an append-only wake-*event* log, not a current-state field, and it goes stale the moment a resolved gate lets the run resume: after you answer a `needs-decision`/`blocked` and the crewmate silently resumes (responds to the gate, the pipeline fixes, it re-validates), the log's last line still reads `needs-decision`/`blocked` while the run-step has moved on.
 So never infer current state from a `tail` of that log; `bin/fm-crew-state.sh` reports the live run-step state and explicitly flags the stale log line superseded, where a raw `tail` would mislead you into re-escalating settled work.
-The status verbs below name the run-step states it reads from `no-mistakes axi status`; run that command directly when you want the full gate findings.
+The fields below name the run-step states and outcomes it reads from `no-mistakes axi status`; run that command directly when you want the full gate findings.
 
 - `running`/`fixing`/`ci` - the pipeline is working (a fix round, a test, or CI monitoring); these run for many minutes and quiet is normal, so leave it alone.
 - `awaiting_approval`/`fix_review` - the run is parked waiting on the agent, surfaced as a top-level `awaiting_agent: parked <duration>` line right after `status:` in `axi status`.
   The crewmate owes a response; if it is idle-waiting for the run to advance on its own, steer it to follow no-mistakes' active-gate help.
+- `outcome: passed` or `checks-passed` - the helper reports `done`; `passed` means the PR is already merged or closed, while `checks-passed` means it is ready for PR review.
+- `outcome: failed` or `cancelled` - the helper reports `failed`; inspect the run details and recover or report failure with evidence.
 - Red flag - self-fix duplication: a validating crewmate making fresh hand-commits, aborting the run, or re-running it mid-validation is re-doing work the pipeline already owns.
   Steer it back to no-mistakes' respond flow; the pipeline, not the crewmate, applies validation fixes.
 
@@ -471,7 +475,7 @@ bin/fm-watch-arm.sh        # safe verified re-arm; run as harness-tracked backgr
 bin/fm-watch-arm.sh --restart  # home-scoped forced restart; never a broad pkill
 bin/fm-watch.sh            # the watcher itself; exits with: signal|stale|check|heartbeat
 bin/fm-wake-drain.sh       # drain queued wake records at turn start; asserts guard after draining
-bin/fm-crew-state.sh <id>  # one-line current-state read; reconciles run-step, pane, and status log
+bin/fm-crew-state.sh <id>  # one-line current-state read; reconciles matching run-step, pane, and status log
 ```
 
 On wake, in order of cheapness:
@@ -518,7 +522,7 @@ This is about firstmate's own session: it includes a no-mistakes pipeline firstm
 Background that work so watcher wakes can interleave with it and the supervision loop stays responsive.
 A crewmate driving its own `no-mistakes` validation does the opposite: it drives that gate loop synchronously and processes every return, never idle-waiting for its own validation run to advance on its own.
 
-Token discipline: for a crewmate's current state prefer `bin/fm-crew-state.sh <id>`, which reads the run-step, then the pane, then the log in that cheap-first order and treats the status log's last line as a wake event rather than the current state; default peeks to 40 lines; never stream a pane repeatedly through yourself; batch what you tell the captain.
+Token discipline: for a crewmate's current state prefer `bin/fm-crew-state.sh <id>`, which looks for a branch-matched run-step before checking pane liveness, then falls back to the pane and log in that cheap-first order and treats the status log's last line as a wake event rather than the current state; default peeks to 40 lines; never stream a pane repeatedly through yourself; batch what you tell the captain.
 The context-% shown in a peek is not actionable as crew health; ignore it and intervene only on real signals (`signal`, `stale`, `needs-decision`, `blocked`), looping or confusion in the pane, or a question the brief already answers.
 Silence is the correct state while a healthy background watcher is waiting.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,7 @@ data/                personal fleet records; LOCAL, gitignored as a whole
   <id>/report.md     scout task deliverable, written by the crewmate; survives teardown
 projects/            cloned repos; gitignored; READ-ONLY for you
 state/               volatile runtime signals; gitignored
-  <id>.status        appended by crewmates: "<state>: <note>" lines
+  <id>.status        appended by crewmates: "<state>: <note>" wake-event lines, not current-state truth
   <id>.turn-ended    touched by turn-end hooks
   <id>.meta          written by fm-spawn: window=, worktree=, project=, harness=, kind=, mode=, yolo=; kind=secondmate also records home= and projects= (fm-pr-check appends pr= and verified pr_head= when available)
   <id>.check.sh      optional slow poll you write per task (e.g. merged-PR check)
@@ -471,6 +471,7 @@ bin/fm-watch-arm.sh        # safe verified re-arm; run as harness-tracked backgr
 bin/fm-watch-arm.sh --restart  # home-scoped forced restart; never a broad pkill
 bin/fm-watch.sh            # the watcher itself; exits with: signal|stale|check|heartbeat
 bin/fm-wake-drain.sh       # drain queued wake records at turn start; asserts guard after draining
+bin/fm-crew-state.sh <id>  # one-line current-state read; reconciles run-step, pane, and status log
 ```
 
 On wake, in order of cheapness:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,7 @@ tests/fm-secondmate-sync.test.sh          # local-HEAD secondmate sync, no-fetch
 tests/fm-secondmate-lifecycle-e2e.test.sh # persistent secondmate routing, seeding, backlog handoff, spawn, recovery, teardown, and FM_HOME flow tests
 tests/fm-secondmate-safety.test.sh        # secondmate home safety, idle charter, handoff validation, and teardown boundary tests
 tests/fm-teardown.test.sh                 # fm-teardown.sh landed-work safety and reminder checks: fork-remote allow, squash/content landings, dirty and unlanded refusals, PR-head metadata, tasks-axi reminder, --force override
+tests/fm-crew-state.test.sh               # fm-crew-state.sh current-state reconciliation: run-step authority, stale needs-decision/blocked superseded by a resumed run, genuine-parked, cross-branch attribution, pane/status-log fallback, scout skip, torn-down/missing-meta graceful
 [ "$(readlink CLAUDE.md)" = "AGENTS.md" ]
 [ "$(readlink .claude/skills)" = "../.agents/skills" ]
 FM_HEARTBEAT=2 FM_POLL=1 bin/fm-watch-arm.sh  # watcher re-arm smoke test (prints arm status, then "heartbeat")

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,7 @@ tests/fm-secondmate-sync.test.sh          # local-HEAD secondmate sync, no-fetch
 tests/fm-secondmate-lifecycle-e2e.test.sh # persistent secondmate routing, seeding, backlog handoff, spawn, recovery, teardown, and FM_HOME flow tests
 tests/fm-secondmate-safety.test.sh        # secondmate home safety, idle charter, handoff validation, and teardown boundary tests
 tests/fm-teardown.test.sh                 # fm-teardown.sh landed-work safety and reminder checks: fork-remote allow, squash/content landings, dirty and unlanded refusals, PR-head metadata, tasks-axi reminder, --force override
-tests/fm-crew-state.test.sh               # fm-crew-state.sh current-state reconciliation: run-step authority, stale needs-decision/blocked superseded by a resumed run, genuine-parked, cross-branch attribution, pane/status-log fallback, scout skip, torn-down/missing-meta graceful
+tests/fm-crew-state.test.sh               # fm-crew-state.sh current-state reconciliation: run-step authority including closed panes, stale needs-decision/blocked superseded by a resumed run, genuine-parked, cross-branch attribution, pane/status-log fallback, scout skip, torn-down/missing-meta graceful
 [ "$(readlink CLAUDE.md)" = "AGENTS.md" ]
 [ "$(readlink .claude/skills)" = "../.agents/skills" ]
 FM_HEARTBEAT=2 FM_POLL=1 bin/fm-watch-arm.sh  # watcher re-arm smoke test (prints arm status, then "heartbeat")

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -112,12 +112,13 @@ map_log_state() {  # <verb>
 LOG_LINE=$(log_last_line || true)
 LOG_VERB=$(log_verb_of "$LOG_LINE")
 
+# pane_readable is consulted ONLY in the no-run fallback below. The run-step path
+# stays authoritative regardless of pane liveness - judge by the run-step, not the
+# shell - so a finished crew whose window has closed still reports its run-step
+# state (e.g. done) instead of being masked as unknown.
 pane_readable() {  # <target>
   tmux display-message -p -t "$1" '#{pane_id}' >/dev/null 2>&1
 }
-
-[ -n "$WIN" ] || emit unknown none "no window recorded"
-pane_readable "$WIN" || emit unknown none "window gone: $WIN"
 
 # --- no-mistakes run lookup (authoritative when a run matches this branch) --
 
@@ -340,10 +341,16 @@ if [ "$HAVE_RUN" = 1 ]; then
   emit "$RUN_STATE" run-step "$RUN_DETAIL"
 fi
 
-# --- fallback: pane busy-signature + status log ----------------------------
+# --- fallback: no run attributed to this crew ------------------------------
+# The run-step path above already handled any crew with a run, regardless of pane
+# liveness, so a finished-but-pane-closed crew never reaches here. Down here there
+# is no run to consult, so a dead/unreadable window means the crew is gone: report
+# unknown rather than trusting a possibly-stale status log as the current state.
+[ -n "$WIN" ] || emit unknown none "no window recorded"
+pane_readable "$WIN" || emit unknown none "window gone: $WIN"
 
-# Secondmates idle on their own watcher (idle pane = healthy), so pane-busy is
-# not a meaningful signal for them; read their state from the status log only.
+# Secondmates idle on their own watcher (idle pane = healthy), so the busy
+# signature is not meaningful for them; read their state from the status log only.
 if [ "$KIND" != secondmate ] && fm_pane_is_busy "$WIN"; then
   emit working pane "harness busy"
 fi

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -74,7 +74,9 @@ KIND=$(meta_value kind)
 [ -n "$KIND" ] || KIND=ship
 
 # A torn-down (or never-created) worktree has no current state to read.
-[ -n "$WT" ] && [ -d "$WT" ] || emit unknown none "worktree gone (torn down?)"
+if [ -z "$WT" ] || [ ! -d "$WT" ]; then
+  emit unknown none "worktree gone (torn down?)"
+fi
 
 # --- status log ------------------------------------------------------------
 

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -147,6 +147,10 @@ nm_run_id_for_branch() {  # <branch> <list-output>
   done | head -1
 }
 
+pane_readable() {  # <target>
+  tmux display-message -p -t "$1" '#{pane_id}' >/dev/null 2>&1
+}
+
 # CREW_BRANCH is empty at detached HEAD (a just-spawned crew, or a scout's
 # scratch worktree); with no branch there is no run to attribute to this crew.
 CREW_BRANCH=$(git -C "$WT" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
@@ -232,9 +236,12 @@ fi
 
 # --- fallback: pane busy-signature + status log ----------------------------
 
+[ -n "$WIN" ] || emit unknown none "no window recorded"
+pane_readable "$WIN" || emit unknown none "window gone: $WIN"
+
 # Secondmates idle on their own watcher (idle pane = healthy), so pane-busy is
 # not a meaningful signal for them; read their state from the status log only.
-if [ "$KIND" != secondmate ] && [ -n "$WIN" ] && fm_pane_is_busy "$WIN"; then
+if [ "$KIND" != secondmate ] && fm_pane_is_busy "$WIN"; then
   emit working pane "harness busy"
 fi
 

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -49,6 +49,7 @@ ID=${1:-}
 META="$STATE/$ID.meta"
 LOG="$STATE/$ID.status"
 NM_TIMEOUT=${FM_CREW_STATE_NM_TIMEOUT:-10}
+case "$NM_TIMEOUT" in ''|*[!0-9]*) NM_TIMEOUT=10 ;; esac
 SEP=' · '
 
 # Emit the one canonical line and exit 0. Detail is optional.
@@ -109,6 +110,13 @@ map_log_state() {  # <verb>
 LOG_LINE=$(log_last_line || true)
 LOG_VERB=$(log_verb_of "$LOG_LINE")
 
+pane_readable() {  # <target>
+  tmux display-message -p -t "$1" '#{pane_id}' >/dev/null 2>&1
+}
+
+[ -n "$WIN" ] || emit unknown none "no window recorded"
+pane_readable "$WIN" || emit unknown none "window gone: $WIN"
+
 # --- no-mistakes run lookup (authoritative when a run matches this branch) --
 
 strip_quotes() { local s=${1:-}; s=${s#\"}; s=${s%\"}; printf '%s' "$s"; }
@@ -117,12 +125,14 @@ strip_quotes() { local s=${1:-}; s=${s#\"}; s=${s%\"}; printf '%s' "$s"; }
 HAVE_TIMEOUT=none
 if command -v timeout >/dev/null 2>&1; then HAVE_TIMEOUT=timeout
 elif command -v gtimeout >/dev/null 2>&1; then HAVE_TIMEOUT=gtimeout
+elif command -v perl >/dev/null 2>&1; then HAVE_TIMEOUT=perl
 fi
 nm_run() {  # <args...>
   case "$HAVE_TIMEOUT" in
     timeout)  ( cd "$WT" && timeout "$NM_TIMEOUT" no-mistakes "$@" ) 2>/dev/null || true ;;
     gtimeout) ( cd "$WT" && gtimeout "$NM_TIMEOUT" no-mistakes "$@" ) 2>/dev/null || true ;;
-    *)        ( cd "$WT" && no-mistakes "$@" ) 2>/dev/null || true ;;
+    perl)     ( cd "$WT" && perl -e 'my $t = shift; my $pid = fork; die "fork failed" unless defined $pid; if (!$pid) { setpgrp(0, 0); exec @ARGV } local $SIG{ALRM} = sub { kill "TERM", -$pid; select undef, undef, undef, 0.2; kill "KILL", -$pid; exit 124 }; alarm $t; waitpid $pid, 0; exit($? >> 8)' "$NM_TIMEOUT" no-mistakes "$@" ) 2>/dev/null || true ;;
+    *)        true ;;
   esac
 }
 
@@ -145,10 +155,6 @@ nm_run_id_for_branch() {  # <branch> <list-output>
     br=${rest%%,*}
     if [ "$br" = "$branch" ]; then printf '%s\n' "$id"; break; fi
   done | head -1
-}
-
-pane_readable() {  # <target>
-  tmux display-message -p -t "$1" '#{pane_id}' >/dev/null 2>&1
 }
 
 # CREW_BRANCH is empty at detached HEAD (a just-spawned crew, or a scout's
@@ -235,9 +241,6 @@ if [ "$HAVE_RUN" = 1 ]; then
 fi
 
 # --- fallback: pane busy-signature + status log ----------------------------
-
-[ -n "$WIN" ] || emit unknown none "no window recorded"
-pane_readable "$WIN" || emit unknown none "window gone: $WIN"
 
 # Secondmates idle on their own watcher (idle pane = healthy), so pane-busy is
 # not a meaningful signal for them; read their state from the status log only.

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -1,0 +1,245 @@
+#!/usr/bin/env bash
+# fm-crew-state.sh — deterministic read of a crew's CURRENT state.
+#
+# Why this exists: state/<id>.status is an append-only, best-effort EVENT LOG.
+# Crews append only wake-worthy transitions (done/needs-decision/blocked/failed)
+# and nothing when they silently resume, so `tail -1` of that log reports the
+# last EVENT, not the current STATE. After firstmate resolves a needs-decision
+# or blocked and the crew resumes (responds to the gate, the pipeline fixes, it
+# re-validates), the log's last line stays stale. This helper never infers the
+# current state from a tail of the log: it reads the authoritative source (an
+# active no-mistakes run-step, else the pane busy-signature) and reconciles the
+# possibly-stale log against it.
+#
+# The determinism lives entirely here — only run-step / pane / log reads plus
+# fixed mapping logic, no heuristics and no LLM. Output is one stable, parseable,
+# token-tight line firstmate can read every heartbeat:
+#
+#   state: <working|parked|done|blocked|failed|unknown> · source: <run-step|pane|status-log|none> · <detail>
+#
+# Logic, in order:
+#   1. Resolve worktree + window + kind from state/<id>.meta.
+#   2. Active no-mistakes run for this crew's branch? The run-step is
+#      AUTHORITATIVE: running/fixing -> working, ci -> working, awaiting_approval/
+#      fix_review -> parked (with gate findings), terminal passed/checks-passed ->
+#      done, failed/cancelled -> failed.
+#   3. Reconcile the status log: if its last line says needs-decision/blocked but
+#      the run-step shows the run moved on, the log is deterministically stale and
+#      is flagged superseded. A genuinely parked run plus a needs-decision log
+#      agree, and are reported as parked.
+#   4. No run for this crew (pre-validation, or kind=scout): fall back to the
+#      pane busy-signature (fm-tmux-lib.sh) + the status log's last line.
+#   5. Missing meta / torn-down worktree / dead window: report unknown · none.
+#
+# Read-only and side-effect free. Always exits 0 on a successful read regardless
+# of state; exit 2 only on a usage error (no id).
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+
+# shellcheck source=bin/fm-tmux-lib.sh
+. "$SCRIPT_DIR/fm-tmux-lib.sh"
+
+ID=${1:-}
+[ -n "$ID" ] || { echo "usage: fm-crew-state.sh <id>" >&2; exit 2; }
+
+META="$STATE/$ID.meta"
+LOG="$STATE/$ID.status"
+NM_TIMEOUT=${FM_CREW_STATE_NM_TIMEOUT:-10}
+SEP=' · '
+
+# Emit the one canonical line and exit 0. Detail is optional.
+emit() {  # <state> <source> [detail]
+  local line="state: $1${SEP}source: $2"
+  [ -n "${3:-}" ] && line="$line${SEP}$3"
+  printf '%s\n' "$line"
+  exit 0
+}
+
+# --- meta resolution --------------------------------------------------------
+
+[ -f "$META" ] || emit unknown none "no metadata for $ID"
+
+meta_value() {  # <key>
+  grep "^$1=" "$META" 2>/dev/null | tail -1 | cut -d= -f2- || true
+}
+
+WT=$(meta_value worktree)
+WIN=$(meta_value window)
+KIND=$(meta_value kind)
+[ -n "$KIND" ] || KIND=ship
+
+# A torn-down (or never-created) worktree has no current state to read.
+[ -n "$WT" ] && [ -d "$WT" ] || emit unknown none "worktree gone (torn down?)"
+
+# --- status log ------------------------------------------------------------
+
+# Last non-empty status line, and its leading verb (the word before the colon).
+log_last_line() {
+  [ -f "$LOG" ] || return 1
+  grep -v '^[[:space:]]*$' "$LOG" 2>/dev/null | tail -1
+}
+log_verb_of() {  # <line>
+  local v=${1%%:*}
+  v="${v#"${v%%[![:space:]]*}"}"
+  v="${v%"${v##*[![:space:]]}"}"
+  printf '%s' "$v"
+}
+log_note_of() {  # <line>
+  case "$1" in
+    *:*) local n=${1#*:}; printf '%s' "${n#"${n%%[![:space:]]*}"}" ;;
+    *)   printf '%s' "$1" ;;
+  esac
+}
+# Map a status-log verb onto a canonical state for the fallback path.
+map_log_state() {  # <verb>
+  case "$1" in
+    working)        echo working ;;
+    needs-decision) echo parked ;;
+    blocked)        echo blocked ;;
+    done)           echo "done" ;;
+    failed)         echo failed ;;
+    *)              echo unknown ;;
+  esac
+}
+
+LOG_LINE=$(log_last_line || true)
+LOG_VERB=$(log_verb_of "$LOG_LINE")
+
+# --- no-mistakes run lookup (authoritative when a run matches this branch) --
+
+strip_quotes() { local s=${1:-}; s=${s#\"}; s=${s%\"}; printf '%s' "$s"; }
+
+# Bounded no-mistakes call in the worktree; stdout only, never fails the script.
+HAVE_TIMEOUT=none
+if command -v timeout >/dev/null 2>&1; then HAVE_TIMEOUT=timeout
+elif command -v gtimeout >/dev/null 2>&1; then HAVE_TIMEOUT=gtimeout
+fi
+nm_run() {  # <args...>
+  case "$HAVE_TIMEOUT" in
+    timeout)  ( cd "$WT" && timeout "$NM_TIMEOUT" no-mistakes "$@" ) 2>/dev/null || true ;;
+    gtimeout) ( cd "$WT" && gtimeout "$NM_TIMEOUT" no-mistakes "$@" ) 2>/dev/null || true ;;
+    *)        ( cd "$WT" && no-mistakes "$@" ) 2>/dev/null || true ;;
+  esac
+}
+
+# Scalar value of a TOON key in the captured run output ($RUN_OUT).
+RUN_OUT=""
+nm_field() {  # <key>
+  printf '%s\n' "$RUN_OUT" | sed -n "s/^[[:space:]]*$1:[[:space:]]*\(.*\)/\1/p" | head -1
+}
+# Finding count from a findings[N]{...} table header; empty when none.
+nm_findings_count() {
+  printf '%s\n' "$RUN_OUT" | grep -oE 'findings\[[0-9]+\]' | head -1 | grep -oE '[0-9]+'
+}
+# Most recent run id whose branch matches, from the `no-mistakes axi` run list.
+nm_run_id_for_branch() {  # <branch> <list-output>
+  local branch=$1 list=$2 row id rest br
+  printf '%s\n' "$list" | grep -E '^[[:space:]]*"[^"]+",' | while IFS= read -r row; do
+    row=${row#"${row%%[![:space:]]*}"}
+    id=${row%%,*}; id=$(strip_quotes "$id")
+    rest=${row#*,}
+    br=${rest%%,*}
+    if [ "$br" = "$branch" ]; then printf '%s\n' "$id"; break; fi
+  done | head -1
+}
+
+# CREW_BRANCH is empty at detached HEAD (a just-spawned crew, or a scout's
+# scratch worktree); with no branch there is no run to attribute to this crew.
+CREW_BRANCH=$(git -C "$WT" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
+
+HAVE_RUN=0
+# Scouts and secondmates never drive a no-mistakes validation of their own
+# worktree, so skip the lookup for them and read state from pane/log directly.
+if [ "$KIND" = ship ] && [ -n "$CREW_BRANCH" ] && command -v no-mistakes >/dev/null 2>&1; then
+  RUN_OUT=$(nm_run axi status)
+  run_branch=$(strip_quotes "$(nm_field branch)")
+  if [ -n "$run_branch" ] && [ "$run_branch" = "$CREW_BRANCH" ]; then
+    HAVE_RUN=1
+  else
+    # The active-or-most-recent run is for another branch; find this branch's
+    # own most recent run in the list, then inspect it directly.
+    list_out=$(nm_run axi)
+    rid=$(nm_run_id_for_branch "$CREW_BRANCH" "$list_out")
+    if [ -n "$rid" ]; then
+      RUN_OUT=$(nm_run axi status --run "$rid")
+      run_branch=$(strip_quotes "$(nm_field branch)")
+      [ "$run_branch" = "$CREW_BRANCH" ] && HAVE_RUN=1
+    fi
+  fi
+fi
+
+# --- run-step authoritative path -------------------------------------------
+
+if [ "$HAVE_RUN" = 1 ]; then
+  status=$(strip_quotes "$(nm_field status)")
+  outcome=$(strip_quotes "$(nm_field outcome)")
+  awaiting=$(printf '%s\n' "$RUN_OUT" | grep -E '^[[:space:]]*awaiting_agent:' | head -1 || true)
+
+  RUN_STATE=working
+  RUN_DETAIL=""
+  if [ -n "$outcome" ]; then
+    case "$outcome" in
+      passed)        RUN_STATE="done"; RUN_DETAIL="run passed: PR merged/closed" ;;
+      checks-passed) RUN_STATE="done"; RUN_DETAIL="checks green: PR ready for review" ;;
+      failed)        RUN_STATE=failed; RUN_DETAIL="run failed" ;;
+      cancelled)     RUN_STATE=failed; RUN_DETAIL="run cancelled" ;;
+      *)             RUN_STATE=unknown; RUN_DETAIL="outcome: $outcome" ;;
+    esac
+  elif [ -n "$awaiting" ] || [ "$status" = awaiting_approval ] || [ "$status" = fix_review ]; then
+    gate=$(strip_quotes "$(nm_field gate)")
+    [ -n "$gate" ] || gate=$status
+    [ -n "$gate" ] || gate=gate
+    RUN_STATE=parked
+    RUN_DETAIL="parked at $gate"
+    fcount=$(nm_findings_count)
+    [ -n "$fcount" ] && RUN_DETAIL="$RUN_DETAIL: $fcount finding(s)"
+    if printf '%s\n' "$RUN_OUT" | grep -q 'ask-user'; then
+      RUN_DETAIL="$RUN_DETAIL (ask-user: captain decision)"
+    fi
+  else
+    case "$status" in
+      ci)             RUN_STATE=working; RUN_DETAIL="ci running" ;;
+      running|fixing) RUN_STATE=working; RUN_DETAIL="validating ($status)" ;;
+      completed)      RUN_STATE="done"; RUN_DETAIL="run completed" ;;
+      failed)         RUN_STATE=failed;  RUN_DETAIL="run failed" ;;
+      cancelled)      RUN_STATE=failed;  RUN_DETAIL="run cancelled" ;;
+      "")             RUN_STATE=working; RUN_DETAIL="run active" ;;
+      *)              RUN_STATE=working; RUN_DETAIL="run active ($status)" ;;
+    esac
+  fi
+
+  # Reconcile the status log. A needs-decision/blocked log line that the run-step
+  # has moved past (anything but a genuinely parked run) is deterministically
+  # stale: the gate resolved and the run resumed or finished.
+  case "$LOG_VERB" in
+    needs-decision|blocked)
+      if [ "$RUN_STATE" != parked ]; then
+        if [ "$RUN_STATE" = working ]; then
+          RUN_DETAIL="$RUN_DETAIL${SEP}status-log superseded by active run"
+        else
+          RUN_DETAIL="$RUN_DETAIL${SEP}status-log superseded (run $RUN_STATE)"
+        fi
+      fi
+      ;;
+  esac
+
+  emit "$RUN_STATE" run-step "$RUN_DETAIL"
+fi
+
+# --- fallback: pane busy-signature + status log ----------------------------
+
+# Secondmates idle on their own watcher (idle pane = healthy), so pane-busy is
+# not a meaningful signal for them; read their state from the status log only.
+if [ "$KIND" != secondmate ] && [ -n "$WIN" ] && fm_pane_is_busy "$WIN"; then
+  emit working pane "harness busy"
+fi
+
+if [ -n "$LOG_VERB" ]; then
+  emit "$(map_log_state "$LOG_VERB")" status-log "$(log_note_of "$LOG_LINE")"
+fi
+
+emit unknown none "no current-state source available"

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -119,6 +119,12 @@ pane_readable "$WIN" || emit unknown none "window gone: $WIN"
 
 # --- no-mistakes run lookup (authoritative when a run matches this branch) --
 
+trim() {
+  local s=${1:-}
+  s="${s#"${s%%[![:space:]]*}"}"
+  s="${s%"${s##*[![:space:]]}"}"
+  printf '%s' "$s"
+}
 strip_quotes() { local s=${1:-}; s=${s#\"}; s=${s%\"}; printf '%s' "$s"; }
 
 # Bounded no-mistakes call in the worktree; stdout only, never fails the script.
@@ -144,6 +150,57 @@ nm_field() {  # <key>
 # Finding count from a findings[N]{...} table header; empty when none.
 nm_findings_count() {
   printf '%s\n' "$RUN_OUT" | grep -oE 'findings\[[0-9]+\]' | head -1 | grep -oE '[0-9]+'
+}
+nm_gate_step_row() {
+  local row step rest status findings
+  row=$(printf '%s\n' "$RUN_OUT" | grep -E '^[[:space:]]*[^,]+,[[:space:]]*"?(awaiting_approval|fix_review)"?[[:space:]]*,' | head -1)
+  [ -n "$row" ] || return 0
+  row=$(trim "$row")
+  step=$(trim "${row%%,*}")
+  rest=${row#*,}
+  status=$(strip_quotes "$(trim "${rest%%,*}")")
+  rest=${rest#*,}
+  findings=$(trim "${rest%%,*}")
+  printf '%s|%s|%s' "$step" "$status" "$findings"
+}
+nm_gate_status() {
+  local s row
+  s=$(printf '%s\n' "$RUN_OUT" | grep -E '^[[:space:]]*(status|state):[[:space:]]*"?(awaiting_approval|fix_review)"?[[:space:]]*$' | head -1)
+  if [ -n "$s" ]; then
+    s=$(strip_quotes "$(trim "${s#*:}")")
+    printf '%s' "$s"
+    return
+  fi
+  row=$(nm_gate_step_row)
+  [ -n "$row" ] && { row=${row#*|}; printf '%s' "${row%%|*}"; }
+}
+nm_gate_name() {
+  local gate row step
+  gate=$(strip_quotes "$(nm_field gate)")
+  [ -n "$gate" ] && { printf '%s' "$gate"; return; }
+  step=$(strip_quotes "$(printf '%s\n' "$RUN_OUT" | sed -n 's/^[[:space:]]*step:[[:space:]]*\(.*\)/\1/p' | head -1)")
+  [ -n "$step" ] && { printf '%s' "$step"; return; }
+  row=$(nm_gate_step_row)
+  [ -n "$row" ] && printf '%s' "${row%%|*}"
+}
+nm_gate_findings_count() {
+  local f row rest
+  f=$(nm_findings_count)
+  [ -n "$f" ] && { printf '%s' "$f"; return; }
+  row=$(nm_gate_step_row)
+  [ -n "$row" ] || return 0
+  rest=${row#*|}
+  rest=${rest#*|}
+  rest=${rest%%|*}
+  case "$rest" in ''|*[!0-9]*) return 0 ;; esac
+  printf '%s' "$rest"
+}
+log_reports_ci_ready() {
+  [ "$LOG_VERB" = "done" ] || return 1
+  case "$(log_note_of "$LOG_LINE")" in
+    *PR*"checks green"*|*"checks green"*PR*) return 0 ;;
+    *) return 1 ;;
+  esac
 }
 # Most recent run id whose branch matches, from the `no-mistakes axi` run list.
 nm_run_id_for_branch() {  # <branch> <list-output>
@@ -188,6 +245,7 @@ if [ "$HAVE_RUN" = 1 ]; then
   status=$(strip_quotes "$(nm_field status)")
   outcome=$(strip_quotes "$(nm_field outcome)")
   awaiting=$(printf '%s\n' "$RUN_OUT" | grep -E '^[[:space:]]*awaiting_agent:' | head -1 || true)
+  gate_status=$(nm_gate_status)
 
   RUN_STATE=working
   RUN_DETAIL=""
@@ -199,13 +257,14 @@ if [ "$HAVE_RUN" = 1 ]; then
       cancelled)     RUN_STATE=failed; RUN_DETAIL="run cancelled" ;;
       *)             RUN_STATE=unknown; RUN_DETAIL="outcome: $outcome" ;;
     esac
-  elif [ -n "$awaiting" ] || [ "$status" = awaiting_approval ] || [ "$status" = fix_review ]; then
-    gate=$(strip_quotes "$(nm_field gate)")
+  elif [ -n "$awaiting" ] || [ "$status" = awaiting_approval ] || [ "$status" = fix_review ] || [ -n "$gate_status" ]; then
+    gate=$(nm_gate_name)
     [ -n "$gate" ] || gate=$status
+    [ -n "$gate" ] || gate=$gate_status
     [ -n "$gate" ] || gate=gate
     RUN_STATE=parked
     RUN_DETAIL="parked at $gate"
-    fcount=$(nm_findings_count)
+    fcount=$(nm_gate_findings_count)
     [ -n "$fcount" ] && RUN_DETAIL="$RUN_DETAIL: $fcount finding(s)"
     if printf '%s\n' "$RUN_OUT" | grep -q 'ask-user'; then
       RUN_DETAIL="$RUN_DETAIL (ask-user: captain decision)"
@@ -220,6 +279,10 @@ if [ "$HAVE_RUN" = 1 ]; then
       "")             RUN_STATE=working; RUN_DETAIL="run active" ;;
       *)              RUN_STATE=working; RUN_DETAIL="run active ($status)" ;;
     esac
+  fi
+
+  if [ "$RUN_STATE" = working ] && log_reports_ci_ready; then
+    emit "done" status-log "$(log_note_of "$LOG_LINE")${SEP}run still monitoring PR"
   fi
 
   # Reconcile the status log. A needs-decision/blocked log line that the run-step

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -125,7 +125,14 @@ trim() {
   s="${s%"${s##*[![:space:]]}"}"
   printf '%s' "$s"
 }
-strip_quotes() { local s=${1:-}; s=${s#\"}; s=${s%\"}; printf '%s' "$s"; }
+strip_quotes() {
+  local s
+  s=$(trim "${1:-}")
+  case "$s" in
+    \"*\") s=${s#\"}; s=${s%\"} ;;
+  esac
+  trim "$s"
+}
 
 # Bounded no-mistakes call in the worktree; stdout only, never fails the script.
 HAVE_TIMEOUT=none
@@ -174,12 +181,21 @@ nm_gate_status() {
   row=$(nm_gate_step_row)
   [ -n "$row" ] && { row=${row#*|}; printf '%s' "${row%%|*}"; }
 }
-nm_gate_name() {
-  local gate row step
+nm_has_gate() {
+  printf '%s\n' "$RUN_OUT" | grep -Eq '^[[:space:]]*gate:[[:space:]]*'
+}
+nm_gate_line_name() {
+  local gate step
   gate=$(strip_quotes "$(nm_field gate)")
   [ -n "$gate" ] && { printf '%s' "$gate"; return; }
-  step=$(strip_quotes "$(printf '%s\n' "$RUN_OUT" | sed -n 's/^[[:space:]]*step:[[:space:]]*\(.*\)/\1/p' | head -1)")
-  [ -n "$step" ] && { printf '%s' "$step"; return; }
+  step=$(printf '%s\n' "$RUN_OUT" | sed -n '/^[[:space:]]*gate:[[:space:]]*$/,/^[^[:space:]][^:]*:/s/^[[:space:]]*step:[[:space:]]*\(.*\)/\1/p' | head -1)
+  step=$(strip_quotes "$step")
+  [ -n "$step" ] && printf '%s' "$step"
+}
+nm_gate_name() {
+  local gate row
+  gate=$(nm_gate_line_name)
+  [ -n "$gate" ] && { printf '%s' "$gate"; return; }
   row=$(nm_gate_step_row)
   [ -n "$row" ] && printf '%s' "${row%%|*}"
 }
@@ -204,14 +220,28 @@ log_reports_ci_ready() {
 }
 # Most recent run id whose branch matches, from the `no-mistakes axi` run list.
 nm_run_id_for_branch() {  # <branch> <list-output>
-  local branch=$1 list=$2 row id rest br
-  printf '%s\n' "$list" | grep -E '^[[:space:]]*"[^"]+",' | while IFS= read -r row; do
-    row=${row#"${row%%[![:space:]]*}"}
+  local branch=$1 list=$2 row id rest br in_runs=0 found=""
+  while IFS= read -r row; do
+    if [[ $(trim "$row") =~ ^runs\[[0-9]+\]\{.*\}:$ ]]; then
+      in_runs=1
+      continue
+    fi
+    [ "$in_runs" = 1 ] || continue
+    case "$row" in
+      '') continue ;;
+      [[:space:]]*) ;;
+      *) break ;;
+    esac
+    row=$(trim "$row")
+    case "$row" in
+      *,*) ;;
+      *) continue ;;
+    esac
     id=${row%%,*}; id=$(strip_quotes "$id")
     rest=${row#*,}
-    br=${rest%%,*}
+    br=${rest%%,*}; br=$(strip_quotes "$br")
     if [ "$br" = "$branch" ]; then printf '%s\n' "$id"; break; fi
-  done | head -1
+  done <<< "$list" | { IFS= read -r found || true; printf '%s' "$found"; }
 }
 
 # CREW_BRANCH is empty at detached HEAD (a just-spawned crew, or a scout's
@@ -246,6 +276,8 @@ if [ "$HAVE_RUN" = 1 ]; then
   outcome=$(strip_quotes "$(nm_field outcome)")
   awaiting=$(printf '%s\n' "$RUN_OUT" | grep -E '^[[:space:]]*awaiting_agent:' | head -1 || true)
   gate_status=$(nm_gate_status)
+  has_gate=0
+  nm_has_gate && has_gate=1
 
   RUN_STATE=working
   RUN_DETAIL=""
@@ -257,10 +289,13 @@ if [ "$HAVE_RUN" = 1 ]; then
       cancelled)     RUN_STATE=failed; RUN_DETAIL="run cancelled" ;;
       *)             RUN_STATE=unknown; RUN_DETAIL="outcome: $outcome" ;;
     esac
-  elif [ -n "$awaiting" ] || [ "$status" = awaiting_approval ] || [ "$status" = fix_review ] || [ -n "$gate_status" ]; then
-    gate=$(nm_gate_name)
+  elif [ -n "$awaiting" ] || [ "$status" = awaiting_approval ] || [ "$status" = fix_review ] || [ -n "$gate_status" ] || [ "$has_gate" = 1 ]; then
+    if [ "$has_gate" = 1 ]; then
+      gate=$(nm_gate_line_name)
+    else
+      gate=$(nm_gate_name)
+    fi
     [ -n "$gate" ] || gate=$status
-    [ -n "$gate" ] || gate=$gate_status
     [ -n "$gate" ] || gate=gate
     RUN_STATE=parked
     RUN_DETAIL="parked at $gate"

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# fm-crew-state.sh — deterministic read of a crew's CURRENT state.
+# fm-crew-state.sh - deterministic read of a crew's CURRENT state.
 #
 # Why this exists: state/<id>.status is an append-only, best-effort EVENT LOG.
 # Crews append only wake-worthy transitions (done/needs-decision/blocked/failed)
@@ -7,11 +7,11 @@
 # last EVENT, not the current STATE. After firstmate resolves a needs-decision
 # or blocked and the crew resumes (responds to the gate, the pipeline fixes, it
 # re-validates), the log's last line stays stale. This helper never infers the
-# current state from a tail of the log: it reads the authoritative source (an
-# active no-mistakes run-step, else the pane busy-signature) and reconciles the
-# possibly-stale log against it.
+# current state from a tail of the log: it reads the authoritative source (a
+# no-mistakes run-step attributed to this crew's branch, else the pane
+# busy-signature) and reconciles the possibly-stale log against it.
 #
-# The determinism lives entirely here — only run-step / pane / log reads plus
+# The determinism lives entirely here - only run-step / pane / log reads plus
 # fixed mapping logic, no heuristics and no LLM. Output is one stable, parseable,
 # token-tight line firstmate can read every heartbeat:
 #
@@ -19,17 +19,19 @@
 #
 # Logic, in order:
 #   1. Resolve worktree + window + kind from state/<id>.meta.
-#   2. Active no-mistakes run for this crew's branch? The run-step is
-#      AUTHORITATIVE: running/fixing -> working, ci -> working, awaiting_approval/
-#      fix_review -> parked (with gate findings), terminal passed/checks-passed ->
-#      done, failed/cancelled -> failed.
+#   2. Matching no-mistakes run for this crew's branch, active or terminal?
+#      The run-step is AUTHORITATIVE: running/fixing -> working, ci -> working,
+#      awaiting_approval/fix_review -> parked (with gate findings), terminal
+#      passed/checks-passed -> done, failed/cancelled -> failed.
 #   3. Reconcile the status log: if its last line says needs-decision/blocked but
 #      the run-step shows the run moved on, the log is deterministically stale and
 #      is flagged superseded. A genuinely parked run plus a needs-decision log
 #      agree, and are reported as parked.
 #   4. No run for this crew (pre-validation, or kind=scout): fall back to the
 #      pane busy-signature (fm-tmux-lib.sh) + the status log's last line.
-#   5. Missing meta / torn-down worktree / dead window: report unknown · none.
+#   5. Missing meta or torn-down worktree: report unknown · none. If no run is
+#      attributed to this crew, a dead window also reports unknown · none rather
+#      than trusting a stale status log.
 #
 # Read-only and side-effect free. Always exits 0 on a successful read regardless
 # of state; exit 2 only on a usage error (no id).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,7 +13,8 @@ Detected wakes are also written to a durable local queue (`state/.wake-queue`) b
 After each drain, `fm-wake-drain.sh` runs the same liveness guard as the supervision scripts, so a lapsed watcher chain surfaces even on a turn that only drains and handles queued wakes.
 Routine watcher polling, re-arm no-ops, elapsed waiting time, and unchanged heartbeat reviews stay silent; an idle crew costs you nothing.
 Crew status files are append-only wake-event logs, not current-state fields.
-`bin/fm-crew-state.sh <id>` is the cheap current-state read for heartbeat review: it attributes an active no-mistakes run to the crew's own branch, falls back to the pane busy-signature and then the status log, and flags stale `needs-decision` or `blocked` events once the run has resumed or finished.
+`bin/fm-crew-state.sh <id>` is the cheap current-state read for heartbeat review: it attributes the matching no-mistakes run, active or terminal, to the crew's own branch and keeps that run-step authoritative even if the pane has closed.
+Only when no matching run exists does it fall back to the pane busy-signature and then the status log; a dead pane without a run reports unknown instead of trusting a stale log.
 
 Routine re-arms go through `bin/fm-watch-arm.sh`, which forks the watcher as a tracked child, verifies it is genuinely alive with a fresh liveness beacon, and prints exactly one honest status line (`started` / `healthy` / `FAILED`, the last exiting non-zero) - never a false `already running` off a dying process.
 Its `--restart` mode signals only the watcher recorded in the current home's `state/.watch.lock`, so restarting one home cannot kill sibling secondmate watchers.
@@ -95,7 +96,7 @@ The mechanics are owned by the `/updatefirstmate` skill and firstmate's operatin
 
 ## Restart-proof
 
-All state lives in tmux, status files, local markdown under `data/`, `data/secondmates.md`, and persistent secondmate homes.
+All state lives in tmux, no-mistakes run records, status event logs, local markdown under `data/`, `data/secondmates.md`, and persistent secondmate homes.
 Kill the first mate session anytime; the next one reconciles and carries on.
 
 ## Development notes

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,6 +12,8 @@ A zero-token bash watcher (`bin/fm-watch.sh`) sleeps on the fleet and wakes the 
 Detected wakes are also written to a durable local queue (`state/.wake-queue`) before detector state advances, so a missed one-shot process exit can be recovered by draining the queue.
 After each drain, `fm-wake-drain.sh` runs the same liveness guard as the supervision scripts, so a lapsed watcher chain surfaces even on a turn that only drains and handles queued wakes.
 Routine watcher polling, re-arm no-ops, elapsed waiting time, and unchanged heartbeat reviews stay silent; an idle crew costs you nothing.
+Crew status files are append-only wake-event logs, not current-state fields.
+`bin/fm-crew-state.sh <id>` is the cheap current-state read for heartbeat review: it attributes an active no-mistakes run to the crew's own branch, falls back to the pane busy-signature and then the status log, and flags stale `needs-decision` or `blocked` events once the run has resumed or finished.
 
 Routine re-arms go through `bin/fm-watch-arm.sh`, which forks the watcher as a tracked child, verifies it is genuinely alive with a fresh liveness beacon, and prints exactly one honest status line (`started` / `healthy` / `FAILED`, the last exiting non-zero) - never a false `already running` off a dying process.
 Its `--restart` mode signals only the watcher recorded in the current home's `state/.watch.lock`, so restarting one home cannot kill sibling secondmate watchers.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -67,6 +67,7 @@ FM_HEARTBEAT=600        # base seconds between fleet reviews; backs off exponent
 FM_HEARTBEAT_MAX=7200   # heartbeat backoff cap
 FM_CHECK_INTERVAL=300   # seconds between slow checks (merged-PR polls)
 FM_CHECK_TIMEOUT=30     # seconds allowed per slow check script
+FM_CREW_STATE_NM_TIMEOUT=10   # seconds allowed per no-mistakes query inside fm-crew-state.sh
 FM_LOCK_STALE_AFTER=2   # seconds before dead-pid lock records can be reclaimed; mid-acquire locks keep at least 2s grace
 FM_GUARD_GRACE=300      # seconds before guard warnings and arm health checks treat a watcher beacon as stale
 FM_ARM_CONFIRM_TIMEOUT=10   # seconds fm-watch-arm waits to confirm a fresh watcher before reporting FAILED

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -21,7 +21,7 @@ Each file also starts with a short header comment.
 | `fm-watch-arm.sh`        | Verified per-home watcher re-arm; reports `started`, `healthy`, or `FAILED`; `--restart` relaunches only this home's watcher |
 | `fm-watch.sh`            | Singleton-safe one-shot watcher; blocks until supervision work is due, queues it durably, then exits with one reason line |
 | `fm-supervise-daemon.sh` | Presence-gated sub-supervisor for walk-away (`/afk`) supervision: wraps `fm-watch.sh`, self-handles routine wakes in bash, and escalates only captain-relevant events as one verified, batched, single-line digest prefixed with a sentinel marker |
-| `fm-crew-state.sh`       | Print one stable current-state line for a crew by reconciling its matching no-mistakes run-step, pane busy-signature, and status-log fallback |
+| `fm-crew-state.sh`       | Print one stable current-state line for a crew by reconciling its matching no-mistakes run-step, even when the pane has closed, with pane and status-log fallback |
 | `fm-tangle-lib.sh`       | Shared default-branch resolution and primary-checkout tangle classification sourced by bootstrap and guard         |
 | `fm-ff-lib.sh`           | Shared guarded fast-forward helper for `/updatefirstmate` origin pulls and no-fetch local secondmate syncs         |
 | `fm-tasks-axi-lib.sh`    | Shared `tasks-axi` compatibility probe sourced by bootstrap and teardown                                            |

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -21,6 +21,7 @@ Each file also starts with a short header comment.
 | `fm-watch-arm.sh`        | Verified per-home watcher re-arm; reports `started`, `healthy`, or `FAILED`; `--restart` relaunches only this home's watcher |
 | `fm-watch.sh`            | Singleton-safe one-shot watcher; blocks until supervision work is due, queues it durably, then exits with one reason line |
 | `fm-supervise-daemon.sh` | Presence-gated sub-supervisor for walk-away (`/afk`) supervision: wraps `fm-watch.sh`, self-handles routine wakes in bash, and escalates only captain-relevant events as one verified, batched, single-line digest prefixed with a sentinel marker |
+| `fm-crew-state.sh`       | Print one stable current-state line for a crew by reconciling its matching no-mistakes run-step, pane busy-signature, and status-log fallback |
 | `fm-tangle-lib.sh`       | Shared default-branch resolution and primary-checkout tangle classification sourced by bootstrap and guard         |
 | `fm-ff-lib.sh`           | Shared guarded fast-forward helper for `/updatefirstmate` origin pulls and no-fetch local secondmate syncs         |
 | `fm-tasks-axi-lib.sh`    | Shared `tasks-axi` compatibility probe sourced by bootstrap and teardown                                            |

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -1,0 +1,404 @@
+#!/usr/bin/env bash
+# Behavior tests for bin/fm-crew-state.sh — the deterministic crew-current-state
+# helper.
+#
+# The status file (state/<id>.status) is a best-effort append-only EVENT LOG, so
+# `tail -1` of it reports the last event, not the current state. fm-crew-state
+# reads the AUTHORITATIVE source (an active no-mistakes run-step, else the pane
+# busy-signature) and reconciles the possibly-stale log against it. These cases
+# pin every branch of that logic, hermetically, over real throwaway git repos
+# with a fake `no-mistakes` (run-step source) and a fake `tmux` (pane source):
+#   (a) active run-step is authoritative                          -> run-step
+#   (b) needs-decision/blocked log + resumed run = SUPERSEDED     -> run-step
+#   (c) genuine parked run + needs-decision log = NOT superseded  -> run-step
+#   (d) terminal run-step (passed/failed) is authoritative        -> run-step
+#   (e) cross-branch attribution: this branch's own run found via list lookup
+#   (f) no run + busy pane                                        -> pane
+#   (g) no run + idle pane falls to the status-log verb           -> status-log
+#   (h) kind=scout skips the run lookup                           -> pane/status-log
+#   (i) torn-down worktree / missing meta                         -> unknown/none
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+CREW_STATE="$ROOT/bin/fm-crew-state.sh"
+TMP_ROOT=$(fm_test_tmproot fm-crew-state)
+fm_git_identity fmtest fmtest@example.invalid
+
+# A real git repo checked out on <branch>, so the helper's branch attribution
+# (git symbolic-ref) resolves like it would for a live crew worktree.
+make_repo_on_branch() {  # <dir> <branch>
+  local dir=$1 branch=$2
+  mkdir -p "$dir"
+  git -C "$dir" init -q
+  git -C "$dir" commit -q --allow-empty -m init
+  git -C "$dir" checkout -q -b "$branch"
+}
+
+# A fakebin with a fake `no-mistakes` (serves the env-driven run output) and a
+# fake `tmux` (serves a busy or idle pane). The fake no-mistakes mirrors the real
+# command surface the helper uses: `axi status`, `axi status --run <id>`, and a
+# bare `axi` (the run list). Each returns the matching FM_FAKE_AXI_* env text.
+make_fakebin() {  # <dir> -> echoes fakebin path
+  local dir=$1 fb="$1/fakebin"
+  mkdir -p "$fb"
+  cat > "$fb/no-mistakes" <<'SH'
+#!/usr/bin/env bash
+set -u
+[ "${1:-}" = axi ] || exit 0
+shift
+case "${1:-}" in
+  status)
+    shift
+    if [ "${1:-}" = --run ]; then printf '%s\n' "${FM_FAKE_AXI_STATUS_RUN:-}"
+    else printf '%s\n' "${FM_FAKE_AXI_STATUS:-}"; fi ;;
+  '') printf '%s\n' "${FM_FAKE_AXI_LIST:-}" ;;
+esac
+exit 0
+SH
+  cat > "$fb/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "${1:-}" in
+  capture-pane)
+    if [ "${FM_FAKE_BUSY:-0}" = 1 ]; then printf 'work in progress\nesc to interrupt\n'
+    else printf 'all quiet\n> \n'; fi ;;
+esac
+exit 0
+SH
+  chmod +x "$fb/no-mistakes" "$fb/tmux"
+  printf '%s\n' "$fb"
+}
+
+# Run the helper for one case dir. FM_FAKE_* env (run output, busy flag) are read
+# from the caller's environment by the fakes above.
+run_crew_state() {  # <case-dir> <id>
+  PATH="$1/fakebin:$PATH" FM_STATE_OVERRIDE="$1/state" "$CREW_STATE" "$2"
+}
+
+new_case() {  # <name> -> echoes case dir with an empty state/
+  local d="$TMP_ROOT/$1"
+  mkdir -p "$d/state"
+  printf '%s\n' "$d"
+}
+
+# Clear the fake-driver vars and (re-)mark them exported, so the per-test plain
+# assignments below stay exported into the fakes without an `export VAR=$(...)`
+# command-substitution assignment (SC2155).
+reset_fakes() {
+  FM_FAKE_AXI_STATUS=""
+  FM_FAKE_AXI_STATUS_RUN=""
+  FM_FAKE_AXI_LIST=""
+  FM_FAKE_BUSY=0
+  export FM_FAKE_AXI_STATUS FM_FAKE_AXI_STATUS_RUN FM_FAKE_AXI_LIST FM_FAKE_BUSY
+}
+
+# --- run-object fixtures (TOON, as `no-mistakes axi status` emits) -----------
+
+run_running() {  # <branch>
+  cat <<EOF
+run:
+  id: "01RUN"
+  branch: $1
+  status: running
+  head: "abc1234"
+  pr: ""
+  findings: none
+  steps[2]{step,status,findings,duration_ms}:
+    intent,completed,0,0
+    review,running,0,0
+EOF
+}
+
+run_fixing() {  # <branch>
+  cat <<EOF
+run:
+  id: "01RUN"
+  branch: $1
+  status: fixing
+  head: "abc1234"
+  pr: ""
+  findings: none
+EOF
+}
+
+run_parked() {  # <branch>
+  cat <<EOF
+run:
+  id: "01RUN"
+  branch: $1
+  status: awaiting_approval
+  awaiting_agent: parked 2m10s
+  head: "abc1234"
+  pr: ""
+  findings[2]{id,severity,file,line,action,description}:
+    r1,warning,a.go,,auto-fix,ignored error
+    r2,error,b.go,,ask-user,changes product behavior
+gate: review
+EOF
+}
+
+run_passed() {  # <branch>
+  cat <<EOF
+run:
+  id: "01RUN"
+  branch: $1
+  status: completed
+  head: "abc1234"
+  pr: "https://github.com/o/r/pull/1"
+  findings: none
+outcome: passed
+EOF
+}
+
+run_failed() {  # <branch>
+  cat <<EOF
+run:
+  id: "01RUN"
+  branch: $1
+  status: completed
+  head: "abc1234"
+  pr: ""
+  findings: none
+outcome: failed
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# (a) active run-step is authoritative
+test_active_run_is_authoritative() {
+  reset_fakes
+  local d; d=$(new_case active)
+  make_repo_on_branch "$d/wt" fm/feat-a
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-a.meta" "window=fm:fm-feat-a" "worktree=$d/wt" "kind=ship"
+  FM_FAKE_AXI_STATUS="$(run_running fm/feat-a)"
+  local out; out=$(run_crew_state "$d" feat-a)
+  assert_contains "$out" "state: working" "active run -> working"
+  assert_contains "$out" "source: run-step" "active run -> run-step source"
+  assert_contains "$out" "validating (running)" "active run reports the step"
+  pass "active run-step is authoritative"
+}
+
+# (b) needs-decision log + a resumed (running/fixing) run = SUPERSEDED
+test_stale_needs_decision_superseded() {
+  reset_fakes
+  local d; d=$(new_case superseded)
+  make_repo_on_branch "$d/wt" fm/feat-b
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-b.meta" "window=fm:fm-feat-b" "worktree=$d/wt" "kind=ship"
+  printf 'working: started\nneeds-decision: pick A or B\n' > "$d/state/feat-b.status"
+  FM_FAKE_AXI_STATUS="$(run_fixing fm/feat-b)"
+  local out; out=$(run_crew_state "$d" feat-b)
+  assert_contains "$out" "state: working" "resumed run -> working despite needs-decision log"
+  assert_contains "$out" "source: run-step" "resumed run -> run-step source"
+  assert_contains "$out" "superseded" "stale needs-decision log flagged superseded"
+  pass "stale needs-decision over active run is superseded"
+}
+
+# blocked log + a resumed run is also superseded
+test_stale_blocked_superseded() {
+  reset_fakes
+  local d; d=$(new_case superseded-blocked)
+  make_repo_on_branch "$d/wt" fm/feat-bb
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-bb.meta" "window=fm:fm-feat-bb" "worktree=$d/wt" "kind=ship"
+  printf 'blocked: waiting on review answer\n' > "$d/state/feat-bb.status"
+  FM_FAKE_AXI_STATUS="$(run_running fm/feat-bb)"
+  local out; out=$(run_crew_state "$d" feat-bb)
+  assert_contains "$out" "state: working" "resumed run -> working despite blocked log"
+  assert_contains "$out" "superseded" "stale blocked log flagged superseded"
+  pass "stale blocked over active run is superseded"
+}
+
+# (c) genuine parked run + needs-decision log AGREE -> parked, NOT superseded
+test_genuine_parked_not_superseded() {
+  reset_fakes
+  local d; d=$(new_case parked)
+  make_repo_on_branch "$d/wt" fm/feat-c
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-c.meta" "window=fm:fm-feat-c" "worktree=$d/wt" "kind=ship"
+  printf 'needs-decision: review gate\n' > "$d/state/feat-c.status"
+  FM_FAKE_AXI_STATUS="$(run_parked fm/feat-c)"
+  local out; out=$(run_crew_state "$d" feat-c)
+  assert_contains "$out" "state: parked" "genuine parked run -> parked"
+  assert_contains "$out" "source: run-step" "parked -> run-step source"
+  assert_contains "$out" "2 finding(s)" "parked includes gate finding count"
+  assert_contains "$out" "ask-user" "parked surfaces ask-user finding"
+  assert_not_contains "$out" "superseded" "agreeing parked+needs-decision not flagged stale"
+  pass "genuine parked run is not flagged superseded"
+}
+
+# (d) terminal run-step is authoritative
+test_terminal_passed() {
+  reset_fakes
+  local d; d=$(new_case passed)
+  make_repo_on_branch "$d/wt" fm/feat-d
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-d.meta" "window=fm:fm-feat-d" "worktree=$d/wt" "kind=ship"
+  FM_FAKE_AXI_STATUS="$(run_passed fm/feat-d)"
+  local out; out=$(run_crew_state "$d" feat-d)
+  assert_contains "$out" "state: done" "passed run -> done"
+  assert_contains "$out" "source: run-step" "passed -> run-step source"
+  pass "terminal passed run is authoritative"
+}
+
+test_terminal_failed() {
+  reset_fakes
+  local d; d=$(new_case failed)
+  make_repo_on_branch "$d/wt" fm/feat-e
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-e.meta" "window=fm:fm-feat-e" "worktree=$d/wt" "kind=ship"
+  FM_FAKE_AXI_STATUS="$(run_failed fm/feat-e)"
+  local out; out=$(run_crew_state "$d" feat-e)
+  assert_contains "$out" "state: failed" "failed run -> failed"
+  assert_contains "$out" "source: run-step" "failed -> run-step source"
+  pass "terminal failed run is authoritative"
+}
+
+# (e) cross-branch attribution: `axi status` returns ANOTHER branch's run, so the
+# helper finds THIS branch's own run via the run list and inspects it directly.
+test_cross_branch_attribution_via_list() {
+  reset_fakes
+  local d; d=$(new_case crossbranch)
+  make_repo_on_branch "$d/wt" fm/feat-f
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-f.meta" "window=fm:fm-feat-f" "worktree=$d/wt" "kind=ship"
+  # The repo-wide active/most-recent run belongs to a different crew's branch.
+  FM_FAKE_AXI_STATUS="$(run_running fm/other-crew)"
+  FM_FAKE_AXI_LIST="$(cat <<EOF
+runs[2]{id,branch,status,head,pr}:
+  "01OTHER",fm/other-crew,running,aa,""
+  "01MINE",fm/feat-f,running,bb,""
+EOF
+)"
+  FM_FAKE_AXI_STATUS_RUN="$(run_running fm/feat-f)"
+  local out; out=$(run_crew_state "$d" feat-f)
+  assert_contains "$out" "state: working" "this branch's own run attributed via list"
+  assert_contains "$out" "source: run-step" "list-resolved run -> run-step source"
+  pass "cross-branch run is attributed via the run list"
+}
+
+# A different-branch run with NO matching list row must NOT be misattributed.
+test_other_branch_run_ignored() {
+  reset_fakes
+  local d; d=$(new_case otherbranch)
+  make_repo_on_branch "$d/wt" fm/feat-g
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-g.meta" "window=fm:fm-feat-g" "worktree=$d/wt" "kind=ship"
+  printf 'done: implemented, ready to validate\n' > "$d/state/feat-g.status"
+  FM_FAKE_AXI_STATUS="$(run_running fm/some-other)"
+  FM_FAKE_AXI_LIST="$(cat <<EOF
+runs[1]{id,branch,status,head,pr}:
+  "01OTHER",fm/some-other,running,aa,""
+EOF
+)"
+  FM_FAKE_BUSY=0
+  local out; out=$(run_crew_state "$d" feat-g)
+  assert_not_contains "$out" "source: run-step" "another branch's run not misattributed"
+  assert_contains "$out" "source: status-log" "no own run -> falls back to status-log"
+  assert_contains "$out" "state: done" "falls back to the log verb"
+  pass "another branch's run is ignored, falls back"
+}
+
+# (f) no run for this crew + a busy pane -> working via pane
+test_no_run_busy_pane() {
+  reset_fakes
+  local d; d=$(new_case busy)
+  make_repo_on_branch "$d/wt" fm/feat-h
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-h.meta" "window=fm:fm-feat-h" "worktree=$d/wt" "kind=ship"
+  # No matching run anywhere.
+  FM_FAKE_AXI_STATUS=""
+  FM_FAKE_AXI_LIST=""
+  FM_FAKE_BUSY=1
+  local out; out=$(run_crew_state "$d" feat-h)
+  assert_contains "$out" "state: working" "busy pane -> working"
+  assert_contains "$out" "source: pane" "busy pane -> pane source"
+  pass "no run + busy pane reads working from the pane"
+}
+
+# (g) no run + idle pane -> the status-log verb, as-is
+test_no_run_idle_pane_uses_log() {
+  reset_fakes
+  local d; d=$(new_case idle)
+  make_repo_on_branch "$d/wt" fm/feat-i
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-i.meta" "window=fm:fm-feat-i" "worktree=$d/wt" "kind=ship"
+  printf 'needs-decision: which database?\n' > "$d/state/feat-i.status"
+  FM_FAKE_AXI_STATUS=""
+  FM_FAKE_BUSY=0
+  local out; out=$(run_crew_state "$d" feat-i)
+  assert_contains "$out" "state: parked" "needs-decision log -> parked"
+  assert_contains "$out" "source: status-log" "idle pane -> status-log source"
+  pass "no run + idle pane uses the status-log verb"
+}
+
+# (h) kind=scout skips the run lookup entirely (its deliverable is a report).
+test_scout_skips_run_lookup() {
+  reset_fakes
+  local d; d=$(new_case scout)
+  make_repo_on_branch "$d/wt" fm/scout-j
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/scout-j.meta" "window=fm:fm-scout-j" "worktree=$d/wt" "kind=scout"
+  # Even if a run existed on this branch, a scout must not read it.
+  FM_FAKE_AXI_STATUS="$(run_running fm/scout-j)"
+  FM_FAKE_BUSY=1
+  local out; out=$(run_crew_state "$d" scout-j)
+  assert_not_contains "$out" "source: run-step" "scout ignores no-mistakes run-step"
+  assert_contains "$out" "source: pane" "scout reads pane busy-signature"
+  pass "scout skips the run lookup"
+}
+
+# (i) torn-down worktree and missing meta are graceful (unknown/none, exit 0)
+test_torn_down_worktree() {
+  reset_fakes
+  local d; d=$(new_case torndown)
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/gone-k.meta" "window=fm:fm-gone-k" "worktree=$d/no-such-worktree" "kind=ship"
+  local out rc
+  out=$(run_crew_state "$d" gone-k); rc=$?
+  expect_code 0 "$rc" "torn-down worktree exits 0"
+  assert_contains "$out" "state: unknown" "torn-down -> unknown"
+  assert_contains "$out" "source: none" "torn-down -> none source"
+  pass "torn-down worktree is handled gracefully"
+}
+
+test_missing_meta() {
+  reset_fakes
+  local d; d=$(new_case nometa)
+  make_fakebin "$d" >/dev/null
+  local out rc
+  out=$(run_crew_state "$d" ghost-z); rc=$?
+  expect_code 0 "$rc" "missing meta exits 0"
+  assert_contains "$out" "state: unknown" "missing meta -> unknown"
+  assert_contains "$out" "source: none" "missing meta -> none source"
+  pass "missing meta is handled gracefully"
+}
+
+# Usage error (no id) is the one non-zero exit.
+test_usage_error() {
+  reset_fakes
+  local rc
+  "$CREW_STATE" >/dev/null 2>&1; rc=$?
+  expect_code 2 "$rc" "no-arg usage error exits 2"
+  pass "usage error exits 2"
+}
+
+test_active_run_is_authoritative
+test_stale_needs_decision_superseded
+test_stale_blocked_superseded
+test_genuine_parked_not_superseded
+test_terminal_passed
+test_terminal_failed
+test_cross_branch_attribution_via_list
+test_other_branch_run_ignored
+test_no_run_busy_pane
+test_no_run_idle_pane_uses_log
+test_scout_skips_run_lookup
+test_torn_down_worktree
+test_missing_meta
+test_usage_error
+
+echo "all fm-crew-state tests passed"

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -156,6 +156,20 @@ gate: review
 EOF
 }
 
+run_parked_scalar_gate_running() {  # <branch>
+  cat <<EOF
+run:
+  id: "01RUN"
+  branch: $1
+  status: running
+  head: "abc1234"
+  pr: ""
+  findings[1]{id,severity,file,line,action,description}:
+    r1,error,b.go,,ask-user,changes product behavior
+gate: review
+EOF
+}
+
 run_parked_in_gate_block() {  # <branch>
   cat <<EOF
 run:
@@ -284,6 +298,23 @@ test_genuine_parked_not_superseded() {
   pass "genuine parked run is not flagged superseded"
 }
 
+test_scalar_gate_parked_not_superseded() {
+  reset_fakes
+  local d; d=$(new_case parked-scalar-gate)
+  make_repo_on_branch "$d/wt" fm/feat-cs
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-cs.meta" "window=fm:fm-feat-cs" "worktree=$d/wt" "kind=ship"
+  printf 'needs-decision: review gate\n' > "$d/state/feat-cs.status"
+  FM_FAKE_AXI_STATUS="$(run_parked_scalar_gate_running fm/feat-cs)"
+  local out; out=$(run_crew_state "$d" feat-cs)
+  assert_contains "$out" "state: parked" "scalar gate wait -> parked"
+  assert_contains "$out" "source: run-step" "scalar gate wait -> run-step source"
+  assert_contains "$out" "parked at review" "scalar gate wait names the gate"
+  assert_contains "$out" "1 finding(s)" "scalar gate wait includes finding count"
+  assert_not_contains "$out" "superseded" "scalar gate wait not flagged stale"
+  pass "scalar gate parked run is not flagged superseded"
+}
+
 test_gate_block_parked_not_superseded() {
   reset_fakes
   local d; d=$(new_case parked-gate-block)
@@ -365,6 +396,26 @@ EOF
   assert_contains "$out" "state: working" "this branch's own run attributed via list"
   assert_contains "$out" "source: run-step" "list-resolved run -> run-step source"
   pass "cross-branch run is attributed via the run list"
+}
+
+test_cross_branch_attribution_unquoted_run_list() {
+  reset_fakes
+  local d; d=$(new_case crossbranch-unquoted)
+  make_repo_on_branch "$d/wt" fm/feat-fq
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-fq.meta" "window=fm:fm-feat-fq" "worktree=$d/wt" "kind=ship"
+  FM_FAKE_AXI_STATUS="$(run_running fm/other-crew)"
+  FM_FAKE_AXI_LIST="$(cat <<EOF
+runs[2]{id,branch,status,head,pr}:
+  01OTHER, "fm/other-crew" ,running,aa,""
+  01MINE, "fm/feat-fq" ,running,bb,""
+EOF
+)"
+  FM_FAKE_AXI_STATUS_RUN="$(run_running fm/feat-fq)"
+  local out; out=$(run_crew_state "$d" feat-fq)
+  assert_contains "$out" "state: working" "unquoted run id attributed via list"
+  assert_contains "$out" "source: run-step" "unquoted list-resolved run -> run-step source"
+  pass "unquoted run-list row is attributed"
 }
 
 # A different-branch run with NO matching list row must NOT be misattributed.
@@ -532,11 +583,13 @@ test_active_run_is_authoritative
 test_stale_needs_decision_superseded
 test_stale_blocked_superseded
 test_genuine_parked_not_superseded
+test_scalar_gate_parked_not_superseded
 test_gate_block_parked_not_superseded
 test_ci_ready_done_log_beats_monitoring_run
 test_terminal_passed
 test_terminal_failed
 test_cross_branch_attribution_via_list
+test_cross_branch_attribution_unquoted_run_list
 test_other_branch_run_ignored
 test_no_run_busy_pane
 test_no_run_idle_pane_uses_log

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -15,7 +15,7 @@
 #   (e) cross-branch attribution: this branch's own run found via list lookup
 #   (f) no run + busy pane                                        -> pane
 #   (g) no run + idle pane falls to the status-log verb           -> status-log
-#   (h) dead pane ignores stale status log                         -> unknown/none
+#   (h) dead pane: no run -> unknown/none; with a run -> run-step (not the shell)
 #   (i) kind=scout skips the run lookup                           -> pane/status-log
 #   (j) torn-down worktree / missing meta                         -> unknown/none
 set -u
@@ -490,19 +490,41 @@ test_dead_window_ignores_stale_status_log() {
   pass "dead window ignores stale status log"
 }
 
-test_dead_window_ignores_matching_run() {
+# A closed/unreadable pane must NOT mask an authoritative run-step: judge by the
+# run-step, not the shell. The common case is a finished crew whose agent has
+# exited and closed its window (the normal gap between completion and teardown) -
+# it must still report its terminal run-step state (e.g. done), never unknown.
+test_dead_window_still_reports_terminal_run_step() {
   reset_fakes
-  local d; d=$(new_case dead-window-run)
-  make_repo_on_branch "$d/wt" fm/feat-dead-run
+  local d; d=$(new_case dead-window-done)
+  make_repo_on_branch "$d/wt" fm/feat-dead-done
   make_fakebin "$d" >/dev/null
-  fm_write_meta "$d/state/feat-dead-run.meta" "window=fm:fm-feat-dead-run" "worktree=$d/wt" "kind=ship"
-  FM_FAKE_AXI_STATUS="$(run_running fm/feat-dead-run)"
+  fm_write_meta "$d/state/feat-dead-done.meta" "window=fm:fm-feat-dead-done" "worktree=$d/wt" "kind=ship"
+  printf 'done: PR https://github.com/o/r/pull/3 checks green\n' > "$d/state/feat-dead-done.status"
+  FM_FAKE_AXI_STATUS="$(run_passed fm/feat-dead-done)"
+  FM_FAKE_TMUX_MISSING=1   # the crew's window has closed
+  local out; out=$(run_crew_state "$d" feat-dead-done)
+  assert_contains "$out" "state: done" "closed pane still reports terminal run-step done"
+  assert_contains "$out" "source: run-step" "closed pane does not mask the run-step"
+  assert_not_contains "$out" "state: unknown" "closed pane with a run must never be unknown"
+  pass "closed pane still reports a terminal run-step"
+}
+
+# The same for an active run: an agent pane that crashed mid-validation while the
+# daemon-backed run continues must report the live run-step, not unknown.
+test_dead_window_still_reports_active_run_step() {
+  reset_fakes
+  local d; d=$(new_case dead-window-active)
+  make_repo_on_branch "$d/wt" fm/feat-dead-act
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-dead-act.meta" "window=fm:fm-feat-dead-act" "worktree=$d/wt" "kind=ship"
+  FM_FAKE_AXI_STATUS="$(run_running fm/feat-dead-act)"
   FM_FAKE_TMUX_MISSING=1
-  local out; out=$(run_crew_state "$d" feat-dead-run)
-  assert_contains "$out" "state: unknown" "dead window with matching run -> unknown"
-  assert_contains "$out" "source: none" "dead window with matching run -> none source"
-  assert_not_contains "$out" "source: run-step" "dead window does not use run-step"
-  pass "dead window ignores matching run"
+  local out; out=$(run_crew_state "$d" feat-dead-act)
+  assert_contains "$out" "state: working" "closed pane still reports active run-step"
+  assert_contains "$out" "source: run-step" "closed pane does not mask the active run-step"
+  assert_not_contains "$out" "state: unknown" "closed pane with an active run must never be unknown"
+  pass "closed pane still reports an active run-step"
 }
 
 test_no_timeout_uses_perl_bound() {
@@ -594,7 +616,8 @@ test_other_branch_run_ignored
 test_no_run_busy_pane
 test_no_run_idle_pane_uses_log
 test_dead_window_ignores_stale_status_log
-test_dead_window_ignores_matching_run
+test_dead_window_still_reports_terminal_run_step
+test_dead_window_still_reports_active_run_step
 test_no_timeout_uses_perl_bound
 test_scout_skips_run_lookup
 test_torn_down_worktree

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
-# Behavior tests for bin/fm-crew-state.sh — the deterministic crew-current-state
+# Behavior tests for bin/fm-crew-state.sh - the deterministic crew-current-state
 # helper.
 #
 # The status file (state/<id>.status) is a best-effort append-only EVENT LOG, so
 # `tail -1` of it reports the last event, not the current state. fm-crew-state
-# reads the AUTHORITATIVE source (an active no-mistakes run-step, else the pane
-# busy-signature) and reconciles the possibly-stale log against it. These cases
-# pin every branch of that logic, hermetically, over real throwaway git repos
-# with a fake `no-mistakes` (run-step source) and a fake `tmux` (pane source):
+# reads the AUTHORITATIVE source (a matching no-mistakes run-step, else the
+# pane busy-signature) and reconciles the possibly-stale log against it. These
+# cases pin every branch of that logic, hermetically, over real throwaway git
+# repos with a fake `no-mistakes` (run-step source) and a fake `tmux` (pane
+# source):
 #   (a) active run-step is authoritative                          -> run-step
 #   (b) needs-decision/blocked log + resumed run = SUPERSEDED     -> run-step
 #   (c) genuine parked run + needs-decision log = NOT superseded  -> run-step

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -76,6 +76,17 @@ SH
   printf '%s\n' "$fb"
 }
 
+make_no_timeout_toolbin() {  # <dir> -> echoes toolbin path
+  local dir=$1 tb="$1/notimeoutbin" tool real
+  mkdir -p "$tb"
+  for tool in bash git grep sed head cut tail dirname perl; do
+    real=$(command -v "$tool" || true)
+    [ -n "$real" ] || fail "missing tool for no-timeout path: $tool"
+    ln -s "$real" "$tb/$tool"
+  done
+  printf '%s\n' "$tb"
+}
+
 # Run the helper for one case dir. FM_FAKE_* env (run output, busy flag) are read
 # from the caller's environment by the fakes above.
 run_crew_state() {  # <case-dir> <id>
@@ -358,6 +369,44 @@ test_dead_window_ignores_stale_status_log() {
   pass "dead window ignores stale status log"
 }
 
+test_dead_window_ignores_matching_run() {
+  reset_fakes
+  local d; d=$(new_case dead-window-run)
+  make_repo_on_branch "$d/wt" fm/feat-dead-run
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-dead-run.meta" "window=fm:fm-feat-dead-run" "worktree=$d/wt" "kind=ship"
+  FM_FAKE_AXI_STATUS="$(run_running fm/feat-dead-run)"
+  FM_FAKE_TMUX_MISSING=1
+  local out; out=$(run_crew_state "$d" feat-dead-run)
+  assert_contains "$out" "state: unknown" "dead window with matching run -> unknown"
+  assert_contains "$out" "source: none" "dead window with matching run -> none source"
+  assert_not_contains "$out" "source: run-step" "dead window does not use run-step"
+  pass "dead window ignores matching run"
+}
+
+test_no_timeout_uses_perl_bound() {
+  reset_fakes
+  local d toolbin out start elapsed
+  d=$(new_case no-timeout)
+  make_repo_on_branch "$d/wt" fm/feat-timeout
+  make_fakebin "$d" >/dev/null
+  cat > "$d/fakebin/no-mistakes" <<'SH'
+#!/usr/bin/env bash
+while :; do :; done
+SH
+  chmod +x "$d/fakebin/no-mistakes"
+  toolbin=$(make_no_timeout_toolbin "$d")
+  fm_write_meta "$d/state/feat-timeout.meta" "window=fm:fm-feat-timeout" "worktree=$d/wt" "kind=ship"
+  FM_FAKE_BUSY=1
+  start=$SECONDS
+  out=$(PATH="$d/fakebin:$toolbin" FM_STATE_OVERRIDE="$d/state" FM_CREW_STATE_NM_TIMEOUT=1 "$CREW_STATE" feat-timeout)
+  elapsed=$((SECONDS - start))
+  assert_contains "$out" "state: working" "timed-out no-mistakes falls back to pane"
+  assert_contains "$out" "source: pane" "timed-out no-mistakes -> pane source"
+  [ "$elapsed" -lt 5 ] || fail "perl timeout did not bound no-mistakes calls (elapsed ${elapsed}s)"
+  pass "no timeout command uses perl bound"
+}
+
 # (i) kind=scout skips the run lookup entirely (its deliverable is a report).
 test_scout_skips_run_lookup() {
   reset_fakes
@@ -420,6 +469,8 @@ test_other_branch_run_ignored
 test_no_run_busy_pane
 test_no_run_idle_pane_uses_log
 test_dead_window_ignores_stale_status_log
+test_dead_window_ignores_matching_run
+test_no_timeout_uses_perl_bound
 test_scout_skips_run_lookup
 test_torn_down_worktree
 test_missing_meta

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -15,8 +15,9 @@
 #   (e) cross-branch attribution: this branch's own run found via list lookup
 #   (f) no run + busy pane                                        -> pane
 #   (g) no run + idle pane falls to the status-log verb           -> status-log
-#   (h) kind=scout skips the run lookup                           -> pane/status-log
-#   (i) torn-down worktree / missing meta                         -> unknown/none
+#   (h) dead pane ignores stale status log                         -> unknown/none
+#   (i) kind=scout skips the run lookup                           -> pane/status-log
+#   (j) torn-down worktree / missing meta                         -> unknown/none
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -61,7 +62,11 @@ SH
 #!/usr/bin/env bash
 set -u
 case "${1:-}" in
+  display-message)
+    [ "${FM_FAKE_TMUX_MISSING:-0}" = 1 ] && exit 1
+    printf '%%1\n' ;;
   capture-pane)
+    [ "${FM_FAKE_TMUX_MISSING:-0}" = 1 ] && exit 1
     if [ "${FM_FAKE_BUSY:-0}" = 1 ]; then printf 'work in progress\nesc to interrupt\n'
     else printf 'all quiet\n> \n'; fi ;;
 esac
@@ -91,7 +96,8 @@ reset_fakes() {
   FM_FAKE_AXI_STATUS_RUN=""
   FM_FAKE_AXI_LIST=""
   FM_FAKE_BUSY=0
-  export FM_FAKE_AXI_STATUS FM_FAKE_AXI_STATUS_RUN FM_FAKE_AXI_LIST FM_FAKE_BUSY
+  FM_FAKE_TMUX_MISSING=0
+  export FM_FAKE_AXI_STATUS FM_FAKE_AXI_STATUS_RUN FM_FAKE_AXI_LIST FM_FAKE_BUSY FM_FAKE_TMUX_MISSING
 }
 
 # --- run-object fixtures (TOON, as `no-mistakes axi status` emits) -----------
@@ -335,7 +341,24 @@ test_no_run_idle_pane_uses_log() {
   pass "no run + idle pane uses the status-log verb"
 }
 
-# (h) kind=scout skips the run lookup entirely (its deliverable is a report).
+test_dead_window_ignores_stale_status_log() {
+  reset_fakes
+  local d; d=$(new_case dead-window)
+  make_repo_on_branch "$d/wt" fm/feat-dead
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-dead.meta" "window=fm:fm-feat-dead" "worktree=$d/wt" "kind=ship"
+  printf 'done: old completion event\n' > "$d/state/feat-dead.status"
+  FM_FAKE_AXI_STATUS=""
+  FM_FAKE_AXI_LIST=""
+  FM_FAKE_TMUX_MISSING=1
+  local out; out=$(run_crew_state "$d" feat-dead)
+  assert_contains "$out" "state: unknown" "dead window -> unknown"
+  assert_contains "$out" "source: none" "dead window -> none source"
+  assert_not_contains "$out" "source: status-log" "dead window does not reuse stale log"
+  pass "dead window ignores stale status log"
+}
+
+# (i) kind=scout skips the run lookup entirely (its deliverable is a report).
 test_scout_skips_run_lookup() {
   reset_fakes
   local d; d=$(new_case scout)
@@ -351,7 +374,7 @@ test_scout_skips_run_lookup() {
   pass "scout skips the run lookup"
 }
 
-# (i) torn-down worktree and missing meta are graceful (unknown/none, exit 0)
+# (j) torn-down worktree and missing meta are graceful (unknown/none, exit 0)
 test_torn_down_worktree() {
   reset_fakes
   local d; d=$(new_case torndown)
@@ -396,6 +419,7 @@ test_cross_branch_attribution_via_list
 test_other_branch_run_ignored
 test_no_run_busy_pane
 test_no_run_idle_pane_uses_log
+test_dead_window_ignores_stale_status_log
 test_scout_skips_run_lookup
 test_torn_down_worktree
 test_missing_meta

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -156,6 +156,26 @@ gate: review
 EOF
 }
 
+run_parked_in_gate_block() {  # <branch>
+  cat <<EOF
+run:
+  id: "01RUN"
+  branch: $1
+  status: running
+  head: "abc1234"
+  pr: ""
+  findings[1]{id,severity,file,line,action,description}:
+    r1,error,b.go,,ask-user,changes product behavior
+gate:
+  step: review
+  status: fix_review
+steps[3]{step,status,findings,duration_ms}:
+  intent,completed,0,0
+  review,fix_review,1,0
+  test,pending,0,0
+EOF
+}
+
 run_passed() {  # <branch>
   cat <<EOF
 run:
@@ -179,6 +199,23 @@ run:
   pr: ""
   findings: none
 outcome: failed
+EOF
+}
+
+run_ci_monitoring() {  # <branch>
+  cat <<EOF
+run:
+  id: "01RUN"
+  branch: $1
+  status: running
+  head: "abc1234"
+  pr: "https://github.com/o/r/pull/2"
+  findings: none
+  steps[4]{step,status,findings,duration_ms}:
+    intent,completed,0,0
+    review,completed,0,0
+    push,completed,0,0
+    ci,running,0,0
 EOF
 }
 
@@ -245,6 +282,39 @@ test_genuine_parked_not_superseded() {
   assert_contains "$out" "ask-user" "parked surfaces ask-user finding"
   assert_not_contains "$out" "superseded" "agreeing parked+needs-decision not flagged stale"
   pass "genuine parked run is not flagged superseded"
+}
+
+test_gate_block_parked_not_superseded() {
+  reset_fakes
+  local d; d=$(new_case parked-gate-block)
+  make_repo_on_branch "$d/wt" fm/feat-cb
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-cb.meta" "window=fm:fm-feat-cb" "worktree=$d/wt" "kind=ship"
+  printf 'needs-decision: review gate\n' > "$d/state/feat-cb.status"
+  FM_FAKE_AXI_STATUS="$(run_parked_in_gate_block fm/feat-cb)"
+  local out; out=$(run_crew_state "$d" feat-cb)
+  assert_contains "$out" "state: parked" "gate block wait -> parked"
+  assert_contains "$out" "source: run-step" "gate block wait -> run-step source"
+  assert_contains "$out" "parked at review" "gate block wait names the gate"
+  assert_contains "$out" "1 finding(s)" "gate block wait includes finding count"
+  assert_not_contains "$out" "superseded" "gate block wait not flagged stale"
+  pass "gate block parked run is not flagged superseded"
+}
+
+test_ci_ready_done_log_beats_monitoring_run() {
+  reset_fakes
+  local d; d=$(new_case ci-ready)
+  make_repo_on_branch "$d/wt" fm/feat-ci
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-ci.meta" "window=fm:fm-feat-ci" "worktree=$d/wt" "kind=ship"
+  printf 'done: PR https://github.com/o/r/pull/2 checks green\n' > "$d/state/feat-ci.status"
+  FM_FAKE_AXI_STATUS="$(run_ci_monitoring fm/feat-ci)"
+  local out; out=$(run_crew_state "$d" feat-ci)
+  assert_contains "$out" "state: done" "ci-ready status log -> done"
+  assert_contains "$out" "source: status-log" "ci-ready state comes from the status log"
+  assert_contains "$out" "checks green" "ci-ready detail preserves the report"
+  assert_not_contains "$out" "state: working" "ci-ready is not hidden by monitoring run"
+  pass "ci-ready status log beats monitoring run"
 }
 
 # (d) terminal run-step is authoritative
@@ -462,6 +532,8 @@ test_active_run_is_authoritative
 test_stale_needs_decision_superseded
 test_stale_blocked_superseded
 test_genuine_parked_not_superseded
+test_gate_block_parked_not_superseded
+test_ci_ready_done_log_beats_monitoring_run
 test_terminal_passed
 test_terminal_failed
 test_cross_branch_attribution_via_list


### PR DESCRIPTION
## Intent

Build a deterministic crew-current-state helper for firstmate supervision, plus the AGENTS.md guidance to use it, and (this revalidation) a follow-up correctness fix.

Problem: firstmate's state/<id>.status is an append-only, best-effort, LLM-discretion wake-EVENT log - crews append only wake-worthy transitions (done/needs-decision/blocked/failed) and nothing when they silently resume. So after firstmate resolves a needs-decision/blocked and the crew resumes, tail -1 of the log stays stale, showing the last event not the current state. The determinism must live in the script + run-step, never in asking an LLM to remember.

What the change delivers: bin/fm-crew-state.sh <id> prints one stable, parseable, token-tight line: 'state: <working|parked|done|blocked|failed|unknown> · source: <run-step|pane|status-log|none> · <detail>'. Logic in order: (1) resolve worktree/window/kind from state/<id>.meta; (2) the active no-mistakes run-step is the source of truth, attributed to the crew's branch - because 'no-mistakes axi status' returns the repo-wide active-or-most-recent run which may be another crew's, match the run branch to the worktree branch and, on mismatch, fall back to the 'no-mistakes axi' run list to find this branch's own most recent run and inspect it via 'axi status --run <id>'; map running/fixing->working, ci->working, awaiting_approval/fix_review (and any gate: scalar/nested/step-row)->parked with gate finding count + ask-user flag, terminal passed/checks-passed->done, failed/cancelled->failed; (3) reconcile the status log - a needs-decision/blocked last line is flagged 'superseded' when the run-step has moved past it, while a genuinely parked run + needs-decision log agree and report parked with no false flag; (4) no run for this crew (pre-validation, kind=scout) falls back to the pane busy-signature then the status-log verb; (5) missing meta / torn-down worktree report 'state: unknown · source: none', always exit 0.

KEY FOLLOW-UP FIX in this revalidation (captain-directed): the pane-readability guard was moved OUT of an early global position and INTO the no-run fallback path, so it runs only AFTER the run-step lookup. The earlier placement made a finished crew whose agent had exited and closed its window report 'unknown' instead of its authoritative run-step state (e.g. 'done') - the normal gap between a crew completing and teardown, and a regression against the helper's core principle of judging by the run-step, not the shell. Now a crew with a run reports its run-step state regardless of pane liveness, while a genuinely runless dead window still reports unknown rather than trusting a stale log. Added two regression tests pinning this: a closed pane with a terminal run reports done, and a closed pane with an active run reports working; replaced the prior test that had encoded the regression.

Deliberate design decisions: pure bash matching repo style and the header-comment convention; reuses fm-tmux-lib.sh busy detection and meta parsing rather than duplicating; fully deterministic (only run-step/pane/log reads + fixed mapping, no heuristics, no LLM); bounded no-mistakes calls via timeout/gtimeout/perl for heartbeat-frequency safety; kind=scout skips the run lookup (its deliverable is a report) and kind=secondmate reads from the status log only (an idle secondmate pane is healthy). Robust TOON parsing: gate detection handles scalar 'gate: <step>', nested gate blocks, and gate step-table rows; the run-list lookup tolerates quoted and unquoted columns and is scoped to the runs[] table. Read-only and side-effect free; only non-zero exit is exit 2 on a usage error.

Also wired AGENTS.md sections 7 (Validate) and 8 (wake-handling order, heartbeat step, token discipline) to read current crew state via bin/fm-crew-state.sh <id> and to stop inferring state from a tail of the status log, while keeping the status file as the wake-event log; this operationalizes the existing 'judge a validating crewmate by the run-step, never its shell' guidance. The watcher core, status-file contract, brief/status-reporting contract, and wake/dedup machinery are intentionally unchanged - a read-side helper plus a guidance edit only. tests/fm-crew-state.test.sh has 22 hermetic cases over real throwaway git repos with a fake no-mistakes and fake tmux; catalogued in CONTRIBUTING.md. shellcheck clean and all tests pass.

## What Changed

- Added `bin/fm-crew-state.sh`, a deterministic current-state helper that resolves crew meta, checks branch-scoped no-mistakes run state before pane/status fallbacks, and always emits one stable parseable line.
- Hardened supervision guidance in `AGENTS.md` and docs so firstmate reads current crew state through the helper instead of inferring it from the append-only status wake log.
- Added hermetic coverage for run-step parsing, gate handling, scout/secondmate fallbacks, missing metadata, and closed-pane cases where authoritative run state must still win, captain.

## Risk Assessment

✅ Low: Captain, the change is well-bounded to a read-only helper plus guidance and focused coverage, with no material correctness issues found in the reviewed diff.

## Testing

Baseline inspection matched the intended helper and regression coverage; `tests/fm-crew-state.test.sh` passed and generated a focused transcript, an initial manual fixture setup mistake was retried with a corrected fixture, and the final manual CLI evidence directly showed run-step state winning over closed pane liveness while a runless closed pane returns unknown. `git status --short` was clean after testing.

<details>
<summary>Evidence: Focused fm-crew-state test transcript</summary>

<code>ok - closed pane still reports a terminal run-step&#10;ok - closed pane still reports an active run-step&#10;all fm-crew-state tests passed</code>

```text
ok - active run-step is authoritative
ok - stale needs-decision over active run is superseded
ok - stale blocked over active run is superseded
ok - genuine parked run is not flagged superseded
ok - scalar gate parked run is not flagged superseded
ok - gate block parked run is not flagged superseded
ok - ci-ready status log beats monitoring run
ok - terminal passed run is authoritative
ok - terminal failed run is authoritative
ok - cross-branch run is attributed via the run list
ok - unquoted run-list row is attributed
ok - another branch's run is ignored, falls back
ok - no run + busy pane reads working from the pane
ok - no run + idle pane uses the status-log verb
ok - dead window ignores stale status log
ok - closed pane still reports a terminal run-step
ok - closed pane still reports an active run-step
ok - no timeout command uses perl bound
ok - scout skips the run lookup
ok - torn-down worktree is handled gracefully
ok - missing meta is handled gracefully
ok - usage error exits 2
all fm-crew-state tests passed
```
</details>
<details>
<summary>Evidence: Manual CLI evidence transcript</summary>

<code>closed-pane-terminal-run&#10;state: done · source: run-step · run passed: PR merged/closed&#10;closed-pane-active-run&#10;state: working · source: run-step · validating (running)&#10;runless-closed-pane&#10;state: unknown · source: none · window gone: fm:fm-manual-runless</code>

```text
closed-pane-terminal-run
state: done · source: run-step · run passed: PR merged/closed
closed-pane-active-run
state: working · source: run-step · validating (running)
runless-closed-pane
state: unknown · source: none · window gone: fm:fm-manual-runless
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `pwd && git status --short --branch`
- <code>`git diff --stat 362fb54e02156f02d65f9f19d48269dbeb85ceb6..dfb64fff65c6398604acadd0ee7d3e63cf93ca66` and `git diff --name-only 362fb54e02156f02d65f9f19d48269dbeb85ceb6..dfb64fff65c6398604acadd0ee7d3e63cf93ca66`</code>
- <code>Read `bin/fm-crew-state.sh`, `tests/fm-crew-state.test.sh`, `tests/lib.sh`, `bin/fm-tmux-lib.sh`, and the changed docs references for intent alignment.</code>
- `bash -o pipefail -c 'bash tests/fm-crew-state.test.sh 2>&1 | tee /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KW3P4ZEQ9TTTZE1XKP8588PA/fm-crew-state-test.log'`
- <code>Corrected manual evidence fixture invoking `bin/fm-crew-state.sh` against throwaway git worktrees plus fake `no-mistakes` and fake missing `tmux` pane for closed-pane terminal run, closed-pane active run, and runless closed-pane scenarios; transcript saved to `/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KW3P4ZEQ9TTTZE1XKP8588PA/fm-crew-state-manual-cli.log`.</code>
- `git status --short`
- `find /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KW3P4ZEQ9TTTZE1XKP8588PA -maxdepth 1 -type f -print`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
