### PR TITLE
feat(harness): add cursor and hermes verified adapters

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harness-adapters
-description: Agent-only reference for firstmate harness operations. Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter. Contains verified facts for claude, codex, opencode, pi, and grok.
+description: Agent-only reference for firstmate harness operations. Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter. Contains verified facts for claude, codex, opencode, pi, grok, cursor, and hermes.
 user-invocable: false
 metadata:
   internal: true
@@ -58,6 +58,8 @@ The supported launch-profile flags below were verified locally on 2026-06-30 wit
 | grok | `--model <model>` | `--reasoning-effort <low\|medium\|high\|xhigh>` | Verified on grok 0.2.73. `--effort` parses too, but firstmate's profile axis is reasoning effort. `--reasoning-effort max` is rejected, so `max` is omitted. |
 | pi | `--model <model>` | `--thinking <low\|medium\|high\|xhigh>` | Verified on pi 0.80.2. `max` prints an invalid-thinking warning, so firstmate omits Pi effort when the requested effort is `max`. |
 | opencode | `--model <provider/model>` | none for firstmate's interactive launch | Verified on opencode 1.17.6. `opencode run` has `--variant`, but firstmate launches the interactive `opencode --prompt` path, which has no verified effort flag. |
+| cursor | `--model <model>` | folded into the model string as a bracket parameter (e.g. `--model 'model[effort=high]'`) | Verified on cursor-agent 2026.07.01 (2026-07-05). cursor has no standalone effort flag; `model_flag_for_harness` folds a valid effort (low/medium/high/xhigh/max) into the model bracket. When effort is set but no model is, there is nothing to attach it to, so it is omitted and left recorded in meta. A model without bracket support ignores the parameter on cursor's side. |
+| hermes | `-m <model>` (provider encoded as `provider/model`, or a separate `--provider`) | none for firstmate's interactive launch | Verified on Hermes Agent v0.18.0 (2026-07-05). firstmate's single `--model` axis maps onto `-m`; a provider is encoded in the model string (`deepseek/deepseek-v4-flash`). No verified interactive effort flag, so requested effort is recorded in meta and omitted, the same contract as opencode. |
 
 When a requested effort value is outside the harness-specific accepted set, `fm-spawn` records the requested `effort=` in meta but emits no effort flag for that harness.
 This preserves launch success instead of passing a known-bad value.
