### PR TITLE
fix(spawn): pin tmux session targets with exact-match form

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,7 @@ tests/fm-x-mode.test.sh                   # X-mode poll, inbox context round-tri
 tests/fm-tangle-guard.test.sh             # primary-checkout tangle detection and spawn/brief isolation tests
 tests/fm-spawn-batch.test.sh              # batch dispatch and FM_HOME project-path scoping tests
 tests/fm-spawn-dispatch-profile.test.sh   # concrete dispatch profile flags: active-profile backstop, harness/model/effort meta, launch templates, batch forwarding, and secondmate exemption
+tests/fm-spawn-tmux-target.test.sh        # end-to-end tmux target disambiguation: exact-match session form lands a spawn in a numeric session named "7" despite an occupied index, keeps the outside-tmux dedicated 'firstmate' session path, and documents the raw bare-target ambiguity
 tests/fm-update.test.sh                   # fast-forward-only self-update, reread, nudge, dedup, and skip-safety tests
 tests/fm-secondmate-sync.test.sh          # local-HEAD secondmate sync, no-fetch, bootstrap nudge gating, and spawn hook tests
 tests/fm-secondmate-harness.test.sh       # secondmate-vs-crewmate harness resolution, optional secondmate model/effort pins, primary-to-secondmate config inheritance, and config-push tests

