### PR TITLE
feat(harness): add cursor agent harness adapter

### DIFF
--- a/.agents/skills/afk/SKILL.md
+++ b/.agents/skills/afk/SKILL.md
@@ -74,7 +74,7 @@ separator, 0x1f), invisible and untypable. This is how firstmate tells a
 daemon escalation apart from a real message in the same pane. The marker
 travels with the message text; it does not rely on harness-level
 typed-vs-injected detection (which is not portable across claude, codex,
-opencode, pi, and grok).
+opencode, pi, grok, and cursor).
 
 ## Busy-guard and composer guard
 

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harness-adapters
-description: Agent-only reference for firstmate harness operations. Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter. Contains verified facts for claude, codex, opencode, pi, and grok.
+description: Agent-only reference for firstmate harness operations. Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter. Contains verified facts for claude, codex, opencode, pi, grok, and cursor.
 user-invocable: false
 metadata:
   internal: true
@@ -34,6 +34,7 @@ If the captain asks for a new harness, propose verifying it first: spawn a trivi
 ## Detection
 
 `bin/fm-harness.sh` prints firstmate's own harness, using verified env markers first and then process ancestry.
+Cursor's marker is `CURSOR_AGENT=1`, checked after claude/pi/grok to stay preference-neutral; its ancestry token is `cursor-agent`.
 `bin/fm-harness.sh crew` resolves the effective crewmate harness from `config/crew-harness` (absent or `default` -> own).
 `bin/fm-harness.sh secondmate` resolves the secondmate-launch harness through the chain `config/secondmate-harness` -> `config/crew-harness` -> own, so an unset `config/secondmate-harness` matches the crew harness.
 `bin/fm-spawn.sh` uses `crew` mode for a crewmate/scout launch and `secondmate` mode for a `--secondmate` launch, re-resolving on every spawn so the split is durable across respawns; an explicit per-spawn harness arg overrides either.
@@ -57,6 +58,7 @@ The supported launch-profile flags below were verified locally on 2026-06-30 wit
 | grok | `--model <model>` | `--reasoning-effort <low\|medium\|high\|xhigh>` | Verified on grok 0.2.73. `--effort` parses too, but firstmate's profile axis is reasoning effort. `--reasoning-effort max` is rejected, so `max` is omitted. |
 | pi | `--model <model>` | `--thinking <low\|medium\|high\|xhigh>` | Verified on pi 0.80.2. `max` prints an invalid-thinking warning, so firstmate omits Pi effort when the requested effort is `max`. |
 | opencode | `--model <provider/model>` | none for firstmate's interactive launch | Verified on opencode 1.17.6. `opencode run` has `--variant`, but firstmate launches the interactive `opencode --prompt` path, which has no verified effort flag. |
+| cursor | `--model <full-id>` | none - effort encoded in the model id | Verified on cursor-agent 2026.07.01. No effort flag: the effort tier is part of the model id (e.g. `claude-opus-4-8-thinking-max`). Autonomy is `--force`. |
 
 When a requested effort value is outside the harness-specific accepted set, `fm-spawn` records the requested `effort=` in meta but emits no effort flag for that harness.
 This preserves launch success instead of passing a known-bad value.
@@ -71,6 +73,7 @@ Natural language is acceptable if uncertain.
 - opencode: no separate verified skill invocation beyond normal slash-command behavior; use natural language if the exact skill command is uncertain.
 - pi: no separate verified skill invocation beyond normal command behavior; use natural language if the exact skill command is uncertain.
 - grok: `/<skill>`, for example `/no-mistakes` (same form as claude). Verified end to end: grok discovers the user-level `no-mistakes` skill, `/no-mistakes` invokes it, and grok drives a real `no-mistakes axi run`. Like codex's `$`/`/` popups, typing `/<skill>` opens grok's slash-autocomplete, so a too-fast Enter selects the popup entry instead of sending, and for an argument-taking command (like `/no-mistakes`'s optional task-first argument) that first Enter only expands the popup selection into an argument-hint placeholder rather than submitting - a genuine second Enter is required (see the grok section below for the 2026-07-03 incident and fix). `fm_tmux_submit_core`'s retried Enter (used by `fm-send` on the tmux backend) already handles this correctly by reading the cursor row; the herdr backend needed a dedicated fix (`fm_backend_herdr_composer_state`, docs/herdr-backend.md) because its prior delta-based verification false-positived on that same popup-close content change.
+- cursor: `/<skill>`, for example `/no-mistakes` (Cursor uses slash commands). Confirm end to end on the first real no-mistakes run; if a slash-autocomplete popup appears, `fm-send`'s retried Enter lands it as with codex/grok.
 
 ## claude (VERIFIED)
 
@@ -184,3 +187,25 @@ The hook reads `$GROK_WORKSPACE_ROOT`, which is always set for hooks and equals 
 This keeps the hook outside the worktree, needs no trust grant, and writes only firstmate-owned files.
 `fm-teardown` removes the worktree pointer before returning a pooled worktree.
 Secondmate spawns skip the pointer (idle panes are healthy, no stale-pane detection for them).
+
+## cursor (VERIFIED 2026-07-02, cursor-agent 2026.07.01)
+
+Cursor agent CLI. Launch with a positional prompt: `cursor-agent --force "$(cat <brief>)"`.
+The canonical binary is `cursor-agent` (the `agent` command is a symlink to it); use `cursor-agent` in the ancestry and lock matchers, never the generic `agent`.
+
+| Fact | Value |
+|---|---|
+| Busy-pane signature | `ctrl+c to stop` (mid-turn footer hint, shown iff a turn is running; also a `Working` spinner). ASCII, locale-safe. |
+| Exit command | UNRESOLVED - `Ctrl+D` and `/quit` did not exit the TUI in testing; teardown kills the tmux window regardless, so this is non-blocking. Revisit if a graceful exit is ever needed. |
+| Interrupt | single `Ctrl+C` (the on-screen `ctrl+c to stop` hint). |
+| Skill invocation | `/<skill>` (e.g. `/no-mistakes`); Cursor uses slash commands. Confirm end-to-end on the first real no-mistakes run. |
+| Autonomy | `--force` (footer shows `Run Everything`); auto-approves every tool execution, verified to run unattended. |
+| Env marker | `CURSOR_AGENT=1`, set for cursor-agent child/tool processes; `CLAUDECODE` is unset. Detection checks `CURSOR_AGENT` AFTER claude/pi/grok so it stays preference-neutral (a genuine Claude session, including one nested in Cursor, resolves to claude). |
+| Resume | `cursor-agent resume` / `--continue` / `--resume <id>`. |
+| Model/effort | `--model <full-id>`; NO effort flag - effort is encoded in the model id (e.g. `claude-opus-4-8-thinking-max`). |
+
+Directory trust dialog on first run per repo: "Do you trust the contents of this directory?" - accept by sending `a`. Peek the pane after spawn and accept, like claude/codex/pi.
+
+Turn-end: cursor fires a `stop` hook at every turn boundary in INTERACTIVE sessions (it does NOT fire in `-p` headless mode, but crewmates run interactively). The stop payload arrives on stdin as JSON including `workspace_roots` (absolute paths); the hook must emit `{}` on stdout. Because cursor hooks live in the operator's SHARED `~/.cursor/hooks.json` (or `$CURSOR_CONFIG_DIR`), `fm-spawn` MERGES a firstmate-owned stop hook idempotently - preserving existing `sessionStart`/`stop` hooks - rather than writing standalone files like grok. The hook is a guarded no-op unless a workspace in the payload holds a `.fm-cursor-turnend` token pointer matching the firstmate registry. The installed hook shells out to `jq`; if `jq` is absent it fails safe to a no-op (turn-end wakes silently stop), so `jq` is a runtime dependency for cursor crewmate supervision.
+
+ZDR/compliance: crewmate models must be ZDR-safe (e.g. `claude-opus-4-8-thinking-max`, `claude-opus-4-8-thinking-high-fast`). Fable 5 is non-ZDR and must not be used. This is a convention only: `effort_ok` in `fm-bootstrap.sh` has no cursor arm, so cursor model ids and effort are not machine-validated.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,7 @@ state/               volatile runtime signals; gitignored
   <id>.status        appended by crewmates: "<state>: <note>" wake-event lines, not current-state truth
   <id>.turn-ended    touched by turn-end hooks
   <id>.grok-turnend-token   firstmate-owned grok hook registry token for the task; removed by teardown
+  <id>.cursor-turnend-token firstmate-owned cursor hook registry token for the task; removed by teardown
   <id>.meta          written by fm-spawn: window=, worktree=, project=, harness=, model=, effort=, kind=, mode=, yolo=, tasktmp=; kind=secondmate also records home= and projects=; a task on a non-default spawn-capable runtime backend also records backend= (absent means tmux, the verified reference backend; herdr and zellij are experimental backends - herdr records herdr_session=, herdr_workspace_id=, herdr_tab_id=, herdr_pane_id= (docs/herdr-backend.md), zellij records zellij_session=, zellij_tab_id=, zellij_pane_id= (docs/zellij-backend.md); orca is primitive-only and cannot create task meta yet; bin/fm-backend.sh, section 8) (fm-pr-check, including through fm-pr-merge, appends pr= and GitHub's pr_head= when available; fm-x-link appends x_request= and x_request_ts= for an X-mention-originated task, section 14)
   <id>.check.sh      optional slow poll you write per task (e.g. merged-PR check)
   x-watch.check.sh   generated X-mode relay poll shim; present only when opted in (section 14)
@@ -200,7 +201,7 @@ If the captain expresses a standing dispatch preference such as "use grok for ne
 Crewmates default to the same harness you are running on.
 The captain may override the static default at any time, typically at bootstrap: record the choice in `config/crew-harness` (a single adapter name; absent or `default` means mirror your own harness).
 Resolve `default` with `bin/fm-harness.sh`; resolve the active static crewmate harness with `bin/fm-harness.sh crew`.
-Verified adapter names are `claude`, `codex`, `opencode`, `pi`, and `grok`.
+Verified adapter names are `claude`, `codex`, `opencode`, `pi`, `grok`, and `cursor`.
 
 ### Crew dispatch profiles
 
@@ -262,6 +263,7 @@ The verified profile axes are:
 - `grok`: model via `--model <name>`, reasoning effort via `--reasoning-effort <low|medium|high|xhigh>`; `max` is not passed because Grok rejects it for `--reasoning-effort`.
 - `pi`: model via `--model <name>`, effort via `--thinking <low|medium|high|xhigh>`; `max` is not passed because the installed Pi CLI warns that it is invalid.
 - `opencode`: model via `--model <provider/model>`; no verified effort flag for firstmate's interactive `opencode --prompt` launch, so effort is not passed.
+- `cursor`: model via `--model <full-id>`; no effort flag because the effort tier is encoded in the model id (e.g. `claude-opus-4-8-thinking-max`), so effort is not passed.
 
 If the selected profile asks for an effort value the selected harness does not accept, `fm-spawn` records the requested `effort=` in meta for traceability but omits the launch flag so the harness starts successfully.
 Bootstrap reports this as a `CREW_DISPATCH` diagnostic when it can see the invalid harness/effort pair in `config/crew-dispatch.json`.
@@ -513,6 +515,7 @@ For `kind=secondmate`, the same script launches in the registered or explicit fi
 For ship and scout tasks, the script creates the runtime endpoint (a tmux window by default, a herdr tab/pane when `backend=herdr`, or a zellij tab/pane when `backend=zellij`), runs `treehouse get`, waits for the worktree subshell, asserts the resolved worktree is a genuine isolated worktree distinct from the primary checkout (aborting the spawn otherwise, to prevent the worktree tangle of section 8), installs the turn-end hook, records `state/<id>.meta`, and launches the agent with the brief.
 Selecting `backend=orca` for a spawn fails before endpoint creation or meta writes because the Orca adapter currently exposes only capture, text send, Enter/Ctrl-C keys, and close for existing terminals.
 For grok, the turn-end hook is one firstmate-owned global hook under `$GROK_HOME/hooks/`, or `~/.grok/hooks/` when `GROK_HOME` is unset, activated only when the worktree holds the per-task `.fm-grok-turnend` token pointer that matches `state/<id>.grok-turnend-token`; teardown removes the pointer and token.
+For cursor, the turn-end hook is one firstmate-owned `stop` hook script merged idempotently into the operator's shared `~/.cursor/hooks.json` (or `$CURSOR_CONFIG_DIR/hooks.json`), preserving existing hooks, activated only when a workspace in the stop payload holds the per-task `.fm-cursor-turnend` token pointer that matches `state/<id>.cursor-turnend-token`; teardown removes the pointer and token.
 For `kind=secondmate`, the script creates the same kind of runtime endpoint but starts directly in the persistent home.
 With herdr, ordinary crewmate and scout spawns use the current `FM_HOME` workspace; a primary `--secondmate` spawn uses the secondmate target home's workspace, so secondmate-owned tabs do not mix into the primary `firstmate` space.
 With zellij there is no per-home workspace split: every task, primary or secondmate, lands as a tab in the one shared `firstmate` zellij session (docs/zellij-backend.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,7 @@ tests/fm-afk-inject-e2e.test.sh           # private-socket end-to-end test of th
 tests/fm-bootstrap.test.sh                # bootstrap dependency, feature-probe, and crew-dispatch reporting tests
 tests/fm-session-start.test.sh            # fm-session-start.sh: ABSENT vs empty-vs-present digest files, lock-refusal read-only path skipping every mutating step, diagnostics-first section ordering, status-tail bounding, tmux/herdr/zellij endpoint liveness, and composition of the real fm-lock/fm-bootstrap/fm-wake-drain scripts
 tests/fm-grok-harness.test.sh             # grok adapter spawn hook, token guard, teardown cleanup, and session-lock detection tests
+tests/fm-cursor-harness.test.sh           # cursor adapter env-marker detection (with claude precedence), fm-lock holder recognition, launch template, hooks.json stop-hook merge/guard, and teardown pointer/token cleanup
 tests/fm-fleet-sync.test.sh               # project clone refresh: safe detached recovery, STUCK drift reports, benign skips, and bootstrap relay
 tests/fm-x-mode.test.sh                   # X-mode poll, inbox context round-trip, reply threading, dismiss, dry-run preview, and .env-presence activation tests
 tests/fm-tangle-guard.test.sh             # primary-checkout tangle detection, read-only remediation suppression, and spawn/brief isolation tests

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Full architecture - the supervision engine, worktree isolation, secondmates, pro
 ## Built-in skills
 
 Firstmate ships these user-invocable built-in skills.
-Claude and grok use the slash form shown here; codex uses the same names with `$`, such as `$afk`.
+Claude, grok, and cursor use the slash form shown here; codex uses the same names with `$`, such as `$afk`.
 
 | Skill              | What it does                                                                                                                                  |
 | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Full detail on every feature lives in [docs/architecture.md](docs/architecture.m
 
 ## Quick Start
 
-**Requirements:** a verified agent harness (claude, codex, opencode, pi, or grok), git with GitHub auth, and tmux for the reference session backend.
+**Requirements:** a verified agent harness (claude, codex, opencode, pi, grok, or cursor), git with GitHub auth, and tmux for the reference session backend.
 Experimental herdr spawns additionally require `herdr` and `jq`, checked at spawn time.
 Experimental zellij spawns additionally require `zellij` and `jq`, checked at spawn time.
 Primitive-only Orca terminal capture, text send, Enter/Ctrl-C keys, and close require the `orca` CLI only when `backend=orca` is selected, but Orca cannot spawn tasks yet.

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -332,7 +332,7 @@ crew_dispatch_validate() {
     return 0
   fi
   err=$(jq -r '
-    def verified($h): ["claude","codex","opencode","pi","grok"] | index($h);
+    def verified($h): ["claude","codex","opencode","pi","grok","cursor"] | index($h);
     def effort_ok($h; $e):
       if $e == null then true
       elif ($e | type) != "string" then false

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Detect the agent harness this process tree runs on.
-# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|grok|unknown
+# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|grok|cursor|unknown
 #        fm-harness.sh crew             print the effective CREWMATE harness
 #                                        (config/crew-harness; "default" resolves to own)
 #        fm-harness.sh secondmate       print the harness the PRIMARY uses to launch

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -35,6 +35,12 @@ detect_own() {
   # It does NOT set CLAUDECODE despite being Claude-Code-compatible, so this marker
   # is unambiguous when firstmate runs natively on grok.
   [ "${GROK_AGENT:-}" = "1" ] && { echo grok; return; }
+  # Cursor sets CURSOR_AGENT=1 for its agent processes (verified 2026-07-02).
+  # Checked AFTER claude/pi/grok so detection stays preference-neutral: a genuine
+  # Claude session (CLAUDECODE=1), including one nested inside a Cursor context,
+  # still resolves to claude. CURSOR_AGENT and CLAUDECODE do not co-occur in a
+  # normal Cursor session, so ordering does not change the result there.
+  [ "${CURSOR_AGENT:-}" = "1" ] && { echo cursor; return; }
   # Layer 2: walk the parent chain and match the command name.
   local pid=$$ comm args
   for _ in 1 2 3 4 5 6 7 8; do
@@ -44,6 +50,7 @@ detect_own() {
       *codex*) echo codex; return ;;
       *opencode*) echo opencode; return ;;
       *grok*) echo grok; return ;;
+      *cursor-agent*) echo cursor; return ;;
       pi) echo pi; return ;;
       node*|python*)
         # Bare interpreter: match the harness name in its script path.
@@ -53,6 +60,7 @@ detect_own() {
           *codex*) echo codex; return ;;
           *opencode*) echo opencode; return ;;
           *grok*) echo grok; return ;;
