### PR TITLE
fix(tests): protect herdr smoke cleanup from default sessions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,7 +90,8 @@ tests/fm-crew-state.test.sh               # fm-crew-state.sh current-state recon
 tests/fm-backend.test.sh                  # runtime-backend abstraction: fm-backend.sh selection/meta/dispatch helpers, and old-vs-new fake-tool command-log conformance for fm-send/fm-peek/fm-spawn/fm-teardown
 tests/fm-backend-tmux-smoke.test.sh       # real (private-socket) tmux smoke test for the tmux adapter: create/duplicate-refuse, send text + Enter, send literal + key, bounded capture, live-window resolve, kill
 tests/fm-backend-herdr.test.sh            # fake herdr CLI unit tests for the experimental herdr adapter, including version/tool gates, target parsing, send/capture, native busy state, and verified CLI bug workarounds
-tests/fm-backend-herdr-smoke.test.sh      # real herdr smoke test, skipped when herdr or jq is unavailable, using an isolated throwaway HERDR_SESSION
+tests/fm-backend-herdr-smoke.test.sh      # real herdr adapter smoke test, skipped when herdr or jq is unavailable, using an isolated throwaway HERDR_SESSION and guarded session cleanup
+tests/fm-backend-autodetect-smoke.test.sh # real herdr auto-detection smoke test, skipped when herdr, jq, or treehouse is unavailable, using the same guarded session cleanup
 [ "$(readlink CLAUDE.md)" = "AGENTS.md" ]
 [ "$(readlink .claude/skills)" = "../.agents/skills" ]
 tmp=$(mktemp -d) && printf 'done: smoke\n' > "$tmp/smoke.status" && FM_STATE_OVERRIDE="$tmp" FM_SIGNAL_GRACE=1 FM_POLL=1 FM_HEARTBEAT=999999 bin/fm-watch-arm.sh  # watcher re-arm smoke test (prints arm status, then an actionable signal)

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -62,10 +62,12 @@ fm_backend_herdr_version_check() {
   return 0
 }
 
