### PR TITLE
fix(brief): remove apostrophe breaking bash -n and guard bash 3.2 set -u in spawn

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,7 @@ tests/fm-grok-harness.test.sh             # grok adapter spawn hook, token guard
 tests/fm-fleet-sync.test.sh               # project clone refresh: safe detached recovery, STUCK drift reports, benign skips, and bootstrap relay
 tests/fm-x-mode.test.sh                   # X-mode poll, inbox context round-trip, reply threading, dismiss, dry-run preview, and .env-presence activation tests
 tests/fm-tangle-guard.test.sh             # primary-checkout tangle detection, read-only remediation suppression, and spawn/brief isolation tests
+tests/fm-brief.test.sh                    # fm-brief.sh bash -n parse regression guard (issue #166) and clean no-mistakes/direct-PR/local-only brief generation tests
 tests/fm-spawn-batch.test.sh              # batch dispatch and FM_HOME project-path scoping tests
 tests/fm-spawn-dispatch-profile.test.sh   # concrete dispatch profile flags: active-profile backstop, harness/model/effort meta, launch templates, batch forwarding, and secondmate exemption
 tests/fm-update.test.sh                   # fast-forward-only self-update, reread, nudge, dedup, and skip-safety tests

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -208,7 +208,7 @@ When you believe it is complete, append \`done: {summary}\` to the status file a
 Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
 
 You drive no-mistakes by responding to its gates, not by implementing fixes.
-Follow the no-mistakes guidance for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.
+Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.
 Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.
 
 Two firstmate-specific rules layer on top of that guidance:

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -180,9 +180,9 @@ if [ "${#POS[@]}" -gt 0 ] && [ "${POS[0]}" != "$idpart" ] && case "$idpart" in *
       rc=2
       continue
     elif [ "$KIND" = scout ]; then
-      if FM_SPAWN_NO_GUARD=1 "$FM_ROOT/bin/fm-spawn.sh" "${pair%%=*}" "${pair#*=}" "${shared_args[@]}" --scout; then :; else echo "batch: FAILED to spawn ${pair%%=*} (${pair#*=})" >&2; rc=1; fi
+      if FM_SPAWN_NO_GUARD=1 "$FM_ROOT/bin/fm-spawn.sh" "${pair%%=*}" "${pair#*=}" "${shared_args[@]+"${shared_args[@]}"}" --scout; then :; else echo "batch: FAILED to spawn ${pair%%=*} (${pair#*=})" >&2; rc=1; fi
     else
-      if FM_SPAWN_NO_GUARD=1 "$FM_ROOT/bin/fm-spawn.sh" "${pair%%=*}" "${pair#*=}" "${shared_args[@]}"; then :; else echo "batch: FAILED to spawn ${pair%%=*} (${pair#*=})" >&2; rc=1; fi
+      if FM_SPAWN_NO_GUARD=1 "$FM_ROOT/bin/fm-spawn.sh" "${pair%%=*}" "${pair#*=}" "${shared_args[@]+"${shared_args[@]}"}"; then :; else echo "batch: FAILED to spawn ${pair%%=*} (${pair#*=})" >&2; rc=1; fi
     fi
   done
   exit "$rc"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -41,14 +41,14 @@ EOF
 # one of these DOD blocks, since a broken heredoc corrupts or empties the
 # generated brief content, not just the script's own syntax.
 test_ship_modes_generate_clean_briefs() {
-  local home id brief out status
+  local home id brief status
   home="$TMP_ROOT/ship-home"
   write_registry "$home"
 
   for id_proj in "brief-nomistakes-a1:no-registry-proj" "brief-directpr-a2:direct-proj" "brief-localonly-a3:local-proj"; do
     id=${id_proj%%:*}
     proj=${id_proj##*:}
-    out=$(FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" "$proj" 2>&1); status=$?
+    FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" "$proj" >/dev/null 2>&1; status=$?
     expect_code 0 "$status" "fm-brief.sh $id $proj should exit 0"
     brief="$home/data/$id/brief.md"
     assert_present "$brief" "$id: brief was not scaffolded"
@@ -65,7 +65,7 @@ test_no_mistakes_dod_wording() {
   local home id brief
   home="$TMP_ROOT/wording-home"
   mkdir -p "$home/data"
-  id=brief-wording-b1
+  id="brief-wording-b1"
   FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj >/dev/null 2>&1
   brief="$home/data/$id/brief.md"
   assert_present "$brief" "brief was not scaffolded"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Behavior tests for bin/fm-brief.sh.
+#
+# Regression coverage for the heredoc-in-command-substitution parse bug (issue
+# #166): each ship-mode branch builds its Definition-of-done text with
+# `VAR=$(cat <<EOF ... EOF)`. Bash's lexer tracks quote state through the
+# heredoc body while it scans for the matching `)` of the command
+# substitution, so a single unescaped apostrophe anywhere in that body breaks
+# parsing of the *entire rest of the script* - `bash -n` fails, not just the
+# generated brief. A plain `cat > file <<EOF ... EOF` (not wrapped in `$(...)`)
+# is unaffected, so the secondmate charter block does not need this guard.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-brief)
+
+# The script itself must always parse. This is the direct regression test for
+# issue #166: a stray apostrophe in any of the three DOD heredoc bodies
+# (no-mistakes/direct-PR/local-only) breaks `bash -n` on the whole file.
+test_script_parses() {
+  bash -n "$ROOT/bin/fm-brief.sh" 2>&1 || fail "bin/fm-brief.sh fails bash -n (heredoc/quote regression)"
+  pass "fm-brief.sh: bash -n succeeds"
+}
+
+# Registry with one project per delivery mode, so each ship-mode DOD branch is
+# exercised. A project absent from the registry defaults to no-mistakes.
+write_registry() {
+  local home=$1
+  mkdir -p "$home/data"
+  cat > "$home/data/projects.md" <<'EOF'
+- direct-proj [direct-PR] - fixture for direct-PR mode (added 2026-07-01)
+- local-proj [local-only] - fixture for local-only mode (added 2026-07-01)
+EOF
+}
+
+# fm-brief.sh must exit 0 and produce a brief with no unreplaced shell
+# metacharacter corruption for every ship delivery mode. This also guards
+# against any *new* unescaped apostrophe or unbalanced quote later added to
+# one of these DOD blocks, since a broken heredoc corrupts or empties the
+# generated brief content, not just the script's own syntax.
+test_ship_modes_generate_clean_briefs() {
+  local home id brief out status
+  home="$TMP_ROOT/ship-home"
+  write_registry "$home"
+
+  for id_proj in "brief-nomistakes-a1:no-registry-proj" "brief-directpr-a2:direct-proj" "brief-localonly-a3:local-proj"; do
+    id=${id_proj%%:*}
+    proj=${id_proj##*:}
+    out=$(FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" "$proj" 2>&1); status=$?
+    expect_code 0 "$status" "fm-brief.sh $id $proj should exit 0"
+    brief="$home/data/$id/brief.md"
+    assert_present "$brief" "$id: brief was not scaffolded"
+    assert_grep "# Definition of done" "$brief" "$id: brief missing Definition of done section"
+    assert_grep "{TASK}" "$brief" "$id: brief missing the {TASK} placeholder"
+    assert_no_grep "EOF" "$brief" "$id: brief leaked a heredoc EOF marker (unterminated heredoc)"
+  done
+  pass "fm-brief.sh: no-mistakes/direct-PR/local-only briefs generate cleanly"
+}
+
+# Pin the specific line the bug lived on: the no-mistakes DOD's no-mistakes
+# reference must render as plain prose with no dangling apostrophe artifact.
+test_no_mistakes_dod_wording() {
+  local home id brief
+  home="$TMP_ROOT/wording-home"
+  mkdir -p "$home/data"
+  id=brief-wording-b1
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_present "$brief" "brief was not scaffolded"
+  assert_grep "no-mistakes itself provides for the mechanics" "$brief" \
+    "no-mistakes DOD lost its guidance-reference sentence"
+  assert_no_grep "no-mistakes' own guidance" "$brief" \
+    "no-mistakes DOD regressed to the apostrophe form that breaks bash -n"
+  pass "fm-brief.sh: no-mistakes DOD wording avoids the apostrophe regression"
+}
+
+test_script_parses
+test_ship_modes_generate_clean_briefs
+test_no_mistakes_dod_wording


### PR DESCRIPTION
## Intent

Fix GitHub issue #166: bin/fm-brief.sh failed bash -n due to an unescaped apostrophe inside a heredoc nested in a $(cat <<EOF...EOF) command substitution in the no-mistakes-mode Definition-of-done block. Reworded the sentence to remove the apostrophe, audited the other two similar DOD heredoc blocks (direct-PR, local-only) for the same issue (none found), verified bash -n passes and all 5 brief-generation modes produce clean output, and added tests/fm-brief.test.sh as a regression guard. This rerun picks the pipeline back up after two GitHub push-permission blockers: first, no write access to origin kunchenguid/firstmate (resolved by the captain creating a fork at nilushan/firstmate and configuring --fork-url); second, the fork push over SSH failed because this machine's default SSH key is bound to a different GitHub account (nilushan-bluekey) than the fork owner (nilushan); resolved by switching the fork remote to HTTPS, which uses gh's correctly-authenticated nilushan credential via the osxkeychain helper (verified with git ls-remote before retrying).

## What Changed

- Removed an unescaped apostrophe from the no-mistakes-mode Definition-of-done heredoc in `bin/fm-brief.sh`, which broke `bash -n` on the generated script (fixes #166); audited the direct-PR and local-only DOD heredocs for the same issue and found none.
- Guarded `bin/fm-spawn.sh`'s batch dispatch against an empty `shared_args` array under bash 3.2's `set -u`, which previously crashed with an unbound-variable error.
- Added `tests/fm-brief.test.sh` as a regression test covering all brief-generation modes, and listed it in `CONTRIBUTING.md`'s test suite inventory.

## Risk Assessment

✅ Low: Small, well-scoped diff: one wording fix that removes the offending apostrophe, one correct bash-3.2-safe empty-array guard consistent across both call sites, a new regression test that accurately matches fm-brief.sh's mode-routing logic, and a docs line — verified bash -n passes and no other risky patterns introduced.

## Testing

Confirmed end-to-end that both bugs targeted by this change are real on the base commit and fixed on the target: bash -n fails on the pre-fix bin/fm-brief.sh due to the apostrophe inside the no-mistakes DOD heredoc and passes clean post-fix, the new tests/fm-brief.test.sh regression test passes and exercises all three ship delivery modes' brief generation, and the companion bash-3.2 `set -u` crash in bin/fm-spawn.sh's batch dispatch was reproduced live on this machine's actual bash 3.2.57 (unbound variable on an empty shared_args array) and shown fixed via tests/fm-spawn-batch.test.sh. No issues found; working tree left clean with no transient artifacts.

<details>
<summary>Evidence: Before/after reproduction transcript for issue #166 and the companion bash 3.2 fix</summary>

```text
Issue #166 fix verification — bin/fm-brief.sh heredoc apostrophe bug
=====================================================================

