### PR TITLE
feat: support image attachments in X replies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -831,12 +831,14 @@ Dismiss tells the relay to drop the request so it stops re-offering it every pol
 Like `bin/fm-x-reply.sh`, the dismiss honors `FMX_DRY_RUN` (recording the would-be dismiss to `state/x-outbox/` instead of posting).
 The reply is **public on a shared bot**, so the skill enforces a strict version of section 9: no task ids, internal vocabulary, captain-private material, or secrets - outcomes only.
 Because public mention text can influence the composed reply, the skill never inlines it into a shell command; it passes the reply via `bin/fm-x-reply.sh <request_id> --text-file <path>` (or stdin), not as an interpolated argument.
+When the reply needs one outbound image, pass `--image <path>` to `bin/fm-x-reply.sh`; the helper reads the local file, detects the media type, base64-encodes the raw bytes, and sends the relay's optional `image` object without inlining image bytes into the shell command.
 
 **Completion follow-up.**
 When an actionable mention spawns a real task rather than completing in the answering turn, the immediate reply is an acknowledgement and the **outcome** is delivered later as a single follow-up reply.
 The skill links the spawned task to its originating mention right after dispatch with `bin/fm-x-link.sh <task-id> <request_id>`, which records `x_request=` and `x_request_ts=` (an epoch) in `state/<id>.meta`.
 When that task reaches a terminal state - PR merged, scout report written, local-only merge, or `failed` - firstmate posts one follow-up on the same completion wake it already handles (the merge `check:`/`done` signal of sections 7 and 8): it confirms the link with `bin/fm-x-followup.sh --check <id>` (which prints the `request_id` when a follow-up is due, and is silent when the task is not X-linked or the window has passed), composes a short public-safe outcome, and posts the single follow-up with `bin/fm-x-followup.sh <id> --text-file <path>` (or stdin).
 That helper posts through `bin/fm-x-reply.sh --followup` to the relay's `connector/followup` endpoint - which retains the request-to-tweet binding for a **24h window** after the initial answer and accepts exactly one thread-bound follow-up - and clears the link on success.
+When the completion follow-up needs one outbound image, pass `--image <path>` to `bin/fm-x-followup.sh`; it forwards the image to `bin/fm-x-reply.sh --followup` so the same relay image contract is used for the follow-up endpoint.
 A `failed` task still warrants an honest follow-up (the work did not pan out), not silence.
 Past the 24h window the relay would drop a late follow-up, so firstmate skips silently and clears the link.
 The follow-up is **one** reply and is held to the same public-safety bar as every other reply here: outcomes only, never task ids, internals, captain-private material, or secrets.
@@ -853,10 +855,12 @@ The skill answers concisely by default - one tweet, two at most - and never hand
 `bin/fm-x-reply.sh` handles length: a reply that fits one tweet is posted as-is; a genuinely long reply is auto-split, premium-independently, into a numbered `(k/n)` thread on word boundaries, each tweet within `FMX_X_REPLY_MAX_CHARS` (default 280) and capped at `FMX_X_THREAD_MAX` tweets (default 25).
 Those reply limits are optional environment or `.env` values, with explicit environment values winning over `.env`.
 A single tweet sends `{request_id, text}`; a thread additionally sends `texts` - the ordered chunks - which the relay posts as chained replies (`text` stays the first chunk so a relay that only reads `text` still posts the opener).
-This is text-only - never an image of prose.
+Do not use an image for prose; image attachments are only for actual visual artifacts such as generated illustrations, screenshots, or diagrams.
+When `--image <path>` accompanies a reply that auto-splits into a thread, the client includes `image` alongside `text` and `texts`, and the relay attaches that image to the first/opener tweet only while later chunks remain text-only.
 
 **Preview / dry-run.**
-Setting `FMX_DRY_RUN` (truthy, in the environment or `.env`) makes `bin/fm-x-reply.sh` compose and surface a reply without posting it: it records the full would-be POST body to `state/x-outbox/<request_id>.json` (`{request_id, text}` for one tweet, or `{request_id, text, texts}` for a thread; a `--followup` preview additionally carries an `endpoint` marker so it is self-describing, while the live body stays unchanged), prints a `DRY RUN` summary to stderr, and still echoes the `request_id` and exits 0.
+Setting `FMX_DRY_RUN` (truthy, in the environment or `.env`) makes `bin/fm-x-reply.sh` compose and surface a reply without posting it: it records the would-be POST body to `state/x-outbox/<request_id>.json` (`{request_id, text}` for one tweet, or `{request_id, text, texts}` for a thread; a `--followup` preview additionally carries an `endpoint` marker so it is self-describing, while the live body stays unchanged), prints a `DRY RUN` summary to stderr, and still echoes the `request_id` and exits 0.
+When `--image <path>` is present, the live POST body carries the real `image.data_base64`, but the dry-run outbox stores only a compact marker `{media_type, bytes, source_path}` so previews do not write multi-MB blobs.
 The same dry-run switch makes `bin/fm-x-dismiss.sh` record `{request_id, endpoint:"dismiss"}` to `state/x-outbox/<request_id>.json` instead of calling the relay, then echo the `request_id` and exit 0.
 Truthy means anything except unset, empty, `0`, `false`, `no`, or `off`; an explicit environment value wins over `.env`.
 These dry-run paths run before token and network checks, so previewing a composed answer or dismiss needs `jq` but does not need `FMX_PAIRING_TOKEN`, `curl`, or a live relay.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -831,7 +831,7 @@ Dismiss tells the relay to drop the request so it stops re-offering it every pol
 Like `bin/fm-x-reply.sh`, the dismiss honors `FMX_DRY_RUN` (recording the would-be dismiss to `state/x-outbox/` instead of posting).
 The reply is **public on a shared bot**, so the skill enforces a strict version of section 9: no task ids, internal vocabulary, captain-private material, or secrets - outcomes only.
 Because public mention text can influence the composed reply, the skill never inlines it into a shell command; it passes the reply via `bin/fm-x-reply.sh <request_id> --text-file <path>` (or stdin), not as an interpolated argument.
-When the reply needs one outbound image, pass `--image <path>` to `bin/fm-x-reply.sh`; the helper reads the local file, detects the media type, base64-encodes the raw bytes, and sends the relay's optional `image` object without inlining image bytes into the shell command.
+When the reply needs one outbound image, pass `--image <path>` to `bin/fm-x-reply.sh`; the helper reads one local PNG, JPEG, GIF, WebP, BMP, or TIFF, detects the media type, base64-encodes the raw bytes, and sends the relay's optional `image` object without inlining image bytes into the shell command.
 
 **Completion follow-up.**
 When an actionable mention spawns a real task rather than completing in the answering turn, the immediate reply is an acknowledgement and the **outcome** is delivered later as a single follow-up reply.

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ The token is standing authorization for those autonomous replies and eligible li
 Requests that finish immediately get one public-safe outcome reply.
 Requests that spawn longer-running work get an acknowledgement first, a task link in local state, and one completion follow-up within the relay's 24h window when that task lands, reports, or fails.
 It preserves parent-tweet context for conversational replies and dismisses pure acknowledgments at the relay without posting.
-Long replies stay text-only: the reply client splits them into bounded numbered threads when needed.
+Replies can attach one local image with `--image <path>` when there is a visual artifact; long replies split into bounded numbered threads when needed, with the image attached only to the opener tweet.
 When firstmate works on itself, spawn-time isolation checks and a primary-checkout tangle alarm keep the operating checkout on its default branch and stop a crewmate that did not land in a separate worktree.
 
 Full architecture - the supervision engine, worktree isolation, secondmates, project modes, optional X mode, fleet sync, and self-update - is in [docs/architecture.md](docs/architecture.md).

--- a/bin/fm-x-followup.sh
+++ b/bin/fm-x-followup.sh
@@ -14,8 +14,8 @@
 #     exit 1, silent               -> not linked, or window elapsed (link pruned)
 #
 # Post (after composing the reply to a file or stdin):
-#   fm-x-followup.sh <task-id> --text-file <path>
-#   fm-x-followup.sh <task-id> -
+#   fm-x-followup.sh <task-id> [--image <path>] --text-file <path>
+#   fm-x-followup.sh <task-id> [--image <path>] -
 #     Linked and within window: posts ONE follow-up via fm-x-reply.sh
 #       --followup, clears the link on success, echoes <request_id>, exit 0.
 #     Window elapsed: clears the link, posts nothing, exit 0 (silent skip).
@@ -25,6 +25,8 @@
 # Dry-run (FMX_DRY_RUN) flows through fm-x-reply.sh: the follow-up is recorded to
 # state/x-outbox/<request_id>.json instead of posted, and the link is cleared
 # exactly as a live post would, so the full loop runs end to end without a tweet.
+# With --image <path>, the follow-up carries one local image attachment; if the
+# reply text splits into a thread, the relay attaches the image to the opener.
 #
 # The 24h window is FMX_FOLLOWUP_MAX_AGE_SECS (default 86400). FMX_NOW_OVERRIDE
 # pins "now" for deterministic tests. Meta read/write lives in fm-x-lib.sh.
@@ -38,7 +40,25 @@ STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 . "$SCRIPT_DIR/fm-x-lib.sh"
 
 usage() {
-  echo "usage: fm-x-followup.sh --check <task-id> | <task-id> --text-file <path> | <task-id> -" >&2
+  echo "usage: fm-x-followup.sh --check <task-id> | <task-id> [--image <path>] --text-file <path> | <task-id> [--image <path>] -" >&2
+}
+
+help() {
+  cat <<'EOF'
+usage: fm-x-followup.sh --check <task-id>
+       fm-x-followup.sh <task-id> [--image <path>] --text-file <path>
+       fm-x-followup.sh <task-id> [--image <path>] -
+
+Post the single completion follow-up for an X-linked task and clear the link.
+
+Options:
+  --check          Print the request_id when a follow-up is due.
+  --image <path>   Attach one local image file; threaded replies attach it to the opener tweet.
+  --text-file <path>
+                   Read follow-up text from a file.
+  -                Read follow-up text from stdin.
+  --help           Show this help.
+EOF
 }
 
 MAX_AGE=${FMX_FOLLOWUP_MAX_AGE_SECS:-86400}
@@ -50,6 +70,10 @@ esac
 # source (--text-file <path> | -) deferred until after the link/window check so a
 # missing link never consumes stdin or posts.
 MODE=post
+case "${1:-}" in
+  --help|-h) help; exit 0 ;;
+esac
+
 if [ "${1:-}" = --check ]; then
   MODE=check
   ID=${2:-}
@@ -58,7 +82,23 @@ else
   ID=${1:-}
   if [ -z "$ID" ]; then usage; exit 2; fi
   shift
-  TS_ARGS=("$@")
+  TS_ARGS=()
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --image)
+        TS_ARGS+=("$1")
+        shift
+        if [ "$#" -lt 1 ] || [ -z "$1" ]; then
+          echo "fm-x-followup: missing --image path" >&2
+          usage
+          exit 2
+        fi
+        TS_ARGS+=("$1")
+        ;;
+      *) TS_ARGS+=("$1") ;;
+    esac
+    shift
+  done
   if [ "${#TS_ARGS[@]}" -lt 1 ]; then usage; exit 2; fi
 fi
 

--- a/bin/fm-x-lib.sh
+++ b/bin/fm-x-lib.sh
@@ -12,6 +12,12 @@
 #                                and FMX_THREAD_MAX (env wins over .env)
 #   fmx_auth_header_file       - write the bearer header to a 0600 temp file
 #   fmx_split_thread <max> <cap> - split a reply (stdin) into a numbered thread
