### PR TITLE
feat(skills): publish public stow skill with internal-skill hiding

### DIFF
--- a/.agents/skills/afk/SKILL.md
+++ b/.agents/skills/afk/SKILL.md
@@ -2,6 +2,8 @@
 name: afk
 description: Enter away-mode supervision. Use when the user invokes /afk (e.g. "/afk", "/afk back in an hour", "going afk"). Sets a durable away-mode flag so the sub-supervisor daemon can self-handle routine wakes and escalate only captain-relevant events as one batched digest, cutting supervision token cost during walk-away stretches. Exit is automatic; any real (unmarked) message returns to full per-wake responsiveness.
 user-invocable: true
+metadata:
+  internal: true
 ---
 
 # afk

--- a/.agents/skills/fmx-respond/SKILL.md
+++ b/.agents/skills/fmx-respond/SKILL.md
@@ -2,6 +2,8 @@
 name: fmx-respond
 description: Agent-only playbook for handling an X mention in X mode. Use on an "x-mention <request_id>" check: wake - read the stashed mention (with any in_reply_to conversation context); the direct author is the firstmate's own owner (captain) under owner-only routing, so classify it as an actionable request to act on through the normal lifecycle, a question to answer from live fleet state, or a pure acknowledgment to dismiss without replying; act autonomously (escalating only destructive/irreversible/security-sensitive work). For a request that spawns real work, acknowledge first, act, link the task with bin/fm-x-link.sh, and let the completion follow-up post on the done wake; for a question or completed action, post or preview a short public-safe reply with bin/fm-x-reply.sh; for a pure acknowledgment, call bin/fm-x-dismiss.sh. Clear the inbox file only after a successful reply or dismiss. Loaded only when X mode is enabled.
 user-invocable: false
+metadata:
+  internal: true
 ---
 
 # fmx-respond

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -2,6 +2,8 @@
 name: harness-adapters
 description: Agent-only reference for firstmate harness operations. Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter. Contains verified facts for claude, codex, opencode, pi, and grok.
 user-invocable: false
+metadata:
+  internal: true
 ---
 
 # harness-adapters

--- a/.agents/skills/secondmate-provisioning/SKILL.md
+++ b/.agents/skills/secondmate-provisioning/SKILL.md
@@ -2,6 +2,8 @@
 name: secondmate-provisioning
 description: Agent-only reference for persistent secondmate setup and retirement. Use when creating, seeding, validating, recovering, handing backlog to, pushing inherited config into, or retiring a secondmate home, or when editing data/secondmates.md. Covers home leases, transactional seeding, project clone restrictions, inherited config push, idle charter, handoff helper, and teardown safety.
 user-invocable: false
+metadata:
+  internal: true
 ---
 
 # secondmate-provisioning

--- a/.agents/skills/stow/SKILL.md
+++ b/.agents/skills/stow/SKILL.md
@@ -2,7 +2,11 @@
 name: stow
 description: Sweep the current session for uncaptured durable knowledge and file it to disk before a context reset. Use when the captain invokes /stow (e.g. "/stow", "stow what you've learned"), before a session reset or context compaction, or periodically to keep operational memory current.
 user-invocable: true
+metadata:
+  internal: true
 ---
+
+<!-- maintainers: this is the firstmate-internal skill. The public, installer-facing counterpart lives at skills/stow/SKILL.md - deliberately a separate file with no shared code or environment branching. Keep them independent. -->
 
 # stow
 

--- a/.agents/skills/stow/SKILL.md
+++ b/.agents/skills/stow/SKILL.md
@@ -51,6 +51,6 @@ The goal is a session that is safe to reset or destroy because everything durabl
 
 `/stow` must **never** store, create, or edit a skill as a destination for any finding.
 There is no "graduate this to a skill" move in this skill's routing.
-This is a deliberate, standing exclusion, not an oversight: repo skills cannot yet distinguish knowledge that is fleet-local to this captain's home from knowledge generalizable to every firstmate user, so writing learnings into skills would silently leak fleet-local material into shared, tracked material (or vice versa).
-That namespace problem is unresolved and deliberately deferred.
-Until it is resolved, route generalizable knowledge to the shared `AGENTS.md` (or other shared, tracked material) via the pipeline, and fleet-local knowledge to `data/`, never to a skill.
+This is a deliberate, standing exclusion, not an oversight: even with the two-tier skill layout, a stow sweep is a memory-routing operation, not a way to author or mutate skills.
+Writing learnings into either `.agents/skills/` or public `skills/` would still risk mixing fleet-local material with shared firstmate behavior or standalone installer-facing behavior.
+Until a human deliberately scopes a skill change as firstmate repo work, route generalizable knowledge to the shared `AGENTS.md` (or other shared, tracked material) via the pipeline, and fleet-local knowledge to `data/`, never to a skill.

--- a/.agents/skills/stuck-crewmate-recovery/SKILL.md
+++ b/.agents/skills/stuck-crewmate-recovery/SKILL.md
@@ -2,6 +2,8 @@
 name: stuck-crewmate-recovery
 description: Agent-only playbook for stuck firstmate direct reports. Use after a stale wake, looping pane, repeated confusion, an answered-by-brief question, an unresponsive crewmate, or a failed steer. Escalates from peek, to one-line steer, to harness-specific interrupt, to relaunch with progress, to failed status.
 user-invocable: false
+metadata:
+  internal: true
 ---
 
 # stuck-crewmate-recovery

--- a/.agents/skills/updatefirstmate/SKILL.md
+++ b/.agents/skills/updatefirstmate/SKILL.md
@@ -2,6 +2,8 @@
 name: updatefirstmate
 description: Self-update a running firstmate and its secondmates to the latest from origin. Use when the captain invokes /updatefirstmate (e.g. "/updatefirstmate", "update firstmate", "pull the latest firstmate"). Fast-forwards this firstmate repo's default branch and every secondmate home from origin (fast-forward only, never forced, never disruptive), then re-reads AGENTS.md and nudges each updated secondmate to do the same, so the whole tree runs the latest bin/ and instructions.
 user-invocable: true
