### PR TITLE
feat(bin): orchestrator dashboard layout with read-only worker watch panes

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Agent-only reference skills live under `.agents/skills/` and are loaded by first
 - [docs/architecture.md](docs/architecture.md) - how the crew, supervision, worktrees, secondmates, and project modes work.
 - [docs/configuration.md](docs/configuration.md) - environment variables, `FM_HOME`, optional X mode, the files you set, and harness support.
 - [docs/scripts.md](docs/scripts.md) - the `bin/` toolbelt reference.
+- [docs/orchestrator-layout.md](docs/orchestrator-layout.md) - the terminal dashboard: a command column plus three swappable worker watch panes.
 - [`AGENTS.md`](AGENTS.md) - firstmate's full operating manual for the orchestrator agent.
 - [CONTRIBUTING.md](CONTRIBUTING.md) - how to contribute, including the dev/test commands.
 

--- a/bin/fm-layout-lib.sh
+++ b/bin/fm-layout-lib.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# fm-layout-lib.sh — shared worker-discovery primitives for the orchestrator
+# dashboard layout (bin/fm-layout.sh, bin/fm-watch-pane.sh, bin/fm-layout-pick.sh).
+#
+# ONE source of truth for: where a firstmate home's state lives, which crewmate
+# windows are live "workers" worth watching, the terse repo/label a worker shows
+# in the summary and watch headers, and the per-slot assignment files. Decoupled
+# from any tmux arrangement so the discovery logic is unit-testable with a fake
+# `tmux list-windows` and fixture state/*.meta, no real terminal required.
+#
+# A "worker" is any task this home recorded in state/<id>.meta whose tmux window
+# is currently live. The orchestrator's own pane has no meta, so it is never a
+# worker. Liveness is read from `tmux list-windows` (stubbable in tests), so a
+# stale meta whose window is gone never appears as an assignable worker.
+#
+# All functions are `set -u`/`set -e` safe so they can be sourced into either an
+# interactive arrange or a long-lived watch loop.
+
+# Resolve this home's state dir the same way every other fm-*.sh does, honoring
+# FM_STATE_OVERRIDE / FM_HOME / FM_ROOT_OVERRIDE. The caller may pre-export
+# FM_LAYOUT_STATE to pin it (the watch panes do this so they read the same home
+# the arrange command used regardless of the pane's inherited environment).
+fm_layout_state() {
+  if [ -n "${FM_LAYOUT_STATE:-}" ]; then
+    printf '%s\n' "$FM_LAYOUT_STATE"
+    return 0
+  fi
+  local script_dir root home
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  root="${FM_ROOT_OVERRIDE:-$(cd "$script_dir/.." && pwd)}"
+  home="${FM_HOME:-${FM_ROOT_OVERRIDE:-$root}}"
+  printf '%s\n' "${FM_STATE_OVERRIDE:-$home/state}"
+}
+
+# fm_layout_label <id>: a terse, deterministic feature label for a task id by
+# dropping the random suffix (the trailing "-<2-3 alnum>") and turning the rest
+# into spaced words. e.g. "scrub-pajamas-refactor-y8" -> "scrub pajamas refactor".
+# Truncated to FM_LAYOUT_LABEL_MAX (default 30) so the summary never long-wraps.
+fm_layout_label() {
+  local id=$1 max=${FM_LAYOUT_LABEL_MAX:-30} base
+  base=$(printf '%s' "$id" | sed -E 's/-[a-z0-9]{2,3}$//')
+  base=${base//-/ }
+  if [ "${#base}" -gt "$max" ]; then
+    base="${base:0:$((max - 1))}…"
+  fi
+  printf '%s' "$base"
+}
+
+# fm_layout_live_windows: print "session:window" for every live tmux window,
+# one per line. Isolated behind a function so tests can stub `tmux`.
+fm_layout_live_windows() {
+  tmux list-windows -a -F '#{session_name}:#{window_name}' 2>/dev/null || true
+}
+
+# fm_layout_meta_field <meta-file> <key>: echo the last value of key= in a meta
+# file (last wins, mirroring fm-peek/fm-send), empty if absent.
+fm_layout_meta_field() {
+  grep "^$2=" "$1" 2>/dev/null | tail -1 | cut -d= -f2- || true
+}
+
+# fm_layout_workers: print every live worker as a TAB-separated record
+#   <session:window>\t<repo>\t<label>
+# sorted by window for stable ordering. A worker is a state/<id>.meta whose
+# window= is currently live. repo is the basename of project=; label comes from
+# fm_layout_label. Secondmate homes (kind=secondmate) are persistent supervisors,
+# not project workers, so they are skipped unless FM_LAYOUT_INCLUDE_SECONDMATES=1.
+fm_layout_workers() {
+  local state live meta id window repo project kind
+  state=$(fm_layout_state)
+  [ -d "$state" ] || return 0
+  live=$(fm_layout_live_windows)
+  for meta in "$state"/*.meta; do
+    [ -e "$meta" ] || continue
+    id=$(basename "$meta" .meta)
+    window=$(fm_layout_meta_field "$meta" window)
+    [ -n "$window" ] || continue
+    # Only live windows are assignable workers.
+    printf '%s\n' "$live" | grep -Fxq "$window" || continue
+    kind=$(fm_layout_meta_field "$meta" kind)
+    if [ "$kind" = secondmate ] && [ "${FM_LAYOUT_INCLUDE_SECONDMATES:-0}" != 1 ]; then
+      continue
+    fi
+    project=$(fm_layout_meta_field "$meta" project)
+    if [ -n "$project" ]; then repo=$(basename "$project"); else repo=$id; fi
+    printf '%s\t%s\t%s\n' "$window" "$repo" "$(fm_layout_label "$id")"
+  done | sort
+}
+
+# fm_layout_slot_file <state> <slot>: path of a slot's assignment file. Slot is
+# 1..3 or the literal "summary". Lives under state/ (gitignored runtime), in the
+# .layout-* namespace the watcher never touches.
+fm_layout_slot_file() {
+  printf '%s/.layout-slot-%s\n' "$1" "$2"
+}

--- a/bin/fm-layout-pick.sh
+++ b/bin/fm-layout-pick.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# fm-layout-pick.sh — interactive keyboard picker for reassigning a dashboard
+# watch slot. Meant to run inside `tmux display-popup -E` (the popup gives it a
+# TTY), but it works in any terminal too. This is the RELIABLE baseline selector:
+# plain numbered prompts, no mouse, no tmux menu plumbing.
+#
+#   fm-layout-pick.sh [slot]   slot 1|2|3; if omitted, it asks which slot first.
+#
+# It only reads worker discovery and calls `fm-layout.sh assign`; it never touches
+# a worker pane. Choosing 0 clears the slot.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LAYOUT="$SCRIPT_DIR/fm-layout.sh"
+
+slot=${1:-}
+if [ -z "$slot" ]; then
+  printf 'Reassign which watch slot? [1-3]: '
+  read -r slot || exit 0
+fi
+case "$slot" in
+  1|2|3) ;;
+  *) echo "invalid slot '$slot' (expected 1, 2, or 3)"; sleep 1.2; exit 0 ;;
+esac
+
+# Snapshot live workers: idx<TAB>window<TAB>repo<TAB>label.
+mapfile -t WORKERS < <("$LAYOUT" workers)
+
+echo "== assign watch slot $slot =="
+if [ "${#WORKERS[@]}" -eq 0 ]; then
+  echo "no active workers to show right now."
+  echo "(0 clears the slot)"
+fi
+
+for row in "${WORKERS[@]}"; do
+  IFS=$'\t' read -r idx win repo label <<<"$row"
+  printf '  %s) %s - %s  (%s)\n' "$idx" "$repo" "$label" "$win"
+done
+echo "  0) clear this slot"
+printf 'choice for slot %s: ' "$slot"
+read -r choice || exit 0
+
+if [ "$choice" = 0 ]; then
+  "$LAYOUT" assign "$slot" -
+  sleep 0.8
+  exit 0
+fi
+
+for row in "${WORKERS[@]}"; do
+  IFS=$'\t' read -r idx win repo label <<<"$row"
+  if [ "$choice" = "$idx" ]; then
+    "$LAYOUT" assign "$slot" "$win"
+    sleep 0.8
+    exit 0
+  fi
+done
+
+echo "no worker numbered '$choice'."
+sleep 1.2

--- a/bin/fm-layout-pick.sh
+++ b/bin/fm-layout-pick.sh
@@ -24,7 +24,10 @@ case "$slot" in
 esac
 
 # Snapshot live workers: idx<TAB>window<TAB>repo<TAB>label.
-mapfile -t WORKERS < <("$LAYOUT" workers)
+WORKERS=()
+while IFS= read -r line; do
+  WORKERS+=("$line")
+done < <("$LAYOUT" workers)
 
 echo "== assign watch slot $slot =="
 if [ "${#WORKERS[@]}" -eq 0 ]; then

--- a/bin/fm-layout.sh
+++ b/bin/fm-layout.sh
@@ -301,7 +301,7 @@ usage() {
 # ---- dispatch --------------------------------------------------------------
 
 cmd=${1:-arrange}
-[ $# -gt 0 ] && shift || true
+if [ $# -gt 0 ]; then shift; fi
 case "$cmd" in
   arrange) cmd_arrange "$@" ;;
   workers) cmd_workers ;;

--- a/bin/fm-layout.sh
+++ b/bin/fm-layout.sh
@@ -1,0 +1,316 @@
+#!/usr/bin/env bash
+# fm-layout.sh — arrange the firstmate orchestrator window into a captain
+# dashboard: a left command column (top 2/3 orchestrator chat, bottom 1/3 a terse
+# active-worker summary) taking 1/3 width, and a right 2/3 column split into three
+# stacked worker watch slots. The watch slots are READ-ONLY mirrors of live worker
+# windows (capture-pane loops, bin/fm-watch-pane.sh); workers keep running in their
+# own windows untouched, so nothing here ever moves, kills, or obscures real work.
+#
+# Safe to re-run: arrange rebuilds only its own viewer panes (those tagged
+# @fm_role=slot:* / summary), never the orchestrator pane, never a worker, and
+# never panes it does not recognize (it refuses a window holding unexpected panes
+# unless --force). Slot assignments survive a rebuild when their worker is still
+# live. The orchestrator pane stays the focused, fully usable command pane.
+#
+# Worker discovery is delegated to bin/fm-layout-lib.sh, so "which workers exist"
+# is identical across the summary pane, the watch panes, and the picker.
+#
+# Subcommands:
+#   arrange [--window <id>] [--force]   build/refresh the dashboard (default)
+#   workers                             print live workers as idx<TAB>window<TAB>repo<TAB>label
+#   slots                               print the three slot assignments
+#   assign <1|2|3> <window|->            assign a worker to a slot (- clears it)
+#   pick [1|2|3]                        open the interactive picker popup
+#   mouse-pick -p <pane> -c <client>    right-click handler (resolves slot from pane)
+#   bind [--mouse]                      install opt-in runtime keybindings
+#   unbind                              remove them
+#
+# Keybindings are runtime-only (tmux bind-key / set, never ~/.tmux.conf) and
+# opt-in via `bind`. See docs/orchestrator-layout.md for the picker UX, the
+# right-click caveats, and how to undo everything.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+export FM_LAYOUT_STATE="$STATE"
+BIN="$SCRIPT_DIR"
+
+# shellcheck source=bin/fm-layout-lib.sh
+. "$SCRIPT_DIR/fm-layout-lib.sh"
+
+# Opt-in prefix keys (capitals, not default tmux bindings); overridable so a
+# captain whose config already uses them can pick others.
+KEY_ARRANGE="${FM_LAYOUT_KEY_ARRANGE:-O}"
+KEY_PICK="${FM_LAYOUT_KEY_PICK:-P}"
+
+die() { echo "fm-layout: $*" >&2; exit 1; }
+
+require_tmux() {
+  command -v tmux >/dev/null 2>&1 || die "tmux not found; this is a tmux layout tool"
+  [ -n "${TMUX:-}" ] || [ -n "${FM_LAYOUT_ALLOW_NO_TMUX:-}" ] \
+    || die "not inside a tmux session; run this from your firstmate terminal"
+}
+
+# ---- worker / slot helpers -------------------------------------------------
+
+# Print live workers with a 1-based index for the picker and tests.
+cmd_workers() {
+  local i=0 line
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    i=$((i + 1))
+    printf '%d\t%s\n' "$i" "$line"
+  done <<EOF
+$(fm_layout_workers)
+EOF
+}
+
+# Echo the TSV record (window\trepo\tlabel) of a live worker by its window, or
+# empty if it is not a live worker.
+worker_record() {  # <window>
+  local want=$1 line win
+  while IFS= read -r line; do
+    win=${line%%	*}
+    [ "$win" = "$want" ] && { printf '%s' "$line"; return 0; }
+  done <<EOF
+$(fm_layout_workers)
+EOF
+  return 0
+}
+
+cmd_assign() {  # <slot> <window|->
+  [ $# -eq 2 ] || die "usage: fm-layout.sh assign <1|2|3> <window|->"
+  local slot=$1 target=$2 file rec
+  case "$slot" in 1|2|3) ;; *) die "slot must be 1, 2, or 3" ;; esac
+  file=$(fm_layout_slot_file "$STATE" "$slot")
+  if [ "$target" = "-" ] || [ -z "$target" ]; then
+    rm -f "$file"
+    echo "slot $slot cleared"
+    return 0
+  fi
+  rec=$(worker_record "$target")
+  [ -n "$rec" ] || die "'$target' is not a live worker (see: fm-layout.sh workers)"
+  printf '%s\n' "$rec" > "$file"
+  echo "slot $slot -> $target"
+}
+
+cmd_slots() {
+  local slot file line
+  for slot in 1 2 3; do
+    file=$(fm_layout_slot_file "$STATE" "$slot")
+    if [ -f "$file" ]; then line=$(cat "$file"); else line=""; fi
+    printf '%s\t%s\n' "$slot" "$line"
+  done
+}
+
+# Fill slot files: keep existing assignments whose worker is still live, then
+# fill empty slots from live workers not already shown. Never spawns work; an
+# empty slot just stays empty when there are fewer than three live workers.
+autofill_slots() {
+  local workers slot file win assigned=" " line
+  workers=$(fm_layout_workers)
+  # Drop stale assignments (worker window no longer live) and collect kept ones.
+  for slot in 1 2 3; do
+    file=$(fm_layout_slot_file "$STATE" "$slot")
+    [ -f "$file" ] || continue
+    win=$(head -1 "$file" | cut -f1)
+    if printf '%s\n' "$workers" | cut -f1 | grep -Fxq "$win"; then
+      assigned="$assigned$win "
+    else
+      rm -f "$file"
+    fi
+  done
+  # Fill empties from unassigned live workers, in discovery order.
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    win=${line%%	*}
+    case "$assigned" in *" $win "*) continue ;; esac
+    for slot in 1 2 3; do
+      file=$(fm_layout_slot_file "$STATE" "$slot")
+      [ -f "$file" ] && continue
+      printf '%s\n' "$line" > "$file"
+      assigned="$assigned$win "
+      break
+    done
+  done <<EOF
+$workers
+EOF
+}
+
+# ---- arrange ---------------------------------------------------------------
+
+viewer_cmd() {  # <slot|summary> -> shell command string for split-window
+  printf 'FM_LAYOUT_STATE=%q exec %q %q' "$STATE" "$BIN/fm-watch-pane.sh" "$1"
+}
+
+cmd_arrange() {
+  require_tmux
+  local win="" force=0
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --window) win=$2; shift 2 ;;
+      --force) force=1; shift ;;
+      *) die "arrange: unknown arg '$1'" ;;
+    esac
+  done
+  [ -n "$win" ] || win=$(tmux display-message -p '#{window_id}') \
+    || die "could not resolve the current tmux window"
+
+  # Refuse to restructure a worker window (named fm-*); only the orchestrator
+  # window is ours to arrange.
+  local wname
+  wname=$(tmux display-message -p -t "$win" '#{window_name}' 2>/dev/null) \
+    || die "window '$win' not found"
+  case "$wname" in
+    fm-*) [ "$force" -eq 1 ] || die "'$wname' looks like a worker window; refusing to arrange it (pass --force to override)" ;;
+  esac
+
+  # Identify the orchestrator pane: a previously-tagged one, else the active pane.
+  local orch
+  orch=$(tmux list-panes -t "$win" -F '#{pane_id} #{@fm_role}' \
+    | awk '$2=="orchestrator"{print $1; exit}')
+  [ -n "$orch" ] || orch=$(tmux display-message -p -t "$win" '#{pane_id}')
+
+  # Tear down only our own prior viewer panes; never the orchestrator or anything
+  # we do not recognize.
+  local pid role
+  while read -r pid role; do
+    [ "$pid" = "$orch" ] && continue
+    case "$role" in
+      slot:*|summary) tmux kill-pane -t "$pid" 2>/dev/null || true ;;
+    esac
+  done < <(tmux list-panes -t "$win" -F '#{pane_id} #{@fm_role}')
+
+  # After clearing our viewers, only the orchestrator should remain. Unknown
+  # leftover panes are not destroyed without an explicit --force.
+  local remaining
+  remaining=$(tmux list-panes -t "$win" -F '#{pane_id}' | grep -c .)
+  if [ "$remaining" -ne 1 ]; then
+    if [ "$force" -eq 1 ]; then
+      tmux list-panes -t "$win" -F '#{pane_id}' | while read -r pid; do
+        [ "$pid" = "$orch" ] || tmux kill-pane -t "$pid" 2>/dev/null || true
+      done
+    else
+      die "window has $((remaining - 1)) unexpected pane(s) besides the command pane; close them or pass --force"
+    fi
+  fi
+
+  # Pre-populate slot assignments so the first paint shows workers immediately.
+  autofill_slots
+
+  local height third slot1 slot2 slot3 summary
+  height=$(tmux display-message -p -t "$win" '#{window_height}')
+  case "$height" in ''|*[!0-9]*) height=24 ;; esac
+  third=$((height / 3))
+  [ "$third" -ge 1 ] || third=1
+
+  # Right 2/3 column, three stacked watch slots.
+  slot1=$(tmux split-window -h -t "$orch" -l 66% -d -P -F '#{pane_id}' "$(viewer_cmd 1)")
+  slot2=$(tmux split-window -v -t "$slot1" -d -P -F '#{pane_id}' "$(viewer_cmd 2)")
+  slot3=$(tmux split-window -v -t "$slot2" -d -P -F '#{pane_id}' "$(viewer_cmd 3)")
+  tmux resize-pane -t "$slot1" -y "$third" 2>/dev/null || true
+  tmux resize-pane -t "$slot2" -y "$third" 2>/dev/null || true
+
+  # Left column: orchestrator keeps the top 2/3, summary takes the bottom 1/3.
+  summary=$(tmux split-window -v -t "$orch" -l 33% -d -P -F '#{pane_id}' "$(viewer_cmd summary)")
+
+  # Tag roles so re-runs and the mouse picker can find panes; titles for clarity.
+  tmux set -p -t "$orch" @fm_role orchestrator
+  tmux set -p -t "$slot1" @fm_role slot:1
+  tmux set -p -t "$slot2" @fm_role slot:2
+  tmux set -p -t "$slot3" @fm_role slot:3
+  tmux set -p -t "$summary" @fm_role summary
+  tmux set -w -t "$win" @fm_layout 1
+  tmux select-pane -t "$orch" -T 'orchestrator' 2>/dev/null || true
+  tmux select-pane -t "$slot1" -T 'watch 1' 2>/dev/null || true
+  tmux select-pane -t "$slot2" -T 'watch 2' 2>/dev/null || true
+  tmux select-pane -t "$slot3" -T 'watch 3' 2>/dev/null || true
+  tmux select-pane -t "$summary" -T 'workers' 2>/dev/null || true
+  tmux set -w -t "$win" pane-border-status top 2>/dev/null || true
+
+  # Keep the captain in the command pane.
+  tmux select-pane -t "$orch"
+  echo "dashboard arranged in $wname: command column (orchestrator + worker summary), 3 watch slots"
+}
+
+# ---- picker entrypoints ----------------------------------------------------
+
+cmd_pick() {  # [slot]
+  require_tmux
+  local slot=${1:-}
+  tmux display-popup -E "$BIN/fm-layout-pick.sh${slot:+ $slot}"
+}
+
+cmd_mouse_pick() {  # -p <pane> -c <client>
+  local pane="" client=""
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      -p) pane=$2; shift 2 ;;
+      -c) client=$2; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+  [ -n "$pane" ] || exit 0
+  local role slot
+  role=$(tmux show -p -t "$pane" -v @fm_role 2>/dev/null || true)
+  case "$role" in
+    slot:*) slot=${role#slot:} ;;
+    *) exit 0 ;;  # right-click outside a watch pane: harmless no-op
+  esac
+  if [ -n "$client" ]; then
+    tmux display-popup -c "$client" -E "$BIN/fm-layout-pick.sh $slot"
+  else
+    tmux display-popup -E "$BIN/fm-layout-pick.sh $slot"
+  fi
+}
+
+# ---- keybindings (opt-in, runtime-only) ------------------------------------
+
+cmd_bind() {
+  require_tmux
+  local mouse=0
+  [ "${1:-}" = "--mouse" ] && mouse=1
+  tmux bind-key "$KEY_ARRANGE" run-shell "$BIN/fm-layout.sh arrange --window '#{window_id}'"
+  tmux bind-key "$KEY_PICK" display-popup -E "$BIN/fm-layout-pick.sh"
+  echo "bound: prefix+$KEY_ARRANGE = arrange/refresh, prefix+$KEY_PICK = pick worker"
+  if [ "$mouse" -eq 1 ]; then
+    tmux set -g mouse on
+    tmux bind-key -n MouseDown3Pane \
+      run-shell "$BIN/fm-layout.sh mouse-pick -p '#{mouse_pane}' -c '#{client_name}'"
+    echo "mouse: right-click a watch pane to reassign it"
+    echo "note: this enabled tmux mouse mode and rebound right-click SERVER-WIDE (best-effort)."
+    echo "      undo with: fm-layout.sh unbind  (then: tmux set -g mouse off  if you want mouse off)"
+  fi
+}
+
+cmd_unbind() {
+  require_tmux
+  tmux unbind-key "$KEY_ARRANGE" 2>/dev/null || true
+  tmux unbind-key "$KEY_PICK" 2>/dev/null || true
+  tmux unbind-key -n MouseDown3Pane 2>/dev/null || true
+  echo "unbound prefix+$KEY_ARRANGE, prefix+$KEY_PICK, and right-click."
+  echo "mouse mode left unchanged; run 'tmux set -g mouse off' to disable it if you enabled it here."
+}
+
+usage() {
+  sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+# ---- dispatch --------------------------------------------------------------
+
+cmd=${1:-arrange}
+[ $# -gt 0 ] && shift || true
+case "$cmd" in
+  arrange) cmd_arrange "$@" ;;
+  workers) cmd_workers ;;
+  slots) cmd_slots ;;
+  assign) cmd_assign "$@" ;;
+  pick) cmd_pick "$@" ;;
+  mouse-pick) cmd_mouse_pick "$@" ;;
+  bind) cmd_bind "$@" ;;
+  unbind) cmd_unbind ;;
+  -h|--help|help) usage ;;
+  *) die "unknown subcommand '$cmd' (try: arrange, workers, slots, assign, pick, bind, unbind)" ;;
+esac

--- a/bin/fm-watch-pane.sh
+++ b/bin/fm-watch-pane.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# fm-watch-pane.sh — the long-lived content of one dashboard pane.
+#
+#   fm-watch-pane.sh <1|2|3>   read-only mirror of the worker assigned to that
+#                              slot: a header plus the tail of the worker's live
+#                              pane, refreshed every FM_LAYOUT_REFRESH seconds.
+#   fm-watch-pane.sh summary   the terse active-worker summary: one "• repo -
+#                              label" bullet per live worker, truncated to fit.
+#
+# This NEVER writes to, sends keys to, or restructures a worker — it only
+# `capture-pane`s. The worker stays in its own window doing its work. Slot
+# assignments come from state/.layout-slot-<n> (written by fm-layout.sh), re-read
+# every refresh, so reassigning a slot is just a file rewrite with no pane churn.
+# A killed pane ends the loop cleanly; that is how arrange tears a viewer down.
+#
+# FM_LAYOUT_REFRESH (default 2) sets the cadence. FM_LAYOUT_ONCE=1 renders a
+# single frame and exits (used by tests and one-shot inspection).
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=bin/fm-layout-lib.sh
+. "$SCRIPT_DIR/fm-layout-lib.sh"
+
+SLOT=${1:-summary}
+STATE=$(fm_layout_state)
+REFRESH=${FM_LAYOUT_REFRESH:-2}
+
+BOLD=$'\033[1m'; DIM=$'\033[2m'; RST=$'\033[0m'
+
+pane_dim() {  # <which: width|height> -> numeric, with a sane fallback
+  local fmt=$1 val=""
+  if [ -n "${TMUX_PANE:-}" ]; then
+    val=$(tmux display-message -p -t "$TMUX_PANE" "#{pane_$fmt}" 2>/dev/null || true)
+  fi
+  case "$val" in ''|*[!0-9]*) [ "$fmt" = width ] && val=80 || val=12 ;; esac
+  printf '%s' "$val"
+}
+
+# Truncate a line to <width> columns (best-effort; byte-wise under C locale, which
+# is enough to stop wrapping in a narrow watch pane).
+fit() {  # <width>
+  local w=$1
+  LC_ALL=C awk -v w="$w" '{ if (length($0) > w) print substr($0, 1, w); else print }'
+}
+
+clear_screen() { printf '\033[H\033[2J'; }
+
+render_slot() {  # <width> <height>
+  local w=$1 h=$2 file win repo label live body lines
+  file=$(fm_layout_slot_file "$STATE" "$SLOT")
+  if [ ! -s "$file" ]; then
+    printf '%s[ watch %s ]%s %s(unassigned)%s\n' "$BOLD" "$SLOT" "$RST" "$DIM" "$RST"
+    printf '%s\n' "$(printf '%*s' "$w" '' | tr ' ' '-')" | fit "$w"
+    printf '%sno worker here — open the picker to assign one%s\n' "$DIM" "$RST"
+    return 0
+  fi
+  IFS=$'\t' read -r win repo label < "$file"
+  printf '%s[ watch %s ]%s %s · %s %s(%s)%s\n' "$BOLD" "$SLOT" "$RST" "$repo" "$label" "$DIM" "$win" "$RST" | fit "$w"
+  printf '%s\n' "$(printf '%*s' "$w" '' | tr ' ' '-')" | fit "$w"
+  if printf '%s\n' "$(fm_layout_live_windows)" | grep -Fxq "$win"; then
+    lines=$((h - 2)); [ "$lines" -ge 1 ] || lines=1
+    body=$(tmux capture-pane -p -t "$win" 2>/dev/null | sed -e 's/[[:space:]]*$//' | grep -v '^$' | tail -n "$lines")
+    printf '%s\n' "$body" | fit "$w"
+  else
+    printf '%sworker ended — reassign this slot from the picker%s\n' "$DIM" "$RST"
+  fi
+}
+
+render_summary() {  # <width>
+  local w=$1 win repo label any=0
+  printf '%sactive workers%s\n' "$BOLD" "$RST"
+  printf '%s\n' "$(printf '%*s' "$w" '' | tr ' ' '-')" | fit "$w"
+  while IFS=$'\t' read -r win repo label; do
+    [ -n "$win" ] || continue
+    any=1
+    printf '%s\n' "• $repo - $label" | fit "$w"
+  done <<EOF
+$(fm_layout_workers)
+EOF
+  [ "$any" -eq 1 ] || printf '%s(none active)%s\n' "$DIM" "$RST"
+}
+
+render() {
+  local w h
+  w=$(pane_dim width); h=$(pane_dim height)
+  clear_screen
+  if [ "$SLOT" = summary ]; then
+    render_summary "$w"
+  else
+    render_slot "$w" "$h"
+  fi
+}
+
+if [ "${FM_LAYOUT_ONCE:-0}" = 1 ]; then
+  render
+  exit 0
+fi
+
+# Long-lived refresh loop. Transient capture/tmux errors never exit it; only a
+# killed pane (SIGHUP/SIGPIPE on the dead terminal) stops it.
+while :; do
+  render || true
+  sleep "$REFRESH" || exit 0
+done

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -135,4 +135,10 @@ FM_CRASH_BACKOFF=60                # seconds to wait after crossing the crash th
 FM_CRASH_NORMAL_SLEEP=5            # seconds to wait after an isolated watcher crash
 FM_LOG_MAX_BYTES=1048576           # daemon log size that triggers trimming
 FM_LOG_KEEP_LINES=2000             # daemon log lines kept when trimming
+# orchestrator dashboard (bin/fm-layout.sh); see docs/orchestrator-layout.md
+FM_LAYOUT_REFRESH=2                # seconds between watch/summary pane refreshes
+FM_LAYOUT_LABEL_MAX=30             # max worker feature-label width before truncation
+FM_LAYOUT_KEY_ARRANGE=O           # prefix key bound to arrange by `fm-layout.sh bind`
+FM_LAYOUT_KEY_PICK=P              # prefix key bound to the picker by `fm-layout.sh bind`
+FM_LAYOUT_INCLUDE_SECONDMATES=    # set to 1 to also watch secondmate homes
 ```

--- a/docs/orchestrator-layout.md
+++ b/docs/orchestrator-layout.md
@@ -1,0 +1,137 @@
+# Orchestrator dashboard layout
+
+A terminal dashboard for the captain: keep the command pane in view while watching
+several workers at once. One command arranges the current firstmate tmux window
+into:
+
+```
+┌─────────────┬───────────────────────────────┐
+│             │           watch 1             │
+│ orchestrator│  (live mirror of a worker)    │
+│   (command) ├───────────────────────────────┤
+│   top 2/3   │           watch 2             │
+│             │                               │
+├─────────────┼───────────────────────────────┤
+│  workers    │           watch 3             │
+│ summary 1/3 │                               │
+└─────────────┴───────────────────────────────┘
+   left 1/3              right 2/3
+```
+
+- **Left 1/3, top 2/3 - orchestrator.** Your existing firstmate chat/command pane,
+  kept focused and fully usable. Arrange never replaces, moves, or obscures it.
+- **Left 1/3, bottom 1/3 - worker summary.** Terse `• repo - label` bullets for
+  every active worker, truncated to fit the small panel (no long wrapping).
+- **Right 2/3 - three stacked watch slots.** Each slot is a **read-only mirror** of
+  a live worker's pane (a `capture-pane` loop). Workers keep running in their own
+  windows, untouched; nothing here ever sends keys, moves, or kills a worker.
+
+## Commands
+
+All live in `bin/`. Run them from your firstmate terminal.
+
+| Command | What it does |
+| --- | --- |
+| `fm-layout.sh` (or `fm-layout.sh arrange`) | Build/refresh the dashboard in the current window. |
+| `fm-layout.sh pick [1\|2\|3]` | Open the keyboard picker to assign a worker to a slot. |
+| `fm-layout.sh workers` | List the live workers (`idx`, window, repo, label). |
+| `fm-layout.sh slots` | Show the three current slot assignments. |
+| `fm-layout.sh assign <1\|2\|3> <window\|->` | Assign a worker to a slot (`-` clears it). |
+| `fm-layout.sh bind [--mouse]` | Install opt-in tmux keybindings (see below). |
+| `fm-layout.sh unbind` | Remove those keybindings. |
+
+`arrange` is **safe to re-run**. It rebuilds only its own viewer panes (the summary
+and the three watch slots), never the orchestrator pane, never a worker, and never
+a pane it does not recognize. If the window holds unexpected panes it refuses and
+leaves everything intact (pass `--force` only if you want those extra panes
+removed). It also refuses to restructure a worker window (one named `fm-*`).
+
+## Worker discovery
+
+Workers are discovered from this home's `state/*.meta` files - any task whose tmux
+window is currently live. The window's `project=` gives the repo; the task id gives
+a terse feature label (the random suffix is dropped and words are spaced, e.g.
+`scrub-pajamas-refactor-y8` → `scrub pajamas refactor`, truncated to
+`FM_LAYOUT_LABEL_MAX`, default 30). Persistent secondmate homes are skipped (set
+`FM_LAYOUT_INCLUDE_SECONDMATES=1` to include them).
+
+When more than three workers are active, the three slots start on the first three
+and you swap any worker into any slot with the picker - the layout never spawns new
+work to fill a slot, and an empty slot just stays empty.
+
+## Reassigning a slot
+
+### Keyboard picker (reliable baseline)
+
+`fm-layout.sh pick` opens a small popup that lists the live workers numbered; type
+the slot, then the worker number (or `0` to clear). This is the dependable path and
+works on any tmux/terminal. Reassignment is just a file rewrite
+(`state/.layout-slot-<n>`); the watch pane re-reads it on its next refresh, so no
+panes are created or destroyed.
+
+### Keybindings (opt-in)
+
+`fm-layout.sh bind` installs two **runtime** prefix bindings (it edits the live tmux
+server with `bind-key`, never your `~/.tmux.conf`):
+
+- `prefix O` - arrange/refresh the dashboard.
+- `prefix P` - open the picker popup.
+
+The keys are capitals to avoid clobbering tmux defaults; override them with
+`FM_LAYOUT_KEY_ARRANGE` / `FM_LAYOUT_KEY_PICK`. Remove them with
+`fm-layout.sh unbind`.
+
+### Mouse / right-click (best-effort, fragile - opt-in)
+
+`fm-layout.sh bind --mouse` additionally lets you right-click a watch pane to open
+its picker. This is **best-effort and intentionally not on by default**, because of
+tmux limitations:
+
+- tmux key tables (including mouse bindings) are **server-global**, not
+  per-session/per-window. There is no way to scope a right-click binding to only the
+  dashboard panes, so enabling it rebinds `MouseDown3Pane` for the whole server.
+  Right-clicking outside a watch pane becomes a harmless no-op rather than your
+  terminal's usual paste/context-menu behavior.
+- It also turns on tmux `mouse` mode server-wide, which changes selection/scroll
+  behavior in every pane.
+
+Because of that global reach, the keyboard picker is the supported path; the mouse
+binding is offered for captains who knowingly accept the trade-off. `unbind` removes
+the right-click binding; it leaves `mouse` mode as-is (run `tmux set -g mouse off`
+yourself if you want it off).
+
+## Environment
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `FM_LAYOUT_REFRESH` | `2` | Seconds between watch/summary refreshes. |
+| `FM_LAYOUT_LABEL_MAX` | `30` | Max feature-label width before truncation. |
+| `FM_LAYOUT_KEY_ARRANGE` | `O` | Prefix key bound to arrange by `bind`. |
+| `FM_LAYOUT_KEY_PICK` | `P` | Prefix key bound to the picker by `bind`. |
+| `FM_LAYOUT_INCLUDE_SECONDMATES` | unset | Set to `1` to watch secondmate homes too. |
+
+## Implementation
+
+- `bin/fm-layout.sh` - arrange/assign/pick/bind CLI.
+- `bin/fm-layout-lib.sh` - shared worker discovery and slot helpers.
+- `bin/fm-watch-pane.sh` - the per-pane mirror/summary refresh loop.
+- `bin/fm-layout-pick.sh` - the interactive popup picker.
+
+Slot assignments live in `state/.layout-slot-<n>` (gitignored runtime state, in the
+`.layout-*` namespace the watcher never touches). The watch panes only
+`capture-pane` their target, so they are read-only by construction.
+
+### Manual verification
+
+The behavior is covered by `tests/fm-layout.test.sh` (real tmux on a private
+socket): discovery/exclusion, label truncation, assign/clear/reject, arrange
+geometry, idempotent re-run, the worker-window and unexpected-pane refusals, and the
+rendered summary/mirror content. To watch it by hand:
+
+```sh
+# from a firstmate window with a few workers in flight:
+bin/fm-layout.sh arrange      # builds the dashboard
+bin/fm-layout.sh workers      # see who is live
+bin/fm-layout.sh pick 3       # assign a 4th worker into slot 3
+bin/fm-layout.sh arrange      # safe to re-run; geometry unchanged
+```

--- a/docs/orchestrator-layout.md
+++ b/docs/orchestrator-layout.md
@@ -26,6 +26,12 @@ into:
   a live worker's pane (a `capture-pane` loop). Workers keep running in their own
   windows, untouched; nothing here ever sends keys, moves, or kills a worker.
 
+## Requirements
+
+The dashboard needs **tmux >= 3.1**. `arrange` sizes its panes with the
+`split-window -l <pct>%` percentage form, which tmux only understands from 3.1
+onward (older tmux used `-p <pct>`); on tmux < 3.1 `arrange` fails.
+
 ## Commands
 
 All live in `bin/`. Run them from your firstmate terminal.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -31,6 +31,10 @@ Each file also starts with a short header comment.
 | `fm-send.sh`             | Send one verified literal line (or `--key Escape`) to a direct-report window; exits non-zero on confirmed swallowed Enter; bare `kind=secondmate` targets are marked as from-firstmate; slash commands and codex `$...` skill invocations get popup-settle before Enter; text sends pause `FM_SEND_SETTLE` seconds after success |
 | `fm-tmux-lib.sh`         | Shared tmux pane primitives for busy detection, dim-ghost-aware and border-aware composer detection, and verified submit retry |
 | `fm-peek.sh`             | Print a bounded tail of a crewmate pane                                                                             |
+| `fm-layout.sh`           | Arrange the orchestrator window into a left command column (chat + worker summary) and three swappable worker watch slots; `arrange`/`workers`/`slots`/`assign`/`pick`/`bind` subcommands ([docs](orchestrator-layout.md)) |
+| `fm-layout-lib.sh`       | Shared live-worker discovery, terse repo/label derivation, and slot-file helpers sourced by the layout scripts      |
+| `fm-watch-pane.sh`       | Read-only refresh loop for one dashboard pane: a `capture-pane` mirror of an assigned worker, or the active-worker summary |
+| `fm-layout-pick.sh`      | Interactive keyboard picker popup that reassigns a watch slot to any live worker                                    |
 | `fm-pr-check.sh`         | Record `pr=` and a verified `pr_head=` when available for a PR-ready task, then arm the watcher's merge poll        |
 | `fm-promote.sh`          | Promote a scout task in place so it becomes a protected ship task                                                   |
 | `fm-teardown.sh`         | Return a clean, landed ship worktree or retire/release a secondmate home; requires scout reports, checks child work, and prints the backlog reminder |

--- a/tests/fm-layout.test.sh
+++ b/tests/fm-layout.test.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# fm-layout.sh — orchestrator dashboard layout behavior.
+#
+# Covers, against a REAL tmux on a private socket (never the captain's session):
+#   1. Worker discovery from state/*.meta: live windows only, secondmates and
+#      windowless/stale metas excluded; repo from project=, label from the id.
+#   2. fm_layout_label: random-suffix strip and FM_LAYOUT_LABEL_MAX truncation.
+#   3. assign/slots round-trip, rejection of a non-worker, and slot clearing.
+#   4. arrange geometry: orchestrator preserved + active, one summary pane, three
+#      slot panes, @fm_layout marker, slots autofilled without spawning work.
+#   5. Re-running arrange is idempotent (still 5 panes) and never kills workers.
+#   6. arrange refuses a worker window and a window with unexpected panes (no
+#      --force), leaving everything intact.
+#   7. The summary pane renders terse bullets; a watch pane mirrors its worker.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+command -v tmux >/dev/null 2>&1 || { echo "1..0 # SKIP tmux not available"; exit 0; }
+REAL_TMUX=$(command -v tmux)
+LAYOUT="$ROOT/bin/fm-layout.sh"
+PANE="$ROOT/bin/fm-watch-pane.sh"
+
+TMP=$(fm_test_tmproot fm-layout)
+SOCK="fmlayout-test-$$"
+STATE="$TMP/state"
+mkdir -p "$STATE" "$TMP/shim"
+
+TM() { "$REAL_TMUX" -L "$SOCK" "$@"; }
+
+# tmux shim so fm-layout's internal `tmux` calls hit our private socket.
+cat > "$TMP/shim/tmux" <<SH
+#!/usr/bin/env bash
+exec "$REAL_TMUX" -L "$SOCK" "\$@"
+SH
+chmod +x "$TMP/shim/tmux"
+
+# Self-contained cleanup that always returns 0: fm_test_tmproot registered its dir
+# inside a $(...) subshell, so the parent's cleanup array is empty here. Returning
+# non-zero from an EXIT trap that runs as the script falls off the end would become
+# the script's exit status, so end on a zero-status command.
+cleanup_layout() {
+  TM kill-server 2>/dev/null || true
+  rm -rf "$TMP"
+  return 0
+}
+trap cleanup_layout EXIT
+
+export PATH="$TMP/shim:$PATH"
+export FM_STATE_OVERRIDE="$STATE" FM_HOME="$TMP" FM_LAYOUT_ALLOW_NO_TMUX=1
+
+meta() {  # <id> <window> <project> <kind>
+  cat > "$STATE/$1.meta" <<EOF
+window=$2
+project=$3
+kind=$4
+EOF
+}
+
+# --- fleet: orchestrator window + worker windows --------------------------
+TM new-session -d -s itest -n opencode -x 200 -y 60
+TM new-window -t itest -n fm-alpha-aa  'while :; do echo alpha-line; sleep 1; done'
+TM new-window -t itest -n fm-beta-bb   'while :; do echo beta-line; sleep 1; done'
+TM new-window -t itest -n fm-gamma-cc  'while :; do echo gamma-line; sleep 1; done'
+TM new-window -t itest -n fm-second-dd 'while :; do echo second-line; sleep 1; done'
+
+meta alpha-aa  itest:fm-alpha-aa  /x/projects/scrub-cx-engine ship
+meta beta-bb   itest:fm-beta-bb   /x/projects/portals-cx      scout
+meta gamma-cc  itest:fm-gamma-cc  /x/projects/synct_utility   ship
+meta second-dd itest:fm-second-dd /x/projects/secret          secondmate
+# Stale meta: its window does not exist on the socket.
+meta stale-zz  itest:fm-stale-zz  /x/projects/gone            ship
+
+ORCH_WIN=$(TM list-windows -t itest -F '#{window_id} #{window_name}' | awk '$2=="opencode"{print $1}')
+ALPHA_WIN=$(TM list-windows -t itest -F '#{window_id} #{window_name}' | awk '$2=="fm-alpha-aa"{print $1}')
+
+# --- 1. discovery ----------------------------------------------------------
+workers=$("$LAYOUT" workers)
+assert_contains "$workers" "scrub-cx-engine	alpha" "alpha worker discovered with repo+label"
+assert_contains "$workers" "portals-cx	beta" "beta worker discovered"
+assert_contains "$workers" "synct_utility	gamma" "gamma worker discovered"
+assert_not_contains "$workers" "secret" "secondmate excluded from workers"
+assert_not_contains "$workers" "gone" "stale (windowless) meta excluded from workers"
+[ "$(printf '%s\n' "$workers" | grep -c .)" -eq 3 ] || fail "expected exactly 3 live workers"
+pass "discovery lists only live, non-secondmate workers with repo+label"
+
+# --- 2. label humanization -------------------------------------------------
+. "$ROOT/bin/fm-layout-lib.sh"
+[ "$(fm_layout_label scrub-pajamas-refactor-y8)" = "scrub pajamas refactor" ] \
+  || fail "label should strip suffix and space words"
+[ "$(FM_LAYOUT_LABEL_MAX=10 fm_layout_label very-long-feature-name-q9)" = "very long…" ] \
+  || fail "label should truncate to FM_LAYOUT_LABEL_MAX with an ellipsis"
+pass "label strips the random suffix and truncates to fit"
+
+# --- 3. assign / slots / reject / clear ------------------------------------
+"$LAYOUT" assign 1 itest:fm-gamma-cc >/dev/null
+"$LAYOUT" assign 2 itest:fm-alpha-aa >/dev/null
+slots=$("$LAYOUT" slots)
+assert_contains "$slots" "itest:fm-gamma-cc" "slot 1 holds the assigned worker"
+assert_contains "$slots" "itest:fm-alpha-aa" "slot 2 holds the assigned worker"
+
+set +e
+out=$("$LAYOUT" assign 3 itest:fm-nope-xx 2>&1); rc=$?
+set -e
+expect_code 1 "$rc" "assigning a non-worker fails"
+assert_contains "$out" "not a live worker" "reject explains the worker is not live"
+
+"$LAYOUT" assign 2 - >/dev/null
+slots=$("$LAYOUT" slots)
+assert_not_contains "$slots" "itest:fm-alpha-aa" "clearing a slot removes its worker"
+pass "assign/slots round-trip, non-worker rejection, and clear all work"
+
+# Reset slot files so arrange's autofill starts clean.
+rm -f "$STATE"/.layout-slot-*
+
+# --- 4. arrange geometry ---------------------------------------------------
+"$LAYOUT" arrange --window "$ORCH_WIN" >/dev/null
+sleep 1
+roles=$(TM list-panes -t "$ORCH_WIN" -F '#{@fm_role}' | sort | tr '\n' ' ')
+assert_contains "$roles" "orchestrator" "orchestrator pane tagged"
+assert_contains "$roles" "summary" "summary pane created"
+assert_contains "$roles" "slot:1 slot:2 slot:3" "three watch slots created"
+[ "$(TM list-panes -t "$ORCH_WIN" | grep -c .)" -eq 5 ] || fail "expected 5 panes after arrange"
+active_role=$(TM display-message -p -t "$ORCH_WIN" '#{@fm_role}')
+[ "$active_role" = orchestrator ] || fail "orchestrator pane must stay active/focused"
+[ "$(TM show -w -t "$ORCH_WIN" -v @fm_layout)" = 1 ] || fail "@fm_layout marker should be set"
+# Autofill: 3 live workers fill all 3 slots; no work was spawned to fill them.
+filled=$(grep -l . "$STATE"/.layout-slot-1 "$STATE"/.layout-slot-2 "$STATE"/.layout-slot-3 2>/dev/null | grep -c .)
+[ "$filled" -eq 3 ] || fail "expected all 3 slots autofilled from the 3 live workers"
+pass "arrange builds command column + 3 slots, preserves the active orchestrator pane"
+
+# --- 5. idempotent re-run, workers untouched -------------------------------
+"$LAYOUT" arrange --window "$ORCH_WIN" >/dev/null
+sleep 1
+[ "$(TM list-panes -t "$ORCH_WIN" | grep -c .)" -eq 5 ] || fail "re-run should keep 5 panes"
+for w in fm-alpha-aa fm-beta-bb fm-gamma-cc; do
+  TM list-windows -t itest -F '#{window_name}' | grep -Fxq "$w" \
+    || fail "worker window $w must survive arrange"
+done
+pass "re-running arrange is idempotent and leaves worker windows intact"
+
+# --- 6. refusals -----------------------------------------------------------
+set +e
+out=$("$LAYOUT" arrange --window "$ALPHA_WIN" 2>&1); rc=$?
+set -e
+expect_code 1 "$rc" "arranging a worker window is refused"
+assert_contains "$out" "worker window" "refusal names the worker-window reason"
+
+TM new-window -t itest -n messy 'sleep 600'
+MESSY_WIN=$(TM list-windows -t itest -F '#{window_id} #{window_name}' | awk '$2=="messy"{print $1}')
+TM split-window -t "$MESSY_WIN" 'sleep 600'
+set +e
+out=$("$LAYOUT" arrange --window "$MESSY_WIN" 2>&1); rc=$?
+set -e
+expect_code 1 "$rc" "arranging a window with unexpected panes is refused"
+assert_contains "$out" "unexpected pane" "refusal names the unexpected-pane reason"
+[ "$(TM list-panes -t "$MESSY_WIN" | grep -c .)" -eq 2 ] || fail "refused window must keep its panes"
+pass "arrange refuses worker windows and unexpected panes without destroying anything"
+
+# --- 7. rendered content ---------------------------------------------------
+summary=$(FM_LAYOUT_ONCE=1 FM_LAYOUT_STATE="$STATE" "$PANE" summary | sed 's/\x1b\[[0-9;]*m//g')
+assert_contains "$summary" "active workers" "summary has a header"
+assert_contains "$summary" "• scrub-cx-engine - alpha" "summary shows a terse repo/label bullet"
+
+"$LAYOUT" assign 1 itest:fm-beta-bb >/dev/null
+slot=$(FM_LAYOUT_ONCE=1 FM_LAYOUT_STATE="$STATE" TMUX_PANE="" "$PANE" 1 | sed 's/\x1b\[[0-9;]*m//g')
+assert_contains "$slot" "portals-cx · beta" "watch pane header shows the assigned worker"
+assert_contains "$slot" "beta-line" "watch pane mirrors the live worker's output"
+pass "summary renders terse bullets and a watch pane mirrors its worker"
+
+echo "# all fm-layout tests passed"


### PR DESCRIPTION
## Intent

Terminal orchestrator dashboard for firstmate (bin/fm-layout.sh): arranges the firstmate tmux window into a left command column (orchestrator chat top 2/3, terse active-worker summary bottom 1/3) and a right column of three stacked worker watch slots that are deliberately READ-ONLY capture-pane mirrors of live worker windows so workers keep running untouched and the orchestrator pane is never obscured. Deliberate design choices a reviewer should not flag as bugs: read-only mirroring instead of join-pane; discovery from state/*.meta with secondmate/stale windows intentionally excluded; mouse/right-click reassignment provided only as an opt-in, explicitly-documented best-effort path because tmux key tables are server-global (keyboard picker is the supported baseline); arrange refuses worker windows and unexpected panes rather than destroying them; keybindings opt-in and runtime-only, never editing ~/.tmux.conf; AGENTS.md prose intentionally left unchanged to avoid overlap with in-flight PR #105. Covered by tests/fm-layout.test.sh on a private tmux socket; documented in docs/orchestrator-layout.md.

## What Changed

- Add `bin/fm-layout.sh` (plus `fm-layout-lib.sh`, `fm-layout-pick.sh`, `fm-watch-pane.sh`) to arrange the firstmate tmux window into a left command column (orchestrator chat over a terse active-worker summary) and a right column of three stacked, read-only `capture-pane` mirrors of live worker windows, with workers discovered from `state/*.meta` (secondmate and stale windows excluded) and an opt-in keyboard/mouse slot reassignment picker.
- Make `arrange` non-destructive: it refuses worker windows and unexpected panes rather than tearing them down, keybindings are runtime-only and never edit `~/.tmux.conf`.
- Use a portable `while IFS= read -r` worker loop instead of the bash 4+ `mapfile` so the picker works on macOS bash 3.2, and document the tmux 3.1 minimum (percentage `split-window -l`) requirement.
- Add `tests/fm-layout.test.sh` (7 cases on a private tmux socket) and `docs/orchestrator-layout.md`, with supporting entries in `README.md`, `docs/configuration.md`, and `docs/scripts.md`.

## Risk Assessment

✅ Low: Additive, well-bounded read-only tmux dashboard tooling with real-tmux test coverage; the prior bash-3.2 portability bug is fixed and the only remaining items are minor robustness/cosmetic edge cases.

## Testing

Ran the existing suite (`tests/fm-layout.test.sh`, 7/7 green) and additionally exercised fm-layout.sh end-to-end against a real tmux 3.6b server on a private socket with three fake live workers plus a secondmate and a stale meta: discovery listed only the three real workers, arrange produced the intended left command column (orchestrator 2/3 + worker summary 1/3) beside three stacked read-only watch panes that mirrored each live worker, re-arrange stayed idempotent without killing workers, and arrange refused a worker window without --force. Visual evidence is reviewer-visible as captured tmux pane text and a stitched composite of the full dashboard (terminal TUI, so the surface is text - no browser/HTML rendering applies). Overall result: pass, no findings.

- Evidence: Composite dashboard view (what the captain sees) (local file: <code>/var/folders/nt/qwfnn1kn15bcm70g15cygtkw0000gn/T/no-mistakes-evidence/01KW5HJ1HKH0VMW40W0C09BCS2/00-dashboard-composite.txt</code>)
<details>
<summary>Evidence: Dashboard pane geometry (left 1/3 command column + right 2/3 three stacked slots)</summary>

<code>%0 role=orchestrator title=&#34;orchestrator&#34; 67x32 @0,1 active=1&#10;%8 role=summary title=&#34;workers&#34; 67x16 @0,34 active=0&#10;%5 role=slot:1 title=&#34;watch 1&#34; 132x15 @68,1 active=0&#10;%6 role=slot:2 title=&#34;watch 2&#34; 132x16 @68,17 active=0&#10;%7 role=slot:3 title=&#34;watch 3&#34; 132x16 @68,34 active=0</code>

```text
%0 role=orchestrator title="orchestrator" 67x32 @0,1 active=1
%8 role=summary title="workers" 67x16 @0,34 active=0
%5 role=slot:1 title="watch 1" 132x15 @68,1 active=0
%6 role=slot:2 title="watch 2" 132x16 @68,17 active=0
%7 role=slot:3 title="watch 3" 132x16 @68,34 active=0
```
</details>
<details>
<summary>Evidence: Worker discovery: only live non-secondmate workers (secondmate + stale meta excluded)</summary>

<code>1 fm:fm-add-export-csv-q7 reportkit add export csv&#10;2 fm:fm-fix-login-k3 webapp fix login&#10;3 fm:fm-repro-crash-on-startup-z2 mobileapp repro crash on startup</code>

```text
1	fm:fm-add-export-csv-q7	reportkit	add export csv
2	fm:fm-fix-login-k3	webapp	fix login
3	fm:fm-repro-crash-on-startup-z2	mobileapp	repro crash on startup
```
</details>
- Evidence: Watch slot 1 read-only mirror of live worker pane (local file: <code>/var/folders/nt/qwfnn1kn15bcm70g15cygtkw0000gn/T/no-mistakes-evidence/01KW5HJ1HKH0VMW40W0C09BCS2/pane-slot-1.txt</code>)
- Evidence: Terse active-worker summary pane (bullets) (local file: <code>/var/folders/nt/qwfnn1kn15bcm70g15cygtkw0000gn/T/no-mistakes-evidence/01KW5HJ1HKH0VMW40W0C09BCS2/pane-summary.txt</code>)
<details>
<summary>Evidence: Idempotency + safety refusal</summary>

<code>panes after re-arrange: 5 (expect 5)&#10;worker windows still alive: 4 (expect 4: 3 workers + 1 secondmate)&#10;--&#10;fm-layout: &#39;fm-fix-login-k3&#39; looks like a worker window; refusing to arrange it (pass --force to override)</code>

```text
panes after re-arrange: 5 (expect 5)
worker windows still alive: 4 (expect 4: 3 workers + 1 secondmate)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ⚠️ `bin/fm-layout-pick.sh:27` - fm-layout-pick.sh uses `mapfile -t WORKERS`, a bash 4+ builtin, but the shebang resolves to bash 3.2.57 on this macOS host (confirmed). Under 3.2 `mapfile` is undefined, leaving WORKERS empty, so the keyboard picker - the documented supported baseline selector - always shows &#39;no active workers&#39; and can never reassign a slot. Every other bin/ script avoids mapfile and uses while-read loops; replace it with a portable `while IFS= read -r line` loop to match.
- ℹ️ `bin/fm-layout.sh:210` - `split-window -l 66%` / `-l 33%` use the percentage form of -l, which tmux only supports from 3.1 onward (older tmux required -p). On tmux &lt; 3.1 `arrange` fails. Document this as a minimum-version requirement.

🔧 Fix: fix(layout): portable worker picker on bash 3.2, document tmux 3.1 requirement
2 infos still open:
- ℹ️ `bin/fm-layout.sh:219` - In cmd_arrange, the @fm_role tags are applied only after all four split-window calls succeed. If any split fails partway (e.g. on tmux &lt; 3.1 where `-l 66%` is unsupported, or a transient tmux error), set -e aborts leaving one or more untagged viewer panes in the window. A subsequent `arrange` then tears down only role-tagged panes, finds the untagged leftovers as &#39;unexpected pane(s)&#39;, and refuses without --force — so a partially-built dashboard can only be recovered with --force. Tagging each pane with its @fm_role immediately after it is created would make re-arrange self-heal a partial build.
- ℹ️ `bin/fm-watch-pane.sh:34` - fit() truncates by byte length, and the header lines passed through it include ANSI escape sequences (BOLD/DIM and the trailing RST reset) that count toward the width budget. On a narrow watch pane, a long worker header can be cut before its `\033[0m` reset, leaking bold/dim attributes onto following lines. The header is also truncated earlier than its visible content warrants because the ~20 escape bytes are billed against the column count. This is an acknowledged best-effort byte-wise tradeoff per the function comment; flagging only as a visual edge case.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-layout.test.sh` — all 7 cases pass on a private tmux socket</code>
- <code>End-to-end demo on a private tmux server: `fm-layout.sh workers` (discovery excluded secondmate + stale meta)</code>
- <code>`fm-layout.sh arrange --window &lt;orch&gt;` then captured pane geometry and per-pane content (orchestrator/summary/slot:1-3)</code>
- <code>Verified read-only worker mirroring: each watch pane reflected its live worker&#39;s pane content; summary rendered terse `• repo - label` bullets</code>
- <code>Idempotency: re-ran `arrange`, confirmed 5 panes and all 4 worker windows still alive/untouched</code>
- <code>Safety: `arrange --window &lt;worker&gt;` refused without --force (exit 1)</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
