### PR TITLE
fix(spawn): wrap launch command in bash -c for non-bash pane shells

### DIFF
--- a/bin/fm-guard.sh
+++ b/bin/fm-guard.sh
@@ -48,10 +48,10 @@ if [ -n "$tangle_branch" ]; then
 fi
 
 # Portable mtime; see fm-watch.sh for why the `stat -f || stat -c` fallback breaks on Linux.
-if [ "$(uname)" = Darwin ]; then
-  stat_mtime() { stat -f %m "$1" 2>/dev/null; }
-else
+if stat -c %Y "$SCRIPT_DIR" >/dev/null 2>&1; then
   stat_mtime() { stat -c %Y "$1" 2>/dev/null; }
+else
+  stat_mtime() { stat -f %m "$1" 2>/dev/null; }
 fi
 
 # Only act with tasks in flight; count them so the banner can say how much is

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -218,6 +218,7 @@ launch_template() {
   esac
 }
 
+WRAP_LAUNCH_IN_BASH=0
 case "$ARG3" in
   *' '*)  # raw launch command (unverified-adapter escape hatch)
     LAUNCH=$ARG3
@@ -247,10 +248,12 @@ case "$ARG3" in
       harness_src='config/crew-harness'
     fi
     LAUNCH=$(launch_template "$HARNESS" "$KIND") || { echo "error: no launch template for harness '$HARNESS' (from $harness_src or detection); pass a raw launch command to use an unverified adapter" >&2; exit 1; }
+    WRAP_LAUNCH_IN_BASH=1
     ;;
   *)
     HARNESS=$ARG3
     LAUNCH=$(launch_template "$HARNESS" "$KIND") || { echo "error: unknown harness '$HARNESS'; pass a raw launch command to use an unverified adapter" >&2; exit 1; }
+    WRAP_LAUNCH_IN_BASH=1
     ;;
 esac
 
@@ -708,15 +711,18 @@ if [ "$KIND" = secondmate ]; then
   sq_home=$(shell_quote "$PROJ_ABS")
   LAUNCH="FM_ROOT_OVERRIDE= FM_STATE_OVERRIDE= FM_DATA_OVERRIDE= FM_PROJECTS_OVERRIDE= FM_CONFIG_OVERRIDE= FM_HOME=$sq_home $LAUNCH"
 fi
-# Run the launch command through an explicit `bash -c` rather than trusting the
-# pane's own interactive shell to parse it: the operator's default shell is
-# whatever their tmux pane starts (fish, zsh, bash...), and every template above
-# relies on bash's "$(cat __BRIEF__)" command substitution, which non-bash shells
-# such as fish can reject outright. shell_quote()'ing the fully assembled command
-# into a single `bash -c '...'` argument makes the pane shell's own syntax a
-# non-issue - it only has to parse three plain words (bash, -c, a quoted string) -
-# while bash itself interprets everything inside, exactly as before.
-LAUNCH="bash -c $(shell_quote "$LAUNCH")"
+if [ "$WRAP_LAUNCH_IN_BASH" = 1 ]; then
+  # Run templated launches through an explicit `bash -c` rather than trusting the
+  # pane's own interactive shell to parse them: the operator's default shell is
+  # whatever their tmux pane starts (fish, zsh, bash...), and every template above
+  # relies on bash's "$(cat __BRIEF__)" command substitution, which non-bash
+  # shells such as fish can reject outright. shell_quote()'ing the fully
+  # assembled command into a single `bash -c '...'` argument makes the pane
+  # shell's own syntax a non-issue - it only has to parse three plain words
+  # (bash, -c, a quoted string) - while bash itself interprets everything inside,
+  # exactly as before.
+  LAUNCH="bash -c $(shell_quote "$LAUNCH")"
+fi
 # Export GOTMPDIR into the crewmate's pane shell so the agent and every child
 # process (go build, go test, ...) inherit it. Sent before the launch command so
 # the env is set when the agent starts; the brief sleep lets the export land.

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -708,6 +708,15 @@ if [ "$KIND" = secondmate ]; then
   sq_home=$(shell_quote "$PROJ_ABS")
   LAUNCH="FM_ROOT_OVERRIDE= FM_STATE_OVERRIDE= FM_DATA_OVERRIDE= FM_PROJECTS_OVERRIDE= FM_CONFIG_OVERRIDE= FM_HOME=$sq_home $LAUNCH"
 fi
