### PR TITLE
fix: parse PR merge URLs for gh-axi

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,8 @@ Hard rules, in priority order:
 3. **Never tear down a worktree that holds unlanded work.**
    `bin/fm-teardown.sh` enforces this; never bypass it with `--force` unless the captain explicitly said to discard the work.
    The work is "landed" once `HEAD` is reachable from any remote-tracking branch (a fork counts as a remote - upstream-contribution PRs pushed to a fork satisfy this in any mode); for a normal ship task whose commits are not so reachable, it is also landed when its PR is merged and GitHub reports a PR head that contains the current local work (including a local `HEAD` that is an ancestor of the PR head, or unpushed local patches that were replayed into that PR head) or when its content is already present in the up-to-date default branch; for `local-only` ship tasks with no remote at all, the work may instead be merged into the local default branch.
-   The PR consulted for that check comes from the task's recorded `pr=` when present, or - when no `pr=` was ever recorded, e.g. a yolo-authorized merge on a repo with no PR CI where the usual "checks green" `fm-pr-check.sh` trigger never fires - from a merged PR discovered by matching the worktree's own branch name, so a missing `pr=` never by itself false-refuses landed work. Use `bin/fm-pr-merge.sh <id> <PR url>` for every merge (captain-requested or yolo) so `pr=` and any available `pr_head=` are recorded as part of the merge itself rather than relying on that discovery fallback.
+   The PR consulted for that check comes from the task's recorded `pr=` when present, or - when no `pr=` was ever recorded, e.g. a yolo-authorized merge on a repo with no PR CI where the usual "checks green" `fm-pr-check.sh` trigger never fires - from a merged PR discovered by matching the worktree's own branch name, so a missing `pr=` never by itself false-refuses landed work.
+   Use `bin/fm-pr-merge.sh <id> <full GitHub PR URL>` for every merge (captain-requested or yolo) so `pr=` and any available `pr_head=` are recorded as part of the merge itself rather than relying on that discovery fallback.
    Uncommitted changes are never landed.
    The scout carve-out: a scout task's worktree is declared scratch from the start - its deliverable is the report, and teardown lets the worktree go once that report exists (section 7).
 4. **Crewmates never address the captain.**
@@ -483,7 +484,11 @@ A ship task's path from `done` to landed on `main` is set by the project's `mode
 When reviewing any crewmate branch diff, use `bin/fm-review-diff.sh <id>` rather than `git diff <default>...branch` directly.
 Pooled clones keep their local default refs frozen at clone time and can lag `origin`; the helper always compares against the authoritative base.
 
-**yolo (orthogonal).** With `yolo=off` (default) every approval is the captain's: ask-user findings, PR merges, the local-only merge. With `yolo=on`, firstmate makes those calls itself without asking - resolve ask-user findings on your judgment, and run `bin/fm-pr-merge.sh <id> <PR url>` / `bin/fm-merge-local.sh` once the work is green/approved - EXCEPT anything destructive, irreversible, or security-sensitive, which still escalates to the captain. Never merge a red PR even under yolo. `bin/fm-pr-merge.sh` always records `pr=` and records `pr_head=` when available before merging, so this holds even on a repo with no PR CI where the "checks green" signal that normally triggers `bin/fm-pr-check.sh` never fires - do not call `gh-axi pr merge` directly for a task's PR, or the recording step can be silently skipped and a later `fm-teardown.sh` has nothing to verify a squash merge against. After any merge you perform without asking the captain, post a one-line "merged <full PR URL or local main> after checks passed" FYI so the captain keeps a trail.
+**yolo (orthogonal).** With `yolo=off` (default) every approval is the captain's: ask-user findings, PR merges, the local-only merge.
+With `yolo=on`, firstmate makes those calls itself without asking - resolve ask-user findings on your judgment, and run `bin/fm-pr-merge.sh <id> <full GitHub PR URL>` / `bin/fm-merge-local.sh` once the work is green/approved - EXCEPT anything destructive, irreversible, or security-sensitive, which still escalates to the captain.
+Never merge a red PR even under yolo.
+`bin/fm-pr-merge.sh` always records `pr=` and records `pr_head=` when available before merging, parses the full `https://github.com/<owner>/<repo>/pull/<n>` URL into `gh-axi pr merge <n> --repo <owner>/<repo>`, and defaults to `--squash` unless an explicit merge method is forwarded after `--`; this holds even on a repo with no PR CI where the "checks green" signal that normally triggers `bin/fm-pr-check.sh` never fires - do not call `gh-axi pr merge` directly for a task's PR, or the recording step can be silently skipped and a later `fm-teardown.sh` has nothing to verify a squash merge against.
+After any merge you perform without asking the captain, post a one-line "merged <full PR URL or local main> after checks passed" FYI so the captain keeps a trail.
 
 ### Validate
 
