### PR TITLE
feat: verify devin CLI as a harness adapter

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harness-adapters
-description: Agent-only reference for firstmate harness operations. Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter. Contains verified facts for claude, codex, opencode, pi, and grok.
+description: Agent-only reference for firstmate harness operations. Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter. Contains verified facts for claude, codex, opencode, pi, grok, and devin.
 user-invocable: false
 ---
 
@@ -66,6 +66,7 @@ Natural language is acceptable if uncertain.
 
 - claude: `/<skill>`, for example `/no-mistakes`.
 - codex: `$<skill>`, for example `$no-mistakes`; `/<skill>` is claude-only and codex rejects it as "Unrecognized command".
+- devin: `/<skill>`, for example `/no-mistakes` (same form as claude).
 - opencode: no separate verified skill invocation beyond normal slash-command behavior; use natural language if the exact skill command is uncertain.
 - pi: no separate verified skill invocation beyond normal command behavior; use natural language if the exact skill command is uncertain.
 - grok: `/<skill>`, for example `/no-mistakes` (same form as claude). Verified end to end: grok discovers the user-level `no-mistakes` skill, `/no-mistakes` invokes it, and grok drives a real `no-mistakes axi run`. Like codex's `$`/`/` popups, typing `/<skill>` opens grok's slash-autocomplete, so a too-fast Enter selects the popup entry instead of sending; `fm_tmux_submit_core`'s retried Enter (used by `fm-send`) lands it.
@@ -153,11 +154,11 @@ Launch with a positional prompt: `grok --always-approve "$(cat <brief>)"`.
 
 | Fact | Value |
 |---|---|
