### PR TITLE
fix(watch): add durable active watcher session

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -467,6 +467,8 @@ The arm chain IS the supervision: while any task is in flight, keep exactly one 
 Each cycle is one harness-tracked background task that blocks until an actionable wake is due (benign wakes are absorbed in bash without ending the task), fires with one reason line, and ends, so the chain survives only when firstmate starts the next cycle after each fire.
 After handling the drained wakes, re-arm before you end the turn by running `bin/fm-watch-arm.sh` as its own background task.
 Arm or re-arm the watcher only through the harness's own tracked background mechanism - the one that survives the call and notifies you when the process exits - so the cycle actually persists and the next wake reaches you.
+If the current harness cannot provide a reliable tracked background call, start the home-scoped durable runner with `bin/fm-watch-session.sh --start` and check it with `bin/fm-watch-session.sh --status`; it records only this `FM_HOME` in `state/.watch-session.lock` and re-arms the normal watcher from a persistent process.
+For a visible pane instead of a detached process, use `bin/fm-watch-session.sh --tmux` to print a ready-to-run tmux command, or run `bin/fm-watch-session.sh --foreground` inside a persistent tmux window.
 Never fire-and-forget the watcher with a shell `&` inside another call: that backgrounded child is reaped when the call returns, so supervision silently stops, and worse, the dying process reports a false "already running" that hides the gap.
 **Standalone, never bundled.**
 Run `bin/fm-watch-arm.sh` as its OWN background task with nothing else in that bash, never tacked onto the tail of a multi-command call: bundled, its self-verifying status line is buried in unrelated output and it can silently no-op as a side effect of those other commands, so no fresh cycle gets established and supervision lapses unnoticed.
