### PR TITLE
feat(spawn): launch ship/scout claude crews with scoped permissions

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -54,6 +54,15 @@ First launch in a fresh worktree, or first ever on a machine, may show a trust o
 After every spawn, peek the pane within about 20 seconds.
 If such a dialog is showing, accept it with `bin/fm-send.sh <window> --key Enter`, or the choice the dialog requires, and verify the brief started processing.
 
+**Scoped permissions (ship/scout crews).** Crewmates do NOT run with `--dangerously-skip-permissions`.
+`fm-spawn.sh` launches a claude ship/scout crew under a scoped `--settings` permission allowlist: safe, expected tools (Read/Edit/Write, git, tsc, expo, gh-axi, common read commands) auto-run, and anything off the list - bare `Bash`, `rm`, `curl`/network, dependency installs - pauses with an in-pane approval dialog.
+The default allowlist lives in `fm-spawn.sh`; override per dispatch with `FM_CREW_ALLOWED_TOOLS` (one rule per line).
+It is passed as a `--settings` JSON blob, never `--allowedTools` (the variadic flag greedily swallows the trailing brief positional - verified).
+When a crewmate pauses on an off-list tool, the pane goes idle and the watcher surfaces it as a `stale` wake; peek, assess whether the requested action is safe, then grant it (answer the dialog via `bin/fm-send.sh`, selecting an always-allow option for clearly-safe recurring categories) or decline.
+Crewmate status appends and approved tool dialogs commonly chain safe commands with `&&`, which won't match per-command allow rules, so early-task prompts are expected; this is the intended review friction, not a fault.
+Secondmates are the exception: a secondmate is itself a supervisor whose pane nobody watches turn-by-turn, so gating it would wedge it on its own prompts - it keeps full autonomy (`--dangerously-skip-permissions`).
+This gates which tool calls run, not OS-level access; it shrinks blast radius but is not a sandbox.
+
 Claude renders a predicted-next-prompt suggestion as dim/faint text inside an otherwise-empty composer after a turn completes.
 A plain `tmux capture-pane` cannot tell that ghost text apart from typed text.
 Firstmate launches every claude crewmate and secondmate with `CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false`, scoped to firstmate-launched agents through `bin/fm-spawn.sh`, so it never touches the captain's global config.

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -124,7 +124,19 @@ launch_template() {
     # does NOT suppress the interactive ghost text (verified empirically), so the env
     # var is the correct control. The dim-aware composer reader in fm-tmux-lib.sh is
     # the defense-in-depth backstop for any pane this flag cannot reach.
-    claude) printf '%s' 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions "$(cat __BRIEF__)"' ;;
+    # Crewmates (ship/scout) launch under a SCOPED permission allowlist via
+    # __CLAUDEPERMS__ (substituted below), not full bypass: off-list tool calls
+    # pause with an in-pane dialog for firstmate to assess+grant, shrinking the
+    # blast radius of an autonomous agent. A secondmate is itself a supervisor
+    # whose pane nobody watches turn-by-turn, so gating it would wedge it on its
+    # own prompts; it keeps full autonomy.
+    claude)
+      if [ "$kind" = secondmate ]; then
+        printf '%s' 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions "$(cat __BRIEF__)"'
+      else
+        printf '%s' 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude __CLAUDEPERMS__ "$(cat __BRIEF__)"'
+      fi
+      ;;
     codex)
       if [ "$kind" = secondmate ]; then
         printf '%s' 'codex --dangerously-bypass-approvals-and-sandbox "$(cat __BRIEF__)"'
@@ -483,9 +495,55 @@ mkdir -p "$STATE"
 sq_brief=$(shell_quote "$BRIEF")
 sq_turnend=$(shell_quote "$TURNEND")
 sq_piext=$(shell_quote "$STATE/$ID.pi-ext.ts")
