### PR TITLE
feat: force code-graph intelligence on crewmates via codebase-memory-mcp

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -504,6 +504,16 @@ Token discipline: status files before panes; default peeks to 40 lines; never st
 The context-% shown in a peek is not actionable as crew health; ignore it and intervene only on real signals (`signal`, `stale`, `needs-decision`, `blocked`), looping or confusion in the pane, or a question the brief already answers.
 Silence is the correct state while a healthy background watcher is waiting.
 
+### Code intelligence (code-graph)
+
+Every crewmate gets graph-level code intelligence with zero manual steps, and it is forced through the search path so it works even when the agent uses plain `grep`.
+The engine is `codebase-memory-mcp` (tree-sitter AST graph, no API keys, no LLM pipeline), registered once at **user scope** so every worktree inherits the `mcp__codebase-memory-mcp__*` tools with no per-project write.
+A global, non-blocking PreToolUse hook (`~/.claude/hooks/cbm-graph-augment.js`, registered on `Grep` and `Bash`) intercepts each code search, queries the graph for the search token, and injects matching symbols and definition sites as reference `additionalContext` alongside the raw search output.
+The hook is structurally non-blocking: it exits 0 on every path, runs on a short timeout, degrades silently when the binary or index is unavailable, and never denies a tool (set `CBM_HOOK_OFF=1` to disable it).
+This replaces the retired graphify/`codegrep` approach, whose sin was blocking real work.
+Indexes live out-of-tree in `~/.cache/codebase-memory-mcp/`, so nothing is ever written into a project (rule #1 safe).
+The lifecycle wiring keeps it invisible: `fm-bootstrap.sh` enables `auto_index` and indexes each base clone; `fm-spawn.sh` warm-indexes each new worktree at its clean base; `fm-brief.sh` points crewmates at the graph tools (`get_architecture`, `trace_path`, `search_graph`); and `fm-review-diff.sh` surfaces `detect_changes` blast radius for a branch.
+
 ### Sub-supervisor (presence-gated via `/afk`)
 
 `bin/fm-supervise-daemon.sh` is the away-mode engine: it wraps `fm-watch.sh`, runs the watcher as a child, classifies each wake reason in bash, and **self-handles the routine majority without consuming a firstmate turn**.

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -61,8 +61,48 @@ install_cmd() {
     treehouse) echo "curl -fsSL https://kunchenguid.github.io/treehouse/install.sh | sh" ;;
     no-mistakes) echo "curl -fsSL https://raw.githubusercontent.com/kunchenguid/no-mistakes/main/docs/install.sh | sh" ;;
     gh-axi|chrome-devtools-axi|lavish-axi) echo "npm install -g $1 && $1 setup hooks" ;;
+    codebase-memory-mcp) echo "curl -fsSL https://raw.githubusercontent.com/DeusData/codebase-memory-mcp/main/install.sh | bash -s -- --skip-config" ;;
     *) return 1 ;;
   esac