@@ -488,6 +490,7 @@ Empty polls, elapsed waiting time, and "still no change" are tool bookkeeping, n
 ```sh
 bin/fm-watch-arm.sh        # safe verified re-arm; run as harness-tracked background; no-ops if healthy
 bin/fm-watch-arm.sh --restart  # home-scoped forced restart; never a broad pkill
+bin/fm-watch-session.sh --start|--status|--stop  # durable active-mode runner for this FM_HOME
 bin/fm-watch.sh            # the watcher itself; exits with: signal|stale|check|heartbeat
 bin/fm-wake-drain.sh       # drain queued wake records at turn start; asserts guard after draining
 bin/fm-crew-state.sh <id>  # one-line current-state read; reconciles matching run-step, pane, and status log
@@ -517,11 +520,11 @@ This exception is narrow: ordinary crewmates still trip stale detection when the
 **Watcher liveness is guarded, not just disciplined.**
 Arming the watcher is the last action of every wake-handling turn - but the protocol no longer relies on remembering that.
 While running, `fm-watch.sh` touches `state/.last-watcher-beat` every poll cycle.
-The supervision scripts (`fm-peek`, `fm-send`, `fm-spawn`, `fm-teardown`, `fm-pr-check`, `fm-promote`, `fm-review-diff`, `fm-fleet-sync`, `fm-update`) call `bin/fm-guard.sh` first, which warns to stderr when any task is in flight (`state/*.meta` exists) but queued wakes are pending, or that beacon is missing or older than `FM_GUARD_GRACE` (default 300s).
-`bin/fm-wake-drain.sh` runs the same guard after it drains, so the liveness check also fires on a drain-and-handle turn that runs no other supervision script, narrowing the window in which a lapsed chain can hide; the grace beacon keeps it silent right after a normal fire and it warns only on a genuine stale-beyond-grace lapse.
-The no-watcher case leads with a prominent, bordered ●-marked banner (in-flight count, beacon age, and the exact one-line re-arm command) so it reads as an alarm rather than a buried stderr line you can skim past.
+The supervision scripts (`fm-peek`, `fm-send`, `fm-spawn`, `fm-teardown`, `fm-pr-check`, `fm-promote`, `fm-review-diff`, `fm-fleet-sync`, `fm-update`) call `bin/fm-guard.sh` first, which warns to stderr when any task is in flight (`state/*.meta` exists) but queued wakes are pending, that beacon is missing or older than `FM_GUARD_GRACE` (default 300s), or the fresh beacon is not backed by `state/.watch.lock` naming a live watcher for this same `FM_HOME` and watcher path.
+`bin/fm-wake-drain.sh` runs the same guard after it drains, so the liveness check also fires on a drain-and-handle turn that runs no other supervision script, narrowing the window in which a lapsed chain can hide.
+The no-watcher case leads with a prominent, bordered ●-marked banner (in-flight count, beacon/lock problem, and the exact one-line re-arm command) so it reads as an alarm rather than a buried stderr line you can skim past.
 So the next time you touch the fleet with queued wakes or no watcher alive, the tool output itself tells you what to do - a pull-based guard that works on any harness, since it rides the script output you already read rather than a harness-specific hook.
-The grace window keeps normal handling (watcher briefly down between a wake and its re-arm) silent.
+The grace window now only helps when a live matching watcher lock is present; a fresh beacon without that lock is treated as a false-fresh state and warns.
 If a guard warning says queued wakes are pending, drain them before doing anything else.
 If a guard warning says watcher liveness is stale, arm `bin/fm-watch-arm.sh` after draining any queued wakes.
 

--- a/bin/fm-guard.sh
+++ b/bin/fm-guard.sh
@@ -4,13 +4,11 @@
 # First, always warn if the firstmate primary checkout (FM_ROOT) is on a named
 # non-default branch, because that means firstmate-on-itself work landed in the
 # primary instead of an isolated worktree.
-# Then, if any task is in flight (a state/<id>.meta exists) and the watcher's
-# liveness beacon (state/.last-watcher-beat, touched every poll cycle) is
-# missing or older than FM_GUARD_GRACE seconds, prints a loud, clearly delimited
-# banner so the agent cannot skim past it in the tool output of whatever it was
-# doing - the one channel every harness has. Normal wake handling (watcher
-# briefly down between a wake and its re-arm) stays inside the grace window and
-# stays silent. Always exits 0: the guard warns, it never blocks.
+# Then, if any task is in flight (a state/<id>.meta exists), prove the watcher is
+# live by checking both the liveness beacon and the home-scoped watcher lock. A
+# fresh state/.last-watcher-beat alone is not enough: a one-shot watcher can write
+# a wake and exit while leaving a fresh beacon behind. Always exits 0: the guard
+# warns, it never blocks.
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -54,6 +52,38 @@ else
   stat_mtime() { stat -c %Y "$1" 2>/dev/null; }
 fi
 
+WATCH_LOCK="$STATE/.watch.lock"
+WATCH_PATH="$SCRIPT_DIR/fm-watch.sh"
+watcher_lock_desc="no watcher lock"
+
+watcher_lock_healthy() {
+  local pid lock_home lock_path lock_identity current_identity
+  watcher_lock_desc="no watcher lock"
+  [ -e "$WATCH_LOCK" ] || [ -L "$WATCH_LOCK" ] || return 1
+  pid=$(cat "$WATCH_LOCK/pid" 2>/dev/null || true)
+  if ! fm_pid_alive "$pid"; then
+    watcher_lock_desc="watcher lock has no live pid"
+    return 1
+  fi
+  lock_home=$(cat "$WATCH_LOCK/fm-home" 2>/dev/null || true)
+  lock_path=$(cat "$WATCH_LOCK/watcher-path" 2>/dev/null || true)
+  lock_identity=$(cat "$WATCH_LOCK/pid-identity" 2>/dev/null || true)
+  if [ "$lock_home" != "$FM_HOME" ] || [ "$lock_path" != "$WATCH_PATH" ] || [ -z "$lock_identity" ]; then
+    watcher_lock_desc="watcher lock does not name a live watcher for this home"
+    return 1
+  fi
+  current_identity=$(fm_pid_identity "$pid") || {
+    watcher_lock_desc="watcher lock pid identity is unavailable"
+    return 1
+  }
+  if [ "$current_identity" != "$lock_identity" ]; then
+    watcher_lock_desc="watcher lock pid identity no longer matches"
+    return 1
+  fi
+  watcher_lock_desc="live watcher pid=$pid"
+  return 0
+}
+
 # Only act with tasks in flight; count them so the banner can say how much is
 # riding on an absent watcher.
 in_flight=0
@@ -80,10 +110,18 @@ if [ -e "$BEAT" ]; then
     beacon_desc=unknown
   fi
 fi
+lock_healthy=false
+watcher_lock_healthy && lock_healthy=true
+watcher_problem=
+if [ "$watcher_fresh" = false ]; then
+  watcher_problem="no fresh beacon (last beat: $beacon_desc, grace ${GRACE}s)"
+elif [ "$lock_healthy" = false ]; then
+  watcher_problem="fresh beacon but no live watcher lock: $watcher_lock_desc"
+fi
 
 # No fresh watcher with tasks in flight is the dangerous state: emit a prominent,
 # bordered banner FIRST so it reads as an alarm, not a buried stderr line.
-if [ "$watcher_fresh" = false ]; then
+if [ -n "$watcher_problem" ]; then
   if "$queue_pending"; then
     fix='After draining queued wakes, re-arm the watcher: run bin/fm-watch-arm.sh as the harness-tracked background task (never a shell & that gets reaped).'
   else
@@ -93,7 +131,7 @@ if [ "$watcher_fresh" = false ]; then
   {
     printf '●%s\n' "$rule"
     printf '●  WATCHER DOWN - SUPERVISION IS OFF\n'
-    printf '●  %s task(s) in flight, but no watcher has a fresh beacon (last beat: %s, grace %ss).\n' "$in_flight" "$beacon_desc" "$GRACE"
+    printf '●  %s task(s) in flight, but watcher liveness is not proved: %s.\n' "$in_flight" "$watcher_problem"
     printf '●  Trust bin/fm-watch-arm.sh for the true state: it confirms a live watcher and a fresh beacon, or fails loudly.\n'
     printf '●  %s\n' "$fix"
     printf '●%s\n' "$rule"

--- a/bin/fm-watch-session.sh
+++ b/bin/fm-watch-session.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# Home-scoped durable active watcher runner.
+#
+# fm-watch-arm.sh intentionally keeps the watcher as its child. That is good for
+# harness-tracked foreground tasks, but fragile when a harness cannot keep that
+# foreground call alive. This wrapper gives active mode a durable process for the
+# current FM_HOME: it starts a small runner that repeatedly arms the watcher,
+# records the runner pid in state/.watch-session.lock, and can report or stop
+# only that home-scoped runner.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=bin/fm-wake-lib.sh
+. "$SCRIPT_DIR/fm-wake-lib.sh"
+
+WATCH_ARM="$SCRIPT_DIR/fm-watch-arm.sh"
+SESSION_LOCK="$STATE/.watch-session.lock"
+LOG="$STATE/.watch-session.log"
+RUNNER_PATH="$SCRIPT_DIR/fm-watch-session.sh"
+
+usage() {
+  echo "usage: $(basename "$0") [--start|--stop|--status|--foreground|--tmux]" >&2
+}
+
+session_lock_matches_pid() {
+  local pid=$1 lock_home lock_path lock_identity current_identity
+  lock_home=$(cat "$SESSION_LOCK/fm-home" 2>/dev/null || true)
+  lock_path=$(cat "$SESSION_LOCK/runner-path" 2>/dev/null || true)
+  lock_identity=$(cat "$SESSION_LOCK/pid-identity" 2>/dev/null || true)
+  [ "$lock_home" = "$FM_HOME" ] || return 1
+  [ "$lock_path" = "$RUNNER_PATH" ] || return 1
+  [ -n "$lock_identity" ] || return 1
+  current_identity=$(fm_pid_identity "$pid") || return 1
+  [ "$current_identity" = "$lock_identity" ]
+}
+
+session_pid() {
+  cat "$SESSION_LOCK/pid" 2>/dev/null || true
+}
+
+session_running() {
+  local pid
+  pid=$(session_pid)
+  fm_pid_alive "$pid" || return 1
+  session_lock_matches_pid "$pid"
+}
+
+write_session_identity() {
+  local pid=$1
+  printf '%s\n' "$FM_HOME" > "$SESSION_LOCK/fm-home" || true
+  printf '%s\n' "$RUNNER_PATH" > "$SESSION_LOCK/runner-path" || true
+  fm_pid_identity "$pid" > "$SESSION_LOCK/pid-identity" 2>/dev/null || true
+}
+
+status_cmd() {
+  local pid
+  if session_running; then
+    pid=$(session_pid)
+    echo "watch-session: running pid=$pid home=$FM_HOME log=$LOG"
+    exit 0
+  fi
+  echo "watch-session: stopped home=$FM_HOME"
+  exit 1
+}
+
+stop_cmd() {
+  local pid i pgid
+  if ! session_running; then
+    fm_lock_remove_path "$SESSION_LOCK" 2>/dev/null || true
+    echo "watch-session: stopped home=$FM_HOME"
+    return 0
+  fi
+  pid=$(session_pid)
+  kill -TERM "$pid" 2>/dev/null || true
+  pgid=$(ps -p "$pid" -o pgid= 2>/dev/null | tr -d ' ' || true)
+  i=0
+  while [ "$i" -lt 80 ] && fm_pid_alive "$pid"; do
+    if [ "$i" -eq 10 ] && [ "$pgid" = "$pid" ]; then
+      kill -TERM "-$pid" 2>/dev/null || true
+    fi
+    sleep 0.1
+    i=$((i + 1))
+  done
+  if fm_pid_alive "$pid"; then
+    echo "watch-session: FAILED - runner still alive pid=$pid" >&2
+    return 1
+  fi
+  fm_lock_remove_path "$SESSION_LOCK" 2>/dev/null || true
+  echo "watch-session: stopped pid=$pid home=$FM_HOME"
+}
+
+foreground_cmd() {
+  if ! fm_lock_try_acquire "$SESSION_LOCK"; then
+    if [ -n "${FM_LOCK_HELD_PID:-}" ] && fm_pid_alive "$FM_LOCK_HELD_PID"; then
+      echo "watch-session: already running pid=$FM_LOCK_HELD_PID home=$FM_HOME" >&2
+    else
+      echo "watch-session: already running home=$FM_HOME" >&2
+    fi
+    exit 1
+  fi
+  trap 'fm_lock_release "$SESSION_LOCK"; exit 143' TERM INT HUP
+  trap 'fm_lock_release "$SESSION_LOCK"' EXIT
+  write_session_identity "${BASHPID:-$$}"
+  while :; do
+    "$WATCH_ARM" >> "$LOG" 2>&1 || true
+    sleep "${FM_WATCH_SESSION_REARM_DELAY:-1}"
+  done
+}
+
+start_cmd() {
+  local pid i
+  if session_running; then
+    pid=$(session_pid)
+    echo "watch-session: running pid=$pid home=$FM_HOME log=$LOG"
+    return 0
+  fi
+  fm_lock_remove_path "$SESSION_LOCK" 2>/dev/null || true
+  : > "$LOG" || {
+    echo "watch-session: FAILED - cannot write $LOG" >&2
+    return 1
+  }
+  if command -v setsid >/dev/null 2>&1; then
+    setsid "$RUNNER_PATH" --foreground >> "$LOG" 2>&1 < /dev/null &
+  else
+    nohup "$RUNNER_PATH" --foreground >> "$LOG" 2>&1 < /dev/null &
+  fi
+  pid=$!
+  i=0
+  while [ "$i" -lt 80 ]; do
+    if session_running; then
+      pid=$(session_pid)
+      echo "watch-session: started pid=$pid home=$FM_HOME log=$LOG"
+      return 0
+    fi
+    sleep 0.1
+    i=$((i + 1))
+  done
+  echo "watch-session: FAILED - runner did not confirm" >&2
+  return 1
+}
+
+mode=${1:---status}
+case "$mode" in
+  --start|start) start_cmd ;;
+  --stop|stop) stop_cmd ;;
+  --status|status) status_cmd ;;
+  --foreground|foreground) foreground_cmd ;;
+  --tmux)
+    echo "tmux new-window -n fm-watch-$(basename "$FM_HOME") 'cd \"$FM_ROOT\" && FM_HOME=\"$FM_HOME\" bin/fm-watch-session.sh --foreground'"
+    ;;
+  -h|--help|help) usage; exit 0 ;;
+  *) usage; exit 2 ;;
+esac

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,7 +21,8 @@ Optional X mode rides the same check path: bootstrap drops a local `state/x-watc
 
 Routine re-arms go through `bin/fm-watch-arm.sh`, which forks the watcher as a tracked child, verifies it is genuinely alive with a fresh liveness beacon, and prints exactly one honest status line (`started` / `healthy` / `FAILED`, the last exiting non-zero) - never a false `already running` off a dying process.
 Its `--restart` mode signals only the watcher recorded in the current home's `state/.watch.lock`, so restarting one home cannot kill sibling secondmate watchers.
-A pull-based guard (`bin/fm-guard.sh`) warns through supervision tool output if the primary checkout is tangled, or if tasks are in flight and that watcher stops running or queued wakes are waiting to be drained.
+For harnesses where a tracked background call is not durable enough, `bin/fm-watch-session.sh` provides a home-scoped runner that repeatedly arms the normal watcher from a persistent process, reports status from `state/.watch-session.lock`, and stops only the runner recorded for the current `FM_HOME`.
+A pull-based guard (`bin/fm-guard.sh`) warns through supervision tool output if the primary checkout is tangled, queued wakes are waiting to be drained, or tasks are in flight and watcher liveness is not proved by both a fresh beacon and a live `state/.watch.lock` for this same home/path.
 The drain script calls that guard after emptying the queue, which avoids repeating the queued-wakes warning for records it just consumed while still warning on stale watcher liveness.
 It leads with prominent bordered banners for the tangle and no-watcher cases so they cannot be skimmed past.
 
@@ -118,5 +119,5 @@ Kill the first mate session anytime; the next one reconciles and carries on.
 
 ## Development notes
 
-The current watcher reliability work combines always-on bash triage with a durable queue for actionable wakes, a race-proof singleton lock, duplicate self-eviction, drain-time liveness assertion, and a self-verifying tracked-child arm wrapper.
+The current watcher reliability work combines always-on bash triage with a durable queue for actionable wakes, a race-proof singleton lock, duplicate self-eviction, drain-time liveness assertion, a self-verifying tracked-child arm wrapper, and a home-scoped durable active-mode session runner.
 The presence-gated sub-supervisor (`bin/fm-supervise-daemon.sh`) provides walk-away supervision via the `/afk` skill while reusing the same shared wake classifier as the always-on watcher.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -108,6 +108,7 @@ FM_LOCK_STALE_AFTER=2   # seconds before dead-pid lock records can be reclaimed;
 FM_GUARD_GRACE=300      # seconds before guard warnings and arm health checks treat a watcher beacon as stale
 FM_ARM_CONFIRM_TIMEOUT=10   # seconds fm-watch-arm waits to confirm a fresh watcher before reporting FAILED
 FM_WATCHER_STALE_GRACE=300   # defaults to FM_GUARD_GRACE; seconds a live watcher lock may have a stale beacon before re-arm errors
+FM_WATCH_SESSION_REARM_DELAY=1   # seconds the durable watch-session runner waits before re-arming after a watcher exit
 FM_SIGNAL_GRACE=30      # seconds to coalesce nearby status and turn-end signals into one wake
 FM_CAPTAIN_RE='done:|needs-decision:|blocked:|failed:|PR ready|checks green|ready in branch|merged'   # status regex that makes watcher and daemon signal/stale/scan output captain-relevant
 FM_STALE_ESCALATE_SECS=240         # idle seconds before a non-terminal stale pane escalates as a possible wedge

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -11,7 +11,7 @@ Each file also starts with a short header comment.
 | `fm-backlog-handoff.sh`  | Move already-judged in-scope queued backlog items from the main home into a seeded secondmate home                 |
 | `fm-brief.sh`            | Scaffold a ship brief with a worktree-isolation assertion, a report-only scout brief with `--scout`, or a secondmate charter with `--secondmate` |
 | `fm-ensure-agents-md.sh` | Ensure project `AGENTS.md` is the real memory file and `CLAUDE.md` symlinks to it                                   |
-| `fm-guard.sh`            | Warn when the primary checkout is tangled, when queued wakes are pending, or when a stale or missing watcher needs a prominent banner |
+| `fm-guard.sh`            | Warn when the primary checkout is tangled, when queued wakes are pending, or when watcher liveness is not proved by a fresh beacon plus a live matching lock |
 | `fm-home-seed.sh`        | Lease/provision a secondmate home transactionally, clone projects, initialize gates, and maintain `data/secondmates.md` |
 | `fm-spawn.sh`            | Spawn one task, several `id=repo` pairs, or a persistent secondmate with `--secondmate`; ship/scout spawns require an isolated treehouse worktree; secondmate spawns locally sync the home before launch |
 | `fm-project-mode.sh`     | Resolve a project's delivery mode and `+yolo` flag from `data/projects.md`                                          |
@@ -19,6 +19,7 @@ Each file also starts with a short header comment.
 | `fm-review-diff.sh`      | Review a crewmate branch against the authoritative base, with optional `--stat` output                              |
 | `fm-marker-lib.sh`       | Shared from-firstmate request marker and detector sourced by `fm-send.sh`, `fm-brief.sh`, and tests                 |
 | `fm-watch-arm.sh`        | Verified per-home watcher re-arm; reports `started`, `healthy`, or `FAILED`; `--restart` relaunches only this home's watcher |
+| `fm-watch-session.sh`    | Home-scoped durable active watcher runner with `--start`, `--status`, `--stop`, `--foreground`, and `--tmux` helpers |
 | `fm-watch.sh`            | Singleton-safe always-on watcher; absorbs benign wakes in bash, queues and exits only for actionable wakes, and reverts to daemon-owned one-shot behavior while `state/.afk` exists |
 | `fm-supervise-daemon.sh` | Presence-gated sub-supervisor for walk-away (`/afk`) supervision: wraps `fm-watch.sh`, uses the shared wake classifier, self-handles routine wakes in bash, and escalates only captain-relevant events as one verified, batched, single-line digest prefixed with a sentinel marker |
 | `fm-crew-state.sh`       | Print one stable current-state line for a crew by reconciling its matching no-mistakes run-step, even when the pane has closed, with pane and status-log fallback |

--- a/tests/fm-wake-daemon-lifecycle-e2e.test.sh
+++ b/tests/fm-wake-daemon-lifecycle-e2e.test.sh
@@ -32,6 +32,7 @@ if [ -z "${FM_TEST_DAEMON_SOURCED:-}" ]; then
 fi
 
 TMP_ROOT=$(fm_test_tmproot fm-wake-daemon-e2e)
+trap fm_test_watch_cleanup_exit EXIT
 
 # Run the daemon-managed watcher once: under the supervise-daemon (away mode) the
 # watcher is one-shot - it exits with a single reason line on EVERY wake and the

--- a/tests/fm-wake-queue.test.sh
+++ b/tests/fm-wake-queue.test.sh
@@ -15,6 +15,7 @@ WATCH="$ROOT/bin/fm-watch.sh"
 DRAIN="$ROOT/bin/fm-wake-drain.sh"
 
 TMP_ROOT=$(fm_test_tmproot fm-wake-tests)
+trap fm_test_watch_cleanup_exit EXIT
 
 
 test_concurrent_append_and_drain() {
@@ -173,7 +174,7 @@ test_drain_dedupes_obvious_duplicates() {
 # when work is in flight with no live watcher, and stay silent right after a
 # normal fire (a fresh beacon within grace), so it never false-alarms every wake.
 test_drain_asserts_watcher_liveness() {
-  local dir state err
+  local dir state err peer identity
   dir=$(make_case drain-liveness)
   state="$dir/state"
   err="$dir/drain.err"
@@ -183,10 +184,26 @@ test_drain_asserts_watcher_liveness() {
   : > "$err"
   touch "$state/.last-watcher-beat"
   FM_STATE_OVERRIDE="$state" FM_GUARD_GRACE=300 "$DRAIN" >/dev/null 2> "$err" || fail "drain failed with a fresh beacon"
-  if grep -F 'WATCHER DOWN' "$err" >/dev/null; then
-    fail "drain false-alarmed right after a normal fire (fresh beacon within grace)"
-  fi
-  pass "drain asserts watcher liveness: warns on a lapse, stays silent right after a fire"
+  grep -F 'fresh beacon but no live watcher lock' "$err" >/dev/null || fail "drain did not warn for a fresh beacon without a live watcher lock"
+
+  : > "$err"
+  sleep 300 &
+  peer=$!
+  identity=$(FM_HOME="$dir" FM_STATE_OVERRIDE="$state" bash -c '. "$1"; fm_pid_identity "$2"' _ "$ROOT/bin/fm-wake-lib.sh" "$peer") || fail "could not identify drain peer pid"
+  mkdir "$state/.watch.lock"
+  printf '%s\n' "$peer" > "$state/.watch.lock/pid"
+  printf '%s\n' "$dir" > "$state/.watch.lock/fm-home"
+  printf '%s\n' "$WATCH" > "$state/.watch.lock/watcher-path"
+  printf '%s\n' "$identity" > "$state/.watch.lock/pid-identity"
+  FM_HOME="$dir" FM_STATE_OVERRIDE="$state" FM_GUARD_GRACE=300 "$DRAIN" >/dev/null 2> "$err" || {
+    kill "$peer" 2>/dev/null || true
+    wait "$peer" 2>/dev/null || true
+    fail "drain failed with a live matching watcher"
+  }
+  [ ! -s "$err" ] || fail "drain warned with a fresh beacon and live matching watcher lock: $(cat "$err")"
+  kill "$peer" 2>/dev/null || true
+  wait "$peer" 2>/dev/null || true
+  pass "drain asserts watcher liveness: warns on missing/fresh-only watcher, stays silent with a live matching lock"
 }
 
 test_concurrent_append_and_drain

--- a/tests/fm-watch-session.test.sh
+++ b/tests/fm-watch-session.test.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# tests/fm-watch-session.test.sh - durable active watcher runner wrapper.
+set -u
+
+# shellcheck source=tests/wake-helpers.sh
+. "$(dirname "${BASH_SOURCE[0]}")/wake-helpers.sh"
+
+SESSION="$ROOT/bin/fm-watch-session.sh"
+WATCH_ARM="$ROOT/bin/fm-watch-arm.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-watch-session-tests)
+trap fm_test_watch_cleanup_exit EXIT
+
+test_status_reports_missing_session() {
+  local dir state out status
+  dir=$(make_case status-missing)
+  state="$dir/state"
+  out="$dir/status.out"
+  status=0
+  FM_HOME="$dir" FM_STATE_OVERRIDE="$state" "$SESSION" --status > "$out" || status=$?
+  [ "$status" -ne 0 ] || fail "status exited zero when no watcher session existed"
+  grep -F 'watch-session: stopped' "$out" >/dev/null || fail "status did not report stopped"
+  pass "watch-session status reports stopped for an empty home"
+}
+
+test_start_status_stop_are_home_scoped() {
+  local dir state other other_state fakebin out start_pid other_pid lock_pid i
+  dir=$(make_case home-scoped)
+  state="$dir/state"
+  other=$(make_case other-home)
+  other_state="$other/state"
+  fakebin="$dir/fakebin"
+  out="$dir/session.out"
+
+  PATH="$fakebin:$PATH" FM_HOME="$other" FM_STATE_OVERRIDE="$other_state" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH_ARM" > "$other/watch-arm.out" &
+  other_pid=$!
+  i=0
+  while [ "$i" -lt 80 ]; do
+    [ -s "$other_state/.watch.lock/pid" ] && [ -e "$other_state/.last-watcher-beat" ] && break
+    sleep 0.1
+    i=$((i + 1))
+  done
+  [ -s "$other_state/.watch.lock/pid" ] && [ -e "$other_state/.last-watcher-beat" ] || fail "other home watcher did not start"
+  start_pid=$(cat "$other_state/.watch.lock/pid")
+
+  PATH="$fakebin:$PATH" FM_HOME="$dir" FM_STATE_OVERRIDE="$state" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$SESSION" --start > "$out" || fail "watch-session start failed: $(cat "$out")"
+  grep -F 'watch-session: started' "$out" >/dev/null || fail "start did not report a started session"
+  lock_pid=$(cat "$state/.watch-session.lock/pid" 2>/dev/null || true)
+  [ -n "$lock_pid" ] || fail "session did not record its runner pid"
+  kill -0 "$lock_pid" 2>/dev/null || fail "recorded session runner is not alive"
+
+  : > "$out"
+  PATH="$fakebin:$PATH" FM_HOME="$dir" FM_STATE_OVERRIDE="$state" "$SESSION" --status > "$out" || fail "status failed for running session"
+  grep -F "watch-session: running pid=$lock_pid" "$out" >/dev/null || fail "status did not report the running session pid"
+
+  : > "$out"
+  PATH="$fakebin:$PATH" FM_HOME="$dir" FM_STATE_OVERRIDE="$state" "$SESSION" --stop > "$out" || fail "stop failed for running session"
+  grep -F "watch-session: stopped pid=$lock_pid" "$out" >/dev/null || fail "stop did not report the stopped session pid"
+  i=0
+  while [ "$i" -lt 80 ] && kill -0 "$lock_pid" 2>/dev/null; do
+    sleep 0.1
+    i=$((i + 1))
+  done
+  ! kill -0 "$lock_pid" 2>/dev/null || fail "session runner remained alive after stop"
+
+  kill -0 "$start_pid" 2>/dev/null || fail "stopping this home killed another home's watcher"
+  kill "$other_pid" "$start_pid" 2>/dev/null || true
+  wait "$other_pid" 2>/dev/null || true
+  pass "watch-session starts, reports, and stops only the current FM_HOME"
+}
+
+test_source_contains_no_broad_pkill() {
+  ! grep -Eq 'pkill[[:space:]].*fm-watch|pkill[[:space:]]+-f' "$SESSION" || fail "watch-session uses broad pkill"
+  pass "watch-session does not use broad pkill"
+}
+
+test_status_reports_missing_session
+test_start_status_stop_are_home_scoped
+test_source_contains_no_broad_pkill

--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -14,6 +14,7 @@ DRAIN="$ROOT/bin/fm-wake-drain.sh"
 LIB="$ROOT/bin/fm-wake-lib.sh"
 
 TMP_ROOT=$(fm_test_tmproot fm-watcher-lock-tests)
+trap fm_test_watch_cleanup_exit EXIT
 
 
 test_singleton_start() {
@@ -89,7 +90,7 @@ test_guard_warnings() {
   #       warning follows it, and the guidance is re-arm-after-drain (never the
   #       old conflicting "restart NOW first").
   #   (2) a fresh watcher and an empty queue: total silence.
-  local dir state err first banner_line queue_line
+  local dir state err first banner_line queue_line peer identity
   dir=$(make_case guard)
   state="$dir/state"
   err="$dir/guard.err"
@@ -122,12 +123,91 @@ test_guard_warnings() {
   state="$dir/state"
   err="$dir/guard.err"
   printf 'project=x\n' > "$state/task.meta"
+  sleep 300 &
+  peer=$!
+  identity=$(FM_HOME="$dir" FM_STATE_OVERRIDE="$state" bash -c '. "$1"; fm_pid_identity "$2"' _ "$LIB" "$peer") || fail "could not identify guard peer pid"
+  mkdir "$state/.watch.lock"
+  printf '%s\n' "$peer" > "$state/.watch.lock/pid"
+  printf '%s\n' "$dir" > "$state/.watch.lock/fm-home"
+  printf '%s\n' "$WATCH" > "$state/.watch.lock/watcher-path"
+  printf '%s\n' "$identity" > "$state/.watch.lock/pid-identity"
   touch "$state/.last-watcher-beat"
   # Non-git FM_ROOT keeps the worktree-tangle check inert so "fresh watcher ->
   # total silence" stays a pure assertion about watcher state.
-  FM_ROOT_OVERRIDE="$dir" FM_STATE_OVERRIDE="$state" FM_GUARD_GRACE=300 "$ROOT/bin/fm-guard.sh" 2> "$err" >/dev/null || fail "guard failed"
-  [ ! -s "$err" ] || fail "guard warned with a fresh watcher and no queued wakes: $(cat "$err")"
-  pass "guard banner leads when down with pending wakes (re-arm-after-drain) and stays silent when fresh"
+  FM_ROOT_OVERRIDE="$dir" FM_HOME="$dir" FM_STATE_OVERRIDE="$state" FM_GUARD_GRACE=300 "$ROOT/bin/fm-guard.sh" 2> "$err" >/dev/null || {
+    kill "$peer" 2>/dev/null || true
+    wait "$peer" 2>/dev/null || true
+    fail "guard failed"
+  }
+  [ ! -s "$err" ] || fail "guard warned with a fresh live watcher and no queued wakes: $(cat "$err")"
+  kill "$peer" 2>/dev/null || true
+  wait "$peer" 2>/dev/null || true
+  pass "guard banner leads when down with pending wakes (re-arm-after-drain) and stays silent when fresh+live"
+}
+
+test_guard_requires_live_matching_watch_lock() {
+  local dir state err peer identity
+
+  # A fresh beacon alone is not proof: the previous watcher may have exited
+  # cleanly after writing a wake, leaving a fresh .last-watcher-beat behind.
+  dir=$(make_case guard-fresh-no-lock)
+  state="$dir/state"
+  err="$dir/guard.err"
+  printf 'window=test:fm-x\nkind=ship\n' > "$state/x.meta"
+  touch "$state/.last-watcher-beat"
+  FM_ROOT_OVERRIDE="$dir" FM_HOME="$dir" FM_STATE_OVERRIDE="$state" FM_GUARD_GRACE=300 "$ROOT/bin/fm-guard.sh" 2> "$err" >/dev/null || fail "guard failed with no lock"
+  grep -F 'WATCHER DOWN - SUPERVISION IS OFF' "$err" >/dev/null || fail "guard stayed silent with fresh beacon but no watcher lock"
+  grep -F 'fresh beacon but no live watcher lock' "$err" >/dev/null || fail "guard did not explain the false-fresh beacon"
+
+  # A live pid is still not proof unless the lock identifies THIS home and the
+  # current watcher script. This protects sibling homes and reused pids.
+  dir=$(make_case guard-live-wrong-home)
+  state="$dir/state"
+  err="$dir/guard.err"
+  printf 'window=test:fm-y\nkind=ship\n' > "$state/y.meta"
+  sleep 300 &
+  peer=$!
+  identity=$(FM_HOME="$dir" FM_STATE_OVERRIDE="$state" bash -c '. "$1"; fm_pid_identity "$2"' _ "$LIB" "$peer") || fail "could not identify peer pid"
+  mkdir "$state/.watch.lock"
+  printf '%s\n' "$peer" > "$state/.watch.lock/pid"
+  printf '%s\n' "$dir/other-home" > "$state/.watch.lock/fm-home"
+  printf '%s\n' "$WATCH" > "$state/.watch.lock/watcher-path"
+  printf '%s\n' "$identity" > "$state/.watch.lock/pid-identity"
+  touch "$state/.last-watcher-beat"
+  FM_ROOT_OVERRIDE="$dir" FM_HOME="$dir" FM_STATE_OVERRIDE="$state" FM_GUARD_GRACE=300 "$ROOT/bin/fm-guard.sh" 2> "$err" >/dev/null || {
+    kill "$peer" 2>/dev/null || true
+    wait "$peer" 2>/dev/null || true
+    fail "guard failed with mismatched lock"
+  }
+  grep -F 'WATCHER DOWN - SUPERVISION IS OFF' "$err" >/dev/null || fail "guard stayed silent for a lock from another home"
+  grep -F 'watcher lock does not name a live watcher for this home' "$err" >/dev/null || fail "guard did not explain the mismatched lock"
+  kill "$peer" 2>/dev/null || true
+  wait "$peer" 2>/dev/null || true
+
+  # Silence requires all three facts: live pid, matching identity/home/path, and
+  # fresh beacon.
+  dir=$(make_case guard-live-matching-home)
+  state="$dir/state"
+  err="$dir/guard.err"
+  printf 'window=test:fm-z\nkind=ship\n' > "$state/z.meta"
+  sleep 300 &
+  peer=$!
+  identity=$(FM_HOME="$dir" FM_STATE_OVERRIDE="$state" bash -c '. "$1"; fm_pid_identity "$2"' _ "$LIB" "$peer") || fail "could not identify matching peer pid"
+  mkdir "$state/.watch.lock"
+  printf '%s\n' "$peer" > "$state/.watch.lock/pid"
+  printf '%s\n' "$dir" > "$state/.watch.lock/fm-home"
+  printf '%s\n' "$WATCH" > "$state/.watch.lock/watcher-path"
+  printf '%s\n' "$identity" > "$state/.watch.lock/pid-identity"
+  touch "$state/.last-watcher-beat"
+  FM_ROOT_OVERRIDE="$dir" FM_HOME="$dir" FM_STATE_OVERRIDE="$state" FM_GUARD_GRACE=300 "$ROOT/bin/fm-guard.sh" 2> "$err" >/dev/null || {
+    kill "$peer" 2>/dev/null || true
+    wait "$peer" 2>/dev/null || true
+    fail "guard failed with matching lock"
+  }
+  [ ! -s "$err" ] || fail "guard warned with a live matching watcher lock and fresh beacon: $(cat "$err")"
+  kill "$peer" 2>/dev/null || true
+  wait "$peer" 2>/dev/null || true
+  pass "guard requires a fresh beacon plus a live matching watcher lock"
 }
 
 test_lock_single_winner_under_concurrency() {
@@ -611,6 +691,7 @@ test_singleton_start
 test_stale_watch_lock_reclaimed
 test_live_stale_watch_lock_is_actionable
 test_guard_warnings
+test_guard_requires_live_matching_watch_lock
 test_lock_single_winner_under_concurrency
 test_lock_steals_dead_pid_lock
 test_lock_stale_steal_single_winner_under_concurrency

--- a/tests/wake-helpers.sh
+++ b/tests/wake-helpers.sh
@@ -227,3 +227,49 @@ dead_pid() {
   done
   printf '%s\n' "$p"
 }
+
+fm_test_cleanup_watch_processes() {
+  local d f pid pgid
+  for d in "${FM_TEST_CLEANUP_DIRS[@]:-}"; do
+    [ -n "$d" ] && [ -d "$d" ] || continue
+    while IFS= read -r f; do
+      pid=$(cat "$f" 2>/dev/null || true)
+      case "$pid" in
+        ''|*[!0-9]*) continue ;;
+      esac
+      [ "$pid" != "$$" ] || continue
+      [ "$pid" != "${BASHPID:-$$}" ] || continue
+      kill -TERM "$pid" 2>/dev/null || true
+    done <<EOF
+$(find -L "$d" -path '*/state/.watch*.lock/pid' -type f 2>/dev/null)
+EOF
+  done
+  sleep 0.2
+  for d in "${FM_TEST_CLEANUP_DIRS[@]:-}"; do
+    [ -n "$d" ] && [ -d "$d" ] || continue
+    while IFS= read -r f; do
+      pid=$(cat "$f" 2>/dev/null || true)
+      case "$pid" in
+        ''|*[!0-9]*) continue ;;
+      esac
+      [ "$pid" != "$$" ] || continue
+      [ "$pid" != "${BASHPID:-$$}" ] || continue
+      if kill -0 "$pid" 2>/dev/null; then
+        pgid=$(ps -p "$pid" -o pgid= 2>/dev/null | tr -d ' ' || true)
+        kill -KILL "$pid" 2>/dev/null || true
+        case "$pgid" in
+          "$pid") kill -KILL "-$pgid" 2>/dev/null || true ;;
+        esac
+      fi
+    done <<EOF
+$(find -L "$d" -path '*/state/.watch*.lock/pid' -type f 2>/dev/null)
+EOF
+  done
+}
+
+fm_test_watch_cleanup_exit() {
+  local rc=$?
+  fm_test_cleanup_watch_processes
+  fm_test_cleanup
+  exit "$rc"
+}


