### PR TITLE
feat(bin): open local review files in tmux and wezterm surfaces

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,7 +135,7 @@ If it is absent, use this template's defaults with no special preferences.
 Treat any harness memory of these preferences as a recall cache only; `data/captain.md` is the canonical, harness-portable home.
 
 Do not dispatch any work until the tools that work needs are present and GitHub auth is good.
-Use `gh-axi` for all GitHub operations, `chrome-devtools-axi` for all browser operations, and `lavish-axi` when a decision or report is complex enough to deserve a rich review surface.
+Use `gh-axi` for all GitHub operations, `chrome-devtools-axi` for all browser operations, and `lavish-axi` when a decision, structured report, plan, comparison, or complex UI/design audit is easier to review as a rich surface than raw Markdown.
 Do not memorize their flags; their session hooks and `--help` are the source of truth.
 If the captain names a different crewmate harness at bootstrap or later, write it to `config/crew-harness` (local, gitignored); that is the whole switch.
 
@@ -430,7 +430,7 @@ With `--force`, teardown is the explicit discard path for child windows, child w
 A scout task follows Intake, Spawn, and Supervise exactly as above - scaffold the brief with `bin/fm-brief.sh <id> <repo> --scout`, spawn with `--scout` - then diverges after the work:
 
 - There is no Validate or PR-ready stage. When the crewmate's status says `done`, read `data/<id>/report.md`.
-- Relay the findings to the captain: plain chat for a focused answer, lavish-axi when the report has structure worth a visual (multiple findings, options, a plan).
+- Relay the findings to the captain: plain chat for a focused answer, `bin/fm-open-file.sh data/<id>/report.md` for a simple Markdown report the captain should inspect directly, and lavish-axi when the report has structure worth a visual (multiple findings, options, a plan, comparison, or complex UI/design audit).
 - Tear down immediately - no merge gate. `bin/fm-teardown.sh` allows a scout worktree's scratch commits and dirty files once the report exists; if the report is missing, it refuses, because the findings are the work product.
 - Record it in Done with the report path instead of a PR link using `tasks-axi done` when compatible tasks-axi is available, otherwise hand-edit `data/backlog.md` and keep Done to the 10 most recent, then re-evaluate the queue and dispatch only queued work whose blockers are gone and whose time/date gate, if any, has arrived.
 
@@ -563,6 +563,7 @@ Reaches the captain immediately:
 
 Does not reach the captain: auto-fixes, retries, routine progress, or firstmate's internal vocabulary and machinery.
 Batch non-urgent updates into your next natural reply.
+Do not leave a bare local path such as `data/<id>/report.md` or `.lavish/<name>.html` as the only way to access a captain-facing artifact. Open simple Markdown or text reports first with `bin/fm-open-file.sh data/<id>/report.md`, then tell the captain the tmux tab name the helper printed. For Lavish HTML artifacts, run `bin/fm-open-file.sh --lavish .lavish/<name>.html` or use `lavish-axi <html-file>` directly when a rich review surface is the right presentation.
 Use lavish-axi for multi-option decisions and structured reports worth a visual; plain chat for yes/no.
 Whenever you reference a PR to the captain - review-ready work, a requested status answer, or a recent-work summary - give its full `https://...` URL, never a bare `#number`: the captain's terminal makes a full URL clickable.
 A shorthand `#number` is fine only as a back-reference after the full URL has already appeared in the same message.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,6 +136,7 @@ Treat any harness memory of these preferences as a recall cache only; `data/capt
 
 Do not dispatch any work until the tools that work needs are present and GitHub auth is good.
 Use `gh-axi` for all GitHub operations, `chrome-devtools-axi` for all browser operations, and `lavish-axi` when a decision, structured report, plan, comparison, or complex UI/design audit is easier to review as a rich surface than raw Markdown.
+For local report artifacts, use `bin/fm-open-file.sh`: single Markdown/text files open in the terminal review surface, while multiple local review targets open in one WezTerm tab with clickable links.
 Do not memorize their flags; their session hooks and `--help` are the source of truth.
 If the captain names a different crewmate harness at bootstrap or later, write it to `config/crew-harness` (local, gitignored); that is the whole switch.
 
@@ -430,7 +431,7 @@ With `--force`, teardown is the explicit discard path for child windows, child w
 A scout task follows Intake, Spawn, and Supervise exactly as above - scaffold the brief with `bin/fm-brief.sh <id> <repo> --scout`, spawn with `--scout` - then diverges after the work:
 
 - There is no Validate or PR-ready stage. When the crewmate's status says `done`, read `data/<id>/report.md`.
-- Relay the findings to the captain: plain chat for a focused answer, `bin/fm-open-file.sh data/<id>/report.md` for a simple Markdown report the captain should inspect directly, and lavish-axi when the report has structure worth a visual (multiple findings, options, a plan, comparison, or complex UI/design audit).
+- Relay the findings to the captain: plain chat for a focused answer, `bin/fm-open-file.sh data/<id>/report.md` for a simple Markdown report the captain should inspect directly, `bin/fm-open-file.sh <path> <path>...` when the review target is a set of local files that should appear as one clickable WezTerm tab, and lavish-axi when the report has structure worth a visual (multiple findings, options, a plan, comparison, or complex UI/design audit).
 - Tear down immediately - no merge gate. `bin/fm-teardown.sh` allows a scout worktree's scratch commits and dirty files once the report exists; if the report is missing, it refuses, because the findings are the work product.
 - Record it in Done with the report path instead of a PR link using `tasks-axi done` when compatible tasks-axi is available, otherwise hand-edit `data/backlog.md` and keep Done to the 10 most recent, then re-evaluate the queue and dispatch only queued work whose blockers are gone and whose time/date gate, if any, has arrived.
 
@@ -563,7 +564,7 @@ Reaches the captain immediately:
 
 Does not reach the captain: auto-fixes, retries, routine progress, or firstmate's internal vocabulary and machinery.
 Batch non-urgent updates into your next natural reply.
-Do not leave a bare local path such as `data/<id>/report.md` or `.lavish/<name>.html` as the only way to access a captain-facing artifact. Open simple Markdown or text reports first with `bin/fm-open-file.sh data/<id>/report.md`, then tell the captain the tmux tab name the helper printed. For Lavish HTML artifacts, run `bin/fm-open-file.sh --lavish .lavish/<name>.html` or use `lavish-axi <html-file>` directly when a rich review surface is the right presentation.
+Do not leave a bare local path such as `data/<id>/report.md` or `.lavish/<name>.html` as the only way to access a captain-facing artifact. Open simple Markdown or text reports first with `bin/fm-open-file.sh data/<id>/report.md`, then tell the captain the tab name the helper printed. When the captain needs several local review targets or clickable local links, pass all paths in one call, such as `bin/fm-open-file.sh data/<id>/report.md .lavish/<name>.html`, so the helper opens one WezTerm tab with clickable links instead of several tmux windows. For Lavish HTML artifacts, run `bin/fm-open-file.sh --lavish .lavish/<name>.html` or use `lavish-axi <html-file>` directly when a rich review surface is the right presentation. Use a tmux review tab only when the captain explicitly asks for one or when terminal text is the right surface.
 Use lavish-axi for multi-option decisions and structured reports worth a visual; plain chat for yes/no.
 Whenever you reference a PR to the captain - review-ready work, a requested status answer, or a recent-work summary - give its full `https://...` URL, never a bare `#number`: the captain's terminal makes a full URL clickable.
 A shorthand `#number` is fine only as a back-reference after the full URL has already appeared in the same message.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,7 @@ tests/fm-secondmate-lifecycle-e2e.test.sh # persistent secondmate routing, seedi
 tests/fm-secondmate-safety.test.sh        # secondmate home safety, idle charter, handoff validation, and teardown boundary tests
 tests/fm-teardown.test.sh                 # fm-teardown.sh landed-work safety and reminder checks: fork-remote allow, squash/content landings, dirty and unlanded refusals, PR-head metadata, tasks-axi reminder, --force override
 tests/fm-crew-state.test.sh               # fm-crew-state.sh current-state reconciliation: run-step authority including closed panes, stale needs-decision/blocked superseded by a resumed run, genuine-parked, cross-branch attribution, pane/status-log fallback, scout skip, torn-down/missing-meta graceful
