### PR TITLE
feat(harness): split secondmate harness configuration

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -12,18 +12,25 @@ Crewmates default to the same harness firstmate is running on unless `config/cre
 The captain may override that file at bootstrap or later; a per-task instruction such as "run this one on codex" overrides it for that dispatch only.
 `default` means mirror firstmate's own harness.
 
+Secondmates have their own harness knob, so a secondmate can run on a different adapter than crewmates.
+`config/secondmate-harness` is the harness the primary uses to launch SECONDMATE agents, resolved through the fallback chain `config/secondmate-harness` -> `config/crew-harness` -> firstmate's own.
+An absent or `default` `config/secondmate-harness` therefore behaves exactly as the crew harness did before this knob existed (secondmates launched on the crew harness); setting it splits the two.
+`config/crew-harness` is inherited by secondmate homes (the primary pushes it down so a secondmate's own crewmates use the primary's value), while `config/secondmate-harness` is the primary's own setting and is never inherited - secondmates do not spawn secondmates.
+
 Each adapter splits into mechanics and knowledge.
 The mechanics, including launch command, autonomy flag, and turn-end hook, live in `bin/fm-spawn.sh`.
 The supervision knowledge lives here: busy signature, exit command, interrupt, dialogs, resume behavior, skill invocation, and quirks.
 
 Never dispatch a crewmate or secondmate on an unverified adapter.
-If `config/crew-harness` names an unverified adapter, tell the captain and fall back to firstmate's own harness until that adapter is verified.
+If `config/crew-harness` or `config/secondmate-harness` names an unverified adapter, tell the captain and fall back to firstmate's own harness until that adapter is verified.
 If the captain asks for a new harness, propose verifying it first: spawn a trivial supervised task using `fm-spawn`'s raw-launch-command escape hatch, confirm every fact empirically, then record the mechanics in `fm-spawn`, the busy signature in `fm-watch.sh` and `fm-tmux-lib.sh` defaults, any needed `FM_COMPOSER_IDLE_RE` empty-composer override, and the verified knowledge here.
 
 ## Detection
 
 `bin/fm-harness.sh` prints firstmate's own harness, using verified env markers first and then process ancestry.
-`bin/fm-harness.sh crew` resolves the effective crewmate harness from `config/crew-harness`.
+`bin/fm-harness.sh crew` resolves the effective crewmate harness from `config/crew-harness` (absent or `default` -> own).
+`bin/fm-harness.sh secondmate` resolves the secondmate-launch harness through the chain `config/secondmate-harness` -> `config/crew-harness` -> own, so an unset `config/secondmate-harness` matches the crew harness.
+`bin/fm-spawn.sh` uses `crew` mode for a crewmate/scout launch and `secondmate` mode for a `--secondmate` launch, re-resolving on every spawn so the split is durable across respawns; an explicit per-spawn harness arg overrides either.
 On `unknown`, ask the captain instead of guessing.
 A captain override always beats detection.
 When verifying a new adapter, record its env marker and command name in `bin/fm-harness.sh`.

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -16,6 +16,8 @@ Secondmates have their own harness knob, so a secondmate can run on a different 
 `config/secondmate-harness` is the harness the primary uses to launch SECONDMATE agents, resolved through the fallback chain `config/secondmate-harness` -> `config/crew-harness` -> firstmate's own.
 An absent or `default` `config/secondmate-harness` therefore behaves exactly as the crew harness did before this knob existed (secondmates launched on the crew harness); setting it splits the two.
 `config/crew-harness` is inherited by secondmate homes (the primary pushes it down so a secondmate's own crewmates use the primary's value), while `config/secondmate-harness` is the primary's own setting and is never inherited - secondmates do not spawn secondmates.
+Inheritance copies the literal `config/crew-harness` file, so for a secondmate's own crewmates to run on the primary's crewmate harness the captain must set `config/crew-harness` to a concrete adapter name, such as `codex`.
+If `config/crew-harness` is unset or `default`, there is no concrete value to inherit, so the secondmate's own crewmates fall back to the secondmate's own/detected harness rather than the primary's effective crewmate harness.
 
 Each adapter splits into mechanics and knowledge.
 The mechanics, including launch command, autonomy flag, and turn-end hook, live in `bin/fm-spawn.sh`.

--- a/.agents/skills/secondmate-provisioning/SKILL.md
+++ b/.agents/skills/secondmate-provisioning/SKILL.md
@@ -48,8 +48,10 @@ The slot stays reserved across restarts until the lease is released.
 Release happens only on explicit retirement or seed rollback, never on routine restart or recovery.
 
 `bin/fm-home-seed.sh` copies the charter into the secondmate home as `data/charter.md`.
-`bin/fm-spawn.sh --secondmate` launches it through the same launch-template path.
+`bin/fm-spawn.sh --secondmate` launches it through the secondmate harness path, resolving `config/secondmate-harness` -> `config/crew-harness` -> the primary's own harness unless an explicit per-spawn harness override is passed.
 Before launch, `fm-spawn.sh --secondmate` locally fast-forwards the home to the primary firstmate checkout's current default-branch commit when it is safe; dirty, diverged, or in-flight homes launch unchanged with a warning.
+The same launch also propagates the primary's declared inheritable local config, currently `config/crew-harness`, into the secondmate home's `config/`.
+`config/secondmate-harness` is not inherited because it is only the primary's knob for launching secondmate agents.
 `bin/fm-home-seed.sh` refuses to copy a missing or placeholder charter.
 
 Direct seed without a preexisting brief requires `FM_SECONDMATE_CHARTER`.
@@ -90,7 +92,7 @@ bin/fm-spawn.sh <id> --secondmate
 
 Use the recorded `home=` in meta.
 If meta is missing but `data/secondmates.md` still registers the secondmate, respawn from the registry entry and its persistent on-disk home.
-Respawn uses the same guarded pre-launch sync, so recovered secondmates converge to the primary firstmate version without fetching from origin whenever their home can be cleanly fast-forwarded.
+Respawn re-resolves the secondmate harness from current config, uses the same guarded pre-launch sync, and re-propagates inheritable config, so recovered secondmates converge to the primary firstmate version and local crew-harness setting whenever their home can be cleanly fast-forwarded.
 
 Do not reconstruct a secondmate's whole tree from the main home.
 The main firstmate reconciles only direct reports.

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ data/
 .DS_Store
 .env
 config/crew-harness
+config/secondmate-harness
 config/x-mode.env

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,8 @@ README.md            public overview and development notes
 .claude/skills       symlink to .agents/skills for claude compatibility
 bin/                 helper scripts, committed; read each script's header before first use
 .env                 optional X-mode pairing token; LOCAL, gitignored; presence-gates section 14
-config/crew-harness  crewmate harness override; LOCAL, gitignored; absent or "default" = same as firstmate
+config/crew-harness  crewmate harness override; LOCAL, gitignored; absent or "default" = same as firstmate. Inherited: the primary pushes this into every secondmate home's config/ (section 4), so a secondmate's own crewmates use the primary's value
+config/secondmate-harness  harness the PRIMARY uses to launch SECONDMATE agents; LOCAL, gitignored; absent or "default" falls back to config/crew-harness then firstmate's own (section 4). The primary's own setting; NOT inherited into secondmate homes (secondmates do not spawn secondmates)
 config/x-mode.env    generated X-mode watcher cadence; LOCAL, gitignored; source before arming watcher when present
 data/                personal fleet records; LOCAL, gitignored as a whole
   backlog.md         task queue, dependencies, history
@@ -115,6 +116,8 @@ Set `FM_FLEET_PRUNE=0` to temporarily disable that branch pruning.
 Bootstrap also sweeps every live secondmate home, fast-forwarding each one's worktree to firstmate's own current default-branch commit so the fleet stays converged on whatever version firstmate is on.
 This is a purely local fast-forward (every secondmate home is a worktree of this same repo, sharing one object store), never a fetch from origin and never a surprise pull: the version followed is simply whatever the primary is currently on, which only the captain changes deliberately via `git pull` or `/updatefirstmate`.
 A tracked-files fast-forward never touches the gitignored operational dirs, so a secondmate's backlog, projects, and in-flight work are never disturbed; a dirty, diverged, or in-flight home is skipped untouched.
+The same sweep also propagates the primary's declared inheritable config (`config/crew-harness` today; section 4) into each live secondmate home's `config/`, so every secondmate's own crewmates stay on the primary's settings.
+Because `config/` is gitignored this is a separate, primary-authoritative copy independent of the tracked-files fast-forward: it re-converges every live home whether or not its tracked files advanced, and it touches only the declared inheritable items (never `config/secondmate-harness`).
 The sweep reports the `NUDGE_SECONDMATES:` line below only when a running secondmate actually advanced with an instruction change, so firstmate knows which ones to live-converge.
 Silence means all good: say nothing and move on.
 Otherwise it prints one line per problem or capability fact; handle each:
@@ -158,10 +161,20 @@ The recorded harness is used for every dispatch until changed; a per-task instru
 Resolve `default` with `bin/fm-harness.sh`; resolve the active crewmate harness with `bin/fm-harness.sh crew`.
 Verified adapter names are `claude`, `codex`, `opencode`, `pi`, and `grok`.
 
+Secondmates can run on a different harness than crewmates.
+`config/secondmate-harness` (a single adapter name; local, gitignored) is the harness the primary uses to launch SECONDMATE agents; resolve it with `bin/fm-harness.sh secondmate`, which follows the fallback chain `config/secondmate-harness` -> `config/crew-harness` -> your own harness.
+So an absent or `default` `config/secondmate-harness` behaves exactly as before this knob existed - secondmates launch on the crew harness - and setting it splits the two: e.g. primary `config/crew-harness=codex` with `config/secondmate-harness=claude` runs the secondmate AGENTS on claude while all crewmates (the primary's and the secondmates' own) run on codex.
+`bin/fm-spawn.sh` resolves a `--secondmate` launch through `secondmate` mode and a crewmate/scout launch through `crew` mode; an explicit per-spawn harness arg still overrides either kind.
+The split is durable: every secondmate respawn (recovery, `/updatefirstmate`, restart) re-resolves from `config/secondmate-harness`, so it survives restarts without being recorded per-task.
+
+`config/crew-harness` is inherited; `config/secondmate-harness` is not.
+The primary pushes its declared inheritable config (`config/crew-harness` today) down into each secondmate home's `config/` - at secondmate spawn and on the bootstrap secondmate sweep (section 3) - so a secondmate's OWN crewmates use the primary's settings (primary `config/crew-harness=codex` makes a secondmate's crewmates spawn on codex too).
+The mechanism is generic over a single declared list (`fm-config-inherit-lib.sh`), primary-authoritative (re-pushed every convergence, mirroring absence), and easy to extend; `config/secondmate-harness` is deliberately excluded because secondmates never spawn secondmates.
+
 Each adapter splits into mechanics and knowledge.
 The mechanics (launch command, autonomy flag, turn-end hook) live in `bin/fm-spawn.sh`; the knowledge you need while supervising (busy signature, exit, interrupt, dialogs, quirks, skill invocation, resume) lives in the agent-only `harness-adapters` skill.
-**Never dispatch a crewmate on an unverified adapter.**
-If `config/crew-harness` names an unverified one, tell the captain and fall back to your own harness until it is verified.
+**Never dispatch a crewmate or secondmate on an unverified adapter.**
+If `config/crew-harness` or `config/secondmate-harness` names an unverified one, tell the captain and fall back to your own harness until it is verified.
 If the captain asks for a new harness, load `harness-adapters`, verify it empirically with a trivial supervised task, then commit the script and knowledge changes.
 Load `harness-adapters` before any spawn, recovery, trust-dialog handling, harness-specific skill invocation, interrupt, exit, resume, or adapter verification.
 
@@ -346,7 +359,7 @@ bin/fm-spawn.sh <id1>=projects/<repo1> <id2>=projects/<repo2> [--scout]   # batc
 Dispatch several tasks in one call by passing `id=repo` pairs instead of a single `<id> <project>`; each pair is spawned through the same single-task path, a shared `--scout` applies to all, and the looping happens inside the script so you never hand-write a multi-task shell loop.
 If one pair fails, the rest still run and the batch exits non-zero.
 
-The script resolves the harness (`fm-harness.sh crew`), owns the verified launch templates, resolves the project's delivery mode (`fm-project-mode.sh`) for ship/scout tasks, and records `harness=`, `kind=`, `mode=`, and `yolo=` in the task's meta; a non-flag third argument containing whitespace is treated as a raw launch command (only for verifying new adapters).
+The script resolves the harness (`fm-harness.sh crew` for crewmate/scout tasks, `fm-harness.sh secondmate` for `kind=secondmate`; section 4), owns the verified launch templates, resolves the project's delivery mode (`fm-project-mode.sh`) for ship/scout tasks, and records `harness=`, `kind=`, `mode=`, and `yolo=` in the task's meta; a non-flag third argument containing whitespace is treated as a raw launch command (only for verifying new adapters).
 For `kind=secondmate`, the same script launches in the registered or explicit firstmate home instead of running `treehouse get` for a project, records `home=` and `projects=`, and uses the charter brief as the launch prompt.
 
 For ship and scout tasks, the script creates the window (in your current tmux session, or a dedicated `firstmate` session when you are outside tmux), runs `treehouse get`, waits for the worktree subshell, asserts the resolved worktree is a genuine isolated worktree distinct from the primary checkout (aborting the spawn otherwise, to prevent the worktree tangle of section 8), installs the turn-end hook, records `state/<id>.meta`, and launches the agent with the brief.
@@ -355,6 +368,7 @@ For `kind=secondmate`, the script creates the same kind of window but starts dir
 Before launching a secondmate, the script fast-forwards its home worktree to firstmate's own current default-branch commit, so a freshly spawned or recovery-respawned secondmate always starts on firstmate's current version.
 This is a purely local fast-forward of tracked files - never a fetch from origin, and never touching the gitignored operational dirs - so the secondmate's backlog, projects, and any prior in-flight work are untouched; a dirty, diverged, or in-flight home is left as-is and launches unchanged.
 If that pre-launch fast-forward is skipped, `fm-spawn.sh` prints a concise warning to stderr and still launches the secondmate from its unchanged checkout.
+The spawn also propagates the primary's declared inheritable config (`config/crew-harness` today; section 4) into the secondmate home's `config/`, so the secondmate's own crewmates inherit the primary's settings; this is a separate gitignored-file copy from the tracked-files fast-forward and a primary with no inheritable config set is a no-op.
 No nudge is needed at spawn because the agent reads `AGENTS.md` fresh on launch.
 Project worktrees start at detached HEAD on a clean default branch; ship briefs tell the crewmate to create its branch, while scout briefs keep the worktree scratch.
 After spawning, peek the pane to confirm the crewmate is processing the brief and handle any trust dialog with `harness-adapters`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,6 +169,8 @@ The split is durable: every secondmate respawn (recovery, `/updatefirstmate`, re
 
 `config/crew-harness` is inherited; `config/secondmate-harness` is not.
 The primary pushes its declared inheritable config (`config/crew-harness` today) down into each secondmate home's `config/` - at secondmate spawn and on the bootstrap secondmate sweep (section 3) - so a secondmate's OWN crewmates use the primary's settings (primary `config/crew-harness=codex` makes a secondmate's crewmates spawn on codex too).
+Inheritance copies the literal `config/crew-harness` file, so for a secondmate's own crewmates to run on the primary's crewmate harness the captain must set `config/crew-harness` to a concrete adapter name, such as `codex`.
+If `config/crew-harness` is unset or `default`, there is no concrete value to inherit, so the secondmate's own crewmates fall back to the secondmate's own/detected harness rather than the primary's effective crewmate harness.
 The mechanism is generic over a single declared list (`fm-config-inherit-lib.sh`), primary-authoritative (re-pushed every convergence, mirroring absence), and easy to extend; `config/secondmate-harness` is deliberately excluded because secondmates never spawn secondmates.
 
 Each adapter splits into mechanics and knowledge.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,7 @@ tests/fm-tangle-guard.test.sh             # primary-checkout tangle detection an
 tests/fm-spawn-batch.test.sh              # batch dispatch and FM_HOME project-path scoping tests
 tests/fm-update.test.sh                   # fast-forward-only self-update, reread, nudge, dedup, and skip-safety tests
 tests/fm-secondmate-sync.test.sh          # local-HEAD secondmate sync, no-fetch, bootstrap nudge gating, and spawn hook tests
+tests/fm-secondmate-harness.test.sh       # secondmate-vs-crewmate harness resolution and primary-to-secondmate config inheritance tests
 tests/fm-secondmate-lifecycle-e2e.test.sh # persistent secondmate routing, seeding, backlog handoff, spawn, recovery, teardown, and FM_HOME flow tests
 tests/fm-secondmate-safety.test.sh        # secondmate home safety, idle charter, handoff validation, and teardown boundary tests
 tests/fm-teardown.test.sh                 # fm-teardown.sh landed-work safety and reminder checks: fork-remote allow, squash/content landings, dirty and unlanded refusals, PR-head metadata, tasks-axi reminder, --force override

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Outside tmux, crewmates land in a detached `firstmate` session you can attach to
 You chat with the first mate.
 It routes each request to a crewmate in its own tmux window and git worktree, supervises the fleet with a zero-token event-driven watcher, and brings you finished PRs, approved local merges, or investigation reports.
 Persistent secondmate homes are linked firstmate worktrees; startup syncs live ones and secondmate launch syncs the target home to the primary default-branch commit without fetching from origin when it is safe.
+Secondmate launch can use a separate local `config/secondmate-harness`, while secondmate homes inherit the primary `config/crew-harness` so their own crewmates use the primary setting.
 When a routed request goes to a secondmate, firstmate marks it so the answer returns through status or a document pointer; direct typing into that secondmate window stays conversational.
 A presence-gated sub-supervisor (`/afk`) can self-handle routine events and batch only what matters while you step away.
 An opt-in X mode can also use the watcher check path to answer your public `@myfirstmate` mentions and act on normal reversible mention requests from the current fleet state, with `FMX_DRY_RUN` available to test the poll -> compose -> would-post loop without publishing.

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -50,6 +50,8 @@ STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 . "$SCRIPT_DIR/fm-tangle-lib.sh"
 # shellcheck source=bin/fm-ff-lib.sh
 . "$SCRIPT_DIR/fm-ff-lib.sh"
+# shellcheck source=bin/fm-config-inherit-lib.sh
+. "$SCRIPT_DIR/fm-config-inherit-lib.sh"
 # shellcheck source=bin/fm-x-lib.sh
 . "$SCRIPT_DIR/fm-x-lib.sh"
 
@@ -125,6 +127,17 @@ secondmate_sync() {
     esac
   done < "$tmp"
   rm -f "$tmp"
+  # Inheritable-config propagation: push the primary's declared LOCAL config
+  # (config/crew-harness today) into every VALIDATED live secondmate home swept
+  # above (FF_SEEN_HOMES is exactly that set). config/ is gitignored, so this is a
+  # separate copy from the tracked-files fast-forward; primary-authoritative, so
+  # it runs whether or not the home's tracked files advanced, keeping the fleet
+  # converged on the primary. Silent (fm-config-inherit-lib.sh); a primary with no
+  # inheritable config set is a complete no-op.
+  local home
+  for home in $FF_SEEN_HOMES; do
+    propagate_inheritable_config "$CONFIG" "$home/config" || true
+  done
   [ -n "$FF_NUDGE_WINDOWS" ] && echo "NUDGE_SECONDMATES:$FF_NUDGE_WINDOWS"
   return 0
 }

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -132,11 +132,28 @@ secondmate_sync() {
   # above (FF_SEEN_HOMES is exactly that set). config/ is gitignored, so this is a
   # separate copy from the tracked-files fast-forward; primary-authoritative, so
   # it runs whether or not the home's tracked files advanced, keeping the fleet
-  # converged on the primary. Silent (fm-config-inherit-lib.sh); a primary with no
-  # inheritable config set is a complete no-op.
-  local home
-  for home in $FF_SEEN_HOMES; do
-    propagate_inheritable_config "$CONFIG" "$home/config" || true
+  # converged on the primary. The propagation helper stays silent on success; a
+  # primary with no inheritable config set and no downstream copy is a no-op.
+  local meta id home home_real propagated_homes
+  propagated_homes=""
+  for meta in "$STATE"/*.meta; do
+    [ -f "$meta" ] || continue
+    grep -q '^kind=secondmate' "$meta" 2>/dev/null || continue
+    id=$(basename "$meta" .meta)
+    home=$(grep '^home=' "$meta" 2>/dev/null | tail -1 | cut -d= -f2- || true)
+    validate_secondmate_home "$id" "$home" || continue
+    home_real="$VALIDATED_HOME"
+    case " $FF_SEEN_HOMES " in
+      *" $home_real "*) ;;
+      *) continue ;;
+    esac
+    case " $propagated_homes " in
+      *" $home_real "*) continue ;;
+    esac
+    propagated_homes="$propagated_homes $home_real"
+    if ! propagate_inheritable_config "$CONFIG" "$home_real/config"; then
+      echo "SECONDMATE_SYNC: secondmate $id: skipped: config inheritance failed"
+    fi
   done
   [ -n "$FF_NUDGE_WINDOWS" ] && echo "NUDGE_SECONDMATES:$FF_NUDGE_WINDOWS"
   return 0

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -15,8 +15,11 @@
 #          commit (a purely LOCAL fast-forward, never an origin fetch) AND whose
 #          instruction surface actually changed; firstmate nudges each to re-read.
 #          Already-current or no-instruction-change homes are silently left alone.
-#          SECONDMATE_SYNC lines report actionable skipped local-HEAD syncs for
-#          live secondmate homes; no-op/current and successful updates stay quiet.
+#          The secondmate sweep also propagates declared inheritable local config
+#          (config/crew-harness today) into each validated live secondmate home.
+#          SECONDMATE_SYNC lines report actionable skipped local-HEAD syncs or
+#          config-inheritance failures for live secondmate homes; no-op/current
+#          and successful updates stay quiet.
 #          A TANGLE line means the firstmate primary checkout (FM_ROOT) is stranded
 #          on a feature branch instead of its default branch - a crewmate's work
 #          landed in the primary instead of its own worktree; restore it per the line.

--- a/bin/fm-config-inherit-lib.sh
+++ b/bin/fm-config-inherit-lib.sh
@@ -27,6 +27,30 @@
 # environment only in tests. Items must not contain whitespace.
 FM_INHERITABLE_CONFIG="${FM_INHERITABLE_CONFIG:-crew-harness}"
 
+copy_inheritable_file() {
+  local src=$1 dest=$2 dest_parent tmp
+  if [ -e "$dest" ] && [ ! -f "$dest" ] && [ ! -L "$dest" ]; then
+    return 1
+  fi
+  dest_parent=${dest%/*}
+  [ -n "$dest_parent" ] && [ "$dest_parent" != "$dest" ] || return 1
+  mkdir -p "$dest_parent" 2>/dev/null || return 1
+  tmp=$(mktemp "$dest_parent/.fm-inherit.XXXXXX" 2>/dev/null) || return 1
+  if ! cp "$src" "$tmp" 2>/dev/null; then
+    rm -f "$tmp" 2>/dev/null || true
+    return 1
+  fi
+  if [ -L "$dest" ] && ! rm -f "$dest" 2>/dev/null; then
+    rm -f "$tmp" 2>/dev/null || true
+    return 1
+  fi
+  if mv -f "$tmp" "$dest" 2>/dev/null; then
+    return 0
+  fi
+  rm -f "$tmp" 2>/dev/null || true
+  return 1
+}
+
 # propagate_inheritable_config <src-config-dir> <dest-config-dir>
 # Copy each declared inheritable item from the primary's config dir (src) into a
 # secondmate home's config dir (dest). SILENT on success - callers parse stdout,
@@ -43,14 +67,16 @@ propagate_inheritable_config() {
   [ -n "$src_config" ] || return 1
   [ -n "$dest_config" ] || return 1
   for item in $FM_INHERITABLE_CONFIG; do
+    case "$item" in
+      ''|/*|.|..|../*|*/../*|*/..) return 1 ;;
+    esac
     src="$src_config/$item"
     dest="$dest_config/$item"
     if [ -f "$src" ]; then
-      if [ ! -f "$dest" ] || ! cmp -s "$src" "$dest"; then
-        mkdir -p "$dest_config" 2>/dev/null || return 1
-        cp "$src" "$dest" 2>/dev/null || return 1
+      if [ -L "$dest" ] || [ ! -f "$dest" ] || ! cmp -s "$src" "$dest"; then
+        copy_inheritable_file "$src" "$dest" || return 1
       fi
-    elif [ -e "$dest" ]; then
+    elif [ -e "$dest" ] || [ -L "$dest" ]; then
       # Primary has no value for this item: mirror the absence downstream.
       rm -f "$dest" 2>/dev/null || return 1
     fi

--- a/bin/fm-config-inherit-lib.sh
+++ b/bin/fm-config-inherit-lib.sh
@@ -52,7 +52,7 @@ propagate_inheritable_config() {
       fi
     elif [ -e "$dest" ]; then
       # Primary has no value for this item: mirror the absence downstream.
-      rm -f "$dest" 2>/dev/null || true
+      rm -f "$dest" 2>/dev/null || return 1
     fi
   done
   return 0

--- a/bin/fm-config-inherit-lib.sh
+++ b/bin/fm-config-inherit-lib.sh
@@ -1,0 +1,59 @@
+# shellcheck shell=bash
+# Inheritable-config propagation: the PRIMARY firstmate pushes a declared,
+# extensible set of LOCAL (gitignored) config items down into each secondmate
+# home's config/, so a secondmate's OWN crewmates inherit the primary's settings
+# (e.g. primary config/crew-harness=codex makes a secondmate's crewmates spawn on
+# codex too).
+#
+# Usage: . bin/fm-config-inherit-lib.sh   (no FM_* setup required)
+#
+# Why this is separate from the tracked-files fast-forward (fm-ff-lib.sh): config/
+# is gitignored, so a tracked-files fast-forward never carries these items. This
+# is an explicit copy run at the two convergence points the primary owns - a
+# secondmate spawn (bin/fm-spawn.sh) and the bootstrap secondmate sweep
+# (bin/fm-bootstrap.sh). It is PRIMARY-AUTHORITATIVE: the primary's value wins and
+# is re-pushed on every convergence, so the fleet stays converged on the primary;
+# an item the primary does not set is mirrored as absence downstream.
+#
+# Extensible by design: FM_INHERITABLE_CONFIG is the single declared list of
+# config-dir-relative items the primary propagates. Add an item there and every
+# convergence point inherits it - no other change needed. Only crew-harness is
+# wired today. config/secondmate-harness is deliberately NOT in the list: it is
+# the primary's own setting for launching secondmates, and a secondmate never
+# spawns secondmates, so it must not flow downstream.
+
+# The declared inheritable set (space-separated, config-dir-relative item paths).
+# Extend here to inherit more of the primary's local config; override via the
+# environment only in tests. Items must not contain whitespace.
+FM_INHERITABLE_CONFIG="${FM_INHERITABLE_CONFIG:-crew-harness}"
+
+# propagate_inheritable_config <src-config-dir> <dest-config-dir>
+# Copy each declared inheritable item from the primary's config dir (src) into a
+# secondmate home's config dir (dest). SILENT on success - callers parse stdout,
+# so this writes nothing there. A source item that is present is copied only when
+# its content differs (idempotent: a re-run never churns mtimes). A source item
+# that is absent is mirrored as a missing destination item, so clearing the
+# primary's value clears it downstream too (primary-authoritative). The
+# destination dir is created lazily, only when there is actually something to
+# write, so a primary with no inheritable config set is a complete no-op (it
+# leaves the secondmate home exactly as it was - the backward-compatible path).
+# Returns non-zero only when the destination cannot be created or written.
+propagate_inheritable_config() {
+  local src_config=$1 dest_config=$2 item src dest
+  [ -n "$src_config" ] || return 1
+  [ -n "$dest_config" ] || return 1
+  for item in $FM_INHERITABLE_CONFIG; do
+    src="$src_config/$item"
+    dest="$dest_config/$item"
+    if [ -f "$src" ]; then
+      if [ ! -f "$dest" ] || ! cmp -s "$src" "$dest"; then
+        mkdir -p "$dest_config" 2>/dev/null || return 1
+        cp "$src" "$dest" 2>/dev/null || return 1
+      fi
+    elif [ -e "$dest" ]; then
+      # Primary has no value for this item: mirror the absence downstream.
+      rm -f "$dest" 2>/dev/null || true
+    fi
+  done
+  return 0
+}

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -1,8 +1,14 @@
 #!/usr/bin/env bash
 # Detect the agent harness this process tree runs on.
-# Usage: fm-harness.sh         print own harness: claude|codex|opencode|pi|grok|unknown
-#        fm-harness.sh crew    print the effective crewmate harness
-#                              (config/crew-harness; "default" resolves to own)
+# Usage: fm-harness.sh             print own harness: claude|codex|opencode|pi|grok|unknown
+#        fm-harness.sh crew        print the effective CREWMATE harness
+#                                  (config/crew-harness; "default" resolves to own)
+#        fm-harness.sh secondmate  print the harness the PRIMARY uses to launch
+#                                  SECONDMATE agents: config/secondmate-harness ->
+#                                  config/crew-harness -> own. "default" or absent
+#                                  defers to the crew resolution, so an unset
+#                                  secondmate-harness behaves exactly as the crew
+#                                  harness did before this knob existed.
 # Detection layers: verified environment markers first, then process ancestry.
 # Record each newly verified env marker here.
 set -u
@@ -49,10 +55,28 @@ detect_own() {
   echo unknown
 }
 
-if [ "${1:-}" = "crew" ]; then
-  crew=
+# Resolve the effective crewmate harness: config/crew-harness (a bare adapter
+# name) wins; absent or "default" mirrors firstmate's own harness.
+resolve_crew() {
+  local crew=
   [ -f "$CONFIG/crew-harness" ] && crew=$(tr -d '[:space:]' < "$CONFIG/crew-harness" || true)
   if [ -z "$crew" ] || [ "$crew" = "default" ]; then detect_own; else echo "$crew"; fi
-else
-  detect_own
-fi
+}
+
+# Resolve the harness the PRIMARY uses to launch SECONDMATE agents: a fallback
+# chain config/secondmate-harness -> config/crew-harness -> own. An absent or
+# "default" config/secondmate-harness defers to the crew resolution, so an unset
+# secondmate-harness behaves exactly as before this knob existed (a secondmate
+# launched on the crew harness). config/secondmate-harness is the PRIMARY's own
+# setting and is never inherited downstream - secondmates do not spawn secondmates.
+resolve_secondmate() {
+  local sm=
+  [ -f "$CONFIG/secondmate-harness" ] && sm=$(tr -d '[:space:]' < "$CONFIG/secondmate-harness" || true)
+  if [ -z "$sm" ] || [ "$sm" = "default" ]; then resolve_crew; else echo "$sm"; fi
+}
+
+case "${1:-}" in
+  crew) resolve_crew ;;
+  secondmate) resolve_secondmate ;;
+  *) detect_own ;;
+esac

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -3,10 +3,17 @@
 # its isolated firstmate home.
 # Usage: fm-spawn.sh <task-id> <project-dir> [harness|launch-command] [--scout]
 #        fm-spawn.sh <task-id> [<firstmate-home>] [harness|launch-command] --secondmate
-#   With no harness arg, the harness comes from fm-harness.sh crew (config/crew-harness,
-#   falling back to firstmate's own harness). A bare adapter name (claude|codex|
-#   opencode|pi|grok) overrides it for this spawn. A non-flag string containing whitespace
-#   is treated as a RAW launch command - the escape hatch for verifying new adapters.
+#   With no harness arg, the harness comes from fm-harness.sh: a crewmate/scout
+#   spawn resolves the CREW harness (config/crew-harness, falling back to firstmate's
+#   own); a --secondmate spawn resolves the SECONDMATE harness (config/secondmate-harness
+#   -> config/crew-harness -> own), so the secondmate-vs-crewmate split is DURABLE
+#   across every respawn (recovery, /updatefirstmate, restart). A bare adapter name
+#   (claude|codex|opencode|pi|grok) overrides it for this spawn (either kind). A
+#   non-flag string containing whitespace is treated as a RAW launch command - the
+#   escape hatch for verifying new adapters.
+#   A --secondmate spawn also propagates the primary's declared inheritable config
+#   (config/crew-harness today) into the secondmate home's config/, so the
+#   secondmate's OWN crewmates inherit the primary's settings (fm-config-inherit-lib.sh).
 #   --scout records kind=scout in the task's meta (report deliverable, scratch worktree;
 #   see AGENTS.md task lifecycle); --secondmate records kind=secondmate and launches in a
 #   provisioned firstmate home; the default is kind=ship.
@@ -40,9 +47,12 @@ FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 PROJECTS="${FM_PROJECTS_OVERRIDE:-$FM_HOME/projects}"
+CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
 SUB_HOME_MARKER=".fm-secondmate-home"
 # shellcheck source=bin/fm-ff-lib.sh
 . "$SCRIPT_DIR/fm-ff-lib.sh"
+# shellcheck source=bin/fm-config-inherit-lib.sh
+. "$SCRIPT_DIR/fm-config-inherit-lib.sh"
 # Skip the watcher guard when re-exec'd for one pair of a batch (FM_SPAWN_NO_GUARD is
 # set by the batch loop below), so the guard runs once for the batch, not once per pair.
 [ -n "${FM_SPAWN_NO_GUARD:-}" ] || "$FM_ROOT/bin/fm-guard.sh" || true
@@ -163,8 +173,21 @@ case "$ARG3" in
     done
     ;;
   '')
-    HARNESS=$("$FM_ROOT/bin/fm-harness.sh" crew)
-    LAUNCH=$(launch_template "$HARNESS" "$KIND") || { echo "error: no launch template for harness '$HARNESS' (from config/crew-harness or detection); pass a raw launch command to use an unverified adapter" >&2; exit 1; }
+    # No explicit harness: resolve from config. A secondmate AGENT launches on the
+    # secondmate harness (config/secondmate-harness -> config/crew-harness -> own);
+    # every other kind uses the crew harness. Resolving here on every spawn is what
+    # makes the split DURABLE - a respawn (recovery, /updatefirstmate, restart)
+    # re-resolves, so config/secondmate-harness keeps governing secondmate launches
+    # across restarts. The launch_template lookup below is the unverified-adapter
+    # guard for both kinds: a harness with no template aborts the spawn.
+    if [ "$KIND" = secondmate ]; then
+      HARNESS=$("$FM_ROOT/bin/fm-harness.sh" secondmate)
+      harness_src='config/secondmate-harness (falling back to config/crew-harness)'
+    else
+      HARNESS=$("$FM_ROOT/bin/fm-harness.sh" crew)
+      harness_src='config/crew-harness'
+    fi
+    LAUNCH=$(launch_template "$HARNESS" "$KIND") || { echo "error: no launch template for harness '$HARNESS' (from $harness_src or detection); pass a raw launch command to use an unverified adapter" >&2; exit 1; }
     ;;
   *)
     HARNESS=$ARG3
@@ -340,6 +363,15 @@ if [ "$KIND" = secondmate ]; then
   else
     echo "warning: secondmate $ID sync skipped before launch: primary default-branch commit cannot be resolved" >&2
   fi
+  # Inheritable-config propagation: push the primary's declared LOCAL config
+  # (config/crew-harness today) into this secondmate home's config/, so the
+  # secondmate's OWN crewmates inherit the primary's settings. config/ is
+  # gitignored, so this is a separate copy from the local-HEAD fast-forward above;
+  # primary-authoritative and re-pushed on every convergence. config/secondmate-harness
+  # is the primary's own knob and is deliberately NOT in the inheritable set
+  # (fm-config-inherit-lib.sh). A primary with no inheritable config set is a no-op.
+  propagate_inheritable_config "$CONFIG" "$PROJ_ABS/config" \
+    || echo "warning: secondmate $ID config inheritance failed for $PROJ_ABS/config" >&2
   if [ -f "$PROJ_ABS/data/charter.md" ]; then
     BRIEF="$PROJ_ABS/data/charter.md"
   else

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -71,9 +71,16 @@ Idle secondmate panes are healthy; teardown is explicit and refuses while the se
 Secondmate homes stay on the same firstmate version as the primary checkout.
 On main firstmate bootstrap, `fm-bootstrap.sh` fast-forwards each live secondmate home recorded in `state/*.meta` to the primary default-branch commit with no origin fetch.
 A tracked-files fast-forward leaves the home's gitignored `data/`, `state/`, `config/`, `projects/`, and `.no-mistakes/` directories untouched.
+Bootstrap separately propagates the primary's declared inheritable local config, currently `config/crew-harness`, into each validated live secondmate home so that secondmate's own crewmates use the primary setting.
+That propagation is primary-authoritative, re-runs even when tracked files were already current, mirrors absence when the primary clears the value, and deliberately never copies `config/secondmate-harness`.
 Dirty, diverged, unsafe, or in-flight homes are reported and left unchanged.
 Only a running secondmate home that actually advanced and changed `AGENTS.md`, `bin/`, or `.agents/skills/` is listed for a re-read nudge.
 `fm-spawn.sh --secondmate` performs the same guarded local fast-forward before launch or recovery respawn; skipped syncs warn and the secondmate launches unchanged.
+Secondmate spawn also propagates the same inheritable config before launch.
+
+Secondmate agents can run on a different verified harness than crewmates.
+`config/secondmate-harness` controls the primary's secondmate launch harness and falls back to `config/crew-harness`, then to the primary's own harness, when unset or `default`.
+`config/crew-harness` remains the crewmate harness and is the only harness config inherited into secondmate homes.
 
 The `data/secondmates.md` line schema and the secondmate environment variables are documented in [configuration.md](configuration.md).
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -48,6 +48,13 @@ When `FM_HOME` is unset, it also behaves as the old whole-root override.
 claude, codex, opencode, pi, and grok are all empirically verified; new harnesses get verified through a supervised trial task before joining the set.
 The verified adapter knowledge - busy signatures, interrupt and exit commands, skill-invocation syntax, and per-harness quirks - lives in [`.agents/skills/harness-adapters/SKILL.md`](../.agents/skills/harness-adapters/SKILL.md).
 Launch mechanics, including the verified command templates, live in [`bin/fm-spawn.sh`](../bin/fm-spawn.sh).
+`config/crew-harness` is a local, gitignored file containing one adapter name for crewmate and scout launches.
+When it is absent or contains `default`, crewmates mirror the firstmate's own harness.
+`config/secondmate-harness` is a separate local, gitignored file containing the adapter the primary uses to launch secondmate agents.
+When it is absent or contains `default`, secondmate launch falls back through `config/crew-harness` and then the primary's own harness, preserving the previous behavior.
+An explicit harness argument to `fm-spawn.sh` still overrides either config file for that spawn only.
+The primary propagates `config/crew-harness` into secondmate homes at secondmate spawn and during the bootstrap secondmate sweep, so a secondmate's own crewmates use the primary's concrete crew-harness value.
+`config/secondmate-harness` is not inherited because secondmates do not launch secondmates.
 For grok, `fm-spawn.sh` installs one firstmate-owned global turn-end hook under `$GROK_HOME/hooks/`, or `~/.grok/hooks/` when `GROK_HOME` is unset, and drops a per-task `.fm-grok-turnend` pointer in the worktree, with teardown removing the task token and pointer.
 
 ## Toolchain
@@ -58,8 +65,8 @@ If compatible `tasks-axi` is already on `PATH`, bootstrap records it as an optio
 Bootstrap also reports a `TANGLE:` line when `FM_ROOT` is on a named non-default branch; follow the printed checkout remediation rather than treating it as an installable tool problem.
 Bootstrap also runs a best-effort project clone refresh through `fm-fleet-sync.sh`.
 It emits `FLEET_SYNC:` for skipped refreshes that may matter, recovered self-heals, and `STUCK:` alarms; local-only and no-origin skips stay silent.
-Bootstrap also runs the guarded local secondmate sync for recorded live secondmate homes.
-It emits `SECONDMATE_SYNC:` only when a home was skipped for an actionable reason, and `NUDGE_SECONDMATES:` only when a running home advanced and its instruction surface changed.
+Bootstrap also runs the guarded local secondmate sync for recorded live secondmate homes, then propagates declared inheritable local config into each validated live home.
+It emits `SECONDMATE_SYNC:` only when a home was skipped for an actionable sync reason or config inheritance failed, and `NUDGE_SECONDMATES:` only when a running home advanced and its instruction surface changed.
 
 ## X mode (.env)
 

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -5,7 +5,7 @@ Each file also starts with a short header comment.
 
 | Script                   | Description                                                                                                         |
 | ------------------------ | ------------------------------------------------------------------------------------------------------------------- |
-| `fm-bootstrap.sh`        | Detect required toolchain and version problems, optional capability facts, primary-checkout `TANGLE:` problems, and actionable clone refresh outcomes; refresh project clones best-effort; locally sync live secondmate homes; set up opt-in X mode; install tools only after consent |
+| `fm-bootstrap.sh`        | Detect required toolchain and version problems, optional capability facts, primary-checkout `TANGLE:` problems, and actionable clone refresh outcomes; refresh project clones best-effort; locally sync live secondmate homes and propagate declared inheritable config; set up opt-in X mode; install tools only after consent |
 | `fm-fleet-sync.sh`       | Fetch clones, fast-forward safe default-branch states, self-heal clean detached ancestor drift, report unsafe drift as `STUCK:`, and safely prune branches whose remote is gone |
 | `fm-update.sh`           | Self-update the running firstmate repo and registered secondmate homes with fast-forward-only pulls from origin     |
 | `fm-backlog-handoff.sh`  | Move already-judged in-scope queued backlog items from the main home into a seeded secondmate home                 |
@@ -13,7 +13,7 @@ Each file also starts with a short header comment.
 | `fm-ensure-agents-md.sh` | Ensure project `AGENTS.md` is the real memory file and `CLAUDE.md` symlinks to it                                   |
 | `fm-guard.sh`            | Warn when the primary checkout is tangled, when queued wakes are pending, or when a stale or missing watcher needs a prominent banner |
 | `fm-home-seed.sh`        | Lease/provision a secondmate home transactionally, clone projects, initialize gates, and maintain `data/secondmates.md` |
-| `fm-spawn.sh`            | Spawn one task, several `id=repo` pairs, or a persistent secondmate with `--secondmate`; ship/scout spawns require an isolated treehouse worktree, install per-harness turn-end signaling, and secondmate spawns locally sync the home before launch |
+| `fm-spawn.sh`            | Spawn one task, several `id=repo` pairs, or a persistent secondmate with `--secondmate`; ship/scout spawns require an isolated treehouse worktree, install per-harness turn-end signaling, and secondmate spawns resolve the secondmate harness, locally sync the home, and propagate declared inheritable config before launch |
 | `fm-project-mode.sh`     | Resolve a project's delivery mode and `+yolo` flag from `data/projects.md`                                          |
 | `fm-merge-local.sh`      | Fast-forward a `local-only` project's local default branch after approval                                           |
 | `fm-review-diff.sh`      | Review a crewmate branch against the authoritative base, with optional `--stat` output                              |

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -24,6 +24,7 @@ Each file also starts with a short header comment.
 | `fm-crew-state.sh`       | Print one stable current-state line for a crew by reconciling its matching no-mistakes run-step, even when the pane has closed, with pane and status-log fallback |
 | `fm-tangle-lib.sh`       | Shared default-branch resolution and primary-checkout tangle classification sourced by bootstrap and guard         |
 | `fm-ff-lib.sh`           | Shared guarded fast-forward helper for `/updatefirstmate` origin pulls and no-fetch local secondmate syncs         |
+| `fm-config-inherit-lib.sh` | Shared primary->secondmate inheritable-config propagation (a declared, extensible item list - `config/crew-harness` today) sourced by spawn and bootstrap |
 | `fm-tasks-axi-lib.sh`    | Shared `tasks-axi` compatibility probe sourced by bootstrap and teardown                                            |
 | `fm-wake-drain.sh`       | Atomically drain queued watcher wakes before handling supervision work, then run the watcher-liveness guard         |
 | `fm-wake-lib.sh`         | Shared durable wake queue and portable lock helpers sourced by the watcher, drain, arm, guard, and daemon          |
@@ -34,7 +35,7 @@ Each file also starts with a short header comment.
 | `fm-pr-check.sh`         | Record `pr=` and a verified `pr_head=` when available for a PR-ready task, then arm the watcher's merge poll        |
 | `fm-promote.sh`          | Promote a scout task in place so it becomes a protected ship task                                                   |
 | `fm-teardown.sh`         | Return a clean, landed ship worktree or retire/release a secondmate home; requires scout reports, checks child work, removes firstmate-owned hook artifacts, and prints the backlog reminder |
-| `fm-harness.sh`          | Detect the running harness; resolve the effective crewmate harness                                                  |
+| `fm-harness.sh`          | Detect the running harness; resolve the effective crewmate (`crew`) or secondmate-launch (`secondmate`) harness     |
 | `fm-lock.sh`             | Per-home firstmate session lock                                                                                     |
 | `fm-x-lib.sh`            | Shared X-mode `.env`, alternate env-file, relay, dry-run config, reply-thread splitting, and task-to-X-request meta-link helpers |
 | `fm-x-poll.sh`           | Do one bounded X relay poll; without `FMX_PAIRING_TOKEN` it is silent, with a pending mention it stashes the full inbox JSON, including `in_reply_to`, and prints `x-mention <request_id>` |

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -97,6 +97,13 @@ test_propagate_lib() {
   propagate_inheritable_config "$src" "$dest"
   [ -e "$dest/crew-harness" ] && fail "absence not mirrored downstream"
 
+  mkdir -p "$dest/crew-harness"
+  if propagate_inheritable_config "$src" "$dest"; then
+    fail "failed absence mirror returned success"
+  fi
+  [ -d "$dest/crew-harness" ] || fail "failed absence mirror removed the wrong path"
+  rm -rf "$dest/crew-harness"
+
   # 5. secondmate-harness is never inherited
   printf 'grok\n' > "$src/secondmate-harness"
   printf 'codex\n' > "$src/crew-harness"
@@ -423,6 +430,21 @@ test_bootstrap_sweep_no_inheritance_is_noop() {
   pass "B9 bootstrap sweep with no inheritable config is a config no-op and still fast-forwards"
 }
 
+test_bootstrap_sweep_surfaces_config_propagation_failure() {
+  local w c1 out fail_line
+  w=$(new_world boot-prop-fail)
+  c1=$(git -C "$w/main" rev-parse HEAD)
+  add_sm_worktree "$w" sm "$c1"
+  mkdir -p "$w/sm/config/crew-harness"
+
+  out=$(run_bootstrap "$w")
+
+  fail_line=$(printf '%s\n' "$out" | grep '^SECONDMATE_SYNC: secondmate sm: skipped: config inheritance failed' || true)
+  [ -n "$fail_line" ] || fail "bootstrap did not surface config propagation failure (got: $out)"
+  [ -d "$w/sm/config/crew-harness" ] || fail "failed propagation removed the wrong path"
+  pass "B10 bootstrap sweep surfaces config propagation failures"
+}
+
 test_harness_resolution
 test_propagate_lib
 test_spawn_split_and_inherit
@@ -433,5 +455,6 @@ test_spawn_unverified_secondmate_harness_refused
 test_bootstrap_sweep_propagates_and_reconverges
 test_bootstrap_sweep_propagates_when_tracked_current
 test_bootstrap_sweep_no_inheritance_is_noop
+test_bootstrap_sweep_surfaces_config_propagation_failure
 
 echo "# all fm-secondmate-harness tests passed"

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -1,0 +1,437 @@
+#!/usr/bin/env bash
+# Tests for the secondmate-vs-crewmate harness split and the primary->secondmate
+# inheritable-config propagation.
+#
+# Two capabilities are under test:
+#   A) Harness split. config/secondmate-harness sets the harness the PRIMARY uses
+#      to launch SECONDMATE agents, independent of config/crew-harness (the
+#      crewmate harness). fm-harness.sh secondmate resolves the fallback chain
+#      config/secondmate-harness -> config/crew-harness -> own; an absent or
+#      "default" secondmate-harness behaves exactly as the crew harness did before
+#      this knob existed (full backward-compat). fm-spawn.sh resolves a secondmate
+#      launch through that mode, durably (every respawn re-resolves), while an
+#      explicit per-spawn harness arg still wins.
+#   B) Inheritance. The primary pushes a declared, extensible set of LOCAL
+#      (gitignored) config items - config/crew-harness today - down into each
+#      secondmate home's config/, so the secondmate's OWN crewmates inherit the
+#      primary's settings. It is primary-authoritative (re-pushed at secondmate
+#      spawn and on the bootstrap secondmate sweep) and config/secondmate-harness
+#      is deliberately NOT inherited (secondmates do not spawn secondmates).
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+# shellcheck source=bin/fm-ff-lib.sh
+. "$ROOT/bin/fm-ff-lib.sh"
+# shellcheck source=bin/fm-config-inherit-lib.sh
+. "$ROOT/bin/fm-config-inherit-lib.sh"
+
+BASE_PATH=${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin}
+fm_git_identity fmtest fmtest@example.com
+TMP_ROOT=$(fm_test_tmproot fm-secondmate-harness)
+
+# ===========================================================================
+# A) fm-harness.sh secondmate resolution + fallback (deterministic detect_own)
+# ===========================================================================
+# detect_own is pinned to claude via CLAUDECODE=1 so the "fall through to own"
+# cases are reproducible. Each row sets crew-harness / secondmate-harness in a
+# fresh config dir (a literal '-' means leave the file absent) and asserts BOTH
+# the secondmate resolution AND that crew resolution is unchanged (backward-compat).
+#   <label>^<crew-harness>^<secondmate-harness>^<expect-secondmate>^<expect-crew>
+test_harness_resolution() {
+  local label crew sm exp_sm exp_crew case_dir cfg got_sm got_crew n
+  n=0
+  while IFS='^' read -r label crew sm exp_sm exp_crew; do
+    [ -n "$label" ] || continue
+    n=$((n + 1))
+    case_dir="$TMP_ROOT/harness-$n"
+    cfg="$case_dir/config"
+    mkdir -p "$cfg"
+    [ "$crew" = "-" ] || printf '%s\n' "$crew" > "$cfg/crew-harness"
+    [ "$sm" = "-" ] || printf '%s\n' "$sm" > "$cfg/secondmate-harness"
+    got_sm=$(CLAUDECODE=1 FM_CONFIG_OVERRIDE="$cfg" "$ROOT/bin/fm-harness.sh" secondmate)
+    got_crew=$(CLAUDECODE=1 FM_CONFIG_OVERRIDE="$cfg" "$ROOT/bin/fm-harness.sh" crew)
+    [ "$got_sm" = "$exp_sm" ] || fail "$label: secondmate resolved '$got_sm', expected '$exp_sm'"
+    [ "$got_crew" = "$exp_crew" ] || fail "$label: crew resolved '$got_crew', expected '$exp_crew'"
+  done <<'ROWS'
+both absent -> own (backward-compat)^-^-^claude^claude
+crew set, secondmate absent -> crew (backward-compat)^codex^-^codex^codex
+crew set, secondmate set -> secondmate wins, crew untouched^codex^grok^grok^codex
+crew absent, secondmate set -> secondmate value, crew own^-^grok^grok^claude
+secondmate=default defers to crew^codex^default^codex^codex
+crew=default resolves to own, secondmate follows^default^-^claude^claude
+secondmate=default with crew absent -> own^-^default^claude^claude
+ROWS
+  pass "A1 fm-harness.sh secondmate resolves the fallback chain; crew mode unchanged"
+}
+
+# ===========================================================================
+# B) propagate_inheritable_config unit behavior
+# ===========================================================================
+test_propagate_lib() {
+  local d src dest m1 m2
+  d="$TMP_ROOT/prop-lib"
+  src="$d/src"
+  dest="$d/dest"
+  mkdir -p "$src" "$dest"
+
+  # 1. present source is copied
+  printf 'codex\n' > "$src/crew-harness"
+  propagate_inheritable_config "$src" "$dest" || fail "propagate returned non-zero"
+  [ "$(cat "$dest/crew-harness")" = codex ] || fail "crew-harness not propagated"
+
+  # 2. idempotent: an unchanged re-run does not churn the mtime
+  m1=$(date -r "$dest/crew-harness" +%s 2>/dev/null || stat -c %Y "$dest/crew-harness")
+  sleep 1
+  propagate_inheritable_config "$src" "$dest"
+  m2=$(date -r "$dest/crew-harness" +%s 2>/dev/null || stat -c %Y "$dest/crew-harness")
+  [ "$m1" = "$m2" ] || fail "idempotent re-run churned mtime ($m1 -> $m2)"
+
+  # 3. a changed source value converges downstream
+  printf 'claude\n' > "$src/crew-harness"
+  propagate_inheritable_config "$src" "$dest"
+  [ "$(cat "$dest/crew-harness")" = claude ] || fail "changed value did not converge"
+
+  # 4. removing the source mirrors absence downstream (primary-authoritative)
+  rm -f "$src/crew-harness"
+  propagate_inheritable_config "$src" "$dest"
+  [ -e "$dest/crew-harness" ] && fail "absence not mirrored downstream"
+
+  # 5. secondmate-harness is never inherited
+  printf 'grok\n' > "$src/secondmate-harness"
+  printf 'codex\n' > "$src/crew-harness"
+  rm -rf "$d/dest2"
+  mkdir -p "$d/dest2"
+  propagate_inheritable_config "$src" "$d/dest2"
+  [ -e "$d/dest2/secondmate-harness" ] && fail "secondmate-harness was inherited (must not be)"
+  [ "$(cat "$d/dest2/crew-harness")" = codex ] || fail "crew-harness not propagated alongside"
+
+  # 6. nothing to propagate -> destination dir is never created (a true no-op)
+  rm -rf "$d/src3" "$d/dest3"
+  mkdir -p "$d/src3"
+  propagate_inheritable_config "$d/src3" "$d/dest3/config"
+  [ -e "$d/dest3/config" ] && fail "empty-source propagation created a destination dir"
+
+  pass "B1 propagate_inheritable_config: copy, idempotence, convergence, absence-mirror, exclusion, no-op"
+}
+
+# ===========================================================================
+# B/A integration: a secondmate spawn resolves the secondmate harness and
+# propagates the crew harness into the home's config.
+# ===========================================================================
+
+# A tmux stub that accepts every subcommand and prints nothing, so no window
+# pre-exists and the spawn proceeds to write its meta. Echoes the fakebin dir.
+make_noop_tmux() {
+  local dir=$1 fakebin="$1/fakebin"
+  mkdir -p "$fakebin"
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+  printf '%s\n' "$fakebin"
+}
+
+# A minimal seeded secondmate home (validate_firstmate_home_for_spawn needs the
+# seed marker, AGENTS.md, bin/, and a charter to launch). config/ is intentionally
+# left absent so the spawn's propagation is what creates it.
+make_seeded_home() {
+  local home=$1 id=$2
+  mkdir -p "$home/bin" "$home/data"
+  printf '# Firstmate\n' > "$home/AGENTS.md"
+  printf '%s\n' "$id" > "$home/.fm-secondmate-home"
+  printf 'charter\n' > "$home/data/charter.md"
+}
+
+# spawn_secondmate <world> <id> <home> [explicit-harness]
+# Runs fm-spawn.sh in secondmate mode. FM_ROOT is the real repo (so fm-harness.sh
+# resolves), the primary config dir is <world>/home/config, and CLAUDECODE pins
+# detect_own. stderr is discarded (the local-HEAD ff sync harmlessly skips a
+# non-worktree home). Inspect <world>/home/state/<id>.meta and <home>/config after.
+spawn_secondmate() {
+  local world=$1 id=$2 home=$3 harness=${4:-} fakebin
+  mkdir -p "$world/home/state" "$world/home/data"
+  fakebin=$(make_noop_tmux "$world/tmux-$id")
+  # An empty harness must contribute zero args, not an empty positional; build the
+  # arg list explicitly so the optional harness is omitted cleanly.
+  local spawn_args=("$id" "$home")
+  [ -n "$harness" ] && spawn_args+=("$harness")
+  spawn_args+=(--secondmate)
+  PATH="$fakebin:$BASE_PATH" TMUX='' CLAUDECODE=1 \
+    FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$world/home" \
+    FM_STATE_OVERRIDE="$world/home/state" FM_DATA_OVERRIDE="$world/home/data" \
+    FM_PROJECTS_OVERRIDE="$world/home/projects" FM_CONFIG_OVERRIDE="$world/home/config" \
+    FM_SPAWN_NO_GUARD=1 \
+    "$ROOT/bin/fm-spawn.sh" "${spawn_args[@]}" >/dev/null 2>&1 || true
+}
+
+meta_harness() { grep '^harness=' "$1" 2>/dev/null | tail -1 | cut -d= -f2-; }
+
+# Split active: crew-harness=claude + secondmate-harness=codex. The secondmate
+# AGENT launches on codex; its own crewmates inherit claude; secondmate-harness
+# does not flow into the home.
+test_spawn_split_and_inherit() {
+  local w sm meta
+  w="$TMP_ROOT/spawn-split"
+  sm="$w/sm"
+  mkdir -p "$w/home/config"
+  printf 'claude\n' > "$w/home/config/crew-harness"
+  printf 'codex\n' > "$w/home/config/secondmate-harness"
+  make_seeded_home "$sm" sm
+
+  spawn_secondmate "$w" sm "$sm"
+
+  meta="$w/home/state/sm.meta"
+  [ -f "$meta" ] || fail "split: no meta written"
+  [ "$(meta_harness "$meta")" = codex ] \
+    || fail "split: secondmate launched on '$(meta_harness "$meta")', expected codex"
+  [ "$(cat "$sm/config/crew-harness" 2>/dev/null)" = claude ] \
+    || fail "split: home crew-harness not inherited as claude (got '$(cat "$sm/config/crew-harness" 2>/dev/null)')"
+  [ -e "$sm/config/secondmate-harness" ] \
+    && fail "split: secondmate-harness leaked into the secondmate home"
+  pass "B2 spawn: secondmate runs the secondmate harness; its crewmates inherit the crew harness"
+}
+
+# Backward-compat: secondmate-harness absent -> the secondmate launches on the
+# crew harness, exactly as before this knob existed, and that crew value is the
+# one inherited.
+test_spawn_backward_compat_crew_fallback() {
+  local w sm meta
+  w="$TMP_ROOT/spawn-compat"
+  sm="$w/sm"
+  mkdir -p "$w/home/config"
+  printf 'codex\n' > "$w/home/config/crew-harness"
+  make_seeded_home "$sm" sm
+
+  spawn_secondmate "$w" sm "$sm"
+
+  meta="$w/home/state/sm.meta"
+  [ "$(meta_harness "$meta")" = codex ] \
+    || fail "compat: secondmate launched on '$(meta_harness "$meta")', expected the crew harness codex"
+  [ "$(cat "$sm/config/crew-harness" 2>/dev/null)" = codex ] \
+    || fail "compat: home crew-harness not inherited as codex"
+  pass "B3 spawn: an absent secondmate-harness falls back to the crew harness (backward-compat)"
+}
+
+# Bare backward-compat: no config at all. The secondmate falls through to its own
+# harness (claude here), and with no inheritable file the home is left untouched -
+# no config/ side effects.
+test_spawn_bare_backward_compat() {
+  local w sm meta
+  w="$TMP_ROOT/spawn-bare"
+  sm="$w/sm"
+  make_seeded_home "$sm" sm
+
+  spawn_secondmate "$w" sm "$sm"
+
+  meta="$w/home/state/sm.meta"
+  [ "$(meta_harness "$meta")" = claude ] \
+    || fail "bare: secondmate launched on '$(meta_harness "$meta")', expected own harness claude"
+  [ -e "$sm/config/crew-harness" ] && fail "bare: an unset primary still created a home crew-harness"
+  pass "B4 spawn: no config at all -> own harness and no propagation side effects"
+}
+
+# An explicit per-spawn harness arg wins over config/secondmate-harness.
+test_spawn_explicit_harness_wins() {
+  local w sm meta
+  w="$TMP_ROOT/spawn-explicit"
+  sm="$w/sm"
+  mkdir -p "$w/home/config"
+  printf 'codex\n' > "$w/home/config/secondmate-harness"
+  make_seeded_home "$sm" sm
+
+  spawn_secondmate "$w" sm "$sm" claude
+
+  meta="$w/home/state/sm.meta"
+  [ "$(meta_harness "$meta")" = claude ] \
+    || fail "explicit: launched on '$(meta_harness "$meta")', expected explicit claude over config codex"
+  pass "B5 spawn: an explicit per-spawn harness arg overrides config/secondmate-harness"
+}
+
+# The unverified-adapter guard holds on the resolved secondmate path: an unknown
+# config/secondmate-harness aborts the spawn (no meta written) and names the source.
+test_spawn_unverified_secondmate_harness_refused() {
+  local w sm fakebin err rc
+  w="$TMP_ROOT/spawn-unverified"
+  sm="$w/sm"
+  mkdir -p "$w/home/config" "$w/home/state"
+  printf 'bogus\n' > "$w/home/config/secondmate-harness"
+  make_seeded_home "$sm" sm
+  fakebin=$(make_noop_tmux "$w/tmux")
+  err="$w/spawn.err"
+  rc=0
+  PATH="$fakebin:$BASE_PATH" TMUX='' CLAUDECODE=1 \
+    FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$w/home" \
+    FM_STATE_OVERRIDE="$w/home/state" FM_DATA_OVERRIDE="$w/home/data" \
+    FM_PROJECTS_OVERRIDE="$w/home/projects" FM_CONFIG_OVERRIDE="$w/home/config" \
+    FM_SPAWN_NO_GUARD=1 \
+    "$ROOT/bin/fm-spawn.sh" sm "$sm" --secondmate >/dev/null 2>"$err" || rc=$?
+
+  [ "$rc" -ne 0 ] || fail "unverified: spawn should have failed"
+  assert_contains "$(cat "$err")" "no launch template for harness 'bogus'" \
+    "unverified: error names the rejected harness"
+  assert_contains "$(cat "$err")" "config/secondmate-harness" \
+    "unverified: error names the secondmate-harness source"
+  [ -e "$w/home/state/sm.meta" ] && fail "unverified: a meta was written despite the abort"
+  pass "B6 spawn: an unverified resolved secondmate harness is refused (guard intact)"
+}
+
+# ===========================================================================
+# B integration: the bootstrap secondmate sweep propagates inheritable config and
+# keeps it converged on the primary (independent of the tracked-files ff status).
+# ===========================================================================
+
+# A PRIMARY firstmate repo on main with one commit + a home dir, mirroring the
+# real gitignore (config/crew-harness ignored, so a propagated value never dirties
+# the secondmate worktree on a later sweep). Echoes the world dir.
+new_world() {
+  local name=$1 w
+  w="$TMP_ROOT/$name"
+  mkdir -p "$w/home/state" "$w/home/data" "$w/home/config"
+  touch "$w/home/state/.last-watcher-beat"
+  git init -q -b main "$w/main"
+  printf 'projects/\nstate/\ndata/\n.no-mistakes/\nconfig/crew-harness\nconfig/secondmate-harness\n' \
+    > "$w/main/.gitignore"
+  printf 'v1\n' > "$w/main/AGENTS.md"
+  printf 'r1\n' > "$w/main/README.md"
+  mkdir -p "$w/main/bin"
+  printf 'echo a\n' > "$w/main/bin/tool.sh"
+  git -C "$w/main" add -A
+  git -C "$w/main" commit -qm c1
+  printf '%s\n' "$w"
+}
+
+# A live secondmate home as a DETACHED worktree of the primary at <commit>, with
+# its seed marker and a live kind=secondmate meta.
+add_sm_worktree() {
+  local w=$1 id=$2 commit=$3
+  git -C "$w/main" worktree add -q --detach "$w/$id" "$commit"
+  printf '%s\n' "$id" > "$w/$id/.fm-secondmate-home"
+  {
+    printf 'window=firstmate:fm-%s\n' "$id"
+    printf 'kind=secondmate\n'
+    printf 'home=%s/%s\n' "$w" "$id"
+  } > "$w/home/state/$id.meta"
+}
+
+make_fake_toolchain() {
+  local dir=$1 fakebin
+  fakebin="$dir/fakebin"
+  mkdir -p "$fakebin"
+  fm_fake_exit0 "$fakebin" tmux node gh-axi chrome-devtools-axi lavish-axi
+  cat > "$fakebin/gh" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  chmod +x "$fakebin/gh"
+  cat > "$fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+if [ "${1:-}" = get ] && [ "${2:-}" = --help ]; then
+  printf '%s\n' 'Usage: treehouse get [--lease]'
+fi
+exit 0
+SH
+  chmod +x "$fakebin/treehouse"
+  cat > "$fakebin/no-mistakes" <<'SH'
+#!/usr/bin/env bash
+if [ "${1:-}" = --version ]; then
+  printf '%s\n' 'no-mistakes version v1.31.2 (fake)'
+  exit 0
+fi
+exit 0
+SH
+  chmod +x "$fakebin/no-mistakes"
+  printf '%s\n' "$fakebin"
+}
+
+run_bootstrap() {
+  local w=$1 fakebin
+  fakebin=$(make_fake_toolchain "$w")
+  PATH="$fakebin:$BASE_PATH" FM_HOME="$w/home" FM_ROOT_OVERRIDE="$w/main" \
+    "$ROOT/bin/fm-bootstrap.sh" 2>/dev/null
+}
+
+# The sweep pushes the primary's crew-harness into a live home, re-converges it
+# when the primary changes it, and mirrors absence when the primary clears it -
+# all while never inheriting secondmate-harness.
+test_bootstrap_sweep_propagates_and_reconverges() {
+  local w c1
+  w=$(new_world boot-prop)
+  c1=$(git -C "$w/main" rev-parse HEAD)
+  add_sm_worktree "$w" sm "$c1"
+
+  # Initial push: primary crew-harness=codex, secondmate-harness=grok (must NOT flow).
+  printf 'codex\n' > "$w/home/config/crew-harness"
+  printf 'grok\n' > "$w/home/config/secondmate-harness"
+  run_bootstrap "$w" >/dev/null
+  [ "$(cat "$w/sm/config/crew-harness" 2>/dev/null)" = codex ] \
+    || fail "sweep: crew-harness not pushed into the live home"
+  [ -e "$w/sm/config/secondmate-harness" ] \
+    && fail "sweep: secondmate-harness was inherited (must not be)"
+
+  # Re-converge: primary changes crew-harness; the home follows on the next sweep.
+  printf 'claude\n' > "$w/home/config/crew-harness"
+  run_bootstrap "$w" >/dev/null
+  [ "$(cat "$w/sm/config/crew-harness" 2>/dev/null)" = claude ] \
+    || fail "sweep: home did not re-converge to the primary's new crew-harness"
+
+  # Mirror absence: primary clears crew-harness; the home's copy is removed.
+  rm -f "$w/home/config/crew-harness"
+  run_bootstrap "$w" >/dev/null
+  [ -e "$w/sm/config/crew-harness" ] \
+    && fail "sweep: home crew-harness not removed after the primary cleared it"
+  pass "B7 bootstrap sweep pushes, re-converges, and mirrors absence; never inherits secondmate-harness"
+}
+
+# Convergence is independent of the tracked-files fast-forward: a home already
+# current on tracked files still receives a config change.
+test_bootstrap_sweep_propagates_when_tracked_current() {
+  local w head
+  w=$(new_world boot-prop-current)
+  head=$(git -C "$w/main" rev-parse HEAD)
+  add_sm_worktree "$w" sm "$head"   # already on the primary's HEAD (ff is a no-op)
+
+  printf 'codex\n' > "$w/home/config/crew-harness"
+  run_bootstrap "$w" >/dev/null
+  [ "$(cat "$w/sm/config/crew-harness" 2>/dev/null)" = codex ] \
+    || fail "config did not propagate to a tracked-current home"
+  pass "B8 bootstrap sweep propagates config even when the home's tracked files are already current"
+}
+
+# Backward-compat: with no inheritable config set, the sweep is a no-op for the
+# home's config/ - exactly as before this feature - and ordinary sweep behavior
+# (fast-forward) is unaffected.
+test_bootstrap_sweep_no_inheritance_is_noop() {
+  local w c1
+  w=$(new_world boot-noop)
+  c1=$(git -C "$w/main" rev-parse HEAD)
+  add_sm_worktree "$w" sm "$c1"
+  # Advance the primary so the sweep has a real fast-forward to perform.
+  printf 'v2\n' > "$w/main/AGENTS.md"
+  git -C "$w/main" add -A
+  git -C "$w/main" commit -qm c2
+  local head
+  head=$(git -C "$w/main" rev-parse HEAD)
+
+  run_bootstrap "$w" >/dev/null
+
+  [ -e "$w/sm/config/crew-harness" ] && fail "no-inheritance sweep created a home crew-harness"
+  [ -e "$w/sm/config" ] && fail "no-inheritance sweep created a home config/ dir"
+  [ "$(git -C "$w/sm" rev-parse HEAD)" = "$head" ] \
+    || fail "no-inheritance sweep did not still fast-forward the tracked files"
+  pass "B9 bootstrap sweep with no inheritable config is a config no-op and still fast-forwards"
+}
+
+test_harness_resolution
+test_propagate_lib
+test_spawn_split_and_inherit
+test_spawn_backward_compat_crew_fallback
+test_spawn_bare_backward_compat
+test_spawn_explicit_harness_wins
+test_spawn_unverified_secondmate_harness_refused
+test_bootstrap_sweep_propagates_and_reconverges
+test_bootstrap_sweep_propagates_when_tracked_current
+test_bootstrap_sweep_no_inheritance_is_noop
+
+echo "# all fm-secondmate-harness tests passed"

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -69,7 +69,7 @@ ROWS
 # B) propagate_inheritable_config unit behavior
 # ===========================================================================
 test_propagate_lib() {
-  local d src dest m1 m2
+  local d src dest m1 m2 outside
   d="$TMP_ROOT/prop-lib"
   src="$d/src"
   dest="$d/dest"
@@ -92,10 +92,25 @@ test_propagate_lib() {
   propagate_inheritable_config "$src" "$dest"
   [ "$(cat "$dest/crew-harness")" = claude ] || fail "changed value did not converge"
 
+  outside="$d/outside-target"
+  rm -f "$dest/crew-harness" "$outside"
+  printf 'outside\n' > "$outside"
+  ln -s "$outside" "$dest/crew-harness"
+  printf 'pi\n' > "$src/crew-harness"
+  propagate_inheritable_config "$src" "$dest"
+  [ ! -L "$dest/crew-harness" ] || fail "destination symlink was not replaced"
+  [ "$(cat "$dest/crew-harness")" = pi ] || fail "destination symlink replacement has wrong content"
+  [ "$(cat "$outside")" = outside ] || fail "destination symlink target was overwritten"
+
   # 4. removing the source mirrors absence downstream (primary-authoritative)
   rm -f "$src/crew-harness"
   propagate_inheritable_config "$src" "$dest"
   [ -e "$dest/crew-harness" ] && fail "absence not mirrored downstream"
+
+  rm -f "$dest/crew-harness"
+  ln -s "$d/missing-target" "$dest/crew-harness"
+  propagate_inheritable_config "$src" "$dest"
+  [ -L "$dest/crew-harness" ] && fail "broken destination symlink not removed on absence mirror"
 
   mkdir -p "$dest/crew-harness"
   if propagate_inheritable_config "$src" "$dest"; then


### PR DESCRIPTION
## Intent

Add two related firstmate harness/config capabilities, fully backward-compatible.

(A) Secondmate-vs-crewmate harness split: let secondmates run on a different agent harness than crewmates. Add config/secondmate-harness (LOCAL, gitignored, like config/crew-harness) as the harness the PRIMARY uses to launch SECONDMATE agents. Add a 'secondmate' resolution mode to bin/fm-harness.sh implementing the fallback chain config/secondmate-harness -> config/crew-harness -> own; 'crew' mode is left behaviorally unchanged (refactored into resolve_crew() to share the fallback). bin/fm-spawn.sh resolves a --secondmate launch via 'secondmate' mode and a crewmate/scout launch via 'crew' mode. DELIBERATE design: the split is durable because every secondmate respawn (recovery, /updatefirstmate, restart) goes through fm-spawn's no-explicit-harness path and re-resolves from config - the per-task meta harness= is only for supervision, never for re-launch. An explicit per-spawn harness arg still wins for either kind, and the existing unverified-adapter guard (launch_template lookup) still aborts the spawn for an unknown harness on the secondmate path too.

(B) Inherit primary settings into secondmate homes (push, extensible): the primary firstmate pushes a DECLARED, EXTENSIBLE set of inheritable LOCAL config items into each secondmate home's config/, so a secondmate's OWN crewmates use the primary's settings. New bin/fm-config-inherit-lib.sh implements a generic mechanism over a single declared list (FM_INHERITABLE_CONFIG); EXACTLY ONE item is wired now by design: config/crew-harness. It is primary-authoritative (re-pushed on every convergence, mirroring absence when the primary clears a value) and idempotent (content-compare, no mtime churn). Propagation runs at secondmate spawn (fm-spawn) AND in the bootstrap secondmate sweep (fm-bootstrap secondmate_sync, iterating the validated FF_SEEN_HOMES). Because config/ is gitignored this is a separate copy from the tracked-files fast-forward, so it converges a home whether or not its tracked files advanced. config/secondmate-harness is the primary's own knob and is DELIBERATELY excluded from inheritance because secondmates never spawn secondmates. Net behavior once a captain sets primary crew-harness=codex + secondmate-harness=claude: secondmate AGENTS run on claude while ALL crewmates (primary's and secondmates' own) run on codex.

Constraints honored: no harness VALUES are committed (the code only READS config with safe fallbacks; config/crew-harness and config/secondmate-harness are the captain's local gitignored config set later). .gitignore now covers config/secondmate-harness. Docs updated: AGENTS.md (section 2 layout, section 3 bootstrap sweep, section 4 harness split + inheritance, section 7 spawn), the harness-adapters skill (new resolution order + crew/secondmate split), and docs/scripts.md. Tests: new tests/fm-secondmate-harness.test.sh covers secondmate resolution + fallback, spawn/respawn honoring config/secondmate-harness, config propagation on spawn and on the bootstrap sweep (with re-converge and absence-mirror), the unverified-adapter guard on the secondmate path, and backward-compat (absent secondmate-harness + no inheritance file behaves exactly as today). Full bash suite and shellcheck pass.

## What Changed

- Adds `config/secondmate-harness` resolution so primary firstmate launches secondmates through a separate harness fallback chain while preserving existing crew harness behavior.
- Adds inherited local config propagation for `config/crew-harness` into secondmate homes during spawn and bootstrap convergence, including stale-value removal and symlink-safe copying.
- Updates firstmate docs, skills, gitignore entries, and shell tests around secondmate harness resolution, propagation, fallback behavior, and unverified adapter rejection. Captain, the supplied pipeline passed after review autofixes.

## Risk Assessment

✅ Low: Captain, risk is low because the change is narrowly scoped to harness resolution and config propagation, with defensive copy behavior and coverage for the key spawn/bootstrap paths.

## Testing

The configured full bash suite had already passed as baseline; I reran the focused secondmate harness test, then manually exercised the end-to-end CLI path showing `crew=codex`, `secondmate=claude`, secondmate spawn meta with `harness=claude`, inherited `crew-harness=codex`, no inherited `secondmate-harness`, and bootstrap re-converging then removing inherited config. The worktree remained clean.

<details>
<summary>Evidence: Focused harness test log</summary>

```text
ok - A1 fm-harness.sh secondmate resolves the fallback chain; crew mode unchanged
ok - B1 propagate_inheritable_config: copy, idempotence, convergence, absence-mirror, exclusion, no-op
ok - B2 spawn: secondmate runs the secondmate harness; its crewmates inherit the crew harness
ok - B3 spawn: an absent secondmate-harness falls back to the crew harness (backward-compat)
ok - B4 spawn: no config at all -> own harness and no propagation side effects
ok - B5 spawn: an explicit per-spawn harness arg overrides config/secondmate-harness
ok - B6 spawn: an unverified resolved secondmate harness is refused (guard intact)
ok - B7 bootstrap sweep pushes, re-converges, and mirrors absence; never inherits secondmate-harness
ok - B8 bootstrap sweep propagates config even when the home's tracked files are already current
ok - B9 bootstrap sweep with no inheritable config is a config no-op and still fast-forwards
ok - B10 bootstrap sweep surfaces config propagation failures
# all fm-secondmate-harness tests passed
```
</details>
<details>
<summary>Evidence: End-to-end CLI transcript</summary>

```text
# secondmate harness split and inheritance E2E transcript
# repo: /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KWATP0Q04EN31G1BFDEM2X4J

## Operator config
$ printf 'codex
' > primary-home/config/crew-harness
$ printf 'claude
' > primary-home/config/secondmate-harness

## Harness resolution from the primary home
$ FM_CONFIG_OVERRIDE=primary-home/config CLAUDECODE=1 bin/fm-harness.sh crew
codex
$ FM_CONFIG_OVERRIDE=primary-home/config CLAUDECODE=1 bin/fm-harness.sh secondmate
claude

## Secondmate spawn uses secondmate-harness, then propagates only crew-harness
$ FM_HOME=primary-home FM_ROOT_OVERRIDE=spawn-root bin/fm-spawn.sh sm secondmate-home --secondmate
spawned sm harness=claude kind=secondmate mode=secondmate yolo=off window=firstmate:fm-sm worktree=/private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KWATP0Q04EN31G1BFDEM2X4J/manual-secondmate-harness/secondmate-home

$ sed -n '/^harness=/p;/^kind=/p;/^home=/p' primary-home/state/sm.meta
harness=claude
kind=secondmate
home=/private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KWATP0Q04EN31G1BFDEM2X4J/manual-secondmate-harness/secondmate-home
$ find secondmate-home/config -maxdepth 1 -type f -print -exec sed -n '1p' {} \;
secondmate-home/config/crew-harness
codex
$ test ! -e secondmate-home/config/secondmate-harness && echo not-inherited
not-inherited
$ FM_HOME=secondmate-home FM_CONFIG_OVERRIDE=secondmate-home/config CLAUDECODE=1 bin/fm-harness.sh crew
codex

## Bootstrap sweep re-converges inherited config and mirrors absence
$ FM_HOME=bootstrap-world/home FM_ROOT_OVERRIDE=bootstrap-world/main bin/fm-bootstrap.sh
CREW_HARNESS_OVERRIDE: codex
$ cat bootstrap-world/sm/config/crew-harness
codex
$ test ! -e bootstrap-world/sm/config/secondmate-harness && echo not-inherited
not-inherited
$ printf 'pi
' > bootstrap-world/home/config/crew-harness; fm-bootstrap.sh
CREW_HARNESS_OVERRIDE: pi
$ cat bootstrap-world/sm/config/crew-harness
pi
$ rm bootstrap-world/home/config/crew-harness; fm-bootstrap.sh
$ test ! -e bootstrap-world/sm/config/crew-harness && echo absence-mirrored
absence-mirrored
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed (3) ✅</summary>

- ⚠️ `bin/fm-config-inherit-lib.sh:48` - The inheritance copies only a literal `config/crew-harness` file. If the primary uses its default own harness and sets only `config/secondmate-harness`, the secondmate starts on the alternate harness but its own crewmates also default to that alternate harness, so the split only holds when the captain also writes a concrete `crew-harness` value. Decide whether to document that requirement or materialize the primary&#39;s effective crew harness downstream.
- ⚠️ `bin/fm-config-inherit-lib.sh:55` - Clearing the primary value is supposed to remove the downstream copy, but `rm -f` failures are swallowed and the function still returns success. If the destination cannot be removed, the stale harness remains silently; return nonzero when removal fails so callers can surface the drift.
- ⚠️ `bin/fm-bootstrap.sh:139` - Bootstrap ignores propagation failures for live secondmate homes. Spawn emits a warning for the same failure path, but bootstrap is the periodic convergence path, so this can leave inherited config stale with no `SECONDMATE_SYNC` or warning line.

🔧 Fix: Surface inherited config propagation failures
1 warning still open:
- ⚠️ `bin/fm-config-inherit-lib.sh:51` - `cp &#34;$src&#34; &#34;$dest&#34;` follows an existing destination symlink, so a stale or malicious `config/crew-harness` symlink inside a secondmate home can make spawn/bootstrap overwrite the symlink target outside the validated config directory. Remove/recreate symlinks or reject non-regular destination paths before copying.

🔧 Fix: Harden inherited config propagation
1 warning still open:
- ⚠️ `bin/fm-config-inherit-lib.sh:75` - Only a literal primary `config/crew-harness` is inherited. If the primary relies on the default/own crew harness and sets only `config/secondmate-harness`, the secondmate home receives no crew override, so that secondmate&#39;s own crewmates default to the secondmate harness instead of the primary&#39;s crewmate harness; either document the need for a concrete `crew-harness` value or materialize the primary&#39;s effective crew harness downstream.

🔧 Fix: Document literal harness inheritance requirement
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- `bash tests/fm-secondmate-harness.test.sh | tee /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KWATP0Q04EN31G1BFDEM2X4J/fm-secondmate-harness-test.log`
- <code>Manual evidence scenario under `/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KWATP0Q04EN31G1BFDEM2X4J/manual-secondmate-harness`: ran `bin/fm-harness.sh crew`, `bin/fm-harness.sh secondmate`, `bin/fm-spawn.sh sm &lt;secondmate-home&gt; --secondmate`, and repeated `bin/fm-bootstrap.sh` convergence checks; transcript saved to `secondmate-harness-e2e-transcript.txt`</code>
- `git status --short`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