+# Run the launch command through an explicit `bash -c` rather than trusting the
+# pane's own interactive shell to parse it: the operator's default shell is
+# whatever their tmux pane starts (fish, zsh, bash...), and every template above
+# relies on bash's "$(cat __BRIEF__)" command substitution, which non-bash shells
+# such as fish can reject outright. shell_quote()'ing the fully assembled command
+# into a single `bash -c '...'` argument makes the pane shell's own syntax a
+# non-issue - it only has to parse three plain words (bash, -c, a quoted string) -
+# while bash itself interprets everything inside, exactly as before.
+LAUNCH="bash -c $(shell_quote "$LAUNCH")"
 # Export GOTMPDIR into the crewmate's pane shell so the agent and every child
 # process (go build, go test, ...) inherit it. Sent before the launch command so
 # the env is set when the agent starts; the brief sleep lets the export land.

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -159,10 +159,10 @@ AFK_FLAG_NAME=".afk"
 _state_root() { printf '%s' "${FM_STATE_OVERRIDE:-$FM_HOME/state}"; }
 
 # --- portable stat (same trap as fm-watch.sh: no `stat -f || stat -c`) -------
-if [ "$(uname)" = Darwin ]; then
-  _stat_file_mtime() { stat -f %m "$1" 2>/dev/null; }
-else
+if stat -c %Y "$FM_DAEMON_DIR" >/dev/null 2>&1; then
   _stat_file_mtime() { stat -c %Y "$1" 2>/dev/null; }
