### PR TITLE
docs: document Orca backend adapter contract

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ See the [no-mistakes quick start](https://kunchenguid.github.io/no-mistakes/star
   Test scripts and helpers in `tests/` are plain bash too.
   `shellcheck bin/*.sh bin/backends/*.sh tests/*.sh` must pass, and CI enforces it.
 - Changes to harness adapters (detection in `bin/fm-harness.sh`, launch and hook mechanics in `bin/fm-spawn.sh`, busy signatures in `bin/fm-watch.sh` and `bin/fm-tmux-lib.sh`, cleanup in `bin/fm-teardown.sh`, and facts in `.agents/skills/harness-adapters/SKILL.md`) must be verified empirically against the real harness, never written from documentation alone.
-- Changes to runtime session backends (`bin/fm-backend.sh`, `bin/backends/`, and the scripts that dispatch through them) need empirical adapter notes in the relevant docs, following `docs/herdr-backend.md` or `docs/zellij-backend.md` for non-tmux backends.
+- Changes to runtime session backends (`bin/fm-backend.sh`, `bin/backends/`, and the scripts that dispatch through them) need empirical adapter notes in the relevant docs, following `docs/herdr-backend.md` or `docs/zellij-backend.md` for implemented non-tmux backends or `docs/orca-backend.md` for the proposed Orca contract.
 - In Markdown, put each full sentence on its own line.
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Agent-only reference skills live under `.agents/skills/` and are loaded by first
 - [docs/configuration.md](docs/configuration.md) - environment variables, `FM_HOME`, runtime backend selection, optional X mode, the files you set, and harness support.
 - [docs/herdr-backend.md](docs/herdr-backend.md) - experimental herdr backend verification notes and known gaps.
 - [docs/zellij-backend.md](docs/zellij-backend.md) - experimental zellij backend verification notes and known gaps.
+- [docs/orca-backend.md](docs/orca-backend.md) - proposed Orca backend adapter contract before an implementation PR.
 - [docs/scripts.md](docs/scripts.md) - the `bin/` toolbelt reference.
 - [`AGENTS.md`](AGENTS.md) - firstmate's full operating manual for the orchestrator agent.
 - [CONTRIBUTING.md](CONTRIBUTING.md) - how to contribute, including the dev/test commands.

--- a/bin/fm-pr-merge.sh
+++ b/bin/fm-pr-merge.sh
@@ -87,4 +87,4 @@ if ! caller_has_merge_method "$@"; then
   merge_args=(--squash)
 fi
 
-gh-axi pr merge "$PR_NUMBER" --repo "$PR_OWNER/$PR_REPO" "${merge_args[@]}" "$@"
+gh-axi pr merge "$PR_NUMBER" --repo "$PR_OWNER/$PR_REPO" ${merge_args[@]+"${merge_args[@]}"} "$@"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -181,9 +181,9 @@ if [ "${#POS[@]}" -gt 0 ] && [ "${POS[0]}" != "$idpart" ] && case "$idpart" in *
       rc=2
       continue
     elif [ "$KIND" = scout ]; then
-      if FM_SPAWN_NO_GUARD=1 "$FM_ROOT/bin/fm-spawn.sh" "${pair%%=*}" "${pair#*=}" "${shared_args[@]+"${shared_args[@]}"}" --scout; then :; else echo "batch: FAILED to spawn ${pair%%=*} (${pair#*=})" >&2; rc=1; fi
+      if FM_SPAWN_NO_GUARD=1 "$FM_ROOT/bin/fm-spawn.sh" "${pair%%=*}" "${pair#*=}" ${shared_args[@]+"${shared_args[@]}"} --scout; then :; else echo "batch: FAILED to spawn ${pair%%=*} (${pair#*=})" >&2; rc=1; fi
     else
-      if FM_SPAWN_NO_GUARD=1 "$FM_ROOT/bin/fm-spawn.sh" "${pair%%=*}" "${pair#*=}" "${shared_args[@]+"${shared_args[@]}"}"; then :; else echo "batch: FAILED to spawn ${pair%%=*} (${pair#*=})" >&2; rc=1; fi
+      if FM_SPAWN_NO_GUARD=1 "$FM_ROOT/bin/fm-spawn.sh" "${pair%%=*}" "${pair#*=}" ${shared_args[@]+"${shared_args[@]}"}; then :; else echo "batch: FAILED to spawn ${pair%%=*} (${pair#*=})" >&2; rc=1; fi
     fi
   done
   exit "$rc"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -50,6 +50,7 @@ Herdr is experimental and can be selected explicitly or by runtime auto-detectio
 Herdr's container shape is workspace-per-home plus tab-per-task: the primary home uses workspace label `firstmate`, secondmate homes use `2ndmate-<secondmate-id>`, and recovery/list-live scopes to the current `FM_HOME`'s workspace.
 Zellij is experimental and selected only explicitly: treehouse remains its worktree provider too, and its full verification - the resolved "gaps to verify" list from the original design report, the unconditional-exit-0 CLI quirk and its mitigation, the focus-steal-on-new-tab finding, and known gaps - is recorded in `docs/zellij-backend.md`.
 Zellij's container shape is simpler than herdr's: one shared `firstmate` session, one tab per task, with no per-home workspace split.
+Orca is documented only as a proposed future adapter contract in `docs/orca-backend.md`; it is not in `bin/fm-backend.sh`'s verified backend set.
 
 ## Worktrees, not branches in your checkout
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,6 +20,7 @@ The file format is unchanged in both modes; tasks-axi and manual edits produce t
 
 The runtime session-provider backend controls where task windows/endpoints are created, captured, sent to, watched, and killed.
 `tmux` is the verified reference backend; `herdr` and `zellij` are experimental backends (see [`docs/herdr-backend.md`](herdr-backend.md) and [`docs/zellij-backend.md`](zellij-backend.md)) - treehouse remains the worktree provider for all three, since herdr and zellij are session providers only.
+`orca` is only a proposed adapter contract in [`docs/orca-backend.md`](orca-backend.md); it is not an accepted `config/backend` value until an implementation registers it.
 New spawns choose the backend in this order: explicit `fm-spawn.sh --backend <name>`, then `FM_BACKEND`, then the first non-empty line of local gitignored `config/backend`, then runtime auto-detection from `$TMUX` or `HERDR_ENV=1`, then default `tmux`.
 If both runtime markers are present, `$TMUX` wins because tmux is the innermost surface firstmate is running on.
 Auto-detected herdr prints a stderr notice naming `config/backend` and `--backend tmux` as opt-outs; auto-detected tmux stays silent to preserve existing default behavior.

--- a/docs/orca-backend.md
+++ b/docs/orca-backend.md
@@ -1,0 +1,104 @@
+# Orca backend adapter specification
+
+This document defines the proposed Orca runtime backend contract before an implementation PR.
+It is intentionally small: enough for upstream review of the adapter boundary, metadata, safety rules, and smoke coverage before any Orca code is ported.
+
+## Status: proposed
+
+Orca is a proposed runtime session and worktree backend for firstmate.
+It is distinct from the crewmate harness.
+The harness is the agent process firstmate launches inside a task endpoint, such as `claude`, `codex`, `opencode`, `pi`, or `grok`.
+The runtime backend owns the endpoint and worktree lifecycle underneath that harness.
+
+The current verified backends are `tmux` and experimental `herdr`.
+Adding Orca should follow the existing adapter layout by introducing `bin/backends/orca.sh` and registering `orca` in `bin/fm-backend.sh` only when the implementation and smoke tests land.
+This spec does not add that registration.
+
+## Backend shape
+
+An Orca task is one Orca worktree plus one Orca terminal.
+Unlike the `tmux` and `herdr` adapters, Orca is expected to provide both the session endpoint and the task worktree.
+That makes `worktree=` a first-class adapter output, not a path discovered after running `treehouse get` inside an existing terminal.
+
+The adapter should still preserve firstmate's normal invariant: each ship or scout task runs outside the project primary checkout in a disposable worktree, and teardown refuses to discard unlanded work.
+
+## Metadata contract
+
+An Orca-spawned task must write these metadata fields before the harness launch is submitted:
+
+```text
+backend=orca
+terminal=<orca terminal id or selector>
+orca_worktree_id=<orca worktree id>
+worktree=<absolute path to the Orca-created git worktree>
+```
+
+`window=` may continue to exist as the generic firstmate target string if call sites still expect it.
+For Orca, the stable operational endpoint is `terminal=`.
+Readers should treat `backend=orca` as the authoritative signal that Orca adapter operations, not tmux fallback lookups, own capture, sends, interrupt, and teardown.
+
+## Adapter operations
+
+The Orca adapter should expose the same categories that `tmux` and `herdr` expose today, mapped to Orca's CLI:
+
+| Operation | Expected behavior |
+| --- | --- |
+| create/spawn | Create an isolated Orca worktree for the project and an Orca terminal for `fm-<id>`, then write metadata before sending the harness launch command. |
+| capture/read | Return bounded plain text from the terminal for `fm-peek.sh`, `fm-watch.sh`, and stale-pane diagnostics. |
+| send text | Type literal text into the terminal without changing the task metadata. |
+| send submit/enter | Submit the current composer, matching firstmate's existing "send text then Enter" behavior. |
+| interrupt | Deliver the backend's interrupt equivalent, normally Ctrl-C, without tearing down the task. |
+| teardown | Close the Orca terminal and release/remove the Orca worktree only after firstmate's landed-work checks permit cleanup. |
+
+The implementation should keep the generic call sites backend-oriented rather than introducing Orca-specific branches in every consumer.
+Where the current interface lacks a clean hook for an Orca primitive, extend the shared backend operation set first.
+
+## Tool gating
+
+Bootstrap should require the `orca` CLI only when the selected runtime backend is Orca.
+Selecting `tmux` must not require Orca.
+Selecting `herdr` must keep its own existing requirements.
+
+Backend selection should follow the existing precedence model:
+
+1. explicit per-spawn backend override,
+2. `FM_BACKEND`,
+3. local `config/backend`,
+4. runtime auto-detection when supported,
+5. default `tmux`.
+
+Orca should not be auto-detected unless there is a reliable, verified Orca runtime marker for the firstmate process itself.
+Absent that marker, Orca should be explicit-only.
+
+## Safety constraints
+
+Secondmate launch must not use Orca in the first implementation.
+`fm-spawn.sh --secondmate` should continue to force or require a supported non-Orca backend until Orca secondmate semantics are separately designed.
+
+The contribution flow must never push directly to `kunchenguid/firstmate`.
+Upstream-bound branches should be based on `upstream/main`, pushed to a contributor fork, and opened as pull requests against `kunchenguid/firstmate:main`.
+
+Teardown must remain fail-closed.
+It may close an Orca terminal and remove an Orca worktree only after the existing landed-work checks say the task is safe to clean up, or after an explicit discard path has been approved.
+Uncommitted changes are never landed.
+Committed work that is not reachable from an accepted remote branch, merged PR head, or accepted local-only merge must keep the worktree alive.
+
+The adapter must not depend on ambient Orca state in a way that can target the wrong terminal or worktree.
+Use recorded IDs from metadata for destructive operations, and fail rather than guessing when an ID is missing or no longer resolves.
+
+## Smoke contract for a future implementation
+
+A future Orca implementation PR should include fake-CLI unit coverage and a real-CLI smoke test that skips cleanly when Orca is unavailable.
+At minimum, the smoke contract should prove:
+
+- bootstrap reports `orca` as required only when Orca is selected;
+- spawn writes `backend=orca`, `terminal=`, `orca_worktree_id=`, and `worktree=` before submitting the harness launch;
+- `fm-peek.sh` or the shared capture path reads bounded terminal output;
+- `fm-send.sh` can send text, submit Enter, and interrupt through the backend adapter;
+- teardown refuses dirty or unlanded work before any Orca terminal/worktree removal;
+- teardown closes the recorded terminal and releases the recorded worktree after landed-work checks pass;
+- `--secondmate` launch refuses or bypasses Orca according to the documented rule;
+- no test or helper attempts a push to `upstream`.
+
+This PR intentionally stops at the specification.
+The implementation PR should port Orca into upstream's current `bin/backends/<name>.sh` adapter shape rather than copying an older monolithic backend switch.

--- a/docs/orca-backend.md
+++ b/docs/orca-backend.md
@@ -28,13 +28,15 @@ An Orca-spawned task must write these metadata fields before the harness launch 
 
 ```text
 backend=orca
+window=<generic firstmate target alias for the Orca terminal>
 terminal=<orca terminal id or selector>
 orca_worktree_id=<orca worktree id>
 worktree=<absolute path to the Orca-created git worktree>
 ```
 
-`window=` may continue to exist as the generic firstmate target string if call sites still expect it.
-For Orca, the stable operational endpoint is `terminal=`.
+`window=` is required until selector resolution, watcher routing, and teardown are explicitly migrated away from the generic firstmate target alias.
+Current core call sites still resolve `fm-<id>` through metadata `window=`, watch the recorded `window=`, and kill the recorded `window=` during teardown.
+For Orca, `terminal=` is the Orca-native stable operational endpoint, while `window=` is the compatibility alias those shared firstmate paths consume.
 Readers should treat `backend=orca` as the authoritative signal that Orca adapter operations, not tmux fallback lookups, own capture, sends, interrupt, and teardown.
 
 ## Adapter operations
@@ -92,7 +94,7 @@ A future Orca implementation PR should include fake-CLI unit coverage and a real
 At minimum, the smoke contract should prove:
 
 - bootstrap reports `orca` as required only when Orca is selected;
-- spawn writes `backend=orca`, `terminal=`, `orca_worktree_id=`, and `worktree=` before submitting the harness launch;
+- spawn writes `backend=orca`, required `window=`, `terminal=`, `orca_worktree_id=`, and `worktree=` before submitting the harness launch;
 - `fm-peek.sh` or the shared capture path reads bounded terminal output;
 - `fm-send.sh` can send text, submit Enter, and interrupt through the backend adapter;
 - teardown refuses dirty or unlanded work before any Orca terminal/worktree removal;


### PR DESCRIPTION
## What Changed

- Added `docs/orca-backend.md` describing the proposed Orca backend adapter contract, target aliasing, lifecycle operations, and validation expectations.
- Linked the Orca backend proposal from the existing backend documentation so it is discoverable from the project docs.
- Included pipeline-discovered Bash nounset fixes in `fm-spawn.sh` and `fm-pr-merge.sh`.

## Risk Assessment

✅ Low: this is a documentation/specification PR and does not make Orca selectable for new task spawns.

## Testing

Completed 1 recorded validation pass.

- Outcome: no-mistakes completed review, test, document, lint, push, and PR stages; GitHub checks are passing on the current head.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

- ⏭️ **intent** - skipped
- ✅ **Rebase** - passed
- ✅ **Review** - passed
- ✅ **Test** - passed
- ✅ **Document** - passed
- ✅ **Lint** - passed
- ✅ **Push** - passed