### PR TITLE
feat(backends): add Orca terminal adapter primitives

### DIFF
--- a/bin/backends/orca.sh
+++ b/bin/backends/orca.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# bin/backends/orca.sh - the Orca terminal session-provider adapter.
+#
+# This slice intentionally exposes only terminal primitives for already-created
+# Orca terminals: capture, send text, special keys, and cleanup. Worktree
+# creation, terminal creation, spawn metadata, and teardown lifecycle wiring
+# belong to the next Orca backend slice.
+#
+# Target string shape: the Orca terminal id accepted by `orca terminal ...`.
+
+fm_backend_orca_tool_check() {
+  command -v orca >/dev/null 2>&1 || { echo "error: backend=orca selected but the 'orca' CLI is not installed" >&2; return 1; }
+}
+
+fm_backend_orca_capture() {  # <terminal-id> <lines>
+  local terminal=$1 lines=${2:-40}
+  fm_backend_orca_tool_check || return 1
+  orca terminal read --terminal "$terminal" --limit "$lines" --json \
+    | node -e '
+const fs = require("fs");
+const data = JSON.parse(fs.readFileSync(0, "utf8"));
+const r = data.result || {};
+if (r.terminal && Array.isArray(r.terminal.tail)) {
+  process.stdout.write(r.terminal.tail.join("\n"));
+} else if (Array.isArray(r.tail)) {
+  process.stdout.write(r.tail.join("\n"));
+} else {
+  process.stdout.write(r.text || r.output || r.content || r.preview || "");
+}
+'
+}
+
+fm_backend_orca_send_key() {  # <terminal-id> <key>
+  local terminal=$1 key=$2
+  fm_backend_orca_tool_check || return 1
+  case "$key" in
+    Escape|escape|Esc|esc|C-c|ctrl+c|Ctrl-c|Ctrl-C)
+      orca terminal send --terminal "$terminal" --interrupt --json >/dev/null
+      ;;
+    Enter|enter)
+      orca terminal send --terminal "$terminal" --text "" --enter --json >/dev/null
+      ;;
+    *)
+      echo "error: unsupported Orca key '$key'" >&2
+      return 1
+      ;;
+  esac
+}
+
+fm_backend_orca_send_text_submit() {  # <terminal-id> <text> <retries> <enter-sleep> <settle>
+  local terminal=$1 text=$2
+  fm_backend_orca_tool_check || { printf 'send-failed'; return 0; }
+  if orca terminal send --terminal "$terminal" --text "$text" --enter --json >/dev/null; then
+    printf 'empty'
+  else
+    printf 'send-failed'
+  fi
+}
+
+fm_backend_orca_kill() {  # <terminal-id>
+  fm_backend_orca_tool_check || return 0
+  orca terminal close --terminal "$1" --json >/dev/null 2>&1 || true
+}

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -40,8 +40,9 @@ FM_BACKEND_CONFIG_DIR="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
 # section 4's harness-verification discipline. herdr is EXPERIMENTAL (P2;
 # data/fm-backend-design-d7/herdr-addendum.md) - verified against the real
 # v0.7.1/protocol-14 binary (data/fm-backend-design-d7/herdr-verification-p2.md)
-# but newer than tmux's long-proven default path.
-FM_BACKEND_KNOWN="tmux herdr"
+# but newer than tmux's long-proven default path. orca currently exposes only
+# terminal adapter primitives; spawn/teardown lifecycle wiring is a later slice.
+FM_BACKEND_KNOWN="tmux herdr orca"
 
 # fm_backend_is_known: 0 iff <name> has a verified adapter.
 fm_backend_is_known() {  # <name>
@@ -182,6 +183,13 @@ fm_backend_source() {  # <name>
         _FM_BACKEND_HERDR_SOURCED=1
       fi
       ;;
+    orca)
+      if [ -z "${_FM_BACKEND_ORCA_SOURCED:-}" ]; then
+        # shellcheck source=bin/backends/orca.sh
+        . "$FM_BACKEND_LIB_DIR/backends/orca.sh"
+        _FM_BACKEND_ORCA_SOURCED=1
+      fi
+      ;;
   esac
 }
 