-| Busy-pane signature | `Ctrl+c:cancel` (the mid-turn cancel hint in grok's keybind bar, shown iff a turn is running; the spinner line is a braille glyph + `<status>… N.Ns` + `[stop]`, e.g. `⠹ Thinking… 1.1s … [stop]`). Idle keybind bar shows only `Shift+Tab:mode │ Ctrl+.:shortcuts`. The ASCII `Ctrl+c:cancel` is the busy regex (avoids locale fragility of matching braille). |
+| Busy-pane signature | `Ctrl+c:cancel` (the mid-turn cancel hint in grok's keybind bar, shown iff a turn is running; the spinner line is a braille glyph + `<status>... N.Ns` + `[stop]`, e.g. `⠹ Thinking... 1.1s ... [stop]`). Idle keybind bar shows only `Shift+Tab:mode | Ctrl+.:shortcuts`. The ASCII `Ctrl+c:cancel` is the busy regex (avoids locale fragility of matching braille). |
 | Exit command | `Ctrl+Q` double-press within 1000ms (it is a confirmed destructive action). Prints `Resume this session with: grok --resume <session-id>`. `Ctrl+D` is the quit key in VS Code family terminals. NOT `/exit` and NOT `Ctrl+C`. |
 | Interrupt | single `Ctrl+C` (cancels the current turn; the footer shows `Ctrl+c:cancel` mid-turn). `Esc` only moves focus to the scrollback, it does NOT interrupt. |
 | Skill invocation | `/<skill>` (e.g. `/no-mistakes`), same as claude. Opens a slash-autocomplete popup, so a too-fast Enter selects the popup entry instead of sending - `fm-send`'s retried Enter lands it. |
-| Autonomy | `--always-approve` (footer shows `· always-approve`); auto-approves every tool execution, verified to run fully unattended. `--permission-mode bypassPermissions` is the stronger equivalent. |
+| Autonomy | `--always-approve` (footer shows `. always-approve`); auto-approves every tool execution, verified to run fully unattended. `--permission-mode bypassPermissions` is the stronger equivalent. |
 | Env marker | `GROK_AGENT=1`, set for child/tool processes. grok does NOT set `CLAUDECODE` despite Claude compatibility, so the marker is unambiguous. |
 | Resume | `grok --resume <session-id>` (id printed on exit) or `grok -c` / `--continue` (most recent for the cwd); `--fork-session` branches a new session id. |
 
@@ -177,3 +178,26 @@ The hook reads `$GROK_WORKSPACE_ROOT`, which is always set for hooks and equals 
 This keeps the hook outside the worktree, needs no trust grant, and writes only firstmate-owned files.
 `fm-teardown` removes the worktree pointer before returning a pooled worktree.
 Secondmate spawns skip the pointer (idle panes are healthy, no stale-pane detection for them).
+
+## devin (VERIFIED 2026-07-02, devin CLI v2026.8.18)
+
+| Fact | Value |
+|---|---|
+| Busy-pane signature | `esc to interrupt` (shown as `Yapping . Ns (esc to interrupt)`) |
+| Exit command | `/exit` (alias `/quit`; plain `exit` or `quit` also work) |
+| Interrupt | single Escape (same as claude) |
+| Skill invocation | `/<skill>` (e.g. `/no-mistakes`), same form as claude |
+
+No trust dialog on first run.
+Devin reads Claude Code-compatible hooks from `.devin/hooks.v1.json`, where the hooks object IS the entire file (no `"hooks"` wrapper key, unlike settings files).
+The `Stop` event fires at every turn boundary, which is the signal the watcher needs.
+`fm-spawn.sh` writes this hook file into the worktree and excludes it from git.
+
+Devin renders its composer placeholder text ("Ask Devin to build features, fix bugs, or work on your code" when idle, "Guide Devin while it works" when busy) using a dark 24-bit RGB color (`ESC[38;2;124;124;124m`), NOT the SGR 2 dim/faint attribute that claude uses for its ghost text.
+The dim-aware ghost stripper in `fm-tmux-lib.sh` only drops SGR 2 runs, so it cannot catch devin's placeholder.
+`fm-tmux-lib.sh` includes these placeholder patterns in `FM_TMUX_COMPOSER_IDLE_RE_DEFAULT` as the targeted backstop, so a devin pane with only placeholder text reads as an empty composer, not pending input.
+
+Resume after exit with `devin --resume <session-id>` or `devin --continue` (most recent session).
+The launch command uses `--prompt-file <brief>` (non-interactive initial prompt) with `--permission-mode dangerous` (auto-approve all tools, the devin equivalent of claude's `--dangerously-skip-permissions`).
+
+Devin has no known env marker for harness detection; `fm-harness.sh` detects it via process ancestry (command name contains `devin`).

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Detect the agent harness this process tree runs on.
-# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|grok|unknown
+# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|grok|devin|unknown
 #        fm-harness.sh crew             print the effective CREWMATE harness
 #                                        (config/crew-harness; "default" resolves to own)
 #        fm-harness.sh secondmate       print the harness the PRIMARY uses to launch
@@ -36,14 +36,18 @@ detect_own() {
   # is unambiguous when firstmate runs natively on grok.
   [ "${GROK_AGENT:-}" = "1" ] && { echo grok; return; }
   # Layer 2: walk the parent chain and match the command name.
+  # Use ${comm##*/} instead of basename(1): comm may start with a dash
+  # (e.g. "-zsh") which basename misreads as a flag on macOS (incident
+  # devin-adapter-verify). Parameter expansion is dash-safe and locale-free.
   local pid=$$ comm args
   for _ in 1 2 3 4 5 6 7 8; do
     comm=$(ps -o comm= -p "$pid" 2>/dev/null) || break
-    case "$(basename "$comm")" in
+    case "${comm##*/}" in
       *claude*) echo claude; return ;;
       *codex*) echo codex; return ;;
       *opencode*) echo opencode; return ;;
       *grok*) echo grok; return ;;
+      *devin*) echo devin; return ;;
       pi) echo pi; return ;;
       node*|python*)
         # Bare interpreter: match the harness name in its script path.
@@ -53,6 +57,7 @@ detect_own() {
           *codex*) echo codex; return ;;
           *opencode*) echo opencode; return ;;
           *grok*) echo grok; return ;;
+          *devin*) echo devin; return ;;
           *" pi "*|*/pi) echo pi; return ;;
         esac ;;
     esac

--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -15,14 +15,15 @@ LOCK="$STATE/.lock"
 mkdir -p "$STATE"
 
 # Known harness command names; extend when a new adapter is verified.