@@ -517,7 +522,9 @@ Run `bin/fm-pr-check.sh <id> <PR url>` - it records `pr=` and GitHub's `pr_head=
 Tell the captain: the PR's full URL (always the complete `https://...` link, never a bare `#number` - the captain's terminal makes a full URL clickable), a one-paragraph summary, and, for `no-mistakes`, the risk level it emitted.
 (The check contract, for any custom `state/<id>.check.sh` you write yourself: print one line only when firstmate should wake, print nothing otherwise, and finish before `FM_CHECK_TIMEOUT`.)
 
-If the captain says "merge it", run `bin/fm-pr-merge.sh <id> <PR url>` yourself; that instruction is the explicit approval. If `yolo=on`, merge a green/approved PR yourself the same way and post the required FYI.
+If the captain says "merge it", run `bin/fm-pr-merge.sh <id> <full GitHub PR URL>` yourself; that instruction is the explicit approval.
+If `yolo=on`, merge a green/approved PR yourself the same way and post the required FYI.
+The helper defaults to `--squash`, accepts explicit merge-method flags such as `-- --merge`, `-- --rebase`, or `-- --method=merge`, and refuses `--repo` or `-R` overrides because the repository is derived from the URL.
 
 ### Ship teardown (only after merge is confirmed)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,7 @@ tests/fm-secondmate-harness.test.sh       # secondmate-vs-crewmate harness resol
 tests/fm-secondmate-lifecycle-e2e.test.sh # persistent secondmate routing, seeding, backlog handoff, spawn, recovery, teardown, and FM_HOME flow tests
 tests/fm-secondmate-safety.test.sh        # secondmate home safety, idle charter, handoff validation, and teardown boundary tests
 tests/fm-teardown.test.sh                 # fm-teardown.sh landed-work safety and reminder checks: fork-remote allow, squash/content landings, dirty and unlanded refusals, PR-head metadata, no-pr= branch discovery, tasks-axi/manual backlog reminder, --force override
-tests/fm-pr-merge.test.sh                 # fm-pr-merge.sh records pr= and available pr_head= before merging, propagates real merge failures, and forwards extra gh-axi pr merge flags
+tests/fm-pr-merge.test.sh                 # fm-pr-merge.sh records pr= and available pr_head= before merging, parses PR URLs into gh-axi number/--repo calls, defaults to squash, preserves explicit merge methods, rejects malformed URLs and repo overrides, and propagates real merge failures
 tests/fm-crew-state.test.sh               # fm-crew-state.sh current-state reconciliation: run-step authority including closed panes, stale needs-decision/blocked superseded by a resumed run, genuine-parked, cross-branch attribution, pane/status-log fallback, scout skip, torn-down/missing-meta graceful
 [ "$(readlink CLAUDE.md)" = "AGENTS.md" ]
 [ "$(readlink .claude/skills)" = "../.agents/skills" ]

--- a/bin/fm-pr-merge.sh
+++ b/bin/fm-pr-merge.sh
@@ -14,6 +14,14 @@
 # by omission. Use it for every PR merge (captain-requested or yolo-authorized),
 # in place of calling `gh-axi pr merge` directly.
 #
+# gh-axi pr merge expects a PR number and --repo <owner>/<repo>; it does not
+# parse a full https://github.com/<owner>/<repo>/pull/<n> URL. This script
+# parses the URL and invokes gh-axi in the form it accepts.
+#
+# Merge method: defaults to --squash when the caller passes none of --squash,
+# --merge, --rebase, or --method after the optional -- separator. An explicit
+# caller method is never overridden.
+#
 # Usage: fm-pr-merge.sh <task-id> <pr-url> [-- <extra gh-axi pr merge args>]
 set -eu
 
@@ -29,6 +37,36 @@ STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 META="$STATE/$ID.meta"
 [ -f "$META" ] || { echo "error: no meta for task $ID at $META; refusing to merge without recording pr=" >&2; exit 1; }
 
