### PR TITLE
docs: add shared agent behavior guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,26 @@ This repo is a shared template, not the captain's personal project.
 The tracking principle: shared, tracked material is tracked under git; anything personal to this captain's fleet (.env, data/, state/, config/, projects/, .no-mistakes/) is not.
 Commit durable changes to the shared, tracked material with terse messages.
 This repo is itself behind the no-mistakes gate: ship shared, tracked material through the pipeline - branch, commit, run the pipeline, PR - and the captain's merge rule applies here exactly as it does to projects.
-Never add an agent name as co-author.
+
+### General agent behavior
+
+These rules apply anywhere this file controls agent behavior.
+They do not relax the delegation model, captain approval, or the no-mistakes gate.
+
+- Never use the em dash character.
+  Use plain dash `-` instead.
+- Never add an agent name as a commit co-author.
+- Never manually modify `CHANGELOG.md` files or any file marked as generated or auto-generated.
+- When writing or substantially editing a long Markdown file, put each full sentence on its own physical line.
+  Preserve normal Markdown structure, but avoid placing multiple sentences on one physical line.
+- When making technical decisions, treat development cost as a weak signal.
+  Prefer quality, simplicity, robustness, scalability, and long-term maintainability.
+- When fixing a bug, first reproduce it in an end-to-end setting as close as practical to the user's real experience.
+  Make the fix prove it solves the real problem.
+- When end-to-end testing a product, inspect the UI critically and hold it to pixel-level polish.
+  If something clearly looks wrong, try to get it fixed along the way even when it is not the original task.
+- Apply the same standard to engineering health.
+  Treat lint failures, test failures, and flaky tests as real defects; if you see one, work to get it fixed even when it was not introduced by the current change.
 
 ## 2. Layout and state
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,7 @@ See the [no-mistakes quick start](https://kunchenguid.github.io/no-mistakes/star
 
 - This repo is a template for running a firstmate orchestrator agent.
   `AGENTS.md` is the agent's main job description and names when to load bundled skills; `CLAUDE.md` is a symlink to it, and `.claude/skills` is a symlink to `.agents/skills`.
+  General firstmate-agent behavior rules, including writing style, generated-file safety, validation rigor, and testing expectations, live in its `General agent behavior` section.
 - Only shared material is tracked: `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `.tasks.toml`, `.github/workflows/`, `bin/`, and `.agents/skills/`.
   Everything personal to one captain's fleet (`.env`, `data/`, `state/`, `config/`, `projects/`, `.no-mistakes/`) is gitignored; never commit it.
   The root `.tasks.toml` is tracked `tasks-axi` config for `data/backlog.md`; compatible `tasks-axi` is the default backend for routine backlog mutations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ See the [no-mistakes quick start](https://kunchenguid.github.io/no-mistakes/star
   Test scripts and helpers in `tests/` are plain bash too.
   `shellcheck bin/*.sh tests/*.sh` must pass, and CI enforces it.
 - Changes to harness adapters (detection in `bin/fm-harness.sh`, launch and hook mechanics in `bin/fm-spawn.sh`, busy signatures in `bin/fm-watch.sh` and `bin/fm-tmux-lib.sh`, cleanup in `bin/fm-teardown.sh`, and facts in `.agents/skills/harness-adapters/SKILL.md`) must be verified empirically against the real harness, never written from documentation alone.
-- In Markdown, put each full sentence on its own line.
+- When writing or substantially editing a long Markdown file, put each full sentence on its own line.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Agent-only reference skills live under `.agents/skills/` and are loaded by first
 - [docs/architecture.md](docs/architecture.md) - how the crew, supervision, worktrees, secondmates, and project modes work.
 - [docs/configuration.md](docs/configuration.md) - environment variables, `FM_HOME`, optional X mode, the files you set, and harness support.
 - [docs/scripts.md](docs/scripts.md) - the `bin/` toolbelt reference.
-- [`AGENTS.md`](AGENTS.md) - firstmate's full operating manual for the orchestrator agent.
+- [`AGENTS.md`](AGENTS.md) - firstmate's full operating manual, including general behavior rules for the orchestrator agent.
 - [CONTRIBUTING.md](CONTRIBUTING.md) - how to contribute, including the dev/test commands.
 
 ## Contributing

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,6 +5,8 @@ The files and environment variables you set to operate firstmate.
 ## Orchestrator behavior (AGENTS.md)
 
 The shared orchestrator behavior lives in [`AGENTS.md`](../AGENTS.md) - edit it like any prompt when the fleet is empty, or dispatch shared-repo edits to a crewmate while tasks are in flight.
+Its `General agent behavior` section is the shared tracked home for system-level writing, generated-file safety, decision-making, and validation expectations.
+Those rules do not relax the delegation model, captain approval, or the no-mistakes gate.
 
 ## Backlog backend (.tasks.toml / config/backlog-backend)
 


### PR DESCRIPTION
## Intent

Create shared tracked system-level agent behavior guidelines for future firstmate agents, reachable from AGENTS.md, without loosening the delegation model or no-mistakes gate.

## What Changed
- Added shared `AGENTS.md` general agent behavior guidelines covering commit attribution, generated files, Markdown sentence layout, technical decision priorities, bug reproduction, UI inspection, and engineering health expectations.
- Linked the shared guidance from `README.md`, `CONTRIBUTING.md`, and `docs/configuration.md` so future agents can find the system-level behavior rules.
- Clarified that the new behavior guidance does not loosen the delegation model, captain approval rules, or the no-mistakes gate.

## Risk Assessment

✅ Low: Captain, the change is documentation-only, localized to agent behavior guidance and cross-references, with no executable behavior or material consistency issue found.

## Testing

The provided baseline command had already passed; I reran the same full bash test suite at target commit 80572df, produced a focused reachability transcript showing the new AGENTS.md section and its navigation/guardrails, and confirmed the worktree had no transient test artifacts left behind.

<details>
<summary>Evidence: System guideline reachability evidence</summary>

```text
System guideline reachability evidence
Generated from commit: 80572df

Checks performed:
147:- [`AGENTS.md`](AGENTS.md) - firstmate's full operating manual, including general behavior rules for the orchestrator agent.
8:Its `General agent behavior` section is the shared tracked home for system-level writing, generated-file safety, decision-making, and validation expectations.
9:Those rules do not relax the delegation model, captain approval, or the no-mistakes gate.
56:### General agent behavior
59:They do not relax the delegation model, captain approval, or the no-mistakes gate.
61:- Never use the em dash character.
64:- Never manually modify `CHANGELOG.md` files or any file marked as generated or auto-generated.
69:- When fixing a bug, first reproduce it in an end-to-end setting as close as practical to the user's real experience.

AGENTS.md section excerpt:
    56	### General agent behavior
    57	
    58	These rules apply anywhere this file controls agent behavior.
    59	They do not relax the delegation model, captain approval, or the no-mistakes gate.
    60	
    61	- Never use the em dash character.
    62	  Use plain dash `-` instead.
    63	- Never add an agent name as a commit co-author.
    64	- Never manually modify `CHANGELOG.md` files or any file marked as generated or auto-generated.
    65	- When writing or substantially editing a long Markdown file, put each full sentence on its own physical line.
    66	  Preserve normal Markdown structure, but avoid placing multiple sentences on one physical line.
    67	- When making technical decisions, treat development cost as a weak signal.
    68	  Prefer quality, simplicity, robustness, scalability, and long-term maintainability.
    69	- When fixing a bug, first reproduce it in an end-to-end setting as close as practical to the user's real experience.
    70	  Make the fix prove it solves the real problem.
    71	- When end-to-end testing a product, inspect the UI critically and hold it to pixel-level polish.
    72	  If something clearly looks wrong, try to get it fixed along the way even when it is not the original task.
    73	- Apply the same standard to engineering health.
    74	  Treat lint failures, test failures, and flaky tests as real defects; if you see one, work to get it fixed even when it was not introduced by the current change.
    75	

README navigation excerpt:
   140	Agent-only reference skills live under `.agents/skills/` and are loaded by firstmate at the trigger points named in [`AGENTS.md`](AGENTS.md).
   141	
   142	## Documentation
   143	
   144	- [docs/architecture.md](docs/architecture.md) - how the crew, supervision, worktrees, secondmates, and project modes work.
   145	- [docs/configuration.md](docs/configuration.md) - environment variables, `FM_HOME`, optional X mode, the files you set, and harness support.
   146	- [docs/scripts.md](docs/scripts.md) - the `bin/` toolbelt reference.
   147	- [`AGENTS.md`](AGENTS.md) - firstmate's full operating manual, including general behavior rules for the orchestrator agent.
   148	- [CONTRIBUTING.md](CONTRIBUTING.md) - how to contribute, including the dev/test commands.

docs/configuration.md excerpt:
     5	## Orchestrator behavior (AGENTS.md)
     6	
     7	The shared orchestrator behavior lives in [`AGENTS.md`](../AGENTS.md) - edit it like any prompt when the fleet is empty, or dispatch shared-repo edits to a crewmate while tasks are in flight.
     8	Its `General agent behavior` section is the shared tracked home for system-level writing, generated-file safety, decision-making, and validation expectations.
     9	Those rules do not relax the delegation model, captain approval, or the no-mistakes gate.
    10	

Result: PASS - the shared behavior rules are reachable from docs and AGENTS.md, and the new section explicitly preserves delegation, captain approval, and no-mistakes gate constraints.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- <code>Baseline already reported successful before this run: `command -v tmux &gt;/dev/null || { echo &#34;tmux is required for e2e tests&#34; &gt;&amp;2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo &#34;== $t ==&#34;; bash &#34;$t&#34; || rc=1; done; exit &#34;$rc&#34;`</code>
- <code>Target run: `command -v tmux &gt;/dev/null || { echo &#34;tmux is required for e2e tests&#34; &gt;&amp;2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo &#34;== $t ==&#34;; bash &#34;$t&#34; || rc=1; done; exit &#34;$rc&#34;`</code>
- <code>Evidence check: generated `/tmp/no-mistakes-evidence/01KWEVDEZT2ZK9AG8GBHNJRAVW/system-guidelines-reachability.txt` from `rg` fixed-string checks and `nl` excerpts of `README.md`, `docs/configuration.md`, and `AGENTS.md`.</code>
- <code>Cleanup check: `git status --short` and `find . -maxdepth 2 -type d \( -name .pytest_cache -o -name node_modules -o -name dist -o -name build -o -name coverage -o -name tmp \) -print`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
