### PR TITLE
fix(fm-brief): bash 3.2 here-doc parse error breaks default brief scaffolding

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -175,50 +175,15 @@ case "$MODE" in
   direct-PR)
     SETUP2=""
     RULE1='1. Never push to the default branch (push only your `fm/'"$ID"'` branch). Never merge a PR.'
-    DOD=$(cat <<EOF
-# Definition of done
-This project ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
-The task is complete only when committed on your branch.
-When it is implemented and committed, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\` to the status file and stop.
-Do NOT run /no-mistakes. The captain reviews and merges the PR; firstmate relays it.
-EOF
-)
     ;;
   local-only)
     SETUP2=""
     RULE1="1. Never push to any remote and never open a PR. Work only on your \`fm/$ID\` branch; firstmate handles the merge into local \`main\`."
-    DOD=$(cat <<EOF
-# Definition of done
-This project ships **local-only**: no remote, no PR, no pipeline.
-The task is complete only when committed on your branch \`fm/$ID\`. Do NOT push, do NOT open a PR, do NOT merge.
-Keep your branch a clean fast-forward onto the current default branch - if \`main\` has advanced, rebase onto it so the eventual merge stays a fast-forward.
-When it is implemented and committed, append \`done: ready in branch fm/$ID\` to the status file and stop.
-Firstmate then reviews your branch diff, the captain approves, and firstmate merges it into local \`main\`.
-EOF
-)
     ;;
   *)  # no-mistakes (default)
     SETUP2="
 2. Run \`no-mistakes doctor\`; if it reports the repo is not initialized here, run \`no-mistakes init\`."
     RULE1='1. Never push to the default branch. Never merge a PR.'
-    DOD=$(cat <<EOF
-# Definition of done
-The task is complete only when committed on your branch.
-When you believe it is complete, append \`done: {summary}\` to the status file and stop.
-Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
-
-You drive no-mistakes by responding to its gates, not by implementing fixes.
-Follow no-mistakes' own guidance for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.
-Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.
-
-Two firstmate-specific rules layer on top of that guidance:
-- ask-user findings are not yours to answer: escalate to firstmate (rule 6) and stop.
-  When the decision comes back, feed it to the gate with \`no-mistakes axi respond\` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
-- Avoid \`--yes\`: the captain, not you, owns the ask-user decisions it would silently auto-resolve.
-
-After /no-mistakes reports CI green, append \`done: PR {url} checks green\` and stop. You are finished.
-EOF
-)
     ;;
 esac
 
@@ -257,6 +222,52 @@ If \`AGENTS.md\` or \`CLAUDE.md\` already exists, or if this task produced durab
 If this task produced durable project-intrinsic knowledge, record it in \`AGENTS.md\` as part of your change.
 Keep it proportionate: skip \`AGENTS.md\` edits for trivial tasks that produced no durable project knowledge.
 
-$DOD
 EOF
+
+# Append the mode-specific Definition of done as a statement-level here-doc.
+# These must NOT be wrapped in $(...) command substitution: GNU bash 3.2's
+# command-substitution parser mis-tokenizes an apostrophe in a here-doc body
+# (e.g. "no-mistakes'") as an opening single-quote and scans to EOF for its
+# match, which breaks default-mode brief scaffolding on stock macOS bash.
+# At statement level the same here-doc bodies parse fine.
+case "$MODE" in
+  direct-PR)
+    cat >> "$BRIEF" <<EOF
+# Definition of done
+This project ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
+The task is complete only when committed on your branch.
+When it is implemented and committed, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\` to the status file and stop.
+Do NOT run /no-mistakes. The captain reviews and merges the PR; firstmate relays it.
+EOF
+    ;;
+  local-only)
+    cat >> "$BRIEF" <<EOF
+# Definition of done
+This project ships **local-only**: no remote, no PR, no pipeline.
+The task is complete only when committed on your branch \`fm/$ID\`. Do NOT push, do NOT open a PR, do NOT merge.
+Keep your branch a clean fast-forward onto the current default branch - if \`main\` has advanced, rebase onto it so the eventual merge stays a fast-forward.
+When it is implemented and committed, append \`done: ready in branch fm/$ID\` to the status file and stop.
+Firstmate then reviews your branch diff, the captain approves, and firstmate merges it into local \`main\`.
+EOF
+    ;;
+  *)  # no-mistakes (default)
+    cat >> "$BRIEF" <<EOF
+# Definition of done
+The task is complete only when committed on your branch.
+When you believe it is complete, append \`done: {summary}\` to the status file and stop.
+Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
+
+You drive no-mistakes by responding to its gates, not by implementing fixes.
+Follow no-mistakes' own guidance for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.
+Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.
+
+Two firstmate-specific rules layer on top of that guidance:
+- ask-user findings are not yours to answer: escalate to firstmate (rule 6) and stop.
+  When the decision comes back, feed it to the gate with \`no-mistakes axi respond\` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
+- Avoid \`--yes\`: the captain, not you, owns the ask-user decisions it would silently auto-resolve.
+
+After /no-mistakes reports CI green, append \`done: PR {url} checks green\` and stop. You are finished.
+EOF
+    ;;
+esac
 echo "scaffolded: $BRIEF (ship, mode=$MODE; replace {TASK})"


### PR DESCRIPTION
## Problem

On stock macOS Bash (GNU bash **3.2.57**, i.e. `/bin/bash`), `bin/fm-brief.sh` fails to parse:

```
$ /bin/bash -n bin/fm-brief.sh
bin/fm-brief.sh: line 211: unexpected EOF while looking for matching `''
bin/fm-brief.sh: line 263: syntax error: unexpected end of file
```

This breaks the **default** task path: no-mistakes-mode briefs cannot be scaffolded at all on a stock-bash machine. It went unnoticed because modern bash (5.x) parses the file fine.

## Root cause

The no-mistakes (default-mode) Definition-of-done block was assigned via command substitution wrapping a here-doc:

```sh
DOD=$(cat <<EOF
...
Follow no-mistakes' own guidance for the mechanics: ...
...
EOF
)
```

That here-doc body contains an apostrophe (`no-mistakes'`). Bash 3.2's command-substitution parser mis-tokenizes the apostrophe inside `$(...)` as an opening single-quote and scans to EOF looking for its match. The `--scout`, `direct-PR`, and `local-only` here-docs happen to contain no apostrophe, so only the default path errored.

A quoted delimiter (`<<'EOF'`) does **not** fix it — the bug is in the `$(...)` command-substitution parser itself, not heredoc quoting (verified: an apostrophe in a `<<'EOF'` body inside `$(...)` still breaks bash 3.2). The same here-doc body parses fine at statement level.

## Fix

Move every mode's Definition-of-done out of `$(...)` and append it directly to the brief with `cat >> "$BRIEF" <<EOF`. The here-doc bodies are byte-identical to before — this is a parser-compatibility fix, not a content change. The assembled brief output is unchanged for all modes: same single blank line at the Project-memory → Definition-of-done join, and `$ID` interpolation plus escaped backticks preserved.

## Validation (stock Bash 3.2.57, `/bin/bash`)

`bash -n` before vs after:

```
# before
bin/fm-brief.sh: line 211: unexpected EOF while looking for matching `''
bin/fm-brief.sh: line 263: syntax error: unexpected end of file   (exit 2)
# after
$ /bin/bash -n bin/fm-brief.sh ; echo $?
0
```

Functionally scaffolded a complete, correct brief under `/bin/bash` for **every** mode and inspected the output:

- **no-mistakes** (default), **direct-PR**, **local-only**, **scout**, and a **--secondmate** charter all scaffold successfully.
- direct-PR / local-only driven via a temp registry (`data/projects.md`); unknown-project fallback (→ no-mistakes) also exercised.
- Confirmed the default-mode brief still contains the unchanged no-mistakes DoD text: the `/no-mistakes` invocation, `no-mistakes axi run --help`, the ask-user / `--yes` rules, and the `done: PR {url} checks green` line.
- Confirmed exactly one blank line at the Project-memory → Definition-of-done join, backticks rendered (not literal `` \` ``), and `$ID` interpolated correctly in Setup, Rule 1, and the local-only/direct-PR DoD.

Diff is limited to `bin/fm-brief.sh`.
