### PR TITLE
feat(spawn): per-task crewmate model selection (--model)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,7 @@ state/               volatile runtime signals; gitignored
   <id>.status        appended by crewmates: "<state>: <note>" wake-event lines, not current-state truth
   <id>.turn-ended    touched by turn-end hooks
   <id>.grok-turnend-token   firstmate-owned grok hook registry token for the task; removed by teardown
-  <id>.meta          written by fm-spawn: window=, worktree=, project=, harness=, kind=, mode=, yolo=; kind=secondmate also records home= and projects= (fm-pr-check appends pr= and verified pr_head= when available; fm-x-link appends x_request= and x_request_ts= for an X-mention-originated task, section 14)
+  <id>.meta          written by fm-spawn: window=, worktree=, project=, harness=, kind=, mode=, yolo=, model= (the per-task crewmate model, default when unset); kind=secondmate also records home= and projects= (fm-pr-check appends pr= and verified pr_head= when available; fm-x-link appends x_request= and x_request_ts= for an X-mention-originated task, section 14)
   <id>.check.sh      optional slow poll you write per task (e.g. merged-PR check)
   x-watch.check.sh   generated X-mode relay poll shim; present only when opted in (section 14)
   x-inbox/           generated X-mode pending mention payloads; fmx-respond drains it (section 14)
@@ -361,13 +361,24 @@ bin/fm-spawn.sh <id> projects/<repo> grok        # per-task harness override
 bin/fm-spawn.sh <id> projects/<repo> --scout     # scout task; records kind=scout in meta
 bin/fm-spawn.sh <id> --secondmate                 # launch a registered persistent secondmate in its home
 bin/fm-spawn.sh <id> <firstmate-home> --secondmate   # launch or recover an explicit secondmate home