+#   fmx_image_file_json <path> <client> - encode one outbound image attachment
+#   fmx_reply_payload_json <request_id> <chunks> <n> [image-json]
+#                                - build the answer/followup POST body
+#   fmx_reply_outbox_json <payload> <followup-0|1> [image-preview-json]
+#                                - build the dry-run record without image bytes
+#   fmx_post_json <endpoint> <payload> - POST JSON to the relay, printing HTTP code
 # Callers must have FM_HOME set before calling fmx_load_config.
 
 # Read the value of KEY from a .env-style file: last assignment wins; tolerates a
@@ -125,6 +131,131 @@ fmx_auth_header_file() {
   chmod 600 "$file" 2>/dev/null || { rm -f "$file"; return 1; }
   printf 'Authorization: Bearer %s\n' "$FMX_TOKEN" > "$file" || { rm -f "$file"; return 1; }
   printf '%s\n' "$file"
+}
+
+fmx_image_media_type_from_path() {
+  local path=$1 lower detected
+  lower=$(printf '%s' "$path" | tr '[:upper:]' '[:lower:]')
+  case "$lower" in
+    *.png) printf 'image/png\n' ;;
+    *.jpg|*.jpeg) printf 'image/jpeg\n' ;;
+    *.gif) printf 'image/gif\n' ;;
+    *.webp) printf 'image/webp\n' ;;
+    *.bmp) printf 'image/bmp\n' ;;
+    *.tif|*.tiff) printf 'image/tiff\n' ;;
+    *)
+      if command -v file >/dev/null 2>&1; then
+        detected=$(file --mime-type -b -- "$path" 2>/dev/null | tr '[:upper:]' '[:lower:]')
+        case "$detected" in
+          image/png|image/jpeg|image/pjpeg|image/gif|image/webp|image/bmp|image/tiff) printf '%s\n' "$detected" ;;
+          *) return 1 ;;
+        esac
+      else
+        return 1
+      fi
+      ;;
+  esac
+}
+
+# fmx_image_file_json <path> <client-name>: validate, encode, and describe a
+# local outbound image. Prints:
+#   {"payload":{"media_type":"...","data_base64":"..."},
+#    "preview":{"media_type":"...","bytes":123,"source_path":"..."}}
+# The payload object is what the relay receives. The preview object is safe for
+# FMX_DRY_RUN outbox records and deliberately omits the base64 bytes.
+fmx_image_file_json() {
+  local path=$1 client=${2:-fm-x-reply} media_type bytes data
+  if [ ! -e "$path" ]; then
+    echo "$client: image file does not exist: $path" >&2
+    return 1
+  fi
+  if [ ! -f "$path" ]; then
+    echo "$client: image path is not a regular file: $path" >&2
+    return 1
+  fi
+  if [ ! -r "$path" ]; then
+    echo "$client: image file is not readable: $path" >&2
+    return 1
+  fi
+  media_type=$(fmx_image_media_type_from_path "$path") || {
+    echo "$client: unsupported image media type for: $path" >&2
+    return 1
+  }
+  command -v base64 >/dev/null 2>&1 || {
+    echo "$client: base64 not found" >&2
+    return 1
+  }
+  bytes=$(wc -c < "$path" | tr -d '[:space:]') || {
+    echo "$client: cannot stat image file: $path" >&2
+    return 1
+  }
+  data=$(base64 < "$path" | tr -d '\n\r') || {
+    echo "$client: cannot read image file: $path" >&2
+    return 1
+  }
+  if [ -z "$data" ]; then
+    echo "$client: image file is empty: $path" >&2
+    return 1
+  fi
+  jq -cn \
+    --arg media_type "$media_type" \
+    --arg data_base64 "$data" \
+    --arg source_path "$path" \
+    --argjson bytes "$bytes" \
+    '{payload:{media_type:$media_type,data_base64:$data_base64},preview:{media_type:$media_type,bytes:$bytes,source_path:$source_path}}'
+}
+
+fmx_reply_payload_json() {
+  local rid=$1 chunks=$2 n=$3 image_json=${4:-}
+  if [ -n "$image_json" ]; then
+    if [ "$n" -le 1 ]; then
+      printf '%s' "$chunks" | jq -c --arg rid "$rid" --argjson image "$image_json" \
+        '{request_id:$rid, text:(.[0] // ""), image:$image}'
+    else
+      printf '%s' "$chunks" | jq -c --arg rid "$rid" --argjson image "$image_json" \
+        '{request_id:$rid, text:.[0], texts:., image:$image}'
+    fi
+  else
+    if [ "$n" -le 1 ]; then
+      printf '%s' "$chunks" | jq -c --arg rid "$rid" '{request_id:$rid, text:(.[0] // "")}'
+    else
+      printf '%s' "$chunks" | jq -c --arg rid "$rid" '{request_id:$rid, text:.[0], texts:.}'
+    fi
+  fi
+}
+
+fmx_reply_outbox_json() {
+  local payload=$1 followup=$2 image_preview_json=${3:-}
+  if [ -n "$image_preview_json" ]; then
+    if [ "$followup" = 1 ]; then
+      printf '%s' "$payload" | jq -c --argjson image "$image_preview_json" \
+        '.image = $image | . + {endpoint:"followup"}'
+    else
+      printf '%s' "$payload" | jq -c --argjson image "$image_preview_json" '.image = $image'
+    fi
+  else
+    if [ "$followup" = 1 ]; then
+      printf '%s' "$payload" | jq -c '. + {endpoint:"followup"}'
+    else
+      printf '%s' "$payload"
+    fi
+  fi
+}
+
+fmx_post_json() {
+  local endpoint=$1 payload=$2 auth_header_file code rc
+  command -v curl >/dev/null 2>&1 || return 127
+  auth_header_file=$(fmx_auth_header_file) || return 3
+  code=$(curl -m 10 -s -o /dev/null -w '%{http_code}' \
+    -X POST \
+    -H "@$auth_header_file" \
+    -H 'Content-Type: application/json' \
+    --data "$payload" \
+    "$FMX_RELAY/connector/$endpoint" 2>/dev/null)
+  rc=$?
+  rm -f "$auth_header_file"
+  [ "$rc" = 0 ] || return 4
+  printf '%s\n' "$code"
 }
 
 # --- task <-> X-request link (state/<id>.meta backed) -----------------------

--- a/bin/fm-x-lib.sh
+++ b/bin/fm-x-lib.sh
@@ -12,12 +12,13 @@
 #                                and FMX_THREAD_MAX (env wins over .env)
 #   fmx_auth_header_file       - write the bearer header to a 0600 temp file
 #   fmx_split_thread <max> <cap> - split a reply (stdin) into a numbered thread
-#   fmx_image_file_json <path> <client> - encode one outbound image attachment
-#   fmx_reply_payload_json <request_id> <chunks> <n> [image-json]
+#   fmx_image_payload_file <path> <client> <payload-file> - encode one image
+#                                attachment to a JSON file and print preview JSON
+#   fmx_reply_payload_json <request_id> <chunks> <n> [image-json-file]
 #                                - build the answer/followup POST body
-#   fmx_reply_outbox_json <payload> <followup-0|1> [image-preview-json]
+#   fmx_reply_outbox_json <request_id> <chunks> <n> <followup-0|1> [image-preview-json]
 #                                - build the dry-run record without image bytes
-#   fmx_post_json <endpoint> <payload> - POST JSON to the relay, printing HTTP code
+#   fmx_post_json <endpoint> <payload-file> - POST JSON to the relay, printing HTTP code
 # Callers must have FM_HOME set before calling fmx_load_config.
 
 # Read the value of KEY from a .env-style file: last assignment wins; tolerates a
@@ -157,14 +158,15 @@ fmx_image_media_type_from_path() {
   esac
 }
 