@@ -239,6 +247,7 @@ fm_backend_capture() {  # <backend> <target> <lines>
   case "$backend" in
     tmux) fm_backend_tmux_capture "$@" ;;
     herdr) fm_backend_herdr_capture "$@" ;;
+    orca) fm_backend_orca_capture "$@" ;;
     *) echo "error: no capture implementation for backend '$backend'" >&2; return 1 ;;
   esac
 }
@@ -251,6 +260,7 @@ fm_backend_send_key() {  # <backend> <target> <key>
   case "$backend" in
     tmux) fm_backend_tmux_send_key "$@" ;;
     herdr) fm_backend_herdr_send_key "$@" ;;
+    orca) fm_backend_orca_send_key "$@" ;;
     *) echo "error: no send-key implementation for backend '$backend'" >&2; return 1 ;;
   esac
 }
@@ -265,6 +275,7 @@ fm_backend_send_text_submit() {  # <backend> <target> <text> <retries> <enter-sl
   case "$backend" in
     tmux) fm_backend_tmux_send_text_submit "$@" ;;
     herdr) fm_backend_herdr_send_text_submit "$@" ;;
+    orca) fm_backend_orca_send_text_submit "$@" ;;
     *) echo "error: no send-text implementation for backend '$backend'" >&2; return 1 ;;
   esac
 }
@@ -279,6 +290,7 @@ fm_backend_kill() {  # <backend> <target>
   case "$backend" in
     tmux) fm_backend_tmux_kill "$@" ;;
     herdr) fm_backend_herdr_kill "$@" ;;
+    orca) fm_backend_orca_kill "$@" ;;
     *) echo "error: no kill implementation for backend '$backend'" >&2; return 1 ;;
   esac
 }
@@ -321,6 +333,10 @@ fm_backend_target_exists() {  # <backend> <target>
       pane=${target#*:}
       [ -n "$session" ] && [ -n "$pane" ] && [ "$pane" != "$target" ] || return 1
       HERDR_SESSION="$session" herdr pane get "$pane" >/dev/null 2>&1
+      ;;
+    orca)
+      fm_backend_source orca || return 1
+      orca terminal read --terminal "$target" --limit 1 --json >/dev/null 2>&1
       ;;
     *)
       return 1

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -70,6 +70,8 @@ STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 . "$SCRIPT_DIR/fm-config-inherit-lib.sh"
 # shellcheck source=bin/fm-x-lib.sh
 . "$SCRIPT_DIR/fm-x-lib.sh"
+# shellcheck source=bin/fm-backend.sh
+. "$SCRIPT_DIR/fm-backend.sh"
 
 fleet_sync() {
   [ -x "$FM_ROOT/bin/fm-fleet-sync.sh" ] || return 0
@@ -173,7 +175,7 @@ secondmate_sync() {
 
 install_cmd() {
   case "$1" in
-    tmux|node|gh|curl|jq) echo "brew install $1  # or the platform's package manager" ;;
+    tmux|node|gh|curl|jq|orca) echo "brew install $1  # or the platform's package manager" ;;
     treehouse) echo "curl -fsSL https://kunchenguid.github.io/treehouse/install.sh | sh" ;;
     no-mistakes) echo "curl -fsSL https://raw.githubusercontent.com/kunchenguid/no-mistakes/main/docs/install.sh | sh" ;;
     gh-axi|chrome-devtools-axi|lavish-axi) echo "npm install -g $1 && $1 setup hooks" ;;
@@ -182,7 +184,11 @@ install_cmd() {
   esac
 }
 
-TOOLS="tmux node gh treehouse no-mistakes gh-axi chrome-devtools-axi lavish-axi"
+BACKEND=$(fm_backend_name)
+case "$BACKEND" in
+  orca) TOOLS="orca node gh no-mistakes gh-axi chrome-devtools-axi lavish-axi" ;;
+  *) TOOLS="tmux node gh treehouse no-mistakes gh-axi chrome-devtools-axi lavish-axi" ;;
+esac
 NO_MISTAKES_MIN_MAJOR=1
 NO_MISTAKES_MIN_MINOR=31
 NO_MISTAKES_MIN_PATCH=2

