### PR TITLE
feat(harness): add cursor (cursor-agent) as a verified harness adapter

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harness-adapters
-description: Agent-only reference for firstmate harness operations. Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter. Contains verified facts for claude, codex, opencode, pi, and grok.
+description: Agent-only reference for firstmate harness operations. Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter. Contains verified facts for claude, codex, opencode, pi, grok, and cursor.
 user-invocable: false
 ---
 

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -55,6 +55,7 @@ The supported launch-profile flags below were verified locally on 2026-06-30 wit
 | grok | `--model <model>` | `--reasoning-effort <low\|medium\|high\|xhigh>` | Verified on grok 0.2.73. `--effort` parses too, but firstmate's profile axis is reasoning effort. `--reasoning-effort max` is rejected, so `max` is omitted. |
 | pi | `--model <model>` | `--thinking <low\|medium\|high\|xhigh>` | Verified on pi 0.80.2. `max` prints an invalid-thinking warning, so firstmate omits Pi effort when the requested effort is `max`. |
 | opencode | `--model <provider/model>` | none for firstmate's interactive launch | Verified on opencode 1.17.6. `opencode run` has `--variant`, but firstmate launches the interactive `opencode --prompt` path, which has no verified effort flag. |
+| cursor | `--model <id>` | none — encoded in model id | Verified on cursor-agent 2026.07.01-41b2de7. No separate effort flag; effort folds into the model id (suffix `-low/-medium/-high/-xhigh/-max`, or bracket `'id[effort=high]'`). `fm-spawn` records the requested effort in meta but emits no effort flag. |
 
 When a requested effort value is outside the harness-specific accepted set, `fm-spawn` records the requested `effort=` in meta but emits no effort flag for that harness.
 This preserves launch success instead of passing a known-bad value.
@@ -69,6 +70,7 @@ Natural language is acceptable if uncertain.
 - opencode: no separate verified skill invocation beyond normal slash-command behavior; use natural language if the exact skill command is uncertain.
 - pi: no separate verified skill invocation beyond normal command behavior; use natural language if the exact skill command is uncertain.
 - grok: `/<skill>`, for example `/no-mistakes` (same form as claude). Verified end to end: grok discovers the user-level `no-mistakes` skill, `/no-mistakes` invokes it, and grok drives a real `no-mistakes axi run`. Like codex's `$`/`/` popups, typing `/<skill>` opens grok's slash-autocomplete, so a too-fast Enter selects the popup entry instead of sending; `fm_tmux_submit_core`'s retried Enter (used by `fm-send`) lands it.
+- cursor: `/<skill>`, for example `/no-mistakes` (same form as claude/grok). cursor auto-discovers the workspace's `.agents/skills/` as `/`-commands (verified cursor-agent 2026.07.01). Note: the user-level `no-mistakes` skill was NOT present in `~/.cursor/skills/` at probe time, so confirm `/no-mistakes` resolves on cursor (cursor may need it symlinked into `~/.cursor/skills/`); natural language is the fallback.
 
 ## claude (VERIFIED)
 
@@ -177,3 +179,36 @@ The hook reads `$GROK_WORKSPACE_ROOT`, which is always set for hooks and equals 
 This keeps the hook outside the worktree, needs no trust grant, and writes only firstmate-owned files.
 `fm-teardown` removes the worktree pointer before returning a pooled worktree.
 Secondmate spawns skip the pointer (idle panes are healthy, no stale-pane detection for them).
