### PR TITLE
fix: harden crew dispatch profile enforcement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,7 +131,9 @@ Otherwise it prints one line per problem or capability fact; handle each:
 - `NEEDS_GH_AUTH` - ask the captain to run `! gh auth login` (interactive; you cannot run it for them).
 - `TANGLE: <remediation>` - the firstmate primary checkout (the repo root, `FM_ROOT`) is stranded on a feature branch instead of its default branch: a crewmate working firstmate-on-itself branched/committed in the primary instead of its own isolated worktree (section 8). The work is safe on that branch ref; restore the primary to its default branch with the printed `git -C <root> checkout <default>`, then re-validate that branch in a proper worktree. This is the only sanctioned firstmate-initiated git write to the primary, and it is a non-destructive branch switch that strands nothing.
 - `CREW_HARNESS_OVERRIDE: <name>` - record and use the override silently; surface a harness fact only if it actually blocks work or the captain asks.
-- `CREW_DISPATCH: invalid config/crew-dispatch.json - <reason>` - the optional dispatch profile file exists but failed low-cost bootstrap validation; continue with the normal fallback chain, fix the JSON, unverified harness name, or invalid harness/effort pair when convenient, and do not select a bad profile.
+- `CREW_DISPATCH: invalid config/crew-dispatch.json - <reason>` - the optional dispatch profile file exists but failed low-cost bootstrap validation; continue with the normal fallback chain, resolve and pass the chosen fallback harness explicitly while the file remains present, fix the JSON, unverified harness name, or invalid harness/effort pair when convenient, and do not select a bad profile.
+- `CREW_DISPATCH: active config/crew-dispatch.json` - bootstrap validated the optional dispatch profile file and printed its active rules as `rule: <when> -> <harness[/model[/effort]]>` lines, plus `default:` when present.
+  Keep this block top-of-mind during intake; it is the reminder that every crewmate or scout dispatch must consult the rules before spawning.
 - `FLEET_SYNC: <repo>: skipped: <reason>` - a benign one-off skip (offline, no origin, local-only); bootstrap continued, investigate only if it blocks work.
 - `FLEET_SYNC: <repo>: recovered: <detail>` - the clone had drifted onto a clean detached HEAD holding no unique commits and the sync self-healed it (re-attached the default branch and fast-forwarded); no action needed, it is reported only so the self-heal is visible.
 - `FLEET_SYNC: <repo>: STUCK: on <state>, N commits behind <base> - needs attention` - the clone is dirty, on a non-default branch, detached with unique commits, or diverged, so the sync left it untouched (never forcing or discarding); it will keep falling behind until you look. A loud STUCK, especially a growing N across bootstraps, means that clone needs hands-on attention; dispatch a crewmate or resolve it before it strands work.
@@ -173,6 +175,7 @@ Verified adapter names are `claude`, `codex`, `opencode`, `pi`, and `grok`.
 It is firstmate-maintained but human-editable.
 When the captain expresses a standing preference such as "use grok for news-dependent work", firstmate codifies it into this file; the captain may also hand-edit it.
 The file is JSON so firstmate can read the natural-language rules and bootstrap can validate it with `jq`.
+When the file is valid, bootstrap prints a concise `CREW_DISPATCH: active config/crew-dispatch.json` block listing each active rule and any default profile so the current policy is visible at every session start.
 See `docs/examples/crew-dispatch.json` for a documented starting point to copy into local `config/crew-dispatch.json`.
 
 Schema:
@@ -200,7 +203,11 @@ Pick the single best-fit rule using your own judgment.
 This is explicitly not first-match: weigh all rules, their `when` text, and their `why` rationales against the actual task.
 Resolve the chosen rule's `use` object into a concrete profile `(harness, model, effort)` and pass it to `bin/fm-spawn.sh` with explicit `--harness`, `--model`, and `--effort` flags for the axes that are set.
 If no rule fits, use `default`.
-If `default` is absent, fall back to `config/crew-harness` through `bin/fm-harness.sh crew`, exactly as the static path did before dispatch profiles.
+If `default` is absent, fall back to `config/crew-harness` through `bin/fm-harness.sh crew`, exactly as the static path did before dispatch profiles, but still pass that resolved harness explicitly.
+This is enforced: when `config/crew-dispatch.json` exists, `bin/fm-spawn.sh` refuses crewmate and scout launches that do not include an explicit harness (`--harness <name>`, a positional adapter name, or a raw launch command).
+That refusal is the consultation backstop, so the rules are never silently skipped.
+The requirement is gated only on the file's presence; when the file is absent, `fm-spawn.sh` keeps resolving the crewmate harness from `config/crew-harness` as before.
+Secondmate launches are exempt because they resolve through `fm-harness.sh secondmate`, not the crewmate dispatch-profile rules.
 
 Precedence, highest first:
 
@@ -213,6 +220,7 @@ Never select an unverified harness.
 Validate every selected harness name against the verified adapter list above.
 If a dispatch rule or default names an unverified harness, ignore that profile, fall back to the next valid source, and note the problem when it affects the dispatch.
 The shell scripts never parse or match the natural-language rules; firstmate does the matching and passes only concrete flags to `fm-spawn`.
+`fm-spawn` only checks whether the file exists so it can enforce the explicit-harness backstop for crewmate and scout dispatches.
 
 The verified profile axes are:
 