Environment: macOS, /bin/bash is GNU bash 3.2.57 (the exact bash version this
repo targets for compatibility), so this is a faithful end-user reproduction,
not a synthetic one.

1) bash -n on the base commit (02f50a3, pre-fix) reproduces the reported bug:

  $ git show 02f50a3:bin/fm-brief.sh > /tmp/fm-brief-base.sh
  $ bash -n /tmp/fm-brief-base.sh
  /tmp/fm-brief-base.sh: line 211: unexpected EOF while looking for matching `''
  /tmp/fm-brief-base.sh: line 263: syntax error: unexpected end of file

2) bash -n on the target commit (6cac45a, post-fix) passes clean:

  $ bash -n bin/fm-brief.sh
  (no output, exit 0)

3) End-to-end: bin/fm-brief.sh actually generates a well-formed brief for all
   three ship delivery modes (no-mistakes, direct-PR, local-only) with no
   leaked heredoc EOF markers and the corrected wording present
   ("no-mistakes itself provides for the mechanics"):

  $ bash tests/fm-brief.test.sh
  ok - fm-brief.sh: bash -n succeeds
  ok - fm-brief.sh: no-mistakes/direct-PR/local-only briefs generate cleanly
  ok - fm-brief.sh: no-mistakes DOD wording avoids the apostrophe regression

4) The companion fix in bin/fm-spawn.sh (bash 3.2 `set -u` guard for an empty
   shared_args array during batch dispatch) is also reproduced against real
   bash 3.2 behavior:

   Base commit (02f50a3), run via a throwaway git worktree, same real bash 3.2:

     $ bash bin/fm-spawn.sh nope-batch-a-z1=projects/none-a nope-batch-b-z2=projects/none-b
     bin/fm-spawn.sh: line 144: shared_args[@]: unbound variable

   Target commit (6cac45a):

     $ bash tests/fm-spawn-batch.test.sh
     ok - batch dispatch re-execs and reports every id=repo pair
     ok - batch detection: single pair batches, non-pair rejected, single-task and slash-id stay single
     ok - projects/ paths are scoped through the firstmate home for single-task spawn

Conclusion: both bugs (the apostrophe-broken heredoc causing bash -n to fail,
and the bash-3.2 unbound-variable crash in batch dispatch) are confirmed
present on the base commit and confirmed fixed on the target commit, on the
exact bash version (3.2.57) where they manifest.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- <code>`bash -n /tmp/fm-brief-base.sh` (base commit 02f50a3 fm-brief.sh) — fails with &#39;unexpected EOF while looking for matching `&#39;&#39;&#39; confirming the reported bug</code>
- <code>`bash -n bin/fm-brief.sh` (target commit 6cac45a) — passes clean</code>
- <code>`bash tests/fm-brief.test.sh` — all 3 assertions pass: script parses, all 3 ship-mode DODs (no-mistakes/direct-PR/local-only) generate clean briefs with no leaked heredoc EOF markers, and the corrected wording is present</code>
- <code>Reproduced the companion bash-3.2 `set -u` unbound-variable crash in bin/fm-spawn.sh batch dispatch by checking out base commit 02f50a3 into a throwaway git worktree and running `bash bin/fm-spawn.sh &lt;two id=repo pairs&gt;` under the machine&#39;s real bash 3.2.57 — confirmed it crashes with &#39;shared_args[@]: unbound variable&#39;</code>
- <code>`bash tests/fm-spawn-batch.test.sh` (target commit) — all 3 assertions pass, including the exact batch-dispatch scenario that crashed on base</code>
- `Full project test suite (tests/*.test.sh) run as baseline plus a partial re-run in this session — no failures observed in fm-brief.test.sh, fm-spawn-batch.test.sh, or other suites reached before a 2-minute tool timeout on the full run`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
