### PR TITLE
fix: detect tmux-launched Codex harness for lock

### DIFF
--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -27,32 +27,59 @@ detect_own() {
   # is unambiguous when firstmate runs natively on grok.
   [ "${GROK_AGENT:-}" = "1" ] && { echo grok; return; }
   # Layer 2: walk the parent chain and match the command name.
-  local pid=$$ comm args
+  local pid=$$ found
   for _ in 1 2 3 4 5 6 7 8; do
-    comm=$(ps -o comm= -p "$pid" 2>/dev/null) || break
-    case "$(basename "$comm")" in
-      *claude*) echo claude; return ;;
-      *codex*) echo codex; return ;;
-      *opencode*) echo opencode; return ;;
-      *grok*) echo grok; return ;;
-      pi) echo pi; return ;;
-      node*|python*)
-        # Bare interpreter: match the harness name in its script path.
-        args=$(ps -o args= -p "$pid" 2>/dev/null)
-        case "$args" in
-          *claude*) echo claude; return ;;
-          *codex*) echo codex; return ;;
-          *opencode*) echo opencode; return ;;
-          *grok*) echo grok; return ;;
-          *" pi "*|*/pi) echo pi; return ;;
-        esac ;;
-    esac
+    found=$(harness_for_pid "$pid") && { echo "$found"; return; }
     pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
     if [ -z "$pid" ] || [ "$pid" -le 1 ]; then
       break
     fi
   done
+  # Layer 3: tmux may keep the stable pane shell as #{pane_pid} while the
+  # harness runs below it. Find a verified harness among that pane's descendants.
+  if pane_pid=$(current_tmux_pane_pid); then
+    found=$(find_harness_descendant "$pane_pid") && { echo "$found"; return; }
+  fi
   echo unknown
+}
+
+current_tmux_pane_pid() {
+  if [ -n "${TMUX_PANE:-}" ]; then
+    tmux display-message -p -t "$TMUX_PANE" '#{pane_pid}' 2>/dev/null && return 0
+  fi
+  tmux display-message -p '#{pane_pid}' 2>/dev/null
+}
+
+harness_for_pid() {
+  local pid=$1 comm args
+  comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
+  case "$(basename "$comm")" in
+    *claude*) echo claude; return 0 ;;
+    *codex*) echo codex; return 0 ;;
+    *opencode*) echo opencode; return 0 ;;
+    *grok*) echo grok; return 0 ;;
+    pi) echo pi; return 0 ;;
+    node*|python*)
+      # Bare interpreter: match the harness name in its script path.
+      args=$(ps -o args= -p "$pid" 2>/dev/null)
+      case "$args" in
+        *claude*) echo claude; return 0 ;;
+        *codex*) echo codex; return 0 ;;
+        *opencode*) echo opencode; return 0 ;;
+        *grok*) echo grok; return 0 ;;
+        *" pi "*|*/pi) echo pi; return 0 ;;
+      esac ;;
+  esac
+  return 1
+}
+
+find_harness_descendant() {
+  local root=$1 child found
+  for child in $(ps -A -o pid=,ppid= | awk -v p="$root" '$2 == p { print $1 }'); do
+    found=$(harness_for_pid "$child") && { echo "$found"; return 0; }
+    found=$(find_harness_descendant "$child") && { echo "$found"; return 0; }
+  done
+  return 1
 }
 
 # Resolve the effective crewmate harness: config/crew-harness (a bare adapter

--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -18,19 +18,46 @@ mkdir -p "$STATE"
 HARNESS_RE='claude|codex|opencode|grok|^pi$'
 
 harness_pid() {
-  local pid=$$ comm args
+  local pid=$$ found
   for _ in 1 2 3 4 5 6 7 8; do
-    comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
-    args=$(ps -o args= -p "$pid" 2>/dev/null)
-    if printf '%s' "$(basename "$comm")" | grep -qE "$HARNESS_RE"; then
-      echo "$pid"; return 0
-    fi
-    # Bare interpreter (e.g. node): match the harness name in its script path.
-    case "$comm" in
-      *node*|*python*) printf '%s' "$args" | grep -qE "$HARNESS_RE" && { echo "$pid"; return 0; } ;;
-    esac
+    found=$(pid_is_harness "$pid") && { echo "$pid"; return 0; }
     pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