-# fmx_image_file_json <path> <client-name>: validate, encode, and describe a
-# local outbound image. Prints:
-#   {"payload":{"media_type":"...","data_base64":"..."},
-#    "preview":{"media_type":"...","bytes":123,"source_path":"..."}}
-# The payload object is what the relay receives. The preview object is safe for
-# FMX_DRY_RUN outbox records and deliberately omits the base64 bytes.
-fmx_image_file_json() {
-  local path=$1 client=${2:-fm-x-reply} media_type bytes data
+# fmx_image_payload_file <path> <client-name> <payload-file>: validate and encode
+# a local outbound image. The relay payload object is written to <payload-file>.
+# The compact preview object is printed for FMX_DRY_RUN outbox records.
+fmx_image_payload_file() {
+  local path=$1 client=${2:-fm-x-reply} payload_file=${3:-} media_type bytes
+  if [ -z "$payload_file" ]; then
+    echo "$client: missing image payload destination" >&2
+    return 1
+  fi
   if [ ! -e "$path" ]; then
     echo "$client: image file does not exist: $path" >&2
     return 1
@@ -189,31 +191,33 @@ fmx_image_file_json() {
     echo "$client: cannot stat image file: $path" >&2
     return 1
   }
-  data=$(base64 < "$path" | tr -d '\n\r') || {
-    echo "$client: cannot read image file: $path" >&2
-    return 1
-  }
-  if [ -z "$data" ]; then
+  if [ "$bytes" = 0 ]; then
     echo "$client: image file is empty: $path" >&2
+    return 1
+  fi
+  if ! (set -o pipefail; base64 < "$path" | tr -d '\n\r' \
+    | jq -Rsc --arg media_type "$media_type" \
+      '{media_type:$media_type,data_base64:.}' > "$payload_file"); then
+    rm -f "$payload_file"
+    echo "$client: cannot read image file: $path" >&2
     return 1
   fi
   jq -cn \
     --arg media_type "$media_type" \
-    --arg data_base64 "$data" \
     --arg source_path "$path" \
     --argjson bytes "$bytes" \
-    '{payload:{media_type:$media_type,data_base64:$data_base64},preview:{media_type:$media_type,bytes:$bytes,source_path:$source_path}}'
+    '{media_type:$media_type,bytes:$bytes,source_path:$source_path}'
 }
 
 fmx_reply_payload_json() {
-  local rid=$1 chunks=$2 n=$3 image_json=${4:-}
-  if [ -n "$image_json" ]; then
+  local rid=$1 chunks=$2 n=$3 image_json_file=${4:-}
+  if [ -n "$image_json_file" ]; then
     if [ "$n" -le 1 ]; then
-      printf '%s' "$chunks" | jq -c --arg rid "$rid" --argjson image "$image_json" \
-        '{request_id:$rid, text:(.[0] // ""), image:$image}'
+      printf '%s' "$chunks" | jq -c --arg rid "$rid" --slurpfile image "$image_json_file" \
+        '{request_id:$rid, text:(.[0] // ""), image:$image[0]}'
     else
-      printf '%s' "$chunks" | jq -c --arg rid "$rid" --argjson image "$image_json" \
-        '{request_id:$rid, text:.[0], texts:., image:$image}'
+      printf '%s' "$chunks" | jq -c --arg rid "$rid" --slurpfile image "$image_json_file" \
+        '{request_id:$rid, text:.[0], texts:., image:$image[0]}'
     fi
   else
     if [ "$n" -le 1 ]; then
@@ -225,38 +229,63 @@ fmx_reply_payload_json() {
 }
 
 fmx_reply_outbox_json() {
-  local payload=$1 followup=$2 image_preview_json=${3:-}
+  local rid=$1 chunks=$2 n=$3 followup=$4 image_preview_json=${5:-}
   if [ -n "$image_preview_json" ]; then
     if [ "$followup" = 1 ]; then
-      printf '%s' "$payload" | jq -c --argjson image "$image_preview_json" \
-        '.image = $image | . + {endpoint:"followup"}'
+      if [ "$n" -le 1 ]; then
+        printf '%s' "$chunks" | jq -c --arg rid "$rid" --argjson image "$image_preview_json" \
+          '{request_id:$rid, text:(.[0] // ""), image:$image, endpoint:"followup"}'
+      else
+        printf '%s' "$chunks" | jq -c --arg rid "$rid" --argjson image "$image_preview_json" \
+          '{request_id:$rid, text:.[0], texts:., image:$image, endpoint:"followup"}'
+      fi
     else
-      printf '%s' "$payload" | jq -c --argjson image "$image_preview_json" '.image = $image'
+      if [ "$n" -le 1 ]; then
+        printf '%s' "$chunks" | jq -c --arg rid "$rid" --argjson image "$image_preview_json" \
+          '{request_id:$rid, text:(.[0] // ""), image:$image}'
+      else
+        printf '%s' "$chunks" | jq -c --arg rid "$rid" --argjson image "$image_preview_json" \
+          '{request_id:$rid, text:.[0], texts:., image:$image}'
+      fi
     fi
   else
     if [ "$followup" = 1 ]; then
-      printf '%s' "$payload" | jq -c '. + {endpoint:"followup"}'
+      if [ "$n" -le 1 ]; then
+        printf '%s' "$chunks" | jq -c --arg rid "$rid" \
+          '{request_id:$rid, text:(.[0] // ""), endpoint:"followup"}'
+      else
+        printf '%s' "$chunks" | jq -c --arg rid "$rid" \
+          '{request_id:$rid, text:.[0], texts:., endpoint:"followup"}'
+      fi
     else
-      printf '%s' "$payload"
+      if [ "$n" -le 1 ]; then
+        printf '%s' "$chunks" | jq -c --arg rid "$rid" '{request_id:$rid, text:(.[0] // "")}'
+      else
+        printf '%s' "$chunks" | jq -c --arg rid "$rid" '{request_id:$rid, text:.[0], texts:.}'
+      fi
     fi
   fi
 }
 
-fmx_post_json() {
-  local endpoint=$1 payload=$2 auth_header_file code rc
+fmx_post_json() (
+  local endpoint=$1 payload_file=$2 auth_header_file code rc
   command -v curl >/dev/null 2>&1 || return 127
+  [ -r "$payload_file" ] || return 2
   auth_header_file=$(fmx_auth_header_file) || return 3
+  trap 'rm -f "$auth_header_file"' EXIT
+  trap 'rm -f "$auth_header_file"; exit 143' HUP INT TERM
   code=$(curl -m 10 -s -o /dev/null -w '%{http_code}' \
     -X POST \
     -H "@$auth_header_file" \
     -H 'Content-Type: application/json' \
-    --data "$payload" \
+    --data-binary "@$payload_file" \
     "$FMX_RELAY/connector/$endpoint" 2>/dev/null)
   rc=$?
   rm -f "$auth_header_file"
+  trap - EXIT HUP INT TERM
   [ "$rc" = 0 ] || return 4
   printf '%s\n' "$code"
-}
+)
 
 # --- task <-> X-request link (state/<id>.meta backed) -----------------------
 #

--- a/bin/fm-x-reply.sh
+++ b/bin/fm-x-reply.sh
@@ -44,13 +44,13 @@
 # Authorization: Bearer <token>.
 #
 # Preview / dry-run: with FMX_DRY_RUN set (truthy), the reply is NOT posted.
-# Instead the full would-be POST body ({request_id, text}, or {request_id, text,
-# texts} for a thread) is recorded to state/x-outbox/<request_id>.json and a
-# "DRY RUN" summary is printed to stderr; stdout still echoes the request_id and
-# the exit is 0, so the loop runs end to end without a public tweet. A follow-up
+# Instead the would-be POST body ({request_id, text}, or {request_id, text,
+# texts} for a thread) is recorded to state/x-outbox/<request_id>.json and a "DRY
+# RUN" summary is printed to stderr; stdout still echoes the request_id and the
+# exit is 0, so the loop runs end to end without a public tweet. A follow-up
 # dry-run additionally carries an "endpoint":"followup" marker in the recorded
 # body so a preview is self-describing; the live POST body is unchanged. With
-# --image, the dry-run record includes a compact image marker
+# --image, the dry-run record replaces image bytes with a compact image marker
 # {media_type,bytes,source_path}, not the base64 bytes. Dry-run needs neither a
 # token nor the relay.
 set -u
@@ -142,7 +142,7 @@ set -- "${ARGS[@]}"
 case "$1" in
   --text-file)
     if [ "$#" -lt 2 ]; then
-      echo "usage: fm-x-reply.sh <request_id> [--followup] --text-file <path>" >&2
+      echo "usage: fm-x-reply.sh <request_id> [--followup] [--image <path>] --text-file <path>" >&2
       exit 2
     fi
     TEXT=$(cat -- "$2") || { echo "fm-x-reply: cannot read text file: $2" >&2; exit 1; }

--- a/bin/fm-x-reply.sh
+++ b/bin/fm-x-reply.sh
@@ -70,11 +70,11 @@ cleanup_tmp_files() {
 }
 trap cleanup_tmp_files EXIT
 
-reply_tmp_file() {
-  local file
+reply_make_tmp_file() {
+  local var_name=$1 file
   file=$(mktemp "${TMPDIR:-/tmp}/fm-x-reply.XXXXXX") || return 1
   TMP_FILES+=("$file")
-  printf '%s\n' "$file"
+  printf -v "$var_name" '%s' "$file"
 }
 
 usage() {
@@ -181,7 +181,7 @@ IMAGE_PAYLOAD_FILE=
 IMAGE_PREVIEW=
 PAYLOAD_FILE=
 if [ -n "$IMAGE_PATH" ]; then
-  IMAGE_PAYLOAD_FILE=$(reply_tmp_file) || {
+  reply_make_tmp_file IMAGE_PAYLOAD_FILE || {
     echo "fm-x-reply: cannot create image payload temp file" >&2; exit 1; }
   IMAGE_PREVIEW=$(fmx_image_payload_file "$IMAGE_PATH" fm-x-reply "$IMAGE_PAYLOAD_FILE") || exit 1
   printf '%s' "$IMAGE_PREVIEW" | jq -e . >/dev/null 2>&1 || {
@@ -203,7 +203,7 @@ case "$N" in ''|*[!0-9]*) echo "fm-x-reply: failed to split reply into a thread"
 # JSON-escaped. A single tweet sends {request_id, text}; a thread also sends
 # {texts: [...]} for the relay to post as chained replies. When image is present
 # on a thread, the relay attaches it to the first chunk only.
-PAYLOAD_FILE=$(reply_tmp_file) || {
+reply_make_tmp_file PAYLOAD_FILE || {
   echo "fm-x-reply: cannot create request payload temp file" >&2; exit 1; }
 if [ -n "$IMAGE_PAYLOAD_FILE" ]; then
   fmx_reply_payload_json "$REQ" "$CHUNKS" "$N" "$IMAGE_PAYLOAD_FILE" > "$PAYLOAD_FILE" || {

--- a/bin/fm-x-reply.sh
+++ b/bin/fm-x-reply.sh
@@ -62,6 +62,21 @@ STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 # shellcheck source=bin/fm-x-lib.sh
 . "$SCRIPT_DIR/fm-x-lib.sh"
 
+TMP_FILES=()
+cleanup_tmp_files() {
+  if [ "${#TMP_FILES[@]}" -gt 0 ]; then
+    rm -f "${TMP_FILES[@]}"
+  fi
+}
+trap cleanup_tmp_files EXIT
+
+reply_tmp_file() {
+  local file
+  file=$(mktemp "${TMPDIR:-/tmp}/fm-x-reply.XXXXXX") || return 1
+  TMP_FILES+=("$file")
+  printf '%s\n' "$file"
+}
+
 usage() {
   echo "usage: fm-x-reply.sh <request_id> [--followup] [--image <path>] <text> | [--followup] [--image <path>] --text-file <path> | [--followup] [--image <path>] -" >&2
 }
@@ -162,13 +177,14 @@ esac
 
 command -v jq >/dev/null 2>&1 || { echo "fm-x-reply: jq not found" >&2; exit 1; }
 
-IMAGE_PAYLOAD=
+IMAGE_PAYLOAD_FILE=
 IMAGE_PREVIEW=
+PAYLOAD_FILE=
 if [ -n "$IMAGE_PATH" ]; then
-  IMAGE_INFO=$(fmx_image_file_json "$IMAGE_PATH" fm-x-reply) || exit 1
-  IMAGE_PAYLOAD=$(printf '%s' "$IMAGE_INFO" | jq -c '.payload') || {
-    echo "fm-x-reply: failed to build image payload" >&2; exit 1; }
-  IMAGE_PREVIEW=$(printf '%s' "$IMAGE_INFO" | jq -c '.preview') || {
+  IMAGE_PAYLOAD_FILE=$(reply_tmp_file) || {
+    echo "fm-x-reply: cannot create image payload temp file" >&2; exit 1; }
+  IMAGE_PREVIEW=$(fmx_image_payload_file "$IMAGE_PATH" fm-x-reply "$IMAGE_PAYLOAD_FILE") || exit 1
+  printf '%s' "$IMAGE_PREVIEW" | jq -e . >/dev/null 2>&1 || {
     echo "fm-x-reply: failed to build image preview" >&2; exit 1; }
 fi
 
@@ -187,8 +203,15 @@ case "$N" in ''|*[!0-9]*) echo "fm-x-reply: failed to split reply into a thread"
 # JSON-escaped. A single tweet sends {request_id, text}; a thread also sends
 # {texts: [...]} for the relay to post as chained replies. When image is present
 # on a thread, the relay attaches it to the first chunk only.
-PAYLOAD=$(fmx_reply_payload_json "$REQ" "$CHUNKS" "$N" "$IMAGE_PAYLOAD") || {
-  echo "fm-x-reply: failed to build request payload" >&2; exit 1; }
+PAYLOAD_FILE=$(reply_tmp_file) || {
+  echo "fm-x-reply: cannot create request payload temp file" >&2; exit 1; }
+if [ -n "$IMAGE_PAYLOAD_FILE" ]; then
+  fmx_reply_payload_json "$REQ" "$CHUNKS" "$N" "$IMAGE_PAYLOAD_FILE" > "$PAYLOAD_FILE" || {
+    echo "fm-x-reply: failed to build request payload" >&2; exit 1; }
+else
+  fmx_reply_payload_json "$REQ" "$CHUNKS" "$N" > "$PAYLOAD_FILE" || {
+    echo "fm-x-reply: failed to build request payload" >&2; exit 1; }
+fi
 
 # Preview / dry-run: surface what we WOULD post and stop, without auth or network.
 if [ -n "$FMX_DRY" ]; then
@@ -201,7 +224,7 @@ if [ -n "$FMX_DRY" ]; then
   # The recorded body is the would-be POST body, except image bytes are replaced
   # by a compact marker. A follow-up preview additionally carries an
   # "endpoint":"followup" marker so an outbox record is self-describing.
-  OUTREC=$(fmx_reply_outbox_json "$PAYLOAD" "$FOLLOWUP" "$IMAGE_PREVIEW") || {
+  OUTREC=$(fmx_reply_outbox_json "$REQ" "$CHUNKS" "$N" "$FOLLOWUP" "$IMAGE_PREVIEW") || {
     echo "fm-x-reply: failed to build dry-run outbox record" >&2; exit 1; }
   printf '%s\n' "$OUTREC" > "$outbox_file" 2>/dev/null || {
     echo "fm-x-reply: cannot write dry-run outbox: $outbox_file" >&2
@@ -223,7 +246,7 @@ if [ -z "$FMX_TOKEN" ]; then
   echo "fm-x-reply: X mode not configured (no FMX_PAIRING_TOKEN)" >&2
   exit 1
 fi
-code=$(fmx_post_json "$ENDPOINT" "$PAYLOAD")
+code=$(fmx_post_json "$ENDPOINT" "$PAYLOAD_FILE")
 post_rc=$?
 case "$post_rc" in
   0) : ;;

--- a/bin/fm-x-reply.sh
+++ b/bin/fm-x-reply.sh
@@ -1,15 +1,20 @@
 #!/usr/bin/env bash
 # Post firstmate's composed answer back to the relay for a pending X mention.
 #
-# Usage: fm-x-reply.sh <request_id> <text>
-#        fm-x-reply.sh <request_id> --text-file <path>   # read the reply from a file
-#        fm-x-reply.sh <request_id> -                    # read the reply from stdin
-#        fm-x-reply.sh <request_id> --followup ...       # post a completion follow-up
+# Usage: fm-x-reply.sh <request_id> [--image <path>] <text>
+#        fm-x-reply.sh <request_id> [--image <path>] --text-file <path>
+#        fm-x-reply.sh <request_id> [--image <path>] -
+#        fm-x-reply.sh <request_id> --followup [--image <path>] ...
 #
 # The --text-file / stdin forms exist so a caller never has to inline reply text
 # (which may be influenced by a public mention) into a shell command, where shell
 # expansion or quote-breakage could bite. fmx-respond uses them; the positional
 # <text> form is kept for back-compat and tests.
+#
+# Optional --image <path> attaches one local image file to the answer or followup
+# POST body as {media_type,data_base64}. Supported extension mapping includes
+# PNG, JPEG, GIF, WebP, BMP, and TIFF. If long text becomes a thread, the relay
+# attaches that image to the first/opener tweet only.
 #
 # Two endpoints, one client. By default the reply is the single answer to a
 # mention, POSTed to $RELAY/connector/answer. With --followup it is instead the
@@ -31,7 +36,8 @@
 # sends {request_id, text}; a thread sends {request_id, text, texts:[chunk,...]}
 # where `texts` is the ordered "(k/n)" chunks for the relay to post as chained
 # replies, and `text` is the first chunk so a relay that only reads `text` still
-# posts the opener. At most FMX_X_THREAD_MAX tweets (default 25) are produced.
+# posts the opener. If --image is present, the relay attaches it to this opener.
+# At most FMX_X_THREAD_MAX tweets (default 25) are produced.
 #
 # Live post config (home .env, FMX_ENV_FILE, or env): FMX_PAIRING_TOKEN
 # (required), FMX_RELAY_URL (default https://myfirstmate.io). Auth:
@@ -43,8 +49,10 @@
 # "DRY RUN" summary is printed to stderr; stdout still echoes the request_id and
 # the exit is 0, so the loop runs end to end without a public tweet. A follow-up
 # dry-run additionally carries an "endpoint":"followup" marker in the recorded
-# body so a preview is self-describing; the live POST body is unchanged. Dry-run
-# needs neither a token nor the relay.
+# body so a preview is self-describing; the live POST body is unchanged. With
+# --image, the dry-run record includes a compact image marker
+# {media_type,bytes,source_path}, not the base64 bytes. Dry-run needs neither a
+# token nor the relay.
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -55,8 +63,30 @@ STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 . "$SCRIPT_DIR/fm-x-lib.sh"
 
 usage() {
-  echo "usage: fm-x-reply.sh <request_id> [--followup] <text> | [--followup] --text-file <path> | [--followup] -" >&2
+  echo "usage: fm-x-reply.sh <request_id> [--followup] [--image <path>] <text> | [--followup] [--image <path>] --text-file <path> | [--followup] [--image <path>] -" >&2
 }
+
+help() {
+  cat <<'EOF'
+usage: fm-x-reply.sh <request_id> [--followup] [--image <path>] <text>
+       fm-x-reply.sh <request_id> [--followup] [--image <path>] --text-file <path>
+       fm-x-reply.sh <request_id> [--followup] [--image <path>] -
+
+Post a public-safe X answer to the relay, or a completion follow-up with --followup.
+
+Options:
+  --followup       POST to /connector/followup instead of /connector/answer.
+  --image <path>   Attach one local image file; threaded replies attach it to the opener tweet.
+  --text-file <path>
+                   Read reply text from a file instead of the command line.
+  -                Read reply text from stdin.
+  --help           Show this help.
+EOF
+}
+
+case "${1:-}" in
+  --help|-h) help; exit 0 ;;
+esac
 
 REQ=${1:-}
 if [ -z "$REQ" ]; then
@@ -67,13 +97,23 @@ shift
 
 # --followup selects the relay's /connector/followup endpoint instead of
 # /connector/answer; it may appear anywhere after the request_id, so strip it out
-# and process the remaining args (the text source) exactly as the answer path
-# always has.
+# along with --image and process the remaining args (the text source) exactly as
+# the answer path always has.
 FOLLOWUP=0
+IMAGE_PATH=
 ARGS=()
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --followup) FOLLOWUP=1 ;;
+    --image)
+      shift
+      if [ "$#" -lt 1 ] || [ -z "$1" ]; then
+        echo "fm-x-reply: missing --image path" >&2
+        usage
+        exit 2
+      fi
+      IMAGE_PATH=$1
+      ;;
     *) ARGS+=("$1") ;;
   esac
   shift
@@ -122,6 +162,16 @@ esac
 
 command -v jq >/dev/null 2>&1 || { echo "fm-x-reply: jq not found" >&2; exit 1; }
 
+IMAGE_PAYLOAD=
+IMAGE_PREVIEW=
+if [ -n "$IMAGE_PATH" ]; then
+  IMAGE_INFO=$(fmx_image_file_json "$IMAGE_PATH" fm-x-reply) || exit 1
+  IMAGE_PAYLOAD=$(printf '%s' "$IMAGE_INFO" | jq -c '.payload') || {
+    echo "fm-x-reply: failed to build image payload" >&2; exit 1; }
+  IMAGE_PREVIEW=$(printf '%s' "$IMAGE_INFO" | jq -c '.preview') || {
+    echo "fm-x-reply: failed to build image preview" >&2; exit 1; }
+fi
+
 # Auto-split a long reply into a numbered thread (premium-independent: each tweet
 # stays within the per-tweet budget). A reply that fits in one tweet stays a
 # single, unnumbered tweet.
@@ -133,18 +183,12 @@ N=$(printf '%s' "$CHUNKS" | jq 'length' 2>/dev/null) || N=
 case "$N" in ''|*[!0-9]*) echo "fm-x-reply: failed to split reply into a thread" >&2; exit 1 ;; esac
 [ "$N" -gt 0 ] || { echo "fm-x-reply: empty reply text" >&2; exit 2; }
 
-# Build the body with jq so the text is correctly JSON-escaped. This is exactly
-# what would be POSTed (and, in dry-run, exactly what we record/preview). A
-# single tweet sends {request_id, text}; a thread also sends {texts: [...]} (the
-# ordered chunks) for the relay to post as chained replies, keeping `text` as the
-# first chunk so a relay that only understands `text` still posts the opener.
-if [ "$N" -le 1 ]; then
-  PAYLOAD=$(printf '%s' "$CHUNKS" | jq -c --arg rid "$REQ" '{request_id:$rid, text:(.[0] // "")}') || {
-    echo "fm-x-reply: failed to build request payload" >&2; exit 1; }
-else
-  PAYLOAD=$(printf '%s' "$CHUNKS" | jq -c --arg rid "$REQ" '{request_id:$rid, text:.[0], texts:.}') || {
-    echo "fm-x-reply: failed to build request payload" >&2; exit 1; }
-fi
+# Build the body with jq so the text and optional image object are correctly
+# JSON-escaped. A single tweet sends {request_id, text}; a thread also sends
+# {texts: [...]} for the relay to post as chained replies. When image is present
+# on a thread, the relay attaches it to the first chunk only.
+PAYLOAD=$(fmx_reply_payload_json "$REQ" "$CHUNKS" "$N" "$IMAGE_PAYLOAD") || {
+  echo "fm-x-reply: failed to build request payload" >&2; exit 1; }
 
 # Preview / dry-run: surface what we WOULD post and stop, without auth or network.
 if [ -n "$FMX_DRY" ]; then
@@ -154,15 +198,11 @@ if [ -n "$FMX_DRY" ]; then
     echo "fm-x-reply: cannot create dry-run outbox: $outbox_dir" >&2
     exit 1
   }
-  # The recorded body is the would-be POST body; a follow-up preview additionally
-  # carries an "endpoint":"followup" marker so an outbox record is self-describing
-  # (the live POST body stays exactly {request_id, text[, texts]} for both paths).
-  if [ "$FOLLOWUP" = 1 ]; then
-    OUTREC=$(printf '%s' "$PAYLOAD" | jq -c '. + {endpoint:"followup"}') || {
-      echo "fm-x-reply: failed to build dry-run outbox record" >&2; exit 1; }
-  else
-    OUTREC=$PAYLOAD
-  fi
+  # The recorded body is the would-be POST body, except image bytes are replaced
+  # by a compact marker. A follow-up preview additionally carries an
+  # "endpoint":"followup" marker so an outbox record is self-describing.
+  OUTREC=$(fmx_reply_outbox_json "$PAYLOAD" "$FOLLOWUP" "$IMAGE_PREVIEW") || {
+    echo "fm-x-reply: failed to build dry-run outbox record" >&2; exit 1; }
   printf '%s\n' "$OUTREC" > "$outbox_file" 2>/dev/null || {
     echo "fm-x-reply: cannot write dry-run outbox: $outbox_file" >&2
     exit 1
@@ -183,22 +223,14 @@ if [ -z "$FMX_TOKEN" ]; then
   echo "fm-x-reply: X mode not configured (no FMX_PAIRING_TOKEN)" >&2
   exit 1
 fi
-command -v curl >/dev/null 2>&1 || { echo "fm-x-reply: curl not found" >&2; exit 1; }
-AUTH_HEADER_FILE=$(fmx_auth_header_file) || {
-  echo "fm-x-reply: invalid FMX_PAIRING_TOKEN" >&2
-  exit 1
-}
-trap 'rm -f "$AUTH_HEADER_FILE"' EXIT
-
-code=$(curl -m 10 -s -o /dev/null -w '%{http_code}' \
-  -X POST \
-  -H "@$AUTH_HEADER_FILE" \
-  -H 'Content-Type: application/json' \
-  --data "$PAYLOAD" \
-  "$FMX_RELAY/connector/$ENDPOINT" 2>/dev/null) || {
-  echo "fm-x-reply: request to relay failed" >&2
-  exit 1
-}
+code=$(fmx_post_json "$ENDPOINT" "$PAYLOAD")
+post_rc=$?
+case "$post_rc" in
+  0) : ;;
+  127) echo "fm-x-reply: curl not found" >&2; exit 1 ;;
+  3) echo "fm-x-reply: invalid FMX_PAIRING_TOKEN" >&2; exit 1 ;;
+  *) echo "fm-x-reply: request to relay failed" >&2; exit 1 ;;
+esac
 
 case "$code" in
   2[0-9][0-9]) printf '%s\n' "$REQ" ;;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -119,13 +119,17 @@ The relay uses owner-only routing: a mention delivered to a home is from that ho
 On bootstrap, that token creates two local artifacts: `state/x-watch.check.sh`, which performs one bounded relay poll through `bin/fm-x-poll.sh`, and `config/x-mode.env`, which sets `FM_CHECK_INTERVAL=30` for watcher arms in that home.
 Without the token, bootstrap removes those artifacts on opt-out and otherwise stays silent, so non-X users see no behavior change.
 Pending mentions are stored as `state/x-inbox/<request_id>.json`; the `fmx-respond` agent-only skill drains that inbox, uses `in_reply_to` parent-tweet context for conversational continuity, classifies each mention as an actionable request, question, or pure acknowledgment, and submits public-safe replies through `bin/fm-x-reply.sh`.
