### PR TITLE
docs: document herdr dual license

### DIFF
--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -102,7 +102,7 @@ fm_backend_herdr_cli() {  # <session> <herdr-subcommand-and-args...>
 
 # fm_backend_herdr_tool_check: refuse loudly if herdr or jq is missing.
 fm_backend_herdr_tool_check() {
-  command -v herdr >/dev/null 2>&1 || { echo "error: backend=herdr selected but the 'herdr' CLI is not installed (https://herdr.dev)" >&2; return 1; }
+  command -v herdr >/dev/null 2>&1 || { echo "error: backend=herdr selected but the 'herdr' CLI is not installed (https://herdr.dev) (dual-licensed AGPL-3.0-or-later/commercial)" >&2; return 1; }
   command -v jq >/dev/null 2>&1 || { echo "error: backend=herdr selected but 'jq' is not installed (required to parse herdr's JSON output)" >&2; return 1; }
   return 0
 }

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -13,6 +13,9 @@ All real-herdr verification in this document uses isolated sessions and guarded 
 
 Pick herdr when you want native per-pane agent-state detection (busy/idle/blocked) instead of tmux's regex-based guessing, and you are comfortable running an experimental backend.
 
+Herdr is dual-licensed AGPL-3.0-or-later / commercial - see its LICENSE file (github.com/ogulcancelik/herdr) or https://herdr.dev.
+Firstmate only drives the `herdr` CLI as a separate process, which carries no AGPL obligations for firstmate users.
+
 Prerequisites:
 
 - `herdr` itself, protocol 14 or newer (installed 0.7.1 verified) - see [herdr.dev](https://herdr.dev) for install instructions.


### PR DESCRIPTION
## Intent

Document herdr's dual license (AGPL-3.0-or-later / commercial) in two places: docs/herdr-backend.md Setup section (where readers decide to install herdr) with a note that firstmate only drives the herdr CLI as a separate process with no AGPL obligations for firstmate users, and bin/backends/herdr.sh missing-binary install hint with a short parenthetical. Scope is exactly those two edits; match doc one-sentence-per-line style; shellcheck-clean.

## What Changed
- Captain, document herdr's AGPL-3.0-or-later/commercial dual license in the Herdr backend setup guidance.
- Update the Herdr missing-binary install hint to surface the same dual-license note at setup time.

## Risk Assessment

✅ Low: Captain, low risk because the branch only adds license wording to docs and a missing-binary hint, and the upstream Herdr README currently matches the AGPL-3.0-or-later/commercial license claim: https://github.com/ogulcancelik/herdr#license.

## Testing

The pre-run full baseline had already passed; I confirmed the diff only touches `docs/herdr-backend.md` and `bin/backends/herdr.sh`, reran the focused herdr backend test suite, captured a transcript showing the documentation and missing-binary CLI behavior, and verified the worktree remained clean.

<details>
<summary>Evidence: Herdr license documentation and missing-binary CLI evidence</summary>

```text
End-user documentation surface: docs/herdr-backend.md Setup excerpt
$ sed -n '/^## Setup$/,/^Prerequisites:$/p' docs/herdr-backend.md

## Setup

Pick herdr when you want native per-pane agent-state detection (busy/idle/blocked) instead of tmux's regex-based guessing, and you are comfortable running an experimental backend.

Herdr is dual-licensed AGPL-3.0-or-later / commercial - see its LICENSE file (github.com/ogulcancelik/herdr) or https://herdr.dev.
Firstmate only drives the `herdr` CLI as a separate process, which carries no AGPL obligations for firstmate users.

Prerequisites:

CLI surface when backend=herdr is selected and herdr is missing
$ /bin/bash -c '. "$0/bin/backends/herdr.sh"; PATH="$1"; fm_backend_herdr_tool_check' "$PWD" "$EMPTY_PATH"

error: backend=herdr selected but the 'herdr' CLI is not installed (https://herdr.dev) (dual-licensed AGPL-3.0-or-later/commercial)

exit=1
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- <code>Baseline already passed before this validation: `command -v tmux &gt;/dev/null || { echo &#34;tmux is required for e2e tests&#34; &gt;&amp;2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo &#34;== $t ==&#34;; bash &#34;$t&#34; || rc=1; done; exit &#34;$rc&#34;`</code>
- `git diff --name-only c1eba8fffdeb86b34bea89b19c2d023e9b255f68..0d2b72f0a470ce0f3fa1370d858ed8f8f0c20ec0`
- `git diff --unified=80 c1eba8fffdeb86b34bea89b19c2d023e9b255f68..0d2b72f0a470ce0f3fa1370d858ed8f8f0c20ec0 -- docs/herdr-backend.md bin/backends/herdr.sh`
- `bash tests/fm-backend-herdr.test.sh`
- <code>Manual evidence transcript: `sed -n &#39;/^## Setup$/,/^Prerequisites:$/p&#39; docs/herdr-backend.md` plus `/bin/bash -c &#39;. &#34;$0/bin/backends/herdr.sh&#34;; PATH=&#34;$1&#34;; fm_backend_herdr_tool_check&#39; &#34;$PWD&#34; &#34;$EMPTY_PATH&#34;`</code>
- `git status --short`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