-HARNESS_RE='claude|codex|opencode|grok|^pi$'
+HARNESS_RE='claude|codex|opencode|grok|^pi$|devin'
 
 harness_pid() {
   local pid=$$ comm args
   for _ in 1 2 3 4 5 6 7 8; do
     comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
     args=$(ps -o args= -p "$pid" 2>/dev/null)
-    if printf '%s' "$(basename "$comm")" | grep -qE "$HARNESS_RE"; then
+    # ${comm##*/} is dash-safe (basename(1) misreads a comm like "-zsh" as a flag).
+    if printf '%s' "${comm##*/}" | grep -qE "$HARNESS_RE"; then
       echo "$pid"; return 0
     fi
     # Bare interpreter (e.g. node): match the harness name in its script path.
@@ -39,7 +40,7 @@ holder_alive() {  # true if $1 is a live process that looks like a harness
   local pid=$1 comm
   kill -0 "$pid" 2>/dev/null || return 1
   comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
-  printf '%s' "$(basename "$comm") $(ps -o args= -p "$pid" 2>/dev/null)" | grep -qE "$HARNESS_RE"
+  printf '%s' "${comm##*/} $(ps -o args= -p "$pid" 2>/dev/null)" | grep -qE "$HARNESS_RE"
 }
 
 if [ "${1:-}" = "status" ]; then

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -23,7 +23,7 @@
 #   profile consultation. A --secondmate spawn is exempt and resolves the SECONDMATE
 #   harness (config/secondmate-harness -> config/crew-harness -> own), so the
 #   secondmate-vs-crewmate split is DURABLE across every respawn (recovery,
-#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|grok)
+#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|grok|devin)
 #   overrides it for this spawn (either kind). A non-flag string containing
 #   whitespace is treated as a RAW launch command - the escape hatch for verifying
 #   new adapters.
@@ -194,7 +194,7 @@ FIRSTMATE_HOME=
 
 if [ "$KIND" = secondmate ]; then
   case "${POS[1]:-}" in
-    ''|claude|codex|opencode|pi|grok)
+    ''|claude|codex|opencode|pi|grok|devin)
       ARG3=${POS[1]:-}
       ;;
     *' '*)
@@ -255,6 +255,13 @@ launch_template() {
     # launch command - it is a Stop-event hook installed below (global hook +
     # per-task pointer), so the template is identical for ship/scout/secondmate.
     grok) printf '%s' 'grok --always-approve __MODELFLAG____EFFORTFLAG__"$(cat __BRIEF__)"' ;;
+    # devin: --prompt-file loads the brief non-interactively as the initial
+    # prompt; --permission-mode dangerous auto-approves every tool (the devin
+    # equivalent of claude's --dangerously-skip-permissions). The turn-end
+    # signal rides a Stop hook in .devin/hooks.v1.json (Claude Code hook format,
+    # which devin reads natively), wired below - not via the launch command, so
+    # the same template serves ship, scout, and secondmate spawns.
+    devin) printf '%s' 'devin --prompt-file __BRIEF__ --permission-mode dangerous' ;;
     *) return 1 ;;
   esac
 }
@@ -757,6 +764,17 @@ EOF
       printf '{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"%s"}]}]}}\n' "$hook_command" > "$GROK_HOOKS_DIR/fm-turn-end.json"
       printf 'token=%s\n' "${auth_file##*/}" > "$WT/.fm-grok-turnend"
       exclude_path '.fm-grok-turnend'
+      ;;
+    devin*)
+      # devin reads Claude Code-compatible hooks from .devin/hooks.v1.json, where
+      # the hooks object IS the entire file (no "hooks" wrapper key, unlike
+      # settings files). The Stop event fires at every turn boundary - exactly
+      # the signal the watcher needs to surface an idle crewmate.
+      mkdir -p "$WT/.devin"
+      cat > "$WT/.devin/hooks.v1.json" <<EOF
+{"Stop":[{"hooks":[{"type":"command","command":"touch '$TURNEND'"}]}]}
+EOF
+      exclude_path '.devin/hooks.v1.json'
       ;;
   esac
 fi

