### PR TITLE
fix(brief): avoid bash 3.2 parse error from apostrophe in heredoc

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -208,7 +208,7 @@ When you believe it is complete, append \`done: {summary}\` to the status file a
 Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
 
 You drive no-mistakes by responding to its gates, not by implementing fixes.
-Follow no-mistakes' own guidance for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.
+Follow the no-mistakes guidance for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.
 Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.
 
 Two firstmate-specific rules layer on top of that guidance:


### PR DESCRIPTION
## Problem

`bin/fm-brief.sh` fails to parse under the `bash` that ships with macOS (GNU bash **3.2.57**, still the default `/bin/bash`). The script's shebang is `#!/usr/bin/env bash`, so on a stock macOS machine it runs under 3.2 and dies before doing anything:

```
$ bash -n bin/fm-brief.sh
bin/fm-brief.sh: line 211: unexpected EOF while looking for matching `''
bin/fm-brief.sh: line 263: syntax error: unexpected end of file
```

The cause is a bash 3.2 parser bug: a lone single quote (apostrophe) inside a here-doc that is nested in a command substitution (`VAR=$(cat <<EOF ... EOF)`) is mis-parsed as the start of a single-quoted string that never closes. Line 211, inside the `no-mistakes` `DOD=$(cat <<EOF ...)` block, contains `no-mistakes'`, which trips it. Bash 4+ parses the same construct correctly, so this only affects users on the stock macOS bash.

Minimal repro:

```bash
cat > /tmp/repro.sh <<'OUTER'
X=$(cat <<EOF
no-mistakes' own guidance
EOF
)
OUTER
bash -n /tmp/repro.sh   # 3.2: "unexpected EOF while looking for matching `''"; 4+: clean
```

## Fix

Rephrase that one line to remove the lone apostrophe (no escaping, keeps it readable):

`Follow no-mistakes' own guidance for the mechanics:` -> `Follow the no-mistakes guidance for the mechanics:`

One line changed; no behavior change. It is the only lone apostrophe inside any of the script's `$(cat <<EOF ...)` blocks.

## Verification

- Before: `bash -n bin/fm-brief.sh` -> 2 errors (under bash 3.2.57).
- After: `bash -n bin/fm-brief.sh` -> clean (exit 0), and scaffolding still produces valid briefs.
