### PR TITLE
feat(cognee): add local lookup manifest checker

### DIFF
--- a/bin/fm-cognee-lookup.sh
+++ b/bin/fm-cognee-lookup.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Local dry-run wrapper for future Cognee lookup integration.
+#
+# This script deliberately does not call Cognee. It accepts a local answer
+# fixture, treats it as an untrusted hint, and asks the local manifest checker to
+# prove whether any cited source can be reopened and checksum-verified.
+set -eu
+
+usage() {
+  cat >&2 <<'USAGE'
+usage: fm-cognee-lookup.sh --dry-run --query <text> [--manifest <manifest.tsv> --answer-file <answer.txt>]
+
+No live mode exists yet. Without --dry-run this command fails closed before any
+network, environment, MCP, or config access can happen.
+USAGE
+}
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DRY_RUN=false
+QUERY=
+MANIFEST=
+ANSWER_FILE=
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    --query)
+      QUERY=${2:-}
+      [ -n "$QUERY" ] || die "--query requires text"
+      shift 2
+      ;;
+    --manifest)
+      MANIFEST=${2:-}
+      [ -n "$MANIFEST" ] || die "--manifest requires a path"
+      shift 2
+      ;;
+    --answer-file)
+      ANSWER_FILE=${2:-}
+      [ -n "$ANSWER_FILE" ] || die "--answer-file requires a path"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if ! "$DRY_RUN"; then
+  echo "label=blocked_missing_proof reason=live_cognee_lookup_not_implemented external_action_authorized=false" >&2
+  exit 2
+fi
+
+[ -n "$QUERY" ] || die "--query is required in dry-run mode"
+
+query_hash=$(printf '%s' "$QUERY" | sha256sum | awk '{print $1}')
+query_bytes=$(printf '%s' "$QUERY" | wc -c | tr -d ' ')
+
+echo "mode=dry-run"
+echo "query_sha256=$query_hash"
+echo "query_bytes=$query_bytes"
+echo "cognee_answer_status=hint_only"
+echo "external_action_authorized=false"
+
+if [ -z "$MANIFEST" ] && [ -z "$ANSWER_FILE" ]; then
+  echo "label=hint_only reason=no_manifest_or_answer_fixture external_action_authorized=false"
+  exit 0
+fi
+
+[ -n "$MANIFEST" ] || die "--manifest is required when --answer-file is used"
+[ -n "$ANSWER_FILE" ] || die "--answer-file is required when --manifest is used"
+
+"$SCRIPT_DIR/fm-cognee-manifest-check.sh" --manifest "$MANIFEST" --answer-file "$ANSWER_FILE"

