### PR TITLE
fix(fm-brief): scaffold ship briefs under bash 3.2

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -171,54 +171,26 @@ read -r MODE _ <<EOF
 $("$FM_ROOT/bin/fm-project-mode.sh" "$REPO")
 EOF
 
+# Only the mode-specific Setup/Rule-1 text is prepared here. The Definition of
+# done is appended to the brief after the common body (see below) with a plain
+# `cat >> "$BRIEF" <<EOF`, NOT captured via `DOD=$(cat <<EOF ... EOF)`: bash 3.2
+# mis-parses a single quote inside a heredoc body nested in $(...) command
+# substitution (the no-mistakes DOD contains apostrophes), which aborts the
+# whole script. Writing the heredoc directly into the brief avoids that pattern
+# entirely while keeping any future apostrophe safe.
 case "$MODE" in
   direct-PR)
     SETUP2=""
     RULE1='1. Never push to the default branch (push only your `fm/'"$ID"'` branch). Never merge a PR.'
-    DOD=$(cat <<EOF
-# Definition of done
-This project ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
-The task is complete only when committed on your branch.
-When it is implemented and committed, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\` to the status file and stop.
-Do NOT run /no-mistakes. The captain reviews and merges the PR; firstmate relays it.
-EOF
-)
     ;;
   local-only)
     SETUP2=""
     RULE1="1. Never push to any remote and never open a PR. Work only on your \`fm/$ID\` branch; firstmate handles the merge into local \`main\`."
-    DOD=$(cat <<EOF
-# Definition of done
-This project ships **local-only**: no remote, no PR, no pipeline.
-The task is complete only when committed on your branch \`fm/$ID\`. Do NOT push, do NOT open a PR, do NOT merge.
-Keep your branch a clean fast-forward onto the current default branch - if \`main\` has advanced, rebase onto it so the eventual merge stays a fast-forward.
-When it is implemented and committed, append \`done: ready in branch fm/$ID\` to the status file and stop.
-Firstmate then reviews your branch diff, the captain approves, and firstmate merges it into local \`main\`.
-EOF
-)
     ;;
   *)  # no-mistakes (default)
     SETUP2="
 2. Run \`no-mistakes doctor\`; if it reports the repo is not initialized here, run \`no-mistakes init\`."
     RULE1='1. Never push to the default branch. Never merge a PR.'
-    DOD=$(cat <<EOF
-# Definition of done
-The task is complete only when committed on your branch.
-When you believe it is complete, append \`done: {summary}\` to the status file and stop.
-Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
-
-You drive no-mistakes by responding to its gates, not by implementing fixes.
-Follow no-mistakes' own guidance for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.
-Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.
-
-Two firstmate-specific rules layer on top of that guidance:
-- ask-user findings are not yours to answer: escalate to firstmate (rule 6) and stop.
-  When the decision comes back, feed it to the gate with \`no-mistakes axi respond\` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
-- Avoid \`--yes\`: the captain, not you, owns the ask-user decisions it would silently auto-resolve.
-
-After /no-mistakes reports CI green, append \`done: PR {url} checks green\` and stop. You are finished.
-EOF
-)
     ;;
 esac
 
@@ -257,6 +229,49 @@ If \`AGENTS.md\` or \`CLAUDE.md\` already exists, or if this task produced durab
 If this task produced durable project-intrinsic knowledge, record it in \`AGENTS.md\` as part of your change.
 Keep it proportionate: skip \`AGENTS.md\` edits for trivial tasks that produced no durable project knowledge.
 
-$DOD
 EOF
+
+# Append the mode-specific Definition of done directly into the brief. This
+# heredoc is NOT wrapped in $(...) command substitution, so an apostrophe in the
+# body (e.g. the no-mistakes text) is safe on bash 3.2 as well as modern bash.
+case "$MODE" in
+  direct-PR)
+    cat >> "$BRIEF" <<EOF
+# Definition of done
+This project ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
+The task is complete only when committed on your branch.
+When it is implemented and committed, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\` to the status file and stop.
+Do NOT run /no-mistakes. The captain reviews and merges the PR; firstmate relays it.
+EOF
+    ;;
+  local-only)
+    cat >> "$BRIEF" <<EOF
+# Definition of done
+This project ships **local-only**: no remote, no PR, no pipeline.
+The task is complete only when committed on your branch \`fm/$ID\`. Do NOT push, do NOT open a PR, do NOT merge.
+Keep your branch a clean fast-forward onto the current default branch - if \`main\` has advanced, rebase onto it so the eventual merge stays a fast-forward.
+When it is implemented and committed, append \`done: ready in branch fm/$ID\` to the status file and stop.
+Firstmate then reviews your branch diff, the captain approves, and firstmate merges it into local \`main\`.
+EOF
+    ;;
+  *)  # no-mistakes (default)
+    cat >> "$BRIEF" <<EOF
+# Definition of done
+The task is complete only when committed on your branch.
+When you believe it is complete, append \`done: {summary}\` to the status file and stop.
+Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
+
+You drive no-mistakes by responding to its gates, not by implementing fixes.
+Follow no-mistakes' own guidance for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.
+Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.
+
+Two firstmate-specific rules layer on top of that guidance:
+- ask-user findings are not yours to answer: escalate to firstmate (rule 6) and stop.
+  When the decision comes back, feed it to the gate with \`no-mistakes axi respond\` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
+- Avoid \`--yes\`: the captain, not you, owns the ask-user decisions it would silently auto-resolve.
+
+After /no-mistakes reports CI green, append \`done: PR {url} checks green\` and stop. You are finished.
+EOF
+    ;;
+esac
 echo "scaffolded: $BRIEF (ship, mode=$MODE; replace {TASK})"


### PR DESCRIPTION
## Problem

`bin/fm-brief.sh` fails to run under macOS's stock bash 3.2 (`/usr/bin/env bash` resolves to `/bin/bash`, GNU bash 3.2.57) whenever it scaffolds a ship brief. Because the failure is at **parse time**, the script cannot scaffold *any* ship brief on a stock macOS box:

```
$ /bin/bash -n bin/fm-brief.sh
bin/fm-brief.sh: line 211: unexpected EOF while looking for matching quote
bin/fm-brief.sh: line 263: syntax error: unexpected end of file
```

## Root cause

The ship-mode section built each mode's "Definition of done" with a heredoc wrapped in command substitution:

```sh
DOD=$(cat <<EOF
...
Follow no-mistakes' own guidance ...
... no-mistakes axi respond ...
EOF
)
```

The no-mistakes DOD body contains apostrophes (`no-mistakes'`). Bash 3.2 has a well-known parser bug where a single quote inside a heredoc body that is itself nested in `$(...)` command substitution is treated as an *opening* quote, so the parser runs to EOF looking for its match and aborts. Modern bash (5.x) parses it fine, which is why it was never caught. The scout path was unaffected because it uses a plain `cat > "$BRIEF" <<EOF` (no command substitution).

## Fix

Fix the structural pattern, not the wording (the apostrophes are intentional and future DOD/Setup bodies could gain more): drop the `DOD` variable and the command substitution, and append each mode's Definition of done directly into the brief with a plain `cat >> "$BRIEF" <<EOF` - the same non-nested heredoc form the scout path already uses. The pre-write `case` now only prepares the mode-specific Setup/Rule-1 text. Any future apostrophe in a DOD/Setup body is now safe.

The shebang is untouched (`#!/usr/bin/env bash`); no hard-coded bash path.

## Byte-for-byte identical output

The generated brief is unchanged from the previous intended output on modern bash. Command substitution stripped the heredoc's single trailing newline before `$DOD` expanded; the common body now ends at the "Project memory" blank line and each DOD is appended exactly where `$DOD` used to expand, reproducing the same join and the same single trailing newline. DOD body text diffs identical to `HEAD` for all three ship modes.

## Verification

Before (on macOS, `/bin/bash` = 3.2.57):

```
$ /bin/bash -n bin/fm-brief.sh
bin/fm-brief.sh: line 211: unexpected EOF while looking for matching quote
```

After:

```
$ /bin/bash -n bin/fm-brief.sh   # exits 0, no output
```

Generated real briefs under bash 3.2.57 for **no-mistakes**, **direct-PR**, **local-only**, and **scout**, plus the secondmate charter - all scaffold with no syntax error and correct content (apostrophes render intact). Confirmed the join point keeps a single blank-line separator and the file ends in exactly one trailing newline (no double newline).

## Scope

Tightly scoped to `fm-brief.sh`. `bin/fm-bootstrap.sh` has the same `$(cat <<EOF)` shape, but its heredoc bodies carry no lone apostrophes, so it parses cleanly under bash 3.2 (`/bin/bash -n bin/fm-bootstrap.sh` -> OK) and is left unchanged.
