### PR TITLE
feat: add live secondmate config push

### DIFF
--- a/.agents/skills/secondmate-provisioning/SKILL.md
+++ b/.agents/skills/secondmate-provisioning/SKILL.md
@@ -52,6 +52,8 @@ Release happens only on explicit retirement or seed rollback, never on routine r
 Before launch, `fm-spawn.sh --secondmate` locally fast-forwards the home to the primary firstmate checkout's current default-branch commit when it is safe; dirty, diverged, or in-flight homes launch unchanged with a warning.
 The same launch also propagates the primary's declared inheritable local config, currently `config/crew-dispatch.json`, `config/crew-harness`, and `config/backlog-backend`, into the secondmate home's `config/`.
 `config/secondmate-harness` is not inherited because it is only the primary's knob for launching secondmate agents.
+For already-live secondmates, use `bin/fm-config-push.sh` to push a mid-session inherited-config change without running the tracked-file fast-forward or nudging the agents.
+It uses the same live-home discovery and propagation helper as bootstrap and reports each item as `pushed`, `unchanged`, `skipped`, or `error`.
 `bin/fm-home-seed.sh` refuses to copy a missing or placeholder charter.
 
 Direct seed without a preexisting brief requires `FM_SECONDMATE_CHARTER`.
@@ -93,6 +95,7 @@ bin/fm-spawn.sh <id> --secondmate
 Use the recorded `home=` in meta.
 If meta is missing but `data/secondmates.md` still registers the secondmate, respawn from the registry entry and its persistent on-disk home.
 Respawn re-resolves the secondmate harness from current config, uses the same guarded pre-launch sync, and re-propagates inheritable config, so recovered secondmates converge to the primary firstmate version and local dispatch, crew-harness, and backlog-backend settings whenever their home can be cleanly fast-forwarded.
+If the secondmate is already running and only inherited config changed, prefer `bin/fm-config-push.sh` over respawning.
 
 Do not reconstruct a secondmate's whole tree from the main home.
 The main firstmate reconciles only direct reports.

--- a/.agents/skills/secondmate-provisioning/SKILL.md
+++ b/.agents/skills/secondmate-provisioning/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: secondmate-provisioning
-description: Agent-only reference for persistent secondmate setup and retirement. Use when creating, seeding, validating, recovering, handing backlog to, or retiring a secondmate home, or when editing data/secondmates.md. Covers home leases, transactional seeding, project clone restrictions, idle charter, handoff helper, and teardown safety.
+description: Agent-only reference for persistent secondmate setup and retirement. Use when creating, seeding, validating, recovering, handing backlog to, pushing inherited config into, or retiring a secondmate home, or when editing data/secondmates.md. Covers home leases, transactional seeding, project clone restrictions, inherited config push, idle charter, handoff helper, and teardown safety.
 user-invocable: false
 ---
 
 # secondmate-provisioning
 
-Use this reference before creating, seeding, validating, handing backlog to, recovering, or retiring a persistent secondmate, and before editing `data/secondmates.md`.
+Use this reference before creating, seeding, validating, handing backlog to, recovering, pushing inherited config into, or retiring a persistent secondmate, and before editing `data/secondmates.md`.
 
 Keep the always-inline routing rules in `AGENTS.md` authoritative: route by natural-language `scope:`, local-only projects stay with the main firstmate, and secondmates are idle by default.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,8 +25,8 @@ Hard rules, in priority order:
 1. **Never write to a project.**
    You must not edit, commit to, or run state-changing commands in anything under `projects/` or in any worktree.
    You read projects to understand them; crewmates change them.
-   Five sanctioned write exceptions are indexed here; their procedures live where they are used: tool-driven project initialization (section 6), fleet sync via `bin/fm-fleet-sync.sh` (sections 3 and 7), local-HEAD secondmate sync via `bin/fm-bootstrap.sh` and `bin/fm-spawn.sh` (sections 3 and 7), self-update via `/updatefirstmate` and `bin/fm-update.sh` (section 12), and approved `local-only` merge via `bin/fm-merge-local.sh` (section 7).
-   All are fast-forward or guarded operations that never force, stash, or discard unlanded work.
+   Six sanctioned write exceptions are indexed here; their procedures live where they are used: tool-driven project initialization (section 6), fleet sync via `bin/fm-fleet-sync.sh` (sections 3 and 7), local-HEAD secondmate sync via `bin/fm-bootstrap.sh` and `bin/fm-spawn.sh` (sections 3 and 7), inheritable config propagation via `bin/fm-config-push.sh` and the bootstrap/spawn convergence paths (sections 3 and 4), self-update via `/updatefirstmate` and `bin/fm-update.sh` (section 12), and approved `local-only` merge via `bin/fm-merge-local.sh` (section 7).
+   All are fast-forward operations, guarded gitignored-config propagation, or guarded local merges that never force, stash, or discard unlanded work.
    Project `AGENTS.md` maintenance is not another exception: firstmate records not-yet-committed project knowledge in `data/`, and crewmates update project `AGENTS.md` through normal delivery (section 6).
 2. **Never merge a PR without the captain's explicit word.**
    The one standing, captain-authorized relaxation is a project's `yolo` flag (section 7): with `yolo` on, firstmate makes routine approval decisions itself, but anything destructive, irreversible, or security-sensitive still escalates to the captain.
