### PR TITLE
feat(agents): add firstmate coding guidelines skill

### DIFF
--- a/.agents/skills/firstmate-coding-guidelines/SKILL.md
+++ b/.agents/skills/firstmate-coding-guidelines/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: firstmate-coding-guidelines
+description: Agent-only reference for changing firstmate's own tracked material (AGENTS.md, bin/, .agents/skills/, docs/, public skills/). Use before editing any of these, whether working as firstmate directly or as a crewmate briefed on a firstmate-repo task. Covers the knowledge-placement decision tree, the one-owner rule for contracts, the inline-stub pattern for content moved into a skill, AGENTS.md size discipline, trigger hygiene for new skills, and repo style rules (one sentence per line, plain dash, no agent co-author, shellcheck-clean bin scripts).
+user-invocable: false
+metadata:
+  internal: true
+---
+
+# firstmate-coding-guidelines
+
+Load this before changing `AGENTS.md`, `bin/`, `.agents/skills/`, `docs/`, or public `skills/`.
+It exists because `AGENTS.md` grew from 585 to 958 lines between its last two restructures, entirely from conditional detail added inline instead of routed to its right home.
+Applying the rules below on every change is what keeps that from happening again.
+
+## Knowledge-placement decision tree
+
+Before writing a new fact anywhere in this repo, ask where it belongs, in this order.
+
+1. Does the firstmate AGENT need this on every session or every turn to operate?
+   If yes: `AGENTS.md`, inline.
+2. Does the agent need it only in a nameable situation - a spawn, a recovery, a specific wake type, a specific lifecycle step?
+   If yes: an agent-only skill under `.agents/skills/`, plus a one-line trigger pointer left inline in `AGENTS.md` (usually section 13).
+3. Is it human/reference detail - a wire format, a verification record, a mechanism narrative, an incident writeup?
+   If yes: `docs/`.
+4. Is it mechanics - exact flags, exact commands, exact paths?
+   If yes: the script's own header comment plus its `--help` output, not prose in `AGENTS.md` or a skill.
+
+Stop at the first tier that answers yes.
+Do not place a fact at a more convenient tier than the one this tree gives you.
+
+## One-owner rule
+
+Every contract - a data format, a state machine, a decision procedure - is stated in full exactly once.
+Every other mention of it is a one-line cross-reference, never a restatement.
+A single deliberate one-line reinforcement at a genuine risk point is allowed, for example a "don't forget X" placed exactly where forgetting X is costly.
+Restating the contract's substance a second time is not allowed: the two copies will drift the moment only one is edited.
+When you touch a contract, grep the repo for its other mentions and update the cross-references, not duplicate the change into a second full copy.
+
+## Inline-stub pattern
+
+When content moves out of `AGENTS.md` into a skill, decide what stays behind by asking one question: what must survive with no skill loaded?
+That is the trigger condition for loading the skill, plus any safety-critical fact that fires on a wake the skill itself is not loaded for.
+Everything else - the procedure, the mechanism, the surrounding detail - moves out completely.
+Do not leave a partial restatement behind "just in case"; a partial copy is exactly the duplication the one-owner rule forbids.
+The model to copy is `AGENTS.md` section 8's "Away-mode stub": it keeps only the marker format, the ownership-transfer rule, and the exit condition inline, and points everything else at the `/afk` skill.
+
+## Size discipline
+
+Apply the decision tree above to every line you are about to add to `AGENTS.md`.
+If an addition needs more than a few lines of conditional detail (detail that matters only in a specific situation) or reference detail (a wire format, an exact schema, historical rationale), you are almost certainly adding it to the wrong file.
+`AGENTS.md`'s token cost is paid by every session of every fleet member, every time, whether or not that session ever hits the situation the new lines describe.
+A skill's cost is paid only by the sessions that actually load it.
+When in doubt, write the fact into the skill or doc first, and add only the one-line trigger to `AGENTS.md`.
+
+## Trigger hygiene
+
+A new skill is dead weight if nothing loads it.
+Every new skill needs its load trigger declared inline: section 13 for agent-only reference skills, or the relevant operating section for anything else.
+State the trigger as a condition ("load before X", "load on Y wake"), never as a vague pointer.
+Briefs for tasks that touch firstmate's own tracked material should tell the crewmate to load this skill.
+`bin/fm-brief.sh`'s `REPO` argument is a caller-supplied string with no reliable signal that it names firstmate's own repo, unlike a project registered in `data/projects.md`, so there is no clean point inside the scaffold to detect this case automatically.
+Firstmate adds this skill's load instruction to firstmate-repo briefs by hand instead; `CONTRIBUTING.md`'s "Development" section carries the same instruction as a durable reminder.
+
+## Repo style rules
+
+- One full sentence per line in tracked Markdown; never wrap multiple sentences onto one physical line.
+- Plain dash `-`, never an em dash.
+- Never add an agent name as a commit co-author.
+- `bin/*.sh` and `bin/backends/*.sh` must pass `shellcheck`; run it before treating a script change as done.
+- Colocate tests with the existing pattern in `tests/`, name them `<subject>.test.sh`, and extend an existing script rather than inventing a new runner.
+- A backend-verification doc (`docs/*-backend.md`) records empirical facts, not assumptions: date, version, exact commands run, exact output; write incidents the same way, as evidence, not narrative alone.