--- a/bin/fm-tmux-lib.sh
+++ b/bin/fm-tmux-lib.sh
@@ -39,6 +39,13 @@
 # (grok's mid-turn cancel hint, shown iff a turn is running - verified grok 0.2.73).
 FM_TMUX_BUSY_REGEX_DEFAULT='esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel'
 
+# Composer placeholder text per harness (idle composer). claude's ghost text
+# uses SGR 2 (dim/faint) and is caught by fm_tmux_strip_ghost. devin renders its
+# placeholder with a dark RGB color (ESC[38;2;124;124;124m), NOT SGR 2, so the
+# dim-aware stripper alone cannot catch it; these literal patterns are the
+# targeted backstop. Extend when a new adapter's placeholder escapes SGR 2.
+FM_TMUX_COMPOSER_IDLE_RE_DEFAULT='Ask Devin to|Guide Devin while'
+
 # fm_tmux_strip_ghost: remove dim/faint (ANSI SGR 2) styled runs from one captured
 # composer line, then drop any remaining escape sequences, leaving only the plain,
 # normal-intensity text, the text a human actually typed. Dim/faint runs are
@@ -133,8 +140,9 @@ fm_tmux_composer_state() {  # <target> -> empty|pending|unknown
   stripped="${stripped%"${stripped##*[![:space:]]}"}"
   # Nothing left inside the box = empty composer.
   [ -n "$stripped" ] || { printf 'empty'; return 0; }
-  if [ -n "${FM_COMPOSER_IDLE_RE:-}" ] \
-     && printf '%s' "$stripped" | grep -qiE "$FM_COMPOSER_IDLE_RE"; then
+  # Known harness placeholder text (e.g. devin's dark-RGB placeholder that
+  # escapes SGR 2 dim/faint) or a captain-supplied override = empty composer.
+  if printf '%s' "$stripped" | grep -qiE "${FM_COMPOSER_IDLE_RE:-$FM_TMUX_COMPOSER_IDLE_RE_DEFAULT}"; then
     printf 'empty'; return 0
   fi
   # Just a bare prompt glyph = empty composer (idle).


### PR DESCRIPTION
## Summary

- Add devin CLI (v2026.8.18) as a firstmate harness adapter, empirically verified via a supervised scout task
- All supervision primitives work: detection, locking, spawning, turn-end signaling, busy detection, composer idle detection, interrupt, exit, and skill invocation

## Changes

- **fm-harness.sh**: detect devin via process ancestry; fix `basename` dash bug (`comm` may start with `-`, e.g. `-zsh`) by using `${comm##*/}`
- **fm-lock.sh**: add devin to `HARNESS_RE`; same `basename` fix
- **fm-spawn.sh**: devin launch template (`--prompt-file` + `--permission-mode dangerous`) and `.devin/hooks.v1.json` Stop hook for turn-end signaling
- **fm-tmux-lib.sh**: `FM_TMUX_COMPOSER_IDLE_RE_DEFAULT` with devin placeholder patterns (devin uses RGB color `ESC[38;2;124;124;124m`, not SGR 2 dim, for placeholder text)
- **harness-adapters skill**: verified devin knowledge section

## Key findings

Devin renders its composer placeholder text ("Ask Devin to build features...") using a dark 24-bit RGB color, not the SGR 2 dim/faint attribute that claude uses. The dim-aware ghost stripper in `fm-tmux-lib.sh` only drops SGR 2 runs, so it cannot catch devin's placeholder. The new `FM_TMUX_COMPOSER_IDLE_RE_DEFAULT` provides the targeted backstop.

Devin reads Claude Code-compatible hooks from `.devin/hooks.v1.json`, where the hooks object IS the entire file (no `"hooks"` wrapper key). The `Stop` event fires at every turn boundary.

#### Test plan

- [x] `bash tests/fm-composer-ghost.test.sh` - all 9 assertions pass
- [x] Full test suite (13 test files) - all pass
- [x] Empirical verification: spawned scout task `devin-verify-4q`, confirmed turn-end hook fires, busy detection works, composer idle detection works, worktree isolation guard passes
- [x] `bash -n` syntax check on all modified scripts