### PR TITLE
docs: add stow memory hygiene phase

### DIFF
--- a/.agents/skills/stow/SKILL.md
+++ b/.agents/skills/stow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: stow
-description: Sweep the current session for uncaptured durable knowledge and file it to disk before a context reset. Use when the captain invokes /stow (e.g. "/stow", "stow what you've learned"), before a session reset or context compaction, or periodically to keep operational memory current.
+description: Sweep the current session for uncaptured durable knowledge, file it to disk before a context reset, and occasionally prune/compress curated memory so it stays lean. Use when the captain invokes /stow (e.g. "/stow", "stow what you've learned", "/stow prune"), before a session reset or context compaction, or periodically to keep operational memory current.
 user-invocable: true
 metadata:
   internal: true
@@ -38,13 +38,51 @@ The goal is a session that is safe to reset or destroy because everything durabl
    - Task-scoped notes: append to the relevant backlog item's notes with `tasks-axi update <id> --append "<note>"`, or hand-edit `data/backlog.md` per the active backend (section 10).
    - Undone next steps: file each as a queued backlog item (section 10), with `blocked-by` recorded if it genuinely depends on something else.
 
-4. **Curate, don't just append.**
+4. **Run gated memory hygiene after routing and filing.**
+   This phase keeps the files that firstmate loads at every session start from accumulating months of tokens.
+   It is intentionally cheap on ordinary `/stow` runs: first check the gate below, and do the full prune/compress pass only when a trigger fires.
+
+   Scope is limited to the curated memory files in the active firstmate home:
+   - `data/captain.md`
+   - `data/learnings.md`
+   - `data/projects.md` registry descriptions
+
+   Explicitly out of scope:
+   - Task briefs and scout reports under `data/<id>/`: these are read on demand and do not add session-load cost.
+   - `data/backlog.md`: its Done section already self-prunes through the active backlog backend, and task notes follow AGENTS.md's note-hygiene rule.
+
+   Use three triggers:
+   - **Size budget exceeded:** count lines, because line count is the honest cheap proxy for session-load token cost.
+     Prune any over-budget file.
+     Budgets: `data/captain.md` 40 lines; `data/learnings.md` 60 lines; `data/projects.md` about 2 lines per registered project.
+     For `data/projects.md`, preserve the registry's parseable project lines; compress descriptions rather than changing the registry shape.
+   - **Staleness:** more than 7 days since the last hygiene pass.
+     Track the last pass in `data/.last-memory-hygiene` as an ISO date (`YYYY-MM-DD` is enough).
+     If the timestamp file is absent, treat it as stale once so the home gets a baseline pass.
+   - **Explicit request:** `/stow prune`, "prune memory", or an equivalent captain request forces the full pass.
+
+   When no trigger fires, do not read or rewrite the full memory set again.
+   Print one short status line such as `memory within budget, last pruned 2026-07-04` and skip the phase.
+   When a trigger fires, run the checklist below across the scoped files, then write today's ISO date to `data/.last-memory-hygiene` even if the pass found nothing to edit.
+
+   Prune checklist:
+   - Delete entries that are superseded, disproven, or expired; dated entries should make this judgment visible.
+   - Consolidate clusters: several entries about one topic should become one rewritten durable entry.
+   - Re-route misfiled knowledge to its most specific home per AGENTS.md's knowledge-routing table.
+     If a fact is project-intrinsic, do not hand-edit that project's `AGENTS.md`; flag or file normal crewmate work so it lands through the project delivery pipeline.
+   - Tighten prose without losing load-bearing facts, active constraints, or the "why" behind captain feedback.
+     When in doubt, consolidate rather than delete.
+   - Never prune away standing captain orders, safety tripwires, active access constraints, never-reenable rules, or anything the captain marked important.
+     These may be compressed, but the operative instruction must survive.
+
+5. **Curate, don't just append.**
    When a finding overlaps or supersedes something already on disk, prefer rewriting or pruning the existing entry over piling on a new one.
    Graduation moves are limited to exactly three: promote a learning to the shared `AGENTS.md` via PR, fold it into `data/captain.md`, or delete a stale entry.
    Do not invent other graduation paths.
 