+tests/fm-open-file.test.sh                # fm-open-file.sh review-surface contract: single Markdown report in a detached tmux tab with collision-safe naming and focus restore, multiple paths in one WezTerm tab with a file:// link per target, no content leak, and rejection of missing/directory/out-of-home/bare/--lavish-misuse inputs
 [ "$(readlink CLAUDE.md)" = "AGENTS.md" ]
 [ "$(readlink .claude/skills)" = "../.agents/skills" ]
 FM_HEARTBEAT=2 FM_POLL=1 bin/fm-watch-arm.sh  # watcher re-arm smoke test (prints arm status, then "heartbeat")

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Outside tmux, crewmates land in a detached `firstmate` session you can attach to
 ```
 
 You chat with the first mate.
-It routes each request to a crewmate in its own tmux window and git worktree, supervises the fleet with a zero-token event-driven watcher, and brings you finished PRs, approved local merges, or investigation reports.
+It routes each request to a crewmate in its own tmux window and git worktree, supervises the fleet with a zero-token event-driven watcher, and brings you finished PRs, approved local merges, or investigation reports. Local reports can be opened with `bin/fm-open-file.sh data/<id>/report.md`; multiple local review targets open together in a WezTerm tab with clickable links.
 Persistent secondmate homes are linked firstmate worktrees; startup syncs live ones and secondmate launch syncs the target home to the primary default-branch commit without fetching from origin when it is safe.
 When a routed request goes to a secondmate, firstmate marks it so the answer returns through status or a document pointer; direct typing into that secondmate window stays conversational.
 A presence-gated sub-supervisor (`/afk`) can self-handle routine events and batch only what matters while you step away.

--- a/bin/fm-open-file.sh
+++ b/bin/fm-open-file.sh
@@ -230,6 +230,7 @@ if [ "$path_count" -gt 1 ]; then
   [ -n "$list_base" ] || list_base=links
   name=$(unique_wezterm_name "$list_base")
   list_file=$(mktemp "${TMPDIR:-/tmp}/firstmate-review-links.XXXXXX") || { echo "error: could not create temporary link list" >&2; exit 1; }
+  trap 'rm -f "$list_file"' EXIT
   {
     printf 'Firstmate review links\n\n'
     idx=1
@@ -244,6 +245,7 @@ if [ "$path_count" -gt 1 ]; then
   qlist=$(quote "$list_file")
   cmd="trap 'rm -f $qlist' EXIT; cat $qlist; read _"
   spawn_wezterm_tab "$name" "$cmd"
+  trap - EXIT
   echo "opened: $path_count files in WezTerm tab $name"
   exit 0
 fi

--- a/bin/fm-open-file.sh
+++ b/bin/fm-open-file.sh
@@ -152,7 +152,7 @@ unique_tmux_name() {  # <session> <base>
     keep=$((28 - ${#suffix}))
     [ "$keep" -gt 0 ] || keep=24
     prefix=$(printf "%.*s" "$keep" "$base" | sed 's/[.-]*$//; s/-*$//')
-    [ -n "$prefix" ] || prefix=file
+    [ -n "$prefix" ] || prefix="file"
     name="$prefix$suffix"
     i=$((i + 1))
   done
@@ -181,7 +181,7 @@ unique_wezterm_name() {  # <base>
     keep=$((28 - ${#suffix}))
     [ "$keep" -gt 0 ] || keep=24
     prefix=$(printf "%.*s" "$keep" "$base" | sed 's/[.-]*$//; s/-*$//')
-    [ -n "$prefix" ] || prefix=file
+    [ -n "$prefix" ] || prefix="file"
     name="$prefix$suffix"
     i=$((i + 1))
   done
@@ -210,7 +210,7 @@ file_uri() {  # <absolute-path>
 }
 
 base=$(base_for_path "$FILE_REAL" "$rel_path")
-[ -n "$base" ] || base=file
+[ -n "$base" ] || base="file"
 qfile=$(quote "$FILE_REAL")
 
 if [ "$path_count" -gt 1 ]; then

--- a/bin/fm-open-file.sh
+++ b/bin/fm-open-file.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Open a local firstmate-home file in a detached tmux review window.
+# Usage: fm-open-file.sh [--allow-outside] [--lavish] <path>
+#
+# Defaults to files under this firstmate home only. Use --allow-outside only for
+# an explicitly chosen file outside the home. Directories are intentionally not
+# supported: the helper is for reports and concrete artifacts, not browsing.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+
+ALLOW_OUTSIDE=0
+LAVISH=0
+
+usage() {
+  echo "usage: $(basename "$0") [--allow-outside] [--lavish] <path>" >&2
+  exit 2
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --allow-outside) ALLOW_OUTSIDE=1; shift ;;
+    --lavish) LAVISH=1; shift ;;
+    -h|--help) usage ;;
+    --) shift; break ;;
+    -*) echo "error: unknown option: $1" >&2; usage ;;
+    *) break ;;
+  esac
+done
+
+[ "$#" -eq 1 ] || usage
+INPUT=$1
+
+abs_path() {  # <path> -> canonical absolute path; path must exist
+  perl -MCwd=abs_path -e '
+    my $p = shift;
+    my $abs = abs_path($p);
+    exit 1 unless defined $abs;
+    print $abs;
+  ' "$1"
+}
+
+HOME_REAL=$(abs_path "$FM_HOME") || { echo "error: firstmate home does not exist: $FM_HOME" >&2; exit 1; }
+case "$INPUT" in
+  /*) CANDIDATE=$INPUT ;;
+  *) CANDIDATE=$HOME_REAL/$INPUT ;;
+esac
+FILE_REAL=$(abs_path "$CANDIDATE") || { echo "error: missing path: $INPUT" >&2; exit 1; }
+
+if [ -d "$FILE_REAL" ]; then
+  echo "error: directories are not supported: $INPUT" >&2
+  exit 1
+fi
+[ -f "$FILE_REAL" ] || { echo "error: not a regular file: $INPUT" >&2; exit 1; }
+
+if [ "$ALLOW_OUTSIDE" -ne 1 ]; then
+  case "$FILE_REAL" in
+    "$HOME_REAL"/*) ;;
+    *) echo "error: path is outside firstmate home; pass --allow-outside only for an explicitly chosen safe file" >&2; exit 1 ;;
+  esac
+fi
+
+rel_path=$FILE_REAL
+case "$FILE_REAL" in
+  "$HOME_REAL"/*) rel_path=${FILE_REAL#"$HOME_REAL"/} ;;
+esac
+
+if [ "$LAVISH" -eq 1 ]; then
+  case "$FILE_REAL" in
+    *.html|*.htm) ;;
+    *) echo "error: --lavish expects an HTML file" >&2; exit 1 ;;
+  esac
+  command -v lavish-axi >/dev/null 2>&1 || { echo "error: lavish-axi not found on PATH" >&2; exit 1; }
+fi
+
+if [ -n "${TMUX:-}" ]; then
+  SES=$(tmux display-message -p '#S') || { echo "error: could not resolve current tmux session" >&2; exit 1; }
+  CURRENT_TARGET=$(tmux display-message -p '#S:#I' 2>/dev/null || true)
+else
+  tmux has-session -t firstmate 2>/dev/null || tmux new-session -d -s firstmate
+  SES=firstmate
+  CURRENT_TARGET=
+fi
+
+slug() {
+  printf '%s' "$1" \
+    | tr '[:upper:]' '[:lower:]' \
+    | tr -cs '[:alnum:]_.-' '-' \
+    | sed 's/^-*//; s/-*$//'
+}
+
+trim_slug() {
+  local s=$1
+  printf '%.28s' "$s" | sed 's/[.-]*$//; s/-*$//'
+}
+
+base_name=$(basename "$FILE_REAL")
+base_no_ext=${base_name%.*}
+case "$rel_path" in
+  data/*/report.md)
+    task_id=${rel_path#data/}
+    task_id=${task_id%%/*}
+    first_word=${task_id%%-*}
+    base="report-$(slug "$first_word")"
+    ;;
+  .lavish/*.html|.lavish/*.htm)
+    base="lavish-$(slug "$base_no_ext")"
+    ;;
+  *)
+    base="file-$(slug "$base_no_ext")"
+    ;;
+esac
+base=$(trim_slug "$base")
+[ -n "$base" ] || base=file
+
+name=$base
+i=2
+while tmux list-windows -t "$SES" -F '#{window_name}' | grep -Fxq "$name"; do
+  suffix="-$i"
+  keep=$((28 - ${#suffix}))
+  [ "$keep" -gt 0 ] || keep=24
+  prefix=$(printf "%.*s" "$keep" "$base" | sed 's/[.-]*$//; s/-*$//')
+  [ -n "$prefix" ] || prefix=file
+  name="$prefix$suffix"
+  i=$((i + 1))
+done
+
+quote() { printf '%q' "$1"; }
+qfile=$(quote "$FILE_REAL")
+
+case "$base_name" in
+  *.md|*.markdown|*.mdown) is_markdown=1 ;;
+  *) is_markdown=0 ;;
+esac
+
+if [ "$LAVISH" -eq 1 ]; then
+  cmd="lavish-axi $qfile; status=\$?; printf '\\nlavish-axi exited with status %s. Press Enter to close this window.' \"\$status\"; read _"
+elif [ "$is_markdown" -eq 1 ]; then
+  cmd="if command -v glow >/dev/null 2>&1; then exec glow -p $qfile; elif command -v bat >/dev/null 2>&1; then exec bat --paging=always --style=plain -- $qfile; else exec less -R -- $qfile; fi"
+else
+  cmd="if command -v bat >/dev/null 2>&1; then exec bat --paging=always --style=plain -- $qfile; else exec less -R -- $qfile; fi"
+fi
+
+tmux new-window -d -t "$SES" -n "$name" -c "$HOME_REAL" "$BASH" -lc "$cmd"
+if [ -n "$CURRENT_TARGET" ]; then
+  tmux select-window -t "$CURRENT_TARGET" 2>/dev/null || true
+fi
+
+echo "opened: $rel_path in tmux tab $name"

--- a/bin/fm-open-file.sh
+++ b/bin/fm-open-file.sh
@@ -1,9 +1,13 @@
 #!/usr/bin/env bash
-# Open a local firstmate-home file in a detached tmux review window.
-# Usage: fm-open-file.sh [--allow-outside] [--lavish] <path>
+# Open local firstmate-home artifacts in a review surface without dumping content.
+# Usage: fm-open-file.sh [--allow-outside] [--lavish] [--tmux] <path> [<path>...]
 #
-# Defaults to files under this firstmate home only. Use --allow-outside only for
-# an explicitly chosen file outside the home. Directories are intentionally not
+# Single Markdown/text files open in a detached tmux review tab with glow, bat,
+# or less. Multiple paths open one WezTerm tab with clickable file:// links.
+# --lavish runs lavish-axi for a single HTML artifact in a WezTerm tab by
+# default. Use --tmux only when terminal text review is explicitly the right
+# surface. Defaults to files under this firstmate home only. Use --allow-outside
+# only for an explicitly chosen file outside the home. Directories are not
 # supported: the helper is for reports and concrete artifacts, not browsing.
 set -eu
 
@@ -13,9 +17,10 @@ FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 
 ALLOW_OUTSIDE=0
 LAVISH=0
+FORCE_TMUX=0
 
 usage() {
-  echo "usage: $(basename "$0") [--allow-outside] [--lavish] <path>" >&2
+  echo "usage: $(basename "$0") [--allow-outside] [--lavish] [--tmux] <path> [<path>...]" >&2
   exit 2
 }
 
@@ -23,6 +28,7 @@ while [ "$#" -gt 0 ]; do
   case "$1" in
     --allow-outside) ALLOW_OUTSIDE=1; shift ;;
     --lavish) LAVISH=1; shift ;;
+    --tmux) FORCE_TMUX=1; shift ;;
     -h|--help) usage ;;
     --) shift; break ;;
     -*) echo "error: unknown option: $1" >&2; usage ;;
@@ -30,8 +36,17 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 
-[ "$#" -eq 1 ] || usage
-INPUT=$1
+[ "$#" -ge 1 ] || usage
+
+if [ "$LAVISH" -eq 1 ] && [ "$#" -ne 1 ]; then
+  echo "error: --lavish expects exactly one HTML file" >&2
+  exit 1
+fi
+
+if [ "$FORCE_TMUX" -eq 1 ] && [ "$#" -ne 1 ]; then
+  echo "error: --tmux opens one terminal review file at a time; omit it to open a clickable WezTerm list" >&2
+  exit 1
+fi
 
 abs_path() {  # <path> -> canonical absolute path; path must exist
   perl -MCwd=abs_path -e '
@@ -43,29 +58,40 @@ abs_path() {  # <path> -> canonical absolute path; path must exist
 }
 
 HOME_REAL=$(abs_path "$FM_HOME") || { echo "error: firstmate home does not exist: $FM_HOME" >&2; exit 1; }
-case "$INPUT" in
-  /*) CANDIDATE=$INPUT ;;
-  *) CANDIDATE=$HOME_REAL/$INPUT ;;
-esac
-FILE_REAL=$(abs_path "$CANDIDATE") || { echo "error: missing path: $INPUT" >&2; exit 1; }
 
-if [ -d "$FILE_REAL" ]; then
-  echo "error: directories are not supported: $INPUT" >&2
-  exit 1
-fi
-[ -f "$FILE_REAL" ] || { echo "error: not a regular file: $INPUT" >&2; exit 1; }
-
-if [ "$ALLOW_OUTSIDE" -ne 1 ]; then
-  case "$FILE_REAL" in
-    "$HOME_REAL"/*) ;;
-    *) echo "error: path is outside firstmate home; pass --allow-outside only for an explicitly chosen safe file" >&2; exit 1 ;;
+FILES_REAL=()
+REL_PATHS=()
+for INPUT in "$@"; do
+  case "$INPUT" in
+    /*) CANDIDATE=$INPUT ;;
+    *) CANDIDATE=$HOME_REAL/$INPUT ;;
   esac
-fi
+  FILE_REAL=$(abs_path "$CANDIDATE") || { echo "error: missing path: $INPUT" >&2; exit 1; }
 
-rel_path=$FILE_REAL
-case "$FILE_REAL" in
-  "$HOME_REAL"/*) rel_path=${FILE_REAL#"$HOME_REAL"/} ;;
-esac
+  if [ -d "$FILE_REAL" ]; then
+    echo "error: directories are not supported: $INPUT" >&2
+    exit 1
+  fi
+  [ -f "$FILE_REAL" ] || { echo "error: not a regular file: $INPUT" >&2; exit 1; }
+
+  if [ "$ALLOW_OUTSIDE" -ne 1 ]; then
+    case "$FILE_REAL" in
+      "$HOME_REAL"/*) ;;
+      *) echo "error: path is outside firstmate home; pass --allow-outside only for an explicitly chosen safe file" >&2; exit 1 ;;
+    esac
+  fi
+
+  rel_path=$FILE_REAL
+  case "$FILE_REAL" in
+    "$HOME_REAL"/*) rel_path=${FILE_REAL#"$HOME_REAL"/} ;;
+  esac
+  FILES_REAL+=("$FILE_REAL")
+  REL_PATHS+=("$rel_path")
+done
+
+FILE_REAL=${FILES_REAL[0]}
+rel_path=${REL_PATHS[0]}
+path_count=${#FILES_REAL[@]}
 
 if [ "$LAVISH" -eq 1 ]; then
   case "$FILE_REAL" in
@@ -73,15 +99,6 @@ if [ "$LAVISH" -eq 1 ]; then
     *) echo "error: --lavish expects an HTML file" >&2; exit 1 ;;
   esac
   command -v lavish-axi >/dev/null 2>&1 || { echo "error: lavish-axi not found on PATH" >&2; exit 1; }
-fi
-
-if [ -n "${TMUX:-}" ]; then
-  SES=$(tmux display-message -p '#S') || { echo "error: could not resolve current tmux session" >&2; exit 1; }
-  CURRENT_TARGET=$(tmux display-message -p '#S:#I' 2>/dev/null || true)
-else
-  tmux has-session -t firstmate 2>/dev/null || tmux new-session -d -s firstmate
-  SES=firstmate
-  CURRENT_TARGET=
 fi
 
 slug() {
@@ -96,48 +113,170 @@ trim_slug() {
   printf '%.28s' "$s" | sed 's/[.-]*$//; s/-*$//'
 }
 
-base_name=$(basename "$FILE_REAL")
-base_no_ext=${base_name%.*}
-case "$rel_path" in
-  data/*/report.md)
-    task_id=${rel_path#data/}
-    task_id=${task_id%%/*}
-    first_word=${task_id%%-*}
-    base="report-$(slug "$first_word")"
-    ;;
-  .lavish/*.html|.lavish/*.htm)
-    base="lavish-$(slug "$base_no_ext")"
-    ;;
-  *)
-    base="file-$(slug "$base_no_ext")"
-    ;;
-esac
-base=$(trim_slug "$base")
-[ -n "$base" ] || base=file
+base_for_path() {  # <real-path> <relative-path>
+  local real=$1 rel=$2 base_name base_no_ext task_id first_word base
+  base_name=$(basename "$real")
+  base_no_ext=${base_name%.*}
+  case "$rel" in
+    data/*/report.md)
+      task_id=${rel#data/}
+      task_id=${task_id%%/*}
+      first_word=${task_id%%-*}
+      base="report-$(slug "$first_word")"
+      ;;
+    .lavish/*.html|.lavish/*.htm)
+      base="lavish-$(slug "$base_no_ext")"
+      ;;
+    *)
+      base="file-$(slug "$base_no_ext")"
+      ;;
+  esac
+  trim_slug "$base"
+}
 
-name=$base
-i=2
-while tmux list-windows -t "$SES" -F '#{window_name}' | grep -Fxq "$name"; do
-  suffix="-$i"
-  keep=$((28 - ${#suffix}))
-  [ "$keep" -gt 0 ] || keep=24
-  prefix=$(printf "%.*s" "$keep" "$base" | sed 's/[.-]*$//; s/-*$//')
-  [ -n "$prefix" ] || prefix=file
-  name="$prefix$suffix"
-  i=$((i + 1))
-done
+tmux_session() {
+  if [ -n "${TMUX:-}" ]; then
+    tmux display-message -p '#S' || return 1
+  else
+    tmux has-session -t firstmate 2>/dev/null || tmux new-session -d -s firstmate
+    printf '%s\n' firstmate
+  fi
+}
+
+unique_tmux_name() {  # <session> <base>
+  local ses=$1 base=$2 name i suffix keep prefix
+  name=$base
+  i=2
+  while tmux list-windows -t "$ses" -F '#{window_name}' | grep -Fxq "$name"; do
+    suffix="-$i"
+    keep=$((28 - ${#suffix}))
+    [ "$keep" -gt 0 ] || keep=24
+    prefix=$(printf "%.*s" "$keep" "$base" | sed 's/[.-]*$//; s/-*$//')
+    [ -n "$prefix" ] || prefix=file
+    name="$prefix$suffix"
+    i=$((i + 1))
+  done
+  printf '%s\n' "$name"
+}
+
+wezterm_name_exists() {  # <name>
+  command -v wezterm >/dev/null 2>&1 || return 1
+  wezterm cli list --format json 2>/dev/null | perl -MJSON::PP -0e '
+    my $target = shift;
+    my $rows = eval { decode_json(<STDIN>) } || [];
+    for my $row (@$rows) {
+      my $title = $row->{tab_title} || $row->{title} || "";
+      exit 0 if $title eq $target;
+    }
+    exit 1;
+  ' "$1"
+}
+
+unique_wezterm_name() {  # <base>
+  local base=$1 name i suffix keep prefix
+  name=$base
+  i=2
+  while wezterm_name_exists "$name"; do
+    suffix="-$i"
+    keep=$((28 - ${#suffix}))
+    [ "$keep" -gt 0 ] || keep=24
+    prefix=$(printf "%.*s" "$keep" "$base" | sed 's/[.-]*$//; s/-*$//')
+    [ -n "$prefix" ] || prefix=file
+    name="$prefix$suffix"
+    i=$((i + 1))
+  done
+  printf '%s\n' "$name"
+}
+
+spawn_wezterm_tab() {  # <name> <cmd>
+  local name=$1 cmd=$2 pane_id
+  command -v wezterm >/dev/null 2>&1 || { echo "error: wezterm not found on PATH" >&2; exit 1; }
+  pane_id=$(wezterm cli spawn --cwd "$HOME_REAL" "$BASH" -lc "$cmd") || {
+    echo "error: could not open WezTerm tab" >&2
+    exit 1
+  }
+  wezterm cli set-tab-title --pane-id "$pane_id" "$name" >/dev/null 2>&1 || true
+}
 
 quote() { printf '%q' "$1"; }
+
+file_uri() {  # <absolute-path>
+  perl -e '
+    my $p = shift;
+    $p =~ s#^/##;
+    $p =~ s/([^A-Za-z0-9._~\/-])/sprintf("%%%02X", ord($1))/ge;
+    print "file:///$p";
+  ' "$1"
+}
+
+base=$(base_for_path "$FILE_REAL" "$rel_path")
+[ -n "$base" ] || base=file
 qfile=$(quote "$FILE_REAL")
 
-case "$base_name" in
+if [ "$path_count" -gt 1 ]; then
+  first_rel=${REL_PATHS[0]}
+  case "$first_rel" in
+    data/*/*)
+      first_task=${first_rel#data/}
+      first_task=${first_task%%/*}
+      list_base="links-$(slug "${first_task%%-*}")"
+      ;;
+    *)
+      first_file=$(basename "${FILES_REAL[0]}")
+      list_base="links-$(slug "${first_file%.*}")"
+      ;;
+  esac
+  list_base=$(trim_slug "$list_base")
+  [ -n "$list_base" ] || list_base=links
+  name=$(unique_wezterm_name "$list_base")
+  list_file=$(mktemp "${TMPDIR:-/tmp}/firstmate-review-links.XXXXXX") || { echo "error: could not create temporary link list" >&2; exit 1; }
+  {
+    printf 'Firstmate review links\n\n'
+    idx=1
+    for n in "${!FILES_REAL[@]}"; do
+      uri=$(file_uri "${FILES_REAL[$n]}")
+      label=${REL_PATHS[$n]}
+      printf '%s. \033]8;;%s\033\\%s\033]8;;\033\\\n' "$idx" "$uri" "$label"
+      idx=$((idx + 1))
+    done
+    printf '\nPress Enter to close this tab.\n'
+  } >"$list_file"
+  qlist=$(quote "$list_file")
+  cmd="trap 'rm -f $qlist' EXIT; cat $qlist; read _"
+  spawn_wezterm_tab "$name" "$cmd"
+  echo "opened: $path_count files in WezTerm tab $name"
+  exit 0
+fi
+
+if [ "$LAVISH" -eq 1 ]; then
+  cmd="lavish-axi $qfile; status=\$?; printf '\\nlavish-axi exited with status %s. Press Enter to close this tab.' \"\$status\"; read _"
+  if [ "$FORCE_TMUX" -eq 1 ]; then
+    SES=$(tmux_session) || { echo "error: could not resolve tmux session" >&2; exit 1; }
+    CURRENT_TARGET=$(tmux display-message -p '#S:#I' 2>/dev/null || true)
+    name=$(unique_tmux_name "$SES" "$base")
+    tmux new-window -d -t "$SES" -n "$name" -c "$HOME_REAL" "$BASH" -lc "$cmd"
+    if [ -n "$CURRENT_TARGET" ]; then
+      tmux select-window -t "$CURRENT_TARGET" 2>/dev/null || true
+    fi
+    echo "opened: $rel_path with lavish-axi in tmux tab $name"
+  else
+    name=$(unique_wezterm_name "$base")
+    spawn_wezterm_tab "$name" "$cmd"
+    echo "opened: $rel_path with lavish-axi in WezTerm tab $name"
+  fi
+  exit 0
+fi
+
+case "$(basename "$FILE_REAL")" in
   *.md|*.markdown|*.mdown) is_markdown=1 ;;
   *) is_markdown=0 ;;
 esac
 
-if [ "$LAVISH" -eq 1 ]; then
-  cmd="lavish-axi $qfile; status=\$?; printf '\\nlavish-axi exited with status %s. Press Enter to close this window.' \"\$status\"; read _"
-elif [ "$is_markdown" -eq 1 ]; then
+SES=$(tmux_session) || { echo "error: could not resolve tmux session" >&2; exit 1; }
+CURRENT_TARGET=$(tmux display-message -p '#S:#I' 2>/dev/null || true)
+name=$(unique_tmux_name "$SES" "$base")
+
+if [ "$is_markdown" -eq 1 ]; then
   cmd="if command -v glow >/dev/null 2>&1; then exec glow -p $qfile; elif command -v bat >/dev/null 2>&1; then exec bat --paging=always --style=plain -- $qfile; else exec less -R -- $qfile; fi"
 else
   cmd="if command -v bat >/dev/null 2>&1; then exec bat --paging=always --style=plain -- $qfile; else exec less -R -- $qfile; fi"

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -16,7 +16,7 @@ Each file also starts with a short header comment.
 | `fm-spawn.sh`            | Spawn one task, several `id=repo` pairs, or a persistent secondmate with `--secondmate`; ship/scout spawns require an isolated treehouse worktree; secondmate spawns locally sync the home before launch |
 | `fm-project-mode.sh`     | Resolve a project's delivery mode and `+yolo` flag from `data/projects.md`                                          |
 | `fm-merge-local.sh`      | Fast-forward a `local-only` project's local default branch after approval                                           |
-| `fm-open-file.sh`        | Open a firstmate-home report or file in a detached tmux review tab using `glow`, `bat`, or `less`; `--lavish` runs `lavish-axi` for HTML review artifacts, and relative paths such as `data/<id>/report.md` resolve from the firstmate home |
+| `fm-open-file.sh`        | Open a firstmate-home report or file without dumping content into chat: one Markdown/text path opens a terminal review tab with `glow`, `bat`, or `less`; multiple paths open one WezTerm tab with clickable links; `--lavish` runs `lavish-axi` for HTML review artifacts; relative paths such as `data/<id>/report.md` resolve from the firstmate home |
 | `fm-review-diff.sh`      | Review a crewmate branch against the authoritative base, with optional `--stat` output                              |
 | `fm-marker-lib.sh`       | Shared from-firstmate request marker and detector sourced by `fm-send.sh`, `fm-brief.sh`, and tests                 |
 | `fm-watch-arm.sh`        | Verified per-home watcher re-arm; reports `started`, `healthy`, or `FAILED`; `--restart` relaunches only this home's watcher |

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -16,6 +16,7 @@ Each file also starts with a short header comment.
 | `fm-spawn.sh`            | Spawn one task, several `id=repo` pairs, or a persistent secondmate with `--secondmate`; ship/scout spawns require an isolated treehouse worktree; secondmate spawns locally sync the home before launch |
 | `fm-project-mode.sh`     | Resolve a project's delivery mode and `+yolo` flag from `data/projects.md`                                          |
 | `fm-merge-local.sh`      | Fast-forward a `local-only` project's local default branch after approval                                           |
+| `fm-open-file.sh`        | Open a firstmate-home report or file in a detached tmux review tab using `glow`, `bat`, or `less`; `--lavish` runs `lavish-axi` for HTML review artifacts, and relative paths such as `data/<id>/report.md` resolve from the firstmate home |
 | `fm-review-diff.sh`      | Review a crewmate branch against the authoritative base, with optional `--stat` output                              |
 | `fm-marker-lib.sh`       | Shared from-firstmate request marker and detector sourced by `fm-send.sh`, `fm-brief.sh`, and tests                 |
 | `fm-watch-arm.sh`        | Verified per-home watcher re-arm; reports `started`, `healthy`, or `FAILED`; `--restart` relaunches only this home's watcher |

--- a/tests/fm-open-file.test.sh
+++ b/tests/fm-open-file.test.sh
@@ -123,7 +123,12 @@ run_open -- data/fix-login-k3/report.md .lavish/plan.html data/audit-x9/report.m
 expect_code 0 "$?" "multi-path open exits 0"
 assert_contains "$OUT" "opened: 3 files in WezTerm tab " "multi-path opens a single WezTerm tab"
 assert_not_contains "$OUT" "secret-sentinel-XYZ" "multi-path opened line must not dump content"
-LIST_FILE=$(ls "$TMP_ROOT"/firstmate-review-links.* 2>/dev/null | head -1)
+LIST_FILE=""
+for _candidate in "$TMP_ROOT"/firstmate-review-links.*; do
+  [ -e "$_candidate" ] || continue
+  LIST_FILE=$_candidate
+  break
+done
 [ -n "$LIST_FILE" ] || fail "no generated review-links list file found"
 assert_grep "file:///" "$LIST_FILE" "link list uses file:// hyperlinks"
 for rel in data/fix-login-k3/report.md .lavish/plan.html data/audit-x9/report.md; do

--- a/tests/fm-open-file.test.sh
+++ b/tests/fm-open-file.test.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# fm-open-file.sh - open a firstmate-home artifact in a review surface without
+# dumping its content into chat.
+#
+# These tests pin the helper's contract hermetically (stubbed tmux + wezterm, no
+# real terminal multiplexer):
+#   1. A single Markdown report opens in a detached tmux review tab, the opened
+#      line names a short collision-safe tab, focus returns to the caller's
+#      window, and no file content leaks into the printed line.
+#   2. Opening the same report twice yields a collision-safe second tab name.
+#   3. Several paths open one WezTerm tab whose link list carries a real
+#      file:// hyperlink per target, and again no content leaks.
+#   4. Missing paths, directories, out-of-home paths, and a bare invocation are
+#      rejected; --lavish refuses a non-HTML file and refuses multiple files.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+OPEN="$ROOT/bin/fm-open-file.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-open-file)
+
+# A firstmate home with a scout report, a Lavish HTML artifact, and a directory.
+# The report carries a sentinel secret so a content-dump regression is caught.
+HOME_DIR="$TMP_ROOT/home"
+mkdir -p "$HOME_DIR/data/fix-login-k3" "$HOME_DIR/data/audit-x9" "$HOME_DIR/.lavish" "$HOME_DIR/browsedir"
+printf '# Report\n\nsecret-sentinel-XYZ must never reach the opened line\n' \
+  > "$HOME_DIR/data/fix-login-k3/report.md"
+printf '# Audit\nfindings here\n' > "$HOME_DIR/data/audit-x9/report.md"
+printf '<html><body>plan</body></html>\n' > "$HOME_DIR/.lavish/plan.html"
+
+OUTSIDE="$TMP_ROOT/outside.md"
+printf 'outside the home\n' > "$OUTSIDE"
+
+# --- stubs ------------------------------------------------------------------
+# tmux: pretend we are inside a session called "firstmate"; record created and
+# selected windows so collision naming and focus restore can be asserted. The
+# set of existing window names lives in FM_FAKE_WINDOWS so a second open sees the
+# first tab and must dodge its name.
+FB=$(fm_fakebin "$TMP_ROOT")
+export FM_FAKE_WINDOWS="$TMP_ROOT/windows.txt" FM_TMUX_LOG="$TMP_ROOT/tmux.log"
+: > "$FM_FAKE_WINDOWS"; : > "$FM_TMUX_LOG"
+cat > "$FB/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+sub=${1:-}; shift || true
+case "$sub" in
+  display-message)
+    fmt=""
+    while [ "$#" -gt 0 ]; do [ "$1" = "-p" ] && { shift; fmt=${1:-}; }; shift || true; done
+    case "$fmt" in
+      '#S') printf 'firstmate\n' ;;
+      '#S:#I') printf 'firstmate:2\n' ;;
+      *) printf 'x\n' ;;
+    esac ;;
+  has-session) exit 0 ;;
+  new-session) exit 0 ;;
+  list-windows) [ -f "$FM_FAKE_WINDOWS" ] && cat "$FM_FAKE_WINDOWS"; exit 0 ;;
+  new-window)
+    name=""
+    while [ "$#" -gt 0 ]; do [ "$1" = "-n" ] && { shift; name=${1:-}; }; shift || true; done
+    printf '%s\n' "$name" >> "$FM_FAKE_WINDOWS"
+    printf 'new-window %s\n' "$name" >> "$FM_TMUX_LOG"
+    exit 0 ;;
+  select-window)
+    printf 'select-window %s\n' "$*" >> "$FM_TMUX_LOG"; exit 0 ;;
+esac
+exit 0
+SH
+chmod +x "$FB/tmux"
+
+# wezterm: no existing tabs, spawn returns a pane id and logs the command it was
+# handed so the generated link-list file can be inspected.
+export FM_WEZTERM_LOG="$TMP_ROOT/wezterm.log"
+: > "$FM_WEZTERM_LOG"
+cat > "$FB/wezterm" <<'SH'
+#!/usr/bin/env bash
+set -u
+[ "${1:-}" = "cli" ] && shift
+case "${1:-}" in
+  list) printf '[]\n' ;;            # no existing tabs
+  spawn)
+    printf '%s\n' "$*" >> "$FM_WEZTERM_LOG"
+    printf '42\n' ;;                # the new pane id
+  set-tab-title) : ;;
+esac
+exit 0
+SH
+chmod +x "$FB/wezterm"
+
+# run_open <env...> -- <args...>: invoke fm-open-file with the stubs on PATH and
+# TMUX set so tmux_session takes the in-session branch. FM_ROOT_OVERRIDE points
+# away from the repo so fm-guard's tangle check stays quiet. Captures stdout into
+# the global OUT and returns the exit code.
+run_open() {
+  local env=()
+  while [ "$#" -gt 0 ] && [ "$1" != "--" ]; do env+=("$1"); shift; done
+  shift  # drop --
+  OUT=$(PATH="$FB:$PATH" TMUX="fake" FM_HOME="$HOME_DIR" FM_ROOT_OVERRIDE="$TMP_ROOT" \
+        TMPDIR="$TMP_ROOT" "${env[@]+"${env[@]}"}" "$OPEN" "$@" 2>/dev/null)
+}
+
+# 1. Single Markdown report -> tmux review tab.
+run_open -- data/fix-login-k3/report.md
+code=$?
+expect_code 0 "$code" "single markdown open exits 0"
+assert_contains "$OUT" "opened: data/fix-login-k3/report.md in tmux tab " "opened line names the relative path and a tmux tab"
+assert_contains "$OUT" "report-fix" "tab name is short and derived from the task id"
+assert_not_contains "$OUT" "secret-sentinel-XYZ" "opened line must not dump file content"
+assert_grep "new-window report-fix" "$FM_TMUX_LOG" "a detached tmux window was created"
+assert_grep "select-window -t firstmate:2" "$FM_TMUX_LOG" "focus is restored to the caller's window"
+pass "single markdown report opens in a focus-preserving tmux tab without leaking content"
+
+# 2. Opening it again must pick a collision-safe name.
+run_open -- data/fix-login-k3/report.md
+expect_code 0 "$?" "second open exits 0"
+assert_contains "$OUT" "report-fix-2" "second tab dodges the first tab's name"
+pass "repeat open yields a collision-safe tab name"
+
+# 3. Several paths -> one WezTerm tab with a clickable link per target.
+run_open -- data/fix-login-k3/report.md .lavish/plan.html data/audit-x9/report.md
+expect_code 0 "$?" "multi-path open exits 0"
+assert_contains "$OUT" "opened: 3 files in WezTerm tab " "multi-path opens a single WezTerm tab"
+assert_not_contains "$OUT" "secret-sentinel-XYZ" "multi-path opened line must not dump content"
+LIST_FILE=$(ls "$TMP_ROOT"/firstmate-review-links.* 2>/dev/null | head -1)
+[ -n "$LIST_FILE" ] || fail "no generated review-links list file found"
+assert_grep "file:///" "$LIST_FILE" "link list uses file:// hyperlinks"
+for rel in data/fix-login-k3/report.md .lavish/plan.html data/audit-x9/report.md; do
+  assert_grep "$rel" "$LIST_FILE" "link list labels target $rel"
+done
+assert_no_grep "secret-sentinel-XYZ" "$LIST_FILE" "link list shows labels, not file contents"
+pass "multiple targets open one WezTerm tab of clickable file:// links"
+
+# 4. Rejections.
+run_open -- data/fix-login-k3/nope.md;          expect_code 1 "$?" "missing path is rejected"
+run_open -- browsedir;                          expect_code 1 "$?" "a directory is rejected"
+run_open -- "$OUTSIDE";                         expect_code 1 "$?" "an out-of-home path is rejected"
+run_open --;                                    expect_code 2 "$?" "a bare invocation prints usage"
+run_open -- --lavish data/fix-login-k3/report.md; expect_code 1 "$?" "--lavish refuses a non-HTML file"
+run_open -- --lavish .lavish/plan.html data/audit-x9/report.md; expect_code 1 "$?" "--lavish refuses multiple files"
+# --allow-outside lets an explicitly chosen outside file through (opens via tmux).
+run_open -- --allow-outside "$OUTSIDE";         expect_code 0 "$?" "--allow-outside permits an explicit outside file"
+pass "missing, directory, out-of-home, bare, and bad --lavish invocations are handled; --allow-outside opt-in works"


### PR DESCRIPTION
## Intent

The developer was building firstmate tooling so that local report and file references become reviewable in the captain's terminal UI instead of being dead, unclickable paths in chat. They wanted a new helper script (bin/fm-open-file.sh) plus updated AGENTS.md/README/docs guidance covering when to use tmux, WezTerm, or Lavish surfaces, with rules for renderer preference, safe window naming, path rejection, preserving orchestrator focus, and concise output. This was a relaunch continuing existing branch fm/tmux-file-open-p2, and the key correction was that multiple review links should open as a clickable list in a single real WezTerm tab (not tmux windows), while single targets open directly in the appropriate surface and tmux is reserved for explicit requests or terminal-text review. They also instructed the agent to verify with shell syntax checks and a test on an existing report, commit on that branch, and then push the change through the no-mistakes gate, including a workaround of deleting and recreating the gate ref and reconfiguring the fork as the push target after an upstream 403 push failure.

## What Changed

- Added `bin/fm-open-file.sh`, a helper that turns local report/file paths into reviewable terminal surfaces: a single Markdown/text target opens directly in a tmux review tab, multiple targets open as a clickable OSC-8 `file://` link list in one real WezTerm tab, and `--lavish` routes a single HTML file to Lavish. It validates paths (rejecting missing, directory, out-of-home, and bare invocations unless `--allow-outside`), uses safe collision-suffixed window names, and restores the orchestrator's focus after opening.
- Updated `AGENTS.md`, `README.md`, `docs/scripts.md`, and `CONTRIBUTING.md` to document when to use the tmux, WezTerm, or Lavish surface for captain-facing artifacts and to register the new script and its test.
- Added `tests/fm-open-file.test.sh` (4 cases) covering surface selection and path rejection; fixed a temp link-list leak on the WezTerm spawn-failure path and resolved shellcheck SC2209/SC2012 warnings.