-# fm_backend_herdr_session: resolve which named herdr session this spawn/op
-# uses. HERDR_SESSION mirrors tmux's $TMUX ambient-selection: an operator (or
-# firstmate's own isolated test harness) sets it explicitly; absent means
-# herdr's own "default" session.
+# fm_backend_herdr_session: resolve which named herdr session this normal
+# spawn/op uses. HERDR_SESSION mirrors tmux's $TMUX ambient-selection for
+# adapter workspace/tab/pane operations: an operator (or firstmate's own
+# isolated test harness) sets it explicitly; absent means herdr's own
+# "default" session. Do not use HERDR_SESSION alone for destructive test
+# cleanup; tests/herdr-test-safety.sh documents and guards that path.
 fm_backend_herdr_session() {
   printf '%s' "${HERDR_SESSION:-default}"
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,6 +27,8 @@ Any value other than `tmux` or `herdr` is rejected until another adapter is impl
 A herdr spawn additionally version-gates against the installed `herdr` binary's protocol and requires `jq`, refusing loudly on an incompatible or missing installation.
 Task meta records `backend=` only for a non-default backend; an absent `backend=` means `tmux`, preserving existing default-path meta files.
 A herdr task additionally records `herdr_session=`, `herdr_workspace_id=`, `herdr_tab_id=`, and `herdr_pane_id=`.
+For normal herdr operations, `HERDR_SESSION` selects the named session, but destructive test cleanup must not rely on `HERDR_SESSION` alone.
+Use the explicit guarded cleanup path described in [`docs/herdr-backend.md`](herdr-backend.md) instead of `herdr server stop`.
 The `config/backend` file is not inherited by secondmate homes.
 
 ## Gate defaults (.no-mistakes.yaml)
@@ -176,7 +178,7 @@ FM_DATA_OVERRIDE=        # alternate data dir, mainly for tests
 FM_PROJECTS_OVERRIDE=    # alternate projects dir, mainly for tests
 FM_CONFIG_OVERRIDE=      # alternate config dir, mainly for tests
 FM_BACKEND=             # optional runtime session-provider backend override for new spawns; tmux (reference) or herdr (experimental)
-HERDR_SESSION=default  # herdr-only: the named herdr session a herdr-backend spawn/op uses (docs/herdr-backend.md)
+HERDR_SESSION=default  # herdr-only: named session for normal backend ops; not enough for destructive cleanup (docs/herdr-backend.md)
 FM_POLL=15              # seconds between watcher poll cycles
 FM_HEARTBEAT=600        # base seconds between heartbeat scans; no-change heartbeats are absorbed while idle
 FM_HEARTBEAT_MAX=7200   # heartbeat backoff cap

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -5,7 +5,8 @@ It is the herdr equivalent of the tmux facts recorded in the `harness-adapters` 
 
 Herdr is [an agent-native terminal multiplexer](https://herdr.dev) with a socket API, CLI wrappers, and native per-pane agent-state detection.
 Verified against the real installed binary: herdr 0.7.1, protocol 14, macOS aarch64.
-All verification testing used isolated `HERDR_SESSION` names, stopped and deleted afterward; the captain's own default herdr session was never touched.
+Current real-herdr verification uses isolated `HERDR_SESSION` names plus the guarded teardown helper in `tests/herdr-test-safety.sh`.
+A 2026-07-02 cleanup bug proved that `HERDR_SESSION` alone is not a safe way to target destructive session cleanup; see "Session targeting: the --session flag, not HERDR_SESSION alone" below.
 
 ## Status: experimental
 
@@ -56,7 +57,7 @@ Herdr tasks additionally record:
 | Operation | Verified herdr call | What was verified |
 |---|---|---|
 | Version/protocol gate | `herdr status --json` -> `.client.protocol` | Session-independent; `.server.*` fields ARE session-dependent. |
-| Headless server start | `HERDR_SESSION=<name> herdr server` (backgrounded) | A bare socket call does NOT auto-start the server; the adapter always starts-then-polls before any workspace/tab/pane call. |
+| Headless server start | `HERDR_SESSION=<name> herdr server` (backgrounded) | A bare socket call does NOT auto-start the server; the adapter always starts-then-polls before any workspace/tab/pane call. This fact is for start only, not cleanup. |
 | Duplicate task check | `herdr tab list --workspace <id>`, match by `.label` | Herdr does NOT enforce tab-label uniqueness itself; two tabs can share a label. The adapter's own duplicate check is required. |
 | Send literal (unsubmitted) | `herdr pane send-text <pane> <text>` | Does NOT auto-submit, contrary to the original design addendum's guess. Verified directly: a unique marker sent this way sits unexecuted in the composer until a separate Enter. Behaves exactly like tmux's `send-keys -l`. |
 | Send + submit atomically | `herdr pane run <pane> <command>` | Runs and submits a command in one call; used for the two fixed spawn-time commands (`treehouse get`, the `GOTMPDIR` export) exactly where tmux used one `send-keys ... Enter` call. |
@@ -65,6 +66,22 @@ Herdr tasks additionally record:
 | Busy state | `herdr agent get <pane>` -> `.result.agent.agent_status` | Verified live against an interactive `claude` session: reports `working` while generating, `done` once idle. Mapped: `working` -> busy; `idle`/`done` -> idle; `blocked` -> idle (surfaced like a stale pane, not suppressed as busy - a blocked agent is stuck waiting on the human, not grinding); anything else -> unknown (the cue for the shared tail-regex fallback). |
 | Kill | `herdr pane close <pane>` | Closing a tab's only (root) pane also closes the tab - no separate tab-close call needed for this adapter's one-pane-per-tab shape. Best-effort: closing an already-closed pane exits non-zero, matching tmux's `kill-window \|\| true` contract. |
 | Recovery / list-live | `herdr tab list --workspace <id>`, filter labels starting with `fm-` | Label-based, never trusts a stored id blindly - see "ID stability" below. |
+| Test session cleanup | `herdr session stop <name> --session <name> --json`, then `herdr session delete <name> --session <name> --json` | Used only after `tests/herdr-test-safety.sh` re-queries `herdr session list --json` and confirms `<name>` is listed and not default. Never use `herdr server stop` for test cleanup. |
+
+## Session targeting: the --session flag, not HERDR_SESSION alone
+
+`HERDR_SESSION=<name>` is still the adapter's normal way to select a named herdr session for start, workspace, tab, pane, capture, send, and busy-state operations.
+The stored herdr target also carries the session explicitly as `<session>:<pane-id>`, so normal firstmate operations re-derive the intended session from task metadata.
+
+Destructive session cleanup is different.
+On herdr 0.7.1, neither an exported `HERDR_SESSION` nor an inline `HERDR_SESSION=<name>` prefix reliably targets `herdr server stop` when another herdr server is already running on the machine.
+`herdr server stop` has no session positional argument and can stop the ambient running server instead of the isolated smoke-test session.
+That failure mode killed the live default herdr server during real smoke-test cleanup on 2026-07-02.
+
+Real-herdr tests must therefore source `tests/herdr-test-safety.sh` and call `herdr_safe_stop_and_delete <name>` for session teardown.
+The helper fails closed on an empty name, literal `default`, a missing session-list entry, a failed `herdr session list --json`, or a listed entry flagged `default:true`.
+Only after that read-only guard passes does it call `herdr session stop <name> --session <name> --json`, re-run the guard, and then call `herdr session delete <name> --session <name> --json`.
+The explicit-by-name `session stop`/`session delete` form and the trailing `--session` flag are both intentional.
 
 ## Verified bug: `pane read --lines N` returns empty for small N
 
@@ -113,7 +130,7 @@ The adapter still implements label-based recovery (`fm_backend_herdr_list_live`)
 
 ## End-to-end verification (spawn -> steer -> peek -> done -> merge -> teardown)
 
-Beyond the fake-CLI unit tests (`tests/fm-backend-herdr.test.sh`) and the real-CLI smoke test (`tests/fm-backend-herdr-smoke.test.sh`), the full firstmate lifecycle was driven end to end against a real `claude` crewmate through this branch's own scripts, in a scratch `FM_HOME`, a scratch `local-only` git project, and an isolated `HERDR_SESSION` (never the default session):
+Beyond the fake-CLI unit tests (`tests/fm-backend-herdr.test.sh`) and the real-CLI smoke tests (`tests/fm-backend-herdr-smoke.test.sh` and `tests/fm-backend-autodetect-smoke.test.sh`), the full firstmate lifecycle was driven end to end against a real `claude` crewmate through this branch's own scripts, in a scratch `FM_HOME`, a scratch `local-only` git project, and an isolated `HERDR_SESSION`:
 
 1. `FM_HOME=<scratch> FM_BACKEND=herdr HERDR_SESSION=<isolated> bin/fm-spawn.sh herdr-e2e-t1 projects/scratch-e2e-project claude` - spawned successfully, printing `backend=herdr` in the summary and writing `herdr_session=`/`herdr_workspace_id=`/`herdr_tab_id=`/`herdr_pane_id=` to the task's meta.
 2. `bin/fm-peek.sh fm-herdr-e2e-t1` - showed the live claude trust dialog.
@@ -130,7 +147,7 @@ Two real, non-obvious bugs were caught and fixed by this pass alone, both alread
 - The `pane read --lines N` small-N bug (see above) - without the fix, this E2E run flaked intermittently on the very first `send_text_line` call.
 - `pane get`'s `.result.pane.cwd` field is frozen at pane-creation time and never updates; `fm_backend_herdr_current_path` originally read it and would have made `fm-spawn.sh`'s worktree-discovery poll misresolve the acquired treehouse worktree path (it would see the pane's ORIGINAL directory, not where `treehouse get`'s subshell actually landed) - fixed by reading `.result.pane.foreground_cwd` instead, which tracks the live running process.
 
-The isolated herdr session, the treehouse pool worktree, and the scratch `FM_HOME` were all stopped/deleted/removed after this run; the captain's default herdr session and the live tmux fleet were never touched at any point.
+The isolated herdr session, the treehouse pool worktree, and the scratch `FM_HOME` were all stopped/deleted/removed after this run with the explicit session-targeting guard described above.
 
 ## Known gaps left for a follow-up
 

--- a/tests/fm-backend-autodetect-smoke.test.sh
+++ b/tests/fm-backend-autodetect-smoke.test.sh
@@ -19,6 +19,12 @@
 # need a live attached tmux client, which a background test script cannot
 # manufacture; the selection LOGIC for that case is already exercised for real
 # by fm_backend_detect's own unit coverage plus that fake-tmux fm-spawn test.
+#
+# Safety (2026-07-02 incident, see tests/herdr-test-safety.sh): cleanup uses
+# ONLY herdr_safe_stop_and_delete, never a bare/inline-prefixed `herdr server
+# stop` - that command killed the captain's live default herdr server twice in
+# production because HERDR_SESSION-based targeting (env var OR inline prefix)
+# is not reliably honored once another herdr server is already running.
 set -u
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -36,6 +42,9 @@ command -v herdr >/dev/null 2>&1 || { echo "skip: herdr not found"; exit 0; }
 command -v jq >/dev/null 2>&1 || { echo "skip: jq not found (required by the herdr adapter)"; exit 0; }
 command -v treehouse >/dev/null 2>&1 || { echo "skip: treehouse not found (required by fm-spawn.sh)"; exit 0; }
 
+# shellcheck source=tests/herdr-test-safety.sh
+. "$ROOT/tests/herdr-test-safety.sh"
+
 # Physically-resolved (mktemp -d "$(pwd -P)"-relative), not the logical
 # ${TMPDIR:-/tmp} path: on macOS /tmp is a symlink to /private/tmp, and
 # fm-spawn.sh's PROJ_ABS uses a logical `cd && pwd` while herdr's own
@@ -52,9 +61,7 @@ trap cleanup_all EXIT
 
 cleanup_all() {
   [ -n "$WT" ] && command -v treehouse >/dev/null 2>&1 && treehouse return --force "$WT" >/dev/null 2>&1
-  HERDR_SESSION="$SESSION" herdr server stop >/dev/null 2>&1 || true
-  sleep 0.5
-  HERDR_SESSION="$SESSION" herdr session delete "$SESSION" --json >/dev/null 2>&1 || true
+  herdr_safe_stop_and_delete "$SESSION"
   rm -rf "$TMP_ROOT"
 }
 
@@ -127,7 +134,7 @@ FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$STATE" FM_DATA_OVERRIDE="$DATA" \
 status=$?
 [ "$status" -eq 0 ] || fail "fm-teardown.sh failed for the auto-detected herdr task"$'\n'"$(cat "$TEARDOWN_OUT")"
 [ -f "$META" ] && fail "fm-teardown.sh did not remove $META"
-if HERDR_SESSION="$SESSION" herdr pane get "$PANE" >/dev/null 2>&1; then
+if herdr pane get "$PANE" --session "$SESSION" >/dev/null 2>&1; then
   fail "fm-teardown.sh did not close the auto-detected herdr pane"
 fi
 WT=

--- a/tests/fm-backend-herdr-smoke.test.sh
+++ b/tests/fm-backend-herdr-smoke.test.sh
@@ -1,12 +1,19 @@
 #!/usr/bin/env bash
 # tests/fm-backend-herdr-smoke.test.sh - real herdr smoke test for the herdr
 # session-provider adapter (bin/backends/herdr.sh), P2 of
-# data/fm-backend-design-d7 (herdr-addendum.md). Mirrors
+# data/fm-backend-design-d7 (herdr-addendum.md), extended for the P3
+# workspace-per-home pass (AGENTS.md task herdr-sm-spaces-k4). Mirrors
 # tests/fm-backend-tmux-smoke.test.sh's structure: every other suite fakes the
 # CLI, this one talks to a REAL herdr server - but ALWAYS on a private, named,
 # throwaway HERDR_SESSION (never the default session), so it never touches a
 # captain's real herdr usage. Skips cleanly when herdr (or jq) is not
 # installed, so CI/dev machines without herdr are unaffected.
+#
+# Safety (2026-07-02 incident, see tests/herdr-test-safety.sh): cleanup uses
+# ONLY herdr_safe_stop_and_delete, never a bare/ambient `herdr server stop` -
+# that command killed the captain's live default herdr server twice in
+# production because HERDR_SESSION-based targeting (env var OR inline prefix)
+# is not reliably honored once another herdr server is already running.
 set -u
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -17,14 +24,15 @@ pass() { printf 'ok - %s\n' "$1"; }
 command -v herdr >/dev/null 2>&1 || { echo "skip: herdr not found"; exit 0; }
 command -v jq >/dev/null 2>&1 || { echo "skip: jq not found (required by the herdr adapter)"; exit 0; }
 
+# shellcheck source=tests/herdr-test-safety.sh
+. "$ROOT/tests/herdr-test-safety.sh"
+
 SESSION="fm-backend-smoke-$$"
 export HERDR_SESSION="$SESSION"
 trap cleanup_all EXIT
 
 cleanup_all() {
-  herdr server stop >/dev/null 2>&1 || true
-  sleep 0.5
-  herdr session delete "$SESSION" --json >/dev/null 2>&1 || true
+  herdr_safe_stop_and_delete "$SESSION"
 }
 
 # shellcheck source=bin/fm-backend.sh
@@ -136,7 +144,7 @@ fi
 # --- kill -----------------------------------------------------------------
 
 fm_backend_herdr_kill "$TARGET"
-if HERDR_SESSION="$SESSION" herdr pane get "$PANE_ID" >/dev/null 2>&1; then
+if herdr pane get "$PANE_ID" --session "$SESSION" >/dev/null 2>&1; then
   fail "kill did not remove the pane"
 fi
 # Best-effort contract: killing an already-gone pane must not error.

--- a/tests/herdr-test-safety.sh
+++ b/tests/herdr-test-safety.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# tests/herdr-test-safety.sh - shared hard guard against a real-herdr test's
+# cleanup ever stopping/deleting the machine's DEFAULT herdr session. Source
+# this from any test file that starts an isolated herdr session and must tear
+# it down.
+#
+# Root cause this guards against (docs/herdr-backend.md "Session targeting: the
+# --session flag, not HERDR_SESSION alone"): on the installed herdr 0.7.1
+# client, NEITHER an exported HERDR_SESSION NOR an inline `HERDR_SESSION="$x"`
+# prefix reliably routes a CLI subcommand to the named session once another
+# herdr server (e.g. the captain's live default session) is already bound on
+# the machine - it silently falls back to whatever server IS running instead
+# of the requested one. This bit production twice on 2026-07-02:
+# tests/fm-backend-herdr-smoke.test.sh's `herdr server stop` (fully unscoped)
+# and tests/fm-backend-autodetect-smoke.test.sh's
+# `HERDR_SESSION="$SESSION" herdr server stop` (inline-prefixed - which looked
+# safer but was verified to be exactly as vulnerable) both killed the
+# captain's live default herdr server instead of their own isolated throwaway
+# session, twice, on two different runs.
+#
+# The fix is two independent layers, because either alone is not enough:
+#
+#   1. Never call the ambient `herdr server stop` (it takes NO target at all -
+#      it always acts on "whatever server is running", resolved ambiently).
+#      Use `herdr session stop <name>` instead: <name> is a REQUIRED
+#      positional argument, so herdr cannot resolve it ambiguously - herdr's
+#      own help text says to literally type "default" to affect the default
+#      session, making an accidental hit structurally much harder. --session
+#      <name> is appended too, for defense in depth (verified empirically to
+#      work in trailing position for every herdr subcommand tried, including
+#      `session stop`/`session delete`; see docs/herdr-backend.md).
+#   2. herdr_refuse_if_default: a READ-ONLY pre-check, run immediately before
+#      ANY stop/delete, that queries `herdr session list --json` (which
+#      enumerates every session, each carrying its own `default` flag) and
+#      refuses outright if <name> is literally "default", is not currently
+#      listed, or IS flagged default:true. This is the "hard guard" layer:
+#      it does not trust that layer 1's explicit targeting worked: it
+#      independently re-verifies from a fresh read before every destructive
+#      call.
+#
+# Fails CLOSED: any ambiguity (a failed/empty session list, a name that does
+# not resolve) refuses rather than proceeding, because the cost of a false
+# refusal (a leaked test session, cleaned up by hand later) is trivially
+# recoverable, while the cost of a false negative (stopping the wrong server)
+# is not.
+set -u
+
+# herdr_refuse_if_default: 0 (SAFE to proceed) only if <name> is a currently-
+# listed, non-default session. 1 (REFUSE) on anything else.
+herdr_refuse_if_default() {  # <name>
+  local name=$1 info flag
+  [ -n "$name" ] || { echo "herdr safety guard: refusing - empty session name" >&2; return 1; }
+  if [ "$name" = default ]; then
+    echo "herdr safety guard: refusing - name is literally 'default'" >&2
+    return 1
+  fi
+  info=$(herdr session list --json 2>/dev/null) || { echo "herdr safety guard: refusing - 'herdr session list --json' failed, cannot verify" >&2; return 1; }
+  flag=$(printf '%s' "$info" | jq -r --arg n "$name" '.sessions[]? | select(.name == $n) | .default' 2>/dev/null)
+  if [ "$flag" = "false" ]; then
+    return 0
+  fi
+  echo "herdr safety guard: refusing - session '$name' not found in 'herdr session list', or flagged default (default=${flag:-<not found>})" >&2
+  return 1
+}
+
+# herdr_safe_stop_and_delete: the ONLY sanctioned way for a test to tear down
+# an isolated session it created. Guards first (herdr_refuse_if_default), then
+# uses the explicit-by-name `session stop`/`session delete` forms (never the
+# ambient `server stop`), with --session appended too. Best-effort past the
+# guard (a session already gone, or never fully started, must not fail the
+# caller's cleanup trap) - but the guard itself is NOT best-effort: a refusal
+# here means cleanup_all leaves the (isolated, throwaway, never-default)
+# session running rather than risk the wrong target.
+herdr_safe_stop_and_delete() {  # <name>
+  local name=$1
+  herdr_refuse_if_default "$name" || return 1
+  herdr session stop "$name" --session "$name" --json >/dev/null 2>&1 || true
+  sleep 0.5
+  herdr session delete "$name" --session "$name" --json >/dev/null 2>&1 || true
+}

--- a/tests/herdr-test-safety.sh
+++ b/tests/herdr-test-safety.sh
@@ -76,5 +76,6 @@ herdr_safe_stop_and_delete() {  # <name>
   herdr_refuse_if_default "$name" || return 1
   herdr session stop "$name" --session "$name" --json >/dev/null 2>&1 || true
   sleep 0.5
+  herdr_refuse_if_default "$name" || return 1
   herdr session delete "$name" --session "$name" --json >/dev/null 2>&1 || true
 }


### PR DESCRIPTION
## Intent

Fix a safety bug in the real-herdr smoke tests: their cleanup used a bare/inline-prefixed 'herdr server stop', which is unscoped and silently falls back to whatever herdr server is already running on the machine instead of the test's own isolated throwaway HERDR_SESSION. This killed the captain's live default herdr server twice in production on 2026-07-02 (once from each of tests/fm-backend-herdr-smoke.test.sh and tests/fm-backend-autodetect-smoke.test.sh). Fix: add tests/herdr-test-safety.sh with herdr_safe_stop_and_delete, which (1) uses the explicit-by-name 'herdr session stop/delete <name>' form instead of the ambient 'server stop', appending --session <name> too, and (2) runs a read-only hard guard (herdr_refuse_if_default) immediately before any stop/delete that re-queries 'herdr session list --json' and refuses if the target is literally default, not found, or flagged default:true - fails closed on any ambiguity. Both smoke test files' cleanup_all now call only this helper. This is a standalone fix, split out from a larger in-progress feature branch (workspace-per-home herdr labeling) specifically so it can merge fast and unblock a separate dependent task; the feature branch will rebase onto this once merged. Verified empirically against a real isolated herdr session (not the fake-CLI mocks): the guard refuses on default/nonexistent/empty session names without ever invoking a destructive command, and correctly tears down a genuinely isolated session while leaving the default session's real workspace state (labels, tab counts) byte-identical before and after.

## What Changed

- Hardened real-herdr smoke test cleanup by routing stop/delete through guarded session-name helpers instead of ambient server shutdown.
- Added a shared test safety helper that refuses destructive cleanup for empty, missing, default, or ambiguous herdr sessions and re-checks immediately before delete.
- Updated herdr smoke test docs and contributor guidance to document the default-session protection.

## Risk Assessment

✅ Low: Captain, the change is narrowly scoped to real-herdr smoke-test cleanup and adds a fail-closed guard before destructive session operations.

## Testing

The already-successful full baseline was complemented with real-herdr end-to-end evidence: the guard failed closed for empty/default/missing targets, safely stopped and deleted an isolated non-default session, both real smoke tests passed, the normalized default herdr workspace/tab labels and counts were byte-identical before and after, and no working-tree artifacts were left behind.

<details>
<summary>Evidence: herdr safety E2E transcript</summary>

```text
== tool versions ==
herdr 0.7.1
jq-1.8.1
== default session shape before ==
{
  "default_sessions": [
    {
      "default": true,
      "name": "default"
    }
  ],
  "tab_shape": [
    {
      "label": "1",
      "pane_count": 1,
      "tab_id": "w3:t1",
      "workspace_id": "w3"
    },
    {
      "label": "fm-dotfiles-d6",
      "pane_count": 1,
      "tab_id": "w3:t2",
      "workspace_id": "w3"
    },
    {
      "label": "fm-sshhip-h7",
      "pane_count": 1,
      "tab_id": "w3:t3",
      "workspace_id": "w3"
    },
    {
      "label": "fm-hibit-h9",
      "pane_count": 1,
      "tab_id": "w3:t4",
      "workspace_id": "w3"
    },
    {
      "label": "fm-oss-triage-t4",
      "pane_count": 1,
      "tab_id": "w3:t5",
      "workspace_id": "w3"
    },
    {
      "label": "fm-herdr-sm-spaces-k4",
      "pane_count": 1,
      "tab_id": "w3:t6",
      "workspace_id": "w3"
    },
    {
      "label": "fm-fm-session-start-q6",
      "pane_count": 1,
      "tab_id": "w3:t7",
      "workspace_id": "w3"
    },
    {
      "label": "fm-herdr-alias-h7",
      "pane_count": 1,
      "tab_id": "w3:t8",
      "workspace_id": "w3"
    }
  ],
  "workspace_shape": [
    {
      "label": "firstmate",
      "pane_count": 8,
      "tab_count": 8,
      "workspace_id": "w3"
    }
  ]
}
== hard guard refusal checks ==
guard refused empty (): herdr safety guard: refusing - empty session name 
guard refused default (default): herdr safety guard: refusing - name is literally 'default' 
guard refused nonexistent (fm-definitely-missing-49211): herdr safety guard: refusing - session 'fm-definitely-missing-49211' not found in 'herdr session list', or flagged default (default=<not found>) 
== isolated helper teardown check using product container ensure ==
created isolated herdr container: fm-guard-evidence-49211:w1
{
  "sessions": [
    {
      "default": true,
      "name": "default"
    },
    {
      "default": false,
      "name": "fm-guard-evidence-49211"
    }
  ]
}
guard allowed isolated non-default session: fm-guard-evidence-49211
helper stopped and deleted isolated session: fm-guard-evidence-49211
== real smoke test: tests/fm-backend-herdr-smoke.test.sh ==
ok - real herdr: version_check accepts the installed binary's protocol
ok - real herdr: container_ensure starts the isolated session's server and ensures the firstmate workspace (fm-backend-smoke-49351:w1)
ok - real herdr: container_ensure is idempotent (reuses the existing firstmate workspace)
ok - real herdr: create_task creates a tab/pane and refuses a duplicate label
ok - real herdr: send_text_line runs a command atomically (pane run) and its output is capturable
ok - real herdr: send_literal + send_key Enter submit as two separate steps (verified: send-text does NOT auto-submit)
ok - real herdr: current_path reads the pane's live cwd
note: FM_HERDR_SMOKE_REAL_CLAUDE=1 not set; skipping the real-agent busy_state check
ok - real herdr: kill removes the pane and is idempotent/best-effort
ok - real herdr: list_live discovers a live task tab by fm-<id> label
== real smoke test: tests/fm-backend-autodetect-smoke.test.sh ==
ok - real herdr: fm-spawn.sh auto-detects herdr from HERDR_ENV=1 (no explicit config) and prints the loud notice
ok - real herdr: auto-detected spawn records backend=herdr and herdr_session/workspace/tab/pane fields in meta
ok - real herdr: the auto-detected spawn's launch command actually ran in the herdr pane
ok - real herdr: teardown completes the auto-detected spawn/teardown cycle (meta cleared, pane closed)
== default session shape after ==
{
  "default_sessions": [
    {
      "default": true,
      "name": "default"
    }
  ],
  "tab_shape": [
    {
      "label": "1",
      "pane_count": 1,
      "tab_id": "w3:t1",
      "workspace_id": "w3"
    },
    {
      "label": "fm-dotfiles-d6",
      "pane_count": 1,
      "tab_id": "w3:t2",
      "workspace_id": "w3"
    },
    {
      "label": "fm-sshhip-h7",
      "pane_count": 1,
      "tab_id": "w3:t3",
      "workspace_id": "w3"
    },
    {
      "label": "fm-hibit-h9",
      "pane_count": 1,
      "tab_id": "w3:t4",
      "workspace_id": "w3"
    },
    {
      "label": "fm-oss-triage-t4",
      "pane_count": 1,
      "tab_id": "w3:t5",
      "workspace_id": "w3"
    },
    {
      "label": "fm-herdr-sm-spaces-k4",
      "pane_count": 1,
      "tab_id": "w3:t6",
      "workspace_id": "w3"
    },
    {
      "label": "fm-fm-session-start-q6",
      "pane_count": 1,
      "tab_id": "w3:t7",
      "workspace_id": "w3"
    },
    {
      "label": "fm-herdr-alias-h7",
      "pane_count": 1,
      "tab_id": "w3:t8",
      "workspace_id": "w3"
    }
  ],
  "workspace_shape": [
    {
      "label": "firstmate",
      "pane_count": 8,
      "tab_count": 8,
      "workspace_id": "w3"
    }
  ]
}
default herdr workspace/tab shape unchanged after guard and smoke tests
== remaining sessions ==
{
  "sessions": [
    {
      "default": true,
      "name": "default"
    }
  ]
}
```
</details>
<details>
<summary>Evidence: default herdr state before</summary>

```text
{
  "default_sessions": [
    {
      "default": true,
      "name": "default"
    }
  ],
  "tab_shape": [
    {
      "label": "1",
      "pane_count": 1,
      "tab_id": "w3:t1",
      "workspace_id": "w3"
    },
    {
      "label": "fm-dotfiles-d6",
      "pane_count": 1,
      "tab_id": "w3:t2",
      "workspace_id": "w3"
    },
    {
      "label": "fm-sshhip-h7",
      "pane_count": 1,
      "tab_id": "w3:t3",
      "workspace_id": "w3"
    },
    {
      "label": "fm-hibit-h9",
      "pane_count": 1,
      "tab_id": "w3:t4",
      "workspace_id": "w3"
    },
    {
      "label": "fm-oss-triage-t4",
      "pane_count": 1,
      "tab_id": "w3:t5",
      "workspace_id": "w3"
    },
    {
      "label": "fm-herdr-sm-spaces-k4",
      "pane_count": 1,
      "tab_id": "w3:t6",
      "workspace_id": "w3"
    },
    {
      "label": "fm-fm-session-start-q6",
      "pane_count": 1,
      "tab_id": "w3:t7",
      "workspace_id": "w3"
    },
    {
      "label": "fm-herdr-alias-h7",
      "pane_count": 1,
      "tab_id": "w3:t8",
      "workspace_id": "w3"
    }
  ],
  "workspace_shape": [
    {
      "label": "firstmate",
      "pane_count": 8,
      "tab_count": 8,
      "workspace_id": "w3"
    }
  ]
}
```
</details>
<details>
<summary>Evidence: default herdr state after</summary>

```text
{
  "default_sessions": [
    {
      "default": true,
      "name": "default"
    }
  ],
  "tab_shape": [
    {
      "label": "1",
      "pane_count": 1,
      "tab_id": "w3:t1",
      "workspace_id": "w3"
    },
    {
      "label": "fm-dotfiles-d6",
      "pane_count": 1,
      "tab_id": "w3:t2",
      "workspace_id": "w3"
    },
    {
      "label": "fm-sshhip-h7",
      "pane_count": 1,
      "tab_id": "w3:t3",
      "workspace_id": "w3"
    },
    {
      "label": "fm-hibit-h9",
      "pane_count": 1,
      "tab_id": "w3:t4",
      "workspace_id": "w3"
    },
    {
      "label": "fm-oss-triage-t4",
      "pane_count": 1,
      "tab_id": "w3:t5",
      "workspace_id": "w3"
    },
    {
      "label": "fm-herdr-sm-spaces-k4",
      "pane_count": 1,
      "tab_id": "w3:t6",
      "workspace_id": "w3"
    },
    {
      "label": "fm-fm-session-start-q6",
      "pane_count": 1,
      "tab_id": "w3:t7",
      "workspace_id": "w3"
    },
    {
      "label": "fm-herdr-alias-h7",
      "pane_count": 1,
      "tab_id": "w3:t8",
      "workspace_id": "w3"
    }
  ],
  "workspace_shape": [
    {
      "label": "firstmate",
      "pane_count": 8,
      "tab_count": 8,
      "workspace_id": "w3"
    }
  ]
}
```
</details>
<details>
<summary>Evidence: default herdr state diff</summary>

Source: default herdr state diff (local file: <code>/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KWJFN7ZD53RJTRBKGD5XR905/default-herdr-state.diff.txt</code>)

```text
empty diff; before/after matched
```
</details>
<details>
<summary>Evidence: sessions after isolated create</summary>

```text
{
  "sessions": [
    {
      "default": true,
      "name": "default"
    },
    {
      "default": false,
      "name": "fm-guard-evidence-49211"
    }
  ]
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `tests/herdr-test-safety.sh:79` - `session delete` runs after `session stop` and a sleep without re-running the safety guard. The helper documents a fresh `herdr_refuse_if_default` before any destructive stop/delete, so a session-list change between the two calls would make the delete path no longer fail closed. Re-check immediately before `session delete`.

🔧 Fix: guard herdr delete with fresh check
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- <code>Baseline already passed before this run: `command -v tmux &gt;/dev/null || { echo &#34;tmux is required for e2e tests&#34; &gt;&amp;2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo &#34;== $t ==&#34;; bash &#34;$t&#34; || rc=1; done; exit &#34;$rc&#34;`</code>
- <code>`herdr --version`; `jq --version`; `treehouse --version`; `herdr session list --json`; `herdr --session default workspace list`; `herdr --session default tab list`</code>
- <code>Evidence harness sourcing `tests/herdr-test-safety.sh`: checked `herdr_refuse_if_default &#34;&#34;`, `herdr_refuse_if_default default`, and `herdr_refuse_if_default fm-definitely-missing-&lt;pid&gt;`</code>
- <code>Evidence harness using `fm_backend_herdr_container_ensure /tmp` to create `fm-guard-evidence-&lt;pid&gt;`, then `herdr_safe_stop_and_delete &lt;session&gt;` and verify that session was gone</code>
- `bash tests/fm-backend-herdr-smoke.test.sh`
- `bash tests/fm-backend-autodetect-smoke.test.sh`
- `diff -u /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KWJFN7ZD53RJTRBKGD5XR905/default-herdr-state.before.json /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KWJFN7ZD53RJTRBKGD5XR905/default-herdr-state.after.json`
- <code>`git status --short`; `herdr session list --json | jq -S &#39;{sessions: [.sessions[]? | {name, default}]}&#39;`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