+caller_has_merge_method() {
+  local arg
+  for arg in "$@"; do
+    case "$arg" in
+      --squash|--merge|--rebase|--method) return 0 ;;
+    esac
+  done
+  return 1
+}
+
+parse_pr_url() {
+  local url=$1
+  if [[ "$url" =~ ^https://github\.com/([^/]+)/([^/]+)/pull/([0-9]+)/?$ ]]; then
+    PR_OWNER="${BASH_REMATCH[1]}"
+    PR_REPO="${BASH_REMATCH[2]}"
+    PR_NUMBER="${BASH_REMATCH[3]}"
+    return 0
+  fi
+  echo "error: PR URL must match https://github.com/<owner>/<repo>/pull/<number> (got: $url)" >&2
+  return 1
+}
+
 "$SCRIPT_DIR/fm-pr-check.sh" "$ID" "$URL"
 grep -qxF "pr=$URL" "$META" || { echo "error: fm-pr-check did not record pr=$URL in $META; refusing to merge" >&2; exit 1; }
-gh-axi pr merge "$URL" "$@"
+
+parse_pr_url "$URL" || exit 1
+
+merge_args=()
+if ! caller_has_merge_method "$@"; then
+  merge_args=(--squash)
+fi
+
+gh-axi pr merge "$PR_NUMBER" --repo "$PR_OWNER/$PR_REPO" "${merge_args[@]}" "$@"

--- a/bin/fm-pr-merge.sh
+++ b/bin/fm-pr-merge.sh
@@ -49,17 +49,33 @@ caller_has_merge_method() {
 
 parse_pr_url() {
   local url=$1
-  if [[ "$url" =~ ^https://github\.com/([^/]+)/([^/]+)/pull/([0-9]+)/?$ ]]; then
+  if [[ "$url" =~ ^https://github\.com/([A-Za-z0-9][A-Za-z0-9-]{0,38})/([A-Za-z0-9._-]+)/pull/([0-9]+)/?$ ]]; then
     PR_OWNER="${BASH_REMATCH[1]}"
     PR_REPO="${BASH_REMATCH[2]}"
     PR_NUMBER="${BASH_REMATCH[3]}"
-    return 0
+    if [[ "$PR_OWNER" != *- ]]; then
+      return 0
+    fi
   fi
   echo "error: PR URL must match https://github.com/<owner>/<repo>/pull/<number> (got: $url)" >&2
   return 1
 }
 
+reject_repo_overrides() {
+  local arg
+  for arg in "$@"; do
+    case "$arg" in
+      --repo|--repo=*|-R|-R?*)
+        echo "error: extra merge args must not override --repo parsed from PR URL (got: $arg)" >&2
+        return 1
+        ;;
+    esac
+  done
+  return 0
+}
+
 parse_pr_url "$URL" || exit 1
+reject_repo_overrides "$@" || exit 1
 
 "$SCRIPT_DIR/fm-pr-check.sh" "$ID" "$URL"
 grep -qxF "pr=$URL" "$META" || { echo "error: fm-pr-check did not record pr=$URL in $META; refusing to merge" >&2; exit 1; }

--- a/bin/fm-pr-merge.sh
+++ b/bin/fm-pr-merge.sh
@@ -41,7 +41,7 @@ caller_has_merge_method() {
   local arg
   for arg in "$@"; do
     case "$arg" in
-      --squash|--merge|--rebase|--method) return 0 ;;
+      --squash|--merge|--rebase|--method|--method=*) return 0 ;;
     esac
   done
   return 1
@@ -59,10 +59,10 @@ parse_pr_url() {
   return 1
 }
 
+parse_pr_url "$URL" || exit 1
+
 "$SCRIPT_DIR/fm-pr-check.sh" "$ID" "$URL"
 grep -qxF "pr=$URL" "$META" || { echo "error: fm-pr-check did not record pr=$URL in $META; refusing to merge" >&2; exit 1; }
-
-parse_pr_url "$URL" || exit 1
 
 merge_args=()
 if ! caller_has_merge_method "$@"; then

--- a/bin/fm-pr-merge.sh
+++ b/bin/fm-pr-merge.sh
@@ -21,6 +21,8 @@
 # Merge method: defaults to --squash when the caller passes none of --squash,
 # --merge, --rebase, or --method after the optional -- separator. An explicit
 # caller method is never overridden.
+# Extra args must not include --repo or -R because the repo is parsed from the
+# PR URL.
 #
 # Usage: fm-pr-merge.sh <task-id> <pr-url> [-- <extra gh-axi pr merge args>]
 set -eu

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -104,6 +104,7 @@ The `data/secondmates.md` line schema and the secondmate environment variables a
 `data/projects.md` records each project's delivery mode and optional `+yolo` autonomy flag.
 `no-mistakes` projects run the full validation pipeline, `direct-PR` projects open PRs without that pipeline, and `local-only` projects stay local until firstmate performs an approved fast-forward merge.
 PR-based task merges go through `bin/fm-pr-merge.sh`, which records `pr=` and any available `pr_head=` through `bin/fm-pr-check.sh` before calling `gh-axi pr merge`.
+The helper requires a full `https://github.com/<owner>/<repo>/pull/<n>` URL, invokes `gh-axi pr merge <n> --repo <owner>/<repo>`, defaults to `--squash`, preserves explicit merge-method flags, and rejects malformed URLs or repo override flags before recording merge state.
 Teardown is fail-closed for ship worktrees: dirty worktrees refuse, and committed work must be landed before the worktree is returned.
 Landed work is accepted when `HEAD` is reachable from any remote-tracking branch, when a merged PR's GitHub head contains the current local work, or when the worktree content is already present in the freshly fetched default branch.
 PR-head containment covers an exact PR head match, a local `HEAD` that is an ancestor of the PR head, or unpushed local patches whose patch IDs appear in the PR head after no-mistakes replayed the branch.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -34,7 +34,7 @@ Each file also starts with a short header comment.
 | `fm-tmux-lib.sh`         | Shared tmux pane primitives for busy detection, dim-ghost-aware and border-aware composer detection, and verified submit retry |
 | `fm-peek.sh`             | Print a bounded tail of a crewmate pane                                                                             |
 | `fm-pr-check.sh`         | Record `pr=` and GitHub's `pr_head=` when available for a PR-ready task, then arm the watcher's merge poll          |
-| `fm-pr-merge.sh`         | Record `pr=` and available `pr_head=` via `fm-pr-check.sh`, then merge the task PR through `gh-axi pr merge` with any extra flags |
+| `fm-pr-merge.sh`         | Require a full GitHub PR URL, record `pr=` and available `pr_head=` via `fm-pr-check.sh`, parse it into `gh-axi pr merge <n> --repo <owner>/<repo>`, default to `--squash` unless a merge method is forwarded, and reject malformed URLs or repo overrides |
 | `fm-promote.sh`          | Promote a scout task in place so it becomes a protected ship task                                                   |
 | `fm-teardown.sh`         | Return a clean, landed ship worktree or retire/release a secondmate home; requires scout reports, checks child work, removes firstmate-owned hook artifacts, and prints the backend-aware backlog reminder |
 | `fm-harness.sh`          | Detect the running harness; resolve the effective crewmate (`crew`) or secondmate-launch (`secondmate`) harness     |

--- a/tests/fm-pr-merge.test.sh
+++ b/tests/fm-pr-merge.test.sh
@@ -13,6 +13,7 @@
 #   (e) PR URL is parsed to number + --repo for gh-axi (defaults to --squash)
 #   (f) malformed PR URL fails fast without calling gh-axi
 #   (g) explicit merge method is not overridden by the default --squash
+#   (h) repo override args fail fast because the repo comes from the URL
 set -u
 
 # shellcheck source=tests/lib.sh

--- a/tests/fm-pr-merge.test.sh
+++ b/tests/fm-pr-merge.test.sh
@@ -8,8 +8,11 @@
 # Matrix:
 #   (a) merge records pr= and pr_head= before merging, and merges
 #   (b) merge is refused when gh-axi pr merge itself fails (no silent success)
-#   (c) extra gh-axi pr merge args are forwarded after the URL
+#   (c) extra gh-axi pr merge args are forwarded after number and --repo
 #   (d) merge is refused before gh-axi when task meta is missing
+#   (e) PR URL is parsed to number + --repo for gh-axi (defaults to --squash)
+#   (f) malformed PR URL fails fast without calling gh-axi
+#   (g) explicit merge method is not overridden by the default --squash
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -107,8 +110,8 @@ test_records_pr_and_head_before_merging() {
     "records-before-merge: pr= was not recorded"
   assert_grep 'pr_head=deadbeefcafefeed0000000000000000deadbeef' "$case_dir/state/task-x1.meta" \
     "records-before-merge: pr_head= was not recorded"
-  grep -qxF 'pr merge https://github.com/example/repo/pull/9' "$case_dir/gh-axi.log" \
-    || fail "records-before-merge: gh-axi pr merge was not invoked with the PR url"
+  grep -qxF 'pr merge 9 --repo example/repo --squash' "$case_dir/gh-axi.log" \
+    || fail "records-before-merge: gh-axi pr merge was not invoked with number, --repo, and default --squash"
   pass "fm-pr-merge records pr= and pr_head= before invoking gh-axi pr merge"
 }
 
@@ -141,7 +144,7 @@ test_extra_merge_args_forwarded() {
   run_pr_merge "$case_dir" task-x1 https://github.com/example/repo/pull/15 -- --squash --delete-branch \
     > "$case_dir/stdout" 2> "$case_dir/stderr" || fail "extra-args: fm-pr-merge failed"
 
-  grep -qxF 'pr merge https://github.com/example/repo/pull/15 --squash --delete-branch' "$case_dir/gh-axi.log" \
+  grep -qxF 'pr merge 15 --repo example/repo --squash --delete-branch' "$case_dir/gh-axi.log" \
     || fail "extra-args: extra gh-axi pr merge flags were not forwarded"
   pass "fm-pr-merge forwards extra flags to gh-axi pr merge after the -- separator"
 }
@@ -169,7 +172,61 @@ test_missing_meta_refuses_before_merge() {
   pass "fm-pr-merge refuses before merging when task meta is missing"
 }
 
+test_malformed_url_refuses_before_merge() {
+  local case_dir rc
+  case_dir=$(make_case malformed-url)
+  mkdir -p "$case_dir/wt"
+  add_gh_mocks "$case_dir" 4444444444444444444444444444444444444444
+  : > "$case_dir/gh-axi.log"
+
+  set +e
+  run_pr_merge "$case_dir" task-x1 'https://gitlab.com/example/repo/-/merge_requests/1' \
+    > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "malformed-url: fm-pr-merge should refuse a non-GitHub PR URL"
+  assert_grep 'PR URL must match https://github.com/<owner>/<repo>/pull/<number>' "$case_dir/stderr" \
+    "malformed-url: refusal did not explain the expected URL shape"
+  grep -qxF 'pr merge' "$case_dir/gh-axi.log" \
+    && fail "malformed-url: gh-axi pr merge was invoked for a malformed URL"
+  pass "fm-pr-merge refuses malformed PR URLs before calling gh-axi"
+}
+
+test_explicit_merge_method_not_overridden() {
+  local case_dir
+  case_dir=$(make_case explicit-merge-method)
+  mkdir -p "$case_dir/wt"
+  add_gh_mocks "$case_dir" 5555555555555555555555555555555555555555
+  : > "$case_dir/gh-axi.log"
+
+  run_pr_merge "$case_dir" task-x1 https://github.com/example/repo/pull/22 -- --merge \
+    > "$case_dir/stdout" 2> "$case_dir/stderr" || fail "explicit-merge-method: fm-pr-merge failed"
+
+  grep -qxF 'pr merge 22 --repo example/repo --merge' "$case_dir/gh-axi.log" \
+    || fail "explicit-merge-method: caller --merge was not forwarded without an extra default --squash"
+  pass "fm-pr-merge does not add default --squash when the caller passes an explicit merge method"
+}
+
+test_parses_pr_url_for_gh_axi() {
+  local case_dir
+  case_dir=$(make_case url-parsing)
+  mkdir -p "$case_dir/wt"
+  add_gh_mocks "$case_dir" 6666666666666666666666666666666666666666
+  : > "$case_dir/gh-axi.log"
+
+  run_pr_merge "$case_dir" task-x1 https://github.com/my-org/my-repo/pull/126/ \
+    > "$case_dir/stdout" 2> "$case_dir/stderr" || fail "url-parsing: fm-pr-merge failed"
+
+  grep -qxF 'pr merge 126 --repo my-org/my-repo --squash' "$case_dir/gh-axi.log" \
+    || fail "url-parsing: gh-axi pr merge was not invoked as number + --repo + default --squash"
+  pass "fm-pr-merge parses a GitHub PR URL into gh-axi number and --repo arguments"
+}
+
 test_records_pr_and_head_before_merging
 test_merge_failure_propagates_after_recording
 test_extra_merge_args_forwarded
 test_missing_meta_refuses_before_merge
+test_malformed_url_refuses_before_merge
+test_explicit_merge_method_not_overridden
+test_parses_pr_url_for_gh_axi

--- a/tests/fm-pr-merge.test.sh
+++ b/tests/fm-pr-merge.test.sh
@@ -188,8 +188,12 @@ test_malformed_url_refuses_before_merge() {
   expect_code 1 "$rc" "malformed-url: fm-pr-merge should refuse a non-GitHub PR URL"
   assert_grep 'PR URL must match https://github.com/<owner>/<repo>/pull/<number>' "$case_dir/stderr" \
     "malformed-url: refusal did not explain the expected URL shape"
-  grep -qxF 'pr merge' "$case_dir/gh-axi.log" \
-    && fail "malformed-url: gh-axi pr merge was invoked for a malformed URL"
+  assert_no_grep 'pr=https://gitlab.com/example/repo/-/merge_requests/1' "$case_dir/state/task-x1.meta" \
+    "malformed-url: malformed PR URL was recorded in meta"
+  assert_absent "$case_dir/state/task-x1.check.sh" \
+    "malformed-url: malformed PR URL armed a merge poll"
+  assert_no_grep 'pr merge' "$case_dir/gh-axi.log" \
+    "malformed-url: gh-axi pr merge was invoked for a malformed URL"
   pass "fm-pr-merge refuses malformed PR URLs before calling gh-axi"
 }
 
@@ -206,6 +210,21 @@ test_explicit_merge_method_not_overridden() {
   grep -qxF 'pr merge 22 --repo example/repo --merge' "$case_dir/gh-axi.log" \
     || fail "explicit-merge-method: caller --merge was not forwarded without an extra default --squash"
   pass "fm-pr-merge does not add default --squash when the caller passes an explicit merge method"
+}
+
+test_method_equals_merge_method_not_overridden() {
+  local case_dir
+  case_dir=$(make_case method-equals-merge-method)
+  mkdir -p "$case_dir/wt"
+  add_gh_mocks "$case_dir" 7777777777777777777777777777777777777777
+  : > "$case_dir/gh-axi.log"
+
+  run_pr_merge "$case_dir" task-x1 https://github.com/example/repo/pull/23 -- --method=merge \
+    > "$case_dir/stdout" 2> "$case_dir/stderr" || fail "method-equals-merge-method: fm-pr-merge failed"
+
+  grep -qxF 'pr merge 23 --repo example/repo --method=merge' "$case_dir/gh-axi.log" \
+    || fail "method-equals-merge-method: caller --method=merge was not forwarded without an extra default --squash"
+  pass "fm-pr-merge respects --method=<value> as an explicit merge method"
 }
 
 test_parses_pr_url_for_gh_axi() {
@@ -229,4 +248,5 @@ test_extra_merge_args_forwarded
 test_missing_meta_refuses_before_merge
 test_malformed_url_refuses_before_merge
 test_explicit_merge_method_not_overridden
+test_method_equals_merge_method_not_overridden
 test_parses_pr_url_for_gh_axi

--- a/tests/fm-pr-merge.test.sh
+++ b/tests/fm-pr-merge.test.sh
@@ -206,6 +206,7 @@ test_rejects_unsafe_url_segments_before_recording() {
   : > "$case_dir/gh-axi.log"
 
   set +e
+  # shellcheck disable=SC2016  # Literal command substitution probes URL parsing safety.
   run_pr_merge "$case_dir" task-x1 'https://github.com/evil$(echo pwned)/repo/pull/7' \
     > "$case_dir/stdout" 2> "$case_dir/stderr"
   rc=$?
@@ -214,6 +215,7 @@ test_rejects_unsafe_url_segments_before_recording() {
   expect_code 1 "$rc" "unsafe-url-segment: fm-pr-merge should refuse unsafe owner/repo characters"
   assert_grep 'PR URL must match https://github.com/<owner>/<repo>/pull/<number>' "$case_dir/stderr" \
     "unsafe-url-segment: refusal did not explain the expected URL shape"
+  # shellcheck disable=SC2016  # Literal command substitution must not reach meta.
   assert_no_grep 'pr=https://github.com/evil$(echo pwned)/repo/pull/7' "$case_dir/state/task-x1.meta" \
     "unsafe-url-segment: unsafe PR URL was recorded in meta"
   assert_absent "$case_dir/state/task-x1.check.sh" \

--- a/tests/fm-pr-merge.test.sh
+++ b/tests/fm-pr-merge.test.sh
@@ -197,6 +197,56 @@ test_malformed_url_refuses_before_merge() {
   pass "fm-pr-merge refuses malformed PR URLs before calling gh-axi"
 }
 
+test_rejects_unsafe_url_segments_before_recording() {
+  local case_dir rc
+  case_dir=$(make_case unsafe-url-segment)
+  mkdir -p "$case_dir/wt"
+  add_gh_mocks "$case_dir" 8888888888888888888888888888888888888888
+  : > "$case_dir/gh-axi.log"
+
+  set +e
+  run_pr_merge "$case_dir" task-x1 'https://github.com/evil$(echo pwned)/repo/pull/7' \
+    > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "unsafe-url-segment: fm-pr-merge should refuse unsafe owner/repo characters"
+  assert_grep 'PR URL must match https://github.com/<owner>/<repo>/pull/<number>' "$case_dir/stderr" \
+    "unsafe-url-segment: refusal did not explain the expected URL shape"
+  assert_no_grep 'pr=https://github.com/evil$(echo pwned)/repo/pull/7' "$case_dir/state/task-x1.meta" \
+    "unsafe-url-segment: unsafe PR URL was recorded in meta"
+  assert_absent "$case_dir/state/task-x1.check.sh" \
+    "unsafe-url-segment: unsafe PR URL armed a merge poll"
+  assert_no_grep 'pr merge' "$case_dir/gh-axi.log" \
+    "unsafe-url-segment: gh-axi pr merge was invoked for an unsafe URL"
+  pass "fm-pr-merge refuses unsafe PR URL segments before recording state"
+}
+
+test_repo_override_args_refuse_before_recording() {
+  local case_dir rc
+  case_dir=$(make_case repo-override)
+  mkdir -p "$case_dir/wt"
+  add_gh_mocks "$case_dir" 9999999999999999999999999999999999999999
+  : > "$case_dir/gh-axi.log"
+
+  set +e
+  run_pr_merge "$case_dir" task-x1 https://github.com/right/repo/pull/5 -- --repo wrong/repo \
+    > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "repo-override: fm-pr-merge should refuse repo override flags"
+  assert_grep 'must not override --repo parsed from PR URL' "$case_dir/stderr" \
+    "repo-override: refusal did not explain the repo override"
+  assert_no_grep 'pr=https://github.com/right/repo/pull/5' "$case_dir/state/task-x1.meta" \
+    "repo-override: PR URL was recorded before rejecting repo override"
+  assert_absent "$case_dir/state/task-x1.check.sh" \
+    "repo-override: repo override armed a merge poll"
+  assert_no_grep 'pr merge' "$case_dir/gh-axi.log" \
+    "repo-override: gh-axi pr merge was invoked despite repo override"
+  pass "fm-pr-merge refuses repo override args before recording state"
+}
+
 test_explicit_merge_method_not_overridden() {
   local case_dir
   case_dir=$(make_case explicit-merge-method)
@@ -247,6 +297,8 @@ test_merge_failure_propagates_after_recording
 test_extra_merge_args_forwarded
 test_missing_meta_refuses_before_merge
 test_malformed_url_refuses_before_merge
+test_rejects_unsafe_url_segments_before_recording
+test_repo_override_args_refuse_before_recording
 test_explicit_merge_method_not_overridden
 test_method_equals_merge_method_not_overridden
 test_parses_pr_url_for_gh_axi


### PR DESCRIPTION
## Intent

Fix bin/fm-pr-merge.sh so it actually merges PRs: gh-axi pr merge rejects a full https://github.com/<owner>/<repo>/pull/<n> URL with 'Missing PR number' and needs the PR number plus --repo <owner>/<repo> because the helper runs from the firstmate repo, not the target project. Parse the URL, invoke gh-axi in the accepted form, default to --squash when the caller passes no merge method (without overriding an explicit --squash/--merge/--rebase/--method), fail fast on malformed URLs, preserve existing pr= recording guards and -- passthrough, and add focused shell tests proving the constructed gh-axi invocation without live merges.

## What Changed
- Parse GitHub PR URLs in `fm-pr-merge.sh` into PR number plus `--repo owner/repo`, rejecting malformed URLs and passthrough repo overrides before merge/check side effects.
- Preserve explicit caller merge methods while defaulting to `--squash` when none is provided, including support for `--method=value` forms.
- Document the captain-approved PR merge URL flow and expand focused shell tests for URL parsing, guard behavior, and constructed `gh-axi pr merge` invocations.

## Risk Assessment

✅ Low: Captain, the change is tightly scoped to URL parsing, gh-axi invocation construction, and focused shell coverage, and I did not find a merge-blocking or follow-up-worthy risk in the current diff.

## Testing

The configured full-suite baseline was already successful, the focused `fm-pr-merge` shell test passed, and the evidence transcript demonstrates the end-user CLI behavior through mocked GitHub calls. The worktree stayed clean and no transient worktree artifacts needed removal.

<details>
<summary>Evidence: fm-pr-merge CLI transcript</summary>

```text
Scenario: default merge method from a full GitHub PR URL
Command: FM_STATE_OVERRIDE=<sandbox>/state PATH=<fakebin> bin/fm-pr-merge.sh task-x1 https://github.com/my-org/my-repo/pull/126/
armed: state/task-x1.check.sh polls https://github.com/my-org/my-repo/pull/126/
Exit: 0

Recorded state/task-x1.meta:
window=fm-task-x1
worktree=<sandbox>/wt
project=<sandbox>/project
kind=ship
mode=no-mistakes
pr=https://github.com/my-org/my-repo/pull/126/
pr_head=feedfacefeedfacefeedfacefeedfacefeedface

Mocked gh-axi invocation log:
pr merge 126 --repo my-org/my-repo --squash

Scenario: malformed non-GitHub PR URL fails before recording or merge
Exit: 1
stderr:
error: PR URL must match https://github.com/<owner>/<repo>/pull/<number> (got: https://gitlab.com/my-org/my-repo/-/merge_requests/126)
Recorded state/task-y1.meta after refusal:
window=fm-task-y1
worktree=<sandbox>/wt
project=<sandbox>/project
kind=ship
mode=no-mistakes
Mocked gh-axi invocation log after refusal:
<empty>

Scenario: explicit --method merge is passed through without default --squash
Command: FM_STATE_OVERRIDE=<sandbox>/state PATH=<fakebin> bin/fm-pr-merge.sh task-z1 https://github.com/example/repo/pull/42 -- --method merge
armed: state/task-z1.check.sh polls https://github.com/example/repo/pull/42
Exit: 0
Mocked gh-axi invocation log:
pr merge 42 --repo example/repo --method merge
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (2) ✅</summary>

- ⚠️ `bin/fm-pr-merge.sh:62` - Malformed URLs are validated only after fm-pr-check runs, so a rejected URL can still append pr= to the task meta and arm state/&lt;id&gt;.check.sh before the script exits. Move parse_pr_url before fm-pr-check so the malformed-url path is actually side-effect free.
- ⚠️ `bin/fm-pr-merge.sh:44` - caller_has_merge_method misses the --method=&lt;value&gt; form that gh-axi&#39;s flag parser accepts. Calling fm-pr-merge.sh with --method=merge or --method=rebase will add the default --squash too, causing gh-axi to reject conflicting merge methods.

🔧 Fix: Harden PR merge validation
2 issues (1 error, 1 warning) still open:
- 🚨 `bin/fm-pr-merge.sh:72` - `&#34;$@&#34;` is appended after the parsed `--repo`, but gh-axi accepts global `--repo`/`-R` there and the last value wins. A call like `fm-pr-merge.sh id https://github.com/right/repo/pull/5 -- --repo wrong/repo` records the right PR in meta while merging PR 5 from another repo; reject repo override flags in passthrough or make the parsed URL repo impossible to override.
- ⚠️ `bin/fm-pr-merge.sh:52` - The URL validator allows any non-slash characters in the owner and repo segments, so malformed strings containing shell metacharacters can still pass and get handed to `fm-pr-check.sh`, which writes the raw URL into `state/&lt;id&gt;.check.sh`. Restrict these captures to GitHub-valid owner/repo characters before calling `fm-pr-check.sh`.

🔧 Fix: Harden PR merge URL guards
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- <code>Baseline already reported successful by the harness: `command -v tmux &gt;/dev/null || { echo &#34;tmux is required for e2e tests&#34; &gt;&amp;2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo &#34;== $t ==&#34;; bash &#34;$t&#34; || rc=1; done; exit &#34;$rc&#34;`.</code>
- `bash tests/fm-pr-merge.test.sh`
- <code>Manual mocked CLI check with fake `gh` and `gh-axi`: ran `bin/fm-pr-merge.sh task-x1 https://github.com/my-org/my-repo/pull/126/`, malformed URL refusal, and `bin/fm-pr-merge.sh task-z1 https://github.com/example/repo/pull/42 -- --method merge`; captured the transcript in `/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KWEC0NY4367QBN0NN0XQDCEV/fm-pr-merge-cli-transcript.txt`.</code>
- <code>Checked cleanup state with `git status --short` and `find . -maxdepth 4 -type d \( -name &#39;.pytest_cache&#39; -o -name &#39;node_modules&#39; -o -name &#39;coverage&#39; -o -name &#39;dist&#39; -o -name &#39;build&#39; -o -name &#39;__pycache__&#39; \) -print`.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