+
+# Scoped claude crew permissions (see launch_template). The default allowlist
+# auto-runs the safe, expected tools for code work; anything off it (bare Bash,
+# rm, curl/network, dep installs) pauses for firstmate to assess and grant.
+# Passed as a --settings JSON blob, NOT --allowedTools: the variadic flag would
+# greedily swallow the trailing brief positional (verified). Each rule is
+# JSON-quoted into permissions.allow; the brief stays the final positional so
+# nothing follows the flag to be consumed.
+#
+# Rules are NEWLINE-delimited (not space) because a rule such as 'Bash(git *)'
+# legitimately contains a space inside its glob. Override per dispatch with
+# FM_CREW_ALLOWED_TOOLS, one rule per line (e.g. $'Read\nBash(git *)\n...').
+default_crew_allowed_tools='Read
+Edit
+Write
+Bash(git *)
+Bash(npx tsc *)
+Bash(npx expo *)
+Bash(npm run *)
+Bash(gh-axi *)
+Bash(grep *)
+Bash(rg *)
+Bash(ls *)
+Bash(cat *)
+Bash(find *)
+Bash(sed *)
+Bash(echo *)
+Bash(mkdir *)
+Bash(node *)
+Bash(jq *)
+Bash(head *)
+Bash(tail *)
+Bash(pwd)'
+claude_perms_flag() {
+  local rules=${FM_CREW_ALLOWED_TOOLS:-$default_crew_allowed_tools} json="" rule
+  while IFS= read -r rule; do
+    [ -n "$rule" ] || continue
+    rule=${rule//\\/\\\\}; rule=${rule//\"/\\\"}
+    json="$json${json:+,}\"$rule\""
+  done <<EOF
+$rules
+EOF
+  printf -- '--settings %s' "$(shell_quote "{\"permissions\":{\"allow\":[$json]}}")"
+}
+
 LAUNCH=${LAUNCH//__BRIEF__/$sq_brief}
 LAUNCH=${LAUNCH//__TURNEND__/$sq_turnend}
 LAUNCH=${LAUNCH//__PIEXT__/$sq_piext}
+LAUNCH=${LAUNCH//__CLAUDEPERMS__/$(claude_perms_flag)}
 if [ "$KIND" = secondmate ]; then
   sq_home=$(shell_quote "$PROJ_ABS")
   LAUNCH="FM_ROOT_OVERRIDE= FM_STATE_OVERRIDE= FM_DATA_OVERRIDE= FM_PROJECTS_OVERRIDE= FM_CONFIG_OVERRIDE= FM_HOME=$sq_home $LAUNCH"


### PR DESCRIPTION
## What

Stop launching ship/scout claude crewmates with `--dangerously-skip-permissions`. They now run under a scoped `--settings` permission allowlist:

- **Auto-run:** the safe, expected tools for code work - Read/Edit/Write, `git`, `npx tsc`, `npx expo`, `npm run`, `gh-axi`, and common read commands (grep/rg/ls/cat/find/sed/echo/mkdir/node/jq/head/tail/pwd).
- **Pause for approval:** anything off the list - bare `Bash`, `rm`, `curl`/network, dependency installs - surfaces an in-pane dialog. The pane goes idle, the watcher fires a stale wake, and the supervisor assesses + grants (or declines).
- **Override:** `FM_CREW_ALLOWED_TOOLS` (one rule per line) per dispatch.

## Why

Full bypass means an autonomous crewmate runs arbitrary shell as the user with no gate. The merge gate protects what reaches `main`, but not the machine mid-run. Scoping tool calls shrinks the blast radius while keeping crews autonomous on routine edits. It gates which tool calls run, not OS access - not a sandbox, but a real reduction.

## Notes

- Passed as a `--settings` JSON blob, **not** `--allowedTools`: the variadic flag greedily consumes the trailing brief positional (verified empirically). The brief stays the final positional so nothing follows the flag.
- Allowlist rules are newline-delimited because `Bash(git *)` legitimately contains a space.
- **Secondmates keep full autonomy** (`--dangerously-skip-permissions`): a secondmate is itself a supervisor whose pane nobody watches turn-by-turn, so gating would wedge it on its own prompts.
- The `__CLAUDEPERMS__` substitution is a no-op for every other adapter/template, so only ship/scout claude crews change.
- Documented in the harness-adapters skill.

Verified: `bash -n` passes; the flag builder and full launch-line assembly produce the exact working `--settings '{...}' "$(cat brief)"` shape.