### PR TITLE
feat: add PR-body contract to ship briefs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -825,6 +825,7 @@ For a ship task the definition of done is shaped by the project's delivery mode 
 The no-mistakes brief points to no-mistakes' version-matched guidance and keeps only firstmate-specific wrapper rules for `ask-user` escalation, `--yes` avoidance, and the CI-green done line.
 The scaffold reads the mode via `fm-project-mode.sh`, so you do not pass it.
 Ship briefs also include the project-memory contract: run `bin/fm-ensure-agents-md.sh` when the project already has agent-memory files or when the task produced durable project-intrinsic knowledge, then record proportionate learnings in `AGENTS.md`.
+PR-producing ship briefs (no-mistakes, direct-PR) also carry the PR-body contract, stated in full only in the `bin/fm-brief.sh` scaffold: the crewmate keeps the PR body's opening Intent/What section a scannable tree and relocates long narrative to a bottom collapsed block.
 For scout tasks add `--scout`: the scaffold swaps the definition of done for the report contract (findings to `data/<id>/report.md`, no branch, no push, no PR) and declares the worktree scratch; scout is mode-agnostic.
 Scout briefs do not include the project-memory step, because their deliverable is a report rather than a committed project change.
 For secondmates use `bin/fm-brief.sh <id> --secondmate <project>...`.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -28,6 +28,9 @@
 # Scout tasks ignore mode - their deliverable is a report, not a merge.
 # Ship tasks include a project-memory section so durable project-intrinsic
 # learnings can be committed to AGENTS.md through the project's delivery path.
+# PR-producing ship briefs (no-mistakes, direct-PR) also carry the PR-body
+# Intent contract: the opening Intent/What section must be a scannable tree,
+# with long narrative collapsed at the bottom; this scaffold owns that contract.
 # Refuses to overwrite an existing brief.
 set -eu
 
@@ -221,6 +224,25 @@ EOF
 )
     ;;
 esac