--- a/.agents/skills/firstmate-coding-guidelines/SKILL.md
+++ b/.agents/skills/firstmate-coding-guidelines/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: firstmate-coding-guidelines
-description: Agent-only reference for changing firstmate's own tracked material (AGENTS.md, bin/, .agents/skills/, docs/, public skills/). Use before editing any of these, whether working as firstmate directly or as a crewmate briefed on a firstmate-repo task. Covers the knowledge-placement decision tree, the one-owner rule for contracts, the inline-stub pattern for content moved into a skill, AGENTS.md size discipline, trigger hygiene for new skills, and repo style rules (one sentence per line, plain dash, no agent co-author, shellcheck-clean bin scripts).
+description: Agent-only reference for changing firstmate's shared, tracked material per AGENTS.md section 1. Use before editing any of that material, whether working as firstmate directly or as a crewmate briefed on a firstmate-repo task. Covers the knowledge-placement decision tree, the one-owner rule for contracts, the inline-stub pattern for content moved into a skill, AGENTS.md size discipline, trigger hygiene for new skills, and repo style rules (one sentence per line, plain dash, no agent co-author, shellcheck-clean bin scripts).
 user-invocable: false
 metadata:
   internal: true
@@ -8,7 +8,7 @@ metadata:
 
 # firstmate-coding-guidelines
 
-Load this before changing `AGENTS.md`, `bin/`, `.agents/skills/`, `docs/`, or public `skills/`.
+Load this before changing firstmate's shared, tracked material, as defined by `AGENTS.md` section 1.
 It exists because `AGENTS.md` grew from 585 to 958 lines between its last two restructures, entirely from conditional detail added inline instead of routed to its right home.
 Applying the rules below on every change is what keeps that from happening again.
 

--- a/.agents/skills/firstmate-coding-guidelines/SKILL.md
+++ b/.agents/skills/firstmate-coding-guidelines/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: firstmate-coding-guidelines
-description: Agent-only reference for changing firstmate's shared, tracked material per AGENTS.md section 1. Use before editing any of that material, whether working as firstmate directly or as a crewmate briefed on a firstmate-repo task. Covers the knowledge-placement decision tree, the one-owner rule for contracts, the inline-stub pattern for content moved into a skill, AGENTS.md size discipline, trigger hygiene for new skills, and repo style rules (one sentence per line, plain dash, no agent co-author, shellcheck-clean bin scripts, colocated tests, and backend-verification evidence).
+description: >-
+  Agent-only reference for changing firstmate's shared, tracked material per AGENTS.md section 1.
+  Use before editing any of that material, whether working as firstmate directly or as a crewmate briefed on a firstmate-repo task.
+  Covers the knowledge-placement decision tree, the one-owner rule for contracts, the inline-stub pattern for content moved into a skill, AGENTS.md size discipline, trigger hygiene for new skills, and repo style rules (one sentence per line, plain dash, no agent co-author, shellcheck-clean bin scripts, colocated tests, and backend-verification evidence).
 user-invocable: false
 metadata:
   internal: true