@@ -120,6 +120,9 @@ This is a purely local fast-forward (every secondmate home is a worktree of this
 A tracked-files fast-forward never touches the gitignored operational dirs, so a secondmate's backlog, projects, and in-flight work are never disturbed; a dirty, diverged, or in-flight home is skipped untouched.
 The same sweep also propagates the primary's declared inheritable config (`config/crew-dispatch.json`, `config/crew-harness`, and `config/backlog-backend`; sections 4 and 10) into each live secondmate home's `config/`, so every secondmate's own crewmates, dispatch profiles, and backlog backend stay on the primary's settings.
 Because `config/` is gitignored this is a separate, primary-authoritative copy independent of the tracked-files fast-forward: it re-converges every live home whether or not its tracked files advanced, and it touches only the declared inheritable items (never `config/secondmate-harness`).
+For a mid-session inheritable-config change that should reach live secondmates without a full bootstrap, run `bin/fm-config-push.sh`.
+It is config-only: it uses the same live secondmate discovery and the same `propagate_inheritable_config` helper as bootstrap, prints a per-home/per-item summary, does not fast-forward tracked files, and does not nudge secondmates.
+The propagation helper itself keeps stdout silent for existing callers, but warns on stderr when an item is skipped because the destination does not allow it or when a copy/remove error occurs.
 The sweep reports the `NUDGE_SECONDMATES:` line below only when a running secondmate actually advanced with an instruction change, so firstmate knows which ones to live-converge.
 Silence means all good: say nothing and move on.
 Otherwise it prints one line per problem or capability fact; handle each:
@@ -247,6 +250,8 @@ Inheritance copies `config/crew-dispatch.json`, so secondmates apply the same be
 Inheritance also copies `config/backlog-backend`, so a primary opt-out with `manual` makes secondmates hand-edit too.
 When the file is absent, every home uses the default tasks-axi backend path independently.
 The mechanism is generic over a single declared list (`fm-config-inherit-lib.sh`), primary-authoritative (re-pushed every convergence, mirroring absence), and easy to extend; `config/secondmate-harness` is deliberately excluded because secondmates never spawn secondmates.
+When changing inherited config mid-session, prefer `bin/fm-config-push.sh` over a full bootstrap if tracked-file sync and reread nudges are not needed.
+It reports `pushed`, `unchanged`, `skipped`, or `error` for each declared item in each live secondmate home; skipped non-ignored items are warnings and real copy/remove errors make the command exit non-zero.
 
 Each adapter splits into mechanics and knowledge.
 The mechanics (launch command, autonomy flag, turn-end hook) live in `bin/fm-spawn.sh`; the knowledge you need while supervising (busy signature, exit, interrupt, dialogs, quirks, skill invocation, resume) lives in the agent-only `harness-adapters` skill.
@@ -452,6 +457,7 @@ This is a purely local fast-forward of tracked files - never a fetch from origin
 If that pre-launch fast-forward is skipped, `fm-spawn.sh` prints a concise warning to stderr and still launches the secondmate from its unchanged checkout.
 The spawn also propagates the primary's declared inheritable config (`config/crew-dispatch.json`, `config/crew-harness`, and `config/backlog-backend`; sections 4 and 10) into the secondmate home's `config/`, so the secondmate's own crewmates, dispatch profiles, and backlog backend inherit the primary's settings; this is a separate gitignored-file copy from the tracked-files fast-forward and a primary with no inheritable config set is a no-op.
 No nudge is needed at spawn because the agent reads `AGENTS.md` fresh on launch.
+For already-live secondmates, use `bin/fm-config-push.sh` when only this inherited config needs to be pushed.
 Project worktrees start at detached HEAD on a clean default branch; ship briefs tell the crewmate to create its branch, while scout briefs keep the worktree scratch.
 After spawning, peek the pane to confirm the crewmate is processing the brief and handle any trust dialog with `harness-adapters`.
 Add the task to `data/backlog.md` under In flight.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,7 @@ Run `bin/fm-bootstrap.sh`.
 Bootstrap also refreshes the fleet via `bin/fm-fleet-sync.sh`, best-effort and non-fatal, under the hard-rule exception in section 1.
 Set `FM_FLEET_PRUNE=0` to temporarily disable that branch pruning.
 Bootstrap also sweeps every live secondmate home, fast-forwarding each one's worktree to firstmate's own current default-branch commit so the fleet stays converged on whatever version firstmate is on.
+The live set comes from `state/<id>.meta` records with `kind=secondmate`; `data/secondmates.md` only backfills `home=` for older or incomplete meta records.
 This is a purely local fast-forward (every secondmate home is a worktree of this same repo, sharing one object store), never a fetch from origin and never a surprise pull: the version followed is simply whatever the primary is currently on, which only the captain changes deliberately via `git pull` or `/updatefirstmate`.
 A tracked-files fast-forward never touches the gitignored operational dirs, so a secondmate's backlog, projects, and in-flight work are never disturbed; a dirty, diverged, or in-flight home is skipped untouched.
 The same sweep also propagates the primary's declared inheritable config (`config/crew-dispatch.json`, `config/crew-harness`, and `config/backlog-backend`; sections 4 and 10) into each live secondmate home's `config/`, so every secondmate's own crewmates, dispatch profiles, and backlog backend stay on the primary's settings.
@@ -243,7 +244,7 @@ So an absent or `default` `config/secondmate-harness` behaves exactly as before 
 The split is durable: every secondmate respawn (recovery, `/updatefirstmate`, restart) re-resolves from `config/secondmate-harness`, so it survives restarts without being recorded per-task.
 
 `config/crew-dispatch.json`, `config/crew-harness`, and `config/backlog-backend` are inherited; `config/secondmate-harness` is not.
-The primary pushes its declared inheritable config down into each secondmate home's `config/` - at secondmate spawn and on the bootstrap secondmate sweep (section 3) - so a secondmate's OWN crewmates, dispatch profiles, and backlog backend use the primary's settings (primary `config/crew-harness=codex` makes a secondmate's crewmates spawn on codex too).
+The primary pushes its declared inheritable config down into each secondmate home's `config/` - at secondmate spawn, on the bootstrap secondmate sweep, and through `bin/fm-config-push.sh` (section 3) - so a secondmate's OWN crewmates, dispatch profiles, and backlog backend use the primary's settings (primary `config/crew-harness=codex` makes a secondmate's crewmates spawn on codex too).
 Inheritance copies the literal `config/crew-harness` file, so for a secondmate's own crewmates to run on the primary's crewmate harness the captain must set `config/crew-harness` to a concrete adapter name, such as `codex`.
 If `config/crew-harness` is unset or `default`, there is no concrete value to inherit, so the secondmate's own crewmates fall back to the secondmate's own/detected harness rather than the primary's effective crewmate harness.
 Inheritance copies `config/crew-dispatch.json`, so secondmates apply the same best-fit dispatch profile behavior for their own crewmates.
