### PR TITLE
fix(spawn): capture worktree lease by repo-identity, not treehouse root

### DIFF
--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -489,6 +489,22 @@ path_is_ancestor_of() {
   return 1
 }
 
+# A captured pane path is the treehouse lease only when it is an existing
+# directory UNDER the treehouse root AND a git worktree. The wait loop below
+# accepts the first pane cwd that differs from the project dir, but shell-init
+# noise (e.g. a transient ~/.oh-my-zsh cwd during zsh startup - itself a git repo)
+# can appear before `treehouse get` lands; the treehouse-root containment is what
+# distinguishes the real lease from such noise, so the loop keeps polling for the
+# genuine worktree instead of recording the noise. The isolation guard after the
+# loop is the backstop; this keeps the loop from ever selecting the wrong path.
+is_treehouse_worktree() {
+  local path=$1 root=$2
+  [ -d "$path" ] || return 1
+  path_is_ancestor_of "$root" "$path" || return 1
+  [ "$(git -C "$path" rev-parse --is-inside-work-tree 2>/dev/null)" = "true" ] || return 1
+  return 0
+}
+
 validate_firstmate_home_for_spawn() {
   local id=$1 home=$2 abs_home abs_active_home abs_root marker_id
   abs_home=$(resolved_existing_dir "$home") || return 1
@@ -649,6 +665,45 @@ real_path_or_raw() {  # <path>
   fi
 }
 
+# Resolve a git worktree's common dir to an absolute real path. `git rev-parse
+# --git-common-dir` may return a path relative to the worktree, so anchor a
+# relative result to the worktree before canonicalizing with pwd -P; this lets
+# two worktrees of the same repository be compared regardless of symlinked paths.
+git_common_dir_real() {
+  local dir=$1 common
+  common=$(git -C "$dir" rev-parse --git-common-dir 2>/dev/null) || return 1
+  [ -n "$common" ] || return 1
+  case "$common" in
+    /*) ;;
+    *) common="$dir/$common" ;;
+  esac
+  [ -d "$common" ] || return 1
+  (cd "$common" && pwd -P)
+}
+
+# A captured pane path is the genuine treehouse lease only when it is a worktree
+# of the SAME repository as the project, resolved distinctly from it. The wait
+# loop below accepts the first pane cwd that differs from the project dir, but
+# shell-init noise (e.g. a transient ~/.oh-my-zsh cwd during zsh startup - itself
+# a git repo, but a DIFFERENT repository) can appear before `treehouse get`
+# lands. Comparing canonical git common dirs distinguishes the real lease from
+# such noise no matter where treehouse.toml places the pool root, and resolving
+# every path with pwd -P keeps a symlinked $HOME from breaking the match. The
+# isolation guard after the loop is the backstop; this keeps the loop from ever
+# selecting the wrong path.
+is_project_worktree() {
+  local candidate=$1 proj_abs=$2 cand_real proj_real cand_common proj_common
+  [ -d "$candidate" ] || return 1
+  [ "$(git -C "$candidate" rev-parse --is-inside-work-tree 2>/dev/null)" = "true" ] || return 1
+  cand_common=$(git_common_dir_real "$candidate") || return 1
+  proj_common=$(git_common_dir_real "$proj_abs") || return 1
+  [ "$cand_common" = "$proj_common" ] || return 1
+  cand_real=$(cd "$candidate" 2>/dev/null && pwd -P) || return 1
+  proj_real=$(cd "$proj_abs" 2>/dev/null && pwd -P) || return 1
+  [ "$cand_real" != "$proj_real" ] || return 1
+  return 0
+}
+
 # Session-provider container-ensure + task creation. tmux stays exactly as P1
 # left it (same session-name / new-window sequence, see bin/backends/tmux.sh);
 # a herdr spawn goes through the version-gated, workspace-per-HOME,
@@ -807,20 +862,23 @@ spawn_send_key() {  # <target> <key>
 if [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   spawn_send_text_line "$T" 'treehouse get'
 
-  # Wait for the treehouse subshell: the pane's cwd moves from the project to the worktree.
-  # Compare against PROJ_ABS_REAL (physical), not PROJ_ABS: a symlinked project
-  # prefix would otherwise make the pane's OS-level cwd read differ from
-  # PROJ_ABS on the very first poll, before the pane has actually moved.
-  for _ in $(seq 1 60); do
+  # Wait for the treehouse subshell: the pane's cwd moves from the project to the
+  # worktree. Only accept a captured path that is genuinely a worktree of the SAME
+  # repository as the project - a bare "differs from the project dir" check once
+  # recorded shell-init noise (e.g. a transient ~/.oh-my-zsh cwd during zsh startup)
+  # that appears before `treehouse get` lands. This needs no knowledge of the
+  # treehouse pool root, so it works wherever treehouse.toml places it.
+  wt_wait="${FM_SPAWN_WORKTREE_WAIT:-60}"
+  for _ in $(seq 1 "$wt_wait"); do
     p=$(spawn_current_path "$T" || true)
-    if [ -n "$p" ] && [ "$(real_path_or_raw "$p")" != "$PROJ_ABS_REAL" ]; then
+    if [ -n "$p" ] && is_project_worktree "$p" "$PROJ_ABS"; then
       WT="$p"
       break
     fi
     sleep 1
   done
   if [ -z "$WT" ]; then
-    echo "error: treehouse get did not enter a worktree within 60s; inspect window $T" >&2
+    echo "error: treehouse get did not enter a worktree within ${wt_wait}s; inspect window $T" >&2
     exit 1
   fi
 

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -489,19 +489,42 @@ path_is_ancestor_of() {
   return 1
 }
 
-# A captured pane path is the treehouse lease only when it is an existing
-# directory UNDER the treehouse root AND a git worktree. The wait loop below
-# accepts the first pane cwd that differs from the project dir, but shell-init
-# noise (e.g. a transient ~/.oh-my-zsh cwd during zsh startup - itself a git repo)
-# can appear before `treehouse get` lands; the treehouse-root containment is what
-# distinguishes the real lease from such noise, so the loop keeps polling for the
-# genuine worktree instead of recording the noise. The isolation guard after the
-# loop is the backstop; this keeps the loop from ever selecting the wrong path.
-is_treehouse_worktree() {
-  local path=$1 root=$2
-  [ -d "$path" ] || return 1
-  path_is_ancestor_of "$root" "$path" || return 1
-  [ "$(git -C "$path" rev-parse --is-inside-work-tree 2>/dev/null)" = "true" ] || return 1
+# Resolve a git worktree's common dir to an absolute real path. `git rev-parse
+# --git-common-dir` may return a path relative to the worktree, so anchor a
+# relative result to the worktree before canonicalizing with pwd -P; this lets
+# two worktrees of the same repository be compared regardless of symlinked paths.
+git_common_dir_real() {
+  local dir=$1 common
+  common=$(git -C "$dir" rev-parse --git-common-dir 2>/dev/null) || return 1
+  [ -n "$common" ] || return 1
+  case "$common" in
+    /*) ;;
+    *) common="$dir/$common" ;;
+  esac
+  [ -d "$common" ] || return 1
+  (cd "$common" && pwd -P)
+}
+
+# A captured pane path is the genuine treehouse lease only when it is a worktree
+# of the SAME repository as the project, resolved distinctly from it. The wait
+# loop below accepts the first pane cwd that differs from the project dir, but
+# shell-init noise (e.g. a transient ~/.oh-my-zsh cwd during zsh startup - itself
+# a git repo, but a DIFFERENT repository) can appear before `treehouse get`
+# lands. Comparing canonical git common dirs distinguishes the real lease from
+# such noise no matter where treehouse.toml places the pool root, and resolving
+# every path with pwd -P keeps a symlinked $HOME from breaking the match. The
+# isolation guard after the loop is the backstop; this keeps the loop from ever
+# selecting the wrong path.
+is_project_worktree() {
+  local candidate=$1 proj_abs=$2 cand_real proj_real cand_common proj_common
+  [ -d "$candidate" ] || return 1
+  [ "$(git -C "$candidate" rev-parse --is-inside-work-tree 2>/dev/null)" = "true" ] || return 1
+  cand_common=$(git_common_dir_real "$candidate") || return 1
+  proj_common=$(git_common_dir_real "$proj_abs") || return 1
+  [ "$cand_common" = "$proj_common" ] || return 1
+  cand_real=$(cd "$candidate" 2>/dev/null && pwd -P) || return 1
+  proj_real=$(cd "$proj_abs" 2>/dev/null && pwd -P) || return 1
+  [ "$cand_real" != "$proj_real" ] || return 1
   return 0
 }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -266,6 +266,7 @@ FM_STALE_WORKTREE_LOCK_RETRY_WAIT_SECS=2 # seconds fm-teardown.sh waits before r
 FM_BUSY_REGEX='esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel'   # busy-pane signatures, shared by watcher, fm-crew-state pane fallback, and tmux helper
 FM_COMPOSER_IDLE_RE=    # optional empty-composer regex, applied after dim-ghost and border stripping
 GROK_HOME=              # optional Grok config home for firstmate's global grok turn-end hook; defaults to ~/.grok
+FM_SPAWN_WORKTREE_WAIT=60   # seconds fm-spawn waits for treehouse get to land the pane in a same-repo isolated worktree before aborting
 FM_SEND_RETRIES=3       # fm-send Enter-retry attempts after typing the line once
 FM_SEND_SLEEP=0.4       # seconds between fm-send submit checks
 FM_SEND_SETTLE=1        # seconds fm-send waits after a successful text submit; 0 disables

--- a/tests/fm-tangle-guard.test.sh
+++ b/tests/fm-tangle-guard.test.sh
@@ -181,6 +181,7 @@ run_spawn() {
     FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
     FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
     FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$pane" TMUX="fake,1,0" \
+    FM_SPAWN_WORKTREE_WAIT=2 \
     PATH="$fakebin:$PATH" \
     "$ROOT/bin/fm-spawn.sh" "$id" "$proj" codex 2>&1
 }
@@ -196,9 +197,12 @@ test_spawn_isolation_abort() {
   mkdir -p "$TMP_ROOT/spawn-notgit" "$proj/sub"
 
   # Abort: the pane resolves to a plain non-git directory (not a worktree at all).
+  # The wait loop only captures a same-repo worktree, so a persistent non-git pane
+  # is treated as "treehouse never landed" and times out rather than reaching the
+  # isolation guard - still a clean abort (exit 1, no meta recorded).
   out=$(run_spawn "$home" abort-notgit-dd4 "$proj" "$TMP_ROOT/spawn-notgit" "$fakebin"); status=$?
   expect_code 1 "$status" "spawn into a non-worktree dir should abort"
-  assert_contains "$out" "did not yield an isolated worktree" "non-worktree spawn lacked the isolation error"
+  assert_contains "$out" "did not enter a worktree" "non-worktree spawn lacked the timeout abort"
   assert_absent "$home/state/abort-notgit-dd4.meta" "aborted spawn must not record meta"
 
   # Abort: the pane resolves INTO the primary checkout (a subdir of PROJ_ABS).


### PR DESCRIPTION
## What Changed

- Replaced the spawn worktree-capture check in `bin/fm-spawn.sh`: instead of accepting the first pane cwd that merely differs from the project dir (which could latch onto shell-init noise like a transient `~/.oh-my-zsh` cwd), it now accepts a path only when it is a genuine worktree of the *same* repository, comparing canonical git common dirs and resolving every path with `pwd -P` so a symlinked `$HOME` or a non-default treehouse pool root no longer breaks the match.
- Made the worktree wait window configurable via `FM_SPAWN_WORKTREE_WAIT` (default 60s), threaded through the loop and the timeout error message, and documented it in `docs/configuration.md`.
- Guarded the bash 3.2 empty-array expansion in `bin/fm-pr-merge.sh` and updated `tests/fm-tangle-guard.test.sh` for the new repo-identity worktree check.

## Risk Assessment

✅ Low: A well-bounded 46-line change to a single spawn helper that faithfully replaces a brittle treehouse-root containment check with a symlink-safe repository-identity check, keeps the existing isolation guard as a backstop, and leaves no orphaned code.

## Testing

Completed 1 recorded test check.

- Outcome: 🔧 1 issue found → auto-fixed ✅ across 2 runs (25m25s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-spawn.sh:655` - is_treehouse_worktree gates lease capture on containment under TH_ROOT=${FM_TREEHOUSE_ROOT:-$HOME/.treehouse}, but treehouse&#39;s pool root is configurable via treehouse.toml (`root` key: worktrees are placed under {root}/.treehouse/, e.g. `root = &#34;./&#34;` puts them under &lt;repo&gt;/.treehouse/). For any repo with a non-default treehouse root, the captured pane cwd will never be under $HOME/.treehouse, so the loop never selects, and spawn fails with the confusing &#39;treehouse get did not enter a worktree within 60s&#39; timeout unless the operator knows to set the undocumented FM_TREEHOUSE_ROOT env var. Since this repo is a shared template for every user, consider deriving the root from treehouse.toml (or relaxing to &#39;is a git worktree distinct from PROJ_ABS&#39; and relying on the existing isolation guard) rather than assuming $HOME/.treehouse.
- ℹ️ `bin/fm-spawn.sh:429` - The containment check uses raw string-prefix matching (path_is_ancestor_of) between the tmux pane_current_path (a resolved physical path on macOS/Linux) and the unresolved TH_ROOT ($HOME/.treehouse). If $HOME contains a symlinked component (common on some Linux hosts where /home is symlinked), the physical pane path won&#39;t be prefixed by the logical $HOME and the match silently fails, causing the same 60s timeout. The later isolation guard resolves both sides with `pwd -P`; this new pre-check does not.

🔧 Fix: replace treehouse-root check with repo-identity worktree check
✅ Re-checked - no issues remain.

</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed ✅</summary>

- 🚨 tests failed with exit code 1
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`

🔧 Fix: guard bash 3.2 empty array in pr-merge; fix stale spawn worktree test
✅ Re-checked - no issues remain.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
