### PR TITLE
chore: no-mistakes(test): make teardown content check portable across git versions

### DIFF
--- a/.agents/skills/secondmate-provisioning/SKILL.md
+++ b/.agents/skills/secondmate-provisioning/SKILL.md
@@ -119,3 +119,5 @@ If `treehouse return` fails for a leased home, teardown stops with state intact 
 With `--force`, teardown is the explicit discard path.
 It kills child windows, discards child work and state inside the secondmate home, removes the route, releases the lease, and removes the retired secondmate home.
 Never use `--force` unless the captain explicitly said to discard the work.
+That captain word is enforced structurally, not just by discipline: `--force` takes effect only when a captain-authorization token exists at `state/<id>.force-granted`, which firstmate creates solely after the captain says to discard that task's work, consumes on every invocation, and audits to `state/.force-audit.log`.
+Without the token, `--force` is inert - the in-flight-work refusal holds and firstmate can never self-authorize the discard (prime directive #3).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,10 @@ Hard rules, in priority order:
    The one standing, captain-authorized relaxation is a project's `yolo` flag (section 7): with `yolo` on, firstmate makes routine approval decisions itself, but anything destructive, irreversible, or security-sensitive still escalates to the captain.
 3. **Never tear down a worktree that holds unlanded work.**
    `bin/fm-teardown.sh` enforces this; never bypass it with `--force` unless the captain explicitly said to discard the work.
+   That captain word is enforced structurally, not just by discipline: `--force` takes effect only when a captain-authorization token exists at `state/<id>.force-granted`.
+   Create that token (`touch state/<id>.force-granted`) ONLY after the captain explicitly says to discard that task's work, then run `bin/fm-teardown.sh <id> --force`.
+   Without the token, `--force` is inert - it falls back to the normal safety check - and firstmate can never self-authorize the discard.
+   The token is consumed on use, so each force-teardown needs a fresh captain OK, and every `--force` invocation is logged to `state/.force-audit.log`.
    The work is "landed" once `HEAD` is reachable from any remote-tracking branch (a fork counts as a remote - upstream-contribution PRs pushed to a fork satisfy this in any mode); for a normal ship task whose commits are not so reachable, it is also landed when its PR is merged and GitHub reports a PR head that contains the current local work (including a local `HEAD` that is an ancestor of the PR head, or unpushed local patches that were replayed into that PR head) or when its content is already present in the up-to-date default branch; for `local-only` ship tasks with no remote at all, the work may instead be merged into the local default branch.
    The PR consulted for that check comes from the task's recorded `pr=` when present, or - when no `pr=` was ever recorded, e.g. a yolo-authorized merge on a repo with no PR CI where the usual "checks green" `fm-pr-check.sh` trigger never fires - from a merged PR discovered by matching the worktree's own branch name, so a missing `pr=` never by itself false-refuses landed work. Use `bin/fm-pr-merge.sh <id> <PR url>` for every merge (captain-requested or yolo) so `pr=` and any available `pr_head=` are recorded as part of the merge itself rather than relying on that discovery fallback.
    Uncommitted changes are never landed.
@@ -91,6 +95,8 @@ state/               volatile runtime signals; gitignored
   <id>.grok-turnend-token   firstmate-owned grok hook registry token for the task; removed by teardown
   <id>.meta          written by fm-spawn: window=, worktree=, project=, harness=, model=, effort=, kind=, mode=, yolo=, tasktmp=; kind=secondmate also records home= and projects= (fm-pr-check, including through fm-pr-merge, appends pr= and GitHub's pr_head= when available; fm-x-link appends x_request= and x_request_ts= for an X-mention-originated task, section 14)
   <id>.check.sh      optional slow poll you write per task (e.g. merged-PR check)
+  <id>.force-granted captain-authorization token for fm-teardown --force (prime directive #3); created only after the captain explicitly OKs discarding that task's work; consumed on use
+  .force-audit.log   append-only audit of every --force invocation (timestamp, task id, caller pid, authorization verdict)
   x-watch.check.sh   generated X-mode relay poll shim; present only when opted in (section 14)
   x-inbox/           generated X-mode pending mention payloads; fmx-respond drains it (section 14)
   x-outbox/          generated X-mode dry-run reply and dismiss previews; inspect it when FMX_DRY_RUN is set (section 14)
@@ -545,6 +551,7 @@ Run `bin/fm-teardown.sh <id>` for `kind=secondmate` only when the captain or mai
 Load `secondmate-provisioning` before retiring it.
 The safety check is the secondmate's own home: teardown refuses while its `state/*.meta` contains in-flight work.
 With `--force`, teardown is the explicit discard path for child windows, child work, state, route, lease, and home; never use it unless the captain explicitly said to discard the work.
+`--force` requires the captain-authorization token `state/<id>.force-granted` (prime directive #3): without it, `--force` is inert and the in-flight-work refusal holds.
 
 ### Scout tasks (report instead of PR)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ tests/fm-secondmate-sync.test.sh          # local-HEAD secondmate sync, no-fetch
 tests/fm-secondmate-harness.test.sh       # secondmate-vs-crewmate harness resolution, primary-to-secondmate config inheritance, and config-push tests
 tests/fm-secondmate-lifecycle-e2e.test.sh # persistent secondmate routing, seeding, backlog handoff, spawn, recovery, teardown, and FM_HOME flow tests
 tests/fm-secondmate-safety.test.sh        # secondmate home safety, idle charter, handoff validation, and teardown boundary tests
-tests/fm-teardown.test.sh                 # fm-teardown.sh landed-work safety and reminder checks: fork-remote allow, squash/content landings, dirty and unlanded refusals, PR-head metadata, no-pr= branch discovery, tasks-axi/manual backlog reminder, --force override
+tests/fm-teardown.test.sh                 # fm-teardown.sh landed-work safety and reminder checks: fork-remote allow, squash/content landings, dirty and unlanded refusals, PR-head metadata, no-pr= branch discovery, tasks-axi/manual backlog reminder, --force override gated on a captain-authorization token (inert without it, consumed on use, audit-logged)
 tests/fm-pr-merge.test.sh                 # fm-pr-merge.sh records pr= and available pr_head= before merging, propagates real merge failures, and forwards extra gh-axi pr merge flags
 tests/fm-crew-state.test.sh               # fm-crew-state.sh current-state reconciliation: run-step authority including closed panes, stale needs-decision/blocked superseded by a resumed run, genuine-parked, cross-branch attribution, pane/status-log fallback, scout skip, torn-down/missing-meta graceful
 [ "$(readlink CLAUDE.md)" = "AGENTS.md" ]

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -703,7 +703,7 @@ remove_grok_turnend_auth "$STATE" "$ID"
 # Remove the per-task temp root (/tmp/fm-<id>/, incl. its gotmp/) recorded by spawn.
 # Read before the state-file rm below; empty (pre-fix tasks without tasktmp=) is a no-op.
 [ -n "$TASK_TMP" ] && rm -rf "$TASK_TMP"
-rm -f "$STATE/$ID.status" "$STATE/$ID.turn-ended" "$STATE/$ID.check.sh" "$STATE/$ID.meta" "$STATE/$ID.pi-ext.ts" "$STATE/$ID.grok-turnend-token"
+rm -f "$STATE/$ID.status" "$STATE/$ID.turn-ended" "$STATE/$ID.check.sh" "$STATE/$ID.meta" "$STATE/$ID.pi-ext.ts" "$STATE/$ID.grok-turnend-token" "$STATE/$ID.force-granted"
 if [ "$KIND" != scout ] && [ "$KIND" != secondmate ] && [ "$MODE" != local-only ]; then
   "$FM_ROOT/bin/fm-fleet-sync.sh" "$PROJ" || true
 fi

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -235,6 +235,28 @@ pr_is_merged() {
   unpushed_patches_are_in_pr_head "$head"
 }
 
+# Tree object a clean 3-way merge of HEAD into $1 would produce (echoed on
+# stdout); non-zero on conflict or failure so the caller refuses. Prefers
+# `git merge-tree --write-tree` (git >= 2.38, full rename detection); on older
+# git it falls back to the same 3-way merge into a throwaway index, so the
+# content check stays portable without touching the worktree's real index.
+merged_tree_against() {
+  local ref=$1 merged_tree base tmpidx
+  if git -C "$WT" merge-tree --write-tree HEAD HEAD >/dev/null 2>&1; then
+    merged_tree=$(git -C "$WT" merge-tree --write-tree "$ref" HEAD 2>/dev/null) || return 1
+    printf '%s\n' "$merged_tree" | head -1
+    return 0
+  fi
+  base=$(git -C "$WT" merge-base "$ref" HEAD 2>/dev/null) || base=$ref
+  tmpidx=$(mktemp) || return 1
+  GIT_INDEX_FILE="$tmpidx" git -C "$WT" read-tree --empty 2>/dev/null \
+    && GIT_INDEX_FILE="$tmpidx" git -C "$WT" read-tree -m "$base" "$ref" HEAD 2>/dev/null \
+    && merged_tree=$(GIT_INDEX_FILE="$tmpidx" git -C "$WT" write-tree 2>/dev/null)
+  rm -f "$tmpidx"
+  [ -n "$merged_tree" ] || return 1
+  printf '%s\n' "$merged_tree"
+}
+
 # Is the branch's content already present in the up-to-date default branch? Fetches
 # first, then 3-way merges the default branch with HEAD: when HEAD introduces nothing
 # the default branch does not already contain (e.g. its change landed via squash) the
@@ -255,8 +277,7 @@ content_in_default() {
   fi
   default_tree=$(git -C "$WT" rev-parse --quiet --verify "$ref^{tree}" 2>/dev/null) || return 1
   [ -n "$default_tree" ] || return 1
-  merged_tree=$(git -C "$WT" merge-tree --write-tree "$ref" HEAD 2>/dev/null) || return 1
-  merged_tree=$(printf '%s\n' "$merged_tree" | head -1)
+  merged_tree=$(merged_tree_against "$ref") || return 1
   [ "$merged_tree" = "$default_tree" ]
 }
 

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -38,6 +38,14 @@
 #   --force skips ordinary-task dirty and landed-work checks, skips scout report
 #   checks, and discards secondmate child work for kind=secondmate. Only use it
 #   when the captain has explicitly said to discard the work.
+#   Two-step model (prime directive #3: firstmate never self-authorizes --force):
+#     1. The captain explicitly OKs discarding THIS task's work.
+#     2. firstmate records that authorization as state/<task-id>.force-granted.
+#     3. firstmate runs `fm-teardown.sh <task-id> --force`.
+#   --force requires that token: without it, --force is INERT (the token is
+#   missing, FORCE is cleared, and the normal safety checks run). The token is
+#   consumed on every --force invocation (authorized or not, success or refuse),
+#   and every --force invocation is logged to state/.force-audit.log.
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -53,6 +61,36 @@ SUB_HOME_MARKER=".fm-secondmate-home"
 "$FM_ROOT/bin/fm-guard.sh" || true
 ID=$1
 FORCE=${2:-}
+
+# --- Captain authorization for --force (prime directive #3) -----------------
+# `--force` bypasses teardown's work-not-landed, dirty, scout-report, and
+# secondmate-child safety checks, so it can discard work the captain has not
+# reviewed. firstmate must NEVER self-authorize it. This guard separates the
+# decision ("firstmate decided to pass --force") from the authorization ("the
+# captain explicitly OK'd discarding THIS task"): --force takes effect ONLY when
+# a captain-authorization token exists at state/<id>.force-granted, which
+# firstmate creates solely after the captain says to discard that task's work.
+# Without the token, --force is INERT (FORCE is cleared and the normal safety
+# checks run). The token is consumed on EVERY --force invocation - authorized or
+# not, and whether teardown later completes or refuses - so a stale token can
+# never carry over and each force-teardown needs a fresh captain OK. Every
+# --force invocation is logged to state/.force-audit.log.
+FORCE_GRANTED="$STATE/$ID.force-granted"
+if [ "$FORCE" = "--force" ]; then
+  FORCE_AUTHORIZED=no
+  [ -f "$FORCE_GRANTED" ] && FORCE_AUTHORIZED=yes
+  printf '%s task=%s caller_pid=%s pid=%s authorized=%s\n' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$ID" "$PPID" "$$" "$FORCE_AUTHORIZED" \
+    >> "$STATE/.force-audit.log"
+  # Consume the token up front so a re-invocation needs a fresh captain OK even
+  # if this teardown later refuses or aborts (fail-closed).
+  rm -f "$FORCE_GRANTED"
+  if [ "$FORCE_AUTHORIZED" != yes ]; then
+    echo "WARNING: --force on $ID is not captain-authorized (no $FORCE_GRANTED token)." >&2
+    echo "firstmate cannot self-authorize --force; falling back to normal safety checks." >&2
+    FORCE=
+  fi
+fi
 
 META="$STATE/$ID.meta"
 [ -f "$META" ] || { echo "error: no meta for task $ID at $META" >&2; exit 1; }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -78,6 +78,7 @@ Bare `fm-send.sh fm-<id>` requests to a live `kind=secondmate` are prefixed with
 Explicit `session:window` sends and direct human typing stay unmarked, so captain intervention in a secondmate pane remains conversational.
 After seeding a secondmate, `fm-backlog-handoff.sh` moves already-judged in-scope queued items from the main backlog into that secondmate home so the domain queue starts in the right place.
 Idle secondmate panes are healthy; teardown is explicit and refuses while the secondmate home has in-flight work unless the captain has approved discard with `--force`.
+The discard path is guarded structurally, not just by discipline: `--force` takes effect only when a captain-authorization token exists at `state/<id>.force-granted`, which firstmate creates solely after the captain says to discard that task's work, consumes on every invocation, and audits to `state/.force-audit.log`; without the token, `--force` is inert and the normal safety checks run (prime directive #3: firstmate never self-authorizes a discard).
 
 Secondmate homes stay on the same firstmate version as the primary checkout.
 On main firstmate bootstrap, `fm-bootstrap.sh` fast-forwards each live secondmate home recorded in `state/*.meta` to the primary default-branch commit with no origin fetch.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -36,7 +36,7 @@ Each file also starts with a short header comment.
 | `fm-pr-check.sh`         | Record `pr=` and GitHub's `pr_head=` when available for a PR-ready task, then arm the watcher's merge poll          |
 | `fm-pr-merge.sh`         | Record `pr=` and available `pr_head=` via `fm-pr-check.sh`, then merge the task PR through `gh-axi pr merge` with any extra flags |
 | `fm-promote.sh`          | Promote a scout task in place so it becomes a protected ship task                                                   |
-| `fm-teardown.sh`         | Return a clean, landed ship worktree or retire/release a secondmate home; requires scout reports, checks child work, removes firstmate-owned hook artifacts, and prints the backend-aware backlog reminder |
+| `fm-teardown.sh`         | Return a clean, landed ship worktree or retire/release a secondmate home; requires scout reports, checks child work, removes firstmate-owned hook artifacts, prints the backend-aware backlog reminder, and gates `--force` discard on a captain-authorization token at `state/<id>.force-granted` (inert without it, consumed on use, audit-logged) |
 | `fm-harness.sh`          | Detect the running harness; resolve the effective crewmate (`crew`) or secondmate-launch (`secondmate`) harness     |
 | `fm-lock.sh`             | Per-home firstmate session lock                                                                                     |
 | `fm-x-lib.sh`            | Shared X-mode `.env`, alternate env-file, relay, dry-run config, reply-thread splitting, outbound image payloads, and task-to-X-request meta-link helpers |

--- a/tests/fm-grok-harness.test.sh
+++ b/tests/fm-grok-harness.test.sh
@@ -105,6 +105,7 @@ EOF
   expect_code 0 "$status" "grok spawn should succeed before teardown"
   token=$(sed -n 's/^token=//p' "$wt/.fm-grok-turnend")
 
+  touch "$home/state/$id.force-granted"
   FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
     GROK_HOME="$grok_home" PATH="$fakebin:$PATH" \
     "$TEARDOWN" "$id" --force >/dev/null 2>&1 \

--- a/tests/fm-secondmate-safety.test.sh
+++ b/tests/fm-secondmate-safety.test.sh
@@ -12,6 +12,13 @@ set -u
 
 TMP_ROOT=$(fm_test_tmproot fm-secondmate-safety)
 
+# Grant the captain-authorization token that lets fm-teardown --force take
+# effect (the two-step model of prime directive #3). Every force-teardown in
+# this suite models a captain-authorized discard, so each grants it before
+# invoking --force; without it --force is inert and falls back to the safety
+# check. Args: <main-firstmate-home>
+grant_domain_force() { touch "$1/state/domain.force-granted"; }
+
 
 test_fm_home_parameterization() {
   local brief home_one home_two out
@@ -1138,6 +1145,7 @@ EOF
     "$ROOT/bin/fm-teardown.sh" domain >/dev/null 2>&1; then
     fail "teardown allowed a secondmate with in-flight child work"
   fi
+  grant_domain_force "$home"
   PATH="$fakebin:$PATH" FM_HOME="$home" FM_FAKE_TMUX_LOG="$log" FM_FAKE_TMUX_CAPTURE="$TMP_ROOT/force-teardown-fake/pane.txt" \
     "$ROOT/bin/fm-teardown.sh" domain --force >/dev/null 2>/dev/null \
     || fail "force teardown failed to discard child work"
@@ -1175,6 +1183,7 @@ EOF
     printf '%s\n' '- domain - design domain (home: '"$subhome"'; scope: design domain; projects: alpha; added 2026-06-22)' > "$home/data/secondmates.md"
     fakebin=$(make_fake_tmux "$TMP_ROOT/symlink-inside-teardown-fake-$opdir")
     log="$TMP_ROOT/symlink-inside-teardown-fake-$opdir/tmux.log"
+    grant_domain_force "$home"
     PATH="$fakebin:$PATH" FM_HOME="$home" FM_FAKE_TMUX_LOG="$log" FM_FAKE_TMUX_CAPTURE="$TMP_ROOT/symlink-inside-teardown-fake-$opdir/pane.txt" \
       "$ROOT/bin/fm-teardown.sh" domain --force >/dev/null 2>"$err" \
       || fail "force teardown refused $opdir symlinked inside the secondmate home"
@@ -1208,6 +1217,7 @@ EOF
   printf '%s\n' '- domain - design domain (home: '"$subhome"'; scope: design domain; projects: alpha; added 2026-06-22)' > "$home/data/secondmates.md"
   fakebin=$(make_fake_tmux "$TMP_ROOT/symlink-state-teardown-fake")
   log="$TMP_ROOT/symlink-state-teardown-fake/tmux.log"
+  grant_domain_force "$home"
   if PATH="$fakebin:$PATH" FM_HOME="$home" FM_FAKE_TMUX_LOG="$log" FM_FAKE_TMUX_CAPTURE="$TMP_ROOT/symlink-state-teardown-fake/pane.txt" \
     "$ROOT/bin/fm-teardown.sh" domain --force >/dev/null 2>"$err"; then
     fail "force teardown accepted a symlinked secondmate state directory"
@@ -1401,6 +1411,7 @@ yolo=off
 EOF
   fakebin=$(make_fake_tmux "$TMP_ROOT/prevalidate-teardown-fake")
   log="$TMP_ROOT/prevalidate-teardown-fake/tmux.log"
+  grant_domain_force "$home"
   if PATH="$fakebin:$PATH" FM_HOME="$home" FM_FAKE_TMUX_LOG="$log" FM_FAKE_TMUX_CAPTURE="$TMP_ROOT/prevalidate-teardown-fake/pane.txt" \
     "$ROOT/bin/fm-teardown.sh" domain --force >/dev/null 2>"$err"; then
     fail "force teardown discarded child work before validating subhome"
@@ -1446,6 +1457,7 @@ yolo=off
 EOF
   fakebin=$(make_fake_tmux "$TMP_ROOT/child-active-descendant-fake")
   log="$TMP_ROOT/child-active-descendant-fake/tmux.log"
+  grant_domain_force "$home"
   if PATH="$fakebin:$PATH" FM_HOME="$home" FM_FAKE_TMUX_LOG="$log" FM_FAKE_TMUX_CAPTURE="$TMP_ROOT/child-active-descendant-fake/pane.txt" \
     "$ROOT/bin/fm-teardown.sh" domain --force >/dev/null 2>"$err"; then
     fail "force teardown removed a child worktree inside active FM_HOME"
@@ -1497,6 +1509,7 @@ yolo=off
 EOF
   fakebin=$(make_fake_tmux "$TMP_ROOT/child-repo-descendant-fake")
   log="$TMP_ROOT/child-repo-descendant-fake/tmux.log"
+  grant_domain_force "$home"
   if PATH="$fakebin:$PATH" FM_ROOT_OVERRIDE="$fakeroot" FM_HOME="$home" FM_FAKE_TMUX_LOG="$log" FM_FAKE_TMUX_CAPTURE="$TMP_ROOT/child-repo-descendant-fake/pane.txt" \
     "$ROOT/bin/fm-teardown.sh" domain --force >/dev/null 2>"$err"; then
     fail "force teardown removed a child worktree inside FM_ROOT"
@@ -1542,6 +1555,7 @@ yolo=off
 EOF
   fakebin=$(make_fake_tmux "$TMP_ROOT/unregistered-child-fake")
   log="$TMP_ROOT/unregistered-child-fake/tmux.log"
+  grant_domain_force "$home"
   if PATH="$fakebin:$PATH" FM_HOME="$home" FM_FAKE_TMUX_LOG="$log" FM_FAKE_TMUX_CAPTURE="$TMP_ROOT/unregistered-child-fake/pane.txt" \
     "$ROOT/bin/fm-teardown.sh" domain --force >/dev/null 2>"$err"; then
     fail "force teardown removed an unregistered child worktree"

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -22,7 +22,7 @@
 #   (c) local-only + merged into local main, no remote         -> ALLOW  (no regression)
 #   (d) no-mistakes + HEAD on origin remote-tracking branch    -> ALLOW  (no regression)
 #   (e) no-mistakes + unpushed, no PR, content not in default  -> REFUSE (safety)
-#   (f) local-only + truly unpushed + --force                  -> ALLOW  (escape hatch)
+#   (f) local-only + truly unpushed + --force (authorized)     -> ALLOW  (escape hatch)
 #   (g) no-mistakes + squash-merged PR, exact PR head          -> ALLOW  (squash fix)
 #   (h) no-mistakes + no PR but content already in default     -> ALLOW  (content fallback)
 #   (i) no-mistakes + dirty worktree, even when work landed     -> REFUSE (dirty wins)
@@ -34,6 +34,9 @@
 #   (o) fm-pr-check rerun after HEAD moved                      -> no stale pr_head
 #   (p) fm-pr-check when local HEAD lags                        -> record remote PR head
 #   (q) no-mistakes + NO pr= recorded, PR discovered by branch  -> ALLOW  (yolo/no-CI merge)
+#   (r) --force without a captain-auth token                    -> INERT  (force guard: PD#3)
+#   (s) --force token is consumed on use                        -> gone   (force guard: PD#3)
+#   (t) --force audit log records every invocation              -> logged (force guard: PD#3)
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -132,6 +135,15 @@ write_meta() {
     "project=$case_dir/project" \
     "kind=$kind" \
     "mode=$mode"
+}
+
+# Record the captain-authorization token that lets --force take effect. The
+# token is the two-step model's separation of "captain authorized" from
+# "firstmate decided": firstmate writes it ONLY after the captain's explicit OK.
+# Args: case_dir
+grant_force() {
+  local case_dir=$1
+  touch "$case_dir/state/task-x1.force-granted"
 }
 
 # Commit something on the worktree's task branch. Args: case_dir [message]
@@ -660,15 +672,104 @@ test_local_only_force_overrides_unpushed() {
   case_dir=$(make_case force-override)
   write_meta "$case_dir" local-only ship
   wt_commit "$case_dir" "unpushed work"
+  # --force now requires the captain-authorization token; grant it for the
+  # authorized escape hatch.
+  grant_force "$case_dir"
 
   set +e
   run_teardown "$case_dir" --force > "$case_dir/stdout" 2> "$case_dir/stderr"
   rc=$?
   set -e
 
-  expect_code 0 "$rc" "force-override: --force should bypass the unpushed-work check"
-  ! grep -q REFUSED "$case_dir/stderr" || fail "force-override: REFUSED printed despite --force"
-  pass "local-only worktree with unpushed work is torn down under --force (escape hatch)"
+  expect_code 0 "$rc" "force-override: authorized --force should bypass the unpushed-work check"
+  ! grep -q REFUSED "$case_dir/stderr" || fail "force-override: REFUSED printed despite authorized --force"
+  pass "local-only worktree with unpushed work is torn down under captain-authorized --force (escape hatch)"
+}
+
+# Without the captain-authorization token, --force is INERT: FORCE is cleared and
+# the normal safety checks run, so genuinely unlanded work is still refused. This
+# is the core guard - firstmate cannot self-authorize a force-discard.
+test_force_without_token_is_inert() {
+  local case_dir rc
+  case_dir=$(make_case force-inert)
+  write_meta "$case_dir" local-only ship
+  wt_commit "$case_dir" "unpushed work"
+  # No grant_force: --force must NOT take effect.
+
+  set +e
+  run_teardown "$case_dir" --force > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "force-inert: --force without a token should fall back to the safety check and refuse"
+  grep -q REFUSED "$case_dir/stderr" || fail "force-inert: no REFUSED line (normal safety check did not run)"
+  grep -q "not captain-authorized" "$case_dir/stderr" \
+    || fail "force-inert: no not-authorized warning in stderr"
+  pass "--force without a captain-authorization token is inert (safety check refuses)"
+}
+
+# The token is consumed on use: after a force-teardown it must be gone, so a
+# second --force needs a fresh captain OK. Verified for both an authorized run
+# (token removed on success) and an inert run (rm -f is a harmless no-op).
+test_force_consumes_token() {
+  local case_dir rc
+  case_dir=$(make_case force-consume)
+  write_meta "$case_dir" local-only ship
+  wt_commit "$case_dir" "unpushed work"
+  grant_force "$case_dir"
+
+  [ -f "$case_dir/state/task-x1.force-granted" ] \
+    || fail "force-consume: precondition - grant_force did not create the token"
+
+  set +e
+  run_teardown "$case_dir" --force > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "force-consume: authorized --force should succeed"
+  [ ! -f "$case_dir/state/task-x1.force-granted" ] \
+    || fail "force-consume: the authorization token was not consumed after teardown"
+  pass "captain-authorization token is consumed after an authorized --force"
+}
+
+# Every --force invocation (authorized or not) is recorded in
+# state/.force-audit.log with timestamp, task id, caller pid, and the
+# authorization verdict.
+test_force_audit_log() {
+  local case_dir rc
+  case_dir=$(make_case force-audit)
+  write_meta "$case_dir" local-only ship
+  wt_commit "$case_dir" "unpushed work"
+
+  # First invocation: no token -> authorized=no, inert.
+  set +e
+  run_teardown "$case_dir" --force > /dev/null 2> "$case_dir/stderr-inert"
+  rc=$?
+  set -e
+  expect_code 1 "$rc" "force-audit: inert run should refuse via the safety check"
+
+  # Second invocation: grant the token -> authorized=yes, effective.
+  grant_force "$case_dir"
+  set +e
+  run_teardown "$case_dir" --force > "$case_dir/stdout" 2> "$case_dir/stderr-auth"
+  rc=$?
+  set -e
+  expect_code 0 "$rc" "force-audit: authorized run should succeed"
+
+  local audit="$case_dir/state/.force-audit.log"
+  [ -f "$audit" ] || fail "force-audit: no audit log at $audit"
+  local lines
+  lines=$(grep -c "^.* task=task-x1 " "$audit" || true)
+  expect_code 2 "$lines" "force-audit: audit log should have one entry per --force invocation"
+  grep -q "task=task-x1 .* authorized=no" "$audit" \
+    || fail "force-audit: missing authorized=no entry for the inert invocation"
+  grep -q "task=task-x1 .* authorized=yes" "$audit" \
+    || fail "force-audit: missing authorized=yes entry for the authorized invocation"
+  grep -Eq "task=task-x1 caller_pid=[0-9]+ pid=[0-9]+" "$audit" \
+    || fail "force-audit: audit entry is missing pid fields"
+  grep -Eq "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z " "$audit" \
+    || fail "force-audit: audit entry is missing an ISO-8601 UTC timestamp"
+  pass "every --force invocation is audited with timestamp, task id, pids, and authorization"
 }
 
 test_local_only_fork_remote_allows
@@ -679,6 +780,9 @@ test_local_only_merged_to_local_main_allows
 test_no_mistakes_origin_remote_allows
 test_no_mistakes_truly_unpushed_refuses
 test_local_only_force_overrides_unpushed
+test_force_without_token_is_inert
+test_force_consumes_token
+test_force_audit_log
 test_squash_merged_branch_deleted_allows
 test_squash_merged_pr_allows_when_head_ancestor_of_pr_head
 test_no_pr_recorded_discovers_merged_pr_by_branch_allows

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -37,6 +37,7 @@
 #   (r) --force without a captain-auth token                    -> INERT  (force guard: PD#3)
 #   (s) --force token is consumed on use                        -> gone   (force guard: PD#3)
 #   (t) --force audit log records every invocation              -> logged (force guard: PD#3)
+#   (u) stale force token removed by normal teardown            -> gone   (force guard: PD#3)
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -772,6 +773,33 @@ test_force_audit_log() {
   pass "every --force invocation is audited with timestamp, task id, pids, and authorization"
 }
 
+# A stale force-granted token (e.g. firstmate recorded captain authorization but
+# then ran a NORMAL teardown without --force) must not survive teardown: the
+# final state cleanup removes it along with the task's other volatile state, so a
+# stale authorization can never linger or be reused.
+test_normal_teardown_cleans_stale_force_token() {
+  local case_dir rc wt_head
+  case_dir=$(make_case stale-token)
+  write_meta "$case_dir" local-only ship
+  wt_commit "$case_dir" "landed work"
+  wt_head=$(git -C "$case_dir/wt" rev-parse HEAD)
+  git -C "$case_dir/project" update-ref refs/heads/main "$wt_head"
+  touch "$case_dir/state/task-x1.force-granted"
+
+  [ -f "$case_dir/state/task-x1.force-granted" ] \
+    || fail "stale-token: precondition - token not created"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "stale-token: normal teardown of landed work should succeed"
+  [ ! -f "$case_dir/state/task-x1.force-granted" ] \
+    || fail "stale-token: a stale force-granted token survived normal teardown"
+  pass "normal teardown cleans up a stale force-granted token"
+}
+
 test_local_only_fork_remote_allows
 test_teardown_prompts_tasks_axi_done_when_compatible
 test_teardown_manual_backend_prompts_hand_edit_even_when_tasks_axi_present
@@ -783,6 +811,7 @@ test_local_only_force_overrides_unpushed
 test_force_without_token_is_inert
 test_force_consumes_token
 test_force_audit_log
+test_normal_teardown_cleans_stale_force_token
 test_squash_merged_branch_deleted_allows
 test_squash_merged_pr_allows_when_head_ancestor_of_pr_head
 test_no_pr_recorded_discovers_merged_pr_by_branch_allows


### PR DESCRIPTION
## Intent

The developer wanted to stop a prime-directive violation where firstmate could self-authorize `fm-teardown.sh --force` without captain approval. The goal was a deterministic structural guard so `--force` only takes effect when a captain-authorization token file (`state/<id>.force-granted`) exists, which firstmate may create only after the captain explicitly authorizes force-teardown of that specific task; without the token, `--force` must be inert and fall back to the normal safety check. The token must be consumed on every invocation (whether teardown succeeds or refuses), and every `--force` call must be logged to `state/.force-audit.log` with timestamp, task id, caller PID, and whether authorization was present. The developer also required a brief documentation comment explaining the two-step model, running existing tests and adding a test for the new guard, and keeping the fix minimal with no unrelated teardown refactoring. The change was to be shipped through the no-mistakes gate rather than any direct push.

## What Changed

652237f no-mistakes(test): make teardown content check portable across git versions
cb52304 no-mistakes(review): grant force token in grok teardown test
7beb028 no-mistakes(document): docs: document teardown --force token guard in secondmate skill
3c53050 fix(teardown): clean up stale force-granted token on normal teardown
d6191c8 no-mistakes(document): docs: document teardown force-authorization token guard
c10d4e5 fix(teardown): require captain-authorization token for --force

## Risk Assessment

✅ Low: The change is a well-bounded, well-tested structural guard with consistent docs; the single Round 1 finding is resolved and no new correctness, security, or behavioral issues were substantiated.

## Testing

Baseline test command (full suite) ran green through every test file before timing out on cleanup (all `ok` lines printed); the three test files this change touches (fm-teardown, fm-secondmate-safety, fm-grok-harness) each pass in isolation with exit 0. The 4 new force-guard tests in fm-teardown.test.sh verify inert behavior, token consumption, the audit-log format (ISO-8601 UTC timestamp, task id, caller_pid, pid, authorized verdict), and stale-token cleanup. Beyond pass/fail, a manual end-to-end script drove the real fm-teardown.sh against a realistic local-only task holding unlanded crewmate work and captured the actual stderr, exit codes, and audit-log contents a firstmate user would see: --force without the token refused the unlanded work (exit 1, `authorized=no`), --force with the token discarded it (exit 0, `authorized=yes`), the token was one-shot, and a stale token did not survive normal teardown. Working tree left clean; evidence files are in the dedicated evidence directory.

<details>
<summary>Evidence: End-to-end force-guard demo transcript</summary>

<code>&gt;&gt;&gt; SCENARIO 1: --force WITHOUT captain-authorization token (must be INERT)&#10;&#10;worktree HEAD (unlanded work): 8d3ab88&#10;token before: ABSENT&#10;exit code: 1 (expect 1 = safety check refused despite --force)&#10;--- stderr (what firstmate sees) ---&#10;WARNING: --force on task-x1 is not captain-authorized (no .../inert/state/task-x1.force-granted token).&#10;firstmate cannot self-authorize --force; falling back to normal safety checks.&#10;REFUSED: local-only worktree .../inert/wt has work not yet merged into main and not on any remote.&#10;commits not yet on main:&#10;8d3ab88 unpushed crewmate work that has NOT landed&#10;Merge the branch into local main first ... or get the captain&#39;s explicit OK to discard, then --force.&#10;--- audit log line ---&#10;2026-07-01T10:18:52Z task=task-x1 caller_pid=867322 pid=867368 authorized=no&#10;token after: ABSENT (consumed even though the run was inert)&#10;&#10;&#10;&gt;&gt;&gt; SCENARIO 2: --force WITH captain-authorization token (escape hatch takes effect)&#10;&#10;token before: present&#10;exit code: 0 (expect 0 = captain-authorized discard succeeded)&#10;--- audit log line ---&#10;2026-07-01T10:18:53Z task=task-x1 caller_pid=867322 pid=867468 authorized=yes&#10;token after: ABSENT (consumed on success)&#10;&#10;&#10;&gt;&gt;&gt; SCENARIO 3: token consumed even on a successful run -&gt; a second --force needs a fresh captain OK&#10;&#10;first authorized --force exit: 0&#10;token after first run: ABSENT (one-shot: gone after use)&#10;audit entries for task-x1: 1&#10;&#10;&#10;&gt;&gt;&gt; SCENARIO 4: normal teardown (no --force) cleans a stale token so it cannot linger&#10;&#10;token before normal teardown: present&#10;exit code: 0 (expect 0 = landed work torn down normally)&#10;token after normal teardown: ABSENT (stale authorization must not survive)</code>

```text

========================================================
>>> SCENARIO 1: --force WITHOUT captain-authorization token (must be INERT)
========================================================
worktree HEAD (unlanded work): 8d3ab88
token before: ABSENT
exit code: 1  (expect 1 = safety check refused despite --force)
--- stderr (what firstmate sees) ---
WARNING: --force on task-x1 is not captain-authorized (no /tmp/fm-force-guard-demo.B3WQNy/inert/state/task-x1.force-granted token).
firstmate cannot self-authorize --force; falling back to normal safety checks.
REFUSED: local-only worktree /tmp/fm-force-guard-demo.B3WQNy/inert/wt has work not yet merged into main and not on any remote.
commits not yet on main:
8d3ab88 unpushed crewmate work that has NOT landed
Merge the branch into local main first (bin/fm-merge-local.sh after the captain approves), or push to a fork/remote, or get the captain's explicit OK to discard, then --force.
--- audit log line ---
2026-07-01T10:18:52Z task=task-x1 caller_pid=867322 pid=867368 authorized=no
token after: ABSENT   (consumed even though the run was inert)

========================================================
>>> SCENARIO 2: --force WITH captain-authorization token (escape hatch takes effect)
========================================================
token before: present
exit code: 0  (expect 0 = captain-authorized discard succeeded)
--- stderr ---
--- audit log line ---
2026-07-01T10:18:53Z task=task-x1 caller_pid=867322 pid=867468 authorized=yes
token after: ABSENT   (consumed on success)

========================================================
>>> SCENARIO 3: token consumed even on a successful run -> a second --force needs a fresh captain OK
========================================================
first authorized --force exit: 0
token after first run: ABSENT   (one-shot: gone after use)
audit entries for task-x1: 1

========================================================
>>> SCENARIO 4: normal teardown (no --force) cleans a stale token so it cannot linger
========================================================
token before normal teardown: present
exit code: 0  (expect 0 = landed work torn down normally)
token after normal teardown: ABSENT   (stale authorization must not survive)

========================================================
>>> DEMO COMPLETE - all four guard behaviors verified end-to-end
========================================================
```
</details>
<details>
<summary>Evidence: Demo script (reproducible)</summary>

```text
#!/usr/bin/env bash
# End-to-end demonstration of the fm-teardown --force captain-authorization
# guard (prime directive #3). Drives the REAL bin/fm-teardown.sh against a
# realistic local-only task with UNLANDED work - exactly the scenario --force
# is meant to discard, and exactly what must be protected unless the captain
# explicitly authorized it.
set -u
ROOT="/home/ubuntu/.no-mistakes/worktrees/507cc8072d97/01KWEG6A3YP7ZWWMKXJ19Z2BZZ"
. "$ROOT/tests/lib.sh"
fm_git_identity fmtest fmtest@example.invalid

TEARDOWN="$ROOT/bin/fm-teardown.sh"
TMP_ROOT=$(fm_test_tmproot fm-force-guard-demo)

make_case() {
  local name=$1 case_dir fakebin
  case_dir="$TMP_ROOT/$name"
  fakebin="$case_dir/fakebin"
  mkdir -p "$case_dir/state" "$case_dir/config" "$fakebin"
  printf '#!/usr/bin/env bash\nexit 0\n' > "$fakebin/treehouse"; chmod +x "$fakebin/treehouse"
  printf '#!/usr/bin/env bash\nexit 0\n' > "$fakebin/tmux"; chmod +x "$fakebin/tmux"
  cat > "$fakebin/gh-axi" <<'SH'
#!/usr/bin/env bash
case "${1:-} ${2:-}" in
  "pr list") printf '%s\n' "count: 0 (showing first 0)" "pull_requests[]: []" ; exit 0 ;;
  "pr view") echo "error: pull request not found" >&2 ; exit 1 ;;
esac
exit 0
SH
  cat > "$fakebin/gh" <<'SH'
#!/usr/bin/env bash
case "${1:-} ${2:-}" in
  "pr view") echo "error: pull request not found" >&2 ; exit 1 ;;
esac
exit 0
SH
  chmod +x "$fakebin/gh-axi" "$fakebin/gh"
  git init -q --bare "$case_dir/origin.git"
  git -C "$case_dir/origin.git" symbolic-ref HEAD refs/heads/main
  git clone -q "$case_dir/origin.git" "$case_dir/_seed" 2>/dev/null
  git -C "$case_dir/_seed" -c user.email=t@t -c user.name=t commit -q --allow-empty -m "origin baseline"
  git -C "$case_dir/_seed" push -q origin main
  rm -rf "$case_dir/_seed"
  git clone -q "$case_dir/origin.git" "$case_dir/project"
  git -C "$case_dir/project" remote set-head origin main 2>/dev/null || true
  git -C "$case_dir/project" worktree add -q -b fm/task-x1 "$case_dir/wt" main
  touch "$case_dir/state/.last-watcher-beat"
  printf '%s\n' "$case_dir"
}

write_meta() {
  fm_write_meta "$1/state/task-x1.meta" \
    "window=fm-task-x1" "worktree=$1/wt" "project=$1/project" "kind=$3" "mode=$2"
}
grant_force() { touch "$1/state/task-x1.force-granted"; }
wt_commit() { git -C "$1/wt" -c user.email=t@t -c user.name=t commit -q --allow-empty -m "${2:-wt work}"; }
run_teardown() {
  local case_dir=$1; shift
  FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$case_dir/state" FM_CONFIG_OVERRIDE="$case_dir/config" \
    PATH="$case_dir/fakebin:$PATH" "$TEARDOWN" task-x1 "$@"
}
# token status without nested-quote pitfalls: echoes "present" or "absent"
tok() { if [ -f "$1/state/task-x1.force-granted" ]; then echo "present"; else echo "ABSENT"; fi; }
banner() { printf '\n========================================================\n>>> %s\n========================================================\n' "$1"; }

banner "SCENARIO 1: --force WITHOUT captain-authorization token (must be INERT)"
c=$(make_case inert)
write_meta "$c" local-only ship
wt_commit "$c" "unpushed crewmate work that has NOT landed"
echo "worktree HEAD (unlanded work): $(git -C "$c/wt" rev-parse --short HEAD)"
echo "token before: $(tok "$c")"
set +e; run_teardown "$c" --force >"$c/out" 2>"$c/err"; rc=$?; set -e
echo "exit code: $rc  (expect 1 = safety check refused despite --force)"
echo "--- stderr (what firstmate sees) ---"; cat "$c/err"
echo "--- audit log line ---"; cat "$c/state/.force-audit.log"
echo "token after: $(tok "$c")   (consumed even though the run was inert)"

banner "SCENARIO 2: --force WITH captain-authorization token (escape hatch takes effect)"
c=$(make_case authd)
write_meta "$c" local-only ship
wt_commit "$c" "unpushed crewmate work the captain approved discarding"
grant_force "$c"
echo "token before: $(tok "$c")"
set +e; run_teardown "$c" --force >"$c/out" 2>"$c/err"; rc=$?; set -e
echo "exit code: $rc  (expect 0 = captain-authorized discard succeeded)"
echo "--- stderr ---"; sed -n '1,5p' "$c/err"
echo "--- audit log line ---"; cat "$c/state/.force-audit.log"
echo "token after: $(tok "$c")   (consumed on success)"

banner "SCENARIO 3: token consumed even on a successful run -> a second --force needs a fresh captain OK"
c=$(make_case refuse-consume)
write_meta "$c" local-only ship
wt_commit "$c" "unpushed work"
grant_force "$c"
set +e; run_teardown "$c" --force >"$c/out1" 2>"$c/err1"; rc1=$?; set -e
echo "first authorized --force exit: $rc1"
echo "token after first run: $(tok "$c")   (one-shot: gone after use)"
echo "audit entries for task-x1: $(grep -c 'task=task-x1' "$c/state/.force-audit.log" 2>/dev/null || true)"

banner "SCENARIO 4: normal teardown (no --force) cleans a stale token so it cannot linger"
c=$(make_case stale)
write_meta "$c" local-only ship
wt_commit "$c" "landed work"
git -C "$c/project" update-ref refs/heads/main "$(git -C "$c/wt" rev-parse HEAD)"
grant_force "$c"
echo "token before normal teardown: $(tok "$c")"
set +e; run_teardown "$c" >"$c/out" 2>"$c/err"; rc=$?; set -e
echo "exit code: $rc  (expect 0 = landed work torn down normally)"
echo "token after normal teardown: $(tok "$c")   (stale authorization must not survive)"

banner "DEMO COMPLETE - all four guard behaviors verified end-to-end"
```
</details>
- Outcome: 🔧 1 issue found → auto-fixed ✅ across 2 runs (25m18s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Rebase** - 2 issues found → auto-fixed ✅</summary>

- ⚠️ `AGENTS.md` - merge conflict rebasing onto origin/main
- ⚠️ `tests/fm-teardown.test.sh` - merge conflict rebasing onto origin/main

🔧 Fix applied.
✅ Re-checked - no issues remain.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `tests/fm-grok-harness.test.sh:110` - `test_grok_teardown_removes_pointer_and_token` invokes `&#34;$TEARDOWN&#34; &#34;$id&#34; --force` WITHOUT creating the `state/&lt;id&gt;.force-granted` token first, unlike every other force-teardown test in this PR (which all grant via `grant_force`/`grant_domain_force`). With the new guard, `--force` is INERT here, so FORCE is cleared and the normal safety checks run. The test still passes only incidentally: the fixture worktree (`fm_git_worktree`) has HEAD identical to the default-branch commit, so `content_in_default()` (fm-teardown.sh:239) returns true and teardown is allowed. This means the test no longer exercises its original intent (force-bypass of checks) and becomes fragile — any future commit added to that fixture worktree would make `content_in_default` return false, causing teardown to REFUSE and the test to fail with a confusing message unrelated to what the test asserts. Add `touch &#34;$home/state/$id.force-granted&#34;` before the teardown call to mirror the established grant pattern and restore the intended force-teardown semantics.

🔧 Fix: grant force token in grok teardown test
✅ Re-checked - no issues remain.

</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed ✅</summary>

- 🚨 tests failed with exit code 1
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`

🔧 Fix: make teardown content check portable across git versions
✅ Re-checked - no issues remain.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- `tests/fm-teardown.test.sh (full suite, incl. test_force_without_token_is_inert, test_force_consumes_token, test_force_audit_log, test_normal_teardown_cleans_stale_force_token) -> all pass, exit 0`
- `tests/fm-secondmate-safety.test.sh (force-teardown cases now grant the domain force token) -> all pass, exit 0`
- `tests/fm-grok-harness.test.sh (grok teardown grants the force token) -> all pass, exit 0`
- <code>manual e2e: `bash /tmp/no-mistakes-evidence/01KWEG6A3YP7ZWWMKXJ19Z2BZZ/force-guard-demo.sh` driving the REAL bin/fm-teardown.sh against a local-only task with unlanded work across 4 scenarios (inert --force, authorized --force, one-shot token consumption, stale-token cleanup by normal teardown) -&gt; exit 0</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