-    [ -n "$pid" ] && [ "$pid" -gt 1 ] || return 1
+    [ -n "$pid" ] && [ "$pid" -gt 1 ] || break
+  done
+  # In tmux-launched sessions, #{pane_pid} can be the stable shell with the
+  # harness running as a descendant. Record that harness PID, not this tool shell.
+  if pane_pid=$(current_tmux_pane_pid); then
+    found=$(find_harness_descendant "$pane_pid") && { echo "$found"; return 0; }
+  fi
+  return 1
+}
+
+current_tmux_pane_pid() {
+  if [ -n "${TMUX_PANE:-}" ]; then
+    tmux display-message -p -t "$TMUX_PANE" '#{pane_pid}' 2>/dev/null && return 0
+  fi
+  tmux display-message -p '#{pane_pid}' 2>/dev/null
+}
+
+pid_is_harness() {
+  local pid=$1 comm args
+  comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
+  args=$(ps -o args= -p "$pid" 2>/dev/null)
+  if printf '%s' "$(basename "$comm")" | grep -qE "$HARNESS_RE"; then
+    return 0
+  fi
+  # Bare interpreter (e.g. node): match the harness name in its script path.
+  case "$comm" in
+    *node*|*python*) printf '%s' "$args" | grep -qE "$HARNESS_RE" && return 0 ;;
+  esac
+  return 1
+}
+
+find_harness_descendant() {
+  local root=$1 child found
+  for child in $(ps -A -o pid=,ppid= | awk -v p="$root" '$2 == p { print $1 }'); do
+    pid_is_harness "$child" && { echo "$child"; return 0; }
+    found=$(find_harness_descendant "$child") && { echo "$found"; return 0; }
   done
   return 1
 }


### PR DESCRIPTION
## Summary
- add a tmux-pane descendant fallback for own harness detection when Codex runs below a stable pane shell
- make fm-lock use the same fallback so it records the harness PID, not a transient shell
- prefer TMUX_PANE-targeted tmux lookup before falling back to bare display-message

## Validation
- bash -n bin/fm-harness.sh bin/fm-lock.sh
- bash -n bin/*.sh
- shellcheck bin/fm-harness.sh bin/fm-lock.sh
- bin/fm-harness.sh -> codex
- bin/fm-harness.sh crew -> codex
- bin/fm-lock.sh status -> lock held by live harness pid 73908
- bin/fm-lock.sh -> lock acquired: harness pid 73908
- tmux targeted check: TMUX_PANE resolved to firstmate:fm-fix-codex-lock-tmux-a1 %2 73600 while bare display-message resolved to firstmate:codex-aarch64-a %1 67810
- codex doctor --summary -> 16 ok, 1 idle, 1 warning: threads rollout files are missing from the state DB
- git status --short --branch --untracked-files=all -> clean on fix-codex-tmux-harness-lock

## Gate notes
- no-mistakes v1.31.2 is installed and doctor passes, but no-mistakes axi run failed before creating a run with: no run started for fix-codex-tmux-harness-lock: no previous run for branch fix-codex-tmux-harness-lock
- no-mistakes rerun also failed with: no previous run for branch fix-codex-tmux-harness-lock
- full tests/*.test.sh loop was attempted manually and failed outside this scope in bin/fm-brief.sh: unexpected EOF while looking for matching apostrophe during the brief scaffold test; this matches the existing open fm-brief scaffold bug

===
sorry for the noise. agent opened this before i could catch it 