@@ -41,7 +44,8 @@ When you touch a contract, grep the repo for its other mentions and update the c
 When content moves out of `AGENTS.md` into a skill, decide what stays behind by asking one question: what must survive with no skill loaded?
 That is the trigger condition for loading the skill, plus any safety-critical fact that fires on a wake the skill itself is not loaded for.
 Everything else - the procedure, the mechanism, the surrounding detail - moves out completely.
-Do not leave a partial restatement behind "just in case"; a partial copy is exactly the duplication the one-owner rule forbids.
+Do not leave a partial restatement behind "just in case".
+A partial copy is exactly the duplication the one-owner rule forbids.
 The model to copy is `AGENTS.md` section 8's "Away-mode stub": it keeps only the marker format, the ownership-transfer rule, and the exit condition inline, and points everything else at the `/afk` skill.
 
 ## Size discipline
@@ -59,13 +63,18 @@ Every new skill needs its load trigger declared inline: section 13 for agent-onl
 State the trigger as a condition ("load before X", "load on Y wake"), never as a vague pointer.
 Briefs for tasks that touch firstmate's own tracked material should tell the crewmate to load this skill.
 `bin/fm-brief.sh`'s `REPO` argument is a caller-supplied string with no reliable signal that it names firstmate's own repo, unlike a project registered in `data/projects.md`, so there is no clean point inside the scaffold to detect this case automatically.
-Firstmate adds this skill's load instruction to firstmate-repo briefs by hand instead; `CONTRIBUTING.md`'s "Development" section carries the same instruction as a durable reminder.
+Firstmate adds this skill's load instruction to firstmate-repo briefs by hand instead.
+`CONTRIBUTING.md`'s "Development" section carries the same instruction as a durable reminder.
 
 ## Repo style rules
 
-- One full sentence per line in tracked Markdown; never wrap multiple sentences onto one physical line.
+- Put one full sentence per line in tracked Markdown.
+- Never wrap multiple sentences onto one physical line.
 - Plain dash `-`, never an em dash.
 - Never add an agent name as a commit co-author.
-- `bin/*.sh` and `bin/backends/*.sh` must pass `shellcheck`; run it before treating a script change as done.
+- `bin/*.sh` and `bin/backends/*.sh` must pass `shellcheck`.
+- Run `shellcheck bin/*.sh bin/backends/*.sh tests/*.sh` before treating a script change as done.
 - Colocate tests with the existing pattern in `tests/`, name them `<subject>.test.sh`, and extend an existing script rather than inventing a new runner.
-- A backend-verification doc (`docs/*-backend.md`) records empirical facts, not assumptions: date, version, exact commands run, exact output; write incidents the same way, as evidence, not narrative alone.
+- A backend-verification doc (`docs/*-backend.md`) records empirical facts, not assumptions.
+- Include the date, version, exact commands run, and exact output.
+- Write incidents the same way, as evidence, not narrative alone.