@@ -416,7 +424,7 @@ Write the brief per section 11.
 Load `harness-adapters` before spawning or recovering any direct report so trust dialogs, verified adapters, and harness-specific behavior are handled correctly.
 
 ```sh
-bin/fm-spawn.sh <id> projects/<repo>             # uses the active crewmate harness
+bin/fm-spawn.sh <id> projects/<repo>             # uses the active crewmate harness only when no crew-dispatch.json is active
 bin/fm-spawn.sh <id> projects/<repo> --harness codex   # explicit per-task harness override
 bin/fm-spawn.sh <id> projects/<repo> codex       # per-task harness override
 bin/fm-spawn.sh <id> projects/<repo> grok        # per-task harness override
@@ -429,8 +437,10 @@ bin/fm-spawn.sh <id1>=projects/<repo1> <id2>=projects/<repo2> [--scout]   # batc
 
 Dispatch several tasks in one call by passing `id=repo` pairs instead of a single `<id> <project>`; each pair is spawned through the same single-task path, shared `--scout`, `--harness`, `--model`, and `--effort` flags apply to all, and the looping happens inside the script so you never hand-write a multi-task shell loop.
 If one pair fails, the rest still run and the batch exits non-zero.
+When `config/crew-dispatch.json` exists, include a shared `--harness` for every crewmate or scout batch after consulting the dispatch rules.
 
-The script resolves the harness (`fm-harness.sh crew` for crewmate/scout tasks, `fm-harness.sh secondmate` for `kind=secondmate`; section 4), owns the verified launch templates, resolves the project's delivery mode (`fm-project-mode.sh`) for ship/scout tasks, and records `harness=`, `model=`, `effort=`, `kind=`, `mode=`, and `yolo=` in the task's meta; a non-flag third argument containing whitespace is treated as a raw launch command (only for verifying new adapters).
+The script resolves the harness (`fm-harness.sh crew` for crewmate/scout tasks only when `config/crew-dispatch.json` is absent, `fm-harness.sh secondmate` for `kind=secondmate`; section 4), owns the verified launch templates, resolves the project's delivery mode (`fm-project-mode.sh`) for ship/scout tasks, and records `harness=`, `model=`, `effort=`, `kind=`, `mode=`, and `yolo=` in the task's meta; a non-flag third argument containing whitespace is treated as a raw launch command (only for verifying new adapters).
+When `config/crew-dispatch.json` exists, the script refuses crewmate or scout launches without an explicit harness because firstmate must have already resolved the profile choice at intake.
 When `--model` or `--effort` is omitted, the corresponding meta value is `default` and no launch flag is passed for that axis.
 For `kind=secondmate`, the same script launches in the registered or explicit firstmate home instead of running `treehouse get` for a project, records `home=` and `projects=`, and uses the charter brief as the launch prompt.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -428,7 +428,7 @@ bin/fm-spawn.sh <id> projects/<repo>             # uses the active crewmate harn
 bin/fm-spawn.sh <id> projects/<repo> --harness codex   # explicit per-task harness override
 bin/fm-spawn.sh <id> projects/<repo> codex       # per-task harness override
 bin/fm-spawn.sh <id> projects/<repo> grok        # per-task harness override
-bin/fm-spawn.sh <id> projects/<repo> --model gpt-5.5 --effort high   # explicit profile axes
+bin/fm-spawn.sh <id> projects/<repo> --harness codex --model gpt-5.5 --effort high   # explicit profile axes
 bin/fm-spawn.sh <id> projects/<repo> --scout     # scout task; records kind=scout in meta
 bin/fm-spawn.sh <id> --secondmate                 # launch a registered persistent secondmate in its home
 bin/fm-spawn.sh <id> <firstmate-home> --secondmate   # launch or recover an explicit secondmate home

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,13 +70,13 @@ tests/fm-send-secondmate-marker.test.sh   # fm-send from-firstmate marker for ki
 tests/fm-wake-daemon-lifecycle-e2e.test.sh # watcher + daemon lifecycle e2e: restart catch-up, batching, dedupe, stale-pane routing, and digest injection
 tests/fm-composer-ghost.test.sh           # dim-ghost stripping, ghost-only composer detection, and escape-free peek tests
 tests/fm-afk-inject-e2e.test.sh           # private-socket end-to-end test of the afk injection path (partial-input deferral, swallowed-Enter retry)
-tests/fm-bootstrap.test.sh                # bootstrap dependency and feature-probe tests
+tests/fm-bootstrap.test.sh                # bootstrap dependency, feature-probe, and crew-dispatch reporting tests
 tests/fm-grok-harness.test.sh             # grok adapter spawn hook, token guard, teardown cleanup, and session-lock detection tests
 tests/fm-fleet-sync.test.sh               # project clone refresh: safe detached recovery, STUCK drift reports, benign skips, and bootstrap relay
 tests/fm-x-mode.test.sh                   # X-mode poll, inbox context round-trip, reply threading, dismiss, dry-run preview, and .env-presence activation tests
 tests/fm-tangle-guard.test.sh             # primary-checkout tangle detection and spawn/brief isolation tests
 tests/fm-spawn-batch.test.sh              # batch dispatch and FM_HOME project-path scoping tests
-tests/fm-spawn-dispatch-profile.test.sh   # concrete dispatch profile flags: harness/model/effort meta, launch templates, and batch forwarding
+tests/fm-spawn-dispatch-profile.test.sh   # concrete dispatch profile flags: active-profile backstop, harness/model/effort meta, launch templates, batch forwarding, and secondmate exemption
 tests/fm-update.test.sh                   # fast-forward-only self-update, reread, nudge, dedup, and skip-safety tests
 tests/fm-secondmate-sync.test.sh          # local-HEAD secondmate sync, no-fetch, bootstrap nudge gating, and spawn hook tests
 tests/fm-secondmate-harness.test.sh       # secondmate-vs-crewmate harness resolution and primary-to-secondmate config inheritance tests

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ You chat with the first mate.
 It routes each request to a crewmate in its own tmux window and git worktree, supervises the fleet with a zero-token event-driven watcher, and brings you finished PRs, approved local merges, or investigation reports.
 Persistent secondmate homes are linked firstmate worktrees; startup syncs live ones and secondmate launch syncs the target home to the primary default-branch commit without fetching from origin when it is safe.
 Crewmate dispatch can stay on a static `config/crew-harness` or use optional natural-language profiles in local `config/crew-dispatch.json` to choose a per-task harness, model, and effort.
+When that profile file exists, crewmate and scout spawns must pass the resolved harness explicitly so `config/crew-harness` is not used as an unnoticed bypass.
 Secondmate launch can use a separate local `config/secondmate-harness`, while secondmate homes inherit the primary's declared local config, including `config/crew-dispatch.json`, `config/crew-harness`, and `config/backlog-backend`, so their own crewmates, dispatch profiles, and backlog backend use the primary settings.
 When a routed request goes to a secondmate, firstmate marks it so the answer returns through status or a document pointer; direct typing into that secondmate window stays conversational.
 A presence-gated sub-supervisor (`/afk`) can self-handle routine events and batch only what matters while you step away.

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -6,6 +6,7 @@
 #          Lines: "MISSING: <tool> (install: <command>)", "NEEDS_GH_AUTH",
 #                 "CREW_HARNESS_OVERRIDE: <name>",
 #                 "CREW_DISPATCH: invalid config/crew-dispatch.json - <reason>",
+#                 "CREW_DISPATCH: active config/crew-dispatch.json" plus indented rules,
 #                 "FLEET_SYNC: <repo>: skipped|recovered|STUCK: <detail>",
 #                 "TASKS_AXI: available", "TANGLE: <remediation>",
 #                 "SECONDMATE_SYNC: secondmate <id>: skipped: <reason>",
@@ -353,7 +354,22 @@ crew_dispatch_validate() {
         end
     end
   ' "$file" 2>/dev/null || true)
-  [ -z "$err" ] || echo "CREW_DISPATCH: invalid config/crew-dispatch.json - $err"
+  if [ -n "$err" ]; then
+    echo "CREW_DISPATCH: invalid config/crew-dispatch.json - $err"
+    return 0
+  fi
+  jq -r '
+    def profile($p):
+      ($p.harness | tostring)
+      + (if ($p.model? != null) then "/" + ($p.model | tostring)
+         elif ($p.effort? != null) then "/default"
+         else "" end)
+      + (if ($p.effort? != null) then "/" + ($p.effort | tostring) else "" end);
+    (["CREW_DISPATCH: active config/crew-dispatch.json"]
+      + [(.rules // [])[]? | "  rule: " + (.when | tostring) + " -> " + profile(.use)]
+      + (if (.default? | type) == "object" then ["  default: " + profile(.default)] else [] end))
+    | .[]
+  ' "$file"
 }
 
 if [ "${1:-}" = "install" ]; then

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -9,14 +9,16 @@
 #   axes chosen by firstmate at intake. They are only threaded into harnesses whose
 #   installed CLIs were verified to support that axis; unsupported axes are omitted
 #   from that harness's launch rather than guessed.
-#   With no harness arg, the harness comes from fm-harness.sh: a crewmate/scout
-#   spawn resolves the CREW harness (config/crew-harness, falling back to firstmate's
-#   own); a --secondmate spawn resolves the SECONDMATE harness (config/secondmate-harness
-#   -> config/crew-harness -> own), so the secondmate-vs-crewmate split is DURABLE
-#   across every respawn (recovery, /updatefirstmate, restart). A bare adapter name
-#   (claude|codex|opencode|pi|grok) overrides it for this spawn (either kind). A
-#   non-flag string containing whitespace is treated as a RAW launch command - the
-#   escape hatch for verifying new adapters.
+#   With no harness arg, a crewmate/scout spawn resolves the CREW harness only when
+#   config/crew-dispatch.json is absent. When that file exists, crewmate/scout
+#   spawns require an explicit harness so firstmate cannot silently skip dispatch
+#   profile consultation. A --secondmate spawn is exempt and resolves the SECONDMATE
+#   harness (config/secondmate-harness -> config/crew-harness -> own), so the
+#   secondmate-vs-crewmate split is DURABLE across every respawn (recovery,
+#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|grok)
+#   overrides it for this spawn (either kind). A non-flag string containing
+#   whitespace is treated as a RAW launch command - the escape hatch for verifying
+#   new adapters.
 #   A --secondmate spawn also propagates the primary's declared inheritable config
 #   into the secondmate home's config/, so the secondmate's OWN crewmates,
 #   dispatch profiles, and backlog backend inherit the primary's settings
@@ -31,9 +33,11 @@
 # Batch dispatch: pass one or more `id=repo` pairs instead of a single <id> <project>, e.g.
 #     fm-spawn.sh fix-a-k3=projects/foo add-b-q7=projects/bar [--scout]
 #   Each pair re-execs this script in single-task mode, so the single path stays the only
-#   source of truth; shared --scout/--harness/--model/--effort applies to every pair. The loop lives here, in bash,
-#   so callers never hand-write a multi-task shell loop (the tool shell is zsh, which does
-#   not word-split unquoted $vars and silently breaks ad-hoc `for ... in $pairs` loops).
+#   source of truth; shared --scout/--harness/--model/--effort applies to every pair.
+#   If config/crew-dispatch.json exists, shared --harness is required for crewmate
+#   and scout batches. The loop lives here, in bash, so callers never hand-write a
+#   multi-task shell loop (the tool shell is zsh, which does not word-split unquoted
+#   $vars and silently breaks ad-hoc `for ... in $pairs` loops).
 #   Launch templates live in launch_template() below; placeholders replaced before launch:
 #     __BRIEF__    absolute path to data/<task-id>/brief.md
 #     __TURNEND__  absolute path to state/<task-id>.turn-ended (for harnesses whose
@@ -116,6 +120,10 @@ esac
 idpart=${POS[0]:-}
 idpart=${idpart%%=*}
 if [ "${#POS[@]}" -gt 0 ] && [ "${POS[0]}" != "$idpart" ] && case "$idpart" in */*) false ;; *) true ;; esac; then
+  if [ "$KIND" != secondmate ] && [ -z "$HARNESS_ARG" ] && [ -f "$CONFIG/crew-dispatch.json" ]; then
+    echo "error: config/crew-dispatch.json is active - pass an explicit harness resolved from the dispatch rules (the consultation backstop, so the rules are never silently skipped)." >&2
+    exit 1
+  fi
   rc=0
   shared_args=()
   [ -z "$HARNESS_ARG" ] || shared_args+=(--harness "$HARNESS_ARG")
@@ -221,15 +229,20 @@ case "$ARG3" in
   '')
     # No explicit harness: resolve from config. A secondmate AGENT launches on the
     # secondmate harness (config/secondmate-harness -> config/crew-harness -> own);
-    # every other kind uses the crew harness. Resolving here on every spawn is what
-    # makes the split DURABLE - a respawn (recovery, /updatefirstmate, restart)
-    # re-resolves, so config/secondmate-harness keeps governing secondmate launches
-    # across restarts. The launch_template lookup below is the unverified-adapter
-    # guard for both kinds: a harness with no template aborts the spawn.
+    # every other kind uses the crew harness only when no dispatch profile file is
+    # active. Resolving here on every spawn is what makes the split DURABLE - a
+    # respawn (recovery, /updatefirstmate, restart) re-resolves, so
+    # config/secondmate-harness keeps governing secondmate launches across restarts.
+    # The launch_template lookup below is the unverified-adapter guard for both
+    # kinds: a harness with no template aborts the spawn.
     if [ "$KIND" = secondmate ]; then
       HARNESS=$("$FM_ROOT/bin/fm-harness.sh" secondmate)
       harness_src='config/secondmate-harness (falling back to config/crew-harness)'
     else
+      if [ -f "$CONFIG/crew-dispatch.json" ]; then
+        echo "error: config/crew-dispatch.json is active - pass an explicit harness resolved from the dispatch rules (the consultation backstop, so the rules are never silently skipped)." >&2
+        exit 1
+      fi
       HARNESS=$("$FM_ROOT/bin/fm-harness.sh" crew)
       harness_src='config/crew-harness'
     fi

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -57,6 +57,9 @@ Ship tasks change projects and ship by project mode (`no-mistakes`, `direct-PR`,
 Crewmate and scout dispatch can stay on the static crewmate harness resolved by `config/crew-harness`, or it can use local dispatch profiles in `config/crew-dispatch.json`.
 The dispatch file is intentionally judgment-based: firstmate reads the natural-language rules at intake, chooses the best matching profile, and passes only concrete `--harness`, `--model`, and `--effort` axes to `fm-spawn.sh`.
 The shell scripts validate the JSON shape and verified harness/effort combinations, but they do not parse task intent or match the natural-language rules.
+Bootstrap surfaces either the active rule block or a concise invalid-config line at startup.
+When the file exists, `fm-spawn.sh` refuses crewmate and scout launches without an explicit harness, so `config/crew-harness` is only automatic when no dispatch profile file is active.
+Secondmate launches are exempt because they resolve the secondmate harness instead.
 Unsupported effort values are still recorded in task meta when passed to `fm-spawn.sh`, but the launch template omits any effort flag that the selected harness does not accept.
 That keeps spawn launch compatible across claude, codex, grok, pi, and opencode while preserving the requested profile for later audit.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -57,6 +57,7 @@ When it is absent or contains `default`, crewmates mirror the firstmate's own ha
 `config/secondmate-harness` is a separate local, gitignored file containing the adapter the primary uses to launch secondmate agents.
 When it is absent or contains `default`, secondmate launch falls back through `config/crew-harness` and then the primary's own harness, preserving the previous behavior.
 An explicit harness argument to `fm-spawn.sh` still overrides either config file for that spawn only.
+When `config/crew-dispatch.json` exists, crewmate and scout spawns require an explicit resolved harness instead of automatically falling back to `config/crew-harness`.
 The primary propagates `config/crew-dispatch.json`, `config/crew-harness`, and `config/backlog-backend` into secondmate homes at secondmate spawn and during the bootstrap secondmate sweep, so a secondmate's own crewmates, dispatch profiles, and backlog backend use the primary values.
 `config/secondmate-harness` is not inherited because secondmates do not launch secondmates.
 For grok, `fm-spawn.sh` installs one firstmate-owned global turn-end hook under `$GROK_HOME/hooks/`, or `~/.grok/hooks/` when `GROK_HOME` is unset, and drops a per-task `.fm-grok-turnend` pointer in the worktree, with teardown removing the task token and pointer.
@@ -65,11 +66,16 @@ For grok, `fm-spawn.sh` installs one firstmate-owned global turn-end hook under 
 
 `config/crew-dispatch.json` is an optional local, gitignored file containing natural-language rules that firstmate reads before dispatching a crewmate or scout.
 The shell scripts do not match those rules; firstmate chooses the best profile with judgment and passes only concrete `--harness`, `--model`, and `--effort` flags to `fm-spawn.sh`.
+When the file exists, `fm-spawn.sh` enforces that contract by refusing crewmate and scout spawns that lack an explicit harness (`--harness`, a positional adapter, or a raw launch command).
+Batch spawns satisfy the same requirement with a shared `--harness`.
+Secondmate spawns are exempt and still resolve through `config/secondmate-harness`.
 Each rule has `when`, `use.harness`, optional `use.model`, optional `use.effort`, and optional `why`; an optional `default` profile uses the same `use` shape without `when`.
 See [`docs/examples/crew-dispatch.json`](examples/crew-dispatch.json) for a starting point to copy into local `config/crew-dispatch.json`.
 When the file exists, bootstrap validates it with `jq`.
+Valid files produce a `CREW_DISPATCH: active config/crew-dispatch.json` block that lists each rule as `rule: <when> -> <harness[/model[/effort]]>` and prints `default:` when present.
 Malformed JSON, an unverified harness, or an effort value unsupported by that harness is reported as `CREW_DISPATCH: invalid config/crew-dispatch.json - ...`; missing `jq` is reported through the normal `MISSING: jq` install-consent flow.
 If no dispatch rule fits, firstmate uses the dispatch profile `default` when present, then falls back to `config/crew-harness`.
+Because the spawn backstop is gated by file presence, any fallback path after a missing match, validation error, or missing `jq` still passes a resolved harness explicitly until the file is fixed or removed.
 Secondmate homes inherit this file from the primary, so a secondmate's own crewmates apply the same dispatch profile behavior.
 
 ## Toolchain

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -5,7 +5,7 @@ Each file also starts with a short header comment.
 
 | Script                   | Description                                                                                                         |
 | ------------------------ | ------------------------------------------------------------------------------------------------------------------- |
-| `fm-bootstrap.sh`        | Detect required toolchain and version problems, dispatch profile JSON errors, default backlog-backend status, primary-checkout `TANGLE:` problems, and actionable clone refresh outcomes; refresh project clones best-effort; locally sync live secondmate homes and propagate declared inheritable config; set up opt-in X mode; install tools only after consent |
+| `fm-bootstrap.sh`        | Detect required toolchain and version problems, dispatch profile JSON errors or active-rule blocks, default backlog-backend status, primary-checkout `TANGLE:` problems, and actionable clone refresh outcomes; refresh project clones best-effort; locally sync live secondmate homes and propagate declared inheritable config; set up opt-in X mode; install tools only after consent |
 | `fm-fleet-sync.sh`       | Fetch clones, fast-forward safe default-branch states, self-heal clean detached ancestor drift, report unsafe drift as `STUCK:`, and safely prune branches whose remote is gone |
 | `fm-update.sh`           | Self-update the running firstmate repo and registered secondmate homes with fast-forward-only pulls from origin     |
 | `fm-backlog-handoff.sh`  | Move already-judged in-scope queued backlog items from the main home into a seeded secondmate home                 |
@@ -13,7 +13,7 @@ Each file also starts with a short header comment.
 | `fm-ensure-agents-md.sh` | Ensure project `AGENTS.md` is the real memory file and `CLAUDE.md` symlinks to it                                   |
 | `fm-guard.sh`            | Warn when the primary checkout is tangled, when queued wakes are pending, or when a stale or missing watcher needs a prominent banner |
 | `fm-home-seed.sh`        | Lease/provision a secondmate home transactionally, clone projects, initialize gates, and maintain `data/secondmates.md` |
-| `fm-spawn.sh`            | Spawn one task, several `id=repo` pairs, or a persistent secondmate with `--secondmate`; accepts concrete `--harness`, `--model`, and `--effort` profile axes; ship/scout spawns require an isolated treehouse worktree, install per-harness turn-end signaling, and secondmate spawns resolve the secondmate harness, locally sync the home, and propagate declared inheritable config before launch |
+| `fm-spawn.sh`            | Spawn one task, several `id=repo` pairs, or a persistent secondmate with `--secondmate`; accepts concrete `--harness`, `--model`, and `--effort` profile axes; ship/scout spawns require an explicit resolved harness when dispatch profiles are active and an isolated treehouse worktree, install per-harness turn-end signaling, and secondmate spawns resolve the secondmate harness, locally sync the home, and propagate declared inheritable config before launch |
 | `fm-project-mode.sh`     | Resolve a project's delivery mode and `+yolo` flag from `data/projects.md`                                          |
 | `fm-merge-local.sh`      | Fast-forward a `local-only` project's local default branch after approval                                           |
 | `fm-review-diff.sh`      | Review a crewmate branch against the authoritative base, with optional `--stat` output                              |

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Behavior tests for fm-bootstrap.sh tool detection.
 #
-# Bootstrap prints one line per problem or capability fact and is silent when all
+# Bootstrap prints one block or line per problem or capability fact and is silent when all
 # is well. firstmate consumes the exact 'MISSING: treehouse (install: ...)',
 # 'MISSING: tasks-axi (install: ...)', and 'TASKS_AXI: available' lines, so those
 # contracts are pinned verbatim. The cases are table-driven over the inputs that
@@ -156,6 +156,23 @@ ROWS
   pass "bootstrap enforces no-mistakes minimum version"
 }
 
+test_crew_dispatch_active_rules_are_surfaced() {
+  local case_dir fakebin out expect
+  case_dir="$TMP_ROOT/dispatch-active"
+  mkdir -p "$case_dir/home/config"
+  printf '%s\n' manual > "$case_dir/home/config/backlog-backend"
+  printf '%s\n' '{"rules":[{"when":"fresh news","use":{"harness":"grok"},"why":"current context"},{"when":"big feature","use":{"harness":"codex","model":"gpt-5.5","effort":"high"}}],"default":{"harness":"claude","model":"haiku","effort":"low"}}' > "$case_dir/home/config/crew-dispatch.json"
+  fakebin=$(make_fake_toolchain "$case_dir")
+  add_real_jq "$fakebin"
+
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+    FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
+
+  expect=$'CREW_DISPATCH: active config/crew-dispatch.json\n  rule: fresh news -> grok\n  rule: big feature -> codex/gpt-5.5/high\n  default: claude/haiku/low'
+  [ "$out" = "$expect" ] || fail "active dispatch profile block mismatch"$'\n'"expected: $expect"$'\n'"actual:   $out"
+  pass "bootstrap surfaces active crew-dispatch rules and default"
+}
+
 test_crew_dispatch_validation() {
   local label body expect mode case_dir fakebin out n
   n=0
@@ -177,7 +194,6 @@ test_crew_dispatch_validation() {
         [ "$out" = "$expect" ] || fail "$label: expected '$expect', got: $out" ;;
     esac
   done <<'ROWS'
-valid dispatch config is accepted^{"rules":[{"when":"fresh news","use":{"harness":"grok"},"why":"current context"},{"when":"big feature","use":{"harness":"codex","model":"gpt-5.5","effort":"high"}}],"default":{"harness":"claude","model":"haiku","effort":"low"}}^empty^
 malformed dispatch config is flagged^{"rules":[^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - malformed JSON
 unverified dispatch harness is flagged^{"rules":[{"when":"anything","use":{"harness":"spaceship"}}],"default":{"harness":"codex"}}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - unverified harness: spaceship
 unsupported codex max effort is flagged^{"rules":[{"when":"big feature","use":{"harness":"codex","model":"gpt-5","effort":"max"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: codex:max
@@ -189,4 +205,5 @@ ROWS
 
 test_bootstrap_reporting
 test_no_mistakes_min_version
+test_crew_dispatch_active_rules_are_surfaced
 test_crew_dispatch_validation

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -66,6 +66,20 @@ make_spawn_case() {
   printf '%s\n' "$case_dir|$home|$proj|$wt|$fakebin|$launchlog"
 }
 
+enable_dispatch_profile() {
+  local home=$1
+  printf '%s\n' '{"rules":[{"when":"current events","use":{"harness":"grok","model":"grok-4","effort":"high"}}],"default":{"harness":"codex","model":"gpt-5","effort":"medium"}}' \
+    > "$home/config/crew-dispatch.json"
+}
+
+make_seeded_secondmate_home() {
+  local home=$1 id=$2
+  mkdir -p "$home/bin" "$home/data"
+  printf '# Firstmate\n' > "$home/AGENTS.md"
+  printf '%s\n' "$id" > "$home/.fm-secondmate-home"
+  printf 'charter for %s\n' "$id" > "$home/data/charter.md"
+}
+
 run_spawn() {
   local home=$1 wt=$2 fakebin=$3 launchlog=$4
   shift 4
@@ -79,7 +93,7 @@ run_spawn() {
 }
 
 read_case_record() {
-  IFS='|' read -r _case_dir HOME_DIR PROJ_DIR WT_DIR FAKEBIN_DIR LAUNCH_LOG <<EOF
+  IFS='|' read -r CASE_DIR HOME_DIR PROJ_DIR WT_DIR FAKEBIN_DIR LAUNCH_LOG <<EOF
 $1
 EOF
 }
@@ -107,6 +121,91 @@ test_no_profile_keeps_claude_launch_unchanged() {
   expected="CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions \"\$(cat '$HOME_DIR/data/$id/brief.md')\""
   [ "$launch" = "$expected" ] || fail "no-profile claude launch changed"$'\n'"expected: $expected"$'\n'"actual:   $launch"
   pass "no --model/--effort records defaults and keeps the claude launch byte-identical"
+}
+
+test_active_dispatch_profile_requires_explicit_harness_for_ship() {
+  local rec id out status
+  id=profile-required-ship-z11
+  rec=$(make_spawn_case profile-required-ship claude "$id")
+  read_case_record "$rec"
+  enable_dispatch_profile "$HOME_DIR"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR")
+  status=$?
+  expect_code 1 "$status" "ship spawn without explicit harness should fail when dispatch profiles are active"
+  assert_contains "$out" "config/crew-dispatch.json is active - pass an explicit harness resolved from the dispatch rules" \
+    "spawn did not explain the dispatch-profile backstop"
+  assert_absent "$HOME_DIR/state/$id.meta" "ship refusal should happen before meta is written"
+  pass "active crew-dispatch profile requires an explicit harness for ship spawns"
+}
+
+test_active_dispatch_profile_requires_explicit_harness_for_scout() {
+  local rec id out status
+  id=profile-required-scout-z12
+  rec=$(make_spawn_case profile-required-scout claude "$id")
+  read_case_record "$rec"
+  enable_dispatch_profile "$HOME_DIR"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --scout)
+  status=$?
+  expect_code 1 "$status" "scout spawn without explicit harness should fail when dispatch profiles are active"
+  assert_contains "$out" "config/crew-dispatch.json is active - pass an explicit harness resolved from the dispatch rules" \
+    "scout refusal did not explain the dispatch-profile backstop"
+  assert_absent "$HOME_DIR/state/$id.meta" "scout refusal should happen before meta is written"
+  pass "active crew-dispatch profile requires an explicit harness for scout spawns"
+}
+
+test_active_dispatch_profile_allows_explicit_harness() {
+  local rec id out status launch
+  id=profile-explicit-z13
+  rec=$(make_spawn_case profile-explicit claude "$id")
+  read_case_record "$rec"
+  enable_dispatch_profile "$HOME_DIR"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
+    "$id" "$PROJ_DIR" --harness codex --model gpt-5 --effort high)
+  status=$?
+  expect_code 0 "$status" "explicit harness should satisfy active dispatch-profile requirement"
+  assert_contains "$out" "spawned $id harness=codex" "spawn did not report explicit codex harness"
+  assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5 high
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "codex --model 'gpt-5' -c 'model_reasoning_effort=\"high\"' --dangerously-bypass-approvals-and-sandbox" \
+    "explicit harness launch did not thread model and effort"
+  pass "active crew-dispatch profile allows an explicit resolved harness"
+}
+
+test_active_dispatch_profile_allows_positional_harness() {
+  local rec id out status
+  id=profile-positional-z14
+  rec=$(make_spawn_case profile-positional claude "$id")
+  read_case_record "$rec"
+  enable_dispatch_profile "$HOME_DIR"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
+    "$id" "$PROJ_DIR" codex --model gpt-5 --effort high)
+  status=$?
+  expect_code 0 "$status" "positional harness should satisfy active dispatch-profile requirement"
+  assert_contains "$out" "spawned $id harness=codex" "spawn did not report positional codex harness"
+  assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5 high
+  pass "active crew-dispatch profile allows the legacy positional harness form"
+}
+
+test_active_dispatch_profile_allows_raw_launch_command() {
+  local rec id out status launch
+  id=profile-raw-z15
+  rec=$(make_spawn_case profile-raw claude "$id")
+  read_case_record "$rec"
+  enable_dispatch_profile "$HOME_DIR"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
+    "$id" "$PROJ_DIR" "custom-agent --flag")
+  status=$?
+  expect_code 0 "$status" "raw launch command should satisfy active dispatch-profile requirement"
+  assert_contains "$out" "spawned $id harness=custom-agent" "spawn did not report raw command harness"
+  assert_meta_profile "$HOME_DIR/state/$id.meta" custom-agent default default
+  launch=$(cat "$LAUNCH_LOG")
+  [ "$launch" = "custom-agent --flag" ] || fail "raw launch command changed"$'\n'"actual: $launch"
+  pass "active crew-dispatch profile allows the raw launch-command escape hatch"
 }
 
 test_claude_threads_model_and_effort() {
@@ -234,6 +333,7 @@ test_batch_forwards_shared_profile_flags() {
   id2=profile-batch-b-z10
   rec=$(make_spawn_case profile-batch claude "$id1" "$id2")
   read_case_record "$rec"
+  enable_dispatch_profile "$HOME_DIR"
 
   out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
     "$id1=$PROJ_DIR" "$id2=$PROJ_DIR" --harness codex --model gpt-5 --effort high)
@@ -246,7 +346,30 @@ test_batch_forwards_shared_profile_flags() {
   pass "batch dispatch forwards shared --harness, --model, and --effort to every pair"
 }
 
+test_active_dispatch_profile_does_not_block_secondmate_launch() {
+  local rec id sm out status
+  id=profile-secondmate-z16
+  rec=$(make_spawn_case profile-secondmate codex "$id")
+  read_case_record "$rec"
+  enable_dispatch_profile "$HOME_DIR"
+  sm="$CASE_DIR/secondmate-home"
+  make_seeded_secondmate_home "$sm" "$id"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$sm" --secondmate)
+  status=$?
+  expect_code 0 "$status" "secondmate spawn should be exempt from the dispatch-profile explicit harness requirement"
+  assert_contains "$out" "spawned $id harness=codex kind=secondmate" "secondmate launch did not use secondmate harness resolution"
+  assert_grep "kind=secondmate" "$HOME_DIR/state/$id.meta" "secondmate meta missing kind=secondmate"
+  assert_meta_profile "$HOME_DIR/state/$id.meta" codex default default
+  pass "active crew-dispatch profile does not block secondmate launches"
+}
+
 test_no_profile_keeps_claude_launch_unchanged
+test_active_dispatch_profile_requires_explicit_harness_for_ship
+test_active_dispatch_profile_requires_explicit_harness_for_scout
+test_active_dispatch_profile_allows_explicit_harness
+test_active_dispatch_profile_allows_positional_harness
+test_active_dispatch_profile_allows_raw_launch_command
 test_claude_threads_model_and_effort
 test_codex_threads_model_and_effort
 test_codex_omits_invalid_max_effort
@@ -255,5 +378,6 @@ test_grok_omits_invalid_max_reasoning_effort
 test_opencode_threads_model_and_ignores_effort_axis
 test_pi_omits_invalid_max_effort
 test_batch_forwards_shared_profile_flags
+test_active_dispatch_profile_does_not_block_secondmate_launch
 
 echo "# all fm-spawn-dispatch-profile tests passed"


### PR DESCRIPTION
## Intent

Harden dispatch-profile consultation so config/crew-dispatch.json cannot be silently bypassed. Bootstrap should print a concise active-rules block for valid crew-dispatch configs while preserving the invalid JSON/schema error path. fm-spawn should require an explicit resolved harness for crewmate and scout dispatches whenever that file exists, while preserving no-file fallback to config/crew-harness, preserving explicit --harness, positional harness, raw launch command, and batch behavior, and exempting --secondmate launches. Update AGENTS.md and focused behavior tests for those contracts.

## What Changed
- Captain, surfaces valid `config/crew-dispatch.json` rules during bootstrap while keeping malformed or invalid config diagnostics intact.
- Requires crewmate and scout spawns to pass an explicit resolved harness whenever dispatch profiles are present, while preserving explicit harness, positional harness, raw launch command, batch, fallback, and secondmate behavior.
- Updates firstmate docs and focused shell tests around dispatch-profile enforcement and bootstrap reporting.

## Risk Assessment

✅ Low: Captain, the change is narrowly scoped to bootstrap reporting and spawn-time harness enforcement, and I found no material correctness or compatibility issues in the reviewed paths.

## Testing

Captain, the configured full-suite baseline was already green per prompt; I reran the focused bootstrap and spawn dispatch-profile behavior tests, then captured CLI evidence showing the intended end-user contracts working in isolated homes with fake tmux and real git worktrees. All focused checks and manual evidence-producing scenarios passed.

<details>
<summary>Evidence: Manual CLI evidence transcript</summary>

```text
## Bootstrap surfaces active dispatch rules
$ FM_HOME=$BOOT_HOME FM_ROOT_OVERRIDE=$BOOT_HOME bin/fm-bootstrap.sh
CREW_DISPATCH: active config/crew-dispatch.json
  rule: fresh news -> grok
  rule: big feature -> codex/gpt-5.5/high
  default: claude/haiku/low

