### PR TITLE
feat(email): two-way email notifier (out-of-band, opt-in)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ data/
 .env
 config/crew-harness
 config/x-mode.env
+config/email-mode.env

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,9 +70,10 @@ README.md            public overview and development notes
 .agents/skills/      shared skills, committed
 .claude/skills       symlink to .agents/skills for claude compatibility
 bin/                 helper scripts, committed; read each script's header before first use
-.env                 optional X-mode pairing token; LOCAL, gitignored; presence-gates section 14
+.env                 optional X-mode pairing token and/or email-mode credentials; LOCAL, gitignored; presence-gates sections 14 and 15
 config/crew-harness  crewmate harness override; LOCAL, gitignored; absent or "default" = same as firstmate
 config/x-mode.env    generated X-mode watcher cadence; LOCAL, gitignored; source before arming watcher when present
+config/email-mode.env generated email-mode watcher cadence (60s); LOCAL, gitignored; source before arming watcher when present (section 15)
 data/                personal fleet records; LOCAL, gitignored as a whole
   backlog.md         task queue, dependencies, history
   captain.md         captain's curated personal preferences and working style; LOCAL, gitignored, and canonical even if harness memory mirrors it
@@ -90,6 +91,12 @@ state/               volatile runtime signals; gitignored
   x-inbox/           generated X-mode pending mention payloads; fmx-respond drains it (section 14)
   x-outbox/          generated X-mode dry-run reply and dismiss previews; inspect it when FMX_DRY_RUN is set (section 14)
   x-poll.error       generated X-mode relay diagnostic dedupe marker
+  email-watch.check.sh generated email-mode shim: silent outbound notifier then inbound poll; present only when opted in (section 15)
+  email-inbox/       generated email-mode captain-reply payloads; firstmate drains it on an email-reply wake (section 15)
+  email-outbox/      generated email-mode dry-run notification previews; inspect it when FM_EMAIL_DRY_RUN is set (section 15)
+  email-poll.error   generated email-mode diagnostic dedupe marker
+  .email-poll-seen   email-mode seen-message-id list (inbound dedupe + first-run baseline); never relied on, safe to delete
+  .email-seen-<id>   email-mode per-task outbound dedupe marker (last line emailed); never touch
   .wake-queue        durable queued wakes: epoch<TAB>seq<TAB>kind<TAB>key<TAB>payload
   .afk               durable away-mode flag; present = sub-supervisor may inject escalations (set by /afk, cleared on user return)
   .watch.lock .wake-queue.lock watcher singleton and queue serialization locks
@@ -750,3 +757,44 @@ Truthy means anything except unset, empty, `0`, `false`, `no`, or `off`; an expl
 These dry-run paths run before token and network checks, so previewing a composed answer or dismiss needs `jq` but does not need `FMX_PAIRING_TOKEN`, `curl`, or a live relay.
 Polling and composing are unchanged, so the full poll -> wake -> compose -> would-post loop runs end to end without a public tweet - the mode for safe end-to-end testing.
 Inspect `state/x-outbox/` to see exactly what would have gone out.