## Risk Assessment

✅ Low: A well-bounded new helper script plus matching docs and hermetic tests; the only prior finding (temp-file leak on WezTerm spawn failure) is correctly fixed with a parent-side EXIT trap, and no further substantiated issues remain.

## Testing

Baseline `bash tests/fm-open-file.test.sh` passes 4/4. Beyond the stubbed unit tests I ran the helper end-to-end against real tmux and a real generated link list: a single report opened in a focus-preserving, collision-safe tmux tab and rendered in-pane (via less, since glow/bat are absent); three review targets produced one WezTerm tab whose link list contains a real OSC-8 file:// hyperlink per target with clean relative-path labels, satisfying the core correction that multiple links open as a clickable list in a single WezTerm tab; and a CLI transcript confirms missing/directory/out-of-home/bare/bad-lavish inputs are rejected while --allow-outside is the explicit opt-in. No file content leaked into any printed line. Because this is a terminal-hyperlink surface, the reviewer-visible artifact is the captured OSC-8 link-list bytes plus the tmux pane capture rather than a GUI screenshot (a headless WezTerm GUI tab cannot be screenshotted here). Transient fixtures and the temporary tmux session were removed; the worktree is clean.

<details>
<summary>Evidence: Generated WezTerm clickable link list (raw OSC-8 hyperlink bytes via cat -v)</summary>