+metadata:
+  internal: true
 ---
 
 # updatefirstmate

--- a/.agents/skills/updatefirstmate/SKILL.md
+++ b/.agents/skills/updatefirstmate/SKILL.md
@@ -9,7 +9,8 @@ metadata:
 # updatefirstmate
 
 Self-update firstmate in place.
-Firstmate is its own repo, behind the same no-mistakes gate as any project, so new tracked material (AGENTS.md, bin/, skills) reaches `main` and then sits there until each running firstmate pulls it.
+Firstmate is its own repo, behind the same no-mistakes gate as any project, so new tracked material (`AGENTS.md`, `bin/`, `.agents/skills/`, and public `skills/`) reaches `main` and then sits there until each running firstmate pulls it.
+Only `AGENTS.md`, `bin/`, and `.agents/skills/` are a running firstmate instruction surface; public `skills/` is installer-facing and is not loaded by firstmate.
 This skill performs that pull for the running main firstmate and every secondmate, without disturbing any in-flight work.
 
 The update is **fast-forward only** - the same sanctioned self-write as the fleet sync firstmate already runs.
@@ -29,7 +30,7 @@ This touches only the firstmate repo and its own worktrees, never anything under
    - `nudge-secondmates: <window-targets...>|none`
 
 2. **Re-read AGENTS.md if your own instructions changed.**
-   When the updater printed `reread-firstmate: yes`, the tracked instruction surface (AGENTS.md, bin/, or skills) just advanced under you.
+   When the updater printed `reread-firstmate: yes`, the tracked instruction surface (`AGENTS.md`, `bin/`, or `.agents/skills/`) just advanced under you.
    **Read `AGENTS.md` now** (CLAUDE.md is a symlink to it) to refresh your operating instructions before doing anything else, so you are acting on the new instructions rather than the stale ones you were started with.
    When it printed `reread-firstmate: no`, nothing changed for you - skip the re-read.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ Hard rules, in priority order:
 
 You may freely write to this repo itself (backlog, briefs, state, even this file when the captain approves a change).
 Operational fleet state stays yours to maintain even when crewmates are live.
-Shared, tracked material means `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `.tasks.toml`, `.github/workflows/`, `bin/`, and agent skill files.
+Shared, tracked material means `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `.tasks.toml`, `.github/workflows/`, `bin/`, `.agents/skills/`, and public `skills/`.
 When one or more crewmates are in flight, delegate changes to shared, tracked material to a crewmate through the normal scout or ship machinery instead of hand-editing them yourself.
 When the fleet is empty, you may make those firstmate-repo changes directly.
 Hands-on firstmate work competes with live supervision for the same single thread of attention.
@@ -69,8 +69,9 @@ CONTRIBUTING.md      contributor workflow and repo conventions
 README.md            public overview and development notes
 .github/workflows/   shared CI and PR enforcement, committed
 .tasks.toml          tracked tasks-axi markdown backend config for the default backlog backend (section 10)
-.agents/skills/      shared skills, committed
+.agents/skills/      firstmate-loaded internal skills, committed; each carries metadata.internal=true for installers
 .claude/skills       symlink to .agents/skills for claude compatibility
+skills/              standalone public installer-facing skills, committed; not loaded by firstmate
 bin/                 helper scripts, committed; read each script's header before first use
 .env                 optional X-mode pairing token; LOCAL, gitignored; presence-gates section 14
 config/crew-harness  crewmate harness override; LOCAL, gitignored; absent or "default" = same as firstmate. Inherited: the primary pushes this into every secondmate home's config/ (section 4), so a secondmate's own crewmates use the primary's value
@@ -838,7 +839,8 @@ Adjust the other sections only when the task genuinely deviates from the standar
 
 ## 12. Self-update
 
-firstmate is its own repo behind the no-mistakes gate, so improvements to `AGENTS.md`, `bin/`, and skills reach `main` and then wait for each running firstmate to pull them.
+firstmate is its own repo behind the no-mistakes gate, so improvements to `AGENTS.md`, `bin/`, `.agents/skills/`, and public `skills/` reach `main` and then wait for each running firstmate to pull them.
+Only `AGENTS.md`, `bin/`, and `.agents/skills/` are a running firstmate instruction surface; public `skills/` is tracked for installers and is not loaded by firstmate.
 When the captain invokes `/updatefirstmate` or asks to update firstmate, load the `/updatefirstmate` skill.
 It performs only fast-forward self-updates of firstmate and registered secondmate homes, re-reads `AGENTS.md` when needed, nudges updated live secondmates, and never touches anything under `projects/`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,7 +155,7 @@ Because `config/` is gitignored this is a separate, primary-authoritative copy i
 For a mid-session inheritable-config change that should reach live secondmates without a full session start, run `bin/fm-config-push.sh`.
 It is config-only: it uses the same live secondmate discovery and the same `propagate_inheritable_config` helper as bootstrap, prints a per-home/per-item summary, does not fast-forward tracked files, and does not nudge secondmates.
 The propagation helper itself keeps stdout silent for existing callers, but warns on stderr when an item is skipped because the destination does not allow it or when a copy/remove error occurs.
-The sweep reports the `NUDGE_SECONDMATES:` line below only when a running secondmate actually advanced with an instruction change, so firstmate knows which ones to live-converge.
+The sweep reports the `NUDGE_SECONDMATES:` line below only when a running secondmate actually advanced with an instruction-surface change (`AGENTS.md`, `bin/`, or `.agents/skills/`), so firstmate knows which ones to live-converge.
 Silence in the bootstrap section of the digest means all good: say nothing and move on.
 Otherwise it prints one line per problem or capability fact; handle each:
 
@@ -177,7 +177,7 @@ Otherwise it prints one line per problem or capability fact; handle each:
   It prints only when `config/backlog-backend` is absent or set to `tasks-axi` and the compatibility probe accepts `tasks-axi --version` as 0.1.1 or newer.
   If the backend is not opted out and `tasks-axi` is missing or incompatible, bootstrap reports `MISSING: tasks-axi (install: npm install -g tasks-axi)` but still falls back to hand-editing and never blocks work.
   If `config/backlog-backend=manual`, bootstrap hand-edits and does not suggest installing `tasks-axi`.
