### PR TITLE
fix(brief): remove lone apostrophe that broke fm-brief.sh parse

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -208,7 +208,7 @@ When you believe it is complete, append \`done: {summary}\` to the status file a
 Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
 
 You drive no-mistakes by responding to its gates, not by implementing fixes.
-Follow no-mistakes' own guidance for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.
+Follow the no-mistakes guidance for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.
 Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.
 
 Two firstmate-specific rules layer on top of that guidance:


### PR DESCRIPTION
## Summary

`bin/fm-brief.sh` failed to parse, aborting every brief-scaffold path (ship no-mistakes / direct-PR / local-only, `--scout`, and `--secondmate`).

## Root cause

Line 211 had a lone apostrophe — `Follow no-mistakes' own guidance` — inside the no-mistakes `DOD=$(cat <<EOF ... EOF)` command substitution. Bash's command-substitution scanner respects quote characters even inside the heredoc body, so it treated that `'` as the start of an unterminated single-quoted string and the whole file failed to parse. Regression from #102.

## Fix

Reword to `Follow the no-mistakes guidance for the mechanics:`, removing the lone apostrophe while keeping the contract's meaning intact.

## Verification

- `bash -n bin/fm-brief.sh` → exit 0; all `bin/*.sh` parse.
- Scaffolder verified end to end for every path (ship no-mistakes / direct-PR / local-only, `--scout`, `--secondmate`) with throwaway ids; generated no-mistakes Definition-of-done reads correctly.
- Audited the other two `DOD=$(cat <<EOF ... EOF)` blocks and the plain heredocs; no other quote could regress the same way.