--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -56,11 +56,18 @@ fm_backend_tmux_send_text_submit() {  # <target> <text> <retries> <enter-sleep> 
 # firstmate itself runs inside tmux, else ensure a dedicated detached
 # "firstmate" session exists. Mirrors fm-spawn.sh's container-ensure block;
 # prints the resolved session name.
+#
+# Session targets use tmux's exact-match form ("=firstmate" here, "=name:" in
+# create-task): the '=' pins exact-name matching (never prefix/fnmatch) and, for
+# a window target, the trailing ':' pins session interpretation. A bare numeric
+# session name (a captain session literally named "7") is otherwise parsed by
+# `-t` as a window INDEX of the current session, landing the window in an
+# unrelated session or failing on an occupied index (verified tmux 3.4).
 fm_backend_tmux_container_ensure() {
   if [ -n "${TMUX:-}" ]; then
     tmux display-message -p '#S'
   else
-    tmux has-session -t firstmate 2>/dev/null || tmux new-session -d -s firstmate
+    tmux has-session -t '=firstmate' 2>/dev/null || tmux new-session -d -s firstmate
     printf 'firstmate'
   fi
 }
@@ -68,14 +75,16 @@ fm_backend_tmux_container_ensure() {
 # fm_backend_tmux_create_task: create the task's window in <proj-abs>,
 # refusing an existing <window-name> in <session>. Mirrors fm-spawn.sh's
 # duplicate-check-then-new-window sequence, including the exact error text
-# (session:window, matching how fm-spawn.sh composed its own $T).
+# (session:window, matching how fm-spawn.sh composed its own $T). Sessions are
+# targeted with the exact-match form "=<session>:" (see container-ensure) so a
+# numeric session name is never misread as a window index.
 fm_backend_tmux_create_task() {  # <session> <window-name> <proj-abs>
   local ses=$1 wname=$2 proj_abs=$3
-  if tmux list-windows -t "$ses" -F '#{window_name}' | grep -qx "$wname"; then
+  if tmux list-windows -t "=$ses:" -F '#{window_name}' | grep -qx "$wname"; then
     echo "error: window $ses:$wname already exists" >&2
     return 1
   fi
-  tmux new-window -d -t "$ses" -n "$wname" -c "$proj_abs"
+  tmux new-window -d -t "=$ses:" -n "$wname" -c "$proj_abs"
 }
 
 # fm_backend_tmux_current_path: the live pane's current working directory, or

--- a/tests/fm-backend-tmux-smoke.test.sh
+++ b/tests/fm-backend-tmux-smoke.test.sh
@@ -48,6 +48,13 @@ TARGET="$SESSION:$WINDOW"
 
 tmux new-session -d -s "$SESSION" -x 200 -y 50 \
   || fail "real tmux: new-session failed"
+# Pin a clean, rc-free bash for every window this private server spawns. The
+# task window's shell must run the POSIX sh syntax this test sends (PS1=...,
+# `for i in $(seq ...); do ... done`); a login/interactive shell can re-exec
+# into the user's preferred shell (e.g. a ~/.bashrc ending in `exec fish`),
+# which cannot parse it, so the sent commands never run.
+tmux set-option -g default-command 'bash --norc --noprofile' \
+  || fail "real tmux: could not pin a POSIX default-command"
 fm_backend_tmux_create_task "$SESSION" "$WINDOW" "$HOME" \
   || fail "fm_backend_tmux_create_task failed to create the task window"
 tmux list-windows -t "$SESSION" -F '#{window_name}' | grep -qx "$WINDOW" \

--- a/tests/fm-spawn-tmux-target.test.sh
+++ b/tests/fm-spawn-tmux-target.test.sh
@@ -61,10 +61,14 @@ for id in "$ID_NUM" "$ID_OUT"; do
   printf 'test brief\n' > "$HOME_DIR/data/$id/brief.md"
 done
 
-# Pane-side fakes. The tmux server starts with PANEBIN on PATH, so every pane
-# shell sees them: 'treehouse get' moves the pane into the worktree named by the
-# pointer file (the real subshell behavior fm-spawn waits for), and 'claude'
-# makes the typed launch command a no-op instead of starting a real agent.
+# Pane-side fakes. The pane shell's PATH is pinned to PANEBIN via default-command
+# below, so every pane resolves these: 'treehouse get' moves the pane into the
+# worktree named by the pointer file (the real subshell behavior fm-spawn waits
+# for), and 'claude' makes the typed launch command a no-op instead of starting a
+# real agent. Pinning is deterministic on purpose: relying on the tmux server
+# inheriting PANEBIN through its environment is fragile (it broke in CI, where no
+# real 'treehouse' exists to mask a missing fake), so the pane PATH is set
+# explicitly rather than inherited.
 cat > "$PANEBIN/treehouse" <<SH
 #!/usr/bin/env bash
 set -u
@@ -88,11 +92,12 @@ chmod +x "$SHIMBIN/tmux"
 
 # Private server: decoy session first, then a session literally named "7" so it
 # is the server's current session; occupy its window indices 1..7 to make the
-# historical bare `-t 7` collide deterministically. Pane shells stay rc-free so
-# the fake-bin PATH from the server environment survives.
-PATH="$PANEBIN:$PATH" "$REAL_TMUX" -L "$SOCKET" new-session -d -s other -x 200 -y 50 \
+# historical bare `-t 7` collide deterministically. default-command pins PANEBIN
+# onto every pane's PATH (and keeps panes rc-free), so a typed `treehouse`/`claude`
+# resolves to the fakes regardless of the server's inherited environment.
+"$REAL_TMUX" -L "$SOCKET" new-session -d -s other -x 200 -y 50 \
   || fail "could not start private tmux server"
-tt set-option -g default-command 'bash --noprofile --norc'
+tt set-option -g default-command "PATH=\"$PANEBIN\":\$PATH exec bash --noprofile --norc"
 tt new-session -d -s 7 -x 200 -y 50
 for i in 1 2 3 4 5 6 7; do tt new-window -d -t "=7:$i"; done
 
@@ -103,6 +108,23 @@ FAKE_TMUX_ENV="$SOCK_PATH,$$,0"
 # the numeric one, exactly the world fm-spawn resolves SES from.
 [ "$(TMUX="$FAKE_TMUX_ENV" "$REAL_TMUX" display-message -p '#S')" = "7" ] \
   || fail "precondition: current session on the private server is not '7'"
+
+# Fail fast, with a clear message, if a pane cannot resolve the fake treehouse -
+# the exact CI failure mode (fm-spawn otherwise just times out after 60s on the
+# missing worktree handoff). Runs one throwaway pane through the pinned PATH.
+probe_pane_resolves_fake_treehouse() {
+  local probe="$TMP_ROOT/probe.out" flag="$TMP_ROOT/probe.flag"
+  rm -f "$probe" "$flag"
+  tt new-window -d -t '=7:' -n fm-probe
+  tt send-keys -t '=7:fm-probe' \
+    "command -v treehouse > '$probe' 2>&1; printf done > '$flag'" Enter
+  local _
+  for _ in $(seq 1 40); do [ -f "$flag" ] && break; sleep 0.25; done
+  tt kill-window -t '=7:fm-probe' 2>/dev/null || true
+  grep -qx "$PANEBIN/treehouse" "$probe" 2>/dev/null
+}
+probe_pane_resolves_fake_treehouse \
+  || fail "pane shell cannot resolve the fake treehouse (PANEBIN not on pane PATH); test world misconfigured"
 
 wait_for_window() { # <session> <window-name> -> 0 once present within ~15s
   local ses=$1 name=$2

--- a/tests/fm-spawn-tmux-target.test.sh
+++ b/tests/fm-spawn-tmux-target.test.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# Regression tests for fm-spawn.sh tmux target disambiguation.
+#
+# Bug guarded against: tmux parses a bare token passed to `-t` ambiguously - a
+# NUMERIC session name (a captain session literally named "7") resolves as a
+# window INDEX of the current session instead of the session itself, so
+# `new-window -t "$SES"` lands the crewmate window in an unrelated session or
+# fails outright on an occupied index (observed 2026-07-01, tmux 3.4). fm-spawn
+# now uses the exact-match session form `-t "=$SES:"` ('=' pins exact-name
+# matching, the trailing ':' pins session interpretation) and
+# `has-session -t '=firstmate'`.
+#
+# These tests run fm-spawn END TO END against a real tmux server on a private
+# socket (tmux -L), like tests/fm-afk-inject-e2e.test.sh: a decoy session and a
+# session literally named "7" with its window index 7 occupied reproduce the
+# ambiguous world, a pane-PATH fake treehouse moves the pane into a real git
+# worktree so the isolation guard passes, and a fake claude keeps the launch a
+# no-op. The first check documents the raw tmux ambiguity itself, so if a future
+# tmux changes bare-target parsing the guard's premise is re-examined loudly.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+# Skip gracefully if tmux is not installed (CI requires it; a dev box may not).
+command -v tmux >/dev/null 2>&1 || { echo "skip: tmux not found"; exit 0; }
+
+SPAWN="$ROOT/bin/fm-spawn.sh"
+REAL_TMUX=$(command -v tmux)
+SOCKET="fm-spawn-tt-$$"
+TMP_ROOT=$(fm_test_tmproot fm-spawn-tmux-target)
+
+ID_NUM="tt-numses-z1"
+ID_OUT="tt-outside-z2"
+
+cleanup() {
+  "$REAL_TMUX" -L "$SOCKET" kill-server 2>/dev/null || true
+  rm -rf "/tmp/fm-$ID_NUM" "/tmp/fm-$ID_OUT"
+  fm_test_cleanup
+}
+trap cleanup EXIT
+
+tt() { "$REAL_TMUX" -L "$SOCKET" "$@"; }
+
+# --- world ------------------------------------------------------------------
+
+HOME_DIR="$TMP_ROOT/home"
+PANEBIN="$TMP_ROOT/panebin"
+SHIMBIN="$TMP_ROOT/shimbin"
+WT_PTR="$TMP_ROOT/wt-pointer"
+mkdir -p "$HOME_DIR/data" "$PANEBIN" "$SHIMBIN"
+
+fm_git_init_commit "$HOME_DIR/projects/alpha"
+git -C "$HOME_DIR/projects/alpha" worktree add --detach "$TMP_ROOT/wt-num" >/dev/null 2>&1 \
+  || fail "could not create fixture worktree wt-num"
+git -C "$HOME_DIR/projects/alpha" worktree add --detach "$TMP_ROOT/wt-out" >/dev/null 2>&1 \
+  || fail "could not create fixture worktree wt-out"
+
+for id in "$ID_NUM" "$ID_OUT"; do
+  mkdir -p "$HOME_DIR/data/$id"
+  printf 'test brief\n' > "$HOME_DIR/data/$id/brief.md"
+done
+
+# Pane-side fakes. The tmux server starts with PANEBIN on PATH, so every pane
+# shell sees them: 'treehouse get' moves the pane into the worktree named by the
+# pointer file (the real subshell behavior fm-spawn waits for), and 'claude'
+# makes the typed launch command a no-op instead of starting a real agent.
+cat > "$PANEBIN/treehouse" <<SH
+#!/usr/bin/env bash
+set -u
+[ "\${1:-}" = get ] || exit 0
+wt=\$(cat '$WT_PTR')
+cd "\$wt" && exec bash --noprofile --norc
+SH
+cat > "$PANEBIN/claude" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+chmod +x "$PANEBIN/treehouse" "$PANEBIN/claude"
+
+# tmux shim for the outside-tmux case: fm-spawn with TMUX unset must still talk
+# to the private server, never the developer's real one.
+cat > "$SHIMBIN/tmux" <<SH
+#!/usr/bin/env bash
+exec '$REAL_TMUX' -L '$SOCKET' "\$@"
+SH
+chmod +x "$SHIMBIN/tmux"
+
+# Private server: decoy session first, then a session literally named "7" so it
+# is the server's current session; occupy its window indices 1..7 to make the
+# historical bare `-t 7` collide deterministically. Pane shells stay rc-free so
+# the fake-bin PATH from the server environment survives.
+PATH="$PANEBIN:$PATH" "$REAL_TMUX" -L "$SOCKET" new-session -d -s other -x 200 -y 50 \
+  || fail "could not start private tmux server"
+tt set-option -g default-command 'bash --noprofile --norc'
+tt new-session -d -s 7 -x 200 -y 50
+for i in 1 2 3 4 5 6 7; do tt new-window -d -t "=7:$i"; done
+
+SOCK_PATH=$(tt display-message -p '#{socket_path}')
+FAKE_TMUX_ENV="$SOCK_PATH,$$,0"
+
+# Precondition: with TMUX pointing at the private socket, the current session is
+# the numeric one, exactly the world fm-spawn resolves SES from.
+[ "$(TMUX="$FAKE_TMUX_ENV" "$REAL_TMUX" display-message -p '#S')" = "7" ] \
+  || fail "precondition: current session on the private server is not '7'"
+
+wait_for_window() { # <session> <window-name> -> 0 once present within ~15s
+  local ses=$1 name=$2
+  for _ in $(seq 1 30); do
+    if tt list-windows -t "=$ses:" -F '#{window_name}' 2>/dev/null | grep -qx "$name"; then
+      return 0
+    fi
+    sleep 0.5
+  done
+  return 1
+}
+
+# --- 1. the raw tmux ambiguity this fix guards against -----------------------
+# Documents the premise: a bare numeric -t target is parsed as a window index of
+# the current session (here: occupied index 7 -> hard failure), while the exact
+# session form lands in session "7" at the next free index. If a future tmux
+# resolves the bare form to the session, say so instead of failing: the fix is
+# then belt-and-braces rather than load-bearing.
+test_raw_tmux_ambiguity() {
+  local out
+  if out=$(TMUX="$FAKE_TMUX_ENV" "$REAL_TMUX" new-window -d -t 7 -n rawbare 2>&1); then
+    if tt list-windows -t '=7:' -F '#{window_name}' | grep -qx rawbare; then
+      pass "raw tmux: bare numeric -t now resolves to the session (fix is belt-and-braces on this tmux)"
+      return
+    fi
+    fail "raw tmux: bare -t 7 created 'rawbare' outside session 7 and outside index interpretation: $out"
+  fi
+  assert_contains "$out" "index 7 in use" "bare -t 7 failed for an unexpected reason"
+  TMUX="$FAKE_TMUX_ENV" "$REAL_TMUX" new-window -d -t '=7:' -n rawexact \
+    || fail "raw tmux: exact form '=7:' failed"
+  tt list-windows -t '=7:' -F '#{window_name}' | grep -qx rawexact \
+    || fail "raw tmux: exact form '=7:' did not land in session 7"
+  tt kill-window -t '=7:rawexact'
+  pass "raw tmux: bare numeric -t collides with a window index; exact form '=7:' pins the session"
+}
+
+# --- 2. fm-spawn inside tmux with a numeric session name ---------------------
+# The acceptance case: firstmate runs inside a session literally named "7" with
+# its window index 7 occupied; the spawned window must land in session 7 with no
+# collision, and nothing may leak into the decoy session.
+test_spawn_numeric_session() {
+  local out
+  printf '%s\n' "$TMP_ROOT/wt-num" > "$WT_PTR"
+  out=$(TMUX="$FAKE_TMUX_ENV" FM_HOME="$HOME_DIR" FM_SPAWN_NO_GUARD=1 \
+    "$SPAWN" "$ID_NUM" projects/alpha claude 2>&1) \
+    || fail "fm-spawn failed in numeric session: $out"
+  assert_contains "$out" "window=7:fm-$ID_NUM" "spawn did not report the numeric-session window"
+  wait_for_window 7 "fm-$ID_NUM" \
+    || fail "window fm-$ID_NUM did not appear in session 7"
+  tt list-windows -t '=other:' -F '#{window_name}' | grep -q "^fm-$ID_NUM$" \
+    && fail "window fm-$ID_NUM leaked into the decoy session 'other'"
+  assert_grep "window=7:fm-$ID_NUM" "$HOME_DIR/state/$ID_NUM.meta" \
+    "meta did not record the numeric-session window target"
+  pass "fm-spawn in a session named '7' lands its window in session 7 despite occupied index 7"
+}
+
+# --- 3. fm-spawn outside tmux keeps the dedicated-session path ---------------
+# Existing behavior must keep working: with TMUX unset, fm-spawn creates/uses the
+# 'firstmate' session (now via exact-match has-session) and spawns there.
+test_spawn_outside_tmux() {
+  local out
+  printf '%s\n' "$TMP_ROOT/wt-out" > "$WT_PTR"
+  out=$(env -u TMUX PATH="$SHIMBIN:$PATH" FM_HOME="$HOME_DIR" FM_SPAWN_NO_GUARD=1 \
+    "$SPAWN" "$ID_OUT" projects/alpha claude 2>&1) \
+    || fail "fm-spawn failed outside tmux: $out"
+  assert_contains "$out" "window=firstmate:fm-$ID_OUT" "spawn did not report the firstmate-session window"
+  tt has-session -t '=firstmate' 2>/dev/null \
+    || fail "outside-tmux spawn did not create the 'firstmate' session"
+  wait_for_window firstmate "fm-$ID_OUT" \
+    || fail "window fm-$ID_OUT did not appear in the firstmate session"
+  pass "fm-spawn outside tmux still creates and targets the dedicated 'firstmate' session"
+}
+
+test_raw_tmux_ambiguity
+test_spawn_numeric_session
+test_spawn_outside_tmux
+
+echo "all fm-spawn tmux target tests passed"


### PR DESCRIPTION
## Intent

Fix a tmux target-ambiguity bug: a numeric tmux session name (e.g. a session literally named 7) passed as a bare -t target resolves as a window index of the current session, landing the crewmate window in an unrelated session or colliding with an occupied index. Pin session targets with tmux's exact-match form (=SES: / =firstmate) in the tmux backend, and add an end-to-end regression test with a numeric session so spawns land in the intended session with no collision.

## What Changed

- Pin tmux session targets to the exact-match form (`=firstmate` in container-ensure, `=<session>:` in create-task's `list-windows`/`new-window`) in `bin/backends/tmux.sh`, so a numeric session name (a session literally named `7`) is no longer misread by `-t` as a window index of the current session — which previously landed the crewmate window in an unrelated session or failed on an occupied index.
- Add explanatory comments in `bin/fm-spawn.sh` and the tmux backend documenting the exact-match targeting rationale.
- Add an end-to-end regression test (`tests/fm-spawn-tmux-target.test.sh`) covering a spawn into a session named `7` with an occupied index 7 and no leak into a decoy session, plus the outside-tmux path still targeting `firstmate`; extend `tests/fm-backend.test.sh`, pin an rc-free bash and pane `PATH` for CI, and list the new test in `CONTRIBUTING.md`.

## Risk Assessment

✅ Low: A tightly-scoped, correct fix that pins only the two bare session-target tmux calls that were misparsing numeric session names, backed by an end-to-end regression test and documentation, with no other unpinned session targets and no functional risk to the safe colon-qualified pane targets.

## Testing

The configured baseline suite already ran green; I ran the smallest relevant set for this change — the new e2e regression test `tests/fm-spawn-tmux-target.test.sh` and the two touched backend suites — all pass. I also captured a manual before/after transcript on a live tmux server showing the bare numeric target failing with `index 7 in use` while the exact-match `=7:` form correctly lands the window in the session named `7`. The full 25-test e2e suite exceeded the 2-minute tool timeout but is unrelated to this change and covered by the baseline. This is a CLI/tooling change with no UI surface, so CLI transcripts are the appropriate reviewer-visible evidence.

<details>
<summary>Evidence: tmux target ambiguity: before/after demo on live tmux server</summary>

<code>Current session: 7 (indices 0-7 in use)&#10;OLD: bare &#39;-t 7&#39; -&gt; FAILED: create window failed: index 7 in use&#10;NEW: exact &#39;=7:&#39; -&gt; SUCCESS: window created in session 7, 0 leak into decoy &#39;other&#39;</code>

```text
### Reproducing the tmux target-ambiguity bug and the exact-match fix ###
tmux 3.4

Current session on server: 7  (window indices in use: 0 1 2 3 4 5 6 7 )

--- OLD behavior: bare '-t 7' (session name misread as window index of current session) ---
FAILED as expected: create window failed: index 7 in use

--- NEW behavior: exact-match '=7:' pins the session named 7 ---
SUCCESS: window 'newexact' created in session 7
session 7 windows now: bash bash bash bash bash bash bash bash newexact 
did it leak into decoy 'other'? -> 0 matches
```
</details>
<details>
<summary>Evidence: end-to-end regression test transcript</summary>

<code>ok - raw tmux: bare numeric -t collides with a window index; exact form &#39;=7:&#39; pins the session&#10;ok - fm-spawn in a session named &#39;7&#39; lands its window in session 7 despite occupied index 7&#10;ok - fm-spawn outside tmux still creates and targets the dedicated &#39;firstmate&#39; session&#10;all fm-spawn tmux target tests passed</code>

```text
### End-to-end regression test: tests/fm-spawn-tmux-target.test.sh ###
(fm-spawn run against a real tmux server whose current session is literally named '7' with index 7 occupied)

ok - raw tmux: bare numeric -t collides with a window index; exact form '=7:' pins the session
ok - fm-spawn in a session named '7' lands its window in session 7 despite occupied index 7
ok - fm-spawn outside tmux still creates and targets the dedicated 'firstmate' session
all fm-spawn tmux target tests passed
EXIT=0
```
</details>
- Outcome: 🔧 1 issue found → auto-fixed ✅ across 2 runs (16m28s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed ✅</summary>

- 🚨 tests failed with exit code 1
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`

🔧 Fix: test(backend): pin rc-free bash for tmux smoke test
✅ Re-checked - no issues remain.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- <code>`bash tests/fm-spawn-tmux-target.test.sh` — e2e: fm-spawn lands in a session literally named `7` (index 7 occupied) with no leak into decoy session; outside-tmux path still targets `firstmate`</code>
- <code>`bash tests/fm-backend.test.sh` — backend selector/send/spawn/teardown byte-identical old vs new</code>
- <code>`bash tests/fm-backend-tmux-smoke.test.sh` — real-tmux create_task/send/capture/kill</code>
- <code>Manual live-tmux demo: bare `-t 7` fails with `index 7 in use`; exact `=7:` form lands the window in session 7 with no decoy leak</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