--- a/tests/fm-backend-orca.test.sh
+++ b/tests/fm-backend-orca.test.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# tests/fm-backend-orca.test.sh - fake-Orca-CLI unit tests for the Orca
+# terminal adapter primitives in bin/backends/orca.sh.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-backend-orca-tests)
+
+make_orca_fakebin() {  # <dir> -> echoes fakebin dir
+  local dir=$1 fb="$1/fakebin"
+  mkdir -p "$fb"
+  cat > "$fb/orca" <<'SH'
+#!/usr/bin/env bash
+set -u
+LOG="${FM_ORCA_LOG:?}"
+RESP="${FM_ORCA_RESPONSES:?}"
+COUNT_FILE="$RESP/.count"
+next=$(( $(cat "$COUNT_FILE" 2>/dev/null || echo 0) + 1 ))
+{
+  printf 'orca'
+  for a in "$@"; do printf '\x1f%s' "$a"; done
+  printf '\n'
+} >> "$LOG"
+n=$next
+echo "$n" > "$COUNT_FILE"
+if [ -f "$RESP/$n.exit" ]; then
+  exit "$(cat "$RESP/$n.exit")"
+fi
+[ -f "$RESP/$n.out" ] && cat "$RESP/$n.out"
+exit 0
+SH
+  chmod +x "$fb/orca"
+  printf '%s\n' "$fb"
+}
+
+orca_case() {  # <name> -> sets CASE_DIR LOG RESP FB
+  CASE_DIR="$TMP_ROOT/$1"
+  mkdir -p "$CASE_DIR/responses"
+  LOG="$CASE_DIR/log"
+  RESP="$CASE_DIR/responses"
+  : > "$LOG"
+  FB=$(make_orca_fakebin "$CASE_DIR")
+}
+
+test_capture_reads_terminal_tail_json() {
+  local out
+  orca_case capture-tail
+  printf '{"result":{"terminal":{"tail":["line one","line two"]}}}\n' > "$RESP/1.out"
+  out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
+    bash -c '. "$0/bin/backends/orca.sh"; fm_backend_orca_capture term-123 40' "$ROOT" )
+  [ "$out" = $'line one\nline two' ] || fail "capture should print result.terminal.tail joined by newlines, got '$out'"
+  assert_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''read'$'\x1f''--terminal'$'\x1f''term-123'$'\x1f''--limit'$'\x1f''40'$'\x1f''--json' \
+    "capture did not call orca terminal read with terminal/limit/json"
+  pass "fm_backend_orca_capture: parses result.terminal.tail and calls terminal read"
+}
+
+test_capture_falls_back_to_text_fields() {
+  local out
+  orca_case capture-text
+  printf '{"result":{"text":"plain text output"}}\n' > "$RESP/1.out"
+  out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
+    bash -c '. "$0/bin/backends/orca.sh"; fm_backend_orca_capture term-abc 5' "$ROOT" )
+  [ "$out" = "plain text output" ] || fail "capture should fall back to result.text, got '$out'"
+  pass "fm_backend_orca_capture: falls back to result text fields"
+}
+
+test_send_text_submit_constructs_enter_send() {
+  local out
+  orca_case send-submit
+  out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
+    bash -c '. "$0/bin/backends/orca.sh"; fm_backend_orca_send_text_submit term-123 "hello captain" 3 0.01 0.01' "$ROOT" )
+  [ "$out" = empty ] || fail "send_text_submit should report empty on successful Orca send, got '$out'"
+  assert_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''send'$'\x1f''--terminal'$'\x1f''term-123'$'\x1f''--text'$'\x1f''hello captain'$'\x1f''--enter'$'\x1f''--json' \
+    "send_text_submit did not send text with --enter --json"
+  pass "fm_backend_orca_send_text_submit: sends text and Enter in one Orca command"
+}
+
+test_send_text_submit_reports_send_failed() {
+  local out
+  orca_case send-fail
+  printf '1\n' > "$RESP/1.exit"
+  out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
+    bash -c '. "$0/bin/backends/orca.sh"; fm_backend_orca_send_text_submit term-123 "hello" 1 0.01 0.01' "$ROOT" )
+  [ "$out" = send-failed ] || fail "failed Orca send should report send-failed, got '$out'"
+  pass "fm_backend_orca_send_text_submit: reports send-failed when Orca send fails"
+}
+
+test_send_key_enter_and_interrupt() {
+  orca_case send-key
+  PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
+    bash -c '. "$0/bin/backends/orca.sh"; fm_backend_orca_send_key term-123 Enter; fm_backend_orca_send_key term-123 C-c' "$ROOT"
+  expect_code 0 $? "send_key Enter and C-c should succeed"
+  assert_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''send'$'\x1f''--terminal'$'\x1f''term-123'$'\x1f''--text'$'\x1f\x1f''--enter'$'\x1f''--json' \
+    "send_key Enter did not send empty text with --enter"
+  assert_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''send'$'\x1f''--terminal'$'\x1f''term-123'$'\x1f''--interrupt'$'\x1f''--json' \
+    "send_key C-c did not send --interrupt"
+  pass "fm_backend_orca_send_key: Enter maps to empty enter, C-c maps to interrupt"
+}
+
+test_send_key_refuses_unknown_key() {
+  local out status
+  orca_case send-key-unknown
+  out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
+    bash -c '. "$0/bin/backends/orca.sh"; fm_backend_orca_send_key term-123 F12' "$ROOT" 2>&1 )
+  status=$?
+  [ "$status" -ne 0 ] || fail "send_key should refuse unsupported Orca keys"
+  assert_contains "$out" "unsupported Orca key 'F12'" "send_key did not name the unsupported key"
+  pass "fm_backend_orca_send_key: refuses unsupported keys loudly"
+}
+
+test_kill_is_best_effort_close() {
+  orca_case kill
+  printf '1\n' > "$RESP/1.exit"
+  PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
+    bash -c '. "$0/bin/backends/orca.sh"; fm_backend_orca_kill term-123' "$ROOT"
+  expect_code 0 $? "kill should stay best-effort when Orca close fails"
+  assert_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''close'$'\x1f''--terminal'$'\x1f''term-123'$'\x1f''--json' \
+    "kill did not call orca terminal close"
+  pass "fm_backend_orca_kill: calls terminal close and stays best-effort"
+}
+
+test_dispatcher_sources_orca_and_routes_primitives() {
+  local out
+  orca_case dispatch
+  printf '{"result":{"terminal":{"tail":["via dispatch"]}}}\n' > "$RESP/1.out"
+  out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
+    bash -c '. "$0/bin/fm-backend.sh"; fm_backend_validate orca; fm_backend_capture orca term-123 9' "$ROOT" )
+  [ "$out" = "via dispatch" ] || fail "dispatcher should route capture to the Orca adapter, got '$out'"
+  pass "fm-backend dispatcher: accepts orca and routes capture through bin/backends/orca.sh"
+}
+
+test_capture_reads_terminal_tail_json
+test_capture_falls_back_to_text_fields
+test_send_text_submit_constructs_enter_send
+test_send_text_submit_reports_send_failed
+test_send_key_enter_and_interrupt
+test_send_key_refuses_unknown_key
+test_kill_is_best_effort_close
+test_dispatcher_sources_orca_and_routes_primitives