+When a reply has a real visual artifact, `--image <path>` attaches one local PNG, JPEG, GIF, WebP, BMP, or TIFF to the relay's optional `{media_type,data_base64}` image object.
 Actionable reversible requests run through firstmate's normal intake, backlog, dispatch, investigation, or ship lifecycle.
 Work that completes in the answering turn gets one outcome reply.
 Work that spawns a longer-running task gets an acknowledgement reply first; `bin/fm-x-link.sh` records `x_request=` and `x_request_ts=` in that task's `state/<id>.meta`, and the terminal completion wake later uses `bin/fm-x-followup.sh` to post one public-safe follow-up through the relay's `connector/followup` endpoint.
+The follow-up helper forwards `--image <path>` to the same reply client when the completion outcome needs an image.
 The follow-up is bounded by a local 24h window, clears the link after success or expiry, and is skipped for tasks that did not originate from an X mention.
 Pure acknowledgments or mentions with nothing to answer are dismissed through `bin/fm-x-dismiss.sh`, which calls the relay's `connector/dismiss` endpoint and posts no text, then the local inbox file is cleared.
-Concise replies stay single unnumbered tweets; genuinely long replies are split by the client into bounded, numbered text threads on word boundaries, with `texts` carrying the ordered chunks for the relay.
-For preview testing, `FMX_DRY_RUN` makes `fm-x-reply.sh` and `fm-x-dismiss.sh` skip the public post or dismiss call and record the full would-be payload under `state/x-outbox/`, including `texts` when the reply would be a thread and an `endpoint` marker when the preview is a completion follow-up or dismiss, while the rest of the poll -> compose -> would-post loop still succeeds.
+Concise replies stay single unnumbered tweets; genuinely long replies are split by the client into bounded, numbered threads on word boundaries, with `texts` carrying the ordered chunks for the relay.
+If an image is attached to a split reply, the relay puts it on the first/opener tweet only and leaves later chunks text-only.
+For preview testing, `FMX_DRY_RUN` makes `fm-x-reply.sh` and `fm-x-dismiss.sh` skip the public post or dismiss call and record the would-be payload under `state/x-outbox/`, including `texts` when the reply would be a thread and an `endpoint` marker when the preview is a completion follow-up or dismiss, while the rest of the poll -> compose -> would-post loop still succeeds.
+Attached images are recorded as compact `{media_type, bytes, source_path}` metadata in dry-run instead of base64 bytes.
 The watcher, wake queue, arm wrapper, and afk daemon are unchanged; X mode is layered on top through the existing check mechanism.
 
 ## Project memory belongs to projects

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -125,7 +125,7 @@ Pure acknowledgments or mentions with nothing to answer are dismissed through `b
 Dismiss sends `POST /connector/dismiss` with `{request_id}`, posts no text, and tells the relay to drop the request instead of re-offering it or falling back to an offline auto-reply.
 Relay auth or config problems are reported once as `x-mode-error ...` until recovery.
 Live replies are posted by `bin/fm-x-reply.sh`, which sends `POST /connector/answer` with `{request_id,text}` for one-tweet replies.
-Add `--image <path>` to attach one local image as the relay's optional `image` object.
+Add `--image <path>` to attach one local PNG, JPEG, GIF, WebP, BMP, or TIFF as `{media_type,data_base64}` in the relay's optional `image` object.
 Completion follow-ups use `bin/fm-x-followup.sh`, which checks the local `state/<id>.meta` link and sends the same payload shape through `POST /connector/followup` by calling `bin/fm-x-reply.sh --followup`.
 Add `--image <path>` there too when the completion follow-up should carry an image.
 The follow-up helper clears the link after a successful post or after the 24h window has elapsed; a failed post leaves the link in place so it can be retried.
@@ -139,7 +139,7 @@ Truthy means anything except unset, empty, `0`, `false`, `no`, or `off`; an expl
 In dry-run, `fm-x-reply.sh` records the would-be payload to `state/x-outbox/<request_id>.json`, including `texts` for a thread and an `endpoint` marker for follow-up previews, prints a `DRY RUN` summary to stderr, echoes the `request_id`, and exits 0.
 When an image is attached, the dry-run record uses compact `{media_type, bytes, source_path}` metadata instead of writing the base64 bytes.
 In dry-run, `fm-x-dismiss.sh` records `{request_id, endpoint:"dismiss"}` to the same outbox path, prints a `DRY RUN` summary, echoes the `request_id`, and exits 0.
-The live answer, follow-up, and dismiss bodies intentionally stay the same shape; the relay distinguishes them by endpoint.
+The live answer and follow-up bodies intentionally stay the same shape, including optional `image`; the relay distinguishes them by endpoint, and dismiss stays `{request_id}`.
 These paths need `jq` to build the JSON payload, but they run before token and network checks, so they need neither `FMX_PAIRING_TOKEN` nor `curl`.
 
 ## Environment variables

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -125,15 +125,19 @@ Pure acknowledgments or mentions with nothing to answer are dismissed through `b
 Dismiss sends `POST /connector/dismiss` with `{request_id}`, posts no text, and tells the relay to drop the request instead of re-offering it or falling back to an offline auto-reply.
 Relay auth or config problems are reported once as `x-mode-error ...` until recovery.
 Live replies are posted by `bin/fm-x-reply.sh`, which sends `POST /connector/answer` with `{request_id,text}` for one-tweet replies.
