### PR TITLE
fix brief no-mistakes pooled setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,9 @@ A crewmate picking up such a brief should load the skill even if the brief preda
 When supervising live crewmates, keep firstmate's own long validation or build commands in the background so watcher wakes can still be handled.
 Crewmate validation follows the installed no-mistakes version's SKILL.md and live `axi` help instead of duplicating gate mechanics in firstmate docs.
 Firstmate's wrapper still matters: `ask-user` findings route to the captain through firstmate, and crewmates avoid `--yes` because it silently resolves captain-owned decisions without escalation.
+Pooled firstmate worktrees must not run `no-mistakes doctor` or `no-mistakes init`.
+The recurring symptom is a first `no-mistakes axi run` failing with `no previous run for branch <branch>` while the shared hook under `~/.no-mistakes/repos/<hash>.git/hooks/post-receive` reverts to a broken form.
+The underlying first-run bug is in the closed no-mistakes binary and belongs upstream, so firstmate keeps initialization at the shared repo level and lets crewmates invoke validation only when firstmate triggers `/no-mistakes`.
 Local `.no-mistakes/` state and test evidence stay out of this repo; `.no-mistakes.yaml` keeps evidence in a temp directory and pins the gate's test command to the same bash behavior suite as CI.
 That is firstmate-specific; do not commit `.no-mistakes/evidence/` here even when another no-mistakes-managed target project keeps committed PR evidence.
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -198,8 +198,12 @@ EOF
 )
     ;;
   *)  # no-mistakes (default)
+# no-mistakes gate state is shared at the repo level, so pooled worktrees must
+# not re-run init/doctor here; those commands can rewrite the shared hook.
     SETUP2="
-2. Run \`no-mistakes doctor\`; if it reports the repo is not initialized here, run \`no-mistakes init\`."
+2. Verify the no-mistakes CLI is present without touching repo gate state: \`command -v no-mistakes >/dev/null\`.
+   If it is missing, append \`blocked: no-mistakes CLI missing\` to the status file and stop.
+3. Do not run \`no-mistakes doctor\` or \`no-mistakes init\` in this pooled worktree; firstmate initializes and maintains the shared gate at the repo level."
     RULE1='1. Never push to the default branch. Never merge a PR.'
     DOD=$(cat <<EOF
 # Definition of done


### PR DESCRIPTION
## Summary
- remove the standard ship-brief setup instruction that told crewmates to run `no-mistakes doctor` and possibly `no-mistakes init` inside pooled worktrees
- replace it with a read-only `command -v no-mistakes` availability check and an explicit prohibition on `doctor`/`init` in pooled worktrees
- document the recurring gate symptom and mitigation in `CONTRIBUTING.md`

## Root Cause
Firstmate's generated no-mistakes ship brief was our-side trigger: it instructed each crewmate to run `no-mistakes doctor`, then `no-mistakes init` if the repo looked uninitialized from inside the disposable pooled worktree. Those commands can rewrite/reinitialize the shared no-mistakes hook and gate state for the repo, which re-breaks the fleet's shared hook patch and leads to first-run failures such as `no previous run for branch <branch>`.

The underlying first-run-on-pooled-worktree behavior is in the closed no-mistakes v1.31.2 binary, so this PR does not try to patch it. The mitigation here is to keep no-mistakes initialization at the shared repo level and prevent crewmates from re-running init/doctor in task worktrees.

## Validation
- generated a pre-patch sample ship brief and confirmed Setup emitted `no-mistakes doctor` / `no-mistakes init`
- generated a post-patch sample ship brief and confirmed Setup emits only the read-only CLI check plus the pooled-worktree prohibition
- `bash -n bin/fm-brief.sh`
- `tests/fm-brief.test.sh`
- `for script in bin/*.sh bin/backends/*.sh; do bash -n "$script" || exit 1; done`
- `git diff --check`

Not run: `shellcheck bin/*.sh bin/backends/*.sh tests/*.sh` because `shellcheck` is not installed in this worktree environment. Per task instruction, I did not run `no-mistakes init`, `no-mistakes doctor`, or any `no-mistakes axi ...` command.