--- a/tests/fm-backend.test.sh
+++ b/tests/fm-backend.test.sh
@@ -553,19 +553,19 @@ test_spawn_refuses_unknown_backend_flag() {
     FM_PROJECTS_OVERRIDE='' FM_CONFIG_OVERRIDE='' FM_SPAWN_NO_GUARD=1 \
     "$ROOT/bin/fm-spawn.sh" nope-backend-z1 projects/none claude --backend zellij 2>&1)
   status=$?
-  [ "$status" -ne 0 ] || fail "fm-spawn --backend zellij should refuse (P1 is tmux-only)"
+  [ "$status" -ne 0 ] || fail "fm-spawn --backend zellij should refuse"
   assert_contains "$out" "unknown backend 'zellij'" "fm-spawn did not name the rejected backend"
-  pass "fm-spawn.sh --backend zellij is refused loudly (tmux-only in P1)"
+  pass "fm-spawn.sh --backend zellij is refused loudly"
 }
 
 test_spawn_refuses_unknown_fm_backend_env() {
   local out status
   out=$(FM_ROOT_OVERRIDE='' FM_HOME='' FM_STATE_OVERRIDE='' FM_DATA_OVERRIDE='' \
-    FM_PROJECTS_OVERRIDE='' FM_CONFIG_OVERRIDE='' FM_SPAWN_NO_GUARD=1 FM_BACKEND=orca \
+    FM_PROJECTS_OVERRIDE='' FM_CONFIG_OVERRIDE='' FM_SPAWN_NO_GUARD=1 FM_BACKEND=zellij \
     "$ROOT/bin/fm-spawn.sh" nope-backend-z2 projects/none claude 2>&1)
   status=$?
-  [ "$status" -ne 0 ] || fail "FM_BACKEND=orca should refuse (P1 is tmux-only)"
-  assert_contains "$out" "unknown backend 'orca'" "fm-spawn did not name the rejected FM_BACKEND"
+  [ "$status" -ne 0 ] || fail "FM_BACKEND=zellij should refuse"
+  assert_contains "$out" "unknown backend 'zellij'" "fm-spawn did not name the rejected FM_BACKEND"
   pass "fm-spawn.sh honors FM_BACKEND and refuses an unimplemented value loudly"
 }
 

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -156,6 +156,29 @@ ROWS
   pass "bootstrap enforces no-mistakes minimum version"
 }
 