+
+## cursor (VERIFIED 2026-07-02, cursor-agent 2026.07.01-41b2de7)
+
+`cursor-agent` (Cursor CLI). Launch with a positional prompt: `cursor-agent --yolo "$(cat <brief>)"`.
+
+| Fact | Value |
+|---|---|
+| Busy-pane signature | `ctrl+c to stop` (right-aligned on the `→ Add a follow-up` composer input line, shown iff a turn is running; idle shows that line bare, no suffix). The spinner line is a braille glyph + `<verb>` + `N.NNk tokens` (e.g. `⠘⠤ Working`, `⠰⠳ Editing 55 tokens`); the glyph rotates so match the ASCII `ctrl+c to stop`, never the spinner. |
+| Exit command | `Ctrl+D` (cleanly exits `node`→shell; `/exit`/`/quit` exist but their slash-autocomplete is menu-finicky under `tmux send-keys`). On exit prints `To resume this session: agent --resume=<chatId>`. |
+| Interrupt | single `Ctrl+C` (cancels the current turn, session survives). `Esc` dismisses the `/`-command menu but does not interrupt. |
+| Autonomy | `--yolo` (alias of `--force`; status bar shows `Run Everything`). Auto-approves every command unless explicitly denied. |
+| Env marker | `CURSOR_AGENT=1`, set for child/tool processes (the cursor analog of claude's `CLAUDECODE`). Also sets `CURSOR_INVOKED_AS=cursor-agent`, `CURSOR_CONVERSATION_ID=<uuid>`. |
+| Skill invocation | `/<skill>` (e.g. `/no-mistakes`), same as claude/grok. Workspace `.agents/skills/` is auto-discovered as `/`-commands. |
+| Resume | `cursor-agent --resume=<chatId>` (id printed on exit) or `--continue`. |
+
+Trust dialog: first launch in an untrusted workspace shows a bordered "Workspace Trust Required" dialog.
+Accept with `a` (or arrow+Enter on the highlighted row); reject with `q`.
+Trust persists per workspace path, so a re-launch in the same path does not re-prompt, but a fresh worktree path prompts anew.
+After every spawn, peek the pane within ~20 seconds and accept with `bin/fm-send.sh <window> --key a` if the dialog is showing.
+Headless `--print` mode skips the dialog entirely with `--trust` (see future fallback below).
+
+Turn-end hook: cursor fires a `stop` hook at every turn boundary (verified: 2 turns → 2 fires), the clean equivalent of claude's Stop / grok's Stop.
+But unlike grok's private `~/.grok/hooks/` tree, cursor's ONLY hook file is `~/.cursor/hooks.json`, which is SHARED with cmux and already holds cmux's own `stop`/`afterAgentResponse`/`beforeSubmitPrompt`/`beforeShellExecution`/`afterShellExecution` entries.
+So `fm-spawn` `jq`-MERGES firstmate's `stop` command in additively and idempotently (back up → merge keyed by the exact firstmate command so re-runs never duplicate → never clobber cmux's entries) and gates it as a no-op for every non-firstmate cursor session with the same per-task token-pointer scheme grok uses.
+The guard command fires only when the current workspace holds a `.fm-cursor-turnend` token pointer that matches the firstmate-owned registry under `~/.cursor/fm-turn-end.d/`; it resolves the workspace from `CURSOR_WORKSPACE_ROOT` (if set) or `pwd`, so it does not depend on cursor setting a workspace env var.
+`fm-spawn` writes that per-task pointer (`<worktree>/.fm-cursor-turnend`, gitignored via git `info/exclude`) and a matching registry entry naming this task's `state/<id>.turn-ended`.
+`fm-teardown` removes the worktree pointer and the per-task registry entry, but deliberately LEAVES the shared `~/.cursor/hooks.json` entry in place: it is idempotent and gated, so once the pointer is gone it is a safe no-op for every other cursor session (cmux's or a future firstmate task).
+This keeps the hook outside the worktree, needs no trust grant, and writes only firstmate-owned files (firstmate never clobbers cmux's entries, so it never removes a shared entry wholesale either).
+Secondmate spawns skip the pointer (idle panes are healthy, no stale-pane detection for them).
+
+Future fallback (not wired today): if the interactive TUI proves too finicky under real supervision (multi-key submit / follow-up prompts via `tmux send-keys` are unreliable and the composer can wedge), cursor-agent has a verified headless mode: `cursor-agent --print --yolo --trust [--output-format json] "<prompt>"` runs one agent turn to stdout and exits 0 cleanly, with `--output-format json` giving structured per-turn output instead of pane-scraping.
+firstmate's interactive TUI launch matches the other five adapters today; headless `--print` is documented here as the documented fallback path if TUI reliability becomes a blocker in real supervision.
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,7 +198,7 @@ If the captain expresses a standing dispatch preference such as "use grok for ne
 Crewmates default to the same harness you are running on.
 The captain may override the static default at any time, typically at bootstrap: record the choice in `config/crew-harness` (a single adapter name; absent or `default` means mirror your own harness).
 Resolve `default` with `bin/fm-harness.sh`; resolve the active static crewmate harness with `bin/fm-harness.sh crew`.
-Verified adapter names are `claude`, `codex`, `opencode`, `pi`, and `grok`.
+Verified adapter names are `claude`, `codex`, `opencode`, `pi`, `grok`, and `cursor`.
 
 ### Crew dispatch profiles
 
@@ -260,6 +260,7 @@ The verified profile axes are:
 - `grok`: model via `--model <name>`, reasoning effort via `--reasoning-effort <low|medium|high|xhigh>`; `max` is not passed because Grok rejects it for `--reasoning-effort`.
 - `pi`: model via `--model <name>`, effort via `--thinking <low|medium|high|xhigh>`; `max` is not passed because the installed Pi CLI warns that it is invalid.
 - `opencode`: model via `--model <provider/model>`; no verified effort flag for firstmate's interactive `opencode --prompt` launch, so effort is not passed.
+- `cursor`: model via `--model <id>` (cursor-specific vocabulary such as `auto`, `composer-2.5-fast`, `claude-opus-4-8-high`); no separate effort flag is passed because effort is folded into the model id (suffix `-low/-medium/-high/-xhigh/-max`, or bracket override `'id[effort=high]'`), so a requested effort is recorded in meta for traceability but not emitted as a flag (verified cursor-agent 2026.07.01-41b2de7).
 
 If the selected profile asks for an effort value the selected harness does not accept, `fm-spawn` records the requested `effort=` in meta for traceability but omits the launch flag so the harness starts successfully.
 Bootstrap reports this as a `CREW_DISPATCH` diagnostic when it can see the invalid harness/effort pair in `config/crew-dispatch.json`.

--- a/README.md
+++ b/README.md
@@ -54,14 +54,14 @@ Full detail on every feature lives in [docs/architecture.md](docs/architecture.m
 
 ## Quick Start
 
-**Requirements:** a verified agent harness (claude, codex, opencode, pi, or grok), git with GitHub auth, and tmux for the reference session backend.
+**Requirements:** a verified agent harness (claude, codex, opencode, pi, grok, or cursor), git with GitHub auth, and tmux for the reference session backend.
 Experimental herdr spawns additionally require `herdr` and `jq`, checked at spawn time.
 The first mate detects and offers to install everything else.
 
 ```sh
 gh auth login
 git clone https://github.com/kunchenguid/firstmate
-cd firstmate && claude   # launch your harness here; AGENTS.md takes over
+cd firstmate && claude   # or cursor-agent, codex, etc.; AGENTS.md takes over
 ```
 
 Then just talk:

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -324,13 +324,13 @@ crew_dispatch_validate() {
     return 0
   fi
   err=$(jq -r '
-    def verified($h): ["claude","codex","opencode","pi","grok"] | index($h);
+    def verified($h): ["claude","codex","opencode","pi","grok","cursor"] | index($h);
     def effort_ok($h; $e):
       if $e == null then true
       elif ($e | type) != "string" then false
       elif $h == "claude" then (["low","medium","high","xhigh","max"] | index($e))
       elif ($h == "codex" or $h == "grok" or $h == "pi") then (["low","medium","high","xhigh"] | index($e))
-      elif $h == "opencode" then false
+      elif ($h == "opencode" or $h == "cursor") then false
       else true
       end;
     def bad_efforts:

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -414,6 +414,20 @@ fi
 crew=
 [ -f "$CONFIG/crew-harness" ] && crew=$(tr -d '[:space:]' < "$CONFIG/crew-harness" || true)
 [ -n "$crew" ] && [ "$crew" != "default" ] && echo "CREW_HARNESS_OVERRIDE: $crew"
+
+# jq is required for cursor harness (to jq-merge the stop hook into the shared
+# ~/.cursor/hooks.json). Already required for X-mode and crew-dispatch (above).
+if [ "$crew" = "cursor" ]; then
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "MISSING: jq (install: $(install_cmd jq))"
+  fi
+fi
+sm=
+[ -f "$CONFIG/secondmate-harness" ] && sm=$(head -1 "$CONFIG/secondmate-harness" 2>/dev/null | tr -d '[:space:]' | cut -d' ' -f1 || true)
+if [ "$sm" = "cursor" ] && ! command -v jq >/dev/null 2>&1; then
+  echo "MISSING: jq (install: $(install_cmd jq))"
+fi
+
 crew_dispatch_validate
 if ! fm_backlog_backend_manual "$CONFIG"; then
   if fm_tasks_axi_compatible; then

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Detect the agent harness this process tree runs on.
-# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|grok|unknown
+# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|grok|cursor|unknown
 #        fm-harness.sh crew             print the effective CREWMATE harness
 #                                        (config/crew-harness; "default" resolves to own)
 #        fm-harness.sh secondmate       print the harness the PRIMARY uses to launch
@@ -35,6 +35,9 @@ detect_own() {
   # It does NOT set CLAUDECODE despite being Claude-Code-compatible, so this marker
   # is unambiguous when firstmate runs natively on grok.
   [ "${GROK_AGENT:-}" = "1" ] && { echo grok; return; }
+  # cursor-agent sets CURSOR_AGENT=1 for its child/tool processes (verified,
+  # cursor-agent 2026.07.01-41b2de7), the cursor analog of claude's CLAUDECODE.
+  [ "${CURSOR_AGENT:-}" = "1" ] && { echo cursor; return; }
   # Layer 2: walk the parent chain and match the command name.
   local pid=$$ comm args
   for _ in 1 2 3 4 5 6 7 8; do
@@ -44,6 +47,7 @@ detect_own() {
       *codex*) echo codex; return ;;
       *opencode*) echo opencode; return ;;
       *grok*) echo grok; return ;;
+      *cursor*) echo cursor; return ;;
       pi) echo pi; return ;;
       node*|python*)
         # Bare interpreter: match the harness name in its script path.
@@ -53,6 +57,7 @@ detect_own() {
           *codex*) echo codex; return ;;
           *opencode*) echo opencode; return ;;
           *grok*) echo grok; return ;;