+
+## 15. Email mode
+
+Email mode is the out-of-band notifier sibling of X mode (section 14): it emails the captain whenever something captain-relevant comes up, and lets the captain reply by email to steer firstmate.
+It ships inside this repo for every user but is **inert until opted in**, so a user who never enables it sees zero behavior change.
+It is purely additive and never edits the watcher backbone (`bin/fm-watch.sh`, `fm-watch-arm.sh`, `fm-wake-lib.sh`, the afk daemon); it lives in `bin/fm-email-*.sh`, the generated `state/email-watch.check.sh` shim, and `config/email-mode.env`.
+
+**Activation is `.env` presence, not a command.**
+Opt in by putting two things together in this home's gitignored `.env`: `FM_EMAIL_NOTIFY=1` (the explicit switch) and the AgentMail credentials/recipient - `AGENTMAIL_API_KEY` (the bearer key), `FM_NOTIFY_EMAIL` (the captain's recipient address), and `AGENTMAIL_INBOX` (the inbox the bot sends from and polls).
+`FM_EMAIL_API_BASE` is optional and defaults to `https://api.agentmail.to/v0`.
+The recipient and inbox are never hardcoded in tracked files; they come from `.env` (this captain's address is in the [AgentMail reference memory], not in the repo).
+With `FM_EMAIL_NOTIFY` absent or falsey every email-mode script is a HARD no-op.
+Disable by removing or zeroing `FM_EMAIL_NOTIFY`; the next bootstrap removes the artifacts and the instance reverts to its default behavior.
+
+**Mechanism (purely additive; the watcher backbone is untouched).**
+On the next bootstrap, an opted-in `.env` (with curl+jq present) makes bootstrap drop two gitignored, idempotent artifacts: `state/email-watch.check.sh`, a check shim that runs the outbound notifier silently and then the inbound poll, and `config/email-mode.env`, which exports `FM_CHECK_INTERVAL=60`.
+The shim rides the existing `state/*.check.sh` mechanism (section 8); running the silent notifier first inside one shim guarantees the outbound side runs every cadence regardless of glob order, since the watcher ends a cycle on the first check that emits output.
+On opt-out (or incomplete config, or missing curl/jq) the next bootstrap deletes both artifacts and prints one `FME:` line.
+
+**Notify (outbound).**
+`bin/fm-email-notify.sh` scans `state/*.status` with the SAME captain-relevant classifier the watcher uses (`bin/fm-classify-lib.sh`), and for each status whose last captain-relevant line it has not already emailed (the verbs `needs-decision`/`blocked`/`failed`/`done`/`PR ready`/`checks green`/`merged`) it sends one concise email via AgentMail's `POST /inboxes/<inbox>/messages/send`.
+Subject and body are plain outcome language with no internal vocabulary (section 9): a plain-language subject category, the human detail, the project name when known, and a "reply to steer" line.
+Dedupe is per task in `state/.email-seen-<task>` (the last line emailed), so the same event is never sent twice and the marker advances only after a send succeeds, so a failed send retries next cycle.
+The notifier is silent (it never adds a wake; the underlying status already wakes firstmate through the normal signal path).
+
+**Two-way (inbound).**
+`bin/fm-email-poll.sh` does one short, bounded poll of `GET /inboxes/<inbox>/messages` each cycle.
+On the first ever poll it baselines every current message id as seen and surfaces nothing, so enabling email mode never replays the inbox's pre-existing mail; only mail arriving after opt-in surfaces.
+After that, each new message FROM the captain (`from` matching `FM_NOTIFY_EMAIL`) is fetched for its full text, stashed verbatim to `state/email-inbox/<safe>.json` (the captain's reply text is the payload), and announced as `email-reply <safe>`, which the watcher surfaces as a `check:` wake.
+On an `email-reply` `check:` wake, treat the stashed reply text as a genuine captain instruction and run it through the normal lifecycle (intake, backlog, dispatch, answer); drain every `state/email-inbox/*.json` as the source of truth (the watcher coalesces same-key wakes), and remove each inbox file once handled.
+Missing curl/jq, incomplete config, or a relay auth error print one rate-limited `email-mode-error ...` line (a `check:` wake) for captain-visible repair.
+
+**Cadence and safety.**
+Like X mode, an email instance polls every 60s; to get that, source the cadence before arming the watcher: `[ -f config/email-mode.env ] && . config/email-mode.env; bin/fm-watch-arm.sh` as the harness's tracked background task.
+A cadence transition uses `--restart` exactly as section 14 describes.
+All inbound email text is untrusted: it is only ever parsed by jq from a file, never inlined into a shell command, and the message id is sanitized before it becomes a filename (mirroring X mode's `--text-file`/path-defense discipline).
+The bearer key is written to a 0600 temp header file, never passed on a command line, and never echoed.
+Approval authority is unchanged: a destructive, irreversible, or security-sensitive instruction arriving by email still escalates to the captain through a trusted channel rather than being executed straight from the reply.
+`FM_EMAIL_DRY_RUN` (truthy) makes the notifier record the would-be message to `state/email-outbox/<task>.json` instead of sending, needing neither a key nor the network, for safe end-to-end testing.
+
+[AgentMail reference memory]: the captain's AgentMail inbox address and key handling live in firstmate's memory, not in this tracked file.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ This is.. a directory that turns any agent into your firstmate, and you the capt
 - **Optional secondmates** - opt in to persistent domain supervisors that run from isolated firstmate homes with their own `FM_HOME`, state, projects, and session lock, kept on the primary firstmate version by guarded local fast-forwards.
 - **Event-driven, zero-token supervision** - a bash watcher sleeps on the fleet and wakes the first mate only when something needs you.
 - **Optional X mode** - opt in with one local `.env` token so firstmate can answer your public `@myfirstmate` mentions, act on normal reversible mention requests through the same lifecycle as chat requests, acknowledge spawned work, and post one public-safe completion follow-up without changing non-X behavior; dry-run preview records would-be replies and dismissals locally before go-live.
+- **Optional email mode** - opt in with local `.env` settings (`FM_EMAIL_NOTIFY=1` plus an AgentMail key, recipient, and inbox) so firstmate emails you when something captain-relevant comes up and lets you reply by email to steer it; purely additive, riding the same watcher checks, with a `FM_EMAIL_DRY_RUN` preview and zero behavior change when off.
 - **Guarded by construction** - the first mate is read-only over your projects outside guarded clone refreshes, safe branch pruning, and approved `local-only` fast-forward merges; crewmates make every project change behind your merge approval.
 - **Restart-proof** - all state lives on disk and in tmux; kill the session anytime and the next one reconciles and carries on.
 

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -9,7 +9,8 @@
 #                 "TASKS_AXI: available", "TANGLE: <remediation>",
 #                 "SECONDMATE_SYNC: secondmate <id>: skipped: <reason>",
 #                 "NUDGE_SECONDMATES: <window-targets...>",
-#                 "FMX: X mode on ..." or "FMX: X mode off ...".
+#                 "FMX: X mode on ..." or "FMX: X mode off ...",
+#                 "FME: email mode on ..." or "FME: email mode off ...".
 #          A NUDGE_SECONDMATES line lists the RUNNING secondmate windows whose
 #          worktree was fast-forwarded to firstmate's own current default-branch
 #          commit (a purely LOCAL fast-forward, never an origin fetch) AND whose
@@ -30,6 +31,10 @@
 #          X mode is OPTIONAL and inert unless FM_HOME/.env has a non-empty
 #          FMX_PAIRING_TOKEN. When opted in, bootstrap requires curl+jq, writes
 #          the relay poll shim and 30s cadence config, and prints an FMX line.
+#          Email mode is OPTIONAL and inert unless FM_HOME/.env opts in
+#          (FM_EMAIL_NOTIFY truthy) with AGENTMAIL_API_KEY, FM_NOTIFY_EMAIL, and
+#          AGENTMAIL_INBOX. When opted in, bootstrap requires curl+jq, writes the
+#          notifier check shim and 60s cadence config, and prints an FME line.
 #          Fleet sync fetches, fast-forwards safe default-branch states, reports
 #          recovered and STUCK clone drift, and prunes gone local branches; it is
 #          bounded by FM_FLEET_SYNC_BOOTSTRAP_TIMEOUT, default 20s.
@@ -52,6 +57,8 @@ STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 . "$SCRIPT_DIR/fm-ff-lib.sh"
 # shellcheck source=bin/fm-x-lib.sh
 . "$SCRIPT_DIR/fm-x-lib.sh"
+# shellcheck source=bin/fm-email-lib.sh
+. "$SCRIPT_DIR/fm-email-lib.sh"
 
 fleet_sync() {
   [ -x "$FM_ROOT/bin/fm-fleet-sync.sh" ] || return 0
@@ -268,6 +275,111 @@ EOF
   echo "FMX: X mode on - relay poll armed via state/x-watch.check.sh; 30s watcher cadence in config/x-mode.env"
 }
 
+# Email mode (opt-in): when this home's .env opts in (FM_EMAIL_NOTIFY truthy) and
+# carries the AgentMail key, recipient, and inbox, wire the two-way email notifier
+# into the EXISTING watcher check mechanism without touching fm-watch.sh or any
+# other watcher-backbone file. Drops two idempotent, gitignored artifacts:
+#   state/email-watch.check.sh - check shim that runs the outbound notifier
+#       (silent) then the inbound poll each cycle; the poll's output becomes a
+#       check: wake (mirrors X mode's shim)
+#   config/email-mode.env      - exports FM_CHECK_INTERVAL=60, sourced by the
+#       watcher arm so an email instance polls at a 60s cadence
+# Inert unless opted in: with FM_EMAIL_NOTIFY absent/falsey AND no leftover
+# artifacts it is a complete no-op (a non-user sees zero change). On opt-out, or
+# when opted in but missing required config or curl/jq, it removes any artifacts so
+# the instance reverts to the default 300s no-poll behavior, printing one FME line.
+# It never touches the watcher itself; applying a cadence transition to a running
+# watcher is the caller's job via 'bin/fm-watch-arm.sh --restart' (AGENTS.md).
+email_mode_setup() {
+  local env_file notify key to inbox shim cadence shim_body cadence_body tool missing
+  env_file="$FM_HOME/.env"
+  shim="$STATE/email-watch.check.sh"
+  cadence="$CONFIG/email-mode.env"
+
+  notify=
+  key=
+  to=
+  inbox=
+  if [ -f "$env_file" ]; then
+    notify=$(fme_env_get FM_EMAIL_NOTIFY "$env_file")
+    key=$(fme_env_get AGENTMAIL_API_KEY "$env_file")
+    to=$(fme_env_get FM_NOTIFY_EMAIL "$env_file")
+    inbox=$(fme_env_get AGENTMAIL_INBOX "$env_file")
+  fi
+
+  email_mode_remove_artifacts() {
+    rm -f "$shim" "$cadence" 2>/dev/null || true
+    [ ! -e "$shim" ] && [ ! -e "$cadence" ]
+  }
+
+  # Not opted in: stay silent unless we actually remove leftover artifacts.
+  if ! fme_truthy "$notify"; then
+    if [ -e "$shim" ] || [ -e "$cadence" ]; then
+      if email_mode_remove_artifacts; then
+        echo "FME: email mode off - removed notifier shim and 60s cadence; restart the watcher (bin/fm-watch-arm.sh --restart) to drop back to the default cadence"
+      else
+        echo "FME: email mode off - failed to remove notifier shim or 60s cadence"
+      fi
+    fi
+    return 0
+  fi
+
+  # Opted in but missing required config: cannot run; clean up and report once.
+  if [ -z "$key" ] || [ -z "$to" ] || [ -z "$inbox" ]; then
+    email_mode_remove_artifacts || true
+    echo "FME: email mode off - opted in but missing AGENTMAIL_API_KEY, FM_NOTIFY_EMAIL, or AGENTMAIL_INBOX in .env"
+    return 0
+  fi
+
+  missing=0
+  for tool in curl jq; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+      echo "MISSING: $tool (install: $(install_cmd "$tool"))"
+      missing=1
+    fi
+  done
+  if [ "$missing" -ne 0 ]; then
+    email_mode_remove_artifacts || true
+    echo "FME: email mode off - missing notifier dependencies; install them and rerun bootstrap"
+    return 0
+  fi
+
+  email_arm_failed() {
+    if email_mode_remove_artifacts; then
+      echo "FME: email mode off - failed to arm notifier shim or 60s cadence"
+    else
+      echo "FME: email mode off - failed to arm notifier shim or 60s cadence; stale artifacts remain"
+    fi
+  }
+
+  mkdir -p "$STATE" "$CONFIG" 2>/dev/null || { email_arm_failed; return 0; }
+
+  shim_body=$(cat <<EOF
+#!/usr/bin/env bash
+# Auto-generated by fm-bootstrap.sh - email notifier check shim.
+# The watcher runs this each check cycle: the outbound notifier sends any pending
+# emails silently, then the inbound poll runs and its output becomes a check: wake.
+export FM_HOME=$(printf '%q' "$FM_HOME")
+$(printf '%q' "$FM_ROOT/bin/fm-email-notify.sh") >/dev/null 2>&1 || true
+exec $(printf '%q' "$FM_ROOT/bin/fm-email-poll.sh")
+EOF
+)
+  write_if_changed "$shim" "$shim_body" || { email_arm_failed; return 0; }
+  chmod +x "$shim" 2>/dev/null || { email_arm_failed; return 0; }
+
+  cadence_body=$(cat <<'EOF'
+# Auto-generated by fm-bootstrap.sh - email notifier watcher cadence.
+# Source this before arming the watcher (see AGENTS.md "Email mode") so
+# fm-watch.sh polls the inbox every 60s. Non-email instances have no such file and
+# keep the default 300s cadence.
+export FM_CHECK_INTERVAL=60
+EOF
+)
+  write_if_changed "$cadence" "$cadence_body" || { email_arm_failed; return 0; }
+
+  echo "FME: email mode on - notifier armed via state/email-watch.check.sh; 60s watcher cadence in config/email-mode.env"
+}
+
 if [ "${1:-}" = "install" ]; then
   shift
   [ $# -gt 0 ] || { echo "usage: fm-bootstrap.sh install <tool>..." >&2; exit 1; }
@@ -304,5 +416,6 @@ crew=
 fm_tasks_axi_compatible && echo "TASKS_AXI: available"
 secondmate_sync
 x_mode_setup
+email_mode_setup
 fleet_sync
 exit 0

--- a/bin/fm-email-lib.sh
+++ b/bin/fm-email-lib.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Shared config resolution for the email notifier (fm-email-notify.sh and
+# fm-email-poll.sh). Email mode is the out-of-band notifier sibling of X mode:
+# an opt-in, purely additive layer that emails the captain on captain-relevant
+# events and surfaces the captain's email replies as check: wakes. It rides the
+# EXISTING state/*.check.sh mechanism and the captain-relevant classifier; it
+# never edits the watcher backbone.
+#
+# Opt-in is two signals together (mirroring the AgentMail reference in memory):
+#   FM_EMAIL_NOTIFY  truthy      - the explicit opt-in switch
+#   AGENTMAIL_API_KEY non-empty  - the AgentMail bearer key (gitignored .env)
+#   FM_NOTIFY_EMAIL  non-empty   - the captain's recipient address
+#   AGENTMAIL_INBOX  non-empty   - the AgentMail inbox the bot sends from / polls
+# Until FM_EMAIL_NOTIFY is truthy every script here is a HARD no-op, so a user who
+# never opts in sees zero behavior change. Dry-run (FM_EMAIL_DRY_RUN) lets the
+# compose path run with no key and no network, for safe end-to-end testing.
+#
+# This file is sourced, never executed. It defines:
+#   fme_env_get <key> <file>   - read one KEY=VALUE from a .env-style file
+#   fme_truthy <value>         - 0 when the value is a truthy opt-in
+#   fme_load_config            - resolve FME_KEY/FME_NOTIFY/FME_TO/FME_INBOX/
+#                                FME_API_BASE/FME_DRY (env wins over .env)
+#   fme_mode_on                - 0 when fully configured (key OR dry-run)
+#   fme_auth_header_file       - write the bearer header to a 0600 temp file
+#   fme_uri_encode <s>         - percent-encode a string for a URL path segment
+# Callers must have FM_HOME set before calling fme_load_config.
+
+# Read the value of KEY from a .env-style file: last assignment wins; tolerates a
+# leading "export ", surrounding whitespace, and one layer of matching single or
+# double quotes. Prints nothing (and succeeds) when the file or key is absent, so
+# callers can treat empty output as "unset".
+fme_env_get() {
+  local key=$1 file=$2 line val
+  [ -f "$file" ] || return 0
+  line=$(grep -E "^[[:space:]]*(export[[:space:]]+)?${key}=" "$file" 2>/dev/null | tail -n1) || return 0
+  [ -n "$line" ] || return 0
+  val=${line#*=}
+  val=${val#"${val%%[![:space:]]*}"}   # strip leading whitespace
+  val=${val%"${val##*[![:space:]]}"}   # strip trailing whitespace (incl. CR)
+  case "$val" in
+    \"*\") val=${val#\"}; val=${val%\"} ;;
+    \'*\') val=${val#\'}; val=${val%\'} ;;
+  esac
+  printf '%s' "$val"
+}
+
+# 0 (truthy) when the value is anything other than unset/empty/0/false/no/off.
+# Used for the FM_EMAIL_NOTIFY opt-in switch and FM_EMAIL_DRY_RUN.
+fme_truthy() {
+  case "$(printf '%s' "${1-}" | tr '[:upper:]' '[:lower:]')" in
+    ''|0|false|no|off) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+# Resolve the email-mode settings. An explicit environment variable always wins
+# over the .env file. FME_API_BASE defaults to the AgentMail production base and
+# has any trailing slash trimmed so callers can append "/inboxes/...". FME_NOTIFY
+# and FME_DRY are normalized to "1"/"" via fme_truthy.
+fme_load_config() {
+  local env_file="${FME_ENV_FILE:-$FM_HOME/.env}" raw
+  if [ -n "${AGENTMAIL_API_KEY+x}" ]; then FME_KEY=${AGENTMAIL_API_KEY-}; else FME_KEY=$(fme_env_get AGENTMAIL_API_KEY "$env_file"); fi
+  if [ -n "${FM_NOTIFY_EMAIL+x}" ]; then FME_TO=${FM_NOTIFY_EMAIL-}; else FME_TO=$(fme_env_get FM_NOTIFY_EMAIL "$env_file"); fi
+  if [ -n "${AGENTMAIL_INBOX+x}" ]; then FME_INBOX=${AGENTMAIL_INBOX-}; else FME_INBOX=$(fme_env_get AGENTMAIL_INBOX "$env_file"); fi
+  if [ -n "${FM_EMAIL_API_BASE+x}" ]; then FME_API_BASE=${FM_EMAIL_API_BASE-}; else FME_API_BASE=$(fme_env_get FM_EMAIL_API_BASE "$env_file"); fi
+  [ -n "$FME_API_BASE" ] || FME_API_BASE="https://api.agentmail.to/v0"
+  FME_API_BASE=${FME_API_BASE%/}
+
+  if [ -n "${FM_EMAIL_NOTIFY+x}" ]; then raw=${FM_EMAIL_NOTIFY-}; else raw=$(fme_env_get FM_EMAIL_NOTIFY "$env_file"); fi
+  # shellcheck disable=SC2034 # FME_NOTIFY is read by callers after sourcing.
+  if fme_truthy "$raw"; then FME_NOTIFY=1; else FME_NOTIFY=""; fi
+
+  if [ -n "${FM_EMAIL_DRY_RUN+x}" ]; then raw=${FM_EMAIL_DRY_RUN-}; else raw=$(fme_env_get FM_EMAIL_DRY_RUN "$env_file"); fi
+  # shellcheck disable=SC2034 # FME_DRY is read by callers after sourcing.
+  if fme_truthy "$raw"; then FME_DRY=1; else FME_DRY=""; fi
+}
+
+# 0 when the live send/poll path is fully configured: a recipient and an inbox,
+# plus a key (or dry-run, which needs neither key nor network). Callers that have
+# already gated on FME_NOTIFY use this to decide live-vs-noop.
+fme_mode_on() {
+  [ -n "$FME_TO" ] && [ -n "$FME_INBOX" ] || return 1
+  [ -n "$FME_KEY" ] || [ -n "$FME_DRY" ]
+}
+
+# Write the bearer header to a private (0600) temp file and echo its path, so the
+# key is never passed on a command line where `ps` could read it. Returns
+# non-zero if the key contains a newline (which would smuggle a second header).
+fme_auth_header_file() {
+  local file
+  case "$FME_KEY" in
+    *$'\n'*|*$'\r'*) return 1 ;;
+  esac
+  file=$(umask 077; mktemp "${TMPDIR:-/tmp}/fm-email-auth.XXXXXX") || return 1
+  chmod 600 "$file" 2>/dev/null || { rm -f "$file"; return 1; }
+  printf 'Authorization: Bearer %s\n' "$FME_KEY" > "$file" || { rm -f "$file"; return 1; }
+  printf '%s\n' "$file"
+}
+
+# Percent-encode a string for safe use as a single URL path segment (the inbox
+# address has an "@" that must become "%40", and message ids carry "<>@"). Uses
+# jq's @uri so encoding is correct and never shells out with the raw value.
+fme_uri_encode() {
+  jq -rn --arg s "$1" '$s|@uri' 2>/dev/null
+}

--- a/bin/fm-email-notify.sh
+++ b/bin/fm-email-notify.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Outbound half of the email notifier: email the captain when a captain-relevant
+# event turns up. Modeled on X mode (bin/fm-x-*.sh): purely additive, opt-in, and
+# riding the EXISTING watcher check mechanism rather than editing the backbone.
+#
+# This is the silent side-effect body of the generated check shim
+# state/email-watch.check.sh: the watcher runs it each check cycle, it sends any
+# pending notifications, and it prints NOTHING (so it never adds a spurious wake -
+# the underlying status already wakes firstmate through the normal signal path).
+#
+# It scans state/*.status with the SAME captain-relevant classifier the watcher
+# uses (bin/fm-classify-lib.sh, scan_captain_relevant_statuses), and for each
+# status whose last captain-relevant line it has not already emailed it sends one
+# concise, plain-language email via AgentMail. Dedupe is per task: the last line
+# emailed for a task is recorded in state/.email-seen-<task>, so the same event is
+# never emailed twice and a settled line is not re-sent every cycle.
+#
+# Inert by default: a HARD no-op (exit 0, no output) unless FM_EMAIL_NOTIFY is
+# truthy AND a recipient/inbox (and a key, unless dry-run) are configured. Email
+# text is composed in plain outcome language (no task ids or internal vocabulary,
+# mirroring AGENTS.md section 9). Status-line text is crewmate-authored and is
+# treated as untrusted: it is only ever passed to jq via --arg, never inlined
+# into a shell command.
+#
+# Config (home .env, FME_ENV_FILE, or env): FM_EMAIL_NOTIFY (opt-in),
+# AGENTMAIL_API_KEY, FM_NOTIFY_EMAIL (recipient), AGENTMAIL_INBOX (send-from),
+# FM_EMAIL_API_BASE (default https://api.agentmail.to/v0), FM_EMAIL_DRY_RUN.
+# Dry-run records the would-be message to state/email-outbox/<task>.json instead
+# of sending, and needs neither a key nor the network.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+# shellcheck source=bin/fm-email-lib.sh
+. "$SCRIPT_DIR/fm-email-lib.sh"
+# shellcheck source=bin/fm-classify-lib.sh
+. "$SCRIPT_DIR/fm-classify-lib.sh"
+
+fme_load_config
+# Hard no-op when email mode is off: this keeps the check shim inert.
+fme_truthy "$FME_NOTIFY" || exit 0
+# Opted in but not fully configured: the outbound side cannot surface an error
+# (it must stay silent), so just no-op; the poll side reports config problems.
+fme_mode_on || exit 0
+command -v jq >/dev/null 2>&1 || exit 0
+
+[ -d "$STATE" ] || exit 0
+
+# Map a captain-relevant status line to a plain-language subject category and a
+# human detail (the line with its leading "verb:" stripped). No task ids, no
+# internal vocabulary - outcomes only (AGENTS.md section 9).
+classify_subject() {  # <line>
+  case "$1" in
+    needs-decision:*) printf 'A decision is needed' ;;
+    blocked:*)        printf 'Work is blocked' ;;
+    failed:*)         printf 'Work did not pan out' ;;
+    *)                printf 'Update on your projects' ;;
+  esac
+}
+
+strip_verb() {  # <line> -> detail without a leading "<verb>: "
+  local line=$1
+  case "$line" in
+    needs-decision:*|blocked:*|failed:*|done:*) printf '%s' "${line#*: }" ;;
+    *) printf '%s' "$line" ;;
+  esac
+}
+
+# Best-effort project label for a task, from state/<task>.meta project=. Returns
+# empty when unknown; the basename keeps it a plain project name, never a path.
+project_label() {  # <task>
+  local meta=$1 line val
+  meta="$STATE/$meta.meta"
+  [ -f "$meta" ] || return 0
+  line=$(grep -E '^project=' "$meta" 2>/dev/null | tail -n1) || return 0
+  val=${line#project=}
+  val=${val##*/}
+  printf '%s' "$val"
+}
+
+seen_path() {  # <task>
+  printf '%s/.email-seen-%s' "$STATE" "$1"
+}
+
+# Send (or, in dry-run, record) one notification email. Returns 0 only when the
+# message was accepted, so the caller advances the dedupe marker exactly once the
+# event has actually gone out.
+send_email() {  # <to> <subject> <text> <task>
+  local to=$1 subject=$2 text=$3 task=$4 payload enc code auth
+
+  payload=$(jq -nc --arg to "$to" --arg subject "$subject" --arg text "$text" \
+    '{to:$to, subject:$subject, text:$text}') || return 1
+
+  if [ -n "$FME_DRY" ]; then
+    local outbox_dir="$STATE/email-outbox" outbox_file
+    outbox_file="$outbox_dir/$task.json"
+    mkdir -p "$outbox_dir" 2>/dev/null || return 1
+    printf '%s\n' "$payload" > "$outbox_file" 2>/dev/null || return 1
+    printf 'fm-email-notify: DRY RUN - would email %s: %s\n' "$to" "$subject" >&2
+    return 0
+  fi
+
+  command -v curl >/dev/null 2>&1 || return 1
+  enc=$(fme_uri_encode "$FME_INBOX") || return 1
+  [ -n "$enc" ] || return 1
+  auth=$(fme_auth_header_file) || return 1
+
+  code=$(curl -m 10 -s -o /dev/null -w '%{http_code}' \
+    -X POST \
+    -H "@$auth" \
+    -H 'Content-Type: application/json' \
+    --data "$payload" \
+    "$FME_API_BASE/inboxes/$enc/messages/send" 2>/dev/null) || { rm -f "$auth"; return 1; }
+  rm -f "$auth"
+
+  case "$code" in
+    2[0-9][0-9]) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# One pass over the fleet's captain-relevant statuses.
+while IFS=$(printf '\t') read -r _ task last; do
+  [ -n "$task" ] || continue
+  # Per-task dedupe: skip when this exact line has already been emailed.
+  prev=$(cat "$(seen_path "$task")" 2>/dev/null || true)
+  [ "$prev" = "$last" ] && continue
+
+  subject=$(classify_subject "$last")
+  detail=$(strip_verb "$last")
+  project=$(project_label "$task")
+
+  if [ -n "$project" ]; then
+    subject="firstmate: $subject ($project)"
+    body=$(printf '%s\n\nProject: %s\n\nReply to this email to steer firstmate.\n' "$detail" "$project")
+  else
+    subject="firstmate: $subject"
+    body=$(printf '%s\n\nReply to this email to steer firstmate.\n' "$detail")
+  fi
+
+  if send_email "$FME_TO" "$subject" "$body" "$task"; then
+    # Advance the dedupe marker only after the event has gone out, so a failed
+    # send is retried on the next cycle instead of being silently dropped.
+    printf '%s' "$last" > "$(seen_path "$task")" 2>/dev/null || true
+  fi
+done < <(scan_captain_relevant_statuses "$STATE")
+
+exit 0

--- a/bin/fm-email-poll.sh
+++ b/bin/fm-email-poll.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# Inbound half of the email notifier: poll the AgentMail inbox for the captain's
+# replies and surface each new one as a check: wake so it can steer firstmate.
+# The two-way sibling of X mode's fm-x-poll.sh, riding the EXISTING watcher check
+# mechanism (state/*.check.sh) with no backbone edits.
+#
+# Inert by default: a HARD no-op (exit 0, no output) unless FM_EMAIL_NOTIFY is
+# truthy. This script is the wake-producing tail of the generated check shim
+# state/email-watch.check.sh, where the contract is "output => wake firstmate,
+# silence => keep sleeping".
+#
+# Behavior when email mode is on:
+#   missing curl/jq, bad config, or relay auth error -> one rate-limited
+#       "email-mode-error <msg>" line (a captain-visible check: wake)
+#   HTTP 204 / empty / no new captain replies               -> print nothing, exit 0
+#   first ever poll (no seen file)                          -> baseline every
+#       current message id as seen and print nothing, so enabling email mode never
+#       floods the captain's existing inbox; only mail arriving AFTER opt-in surfaces
+#   a new message FROM the captain (FM_NOTIFY_EMAIL)        -> stash the message
+#       object (with full text fetched best-effort) to state/email-inbox/<safe>.json
+#       and print "email-reply <safe>"
+# The captain's reply text is kept as the stashed payload; firstmate drains
+# state/email-inbox/ as the source of truth (mirroring fmx-respond and x-inbox).
+#
+# Email content (subject/body/from) is untrusted public-ish input: it is only ever
+# parsed by jq from a file, never inlined into a shell command, and the message id
+# is sanitized before it becomes a filename.
+#
+# Config (home .env, FME_ENV_FILE, or env): FM_EMAIL_NOTIFY (opt-in),
+# AGENTMAIL_API_KEY, FM_NOTIFY_EMAIL (the captain's address, used as the
+# from-captain filter), AGENTMAIL_INBOX (the inbox to poll), FM_EMAIL_API_BASE
+# (default https://api.agentmail.to/v0).
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+# shellcheck source=bin/fm-email-lib.sh
+. "$SCRIPT_DIR/fm-email-lib.sh"
+
+fme_load_config
+# Hard no-op when email mode is off.
+fme_truthy "$FME_NOTIFY" || exit 0
+
+ERROR_FILE="$STATE/email-poll.error"
+SEEN_FILE="$STATE/.email-poll-seen"
+INBOX="$STATE/email-inbox"
+
+emit_error_once() {
+  local msg=$1
+  mkdir -p "$STATE" 2>/dev/null || true
+  if [ -f "$ERROR_FILE" ] && [ "$(cat "$ERROR_FILE" 2>/dev/null)" = "$msg" ]; then
+    return 0
+  fi
+  printf '%s\n' "$msg" > "$ERROR_FILE" 2>/dev/null || true
+  printf 'email-mode-error %s\n' "$msg"
+}
+
+clear_error() { rm -f "$ERROR_FILE" 2>/dev/null || true; }
+
+command -v curl >/dev/null 2>&1 || { emit_error_once "missing curl"; exit 0; }
+command -v jq   >/dev/null 2>&1 || { emit_error_once "missing jq"; exit 0; }
+
+# Opted in but not fully configured.
+if [ -z "$FME_KEY" ] || [ -z "$FME_TO" ] || [ -z "$FME_INBOX" ]; then
+  emit_error_once "email mode not fully configured (need AGENTMAIL_API_KEY, FM_NOTIFY_EMAIL, AGENTMAIL_INBOX)"
+  exit 0
+fi
+
+INBOX_ENC=$(fme_uri_encode "$FME_INBOX")
+[ -n "$INBOX_ENC" ] || { emit_error_once "invalid AGENTMAIL_INBOX"; exit 0; }
+
+AUTH_HEADER_FILE=$(fme_auth_header_file) || { emit_error_once "invalid AGENTMAIL_API_KEY"; exit 0; }
+BODY_FILE=$(mktemp "${TMPDIR:-/tmp}/fm-email-poll.XXXXXX") || { rm -f "$AUTH_HEADER_FILE"; exit 0; }
+trap 'rm -f "$BODY_FILE" "$AUTH_HEADER_FILE"' EXIT
+
+# Short, bounded poll: a failure or timeout just means "no wake this cycle".
+code=$(curl -m 5 -s -o "$BODY_FILE" -w '%{http_code}' \
+  -H "@$AUTH_HEADER_FILE" \
+  -H 'Accept: application/json' \
+  "$FME_API_BASE/inboxes/$INBOX_ENC/messages" 2>/dev/null) || exit 0
+
+case "$code" in
+  200) ;;
+  204) clear_error; exit 0 ;;
+  400|401|403|404) emit_error_once "relay returned HTTP $code"; exit 0 ;;
+  *) exit 0 ;;
+esac
+[ -s "$BODY_FILE" ] || { clear_error; exit 0; }
+
+# All current message ids (any sender) - used both for the first-run baseline and,
+# below, to dedupe. A malformed body yields nothing and we treat it as "no mail".
+ALL_IDS=$(jq -r '(.messages // [])[]? | (.message_id // empty)' "$BODY_FILE" 2>/dev/null) || { clear_error; exit 0; }
+
+mkdir -p "$STATE" 2>/dev/null || { emit_error_once "cannot create state dir"; exit 0; }
+
+# First ever poll: baseline every current id as already-seen and surface nothing,
+# so enabling email mode never replays the inbox's pre-existing mail.
+if [ ! -f "$SEEN_FILE" ]; then
+  printf '%s\n' "$ALL_IDS" | grep -v '^[[:space:]]*$' > "$SEEN_FILE" 2>/dev/null || true
+  clear_error
+  exit 0
+fi
+
+# Candidate ids: messages FROM the captain (case-insensitive substring of the
+# from header, which may be "Name <addr>"). jq does the filtering so the untrusted
+# from/subject text never reaches the shell.
+CAP_LC=$(printf '%s' "$FME_TO" | tr '[:upper:]' '[:lower:]')
+CANDIDATES=$(jq -r --arg cap "$CAP_LC" '
+  (.messages // [])[]?
+  | select(((.from // "") | ascii_downcase) | contains($cap))
+  | (.message_id // empty)
+' "$BODY_FILE" 2>/dev/null) || { clear_error; exit 0; }
+
+emitted=0
+while IFS= read -r mid; do
+  [ -n "$mid" ] || continue
+  case "$mid" in *[[:space:]]*) continue ;; esac          # ignore malformed ids
+  grep -Fxq -- "$mid" "$SEEN_FILE" 2>/dev/null && continue  # already surfaced
+
+  # Sanitize the relay-issued id into a safe filename slug; keep a cksum suffix
+  # when sanitizing changed it so distinct ids never collide.
+  safe=$(printf '%s' "$mid" | tr -c 'A-Za-z0-9._-' '_')
+  if [ -z "$safe" ] || [ "$safe" != "$mid" ]; then
+    safe="${safe:0:80}-$(printf '%s' "$mid" | cksum | cut -d' ' -f1)"
+  fi
+
+  # The list endpoint carries only a preview; fetch the full message text
+  # best-effort so the captain's whole reply is the payload, falling back to the
+  # preview if the per-message fetch fails.
+  mid_enc=$(fme_uri_encode "$mid")
+  full_text=
+  if [ -n "$mid_enc" ]; then
+    msg_file=$(mktemp "${TMPDIR:-/tmp}/fm-email-msg.XXXXXX") || msg_file=
+    if [ -n "$msg_file" ]; then
+      mcode=$(curl -m 5 -s -o "$msg_file" -w '%{http_code}' \
+        -H "@$AUTH_HEADER_FILE" -H 'Accept: application/json' \
+        "$FME_API_BASE/inboxes/$INBOX_ENC/messages/$mid_enc" 2>/dev/null) || mcode=
+      case "$mcode" in
+        200) full_text=$(jq -r '(.text // empty)' "$msg_file" 2>/dev/null) || full_text= ;;
+      esac
+      rm -f "$msg_file"
+    fi
+  fi
+
+  # Stash the message object, folding in the fetched full text when we got one
+  # (otherwise the list object keeps its preview). Written atomically so a
+  # concurrent reader never sees a half-written file.
+  mkdir -p "$INBOX" 2>/dev/null || { emit_error_once "cannot create inbox"; break; }
+  if jq --arg id "$mid" --arg ft "$full_text" '
+        (.messages // [])[] | select((.message_id // "") == $id)
+        | . + (if ($ft | length) > 0 then {text:$ft} else {} end)
+      ' "$BODY_FILE" > "$INBOX/$safe.json.tmp" 2>/dev/null \
+     && [ -s "$INBOX/$safe.json.tmp" ] \
+     && mv -f "$INBOX/$safe.json.tmp" "$INBOX/$safe.json" 2>/dev/null; then
+    printf '%s\n' "$mid" >> "$SEEN_FILE" 2>/dev/null || true
+    printf 'email-reply %s\n' "$safe"
+    emitted=$((emitted + 1))
+  else
+    rm -f "$INBOX/$safe.json.tmp" 2>/dev/null || true
+    emit_error_once "cannot write inbox"
+    break
+  fi
+done <<EOF
+$CANDIDATES
+EOF
+
+# Bound the seen file's growth without losing recent ids.
+if [ -f "$SEEN_FILE" ]; then
+  tail -n 2000 "$SEEN_FILE" > "$SEEN_FILE.tmp" 2>/dev/null && mv -f "$SEEN_FILE.tmp" "$SEEN_FILE" 2>/dev/null || rm -f "$SEEN_FILE.tmp" 2>/dev/null || true
+fi
+
+[ "$emitted" -gt 0 ] && exit 0
+clear_error
+exit 0

--- a/tests/fm-email-mode.test.sh
+++ b/tests/fm-email-mode.test.sh
@@ -1,0 +1,408 @@
+#!/usr/bin/env bash
+# Behavior tests for email mode: the outbound notifier (fm-email-notify.sh), the
+# inbound inbox poll (fm-email-poll.sh), and bootstrap's .env-presence activation.
+#
+# Email mode must be INERT by default (no opt-in -> both scripts are hard no-ops
+# and bootstrap writes/prints nothing) and additive when on (a single check shim +
+# a 60s cadence config, both idempotent). The AgentMail HTTP layer is stubbed with
+# a fakebin `curl` so these stay hermetic: no ports, no server, no real key,
+# deterministic in CI. jq stays the real tool. The classify->compose path is also
+# exercised keylessly via the dry-run preview, and the inbound-parse path via the
+# fake curl serving canned list/message JSON.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+BASE_PATH=${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin}
+JQ_DIR=$(command -v jq 2>/dev/null) && JQ_DIR=$(dirname "$JQ_DIR") || JQ_DIR=
+[ -n "$JQ_DIR" ] && BASE_PATH="$JQ_DIR:$BASE_PATH"
+TMP_ROOT=$(fm_test_tmproot fm-email-mode-tests)
+
+# A fakebin `curl` that mimics AgentMail: it reads its behavior from env
+# (FAKE_LIST_CODE/FAKE_LIST_BODY for GET .../messages, FAKE_MSG_BODY for GET a
+# single message, FAKE_SEND_CODE for POST .../messages/send), records each call to
+# FAKE_CURL_LOG (with the auth header, url, method, and posted data), writes the
+# response body to the script's -o file, and prints the HTTP code to stdout
+# exactly as the real `-w '%{http_code}'` would.
+make_fake_curl() {
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/curl" <<'SH'
+#!/usr/bin/env bash
+ofile="" method=GET data="" url="" auth=""
+argv=$*
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -o) ofile=$2; shift 2 ;;
+    -X) method=$2; shift 2 ;;
+    --data) data=$2; shift 2 ;;
+    -H)
+      case "$2" in
+        @*) while IFS= read -r header; do case "$header" in Authorization:*) auth=$header ;; esac; done < "${2#@}" ;;
+        Authorization:*) auth=$2 ;;
+      esac
+      shift 2
+      ;;
+    -m|-w) shift 2 ;;
+    -s) shift ;;
+    http://*|https://*) url=$1; shift ;;
+    *) shift ;;
+  esac
+done
+if [ -n "${FAKE_CURL_LOG:-}" ]; then
+  { echo "argv=$argv"; echo "method=$method"; echo "url=$url"; echo "auth=$auth"; echo "data=$data"; } >> "$FAKE_CURL_LOG"
+fi
+case "$url" in
+  */messages/send)
+    printf '%s' "${FAKE_SEND_CODE:-200}"
+    ;;
+  */messages/*)
+    [ -n "$ofile" ] && printf '%s' "${FAKE_MSG_BODY:-}" > "$ofile"
+    printf '%s' "${FAKE_MSG_CODE:-200}"
+    ;;
+  */messages)
+    [ -n "$ofile" ] && printf '%s' "${FAKE_LIST_BODY:-}" > "$ofile"
+    printf '%s' "${FAKE_LIST_CODE:-200}"
+    ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/curl"
+  printf '%s\n' "$fakebin"
+}
+
+# Common live-mode env for the configured-on path.
+email_on_env() {
+  printf 'FM_EMAIL_NOTIFY=1\nAGENTMAIL_API_KEY=key-abc\nFM_NOTIFY_EMAIL=cap@example.com\nAGENTMAIL_INBOX=d-8274@agentmail.to\n'
+}
+
+# ---------------------------------------------------------------------------
+# Outbound notifier
+# ---------------------------------------------------------------------------
+
+test_notify_no_optin_is_hard_noop() {
+  local home fakebin out rc
+  home="$TMP_ROOT/notify-noop"; mkdir -p "$home/state"
+  fakebin=$(make_fake_curl "$home")
+  printf 'needs-decision: pick a db\n' > "$home/state/t1.status"
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$home" "$ROOT/bin/fm-email-notify.sh"); rc=$?
+  expect_code 0 "$rc" "notify no-optin exit"
+  [ -z "$out" ] || fail "notify no-optin must be silent (got: $out)"
+  assert_absent "$home/state/email-outbox" "notify no-optin must not write an outbox"
+  pass "fm-email-notify is a hard no-op without opt-in (inert default)"
+}
+
+test_notify_dry_run_composes_keyless() {
+  local home out body
+  home="$TMP_ROOT/notify-dry"; mkdir -p "$home/state"
+  # No key, no curl on PATH: dry-run must compose purely from jq.
+  printf 'needs-decision: Clerk vs custom auth\n' > "$home/state/fix-login.status"
+  printf 'project=projects/yourapp\nkind=ship\n' > "$home/state/fix-login.meta"
+  out=$(PATH="$JQ_DIR:/usr/bin:/bin" FM_HOME="$home" FM_EMAIL_NOTIFY=1 \
+    FM_NOTIFY_EMAIL=cap@example.com AGENTMAIL_INBOX=d-8274@agentmail.to \
+    FM_EMAIL_DRY_RUN=1 "$ROOT/bin/fm-email-notify.sh" 2>&1)
+  assert_contains "$out" "DRY RUN" "dry-run prints a preview"
+  assert_present "$home/state/email-outbox/fix-login.json" "dry-run records the outbox"
+  body=$(cat "$home/state/email-outbox/fix-login.json")
+  assert_contains "$body" '"to":"cap@example.com"' "outbox carries the recipient"
+  assert_contains "$body" "A decision is needed" "subject is plain-language for needs-decision"
+  assert_contains "$body" "yourapp" "body carries the project label"
+  assert_contains "$body" "Clerk vs custom auth" "body carries the detail"
+  assert_not_contains "$body" "fix-login" "no task id leaks into the email"
+  pass "fm-email-notify dry-run composes a plain-language email with no key or network"
+}
+
+test_notify_dedupe_same_event() {
+  local home out
+  home="$TMP_ROOT/notify-dedupe"; mkdir -p "$home/state"
+  printf 'blocked: needs staging credentials\n' > "$home/state/job.status"
+  PATH="$JQ_DIR:/usr/bin:/bin" FM_HOME="$home" FM_EMAIL_NOTIFY=1 \
+    FM_NOTIFY_EMAIL=cap@example.com AGENTMAIL_INBOX=d-8274@agentmail.to \
+    FM_EMAIL_DRY_RUN=1 "$ROOT/bin/fm-email-notify.sh" >/dev/null 2>&1
+  assert_present "$home/state/.email-seen-job" "first send advances the dedupe marker"
+  out=$(PATH="$JQ_DIR:/usr/bin:/bin" FM_HOME="$home" FM_EMAIL_NOTIFY=1 \
+    FM_NOTIFY_EMAIL=cap@example.com AGENTMAIL_INBOX=d-8274@agentmail.to \
+    FM_EMAIL_DRY_RUN=1 "$ROOT/bin/fm-email-notify.sh" 2>&1)
+  [ -z "$out" ] || fail "second run on the same event must be silent (got: $out)"
+  pass "fm-email-notify dedupes the same event"
+}
+
+test_notify_new_line_after_marker_resends() {
+  local home out
+  home="$TMP_ROOT/notify-resend"; mkdir -p "$home/state"
+  printf 'blocked: waiting on creds\n' > "$home/state/job.status"
+  PATH="$JQ_DIR:/usr/bin:/bin" FM_HOME="$home" FM_EMAIL_NOTIFY=1 \
+    FM_NOTIFY_EMAIL=cap@example.com AGENTMAIL_INBOX=d-8274@agentmail.to \
+    FM_EMAIL_DRY_RUN=1 "$ROOT/bin/fm-email-notify.sh" >/dev/null 2>&1
+  # A new captain-relevant line appears -> a fresh notification.
+  printf 'done: PR https://github.com/o/r/pull/7 checks green\n' >> "$home/state/job.status"
+  out=$(PATH="$JQ_DIR:/usr/bin:/bin" FM_HOME="$home" FM_EMAIL_NOTIFY=1 \
+    FM_NOTIFY_EMAIL=cap@example.com AGENTMAIL_INBOX=d-8274@agentmail.to \
+    FM_EMAIL_DRY_RUN=1 "$ROOT/bin/fm-email-notify.sh" 2>&1)
+  assert_contains "$out" "DRY RUN" "a new captain-relevant line re-notifies"
+  assert_contains "$(cat "$home/state/email-outbox/job.json")" "Update on your projects" "done maps to an update subject"
+  pass "fm-email-notify re-notifies on a new captain-relevant line"
+}
+
+test_notify_ignores_non_captain_relevant() {
+  local home out
+  home="$TMP_ROOT/notify-irrelevant"; mkdir -p "$home/state"
+  printf 'working: still compiling\n' > "$home/state/t.status"
+  out=$(PATH="$JQ_DIR:/usr/bin:/bin" FM_HOME="$home" FM_EMAIL_NOTIFY=1 \
+    FM_NOTIFY_EMAIL=cap@example.com AGENTMAIL_INBOX=d-8274@agentmail.to \
+    FM_EMAIL_DRY_RUN=1 "$ROOT/bin/fm-email-notify.sh" 2>&1)
+  [ -z "$out" ] || fail "a non-captain-relevant status must not email (got: $out)"
+  assert_absent "$home/state/email-outbox" "no outbox for a non-captain-relevant status"
+  pass "fm-email-notify ignores non-captain-relevant statuses"
+}
+
+test_notify_live_posts_to_send_endpoint() {
+  local home fakebin log out
+  home="$TMP_ROOT/notify-live"; mkdir -p "$home/state"
+  fakebin=$(make_fake_curl "$home")
+  log="$home/curl.log"
+  email_on_env > "$home/.env"
+  printf 'failed: the migration could not complete\n' > "$home/state/mig.status"
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$home" FAKE_CURL_LOG="$log" FAKE_SEND_CODE=200 \
+    "$ROOT/bin/fm-email-notify.sh");
+  [ -z "$out" ] || fail "live notify must be silent on stdout (got: $out)"
+  assert_grep "method=POST" "$log" "notify POSTs the email"
+  assert_grep "/inboxes/d-8274%40agentmail.to/messages/send" "$log" "notify hits the send endpoint with an encoded inbox"
+  assert_grep "auth=Authorization: Bearer key-abc" "$log" "notify sends the bearer key"
+  assert_grep "Work did not pan out" "$log" "failed maps to a plain-language subject"
+  if grep '^argv=' "$log" | grep -F 'key-abc' >/dev/null 2>&1; then
+    fail "the key must never appear on curl's argv"
+  fi
+  assert_present "$home/state/.email-seen-mig" "a successful send advances the marker"
+  pass "fm-email-notify live-posts to the AgentMail send endpoint with the bearer key off-argv"
+}
+
+test_notify_failed_send_does_not_advance_marker() {
+  local home fakebin
+  home="$TMP_ROOT/notify-fail"; mkdir -p "$home/state"
+  fakebin=$(make_fake_curl "$home")
+  email_on_env > "$home/.env"
+  printf 'needs-decision: which region\n' > "$home/state/region.status"
+  PATH="$fakebin:$BASE_PATH" FM_HOME="$home" FAKE_SEND_CODE=500 \
+    "$ROOT/bin/fm-email-notify.sh" >/dev/null 2>&1
+  assert_absent "$home/state/.email-seen-region" "a failed send must not advance the dedupe marker (so it retries)"
+  pass "fm-email-notify retries after a failed send (marker not advanced)"
+}
+
+# ---------------------------------------------------------------------------
+# Inbound poll
+# ---------------------------------------------------------------------------
+
+test_poll_no_optin_is_hard_noop() {
+  local home fakebin out rc
+  home="$TMP_ROOT/poll-noop"; mkdir -p "$home"
+  fakebin=$(make_fake_curl "$home")
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$home" "$ROOT/bin/fm-email-poll.sh"); rc=$?
+  expect_code 0 "$rc" "poll no-optin exit"
+  [ -z "$out" ] || fail "poll no-optin must be silent (got: $out)"
+  assert_absent "$home/state/email-inbox" "poll no-optin must not create an inbox"
+  pass "fm-email-poll is a hard no-op without opt-in (inert default)"
+}
+
+test_poll_incomplete_config_reports_once() {
+  local home fakebin out
+  home="$TMP_ROOT/poll-incomplete"; mkdir -p "$home/state"
+  fakebin=$(make_fake_curl "$home")
+  # Opted in but no key/recipient/inbox.
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$home" FM_EMAIL_NOTIFY=1 \
+    "$ROOT/bin/fm-email-poll.sh")
+  assert_contains "$out" "email-mode-error" "incomplete config surfaces a config error"
+  # Deduped on the next poll with the same error.
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$home" FM_EMAIL_NOTIFY=1 \
+    "$ROOT/bin/fm-email-poll.sh")
+  [ -z "$out" ] || fail "a repeated identical config error must be deduped (got: $out)"
+  pass "fm-email-poll reports incomplete config once"
+}
+
+test_poll_baseline_then_new_reply() {
+  local home fakebin out list list2 msg safe
+  home="$TMP_ROOT/poll-baseline"; mkdir -p "$home/state"
+  fakebin=$(make_fake_curl "$home")
+  email_on_env > "$home/.env"
+  list='{"messages":[{"message_id":"<m1@x>","from":"Captain <cap@example.com>","subject":"hi","preview":"old"},{"message_id":"n2","from":"noreply@other.com","subject":"x","preview":"y"}]}'
+  # First poll: baseline every current id, surface nothing.
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$home" FAKE_LIST_BODY="$list" \
+    "$ROOT/bin/fm-email-poll.sh")
+  [ -z "$out" ] || fail "first poll must baseline silently (got: $out)"
+  assert_grep "<m1@x>" "$home/state/.email-poll-seen" "baseline records existing ids"
+  assert_absent "$home/state/email-inbox" "baseline surfaces nothing"
+
+  # Second poll: a new reply from the captain arrives.
+  list2='{"messages":[{"message_id":"<m1@x>","from":"Captain <cap@example.com>","subject":"hi","preview":"old"},{"message_id":"n2","from":"noreply@other.com","subject":"x","preview":"y"},{"message_id":"<m3@x>","from":"cap@example.com","subject":"Re: blocked","preview":"use staging"}]}'
+  msg='{"message_id":"<m3@x>","from":"cap@example.com","subject":"Re: blocked","text":"Use the staging db for now.","preview":"use staging"}'
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$home" FAKE_LIST_BODY="$list2" FAKE_MSG_BODY="$msg" \
+    "$ROOT/bin/fm-email-poll.sh")
+  assert_contains "$out" "email-reply " "a new captain reply produces a wake"
+  safe=$(printf '%s' "$out" | sed -n 's/^email-reply //p' | head -1)
+  assert_present "$home/state/email-inbox/$safe.json" "the new reply is stashed"
+  assert_grep "Use the staging db for now." "$home/state/email-inbox/$safe.json" "full text is fetched and stashed as the payload"
+  pass "fm-email-poll baselines on first run, then surfaces a new captain reply with full text"
+}
+
+test_poll_ignores_non_captain_sender() {
+  local home fakebin out list
+  home="$TMP_ROOT/poll-nonsender"; mkdir -p "$home/state"
+  fakebin=$(make_fake_curl "$home")
+  email_on_env > "$home/.env"
+  # Baseline empty so any new message would surface if not filtered.
+  printf '' > "$home/state/.email-poll-seen"
+  list='{"messages":[{"message_id":"s1","from":"stranger@evil.com","subject":"spam","preview":"buy"}]}'
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$home" FAKE_LIST_BODY="$list" \
+    "$ROOT/bin/fm-email-poll.sh")
+  [ -z "$out" ] || fail "a message from a non-captain sender must not surface (got: $out)"
+  assert_absent "$home/state/email-inbox" "no inbox stash for a non-captain sender"
+  pass "fm-email-poll only surfaces replies from the captain's address"
+}
+
+test_poll_dedupes_seen_reply() {
+  local home fakebin out list msg
+  home="$TMP_ROOT/poll-dedupe"; mkdir -p "$home/state"
+  fakebin=$(make_fake_curl "$home")
+  email_on_env > "$home/.env"
+  printf '' > "$home/state/.email-poll-seen"
+  list='{"messages":[{"message_id":"r9","from":"cap@example.com","subject":"Re","preview":"ok"}]}'
+  msg='{"message_id":"r9","from":"cap@example.com","subject":"Re","text":"ok do it","preview":"ok"}'
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$home" FAKE_LIST_BODY="$list" FAKE_MSG_BODY="$msg" \
+    "$ROOT/bin/fm-email-poll.sh")
+  assert_contains "$out" "email-reply r9" "first sighting surfaces"
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$home" FAKE_LIST_BODY="$list" FAKE_MSG_BODY="$msg" \
+    "$ROOT/bin/fm-email-poll.sh")
+  [ -z "$out" ] || fail "an already-seen reply must not surface again (got: $out)"
+  pass "fm-email-poll dedupes an already-surfaced reply"
+}
+
+test_poll_sanitizes_unsafe_message_id() {
+  local home fakebin out list msg safe
+  home="$TMP_ROOT/poll-unsafe"; mkdir -p "$home/state"
+  fakebin=$(make_fake_curl "$home")
+  email_on_env > "$home/.env"
+  printf '' > "$home/state/.email-poll-seen"
+  list='{"messages":[{"message_id":"../../etc/passwd","from":"cap@example.com","subject":"x","preview":"p"}]}'
+  msg='{"message_id":"../../etc/passwd","from":"cap@example.com","subject":"x","text":"hi","preview":"p"}'
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$home" FAKE_LIST_BODY="$list" FAKE_MSG_BODY="$msg" \
+    "$ROOT/bin/fm-email-poll.sh")
+  safe=$(printf '%s' "$out" | sed -n 's/^email-reply //p' | head -1)
+  # A flat slug (no slash, and never exactly "." or "..") cannot traverse.
+  case "$safe" in
+    */*|.|..) fail "the stash slug must be a flat, non-traversing filename (got: $safe)" ;;
+  esac
+  assert_present "$home/state/email-inbox/$safe.json" "the sanitized stash lands inside the inbox dir"
+  assert_absent "$home/state/email-inbox/../../etc/passwd" "no traversal write happened"
+  pass "fm-email-poll sanitizes an unsafe message id into a safe slug"
+}
+
+test_poll_204_is_silent() {
+  local home fakebin out rc
+  home="$TMP_ROOT/poll-204"; mkdir -p "$home/state"
+  fakebin=$(make_fake_curl "$home")
+  email_on_env > "$home/.env"
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$home" FAKE_LIST_CODE=204 \
+    "$ROOT/bin/fm-email-poll.sh"); rc=$?
+  expect_code 0 "$rc" "poll 204 exit"
+  [ -z "$out" ] || fail "poll 204 must be silent (got: $out)"
+  pass "fm-email-poll is silent on HTTP 204"
+}
+
+test_poll_auth_error_reports_once() {
+  local home fakebin out
+  home="$TMP_ROOT/poll-auth"; mkdir -p "$home/state"
+  fakebin=$(make_fake_curl "$home")
+  email_on_env > "$home/.env"
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$home" FAKE_LIST_CODE=401 \
+    "$ROOT/bin/fm-email-poll.sh")
+  assert_contains "$out" "email-mode-error relay returned HTTP 401" "auth error surfaces"
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$home" FAKE_LIST_CODE=401 \
+    "$ROOT/bin/fm-email-poll.sh")
+  [ -z "$out" ] || fail "a repeated identical auth error must be deduped (got: $out)"
+  pass "fm-email-poll reports an auth error once"
+}
+
+# ---------------------------------------------------------------------------
+# Bootstrap activation
+# ---------------------------------------------------------------------------
+
+run_bootstrap() {  # <home> -> stdout; PATH has the tools bootstrap needs
+  local home=$1; shift
+  PATH="$JQ_DIR:$BASE_PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" \
+    FM_STATE_OVERRIDE="$home/state" FM_CONFIG_OVERRIDE="$home/config" \
+    FM_PROJECTS_OVERRIDE="$home/projects" "$@" "$ROOT/bin/fm-bootstrap.sh" 2>/dev/null
+}
+
+test_bootstrap_inert_without_optin() {
+  local home out
+  home="$TMP_ROOT/bs-inert"; mkdir -p "$home"
+  out=$(run_bootstrap "$home")
+  assert_not_contains "$out" "FME:" "no FME line without opt-in"
+  assert_absent "$home/state/email-watch.check.sh" "no shim without opt-in"
+  assert_absent "$home/config/email-mode.env" "no cadence without opt-in"
+  pass "bootstrap is inert for email mode without opt-in"
+}
+
+test_bootstrap_activates_on_full_config() {
+  local home out
+  home="$TMP_ROOT/bs-on"; mkdir -p "$home"
+  email_on_env > "$home/.env"
+  out=$(run_bootstrap "$home")
+  assert_contains "$out" "FME: email mode on" "bootstrap announces email mode on"
+  assert_present "$home/state/email-watch.check.sh" "bootstrap writes the check shim"
+  assert_present "$home/config/email-mode.env" "bootstrap writes the cadence config"
+  assert_grep "FM_CHECK_INTERVAL=60" "$home/config/email-mode.env" "cadence is 60s"
+  assert_grep "fm-email-notify.sh" "$home/state/email-watch.check.sh" "shim runs the outbound notifier"
+  assert_grep "fm-email-poll.sh" "$home/state/email-watch.check.sh" "shim runs the inbound poll"
+  # Idempotent re-run.
+  run_bootstrap "$home" >/dev/null
+  assert_present "$home/state/email-watch.check.sh" "shim survives a re-run"
+  pass "bootstrap activates email mode on full .env config (idempotently)"
+}
+
+test_bootstrap_optin_missing_config_reports_off() {
+  local home out
+  home="$TMP_ROOT/bs-missing"; mkdir -p "$home"
+  printf 'FM_EMAIL_NOTIFY=1\n' > "$home/.env"
+  out=$(run_bootstrap "$home")
+  assert_contains "$out" "FME: email mode off" "opted in but missing config reports off"
+  assert_absent "$home/state/email-watch.check.sh" "no shim when config is incomplete"
+  pass "bootstrap reports off when opted in but missing required config"
+}
+
+test_bootstrap_opt_out_cleanup() {
+  local home out
+  home="$TMP_ROOT/bs-optout"; mkdir -p "$home/state" "$home/config"
+  # Pretend a prior activation left artifacts.
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$home/state/email-watch.check.sh"
+  printf 'export FM_CHECK_INTERVAL=60\n' > "$home/config/email-mode.env"
+  # No .env / no opt-in now.
+  out=$(run_bootstrap "$home")
+  assert_contains "$out" "FME: email mode off - removed" "opt-out reports cleanup"
+  assert_absent "$home/state/email-watch.check.sh" "opt-out removes the shim"
+  assert_absent "$home/config/email-mode.env" "opt-out removes the cadence"
+  pass "bootstrap cleans up email artifacts on opt-out"
+}
+
+# ---------------------------------------------------------------------------
+
+test_notify_no_optin_is_hard_noop
+test_notify_dry_run_composes_keyless
+test_notify_dedupe_same_event
+test_notify_new_line_after_marker_resends
+test_notify_ignores_non_captain_relevant
+test_notify_live_posts_to_send_endpoint
+test_notify_failed_send_does_not_advance_marker
+test_poll_no_optin_is_hard_noop
+test_poll_incomplete_config_reports_once
+test_poll_baseline_then_new_reply
+test_poll_ignores_non_captain_sender
+test_poll_dedupes_seen_reply
+test_poll_sanitizes_unsafe_message_id
+test_poll_204_is_silent
+test_poll_auth_error_reports_once
+test_bootstrap_inert_without_optin
+test_bootstrap_activates_on_full_config
+test_bootstrap_optin_missing_config_reports_off
+test_bootstrap_opt_out_cleanup


### PR DESCRIPTION
## Two-way email notifier for firstmate (out-of-band notifier, opt-in)

Implements the pluggable out-of-band notifier from #106: firstmate emails the captain when something captain-relevant comes up, and the captain can reply by email to steer it. Modeled closely on X mode (section 14) so it is purely additive and opt-in.

### Opt-in and additive (zero behavior change when off)
Gated on `.env`: `FM_EMAIL_NOTIFY=1` plus `AGENTMAIL_API_KEY`, `FM_NOTIFY_EMAIL` (recipient), and `AGENTMAIL_INBOX`. With the switch absent/falsey every script is a hard no-op and bootstrap writes/prints nothing. No edits to the watcher backbone (`fm-watch.sh`, `fm-watch-arm.sh`, `fm-wake-lib.sh`, the afk daemon); it rides the existing `state/*.check.sh` mechanism and the shared captain-relevant classifier (`fm-classify-lib.sh`).

### Outbound (`bin/fm-email-notify.sh`)
Scans `state/*.status` with the same classifier the watcher uses and emails the captain on `needs-decision`/`blocked`/`failed`/`done`/`PR ready`/`checks green`/`merged` via AgentMail `POST /inboxes/<inbox>/messages/send`. Plain outcome language (no internal jargon, mirrors section 9), deduped per task in `state/.email-seen-<task>` (marker advances only after a successful send, so failures retry). Silent: never adds a wake.

### Inbound / two-way (`bin/fm-email-poll.sh`)
Polls `GET /inboxes/<inbox>/messages`, baselines on first run (never replays pre-existing mail), and surfaces each new reply from the captain as an `email-reply <id>` `check:` wake with the full reply text stashed to `state/email-inbox/<id>.json` as the payload, so a reply can steer firstmate. Config/auth errors surface one rate-limited `email-mode-error` line.

### Secrets and untrusted input
Key and recipient come only from gitignored `.env`; the captain's address is never hardcoded in tracked files. Bearer key goes to a 0600 header file, never on argv, never echoed. Inbound email text is only ever parsed by jq from a file (never inlined into a shell), and message ids are sanitized before becoming filenames.

### Bootstrap, cadence, docs, tests
Bootstrap drops an idempotent `state/email-watch.check.sh` shim (silent notify then poll, one shim so outbound always runs each cadence) and `config/email-mode.env` (60s cadence), removed on opt-out. `FM_EMAIL_DRY_RUN` previews notifications to `state/email-outbox/` with no key or network. Documented in AGENTS.md section 15 and README; `config/email-mode.env` added to `.gitignore`.

`tests/fm-email-mode.test.sh`: 19 hermetic tests with the AgentMail HTTP call faked (no real network or keys) covering inert-by-default, classify/compose, dedupe, live send, baseline, inbound parse, sender filtering, id sanitization, error reporting, and bootstrap activation/opt-out.

### Validation
`shellcheck bin/*.sh tests/*.sh` clean; the new suite and the rest of the suite pass (two unrelated tests fail only under the local macOS bash 3.2 due to a pre-existing `fm-brief.sh` heredoc issue; they pass on CI's Ubuntu bash 5).

Delivered via direct-PR from a fork because the no-mistakes gate is currently not creating runs. Captain merges.
