### PR TITLE
Add Mattermost outbox watcher

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,7 @@ tests/fm-bootstrap.test.sh                # bootstrap dependency, feature-probe,
 tests/fm-grok-harness.test.sh             # grok adapter spawn hook, token guard, teardown cleanup, and session-lock detection tests
 tests/fm-fleet-sync.test.sh               # project clone refresh: safe detached recovery, STUCK drift reports, benign skips, and bootstrap relay
 tests/fm-x-mode.test.sh                   # X-mode poll, inbox context round-trip, reply threading, dismiss, dry-run preview, and .env-presence activation tests
+tests/fm-mattermost-outbox-watch.test.sh  # Mattermost PR outbox scan, target resolution, duplicate suppression, and safe failures
 tests/fm-tangle-guard.test.sh             # primary-checkout tangle detection and spawn/brief isolation tests
 tests/fm-spawn-batch.test.sh              # batch dispatch and FM_HOME project-path scoping tests
 tests/fm-spawn-dispatch-profile.test.sh   # concrete dispatch profile flags: active-profile backstop, harness/model/effort meta, launch templates, batch forwarding, and secondmate exemption

--- a/bin/fm-mattermost-outbox-watch.sh
+++ b/bin/fm-mattermost-outbox-watch.sh
@@ -69,9 +69,10 @@ with_lock() {
     sleep 0.1
   done
   _LOCK_PATH="$lock"
-  scan_once
+  scan_once; local rc=$?
   rmdir "$lock" 2>/dev/null || true
   _LOCK_PATH=
+  return "$rc"
 }
 
 hermes_target() {

--- a/bin/fm-mattermost-outbox-watch.sh
+++ b/bin/fm-mattermost-outbox-watch.sh
@@ -26,6 +26,9 @@ STATE="${FM_MATTERMOST_STATE_DIR:-$FM_HOME/state/mattermost-outbox}"
 THREAD_NAME="${FM_MATTERMOST_THREAD_NAME:-SG AI Coordination}"
 POLL="${FM_MATTERMOST_POLL:-5}"
 
+_LOCK_PATH=
+trap 'rmdir "$_LOCK_PATH" 2>/dev/null || true' EXIT
+
 usage() {
   cat >&2 <<'EOF'
 usage: fm-mattermost-outbox-watch.sh [--once|--watch]
@@ -65,8 +68,10 @@ with_lock() {
     fi
     sleep 0.1
   done
-  trap 'rmdir "$lock" 2>/dev/null || true' RETURN
+  _LOCK_PATH="$lock"
   scan_once
+  rmdir "$lock" 2>/dev/null || true
+  _LOCK_PATH=
 }
 
 hermes_target() {

--- a/bin/fm-mattermost-outbox-watch.sh
+++ b/bin/fm-mattermost-outbox-watch.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+# Scan firstmate's local data/outbox/*.json records and post new PR entries to
+# the canonical Services Ground Mattermost coordination thread through hermes.
+#
+# Default mode is one scan, suitable for systemd path activation:
+#   bin/fm-mattermost-outbox-watch.sh
+#
+# Optional polling mode is useful for manual smoke tests:
+#   bin/fm-mattermost-outbox-watch.sh --watch
+#
+# Config:
+#   FM_MATTERMOST_TARGET       Direct hermes target, e.g. mattermost:<post>:<thread>.
+#   FM_MATTERMOST_THREAD_NAME  Target label to resolve from `hermes send --list
+#                              mattermost --json`; defaults to SG AI Coordination.
+#   FM_MATTERMOST_OUTBOX_DIR   Override input dir; defaults to $FM_HOME/data/outbox.
+#   FM_MATTERMOST_STATE_DIR    Override durable state dir; defaults to
+#                              $FM_HOME/state/mattermost-outbox.
+#   FM_MATTERMOST_POLL         Poll interval for --watch; defaults to 5 seconds.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+OUTBOX="${FM_MATTERMOST_OUTBOX_DIR:-$FM_HOME/data/outbox}"
+STATE="${FM_MATTERMOST_STATE_DIR:-$FM_HOME/state/mattermost-outbox}"
+THREAD_NAME="${FM_MATTERMOST_THREAD_NAME:-SG AI Coordination}"
+POLL="${FM_MATTERMOST_POLL:-5}"
+
+usage() {
+  cat >&2 <<'EOF'
+usage: fm-mattermost-outbox-watch.sh [--once|--watch]
+
+Scan data/outbox/*.json for new PR entries and post each PR URL plus risk to the
+Services Ground Mattermost coordination thread through hermes.
+EOF
+}
+
+MODE=once
+case "${1:-}" in
+  ""|--once) MODE=once ;;
+  --watch) MODE=watch ;;
+  --help|-h) usage; exit 0 ;;
+  *) usage; exit 2 ;;
+esac
+
+case "$POLL" in
+  ''|*[!0-9]*) echo "fm-mattermost-outbox-watch: invalid FM_MATTERMOST_POLL: $POLL" >&2; exit 2 ;;
+esac
+
+mkdir_p_state() {
+  mkdir -p "$STATE/posted" 2>/dev/null || {
+    echo "fm-mattermost-outbox-watch: cannot create state dir: $STATE" >&2
+    return 1
+  }
+}
+
+with_lock() {
+  local lock="$STATE/lock" n=0
+  mkdir_p_state || return 1
+  while ! mkdir "$lock" 2>/dev/null; do
+    n=$((n + 1))
+    if [ "$n" -ge 20 ]; then
+      echo "fm-mattermost-outbox-watch: another scan is still running" >&2
+      return 0
+    fi
+    sleep 0.1
+  done
+  trap 'rmdir "$lock" 2>/dev/null || true' RETURN
+  scan_once
+}
+
+hermes_target() {
+  if [ -n "${FM_MATTERMOST_TARGET:-}" ]; then
+    printf '%s\n' "$FM_MATTERMOST_TARGET"
+    return 0
+  fi
+
+  command -v hermes >/dev/null 2>&1 || {
+    echo "fm-mattermost-outbox-watch: hermes not found; set PATH or install hermes" >&2
+    return 1
+  }
+  command -v jq >/dev/null 2>&1 || {
+    echo "fm-mattermost-outbox-watch: jq not found" >&2
+    return 1
+  }
+
+  local targets target_id
+  targets=$(hermes send --list mattermost --json 2>/dev/null) || {
+    echo "fm-mattermost-outbox-watch: cannot list hermes Mattermost targets" >&2
+    return 1
+  }
+  target_id=$(printf '%s\n' "$targets" | jq -r --arg name "$THREAD_NAME" '
+    [.platforms.mattermost[]? | select(.name == $name) | .id] as $exact
+    | if ($exact | length) == 1 then $exact[0]
+      elif ($exact | length) > 1 then "AMBIGUOUS"
+      else
+        [.platforms.mattermost[]? | select(.name | contains($name)) | .id] as $partial
+        | if ($partial | length) == 1 then $partial[0]
+          elif ($partial | length) > 1 then "AMBIGUOUS"
+          else empty end
+      end
+  ' 2>/dev/null) || target_id=
+
+  case "$target_id" in
+    "")
+      echo "fm-mattermost-outbox-watch: cannot resolve Mattermost target '$THREAD_NAME'; set FM_MATTERMOST_TARGET" >&2
+      return 1
+      ;;
+    AMBIGUOUS)
+      echo "fm-mattermost-outbox-watch: Mattermost target '$THREAD_NAME' is ambiguous; set FM_MATTERMOST_TARGET" >&2
+      return 1
+      ;;
+  esac
+  printf 'mattermost:%s\n' "$target_id"
+}
+
+json_pr_url() {
+  local file=$1
+  jq -r '
+    [
+      .pr_url?,
+      .pull_request_url?,
+      .html_url?,
+      .url?,
+      .pr.url?,
+      .pr.html_url?,
+      .pull_request.url?,
+      .pull_request.html_url?
+    ]
+    | map(select(type == "string" and test("^https?://github[.]com/[^[:space:]]+/pull/[0-9]+([/?#].*)?$")))
+    | .[0] // empty
+  ' "$file"
+}
+
+json_risk() {
+  local file=$1
+  jq -r '
+    [
+      .risk?,
+      .risk_value?,
+      .emitted_risk?,
+      .validation.risk?,
+      .checks.risk?
+    ]
+    | map(select(. != null))
+    | .[0] // "unknown"
+    | if type == "string" then . else tostring end
+  ' "$file"
+}
+
+post_key() {
+  printf '%s' "$1" | sha256sum | awk '{print $1}'
+}
+
+message_file_for() {
+  local url=$1 risk=$2 out=$3
+  {
+    printf 'PR: %s\n' "$url"
+    printf 'Risk: %s\n' "$risk"
+  } > "$out"
+}
+
+post_pr() {
+  local file=$1 target=$2 url risk key marker tmp msg rc
+  url=$(json_pr_url "$file" 2>/dev/null) || {
+    echo "fm-mattermost-outbox-watch: malformed JSON: $file" >&2
+    return 0
+  }
+  [ -n "$url" ] || return 0
+
+  risk=$(json_risk "$file" 2>/dev/null) || risk=unknown
+  key=$(post_key "$url")
+  marker="$STATE/posted/$key.posted"
+  [ -e "$marker" ] && return 0
+
+  msg=$(mktemp "${TMPDIR:-/tmp}/fm-mattermost-outbox.XXXXXX") || {
+    echo "fm-mattermost-outbox-watch: cannot create temp message" >&2
+    return 1
+  }
+  message_file_for "$url" "$risk" "$msg"
+  hermes send --to "$target" --file "$msg" --quiet
+  rc=$?
+  rm -f "$msg"
+  if [ "$rc" -ne 0 ]; then
+    echo "fm-mattermost-outbox-watch: hermes send failed for $file" >&2
+    return 1
+  fi
+
+  tmp="$marker.tmp.$$"
+  {
+    printf 'url=%s\n' "$url"
+    printf 'risk=%s\n' "$risk"
+    printf 'source=%s\n' "$file"
+    date -u '+posted_at=%Y-%m-%dT%H:%M:%SZ'
+  } > "$tmp" && mv -f "$tmp" "$marker"
+}
+
+scan_once() {
+  [ -d "$OUTBOX" ] || return 0
+  command -v hermes >/dev/null 2>&1 || {
+    echo "fm-mattermost-outbox-watch: hermes not found; set PATH or install hermes" >&2
+    return 1
+  }
+  command -v jq >/dev/null 2>&1 || {
+    echo "fm-mattermost-outbox-watch: jq not found" >&2
+    return 1
+  }
+
+  local target file
+  target=$(hermes_target) || return 1
+
+  find "$OUTBOX" -maxdepth 1 -type f -name '*.json' -print | LC_ALL=C sort | while IFS= read -r file; do
+    post_pr "$file" "$target" || exit 1
+  done
+}
+
+if [ "$MODE" = watch ]; then
+  while :; do
+    with_lock || exit 1
+    sleep "$POLL"
+  done
+else
+  with_lock
+fi

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -17,6 +17,7 @@ Each file also starts with a short header comment.
 | `fm-config-push.sh`      | Config-only mid-session push of declared inheritable local config into live secondmate homes; reports each item as pushed, unchanged, skipped, or error without fast-forwarding tracked files or nudging agents |
 | `fm-project-mode.sh`     | Resolve a project's delivery mode and `+yolo` flag from `data/projects.md`                                          |
 | `fm-merge-local.sh`      | Fast-forward a `local-only` project's local default branch after approval                                           |
+| `fm-mattermost-outbox-watch.sh` | Scan `data/outbox/*.json` for new PR entries and post each PR URL plus risk to the Services Ground Mattermost coordination thread through `hermes`, using durable `state/mattermost-outbox/posted/` markers to avoid duplicate posts |
 | `fm-review-diff.sh`      | Review a crewmate branch against the authoritative base, with optional `--stat` output                              |
 | `fm-marker-lib.sh`       | Shared from-firstmate request marker and detector sourced by `fm-send.sh`, `fm-brief.sh`, and tests                 |
 | `fm-watch-arm.sh`        | Verified per-home watcher re-arm; reports `started`, `healthy`, or `FAILED`; `--restart` relaunches only this home's watcher |

--- a/systemd/user/firstmate-mattermost-outbox.path
+++ b/systemd/user/firstmate-mattermost-outbox.path
@@ -3,7 +3,6 @@ Description=Watch firstmate PR outbox entries for Services Ground Mattermost
 Documentation=man:systemd.path(5)
 
 [Path]
-PathExistsGlob=%h/firstmate/data/outbox/*.json
 PathChanged=%h/firstmate/data/outbox
 Unit=firstmate-mattermost-outbox.service
 

--- a/systemd/user/firstmate-mattermost-outbox.path
+++ b/systemd/user/firstmate-mattermost-outbox.path
@@ -1,0 +1,11 @@
+[Unit]
+Description=Watch firstmate PR outbox entries for Services Ground Mattermost
+Documentation=man:systemd.path(5)
+
+[Path]
+PathExistsGlob=%h/firstmate/data/outbox/*.json
+PathChanged=%h/firstmate/data/outbox
+Unit=firstmate-mattermost-outbox.service
+
+[Install]
+WantedBy=default.target

--- a/systemd/user/firstmate-mattermost-outbox.service
+++ b/systemd/user/firstmate-mattermost-outbox.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Post firstmate PR outbox entries to Services Ground Mattermost
+Documentation=man:systemd.service(5)
+
+[Service]
+Type=oneshot
+WorkingDirectory=%h/firstmate
+Environment=FM_HOME=%h/firstmate
+Environment="FM_MATTERMOST_THREAD_NAME=SG AI Coordination"
+ExecStart=/usr/bin/env bash %h/firstmate/bin/fm-mattermost-outbox-watch.sh --once

--- a/tests/fm-mattermost-outbox-watch.test.sh
+++ b/tests/fm-mattermost-outbox-watch.test.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+# tests/fm-mattermost-outbox-watch.test.sh - Mattermost outbox watcher behavior.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-mattermost-outbox)
+
+make_hermes_stub() {
+  local fakebin=$1 log=$2 list_json=$3
+  cat > "$fakebin/hermes" <<SH
+#!/usr/bin/env bash
+set -u
+log=$log
+list_json=$list_json
+if [ "\${1:-}" = send ] && [ "\${2:-}" = --list ]; then
+  cat "\$list_json"
+  exit 0
+fi
+if [ "\${1:-}" = send ]; then
+  shift
+  to=
+  file=
+  while [ "\$#" -gt 0 ]; do
+    case "\$1" in
+      --to|-t) shift; to=\${1:-} ;;
+      --file|-f) shift; file=\${1:-} ;;
+      --quiet|-q) : ;;
+    esac
+    shift || true
+  done
+  {
+    printf 'TO=%s\n' "\$to"
+    printf 'BODY<<EOF\n'
+    cat "\$file"
+    printf 'EOF\n'
+  } >> "\$log"
+  exit 0
+fi
+exit 2
+SH
+  chmod +x "$fakebin/hermes"
+}
+
+write_target_list() {
+  local file=$1
+  cat > "$file" <<'JSON'
+{
+  "platforms": {
+    "mattermost": [
+      {
+        "id": "post123:thread456",
+        "name": "SG AI Coordination",
+        "type": "channel",
+        "thread_id": "thread456"
+      }
+    ]
+  }
+}
+JSON
+}
+
+test_posts_pr_once_and_records_marker() {
+  local w="$TMP_ROOT/once" fakebin log targets
+  mkdir -p "$w/home/data/outbox" "$w/home/state"
+  fakebin=$(fm_fakebin "$w")
+  log="$w/hermes.log"
+  targets="$w/targets.json"
+  : > "$log"
+  write_target_list "$targets"
+  make_hermes_stub "$fakebin" "$log" "$targets"
+  cat > "$w/home/data/outbox/pr.json" <<'JSON'
+{"type":"pr","pr_url":"https://github.com/kunchenguid/firstmate/pull/123","risk":"low"}
+JSON
+
+  PATH="$fakebin:$PATH" FM_HOME="$w/home" "$ROOT/bin/fm-mattermost-outbox-watch.sh" \
+    || fail "watcher failed to post PR"
+  PATH="$fakebin:$PATH" FM_HOME="$w/home" "$ROOT/bin/fm-mattermost-outbox-watch.sh" \
+    || fail "watcher failed on duplicate scan"
+
+  [ "$(grep -c '^TO=' "$log")" = 1 ] || fail "watcher must not duplicate posts across restarts"
+  assert_grep "TO=mattermost:post123:thread456" "$log" "watcher must send to resolved Mattermost thread"
+  assert_grep "PR: https://github.com/kunchenguid/firstmate/pull/123" "$log" "message must include PR URL"
+  assert_grep "Risk: low" "$log" "message must include risk"
+  find "$w/home/state/mattermost-outbox/posted" -type f -name '*.posted' | grep . >/dev/null \
+    || fail "watcher must record a durable posted marker"
+  pass "Mattermost outbox watcher posts a PR once and records a durable marker"
+}
+
+test_missing_outbox_is_noop_without_hermes() {
+  local w="$TMP_ROOT/missing"
+  mkdir -p "$w/home"
+  FM_HOME="$w/home" PATH="/usr/bin:/bin" "$ROOT/bin/fm-mattermost-outbox-watch.sh" \
+    || fail "missing outbox should be a safe no-op even when hermes is absent"
+  pass "missing outbox is a safe no-op"
+}
+
+test_malformed_json_does_not_send_or_mark() {
+  local w="$TMP_ROOT/malformed" fakebin log targets
+  mkdir -p "$w/home/data/outbox" "$w/home/state"
+  fakebin=$(fm_fakebin "$w")
+  log="$w/hermes.log"
+  targets="$w/targets.json"
+  : > "$log"
+  write_target_list "$targets"
+  make_hermes_stub "$fakebin" "$log" "$targets"
+  printf '{not json\n' > "$w/home/data/outbox/bad.json"
+
+  PATH="$fakebin:$PATH" FM_HOME="$w/home" "$ROOT/bin/fm-mattermost-outbox-watch.sh" \
+    2>"$w/err" || fail "malformed JSON should not crash the watcher"
+  assert_grep "malformed JSON" "$w/err" "malformed JSON should be reported"
+  [ ! -s "$log" ] || fail "malformed JSON must not be sent"
+  if find "$w/home/state/mattermost-outbox/posted" -type f -name '*.posted' | grep . >/dev/null; then
+    fail "malformed JSON must not create posted markers"
+  fi
+  pass "malformed JSON fails safely without sending"
+}
+
+test_target_resolution_failure_fails_closed() {
+  local w="$TMP_ROOT/no-target" fakebin log targets
+  mkdir -p "$w/home/data/outbox" "$w/home/state"
+  fakebin=$(fm_fakebin "$w")
+  log="$w/hermes.log"
+  targets="$w/targets.json"
+  : > "$log"
+  printf '{"platforms":{"mattermost":[]}}\n' > "$targets"
+  make_hermes_stub "$fakebin" "$log" "$targets"
+  cat > "$w/home/data/outbox/pr.json" <<'JSON'
+{"pr_url":"https://github.com/kunchenguid/firstmate/pull/124","risk":"medium"}
+JSON
+
+  if PATH="$fakebin:$PATH" FM_HOME="$w/home" "$ROOT/bin/fm-mattermost-outbox-watch.sh" 2>"$w/err"; then
+    fail "unresolved Mattermost target should fail closed"
+  fi
+  assert_grep "cannot resolve Mattermost target" "$w/err" "target failure should explain the problem"
+  [ ! -s "$log" ] || fail "unresolved target must not send"
+  pass "unresolved Mattermost target fails closed"
+}
+
+test_explicit_target_skips_target_listing() {
+  local w="$TMP_ROOT/explicit" fakebin log
+  mkdir -p "$w/home/data/outbox" "$w/home/state"
+  fakebin=$(fm_fakebin "$w")
+  log="$w/hermes.log"
+  : > "$log"
+  cat > "$fakebin/hermes" <<SH
+#!/usr/bin/env bash
+set -u
+log=$log
+if [ "\${1:-}" = send ] && [ "\${2:-}" = --list ]; then
+  exit 9
+fi
+shift
+to=
+file=
+while [ "\$#" -gt 0 ]; do
+  case "\$1" in
+    --to|-t) shift; to=\${1:-} ;;
+    --file|-f) shift; file=\${1:-} ;;
+    --quiet|-q) : ;;
+  esac
+  shift || true
+done
+printf 'TO=%s\n' "\$to" >> "\$log"
+cat "\$file" >> "\$log"
+exit 0
+SH
+  chmod +x "$fakebin/hermes"
+  cat > "$w/home/data/outbox/pr.json" <<'JSON'
+{"html_url":"https://github.com/kunchenguid/firstmate/pull/125","risk":"high"}
+JSON
+
+  PATH="$fakebin:$PATH" FM_HOME="$w/home" FM_MATTERMOST_TARGET="mattermost:direct:thread" \
+    "$ROOT/bin/fm-mattermost-outbox-watch.sh" || fail "explicit target should send without listing"
+  assert_grep "TO=mattermost:direct:thread" "$log" "explicit target should be used directly"
+  pass "explicit Mattermost target bypasses target listing"
+}
+
+test_posts_pr_once_and_records_marker
+test_missing_outbox_is_noop_without_hermes
+test_malformed_json_does_not_send_or_mark
+test_target_resolution_failure_fails_closed
+test_explicit_target_skips_target_listing


### PR DESCRIPTION
Summary:
- Add fm-mattermost-outbox-watch.sh to post PR outbox JSON entries to the SG AI Coordination Mattermost thread via hermes.
- Add systemd user service/path units for ~/firstmate/data/outbox changes.
- Add bash tests for target resolution, duplicate suppression, malformed JSON, missing outbox, and explicit target handling.

Validation:
- tests/fm-mattermost-outbox-watch.test.sh
- bash -n bin/fm-mattermost-outbox-watch.sh tests/fm-mattermost-outbox-watch.test.sh
- systemd-analyze verify --user systemd/user/firstmate-mattermost-outbox.service systemd/user/firstmate-mattermost-outbox.path
- no-mistakes full test command ran all tests successfully; no-mistakes failed afterward because its Claude-backed evidence agent hit a session limit.