+          *cursor*) echo cursor; return ;;
           *" pi "*|*/pi) echo pi; return ;;
         esac ;;
     esac

--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -15,7 +15,7 @@ LOCK="$STATE/.lock"
 mkdir -p "$STATE"
 
 # Known harness command names; extend when a new adapter is verified.
-HARNESS_RE='claude|codex|opencode|grok|^pi$'
+HARNESS_RE='claude|codex|opencode|grok|cursor|^pi$'
 
 harness_pid() {
   local pid=$$ comm args

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -430,6 +430,9 @@ json_escape() {
 # idempotency key). Other stop entries (cmux's or the captain's) are left intact.
 # Re-running spawn for any task produces the same single firstmate entry; the
 # per-task gate lives in the command, not here.
+#
+# Failures (bad JSON, unmergeable, etc.) are fatal: the spawn exits non-zero rather
+# than launching without a working turn-end hook.
 fm_cursor_merge_hooks() {
   local hooks_file=$1 fm_command=$2
   # Guarded by early check in spawn when HARNESS=cursor (plus bootstrap reporting).
@@ -455,7 +458,8 @@ fm_cursor_merge_hooks() {
     mv "$tmp" "$hooks_file"
   else
     rm -f "$tmp"
-    echo "warning: cursor hooks merge failed; left $hooks_file untouched" >&2
+    echo "error: cursor hooks merge failed for $hooks_file (malformed JSON or unmergeable shape); refusing to launch without the turn-end hook" >&2
+    exit 1
   fi
 }
 

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -432,9 +432,12 @@ json_escape() {
 # per-task gate lives in the command, not here.
 fm_cursor_merge_hooks() {
   local hooks_file=$1 fm_command=$2
+  # Guarded by early check in spawn when HARNESS=cursor (plus bootstrap reporting).
+  # If we reach here without jq, something is wrong — fail hard.
   if ! command -v jq >/dev/null 2>&1; then
-    echo "warning: jq not found; cannot install cursor turn-end hook into $hooks_file" >&2
-    return 0
+    echo "error: jq is required for cursor harness turn-end hook" >&2
+    echo "MISSING: jq (install: brew install jq  # or equivalent for your platform)" >&2
+    exit 1
   fi
   [ -f "$hooks_file" ] || printf '{"hooks":{},"version":1}\n' > "$hooks_file"
   cp -p "$hooks_file" "$hooks_file.fm-bak" 2>/dev/null || true

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -307,6 +307,16 @@ case "$ARG3" in
     ;;
 esac
 
+# jq is required for cursor to merge the turn-end hook into ~/.cursor/hooks.json
+# (shared with cmux). Fail before launching the agent if missing (bootstrap
+# reports it when crew-harness or secondmate-harness selects cursor).
+if [ "$HARNESS" = "cursor" ] && ! command -v jq >/dev/null 2>&1; then
+  echo "error: jq is required for cursor harness (to install the stop hook that fires state/<id>.turn-ended)" >&2
+  echo "MISSING: jq (install: brew install jq  # or equivalent for your platform)" >&2
+  exit 1
+fi
+
+
 # config/secondmate-harness may carry optional model/effort tokens alongside the
 # harness ("<harness> [<model>] [<effort>]"). They apply only when this is a
 # --secondmate spawn and no explicit per-spawn harness/raw launch was supplied, so

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -23,7 +23,7 @@
 #   profile consultation. A --secondmate spawn is exempt and resolves the SECONDMATE
 #   harness (config/secondmate-harness -> config/crew-harness -> own), so the
 #   secondmate-vs-crewmate split is DURABLE across every respawn (recovery,
-#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|grok)
+#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|grok|cursor)
 #   overrides it for this spawn (either kind). A non-flag string containing
 #   whitespace is treated as a RAW launch command - the escape hatch for verifying
 #   new adapters.

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -194,7 +194,7 @@ FIRSTMATE_HOME=
 
 if [ "$KIND" = secondmate ]; then
   case "${POS[1]:-}" in
-    ''|claude|codex|opencode|pi|grok)
+    ''|claude|codex|opencode|pi|grok|cursor)
       ARG3=${POS[1]:-}
       ;;
     *' '*)
@@ -255,6 +255,18 @@ launch_template() {
     # launch command - it is a Stop-event hook installed below (global hook +
     # per-task pointer), so the template is identical for ship/scout/secondmate.
     grok) printf '%s' 'grok --always-approve __MODELFLAG____EFFORTFLAG__"$(cat __BRIEF__)"' ;;
+    # cursor (cursor-agent TUI): a positional prompt starts the supervised
+    # interactive session. --yolo (alias of --force, "Run Everything") auto-
+    # approves every tool execution, which an unattended crewmate needs; it is the
+    # targeted equivalent of claude's --dangerously-skip-permissions. cursor's
+    # turn-end signal rides a Stop hook in the shared ~/.cursor/hooks.json,
+    # installed additively below (merged with cmux's entries, guarded by a per-task
+    # token pointer), so the template is identical for ship/scout/secondmate. There
+    # is NO separate effort flag: effort is folded into the model id (suffix
+    # -low/-medium/-high/-xhigh/-max or bracket override 'id[effort=high]'), so
+    # __EFFORTFLAG__ stays empty for cursor until a model-id-suffix mapping exists;
+    # the requested effort is recorded in meta for traceability.
+    cursor) printf '%s' 'cursor-agent --yolo __MODELFLAG____EFFORTFLAG__"$(cat __BRIEF__)"' ;;
     *) return 1 ;;
   esac
 }
@@ -342,7 +354,7 @@ model_flag_for_harness() {
   local harness=$1 model=$2
   [ -n "$model" ] && [ "$model" != default ] || return 0
   case "$harness" in
-    claude|codex|opencode|pi|grok)
+    claude|codex|opencode|pi|grok|cursor)
       printf -- '--model %s ' "$(shell_quote "$model")"
       ;;
   esac