--- a/.agents/skills/firstmate-coding-guidelines/SKILL.md
+++ b/.agents/skills/firstmate-coding-guidelines/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: firstmate-coding-guidelines
-description: Agent-only reference for changing firstmate's shared, tracked material per AGENTS.md section 1. Use before editing any of that material, whether working as firstmate directly or as a crewmate briefed on a firstmate-repo task. Covers the knowledge-placement decision tree, the one-owner rule for contracts, the inline-stub pattern for content moved into a skill, AGENTS.md size discipline, trigger hygiene for new skills, and repo style rules (one sentence per line, plain dash, no agent co-author, shellcheck-clean bin scripts).
+description: Agent-only reference for changing firstmate's shared, tracked material per AGENTS.md section 1. Use before editing any of that material, whether working as firstmate directly or as a crewmate briefed on a firstmate-repo task. Covers the knowledge-placement decision tree, the one-owner rule for contracts, the inline-stub pattern for content moved into a skill, AGENTS.md size discipline, trigger hygiene for new skills, and repo style rules (one sentence per line, plain dash, no agent co-author, shellcheck-clean bin scripts, colocated tests, and backend-verification evidence).
 user-invocable: false
 metadata:
   internal: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -870,6 +870,7 @@ These skills are not captain-invocable; they are conditional operating reference
 - `stuck-crewmate-recovery` - load after a stale wake, looping pane, repeated confusion, an answered-by-brief question, an unresponsive crewmate, or a failed steer.
 - `secondmate-provisioning` - load before creating, seeding, validating, recovering, handing backlog to, pushing inherited config into, or retiring a secondmate home, and before editing `data/secondmates.md`.
 - `fmx-respond` - load on an `x-mention <request_id>` `check:` wake to classify the mention, act on actionable requests through the normal lifecycle, post or preview a public-safe outcome reply for work that completes immediately, dismiss pure acknowledgments at the relay without replying, or acknowledge and link spawned work so up to three completion follow-ups can post over time, ending with a final one (section 14); relevant only when X mode is on.
+- `firstmate-coding-guidelines` - load before changing firstmate's own tracked material (`AGENTS.md`, `bin/`, `.agents/skills/`, `docs/`, public `skills/`), whether editing directly or briefing a crewmate for a firstmate-repo task.
 
 ## 14. X mode
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -870,7 +870,7 @@ These skills are not captain-invocable; they are conditional operating reference
 - `stuck-crewmate-recovery` - load after a stale wake, looping pane, repeated confusion, an answered-by-brief question, an unresponsive crewmate, or a failed steer.
 - `secondmate-provisioning` - load before creating, seeding, validating, recovering, handing backlog to, pushing inherited config into, or retiring a secondmate home, and before editing `data/secondmates.md`.
 - `fmx-respond` - load on an `x-mention <request_id>` `check:` wake to classify the mention, act on actionable requests through the normal lifecycle, post or preview a public-safe outcome reply for work that completes immediately, dismiss pure acknowledgments at the relay without replying, or acknowledge and link spawned work so up to three completion follow-ups can post over time, ending with a final one (section 14); relevant only when X mode is on.