@@ -72,6 +74,8 @@ Natural language is acceptable if uncertain.
 - opencode: no separate verified skill invocation beyond normal slash-command behavior; use natural language if the exact skill command is uncertain.
 - pi: no separate verified skill invocation beyond normal command behavior; use natural language if the exact skill command is uncertain.
 - grok: `/<skill>`, for example `/no-mistakes` (same form as claude). Verified end to end: grok discovers the user-level `no-mistakes` skill, `/no-mistakes` invokes it, and grok drives a real `no-mistakes axi run`. Like codex's `$`/`/` popups, typing `/<skill>` opens grok's slash-autocomplete, so a too-fast Enter selects the popup entry instead of sending, and for an argument-taking command (like `/no-mistakes`'s optional task-first argument) that first Enter only expands the popup selection into an argument-hint placeholder rather than submitting - a genuine second Enter is required (see the grok section below for the 2026-07-03 incident and fix). `fm_tmux_submit_core`'s retried Enter (used by `fm-send` on the tmux backend) already handles this correctly by reading the cursor row; the herdr backend needed a dedicated fix (`fm_backend_herdr_composer_state`, docs/herdr-backend.md) because its prior delta-based verification false-positived on that same popup-close content change.
+- cursor: `/<skill>`, for example `/no-mistakes` (same form as claude). Verified 2026-07-05: cursor discovers the user-level `no-mistakes` skill and surfaces it in the `/` slash-autocomplete popup. Same popup submit-hazard as claude/grok - a too-fast Enter selects the popup entry instead of sending - but `fm_tmux_submit_core`'s retried Enter (used by `fm-send` on the tmux backend) handles it by reading the cursor row (verified: a plain steer submitted cleanly on the first landed Enter).
+- hermes: no verified slash form for `no-mistakes` - hermes has its own separate skills ecosystem (`hermes skills`, 68 skills preloadable via `--skills`), and `no-mistakes` is not among them. Its built-in slash commands are session controls (`/exit`, `/help`, `/queue`, `/bg`, `/steer`, `/rollback`). Use natural language to trigger validation.
 
 ## claude (VERIFIED)
 
@@ -192,3 +196,60 @@ The hook reads `$GROK_WORKSPACE_ROOT`, which is always set for hooks and equals 
 This keeps the hook outside the worktree, needs no trust grant, and writes only firstmate-owned files.
 `fm-teardown` removes the worktree pointer before returning a pooled worktree.
 Secondmate spawns skip the pointer (idle panes are healthy, no stale-pane detection for them).
+
+## cursor (VERIFIED 2026-07-05, cursor-agent 2026.07.01-41b2de7)
+
+Cursor Agent (`cursor-agent`), Cursor's Claude-Code-compatible CLI.
+Binary at `~/.local/bin/cursor-agent`; `~/.local/bin` must be on PATH for the spawn shell to find it.
+Launch with a positional prompt: `cursor-agent --force "$(cat <brief>)"`.
+
+| Fact | Value |
+|---|---|
+| Busy-pane signature | `ctrl+c to stop` (ASCII, in the footer while a turn runs, shown with a braille spinner + `N tokens`). Idle composer shows `→ Add a follow-up`. The ASCII `ctrl+c to stop` is the busy regex. |
+| Exit command | double `Ctrl-C`. On exit it prints `To resume this session: agent --resume=<id>`. A single `Ctrl-C` only interrupts the current turn. |
+| Interrupt | single `Ctrl-C` (stops the current turn; the footer's `ctrl+c to stop` clears back to `→ Add a follow-up`). |
+| Skill invocation | `/<skill>`, e.g. `/no-mistakes`. Opens the `/` slash-autocomplete popup (built-in commands like `/model`, `/plan` plus discovered skills such as `/no-mistakes`), so the same too-fast-Enter popup hazard as claude/grok applies; the shared submit retry handles it (see below). |
+| Autonomy | `--force` (alias `--yolo`, footer shows `Run Everything`); runs every tool without the per-command allowlist approval dialog. The targeted equivalent of claude's `--dangerously-skip-permissions`. |
+| Env marker | `CURSOR_AGENT=1` (also sets `CURSOR_INVOKED_AS=cursor-agent` and `CURSOR_CONVERSATION_ID`). IMPORTANT: cursor ALSO sets `CLAUDECODE=1` and `AI_AGENT=claude-code_*` (it is Claude-Code-compatible under the hood), so `bin/fm-harness.sh` checks `CURSOR_AGENT` BEFORE the claude marker; a claude-first check would misdetect a cursor session as claude. |
+| Resume | `cursor-agent --resume=<id>` (id printed on exit) or `--continue`. |
+| Model / effort | `--model <id>`; effort rides the model string as a bracket parameter, e.g. `--model 'claude-opus-4-8[effort=high]'`. `fm-spawn` folds a valid effort into that bracket; a model without bracket support ignores the parameter. |
+
+Trust dialog on first interactive launch per workspace: "Do you trust the contents of this directory?" with `[a] Trust this workspace` / `[q] Quit` (the selector defaults to Trust).
+Accept with Enter.
+The `--trust` flag exists but works only in `--print`/headless mode, so it cannot be used to pre-clear the interactive dialog; peek the pane after spawn and accept with `bin/fm-send.sh <window> --key Enter`.
+
+Submit hazard and its handling (verified 2026-07-05): a `/`-command or any steer sent via `fm-send` on the tmux backend submits cleanly.
+`fm_tmux_submit_core`'s cursor-row-read retry (`bin/fm-tmux-lib.sh`) recognizes the composer's post-submit empty state and does not false-retry; a plain steer landed and was processed on the first landed Enter, so no bespoke settle is needed.
+Cursor's idle `→ Add a follow-up` footer sits below the composer, not on the cursor row, so an idle cursor pane reads as an empty composer without a `FM_COMPOSER_IDLE_RE` override.
+
+Turn-end hook: none is wired.
+cursor-agent is Claude-Code-compatible but its interactive Stop/turn-end hook surface is unverified, so firstmate does not assume one and relies on the busy signature (provably-working check) plus stale-pane detection, the same hookless path as opencode.
+Headless mode (not the crew path): `cursor-agent -p --force --output-format stream-json` emits Claude-Code-compatible events (system/init with `session_id`, thinking deltas), and `-w [name]` creates a native git worktree - neither is used by firstmate's interactive crew launch.
+
+## hermes (VERIFIED 2026-07-05, Hermes Agent v0.18.0)
+
+Hermes Agent (`hermes`), Nous Research's tool-calling agent CLI.
+Binary at `~/.local/bin/hermes` (managed install under `~/.hermes`); `~/.local/bin` must be on PATH.
+The interactive TUI is `hermes chat`, which takes NO positional prompt (verified: bare `hermes '<x>'` errors because the first positional is parsed as a subcommand, and `hermes chat '<x>'` errors as an unrecognized argument; `-q`/`-z` are one-shot non-interactive modes that exit).
+So firstmate launches `hermes chat --yolo` and delivers the brief as the first interactive message once the TUI is ready (see below).
+
+| Fact | Value |
+|---|---|
+| Busy-pane signature | `Ctrl+C cancel` (ASCII, in the input bar while a turn runs: `⚕ ❯ msg=interrupt · /queue · /bg · /steer · Ctrl+C cancel`). Idle composer shows a lone `❯`. The ASCII `Ctrl+C cancel` is the busy regex. |
+| Exit command | `/exit`. Prints `Resume this session with: hermes --resume <id>`. |
+| Interrupt | single `Ctrl+C` (the footer itself reads `Ctrl+C cancel`). |
+| Skill invocation | no `no-mistakes` slash skill (hermes has its own separate skills ecosystem); built-in slash commands are session controls (`/exit`, `/help`, `/queue`, `/bg`, `/steer`, `/rollback`). Use natural language to trigger validation. |
+| Autonomy | `--yolo` (banner shows a "YOLO mode, all approval prompts bypassed" line); bypasses hermes' dangerous-command approval prompts. |
+| Env marker | `HERMES_SESSION_ID` (set for every session; `bin/fm-harness.sh` matches this). Interactive sessions also set `HERMES_INTERACTIVE=1` and, under `--yolo`, `HERMES_YOLO_MODE=1`. |
+| Resume | `hermes --resume <id>` (id printed on exit) or `--continue`. |
+| Model / effort | model via `-m <model>`; a provider is encoded in the model string as `provider/model` (e.g. `deepseek/deepseek-v4-flash`) or set separately with `--provider`. No verified interactive effort flag, so `fm-spawn` records requested effort in meta and omits it. |
+
+Brief delivery (the key difference from every other adapter): because `hermes chat` accepts no positional prompt, `fm-spawn` sends `hermes chat --yolo`, waits for the readiness banner (`/help for commands`, about 5s), then delivers the brief as the first message.
+It sends a single-line pointer to the on-disk brief (`Your task brief is the file at <path>. Read it in full now and follow it ...`) rather than pasting the brief body: a single line submits cleanly with one Enter on every backend, whereas raw multi-line keystrokes submit line by line, and a tmux bracketed-paste that avoids that (verified to work on tmux) is not portable across backends.
+A plain first message submits on the first Enter (verified: no popup/placeholder hazard like grok/cursor).
+The crewmate's first action is to read its brief - the same brief content every other adapter receives inline.
+
+Turn-end hook: none is wired.
+hermes DOES expose a per-turn `stop` shell-hook event (fires at the end of every conversation turn), but wiring it requires declaring the hook in the user's global `~/.hermes/config.yaml` and clearing a first-use consent allowlist (`~/.hermes/shell-hooks-allowlist.json`) - a higher-blast-radius write into hermes' own managed config than grok's always-trusted `~/.grok/hooks/` drop-in.
+That precise per-turn wake is deferred; hermes' clear busy signature (`Ctrl+C cancel`) backs the provably-working check and stale-pane detection covers supervision, the same hookless path as opencode.
+The `--yolo` interactive TUI has no per-tool permission gate, so no trust/approval dialog appears after launch.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -200,7 +200,7 @@ If the captain expresses a standing dispatch preference such as "use grok for ne
 Crewmates default to the same harness you are running on.
 The captain may override the static default at any time, typically at bootstrap: record the choice in `config/crew-harness` (a single adapter name; absent or `default` means mirror your own harness).
 Resolve `default` with `bin/fm-harness.sh`; resolve the active static crewmate harness with `bin/fm-harness.sh crew`.
-Verified adapter names are `claude`, `codex`, `opencode`, `pi`, and `grok`.
+Verified adapter names are `claude`, `codex`, `opencode`, `pi`, `grok`, `cursor`, and `hermes`.
 
 ### Crew dispatch profiles
 

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -332,13 +332,13 @@ crew_dispatch_validate() {
     return 0
   fi
   err=$(jq -r '
-    def verified($h): ["claude","codex","opencode","pi","grok"] | index($h);
+    def verified($h): ["claude","codex","opencode","pi","grok","cursor","hermes"] | index($h);
     def effort_ok($h; $e):
       if $e == null then true
       elif ($e | type) != "string" then false
-      elif $h == "claude" then (["low","medium","high","xhigh","max"] | index($e))
+      elif ($h == "claude" or $h == "cursor") then (["low","medium","high","xhigh","max"] | index($e))
       elif ($h == "codex" or $h == "grok" or $h == "pi") then (["low","medium","high","xhigh"] | index($e))
-      elif $h == "opencode" then false
+      elif ($h == "opencode" or $h == "hermes") then false
       else true
       end;
     def bad_efforts:

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Detect the agent harness this process tree runs on.
-# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|grok|unknown
+# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|grok|cursor|hermes|unknown
 #        fm-harness.sh crew             print the effective CREWMATE harness
 #                                        (config/crew-harness; "default" resolves to own)
 #        fm-harness.sh secondmate       print the harness the PRIMARY uses to launch
@@ -29,8 +29,18 @@ CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
 
 detect_own() {
   # Layer 1: environment markers for verified harnesses.
+  # cursor (cursor-agent) is checked FIRST because it ALSO sets CLAUDECODE=1 and
+  # AI_AGENT=claude-code_* (it is Claude-Code-compatible under the hood), so a
+  # claude-first check would misdetect a cursor session as claude. CURSOR_AGENT=1
+  # is set only by cursor-agent (verified 2026-07-05, cursor-agent 2026.07.01).
+  [ "${CURSOR_AGENT:-}" = "1" ] && { echo cursor; return; }
   [ "${CLAUDECODE:-}" = "1" ] && { echo claude; return; }
   [ "${PI_CODING_AGENT:-}" = "true" ] && { echo pi; return; }
+  # hermes sets HERMES_SESSION_ID for every session (interactive and one-shot),
+  # plus HERMES_INTERACTIVE=1 and HERMES_YOLO_MODE=1 in the interactive TUI
+  # (verified 2026-07-05, Hermes Agent v0.18.0). HERMES_SESSION_ID is the most
+  # universal marker, so match it.
+  [ -n "${HERMES_SESSION_ID:-}" ] && { echo hermes; return; }
   # grok sets GROK_AGENT=1 for its child/tool processes (verified, grok 0.2.73).
   # It does NOT set CLAUDECODE despite being Claude-Code-compatible, so this marker
   # is unambiguous when firstmate runs natively on grok.
@@ -40,19 +50,23 @@ detect_own() {
   for _ in 1 2 3 4 5 6 7 8; do
     comm=$(ps -o comm= -p "$pid" 2>/dev/null) || break
     case "$(basename "$comm")" in
+      *cursor-agent*|*cursor*) echo cursor; return ;;
       *claude*) echo claude; return ;;
       *codex*) echo codex; return ;;
       *opencode*) echo opencode; return ;;
       *grok*) echo grok; return ;;
+      *hermes*) echo hermes; return ;;
       pi) echo pi; return ;;
       node*|python*)
         # Bare interpreter: match the harness name in its script path.
         args=$(ps -o args= -p "$pid" 2>/dev/null)
         case "$args" in