+Add `--image <path>` to attach one local image as the relay's optional `image` object.
 Completion follow-ups use `bin/fm-x-followup.sh`, which checks the local `state/<id>.meta` link and sends the same payload shape through `POST /connector/followup` by calling `bin/fm-x-reply.sh --followup`.
+Add `--image <path>` there too when the completion follow-up should carry an image.
 The follow-up helper clears the link after a successful post or after the 24h window has elapsed; a failed post leaves the link in place so it can be retried.
-If the reply exceeds `FMX_X_REPLY_MAX_CHARS`, the client splits it into a numbered, text-only thread on word boundaries and sends `{request_id,text,texts}`, where `texts` is the ordered chunk list and `text` remains the first chunk for older relays.
+If the reply exceeds `FMX_X_REPLY_MAX_CHARS`, the client splits it into a numbered thread on word boundaries and sends `{request_id,text,texts}`, where `texts` is the ordered chunk list and `text` remains the first chunk for older relays.
+When `--image <path>` is present on a split reply, the image rides the first/opener tweet and later chunks stay text-only.
 `FMX_X_REPLY_MAX_CHARS` defaults to 280 and clamps to a minimum of 50; `FMX_X_THREAD_MAX` defaults to 25 and caps oversized replies, marking the last retained tweet with an ellipsis when truncation is needed.
 `FMX_FOLLOWUP_MAX_AGE_SECS` defaults to 86400 and controls the local completion follow-up window.
 
 Set `FMX_DRY_RUN` to preview replies and dismissals without posting.
 Truthy means anything except unset, empty, `0`, `false`, `no`, or `off`; an explicit environment value wins over `.env`.
-In dry-run, `fm-x-reply.sh` records the full would-be payload to `state/x-outbox/<request_id>.json`, including `texts` for a thread and an `endpoint` marker for follow-up previews, prints a `DRY RUN` summary to stderr, echoes the `request_id`, and exits 0.
+In dry-run, `fm-x-reply.sh` records the would-be payload to `state/x-outbox/<request_id>.json`, including `texts` for a thread and an `endpoint` marker for follow-up previews, prints a `DRY RUN` summary to stderr, echoes the `request_id`, and exits 0.
+When an image is attached, the dry-run record uses compact `{media_type, bytes, source_path}` metadata instead of writing the base64 bytes.
 In dry-run, `fm-x-dismiss.sh` records `{request_id, endpoint:"dismiss"}` to the same outbox path, prints a `DRY RUN` summary, echoes the `request_id`, and exits 0.
 The live answer, follow-up, and dismiss bodies intentionally stay the same shape; the relay distinguishes them by endpoint.
 These paths need `jq` to build the JSON payload, but they run before token and network checks, so they need neither `FMX_PAIRING_TOKEN` nor `curl`.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -38,9 +38,9 @@ Each file also starts with a short header comment.
 | `fm-teardown.sh`         | Return a clean, landed ship worktree or retire/release a secondmate home; requires scout reports, checks child work, removes firstmate-owned hook artifacts, and prints the backend-aware backlog reminder |
 | `fm-harness.sh`          | Detect the running harness; resolve the effective crewmate (`crew`) or secondmate-launch (`secondmate`) harness     |
 | `fm-lock.sh`             | Per-home firstmate session lock                                                                                     |
-| `fm-x-lib.sh`            | Shared X-mode `.env`, alternate env-file, relay, dry-run config, reply-thread splitting, and task-to-X-request meta-link helpers |
+| `fm-x-lib.sh`            | Shared X-mode `.env`, alternate env-file, relay, dry-run config, reply-thread splitting, outbound image payloads, and task-to-X-request meta-link helpers |
 | `fm-x-poll.sh`           | Do one bounded X relay poll; without `FMX_PAIRING_TOKEN` it is silent, with a pending mention it stashes the full inbox JSON, including `in_reply_to`, and prints `x-mention <request_id>` |
-| `fm-x-reply.sh`          | Post or dry-run preview a composed public-safe X answer or `--followup`, auto-splitting long text into `{request_id,text,texts}` threads; reads text from an argument, stdin, or `--text-file` |
+| `fm-x-reply.sh`          | Post or dry-run preview a composed public-safe X answer or `--followup`, auto-splitting long text into `{request_id,text,texts}` threads and optionally attaching `--image <path>` to the opener; reads text from an argument, stdin, or `--text-file` |
 | `fm-x-dismiss.sh`        | Dismiss or dry-run preview a skipped X mention without replying by sending `{request_id}` to the relay's `connector/dismiss` endpoint |
 | `fm-x-link.sh`           | Link a spawned task to its originating X mention by recording `x_request=` and `x_request_ts=` in `state/<id>.meta` |
-| `fm-x-followup.sh`       | Detect, post, and clear the single completion follow-up for an X-linked task, enforcing the local 24h window and retrying only when the relay post fails |
+| `fm-x-followup.sh`       | Detect, post, and clear the single completion follow-up for an X-linked task, forwarding optional `--image <path>`, enforcing the local 24h window, and retrying only when the relay post fails |

--- a/tests/fm-x-mode.test.sh
+++ b/tests/fm-x-mode.test.sh
@@ -74,6 +74,17 @@ SH
   printf '%s\n' "$fakebin"
 }
 