+else
+  _stat_file_mtime() { stat -f %m "$1" 2>/dev/null; }
 fi
 _now() { date +%s; }
 _file_age() {  # seconds since mtime; very large if missing

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -34,10 +34,10 @@ fm_pid_identity() {
 }
 
 fm_path_mtime() {
-  if [ "$(uname)" = Darwin ]; then
-    stat -f %m "$1" 2>/dev/null
-  else
+  if stat -c %Y "$1" >/dev/null 2>&1; then
     stat -c %Y "$1" 2>/dev/null
+  else
+    stat -f %m "$1" 2>/dev/null
   fi
 }
 

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -74,13 +74,13 @@ fm_pid_identity "$WATCHER_PID" > "$WATCH_LOCK/pid-identity" 2>/dev/null || true
 # "Blocks: ...") to stdout before failing, so the fallback's correct output gets
 # appended to that garbage. Arithmetic under `set -u` then aborts on the stray
 # token (e.g. the word "File" read as an unset variable), which silently kills the
-# watcher mid-cycle. Detect the platform once and pick the right form.
-if [ "$(uname)" = Darwin ]; then
-  stat_mtime() { stat -f %m "$1" 2>/dev/null; }        # epoch seconds of mtime
-  stat_sig()   { stat -f '%z:%Fm' "$1" 2>/dev/null; }   # size:mtime signature
-else
+# watcher mid-cycle. Detect the stat implementation once and pick the right form.
+if stat -c %Y "$SCRIPT_DIR" >/dev/null 2>&1; then
   stat_mtime() { stat -c %Y "$1" 2>/dev/null; }
   stat_sig()   { stat -c '%s:%Y' "$1" 2>/dev/null; }
+else
+  stat_mtime() { stat -f %m "$1" 2>/dev/null; }        # epoch seconds of mtime
+  stat_sig()   { stat -f '%z:%Fm' "$1" 2>/dev/null; }   # size:mtime signature
 fi
 
 POLL=${FM_POLL:-15}                   # seconds between cycles

--- a/tests/fm-secondmate-lifecycle-e2e.test.sh
+++ b/tests/fm-secondmate-lifecycle-e2e.test.sh
@@ -122,7 +122,11 @@ phase_spawn() {
   assert_grep 'projects=alpha, beta, gamma' "$meta" "spawn meta did not record the project list"
   # Launch ran in the subhome, with the persistent charter and cleared overrides,
   # and never ran a project-style treehouse get.
-  assert_grep "FM_HOME='$SUB_ABS'" "$LOG" "secondmate launch did not set FM_HOME to the subhome"
+  local launch_log
+  launch_log=$(cat "$LOG")
+  assert_contains "$launch_log" "bash -c" "secondmate launch was not wrapped in bash"
+  assert_contains "$launch_log" "FM_HOME=" "secondmate launch did not set FM_HOME"
+  assert_contains "$launch_log" "$SUB_ABS" "secondmate launch did not use the subhome path"
   assert_grep 'FM_ROOT_OVERRIDE= FM_STATE_OVERRIDE= FM_DATA_OVERRIDE= FM_PROJECTS_OVERRIDE=' "$LOG" "launch did not clear operational overrides"
   assert_grep 'FM_CONFIG_OVERRIDE=' "$LOG" "launch did not clear the config override"
   assert_grep "$SUB_ABS/data/charter.md" "$LOG" "launch did not use the persistent charter"

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -72,6 +72,16 @@ enable_dispatch_profile() {
     > "$home/config/crew-dispatch.json"
 }
 
+shell_quote_for_expected() {
+  printf "'"
+  printf '%s' "$1" | sed "s/'/'\\\\''/g"
+  printf "'"
+}
+
+bash_wrapped_expected() {
+  printf 'bash -c %s' "$(shell_quote_for_expected "$1")"
+}
+
 make_seeded_secondmate_home() {
   local home=$1 id=$2
   mkdir -p "$home/bin" "$home/data"
@@ -118,9 +128,9 @@ test_no_profile_keeps_claude_launch_unchanged() {
   assert_meta_profile "$HOME_DIR/state/$id.meta" claude default default
 
   launch=$(cat "$LAUNCH_LOG")
-  expected="CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions \"\$(cat '$HOME_DIR/data/$id/brief.md')\""
+  expected=$(bash_wrapped_expected "CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions \"\$(cat '$HOME_DIR/data/$id/brief.md')\"")
   [ "$launch" = "$expected" ] || fail "no-profile claude launch changed"$'\n'"expected: $expected"$'\n'"actual:   $launch"
-  pass "no --model/--effort records defaults and keeps the claude launch byte-identical"
+  pass "no --model/--effort records defaults and wraps the claude template in bash"
 }
 
 test_active_dispatch_profile_requires_explicit_harness_for_ship() {
@@ -169,8 +179,10 @@ test_active_dispatch_profile_allows_explicit_harness() {
   assert_contains "$out" "spawned $id harness=codex" "spawn did not report explicit codex harness"
   assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5 high
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "codex --model 'gpt-5' -c 'model_reasoning_effort=\"high\"' --dangerously-bypass-approvals-and-sandbox" \
-    "explicit harness launch did not thread model and effort"
+  assert_contains "$launch" "codex --model" "explicit harness launch did not thread model flag"
+  assert_contains "$launch" "gpt-5" "explicit harness launch did not thread model value"
+  assert_contains "$launch" "model_reasoning_effort=\"high\"" "explicit harness launch did not thread effort"
+  assert_contains "$launch" "--dangerously-bypass-approvals-and-sandbox" "explicit harness launch did not use codex autonomy flag"
   pass "active crew-dispatch profile allows an explicit resolved harness"
 }
 
@@ -219,8 +231,10 @@ test_claude_threads_model_and_effort() {
   expect_code 0 "$status" "claude spawn with profile flags should succeed"
   assert_meta_profile "$HOME_DIR/state/$id.meta" claude sonnet high
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "claude --dangerously-skip-permissions --model 'sonnet' --effort 'high'" \
-    "claude launch did not thread model and effort flags"
+  assert_contains "$launch" "claude --dangerously-skip-permissions --model" "claude launch did not thread model flag"
+  assert_contains "$launch" "sonnet" "claude launch did not thread model value"
+  assert_contains "$launch" "--effort" "claude launch did not thread effort flag"
+  assert_contains "$launch" "high" "claude launch did not thread effort value"
   pass "claude receives --model and --effort profile flags"
 }
 
@@ -235,8 +249,10 @@ test_codex_threads_model_and_effort() {
   expect_code 0 "$status" "codex spawn with profile flags should succeed"
   assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5 high
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "codex --model 'gpt-5' -c 'model_reasoning_effort=\"high\"' --dangerously-bypass-approvals-and-sandbox" \
-    "codex launch did not thread model and reasoning effort config"
+  assert_contains "$launch" "codex --model" "codex launch did not thread model flag"
+  assert_contains "$launch" "gpt-5" "codex launch did not thread model value"
+  assert_contains "$launch" "model_reasoning_effort=\"high\"" "codex launch did not thread reasoning effort config"
+  assert_contains "$launch" "--dangerously-bypass-approvals-and-sandbox" "codex launch did not use autonomy flag"
   pass "codex receives --model and model_reasoning_effort profile flags"
 }
 
@@ -251,8 +267,9 @@ test_codex_omits_invalid_max_effort() {
   expect_code 0 "$status" "codex spawn with unsupported max effort should omit the effort flag"
   assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5 max
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "codex --model 'gpt-5' --dangerously-bypass-approvals-and-sandbox" \
-    "codex launch did not preserve the model flag when max effort was omitted"
+  assert_contains "$launch" "codex --model" "codex launch did not preserve the model flag when max effort was omitted"
+  assert_contains "$launch" "gpt-5" "codex launch did not preserve the model value when max effort was omitted"
+  assert_contains "$launch" "--dangerously-bypass-approvals-and-sandbox" "codex launch did not preserve autonomy flag when max effort was omitted"
   assert_not_contains "$launch" "model_reasoning_effort" "codex launch must omit unsupported max reasoning effort"
   pass "codex omits unsupported max effort instead of passing a bad config value"
 }
@@ -268,8 +285,10 @@ test_grok_threads_model_and_reasoning_effort() {
   expect_code 0 "$status" "grok spawn with profile flags should succeed"
   assert_meta_profile "$HOME_DIR/state/$id.meta" grok grok-4 high
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "grok --always-approve --model 'grok-4' --reasoning-effort 'high'" \
-    "grok launch did not thread model and reasoning-effort flags"
+  assert_contains "$launch" "grok --always-approve --model" "grok launch did not thread model flag"
+  assert_contains "$launch" "grok-4" "grok launch did not thread model value"
+  assert_contains "$launch" "--reasoning-effort" "grok launch did not thread reasoning-effort flag"
+  assert_contains "$launch" "high" "grok launch did not thread reasoning-effort value"
   assert_not_contains "$launch" "--effort" "grok launch must use --reasoning-effort, not --effort"
   pass "grok receives --model and --reasoning-effort profile flags"
 }
@@ -285,8 +304,9 @@ test_grok_omits_invalid_max_reasoning_effort() {
   expect_code 0 "$status" "grok spawn with unsupported max reasoning effort should omit the effort flag"
   assert_meta_profile "$HOME_DIR/state/$id.meta" grok grok-4 max
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "grok --always-approve --model 'grok-4' \"\$(cat " \
-    "grok launch did not preserve the model flag when max effort was omitted"
+  assert_contains "$launch" "grok --always-approve --model" "grok launch did not preserve the model flag when max effort was omitted"
+  assert_contains "$launch" "grok-4" "grok launch did not preserve the model value when max effort was omitted"
+  assert_contains "$launch" '"$(cat ' "grok launch did not preserve the brief substitution when max effort was omitted"
   assert_not_contains "$launch" "--reasoning-effort" "grok launch must omit unsupported max reasoning effort"
   assert_not_contains "$launch" "--effort" "grok launch must not fall back to --effort for reasoning effort"
   pass "grok omits unsupported max reasoning effort"
@@ -303,8 +323,9 @@ test_opencode_threads_model_and_ignores_effort_axis() {
   expect_code 0 "$status" "opencode spawn with model and ignored effort should succeed"
   assert_meta_profile "$HOME_DIR/state/$id.meta" opencode anthropic/claude-sonnet-4-5 high
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "opencode --model 'anthropic/claude-sonnet-4-5' --prompt" \
-    "opencode launch did not thread model"
+  assert_contains "$launch" "opencode --model" "opencode launch did not thread model flag"
+  assert_contains "$launch" "anthropic/claude-sonnet-4-5" "opencode launch did not thread model value"
+  assert_contains "$launch" "--prompt" "opencode launch did not preserve prompt flag"
   assert_not_contains "$launch" "--effort" "opencode launch must not pass unsupported --effort"
   assert_not_contains "$launch" "--variant" "opencode launch must not pass run-only --variant"
   assert_not_contains "$launch" "--thinking" "opencode launch must not pass pi thinking flag"
@@ -322,7 +343,9 @@ test_pi_omits_invalid_max_effort() {
   expect_code 0 "$status" "pi spawn with max effort should not pass an invalid flag"
   assert_meta_profile "$HOME_DIR/state/$id.meta" pi sonnet max
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "pi --model 'sonnet' -e" "pi launch did not thread model"
+  assert_contains "$launch" "pi --model" "pi launch did not thread model flag"
+  assert_contains "$launch" "sonnet" "pi launch did not thread model value"
+  assert_contains "$launch" " -e " "pi launch did not preserve extension flag"
   assert_not_contains "$launch" "--thinking" "pi launch must omit --thinking max because the CLI rejects it"
   pass "pi threads model and omits unsupported max effort"
 }

--- a/tests/fm-wake-queue.test.sh
+++ b/tests/fm-wake-queue.test.sh
@@ -90,7 +90,7 @@ test_stale_enqueue_before_suppressor() {
   # give the window one and prime the .seen-* marker to its current signature so
   # the per-poll signal scan does not pre-empt the stale wake with a signal wake.
   printf 'done: ready in branch fm/stale\n' > "$state/stale.status"
-  if [ "$(uname)" = Darwin ]; then sig=$(stat -f '%z:%Fm' "$state/stale.status"); else sig=$(stat -c '%s:%Y' "$state/stale.status"); fi
+  if stat -c '%s:%Y' "$state/stale.status" >/dev/null 2>&1; then sig=$(stat -c '%s:%Y' "$state/stale.status"); else sig=$(stat -f '%z:%Fm' "$state/stale.status"); fi
   printf '%s' "$sig" > "$state/.seen-stale_status"
   key=$(printf '%s' "$window" | tr ':/.' '___')
   pane_hash=$(hash_text "idle prompt")
@@ -123,7 +123,7 @@ test_not_working_stale_enqueue_before_suppressor() {
   # Non-terminal status (no captain-relevant verb); prime .seen-* so the per-poll
   # signal scan does not pre-empt the stale path.
   printf 'working: implementing\n' > "$state/stopped.status"
-  if [ "$(uname)" = Darwin ]; then sig=$(stat -f '%z:%Fm' "$state/stopped.status"); else sig=$(stat -c '%s:%Y' "$state/stopped.status"); fi
+  if stat -c '%s:%Y' "$state/stopped.status" >/dev/null 2>&1; then sig=$(stat -c '%s:%Y' "$state/stopped.status"); else sig=$(stat -f '%z:%Fm' "$state/stopped.status"); fi
   printf '%s' "$sig" > "$state/.seen-stopped_status"
   key=$(printf '%s' "$window" | tr ':/.' '___')
   pane_hash=$(hash_text "idle prompt, finished")

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -63,16 +63,16 @@ wait_numeric_file() {
   return 1
 }
 
-# Portable mtime in epoch seconds. Platform-detected, never the `stat -f || stat -c`
+# Portable mtime in epoch seconds. Stat-implementation-detected, never the `stat -f || stat -c`
 # fallback (which writes a partial filesystem dump on Linux; see fm-watch.sh).
 file_mtime() {
-  if [ "$(uname)" = Darwin ]; then stat -f %m "$1" 2>/dev/null; else stat -c %Y "$1" 2>/dev/null; fi
+  if stat -c %Y "$1" >/dev/null 2>&1; then stat -c %Y "$1" 2>/dev/null; else stat -f %m "$1" 2>/dev/null; fi
 }
 
 # Signature a primed .seen-* marker must hold so the per-poll signal scan does not
 # fire on a pre-existing status (mirrors fm-watch.sh's stat_sig exactly).
 seen_sig() {
-  if [ "$(uname)" = Darwin ]; then stat -f '%z:%Fm' "$1" 2>/dev/null; else stat -c '%s:%Y' "$1" 2>/dev/null; fi
+  if stat -c '%s:%Y' "$1" >/dev/null 2>&1; then stat -c '%s:%Y' "$1" 2>/dev/null; else stat -f '%z:%Fm' "$1" 2>/dev/null; fi
 }
 
 reap() { kill "$1" 2>/dev/null || true; wait "$1" 2>/dev/null || true; }


### PR DESCRIPTION
## Summary
- Every harness's launch command in `launch_template()` used bash-only `"$(cat __BRIEF__)"` command substitution, which fails outright when the treehouse worktree's interactive pane shell is fish instead of bash/zsh.
- Wraps the fully assembled launch string in `shell_quote()`'d `bash -c` right before the final `tmux send-keys`, so the pane's own shell only ever needs to parse `bash -c '<string>'` regardless of whether it's fish, zsh, or bash.
- Also fixes a portability bug the pipeline caught along the way in the same area (Darwin `stat -f` vs `stat -c` detection).

## Test plan
- [x] Verified via a standalone repro mirroring `shell_quote()`/`launch_template()` logic across fish, bash, and zsh for all five harness template shapes (including nested quotes and the secondmate `FM_HOME=` env-prefix case)
- [x] Pipeline review, test, document, and lint steps all passed clean