+bin/fm-spawn.sh <id> projects/<repo> --model sonnet   # pick the crewmate model for this task
 bin/fm-spawn.sh <id1>=projects/<repo1> <id2>=projects/<repo2> [--scout]   # batch: one call, several tasks
 ```
 
 Dispatch several tasks in one call by passing `id=repo` pairs instead of a single `<id> <project>`; each pair is spawned through the same single-task path, a shared `--scout` applies to all, and the looping happens inside the script so you never hand-write a multi-task shell loop.
 If one pair fails, the rest still run and the batch exits non-zero.
 
-The script resolves the harness (`fm-harness.sh crew` for crewmate/scout tasks, `fm-harness.sh secondmate` for `kind=secondmate`; section 4), owns the verified launch templates, resolves the project's delivery mode (`fm-project-mode.sh`) for ship/scout tasks, and records `harness=`, `kind=`, `mode=`, and `yolo=` in the task's meta; a non-flag third argument containing whitespace is treated as a raw launch command (only for verifying new adapters).
+**Per-task model (`--model <name>`).**
+Pass `--model <name>` (values like `haiku`, `sonnet`, or `opus`, or any string the harness accepts) to choose the crewmate model for a spawn; a shared `--model` in a batch applies to every pair.
+It is recorded as `model=<name>` in the task meta (`model=default` when omitted), and omitting it reproduces today's launch exactly.
+Model selection is wired for the claude harness today (it threads `--model "<name>"` into the launch); the other adapters ignore it for now.
+Pick the tier by the work's difficulty, defaulting to the captain's standing instruction or `default` when unsure:
+
+- **Haiku** - trivial mechanical work: sweeps, file gathering, find/replace, rote renames.
+- **Sonnet** - straightforward edits, scout investigations, and integration/merge work.
+- **Opus** - complex, ambiguous, or multi-file work, and integrator tasks that must hold a lot in mind.
+
+The script resolves the harness (`fm-harness.sh crew` for crewmate/scout tasks, `fm-harness.sh secondmate` for `kind=secondmate`; section 4), owns the verified launch templates, resolves the project's delivery mode (`fm-project-mode.sh`) for ship/scout tasks, and records `harness=`, `kind=`, `mode=`, `yolo=`, and `model=` in the task's meta; a non-flag argument containing whitespace is treated as a raw launch command (only for verifying new adapters).
 For `kind=secondmate`, the same script launches in the registered or explicit firstmate home instead of running `treehouse get` for a project, records `home=` and `projects=`, and uses the charter brief as the launch prompt.
 
 For ship and scout tasks, the script creates the window (in your current tmux session, or a dedicated `firstmate` session when you are outside tmux), runs `treehouse get`, waits for the worktree subshell, asserts the resolved worktree is a genuine isolated worktree distinct from the primary checkout (aborting the spawn otherwise, to prevent the worktree tangle of section 8), installs the turn-end hook, records `state/<id>.meta`, and launches the agent with the brief.

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1,8 +1,13 @@
 #!/usr/bin/env bash
 # Spawn a direct report: a crewmate in a treehouse worktree, or a secondmate in
 # its isolated firstmate home.
-# Usage: fm-spawn.sh <task-id> <project-dir> [harness|launch-command] [--scout]
+# Usage: fm-spawn.sh <task-id> <project-dir> [harness|launch-command] [--model <name>] [--scout]
 #        fm-spawn.sh <task-id> [<firstmate-home>] [harness|launch-command] --secondmate
+#   --model <name> selects the crewmate model for this spawn (e.g. haiku|sonnet|opus,
+#   or any string the harness accepts). Currently wired for the claude harness only,
+#   where it threads `--model "<name>"` into the launch ahead of the prompt; other
+#   harnesses ignore it for now (others TODO). With no --model the launch is identical
+#   to before. Recorded as model=<name> in the task meta (model=default when unset).
 #   With no harness arg, the harness comes from fm-harness.sh: a crewmate/scout
 #   spawn resolves the CREW harness (config/crew-harness, falling back to firstmate's
 #   own); a --secondmate spawn resolves the SECONDMATE harness (config/secondmate-harness
@@ -36,7 +41,7 @@
 # Per-harness turn-end hooks are installed automatically; some live outside the worktree.
 # grok uses a firstmate-owned global hook under ${GROK_HOME:-$HOME/.grok}/hooks
 # plus a gitignored .fm-grok-turnend worktree pointer and a state token.
-# On success prints: spawned <id> harness=<name> kind=<ship|scout|secondmate> mode=<mode> yolo=<on|off> window=<session:window> worktree=<path>
+# On success prints: spawned <id> harness=<name> kind=<ship|scout|secondmate> mode=<mode> yolo=<on|off> model=<name|default> window=<session:window> worktree=<path>
 # mode/yolo are resolved per-project from data/projects.md for ship/scout tasks;
 # secondmate spawns record mode=secondmate, yolo=off, home=, and projects=.
 set -eu
@@ -57,14 +62,24 @@ SUB_HOME_MARKER=".fm-secondmate-home"
 # set by the batch loop below), so the guard runs once for the batch, not once per pair.
 [ -n "${FM_SPAWN_NO_GUARD:-}" ] || "$FM_ROOT/bin/fm-guard.sh" || true
 KIND=ship
+MODEL=
 POS=()
+want_model=
 for a in "$@"; do
+  if [ -n "$want_model" ]; then
+    MODEL=$a
+    want_model=
+    continue
+  fi
   case "$a" in
     --scout) KIND=scout ;;
     --secondmate) KIND=secondmate ;;
+    --model) want_model=1 ;;
+    --model=*) MODEL=${a#--model=} ;;
     *) POS+=("$a") ;;
   esac
 done
+[ -z "$want_model" ] || { echo "error: --model requires a value (e.g. --model sonnet)" >&2; exit 1; }
 
 # Batch dispatch (see header): when the first positional is an `id=repo` pair, treat every
 # positional as one and spawn each by re-execing this script in single-task mode. We use
@@ -76,6 +91,9 @@ idpart=${POS[0]:-}
 idpart=${idpart%%=*}
 if [ "${#POS[@]}" -gt 0 ] && [ "${POS[0]}" != "$idpart" ] && case "$idpart" in */*) false ;; *) true ;; esac; then
   rc=0
+  # A shared --model applies to every pair (passed through to each single-task re-exec).
+  model_args=()
+  [ -z "$MODEL" ] || model_args=(--model "$MODEL")
   for pair in "${POS[@]}"; do
     case "$pair" in
       *=*) : ;;
@@ -86,9 +104,9 @@ if [ "${#POS[@]}" -gt 0 ] && [ "${POS[0]}" != "$idpart" ] && case "$idpart" in *
       rc=2
       continue
     elif [ "$KIND" = scout ]; then
-      if FM_SPAWN_NO_GUARD=1 "$FM_ROOT/bin/fm-spawn.sh" "${pair%%=*}" "${pair#*=}" --scout; then :; else echo "batch: FAILED to spawn ${pair%%=*} (${pair#*=})" >&2; rc=1; fi
+      if FM_SPAWN_NO_GUARD=1 "$FM_ROOT/bin/fm-spawn.sh" "${pair%%=*}" "${pair#*=}" ${model_args[@]+"${model_args[@]}"} --scout; then :; else echo "batch: FAILED to spawn ${pair%%=*} (${pair#*=})" >&2; rc=1; fi
     else
-      if FM_SPAWN_NO_GUARD=1 "$FM_ROOT/bin/fm-spawn.sh" "${pair%%=*}" "${pair#*=}"; then :; else echo "batch: FAILED to spawn ${pair%%=*} (${pair#*=})" >&2; rc=1; fi
+      if FM_SPAWN_NO_GUARD=1 "$FM_ROOT/bin/fm-spawn.sh" "${pair%%=*}" "${pair#*=}" ${model_args[@]+"${model_args[@]}"}; then :; else echo "batch: FAILED to spawn ${pair%%=*} (${pair#*=})" >&2; rc=1; fi
     fi
   done
   exit "$rc"
@@ -136,7 +154,11 @@ launch_template() {
     # does NOT suppress the interactive ghost text (verified empirically), so the env
     # var is the correct control. The dim-aware composer reader in fm-tmux-lib.sh is
     # the defense-in-depth backstop for any pane this flag cannot reach.
-    claude) printf '%s' 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions "$(cat __BRIEF__)"' ;;
+    # __MODELFLAG__ is replaced below with `--model "<name>" ` when --model was passed,
+    # or with nothing otherwise (so the launch is byte-for-byte today's without --model).
+    # Model selection is wired only for claude here; the other adapters carry no
+    # __MODELFLAG__ placeholder, so they simply never receive a per-task model (others TODO).
+    claude) printf '%s' 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions __MODELFLAG__"$(cat __BRIEF__)"' ;;
     codex)
       if [ "$kind" = secondmate ]; then
         printf '%s' 'codex --dangerously-bypass-approvals-and-sandbox "$(cat __BRIEF__)"'
@@ -570,6 +592,7 @@ fi
   echo "kind=$KIND"
   echo "mode=$MODE"
   echo "yolo=$YOLO"
+  echo "model=${MODEL:-default}"
   if [ "$KIND" = secondmate ]; then
     echo "home=$PROJ_ABS"
     echo "projects=$SECONDMATE_PROJECTS"
@@ -579,6 +602,15 @@ fi
 sq_brief=$(shell_quote "$BRIEF")
 sq_turnend=$(shell_quote "$TURNEND")
 sq_piext=$(shell_quote "$STATE/$ID.pi-ext.ts")
+# Per-task model flag (claude only; see launch_template). Empty when --model was not
+# passed, so a no-model launch is identical to today's. A trailing space keeps the
+# prompt arg separated from the flag.
+if [ -n "$MODEL" ] && [ "$MODEL" != default ]; then
+  MODELFLAG="--model $(shell_quote "$MODEL") "
+else
+  MODELFLAG=
+fi
+LAUNCH=${LAUNCH//__MODELFLAG__/$MODELFLAG}
 LAUNCH=${LAUNCH//__BRIEF__/$sq_brief}
 LAUNCH=${LAUNCH//__TURNEND__/$sq_turnend}
 LAUNCH=${LAUNCH//__PIEXT__/$sq_piext}
@@ -590,4 +622,4 @@ tmux send-keys -t "$T" -l "$LAUNCH"
 sleep 0.3
 tmux send-keys -t "$T" Enter
 
-echo "spawned $ID harness=$HARNESS kind=$KIND mode=$MODE yolo=$YOLO window=$T worktree=$WT"
+echo "spawned $ID harness=$HARNESS kind=$KIND mode=$MODE yolo=$YOLO model=${MODEL:-default} window=$T worktree=$WT"


### PR DESCRIPTION
Closes #146.

Adds an optional `--model <name>` to `bin/fm-spawn.sh` so firstmate can pick the crewmate model per dispatch (e.g. Haiku for trivial work, Opus for hard work) instead of every crewmate inheriting the CLI default.

## Changes
- `--model <name>` / `--model=<name>` flag; errors if the value is missing; a shared `--model` in a batch applies to every pair (set -u-safe array forwarding).
- claude launch threads `--model "<name>"` ahead of the prompt; **no --model reproduces today's launch byte-for-byte**. Other harnesses record the choice but ignore it for now (TODO noted inline).
- Records `model=<name>` (`model=default` when unset) in `state/<id>.meta` and the `spawned` line.
- AGENTS.md documents the flag and the Haiku/Sonnet/Opus tier policy.

## Verification
`bash -n` clean; no-model launch confirmed byte-identical; value is shell-quoted (no injection); batch forwarding tested.