+make_sample_image() {
+  local path=$1
+  case "$path" in
+    *.png) printf '\211PNG\r\n\032\nfirstmate-test-png' > "$path" ;;
+    *.jpg|*.jpeg) printf '\377\330\377firstmate-test-jpeg' > "$path" ;;
+    *.gif) printf 'GIF89afirstmate-test-gif' > "$path" ;;
+    *.webp) printf 'RIFF....WEBPfirstmate-test-webp' > "$path" ;;
+    *) printf 'firstmate-test-image' > "$path" ;;
+  esac
+}
+
 # ---------------------------------------------------------------------------
 
 test_poll_no_token_is_hard_noop() {
@@ -314,11 +325,24 @@ test_reply_non_2xx_fails() {
 }
 
 test_reply_usage_error() {
-  local home rc
+  local home rc err
   home="$TMP_ROOT/reply-usage"; mkdir -p "$home"
-  PATH="$BASE_PATH" FM_HOME="$home" "$ROOT/bin/fm-x-reply.sh" "only-one" >/dev/null 2>&1; rc=$?
+  err="$home/err.txt"
+  PATH="$BASE_PATH" FM_HOME="$home" "$ROOT/bin/fm-x-reply.sh" "only-one" >/dev/null 2>"$err"; rc=$?
   expect_code 2 "$rc" "reply usage error exit"
+  assert_grep "--image <path>" "$err" "reply usage must mention --image"
   pass "fm-x-reply rejects missing arguments with a usage error"
+}
+
+test_reply_help_mentions_image() {
+  local home out rc
+  home="$TMP_ROOT/reply-help"; mkdir -p "$home"
+  out=$(PATH="$BASE_PATH" FM_HOME="$home" "$ROOT/bin/fm-x-reply.sh" --help); rc=$?
+  expect_code 0 "$rc" "reply --help exit"
+  assert_contains "$out" "--image <path>" "reply help must mention --image"
+  assert_contains "$out" "threaded replies attach it to the opener tweet" \
+    "reply help must document thread image placement"
+  pass "fm-x-reply --help makes image support discoverable"
 }
 
 test_reply_whitespace_text_rejected() {
@@ -693,6 +717,82 @@ test_reply_thread_live_posts_texts() {
   pass "fm-x-reply posts a thread payload (texts[]) to the relay"
 }
 
+test_reply_image_live_posts_image_object() {
+  local home fakebin log out rc data img expected
+  home="$TMP_ROOT/reply-image-live"; mkdir -p "$home"
+  fakebin=$(make_fake_curl "$home")
+  log="$home/curl.log"
+  img="$home/diagram.png"
+  make_sample_image "$img"
+  expected=$(base64 < "$img" | tr -d '\n\r')
+  printf 'FMX_PAIRING_TOKEN=tok-img\n' > "$home/.env"
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$home" FMX_RELAY_URL="https://relay.test" \
+    FAKE_CURL_LOG="$log" FAKE_ANSWER_CODE=200 \
+    "$ROOT/bin/fm-x-reply.sh" "req-img" --image "$img" "Here is the illustration."); rc=$?
+  expect_code 0 "$rc" "reply image live exit"
+  [ "$out" = "req-img" ] || fail "image reply must echo only the request_id (got: $out)"
+  data=$(grep '^data=' "$log" | tail -1 | sed 's/^data=//')
+  [ "$(printf '%s' "$data" | jq -r '.image.media_type')" = "image/png" ] \
+    || fail "image reply must detect PNG media_type"
+  [ "$(printf '%s' "$data" | jq -r '.image.data_base64')" = "$expected" ] \
+    || fail "image reply must include base64 image bytes"
+  [ "$(printf '%s' "$data" | jq -r '.text')" = "Here is the illustration." ] \
+    || fail "image reply must preserve text"
+  pass "fm-x-reply --image posts an image object on answer"
+}
+
+test_reply_image_thread_dry_run_records_compact_marker() {
+  local home fakebin log out rc img bytes
+  home="$TMP_ROOT/reply-image-thread-dry"; mkdir -p "$home"
+  fakebin=$(make_fake_curl "$home")
+  log="$home/curl.log"
+  img="$home/illustration.webp"
+  make_sample_image "$img"
+  bytes=$(wc -c < "$img" | tr -d '[:space:]')
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$home" FMX_DRY_RUN=1 FMX_X_REPLY_MAX_CHARS=50 \
+    FAKE_CURL_LOG="$log" \
+    "$ROOT/bin/fm-x-reply.sh" "req-img-dry" --image "$img" \
+    "alpha bravo charlie delta echo foxtrot golf hotel india juliet kilo lima mike november" \
+    2>"$home/err"); rc=$?
+  expect_code 0 "$rc" "reply image dry-run exit"
+  [ "$out" = "req-img-dry" ] || fail "image dry-run must echo the request_id (got: $out)"
+  [ -f "$log" ] && grep -q "method=POST" "$log" && fail "image dry-run must not POST"
+  assert_present "$home/state/x-outbox/req-img-dry.json" "image dry-run must record the preview"
+  jq -e '.texts and (.texts|length>1)' "$home/state/x-outbox/req-img-dry.json" >/dev/null \
+    || fail "image dry-run thread must keep texts[]"
+  [ "$(jq -r '.image.media_type' "$home/state/x-outbox/req-img-dry.json")" = "image/webp" ] \
+    || fail "image dry-run marker must hold media_type"
+  [ "$(jq -r '.image.bytes' "$home/state/x-outbox/req-img-dry.json")" = "$bytes" ] \
+    || fail "image dry-run marker must hold byte count"
+  [ "$(jq -r '.image.source_path' "$home/state/x-outbox/req-img-dry.json")" = "$img" ] \
+    || fail "image dry-run marker must hold source_path"
+  jq -e '.image | has("data_base64") | not' "$home/state/x-outbox/req-img-dry.json" >/dev/null \
+    || fail "image dry-run marker must not include base64 bytes"
+  pass "fm-x-reply dry-run records compact image metadata for threaded replies"
+}
+
+test_reply_image_path_errors_are_clear() {
+  local home out rc err img
+  home="$TMP_ROOT/reply-image-errors"; mkdir -p "$home"
+  err="$home/err.txt"
+  out=$(PATH="$BASE_PATH" FM_HOME="$home" FMX_DRY_RUN=1 \
+    "$ROOT/bin/fm-x-reply.sh" "req-missing" --image "$home/missing.png" "text" 2>"$err"); rc=$?
+  [ "$rc" -ne 0 ] || fail "missing image path must fail"
+  [ -z "$out" ] || fail "missing image path must not echo the request_id (got: $out)"
+  assert_grep "image file does not exist" "$err" "missing image path must explain the error"
+  img="$home/not-image.txt"
+  printf 'not an image' > "$img"
+  out=$(PATH="$BASE_PATH" FM_HOME="$home" FMX_DRY_RUN=1 \
+    "$ROOT/bin/fm-x-reply.sh" "req-badtype" --image "$img" "text" 2>"$err"); rc=$?
+  [ "$rc" -ne 0 ] || fail "unsupported image path must fail"
+  assert_grep "unsupported image media type" "$err" "unsupported image path must explain the error"
+  out=$(PATH="$BASE_PATH" FM_HOME="$home" FMX_DRY_RUN=1 \
+    "$ROOT/bin/fm-x-reply.sh" "req-noarg" --image 2>"$err"); rc=$?
+  expect_code 2 "$rc" "missing --image argument exit"
+  assert_grep "missing --image path" "$err" "missing --image argument must explain the error"
+  pass "fm-x-reply --image rejects missing and unsupported image paths clearly"
+}
+
 # --- follow-up reply mode (--followup -> /connector/followup) ----------------
 
 test_reply_followup_live_posts_to_followup_endpoint() {
@@ -715,6 +815,30 @@ test_reply_followup_live_posts_to_followup_endpoint() {
   [ "$keys" = "request_id,text" ] || fail "followup live body must carry only request_id,text (got: $keys)"
   [ "$(printf '%s' "$data" | jq -r .request_id)" = "req-7" ] || fail "followup body request_id"
   pass "fm-x-reply --followup posts to /connector/followup with the same request-bound body"
+}
+
+test_reply_followup_image_live_posts_image_object() {
+  local home fakebin log out rc data img expected
+  home="$TMP_ROOT/reply-followup-image-live"; mkdir -p "$home"
+  fakebin=$(make_fake_curl "$home")
+  log="$home/curl.log"
+  img="$home/result.jpg"
+  make_sample_image "$img"
+  expected=$(base64 < "$img" | tr -d '\n\r')
+  printf 'FMX_PAIRING_TOKEN=tok-fu-img\n' > "$home/.env"
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$home" FMX_RELAY_URL="https://relay.test" \
+    FAKE_CURL_LOG="$log" FAKE_FOLLOWUP_CODE=200 \
+    "$ROOT/bin/fm-x-reply.sh" "req-fu-img" --followup --image "$img" \
+    "Done - here is the generated image."); rc=$?
+  expect_code 0 "$rc" "followup image live exit"
+  [ "$out" = "req-fu-img" ] || fail "followup image must echo only the request_id (got: $out)"
+  assert_grep "url=https://relay.test/connector/followup" "$log" "image followup must hit followup endpoint"
+  data=$(grep '^data=' "$log" | tail -1 | sed 's/^data=//')
+  [ "$(printf '%s' "$data" | jq -r '.image.media_type')" = "image/jpeg" ] \
+    || fail "image followup must detect JPEG media_type"
+  [ "$(printf '%s' "$data" | jq -r '.image.data_base64')" = "$expected" ] \
+    || fail "image followup must include base64 image bytes"
+  pass "fm-x-reply --followup --image posts an image object"
 }
 
 test_reply_followup_flag_position_is_flexible() {
@@ -774,6 +898,25 @@ test_reply_followup_thread_dry_run() {
   [ "$(jq -r '.text' "$home/state/x-outbox/req-ft.json")" = "$(jq -r '.texts[0]' "$home/state/x-outbox/req-ft.json")" ] \
     || fail "followup thread text must equal the first chunk"
   pass "fm-x-reply --followup auto-splits a long follow-up into a marked thread"
+}
+
+test_reply_followup_image_dry_run_marks_endpoint_and_compacts_image() {
+  local home out rc img
+  home="$TMP_ROOT/reply-followup-image-dry"; mkdir -p "$home"
+  img="$home/result.gif"
+  make_sample_image "$img"
+  out=$(FM_HOME="$home" FMX_DRY_RUN=1 \
+    "$ROOT/bin/fm-x-reply.sh" "req-fu-img-dry" --followup --image "$img" "Done with art." \
+    2>"$home/err"); rc=$?
+  expect_code 0 "$rc" "followup image dry-run exit"
+  [ "$out" = "req-fu-img-dry" ] || fail "followup image dry-run must echo the request_id (got: $out)"
+  [ "$(jq -r '.endpoint' "$home/state/x-outbox/req-fu-img-dry.json")" = "followup" ] \
+    || fail "followup image dry-run must carry endpoint marker"
+  [ "$(jq -r '.image.media_type' "$home/state/x-outbox/req-fu-img-dry.json")" = "image/gif" ] \
+    || fail "followup image dry-run must detect GIF media_type"
+  jq -e '.image | has("data_base64") | not' "$home/state/x-outbox/req-fu-img-dry.json" >/dev/null \
+    || fail "followup image dry-run must omit base64 bytes"
+  pass "fm-x-reply followup dry-run keeps endpoint marker and compact image metadata"
 }
 
 # --- fm-x-dismiss: drop a mention at the relay without replying ---------------
@@ -1027,6 +1170,32 @@ test_followup_post_within_window_posts_and_clears() {
   pass "fm-x-followup posts the follow-up and clears the link on success"
 }
 
+test_followup_post_forwards_image_to_reply_client() {
+  local home fakebin log out rc meta data img expected
+  home="$TMP_ROOT/fu-post-image"; mkdir -p "$home/state"
+  fakebin=$(make_fake_curl "$home")
+  log="$home/curl.log"
+  img="$home/followup.png"
+  make_sample_image "$img"
+  expected=$(base64 < "$img" | tr -d '\n\r')
+  printf 'FMX_PAIRING_TOKEN=tok-fu-img\n' > "$home/.env"
+  mk_linked_task "$home" task-img req-img 1700000000
+  meta="$home/state/task-img.meta"
+  printf 'Done - generated image attached.' > "$home/reply.txt"
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$home" FMX_RELAY_URL="https://relay.test" \
+    FMX_NOW_OVERRIDE=1700003600 FAKE_CURL_LOG="$log" FAKE_FOLLOWUP_CODE=200 \
+    "$ROOT/bin/fm-x-followup.sh" task-img --image "$img" --text-file "$home/reply.txt"); rc=$?
+  expect_code 0 "$rc" "followup wrapper image post exit"
+  [ "$out" = "req-img" ] || fail "followup wrapper image post must echo the request_id (got: $out)"
+  data=$(grep '^data=' "$log" | tail -1 | sed 's/^data=//')
+  [ "$(printf '%s' "$data" | jq -r '.image.media_type')" = "image/png" ] \
+    || fail "followup wrapper must forward image media_type"
+  [ "$(printf '%s' "$data" | jq -r '.image.data_base64')" = "$expected" ] \
+    || fail "followup wrapper must forward image base64"
+  assert_no_grep "x_request=" "$meta" "a successful image followup must clear the link"
+  pass "fm-x-followup --image forwards the attachment through fm-x-reply --followup"
+}
+
 test_followup_post_failure_keeps_link() {
   local home fakebin out rc meta
   home="$TMP_ROOT/fu-post-fail"; mkdir -p "$home/state"
@@ -1088,16 +1257,26 @@ test_followup_post_dry_run_records_and_clears() {
 }
 
 test_followup_usage_errors() {
-  local home rc
+  local home rc err out
   home="$TMP_ROOT/fu-usage"; mkdir -p "$home/state"
-  PATH="$BASE_PATH" FM_HOME="$home" "$ROOT/bin/fm-x-followup.sh" >/dev/null 2>&1; rc=$?
+  err="$home/err.txt"
+  PATH="$BASE_PATH" FM_HOME="$home" "$ROOT/bin/fm-x-followup.sh" >/dev/null 2>"$err"; rc=$?
   expect_code 2 "$rc" "followup no-args exit"
+  assert_grep "--image <path>" "$err" "followup usage must mention --image"
   PATH="$BASE_PATH" FM_HOME="$home" "$ROOT/bin/fm-x-followup.sh" --check >/dev/null 2>&1; rc=$?
   expect_code 2 "$rc" "followup --check no-id exit"
   PATH="$BASE_PATH" FM_HOME="$home" "$ROOT/bin/fm-x-followup.sh" some-task >/dev/null 2>&1; rc=$?
   expect_code 2 "$rc" "followup post no-text-source exit"
+  out=$(PATH="$BASE_PATH" FM_HOME="$home" "$ROOT/bin/fm-x-followup.sh" --help); rc=$?
+  expect_code 0 "$rc" "followup --help exit"
+  assert_contains "$out" "--image <path>" "followup help must mention --image"
+  assert_contains "$out" "threaded replies attach it to the opener tweet" \
+    "followup help must document thread image placement"
   PATH="$BASE_PATH" FM_HOME="$home" "$ROOT/bin/fm-x-followup.sh" "../evil" --text-file /dev/null >/dev/null 2>&1; rc=$?
   expect_code 2 "$rc" "followup unsafe-id exit"
+  PATH="$BASE_PATH" FM_HOME="$home" "$ROOT/bin/fm-x-followup.sh" some-task --image >/dev/null 2>"$err"; rc=$?
+  expect_code 2 "$rc" "followup missing --image argument exit"
+  assert_grep "missing --image path" "$err" "followup missing --image argument must explain the error"
   pass "fm-x-followup rejects malformed invocations"
 }
 
@@ -1115,6 +1294,7 @@ test_reply_success_posts_request_bound_only
 test_reply_text_file_and_stdin
 test_reply_non_2xx_fails
 test_reply_usage_error
+test_reply_help_mentions_image
 test_reply_whitespace_text_rejected
 test_reply_dry_run_records_not_posts
 test_reply_dry_run_needs_no_token
@@ -1126,10 +1306,15 @@ test_reply_single_no_texts
 test_reply_thread_dry_run
 test_reply_max_chars_floor_clamps_to_minimum
 test_reply_thread_live_posts_texts
+test_reply_image_live_posts_image_object
+test_reply_image_thread_dry_run_records_compact_marker
+test_reply_image_path_errors_are_clear
 test_reply_followup_live_posts_to_followup_endpoint
+test_reply_followup_image_live_posts_image_object
 test_reply_followup_flag_position_is_flexible
 test_reply_followup_dry_run_marks_endpoint
 test_reply_followup_thread_dry_run
+test_reply_followup_image_dry_run_marks_endpoint_and_compacts_image
 test_dismiss_success_posts_request_only
 test_dismiss_dry_run_records_not_posts
 test_dismiss_dry_run_needs_no_token
@@ -1143,6 +1328,7 @@ test_link_rejects_unsafe_and_missing
 test_followup_check_states
 test_followup_check_expired_prunes_link
 test_followup_post_within_window_posts_and_clears
+test_followup_post_forwards_image_to_reply_client
 test_followup_post_failure_keeps_link
 test_followup_post_expired_skips_and_clears
 test_followup_post_not_linked_is_noop

--- a/tests/fm-x-mode.test.sh
+++ b/tests/fm-x-mode.test.sh
@@ -37,6 +37,14 @@ while [ $# -gt 0 ]; do
     -o) ofile=$2; shift 2 ;;
     -X) method=$2; shift 2 ;;
     --data) data=$2; shift 2 ;;