+          *cursor-agent*|*cursor*) echo cursor; return ;;
           *claude*) echo claude; return ;;
           *codex*) echo codex; return ;;
           *opencode*) echo opencode; return ;;
           *grok*) echo grok; return ;;
+          *hermes*) echo hermes; return ;;
           *" pi "*|*/pi) echo pi; return ;;
         esac ;;
     esac

--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -15,7 +15,8 @@ LOCK="$STATE/.lock"
 mkdir -p "$STATE"
 
 # Known harness command names; extend when a new adapter is verified.
-HARNESS_RE='claude|codex|opencode|grok|^pi$'
+# cursor matches cursor-agent's basename; hermes matches its own.
+HARNESS_RE='claude|codex|opencode|grok|cursor|hermes|^pi$'
 
 harness_pid() {
   local pid=$$ comm args

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -32,7 +32,7 @@
 #   profile consultation. A --secondmate spawn is exempt and resolves the SECONDMATE
 #   harness (config/secondmate-harness -> config/crew-harness -> own), so the
 #   secondmate-vs-crewmate split is DURABLE across every respawn (recovery,
-#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|grok)
+#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|grok|cursor|hermes)
 #   overrides it for this spawn (either kind). A non-flag string containing
 #   whitespace is treated as a RAW launch command - the escape hatch for verifying
 #   new adapters.
@@ -267,7 +267,7 @@ FIRSTMATE_HOME=
 
 if [ "$KIND" = secondmate ]; then
   case "${POS[1]:-}" in
-    ''|claude|codex|opencode|pi|grok)
+    ''|claude|codex|opencode|pi|grok|cursor|hermes)
       ARG3=${POS[1]:-}
       ;;
     *' '*)