## Bootstrap preserves malformed JSON error path
$ FM_HOME=$BOOT_HOME FM_ROOT_OVERRIDE=$BOOT_HOME bin/fm-bootstrap.sh
CREW_DISPATCH: invalid config/crew-dispatch.json - malformed JSON

## fm-spawn refuses crewmate spawn when dispatch profile is active and no harness was passed
$ bin/fm-spawn.sh evidence-ship-z1 <project>
exit=1
error: config/crew-dispatch.json is active - pass an explicit harness resolved from the dispatch rules (the consultation backstop, so the rules are never silently skipped).
meta exists? no

## fm-spawn accepts explicit resolved harness and records launch details
$ bin/fm-spawn.sh evidence-explicit-z2 <project> --harness codex --model gpt-5 --effort high
exit=0
spawned evidence-explicit-z2 harness=codex kind=ship mode=no-mistakes yolo=off window=firstmate:fm-evidence-explicit-z2 worktree=/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KWBNS83NX0YWR86G0RNFPEYP/manual-cli/worktree
harness=codex
kind=ship
model=gpt-5
effort=high
captured launch command:
codex --model 'gpt-5' -c 'model_reasoning_effort="high"' --dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch '/private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KWBNS83NX0YWR86G0RNFPEYP/manual-cli/spawn-home/state/evidence-explicit-z2.turn-ended'\"]" "$(cat '/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KWBNS83NX0YWR86G0RNFPEYP/manual-cli/spawn-home/data/evidence-explicit-z2/brief.md')"

