### PR TITLE
feat(harness): add Kimi CLI as a verified crewmate harness

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -116,3 +116,21 @@ The decision persists per path in `~/.pi/agent/trust.json`, so later spawns in t
 `fm-spawn` keeps the turn-end extension in `state/`, outside the worktree, because project-local extension files make the trust gate strictly worse and pollute the project.
 The extension must listen for pi's `turn_end` event, not `agent_end`, so the watcher wakes after each completed turn instead of only when the whole agent run exits.
 Pi sets `PI_CODING_AGENT=true` for its children; this is its harness-detection env marker.
+
+## kimi / kimi-cli (VERIFIED 2026-06-28)
+
+| Fact | Value |
+|---|---|
+| Launch binary | `kimi-cli` |
+| Launch flags | `--afk --print --mcp-config-file <empty-config> --prompt "$(cat <brief>)"` |
+| Busy-pane signature | `TurnBegin(...)` / `StepBegin(n=...)` output streaming; idle when shell prompt returns |
+| Exit command | n/a (exits automatically when the prompt finishes) |
+| Interrupt | Ctrl-C in the pane, or `tmux send-keys C-c` |
+| Turn-end signal | `fm-spawn` appends `; touch <turnend>` to the launch command; marker written after `kimi-cli` exits |
+
+Kimi CLI runs the prompt in non-interactive `--print` mode and exits once it believes the task is done.
+`--afk` auto-dismisses `AskUserQuestion` and auto-approves tool calls, so the crewmate can run unattended.
+`--mcp-config-file` is pointed at an empty MCP config to prevent a broken server in the user's default `~/.kimi/mcp.json` from blocking launch; the agent still has the built-in shell and file tools.
+If you want Stripe / Playwright / Umami MCP tools available, fix or remove the broken server in `~/.kimi/mcp.json` first, then update `config/kimi-empty-mcp.json` or remove the `--mcp-config-file` override.
+
+Firstmate detects the current harness as `kimi` when the process ancestry contains `kimi`, `kimi-cli`, or `kimi-code`.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -208,7 +208,7 @@ When you believe it is complete, append \`done: {summary}\` to the status file a
 Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
 
 You drive no-mistakes by responding to its gates, not by implementing fixes.
-Follow no-mistakes' own guidance for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.
+Follow the no-mistakes guidance for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.
 Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.
 
 Two firstmate-specific rules layer on top of that guidance:

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -25,6 +25,7 @@ detect_own() {
       *codex*) echo codex; return ;;
       *opencode*) echo opencode; return ;;
       pi) echo pi; return ;;
+      kimi|kimi-cli|kimi-code) echo kimi; return ;;
       node*|python*)
         # Bare interpreter: match the harness name in its script path.
         args=$(ps -o args= -p "$pid" 2>/dev/null)
@@ -33,6 +34,7 @@ detect_own() {
           *codex*) echo codex; return ;;
           *opencode*) echo opencode; return ;;
           *" pi "*|*/pi) echo pi; return ;;
+          *kimi-cli*|*/kimi-cli|*kimi-code*|*/kimi-code) echo kimi; return ;;
         esac ;;
     esac
     pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -5,7 +5,7 @@
 #        fm-spawn.sh <task-id> [<firstmate-home>] [harness|launch-command] --secondmate
 #   With no harness arg, the harness comes from fm-harness.sh crew (config/crew-harness,
 #   falling back to firstmate's own harness). A bare adapter name (claude|codex|
-#   opencode|pi) overrides it for this spawn. A non-flag string containing whitespace
+#   opencode|pi|kimi) overrides it for this spawn. A non-flag string containing whitespace
 #   is treated as a RAW launch command - the escape hatch for verifying new adapters.
 #   --scout records kind=scout in the task's meta (report deliverable, scratch worktree;
 #   see AGENTS.md task lifecycle); --secondmate records kind=secondmate and launches in a
@@ -88,7 +88,7 @@ FIRSTMATE_HOME=
 
 if [ "$KIND" = secondmate ]; then
   case "${POS[1]:-}" in
-    ''|claude|codex|opencode|pi)
+    ''|claude|codex|opencode|pi|kimi)
       ARG3=${POS[1]:-}
       ;;
     *' '*)
@@ -139,6 +139,13 @@ launch_template() {
       else
         printf '%s' 'pi -e __PIEXT__ "$(cat __BRIEF__)"'
       fi
+      ;;
+    kimi)
+      # kimi-cli --afk --print runs the prompt non-interactively and exits when done.
+      # --mcp-config-file points to an empty MCP config so a broken server in the user's
+      # default ~/.kimi/mcp.json cannot block launch; the agent still has the built-in shell
+      # and file tools. The trailing '; touch __TURNEND__' signals the watcher after exit.
+      printf '%s' "kimi-cli --afk --print --mcp-config-file '$FM_HOME/config/kimi-empty-mcp.json' --prompt \"\$(cat __BRIEF__)\"; touch __TURNEND__"
       ;;
     *) return 1 ;;
   esac
@@ -355,7 +362,8 @@ fi
 
 tmux new-window -d -t "$SES" -n "$W" -c "$PROJ_ABS"
 if [ "$KIND" != secondmate ]; then
-  tmux send-keys -t "$T" 'treehouse get' Enter
+  # Disable oh-my-zsh auto-update prompts that can swallow/mangle the typed command.
+  tmux send-keys -t "$T" 'DISABLE_AUTO_UPDATE=true ZSH_DISABLE_COMPFIX=true treehouse get' Enter
 
   # Wait for the treehouse subshell: the pane's cwd moves from the project to the worktree.
   for _ in $(seq 1 60); do
@@ -445,6 +453,10 @@ EOF
       ;;
     codex*)
       # codex: turn-end rides the launch command via -c notify=[...] and __TURNEND__.
+      ;;
+    kimi*)
+      # kimi-cli exits after the prompt finishes; the '; touch __TURNEND__' in the
+      # launch template writes the marker without needing a project-local hook.
       ;;
   esac
 fi

--- a/config/kimi-empty-mcp.json
+++ b/config/kimi-empty-mcp.json
@@ -1,0 +1,1 @@
+{"mcpServers": {}}


### PR DESCRIPTION
Adds Kimi CLI as a first-class crewmate harness so tasks can run as background tmux agents.

Changes:
- Detect `kimi`/`kimi-cli`/`kimi-code` in `bin/fm-harness.sh` process ancestry
- Add `kimi` launch template to `bin/fm-spawn.sh` using `kimi-cli --afk --print`
- Add `config/kimi-empty-mcp.json` so a broken server in `~/.kimi/mcp.json` cannot block launch
- Document Kimi CLI harness facts in `.agents/skills/harness-adapters/SKILL.md`
- Fix `bin/fm-brief.sh` shell-parse error from apostrophe inside heredoc
- Fix `bin/fm-spawn.sh` oh-my-zsh auto-update prompt mangling `treehouse get`

Verification:
- End-to-end test spawn completed: agent read brief, ran shell commands, wrote status, exited, and triggered the watcher.