@@ -328,6 +328,23 @@ launch_template() {
     # launch command - it is a Stop-event hook installed below (global hook +
     # per-task pointer), so the template is identical for ship/scout/secondmate.
     grok) printf '%s' 'grok --always-approve __MODELFLAG____EFFORTFLAG__"$(cat __BRIEF__)"' ;;
+    # cursor (cursor-agent): a positional prompt starts the supervised interactive
+    # session. --force (alias --yolo) runs every tool without the per-command
+    # allowlist approval dialog, which an unattended crewmate needs - the targeted
+    # equivalent of claude's --dangerously-skip-permissions. cursor's effort rides
+    # the model string as a bracket parameter (see model_flag_for_harness), so there
+    # is no __EFFORTFLAG__. No turn-end hook is wired (see the turn-end case below),
+    # so the template is identical for ship/scout/secondmate.
+    cursor) printf '%s' 'cursor-agent --force __MODELFLAG__"$(cat __BRIEF__)"' ;;
+    # hermes (Hermes Agent): the interactive TUI is `hermes chat`, which takes NO
+    # positional prompt (verified: bare `hermes '<x>'` and `hermes chat '<x>'` both
+    # error; -q/-z are one-shot non-interactive). So the brief is NOT in the launch
+    # command - it is delivered as the first interactive message after the TUI is
+    # ready (see the hermes post-launch block below). --yolo bypasses hermes'
+    # dangerous-command approval prompts for an unattended crewmate. hermes has no
+    # verified interactive effort flag, so there is no __EFFORTFLAG__ (requested
+    # effort is still recorded in meta). No turn-end hook is wired (stale-pane).
+    hermes) printf '%s' 'hermes chat --yolo __MODELFLAG__' ;;
     *) return 1 ;;
   esac
 }
@@ -412,11 +429,31 @@ shell_quote() {
 }
 
 model_flag_for_harness() {
-  local harness=$1 model=$2
+  local harness=$1 model=$2 effort=${3:-}
   [ -n "$model" ] && [ "$model" != default ] || return 0
   case "$harness" in
     claude|codex|opencode|pi|grok)
       printf -- '--model %s ' "$(shell_quote "$model")"
+      ;;
+    hermes)
+      # hermes selects the model with -m; a provider is encoded in the model string
+      # as "provider/model" (e.g. deepseek/deepseek-v4-flash), so firstmate's single
+      # --model axis maps cleanly without a separate provider axis.
+      printf -- '-m %s ' "$(shell_quote "$model")"
+      ;;
+    cursor)
+      # cursor has no standalone effort flag; effort rides the model string as a
+      # bracket parameter (e.g. 'claude-opus-4-8[effort=high]'), so it is folded in
+      # here rather than via effort_flag_for_harness. A model without bracket support
+      # ignores the parameter on cursor's side; when only effort (no model) is
+      # requested there is nothing to attach it to, so it is omitted and left
+      # recorded in meta - the same "record then omit" contract the other adapters use.
+      case "$effort" in
+        low|medium|high|xhigh|max)
+          printf -- '--model %s ' "$(shell_quote "${model}[effort=${effort}]")" ;;
+        *)
+          printf -- '--model %s ' "$(shell_quote "$model")" ;;
+      esac
       ;;
   esac
 }
