### PR TITLE
fix(fm-brief): unbalanced apostrophe breaks ship-brief scaffolding

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -208,7 +208,7 @@ When you believe it is complete, append \`done: {summary}\` to the status file a
 Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
 
 You drive no-mistakes by responding to its gates, not by implementing fixes.
-Follow no-mistakes' own guidance for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.
+Follow the no-mistakes guidance for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.
 Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.
 
 Two firstmate-specific rules layer on top of that guidance:


### PR DESCRIPTION
## Bug

Scaffolding a **ship** brief with `bin/fm-brief.sh` fails outright:

```
bin/fm-brief.sh: line 211: unexpected EOF while looking for matching `''
```

The script does not parse, so `fm-brief.sh <id> <repo>` (ship path) errors and writes nothing. Scout briefs use a different code path and are unaffected.

## Root cause

In the no-mistakes ship-brief branch (the `*)` default of the `case`), the definition-of-done text is built inside a command-substitution heredoc:

```sh
DOD=$(cat <<EOF
...
Follow no-mistakes' own guidance for the mechanics: ...
...
EOF
)
```

The lone apostrophe in `no-mistakes'` is read by bash's command-substitution parser as an opening single quote that is never closed, so the whole `$( ... )` — and the rest of the script — fails to tokenize.

## Fix

Reword `no-mistakes' own guidance` -> `the no-mistakes guidance` so no unbalanced single quote remains in that heredoc. Minimal one-line change; no restructuring. Grepped the file for other lone/unbalanced single quotes inside `$( ... )` heredocs — line 211 was the only one (other apostrophes are in comments, in single-quoted assignments, or in the plain `cat > "$BRIEF"` redirect heredoc, which is not parsed the same way).

## Verification

- `bash -n bin/fm-brief.sh` now exits 0.
- `bin/fm-brief.sh <throwaway-id> grafana-recommender` (ship, no-mistakes mode — the previously-broken path) prints `scaffolded: ...` and writes a valid brief; throwaway data dir removed afterward.
- `--scout` path still scaffolds correctly.
- Generated ship-brief text reads sensibly after the reword.

Note: related to #166 and overlaps with #173 (which also touches this apostrophe among other changes).