### PR DESCRIPTION
## Summary

Active-mode supervision no longer treats a fresh watcher beacon as proof by itself. The guard now requires a live watcher lock for the same `FM_HOME` and watcher path, so a one-shot watcher that exited after writing a wake cannot leave firstmate falsely quiet.

This also adds a home-scoped durable watcher session runner for harnesses where foreground background calls are not reliable. The runner has `--start`, `--status`, `--stop`, `--foreground`, and `--tmux` modes, records only the current home in `state/.watch-session.lock`, and avoids broad process killing.

## Validation

- `bash tests/fm-watcher-lock.test.sh`
- `bash tests/fm-wake-queue.test.sh`
- `bash tests/fm-wake-daemon-lifecycle-e2e.test.sh`
- `bash tests/fm-watch-session.test.sh`
- `bash -n bin/fm-guard.sh bin/fm-watch-session.sh tests/fm-wake-daemon-lifecycle-e2e.test.sh tests/fm-wake-queue.test.sh tests/fm-watcher-lock.test.sh tests/fm-watch-session.test.sh tests/wake-helpers.sh`
- `for test_script in tests/*.test.sh; do echo "== $test_script"; bash "$test_script" || exit $?; done`

Not run: `shellcheck bin/*.sh tests/*.sh` because `shellcheck` is not installed in this environment.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