@@ -456,6 +493,10 @@ effort_flag_for_harness() {
     # opencode's interactive `opencode --prompt` launch has a verified --model
     # flag but no verified effort flag. Its `opencode run --variant` flag belongs
     # to a different, non-interactive launch mode, so fm-spawn does not pass it.
+    # cursor has no standalone effort flag either: its effort is folded into the
+    # model string as a bracket parameter by model_flag_for_harness, so nothing is
+    # emitted here. hermes has no verified interactive effort flag, so it too emits
+    # nothing; the requested effort stays recorded in meta for both.
   esac
 }
 
@@ -785,6 +826,15 @@ spawn_send_key() {  # <target> <key>
     cmux) fm_backend_cmux_send_key "$1" "$2" "$W" ;;
   esac
 }
+spawn_capture() {  # <target> <lines> -> bounded plain-text pane capture
+  case "$BACKEND" in
+    tmux) fm_backend_tmux_capture "$1" "$2" ;;
+    herdr) fm_backend_herdr_capture "$1" "$2" ;;
+    zellij) fm_backend_zellij_capture "$1" "$2" ;;
+    orca) fm_backend_orca_capture "$1" "$2" ;;
+    cmux) fm_backend_cmux_capture "$1" "$2" ;;
+  esac
+}
 if [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   spawn_send_text_line "$T" 'treehouse get'
 
@@ -913,6 +963,23 @@ EOF
       printf 'token=%s\n' "${auth_file##*/}" > "$WT/.fm-grok-turnend"
       exclude_path '.fm-grok-turnend'
       ;;
+    cursor*)
+      # cursor: no turn-end hook is wired. cursor-agent is Claude-Code-compatible but
+      # its interactive Stop/turn-end hook surface is unverified, so firstmate does
+      # not assume one. cursor draws a clear busy footer ("ctrl+c to stop"), so the
+      # watcher's provably-working check and stale-pane detection cover supervision -
+      # the same hookless path opencode uses. Verified 2026-07-05, cursor-agent 2026.07.01.
+      ;;
+    hermes*)
+      # hermes: no turn-end hook is wired. hermes DOES expose a per-turn `stop` shell
+      # hook (fires at the end of every conversation turn), but wiring it requires
+      # declaring the hook in the user's global ~/.hermes/config.yaml and clearing a
+      # first-use consent allowlist - a higher-blast-radius write into hermes' own
+      # managed config than grok's always-trusted ~/.grok/hooks/ drop-in. That is
+      # deferred; hermes draws a clear busy footer ("Ctrl+C cancel"), so the watcher's
+      # provably-working check and stale-pane detection cover supervision, the same
+      # hookless path opencode uses. Verified 2026-07-05, Hermes Agent v0.18.0.
+      ;;
   esac
 fi
 
@@ -978,7 +1045,7 @@ META_WINDOW=$T
 sq_brief=$(shell_quote "$BRIEF")
 sq_turnend=$(shell_quote "$TURNEND")
 sq_piext=$(shell_quote "$STATE/$ID.pi-ext.ts")