--- a/bin/fm-cognee-manifest-check.sh
+++ b/bin/fm-cognee-manifest-check.sh
@@ -1,0 +1,275 @@
+#!/usr/bin/env bash
+# Validate local Cognee manifest rows and verify answer references against them.
+#
+# This is intentionally local-only. It never calls Cognee, never mutates config,
+# and never treats a generated answer as proof without reopening the local source.
+set -eu
+
+usage() {
+  cat >&2 <<'USAGE'
+usage: fm-cognee-manifest-check.sh --manifest <manifest.tsv> [--validate | --answer-file <answer.txt>]
+
+The manifest must be TSV with the row fields from the Cognee import policy.
+Answer verification looks for SOURCE_ID=, SOURCE_PATH=, and SEED_FILE= labels.
+USAGE
+}
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+MANIFEST=
+ANSWER_FILE=
+VALIDATE=false
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --manifest)
+      MANIFEST=${2:-}
+      [ -n "$MANIFEST" ] || die "--manifest requires a path"
+      shift 2
+      ;;
+    --answer-file)
+      ANSWER_FILE=${2:-}
+      [ -n "$ANSWER_FILE" ] || die "--answer-file requires a path"
+      shift 2
+      ;;
+    --validate)
+      VALIDATE=true
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+[ -n "$MANIFEST" ] || { usage; exit 1; }
+[ -f "$MANIFEST" ] || die "manifest not found: $MANIFEST"
+if [ -n "$ANSWER_FILE" ]; then
+  [ -f "$ANSWER_FILE" ] || die "answer file not found: $ANSWER_FILE"
+fi
+if ! "$VALIDATE" && [ -z "$ANSWER_FILE" ]; then
+  usage
+  exit 1
+fi
+
+required_fields='row_id source_group source_path source_truth_pointer source_kind recommended_tier decision_status redaction_status redaction_notes sensitivity_label stale_risk supersession_check source_size_bytes source_mtime_utc source_sha256 estimated_words estimated_tokens estimated_cost_formula import_text_prefix raw_readback_status verification_status'
+allowed_redaction=' passed redacted summarized path_index_only '
+allowed_stale=' low medium high live_external unknown '
+allowed_raw=' not_attempted passed failed_404 not_trusted not_applicable '
+allowed_verification=' not_imported verified_local_source hint_only failed stale '
+
+declare -A IDX
+IFS=$'\t' read -r -a HEADER < "$MANIFEST" || die "manifest is empty"
+for i in "${!HEADER[@]}"; do
+  IDX["${HEADER[$i]}"]=$i
+done
+
+for field in $required_fields; do
+  [ -n "${IDX[$field]+x}" ] || die "manifest missing required field: $field"
+done
+
+field_value() {
+  local name=$1 idx=${IDX[$1]}
+  printf '%s' "${COLS[$idx]:-}"
+}
+
+sha256_file() {
+  sha256sum "$1" | awk '{print $1}'
+}
+
+row_matches_ref() {
+  local kind=$1 value=$2
+  local row_id source_path import_text cognee_source_id cognee_data_id cognee_chunk_ids summary_path seed_name
+  row_id=$(field_value row_id)
+  source_path=$(field_value source_path)
+  import_text=$(field_value import_text_prefix)
+  cognee_source_id=
+  cognee_data_id=
+  cognee_chunk_ids=
+  summary_path=
+  [ -n "${IDX[cognee_source_id]+x}" ] && cognee_source_id=$(field_value cognee_source_id)
+  [ -n "${IDX[cognee_data_id]+x}" ] && cognee_data_id=$(field_value cognee_data_id)
+  [ -n "${IDX[cognee_chunk_ids]+x}" ] && cognee_chunk_ids=$(field_value cognee_chunk_ids)
+  [ -n "${IDX[summary_path]+x}" ] && summary_path=$(field_value summary_path)
+  seed_name=$(basename "$source_path")
+
+  case "$kind" in
+    SOURCE_ID)
+      [ "$value" = "$row_id" ] && return 0
+      [ -n "$cognee_source_id" ] && [ "$value" = "$cognee_source_id" ] && return 0
+      [ -n "$cognee_data_id" ] && [ "$value" = "$cognee_data_id" ] && return 0
+      case " $cognee_chunk_ids " in *" $value "*) return 0 ;; esac
+      case "$import_text" in *"SOURCE_ID=$value"*|*"SOURCE_ID: $value"*) return 0 ;; esac
+      ;;
+    SOURCE_PATH)
+      [ "$value" = "$source_path" ] && return 0
+      [ -n "$summary_path" ] && [ "$value" = "$summary_path" ] && return 0
+      ;;
+    SEED_FILE)
+      [ "$value" = "$seed_name" ] && return 0
+      case "$import_text" in *"SEED_FILE=$value"*|*"SEED_FILE: $value"*) return 0 ;; esac
+      ;;
+  esac
+  return 1
+}
+
+validate_current_row() {
+  local field value source_path source_path_lc expected actual actual_size redaction stale raw verification size
+
+  for field in $required_fields; do
+    value=$(field_value "$field")
+    [ -n "$value" ] || {
+      echo "label=blocked_missing_proof reason=missing_$field external_action_authorized=false"
+      return 1
+    }
+  done
+
+  source_path=$(field_value source_path)
+  source_path_lc=$(printf '%s' "$source_path" | tr '[:upper:]' '[:lower:]')
+  case "$source_path_lc" in
+    *secret*|*token*|*api_key*|*password*|*credential*|*auth*|*bearer*|*cookie*|*private_key*|*.env*|*session*|*oauth*|*signed*)
+      echo "label=blocked_missing_proof reason=path_risk_scan_failed external_action_authorized=false"
+      return 1
+      ;;
+  esac
+
+  case "$source_path" in
+    /*) ;;
+    *)
+      echo "label=blocked_missing_proof reason=source_path_not_absolute source_path=$source_path external_action_authorized=false"
+      return 1
+      ;;
+  esac
+  [ -r "$source_path" ] || {
+    echo "label=blocked_missing_proof reason=source_unreadable source_path=$source_path external_action_authorized=false"
+    return 1
+  }
+
+  redaction=$(field_value redaction_status)
+  case "$allowed_redaction" in
+    *" $redaction "*) ;;
+    *)
+      echo "label=blocked_missing_proof reason=redaction_not_passed redaction_status=$redaction source_path=$source_path external_action_authorized=false"
+      return 1
+      ;;
+  esac
+
+  stale=$(field_value stale_risk)
+  case "$allowed_stale" in
+    *" $stale "*) ;;
+    *)
+      echo "label=blocked_missing_proof reason=invalid_stale_risk stale_risk=$stale source_path=$source_path external_action_authorized=false"
+      return 1
+      ;;
+  esac
+
+  raw=$(field_value raw_readback_status)
+  case "$allowed_raw" in
+    *" $raw "*) ;;
+    *)
+      echo "label=blocked_missing_proof reason=invalid_raw_readback_status raw_readback_status=$raw source_path=$source_path external_action_authorized=false"
+      return 1
+      ;;
+  esac
+
+  verification=$(field_value verification_status)
+  case "$allowed_verification" in
+    *" $verification "*) ;;
+    *)
+      echo "label=blocked_missing_proof reason=invalid_verification_status verification_status=$verification source_path=$source_path external_action_authorized=false"
+      return 1
+      ;;
+  esac
+
+  size=$(field_value source_size_bytes)
+  actual_size=$(wc -c < "$source_path" | tr -d ' ')
+  [ "$size" = "$actual_size" ] || {
+    echo "label=blocked_missing_proof reason=size_mismatch source_path=$source_path external_action_authorized=false"
+    return 1
+  }
+
+  expected=$(field_value source_sha256)
+  actual=$(sha256_file "$source_path")
+  [ "$expected" = "$actual" ] || {
+    echo "label=blocked_missing_proof reason=checksum_mismatch source_path=$source_path external_action_authorized=false"
+    return 1
+  }
+
+  return 0
+}
+
+sanitize_ref() {
+  # Strip wrapping punctuation without printing answer text.
+  sed -E 's/^[`"'\''[:space:]]+//; s/[`"'\'',.;:)[:space:]]+$//'
+}
+
+REFS=$(mktemp "${TMPDIR:-/tmp}/fm-cognee-refs.XXXXXX")
+trap 'rm -f "$REFS"' EXIT
+
+if [ -n "$ANSWER_FILE" ]; then
+  {
+    grep -Eoh 'SOURCE_ID[[:space:]]*[:=][[:space:]]*[^[:space:],;)]+' "$ANSWER_FILE" 2>/dev/null \
+      | sed -E 's/^SOURCE_ID[[:space:]]*[:=][[:space:]]*//' | sanitize_ref | awk 'NF {print "SOURCE_ID\t"$0}'
+    grep -Eoh 'SOURCE_PATH[[:space:]]*[:=][[:space:]]*[^[:space:],;)]+' "$ANSWER_FILE" 2>/dev/null \
+      | sed -E 's/^SOURCE_PATH[[:space:]]*[:=][[:space:]]*//' | sanitize_ref | awk 'NF {print "SOURCE_PATH\t"$0}'
+    grep -Eoh 'SEED_FILE[[:space:]]*[:=][[:space:]]*[^[:space:],;)]+' "$ANSWER_FILE" 2>/dev/null \
+      | sed -E 's/^SEED_FILE[[:space:]]*[:=][[:space:]]*//' | sanitize_ref | awk 'NF {print "SEED_FILE\t"$0}'
+  } | sort -u > "$REFS"
+fi
+
+if "$VALIDATE"; then
+  ok=true
+  while IFS=$'\t' read -r -a COLS || [ "${#COLS[@]}" -gt 0 ]; do
+    [ "${#COLS[@]}" -eq 0 ] && continue
+    validate_current_row || ok=false
+  done < <(tail -n +2 "$MANIFEST")
+  "$ok" || exit 1
+  echo "manifest_status=valid external_action_authorized=false"
+fi
+
+if [ -n "$ANSWER_FILE" ]; then
+  if [ ! -s "$REFS" ]; then
+    echo "label=blocked_missing_proof reason=no_usable_citations external_action_authorized=false"
+    exit 3
+  fi
+
+  found=false
+  failed=false
+  while IFS=$'\t' read -r -a COLS || [ "${#COLS[@]}" -gt 0 ]; do
+    [ "${#COLS[@]}" -eq 0 ] && continue
+    while IFS=$'\t' read -r ref_kind ref_value; do
+      if row_matches_ref "$ref_kind" "$ref_value"; then
+        if validate_current_row >/dev/null; then
+          found=true
+          row_id=$(field_value row_id)
+          source_path=$(field_value source_path)
+          stale=$(field_value stale_risk)
+          verification=$(field_value verification_status)
+          label=verified_local_source
+          case "$stale" in high|live_external) label=stale_warning ;; esac
+          echo "label=$label row_id=$row_id matched_ref=$ref_kind source_path=$source_path stale_risk=$stale manifest_verification_status=$verification external_action_authorized=false"
+        else
+          failed=true
+          validate_current_row || true
+        fi
+        break
+      fi
+    done < "$REFS"
+  done < <(tail -n +2 "$MANIFEST")
+
+  if ! "$found"; then
+    if "$failed"; then
+      exit 1
+    fi
+    echo "label=blocked_missing_proof reason=manifest_reference_not_found external_action_authorized=false"
+    exit 3
+  fi
+fi

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -17,6 +17,8 @@ Each file also starts with a short header comment.
 | `fm-project-mode.sh`     | Resolve a project's delivery mode and `+yolo` flag from `data/projects.md`                                          |
 | `fm-merge-local.sh`      | Fast-forward a `local-only` project's local default branch after approval                                           |
 | `fm-review-diff.sh`      | Review a crewmate branch against the authoritative base, with optional `--stat` output                              |
