### PR TITLE
feat(bin): fm-coderabbit-poll.sh — hourly host-cron CodeRabbit review babysitter

### DIFF
--- a/bin/fm-coderabbit-poll.sh
+++ b/bin/fm-coderabbit-poll.sh
@@ -88,6 +88,63 @@ actionable_count() {
     || printf '0'
 }
 
+# CodeRabbit ships two bot users: coderabbitai[bot] (paid) and coderabbit-oss[bot]
+# (public OSS variant, per-user rate limits).  Match either everywhere so the
+# poll serves both a captain's own repos and OSS repos they contribute to.
+BOT_JQ_FILTER='.user.login=="coderabbitai[bot]" or .user.login=="coderabbit-oss[bot]"'
+
+# Turn a bot login into the @mention handle used to request a review.
+mention_for_bot() {
+  case "$1" in
+    "coderabbit-oss[bot]") printf '@coderabbit-oss' ;;
+    *) printf '@coderabbitai' ;;
+  esac
+}
+
+# Look at the newest bot activity on the PR (review OR issue comment) and
+# report which bot to talk to.  Fallback: paid coderabbitai[bot], matching the
+# historical default before the OSS variant existed.
+detect_bot_login() {
+  local owner=$1 repo=$2 pr_num=$3
+  local latest login
+  latest=$(gh api "repos/$owner/$repo/issues/$pr_num/comments" \
+    --jq "[.[] | select($BOT_JQ_FILTER)] | max_by(.created_at) // empty" \
+    2>/dev/null) || true
+  if [ -n "$latest" ] && [ "$latest" != "null" ]; then
+    login=$(printf '%s' "$latest" | jq -r '.user.login')
+    if [ -n "$login" ] && [ "$login" != "null" ]; then
+      printf '%s' "$login"
+      return 0
+    fi
+  fi
+  printf 'coderabbitai[bot]'
+}
+
+# Check the newest bot issue comment for CodeRabbit's "Review limit reached"
+# cooldown notice.  Prints a short human note to stdout and returns 0 when
+# cooldown is active (caller should skip the request); returns 1 when clear.
+bot_cooldown_active() {
+  local owner=$1 repo=$2 pr_num=$3
+  local comment body countdown
+  comment=$(gh api "repos/$owner/$repo/issues/$pr_num/comments" \
+    --jq "[.[] | select($BOT_JQ_FILTER)] | max_by(.created_at) // empty" \
+    2>/dev/null) || return 1
+  if [ -z "$comment" ] || [ "$comment" = "null" ]; then
+    return 1
+  fi
+  body=$(printf '%s' "$comment" | jq -r '.body // ""')
+  if ! printf '%s' "$body" | grep -qi 'Review limit reached'; then
+    return 1
+  fi
+  countdown=$(printf '%s' "$body" | grep -oiE '[0-9]+ (minute|hour|second)s?' | head -1 || true)
+  if [ -n "$countdown" ]; then
+    printf 'next review available in %s' "$countdown"
+  else
+    printf 'cooldown active'
+  fi
+  return 0
+}
+
 # Find a firstmate project clone that matches the target repo, or fall back to
 # any project (the crewmate does real work in a scratch clone regardless).
 resolve_project() {
@@ -196,7 +253,7 @@ process_pr() {
 
   local latest_review
   latest_review=$(gh api "repos/$owner/$repo/pulls/$pr_num/reviews" \
-    --jq '[.[] | select(.user.login=="coderabbitai[bot]")] | max_by(.submitted_at) // empty' \
+    --jq "[.[] | select($BOT_JQ_FILTER)] | max_by(.submitted_at) // empty" \
     2>/dev/null) || return 0
 
   if [ -z "$latest_review" ] || [ "$latest_review" = "null" ]; then
@@ -204,11 +261,21 @@ process_pr() {
     # done so this cycle (the free-tier quota is org-wide, so we can spend at
     # most one review request per fire before waiting for the next hour).
     if [ "${REVIEW_REQUESTED_THIS_CYCLE:-0}" -eq 0 ]; then
-      log "$url: no CodeRabbit review yet - requesting @coderabbitai review"
-      if gh pr comment "$pr_num" --repo "$owner/$repo" --body '@coderabbitai review' >/dev/null 2>&1; then
+      # Skip when CodeRabbit itself just told us it is in cooldown -
+      # otherwise every hourly fire burns a queued-request slot for nothing.
+      local cooldown
+      if cooldown=$(bot_cooldown_active "$owner" "$repo" "$pr_num"); then
+        log "$url: CodeRabbit cooldown - $cooldown, skipping request"
+        return 0
+      fi
+      local bot_login mention
+      bot_login=$(detect_bot_login "$owner" "$repo" "$pr_num")
+      mention=$(mention_for_bot "$bot_login")
+      log "$url: no CodeRabbit review yet - requesting $mention review"
+      if gh pr comment "$pr_num" --repo "$owner/$repo" --body "$mention review" >/dev/null 2>&1; then
         REVIEW_REQUESTED_THIS_CYCLE=1
       else
-        warn "$url: failed to post @coderabbitai review request"
+        warn "$url: failed to post $mention review request"
       fi
     else
       log "$url: no review yet, but quota already spent this cycle - will retry next hour"

--- a/bin/fm-coderabbit-poll.sh
+++ b/bin/fm-coderabbit-poll.sh
@@ -132,9 +132,11 @@ The FULL review body is at $brief_dir/review.md — read it once, then decide wh
 5. For each actionable finding, verify against current code (files may have moved since the review), then either:
    - Fix it with a focused commit if the finding is still valid and the fix is uncontroversial (docs, one-line code, straightforward test tweak), OR
    - Decline it with a brief PR comment via \`gh pr comment $pr_num --repo $owner/$repo --body "..."\` if it is stylistic disagreement, out of scope, already addressed, or judgment-heavy.
-6. If you made commits, push: \`git push origin \$(git branch --show-current)\`. Then post a single summary PR comment listing which findings were fixed (with commit shas) and which were declined (with brief reasons).
-7. If you made NO commits (declined everything), still post one summary PR comment listing what was declined and why.
+6. If you made commits, push: \`git push origin \$(git branch --show-current)\`. Then post a single summary PR comment listing which findings were fixed (with commit shas) and which were declined (with brief reasons). AFTER that summary comment, request CodeRabbit re-review by posting a second comment: \`gh pr comment $pr_num --repo $owner/$repo --body "@coderabbitai review"\`. Do NOT ping \`@coderabbitai\` if you made no commits — a re-review with no code change wastes org quota.
+7. If you made NO commits (declined everything), still post one summary PR comment listing what was declined and why. Do NOT request re-review.
 8. Append \`done: <one-line summary>\` to /home/dep/tools/firstmate/state/$id.status and stop.
+
+CodeRabbit rate-limit note: the free-tier is 1 review per hour org-wide. If you post \`@coderabbitai review\` and CodeRabbit is within the cooldown, it will queue the request or respond with a countdown — that's fine, do NOT try to interpret or wait for the countdown yourself. Just post once and finish. The next hourly cron fire will pick up whatever CodeRabbit posts in response.
 
 ## Hard rules
 - Docs and minor fixes only. Do NOT rewrite production code unless the fix is a one-liner and clearly correct.

--- a/bin/fm-coderabbit-poll.sh
+++ b/bin/fm-coderabbit-poll.sh
@@ -160,8 +160,21 @@ BRIEF
     return 1
   fi
 
+  # Harness and model come from environment; both are optional. When
+  # FM_CODERABBIT_POLL_HARNESS is unset, we default to `opencode` (public,
+  # part of any firstmate install). When FM_CODERABBIT_POLL_MODEL is unset,
+  # we do NOT pass --model at all, so fm-spawn resolves the model through
+  # its normal precedence chain (config/crew-dispatch.json, then the harness
+  # default). This keeps the script generic and avoids leaking any operator's
+  # private tier names or endpoints.
+  local harness_flag=(--harness "${FM_CODERABBIT_POLL_HARNESS:-opencode}")
+  local model_flag=()
+  if [ -n "${FM_CODERABBIT_POLL_MODEL:-}" ]; then
+    model_flag=(--model "$FM_CODERABBIT_POLL_MODEL")
+  fi
+
   log "spawning $id (project=$project) for $url review $review_id"
-  "$FM_ROOT/bin/fm-spawn.sh" "$id" "$project" --harness opencode --model litellm/coder
+  "$FM_ROOT/bin/fm-spawn.sh" "$id" "$project" "${harness_flag[@]}" "${model_flag[@]}"
 }
 
 process_pr() {

--- a/bin/fm-coderabbit-poll.sh
+++ b/bin/fm-coderabbit-poll.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+# fm-coderabbit-poll.sh
+#
+# Poll PRs listed in $FM_HOME/data/coderabbit-queue.txt for new CodeRabbit
+# reviews.  For each new actionable review found, spawn a scoped crewmate to
+# address it.  Designed to run periodically via host cron (hourly recommended,
+# matching CodeRabbit free-tier's org-wide 1-review-per-hour rate limit).
+#
+# Uses flock so overlapping fires never double-spawn.  Watermarks per PR keep
+# already-processed reviews from being re-dispatched.
+#
+# See docs/coderabbit-poll.md for full details, queue-file format, and the
+# recommended crontab line.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+DATA="$FM_HOME/data"
+
+QUEUE_FILE="$DATA/coderabbit-queue.txt"
+WATERMARK_FILE="$STATE/coderabbit-watermarks.tsv"
+LOCK_FILE="$STATE/coderabbit-poll.lock"
+LOG_TAG="[fm-coderabbit-poll]"
+
+log() { printf '%s %s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$LOG_TAG" "$*"; }
+warn() { log "$*" >&2; }
+
+if [ ! -f "$QUEUE_FILE" ]; then
+  # No queue file = nothing to do.  This is the normal resting state on a
+  # captain who has not enabled the poll yet.  Silent success.
+  exit 0
+fi
+if ! command -v gh >/dev/null 2>&1; then
+  warn "error: gh CLI not installed or not on PATH"
+  exit 1
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  warn "error: jq not installed"
+  exit 1
+fi
+if ! command -v flock >/dev/null 2>&1; then
+  warn "error: flock not available"
+  exit 1
+fi
+
+mkdir -p "$STATE"
+touch "$WATERMARK_FILE"
+
+# Non-blocking lock: overlapping fires just skip.  With hourly cron this should
+# never trigger, but a long crewmate spawn or a manual test could hold the lock.
+exec {LOCK_FD}> "$LOCK_FILE"
+if ! flock -n "$LOCK_FD"; then
+  log "previous poll still holding lock, skipping this fire"
+  exit 0
+fi
+
+read_queue() {
+  # Skip blank lines and #-comments.
+  grep -Ev '^[[:space:]]*(#|$)' "$QUEUE_FILE" || true
+}
+
+watermark_get() {
+  awk -F'\t' -v u="$1" '$1==u{print $2; exit}' "$WATERMARK_FILE"
+}
+
+watermark_set() {
+  # $1 url, $2 iso-timestamp.  Overwrites existing row for url, appends if new.
+  local url=$1 ts=$2 tmp
+  tmp=$(mktemp)
+  awk -F'\t' -v u="$url" -v t="$ts" '$1!=u{print} END{print u"\t"t}' \
+    "$WATERMARK_FILE" > "$tmp"
+  mv "$tmp" "$WATERMARK_FILE"
+}
+
+# For the crewmate task id we sanitize the repo name.  Numeric review ids from
+# GitHub's API are fine as-is.
+sanitize_slug() { printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9-' '-' | sed -E 's/-+/-/g; s/^-|-$//g'; }
+
+# Extract "Actionable comments posted: N" from CodeRabbit review body.  Returns
+# 0 (no findings) when the marker is absent.
+actionable_count() {
+  printf '%s' "$1" \
+    | grep -oE 'Actionable comments posted: [0-9]+' \
+    | head -1 \
+    | grep -oE '[0-9]+$' \
+    || printf '0'
+}
+
+# Find a firstmate project clone that matches the target repo, or fall back to
+# any project (the crewmate does real work in a scratch clone regardless).
+resolve_project() {
+  local repo=$1 match
+  match=$(find "$FM_HOME/projects" -maxdepth 1 -mindepth 1 -type d -name "$repo" 2>/dev/null | head -1 || true)
+  if [ -n "$match" ]; then
+    printf '%s' "$match"
+    return 0
+  fi
+  match=$(find "$FM_HOME/projects" -maxdepth 1 -mindepth 1 -type d 2>/dev/null | head -1 || true)
+  if [ -n "$match" ]; then
+    printf '%s' "$match"
+    return 0
+  fi
+  return 1
+}
+
+spawn_fix_crewmate() {
+  local owner=$1 repo=$2 pr_num=$3 url=$4 review_id=$5 review_body=$6
+
+  local repo_slug id brief_dir
+  repo_slug=$(sanitize_slug "$repo")
+  id="cr-$repo_slug-pr$pr_num-$review_id"
+  brief_dir="$DATA/$id"
+  mkdir -p "$brief_dir"
+
+  printf '%s' "$review_body" > "$brief_dir/review.md"
+
+  cat > "$brief_dir/brief.md" <<BRIEF
+You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
+
+# Task
+CodeRabbit posted a new actionable review on $url. Address the actionable findings, push the fixes if any, and stop.
+
+The FULL review body is at $brief_dir/review.md — read it once, then decide which findings to fix and which to decline. Do NOT re-query CodeRabbit; this review is what you are responding to.
+
+## Do these in order
+1. Verify you are in an isolated treehouse worktree — \`pwd -P\` and \`git rev-parse --show-toplevel\` should both resolve to a treehouse pool path, not the firstmate root.
+2. Clone the target repo INSIDE your worktree: \`gh repo clone $owner/$repo ./scratch\` then \`cd scratch\`.
+3. Fetch and check out the PR branch: \`gh pr checkout $pr_num --repo $owner/$repo\`.
+4. Read \`$brief_dir/review.md\` — the exact CodeRabbit review body.
+5. For each actionable finding, verify against current code (files may have moved since the review), then either:
+   - Fix it with a focused commit if the finding is still valid and the fix is uncontroversial (docs, one-line code, straightforward test tweak), OR
+   - Decline it with a brief PR comment via \`gh pr comment $pr_num --repo $owner/$repo --body "..."\` if it is stylistic disagreement, out of scope, already addressed, or judgment-heavy.
+6. If you made commits, push: \`git push origin \$(git branch --show-current)\`. Then post a single summary PR comment listing which findings were fixed (with commit shas) and which were declined (with brief reasons).
+7. If you made NO commits (declined everything), still post one summary PR comment listing what was declined and why.
+8. Append \`done: <one-line summary>\` to /home/dep/tools/firstmate/state/$id.status and stop.
+
+## Hard rules
+- Docs and minor fixes only. Do NOT rewrite production code unless the fix is a one-liner and clearly correct.
+- Never merge the PR. The captain merges.
+- Never force-push. Never rebase-and-force.
+- If CodeRabbit asks for something destructive, judgment-heavy, or scope-creep (architecture change, dep bumps, refactor), decline in a PR comment with a brief reason and move on. Do NOT wake firstmate for this.
+- Only append \`blocked:\` or \`needs-decision:\` if you literally cannot proceed (auth failure, repo gone, tools missing). Ordinary "hard call about whether to fix" is a decline-with-comment, not an escalation.
+
+## Setup
+You are in a disposable git worktree. Do NOT commit or edit inside the pool worktree's own tracked files — all real work happens in \`./scratch\` you clone yourself.
+
+## Rules
+1. Never merge the PR.
+2. Report status via \`echo "{state}: {short line}" >> "/home/dep/tools/firstmate/state/$id.status"\` — states: working, needs-decision, blocked, done, failed. Append sparingly.
+3. If you hit the same obstacle twice, append \`blocked: {why}\` and stop.
+BRIEF
+
+  local project
+  if ! project=$(resolve_project "$repo"); then
+    warn "no project clone available under $FM_HOME/projects — cannot spawn crewmate for $url"
+    return 1
+  fi
+
+  log "spawning $id (project=$project) for $url review $review_id"
+  "$FM_ROOT/bin/fm-spawn.sh" "$id" "$project" --harness opencode --model litellm/coder
+}
+
+process_pr() {
+  local url=$1
+  if ! [[ "$url" =~ ^https://github\.com/([^/]+)/([^/]+)/pull/([0-9]+)$ ]]; then
+    warn "skipping malformed queue entry: $url"
+    return 0
+  fi
+  local owner="${BASH_REMATCH[1]}" repo="${BASH_REMATCH[2]}" pr_num="${BASH_REMATCH[3]}"
+
+  local latest_review
+  latest_review=$(gh api "repos/$owner/$repo/pulls/$pr_num/reviews" \
+    --jq '[.[] | select(.user.login=="coderabbitai[bot]")] | max_by(.submitted_at) // empty' \
+    2>/dev/null) || return 0
+  if [ -z "$latest_review" ] || [ "$latest_review" = "null" ]; then
+    return 0
+  fi
+
+  local review_ts review_id review_body
+  review_ts=$(printf '%s' "$latest_review" | jq -r '.submitted_at')
+  review_id=$(printf '%s' "$latest_review" | jq -r '.id')
+  review_body=$(printf '%s' "$latest_review" | jq -r '.body // ""')
+
+  local wm
+  wm=$(watermark_get "$url")
+  if [ "$review_ts" = "$wm" ]; then
+    return 0
+  fi
+
+  local actionable
+  actionable=$(actionable_count "$review_body")
+  if [ "${actionable:-0}" -eq 0 ]; then
+    log "$url: new review $review_id has 0 actionable findings — advancing watermark, no crewmate"
+    watermark_set "$url" "$review_ts"
+    return 0
+  fi
+
+  if spawn_fix_crewmate "$owner" "$repo" "$pr_num" "$url" "$review_id" "$review_body"; then
+    watermark_set "$url" "$review_ts"
+  else
+    warn "spawn failed for $url review $review_id — watermark NOT advanced, will retry next fire"
+  fi
+}
+
+while IFS= read -r url; do
+  [ -z "$url" ] && continue
+  process_pr "$url" || warn "unhandled error processing $url"
+done < <(read_queue)
+
+log "poll cycle complete"

--- a/bin/fm-coderabbit-poll.sh
+++ b/bin/fm-coderabbit-poll.sh
@@ -185,11 +185,34 @@ process_pr() {
   fi
   local owner="${BASH_REMATCH[1]}" repo="${BASH_REMATCH[2]}" pr_num="${BASH_REMATCH[3]}"
 
+  # PR state: skip closed/merged so we do not consume the org's CodeRabbit
+  # quota requesting reviews on already-landed work.
+  local pr_state
+  pr_state=$(gh api "repos/$owner/$repo/pulls/$pr_num" --jq '.state' 2>/dev/null) || return 0
+  if [ "$pr_state" != "open" ]; then
+    log "$url: state=$pr_state, skipping"
+    return 0
+  fi
+
   local latest_review
   latest_review=$(gh api "repos/$owner/$repo/pulls/$pr_num/reviews" \
     --jq '[.[] | select(.user.login=="coderabbitai[bot]")] | max_by(.submitted_at) // empty' \
     2>/dev/null) || return 0
+
   if [ -z "$latest_review" ] || [ "$latest_review" = "null" ]; then
+    # No CodeRabbit review yet.  Request one, but only if we have not already
+    # done so this cycle (the free-tier quota is org-wide, so we can spend at
+    # most one review request per fire before waiting for the next hour).
+    if [ "${REVIEW_REQUESTED_THIS_CYCLE:-0}" -eq 0 ]; then
+      log "$url: no CodeRabbit review yet - requesting @coderabbitai review"
+      if gh pr comment "$pr_num" --repo "$owner/$repo" --body '@coderabbitai review' >/dev/null 2>&1; then
+        REVIEW_REQUESTED_THIS_CYCLE=1
+      else
+        warn "$url: failed to post @coderabbitai review request"
+      fi
+    else
+      log "$url: no review yet, but quota already spent this cycle - will retry next hour"
+    fi
     return 0
   fi
 
@@ -201,21 +224,23 @@ process_pr() {
   local wm
   wm=$(watermark_get "$url")
   if [ "$review_ts" = "$wm" ]; then
+    log "$url: review $review_id already processed (watermark match)"
     return 0
   fi
 
   local actionable
   actionable=$(actionable_count "$review_body")
   if [ "${actionable:-0}" -eq 0 ]; then
-    log "$url: new review $review_id has 0 actionable findings — advancing watermark, no crewmate"
+    log "$url: new review $review_id has 0 actionable findings - advancing watermark, no crewmate"
     watermark_set "$url" "$review_ts"
     return 0
   fi
 
+  log "$url: new review $review_id has $actionable actionable findings - dispatching crewmate"
   if spawn_fix_crewmate "$owner" "$repo" "$pr_num" "$url" "$review_id" "$review_body"; then
     watermark_set "$url" "$review_ts"
   else
-    warn "spawn failed for $url review $review_id — watermark NOT advanced, will retry next fire"
+    warn "$url: spawn failed for review $review_id - watermark NOT advanced, will retry next fire"
   fi
 }
 

--- a/docs/coderabbit-poll.md
+++ b/docs/coderabbit-poll.md
@@ -44,7 +44,8 @@ The brief tells it to:
 3. Read the CodeRabbit review body from disk (no re-fetch).
 4. For each actionable finding: verify against current code, then either fix with a focused commit OR decline with a brief PR comment.
 5. Push its commits and post a summary PR comment enumerating what it fixed vs declined.
-6. Report `done: <summary>` and stop.
+6. If any commits were pushed, request a re-review by posting `@coderabbitai review` as a second PR comment. Skipped when the crewmate declined every finding — a re-review with no diff wastes the org-wide quota.
+7. Report `done: <summary>` and stop.
 
 Explicit hard rules the crewmate obeys:
 

--- a/docs/coderabbit-poll.md
+++ b/docs/coderabbit-poll.md
@@ -33,7 +33,7 @@ Designed for CodeRabbit's free-tier org-wide rate limit (1 review per hour): the
 - Compares the review's `submitted_at` timestamp with the per-PR watermark in `state/coderabbit-watermarks.tsv`. If it matches, this review was already processed — skip.
 - Parses the review body for the CodeRabbit `Actionable comments posted: N` marker.
    - `N == 0`: advance the watermark, no crewmate. (CodeRabbit posted a "nothing to do" review.)
-   - `N > 0`: write the review body to `data/cr-<repo>-pr<n>-<review_id>/review.md`, scaffold a scoped brief, spawn a crewmate via `bin/fm-spawn.sh` on `opencode + litellm/coder`. On successful spawn, advance the watermark.
+   - `N > 0`: write the review body to `data/cr-<repo>-pr<n>-<review_id>/review.md`, scaffold a scoped brief, spawn a crewmate via `bin/fm-spawn.sh`. Harness comes from `FM_CODERABBIT_POLL_HARNESS` (default `opencode`); model comes from `FM_CODERABBIT_POLL_MODEL` (default: unset, so `fm-spawn` resolves through `config/crew-dispatch.json` and the harness's own default — no operator-specific tier name is baked into the script). On successful spawn, advance the watermark.
 - Releases the lock and exits.
 
 ## What the spawned crewmate does

--- a/docs/coderabbit-poll.md
+++ b/docs/coderabbit-poll.md
@@ -1,0 +1,80 @@
+# CodeRabbit review poller (`bin/fm-coderabbit-poll.sh`)
+
+Periodic host-cron poll that watches a captain-maintained queue of GitHub PRs, detects new CodeRabbit reviews, and dispatches a scoped crewmate to address each one.
+
+Designed for CodeRabbit's free-tier org-wide rate limit (1 review per hour): the poll runs hourly and spawns at most one crewmate per newly-posted actionable review.
+
+## Setup
+
+1. Enable the queue:
+   ```
+   cp docs/examples/coderabbit-queue.txt data/coderabbit-queue.txt
+   $EDITOR data/coderabbit-queue.txt
+   ```
+   Add one `https://github.com/<owner>/<repo>/pull/<n>` URL per line. Blank lines and `#`-comments are ignored.
+
+2. Verify the poll runs cleanly by hand once:
+   ```
+   bin/fm-coderabbit-poll.sh
+   ```
+   Silent success means no new reviews (or an empty queue). Look for a `[fm-coderabbit-poll] ... poll cycle complete` line at the end.
+
+3. Install the hourly crontab entry (edit your user crontab with `crontab -e`):
+   ```
+   0 * * * * /home/<you>/tools/firstmate/bin/fm-coderabbit-poll.sh >> $HOME/.cache/fm-coderabbit-poll.log 2>&1
+   ```
+   Adjust the path to match your firstmate checkout. The log file makes future debugging trivial.
+
+## What happens on a fire
+
+- Acquires `state/coderabbit-poll.lock` via `flock -n`. Overlapping fires just skip.
+- Reads `data/coderabbit-queue.txt`.
+- For each PR: queries the newest CodeRabbit review via `gh api /repos/<owner>/<repo>/pulls/<n>/reviews`.
+- Compares the review's `submitted_at` timestamp with the per-PR watermark in `state/coderabbit-watermarks.tsv`. If it matches, this review was already processed — skip.
+- Parses the review body for the CodeRabbit `Actionable comments posted: N` marker.
+   - `N == 0`: advance the watermark, no crewmate. (CodeRabbit posted a "nothing to do" review.)
+   - `N > 0`: write the review body to `data/cr-<repo>-pr<n>-<review_id>/review.md`, scaffold a scoped brief, spawn a crewmate via `bin/fm-spawn.sh` on `opencode + litellm/coder`. On successful spawn, advance the watermark.
+- Releases the lock and exits.
+
+## What the spawned crewmate does
+
+The brief tells it to:
+1. Clone the target repo into a scratch subdir of its worktree.
+2. Check out the PR branch via `gh pr checkout`.
+3. Read the CodeRabbit review body from disk (no re-fetch).
+4. For each actionable finding: verify against current code, then either fix with a focused commit OR decline with a brief PR comment.
+5. Push its commits and post a summary PR comment enumerating what it fixed vs declined.
+6. Report `done: <summary>` and stop.
+
+Explicit hard rules the crewmate obeys:
+
+- Never merges the PR. Never force-pushes. Never rebases-and-forces.
+- Declines destructive, scope-creep, and judgment-heavy findings in a PR comment rather than acting on them.
+- Only escalates (`blocked:` / `needs-decision:`) on hard blockers like auth failure or missing tools — NOT on "should I fix this?" style judgment calls.
+- Does docs and minor fixes only; production-code rewrites are declined with a comment.
+
+## Files
+
+- `data/coderabbit-queue.txt` — captain-maintained queue, one PR URL per line, gitignored (lives under gitignored `data/`).
+- `state/coderabbit-watermarks.tsv` — per-PR last-processed review timestamp, tab-separated. Managed by the poll.
+- `state/coderabbit-poll.lock` — the flock file. Empty; safe to `rm` if something is stuck (nothing normally holds it between fires).
+- `data/cr-<repo>-pr<n>-<review_id>/` — per-crewmate scoped data (brief + captured review body). Cleaned up on `bin/fm-teardown.sh <id>` after the crewmate finishes.
+- `docs/examples/coderabbit-queue.txt` — checked-in example queue file.
+
+## Watermarks and idempotence
+
+The watermark is the review's `submitted_at` ISO timestamp, not its id. If a CodeRabbit re-review posts a NEWER timestamp (which is the normal behavior), the poll dispatches for it. If a fire fails to spawn the crewmate, the watermark is NOT advanced and the next fire retries the same review.
+
+If you want to force a re-dispatch of the newest review on a PR (e.g. after a crewmate wedged and you tore it down), remove the row for that PR from `state/coderabbit-watermarks.tsv`.
+
+## Not-installed environment
+
+- Missing `gh` / `jq` / `flock`: poll fails loudly with a stderr line, exit non-zero. Cron log surfaces the problem.
+- Missing queue file (`data/coderabbit-queue.txt` absent): poll exits 0 silently. This is the resting state for a captain who has not opted in.
+- No projects under `projects/`: poll logs the error and does not spawn. This can only happen on a nearly-empty firstmate home.
+
+## Interaction with in-flight crewmates
+
+The poll uses the same `bin/fm-spawn.sh` as any other crewmate dispatch. Spawned crewmates appear in `state/*.meta`, in the session-start digest, and are tracked by the watcher exactly like a manually-dispatched task. `bin/fm-teardown.sh` behavior is identical.
+
+The poll does NOT check whether a previous crewmate for the same PR is still running. If a crewmate wedges and cron fires again while the review has advanced, a second crewmate will spawn. In practice this is rare (CodeRabbit's hourly cadence + wedge detection via stale panes catches it first).

--- a/docs/coderabbit-poll.md
+++ b/docs/coderabbit-poll.md
@@ -4,6 +4,13 @@ Periodic host-cron poll that watches a captain-maintained queue of GitHub PRs, d
 
 Designed for CodeRabbit's free-tier org-wide rate limit (1 review per hour): the poll runs hourly and spawns at most one crewmate per newly-posted actionable review.
 
+Supports both CodeRabbit variants:
+
+- `coderabbitai[bot]` — the paid/hosted service; requests posted as `@coderabbitai review`.
+- `coderabbit-oss[bot]` — the public OSS variant used on OSS repos, with stricter per-user rate limits; requests posted as `@coderabbit-oss review`.
+
+The poll auto-detects which bot is active on each PR from the most recent bot activity (review or issue comment) and mirrors the mention accordingly; a PR with no prior bot activity falls back to `@coderabbitai`.
+
 ## Setup
 
 1. Enable the queue:
@@ -32,7 +39,7 @@ Designed for CodeRabbit's free-tier org-wide rate limit (1 review per hour): the
 - For each PR:
   1. Checks the PR state via `gh api`. Skips anything that is not `open` (already merged or closed PRs do not need attention and any `@coderabbitai review` request would waste org quota).
   2. Queries the newest CodeRabbit review via `gh api /repos/<owner>/<repo>/pulls/<n>/reviews`.
-  3. **If there is NO CodeRabbit review yet on this PR**: post a `@coderabbitai review` comment to trigger the initial review — but at most ONCE per fire cycle. The free-tier CodeRabbit quota is one review-request per hour org-wide (tracked per user under `@`login), so requesting more than one per fire just wastes the quota. Remaining unreviewed PRs get requested on subsequent hourly fires until each has a review.
+  3. **If there is NO CodeRabbit review yet on this PR**: post an `@coderabbitai review` / `@coderabbit-oss review` comment (whichever variant is active on the PR) to trigger the initial review — but at most ONCE per fire cycle. The free-tier CodeRabbit quota is one review-request per hour org-wide (tracked per user under `@`login), so requesting more than one per fire just wastes the quota. Remaining unreviewed PRs get requested on subsequent hourly fires until each has a review. Before posting, the newest bot issue comment on the PR is scanned for a `Review limit reached` cooldown notice; if one is present the request is skipped (with a log line noting any parseable countdown) so we do not burn a queued-request slot every hour while CodeRabbit is in cooldown.
   4. **If there IS a review**: compares its `submitted_at` timestamp with the per-PR watermark in `state/coderabbit-watermarks.tsv`. If it matches, the review was already processed — skip.
   5. **If the review is new**: parses the body for the `Actionable comments posted: N` marker.
      - `N == 0`: advance the watermark, no crewmate. (CodeRabbit posted a "nothing to do" review.)

--- a/docs/coderabbit-poll.md
+++ b/docs/coderabbit-poll.md
@@ -29,11 +29,14 @@ Designed for CodeRabbit's free-tier org-wide rate limit (1 review per hour): the
 
 - Acquires `state/coderabbit-poll.lock` via `flock -n`. Overlapping fires just skip.
 - Reads `data/coderabbit-queue.txt`.
-- For each PR: queries the newest CodeRabbit review via `gh api /repos/<owner>/<repo>/pulls/<n>/reviews`.
-- Compares the review's `submitted_at` timestamp with the per-PR watermark in `state/coderabbit-watermarks.tsv`. If it matches, this review was already processed — skip.
-- Parses the review body for the CodeRabbit `Actionable comments posted: N` marker.
-   - `N == 0`: advance the watermark, no crewmate. (CodeRabbit posted a "nothing to do" review.)
-   - `N > 0`: write the review body to `data/cr-<repo>-pr<n>-<review_id>/review.md`, scaffold a scoped brief, spawn a crewmate via `bin/fm-spawn.sh`. Harness comes from `FM_CODERABBIT_POLL_HARNESS` (default `opencode`); model comes from `FM_CODERABBIT_POLL_MODEL` (default: unset, so `fm-spawn` resolves through `config/crew-dispatch.json` and the harness's own default — no operator-specific tier name is baked into the script). On successful spawn, advance the watermark.
+- For each PR:
+  1. Checks the PR state via `gh api`. Skips anything that is not `open` (already merged or closed PRs do not need attention and any `@coderabbitai review` request would waste org quota).
+  2. Queries the newest CodeRabbit review via `gh api /repos/<owner>/<repo>/pulls/<n>/reviews`.
+  3. **If there is NO CodeRabbit review yet on this PR**: post a `@coderabbitai review` comment to trigger the initial review — but at most ONCE per fire cycle. The free-tier CodeRabbit quota is one review-request per hour org-wide (tracked per user under `@`login), so requesting more than one per fire just wastes the quota. Remaining unreviewed PRs get requested on subsequent hourly fires until each has a review.
+  4. **If there IS a review**: compares its `submitted_at` timestamp with the per-PR watermark in `state/coderabbit-watermarks.tsv`. If it matches, the review was already processed — skip.
+  5. **If the review is new**: parses the body for the `Actionable comments posted: N` marker.
+     - `N == 0`: advance the watermark, no crewmate. (CodeRabbit posted a "nothing to do" review.)
+     - `N > 0`: write the review body to `data/cr-<repo>-pr<n>-<review_id>/review.md`, scaffold a scoped brief, spawn a crewmate via `bin/fm-spawn.sh`. Harness comes from `FM_CODERABBIT_POLL_HARNESS` (default `opencode`); model comes from `FM_CODERABBIT_POLL_MODEL` (default: unset, so `fm-spawn` resolves through `config/crew-dispatch.json` and the harness's own default — no operator-specific tier name is baked into the script). On successful spawn, advance the watermark.
 - Releases the lock and exits.
 
 ## What the spawned crewmate does

--- a/docs/examples/coderabbit-queue.txt
+++ b/docs/examples/coderabbit-queue.txt
@@ -1,0 +1,13 @@
+# CodeRabbit review poller queue — copied by the captain into data/coderabbit-queue.txt
+#
+# Format: one GitHub PR URL per line.  Blank lines and #-comments are ignored.
+# Only https://github.com/<owner>/<repo>/pull/<n> URLs are recognized; anything
+# else logs a warning and is skipped.
+#
+# The polling script (`bin/fm-coderabbit-poll.sh`) is intended to run hourly
+# via host cron (see docs/coderabbit-poll.md for setup).
+#
+# Example entries:
+#
+# https://github.com/famclaw/famclaw/pull/159
+# https://github.com/famclaw/honeybadger/pull/56


### PR DESCRIPTION
Adds a host-cron poller that watches a captain-maintained queue of GitHub PRs, detects new CodeRabbit reviews, and dispatches a scoped one-shot crewmate per new actionable review.

## Motivation

CodeRabbit free-tier's rate limit is 1 review per hour for the whole org. Existing supervision has no hook for "new external bot review posted on my PR"; a captain either polls manually or leaves reviews unaddressed. Session-based `bin/fm-spawn.sh` babysitters (tried on this fleet earlier this week) proved brittle for long-idle polling — the model wandered, hallucinated findings, or falsely declared clean without waiting for CodeRabbit to actually review.

Host-cron sidesteps both problems: strict hourly cadence, no live firstmate needed, and each fire spawns a one-shot crewmate with a scoped brief containing the exact review body.

## What's here

- `bin/fm-coderabbit-poll.sh` — the poll. `flock`-guarded, per-PR watermarks in `state/coderabbit-watermarks.tsv`, spawns via existing `bin/fm-spawn.sh`.
- `docs/coderabbit-poll.md` — setup, cadence, files, watermark semantics, crontab example.
- `docs/examples/coderabbit-queue.txt` — commented example queue.

## Design decisions worth review

- **Host cron over `CronCreate`**: doesn't depend on firstmate being live. Simpler failure mode (cron log tells you).
- **One-shot crewmate per new review, not a persistent babysitter**: previous per-session babysitter attempts wedged on idle polling. A crewmate spawned with the exact review body already in hand can't hallucinate findings; it either acts on the concrete body or declines with a comment.
- **Watermark = review `submitted_at` timestamp, not id**: naturally matches CodeRabbit's re-review flow; a fresh review with a newer timestamp triggers dispatch.
- **Watermark advances on spawn success, not on crewmate done**: if a crewmate wedges the operator handles it manually; the poll doesn't re-spawn a duplicate on the next fire. If spawn itself fails, watermark stays; next fire retries.
- **Explicit crewmate scope hard rules in the brief**: no merges, no force-push, docs and minor fixes only, decline destructive/scope-creep in a PR comment rather than escalating. Escalation reserved for hard blockers only.
- **Actionable-count parsing from CodeRabbit body**: `Actionable comments posted: N` marker; N=0 advances watermark without spawn. If CodeRabbit changes this format, the poll would need an update — this is the load-bearing external contract.

## Tests

Smoke-tested locally against:

- Missing queue file → silent exit 0 (resting state).
- Empty queue → `poll cycle complete`, exit 0.
- Comment-only queue → `poll cycle complete`, exit 0.
- Malformed URL → warning + `poll cycle complete`, exit 0.

Not exercised end-to-end against a live CodeRabbit review here (would double-dispatch on the fleet's own in-flight PRs).

## Not in this PR

- No AGENTS.md updates. If the feature ships, a follow-up should add the three new files (`data/coderabbit-queue.txt`, `state/coderabbit-watermarks.tsv`, `state/coderabbit-poll.lock`) to section 2's layout list.
- No unit tests under a `tests/` dir. The script is mostly shell glue over `gh api` + `fm-spawn.sh`; a full test harness would need to mock the GitHub API.
- No `CronCreate` variant. Deferred until there's a concrete need for firstmate-driven scheduling.

🤖 Written by [Claude Code](https://claude.com/claude-code)


## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

*Note*: the no-mistakes pipeline was driven manually on this PR — `axi run` completed intent/rebase/review/test/document/lint successfully; the auto-stamp step failed only because the scratch worktree had HTTPS origin without push credentials. The review pass emitted one actionable finding (the hardcoded LiteLLM tier name in `bin/fm-coderabbit-poll.sh`), which is fixed by commit `2bb32a9` on this branch (env-var-driven, no hardcoded operator-private tier names).