@@ -311,7 +312,7 @@ Every persistent secondmate has one line:
 ```
 
 The `scope:` field is used during intake; the `projects:` field is a non-exclusive clone list, not ownership.
-Load `secondmate-provisioning` before creating, seeding, validating, handing backlog to, recovering, or retiring a secondmate home, and before editing `data/secondmates.md`.
+Load `secondmate-provisioning` before creating, seeding, validating, handing backlog to, recovering, pushing inherited config into, or retiring a secondmate home, and before editing `data/secondmates.md`.
 That reference owns home leases, transactional rollback, validation, project clone restrictions, handoff edge cases, charter copy rules, and teardown internals.
 
 A secondmate is idle by default: it acts only on work the main firstmate routes to it.
@@ -777,7 +778,7 @@ These skills are not captain-invocable; they are conditional operating reference
 
 - `harness-adapters` - load before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter.
 - `stuck-crewmate-recovery` - load after a stale wake, looping pane, repeated confusion, an answered-by-brief question, an unresponsive crewmate, or a failed steer.
-- `secondmate-provisioning` - load before creating, seeding, validating, recovering, handing backlog to, or retiring a secondmate home, and before editing `data/secondmates.md`.
+- `secondmate-provisioning` - load before creating, seeding, validating, recovering, handing backlog to, pushing inherited config into, or retiring a secondmate home, and before editing `data/secondmates.md`.
 - `fmx-respond` - load on an `x-mention <request_id>` `check:` wake to classify the mention, act on actionable requests through the normal lifecycle, post or preview a public-safe outcome reply for work that completes immediately, dismiss pure acknowledgments at the relay without replying, or acknowledge and link spawned work so one completion follow-up posts later (section 14); relevant only when X mode is on.
 
 ## 14. X mode

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ tests/fm-spawn-batch.test.sh              # batch dispatch and FM_HOME project-p
 tests/fm-spawn-dispatch-profile.test.sh   # concrete dispatch profile flags: active-profile backstop, harness/model/effort meta, launch templates, batch forwarding, and secondmate exemption
 tests/fm-update.test.sh                   # fast-forward-only self-update, reread, nudge, dedup, and skip-safety tests
 tests/fm-secondmate-sync.test.sh          # local-HEAD secondmate sync, no-fetch, bootstrap nudge gating, and spawn hook tests
-tests/fm-secondmate-harness.test.sh       # secondmate-vs-crewmate harness resolution and primary-to-secondmate config inheritance tests
+tests/fm-secondmate-harness.test.sh       # secondmate-vs-crewmate harness resolution, primary-to-secondmate config inheritance, and config-push tests
 tests/fm-secondmate-lifecycle-e2e.test.sh # persistent secondmate routing, seeding, backlog handoff, spawn, recovery, teardown, and FM_HOME flow tests
 tests/fm-secondmate-safety.test.sh        # secondmate home safety, idle charter, handoff validation, and teardown boundary tests
 tests/fm-teardown.test.sh                 # fm-teardown.sh landed-work safety and reminder checks: fork-remote allow, squash/content landings, dirty and unlanded refusals, PR-head metadata, tasks-axi/manual backlog reminder, --force override

--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ It routes each request to a crewmate in its own tmux window and git worktree, su
 Persistent secondmate homes are linked firstmate worktrees; startup syncs live ones and secondmate launch syncs the target home to the primary default-branch commit without fetching from origin when it is safe.
 Crewmate dispatch can stay on a static `config/crew-harness` or use optional natural-language profiles in local `config/crew-dispatch.json` to choose a per-task harness, model, and effort.
 When that profile file exists, crewmate and scout spawns must pass the resolved harness explicitly so `config/crew-harness` is not used as an unnoticed bypass.
-Secondmate launch can use a separate local `config/secondmate-harness`, while secondmate homes inherit the primary's declared local config, including `config/crew-dispatch.json`, `config/crew-harness`, and `config/backlog-backend`, so their own crewmates, dispatch profiles, and backlog backend use the primary settings.
+Secondmate launch can use a separate local `config/secondmate-harness`.
+Secondmate homes inherit the primary's declared local config, including `config/crew-dispatch.json`, `config/crew-harness`, and `config/backlog-backend`, at launch, bootstrap, or an explicit `bin/fm-config-push.sh` run, so their own crewmates, dispatch profiles, and backlog backend use the primary settings.
 When a routed request goes to a secondmate, firstmate marks it so the answer returns through status or a document pointer; direct typing into that secondmate window stays conversational.
 A presence-gated sub-supervisor (`/afk`) can self-handle routine events and batch only what matters while you step away.
 An opt-in X mode can also use the watcher check path to answer your public `@myfirstmate` mentions and act on normal reversible mention requests from the current fleet state, with `FMX_DRY_RUN` available to test the poll -> compose -> would-post loop without publishing.

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -141,9 +141,9 @@ secondmate_sync() {
   # it runs whether or not the home's tracked files advanced, keeping the fleet
   # converged on the primary. The propagation helper stays silent on success; a
   # primary with no inheritable config set and no downstream copy is a no-op.
-  local meta id home window home_real propagated_homes
+  local id home home_real propagated_homes
   propagated_homes=""
-  while IFS='|' read -r id home window meta; do
+  while IFS='|' read -r id home _window _meta; do
     validate_secondmate_home "$id" "$home" || continue
     home_real="$VALIDATED_HOME"
     case " $FF_SEEN_HOMES " in

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -141,13 +141,9 @@ secondmate_sync() {
   # it runs whether or not the home's tracked files advanced, keeping the fleet
   # converged on the primary. The propagation helper stays silent on success; a
   # primary with no inheritable config set and no downstream copy is a no-op.
-  local meta id home home_real propagated_homes
+  local meta id home window home_real propagated_homes
   propagated_homes=""
-  for meta in "$STATE"/*.meta; do
-    [ -f "$meta" ] || continue
-    grep -q '^kind=secondmate' "$meta" 2>/dev/null || continue
-    id=$(basename "$meta" .meta)
-    home=$(grep '^home=' "$meta" 2>/dev/null | tail -1 | cut -d= -f2- || true)
+  while IFS='|' read -r id home window meta; do
     validate_secondmate_home "$id" "$home" || continue
     home_real="$VALIDATED_HOME"
     case " $FF_SEEN_HOMES " in
@@ -161,7 +157,7 @@ secondmate_sync() {
     if ! propagate_inheritable_config "$CONFIG" "$home_real/config"; then
       echo "SECONDMATE_SYNC: secondmate $id: skipped: config inheritance failed"
     fi
-  done
+  done < <(live_secondmate_meta_records "$STATE" "$FM_HOME/data/secondmates.md")
   [ -n "$FF_NUDGE_WINDOWS" ] && echo "NUDGE_SECONDMATES:$FF_NUDGE_WINDOWS"
   return 0
 }

--- a/bin/fm-config-inherit-lib.sh
+++ b/bin/fm-config-inherit-lib.sh
@@ -86,8 +86,9 @@ destination_allows_inherited_item() {
 # backward-compatible path). When FM_CONFIG_INHERIT_REPORT points at a writable
 # file, one tab-separated line per item is appended there:
 #   <item> <status> <reason>
-# Status is pushed, unchanged, skipped, or error. Returns non-zero only when the
-# destination cannot be created or written.
+# Status is pushed, unchanged, skipped, or error. Skipped items are warnings and
+# do not affect the exit code. Returns non-zero only when a real propagation
+# error, such as copy or remove failure, occurs.
 record_inheritable_config_result() {
   local item=$1 status=$2 reason=${3:-}
   [ -n "${FM_CONFIG_INHERIT_REPORT:-}" ] || return 0

--- a/bin/fm-config-inherit-lib.sh
+++ b/bin/fm-config-inherit-lib.sh
@@ -11,11 +11,12 @@
 #
 # Why this is separate from the tracked-files fast-forward (fm-ff-lib.sh): config/
 # is gitignored, so a tracked-files fast-forward never carries these items. This
-# is an explicit copy run at the two convergence points the primary owns - a
-# secondmate spawn (bin/fm-spawn.sh) and the bootstrap secondmate sweep
-# (bin/fm-bootstrap.sh). It is PRIMARY-AUTHORITATIVE: the primary's value wins and
-# is re-pushed on every convergence, so the fleet stays converged on the primary;
-# an item the primary does not set is mirrored as absence downstream.
+# is an explicit copy run at the convergence points the primary owns - a
+# secondmate spawn (bin/fm-spawn.sh), the bootstrap secondmate sweep
+# (bin/fm-bootstrap.sh), and the focused mid-session config push
+# (bin/fm-config-push.sh). It is PRIMARY-AUTHORITATIVE: the primary's value wins
+# and is re-pushed on every convergence, so the fleet stays converged on the
+# primary; an item the primary does not set is mirrored as absence downstream.
 #
 # Extensible by design: FM_INHERITABLE_CONFIG is the single declared list of
 # config-dir-relative items the primary propagates. Add an item there and every
@@ -73,19 +74,45 @@ destination_allows_inherited_item() {
 
 # propagate_inheritable_config <src-config-dir> <dest-config-dir>
 # Copy each declared inheritable item from the primary's config dir (src) into a
-# secondmate home's config dir (dest). SILENT on success - callers parse stdout,
-# so this writes nothing there. A source item that is present is copied only when
-# its content differs (idempotent: a re-run never churns mtimes). A source item
-# that is absent is mirrored as a missing destination item, so clearing the
-# primary's value clears it downstream too (primary-authoritative). The
-# destination dir is created lazily, only when there is actually something to
-# write, so a primary with no inheritable config set is a complete no-op (it
-# leaves the secondmate home exactly as it was - the backward-compatible path).
-# Returns non-zero only when the destination cannot be created or written.
+# secondmate home's config dir (dest). SILENT on stdout - callers parse stdout,
+# so this writes nothing there. It emits concise stderr diagnostics only for
+# notable events: a guard skip or a copy/remove error. A source item that is
+# present is copied only when its content differs (idempotent: a re-run never
+# churns mtimes). A source item that is absent is mirrored as a missing
+# destination item, so clearing the primary's value clears it downstream too
+# (primary-authoritative). The destination dir is created lazily, only when there
+# is actually something to write, so a primary with no inheritable config set is a
+# complete no-op (it leaves the secondmate home exactly as it was - the
+# backward-compatible path). When FM_CONFIG_INHERIT_REPORT points at a writable
+# file, one tab-separated line per item is appended there:
+#   <item> <status> <reason>
+# Status is pushed, unchanged, skipped, or error. Returns non-zero only when the
+# destination cannot be created or written.
+record_inheritable_config_result() {
+  local item=$1 status=$2 reason=${3:-}
+  [ -n "${FM_CONFIG_INHERIT_REPORT:-}" ] || return 0
+  printf '%s\t%s\t%s\n' "$item" "$status" "$reason" >> "$FM_CONFIG_INHERIT_REPORT" 2>/dev/null || true
+}
+
+inheritable_config_skip_reason() {
+  printf '%s' "destination does not allow inherited item (not gitignored or guard failed)"
+}
+
+warn_inheritable_config_skip() {
+  local item=$1 dest_config=$2 reason=$3
+  echo "fm-config-inherit: warning: skipped $item for $dest_config: $reason" >&2
+}
+
+warn_inheritable_config_error() {
+  local item=$1 dest=$2 reason=$3
+  echo "fm-config-inherit: error: $reason $item at $dest" >&2
+}
+
 propagate_inheritable_config() {
-  local src_config=$1 dest_config=$2 item src dest
+  local src_config=$1 dest_config=$2 item src dest reason rc
   [ -n "$src_config" ] || return 1
   [ -n "$dest_config" ] || return 1
+  rc=0
   for item in $FM_INHERITABLE_CONFIG; do
     case "$item" in
       ''|/*|.|..|../*|*/../*|*/..) return 1 ;;
@@ -93,15 +120,43 @@ propagate_inheritable_config() {
     src="$src_config/$item"
     dest="$dest_config/$item"
     if [ -f "$src" ]; then
-      destination_allows_inherited_item "$dest_config" "$item" || continue
+      if ! destination_allows_inherited_item "$dest_config" "$item"; then
+        reason=$(inheritable_config_skip_reason)
+        warn_inheritable_config_skip "$item" "$dest_config" "$reason"
+        record_inheritable_config_result "$item" skipped "$reason"
+        continue
+      fi
       if [ -L "$dest" ] || [ ! -f "$dest" ] || ! cmp -s "$src" "$dest"; then
-        copy_inheritable_file "$src" "$dest" || return 1
+        if copy_inheritable_file "$src" "$dest"; then
+          record_inheritable_config_result "$item" pushed ""
+        else
+          reason="failed to copy"
+          warn_inheritable_config_error "$item" "$dest" "$reason"
+          record_inheritable_config_result "$item" error "$reason"
+          rc=1
+        fi
+      else
+        record_inheritable_config_result "$item" unchanged ""
       fi
     elif [ -e "$dest" ] || [ -L "$dest" ]; then
-      destination_allows_inherited_item "$dest_config" "$item" || continue
+      if ! destination_allows_inherited_item "$dest_config" "$item"; then
+        reason=$(inheritable_config_skip_reason)
+        warn_inheritable_config_skip "$item" "$dest_config" "$reason"
+        record_inheritable_config_result "$item" skipped "$reason"
+        continue
+      fi
       # Primary has no value for this item: mirror the absence downstream.
-      rm -f "$dest" 2>/dev/null || return 1
+      if rm -f "$dest" 2>/dev/null; then
+        record_inheritable_config_result "$item" pushed "mirrored primary absence"
+      else
+        reason="failed to remove"
+        warn_inheritable_config_error "$item" "$dest" "$reason"
+        record_inheritable_config_result "$item" error "$reason"
+        rc=1
+      fi
+    else
+      record_inheritable_config_result "$item" unchanged ""
     fi
   done
-  return 0
+  return "$rc"
 }

--- a/bin/fm-config-push.sh
+++ b/bin/fm-config-push.sh
@@ -97,7 +97,7 @@ echo "config-push: $CONFIG -> live secondmate homes"
 
 seen_homes=""
 errors=0
-while IFS='|' read -r id home window meta; do
+while IFS='|' read -r id home _window meta; do
   [ -n "$id" ] || continue
   if [ -z "$home" ]; then
     printf 'secondmate %s: skipped - no home= in %s and no registry home\n' "$id" "$meta"

--- a/bin/fm-config-push.sh
+++ b/bin/fm-config-push.sh
@@ -3,9 +3,11 @@
 # Usage: fm-config-push.sh [--help]
 #
 # Config-only convergence for mid-session changes such as config/crew-dispatch.json
-# edits. This reuses the same live secondmate discovery and
+# edits. This discovers live secondmate homes from state/*.meta, backfills
+# home= from data/secondmates.md for older meta records, and reuses the same
 # propagate_inheritable_config machinery as bootstrap, but deliberately does not
 # fast-forward tracked files and does not nudge running secondmates.
+# Warnings-only skips exit 0; real propagation errors exit non-zero.
 set -u
 
 usage() {
@@ -20,6 +22,11 @@ This is config-only:
   - does not nudge secondmates
   - reports each live home and each inheritable item as pushed, unchanged,
     skipped, or error
+  - exits non-zero only for real propagation errors
+
+Live homes come from state/*.meta records with kind=secondmate.
+data/secondmates.md is only a fallback for missing home= fields in older or
+incomplete meta records.
 
 Environment overrides follow the rest of firstmate:
   FM_HOME            active firstmate home

--- a/bin/fm-config-push.sh
+++ b/bin/fm-config-push.sh
@@ -78,6 +78,7 @@ print_item_report() {
 
 records=$(mktemp "${TMPDIR:-/tmp}/fm-config-push-records.XXXXXX" 2>/dev/null) || exit 1
 reports=""
+# shellcheck disable=SC2317,SC2329 # Invoked by trap handlers below.
 cleanup() {
   local report_file
   rm -f "$records"

--- a/bin/fm-config-push.sh
+++ b/bin/fm-config-push.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# Push declared inheritable local config to live secondmate homes.
+# Usage: fm-config-push.sh [--help]
+#
+# Config-only convergence for mid-session changes such as config/crew-dispatch.json
+# edits. This reuses the same live secondmate discovery and
+# propagate_inheritable_config machinery as bootstrap, but deliberately does not
+# fast-forward tracked files and does not nudge running secondmates.
+set -u
+
+usage() {
+  cat <<'EOF'
+Usage: fm-config-push.sh [--help]
+
+Push the primary firstmate home's declared inheritable local config into each
+live secondmate home's config/ directory.
+
+This is config-only:
+  - does not fast-forward tracked files
+  - does not nudge secondmates
+  - reports each live home and each inheritable item as pushed, unchanged,
+    skipped, or error
+
+Environment overrides follow the rest of firstmate:
+  FM_HOME            active firstmate home
+  FM_ROOT_OVERRIDE  firstmate repo root
+  FM_STATE_OVERRIDE state dir
+  FM_CONFIG_OVERRIDE config dir
+EOF
+}
+
+case "${1:-}" in
+  -h|--help)
+    usage
+    exit 0
+    ;;
+  "")
+    ;;
+  *)
+    echo "usage: fm-config-push.sh [--help]" >&2
+    exit 2
+    ;;
+esac
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+DATA="$FM_HOME/data"
+SECONDMATES_MD="$DATA/secondmates.md"
+
+"$SCRIPT_DIR/fm-guard.sh" || true
+
+# shellcheck source=bin/fm-ff-lib.sh
+. "$SCRIPT_DIR/fm-ff-lib.sh"
+# shellcheck source=bin/fm-config-inherit-lib.sh
+. "$SCRIPT_DIR/fm-config-inherit-lib.sh"
+
+print_item_report() {
+  local report=$1 item status reason
+  while IFS=$'\t' read -r item status reason; do
+    [ -n "$item" ] || continue
+    if [ -n "$reason" ]; then
+      printf '  %s: %s - %s\n' "$item" "$status" "$reason"
+    else
+      printf '  %s: %s\n' "$item" "$status"
+    fi
+  done < "$report"
+}
+
+records=$(mktemp "${TMPDIR:-/tmp}/fm-config-push-records.XXXXXX" 2>/dev/null) || exit 1
+reports=""
+cleanup() {
+  local report_file
+  rm -f "$records"
+  for report_file in $reports; do
+    rm -f "$report_file"
+  done
+}
+trap cleanup EXIT
+
+live_secondmate_meta_records "$STATE" "$SECONDMATES_MD" > "$records"
+if [ ! -s "$records" ]; then
+  echo "config-push: no live secondmate homes found"
+  exit 0
+fi
+
+echo "config-push: $CONFIG -> live secondmate homes"
+
+seen_homes=""
+errors=0
+while IFS='|' read -r id home window meta; do
+  [ -n "$id" ] || continue
+  if [ -z "$home" ]; then
+    printf 'secondmate %s: skipped - no home= in %s and no registry home\n' "$id" "$meta"
+    continue
+  fi
+  if ! validate_secondmate_home "$id" "$home"; then
+    printf 'secondmate %s (%s): skipped - unsafe home: %s\n' "$id" "$home" "$VALIDATION_ERROR"
+    continue
+  fi
+  home_real="$VALIDATED_HOME"
+  case " $seen_homes " in
+    *" $home_real "*)
+      printf 'secondmate %s (%s): skipped - already processed for another live meta\n' "$id" "$home_real"
+      continue
+      ;;
+  esac
+  seen_homes="$seen_homes $home_real"
+
+  printf 'secondmate %s (%s):\n' "$id" "$home_real"
+  dirty=$(dirty_status "$home_real" yes || true)
+  if [ -n "$dirty" ]; then
+    echo "  home: dirty working tree - config-only push continuing"
+  fi
+
+  report=$(mktemp "${TMPDIR:-/tmp}/fm-config-push-report.XXXXXX" 2>/dev/null) || {
+    echo "  home: error - could not create report file"
+    errors=1
+    continue
+  }
+  reports="$reports $report"
+  if FM_CONFIG_INHERIT_REPORT="$report" propagate_inheritable_config "$CONFIG" "$home_real/config"; then
+    print_item_report "$report"
+  else
+    errors=1
+    print_item_report "$report"
+  fi
+done < "$records"
+
+[ "$errors" -eq 0 ] || exit 1
+exit 0

--- a/bin/fm-ff-lib.sh
+++ b/bin/fm-ff-lib.sh
@@ -224,6 +224,40 @@ dirty_status() {
   fi
 }
 
+secondmate_registry_field() {
+  local reg=$1 id=$2 key=$3 line value
+  [ -f "$reg" ] || return 1
+  line=$(grep -E "^- $id( |$)" "$reg" | tail -1 || true)
+  [ -n "$line" ] || return 1
+  case "$key" in
+    home) value=$(printf '%s\n' "$line" | sed -n 's/.*(home:[[:space:]]*\([^;)]*\);.*/\1/p' | sed 's/[[:space:]]*$//') ;;
+    projects) value=$(printf '%s\n' "$line" | sed -n 's/.*; projects:[[:space:]]*\([^;)]*\); added .*/\1/p' | sed 's/[[:space:]]*$//') ;;
+    *) return 1 ;;
+  esac
+  [ -n "$value" ] || return 1
+  printf '%s\n' "$value"
+}
+
+# List this home's LIVE secondmate direct reports from state/<id>.meta records.
+# The meta file is the liveness signal; data/secondmates.md is only the fallback
+# for durable fields such as home= when an older/incomplete meta lacks them.
+# Output is pipe-delimited: id|home|window|meta-file.
+live_secondmate_meta_records() {
+  local state=$1 registry=${2:-} meta id home window
+  [ -d "$state" ] || return 0
+  for meta in "$state"/*.meta; do
+    [ -f "$meta" ] || continue
+    grep -q '^kind=secondmate$' "$meta" 2>/dev/null || continue
+    id=$(basename "$meta" .meta)
+    home=$(grep '^home=' "$meta" 2>/dev/null | tail -1 | cut -d= -f2- || true)
+    if [ -z "$home" ] && [ -n "$registry" ]; then
+      home=$(secondmate_registry_field "$registry" "$id" home || true)
+    fi
+    window=$(grep '^window=' "$meta" 2>/dev/null | tail -1 | cut -d= -f2- || true)
+    printf '%s|%s|%s|%s\n' "$id" "$home" "$window" "$meta"
+  done
+}
+
 # Fast-forward one target to a base. Prints its status line. Sets globals for the
 # caller:
 #   FF_STATUS = updated|current|skipped
@@ -376,14 +410,9 @@ process_secondmate() {
 # nudge_requires_instr through to process_secondmate. Accumulates into
 # FF_NUDGE_WINDOWS / FF_SEEN_HOMES, which the caller resets before and reads after.
 sweep_live_secondmate_metas() {
-  local state=$1 base_mode=$2 nudge_requires_instr=${3:-no} meta id home window
+  local state=$1 base_mode=$2 nudge_requires_instr=${3:-no} registry=${4:-$FM_HOME/data/secondmates.md} id home window meta
   [ -d "$state" ] || return 0
-  for meta in "$state"/*.meta; do
-    [ -f "$meta" ] || continue
-    grep -q '^kind=secondmate' "$meta" 2>/dev/null || continue
-    id=$(basename "$meta" .meta)
-    home=$(grep '^home=' "$meta" 2>/dev/null | tail -1 | cut -d= -f2- || true)
-    window=$(grep '^window=' "$meta" 2>/dev/null | tail -1 | cut -d= -f2- || true)
+  while IFS='|' read -r id home window meta; do
     process_secondmate "$id" "$home" "$window" "$base_mode" "$nudge_requires_instr"
-  done
+  done < <(live_secondmate_meta_records "$state" "$registry")
 }

--- a/bin/fm-ff-lib.sh
+++ b/bin/fm-ff-lib.sh
@@ -409,6 +409,7 @@ process_secondmate() {
 # kind=secondmate - fast-forwarding each to base_mode. Passes base_mode and
 # nudge_requires_instr through to process_secondmate. Accumulates into
 # FF_NUDGE_WINDOWS / FF_SEEN_HOMES, which the caller resets before and reads after.
+# The registry argument is only for home= fallback on older or incomplete meta records.
 sweep_live_secondmate_metas() {
   local state=$1 base_mode=$2 nudge_requires_instr=${3:-no} registry=${4:-$FM_HOME/data/secondmates.md} id home window meta
   [ -d "$state" ] || return 0

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -81,6 +81,7 @@ Idle secondmate panes are healthy; teardown is explicit and refuses while the se
 
 Secondmate homes stay on the same firstmate version as the primary checkout.
 On main firstmate bootstrap, `fm-bootstrap.sh` fast-forwards each live secondmate home recorded in `state/*.meta` to the primary default-branch commit with no origin fetch.
+The live signal is a `state/<id>.meta` record with `kind=secondmate`; `data/secondmates.md` only backfills `home=` for older or incomplete meta records.
 A tracked-files fast-forward leaves the home's gitignored `data/`, `state/`, `config/`, `projects/`, and `.no-mistakes/` directories untouched.
 Bootstrap separately propagates the primary's declared inheritable local config, currently `config/crew-dispatch.json`, `config/crew-harness`, and `config/backlog-backend`, into each validated live secondmate home so that secondmate's own crewmates, dispatch profiles, and backlog backend use the primary settings.
 That propagation is primary-authoritative, re-runs even when tracked files were already current, mirrors absence when the primary clears the value, and deliberately never copies `config/secondmate-harness`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -84,8 +84,9 @@ On main firstmate bootstrap, `fm-bootstrap.sh` fast-forwards each live secondmat
 A tracked-files fast-forward leaves the home's gitignored `data/`, `state/`, `config/`, `projects/`, and `.no-mistakes/` directories untouched.
 Bootstrap separately propagates the primary's declared inheritable local config, currently `config/crew-dispatch.json`, `config/crew-harness`, and `config/backlog-backend`, into each validated live secondmate home so that secondmate's own crewmates, dispatch profiles, and backlog backend use the primary settings.
 That propagation is primary-authoritative, re-runs even when tracked files were already current, mirrors absence when the primary clears the value, and deliberately never copies `config/secondmate-harness`.
-Dirty, diverged, unsafe, or in-flight homes are reported and left unchanged.
+Dirty, diverged, unsafe, or in-flight homes are reported and left unchanged by the tracked-file sync.
 Only a running secondmate home that actually advanced and changed `AGENTS.md`, `bin/`, or `.agents/skills/` is listed for a re-read nudge.
+`fm-config-push.sh` is the focused mid-session version of that same inheritance path: it discovers the same live secondmate homes, calls the same propagation helper, and reports per-home/per-item results without running the tracked-file fast-forward or sending reread nudges.
 `fm-spawn.sh --secondmate` performs the same guarded local fast-forward before launch or recovery respawn; skipped syncs warn and the secondmate launches unchanged.
 Secondmate spawn also propagates the same inheritable config before launch.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -58,7 +58,7 @@ When it is absent or contains `default`, crewmates mirror the firstmate's own ha
 When it is absent or contains `default`, secondmate launch falls back through `config/crew-harness` and then the primary's own harness, preserving the previous behavior.
 An explicit harness argument to `fm-spawn.sh` still overrides either config file for that spawn only.
 When `config/crew-dispatch.json` exists, crewmate and scout spawns require an explicit resolved harness instead of automatically falling back to `config/crew-harness`.
-The primary propagates `config/crew-dispatch.json`, `config/crew-harness`, and `config/backlog-backend` into secondmate homes at secondmate spawn and during the bootstrap secondmate sweep, so a secondmate's own crewmates, dispatch profiles, and backlog backend use the primary values.
+The primary propagates `config/crew-dispatch.json`, `config/crew-harness`, and `config/backlog-backend` into secondmate homes at secondmate spawn, during the bootstrap secondmate sweep, and during explicit `bin/fm-config-push.sh` runs, so a secondmate's own crewmates, dispatch profiles, and backlog backend use the primary values.
 `config/secondmate-harness` is not inherited because secondmates do not launch secondmates.
 For grok, `fm-spawn.sh` installs one firstmate-owned global turn-end hook under `$GROK_HOME/hooks/`, or `~/.grok/hooks/` when `GROK_HOME` is unset, and drops a per-task `.fm-grok-turnend` pointer in the worktree, with teardown removing the task token and pointer.
 
@@ -94,6 +94,7 @@ Bootstrap also runs the guarded local secondmate sync for recorded live secondma
 It emits `SECONDMATE_SYNC:` only when a home was skipped for an actionable sync reason or config inheritance failed, and `NUDGE_SECONDMATES:` only when a running home advanced and its instruction surface changed.
 For a mid-session inherited config edit where tracked-file sync and reread nudges are not needed, run `bin/fm-config-push.sh`.
 It uses the same live secondmate discovery and propagation helper as bootstrap, prints each live home's `crew-dispatch.json`, `crew-harness`, and `backlog-backend` result as `pushed`, `unchanged`, `skipped`, or `error`, and exits non-zero only for real propagation errors.
+That live discovery starts from `state/*.meta` records with `kind=secondmate`; `data/secondmates.md` only backfills `home=` for older or incomplete meta records.
 Skipped items, such as a destination checkout that does not yet gitignore the item, are visible warnings but not hard failures.
 
 ## X mode (.env)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -92,6 +92,9 @@ Bootstrap also runs a best-effort project clone refresh through `fm-fleet-sync.s
 It emits `FLEET_SYNC:` for skipped refreshes that may matter, recovered self-heals, and `STUCK:` alarms; local-only and no-origin skips stay silent.
 Bootstrap also runs the guarded local secondmate sync for recorded live secondmate homes, then propagates declared inheritable local config into each validated live home.
 It emits `SECONDMATE_SYNC:` only when a home was skipped for an actionable sync reason or config inheritance failed, and `NUDGE_SECONDMATES:` only when a running home advanced and its instruction surface changed.
+For a mid-session inherited config edit where tracked-file sync and reread nudges are not needed, run `bin/fm-config-push.sh`.
+It uses the same live secondmate discovery and propagation helper as bootstrap, prints each live home's `crew-dispatch.json`, `crew-harness`, and `backlog-backend` result as `pushed`, `unchanged`, `skipped`, or `error`, and exits non-zero only for real propagation errors.
+Skipped items, such as a destination checkout that does not yet gitignore the item, are visible warnings but not hard failures.
 
 ## X mode (.env)
 

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -14,6 +14,7 @@ Each file also starts with a short header comment.
 | `fm-guard.sh`            | Warn when the primary checkout is tangled, when queued wakes are pending, or when a stale or missing watcher needs a prominent banner |
 | `fm-home-seed.sh`        | Lease/provision a secondmate home transactionally, clone projects, initialize gates, and maintain `data/secondmates.md` |
 | `fm-spawn.sh`            | Spawn one task, several `id=repo` pairs, or a persistent secondmate with `--secondmate`; accepts concrete `--harness`, `--model`, and `--effort` profile axes; ship/scout spawns require an explicit resolved harness when dispatch profiles are active and an isolated treehouse worktree, install per-harness turn-end signaling, and secondmate spawns resolve the secondmate harness, locally sync the home, and propagate declared inheritable config before launch |
+| `fm-config-push.sh`      | Config-only mid-session push of declared inheritable local config into live secondmate homes; reports each item as pushed, unchanged, skipped, or error without fast-forwarding tracked files or nudging agents |
 | `fm-project-mode.sh`     | Resolve a project's delivery mode and `+yolo` flag from `data/projects.md`                                          |
 | `fm-merge-local.sh`      | Fast-forward a `local-only` project's local default branch after approval                                           |
 | `fm-review-diff.sh`      | Review a crewmate branch against the authoritative base, with optional `--stat` output                              |
@@ -24,7 +25,7 @@ Each file also starts with a short header comment.
 | `fm-crew-state.sh`       | Print one stable current-state line for a crew by reconciling its matching no-mistakes run-step, even when the pane has closed, with pane and status-log fallback |
 | `fm-tangle-lib.sh`       | Shared default-branch resolution and primary-checkout tangle classification sourced by bootstrap and guard         |
 | `fm-ff-lib.sh`           | Shared guarded fast-forward helper for `/updatefirstmate` origin pulls and no-fetch local secondmate syncs         |
-| `fm-config-inherit-lib.sh` | Shared primary->secondmate inheritable-config propagation (a declared, extensible item list - currently `config/crew-dispatch.json`, `config/crew-harness`, and `config/backlog-backend`) sourced by spawn and bootstrap |
+| `fm-config-inherit-lib.sh` | Shared primary->secondmate inheritable-config propagation (a declared, extensible item list - currently `config/crew-dispatch.json`, `config/crew-harness`, and `config/backlog-backend`) sourced by spawn, bootstrap, and config push |
 | `fm-tasks-axi-lib.sh`    | Shared backlog-backend selector and `tasks-axi` compatibility probe sourced by bootstrap and teardown              |
 | `fm-wake-drain.sh`       | Atomically drain queued watcher wakes before handling supervision work, then run the watcher-liveness guard         |
 | `fm-wake-lib.sh`         | Shared durable wake queue and portable lock helpers sourced by the watcher, drain, arm, guard, and daemon          |

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -16,9 +16,9 @@
 #      and config/backlog-backend - down into each secondmate home's config/, so
 #      the secondmate's OWN crewmates, dispatch profiles, and backlog backend
 #      inherit the primary's settings. It is primary-authoritative (re-pushed at
-#      secondmate spawn and on the bootstrap secondmate sweep) and
-#      config/secondmate-harness is
-#      deliberately NOT inherited (secondmates do not spawn secondmates).
+#      secondmate spawn, on the bootstrap secondmate sweep, and by config push).
+#      config/secondmate-harness is deliberately NOT inherited (secondmates do
+#      not spawn secondmates).
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -353,8 +353,8 @@ test_spawn_unverified_secondmate_harness_refused() {
 }
 
 # ===========================================================================
-# B integration: the bootstrap secondmate sweep propagates inheritable config and
-# keeps it converged on the primary (independent of the tracked-files ff status).
+# B integration: spawn, bootstrap, and config push propagate inheritable config
+# and keep it converged on the primary (independent of tracked-file ff status).
 # ===========================================================================
 
 # A PRIMARY firstmate repo on main with one commit + a home dir, mirroring the

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -71,7 +71,7 @@ ROWS
 # B) propagate_inheritable_config unit behavior
 # ===========================================================================
 test_propagate_lib() {
-  local d src dest m1 m2 outside
+  local d src dest m1 m2 outside stdout stderr guard_repo err_text
   d="$TMP_ROOT/prop-lib"
   src="$d/src"
   dest="$d/dest"
@@ -81,7 +81,11 @@ test_propagate_lib() {
   printf '{"default":{"harness":"codex"}}\n' > "$src/crew-dispatch.json"
   printf 'codex\n' > "$src/crew-harness"
   printf 'manual\n' > "$src/backlog-backend"
-  propagate_inheritable_config "$src" "$dest" || fail "propagate returned non-zero"
+  stdout="$d/clean-copy.out"
+  stderr="$d/clean-copy.err"
+  propagate_inheritable_config "$src" "$dest" >"$stdout" 2>"$stderr" || fail "propagate returned non-zero"
+  [ ! -s "$stdout" ] || fail "clean copy wrote to stdout"
+  [ ! -s "$stderr" ] || fail "clean copy wrote to stderr"
   [ "$(cat "$dest/crew-dispatch.json")" = '{"default":{"harness":"codex"}}' ] || fail "crew-dispatch.json not propagated"
   [ "$(cat "$dest/crew-harness")" = codex ] || fail "crew-harness not propagated"
   [ "$(cat "$dest/backlog-backend")" = manual ] || fail "backlog-backend not propagated"
@@ -89,7 +93,11 @@ test_propagate_lib() {
   # 2. idempotent: an unchanged re-run does not churn the mtime
   m1=$(date -r "$dest/crew-harness" +%s 2>/dev/null || stat -c %Y "$dest/crew-harness")
   sleep 1
-  propagate_inheritable_config "$src" "$dest"
+  stdout="$d/unchanged.out"
+  stderr="$d/unchanged.err"
+  propagate_inheritable_config "$src" "$dest" >"$stdout" 2>"$stderr"
+  [ ! -s "$stdout" ] || fail "unchanged propagation wrote to stdout"
+  [ ! -s "$stderr" ] || fail "unchanged propagation wrote to stderr"
   m2=$(date -r "$dest/crew-harness" +%s 2>/dev/null || stat -c %Y "$dest/crew-harness")
   [ "$m1" = "$m2" ] || fail "idempotent re-run churned mtime ($m1 -> $m2)"
 
@@ -125,9 +133,12 @@ test_propagate_lib() {
   [ -L "$dest/crew-harness" ] && fail "broken destination symlink not removed on absence mirror"
 
   mkdir -p "$dest/crew-harness"
-  if propagate_inheritable_config "$src" "$dest"; then
+  stderr="$d/remove-error.err"
+  if propagate_inheritable_config "$src" "$dest" 2>"$stderr"; then
     fail "failed absence mirror returned success"
   fi
+  assert_contains "$(cat "$stderr")" "fm-config-inherit: error: failed to remove crew-harness" \
+    "remove error did not emit a stderr diagnostic"
   [ -d "$dest/crew-harness" ] || fail "failed absence mirror removed the wrong path"
   rm -rf "$dest/crew-harness"
 
@@ -150,7 +161,26 @@ test_propagate_lib() {
   propagate_inheritable_config "$d/src3" "$d/dest3/config"
   [ -e "$d/dest3/config" ] && fail "empty-source propagation created a destination dir"
 
-  pass "B1 propagate_inheritable_config: copy, idempotence, convergence, absence-mirror, exclusion, no-op"
+  # 7. a git worktree that does not ignore an inherited item gets a visible
+  # stderr warning and a skip, not a silent miss.
+  guard_repo="$d/guard-repo"
+  git init -q -b main "$guard_repo"
+  printf 'config/crew-harness\nconfig/backlog-backend\n' > "$guard_repo/.gitignore"
+  printf 'guard\n' > "$guard_repo/README.md"
+  git -C "$guard_repo" add -A
+  git -C "$guard_repo" commit -qm guard
+  printf '{"default":{"harness":"grok"}}\n' > "$src/crew-dispatch.json"
+  stdout="$d/guard-skip.out"
+  stderr="$d/guard-skip.err"
+  FM_INHERITABLE_CONFIG=crew-dispatch.json propagate_inheritable_config "$src" "$guard_repo/config" >"$stdout" 2>"$stderr" \
+    || fail "guard skip should not make propagation fail"
+  [ ! -s "$stdout" ] || fail "guard skip wrote to stdout"
+  err_text=$(cat "$stderr")
+  assert_contains "$err_text" "fm-config-inherit: warning: skipped crew-dispatch.json" \
+    "guard skip did not emit a stderr warning"
+  [ ! -e "$guard_repo/config/crew-dispatch.json" ] || fail "guard skip still copied the unignored item"
+
+  pass "B1 propagate_inheritable_config: copy, idempotence, convergence, absence-mirror, exclusion, no-op, skip diagnostics"
 }
 
 # ===========================================================================
@@ -400,6 +430,12 @@ run_bootstrap() {
     "$ROOT/bin/fm-bootstrap.sh" 2>/dev/null
 }
 
+run_config_push() {
+  local w=$1
+  PATH="$BASE_PATH" FM_HOME="$w/home" FM_ROOT_OVERRIDE="$w/main" \
+    "$ROOT/bin/fm-config-push.sh"
+}
+
 # The sweep pushes the primary's inheritable config into a live home, re-converges
 # it when the primary changes it, and mirrors absence when the primary clears it -
 # all while never inheriting secondmate-harness.
@@ -538,6 +574,124 @@ test_bootstrap_sweep_surfaces_config_propagation_failure() {
   pass "B11 bootstrap sweep surfaces config propagation failures"
 }
 
+test_config_push_propagates_reports_without_ff_or_nudge() {
+  local w c1 sm_real old_head out err status out2 tmp
+  w=$(new_world config-push-basic)
+  c1=$(git -C "$w/main" rev-parse HEAD)
+  add_sm_worktree "$w" sm "$c1"
+  sm_real=$(cd "$w/sm" && pwd -P)
+  printf -- '- sm - config push target (home: %s; scope: config; projects: alpha; added 2026-06-30)\n' "$sm_real" > "$w/home/data/secondmates.md"
+  tmp="$w/home/state/sm.meta.tmp"
+  grep -v '^home=' "$w/home/state/sm.meta" > "$tmp"
+  mv "$tmp" "$w/home/state/sm.meta"
+
+  printf 'v2\n' > "$w/main/AGENTS.md"
+  git -C "$w/main" add AGENTS.md
+  git -C "$w/main" commit -qm c2
+  old_head=$(git -C "$w/sm" rev-parse HEAD)
+
+  printf '{"default":{"harness":"codex"}}\n' > "$w/home/config/crew-dispatch.json"
+  printf 'codex\n' > "$w/home/config/crew-harness"
+  printf 'manual\n' > "$w/home/config/backlog-backend"
+  err="$w/config-push-basic.err"
+  out=$(run_config_push "$w" 2>"$err"); status=$?
+
+  expect_code 0 "$status" "config push should succeed"
+  assert_contains "$out" "config-push: $w/home/config -> live secondmate homes" \
+    "config push lacked the header"
+  assert_contains "$out" "secondmate sm ($sm_real):" \
+    "config push did not discover the live secondmate through registry fallback"
+  assert_contains "$out" "crew-dispatch.json: pushed" \
+    "config push did not report crew-dispatch as pushed"
+  assert_contains "$out" "crew-harness: pushed" \
+    "config push did not report crew-harness as pushed"
+  assert_contains "$out" "backlog-backend: pushed" \
+    "config push did not report backlog-backend as pushed"
+  assert_not_contains "$out" "NUDGE_SECONDMATES" \
+    "config push must not nudge secondmates"
+  [ "$(git -C "$w/sm" rev-parse HEAD)" = "$old_head" ] \
+    || fail "config push fast-forwarded tracked files"
+  [ ! -s "$err" ] || fail "clean config push wrote unexpected stderr: $(cat "$err")"
+
+  out2=$(run_config_push "$w" 2>"$err"); status=$?
+  expect_code 0 "$status" "idempotent config push should succeed"
+  assert_contains "$out2" "crew-dispatch.json: unchanged" \
+    "idempotent config push did not report crew-dispatch as unchanged"
+  assert_contains "$out2" "crew-harness: unchanged" \
+    "idempotent config push did not report crew-harness as unchanged"
+  assert_contains "$out2" "backlog-backend: unchanged" \
+    "idempotent config push did not report backlog-backend as unchanged"
+  pass "B12 config-push propagates via shared live discovery, reports items, and does not fast-forward or nudge"
+}
+
+test_config_push_reports_skips_dirty_and_invalid_home() {
+  local w head out err status stale_real dirty_real bad_home err_text tmp
+  w=$(new_world config-push-warnings)
+  head=$(git -C "$w/main" rev-parse HEAD)
+  add_sm_worktree "$w" dirty "$head"
+  add_sm_worktree "$w" stale "$head"
+  dirty_real=$(cd "$w/dirty" && pwd -P)
+  stale_real=$(cd "$w/stale" && pwd -P)
+
+  printf 'local edit\n' >> "$w/dirty/README.md"
+  tmp="$w/stale/.gitignore.tmp"
+  grep -v '^config/crew-dispatch.json$' "$w/stale/.gitignore" > "$tmp"
+  mv "$tmp" "$w/stale/.gitignore"
+
+  bad_home="$w/not-secondmate"
+  mkdir -p "$bad_home"
+  {
+    printf 'window=firstmate:fm-bad\n'
+    printf 'kind=secondmate\n'
+    printf 'home=%s\n' "$bad_home"
+  } > "$w/home/state/bad.meta"
+
+  printf '{"default":{"harness":"codex"}}\n' > "$w/home/config/crew-dispatch.json"
+  printf 'codex\n' > "$w/home/config/crew-harness"
+  printf 'manual\n' > "$w/home/config/backlog-backend"
+  err="$w/config-push-warnings.err"
+  out=$(run_config_push "$w" 2>"$err"); status=$?
+
+  expect_code 0 "$status" "warnings-only config push should exit zero"
+  assert_contains "$out" "secondmate dirty ($dirty_real):" \
+    "config push did not report dirty home"
+  assert_contains "$out" "home: dirty working tree - config-only push continuing" \
+    "config push did not surface dirty state"
+  assert_contains "$out" "secondmate stale ($stale_real):" \
+    "config push did not report stale home"
+  assert_contains "$out" "crew-dispatch.json: skipped - destination does not allow inherited item" \
+    "config push did not report non-allowing item skip"
+  assert_contains "$out" "secondmate bad ($bad_home): skipped - unsafe home: not a seeded secondmate home" \
+    "config push did not report invalid secondmate home"
+  err_text=$(cat "$err")
+  assert_contains "$err_text" "fm-config-inherit: warning: skipped crew-dispatch.json" \
+    "config push did not inherit the lib's skip stderr warning"
+  pass "B13 config-push reports dirty, non-allowing, and invalid homes without failing warnings-only runs"
+}
+
+test_config_push_exits_nonzero_on_copy_error() {
+  local w head out err status sm_real err_text
+  w=$(new_world config-push-error)
+  head=$(git -C "$w/main" rev-parse HEAD)
+  add_sm_worktree "$w" sm "$head"
+  sm_real=$(cd "$w/sm" && pwd -P)
+  printf 'codex\n' > "$w/home/config/crew-harness"
+  mkdir -p "$w/sm/config/crew-harness"
+
+  err="$w/config-push-error.err"
+  out=$(run_config_push "$w" 2>"$err"); status=$?
+
+  expect_code 1 "$status" "copy-error config push should exit non-zero"
+  assert_contains "$out" "secondmate sm ($sm_real):" \
+    "config push error output missed the home"
+  assert_contains "$out" "crew-harness: error - failed to copy" \
+    "config push did not report the per-item copy error"
+  err_text=$(cat "$err")
+  assert_contains "$err_text" "fm-config-inherit: error: failed to copy crew-harness" \
+    "copy error did not emit a stderr diagnostic"
+  pass "B14 config-push exits nonzero on real propagation errors"
+}
+
 test_harness_resolution
 test_propagate_lib
 test_spawn_split_and_inherit
@@ -550,5 +704,8 @@ test_bootstrap_sweep_propagates_when_tracked_current
 test_bootstrap_sweep_defers_dispatch_on_stale_unignored_home
 test_bootstrap_sweep_no_inheritance_is_noop
 test_bootstrap_sweep_surfaces_config_propagation_failure
+test_config_push_propagates_reports_without_ff_or_nudge
+test_config_push_reports_skips_dirty_and_invalid_home
+test_config_push_exits_nonzero_on_copy_error
 
 echo "# all fm-secondmate-harness tests passed"


### PR DESCRIPTION
## Intent

Improve firstmate inheritable-config propagation so mid-session changes to local inherited config, especially config/crew-dispatch.json, reach already-live secondmate homes reliably and visibly. Keep propagate_inheritable_config as the single propagation truth with stdout still silent for existing callers, but emit concise stderr diagnostics for guard skips and copy/remove errors. Add a focused config-only push command that reuses shared live secondmate discovery from state/*.meta plus data/secondmates.md fallback and the same propagation helper, reports per-home/per-item pushed/unchanged/skipped/error results, does not fast-forward tracked files, and does not nudge secondmates. Update AGENTS/docs/secondmate-provisioning guidance and tests for visible skips, clean silent propagation, command reporting, no-fast-forward/no-nudge behavior, warning vs hard-error exit codes, and dirty/invalid home visibility.

## What Changed

- Added `bin/fm-config-push.sh` to push inheritable config into live secondmate homes without fast-forwarding tracked files or nudging secondmates.
- Centralized live secondmate discovery and enhanced `propagate_inheritable_config` with silent success behavior plus visible stderr diagnostics for guard skips and copy/remove errors.
- Updated firstmate guidance, script/config docs, and secondmate harness tests to cover config-only push reporting, dirty or invalid homes, skip visibility, and no-nudge behavior.

Captain, pipeline validation passed for intent, rebase, review, tests, docs, lint, and push.

## Risk Assessment

✅ Low: Captain, the change is well-scoped to config propagation/discovery, keeps the existing guarded inheritance model intact, and I did not find material correctness or safety regressions.

## Testing

The configured full test command was already reported successful as baseline; I reran the focused secondmate harness/config and sync suites, captured their outputs, and manually exercised the live config-push flow with persisted CLI evidence. All checks passed, and the worktree stayed clean.

<details>
<summary>Evidence: manual config-push transcript</summary>

```text
# Manual smoke: fm-config-push live secondmate config propagation
worktree under evidence: /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KWCTDVJXV9958P12A1Q5CQE0/manual-config-push-world

$ git init primary firstmate repo and live detached secondmate home
secondmate HEAD before primary advances: 3d5d59d

$ advance primary tracked files to prove config-push does not fast-forward the secondmate
primary HEAD after tracked-file change: 1460368

$ write primary inherited config and run bin/fm-config-push.sh
exit status: 0
--- stdout ---
config-push: <world>/home/config -> live secondmate homes
secondmate sm-live (<world>/sm-live):
  crew-dispatch.json: pushed
  crew-harness: pushed
  backlog-backend: pushed
--- stderr ---

$ verify downstream config and tracked HEAD
secondmate HEAD after config-push: 3d5d59d
tracked HEAD unchanged: yes
crew-dispatch.json: {"default":{"harness":"codex","model":"gpt-5","effort":"low"}}
crew-harness: codex
backlog-backend: manual
nudge emitted: no

$ run the same command again to prove idempotent unchanged reporting
--- stdout ---
config-push: <world>/home/config -> live secondmate homes
secondmate sm-live (<world>/sm-live):
  crew-dispatch.json: unchanged
  crew-harness: unchanged
  backlog-backend: unchanged
--- stderr ---
```
</details>
<details>
<summary>Evidence: fm-secondmate-harness test output</summary>

```text
ok - A1 fm-harness.sh secondmate resolves the fallback chain; crew mode unchanged
ok - B1 propagate_inheritable_config: copy, idempotence, convergence, absence-mirror, exclusion, no-op, skip diagnostics
ok - B2 spawn: secondmate runs the secondmate harness; its home inherits declared config
ok - B3 spawn: an absent secondmate-harness falls back to the crew harness (backward-compat)
ok - B4 spawn: no config at all -> own harness and no propagation side effects
ok - B5 spawn: an explicit per-spawn harness arg overrides config/secondmate-harness
ok - B6 spawn: an unverified resolved secondmate harness is refused (guard intact)
ok - B7 bootstrap sweep pushes, re-converges, and mirrors absence; never inherits secondmate-harness
ok - B8 bootstrap sweep propagates config even when the home's tracked files are already current
ok - B9 bootstrap sweep defers new inherited config until the home ignores it
ok - B10 bootstrap sweep with no inheritable config is a config no-op and still fast-forwards
ok - B11 bootstrap sweep surfaces config propagation failures
ok - B12 config-push propagates via shared live discovery, reports items, and does not fast-forward or nudge
ok - B13 config-push reports dirty, non-allowing, and invalid homes without failing warnings-only runs
ok - B14 config-push exits nonzero on real propagation errors
# all fm-secondmate-harness tests passed
```
</details>
<details>
<summary>Evidence: fm-secondmate-sync test output</summary>

```text
ok - T1 updated: a behind home fast-forwards to the primary's local HEAD
ok - T2 current: an already-current home is a no-op and reports no instruction change
ok - T3 dirty: an uncommitted home is skipped, its edit preserved
ok - T4 diverged: a home that is not an ancestor of the primary's HEAD is skipped
ok - T5 in-flight: a home on a feature branch is skipped, its work preserved
ok - T6 no fetch: the local-HEAD sync never invokes git fetch
ok - T7 sweep nudges on a real instruction change only, but still fast-forwards
ok - T8 bootstrap sweeps live homes, nudges only the running real-instruction-change secondmate
ok - T9 bootstrap surfaces a skipped dirty live secondmate home
ok - T10 spawn fast-forwards a secondmate worktree to the primary's local HEAD before launch
ok - T11 spawn warns when pre-launch sync is skipped
# all fm-secondmate-sync tests passed
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- `bash tests/fm-secondmate-harness.test.sh`
- `bash tests/fm-secondmate-sync.test.sh`
- `bash tests/fm-secondmate-harness.test.sh > /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KWCTDVJXV9958P12A1Q5CQE0/fm-secondmate-harness.test.out 2>&1`
- `bash tests/fm-secondmate-sync.test.sh > /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KWCTDVJXV9958P12A1Q5CQE0/fm-secondmate-sync.test.out 2>&1`
- <code>Manual end-to-end smoke check captured in `/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KWCTDVJXV9958P12A1Q5CQE0/manual-config-push-transcript.txt`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
