### PR TITLE
feat: add cmux terminal backend slice

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,7 +147,7 @@ Otherwise it prints one line per problem or capability fact; handle each:
   It prints only when `config/backlog-backend` is absent or set to `tasks-axi` and the compatibility probe accepts `tasks-axi --version` as 0.1.1 or newer.
   If the backend is not opted out and `tasks-axi` is missing or incompatible, bootstrap reports `MISSING: tasks-axi (install: npm install -g tasks-axi)` but still falls back to hand-editing and never blocks work.
   If `config/backlog-backend=manual`, bootstrap hand-edits and does not suggest installing `tasks-axi`.
-- `NUDGE_SECONDMATES: <window-targets...>` - the secondmate sweep fast-forwarded one or more *running* secondmate homes to firstmate's current version and their instructions actually changed; for each listed window, send a one-line re-read nudge with `bin/fm-send.sh <window-target> 'firstmate was updated to the latest - please re-read your AGENTS.md to pick up the new instructions.'` so that secondmate picks up its new instructions.
+- `NUDGE_SECONDMATES: <window-targets...>` - the secondmate sweep fast-forwarded one or more _running_ secondmate homes to firstmate's current version and their instructions actually changed; for each listed window, send a one-line re-read nudge with `bin/fm-send.sh <window-target> 'firstmate was updated to the latest - please re-read your AGENTS.md to pick up the new instructions.'` so that secondmate picks up its new instructions.
   This mirrors `/updatefirstmate`'s `nudge-secondmates:` report: it is a gentle steer, never an interruption, and the fast-forward already landed safely.
   A secondmate that was skipped, already current, or whose advance changed no instructions is not listed and must not be disturbed.
 - `FMX: X mode on ...` / `FMX: X mode off ...` - bootstrap confirmed or removed the local X-mode poll artifacts; follow section 14 for watcher cadence restart only when a running watcher needs the transition applied immediately.
@@ -190,11 +190,19 @@ Schema:
   "rules": [
     {
       "when": "<natural-language condition describing a kind of task>",
-      "use": { "harness": "<adapter>", "model": "<optional model>", "effort": "<low|medium|high|xhigh|max, optional>" },
+      "use": {
+        "harness": "<adapter>",
+        "model": "<optional model>",
+        "effort": "<low|medium|high|xhigh|max, optional>"
+      },
       "why": "<optional rationale that helps firstmate choose>"
     }
   ],
-  "default": { "harness": "<adapter>", "model": "<optional model>", "effort": "<optional effort>" }
+  "default": {
+    "harness": "<adapter>",
+    "model": "<optional model>",
+    "effort": "<optional effort>"
+  }
 }
 ```
 
@@ -437,14 +445,18 @@ bin/fm-spawn.sh <id> projects/<repo> codex       # per-task harness override
 bin/fm-spawn.sh <id> projects/<repo> grok        # per-task harness override
 bin/fm-spawn.sh <id> projects/<repo> --harness codex --model gpt-5.5 --effort high   # explicit profile axes
 bin/fm-spawn.sh <id> projects/<repo> --scout     # scout task; records kind=scout in meta
+bin/fm-spawn.sh <id> projects/<repo> --title '<project> · <doing>'   # cmux only: plain-English tab title, display-only
 bin/fm-spawn.sh <id> --secondmate                 # launch a registered persistent secondmate in its home
 bin/fm-spawn.sh <id> <firstmate-home> --secondmate   # launch or recover an explicit secondmate home
 bin/fm-spawn.sh <id1>=projects/<repo1> <id2>=projects/<repo2> [--scout]   # batch: one call, several tasks
 ```
 
+On the cmux backend, pass `--title` with a plain-English `<project> · <doing>` title on every dispatch so the captain reads worker tabs at a glance instead of decoding machine ids; it is display-only (docs/cmux-terminal-backend/spec.md) and does nothing on the tmux backend beyond being recorded in meta.
+
 Dispatch several tasks in one call by passing `id=repo` pairs instead of a single `<id> <project>`; each pair is spawned through the same single-task path, shared `--scout`, `--harness`, `--model`, and `--effort` flags apply to all, and the looping happens inside the script so you never hand-write a multi-task shell loop.
 If one pair fails, the rest still run and the batch exits non-zero.
 When `config/crew-dispatch.json` exists, include a shared `--harness` for every crewmate or scout batch after consulting the dispatch rules.
+`--title` is per-task, not shared: the batch form refuses it with a clear error, since a plain-English title only makes sense per dispatch.
 
 The script resolves the harness (`fm-harness.sh crew` for crewmate/scout tasks only when `config/crew-dispatch.json` is absent, `fm-harness.sh secondmate` for `kind=secondmate`; section 4), owns the verified launch templates, resolves the project's delivery mode (`fm-project-mode.sh`) for ship/scout tasks, and records `harness=`, `model=`, `effort=`, `kind=`, `mode=`, and `yolo=` in the task's meta; a non-flag third argument containing whitespace is treated as a raw launch command (only for verifying new adapters).
 When `config/crew-dispatch.json` exists, the script refuses crewmate or scout launches without an explicit harness because firstmate must have already resolved the profile choice at intake.
@@ -498,7 +510,7 @@ Use chat for yes/no decisions; use lavish-axi when there are multiple findings o
 Judge a validating crewmate by the run's step status, never by whether its shell is still running.
 Read its current state with `bin/fm-crew-state.sh <id>`: a deterministic, token-tight one-line read that takes the matching no-mistakes run-step as the source of truth and reconciles it against the crewmate's `state/<id>.status` log.
 Because the run-step is authoritative before pane liveness, a crewmate whose window closed after or during validation can still report `done` or `working` from its run; a missing pane becomes `unknown` only when no matching run exists.
-That log is an append-only wake-*event* log, not a current-state field, and it goes stale the moment a resolved gate lets the run resume: after you answer a `needs-decision`/`blocked` and the crewmate silently resumes (responds to the gate, the pipeline fixes, it re-validates), the log's last line still reads `needs-decision`/`blocked` while the run-step has moved on.
+That log is an append-only wake-_event_ log, not a current-state field, and it goes stale the moment a resolved gate lets the run resume: after you answer a `needs-decision`/`blocked` and the crewmate silently resumes (responds to the gate, the pipeline fixes, it re-validates), the log's last line still reads `needs-decision`/`blocked` while the run-step has moved on.
 So never infer current state from a `tail` of that log; `bin/fm-crew-state.sh` reports the live run-step state and explicitly flags the stale log line superseded, where a raw `tail` would mislead you into re-escalating settled work.
 The fields below name the run-step states and outcomes it reads from `no-mistakes axi status`; run that command directly when you want the full gate findings.
 
@@ -571,7 +583,7 @@ The no-verb path - a `signal` whose status carries no captain-relevant verb (a `
 The watcher reads that evidence with `bin/fm-crew-state.sh` (run-step first, then pane), so a finish that wrote no `done:` status - for example one reported only through interactive pane menus - is no longer swallowed.
 A `heartbeat` with no captain-relevant change is likewise absorbed.
 Absorbed wakes are advanced past their suppression marker and logged to `state/.watch-triage.log` while the watcher keeps blocking - no queue entry, no exit, no LLM turn.
-It exits with one reason line on an *actionable* wake: a `signal` carrying a captain-relevant verb (`needs-decision:`/`blocked:`/`failed:`/`done:`/`PR ready`/`checks green`/`ready in branch`/`merged`); a no-verb `signal` whose crewmate is NOT provably working (it stopped its turn with no running pipeline and no busy pane, so it may be done, waiting on a decision, or wedged); any `check`; a terminal `stale`; a non-terminal `stale` whose crewmate is not provably working (surfaced at once, never left to wait out the timer); a provably-working non-terminal `stale` that stays idle past the wedge threshold (`FM_STALE_ESCALATE_SECS`, default 240s); or the heartbeat fleet-scan's fail-safe backstop catching a captain-relevant status the per-wake path missed.
+It exits with one reason line on an _actionable_ wake: a `signal` carrying a captain-relevant verb (`needs-decision:`/`blocked:`/`failed:`/`done:`/`PR ready`/`checks green`/`ready in branch`/`merged`); a no-verb `signal` whose crewmate is NOT provably working (it stopped its turn with no running pipeline and no busy pane, so it may be done, waiting on a decision, or wedged); any `check`; a terminal `stale`; a non-terminal `stale` whose crewmate is not provably working (surfaced at once, never left to wait out the timer); a provably-working non-terminal `stale` that stays idle past the wedge threshold (`FM_STALE_ESCALATE_SECS`, default 240s); or the heartbeat fleet-scan's fail-safe backstop catching a captain-relevant status the per-wake path missed.
 Only an actionable wake is written to the durable queue at `state/.wake-queue` - before advancing suppression markers such as `.seen-*`, `.stale-*`, `.last-check`, or `.last-heartbeat` - and only an actionable wake ends the background task, so you re-arm exactly once per actionable event instead of once per wake.
 That is what eliminates the quiet-stretch churn without swallowing a finish: during a long crew validation the run is actively running, so the crewmate's `turn-ended`/`working:`/non-terminal-stale wakes (and no-change heartbeats) are absorbed in bash, the liveness beacon (`state/.last-watcher-beat`) stays fresh the whole time so `fm-guard.sh` never false-alarms, and your LLM is woken only when something genuinely needs you - including the moment that crewmate stops with no running pipeline, which now surfaces immediately.
 The classifier lives in `bin/fm-classify-lib.sh` and is shared: the captain-relevant verb set and status-scan primitives back both this always-on watcher and the away-mode daemon, so the overlapping policy cannot drift; the provably-working predicate (`crew_is_provably_working`, reusing `bin/fm-crew-state.sh`) lives in that same library and runs only on the watcher's no-verb path, never on every wake, so the per-wake triage stays cheap.
@@ -613,7 +625,7 @@ On wake, in order of cheapness:
 
 1. Read the reason line and drain queued wake records with `bin/fm-wake-drain.sh`.
 2. `signal:` read the listed status files first; a wake lists every signal that landed within the coalescing grace window (e.g. a status write plus the same turn's turn-end marker), and each is ~30 tokens and usually sufficient.
-   A status line is the wake *event*, not the crewmate's current state; when you need the live state - especially to confirm a `needs-decision`/`blocked` is still real and not already resolved-and-resumed - read it with `bin/fm-crew-state.sh <id>`, which reconciles the authoritative run-step over the possibly-stale log line, and never `tail` the status log as the current-state source.
+   A status line is the wake _event_, not the crewmate's current state; when you need the live state - especially to confirm a `needs-decision`/`blocked` is still real and not already resolved-and-resumed - read it with `bin/fm-crew-state.sh <id>`, which reconciles the authoritative run-step over the possibly-stale log line, and never `tail` the status log as the current-state source.
 3. `stale:` the crewmate stopped without reporting; peek the pane (`bin/fm-peek.sh <window>`) to diagnose.
    If the pane is waiting, looping, confused, or unresponsive, load `stuck-crewmate-recovery`.
 4. `check:` a per-task poll fired (usually a merge, or X mode when enabled); act on it.
@@ -708,12 +720,15 @@ Update it on every dispatch, completion, and decision.
 
 ```markdown
 ## In flight
+
 - [ ] <id> - <one line> (repo: <name>, since <date>)
 
 ## Queued
+
 - [ ] <id> - <one line> (repo: <name>) blocked-by: <id> - <reason>
 
 ## Done
+
 - [x] <id> - <one line> - <https://github.com/owner/repo/pull/number> (merged <date>)
 - [x] <id> - <one line> - local main (merged <date>)
 - [x] <id> - <one line> - data/<id>/report.md (reported <date>)

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -208,7 +208,7 @@ When you believe it is complete, append \`done: {summary}\` to the status file a
 Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
 
 You drive no-mistakes by responding to its gates, not by implementing fixes.
-Follow no-mistakes' own guidance for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.
+Follow no-mistakes guidance for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.
 Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.
 
 Two firstmate-specific rules layer on top of that guidance:

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -42,8 +42,8 @@ FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 
-# shellcheck source=bin/fm-tmux-lib.sh
-. "$SCRIPT_DIR/fm-tmux-lib.sh"
+# shellcheck source=bin/fm-terminal-lib.sh
+. "$SCRIPT_DIR/fm-terminal-lib.sh"
 
 ID=${1:-}
 [ -n "$ID" ] || { echo "usage: fm-crew-state.sh <id>" >&2; exit 2; }
@@ -72,6 +72,8 @@ meta_value() {  # <key>
 
 WT=$(meta_value worktree)
 WIN=$(meta_value window)
+BACKEND=$(meta_value terminal_backend)
+[ -n "$BACKEND" ] || BACKEND=tmux
 KIND=$(meta_value kind)
 [ -n "$KIND" ] || KIND=ship
 
@@ -119,7 +121,10 @@ LOG_VERB=$(log_verb_of "$LOG_LINE")
 # shell - so a finished crew whose window has closed still reports its run-step
 # state (e.g. done) instead of being masked as unknown.
 pane_readable() {  # <target>
-  tmux display-message -p -t "$1" '#{pane_id}' >/dev/null 2>&1
+  case "$BACKEND" in
+    cmux) fm_terminal_read "fm-$ID" 1 >/dev/null 2>&1 ;;
+    *) tmux display-message -p -t "$1" '#{pane_id}' >/dev/null 2>&1 ;;
+  esac
 }
 
 # --- no-mistakes run lookup (authoritative when a run matches this branch) --
@@ -350,13 +355,32 @@ fi
 # liveness, so a finished-but-pane-closed crew never reaches here. Down here there
 # is no run to consult, so a dead/unreadable window means the crew is gone: report
 # unknown rather than trusting a possibly-stale status log as the current state.
-[ -n "$WIN" ] || emit unknown none "no window recorded"
-pane_readable "$WIN" || emit unknown none "window gone: $WIN"
+if [ "$BACKEND" = cmux ]; then
+  TARGET="fm-$ID"
+else
+  [ -n "$WIN" ] || emit unknown none "no window recorded"
+  TARGET="$WIN"
+fi
+pane_readable "$TARGET" || emit unknown none "terminal gone: $TARGET"
 
 # Secondmates idle on their own watcher (idle pane = healthy), so the busy
 # signature is not meaningful for them; read their state from the status log only.
-if [ "$KIND" != secondmate ] && fm_pane_is_busy "$WIN"; then
-  emit working pane "harness busy"
+if [ "$KIND" != secondmate ]; then
+  if [ "$BACKEND" = cmux ]; then
+    fm_terminal_busy "fm-$ID" && emit working pane "harness busy"
+    SCREEN_TAIL=$(fm_terminal_read "fm-$ID" 80 2>/dev/null || true)
+    if printf '%s\n' "$SCREEN_TAIL" | grep -qiE '(^|[^[:alpha:]])(failed:|FAILED:)'; then
+      emit failed pane "failure marker in terminal"
+    fi
+    if printf '%s\n' "$SCREEN_TAIL" | grep -qiE '(^|[^[:alpha:]])(needs-decision:|NEEDS_DECISION:)'; then
+      emit parked pane "needs-decision marker in terminal"
+    fi
+    if printf '%s\n' "$SCREEN_TAIL" | grep -qiE '(^|[^[:alpha:]])(done:|ready in branch|checks green)'; then
+      emit "done" pane "done marker in terminal"
+    fi
+  elif fm_pane_is_busy "$WIN"; then
+    emit working pane "harness busy"
+  fi
 fi
 
 if [ -n "$LOG_VERB" ]; then

--- a/bin/fm-peek.sh
+++ b/bin/fm-peek.sh
@@ -1,35 +1,20 @@
 #!/usr/bin/env bash
-# Print the tail of a crewmate pane (bounded, for cheap diagnosis).
-# Usage: fm-peek.sh <window> [lines=40]
-#   <window> may be a bare firstmate window name (fm-xyz), resolved through
-#   this home's state/<id>.meta, or explicit session:window.
+# Print the tail of a crewmate terminal (bounded, for cheap diagnosis).
+# Usage: fm-peek.sh <target> [lines=40]
+#   <target> may be a bare firstmate target (fm-xyz), resolved through this
+#   home's state/<id>.meta, or explicit session:window for tmux.
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
+
+# shellcheck source=bin/fm-terminal-lib.sh
+. "$SCRIPT_DIR/fm-terminal-lib.sh"
 
 "$SCRIPT_DIR/fm-guard.sh" || true
 
-resolve() {
-  case "$1" in
-    *:*) echo "$1" ;;
-    fm-*)
-      meta="$STATE/${1#fm-}.meta"
-      if [ ! -f "$meta" ]; then
-        echo "error: no metadata for $1 in $STATE; pass session:window to target a window outside this firstmate home" >&2
-        exit 1
-      fi
-      window=$(grep '^window=' "$meta" 2>/dev/null | tail -1 | cut -d= -f2- || true)
-      [ -n "$window" ] || { echo "error: no window recorded in $meta" >&2; exit 1; }
-      echo "$window"
-      ;;
-    *) tmux list-windows -a -F '#{session_name}:#{window_name}' | grep -m1 ":$1\$" \
-         || { echo "error: no window named $1" >&2; exit 1; } ;;
-  esac
-}
-
-T=$(resolve "$1")
 N=${2:-40}
-tmux capture-pane -p -t "$T" -S -"$N"
+fm_terminal_read "$1" "$N"

--- a/bin/fm-send.sh
+++ b/bin/fm-send.sh
@@ -34,33 +34,20 @@ FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 
-# shellcheck source=bin/fm-tmux-lib.sh
-. "$SCRIPT_DIR/fm-tmux-lib.sh"
+# shellcheck source=bin/fm-terminal-lib.sh
+. "$SCRIPT_DIR/fm-terminal-lib.sh"
 # shellcheck source=bin/fm-marker-lib.sh
 . "$SCRIPT_DIR/fm-marker-lib.sh"
 
 "$SCRIPT_DIR/fm-guard.sh" || true
 
-resolve() {
-  case "$1" in
-    *:*) echo "$1" ;;
-    fm-*)
-      meta="$STATE/${1#fm-}.meta"
-      if [ ! -f "$meta" ]; then
-        echo "error: no metadata for $1 in $STATE; pass session:window to target a window outside this firstmate home" >&2
-        exit 1
-      fi
-      window=$(grep '^window=' "$meta" 2>/dev/null | tail -1 | cut -d= -f2- || true)
-      [ -n "$window" ] || { echo "error: no window recorded in $meta" >&2; exit 1; }
-      echo "$window"
-      ;;
-    *) tmux list-windows -a -F '#{session_name}:#{window_name}' | grep -m1 ":$1\$" \
-         || { echo "error: no window named $1" >&2; exit 1; } ;;
-  esac
-}
-
 RAW_TARGET=$1
-T=$(resolve "$1")
+BACKEND=$(fm_terminal_target_backend "$RAW_TARGET")
+if [ "$BACKEND" = tmux ]; then
+  T=$(fm_terminal_resolve_tmux "$RAW_TARGET")
+else
+  T=$RAW_TARGET
+fi
 shift
 
 # Mark a from-firstmate -> secondmate request. Only a bare `fm-<id>` target,
@@ -93,7 +80,7 @@ case "$RAW_TARGET" in
 esac
 
 if [ "${1:-}" = "--key" ]; then
-  tmux send-keys -t "$T" "$2"
+  fm_terminal_send_key "$RAW_TARGET" "$2"
 else
   # Slash commands open a completion popup in some TUIs (verified on codex);
   # submitting too fast selects nothing, so give the popup time to settle before
@@ -112,19 +99,26 @@ else
   esac
   retries=${FM_SEND_RETRIES:-3}
   sleep_s=${FM_SEND_SLEEP:-0.4}
-  # Type once, submit, verify. Lenient: only a positively-confirmed swallow
-  # (text still in the composer) is an error; an unreadable pane is assumed sent.
-  verdict=$(fm_tmux_submit_core "$T" "$MARK_PREFIX$*" "$retries" "$sleep_s" "$settle")
-  case "$verdict" in
-    pending)
-      echo "error: text not submitted to $T (Enter swallowed; text left in composer)" >&2
-      exit 1
-      ;;
-    send-failed)
-      echo "error: text not sent to $T (tmux send-keys failed)" >&2
-      exit 1
-      ;;
-  esac
+  if [ "$BACKEND" = cmux ]; then
+    ws=$(fm_terminal_cmux_workspace "$RAW_TARGET")
+    surface=$(fm_terminal_cmux_surface "$RAW_TARGET")
+    cmux send --workspace "$ws" --surface "$surface" "$MARK_PREFIX$*\n" \
+      || { echo "error: text not sent to $RAW_TARGET (cmux send failed)" >&2; exit 1; }
+  else
+    # Type once, submit, verify. Lenient: only a positively-confirmed swallow
+    # (text still in the composer) is an error; an unreadable pane is assumed sent.
+    verdict=$(fm_tmux_submit_core "$T" "$MARK_PREFIX$*" "$retries" "$sleep_s" "$settle")
+    case "$verdict" in
+      pending)
+        echo "error: text not submitted to $T (Enter swallowed; text left in composer)" >&2
+        exit 1
+        ;;
+      send-failed)
+        echo "error: text not sent to $T (tmux send-keys failed)" >&2
+        exit 1
+        ;;
+    esac
+  fi
   # Submit landed (verdict was not pending/send-failed). The cleared composer only
   # proves the text was submitted; the harness still needs a beat to spin up the
   # turn before its busy footer shows. Pause so an immediate peek catches the

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -141,9 +141,9 @@ if [ "${#POS[@]}" -gt 0 ] && [ "${POS[0]}" != "$idpart" ] && case "$idpart" in *
       rc=2
       continue
     elif [ "$KIND" = scout ]; then
-      if FM_SPAWN_NO_GUARD=1 "$FM_ROOT/bin/fm-spawn.sh" "${pair%%=*}" "${pair#*=}" "${shared_args[@]}" --scout; then :; else echo "batch: FAILED to spawn ${pair%%=*} (${pair#*=})" >&2; rc=1; fi
+      if FM_SPAWN_NO_GUARD=1 "$FM_ROOT/bin/fm-spawn.sh" "${pair%%=*}" "${pair#*=}" ${shared_args[@]+"${shared_args[@]}"} --scout; then :; else echo "batch: FAILED to spawn ${pair%%=*} (${pair#*=})" >&2; rc=1; fi
     else
-      if FM_SPAWN_NO_GUARD=1 "$FM_ROOT/bin/fm-spawn.sh" "${pair%%=*}" "${pair#*=}" "${shared_args[@]}"; then :; else echo "batch: FAILED to spawn ${pair%%=*} (${pair#*=})" >&2; rc=1; fi
+      if FM_SPAWN_NO_GUARD=1 "$FM_ROOT/bin/fm-spawn.sh" "${pair%%=*}" "${pair#*=}" ${shared_args[@]+"${shared_args[@]}"}; then :; else echo "batch: FAILED to spawn ${pair%%=*} (${pair#*=})" >&2; rc=1; fi
     fi
   done
   exit "$rc"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -498,7 +498,10 @@ spawn_cmux_and_exit() {
   cmux ping >/dev/null 2>&1 || { echo "error: terminal backend is cmux but cmux is not reachable" >&2; exit 1; }
   command -v python3 >/dev/null 2>&1 || { echo "error: cmux backend needs python3 to parse cmux identify output" >&2; exit 1; }
 
-  local identify caller_ws caller_surface lease_out cmux_out surface pane task_title
+  local identify caller_ws caller_surface lease_out cmux_out surface pane task_title layout
+  # Resolve the layout policy up front so an invalid config/cmux-layout fails fast,
+  # before any treehouse lease or cmux surface is created.
+  layout=$(fm_terminal_cmux_layout) || exit 1
   identify=$(cmux identify --json 2>/dev/null) || { echo "error: cmux identify failed; run firstmate from inside cmux or set terminal-backend=tmux" >&2; exit 1; }
   caller_ws=$(printf '%s\n' "$identify" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("caller",{}).get("workspace_ref", ""))')
   caller_surface=$(printf '%s\n' "$identify" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("caller",{}).get("surface_ref", ""))')
@@ -523,19 +526,14 @@ spawn_cmux_and_exit() {
   fi
 
   task_title="fm-$ID"
-  if [ -n "$caller_surface" ]; then
-    cmux_out=$(cmux new-split right --workspace "$caller_ws" --surface "$caller_surface" --focus false 2>&1) || {
-      echo "error: cmux split failed after leasing worktree $WT: $cmux_out" >&2
-      ( cd "$PROJ_ABS" && treehouse return --force "$WT" ) >/dev/null 2>&1 || true
-      exit 1
-    }
-  else
-    cmux_out=$(cmux new-pane --type terminal --direction right --workspace "$caller_ws" --focus false 2>&1) || {
-      echo "error: cmux pane failed after leasing worktree $WT: $cmux_out" >&2
-      ( cd "$PROJ_ABS" && treehouse return --force "$WT" ) >/dev/null 2>&1 || true
-      exit 1
-    }
-  fi
+  # Place the worker per the layout policy: visible splits for 1-3 workers, tab
+  # overflow for the 4th+ under auto/hybrid; explicit splits/tabs honored. Never
+  # steals focus. The first worker always opens a visible split.
+  cmux_out=$(fm_terminal_cmux_place_worker "$caller_ws" "$caller_surface" "$layout" "$ID") || {
+    echo "error: cmux worker placement failed after leasing worktree $WT: $cmux_out" >&2
+    ( cd "$PROJ_ABS" && treehouse return --force "$WT" ) >/dev/null 2>&1 || true
+    exit 1
+  }
   surface=$(printf '%s\n' "$cmux_out" | grep -o 'surface:[0-9][0-9]*' | tail -1 || true)
   if [ -z "$surface" ]; then
     echo "error: cmux did not report a surface after leasing worktree $WT: $cmux_out" >&2

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -504,7 +504,7 @@ spawn_cmux_and_exit() {
   cmux ping >/dev/null 2>&1 || { echo "error: terminal backend is cmux but cmux is not reachable" >&2; exit 1; }
   command -v python3 >/dev/null 2>&1 || { echo "error: cmux backend needs python3 to parse cmux identify output" >&2; exit 1; }
 
-  local identify caller_ws caller_surface lease_out cmux_out surface pane task_title layout
+  local identify caller_ws caller_surface lease_out cmux_out surface worker_ws pane task_title layout
   # Resolve the layout policy up front so an invalid config/cmux-layout fails fast,
   # before any treehouse lease or cmux surface is created.
   layout=$(fm_terminal_cmux_layout) || exit 1
@@ -536,9 +536,10 @@ spawn_cmux_and_exit() {
   fi
 
   task_title="fm-$ID"
-  # Place the worker per the layout policy: visible splits for 1-3 workers, tab
-  # overflow for the 4th+ under auto/hybrid; explicit splits/tabs honored. Never
-  # steals focus. The first worker always opens a visible split.
+  # Place the worker per the layout policy: under auto, tile a 2-row grid to the
+  # right of firstmate (2x2 for the default capacity) and overflow to a NEW cmux
+  # window once the grid is full; explicit splits/tabs/hybrid honored. Never steals
+  # focus. The first worker always opens a visible split off firstmate.
   cmux_out=$(fm_terminal_cmux_place_worker "$caller_ws" "$caller_surface" "$layout" "$ID") || {
     echo "error: cmux worker placement failed for $WT: $cmux_out" >&2
     [ "$KIND" = secondmate ] || ( cd "$PROJ_ABS" && treehouse return --force "$WT" ) >/dev/null 2>&1 || true
@@ -550,7 +551,14 @@ spawn_cmux_and_exit() {
     [ "$KIND" = secondmate ] || ( cd "$PROJ_ABS" && treehouse return --force "$WT" ) >/dev/null 2>&1 || true
     exit 1
   fi
-  pane=$(for p in $(cmux list-panes --workspace "$caller_ws" 2>/dev/null | grep -o 'pane:[0-9][0-9]*'); do cmux list-pane-surfaces --workspace "$caller_ws" --pane "$p" 2>/dev/null | grep -q "${surface}" && { echo "$p"; break; }; done)
+  # The worker's workspace is firstmate's own for a grid/split/tab placement, but a
+  # NEW workspace when auto overflowed to a new window - the placement echoes it in
+  # that case. Capture it (falling back to the caller workspace) and use it for the
+  # pane lookup, meta, rename, and launch send so a new-window worker is addressed
+  # in its own window rather than firstmate's.
+  worker_ws=$(printf '%s\n' "$cmux_out" | grep -o 'workspace:[0-9][0-9]*' | tail -1 || true)
+  [ -n "$worker_ws" ] || worker_ws=$caller_ws
+  pane=$(for p in $(cmux list-panes --workspace "$worker_ws" 2>/dev/null | grep -o 'pane:[0-9][0-9]*'); do cmux list-pane-surfaces --workspace "$worker_ws" --pane "$p" 2>/dev/null | grep -q "${surface}" && { echo "$p"; break; }; done)
 
   TASK_TMP="/tmp/fm-$ID"
   mkdir -p "$TASK_TMP/gotmp" "$STATE"
@@ -603,7 +611,7 @@ EOF
 
   {
     echo "terminal_backend=cmux"
-    echo "workspace=$caller_ws"
+    echo "workspace=$worker_ws"
     [ -n "$pane" ] && echo "pane=$pane"
     echo "surface=$surface"
     echo "harness=$HARNESS"
@@ -627,15 +635,15 @@ EOF
   } > "$STATE/$ID.meta"
 
   launch_line="cd $(shell_quote "$WT") && export GOTMPDIR=$(shell_quote "$TASK_TMP/gotmp") && $LAUNCH"
-  cmux rename-tab --workspace "$caller_ws" --surface "$surface" "$task_title" >/dev/null 2>&1 || true
-  cmux send --workspace "$caller_ws" --surface "$surface" "$launch_line\n" || {
-    echo "error: cmux launch send failed; workspace=$caller_ws surface=$surface path=$WT" >&2
+  cmux rename-tab --workspace "$worker_ws" --surface "$surface" "$task_title" >/dev/null 2>&1 || true
+  cmux send --workspace "$worker_ws" --surface "$surface" "$launch_line\n" || {
+    echo "error: cmux launch send failed; workspace=$worker_ws surface=$surface path=$WT" >&2
     exit 1
   }
   if [ "$KIND" = secondmate ]; then
-    echo "spawned $ID harness=$HARNESS kind=$KIND mode=$MODE yolo=$YOLO terminal=cmux workspace=$caller_ws surface=$surface home=$PROJ_ABS"
+    echo "spawned $ID harness=$HARNESS kind=$KIND mode=$MODE yolo=$YOLO terminal=cmux workspace=$worker_ws surface=$surface home=$PROJ_ABS"
   else
-    echo "spawned $ID harness=$HARNESS kind=$KIND mode=$MODE yolo=$YOLO terminal=cmux workspace=$caller_ws surface=$surface worktree=$WT"
+    echo "spawned $ID harness=$HARNESS kind=$KIND mode=$MODE yolo=$YOLO terminal=cmux workspace=$worker_ws surface=$surface worktree=$WT"
   fi
   exit 0
 }

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -64,6 +64,8 @@ SUB_HOME_MARKER=".fm-secondmate-home"
 . "$SCRIPT_DIR/fm-ff-lib.sh"
 # shellcheck source=bin/fm-config-inherit-lib.sh
 . "$SCRIPT_DIR/fm-config-inherit-lib.sh"
+# shellcheck source=bin/fm-terminal-lib.sh
+. "$SCRIPT_DIR/fm-terminal-lib.sh"
 # Skip the watcher guard when re-exec'd for one pair of a batch (FM_SPAWN_NO_GUARD is
 # set by the batch loop below), so the guard runs once for the batch, not once per pair.
 [ -n "${FM_SPAWN_NO_GUARD:-}" ] || "$FM_ROOT/bin/fm-guard.sh" || true
@@ -490,6 +492,117 @@ else
   BRIEF="$DATA/$ID/brief.md"
 fi
 [ -f "$BRIEF" ] || { echo "error: no brief at $BRIEF" >&2; exit 1; }
+
+spawn_cmux_and_exit() {
+  command -v cmux >/dev/null 2>&1 || { echo "error: terminal backend is cmux but cmux is not on PATH" >&2; exit 1; }
+  cmux ping >/dev/null 2>&1 || { echo "error: terminal backend is cmux but cmux is not reachable" >&2; exit 1; }
+  command -v python3 >/dev/null 2>&1 || { echo "error: cmux backend needs python3 to parse cmux identify output" >&2; exit 1; }
+
+  local identify caller_ws caller_surface lease_out cmux_out surface pane task_title
+  identify=$(cmux identify --json 2>/dev/null) || { echo "error: cmux identify failed; run firstmate from inside cmux or set terminal-backend=tmux" >&2; exit 1; }
+  caller_ws=$(printf '%s\n' "$identify" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("caller",{}).get("workspace_ref", ""))')
+  caller_surface=$(printf '%s\n' "$identify" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("caller",{}).get("surface_ref", ""))')
+  [ -n "$caller_ws" ] || { echo "error: cmux caller workspace could not be resolved" >&2; exit 1; }
+
+  lease_out=$(cd "$PROJ_ABS" && treehouse get --lease --lease-holder "$ID") || { echo "error: treehouse lease failed for $PROJ_ABS" >&2; exit 1; }
+  WT=$(printf '%s\n' "$lease_out" | grep '^/' | tail -1 || true)
+  [ -n "$WT" ] || WT=$(printf '%s\n' "$lease_out" | tail -1)
+  [ -d "$WT" ] || { echo "error: treehouse lease did not return a worktree path; output: $lease_out" >&2; exit 1; }
+
+  wt_real=
+  wt_real=$(cd "$WT" 2>/dev/null && pwd -P) || wt_real=
+  proj_real=
+  proj_real=$(cd "$PROJ_ABS" 2>/dev/null && pwd -P) || proj_real=
+  wt_top=$(git -C "$WT" rev-parse --show-toplevel 2>/dev/null || true)
+  wt_top_real=
+  wt_top_real=$(cd "$wt_top" 2>/dev/null && pwd -P) || wt_top_real=
+  if [ -z "$wt_real" ] || [ -z "$wt_top_real" ] || [ "$wt_real" != "$wt_top_real" ] || [ "$wt_real" = "$proj_real" ]; then
+    echo "error: treehouse lease did not yield an isolated worktree (resolved '$WT'; worktree root '${wt_top:-none}'; primary '$PROJ_ABS')" >&2
+    ( cd "$PROJ_ABS" && treehouse return --force "$WT" ) >/dev/null 2>&1 || true
+    exit 1
+  fi
+
+  task_title="fm-$ID"
+  if [ -n "$caller_surface" ]; then
+    cmux_out=$(cmux new-split right --workspace "$caller_ws" --surface "$caller_surface" --focus false 2>&1) || {
+      echo "error: cmux split failed after leasing worktree $WT: $cmux_out" >&2
+      ( cd "$PROJ_ABS" && treehouse return --force "$WT" ) >/dev/null 2>&1 || true
+      exit 1
+    }
+  else
+    cmux_out=$(cmux new-pane --type terminal --direction right --workspace "$caller_ws" --focus false 2>&1) || {
+      echo "error: cmux pane failed after leasing worktree $WT: $cmux_out" >&2
+      ( cd "$PROJ_ABS" && treehouse return --force "$WT" ) >/dev/null 2>&1 || true
+      exit 1
+    }
+  fi
+  surface=$(printf '%s\n' "$cmux_out" | grep -o 'surface:[0-9][0-9]*' | tail -1 || true)
+  if [ -z "$surface" ]; then
+    echo "error: cmux did not report a surface after leasing worktree $WT: $cmux_out" >&2
+    ( cd "$PROJ_ABS" && treehouse return --force "$WT" ) >/dev/null 2>&1 || true
+    exit 1
+  fi
+  pane=$(for p in $(cmux list-panes --workspace "$caller_ws" 2>/dev/null | grep -o 'pane:[0-9][0-9]*'); do cmux list-pane-surfaces --workspace "$caller_ws" --pane "$p" 2>/dev/null | grep -q "${surface}" && { echo "$p"; break; }; done)
+
+  TASK_TMP="/tmp/fm-$ID"
+  mkdir -p "$TASK_TMP/gotmp" "$STATE"
+  STATE_REAL=$(cd "$STATE" && pwd -P)
+  TURNEND="$STATE_REAL/$ID.turn-ended"
+  cat > "$STATE/$ID.pi-ext.ts" <<EOF
+// Firstmate turn-end signal; written by fm-spawn.
+import { execFile } from "node:child_process";
+export default function (pi: any) {
+  pi.on("turn_end", () => execFile("touch", ["$TURNEND"]));
+}
+EOF
+
+  PROJ_NAME=$(basename "$PROJ_ABS")
+  read -r MODE YOLO <<EOF
+$("$FM_ROOT/bin/fm-project-mode.sh" "$PROJ_NAME")
+EOF
+
+  sq_brief=$(shell_quote "$BRIEF")
+  sq_turnend=$(shell_quote "$TURNEND")
+  sq_piext=$(shell_quote "$STATE/$ID.pi-ext.ts")
+  local cmux_modelflag cmux_effortflag
+  cmux_modelflag=$(model_flag_for_harness "$HARNESS" "$MODEL")
+  cmux_effortflag=$(effort_flag_for_harness "$HARNESS" "$EFFORT")
+  LAUNCH=${LAUNCH//__MODELFLAG__/$cmux_modelflag}
+  LAUNCH=${LAUNCH//__EFFORTFLAG__/$cmux_effortflag}
+  LAUNCH=${LAUNCH//__BRIEF__/$sq_brief}
+  LAUNCH=${LAUNCH//__TURNEND__/$sq_turnend}
+  LAUNCH=${LAUNCH//__PIEXT__/$sq_piext}
+
+  {
+    echo "terminal_backend=cmux"
+    echo "workspace=$caller_ws"
+    [ -n "$pane" ] && echo "pane=$pane"
+    echo "surface=$surface"
+    echo "worktree=$WT"
+    echo "project=$PROJ_ABS"
+    echo "harness=$HARNESS"
+    echo "kind=$KIND"
+    echo "mode=$MODE"
+    echo "yolo=$YOLO"
+    echo "tasktmp=$TASK_TMP"
+    echo "model=${MODEL:-default}"
+    echo "effort=${EFFORT:-default}"
+  } > "$STATE/$ID.meta"
+
+  launch_line="cd $(shell_quote "$WT") && export GOTMPDIR=$(shell_quote "$TASK_TMP/gotmp") && $LAUNCH"
+  cmux rename-tab --workspace "$caller_ws" --surface "$surface" "$task_title" >/dev/null 2>&1 || true
+  cmux send --workspace "$caller_ws" --surface "$surface" "$launch_line\n" || {
+    echo "error: cmux launch send failed; workspace=$caller_ws surface=$surface worktree=$WT" >&2
+    exit 1
+  }
+  echo "spawned $ID harness=$HARNESS kind=$KIND mode=$MODE yolo=$YOLO terminal=cmux workspace=$caller_ws surface=$surface worktree=$WT"
+  exit 0
+}
+
+TERMINAL_BACKEND=$(fm_terminal_config_backend) || exit 1
+if [ "$KIND" != secondmate ] && [ "$TERMINAL_BACKEND" = cmux ]; then
+  spawn_cmux_and_exit
+fi
 
 # Same session when firstmate already runs inside tmux; dedicated session otherwise.
 if [ -n "${TMUX:-}" ]; then

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -493,6 +493,12 @@ else
 fi
 [ -f "$BRIEF" ] || { echo "error: no brief at $BRIEF" >&2; exit 1; }
 
+# Spawn a worker into a cmux surface and exit. For a ship/scout crewmate this leases
+# an isolated treehouse worktree; for a secondmate (kind=secondmate) it launches in
+# the persistent firstmate home (PROJ_ABS/WT already resolved above, with the
+# pre-launch home fast-forward and inheritable-config propagation already applied) and
+# never leases a worktree. Only the terminal changes vs the tmux secondmate path; every
+# other secondmate invariant is preserved (Phase B slice 3).
 spawn_cmux_and_exit() {
   command -v cmux >/dev/null 2>&1 || { echo "error: terminal backend is cmux but cmux is not on PATH" >&2; exit 1; }
   cmux ping >/dev/null 2>&1 || { echo "error: terminal backend is cmux but cmux is not reachable" >&2; exit 1; }
@@ -507,22 +513,26 @@ spawn_cmux_and_exit() {
   caller_surface=$(printf '%s\n' "$identify" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("caller",{}).get("surface_ref", ""))')
   [ -n "$caller_ws" ] || { echo "error: cmux caller workspace could not be resolved" >&2; exit 1; }
 
-  lease_out=$(cd "$PROJ_ABS" && treehouse get --lease --lease-holder "$ID") || { echo "error: treehouse lease failed for $PROJ_ABS" >&2; exit 1; }
-  WT=$(printf '%s\n' "$lease_out" | grep '^/' | tail -1 || true)
-  [ -n "$WT" ] || WT=$(printf '%s\n' "$lease_out" | tail -1)
-  [ -d "$WT" ] || { echo "error: treehouse lease did not return a worktree path; output: $lease_out" >&2; exit 1; }
+  if [ "$KIND" != secondmate ]; then
+    # Crewmate/scout: lease an isolated treehouse worktree. A secondmate skips this
+    # entirely - it runs in its persistent home (WT already == PROJ_ABS == home).
+    lease_out=$(cd "$PROJ_ABS" && treehouse get --lease --lease-holder "$ID") || { echo "error: treehouse lease failed for $PROJ_ABS" >&2; exit 1; }
+    WT=$(printf '%s\n' "$lease_out" | grep '^/' | tail -1 || true)
+    [ -n "$WT" ] || WT=$(printf '%s\n' "$lease_out" | tail -1)
+    [ -d "$WT" ] || { echo "error: treehouse lease did not return a worktree path; output: $lease_out" >&2; exit 1; }
 
-  wt_real=
-  wt_real=$(cd "$WT" 2>/dev/null && pwd -P) || wt_real=
-  proj_real=
-  proj_real=$(cd "$PROJ_ABS" 2>/dev/null && pwd -P) || proj_real=
-  wt_top=$(git -C "$WT" rev-parse --show-toplevel 2>/dev/null || true)
-  wt_top_real=
-  wt_top_real=$(cd "$wt_top" 2>/dev/null && pwd -P) || wt_top_real=
-  if [ -z "$wt_real" ] || [ -z "$wt_top_real" ] || [ "$wt_real" != "$wt_top_real" ] || [ "$wt_real" = "$proj_real" ]; then
-    echo "error: treehouse lease did not yield an isolated worktree (resolved '$WT'; worktree root '${wt_top:-none}'; primary '$PROJ_ABS')" >&2
-    ( cd "$PROJ_ABS" && treehouse return --force "$WT" ) >/dev/null 2>&1 || true
-    exit 1
+    wt_real=
+    wt_real=$(cd "$WT" 2>/dev/null && pwd -P) || wt_real=
+    proj_real=
+    proj_real=$(cd "$PROJ_ABS" 2>/dev/null && pwd -P) || proj_real=
+    wt_top=$(git -C "$WT" rev-parse --show-toplevel 2>/dev/null || true)
+    wt_top_real=
+    wt_top_real=$(cd "$wt_top" 2>/dev/null && pwd -P) || wt_top_real=
+    if [ -z "$wt_real" ] || [ -z "$wt_top_real" ] || [ "$wt_real" != "$wt_top_real" ] || [ "$wt_real" = "$proj_real" ]; then
+      echo "error: treehouse lease did not yield an isolated worktree (resolved '$WT'; worktree root '${wt_top:-none}'; primary '$PROJ_ABS')" >&2
+      ( cd "$PROJ_ABS" && treehouse return --force "$WT" ) >/dev/null 2>&1 || true
+      exit 1
+    fi
   fi
 
   task_title="fm-$ID"
@@ -530,14 +540,14 @@ spawn_cmux_and_exit() {
   # overflow for the 4th+ under auto/hybrid; explicit splits/tabs honored. Never
   # steals focus. The first worker always opens a visible split.
   cmux_out=$(fm_terminal_cmux_place_worker "$caller_ws" "$caller_surface" "$layout" "$ID") || {
-    echo "error: cmux worker placement failed after leasing worktree $WT: $cmux_out" >&2
-    ( cd "$PROJ_ABS" && treehouse return --force "$WT" ) >/dev/null 2>&1 || true
+    echo "error: cmux worker placement failed for $WT: $cmux_out" >&2
+    [ "$KIND" = secondmate ] || ( cd "$PROJ_ABS" && treehouse return --force "$WT" ) >/dev/null 2>&1 || true
     exit 1
   }
   surface=$(printf '%s\n' "$cmux_out" | grep -o 'surface:[0-9][0-9]*' | tail -1 || true)
   if [ -z "$surface" ]; then
-    echo "error: cmux did not report a surface after leasing worktree $WT: $cmux_out" >&2
-    ( cd "$PROJ_ABS" && treehouse return --force "$WT" ) >/dev/null 2>&1 || true
+    echo "error: cmux did not report a surface for $WT: $cmux_out" >&2
+    [ "$KIND" = secondmate ] || ( cd "$PROJ_ABS" && treehouse return --force "$WT" ) >/dev/null 2>&1 || true
     exit 1
   fi
   pane=$(for p in $(cmux list-panes --workspace "$caller_ws" 2>/dev/null | grep -o 'pane:[0-9][0-9]*'); do cmux list-pane-surfaces --workspace "$caller_ws" --pane "$p" 2>/dev/null | grep -q "${surface}" && { echo "$p"; break; }; done)
@@ -546,18 +556,32 @@ spawn_cmux_and_exit() {
   mkdir -p "$TASK_TMP/gotmp" "$STATE"
   STATE_REAL=$(cd "$STATE" && pwd -P)
   TURNEND="$STATE_REAL/$ID.turn-ended"
-  cat > "$STATE/$ID.pi-ext.ts" <<EOF
+  # Per-worktree turn-end hook: secondmates skip it (mirror the tmux path). A
+  # secondmate is supervised by status writes + heartbeats, not a turn-end signal,
+  # and its secondmate launch template carries no __PIEXT__ placeholder anyway.
+  if [ "$KIND" != secondmate ]; then
+    cat > "$STATE/$ID.pi-ext.ts" <<EOF
 // Firstmate turn-end signal; written by fm-spawn.
 import { execFile } from "node:child_process";
 export default function (pi: any) {
   pi.on("turn_end", () => execFile("touch", ["$TURNEND"]));
 }
 EOF
+  fi
 
-  PROJ_NAME=$(basename "$PROJ_ABS")
-  read -r MODE YOLO <<EOF
+  # MODE/YOLO: a secondmate is always mode=secondmate/yolo=off (the tmux path sets
+  # the same); a ship/scout crewmate resolves the project's delivery mode.
+  SECONDMATE_PROJECTS=
+  if [ "$KIND" = secondmate ]; then
+    MODE=secondmate
+    YOLO=off
+    SECONDMATE_PROJECTS=$(secondmate_registry_value "$ID" projects || true)
+  else
+    PROJ_NAME=$(basename "$PROJ_ABS")
+    read -r MODE YOLO <<EOF
 $("$FM_ROOT/bin/fm-project-mode.sh" "$PROJ_NAME")
 EOF
+  fi
 
   sq_brief=$(shell_quote "$BRIEF")
   sq_turnend=$(shell_quote "$TURNEND")
@@ -570,14 +594,18 @@ EOF
   LAUNCH=${LAUNCH//__BRIEF__/$sq_brief}
   LAUNCH=${LAUNCH//__TURNEND__/$sq_turnend}
   LAUNCH=${LAUNCH//__PIEXT__/$sq_piext}
+  if [ "$KIND" = secondmate ]; then
+    # The secondmate agent runs on its OWN home: clear inherited operational
+    # overrides and point FM_HOME at the home, exactly as the tmux secondmate path.
+    sq_home=$(shell_quote "$PROJ_ABS")
+    LAUNCH="FM_ROOT_OVERRIDE= FM_STATE_OVERRIDE= FM_DATA_OVERRIDE= FM_PROJECTS_OVERRIDE= FM_CONFIG_OVERRIDE= FM_HOME=$sq_home $LAUNCH"
+  fi
 
   {
     echo "terminal_backend=cmux"
     echo "workspace=$caller_ws"
     [ -n "$pane" ] && echo "pane=$pane"
     echo "surface=$surface"
-    echo "worktree=$WT"
-    echo "project=$PROJ_ABS"
     echo "harness=$HARNESS"
     echo "kind=$KIND"
     echo "mode=$MODE"
@@ -585,20 +613,38 @@ EOF
     echo "tasktmp=$TASK_TMP"
     echo "model=${MODEL:-default}"
     echo "effort=${EFFORT:-default}"
+    if [ "$KIND" = secondmate ]; then
+      # A cmux secondmate runs in its persistent home, not a leased worktree, so it
+      # records home=/projects= and NO worktree=/window= (a cmux secondmate has
+      # neither). Recovery keys off kind=secondmate + home=; the watcher enumerates
+      # it as fm-<id> (no window=) and skips its stale-pane wake as a secondmate.
+      echo "home=$PROJ_ABS"
+      echo "projects=$SECONDMATE_PROJECTS"
+    else
+      echo "worktree=$WT"
+      echo "project=$PROJ_ABS"
+    fi
   } > "$STATE/$ID.meta"
 
   launch_line="cd $(shell_quote "$WT") && export GOTMPDIR=$(shell_quote "$TASK_TMP/gotmp") && $LAUNCH"
   cmux rename-tab --workspace "$caller_ws" --surface "$surface" "$task_title" >/dev/null 2>&1 || true
   cmux send --workspace "$caller_ws" --surface "$surface" "$launch_line\n" || {
-    echo "error: cmux launch send failed; workspace=$caller_ws surface=$surface worktree=$WT" >&2
+    echo "error: cmux launch send failed; workspace=$caller_ws surface=$surface path=$WT" >&2
     exit 1
   }
-  echo "spawned $ID harness=$HARNESS kind=$KIND mode=$MODE yolo=$YOLO terminal=cmux workspace=$caller_ws surface=$surface worktree=$WT"
+  if [ "$KIND" = secondmate ]; then
+    echo "spawned $ID harness=$HARNESS kind=$KIND mode=$MODE yolo=$YOLO terminal=cmux workspace=$caller_ws surface=$surface home=$PROJ_ABS"
+  else
+    echo "spawned $ID harness=$HARNESS kind=$KIND mode=$MODE yolo=$YOLO terminal=cmux workspace=$caller_ws surface=$surface worktree=$WT"
+  fi
   exit 0
 }
 
 TERMINAL_BACKEND=$(fm_terminal_config_backend) || exit 1
-if [ "$KIND" != secondmate ] && [ "$TERMINAL_BACKEND" = cmux ]; then
+if [ "$TERMINAL_BACKEND" = cmux ]; then
+  # Ship/scout crewmates AND secondmates all launch into a cmux surface when the
+  # backend is cmux; spawn_cmux_and_exit branches on kind=secondmate to skip the
+  # worktree lease and launch in the persistent home instead (Phase B slice 3).
   spawn_cmux_and_exit
 fi
 

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -504,7 +504,7 @@ spawn_cmux_and_exit() {
   cmux ping >/dev/null 2>&1 || { echo "error: terminal backend is cmux but cmux is not reachable" >&2; exit 1; }
   command -v python3 >/dev/null 2>&1 || { echo "error: cmux backend needs python3 to parse cmux identify output" >&2; exit 1; }
 
-  local identify caller_ws caller_surface lease_out cmux_out surface worker_ws pane task_title layout
+  local identify caller_ws caller_surface lease_out cmux_out surface worker_ws pane task_title layout owned_workspace
   # Resolve the layout policy up front so an invalid config/cmux-layout fails fast,
   # before any treehouse lease or cmux surface is created.
   layout=$(fm_terminal_cmux_layout) || exit 1
@@ -537,9 +537,10 @@ spawn_cmux_and_exit() {
 
   task_title="fm-$ID"
   # Place the worker per the layout policy: under auto, tile a 2-row grid to the
-  # right of firstmate (2x2 for the default capacity) and overflow to a NEW cmux
-  # window once the grid is full; explicit splits/tabs/hybrid honored. Never steals
-  # focus. The first worker always opens a visible split off firstmate.
+  # right of firstmate (2x2 for the default capacity) and overflow to a NEW named
+  # cmux workspace in firstmate's current window once the grid is full; explicit
+  # splits/tabs/hybrid honored. Never steals focus. The first worker always opens
+  # a visible split off firstmate.
   cmux_out=$(fm_terminal_cmux_place_worker "$caller_ws" "$caller_surface" "$layout" "$ID") || {
     echo "error: cmux worker placement failed for $WT: $cmux_out" >&2
     [ "$KIND" = secondmate ] || ( cd "$PROJ_ABS" && treehouse return --force "$WT" ) >/dev/null 2>&1 || true
@@ -552,12 +553,11 @@ spawn_cmux_and_exit() {
     exit 1
   fi
   # The worker's workspace is firstmate's own for a grid/split/tab placement, but a
-  # NEW workspace when auto overflowed to a new window - the placement echoes it in
-  # that case. Capture it (falling back to the caller workspace) and use it for the
-  # pane lookup, meta, rename, and launch send so a new-window worker is addressed
-  # in its own window rather than firstmate's.
+  # NEW owned workspace when auto overflowed. Capture it (falling back to the
+  # caller workspace) and use it for the pane lookup, meta, rename, and launch send.
   worker_ws=$(printf '%s\n' "$cmux_out" | grep -o 'workspace:[0-9][0-9]*' | tail -1 || true)
   [ -n "$worker_ws" ] || worker_ws=$caller_ws
+  owned_workspace=$(printf '%s\n' "$cmux_out" | grep '^owned_workspace=1$' || true)
   pane=$(for p in $(cmux list-panes --workspace "$worker_ws" 2>/dev/null | grep -o 'pane:[0-9][0-9]*'); do cmux list-pane-surfaces --workspace "$worker_ws" --pane "$p" 2>/dev/null | grep -q "${surface}" && { echo "$p"; break; }; done)
 
   TASK_TMP="/tmp/fm-$ID"
@@ -612,6 +612,7 @@ EOF
   {
     echo "terminal_backend=cmux"
     echo "workspace=$worker_ws"
+    [ -n "$owned_workspace" ] && echo "owned_workspace=1"
     [ -n "$pane" ] && echo "pane=$pane"
     echo "surface=$surface"
     echo "harness=$HARNESS"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Spawn a direct report: a crewmate in a treehouse worktree, or a secondmate in
 # its isolated firstmate home.
-# Usage: fm-spawn.sh <task-id> <project-dir> [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--scout]
+# Usage: fm-spawn.sh <task-id> <project-dir> [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--title <text>] [--scout]
 #        fm-spawn.sh <task-id> [<firstmate-home>] [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] --secondmate
 #   --harness <name> is the explicit per-spawn harness/profile adapter. The old
 #   positional harness arg still works for back-compat.
@@ -9,6 +9,14 @@
 #   axes chosen by firstmate at intake. They are only threaded into harnesses whose
 #   installed CLIs were verified to support that axis; unsupported axes are omitted
 #   from that harness's launch rather than guessed.
+#   --title <text> is an optional plain-English display title ("<project> · <doing>"),
+#   cmux backend only: it renames the worker's cmux tab instead of the default
+#   machine-id title and is recorded as title= in meta. Purely cosmetic - nothing
+#   matches on it, the machine id (workspace=/surface=/window=) stays the
+#   functional identifier everywhere. Truncated to 48 chars with an ellipsis.
+#   Single-task spawns only; the id=repo batch form refuses it (titles are per-task).
+#   On the tmux backend the flag is accepted and recorded in meta but otherwise
+#   unused - the tmux window name stays the functional fm-<id>.
 #   With no harness arg, a crewmate/scout spawn resolves the CREW harness only when
 #   config/crew-dispatch.json is absent. When that file exists, crewmate/scout
 #   spawns require an explicit harness so firstmate cannot silently skip dispatch
@@ -73,9 +81,11 @@ KIND=ship
 HARNESS_ARG=
 MODEL=
 EFFORT=
+TITLE=
 HARNESS_SET=0
 MODEL_SET=0
 EFFORT_SET=0
+TITLE_SET=0
 POS=()
 want_value=
 for a in "$@"; do
@@ -87,6 +97,7 @@ for a in "$@"; do
       harness) HARNESS_ARG=$a; HARNESS_SET=1 ;;
       model) MODEL=$a; MODEL_SET=1 ;;
       effort) EFFORT=$a; EFFORT_SET=1 ;;
+      title) TITLE=$a; TITLE_SET=1 ;;
       *) echo "error: internal parser state for --$want_value" >&2; exit 1 ;;
     esac
     want_value=
@@ -101,6 +112,8 @@ for a in "$@"; do
     --model=*) MODEL=${a#--model=}; MODEL_SET=1 ;;
     --effort) want_value=effort ;;
     --effort=*) EFFORT=${a#--effort=}; EFFORT_SET=1 ;;
+    --title) want_value=title ;;
+    --title=*) TITLE=${a#--title=}; TITLE_SET=1 ;;
     *) POS+=("$a") ;;
   esac
 done
@@ -108,6 +121,12 @@ done
 [ "$HARNESS_SET" -eq 0 ] || [ -n "$HARNESS_ARG" ] || { echo "error: --harness requires a non-empty value" >&2; exit 1; }
 [ "$MODEL_SET" -eq 0 ] || [ -n "$MODEL" ] || { echo "error: --model requires a non-empty value" >&2; exit 1; }
 [ "$EFFORT_SET" -eq 0 ] || [ -n "$EFFORT" ] || { echo "error: --effort requires a non-empty value" >&2; exit 1; }
+[ "$TITLE_SET" -eq 0 ] || [ -n "$TITLE" ] || { echo "error: --title requires a non-empty value" >&2; exit 1; }
+# Cap the human title so sidebar/tab display never overflows; truncate with a
+# single ellipsis char rather than three dots to keep the cap tight.
+if [ "$TITLE_SET" -eq 1 ] && [ "${#TITLE}" -gt 48 ]; then
+  TITLE="${TITLE:0:47}…"
+fi
 case "$EFFORT" in
   ''|low|medium|high|xhigh|max) ;;
   *) echo "error: --effort must be one of low, medium, high, xhigh, max" >&2; exit 1 ;;
@@ -124,6 +143,10 @@ idpart=${idpart%%=*}
 if [ "${#POS[@]}" -gt 0 ] && [ "${POS[0]}" != "$idpart" ] && case "$idpart" in */*) false ;; *) true ;; esac; then
   if [ "$KIND" != secondmate ] && [ -z "$HARNESS_ARG" ] && [ -f "$CONFIG/crew-dispatch.json" ]; then
     echo "error: config/crew-dispatch.json is active - pass an explicit harness resolved from the dispatch rules (the consultation backstop, so the rules are never silently skipped)." >&2
+    exit 1
+  fi
+  if [ "$TITLE_SET" -eq 1 ]; then
+    echo "error: --title applies to a single-task spawn only; batch id=repo dispatch does not support a shared title" >&2
     exit 1
   fi
   rc=0
@@ -576,7 +599,16 @@ spawn_cmux_and_exit() {
     fi
   fi
 
-  task_title="fm-$ID"
+  # Display-only: the cmux tab title is cosmetic (verified - nothing matches on
+  # it; supervision/teardown/recovery address workers by workspace=/surface=
+  # refs recorded in meta, section 8/AGENTS.md). --title lets firstmate show a
+  # plain-English "<project> · <doing>" title instead of the machine id; the
+  # machine id remains the functional identifier in meta/state either way.
+  if [ "$TITLE_SET" -eq 1 ]; then
+    task_title="$TITLE"
+  else
+    task_title="fm-$ID"
+  fi
   # Place the worker per the layout policy: under auto, tile a 2-row grid to the
   # right of firstmate (2x2 for the default capacity) and overflow to a NEW named
   # cmux workspace in firstmate's current window once the grid is full; explicit
@@ -692,6 +724,7 @@ EOF
     echo "tasktmp=$TASK_TMP"
     echo "model=${MODEL:-default}"
     echo "effort=${EFFORT:-default}"
+    [ "$TITLE_SET" -eq 0 ] || echo "title=$TITLE"
     if [ "$KIND" = secondmate ]; then
       # A cmux secondmate runs in its persistent home, not a leased worktree, so it
       # records home=/projects= and NO worktree=/window= (a cmux secondmate has
@@ -917,6 +950,7 @@ fi
   echo "tasktmp=$TASK_TMP"
   echo "model=${MODEL:-default}"
   echo "effort=${EFFORT:-default}"
+  [ "$TITLE_SET" -eq 0 ] || echo "title=$TITLE"
   if [ "$KIND" = secondmate ]; then
     echo "home=$PROJ_ABS"
     echo "projects=$SECONDMATE_PROJECTS"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -499,12 +499,53 @@ fi
 # pre-launch home fast-forward and inheritable-config propagation already applied) and
 # never leases a worktree. Only the terminal changes vs the tmux secondmate path; every
 # other secondmate invariant is preserved (Phase B slice 3).
+fm_cmux_surface_attached() {  # <workspace> <surface>
+  local ws=$1 surface=$2 screen_out health_out
+  if screen_out=$(cmux read-screen --workspace "$ws" --surface "$surface" --lines 1 2>&1); then
+    return 0
+  fi
+  health_out=$(cmux surface-health --workspace "$ws" 2>/dev/null || true)
+  case "$screen_out
+$health_out" in
+    *'Terminal surface not found'*|*'in_window=false'*) return 1 ;;
+    *) return 1 ;;
+  esac
+}
+
+fm_cmux_wait_surface_attached() {  # <workspace> <surface>
+  local ws=$1 surface=$2 attempts=${FM_CMUX_ATTACH_PROBES:-6} delay=${FM_CMUX_ATTACH_DELAY:-0.5} i=0
+  case "$attempts" in ''|*[!0-9]*) attempts=6 ;; esac
+  [ "$attempts" -gt 0 ] 2>/dev/null || attempts=1
+  while [ "$i" -lt "$attempts" ]; do
+    fm_cmux_surface_attached "$ws" "$surface" && return 0
+    i=$((i + 1))
+    [ "$i" -lt "$attempts" ] && sleep "$delay"
+  done
+  return 1
+}
+
+fm_cmux_repair_ghost_surface() {  # <workspace> <surface>
+  local ws=$1 surface=$2 original_ws
+  original_ws=$(cmux current-workspace 2>/dev/null | tail -1 | awk '{print $NF}' || true)
+  if ! cmux select-workspace --workspace "$ws" >/dev/null 2>&1; then
+    echo "warning: cmux ghost repair could not select target workspace; workspace=$ws surface=$surface" >&2
+    return 1
+  fi
+  cmux refresh-surfaces >/dev/null 2>&1 || true
+  if [ -n "$original_ws" ] && [ "$original_ws" != "$ws" ]; then
+    if ! cmux select-workspace --workspace "$original_ws" >/dev/null 2>&1; then
+      echo "warning: cmux ghost repair could not restore original workspace; original_workspace=$original_ws target_workspace=$ws surface=$surface" >&2
+      return 1
+    fi
+  fi
+}
+
 spawn_cmux_and_exit() {
   command -v cmux >/dev/null 2>&1 || { echo "error: terminal backend is cmux but cmux is not on PATH" >&2; exit 1; }
   cmux ping >/dev/null 2>&1 || { echo "error: terminal backend is cmux but cmux is not reachable" >&2; exit 1; }
   command -v python3 >/dev/null 2>&1 || { echo "error: cmux backend needs python3 to parse cmux identify output" >&2; exit 1; }
 
-  local identify caller_ws caller_surface lease_out cmux_out surface worker_ws pane task_title layout owned_workspace
+  local identify caller_ws caller_surface lease_out cmux_out surface worker_ws pane task_title layout owned_workspace repair_attempt repair_attempts
   # Resolve the layout policy up front so an invalid config/cmux-layout fails fast,
   # before any treehouse lease or cmux surface is created.
   layout=$(fm_terminal_cmux_layout) || exit 1
@@ -609,6 +650,35 @@ EOF
     LAUNCH="FM_ROOT_OVERRIDE= FM_STATE_OVERRIDE= FM_DATA_OVERRIDE= FM_PROJECTS_OVERRIDE= FM_CONFIG_OVERRIDE= FM_HOME=$sq_home $LAUNCH"
   fi
 
+  launch_line="cd $(shell_quote "$WT") && export GOTMPDIR=$(shell_quote "$TASK_TMP/gotmp") && $LAUNCH"
+  cmux rename-tab --workspace "$worker_ws" --surface "$surface" "$task_title" >/dev/null 2>&1 || true
+  cmux send --workspace "$worker_ws" --surface "$surface" "$launch_line\n" || {
+    echo "error: cmux launch send failed; workspace=$worker_ws surface=$surface path=$WT" >&2
+    [ "$KIND" = secondmate ] || ( cd "$PROJ_ABS" && treehouse return --force "$WT" ) >/dev/null 2>&1 || true
+    exit 1
+  }
+  if ! fm_cmux_wait_surface_attached "$worker_ws" "$surface"; then
+    repair_attempt=1
+    repair_attempts=${FM_CMUX_GHOST_REPAIRS:-2}
+    case "$repair_attempts" in ''|*[!0-9]*) repair_attempts=2 ;; esac
+    while [ "$repair_attempt" -le "$repair_attempts" ]; do
+      if fm_cmux_repair_ghost_surface "$worker_ws" "$surface"; then
+        cmux send --workspace "$worker_ws" --surface "$surface" "$launch_line\n" || {
+          echo "error: cmux launch resend failed after ghost repair; workspace=$worker_ws surface=$surface path=$WT" >&2
+          [ "$KIND" = secondmate ] || ( cd "$PROJ_ABS" && treehouse return --force "$WT" ) >/dev/null 2>&1 || true
+          exit 1
+        }
+        fm_cmux_wait_surface_attached "$worker_ws" "$surface" && break
+      fi
+      repair_attempt=$((repair_attempt + 1))
+    done
+    if [ "$repair_attempt" -gt "$repair_attempts" ]; then
+      echo "error: cmux surface did not attach after launch/repair; workspace=$worker_ws surface=$surface path=$WT" >&2
+      [ "$KIND" = secondmate ] || ( cd "$PROJ_ABS" && treehouse return --force "$WT" ) >/dev/null 2>&1 || true
+      exit 1
+    fi
+  fi
+
   {
     echo "terminal_backend=cmux"
     echo "workspace=$worker_ws"
@@ -634,13 +704,6 @@ EOF
       echo "project=$PROJ_ABS"
     fi
   } > "$STATE/$ID.meta"
-
-  launch_line="cd $(shell_quote "$WT") && export GOTMPDIR=$(shell_quote "$TASK_TMP/gotmp") && $LAUNCH"
-  cmux rename-tab --workspace "$worker_ws" --surface "$surface" "$task_title" >/dev/null 2>&1 || true
-  cmux send --workspace "$worker_ws" --surface "$surface" "$launch_line\n" || {
-    echo "error: cmux launch send failed; workspace=$worker_ws surface=$surface path=$WT" >&2
-    exit 1
-  }
   if [ "$KIND" = secondmate ]; then
     echo "spawned $ID harness=$HARNESS kind=$KIND mode=$MODE yolo=$YOLO terminal=cmux workspace=$worker_ws surface=$surface home=$PROJ_ABS"
   else

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -50,6 +50,8 @@ SECONDMATE_REG="$DATA/secondmates.md"
 SUB_HOME_MARKER=".fm-secondmate-home"
 # shellcheck source=bin/fm-tasks-axi-lib.sh
 . "$SCRIPT_DIR/fm-tasks-axi-lib.sh"
+# shellcheck source=bin/fm-terminal-lib.sh
+. "$SCRIPT_DIR/fm-terminal-lib.sh"
 "$FM_ROOT/bin/fm-guard.sh" || true
 ID=$1
 FORCE=${2:-}
@@ -57,7 +59,9 @@ FORCE=${2:-}
 META="$STATE/$ID.meta"
 [ -f "$META" ] || { echo "error: no meta for task $ID at $META" >&2; exit 1; }
 WT=$(grep '^worktree=' "$META" | cut -d= -f2-)
-T=$(grep '^window=' "$META" | cut -d= -f2-)
+T=$(grep '^window=' "$META" | cut -d= -f2- || true)
+BACKEND=$(grep '^terminal_backend=' "$META" | cut -d= -f2- || true)
+[ -n "$BACKEND" ] || BACKEND=tmux
 PROJ=$(grep '^project=' "$META" | cut -d= -f2-)
 HOME_PATH=$(grep '^home=' "$META" | cut -d= -f2- || true)
 PR_URL=$(grep '^pr=' "$META" | tail -1 | cut -d= -f2- || true)
@@ -655,7 +659,15 @@ if [ -d "$WT" ] && [ "$KIND" != secondmate ]; then
   ( cd "$PROJ" && treehouse return --force "$WT" )
 fi
 
-tmux kill-window -t "$T" 2>/dev/null || true
+CLOSE_FAILED=0
+if [ "$BACKEND" = cmux ]; then
+  if ! fm_terminal_close "fm-$ID" 2>/dev/null; then
+    echo "warning: could not close cmux surface for $ID; preserving $META for manual cleanup" >&2
+    CLOSE_FAILED=1
+  fi
+else
+  [ -n "$T" ] && tmux kill-window -t "$T" 2>/dev/null || true
+fi
 if [ "$KIND" = secondmate ]; then
   [ -n "$HOME_PATH" ] || HOME_PATH=$WT
   remove_firstmate_home "$HOME_PATH" "secondmate home" "$ID"
@@ -665,9 +677,14 @@ remove_grok_turnend_auth "$STATE" "$ID"
 # Remove the per-task temp root (/tmp/fm-<id>/, incl. its gotmp/) recorded by spawn.
 # Read before the state-file rm below; empty (pre-fix tasks without tasktmp=) is a no-op.
 [ -n "$TASK_TMP" ] && rm -rf "$TASK_TMP"
+if [ "$CLOSE_FAILED" = 1 ]; then
+  rm -f "$STATE/$ID.status" "$STATE/$ID.turn-ended" "$STATE/$ID.check.sh" "$STATE/$ID.pi-ext.ts" "$STATE/$ID.grok-turnend-token"
+  echo "teardown $ID incomplete: worktree returned but cmux surface close failed; inspect $META" >&2
+  exit 1
+fi
 rm -f "$STATE/$ID.status" "$STATE/$ID.turn-ended" "$STATE/$ID.check.sh" "$STATE/$ID.meta" "$STATE/$ID.pi-ext.ts" "$STATE/$ID.grok-turnend-token"
 if [ "$KIND" != scout ] && [ "$KIND" != secondmate ] && [ "$MODE" != local-only ]; then
   "$FM_ROOT/bin/fm-fleet-sync.sh" "$PROJ" || true
 fi
-echo "teardown $ID complete (window $T, worktree $WT)"
+echo "teardown $ID complete (terminal ${T:-$BACKEND}, worktree $WT)"
 backlog_refresh_reminder

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -95,6 +95,28 @@ meta_value() {
   grep "^$key=" "$meta" | cut -d= -f2- || true
 }
 
+cmux_workspace_still_referenced() {  # <workspace> <current-meta>
+  local workspace=$1 current_meta=$2 meta
+  [ -n "$workspace" ] || return 1
+  for meta in "$STATE"/*.meta; do
+    [ -f "$meta" ] || continue
+    [ "$meta" = "$current_meta" ] && continue
+    [ "$(meta_value "$meta" workspace)" = "$workspace" ] && return 0
+  done
+  return 1
+}
+
+close_owned_cmux_workspace_if_empty() {  # <meta>
+  local meta=$1 workspace close_out
+  [ "$(meta_value "$meta" owned_workspace)" = 1 ] || return 0
+  workspace=$(meta_value "$meta" workspace)
+  [ -n "$workspace" ] || return 0
+  cmux_workspace_still_referenced "$workspace" "$meta" && return 0
+  close_out=$(cmux close-workspace --workspace "$workspace" 2>&1) && return 0
+  echo "warning: could not close owned cmux workspace $workspace for $ID; leftover workspace remains: $close_out" >&2
+  return 0
+}
+
 remove_grok_turnend_auth() {
   local state_dir=$1 id=$2 token hooks_dir
   token=$(cat "$state_dir/$id.grok-turnend-token" 2>/dev/null || true)
@@ -664,6 +686,8 @@ if [ "$BACKEND" = cmux ]; then
   if ! fm_terminal_close "fm-$ID" 2>/dev/null; then
     echo "warning: could not close cmux surface for $ID; preserving $META for manual cleanup" >&2
     CLOSE_FAILED=1
+  else
+    close_owned_cmux_workspace_if_empty "$META"
   fi
 else
   [ -n "$T" ] && tmux kill-window -t "$T" 2>/dev/null || true

--- a/bin/fm-terminal-lib.sh
+++ b/bin/fm-terminal-lib.sh
@@ -30,6 +30,102 @@ fm_terminal_config_backend() {  # -> tmux|cmux
   esac
 }
 
+# --- cmux multi-worker layout policy ---------------------------------------
+#
+# Placement policy for a NEW cmux worker, given how many cmux workers this home
+# already has. Mielye default (auto): the 1st..3rd workers each get their own
+# visible split so they are watchable at once; the 4th and later workers overflow
+# to a tab (extra surface) in an existing worker pane instead of an unbounded pile
+# of splits. Explicit config/cmux-layout values force one shape.
+#
+# FM_CMUX_SPLIT_THRESHOLD is the max number of EXISTING workers that still get a
+# split under auto/hybrid: a new worker splits while count < threshold and
+# overflows to a tab once count >= threshold (so with 3, workers 1-3 split and
+# worker 4+ tabs). Named so it is obvious and tunable.
+FM_CMUX_SPLIT_THRESHOLD=${FM_CMUX_SPLIT_THRESHOLD:-3}
+
+fm_terminal_cmux_layout() {  # -> splits|tabs|hybrid|auto
+  local config_dir=${FM_CONFIG_OVERRIDE:-${CONFIG:-${FM_HOME:-}/config}} raw
+  raw=auto
+  [ -n "$config_dir" ] && [ -f "$config_dir/cmux-layout" ] && raw=$(tr -d '[:space:]' < "$config_dir/cmux-layout")
+  [ -n "$raw" ] || raw=auto
+  case "$raw" in
+    splits|tabs|hybrid|auto) printf '%s\n' "$raw" ;;
+    *) echo "error: invalid cmux layout '$raw' in $config_dir/cmux-layout (expected splits, tabs, hybrid, or auto)" >&2; return 2 ;;
+  esac
+}
+
+# Count live cmux workers this home already has: state/<id>.meta with
+# terminal_backend=cmux, excluding the task being spawned and any secondmate.
+fm_terminal_cmux_worker_count() {  # <exclude-id> -> N
+  local exclude=$1 state=${STATE:?STATE required} meta base n=0
+  for meta in "$state"/*.meta; do
+    [ -f "$meta" ] || continue
+    base=$(basename "$meta" .meta)
+    [ "$base" = "$exclude" ] && continue
+    [ "$(fm_terminal_meta_value "$meta" terminal_backend)" = cmux ] || continue
+    [ "$(fm_terminal_meta_value "$meta" kind)" = secondmate ] && continue
+    n=$((n + 1))
+  done
+  printf '%s\n' "$n"
+}
+
+# Decide placement for a new worker: split (own visible pane) or tab (overflow
+# surface). N is the existing cmux worker count.
+fm_terminal_cmux_layout_action() {  # <layout> <N> -> split|tab
+  local layout=$1 n=$2
+  case "$layout" in
+    splits) printf 'split\n' ;;
+    # tabs: the first worker still opens a visible split to create the crew pane;
+    # every later worker becomes a tab in it.
+    tabs) [ "$n" -eq 0 ] && printf 'split\n' || printf 'tab\n' ;;
+    # hybrid and auto share the Mielye default: split up to the threshold, then tab.
+    *) [ "$n" -lt "$FM_CMUX_SPLIT_THRESHOLD" ] && printf 'split\n' || printf 'tab\n' ;;
+  esac
+}
+
+# The pane a tab-overflow worker should stack into: the pane of the most recently
+# spawned cmux worker, so overflow lands in an existing worker pane. Empty (rc 1)
+# when no such pane is recorded, letting the caller fall back to a split.
+fm_terminal_cmux_overflow_pane() {  # <exclude-id> -> pane:N
+  local exclude=$1 state=${STATE:?STATE required} meta base pane newest='' newest_pane=''
+  for meta in "$state"/*.meta; do
+    [ -f "$meta" ] || continue
+    base=$(basename "$meta" .meta)
+    [ "$base" = "$exclude" ] && continue
+    [ "$(fm_terminal_meta_value "$meta" terminal_backend)" = cmux ] || continue
+    [ "$(fm_terminal_meta_value "$meta" kind)" = secondmate ] && continue
+    pane=$(fm_terminal_meta_value "$meta" pane)
+    [ -n "$pane" ] || continue
+    if [ -z "$newest" ] || [ "$meta" -nt "$newest" ]; then
+      newest=$meta; newest_pane=$pane
+    fi
+  done
+  [ -n "$newest_pane" ] || return 1
+  printf '%s\n' "$newest_pane"
+}
+
+# Create the worker surface per the resolved layout and echo cmux's output so the
+# caller can grep out surface:N. Runs exactly one cmux command (never steals focus)
+# and returns its exit status. Split uses new-split off the caller surface (or a
+# new-pane when there is no caller surface); tab overflow uses new-surface in an
+# existing worker pane, falling back to a split when no such pane exists yet.
+fm_terminal_cmux_place_worker() {  # <workspace> <caller_surface> <layout> <exclude-id>
+  local ws=$1 caller_surface=$2 layout=$3 exclude=$4 n action pane
+  n=$(fm_terminal_cmux_worker_count "$exclude") || return 1
+  action=$(fm_terminal_cmux_layout_action "$layout" "$n")
+  if [ "$action" = tab ]; then
+    pane=$(fm_terminal_cmux_overflow_pane "$exclude") || action='split'
+  fi
+  if [ "$action" = tab ]; then
+    cmux new-surface --type terminal --pane "$pane" --workspace "$ws" --focus false 2>&1
+  elif [ -n "$caller_surface" ]; then
+    cmux new-split right --workspace "$ws" --surface "$caller_surface" --focus false 2>&1
+  else
+    cmux new-pane --type terminal --direction right --workspace "$ws" --focus false 2>&1
+  fi
+}
+
 fm_terminal_target_meta() {  # <target> -> meta path or empty
   case "$1" in
     fm-*) printf '%s/%s.meta\n' "${STATE:?STATE required}" "${1#fm-}" ;;

--- a/bin/fm-terminal-lib.sh
+++ b/bin/fm-terminal-lib.sh
@@ -36,36 +36,37 @@ fm_terminal_config_backend() {  # -> tmux|cmux
 # already has. Mielye default (auto): firstmate's own pane stays pinned on the
 # LEFT and is never sliced into a strip; workers tile into a 2-row grid to its
 # right (a 2x2 for the default capacity of 4). When the grid is full the next
-# worker opens a NEW cmux window and the grid fills again there. Explicit
+# worker opens a NEW cmux workspace in firstmate's current window and the grid
+# fills again there. Explicit
 # config/cmux-layout values force one shape:
 #   splits - a visible right-split off firstmate per worker (vertical strips).
 #   tabs   - one crew pane (first worker splits) then worker tabs.
 #   hybrid - split up to FM_CMUX_SPLIT_THRESHOLD, then tab overflow (the pre-grid
 #            "auto" behaviour, kept available under its own name).
-#   auto   - grid + new-window overflow (the new default described above).
+#   auto   - grid + same-window workspace overflow (the default described above).
 #
 # Grid tiling detail (auto), column-major over FM_CMUX_GRID_ROWS rows:
 #   worker 1 -> new-split right off firstmate's caller surface (top-right cell)
 #   worker 2 -> new-split down off worker 1  (bottom of column 1)
 #   worker 3 -> new-split right off worker 1 (top of column 2)
 #   worker 4 -> new-split down off worker 3  (bottom of column 2)
-#   worker 5 -> new cmux window (grid at capacity); `cmux new-window` auto-creates
-#              a default workspace + terminal surface in that window (resolved via
-#              `cmux identify`, not a separate new-workspace/new-pane call), then
-#              the grid fills again there.
+#   worker 5 -> new named workspace in firstmate's current window (grid at
+#              capacity); `cmux new-workspace` creates the first terminal surface
+#              for that workspace, then the grid fills again there.
 # Anchors are resolved from the recorded worker surfaces/workspaces in
 # state/*.meta, ordered by cmux's monotonically-increasing surface ref (a later
 # worker gets a higher surface number), so the ordering is stable across meta
-# appends and across windows.
+# appends and across workspaces.
 #
 # FM_CMUX_SPLIT_THRESHOLD is the max number of EXISTING workers that still get a
 # split under hybrid: a new worker splits while count < threshold and overflows
 # to a tab once count >= threshold (so with 3, workers 1-3 split and worker 4+
 # tabs). Named so it is obvious and tunable.
 FM_CMUX_SPLIT_THRESHOLD=${FM_CMUX_SPLIT_THRESHOLD:-3}
-# FM_CMUX_GRID_CAPACITY is how many workers fill one grid (one window) before the
-# next worker overflows to a new window. Default 4 = the 2x2 grid.
-FM_CMUX_GRID_CAPACITY=${FM_CMUX_GRID_CAPACITY:-4}
+# FM_CMUX_GRID_CAPACITY is how many workers fill one grid before the next worker
+# overflows to a new same-window workspace. Env overrides config/cmux-grid-capacity;
+# invalid or non-positive values fall back to 4.
+FM_CMUX_GRID_CAPACITY_DEFAULT=4
 # FM_CMUX_GRID_ROWS is the grid height (rows per column). The grid fills
 # column-major: each column is filled top-to-bottom before the next column opens
 # to its right. Default 2 gives the 2x2 grid at the default capacity.
@@ -79,6 +80,18 @@ fm_terminal_cmux_layout() {  # -> splits|tabs|hybrid|auto
   case "$raw" in
     splits|tabs|hybrid|auto) printf '%s\n' "$raw" ;;
     *) echo "error: invalid cmux layout '$raw' in $config_dir/cmux-layout (expected splits, tabs, hybrid, or auto)" >&2; return 2 ;;
+  esac
+}
+
+fm_terminal_cmux_grid_capacity() {  # -> positive integer
+  local config_dir=${FM_CONFIG_OVERRIDE:-${CONFIG:-${FM_HOME:-}/config}} raw
+  raw=${FM_CMUX_GRID_CAPACITY:-}
+  if [ -z "$raw" ] && [ -n "$config_dir" ] && [ -f "$config_dir/cmux-grid-capacity" ]; then
+    raw=$(tr -d '[:space:]' < "$config_dir/cmux-grid-capacity")
+  fi
+  case "$raw" in
+    ''|*[!0-9]*) printf '%s\n' "$FM_CMUX_GRID_CAPACITY_DEFAULT" ;;
+    *) if [ "$raw" -gt 0 ] 2>/dev/null; then printf '%s\n' "$raw"; else printf '%s\n' "$FM_CMUX_GRID_CAPACITY_DEFAULT"; fi ;;
   esac
 }
 
@@ -102,10 +115,10 @@ fm_terminal_cmux_worker_count() {  # <exclude-id> -> N
 # Decide placement for a new worker. N is the existing cmux worker count.
 # Returns: split (right-split off firstmate), tab (overflow surface in a worker
 # pane), grid (auto grid placement, resolve direction+anchor via grid_slot), or
-# window (auto overflow to a new cmux window).
-fm_terminal_cmux_layout_action() {  # <layout> <N> -> split|tab|grid|window
-  local layout=$1 n=$2 cap=${FM_CMUX_GRID_CAPACITY:-4}
-  [ "$cap" -ge 1 ] 2>/dev/null || cap=4
+# workspace (auto overflow to a new cmux workspace in the current window).
+fm_terminal_cmux_layout_action() {  # <layout> <N> -> split|tab|grid|workspace
+  local layout=$1 n=$2 cap
+  cap=$(fm_terminal_cmux_grid_capacity)
   case "$layout" in
     splits) printf 'split\n' ;;
     # tabs: the first worker still opens a visible split to create the crew pane;
@@ -113,8 +126,8 @@ fm_terminal_cmux_layout_action() {  # <layout> <N> -> split|tab|grid|window
     tabs) [ "$n" -eq 0 ] && printf 'split\n' || printf 'tab\n' ;;
     # hybrid: the pre-grid default - split up to the threshold, then tab overflow.
     hybrid) [ "$n" -lt "$FM_CMUX_SPLIT_THRESHOLD" ] && printf 'split\n' || printf 'tab\n' ;;
-    # auto: grid placement, overflowing to a new window each time the grid fills.
-    *) if [ "$n" -gt 0 ] && [ $((n % cap)) -eq 0 ]; then printf 'window\n'; else printf 'grid\n'; fi ;;
+    # auto: grid placement, overflowing to a new workspace each time the grid fills.
+    *) if [ "$n" -gt 0 ] && [ $((n % cap)) -eq 0 ]; then printf 'workspace\n'; else printf 'grid\n'; fi ;;
   esac
 }
 
@@ -125,8 +138,8 @@ fm_terminal_cmux_layout_action() {  # <layout> <N> -> split|tab|grid|window
 # surface, only the very first worker) or a 0-based creation-order index into the
 # existing worker surfaces (see fm_terminal_cmux_worker_slots).
 fm_terminal_cmux_grid_slot() {  # <N> -> "<left|right|up|down> <caller|index>"
-  local n=$1 cap=${FM_CMUX_GRID_CAPACITY:-4} rows=${FM_CMUX_GRID_ROWS:-2} p g col row
-  [ "$cap" -ge 1 ] 2>/dev/null || cap=4
+  local n=$1 rows=${FM_CMUX_GRID_ROWS:-2} cap p g col row
+  cap=$(fm_terminal_cmux_grid_capacity)
   [ "$rows" -ge 1 ] 2>/dev/null || rows=2
   p=$((n % cap)); g=$((n / cap)); col=$((p / rows)); row=$((p % rows))
   if [ "$row" -eq 0 ]; then
@@ -148,7 +161,7 @@ fm_terminal_cmux_grid_slot() {  # <N> -> "<left|right|up|down> <caller|index>"
 # Ordered existing cmux worker (workspace, surface) pairs in creation order,
 # excluding <exclude-id>. Creation order is the numeric surface ref, which cmux
 # assigns monotonically per session (a later worker gets a higher number), so it
-# is stable across meta appends (unlike file mtime) and across windows (surface
+# is stable across meta appends (unlike file mtime) and across workspaces (surface
 # refs are global). One "<workspace>\t<surface>" per line; workspace may be empty
 # when a meta recorded none, in which case the caller falls back to its own
 # workspace. This is the anchor source for grid placement.
@@ -224,36 +237,38 @@ fm_terminal_cmux_place_grid() {  # <workspace> <caller_surface> <exclude-id> <N>
   cmux new-split "$dir" --workspace "$anchor_ws" --surface "$anchor_surface" --focus false 2>&1
 }
 
-# Overflow to a NEW cmux window. `cmux new-window` prints a bare "OK <uuid>" (NOT
-# a "window:N" short ref like every other placement command here), so capture the
-# raw handle rather than grepping for a short ref that will never appear. It also
-# auto-creates a default workspace + terminal surface in the new window and takes
-# focus there - the one placement command with no --focus flag - so the correct
-# follow-up is `cmux identify`, which resolves that now-focused window's
-# auto-created workspace/surface directly. Do not call `cmux new-workspace`/
-# `cmux new-pane` here: that would create a SECOND, unwanted workspace/surface on
-# top of the one new-window already made, and an accidentally empty --window arg
-# on new-workspace silently retargets the current/live window instead of the new
-# one. Echoes a single normalized "<surface:N> <workspace:N>" line so the caller
-# captures BOTH the new surface and the new window's workspace (which differs
-# from firstmate's).
-fm_terminal_cmux_place_new_window() {
-  local win_out win ident_out ws surface
-  win_out=$(cmux new-window 2>&1) || { printf '%s\n' "$win_out" >&2; return 1; }
-  win=$(printf '%s\n' "$win_out" | tail -1 | awk '{print $NF}')
-  [ -n "$win" ] || { echo "error: cmux new-window did not report a window ref: $win_out" >&2; return 1; }
-  ident_out=$(cmux identify --json 2>&1) || { printf '%s\n' "$ident_out" >&2; return 1; }
-  ws=$(printf '%s\n' "$ident_out" | grep -o 'workspace:[0-9][0-9]*' | tail -1 || true)
-  [ -n "$ws" ] || { echo "error: cmux identify did not report a workspace ref for new window $win: $ident_out" >&2; return 1; }
-  surface=$(printf '%s\n' "$ident_out" | grep -o 'surface:[0-9][0-9]*' | tail -1 || true)
-  [ -n "$surface" ] || { echo "error: cmux identify did not report a surface ref for new window $win: $ident_out" >&2; return 1; }
-  printf '%s %s\n' "$surface" "$ws"
+# Overflow to a NEW named cmux workspace in firstmate's current window. Never
+# pass an empty --window: resolve the current window explicitly first. cmux
+# current-window may print a bare UUID rather than a window:N ref, and
+# new-workspace accepts either. Echo a normalized "<surface:N> <workspace:N>" line
+# plus owned_workspace=1 so spawn can record cleanup ownership in task meta.
+fm_terminal_cmux_place_workspace() {  # <N>
+  local n=$1 cap grid_index name win ws_out ws surface pane surfaces
+  cap=$(fm_terminal_cmux_grid_capacity)
+  grid_index=$((n / cap + 1))
+  name="fm crew $grid_index"
+  win=$(cmux current-window 2>/dev/null | tail -1 | awk '{print $NF}') || win=
+  [ -n "$win" ] || { echo "error: cmux current-window did not report a window ref" >&2; return 1; }
+  ws_out=$(cmux new-workspace --name "$name" --window "$win" --focus false 2>&1) || { printf '%s\n' "$ws_out" >&2; return 1; }
+  ws=$(printf '%s\n' "$ws_out" | grep -o 'workspace:[0-9][0-9]*' | tail -1 || true)
+  [ -n "$ws" ] || { echo "error: cmux new-workspace did not report a workspace ref for $name in $win: $ws_out" >&2; return 1; }
+  surface=$(printf '%s\n' "$ws_out" | grep -o 'surface:[0-9][0-9]*' | tail -1 || true)
+  if [ -z "$surface" ]; then
+    for pane in $(cmux list-panes --workspace "$ws" 2>/dev/null | grep -o 'pane:[0-9][0-9]*'); do
+      surfaces=$(cmux list-pane-surfaces --workspace "$ws" --pane "$pane" 2>/dev/null | grep -o 'surface:[0-9][0-9]*' || true)
+      surface=$(printf '%s\n' "$surfaces" | head -1)
+      [ -n "$surface" ] && break
+    done
+  fi
+  [ -n "$surface" ] || { echo "error: cmux new-workspace did not create or report a terminal surface for $name in $win: $ws_out" >&2; return 1; }
+  printf '%s %s\nowned_workspace=1\n' "$surface" "$ws"
 }
 
 # Create the worker surface per the resolved layout and echo cmux's output so the
-# caller can grep out surface:N (and, for the new-window path, workspace:N). Never
+# caller can grep out surface:N (and, for the workspace overflow path, workspace:N
+# plus owned_workspace=1). Never
 # steals focus. splits/tabs/hybrid keep their pre-grid shapes; auto tiles a grid
-# and overflows to a new window when the grid is full.
+# and overflows to a new same-window workspace when the grid is full.
 fm_terminal_cmux_place_worker() {  # <workspace> <caller_surface> <layout> <exclude-id>
   local ws=$1 caller_surface=$2 layout=$3 exclude=$4 n action pane
   n=$(fm_terminal_cmux_worker_count "$exclude") || return 1
@@ -264,7 +279,7 @@ fm_terminal_cmux_place_worker() {  # <workspace> <caller_surface> <layout> <excl
   case "$action" in
     tab)    cmux new-surface --type terminal --pane "$pane" --workspace "$ws" --focus false 2>&1 ;;
     grid)   fm_terminal_cmux_place_grid "$ws" "$caller_surface" "$exclude" "$n" ;;
-    window) fm_terminal_cmux_place_new_window ;;
+    workspace) fm_terminal_cmux_place_workspace "$n" ;;
     *)      fm_terminal_cmux_split_off_caller "$ws" "$caller_surface" right ;;
   esac
 }

--- a/bin/fm-terminal-lib.sh
+++ b/bin/fm-terminal-lib.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# fm-terminal-lib.sh — backend-neutral terminal targeting for firstmate.
+# Source from scripts that need to send, read, classify, or close a direct report
+# without assuming every report is a tmux window.
+
+# shellcheck source=bin/fm-tmux-lib.sh
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/fm-tmux-lib.sh"
+
+FM_TERMINAL_BUSY_REGEX_DEFAULT='esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel'
+
+fm_terminal_meta_value() {  # <meta> <key>
+  grep "^$2=" "$1" 2>/dev/null | tail -1 | cut -d= -f2- || true
+}
+
+fm_terminal_config_backend() {  # -> tmux|cmux
+  local config_dir=${FM_CONFIG_OVERRIDE:-${CONFIG:-${FM_HOME:-}/config}} raw
+  raw=auto
+  [ -n "$config_dir" ] && [ -f "$config_dir/terminal-backend" ] && raw=$(tr -d '[:space:]' < "$config_dir/terminal-backend")
+  [ -n "$raw" ] || raw=auto
+  case "$raw" in
+    tmux|cmux) printf '%s\n' "$raw" ;;
+    auto)
+      if [ -n "${CMUX_WORKSPACE_ID:-}" ] && command -v cmux >/dev/null 2>&1 && cmux ping >/dev/null 2>&1; then
+        printf 'cmux\n'
+      else
+        printf 'tmux\n'
+      fi
+      ;;
+    *) echo "error: invalid terminal backend '$raw' in $config_dir/terminal-backend (expected tmux, cmux, or auto)" >&2; return 2 ;;
+  esac
+}
+
+fm_terminal_target_meta() {  # <target> -> meta path or empty
+  case "$1" in
+    fm-*) printf '%s/%s.meta\n' "${STATE:?STATE required}" "${1#fm-}" ;;
+  esac
+}
+
+fm_terminal_target_backend() {  # <target> -> tmux|cmux
+  local meta
+  case "$1" in
+    *:*) printf 'tmux\n'; return 0 ;;
+    fm-*)
+      meta=$(fm_terminal_target_meta "$1")
+      [ -f "$meta" ] || { echo "error: no metadata for $1 in $STATE; pass session:window to target a tmux window outside this firstmate home" >&2; return 1; }
+      fm_terminal_meta_value "$meta" terminal_backend | grep -q . && fm_terminal_meta_value "$meta" terminal_backend || printf 'tmux\n'
+      ;;
+    *) printf 'tmux\n' ;;
+  esac
+}
+
+fm_terminal_resolve_tmux() {  # <target> -> session:window
+  local meta window
+  case "$1" in
+    *:*) echo "$1" ;;
+    fm-*)
+      meta=$(fm_terminal_target_meta "$1")
+      [ -f "$meta" ] || { echo "error: no metadata for $1 in $STATE; pass session:window to target a window outside this firstmate home" >&2; return 1; }
+      window=$(fm_terminal_meta_value "$meta" window)
+      [ -n "$window" ] || { echo "error: no tmux window recorded in $meta" >&2; return 1; }
+      echo "$window"
+      ;;
+    *) tmux list-windows -a -F '#{session_name}:#{window_name}' | grep -m1 ":$1\$" \
+         || { echo "error: no window named $1" >&2; return 1; } ;;
+  esac
+}
+
+fm_terminal_cmux_workspace() {  # <fm-target>
+  local meta ws
+  meta=$(fm_terminal_target_meta "$1")
+  ws=$(fm_terminal_meta_value "$meta" workspace)
+  [ -n "$ws" ] || { echo "error: no cmux workspace recorded in $meta" >&2; return 1; }
+  printf '%s\n' "$ws"
+}
+
+fm_terminal_cmux_surface() {  # <fm-target>
+  local meta surface
+  meta=$(fm_terminal_target_meta "$1")
+  surface=$(fm_terminal_meta_value "$meta" surface)
+  [ -n "$surface" ] || { echo "error: no cmux surface recorded in $meta" >&2; return 1; }
+  printf '%s\n' "$surface"
+}
+
+fm_terminal_send_key() {  # <target> <key>
+  local target=$1 key=$2 backend t ws surface
+  backend=$(fm_terminal_target_backend "$target") || return 1
+  case "$backend" in
+    cmux)
+      case "$key" in
+        C-c) key='ctrl+c' ;;
+        C-d) key='ctrl+d' ;;
+      esac
+      ws=$(fm_terminal_cmux_workspace "$target") || return 1
+      surface=$(fm_terminal_cmux_surface "$target") || return 1
+      cmux send-key --workspace "$ws" --surface "$surface" "$key"
+      ;;
+    *)
+      t=$(fm_terminal_resolve_tmux "$target") || return 1
+      tmux send-keys -t "$t" "$key"
+      ;;
+  esac
+}
+
+fm_terminal_read() {  # <target> <lines>
+  local target=$1 lines=${2:-40} backend t ws surface
+  backend=$(fm_terminal_target_backend "$target") || return 1
+  case "$backend" in
+    cmux)
+      ws=$(fm_terminal_cmux_workspace "$target") || return 1
+      surface=$(fm_terminal_cmux_surface "$target") || return 1
+      cmux read-screen --workspace "$ws" --surface "$surface" --lines "$lines"
+      ;;
+    *)
+      t=$(fm_terminal_resolve_tmux "$target") || return 1
+      tmux capture-pane -p -t "$t" -S -"$lines"
+      ;;
+  esac
+}
+
+fm_terminal_busy() {  # <target>
+  local backend tail40 t
+  backend=$(fm_terminal_target_backend "$1") || return 1
+  case "$backend" in
+    cmux)
+      tail40=$(fm_terminal_read "$1" 40 2>/dev/null) || return 1
+      printf '%s' "$tail40" | grep -v '^[[:space:]]*$' | tail -6 \
+        | grep -qiE "${FM_BUSY_REGEX:-$FM_TERMINAL_BUSY_REGEX_DEFAULT}"
+      ;;
+    *)
+      t=$(fm_terminal_resolve_tmux "$1") || return 1
+      fm_pane_is_busy "$t"
+      ;;
+  esac
+}
+
+fm_terminal_close() {  # <target>
+  local backend t ws surface close_out
+  backend=$(fm_terminal_target_backend "$1") || return 1
+  case "$backend" in
+    cmux)
+      ws=$(fm_terminal_cmux_workspace "$1") || return 1
+      surface=$(fm_terminal_cmux_surface "$1") || return 1
+      close_out=$(cmux close-surface --workspace "$ws" --surface "$surface" 2>&1) && return 0
+      # If the process already exited, cmux may already have removed the surface.
+      # Treat that as closed. If this is the last surface in its pane, ask the
+      # terminal shell to exit instead; cmux will remove the dead surface/pane.
+      case "$close_out" in
+        *'not_found'*|*'Surface not found'*) return 0 ;;
+        *'Cannot close the last surface'*) cmux send-key --workspace "$ws" --surface "$surface" 'ctrl+d' >/dev/null 2>&1 || true; return 0 ;;
+      esac
+      printf '%s\n' "$close_out" >&2
+      return 1
+      ;;
+    *)
+      t=$(fm_terminal_resolve_tmux "$1") || return 1
+      tmux kill-window -t "$t" 2>/dev/null || true
+      ;;
+  esac
+}

--- a/bin/fm-terminal-lib.sh
+++ b/bin/fm-terminal-lib.sh
@@ -49,7 +49,10 @@ fm_terminal_config_backend() {  # -> tmux|cmux
 #   worker 2 -> new-split down off worker 1  (bottom of column 1)
 #   worker 3 -> new-split right off worker 1 (top of column 2)
 #   worker 4 -> new-split down off worker 3  (bottom of column 2)
-#   worker 5 -> new cmux window (grid at capacity), then the grid fills again.
+#   worker 5 -> new cmux window (grid at capacity); `cmux new-window` auto-creates
+#              a default workspace + terminal surface in that window (resolved via
+#              `cmux identify`, not a separate new-workspace/new-pane call), then
+#              the grid fills again there.
 # Anchors are resolved from the recorded worker surfaces/workspaces in
 # state/*.meta, ordered by cmux's monotonically-increasing surface ref (a later
 # worker gets a higher surface number), so the ordering is stable across meta
@@ -221,23 +224,29 @@ fm_terminal_cmux_place_grid() {  # <workspace> <caller_surface> <exclude-id> <N>
   cmux new-split "$dir" --workspace "$anchor_ws" --surface "$anchor_surface" --focus false 2>&1
 }
 
-# Overflow to a NEW cmux window: create the window, a workspace in it, and a
-# terminal surface in that workspace. cmux new-window is bare (no --focus flag),
-# so it may take focus - every command that CAN take --focus false does. Echoes a
-# single normalized "<surface:N> <workspace:N>" line so the caller captures BOTH
-# the new surface and the new window's workspace (which differs from firstmate's).
+# Overflow to a NEW cmux window. `cmux new-window` prints a bare "OK <uuid>" (NOT
+# a "window:N" short ref like every other placement command here), so capture the
+# raw handle rather than grepping for a short ref that will never appear. It also
+# auto-creates a default workspace + terminal surface in the new window and takes
+# focus there - the one placement command with no --focus flag - so the correct
+# follow-up is `cmux identify`, which resolves that now-focused window's
+# auto-created workspace/surface directly. Do not call `cmux new-workspace`/
+# `cmux new-pane` here: that would create a SECOND, unwanted workspace/surface on
+# top of the one new-window already made, and an accidentally empty --window arg
+# on new-workspace silently retargets the current/live window instead of the new
+# one. Echoes a single normalized "<surface:N> <workspace:N>" line so the caller
+# captures BOTH the new surface and the new window's workspace (which differs
+# from firstmate's).
 fm_terminal_cmux_place_new_window() {
-  local win_out win ws_out ws pane_out surface
+  local win_out win ident_out ws surface
   win_out=$(cmux new-window 2>&1) || { printf '%s\n' "$win_out" >&2; return 1; }
-  win=$(printf '%s\n' "$win_out" | grep -o 'window:[0-9][0-9]*' | tail -1 || true)
-  [ -n "$win" ] || win=$(cmux current-window 2>/dev/null | grep -o 'window:[0-9][0-9]*' | tail -1 || true)
-  [ -n "$win" ] || { echo "error: cmux new-window did not report a window ref" >&2; return 1; }
-  ws_out=$(cmux new-workspace --window "$win" --focus false 2>&1) || { printf '%s\n' "$ws_out" >&2; return 1; }
-  ws=$(printf '%s\n' "$ws_out" | grep -o 'workspace:[0-9][0-9]*' | tail -1 || true)
-  [ -n "$ws" ] || { echo "error: cmux new-workspace did not report a workspace ref" >&2; return 1; }
-  pane_out=$(cmux new-pane --type terminal --direction right --workspace "$ws" --focus false 2>&1) || { printf '%s\n' "$pane_out" >&2; return 1; }
-  surface=$(printf '%s\n' "$pane_out" | grep -o 'surface:[0-9][0-9]*' | tail -1 || true)
-  [ -n "$surface" ] || { echo "error: cmux new-pane did not report a surface ref in the new window: $pane_out" >&2; return 1; }
+  win=$(printf '%s\n' "$win_out" | tail -1 | awk '{print $NF}')
+  [ -n "$win" ] || { echo "error: cmux new-window did not report a window ref: $win_out" >&2; return 1; }
+  ident_out=$(cmux identify --json 2>&1) || { printf '%s\n' "$ident_out" >&2; return 1; }
+  ws=$(printf '%s\n' "$ident_out" | grep -o 'workspace:[0-9][0-9]*' | tail -1 || true)
+  [ -n "$ws" ] || { echo "error: cmux identify did not report a workspace ref for new window $win: $ident_out" >&2; return 1; }
+  surface=$(printf '%s\n' "$ident_out" | grep -o 'surface:[0-9][0-9]*' | tail -1 || true)
+  [ -n "$surface" ] || { echo "error: cmux identify did not report a surface ref for new window $win: $ident_out" >&2; return 1; }
   printf '%s %s\n' "$surface" "$ws"
 }
 

--- a/bin/fm-terminal-lib.sh
+++ b/bin/fm-terminal-lib.sh
@@ -33,16 +33,40 @@ fm_terminal_config_backend() {  # -> tmux|cmux
 # --- cmux multi-worker layout policy ---------------------------------------
 #
 # Placement policy for a NEW cmux worker, given how many cmux workers this home
-# already has. Mielye default (auto): the 1st..3rd workers each get their own
-# visible split so they are watchable at once; the 4th and later workers overflow
-# to a tab (extra surface) in an existing worker pane instead of an unbounded pile
-# of splits. Explicit config/cmux-layout values force one shape.
+# already has. Mielye default (auto): firstmate's own pane stays pinned on the
+# LEFT and is never sliced into a strip; workers tile into a 2-row grid to its
+# right (a 2x2 for the default capacity of 4). When the grid is full the next
+# worker opens a NEW cmux window and the grid fills again there. Explicit
+# config/cmux-layout values force one shape:
+#   splits - a visible right-split off firstmate per worker (vertical strips).
+#   tabs   - one crew pane (first worker splits) then worker tabs.
+#   hybrid - split up to FM_CMUX_SPLIT_THRESHOLD, then tab overflow (the pre-grid
+#            "auto" behaviour, kept available under its own name).
+#   auto   - grid + new-window overflow (the new default described above).
+#
+# Grid tiling detail (auto), column-major over FM_CMUX_GRID_ROWS rows:
+#   worker 1 -> new-split right off firstmate's caller surface (top-right cell)
+#   worker 2 -> new-split down off worker 1  (bottom of column 1)
+#   worker 3 -> new-split right off worker 1 (top of column 2)
+#   worker 4 -> new-split down off worker 3  (bottom of column 2)
+#   worker 5 -> new cmux window (grid at capacity), then the grid fills again.
+# Anchors are resolved from the recorded worker surfaces/workspaces in
+# state/*.meta, ordered by cmux's monotonically-increasing surface ref (a later
+# worker gets a higher surface number), so the ordering is stable across meta
+# appends and across windows.
 #
 # FM_CMUX_SPLIT_THRESHOLD is the max number of EXISTING workers that still get a
-# split under auto/hybrid: a new worker splits while count < threshold and
-# overflows to a tab once count >= threshold (so with 3, workers 1-3 split and
-# worker 4+ tabs). Named so it is obvious and tunable.
+# split under hybrid: a new worker splits while count < threshold and overflows
+# to a tab once count >= threshold (so with 3, workers 1-3 split and worker 4+
+# tabs). Named so it is obvious and tunable.
 FM_CMUX_SPLIT_THRESHOLD=${FM_CMUX_SPLIT_THRESHOLD:-3}
+# FM_CMUX_GRID_CAPACITY is how many workers fill one grid (one window) before the
+# next worker overflows to a new window. Default 4 = the 2x2 grid.
+FM_CMUX_GRID_CAPACITY=${FM_CMUX_GRID_CAPACITY:-4}
+# FM_CMUX_GRID_ROWS is the grid height (rows per column). The grid fills
+# column-major: each column is filled top-to-bottom before the next column opens
+# to its right. Default 2 gives the 2x2 grid at the default capacity.
+FM_CMUX_GRID_ROWS=${FM_CMUX_GRID_ROWS:-2}
 
 fm_terminal_cmux_layout() {  # -> splits|tabs|hybrid|auto
   local config_dir=${FM_CONFIG_OVERRIDE:-${CONFIG:-${FM_HOME:-}/config}} raw
@@ -72,18 +96,71 @@ fm_terminal_cmux_worker_count() {  # <exclude-id> -> N
   printf '%s\n' "$n"
 }
 
-# Decide placement for a new worker: split (own visible pane) or tab (overflow
-# surface). N is the existing cmux worker count.
-fm_terminal_cmux_layout_action() {  # <layout> <N> -> split|tab
-  local layout=$1 n=$2
+# Decide placement for a new worker. N is the existing cmux worker count.
+# Returns: split (right-split off firstmate), tab (overflow surface in a worker
+# pane), grid (auto grid placement, resolve direction+anchor via grid_slot), or
+# window (auto overflow to a new cmux window).
+fm_terminal_cmux_layout_action() {  # <layout> <N> -> split|tab|grid|window
+  local layout=$1 n=$2 cap=${FM_CMUX_GRID_CAPACITY:-4}
+  [ "$cap" -ge 1 ] 2>/dev/null || cap=4
   case "$layout" in
     splits) printf 'split\n' ;;
     # tabs: the first worker still opens a visible split to create the crew pane;
     # every later worker becomes a tab in it.
     tabs) [ "$n" -eq 0 ] && printf 'split\n' || printf 'tab\n' ;;
-    # hybrid and auto share the Mielye default: split up to the threshold, then tab.
-    *) [ "$n" -lt "$FM_CMUX_SPLIT_THRESHOLD" ] && printf 'split\n' || printf 'tab\n' ;;
+    # hybrid: the pre-grid default - split up to the threshold, then tab overflow.
+    hybrid) [ "$n" -lt "$FM_CMUX_SPLIT_THRESHOLD" ] && printf 'split\n' || printf 'tab\n' ;;
+    # auto: grid placement, overflowing to a new window each time the grid fills.
+    *) if [ "$n" -gt 0 ] && [ $((n % cap)) -eq 0 ]; then printf 'window\n'; else printf 'grid\n'; fi ;;
   esac
+}
+
+# Grid slot for the new worker at existing-count N: which direction to split and
+# what to anchor on. Pure arithmetic (column-major over FM_CMUX_GRID_ROWS rows,
+# FM_CMUX_GRID_CAPACITY per grid), so it is unit-testable without cmux. Prints
+# "<direction> <anchor>" where <anchor> is "caller" (split off firstmate's own
+# surface, only the very first worker) or a 0-based creation-order index into the
+# existing worker surfaces (see fm_terminal_cmux_worker_slots).
+fm_terminal_cmux_grid_slot() {  # <N> -> "<left|right|up|down> <caller|index>"
+  local n=$1 cap=${FM_CMUX_GRID_CAPACITY:-4} rows=${FM_CMUX_GRID_ROWS:-2} p g col row
+  [ "$cap" -ge 1 ] 2>/dev/null || cap=4
+  [ "$rows" -ge 1 ] 2>/dev/null || rows=2
+  p=$((n % cap)); g=$((n / cap)); col=$((p / rows)); row=$((p % rows))
+  if [ "$row" -eq 0 ]; then
+    # Top of a column: open the column with a rightward split. The very first
+    # worker (p==0, g==0) splits off firstmate; a later column's top splits off
+    # the top worker of the previous column in this same grid.
+    if [ "$p" -eq 0 ]; then
+      printf 'right caller\n'
+    else
+      printf 'right %d\n' $((g * cap + (col - 1) * rows))
+    fi
+  else
+    # Lower cell in a column: split down off the worker directly above it, which
+    # is always the immediately-preceding worker (index N-1).
+    printf 'down %d\n' $((n - 1))
+  fi
+}
+
+# Ordered existing cmux worker (workspace, surface) pairs in creation order,
+# excluding <exclude-id>. Creation order is the numeric surface ref, which cmux
+# assigns monotonically per session (a later worker gets a higher number), so it
+# is stable across meta appends (unlike file mtime) and across windows (surface
+# refs are global). One "<workspace>\t<surface>" per line; workspace may be empty
+# when a meta recorded none, in which case the caller falls back to its own
+# workspace. This is the anchor source for grid placement.
+fm_terminal_cmux_worker_slots() {  # <exclude-id>
+  local exclude=$1 state=${STATE:?STATE required} meta base surface workspace
+  for meta in "$state"/*.meta; do
+    [ -f "$meta" ] || continue
+    base=$(basename "$meta" .meta)
+    [ "$base" = "$exclude" ] && continue
+    [ "$(fm_terminal_meta_value "$meta" terminal_backend)" = cmux ] || continue
+    surface=$(fm_terminal_meta_value "$meta" surface)
+    [ -n "$surface" ] || continue
+    workspace=$(fm_terminal_meta_value "$meta" workspace)
+    printf '%s\t%s\t%s\n' "${surface#surface:}" "$workspace" "$surface"
+  done | sort -t"$(printf '\t')" -k1,1n | cut -f2,3
 }
 
 # The pane a tab-overflow worker should stack into: the pane of the most recently
@@ -108,11 +185,66 @@ fm_terminal_cmux_overflow_pane() {  # <exclude-id> -> pane:N
   printf '%s\n' "$newest_pane"
 }
 
+# Split off firstmate's own caller surface (or a fresh right-pane when there is
+# no caller surface). Used by the splits/tabs/hybrid first-worker path and as the
+# grid's caller/fallback anchor. Echoes cmux output; --focus false never steals
+# focus.
+fm_terminal_cmux_split_off_caller() {  # <workspace> <caller_surface> <direction>
+  local ws=$1 caller_surface=$2 dir=${3:-right}
+  if [ -n "$caller_surface" ]; then
+    cmux new-split "$dir" --workspace "$ws" --surface "$caller_surface" --focus false 2>&1
+  else
+    cmux new-pane --type terminal --direction "$dir" --workspace "$ws" --focus false 2>&1
+  fi
+}
+
+# Grid placement for the new worker at existing-count N: resolve the direction and
+# anchor from grid_slot, then split off the anchor worker's own surface/workspace
+# (so a later column and a later window both split off the correct prior worker).
+# Falls back to splitting off firstmate if the anchor cannot be resolved.
+fm_terminal_cmux_place_grid() {  # <workspace> <caller_surface> <exclude-id> <N>
+  local ws=$1 caller_surface=$2 exclude=$3 n=$4 slot dir anchor line anchor_ws anchor_surface
+  slot=$(fm_terminal_cmux_grid_slot "$n")
+  dir=${slot%% *}; anchor=${slot##* }
+  if [ "$anchor" = caller ]; then
+    fm_terminal_cmux_split_off_caller "$ws" "$caller_surface" "$dir"
+    return
+  fi
+  line=$(fm_terminal_cmux_worker_slots "$exclude" | sed -n "$((anchor + 1))p")
+  anchor_ws=$(printf '%s' "$line" | cut -f1)
+  anchor_surface=$(printf '%s' "$line" | cut -f2)
+  if [ -z "$anchor_surface" ]; then
+    fm_terminal_cmux_split_off_caller "$ws" "$caller_surface" "$dir"
+    return
+  fi
+  [ -n "$anchor_ws" ] || anchor_ws=$ws
+  cmux new-split "$dir" --workspace "$anchor_ws" --surface "$anchor_surface" --focus false 2>&1
+}
+
+# Overflow to a NEW cmux window: create the window, a workspace in it, and a
+# terminal surface in that workspace. cmux new-window is bare (no --focus flag),
+# so it may take focus - every command that CAN take --focus false does. Echoes a
+# single normalized "<surface:N> <workspace:N>" line so the caller captures BOTH
+# the new surface and the new window's workspace (which differs from firstmate's).
+fm_terminal_cmux_place_new_window() {
+  local win_out win ws_out ws pane_out surface
+  win_out=$(cmux new-window 2>&1) || { printf '%s\n' "$win_out" >&2; return 1; }
+  win=$(printf '%s\n' "$win_out" | grep -o 'window:[0-9][0-9]*' | tail -1 || true)
+  [ -n "$win" ] || win=$(cmux current-window 2>/dev/null | grep -o 'window:[0-9][0-9]*' | tail -1 || true)
+  [ -n "$win" ] || { echo "error: cmux new-window did not report a window ref" >&2; return 1; }
+  ws_out=$(cmux new-workspace --window "$win" --focus false 2>&1) || { printf '%s\n' "$ws_out" >&2; return 1; }
+  ws=$(printf '%s\n' "$ws_out" | grep -o 'workspace:[0-9][0-9]*' | tail -1 || true)
+  [ -n "$ws" ] || { echo "error: cmux new-workspace did not report a workspace ref" >&2; return 1; }
+  pane_out=$(cmux new-pane --type terminal --direction right --workspace "$ws" --focus false 2>&1) || { printf '%s\n' "$pane_out" >&2; return 1; }
+  surface=$(printf '%s\n' "$pane_out" | grep -o 'surface:[0-9][0-9]*' | tail -1 || true)
+  [ -n "$surface" ] || { echo "error: cmux new-pane did not report a surface ref in the new window: $pane_out" >&2; return 1; }
+  printf '%s %s\n' "$surface" "$ws"
+}
+
 # Create the worker surface per the resolved layout and echo cmux's output so the
-# caller can grep out surface:N. Runs exactly one cmux command (never steals focus)
-# and returns its exit status. Split uses new-split off the caller surface (or a
-# new-pane when there is no caller surface); tab overflow uses new-surface in an
-# existing worker pane, falling back to a split when no such pane exists yet.
+# caller can grep out surface:N (and, for the new-window path, workspace:N). Never
+# steals focus. splits/tabs/hybrid keep their pre-grid shapes; auto tiles a grid
+# and overflows to a new window when the grid is full.
 fm_terminal_cmux_place_worker() {  # <workspace> <caller_surface> <layout> <exclude-id>
   local ws=$1 caller_surface=$2 layout=$3 exclude=$4 n action pane
   n=$(fm_terminal_cmux_worker_count "$exclude") || return 1
@@ -120,13 +252,12 @@ fm_terminal_cmux_place_worker() {  # <workspace> <caller_surface> <layout> <excl
   if [ "$action" = tab ]; then
     pane=$(fm_terminal_cmux_overflow_pane "$exclude") || action='split'
   fi
-  if [ "$action" = tab ]; then
-    cmux new-surface --type terminal --pane "$pane" --workspace "$ws" --focus false 2>&1
-  elif [ -n "$caller_surface" ]; then
-    cmux new-split right --workspace "$ws" --surface "$caller_surface" --focus false 2>&1
-  else
-    cmux new-pane --type terminal --direction right --workspace "$ws" --focus false 2>&1
-  fi
+  case "$action" in
+    tab)    cmux new-surface --type terminal --pane "$pane" --workspace "$ws" --focus false 2>&1 ;;
+    grid)   fm_terminal_cmux_place_grid "$ws" "$caller_surface" "$exclude" "$n" ;;
+    window) fm_terminal_cmux_place_new_window ;;
+    *)      fm_terminal_cmux_split_off_caller "$ws" "$caller_surface" right ;;
+  esac
 }
 
 fm_terminal_target_meta() {  # <target> -> meta path or empty

--- a/bin/fm-terminal-lib.sh
+++ b/bin/fm-terminal-lib.sh
@@ -56,7 +56,10 @@ fm_terminal_cmux_layout() {  # -> splits|tabs|hybrid|auto
 }
 
 # Count live cmux workers this home already has: state/<id>.meta with
-# terminal_backend=cmux, excluding the task being spawned and any secondmate.
+# terminal_backend=cmux, excluding only the task being spawned. Secondmates count
+# like any other cmux worker (Phase B slice 3): a cmux secondmate is a first-class
+# visible worker, so it participates in the layout count for its own placement and
+# for later workers' placement.
 fm_terminal_cmux_worker_count() {  # <exclude-id> -> N
   local exclude=$1 state=${STATE:?STATE required} meta base n=0
   for meta in "$state"/*.meta; do
@@ -64,7 +67,6 @@ fm_terminal_cmux_worker_count() {  # <exclude-id> -> N
     base=$(basename "$meta" .meta)
     [ "$base" = "$exclude" ] && continue
     [ "$(fm_terminal_meta_value "$meta" terminal_backend)" = cmux ] || continue
-    [ "$(fm_terminal_meta_value "$meta" kind)" = secondmate ] && continue
     n=$((n + 1))
   done
   printf '%s\n' "$n"
@@ -86,7 +88,9 @@ fm_terminal_cmux_layout_action() {  # <layout> <N> -> split|tab
 
 # The pane a tab-overflow worker should stack into: the pane of the most recently
 # spawned cmux worker, so overflow lands in an existing worker pane. Empty (rc 1)
-# when no such pane is recorded, letting the caller fall back to a split.
+# when no such pane is recorded, letting the caller fall back to a split. A cmux
+# secondmate counts like any other cmux worker (Phase B slice 3), so its pane is a
+# valid overflow target too.
 fm_terminal_cmux_overflow_pane() {  # <exclude-id> -> pane:N
   local exclude=$1 state=${STATE:?STATE required} meta base pane newest='' newest_pane=''
   for meta in "$state"/*.meta; do
@@ -94,7 +98,6 @@ fm_terminal_cmux_overflow_pane() {  # <exclude-id> -> pane:N
     base=$(basename "$meta" .meta)
     [ "$base" = "$exclude" ] && continue
     [ "$(fm_terminal_meta_value "$meta" terminal_backend)" = cmux ] || continue
-    [ "$(fm_terminal_meta_value "$meta" kind)" = secondmate ] && continue
     pane=$(fm_terminal_meta_value "$meta" pane)
     [ -n "$pane" ] || continue
     if [ -z "$newest" ] || [ "$meta" -nt "$newest" ]; then

--- a/bin/fm-terminal-lib.sh
+++ b/bin/fm-terminal-lib.sh
@@ -33,11 +33,9 @@ fm_terminal_config_backend() {  # -> tmux|cmux
 # --- cmux multi-worker layout policy ---------------------------------------
 #
 # Placement policy for a NEW cmux worker, given how many cmux workers this home
-# already has. Mielye default (auto): firstmate's own pane stays pinned on the
-# LEFT and is never sliced into a strip; workers tile into a 2-row grid to its
-# right (a 2x2 for the default capacity of 4). When the grid is full the next
-# worker opens a NEW cmux workspace in firstmate's current window and the grid
-# fills again there. Explicit
+# already has. Mielye default (auto): workers never share firstmate's caller
+# workspace. Each grid lives in an owned cmux workspace in firstmate's current
+# window, starting with worker 1 in "fm crew 1". Explicit
 # config/cmux-layout values force one shape:
 #   splits - a visible right-split off firstmate per worker (vertical strips).
 #   tabs   - one crew pane (first worker splits) then worker tabs.
@@ -46,11 +44,12 @@ fm_terminal_config_backend() {  # -> tmux|cmux
 #   auto   - grid + same-window workspace overflow (the default described above).
 #
 # Grid tiling detail (auto), column-major over FM_CMUX_GRID_ROWS rows:
-#   worker 1 -> new-split right off firstmate's caller surface (top-right cell)
+#   worker 1 -> new named workspace "fm crew 1"; its first surface is top-left
 #   worker 2 -> new-split down off worker 1  (bottom of column 1)
 #   worker 3 -> new-split right off worker 1 (top of column 2)
 #   worker 4 -> new-split down off worker 3  (bottom of column 2)
-#   worker 5 -> new named workspace in firstmate's current window (grid at
+#   worker 5 -> new named workspace "fm crew 2" in firstmate's current window
+#              (grid at
 #              capacity); `cmux new-workspace` creates the first terminal surface
 #              for that workspace, then the grid fills again there.
 # Anchors are resolved from the recorded worker surfaces/workspaces in
@@ -126,8 +125,8 @@ fm_terminal_cmux_layout_action() {  # <layout> <N> -> split|tab|grid|workspace
     tabs) [ "$n" -eq 0 ] && printf 'split\n' || printf 'tab\n' ;;
     # hybrid: the pre-grid default - split up to the threshold, then tab overflow.
     hybrid) [ "$n" -lt "$FM_CMUX_SPLIT_THRESHOLD" ] && printf 'split\n' || printf 'tab\n' ;;
-    # auto: grid placement, overflowing to a new workspace each time the grid fills.
-    *) if [ "$n" -gt 0 ] && [ $((n % cap)) -eq 0 ]; then printf 'workspace\n'; else printf 'grid\n'; fi ;;
+    # auto: each grid starts in an owned workspace, including the first worker.
+    *) if [ $((n % cap)) -eq 0 ]; then printf 'workspace\n'; else printf 'grid\n'; fi ;;
   esac
 }
 
@@ -135,8 +134,9 @@ fm_terminal_cmux_layout_action() {  # <layout> <N> -> split|tab|grid|workspace
 # what to anchor on. Pure arithmetic (column-major over FM_CMUX_GRID_ROWS rows,
 # FM_CMUX_GRID_CAPACITY per grid), so it is unit-testable without cmux. Prints
 # "<direction> <anchor>" where <anchor> is "caller" (split off firstmate's own
-# surface, only the very first worker) or a 0-based creation-order index into the
-# existing worker surfaces (see fm_terminal_cmux_worker_slots).
+# surface, retained as a defensive pure-arithmetic case but unreachable through
+# auto placement) or a 0-based creation-order index into the existing worker
+# surfaces (see fm_terminal_cmux_worker_slots).
 fm_terminal_cmux_grid_slot() {  # <N> -> "<left|right|up|down> <caller|index>"
   local n=$1 rows=${FM_CMUX_GRID_ROWS:-2} cap p g col row
   cap=$(fm_terminal_cmux_grid_capacity)
@@ -202,9 +202,8 @@ fm_terminal_cmux_overflow_pane() {  # <exclude-id> -> pane:N
 }
 
 # Split off firstmate's own caller surface (or a fresh right-pane when there is
-# no caller surface). Used by the splits/tabs/hybrid first-worker path and as the
-# grid's caller/fallback anchor. Echoes cmux output; --focus false never steals
-# focus.
+# no caller surface). Used by forced splits/tabs/hybrid paths only. Echoes cmux
+# output; --focus false never steals focus.
 fm_terminal_cmux_split_off_caller() {  # <workspace> <caller_surface> <direction>
   local ws=$1 caller_surface=$2 dir=${3:-right}
   if [ -n "$caller_surface" ]; then
@@ -217,23 +216,27 @@ fm_terminal_cmux_split_off_caller() {  # <workspace> <caller_surface> <direction
 # Grid placement for the new worker at existing-count N: resolve the direction and
 # anchor from grid_slot, then split off the anchor worker's own surface/workspace
 # (so a later column and a later window both split off the correct prior worker).
-# Falls back to splitting off firstmate if the anchor cannot be resolved.
+# Falls back to a fresh owned workspace if the anchor cannot be resolved, because
+# auto placement must never target the caller's workspace.
 fm_terminal_cmux_place_grid() {  # <workspace> <caller_surface> <exclude-id> <N>
-  local ws=$1 caller_surface=$2 exclude=$3 n=$4 slot dir anchor line anchor_ws anchor_surface
+  local exclude=$3 n=$4 slot dir anchor line anchor_ws anchor_surface
   slot=$(fm_terminal_cmux_grid_slot "$n")
   dir=${slot%% *}; anchor=${slot##* }
   if [ "$anchor" = caller ]; then
-    fm_terminal_cmux_split_off_caller "$ws" "$caller_surface" "$dir"
+    fm_terminal_cmux_place_workspace "$n"
     return
   fi
   line=$(fm_terminal_cmux_worker_slots "$exclude" | sed -n "$((anchor + 1))p")
   anchor_ws=$(printf '%s' "$line" | cut -f1)
   anchor_surface=$(printf '%s' "$line" | cut -f2)
   if [ -z "$anchor_surface" ]; then
-    fm_terminal_cmux_split_off_caller "$ws" "$caller_surface" "$dir"
+    fm_terminal_cmux_place_workspace "$n"
     return
   fi
-  [ -n "$anchor_ws" ] || anchor_ws=$ws
+  if [ -z "$anchor_ws" ]; then
+    fm_terminal_cmux_place_workspace "$n"
+    return
+  fi
   cmux new-split "$dir" --workspace "$anchor_ws" --surface "$anchor_surface" --focus false 2>&1
 }
 
@@ -267,8 +270,8 @@ fm_terminal_cmux_place_workspace() {  # <N>
 # Create the worker surface per the resolved layout and echo cmux's output so the
 # caller can grep out surface:N (and, for the workspace overflow path, workspace:N
 # plus owned_workspace=1). Never
-# steals focus. splits/tabs/hybrid keep their pre-grid shapes; auto tiles a grid
-# and overflows to a new same-window workspace when the grid is full.
+# steals focus. splits/tabs/hybrid keep their pre-grid shapes; auto tiles in
+# owned same-window workspaces and starts a new workspace when each grid fills.
 fm_terminal_cmux_place_worker() {  # <workspace> <caller_surface> <layout> <exclude-id>
   local ws=$1 caller_surface=$2 layout=$3 exclude=$4 n action pane
   n=$(fm_terminal_cmux_worker_count "$exclude") || return 1

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -11,9 +11,11 @@
 #   signal: <file>...      status/turn-end signals, surfaced when a listed status
 #                          has a captain-relevant verb OR a no-verb signal's crew
 #                          is not provably working, unless afk is active
-#   stale: <window>        terminal stale pane, a non-terminal stale whose crew is
+#   stale: <worker>        terminal stale pane, a non-terminal stale whose crew is
 #                          not provably working (surfaced at once), or a provably-
-#                          working stale past the wedge threshold, unless afk active
+#                          working stale past the wedge threshold, unless afk active.
+#                          <worker> is a tmux window (session:window) or, for a cmux
+#                          worker, its fm-<id> terminal target
 #   check: <script>: <out> per-task check output, always actionable
 #   heartbeat              fleet-scan backstop found an unsurfaced captain-relevant
 #                          status, unless afk is active
@@ -36,6 +38,13 @@ mkdir -p "$STATE"
 # has one definition.
 # shellcheck source=bin/fm-classify-lib.sh
 . "$SCRIPT_DIR/fm-classify-lib.sh"
+# Backend-neutral terminal boundary (tmux today, cmux workers too). The stale-pane
+# read below goes through fm_terminal_read so a cmux worker (which records no
+# window=, only workspace/surface) is supervised the same way a tmux window is.
+# For a tmux window target the lib runs the identical `tmux capture-pane` it did
+# before, so tmux behavior is unchanged.
+# shellcheck source=bin/fm-terminal-lib.sh
+. "$SCRIPT_DIR/fm-terminal-lib.sh"
 
 WATCH_LOCK="$STATE/.watch.lock"
 WATCH_PATH="$SCRIPT_DIR/fm-watch.sh"
@@ -143,12 +152,28 @@ hash_pane() {
   if command -v md5 >/dev/null 2>&1; then md5 -q; else md5sum | cut -d' ' -f1; fi
 }
 
-window_kind() {
-  local w=$1 meta mw kind
+# Kind of the worker a stale-loop token refers to. The token is either a tmux
+# window (session:window, contains a colon) or a cmux terminal target (fm-<id>,
+# no colon). A tmux token is resolved by matching window= across metas, exactly
+# as before; a cmux token resolves its meta directly by task id.
+worker_kind() {
+  local tok=$1 meta mw kind id
+  case "$tok" in
+    *:*) : ;;   # tmux window token: match by window= below (unchanged behavior)
+    *)
+      id=$(window_to_task "$tok")
+      meta="$STATE/$id.meta"
+      [ -e "$meta" ] || { echo unknown; return 0; }
+      kind=$(grep '^kind=' "$meta" | cut -d= -f2- || true)
+      [ -n "$kind" ] || kind=ship
+      echo "$kind"
+      return 0
+      ;;
+  esac
   for meta in "$STATE"/*.meta; do
     [ -e "$meta" ] || continue
     mw=$(grep '^window=' "$meta" | cut -d= -f2- || true)
-    [ "$mw" = "$w" ] || continue
+    [ "$mw" = "$tok" ] || continue
     kind=$(grep '^kind=' "$meta" | cut -d= -f2- || true)
     [ -n "$kind" ] || kind=ship
     echo "$kind"
@@ -157,12 +182,23 @@ window_kind() {
   echo unknown
 }
 
-recorded_windows() {
-  local meta w seen=
+# Enumerate the workers the stale loop should read, one token per line. A tmux
+# task records window=<session:window> and is emitted as that window (unchanged).
+# A cmux task records no window=, only terminal_backend=cmux + workspace/surface,
+# so it is emitted as its fm-<id> terminal target; the stale loop then reads its
+# screen through fm_terminal_read like any other worker. Metas with neither are
+# skipped (nothing pane-based to supervise).
+recorded_workers() {
+  local meta w backend id seen=
   for meta in "$STATE"/*.meta; do
     [ -e "$meta" ] || continue
     w=$(grep '^window=' "$meta" | cut -d= -f2- || true)
-    [ -n "$w" ] || continue
+    if [ -z "$w" ]; then
+      backend=$(grep '^terminal_backend=' "$meta" | cut -d= -f2- || true)
+      [ "$backend" = cmux ] || continue
+      id=$(basename "$meta" .meta)
+      w="fm-$id"
+    fi
     case "$seen" in
       *"|$w|"*) continue ;;
     esac
@@ -378,8 +414,12 @@ EOF
   while IFS= read -r w; do
     # A secondmate idling on its own watcher is healthy. Its parent supervises
     # it through status writes and heartbeats, not pane-idle staleness.
-    [ "$(window_kind "$w")" = secondmate ] && continue
-    tail40=$(tmux capture-pane -p -t "$w" -S -40 2>/dev/null) || continue
+    [ "$(worker_kind "$w")" = secondmate ] && continue
+    # Read the worker's screen through the terminal boundary: a tmux window runs
+    # the identical `tmux capture-pane -p -t <w> -S -40`, a cmux worker runs
+    # `cmux read-screen`. A read failure (torn-down/unreadable) is skipped, so a
+    # missing screen reports nothing rather than a guessed state.
+    tail40=$(fm_terminal_read "$w" 40 2>/dev/null) || continue
     h=$(printf '%s' "$tail40" | hash_pane)
     key=$(printf '%s' "$w" | tr ':/.' '___')
     hf="$STATE/.hash-$key"
@@ -464,7 +504,7 @@ EOF
       # Pane content changed: the crew is active again, so reset the escalation timer.
       rm -f "$ssf"
     fi
-  done < <(recorded_windows)
+  done < <(recorded_workers)
 
   # Heartbeat: the watcher runs a cheap fleet-scan at a regular cadence no matter
   # what. Time-based via .last-heartbeat mtime; interval doubles per consecutive

--- a/docs/cmux-terminal-backend/spec.md
+++ b/docs/cmux-terminal-backend/spec.md
@@ -227,6 +227,7 @@ Cheapest proof for first slice:
    - teardown safely.
 4. Verify branch/commit preservation from the primary sandbox repo after cleanup.
 5. Layout policy (slice 2): under `auto`, spawn workers in sequence and confirm the 1st–3rd each open a visible split and the 4th+ overflow to a tab in an existing worker pane; confirm `config/cmux-layout=splits|tabs|hybrid` force the expected shape and none steal focus.
+6. Secondmate cmux (slice 3): with `config/terminal-backend=cmux`, route/spawn a secondmate and confirm it opens a visible cmux surface in its persistent firstmate home (no treehouse worktree lease), placed by the same layout policy without stealing focus; its meta records `terminal_backend=cmux` + `surface`/`workspace`/`pane` + `home`/`projects` and no `worktree=`/`window=`; the pre-launch home fast-forward and config inheritance still run; and the watcher leaves the idle secondmate surface alone (idle = healthy).
 
 ## Testing strategy
 
@@ -238,7 +239,7 @@ Cheapest proof for first slice:
 ## Out of scope for first slice
 
 - Replacing every watcher path in one PR.
-- Full secondmate cmux support; secondmate spawn remains tmux-only in the first slice even when `config/terminal-backend=cmux`.
+- Full secondmate cmux support; secondmate spawn remains tmux-only in the first slice even when `config/terminal-backend=cmux`. (Landed later in slice 3: secondmates launch in cmux surfaces in their persistent home — see verification step 6.)
 - X mode / public reply integration.
 - Automatic PR creation or no-mistakes changes.
 - Polished status UI, badges, or notifications beyond basic surface naming/flash.

--- a/docs/cmux-terminal-backend/spec.md
+++ b/docs/cmux-terminal-backend/spec.md
@@ -68,10 +68,10 @@ config/cmux-layout
 
 Allowed values:
 
-- `splits` — visible split per worker.
-- `tabs` — one crew pane with worker tabs.
-- `hybrid` — split layout up to threshold, then tab overflow.
-- absent / `auto` — Mielye default: visible splits for 1–3 workers, hybrid for 4+.
+- `splits` — a visible right-split off firstmate per worker (vertical strips).
+- `tabs` — one crew pane (first worker splits) with worker tabs.
+- `hybrid` — split up to `FM_CMUX_SPLIT_THRESHOLD`, then tab overflow (the pre-grid `auto` behaviour, kept under its own name).
+- absent / `auto` — Mielye default: firstmate pinned left, workers tile a grid to its right, overflowing to a new window when the grid is full (see Layout policy).
 
 ### Backend library
 
@@ -133,16 +133,39 @@ For cmux worker spawn:
 
 ### Layout policy
 
-Mielye default:
+Mielye default (`auto`): firstmate's own pane stays pinned on the **left** and is
+never sliced into a strip. Workers tile into a **grid** to its right — a 2-row
+grid filled column-major (a 2×2 for the default capacity of 4). When the grid is
+full the next worker opens a **new cmux window** and the grid fills again there.
 
-- 1–3 active workers: create visible splits, so workers are watchable at once.
-- 4+ active workers: use hybrid overflow, preserving firstmate visibility and avoiding pane chaos.
+Concrete tiling for `auto` (capacity `FM_CMUX_GRID_CAPACITY`, default 4; rows
+`FM_CMUX_GRID_ROWS`, default 2):
 
-Implementation can start simpler:
+- Worker 1: `cmux new-split right` off firstmate's caller surface → top-right cell.
+- Worker 2: `cmux new-split down` off worker 1's surface → bottom of column 1.
+- Worker 3: `cmux new-split right` off worker 1's surface → top of column 2.
+- Worker 4: `cmux new-split down` off worker 3's surface → bottom of column 2.
+- Worker 5 (grid full): `cmux new-window`, a `cmux new-workspace` in it, and a
+  `cmux new-pane` terminal surface — then the grid fills again in that window.
 
-- first cmux slice may create one right-side worker pane only;
-- first slice should explicitly mark layout threshold support as not implemented yet;
-- second slice adds split counting + hybrid overflow.
+Later workers anchor (split) off a **prior worker's** surface with an alternating
+direction, so firstmate is only ever the anchor for worker 1. Anchors are
+resolved from the recorded worker `surface`/`workspace` values in `state/*.meta`,
+ordered by cmux's monotonically-increasing surface ref (a later worker gets a
+higher number), so ordering is stable across meta appends and across windows.
+Every command that accepts `--focus` passes `--focus false`; `cmux new-window` is
+bare (no `--focus` flag) and is the one command that can take focus.
+
+Tunables (local, env): `FM_CMUX_GRID_CAPACITY` sets how many workers fill one grid
+(one window) before overflow; `FM_CMUX_GRID_ROWS` sets the grid height;
+`FM_CMUX_SPLIT_THRESHOLD` still governs `hybrid`.
+
+Implementation history:
+
+- first cmux slice created one right-side worker pane only;
+- second slice added split counting + hybrid tab overflow;
+- this slice replaced the `auto` default with the grid + new-window policy above
+  (`hybrid` keeps the old split-then-tab behaviour under its own name).
 
 ### Outcome detection
 
@@ -175,7 +198,7 @@ cmux teardown must preserve the current safety invariant:
 - Use backend abstraction, not a one-off cmux fork.
 - Keep tmux fallback.
 - Use `treehouse get --lease` for cmux instead of interactive `treehouse get`.
-- Default UX is visible splits for up to 3 workers, hybrid for 4+.
+- Default UX (`auto`) is firstmate pinned left with workers in a grid to its right, overflowing to a new window when the grid is full; `hybrid` retains the earlier split-to-threshold-then-tab behaviour.
 - First implementation slice should not attempt every firstmate feature at once.
 - X mode is additive over the terminal backend, not a per-backend fork (slice 4). The X-path scripts (`bin/fm-x-*.sh`) and the `fmx-respond` skill are terminal-independent: they only read/write `state/<id>.meta` by line and talk to the relay, never reading `window=` or calling tmux. An X mention that spawns real work rides the same cmux-aware lifecycle as any task — `fm-spawn.sh` (slices 1–2), `fm-watch.sh` (slice 1), and `fm-crew-state.sh` (slice 1) — so the audit found no residual tmux/`window=` assumption to fix.
 
@@ -210,8 +233,9 @@ cmux teardown must preserve the current safety invariant:
 
 Later-slice layout acceptance:
 
-- Given 1–3 live cmux workers, when new workers spawn, then they appear as visible splits.
-- Given 4+ live cmux workers, when another worker spawns, then overflow uses hybrid/tab behavior instead of unlimited random splits.
+- Given `auto` and an empty-to-full grid, when workers 1–4 spawn, then they tile a 2×2 grid to firstmate's right (right/down/right/down, anchored off firstmate then prior workers), with firstmate never sliced into a strip.
+- Given `auto` and a full grid (`FM_CMUX_GRID_CAPACITY` workers), when another worker spawns, then it opens a new cmux window and is placed there instead of piling more splits/tabs into the existing window.
+- Given `config/cmux-layout=splits|tabs|hybrid`, when workers spawn, then each forces its named shape and none steal focus.
 
 Slice 4 X-mode-under-cmux acceptance:
 
@@ -233,7 +257,7 @@ Cheapest proof for first slice:
    - interrupt long command;
    - teardown safely.
 4. Verify branch/commit preservation from the primary sandbox repo after cleanup.
-5. Layout policy (slice 2): under `auto`, spawn workers in sequence and confirm the 1st–3rd each open a visible split and the 4th+ overflow to a tab in an existing worker pane; confirm `config/cmux-layout=splits|tabs|hybrid` force the expected shape and none steal focus.
+5. Layout policy: under `auto`, spawn workers in sequence and confirm workers 1–4 tile a 2×2 grid to firstmate's right (right/down/right/down, anchored off firstmate then prior workers) and worker 5 opens a new cmux window; confirm `config/cmux-layout=splits|tabs|hybrid` force the expected shape and none steal focus. Automated coverage lives in `tests/fm-terminal-cmux.test.sh` (grid arithmetic, grid command shapes, new-window overflow, cross-window anchoring, focus).
 6. Secondmate cmux (slice 3): with `config/terminal-backend=cmux`, route/spawn a secondmate and confirm it opens a visible cmux surface in its persistent firstmate home (no treehouse worktree lease), placed by the same layout policy without stealing focus; its meta records `terminal_backend=cmux` + `surface`/`workspace`/`pane` + `home`/`projects` and no `worktree=`/`window=`; the pre-launch home fast-forward and config inheritance still run; and the watcher leaves the idle secondmate surface alone (idle = healthy).
 7. X mode under cmux (slice 4): automated coverage lives in `tests/fm-x-cmux.test.sh` — the link records into a cmux meta (no `window=`), `fm-x-followup.sh --check` reports/prunes the due `request_id` for a cmux-linked task, the dry-run follow-up loop clears the link, and the X path never shells out to tmux for a cmux task (tmux tripwire). Manual live-cmux checklist (needs a live relay + cmux app): with `FMX_PAIRING_TOKEN` in `.env` and `config/terminal-backend=cmux`, post an actionable mention to `@myfirstmate`, then confirm the poll wakes firstmate, `fmx-respond` spawns a **visible cmux worker** for the work, `bin/fm-x-link.sh` links it, and when that cmux worker finishes the single completion follow-up posts back to the mention (verify via `state/x-outbox/` under `FMX_DRY_RUN` first, then live).
 

--- a/docs/cmux-terminal-backend/spec.md
+++ b/docs/cmux-terminal-backend/spec.md
@@ -143,32 +143,37 @@ For cmux worker spawn:
 
 ### Layout policy
 
-Mielye default (`auto`): firstmate's own pane stays pinned on the **left** and is
-never sliced into a strip. Workers tile into a **grid** to its right — a 2-row
-grid filled column-major (a 2×2 for the default capacity of 4). When the grid is
-full the next worker opens a **new named workspace in firstmate's current cmux
-window** and the grid fills again there. Overflow never opens a new OS window.
+Mielye default (`auto`): workers never share firstmate's caller workspace. Each
+grid lives in an owned **new named workspace in firstmate's current cmux window**,
+starting with worker 1 in `fm crew 1`; the grid fills column-major (a 2×2 for the
+default capacity of 4), and when it is full the next worker opens `fm crew 2`,
+then `fm crew 3`, and so on. Overflow never opens a new OS window. Rationale:
+on 2026-07-02, closing a worker surface in the caller workspace killed the live
+firstmate chat, so `auto` must isolate workers from the caller workspace.
 
 Concrete tiling for `auto` (capacity `FM_CMUX_GRID_CAPACITY`, default 4; rows
 `FM_CMUX_GRID_ROWS`, default 2):
 
-- Worker 1: `cmux new-split right` off firstmate's caller surface → top-right cell.
+- Worker 1: resolve firstmate's current window explicitly with
+  `cmux current-window`, then `cmux new-workspace --name "fm crew 1" --window <id>
+  --focus false`. The new workspace's first terminal surface becomes worker 1.
 - Worker 2: `cmux new-split down` off worker 1's surface → bottom of column 1.
 - Worker 3: `cmux new-split right` off worker 1's surface → top of column 2.
 - Worker 4: `cmux new-split down` off worker 3's surface → bottom of column 2.
-- Worker 5 (grid full): resolve firstmate's current window explicitly with
-  `cmux current-window`, then `cmux new-workspace --name "fm crew 2" --window <id>
-  --focus false`. The new workspace's first terminal surface becomes worker 5.
+- Worker 5 (grid full): create `fm crew 2`. The new workspace's first terminal
+  surface becomes worker 5.
 - Worker 6+: split within that overflow workspace using the recorded
   `workspace=`/`surface=` anchors from prior workers. The next overflow workspace
   is named `fm crew 3`, and so on.
 
 Later workers anchor (split) off a **prior worker's** surface with an alternating
-direction, so firstmate is only ever the anchor for worker 1. Anchors are
-resolved from the recorded worker `surface`/`workspace` values in `state/*.meta`,
-ordered by cmux's monotonically-increasing surface ref (a later worker gets a
-higher number), so ordering is stable across meta appends and across workspaces.
-Every command that accepts `--focus` passes `--focus false`.
+direction. Firstmate's caller workspace is never a placement target under
+`auto`; if a grid anchor is missing, placement starts a fresh owned crew
+workspace instead of splitting off the caller. Anchors are resolved from the
+recorded worker `surface`/`workspace` values in `state/*.meta`, ordered by cmux's
+monotonically-increasing surface ref (a later worker gets a higher number), so
+ordering is stable across meta appends and across workspaces. Every command that
+accepts `--focus` passes `--focus false`.
 
 Tunables: `FM_CMUX_GRID_CAPACITY` or `config/cmux-grid-capacity` sets how many
 workers fill one grid before workspace overflow; `FM_CMUX_GRID_ROWS` sets the
@@ -178,9 +183,8 @@ Implementation history:
 
 - first cmux slice created one right-side worker pane only;
 - second slice added split counting + hybrid tab overflow;
-- this slice replaced the `auto` default with the grid + same-window workspace
-  overflow policy above (`hybrid` keeps the old split-then-tab behaviour under
-  its own name).
+- this slice replaced the `auto` default with owned crew workspaces from worker
+  1 (`hybrid` keeps the old split-then-tab behaviour under its own name).
 
 ### Outcome detection
 
@@ -253,8 +257,8 @@ cmux teardown must preserve the current safety invariant:
 
 Later-slice layout acceptance:
 
-- Given `auto` and an empty-to-full grid, when workers 1–4 spawn, then they tile a 2×2 grid to firstmate's right (right/down/right/down, anchored off firstmate then prior workers), with firstmate never sliced into a strip.
-- Given `auto` and a full grid (`FM_CMUX_GRID_CAPACITY` workers), when another worker spawns, then it opens a named workspace (`fm crew 2`, `fm crew 3`, ...) in firstmate's current cmux window and is placed there instead of piling more splits/tabs into the existing workspace or opening a new OS window.
+- Given `auto` and an empty-to-full grid, when workers 1–4 spawn, then worker 1 creates `fm crew 1` and workers 2–4 tile inside that owned workspace using prior-worker anchors, with firstmate's caller workspace never used as a placement target.
+- Given `auto` and a full grid (`FM_CMUX_GRID_CAPACITY` workers), when another worker spawns, then it opens the next named workspace (`fm crew 2`, `fm crew 3`, ...) in firstmate's current cmux window and is placed there instead of piling more splits/tabs into the existing workspace or opening a new OS window.
 - Given a task owns an overflow workspace (`owned_workspace=1`), when teardown closes its surface and no other live meta references that workspace, then teardown closes the workspace; without the marker, or while another live task references the workspace, teardown never closes it.
 - Given `config/cmux-layout=splits|tabs|hybrid`, when workers spawn, then each forces its named shape and none steal focus.
 
@@ -278,7 +282,7 @@ Cheapest proof for first slice:
    - interrupt long command;
    - teardown safely.
 4. Verify branch/commit preservation from the primary sandbox repo after cleanup.
-5. Layout policy: under `auto`, spawn workers in sequence and confirm workers 1–4 tile a 2×2 grid to firstmate's right (right/down/right/down, anchored off firstmate then prior workers) and worker 5 opens `fm crew 2` in the same cmux window; confirm `config/cmux-layout=splits|tabs|hybrid` force the expected shape and none steal focus. Automated coverage lives in `tests/fm-terminal-cmux.test.sh` (grid arithmetic, capacity config, grid command shapes, workspace overflow, cross-workspace anchoring, focus, and owned-workspace teardown).
+5. Layout policy: under `auto`, spawn workers in sequence and confirm worker 1 opens `fm crew 1`, workers 2–4 tile inside that workspace, worker 5 opens `fm crew 2`, and no `auto` placement targets firstmate's caller workspace; confirm `config/cmux-layout=splits|tabs|hybrid` force the expected shape and none steal focus. Automated coverage lives in `tests/fm-terminal-cmux.test.sh` (grid arithmetic, capacity config, grid command shapes, workspace overflow, cross-workspace anchoring, focus, and owned-workspace teardown).
 6. Secondmate cmux (slice 3): with `config/terminal-backend=cmux`, route/spawn a secondmate and confirm it opens a visible cmux surface in its persistent firstmate home (no treehouse worktree lease), placed by the same layout policy without stealing focus; its meta records `terminal_backend=cmux` + `surface`/`workspace`/`pane` + `home`/`projects` and no `worktree=`/`window=`; the pre-launch home fast-forward and config inheritance still run; and the watcher leaves the idle secondmate surface alone (idle = healthy).
 7. X mode under cmux (slice 4): automated coverage lives in `tests/fm-x-cmux.test.sh` — the link records into a cmux meta (no `window=`), `fm-x-followup.sh --check` reports/prunes the due `request_id` for a cmux-linked task, the dry-run follow-up loop clears the link, and the X path never shells out to tmux for a cmux task (tmux tripwire). Manual live-cmux checklist (needs a live relay + cmux app): with `FMX_PAIRING_TOKEN` in `.env` and `config/terminal-backend=cmux`, post an actionable mention to `@myfirstmate`, then confirm the poll wakes firstmate, `fmx-respond` spawns a **visible cmux worker** for the work, `bin/fm-x-link.sh` links it, and when that cmux worker finishes the single completion follow-up posts back to the mention (verify via `state/x-outbox/` under `FMX_DRY_RUN` first, then live).
 

--- a/docs/cmux-terminal-backend/spec.md
+++ b/docs/cmux-terminal-backend/spec.md
@@ -71,7 +71,17 @@ Allowed values:
 - `splits` — a visible right-split off firstmate per worker (vertical strips).
 - `tabs` — one crew pane (first worker splits) with worker tabs.
 - `hybrid` — split up to `FM_CMUX_SPLIT_THRESHOLD`, then tab overflow (the pre-grid `auto` behaviour, kept under its own name).
-- absent / `auto` — Mielye default: firstmate pinned left, workers tile a grid to its right, overflowing to a new window when the grid is full (see Layout policy).
+- absent / `auto` — Mielye default: firstmate pinned left, workers tile a grid to its right, overflowing to a named workspace in the same cmux window when the grid is full (see Layout policy).
+
+Add optional local grid-capacity config:
+
+```text
+config/cmux-grid-capacity
+```
+
+Single positive integer. Precedence is `FM_CMUX_GRID_CAPACITY` env, then
+`config/cmux-grid-capacity`, then default `4`. Invalid, empty, or non-positive
+values fall back to `4` without failing spawn.
 
 ### Backend library
 
@@ -136,7 +146,8 @@ For cmux worker spawn:
 Mielye default (`auto`): firstmate's own pane stays pinned on the **left** and is
 never sliced into a strip. Workers tile into a **grid** to its right — a 2-row
 grid filled column-major (a 2×2 for the default capacity of 4). When the grid is
-full the next worker opens a **new cmux window** and the grid fills again there.
+full the next worker opens a **new named workspace in firstmate's current cmux
+window** and the grid fills again there. Overflow never opens a new OS window.
 
 Concrete tiling for `auto` (capacity `FM_CMUX_GRID_CAPACITY`, default 4; rows
 `FM_CMUX_GRID_ROWS`, default 2):
@@ -145,29 +156,31 @@ Concrete tiling for `auto` (capacity `FM_CMUX_GRID_CAPACITY`, default 4; rows
 - Worker 2: `cmux new-split down` off worker 1's surface → bottom of column 1.
 - Worker 3: `cmux new-split right` off worker 1's surface → top of column 2.
 - Worker 4: `cmux new-split down` off worker 3's surface → bottom of column 2.
-- Worker 5 (grid full): `cmux new-window` — which prints a bare `OK <uuid>`, not a
-  `window:N` short ref, and auto-creates a default workspace + terminal surface in
-  the new window, taking focus there — resolved via `cmux identify` (no separate
-  `new-workspace`/`new-pane` call) — then the grid fills again in that window.
+- Worker 5 (grid full): resolve firstmate's current window explicitly with
+  `cmux current-window`, then `cmux new-workspace --name "fm crew 2" --window <id>
+  --focus false`. The new workspace's first terminal surface becomes worker 5.
+- Worker 6+: split within that overflow workspace using the recorded
+  `workspace=`/`surface=` anchors from prior workers. The next overflow workspace
+  is named `fm crew 3`, and so on.
 
 Later workers anchor (split) off a **prior worker's** surface with an alternating
 direction, so firstmate is only ever the anchor for worker 1. Anchors are
 resolved from the recorded worker `surface`/`workspace` values in `state/*.meta`,
 ordered by cmux's monotonically-increasing surface ref (a later worker gets a
-higher number), so ordering is stable across meta appends and across windows.
-Every command that accepts `--focus` passes `--focus false`; `cmux new-window` is
-bare (no `--focus` flag) and is the one command that can take focus.
+higher number), so ordering is stable across meta appends and across workspaces.
+Every command that accepts `--focus` passes `--focus false`.
 
-Tunables (local, env): `FM_CMUX_GRID_CAPACITY` sets how many workers fill one grid
-(one window) before overflow; `FM_CMUX_GRID_ROWS` sets the grid height;
-`FM_CMUX_SPLIT_THRESHOLD` still governs `hybrid`.
+Tunables: `FM_CMUX_GRID_CAPACITY` or `config/cmux-grid-capacity` sets how many
+workers fill one grid before workspace overflow; `FM_CMUX_GRID_ROWS` sets the
+grid height; `FM_CMUX_SPLIT_THRESHOLD` still governs `hybrid`.
 
 Implementation history:
 
 - first cmux slice created one right-side worker pane only;
 - second slice added split counting + hybrid tab overflow;
-- this slice replaced the `auto` default with the grid + new-window policy above
-  (`hybrid` keeps the old split-then-tab behaviour under its own name).
+- this slice replaced the `auto` default with the grid + same-window workspace
+  overflow policy above (`hybrid` keeps the old split-then-tab behaviour under
+  its own name).
 
 ### Outcome detection
 
@@ -193,14 +206,19 @@ cmux teardown must preserve the current safety invariant:
 - never close/return a worker with uncommitted work unless explicitly forced;
 - never discard committed work not merged/pushed/landed;
 - close cmux surface only after worktree safety checks pass;
+- when teardown closes a task whose meta carries `owned_workspace=1`, close that
+  workspace only if no other live `state/*.meta` references the same `workspace=`;
+  never close unmarked workspaces;
 - if close-surface fails, leave metadata and report the surface handle.
+- if close-workspace fails, report the leftover workspace ref but continue
+  teardown.
 
 ## Decisions
 
 - Use backend abstraction, not a one-off cmux fork.
 - Keep tmux fallback.
 - Use `treehouse get --lease` for cmux instead of interactive `treehouse get`.
-- Default UX (`auto`) is firstmate pinned left with workers in a grid to its right, overflowing to a new window when the grid is full; `hybrid` retains the earlier split-to-threshold-then-tab behaviour.
+- Default UX (`auto`) is firstmate pinned left with workers in a grid to its right, overflowing to a named workspace in the same cmux window when the grid is full; `hybrid` retains the earlier split-to-threshold-then-tab behaviour.
 - First implementation slice should not attempt every firstmate feature at once.
 - X mode is additive over the terminal backend, not a per-backend fork (slice 4). The X-path scripts (`bin/fm-x-*.sh`) and the `fmx-respond` skill are terminal-independent: they only read/write `state/<id>.meta` by line and talk to the relay, never reading `window=` or calling tmux. An X mention that spawns real work rides the same cmux-aware lifecycle as any task — `fm-spawn.sh` (slices 1–2), `fm-watch.sh` (slice 1), and `fm-crew-state.sh` (slice 1) — so the audit found no residual tmux/`window=` assumption to fix.
 
@@ -236,7 +254,8 @@ cmux teardown must preserve the current safety invariant:
 Later-slice layout acceptance:
 
 - Given `auto` and an empty-to-full grid, when workers 1–4 spawn, then they tile a 2×2 grid to firstmate's right (right/down/right/down, anchored off firstmate then prior workers), with firstmate never sliced into a strip.
-- Given `auto` and a full grid (`FM_CMUX_GRID_CAPACITY` workers), when another worker spawns, then it opens a new cmux window and is placed there instead of piling more splits/tabs into the existing window.
+- Given `auto` and a full grid (`FM_CMUX_GRID_CAPACITY` workers), when another worker spawns, then it opens a named workspace (`fm crew 2`, `fm crew 3`, ...) in firstmate's current cmux window and is placed there instead of piling more splits/tabs into the existing workspace or opening a new OS window.
+- Given a task owns an overflow workspace (`owned_workspace=1`), when teardown closes its surface and no other live meta references that workspace, then teardown closes the workspace; without the marker, or while another live task references the workspace, teardown never closes it.
 - Given `config/cmux-layout=splits|tabs|hybrid`, when workers spawn, then each forces its named shape and none steal focus.
 
 Slice 4 X-mode-under-cmux acceptance:
@@ -259,7 +278,7 @@ Cheapest proof for first slice:
    - interrupt long command;
    - teardown safely.
 4. Verify branch/commit preservation from the primary sandbox repo after cleanup.
-5. Layout policy: under `auto`, spawn workers in sequence and confirm workers 1–4 tile a 2×2 grid to firstmate's right (right/down/right/down, anchored off firstmate then prior workers) and worker 5 opens a new cmux window; confirm `config/cmux-layout=splits|tabs|hybrid` force the expected shape and none steal focus. Automated coverage lives in `tests/fm-terminal-cmux.test.sh` (grid arithmetic, grid command shapes, new-window overflow, cross-window anchoring, focus).
+5. Layout policy: under `auto`, spawn workers in sequence and confirm workers 1–4 tile a 2×2 grid to firstmate's right (right/down/right/down, anchored off firstmate then prior workers) and worker 5 opens `fm crew 2` in the same cmux window; confirm `config/cmux-layout=splits|tabs|hybrid` force the expected shape and none steal focus. Automated coverage lives in `tests/fm-terminal-cmux.test.sh` (grid arithmetic, capacity config, grid command shapes, workspace overflow, cross-workspace anchoring, focus, and owned-workspace teardown).
 6. Secondmate cmux (slice 3): with `config/terminal-backend=cmux`, route/spawn a secondmate and confirm it opens a visible cmux surface in its persistent firstmate home (no treehouse worktree lease), placed by the same layout policy without stealing focus; its meta records `terminal_backend=cmux` + `surface`/`workspace`/`pane` + `home`/`projects` and no `worktree=`/`window=`; the pre-launch home fast-forward and config inheritance still run; and the watcher leaves the idle secondmate surface alone (idle = healthy).
 7. X mode under cmux (slice 4): automated coverage lives in `tests/fm-x-cmux.test.sh` — the link records into a cmux meta (no `window=`), `fm-x-followup.sh --check` reports/prunes the due `request_id` for a cmux-linked task, the dry-run follow-up loop clears the link, and the X path never shells out to tmux for a cmux task (tmux tripwire). Manual live-cmux checklist (needs a live relay + cmux app): with `FMX_PAIRING_TOKEN` in `.env` and `config/terminal-backend=cmux`, post an actionable mention to `@myfirstmate`, then confirm the poll wakes firstmate, `fmx-respond` spawns a **visible cmux worker** for the work, `bin/fm-x-link.sh` links it, and when that cmux worker finishes the single completion follow-up posts back to the mention (verify via `state/x-outbox/` under `FMX_DRY_RUN` first, then live).
 

--- a/docs/cmux-terminal-backend/spec.md
+++ b/docs/cmux-terminal-backend/spec.md
@@ -226,6 +226,7 @@ Cheapest proof for first slice:
    - interrupt long command;
    - teardown safely.
 4. Verify branch/commit preservation from the primary sandbox repo after cleanup.
+5. Layout policy (slice 2): under `auto`, spawn workers in sequence and confirm the 1st–3rd each open a visible split and the 4th+ overflow to a tab in an existing worker pane; confirm `config/cmux-layout=splits|tabs|hybrid` force the expected shape and none steal focus.
 
 ## Testing strategy
 

--- a/docs/cmux-terminal-backend/spec.md
+++ b/docs/cmux-terminal-backend/spec.md
@@ -145,8 +145,10 @@ Concrete tiling for `auto` (capacity `FM_CMUX_GRID_CAPACITY`, default 4; rows
 - Worker 2: `cmux new-split down` off worker 1's surface → bottom of column 1.
 - Worker 3: `cmux new-split right` off worker 1's surface → top of column 2.
 - Worker 4: `cmux new-split down` off worker 3's surface → bottom of column 2.
-- Worker 5 (grid full): `cmux new-window`, a `cmux new-workspace` in it, and a
-  `cmux new-pane` terminal surface — then the grid fills again in that window.
+- Worker 5 (grid full): `cmux new-window` — which prints a bare `OK <uuid>`, not a
+  `window:N` short ref, and auto-creates a default workspace + terminal surface in
+  the new window, taking focus there — resolved via `cmux identify` (no separate
+  `new-workspace`/`new-pane` call) — then the grid fills again in that window.
 
 Later workers anchor (split) off a **prior worker's** surface with an alternating
 direction, so firstmate is only ever the anchor for worker 1. Anchors are

--- a/docs/cmux-terminal-backend/spec.md
+++ b/docs/cmux-terminal-backend/spec.md
@@ -177,6 +177,7 @@ cmux teardown must preserve the current safety invariant:
 - Use `treehouse get --lease` for cmux instead of interactive `treehouse get`.
 - Default UX is visible splits for up to 3 workers, hybrid for 4+.
 - First implementation slice should not attempt every firstmate feature at once.
+- X mode is additive over the terminal backend, not a per-backend fork (slice 4). The X-path scripts (`bin/fm-x-*.sh`) and the `fmx-respond` skill are terminal-independent: they only read/write `state/<id>.meta` by line and talk to the relay, never reading `window=` or calling tmux. An X mention that spawns real work rides the same cmux-aware lifecycle as any task — `fm-spawn.sh` (slices 1–2), `fm-watch.sh` (slice 1), and `fm-crew-state.sh` (slice 1) — so the audit found no residual tmux/`window=` assumption to fix.
 
 ## Invariants
 
@@ -212,6 +213,12 @@ Later-slice layout acceptance:
 - Given 1–3 live cmux workers, when new workers spawn, then they appear as visible splits.
 - Given 4+ live cmux workers, when another worker spawns, then overflow uses hybrid/tab behavior instead of unlimited random splits.
 
+Slice 4 X-mode-under-cmux acceptance:
+
+- Given `config/terminal-backend=cmux`, when an actionable X mention spawns a task, then it spawns a cmux worker (no `window=`; `terminal_backend=cmux` + `surface`) through the normal lifecycle, with no X-specific spawn path.
+- Given a cmux task, when `bin/fm-x-link.sh` links it to its originating mention, then `x_request=`/`x_request_ts=` are recorded and every cmux meta field is preserved, and no `window=` line is introduced.
+- Given a cmux X-linked task reaches a terminal state, when the completion wake fires (via `fm-crew-state.sh`, slice 1), then `bin/fm-x-followup.sh --check` reports the due `request_id` and the single follow-up posts through `bin/fm-x-reply.sh --followup`; a link past the 24h window is pruned silently.
+
 ## Verification loop
 
 Cheapest proof for first slice:
@@ -228,6 +235,7 @@ Cheapest proof for first slice:
 4. Verify branch/commit preservation from the primary sandbox repo after cleanup.
 5. Layout policy (slice 2): under `auto`, spawn workers in sequence and confirm the 1st–3rd each open a visible split and the 4th+ overflow to a tab in an existing worker pane; confirm `config/cmux-layout=splits|tabs|hybrid` force the expected shape and none steal focus.
 6. Secondmate cmux (slice 3): with `config/terminal-backend=cmux`, route/spawn a secondmate and confirm it opens a visible cmux surface in its persistent firstmate home (no treehouse worktree lease), placed by the same layout policy without stealing focus; its meta records `terminal_backend=cmux` + `surface`/`workspace`/`pane` + `home`/`projects` and no `worktree=`/`window=`; the pre-launch home fast-forward and config inheritance still run; and the watcher leaves the idle secondmate surface alone (idle = healthy).
+7. X mode under cmux (slice 4): automated coverage lives in `tests/fm-x-cmux.test.sh` — the link records into a cmux meta (no `window=`), `fm-x-followup.sh --check` reports/prunes the due `request_id` for a cmux-linked task, the dry-run follow-up loop clears the link, and the X path never shells out to tmux for a cmux task (tmux tripwire). Manual live-cmux checklist (needs a live relay + cmux app): with `FMX_PAIRING_TOKEN` in `.env` and `config/terminal-backend=cmux`, post an actionable mention to `@myfirstmate`, then confirm the poll wakes firstmate, `fmx-respond` spawns a **visible cmux worker** for the work, `bin/fm-x-link.sh` links it, and when that cmux worker finishes the single completion follow-up posts back to the mention (verify via `state/x-outbox/` under `FMX_DRY_RUN` first, then live).
 
 ## Testing strategy
 
@@ -240,7 +248,7 @@ Cheapest proof for first slice:
 
 - Replacing every watcher path in one PR.
 - Full secondmate cmux support; secondmate spawn remains tmux-only in the first slice even when `config/terminal-backend=cmux`. (Landed later in slice 3: secondmates launch in cmux surfaces in their persistent home — see verification step 6.)
-- X mode / public reply integration.
+- X mode / public reply integration. (Audited in slice 4: X mode is additive and already works under cmux via the slices-1–3 cmux-aware lifecycle — no core change needed; see verification step 7 and `tests/fm-x-cmux.test.sh`.)
 - Automatic PR creation or no-mistakes changes.
 - Polished status UI, badges, or notifications beyond basic surface naming/flash.
 - Removing tmux.

--- a/docs/cmux-terminal-backend/spec.md
+++ b/docs/cmux-terminal-backend/spec.md
@@ -1,0 +1,248 @@
+# cmux terminal backend spec
+
+## What
+
+Add a terminal backend boundary to firstmate so workers can run in visible cmux panes while keeping the existing tmux implementation as the default fallback.
+
+First slice: cmux mode can spawn one visible ship/scout worker in an isolated treehouse worktree, send it the brief, read its screen, detect terminal outcomes, and clean it up safely. Secondmates stay on the existing tmux path until a later slice.
+
+## Context
+
+firstmate currently assumes tmux in its core lifecycle:
+
+- `bin/fm-spawn.sh` creates tmux windows, runs `treehouse get`, launches the harness, and records `window=<session:window>`.
+- `bin/fm-send.sh` sends prompts with tmux key injection.
+- `bin/fm-peek.sh` reads panes with tmux capture.
+- `bin/fm-watch.sh` detects stale/busy workers from tmux pane text.
+- `bin/fm-teardown.sh` kills tmux windows and returns treehouse worktrees.
+
+Manual smoke tests on 2026-06-29 proved cmux has the needed primitives:
+
+- visible worker panes can launch `pi` directly;
+- `cmux send` can steer an idle worker;
+- `cmux read-screen` can read worker output;
+- `cmux send-key ctrl+c` can interrupt a long command;
+- parallel cmux workers can use separate treehouse worktrees and commit safely;
+- cleanup can return treehouse worktrees, close surfaces, and preserve committed branches.
+
+## Requirements
+
+- Preserve existing tmux behavior unless cmux mode is explicitly selected or safely auto-detected.
+- Add a backend boundary instead of scattering cmux conditionals through every script.
+- Support at least these backend operations:
+  - spawn surface/window in a project/worktree path;
+  - send literal text and submit it reliably (`cmux send` requires a trailing `\n` / `\r` to press Enter);
+  - send special keys, especially `ctrl+c` / Escape / Enter where supported;
+  - read recent screen text;
+  - detect whether the worker is busy from footer text;
+  - close the worker surface/window;
+  - store a durable target handle in `state/<id>.meta`.
+- For cmux mode, record enough metadata to recover after firstmate restarts: `terminal_backend=cmux`, `workspace=...`, `surface=...`, `pane=...`, `worktree=...`.
+- All scripts that read meta must tolerate cmux tasks without `window=`; today some paths assume `window=` exists under `set -e`, so target resolution must move behind the backend boundary before cmux meta is written.
+- For tmux mode, continue to record existing `window=<session:window>` and keep old scripts compatible.
+- Use `treehouse get --lease --lease-holder <id>` for cmux worker acquisition so spawn can get the worktree path without an interactive subshell.
+- Return cmux worktrees with `treehouse return --force <worktree>` only after the same landed/dirty safety checks already used by teardown.
+- If cmux CLI/socket is unavailable, fail clearly or fall back to tmux depending on config.
+
+## Design
+
+### Config
+
+Add a local config knob:
+
+```text
+config/terminal-backend
+```
+
+Allowed values:
+
+- `tmux` — current behavior.
+- `cmux` — visible cmux workers.
+- absent / `auto` — use cmux only when `CMUX_WORKSPACE_ID` and `cmux ping` are available; otherwise tmux.
+
+Add optional local layout config:
+
+```text
+config/cmux-layout
+```
+
+Allowed values:
+
+- `splits` — visible split per worker.
+- `tabs` — one crew pane with worker tabs.
+- `hybrid` — split layout up to threshold, then tab overflow.
+- absent / `auto` — Mielye default: visible splits for 1–3 workers, hybrid for 4+.
+
+### Backend library
+
+Add a new backend abstraction, likely:
+
+```text
+bin/fm-terminal-lib.sh
+bin/fm-terminal-tmux.sh
+bin/fm-terminal-cmux.sh
+```
+
+The public functions should be small and shell-friendly:
+
+```sh
+fm_terminal_backend_resolve
+fm_terminal_spawn <id> <cwd> <title> <launch-command>
+fm_terminal_send <id-or-target> <text>
+fm_terminal_send_key <id-or-target> <key>
+fm_terminal_read <id-or-target> <lines>
+fm_terminal_busy <id-or-target>
+fm_terminal_close <id-or-target>
+```
+
+Use shell-safe function names; avoid pseudo-subcommands in function names unless implemented as one dispatcher function with an explicit subcommand argument.
+
+Existing scripts call the generic functions. Backend files own tmux/cmux command details.
+
+Target compatibility rules:
+
+- Bare `fm-<id>` resolves through `state/<id>.meta` and chooses the backend recorded there.
+- Explicit `session:window` remains a tmux escape hatch for existing operators/tests.
+- cmux targeting uses `workspace + surface`; pane is recorded for layout/recovery, but `surface` is the normal send/read/close target.
+
+### cmux spawn shape
+
+For cmux worker spawn:
+
+1. Resolve current workspace from `CMUX_WORKSPACE_ID` or `cmux identify --json`.
+2. Lease worktree:
+   ```sh
+   WT=$(cd "$PROJECT" && treehouse get --lease --lease-holder "$ID")
+   ```
+3. Create worker pane/surface based on layout policy, capturing the returned `workspace`, `pane`, and `surface` refs.
+4. Start the harness in `WT` with the generated launch command by sending a single setup command to the new surface, for example `cd <WT> && export GOTMPDIR=... && <launch>\n`. cmux split/surface commands do not take `cwd` / `command` flags the way `new-workspace` does.
+5. Record meta only after the worktree and surface exist and launch setup has been sent:
+   ```text
+   terminal_backend=cmux
+   workspace=workspace:N
+   pane=pane:N
+   surface=surface:N
+   worktree=/...
+   project=/...
+   harness=pi|claude|codex|...
+   kind=ship|scout
+   mode=...
+   yolo=...
+   tasktmp=/tmp/fm-<id>
+   ```
+
+### Layout policy
+
+Mielye default:
+
+- 1–3 active workers: create visible splits, so workers are watchable at once.
+- 4+ active workers: use hybrid overflow, preserving firstmate visibility and avoiding pane chaos.
+
+Implementation can start simpler:
+
+- first cmux slice may create one right-side worker pane only;
+- first slice should explicitly mark layout threshold support as not implemented yet;
+- second slice adds split counting + hybrid overflow.
+
+### Outcome detection
+
+Do not depend only on visual text long-term. Preserve status-file signaling where harness hooks already exist.
+
+For cmux screen-reading, detect public markers as fallback:
+
+- `done:` / `ready in branch` / `checks green`
+- `needs-decision:` / `NEEDS_DECISION:`
+- `blocked:`
+- `failed:` / `FAILED:`
+
+Busy detection can reuse the current busy footer patterns:
+
+- Claude/Codex: `esc to interrupt`
+- Pi: `Working...`
+- Grok: `Ctrl+c:cancel`
+
+### Cleanup
+
+cmux teardown must preserve the current safety invariant:
+
+- never close/return a worker with uncommitted work unless explicitly forced;
+- never discard committed work not merged/pushed/landed;
+- close cmux surface only after worktree safety checks pass;
+- if close-surface fails, leave metadata and report the surface handle.
+
+## Decisions
+
+- Use backend abstraction, not a one-off cmux fork.
+- Keep tmux fallback.
+- Use `treehouse get --lease` for cmux instead of interactive `treehouse get`.
+- Default UX is visible splits for up to 3 workers, hybrid for 4+.
+- First implementation slice should not attempt every firstmate feature at once.
+
+## Invariants
+
+- A worker must never edit the primary project checkout directly.
+- A worker must always run in a distinct treehouse worktree for project work.
+- Teardown must refuse dirty or unlanded work unless forced by explicit user approval.
+- Existing tmux behavior and tests must keep passing.
+- Meta files must contain enough target information for recovery.
+- cmux focus should not be stolen unless the user explicitly asks; use `--focus false` where supported.
+
+## Error behavior
+
+- If `config/terminal-backend=cmux` but `cmux ping` fails, spawn exits with a clear error and does not create a task meta file.
+- If cmux pane creation succeeds but harness launch fails, keep the pane open and report the surface handle for inspection.
+- If treehouse lease succeeds but cmux spawn fails before meta is written, return the lease or clearly report the leased worktree path.
+- If cmux surface creation succeeds but later setup fails, preserve enough temporary state in the error output for manual cleanup (`workspace`, `surface`, `worktree`).
+- If screen read fails, report `unknown` rather than guessing worker state.
+- If cleanup cannot close the cmux surface, preserve metadata and report manual cleanup instructions.
+
+## Acceptance criteria
+
+- Given `config/terminal-backend=tmux`, when a sandbox worker is spawned, then existing tmux window behavior still works and current tests pass.
+- Given `config/terminal-backend=cmux` inside cmux, when a sandbox worker is spawned, then a visible cmux surface opens and runs the harness in a leased treehouse worktree.
+- Given a cmux worker is idle, when firstmate sends a follow-up instruction, then the worker receives it and acts on it.
+- Given a cmux worker has output, when firstmate peeks/reads it, then recent screen text is returned without using tmux.
+- Given a cmux worker prints `needs-decision:` or `FAILED:`, when supervision reads the surface, then the state is classified as needing attention or failed.
+- Given a cmux worker runs a long foreground command, when firstmate sends interrupt, then the command stops and the worker surface remains usable.
+- Given a cmux worker has uncommitted changes, when teardown runs without force, then cleanup is refused and the surface stays open.
+- Given a cmux worker has committed work that is merged/landed, when teardown runs, then treehouse returns the worktree and cmux closes the surface.
+
+Later-slice layout acceptance:
+
+- Given 1–3 live cmux workers, when new workers spawn, then they appear as visible splits.
+- Given 4+ live cmux workers, when another worker spawns, then overflow uses hybrid/tab behavior instead of unlimited random splits.
+
+## Verification loop
+
+Cheapest proof for first slice:
+
+1. Run existing firstmate shell tests.
+2. Run a tmux sandbox spawn to prove fallback was not broken.
+3. Run cmux sandbox smoke:
+   - spawn worker visibly;
+   - send prompt;
+   - read screen;
+   - detect done/failure/needs-decision marker;
+   - interrupt long command;
+   - teardown safely.
+4. Verify branch/commit preservation from the primary sandbox repo after cleanup.
+
+## Testing strategy
+
+- Unit-test backend target parsing and config resolution with shell tests.
+- Stub `cmux` in tests for spawn/send/read/close command formation.
+- Keep existing tmux tests untouched and passing.
+- Add one manual cmux integration checklist because full cmux UI behavior needs a live cmux app/socket.
+
+## Out of scope for first slice
+
+- Replacing every watcher path in one PR.
+- Full secondmate cmux support; secondmate spawn remains tmux-only in the first slice even when `config/terminal-backend=cmux`.
+- X mode / public reply integration.
+- Automatic PR creation or no-mistakes changes.
+- Polished status UI, badges, or notifications beyond basic surface naming/flash.
+- Removing tmux.
+
+## Handoff
+
+Next: `single-task-build` for the first vertical slice: backend config + cmux spawn/send/read/cleanup for one sandbox worker, preserving tmux fallback.

--- a/docs/cmux-terminal-backend/spec.md
+++ b/docs/cmux-terminal-backend/spec.md
@@ -235,6 +235,10 @@ cmux teardown must preserve the current safety invariant:
 - Meta files must contain enough target information for recovery.
 - cmux focus should not be stolen unless the user explicitly asks; use `--focus false` where supported.
 
+## Ghost surface repair
+
+cmux currently has a ghost-surface defect when a terminal surface is created in a non-visible workspace: the surface is listed, but the terminal has not attached, so `read-screen` fails with "Terminal surface not found" and `surface-health` can report `in_window=false`. After every cmux spawn launch, firstmate probes the new surface for a short bounded window. If the surface is a ghost, spawn repairs it by briefly selecting the worker workspace and immediately restoring the previously focused workspace, then resends the launch line. Repair attempts are capped; if the surface still will not attach, spawn exits non-zero with the workspace/surface refs and does not write task meta for the dead worker.
+
 ## Error behavior
 
 - If `config/terminal-backend=cmux` but `cmux ping` fails, spawn exits with a clear error and does not create a task meta file.

--- a/docs/cmux-terminal-backend/spec.md
+++ b/docs/cmux-terminal-backend/spec.md
@@ -141,6 +141,10 @@ For cmux worker spawn:
    tasktmp=/tmp/fm-<id>
    ```
 
+### Worker tab titles
+
+`fm-spawn.sh` accepts an optional `--title '<text>'` flag on cmux spawns. When present, it renames the worker's cmux tab to that text (`cmux rename-tab`) and records `title=<text>` in meta; firstmate passes a plain-English `<project> · <doing>` title on every cmux dispatch so the captain reads the sidebar/tabs without decoding machine ids. This is display-only: the tab title is cosmetic, and every functional reference to a worker (supervision, teardown, recovery) uses the `workspace=`/`surface=` refs in meta, never the tab text. Without `--title`, the tab keeps its prior default (`fm-<id>`). The tmux backend accepts and records the same flag for consistency but does not use it — the tmux window name stays the functional `fm-<id>`.
+
 ### Layout policy
 
 Mielye default (`auto`): workers never share firstmate's caller workspace. Each
@@ -156,7 +160,7 @@ Concrete tiling for `auto` (capacity `FM_CMUX_GRID_CAPACITY`, default 4; rows
 
 - Worker 1: resolve firstmate's current window explicitly with
   `cmux current-window`, then `cmux new-workspace --name "fm crew 1" --window <id>
-  --focus false`. The new workspace's first terminal surface becomes worker 1.
+--focus false`. The new workspace's first terminal surface becomes worker 1.
 - Worker 2: `cmux new-split down` off worker 1's surface → bottom of column 1.
 - Worker 3: `cmux new-split right` off worker 1's surface → top of column 2.
 - Worker 4: `cmux new-split down` off worker 3's surface → bottom of column 2.

--- a/tests/fm-gotmp.test.sh
+++ b/tests/fm-gotmp.test.sh
@@ -43,8 +43,10 @@ make_fake_root() {
   local id=$1 tasktmp=$2
   local fake="$TMP_ROOT/$id"
   mkdir -p "$fake/bin" "$fake/state"
-  # Symlink the REAL teardown so the test exercises actual code, not a copy.
+  # Symlink the REAL teardown and terminal libs so the test exercises actual code, not a copy.
   ln -s "$TEARDOWN" "$fake/bin/fm-teardown.sh"
+  ln -s "$ROOT/bin/fm-terminal-lib.sh" "$fake/bin/fm-terminal-lib.sh"
+  ln -s "$ROOT/bin/fm-tmux-lib.sh" "$fake/bin/fm-tmux-lib.sh"
   # fm-guard.sh: stub (teardown calls it with `|| true`).
   cat > "$fake/bin/fm-guard.sh" <<'SH'
 #!/usr/bin/env bash
@@ -136,6 +138,8 @@ test_teardown_skips_gracefully_without_tasktmp() {
   local fake="$TMP_ROOT/$id-root"
   mkdir -p "$fake/bin" "$fake/state"
   ln -s "$TEARDOWN" "$fake/bin/fm-teardown.sh"
+  ln -s "$ROOT/bin/fm-terminal-lib.sh" "$fake/bin/fm-terminal-lib.sh"
+  ln -s "$ROOT/bin/fm-tmux-lib.sh" "$fake/bin/fm-tmux-lib.sh"
   cat > "$fake/bin/fm-guard.sh" <<'SH'
 #!/usr/bin/env bash
 exit 0

--- a/tests/fm-secondmate-cmux.test.sh
+++ b/tests/fm-secondmate-cmux.test.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+# tests/fm-secondmate-cmux.test.sh - Phase B slice 3: a secondmate launches in a
+# cmux surface (bin/fm-spawn.sh spawn_cmux_and_exit) when the terminal backend is
+# cmux, mirroring the tmux secondmate semantics exactly - only the terminal changes.
+#
+# What this locks down (must not regress):
+#   - a cmux-mode secondmate spawn does NOT lease a treehouse worktree (it runs in
+#     its persistent firstmate home), creates a cmux surface via the layout policy,
+#     launches with a `cd <home>` + FM_HOME=<home> line and the persistent charter,
+#     and records kind=secondmate + terminal_backend=cmux + surface/workspace/pane
+#     + home/projects meta with NO worktree=/window=;
+#   - the backend-independent secondmate invariants still run on the cmux path:
+#     inheritable-config propagation into the home's config/, and NO per-worktree
+#     turn-end hook (no pi-ext.ts) - both mirror the tmux secondmate path;
+#   - the tmux secondmate path is unchanged: with no cmux backend a secondmate still
+#     records window= and never touches cmux;
+#   - the always-on watcher skips a cmux secondmate's stale-pane wake (idle = healthy):
+#     it enumerates the cmux secondmate as fm-<id> but never reads its screen.
+#
+# The tmux secondmate lifecycle (seed/send/handoff/recovery/teardown) is owned by
+# fm-secondmate-lifecycle-e2e.test.sh; the cmux crewmate layout policy by
+# fm-terminal-cmux.test.sh; the watcher cmux crewmate path by fm-watch-cmux.test.sh.
+set -u
+
+# shellcheck source=tests/secondmate-helpers.sh
+# secondmate-helpers.sh brings seed/spawn fixtures (make_fake_tmux, the fake
+# treehouse, scaffold_secondmate_charter, wait_live) and lib.sh. wake-helpers.sh is
+# deliberately NOT sourced: it exports FM_ROOT_OVERRIDE at source time, which would
+# repoint fm-spawn/fm-home-seed away from the real repo. The one watcher-path helper
+# needed (a pane hash) is tiny and defined locally.
+. "$(dirname "${BASH_SOURCE[0]}")/secondmate-helpers.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-secondmate-cmux)
+
+# Same pane-hash the watcher's hash_pane computes (md5 of the screen text).
+hash_text() {
+  if command -v md5 >/dev/null 2>&1; then printf '%s' "$1" | md5 -q; else printf '%s' "$1" | md5sum | cut -d' ' -f1; fi
+}
+
+HOME_DIR="$TMP_ROOT/main-home"
+SUB="$TMP_ROOT/triage-home"
+SUB_ABS=
+FAKEBIN=
+TMUX_LOG="$TMP_ROOT/tmux.log"     # fake tmux + fake treehouse activity
+CMUX_LOG="$TMP_ROOT/cmux.log"     # fake cmux activity
+
+# A fake cmux that logs every call and serves the spawn primitives (identify,
+# split/pane/surface creation, pane lookup) plus read-screen for the watcher path.
+install_cmux_stub() {  # <fakebin>
+  cat > "$1/cmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+printf '%s\n' "$*" >> "${CMUX_FAKE_LOG:-/dev/null}"
+case "${1:-}" in
+  ping) exit 0 ;;
+  identify) printf '{"caller":{"workspace_ref":"workspace:1","surface_ref":"surface:5"}}\n'; exit 0 ;;
+  new-split|new-pane|new-surface) printf 'created surface:7 workspace:1\n'; exit 0 ;;
+  list-panes) printf 'pane:3\n'; exit 0 ;;
+  list-pane-surfaces) printf 'surface:7\n'; exit 0 ;;
+  read-screen) printf '%s\n' "${CMUX_FAKE_SCREEN:-idle prompt}"; exit 0 ;;
+  send|send-key|rename-tab|close-surface) exit 0 ;;
+  *) exit 0 ;;
+esac
+SH
+  chmod +x "$1/cmux"
+}
+
+reap() { kill "$1" 2>/dev/null || true; wait "$1" 2>/dev/null || true; }
+
+# --- shared world: a seeded triage secondmate home --------------------------
+setup_world() {
+  mkdir -p "$HOME_DIR/projects" "$HOME_DIR/data" "$HOME_DIR/state" "$HOME_DIR/config"
+  fm_git_init_commit "$HOME_DIR/projects/alpha"
+  fm_git_add_origin "$HOME_DIR/projects/alpha" "$TMP_ROOT/remotes/alpha.git"
+  cat > "$HOME_DIR/data/projects.md" <<EOF
+- alpha [direct-PR] - alpha project (added 2026-06-30)
+EOF
+  FAKEBIN=$(make_fake_tmux "$TMP_ROOT/fake")
+  install_cmux_stub "$FAKEBIN"
+
+  FM_SECONDMATE_SCOPE='triage from brief' \
+    scaffold_secondmate_charter "$HOME_DIR" triage 'triage charter' alpha \
+    || fail "secondmate charter scaffold failed"
+
+  PATH="$FAKEBIN:$PATH" FM_HOME="$HOME_DIR" \
+    "$ROOT/bin/fm-home-seed.sh" triage "$SUB" alpha >/dev/null \
+    || fail "seed failed"
+  SUB_ABS=$(cd "$SUB" && pwd -P)
+}
+
+# --- cmux secondmate spawn --------------------------------------------------
+test_cmux_secondmate_launches_in_surface() {
+  : > "$TMUX_LOG"; : > "$CMUX_LOG"
+  # Force the cmux backend, and put an inheritable value in the parent config so we
+  # can prove config inheritance still runs on the cmux secondmate path.
+  printf 'cmux\n' > "$HOME_DIR/config/terminal-backend"
+  printf 'codex\n' > "$HOME_DIR/config/crew-harness"
+  rm -f "$HOME_DIR/state/triage.meta" "$HOME_DIR/state/triage.pi-ext.ts"
+
+  local out
+  out=$(PATH="$FAKEBIN:$PATH" FM_HOME="$HOME_DIR" \
+    FM_FAKE_TMUX_LOG="$TMUX_LOG" CMUX_FAKE_LOG="$CMUX_LOG" \
+    "$ROOT/bin/fm-spawn.sh" triage "$SUB" codex --secondmate 2>/dev/null) \
+    || fail "cmux secondmate spawn failed"
+
+  # Success line reports a cmux secondmate landing in its home (not a worktree).
+  assert_contains "$out" 'kind=secondmate' "spawn success line did not report kind=secondmate"
+  assert_contains "$out" 'terminal=cmux' "spawn success line did not report the cmux terminal"
+  assert_contains "$out" "home=$SUB_ABS" "spawn success line did not report the home"
+
+  # No treehouse lease: a secondmate runs in its persistent home, never a worktree.
+  assert_no_grep 'treehouse get' "$TMUX_LOG" "cmux secondmate spawn leased a treehouse worktree"
+  assert_no_grep 'treehouse ' "$TMUX_LOG" "cmux secondmate spawn invoked treehouse at all"
+
+  # A cmux surface was created via the layout policy (first worker -> visible split),
+  # never stealing focus.
+  assert_grep 'new-split right --workspace workspace:1 --surface surface:5 --focus false' "$CMUX_LOG" \
+    "cmux secondmate did not create a surface through the layout policy"
+
+  # The launch cd's to the HOME and runs the harness with the persistent charter and
+  # cleared operational overrides pointed at the home (mirrors the tmux path).
+  assert_grep "cd '$SUB_ABS'" "$CMUX_LOG" "cmux secondmate launch did not cd to the home"
+  assert_grep "FM_HOME='$SUB_ABS'" "$CMUX_LOG" "cmux secondmate launch did not set FM_HOME to the home"
+  assert_grep 'FM_ROOT_OVERRIDE= FM_STATE_OVERRIDE= FM_DATA_OVERRIDE= FM_PROJECTS_OVERRIDE=' "$CMUX_LOG" \
+    "cmux secondmate launch did not clear operational overrides"
+  assert_grep "$SUB_ABS/data/charter.md" "$CMUX_LOG" "cmux secondmate launch did not use the persistent charter"
+
+  # Meta: cmux target fields + secondmate fields, and crucially NO worktree=/window=.
+  local meta="$HOME_DIR/state/triage.meta"
+  assert_grep 'terminal_backend=cmux' "$meta" "meta did not record terminal_backend=cmux"
+  assert_grep 'kind=secondmate' "$meta" "meta did not record kind=secondmate"
+  assert_grep 'mode=secondmate' "$meta" "meta did not record mode=secondmate"
+  assert_grep 'yolo=off' "$meta" "meta did not record yolo=off"
+  assert_grep 'workspace=workspace:1' "$meta" "meta did not record the cmux workspace"
+  assert_grep 'surface=surface:7' "$meta" "meta did not record the cmux surface"
+  assert_grep 'pane=pane:3' "$meta" "meta did not record the cmux pane"
+  assert_grep "home=$SUB_ABS" "$meta" "meta did not record the home"
+  assert_grep 'projects=alpha' "$meta" "meta did not record the project list"
+  assert_no_grep 'worktree=' "$meta" "cmux secondmate meta wrongly recorded a worktree"
+  assert_no_grep 'window=' "$meta" "cmux secondmate meta wrongly recorded a tmux window"
+
+  # Backend-independent secondmate invariants still run on the cmux path:
+  # inheritable-config propagation into the home's config/ (proof the pre-guard
+  # secondmate block, which also does the home fast-forward, executed)...
+  assert_grep 'codex' "$SUB/config/crew-harness" "cmux secondmate spawn did not propagate inheritable config into the home"
+  # ...and NO per-worktree turn-end hook (mirror tmux: secondmates skip it).
+  assert_absent "$HOME_DIR/state/triage.pi-ext.ts" "cmux secondmate wrongly wrote a turn-end hook"
+
+  pass "cmux secondmate: launches in its home surface (no lease), records secondmate+cmux meta, keeps config inheritance and skips the turn-end hook"
+}
+
+# --- tmux secondmate path is unchanged --------------------------------------
+test_tmux_secondmate_unchanged() {
+  : > "$TMUX_LOG"; : > "$CMUX_LOG"
+  # Force the tmux backend explicitly (a stubbed cmux answering ping plus a set
+  # CMUX_WORKSPACE_ID would otherwise auto-resolve to cmux): the secondmate must
+  # take the existing tmux path, recording a window= and never touching cmux.
+  printf 'tmux\n' > "$HOME_DIR/config/terminal-backend"
+  rm -f "$HOME_DIR/state/triage.meta"
+
+  PATH="$FAKEBIN:$PATH" FM_HOME="$HOME_DIR" \
+    FM_FAKE_TMUX_LOG="$TMUX_LOG" FM_FAKE_TMUX_CAPTURE="$TMP_ROOT/pane.txt" CMUX_FAKE_LOG="$CMUX_LOG" \
+    "$ROOT/bin/fm-spawn.sh" triage "$SUB" codex --secondmate >/dev/null 2>&1 \
+    || fail "tmux secondmate spawn failed"
+
+  local meta="$HOME_DIR/state/triage.meta"
+  assert_grep 'window=firstmate:fm-triage' "$meta" "tmux secondmate did not record its window"
+  assert_grep 'kind=secondmate' "$meta" "tmux secondmate meta did not record kind=secondmate"
+  assert_grep "home=$SUB_ABS" "$meta" "tmux secondmate meta did not record the home"
+  assert_no_grep 'terminal_backend=cmux' "$meta" "tmux secondmate wrongly recorded the cmux backend"
+  [ ! -s "$CMUX_LOG" ] || fail "the tmux secondmate path invoked cmux (should stay tmux-only): $(cat "$CMUX_LOG")"
+  pass "tmux secondmate path is unchanged (window= meta, cmux never invoked)"
+}
+
+# --- watcher skips a cmux secondmate's stale-pane wake ----------------------
+test_watcher_skips_cmux_secondmate() {
+  local dir state fakebin out cmux_log key pid
+  dir="$TMP_ROOT/cmux-sm-skip"; state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"; cmux_log="$dir/cmux.log"
+  mkdir -p "$state" "$fakebin" "$dir/home"
+  install_cmux_stub "$fakebin"
+  fm_fake_exit0 "$fakebin" tmux
+  # A cmux secondmate meta: terminal_backend=cmux + workspace/surface/pane, kind=
+  # secondmate, home=, and crucially NO window=. The watcher enumerates it as
+  # fm-<id> and must skip it as a supervised secondmate (idle = healthy).
+  fm_write_meta "$state/triagesm.meta" \
+    'terminal_backend=cmux' \
+    'workspace=workspace:1' \
+    'surface=surface:2' \
+    'pane=pane:3' \
+    'harness=codex' \
+    'kind=secondmate' \
+    'mode=secondmate' \
+    "home=$dir/home"
+  # Prime a stable (stale) pane hash so a NON-secondmate worker here would surface.
+  local screen='idle prompt, awaiting routed work'
+  key=$(printf '%s' "fm-triagesm" | tr ':/.' '___')
+  printf '%s' "$(hash_text "$screen")" > "$state/.hash-$key"
+  printf '1\n' > "$state/.count-$key"
+
+  PATH="$fakebin:$PATH" CMUX_FAKE_LOG="$cmux_log" CMUX_FAKE_SCREEN="$screen" \
+    FM_STATE_OVERRIDE="$state" \
+    FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$ROOT/bin/fm-watch.sh" > "$out" &
+  pid=$!
+  if ! wait_live "$pid" 30; then reap "$pid"; fail "watcher exited for an idle cmux secondmate (should skip as healthy): $(cat "$out")"; fi
+  [ ! -s "$out" ] || { reap "$pid"; fail "idle cmux secondmate printed a wake reason: $(cat "$out")"; }
+  [ ! -s "$state/.wake-queue" ] || { reap "$pid"; fail "idle cmux secondmate enqueued a durable wake record"; }
+  # The skip happens BEFORE the screen read, so the secondmate triggers ZERO cmux
+  # calls: an empty (or absent) cmux log proves its surface was never read.
+  [ ! -s "$cmux_log" ] || { reap "$pid"; fail "watcher invoked cmux for a secondmate (should skip it entirely): $(cat "$cmux_log")"; }
+  reap "$pid"
+  pass "watcher skips a cmux secondmate's stale-pane wake (idle = healthy, screen never read)"
+}
+
+# --- a cmux secondmate counts like any other cmux worker for layout -----------
+# Phase B slice 3 makes a cmux secondmate a first-class worker in the layout count,
+# so it participates in split/tab placement decisions (its own and later workers').
+test_cmux_secondmate_counts_as_worker() {
+  local dir state n
+  dir="$TMP_ROOT/count"; state="$dir/state"; mkdir -p "$state"
+  fm_write_meta "$state/sm.meta" 'terminal_backend=cmux' 'pane=pane:1' 'surface=surface:1' 'kind=secondmate'
+  fm_write_meta "$state/ship.meta" 'terminal_backend=cmux' 'pane=pane:2' 'surface=surface:2' 'kind=ship'
+  # Both a cmux secondmate and a cmux crewmate count; excluding one by id leaves 1.
+  n=$(STATE="$state" bash -c '. "$1"; fm_terminal_cmux_worker_count "$2"' _ "$ROOT/bin/fm-terminal-lib.sh" newcomer)
+  [ "$n" = 2 ] || fail "cmux worker count did not include the secondmate (expected 2, got $n)"
+  n=$(STATE="$state" bash -c '. "$1"; fm_terminal_cmux_worker_count "$2"' _ "$ROOT/bin/fm-terminal-lib.sh" ship)
+  [ "$n" = 1 ] || fail "cmux secondmate was not counted as a worker (expected 1, got $n)"
+  pass "a cmux secondmate counts like any other cmux worker in the layout policy"
+}
+
+setup_world
+test_cmux_secondmate_launches_in_surface
+test_tmux_secondmate_unchanged
+test_watcher_skips_cmux_secondmate
+test_cmux_secondmate_counts_as_worker

--- a/tests/fm-secondmate-cmux.test.sh
+++ b/tests/fm-secondmate-cmux.test.sh
@@ -54,6 +54,18 @@ printf '%s\n' "$*" >> "${CMUX_FAKE_LOG:-/dev/null}"
 case "${1:-}" in
   ping) exit 0 ;;
   identify) printf '{"caller":{"workspace_ref":"workspace:1","surface_ref":"surface:5"}}\n'; exit 0 ;;
+  current-window) printf 'E566A1D2-0000-0000-0000-000000000002\n'; exit 0 ;;
+  new-workspace)
+    win_seen=0; win_value=
+    prev=
+    for arg in "$@"; do
+      if [ "$prev" = "--window" ]; then win_seen=1; win_value=$arg; fi
+      prev=$arg
+    done
+    [ "$win_seen" = 1 ] && [ -n "$win_value" ] || { echo 'missing explicit --window' >&2; exit 98; }
+    printf 'created workspace:9 surface:7\n'
+    exit 0
+    ;;
   new-split|new-pane|new-surface) printf 'created surface:7 workspace:1\n'; exit 0 ;;
   list-panes) printf 'pane:3\n'; exit 0 ;;
   list-pane-surfaces) printf 'surface:7\n'; exit 0 ;;
@@ -112,10 +124,12 @@ test_cmux_secondmate_launches_in_surface() {
   assert_no_grep 'treehouse get' "$TMUX_LOG" "cmux secondmate spawn leased a treehouse worktree"
   assert_no_grep 'treehouse ' "$TMUX_LOG" "cmux secondmate spawn invoked treehouse at all"
 
-  # A cmux surface was created via the layout policy (first worker -> visible split),
+  # A cmux surface was created via the layout policy (first worker -> owned crew workspace),
   # never stealing focus.
-  assert_grep 'new-split right --workspace workspace:1 --surface surface:5 --focus false' "$CMUX_LOG" \
+  assert_grep 'new-workspace --name fm crew 1 --window E566A1D2-0000-0000-0000-000000000002 --focus false' "$CMUX_LOG" \
     "cmux secondmate did not create a surface through the layout policy"
+  assert_no_grep 'new-split right --workspace workspace:1 --surface surface:5' "$CMUX_LOG" \
+    "cmux secondmate used the caller workspace under auto layout"
 
   # The launch cd's to the HOME and runs the harness with the persistent charter and
   # cleared operational overrides pointed at the home (mirrors the tmux path).
@@ -131,7 +145,7 @@ test_cmux_secondmate_launches_in_surface() {
   assert_grep 'kind=secondmate' "$meta" "meta did not record kind=secondmate"
   assert_grep 'mode=secondmate' "$meta" "meta did not record mode=secondmate"
   assert_grep 'yolo=off' "$meta" "meta did not record yolo=off"
-  assert_grep 'workspace=workspace:1' "$meta" "meta did not record the cmux workspace"
+  assert_grep 'workspace=workspace:9' "$meta" "meta did not record the cmux workspace"
   assert_grep 'surface=surface:7' "$meta" "meta did not record the cmux surface"
   assert_grep 'pane=pane:3' "$meta" "meta did not record the cmux pane"
   assert_grep "home=$SUB_ABS" "$meta" "meta did not record the home"

--- a/tests/fm-terminal-cmux.test.sh
+++ b/tests/fm-terminal-cmux.test.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# cmux terminal backend routing for send/peek.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-terminal-cmux)
+FAKEBIN=$(fm_fakebin "$TMP_ROOT")
+HOME_DIR="$TMP_ROOT/home"
+STATE_DIR="$HOME_DIR/state"
+CONFIG_DIR="$HOME_DIR/config"
+LOG="$TMP_ROOT/cmux.log"
+mkdir -p "$STATE_DIR" "$CONFIG_DIR" "$TMP_ROOT/wt" "$TMP_ROOT/project"
+
+cat > "$FAKEBIN/cmux" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$CMUX_FAKE_LOG"
+case "$1" in
+  ping) exit 0 ;;
+  read-screen) printf 'done: fake cmux output\n'; exit 0 ;;
+  send|send-key|close-surface) printf 'OK surface:2 workspace:1\n'; exit 0 ;;
+  *) exit 0 ;;
+esac
+SH
+chmod +x "$FAKEBIN/cmux"
+
+write_cmux_meta() {
+  fm_write_meta "$STATE_DIR/task.meta" \
+    'terminal_backend=cmux' \
+    'workspace=workspace:1' \
+    'surface=surface:2' \
+    'worktree='"$TMP_ROOT"/wt \
+    'project='"$TMP_ROOT"/project \
+    'harness=pi' \
+    'kind=ship' \
+    'mode=local-only'
+}
+
+test_peek_uses_cmux_read_screen() {
+  write_cmux_meta
+  : > "$LOG"
+  out=$(PATH="$FAKEBIN:$PATH" CMUX_FAKE_LOG="$LOG" FM_HOME="$HOME_DIR" FM_STATE_OVERRIDE="$STATE_DIR" FM_CONFIG_OVERRIDE="$CONFIG_DIR" \
+    "$ROOT/bin/fm-peek.sh" fm-task 5 2>/dev/null) || fail "fm-peek failed for cmux target"
+  assert_contains "$out" 'done: fake cmux output' "fm-peek did not return cmux read-screen output"
+  assert_grep 'read-screen --workspace workspace:1 --surface surface:2 --lines 5' "$LOG" "fm-peek did not call cmux read-screen with recorded handles"
+  pass "fm-peek routes terminal_backend=cmux targets through cmux read-screen"
+}
+
+test_send_uses_cmux_send_and_newline() {
+  write_cmux_meta
+  : > "$LOG"
+  PATH="$FAKEBIN:$PATH" CMUX_FAKE_LOG="$LOG" FM_HOME="$HOME_DIR" FM_STATE_OVERRIDE="$STATE_DIR" FM_CONFIG_OVERRIDE="$CONFIG_DIR" FM_SEND_SETTLE=0 \
+    "$ROOT/bin/fm-send.sh" fm-task 'echo hello' >/dev/null 2>/dev/null || fail "fm-send failed for cmux target"
+  assert_grep 'send --workspace workspace:1 --surface surface:2 echo hello\n' "$LOG" "fm-send did not submit text with trailing newline through cmux"
+  pass "fm-send routes cmux targets through cmux send with submit newline"
+}
+
+test_send_key_maps_ctrl_c() {
+  write_cmux_meta
+  : > "$LOG"
+  PATH="$FAKEBIN:$PATH" CMUX_FAKE_LOG="$LOG" FM_HOME="$HOME_DIR" FM_STATE_OVERRIDE="$STATE_DIR" FM_CONFIG_OVERRIDE="$CONFIG_DIR" \
+    "$ROOT/bin/fm-send.sh" fm-task --key C-c >/dev/null 2>/dev/null || fail "fm-send --key failed for cmux target"
+  assert_grep 'send-key --workspace workspace:1 --surface surface:2 ctrl+c' "$LOG" "fm-send did not map C-c to cmux ctrl+c"
+  pass "fm-send maps tmux-style C-c to cmux ctrl+c"
+}
+
+test_peek_uses_cmux_read_screen
+test_send_uses_cmux_send_and_newline
+test_send_key_maps_ctrl_c

--- a/tests/fm-terminal-cmux.test.sh
+++ b/tests/fm-terminal-cmux.test.sh
@@ -21,6 +21,9 @@ case "$1" in
   read-screen) printf 'done: fake cmux output\n'; exit 0 ;;
   send|send-key|close-surface) printf 'OK surface:2 workspace:1\n'; exit 0 ;;
   new-split|new-pane|new-surface) printf 'created surface:7 workspace:1\n'; exit 0 ;;
+  new-window) printf 'created window:2\n'; exit 0 ;;
+  current-window) printf 'window:2\n'; exit 0 ;;
+  new-workspace) printf 'created workspace:9\n'; exit 0 ;;
   *) exit 0 ;;
 esac
 SH
@@ -85,28 +88,124 @@ seed_cmux_workers() {  # <count> [pane]
   done
 }
 
+# Seed <count> existing cmux workers with distinct, creation-ordered surfaces
+# (surface:11, surface:12, ...) so grid anchor assertions are unambiguous vs the
+# firstmate caller surface. No workspace is recorded, so grid placement falls back
+# to the passed workspace (a single-window grid). Clears prior worker metas first.
+seed_grid_workers() {  # <count>
+  local count=$1 i=1
+  rm -f "$STATE_DIR"/*.meta
+  while [ "$i" -le "$count" ]; do
+    fm_write_meta "$STATE_DIR/gw-$i.meta" \
+      'terminal_backend=cmux' \
+      "surface=surface:$((10 + i))" \
+      'kind=ship'
+    i=$((i + 1))
+  done
+}
+
 # Run fm_terminal_cmux_place_worker from the lib with STATE/cmux stub wired up.
 place() {  # <workspace> <caller_surface> <layout> <exclude-id>
   STATE="$STATE_DIR" PATH="$FAKEBIN:$PATH" CMUX_FAKE_LOG="$LOG" \
     bash -c '. "$1"; shift; fm_terminal_cmux_place_worker "$@"' _ "$ROOT/bin/fm-terminal-lib.sh" "$@"
 }
 
-test_auto_splits_1_to_3_then_tab_overflow() {
-  # 1st worker (0 existing) -> visible split
-  seed_cmux_workers 0; : > "$LOG"
-  place workspace:1 surface:1 auto newtask >/dev/null || fail "auto placement failed at N=0"
-  assert_grep 'new-split right --workspace workspace:1 --surface surface:1 --focus false' "$LOG" "auto 1st worker was not a split"
-  assert_no_grep 'new-surface' "$LOG" "auto 1st worker overflowed to a tab"
-  # 2nd and 3rd workers -> still splits
-  seed_cmux_workers 1; : > "$LOG"; place workspace:1 surface:1 auto newtask >/dev/null
-  assert_grep 'new-split right' "$LOG" "auto 2nd worker was not a split"
-  seed_cmux_workers 2; : > "$LOG"; place workspace:1 surface:1 auto newtask >/dev/null
-  assert_grep 'new-split right' "$LOG" "auto 3rd worker was not a split"
-  # 4th worker (3 existing) -> tab overflow into the crew pane
-  seed_cmux_workers 3; : > "$LOG"; place workspace:1 surface:1 auto newtask >/dev/null
-  assert_grep 'new-surface --type terminal --pane pane:9 --workspace workspace:1 --focus false' "$LOG" "auto 4th worker did not overflow to a tab in the crew pane"
-  assert_no_grep 'new-split' "$LOG" "auto 4th worker created a split instead of overflowing"
-  pass "auto layout: splits for workers 1-3, tab overflow for the 4th"
+# Run a pure lib function (no cmux) for the arithmetic unit tests.
+action() { bash -c '. "$1"; fm_terminal_cmux_layout_action "$2" "$3"' _ "$ROOT/bin/fm-terminal-lib.sh" "$@"; }
+slot() { bash -c '. "$1"; fm_terminal_cmux_grid_slot "$2"' _ "$ROOT/bin/fm-terminal-lib.sh" "$@"; }
+
+test_layout_action_grid_and_window() {
+  local a n
+  # auto: grid within a window, overflow to a new window each time it fills (cap 4).
+  for n in 0 1 2 3; do a=$(action auto "$n"); [ "$a" = grid ] || fail "auto N=$n expected grid, got '$a'"; done
+  a=$(action auto 4); [ "$a" = window ] || fail "auto N=4 expected window, got '$a'"
+  for n in 5 6 7; do a=$(action auto "$n"); [ "$a" = grid ] || fail "auto N=$n expected grid, got '$a'"; done
+  a=$(action auto 8); [ "$a" = window ] || fail "auto N=8 expected window, got '$a'"
+  # capacity is tunable: at cap 2, the boundary moves to N=2.
+  a=$(FM_CMUX_GRID_CAPACITY=2 bash -c '. "$1"; fm_terminal_cmux_layout_action "$2" "$3"' _ "$ROOT/bin/fm-terminal-lib.sh" auto 2)
+  [ "$a" = window ] || fail "auto N=2 at capacity 2 expected window, got '$a'"
+  # splits/tabs/hybrid keep their pre-grid shapes.
+  a=$(action splits 5); [ "$a" = split ] || fail "splits expected split, got '$a'"
+  a=$(action tabs 0); [ "$a" = split ] || fail "tabs N=0 expected split, got '$a'"
+  a=$(action tabs 1); [ "$a" = tab ] || fail "tabs N=1 expected tab, got '$a'"
+  a=$(action hybrid 2); [ "$a" = split ] || fail "hybrid N=2 expected split, got '$a'"
+  a=$(action hybrid 3); [ "$a" = tab ] || fail "hybrid N=3 expected tab, got '$a'"
+  pass "layout_action: auto grid/window boundary at capacity (tunable); splits/tabs/hybrid unchanged"
+}
+
+test_grid_slot_arithmetic() {
+  local s
+  # First grid (2x2): right off firstmate, down off W1, right off W1, down off W3.
+  s=$(slot 0); [ "$s" = 'right caller' ] || fail "slot 0 expected 'right caller', got '$s'"
+  s=$(slot 1); [ "$s" = 'down 0' ] || fail "slot 1 expected 'down 0', got '$s'"
+  s=$(slot 2); [ "$s" = 'right 0' ] || fail "slot 2 expected 'right 0', got '$s'"
+  s=$(slot 3); [ "$s" = 'down 2' ] || fail "slot 3 expected 'down 2', got '$s'"
+  # Second grid (a new window): anchors are GLOBAL creation indices, never caller.
+  s=$(slot 5); [ "$s" = 'down 4' ] || fail "slot 5 expected 'down 4', got '$s'"
+  s=$(slot 6); [ "$s" = 'right 4' ] || fail "slot 6 expected 'right 4', got '$s'"
+  s=$(slot 7); [ "$s" = 'down 6' ] || fail "slot 7 expected 'down 6', got '$s'"
+  pass "grid_slot: right/down alternation, caller anchor only for worker 1, global anchors across windows"
+}
+
+test_auto_grid_then_new_window() {
+  # Worker 1 (0 existing): split RIGHT off firstmate's caller surface (top-right).
+  seed_grid_workers 0; : > "$LOG"
+  place workspace:1 surface:5 auto newtask >/dev/null || fail "auto grid placement failed at N=0"
+  assert_grep 'new-split right --workspace workspace:1 --surface surface:5 --focus false' "$LOG" "grid worker 1 was not a right split off firstmate"
+  assert_no_grep 'new-window' "$LOG" "grid worker 1 wrongly opened a new window"
+  assert_no_grep 'new-surface' "$LOG" "grid worker 1 overflowed to a tab"
+  # Worker 2 (1 existing): split DOWN off worker 1 (surface:11) -> bottom of column 1.
+  seed_grid_workers 1; : > "$LOG"; place workspace:1 surface:5 auto newtask >/dev/null
+  assert_grep 'new-split down --workspace workspace:1 --surface surface:11 --focus false' "$LOG" "grid worker 2 did not split down off worker 1"
+  # Worker 3 (2 existing): split RIGHT off worker 1 (surface:11) -> top of column 2.
+  seed_grid_workers 2; : > "$LOG"; place workspace:1 surface:5 auto newtask >/dev/null
+  assert_grep 'new-split right --workspace workspace:1 --surface surface:11 --focus false' "$LOG" "grid worker 3 did not split right off worker 1"
+  # Worker 4 (3 existing): split DOWN off worker 3 (surface:13) -> bottom of column 2.
+  seed_grid_workers 3; : > "$LOG"; place workspace:1 surface:5 auto newtask >/dev/null
+  assert_grep 'new-split down --workspace workspace:1 --surface surface:13 --focus false' "$LOG" "grid worker 4 did not split down off worker 3"
+  # firstmate's own surface (surface:5) anchors ONLY worker 1: later workers split
+  # off prior WORKERS, so firstmate is pinned left and never sliced into a strip.
+  assert_no_grep 'surface:5' "$LOG" "grid worker 4 sliced firstmate's own surface"
+  # Worker 5 (4 existing = capacity): overflow to a NEW window, not a split/tab.
+  seed_grid_workers 4; : > "$LOG"; place workspace:1 surface:5 auto newtask >/dev/null
+  assert_grep 'new-window' "$LOG" "grid worker 5 did not overflow to a new window at capacity"
+  assert_no_grep 'new-split' "$LOG" "grid worker 5 wrongly created a split at capacity"
+  assert_no_grep 'new-surface' "$LOG" "grid worker 5 wrongly created a tab at capacity"
+  pass "auto layout: 2x2 grid (right/down/right/down off firstmate then workers), new window at capacity"
+}
+
+test_auto_overflow_new_window_shape() {
+  # At capacity the overflow builds a worker surface in a fresh window: new-window,
+  # then a workspace in it, then a terminal pane. It echoes both the new surface and
+  # the new window's workspace so the spawner addresses the worker in its own window.
+  seed_grid_workers 4; : > "$LOG"
+  local out
+  out=$(place workspace:1 surface:5 auto newtask) || fail "new-window overflow placement failed"
+  assert_grep 'new-window' "$LOG" "overflow did not create a new window"
+  assert_grep 'new-workspace --window window:2 --focus false' "$LOG" "overflow did not create a workspace in the new window"
+  assert_grep 'new-pane --type terminal --direction right --workspace workspace:9 --focus false' "$LOG" "overflow did not create a terminal pane in the new workspace"
+  assert_contains "$out" 'surface:7' "new-window placement did not echo the worker surface"
+  assert_contains "$out" 'workspace:9' "new-window placement did not echo the new window's workspace"
+  pass "auto overflow: new window -> workspace -> terminal pane, echoing the new surface + workspace"
+}
+
+test_grid_anchor_uses_recorded_workspace() {
+  # A worker that lives in a new window records its own workspace. When a later
+  # worker tiles beside it, the split must be addressed in THAT workspace, not
+  # firstmate's, so grid tiling is correct across windows.
+  rm -f "$STATE_DIR"/*.meta; : > "$LOG"
+  local i=1
+  while [ "$i" -le 4 ]; do
+    fm_write_meta "$STATE_DIR/gw-$i.meta" 'terminal_backend=cmux' "surface=surface:$((10 + i))" 'workspace=workspace:1' 'kind=ship'
+    i=$((i + 1))
+  done
+  # Worker 5 lives in the NEW window's workspace:9.
+  fm_write_meta "$STATE_DIR/gw-5.meta" 'terminal_backend=cmux' 'surface=surface:15' 'workspace=workspace:9' 'kind=ship'
+  # Worker 6 (5 existing): grid_slot(5) = 'down 4' -> split down off worker 5,
+  # addressed in worker 5's own workspace (workspace:9).
+  place workspace:1 surface:5 auto newtask >/dev/null
+  assert_grep 'new-split down --workspace workspace:9 --surface surface:15 --focus false' "$LOG" "second-window grid did not anchor in the prior worker's recorded workspace"
+  pass "grid anchors off the prior worker's own recorded workspace (correct across windows)"
 }
 
 test_explicit_layout_modes() {
@@ -128,15 +227,24 @@ test_explicit_layout_modes() {
 }
 
 test_focus_never_stolen() {
-  # every placement shape must pass --focus false
-  seed_cmux_workers 0; : > "$LOG"; place workspace:1 surface:1 auto newtask >/dev/null
-  assert_grep '--focus false' "$LOG" "split placement did not pass --focus false"
-  seed_cmux_workers 3; : > "$LOG"; place workspace:1 surface:1 auto newtask >/dev/null
+  # grid split off firstmate (worker 1) passes --focus false
+  seed_grid_workers 0; : > "$LOG"; place workspace:1 surface:5 auto newtask >/dev/null
+  assert_grep 'new-split right --workspace workspace:1 --surface surface:5 --focus false' "$LOG" "grid split placement stole focus"
+  # a later grid split (worker 4) also passes --focus false
+  seed_grid_workers 3; : > "$LOG"; place workspace:1 surface:5 auto newtask >/dev/null
+  assert_grep '--focus false' "$LOG" "later grid split did not pass --focus false"
+  # new-window overflow: every command that CAN take --focus false does (cmux
+  # new-window itself is bare and has no --focus flag).
+  seed_grid_workers 4; : > "$LOG"; place workspace:1 surface:5 auto newtask >/dev/null
+  assert_grep 'new-workspace --window window:2 --focus false' "$LOG" "new-window workspace did not pass --focus false"
+  assert_grep 'new-pane --type terminal --direction right --workspace workspace:9 --focus false' "$LOG" "new-window pane did not pass --focus false"
+  # tab overflow (explicit tabs layout) passes --focus false
+  seed_cmux_workers 1; : > "$LOG"; place workspace:1 surface:1 tabs newtask >/dev/null
   assert_grep '--focus false' "$LOG" "tab placement did not pass --focus false"
   # no caller surface -> new-pane fallback, still --focus false
-  seed_cmux_workers 0; : > "$LOG"; place workspace:1 '' auto newtask >/dev/null
+  seed_grid_workers 0; : > "$LOG"; place workspace:1 '' auto newtask >/dev/null
   assert_grep 'new-pane --type terminal --direction right --workspace workspace:1 --focus false' "$LOG" "empty caller surface did not fall back to new-pane"
-  pass "placement never steals focus (--focus false on split, tab, and pane)"
+  pass "placement never steals focus (--focus false on grid splits, new-window workspace/pane, tab, and fallback pane)"
 }
 
 test_invalid_layout_errors() {
@@ -153,7 +261,11 @@ test_invalid_layout_errors() {
 test_peek_uses_cmux_read_screen
 test_send_uses_cmux_send_and_newline
 test_send_key_maps_ctrl_c
-test_auto_splits_1_to_3_then_tab_overflow
+test_layout_action_grid_and_window
+test_grid_slot_arithmetic
+test_auto_grid_then_new_window
+test_auto_overflow_new_window_shape
+test_grid_anchor_uses_recorded_workspace
 test_explicit_layout_modes
 test_focus_never_stolen
 test_invalid_layout_errors

--- a/tests/fm-terminal-cmux.test.sh
+++ b/tests/fm-terminal-cmux.test.sh
@@ -101,16 +101,25 @@ seed_cmux_workers() {  # <count> [pane]
 
 # Seed <count> existing cmux workers with distinct, creation-ordered surfaces
 # (surface:11, surface:12, ...) so grid anchor assertions are unambiguous vs the
-# firstmate caller surface. No workspace is recorded, so grid placement falls back
-# to the passed workspace (a single-window grid). Clears prior worker metas first.
-seed_grid_workers() {  # <count>
-  local count=$1 i=1
+# firstmate caller surface. By default they record the owned crew workspace used
+# by the first auto grid. Pass "none" to omit workspace and exercise the safe
+# missing-anchor fallback. Clears prior worker metas first.
+seed_grid_workers() {  # <count> [workspace|none]
+  local count=$1 workspace=${2:-workspace:9} i=1
   rm -f "$STATE_DIR"/*.meta
   while [ "$i" -le "$count" ]; do
-    fm_write_meta "$STATE_DIR/gw-$i.meta" \
-      'terminal_backend=cmux' \
-      "surface=surface:$((10 + i))" \
-      'kind=ship'
+    if [ "$workspace" = none ]; then
+      fm_write_meta "$STATE_DIR/gw-$i.meta" \
+        'terminal_backend=cmux' \
+        "surface=surface:$((10 + i))" \
+        'kind=ship'
+    else
+      fm_write_meta "$STATE_DIR/gw-$i.meta" \
+        'terminal_backend=cmux' \
+        "surface=surface:$((10 + i))" \
+        "workspace=$workspace" \
+        'kind=ship'
+    fi
     i=$((i + 1))
   done
 }
@@ -121,6 +130,12 @@ place() {  # <workspace> <caller_surface> <layout> <exclude-id>
     bash -c '. "$1"; shift; fm_terminal_cmux_place_worker "$@"' _ "$ROOT/bin/fm-terminal-lib.sh" "$@"
 }
 
+assert_auto_never_targets_caller() {
+  assert_no_grep '--workspace workspace:1' "$LOG" "auto placement targeted the caller workspace"
+  assert_no_grep '--surface surface:5' "$LOG" "auto placement split off the caller surface"
+  assert_no_grep 'new-pane --type terminal' "$LOG" "auto placement fell back to a caller workspace pane"
+}
+
 # Run a pure lib function (no cmux) for the arithmetic unit tests.
 action() { FM_CONFIG_OVERRIDE="$CONFIG_DIR" bash -c '. "$1"; fm_terminal_cmux_layout_action "$2" "$3"' _ "$ROOT/bin/fm-terminal-lib.sh" "$@"; }
 slot() { FM_CONFIG_OVERRIDE="$CONFIG_DIR" bash -c '. "$1"; fm_terminal_cmux_grid_slot "$2"' _ "$ROOT/bin/fm-terminal-lib.sh" "$@"; }
@@ -128,12 +143,15 @@ capacity() { FM_CONFIG_OVERRIDE="$CONFIG_DIR" bash -c '. "$1"; fm_terminal_cmux_
 
 test_layout_action_grid_and_workspace() {
   local a n
-  # auto: grid within a workspace, overflow to a new workspace each time it fills (cap 4).
-  for n in 0 1 2 3; do a=$(action auto "$n"); [ "$a" = grid ] || fail "auto N=$n expected grid, got '$a'"; done
+  # auto: every grid starts in a workspace, including the first worker (cap 4).
+  a=$(action auto 0); [ "$a" = workspace ] || fail "auto N=0 expected workspace, got '$a'"
+  for n in 1 2 3; do a=$(action auto "$n"); [ "$a" = grid ] || fail "auto N=$n expected grid, got '$a'"; done
   a=$(action auto 4); [ "$a" = workspace ] || fail "auto N=4 expected workspace, got '$a'"
   for n in 5 6 7; do a=$(action auto "$n"); [ "$a" = grid ] || fail "auto N=$n expected grid, got '$a'"; done
   a=$(action auto 8); [ "$a" = workspace ] || fail "auto N=8 expected workspace, got '$a'"
   # capacity is tunable: at cap 2, the boundary moves to N=2.
+  a=$(FM_CMUX_GRID_CAPACITY=2 bash -c '. "$1"; fm_terminal_cmux_layout_action "$2" "$3"' _ "$ROOT/bin/fm-terminal-lib.sh" auto 0)
+  [ "$a" = workspace ] || fail "auto N=0 at capacity 2 expected workspace, got '$a'"
   a=$(FM_CMUX_GRID_CAPACITY=2 bash -c '. "$1"; fm_terminal_cmux_layout_action "$2" "$3"' _ "$ROOT/bin/fm-terminal-lib.sh" auto 2)
   [ "$a" = workspace ] || fail "auto N=2 at capacity 2 expected workspace, got '$a'"
   # splits/tabs/hybrid keep their pre-grid shapes.
@@ -142,12 +160,13 @@ test_layout_action_grid_and_workspace() {
   a=$(action tabs 1); [ "$a" = tab ] || fail "tabs N=1 expected tab, got '$a'"
   a=$(action hybrid 2); [ "$a" = split ] || fail "hybrid N=2 expected split, got '$a'"
   a=$(action hybrid 3); [ "$a" = tab ] || fail "hybrid N=3 expected tab, got '$a'"
-  pass "layout_action: auto grid/workspace boundary at capacity (tunable); splits/tabs/hybrid unchanged"
+  pass "layout_action: auto starts every grid in an owned workspace; splits/tabs/hybrid unchanged"
 }
 
 test_grid_slot_arithmetic() {
   local s
-  # First grid (2x2): right off firstmate, down off W1, right off W1, down off W3.
+  # First grid arithmetic (2x2): the caller case remains defensive, but auto
+  # placement now starts worker 1 with a workspace so slot 0 is not used there.
   s=$(slot 0); [ "$s" = 'right caller' ] || fail "slot 0 expected 'right caller', got '$s'"
   s=$(slot 1); [ "$s" = 'down 0' ] || fail "slot 1 expected 'down 0', got '$s'"
   s=$(slot 2); [ "$s" = 'right 0' ] || fail "slot 2 expected 'right 0', got '$s'"
@@ -156,7 +175,7 @@ test_grid_slot_arithmetic() {
   s=$(slot 5); [ "$s" = 'down 4' ] || fail "slot 5 expected 'down 4', got '$s'"
   s=$(slot 6); [ "$s" = 'right 4' ] || fail "slot 6 expected 'right 4', got '$s'"
   s=$(slot 7); [ "$s" = 'down 6' ] || fail "slot 7 expected 'down 6', got '$s'"
-  pass "grid_slot: right/down alternation, caller anchor only for worker 1, global anchors across workspaces"
+  pass "grid_slot: right/down alternation with global anchors across workspaces"
 }
 
 test_grid_capacity_env_config_default_precedence() {
@@ -180,32 +199,37 @@ test_grid_capacity_env_config_default_precedence() {
 }
 
 test_auto_grid_then_workspace_overflow() {
-  # Worker 1 (0 existing): split RIGHT off firstmate's caller surface (top-right).
+  # Worker 1 (0 existing): create the owned first crew workspace.
   seed_grid_workers 0; : > "$LOG"
-  place workspace:1 surface:5 auto newtask >/dev/null || fail "auto grid placement failed at N=0"
-  assert_grep 'new-split right --workspace workspace:1 --surface surface:5 --focus false' "$LOG" "grid worker 1 was not a right split off firstmate"
+  out=$(place workspace:1 surface:5 auto newtask) || fail "auto workspace placement failed at N=0"
+  assert_grep 'current-window' "$LOG" "grid worker 1 did not resolve the current window explicitly"
+  assert_grep 'new-workspace --name fm crew 1 --window E566A1D2-0000-0000-0000-000000000002 --focus false' "$LOG" "grid worker 1 did not create the first named crew workspace"
+  assert_contains "$out" 'workspace:9' "first crew workspace placement did not echo the workspace"
+  assert_contains "$out" 'owned_workspace=1' "first crew workspace placement did not echo ownership"
+  assert_auto_never_targets_caller
   assert_no_grep 'new-window' "$LOG" "grid worker 1 wrongly opened a new window"
   assert_no_grep 'new-surface' "$LOG" "grid worker 1 overflowed to a tab"
   # Worker 2 (1 existing): split DOWN off worker 1 (surface:11) -> bottom of column 1.
   seed_grid_workers 1; : > "$LOG"; place workspace:1 surface:5 auto newtask >/dev/null
-  assert_grep 'new-split down --workspace workspace:1 --surface surface:11 --focus false' "$LOG" "grid worker 2 did not split down off worker 1"
+  assert_grep 'new-split down --workspace workspace:9 --surface surface:11 --focus false' "$LOG" "grid worker 2 did not split down off worker 1 inside the crew workspace"
+  assert_auto_never_targets_caller
   # Worker 3 (2 existing): split RIGHT off worker 1 (surface:11) -> top of column 2.
   seed_grid_workers 2; : > "$LOG"; place workspace:1 surface:5 auto newtask >/dev/null
-  assert_grep 'new-split right --workspace workspace:1 --surface surface:11 --focus false' "$LOG" "grid worker 3 did not split right off worker 1"
+  assert_grep 'new-split right --workspace workspace:9 --surface surface:11 --focus false' "$LOG" "grid worker 3 did not split right off worker 1 inside the crew workspace"
+  assert_auto_never_targets_caller
   # Worker 4 (3 existing): split DOWN off worker 3 (surface:13) -> bottom of column 2.
   seed_grid_workers 3; : > "$LOG"; place workspace:1 surface:5 auto newtask >/dev/null
-  assert_grep 'new-split down --workspace workspace:1 --surface surface:13 --focus false' "$LOG" "grid worker 4 did not split down off worker 3"
-  # firstmate's own surface (surface:5) anchors ONLY worker 1: later workers split
-  # off prior WORKERS, so firstmate is pinned left and never sliced into a strip.
-  assert_no_grep 'surface:5' "$LOG" "grid worker 4 sliced firstmate's own surface"
+  assert_grep 'new-split down --workspace workspace:9 --surface surface:13 --focus false' "$LOG" "grid worker 4 did not split down off worker 3 inside the crew workspace"
+  assert_auto_never_targets_caller
   # Worker 5 (4 existing = capacity): overflow to a NEW workspace, not a split/tab/window.
   seed_grid_workers 4; : > "$LOG"; place workspace:1 surface:5 auto newtask >/dev/null
   assert_grep 'current-window' "$LOG" "grid worker 5 did not resolve the current window explicitly"
   assert_grep 'new-workspace --name fm crew 2 --window E566A1D2-0000-0000-0000-000000000002 --focus false' "$LOG" "grid worker 5 did not overflow to a named workspace in the current window"
+  assert_auto_never_targets_caller
   assert_no_grep 'new-window' "$LOG" "grid worker 5 wrongly opened a new OS window"
   assert_no_grep 'new-split' "$LOG" "grid worker 5 wrongly created a split at capacity"
   assert_no_grep 'new-surface' "$LOG" "grid worker 5 wrongly created a tab at capacity"
-  pass "auto layout: 2x2 grid (right/down/right/down off firstmate then workers), same-window workspace at capacity"
+  pass "auto layout: owned fm crew workspaces from worker 1, grid cells stay inside them"
 }
 
 test_auto_overflow_workspace_shape() {
@@ -224,6 +248,16 @@ test_auto_overflow_workspace_shape() {
   assert_contains "$out" 'workspace:9' "workspace placement did not echo the overflow workspace"
   assert_contains "$out" 'owned_workspace=1' "workspace placement did not echo the owned workspace marker"
   pass "auto overflow: named same-window workspace using explicit current-window, echoing surface + workspace + ownership"
+}
+
+test_auto_missing_anchor_starts_owned_workspace() {
+  seed_grid_workers 1 none; : > "$LOG"
+  local out
+  out=$(place workspace:1 surface:5 auto newtask) || fail "missing-anchor auto fallback failed"
+  assert_grep 'new-workspace --name fm crew 1 --window E566A1D2-0000-0000-0000-000000000002 --focus false' "$LOG" "missing-anchor fallback did not start an owned crew workspace"
+  assert_contains "$out" 'owned_workspace=1' "missing-anchor fallback did not echo ownership"
+  assert_auto_never_targets_caller
+  pass "auto fallback: missing grid anchors start an owned workspace, never caller placement"
 }
 
 test_grid_anchor_uses_recorded_workspace() {
@@ -264,9 +298,9 @@ test_explicit_layout_modes() {
 }
 
 test_focus_never_stolen() {
-  # grid split off firstmate (worker 1) passes --focus false
+  # first auto worker creates an owned workspace with --focus false
   seed_grid_workers 0; : > "$LOG"; place workspace:1 surface:5 auto newtask >/dev/null
-  assert_grep 'new-split right --workspace workspace:1 --surface surface:5 --focus false' "$LOG" "grid split placement stole focus"
+  assert_grep 'new-workspace --name fm crew 1 --window E566A1D2-0000-0000-0000-000000000002 --focus false' "$LOG" "first auto workspace placement stole focus"
   # a later grid split (worker 4) also passes --focus false
   seed_grid_workers 3; : > "$LOG"; place workspace:1 surface:5 auto newtask >/dev/null
   assert_grep '--focus false' "$LOG" "later grid split did not pass --focus false"
@@ -278,9 +312,9 @@ test_focus_never_stolen() {
   # tab overflow (explicit tabs layout) passes --focus false
   seed_cmux_workers 1; : > "$LOG"; place workspace:1 surface:1 tabs newtask >/dev/null
   assert_grep '--focus false' "$LOG" "tab placement did not pass --focus false"
-  # no caller surface -> new-pane fallback, still --focus false
-  seed_grid_workers 0; : > "$LOG"; place workspace:1 '' auto newtask >/dev/null
-  assert_grep 'new-pane --type terminal --direction right --workspace workspace:1 --focus false' "$LOG" "empty caller surface did not fall back to new-pane"
+  # forced split with no caller surface still keeps the old new-pane fallback.
+  seed_cmux_workers 0; : > "$LOG"; place workspace:1 '' splits newtask >/dev/null
+  assert_grep 'new-pane --type terminal --direction right --workspace workspace:1 --focus false' "$LOG" "forced split empty-caller fallback did not pass --focus false"
   pass "placement never steals focus (--focus false on grid splits, workspace overflow, tab, and fallback pane)"
 }
 
@@ -422,6 +456,7 @@ test_grid_slot_arithmetic
 test_grid_capacity_env_config_default_precedence
 test_auto_grid_then_workspace_overflow
 test_auto_overflow_workspace_shape
+test_auto_missing_anchor_starts_owned_workspace
 test_grid_anchor_uses_recorded_workspace
 test_explicit_layout_modes
 test_focus_never_stolen

--- a/tests/fm-terminal-cmux.test.sh
+++ b/tests/fm-terminal-cmux.test.sh
@@ -21,9 +21,13 @@ case "$1" in
   read-screen) printf 'done: fake cmux output\n'; exit 0 ;;
   send|send-key|close-surface) printf 'OK surface:2 workspace:1\n'; exit 0 ;;
   new-split|new-pane|new-surface) printf 'created surface:7 workspace:1\n'; exit 0 ;;
-  new-window) printf 'created window:2\n'; exit 0 ;;
+  # Real cmux new-window prints a bare "OK <uuid>", never a window:N short ref.
+  new-window) printf 'OK E566A1D2-0000-0000-0000-000000000002\n'; exit 0 ;;
   current-window) printf 'window:2\n'; exit 0 ;;
   new-workspace) printf 'created workspace:9\n'; exit 0 ;;
+  # new-window auto-creates a default workspace + terminal surface and focuses the
+  # new window, so identify (called with no --window override) resolves them.
+  identify) printf '{"window":"window:2","workspace":"workspace:9","surface":"surface:7"}\n'; exit 0 ;;
   *) exit 0 ;;
 esac
 SH
@@ -175,18 +179,33 @@ test_auto_grid_then_new_window() {
 }
 
 test_auto_overflow_new_window_shape() {
-  # At capacity the overflow builds a worker surface in a fresh window: new-window,
-  # then a workspace in it, then a terminal pane. It echoes both the new surface and
-  # the new window's workspace so the spawner addresses the worker in its own window.
+  # At capacity the overflow creates a new window - cmux new-window auto-creates a
+  # default workspace + terminal surface in it and takes focus there, so placement
+  # reads those back via `cmux identify` instead of issuing its own new-workspace/
+  # new-pane calls (which would create a second, unwanted surface). It echoes both
+  # the new surface and the new window's workspace so the spawner addresses the
+  # worker in its own window.
   seed_grid_workers 4; : > "$LOG"
   local out
   out=$(place workspace:1 surface:5 auto newtask) || fail "new-window overflow placement failed"
   assert_grep 'new-window' "$LOG" "overflow did not create a new window"
-  assert_grep 'new-workspace --window window:2 --focus false' "$LOG" "overflow did not create a workspace in the new window"
-  assert_grep 'new-pane --type terminal --direction right --workspace workspace:9 --focus false' "$LOG" "overflow did not create a terminal pane in the new workspace"
+  assert_grep 'identify' "$LOG" "overflow did not resolve the auto-created workspace/surface via cmux identify"
+  assert_no_grep 'new-workspace' "$LOG" "overflow wrongly created a second workspace (new-window already auto-creates one)"
+  assert_no_grep 'new-pane\|new-surface' "$LOG" "overflow wrongly created a second surface (new-window already auto-creates one)"
   assert_contains "$out" 'surface:7' "new-window placement did not echo the worker surface"
   assert_contains "$out" 'workspace:9' "new-window placement did not echo the new window's workspace"
-  pass "auto overflow: new window -> workspace -> terminal pane, echoing the new surface + workspace"
+  pass "auto overflow: new window -> identify (auto-created workspace/surface), echoing the new surface + workspace"
+}
+
+test_new_window_parses_bare_uuid_not_short_ref() {
+  # cmux new-window prints a bare "OK <uuid>", never a "window:N" short ref (unlike
+  # every other placement command). Placement must still succeed off that uuid
+  # rather than grepping for a window:N pattern that will never match.
+  seed_grid_workers 4; : > "$LOG"
+  out=$(place workspace:1 surface:5 auto newtask) || fail "placement failed to parse a bare-uuid new-window response"
+  assert_contains "$out" 'surface:7' "bare-uuid new-window did not still resolve a worker surface"
+  assert_contains "$out" 'workspace:9' "bare-uuid new-window did not still resolve the new window's workspace"
+  pass "new-window overflow parses a bare UUID window ref, not a window:N short ref"
 }
 
 test_grid_anchor_uses_recorded_workspace() {
@@ -233,11 +252,14 @@ test_focus_never_stolen() {
   # a later grid split (worker 4) also passes --focus false
   seed_grid_workers 3; : > "$LOG"; place workspace:1 surface:5 auto newtask >/dev/null
   assert_grep '--focus false' "$LOG" "later grid split did not pass --focus false"
-  # new-window overflow: every command that CAN take --focus false does (cmux
-  # new-window itself is bare and has no --focus flag).
+  # new-window overflow: cmux new-window is bare and has no --focus flag (the one
+  # placement command that can take focus). Its auto-created workspace/surface are
+  # then read back with `cmux identify`, a read-only call with no focus
+  # implications and no further pane/workspace creation that could steal focus.
   seed_grid_workers 4; : > "$LOG"; place workspace:1 surface:5 auto newtask >/dev/null
-  assert_grep 'new-workspace --window window:2 --focus false' "$LOG" "new-window workspace did not pass --focus false"
-  assert_grep 'new-pane --type terminal --direction right --workspace workspace:9 --focus false' "$LOG" "new-window pane did not pass --focus false"
+  assert_grep 'new-window' "$LOG" "new-window overflow did not create a new window"
+  assert_grep 'identify' "$LOG" "new-window overflow did not resolve via cmux identify"
+  assert_no_grep 'new-split\|new-pane\|new-surface\|new-workspace' "$LOG" "new-window overflow issued an unnecessary focus-affecting command"
   # tab overflow (explicit tabs layout) passes --focus false
   seed_cmux_workers 1; : > "$LOG"; place workspace:1 surface:1 tabs newtask >/dev/null
   assert_grep '--focus false' "$LOG" "tab placement did not pass --focus false"
@@ -265,6 +287,7 @@ test_layout_action_grid_and_window
 test_grid_slot_arithmetic
 test_auto_grid_then_new_window
 test_auto_overflow_new_window_shape
+test_new_window_parses_bare_uuid_not_short_ref
 test_grid_anchor_uses_recorded_workspace
 test_explicit_layout_modes
 test_focus_never_stolen

--- a/tests/fm-terminal-cmux.test.sh
+++ b/tests/fm-terminal-cmux.test.sh
@@ -337,6 +337,120 @@ test_spawn_source_records_owned_workspace_marker() {
   pass "spawn records the owned workspace marker emitted by overflow placement"
 }
 
+# --- cmux spawn ghost-surface repair ---------------------------------------
+
+make_cmux_spawn_root() {  # <case>
+  local name=$1 fake
+  fake="$TMP_ROOT/$name"
+  mkdir -p "$fake/home/state" "$fake/home/data" "$fake/home/config" "$fake/fakebin"
+  printf 'cmux\n' > "$fake/home/config/terminal-backend"
+  printf '%s\n' '- project [local-only] - test project (added 2026-07-02)' > "$fake/home/data/projects.md"
+  fm_git_worktree "$fake/project" "$fake/wt" worker-branch
+  cat > "$fake/fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "treehouse $*" >> "$CMUX_FAKE_LOG"
+case "$1" in
+  get) printf '%s\n' "$FM_FAKE_WT" ;;
+  return) printf 'returned %s\n' "${3:-}" ;;
+  *) exit 0 ;;
+esac
+SH
+  chmod +x "$fake/fakebin/treehouse"
+  cat > "$fake/fakebin/cmux" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$CMUX_FAKE_LOG"
+attached() {
+  [ "${CMUX_GHOST_MODE:-healthy}" = healthy ] || [ -f "$CMUX_FAKE_STATE.attached" ]
+}
+case "$1" in
+  ping) exit 0 ;;
+  identify) printf '{"caller":{"workspace_ref":"workspace:1","surface_ref":"surface:5"}}\n'; exit 0 ;;
+  current-window) printf 'window:2\n'; exit 0 ;;
+  current-workspace) printf 'workspace:1\n'; exit 0 ;;
+  new-workspace) printf 'created workspace:9 surface:7\n'; exit 0 ;;
+  list-panes) printf 'pane:4\n'; exit 0 ;;
+  list-pane-surfaces) printf 'surface:7\n'; exit 0 ;;
+  rename-tab|send|refresh-surfaces) exit 0 ;;
+  read-screen)
+    if attached; then printf 'codex prompt ready\n'; exit 0; fi
+    printf 'Terminal surface not found\n' >&2
+    exit 1
+    ;;
+  surface-health)
+    if attached; then printf 'surface:7 in_window=true\n'; else printf 'surface:7 in_window=false\n'; fi
+    exit 0
+    ;;
+  select-workspace)
+    if [ "${3:-}" = workspace:9 ] && [ "${CMUX_GHOST_MODE:-}" != never ]; then
+      : > "$CMUX_FAKE_STATE.attached"
+    fi
+    exit 0
+    ;;
+  *) exit 0 ;;
+esac
+SH
+  chmod +x "$fake/fakebin/cmux"
+  printf '%s\n' "$fake"
+}
+
+run_cmux_spawn_case() {  # <fake-root> <id> <healthy|ghost|never>
+  local fake=$1 id=$2 mode=$3
+  mkdir -p "$fake/home/data/$id"
+  printf 'Read this test brief.\n' > "$fake/home/data/$id/brief.md"
+  : > "$fake/cmux.log"
+  rm -f "$fake/cmux-state.attached"
+  PATH="$fake/fakebin:$PATH" \
+    FM_HOME="$fake/home" FM_STATE_OVERRIDE="$fake/home/state" FM_DATA_OVERRIDE="$fake/home/data" FM_CONFIG_OVERRIDE="$fake/home/config" \
+    FM_SPAWN_NO_GUARD=1 FM_FAKE_WT="$fake/wt" CMUX_FAKE_LOG="$fake/cmux.log" CMUX_FAKE_STATE="$fake/cmux-state" CMUX_GHOST_MODE="$mode" \
+    FM_CMUX_ATTACH_PROBES=1 FM_CMUX_ATTACH_DELAY=0 FM_CMUX_GHOST_REPAIRS=2 \
+    "$ROOT/bin/fm-spawn.sh" "$id" "$fake/project" codex >"$fake/out" 2>"$fake/err"
+}
+
+cmux_log_count() {  # <pattern> <file>
+  awk -v pat="$1" 'index($0, pat) { n++ } END { print n + 0 }' "$2"
+}
+
+test_spawn_healthy_surface_skips_repair() {
+  local fake sends
+  fake=$(make_cmux_spawn_root spawn-healthy)
+  run_cmux_spawn_case "$fake" ok-healthy healthy || fail "healthy cmux spawn failed: $(cat "$fake/err")"
+  assert_present "$fake/home/state/ok-healthy.meta" "healthy spawn did not write meta"
+  assert_grep 'read-screen --workspace workspace:9 --surface surface:7 --lines 1' "$fake/cmux.log" "healthy spawn did not probe the surface"
+  assert_no_grep 'select-workspace --workspace workspace:9' "$fake/cmux.log" "healthy spawn ran ghost repair"
+  sends=$(cmux_log_count 'send --workspace workspace:9 --surface surface:7' "$fake/cmux.log")
+  [ "$sends" = 1 ] || fail "healthy spawn should send launch once, sent $sends times"
+  pass "spawn probes healthy cmux surfaces without repair"
+}
+
+test_spawn_repairs_ghost_surface_and_resends_launch() {
+  local fake sends target_line back_line
+  fake=$(make_cmux_spawn_root spawn-ghost)
+  run_cmux_spawn_case "$fake" repair-ghost ghost || fail "ghost-repair cmux spawn failed: $(cat "$fake/err")"
+  assert_present "$fake/home/state/repair-ghost.meta" "repaired ghost spawn did not write meta"
+  assert_grep 'select-workspace --workspace workspace:9' "$fake/cmux.log" "ghost repair did not select the worker workspace"
+  assert_grep 'select-workspace --workspace workspace:1' "$fake/cmux.log" "ghost repair did not restore the original workspace"
+  target_line=$(grep -n -F 'select-workspace --workspace workspace:9' "$fake/cmux.log" | head -1 | cut -d: -f1)
+  back_line=$(grep -n -F 'select-workspace --workspace workspace:1' "$fake/cmux.log" | head -1 | cut -d: -f1)
+  [ "$target_line" -lt "$back_line" ] || fail "ghost repair did not select target before restoring original workspace"
+  sends=$(cmux_log_count 'send --workspace workspace:9 --surface surface:7' "$fake/cmux.log")
+  [ "$sends" = 2 ] || fail "ghost repair should send launch twice, sent $sends times"
+  pass "spawn repairs ghost cmux surfaces with select-toggle and launch resend"
+}
+
+test_spawn_fails_loudly_when_ghost_never_attaches() {
+  local fake status repairs sends
+  fake=$(make_cmux_spawn_root spawn-never)
+  run_cmux_spawn_case "$fake" dead-ghost never; status=$?
+  expect_code 1 "$status" "unrepaired ghost spawn did not fail"
+  assert_absent "$fake/home/state/dead-ghost.meta" "unrepaired ghost spawn must not leave meta"
+  assert_grep 'cmux surface did not attach after launch/repair; workspace=workspace:9 surface=surface:7' "$fake/err" "unrepaired ghost error did not name workspace and surface"
+  repairs=$(cmux_log_count 'select-workspace --workspace workspace:9' "$fake/cmux.log")
+  [ "$repairs" = 2 ] || fail "unrepaired ghost should cap repair attempts at 2, saw $repairs"
+  sends=$(cmux_log_count 'send --workspace workspace:9 --surface surface:7' "$fake/cmux.log")
+  [ "$sends" = 3 ] || fail "unrepaired ghost should send initial launch plus 2 repair resends, sent $sends times"
+  pass "spawn fails loudly with no meta when cmux ghost repair is exhausted"
+}
+
 # --- cmux teardown workspace cleanup ---------------------------------------
 
 make_teardown_root() {  # <case> <id> <marker:yes|no> <shared:yes|no>
@@ -462,6 +576,9 @@ test_explicit_layout_modes
 test_focus_never_stolen
 test_invalid_layout_errors
 test_spawn_source_records_owned_workspace_marker
+test_spawn_healthy_surface_skips_repair
+test_spawn_repairs_ghost_surface_and_resends_launch
+test_spawn_fails_loudly_when_ghost_never_attaches
 test_teardown_closes_owned_unshared_workspace
 test_teardown_does_not_close_unmarked_workspace
 test_teardown_does_not_close_shared_owned_workspace

--- a/tests/fm-terminal-cmux.test.sh
+++ b/tests/fm-terminal-cmux.test.sh
@@ -20,6 +20,7 @@ case "$1" in
   ping) exit 0 ;;
   read-screen) printf 'done: fake cmux output\n'; exit 0 ;;
   send|send-key|close-surface) printf 'OK surface:2 workspace:1\n'; exit 0 ;;
+  new-split|new-pane|new-surface) printf 'created surface:7 workspace:1\n'; exit 0 ;;
   *) exit 0 ;;
 esac
 SH
@@ -65,6 +66,94 @@ test_send_key_maps_ctrl_c() {
   pass "fm-send maps tmux-style C-c to cmux ctrl+c"
 }
 
+# --- multi-worker layout policy --------------------------------------------
+
+# Seed <count> existing cmux worker metas, each recording the crew pane so a tab
+# overflow has an unambiguous target. Clears prior worker metas first.
+seed_cmux_workers() {  # <count> [pane]
+  local count=$1 pane=${2:-pane:9} i=1
+  # Clear ALL metas (including task.meta left by the send/peek tests) so the live
+  # cmux worker count is exactly <count>.
+  rm -f "$STATE_DIR"/*.meta
+  while [ "$i" -le "$count" ]; do
+    fm_write_meta "$STATE_DIR/worker-$i.meta" \
+      'terminal_backend=cmux' \
+      "pane=$pane" \
+      "surface=surface:$i" \
+      'kind=ship'
+    i=$((i + 1))
+  done
+}
+
+# Run fm_terminal_cmux_place_worker from the lib with STATE/cmux stub wired up.
+place() {  # <workspace> <caller_surface> <layout> <exclude-id>
+  STATE="$STATE_DIR" PATH="$FAKEBIN:$PATH" CMUX_FAKE_LOG="$LOG" \
+    bash -c '. "$1"; shift; fm_terminal_cmux_place_worker "$@"' _ "$ROOT/bin/fm-terminal-lib.sh" "$@"
+}
+
+test_auto_splits_1_to_3_then_tab_overflow() {
+  # 1st worker (0 existing) -> visible split
+  seed_cmux_workers 0; : > "$LOG"
+  place workspace:1 surface:1 auto newtask >/dev/null || fail "auto placement failed at N=0"
+  assert_grep 'new-split right --workspace workspace:1 --surface surface:1 --focus false' "$LOG" "auto 1st worker was not a split"
+  assert_no_grep 'new-surface' "$LOG" "auto 1st worker overflowed to a tab"
+  # 2nd and 3rd workers -> still splits
+  seed_cmux_workers 1; : > "$LOG"; place workspace:1 surface:1 auto newtask >/dev/null
+  assert_grep 'new-split right' "$LOG" "auto 2nd worker was not a split"
+  seed_cmux_workers 2; : > "$LOG"; place workspace:1 surface:1 auto newtask >/dev/null
+  assert_grep 'new-split right' "$LOG" "auto 3rd worker was not a split"
+  # 4th worker (3 existing) -> tab overflow into the crew pane
+  seed_cmux_workers 3; : > "$LOG"; place workspace:1 surface:1 auto newtask >/dev/null
+  assert_grep 'new-surface --type terminal --pane pane:9 --workspace workspace:1 --focus false' "$LOG" "auto 4th worker did not overflow to a tab in the crew pane"
+  assert_no_grep 'new-split' "$LOG" "auto 4th worker created a split instead of overflowing"
+  pass "auto layout: splits for workers 1-3, tab overflow for the 4th"
+}
+
+test_explicit_layout_modes() {
+  # splits: always a split, even past the threshold
+  seed_cmux_workers 5; : > "$LOG"; place workspace:1 surface:1 splits newtask >/dev/null
+  assert_grep 'new-split right' "$LOG" "splits mode did not form a split at N=5"
+  assert_no_grep 'new-surface' "$LOG" "splits mode overflowed to a tab"
+  # tabs: first worker splits to create the crew pane, later workers become tabs
+  seed_cmux_workers 0; : > "$LOG"; place workspace:1 surface:1 tabs newtask >/dev/null
+  assert_grep 'new-split right' "$LOG" "tabs mode N=0 did not open a visible split"
+  seed_cmux_workers 1; : > "$LOG"; place workspace:1 surface:1 tabs newtask >/dev/null
+  assert_grep 'new-surface --type terminal --pane pane:9' "$LOG" "tabs mode N=1 did not overflow to a tab"
+  # hybrid: same threshold as auto (split < 3, tab >= 3)
+  seed_cmux_workers 2; : > "$LOG"; place workspace:1 surface:1 hybrid newtask >/dev/null
+  assert_grep 'new-split right' "$LOG" "hybrid N=2 was not a split"
+  seed_cmux_workers 3; : > "$LOG"; place workspace:1 surface:1 hybrid newtask >/dev/null
+  assert_grep 'new-surface --type terminal --pane pane:9' "$LOG" "hybrid N=3 did not overflow to a tab"
+  pass "explicit splits/tabs/hybrid layouts form the expected commands"
+}
+
+test_focus_never_stolen() {
+  # every placement shape must pass --focus false
+  seed_cmux_workers 0; : > "$LOG"; place workspace:1 surface:1 auto newtask >/dev/null
+  assert_grep '--focus false' "$LOG" "split placement did not pass --focus false"
+  seed_cmux_workers 3; : > "$LOG"; place workspace:1 surface:1 auto newtask >/dev/null
+  assert_grep '--focus false' "$LOG" "tab placement did not pass --focus false"
+  # no caller surface -> new-pane fallback, still --focus false
+  seed_cmux_workers 0; : > "$LOG"; place workspace:1 '' auto newtask >/dev/null
+  assert_grep 'new-pane --type terminal --direction right --workspace workspace:1 --focus false' "$LOG" "empty caller surface did not fall back to new-pane"
+  pass "placement never steals focus (--focus false on split, tab, and pane)"
+}
+
+test_invalid_layout_errors() {
+  printf 'bogus\n' > "$CONFIG_DIR/cmux-layout"
+  err=$(FM_CONFIG_OVERRIDE="$CONFIG_DIR" \
+    bash -c '. "$1"; fm_terminal_cmux_layout' _ "$ROOT/bin/fm-terminal-lib.sh" 2>&1)
+  code=$?
+  rm -f "$CONFIG_DIR/cmux-layout"
+  expect_code 2 "$code" "invalid cmux-layout did not exit 2"
+  assert_contains "$err" 'invalid cmux layout' "invalid cmux-layout error message unclear"
+  pass "invalid config/cmux-layout errors clearly"
+}
+
 test_peek_uses_cmux_read_screen
 test_send_uses_cmux_send_and_newline
 test_send_key_maps_ctrl_c
+test_auto_splits_1_to_3_then_tab_overflow
+test_explicit_layout_modes
+test_focus_never_stolen
+test_invalid_layout_errors

--- a/tests/fm-terminal-cmux.test.sh
+++ b/tests/fm-terminal-cmux.test.sh
@@ -370,7 +370,13 @@ case "$1" in
   new-workspace) printf 'created workspace:9 surface:7\n'; exit 0 ;;
   list-panes) printf 'pane:4\n'; exit 0 ;;
   list-pane-surfaces) printf 'surface:7\n'; exit 0 ;;
-  rename-tab|send|refresh-surfaces) exit 0 ;;
+  rename-tab)
+    # Log arg count too, so a test can confirm the title landed as ONE shell
+    # argument (unsplit) rather than several word-split arguments.
+    printf 'RENAME_ARGC=%s\n' "$#" >> "$CMUX_FAKE_LOG"
+    exit 0
+    ;;
+  send|refresh-surfaces) exit 0 ;;
   read-screen)
     if attached; then printf 'codex prompt ready\n'; exit 0; fi
     printf 'Terminal surface not found\n' >&2
@@ -408,6 +414,20 @@ run_cmux_spawn_case() {  # <fake-root> <id> <healthy|ghost|never>
 
 cmux_log_count() {  # <pattern> <file>
   awk -v pat="$1" 'index($0, pat) { n++ } END { print n + 0 }' "$2"
+}
+
+run_cmux_spawn_case_extra() {  # <fake-root> <id> <healthy|ghost|never> [extra fm-spawn.sh args...]
+  local fake=$1 id=$2 mode=$3
+  shift 3
+  mkdir -p "$fake/home/data/$id"
+  printf 'Read this test brief.\n' > "$fake/home/data/$id/brief.md"
+  : > "$fake/cmux.log"
+  rm -f "$fake/cmux-state.attached"
+  PATH="$fake/fakebin:$PATH" \
+    FM_HOME="$fake/home" FM_STATE_OVERRIDE="$fake/home/state" FM_DATA_OVERRIDE="$fake/home/data" FM_CONFIG_OVERRIDE="$fake/home/config" \
+    FM_SPAWN_NO_GUARD=1 FM_FAKE_WT="$fake/wt" CMUX_FAKE_LOG="$fake/cmux.log" CMUX_FAKE_STATE="$fake/cmux-state" CMUX_GHOST_MODE="$mode" \
+    FM_CMUX_ATTACH_PROBES=1 FM_CMUX_ATTACH_DELAY=0 FM_CMUX_GHOST_REPAIRS=2 \
+    "$ROOT/bin/fm-spawn.sh" "$id" "$fake/project" codex "$@" >"$fake/out" 2>"$fake/err"
 }
 
 test_spawn_healthy_surface_skips_repair() {
@@ -449,6 +469,71 @@ test_spawn_fails_loudly_when_ghost_never_attaches() {
   sends=$(cmux_log_count 'send --workspace workspace:9 --surface surface:7' "$fake/cmux.log")
   [ "$sends" = 3 ] || fail "unrepaired ghost should send initial launch plus 2 repair resends, sent $sends times"
   pass "spawn fails loudly with no meta when cmux ghost repair is exhausted"
+}
+
+# --- cmux spawn plain-English tab titles ------------------------------------
+
+test_spawn_title_renames_cmux_tab() {
+  local fake
+  fake=$(make_cmux_spawn_root spawn-title)
+  run_cmux_spawn_case_extra "$fake" titled-ok healthy --title 'twinfield · fixing date test' \
+    || fail "titled cmux spawn failed: $(cat "$fake/err")"
+  assert_grep "rename-tab --workspace workspace:9 --surface surface:7 twinfield · fixing date test" "$fake/cmux.log" \
+    "titled spawn did not rename the cmux tab to the exact title"
+  assert_grep 'RENAME_ARGC=6' "$fake/cmux.log" "titled spawn did not pass the title as a single shell argument"
+  assert_grep 'title=twinfield · fixing date test' "$fake/home/state/titled-ok.meta" "titled spawn did not record title= in meta"
+  pass "spawn renames the cmux tab and records title= when --title is given"
+}
+
+test_spawn_without_title_uses_default_tab() {
+  local fake
+  fake=$(make_cmux_spawn_root spawn-notitle)
+  run_cmux_spawn_case_extra "$fake" no-title healthy \
+    || fail "untitled cmux spawn failed: $(cat "$fake/err")"
+  assert_grep 'rename-tab --workspace workspace:9 --surface surface:7 fm-no-title' "$fake/cmux.log" \
+    "untitled spawn did not fall back to the machine-id tab title"
+  assert_no_grep 'title=' "$fake/home/state/no-title.meta" "untitled spawn should not record title= in meta"
+  pass "spawn without --title keeps the machine-id tab title and records no title="
+}
+
+test_spawn_title_truncates_overlong() {
+  local fake long_title truncated
+  fake=$(make_cmux_spawn_root spawn-longtitle)
+  long_title="nemesis-item-tracker · reconciling the par level algorithm against yesterday's stockout data across every location"
+  run_cmux_spawn_case_extra "$fake" long-title healthy --title "$long_title" \
+    || fail "overlong-title cmux spawn failed: $(cat "$fake/err")"
+  truncated="${long_title:0:47}…"
+  assert_grep "rename-tab --workspace workspace:9 --surface surface:7 $truncated" "$fake/cmux.log" \
+    "overlong title was not truncated to 47 chars plus ellipsis"
+  assert_grep "title=$truncated" "$fake/home/state/long-title.meta" "overlong title in meta was not truncated"
+  pass "spawn truncates an overlong --title with an ellipsis and never breaks rename-tab"
+}
+
+test_spawn_title_with_apostrophe_and_spaces() {
+  local fake
+  fake=$(make_cmux_spawn_root spawn-apostrophe)
+  run_cmux_spawn_case_extra "$fake" quote-title healthy --title "mysubo's dashboard · fixing captain's chart" \
+    || fail "apostrophe-title cmux spawn failed: $(cat "$fake/err")"
+  assert_grep "rename-tab --workspace workspace:9 --surface surface:7 mysubo's dashboard · fixing captain's chart" "$fake/cmux.log" \
+    "title with apostrophes and spaces did not pass through safely"
+  assert_grep 'RENAME_ARGC=6' "$fake/cmux.log" "apostrophe title was not passed as a single shell argument"
+  pass "spawn passes a --title containing apostrophes and spaces through safely"
+}
+
+test_batch_spawn_title_refused() {
+  local fake out err status
+  fake=$(make_cmux_spawn_root spawn-batch-title)
+  mkdir -p "$fake/home/data/batch-a"
+  printf 'Read this test brief.\n' > "$fake/home/data/batch-a/brief.md"
+  out="$fake/batch.out"; err="$fake/batch.err"
+  PATH="$fake/fakebin:$PATH" \
+    FM_HOME="$fake/home" FM_STATE_OVERRIDE="$fake/home/state" FM_DATA_OVERRIDE="$fake/home/data" FM_CONFIG_OVERRIDE="$fake/home/config" \
+    FM_FAKE_WT="$fake/wt" CMUX_FAKE_LOG="$fake/cmux.log" CMUX_FAKE_STATE="$fake/cmux-state" \
+    "$ROOT/bin/fm-spawn.sh" "batch-a=$fake/project" codex --title 'shared title' >"$out" 2>"$err"; status=$?
+  expect_code 1 "$status" "batch spawn with --title should be refused"
+  assert_grep 'title applies to a single-task spawn only' "$err" "batch --title refusal did not explain per-task scoping"
+  assert_absent "$fake/home/state/batch-a.meta" "refused batch --title spawn must not leave meta"
+  pass "batch id=repo dispatch refuses a shared --title with a clear error"
 }
 
 # --- cmux teardown workspace cleanup ---------------------------------------
@@ -579,6 +664,11 @@ test_spawn_source_records_owned_workspace_marker
 test_spawn_healthy_surface_skips_repair
 test_spawn_repairs_ghost_surface_and_resends_launch
 test_spawn_fails_loudly_when_ghost_never_attaches
+test_spawn_title_renames_cmux_tab
+test_spawn_without_title_uses_default_tab
+test_spawn_title_truncates_overlong
+test_spawn_title_with_apostrophe_and_spaces
+test_batch_spawn_title_refused
 test_teardown_closes_owned_unshared_workspace
 test_teardown_does_not_close_unmarked_workspace
 test_teardown_does_not_close_shared_owned_workspace

--- a/tests/fm-terminal-cmux.test.sh
+++ b/tests/fm-terminal-cmux.test.sh
@@ -19,14 +19,21 @@ printf '%s\n' "$*" >> "$CMUX_FAKE_LOG"
 case "$1" in
   ping) exit 0 ;;
   read-screen) printf 'done: fake cmux output\n'; exit 0 ;;
-  send|send-key|close-surface) printf 'OK surface:2 workspace:1\n'; exit 0 ;;
+  send|send-key|close-surface|close-workspace) printf 'OK surface:2 workspace:1\n'; exit 0 ;;
   new-split|new-pane|new-surface) printf 'created surface:7 workspace:1\n'; exit 0 ;;
-  # Real cmux new-window prints a bare "OK <uuid>", never a window:N short ref.
-  new-window) printf 'OK E566A1D2-0000-0000-0000-000000000002\n'; exit 0 ;;
-  current-window) printf 'window:2\n'; exit 0 ;;
-  new-workspace) printf 'created workspace:9\n'; exit 0 ;;
-  # new-window auto-creates a default workspace + terminal surface and focuses the
-  # new window, so identify (called with no --window override) resolves them.
+  new-window) echo 'new-window must not be used for cmux auto overflow' >&2; exit 99 ;;
+  current-window) printf 'E566A1D2-0000-0000-0000-000000000002\n'; exit 0 ;;
+  new-workspace)
+    win_seen=0; win_value=
+    prev=
+    for arg in "$@"; do
+      if [ "$prev" = "--window" ]; then win_seen=1; win_value=$arg; fi
+      prev=$arg
+    done
+    [ "$win_seen" = 1 ] && [ -n "$win_value" ] || { echo 'missing explicit --window' >&2; exit 98; }
+    printf 'created workspace:9 surface:7\n'
+    exit 0
+    ;;
   identify) printf '{"window":"window:2","workspace":"workspace:9","surface":"surface:7"}\n'; exit 0 ;;
   *) exit 0 ;;
 esac
@@ -115,26 +122,27 @@ place() {  # <workspace> <caller_surface> <layout> <exclude-id>
 }
 
 # Run a pure lib function (no cmux) for the arithmetic unit tests.
-action() { bash -c '. "$1"; fm_terminal_cmux_layout_action "$2" "$3"' _ "$ROOT/bin/fm-terminal-lib.sh" "$@"; }
-slot() { bash -c '. "$1"; fm_terminal_cmux_grid_slot "$2"' _ "$ROOT/bin/fm-terminal-lib.sh" "$@"; }
+action() { FM_CONFIG_OVERRIDE="$CONFIG_DIR" bash -c '. "$1"; fm_terminal_cmux_layout_action "$2" "$3"' _ "$ROOT/bin/fm-terminal-lib.sh" "$@"; }
+slot() { FM_CONFIG_OVERRIDE="$CONFIG_DIR" bash -c '. "$1"; fm_terminal_cmux_grid_slot "$2"' _ "$ROOT/bin/fm-terminal-lib.sh" "$@"; }
+capacity() { FM_CONFIG_OVERRIDE="$CONFIG_DIR" bash -c '. "$1"; fm_terminal_cmux_grid_capacity' _ "$ROOT/bin/fm-terminal-lib.sh"; }
 
-test_layout_action_grid_and_window() {
+test_layout_action_grid_and_workspace() {
   local a n
-  # auto: grid within a window, overflow to a new window each time it fills (cap 4).
+  # auto: grid within a workspace, overflow to a new workspace each time it fills (cap 4).
   for n in 0 1 2 3; do a=$(action auto "$n"); [ "$a" = grid ] || fail "auto N=$n expected grid, got '$a'"; done
-  a=$(action auto 4); [ "$a" = window ] || fail "auto N=4 expected window, got '$a'"
+  a=$(action auto 4); [ "$a" = workspace ] || fail "auto N=4 expected workspace, got '$a'"
   for n in 5 6 7; do a=$(action auto "$n"); [ "$a" = grid ] || fail "auto N=$n expected grid, got '$a'"; done
-  a=$(action auto 8); [ "$a" = window ] || fail "auto N=8 expected window, got '$a'"
+  a=$(action auto 8); [ "$a" = workspace ] || fail "auto N=8 expected workspace, got '$a'"
   # capacity is tunable: at cap 2, the boundary moves to N=2.
   a=$(FM_CMUX_GRID_CAPACITY=2 bash -c '. "$1"; fm_terminal_cmux_layout_action "$2" "$3"' _ "$ROOT/bin/fm-terminal-lib.sh" auto 2)
-  [ "$a" = window ] || fail "auto N=2 at capacity 2 expected window, got '$a'"
+  [ "$a" = workspace ] || fail "auto N=2 at capacity 2 expected workspace, got '$a'"
   # splits/tabs/hybrid keep their pre-grid shapes.
   a=$(action splits 5); [ "$a" = split ] || fail "splits expected split, got '$a'"
   a=$(action tabs 0); [ "$a" = split ] || fail "tabs N=0 expected split, got '$a'"
   a=$(action tabs 1); [ "$a" = tab ] || fail "tabs N=1 expected tab, got '$a'"
   a=$(action hybrid 2); [ "$a" = split ] || fail "hybrid N=2 expected split, got '$a'"
   a=$(action hybrid 3); [ "$a" = tab ] || fail "hybrid N=3 expected tab, got '$a'"
-  pass "layout_action: auto grid/window boundary at capacity (tunable); splits/tabs/hybrid unchanged"
+  pass "layout_action: auto grid/workspace boundary at capacity (tunable); splits/tabs/hybrid unchanged"
 }
 
 test_grid_slot_arithmetic() {
@@ -144,14 +152,34 @@ test_grid_slot_arithmetic() {
   s=$(slot 1); [ "$s" = 'down 0' ] || fail "slot 1 expected 'down 0', got '$s'"
   s=$(slot 2); [ "$s" = 'right 0' ] || fail "slot 2 expected 'right 0', got '$s'"
   s=$(slot 3); [ "$s" = 'down 2' ] || fail "slot 3 expected 'down 2', got '$s'"
-  # Second grid (a new window): anchors are GLOBAL creation indices, never caller.
+  # Second grid (a new workspace): anchors are GLOBAL creation indices, never caller.
   s=$(slot 5); [ "$s" = 'down 4' ] || fail "slot 5 expected 'down 4', got '$s'"
   s=$(slot 6); [ "$s" = 'right 4' ] || fail "slot 6 expected 'right 4', got '$s'"
   s=$(slot 7); [ "$s" = 'down 6' ] || fail "slot 7 expected 'down 6', got '$s'"
-  pass "grid_slot: right/down alternation, caller anchor only for worker 1, global anchors across windows"
+  pass "grid_slot: right/down alternation, caller anchor only for worker 1, global anchors across workspaces"
 }
 
-test_auto_grid_then_new_window() {
+test_grid_capacity_env_config_default_precedence() {
+  local c a s
+  rm -f "$CONFIG_DIR/cmux-grid-capacity"
+  c=$(capacity); [ "$c" = 4 ] || fail "default capacity expected 4, got '$c'"
+  printf '6\n' > "$CONFIG_DIR/cmux-grid-capacity"
+  c=$(capacity); [ "$c" = 6 ] || fail "config capacity expected 6, got '$c'"
+  c=$(FM_CMUX_GRID_CAPACITY=5 capacity); [ "$c" = 5 ] || fail "env capacity should override config (expected 5, got '$c')"
+  printf 'bogus\n' > "$CONFIG_DIR/cmux-grid-capacity"
+  c=$(capacity); [ "$c" = 4 ] || fail "invalid config capacity should fall back to 4, got '$c'"
+  printf '0\n' > "$CONFIG_DIR/cmux-grid-capacity"
+  c=$(capacity); [ "$c" = 4 ] || fail "non-positive config capacity should fall back to 4, got '$c'"
+  printf '6\n' > "$CONFIG_DIR/cmux-grid-capacity"
+  a=$(action auto 5); [ "$a" = grid ] || fail "cap=6 N=5 expected grid, got '$a'"
+  a=$(action auto 6); [ "$a" = workspace ] || fail "cap=6 N=6 expected workspace, got '$a'"
+  s=$(FM_CMUX_GRID_ROWS=2 slot 4); [ "$s" = 'right 2' ] || fail "cap=6 rows=2 slot 4 expected 'right 2', got '$s'"
+  s=$(FM_CMUX_GRID_ROWS=2 slot 5); [ "$s" = 'down 4' ] || fail "cap=6 rows=2 slot 5 expected 'down 4', got '$s'"
+  rm -f "$CONFIG_DIR/cmux-grid-capacity"
+  pass "grid capacity: env > config/cmux-grid-capacity > default 4; invalid falls back; cap=6 rows=2 math is column-major"
+}
+
+test_auto_grid_then_workspace_overflow() {
   # Worker 1 (0 existing): split RIGHT off firstmate's caller surface (top-right).
   seed_grid_workers 0; : > "$LOG"
   place workspace:1 surface:5 auto newtask >/dev/null || fail "auto grid placement failed at N=0"
@@ -170,61 +198,51 @@ test_auto_grid_then_new_window() {
   # firstmate's own surface (surface:5) anchors ONLY worker 1: later workers split
   # off prior WORKERS, so firstmate is pinned left and never sliced into a strip.
   assert_no_grep 'surface:5' "$LOG" "grid worker 4 sliced firstmate's own surface"
-  # Worker 5 (4 existing = capacity): overflow to a NEW window, not a split/tab.
+  # Worker 5 (4 existing = capacity): overflow to a NEW workspace, not a split/tab/window.
   seed_grid_workers 4; : > "$LOG"; place workspace:1 surface:5 auto newtask >/dev/null
-  assert_grep 'new-window' "$LOG" "grid worker 5 did not overflow to a new window at capacity"
+  assert_grep 'current-window' "$LOG" "grid worker 5 did not resolve the current window explicitly"
+  assert_grep 'new-workspace --name fm crew 2 --window E566A1D2-0000-0000-0000-000000000002 --focus false' "$LOG" "grid worker 5 did not overflow to a named workspace in the current window"
+  assert_no_grep 'new-window' "$LOG" "grid worker 5 wrongly opened a new OS window"
   assert_no_grep 'new-split' "$LOG" "grid worker 5 wrongly created a split at capacity"
   assert_no_grep 'new-surface' "$LOG" "grid worker 5 wrongly created a tab at capacity"
-  pass "auto layout: 2x2 grid (right/down/right/down off firstmate then workers), new window at capacity"
+  pass "auto layout: 2x2 grid (right/down/right/down off firstmate then workers), same-window workspace at capacity"
 }
 
-test_auto_overflow_new_window_shape() {
-  # At capacity the overflow creates a new window - cmux new-window auto-creates a
-  # default workspace + terminal surface in it and takes focus there, so placement
-  # reads those back via `cmux identify` instead of issuing its own new-workspace/
-  # new-pane calls (which would create a second, unwanted surface). It echoes both
-  # the new surface and the new window's workspace so the spawner addresses the
-  # worker in its own window.
+test_auto_overflow_workspace_shape() {
+  # At capacity the overflow creates a named workspace in firstmate's current
+  # window. It never passes an empty --window and never shells out to new-window.
+  # It echoes both the new surface and workspace so spawn addresses the worker in
+  # that overflow workspace, plus an ownership marker for teardown.
   seed_grid_workers 4; : > "$LOG"
   local out
-  out=$(place workspace:1 surface:5 auto newtask) || fail "new-window overflow placement failed"
-  assert_grep 'new-window' "$LOG" "overflow did not create a new window"
-  assert_grep 'identify' "$LOG" "overflow did not resolve the auto-created workspace/surface via cmux identify"
-  assert_no_grep 'new-workspace' "$LOG" "overflow wrongly created a second workspace (new-window already auto-creates one)"
-  assert_no_grep 'new-pane\|new-surface' "$LOG" "overflow wrongly created a second surface (new-window already auto-creates one)"
-  assert_contains "$out" 'surface:7' "new-window placement did not echo the worker surface"
-  assert_contains "$out" 'workspace:9' "new-window placement did not echo the new window's workspace"
-  pass "auto overflow: new window -> identify (auto-created workspace/surface), echoing the new surface + workspace"
-}
-
-test_new_window_parses_bare_uuid_not_short_ref() {
-  # cmux new-window prints a bare "OK <uuid>", never a "window:N" short ref (unlike
-  # every other placement command). Placement must still succeed off that uuid
-  # rather than grepping for a window:N pattern that will never match.
-  seed_grid_workers 4; : > "$LOG"
-  out=$(place workspace:1 surface:5 auto newtask) || fail "placement failed to parse a bare-uuid new-window response"
-  assert_contains "$out" 'surface:7' "bare-uuid new-window did not still resolve a worker surface"
-  assert_contains "$out" 'workspace:9' "bare-uuid new-window did not still resolve the new window's workspace"
-  pass "new-window overflow parses a bare UUID window ref, not a window:N short ref"
+  out=$(place workspace:1 surface:5 auto newtask) || fail "workspace overflow placement failed"
+  assert_no_grep 'new-window' "$LOG" "overflow invoked forbidden cmux new-window"
+  assert_grep 'current-window' "$LOG" "overflow did not explicitly resolve the current window"
+  assert_grep 'new-workspace --name fm crew 2 --window E566A1D2-0000-0000-0000-000000000002 --focus false' "$LOG" "overflow did not target the resolved current window with focus disabled"
+  assert_no_grep ' --window  ' "$LOG" "overflow passed an empty --window"
+  assert_contains "$out" 'surface:7' "workspace placement did not echo the worker surface"
+  assert_contains "$out" 'workspace:9' "workspace placement did not echo the overflow workspace"
+  assert_contains "$out" 'owned_workspace=1' "workspace placement did not echo the owned workspace marker"
+  pass "auto overflow: named same-window workspace using explicit current-window, echoing surface + workspace + ownership"
 }
 
 test_grid_anchor_uses_recorded_workspace() {
-  # A worker that lives in a new window records its own workspace. When a later
+  # A worker that lives in an overflow workspace records its own workspace. When a later
   # worker tiles beside it, the split must be addressed in THAT workspace, not
-  # firstmate's, so grid tiling is correct across windows.
+  # firstmate's, so grid tiling is correct across workspaces.
   rm -f "$STATE_DIR"/*.meta; : > "$LOG"
   local i=1
   while [ "$i" -le 4 ]; do
     fm_write_meta "$STATE_DIR/gw-$i.meta" 'terminal_backend=cmux' "surface=surface:$((10 + i))" 'workspace=workspace:1' 'kind=ship'
     i=$((i + 1))
   done
-  # Worker 5 lives in the NEW window's workspace:9.
+  # Worker 5 lives in the overflow workspace:9.
   fm_write_meta "$STATE_DIR/gw-5.meta" 'terminal_backend=cmux' 'surface=surface:15' 'workspace=workspace:9' 'kind=ship'
   # Worker 6 (5 existing): grid_slot(5) = 'down 4' -> split down off worker 5,
   # addressed in worker 5's own workspace (workspace:9).
   place workspace:1 surface:5 auto newtask >/dev/null
-  assert_grep 'new-split down --workspace workspace:9 --surface surface:15 --focus false' "$LOG" "second-window grid did not anchor in the prior worker's recorded workspace"
-  pass "grid anchors off the prior worker's own recorded workspace (correct across windows)"
+  assert_grep 'new-split down --workspace workspace:9 --surface surface:15 --focus false' "$LOG" "second-workspace grid did not anchor in the prior worker's recorded workspace"
+  pass "grid anchors off the prior worker's own recorded workspace (correct across workspaces)"
 }
 
 test_explicit_layout_modes() {
@@ -252,21 +270,18 @@ test_focus_never_stolen() {
   # a later grid split (worker 4) also passes --focus false
   seed_grid_workers 3; : > "$LOG"; place workspace:1 surface:5 auto newtask >/dev/null
   assert_grep '--focus false' "$LOG" "later grid split did not pass --focus false"
-  # new-window overflow: cmux new-window is bare and has no --focus flag (the one
-  # placement command that can take focus). Its auto-created workspace/surface are
-  # then read back with `cmux identify`, a read-only call with no focus
-  # implications and no further pane/workspace creation that could steal focus.
+  # workspace overflow: new-workspace explicitly targets firstmate's current window
+  # and passes --focus false.
   seed_grid_workers 4; : > "$LOG"; place workspace:1 surface:5 auto newtask >/dev/null
-  assert_grep 'new-window' "$LOG" "new-window overflow did not create a new window"
-  assert_grep 'identify' "$LOG" "new-window overflow did not resolve via cmux identify"
-  assert_no_grep 'new-split\|new-pane\|new-surface\|new-workspace' "$LOG" "new-window overflow issued an unnecessary focus-affecting command"
+  assert_grep 'new-workspace --name fm crew 2 --window E566A1D2-0000-0000-0000-000000000002 --focus false' "$LOG" "workspace overflow did not pass --focus false"
+  assert_no_grep 'new-window' "$LOG" "workspace overflow invoked forbidden new-window"
   # tab overflow (explicit tabs layout) passes --focus false
   seed_cmux_workers 1; : > "$LOG"; place workspace:1 surface:1 tabs newtask >/dev/null
   assert_grep '--focus false' "$LOG" "tab placement did not pass --focus false"
   # no caller surface -> new-pane fallback, still --focus false
   seed_grid_workers 0; : > "$LOG"; place workspace:1 '' auto newtask >/dev/null
   assert_grep 'new-pane --type terminal --direction right --workspace workspace:1 --focus false' "$LOG" "empty caller surface did not fall back to new-pane"
-  pass "placement never steals focus (--focus false on grid splits, new-window workspace/pane, tab, and fallback pane)"
+  pass "placement never steals focus (--focus false on grid splits, workspace overflow, tab, and fallback pane)"
 }
 
 test_invalid_layout_errors() {
@@ -280,15 +295,139 @@ test_invalid_layout_errors() {
   pass "invalid config/cmux-layout errors clearly"
 }
 
+test_spawn_source_records_owned_workspace_marker() {
+  grep -F 'grep '\''^owned_workspace=1$'\''' "$ROOT/bin/fm-spawn.sh" >/dev/null \
+    || fail "fm-spawn does not detect owned_workspace=1 from placement output"
+  grep -F 'echo "owned_workspace=1"' "$ROOT/bin/fm-spawn.sh" >/dev/null \
+    || fail "fm-spawn does not record owned_workspace=1 in meta"
+  pass "spawn records the owned workspace marker emitted by overflow placement"
+}
+
+# --- cmux teardown workspace cleanup ---------------------------------------
+
+make_teardown_root() {  # <case> <id> <marker:yes|no> <shared:yes|no>
+  local name=$1 id=$2 marker=$3 shared=$4 fake
+  fake="$TMP_ROOT/$name"
+  mkdir -p "$fake/bin" "$fake/state" "$fake/config" "$fake/fakebin"
+  ln -s "$ROOT/bin/fm-teardown.sh" "$fake/bin/fm-teardown.sh"
+  ln -s "$ROOT/bin/fm-terminal-lib.sh" "$fake/bin/fm-terminal-lib.sh"
+  ln -s "$ROOT/bin/fm-tmux-lib.sh" "$fake/bin/fm-tmux-lib.sh"
+  cat > "$fake/bin/fm-guard.sh" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  chmod +x "$fake/bin/fm-guard.sh"
+  cat > "$fake/bin/fm-fleet-sync.sh" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  chmod +x "$fake/bin/fm-fleet-sync.sh"
+  cat > "$fake/bin/fm-tasks-axi-lib.sh" <<'SH'
+fm_tasks_axi_backend_available() { return 1; }
+SH
+  cat > "$fake/fakebin/cmux" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$CMUX_FAKE_LOG"
+case "$1" in
+  close-surface) printf 'OK closed surface\n'; exit 0 ;;
+  close-workspace)
+    if [ "${CMUX_CLOSE_WORKSPACE_FAIL:-}" = 1 ]; then
+      echo 'simulated close-workspace failure' >&2
+      exit 42
+    fi
+    printf 'OK closed workspace\n'
+    exit 0
+    ;;
+  *) exit 0 ;;
+esac
+SH
+  chmod +x "$fake/fakebin/cmux"
+  fm_write_meta "$fake/state/$id.meta" \
+    'terminal_backend=cmux' \
+    'workspace=workspace:9' \
+    'surface=surface:7' \
+    "worktree=$fake/nonexistent-wt" \
+    "project=$fake/nonexistent-project" \
+    'harness=pi' \
+    'kind=ship' \
+    'mode=local-only'
+  if [ "$marker" = yes ]; then
+    printf '%s\n' 'owned_workspace=1' >> "$fake/state/$id.meta"
+  fi
+  if [ "$shared" = yes ]; then
+    fm_write_meta "$fake/state/other.meta" \
+      'terminal_backend=cmux' \
+      'workspace=workspace:9' \
+      'surface=surface:8' \
+      'harness=pi' \
+      'kind=ship' \
+      'mode=local-only'
+  fi
+  printf '%s\n' "$fake"
+}
+
+run_teardown_case() {  # <fake-root> <id> [stderr-file]
+  local fake=$1 id=$2 err=${3:-/dev/null}
+  PATH="$fake/fakebin:$PATH" CMUX_FAKE_LOG="$LOG" CMUX_CLOSE_WORKSPACE_FAIL="${CMUX_CLOSE_WORKSPACE_FAIL:-}" FM_HOME="$fake" FM_STATE_OVERRIDE="$fake/state" FM_CONFIG_OVERRIDE="$fake/config" \
+    bash "$fake/bin/fm-teardown.sh" "$id" >"$fake/out" 2>"$err"
+}
+
+test_teardown_closes_owned_unshared_workspace() {
+  local fake
+  fake=$(make_teardown_root td-owned-close task-owned yes no)
+  : > "$LOG"
+  run_teardown_case "$fake" task-owned || fail "teardown failed for owned unshared workspace"
+  assert_grep 'close-surface --workspace workspace:9 --surface surface:7' "$LOG" "teardown did not close the worker surface"
+  assert_grep 'close-workspace --workspace workspace:9' "$LOG" "teardown did not close an owned unshared workspace"
+  pass "teardown closes an owned overflow workspace when no other live meta references it"
+}
+
+test_teardown_does_not_close_unmarked_workspace() {
+  local fake
+  fake=$(make_teardown_root td-unmarked task-unmarked no no)
+  : > "$LOG"
+  run_teardown_case "$fake" task-unmarked || fail "teardown failed for unmarked workspace"
+  assert_grep 'close-surface --workspace workspace:9 --surface surface:7' "$LOG" "teardown did not close the worker surface"
+  assert_no_grep 'close-workspace --workspace workspace:9' "$LOG" "teardown closed an unmarked workspace"
+  pass "teardown never closes a workspace without owned_workspace=1"
+}
+
+test_teardown_does_not_close_shared_owned_workspace() {
+  local fake
+  fake=$(make_teardown_root td-shared task-shared yes yes)
+  : > "$LOG"
+  run_teardown_case "$fake" task-shared || fail "teardown failed for shared owned workspace"
+  assert_grep 'close-surface --workspace workspace:9 --surface surface:7' "$LOG" "teardown did not close the worker surface"
+  assert_no_grep 'close-workspace --workspace workspace:9' "$LOG" "teardown closed a workspace still referenced by another live meta"
+  pass "teardown keeps an owned workspace open while another live task references it"
+}
+
+test_teardown_workspace_close_failure_is_nonfatal() {
+  local fake err
+  fake=$(make_teardown_root td-close-fail task-close-fail yes no)
+  err="$fake/err"
+  : > "$LOG"
+  CMUX_CLOSE_WORKSPACE_FAIL=1 run_teardown_case "$fake" task-close-fail "$err" \
+    || fail "teardown failed when close-workspace failed nonfatally"
+  assert_grep 'close-workspace --workspace workspace:9' "$LOG" "teardown did not attempt to close the owned workspace"
+  assert_grep 'leftover workspace remains' "$err" "teardown did not report the leftover workspace after close-workspace failed"
+  pass "teardown reports close-workspace failure but completes cleanup"
+}
+
 test_peek_uses_cmux_read_screen
 test_send_uses_cmux_send_and_newline
 test_send_key_maps_ctrl_c
-test_layout_action_grid_and_window
+test_layout_action_grid_and_workspace
 test_grid_slot_arithmetic
-test_auto_grid_then_new_window
-test_auto_overflow_new_window_shape
-test_new_window_parses_bare_uuid_not_short_ref
+test_grid_capacity_env_config_default_precedence
+test_auto_grid_then_workspace_overflow
+test_auto_overflow_workspace_shape
 test_grid_anchor_uses_recorded_workspace
 test_explicit_layout_modes
 test_focus_never_stolen
 test_invalid_layout_errors
+test_spawn_source_records_owned_workspace_marker
+test_teardown_closes_owned_unshared_workspace
+test_teardown_does_not_close_unmarked_workspace
+test_teardown_does_not_close_shared_owned_workspace
+test_teardown_workspace_close_failure_is_nonfatal

--- a/tests/fm-watch-cmux.test.sh
+++ b/tests/fm-watch-cmux.test.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+# tests/fm-watch-cmux.test.sh - the cmux worker path of the always-on watcher
+# (bin/fm-watch.sh). Phase B slice 1 routes the watcher's stale-pane supervision
+# through the terminal boundary (bin/fm-terminal-lib.sh), so a cmux worker - which
+# records terminal_backend=cmux + workspace/surface and NO window= - is enumerated,
+# has its screen read through `cmux read-screen`, and is classified (busy footer,
+# stale-with-outcome) the same way a tmux window is.
+#
+# These cases drive a real fm-watch.sh subprocess with a stubbed `cmux` (as
+# tests/fm-terminal-cmux.test.sh stubs it for spawn) and assert:
+#   - a cmux-meta task is ENUMERATED and its screen READ through the boundary;
+#   - a busy footer on the cmux screen is NOT stale (absorbed);
+#   - a stale cmux worker sitting on a done/needs-decision/failed STATUS is surfaced;
+#   - a stale cmux worker whose OUTCOME marker is only on the screen is classified
+#     via the real fm-crew-state.sh (screen-read fallback) and surfaced;
+#   - the tmux worker path is unchanged and never touches cmux.
+#
+# The generic tmux triage matrix lives in fm-watch-triage.test.sh; cmux backend
+# routing for send/peek in fm-terminal-cmux.test.sh; crew-state reads in
+# fm-crew-state.test.sh.
+set -u
+
+# shellcheck source=tests/wake-helpers.sh
+. "$(dirname "${BASH_SOURCE[0]}")/wake-helpers.sh"
+
+WATCH="$ROOT/bin/fm-watch.sh"
+DRAIN="$ROOT/bin/fm-wake-drain.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-watch-cmux-tests)
+
+# --- local helpers (mirror fm-watch-triage.test.sh) -------------------------
+
+# Wait up to <limit> 0.1s ticks while <pid> stays alive; 0 if still alive, 1 if died.
+wait_live() {
+  local pid=$1 limit=${2:-30} i=0
+  while [ "$i" -lt "$limit" ]; do
+    kill -0 "$pid" 2>/dev/null || return 1
+    sleep 0.1
+    i=$((i + 1))
+  done
+  return 0
+}
+
+reap() { kill "$1" 2>/dev/null || true; wait "$1" 2>/dev/null || true; }
+
+# Signature a primed .seen-* marker must hold so the per-poll signal scan does not
+# fire on a pre-existing status (mirrors fm-watch.sh's stat_sig exactly).
+seen_sig() {
+  if [ "$(uname)" = Darwin ]; then stat -f '%z:%Fm' "$1" 2>/dev/null; else stat -c '%s:%Y' "$1" 2>/dev/null; fi
+}
+
+# A fake cmux that logs every invocation and serves a controllable screen. Mirrors
+# the spawn stub in fm-terminal-cmux.test.sh; read-screen echoes CMUX_FAKE_SCREEN so
+# a test can inject a busy footer or an outcome marker into the worker's screen.
+install_cmux_stub() {  # <fakebin>
+  cat > "$1/cmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+printf '%s\n' "$*" >> "${CMUX_FAKE_LOG:-/dev/null}"
+case "${1:-}" in
+  ping) exit 0 ;;
+  read-screen) printf '%s\n' "${CMUX_FAKE_SCREEN:-idle prompt}"; exit 0 ;;
+  send|send-key|close-surface) exit 0 ;;
+  *) exit 0 ;;
+esac
+SH
+  chmod +x "$1/cmux"
+}
+
+# A cmux task's meta: terminal_backend=cmux + workspace/surface, and crucially NO
+# window= (the thing that used to make cmux workers invisible to the stale loop).
+write_cmux_meta() {  # <state> <id> <worktree>
+  fm_write_meta "$1/$2.meta" \
+    'terminal_backend=cmux' \
+    'workspace=workspace:1' \
+    'surface=surface:2' \
+    'pane=pane:3' \
+    "worktree=$3" \
+    'harness=pi' \
+    'kind=ship' \
+    'mode=local-only'
+}
+
+# The stale-loop marker key for a cmux worker token (fm-<id>), matching fm-watch.sh.
+cmux_key() { printf '%s' "fm-$1" | tr ':/.' '___'; }
+
+# Prime a matching stale hash + count so the stale path fires on the first poll,
+# exactly as the tmux stale cases in fm-watch-triage.test.sh do.
+prime_stale() {  # <state> <id> <screen>
+  local key; key=$(cmux_key "$2")
+  printf '%s' "$(hash_text "$3")" > "$1/.hash-$key"
+  printf '1\n' > "$1/.count-$key"
+}
+
+# --- enumeration + boundary read + not-working stale surfaced ---------------
+
+test_cmux_enumerated_and_read_through_boundary() {
+  local dir state fakebin out drain_out cmux_log wt screen pid
+  dir=$(make_case cmux-enum); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"; drain_out="$dir/drain.out"; cmux_log="$dir/cmux.log"
+  wt="$dir/wt"; mkdir -p "$wt"
+  install_cmux_stub "$fakebin"
+  write_cmux_meta "$state" cmuxtask "$wt"
+  screen='worker idle prompt'
+  prime_stale "$state" cmuxtask "$screen"
+  # No running pipeline, not busy: the worker has stopped -> NOT provably working
+  # -> surface (the stubbed crew-state returns an unknown verdict).
+  PATH="$fakebin:$PATH" CMUX_FAKE_LOG="$cmux_log" CMUX_FAKE_SCREEN="$screen" \
+    FM_FAKE_CREW_STATE='state: unknown · source: none · no current-state source available' \
+    FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" \
+    FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  wait_for_exit "$pid" 40 || fail "watcher did not surface a stopped stale cmux worker"
+  grep -Fx "stale: fm-cmuxtask" "$out" >/dev/null || fail "watcher did not print the cmux stale wake (got: $(cat "$out"))"
+  # The screen was read through the terminal boundary with the recorded handles.
+  assert_grep 'read-screen --workspace workspace:1 --surface surface:2 --lines 40' "$cmux_log" \
+    "watcher did not read the cmux screen through the terminal boundary"
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$drain_out" 2>/dev/null || fail "drain after the cmux stale failed"
+  grep "$(printf '\tstale\t')" "$drain_out" | grep -F "fm-cmuxtask" >/dev/null || fail "cmux stale wake was not queued"
+  pass "watcher enumerates a cmux worker, reads its screen through the boundary, and surfaces a stopped stale worker"
+}
+
+# --- busy footer on the cmux screen is not stale (absorbed) ------------------
+
+test_cmux_busy_footer_absorbed() {
+  local dir state fakebin out cmux_log wt screen pid
+  dir=$(make_case cmux-busy); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"; cmux_log="$dir/cmux.log"; wt="$dir/wt"; mkdir -p "$wt"
+  install_cmux_stub "$fakebin"
+  write_cmux_meta "$state" cmuxtask "$wt"
+  # A busy footer on the cmux screen: the worker is mid-turn, so a stable pane is
+  # not a stale worker. The inline busy grep runs on the boundary-read screen text.
+  screen='building things
+Working...'
+  prime_stale "$state" cmuxtask "$screen"
+  PATH="$fakebin:$PATH" CMUX_FAKE_LOG="$cmux_log" CMUX_FAKE_SCREEN="$screen" \
+    FM_FAKE_CREW_STATE='state: working · source: pane · harness busy' \
+    FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" \
+    FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  if ! wait_live "$pid" 30; then reap "$pid"; fail "watcher exited for a busy cmux worker (should absorb): $(cat "$out")"; fi
+  [ ! -s "$out" ] || { reap "$pid"; fail "busy cmux worker printed a wake reason: $(cat "$out")"; }
+  [ ! -s "$state/.wake-queue" ] || { reap "$pid"; fail "busy cmux worker enqueued a durable wake record"; }
+  # It still read the screen through the boundary to make the busy call.
+  assert_grep 'read-screen --workspace workspace:1 --surface surface:2 --lines 40' "$cmux_log" \
+    "busy classification did not read the cmux screen through the terminal boundary"
+  reap "$pid"
+  pass "a cmux worker showing a busy footer is not stale (absorbed), classified from the boundary-read screen"
+}
+
+# --- stale cmux worker on a captain-relevant STATUS is surfaced --------------
+# The status file stays the primary outcome signal; this proves the STALE path now
+# covers cmux workers (they were previously invisible to it for lack of a window=).
+
+run_terminal_outcome_case() {  # <casename> <status-line>
+  local name=$1 status=$2 dir state fakebin out drain_out cmux_log wt screen sig pid
+  dir=$(make_case "$name"); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"; drain_out="$dir/drain.out"; cmux_log="$dir/cmux.log"
+  wt="$dir/wt"; mkdir -p "$wt"
+  install_cmux_stub "$fakebin"
+  write_cmux_meta "$state" cmuxtask "$wt"
+  screen='idle, awaiting review'
+  # The captain-relevant outcome is in the STATUS file; prime .seen-* so the signal
+  # scan stays quiet and the STALE path is the one that classifies this worker.
+  printf '%s\n' "$status" > "$state/cmuxtask.status"
+  sig=$(seen_sig "$state/cmuxtask.status"); printf '%s' "$sig" > "$state/.seen-cmuxtask_status"
+  prime_stale "$state" cmuxtask "$screen"
+  PATH="$fakebin:$PATH" CMUX_FAKE_LOG="$cmux_log" CMUX_FAKE_SCREEN="$screen" \
+    FM_FAKE_CREW_STATE='state: unknown · source: none · fake' \
+    FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" \
+    FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  wait_for_exit "$pid" 40 || fail "watcher did not surface a stale cmux worker on '$status'"
+  grep -Fx "stale: fm-cmuxtask" "$out" >/dev/null || fail "watcher did not print the cmux terminal stale wake for '$status' (got: $(cat "$out"))"
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$drain_out" 2>/dev/null || fail "drain failed for '$status'"
+  grep "$(printf '\tstale\t')" "$drain_out" | grep -F 'fm-cmuxtask' >/dev/null || fail "cmux terminal stale not queued for '$status'"
+}
+
+test_cmux_terminal_outcome_surfaced() {
+  run_terminal_outcome_case cmux-term-done  'done: ready in branch fm/x'
+  run_terminal_outcome_case cmux-term-needs 'needs-decision: pick A or B'
+  run_terminal_outcome_case cmux-term-fail  'failed: build broke with evidence'
+  pass "a stale cmux worker sitting on a done/needs-decision/failed status is surfaced (outcome classification)"
+}
+
+# --- outcome marker only on the cmux SCREEN, classified via real fm-crew-state ---
+# When no captain-relevant status verb exists, the screen-read fallback must catch
+# the outcome: the real fm-crew-state.sh reads the cmux screen through the boundary,
+# classifies a needs-decision marker as parked (NOT provably working), and the
+# watcher surfaces it. Exercises the whole enumeration -> boundary read -> classify
+# chain end to end (no stubbed verdict).
+
+test_cmux_screen_marker_surfaced_via_crew_state() {
+  local dir state fakebin out drain_out cmux_log wt screen pid
+  dir=$(make_case cmux-screen-marker); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"; drain_out="$dir/drain.out"; cmux_log="$dir/cmux.log"
+  # A plain (non-git) worktree: crew-state finds no branch/run and falls to its
+  # pane/marker read, which for cmux is a boundary screen read.
+  wt="$dir/wt"; mkdir -p "$wt"
+  install_cmux_stub "$fakebin"
+  write_cmux_meta "$state" cmuxtask "$wt"
+  # The outcome marker is ONLY on the screen (no captain-relevant status verb).
+  screen='waiting for input
+needs-decision: choose the database'
+  prime_stale "$state" cmuxtask "$screen"
+  PATH="$fakebin:$PATH" CMUX_FAKE_LOG="$cmux_log" CMUX_FAKE_SCREEN="$screen" \
+    FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$ROOT/bin/fm-crew-state.sh" \
+    FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  wait_for_exit "$pid" 60 || fail "watcher did not surface a cmux worker whose screen shows a needs-decision marker"
+  grep -Fx "stale: fm-cmuxtask" "$out" >/dev/null || fail "watcher did not print the cmux screen-marker stale wake (got: $(cat "$out"))"
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$drain_out" 2>/dev/null || fail "drain after the cmux screen-marker failed"
+  grep "$(printf '\tstale\t')" "$drain_out" | grep -F 'fm-cmuxtask' >/dev/null || fail "cmux screen-marker stale was not queued"
+  pass "a cmux worker whose screen shows a needs-decision outcome is classified via the terminal boundary (real fm-crew-state) and surfaced"
+}
+
+# --- the tmux worker path is unchanged and never touches cmux ----------------
+
+test_tmux_path_unchanged_alongside_cmux_support() {
+  local dir state fakebin out drain_out cmux_log capture window key h sig pid
+  dir=$(make_case cmux-tmux-unchanged); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"; drain_out="$dir/drain.out"; cmux_log="$dir/cmux.log"; capture="$dir/pane.txt"
+  install_cmux_stub "$fakebin"
+  window='test:fm-tmuxtask'
+  printf 'finished, awaiting review' > "$capture"
+  printf 'window=%s\nkind=ship\n' "$window" > "$state/tmuxtask.meta"
+  printf 'done: PR https://example.test/pr/9\n' > "$state/tmuxtask.status"
+  sig=$(seen_sig "$state/tmuxtask.status"); printf '%s' "$sig" > "$state/.seen-tmuxtask_status"
+  key=$(printf '%s' "$window" | tr ':/.' '___')
+  h=$(hash_text 'finished, awaiting review')
+  printf '%s' "$h" > "$state/.hash-$key"
+  printf '1\n' > "$state/.count-$key"
+  PATH="$fakebin:$PATH" CMUX_FAKE_LOG="$cmux_log" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture" \
+    FM_STATE_OVERRIDE="$state" FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  wait_for_exit "$pid" 40 || fail "watcher did not surface a stale tmux worker (tmux path regressed)"
+  grep -Fx "stale: $window" "$out" >/dev/null || fail "watcher did not print the tmux stale wake (got: $(cat "$out"))"
+  # A tmux worker is read through tmux, never cmux: the cmux stub must stay untouched.
+  [ ! -s "$cmux_log" ] || fail "the tmux worker path invoked cmux (should stay tmux-only): $(cat "$cmux_log")"
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$drain_out" 2>/dev/null || fail "drain after the tmux stale failed"
+  grep "$(printf '\tstale\t')" "$drain_out" | grep -F "$window" >/dev/null || fail "tmux stale wake was not queued"
+  pass "the tmux worker path is unchanged (read through tmux, cmux never invoked) alongside cmux support"
+}
+
+test_cmux_enumerated_and_read_through_boundary
+test_cmux_busy_footer_absorbed
+test_cmux_terminal_outcome_surfaced
+test_cmux_screen_marker_surfaced_via_crew_state
+test_tmux_path_unchanged_alongside_cmux_support

--- a/tests/fm-x-cmux.test.sh
+++ b/tests/fm-x-cmux.test.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# Prove the X-mention -> (cmux) spawn -> supervise -> completion-follow-up loop
+# works for a cmux task, i.e. that X mode is additive under the cmux terminal
+# backend (Phase B slice 4, audit-and-prove).
+#
+# Why no core change was needed: the X path is terminal-INDEPENDENT. fm-x-link.sh,
+# fm-x-followup.sh, and fm-x-reply.sh only read/write state/<id>.meta by line and
+# talk to the relay - none of them reads window=, calls tmux, or assumes a tmux
+# window. The terminal-touching hops the loop rides (spawn via fm-spawn.sh,
+# supervision via fm-watch.sh, current-state detection via fm-crew-state.sh) were
+# already made cmux-aware in slices 1-3 and are pinned by their own suites
+# (fm-terminal-cmux, fm-watch-cmux, fm-crew-state). This suite pins the remaining
+# X-specific claim: the link/follow-up records into and reads from a cmux meta
+# (terminal_backend=cmux, surface=, and NO window=) exactly as it does for a tmux
+# meta, and never shells out to tmux to do it.
+#
+# A cmux meta is written exactly as fm-spawn.sh's spawn_cmux_and_exit writes it:
+# terminal_backend/workspace/pane/surface plus worktree/project, and crucially NO
+# window= line. The network is never touched here - link and --check are offline,
+# and the follow-up loop is exercised with FMX_DRY_RUN, which records the would-be
+# post to state/x-outbox instead of calling the relay. jq stays the real tool.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+BASE_PATH=${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin}
+# The follow-up dry-run path (fm-x-reply.sh) uses the real jq; make it resolvable
+# regardless of where it is installed, prepended so it wins over BASE_PATH but
+# after the tmux tripwire below.
+JQ_DIR=$(command -v jq 2>/dev/null) && JQ_DIR=$(dirname "$JQ_DIR") || JQ_DIR=
+[ -n "$JQ_DIR" ] && BASE_PATH="$JQ_DIR:$BASE_PATH"
+TMP_ROOT=$(fm_test_tmproot fm-x-cmux-tests)
+
+# A cmux ship-task meta exactly as fm-spawn.sh writes for a cmux worker:
+# terminal_backend=cmux, workspace/pane/surface, worktree/project, and NO window=.
+write_cmux_meta() { # <home> <id>
+  local home=$1 id=$2
+  mkdir -p "$home/state"
+  fm_write_meta "$home/state/$id.meta" \
+    'terminal_backend=cmux' \
+    'workspace=workspace:1' \
+    'pane=pane:3' \
+    'surface=surface:2' \
+    'harness=pi' \
+    'kind=ship' \
+    'mode=no-mistakes' \
+    'yolo=off' \
+    'tasktmp=/tmp/t' \
+    'model=default' \
+    'effort=default' \
+    "worktree=$home/wt" \
+    "project=$home/proj"
+}
+
+# A tmux tripwire: a stub that records any invocation and fails loudly. Placed
+# FIRST on PATH so it shadows any real tmux; if the X path ever shells out to tmux
+# for a cmux-meta task, the sentinel appears and the exit code is non-zero. This
+# turns "no tmux dependency" from a code-read into an executable assertion.
+make_tmux_tripwire() { # <dir> -> fakebin
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+: > "${FM_TMUX_TRIPPED:?FM_TMUX_TRIPPED unset}"
+echo "tmux was invoked for a cmux task: $*" >&2
+exit 3
+SH
+  chmod +x "$fakebin/tmux"
+  printf '%s\n' "$fakebin"
+}
+
+# ---------------------------------------------------------------------------
+
+test_link_records_into_cmux_meta_without_window() {
+  local home meta out rc
+  home="$TMP_ROOT/link-cmux"; mkdir -p "$home"
+  write_cmux_meta "$home" cmux-ship-a
+  meta="$home/state/cmux-ship-a.meta"
+  out=$(FM_HOME="$home" FMX_NOW_OVERRIDE=1700000000 \
+    "$ROOT/bin/fm-x-link.sh" cmux-ship-a req-cmux-a); rc=$?
+  expect_code 0 "$rc" "link into cmux meta exit"
+  assert_grep "x_request=req-cmux-a" "$meta" "link must record the request_id in a cmux meta"
+  assert_grep "x_request_ts=1700000000" "$meta" "link must record the timestamp in a cmux meta"
+  # The cmux-specific fields must survive verbatim - this is the crux: the link
+  # rewrite drops only x_request/x_request_ts and preserves every other line.
+  assert_grep "terminal_backend=cmux" "$meta" "link must preserve terminal_backend=cmux"
+  assert_grep "surface=surface:2" "$meta" "link must preserve the cmux surface"
+  assert_grep "workspace=workspace:1" "$meta" "link must preserve the cmux workspace"
+  assert_grep "pane=pane:3" "$meta" "link must preserve the cmux pane"
+  assert_grep "kind=ship" "$meta" "link must preserve kind"
+  # And it must NOT invent a tmux window= line for a cmux task.
+  assert_no_grep "window=" "$meta" "link must not introduce a window= line into a cmux meta"
+  # Re-linking replaces rather than duplicating, exactly as for a tmux meta.
+  FM_HOME="$home" FMX_NOW_OVERRIDE=1700009999 \
+    "$ROOT/bin/fm-x-link.sh" cmux-ship-a req-cmux-b >/dev/null
+  [ "$(grep -c '^x_request=' "$meta")" = "1" ] || fail "re-link must not duplicate x_request in a cmux meta"
+  assert_grep "x_request=req-cmux-b" "$meta" "re-link must replace the request_id"
+  assert_no_grep "window=" "$meta" "re-link must still not introduce a window= line"
+  pass "fm-x-link records the X link into a cmux meta and never adds a window="
+}
+
+test_followup_check_for_cmux_linked_task() {
+  local home meta out rc
+  home="$TMP_ROOT/fu-check-cmux"; mkdir -p "$home"
+  write_cmux_meta "$home" cmux-ship-b
+  meta="$home/state/cmux-ship-b.meta"
+  FM_HOME="$home" FMX_NOW_OVERRIDE=1700000000 \
+    "$ROOT/bin/fm-x-link.sh" cmux-ship-b req-cmux-c >/dev/null
+  # Within the 24h window -> exit 0, prints the request_id for the cmux task.
+  out=$(FM_HOME="$home" FMX_NOW_OVERRIDE=1700003600 \
+    "$ROOT/bin/fm-x-followup.sh" --check cmux-ship-b); rc=$?
+  expect_code 0 "$rc" "cmux followup --check within-window exit"
+  [ "$out" = "req-cmux-c" ] || fail "check on a cmux-linked task must print the request_id (got: $out)"
+  # A cmux task that never came from an X mention -> exit 1, silent (not linked).
+  write_cmux_meta "$home" cmux-ship-plain
+  out=$(FM_HOME="$home" "$ROOT/bin/fm-x-followup.sh" --check cmux-ship-plain 2>/dev/null); rc=$?
+  expect_code 1 "$rc" "cmux followup --check not-linked exit"
+  [ -z "$out" ] || fail "check on a non-linked cmux task must be silent (got: $out)"
+  # Past the 24h window -> exit 1, silent, and the link is pruned while the cmux
+  # fields stay intact.
+  out=$(FM_HOME="$home" FMX_NOW_OVERRIDE=$((1700000000 + 25*3600)) \
+    "$ROOT/bin/fm-x-followup.sh" --check cmux-ship-b 2>/dev/null); rc=$?
+  expect_code 1 "$rc" "cmux followup --check expired exit"
+  [ -z "$out" ] || fail "check on an expired cmux link must be silent (got: $out)"
+  assert_no_grep "x_request=" "$meta" "expired --check must prune the link from a cmux meta"
+  assert_grep "terminal_backend=cmux" "$meta" "expired --check must preserve the cmux fields"
+  assert_no_grep "window=" "$meta" "expired --check must not introduce a window= line"
+  pass "fm-x-followup --check reports the due request_id for a cmux-linked task and prunes on expiry"
+}
+
+test_followup_dry_run_loop_for_cmux_meta() {
+  local home meta out rc
+  home="$TMP_ROOT/fu-loop-cmux"; mkdir -p "$home"
+  write_cmux_meta "$home" cmux-ship-c
+  meta="$home/state/cmux-ship-c.meta"
+  FM_HOME="$home" FMX_NOW_OVERRIDE=1700000000 \
+    "$ROOT/bin/fm-x-link.sh" cmux-ship-c req-cmux-d >/dev/null
+  # The completion follow-up (dry-run) records the would-be post and clears the
+  # link exactly as a live post would - the whole acknowledge -> act -> follow-up
+  # loop for a cmux task, without a token or the relay.
+  out=$(PATH="$BASE_PATH" FM_HOME="$home" FMX_DRY_RUN=1 FMX_NOW_OVERRIDE=1700003600 \
+    "$ROOT/bin/fm-x-followup.sh" cmux-ship-c - <<<"Done, captain - shipped and green." 2>/dev/null); rc=$?
+  expect_code 0 "$rc" "cmux followup dry-run post exit"
+  [ "$out" = "req-cmux-d" ] || fail "cmux followup dry-run must echo the request_id (got: $out)"
+  assert_present "$home/state/x-outbox/req-cmux-d.json" "cmux followup dry-run must record the would-be follow-up"
+  [ "$(jq -r '.endpoint' "$home/state/x-outbox/req-cmux-d.json")" = "followup" ] \
+    || fail "cmux followup dry-run must carry the followup endpoint marker"
+  assert_no_grep "x_request=" "$meta" "a cmux followup post must clear the link"
+  assert_grep "terminal_backend=cmux" "$meta" "clearing the link must preserve the cmux fields"
+  assert_no_grep "window=" "$meta" "the follow-up loop must not introduce a window= line"
+  pass "fm-x-followup runs the completion follow-up loop for a cmux-linked task (dry-run)"
+}
+
+test_x_path_never_shells_out_to_tmux_for_cmux_task() {
+  local home meta fakebin tripped rc out
+  home="$TMP_ROOT/no-tmux-cmux"; mkdir -p "$home"
+  write_cmux_meta "$home" cmux-ship-d
+  meta="$home/state/cmux-ship-d.meta"
+  fakebin=$(make_tmux_tripwire "$home")
+  tripped="$home/tmux-tripped"
+  # tmux tripwire FIRST on PATH so it shadows any real tmux; jq/coreutils follow.
+  # Run every X-path hop the loop uses for a cmux task: link, --check, and the
+  # dry-run follow-up post. None may invoke tmux.
+  out=$(PATH="$fakebin:$BASE_PATH" FM_TMUX_TRIPPED="$tripped" FM_HOME="$home" \
+    FMX_NOW_OVERRIDE=1700000000 \
+    "$ROOT/bin/fm-x-link.sh" cmux-ship-d req-cmux-e); rc=$?
+  expect_code 0 "$rc" "link under tmux tripwire exit"
+  assert_absent "$tripped" "fm-x-link must not shell out to tmux for a cmux task"
+  out=$(PATH="$fakebin:$BASE_PATH" FM_TMUX_TRIPPED="$tripped" FM_HOME="$home" \
+    FMX_NOW_OVERRIDE=1700003600 \
+    "$ROOT/bin/fm-x-followup.sh" --check cmux-ship-d); rc=$?
+  expect_code 0 "$rc" "check under tmux tripwire exit"
+  [ "$out" = "req-cmux-e" ] || fail "check under tripwire must still print the request_id (got: $out)"
+  assert_absent "$tripped" "fm-x-followup --check must not shell out to tmux for a cmux task"
+  out=$(PATH="$fakebin:$BASE_PATH" FM_TMUX_TRIPPED="$tripped" FM_HOME="$home" \
+    FMX_DRY_RUN=1 FMX_NOW_OVERRIDE=1700003600 \
+    "$ROOT/bin/fm-x-followup.sh" cmux-ship-d - <<<"Shipped." 2>/dev/null); rc=$?
+  expect_code 0 "$rc" "followup post under tmux tripwire exit"
+  assert_absent "$tripped" "fm-x-followup post must not shell out to tmux for a cmux task"
+  pass "the X path never invokes tmux for a cmux-meta task (terminal-independent)"
+}
+
+test_link_records_into_cmux_meta_without_window
+test_followup_check_for_cmux_linked_task
+test_followup_dry_run_loop_for_cmux_meta
+test_x_path_never_shells_out_to_tmux_for_cmux_task


### PR DESCRIPTION
## What changed

- Added `docs/cmux-terminal-backend/spec.md` to capture the terminal-backend design.
- Added `bin/fm-terminal-lib.sh` for backend-neutral terminal targeting.
- Wired first-slice cmux support into spawn, send, peek, state, and teardown flows.
- Added cmux routing tests and adjusted GOTMP teardown fixtures for the new sourced terminal library.
- Fixed an existing `fm-brief.sh` parse failure caused by an apostrophe in generated no-mistakes guidance.

## Why

This introduces the first vertical slice of a cmux-native worker backend while preserving the existing tmux path as the default/fallback. It lets a firstmate task run in a visible cmux pane, receive instructions, be read by firstmate, and be cleaned up safely through existing treehouse safety checks.

## How to verify

Already run locally:

- `bash -n bin/fm-terminal-lib.sh bin/fm-send.sh bin/fm-peek.sh bin/fm-crew-state.sh bin/fm-teardown.sh bin/fm-spawn.sh tests/fm-terminal-cmux.test.sh`
- `tests/fm-terminal-cmux.test.sh`
- `env -u CMUX_WORKSPACE_ID -u CMUX_SURFACE_ID tests/fm-send-secondmate-marker.test.sh`
- `env -u CMUX_WORKSPACE_ID -u CMUX_SURFACE_ID tests/fm-send-settle.test.sh`
- `env -u CMUX_WORKSPACE_ID -u CMUX_SURFACE_ID tests/fm-spawn-batch.test.sh`
- `env -u CMUX_WORKSPACE_ID -u CMUX_SURFACE_ID tests/fm-crew-state.test.sh`
- `env -u CMUX_WORKSPACE_ID -u CMUX_SURFACE_ID tests/fm-teardown.test.sh`
- `env -u CMUX_WORKSPACE_ID -u CMUX_SURFACE_ID tests/fm-secondmate-safety.test.sh`
- Full `tests/*.test.sh` suite in two passes with `CMUX_WORKSPACE_ID`/`CMUX_SURFACE_ID` unset.
- Live cmux sandbox smoke: spawn/read/send/interrupt/teardown.

## Files touched

- `docs/cmux-terminal-backend/spec.md`
- `bin/fm-terminal-lib.sh`
- `bin/fm-spawn.sh`
- `bin/fm-send.sh`
- `bin/fm-peek.sh`
- `bin/fm-crew-state.sh`
- `bin/fm-teardown.sh`
- `bin/fm-brief.sh`
- `tests/fm-terminal-cmux.test.sh`
- `tests/fm-gotmp.test.sh`
