### PR TITLE
fix: tighten Orca backend parsing

### DIFF
--- a/bin/backends/orca.sh
+++ b/bin/backends/orca.sh
@@ -43,6 +43,10 @@ process.exit(1);
 }
 
 fm_backend_orca_json_get() {  # <field> ; fields: worktree-id worktree-path terminal-handle worktree-terminal-handle repo-id
+  # Terminal handles are accepted only from verified terminal result shapes:
+  # result.terminal or a root terminal object with .handle. Undocumented
+  # result.id and result.worktree.terminal shapes are ignored until a real Orca
+  # smoke run proves them.
   local field=$1
   node -e '
 const fs = require("fs");
@@ -255,6 +259,10 @@ fm_backend_orca_read_text_paged() {  # <terminal-id> <limit>
 FM_BACKEND_ORCA_COMPOSER_LINES=${FM_BACKEND_ORCA_COMPOSER_LINES:-200}
 FM_BACKEND_ORCA_IDLE_RE=${FM_BACKEND_ORCA_IDLE_RE:-'^Type a message\.\.\.$'}
 
+# fm_backend_orca_composer_state: classify the composer's own bordered row as
+# empty|pending|unknown. Real text stays pending, including a slash-command
+# popup that closed by filling an argument-hint placeholder into the composer;
+# that first Enter selected the popup item, it did not submit the command.
 fm_backend_orca_composer_state() {  # <terminal-id> -> empty|pending|unknown
   local terminal=$1 cap line trimmed stripped="" found=0
   cap=$(fm_backend_orca_read_text_paged "$terminal" "$FM_BACKEND_ORCA_COMPOSER_LINES") || { printf 'unknown'; return 0; }
@@ -308,6 +316,9 @@ fm_backend_orca_send_key() {  # <terminal-id> <key>
   esac
 }
 
+# fm_backend_orca_send_text_submit: type <text> once, then retry Enter until
+# the composer row reads empty. Retries send only Enter, so a slash-command
+# popup placeholder fill gets the required second Enter without duplicating text.
 fm_backend_orca_send_text_submit() {  # <terminal-id> <text> <retries> <enter-sleep> <settle>
   local terminal=$1 text=$2 retries=$3 sleep_s=$4 settle=$5 i=0 state
   fm_backend_orca_tool_check || { printf 'send-failed'; return 0; }

--- a/bin/backends/orca.sh
+++ b/bin/backends/orca.sh
@@ -55,21 +55,21 @@ if (data.ok === false) {
 }
 const r = data.result || {};
 const wt = r.worktree || r.item || r;
-const explicitTerm = r.terminal || wt.terminal || null;
+const explicitTerm = r.terminal || null;
 const repo = r.repo || r.repository || r;
 function scalar(v) {
   return (typeof v === "string" || typeof v === "number") ? String(v) : "";
 }
-function handle(obj, allowRootId) {
+function handle(obj) {
   if (!obj) return "";
   if (typeof obj === "string" || typeof obj === "number") return String(obj);
-  return scalar(obj.handle) || (allowRootId ? scalar(obj.id) : "") || "";
+  return scalar(obj.handle) || "";
 }
 let v = "";
 if (field === "worktree-id") v = wt.id || wt.worktreeId || r.worktreeId || "";
 if (field === "worktree-path") v = wt.path || (wt.git && wt.git.path) || r.path || "";
-if (field === "terminal-handle") v = handle(explicitTerm || r, true) || "";
-if (field === "worktree-terminal-handle") v = handle(explicitTerm, true) || "";
+if (field === "terminal-handle") v = handle(explicitTerm || r) || "";
+if (field === "worktree-terminal-handle") v = handle(explicitTerm) || "";
 if (field === "repo-id") v = repo.id || repo.repoId || r.repoId || "";
 if (!v) process.exit(1);
 process.stdout.write(String(v));

--- a/docs/orca-backend.md
+++ b/docs/orca-backend.md
@@ -42,14 +42,14 @@ Spawn:
 
 1. Ensure the project repo is registered in Orca, adding it with `orca repo add --path` when needed.
 2. Create an independent Orca worktree with `orca worktree create --repo id:<repo> --name fm-<id> --no-parent --setup skip`.
-3. Reuse the terminal returned by Orca worktree creation when present, or create a titled terminal in that worktree when Orca returns only the worktree.
+3. Reuse the terminal returned by Orca worktree creation only when it appears in the verified `result.terminal.handle` shape, or create a titled terminal in that worktree when Orca returns only the worktree.
 4. Install firstmate's per-harness turn-end hooks in the Orca worktree.
 5. Write metadata, then send `GOTMPDIR` export and the selected harness launch through the recorded Orca terminal.
 
 Operation routing:
 
 - `fm-peek.sh` captures with `orca terminal read`.
-- `fm-send.sh` types text with `orca terminal send --text ...`, submits with Enter, and verifies the composer row cleared before returning; when Orca reports a limited page, the verifier follows `oldestCursor` and preserves the current tail so older text cannot hide still-pending composer input.
+- `fm-send.sh` types text with `orca terminal send --text ...`, submits with Enter, and verifies the composer row cleared before returning; when Orca reports a limited page, the verifier follows `oldestCursor` and preserves the current tail so older text cannot hide still-pending composer input. A slash-command popup that closes by filling an argument-hint placeholder still reads as pending, so the retry loop sends the required second Enter rather than treating the first Enter as a submission.
 - `fm-send.sh --key Enter` and `--key C-c` are supported.
 - `fm-watch.sh` treats Orca as a pull backend with no native busy-state primitive, so it falls back to the same terminal-tail busy regex used for tmux and zellij.
 - `fm-crew-state.sh` reads the recorded Orca terminal when no no-mistakes run-step applies.
@@ -73,13 +73,16 @@ Teardown:
 
 Real-Orca smoke verification was run against `/usr/local/bin/orca` with `/Applications/Orca.app` reporting bundle version `1.4.116`; `orca status --json` reported `result.runtime.reachable=true` and `result.runtime.state="ready"`.
 The verified terminal creation handle field is `result.terminal.handle` from `orca terminal create --json`; worktree creation returned `result.worktree.id` and `result.worktree.path` in the same smoke run.
+Firstmate intentionally ignores speculative terminal-handle shapes such as bare `result.id` and nested `result.worktree.terminal` until a real Orca smoke run proves them.
 
 Fake-Orca tests cover:
 
-- helper parsing for repo registration, worktree creation, implicit-terminal reuse, terminal creation, terminal sends, and worktree removal;
+- helper parsing for repo registration, worktree creation, verified implicit-terminal reuse, terminal creation, terminal sends, and worktree removal;
+- rejection of undocumented terminal-handle result shapes;
 - runtime readiness gating through `orca status --json`;
 - `fm-spawn.sh --backend orca` metadata creation and harness launch;
 - `fm-peek.sh`, `fm-send.sh`, and `fm-crew-state.sh` routing through recorded Orca metadata;
+- slash-command popup placeholder handling that requires a second Enter before `fm-send.sh` reports submission;
 - scout teardown releasing an Orca worktree through `orca worktree rm`;
 - ship teardown failing closed when the recorded Orca worktree id is missing, cannot resolve to a path, or resolves to a different path than `worktree=`.
 

--- a/docs/orca-backend.md
+++ b/docs/orca-backend.md
@@ -49,7 +49,8 @@ Spawn:
 Operation routing:
 
 - `fm-peek.sh` captures with `orca terminal read`.
-- `fm-send.sh` types text with `orca terminal send --text ...`, submits with Enter, and verifies the composer row cleared before returning; when Orca reports a limited page, the verifier follows `oldestCursor` and preserves the current tail so older text cannot hide still-pending composer input. A slash-command popup that closes by filling an argument-hint placeholder still reads as pending, so the retry loop sends the required second Enter rather than treating the first Enter as a submission.
+- `fm-send.sh` types text with `orca terminal send --text ...`, submits with Enter, and verifies the composer row cleared before returning; when Orca reports a limited page, the verifier follows `oldestCursor` and preserves the current tail so older text cannot hide still-pending composer input.
+  A slash-command popup that closes by filling an argument-hint placeholder still reads as pending, so the retry loop sends the required second Enter rather than treating the first Enter as a submission.
 - `fm-send.sh --key Enter` and `--key C-c` are supported.
 - `fm-watch.sh` treats Orca as a pull backend with no native busy-state primitive, so it falls back to the same terminal-tail busy regex used for tmux and zellij.
 - `fm-crew-state.sh` reads the recorded Orca terminal when no no-mistakes run-step applies.

--- a/tests/fm-backend-orca.test.sh
+++ b/tests/fm-backend-orca.test.sh
@@ -187,6 +187,38 @@ test_send_text_submit_retries_when_composer_stays_pending() {
   pass "fm_backend_orca_send_text_submit: retries Enter while composer remains pending"
 }
 
+test_composer_state_popup_placeholder_fill_is_pending() {
+  local out
+  orca_case composer-popup-placeholder
+  printf '{"ok":true,"result":{"terminal":{"tail":["  ╭──────────────────────────────────────╮","  │ ❯ /compact compaction instructions    │","  ╰──────────────── Composer ─────────────╯","","  Enter:send"]}}}\n' > "$RESP/1.out"
+  out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
+    bash -c '. "$0/bin/backends/orca.sh"; fm_backend_orca_composer_state term-123' "$ROOT" )
+  [ "$out" = pending ] || fail "a popup-close-with-placeholder-fill must still read as pending (not yet submitted), got '$out'"
+  pass "fm_backend_orca_composer_state: a slash-command popup's argument-hint placeholder still reads pending"
+}
+
+test_send_text_submit_popup_autocomplete_requires_second_enter() {
+  local out log_text enter_count
+  orca_case send-submit-popup-autocomplete
+  # 1: literal send "/compact"
+  # 2: Enter #1 closes the popup and fills the placeholder
+  # 3: read - composer still holds real pending text
+  printf '{"ok":true,"result":{"send":{"handle":"term-123","accepted":true}}}\n' > "$RESP/1.out"
+  printf '{"ok":true,"result":{"send":{"handle":"term-123","accepted":true}}}\n' > "$RESP/2.out"
+  printf '{"ok":true,"result":{"terminal":{"tail":["  ╭──────────────────────────────────────╮","  │ ❯ /compact compaction instructions    │","  ╰──────────────── Composer ─────────────╯","","  Enter:send"]}}}\n' > "$RESP/3.out"
+  # 4: Enter #2 actually submits
+  # 5: read - composer is empty
+  printf '{"ok":true,"result":{"send":{"handle":"term-123","accepted":true}}}\n' > "$RESP/4.out"
+  printf '{"ok":true,"result":{"terminal":{"tail":["  ╭────────────────────────╮","  │ ❯                      │","  ╰──────── Composer ─────╯","","  Shift+Tab:mode"]}}}\n' > "$RESP/5.out"
+  out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
+    bash -c '. "$0/bin/backends/orca.sh"; fm_backend_orca_send_text_submit term-123 "/compact" 3 0.01 1.2' "$ROOT" )
+  [ "$out" = empty ] || fail "send_text_submit should eventually report empty once the SECOND Enter actually clears the composer, got '$out'"
+  log_text=$(cat "$LOG")
+  enter_count=$(printf '%s\n' "$log_text" | grep -c $'orca\x1fterminal\x1fsend\x1f--terminal\x1fterm-123\x1f--text\x1f\x1f--enter\x1f--json')
+  [ "$enter_count" -eq 2 ] || fail "send_text_submit must send a SECOND Enter after the popup-placeholder fill still reads pending, got $enter_count Enter(s)"
+  pass "fm_backend_orca_send_text_submit: a slash-command popup's placeholder fill on Enter #1 does not short-circuit as submitted; Enter #2 is retried and lands it"
+}
+
 test_send_literal_constructs_non_enter_send() {
   orca_case send-literal
   PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
@@ -314,6 +346,32 @@ test_worktree_path_resolves_id() {
   assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''show'$'\x1f''--worktree'$'\x1f''id:wt-123'$'\x1f''--json' \
     "worktree path helper did not call orca worktree show"
   pass "fm_backend_orca_worktree_path: resolves an Orca worktree id to its path"
+}
+
+test_json_get_ignores_undocumented_terminal_id_shapes() {
+  local out status wt_id wt_path term
+  orca_case parser-pruned-terminal-shapes
+
+  set +e
+  out=$( printf '{"ok":true,"result":{"id":"term-root-id"}}\n' | \
+    bash -c '. "$0/bin/backends/orca.sh"; fm_backend_orca_json_get terminal-handle' "$ROOT" )
+  status=$?
+  set +e
+  [ "$status" -ne 0 ] || fail "terminal-handle should not treat undocumented result.id as a terminal handle, got '$out'"
+
+  printf '1\n' > "$RESP/1.exit"
+  printf '{"ok":true,"result":{"repo":{"id":"repo-123"}}}\n' > "$RESP/2.out"
+  printf '{"ok":true,"result":{"worktree":{"id":"wt-123","path":"/tmp/orca-wt","terminal":{"handle":"term-nested"}}}}\n' > "$RESP/3.out"
+  out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
+    bash -c '. "$0/bin/backends/orca.sh"; fm_backend_orca_worktree_create /repo/path fm-task' "$ROOT" )
+  wt_id=${out%%$'\t'*}
+  wt_path=${out#*$'\t'}
+  term=${wt_path#*$'\t'}
+  wt_path=${wt_path%%$'\t'*}
+  [ "$wt_id" = wt-123 ] || fail "worktree helper should still print worktree id, got '$wt_id'"
+  [ "$wt_path" = /tmp/orca-wt ] || fail "worktree helper should still print worktree path, got '$wt_path'"
+  [ "$term" = "$wt_path" ] || fail "worktree helper should ignore undocumented result.worktree.terminal and omit an implicit terminal, got '$out'"
+  pass "fm_backend_orca_json_get: ignores undocumented terminal id shapes"
 }
 
 test_worktree_and_terminal_helpers_parse_json() {
@@ -1206,6 +1264,8 @@ test_runtime_check_refuses_unready_orca_status
 test_send_text_submit_verifies_empty_composer_after_enter
 test_send_text_submit_keeps_current_tail_when_limited
 test_send_text_submit_retries_when_composer_stays_pending
+test_composer_state_popup_placeholder_fill_is_pending
+test_send_text_submit_popup_autocomplete_requires_second_enter
 test_send_literal_constructs_non_enter_send
 test_send_text_submit_reports_send_failed
 test_send_helpers_reject_orca_error_json
@@ -1217,6 +1277,7 @@ test_remove_worktree_refuses_empty_id
 test_remove_worktree_rejects_orca_error_json
 test_worktree_path_resolves_id
 test_dispatcher_sources_orca_and_routes_primitives
+test_json_get_ignores_undocumented_terminal_id_shapes
 test_worktree_and_terminal_helpers_parse_json
 test_worktree_create_removes_worktree_when_path_missing
 test_spawn_preserves_orca_metadata_when_pathless_worktree_cleanup_fails


### PR DESCRIPTION
## Intent

Implement the two non-blocking Orca backend follow-ups from kunchenguid's PR #228 merge comment as one PR: prune speculative Orca JSON parser terminal paths unless backed by real evidence, and add Orca-side popup placeholder/second-Enter regression coverage at parity with the existing herdr tests. The implementation deliberately drops undocumented result.worktree.terminal and bare result.id terminal-handle fallbacks because the existing docs and smoke notes only justify result.terminal.handle plus worktree id/path. It adds fake-Orca tests proving those undocumented shapes are ignored, plus composer-state and send_text_submit fixtures proving a slash-command popup placeholder fill remains pending and requires a second Enter.

## What Changed
- Captain, tighten the Orca backend parser to accept documented `result.terminal.handle` data while ignoring unsupported `result.id` and `result.worktree.terminal` terminal-handle fallbacks.
- Add Orca regression coverage for terminal parsing, popup placeholder `pending` composer state, and `send_text_submit` issuing the required second Enter before reporting `empty`.
- Update the Orca backend docs to match the supported terminal/worktree JSON shapes.

## Risk Assessment

✅ Low: Captain, the change is narrow, backed by focused fake-Orca coverage, and I found no material correctness or safety regressions in the reviewed diff.

## Testing

Baseline full tests were already green; I reran the Orca backend suite and produced an end-to-end fake-Orca transcript proving the parser pruning and popup second-Enter behavior, with no working-tree cleanup needed.

<details>
<summary>Evidence: Orca follow-up end-to-end transcript</summary>

```text
Orca backend follow-up evidence

1. Documented terminal handle shape is accepted:
term-documented
2. Undocumented bare result.id terminal shape is rejected:
exit=1 output=<empty>

3. Undocumented result.worktree.terminal handle is ignored for implicit terminal reuse:
exit=1 output=<empty>

4. Slash-command popup placeholder fill remains pending after first Enter:
pending

5. send_text_submit sends Enter twice when the first Enter only fills the placeholder:
result=empty
enter_count=2
fake Orca call log:
orca terminal send --terminal term-123 --text /compact --json
orca terminal send --terminal term-123 --text  --enter --json
orca terminal read --terminal term-123 --limit 200 --json
orca terminal send --terminal term-123 --text  --enter --json
orca terminal read --terminal term-123 --limit 200 --json
```
</details>
<details>
<summary>Evidence: Targeted Orca backend test output</summary>

```text
ok - fm_backend_orca_capture: parses result.terminal.tail and calls terminal read
ok - fm_backend_orca_capture: falls back to result text fields
ok - fm_backend_orca_capture: fails closed on Orca read error JSON
ok - fm_backend_orca_runtime_check: accepts reachable ready runtime
ok - fm_backend_orca_runtime_check: fails closed when runtime is not ready
ok - fm_backend_orca_send_text_submit: verifies empty composer after Enter
ok - fm_backend_orca_send_text_submit: preserves current tail when limited reads fetch older cursor text
ok - fm_backend_orca_send_text_submit: retries Enter while composer remains pending
ok - fm_backend_orca_composer_state: a slash-command popup's argument-hint placeholder still reads pending
ok - fm_backend_orca_send_text_submit: a slash-command popup's placeholder fill on Enter #1 does not short-circuit as submitted; Enter #2 is retried and lands it
ok - fm_backend_orca_send_literal: sends text without submitting
ok - fm_backend_orca_send_text_submit: reports send-failed when Orca send fails
ok - Orca send helpers: fail closed on ok:false JSON
ok - fm_backend_orca_send_key: Enter maps to empty enter, C-c maps to interrupt
ok - fm_backend_orca_send_key: refuses unsupported keys loudly
ok - fm_backend_orca_send_key: refuses Escape instead of mapping it to interrupt
ok - fm_backend_orca_kill: calls terminal close and stays best-effort
ok - fm_backend_orca_remove_worktree: refuses empty worktree ids
ok - fm_backend_orca_remove_worktree: fails closed on ok:false JSON
ok - fm_backend_orca_worktree_path: resolves an Orca worktree id to its path
ok - fm-backend dispatcher: accepts orca and routes capture through bin/backends/orca.sh
ok - fm_backend_orca_json_get: ignores undocumented terminal id shapes
ok - Orca lifecycle helpers: register repo, create worktree, create terminal, parse stable ids
ok - fm_backend_orca_worktree_create: removes created worktree when path is missing
ok - fm-spawn.sh --backend orca: preserves metadata when pathless cleanup fails
ok - fm-spawn.sh --backend orca: reuses implicit terminal, records metadata, launches harness
ok - fm-spawn.sh --backend orca --secondmate: refuses before secondmate-home mutation
ok - fm-spawn.sh --backend orca: refuses before mutation when Orca runtime is not ready
ok - fm-spawn.sh --backend orca: refuses non-isolated worktrees and closes implicit terminals
ok - fm-spawn.sh --backend orca: removes worktree when terminal creation fails
ok - fm-spawn.sh --backend orca: preserves metadata when abort cleanup fails
ok - fm-spawn.sh --backend orca: releases terminal and worktree on later aborts
ok - fm-peek/fm-send/fm-crew-state route through backend=orca metadata
ok - fm-peek/fm-crew-state: Orca read error JSON fails closed
ok - fm_backend_target_exists: Orca ok:false read JSON is not live
ok - fm-teardown.sh backend=orca: scout report gate then helper-backed worktree removal
ok - fm-teardown.sh backend=orca: scout teardown refuses id/path mismatches
ok - fm-teardown.sh backend=orca: releases terminal/worktree when path is absent
ok - fm-teardown.sh backend=orca: preserves metadata on remove ok:false JSON
ok - fm-teardown.sh backend=orca: scout report gate precedes pathless helper cleanup
ok - fm-teardown.sh backend=orca: ship teardown fails closed when worktree path is missing
ok - fm-teardown.sh backend=orca: ship teardown requires a matching Orca id path
ok - fm-teardown.sh backend=orca: ship teardown fails closed when id resolution fails
ok - fm-teardown.sh backend=orca: ship teardown refuses id/path mismatches
ok - fm-teardown.sh backend=orca: refuses missing worktree ids before cleanup
ok - fm-teardown.sh backend=orca: removes partial worktree-only metadata
ok - fm-teardown.sh --force: removes Orca secondmate children through Orca
ok - fm-teardown.sh --force: refuses Orca child id/path mismatches
ok - fm-teardown.sh --force: removes partial Orca secondmate children
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- <code>Baseline already reported successful before this run: `command -v tmux &gt;/dev/null || { echo &#34;tmux is required for e2e tests&#34; &gt;&amp;2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo &#34;== $t ==&#34;; bash &#34;$t&#34; || rc=1; done; exit &#34;$rc&#34;`.</code>
- <code>Ran targeted regression suite: `bash tests/fm-backend-orca.test.sh`.</code>
- <code>Created reviewer evidence transcript with a fake Orca CLI showing documented `result.terminal.handle` accepted, undocumented `result.id` and `result.worktree.terminal` rejected/ignored, popup placeholder state reported `pending`, and `send_text_submit` issuing two Enter sends before `empty`.</code>
- <code>Checked `git status --short` after testing; no working-tree artifacts were created.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
