### PR TITLE
feat(stow): add operational memory capture

### DIFF
--- a/.agents/skills/stow/SKILL.md
+++ b/.agents/skills/stow/SKILL.md
@@ -31,7 +31,7 @@ The goal is a session that is safe to reset or destroy because everything durabl
      Route it through a normal ship task so a crewmate records it via `bin/fm-ensure-agents-md.sh` and commits it through that project's delivery pipeline, exactly as section 6 describes.
      If the fleet is live, delegate this to a crewmate rather than doing it inline.
    - Knowledge generalizable to every firstmate user: this repo's own `AGENTS.md` (or other shared, tracked material), shipped through the normal branch -> no-mistakes -> PR -> captain-merge pipeline for this repo (section 1), never hand-committed straight to `main`.
-   - Task-scoped notes: append to the relevant backlog item's notes with `tasks-axi update --append`, or hand-edit `data/backlog.md` per the active backend (section 10).
+   - Task-scoped notes: append to the relevant backlog item's notes with `tasks-axi update <id> --append "<note>"`, or hand-edit `data/backlog.md` per the active backend (section 10).
    - Undone next steps: file each as a queued backlog item (section 10), with `blocked-by` recorded if it genuinely depends on something else.
 
 4. **Curate, don't just append.**

--- a/.agents/skills/stow/SKILL.md
+++ b/.agents/skills/stow/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: stow
+description: Sweep the current session for uncaptured durable knowledge and file it to disk before a context reset. Use when the captain invokes /stow (e.g. "/stow", "stow what you've learned"), before a session reset or context compaction, or periodically to keep operational memory current.
+user-invocable: true
+---
+
+# stow
+
+Sweep this session for durable knowledge that only exists in conversation right now, and write it to the disk locations firstmate already reads on the next bootstrap.
+The goal is a session that is safe to reset or destroy because everything durable has already been captured.
+
+## What it does
+
+1. **Sweep the session for uncaptured durable knowledge.**
+   Read back over this conversation and look for:
+   - Operational learnings: fleet-local facts and gotchas discovered while operating firstmate (a script's sharp edge, a harness quirk, a recurring false alarm and its real cause).
+   - Captain preferences expressed in passing: a working-style or approval preference the captain stated conversationally rather than through `data/captain.md` directly.
+   - Project-intrinsic facts discovered: build, test, release, or architecture facts about a project that belong in that project's own `AGENTS.md`.
+   - Decisions made: a standing choice the captain made this session that should outlive it.
+   - Undone next steps: anything left open that has not yet been filed as backlog work.
+
+2. **Route each finding using AGENTS.md's knowledge-routing table.**
+   AGENTS.md (section 6, "Knowledge routing") is the single source of truth for where each kind of knowledge belongs.
+   Read that table and route each finding there instead of re-deriving the mapping here.
+
+3. **Write within firstmate's existing write boundaries.**
+   This skill does not grant any new write permission; it only prompts firstmate to use the boundaries that already exist (AGENTS.md section 1):
+   - Captain preferences and fleet-local operational facts: hand-write directly, to `data/captain.md` and `data/learnings.md` respectively.
+     `data/learnings.md` may not exist yet; create it on first learning, in the same dated, evidence-backed, curated style as `data/captain.md` - rewrite and prune stale or superseded entries rather than appending forever.
+   - Project-intrinsic knowledge: never hand-write a project's `AGENTS.md`.
+     Route it through a normal ship task so a crewmate records it via `bin/fm-ensure-agents-md.sh` and commits it through that project's delivery pipeline, exactly as section 6 describes.
+     If the fleet is live, delegate this to a crewmate rather than doing it inline.
+   - Knowledge generalizable to every firstmate user: this repo's own `AGENTS.md` (or other shared, tracked material), shipped through the normal branch -> no-mistakes -> PR -> captain-merge pipeline for this repo (section 1), never hand-committed straight to `main`.
+   - Task-scoped notes: append to the relevant backlog item's notes with `tasks-axi update --append`, or hand-edit `data/backlog.md` per the active backend (section 10).
+   - Undone next steps: file each as a queued backlog item (section 10), with `blocked-by` recorded if it genuinely depends on something else.
+
+4. **Curate, don't just append.**
+   When a finding overlaps or supersedes something already on disk, prefer rewriting or pruning the existing entry over piling on a new one.
+   Graduation moves are limited to exactly three: promote a learning to the shared `AGENTS.md` via PR, fold it into `data/captain.md`, or delete a stale entry.
+   Do not invent other graduation paths.
+
+5. **Report to the captain.**
+   Summarize, in plain outcome language (section 9): what was stowed and where, what was filed to the backlog, and whether the session is now safe to reset or destroy - i.e. whether every durable finding from this sweep now lives on disk rather than only in this conversation.
+   If something could not be captured yet (for example, project-intrinsic knowledge waiting on a crewmate to land it), say so explicitly rather than reporting the session fully safe.
+
+## Scope exclusion: no skill storage
+
+`/stow` must **never** store, create, or edit a skill as a destination for any finding.
+There is no "graduate this to a skill" move in this skill's routing.
+This is a deliberate, standing exclusion, not an oversight: repo skills cannot yet distinguish knowledge that is fleet-local to this captain's home from knowledge generalizable to every firstmate user, so writing learnings into skills would silently leak fleet-local material into shared, tracked material (or vice versa).
+That namespace problem is unresolved and deliberately deferred.
+Until it is resolved, route generalizable knowledge to the shared `AGENTS.md` (or other shared, tracked material) via the pipeline, and fleet-local knowledge to `data/`, never to a skill.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,7 @@ config/x-mode.env    generated X-mode watcher cadence; LOCAL, gitignored; source
 data/                personal fleet records; LOCAL, gitignored as a whole
   backlog.md         task queue, dependencies, history
   captain.md         captain's curated personal preferences and working style; LOCAL, gitignored, and canonical even if harness memory mirrors it
+  learnings.md       fleet-local operational facts and gotchas; LOCAL, gitignored; dated, evidence-backed, curated - rewrite and prune rather than append forever, the same contract as captain.md; created lazily, absent until this home has a learning to store
   projects.md        thin fleet navigation registry; firstmate-private, parsed by fm-project-mode.sh (section 6)
   secondmates.md      secondmate routing table; firstmate-private, maintained by fm-home-seed.sh (section 6)
   <id>/brief.md      per-task crewmate brief, or per-secondmate charter brief when kind=secondmate
@@ -163,6 +164,8 @@ Then read `data/secondmates.md` if present so intake can route work by registere
 Then read `data/captain.md` if present, to load this captain's curated preferences and working style.
 If it is absent, use this template's defaults with no special preferences.
 Treat any harness memory of these preferences as a recall cache only; `data/captain.md` is the canonical, harness-portable home.
+Then read `data/learnings.md` if present, to load fleet-local operational facts and gotchas this home has captured.
+If it is absent, there is nothing yet to load and that is fine.
 
 Do not dispatch any work until the tools that work needs are present and GitHub auth is good.
 Use `gh-axi` for all GitHub operations, `chrome-devtools-axi` for all browser operations, and `lavish-axi` when a decision or report is complex enough to deserve a rich review surface.
@@ -363,6 +366,19 @@ Firstmate's own not-yet-committed project knowledge lives in `data/` until a cre
 Create a project's `AGENTS.md` lazily on first need.
 The first ship task that touches a project lacking one and has durable project-intrinsic knowledge to record should run `bin/fm-ensure-agents-md.sh`, add that knowledge, and commit both through the normal project delivery pipeline.
 Do not eagerly backfill every project.
+
+### Knowledge routing
+
+Route each piece of durable knowledge to its most specific home:
+
+| Kind of knowledge | Home |
+| --- | --- |
+| Captain preferences and working style | `data/captain.md` |
+| Project-intrinsic knowledge | that project's own `AGENTS.md`, via normal crewmate delivery, never hand-written by firstmate |
+| Fleet-local operational facts and gotchas | `data/learnings.md` |
+| Knowledge generalizable to every firstmate user | the shared `AGENTS.md`, shipped via PR through the pipeline |
+| Task-scoped notes | backlog item notes (`tasks-axi update --append`, or hand-edit per the active backend) |
+| Investigation findings | scout reports at `data/<id>/report.md` |
 
 **Delivery mode (choose at add).** `<mode>` is how a finished change reaches `main`, picked per project when you add it and recorded in the registry line (`fm-project-mode.sh` parses it; `fm-spawn` records it into each task's meta):
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -302,7 +302,7 @@ Reconcile reality with your records before doing anything else:
 10. Handle drained wakes, then follow the section 8 watcher checklist; if `state/.afk` exists, the daemon owns the watcher.
 
 A firstmate restart must be a non-event.
-All truth lives in each task's backend live-task inventory (tmux by hard default, or herdr when selected or auto-detected), state files, data/backlog.md, data/secondmates.md, persistent secondmate homes, and treehouse; your conversation memory is a cache.
+All truth lives in each task's backend live-task inventory (tmux by hard default, or herdr when selected or auto-detected), state files, data/backlog.md, data/captain.md, data/learnings.md, data/secondmates.md, persistent secondmate homes, and treehouse; your conversation memory is a cache.
 
 ## 6. Project management
 
@@ -379,6 +379,9 @@ Route each piece of durable knowledge to its most specific home:
 | Knowledge generalizable to every firstmate user | the shared `AGENTS.md`, shipped via PR through the pipeline |
 | Task-scoped notes | backlog item notes (`tasks-axi update <id> --append "<note>"`, or hand-edit per the active backend) |
 | Investigation findings | scout reports at `data/<id>/report.md` |
+
+When the captain invokes `/stow`, load the `stow` skill.
+It sweeps the current session for uncaptured durable knowledge, routes findings with this table, files undone next steps to the backlog, and reports whether the session is safe to reset.
 
 **Delivery mode (choose at add).** `<mode>` is how a finished change reaches `main`, picked per project when you add it and recorded in the registry line (`fm-project-mode.sh` parses it; `fm-spawn` records it into each task's meta):
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -377,7 +377,7 @@ Route each piece of durable knowledge to its most specific home:
 | Project-intrinsic knowledge | that project's own `AGENTS.md`, via normal crewmate delivery, never hand-written by firstmate |
 | Fleet-local operational facts and gotchas | `data/learnings.md` |
 | Knowledge generalizable to every firstmate user | the shared `AGENTS.md`, shipped via PR through the pipeline |
-| Task-scoped notes | backlog item notes (`tasks-axi update --append`, or hand-edit per the active backend) |
+| Task-scoped notes | backlog item notes (`tasks-axi update <id> --append "<note>"`, or hand-edit per the active backend) |
 | Investigation findings | scout reports at `data/<id>/report.md` |
 
 **Delivery mode (choose at add).** `<mode>` is how a finished change reaches `main`, picked per project when you add it and recorded in the registry line (`fm-project-mode.sh` parses it; `fm-spawn` records it into each task's meta):

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Claude and grok use the slash form shown here; codex uses the same names with `$
 | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
 | `/afk`             | Enter away-mode supervision: the sub-supervisor self-handles routine wakes in bash and escalates only captain-relevant events as one batched digest, cutting supervision cost while you step away |
 | `/updatefirstmate` | Self-update the running firstmate and its secondmates to the latest from origin with fast-forward-only pulls, then re-read instructions and nudge secondmates |
+| `/stow`            | Sweep the session for uncaptured durable knowledge, route each finding to its disk home per AGENTS.md, file undone next steps to the backlog, and report what is now safe to reset |
 
 Agent-only reference skills live under `.agents/skills/` and are loaded by firstmate at the trigger points named in [`AGENTS.md`](AGENTS.md).
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -158,6 +158,12 @@ Durable project-intrinsic agent knowledge lives in each project's committed `AGE
 Ship briefs prompt crewmates to create or update those files through the normal delivery path; `data/projects.md` stays a thin private registry.
 The full ownership rule - what is project-intrinsic versus fleet-private, and how firstmate keeps the two apart without writing into project clones - is owned by firstmate's operating manual in [`AGENTS.md`](../AGENTS.md) (project memory ownership).
 
+## Operational memory routing
+
+`/stow` sweeps the current session for durable knowledge that only exists in conversation and routes each finding to the most specific disk home.
+Captain preferences go to `data/captain.md`, fleet-local operational facts and gotchas go to `data/learnings.md`, project-intrinsic knowledge goes through normal crewmate delivery into that project's committed `AGENTS.md`, and task-scoped notes or undone next steps go to the backlog.
+Generalizable firstmate knowledge goes to shared tracked docs through the normal PR pipeline; `/stow` deliberately never stores findings in skills.
+
 ## Local clones stay fresh
 
 Bootstrap and PR-based teardown refresh remote-backed project clones when the clone is safe to move.
@@ -175,8 +181,8 @@ The mechanics are owned by the `/updatefirstmate` skill and firstmate's operatin
 
 ## Restart-proof
 
-All state lives in each task's session-provider backend (tmux by hard default, herdr when selected or auto-detected), no-mistakes run records, status event logs, local markdown under `data/`, `data/secondmates.md`, and persistent secondmate homes.
-Kill the first mate session anytime; the next one reconciles and carries on.
+Fleet state lives in each task's session-provider backend (tmux by hard default, herdr when selected or auto-detected), no-mistakes run records, status event logs, local markdown under `data/` including `data/captain.md` and `data/learnings.md`, and persistent secondmate homes.
+Use `/stow` before an intentional reset when the conversation may hold durable knowledge that has not yet been written to disk; after that, the next firstmate session can reconcile and carry on.
 
 ## Development notes
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,6 +39,11 @@ It intentionally mirrors the behavior-test baseline in [`.github/workflows/ci.ym
 
 Personal preferences for one captain's fleet live locally in `data/captain.md`; it is gitignored and read after `data/projects.md` and optional `data/secondmates.md` during bootstrap.
 
+## Operational learnings (data/learnings.md)
+
+Fleet-local operational facts and gotchas live locally in `data/learnings.md`; it is gitignored and read right after `data/captain.md` during bootstrap.
+The file is created lazily on first learning and follows the same dated, evidence-backed, curated style as `data/captain.md`: rewrite or prune stale entries instead of appending forever.
+
 ## Secondmate routes (data/secondmates.md)
 
 Persistent secondmate routes live locally in `data/secondmates.md`.


### PR DESCRIPTION
## Intent

Ship the /stow operational-memory feature for firstmate, per a locked captain design (2026-07-02): (1) establish data/learnings.md as each firstmate home's operational-learnings file - fleet-local operational facts and gotchas, dated/evidence-backed/curated like data/captain.md, created lazily and never itself tracked in git since data/ is gitignored; (2) add a compact knowledge-routing table to AGENTS.md (captain prefs -> data/captain.md, project-intrinsic -> project's own AGENTS.md via crewmate delivery, fleet-local ops facts -> data/learnings.md, generalizable knowledge -> shared AGENTS.md via PR, task-scoped notes -> backlog item notes, investigation findings -> scout reports) plus a bootstrap read-if-present step for data/learnings.md right after the existing data/captain.md read, plus a Layout section line describing data/learnings.md; (3) create a new user-invocable /stow skill at .agents/skills/stow/SKILL.md (resolves via the existing .claude/skills -> .agents/skills symlink) that sweeps the session for uncaptured durable knowledge, routes each finding via the AGENTS.md table (referencing it rather than duplicating it), files undone next steps to the backlog, and reports what was stowed and whether the session is safe to reset. A firm, explicit scope exclusion (captain's decision): /stow must never store, create, or edit anything in skills - no 'graduate to a skill' move - because repo skills cannot yet distinguish fleet-local from all-firstmate-user scope; this exclusion is written into the skill text itself. Also added a terse one-row README table entry for /stow alongside the existing /afk and /updatefirstmate rows. These are locked design decisions to implement as specified, not to redesign.

## What Changed

- Added a `/stow` skill that sweeps for durable operational knowledge before reset, routes findings through the documented memory destinations, files undone next steps to backlog notes, and reports reset readiness.
- Documented `data/learnings.md` as the lazy, fleet-local operational learnings file and added bootstrap handling to read it when present.
- Updated user-facing docs with the `/stow` command entry and memory-routing guidance, including the explicit exclusion from writing repo skills.

## Risk Assessment

✅ Low: Captain, this is a documentation and skill-instruction change with consistent routing and no executable behavior changes.

## Testing

<code>The baseline full test command was already reported passing; I additionally ran the targeted bootstrap suite and a reviewer-visible end-to-end transcript that proves /stow is listed in README, discoverable via `.claude/skills -&gt; .agents/skills`, user-invocable in skill metadata, routed through AGENTS.md to gitignored `data/learnings.md`, and explicitly barred from storing findings in skills. The working tree was clean afterward.</code>

<details>
<summary>Evidence: stow end-to-end evidence transcript</summary>

```text
stow operational-memory end-to-end evidence
repo: /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KWJ9K4JDYQVSGRFJC3EX51TF
head: 23704f61e8ff

1. README exposes the user-invocable /stow command
PASS: README built-in skills table includes /stow
144:| `/stow`            | Sweep the session for uncaptured durable knowledge, route each finding to its disk home per AGENTS.md, file undone next steps to the backlog, and report what is now safe to reset |

2. Harness skill path resolves through .claude/skills -> .agents/skills
.claude/skills symlink: ../.agents/skills
.agents skill: /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KWJ9K4JDYQVSGRFJC3EX51TF/.agents/skills/stow/SKILL.md
.claude skill: /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KWJ9K4JDYQVSGRFJC3EX51TF/.agents/skills/stow/SKILL.md
PASS: /stow is discoverable through both skill roots

3. Skill metadata is user-invocable and describes /stow
---
name: stow
description: Sweep the current session for uncaptured durable knowledge and file it to disk before a context reset. Use when the captain invokes /stow (e.g. "/stow", "stow what you've learned"), before a session reset or context compaction, or periodically to keep operational memory current.
user-invocable: true
---
PASS: skill frontmatter name is stow
2:name: stow
PASS: skill is user-invocable
4:user-invocable: true
PASS: skill trigger mentions /stow
3:description: Sweep the current session for uncaptured durable knowledge and file it to disk before a context reset. Use when the captain invokes /stow (e.g. "/stow", "stow what you've learned"), before a session reset or context compaction, or periodically to keep operational memory current.

4. AGENTS.md records the operational-memory storage contract
PASS: layout documents data/learnings.md as local fleet memory
85:  learnings.md       fleet-local operational facts and gotchas; LOCAL, gitignored; dated, evidence-backed, curated - rewrite and prune rather than append forever, the same contract as captain.md; created lazily, absent until this home has a learning to store
PASS: bootstrap instructions read data/learnings.md after captain.md
167:Then read `data/learnings.md` if present, to load fleet-local operational facts and gotchas this home has captured.
PASS: knowledge routing sends fleet-local facts to data/learnings.md
378:| Fleet-local operational facts and gotchas | `data/learnings.md` |
PASS: knowledge routing covers scout reports
381:| Investigation findings | scout reports at `data/<id>/report.md` |

5. /stow preserves the no-skill-storage exclusion
PASS: skill forbids storing findings in skills
48:`/stow` must **never** store, create, or edit a skill as a destination for any finding.
PASS: skill forbids graduate-to-skill routing
49:There is no "graduate this to a skill" move in this skill's routing.

6. data/learnings.md would stay fleet-local and untracked
PASS: data directory is gitignored
3:data/
git check-ignore -v data/learnings.md => .gitignore:3:data/	data/learnings.md
PASS: data/learnings.md is not tracked by git

RESULT: /stow is documented, discoverable through the harness skill path, routes operational memory to data/learnings.md, and explicitly excludes skill storage.
```
</details>
<details>
<summary>Evidence: stow evidence verification script</summary>

```text
#!/usr/bin/env bash
set -euo pipefail
repo=${1:-$(pwd)}
cd "$repo"

say() { printf '%s\n' "$*"; }
require_fixed() {
  local needle=$1 file=$2 label=$3
  if grep -F -- "$needle" "$file" >/dev/null; then
    say "PASS: $label"
    grep -Fn -- "$needle" "$file" | head -n 1
  else
    say "FAIL: $label"
    say "missing: $needle"
    exit 1
  fi
}

say "stow operational-memory end-to-end evidence"
say "repo: $repo"
say "head: $(git rev-parse --short=12 HEAD)"
say ""

say "1. README exposes the user-invocable /stow command"
require_fixed '| `/stow`' README.md 'README built-in skills table includes /stow'
say ""

say "2. Harness skill path resolves through .claude/skills -> .agents/skills"
say ".claude/skills symlink: $(readlink .claude/skills)"
agent_skill=$(realpath .agents/skills/stow/SKILL.md)
claude_skill=$(realpath .claude/skills/stow/SKILL.md)
say ".agents skill: $agent_skill"
say ".claude skill: $claude_skill"
[ "$agent_skill" = "$claude_skill" ] || { say 'FAIL: symlink does not resolve to the stow skill'; exit 1; }
say 'PASS: /stow is discoverable through both skill roots'
say ""

say "3. Skill metadata is user-invocable and describes /stow"
awk 'NR==1{inside=0} /^---$/{inside=!inside; print; next} NR>1 && inside{print}' .agents/skills/stow/SKILL.md
require_fixed 'name: stow' .agents/skills/stow/SKILL.md 'skill frontmatter name is stow'
require_fixed 'user-invocable: true' .agents/skills/stow/SKILL.md 'skill is user-invocable'
require_fixed 'Use when the captain invokes /stow' .agents/skills/stow/SKILL.md 'skill trigger mentions /stow'
say ""

say "4. AGENTS.md records the operational-memory storage contract"
require_fixed 'learnings.md       fleet-local operational facts and gotchas; LOCAL, gitignored' AGENTS.md 'layout documents data/learnings.md as local fleet memory'
require_fixed 'Then read `data/learnings.md` if present' AGENTS.md 'bootstrap instructions read data/learnings.md after captain.md'
require_fixed '| Fleet-local operational facts and gotchas | `data/learnings.md` |' AGENTS.md 'knowledge routing sends fleet-local facts to data/learnings.md'
require_fixed '| Investigation findings | scout reports at `data/<id>/report.md` |' AGENTS.md 'knowledge routing covers scout reports'
say ""

say "5. /stow preserves the no-skill-storage exclusion"
require_fixed '/stow` must **never** store, create, or edit a skill as a destination for any finding.' .agents/skills/stow/SKILL.md 'skill forbids storing findings in skills'
require_fixed 'There is no "graduate this to a skill" move' .agents/skills/stow/SKILL.md 'skill forbids graduate-to-skill routing'
say ""

say "6. data/learnings.md would stay fleet-local and untracked"
require_fixed 'data/' .gitignore 'data directory is gitignored'
check_ignore=$(git check-ignore -v data/learnings.md)
say "git check-ignore -v data/learnings.md => $check_ignore"
tracked=$(git ls-files data/learnings.md)
[ -z "$tracked" ] || { say "FAIL: data/learnings.md is tracked as: $tracked"; exit 1; }
say 'PASS: data/learnings.md is not tracked by git'
say ""

say 'RESULT: /stow is documented, discoverable through the harness skill path, routes operational memory to data/learnings.md, and explicitly excludes skill storage.'
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `.agents/skills/stow/SKILL.md:34` - The task-note append command is incomplete: section 10 documents the required form as `tasks-axi update &lt;id&gt; --append &#34;&lt;note&gt;&#34;`, but `/stow` tells agents to run `tasks-axi update --append`. Because this skill is meant to persist task-scoped notes during reset prep, following the text literally can fail to write the note; include the `&lt;id&gt;` and note argument here and in the AGENTS.md routing table copy.

🔧 Fix: Fix stow backlog note command
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- <code>Baseline already provided as passing: `command -v tmux &gt;/dev/null || { echo &#34;tmux is required for e2e tests&#34; &gt;&amp;2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo &#34;== $t ==&#34;; bash &#34;$t&#34; || rc=1; done; exit &#34;$rc&#34;`</code>
- <code>Inspected target diff: `git diff --name-status 30a89bc1102fbe6610f27aa62c44885ac7dbfdc2..23704f61e8fffe2d5c2c1d93b9d45c86eeb00acd` and `git diff 30a89bc1102fbe6610f27aa62c44885ac7dbfdc2..23704f61e8fffe2d5c2c1d93b9d45c86eeb00acd -- AGENTS.md README.md .agents/skills/stow/SKILL.md`</code>
- <code>Ran targeted existing regression coverage: `bash tests/fm-bootstrap.test.sh`</code>
- <code>Created and ran evidence check: `/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KWJ9K4JDYQVSGRFJC3EX51TF/verify_stow_e2e.sh &#34;$PWD&#34; | tee /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KWJ9K4JDYQVSGRFJC3EX51TF/stow_end_to_end_transcript.txt`</code>
- <code>Checked cleanup state: `git status --short --untracked-files=all`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