-- `firstmate-coding-guidelines` - load before changing firstmate's own tracked material (`AGENTS.md`, `bin/`, `.agents/skills/`, `docs/`, public `skills/`), whether editing directly or briefing a crewmate for a firstmate-repo task.
+- `firstmate-coding-guidelines` - load before changing firstmate's shared, tracked material, as defined by section 1's list, whether editing directly or briefing a crewmate for a firstmate-repo task.
 
 ## 14. X mode
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,8 @@ See the [no-mistakes quick start](https://kunchenguid.github.io/no-mistakes/star
 ## Development
 
 Tracked changes to firstmate itself - `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `.tasks.toml`, `.github/workflows/`, `bin/`, `.agents/skills/`, and `skills/` - ship through the `no-mistakes` pipeline on a feature branch and require an explicit merge approval.
+Before making any such change, load the agent-only `firstmate-coding-guidelines` skill (`.agents/skills/firstmate-coding-guidelines/SKILL.md`); it has the knowledge-placement rules that keep `AGENTS.md` from regrowing every diet pass reverses.
+There is no reliable way for `bin/fm-brief.sh`'s scaffold to detect that a task's repo is firstmate itself, so firstmate adds this skill's load line to firstmate-repo briefs by hand; a crewmate picking up such a brief should load the skill even if the brief predates this instruction.
 When supervising live crewmates, keep firstmate's own long validation or build commands in the background so watcher wakes can still be handled.
 Crewmate validation follows the installed no-mistakes version's SKILL.md and live `axi` help instead of duplicating gate mechanics in firstmate docs.
 Firstmate's wrapper still matters: `ask-user` findings route to the captain through firstmate, and crewmates avoid `--yes` because it silently resolves captain-owned decisions without escalation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ See the [no-mistakes quick start](https://kunchenguid.github.io/no-mistakes/star
 ## Development
 
 Tracked changes to firstmate itself - `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `.tasks.toml`, `.github/workflows/`, `bin/`, `.agents/skills/`, and `skills/` - ship through the `no-mistakes` pipeline on a feature branch and require an explicit merge approval.
-Before making any such change, load the agent-only `firstmate-coding-guidelines` skill (`.agents/skills/firstmate-coding-guidelines/SKILL.md`); it has the knowledge-placement rules that keep `AGENTS.md` from regrowing every diet pass reverses.
+Before making any such change, load the agent-only `firstmate-coding-guidelines` skill (`.agents/skills/firstmate-coding-guidelines/SKILL.md`); it has the knowledge-placement rules that keep `AGENTS.md` from regrowing after each diet pass.
 There is no reliable way for `bin/fm-brief.sh`'s scaffold to detect that a task's repo is firstmate itself, so firstmate adds this skill's load line to firstmate-repo briefs by hand; a crewmate picking up such a brief should load the skill even if the brief predates this instruction.
 When supervising live crewmates, keep firstmate's own long validation or build commands in the background so watcher wakes can still be handled.
 Crewmate validation follows the installed no-mistakes version's SKILL.md and live `axi` help instead of duplicating gate mechanics in firstmate docs.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,8 +54,10 @@ See the [no-mistakes quick start](https://kunchenguid.github.io/no-mistakes/star
 ## Development
 
 Tracked changes to firstmate itself - `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `.tasks.toml`, `.github/workflows/`, `bin/`, `.agents/skills/`, and `skills/` - ship through the `no-mistakes` pipeline on a feature branch and require an explicit merge approval.
-Before making any such change, load the agent-only `firstmate-coding-guidelines` skill (`.agents/skills/firstmate-coding-guidelines/SKILL.md`); it has the knowledge-placement rules that keep `AGENTS.md` from regrowing after each diet pass.
-There is no reliable way for `bin/fm-brief.sh`'s scaffold to detect that a task's repo is firstmate itself, so firstmate adds this skill's load line to firstmate-repo briefs by hand; a crewmate picking up such a brief should load the skill even if the brief predates this instruction.
+Before making any such change, load the agent-only `firstmate-coding-guidelines` skill (`.agents/skills/firstmate-coding-guidelines/SKILL.md`).
+It has the knowledge-placement rules that keep `AGENTS.md` from regrowing after each diet pass.
+There is no reliable way for `bin/fm-brief.sh`'s scaffold to detect that a task's repo is firstmate itself, so firstmate adds this skill's load line to firstmate-repo briefs by hand.
+A crewmate picking up such a brief should load the skill even if the brief predates this instruction.
 When supervising live crewmates, keep firstmate's own long validation or build commands in the background so watcher wakes can still be handled.
 Crewmate validation follows the installed no-mistakes version's SKILL.md and live `axi` help instead of duplicating gate mechanics in firstmate docs.
 Firstmate's wrapper still matters: `ask-user` findings route to the captain through firstmate, and crewmates avoid `--yes` because it silently resolves captain-owned decisions without escalation.


### PR DESCRIPTION
## Intent

Create the firstmate-coding-guidelines agent-only skill (PR 0 of the AGENTS.md diet series). AGENTS.md grew from 585 to 958 lines since its last restructure because contributions kept adding conditional detail inline instead of routing it to its right home; this skill makes the placement discipline durable by encoding: the knowledge-placement decision tree (agent-needs-every-turn -> AGENTS.md inline; agent-needs-in-a-nameable-situation -> agent-only skill with a one-line AGENTS.md trigger; human/reference detail -> docs/; mechanics -> script header + --help), the one-owner rule (state each contract in full exactly once, cross-reference elsewhere), the inline-stub pattern modeled on AGENTS.md section 8's away-mode stub, AGENTS.md size discipline, trigger hygiene for new skills, and existing repo style rules (one sentence per line, plain dash never em dash, no agent co-author, shellcheck-clean bin scripts, colocated tests, backend-verification evidence conventions). Deliberate scope decisions: (1) only a single one-line trigger was added to AGENTS.md section 13 - no trimming of existing AGENTS.md content, since that trimming is explicitly deferred to separate PRs 1-3 in the diet series; (2) investigated whether bin/fm-brief.sh's ship-brief scaffold could auto-detect when a task's repo is firstmate's own repo (to auto-insert a load instruction into the generated crewmate brief), but found no reliable detection point - the REPO argument passed to fm-brief.sh is an arbitrary caller-supplied string with no structural signal distinguishing firstmate's own repo from any other project (unlike projects registered in data/projects.md) - so instead of a fragile/over-engineered heuristic, the load instruction was added to CONTRIBUTING.md's Development section as a durable reminder, and firstmate will hand-add the skill's load line to firstmate-repo briefs; (3) no bin/ script logic was changed, so no test file was extended. This is intentionally the smallest safe PR: a new skill file, one AGENTS.md trigger line, and a CONTRIBUTING.md hook.

## What Changed
- Added the `firstmate-coding-guidelines` agent-only skill covering knowledge placement, one-owner contracts, inline stubs, AGENTS.md size discipline, trigger hygiene, and repo style rules.
- Added a one-line AGENTS.md trigger so agents load the skill before changing firstmate shared, tracked material.
- Updated CONTRIBUTING.md to remind firstmate-repo work to load the skill during development.

## Risk Assessment

✅ Low: Captain, the change is confined to a new internal guidance skill and two trigger reminders, with no behavior-changing code paths or material consistency risks found.

## Testing

The pre-run full bash test baseline was already successful; I reran the focused `fm-brief` behavior test tied to the scaffold decision, then produced and inspected a reviewer-visible transcript showing the new internal skill metadata, section 13 trigger, CONTRIBUTING reminder, and knowledge-placement decision tree. No UI screenshot was captured because this change has no rendered UI surface.

<details>
<summary>Evidence: firstmate-coding-guidelines validation evidence</summary>

```text
# firstmate-coding-guidelines validation evidence

Intent surface: a new internal agent-only skill, a one-line AGENTS.md trigger, and a CONTRIBUTING.md reminder for firstmate-repo work.

## Changed files
.agents/skills/firstmate-coding-guidelines/SKILL.md
AGENTS.md
CONTRIBUTING.md

## AGENTS.md section 13 trigger excerpt
   866	
   867	These skills are not captain-invocable; they are conditional operating references you must load at the trigger points below.
   868	
   869	- `harness-adapters` - load before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter.
   870	- `stuck-crewmate-recovery` - load after a stale wake, looping pane, repeated confusion, an answered-by-brief question, an unresponsive crewmate, or a failed steer.
   871	- `secondmate-provisioning` - load before creating, seeding, validating, recovering, handing backlog to, pushing inherited config into, or retiring a secondmate home, and before editing `data/secondmates.md`.
   872	- `fmx-respond` - load on an `x-mention <request_id>` `check:` wake to classify the mention, act on actionable requests through the normal lifecycle, post or preview a public-safe outcome reply for work that completes immediately, dismiss pure acknowledgments at the relay without replying, or acknowledge and link spawned work so up to three completion follow-ups can post over time, ending with a final one (section 14); relevant only when X mode is on.
   873	- `firstmate-coding-guidelines` - load before changing firstmate's shared, tracked material, as defined by section 1's list, whether editing directly or briefing a crewmate for a firstmate-repo task.
   874	

## CONTRIBUTING.md Development excerpt
    54	## Development
    55	
    56	Tracked changes to firstmate itself - `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `.tasks.toml`, `.github/workflows/`, `bin/`, `.agents/skills/`, and `skills/` - ship through the `no-mistakes` pipeline on a feature branch and require an explicit merge approval.
    57	Before making any such change, load the agent-only `firstmate-coding-guidelines` skill (`.agents/skills/firstmate-coding-guidelines/SKILL.md`); it has the knowledge-placement rules that keep `AGENTS.md` from regrowing every diet pass reverses.
    58	There is no reliable way for `bin/fm-brief.sh`'s scaffold to detect that a task's repo is firstmate itself, so firstmate adds this skill's load line to firstmate-repo briefs by hand; a crewmate picking up such a brief should load the skill even if the brief predates this instruction.
    59	When supervising live crewmates, keep firstmate's own long validation or build commands in the background so watcher wakes can still be handled.
    60	Crewmate validation follows the installed no-mistakes version's SKILL.md and live `axi` help instead of duplicating gate mechanics in firstmate docs.

## Skill metadata excerpt
     1	---
     2	name: firstmate-coding-guidelines
     3	description: Agent-only reference for changing firstmate's shared, tracked material per AGENTS.md section 1. Use before editing any of that material, whether working as firstmate directly or as a crewmate briefed on a firstmate-repo task. Covers the knowledge-placement decision tree, the one-owner rule for contracts, the inline-stub pattern for content moved into a skill, AGENTS.md size discipline, trigger hygiene for new skills, and repo style rules (one sentence per line, plain dash, no agent co-author, shellcheck-clean bin scripts).
     4	user-invocable: false
     5	metadata:
     6	  internal: true
     7	---
     8	
     9	# firstmate-coding-guidelines
    10	
    11	Load this before changing firstmate's shared, tracked material, as defined by `AGENTS.md` section 1.
    12	It exists because `AGENTS.md` grew from 585 to 958 lines between its last two restructures, entirely from conditional detail added inline instead of routed to its right home.

## Skill sections loaded from SKILL.md
15:## Knowledge-placement decision tree
31:## One-owner rule
39:## Inline-stub pattern
47:## Size discipline
55:## Trigger hygiene
64:## Repo style rules

## Knowledge-placement decision tree excerpt
    15	## Knowledge-placement decision tree
    16	
    17	Before writing a new fact anywhere in this repo, ask where it belongs, in this order.
    18	
    19	1. Does the firstmate AGENT need this on every session or every turn to operate?
    20	   If yes: `AGENTS.md`, inline.
    21	2. Does the agent need it only in a nameable situation - a spawn, a recovery, a specific wake type, a specific lifecycle step?
    22	   If yes: an agent-only skill under `.agents/skills/`, plus a one-line trigger pointer left inline in `AGENTS.md` (usually section 13).
    23	3. Is it human/reference detail - a wire format, a verification record, a mechanism narrative, an incident writeup?
    24	   If yes: `docs/`.
    25	4. Is it mechanics - exact flags, exact commands, exact paths?
    26	   If yes: the script's own header comment plus its `--help` output, not prose in `AGENTS.md` or a skill.
    27	
    28	Stop at the first tier that answers yes.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `AGENTS.md:873` - The trigger says this skill loads before changing firstmate&#39;s own tracked material, but the list omits README.md, CONTRIBUTING.md, .tasks.toml, and .github/workflows even though AGENTS.md section 1 and CONTRIBUTING.md define those as tracked firstmate material. Agents changing those files can miss the skill and bypass the placement/style rules this PR is meant to enforce; expand the trigger/scope or make the narrower scope explicit if that was deliberate.

🔧 Fix: Captain, align tracked-material trigger scope
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- <code>Baseline already reported successful before this validation: `command -v tmux &gt;/dev/null || { echo &#34;tmux is required for e2e tests&#34; &gt;&amp;2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo &#34;== $t ==&#34;; bash &#34;$t&#34; || rc=1; done; exit &#34;$rc&#34;`</code>
- `bash tests/fm-brief.test.sh`
- <code>Generated `/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KWQ7S48SMXDYBH6M9KEAE8X2/firstmate-coding-guidelines-validation.txt` from the changed skill, AGENTS.md trigger, and CONTRIBUTING.md hook</code>
- `sed -n '1,220p' /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KWQ7S48SMXDYBH6M9KEAE8X2/firstmate-coding-guidelines-validation.txt`
- `git status --short`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
