### PR TITLE
feat(bin): orchestrator dashboard layout with swappable worker watch panes and reference picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Agent-only reference skills live under `.agents/skills/` and are loaded by first
 - [docs/architecture.md](docs/architecture.md) - how the crew, supervision, worktrees, secondmates, and project modes work.
 - [docs/configuration.md](docs/configuration.md) - environment variables, `FM_HOME`, optional X mode, the files you set, and harness support.
 - [docs/scripts.md](docs/scripts.md) - the `bin/` toolbelt reference.
+- [docs/orchestrator-layout.md](docs/orchestrator-layout.md) - the terminal dashboard: a command column plus three swappable worker watch panes.
 - [`AGENTS.md`](AGENTS.md) - firstmate's full operating manual for the orchestrator agent.
 - [CONTRIBUTING.md](CONTRIBUTING.md) - how to contribute, including the dev/test commands.
 

--- a/bin/fm-layout-lib.sh
+++ b/bin/fm-layout-lib.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# fm-layout-lib.sh — shared worker-discovery primitives for the orchestrator
+# dashboard layout (bin/fm-layout.sh, bin/fm-watch-pane.sh, bin/fm-layout-pick.sh).
+#
+# ONE source of truth for: where a firstmate home's state lives, which crewmate
+# windows are live "workers" worth watching, the terse repo/label a worker shows
+# in the summary and watch headers, and the per-slot assignment files. Decoupled
+# from any tmux arrangement so the discovery logic is unit-testable with a fake
+# `tmux list-windows` and fixture state/*.meta, no real terminal required.
+#
+# A "worker" is any task this home recorded in state/<id>.meta whose tmux window
+# is currently live. The orchestrator's own pane has no meta, so it is never a
+# worker. Liveness is read from `tmux list-windows` (stubbable in tests), so a
+# stale meta whose window is gone never appears as an assignable worker.
+#
+# All functions are `set -u`/`set -e` safe so they can be sourced into either an
+# interactive arrange or a long-lived watch loop.
+
+# Resolve this home's state dir the same way every other fm-*.sh does, honoring
+# FM_STATE_OVERRIDE / FM_HOME / FM_ROOT_OVERRIDE. The caller may pre-export
+# FM_LAYOUT_STATE to pin it (the watch panes do this so they read the same home
+# the arrange command used regardless of the pane's inherited environment).
+fm_layout_state() {
+  if [ -n "${FM_LAYOUT_STATE:-}" ]; then
+    printf '%s\n' "$FM_LAYOUT_STATE"
+    return 0
+  fi
+  local script_dir root home
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  root="${FM_ROOT_OVERRIDE:-$(cd "$script_dir/.." && pwd)}"
+  home="${FM_HOME:-${FM_ROOT_OVERRIDE:-$root}}"
+  printf '%s\n' "${FM_STATE_OVERRIDE:-$home/state}"
+}
+
+# fm_layout_label <id>: a terse, deterministic feature label for a task id by
+# dropping the random suffix (the trailing "-<2-3 alnum>") and turning the rest
+# into spaced words. e.g. "scrub-pajamas-refactor-y8" -> "scrub pajamas refactor".
+# Truncated to FM_LAYOUT_LABEL_MAX (default 30) so the summary never long-wraps.
+fm_layout_label() {
+  local id=$1 max=${FM_LAYOUT_LABEL_MAX:-30} base
+  base=$(printf '%s' "$id" | sed -E 's/-[a-z0-9]{2,3}$//')
+  base=${base//-/ }
+  if [ "${#base}" -gt "$max" ]; then
+    base="${base:0:$((max - 1))}…"
+  fi
+  printf '%s' "$base"
+}
+
+# fm_layout_live_windows: print "session:window" for every live tmux window,
+# one per line. Isolated behind a function so tests can stub `tmux`.
+fm_layout_live_windows() {
+  tmux list-windows -a -F '#{session_name}:#{window_name}' 2>/dev/null || true
+}
+
+# fm_layout_meta_field <meta-file> <key>: echo the last value of key= in a meta
+# file (last wins, mirroring fm-peek/fm-send), empty if absent.
+fm_layout_meta_field() {
+  grep "^$2=" "$1" 2>/dev/null | tail -1 | cut -d= -f2- || true
+}
+
+# fm_layout_workers: print every live worker as a TAB-separated record
+#   <session:window>\t<repo>\t<label>
+# sorted by window for stable ordering. A worker is a state/<id>.meta whose
+# window= is currently live. repo is the basename of project=; label comes from
+# fm_layout_label. Secondmate homes (kind=secondmate) are persistent supervisors,
+# not project workers, so they are skipped unless FM_LAYOUT_INCLUDE_SECONDMATES=1.
+fm_layout_workers() {
+  local state live meta id window repo project kind
+  state=$(fm_layout_state)
+  [ -d "$state" ] || return 0
+  live=$(fm_layout_live_windows)
+  for meta in "$state"/*.meta; do
+    [ -e "$meta" ] || continue
+    id=$(basename "$meta" .meta)
+    window=$(fm_layout_meta_field "$meta" window)
+    [ -n "$window" ] || continue
+    # Only live windows are assignable workers.
+    printf '%s\n' "$live" | grep -Fxq "$window" || continue
+    kind=$(fm_layout_meta_field "$meta" kind)
+    if [ "$kind" = secondmate ] && [ "${FM_LAYOUT_INCLUDE_SECONDMATES:-0}" != 1 ]; then
+      continue
+    fi
+    project=$(fm_layout_meta_field "$meta" project)
+    if [ -n "$project" ]; then repo=$(basename "$project"); else repo=$id; fi
+    printf '%s\t%s\t%s\n' "$window" "$repo" "$(fm_layout_label "$id")"
+  done | sort
+}
+
+# fm_layout_slot_file <state> <slot>: path of a slot's assignment file. Slot is
+# 1..3 or the literal "summary". Lives under state/ (gitignored runtime), in the
+# .layout-* namespace the watcher never touches.
+fm_layout_slot_file() {
+  printf '%s/.layout-slot-%s\n' "$1" "$2"
+}

--- a/bin/fm-layout-lib.sh
+++ b/bin/fm-layout-lib.sh
@@ -92,3 +92,22 @@ fm_layout_workers() {
 fm_layout_slot_file() {
   printf '%s/.layout-slot-%s\n' "$1" "$2"
 }
+
+# fm_layout_ref <window> [format]: the worker-reference token to type into the
+# composer for a worker, given its session:window. The format (default from
+# FM_LAYOUT_REF_FORMAT, else "target") chooses what reaches the captain's message
+# so they stop hand-copying terminal targets:
+#   target  - "session:window" as-is (e.g. firstmate:fm-foo-k9); the literal tmux
+#             target, directly usable with tmux and resolvable by fm-send/fm-peek.
+#   window  - just "fm-foo-k9" (the bare window name firstmate's tools resolve).
+#   select  - a ready-to-run "tmux select-window -t session:window" command.
+# An unknown format falls back to target. This is pure string work (no tmux call),
+# so it is trivially testable.
+fm_layout_ref() {
+  local window=$1 format=${2:-${FM_LAYOUT_REF_FORMAT:-target}}
+  case "$format" in
+    window) printf '%s' "${window##*:}" ;;
+    select) printf 'tmux select-window -t %s' "$window" ;;
+    target|*) printf '%s' "$window" ;;
+  esac
+}

--- a/bin/fm-layout-lib.sh
+++ b/bin/fm-layout-lib.sh
@@ -95,16 +95,17 @@ fm_layout_slot_file() {
 
 # fm_layout_ref <window> [format]: the worker-reference token to type into the
 # composer for a worker, given its session:window. The format (default from
-# FM_LAYOUT_REF_FORMAT, else "target") chooses what reaches the captain's message
+# FM_LAYOUT_REF_FORMAT, else "window") chooses what reaches the captain's message
 # so they stop hand-copying terminal targets:
+#   window  - just "fm-foo-k9" (the bare window name firstmate's tools resolve);
+#             the short, human-readable default.
 #   target  - "session:window" as-is (e.g. firstmate:fm-foo-k9); the literal tmux
 #             target, directly usable with tmux and resolvable by fm-send/fm-peek.
-#   window  - just "fm-foo-k9" (the bare window name firstmate's tools resolve).
 #   select  - a ready-to-run "tmux select-window -t session:window" command.
 # An unknown format falls back to target. This is pure string work (no tmux call),
 # so it is trivially testable.
 fm_layout_ref() {
-  local window=$1 format=${2:-${FM_LAYOUT_REF_FORMAT:-target}}
+  local window=$1 format=${2:-${FM_LAYOUT_REF_FORMAT:-window}}
   case "$format" in
     window) printf '%s' "${window##*:}" ;;
     select) printf 'tmux select-window -t %s' "$window" ;;

--- a/bin/fm-layout-pick.sh
+++ b/bin/fm-layout-pick.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# fm-layout-pick.sh — interactive keyboard picker for reassigning a dashboard
+# watch slot. Meant to run inside `tmux display-popup -E` (the popup gives it a
+# TTY), but it works in any terminal too. This is the RELIABLE baseline selector:
+# plain numbered prompts, no mouse, no tmux menu plumbing.
+#
+#   fm-layout-pick.sh [slot]   slot 1|2|3; if omitted, it asks which slot first.
+#
+# It only reads worker discovery and calls `fm-layout.sh assign`; it never touches
+# a worker pane. Choosing 0 clears the slot.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LAYOUT="$SCRIPT_DIR/fm-layout.sh"
+
+slot=${1:-}
+if [ -z "$slot" ]; then
+  printf 'Reassign which watch slot? [1-3]: '
+  read -r slot || exit 0
+fi
+case "$slot" in
+  1|2|3) ;;
+  *) echo "invalid slot '$slot' (expected 1, 2, or 3)"; sleep 1.2; exit 0 ;;
+esac
+
+# Snapshot live workers: idx<TAB>window<TAB>repo<TAB>label.
+mapfile -t WORKERS < <("$LAYOUT" workers)
+
+echo "== assign watch slot $slot =="
+if [ "${#WORKERS[@]}" -eq 0 ]; then
+  echo "no active workers to show right now."
+  echo "(0 clears the slot)"
+fi
+
+for row in "${WORKERS[@]}"; do
+  IFS=$'\t' read -r idx win repo label <<<"$row"
+  printf '  %s) %s - %s  (%s)\n' "$idx" "$repo" "$label" "$win"
+done
+echo "  0) clear this slot"
+printf 'choice for slot %s: ' "$slot"
+read -r choice || exit 0
+
+if [ "$choice" = 0 ]; then
+  "$LAYOUT" assign "$slot" -
+  sleep 0.8
+  exit 0
+fi
+
+for row in "${WORKERS[@]}"; do
+  IFS=$'\t' read -r idx win repo label <<<"$row"
+  if [ "$choice" = "$idx" ]; then
+    "$LAYOUT" assign "$slot" "$win"
+    sleep 0.8
+    exit 0
+  fi
+done
+
+echo "no worker numbered '$choice'."
+sleep 1.2

--- a/bin/fm-layout-pick.sh
+++ b/bin/fm-layout-pick.sh
@@ -35,7 +35,7 @@ if [ "${#WORKERS[@]}" -eq 0 ]; then
   echo "(0 clears the slot)"
 fi
 
-for row in "${WORKERS[@]}"; do
+for row in "${WORKERS[@]+"${WORKERS[@]}"}"; do
   IFS=$'\t' read -r idx win repo label <<<"$row"
   printf '  %s) %s - %s  (%s)\n' "$idx" "$repo" "$label" "$win"
 done
@@ -49,7 +49,7 @@ if [ "$choice" = 0 ]; then
   exit 0
 fi
 
-for row in "${WORKERS[@]}"; do
+for row in "${WORKERS[@]+"${WORKERS[@]}"}"; do
   IFS=$'\t' read -r idx win repo label <<<"$row"
   if [ "$choice" = "$idx" ]; then
     "$LAYOUT" assign "$slot" "$win"

--- a/bin/fm-layout-pick.sh
+++ b/bin/fm-layout-pick.sh
@@ -24,7 +24,10 @@ case "$slot" in
 esac
 
 # Snapshot live workers: idx<TAB>window<TAB>repo<TAB>label.
-mapfile -t WORKERS < <("$LAYOUT" workers)
+WORKERS=()
+while IFS= read -r line; do
+  WORKERS+=("$line")
+done < <("$LAYOUT" workers)
 
 echo "== assign watch slot $slot =="
 if [ "${#WORKERS[@]}" -eq 0 ]; then

--- a/bin/fm-layout.sh
+++ b/bin/fm-layout.sh
@@ -279,7 +279,7 @@ cmd_mouse_pick() {  # -p <pane> -c <client>
 # via a prefix chord (prefix #) that captures the active pane, then a tmux
 # display-menu (keyboard-navigable AND mouse-clickable, like the @/ pickers).
 # Selecting a worker runs `insert-ref`, which send-keys the reference (default the
-# tmux target) into the composer so the captain never hand-copies a terminal
+# short window name) into the composer so the captain never hand-copies a terminal
 # target. With --print it prints the menu targets instead (used by tests).
 cmd_ref() {  # -p <pane> [-c <client>] [--print]
   require_tmux

--- a/bin/fm-layout.sh
+++ b/bin/fm-layout.sh
@@ -22,6 +22,8 @@
 #   assign <1|2|3> <window|->            assign a worker to a slot (- clears it)
 #   pick [1|2|3]                        open the interactive picker popup
 #   mouse-pick -p <pane> -c <client>    right-click handler (resolves slot from pane)
+#   ref -p <pane> [-c <client>]         worker-reference picker: type a worker ref into the composer
+#   insert-ref -p <pane> -w <window>    type one worker's reference into a pane
 #   bind [--mouse]                      install opt-in runtime keybindings
 #   unbind                              remove them
 #
@@ -44,6 +46,9 @@ BIN="$SCRIPT_DIR"
 # captain whose config already uses them can pick others.
 KEY_ARRANGE="${FM_LAYOUT_KEY_ARRANGE:-O}"
 KEY_PICK="${FM_LAYOUT_KEY_PICK:-P}"
+# The worker-reference chord. A bare '#' cannot be intercepted inside an agent
+# composer (see docs/orchestrator-layout.md), so this is a prefix chord: prefix #.
+KEY_REF="${FM_LAYOUT_KEY_REF:-#}"
 
 die() { echo "fm-layout: $*" >&2; exit 1; }
 
@@ -266,6 +271,81 @@ cmd_mouse_pick() {  # -p <pane> -c <client>
   fi
 }
 
+# ---- worker-reference shortcut (the "#"-style picker) ----------------------
+
+# cmd_ref: open a worker picker and type the chosen worker's reference into the
+# composer pane. This is the closest practical analog to an "@"/"#" mention: a
+# bare '#' cannot be trapped inside a third-party agent composer, so it is reached
+# via a prefix chord (prefix #) that captures the active pane, then a tmux
+# display-menu (keyboard-navigable AND mouse-clickable, like the @/ pickers).
+# Selecting a worker runs `insert-ref`, which send-keys the reference (default the
+# tmux target) into the composer so the captain never hand-copies a terminal
+# target. With --print it prints the menu targets instead (used by tests).
+cmd_ref() {  # -p <pane> [-c <client>] [--print]
+  require_tmux
+  local pane="" client="" printonly=0
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      -p) pane=$2; shift 2 ;;
+      -c) client=$2; shift 2 ;;
+      --print) printonly=1; shift ;;
+      *) shift ;;
+    esac
+  done
+  [ -n "$pane" ] || pane=$(tmux display-message -p '#{pane_id}' 2>/dev/null || true)
+
+  local workers menu=() i=0 win repo label key
+  workers=$(fm_layout_workers)
+  while IFS=$'\t' read -r win repo label; do
+    [ -n "$win" ] || continue
+    i=$((i + 1))
+    if [ "$printonly" -eq 1 ]; then
+      printf '%d\t%s\t%s\n' "$i" "$win" "$(fm_layout_ref "$win")"
+      continue
+    fi
+    if [ "$i" -le 9 ]; then key=$i; else key=""; fi
+    menu+=("$repo - $label" "$key" "run-shell \"$BIN/fm-layout.sh insert-ref -p $pane -w $win\"")
+  done <<EOF
+$workers
+EOF
+
+  [ "$printonly" -eq 1 ] && return 0
+  if [ "$i" -eq 0 ]; then
+    tmux display-message "fm-layout: no active workers to reference"
+    return 0
+  fi
+  [ -n "$client" ] || client=$(tmux display-message -p '#{client_name}' 2>/dev/null || true)
+  if [ -n "$client" ]; then
+    tmux display-menu -c "$client" -T " #worker -> composer " "${menu[@]}"
+  else
+    tmux display-menu -T " #worker -> composer " "${menu[@]}"
+  fi
+}
+
+# cmd_insert_ref: type a worker's reference token into a target pane. Validates the
+# window is a live worker first, then send-keys the reference (FM_LAYOUT_REF_FORMAT)
+# plus a trailing space so the captain keeps typing the rest of the message.
+cmd_insert_ref() {  # -p <pane> -w <window>
+  require_tmux
+  local pane="" window=""
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      -p) pane=$2; shift 2 ;;
+      -w) window=$2; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+  [ -n "$pane" ] && [ -n "$window" ] || die "usage: fm-layout.sh insert-ref -p <pane> -w <window>"
+  local rec ref
+  rec=$(worker_record "$window")
+  if [ -z "$rec" ]; then
+    tmux display-message "fm-layout: '$window' is no longer a live worker" 2>/dev/null || true
+    return 0
+  fi
+  ref=$(fm_layout_ref "$window")
+  tmux send-keys -t "$pane" -l "$ref "
+}
+
 # ---- keybindings (opt-in, runtime-only) ------------------------------------
 
 cmd_bind() {
@@ -274,7 +354,8 @@ cmd_bind() {
   [ "${1:-}" = "--mouse" ] && mouse=1
   tmux bind-key "$KEY_ARRANGE" run-shell "$BIN/fm-layout.sh arrange --window '#{window_id}'"
   tmux bind-key "$KEY_PICK" display-popup -E "$BIN/fm-layout-pick.sh"
-  echo "bound: prefix+$KEY_ARRANGE = arrange/refresh, prefix+$KEY_PICK = pick worker"
+  tmux bind-key "$KEY_REF" run-shell "$BIN/fm-layout.sh ref -p '#{pane_id}' -c '#{client_name}'"
+  echo "bound: prefix+$KEY_ARRANGE = arrange/refresh, prefix+$KEY_PICK = pick worker, prefix+$KEY_REF = insert worker reference"
   if [ "$mouse" -eq 1 ]; then
     tmux set -g mouse on
     tmux bind-key -n MouseDown3Pane \
@@ -289,8 +370,9 @@ cmd_unbind() {
   require_tmux
   tmux unbind-key "$KEY_ARRANGE" 2>/dev/null || true
   tmux unbind-key "$KEY_PICK" 2>/dev/null || true
+  tmux unbind-key "$KEY_REF" 2>/dev/null || true
   tmux unbind-key -n MouseDown3Pane 2>/dev/null || true
-  echo "unbound prefix+$KEY_ARRANGE, prefix+$KEY_PICK, and right-click."
+  echo "unbound prefix+$KEY_ARRANGE, prefix+$KEY_PICK, prefix+$KEY_REF, and right-click."
   echo "mouse mode left unchanged; run 'tmux set -g mouse off' to disable it if you enabled it here."
 }
 
@@ -309,8 +391,10 @@ case "$cmd" in
   assign) cmd_assign "$@" ;;
   pick) cmd_pick "$@" ;;
   mouse-pick) cmd_mouse_pick "$@" ;;
+  ref) cmd_ref "$@" ;;
+  insert-ref) cmd_insert_ref "$@" ;;
   bind) cmd_bind "$@" ;;
   unbind) cmd_unbind ;;
   -h|--help|help) usage ;;
-  *) die "unknown subcommand '$cmd' (try: arrange, workers, slots, assign, pick, bind, unbind)" ;;
+  *) die "unknown subcommand '$cmd' (try: arrange, workers, slots, assign, pick, ref, bind, unbind)" ;;
 esac

--- a/bin/fm-layout.sh
+++ b/bin/fm-layout.sh
@@ -335,7 +335,7 @@ cmd_insert_ref() {  # -p <pane> -w <window>
       *) shift ;;
     esac
   done
-  [ -n "$pane" ] && [ -n "$window" ] || die "usage: fm-layout.sh insert-ref -p <pane> -w <window>"
+  if [ -z "$pane" ] || [ -z "$window" ]; then die "usage: fm-layout.sh insert-ref -p <pane> -w <window>"; fi
   local rec ref
   rec=$(worker_record "$window")
   if [ -z "$rec" ]; then
@@ -383,7 +383,7 @@ usage() {
 # ---- dispatch --------------------------------------------------------------
 
 cmd=${1:-arrange}
-[ $# -gt 0 ] && shift || true
+if [ $# -gt 0 ]; then shift; fi
 case "$cmd" in
   arrange) cmd_arrange "$@" ;;
   workers) cmd_workers ;;

--- a/bin/fm-layout.sh
+++ b/bin/fm-layout.sh
@@ -1,0 +1,316 @@
+#!/usr/bin/env bash
+# fm-layout.sh — arrange the firstmate orchestrator window into a captain
+# dashboard: a left command column (top 2/3 orchestrator chat, bottom 1/3 a terse
+# active-worker summary) taking 1/3 width, and a right 2/3 column split into three
+# stacked worker watch slots. The watch slots are READ-ONLY mirrors of live worker
+# windows (capture-pane loops, bin/fm-watch-pane.sh); workers keep running in their
+# own windows untouched, so nothing here ever moves, kills, or obscures real work.
+#
+# Safe to re-run: arrange rebuilds only its own viewer panes (those tagged
+# @fm_role=slot:* / summary), never the orchestrator pane, never a worker, and
+# never panes it does not recognize (it refuses a window holding unexpected panes
+# unless --force). Slot assignments survive a rebuild when their worker is still
+# live. The orchestrator pane stays the focused, fully usable command pane.
+#
+# Worker discovery is delegated to bin/fm-layout-lib.sh, so "which workers exist"
+# is identical across the summary pane, the watch panes, and the picker.
+#
+# Subcommands:
+#   arrange [--window <id>] [--force]   build/refresh the dashboard (default)
+#   workers                             print live workers as idx<TAB>window<TAB>repo<TAB>label
+#   slots                               print the three slot assignments
+#   assign <1|2|3> <window|->            assign a worker to a slot (- clears it)
+#   pick [1|2|3]                        open the interactive picker popup
+#   mouse-pick -p <pane> -c <client>    right-click handler (resolves slot from pane)
+#   bind [--mouse]                      install opt-in runtime keybindings
+#   unbind                              remove them
+#
+# Keybindings are runtime-only (tmux bind-key / set, never ~/.tmux.conf) and
+# opt-in via `bind`. See docs/orchestrator-layout.md for the picker UX, the
+# right-click caveats, and how to undo everything.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+export FM_LAYOUT_STATE="$STATE"
+BIN="$SCRIPT_DIR"
+
+# shellcheck source=bin/fm-layout-lib.sh
+. "$SCRIPT_DIR/fm-layout-lib.sh"
+
+# Opt-in prefix keys (capitals, not default tmux bindings); overridable so a
+# captain whose config already uses them can pick others.
+KEY_ARRANGE="${FM_LAYOUT_KEY_ARRANGE:-O}"
+KEY_PICK="${FM_LAYOUT_KEY_PICK:-P}"
+
+die() { echo "fm-layout: $*" >&2; exit 1; }
+
+require_tmux() {
+  command -v tmux >/dev/null 2>&1 || die "tmux not found; this is a tmux layout tool"
+  [ -n "${TMUX:-}" ] || [ -n "${FM_LAYOUT_ALLOW_NO_TMUX:-}" ] \
+    || die "not inside a tmux session; run this from your firstmate terminal"
+}
+
+# ---- worker / slot helpers -------------------------------------------------
+
+# Print live workers with a 1-based index for the picker and tests.
+cmd_workers() {
+  local i=0 line
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    i=$((i + 1))
+    printf '%d\t%s\n' "$i" "$line"
+  done <<EOF
+$(fm_layout_workers)
+EOF
+}
+
+# Echo the TSV record (window\trepo\tlabel) of a live worker by its window, or
+# empty if it is not a live worker.
+worker_record() {  # <window>
+  local want=$1 line win
+  while IFS= read -r line; do
+    win=${line%%	*}
+    [ "$win" = "$want" ] && { printf '%s' "$line"; return 0; }
+  done <<EOF
+$(fm_layout_workers)
+EOF
+  return 0
+}
+
+cmd_assign() {  # <slot> <window|->
+  [ $# -eq 2 ] || die "usage: fm-layout.sh assign <1|2|3> <window|->"
+  local slot=$1 target=$2 file rec
+  case "$slot" in 1|2|3) ;; *) die "slot must be 1, 2, or 3" ;; esac
+  file=$(fm_layout_slot_file "$STATE" "$slot")
+  if [ "$target" = "-" ] || [ -z "$target" ]; then
+    rm -f "$file"
+    echo "slot $slot cleared"
+    return 0
+  fi
+  rec=$(worker_record "$target")
+  [ -n "$rec" ] || die "'$target' is not a live worker (see: fm-layout.sh workers)"
+  printf '%s\n' "$rec" > "$file"
+  echo "slot $slot -> $target"
+}
+
+cmd_slots() {
+  local slot file line
+  for slot in 1 2 3; do
+    file=$(fm_layout_slot_file "$STATE" "$slot")
+    if [ -f "$file" ]; then line=$(cat "$file"); else line=""; fi
+    printf '%s\t%s\n' "$slot" "$line"
+  done
+}
+
+# Fill slot files: keep existing assignments whose worker is still live, then
+# fill empty slots from live workers not already shown. Never spawns work; an
+# empty slot just stays empty when there are fewer than three live workers.
+autofill_slots() {
+  local workers slot file win assigned=" " line
+  workers=$(fm_layout_workers)
+  # Drop stale assignments (worker window no longer live) and collect kept ones.
+  for slot in 1 2 3; do
+    file=$(fm_layout_slot_file "$STATE" "$slot")
+    [ -f "$file" ] || continue
+    win=$(head -1 "$file" | cut -f1)
+    if printf '%s\n' "$workers" | cut -f1 | grep -Fxq "$win"; then
+      assigned="$assigned$win "
+    else
+      rm -f "$file"
+    fi
+  done
+  # Fill empties from unassigned live workers, in discovery order.
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    win=${line%%	*}
+    case "$assigned" in *" $win "*) continue ;; esac
+    for slot in 1 2 3; do
+      file=$(fm_layout_slot_file "$STATE" "$slot")
+      [ -f "$file" ] && continue
+      printf '%s\n' "$line" > "$file"
+      assigned="$assigned$win "
+      break
+    done
+  done <<EOF
+$workers
+EOF
+}
+
+# ---- arrange ---------------------------------------------------------------
+
+viewer_cmd() {  # <slot|summary> -> shell command string for split-window
+  printf 'FM_LAYOUT_STATE=%q exec %q %q' "$STATE" "$BIN/fm-watch-pane.sh" "$1"
+}
+
+cmd_arrange() {
+  require_tmux
+  local win="" force=0
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --window) win=$2; shift 2 ;;
+      --force) force=1; shift ;;
+      *) die "arrange: unknown arg '$1'" ;;
+    esac
+  done
+  [ -n "$win" ] || win=$(tmux display-message -p '#{window_id}') \
+    || die "could not resolve the current tmux window"
+
+  # Refuse to restructure a worker window (named fm-*); only the orchestrator
+  # window is ours to arrange.
+  local wname
+  wname=$(tmux display-message -p -t "$win" '#{window_name}' 2>/dev/null) \
+    || die "window '$win' not found"
+  case "$wname" in
+    fm-*) [ "$force" -eq 1 ] || die "'$wname' looks like a worker window; refusing to arrange it (pass --force to override)" ;;
+  esac
+
+  # Identify the orchestrator pane: a previously-tagged one, else the active pane.
+  local orch
+  orch=$(tmux list-panes -t "$win" -F '#{pane_id} #{@fm_role}' \
+    | awk '$2=="orchestrator"{print $1; exit}')
+  [ -n "$orch" ] || orch=$(tmux display-message -p -t "$win" '#{pane_id}')
+
+  # Tear down only our own prior viewer panes; never the orchestrator or anything
+  # we do not recognize.
+  local pid role
+  while read -r pid role; do
+    [ "$pid" = "$orch" ] && continue
+    case "$role" in
+      slot:*|summary) tmux kill-pane -t "$pid" 2>/dev/null || true ;;
+    esac
+  done < <(tmux list-panes -t "$win" -F '#{pane_id} #{@fm_role}')
+
+  # After clearing our viewers, only the orchestrator should remain. Unknown
+  # leftover panes are not destroyed without an explicit --force.
+  local remaining
+  remaining=$(tmux list-panes -t "$win" -F '#{pane_id}' | grep -c .)
+  if [ "$remaining" -ne 1 ]; then
+    if [ "$force" -eq 1 ]; then
+      tmux list-panes -t "$win" -F '#{pane_id}' | while read -r pid; do
+        [ "$pid" = "$orch" ] || tmux kill-pane -t "$pid" 2>/dev/null || true
+      done
+    else
+      die "window has $((remaining - 1)) unexpected pane(s) besides the command pane; close them or pass --force"
+    fi
+  fi
+
+  # Pre-populate slot assignments so the first paint shows workers immediately.
+  autofill_slots
+
+  local height third slot1 slot2 slot3 summary
+  height=$(tmux display-message -p -t "$win" '#{window_height}')
+  case "$height" in ''|*[!0-9]*) height=24 ;; esac
+  third=$((height / 3))
+  [ "$third" -ge 1 ] || third=1
+
+  # Right 2/3 column, three stacked watch slots.
+  slot1=$(tmux split-window -h -t "$orch" -l 66% -d -P -F '#{pane_id}' "$(viewer_cmd 1)")
+  slot2=$(tmux split-window -v -t "$slot1" -d -P -F '#{pane_id}' "$(viewer_cmd 2)")
+  slot3=$(tmux split-window -v -t "$slot2" -d -P -F '#{pane_id}' "$(viewer_cmd 3)")
+  tmux resize-pane -t "$slot1" -y "$third" 2>/dev/null || true
+  tmux resize-pane -t "$slot2" -y "$third" 2>/dev/null || true
+
+  # Left column: orchestrator keeps the top 2/3, summary takes the bottom 1/3.
+  summary=$(tmux split-window -v -t "$orch" -l 33% -d -P -F '#{pane_id}' "$(viewer_cmd summary)")
+
+  # Tag roles so re-runs and the mouse picker can find panes; titles for clarity.
+  tmux set -p -t "$orch" @fm_role orchestrator
+  tmux set -p -t "$slot1" @fm_role slot:1
+  tmux set -p -t "$slot2" @fm_role slot:2
+  tmux set -p -t "$slot3" @fm_role slot:3
+  tmux set -p -t "$summary" @fm_role summary
+  tmux set -w -t "$win" @fm_layout 1
+  tmux select-pane -t "$orch" -T 'orchestrator' 2>/dev/null || true
+  tmux select-pane -t "$slot1" -T 'watch 1' 2>/dev/null || true
+  tmux select-pane -t "$slot2" -T 'watch 2' 2>/dev/null || true
+  tmux select-pane -t "$slot3" -T 'watch 3' 2>/dev/null || true
+  tmux select-pane -t "$summary" -T 'workers' 2>/dev/null || true
+  tmux set -w -t "$win" pane-border-status top 2>/dev/null || true
+
+  # Keep the captain in the command pane.
+  tmux select-pane -t "$orch"
+  echo "dashboard arranged in $wname: command column (orchestrator + worker summary), 3 watch slots"
+}
+
+# ---- picker entrypoints ----------------------------------------------------
+
+cmd_pick() {  # [slot]
+  require_tmux
+  local slot=${1:-}
+  tmux display-popup -E "$BIN/fm-layout-pick.sh${slot:+ $slot}"
+}
+
+cmd_mouse_pick() {  # -p <pane> -c <client>
+  local pane="" client=""
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      -p) pane=$2; shift 2 ;;
+      -c) client=$2; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+  [ -n "$pane" ] || exit 0
+  local role slot
+  role=$(tmux show -p -t "$pane" -v @fm_role 2>/dev/null || true)
+  case "$role" in
+    slot:*) slot=${role#slot:} ;;
+    *) exit 0 ;;  # right-click outside a watch pane: harmless no-op
+  esac
+  if [ -n "$client" ]; then
+    tmux display-popup -c "$client" -E "$BIN/fm-layout-pick.sh $slot"
+  else
+    tmux display-popup -E "$BIN/fm-layout-pick.sh $slot"
+  fi
+}
+
+# ---- keybindings (opt-in, runtime-only) ------------------------------------
+
+cmd_bind() {
+  require_tmux
+  local mouse=0
+  [ "${1:-}" = "--mouse" ] && mouse=1
+  tmux bind-key "$KEY_ARRANGE" run-shell "$BIN/fm-layout.sh arrange --window '#{window_id}'"
+  tmux bind-key "$KEY_PICK" display-popup -E "$BIN/fm-layout-pick.sh"
+  echo "bound: prefix+$KEY_ARRANGE = arrange/refresh, prefix+$KEY_PICK = pick worker"
+  if [ "$mouse" -eq 1 ]; then
+    tmux set -g mouse on
+    tmux bind-key -n MouseDown3Pane \
+      run-shell "$BIN/fm-layout.sh mouse-pick -p '#{mouse_pane}' -c '#{client_name}'"
+    echo "mouse: right-click a watch pane to reassign it"
+    echo "note: this enabled tmux mouse mode and rebound right-click SERVER-WIDE (best-effort)."
+    echo "      undo with: fm-layout.sh unbind  (then: tmux set -g mouse off  if you want mouse off)"
+  fi
+}
+
+cmd_unbind() {
+  require_tmux
+  tmux unbind-key "$KEY_ARRANGE" 2>/dev/null || true
+  tmux unbind-key "$KEY_PICK" 2>/dev/null || true
+  tmux unbind-key -n MouseDown3Pane 2>/dev/null || true
+  echo "unbound prefix+$KEY_ARRANGE, prefix+$KEY_PICK, and right-click."
+  echo "mouse mode left unchanged; run 'tmux set -g mouse off' to disable it if you enabled it here."
+}
+
+usage() {
+  sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+# ---- dispatch --------------------------------------------------------------
+
+cmd=${1:-arrange}
+[ $# -gt 0 ] && shift || true
+case "$cmd" in
+  arrange) cmd_arrange "$@" ;;
+  workers) cmd_workers ;;
+  slots) cmd_slots ;;
+  assign) cmd_assign "$@" ;;
+  pick) cmd_pick "$@" ;;
+  mouse-pick) cmd_mouse_pick "$@" ;;
+  bind) cmd_bind "$@" ;;
+  unbind) cmd_unbind ;;
+  -h|--help|help) usage ;;
+  *) die "unknown subcommand '$cmd' (try: arrange, workers, slots, assign, pick, bind, unbind)" ;;
+esac

--- a/bin/fm-watch-pane.sh
+++ b/bin/fm-watch-pane.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# fm-watch-pane.sh — the long-lived content of one dashboard pane.
+#
+#   fm-watch-pane.sh <1|2|3>   read-only mirror of the worker assigned to that
+#                              slot: a header plus the tail of the worker's live
+#                              pane, refreshed every FM_LAYOUT_REFRESH seconds.
+#   fm-watch-pane.sh summary   the terse active-worker summary: one "• repo -
+#                              label" bullet per live worker, truncated to fit.
+#
+# This NEVER writes to, sends keys to, or restructures a worker — it only
+# `capture-pane`s. The worker stays in its own window doing its work. Slot
+# assignments come from state/.layout-slot-<n> (written by fm-layout.sh), re-read
+# every refresh, so reassigning a slot is just a file rewrite with no pane churn.
+# A killed pane ends the loop cleanly; that is how arrange tears a viewer down.
+#
+# FM_LAYOUT_REFRESH (default 2) sets the cadence. FM_LAYOUT_ONCE=1 renders a
+# single frame and exits (used by tests and one-shot inspection).
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=bin/fm-layout-lib.sh
+. "$SCRIPT_DIR/fm-layout-lib.sh"
+
+SLOT=${1:-summary}
+STATE=$(fm_layout_state)
+REFRESH=${FM_LAYOUT_REFRESH:-2}
+
+BOLD=$'\033[1m'; DIM=$'\033[2m'; RST=$'\033[0m'
+
+pane_dim() {  # <which: width|height> -> numeric, with a sane fallback
+  local fmt=$1 val=""
+  if [ -n "${TMUX_PANE:-}" ]; then
+    val=$(tmux display-message -p -t "$TMUX_PANE" "#{pane_$fmt}" 2>/dev/null || true)
+  fi
+  case "$val" in ''|*[!0-9]*) [ "$fmt" = width ] && val=80 || val=12 ;; esac
+  printf '%s' "$val"
+}
+
+# Truncate a line to <width> columns (best-effort; byte-wise under C locale, which
+# is enough to stop wrapping in a narrow watch pane).
+fit() {  # <width>
+  local w=$1
+  LC_ALL=C awk -v w="$w" '{ if (length($0) > w) print substr($0, 1, w); else print }'
+}
+
+clear_screen() { printf '\033[H\033[2J'; }
+
+render_slot() {  # <width> <height>
+  local w=$1 h=$2 file win repo label live body lines
+  file=$(fm_layout_slot_file "$STATE" "$SLOT")
+  if [ ! -s "$file" ]; then
+    printf '%s[ watch %s ]%s %s(unassigned)%s\n' "$BOLD" "$SLOT" "$RST" "$DIM" "$RST"
+    printf '%s\n' "$(printf '%*s' "$w" '' | tr ' ' '-')" | fit "$w"
+    printf '%sno worker here — open the picker to assign one%s\n' "$DIM" "$RST"
+    return 0
+  fi
+  IFS=$'\t' read -r win repo label < "$file"
+  printf '%s[ watch %s ]%s %s · %s %s(%s)%s\n' "$BOLD" "$SLOT" "$RST" "$repo" "$label" "$DIM" "$win" "$RST" | fit "$w"
+  printf '%s\n' "$(printf '%*s' "$w" '' | tr ' ' '-')" | fit "$w"
+  if printf '%s\n' "$(fm_layout_live_windows)" | grep -Fxq "$win"; then
+    lines=$((h - 2)); [ "$lines" -ge 1 ] || lines=1
+    body=$(tmux capture-pane -p -t "$win" 2>/dev/null | sed -e 's/[[:space:]]*$//' | grep -v '^$' | tail -n "$lines")
+    printf '%s\n' "$body" | fit "$w"
+  else
+    printf '%sworker ended — reassign this slot from the picker%s\n' "$DIM" "$RST"
+  fi
+}
+
+render_summary() {  # <width>
+  local w=$1 win repo label any=0
+  printf '%sactive workers%s\n' "$BOLD" "$RST"
+  printf '%s\n' "$(printf '%*s' "$w" '' | tr ' ' '-')" | fit "$w"
+  while IFS=$'\t' read -r win repo label; do
+    [ -n "$win" ] || continue
+    any=1
+    printf '%s\n' "• $repo - $label" | fit "$w"
+  done <<EOF
+$(fm_layout_workers)
+EOF
+  [ "$any" -eq 1 ] || printf '%s(none active)%s\n' "$DIM" "$RST"
+}
+
+render() {
+  local w h
+  w=$(pane_dim width); h=$(pane_dim height)
+  clear_screen
+  if [ "$SLOT" = summary ]; then
+    render_summary "$w"
+  else
+    render_slot "$w" "$h"
+  fi
+}
+
+if [ "${FM_LAYOUT_ONCE:-0}" = 1 ]; then
+  render
+  exit 0
+fi
+
+# Long-lived refresh loop. Transient capture/tmux errors never exit it; only a
+# killed pane (SIGHUP/SIGPIPE on the dead terminal) stops it.
+while :; do
+  render || true
+  sleep "$REFRESH" || exit 0
+done

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -145,6 +145,8 @@ FM_LOG_KEEP_LINES=2000             # daemon log lines kept when trimming
 FM_LAYOUT_REFRESH=2                # seconds between watch/summary pane refreshes
 FM_LAYOUT_LABEL_MAX=30             # max worker feature-label width before truncation
 FM_LAYOUT_KEY_ARRANGE=O           # prefix key bound to arrange by `fm-layout.sh bind`
-FM_LAYOUT_KEY_PICK=P              # prefix key bound to the picker by `fm-layout.sh bind`
+FM_LAYOUT_KEY_PICK=P              # prefix key bound to the slot picker by `fm-layout.sh bind`
+FM_LAYOUT_KEY_REF=#               # prefix key bound to the worker-reference picker by `fm-layout.sh bind`
+FM_LAYOUT_REF_FORMAT=target       # what the reference picker types: target|window|select
 FM_LAYOUT_INCLUDE_SECONDMATES=    # set to 1 to also watch secondmate homes
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -141,4 +141,10 @@ FM_CRASH_BACKOFF=60                # seconds to wait after crossing the crash th
 FM_CRASH_NORMAL_SLEEP=5            # seconds to wait after an isolated watcher crash
 FM_LOG_MAX_BYTES=1048576           # daemon log size that triggers trimming
 FM_LOG_KEEP_LINES=2000             # daemon log lines kept when trimming
+# orchestrator dashboard (bin/fm-layout.sh); see docs/orchestrator-layout.md
+FM_LAYOUT_REFRESH=2                # seconds between watch/summary pane refreshes
+FM_LAYOUT_LABEL_MAX=30             # max worker feature-label width before truncation
+FM_LAYOUT_KEY_ARRANGE=O           # prefix key bound to arrange by `fm-layout.sh bind`
+FM_LAYOUT_KEY_PICK=P              # prefix key bound to the picker by `fm-layout.sh bind`
+FM_LAYOUT_INCLUDE_SECONDMATES=    # set to 1 to also watch secondmate homes
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -147,6 +147,6 @@ FM_LAYOUT_LABEL_MAX=30             # max worker feature-label width before trunc
 FM_LAYOUT_KEY_ARRANGE=O           # prefix key bound to arrange by `fm-layout.sh bind`
 FM_LAYOUT_KEY_PICK=P              # prefix key bound to the slot picker by `fm-layout.sh bind`
 FM_LAYOUT_KEY_REF=#               # prefix key bound to the worker-reference picker by `fm-layout.sh bind`
-FM_LAYOUT_REF_FORMAT=target       # what the reference picker types: target|window|select
+FM_LAYOUT_REF_FORMAT=window       # what the reference picker types: window|target|select
 FM_LAYOUT_INCLUDE_SECONDMATES=    # set to 1 to also watch secondmate homes
 ```

--- a/docs/orchestrator-layout.md
+++ b/docs/orchestrator-layout.md
@@ -117,7 +117,7 @@ composer**, so you stop hand-copying terminal targets:
 
 ```
 Captain types:  <prefix> #   ->  picks "portals-cx - close issues"
-Composer becomes:  firstmate:fm-close-portals-resolved-issues-h6 ▮
+Composer becomes:  fm-close-portals-resolved-issues-h6 ▮
                    ...then continue typing: "refactor is done, now add X"
 ```
 
@@ -153,8 +153,8 @@ the same under any agent harness and needs no credentials.
 
 | Value | Inserts | Use |
 | --- | --- | --- |
-| `target` (default) | `firstmate:fm-<id>` | the literal tmux target - usable with `tmux`, and resolved by `fm-send`/`fm-peek`. |
-| `window` | `fm-<id>` | the bare window name firstmate's tools resolve. |
+| `window` (default) | `fm-<id>` | the short, human-readable window name firstmate's tools resolve. |
+| `target` | `firstmate:fm-<id>` | the literal tmux target - usable with `tmux`, and resolved by `fm-send`/`fm-peek`. |
 | `select` | `tmux select-window -t firstmate:fm-<id>` | a ready-to-run command to jump to that worker. |
 
 The same reference is shown in each watch pane's header `(…)`, so the dashboard and
@@ -179,7 +179,7 @@ strings `fm-layout.sh ref --print` produces apply.
 | `FM_LAYOUT_KEY_ARRANGE` | `O` | Prefix key bound to arrange by `bind`. |
 | `FM_LAYOUT_KEY_PICK` | `P` | Prefix key bound to the slot picker by `bind`. |
 | `FM_LAYOUT_KEY_REF` | `#` | Prefix key bound to the worker-reference picker by `bind`. |
-| `FM_LAYOUT_REF_FORMAT` | `target` | What the reference picker types: `target`, `window`, or `select`. |
+| `FM_LAYOUT_REF_FORMAT` | `window` | What the reference picker types: `window`, `target`, or `select`. |
 | `FM_LAYOUT_INCLUDE_SECONDMATES` | unset | Set to `1` to watch secondmate homes too. |
 
 ## Implementation

--- a/docs/orchestrator-layout.md
+++ b/docs/orchestrator-layout.md
@@ -1,0 +1,137 @@
+# Orchestrator dashboard layout
+
+A terminal dashboard for the captain: keep the command pane in view while watching
+several workers at once. One command arranges the current firstmate tmux window
+into:
+
+```
+┌─────────────┬───────────────────────────────┐
+│             │           watch 1             │
+│ orchestrator│  (live mirror of a worker)    │
+│   (command) ├───────────────────────────────┤
+│   top 2/3   │           watch 2             │
+│             │                               │
+├─────────────┼───────────────────────────────┤
+│  workers    │           watch 3             │
+│ summary 1/3 │                               │
+└─────────────┴───────────────────────────────┘
+   left 1/3              right 2/3
+```
+
+- **Left 1/3, top 2/3 - orchestrator.** Your existing firstmate chat/command pane,
+  kept focused and fully usable. Arrange never replaces, moves, or obscures it.
+- **Left 1/3, bottom 1/3 - worker summary.** Terse `• repo - label` bullets for
+  every active worker, truncated to fit the small panel (no long wrapping).
+- **Right 2/3 - three stacked watch slots.** Each slot is a **read-only mirror** of
+  a live worker's pane (a `capture-pane` loop). Workers keep running in their own
+  windows, untouched; nothing here ever sends keys, moves, or kills a worker.
+
+## Commands
+
+All live in `bin/`. Run them from your firstmate terminal.
+
+| Command | What it does |
+| --- | --- |
+| `fm-layout.sh` (or `fm-layout.sh arrange`) | Build/refresh the dashboard in the current window. |
+| `fm-layout.sh pick [1\|2\|3]` | Open the keyboard picker to assign a worker to a slot. |
+| `fm-layout.sh workers` | List the live workers (`idx`, window, repo, label). |
+| `fm-layout.sh slots` | Show the three current slot assignments. |
+| `fm-layout.sh assign <1\|2\|3> <window\|->` | Assign a worker to a slot (`-` clears it). |
+| `fm-layout.sh bind [--mouse]` | Install opt-in tmux keybindings (see below). |
+| `fm-layout.sh unbind` | Remove those keybindings. |
+
+`arrange` is **safe to re-run**. It rebuilds only its own viewer panes (the summary
+and the three watch slots), never the orchestrator pane, never a worker, and never
+a pane it does not recognize. If the window holds unexpected panes it refuses and
+leaves everything intact (pass `--force` only if you want those extra panes
+removed). It also refuses to restructure a worker window (one named `fm-*`).
+
+## Worker discovery
+
+Workers are discovered from this home's `state/*.meta` files - any task whose tmux
+window is currently live. The window's `project=` gives the repo; the task id gives
+a terse feature label (the random suffix is dropped and words are spaced, e.g.
+`scrub-pajamas-refactor-y8` → `scrub pajamas refactor`, truncated to
+`FM_LAYOUT_LABEL_MAX`, default 30). Persistent secondmate homes are skipped (set
+`FM_LAYOUT_INCLUDE_SECONDMATES=1` to include them).
+
+When more than three workers are active, the three slots start on the first three
+and you swap any worker into any slot with the picker - the layout never spawns new
+work to fill a slot, and an empty slot just stays empty.
+
+## Reassigning a slot
+
+### Keyboard picker (reliable baseline)
+
+`fm-layout.sh pick` opens a small popup that lists the live workers numbered; type
+the slot, then the worker number (or `0` to clear). This is the dependable path and
+works on any tmux/terminal. Reassignment is just a file rewrite
+(`state/.layout-slot-<n>`); the watch pane re-reads it on its next refresh, so no
+panes are created or destroyed.
+
+### Keybindings (opt-in)
+
+`fm-layout.sh bind` installs two **runtime** prefix bindings (it edits the live tmux
+server with `bind-key`, never your `~/.tmux.conf`):
+
+- `prefix O` - arrange/refresh the dashboard.
+- `prefix P` - open the picker popup.
+
+The keys are capitals to avoid clobbering tmux defaults; override them with
+`FM_LAYOUT_KEY_ARRANGE` / `FM_LAYOUT_KEY_PICK`. Remove them with
+`fm-layout.sh unbind`.
+
+### Mouse / right-click (best-effort, fragile - opt-in)
+
+`fm-layout.sh bind --mouse` additionally lets you right-click a watch pane to open
+its picker. This is **best-effort and intentionally not on by default**, because of
+tmux limitations:
+
+- tmux key tables (including mouse bindings) are **server-global**, not
+  per-session/per-window. There is no way to scope a right-click binding to only the
+  dashboard panes, so enabling it rebinds `MouseDown3Pane` for the whole server.
+  Right-clicking outside a watch pane becomes a harmless no-op rather than your
+  terminal's usual paste/context-menu behavior.
+- It also turns on tmux `mouse` mode server-wide, which changes selection/scroll
+  behavior in every pane.
+
+Because of that global reach, the keyboard picker is the supported path; the mouse
+binding is offered for captains who knowingly accept the trade-off. `unbind` removes
+the right-click binding; it leaves `mouse` mode as-is (run `tmux set -g mouse off`
+yourself if you want it off).
+
+## Environment
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `FM_LAYOUT_REFRESH` | `2` | Seconds between watch/summary refreshes. |
+| `FM_LAYOUT_LABEL_MAX` | `30` | Max feature-label width before truncation. |
+| `FM_LAYOUT_KEY_ARRANGE` | `O` | Prefix key bound to arrange by `bind`. |
+| `FM_LAYOUT_KEY_PICK` | `P` | Prefix key bound to the picker by `bind`. |
+| `FM_LAYOUT_INCLUDE_SECONDMATES` | unset | Set to `1` to watch secondmate homes too. |
+
+## Implementation
+
+- `bin/fm-layout.sh` - arrange/assign/pick/bind CLI.
+- `bin/fm-layout-lib.sh` - shared worker discovery and slot helpers.
+- `bin/fm-watch-pane.sh` - the per-pane mirror/summary refresh loop.
+- `bin/fm-layout-pick.sh` - the interactive popup picker.
+
+Slot assignments live in `state/.layout-slot-<n>` (gitignored runtime state, in the
+`.layout-*` namespace the watcher never touches). The watch panes only
+`capture-pane` their target, so they are read-only by construction.
+
+### Manual verification
+
+The behavior is covered by `tests/fm-layout.test.sh` (real tmux on a private
+socket): discovery/exclusion, label truncation, assign/clear/reject, arrange
+geometry, idempotent re-run, the worker-window and unexpected-pane refusals, and the
+rendered summary/mirror content. To watch it by hand:
+
+```sh
+# from a firstmate window with a few workers in flight:
+bin/fm-layout.sh arrange      # builds the dashboard
+bin/fm-layout.sh workers      # see who is live
+bin/fm-layout.sh pick 3       # assign a 4th worker into slot 3
+bin/fm-layout.sh arrange      # safe to re-run; geometry unchanged
+```

--- a/docs/orchestrator-layout.md
+++ b/docs/orchestrator-layout.md
@@ -26,6 +26,12 @@ into:
   a live worker's pane (a `capture-pane` loop). Workers keep running in their own
   windows, untouched; nothing here ever sends keys, moves, or kills a worker.
 
+## Requirements
+
+The dashboard needs **tmux >= 3.1**. `arrange` sizes its panes with the
+`split-window -l <pct>%` percentage form, which tmux only understands from 3.1
+onward (older tmux used `-p <pct>`); on tmux < 3.1 `arrange` fails.
+
 ## Commands
 
 All live in `bin/`. Run them from your firstmate terminal.

--- a/docs/orchestrator-layout.md
+++ b/docs/orchestrator-layout.md
@@ -157,9 +157,11 @@ the same under any agent harness and needs no credentials.
 | `target` | `firstmate:fm-<id>` | the literal tmux target - usable with `tmux`, and resolved by `fm-send`/`fm-peek`. |
 | `select` | `tmux select-window -t firstmate:fm-<id>` | a ready-to-run command to jump to that worker. |
 
-The same reference is shown in each watch pane's header `(…)`, so the dashboard and
-the typed token always agree. `fm-layout.sh ref --print` lists the menu's targets
-(used by tests and scripting).
+Each watch pane's header shows the worker's full `session:window` target in `(…)`;
+the typed reference is that same target, or in the default `window` form its
+window-name part, so the dashboard and the typed token always point at the same
+worker. `fm-layout.sh ref --print` lists the menu's targets (used by tests and
+scripting).
 
 ### Optional: cmux delivery
 

--- a/docs/orchestrator-layout.md
+++ b/docs/orchestrator-layout.md
@@ -43,6 +43,7 @@ All live in `bin/`. Run them from your firstmate terminal.
 | `fm-layout.sh workers` | List the live workers (`idx`, window, repo, label). |
 | `fm-layout.sh slots` | Show the three current slot assignments. |
 | `fm-layout.sh assign <1\|2\|3> <window\|->` | Assign a worker to a slot (`-` clears it). |
+| `fm-layout.sh ref` | Open the worker-reference picker and type the chosen worker's reference into the composer (see [Worker references](#worker-references-the--shortcut)). |
 | `fm-layout.sh bind [--mouse]` | Install opt-in tmux keybindings (see below). |
 | `fm-layout.sh unbind` | Remove those keybindings. |
 
@@ -81,11 +82,12 @@ panes are created or destroyed.
 server with `bind-key`, never your `~/.tmux.conf`):
 
 - `prefix O` - arrange/refresh the dashboard.
-- `prefix P` - open the picker popup.
+- `prefix P` - open the slot picker popup.
+- `prefix #` - open the worker-reference picker (types a worker reference into the composer; see [Worker references](#worker-references-the--shortcut)).
 
-The keys are capitals to avoid clobbering tmux defaults; override them with
-`FM_LAYOUT_KEY_ARRANGE` / `FM_LAYOUT_KEY_PICK`. Remove them with
-`fm-layout.sh unbind`.
+The arrange/pick keys are capitals to avoid clobbering tmux defaults; override them
+with `FM_LAYOUT_KEY_ARRANGE` / `FM_LAYOUT_KEY_PICK` / `FM_LAYOUT_KEY_REF`. Remove
+them all with `fm-layout.sh unbind`.
 
 ### Mouse / right-click (best-effort, fragile - opt-in)
 
@@ -106,6 +108,68 @@ binding is offered for captains who knowingly accept the trade-off. `unbind` rem
 the right-click binding; it leaves `mouse` mode as-is (run `tmux set -g mouse off`
 yourself if you want it off).
 
+## Worker references (the `#` shortcut)
+
+When you message the orchestrator about a specific worker, you often need that
+worker's terminal target ("which one is worker 3?"). The reference shortcut lets
+you pick a worker from a menu and have its reference **typed straight into your
+composer**, so you stop hand-copying terminal targets:
+
+```
+Captain types:  <prefix> #   ->  picks "portals-cx - close issues"
+Composer becomes:  firstmate:fm-close-portals-resolved-issues-h6 ▮
+                   ...then continue typing: "refactor is done, now add X"
+```
+
+`fm-layout.sh bind` wires this to **`prefix #`**. Pressing it opens a tmux
+`display-menu` of the live workers (keyboard-navigable with `1`-`9`/arrows, and
+mouse-clickable - the same feel as an `@`/`/` picker); choosing one types that
+worker's reference into the pane you were in, plus a trailing space.
+
+### Why a prefix chord and not a bare `#`
+
+The ask was for a bare `#` (typed in the composer) to open the picker, mirroring
+`@`/`/`. **That is not feasible to intercept reliably**, and here is why for each
+layer:
+
+- **Agent composers (Claude, OpenCode, Codex, pi):** their `@`/`/` pickers are
+  built into each program. There is no public hook to register a new trigger
+  character from the outside; intercepting `#` would mean patching every harness.
+- **cmux:** its control CLI can `send` text to a surface and enumerate workspaces,
+  and it has configurable shortcuts - but those shortcuts only rebind cmux's own
+  built-in actions, there is no "bind `#` to run a script" facility, and no
+  `#`/`@` mention-trigger in its text box. Its control socket is also
+  password-gated, so an agent cannot drive it without the captain's credential.
+- **tmux:** binding a literal `#` in the root key table would hijack **every** `#`
+  you type (code, Markdown headings, shell comments), which is unacceptable.
+
+So the closest robust, harness-agnostic workflow is a tmux **prefix chord**
+(`prefix #`) that types the reference into whatever composer is focused. It works
+the same under any agent harness and needs no credentials.
+
+### Reference format
+
+`FM_LAYOUT_REF_FORMAT` chooses what gets typed:
+
+| Value | Inserts | Use |
+| --- | --- | --- |
+| `target` (default) | `firstmate:fm-<id>` | the literal tmux target - usable with `tmux`, and resolved by `fm-send`/`fm-peek`. |
+| `window` | `fm-<id>` | the bare window name firstmate's tools resolve. |
+| `select` | `tmux select-window -t firstmate:fm-<id>` | a ready-to-run command to jump to that worker. |
+
+The same reference is shown in each watch pane's header `(…)`, so the dashboard and
+the typed token always agree. `fm-layout.sh ref --print` lists the menu's targets
+(used by tests and scripting).
+
+### Optional: cmux delivery
+
+On cmux, `cmux send <surface> <text>` can deliver a reference to a surface's text
+box instead of typing locally. firstmate does not depend on this (the cmux control
+socket is password-gated and environment-specific), but if you have the socket
+password set (`CMUX_SOCKET_PASSWORD` or cmux Settings), `cmux workspace list` /
+`cmux tree` enumerate workers and `cmux send` routes text - the same reference
+strings `fm-layout.sh ref --print` produces apply.
+
 ## Environment
 
 | Variable | Default | Meaning |
@@ -113,15 +177,17 @@ yourself if you want it off).
 | `FM_LAYOUT_REFRESH` | `2` | Seconds between watch/summary refreshes. |
 | `FM_LAYOUT_LABEL_MAX` | `30` | Max feature-label width before truncation. |
 | `FM_LAYOUT_KEY_ARRANGE` | `O` | Prefix key bound to arrange by `bind`. |
-| `FM_LAYOUT_KEY_PICK` | `P` | Prefix key bound to the picker by `bind`. |
+| `FM_LAYOUT_KEY_PICK` | `P` | Prefix key bound to the slot picker by `bind`. |
+| `FM_LAYOUT_KEY_REF` | `#` | Prefix key bound to the worker-reference picker by `bind`. |
+| `FM_LAYOUT_REF_FORMAT` | `target` | What the reference picker types: `target`, `window`, or `select`. |
 | `FM_LAYOUT_INCLUDE_SECONDMATES` | unset | Set to `1` to watch secondmate homes too. |
 
 ## Implementation
 
-- `bin/fm-layout.sh` - arrange/assign/pick/bind CLI.
-- `bin/fm-layout-lib.sh` - shared worker discovery and slot helpers.
+- `bin/fm-layout.sh` - arrange/assign/pick/ref/bind CLI.
+- `bin/fm-layout-lib.sh` - shared worker discovery, slot, and reference helpers.
 - `bin/fm-watch-pane.sh` - the per-pane mirror/summary refresh loop.
-- `bin/fm-layout-pick.sh` - the interactive popup picker.
+- `bin/fm-layout-pick.sh` - the interactive slot-picker popup.
 
 Slot assignments live in `state/.layout-slot-<n>` (gitignored runtime state, in the
 `.layout-*` namespace the watcher never touches). The watch panes only
@@ -131,8 +197,9 @@ Slot assignments live in `state/.layout-slot-<n>` (gitignored runtime state, in 
 
 The behavior is covered by `tests/fm-layout.test.sh` (real tmux on a private
 socket): discovery/exclusion, label truncation, assign/clear/reject, arrange
-geometry, idempotent re-run, the worker-window and unexpected-pane refusals, and the
-rendered summary/mirror content. To watch it by hand:
+geometry, idempotent re-run, the worker-window and unexpected-pane refusals, the
+rendered summary/mirror content, and the worker-reference resolver/insertion. To
+watch it by hand:
 
 ```sh
 # from a firstmate window with a few workers in flight:
@@ -140,4 +207,5 @@ bin/fm-layout.sh arrange      # builds the dashboard
 bin/fm-layout.sh workers      # see who is live
 bin/fm-layout.sh pick 3       # assign a 4th worker into slot 3
 bin/fm-layout.sh arrange      # safe to re-run; geometry unchanged
+bin/fm-layout.sh bind         # then press: prefix #  -> pick a worker, ref is typed in
 ```

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -31,6 +31,10 @@ Each file also starts with a short header comment.
 | `fm-send.sh`             | Send one verified literal line (or `--key Escape`) to a direct-report window; exits non-zero on confirmed swallowed Enter; bare `kind=secondmate` targets are marked as from-firstmate; slash commands and codex `$...` skill invocations get popup-settle before Enter; text sends pause `FM_SEND_SETTLE` seconds after success |
 | `fm-tmux-lib.sh`         | Shared tmux pane primitives for busy detection, dim-ghost-aware and border-aware composer detection, and verified submit retry |
 | `fm-peek.sh`             | Print a bounded tail of a crewmate pane                                                                             |
+| `fm-layout.sh`           | Arrange the orchestrator window into a left command column (chat + worker summary) and three swappable worker watch slots; `arrange`/`workers`/`slots`/`assign`/`pick`/`bind` subcommands ([docs](orchestrator-layout.md)) |
+| `fm-layout-lib.sh`       | Shared live-worker discovery, terse repo/label derivation, and slot-file helpers sourced by the layout scripts      |
+| `fm-watch-pane.sh`       | Read-only refresh loop for one dashboard pane: a `capture-pane` mirror of an assigned worker, or the active-worker summary |
+| `fm-layout-pick.sh`      | Interactive keyboard picker popup that reassigns a watch slot to any live worker                                    |
 | `fm-pr-check.sh`         | Record `pr=` and a verified `pr_head=` when available for a PR-ready task, then arm the watcher's merge poll        |
 | `fm-promote.sh`          | Promote a scout task in place so it becomes a protected ship task                                                   |
 | `fm-teardown.sh`         | Return a clean, landed ship worktree or retire/release a secondmate home; requires scout reports, checks child work, and prints the backlog reminder |

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -31,7 +31,7 @@ Each file also starts with a short header comment.
 | `fm-send.sh`             | Send one verified literal line (or `--key Escape`) to a direct-report window; exits non-zero on confirmed swallowed Enter; bare `kind=secondmate` targets are marked as from-firstmate; slash commands and codex `$...` skill invocations get popup-settle before Enter; text sends pause `FM_SEND_SETTLE` seconds after success |
 | `fm-tmux-lib.sh`         | Shared tmux pane primitives for busy detection, dim-ghost-aware and border-aware composer detection, and verified submit retry |
 | `fm-peek.sh`             | Print a bounded tail of a crewmate pane                                                                             |
-| `fm-layout.sh`           | Arrange the orchestrator window into a left command column (chat + worker summary) and three swappable worker watch slots; `arrange`/`workers`/`slots`/`assign`/`pick`/`bind` subcommands ([docs](orchestrator-layout.md)) |
+| `fm-layout.sh`           | Arrange the orchestrator window into a left command column (chat + worker summary) and three swappable worker watch slots, and type worker references into the composer (`prefix #`); `arrange`/`workers`/`slots`/`assign`/`pick`/`ref`/`bind` subcommands ([docs](orchestrator-layout.md)) |
 | `fm-layout-lib.sh`       | Shared live-worker discovery, terse repo/label derivation, and slot-file helpers sourced by the layout scripts      |
 | `fm-watch-pane.sh`       | Read-only refresh loop for one dashboard pane: a `capture-pane` mirror of an assigned worker, or the active-worker summary |
 | `fm-layout-pick.sh`      | Interactive keyboard picker popup that reassigns a watch slot to any live worker                                    |

--- a/tests/fm-layout.test.sh
+++ b/tests/fm-layout.test.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# fm-layout.sh — orchestrator dashboard layout behavior.
+#
+# Covers, against a REAL tmux on a private socket (never the captain's session):
+#   1. Worker discovery from state/*.meta: live windows only, secondmates and
+#      windowless/stale metas excluded; repo from project=, label from the id.
+#   2. fm_layout_label: random-suffix strip and FM_LAYOUT_LABEL_MAX truncation.
+#   3. assign/slots round-trip, rejection of a non-worker, and slot clearing.
+#   4. arrange geometry: orchestrator preserved + active, one summary pane, three
+#      slot panes, @fm_layout marker, slots autofilled without spawning work.
+#   5. Re-running arrange is idempotent (still 5 panes) and never kills workers.
+#   6. arrange refuses a worker window and a window with unexpected panes (no
+#      --force), leaving everything intact.
+#   7. The summary pane renders terse bullets; a watch pane mirrors its worker.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+command -v tmux >/dev/null 2>&1 || { echo "1..0 # SKIP tmux not available"; exit 0; }
+REAL_TMUX=$(command -v tmux)
+LAYOUT="$ROOT/bin/fm-layout.sh"
+PANE="$ROOT/bin/fm-watch-pane.sh"
+
+TMP=$(fm_test_tmproot fm-layout)
+SOCK="fmlayout-test-$$"
+STATE="$TMP/state"
+mkdir -p "$STATE" "$TMP/shim"
+
+TM() { "$REAL_TMUX" -L "$SOCK" "$@"; }
+
+# tmux shim so fm-layout's internal `tmux` calls hit our private socket.
+cat > "$TMP/shim/tmux" <<SH
+#!/usr/bin/env bash
+exec "$REAL_TMUX" -L "$SOCK" "\$@"
+SH
+chmod +x "$TMP/shim/tmux"
+
+# Self-contained cleanup that always returns 0: fm_test_tmproot registered its dir
+# inside a $(...) subshell, so the parent's cleanup array is empty here. Returning
+# non-zero from an EXIT trap that runs as the script falls off the end would become
+# the script's exit status, so end on a zero-status command.
+cleanup_layout() {
+  TM kill-server 2>/dev/null || true
+  rm -rf "$TMP"
+  return 0
+}
+trap cleanup_layout EXIT
+
+export PATH="$TMP/shim:$PATH"
+export FM_STATE_OVERRIDE="$STATE" FM_HOME="$TMP" FM_LAYOUT_ALLOW_NO_TMUX=1
+
+meta() {  # <id> <window> <project> <kind>
+  cat > "$STATE/$1.meta" <<EOF
+window=$2
+project=$3
+kind=$4
+EOF
+}
+
+# --- fleet: orchestrator window + worker windows --------------------------
+TM new-session -d -s itest -n opencode -x 200 -y 60
+TM new-window -t itest -n fm-alpha-aa  'while :; do echo alpha-line; sleep 1; done'
+TM new-window -t itest -n fm-beta-bb   'while :; do echo beta-line; sleep 1; done'
+TM new-window -t itest -n fm-gamma-cc  'while :; do echo gamma-line; sleep 1; done'
+TM new-window -t itest -n fm-second-dd 'while :; do echo second-line; sleep 1; done'
+
+meta alpha-aa  itest:fm-alpha-aa  /x/projects/scrub-cx-engine ship
+meta beta-bb   itest:fm-beta-bb   /x/projects/portals-cx      scout
+meta gamma-cc  itest:fm-gamma-cc  /x/projects/synct_utility   ship
+meta second-dd itest:fm-second-dd /x/projects/secret          secondmate
+# Stale meta: its window does not exist on the socket.
+meta stale-zz  itest:fm-stale-zz  /x/projects/gone            ship
+
+ORCH_WIN=$(TM list-windows -t itest -F '#{window_id} #{window_name}' | awk '$2=="opencode"{print $1}')
+ALPHA_WIN=$(TM list-windows -t itest -F '#{window_id} #{window_name}' | awk '$2=="fm-alpha-aa"{print $1}')
+
+# --- 1. discovery ----------------------------------------------------------
+workers=$("$LAYOUT" workers)
+assert_contains "$workers" "scrub-cx-engine	alpha" "alpha worker discovered with repo+label"
+assert_contains "$workers" "portals-cx	beta" "beta worker discovered"
+assert_contains "$workers" "synct_utility	gamma" "gamma worker discovered"
+assert_not_contains "$workers" "secret" "secondmate excluded from workers"
+assert_not_contains "$workers" "gone" "stale (windowless) meta excluded from workers"
+[ "$(printf '%s\n' "$workers" | grep -c .)" -eq 3 ] || fail "expected exactly 3 live workers"
+pass "discovery lists only live, non-secondmate workers with repo+label"
+
+# --- 2. label humanization -------------------------------------------------
+. "$ROOT/bin/fm-layout-lib.sh"
+[ "$(fm_layout_label scrub-pajamas-refactor-y8)" = "scrub pajamas refactor" ] \
+  || fail "label should strip suffix and space words"
+[ "$(FM_LAYOUT_LABEL_MAX=10 fm_layout_label very-long-feature-name-q9)" = "very long…" ] \
+  || fail "label should truncate to FM_LAYOUT_LABEL_MAX with an ellipsis"
+pass "label strips the random suffix and truncates to fit"
+
+# --- 3. assign / slots / reject / clear ------------------------------------
+"$LAYOUT" assign 1 itest:fm-gamma-cc >/dev/null
+"$LAYOUT" assign 2 itest:fm-alpha-aa >/dev/null
+slots=$("$LAYOUT" slots)
+assert_contains "$slots" "itest:fm-gamma-cc" "slot 1 holds the assigned worker"
+assert_contains "$slots" "itest:fm-alpha-aa" "slot 2 holds the assigned worker"
+
+set +e
+out=$("$LAYOUT" assign 3 itest:fm-nope-xx 2>&1); rc=$?
+set -e
+expect_code 1 "$rc" "assigning a non-worker fails"
+assert_contains "$out" "not a live worker" "reject explains the worker is not live"
+
+"$LAYOUT" assign 2 - >/dev/null
+slots=$("$LAYOUT" slots)
+assert_not_contains "$slots" "itest:fm-alpha-aa" "clearing a slot removes its worker"
+pass "assign/slots round-trip, non-worker rejection, and clear all work"
+
+# Reset slot files so arrange's autofill starts clean.
+rm -f "$STATE"/.layout-slot-*
+
+# --- 4. arrange geometry ---------------------------------------------------
+"$LAYOUT" arrange --window "$ORCH_WIN" >/dev/null
+sleep 1
+roles=$(TM list-panes -t "$ORCH_WIN" -F '#{@fm_role}' | sort | tr '\n' ' ')
+assert_contains "$roles" "orchestrator" "orchestrator pane tagged"
+assert_contains "$roles" "summary" "summary pane created"
+assert_contains "$roles" "slot:1 slot:2 slot:3" "three watch slots created"
+[ "$(TM list-panes -t "$ORCH_WIN" | grep -c .)" -eq 5 ] || fail "expected 5 panes after arrange"
+active_role=$(TM display-message -p -t "$ORCH_WIN" '#{@fm_role}')
+[ "$active_role" = orchestrator ] || fail "orchestrator pane must stay active/focused"
+[ "$(TM show -w -t "$ORCH_WIN" -v @fm_layout)" = 1 ] || fail "@fm_layout marker should be set"
+# Autofill: 3 live workers fill all 3 slots; no work was spawned to fill them.
+filled=$(grep -l . "$STATE"/.layout-slot-1 "$STATE"/.layout-slot-2 "$STATE"/.layout-slot-3 2>/dev/null | grep -c .)
+[ "$filled" -eq 3 ] || fail "expected all 3 slots autofilled from the 3 live workers"
+pass "arrange builds command column + 3 slots, preserves the active orchestrator pane"
+
+# --- 5. idempotent re-run, workers untouched -------------------------------
+"$LAYOUT" arrange --window "$ORCH_WIN" >/dev/null
+sleep 1
+[ "$(TM list-panes -t "$ORCH_WIN" | grep -c .)" -eq 5 ] || fail "re-run should keep 5 panes"
+for w in fm-alpha-aa fm-beta-bb fm-gamma-cc; do
+  TM list-windows -t itest -F '#{window_name}' | grep -Fxq "$w" \
+    || fail "worker window $w must survive arrange"
+done
+pass "re-running arrange is idempotent and leaves worker windows intact"
+
+# --- 6. refusals -----------------------------------------------------------
+set +e
+out=$("$LAYOUT" arrange --window "$ALPHA_WIN" 2>&1); rc=$?
+set -e
+expect_code 1 "$rc" "arranging a worker window is refused"
+assert_contains "$out" "worker window" "refusal names the worker-window reason"
+
+TM new-window -t itest -n messy 'sleep 600'
+MESSY_WIN=$(TM list-windows -t itest -F '#{window_id} #{window_name}' | awk '$2=="messy"{print $1}')
+TM split-window -t "$MESSY_WIN" 'sleep 600'
+set +e
+out=$("$LAYOUT" arrange --window "$MESSY_WIN" 2>&1); rc=$?
+set -e
+expect_code 1 "$rc" "arranging a window with unexpected panes is refused"
+assert_contains "$out" "unexpected pane" "refusal names the unexpected-pane reason"
+[ "$(TM list-panes -t "$MESSY_WIN" | grep -c .)" -eq 2 ] || fail "refused window must keep its panes"
+pass "arrange refuses worker windows and unexpected panes without destroying anything"
+
+# --- 7. rendered content ---------------------------------------------------
+summary=$(FM_LAYOUT_ONCE=1 FM_LAYOUT_STATE="$STATE" "$PANE" summary | sed 's/\x1b\[[0-9;]*m//g')
+assert_contains "$summary" "active workers" "summary has a header"
+assert_contains "$summary" "• scrub-cx-engine - alpha" "summary shows a terse repo/label bullet"
+
+"$LAYOUT" assign 1 itest:fm-beta-bb >/dev/null
+slot=$(FM_LAYOUT_ONCE=1 FM_LAYOUT_STATE="$STATE" TMUX_PANE="" "$PANE" 1 | sed 's/\x1b\[[0-9;]*m//g')
+assert_contains "$slot" "portals-cx · beta" "watch pane header shows the assigned worker"
+assert_contains "$slot" "beta-line" "watch pane mirrors the live worker's output"
+pass "summary renders terse bullets and a watch pane mirrors its worker"
+
+echo "# all fm-layout tests passed"

--- a/tests/fm-layout.test.sh
+++ b/tests/fm-layout.test.sh
@@ -171,10 +171,12 @@ pass "summary renders terse bullets and a watch pane mirrors its worker"
 
 # --- 8. worker-reference shortcut (#-style picker) -------------------------
 # fm_layout_ref reference formats (lib already sourced above).
-[ "$(fm_layout_ref firstmate:fm-foo-k9)" = "firstmate:fm-foo-k9" ] \
-  || fail "ref default (target) format should be the session:window"
+[ "$(fm_layout_ref firstmate:fm-foo-k9)" = "fm-foo-k9" ] \
+  || fail "ref default (window) format should be the bare window name"
 [ "$(fm_layout_ref firstmate:fm-foo-k9 window)" = "fm-foo-k9" ] \
   || fail "ref window format should be the bare window name"
+[ "$(fm_layout_ref firstmate:fm-foo-k9 target)" = "firstmate:fm-foo-k9" ] \
+  || fail "ref target format should be the session:window"
 [ "$(fm_layout_ref firstmate:fm-foo-k9 select)" = "tmux select-window -t firstmate:fm-foo-k9" ] \
   || fail "ref select format should be a runnable tmux command"
 
@@ -190,7 +192,7 @@ CPANE=$(TM list-panes -t itest:composer -F '#{pane_id}')
 "$LAYOUT" insert-ref -p "$CPANE" -w itest:fm-beta-bb
 sleep 0.4
 typed=$(TM capture-pane -p -t "$CPANE")
-assert_contains "$typed" "itest:fm-beta-bb" "insert-ref types the worker reference into the composer pane"
+assert_contains "$typed" "fm-beta-bb" "insert-ref types the worker reference into the composer pane"
 
 # insert-ref refuses a dead worker - nothing typed.
 "$LAYOUT" insert-ref -p "$CPANE" -w itest:fm-nope-zz >/dev/null 2>&1 || true

--- a/tests/fm-layout.test.sh
+++ b/tests/fm-layout.test.sh
@@ -169,4 +169,34 @@ assert_contains "$slot" "portals-cx · beta" "watch pane header shows the assign
 assert_contains "$slot" "beta-line" "watch pane mirrors the live worker's output"
 pass "summary renders terse bullets and a watch pane mirrors its worker"
 
+# --- 8. worker-reference shortcut (#-style picker) -------------------------
+# fm_layout_ref reference formats (lib already sourced above).
+[ "$(fm_layout_ref firstmate:fm-foo-k9)" = "firstmate:fm-foo-k9" ] \
+  || fail "ref default (target) format should be the session:window"
+[ "$(fm_layout_ref firstmate:fm-foo-k9 window)" = "fm-foo-k9" ] \
+  || fail "ref window format should be the bare window name"
+[ "$(fm_layout_ref firstmate:fm-foo-k9 select)" = "tmux select-window -t firstmate:fm-foo-k9" ] \
+  || fail "ref select format should be a runnable tmux command"
+
+# `ref --print` lists every live worker with its reference token.
+refs=$("$LAYOUT" ref --print -p dummy)
+assert_contains "$refs" "itest:fm-alpha-aa" "ref --print lists the alpha worker reference"
+assert_contains "$refs" "itest:fm-gamma-cc" "ref --print lists the gamma worker reference"
+assert_not_contains "$refs" "fm-second-dd" "ref --print excludes the secondmate"
+
+# insert-ref types the chosen worker's reference into a composer pane.
+TM new-window -t itest -n composer 'cat'
+CPANE=$(TM list-panes -t itest:composer -F '#{pane_id}')
+"$LAYOUT" insert-ref -p "$CPANE" -w itest:fm-beta-bb
+sleep 0.4
+typed=$(TM capture-pane -p -t "$CPANE")
+assert_contains "$typed" "itest:fm-beta-bb" "insert-ref types the worker reference into the composer pane"
+
+# insert-ref refuses a dead worker - nothing typed.
+"$LAYOUT" insert-ref -p "$CPANE" -w itest:fm-nope-zz >/dev/null 2>&1 || true
+sleep 0.2
+typed2=$(TM capture-pane -p -t "$CPANE")
+assert_not_contains "$typed2" "fm-nope-zz" "insert-ref never types a dead worker reference"
+pass "worker-reference picker resolves refs and types them into the composer"
+
 echo "# all fm-layout tests passed"


### PR DESCRIPTION
## Intent

The developer (the orchestrator/captain) asked for a durable worker-reference shortcut for their Firstmate terminal dashboard, framed as a follow-up to already-completed orchestrator dashboard work. The desired UX was that typing # would open a picker of the current worker list, similar to @ or / pickers in agent composers, so the captain could write messages that reference and route to a selected worker without manually copying terminal targets. They asked the agent to first investigate feasibility across cmux/OpenCode/Codex/Claude terminal contexts, and if direct interception of # in agent composers was not possible, to implement the closest practical workflow: a command/shortcut/picker that lists current workers by short, human-readable names and inserts or sends the selected worker reference, with documentation. They explicitly required keeping worker names short and readable, doing the work cleanly on a separate branch/PR rather than mixing unsafe state into the finished dashboard PR, and reporting feasibility, implementation, and validation clearly. Across the broader session the developer also wanted off-screen workers made visible, and directed clearing the blocking PR and updating no-mistakes to v1.31.2 so validation could proceed.

## What Changed

- Added `bin/fm-layout.sh`, `bin/fm-layout-lib.sh`, and `bin/fm-watch-pane.sh` to build a tmux orchestrator dashboard whose side panes watch live workers and can be swapped between them, surfacing off-screen workers without leaving the composer.
- Added a worker-reference shortcut: `bin/fm-layout-pick.sh` lists current workers by short, human-readable names and `fm-layout.sh` inserts the selected reference (or sends it) into the composer pane, bound to a `prefix`-key chord; the reference format defaults to the short `fm-<id>` window form and is configurable via `FM_LAYOUT_REF_FORMAT`.
- Hardened the picker for the macOS bash 3.2 default shell (safe empty-array expansion so a zero-worker picker exits cleanly), and added `tests/fm-layout.test.sh` plus documentation in `docs/orchestrator-layout.md`, `docs/configuration.md`, `docs/scripts.md`, and the README.

## Risk Assessment

✅ Low: Well-bounded, additive tmux-layout tooling with no behavior changes to existing supervision code; both prior-round errors are verifiably fixed, the new worker-reference path is read-only toward workers and well-tested, and helpers are bash-3.2 safe.

## Testing

Ran the full `tests/fm-layout.test.sh` suite against a real tmux (8/8 pass) and additionally drove the feature manually to produce reviewer-visible CLI/tmux transcripts: the picker listing workers by short readable names with the secondmate excluded, the selected reference being typed live into a composer pane mid-message, the dead-worker safety path typing nothing, the empty-picker not crashing on the system bash 3.2 (the review fix), and the `prefix #` chord being wired by `bind`. This is a tmux/terminal CLI surface with no rendered web/graphical UI, so evidence is captured as tmux pane captures and command transcripts rather than screenshots - that is the actual end-user surface here. All checks passed and the working tree was left clean.

<details>
<summary>Evidence: Picker lists current workers by short names (secondmate excluded)</summary>

<code>$ fm-layout.sh ref --print -p %composer&#10;1 firstmate:fm-api-audit-p7 fm-api-audit-p7&#10;2 firstmate:fm-cache-bug-z2 fm-cache-bug-z2&#10;3 firstmate:fm-login-fix-k3 fm-login-fix-k3&#10;(secondmate fm-triage-dd excluded)</code>

```text
$ # --- The captain types `prefix #` in the orchestrator composer. The picker
$ #     lists current workers by short, human-readable names (like an @ / picker).
$ fm-layout.sh ref --print -p %composer
1	firstmate:fm-api-audit-p7	fm-api-audit-p7
2	firstmate:fm-cache-bug-z2	fm-cache-bug-z2
3	firstmate:fm-login-fix-k3	fm-login-fix-k3

$ # Each row: menu-key <TAB> tmux-target <TAB> reference token that gets typed.
$ #     Note the secondmate (fm-triage-dd) is excluded - only real workers listed.
```
</details>
<details>
<summary>Evidence: Selected reference typed into the composer pane mid-message</summary>

<code>composer reads: please rebase fm-login-fix-k3 onto main and rerun CI&#10;(short readable worker ref inserted mid-message with a trailing space; no hand-copied tmux target)</code>

```text
$ # Captain typed "please rebase ", opened the # picker, selected worker 3,
$ #     then kept typing. The composer now reads:

    ┌─ orchestrator composer ─────────────────────────────────┐
    │ please rebase fm-login-fix-k3 onto main and rerun CI
    └─────────────────────────────────────────────────────────┘

$ # The short, readable worker reference "fm-login-fix-k3" was inserted
$ #     mid-message (with a trailing space) - no hand-copying a tmux target.
```
</details>
<details>
<summary>Evidence: Dead-worker safety: nothing typed for a non-live worker</summary>

```text
$ # Safety: selecting/targeting a worker that is no longer live types nothing.
$ fm-layout.sh insert-ref -p %composer -w firstmate:fm-ghost-xx
composer after (no "fm-ghost-xx" appears):
    please rebase fm-login-fix-k3 onto main and rerun CI
    please rebase fm-login-fix-k3 onto main and rerun CI
```
</details>
<details>
<summary>Evidence: bind wires the prefix # chord</summary>

<code>bound: prefix+O = arrange/refresh, prefix+P = pick worker, prefix+# = insert worker reference&#10;bind-key -T prefix \# run-shell &#34;.../bin/fm-layout.sh ref -p &#39;#{pane_id}&#39; -c &#39;#{client_name}&#39;&#34;</code>

```text
$ fm-layout.sh bind   (run from inside the firstmate tmux session)
bound: prefix+O = arrange/refresh, prefix+P = pick worker, prefix+# = insert worker reference

$ tmux list-keys | grep "fm-layout.sh ref"   # the prefix # chord is now live:
bind-key  -T prefix  \#  run-shell ".../bin/fm-layout.sh ref -p '#{pane_id}' -c '#{client_name}'"

# Captain presses `prefix #` in the orchestrator composer -> picker opens ->
# pick a worker -> its short reference is typed into the composer.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed ✅</summary>

- 🚨 `bin/fm-layout-pick.sh:38` - fm-layout-pick.sh iterates `for row in &#34;${WORKERS[@]}&#34;` (lines 38 and 52) under `set -u`. On bash 3.2.57 (the macOS default shell this branch&#39;s prior commit explicitly hardened for), iterating an empty array with `set -u` aborts with `WORKERS[@]: unbound variable` (verified directly on the system bash). When no workers are live, the empty-workers branch at line 34 prints its message but does not exit, so control falls into the line-38 loop and the picker crashes before it can show &#34;0) clear this slot&#34; or read a choice. The picker is documented as the dependable path that &#34;works on any tmux/terminal&#34;. Fix mechanically with the safe expansion `&#34;${WORKERS[@]+&#34;${WORKERS[@]}&#34;}&#34;` on both loops, or exit/guard after the empty message.
- ℹ️ `bin/fm-layout.sh:50` - `bind` maps `prefix #` (KEY_REF default `#`), which overrides tmux&#39;s built-in `prefix #` = list-buffers binding, and `unbind` leaves `#` unbound rather than restoring the default. The in-code comment &#34;Opt-in prefix keys (capitals, not default tmux bindings)&#34; applies to O/P but not to `#`, which is a tmux default. This is an opt-in, documented tradeoff; noting for awareness.
- ℹ️ `bin/fm-layout.sh:51` - The worker-reference picker defaults to FM_LAYOUT_REF_FORMAT=target, inserting the full `firstmate:fm-&lt;long-id&gt;` tmux target into the composer. The captain&#39;s stated requirement emphasized short, human-readable names; the inserted token is the routing target, not the readable label shown in the menu. This is configurable (`window` format yields the shorter `fm-&lt;id&gt;`) and documented, so flagging only to confirm the default matches intent.

🔧 Fix: fix bash 3.2 empty-picker crash, default worker-ref to window form
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-layout.test.sh` (8/8 ok, including the worker-reference picker block: ref formats, `ref --print` listing/exclusion, `insert-ref` typing into a real composer pane, dead-worker rejection)</code>
- <code>Manual end-to-end on a private tmux socket: `fm-layout.sh ref --print -p %composer` lists 3 live workers by short names, excludes the secondmate</code>
- <code>Manual: `fm-layout.sh insert-ref -p &lt;composer&gt; -w firstmate:fm-login-fix-k3` inserts `fm-login-fix-k3 ` mid-message into a live composer pane (captured: `please rebase fm-login-fix-k3 onto main and rerun CI`)</code>
- <code>Manual: `insert-ref` targeting a non-live worker (`fm-ghost-xx`) types nothing</code>
- <code>Manual on bash 3.2.57: `fm-layout.sh ref --print` with zero workers exits 0 with no output (review-fix for the empty-array crash)</code>
- <code>Manual: `fm-layout.sh bind` from inside tmux reports the `prefix+#` binding and `tmux list-keys` confirms the `prefix #` chord runs `fm-layout.sh ref`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