<code>Firstmate review links&#10;&#10;1. ^[]8;;file:///.../data/fix-login-k3/report.md^[\data/fix-login-k3/report.md^[]8;;^[\&#10;2. ^[]8;;file:///.../.lavish/plan.html^[\.lavish/plan.html^[]8;;^[\&#10;3. ^[]8;;file:///.../data/audit-x9/report.md^[\data/audit-x9/report.md^[]8;;^[\&#10;&#10;Press Enter to close this tab.</code>

```text
Firstmate review links

1. ^[]8;;file:///private/tmp/fmopen-e2e.hZ3Es1/home/data/fix-login-k3/report.md^[\data/fix-login-k3/report.md^[]8;;^[\
2. ^[]8;;file:///private/tmp/fmopen-e2e.hZ3Es1/home/.lavish/plan.html^[\.lavish/plan.html^[]8;;^[\
3. ^[]8;;file:///private/tmp/fmopen-e2e.hZ3Es1/home/data/audit-x9/report.md^[\data/audit-x9/report.md^[]8;;^[\

Press Enter to close this tab.
```
</details>
<details>
<summary>Evidence: Raw .ansi link list (terminal renders these as clickable file:// links)</summary>

```text
Firstmate review links

1. ]8;;file:///private/tmp/fmopen-e2e.hZ3Es1/home/data/fix-login-k3/report.md\data/fix-login-k3/report.md]8;;\
2. ]8;;file:///private/tmp/fmopen-e2e.hZ3Es1/home/.lavish/plan.html\.lavish/plan.html]8;;\
3. ]8;;file:///private/tmp/fmopen-e2e.hZ3Es1/home/data/audit-x9/report.md\data/audit-x9/report.md]8;;\

Press Enter to close this tab.
```
</details>
<details>
<summary>Evidence: Single report rendered in the tmux review tab</summary>

<code># Login fix report&#10;Reproduced the 500 on empty password. Root cause in auth.go:42.&#10;/private/tmp/.../report.md (END)</code>

```text
# Login fix report
Reproduced the 500 on empty password. Root cause in auth.go:42.
/private/tmp/fmopen-e2e.hZ3Es1/home/data/fix-login-k3/report.md (END)
```
</details>
<details>
<summary>Evidence: Path-rejection / safety CLI transcript</summary>

`missing path -> exit 1; directory -> exit 1; outside-home -> exit 1; bare -> usage exit 2; --lavish non-HTML -> exit 1; --lavish multi-file -> exit 1; --allow-outside outside.md -> opened in tmux tab file-outside, exit 0`

```text
### Rejection / safety contract (end-user CLI behavior)

$ fm-open-file.sh data/fix-login-k3/nope.md
error: not a regular file: data/fix-login-k3/nope.md
  -> exit 1

$ fm-open-file.sh browsedir
error: directories are not supported: browsedir
  -> exit 1

$ fm-open-file.sh /tmp/fmopen-e2e.hZ3Es1/outside.md
error: path is outside firstmate home; pass --allow-outside only for an explicitly chosen safe file
  -> exit 1

$ fm-open-file.sh 
usage: fm-open-file.sh [--allow-outside] [--lavish] [--tmux] <path> [<path>...]
  -> exit 2

$ fm-open-file.sh --lavish data/fix-login-k3/report.md
error: --lavish expects an HTML file
  -> exit 1

$ fm-open-file.sh --lavish .lavish/plan.html data/audit-x9/report.md
error: --lavish expects exactly one HTML file
  -> exit 1

### Opt-in escape hatch for an explicitly chosen outside file
$ fm-open-file.sh --allow-outside /tmp/fmopen-e2e.hZ3Es1/outside.md
opened: /private/tmp/fmopen-e2e.hZ3Es1/outside.md in tmux tab file-outside
  -> exit 0
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-open-file.sh:232` - In the multi-path WezTerm branch, the temp link-list file is created at line 232 but its only cleanup is the `trap &#39;... EXIT&#39;` that runs inside the spawned WezTerm shell. If spawn_wezterm_tab fails (wezterm not on PATH at line 193, or `wezterm cli spawn` fails at line 194), the function calls `exit 1` in the parent before that shell ever starts, leaking the mktemp file. Add a parent-side cleanup (e.g. a parent EXIT trap that rm&#39;s $list_file, or rm on the spawn error path) so the file is removed when the tab never opens.

🔧 Fix: fix temp link-list leak on WezTerm spawn failure
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-open-file.test.sh` (4/4 pass)</code>
- <code>Real tmux: `bin/fm-open-file.sh data/fix-login-k3/report.md` twice -&gt; tabs report-fix and report-fix-2, focus restored</code>
- <code>`tmux capture-pane -t firstmate:report-fix` -&gt; report rendered in the review tab</code>
- <code>Multi-target run `bin/fm-open-file.sh report.md plan.html report.md` -&gt; single WezTerm tab &#39;links-fix&#39; with one OSC-8 file:// hyperlink per target (inspected generated link-list bytes)</code>
- <code>Rejection transcript: missing path, directory, out-of-home, bare invocation, `--lavish` non-HTML, `--lavish` multi-file all exit non-zero; `--allow-outside` opens an explicit outside file</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