+| `fm-cognee-lookup.sh`    | Local-only dry-run wrapper for future Cognee lookup; treats answer fixtures as hints and delegates source proof to the manifest checker |
+| `fm-cognee-manifest-check.sh` | Validate TSV Cognee manifest rows and verify `SOURCE_ID`, `SOURCE_PATH`, or `SEED_FILE` answer references against reopened local files |
 | `fm-marker-lib.sh`       | Shared from-firstmate request marker and detector sourced by `fm-send.sh`, `fm-brief.sh`, and tests                 |
 | `fm-watch-arm.sh`        | Verified per-home watcher re-arm; reports `started`, `healthy`, or `FAILED`; `--restart` relaunches only this home's watcher |
 | `fm-watch.sh`            | Singleton-safe always-on watcher; absorbs no-verb signal and stale wakes only when the crew is provably working, queues and exits for actionable wakes, and reverts to daemon-owned one-shot behavior while `state/.afk` exists |

--- a/tests/fm-cognee-lookup.test.sh
+++ b/tests/fm-cognee-lookup.test.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# Behavior tests for local-only Cognee lookup and manifest verification.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-cognee-lookup-tests)
+
+write_manifest() {
+  local manifest=$1 row_id=$2 source_path=$3 source_sha=$4 redaction=${5:-passed} stale=${6:-low}
+  local size mtime
+  size=$(wc -c < "$source_path" | tr -d ' ')
+  mtime=$(date -u -r "$source_path" '+%Y-%m-%dT%H:%M:%SZ')
+  {
+    printf '%s\t' row_id source_group source_path source_truth_pointer source_kind recommended_tier decision_status redaction_status redaction_notes sensitivity_label stale_risk supersession_check source_size_bytes source_mtime_utc source_sha256 estimated_words estimated_tokens estimated_cost_formula import_text_prefix raw_readback_status verification_status cognee_source_id
+    printf '\n'
+    printf '%s\t' "$row_id" firstmate_reports "$source_path" "$source_path" report direct_import allowed "$redaction" "test scan" internal "$stale" checked_current "$size" "$mtime" "$source_sha" 12 16 "words * 1.3" "SOURCE_ID=$row_id SOURCE_PATH=$source_path SEED_FILE=$(basename "$source_path")" not_trusted verified_local_source "$row_id"
+    printf '\n'
+  } > "$manifest"
+}
+
+test_dry_run_blocks_live_mode() {
+  local out code
+  out=$("$ROOT/bin/fm-cognee-lookup.sh" --query "find cognee proof" 2>&1)
+  code=$?
+  expect_code 2 "$code" "live lookup fails closed"
+  assert_contains "$out" "reason=live_cognee_lookup_not_implemented" "live mode states why it is blocked"
+  pass "cognee lookup has no live/API mode"
+}
+
+test_dry_run_verifies_local_source_without_echoing_answer() {
+  local dir source manifest answer out code sha
+  dir="$TMP_ROOT/verified"
+  mkdir -p "$dir"
+  source="$dir/source.md"
+  manifest="$dir/manifest.tsv"
+  answer="$dir/answer.txt"
+  printf 'local source truth\n' > "$source"
+  sha=$(sha256sum "$source" | awk '{print $1}')
+  write_manifest "$manifest" fm-cognee-001 "$source" "$sha"
+  printf 'Generated answer with SOURCE_ID=fm-cognee-001 and secret-like body DO_NOT_PRINT_ME.\n' > "$answer"
+
+  out=$("$ROOT/bin/fm-cognee-lookup.sh" --dry-run --query "which report matters" --manifest "$manifest" --answer-file "$answer")
+  code=$?
+  expect_code 0 "$code" "verified dry-run exits successfully"
+  assert_contains "$out" "cognee_answer_status=hint_only" "raw Cognee answer remains hint-only"
+  assert_contains "$out" "label=verified_local_source" "manifest and source checksum produce verified label"
+  assert_contains "$out" "external_action_authorized=false" "verified lookup still cannot authorize action"
+  assert_not_contains "$out" "DO_NOT_PRINT_ME" "wrapper does not echo answer body"
+  assert_not_contains "$out" "which report matters" "wrapper does not echo query text"
+  pass "dry-run verifies local source without echoing raw query or answer"
+}
+
+test_missing_citation_blocks_proof() {
+  local dir source manifest answer out code sha
+  dir="$TMP_ROOT/missing-citation"
+  mkdir -p "$dir"
+  source="$dir/source.md"
+  manifest="$dir/manifest.tsv"
+  answer="$dir/answer.txt"
+  printf 'local source truth\n' > "$source"
+  sha=$(sha256sum "$source" | awk '{print $1}')
+  write_manifest "$manifest" fm-cognee-002 "$source" "$sha"
+  printf 'Generated answer with no source labels.\n' > "$answer"
+
+  out=$("$ROOT/bin/fm-cognee-lookup.sh" --dry-run --query "lookup" --manifest "$manifest" --answer-file "$answer")
+  code=$?
+  expect_code 3 "$code" "missing citation exits as blocked"
+  assert_contains "$out" "label=blocked_missing_proof" "missing citation cannot verify"
+  assert_contains "$out" "reason=no_usable_citations" "missing citation reason is explicit"
+  pass "missing Cognee citations fail closed"
+}
+
+test_source_path_and_seed_file_references_verify() {
+  local dir source manifest answer out code sha
+  dir="$TMP_ROOT/path-seed"
+  mkdir -p "$dir"
+  source="$dir/source.md"
+  manifest="$dir/manifest.tsv"
+  answer="$dir/answer.txt"
+  printf 'local source truth\n' > "$source"
+  sha=$(sha256sum "$source" | awk '{print $1}')
+  write_manifest "$manifest" fm-cognee-002b "$source" "$sha"
+  printf 'Generated answer cites SOURCE_PATH=%s.\n' "$source" > "$answer"
+
+  out=$("$ROOT/bin/fm-cognee-lookup.sh" --dry-run --query "lookup" --manifest "$manifest" --answer-file "$answer")
+  code=$?
+  expect_code 0 "$code" "source path dry-run exits successfully"
+  assert_contains "$out" "label=verified_local_source" "SOURCE_PATH references can verify"
+  assert_contains "$out" "matched_ref=SOURCE_PATH" "source path reference is recognized"
+
+  printf 'Generated answer cites SEED_FILE=%s.\n' "$(basename "$source")" > "$answer"
+  out=$("$ROOT/bin/fm-cognee-lookup.sh" --dry-run --query "lookup" --manifest "$manifest" --answer-file "$answer")
+  code=$?
+  expect_code 0 "$code" "seed file dry-run exits successfully"
+  assert_contains "$out" "label=verified_local_source" "SEED_FILE references can verify"
+  assert_contains "$out" "matched_ref=SEED_FILE" "seed file reference is recognized"
+  pass "SOURCE_PATH and SEED_FILE references can verify local sources"
+}
+
+test_checksum_mismatch_blocks_proof() {
+  local dir source manifest answer out code sha
+  dir="$TMP_ROOT/checksum"
+  mkdir -p "$dir"
+  source="$dir/source.md"
+  manifest="$dir/manifest.tsv"
+  answer="$dir/answer.txt"
+  printf 'local source truth\n' > "$source"
+  sha=$(printf 'wrong' | sha256sum | awk '{print $1}')
+  write_manifest "$manifest" fm-cognee-003 "$source" "$sha"
+  printf 'SOURCE_ID=fm-cognee-003\n' > "$answer"
+
+  out=$("$ROOT/bin/fm-cognee-lookup.sh" --dry-run --query "lookup" --manifest "$manifest" --answer-file "$answer")
+  code=$?
+  expect_code 1 "$code" "checksum mismatch exits as invalid"
+  assert_contains "$out" "reason=checksum_mismatch" "checksum mismatch is reported"
+  assert_not_contains "$out" "label=verified_local_source" "bad checksum cannot verify"
+  pass "checksum mismatch blocks proof"
+}
+
+test_redaction_not_checked_blocks_proof() {
+  local dir source manifest answer out code sha
+  dir="$TMP_ROOT/redaction"
+  mkdir -p "$dir"
+  source="$dir/source.md"
+  manifest="$dir/manifest.tsv"
+  answer="$dir/answer.txt"
+  printf 'local source truth\n' > "$source"
+  sha=$(sha256sum "$source" | awk '{print $1}')
+  write_manifest "$manifest" fm-cognee-004 "$source" "$sha" not_checked
+  printf 'SOURCE_ID=fm-cognee-004\n' > "$answer"
+
+  out=$("$ROOT/bin/fm-cognee-lookup.sh" --dry-run --query "lookup" --manifest "$manifest" --answer-file "$answer")
+  code=$?
+  expect_code 1 "$code" "unchecked redaction exits as invalid"
+  assert_contains "$out" "reason=redaction_not_passed" "redaction status blocks local verification"
+  pass "unchecked redaction blocks proof"
+}
+
+test_secret_risk_path_blocks_without_echoing_path() {
+  local dir source manifest answer out code sha
+  dir="$TMP_ROOT/secret-token-source"
+  mkdir -p "$dir"
+  source="$dir/source.md"
+  manifest="$dir/manifest.tsv"
+  answer="$dir/answer.txt"
+  printf 'local source truth\n' > "$source"
+  sha=$(sha256sum "$source" | awk '{print $1}')
+  write_manifest "$manifest" fm-cognee-004b "$source" "$sha"
+  printf 'SOURCE_ID=fm-cognee-004b\n' > "$answer"
+
+  out=$("$ROOT/bin/fm-cognee-lookup.sh" --dry-run --query "lookup" --manifest "$manifest" --answer-file "$answer")
+  code=$?
+  expect_code 1 "$code" "secret-looking path exits as invalid"
+  assert_contains "$out" "reason=path_risk_scan_failed" "path risk scan blocks local verification"
+  assert_not_contains "$out" "$dir" "risky source path is not echoed"
+  pass "secret-risk paths block without echoing the risky path"
+}
+
+test_high_stale_risk_warns_after_local_verification() {
+  local dir source manifest answer out code sha
+  dir="$TMP_ROOT/stale"
+  mkdir -p "$dir"
+  source="$dir/source.md"
+  manifest="$dir/manifest.tsv"
+  answer="$dir/answer.txt"
+  printf 'historical source truth\n' > "$source"
+  sha=$(sha256sum "$source" | awk '{print $1}')
+  write_manifest "$manifest" fm-cognee-005 "$source" "$sha" passed high
+  printf 'SOURCE_ID=fm-cognee-005\n' > "$answer"
+
+  out=$("$ROOT/bin/fm-cognee-lookup.sh" --dry-run --query "lookup" --manifest "$manifest" --answer-file "$answer")
+  code=$?
+  expect_code 0 "$code" "stale warning exits successfully"
+  assert_contains "$out" "label=stale_warning" "high stale risk is not plain proof"
+  assert_contains "$out" "stale_risk=high" "stale risk is surfaced"
+  pass "high stale risk remains visible after local verification"
+}
+
+test_dry_run_blocks_live_mode
+test_dry_run_verifies_local_source_without_echoing_answer
+test_missing_citation_blocks_proof
+test_source_path_and_seed_file_references_verify
+test_checksum_mismatch_blocks_proof
+test_redaction_not_checked_blocks_proof
+test_secret_risk_path_blocks_without_echoing_path
+test_high_stale_risk_warns_after_local_verification