-- `NUDGE_SECONDMATES: <window-targets...>` - the secondmate sweep fast-forwarded one or more *running* secondmate homes to firstmate's current version and their instructions actually changed; for each listed window, send a one-line re-read nudge with `bin/fm-send.sh <window-target> 'firstmate was updated to the latest - please re-read your AGENTS.md to pick up the new instructions.'` so that secondmate picks up its new instructions.
+- `NUDGE_SECONDMATES: <window-targets...>` - the secondmate sweep fast-forwarded one or more *running* secondmate homes to firstmate's current version and their instruction surface (`AGENTS.md`, `bin/`, or `.agents/skills/`) actually changed; for each listed window, send a one-line re-read nudge with `bin/fm-send.sh <window-target> 'firstmate was updated to the latest - please re-read your AGENTS.md to pick up the new instructions.'` so that secondmate picks up its new instructions.
   This mirrors `/updatefirstmate`'s `nudge-secondmates:` report: it is a gentle steer, never an interruption, and the fast-forward already landed safely.
   A secondmate that was skipped, already current, or whose advance changed no instructions is not listed and must not be disturbed.
 - `FMX: X mode on ...` / `FMX: X mode off ...` - bootstrap confirmed or removed the local X-mode poll artifacts; follow section 14 for watcher cadence restart only when a running watcher needs the transition applied immediately.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ See the [no-mistakes quick start](https://kunchenguid.github.io/no-mistakes/star
 
 ## Development
 
-Tracked changes to firstmate itself - `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `.tasks.toml`, `.github/workflows/`, `bin/`, and agent skill files - ship through the `no-mistakes` pipeline on a feature branch and require an explicit merge approval.
+Tracked changes to firstmate itself - `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `.tasks.toml`, `.github/workflows/`, `bin/`, `.agents/skills/`, and `skills/` - ship through the `no-mistakes` pipeline on a feature branch and require an explicit merge approval.
 When supervising live crewmates, keep firstmate's own long validation or build commands in the background so watcher wakes can still be handled.
 Crewmate validation follows the installed no-mistakes version's SKILL.md and live `axi` help instead of duplicating gate mechanics in firstmate docs.
 Firstmate's wrapper still matters: `ask-user` findings route to the captain through firstmate, and crewmates avoid `--yes` because it silently resolves captain-owned decisions without escalation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ See the [no-mistakes quick start](https://kunchenguid.github.io/no-mistakes/star
 ## Repo conventions
 
 - This repo is a template for running a firstmate orchestrator agent.
-  `AGENTS.md` is the agent's main job description and names when to load bundled skills; `CLAUDE.md` is a symlink to it, and `.claude/skills` is a symlink to `.agents/skills`.
+  `AGENTS.md` is the agent's main job description and names when to load bundled firstmate skills; `CLAUDE.md` is a symlink to it, and `.claude/skills` is a symlink to `.agents/skills`.
 - Only shared material is tracked: `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `.tasks.toml`, `.github/workflows/`, `bin/`, `.agents/skills/`, and `skills/`.
   `.agents/skills/` holds agent-loaded skills that assume a live firstmate home and carry `metadata.internal: true` so installers such as [skills.sh](https://skills.sh) hide them from discovery; `skills/` holds standalone, installer-facing public skills with no firstmate dependency (see the README's "Two-tier skill layout").
   Everything personal to one captain's fleet (`.env`, `data/`, `state/`, `config/`, `projects/`, `.no-mistakes/`) is gitignored; never commit it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,8 @@ See the [no-mistakes quick start](https://kunchenguid.github.io/no-mistakes/star
 
 - This repo is a template for running a firstmate orchestrator agent.
   `AGENTS.md` is the agent's main job description and names when to load bundled skills; `CLAUDE.md` is a symlink to it, and `.claude/skills` is a symlink to `.agents/skills`.
-- Only shared material is tracked: `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `.tasks.toml`, `.github/workflows/`, `bin/`, and `.agents/skills/`.
+- Only shared material is tracked: `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `.tasks.toml`, `.github/workflows/`, `bin/`, `.agents/skills/`, and `skills/`.
+  `.agents/skills/` holds agent-loaded skills that assume a live firstmate home and carry `metadata.internal: true` so installers such as [skills.sh](https://skills.sh) hide them from discovery; `skills/` holds standalone, installer-facing public skills with no firstmate dependency (see the README's "Two-tier skill layout").
   Everything personal to one captain's fleet (`.env`, `data/`, `state/`, `config/`, `projects/`, `.no-mistakes/`) is gitignored; never commit it.
   The root `.tasks.toml` is tracked `tasks-axi` config for `data/backlog.md`; compatible `tasks-axi` is the default backend for routine backlog mutations.
   A local `config/backlog-backend=manual` opt-out forces hand-editing and stays gitignored.

--- a/README.md
+++ b/README.md
@@ -152,6 +152,13 @@ Claude and grok use the slash form shown here; codex uses the same names with `$
 
 Agent-only reference skills live under `.agents/skills/` and are loaded by firstmate at the trigger points named in [`AGENTS.md`](AGENTS.md).
 
+### Two-tier skill layout
+
+Firstmate's skills live in two separate places with different audiences:
+
+- `.agents/skills/` - agent-loaded skills (this section's table, plus firstmate's agent-only reference skills). Every one of these assumes a live firstmate home and is meaningless, or actively misleading, installed anywhere else, so each carries `metadata.internal: true` in its frontmatter. That flag hides them from installer discovery (tools like the [skills.sh](https://skills.sh) `npx skills add` installer) without affecting how firstmate itself loads them - frontmatter metadata is inert to the agent's own skill loader.
+- `skills/` - public, installer-facing skills meant to be installed standalone into any project, independent of firstmate. Each one is a self-contained skill with no dependency on firstmate's paths, tools, or vocabulary. Today that is `skills/stow`, a generic session-knowledge-sweep skill; it intentionally shares no code with the firstmate-internal `.agents/skills/stow` it is named after, so the two can evolve independently.
+
 ## Documentation
 
 - [docs/architecture.md](docs/architecture.md) - how the crew, supervision, worktrees, secondmates, and project modes work.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ But the moment you want three project tasks done in parallel - fixes, investigat
 firstmate flips the model.
 You talk to a single agent - the first mate - and it runs the crew for you: spawning autonomous agents in a visible session backend, giving each a clean git worktree, supervising them to completion, and handing you finished PRs, approved local merges, or standalone investigation reports.
 For larger fleets, you can opt in to persistent secondmates: domain supervisors that are still ordinary direct reports, but run from their own isolated firstmate homes.
-There is no app to install; the orchestrator is `AGENTS.md`, bundled skills, and helper scripts that any terminal coding agent can follow.
+There is no app to install; the orchestrator is `AGENTS.md`, bundled firstmate skills, and helper scripts that any terminal coding agent can follow.
 
 This is not an agent harness. This is not a single skill. This is not a CLI.
 This is.. a directory that turns any agent into your firstmate, and you the captain.

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -15,7 +15,8 @@
 #          A NUDGE_SECONDMATES line lists the RUNNING secondmate windows whose
 #          worktree was fast-forwarded to firstmate's own current default-branch
 #          commit (a purely LOCAL fast-forward, never an origin fetch) AND whose
-#          instruction surface actually changed; firstmate nudges each to re-read.
+#          instruction surface (AGENTS.md, bin/, or .agents/skills/) actually
+#          changed; firstmate nudges each to re-read.
 #          Already-current or no-instruction-change homes are silently left alone.
 #          The secondmate sweep also propagates declared inheritable local config
 #          into each validated live secondmate home.
@@ -118,10 +119,11 @@ secondmate_sync() {
   # to the primary checkout's current default-branch commit. Purely LOCAL - no
   # fetch, no origin dependency: a secondmate home is a worktree of this same repo
   # and already holds the primary's commit (fm-ff-lib.sh). Emits NUDGE_SECONDMATES:
-  # only for RUNNING secondmates whose instruction surface actually changed, so a
-  # secondmate already on the primary's version is never disturbed (AGENTS.md
-  # bootstrap + supervision). Mirrors fm-update's nudge-secondmates: report so
-  # firstmate can live-converge the listed windows.
+  # only for RUNNING secondmates whose instruction surface (AGENTS.md, bin/, or
+  # .agents/skills/) actually changed, so a secondmate already on the primary's
+  # version is never disturbed (AGENTS.md bootstrap + supervision). Mirrors
+  # fm-update's nudge-secondmates: report so firstmate can live-converge the
+  # listed windows.
   [ -d "$STATE" ] || return 0
   local primary_head
   if ! primary_head=$(primary_head_commit "$FM_ROOT"); then

--- a/bin/fm-ff-lib.sh
+++ b/bin/fm-ff-lib.sh
@@ -204,7 +204,9 @@ fetch_once() {
 
 # Which watched instruction paths changed between HEAD and BASE (comma list).
 # These are the files a running agent actually reads or runs: its instructions
-# (AGENTS.md, which CLAUDE.md symlinks), its skills, and its tooling (bin/).
+# (AGENTS.md, which CLAUDE.md symlinks), its agent-loaded skills
+# (.agents/skills/), and its tooling (bin/). Public skills/ is installer-facing
+# and intentionally not part of this watched instruction surface.
 changed_instr() {
   local dir=$1 base=$2 p out=""
   for p in AGENTS.md bin .agents/skills; do

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -108,6 +108,7 @@ The locked session-start bootstrap step separately propagates the primary's decl
 That propagation is primary-authoritative, re-runs even when tracked files were already current, mirrors absence when the primary clears the value, and deliberately never copies `config/secondmate-harness`.
 Dirty, diverged, unsafe, or in-flight homes are reported and left unchanged by the tracked-file sync.
 Only a running secondmate home that actually advanced and changed `AGENTS.md`, `bin/`, or `.agents/skills/` is listed for a re-read nudge.
+Changes under public `skills/` fast-forward like other tracked files, but they are not part of the running firstmate instruction surface.
 `fm-config-push.sh` is the focused mid-session version of that same inheritance path: it discovers the same live secondmate homes, calls the same propagation helper, and reports per-home/per-item results without running the tracked-file fast-forward or sending reread nudges.
 `fm-spawn.sh --secondmate` performs the same guarded local fast-forward before launch or recovery respawn; skipped syncs warn and the secondmate launches unchanged.
 Secondmate spawn also propagates the same inheritable config before launch.
@@ -170,7 +171,7 @@ The full ownership rule - what is project-intrinsic versus fleet-private, and ho
 
 `/stow` sweeps the current session for durable knowledge that only exists in conversation and routes each finding to the most specific disk home.
 Captain preferences go to `data/captain.md`, fleet-local operational facts and gotchas go to `data/learnings.md`, project-intrinsic knowledge goes through normal crewmate delivery into that project's committed `AGENTS.md`, and task-scoped notes or undone next steps go to the backlog.
-Generalizable firstmate knowledge goes to shared tracked docs through the normal PR pipeline; `/stow` deliberately never stores findings in skills.
+Generalizable firstmate knowledge goes to shared tracked docs through the normal PR pipeline; the firstmate-internal `/stow` deliberately never stores findings in either skill directory.
 
 ## Local clones stay fresh
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -130,7 +130,7 @@ In a read-only session that did not get the fleet lock, the same line is advisor
 The locked session-start bootstrap step also runs a best-effort project clone refresh through `fm-fleet-sync.sh`.
 It emits `FLEET_SYNC:` for skipped refreshes that may matter, recovered self-heals, and `STUCK:` alarms; local-only and no-origin skips stay silent.
 The locked session-start bootstrap step also runs the guarded local secondmate sync for recorded live secondmate homes, then propagates declared inheritable local config into each validated live home.
-It emits `SECONDMATE_SYNC:` only when a home was skipped for an actionable sync reason or config inheritance failed, and `NUDGE_SECONDMATES:` only when a running home advanced and its instruction surface changed.
+It emits `SECONDMATE_SYNC:` only when a home was skipped for an actionable sync reason or config inheritance failed, and `NUDGE_SECONDMATES:` only when a running home advanced and its instruction surface (`AGENTS.md`, `bin/`, or `.agents/skills/`) changed.
 For a mid-session inherited config edit where tracked-file sync and reread nudges are not needed, run `bin/fm-config-push.sh`.
 It uses the same live secondmate discovery and propagation helper as bootstrap, prints each live home's `crew-dispatch.json`, `crew-harness`, and `backlog-backend` result as `pushed`, `unchanged`, `skipped`, or `error`, and exits non-zero only for real propagation errors.
 That live discovery starts from `state/*.meta` records with `kind=secondmate`; `data/secondmates.md` only backfills `home=` for older or incomplete meta records.

--- a/skills/stow/SKILL.md
+++ b/skills/stow/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: stow
+description: Sweep the current conversation for durable knowledge - user preferences, project facts, operational gotchas, and unfinished next steps - and file each into wherever the project or user already keeps that kind of note, so nothing is lost when the session ends. Use when the user invokes /stow, asks to save or write down what was learned this session, or before a context reset or long break.
+user-invocable: true
+---
+
+<!-- maintainers: this is the public, installer-facing skill. The firstmate-internal counterpart lives at .agents/skills/stow/SKILL.md - deliberately a separate file with no shared code or environment branching. Keep them independent. -->
+
+# stow
+
+Sweep this conversation for durable knowledge that only exists in chat right now, and write it to wherever this project or user already keeps that kind of note.
+The goal is a conversation that is safe to end, reset, or hand off because everything durable has already been captured on disk (or in a tracker), not left stranded in the transcript.
+
+## What it does
+
+1. **Sweep the conversation for uncaptured durable knowledge.**
+   Read back over the session and look for:
+   - User preferences: a working-style, tooling, formatting, or approval preference the user stated in passing rather than through a config file.
+   - Project facts: build, test, deploy, architecture, or convention facts about the current project that would help anyone (or any agent) working in it later.
+   - Operational gotchas: a sharp edge, workaround, recurring mistake, or non-obvious cause discovered while working here.
+   - Undone next steps: anything left open or agreed to that has not yet been written down anywhere.
+
+2. **Discover the host's existing conventions before deciding where anything goes.**
+   Don't assume a destination - look for what's actually there, roughly in this order:
+   - A project-level memory file, such as `CLAUDE.md`, `AGENTS.md`, or an equivalent at the repo root or nearby.
+   - A user-level (global) memory file the running agent reads across projects, if one exists and is readable.
+   - A `TODO`, `BACKLOG`, `NOTES`, or similarly named plain file already tracked in the project.
+   - An issue tracker the repo evidently uses - a configured git host remote, a `.github/` or `.gitlab/` folder, or a tracker referenced in existing docs or config.
+   Use only what genuinely exists; do not invent a location that isn't already a convention here.
+
+3. **Route each finding to the most specific existing home.**
+   - User preferences -> the discovered user-level memory file, if one exists and is writable.
+   - Project facts -> the project's own memory file (e.g. `CLAUDE.md`/`AGENTS.md`), if it exists.
+   - Operational gotchas -> the same project memory file, or a project `NOTES`/`BACKLOG` file if that is this project's convention for that kind of thing.
+   - Undone next steps -> the project's issue tracker if it has one, otherwise its `TODO`/`BACKLOG` file.
+
+4. **When it's genuinely ambiguous, ask once - then remember the answer.**
+   If no discovered convention clearly fits a finding, or more than one plausibly does, ask the user once, plainly, where they want that kind of note to live going forward.
+   Once they answer, offer to remember it for next time: with their explicit permission, record a short standing note of that choice in the discovered (or newly agreed) user-level memory file, so the same question doesn't need to be asked again in this project.
+   Always ask before adding that note - never establish the convention silently on your own judgment.
+
+5. **Write only into locations that already exist as a real convention, or that the user just approved in step 4.**
+   Do not invent new note files, new folders, or new tracker categories the project doesn't already have.
+   If nothing existing fits and the user doesn't want to establish a new convention, say so plainly and leave that finding unfiled rather than fabricate a destination for it.
+
+6. **Curate, don't just append.**
+   When a finding overlaps or supersedes something already recorded, prefer editing or replacing the existing note over piling on a duplicate.
+
+7. **Finish with an honest safe-to-end verdict.**
+   Tell the user, in plain language, what was captured and where, what could not be captured (and why), and whether the conversation is now safe to end or reset - i.e. whether every durable finding from this sweep now lives on disk or in a tracker rather than only in this chat.
+   If something could not be captured yet, say so explicitly instead of reporting the session fully safe.
+
+## What this skill does not do
+
+It does not invent a new note-taking system, initialize version control, or commit/push anything on the user's behalf beyond editing a file the discovered convention already made writable.
+It never files credentials, secrets, or other sensitive material - only knowledge that's safe to keep in plain text wherever it lands.

--- a/skills/stow/SKILL.md
+++ b/skills/stow/SKILL.md
@@ -54,11 +54,11 @@ Everything this skill files goes to a local file by default; it only ever reache
    When a finding overlaps or supersedes something already recorded, prefer editing or replacing the existing note over piling on a duplicate.
 
 7. **Finish with an honest safe-to-end verdict.**
-   Tell the user, in plain language, what was captured and where, what could not be captured (and why), and whether the conversation is now safe to end or reset - i.e. whether every durable finding from this sweep now lives on disk or in a tracker rather than only in this chat.
+   Tell the user, in plain language, what was captured and where, what could not be captured (and why), and whether the conversation is now safe to end or reset - i.e. whether every durable finding from this sweep now lives on disk or in an explicitly requested tracker rather than only in this chat.
    If something could not be captured yet, say so explicitly instead of reporting the session fully safe.
 
 ## What this skill does not do
 
-It does not invent a new note-taking system, initialize version control, or commit/push anything on the user's behalf beyond editing a file the discovered convention already made writable.
+It does not invent a new note-taking system, initialize version control, or commit/push anything on the user's behalf beyond editing a file the discovered convention already made writable, creating the local scratch-file fallback for undone next steps, or using a destination the user explicitly approved.
 It never files credentials, secrets, or other sensitive material - only knowledge that's safe to keep in plain text wherever it lands.
 It never files anything to an issue tracker, hosted board, or other external/public system on its own inference - that only ever happens on the user's explicit say-so, per the hard rule in step 3.

--- a/skills/stow/SKILL.md
+++ b/skills/stow/SKILL.md
@@ -9,7 +9,8 @@ user-invocable: true
 # stow
 
 Sweep this conversation for durable knowledge that only exists in chat right now, and write it to wherever this project or user already keeps that kind of note.
-The goal is a conversation that is safe to end, reset, or hand off because everything durable has already been captured on disk (or in a tracker), not left stranded in the transcript.
+The goal is a conversation that is safe to end, reset, or hand off because everything durable has already been captured on disk, not left stranded in the transcript.
+Everything this skill files goes to a local file by default; it only ever reaches an external system such as an issue tracker when you have explicitly said to use one.
 
 ## What it does
 
@@ -25,24 +26,28 @@ The goal is a conversation that is safe to end, reset, or hand off because every
    - A project-level memory file, such as `CLAUDE.md`, `AGENTS.md`, or an equivalent at the repo root or nearby.
    - A user-level (global) memory file the running agent reads across projects, if one exists and is readable.
    - A `TODO`, `BACKLOG`, `NOTES`, or similarly named plain file already tracked in the project.
-   - An issue tracker only when there is real evidence issues are the active backlog convention, such as a tracker explicitly referenced in the project's own docs or config, or existing open-issue activity visible to the current tools.
-     A configured git host remote or a bare `.github/`/`.gitlab/` folder is only weak hosting evidence; use it to identify a possible tracker, not to make the tracker the suggested destination.
-   Use only what genuinely exists; do not invent a location that isn't already a convention here.
+   This step is about local, private files only.
+   Do not scan for or infer an issue tracker here - see the hard rule in step 3.
 
-3. **Route each finding to the most specific existing home.**
+3. **Route each finding to the most specific existing home, local-first.**
    - User preferences -> the discovered user-level memory file, if one exists and is writable.
    - Project facts -> the project's own memory file (e.g. `CLAUDE.md`/`AGENTS.md`), if it exists.
    - Operational gotchas -> the same project memory file, or a project `NOTES`/`BACKLOG` file if that is this project's convention for that kind of thing.
-   - Undone next steps -> the project's `TODO`/`BACKLOG`/`NOTES` file when that exists, or the project's issue tracker only when real active-backlog evidence exists and the user explicitly confirms filing that specific item there.
-     Before creating any external/public tracker item, always ask the user for explicit confirmation first; never silently file GitHub/GitLab issues or other external tracker records.
+   - Undone next steps -> **always local by default**: the project's `TODO`/`BACKLOG`/`NOTES` file when one already exists, or otherwise a small local notes/scratch file you create for this purpose.
+     A freshly created local notes file lives only on the user's own machine, is private, and is trivially reversible, so creating one for this specific case is fine even though step 5 otherwise avoids inventing new files.
+   **Hard rule: never route anything to an external or public system - an issue tracker, a hosted project board, a ticketing system, or similar - based on inference or heuristics.**
+   A configured git host remote, a `.github/`/`.gitlab/` folder, or any other signal that a tracker probably exists is never by itself grounds to file anything there.
+   Use a tracker (or any other non-local system) only when the user has explicitly told you to - either said plainly earlier in this conversation, or previously recorded as a standing choice in the discovered user-level memory file (see step 4).
+   Absent that explicit instruction, everything stays local, and no confirmation dance is needed for the local-first default itself.
 
 4. **When it's genuinely ambiguous, ask once - then remember the answer.**
-   If no discovered convention clearly fits a finding, or more than one plausibly does, ask the user once, plainly, where they want that kind of note to live going forward.
-   Once they answer, offer to remember it for next time: with their explicit permission, record a short standing note of that choice in the discovered (or newly agreed) user-level memory file, so the same question doesn't need to be asked again in this project.
+   If no discovered convention clearly fits a finding (for user preferences, project facts, or operational gotchas), or more than one plausibly does, ask the user once, plainly, where they want that kind of note to live going forward.
+   The same applies if the user gives an explicit instruction to use a tracker or other non-local system going forward rather than just for one item right now.
+   Once they answer, offer to remember it for next time: with their explicit permission, record a short standing note of that choice in the discovered (or newly agreed) user-level memory file, so the same question - or the same tracker instruction - doesn't need to be repeated in this project.
    Always ask before adding that note - never establish the convention silently on your own judgment.
 
-5. **Write only into locations that already exist as a real convention, or that the user just approved in step 4.**
-   Do not invent new note files, new folders, or new tracker categories the project doesn't already have.
+5. **Write only into locations that already exist as a real convention, the local scratch-file fallback from step 3, or a destination the user just approved in step 4.**
+   Do not invent new shared files, new folders, or new tracker categories the project doesn't already have.
    If nothing existing fits and the user doesn't want to establish a new convention, say so plainly and leave that finding unfiled rather than fabricate a destination for it.
 
 6. **Curate, don't just append.**
@@ -56,3 +61,4 @@ The goal is a conversation that is safe to end, reset, or hand off because every
 
 It does not invent a new note-taking system, initialize version control, or commit/push anything on the user's behalf beyond editing a file the discovered convention already made writable.
 It never files credentials, secrets, or other sensitive material - only knowledge that's safe to keep in plain text wherever it lands.
+It never files anything to an issue tracker, hosted board, or other external/public system on its own inference - that only ever happens on the user's explicit say-so, per the hard rule in step 3.

--- a/skills/stow/SKILL.md
+++ b/skills/stow/SKILL.md
@@ -25,14 +25,16 @@ The goal is a conversation that is safe to end, reset, or hand off because every
    - A project-level memory file, such as `CLAUDE.md`, `AGENTS.md`, or an equivalent at the repo root or nearby.
    - A user-level (global) memory file the running agent reads across projects, if one exists and is readable.
    - A `TODO`, `BACKLOG`, `NOTES`, or similarly named plain file already tracked in the project.
-   - An issue tracker the repo evidently uses - a configured git host remote, a `.github/` or `.gitlab/` folder, or a tracker referenced in existing docs or config.
+   - An issue tracker only when there is real evidence issues are the active backlog convention, such as a tracker explicitly referenced in the project's own docs or config, or existing open-issue activity visible to the current tools.
+     A configured git host remote or a bare `.github/`/`.gitlab/` folder is only weak hosting evidence; use it to identify a possible tracker, not to make the tracker the suggested destination.
    Use only what genuinely exists; do not invent a location that isn't already a convention here.
 
 3. **Route each finding to the most specific existing home.**
    - User preferences -> the discovered user-level memory file, if one exists and is writable.
    - Project facts -> the project's own memory file (e.g. `CLAUDE.md`/`AGENTS.md`), if it exists.
    - Operational gotchas -> the same project memory file, or a project `NOTES`/`BACKLOG` file if that is this project's convention for that kind of thing.
-   - Undone next steps -> the project's issue tracker if it has one, otherwise its `TODO`/`BACKLOG` file.
+   - Undone next steps -> the project's `TODO`/`BACKLOG`/`NOTES` file when that exists, or the project's issue tracker only when real active-backlog evidence exists and the user explicitly confirms filing that specific item there.
+     Before creating any external/public tracker item, always ask the user for explicit confirmation first; never silently file GitHub/GitLab issues or other external tracker records.
 
 4. **When it's genuinely ambiguous, ask once - then remember the answer.**
    If no discovered convention clearly fits a finding, or more than one plausibly does, ask the user once, plainly, where they want that kind of note to live going forward.

--- a/tests/fm-secondmate-sync.test.sh
+++ b/tests/fm-secondmate-sync.test.sh
@@ -76,7 +76,7 @@ add_sm_worktree() {
 }
 
 # bump_primary <w> <mode>: advance the PRIMARY's main branch by one local commit.
-# instr changes the instruction surface (AGENTS.md, bin, skills) plus README;
+# instr changes the instruction surface (AGENTS.md, bin, .agents/skills) plus README;
 # readme changes only README. No push - the sync follows the primary's local HEAD.
 bump_primary() {
   local w=$1 mode=$2

--- a/tests/fm-update.test.sh
+++ b/tests/fm-update.test.sh
@@ -12,7 +12,7 @@
 #     fast-forward of one worktree never disturbs another worktree's checkout
 #     or the shared default branch.
 #   - The caller-action summary is correct: reread-firstmate flips to yes only
-#     when the instruction surface (AGENTS.md / bin / skills) changed, and
+#     when the instruction surface (AGENTS.md / bin / .agents/skills) changed, and
 #     nudge-secondmates lists exactly the live secondmates that advanced.
 #   - Secondmate homes resolve from both state/<id>.meta and the
 #     data/secondmates.md registry, deduped, and the firstmate repo is never
@@ -31,7 +31,7 @@ TMP_ROOT=$(fm_test_tmproot fm-update-tests)
 
 # Build a fresh world: a bare origin seeded with one commit, a firstmate repo
 # clone checked out on main, and a home dir with state/ and data/. Echoes the
-# world dir. Files seeded: AGENTS.md, README.md, bin/tool.sh, a skill note.
+# world dir. Files seeded: AGENTS.md, README.md, bin/tool.sh, and an internal skill note.
 new_world() {
   local name=$1 w
   w="$TMP_ROOT/$name"
@@ -72,7 +72,7 @@ add_sm() {
 }
 
 # Advance origin by one commit. mode=instr changes the instruction surface
-# (AGENTS.md, bin, skills) plus README; mode=readme changes only README.
+# (AGENTS.md, bin, .agents/skills) plus README; mode=readme changes only README.
 bump_origin() {
   local w=$1 mode=$2
   git -C "$w/seed" pull -q origin main >/dev/null 2>&1 || true


### PR DESCRIPTION
## Intent

Follow-up to the earlier /no-mistakes run on this branch (fm/fm-skills-internal-audit-p5, PR #221). The review gate previously flagged finding public-stow-tracker-side-effect: the new standalone skills/stow/SKILL.md routed undone next steps to a repo's issue tracker based on weak inferred signals (a git host remote, a .github/ folder), without asking first - a real risk since a public installer-facing skill running in a stranger's repo could create real, public tracker items unprompted. The first fix round (commit b4c8216, 'Tighten public stow tracker routing') applied the captain's initial call: require explicit per-item confirmation before any tracker write, and require stronger evidence before even suggesting a tracker. The captain then REVISED that decision further (superseding the first one) to be safety-maximal: undone next steps must ALWAYS default to a local file (an existing TODO/BACKLOG/NOTES file, or a freshly created local scratch file otherwise) with no tracker-detection heuristics at all; the skill must NEVER route anything to an external/public system (issue tracker, hosted board, etc.) based on any inference, including a detected git remote or .github/.gitlab folder presence - a tracker (or any other non-local system) is only ever used when the user has given EXPLICIT instruction to do so, either in the current conversation or as a previously recorded standing preference in the discovered user-level memory file. This new commit (892b02e) implements that revised, stricter rule: it removes the issue-tracker discovery/detection step entirely from step 2, makes step 3's 'Undone next steps' routing always local-first (existing TODO/BACKLOG/NOTES file, else a newly created local scratch file - justified as safe since it is local, private, and reversible), states the hard rule that external/public systems are only used on the user's explicit say-so (this session or a remembered standing preference), and updates the intro paragraph and the 'What this skill does not do' closing section to match. This should resolve the public-stow-tracker-side-effect finding more cleanly than the prior fix, since the local-first default removes the need for any ask-before-filing dance in the common case.

## What Changed
- Added the public standalone `stow` skill while marking internal agent-only skills as hidden from installer discovery.
- Tightened public `stow` routing so unfinished next steps stay local by default and external trackers are used only with explicit user direction.
- Updated firstmate docs and sync tests to reflect internal-skill metadata and standalone skill distribution behavior.

## Risk Assessment

✅ Low: Captain, the branch is mostly documentation plus a new standalone skill, and the reviewed changes keep the public stow workflow local-first without introducing a substantiated merge-blocking risk.

## Testing

The configured baseline suite had already passed; I reran the same suite on the target commit, inspected the standalone stow skill, and produced a reviewer-visible acceptance transcript for a GitHub-remote/.github scenario with no local task file, confirming the skill still keeps undone next steps local unless the user explicitly opts into an external tracker.

<details>
<summary>Evidence: Public stow local-first routing evidence</summary>

<code>Acceptance transcript showing a scratch repo with a GitHub remote and `.github/` still routes undone stow next steps local-first, with all targeted checks passing.</code>

```text
Public stow routing acceptance evidence
Source skill: /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KWMNTRPF3P9D47SPCV8KQA27/skills/stow/SKILL.md
Source commit: fa9f40938779a914694496485ac95e202f910494

Scenario visible to an end user invoking the standalone stow skill:
- Scratch repo path: /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KWMNTRPF3P9D47SPCV8KQA27/public-stow-scenario-repo
- Git remote present: git@github.com:example/public-repo.git
- GitHub folder present: yes
- Existing TODO/BACKLOG/NOTES files: none

Reviewer-visible skill instructions that govern this scenario:
    24	2. **Discover the host's existing conventions before deciding where anything goes.**
    25	   Don't assume a destination - look for what's actually there, roughly in this order:
    26	   - A project-level memory file, such as `CLAUDE.md`, `AGENTS.md`, or an equivalent at the repo root or nearby.
    27	   - A user-level (global) memory file the running agent reads across projects, if one exists and is readable.
    28	   - A `TODO`, `BACKLOG`, `NOTES`, or similarly named plain file already tracked in the project.
    29	   This step is about local, private files only.
    30	   Do not scan for or infer an issue tracker here - see the hard rule in step 3.
    31	
    32	3. **Route each finding to the most specific existing home, local-first.**
    33	   - User preferences -> the discovered user-level memory file, if one exists and is writable.
    34	   - Project facts -> the project's own memory file (e.g. `CLAUDE.md`/`AGENTS.md`), if it exists.
    35	   - Operational gotchas -> the same project memory file, or a project `NOTES`/`BACKLOG` file if that is this project's convention for that kind of thing.
    36	   - Undone next steps -> **always local by default**: the project's `TODO`/`BACKLOG`/`NOTES` file when one already exists, or otherwise a small local notes/scratch file you create for this purpose.
    37	     A freshly created local notes file lives only on the user's own machine, is private, and is trivially reversible, so creating one for this specific case is fine even though step 5 otherwise avoids inventing new files.
    38	   **Hard rule: never route anything to an external or public system - an issue tracker, a hosted project board, a ticketing system, or similar - based on inference or heuristics.**
    39	   A configured git host remote, a `.github/`/`.gitlab/` folder, or any other signal that a tracker probably exists is never by itself grounds to file anything there.
    40	   Use a tracker (or any other non-local system) only when the user has explicitly told you to - either said plainly earlier in this conversation, or previously recorded as a standing choice in the discovered user-level memory file (see step 4).
    41	   Absent that explicit instruction, everything stays local, and no confirmation dance is needed for the local-first default itself.
    60	## What this skill does not do
    61	
    62	It does not invent a new note-taking system, initialize version control, or commit/push anything on the user's behalf beyond editing a file the discovered convention already made writable.
    63	It never files credentials, secrets, or other sensitive material - only knowledge that's safe to keep in plain text wherever it lands.
    64	It never files anything to an issue tracker, hosted board, or other external/public system on its own inference - that only ever happens on the user's explicit say-so, per the hard rule in step 3.

Executable acceptance checks against the skill text:
PASS - discovery is limited to local/private files
PASS - tracker discovery is removed from convention discovery
PASS - undone next steps default to local routing
PASS - missing TODO/BACKLOG/NOTES falls back to a local scratch file
PASS - external/public routing by inference is forbidden
PASS - git remote and .github/.gitlab signals are explicitly ignored
PASS - external tracker use requires explicit current or remembered user instruction
PASS - closing section repeats the no-inferred-external-write rule

Result: In a repo with both a GitHub remote and .github/ metadata, the standalone public stow skill still instructs the agent to keep undone next steps local by default and to use external trackers only on explicit user instruction.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- <code>Baseline already completed before this validator run: `command -v tmux &gt;/dev/null || { echo &#34;tmux is required for e2e tests&#34; &gt;&amp;2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo &#34;== $t ==&#34;; bash &#34;$t&#34; || rc=1; done; exit &#34;$rc&#34;`</code>
- <code>Target rerun: `command -v tmux &gt;/dev/null || { echo &#34;tmux is required for e2e tests&#34; &gt;&amp;2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo &#34;== $t ==&#34;; bash &#34;$t&#34; || rc=1; done; exit &#34;$rc&#34;`</code>
- <code>Inspected the public skill surface with `nl -ba skills/stow/SKILL.md` and targeted `rg` searches for tracker, remote, GitHub/GitLab, external, explicit, TODO/BACKLOG/NOTES, and scratch-file routing terms.</code>
- <code>Created `/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KWMNTRPF3P9D47SPCV8KQA27/public-stow-scenario-repo` with a GitHub remote, `.github/`, and no TODO/BACKLOG/NOTES files, then checked the skill text requires local-first scratch-file routing and forbids inferred tracker writes.</code>
- <code>Final cleanup check: `git status --short` returned clean.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