+          *cursor-agent*) echo cursor; return ;;
           *" pi "*|*/pi) echo pi; return ;;
         esac ;;
     esac

--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -15,7 +15,7 @@ LOCK="$STATE/.lock"
 mkdir -p "$STATE"
 
 # Known harness command names; extend when a new adapter is verified.
-HARNESS_RE='claude|codex|opencode|grok|^pi$'
+HARNESS_RE='claude|codex|opencode|grok|cursor-agent|^pi$'
 
 harness_pid() {
   local pid=$$ comm args

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -197,7 +197,7 @@ FIRSTMATE_HOME=
 
 if [ "$KIND" = secondmate ]; then
   case "${POS[1]:-}" in
-    ''|claude|codex|opencode|pi|grok)
+    ''|claude|codex|opencode|pi|grok|cursor)
       ARG3=${POS[1]:-}
       ;;
     *' '*)
@@ -258,6 +258,15 @@ launch_template() {
     # launch command - it is a Stop-event hook installed below (global hook +
     # per-task pointer), so the template is identical for ship/scout/secondmate.
     grok) printf '%s' 'grok --always-approve __MODELFLAG____EFFORTFLAG__"$(cat __BRIEF__)"' ;;
+    # cursor (Cursor agent CLI): a positional prompt starts the supervised
+    # interactive session. --force auto-approves every tool execution (footer shows
+    # "Run Everything") - the unattended-crewmate equivalent of claude's
+    # --dangerously-skip-permissions. There is no effort flag: effort is encoded in
+    # the model id (e.g. claude-opus-4-8-thinking-max), so no __EFFORTFLAG__. The
+    # turn-end signal does NOT ride the launch command - it is a Stop-event hook
+    # installed below (global hook merged into ~/.cursor/hooks.json + per-task
+    # pointer), so the template is identical for ship/scout/secondmate.
+    cursor) printf '%s' 'cursor-agent __MODELFLAG__--force "$(cat __BRIEF__)"' ;;
     *) return 1 ;;
   esac
 }
@@ -345,7 +354,7 @@ model_flag_for_harness() {
   local harness=$1 model=$2
   [ -n "$model" ] && [ "$model" != default ] || return 0
   case "$harness" in
-    claude|codex|opencode|pi|grok)
+    claude|codex|opencode|pi|grok|cursor)
       printf -- '--model %s ' "$(shell_quote "$model")"
       ;;
   esac

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -810,6 +810,63 @@ EOF
       printf 'token=%s\n' "${auth_file##*/}" > "$WT/.fm-grok-turnend"
       exclude_path '.fm-grok-turnend'
       ;;
+    cursor*)
+      # cursor fires a `stop` hook at every turn boundary (verified interactive,
+      # cursor-agent 2026.07.01; it does NOT fire in -p headless mode, but crewmates
+      # run interactively). Unlike grok's standalone files, cursor hooks live in the
+      # operator's SHARED hooks.json, so firstmate MERGES its stop entry idempotently
+      # (preserving existing sessionStart/stop hooks) and the hook reads the stop
+      # payload's workspace_roots from stdin JSON (not an env var). The hook is a
+      # guarded no-op unless a workspace holds a .fm-cursor-turnend token pointer that
+      # matches the firstmate-owned registry, and it emits {} on stdout as cursor expects.
+      CURSOR_CFG="${CURSOR_CONFIG_DIR:-$HOME/.cursor}"
+      CURSOR_HOOKS_DIR="$CURSOR_CFG/hooks"
+      CURSOR_AUTH_DIR="$CURSOR_HOOKS_DIR/fm-turn-end.d"
+      mkdir -p "$CURSOR_AUTH_DIR"
+      old_umask=$(umask)
+      umask 077
+      auth_file=$(mktemp "$CURSOR_AUTH_DIR/fm.XXXXXXXXXXXX")
+      umask "$old_umask"
+      printf '%s\n' "$TURNEND" > "$auth_file"
+      printf '%s\n' "${auth_file##*/}" > "$STATE/$ID.cursor-turnend-token"
+      sq_cursor_auth_dir=$(shell_quote "$CURSOR_AUTH_DIR")
+      cat > "$CURSOR_HOOKS_DIR/fm-turn-end.sh" <<EOF
+#!/usr/bin/env bash
+set -u
+auth_dir=$sq_cursor_auth_dir
+payload=\$(cat 2>/dev/null || true)
+roots=\$(printf '%s' "\$payload" | jq -r '.workspace_roots[]?' 2>/dev/null) || roots=
+while IFS= read -r ws; do
+  [ -n "\$ws" ] || continue
+  p="\$ws/.fm-cursor-turnend"
+  [ -f "\$p" ] || continue
+  first=
+  IFS= read -r -n 256 first < "\$p" 2>/dev/null || [ -n "\$first" ] || continue
+  case "\$first" in token=*) token=\${first#token=} ;; *) continue ;; esac
+  case "\$token" in fm.????????????) : ;; *) continue ;; esac
+  case "\$token" in *[!A-Za-z0-9._-]*) continue ;; esac
+  t=\$(cat "\$auth_dir/\$token" 2>/dev/null) || continue
+  case "\$t" in /*.turn-ended) : ;; *) continue ;; esac
+  touch "\$t" 2>/dev/null || true
+done <<ROOTS
+\$roots
+ROOTS
+printf '{}'
+exit 0
+EOF
+      chmod +x "$CURSOR_HOOKS_DIR/fm-turn-end.sh"
+      HOOKS_JSON="$CURSOR_CFG/hooks.json"
+      [ -f "$HOOKS_JSON" ] || printf '{"version":1,"hooks":{}}\n' > "$HOOKS_JSON"
+      cursor_hook_cmd="$CURSOR_HOOKS_DIR/fm-turn-end.sh"
+      cursor_hook_tmp=$(mktemp)
+      if jq --arg cmd "$cursor_hook_cmd" '.hooks.stop = ((.hooks.stop // []) | if any(.command == $cmd) then . else . + [{"command":$cmd,"timeout":10}] end)' "$HOOKS_JSON" > "$cursor_hook_tmp" 2>/dev/null; then
+        mv "$cursor_hook_tmp" "$HOOKS_JSON"
+      else
+        rm -f "$cursor_hook_tmp"
+      fi
+      printf 'token=%s\n' "${auth_file##*/}" > "$WT/.fm-cursor-turnend"
+      exclude_path '.fm-cursor-turnend'
+      ;;
   esac
 fi
 

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -26,7 +26,7 @@
 #   profile consultation. A --secondmate spawn is exempt and resolves the SECONDMATE
 #   harness (config/secondmate-harness -> config/crew-harness -> own), so the
 #   secondmate-vs-crewmate split is DURABLE across every respawn (recovery,
-#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|grok)
+#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|grok|cursor)
 #   overrides it for this spawn (either kind). A non-flag string containing
 #   whitespace is treated as a RAW launch command - the escape hatch for verifying
 #   new adapters.

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -102,6 +102,14 @@ remove_grok_turnend_auth() {
   rm -f "$hooks_dir/$token"
 }
 
+remove_cursor_turnend_auth() {
+  local state_dir=$1 id=$2 token hooks_dir
+  token=$(cat "$state_dir/$id.cursor-turnend-token" 2>/dev/null || true)
+  case "$token" in ''|*[!A-Za-z0-9._-]*) return 0 ;; esac
+  hooks_dir="${CURSOR_CONFIG_DIR:-$HOME/.cursor}/hooks/fm-turn-end.d"
+  rm -f "$hooks_dir/$token"
+}
+
 # Resolve the PR number for a worktree branch via gh-axi. Echoes the number on a
 # single match and returns 0; returns non-zero on no match or any lookup failure,
 # so the caller treats it as "no PR found" (fail-safe).
