### PR TITLE
Extract crew contract into globally-loaded fm-crewmate skill

### DIFF
--- a/.agents/skills/fm-crewmate/SKILL.md
+++ b/.agents/skills/fm-crewmate/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: fm-crewmate
+description: The firstmate crew contract. Load this at the START of every firstmate-dispatched crew task, before you branch, commit, or report status. Defines worktree isolation, the status-reporting protocol, escalation, tools, the ship Setup and per-mode Definition of Done (no-mistakes, direct-PR, local-only), the scout-task contract, project memory, and the PR-review variant. Your brief supplies this run's variables (task, repo, delivery mode, branch, status-file path, report path, FM_ROOT); this skill supplies the standing rules.
+user-invocable: false
+---
+
+# fm-crewmate
+
+You are a crewmate: an autonomous worker agent managed by firstmate. Work on your
+own; do not wait for a human. Your brief names your **delivery mode** and your
+**task**, and supplies this run's variables; this skill is the standing contract
+every crew task shares. Read the section for your mode; ignore the others.
+
+## Every task (all modes)
+
+**Verify isolation before anything else.** Run `pwd -P` and
+`git rev-parse --show-toplevel`; both must resolve to the disposable treehouse
+worktree you were launched in (typically under a `.treehouse/` pool), not the
+primary checkout firstmate operates from. The path check is authoritative:
+`git rev-parse --git-dir` / `--git-common-dir` help inspect the repo but do not
+prove you are outside the primary checkout. If the top-level path is the primary
+checkout or not the worktree you were launched in, STOP - do not branch or commit
+- append `blocked: launched in primary checkout, not an isolated worktree` to your
+status file and stop.
+
+**Status-reporting protocol.** Report by appending one line to your status file:
+`echo "{state}: {one short line}" >> <STATUS_FILE>`. States: `working`,
+`needs-decision`, `blocked`, `done`, `failed`. Each append wakes firstmate, so
+report **sparingly**: only supervisor-actionable phase changes (setup done, bug
+reproduced, fix implemented, validation passed) and the terminal/decision states.
+No step-by-step FYI lines - firstmate reads your pane for that.
+
+**Escalation.** If you hit the same obstacle twice, append `blocked: {why}` and
+stop; firstmate will help. If a decision belongs to a human (product choices,
+destructive actions, ask-user findings), append `needs-decision: {options}` and
+stop; firstmate will reply with the decision.
+
+**Tools.** Use `gh-axi` for GitHub operations and `chrome-devtools-axi` for
+browser operations.
+
+**Verification / no hallucination.** Never report a task done without proving it
+works: run it, show the evidence, cite `file:line`. Do not invent file paths,
+flags, APIs, or command output - if you did not run it or read it, do not claim
+it. Report outcomes faithfully; if something failed or was skipped, say so with
+the real output.
+
+## Ship task - Setup
+
+Stay inside this worktree; modify nothing outside it (except your status file).
+First action after the isolation check: create your branch: `git checkout -b fm/<id>`.
+For **no-mistakes** mode only, then run `no-mistakes doctor`; if it reports the
+repo is not initialized here, run `no-mistakes init`.
+
+## Ship task - Definition of done, by mode
+
+**no-mistakes (default).** Never push to the default branch; never merge a PR. The
+task is complete only when committed on your branch - then append `done: {summary}`
+and stop. Firstmate will then instruct you to run `/no-mistakes` to validate and
+ship a PR. You drive that pipeline by responding to its gates, not by implementing
+fixes: follow no-mistakes' own version-matched guidance (it loads when you invoke
+`/no-mistakes`; `no-mistakes axi run --help` and the `help` lines in each `axi`
+response are authoritative). Do not hand-edit, commit, or fix findings while a run
+is active - the pipeline applies every fix. Two firstmate rules layer on top:
+- ask-user findings are not yours to answer: escalate via `needs-decision` and
+  stop. When the decision comes back, feed it to the gate with
+  `no-mistakes axi respond` and let the pipeline apply it - do not route the
+  question to "the user" or implement the fix yourself.
+- Avoid `--yes`: the captain, not you, owns the ask-user decisions it would
+  silently auto-resolve.
+
+After `/no-mistakes` reports CI green, append `done: PR {url} checks green` and
+stop. You are finished.
+
+**direct-PR.** Never push to the default branch (push only your `fm/<id>` branch);
+never merge a PR. No pipeline. When implemented and committed, push your branch,
+open a PR with `gh-axi`, append `done: PR {url}`, and stop. Do NOT run
+`/no-mistakes`. The captain reviews and merges the PR; firstmate relays it.
+
+**local-only.** Never push to any remote and never open a PR. Work only on your
+`fm/<id>` branch; keep it a clean fast-forward onto the current default branch - if
+`main` has advanced, rebase onto it so the eventual merge stays a fast-forward.
+When implemented and committed, append `done: ready in branch fm/<id>` and stop.
+Firstmate reviews the diff, the captain approves, and firstmate merges to local
+`main`.
+
+## Ship task - Project memory
+
+If `AGENTS.md` / `CLAUDE.md` already exists, or this task produced durable
+project-intrinsic knowledge, run `<FM_ROOT>/bin/fm-ensure-agents-md.sh .` in the
+worktree and record proportionate learnings in `AGENTS.md` as part of your change.
+Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no
+durable project knowledge.
+
+## Scout task
+
+The deliverable is a written report, not a PR. The worktree is your scratch lab -
+install, run, edit, and make scratch commits freely; all of it is discarded at
+teardown, so anything worth keeping must be in the report. Rules: never push and
+never open a PR; the only files you may write outside the worktree are the report
+and the status file. Write findings to `<DATA>/<id>/report.md`: what you did, what
+you found, the evidence (commands run, output, `file:line` references), and what
+you recommend. It must stand alone. When the report is complete, append
+`done: {one-line conclusion}` to the status file and stop. If your findings reveal
+shippable work (a reproduced bug with a clear fix), say so in the report -
+firstmate may promote this task in place and send you mode-specific ship
+instructions as a follow-up.
+
+## PR-review variant (any mode)
+
+When your task is reviewing an existing PR rather than shipping new work, your
+deliverable is the review, not a branch: read the diff with `gh-axi`, report
+findings grouped by severity with `file:line` anchors and a concrete fix each, and
+append `done: reviewed PR {url}` (or `needs-decision:` if a call is the captain's).
+Do not push commits to someone else's PR unless the brief says so.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -756,14 +756,13 @@ Map firstmate's real backlog operations to the approved commands:
 
 ## 11. Crewmate briefs
 
-Scaffold with `bin/fm-brief.sh <id> <repo-name>` - it writes `data/<id>/brief.md` with the standard contract (branch setup, status-reporting protocol, push/merge rules, definition of done) and all paths filled in.
-The ship-brief Setup opens with a worktree-isolation assertion ahead of the branch step: the crewmate confirms it is in its own treehouse worktree, not the primary checkout, and stops with `blocked: launched in primary checkout, not an isolated worktree` if not - the upstream half of the worktree-tangle guard (section 8).
-For a ship task the definition of done is shaped by the project's delivery mode (section 6): `no-mistakes` stops after the implementation commit, then firstmate triggers the harness-appropriate no-mistakes validation pipeline; `direct-PR` has the crewmate push and open the PR itself, and `local-only` has it stop at "ready in branch" for firstmate to review and merge locally.
-The no-mistakes brief points to no-mistakes' version-matched guidance and keeps only firstmate-specific wrapper rules for `ask-user` escalation, `--yes` avoidance, and the CI-green done line.
-The scaffold reads the mode via `fm-project-mode.sh`, so you do not pass it.
-Ship briefs also include the project-memory contract: run `bin/fm-ensure-agents-md.sh` when the project already has agent-memory files or when the task produced durable project-intrinsic knowledge, then record proportionate learnings in `AGENTS.md`.
-For scout tasks add `--scout`: the scaffold swaps the definition of done for the report contract (findings to `data/<id>/report.md`, no branch, no push, no PR) and declares the worktree scratch; scout is mode-agnostic.
-Scout briefs do not include the project-memory step, because their deliverable is a report rather than a committed project change.
+The standing crew contract lives once in the `fm-crewmate` skill, not in each brief.
+That skill is firstmate-owned (canonical at `.agents/skills/fm-crewmate/SKILL.md`, so it travels with firstmate through git and `/updatefirstmate`) and globally auto-loaded: `bin/fm-bootstrap.sh` idempotently symlinks it into `~/.claude/skills/fm-crewmate`, so every crew in every repo discovers it, and briefs reference it unconditionally with no per-repo fallback.
+The skill holds the worktree-isolation assertion, the status-reporting protocol, escalation, tools, the ship Setup and per-mode definition of done (`no-mistakes`, `direct-PR`, `local-only`), the scout-task contract, project memory, and the PR-review variant.
+A brief is therefore just an identity line, a pointer to the `fm-crewmate` skill, the `# Task`, and this run's variables.
+Scaffold with `bin/fm-brief.sh <id> <repo-name>` - it writes `data/<id>/brief.md` in that slim shape, resolving the delivery mode via `fm-project-mode.sh` (so you do not pass it) and naming it in the brief so the crewmate applies the matching definition-of-done section.
+The variables the slim brief supplies are the ones the skill's placeholders need: task, repo, delivery mode, branch `fm/$ID`, status-file path, and `FM_ROOT` (for `fm-ensure-agents-md.sh`).
+For scout tasks add `--scout`: the scaffold points the same skill at the scout contract (findings to `data/<id>/report.md`, no branch, no push, no PR) and supplies the report path; scout is mode-agnostic.
 For secondmates use `bin/fm-brief.sh <id> --secondmate <project>...`.
 The scaffold writes a charter brief instead of a task brief.
 Set `FM_SECONDMATE_CHARTER='<charter>'` to fill the charter text and `FM_SECONDMATE_SCOPE='<scope>'` when the routing scope differs.

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -11,6 +11,8 @@
 #                 "TASKS_AXI: available", "TANGLE: <remediation>",
 #                 "SECONDMATE_SYNC: secondmate <id>: skipped: <reason>",
 #                 "NUDGE_SECONDMATES: <window-targets...>",
+#                 "SKILL_LINK: <detail>" (only when the global fm-crewmate skill
+#                   symlink could not be created; success is silent),
 #                 "FMX: X mode on ..." or "FMX: X mode off ...".
 #          A NUDGE_SECONDMATES line lists the RUNNING secondmate windows whose
 #          worktree was fast-forwarded to firstmate's own current default-branch
@@ -207,6 +209,33 @@ write_if_changed() {
   local dest=$1 content=$2
   [ -f "$dest" ] && [ "$(cat "$dest" 2>/dev/null)" = "$content" ] && return 0
   printf '%s\n' "$content" > "$dest"
+}
+
+# Ensure the firstmate-owned fm-crewmate skill is globally auto-loaded so every
+# crew in EVERY repo (not just firstmate) discovers it: symlink the harness global
+# skills dir entry at the firstmate-owned canonical skill under FM_ROOT. The skill
+# travels with firstmate through git + /updatefirstmate, so this points at the
+# primary checkout's copy, never at a crewmate's disposable worktree.
+# Idempotent and best-effort: a failure here must never abort bootstrap, and an
+# existing real (non-symlink) dir/file at the target is never clobbered.
+# Scoped to claude's global skills dir (~/.claude/skills). Other harnesses that
+# support user-global skills would need their own link added here the same way.
+ensure_global_crew_skill() {
+  local src="$FM_ROOT/.agents/skills/fm-crewmate"
+  local dir="$HOME/.claude/skills"
+  local link="$dir/fm-crewmate"
+  [ -d "$src" ] || return 0
+  mkdir -p "$dir" 2>/dev/null || { echo "SKILL_LINK: could not create $dir - skipped"; return 0; }
+  if [ -L "$link" ]; then
+    [ "$(readlink "$link" 2>/dev/null)" = "$src" ] && return 0
+    ln -sfn "$src" "$link" 2>/dev/null || echo "SKILL_LINK: could not repoint $link -> $src - skipped"
+    return 0
+  fi
+  if [ -e "$link" ]; then
+    echo "SKILL_LINK: $link exists and is not a symlink - left untouched (remove it manually to enable the global fm-crewmate skill)"
+    return 0
+  fi
+  ln -s "$src" "$link" 2>/dev/null || echo "SKILL_LINK: could not create $link -> $src - skipped"
 }
 
 # X mode (opt-in): when this home's .env carries a non-empty FMX_PAIRING_TOKEN,
@@ -409,6 +438,7 @@ if ! fm_backlog_backend_manual "$CONFIG"; then
     echo "MISSING: tasks-axi (install: $(install_cmd tasks-axi))"
   fi
 fi
+ensure_global_crew_skill
 secondmate_sync
 x_mode_setup
 fleet_sync

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -1,11 +1,16 @@
 #!/usr/bin/env bash
 # Scaffold a crewmate brief or persistent secondmate charter at
 # data/<task-id>/brief.md under the active firstmate home.
-# For ordinary tasks, the standard Setup/Rules/Definition-of-done contract is
-# filled in. Firstmate then replaces the {TASK} placeholder with the task
-# description, acceptance criteria, and context, and may adjust other sections
-# when the task genuinely deviates (e.g. working an existing external PR instead
-# of shipping a new one).
+# For ordinary (crew) tasks the standing contract - worktree isolation, status
+# protocol, escalation, tools, per-mode definition of done, project memory, scout
+# rules - lives in the globally-loaded fm-crewmate skill (firstmate-owned at
+# .agents/skills/fm-crewmate, symlinked into ~/.claude/skills by fm-bootstrap.sh).
+# The brief therefore only points at that skill and supplies this run's variables
+# (task, repo, delivery mode, branch, status-file path, report path, FM_ROOT).
+# Firstmate then replaces the {TASK} placeholder with the task description,
+# acceptance criteria, and context, and may adjust other sections when the task
+# genuinely deviates (e.g. working an existing external PR instead of shipping a
+# new one).
 # Usage: fm-brief.sh <task-id> <repo-name> [--scout]
 #        fm-brief.sh <task-id> --secondmate <project>...
 #   --scout writes the scout contract instead: the deliverable is a report at
@@ -24,10 +29,10 @@
 #   direct-PR    implement -> push + open PR via gh-axi (no pipeline) -> captain merge
 #   local-only   implement on branch, stop and report "ready in branch" (no push/PR);
 #                firstmate reviews, captain approves, firstmate merges to local main
-# Ship briefs begin with a worktree-isolation assertion before the branch step.
+# The fm-crewmate skill carries the worktree-isolation assertion, the project-memory
+# step, and the per-mode definition of done; the ship brief only names the mode so
+# the crewmate applies the matching section.
 # Scout tasks ignore mode - their deliverable is a report, not a merge.
-# Ship tasks include a project-memory section so durable project-intrinsic
-# learnings can be committed to AGENTS.md through the project's delivery path.
 # Refuses to overwrite an existing brief.
 set -eu
 
@@ -130,133 +135,43 @@ REPO=${POS[1]}
 
 if [ "$KIND" = scout ]; then
 cat > "$BRIEF" <<EOF
-You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
+You are a crewmate managed by firstmate. **Follow the \`fm-crewmate\` skill** - it
+is your standing contract (worktree isolation, status protocol, escalation, tools,
+scout-task rules, and the definition of done). This is a SCOUT task.
 
 # Task
 {TASK}
 
-# Setup
-You are in a disposable git worktree of $REPO, at a detached HEAD on a clean default branch.
-This is a SCOUT task: the deliverable is a written report, not a PR.
-The worktree is your laboratory - install, run, edit, and make scratch commits freely; all of it is discarded at teardown.
-The report is the only thing that survives, so anything worth keeping must be in it.
-
-# Rules
-1. Never push to any remote and never open a PR.
-2. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
-3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
-4. Report status by appending one line:
-   \`echo "{state}: {one short line}" >> $STATUS_FILE\`
-   States: working, needs-decision, blocked, done, failed.
-   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
-   would act on and the needs-decision/blocked/done/failed states. No step-by-step
-   FYI progress lines; firstmate reads your pane for that.
-5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
-6. If a decision belongs to a human (product choices, destructive actions),
-   append \`needs-decision: {summary of options}\` and stop. Firstmate will reply with the decision.
-
-# Definition of done
-Write your findings to \`$DATA/$ID/report.md\`.
-The report must stand alone: what you did, what you found, the evidence (commands run, output, file:line references), and what you recommend.
-When the report is complete, append \`done: {one-line conclusion}\` to the status file and stop.
-If your findings reveal work that should ship (e.g. you reproduced a bug and the fix is clear), say so in the report; firstmate may promote this task in place, and you would then receive mode-specific ship instructions as a follow-up message.
+# This run's variables
+- Repo (disposable worktree of): $REPO
+- Status file (\`<STATUS_FILE>\`): append status lines to $STATUS_FILE
+- Report (\`<DATA>/<id>/report.md\`): write findings to $DATA/$ID/report.md
 EOF
 echo "scaffolded: $BRIEF (scout; replace {TASK})"
 exit 0
 fi
 
-# Ship task: shape Setup / Rule 1 / Definition of done by the project's delivery mode.
+# Ship task: the delivery mode selects which "Definition of done" the crewmate
+# applies (all modes live in the fm-crewmate skill); the brief only names it.
 # yolo does not affect the brief (it governs firstmate's approval behaviour), so discard it.
 read -r MODE _ <<EOF
 $("$FM_ROOT/bin/fm-project-mode.sh" "$REPO")
 EOF
 
-case "$MODE" in
-  direct-PR)
-    SETUP2=""
-    RULE1='1. Never push to the default branch (push only your `fm/'"$ID"'` branch). Never merge a PR.'
-    DOD=$(cat <<EOF
-# Definition of done
-This project ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
-The task is complete only when committed on your branch.
-When it is implemented and committed, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\` to the status file and stop.
-Do NOT run /no-mistakes. The captain reviews and merges the PR; firstmate relays it.
-EOF
-)
-    ;;
-  local-only)
-    SETUP2=""
-    RULE1="1. Never push to any remote and never open a PR. Work only on your \`fm/$ID\` branch; firstmate handles the merge into local \`main\`."
-    DOD=$(cat <<EOF
-# Definition of done
-This project ships **local-only**: no remote, no PR, no pipeline.
-The task is complete only when committed on your branch \`fm/$ID\`. Do NOT push, do NOT open a PR, do NOT merge.
-Keep your branch a clean fast-forward onto the current default branch - if \`main\` has advanced, rebase onto it so the eventual merge stays a fast-forward.
-When it is implemented and committed, append \`done: ready in branch fm/$ID\` to the status file and stop.
-Firstmate then reviews your branch diff, the captain approves, and firstmate merges it into local \`main\`.
-EOF
-)
-    ;;
-  *)  # no-mistakes (default)
-    SETUP2="
-2. Run \`no-mistakes doctor\`; if it reports the repo is not initialized here, run \`no-mistakes init\`."
-    RULE1='1. Never push to the default branch. Never merge a PR.'
-    DOD=$(cat <<EOF
-# Definition of done
-The task is complete only when committed on your branch.
-When you believe it is complete, append \`done: {summary}\` to the status file and stop.
-Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
-
-You drive no-mistakes by responding to its gates, not by implementing fixes.
-Follow no-mistakes' own guidance for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.
-Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.
-
-Two firstmate-specific rules layer on top of that guidance:
-- ask-user findings are not yours to answer: escalate to firstmate (rule 6) and stop.
-  When the decision comes back, feed it to the gate with \`no-mistakes axi respond\` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
-- Avoid \`--yes\`: the captain, not you, owns the ask-user decisions it would silently auto-resolve.
-
-After /no-mistakes reports CI green, append \`done: PR {url} checks green\` and stop. You are finished.
-EOF
-)
-    ;;
-esac
-
 cat > "$BRIEF" <<EOF
-You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
+You are a crewmate managed by firstmate. **Follow the \`fm-crewmate\` skill** - it
+is your standing contract (worktree isolation, branch setup, status protocol,
+escalation, push/merge rules, project memory, and the definition of done for your
+delivery mode). Read the section matching the mode below.
 
 # Task
 {TASK}
 
-# Setup
-You are in a disposable git worktree of $REPO, at a detached HEAD on a clean default branch.
-
-**Verify isolation before anything else.** Run \`pwd -P\` and \`git rev-parse --show-toplevel\`; both must resolve to the disposable treehouse worktree you were launched in, typically a path under a \`.treehouse/\` pool, not the primary checkout firstmate operates from.
-The path check is authoritative: \`git rev-parse --git-dir\` and \`git rev-parse --git-common-dir\` can help inspect the repo, but they do not prove you are outside the primary checkout.
-If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append \`blocked: launched in primary checkout, not an isolated worktree\` to the status file and stop.
-
-1. First action: create your branch: \`git checkout -b fm/$ID\`$SETUP2
-
-# Rules
-$RULE1
-2. Stay inside this worktree; modify nothing outside it.
-3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
-4. Report status by appending one line:
-   \`echo "{state}: {one short line}" >> $STATUS_FILE\`
-   States: working, needs-decision, blocked, done, failed.
-   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
-   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
-   needs-decision/blocked/done/failed states. No step-by-step FYI progress lines;
-   firstmate reads your pane for that.
-5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
-6. If a decision belongs to a human (product choices, destructive actions, ask-user findings),
-   append \`needs-decision: {summary of options}\` and stop. Firstmate will reply with the decision.
-
-# Project memory
-If \`AGENTS.md\` or \`CLAUDE.md\` already exists, or if this task produced durable project-intrinsic knowledge, run \`$FM_ROOT/bin/fm-ensure-agents-md.sh .\` in the worktree.
-If this task produced durable project-intrinsic knowledge, record it in \`AGENTS.md\` as part of your change.
-Keep it proportionate: skip \`AGENTS.md\` edits for trivial tasks that produced no durable project knowledge.
-
-$DOD
+# This run's variables
+- Repo (disposable worktree of): $REPO
+- Delivery mode: **$MODE**   (apply the matching "Definition of done" section)
+- Branch to create (\`fm/<id>\`): fm/$ID
+- Status file (\`<STATUS_FILE>\`): append status lines to $STATUS_FILE
+- FM_ROOT (\`<FM_ROOT>\`, for fm-ensure-agents-md.sh): $FM_ROOT
 EOF
 echo "scaffolded: $BRIEF (ship, mode=$MODE; replace {TASK})"


### PR DESCRIPTION
## Phase 1 of the context-slimming plan: extract the crew contract into a reusable, globally-loaded `fm-crewmate` skill

Follows `data/scout-skill-extraction-ba/report.md` Part 1, with the captain's decision on skill home (firstmate-owned + global via symlink).

### The problem
`bin/fm-brief.sh` re-emitted the entire crewmate contract into **every** brief via two large heredocs plus a per-mode `case` block. The invariant contract (worktree isolation, status protocol, escalation, push/merge rules, per-mode definition of done, project memory, scout rules) was duplicated on every dispatch and re-transmitted to the crewmate in full each time.

### The change

**1. New skill `.agents/skills/fm-crewmate/SKILL.md` (firstmate-owned, canonical).**
Holds the whole standing contract for all delivery shapes: worktree-isolation assertion, status-reporting protocol, escalation, tools (`gh-axi`/`chrome-devtools-axi`), verification/no-hallucination, ship Setup (branch creation + no-mistakes init note), the per-mode Definition of Done (`no-mistakes`, `direct-PR`, `local-only`), the scout-task contract, the project-memory step, and the PR-review variant. Placeholders (`<id>`, `<STATUS_FILE>`, `<DATA>`, `<FM_ROOT>`) are supplied by the brief. Frontmatter `user-invocable: false`. Lives in the repo so it travels with firstmate through git + `/updatefirstmate` (`.claude/skills` already symlinks to `.agents/skills`).

**2. Global auto-load via bootstrap symlink.**
`bin/fm-bootstrap.sh` gains an idempotent, best-effort `ensure_global_crew_skill` that symlinks `~/.claude/skills/fm-crewmate -> <FM_ROOT>/.agents/skills/fm-crewmate`, so every crew in **every** repo (not just firstmate) auto-loads it. Creates `~/.claude/skills` if missing; never clobbers a real (non-symlink) dir/file there (warns + skips via a new `SKILL_LINK:` line); a symlink failure never aborts bootstrap. Scoped to claude's global skills dir, with a comment noting other harnesses would need their own link.

**3. Slim `bin/fm-brief.sh`.**
Both contract heredocs and the `case "$MODE"` fragment-assembly block are gone (only mode resolution via `fm-project-mode.sh` remains). Briefs now emit an identity line + a pointer to the `fm-crewmate` skill + this run's variables (task, repo, delivery mode, branch `fm/$ID`, status-file path, report path for scout, `FM_ROOT`). Reference is unconditional (the skill is globally available). Net: `bin/fm-brief.sh` loses ~125 lines; each brief transmits ~10 lines of variables instead of ~35-70 lines of contract.

**4. `AGENTS.md` section 11** updated to the new brief shape and notes the skill is firstmate-owned + globally symlinked. (The larger AGENTS.md self-slimming is a later phase, out of scope here.)

### Verification (all run, not asserted)
- `bash -n bin/fm-brief.sh` and `bash -n bin/fm-bootstrap.sh` both pass.
- Ran the scaffolder end-to-end for scout + all three ship modes (`no-mistakes`, `direct-PR`, `local-only`); every generated brief references the `fm-crewmate` skill and carries all needed variables with the correct resolved mode.
- Exercised `ensure_global_crew_skill` in an isolated HOME: fresh create produces the symlink and `SKILL.md` resolves; re-run is a silent idempotent no-op; a non-symlink at the target is left untouched with a `SKILL_LINK:` warning.
- No broken global symlink was left pointing at the disposable worktree; bootstrap creates the real link from the primary `FM_ROOT` post-merge (guarded by an `[ -d "$src" ]` check).

### Out of scope (later phases)
- The big AGENTS.md → on-demand-skills extraction.
- The struction CLAUDE.md/AGENTS.md reconcile + skill-tree symlinks.
- `bin/fm-spawn.sh` (has intentional local uncommitted edits in the primary).
