### PR TITLE
fix(backends): reuse the herdr firstmate workspace instead of leaking one per spawn

### DIFF
--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -181,11 +181,15 @@ fm_backend_herdr_workspace_find() {  # <session>
 # fm_backend_herdr_workspace_prune_default_tabs: close the tab herdr
 # auto-creates inside a freshly created workspace (label "1", never an
 # fm-<id> task tab), so the persistent "firstmate" workspace holds only real
-# task tabs - the documented one-tab-per-task shape. Runs only on the create
-# path (find already reuses an existing workspace), when the ONLY tab present
-# is that auto-created default, so filtering to non-fm- tabs never touches a
-# task tab. Best-effort: a failure here never fails the spawn, mirroring the
-# fm_backend_herdr_kill `|| true` contract.
+# task tabs - the documented one-tab-per-task shape. Best-effort: a failure
+# here never fails the caller, mirroring the fm_backend_herdr_kill `|| true`
+# contract.
+#
+# Verified real-herdr behavior (not modeled by the fake-CLI unit tests):
+# closing a workspace's LAST remaining tab deletes the whole workspace, not
+# just the tab. So this must never run while the auto-created default tab is
+# still the ONLY tab - callers only invoke it once at least one other (real
+# task) tab exists alongside it, never right after workspace creation.
 fm_backend_herdr_workspace_prune_default_tabs() {  # <session> <workspace_id>
   local session=$1 wsid=$2 tabs tab_id pane_id
   tabs=$(fm_backend_herdr_cli "$session" tab list --workspace "$wsid" 2>/dev/null) || return 0
@@ -218,8 +222,11 @@ fm_backend_herdr_workspace_ensure() {  # <session> <cwd>
   wsid=$(printf '%s' "$out" | jq -r '.result.workspace.workspace_id // empty' 2>/dev/null)
   [ -n "$wsid" ] || return 1
   # Herdr seeds a new workspace with one auto-created default tab firstmate
-  # never uses; drop it so only task tabs remain. Best-effort.
-  fm_backend_herdr_workspace_prune_default_tabs "$session" "$wsid"
+  # never uses. It is NOT pruned here: at this instant it is the workspace's
+  # ONLY tab, and closing a workspace's last tab deletes the workspace itself
+  # (verified against the real herdr binary) - pruning here would destroy the
+  # workspace we just created. fm_backend_herdr_create_task prunes it instead,
+  # once the first real task tab exists alongside it.
   printf '%s' "$wsid"
 }
 
@@ -241,9 +248,13 @@ fm_backend_herdr_container_ensure() {  # <cwd-for-a-fresh-workspace>
 # label), so the duplicate check is ours, mirroring tmux's manual check.
 # --no-focus: verified tab create never focuses by default regardless of
 # sibling tabs, so this is defense in depth rather than a behavior change.
+# If <container>'s workspace was JUST created (its only tab beforehand was
+# herdr's auto-created default, label "1"), prune that default tab now that
+# this call has added a real tab alongside it - see
+# fm_backend_herdr_workspace_ensure for why pruning cannot happen any earlier.
 # Echoes "<tab_id> <pane_id>" on success.
 fm_backend_herdr_create_task() {  # <container> <label> <cwd>
-  local container=$1 label=$2 cwd=$3 session wsid list dup out tab_id pane_id
+  local container=$1 label=$2 cwd=$3 session wsid list dup out tab_id pane_id only_default
   session=${container%%:*}
   wsid=${container#*:}
   list=$(fm_backend_herdr_cli "$session" tab list --workspace "$wsid" 2>/dev/null) || return 1
@@ -252,6 +263,8 @@ fm_backend_herdr_create_task() {  # <container> <label> <cwd>
     echo "error: herdr tab '$label' already exists in workspace $wsid (session $session)" >&2
     return 1
   fi
+  only_default=$(printf '%s' "$list" | jq -r \
+    'if (.result.tabs? // [] | length) == 1 and .result.tabs[0].label == "1" then "1" else empty end' 2>/dev/null)
   out=$(fm_backend_herdr_cli "$session" tab create --workspace "$wsid" --cwd "$cwd" --label "$label" --no-focus 2>/dev/null) || return 1
   tab_id=$(printf '%s' "$out" | jq -r '.result.tab.tab_id // empty' 2>/dev/null)
   pane_id=$(printf '%s' "$out" | jq -r '.result.root_pane.pane_id // empty' 2>/dev/null)
@@ -259,6 +272,7 @@ fm_backend_herdr_create_task() {  # <container> <label> <cwd>
     echo "error: could not parse tab/pane id from herdr tab create output" >&2
     return 1
   fi
+  [ -z "$only_default" ] || fm_backend_herdr_workspace_prune_default_tabs "$session" "$wsid"
   printf '%s %s' "$tab_id" "$pane_id"
 }
 

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -169,8 +169,32 @@ fm_backend_herdr_workspace_find() {  # <session>
   local session=$1 label list
   label=$(fm_backend_herdr_workspace_label)
   list=$(fm_backend_herdr_cli "$session" workspace list 2>/dev/null) || return 0
-  printf '%s' "$list" | jq -r --arg label "$label" \
-    '.result.workspaces[]? | select(.label == $label) | .workspace_id' 2>/dev/null | head -1
+  # NOTE: the jq variable is $want, NOT $label - `label` is a jq reserved
+  # keyword (label/break), so declaring a jq variable named "label" is a
+  # compile error that `2>/dev/null` would silently swallow, making this find
+  # ALWAYS return empty and every spawn mint a fresh "firstmate" workspace
+  # (the workspace leak).
+  printf '%s' "$list" | jq -r --arg want "$label" \
+    '.result.workspaces[]? | select(.label == $want) | .workspace_id' 2>/dev/null | head -1
+}
+
+# fm_backend_herdr_workspace_prune_default_tabs: close the tab herdr
+# auto-creates inside a freshly created workspace (label "1", never an
+# fm-<id> task tab), so the persistent "firstmate" workspace holds only real
+# task tabs - the documented one-tab-per-task shape. Runs only on the create
+# path (find already reuses an existing workspace), when the ONLY tab present
+# is that auto-created default, so filtering to non-fm- tabs never touches a
+# task tab. Best-effort: a failure here never fails the spawn, mirroring the
+# fm_backend_herdr_kill `|| true` contract.
+fm_backend_herdr_workspace_prune_default_tabs() {  # <session> <workspace_id>
+  local session=$1 wsid=$2 tabs tab_id pane_id
+  tabs=$(fm_backend_herdr_cli "$session" tab list --workspace "$wsid" 2>/dev/null) || return 0
+  while IFS= read -r tab_id; do
+    [ -n "$tab_id" ] || continue
+    pane_id=$(fm_backend_herdr_pane_for_tab "$session" "$wsid" "$tab_id") || continue
+    [ -n "$pane_id" ] || continue
+    fm_backend_herdr_cli "$session" pane close "$pane_id" >/dev/null 2>&1 || true
+  done < <(printf '%s' "$tabs" | jq -r '.result.tabs[]? | select((.label // "" | startswith("fm-")) | not) | .tab_id' 2>/dev/null)
 }
 
 # fm_backend_herdr_workspace_ensure: this HOME's persistent workspace inside
@@ -193,6 +217,9 @@ fm_backend_herdr_workspace_ensure() {  # <session> <cwd>
   out=$(fm_backend_herdr_cli "$session" workspace create --cwd "$cwd" --label "$label" --no-focus 2>/dev/null) || return 1
   wsid=$(printf '%s' "$out" | jq -r '.result.workspace.workspace_id // empty' 2>/dev/null)
   [ -n "$wsid" ] || return 1
+  # Herdr seeds a new workspace with one auto-created default tab firstmate
+  # never uses; drop it so only task tabs remain. Best-effort.
+  fm_backend_herdr_workspace_prune_default_tabs "$session" "$wsid"
   printf '%s' "$wsid"
 }
 
@@ -220,7 +247,7 @@ fm_backend_herdr_create_task() {  # <container> <label> <cwd>
   session=${container%%:*}
   wsid=${container#*:}
   list=$(fm_backend_herdr_cli "$session" tab list --workspace "$wsid" 2>/dev/null) || return 1
-  dup=$(printf '%s' "$list" | jq -r --arg label "$label" '.result.tabs[]? | select(.label == $label) | .tab_id' 2>/dev/null | head -1)
+  dup=$(printf '%s' "$list" | jq -r --arg want "$label" '.result.tabs[]? | select(.label == $want) | .tab_id' 2>/dev/null | head -1)
   if [ -n "$dup" ]; then
     echo "error: herdr tab '$label' already exists in workspace $wsid (session $session)" >&2
     return 1
@@ -417,8 +444,8 @@ fm_backend_herdr_resolve_bare_selector() {  # <name>
   while IFS= read -r session; do
     [ -n "$session" ] || continue
     tabs=$(fm_backend_herdr_cli "$session" tab list 2>/dev/null) || continue
-    tab_id=$(printf '%s' "$tabs" | jq -r --arg label "$name" \
-      '.result.tabs[]? | select(.label == $label) | .tab_id' 2>/dev/null | head -1)
+    tab_id=$(printf '%s' "$tabs" | jq -r --arg want "$name" \
+      '.result.tabs[]? | select(.label == $want) | .tab_id' 2>/dev/null | head -1)
     [ -n "$tab_id" ] || continue
     wsid=$(printf '%s' "$tabs" | jq -r --arg tab "$tab_id" '.result.tabs[]? | select(.tab_id == $tab) | .workspace_id' 2>/dev/null | head -1)
     [ -n "$wsid" ] || continue

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -93,28 +93,17 @@ Workspace-per-task - tried against the real binary in P2 and again considered he
 
 ## Workspace lifecycle: one persistent `firstmate` workspace, reused
 
-The `firstmate` workspace is created once per session and then reused by every subsequent spawn, exactly like tmux's session: `fm_backend_herdr_workspace_ensure` calls `fm_backend_herdr_workspace_find` first and creates a workspace only when no `firstmate`-labelled one exists.
-Teardown (`fm_backend_herdr_kill`) closes only the task's pane/tab; it never removes the workspace, so the workspace persists across the whole session and repeated spawn/teardown cycles never accumulate workspaces.
+The `firstmate` workspace is created once per session and reused by every subsequent spawn: `fm_backend_herdr_workspace_ensure` calls `fm_backend_herdr_workspace_find` first and creates a workspace only when no `firstmate`-labelled one exists.
+Teardown (`fm_backend_herdr_kill`) closes only the task's pane/tab, never the workspace.
 
-### The workspace-leak bug (fixed) and its root cause
+Reserved-keyword guard: never name a `jq --arg`/`--argjson` after a `jq` keyword (`label`, `and`, `or`, `not`, `if`, `then`, `else`, `end`, `reduce`, `foreach`, `import`, `def`, `as`, `__loc__`).
+jq <= 1.6 rejects a keyword-named `$`-variable as a compile error, and this adapter pipes `jq`'s stderr to `/dev/null`, so on jq <= 1.6 the error silently becomes an empty result rather than a visible failure.
+Use a distinct name such as `$want` instead; `tests/fm-backend.test.sh` greps `bin/` for this pattern so a new violation fails loudly rather than silently.
 
-An earlier version leaked one orphaned `firstmate` workspace per crewmate: every spawn minted a fresh workspace instead of reusing the existing one, so `herdr workspace list` filled up with many `label=firstmate` workspaces, most belonging to already-torn-down tasks.
+Default-tab prune: `herdr workspace create` seeds the new workspace with one auto-created default tab (label `1`) that firstmate never uses.
+`fm_backend_herdr_create_task` prunes it (best-effort, via `fm_backend_herdr_workspace_prune_default_tabs`) right after creating the first real task tab in a freshly created workspace, never earlier: closing a workspace's LAST tab deletes the whole workspace on real herdr, and immediately after creation the default tab is the only one present.
 
-The root cause was a `jq` reserved-keyword collision, not a logic error in the find-or-create flow.
-`label` is a reserved keyword in `jq` (used by `label $out | ... break $out`), so a filter written as `jq --arg label "$X" '... select(.label == $label) ...'` is a **compile error**, not a match.
-`fm_backend_herdr_workspace_find` discarded `jq`'s stderr (`2>/dev/null`), so that error surfaced as empty output: the find silently returned nothing on every call, `workspace_ensure` always took the create path, and a new `firstmate` workspace was minted per spawn.
-The fix renames the `jq` variable to `$want` (a non-keyword) in the three affected filters - `fm_backend_herdr_workspace_find`, the `fm_backend_herdr_create_task` duplicate-tab check, and `fm_backend_herdr_resolve_bare_selector`.
-The same collision had also silently disabled the create-task duplicate-label check and the bare-selector tab lookup; both work again with the rename.
-
-Guard for future filters in this adapter: never name a `jq --arg` after a `jq` keyword (`label`, `and`, `or`, `not`, `if`, `then`, `else`, `end`, `reduce`, `foreach`, `import`, `def`, `as`, `__loc__`).
-Prefer a distinct name like `$want`.
-
-### The stray auto-created default tab
-
-`herdr workspace create` seeds the new workspace with one auto-created default tab (label `1`) that firstmate never uses.
-Without handling it, that tab lingered alongside the real `fm-<id>` task tab.
-`fm_backend_herdr_workspace_ensure` now prunes it right after creating the workspace (`fm_backend_herdr_workspace_prune_default_tabs`, best-effort), closing every non-`fm-` tab in the freshly created workspace - at that instant the default tab is the only tab present, so real task tabs are never at risk.
-Because reuse skips the create path, pruning runs at most once per session.
+Because closing a workspace's last tab deletes it, the `firstmate` workspace does not outlive a fully idle fleet (zero live tasks) - the next spawn's `workspace_find` simply finds nothing and recreates it. Reuse holds across concurrent and sequential tasks; it is not a guarantee that the workspace itself survives the whole session unconditionally.
 
 ### Anomaly: a workspace labelled with a project name
 
@@ -149,8 +138,8 @@ Herdr tasks additionally record:
 | Send key | `herdr pane send-keys <pane> <key>` | Verified names: `enter`, `escape` (alias `esc`), `ctrl+c` (aliases `C-c`, `c-c`). `ctrl+c` verified to interrupt a running foreground process immediately. |
 | Bounded capture | `herdr pane read <pane> --source recent --lines N` | See "Verified bug" below - N is never passed through directly. |
 | Busy state | `herdr agent get <pane>` -> `.result.agent.agent_status` | Verified live against an interactive `claude` session: reports `working` while generating, `done` once idle. Mapped: `working` -> busy; `idle`/`done` -> idle; `blocked` -> idle (surfaced like a stale pane, not suppressed as busy - a blocked agent is stuck waiting on the human, not grinding); anything else -> unknown (the cue for the shared tail-regex fallback). |
-| Kill | `herdr pane close <pane>` | Closing a tab's only (root) pane also closes the tab - no separate tab-close call needed for this adapter's one-pane-per-tab shape. Best-effort: closing an already-closed pane exits non-zero, matching tmux's `kill-window \|\| true` contract. Teardown removes only the task's pane/tab; the `firstmate` workspace is persistent (like tmux's session) and is NOT removed - see "Workspace lifecycle" above. |
-| Default-tab prune (workspace create only) | `herdr tab list --workspace <id>`, then `herdr pane close <pane>` on each non-`fm-` tab | `herdr workspace create` seeds the new workspace with one auto-created default tab (label `1`) firstmate never uses. The adapter closes it right after creating the workspace so only real task tabs remain. Best-effort; runs on the create path only (reuse never re-prunes). |
+| Kill | `herdr pane close <pane>` | Closing a tab's only (root) pane also closes the tab - no separate tab-close call needed for this adapter's one-pane-per-tab shape. Best-effort: closing an already-closed pane exits non-zero, matching tmux's `kill-window \|\| true` contract. Teardown itself only ever closes the task's own pane/tab, never the workspace - but closing a workspace's LAST tab (verified real-herdr behavior) deletes the workspace as a side effect, so the `firstmate` workspace persists only while at least one task tab remains; see "Workspace lifecycle" above. |
+| Default-tab prune (create_task, first task in a fresh workspace only) | `herdr tab list --workspace <id>`, then `herdr pane close <pane>` on the non-`fm-` default tab | `herdr workspace create` seeds the new workspace with one auto-created default tab (label `1`) firstmate never uses. `fm_backend_herdr_create_task` closes it right after creating the first real task tab in a freshly created workspace - never right after `workspace create` itself, because at that point the default tab is the workspace's ONLY tab and closing it would delete the whole workspace (see Kill row). Best-effort; a workspace being reused (not freshly created) never re-prunes. |
 | Recovery / list-live | `herdr tab list --workspace <id>`, filter labels starting with `fm-` | Label-based, never trusts a stored id blindly - see "ID stability" below. `<id>` is always THIS home's own workspace (`fm_backend_herdr_workspace_find`), so recovery never sees a sibling home's tabs. |
 | Workspace create / tab create (focus) | `herdr workspace create --no-focus`, `herdr tab create --no-focus` | Verified: neither focuses by default once a workspace already exists in the session, matching pre-P3 (flagless) behavior; `--no-focus` is passed anyway for defense in depth, since the very first workspace ever created in a brand-new session focuses regardless of the flag. `--focus` was separately verified to reliably focus, confirming the flag has real effect. |
 | Session targeting for DESTRUCTIVE calls | `herdr session stop <name> --session <name> --json`, then `herdr session delete <name> --session <name> --json`; never `herdr server stop` | Used only through `tests/herdr-test-safety.sh`, which re-queries `herdr session list --json` before every destructive call. See "Session targeting" below - `HERDR_SESSION` alone is not reliably honored once another herdr server is already running on the machine. |

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -91,25 +91,21 @@ If an older live workspace is still labeled `firstmate-<secondmate-id>`, rename 
 Tab-per-task (within each home's own workspace) still wins on the human-watching axis for the reason P2 originally found: attaching once shows every one of that home's tasks as a tab in one tab bar, switchable with `ctrl+b <n>`, matching how a captain already watches a tmux-backed fleet.
 Workspace-per-task - tried against the real binary in P2 and again considered here - would still only show one task's workspace at a time by default, requiring a separate top-level "space" switch to see the rest of even a single home's fleet; that tradeoff is unchanged by the per-home refinement and workspace-per-task remains rejected.
 
-## Workspace lifecycle: one persistent `firstmate` workspace, reused
+## Workspace lifecycle: one persistent per-home workspace, reused
 
-The `firstmate` workspace is created once per session and reused by every subsequent spawn: `fm_backend_herdr_workspace_ensure` calls `fm_backend_herdr_workspace_find` first and creates a workspace only when no `firstmate`-labelled one exists.
+Each home's own workspace (`firstmate` for the primary, `2ndmate-<secondmate-id>` for a secondmate - see "Label derivation" above) is created once per session and reused by every subsequent spawn from that home: `fm_backend_herdr_workspace_ensure` calls `fm_backend_herdr_workspace_find` first and creates a workspace only when none labelled for that home exists yet.
 Teardown (`fm_backend_herdr_kill`) closes only the task's pane/tab, never the workspace.
 
 Reserved-keyword guard: never name a `jq --arg`/`--argjson` after a `jq` keyword (`label`, `and`, `or`, `not`, `if`, `then`, `else`, `end`, `reduce`, `foreach`, `import`, `def`, `as`, `__loc__`).
 jq <= 1.6 rejects a keyword-named `$`-variable as a compile error, and this adapter pipes `jq`'s stderr to `/dev/null`, so on jq <= 1.6 the error silently becomes an empty result rather than a visible failure.
-Use a distinct name such as `$want` instead; `tests/fm-backend.test.sh` greps `bin/` for this pattern so a new violation fails loudly rather than silently.
+Use a distinct name such as `$want` instead; `tests/fm-backend-herdr.test.sh` greps `bin/` for this pattern so a new violation fails loudly rather than silently.
 
 Default-tab prune: `herdr workspace create` seeds the new workspace with one auto-created default tab (label `1`) that firstmate never uses.
 `fm_backend_herdr_create_task` prunes it (best-effort, via `fm_backend_herdr_workspace_prune_default_tabs`) right after creating the first real task tab in a freshly created workspace, never earlier: closing a workspace's LAST tab deletes the whole workspace on real herdr, and immediately after creation the default tab is the only one present.
 
-Because closing a workspace's last tab deletes it, the `firstmate` workspace does not outlive a fully idle fleet (zero live tasks) - the next spawn's `workspace_find` simply finds nothing and recreates it. Reuse holds across concurrent and sequential tasks; it is not a guarantee that the workspace itself survives the whole session unconditionally.
+Because closing a workspace's last tab deletes it, a home's workspace does not outlive a fully idle fleet (zero live tasks for that home) - the next spawn's `workspace_find` simply finds nothing and recreates it. Reuse holds across concurrent and sequential tasks; it is not a guarantee that the workspace itself survives the whole session unconditionally.
 
-### Anomaly: a workspace labelled with a project name
-
-A workspace whose label is a project name (e.g. `python-teslemetry-stream`) rather than `firstmate` is **not** created by this adapter.
-Firstmate's adapter always creates its workspace with the fixed `--label firstmate` (`FM_BACKEND_HERDR_WORKSPACE_LABEL`) and never derives a label from the project.
-Such a workspace originates outside the adapter - herdr's own default/auto-created workspace for a session, or manual/agent activity - so firstmate leaves it untouched (`fm_backend_herdr_workspace_find` and `fm_backend_herdr_list_live` match only the `firstmate` label and `fm-` tab labels respectively, so a project-labelled workspace is neither reused nor torn down by firstmate).
+A workspace whose label this adapter did not derive (see "Label derivation" above) is never adopted, reused, or torn down by firstmate - `fm_backend_herdr_workspace_find` and `fm_backend_herdr_list_live` only ever match a home's own derived label.
 
 ## Target string and meta fields
 
@@ -138,7 +134,7 @@ Herdr tasks additionally record:
 | Send key | `herdr pane send-keys <pane> <key>` | Verified names: `enter`, `escape` (alias `esc`), `ctrl+c` (aliases `C-c`, `c-c`). `ctrl+c` verified to interrupt a running foreground process immediately. |
 | Bounded capture | `herdr pane read <pane> --source recent --lines N` | See "Verified bug" below - N is never passed through directly. |
 | Busy state | `herdr agent get <pane>` -> `.result.agent.agent_status` | Verified live against an interactive `claude` session: reports `working` while generating, `done` once idle. Mapped: `working` -> busy; `idle`/`done` -> idle; `blocked` -> idle (surfaced like a stale pane, not suppressed as busy - a blocked agent is stuck waiting on the human, not grinding); anything else -> unknown (the cue for the shared tail-regex fallback). |
-| Kill | `herdr pane close <pane>` | Closing a tab's only (root) pane also closes the tab - no separate tab-close call needed for this adapter's one-pane-per-tab shape. Best-effort: closing an already-closed pane exits non-zero, matching tmux's `kill-window \|\| true` contract. Teardown itself only ever closes the task's own pane/tab, never the workspace - but closing a workspace's LAST tab (verified real-herdr behavior) deletes the workspace as a side effect, so the `firstmate` workspace persists only while at least one task tab remains; see "Workspace lifecycle" above. |
+| Kill | `herdr pane close <pane>` | Closing a tab's only (root) pane also closes the tab - no separate tab-close call needed for this adapter's one-pane-per-tab shape. Best-effort: closing an already-closed pane exits non-zero, matching tmux's `kill-window \|\| true` contract. Teardown itself only ever closes the task's own pane/tab, never the workspace - but closing a workspace's LAST tab (verified real-herdr behavior) deletes the workspace as a side effect, so a home's own workspace persists only while at least one task tab remains; see "Workspace lifecycle" above. |
 | Default-tab prune (create_task, first task in a fresh workspace only) | `herdr tab list --workspace <id>`, then `herdr pane close <pane>` on the non-`fm-` default tab | `herdr workspace create` seeds the new workspace with one auto-created default tab (label `1`) firstmate never uses. `fm_backend_herdr_create_task` closes it right after creating the first real task tab in a freshly created workspace - never right after `workspace create` itself, because at that point the default tab is the workspace's ONLY tab and closing it would delete the whole workspace (see Kill row). Best-effort; a workspace being reused (not freshly created) never re-prunes. |
 | Recovery / list-live | `herdr tab list --workspace <id>`, filter labels starting with `fm-` | Label-based, never trusts a stored id blindly - see "ID stability" below. `<id>` is always THIS home's own workspace (`fm_backend_herdr_workspace_find`), so recovery never sees a sibling home's tabs. |
 | Workspace create / tab create (focus) | `herdr workspace create --no-focus`, `herdr tab create --no-focus` | Verified: neither focuses by default once a workspace already exists in the session, matching pre-P3 (flagless) behavior; `--no-focus` is passed anyway for defense in depth, since the very first workspace ever created in a brand-new session focuses regardless of the flag. `--focus` was separately verified to reliably focus, confirming the flag has real effect. |

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -91,6 +91,37 @@ If an older live workspace is still labeled `firstmate-<secondmate-id>`, rename 
 Tab-per-task (within each home's own workspace) still wins on the human-watching axis for the reason P2 originally found: attaching once shows every one of that home's tasks as a tab in one tab bar, switchable with `ctrl+b <n>`, matching how a captain already watches a tmux-backed fleet.
 Workspace-per-task - tried against the real binary in P2 and again considered here - would still only show one task's workspace at a time by default, requiring a separate top-level "space" switch to see the rest of even a single home's fleet; that tradeoff is unchanged by the per-home refinement and workspace-per-task remains rejected.
 
+## Workspace lifecycle: one persistent `firstmate` workspace, reused
+
+The `firstmate` workspace is created once per session and then reused by every subsequent spawn, exactly like tmux's session: `fm_backend_herdr_workspace_ensure` calls `fm_backend_herdr_workspace_find` first and creates a workspace only when no `firstmate`-labelled one exists.
+Teardown (`fm_backend_herdr_kill`) closes only the task's pane/tab; it never removes the workspace, so the workspace persists across the whole session and repeated spawn/teardown cycles never accumulate workspaces.
+
+### The workspace-leak bug (fixed) and its root cause
+
+An earlier version leaked one orphaned `firstmate` workspace per crewmate: every spawn minted a fresh workspace instead of reusing the existing one, so `herdr workspace list` filled up with many `label=firstmate` workspaces, most belonging to already-torn-down tasks.
+
+The root cause was a `jq` reserved-keyword collision, not a logic error in the find-or-create flow.
+`label` is a reserved keyword in `jq` (used by `label $out | ... break $out`), so a filter written as `jq --arg label "$X" '... select(.label == $label) ...'` is a **compile error**, not a match.
+`fm_backend_herdr_workspace_find` discarded `jq`'s stderr (`2>/dev/null`), so that error surfaced as empty output: the find silently returned nothing on every call, `workspace_ensure` always took the create path, and a new `firstmate` workspace was minted per spawn.
+The fix renames the `jq` variable to `$want` (a non-keyword) in the three affected filters - `fm_backend_herdr_workspace_find`, the `fm_backend_herdr_create_task` duplicate-tab check, and `fm_backend_herdr_resolve_bare_selector`.
+The same collision had also silently disabled the create-task duplicate-label check and the bare-selector tab lookup; both work again with the rename.
+
+Guard for future filters in this adapter: never name a `jq --arg` after a `jq` keyword (`label`, `and`, `or`, `not`, `if`, `then`, `else`, `end`, `reduce`, `foreach`, `import`, `def`, `as`, `__loc__`).
+Prefer a distinct name like `$want`.
+
+### The stray auto-created default tab
+
+`herdr workspace create` seeds the new workspace with one auto-created default tab (label `1`) that firstmate never uses.
+Without handling it, that tab lingered alongside the real `fm-<id>` task tab.
+`fm_backend_herdr_workspace_ensure` now prunes it right after creating the workspace (`fm_backend_herdr_workspace_prune_default_tabs`, best-effort), closing every non-`fm-` tab in the freshly created workspace - at that instant the default tab is the only tab present, so real task tabs are never at risk.
+Because reuse skips the create path, pruning runs at most once per session.
+
+### Anomaly: a workspace labelled with a project name
+
+A workspace whose label is a project name (e.g. `python-teslemetry-stream`) rather than `firstmate` is **not** created by this adapter.
+Firstmate's adapter always creates its workspace with the fixed `--label firstmate` (`FM_BACKEND_HERDR_WORKSPACE_LABEL`) and never derives a label from the project.
+Such a workspace originates outside the adapter - herdr's own default/auto-created workspace for a session, or manual/agent activity - so firstmate leaves it untouched (`fm_backend_herdr_workspace_find` and `fm_backend_herdr_list_live` match only the `firstmate` label and `fm-` tab labels respectively, so a project-labelled workspace is neither reused nor torn down by firstmate).
+
 ## Target string and meta fields
 
 A herdr task's `window=` meta field holds `<herdr-session>:<pane-id>`, for example `default:w1:p2`.
@@ -118,7 +149,8 @@ Herdr tasks additionally record:
 | Send key | `herdr pane send-keys <pane> <key>` | Verified names: `enter`, `escape` (alias `esc`), `ctrl+c` (aliases `C-c`, `c-c`). `ctrl+c` verified to interrupt a running foreground process immediately. |
 | Bounded capture | `herdr pane read <pane> --source recent --lines N` | See "Verified bug" below - N is never passed through directly. |
 | Busy state | `herdr agent get <pane>` -> `.result.agent.agent_status` | Verified live against an interactive `claude` session: reports `working` while generating, `done` once idle. Mapped: `working` -> busy; `idle`/`done` -> idle; `blocked` -> idle (surfaced like a stale pane, not suppressed as busy - a blocked agent is stuck waiting on the human, not grinding); anything else -> unknown (the cue for the shared tail-regex fallback). |
-| Kill | `herdr pane close <pane>` | Closing a tab's only (root) pane also closes the tab - no separate tab-close call needed for this adapter's one-pane-per-tab shape. Best-effort: closing an already-closed pane exits non-zero, matching tmux's `kill-window \|\| true` contract. |
+| Kill | `herdr pane close <pane>` | Closing a tab's only (root) pane also closes the tab - no separate tab-close call needed for this adapter's one-pane-per-tab shape. Best-effort: closing an already-closed pane exits non-zero, matching tmux's `kill-window \|\| true` contract. Teardown removes only the task's pane/tab; the `firstmate` workspace is persistent (like tmux's session) and is NOT removed - see "Workspace lifecycle" above. |
+| Default-tab prune (workspace create only) | `herdr tab list --workspace <id>`, then `herdr pane close <pane>` on each non-`fm-` tab | `herdr workspace create` seeds the new workspace with one auto-created default tab (label `1`) firstmate never uses. The adapter closes it right after creating the workspace so only real task tabs remain. Best-effort; runs on the create path only (reuse never re-prunes). |
 | Recovery / list-live | `herdr tab list --workspace <id>`, filter labels starting with `fm-` | Label-based, never trusts a stored id blindly - see "ID stability" below. `<id>` is always THIS home's own workspace (`fm_backend_herdr_workspace_find`), so recovery never sees a sibling home's tabs. |
 | Workspace create / tab create (focus) | `herdr workspace create --no-focus`, `herdr tab create --no-focus` | Verified: neither focuses by default once a workspace already exists in the session, matching pre-P3 (flagless) behavior; `--no-focus` is passed anyway for defense in depth, since the very first workspace ever created in a brand-new session focuses regardless of the flag. `--focus` was separately verified to reliably focus, confirming the flag has real effect. |
 | Session targeting for DESTRUCTIVE calls | `herdr session stop <name> --session <name> --json`, then `herdr session delete <name> --session <name> --json`; never `herdr server stop` | Used only through `tests/herdr-test-safety.sh`, which re-queries `herdr session list --json` before every destructive call. See "Session targeting" below - `HERDR_SESSION` alone is not reliably honored once another herdr server is already running on the machine. |

--- a/tests/fm-backend-herdr-smoke.test.sh
+++ b/tests/fm-backend-herdr-smoke.test.sh
@@ -231,6 +231,14 @@ pass "real herdr: kill removes the pane and is idempotent/best-effort"
 
 # --- list_live (label-based recovery discovery) ------------------------------
 
+# Real firstmate spawns always re-run container_ensure immediately before
+# create_task (bin/fm-spawn.sh), never reusing a container reference from an
+# earlier spawn. This test must do the same: the kill above closed the only
+# remaining tab in $CONTAINER's workspace, and closing a workspace's last tab
+# deletes the workspace itself (verified real-herdr behavior), so the stale
+# $CONTAINER from container_ensure at test start no longer names a live
+# workspace.
+CONTAINER=$(fm_backend_herdr_container_ensure /tmp) || fail "container_ensure for the second task failed"
 LABEL2="fm-smoke2"
 TASK_IDS2=$(fm_backend_herdr_create_task "$CONTAINER" "$LABEL2" /tmp) || fail "second create_task failed"
 read -r _TAB_ID2 PANE_ID2 <<EOF

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -751,6 +751,23 @@ EOF
   pass "herdr repeated spawn/teardown: one persistent firstmate workspace reused, zero orphans, default tab pruned, create ran once"
 }
 
+# test_no_jq_reserved_keyword_arg_names: regression guard for the
+# workspace-leak root cause (a jq `--arg`/`--argjson` named after a jq
+# reserved keyword, e.g. `label`, is a compile error on jq <= 1.6; this
+# adapter discards jq's stderr, so the error silently becomes an empty
+# result instead of a visible failure). Greps every bin/ script for the
+# pattern so a future filter reintroducing it fails loudly here instead of
+# silently misbehaving on an older jq.
+test_no_jq_reserved_keyword_arg_names() {
+  local reserved='and|as|catch|def|elif|else|end|foreach|if|import|include|label|module|or|reduce|then|try'
+  local hits
+  hits=$(grep -rnE -- "--arg(json)?[[:space:]]+($reserved)\b" "$ROOT/bin" 2>/dev/null)
+  if [ -n "$hits" ]; then
+    fail "a jq --arg/--argjson variable is named after a jq reserved keyword (compile error on jq <= 1.6, silently swallowed by 2>/dev/null):"$'\n'"$hits"
+  fi
+  pass "no bin/ jq filter names a --arg/--argjson variable after a jq reserved keyword"
+}
+
 # shellcheck source=bin/fm-backend.sh
 . "$ROOT/bin/fm-backend.sh"
 
@@ -769,6 +786,7 @@ test_container_ensure_creates_with_no_focus_flag
 test_container_ensure_uses_secondmate_home_label
 test_workspace_ensure_prunes_default_tab
 test_repeated_cycles_reuse_one_workspace_no_orphans
+test_no_jq_reserved_keyword_arg_names
 test_create_task_refuses_duplicate_label
 test_create_task_creates_and_parses_ids
 test_create_task_creates_with_no_focus_flag

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -55,6 +55,87 @@ SH
   printf '%s\n' "$fb"
 }
 
+# make_herdr_statefake: a STATEFUL `herdr` stub that models the parts of herdr's
+# real container behavior the workspace-leak fix depends on, so a full
+# spawn->teardown cycle can be replayed repeatedly and the "one persistent
+# firstmate workspace, no orphans" invariant asserted end to end (the canned,
+# call-numbered make_herdr_fakebin above cannot model state carried ACROSS
+# calls). Backed by a JSON state file ($FM_FAKE_HERDR_STATE) mutated with real
+# jq. Modeled behaviors, all verified real-herdr facts recorded in
+# docs/herdr-backend.md: `workspace create` seeds the new workspace with one
+# auto-created default tab (label "1"); `pane close` removes the pane's
+# single-pane tab (closing a tab's only pane closes the tab); `workspace list`
+# / `tab list` / `pane list` reflect live state. Every call is logged to
+# $FM_HERDR_LOG in the same unit-separated form as make_herdr_fakebin.
+make_herdr_statefake() {  # <dir> -> echoes fakebin dir; seeds an empty state file
+  local dir=$1 fb="$1/fakebin"
+  mkdir -p "$fb"
+  printf '{"next":1,"workspaces":[],"tabs":[]}\n' > "$dir/state.json"
+  cat > "$fb/herdr" <<'SH'
+#!/usr/bin/env bash
+set -u
+LOG="${FM_HERDR_LOG:?}"
+STATE="${FM_FAKE_HERDR_STATE:?}"
+{
+  printf 'HERDR_SESSION=%s' "${HERDR_SESSION:-}"
+  for a in "$@"; do printf '\x1f%s' "$a"; done
+  printf '\n'
+} >> "$LOG"
+
+jq_state() { jq "$@" "$STATE"; }
+save() { local tmp="$STATE.tmp.$$"; cat > "$tmp" && mv "$tmp" "$STATE"; }
+
+cmd=${1:-}; sub=${2:-}
+ws=""; label=""
+args=("$@")
+for ((i=0; i<${#args[@]}; i++)); do
+  case "${args[$i]}" in
+    --workspace) ws=${args[$((i+1))]:-} ;;
+    --label) label=${args[$((i+1))]:-} ;;
+  esac
+done
+
+case "$cmd $sub" in
+  "status --json")
+    printf '{"client":{"version":"0.7.1","protocol":14},"server":{"running":true}}\n'
+    ;;
+  "workspace list")
+    jq_state '{result:{workspaces:.workspaces}}'
+    ;;
+  "workspace create")
+    n=$(jq_state -r '.next'); wsid="w$n"; dn=$((n + 1))
+    jq_state --arg wsid "$wsid" --arg wlabel "$label" \
+      --arg tabid "$wsid:t$dn" --arg paneid "$wsid:p$dn" \
+      '.workspaces += [{workspace_id:$wsid, label:$wlabel}]
+       | .tabs += [{tab_id:$tabid, label:"1", workspace_id:$wsid, pane_id:$paneid}]
+       | .next = (.next + 2)' | save
+    printf '{"result":{"workspace":{"workspace_id":"%s","label":"%s"}}}\n' "$wsid" "$label"
+    ;;
+  "tab list")
+    jq_state --arg w "$ws" '{result:{tabs:[.tabs[]|select(.workspace_id==$w)]}}'
+    ;;
+  "tab create")
+    n=$(jq_state -r '.next'); tabid="$ws:t$n"; paneid="$ws:p$n"
+    jq_state --arg w "$ws" --arg wlabel "$label" --arg tabid "$tabid" --arg paneid "$paneid" \
+      '.tabs += [{tab_id:$tabid, label:$wlabel, workspace_id:$w, pane_id:$paneid}]
+       | .next = (.next + 1)' | save
+    printf '{"result":{"tab":{"tab_id":"%s"},"root_pane":{"pane_id":"%s"}}}\n' "$tabid" "$paneid"
+    ;;
+  "pane list")
+    jq_state --arg w "$ws" '{result:{panes:[.tabs[]|select(.workspace_id==$w)|{pane_id:.pane_id, tab_id:.tab_id}]}}'
+    ;;
+  "pane close")
+    pane=${3:-}
+    jq_state --arg p "$pane" '.tabs |= [.[]|select(.pane_id != $p)]' | save
+    ;;
+  *) : ;;
+esac
+exit 0
+SH
+  chmod +x "$fb/herdr"
+  printf '%s\n' "$fb"
+}
+
 # herdr_case <name> -> sets up FM_HERDR_LOG/FM_HERDR_RESPONSES/fb for one test,
 # registers cleanup-free tmp dirs under TMP_ROOT.
 herdr_env() {  # <name>
@@ -596,6 +677,65 @@ SH
   pass "fm-peek/fm-send: explicit stale targets matching metadata use the recorded backend"
 }
 
+# --- workspace lifecycle: reuse, no orphans, default-tab pruning -------------
+
+test_workspace_ensure_prunes_default_tab() {
+  local dir log state fb container wsid defcount
+  dir="$TMP_ROOT/prune-default"; mkdir -p "$dir"; log="$dir/log"; state="$dir/state.json"; : > "$log"
+  fb=$(make_herdr_statefake "$dir")
+  container=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_FAKE_HERDR_STATE="$state" HERDR_SESSION=fmtest \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_container_ensure /proj' "$ROOT" ) \
+    || fail "container_ensure failed against the stateful fake"
+  wsid=${container#*:}
+  # herdr seeds a fresh workspace with one auto-created default tab (label "1");
+  # the adapter must close it so the workspace holds only real task tabs.
+  defcount=$(jq -r --arg w "$wsid" '[.tabs[]|select(.workspace_id==$w)]|length' "$state")
+  [ "$defcount" = 0 ] || fail "the auto-created default tab should be pruned on workspace creation, $defcount tab(s) remain: $(jq -c '.tabs' "$state")"
+  assert_contains "$(cat "$log")" $'\x1f''pane'$'\x1f''close' "workspace_ensure did not close the default tab's pane"
+  pass "fm_backend_herdr_workspace_ensure: prunes herdr's auto-created default tab so only task tabs remain"
+}
+
+test_repeated_cycles_reuse_one_workspace_no_orphans() {
+  local dir log state fb i container wsid ids pane first_ws="" wscount total tabcount created
+  dir="$TMP_ROOT/cycles"; mkdir -p "$dir"; log="$dir/log"; state="$dir/state.json"; : > "$log"
+  fb=$(make_herdr_statefake "$dir")
+  for i in 1 2 3; do
+    container=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_FAKE_HERDR_STATE="$state" HERDR_SESSION=fmtest \
+      bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_container_ensure /proj' "$ROOT" ) \
+      || fail "cycle $i: container_ensure failed"
+    case "$container" in fmtest:w*) : ;; *) fail "cycle $i: unexpected container '$container'" ;; esac
+    wsid=${container#*:}
+    if [ -z "$first_ws" ]; then
+      first_ws=$wsid
+    else
+      [ "$wsid" = "$first_ws" ] || fail "cycle $i: workspace not reused ('$wsid' != '$first_ws')"
+    fi
+    ids=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_FAKE_HERDR_STATE="$state" HERDR_SESSION=fmtest \
+      bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_create_task "$1" "$2" /proj' "$ROOT" "$container" "fm-cycle$i" ) \
+      || fail "cycle $i: create_task failed"
+    read -r _ pane <<EOF
+$ids
+EOF
+    [ -n "$pane" ] || fail "cycle $i: create_task returned no pane id"
+    PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_FAKE_HERDR_STATE="$state" HERDR_SESSION=fmtest \
+      bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_kill "$1"' "$ROOT" "fmtest:$pane" \
+      || fail "cycle $i: kill failed"
+  done
+  # exactly one firstmate workspace survives three spawn/teardown cycles
+  wscount=$(jq -r '[.workspaces[]|select(.label=="firstmate")]|length' "$state")
+  [ "$wscount" = 1 ] || fail "expected exactly 1 firstmate workspace after 3 cycles, got $wscount: $(jq -c '.workspaces' "$state")"
+  # and no orphaned workspaces of any label
+  total=$(jq -r '.workspaces|length' "$state")
+  [ "$total" = 1 ] || fail "expected no orphaned workspaces after 3 cycles, got $total total: $(jq -c '.workspaces' "$state")"
+  # zero tabs remain: every fm- task tab torn down AND the default tab pruned
+  tabcount=$(jq -r '.tabs|length' "$state")
+  [ "$tabcount" = 0 ] || fail "expected 0 tabs after teardown (default tab pruned, task tabs killed), got $tabcount: $(jq -c '.tabs' "$state")"
+  # the workspace was minted once and reused thereafter, never re-created
+  created=$(grep -c $'\x1f''workspace'$'\x1f''create' "$log")
+  [ "$created" = 1 ] || fail "workspace create should run exactly once across 3 cycles (reuse, not re-mint), ran $created times"
+  pass "herdr repeated spawn/teardown: one persistent firstmate workspace reused, zero orphans, default tab pruned, create ran once"
+}
+
 # shellcheck source=bin/fm-backend.sh
 . "$ROOT/bin/fm-backend.sh"
 
@@ -612,6 +752,8 @@ test_container_ensure_starts_server_and_workspace
 test_container_ensure_reuses_existing_workspace
 test_container_ensure_creates_with_no_focus_flag
 test_container_ensure_uses_secondmate_home_label
+test_workspace_ensure_prunes_default_tab
+test_repeated_cycles_reuse_one_workspace_no_orphans
 test_create_task_refuses_duplicate_label
 test_create_task_creates_and_parses_ids
 test_create_task_creates_with_no_focus_flag

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -680,19 +680,34 @@ SH
 # --- workspace lifecycle: reuse, no orphans, default-tab pruning -------------
 
 test_workspace_ensure_prunes_default_tab() {
-  local dir log state fb container wsid defcount
+  local dir log state fb container wsid ids pane tabcount
   dir="$TMP_ROOT/prune-default"; mkdir -p "$dir"; log="$dir/log"; state="$dir/state.json"; : > "$log"
   fb=$(make_herdr_statefake "$dir")
   container=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_FAKE_HERDR_STATE="$state" HERDR_SESSION=fmtest \
     bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_container_ensure /proj' "$ROOT" ) \
     || fail "container_ensure failed against the stateful fake"
   wsid=${container#*:}
-  # herdr seeds a fresh workspace with one auto-created default tab (label "1");
-  # the adapter must close it so the workspace holds only real task tabs.
-  defcount=$(jq -r --arg w "$wsid" '[.tabs[]|select(.workspace_id==$w)]|length' "$state")
-  [ "$defcount" = 0 ] || fail "the auto-created default tab should be pruned on workspace creation, $defcount tab(s) remain: $(jq -c '.tabs' "$state")"
-  assert_contains "$(cat "$log")" $'\x1f''pane'$'\x1f''close' "workspace_ensure did not close the default tab's pane"
-  pass "fm_backend_herdr_workspace_ensure: prunes herdr's auto-created default tab so only task tabs remain"
+  # herdr seeds a fresh workspace with one auto-created default tab (label "1")
+  # and closing a workspace's LAST tab deletes the whole workspace on real
+  # herdr, so the adapter must not prune it until a real task tab exists
+  # alongside it - verify it is still present right after container_ensure.
+  tabcount=$(jq -r --arg w "$wsid" '[.tabs[]|select(.workspace_id==$w)]|length' "$state")
+  [ "$tabcount" = 1 ] || fail "expected the untouched default tab to remain after container_ensure alone, got $tabcount tab(s): $(jq -c '.tabs' "$state")"
+  ids=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_FAKE_HERDR_STATE="$state" HERDR_SESSION=fmtest \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_create_task "$1" "$2" /proj' "$ROOT" "$container" "fm-prunetest" ) \
+    || fail "create_task failed against the stateful fake"
+  read -r _ pane <<EOF
+$ids
+EOF
+  [ -n "$pane" ] || fail "create_task returned no pane id"
+  # Once the real task tab exists, create_task must prune the default tab so
+  # only the real task tab remains.
+  tabcount=$(jq -r --arg w "$wsid" '[.tabs[]|select(.workspace_id==$w)]|length' "$state")
+  [ "$tabcount" = 1 ] || fail "the auto-created default tab should be pruned once a real task tab exists, $tabcount tab(s) remain: $(jq -c '.tabs' "$state")"
+  jq -r --arg w "$wsid" '[.tabs[]|select(.workspace_id==$w)][0].label' "$state" | grep -qx 'fm-prunetest' \
+    || fail "the surviving tab should be the real task tab, not the default: $(jq -c '.tabs' "$state")"
+  assert_contains "$(cat "$log")" $'\x1f''pane'$'\x1f''close' "create_task did not close the default tab's pane"
+  pass "fm_backend_herdr_create_task: prunes herdr's auto-created default tab once the first real task tab exists"
 }
 
 test_repeated_cycles_reuse_one_workspace_no_orphans() {


### PR DESCRIPTION
## The leak

On the experimental **herdr** runtime backend, every crewmate left an orphaned herdr *workspace* behind. `herdr workspace list` steadily filled with many `label=firstmate` workspaces — effectively one per task, most belonging to already-torn-down crewmates. The documented design is one persistent `firstmate` workspace per session with one tab per task (mirroring tmux's one session / one window per task), so these should never accumulate.

## Root cause

Not a flaw in the find-or-create flow — a **`jq` reserved-keyword collision**.

`fm_backend_herdr_workspace_find` filtered with `jq --arg label "$X" '... select(.label == $label) ...'`. But `label` is a reserved keyword in `jq` (used by `label $out | … break $out`), so `$label` makes the whole filter a **compile error**, not a match. The function discarded `jq`'s stderr with `2>/dev/null`, so the error surfaced as empty output: the find returned nothing on every call, `fm_backend_herdr_workspace_ensure` always took the create path, and a fresh `firstmate` workspace was minted on every spawn.

The same collision silently disabled two other filters that used `$label`: the `create_task` duplicate-tab-label check and `resolve_bare_selector`'s tab lookup.

## The fix

- Rename the `jq` variable to `$want` (a non-keyword) in all three affected filters (`workspace_find`, the `create_task` duplicate check, `resolve_bare_selector`). Reuse, duplicate detection, and bare-selector lookup all work again.
- With reuse restored, the single `firstmate` workspace is **persistent** (like tmux's session). Teardown (`fm_backend_herdr_kill`) still closes only the task's pane/tab and correctly leaves the workspace in place — so repeated spawn/teardown cycles no longer accumulate workspaces. No workspace-deletion logic is needed.
- **Default tab:** `herdr workspace create` seeds a new workspace with an auto-created default tab (label `1`) firstmate never uses. `workspace_ensure` now prunes it (best-effort) right after creation, so the workspace holds only real `fm-<id>` task tabs.
- **Project-labelled-workspace anomaly** (e.g. a workspace labelled `python-teslemetry-stream`): the adapter always creates with the fixed `--label firstmate` and never derives a label from the project, so such a workspace is not adapter-created; firstmate matches only the `firstmate` label / `fm-` tab labels and leaves it untouched. Documented rather than "fixed".

## Tests

Extended `tests/fm-backend-herdr.test.sh` with a **stateful fake herdr CLI** that models herdr's real container behaviour (workspace-create seeds a default tab; `pane close` closes the tab; live `workspace/tab/pane list`). New assertions:

- repeated spawn→teardown cycles reuse a **single** `firstmate` workspace, leave **zero** orphaned workspaces, tear down every task tab, and invoke `workspace create` **exactly once**;
- the auto-created default tab is pruned on workspace creation.

The full existing suite passes (`bin/backends/herdr.sh` is shellcheck-clean).

**Real-CLI confirmation** (isolated `HERDR_SESSION`, guarded cleanup — never the `default` session): the pre-fix code failed the smoke idempotency check, minting a second workspace on the second `container_ensure` (`wE` then `wF`); the fixed code passes the real-herdr smoke test 9/9.

## Docs

`docs/herdr-backend.md` updated: the Kill row now states the workspace is persistent and not removed at teardown, plus a new default-tab-prune row and a "Workspace lifecycle" section covering the reuse model, the jq-keyword root cause and a guard against it, the default-tab handling, and the project-labelled-workspace anomaly.