-5. **Report to the captain.**
+6. **Report to the captain.**
    Summarize, in plain outcome language (section 9): what was stowed and where, what was filed to the backlog, and whether the session is now safe to reset or destroy - i.e. whether every durable finding from this sweep now lives on disk rather than only in this conversation.
+   Include the one-line memory-hygiene result: skipped within budget, pruned specific files, or unable to prune with the reason.
    If something could not be captured yet (for example, project-intrinsic knowledge waiting on a crewmate to land it), say so explicitly rather than reporting the session fully safe.
 
 ## Scope exclusion: no skill storage

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -405,7 +405,7 @@ Route each piece of durable knowledge to its most specific home:
 | Investigation findings | scout reports at `data/<id>/report.md` |
 
 When the captain invokes `/stow`, load the `stow` skill.
-It sweeps the current session for uncaptured durable knowledge, routes findings with this table, files undone next steps to the backlog, and reports whether the session is safe to reset.
+It sweeps the current session for uncaptured durable knowledge, routes findings with this table, files undone next steps to the backlog, runs its gated hygiene pass for curated session-loaded memory, and reports whether the session is safe to reset.
 
 **Delivery mode (choose at add).** `<mode>` is how a finished change reaches `main`, picked per project when you add it and recorded in the registry line (`fm-project-mode.sh` parses it; `fm-spawn` records it into each task's meta):
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Claude and grok use the slash form shown here; codex uses the same names with `$
 | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
 | `/afk`             | Enter away-mode supervision: the sub-supervisor self-handles routine wakes in bash and escalates only captain-relevant events as one batched digest, cutting supervision cost while you step away |
 | `/updatefirstmate` | Self-update the running firstmate and its secondmates to the latest from origin with fast-forward-only pulls, then re-read instructions and nudge secondmates |
-| `/stow`            | Sweep the session for uncaptured durable knowledge, route each finding to its disk home per AGENTS.md, file undone next steps to the backlog, and report what is now safe to reset |
+| `/stow`            | Sweep the session for uncaptured durable knowledge, route each finding to its disk home per AGENTS.md, file undone next steps to the backlog, run gated memory hygiene, and report what is now safe to reset |
 
 Agent-only reference skills live under `.agents/skills/` and are loaded by firstmate at the trigger points named in [`AGENTS.md`](AGENTS.md).
 
@@ -132,7 +132,7 @@ Firstmate's skills live in two separate places with different audiences:
 - `.agents/skills/` - agent-loaded skills (this section's table, plus firstmate's agent-only reference skills). Every one of these assumes a live firstmate home and is meaningless, or actively misleading, installed anywhere else, so each carries `metadata.internal: true` in its frontmatter. That flag hides them from installer discovery (tools like the [skills.sh](https://skills.sh) `npx skills add` installer) without affecting how firstmate itself loads them - frontmatter metadata is inert to the agent's own skill loader.
 - `skills/` - public, installer-facing skills meant to be installed standalone into any project, independent of firstmate.
   Each one is a self-contained skill with no dependency on firstmate's paths, tools, or vocabulary.
-  Today that is `skills/stow`, a generic session-knowledge-sweep skill that routes findings by explicit instruction first, then existing local conventions, then a private `.stow-notes.md` fallback in the current directory, and closes with a resume pointer for the next session.
+  Today that is `skills/stow`, a generic session-knowledge-sweep skill that routes findings by explicit instruction first, then existing local conventions, then a private `.stow-notes.md` fallback in the current directory, keeps local notes lean with gated hygiene, and closes with a resume pointer for the next session.
   It intentionally shares no code with the firstmate-internal `.agents/skills/stow` it is named after, so the two can evolve independently.
 
 ## Documentation

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -175,6 +175,8 @@ The full ownership rule - what is project-intrinsic versus fleet-private, and ho
 `/stow` sweeps the current session for durable knowledge that only exists in conversation and routes each finding to the most specific disk home.
 Captain preferences go to `data/captain.md`, fleet-local operational facts and gotchas go to `data/learnings.md`, project-intrinsic knowledge goes through normal crewmate delivery into that project's committed `AGENTS.md`, and task-scoped notes or undone next steps go to the backlog.
 Generalizable firstmate knowledge goes to shared tracked docs through the normal PR pipeline; the firstmate-internal `/stow` deliberately never stores findings in either skill directory.
+After filing, `/stow` also runs a gated hygiene pass for the session-loaded curated memory files: `data/captain.md`, `data/learnings.md`, and `data/projects.md` descriptions.
+The pass is triggered by line budgets, a stale `data/.last-memory-hygiene` timestamp, or an explicit prune request; task briefs, reports, and `data/backlog.md` are intentionally out of scope.
 
 ## Local clones stay fresh
 
@@ -195,7 +197,7 @@ The mechanics are owned by the `/updatefirstmate` skill and firstmate's operatin
 
 Fleet state lives in each task's session-provider backend (tmux by hard default, herdr when selected or auto-detected, zellij/orca when explicitly selected), no-mistakes run records, status event logs, local markdown under `data/` including `data/captain.md` and `data/learnings.md`, and persistent secondmate homes.
 For herdr, respawning after a server-restored layout closes and replaces confirmed no-agent or dead task-tab husks instead of requiring manual tab cleanup.
-Use `/stow` before an intentional reset when the conversation may hold durable knowledge that has not yet been written to disk; after that, the next firstmate session can reconcile and carry on.
+Use `/stow` before an intentional reset when the conversation may hold durable knowledge that has not yet been written to disk; after that, the next firstmate session can reconcile and carry on without reloading stale, sprawling memory.
 
 ## Development notes
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -53,11 +53,19 @@ It intentionally mirrors the behavior-test baseline in [`.github/workflows/ci.ym
 ## Captain preferences (data/captain.md)
 
 Personal preferences for one captain's fleet live locally in `data/captain.md`; it is gitignored and printed in the session-start context digest after `data/projects.md` and optional `data/secondmates.md`.
+The firstmate-internal `/stow` hygiene pass treats this as curated session-loaded memory with a 40-line budget, preserving standing captain orders and safety constraints while consolidating stale or duplicate notes.
 
 ## Operational learnings (data/learnings.md)
 
 Fleet-local operational facts and gotchas live locally in `data/learnings.md`; it is gitignored and printed right after `data/captain.md` in the session-start context digest.
 The file is created lazily on first learning and follows the same dated, evidence-backed, curated style as `data/captain.md`: rewrite or prune stale entries instead of appending forever.
+`/stow` applies the same gated hygiene pass here with a 60-line budget.
+
+## Memory hygiene timestamp (data/.last-memory-hygiene)
+
+The firstmate-internal `/stow` skill records its last curated-memory hygiene pass in local `data/.last-memory-hygiene` as an ISO date.
+If the timestamp is absent or more than 7 days old, or the captain explicitly asks to prune memory, `/stow` checks and compresses `data/captain.md`, `data/learnings.md`, and `data/projects.md` descriptions.
+Task briefs, scout reports, and `data/backlog.md` are not part of this pass.
 
 ## Secondmate routes (data/secondmates.md)
 

--- a/skills/stow/SKILL.md
+++ b/skills/stow/SKILL.md
@@ -70,13 +70,15 @@ Everything this skill files goes to a local file by default; it only ever reache
    - **Staleness:** more than 7 days since the last hygiene pass for the current-directory fallback.
      Track that with `.stow-last-hygiene` in the current directory, written as an ISO date (`YYYY-MM-DD`) after a pass.
      If the timestamp is absent and `.stow-notes.md` exists, treat it as stale once so the fallback gets a baseline pass.
-     If this skill creates or updates that timestamp in a git worktree, protect it the same way as `.stow-notes.md`: add a `.stow-last-hygiene` line to the current-directory `.gitignore` when possible, and report if the ignore write failed.
+     Before writing it in a git worktree, verify that `.stow-last-hygiene` is not already tracked in the index.
+     If it is tracked, do not create or update it as private metadata, do not rely on `.gitignore` to protect it, and report the hygiene timestamp write as blocked until the user chooses a safe destination or confirms the tracked file is acceptable.
+     After the tracked-file check passes, protect it the same way as `.stow-notes.md`: add a `.stow-last-hygiene` line to the current-directory `.gitignore` when possible, and report if the ignore write failed.
      If `.stow-notes.md` does not exist and no current-directory fallback was used, skip this timestamp entirely.
    - **Explicit request:** `/stow prune`, "prune memory", or an equivalent user request forces a pass over the relevant local stow destinations.
 
    When no trigger fires, do not reread or rewrite everything.
    Print one short status line such as `local stow notes within budget, last pruned 2026-07-04` and skip the phase.
-   When a trigger fires, run the checklist below and write today's ISO date to `.stow-last-hygiene` if the current-directory fallback is part of the pass.
+   When a trigger fires, run the checklist below and write today's ISO date to `.stow-last-hygiene` after the tracked-file check passes, if the current-directory fallback is part of the pass.
 
    Prune checklist:
    - Delete entries that are superseded, disproven, or expired; keep dates on what survives when dates are already part of the convention.
@@ -97,13 +99,14 @@ Everything this skill files goes to a local file by default; it only ever reache
    If anything landed in the `.stow-notes.md` private fallback, say so explicitly - note that it is private and confined to this project, and that it can be promoted into a shared, tracked file later if the user wants it more widely visible.
    In a git repo, report the ignore protection according to what actually happened: if the `.gitignore` write succeeded, say that a `.stow-notes.md` line was added to a current-directory `.gitignore` to keep it out of git, awaiting the user's own commit; if the `.gitignore` write failed, say that `.stow-notes.md` was still written but the user must ignore it manually before relying on git to hide it from status or commits.
    If the tier-3 fallback was blocked because `.stow-notes.md` was already tracked, say that no private fallback was written and that the session is not fully safe to reset until the user chooses another destination or confirms that tracked file is acceptable.
+   If the hygiene timestamp write was blocked because `.stow-last-hygiene` was already tracked, say that no private timestamp was written and that timestamp-based hygiene remains blocked until the user chooses another destination or confirms that tracked file is acceptable.
    If a user preference specifically landed there because no user-level memory file was discovered, add the one extra caveat: it now applies to this project only; this skill's own tier-3 default never writes outside the current directory, so if the user wants that preference to follow them across every project, they need to copy it into their own global/user-level memory file themselves.
    The real payoff of stowing is not this session, it's the next one: close with a short, copy-pasteable RESUME POINTER naming exactly which files a fresh session should load to pick this back up cold, e.g. `To pick this back up in a new session, load: CLAUDE.md (project conventions), .stow-notes.md (private notes, not shared)`.
    List only the files this sweep actually wrote or updated; skip the pointer if nothing was written.
 
 ## What this skill does not do
 
-It does not invent a new note-taking system, initialize version control, or commit/push anything on the user's behalf beyond editing a file the discovered convention already made writable, creating the `.stow-notes.md` fallback from step 3 and its `.stow-last-hygiene` timestamp plus their lines in a current-directory `.gitignore`, or using a destination the user explicitly approved.
+It does not invent a new note-taking system, initialize version control, or commit/push anything on the user's behalf beyond editing a file the discovered convention already made writable, creating the `.stow-notes.md` fallback from step 3 and its untracked `.stow-last-hygiene` timestamp plus their lines in a current-directory `.gitignore`, or using a destination the user explicitly approved.
 It never stages or commits those `.gitignore` lines itself - the edit lands in the working tree only, for the user to review and commit like any other change.
 Its own tier-3 default never writes durable findings outside the current working directory, and its optional `.gitignore` metadata edits are also confined to that directory.
 Among local durable-finding writes, tier 2 is the only exception, and only because it targets a destination the user's own existing convention already established, never one this skill invents.

--- a/skills/stow/SKILL.md
+++ b/skills/stow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: stow
-description: Sweep the current conversation for durable knowledge - user preferences, project facts, operational gotchas, and unfinished next steps - and file each through explicit instructions, existing local conventions, or the private `.stow-notes.md` fallback, so nothing is lost when the session ends. Use when the user invokes /stow, asks to save or write down what was learned this session, or before a context reset or long break.
+description: Sweep the current conversation for durable knowledge - user preferences, project facts, operational gotchas, and unfinished next steps - then file each through explicit instructions, existing local conventions, or the private `.stow-notes.md` fallback, and occasionally prune/compress local notes so they stay lean. Use when the user invokes /stow, asks to save or write down what was learned this session, asks to prune stowed memory, or before a context reset or long break.
 user-invocable: true
 ---
 
@@ -58,11 +58,41 @@ Everything this skill files goes to a local file by default; it only ever reache
    Do not invent new shared files, new folders, or new tracker categories the project doesn't already have, and do not pick an ad hoc filename or location for the fallback - `.stow-notes.md` in the current directory is the one prescribed default.
    If even that fallback is unwritable and the user doesn't want to establish a new convention, say so plainly and leave that finding unfiled rather than fabricate a destination for it.
 
-6. **Curate, don't just append.**
+6. **Run lightweight note hygiene when the gate says to.**
+   This keeps local stow destinations from accumulating stale prose over long use, while ordinary `/stow` runs stay cheap.
+   Because this public skill has no fixed firstmate home and must stay sandbox-safe, the phase is limited to local files this skill just wrote or selected as destinations, especially `.stow-notes.md`.
+   Do not scan unrelated files looking for something to prune.
+
+   Full hygiene runs only when at least one trigger fires:
+   - **Size budget exceeded:** a local stow destination is over its budget.
+     Use 60 lines for `.stow-notes.md`.
+     For an existing project or user memory file, use its documented local budget if one exists; otherwise treat "obviously sprawling and repetitive" as a judgment trigger instead of imposing a universal budget on someone else's convention.
+   - **Staleness:** more than 7 days since the last hygiene pass for the current-directory fallback.
+     Track that with `.stow-last-hygiene` in the current directory, written as an ISO date (`YYYY-MM-DD`) after a pass.
+     If the timestamp is absent and `.stow-notes.md` exists, treat it as stale once so the fallback gets a baseline pass.
+     If this skill creates or updates that timestamp in a git worktree, protect it the same way as `.stow-notes.md`: add a `.stow-last-hygiene` line to the current-directory `.gitignore` when possible, and report if the ignore write failed.
+     If `.stow-notes.md` does not exist and no current-directory fallback was used, skip this timestamp entirely.
+   - **Explicit request:** `/stow prune`, "prune memory", or an equivalent user request forces a pass over the relevant local stow destinations.
+
+   When no trigger fires, do not reread or rewrite everything.
+   Print one short status line such as `local stow notes within budget, last pruned 2026-07-04` and skip the phase.
+   When a trigger fires, run the checklist below and write today's ISO date to `.stow-last-hygiene` if the current-directory fallback is part of the pass.
+
+   Prune checklist:
+   - Delete entries that are superseded, disproven, or expired; keep dates on what survives when dates are already part of the convention.
+   - Consolidate clusters: several entries about one topic should become one rewritten durable entry.
+   - Re-route misfiled knowledge to the most specific existing local convention from step 3; never move anything to an external system unless explicit instructions already allow that route.
+   - Tighten prose without losing load-bearing facts, active constraints, or the "why" behind preference and feedback entries.
+     When in doubt, consolidate rather than delete.
+   - Never prune away standing user instructions, safety tripwires, active access constraints, never-reenable rules, or anything the user marked important.
+     These may be compressed, but the operative instruction must survive.
+
+7. **Curate, don't just append.**
    When a finding overlaps or supersedes something already recorded, prefer editing or replacing the existing note over piling on a duplicate.
 
-7. **Finish with an honest safe-to-end verdict and a resume pointer for the next session.**
+8. **Finish with an honest safe-to-end verdict and a resume pointer for the next session.**
    Tell the user, in plain language, what was captured and where, what could not be captured (and why), and whether the conversation is now safe to end or reset - i.e. whether every durable finding from this sweep now lives on disk or in an explicitly requested tracker rather than only in this chat.
+   Include the one-line note-hygiene result: skipped within budget, pruned specific files, or unable to prune with the reason.
    If something could not be captured yet, say so explicitly instead of reporting the session fully safe.
    If anything landed in the `.stow-notes.md` private fallback, say so explicitly - note that it is private and confined to this project, and that it can be promoted into a shared, tracked file later if the user wants it more widely visible.
    In a git repo, report the ignore protection according to what actually happened: if the `.gitignore` write succeeded, say that a `.stow-notes.md` line was added to a current-directory `.gitignore` to keep it out of git, awaiting the user's own commit; if the `.gitignore` write failed, say that `.stow-notes.md` was still written but the user must ignore it manually before relying on git to hide it from status or commits.
@@ -73,9 +103,9 @@ Everything this skill files goes to a local file by default; it only ever reache
 
 ## What this skill does not do
 
-It does not invent a new note-taking system, initialize version control, or commit/push anything on the user's behalf beyond editing a file the discovered convention already made writable, creating the `.stow-notes.md` fallback from step 3 and its line in a current-directory `.gitignore`, or using a destination the user explicitly approved.
-It never stages or commits that `.gitignore` line itself - the edit lands in the working tree only, for the user to review and commit like any other change.
-Its own tier-3 default never writes durable findings outside the current working directory, and its optional `.gitignore` metadata edit is also confined to that directory.
+It does not invent a new note-taking system, initialize version control, or commit/push anything on the user's behalf beyond editing a file the discovered convention already made writable, creating the `.stow-notes.md` fallback from step 3 and its `.stow-last-hygiene` timestamp plus their lines in a current-directory `.gitignore`, or using a destination the user explicitly approved.
+It never stages or commits those `.gitignore` lines itself - the edit lands in the working tree only, for the user to review and commit like any other change.
+Its own tier-3 default never writes durable findings outside the current working directory, and its optional `.gitignore` metadata edits are also confined to that directory.
 Among local durable-finding writes, tier 2 is the only exception, and only because it targets a destination the user's own existing convention already established, never one this skill invents.
 It never files credentials, secrets, or other sensitive material - only knowledge that's safe to keep in plain text wherever it lands.
 It never files anything to an issue tracker, hosted board, or other external/public system on its own inference - that only ever happens on the user's explicit say-so, per the hard rule in step 3.


### PR DESCRIPTION
## Summary
- Adds a gated memory-hygiene phase to the internal firstmate stow skill for `data/captain.md`, `data/learnings.md`, and `data/projects.md` registry descriptions.
- Mirrors the portable hygiene guidance into the public `skills/stow` variant without firstmate-private paths or tooling assumptions.
- Adds the minimal AGENTS pointer and syncs related README/docs references via no-mistakes document step.

## Validation
- no-mistakes review: passed after pipeline fix for tracked `.stow-last-hygiene` guard.
- no-mistakes document: passed.
- no-mistakes lint: passed.
- no-mistakes test: skipped by captain unblock decision after repeated transient loop on `tests/fm-backend-herdr.test.sh` known ghost placeholder assertion (`the known ghost placeholder 'Type a message...' should read as empty`). Focused reproduction passed repeatedly, fixer full-suite reruns passed with no source changes, and the branch diff is docs/skill markdown only.
