### PR TITLE
Fix watcher stat mtime probing

### DIFF
--- a/bin/fm-guard.sh
+++ b/bin/fm-guard.sh
@@ -47,13 +47,6 @@ if [ -n "$tangle_branch" ]; then
   } >&2
 fi
 
-# Portable mtime; see fm-watch.sh for why the `stat -f || stat -c` fallback breaks on Linux.
-if [ "$(uname)" = Darwin ]; then
-  stat_mtime() { stat -f %m "$1" 2>/dev/null; }
-else
-  stat_mtime() { stat -c %Y "$1" 2>/dev/null; }
-fi
-
 # Only act with tasks in flight; count them so the banner can say how much is
 # riding on an absent watcher.
 in_flight=0
@@ -71,8 +64,7 @@ BEAT="$STATE/.last-watcher-beat"
 watcher_fresh=false
 beacon_desc=never
 if [ -e "$BEAT" ]; then
-  m=$(stat_mtime "$BEAT")
-  if [ -n "$m" ]; then
+  if m=$(fm_path_mtime "$BEAT"); then
     age=$(( $(date +%s) - m ))
     beacon_desc="${age}s ago"
     [ "$age" -lt "$GRACE" ] && watcher_fresh=true

--- a/bin/fm-stat-lib.sh
+++ b/bin/fm-stat-lib.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Shared stat helpers. Always validate numeric output before callers use it in
+# arithmetic; PATH may contain GNU stat even on Darwin.
+
+fm_is_uint() {
+  case "${1:-}" in
+    ''|*[!0-9]*) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+fm_stat_first_line() {
+  sed -n '1p'
+}
+
+fm_path_mtime() {
+  local path=$1 out
+  if [ "$(uname)" = Darwin ]; then
+    if [ -x /usr/bin/stat ]; then
+      out=$(/usr/bin/stat -f %m "$path" 2>/dev/null | fm_stat_first_line) && fm_is_uint "$out" && { printf '%s\n' "$out"; return 0; }
+    fi
+    out=$(stat -f %m "$path" 2>/dev/null | fm_stat_first_line) && fm_is_uint "$out" && { printf '%s\n' "$out"; return 0; }
+  fi
+  out=$(stat -c %Y "$path" 2>/dev/null | fm_stat_first_line) && fm_is_uint "$out" && { printf '%s\n' "$out"; return 0; }
+  return 1
+}
+
+fm_path_sig() {
+  local path=$1 out
+  if [ "$(uname)" = Darwin ]; then
+    if [ -x /usr/bin/stat ]; then
+      out=$(/usr/bin/stat -f '%z:%Fm' "$path" 2>/dev/null | fm_stat_first_line) && fm_valid_path_sig "$out" && { printf '%s\n' "$out"; return 0; }
+    fi
+    out=$(stat -f '%z:%Fm' "$path" 2>/dev/null | fm_stat_first_line) && fm_valid_path_sig "$out" && { printf '%s\n' "$out"; return 0; }
+  fi
+  out=$(stat -c '%s:%Y' "$path" 2>/dev/null | fm_stat_first_line) && fm_valid_path_sig "$out" && { printf '%s\n' "$out"; return 0; }
+  return 1
+}
+
+fm_valid_path_sig() {
+  case "${1:-}" in
+    *[!0-9:]*|''|:*|*:) return 1 ;;
+    *:*) return 0 ;;
+    *) return 1 ;;
+  esac
+}