-MODELFLAG=$(model_flag_for_harness "$HARNESS" "$MODEL")
+MODELFLAG=$(model_flag_for_harness "$HARNESS" "$MODEL" "$EFFORT")
 EFFORTFLAG=$(effort_flag_for_harness "$HARNESS" "$EFFORT")
 LAUNCH=${LAUNCH//__MODELFLAG__/$MODELFLAG}
 LAUNCH=${LAUNCH//__EFFORTFLAG__/$EFFORTFLAG}
@@ -997,5 +1064,32 @@ sleep 0.3
 spawn_send_literal "$T" "$LAUNCH"
 sleep 0.3
 spawn_send_key "$T" Enter
+
+# hermes: the interactive `hermes chat` TUI takes no positional prompt, so unlike
+# every other adapter the brief cannot ride the launch command. Deliver it as the
+# first interactive message once the TUI is ready. A single-line pointer to the
+# on-disk brief ($BRIEF, an absolute path) is used rather than pasting the brief's
+# multi-line body: a single line submits cleanly with one Enter on every backend
+# (verified 2026-07-05), whereas raw multi-line keystrokes would submit line by line
+# and a tmux bracketed-paste that avoids that is not portable across backends. The
+# crewmate's first action is to read its brief - the same brief content every other
+# adapter receives inline. Best-effort readiness wait: hermes prints its "/help for
+# commands" welcome banner when the composer is ready (about 5s).
+case "$HARNESS" in
+  hermes*)
+    hermes_ready=0
+    for _ in $(seq 1 40); do
+      if spawn_capture "$T" 60 2>/dev/null | grep -q '/help for commands'; then
+        hermes_ready=1
+        break
+      fi
+      sleep 1
+    done
+    [ "$hermes_ready" = 1 ] || echo "warning: hermes TUI readiness banner not seen within 40s; delivering brief anyway (inspect window $T)" >&2
+    spawn_send_literal "$T" "Your task brief is the file at $BRIEF. Read it in full now and follow it as your complete instructions; begin immediately."
+    sleep 0.3
+    spawn_send_key "$T" Enter
+    ;;
+esac
 
 echo "spawned $ID harness=$HARNESS kind=$KIND mode=$MODE yolo=$YOLO window=$META_WINDOW worktree=$WT"

--- a/bin/fm-tmux-lib.sh
+++ b/bin/fm-tmux-lib.sh
@@ -36,8 +36,11 @@
 
 # Busy footers per harness (mirror fm-watch.sh). claude/codex: "esc to
 # interrupt"; opencode: "esc interrupt"; pi: "Working..."; grok: "Ctrl+c:cancel"
-# (grok's mid-turn cancel hint, shown iff a turn is running - verified grok 0.2.73).
-FM_TMUX_BUSY_REGEX_DEFAULT='esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel'
+# (grok's mid-turn cancel hint, shown iff a turn is running - verified grok 0.2.73);
+# cursor: "ctrl+c to stop" (footer while a turn runs - verified cursor-agent
+# 2026.07.01); hermes: "Ctrl+C cancel" (the mid-turn cancel hint in its input bar -
+# verified Hermes Agent v0.18.0). Matched case-insensitively (grep -qiE).
+FM_TMUX_BUSY_REGEX_DEFAULT='esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel|ctrl\+c to stop|Ctrl\+C cancel'
 
 # fm_tmux_strip_ghost: remove dim/faint (ANSI SGR 2) styled runs from one captured
 # composer line, then drop any remaining escape sequences, leaving only the plain,

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -110,8 +110,11 @@ SIGNAL_GRACE=${FM_SIGNAL_GRACE:-30}   # seconds to linger after a signal so trai
 # claude/codex: "esc to interrupt"; opencode: "esc interrupt"; pi: "Working...";
 # grok: "Ctrl+c:cancel" (the mid-turn cancel hint in grok's keybind bar, shown iff a
 # turn is running; absent when idle - verified grok 0.2.73, ASCII to avoid the
-# locale fragility of matching grok's braille spinner glyph directly).
-BUSY_REGEX=${FM_BUSY_REGEX:-'esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel'}
+# locale fragility of matching grok's braille spinner glyph directly);
+# cursor: "ctrl+c to stop" (footer while a turn runs - verified cursor-agent
+# 2026.07.01); hermes: "Ctrl+C cancel" (the mid-turn cancel hint in its input bar -
+# verified Hermes Agent v0.18.0). All matched case-insensitively.
+BUSY_REGEX=${FM_BUSY_REGEX:-'esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel|ctrl\+c to stop|Ctrl\+C cancel'}
 # Always-on wake triage: most wakes during a long crew validation are benign (a
 # working: note or turn-end while a pipeline runs, a no-change heartbeat). Rather
 # than wake firstmate's LLM for each, this watcher classifies every wake in bash

--- a/tests/fm-cursor-hermes-harness.test.sh
+++ b/tests/fm-cursor-hermes-harness.test.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+set -u
+
+# Detection, launch mechanics, and busy signatures for the cursor (cursor-agent)
+# and hermes (Hermes Agent) harness adapters. Mirrors tests/fm-grok-harness.test.sh:
+# a fake tmux stands in for the backend, and the launch command typed into the pane
+# is captured to a send-log so the template, autonomy flag, model/effort flags, and
+# (for hermes) the post-launch brief delivery can be asserted without a live agent.
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SPAWN="$ROOT/bin/fm-spawn.sh"
+HARNESS="$ROOT/bin/fm-harness.sh"
+TMP_ROOT=$(fm_test_tmproot fm-cursor-hermes-harness)
+
+# Fake tmux that logs every send-keys payload to $FM_TEST_SENDLOG and answers the
+# reads fm-spawn makes: pane_current_path (worktree entry poll) and capture-pane
+# (hermes readiness banner). Everything else is a no-op exit 0.
+make_spawn_fakebin() {
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+esac
+case "${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+  capture-pane)
+    # hermes readiness poll greps for this welcome banner line.
+    printf 'Welcome to Hermes Agent! Type your message or /help for commands.\n'
+    exit 0 ;;
+  send-keys)
+    [ -n "${FM_TEST_SENDLOG:-}" ] && printf '%s\n' "$*" >> "$FM_TEST_SENDLOG"
+    exit 0 ;;
+  list-windows) exit 0 ;;
+  has-session|new-session|new-window|kill-window) exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" treehouse gh-axi gh
+  printf '%s\n' "$fakebin"
+}
+
+make_spawn_case() {
+  local name=$1 case_dir home proj wt fakebin id
+  case_dir="$TMP_ROOT/$name"
+  home="$case_dir/home"
+  proj="$case_dir/project"
+  wt="$case_dir/wt"
+  fakebin=$(make_spawn_fakebin "$case_dir/fake")
+  id="ch-$name-x1"
+  mkdir -p "$home/data/$id" "$home/projects" "$home/state" "$home/config"
+  printf 'brief body\n' > "$home/data/$id/brief.md"
+  fm_git_worktree "$proj" "$wt" "fm/$id"
+  touch "$home/state/.last-watcher-beat"
+  printf '%s\n' "$case_dir|$home|$proj|$wt|$fakebin|$id"
+}
+
+run_spawn() {  # <home> <proj> <wt> <fakebin> <sendlog> <id> <extra-args...>
+  local home=$1 proj=$2 wt=$3 fakebin=$4 sendlog=$5 id=$6
+  shift 6
+  FM_ROOT_OVERRIDE='' FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
+    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" TMUX="fake,1,0" \
+    FM_TEST_SENDLOG="$sendlog" PATH="$fakebin:$PATH" \
+    "$SPAWN" "$id" "$proj" "$@" 2>&1
+}
+
+# --- detection --------------------------------------------------------------
+
+test_detects_cursor_before_claude() {
+  local out
+  # cursor-agent ALSO sets CLAUDECODE=1; the cursor marker must win.
+  out=$(env -i CURSOR_AGENT=1 CLAUDECODE=1 bash "$HARNESS")
+  expect_code 0 $? "fm-harness cursor detection should exit 0"
+  [ "$out" = cursor ] || fail "cursor+claude markers detected as '$out', expected cursor"
+  out=$(env -i CLAUDECODE=1 bash "$HARNESS")
+  [ "$out" = claude ] || fail "claude marker alone detected as '$out', expected claude"
+  pass "CURSOR_AGENT wins over CLAUDECODE"
+}
+
+test_detects_hermes() {
+  local out
+  out=$(env -i HERMES_SESSION_ID=20260705_x bash "$HARNESS")
+  [ "$out" = hermes ] || fail "HERMES_SESSION_ID detected as '$out', expected hermes"
+  out=$(env -i HERMES_INTERACTIVE=1 HERMES_SESSION_ID=x bash "$HARNESS")
+  [ "$out" = hermes ] || fail "interactive hermes detected as '$out', expected hermes"
+  pass "hermes detected from HERMES_SESSION_ID"
+}
+
+test_resolves_as_crew_and_secondmate() {
+  local cfg
+  cfg="$TMP_ROOT/resolve-config"
+  mkdir -p "$cfg"
+  printf 'cursor\n' > "$cfg/crew-harness"
+  [ "$(FM_CONFIG_OVERRIDE=$cfg bash "$HARNESS" crew)" = cursor ] \
+    || fail "crew-harness=cursor did not resolve to cursor"
+  printf 'hermes\n' > "$cfg/secondmate-harness"
+  [ "$(FM_CONFIG_OVERRIDE=$cfg bash "$HARNESS" secondmate)" = hermes ] \
+    || fail "secondmate-harness=hermes did not resolve to hermes"
+  pass "cursor/hermes resolve as crew and secondmate harnesses"
+}
+
+# --- cursor launch mechanics ------------------------------------------------
+
+test_cursor_launch_template() {
+  local rec case_dir home proj wt fakebin id sendlog out
+  rec=$(make_spawn_case cursor-launch)
+  IFS='|' read -r case_dir home proj wt fakebin id <<EOF
+$rec
+EOF
+  sendlog="$case_dir/sendlog"
+  out=$(run_spawn "$home" "$proj" "$wt" "$fakebin" "$sendlog" "$id" cursor)
+  expect_code 0 $? "cursor spawn should succeed"
+  assert_contains "$out" "spawned $id harness=cursor" "cursor spawn did not report success"
+  assert_grep "harness=cursor" "$home/state/$id.meta" "meta did not record harness=cursor"
+  assert_grep "cursor-agent --force " "$sendlog" "cursor launch command missing --force autonomy flag"
+  # cursor is hookless (stale-pane): no worktree turn-end hook file is written, and
+  # in particular NOT claude's Stop hook (cursor is Claude-Code-compatible under the hood).
+  assert_absent "$wt/.claude/settings.local.json" "cursor wrongly installed a claude Stop hook"
+  assert_absent "$wt/.fm-grok-turnend" "cursor wrongly installed a grok pointer"
+  # No hermes post-launch brief pointer for a cursor spawn (the brief rides the launch command).
+  assert_no_grep "Your task brief is the file at" "$sendlog" "cursor wrongly got a hermes-style brief pointer"
+  pass "cursor launches with --force and no turn-end hook"
+}
+
+test_cursor_model_effort_bracket() {
+  local rec case_dir home proj wt fakebin id sendlog
+  rec=$(make_spawn_case cursor-model)
+  IFS='|' read -r case_dir home proj wt fakebin id <<EOF
+$rec
+EOF
+  sendlog="$case_dir/sendlog"
+  run_spawn "$home" "$proj" "$wt" "$fakebin" "$sendlog" "$id" \
+    cursor --model composer-2.5 --effort high >/dev/null
+  expect_code 0 $? "cursor spawn with model+effort should succeed"
+  # cursor folds effort into the model string as a bracket parameter.
+  assert_grep "--model 'composer-2.5[effort=high]'" "$sendlog" \
+    "cursor did not fold effort into the model bracket"
+  assert_grep "model=composer-2.5" "$home/state/$id.meta" "meta did not record the cursor model"
+  assert_grep "effort=high" "$home/state/$id.meta" "meta did not record the requested cursor effort"
+  pass "cursor maps --effort onto the model bracket form"
+}
+
+# --- hermes launch mechanics ------------------------------------------------
+
+test_hermes_launch_and_brief_delivery() {
+  local rec case_dir home proj wt fakebin id sendlog out
+  rec=$(make_spawn_case hermes-launch)
+  IFS='|' read -r case_dir home proj wt fakebin id <<EOF
+$rec
+EOF
+  sendlog="$case_dir/sendlog"
+  out=$(run_spawn "$home" "$proj" "$wt" "$fakebin" "$sendlog" "$id" hermes)
+  expect_code 0 $? "hermes spawn should succeed"
+  assert_contains "$out" "spawned $id harness=hermes" "hermes spawn did not report success"
+  assert_grep "harness=hermes" "$home/state/$id.meta" "meta did not record harness=hermes"
+  # The interactive TUI is `hermes chat --yolo` with NO positional brief.
+  assert_grep "hermes chat --yolo" "$sendlog" "hermes launch command wrong"
+  assert_no_grep 'hermes chat --yolo -m' "$sendlog" "hermes launch wrongly carried a model flag when none was set"
+  # The brief is delivered as the first interactive message, pointing at the on-disk brief.
+  assert_grep "Your task brief is the file at $home/data/$id/brief.md" "$sendlog" \
+    "hermes did not deliver the post-launch brief pointer"
+  # hermes is hookless (stale-pane): no worktree turn-end hook file.
+  assert_absent "$wt/.claude/settings.local.json" "hermes wrongly installed a claude Stop hook"
+  assert_absent "$wt/.fm-grok-turnend" "hermes wrongly installed a grok pointer"
+  pass "hermes launches via chat --yolo and delivers the brief as the first message"
+}
+
+test_hermes_model_flag() {
+  local rec case_dir home proj wt fakebin id sendlog
+  rec=$(make_spawn_case hermes-model)
+  IFS='|' read -r case_dir home proj wt fakebin id <<EOF
+$rec
+EOF
+  sendlog="$case_dir/sendlog"
+  run_spawn "$home" "$proj" "$wt" "$fakebin" "$sendlog" "$id" \
+    hermes --model 'deepseek/deepseek-v4-flash' >/dev/null
+  expect_code 0 $? "hermes spawn with model should succeed"
+  assert_grep "hermes chat --yolo -m 'deepseek/deepseek-v4-flash'" "$sendlog" \
+    "hermes did not wire --model onto -m (provider encoded in the model string)"
+  pass "hermes wires firstmate --model onto -m"
+}
+
+# --- busy signatures --------------------------------------------------------
+
+test_busy_signatures_match() {
+  # shellcheck source=bin/fm-tmux-lib.sh
+  . "$ROOT/bin/fm-tmux-lib.sh"
+  local re=$FM_TMUX_BUSY_REGEX_DEFAULT
+  printf '%s\n' '  → Add a follow-up                    ctrl+c to stop' | grep -qiE "$re" \
+    || fail "cursor busy footer 'ctrl+c to stop' not matched"
+  printf '%s\n' '⚕ ❯ msg=interrupt · /queue · /bg · /steer · Ctrl+C cancel' | grep -qiE "$re" \
+    || fail "hermes busy footer 'Ctrl+C cancel' not matched"
+  # Idle footers must not read as busy.
+  printf '%s\n' '  → Add a follow-up' | grep -qiE "$re" \
+    && fail "cursor idle footer wrongly matched busy" || :
+  printf '%s\n' '❯' | grep -qiE "$re" \
+    && fail "hermes idle prompt wrongly matched busy" || :
+  pass "cursor/hermes busy signatures registered in the default busy regex"
+}
+
+# --- lock live-holder recognition -------------------------------------------
+
+test_fm_lock_recognizes_holders() {
+  local harness comm home fakebin out
+  for harness in cursor hermes; do
+    home="$TMP_ROOT/lock-$harness"
+    fakebin=$(fm_fakebin "$TMP_ROOT/lock-fake-$harness")
+    mkdir -p "$home/state"
+    printf '%s\n' "$$" > "$home/state/.lock"
+    # cursor's process basename is cursor-agent; hermes' is hermes.
+    comm="/usr/local/bin/$harness"
+    [ "$harness" = cursor ] && comm="/home/u/.local/bin/cursor-agent"
+    cat > "$fakebin/ps" <<SH
+#!/usr/bin/env bash
+case "\$*" in
+  *"comm="*) printf '%s\n' '$comm'; exit 0 ;;
+  *"args="*) printf '%s\n' '$harness'; exit 0 ;;
+esac
+exit 1
+SH
+    chmod +x "$fakebin/ps"
+    out=$(FM_HOME="$home" PATH="$fakebin:$PATH" "$ROOT/bin/fm-lock.sh" status)
+    assert_contains "$out" "lock: held by live harness pid" \
+      "fm-lock did not recognize $harness as a live holder"
+  done
+  pass "fm-lock recognizes cursor and hermes harness processes"
+}
+
+test_detects_cursor_before_claude
+test_detects_hermes
+test_fm_lock_recognizes_holders
+test_resolves_as_crew_and_secondmate
+test_cursor_launch_template
+test_cursor_model_effort_bracket
+test_hermes_launch_and_brief_delivery
+test_hermes_model_flag
+test_busy_signatures_match


### PR DESCRIPTION
Adds two verified harness adapters — `cursor` (Cursor `cursor-agent`) and `hermes` (Nous Research `hermes`) — to firstmate's harness system, so crewmates and secondmates can be spawned on them like the existing claude/codex/grok/pi/opencode adapters.

All mechanics verified live 2026-07-05: detection env markers, busy-pane signatures, model/effort flags, interrupt/exit, resume, and the tmux submit-retry behavior. 703 assertions green; shellcheck clean; adapter knowledge recorded in the harness-adapters skill; both added to the verified-adapter list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)