+}
+
+# Resolve the codebase-memory-mcp binary without relying on PATH (it installs to
+# ~/.local/bin, which may be off firstmate's PATH). Echoes a path or nothing.
+cbm_bin() {
+  local c
+  c=$(command -v codebase-memory-mcp 2>/dev/null) && { echo "$c"; return 0; }
+  for c in "$HOME/.local/bin/codebase-memory-mcp" /usr/local/bin/codebase-memory-mcp /opt/homebrew/bin/codebase-memory-mcp; do
+    [ -x "$c" ] && { echo "$c"; return 0; }
+  done
+  return 1
+}
+
+# Ensure the code-graph engine is set up and each base clone is indexed. Every
+# step is best-effort and non-fatal — code intelligence must never block startup.
+cbm_setup() {
+  local bin
+  bin=$(cbm_bin) || return 0
+  # one-time: enable self-indexing (idempotent, quiet)
+  "$bin" config set auto_index true >/dev/null 2>&1 || true
+  [ -d "$PROJECTS" ] || return 0
+  local known clone abs
+  known=$("$bin" cli list_projects '{}' 2>/dev/null || echo '')
+  for clone in "$PROJECTS"/*/; do
+    [ -d "$clone" ] || continue
+    abs=$(cd "$clone" 2>/dev/null && pwd) || continue
+    # rule #1 defensive: keep any in-tree index artifact out of git (untracked exclude)
+    if [ -d "$clone/.git" ] || [ -f "$clone/.git" ]; then
+      local excl="$clone/.git/info/exclude"
+      if [ -w "$(dirname "$excl")" ] 2>/dev/null || [ ! -e "$excl" ]; then
+        grep -qxF '.codebase-memory/' "$excl" 2>/dev/null || echo '.codebase-memory/' >> "$excl" 2>/dev/null || true
+      fi
+    fi
+    # index once if this clone is not yet known (auto_index keeps it fresh after)
+    case "$known" in
+      *"\"$abs\""*) ;;
+      *) nohup "$bin" cli index_repository "{\"repo_path\":\"$abs\"}" >/dev/null 2>&1 & ;;
+    esac
+  done
 }
 
 TOOLS="tmux node gh treehouse no-mistakes gh-axi chrome-devtools-axi lavish-axi"
@@ -82,9 +122,11 @@ fi
 for t in $TOOLS; do
   command -v "$t" >/dev/null || echo "MISSING: $t (install: $(install_cmd "$t"))"
 done
+cbm_bin >/dev/null || echo "MISSING: codebase-memory-mcp (install: $(install_cmd codebase-memory-mcp))"
 gh auth status >/dev/null 2>&1 || echo "NEEDS_GH_AUTH"
 crew=
 [ -f "$CONFIG/crew-harness" ] && crew=$(tr -d '[:space:]' < "$CONFIG/crew-harness" || true)
 [ -n "$crew" ] && [ "$crew" != "default" ] && echo "CREW_HARNESS_OVERRIDE: $crew"
 fleet_sync
+cbm_setup
 exit 0

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -135,6 +135,10 @@ The report is the only thing that survives, so anything worth keeping must be in
 6. If a decision belongs to a human (product choices, destructive actions),
    append \`needs-decision: {summary of options}\` and stop. Firstmate will reply with the decision.
 
+# Code intelligence
+A code-graph index of this repo is available, and your \`grep\`/Grep searches are auto-augmented with graph context (matching symbols, definition sites, files) with no action on your part.
+For structural investigation prefer the graph tools over reading many files: \`mcp__codebase-memory-mcp__get_architecture\`, \`trace_path\` (callers/callees, depth 1-5), \`search_graph\`, and \`detect_changes\` (change blast-radius). They are degrade-safe; if unavailable, fall back to normal search.
+
 # Definition of done
 Write your findings to \`$DATA/$ID/report.md\`.
 The report must stand alone: what you did, what you found, the evidence (commands run, output, file:line references), and what you recommend.
@@ -217,6 +221,11 @@ $RULE1
 5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
 6. If a decision belongs to a human (product choices, destructive actions, ask-user findings),
    append \`needs-decision: {summary of options}\` and stop. Firstmate will reply with the decision.
+
+# Code intelligence
+A code-graph index of this repo is available, and your \`grep\`/Grep searches are auto-augmented with graph context (matching symbols, definition sites, files) with no action on your part.
+For structural questions prefer the graph tools over reading many files: \`mcp__codebase-memory-mcp__get_architecture\`, \`trace_path\` (callers/callees, depth 1-5), and \`search_graph\`.
+At the review stage, run the \`detect_changes\` tool on your branch diff to see affected symbols + blast radius + risk, and fold that into your review notes. The tooling is degrade-safe; if unavailable, proceed with normal search.
 
 # Project memory
 If \`AGENTS.md\` or \`CLAUDE.md\` already exists, or if this task produced durable project-intrinsic knowledge, run \`$FM_ROOT/bin/fm-ensure-agents-md.sh .\` in the worktree.

--- a/bin/fm-review-diff.sh
+++ b/bin/fm-review-diff.sh
@@ -61,6 +61,42 @@ default_branch() {
 
 DEFAULT=$(default_branch) || { echo "error: cannot determine default branch for $PROJ; expected origin/HEAD, main, or master" >&2; exit 1; }
 
+# Optional code-graph blast radius (codebase-memory-mcp detect_changes). The
+# worktree was warm-indexed at its clean base when the task was spawned, so
+# detect_changes surfaces the symbols changed on the branch since that baseline.
+# Fully degrade-safe: prints nothing if the binary, the index, or a delta is
+# absent. Never affects the git diff below.
+cbm_bin() {
+  local c
+  c=$(command -v codebase-memory-mcp 2>/dev/null) && { echo "$c"; return 0; }
+  for c in "$HOME/.local/bin/codebase-memory-mcp" /usr/local/bin/codebase-memory-mcp /opt/homebrew/bin/codebase-memory-mcp; do
+    [ -x "$c" ] && { echo "$c"; return 0; }
+  done
+  return 1
+}
+cbm_blast_radius() {
+  local bin proj_slug wt_abs
+  bin=$(cbm_bin) || return 0
+  wt_abs=$(cd "$WT" 2>/dev/null && pwd -P) || return 0
+  proj_slug=$("$bin" cli list_projects '{}' 2>/dev/null | node -e '
+    let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>{
+      try{const t=process.argv[1];const p=(JSON.parse(d).projects||[]).find(x=>x.root_path===t);process.stdout.write(p?p.name:"")}catch{ }
+    })' "$wt_abs" 2>/dev/null) || return 0
+  [ -n "$proj_slug" ] || return 0
+  "$bin" cli detect_changes "{\"project\":\"$proj_slug\"}" 2>/dev/null | node -e '
+    let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>{
+      try{
+        const j=JSON.parse(d);
+        if(!j||!j.changed_count)return;
+        const syms=(j.impacted_symbols||[]).filter(s=>s.label&&s.label!=="Module");
+        console.log("code-graph blast radius: "+j.changed_count+" changed file(s), "+syms.length+" impacted symbol(s)");
+        syms.slice(0,12).forEach(s=>console.log("  - "+s.name+" ("+s.label+") "+(s.file||"")));
+        if(syms.length>12)console.log("  ... +"+(syms.length-12)+" more");
+      }catch{ }
+    })' 2>/dev/null || true
+  return 0
+}
+
 BRANCH="fm/$ID"
 if ! git -C "$WT" rev-parse --verify --quiet "refs/heads/$BRANCH" >/dev/null; then
   BRANCH=$(git -C "$WT" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
@@ -87,6 +123,8 @@ if git -C "$WT" diff --quiet "$BASE...$BRANCH" --; then
 fi
 
 git -C "$WT" diff --stat "$BASE...$BRANCH" --
+BR=$(cbm_blast_radius) || true
+[ -n "$BR" ] && { echo; printf '%s\n' "$BR"; }
 if ! "$STAT_ONLY"; then
   echo
   git -C "$WT" diff "$BASE...$BRANCH" --

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -389,6 +389,22 @@ EOF
   esac
 fi
 
+# Warm the code-graph index for this worktree so the crewmate's first
+# graph-augmented search is fast (the global PreToolUse hook queries this index;
+# see AGENTS.md section 8). Best-effort and fully backgrounded — indexing must
+# never block or fail a spawn. auto_index also covers this incrementally.
+if [ "$KIND" != secondmate ] && [ -n "$WT" ]; then
+  CBM=$(command -v codebase-memory-mcp 2>/dev/null || true)
+  if [ -z "$CBM" ]; then
+    for c in "$HOME/.local/bin/codebase-memory-mcp" /usr/local/bin/codebase-memory-mcp /opt/homebrew/bin/codebase-memory-mcp; do
+      if [ -x "$c" ]; then CBM=$c; break; fi
+    done
+  fi
+  if [ -n "$CBM" ]; then
+    nohup "$CBM" cli index_repository "{\"repo_path\":\"$WT\"}" >/dev/null 2>&1 &
+  fi
+fi
+
 # Per-project delivery mode + yolo flag (bin/fm-project-mode.sh; AGENTS.md sections 6-7).
 # Recorded in meta so fm-teardown's safety check and the validate/merge stages can
 # branch on them. Mode governs ship tasks; a scout's deliverable is a report, not a


### PR DESCRIPTION
Adopts DeusData/codebase-memory-mcp + a non-blocking PreToolUse hook that injects code-graph context (call chains, blast radius, related files) into plain Grep/Bash-grep results, so crewmates get graph intelligence without remembering to call an MCP tool.

- Global hook `cbm-graph-augment` live (degrade-safe, exit 0 always); retires graphify-guard.js + codegrep.
- MCP installed user-scope; backend indexed (~25.5k nodes); `.codebase-memory/` gitignored.
- Wired into fm-bootstrap (index base clones), fm-spawn (warm-index worktrees), fm-brief (code-intel section), fm-review-diff (detect_changes blast radius on review).
- Phase 0 spike confirmed additionalContext is honored on Grep + Bash-grep (claude 2.1.198).

Plan: data/codebase-memory-mcp-plan.md