--- a/bin/fm-stat-lib.sh
+++ b/bin/fm-stat-lib.sh
@@ -29,9 +29,9 @@ fm_path_sig() {
   local path=$1 out
   if [ "$(uname)" = Darwin ]; then
     if [ -x /usr/bin/stat ]; then
-      out=$(/usr/bin/stat -f '%z:%Fm' "$path" 2>/dev/null | fm_stat_first_line) && fm_valid_path_sig "$out" && { printf '%s\n' "$out"; return 0; }
+      out=$(/usr/bin/stat -f '%z:%m' "$path" 2>/dev/null | fm_stat_first_line) && fm_valid_path_sig "$out" && { printf '%s\n' "$out"; return 0; }
     fi
-    out=$(stat -f '%z:%Fm' "$path" 2>/dev/null | fm_stat_first_line) && fm_valid_path_sig "$out" && { printf '%s\n' "$out"; return 0; }
+    out=$(stat -f '%z:%m' "$path" 2>/dev/null | fm_stat_first_line) && fm_valid_path_sig "$out" && { printf '%s\n' "$out"; return 0; }
   fi
   out=$(stat -c '%s:%Y' "$path" 2>/dev/null | fm_stat_first_line) && fm_valid_path_sig "$out" && { printf '%s\n' "$out"; return 0; }
   return 1

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -116,6 +116,10 @@ FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 # shellcheck source=bin/fm-classify-lib.sh
 . "$FM_DAEMON_DIR/fm-classify-lib.sh"
 
+# Shared stat helpers for validated file mtimes.
+# shellcheck source=bin/fm-stat-lib.sh
+. "$FM_DAEMON_DIR/fm-stat-lib.sh"
+
 # --- tunables ---------------------------------------------------------------
 FM_SUPERVISOR_TARGET_DEFAULT="firstmate:0"
 INJECT_SKIP_DEFAULT="heartbeat"
@@ -158,16 +162,10 @@ AFK_FLAG_NAME=".afk"
 # classifiers can take an explicit state arg without depending on globals.
 _state_root() { printf '%s' "${FM_STATE_OVERRIDE:-$FM_HOME/state}"; }
 
-# --- portable stat (same trap as fm-watch.sh: no `stat -f || stat -c`) -------
-if [ "$(uname)" = Darwin ]; then
-  _stat_file_mtime() { stat -f %m "$1" 2>/dev/null; }
-else
-  _stat_file_mtime() { stat -c %Y "$1" 2>/dev/null; }
-fi
 _now() { date +%s; }
 _file_age() {  # seconds since mtime; very large if missing
   local f=$1 m
-  m=$(_stat_file_mtime "$f") || { echo 999999; return; }
+  m=$(fm_path_mtime "$f") || { echo 999999; return; }
   echo $(( $(_now) - m ))
 }
 

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -11,6 +11,9 @@ FM_WAKE_QUEUE_LOCK="${FM_WAKE_QUEUE_LOCK:-$STATE/.wake-queue.lock}"
 FM_LOCK_STALE_AFTER="${FM_LOCK_STALE_AFTER:-2}"
 mkdir -p "$STATE"
 
+# shellcheck source=bin/fm-stat-lib.sh
+. "$FM_WAKE_LIB_DIR/fm-stat-lib.sh"
+
 fm_current_pid() {
   printf '%s\n' "${BASHPID:-$$}"
 }
@@ -31,14 +34,6 @@ fm_pid_identity() {
   out=$(ps -p "$pid" -o lstart= -o command= 2>/dev/null) || return 1
   [ -n "$out" ] || return 1
   printf '%s\n' "$out" | sed 's/^[[:space:]]*//'
-}
-
-fm_path_mtime() {
-  if [ "$(uname)" = Darwin ]; then
-    stat -f %m "$1" 2>/dev/null
-  else
-    stat -c %Y "$1" 2>/dev/null
-  fi
 }
 
 fm_path_age() {

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -68,21 +68,6 @@ printf '%s\n' "$FM_HOME" > "$WATCH_LOCK/fm-home" || true
 printf '%s\n' "$WATCH_PATH" > "$WATCH_LOCK/watcher-path" || true
 fm_pid_identity "$WATCHER_PID" > "$WATCH_LOCK/pid-identity" 2>/dev/null || true
 
-# Portable stat. macOS (BSD) stat uses `-f <fmt>`; Linux (GNU) stat uses `-c <fmt>`.
-# Do NOT use the `stat -f <fmt> ... || stat -c <fmt> ...` fallback form: on Linux
-# `stat -f` is *filesystem* stat and writes a partial filesystem dump ("File: ...",
-# "Blocks: ...") to stdout before failing, so the fallback's correct output gets
-# appended to that garbage. Arithmetic under `set -u` then aborts on the stray
-# token (e.g. the word "File" read as an unset variable), which silently kills the
-# watcher mid-cycle. Detect the platform once and pick the right form.
-if [ "$(uname)" = Darwin ]; then
-  stat_mtime() { stat -f %m "$1" 2>/dev/null; }        # epoch seconds of mtime
-  stat_sig()   { stat -f '%z:%Fm' "$1" 2>/dev/null; }   # size:mtime signature
-else
-  stat_mtime() { stat -c %Y "$1" 2>/dev/null; }
-  stat_sig()   { stat -c '%s:%Y' "$1" 2>/dev/null; }
-fi
-
 POLL=${FM_POLL:-15}                   # seconds between cycles
 HEARTBEAT=${FM_HEARTBEAT:-600}        # base seconds between heartbeat scans
 HEARTBEAT_MAX=${FM_HEARTBEAT_MAX:-7200}  # heartbeat backoff cap
@@ -188,7 +173,7 @@ wake() {
 # busy fleet. Persist the schedule as file mtimes instead.
 age_of() {  # seconds since file mtime; "due immediately" if missing
   local f=$1 m
-  m=$(stat_mtime "$f") || { echo 999999; return; }
+  m=$(fm_path_mtime "$f") || { echo 999999; return; }
   echo $(( $(date +%s) - m ))
 }
 
@@ -206,7 +191,7 @@ scan_signals() {
   local f sig sf
   for f in "$STATE"/*.status "$STATE"/*.turn-ended; do
     [ -e "$f" ] || continue
-    sig=$(stat_sig "$f") || continue
+    sig=$(fm_path_sig "$f") || continue
     sf="$STATE/.seen-$(basename "$f" | tr '.' '_')"
     if [ "$sig" != "$(cat "$sf" 2>/dev/null)" ]; then
       printf '%s\t%s\t%s\n' "$sf" "$sig" "$f"

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -29,6 +29,7 @@ Each file also starts with a short header comment.
 | `fm-tasks-axi-lib.sh`    | Shared backlog-backend selector and `tasks-axi` compatibility probe sourced by bootstrap and teardown              |
 | `fm-wake-drain.sh`       | Atomically drain queued watcher wakes before handling supervision work, then run the watcher-liveness guard         |
 | `fm-wake-lib.sh`         | Shared durable wake queue and portable lock helpers sourced by the watcher, drain, arm, guard, and daemon          |
+| `fm-stat-lib.sh`         | Shared portable stat helpers (validated mtime and `size:mtime` signatures, guarded against GNU stat on the macOS PATH) sourced by the watcher, guard, daemon, and wake-queue library |
 | `fm-classify-lib.sh`     | Shared captain-relevant wake classifier sourced by the watcher and daemon, plus the watcher's provably-working predicate |
 | `fm-send.sh`             | Send one verified literal line (or `--key Escape`) to a direct-report window; exits non-zero on confirmed swallowed Enter; bare `kind=secondmate` targets are marked as from-firstmate; slash commands and codex `$...` skill invocations get popup-settle before Enter; text sends pause `FM_SEND_SETTLE` seconds after success |
 | `fm-tmux-lib.sh`         | Shared tmux pane primitives for busy detection, dim-ghost-aware and border-aware composer detection, and verified submit retry |

--- a/tests/fm-wake-queue.test.sh
+++ b/tests/fm-wake-queue.test.sh
@@ -10,6 +10,8 @@ set -u
 
 # shellcheck source=tests/wake-helpers.sh
 . "$(dirname "${BASH_SOURCE[0]}")/wake-helpers.sh"
+# shellcheck source=bin/fm-stat-lib.sh
+. "$ROOT/bin/fm-stat-lib.sh"
 
 WATCH="$ROOT/bin/fm-watch.sh"
 DRAIN="$ROOT/bin/fm-wake-drain.sh"
@@ -90,7 +92,7 @@ test_stale_enqueue_before_suppressor() {
   # give the window one and prime the .seen-* marker to its current signature so
   # the per-poll signal scan does not pre-empt the stale wake with a signal wake.
   printf 'done: ready in branch fm/stale\n' > "$state/stale.status"
-  if [ "$(uname)" = Darwin ]; then sig=$(stat -f '%z:%Fm' "$state/stale.status"); else sig=$(stat -c '%s:%Y' "$state/stale.status"); fi
+  sig=$(fm_path_sig "$state/stale.status") || fail "could not stat stale status"
   printf '%s' "$sig" > "$state/.seen-stale_status"
   key=$(printf '%s' "$window" | tr ':/.' '___')
   pane_hash=$(hash_text "idle prompt")
@@ -123,7 +125,7 @@ test_not_working_stale_enqueue_before_suppressor() {
   # Non-terminal status (no captain-relevant verb); prime .seen-* so the per-poll
   # signal scan does not pre-empt the stale path.
   printf 'working: implementing\n' > "$state/stopped.status"
-  if [ "$(uname)" = Darwin ]; then sig=$(stat -f '%z:%Fm' "$state/stopped.status"); else sig=$(stat -c '%s:%Y' "$state/stopped.status"); fi
+  sig=$(fm_path_sig "$state/stopped.status") || fail "could not stat stopped status"
   printf '%s' "$sig" > "$state/.seen-stopped_status"
   key=$(printf '%s' "$window" | tr ':/.' '___')
   pane_hash=$(hash_text "idle prompt, finished")

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -20,6 +20,8 @@ set -u
 . "$(dirname "${BASH_SOURCE[0]}")/wake-helpers.sh"
 # shellcheck source=bin/fm-classify-lib.sh
 . "$ROOT/bin/fm-classify-lib.sh"
+# shellcheck source=bin/fm-stat-lib.sh
+. "$ROOT/bin/fm-stat-lib.sh"
 
 WATCH="$ROOT/bin/fm-watch.sh"
 DRAIN="$ROOT/bin/fm-wake-drain.sh"
@@ -63,16 +65,12 @@ wait_numeric_file() {
   return 1
 }
 
-# Portable mtime in epoch seconds. Platform-detected, never the `stat -f || stat -c`
-# fallback (which writes a partial filesystem dump on Linux; see fm-watch.sh).
 file_mtime() {
-  if [ "$(uname)" = Darwin ]; then stat -f %m "$1" 2>/dev/null; else stat -c %Y "$1" 2>/dev/null; fi
+  fm_path_mtime "$1"
 }
 
-# Signature a primed .seen-* marker must hold so the per-poll signal scan does not
-# fire on a pre-existing status (mirrors fm-watch.sh's stat_sig exactly).
 seen_sig() {
-  if [ "$(uname)" = Darwin ]; then stat -f '%z:%Fm' "$1" 2>/dev/null; else stat -c '%s:%Y' "$1" 2>/dev/null; fi
+  fm_path_sig "$1"
 }
 
 reap() { kill "$1" 2>/dev/null || true; wait "$1" 2>/dev/null || true; }

--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -658,6 +658,28 @@ test_arm_fails_loud_when_no_fresh_watcher_confirmable() {
   pass "arm reports FAILED and exits non-zero when no fresh watcher can be confirmed"
 }
 
+test_path_sig_darwin_bsd_stat() {
+  local sig valid_int valid_float
+  # Regression: %Fm (float-precision mtime) produced '0:1750000000.123456000'
+  # which fm_valid_path_sig rejects.  After the fix to %m (integer epoch-seconds)
+  # the output is '0:1750000000' which must pass.
+  valid_int=$(bash -c '. "$1"; fm_valid_path_sig "0:1750000000" && echo ok || echo fail' _ "$ROOT/bin/fm-stat-lib.sh")
+  [ "$valid_int" = ok ] || fail "fm_valid_path_sig rejected integer sig '0:1750000000'"
+  valid_float=$(bash -c '. "$1"; fm_valid_path_sig "0:1750000000.123456000" && echo ok || echo fail' _ "$ROOT/bin/fm-stat-lib.sh")
+  [ "$valid_float" = fail ] || fail "fm_valid_path_sig accepted float sig '0:1750000000.123456000'"
+  if [ "$(uname)" = Darwin ]; then
+    sig=$(bash -c '. "$1"; fm_path_sig /dev/null' _ "$ROOT/bin/fm-stat-lib.sh") \
+      || fail "fm_path_sig returned non-zero on Darwin"
+    case "$sig" in
+      *[!0-9:]*|''|:*|*:) fail "fm_path_sig returned non-integer sig on Darwin: '$sig'" ;;
+      *:*) ;;
+      *) fail "fm_path_sig returned sig with no colon on Darwin: '$sig'" ;;
+    esac
+  fi
+  pass "fm_valid_path_sig accepts integer and rejects float; fm_path_sig works on Darwin"
+}
+
+test_path_sig_darwin_bsd_stat
 test_singleton_start
 test_stale_watch_lock_reclaimed
 test_live_stale_watch_lock_is_actionable

--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -142,6 +142,45 @@ test_guard_warnings() {
   pass "guard banner leads when down with pending wakes (re-arm-after-drain) and stays silent when fresh"
 }
 
+test_guard_darwin_ignores_path_gnu_stat() {
+  local dir state fakebin err
+  dir=$(make_case guard-darwin-gnu-stat)
+  state="$dir/state"
+  fakebin="$dir/fakebin"
+  err="$dir/guard.err"
+  mkdir -p "$fakebin"
+  cat > "$fakebin/uname" <<'SH'
+#!/usr/bin/env bash
+echo Darwin
+SH
+  cat > "$fakebin/stat" <<'SH'
+#!/usr/bin/env bash
+if [ "${1:-}" = "-f" ]; then
+  cat <<'OUT'
+  File: "fake"
+    ID: 0        Namelen: 255     Type: overlayfs
+OUT
+  exit 0
+fi
+if [ "${1:-}" = "-c" ]; then
+  case "${2:-}" in
+    %Y) date +%s ;;
+    '%s:%Y') printf '1:%s\n' "$(date +%s)" ;;
+    *) exit 1 ;;
+  esac
+  exit 0
+fi
+exit 1
+SH
+  chmod +x "$fakebin/uname" "$fakebin/stat"
+
+  printf 'project=x\n' > "$state/task.meta"
+  touch "$state/.last-watcher-beat"
+  PATH="$fakebin:$PATH" FM_ROOT_OVERRIDE="$dir" FM_STATE_OVERRIDE="$state" FM_GUARD_GRACE=300 "$ROOT/bin/fm-guard.sh" 2> "$err" >/dev/null || fail "guard failed with GNU stat earlier on PATH"
+  [ ! -s "$err" ] || fail "guard warned with fresh beacon under Darwin/GNU stat PATH: $(cat "$err")"
+  pass "guard uses validated mtime when Darwin branch sees GNU stat earlier on PATH"
+}
+
 test_lock_single_winner_under_concurrency() {
   local dir state lockdir marker i pids pid wins
   dir=$(make_case lock-concurrency)
@@ -623,6 +662,7 @@ test_singleton_start
 test_stale_watch_lock_reclaimed
 test_live_stale_watch_lock_is_actionable
 test_guard_warnings
+test_guard_darwin_ignores_path_gnu_stat
 test_lock_single_winner_under_concurrency
 test_lock_steals_dead_pid_lock
 test_lock_stale_steal_single_winner_under_concurrency


### PR DESCRIPTION
## Summary
- add a shared validated stat helper for watcher/guard/wake mtime and signature reads
- prefer BSD /usr/bin/stat on Darwin while rejecting nonnumeric GNU filesystem-stat output
- fix BSD fm_path_sig to use integer %m instead of float %Fm and add Darwin coverage

## Validation
- no-mistakes run 01KWD0AC18D09ZSFGXFAWT21TJ passed review, test, document, and lint on head 4f6f939c1d2a6b13774ec57fb8ce2dafc99e13c0
- no-mistakes push to upstream failed with 403 for benawad on kunchenguid/firstmate, so this PR is opened from the authorized fork benawad/firstmate
- manual pre-gate validation also passed: bash -n bin/*.sh tests/*.sh; for test_script in tests/*.test.sh; do bash ""; done

## Pipeline
Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)