@@ -383,11 +395,54 @@ effort_flag_for_harness() {
     # opencode's interactive `opencode --prompt` launch has a verified --model
     # flag but no verified effort flag. Its `opencode run --variant` flag belongs
     # to a different, non-interactive launch mode, so fm-spawn does not pass it.
+    #
+    # cursor has no separate effort/reasoning flag in interactive mode. Effort is
+    # encoded in the model id itself (suffix -low/-medium/-high/-xhigh/-max, or the
+    # bracket override 'id[effort=high]'). firstmate's dispatch-profile effort axis
+    # would therefore map to an effort-suffixed model id, not a flag; until that
+    # model-id-suffix mapping exists, fm-spawn emits no effort flag for cursor and
+    # the requested effort is recorded in meta for traceability (verified
+    # cursor-agent 2026.07.01-41b2de7).
   esac
 }
 
 json_escape() {
   printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+
+# fm_cursor_merge_hooks <hooks.json> <json-escaped command>
+# Merge firstmate's stop hook into the SHARED ~/.cursor/hooks.json additively and
+# idempotently. The file is shared with cmux and already holds cmux's own entries,
+# so this NEVER clobbers existing hooks: it backs up the file, ensures the top-level
+# {"hooks": ...,"version":1} shape exists, and adds exactly one stop entry whose
+# command is the firstmate guard script - but only if a stop entry with that exact
+# firstmate command is not already present (the idempotency key). Other stop entries
+# (cmux's or the captain's) are left intact. Re-running spawn for any task produces
+# the same single firstmate entry; the per-task gate lives in the command, not here.
+fm_cursor_merge_hooks() {
+  local hooks_file=$1 fm_command=$2
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "warning: jq not found; cannot install cursor turn-end hook into $hooks_file" >&2
+    return 0
+  fi
+  [ -f "$hooks_file" ] || printf '{"hooks":{},"version":1}\n' > "$hooks_file"
+  cp -p "$hooks_file" "$hooks_file.fm-bak" 2>/dev/null || true
+  local tmp
+  tmp=$(mktemp) || return 0
+  if jq --arg cmd "$fm_command" '
+      ( . + {"version":1} ) as $base
+      | ($base.hooks // {}) as $h
+      | ($h.stop // []) as $stops
+      | ($stops | map(select(.hooks // [] | any(.command == $cmd))) | length) as $have
+      | (if $have > 0 then $stops
+         else $stops + [{"hooks":[{"type":"command","command":$cmd}]}] end) as $newstops
+      | $base + {"hooks":($h + {"stop":$newstops})}
+    ' "$hooks_file" > "$tmp" 2>/dev/null; then
+    mv "$tmp" "$hooks_file"
+  else
+    rm -f "$tmp"
+    echo "warning: cursor hooks merge failed; left $hooks_file untouched" >&2
+  fi
 }
 
 resolved_existing_dir() {
@@ -781,6 +836,57 @@ EOF
       printf '{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"%s"}]}]}}\n' "$hook_command" > "$GROK_HOOKS_DIR/fm-turn-end.json"
       printf 'token=%s\n' "${auth_file##*/}" > "$WT/.fm-grok-turnend"
       exclude_path '.fm-grok-turnend'
+      ;;
+    cursor*)
+      # cursor fires a stop hook at every turn boundary (verified,
+      # cursor-agent 2026.07.01: 2 turns -> 2 stop fires), the clean equivalent of
+      # claude's Stop / codex's notify= / grok's Stop. But unlike grok's private
+      # ~/.grok/hooks/ tree, cursor's ONLY hook file is ~/.cursor/hooks.json,
+      # which is SHARED with cmux and already holds cmux's own stop /
+      # afterAgentResponse / beforeSubmitPrompt / beforeShellExecution /
+      # afterShellExecution entries. So firstmate jq-MERGES its stop command in
+      # additively and idempotently (back up -> merge keyed by a firstmate marker
+      # so re-runs never duplicate -> never clobber cmux's entries), and gates it
+      # as a no-op for every non-firstmate cursor session with the SAME per-task
+      # token-pointer scheme grok uses: the command fires only when the current
+      # workspace holds a .fm-cursor-turnend token pointer that matches the
+      # firstmate-owned hook registry. Result: cmux's hooks are untouched, and
+      # firstmate's hook never fires for cmux-driven or the captain's own cursor
+      # sessions. cursor's hook cwd is the workspace, so the guard resolves the
+      # workspace from CURSOR_WORKSPACE_ROOT (if set) or pwd, then reads the
+      # pointer; it does not depend on cursor setting a workspace env var.
+      CURSOR_HOOKS_FILE="$HOME/.cursor/hooks.json"
+      CURSOR_AUTH_DIR="$HOME/.cursor/fm-turn-end.d"
+      mkdir -p "$CURSOR_AUTH_DIR"
+      old_umask=$(umask)
+      umask 077
+      auth_file=$(mktemp "$CURSOR_AUTH_DIR/fm.XXXXXXXXXXXX")
+      umask "$old_umask"
+      printf '%s\n' "$TURNEND" > "$auth_file"
+      printf '%s\n' "${auth_file##*/}" > "$STATE/$ID.cursor-turnend-token"
+      sq_cursor_auth_dir=$(shell_quote "$CURSOR_AUTH_DIR")
+      cat > "$CURSOR_AUTH_DIR/fm-turn-end.sh" <<EOF
+#!/usr/bin/env bash
+set -u
+auth_dir=$sq_cursor_auth_dir
+workspace=\${CURSOR_WORKSPACE_ROOT:-\$PWD}
+p="\$workspace/.fm-cursor-turnend"
+[ -f "\$p" ] || exit 0
+first=
+IFS= read -r -n 256 first < "\$p" 2>/dev/null || [ -n "\$first" ] || exit 0
+case "\$first" in token=*) token=\${first#token=} ;; *) exit 0 ;; esac
+case "\$token" in fm.????????????) : ;; *) exit 0 ;; esac
+case "\$token" in *[!A-Za-z0-9._-]*) exit 0 ;; esac
+t=\$(cat "\$auth_dir/\$token" 2>/dev/null) || exit 0
+case "\$t" in /*.turn-ended) : ;; *) exit 0 ;; esac
+touch "\$t" 2>/dev/null || true
+exit 0
+EOF
+      chmod +x "$CURSOR_AUTH_DIR/fm-turn-end.sh"
+      hook_command=$(json_escape "bash $(shell_quote "$CURSOR_AUTH_DIR/fm-turn-end.sh")")
+      fm_cursor_merge_hooks "$CURSOR_HOOKS_FILE" "$hook_command"
+      printf 'token=%s\n' "${auth_file##*/}" > "$WT/.fm-cursor-turnend"
+      exclude_path '.fm-cursor-turnend'
       ;;
   esac
 fi

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -414,11 +414,12 @@ json_escape() {
 # Merge firstmate's stop hook into the SHARED ~/.cursor/hooks.json additively and
 # idempotently. The file is shared with cmux and already holds cmux's own entries,
 # so this NEVER clobbers existing hooks: it backs up the file, ensures the top-level
-# {"hooks": ...,"version":1} shape exists, and adds exactly one stop entry whose
-# command is the firstmate guard script - but only if a stop entry with that exact
-# firstmate command is not already present (the idempotency key). Other stop entries
-# (cmux's or the captain's) are left intact. Re-running spawn for any task produces
-# the same single firstmate entry; the per-task gate lives in the command, not here.
+# {"hooks": ...,"version":1} shape exists, and adds exactly one stop entry with a
+# direct top-level "command" (per Cursor's documented hooks schema) - but only if
+# a stop entry with that exact firstmate command is not already present (the
+# idempotency key). Other stop entries (cmux's or the captain's) are left intact.
+# Re-running spawn for any task produces the same single firstmate entry; the
+# per-task gate lives in the command, not here.
 fm_cursor_merge_hooks() {
   local hooks_file=$1 fm_command=$2
   if ! command -v jq >/dev/null 2>&1; then
@@ -433,9 +434,9 @@ fm_cursor_merge_hooks() {
       ( . + {"version":1} ) as $base
       | ($base.hooks // {}) as $h
       | ($h.stop // []) as $stops
-      | ($stops | map(select(.hooks // [] | any(.command == $cmd))) | length) as $have
+      | ($stops | map(select(.command == $cmd)) | length) as $have
       | (if $have > 0 then $stops
-         else $stops + [{"hooks":[{"type":"command","command":$cmd}]}] end) as $newstops
+         else $stops + [{"command":$cmd}] end) as $newstops
       | $base + {"hooks":($h + {"stop":$newstops})}
     ' "$hooks_file" > "$tmp" 2>/dev/null; then
     mv "$tmp" "$hooks_file"

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -102,6 +102,21 @@ remove_grok_turnend_auth() {
   rm -f "$hooks_dir/$token"
 }
 
+# Remove this task's cursor turn-end auth (the per-task registry entry + state
+# token). The per-worktree pointer is dropped by the caller. The SHARED
+# ~/.cursor/hooks.json stop entry is deliberately LEFT in place: it is idempotent
+# (fm-spawn merges additively and never duplicates) and gated by the per-task token
+# pointer, so once the pointer is gone it is a safe no-op for every other cursor
+# session (cmux's or a future firstmate task). Firstmate never clobbers cmux's
+# entries, so it never removes a shared entry wholesale either.
+remove_cursor_turnend_auth() {
+  local state_dir=$1 id=$2 token auth_dir
+  token=$(cat "$state_dir/$id.cursor-turnend-token" 2>/dev/null || true)
+  case "$token" in ''|*[!A-Za-z0-9._-]*) return 0 ;; esac
+  auth_dir="$HOME/.cursor/fm-turn-end.d"
+  rm -f "$auth_dir/$token"
+}
+
 # Resolve the PR number for a worktree branch via gh-axi. Echoes the number on a
 # single match and returns 0; returns non-zero on no match or any lookup failure,
 # so the caller treats it as "no PR found" (fail-safe).
@@ -536,7 +551,7 @@ cleanup_firstmate_home_children() {
       fi
     elif [ -n "$child_wt" ] && [ -d "$child_wt" ]; then
       validate_child_worktree_for_removal "$child_wt" "$child_proj" >/dev/null || return 1
-      rm -f "$child_wt/.claude/settings.local.json" "$child_wt/.opencode/plugins/fm-turn-end.js" "$child_wt/.fm-grok-turnend"
+      rm -f "$child_wt/.claude/settings.local.json" "$child_wt/.opencode/plugins/fm-turn-end.js" "$child_wt/.fm-grok-turnend" "$child_wt/.fm-cursor-turnend"
       if [ -n "$child_proj" ] && [ -d "$child_proj" ] && command -v treehouse >/dev/null 2>&1; then
         ( cd "$child_proj" && treehouse return --force "$child_wt" ) || safe_rm_rf_child_worktree "$child_wt" "$child_proj"
       else
@@ -544,7 +559,8 @@ cleanup_firstmate_home_children() {
       fi
     fi
     remove_grok_turnend_auth "$sub_state" "$child_id"
-    rm -f "$sub_state/$child_id.status" "$sub_state/$child_id.turn-ended" "$sub_state/$child_id.check.sh" "$sub_state/$child_id.meta" "$sub_state/$child_id.pi-ext.ts" "$sub_state/$child_id.grok-turnend-token"
+    remove_cursor_turnend_auth "$sub_state" "$child_id"
+    rm -f "$sub_state/$child_id.status" "$sub_state/$child_id.turn-ended" "$sub_state/$child_id.check.sh" "$sub_state/$child_id.meta" "$sub_state/$child_id.pi-ext.ts" "$sub_state/$child_id.grok-turnend-token" "$sub_state/$child_id.cursor-turnend-token"
   done
 }
 
@@ -593,7 +609,7 @@ if [ -d "$WT" ] && [ "$FORCE" != "--force" ]; then
     fi
   else
     # The fm-spawn hook file is ours, never work product; ignore it in the dirty check.
-    dirty=$(git -C "$WT" status --porcelain 2>/dev/null | grep -vE '^\?\? (\.claude/|\.fm-grok-turnend$)' | head -1 || true)
+    dirty=$(git -C "$WT" status --porcelain 2>/dev/null | grep -vE '^\?\? (\.claude/|\.fm-grok-turnend$|\.fm-cursor-turnend$)' | head -1 || true)
     # Reachability test: is HEAD reachable from ANY remote-tracking branch? Empty
     # means the work is already pushed (a fork is a remote too, so upstream-
     # contribution PRs pushed to a fork pass here). Non-empty does NOT prove the work
@@ -651,7 +667,7 @@ if [ -d "$WT" ] && [ "$KIND" != secondmate ]; then
     fi
   fi
   # Remove our hook file so a reused pool worktree cannot fire signals for a dead task.
-  rm -f "$WT/.claude/settings.local.json" "$WT/.opencode/plugins/fm-turn-end.js" "$WT/.fm-grok-turnend"
+  rm -f "$WT/.claude/settings.local.json" "$WT/.opencode/plugins/fm-turn-end.js" "$WT/.fm-grok-turnend" "$WT/.fm-cursor-turnend"
   # Kills remaining processes in the worktree (including the agent), resets, returns
   # to pool. treehouse resolves the pool from the working directory, so run it from
   # the project.
@@ -665,10 +681,11 @@ if [ "$KIND" = secondmate ]; then
   remove_secondmate_registry_entry "$ID"
 fi
 remove_grok_turnend_auth "$STATE" "$ID"
+remove_cursor_turnend_auth "$STATE" "$ID"
 # Remove the per-task temp root (/tmp/fm-<id>/, incl. its gotmp/) recorded by spawn.
 # Read before the state-file rm below; empty (pre-fix tasks without tasktmp=) is a no-op.
 [ -n "$TASK_TMP" ] && rm -rf "$TASK_TMP"
-rm -f "$STATE/$ID.status" "$STATE/$ID.turn-ended" "$STATE/$ID.check.sh" "$STATE/$ID.meta" "$STATE/$ID.pi-ext.ts" "$STATE/$ID.grok-turnend-token"
+rm -f "$STATE/$ID.status" "$STATE/$ID.turn-ended" "$STATE/$ID.check.sh" "$STATE/$ID.meta" "$STATE/$ID.pi-ext.ts" "$STATE/$ID.grok-turnend-token" "$STATE/$ID.cursor-turnend-token"
 if [ "$KIND" != scout ] && [ "$KIND" != secondmate ] && [ "$MODE" != local-only ]; then
   "$FM_ROOT/bin/fm-fleet-sync.sh" "$PROJ" || true
 fi

--- a/bin/fm-tmux-lib.sh
+++ b/bin/fm-tmux-lib.sh
@@ -37,7 +37,9 @@
 # Busy footers per harness (mirror fm-watch.sh). claude/codex: "esc to
 # interrupt"; opencode: "esc interrupt"; pi: "Working..."; grok: "Ctrl+c:cancel"
 # (grok's mid-turn cancel hint, shown iff a turn is running - verified grok 0.2.73).
-FM_TMUX_BUSY_REGEX_DEFAULT='esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel'
+# cursor: "ctrl+c to stop" (cursor-agent's mid-turn hint on the composer input line,
+# shown iff a turn is running - verified cursor-agent 2026.07.01).
+FM_TMUX_BUSY_REGEX_DEFAULT='esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel|ctrl\+c to stop'
 
 # fm_tmux_strip_ghost: remove dim/faint (ANSI SGR 2) styled runs from one captured
 # composer line, then drop any remaining escape sequences, leaving only the plain,

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -106,7 +106,10 @@ SIGNAL_GRACE=${FM_SIGNAL_GRACE:-30}   # seconds to linger after a signal so trai
 # grok: "Ctrl+c:cancel" (the mid-turn cancel hint in grok's keybind bar, shown iff a
 # turn is running; absent when idle - verified grok 0.2.73, ASCII to avoid the
 # locale fragility of matching grok's braille spinner glyph directly).
-BUSY_REGEX=${FM_BUSY_REGEX:-'esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel'}
+# cursor: "ctrl+c to stop" (right-aligned on the composer input line, shown iff a
+# turn is running; absent when idle - verified cursor-agent 2026.07.01, ASCII to
+# avoid matching cursor's rotating braille spinner glyph).
+BUSY_REGEX=${FM_BUSY_REGEX:-'esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel|ctrl\+c to stop'}
 # Always-on wake triage: most wakes during a long crew validation are benign (a
 # working: note or turn-end while a pipeline runs, a no-change heartbeat). Rather
 # than wake firstmate's LLM for each, this watcher classifies every wake in bash

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -77,7 +77,7 @@ The session-start bootstrap step surfaces either the active rule block or a conc
 When the file exists, `fm-spawn.sh` refuses crewmate and scout launches without an explicit harness, so `config/crew-harness` is only automatic when no dispatch profile file is active.
 Secondmate launches are exempt because they resolve the secondmate harness and any optional secondmate model or effort tokens instead.
 Unsupported effort values are still recorded in task meta when passed to `fm-spawn.sh`, but the launch template omits any effort flag that the selected harness does not accept.
-That keeps spawn launch compatible across claude, codex, grok, pi, and opencode while preserving the requested profile for later audit.
+That keeps spawn launch compatible across claude, codex, grok, pi, opencode, and cursor while preserving the requested profile for later audit.
 
 ## Optional secondmates
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -72,7 +72,7 @@ For the herdr backend, `FM_HOME` also determines the workspace label used by the
 
 ## Harness support
 
-claude, codex, opencode, pi, and grok are all empirically verified; new harnesses get verified through a supervised trial task before joining the set.
+claude, codex, opencode, pi, grok, and cursor are all empirically verified; new harnesses get verified through a supervised trial task before joining the set.
 The verified adapter knowledge - busy signatures, interrupt and exit commands, skill-invocation syntax, and per-harness quirks - lives in [`.agents/skills/harness-adapters/SKILL.md`](../.agents/skills/harness-adapters/SKILL.md).
 Launch mechanics, including the verified command templates, live in [`bin/fm-spawn.sh`](../bin/fm-spawn.sh).
 `config/crew-harness` is a local, gitignored file containing one adapter name for crewmate and scout launches.

--- a/tests/fm-cursor-harness.test.sh
+++ b/tests/fm-cursor-harness.test.sh
@@ -6,7 +6,8 @@ set -u
 # CURSOR_AGENT=1 and from a cursor-agent process name; fm-spawn.sh launch_template
 # emitting the verified `cursor-agent --yolo ...` string; and the SHARED
 # ~/.cursor/hooks.json merge being idempotent (apply twice -> same content) while
-# preserving an unrelated existing (cmux) entry.
+# preserving an unrelated existing (cmux) entry, using Cursor's documented flat
+# "command" schema for stop entries.
 
 # shellcheck source=tests/lib.sh
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
@@ -146,8 +147,10 @@ test_cursor_hook_merge_idempotent_and_preserves_cmux() {
 $rec
 EOF
   # Pre-seed the SHARED hooks.json with cmux's own entries (the realistic state).
+  # Use Cursor's documented flat schema: each stop (and other hook) entry has a
+  # top-level "command" (not a nested {"hooks":[{...}]} wrapper).
   hooks="$home/.cursor/hooks.json"
-  printf '%s\n' '{"hooks":{"afterAgentResponse":[{"hooks":[{"type":"command","command":"cmux-after.sh"}]}],"stop":[{"hooks":[{"type":"command","command":"cmux-stop.sh"}]}]},"version":1}' > "$hooks"
+  printf '%s\n' '{"hooks":{"afterAgentResponse":[{"command":"cmux-after.sh"}],"stop":[{"command":"cmux-stop.sh"}]},"version":1}' > "$hooks"
   cmux_hash=$(jq -S . "$hooks" | shasum)
 
   out=$(run_cursor_spawn "$home" "$proj" "$wt" "$fakebin" "$id")
@@ -159,13 +162,13 @@ EOF
   assert_present "$auth/fm-turn-end.sh" "cursor guard script was not installed"
 
   # cmux's afterAgentResponse entry must survive the merge untouched.
-  jq -e '.hooks.afterAgentResponse[0].hooks[0].command == "cmux-after.sh"' "$hooks" >/dev/null \
+  jq -e '.hooks.afterAgentResponse[0].command == "cmux-after.sh"' "$hooks" >/dev/null \
     || fail "cursor merge clobbered cmux's afterAgentResponse entry"
   # cmux's own stop entry must survive; firstmate's stop entry added alongside it.
-  jq -e '.hooks.stop | map(select(.hooks[0].command == "cmux-stop.sh")) | length == 1' "$hooks" >/dev/null \
+  jq -e '.hooks.stop | map(select(.command == "cmux-stop.sh")) | length == 1' "$hooks" >/dev/null \
     || fail "cursor merge dropped cmux's stop entry"
   fm_count=$(jq --arg cmd "$auth/fm-turn-end.sh" \
-    '.hooks.stop | map(select(any(.hooks[]?; (.command | test($cmd))))) | length' "$hooks")
+    '.hooks.stop | map(select(.command | test($cmd))) | length' "$hooks")
   [ "$fm_count" = "1" ] || fail "expected exactly one firstmate stop entry, got $fm_count"
 
   # Re-run the SAME spawn a second time (simulating a respawn or a second task
@@ -174,9 +177,9 @@ EOF
   out=$(run_cursor_spawn "$home" "$proj" "$wt" "$fakebin" "$id")
   expect_code 0 $? "second cursor spawn should succeed"
   fm_count2=$(jq --arg cmd "$home/.cursor/fm-turn-end.d/fm-turn-end.sh" \
-    '.hooks.stop | map(select(any(.hooks[]?; (.command | test($cmd))))) | length' "$hooks")
+    '.hooks.stop | map(select(.command | test($cmd))) | length' "$hooks")
   [ "$fm_count2" = "1" ] || fail "second cursor spawn duplicated the firstmate stop entry (got $fm_count2)"
-  jq -e '.hooks.afterAgentResponse[0].hooks[0].command == "cmux-after.sh"' "$hooks" >/dev/null \
+  jq -e '.hooks.afterAgentResponse[0].command == "cmux-after.sh"' "$hooks" >/dev/null \
     || fail "second cursor spawn clobbered cmux's afterAgentResponse"
 
   # The guard must fire the right target: this task's pointer -> its turn-ended,

--- a/tests/fm-cursor-harness.test.sh
+++ b/tests/fm-cursor-harness.test.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+set -u
+
+# cursor (cursor-agent) harness-adapter wiring tests, modeled on
+# tests/fm-grok-harness.test.sh. Covers: fm-harness.sh self-detection from
+# CURSOR_AGENT=1 and from a cursor-agent process name; fm-spawn.sh launch_template
+# emitting the verified `cursor-agent --yolo ...` string; and the SHARED
+# ~/.cursor/hooks.json merge being idempotent (apply twice -> same content) while
+# preserving an unrelated existing (cmux) entry.
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SPAWN="$ROOT/bin/fm-spawn.sh"
+HARNESS="$ROOT/bin/fm-harness.sh"
+TMP_ROOT=$(fm_test_tmproot fm-cursor-harness)
+
+# --- fm-harness.sh self-detection -------------------------------------------
+
+test_fm_harness_detects_cursor_env_marker() {
+  local out
+  # Unset the competing markers (this test process runs inside a claude crewmate,
+  # where CLAUDECODE=1 would otherwise win the layer-1 env check first). Real
+  # firstmate-on-cursor sets only CURSOR_AGENT=1, never CLAUDECODE.
+  out=$(env -u CLAUDECODE -u GROK_AGENT -u PI_CODING_AGENT CURSOR_AGENT=1 "$HARNESS")
+  assert_contains "$out" "cursor" "fm-harness did not detect CURSOR_AGENT=1 env marker"
+  pass "fm-harness detects cursor via CURSOR_AGENT=1"
+}
+
+test_fm_harness_detects_cursor_process_name() {
+  # Layer-2 (process-name) detection is exercised through fm-lock.sh's HARNESS_RE,
+  # which shares the same basename-matching logic as fm-harness.sh's ancestry walk.
+  # Directly testing layer 2 via exec -a is unreliable on macOS (ps -o comm returns
+  # the real binary path, not argv[0]), so the deterministic test is fm-lock with a
+  # fake ps that reports a cursor-agent process (the captain's actual hit bug).
+  local home fakebin out
+  home="$TMP_ROOT/harness-lock-home"
+  fakebin=$(fm_fakebin "$TMP_ROOT/harness-lock-fake")
+  mkdir -p "$home/state"
+  printf '%s\n' "$$" > "$home/state/.lock"
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *"comm="*) printf '%s\n' '/Users/x/.local/bin/cursor-agent'; exit 0 ;;
+  *"args="*) printf '%s\n' 'cursor-agent'; exit 0 ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/ps"
+  out=$(FM_HOME="$home" PATH="$fakebin:$PATH" "$ROOT/bin/fm-lock.sh" status)
+  assert_contains "$out" "lock: held by live harness pid" "fm-harness/fm-lock did not recognize cursor-agent process name"
+  pass "fm-harness layer-2 process-name arm recognizes cursor-agent"
+}
+
+# --- fm-spawn.sh launch_template --------------------------------------------
+
+make_spawn_fakebin() {
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+esac
+case "${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+  list-windows) exit 0 ;;
+  has-session|new-session|new-window|send-keys|kill-window) exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" treehouse gh-axi gh
+  printf '%s\n' "$fakebin"
+}
+
+make_spawn_case() {
+  local name=$1 case_dir home proj wt fakebin id
+  case_dir="$TMP_ROOT/$name"
+  home="$case_dir/home"
+  proj="$case_dir/project"
+  wt="$case_dir/wt"
+  fakebin=$(make_spawn_fakebin "$case_dir/fake")
+  id="cursor-$name-x1"
+  mkdir -p "$home/data/$id" "$home/projects" "$home/state" "$home/config" "$home/.cursor"
+  printf 'brief\n' > "$home/data/$id/brief.md"
+  fm_git_worktree "$proj" "$wt" "fm/$id"
+  touch "$home/state/.last-watcher-beat"
+  printf '%s\n' "$case_dir|$home|$proj|$wt|$fakebin|$id"
+}
+
+run_cursor_spawn() {
+  local home=$1 proj=$2 wt=$3 fakebin=$4 id=$5
+  FM_ROOT_OVERRIDE='' FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
+    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" TMUX="fake,1,0" \
+    HOME="$home" PATH="$fakebin:$PATH" \
+    "$SPAWN" "$id" "$proj" cursor 2>&1
+}
+
+test_spawn_emits_cursor_launch_template() {
+  local rec case_dir home proj wt fakebin id out status sendlog
+  rec=$(make_spawn_case launch)
+  IFS='|' read -r case_dir home proj wt fakebin id <<EOF
+$rec
+EOF
+  # The verified launch string is what fm-spawn sends to tmux via send-keys.
+  # Point the fake tmux at a log so we can assert the exact cursor-agent command.
+  sendlog="$case_dir/sendkeys.log"
+  export FM_TEST_SENDLOG="$sendlog"
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+esac
+case "${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+  list-windows) exit 0 ;;
+  has-session|new-session|new-window|kill-window) exit 0 ;;
+  send-keys) printf '%s\n' "$*" >> "${FM_TEST_SENDLOG:-/dev/null}"; exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+  out=$(run_cursor_spawn "$home" "$proj" "$wt" "$fakebin" "$id")
+  status=$?
+  expect_code 0 "$status" "cursor spawn should succeed"
+  assert_contains "$out" "spawned $id harness=cursor" "cursor spawn did not report success"
+  assert_present "$sendlog" "tmux send-keys was not invoked by cursor spawn"
+  local sent
+  sent=$(cat "$sendlog")
+  assert_contains "$sent" 'cursor-agent --yolo' "launch_template did not emit 'cursor-agent --yolo'"
+  assert_not_contains "$sent" '--prompt' "cursor launch used --prompt instead of a positional prompt"
+  pass "cursor launch_template emits verified cursor-agent --yolo command"
+}
+
+# --- shared ~/.cursor/hooks.json merge: idempotent + preserves cmux -----------
+
+test_cursor_hook_merge_idempotent_and_preserves_cmux() {
+  local rec case_dir home proj wt fakebin id out hooks auth token target
+  rec=$(make_spawn_case hooks1)
+  IFS='|' read -r case_dir home proj wt fakebin id <<EOF
+$rec
+EOF
+  # Pre-seed the SHARED hooks.json with cmux's own entries (the realistic state).
+  hooks="$home/.cursor/hooks.json"
+  printf '%s\n' '{"hooks":{"afterAgentResponse":[{"hooks":[{"type":"command","command":"cmux-after.sh"}]}],"stop":[{"hooks":[{"type":"command","command":"cmux-stop.sh"}]}]},"version":1}' > "$hooks"
+  cmux_hash=$(jq -S . "$hooks" | shasum)
+
+  out=$(run_cursor_spawn "$home" "$proj" "$wt" "$fakebin" "$id")
+  expect_code 0 $? "cursor spawn with shared hooks.json should succeed"
+  token=$(sed -n 's/^token=//p' "$wt/.fm-cursor-turnend")
+  [ -n "$token" ] || fail "cursor pointer did not record a token (got empty)"
+  auth="$home/.cursor/fm-turn-end.d"
+  assert_present "$auth/$token" "cursor auth registry entry was not written"
+  assert_present "$auth/fm-turn-end.sh" "cursor guard script was not installed"
+
+  # cmux's afterAgentResponse entry must survive the merge untouched.
+  jq -e '.hooks.afterAgentResponse[0].hooks[0].command == "cmux-after.sh"' "$hooks" >/dev/null \
+    || fail "cursor merge clobbered cmux's afterAgentResponse entry"
+  # cmux's own stop entry must survive; firstmate's stop entry added alongside it.
+  jq -e '.hooks.stop | map(select(.hooks[0].command == "cmux-stop.sh")) | length == 1' "$hooks" >/dev/null \
+    || fail "cursor merge dropped cmux's stop entry"
+  fm_count=$(jq --arg cmd "$auth/fm-turn-end.sh" \
+    '.hooks.stop | map(select(any(.hooks[]?; (.command | test($cmd))))) | length' "$hooks")
+  [ "$fm_count" = "1" ] || fail "expected exactly one firstmate stop entry, got $fm_count"
+
+  # Re-run the SAME spawn a second time (simulating a respawn or a second task
+  # against the same shared hooks.json): must NOT duplicate the firstmate entry
+  # and must NOT touch cmux's entries.
+  out=$(run_cursor_spawn "$home" "$proj" "$wt" "$fakebin" "$id")
+  expect_code 0 $? "second cursor spawn should succeed"
+  fm_count2=$(jq --arg cmd "$home/.cursor/fm-turn-end.d/fm-turn-end.sh" \
+    '.hooks.stop | map(select(any(.hooks[]?; (.command | test($cmd))))) | length' "$hooks")
+  [ "$fm_count2" = "1" ] || fail "second cursor spawn duplicated the firstmate stop entry (got $fm_count2)"
+  jq -e '.hooks.afterAgentResponse[0].hooks[0].command == "cmux-after.sh"' "$hooks" >/dev/null \
+    || fail "second cursor spawn clobbered cmux's afterAgentResponse"
+
+  # The guard must fire the right target: this task's pointer -> its turn-ended,
+  # and must stay silent when no pointer is present (the cmux-session case).
+  target="$home/state/$id.turn-ended"
+  rm -f "$target"
+  CURSOR_WORKSPACE_ROOT="$wt" bash "$auth/fm-turn-end.sh"
+  assert_present "$target" "cursor guard did not touch the task turn-ended for a registered pointer"
+  # Silent when the pointer is absent (cmux-driven session).
+  rm -f "$target" "$wt/.fm-cursor-turnend"
+  CURSOR_WORKSPACE_ROOT="$wt" bash "$auth/fm-turn-end.sh"
+  assert_absent "$target" "cursor guard fired for a workspace with no firstmate pointer"
+  pass "cursor hooks.json merge is idempotent and preserves cmux entries"
+}
+
+test_fm_harness_detects_cursor_env_marker
+test_fm_harness_detects_cursor_process_name
+test_spawn_emits_cursor_launch_template
+test_cursor_hook_merge_idempotent_and_preserves_cmux


### PR DESCRIPTION
Adds `cursor` (cursor-agent) as a fully verified harness adapter.

This completes the work to let you run firstmate (primary + crew) on Cursor instead of Claude.

## Summary of changes
- Harness detection (`fm-harness.sh`, `fm-lock.sh`): `CURSOR_AGENT=1` + `cursor-agent` process name.
- Launch (`fm-spawn.sh`): `cursor-agent --yolo ...` (the autonomy flag), `--model` support. Effort is _not_ a separate flag — it is encoded in the model id (e.g. suffix `-high` or bracket form `id[effort=high]`). Requested effort is still recorded in meta.
- Turn-end signal: cursor fires a `stop` hook every turn boundary. We jq-merge a guarded firstmate command into the **shared** `~/.cursor/hooks.json` (additively and idempotently so cmux entries are untouched). Guard uses the same per-task token pointer pattern as grok (`.fm-cursor-turnend` in the worktree + registry under `~/.cursor/fm-turn-end.d/`).
- Busy detection (`fm-watch.sh`, `fm-tmux-lib.sh`): matches `ctrl+c to stop` on the composer line.
- Teardown (`fm-teardown.sh`): cleans per-task pointers and registry tokens. Deliberately leaves the shared hooks.json entry in place (it becomes a safe no-op without the pointer).
- Other: bootstrap verified list, dispatch profiles, secondmate harness support, and full documentation.
- Tests: dedicated `tests/fm-cursor-harness.test.sh` (env marker, process name via lock, launch template, safe hooks merge).

Verified against cursor-agent 2026.07.01-41b2de7.

## How to use after merge
- Run your firstmate session inside cursor-agent → `bin/fm-harness.sh` will report `cursor`.
- `config/crew-harness` (or leave as default) controls what crewmates use.
- Per-task override: `fm-spawn ... cursor` or `--harness cursor --model "..."`.
- `/no-mistakes` and other skills work via `/` (cursor discovers `.agents/skills/`).

See the harness-adapters skill and updated AGENTS.md for details.

Closes the cursor adapter request.