## fm-spawn preserves no-profile fallback to config/crew-harness
$ rm config/crew-dispatch.json; bin/fm-spawn.sh evidence-fallback-z3 <project>
exit=0
spawned evidence-fallback-z3 harness=codex kind=ship mode=no-mistakes yolo=off window=firstmate:fm-evidence-fallback-z3 worktree=/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KWBNS83NX0YWR86G0RNFPEYP/manual-cli/worktree
harness=codex
kind=ship
model=default
effort=default

## fm-spawn exempts secondmate launches from the crewmate dispatch backstop
$ bin/fm-spawn.sh evidence-secondmate-z4 <secondmate-home> --secondmate
exit=0
warning: secondmate evidence-secondmate-z4 sync skipped before launch: primary default-branch commit cannot be resolved
spawned evidence-secondmate-z4 harness=codex kind=secondmate mode=secondmate yolo=off window=firstmate:fm-evidence-secondmate-z4 worktree=/private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KWBNS83NX0YWR86G0RNFPEYP/manual-cli/secondmate-home
harness=codex
kind=secondmate
model=default
effort=default
home=/private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KWBNS83NX0YWR86G0RNFPEYP/manual-cli/secondmate-home
captured launch command:
FM_ROOT_OVERRIDE= FM_STATE_OVERRIDE= FM_DATA_OVERRIDE= FM_PROJECTS_OVERRIDE= FM_CONFIG_OVERRIDE= FM_HOME='/private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KWBNS83NX0YWR86G0RNFPEYP/manual-cli/secondmate-home' codex --dangerously-bypass-approvals-and-sandbox "$(cat '/private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KWBNS83NX0YWR86G0RNFPEYP/manual-cli/secondmate-home/data/charter.md')"
```
</details>
<details>
<summary>Evidence: Focused bootstrap behavior test log</summary>

```text
ok - bootstrap reports treehouse lease + tasks-axi default/backend contracts
ok - bootstrap enforces no-mistakes minimum version
ok - bootstrap surfaces active crew-dispatch rules and default
ok - bootstrap validates crew-dispatch.json and reports malformed or unverified configs
```
</details>
<details>
<summary>Evidence: Focused spawn dispatch-profile behavior test log</summary>

```text
ok - no --model/--effort records defaults and keeps the claude launch byte-identical
ok - active crew-dispatch profile requires an explicit harness for ship spawns
ok - active crew-dispatch profile requires an explicit harness for scout spawns
ok - active crew-dispatch profile allows an explicit resolved harness
ok - active crew-dispatch profile allows the legacy positional harness form
ok - active crew-dispatch profile allows the raw launch-command escape hatch
ok - claude receives --model and --effort profile flags
ok - codex receives --model and model_reasoning_effort profile flags
ok - codex omits unsupported max effort instead of passing a bad config value
ok - grok receives --model and --reasoning-effort profile flags
ok - grok omits unsupported max reasoning effort
ok - opencode receives --model and omits the unsupported effort axis
ok - pi threads model and omits unsupported max effort
ok - batch dispatch forwards shared --harness, --model, and --effort to every pair
ok - active crew-dispatch profile does not block secondmate launches
# all fm-spawn-dispatch-profile tests passed
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- <code>Baseline already successful per prompt: `command -v tmux &gt;/dev/null || { echo &#34;tmux is required for e2e tests&#34; &gt;&amp;2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo &#34;== $t ==&#34;; bash &#34;$t&#34; || rc=1; done; exit &#34;$rc&#34;`</code>
- `bash tests/fm-bootstrap.test.sh > /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KWBNS83NX0YWR86G0RNFPEYP/fm-bootstrap-test.log 2>&1`
- `bash tests/fm-spawn-dispatch-profile.test.sh > /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KWBNS83NX0YWR86G0RNFPEYP/fm-spawn-dispatch-profile-test.log 2>&1`
- <code>Manual isolated CLI verification saved to `dispatch-profile-cli-transcript.txt`: `fm-bootstrap.sh` valid active rules, malformed JSON error path, `fm-spawn.sh` no-harness refusal with no meta, explicit codex spawn with captured launch command, no-profile `config/crew-harness` fallback, and `--secondmate` exemption.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