+
+# PR-producing modes (no-mistakes, direct-PR) carry the PR-body Intent contract;
+# local-only has no PR. Same $(cat <<EOF) apostrophe hazard as the DOD blocks above.
+if [ "$MODE" != local-only ]; then
+PRBODY=$(cat <<EOF
+# PR body
+After the PR exists (whether you opened it or the pipeline did), make its opening \`## Intent\` (or \`## What\`) section a scannable tree, not a prose wall; restructure it with \`gh-axi pr edit\` if the auto-generated body needs it.
+- Top-level bullets: the issue or issues addressed, with evidence numbers only where they genuinely matter to a reviewer.
+- Sub-bullets: the fix approach, implications (behavior changes, operational notes, deploy requirements), and explicit scope boundaries (what was deliberately NOT done).
+- Typically 3-8 top-level bullets, nested 2-3 levels max; let the shape flex with the change type (bug fix: issue -> root cause -> fix -> implication; feature: goal -> approach -> limits; ops: what -> why -> blast radius), never a rigid template.
+Long-form narrative or the original task prompt may appear only at the BOTTOM of the body, collapsed inside \`<details><summary>Full narrative / original brief</summary>...</details>\`, never at the top.
+Keep the other body sections (What Changed, Risk Assessment, Testing, evidence details) intact.
+These rules apply where we own the PR template; a repo with its own strict upstream PR template wins - follow that template, and keep the description concise and human: explain why and toward what goal, not a line-by-line tour of the diff (the reviewer reads the code).
+EOF
+)
+DOD="$PRBODY
+
+$DOD"
+fi
 
 cat > "$BRIEF" <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -78,6 +78,7 @@ Ship briefs also tell the crewmate to verify `pwd -P` and `git rev-parse --show-
 ## Two task shapes
 
 Ship tasks change projects and ship by project mode (`no-mistakes`, `direct-PR`, or `local-only`); scout tasks investigate, plan, reproduce bugs, or audit, then leave a report at `data/<id>/report.md` and never push.
+For PR-producing ship modes (`no-mistakes` and `direct-PR`), generated briefs also require a scannable opening PR-body Intent/What section and move long narrative to a collapsed block at the bottom.
 
 ## Dispatch profiles
 

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -11,7 +11,7 @@ If you have changed away from the firstmate home in an interactive shell, invoke
 | `fm-fleet-sync.sh`       | Fetch clones, fast-forward safe default-branch states, self-heal clean detached ancestor drift, report unsafe drift as `STUCK:`, and safely prune branches whose remote is gone |
 | `fm-update.sh`           | Self-update the running firstmate repo and registered secondmate homes with fast-forward-only pulls from origin     |
 | `fm-backlog-handoff.sh`  | Move already-judged in-scope queued backlog items from the main home into a seeded secondmate home                 |
-| `fm-brief.sh`            | Scaffold a ship brief with a worktree-isolation assertion, a report-only scout brief with `--scout`, or a secondmate charter with `--secondmate` |
+| `fm-brief.sh`            | Scaffold a ship brief with a worktree-isolation assertion and PR-body contract for PR-producing modes, a report-only scout brief with `--scout`, or a secondmate charter with `--secondmate` |
 | `fm-ensure-agents-md.sh` | Ensure project `AGENTS.md` is the real memory file and `CLAUDE.md` symlinks to it                                   |
 | `fm-guard.sh`            | Warn when the primary checkout is tangled, when queued wakes are pending, or when a stale or missing watcher needs a prominent banner; `FM_GUARD_READ_ONLY=1` keeps the alarms but suppresses drain, arm, and checkout repair commands |
 | `fm-turnend-guard.sh`    | Claude Code Stop hook, primary-scoped only: blocks (exit 2, exact reason) a primary turn end when work is in flight without a live identity-matched watcher lock and fresh beacon, using Claude Code's own `stop_hook_active` field so it never blocks twice in one turn (docs/turnend-guard.md) |

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -76,6 +76,36 @@ test_no_mistakes_dod_wording() {
   pass "fm-brief.sh: no-mistakes DOD wording avoids the apostrophe regression"
 }
 
+# The PR-body Intent contract rides only on PR-producing modes: no-mistakes and
+# direct-PR briefs get the "# PR body" section (tree-shaped opening section,
+# narrative collapsed at the bottom, gh-axi pr edit as the restructure tool);
+# local-only has no PR, so its brief must not carry the section.
+test_pr_body_contract_by_mode() {
+  local home brief
+  home="$TMP_ROOT/prbody-home"
+  write_registry "$home"
+
+  for id_proj in "brief-prbody-nm-c1:no-registry-proj" "brief-prbody-dp-c2:direct-proj"; do
+    id=${id_proj%%:*}
+    proj=${id_proj##*:}
+    FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" "$proj" >/dev/null 2>&1
+    brief="$home/data/$id/brief.md"
+    assert_present "$brief" "$id: brief was not scaffolded"
+    assert_grep "# PR body" "$brief" "$id: brief missing the PR body section"
+    assert_grep "scannable tree" "$brief" "$id: PR body section lost the tree requirement"
+    assert_grep "gh-axi pr edit" "$brief" "$id: PR body section lost the restructure tool"
+    assert_grep "BOTTOM of the body" "$brief" "$id: PR body section lost the bottom-narrative rule"
+    assert_grep "strict upstream PR template" "$brief" "$id: PR body section lost the upstream-template exception"
+  done
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-prbody-lo-c3 local-proj >/dev/null 2>&1
+  brief="$home/data/brief-prbody-lo-c3/brief.md"
+  assert_present "$brief" "local-only: brief was not scaffolded"
+  assert_no_grep "# PR body" "$brief" "local-only brief must not carry the PR body section (no PR exists)"
+  pass "fm-brief.sh: PR body contract present for no-mistakes/direct-PR, absent for local-only"
+}
+
 test_script_parses
 test_ship_modes_generate_clean_briefs
 test_no_mistakes_dod_wording
+test_pr_body_contract_by_mode

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -256,8 +256,9 @@ $rec
 EOF
   make_fake_toolchain "$fakebin"
   make_fake_ps_claude "$fakebin"
-  # Force a MISSING diagnostic line so the bootstrap section is non-trivial.
-  rm -f "$fakebin/node"
+  # Force a deterministic MISSING diagnostic line so the bootstrap section is
+  # non-trivial. Do not use node here: a real host node may exist later in PATH.
+  rm -f "$fakebin/gh-axi"
 
   printf 'window=fm-sess:w1\nkind=ship\n' > "$home/state/task-a.meta"
 
@@ -280,7 +281,7 @@ EOF
   [ "$context_line" -lt "$fleet_line" ] || fail "CONTEXT did not precede FLEET STATE"
   [ "$fleet_line" -lt "$next_line" ] || fail "FLEET STATE did not precede NEXT STEP"
 
-  missing_line=$(printf '%s\n' "$out" | grep -n 'MISSING: node' | head -1 | cut -d: -f1)
+  missing_line=$(printf '%s\n' "$out" | grep -n 'MISSING: gh-axi' | head -1 | cut -d: -f1)
   [ -n "$missing_line" ] || fail "MISSING diagnostic did not appear at all"
   [ "$missing_line" -lt "$fleet_line" ] || fail "actionable MISSING diagnostic was buried after the bulk fleet-state digest"
 
@@ -400,7 +401,7 @@ $rec
 EOF
   make_fake_toolchain "$fakebin"
   make_fake_ps_claude "$fakebin"
-  rm -f "$fakebin/node"
+  rm -f "$fakebin/gh-axi"
 
   append_wake "$home/state" signal task-z "needs-decision: pick a library"
 
@@ -409,7 +410,7 @@ EOF
   # fm-lock.sh's own exact success text.
   assert_contains "$out" "lock acquired: harness pid" "fm-lock.sh's real output did not appear (composition, not reimplementation)"
   # fm-bootstrap.sh's own exact MISSING-tool line format.
-  assert_contains "$out" "MISSING: node (install:" "fm-bootstrap.sh's real detect line did not appear verbatim"
+  assert_contains "$out" "MISSING: gh-axi (install:" "fm-bootstrap.sh's real detect line did not appear verbatim"
   # fm-wake-drain.sh's real drained record (raw tab-separated queue line).
   assert_contains "$out" "$(printf 'signal\ttask-z\tneeds-decision: pick a library')" "fm-wake-drain.sh's real drained record did not appear"
 


### PR DESCRIPTION
## Intent

Re-raise already-open PR #278 through no-mistakes so the 'PR must be raised via no-mistakes' required check passes; content (the AGENTS.md brief-scaffold pointer line) is already correct and needs no rework.

## What Changed

- Captain, updated `fm-brief.sh` so PR-producing ship briefs include a PR body contract requiring a `## Intent` section while keeping direct-PR and local-only flows aligned.
- Documented the new brief contract in the firstmate instructions and architecture/script docs.
- Added `fm-brief` coverage for generated PR-body guidance and stabilized the session-start missing-tool fixture touched by the test run.

## Risk Assessment

✅ Low: Captain, the change is narrowly scoped to generated brief text plus matching documentation and coverage, with no material correctness or safety issues found in the reviewed diff.

## Testing

Captain, the pre-run full baseline was already green; I then ran the focused brief and session-start tests plus an end-to-end scaffold check that produced reviewer-visible generated brief artifacts showing the PR-body guidance appears only for PR-producing modes.

<details>
<summary>Evidence: Generated brief evidence summary</summary>

```text
# Generated brief evidence

## no-mistakes brief PR body section
# PR body
After the PR exists (whether you opened it or the pipeline did), make its opening `## Intent` (or `## What`) section a scannable tree, not a prose wall; restructure it with `gh-axi pr edit` if the auto-generated body needs it.
- Top-level bullets: the issue or issues addressed, with evidence numbers only where they genuinely matter to a reviewer.
- Sub-bullets: the fix approach, implications (behavior changes, operational notes, deploy requirements), and explicit scope boundaries (what was deliberately NOT done).
- Typically 3-8 top-level bullets, nested 2-3 levels max; let the shape flex with the change type (bug fix: issue -> root cause -> fix -> implication; feature: goal -> approach -> limits; ops: what -> why -> blast radius), never a rigid template.
Long-form narrative or the original task prompt may appear only at the BOTTOM of the body, collapsed inside `<details><summary>Full narrative / original brief</summary>...</details>`, never at the top.
Keep the other body sections (What Changed, Risk Assessment, Testing, evidence details) intact.
These rules apply where we own the PR template; a repo with its own strict upstream PR template wins - follow that template, and keep the description concise and human: explain why and toward what goal, not a line-by-line tour of the diff (the reviewer reads the code).

# Definition of done

## direct-PR brief PR body section
# PR body
After the PR exists (whether you opened it or the pipeline did), make its opening `## Intent` (or `## What`) section a scannable tree, not a prose wall; restructure it with `gh-axi pr edit` if the auto-generated body needs it.
- Top-level bullets: the issue or issues addressed, with evidence numbers only where they genuinely matter to a reviewer.
- Sub-bullets: the fix approach, implications (behavior changes, operational notes, deploy requirements), and explicit scope boundaries (what was deliberately NOT done).
- Typically 3-8 top-level bullets, nested 2-3 levels max; let the shape flex with the change type (bug fix: issue -> root cause -> fix -> implication; feature: goal -> approach -> limits; ops: what -> why -> blast radius), never a rigid template.
Long-form narrative or the original task prompt may appear only at the BOTTOM of the body, collapsed inside `<details><summary>Full narrative / original brief</summary>...</details>`, never at the top.
Keep the other body sections (What Changed, Risk Assessment, Testing, evidence details) intact.
These rules apply where we own the PR template; a repo with its own strict upstream PR template wins - follow that template, and keep the description concise and human: explain why and toward what goal, not a line-by-line tour of the diff (the reviewer reads the code).

# Definition of done

## local-only PR body search
No '# PR body' section found in local-only brief.
```
</details>
<details>
<summary>Evidence: Generated no-mistakes brief</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Setup
You are in a disposable git worktree of unregistered-proj, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/prbody-nm-demo`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/no-mistakes-evidence/01KWVHTWKSZ134578VAG2F0KJ1/fm-brief-prbody-home/state/prbody-nm-demo.status'`
   States: working, needs-decision, blocked, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs to a human (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/home/brett/.no-mistakes/worktrees/79c6c560454e/01KWVHTWKSZ134578VAG2F0KJ1/bin/fm-ensure-agents-md.sh .` in the worktree.
If this task produced durable project-intrinsic knowledge, record it in `AGENTS.md` as part of your change.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# PR body
After the PR exists (whether you opened it or the pipeline did), make its opening `## Intent` (or `## What`) section a scannable tree, not a prose wall; restructure it with `gh-axi pr edit` if the auto-generated body needs it.
- Top-level bullets: the issue or issues addressed, with evidence numbers only where they genuinely matter to a reviewer.
- Sub-bullets: the fix approach, implications (behavior changes, operational notes, deploy requirements), and explicit scope boundaries (what was deliberately NOT done).
- Typically 3-8 top-level bullets, nested 2-3 levels max; let the shape flex with the change type (bug fix: issue -> root cause -> fix -> implication; feature: goal -> approach -> limits; ops: what -> why -> blast radius), never a rigid template.
Long-form narrative or the original task prompt may appear only at the BOTTOM of the body, collapsed inside `<details><summary>Full narrative / original brief</summary>...</details>`, never at the top.
Keep the other body sections (What Changed, Risk Assessment, Testing, evidence details) intact.
These rules apply where we own the PR template; a repo with its own strict upstream PR template wins - follow that template, and keep the description concise and human: explain why and toward what goal, not a line-by-line tour of the diff (the reviewer reads the code).

# Definition of done
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are not yours to answer: escalate to firstmate (rule 6) and stop.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: the captain, not you, owns the ask-user decisions it would silently auto-resolve.

After /no-mistakes reports CI green, append `done: PR {url} checks green` and stop. You are finished.
```
</details>
<details>
<summary>Evidence: Generated direct-PR brief</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Setup
You are in a disposable git worktree of direct-proj, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/prbody-dp-demo`

# Rules
1. Never push to the default branch (push only your `fm/prbody-dp-demo` branch). Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/no-mistakes-evidence/01KWVHTWKSZ134578VAG2F0KJ1/fm-brief-prbody-home/state/prbody-dp-demo.status'`
   States: working, needs-decision, blocked, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs to a human (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/home/brett/.no-mistakes/worktrees/79c6c560454e/01KWVHTWKSZ134578VAG2F0KJ1/bin/fm-ensure-agents-md.sh .` in the worktree.
If this task produced durable project-intrinsic knowledge, record it in `AGENTS.md` as part of your change.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# PR body
After the PR exists (whether you opened it or the pipeline did), make its opening `## Intent` (or `## What`) section a scannable tree, not a prose wall; restructure it with `gh-axi pr edit` if the auto-generated body needs it.
- Top-level bullets: the issue or issues addressed, with evidence numbers only where they genuinely matter to a reviewer.
- Sub-bullets: the fix approach, implications (behavior changes, operational notes, deploy requirements), and explicit scope boundaries (what was deliberately NOT done).
- Typically 3-8 top-level bullets, nested 2-3 levels max; let the shape flex with the change type (bug fix: issue -> root cause -> fix -> implication; feature: goal -> approach -> limits; ops: what -> why -> blast radius), never a rigid template.
Long-form narrative or the original task prompt may appear only at the BOTTOM of the body, collapsed inside `<details><summary>Full narrative / original brief</summary>...</details>`, never at the top.
Keep the other body sections (What Changed, Risk Assessment, Testing, evidence details) intact.
These rules apply where we own the PR template; a repo with its own strict upstream PR template wins - follow that template, and keep the description concise and human: explain why and toward what goal, not a line-by-line tour of the diff (the reviewer reads the code).

# Definition of done
This project ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
The task is complete only when committed on your branch.
When it is implemented and committed, push your branch and open a PR with `gh-axi`, then append `done: PR {url}` to the status file and stop.
Do NOT run /no-mistakes. The captain reviews and merges the PR; firstmate relays it.
```
</details>
<details>
<summary>Evidence: Generated local-only brief</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Setup
You are in a disposable git worktree of local-proj, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/prbody-lo-demo`

# Rules
1. Never push to any remote and never open a PR. Work only on your `fm/prbody-lo-demo` branch; firstmate handles the merge into local `main`.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/no-mistakes-evidence/01KWVHTWKSZ134578VAG2F0KJ1/fm-brief-prbody-home/state/prbody-lo-demo.status'`
   States: working, needs-decision, blocked, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs to a human (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/home/brett/.no-mistakes/worktrees/79c6c560454e/01KWVHTWKSZ134578VAG2F0KJ1/bin/fm-ensure-agents-md.sh .` in the worktree.
If this task produced durable project-intrinsic knowledge, record it in `AGENTS.md` as part of your change.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
This project ships **local-only**: no remote, no PR, no pipeline.
The task is complete only when committed on your branch `fm/prbody-lo-demo`. Do NOT push, do NOT open a PR, do NOT merge.
Keep your branch a clean fast-forward onto the current default branch - if `main` has advanced, rebase onto it so the eventual merge stays a fast-forward.
When it is implemented and committed, append `done: ready in branch fm/prbody-lo-demo` to the status file and stop.
Firstmate then reviews your branch diff, the captain approves, and firstmate merges it into local `main`.
```
</details>
- Outcome: 🔧 1 issue found → auto-fixed ✅ across 2 runs (16m24s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed ✅</summary>

- 🚨 tests failed with exit code 1
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`

🔧 Fix: Stabilize session-start missing-tool fixture
✅ Re-checked - no issues remain.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- <code>Baseline already completed before this round: `command -v tmux &gt;/dev/null || { echo &#34;tmux is required for e2e tests&#34; &gt;&amp;2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo &#34;== $t ==&#34;; bash &#34;$t&#34; || rc=1; done; exit &#34;$rc&#34;`</code>
- `bash tests/fm-brief.test.sh`
- `bash tests/fm-session-start.test.sh`
- <code>Generated real briefs with `FM_HOME=/tmp/no-mistakes-evidence/01KWVHTWKSZ134578VAG2F0KJ1/fm-brief-prbody-home bin/fm-brief.sh ...` for default no-mistakes, direct-PR, and local-only modes, then captured their PR-body sections into `/tmp/no-mistakes-evidence/01KWVHTWKSZ134578VAG2F0KJ1/generated-brief-evidence.md`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