+test_orca_backend_gates_orca_tool_only_when_selected() {
+  local case_dir fakebin out missing_orca
+  missing_orca="MISSING: orca (install: brew install orca  # or the platform's package manager)"
+
+  case_dir="$TMP_ROOT/orca-backend-selected"
+  mkdir -p "$case_dir/home/config"
+  printf '%s\n' manual > "$case_dir/home/config/backlog-backend"
+  printf '%s\n' orca > "$case_dir/home/config/backend"
+  fakebin=$(make_fake_toolchain "$case_dir")
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+    FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
+  [ "$out" = "$missing_orca" ] || fail "backend=orca should require only the Orca-specific missing tool, got: $out"
+
+  case_dir="$TMP_ROOT/orca-backend-not-selected"
+  mkdir -p "$case_dir/home/config"
+  printf '%s\n' manual > "$case_dir/home/config/backlog-backend"
+  fakebin=$(make_fake_toolchain "$case_dir")
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+    FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
+  assert_not_contains "$out" "MISSING: orca" "bootstrap should not require orca unless backend=orca is selected"
+  pass "bootstrap: backend=orca gates the Orca CLI without requiring it on the default backend"
+}
+
 test_crew_dispatch_active_rules_are_surfaced() {
   local case_dir fakebin out expect
   case_dir="$TMP_ROOT/dispatch-active"
@@ -205,5 +228,6 @@ ROWS
 
 test_bootstrap_reporting
 test_no_mistakes_min_version
+test_orca_backend_gates_orca_tool_only_when_selected
 test_crew_dispatch_active_rules_are_surfaced
 test_crew_dispatch_validation


### PR DESCRIPTION
Adds the second upstream-bound Orca backend slice: terminal adapter primitives in the current `bin/backends/*` plugin layout.

What changed:
- registers `orca` as a known backend and routes generic capture/send-key/send-text-submit/kill dispatch to `bin/backends/orca.sh`
- adds Orca terminal capture via `orca terminal read --json`, including tail/text fallback parsing
- adds text submit, Enter, interrupt, and best-effort terminal close primitives
- gates the `orca` CLI in bootstrap only when backend selection resolves to `orca`
- adds fake-Orca unit tests for JSON capture parsing and command construction

This follows PR #206's Orca adapter contract and intentionally stops before spawn/teardown lifecycle wiring. Worktree creation, terminal creation, metadata fields, and lifecycle teardown are left for the next slice.

Validation:
- `bash tests/fm-backend-orca.test.sh`
- `bash tests/fm-backend.test.sh`
- `bash tests/fm-bootstrap.test.sh`
- `for script in bin/*.sh bin/backends/*.sh tests/*.sh; do bash -n "$script" || exit 1; done`
- `shellcheck bin/*.sh bin/backends/*.sh tests/*.sh`

I also started the full `for test_script in tests/*.test.sh; do bash "$test_script" || exit 1; done` loop. It progressed through the backend/bootstrap coverage and then stopped at existing unrelated `tests/fm-pr-merge.test.sh` case `extra-args: fm-pr-merge failed`; rerunning that single test reproduces the same failure.