### PR TITLE
fix(bin): fix bash 3.2 heredoc and unbound-variable crashes in fm-brief/fm-pr-merge

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,12 @@ See the [no-mistakes quick start](https://kunchenguid.github.io/no-mistakes/star
   Each starts with a usage header comment; keep it accurate when you change behavior.
   Test scripts and helpers in `tests/` are plain bash too.
   `shellcheck bin/*.sh bin/backends/*.sh tests/*.sh` must pass, and CI enforces it.
+  Scripts must also run under bash 3.2, macOS's default `/bin/bash` (Apple ships this ancient version due to GPLv3 licensing).
+  CI runs on `ubuntu-latest` with a modern bash and will not catch a 3.2-only regression, so verify locally on macOS when touching quoting-sensitive constructs.
+  In particular, never write `VAR=$(cat <<EOF ... EOF)`.
+  Bash 3.2 has a parser bug where a heredoc nested inside a `$(...)` command substitution mis-scans a bare apostrophe in the body, hunting for a matching quote past the heredoc's own terminator until it hits a spurious "unexpected EOF" past real end-of-file.
+  Use `read -r -d '' VAR <<EOF ... EOF || true` instead; the trailing `|| true` absorbs `read`'s expected exit-1 from hitting EOF without its NUL delimiter.
+  This form is immune because the heredoc is a plain redirection target, not wrapped in a command substitution.
 - Changes to harness adapters (detection in `bin/fm-harness.sh`, launch and hook mechanics in `bin/fm-spawn.sh`, busy signatures in `bin/fm-watch.sh` and `bin/fm-tmux-lib.sh`, cleanup in `bin/fm-teardown.sh`, and facts in `.agents/skills/harness-adapters/SKILL.md`) must be verified empirically against the real harness, never written from documentation alone.
 - Changes to runtime session backends (`bin/fm-backend.sh`, `bin/backends/`, and the scripts that dispatch through them) need empirical adapter notes in the relevant docs, following `docs/herdr-backend.md` for non-tmux backends.
 - In Markdown, put each full sentence on its own line.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,8 @@ See the [no-mistakes quick start](https://kunchenguid.github.io/no-mistakes/star
   Bash 3.2 has a parser bug where a heredoc nested inside a `$(...)` command substitution mis-scans a bare apostrophe in the body, hunting for a matching quote past the heredoc's own terminator until it hits a spurious "unexpected EOF" past real end-of-file.
   Use `read -r -d '' VAR <<EOF ... EOF || true` instead; the trailing `|| true` absorbs `read`'s expected exit-1 from hitting EOF without its NUL delimiter.
   This form is immune because the heredoc is a plain redirection target, not wrapped in a command substitution.
+  Also, under `set -u`, bash 3.2 treats `"${arr[@]}"` on a possibly-empty array as an unbound-variable error, unlike bash 4.4+.
+  Guard it with `"${arr[@]+"${arr[@]}"}"` wherever the array can be empty.
 - Changes to harness adapters (detection in `bin/fm-harness.sh`, launch and hook mechanics in `bin/fm-spawn.sh`, busy signatures in `bin/fm-watch.sh` and `bin/fm-tmux-lib.sh`, cleanup in `bin/fm-teardown.sh`, and facts in `.agents/skills/harness-adapters/SKILL.md`) must be verified empirically against the real harness, never written from documentation alone.
 - Changes to runtime session backends (`bin/fm-backend.sh`, `bin/backends/`, and the scripts that dispatch through them) need empirical adapter notes in the relevant docs, following `docs/herdr-backend.md` for non-tmux backends.
 - In Markdown, put each full sentence on its own line.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -175,19 +175,21 @@ case "$MODE" in
   direct-PR)
     SETUP2=""
     RULE1='1. Never push to the default branch (push only your `fm/'"$ID"'` branch). Never merge a PR.'
-    DOD=$(cat <<EOF
+    # bash 3.2 (macOS default) mis-scans a bare apostrophe inside a heredoc
+    # nested in $(...), running past the heredoc's own EOF; read -d '' keeps
+    # the heredoc as a plain redirection target instead, which is immune.
+    read -r -d '' DOD <<EOF || true
 # Definition of done
 This project ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
 The task is complete only when committed on your branch.
 When it is implemented and committed, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\` to the status file and stop.
 Do NOT run /no-mistakes. The captain reviews and merges the PR; firstmate relays it.
 EOF
-)
     ;;
   local-only)
     SETUP2=""
     RULE1="1. Never push to any remote and never open a PR. Work only on your \`fm/$ID\` branch; firstmate handles the merge into local \`main\`."
-    DOD=$(cat <<EOF
+    read -r -d '' DOD <<EOF || true
 # Definition of done
 This project ships **local-only**: no remote, no PR, no pipeline.
 The task is complete only when committed on your branch \`fm/$ID\`. Do NOT push, do NOT open a PR, do NOT merge.
@@ -195,13 +197,12 @@ Keep your branch a clean fast-forward onto the current default branch - if \`mai
 When it is implemented and committed, append \`done: ready in branch fm/$ID\` to the status file and stop.
 Firstmate then reviews your branch diff, the captain approves, and firstmate merges it into local \`main\`.
 EOF
-)
     ;;
   *)  # no-mistakes (default)
     SETUP2="
 2. Run \`no-mistakes doctor\`; if it reports the repo is not initialized here, run \`no-mistakes init\`."
     RULE1='1. Never push to the default branch. Never merge a PR.'
-    DOD=$(cat <<EOF
+    read -r -d '' DOD <<EOF || true
 # Definition of done
 The task is complete only when committed on your branch.
 When you believe it is complete, append \`done: {summary}\` to the status file and stop.
@@ -218,7 +219,6 @@ Two firstmate-specific rules layer on top of that guidance:
 
 After /no-mistakes reports CI green, append \`done: PR {url} checks green\` and stop. You are finished.
 EOF
-)
     ;;
 esac
 

--- a/bin/fm-pr-merge.sh
+++ b/bin/fm-pr-merge.sh
@@ -87,4 +87,4 @@ if ! caller_has_merge_method "$@"; then
   merge_args=(--squash)
 fi
 
-gh-axi pr merge "$PR_NUMBER" --repo "$PR_OWNER/$PR_REPO" "${merge_args[@]}" "$@"
+gh-axi pr merge "$PR_NUMBER" --repo "$PR_OWNER/$PR_REPO" "${merge_args[@]+"${merge_args[@]}"}" "$@"


### PR DESCRIPTION
## Intent

Fixes bin/fm-brief.sh crashing on macOS's default bash 3.2.57 with "unexpected EOF while looking for matching `''" when scaffolding a no-mistakes-mode ship brief. Root cause: bash 3.2 mis-scans a bare apostrophe inside a heredoc nested in $(...) command substitution. Replaced the affected VAR=$(cat <<EOF ... EOF) assignments with read -r -d '' VAR <<EOF ... EOF || true, which keeps the heredoc as a plain redirection target rather than wrapping it in a command substitution. Also documents the pattern as a CONTRIBUTING.md convention, and fixes a related pre-existing bash-3.2 empty-array-under-set -u unbound-variable bug surfaced by the pipeline's own test suite in fm-pr-merge.sh/fm-spawn.sh. Verified against real bash 3.2.57: all five brief modes (no-mistakes, direct-PR, local-only, --scout, --secondmate) scaffold correctly; existing tests/fm-secondmate-safety.test.sh and tests/fm-tangle-guard.test.sh (which exercise fm-brief.sh's default path) fail without the fix and pass with it.

## What Changed
- `bin/fm-brief.sh`: replaced `VAR=$(cat <<EOF ... EOF)` heredoc-in-command-substitution assignments with `read -r -d '' VAR <<EOF ... EOF || true`, avoiding a bash 3.2 parser bug that crashes with "unexpected EOF while looking for matching `''" when the heredoc body contains a bare apostrophe.
- `bin/fm-pr-merge.sh`: guarded an empty-array expansion (`"${merge_args[@]}"`) under `set -u` so it no longer trips "unbound variable" on bash 3.2.
- `CONTRIBUTING.md`: documented the bash 3.2 empty-array/heredoc-in-command-substitution pitfalls as a contributor convention to prevent regressions.

## Risk Assessment

✅ Low: The change mechanically replaces `VAR=$(cat <<EOF ... EOF)` with the equivalent `read -r -d '' VAR <<EOF ... EOF || true` (verified faithful: same content, same trailing-newline stripping, all instances converted) and adds a matching empty-array unbound-var guard consistent with existing usage elsewhere in the codebase; documentation update accurately describes both pitfalls.

## Testing

Reproduced both root-cause bash-3.2 bugs from scratch on this machine's real bash 3.2.57 (the exact "unexpected EOF while looking for matching `''" heredoc-in-$(...) crash and the set -u empty-array unbound-variable crash), confirmed the target commit's read -r -d '' and ${arr[@]+"${arr[@]}"} rewrites eliminate both, and ran the tests named in the intent (fm-brief.test.sh, fm-secondmate-safety.test.sh, fm-tangle-guard.test.sh) plus fm-pr-merge.test.sh, all passing cleanly on target under bash 3.2.57; the configured full suite had already passed as baseline and a fresh full re-run was still in progress in the background at report time. No findings.

<details>
<summary>Evidence: bash 3.2.57 repro: apostrophe-in-heredoc-in-$(...) crash (pre-fix pattern)</summary>

```text
$ bash --version
GNU bash, version 3.2.57(1)-release (arm64-apple-darwin25)
$ cat /tmp/repro.sh
RULE1='1. Do not push (push only your `fm/'"ABC"'` branch). Never merge.'
DOD=$(cat <<EOF
# Definition of done
The captain's decision matters here.
Use \`no-mistakes\` when needed.
EOF
)
$ bash /tmp/repro.sh
/tmp/repro.sh: line 6: unexpected EOF while looking for matching `''
exit=2
```
</details>
<details>
<summary>Evidence: Same script rewritten with the fix&#39;s read -r -d &#39;&#39; pattern: no crash</summary>

```text
$ cat /tmp/repro3.sh
read -r -d '' DOD <<EOF || true
# Definition of done
The captain's decision matters here.
Use \`no-mistakes\` when needed.
EOF
$ bash /tmp/repro3.sh
DOD=# Definition of done
The captain's decision matters here.
Use `no-mistakes` when needed.
done
exit=0
```
</details>
<details>
<summary>Evidence: bash 3.2.57 repro: set -u unbound-variable on empty array (fm-pr-merge.sh pre-fix pattern) vs fixed guard</summary>

```text
$ merge_args=(); echo "${merge_args[@]}" # under set -eu
.../repro_arr.sh: line 5: merge_args[@]: unbound variable (exit 1)

$ merge_args=(); echo "${merge_args[@]+"${merge_args[@]}"}" # fixed guard, under set -eu
args: (exit 0)
```
</details>
<details>
<summary>Evidence: tests/fm-brief.test.sh on target (792cbf7) under real bash 3.2.57</summary>

```text
ok - fm-brief.sh: bash -n succeeds
ok - fm-brief.sh: no-mistakes/direct-PR/local-only briefs generate cleanly
ok - fm-brief.sh: no-mistakes DOD wording avoids the apostrophe regression
exit=0
```
</details>
<details>
<summary>Evidence: tests/fm-secondmate-safety.test.sh and tests/fm-tangle-guard.test.sh (named in user intent) plus fm-pr-merge.test.sh</summary>

```text
fm-secondmate-safety.test.sh: 49 ok, 0 not-ok, exit=0
fm-tangle-guard.test.sh: 5 ok, 0 not-ok, exit=0
fm-pr-merge.test.sh: 10 ok, 0 not-ok, exit=0 (includes 'forwards extra flags ... after the -- separator' which exercises the empty merge_args[] path)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- `bash --version (confirmed real bash 3.2.57, macOS default /bin/bash, is the interpreter for all tests in this environment)`
- <code>Minimal repro: VAR=$(cat &lt;&lt;EOF ... apostrophe in body ... EOF) crashes with &#39;unexpected EOF while looking for matching `&#39;&#39;&#39; under bash 3.2.57</code>
- `Same content rewritten as read -r -d '' VAR <<EOF ... EOF || true: exits 0, no crash`
- `Minimal repro: merge_args=(); "${merge_args[@]}" under set -eu crashes with 'unbound variable' under bash 3.2.57; "${merge_args[@]+"${merge_args[@]}"}" guard fixes it`
- `bash tests/fm-brief.test.sh on target commit 792cbf7 (real bash 3.2.57): 3/3 pass`
- `bash tests/fm-secondmate-safety.test.sh on target: 49/49 pass`
- `bash tests/fm-tangle-guard.test.sh on target: 5/5 pass`
- `bash tests/fm-pr-merge.test.sh on target: 10/10 pass (includes the extra-merge-args-forwarded case that exercises the empty merge_args[] path)`
- `bash -n bin/fm-brief.sh, bash -n bin/fm-pr-merge.sh, bash -n bin/fm-spawn.sh all pass on target`
- `Ran base commit (1ff50b1) fm-brief.test.sh via a temporary detached worktree for comparison; confirmed base's own DOD heredoc text happened not to contain a literal apostrophe (so it didn't trip the latent bug at that exact revision), which is why the fix is a structural/preventive change rather than a one-off text edit — verified by injecting a representative apostrophe into the old pattern and reproducing the crash`
- `Started the full configured suite (for t in tests/*.test.sh; do bash "$t"; done) in the background under real bash 3.2.57; it was still progressing through the tmux e2e suite when this report was finalized`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
