### PR TITLE
ci: cover backend-abstraction branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, backend-abstraction]
   pull_request:
-    branches: [main]
+    branches: [main, backend-abstraction]
 
 permissions:
   contents: read

--- a/.github/workflows/no-mistakes-required.yml
+++ b/.github/workflows/no-mistakes-required.yml
@@ -5,6 +5,7 @@ on:
     types: [opened, edited, synchronize, reopened]
     branches:
       - main
+      - backend-abstraction
 
 permissions:
   contents: read

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,13 +3,14 @@
 Thanks for wanting to contribute.
 One rule up front:
 
-**Human-authored pull requests targeting `main` must be raised through [`no-mistakes`](https://github.com/kunchenguid/no-mistakes).**
+**Human-authored pull requests targeting `main` or `backend-abstraction` must be raised through [`no-mistakes`](https://github.com/kunchenguid/no-mistakes).**
 We require this to reduce the maintainer's burden of reviewing and merging contributions.
 
 `no-mistakes` puts a local git proxy in front of your real remote.
 Pushing through it runs an AI-driven review/test/lint pipeline in an isolated worktree, forwards the push upstream only after every check passes, and opens a clean PR automatically.
 
-A GitHub Actions check (`Require no-mistakes`) runs on PRs targeting `main` and fails if the body is missing the deterministic signature that no-mistakes writes.
+A GitHub Actions check (`Require no-mistakes`) runs on PRs targeting `main` or `backend-abstraction` and fails if the body is missing the deterministic signature that no-mistakes writes.
+The normal CI workflow also runs on pushes and PRs for that same branch set.
 Dependency bots are exempt so their automation keeps working, but regular contributor PRs without the signature will not be reviewed or merged.
 
 ## Workflow


### PR DESCRIPTION
## Intent

Widen firstmate's GitHub Actions triggers so the long-lived integration branch backend-abstraction gets the same CI and PR enforcement as main. Phase PRs for the multi-phase runtime-backend abstraction rollout will target backend-abstraction instead of main, and today neither workflow fires for PRs to a non-main base. Exact scope: in ci.yml change on.push.branches and on.pull_request.branches from [main] to [main, backend-abstraction]; in no-mistakes-required.yml add backend-abstraction alongside main under on.pull_request.branches. No other changes—no job content, permissions, or concurrency edits.

## What Changed
- Expanded the CI workflow branch filters so pushes and pull requests for `backend-abstraction` run alongside `main`.
- Added `backend-abstraction` to the `Require no-mistakes` pull request branch filter.
- Updated contributor guidance to document that both CI and no-mistakes enforcement apply to `main` and `backend-abstraction`.

## Risk Assessment

✅ Low: Captain, the diff is limited to adding backend-abstraction to existing GitHub Actions branch filters, with no job, permission, or enforcement logic changes.

## Testing

Captain, the baseline behavior suite was already green; the focused workflow validation also passed and produced evidence showing CI plus Require no-mistakes now run for `backend-abstraction` while non-trigger workflow content stayed unchanged.

<details>
<summary>Evidence: Workflow trigger event matrix</summary>

```text
Workflow trigger validation: PASS
Base commit: 1bc8842d2629a9f6497003e544296aa07d787639
Target commit: f582241d5720024714df74a720f2cf83afc073e8
Changed files: .github/workflows/ci.yml, .github/workflows/no-mistakes-required.yml

Target branch filters:
  ci.yml push: ['main', 'backend-abstraction']
  ci.yml pull_request: ['main', 'backend-abstraction']
  no-mistakes-required.yml pull_request: ['main', 'backend-abstraction']

Non-trigger workflow content unchanged after removing branch filters: yes

Simulated GitHub event matrix:
  ci.yml: push on main -> RUNS
  ci.yml: push on backend-abstraction -> RUNS
  ci.yml: push on feature/example -> skipped
  ci.yml: pull_request on main -> RUNS
  ci.yml: pull_request on backend-abstraction -> RUNS
  ci.yml: pull_request on feature/example -> skipped
  no-mistakes-required.yml: pull_request on main -> RUNS
  no-mistakes-required.yml: pull_request on backend-abstraction -> RUNS
  no-mistakes-required.yml: pull_request on feature/example -> skipped

Machine-readable matrix:
[
  {
    "workflow": "ci.yml",
    "event": "push",
    "branch_or_pr_base": "main",
    "would_run": true
  },
  {
    "workflow": "ci.yml",
    "event": "push",
    "branch_or_pr_base": "backend-abstraction",
    "would_run": true
  },
  {
    "workflow": "ci.yml",
    "event": "push",
    "branch_or_pr_base": "feature/example",
    "would_run": false
  },
  {
    "workflow": "ci.yml",
    "event": "pull_request",
    "branch_or_pr_base": "main",
    "would_run": true
  },
  {
    "workflow": "ci.yml",
    "event": "pull_request",
    "branch_or_pr_base": "backend-abstraction",
    "would_run": true
  },
  {
    "workflow": "ci.yml",
    "event": "pull_request",
    "branch_or_pr_base": "feature/example",
    "would_run": false
  },
  {
    "workflow": "no-mistakes-required.yml",
    "event": "pull_request",
    "branch_or_pr_base": "main",
    "would_run": true
  },
  {
    "workflow": "no-mistakes-required.yml",
    "event": "pull_request",
    "branch_or_pr_base": "backend-abstraction",
    "would_run": true
  },
  {
    "workflow": "no-mistakes-required.yml",
    "event": "pull_request",
    "branch_or_pr_base": "feature/example",
    "would_run": false
  }
]
```
</details>
<details>
<summary>Evidence: Workflow trigger scope diff</summary>

```text
diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
index f8b0afc..49339d9 100644
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, backend-abstraction]
   pull_request:
-    branches: [main]
+    branches: [main, backend-abstraction]
 
 permissions:
   contents: read
diff --git a/.github/workflows/no-mistakes-required.yml b/.github/workflows/no-mistakes-required.yml
index ab1224d..38f81e7 100644
--- a/.github/workflows/no-mistakes-required.yml
+++ b/.github/workflows/no-mistakes-required.yml
@@ -5,6 +5,7 @@ on:
     types: [opened, edited, synchronize, reopened]
     branches:
       - main
+      - backend-abstraction
 
 permissions:
   contents: read
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- <code>Baseline provided by the gate: `command -v tmux &gt;/dev/null || { echo &#34;tmux is required for e2e tests&#34; &gt;&amp;2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo &#34;== $t ==&#34;; bash &#34;$t&#34; || rc=1; done; exit &#34;$rc&#34;`</code>
- <code>Reviewed target diff with `git diff --color=never 1bc8842d2629a9f6497003e544296aa07d787639..f582241d5720024714df74a720f2cf83afc073e8 -- .github/workflows/ci.yml .github/workflows/no-mistakes-required.yml`</code>
- <code>Ran a focused Python/PyYAML workflow-trigger validation that compared base vs target, asserted changed files were limited to the two workflows, asserted non-branch-filter workflow content was unchanged, and simulated push / pull_request branch matching for `main`, `backend-abstraction`, and `feature/example`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