### PR DESCRIPTION
## Summary

Firstmate can now rehearse Cognee lookup locally without touching Cognee, MCP config, env files, or remote datasets. A dry-run wrapper treats answer text as `hint_only` by default, then upgrades only locally verified references to `verified_local_source` or `stale_warning` after manifest, checksum, path-risk, and source reopen checks pass.

The checker fails closed for missing citations, unknown manifest references, unsafe redaction status, risky source paths, bad size/checksum, and high/live stale-risk labels. Even verified local matches keep `external_action_authorized=false`, so memory output cannot become merge, deploy, cleanup, vendor, or customer authority.

## Notes

- Manifest support is TSV-only in this first wrapper; JSONL can be added later if a real importer needs it.
- No Cognee API path is implemented. Running without `--dry-run` exits before any network or config access.
- Code review was a manual staged-diff review. The multi-agent CE review path was not used because this harness exposes sub-agents only when the user explicitly requests delegation.

## Tests

- `bash -n bin/*.sh tests/*.sh`
- `tests/fm-cognee-lookup.test.sh`
- `for t in tests/*.test.sh; do bash "$t"; done`

## Post-Deploy Monitoring & Validation

No additional production monitoring is required. This is local CLI plumbing only, with no daemon, network call, config mutation, or remote dataset mutation. Healthy validation is continued passing shell tests and local dry-run output that keeps unverified Cognee text labeled as `hint_only`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