@@ -536,7 +544,7 @@ cleanup_firstmate_home_children() {
       fi
     elif [ -n "$child_wt" ] && [ -d "$child_wt" ]; then
       validate_child_worktree_for_removal "$child_wt" "$child_proj" >/dev/null || return 1
-      rm -f "$child_wt/.claude/settings.local.json" "$child_wt/.opencode/plugins/fm-turn-end.js" "$child_wt/.fm-grok-turnend"
+      rm -f "$child_wt/.claude/settings.local.json" "$child_wt/.opencode/plugins/fm-turn-end.js" "$child_wt/.fm-grok-turnend" "$child_wt/.fm-cursor-turnend"
       if [ -n "$child_proj" ] && [ -d "$child_proj" ] && command -v treehouse >/dev/null 2>&1; then
         ( cd "$child_proj" && treehouse return --force "$child_wt" ) || safe_rm_rf_child_worktree "$child_wt" "$child_proj"
       else
@@ -544,7 +552,8 @@ cleanup_firstmate_home_children() {
       fi
     fi
     remove_grok_turnend_auth "$sub_state" "$child_id"
-    rm -f "$sub_state/$child_id.status" "$sub_state/$child_id.turn-ended" "$sub_state/$child_id.check.sh" "$sub_state/$child_id.meta" "$sub_state/$child_id.pi-ext.ts" "$sub_state/$child_id.grok-turnend-token"
+    remove_cursor_turnend_auth "$sub_state" "$child_id"
+    rm -f "$sub_state/$child_id.status" "$sub_state/$child_id.turn-ended" "$sub_state/$child_id.check.sh" "$sub_state/$child_id.meta" "$sub_state/$child_id.pi-ext.ts" "$sub_state/$child_id.grok-turnend-token" "$sub_state/$child_id.cursor-turnend-token"
   done
 }
 
@@ -593,7 +602,7 @@ if [ -d "$WT" ] && [ "$FORCE" != "--force" ]; then
     fi
   else
     # The fm-spawn hook file is ours, never work product; ignore it in the dirty check.
-    dirty=$(git -C "$WT" status --porcelain 2>/dev/null | grep -vE '^\?\? (\.claude/|\.fm-grok-turnend$)' | head -1 || true)
+    dirty=$(git -C "$WT" status --porcelain 2>/dev/null | grep -vE '^\?\? (\.claude/|\.fm-grok-turnend$|\.fm-cursor-turnend$)' | head -1 || true)
     # Reachability test: is HEAD reachable from ANY remote-tracking branch? Empty
     # means the work is already pushed (a fork is a remote too, so upstream-
     # contribution PRs pushed to a fork pass here). Non-empty does NOT prove the work
@@ -651,7 +660,7 @@ if [ -d "$WT" ] && [ "$KIND" != secondmate ]; then
     fi
   fi
   # Remove our hook file so a reused pool worktree cannot fire signals for a dead task.
-  rm -f "$WT/.claude/settings.local.json" "$WT/.opencode/plugins/fm-turn-end.js" "$WT/.fm-grok-turnend"
+  rm -f "$WT/.claude/settings.local.json" "$WT/.opencode/plugins/fm-turn-end.js" "$WT/.fm-grok-turnend" "$WT/.fm-cursor-turnend"
   # Kills remaining processes in the worktree (including the agent), resets, returns
   # to pool. treehouse resolves the pool from the working directory, so run it from
   # the project.
@@ -665,10 +674,11 @@ if [ "$KIND" = secondmate ]; then
   remove_secondmate_registry_entry "$ID"
 fi
 remove_grok_turnend_auth "$STATE" "$ID"
+remove_cursor_turnend_auth "$STATE" "$ID"
 # Remove the per-task temp root (/tmp/fm-<id>/, incl. its gotmp/) recorded by spawn.
 # Read before the state-file rm below; empty (pre-fix tasks without tasktmp=) is a no-op.
 [ -n "$TASK_TMP" ] && rm -rf "$TASK_TMP"
-rm -f "$STATE/$ID.status" "$STATE/$ID.turn-ended" "$STATE/$ID.check.sh" "$STATE/$ID.meta" "$STATE/$ID.pi-ext.ts" "$STATE/$ID.grok-turnend-token"
+rm -f "$STATE/$ID.status" "$STATE/$ID.turn-ended" "$STATE/$ID.check.sh" "$STATE/$ID.meta" "$STATE/$ID.pi-ext.ts" "$STATE/$ID.grok-turnend-token" "$STATE/$ID.cursor-turnend-token"
 if [ "$KIND" != scout ] && [ "$KIND" != secondmate ] && [ "$MODE" != local-only ]; then
   "$FM_ROOT/bin/fm-fleet-sync.sh" "$PROJ" || true
 fi

--- a/bin/fm-tmux-lib.sh
+++ b/bin/fm-tmux-lib.sh
@@ -36,8 +36,9 @@
 
 # Busy footers per harness (mirror fm-watch.sh). claude/codex: "esc to
 # interrupt"; opencode: "esc interrupt"; pi: "Working..."; grok: "Ctrl+c:cancel"
-# (grok's mid-turn cancel hint, shown iff a turn is running - verified grok 0.2.73).
-FM_TMUX_BUSY_REGEX_DEFAULT='esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel'
+# (grok's mid-turn cancel hint, shown iff a turn is running - verified grok 0.2.73);
+# cursor: "ctrl+c to stop" (mid-turn footer hint - verified cursor-agent 2026.07.01).
+FM_TMUX_BUSY_REGEX_DEFAULT='esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel|ctrl\+c to stop'
 
 # fm_tmux_strip_ghost: remove dim/faint (ANSI SGR 2) styled runs from one captured
 # composer line, then drop any remaining escape sequences, leaving only the plain,

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -106,7 +106,9 @@ SIGNAL_GRACE=${FM_SIGNAL_GRACE:-30}   # seconds to linger after a signal so trai
 # grok: "Ctrl+c:cancel" (the mid-turn cancel hint in grok's keybind bar, shown iff a
 # turn is running; absent when idle - verified grok 0.2.73, ASCII to avoid the
 # locale fragility of matching grok's braille spinner glyph directly).
-BUSY_REGEX=${FM_BUSY_REGEX:-'esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel'}
+# cursor: "ctrl+c to stop" (the mid-turn footer hint, shown iff a turn is running;
+# absent when idle - verified cursor-agent 2026.07.01).
+BUSY_REGEX=${FM_BUSY_REGEX:-'esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel|ctrl\+c to stop'}
 # Always-on wake triage: most wakes during a long crew validation are benign (a
 # working: note or turn-end while a pipeline runs, a no-change heartbeat). Rather
 # than wake firstmate's LLM for each, this watcher classifies every wake in bash

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -81,7 +81,7 @@ The session-start bootstrap step surfaces either the active rule block or a conc
 When the file exists, `fm-spawn.sh` refuses crewmate and scout launches without an explicit harness, so `config/crew-harness` is only automatic when no dispatch profile file is active.
 Secondmate launches are exempt because they resolve the secondmate harness and any optional secondmate model or effort tokens instead.
 Unsupported effort values are still recorded in task meta when passed to `fm-spawn.sh`, but the launch template omits any effort flag that the selected harness does not accept.
-That keeps spawn launch compatible across claude, codex, grok, pi, and opencode while preserving the requested profile for later audit.
+That keeps spawn launch compatible across claude, codex, grok, pi, opencode, and cursor while preserving the requested profile for later audit.
 
 ## Optional secondmates
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -82,7 +82,7 @@ For the zellij backend, `FM_HOME` does not split containers; use `FM_ZELLIJ_SESS
 
 ## Harness support
 
-claude, codex, opencode, pi, and grok are all empirically verified; new harnesses get verified through a supervised trial task before joining the set.
+claude, codex, opencode, pi, grok, and cursor are all empirically verified; new harnesses get verified through a supervised trial task before joining the set.
 The verified adapter knowledge - busy signatures, interrupt and exit commands, skill-invocation syntax, and per-harness quirks - lives in [`.agents/skills/harness-adapters/SKILL.md`](../.agents/skills/harness-adapters/SKILL.md).
 Launch mechanics, including the verified command templates, live in [`bin/fm-spawn.sh`](../bin/fm-spawn.sh).
 `config/crew-harness` is a local, gitignored file containing one adapter name for crewmate and scout launches.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -98,6 +98,8 @@ When `config/crew-dispatch.json` exists, crewmate and scout spawns require an ex
 The primary propagates `config/crew-dispatch.json`, `config/crew-harness`, and `config/backlog-backend` into secondmate homes at secondmate spawn, during the locked session-start bootstrap secondmate sweep, and during explicit `bin/fm-config-push.sh` runs, so a secondmate's own crewmates, dispatch profiles, and backlog backend use the primary values.
 `config/secondmate-harness` is not inherited because secondmates do not launch secondmates.
 For grok, `fm-spawn.sh` installs one firstmate-owned global turn-end hook under `$GROK_HOME/hooks/`, or `~/.grok/hooks/` when `GROK_HOME` is unset, and drops a per-task `.fm-grok-turnend` pointer in the worktree, with teardown removing the task token and pointer.
+For cursor, `fm-spawn.sh` merges one firstmate-owned `stop` hook idempotently into the operator's shared `~/.cursor/hooks.json` (or `$CURSOR_CONFIG_DIR/hooks.json`), preserving existing hooks, and drops a per-task `.fm-cursor-turnend` pointer in the worktree, with teardown removing the task token and pointer.
+The cursor hook shells out to `jq`, so `jq` is a runtime dependency for cursor crewmate turn-end supervision.
 
 ## Crew dispatch profiles (config/crew-dispatch.json)
 
@@ -224,9 +226,10 @@ FM_STALE_ESCALATE_SECS=240         # idle seconds before a provably-working non-
 FM_WATCH_TRIAGE_LOG_MAX_BYTES=262144   # size cap for the watcher's absorbed-wake debug log
 FM_FLEET_SYNC_BOOTSTRAP_TIMEOUT=20   # seconds allowed for bootstrap's best-effort clone refresh
 FM_FLEET_PRUNE=1        # set to 0 to skip pruning local branches whose upstream is gone
-FM_BUSY_REGEX='esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel'   # busy-pane signatures, shared by watcher, fm-crew-state pane fallback, and tmux helper
+FM_BUSY_REGEX='esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel|ctrl\+c to stop'   # busy-pane signatures, shared by watcher, fm-crew-state pane fallback, and tmux helper
 FM_COMPOSER_IDLE_RE=    # optional empty-composer regex, applied after dim-ghost and border stripping
 GROK_HOME=              # optional Grok config home for firstmate's global grok turn-end hook; defaults to ~/.grok
+CURSOR_CONFIG_DIR=      # optional Cursor config home for firstmate's merged cursor turn-end stop hook; defaults to ~/.cursor
 FM_SEND_RETRIES=3       # fm-send Enter-retry attempts after typing the line once
 FM_SEND_SLEEP=0.4       # seconds between fm-send submit checks
 FM_SEND_SETTLE=1        # seconds fm-send waits after a successful text submit; 0 disables

--- a/docs/design-docs/2026-07-02-cursor-harness-adapter-design.md
+++ b/docs/design-docs/2026-07-02-cursor-harness-adapter-design.md
@@ -21,7 +21,10 @@ Goal: make `cursor` a first-class, verified firstmate harness so that both the o
 ## Decisions made during brainstorming
 
 - Scope: both the first mate and the crewmates run on Cursor.
-- Persistence: land the adapter as an upstream PR through firstmate's `no-mistakes` pipeline (survives `/updatefirstmate`, reviewable, benefits everyone).
+- Persistence: local-first.
+  Install and use the adapter locally for a few weeks to prove it out, then open the upstream PR through firstmate's `no-mistakes` pipeline once it is good enough.
+- Preference neutrality: the adapter must not impose one operator's harness preference on others.
+  Some operators rank Claude above Cursor, so detection and defaults must stay neutral (see Detection).
 - Models: tiered via `config/crew-dispatch.json`, heavy work on `claude-opus-4-8-thinking-max`, light work on a faster ZDR-safe tier; the orchestrator runs a lighter ZDR-safe model.
 - Turn-end supervision: a global guarded `stop`-hook, following the grok adapter pattern.
 
@@ -34,15 +37,18 @@ It already establishes the pattern this design reuses: an autonomy flag, a globa
 
 ### 1. Detection (`bin/fm-harness.sh`)
 
-Add a Cursor env-marker check to `detect_own()` placed before the `CLAUDECODE` check:
+Add a Cursor env-marker check to `detect_own()` placed after the existing claude, pi, and grok env markers (not before `CLAUDECODE`):
 
 ```sh
 [ "${CURSOR_AGENT:-}" = "1" ] && { echo cursor; return; }
 ```
 
-Ordering matters as insurance: a Cursor session running a Claude model reports `AI_AGENT=claude-code_...`, and if it ever also exported `CLAUDECODE=1` the existing claude check would win and misdetect the harness.
-Empirically, `CURSOR_AGENT=1` is set for Cursor agent child and tool processes, and `CLAUDECODE` is unset, but the ordering removes the risk regardless.
+Placing it after `CLAUDECODE` keeps detection preference-neutral: the adapter must not impose a "Cursor wins over Claude" default on operators who prefer Claude.
+This is also correct, not just polite.
+Empirically `CURSOR_AGENT=1` is set for Cursor agent processes while `CLAUDECODE` is unset, so the two markers do not co-occur in a normal Cursor session and the ordering does not change the result.
+In the one case where both could be set, a Claude session launched from within a Cursor context, the operator is genuinely in Claude, so resolving to claude is the right answer.
 Add a `*cursor*` case to the process-ancestry backstop as a secondary signal.
+Note that per-operator harness preference is expressed through configuration (`config/crew-harness`, `config/crew-dispatch.json`, and how the operator launches the first mate), not through `detect_own()`, so the adapter changes impose no preference.
 
 Session lock detection is separate and does not use the env marker.
 `bin/fm-lock.sh` defines `HARNESS_RE` and walks process ancestry to find the session-holding harness PID.
@@ -108,7 +114,7 @@ Add a `cursor (VERIFIED <date>)` section recording the busy signature, exit comm
 Derived from a full audit of every place the grok adapter touches the code.
 Each item must gain a `cursor` arm:
 
-- `bin/fm-harness.sh`: `CURSOR_AGENT=1` env-marker check before `CLAUDECODE`; `*cursor*` ancestry backstop case.
+- `bin/fm-harness.sh`: `CURSOR_AGENT=1` env-marker check after the existing claude/pi/grok markers (preference-neutral); `*cursor*` ancestry backstop case.
 - `bin/fm-lock.sh`: add the canonical Cursor binary token to `HARNESS_RE` (ancestry-based; required for the first mate to hold the session lock).
 - `bin/fm-spawn.sh`: `launch_template()` cursor case; `model_flag_for_harness()` cursor case; `--secondmate` bare-name list; per-harness effort handling (no flag); the global stop-hook install plus per-task pointer and registry writes.
 - `bin/fm-teardown.sh`: dirty-check regex exclusion for `.fm-cursor-turnend`; the two pointer removals; `remove_cursor_turnend_auth()` plus `$STATE/$ID.cursor-turnend-token` removal at both sites.
@@ -142,9 +148,23 @@ Before finalizing, a supervised throwaway task using fm-spawn's raw-launch escap
 
 The verification is driven directly from a Cursor agent, which can observe Cursor behavior firsthand.
 
-## Landing as an upstream PR
+## Rollout: local-first, then upstream PR
+
+The change is proven locally before it is proposed upstream.
+
+Phase 1, local (now):
 
 - All work happens on the `feat/cursor-harness-adapter` branch in a dedicated worktree, leaving the fleet's primary checkout on `main`.
+- Implement the adapter and configuration, then run the operator's own fleet on Cursor from this branch for a few weeks.
+- Because this is local, the operator may keep the checkout on the feature branch or apply the changes to their own working copy; the point is real daily use before committing to an upstream contract.
+
+Phase 2, upstream (after it proves out):
+
+- Open the PR through firstmate's `no-mistakes` pipeline once the adapter is good enough, so it survives `/updatefirstmate` and benefits everyone.
+- The upstream version must keep the preference-neutral detection above, so it does not regress operators who prefer Claude.
+
+Implementation details for both phases:
+
 - Implement the adapter (sections 1 through 5) plus the configuration documentation.
 - Add tests mirroring existing patterns, using `tests/fm-grok-harness.test.sh` as the primary template since grok is the closest adapter:
   - detection: `CURSOR_AGENT` maps to `cursor`, and ordering relative to `CLAUDECODE`;

--- a/docs/design-docs/2026-07-02-cursor-harness-adapter-design.md
+++ b/docs/design-docs/2026-07-02-cursor-harness-adapter-design.md
@@ -1,0 +1,118 @@
+# Cursor agent harness adapter
+
+Status: approved design, pending implementation plan.
+Date: 2026-07-02.
+
+## Problem and motivation
+
+firstmate currently supports the harnesses claude, codex, opencode, pi, and grok.
+The operator's organization cannot rely on direct Claude access for real work: Anthropic org usage limits make it unreliable, and the organization's Business Associate Agreement (BAA) for PHI-adjacent work is with Cursor, not with the direct Anthropic or OpenAI APIs.
+The Cursor agent CLI routes to models under Cursor's BAA with zero-data-retention (ZDR) enforcement, which is the only compliant and reliable harness for this operator.
+
+Goal: make `cursor` a first-class, verified firstmate harness so that both the orchestrator (first mate) and the crewmates run on the Cursor agent, fully off direct Claude.
+
+## Constraints
+
+- Compliance first: crewmates run autonomously against real repositories, so every model they use must be ZDR-safe.
+  Fable 5 is explicitly excluded because it is tagged non-ZDR.
+- The firstmate repository is itself behind its own `no-mistakes` validation gate and is a shared template, so the change must land as an upstream pull request through that pipeline.
+- The running fleet's primary checkout must not be disturbed: all feature work happens in a dedicated git worktree on a feature branch, never by switching the primary checkout's branch (that would trip firstmate's tangle guard).
+
+## Decisions made during brainstorming
+
+- Scope: both the first mate and the crewmates run on Cursor.
+- Persistence: land the adapter as an upstream PR through firstmate's `no-mistakes` pipeline (survives `/updatefirstmate`, reviewable, benefits everyone).
+- Models: tiered via `config/crew-dispatch.json`, heavy work on `claude-opus-4-8-thinking-max`, light work on a faster ZDR-safe tier; the orchestrator runs a lighter ZDR-safe model.
+- Turn-end supervision: a global guarded `stop`-hook, following the grok adapter pattern.
+
+## Reference implementation
+
+The grok adapter (commit `2a661da`, "feat: add grok crewmate harness support") is the closest existing template.
+It already establishes the pattern this design reuses: an autonomy flag, a global firstmate-owned turn-end hook guarded to a no-op for non-firstmate sessions, and a per-task token pointer plus registry entry in the worktree.
+
+## Adapter design
+
+### 1. Detection (`bin/fm-harness.sh`)
+
+Add a Cursor env-marker check to `detect_own()` placed before the `CLAUDECODE` check:
+
+```sh
+[ "${CURSOR_AGENT:-}" = "1" ] && { echo cursor; return; }
+```
+
+Ordering matters as insurance: a Cursor session running a Claude model reports `AI_AGENT=claude-code_...`, and if it ever also exported `CLAUDECODE=1` the existing claude check would win and misdetect the harness.
+Empirically, `CURSOR_AGENT=1` is set for Cursor agent child and tool processes, and `CLAUDECODE` is unset, but the ordering removes the risk regardless.
+Add a `*cursor*` case to the process-ancestry backstop as a secondary signal.
+
+### 2. Launch mechanics (`bin/fm-spawn.sh`)
+
+- Add `cursor` to the accepted adapter names.
+- Launch template (positional prompt plus autonomy):
+
+```sh
+agent __MODELFLAG__--force "$(cat __BRIEF__)"
+```
+
+- `--force` is the autonomy flag, equivalent to claude's `--dangerously-skip-permissions`.
+- No `--effort` flag is emitted for Cursor: effort is encoded in the model id (for example `claude-opus-4-8-thinking-max`), so dispatch passes the full model id via `--model` and firstmate records `effort=` in meta without emitting a flag.
+  This reuses the existing "unsupported effort is recorded but not passed" pattern.
+- Turn-end does not ride the launch command; it is delivered by the global hook below, exactly as grok does.
+- The canonical binary name (`agent` versus `cursor-agent`) is confirmed during verification and the template uses whichever is canonical.
+
+### 3. Turn-end: global guarded `stop`-hook
+
+- firstmate owns `~/.cursor/hooks/fm-turn-end.sh` and ensures the `stop` array in `~/.cursor/hooks.json` contains it, added idempotently with `jq` and merged with the operator's existing hooks (the `sessionStart` hooks and the bell `notify-stop.sh`), never overwriting them.
+- On each spawn firstmate writes `<worktree>/.fm-cursor-turnend` (a token pointer, gitignored via `git info/exclude`) and a registry entry at `~/.cursor/hooks/fm-turn-end.d/<token>` naming that task's `state/<id>.turn-ended`.
+- On a `stop` event the hook reads the payload's `workspace_roots`, finds the pointer in that root, resolves the registry entry, and touches the referenced `turn-ended` file.
+  It is a no-op for any non-firstmate Cursor session.
+- Teardown removes the per-task pointer and registry entry; the global hook stays installed as a harmless no-op.
+
+### 4. Busy signature and supervision (`bin/fm-watch.sh`, `bin/fm-tmux-lib.sh`)
+
+- Add the Cursor busy-pane signature to the `FM_BUSY_REGEX` defaults; the exact string is captured during verification.
+- `suggestNextPrompt` is already `false` in the operator's `cli-config.json`, so no composer ghost-text override is expected; this is confirmed during verification.
+
+### 5. Adapter knowledge (`.agents/skills/harness-adapters/SKILL.md`)
+
+Add a `cursor (VERIFIED <date>)` section recording the busy signature, exit command, interrupt key, trust-dialog handling, the `/no-mistakes` skill-invocation form, resume behavior (`agent resume` / `--continue`), the env marker `CURSOR_AGENT=1`, the autonomy flag `--force`, and a launch-profile row (model via full id, no effort flag).
+
+## Configuration
+
+All of the following are local and gitignored.
+
+- First mate on Cursor: launch the orchestrator with a lighter ZDR-safe model, for example `agent --model claude-opus-4-8-high-fast` from the firstmate home.
+- `config/crew-dispatch.json`: tiered rules, all `harness: cursor`, with ZDR-safe model ids.
+  - Heavy, architecture, or multi-file work maps to `claude-opus-4-8-thinking-max`.
+  - Quick or scoped fixes map to `claude-opus-4-8-thinking-high-fast`.
+  - The `default` profile maps to `claude-opus-4-8-thinking-high-fast`.
+- `config/crew-harness` set to `cursor` as the fallback when no dispatch rule matches.
+- Model ids are tunable; the defaults above are strong but ZDR-safe, and Fable 5 is excluded everywhere.
+
+## Verification trial
+
+Before finalizing, a supervised throwaway task using fm-spawn's raw-launch escape hatch confirms the unknowns by observing the live Cursor TUI:
+
+- busy-pane signature for `FM_BUSY_REGEX`
+- exit command, interrupt key, and first-run trust-dialog flow
+- the `/no-mistakes` skill-invocation form
+- the canonical binary name (`agent` versus `cursor-agent`)
+- whether `CLAUDECODE` appears when running a Claude model
+- composer ghost-text behavior
+
+The verification is driven directly from a Cursor agent, which can observe Cursor behavior firsthand.
+
+## Landing as an upstream PR
+
+- All work happens on the `feat/cursor-harness-adapter` branch in a dedicated worktree, leaving the fleet's primary checkout on `main`.
+- Implement the adapter (sections 1 through 5) plus the configuration documentation.
+- Add tests mirroring existing patterns such as `fm-secondmate-harness.test.sh`: detection (`CURSOR_AGENT` maps to `cursor`, and ordering relative to `CLAUDECODE`), the spawn launch template (autonomy flag present, model passed as a full id, no effort flag), turn-end pointer creation, and teardown cleanup.
+- Run the behavior suite (`tests/*.test.sh` per `.no-mistakes.yaml`), open the PR, and the captain merges.
+- Because firstmate cannot reliably run on Claude, this implementation is done directly from a Cursor agent rather than dispatched to a Claude crewmate; this is the bootstrap that makes the fleet self-hosting on Cursor afterward.
+
+## Risks and open questions
+
+- Binary name (`agent` versus `cursor-agent`) is resolved during verification.
+- First-run trust dialog per repository is handled in spawn with a peek-and-accept, like claude, codex, and pi.
+- The `hooks.json` merge must be idempotent and must preserve existing hooks.
+- ZDR guardrail: dispatch rules are restricted to ZDR-safe model ids, with a comment so Fable 5 is not added later.
+- Long orchestration sessions on the Cursor agent are expected to be fine but will be watched on the first real run.

--- a/docs/design-docs/2026-07-02-cursor-harness-adapter-design.md
+++ b/docs/design-docs/2026-07-02-cursor-harness-adapter-design.md
@@ -44,9 +44,23 @@ Ordering matters as insurance: a Cursor session running a Claude model reports `
 Empirically, `CURSOR_AGENT=1` is set for Cursor agent child and tool processes, and `CLAUDECODE` is unset, but the ordering removes the risk regardless.
 Add a `*cursor*` case to the process-ancestry backstop as a secondary signal.
 
+Session lock detection is separate and does not use the env marker.
+`bin/fm-lock.sh` defines `HARNESS_RE` and walks process ancestry to find the session-holding harness PID.
+Because the first mate itself runs on Cursor, `fm-lock.sh` must recognize the Cursor process in the ancestry, or `harness_pid()` fails with "cannot locate harness process in ancestry" and the session lock breaks.
+This is ancestry-only, so `CURSOR_AGENT` does not help here; the canonical binary token (see the binary-name note below) must be added to `HARNESS_RE`.
+
+Binary-name caution: the canonical binary name is resolved during verification, but `agent` is dangerously generic for the ancestry and lock matchers.
+The design prefers a specific token (`cursor-agent`).
+If only `agent` exists, the ancestry and lock matchers must use a tightened pattern rather than a bare `*agent*`, and detection should lean on the `CURSOR_AGENT` env marker wherever possible.
+
 ### 2. Launch mechanics (`bin/fm-spawn.sh`)
 
-- Add `cursor` to the accepted adapter names.
+- Add `cursor` to every adapter-name enumeration in the script, not just one.
+  There are several distinct lists that each need a `cursor` arm:
+  - the `launch_template()` case that maps a harness to its command template;
+  - `model_flag_for_harness()` (currently only `claude|codex|opencode|pi|grok`), which must gain a `cursor` case or `__MODELFLAG__` is left empty and the full model id is never passed, defeating the tiered-model plan;
+  - the `--secondmate` bare-name-versus-path list (currently `''|claude|codex|opencode|pi|grok`);
+  - the per-harness effort handling (cursor emits no effort flag).
 - Launch template (positional prompt plus autonomy):
 
 ```sh
@@ -65,7 +79,20 @@ agent __MODELFLAG__--force "$(cat __BRIEF__)"
 - On each spawn firstmate writes `<worktree>/.fm-cursor-turnend` (a token pointer, gitignored via `git info/exclude`) and a registry entry at `~/.cursor/hooks/fm-turn-end.d/<token>` naming that task's `state/<id>.turn-ended`.
 - On a `stop` event the hook reads the payload's `workspace_roots`, finds the pointer in that root, resolves the registry entry, and touches the referenced `turn-ended` file.
   It is a no-op for any non-firstmate Cursor session.
-- Teardown removes the per-task pointer and registry entry; the global hook stays installed as a harmless no-op.
+
+Teardown (`bin/fm-teardown.sh`) needs concrete cursor branches mirroring the four grok touch points, not just a vague "remove the pointer":
+
+- the dirty-check regex (which currently excludes `.claude/` and `.fm-grok-turnend`) must also exclude `.fm-cursor-turnend`, or a stale pointer in a pooled worktree trips the dirty guard and blocks teardown;
+- the two hardcoded worktree-pointer removals (`rm -f ... .fm-grok-turnend`) need a `.fm-cursor-turnend` analog, or the pointer leaks into a reused pool worktree and can fire signals for a dead task;
+- the state token cleanup: a `remove_cursor_turnend_auth()` equivalent plus removal of the `$STATE/$ID.cursor-turnend-token` file at both teardown sites (grok has `remove_grok_turnend_auth()` and two `$STATE/$ID.grok-turnend-token` removals).
+
+The global hook itself stays installed on teardown as a harmless no-op.
+
+### 3a. Bootstrap verified-harness allowlist (`bin/fm-bootstrap.sh`)
+
+`fm-bootstrap.sh` hardcodes the verified-harness allowlist (`["claude","codex","opencode","pi","grok"]`) used by `crew_dispatch_validate`.
+Until `cursor` is added there, any `crew-dispatch.json` rule with `harness: cursor` is rejected at bootstrap as an unverified harness, which would break the entire configuration plan below.
+The `effort_ok` check has no `cursor` arm and falls through to `true`, so cursor model ids and effort are not machine-validated; this is acceptable but must be stated (the ZDR guardrail is a comment, not an enforced check).
 
 ### 4. Busy signature and supervision (`bin/fm-watch.sh`, `bin/fm-tmux-lib.sh`)
 
@@ -75,6 +102,20 @@ agent __MODELFLAG__--force "$(cat __BRIEF__)"
 ### 5. Adapter knowledge (`.agents/skills/harness-adapters/SKILL.md`)
 
 Add a `cursor (VERIFIED <date>)` section recording the busy signature, exit command, interrupt key, trust-dialog handling, the `/no-mistakes` skill-invocation form, resume behavior (`agent resume` / `--continue`), the env marker `CURSOR_AGENT=1`, the autonomy flag `--force`, and a launch-profile row (model via full id, no effort flag).
+
+## Complete touch-point checklist
+
+Derived from a full audit of every place the grok adapter touches the code.
+Each item must gain a `cursor` arm:
+
+- `bin/fm-harness.sh`: `CURSOR_AGENT=1` env-marker check before `CLAUDECODE`; `*cursor*` ancestry backstop case.
+- `bin/fm-lock.sh`: add the canonical Cursor binary token to `HARNESS_RE` (ancestry-based; required for the first mate to hold the session lock).
+- `bin/fm-spawn.sh`: `launch_template()` cursor case; `model_flag_for_harness()` cursor case; `--secondmate` bare-name list; per-harness effort handling (no flag); the global stop-hook install plus per-task pointer and registry writes.
+- `bin/fm-teardown.sh`: dirty-check regex exclusion for `.fm-cursor-turnend`; the two pointer removals; `remove_cursor_turnend_auth()` plus `$STATE/$ID.cursor-turnend-token` removal at both sites.
+- `bin/fm-bootstrap.sh`: add `cursor` to the verified-harness allowlist used by `crew_dispatch_validate`.
+- `bin/fm-watch.sh` and `bin/fm-tmux-lib.sh`: add the Cursor busy signature to `FM_BUSY_REGEX`.
+- `.agents/skills/harness-adapters/SKILL.md`: the `cursor (VERIFIED ...)` knowledge section and launch-profile row.
+- New files: `~/.cursor/hooks/fm-turn-end.sh` (firstmate-owned) and the `~/.cursor/hooks/fm-turn-end.d/` registry directory; per-task `<worktree>/.fm-cursor-turnend` pointer, gitignored via `git info/exclude` (no repo `.gitignore` change needed).
 
 ## Configuration
 
@@ -105,14 +146,23 @@ The verification is driven directly from a Cursor agent, which can observe Curso
 
 - All work happens on the `feat/cursor-harness-adapter` branch in a dedicated worktree, leaving the fleet's primary checkout on `main`.
 - Implement the adapter (sections 1 through 5) plus the configuration documentation.
-- Add tests mirroring existing patterns such as `fm-secondmate-harness.test.sh`: detection (`CURSOR_AGENT` maps to `cursor`, and ordering relative to `CLAUDECODE`), the spawn launch template (autonomy flag present, model passed as a full id, no effort flag), turn-end pointer creation, and teardown cleanup.
+- Add tests mirroring existing patterns, using `tests/fm-grok-harness.test.sh` as the primary template since grok is the closest adapter:
+  - detection: `CURSOR_AGENT` maps to `cursor`, and ordering relative to `CLAUDECODE`;
+  - spawn launch template: autonomy flag present, model passed as a full id via `--model`, no effort flag;
+  - turn-end: per-task pointer and registry entry creation;
+  - teardown: pointer removal, state token removal, and dirty-check exclusion (grok's test explicitly checks token removal);
+  - `fm-lock` recognition: an `fm-lock` cursor-holder test (grok has `test_fm_lock_recognizes_grok_holder`);
+  - bootstrap: a `crew-dispatch.json` validation test asserting `harness: cursor` is accepted (mirroring the grok case in `fm-bootstrap.test.sh`);
+  - hooks.json merge: a dedicated test that adding the firstmate stop hook preserves the operator's existing `sessionStart` hooks and the bell `notify-stop.sh`, and that teardown leaves them untouched.
 - Run the behavior suite (`tests/*.test.sh` per `.no-mistakes.yaml`), open the PR, and the captain merges.
 - Because firstmate cannot reliably run on Claude, this implementation is done directly from a Cursor agent rather than dispatched to a Claude crewmate; this is the bootstrap that makes the fleet self-hosting on Cursor afterward.
 
 ## Risks and open questions
 
 - Binary name (`agent` versus `cursor-agent`) is resolved during verification.
+  `agent` is dangerously generic for the ancestry and lock matchers, so the design prefers `cursor-agent`; if only `agent` exists, use a tightened pattern and lean on the `CURSOR_AGENT` env marker rather than a bare `*agent*`.
 - First-run trust dialog per repository is handled in spawn with a peek-and-accept, like claude, codex, and pi.
-- The `hooks.json` merge must be idempotent and must preserve existing hooks.
-- ZDR guardrail: dispatch rules are restricted to ZDR-safe model ids, with a comment so Fable 5 is not added later.
+- The shared `hooks.json` merge is genuinely new risk surface, not a grok mirror: grok installs standalone files it fully owns, whereas Cursor merges into the operator's shared `~/.cursor/hooks.json`.
+  The idempotent jq merge and the "leave the no-op installed on teardown" behavior must be treated as their own tested unit, verifying the operator's existing `sessionStart` hooks and `notify-stop.sh` survive both add and teardown.
+- ZDR guardrail: dispatch rules are restricted to ZDR-safe model ids by convention and comment only; nothing in the pipeline enforces the allowlist (`effort_ok` has no cursor arm and falls through to `true`), so Fable 5 exclusion is a discipline, not a machine check.
 - Long orchestration sessions on the Cursor agent are expected to be fine but will be watched on the first real run.

--- a/docs/design-docs/2026-07-02-cursor-harness-adapter-plan.md
+++ b/docs/design-docs/2026-07-02-cursor-harness-adapter-plan.md
@@ -59,11 +59,29 @@ bin/fm-spawn.sh cursor-verify-x1 <scratch-project-dir> "<BIN> --force \"\$(cat <
 ```
 Attach to the `fm-cursor-verify-x1` tmux window and record: the busy-pane line while it works (`BUSY`), the exit key (`EXITKEY`), the interrupt key (`INTKEY`), any first-run trust dialog and how it is accepted, the `/no-mistakes` invocation form (`SKILLFORM`), and whether an empty composer shows ghost/suggested text.
 
-- [ ] **Step 3: Record findings**
+- [ ] **Step 3: Confirm the stop-hook contract (highest-risk, novel piece)**
 
-Write all resolved values into `docs/design-docs/cursor-verification-notes.md`. Do not commit this scratch file.
+Before Task 4 hardcodes it, empirically confirm Cursor's `stop`-hook API. Install a temporary logging stop hook in a scratch `CURSOR_CONFIG_DIR` and run one turn:
+```bash
+export CURSOR_CONFIG_DIR=$(mktemp -d)
+mkdir -p "$CURSOR_CONFIG_DIR/hooks"
+cat > "$CURSOR_CONFIG_DIR/hooks/log.sh" <<'SH'
+#!/usr/bin/env bash
+cat > /tmp/cursor-stop-payload.json
+printf '{}'
+SH
+chmod +x "$CURSOR_CONFIG_DIR/hooks/log.sh"
+printf '{"version":1,"hooks":{"stop":[{"command":"%s/hooks/log.sh","timeout":10}]}}' "$CURSOR_CONFIG_DIR" > "$CURSOR_CONFIG_DIR/hooks.json"
+# run a one-shot cursor turn in the scratch config, then:
+cat /tmp/cursor-stop-payload.json
+```
+Confirm and record: the event key is `stop`, the payload contains `workspace_roots` (array of absolute paths), the entry shape is `{"command","timeout"}`, and the hook is expected to emit JSON (`{}`) on stdout. If any differ, update Task 4 before implementing it.
 
-- [ ] **Step 4: Tear down the trial**
+- [ ] **Step 4: Record findings**
+
+Write all resolved values (including the stop-hook schema) into `docs/design-docs/cursor-verification-notes.md`. Do not commit this scratch file. Note that the installed hook shells out to `jq` at turn-end, so `jq` is a runtime dependency (it fails safe to a no-op if absent, meaning turn-end wakes silently stop - record this in the SKILL).
+
+- [ ] **Step 5: Tear down the trial**
 
 ```bash
 bin/fm-teardown.sh cursor-verify-x1 --force
@@ -165,7 +183,7 @@ HARNESS_RE='claude|codex|opencode|grok|cursor-agent|^pi$'
 - Modify: `bin/fm-spawn.sh` - `launch_template()` (~line 216), `model_flag_for_harness()` (line 282), `--secondmate` bare-name case (line 156)
 - Test: `tests/fm-cursor-harness.test.sh`
 
-- [ ] **Step 1: Write the failing test** - a spawn test (mirror `run_grok_spawn`/`make_spawn_case` from `tests/fm-grok-harness.test.sh`, using `cursor` as the harness arg and a fake `BIN`), asserting the spawn succeeds (`spawned <id> harness=cursor`) and that the tmux send-keys captured launch line contains `--force` and `--model <id>` and NO `--effort`. (Capture the launch by having the fake `tmux` log `send-keys -l` payloads to a file.)
+- [ ] **Step 1: Write the failing test** - a spawn test (mirror `run_grok_spawn`/`make_spawn_case` from `tests/fm-grok-harness.test.sh`, using `cursor` as the harness arg and a fake `BIN`), asserting the spawn succeeds (`spawned <id> harness=cursor`) and that the launch line contains `--force` and `--model <id>` and NO `--effort`. Note: the grok test's fake `tmux` discards `send-keys` (`send-keys) exit 0`), so write a NEW tmux stub that logs the launch payload - and filter specifically to the `send-keys -t <t> -l <payload>` invocation, because `fm-spawn.sh` also sends `export GOTMPDIR=...` and a bare `Enter` (lines 714/718). Capture only the `-l` payload.
 
 - [ ] **Step 2: Run it red.**
 
@@ -249,7 +267,8 @@ The novel piece. Cursor hooks live in the shared `~/.cursor/hooks.json` (or `$CU
     tmp=$(mktemp)
     jq --arg cmd "$cmd" '.hooks.stop = ((.hooks.stop // []) | if any(.command == $cmd) then . else . + [{"command":$cmd,"timeout":10}] end)' "$HOOKS_JSON" > "$tmp" && mv "$tmp" "$HOOKS_JSON"
     ```
-  - Skip the pointer for `kind=secondmate`, exactly as grok does.
+  - The entire turn-end `case "$HARNESS"` block is already wrapped in `if [ "$KIND" != secondmate ]` (fm-spawn.sh:574), so the `cursor*)` arm needs NO internal secondmate guard - grok's arm has none either.
+  - Heredoc caution: the `cat > .../fm-turn-end.sh <<EOF` block (and its nested `done <<ROOTS` ... `ROOTS`) uses a plain (non-`<<-`) heredoc, so every line - the `#!/usr/bin/env bash` shebang, the nested heredoc body, and the `ROOTS` terminator - must be emitted flush-left at column 0, exactly as grok's arm does at fm-spawn.sh:637-654, or the generated script gets an invalid shebang or unterminated heredoc.
 
 - [ ] **Step 4: Run it green.**
 
@@ -270,7 +289,7 @@ The novel piece. Cursor hooks live in the shared `~/.cursor/hooks.json` (or `$CU
 - [ ] **Step 3: Implement** - add cursor arms mirroring every grok touch point:
   - dirty-check regex: `grep -vE '^\?\? (\.claude/|\.fm-grok-turnend$|\.fm-cursor-turnend$)'`
   - both `rm -f ... .fm-grok-turnend` sites: also `rm -f "$WT/.fm-cursor-turnend"`
-  - add `remove_cursor_turnend_auth()` (read token from `$STATE/$ID.cursor-turnend-token`, `rm -f "$CURSOR_AUTH_DIR/$token"`) and call it at both teardown sites, then `rm -f "$STATE/$ID.cursor-turnend-token"`.
+  - add `remove_cursor_turnend_auth()` mirroring `remove_grok_turnend_auth()` (fm-teardown.sh:94): compute the registry dir LOCALLY inside the function as `"${CURSOR_CONFIG_DIR:-$HOME/.cursor}/hooks/fm-turn-end.d"` (there is no global `$CURSOR_AUTH_DIR` in teardown), read the token from `$STATE/$ID.cursor-turnend-token`, `rm -f "<dir>/$token"`; call it at both teardown sites, then `rm -f "$STATE/$ID.cursor-turnend-token"`.
   - Leave the global hook + hooks.json entry installed (harmless no-op).
 
 - [ ] **Step 4: Run it green.**

--- a/docs/design-docs/2026-07-02-cursor-harness-adapter-plan.md
+++ b/docs/design-docs/2026-07-02-cursor-harness-adapter-plan.md
@@ -27,11 +27,17 @@ Created:
 - `tests/fm-cursor-harness.test.sh` - detection, spawn, turn-end hook, teardown, fm-lock, hooks.json merge
 - Local, gitignored (not committed to the PR): `config/crew-dispatch.json`, `config/crew-harness` in the operator's firstmate home
 
-Key facts to resolve first (Task 0), then substituted throughout:
-- `BIN` = canonical Cursor CLI command (`cursor-agent` preferred; `agent` fallback)
-- `BUSY` = Cursor busy-pane signature string
-- `EXITKEY`, `INTKEY` = exit / interrupt keys
-- `SKILLFORM` = `/no-mistakes` invocation form
+Key facts (RESOLVED by Task 0 on 2026-07-02):
+- `BIN` = **`cursor-agent`** (canonical; `agent` is a symlink to it). Use `cursor-agent` in ancestry/lock matchers.
+- Detection marker: **`CURSOR_AGENT=1`**; `CLAUDECODE` unset in Cursor sessions.
+- `BUSY` = **`ctrl+c to stop`** (also a `Working` spinner). Neither matches the existing `FM_BUSY_REGEX`, so it must be added. Regex-safe form: `ctrl\+c to stop`.
+- `INTKEY` = **Ctrl+C** (from the on-screen `ctrl+c to stop` hint).
+- `EXITKEY` = **unresolved** - Ctrl+D and `/quit` did not exit; teardown kills the tmux window regardless, so non-blocking. Record as open in the SKILL.
+- Trust dialog: **"Do you trust the contents of this directory?" → accept by sending `a`** (peek-and-accept in spawn).
+- Autonomy: `--force` → footer shows **"Run Everything"**.
+- Turn-end `stop` hook: **fires in interactive sessions** (NOT in `-p` headless mode - fine, crewmates are interactive). Payload keys include `workspace_roots` (array of absolute paths), `hook_event_name`, `status`, `loop_count`, `conversation_id`, `model`; hook must emit JSON (`{}`) on stdout.
+- `SKILLFORM` = `/no-mistakes` (Cursor uses slash commands; confirm on first real no-mistakes run).
+- Idle composer shows a `→ Add a follow-up` placeholder - verify it is dim (SGR2) so the composer reader ignores it; if not, set `FM_COMPOSER_IDLE_RE`.
 
 ---
 

--- a/docs/design-docs/2026-07-02-cursor-harness-adapter-plan.md
+++ b/docs/design-docs/2026-07-02-cursor-harness-adapter-plan.md
@@ -1,0 +1,363 @@
+# Cursor agent harness adapter - Implementation Plan
+
+> **For agentic workers:** Implement this plan task by task. Steps use checkbox (`- [ ]`) syntax for tracking. TDD where the change is testable: write the failing test, run it red, implement, run it green, commit.
+
+**Goal:** Add `cursor` as a verified firstmate harness so the orchestrator and crewmates run on the Cursor agent (BAA/ZDR), off direct Claude, landed local-first and later upstreamed.
+
+**Architecture:** Mirror the grok adapter across the seven grok-bearing `bin/` files plus the harness-adapters skill, with one novel piece: the turn-end `stop`-hook is idempotently merged into the operator's shared `~/.cursor/hooks.json` (grok writes standalone files it fully owns), and the hook reads Cursor's stdin JSON payload (`workspace_roots`) rather than an env var.
+
+**Tech Stack:** Bash (POSIX-ish, macOS bash 3.2 compatible), `jq`, tmux, git worktrees, `tests/*.test.sh` behavior suite run by `no-mistakes` via `.no-mistakes.yaml`.
+
+**Spec:** `docs/design-docs/2026-07-02-cursor-harness-adapter-design.md`
+
+---
+
+## File structure
+
+Modified:
+- `bin/fm-harness.sh` - detection (env marker + ancestry backstop)
+- `bin/fm-lock.sh` - `HARNESS_RE` session-holder recognition
+- `bin/fm-spawn.sh` - `launch_template`, `model_flag_for_harness`, `--secondmate` bare-name list, turn-end hook install
+- `bin/fm-teardown.sh` - pointer/token/dirty-check cleanup
+- `bin/fm-bootstrap.sh` - verified-harness allowlist
+- `bin/fm-watch.sh`, `bin/fm-tmux-lib.sh` - busy signature defaults
+- `.agents/skills/harness-adapters/SKILL.md` - cursor knowledge section
+
+Created:
+- `tests/fm-cursor-harness.test.sh` - detection, spawn, turn-end hook, teardown, fm-lock, hooks.json merge
+- Local, gitignored (not committed to the PR): `config/crew-dispatch.json`, `config/crew-harness` in the operator's firstmate home
+
+Key facts to resolve first (Task 0), then substituted throughout:
+- `BIN` = canonical Cursor CLI command (`cursor-agent` preferred; `agent` fallback)
+- `BUSY` = Cursor busy-pane signature string
+- `EXITKEY`, `INTKEY` = exit / interrupt keys
+- `SKILLFORM` = `/no-mistakes` invocation form
+
+---
+
+## Task 0: Verification trial (fills the empirical unknowns)
+
+Not TDD - a supervised observation run. Everything downstream depends on these facts.
+
+**Files:**
+- Create (scratch, not committed): `docs/design-docs/cursor-verification-notes.md`
+
+- [ ] **Step 1: Confirm the binary name and env markers**
+
+Run:
+```bash
+command -v cursor-agent; command -v agent
+env | grep -iE 'cursor|claudecode|ai_agent'
+```
+Record `BIN` (prefer `cursor-agent` if present, else `agent`), confirm `CURSOR_AGENT=1`, and whether `CLAUDECODE` is set.
+
+- [ ] **Step 2: Spawn a throwaway Cursor crewmate via the raw-launch escape hatch and observe the TUI**
+
+Use a scratch repo/worktree and run (from a firstmate home):
+```bash
+bin/fm-spawn.sh cursor-verify-x1 <scratch-project-dir> "<BIN> --force \"\$(cat <brief>)\""
+```
+Attach to the `fm-cursor-verify-x1` tmux window and record: the busy-pane line while it works (`BUSY`), the exit key (`EXITKEY`), the interrupt key (`INTKEY`), any first-run trust dialog and how it is accepted, the `/no-mistakes` invocation form (`SKILLFORM`), and whether an empty composer shows ghost/suggested text.
+
+- [ ] **Step 3: Record findings**
+
+Write all resolved values into `docs/design-docs/cursor-verification-notes.md`. Do not commit this scratch file.
+
+- [ ] **Step 4: Tear down the trial**
+
+```bash
+bin/fm-teardown.sh cursor-verify-x1 --force
+```
+
+---
+
+## Task 1: Detection (`bin/fm-harness.sh`)
+
+**Files:**
+- Modify: `bin/fm-harness.sh` (`detect_own()`, after the grok marker ~line 28; ancestry `case` ~line 34-47)
+- Test: `tests/fm-cursor-harness.test.sh`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/fm-cursor-harness.test.sh` with a detection test:
+```bash
+#!/usr/bin/env bash
+set -u
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+HARNESS="$ROOT/bin/fm-harness.sh"
+
+test_detects_cursor_via_env_marker() {
+  local out
+  out=$(CURSOR_AGENT=1 CLAUDECODE= "$HARNESS")
+  assert_contains "$out" "cursor" "CURSOR_AGENT=1 should detect cursor"
+  pass "detects cursor via CURSOR_AGENT"
+}
+
+test_claude_still_wins_when_both_set() {
+  local out
+  out=$(CURSOR_AGENT=1 CLAUDECODE=1 "$HARNESS")
+  assert_contains "$out" "claude" "a genuine claude session must resolve to claude"
+  pass "preference-neutral: claude wins when CLAUDECODE set"
+}
+
+test_detects_cursor_via_env_marker
+test_claude_still_wins_when_both_set
+```
+
+- [ ] **Step 2: Run it red**
+
+Run: `bash tests/fm-cursor-harness.test.sh`
+Expected: FAIL - first test prints `unknown`/no `cursor`.
+
+- [ ] **Step 3: Implement**
+
+In `detect_own()`, add AFTER the grok marker line (`[ "${GROK_AGENT:-}" = "1" ] && { echo grok; return; }`):
+```sh
+  # Cursor sets CURSOR_AGENT=1 for its agent processes (verified). Placed after
+  # claude/pi/grok so detection stays preference-neutral: a genuine Claude session
+  # (CLAUDECODE=1), including one nested inside Cursor, still resolves to claude.
+  [ "${CURSOR_AGENT:-}" = "1" ] && { echo cursor; return; }
+```
+Add to BOTH ancestry `case` blocks (comm and args), mirroring the grok arm, using `BIN`:
+```sh
+      *cursor-agent*) echo cursor; return ;;
+```
+
+- [ ] **Step 4: Run it green**
+
+Run: `bash tests/fm-cursor-harness.test.sh`
+Expected: PASS (both detection tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bin/fm-harness.sh tests/fm-cursor-harness.test.sh
+git commit -m "feat(harness): detect cursor agent (preference-neutral)"
+```
+
+---
+
+## Task 2: Session lock recognition (`bin/fm-lock.sh`)
+
+**Files:**
+- Modify: `bin/fm-lock.sh:18` (`HARNESS_RE`)
+- Test: `tests/fm-cursor-harness.test.sh`
+
+- [ ] **Step 1: Add the failing test** (mirror `test_fm_lock_recognizes_grok_holder` from `tests/fm-grok-harness.test.sh:119`), with the fake `ps` returning the Cursor binary path/args, asserting `fm-lock.sh status` prints `lock: held by live harness pid`.
+
+- [ ] **Step 2: Run it red** - `bash tests/fm-cursor-harness.test.sh` -> the lock test fails ("cannot locate harness process").
+
+- [ ] **Step 3: Implement** - extend `HARNESS_RE`:
+```sh
+HARNESS_RE='claude|codex|opencode|grok|cursor-agent|^pi$'
+```
+(Use the tightened `cursor-agent` token, never a bare `agent`; if Task 0 found only `agent`, keep the env-marker-first detection and use a precise anchored `agent` alternative here, e.g. `(^|/)agent$`.)
+
+- [ ] **Step 4: Run it green.**
+
+- [ ] **Step 5: Commit** - `git commit -am "feat(lock): recognize cursor as session holder"`.
+
+---
+
+## Task 3: Spawn - launch template, model flag, secondmate list (`bin/fm-spawn.sh`)
+
+**Files:**
+- Modify: `bin/fm-spawn.sh` - `launch_template()` (~line 216), `model_flag_for_harness()` (line 282), `--secondmate` bare-name case (line 156)
+- Test: `tests/fm-cursor-harness.test.sh`
+
+- [ ] **Step 1: Write the failing test** - a spawn test (mirror `run_grok_spawn`/`make_spawn_case` from `tests/fm-grok-harness.test.sh`, using `cursor` as the harness arg and a fake `BIN`), asserting the spawn succeeds (`spawned <id> harness=cursor`) and that the tmux send-keys captured launch line contains `--force` and `--model <id>` and NO `--effort`. (Capture the launch by having the fake `tmux` log `send-keys -l` payloads to a file.)
+
+- [ ] **Step 2: Run it red.**
+
+- [ ] **Step 3: Implement.**
+`launch_template()`, add after the grok arm:
+```sh
+    # cursor (Cursor agent CLI): positional prompt starts the supervised session.
+    # --force auto-approves every tool execution (the unattended-crewmate equivalent
+    # of claude's --dangerously-skip-permissions). No effort flag: effort is encoded
+    # in the model id. Turn-end does NOT ride the launch command - it is a stop-hook
+    # installed below.
+    cursor) printf '%s' 'cursor-agent __MODELFLAG__--force "$(cat __BRIEF__)"' ;;
+```
+`model_flag_for_harness()`, add `cursor` to the case list so `--model` is emitted:
+```sh
+    claude|codex|opencode|pi|grok|cursor)
+```
+`effort_flag_for_harness()`: leave cursor out of the case (no arm) so no effort flag is emitted - effort is recorded in meta only. Add a brief comment noting effort is encoded in the cursor model id.
+`--secondmate` bare-name list (line 156): `''|claude|codex|opencode|pi|grok|cursor)`.
+
+- [ ] **Step 4: Run it green.**
+
+- [ ] **Step 5: Commit** - `git commit -am "feat(spawn): cursor launch template, model flag, secondmate name"`.
+
+---
+
+## Task 4: Spawn - turn-end stop-hook (`bin/fm-spawn.sh`)
+
+The novel piece. Cursor hooks live in the shared `~/.cursor/hooks.json` (or `$CURSOR_CONFIG_DIR/hooks.json`) and receive the event payload on stdin as JSON; the hook must merge idempotently and preserve existing hooks.
+
+**Files:**
+- Modify: `bin/fm-spawn.sh` - the turn-end `case "$HARNESS" in` block (add a `cursor*)` arm after `grok*)` ~line 660)
+- Test: `tests/fm-cursor-harness.test.sh`
+
+- [ ] **Step 1: Write the failing test** (mirror `test_grok_hook_requires_registered_token`): after a cursor spawn, assert:
+  - the hook script exists at `<cursor_home>/hooks/fm-turn-end.sh`;
+  - `<cursor_home>/hooks.json` `.hooks.stop` contains an entry whose command is that script, AND a pre-seeded `sessionStart` hook + a pre-existing `stop` entry both survive (preservation);
+  - `<worktree>/.fm-cursor-turnend` contains `token=` and does NOT contain the turn-ended path;
+  - the registry entry `<cursor_home>/hooks/fm-turn-end.d/<token>` names `state/<id>.turn-ended`;
+  - piping `{"workspace_roots":["<worktree>"]}` to the hook on stdin touches `state/<id>.turn-ended`, while an evil pointer to an arbitrary target does NOT.
+  Use a `CURSOR_CONFIG_DIR` (or `HOME`) override pointing at the case's cursor home so the test never touches the real `~/.cursor`.
+
+- [ ] **Step 2: Run it red.**
+
+- [ ] **Step 3: Implement.** Add a `cursor*)` arm mirroring grok's block (`bin/fm-spawn.sh:612-660`) with these differences:
+  - Resolve the hooks dir: `CURSOR_HOOKS_DIR="${CURSOR_CONFIG_DIR:-$HOME/.cursor}/hooks"`; registry `CURSOR_AUTH_DIR="$CURSOR_HOOKS_DIR/fm-turn-end.d"`.
+  - Write the auth file + `$STATE/$ID.cursor-turnend-token` + `<worktree>/.fm-cursor-turnend` pointer (`token=...`), and `exclude_path '.fm-cursor-turnend'` - identical shape to grok.
+  - Hook script reads Cursor's stdin JSON (not an env var) and emits `{}`:
+    ```sh
+    cat > "$CURSOR_HOOKS_DIR/fm-turn-end.sh" <<EOF
+    #!/usr/bin/env bash
+    set -u
+    auth_dir=$sq_cursor_auth_dir
+    payload=\$(cat 2>/dev/null || true)
+    roots=\$(printf '%s' "\$payload" | jq -r '.workspace_roots[]?' 2>/dev/null) || roots=""
+    while IFS= read -r ws; do
+      [ -n "\$ws" ] || continue
+      p="\$ws/.fm-cursor-turnend"
+      [ -f "\$p" ] || continue
+      first=
+      IFS= read -r -n 256 first < "\$p" 2>/dev/null || [ -n "\$first" ] || continue
+      case "\$first" in token=*) token=\${first#token=} ;; *) continue ;; esac
+      case "\$token" in fm.????????????) : ;; *) continue ;; esac
+      case "\$token" in *[!A-Za-z0-9._-]*) continue ;; esac
+      t=\$(cat "\$auth_dir/\$token" 2>/dev/null) || continue
+      case "\$t" in /*.turn-ended) : ;; *) continue ;; esac
+      touch "\$t" 2>/dev/null || true
+    done <<ROOTS
+    \$roots
+    ROOTS
+    printf '{}'
+    exit 0
+    EOF
+    chmod +x "$CURSOR_HOOKS_DIR/fm-turn-end.sh"
+    ```
+  - Idempotent merge into hooks.json (preserve existing), instead of grok's standalone `.json`:
+    ```sh
+    HOOKS_JSON="${CURSOR_CONFIG_DIR:-$HOME/.cursor}/hooks.json"
+    [ -f "$HOOKS_JSON" ] || printf '{"version":1,"hooks":{}}' > "$HOOKS_JSON"
+    cmd="$CURSOR_HOOKS_DIR/fm-turn-end.sh"
+    tmp=$(mktemp)
+    jq --arg cmd "$cmd" '.hooks.stop = ((.hooks.stop // []) | if any(.command == $cmd) then . else . + [{"command":$cmd,"timeout":10}] end)' "$HOOKS_JSON" > "$tmp" && mv "$tmp" "$HOOKS_JSON"
+    ```
+  - Skip the pointer for `kind=secondmate`, exactly as grok does.
+
+- [ ] **Step 4: Run it green.**
+
+- [ ] **Step 5: Commit** - `git commit -am "feat(spawn): cursor turn-end stop-hook merged into hooks.json"`.
+
+---
+
+## Task 5: Teardown cleanup (`bin/fm-teardown.sh`)
+
+**Files:**
+- Modify: `bin/fm-teardown.sh` - dirty-check regex (line 593), the two pointer removals (lines 536, 651), and a `remove_cursor_turnend_auth()` + `$STATE/$ID.cursor-turnend-token` removals mirroring grok (lines 94, 543/544, 664/668)
+- Test: `tests/fm-cursor-harness.test.sh`
+
+- [ ] **Step 1: Write the failing test** (mirror `test_grok_teardown_removes_pointer_and_token`): after spawn+teardown, assert `<worktree>/.fm-cursor-turnend`, `<cursor_home>/hooks/fm-turn-end.d/<token>`, and `state/<id>.cursor-turnend-token` are all absent. Add a case asserting a dirty worktree containing only `?? .fm-cursor-turnend` is NOT treated as dirty.
+
+- [ ] **Step 2: Run it red.**
+
+- [ ] **Step 3: Implement** - add cursor arms mirroring every grok touch point:
+  - dirty-check regex: `grep -vE '^\?\? (\.claude/|\.fm-grok-turnend$|\.fm-cursor-turnend$)'`
+  - both `rm -f ... .fm-grok-turnend` sites: also `rm -f "$WT/.fm-cursor-turnend"`
+  - add `remove_cursor_turnend_auth()` (read token from `$STATE/$ID.cursor-turnend-token`, `rm -f "$CURSOR_AUTH_DIR/$token"`) and call it at both teardown sites, then `rm -f "$STATE/$ID.cursor-turnend-token"`.
+  - Leave the global hook + hooks.json entry installed (harmless no-op).
+
+- [ ] **Step 4: Run it green.**
+
+- [ ] **Step 5: Commit** - `git commit -am "feat(teardown): clean up cursor turn-end pointer and token"`.
+
+---
+
+## Task 6: Bootstrap allowlist (`bin/fm-bootstrap.sh`)
+
+**Files:**
+- Modify: `bin/fm-bootstrap.sh:318` (`verified($h)` list)
+- Test: `tests/fm-cursor-harness.test.sh` (or extend `tests/fm-bootstrap.test.sh`, mirroring its grok crew-dispatch case)
+
+- [ ] **Step 1: Write the failing test** - a `crew-dispatch.json` with a rule `{"when":"...","use":{"harness":"cursor","model":"claude-opus-4-8-thinking-max"}}` validates as `CREW_DISPATCH: active` (not `invalid ... unverified harness`).
+
+- [ ] **Step 2: Run it red.**
+
+- [ ] **Step 3: Implement** - `def verified($h): ["claude","codex","opencode","pi","grok","cursor"] | ...`. Leave `effort_ok` without a cursor arm (falls through to `true`); add a comment that cursor effort/model ids are not machine-validated (ZDR is a convention).
+
+- [ ] **Step 4: Run it green.**
+
+- [ ] **Step 5: Commit** - `git commit -am "feat(bootstrap): accept cursor as a verified harness"`.
+
+---
+
+## Task 7: Busy signature (`bin/fm-watch.sh`, `bin/fm-tmux-lib.sh`)
+
+**Files:**
+- Modify: `bin/fm-watch.sh:99` (`BUSY_REGEX` default), `bin/fm-tmux-lib.sh:40` (`FM_TMUX_BUSY_REGEX_DEFAULT`)
+
+- [ ] **Step 1: Implement** - add the `BUSY` string from Task 0 as an alternation to both default regexes (only if it is not already matched by the existing `esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel` set; if Cursor uses `esc to interrupt`, no change is needed - note that in the commit).
+
+- [ ] **Step 2: Sanity check** - `bash -n bin/fm-watch.sh bin/fm-tmux-lib.sh`.
+
+- [ ] **Step 3: Commit** (only if changed) - `git commit -am "feat(watch): add cursor busy signature"`.
+
+---
+
+## Task 8: Adapter knowledge (`.agents/skills/harness-adapters/SKILL.md`)
+
+**Files:**
+- Modify: `.agents/skills/harness-adapters/SKILL.md`
+
+- [ ] **Step 1: Add a `cursor (VERIFIED <date>)` section** with the Task 0 facts: busy signature, exit command, interrupt key, trust-dialog handling, `SKILLFORM` for `/no-mistakes`, resume (`cursor-agent resume` / `--continue`), env marker `CURSOR_AGENT=1`, autonomy `--force`, and a launch-profile table row (model via full id, no effort flag). Add `cursor` to the detection/launch-axes prose and the verified-set line.
+
+- [ ] **Step 2: Commit** - `git commit -am "docs(harness-adapters): add verified cursor section"`.
+
+---
+
+## Task 9: Local configuration + run the fleet on Cursor
+
+Local and gitignored - NOT part of the upstream PR.
+
+**Files:**
+- Create (in the operator's firstmate home): `config/crew-harness`, `config/crew-dispatch.json`
+
+- [ ] **Step 1: Set the crew harness fallback** - `printf 'cursor\n' > config/crew-harness`.
+
+- [ ] **Step 2: Write `config/crew-dispatch.json`** (all ZDR-safe, no Fable 5):
+```json
+{
+  "rules": [
+    { "when": "heavy, architectural, or multi-file changes", "use": { "harness": "cursor", "model": "claude-opus-4-8-thinking-max" } },
+    { "when": "quick or scoped fixes", "use": { "harness": "cursor", "model": "claude-opus-4-8-thinking-high-fast" } }
+  ],
+  "default": { "use": { "harness": "cursor", "model": "claude-opus-4-8-thinking-high-fast" } }
+}
+```
+
+- [ ] **Step 3: Launch the first mate on Cursor** - from the firstmate home: `cursor-agent --model claude-opus-4-8-high-fast`, then `bootstrap yourself`.
+
+- [ ] **Step 4: Smoke test** - dispatch one trivial ship task, confirm a crewmate spawns on cursor, works, wakes the watcher on turn-end, and tears down cleanly.
+
+---
+
+## Task 10: Full behavior suite
+
+- [ ] **Step 1: Run the suite** - `tmux -V && for t in tests/*.test.sh; do bash "$t" || echo "FAIL: $t"; done` (this is what `.no-mistakes.yaml` runs).
+Expected: all pass, including `tests/fm-cursor-harness.test.sh`.
+
+- [ ] **Step 2: Fix any failures, re-run.**
+
+- [ ] **Step 3: Final commit if needed.**
+
+---
+
+## Deferred: upstream PR (Phase 2, after weeks of local use)
+
+Once proven locally: run `no-mistakes` on the branch, open the PR (keeping the preference-neutral detection so Claude-first operators are not regressed), captain merges. Drop the scratch `cursor-verification-notes.md` and the local `config/*` from the PR.

--- a/docs/orca-backend.md
+++ b/docs/orca-backend.md
@@ -7,7 +7,7 @@ It is intentionally small: enough for upstream review of the adapter boundary, m
 
 Orca is a proposed runtime session and worktree backend for firstmate.
 It is distinct from the crewmate harness.
-The harness is the agent process firstmate launches inside a task endpoint, such as `claude`, `codex`, `opencode`, `pi`, or `grok`.
+The harness is the agent process firstmate launches inside a task endpoint, such as `claude`, `codex`, `opencode`, `pi`, `grok`, or `cursor`.
 The runtime backend owns the endpoint and worktree lifecycle underneath that harness.
 
 The current verified backends are `tmux` and experimental `herdr`.

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -226,8 +226,24 @@ ROWS
   pass "bootstrap validates crew-dispatch.json and reports malformed or unverified configs"
 }
 
+test_crew_dispatch_accepts_cursor() {
+  local case_dir fakebin out
+  case_dir="$TMP_ROOT/dispatch-cursor"
+  mkdir -p "$case_dir/home/config"
+  printf '%s\n' manual > "$case_dir/home/config/backlog-backend"
+  printf '%s\n' '{"rules":[{"when":"heavy work","use":{"harness":"cursor","model":"claude-opus-4-8-thinking-max"}}],"default":{"harness":"cursor","model":"claude-opus-4-8-thinking-high-fast"}}' > "$case_dir/home/config/crew-dispatch.json"
+  fakebin=$(make_fake_toolchain "$case_dir")
+  add_real_jq "$fakebin"
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+    FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
+  assert_contains "$out" "CREW_DISPATCH: active" "cursor dispatch config should validate as active (cursor is verified)"
+  assert_contains "$out" "-> cursor/claude-opus-4-8-thinking-max" "cursor dispatch rule should be surfaced"
+  pass "bootstrap accepts cursor as a verified crew-dispatch harness"
+}
+
 test_bootstrap_reporting
 test_no_mistakes_min_version
 test_orca_backend_gates_orca_tool_only_when_selected
 test_crew_dispatch_active_rules_are_surfaced
 test_crew_dispatch_validation
+test_crew_dispatch_accepts_cursor

--- a/tests/fm-cursor-harness.test.sh
+++ b/tests/fm-cursor-harness.test.sh
@@ -5,7 +5,82 @@ set -u
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 HARNESS="$ROOT/bin/fm-harness.sh"
+SPAWN="$ROOT/bin/fm-spawn.sh"
+TEARDOWN="$ROOT/bin/fm-teardown.sh"
 TMP_ROOT=$(fm_test_tmproot fm-cursor-harness)
+
+# Fake tmux that logs the `send-keys -l <payload>` launch line so tests can
+# inspect the composed launch command without running a real agent.
+make_spawn_fakebin() {
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+esac
+case "${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+  list-windows) exit 0 ;;
+  send-keys)
+    shift
+    prev=""
+    for a in "$@"; do
+      [ "$prev" = "-l" ] && printf '%s\n' "$a" >> "${FM_FAKE_SENDKEYS_LOG:-/dev/null}"
+      prev="$a"
+    done
+    exit 0 ;;
+  has-session|new-session|new-window|kill-window) exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" treehouse gh-axi gh
+  printf '%s\n' "$fakebin"
+}
+
+make_spawn_case() {
+  local name=$1 case_dir home proj wt fakebin cursor_cfg id
+  case_dir="$TMP_ROOT/$name"
+  home="$case_dir/home"; proj="$case_dir/project"; wt="$case_dir/wt"
+  fakebin=$(make_spawn_fakebin "$case_dir/fake")
+  cursor_cfg="$case_dir/cursorcfg"
+  id="cursor-$name-x1"
+  mkdir -p "$home/data/$id" "$home/projects" "$home/state" "$home/config" "$cursor_cfg/hooks"
+  printf 'brief\n' > "$home/data/$id/brief.md"
+  fm_git_worktree "$proj" "$wt" "fm/$id"
+  touch "$home/state/.last-watcher-beat"
+  printf '%s\n' "$case_dir|$home|$proj|$wt|$fakebin|$cursor_cfg|$id"
+}
+
+run_cursor_spawn() {
+  local home=$1 proj=$2 wt=$3 fakebin=$4 cursor_cfg=$5 id=$6 log=$7
+  FM_ROOT_OVERRIDE='' FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
+    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" TMUX="fake,1,0" \
+    CURSOR_CONFIG_DIR="$cursor_cfg" FM_FAKE_SENDKEYS_LOG="$log" \
+    PATH="$fakebin:$PATH" \
+    "$SPAWN" "$id" "$proj" cursor --model claude-opus-4-8-thinking-max 2>&1
+}
+
+test_cursor_launch_template() {
+  local rec case_dir home proj wt fakebin cursor_cfg id log out status
+  rec=$(make_spawn_case launch)
+  IFS='|' read -r case_dir home proj wt fakebin cursor_cfg id <<EOF
+$rec
+EOF
+  log="$case_dir/sendkeys.log"; : > "$log"
+  out=$(run_cursor_spawn "$home" "$proj" "$wt" "$fakebin" "$cursor_cfg" "$id" "$log")
+  status=$?
+  expect_code 0 "$status" "cursor spawn should succeed"
+  assert_contains "$out" "spawned $id harness=cursor" "cursor spawn did not report success"
+  assert_grep 'force' "$log" "launch did not include the --force autonomy flag"
+  assert_grep 'claude-opus-4-8-thinking-max' "$log" "launch did not include the model id"
+  assert_no_grep 'effort' "$log" "cursor launch must not include an effort flag (effort is in the model id)"
+  pass "cursor launch template uses --force, --model, and no --effort"
+}
 
 test_detects_cursor_via_env_marker() {
   local out
@@ -44,3 +119,4 @@ SH
 test_detects_cursor_via_env_marker
 test_claude_still_wins_when_both_set
 test_fm_lock_recognizes_cursor_holder
+test_cursor_launch_template

--- a/tests/fm-cursor-harness.test.sh
+++ b/tests/fm-cursor-harness.test.sh
@@ -151,8 +151,31 @@ EOF
   pass "cursor stop-hook fires only for a registered worktree and preserves existing hooks"
 }
 
+test_cursor_teardown_removes_pointer_and_token() {
+  local rec case_dir home proj wt fakebin cursor_cfg id log out token
+  rec=$(make_spawn_case teardown)
+  IFS='|' read -r case_dir home proj wt fakebin cursor_cfg id <<EOF
+$rec
+EOF
+  log="$case_dir/sendkeys.log"; : > "$log"
+  out=$(run_cursor_spawn "$home" "$proj" "$wt" "$fakebin" "$cursor_cfg" "$id" "$log")
+  expect_code 0 $? "cursor spawn should succeed before teardown"
+  token=$(sed -n 's/^token=//p' "$wt/.fm-cursor-turnend")
+
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    CURSOR_CONFIG_DIR="$cursor_cfg" PATH="$fakebin:$PATH" \
+    "$TEARDOWN" "$id" --force >/dev/null 2>&1 \
+    || fail "cursor teardown failed"
+
+  assert_absent "$wt/.fm-cursor-turnend" "cursor pointer survived teardown"
+  assert_absent "$cursor_cfg/hooks/fm-turn-end.d/$token" "cursor auth token survived teardown"
+  assert_absent "$home/state/$id.cursor-turnend-token" "cursor state token survived teardown"
+  pass "cursor teardown removes pointer and token state"
+}
+
 test_detects_cursor_via_env_marker
 test_claude_still_wins_when_both_set
 test_fm_lock_recognizes_cursor_holder
 test_cursor_launch_template
 test_cursor_turnend_hook
+test_cursor_teardown_removes_pointer_and_token

--- a/tests/fm-cursor-harness.test.sh
+++ b/tests/fm-cursor-harness.test.sh
@@ -116,7 +116,43 @@ SH
   pass "fm-lock recognizes cursor-agent harness processes"
 }
 
+test_cursor_turnend_hook() {
+  local rec case_dir home proj wt fakebin cursor_cfg id log out status hook token target evil evil_target
+  rec=$(make_spawn_case turnend)
+  IFS='|' read -r case_dir home proj wt fakebin cursor_cfg id <<EOF
+$rec
+EOF
+  # Pre-seed existing hooks so the test proves the merge preserves them.
+  printf '%s\n' '{"version":1,"hooks":{"sessionStart":[{"command":"hooks/existing-start.sh","timeout":10}],"stop":[{"command":"hooks/notify-stop.sh","timeout":10}]}}' > "$cursor_cfg/hooks.json"
+  log="$case_dir/sendkeys.log"; : > "$log"
+  out=$(run_cursor_spawn "$home" "$proj" "$wt" "$fakebin" "$cursor_cfg" "$id" "$log")
+  status=$?
+  expect_code 0 "$status" "cursor spawn should succeed"
+
+  hook="$cursor_cfg/hooks/fm-turn-end.sh"
+  assert_present "$hook" "cursor turn-end hook script was not installed"
+  assert_grep 'existing-start.sh' "$cursor_cfg/hooks.json" "sessionStart hook was clobbered by the merge"
+  assert_grep 'notify-stop.sh' "$cursor_cfg/hooks.json" "pre-existing stop hook was clobbered by the merge"
+  assert_grep 'fm-turn-end.sh' "$cursor_cfg/hooks.json" "fm-turn-end stop hook was not added to hooks.json"
+
+  assert_grep 'token=' "$wt/.fm-cursor-turnend" "cursor pointer did not contain a token"
+  token=$(sed -n 's/^token=//p' "$wt/.fm-cursor-turnend")
+  assert_present "$cursor_cfg/hooks/fm-turn-end.d/$token" "cursor auth registry entry was not written"
+  target=$(cat "$cursor_cfg/hooks/fm-turn-end.d/$token")
+  assert_no_grep "$target" "$wt/.fm-cursor-turnend" "cursor pointer exposed the turn-end path"
+
+  evil="$case_dir/evil"; evil_target="$case_dir/evil-target.turn-ended"; mkdir -p "$evil"
+  printf '%s\n' "$evil_target" > "$evil/.fm-cursor-turnend"
+  printf '%s' "{\"workspace_roots\":[\"$evil\"]}" | bash "$hook" >/dev/null
+  assert_absent "$evil_target" "unregistered cursor pointer touched an arbitrary target"
+
+  printf '%s' "{\"workspace_roots\":[\"$wt\"]}" | bash "$hook" >/dev/null
+  assert_present "$target" "registered cursor pointer did not touch the task turn-end file"
+  pass "cursor stop-hook fires only for a registered worktree and preserves existing hooks"
+}
+
 test_detects_cursor_via_env_marker
 test_claude_still_wins_when_both_set
 test_fm_lock_recognizes_cursor_holder
 test_cursor_launch_template
+test_cursor_turnend_hook

--- a/tests/fm-cursor-harness.test.sh
+++ b/tests/fm-cursor-harness.test.sh
@@ -84,7 +84,7 @@ EOF
 
 test_detects_cursor_via_env_marker() {
   local out
-  out=$(CURSOR_AGENT=1 CLAUDECODE= PI_CODING_AGENT= GROK_AGENT= "$HARNESS")
+  out=$(CURSOR_AGENT=1 CLAUDECODE='' PI_CODING_AGENT='' GROK_AGENT='' "$HARNESS")
   assert_contains "$out" "cursor" "CURSOR_AGENT=1 should detect the cursor harness"
   pass "detects cursor via CURSOR_AGENT marker"
 }

--- a/tests/fm-cursor-harness.test.sh
+++ b/tests/fm-cursor-harness.test.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+HARNESS="$ROOT/bin/fm-harness.sh"
+
+test_detects_cursor_via_env_marker() {
+  local out
+  out=$(CURSOR_AGENT=1 CLAUDECODE= PI_CODING_AGENT= GROK_AGENT= "$HARNESS")
+  assert_contains "$out" "cursor" "CURSOR_AGENT=1 should detect the cursor harness"
+  pass "detects cursor via CURSOR_AGENT marker"
+}
+
+test_claude_still_wins_when_both_set() {
+  local out
+  out=$(CURSOR_AGENT=1 CLAUDECODE=1 "$HARNESS")
+  assert_contains "$out" "claude" "a genuine claude session (CLAUDECODE=1) must resolve to claude, not cursor"
+  pass "preference-neutral: claude wins when CLAUDECODE is set"
+}
+
+test_detects_cursor_via_env_marker
+test_claude_still_wins_when_both_set

--- a/tests/fm-cursor-harness.test.sh
+++ b/tests/fm-cursor-harness.test.sh
@@ -5,6 +5,7 @@ set -u
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 HARNESS="$ROOT/bin/fm-harness.sh"
+TMP_ROOT=$(fm_test_tmproot fm-cursor-harness)
 
 test_detects_cursor_via_env_marker() {
   local out
@@ -20,5 +21,26 @@ test_claude_still_wins_when_both_set() {
   pass "preference-neutral: claude wins when CLAUDECODE is set"
 }
 
+test_fm_lock_recognizes_cursor_holder() {
+  local home fakebin out
+  home="$TMP_ROOT/lock-home"
+  fakebin=$(fm_fakebin "$TMP_ROOT/lock-fake")
+  mkdir -p "$home/state"
+  printf '%s\n' "$$" > "$home/state/.lock"
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *"comm="*) printf '%s\n' '/Users/x/.local/share/cursor-agent/versions/v/cursor-agent'; exit 0 ;;
+  *"args="*) printf '%s\n' 'cursor-agent'; exit 0 ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/ps"
+  out=$(FM_HOME="$home" PATH="$fakebin:$PATH" "$ROOT/bin/fm-lock.sh" status)
+  assert_contains "$out" "lock: held by live harness pid" "fm-lock did not recognize cursor-agent as a live holder"
+  pass "fm-lock recognizes cursor-agent harness processes"
+}
+
 test_detects_cursor_via_env_marker
 test_claude_still_wins_when_both_set
+test_fm_lock_recognizes_cursor_holder


### PR DESCRIPTION
## What Changed

- Added `cursor` as a verified harness adapter: detection in `fm-harness.sh`, session-holder recognition in `fm-lock.sh`, bootstrap verification, and a cursor busy signature in `fm-watch.sh`.
- Wired the cursor lifecycle into `fm-spawn.sh` (launch template, `--model` full-id flag, secondmate naming) and its turn-end signaling via a `stop` hook merged idempotently into the operator's shared `~/.cursor/hooks.json`, gated by a per-task token pointer; `fm-teardown.sh` now removes that pointer, token, and registry entry.
- Documented the adapter across the `harness-adapters` skill, `AGENTS.md`, and supporting docs, and added `tests/fm-cursor-harness.test.sh` plus bootstrap test coverage for cursor detection and verification.

## Risk Assessment

✅ Low: A well-bounded, thoroughly tested harness-adapter addition that faithfully mirrors the existing grok pattern across detection, lock, spawn, the guarded stop-hook, and teardown, with a security test proving the hook cannot touch unregistered targets and no substantiated defects found.

## Testing

Completed 1 recorded test check.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