+    --data-binary)
+      case "$2" in
+        @-) data=$(cat) ;;
+        @*) data=$(cat -- "${2#@}") ;;
+        *) data=$2 ;;
+      esac
+      shift 2
+      ;;
     -H)
       case "$2" in
         @*) while IFS= read -r header; do case "$header" in Authorization:*) auth=$header ;; esac; done < "${2#@}" ;;
@@ -322,6 +330,42 @@ test_reply_non_2xx_fails() {
   [ "$rc" -ne 0 ] || fail "reply must exit non-zero on a non-2xx response"
   assert_grep "HTTP 500" "$err" "reply must report the failing status"
   pass "fm-x-reply exits non-zero on a non-2xx relay response"
+}
+
+test_reply_auth_header_tempfile_cleans_up_on_interrupted_post() {
+  local home fakebin log out rc auth_file
+  home="$TMP_ROOT/reply-auth-interrupt"; mkdir -p "$home"
+  fakebin=$(fm_fakebin "$home")
+  log="$home/auth-file.txt"
+  cat > "$fakebin/curl" <<'SH'
+#!/usr/bin/env bash
+auth_file=
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -H)
+      case "$2" in @*) auth_file=${2#@} ;; esac
+      shift 2
+      ;;
+    -o|-w|-X|-m|--data|--data-binary) shift 2 ;;
+    -s) shift ;;
+    *) shift ;;
+  esac
+done
+printf '%s\n' "$auth_file" > "$FAKE_AUTH_FILE_LOG"
+kill -TERM "$PPID"
+exit 143
+SH
+  chmod +x "$fakebin/curl"
+  printf 'FMX_PAIRING_TOKEN=tok-clean\n' > "$home/.env"
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$home" FMX_RELAY_URL="https://relay.test" \
+    FAKE_AUTH_FILE_LOG="$log" \
+    "$ROOT/bin/fm-x-reply.sh" "req-clean" "Hello." 2>"$home/err"); rc=$?
+  [ "$rc" -ne 0 ] || fail "interrupted relay post must fail"
+  [ -z "$out" ] || fail "interrupted relay post must not echo the request_id (got: $out)"
+  auth_file=$(cat "$log")
+  [ -n "$auth_file" ] || fail "fake curl must record the auth header temp file"
+  [ ! -e "$auth_file" ] || fail "auth header temp file must be removed after an interrupted post"
+  pass "fm-x-reply cleans up auth header temp files on interrupted posts"
 }
 
 test_reply_usage_error() {
@@ -739,6 +783,33 @@ test_reply_image_live_posts_image_object() {
   [ "$(printf '%s' "$data" | jq -r '.text')" = "Here is the illustration." ] \
     || fail "image reply must preserve text"
   pass "fm-x-reply --image posts an image object on answer"
+}
+
+test_reply_image_live_streams_payload_file() {
+  local home fakebin log out rc data img i
+  home="$TMP_ROOT/reply-image-stream"; mkdir -p "$home"
+  fakebin=$(make_fake_curl "$home")
+  log="$home/curl.log"
+  img="$home/large.png"
+  make_sample_image "$img"
+  i=0
+  while [ "$i" -lt 4096 ]; do
+    printf '0123456789abcdef0123456789abcdef' >> "$img"
+    i=$((i + 1))
+  done
+  printf 'FMX_PAIRING_TOKEN=tok-img-stream\n' > "$home/.env"
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$home" FMX_RELAY_URL="https://relay.test" \
+    FAKE_CURL_LOG="$log" FAKE_ANSWER_CODE=200 \
+    "$ROOT/bin/fm-x-reply.sh" "req-img-stream" --image "$img" "Here is the illustration."); rc=$?
+  expect_code 0 "$rc" "streamed image reply exit"
+  [ "$out" = "req-img-stream" ] || fail "streamed image reply must echo only the request_id (got: $out)"
+  assert_grep "--data-binary @" "$log" "image reply must stream the POST body from a file"
+  grep '^argv=' "$log" | tail -1 | grep -F 'data_base64' >/dev/null 2>&1 \
+    && fail "image reply must not place image JSON in curl argv"
+  data=$(grep '^data=' "$log" | tail -1 | sed 's/^data=//')
+  printf '%s' "$data" | jq -e '.image.media_type == "image/png" and (.image.data_base64 | length > 100000)' >/dev/null \
+    || fail "streamed image reply must still send the base64 image body"
+  pass "fm-x-reply streams large image payloads outside curl argv"
 }
 
 test_reply_image_thread_dry_run_records_compact_marker() {
@@ -1293,6 +1364,7 @@ test_poll_rejects_unsafe_request_id
 test_reply_success_posts_request_bound_only
 test_reply_text_file_and_stdin
 test_reply_non_2xx_fails
+test_reply_auth_header_tempfile_cleans_up_on_interrupted_post
 test_reply_usage_error
 test_reply_help_mentions_image
 test_reply_whitespace_text_rejected
@@ -1307,6 +1379,7 @@ test_reply_thread_dry_run
 test_reply_max_chars_floor_clamps_to_minimum
 test_reply_thread_live_posts_texts
 test_reply_image_live_posts_image_object
+test_reply_image_live_streams_payload_file
 test_reply_image_thread_dry_run_records_compact_marker
 test_reply_image_path_errors_are_clear
 test_reply_followup_live_posts_to_followup_endpoint

--- a/tests/fm-x-mode.test.sh
+++ b/tests/fm-x-mode.test.sh
@@ -842,6 +842,22 @@ test_reply_image_thread_dry_run_records_compact_marker() {
   pass "fm-x-reply dry-run records compact image metadata for threaded replies"
 }
 
+test_reply_image_dry_run_cleans_payload_temp_files() {
+  local home tmpdir img out rc leftovers
+  home="$TMP_ROOT/reply-image-temp-clean"; mkdir -p "$home"
+  tmpdir="$home/tmp"; mkdir -p "$tmpdir"
+  img="$home/preview.png"
+  make_sample_image "$img"
+  out=$(PATH="$BASE_PATH" TMPDIR="$tmpdir" FM_HOME="$home" FMX_DRY_RUN=1 \
+    "$ROOT/bin/fm-x-reply.sh" "req-img-temp-clean" --image "$img" "Here is the image." \
+    2>"$home/err"); rc=$?
+  expect_code 0 "$rc" "reply image temp cleanup exit"
+  [ "$out" = "req-img-temp-clean" ] || fail "image dry-run temp cleanup must echo the request_id (got: $out)"
+  leftovers=$(find "$tmpdir" -type f -name 'fm-x-reply.*' -print)
+  [ -z "$leftovers" ] || fail "reply temp files must be cleaned (left: $leftovers)"
+  pass "fm-x-reply cleans image and payload temp files"
+}
+
 test_reply_image_path_errors_are_clear() {
   local home out rc err img
   home="$TMP_ROOT/reply-image-errors"; mkdir -p "$home"
@@ -1381,6 +1397,7 @@ test_reply_thread_live_posts_texts
 test_reply_image_live_posts_image_object
 test_reply_image_live_streams_payload_file
 test_reply_image_thread_dry_run_records_compact_marker
+test_reply_image_dry_run_cleans_payload_temp_files
 test_reply_image_path_errors_are_clear
 test_reply_followup_live_posts_to_followup_endpoint
 test_reply_followup_image_live_posts_image_object


### PR DESCRIPTION
## Intent

Add proper image attachment support to firstmate's X reply client. The reply helper must accept --image <path>, validate and encode a local image, detect media_type from common image extensions, and include the relay's optional image object on both /connector/answer and /connector/followup. The follow-up helper must forward --image through to fm-x-reply.sh --followup. Help text, header usage, AGENTS.md section 14, and public docs should make image support immediately discoverable. Threaded replies must keep the image on the first opener tweet, matching the relay contract. FMX_DRY_RUN should preview a compact image marker with media_type, bytes, and source_path instead of the base64 blob. Preserve existing no-image behavior and current exit contracts, with tests for answer, followup, bad image paths, dry-run, help, and unchanged no-image paths.

## What Changed

- Add `--image <path>` support to the X reply path, including local image validation, extension-based `media_type` detection, base64 payload construction, and relay `image` objects for both answers and followups.
- Preserve existing no-image replies while routing threaded image replies through the opener tweet and showing compact image metadata in `FMX_DRY_RUN` instead of raw base64.
- Update `fm-x-followup` forwarding, CLI help, firstmate/docs references, and X mode tests for answer, followup, dry-run, missing image, help, and unchanged no-image paths, captain.

## Risk Assessment

✅ Low: Captain, the change is well-scoped to X reply/follow-up image payload handling and the earlier temp-file and argv-limit risks are addressed without introducing material regressions I can substantiate.

## Testing

Baseline full tests were already green; I reran the X-mode suite and manually exercised the end-user CLI flows for image answer, image follow-up, threaded dry-run preview, bad image path handling, help/docs discoverability, and no-image preservation, with all checks passing and reviewer evidence saved in the requested evidence directory.

<details>
<summary>Evidence: CLI transcript</summary>

<code>## answer with image&#10;req-e2e-answer&#10;&#10;## no-image answer stays unchanged&#10;req-e2e-noimage&#10;&#10;## follow-up wrapper with image&#10;req-e2e-followup&#10;&#10;## threaded dry-run with image marker&#10;req-e2e-thread&#10;&#10;## bad image path&#10;exit=1&#10;fm-x-reply: image file does not exist: /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KWCX362DRKDW9H4EQZ8RSPXH/assets/missing.png</code>

```text
## answer with image
req-e2e-answer

## no-image answer stays unchanged
req-e2e-noimage

## follow-up wrapper with image
req-e2e-followup

## threaded dry-run with image marker
req-e2e-thread

## bad image path
exit=1
fm-x-reply: image file does not exist: /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KWCX362DRKDW9H4EQZ8RSPXH/assets/missing.png

## help excerpts
usage: fm-x-reply.sh <request_id> [--followup] [--image <path>] <text>
       fm-x-reply.sh <request_id> [--followup] [--image <path>] --text-file <path>
       fm-x-reply.sh <request_id> [--followup] [--image <path>] -
  --image <path>   Attach one local image file; threaded replies attach it to the opener tweet.
       fm-x-followup.sh <task-id> [--image <path>] --text-file <path>
       fm-x-followup.sh <task-id> [--image <path>] -
  --image <path>   Attach one local image file; threaded replies attach it to the opener tweet.
```
</details>
<details>
<summary>Evidence: Answer image payload summary</summary>

`{"request_id":"req-e2e-answer","text":"Here is the generated diagram.","image":{"media_type":"image/png","data_base64_length":92}}`

```text
{
  "request_id": "req-e2e-answer",
  "text": "Here is the generated diagram.",
  "image": {
    "media_type": "image/png",
    "data_base64_length": 92
  }
}
```
</details>
<details>
<summary>Evidence: Follow-up image payload summary</summary>

`{"request_id":"req-e2e-followup","text":"Done - generated image attached.","image":{"media_type":"image/png","data_base64_length":92}}`

```text
{
  "request_id": "req-e2e-followup",
  "text": "Done - generated image attached.",
  "image": {
    "media_type": "image/png",
    "data_base64_length": 92
  }
}
```
</details>
<details>
<summary>Evidence: No-image payload summary</summary>

`{"request_id":"req-e2e-noimage","text":"Plain text answer.","has_image":false,"keys":["request_id","text"]}`

```text
{
  "request_id": "req-e2e-noimage",
  "text": "Plain text answer.",
  "has_image": false,
  "keys": [
    "request_id",
    "text"
  ]
}
```
</details>
<details>
<summary>Evidence: Threaded dry-run image marker</summary>

`{"request_id":"req-e2e-thread","texts_count":3,"image":{"media_type":"image/webp","bytes":34},"has_base64":false}`

```text
{
  "request_id": "req-e2e-thread",
  "text": "alpha bravo charlie delta echo foxtrot (1/3)",
  "texts_count": 3,
  "image": {
    "media_type": "image/webp",
    "bytes": 34,
    "source_path": "/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KWCX362DRKDW9H4EQZ8RSPXH/assets/thread-preview.webp"
  },
  "has_base64": false
}
```
</details>
<details>
<summary>Evidence: Raw answer relay payload</summary>

```text
{"request_id":"req-e2e-answer","text":"Here is the generated diagram.","image":{"media_type":"image/png","data_base64":"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII="}}
```
</details>
<details>
<summary>Evidence: Raw follow-up relay payload</summary>

```text
{"request_id":"req-e2e-followup","text":"Done - generated image attached.","image":{"media_type":"image/png","data_base64":"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII="}}
```
</details>
<details>
<summary>Evidence: Docs and help discoverability grep</summary>

```text
bin/fm-x-followup.sh:17:#   fm-x-followup.sh <task-id> [--image <path>] --text-file <path>
bin/fm-x-followup.sh:18:#   fm-x-followup.sh <task-id> [--image <path>] -
bin/fm-x-followup.sh:28:# With --image <path>, the follow-up carries one local image attachment; if the
bin/fm-x-followup.sh:43:  echo "usage: fm-x-followup.sh --check <task-id> | <task-id> [--image <path>] --text-file <path> | <task-id> [--image <path>] -" >&2
bin/fm-x-followup.sh:49:       fm-x-followup.sh <task-id> [--image <path>] --text-file <path>
bin/fm-x-followup.sh:50:       fm-x-followup.sh <task-id> [--image <path>] -
bin/fm-x-followup.sh:56:  --image <path>   Attach one local image file; threaded replies attach it to the opener tweet.
bin/fm-x-reply.sh:4:# Usage: fm-x-reply.sh <request_id> [--image <path>] <text>
bin/fm-x-reply.sh:5:#        fm-x-reply.sh <request_id> [--image <path>] --text-file <path>
bin/fm-x-reply.sh:6:#        fm-x-reply.sh <request_id> [--image <path>] -
bin/fm-x-reply.sh:7:#        fm-x-reply.sh <request_id> --followup [--image <path>] ...
bin/fm-x-reply.sh:14:# Optional --image <path> attaches one local image file to the answer or followup
bin/fm-x-reply.sh:17:# attaches that image to the first/opener tweet only.
bin/fm-x-reply.sh:81:  echo "usage: fm-x-reply.sh <request_id> [--followup] [--image <path>] <text> | [--followup] [--image <path>] --text-file <path> | [--followup] [--image <path>] -" >&2
bin/fm-x-reply.sh:86:usage: fm-x-reply.sh <request_id> [--followup] [--image <path>] <text>
bin/fm-x-reply.sh:87:       fm-x-reply.sh <request_id> [--followup] [--image <path>] --text-file <path>
bin/fm-x-reply.sh:88:       fm-x-reply.sh <request_id> [--followup] [--image <path>] -
bin/fm-x-reply.sh:94:  --image <path>   Attach one local image file; threaded replies attach it to the opener tweet.
bin/fm-x-reply.sh:202:# Build the body with jq so the text and optional image object are correctly
docs/scripts.md:41:| `fm-x-lib.sh`            | Shared X-mode `.env`, alternate env-file, relay, dry-run config, reply-thread splitting, outbound image payloads, and task-to-X-request meta-link helpers |
docs/scripts.md:43:| `fm-x-reply.sh`          | Post or dry-run preview a composed public-safe X answer or `--followup`, auto-splitting long text into `{request_id,text,texts}` threads and optionally attaching `--image <path>` to the opener; reads text from an argument, stdin, or `--text-file` |
docs/scripts.md:46:| `fm-x-followup.sh`       | Detect, post, and clear the single completion follow-up for an X-linked task, forwarding optional `--image <path>`, enforcing the local 24h window, and retrying only when the relay post fails |
docs/configuration.md:128:Add `--image <path>` to attach one local image as the relay's optional `image` object.
docs/configuration.md:130:Add `--image <path>` there too when the completion follow-up should carry an image.
docs/configuration.md:133:When `--image <path>` is present on a split reply, the image rides the first/opener tweet and later chunks stay text-only.
docs/configuration.md:140:When an image is attached, the dry-run record uses compact `{media_type, bytes, source_path}` metadata instead of writing the base64 bytes.
AGENTS.md:834:When the reply needs one outbound image, pass `--image <path>` to `bin/fm-x-reply.sh`; the helper reads the local file, detects the media type, base64-encodes the raw bytes, and sends the relay's optional `image` object without inlining image bytes into the shell command.
AGENTS.md:841:When the completion follow-up needs one outbound image, pass `--image <path>` to `bin/fm-x-followup.sh`; it forwards the image to `bin/fm-x-reply.sh --followup` so the same relay image contract is used for the follow-up endpoint.
AGENTS.md:859:When `--image <path>` accompanies a reply that auto-splits into a thread, the client includes `image` alongside `text` and `texts`, and the relay attaches that image to the first/opener tweet only while later chunks remain text-only.
AGENTS.md:863:When `--image <path>` is present, the live POST body carries the real `image.data_base64`, but the dry-run outbox stores only a compact marker `{media_type, bytes, source_path}` so previews do not write multi-MB blobs.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (2) ✅</summary>

- 🚨 `bin/fm-x-lib.sh:202` - `--image` stores the base64 blob in a shell variable and passes it to `jq` via `--arg`; the final payload is later passed to `curl --data` the same way. Normal screenshots or generated images can exceed the OS argument limit, so valid image replies will fail before reaching the relay. Stream the encoded data and POST body through stdin or temp files instead, for example `jq -Rs` plus `curl --data-binary @-`.
- ⚠️ `bin/fm-x-lib.sh:248` - The refactor removed the reply client&#39;s EXIT cleanup trap for the bearer-token header file. If the process is interrupted after `fmx_auth_header_file` succeeds and before the explicit `rm`, the token-bearing temp file can be left behind. Restore scoped trap cleanup inside `fmx_post_json` or avoid creating a persistent header file for this path.

🔧 Fix: Stream X image replies safely
1 warning still open:
- ⚠️ `bin/fm-x-reply.sh:76` - `reply_tmp_file` appends to `TMP_FILES`, but every caller invokes it through command substitution, so the append happens in a subshell and the parent EXIT trap never sees the paths. Successful replies and dry-runs now leave request payload temp files behind, and image replies leave base64 image payload files in TMPDIR; create/register the temp path in the parent shell instead.

🔧 Fix: Captain, clean X reply temp tracking
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- <code>Baseline already completed successfully before this run: `command -v tmux &gt;/dev/null || { echo &#34;tmux is required for e2e tests&#34; &gt;&amp;2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo &#34;== $t ==&#34;; bash &#34;$t&#34; || rc=1; done; exit &#34;$rc&#34;`</code>
- `bash tests/fm-x-mode.test.sh`
- <code>Manual fake-relay CLI evidence: `bin/fm-x-reply.sh req-e2e-answer --image &lt;png&gt; ...`, `bin/fm-x-reply.sh req-e2e-noimage ...`, `bin/fm-x-followup.sh task-img --image &lt;png&gt; --text-file ...`, `FMX_DRY_RUN=1 FMX_X_REPLY_MAX_CHARS=50 bin/fm-x-reply.sh req-e2e-thread --image &lt;webp&gt; ...`, missing-image failure, and `--help` excerpts</code>
- `rg -n -- '--image <path>|opener tweet|image object|dry-run record uses compact|compact \{media_type|image support|outbound image' AGENTS.md docs/configuration.md docs/scripts.md bin/fm-x-reply.sh bin/fm-x-followup.sh > /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KWCX362DRKDW9H4EQZ8RSPXH/docs-discoverability.txt`
- <code>`git status --short` and transient artifact scan confirmed no working-tree artifacts were left behind</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
