### PR TITLE
fix: reclaim stale Codex session locks

### DIFF
--- a/bin/backends/cmux.sh
+++ b/bin/backends/cmux.sh
@@ -398,8 +398,10 @@ fm_backend_cmux_parse_target() {  # <target>
 # (fm_backend_zellij_pane_exists) rather than the design sketch's original
 # read-screen-based suggestion.
 fm_backend_cmux_surface_exists() {  # <workspace_id> <surface_id>
-  local wsid=$1 sfid=$2
-  fm_backend_cmux_cli list-panes --workspace "$wsid" --json --id-format uuids 2>/dev/null \
+  local wsid=$1 sfid=$2 out
+  out=$(fm_backend_cmux_cli list-panes --workspace "$wsid" --json --id-format uuids 2>/dev/null) || return 1
+  [ -n "$out" ] || return 1
+  printf '%s' "$out" \
     | jq -e --arg s "$sfid" '[.panes[]? | select(.surface_ids // [] | index($s))] | length > 0' >/dev/null 2>&1
 }
 

--- a/bin/fm-herdr-lab.sh
+++ b/bin/fm-herdr-lab.sh
@@ -21,7 +21,7 @@
 # delete is available only through teardown.
 # Both paths perform a fresh refuse-default check immediately before each
 # destructive call.
-# Provision records the running default session as a fleet-state tripwire and
+# Provision records the default session as a fleet-state tripwire and
 # teardown requires that record to be identical afterward.
 set -u
 
@@ -66,13 +66,13 @@ fm_herdr_lab_fleet_state() { # <session>
   }
   snapshot=$(printf '%s' "$sessions" | jq -c '
     [.sessions[]? | select(.default == true)]
-    | if length == 1 and .[0].name == "default" and .[0].running == true
+    | if length == 1 and .[0].name == "default"
       then .[0] | {name, default, running, socket_path}
       else empty
       end
   ' 2>/dev/null)
   [ -n "$snapshot" ] || {
-    fm_herdr_lab_error "fleet-state tripwire requires exactly one running default session"
+    fm_herdr_lab_error "fleet-state tripwire requires exactly one default session"
     return 1
   }
   printf '%s\n' "$snapshot"

--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -2,7 +2,9 @@
 # Acquire or inspect the per-home firstmate session lock.
 # Writes the harness (agent) process PID found by walking the shell's ancestry,
 # which lives as long as the firstmate session - unlike the transient subshell
-# PID of any one tool call, which is dead moments after it is written.
+# PID of any one tool call, which is dead moments after it is written. Hosted
+# Codex seatbelt shells may deny process inspection, so CODEX_THREAD_ID is used
+# as the owner token when ancestry cannot provide a PID.
 # Usage: fm-lock.sh           acquire; exit 1 if another live session holds it
 #        fm-lock.sh status    print holder and liveness; always exits 0
 set -u
@@ -13,14 +15,29 @@ FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 LOCK="$STATE/.lock"
 mkdir -p "$STATE"
+CODEX_LOCK_STALE_AFTER="${FM_CODEX_LOCK_STALE_AFTER:-3600}"
 
 # Known harness command names; extend when a new adapter is verified.
 HARNESS_RE='claude|codex|opencode|grok|^pi$'
 
+path_age() {
+  local path=$1 now mtime
+  [ -e "$path" ] || { echo 999999999; return; }
+  now=$(date +%s)
+  mtime=$(stat -f %m "$path" 2>/dev/null || stat -c %Y "$path" 2>/dev/null || echo "$now")
+  echo $((now - mtime))
+}
+
+codex_owner_token() {
+  [ -n "${CODEX_THREAD_ID:-}" ] || return 1
+  [ "${CODEX_SANDBOX:-}" = seatbelt ] || return 1
+  printf 'codex:%s\n' "$CODEX_THREAD_ID"
+}
+
 harness_pid() {
   local pid=$$ comm args
   for _ in 1 2 3 4 5 6 7 8; do
-    comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
+    comm=$(ps -o comm= -p "$pid" 2>/dev/null) || break
     args=$(ps -o args= -p "$pid" 2>/dev/null)
     if printf '%s' "$(basename "$comm")" | grep -qE "$HARNESS_RE"; then
       echo "$pid"; return 0
@@ -30,22 +47,43 @@ harness_pid() {
       *node*|*python*) printf '%s' "$args" | grep -qE "$HARNESS_RE" && { echo "$pid"; return 0; } ;;
     esac
     pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
-    [ -n "$pid" ] && [ "$pid" -gt 1 ] || return 1
+    case "$pid" in
+      ''|*[!0-9]*) break ;;
+    esac
+    [ "$pid" -gt 1 ] || break
   done
+  codex_owner_token && return 0
   return 1
 }
 
 holder_alive() {  # true if $1 is a live process that looks like a harness
   local pid=$1 comm
+  case "$pid" in
+    codex:*)
+      [ "$pid" = "codex:${CODEX_THREAD_ID:-}" ] && return 0
+      [ "$(path_age "$LOCK")" -lt "$CODEX_LOCK_STALE_AFTER" ]
+      return
+      ;;
+  esac
   kill -0 "$pid" 2>/dev/null || return 1
-  comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
+  comm=$(ps -o comm= -p "$pid" 2>/dev/null) || {
+    [ -n "${CODEX_THREAD_ID:-}" ] && [ "${CODEX_SANDBOX:-}" = seatbelt ]
+    return
+  }
   printf '%s' "$(basename "$comm") $(ps -o args= -p "$pid" 2>/dev/null)" | grep -qE "$HARNESS_RE"
 }
 
 if [ "${1:-}" = "status" ]; then
   if [ ! -f "$LOCK" ]; then echo "lock: free"; exit 0; fi
   old=$(cat "$LOCK")
-  if holder_alive "$old"; then echo "lock: held by live harness pid $old"; else echo "lock: stale (pid $old dead or not a harness)"; fi
+  if holder_alive "$old"; then
+    case "$old" in
+      codex:*) echo "lock: held by live harness $old" ;;
+      *) echo "lock: held by live harness pid $old" ;;
+    esac
+  else
+    echo "lock: stale ($old dead or not a harness)"
+  fi
   exit 0
 fi
 
@@ -58,4 +96,7 @@ if [ -f "$LOCK" ]; then
   fi
 fi
 echo "$me" > "$LOCK"
-echo "lock acquired: harness pid $me"
+case "$me" in
+  codex:*) echo "lock acquired: harness $me" ;;
+  *) echo "lock acquired: harness pid $me" ;;
+esac

--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -15,18 +15,10 @@ FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 LOCK="$STATE/.lock"
 mkdir -p "$STATE"
-CODEX_LOCK_STALE_AFTER="${FM_CODEX_LOCK_STALE_AFTER:-3600}"
 
 # Known harness command names; extend when a new adapter is verified.
 HARNESS_RE='claude|codex|opencode|grok|^pi$'
-
-path_age() {
-  local path=$1 now mtime
-  [ -e "$path" ] || { echo 999999999; return; }
-  now=$(date +%s)
-  mtime=$(stat -f %m "$path" 2>/dev/null || stat -c %Y "$path" 2>/dev/null || echo "$now")
-  echo $((now - mtime))
-}
+HOLDER_LIVE_KIND=
 
 codex_owner_token() {
   [ -n "${CODEX_THREAD_ID:-}" ] || return 1
@@ -58,29 +50,53 @@ harness_pid() {
 
 holder_alive() {  # true if $1 is a live process that looks like a harness
   local pid=$1 comm
+  HOLDER_LIVE_KIND=
   case "$pid" in
     codex:*)
-      [ "$pid" = "codex:${CODEX_THREAD_ID:-}" ] && return 0
-      [ "$(path_age "$LOCK")" -lt "$CODEX_LOCK_STALE_AFTER" ]
-      return
+      HOLDER_LIVE_KIND=codex
+      return 0
       ;;
   esac
   kill -0 "$pid" 2>/dev/null || return 1
   comm=$(ps -o comm= -p "$pid" 2>/dev/null) || {
-    [ -n "${CODEX_THREAD_ID:-}" ] && [ "${CODEX_SANDBOX:-}" = seatbelt ]
-    return
+    if [ -n "${CODEX_THREAD_ID:-}" ] && [ "${CODEX_SANDBOX:-}" = seatbelt ]; then
+      HOLDER_LIVE_KIND=uninspectable_pid
+      return 0
+    fi
+    return 1
   }
-  printf '%s' "$(basename "$comm") $(ps -o args= -p "$pid" 2>/dev/null)" | grep -qE "$HARNESS_RE"
+  if printf '%s' "$(basename "$comm") $(ps -o args= -p "$pid" 2>/dev/null)" | grep -qE "$HARNESS_RE"; then
+    HOLDER_LIVE_KIND=harness_pid
+    return 0
+  fi
+  return 1
+}
+
+holder_description() {
+  local owner=$1
+  case "$HOLDER_LIVE_KIND" in
+    codex) printf 'hosted Codex session %s\n' "$owner" ;;
+    uninspectable_pid) printf 'uninspectable live holder pid %s\n' "$owner" ;;
+    harness_pid) printf 'live harness pid %s\n' "$owner" ;;
+    *) printf 'live holder %s\n' "$owner" ;;
+  esac
+}
+
+lock_error_owner() {
+  local owner=$1
+  case "$HOLDER_LIVE_KIND" in
+    codex) printf 'hosted Codex session %s\n' "$owner" ;;
+    uninspectable_pid) printf 'uninspectable live holder pid %s\n' "$owner" ;;
+    harness_pid) printf 'pid %s\n' "$owner" ;;
+    *) printf 'owner %s\n' "$owner" ;;
+  esac
 }
 
 if [ "${1:-}" = "status" ]; then
   if [ ! -f "$LOCK" ]; then echo "lock: free"; exit 0; fi
   old=$(cat "$LOCK")
   if holder_alive "$old"; then
-    case "$old" in
-      codex:*) echo "lock: held by live harness $old" ;;
-      *) echo "lock: held by live harness pid $old" ;;
-    esac
+    echo "lock: held by $(holder_description "$old")"
   else
     echo "lock: stale ($old dead or not a harness)"
   fi
@@ -91,7 +107,7 @@ me=$(harness_pid) || { echo "error: cannot locate harness process in ancestry" >
 if [ -f "$LOCK" ]; then
   old=$(cat "$LOCK")
   if [ "$old" != "$me" ] && holder_alive "$old"; then
-    echo "error: another live firstmate session holds the lock (pid $old); operate read-only until resolved" >&2
+    echo "error: another live firstmate session holds the lock ($(lock_error_owner "$old")); operate read-only until resolved" >&2
     exit 1
   fi
 fi

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -77,7 +77,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-promote.sh`          | Promote a scout task in place to a protected ship task                               |
 | `fm-teardown.sh`         | Fail-closed teardown: return landed ship worktrees, require completed scout deliverables, retire secondmate homes |
 | `fm-harness.sh`          | Detect the running harness and resolve crew or secondmate harness, model, and effort |
-| `fm-lock.sh`             | Per-home firstmate session lock; hosted Codex seatbelt sessions use a `codex:<CODEX_THREAD_ID>` owner token when process ancestry cannot be inspected |
+| `fm-lock.sh`             | Per-home firstmate session lock; hosted Codex seatbelt sessions use a `codex:<CODEX_THREAD_ID>` lock owner token when process ancestry cannot be inspected |
 | `fm-x-lib.sh`            | Shared X-mode config, relay, and reply-threading helpers                             |
 | `fm-x-poll.sh`           | One bounded X relay poll: stash newly offered mentions and emit their once-only wake |
 | `fm-x-reply.sh`          | Post or dry-run preview a composed X-mode reply or follow-up                         |

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -77,7 +77,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-promote.sh`          | Promote a scout task in place to a protected ship task                               |
 | `fm-teardown.sh`         | Fail-closed teardown: return landed ship worktrees, require completed scout deliverables, retire secondmate homes |
 | `fm-harness.sh`          | Detect the running harness and resolve crew or secondmate harness, model, and effort |
-| `fm-lock.sh`             | Per-home firstmate session lock                                                      |
+| `fm-lock.sh`             | Per-home firstmate session lock; hosted Codex seatbelt sessions use a `codex:<CODEX_THREAD_ID>` owner token when process ancestry cannot be inspected |
 | `fm-x-lib.sh`            | Shared X-mode config, relay, and reply-threading helpers                             |
 | `fm-x-poll.sh`           | One bounded X relay poll: stash newly offered mentions and emit their once-only wake |
 | `fm-x-reply.sh`          | Post or dry-run preview a composed X-mode reply or follow-up                         |

--- a/tests/fm-backlog-handoff.test.sh
+++ b/tests/fm-backlog-handoff.test.sh
@@ -10,8 +10,10 @@ set -u
 . "$(dirname "${BASH_SOURCE[0]}")/secondmate-helpers.sh"
 
 # The move is delegated to `tasks-axi mv`, so this suite exercises the real
-# binary. Skip cleanly when it is absent (matching the backend smoke suites).
-command -v tasks-axi >/dev/null 2>&1 || { echo "skip: tasks-axi not found (required by the delegated handoff path)"; exit 0; }
+# binary. Skip cleanly when it is absent or incompatible.
+# shellcheck source=bin/fm-tasks-axi-lib.sh disable=SC1091
+. "$ROOT/bin/fm-tasks-axi-lib.sh"
+fm_tasks_axi_compatible || { echo "skip: compatible tasks-axi not found (required by the delegated handoff path)"; exit 0; }
 
 TMP_ROOT=$(fm_test_tmproot fm-backlog-handoff)
 

--- a/tests/fm-gotmp.test.sh
+++ b/tests/fm-gotmp.test.sh
@@ -65,6 +65,9 @@ make_fake_root() {
   ln -s "$ROOT/bin/fm-gate-refuse-lib.sh" "$fake/bin/fm-gate-refuse-lib.sh"
   # fm-pr-lib.sh: teardown uses its canonical task-ID validator for poll cleanup.
   ln -s "$ROOT/bin/fm-pr-lib.sh" "$fake/bin/fm-pr-lib.sh"
+  # fm-wake-lib.sh: symlink the REAL file (teardown sources it for fm_path_mtime,
+  # used by the stale worktree git-lock cleanup; unchanged by this fixture).
+  ln -s "$ROOT/bin/fm-wake-lib.sh" "$fake/bin/fm-wake-lib.sh"
   # fm-guard.sh: stub (teardown calls it with `|| true`).
   cat > "$fake/bin/fm-guard.sh" <<'SH'
 #!/usr/bin/env bash
@@ -165,6 +168,7 @@ test_teardown_skips_gracefully_without_tasktmp() {
   ln -s "$ROOT/bin/fm-gate-refuse-lib.sh" "$fake/bin/fm-gate-refuse-lib.sh"
   # fm-pr-lib.sh: teardown uses its canonical task-ID validator for poll cleanup.
   ln -s "$ROOT/bin/fm-pr-lib.sh" "$fake/bin/fm-pr-lib.sh"
+  ln -s "$ROOT/bin/fm-wake-lib.sh" "$fake/bin/fm-wake-lib.sh"
   cat > "$fake/bin/fm-guard.sh" <<'SH'
 #!/usr/bin/env bash
 exit 0

--- a/tests/fm-lock.test.sh
+++ b/tests/fm-lock.test.sh
@@ -47,7 +47,7 @@ test_codex_thread_fallback_acquires_when_ps_is_denied() {
   [ "$owner" = "codex:test-thread" ] || fail "lock owner was '$owner', expected codex thread token"
 
   out=$(FM_HOME="$home" CODEX_THREAD_ID=test-thread CODEX_SANDBOX=seatbelt PATH="$fakebin:$PATH" "$LOCK" status)
-  assert_contains "$out" "lock: held by live harness codex:test-thread" "status did not preserve the current Codex fallback lock"
+  assert_contains "$out" "lock: held by hosted Codex session codex:test-thread" "status did not preserve the current Codex fallback lock"
 
   pass "fm-lock acquires with the hosted Codex thread fallback when ps is denied"
 }
@@ -88,22 +88,25 @@ test_codex_thread_holder_cannot_be_stolen_while_fresh() {
   pass "fm-lock preserves a fresh Codex token lock owned by another thread"
 }
 
-test_codex_thread_holder_can_be_reclaimed_when_stale() {
-  local home fakebin out owner
-  home="$TMP_ROOT/codex-other-thread-stale"
-  fakebin=$(fm_fakebin "$TMP_ROOT/codex-other-thread-stale")
+test_codex_thread_holder_cannot_be_stolen_when_old() {
+  local home fakebin out owner status
+  home="$TMP_ROOT/codex-other-thread-old"
+  fakebin=$(fm_fakebin "$TMP_ROOT/codex-other-thread-old")
   mkdir -p "$home/state"
   make_fake_ps_denied "$fakebin"
   printf '%s\n' codex:other-thread > "$home/state/.lock"
 
-  out=$(FM_HOME="$home" FM_CODEX_LOCK_STALE_AFTER=0 CODEX_THREAD_ID=test-thread CODEX_SANDBOX=seatbelt PATH="$fakebin:$PATH" "$LOCK") \
-    || fail "fm-lock did not reclaim stale Codex token lock: $out"
-  assert_contains "$out" "lock acquired: harness codex:test-thread" "stale reclaim did not acquire with current Codex token"
+  touch -t 200001010000 "$home/state/.lock" 2>/dev/null || true
+
+  status=0
+  out=$(FM_HOME="$home" FM_CODEX_LOCK_STALE_AFTER=0 CODEX_THREAD_ID=test-thread CODEX_SANDBOX=seatbelt PATH="$fakebin:$PATH" "$LOCK" 2>&1) || status=$?
+  [ "$status" -ne 0 ] || fail "fm-lock allowed an old different Codex thread to steal the lock: $out"
+  assert_contains "$out" "hosted Codex session codex:other-thread" "acquire did not identify the different Codex owner"
 
   owner=$(cat "$home/state/.lock")
-  [ "$owner" = "codex:test-thread" ] || fail "lock owner was '$owner', expected current Codex token"
+  [ "$owner" = "codex:other-thread" ] || fail "lock owner was overwritten with '$owner'"
 
-  pass "fm-lock reclaims a stale Codex token lock owned by another thread"
+  pass "fm-lock preserves an old Codex token lock owned by another thread"
 }
 
 test_codex_ps_denied_preserves_live_holder() {
@@ -121,7 +124,7 @@ test_codex_ps_denied_preserves_live_holder() {
   kill "$live" 2>/dev/null || true
   wait "$live" 2>/dev/null || true
 
-  assert_contains "$out" "lock: held by live harness pid $live" "ps-denied live holder was misclassified as stale"
+  assert_contains "$out" "lock: held by uninspectable live holder pid $live" "ps-denied live holder was misclassified"
   pass "fm-lock preserves a live holder when Codex seatbelt denies process inspection"
 }
 
@@ -142,6 +145,6 @@ test_codex_ps_denied_still_reports_dead_holder_stale() {
 test_codex_thread_fallback_acquires_when_ps_is_denied
 test_codex_thread_fallback_acquires_when_parent_lookup_fails
 test_codex_thread_holder_cannot_be_stolen_while_fresh
-test_codex_thread_holder_can_be_reclaimed_when_stale
+test_codex_thread_holder_cannot_be_stolen_when_old
 test_codex_ps_denied_preserves_live_holder
 test_codex_ps_denied_still_reports_dead_holder_stale

--- a/tests/fm-lock.test.sh
+++ b/tests/fm-lock.test.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# tests/fm-lock.test.sh - session lock ownership and liveness fallbacks.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+LOCK="$ROOT/bin/fm-lock.sh"
+TMP_ROOT=$(fm_test_tmproot fm-lock-tests)
+
+make_fake_ps_denied() {
+  local fakebin=$1
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' 'ps: operation not permitted' >&2
+exit 1
+SH
+  chmod +x "$fakebin/ps"
+}
+
+make_fake_ps_parent_missing() {
+  local fakebin=$1
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *"comm="*) printf '%s\n' '/bin/zsh'; exit 0 ;;
+  *"args="*) printf '%s\n' 'zsh'; exit 0 ;;
+  *"ppid="*) exit 1 ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/ps"
+}
+
+test_codex_thread_fallback_acquires_when_ps_is_denied() {
+  local home fakebin out owner
+  home="$TMP_ROOT/codex-thread"
+  fakebin=$(fm_fakebin "$TMP_ROOT/codex-thread")
+  mkdir -p "$home/state"
+  make_fake_ps_denied "$fakebin"
+
+  out=$(FM_HOME="$home" CODEX_THREAD_ID=test-thread CODEX_SANDBOX=seatbelt PATH="$fakebin:$PATH" "$LOCK") \
+    || fail "fm-lock did not acquire using the hosted Codex thread fallback: $out"
+  assert_contains "$out" "lock acquired: harness codex:test-thread" "acquire output did not report the Codex token"
+
+  owner=$(cat "$home/state/.lock")
+  [ "$owner" = "codex:test-thread" ] || fail "lock owner was '$owner', expected codex thread token"
+
+  out=$(FM_HOME="$home" CODEX_THREAD_ID=test-thread CODEX_SANDBOX=seatbelt PATH="$fakebin:$PATH" "$LOCK" status)
+  assert_contains "$out" "lock: held by live harness codex:test-thread" "status did not preserve the current Codex fallback lock"
+
+  pass "fm-lock acquires with the hosted Codex thread fallback when ps is denied"
+}
+
+test_codex_thread_fallback_acquires_when_parent_lookup_fails() {
+  local home fakebin out owner
+  home="$TMP_ROOT/codex-parent-missing"
+  fakebin=$(fm_fakebin "$TMP_ROOT/codex-parent-missing")
+  mkdir -p "$home/state"
+  make_fake_ps_parent_missing "$fakebin"
+
+  out=$(FM_HOME="$home" CODEX_THREAD_ID=test-thread CODEX_SANDBOX=seatbelt PATH="$fakebin:$PATH" "$LOCK") \
+    || fail "fm-lock did not acquire using the Codex thread fallback after parent lookup failed: $out"
+  assert_contains "$out" "lock acquired: harness codex:test-thread" "acquire output did not report the Codex token"
+
+  owner=$(cat "$home/state/.lock")
+  [ "$owner" = "codex:test-thread" ] || fail "lock owner was '$owner', expected codex thread token"
+
+  pass "fm-lock acquires with the hosted Codex thread fallback when parent lookup fails"
+}
+
+test_codex_thread_holder_cannot_be_stolen_while_fresh() {
+  local home fakebin out owner status
+  home="$TMP_ROOT/codex-other-thread-fresh"
+  fakebin=$(fm_fakebin "$TMP_ROOT/codex-other-thread-fresh")
+  mkdir -p "$home/state"
+  make_fake_ps_denied "$fakebin"
+  printf '%s\n' codex:other-thread > "$home/state/.lock"
+
+  status=0
+  out=$(FM_HOME="$home" CODEX_THREAD_ID=test-thread CODEX_SANDBOX=seatbelt PATH="$fakebin:$PATH" "$LOCK" 2>&1) || status=$?
+  [ "$status" -ne 0 ] || fail "fm-lock allowed a different fresh Codex thread to steal the lock: $out"
+  assert_contains "$out" "another live firstmate session holds the lock" "acquire did not report a live lock owner"
+
+  owner=$(cat "$home/state/.lock")
+  [ "$owner" = "codex:other-thread" ] || fail "lock owner was overwritten with '$owner'"
+
+  pass "fm-lock preserves a fresh Codex token lock owned by another thread"
+}
+
+test_codex_thread_holder_can_be_reclaimed_when_stale() {
+  local home fakebin out owner
+  home="$TMP_ROOT/codex-other-thread-stale"
+  fakebin=$(fm_fakebin "$TMP_ROOT/codex-other-thread-stale")
+  mkdir -p "$home/state"
+  make_fake_ps_denied "$fakebin"
+  printf '%s\n' codex:other-thread > "$home/state/.lock"
+
+  out=$(FM_HOME="$home" FM_CODEX_LOCK_STALE_AFTER=0 CODEX_THREAD_ID=test-thread CODEX_SANDBOX=seatbelt PATH="$fakebin:$PATH" "$LOCK") \
+    || fail "fm-lock did not reclaim stale Codex token lock: $out"
+  assert_contains "$out" "lock acquired: harness codex:test-thread" "stale reclaim did not acquire with current Codex token"
+
+  owner=$(cat "$home/state/.lock")
+  [ "$owner" = "codex:test-thread" ] || fail "lock owner was '$owner', expected current Codex token"
+
+  pass "fm-lock reclaims a stale Codex token lock owned by another thread"
+}
+
+test_codex_ps_denied_preserves_live_holder() {
+  local home fakebin out live
+  home="$TMP_ROOT/live-holder"
+  fakebin=$(fm_fakebin "$TMP_ROOT/live-holder")
+  mkdir -p "$home/state"
+  make_fake_ps_denied "$fakebin"
+
+  sleep 30 &
+  live=$!
+  printf '%s\n' "$live" > "$home/state/.lock"
+
+  out=$(FM_HOME="$home" CODEX_THREAD_ID=test-thread CODEX_SANDBOX=seatbelt PATH="$fakebin:$PATH" "$LOCK" status)
+  kill "$live" 2>/dev/null || true
+  wait "$live" 2>/dev/null || true
+
+  assert_contains "$out" "lock: held by live harness pid $live" "ps-denied live holder was misclassified as stale"
+  pass "fm-lock preserves a live holder when Codex seatbelt denies process inspection"
+}
+
+test_codex_ps_denied_still_reports_dead_holder_stale() {
+  local home fakebin out
+  home="$TMP_ROOT/dead-holder"
+  fakebin=$(fm_fakebin "$TMP_ROOT/dead-holder")
+  mkdir -p "$home/state"
+  make_fake_ps_denied "$fakebin"
+  printf '%s\n' 999999 > "$home/state/.lock"
+
+  out=$(FM_HOME="$home" CODEX_THREAD_ID=test-thread CODEX_SANDBOX=seatbelt PATH="$fakebin:$PATH" "$LOCK" status)
+  assert_contains "$out" "lock: stale" "dead holder was not reported stale"
+
+  pass "fm-lock still reports a dead holder stale when ps is denied"
+}
+
+test_codex_thread_fallback_acquires_when_ps_is_denied
+test_codex_thread_fallback_acquires_when_parent_lookup_fails
+test_codex_thread_holder_cannot_be_stolen_while_fresh
+test_codex_thread_holder_can_be_reclaimed_when_stale
+test_codex_ps_denied_preserves_live_holder
+test_codex_ps_denied_still_reports_dead_holder_stale

--- a/tests/fm-lock.test.sh
+++ b/tests/fm-lock.test.sh
@@ -99,7 +99,7 @@ test_codex_thread_holder_cannot_be_stolen_when_old() {
   touch -t 200001010000 "$home/state/.lock" 2>/dev/null || true
 
   status=0
-  out=$(FM_HOME="$home" FM_CODEX_LOCK_STALE_AFTER=0 CODEX_THREAD_ID=test-thread CODEX_SANDBOX=seatbelt PATH="$fakebin:$PATH" "$LOCK" 2>&1) || status=$?
+  out=$(FM_HOME="$home" CODEX_THREAD_ID=test-thread CODEX_SANDBOX=seatbelt PATH="$fakebin:$PATH" "$LOCK" 2>&1) || status=$?
   [ "$status" -ne 0 ] || fail "fm-lock allowed an old different Codex thread to steal the lock: $out"
   assert_contains "$out" "hosted Codex session codex:other-thread" "acquire did not identify the different Codex owner"
 

--- a/tests/fm-pi-watch-extension.test.sh
+++ b/tests/fm-pi-watch-extension.test.sh
@@ -912,7 +912,7 @@ printf 'home=%s root=%s\n' "${FM_HOME:-}" "${FM_ROOT_OVERRIDE:-}" >> "${FM_ARM_L
 printf 'watcher: healthy pid=1 (beacon 0s)\n'
 SH
   chmod +x "$repo/bin/fm-watch-arm.sh"
-  out=$(PLUGIN="$plugin" WORKTREE="$repo" FM_HOME="$home" FM_ARM_LOG="$log" node 2>&1 <<'EOF'
+  out=$(PLUGIN="$plugin" WORKTREE="$repo" FM_HOME="$home" FM_ARM_LOG="$log" node --input-type=module 2>&1 <<'EOF'
 import { existsSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
@@ -962,7 +962,7 @@ printf 'poll=%s\n' "${FM_POLL:-missing}" >> "${FM_ARM_LOG:?}"
 printf 'watcher: healthy pid=1 (beacon 0s)\n'
 SH
   chmod +x "$repo/bin/fm-watch-arm.sh"
-  out=$(PLUGIN="$plugin" WORKTREE="$repo" FM_HOME="$home" FM_ARM_LOG="$log" node 2>&1 <<'EOF'
+  out=$(PLUGIN="$plugin" WORKTREE="$repo" FM_HOME="$home" FM_ARM_LOG="$log" node --input-type=module 2>&1 <<'EOF'
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
@@ -1011,7 +1011,7 @@ printf 'arm\n' >> "${FM_ARM_LOG:?}"
 printf 'watcher: healthy pid=1 (beacon 0s)\n'
 SH
   chmod +x "$repo/bin/fm-watch-arm.sh"
-  out=$(PLUGIN="$plugin" WORKTREE="$repo" FM_HOME="$home" FM_ARM_LOG="$log" node 2>&1 <<'EOF'
+  out=$(PLUGIN="$plugin" WORKTREE="$repo" FM_HOME="$home" FM_ARM_LOG="$log" node --input-type=module 2>&1 <<'EOF'
 import { existsSync, writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
@@ -1064,7 +1064,7 @@ printf 'arm\n' >> "${FM_ARM_LOG:?}"
 printf 'watcher: healthy pid=1 (beacon 0s)\n'
 SH
   chmod +x "$repo/bin/fm-watch-arm.sh"
-  out=$(PLUGIN="$plugin" WORKTREE="$repo" FM_HOME="$home" FM_ARM_LOG="$log" node 2>&1 <<'EOF'
+  out=$(PLUGIN="$plugin" WORKTREE="$repo" FM_HOME="$home" FM_ARM_LOG="$log" node --input-type=module 2>&1 <<'EOF'
 import { existsSync, writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
@@ -1698,7 +1698,7 @@ printf 'guard should not run\n' >&2
 exit 2
 SH
   chmod +x "$repo/bin/fm-watch-arm.sh" "$repo/bin/fm-turnend-guard.sh"
-  out=$(ARM_PLUGIN="$arm_plugin" GUARD_PLUGIN="$guard_plugin" WORKTREE="$repo" FM_HOME="$home" FM_ARM_LOG="$log" FM_GUARD_LOG="$guard_log" node 2>&1 <<'EOF'
+  out=$(ARM_PLUGIN="$arm_plugin" GUARD_PLUGIN="$guard_plugin" WORKTREE="$repo" FM_HOME="$home" FM_ARM_LOG="$log" FM_GUARD_LOG="$guard_log" node --input-type=module 2>&1 <<'EOF'
 import { existsSync, writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
@@ -1771,7 +1771,7 @@ printf 'guard ran after external healthy watcher\n' >&2
 exit 2
 SH
   chmod +x "$repo/bin/fm-watch-arm.sh" "$repo/bin/fm-turnend-guard.sh"
-  out=$(ARM_PLUGIN="$arm_plugin" GUARD_PLUGIN="$guard_plugin" WORKTREE="$repo" FM_HOME="$home" FM_ARM_LOG="$log" FM_GUARD_LOG="$guard_log" node 2>&1 <<'EOF'
+  out=$(ARM_PLUGIN="$arm_plugin" GUARD_PLUGIN="$guard_plugin" WORKTREE="$repo" FM_HOME="$home" FM_ARM_LOG="$log" FM_GUARD_LOG="$guard_log" node --input-type=module 2>&1 <<'EOF'
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
@@ -1826,6 +1826,10 @@ EOF
 
 test_tracked_extension_present_and_self_hashing
 test_spawn_template_mentions_pi_watch_placeholder
+if [ "$(node -p 'Number(process.versions.node.split(".")[0])')" -lt 22 ]; then
+  printf 'skip: Node.js 22+ is required for direct TypeScript extension runtime tests\n'
+  exit 0
+fi
 test_pi_extension_reports_external_healthy_watcher
 test_pi_tool_returns_agent_tool_result
 test_pi_actionable_close_starts_single_successor_before_delivery

--- a/tests/fm-secondmate-lifecycle-e2e.test.sh
+++ b/tests/fm-secondmate-lifecycle-e2e.test.sh
@@ -151,10 +151,12 @@ phase_send() {
 }
 
 phase_handoff() {
-  # The move is delegated to `tasks-axi mv`; skip cleanly when it is absent (the
-  # downstream recovery and teardown phases do not depend on this phase).
-  if ! command -v tasks-axi >/dev/null 2>&1; then
-    echo "skip: tasks-axi not found (backlog handoff delegates to it)"
+  # The move is delegated to `tasks-axi mv`; skip cleanly when it is absent or
+  # incompatible (the downstream phases do not depend on this phase).
+  # shellcheck source=bin/fm-tasks-axi-lib.sh disable=SC1091
+  . "$ROOT/bin/fm-tasks-axi-lib.sh"
+  if ! fm_tasks_axi_compatible; then
+    echo "skip: compatible tasks-axi not found (backlog handoff delegates to it)"
     return 0
   fi
   cat > "$HOME_DIR/data/backlog.md" <<'EOF'

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -191,6 +191,16 @@ SH
   chmod +x "$fakebin/ps"
 }
 
+make_fake_ps_denied() {
+  local fakebin=$1
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' 'ps: operation not permitted' >&2
+exit 1
+SH
+  chmod +x "$fakebin/ps"
+}
+
 # make_fake_tmux <fakebin> <live-target>: display-message succeeds only for
 # the given "session:window" target - the exact primitive
 # fm_backend_target_exists uses for a tmux endpoint liveness read.
@@ -603,6 +613,27 @@ EOF
   pass "fm-session-start.sh composes the real fm-lock.sh, fm-bootstrap.sh, and fm-wake-drain.sh output verbatim"
 }
 
+test_codex_ps_denied_lock_owner_survives_session_start() {
+  local rec root home fakebin out owner status
+  rec=$(new_world codex-lock-owner)
+  IFS='|' read -r root home fakebin <<EOF
+$rec
+EOF
+  make_fake_toolchain "$fakebin"
+  make_fake_ps_denied "$fakebin"
+
+  out=$(CODEX_THREAD_ID=test-thread CODEX_SANDBOX=seatbelt run_session_start "$home" "$root" "$fakebin:$BASE_PATH")
+  assert_contains "$out" "lock acquired: harness codex:test-thread" "session start did not acquire through Codex fallback"
+
+  owner=$(cat "$home/state/.lock")
+  [ "$owner" = "codex:test-thread" ] || fail "session-start lock owner was '$owner', expected Codex thread token"
+
+  status=$(FM_HOME="$home" CODEX_THREAD_ID=test-thread CODEX_SANDBOX=seatbelt PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-lock.sh" status)
+  assert_contains "$status" "lock: held by live harness codex:test-thread" "session-start lock owner was stale after the subprocess exited"
+
+  pass "fm-session-start uses a stable Codex thread lock owner when ps is denied"
+}
+
 # --- fleet-state digest: compact backlog rendering --------------------------
 
 write_long_body_backlog() {
@@ -912,6 +943,7 @@ test_orphan_status_logs_are_printed
 test_endpoint_liveness_tmux
 test_endpoint_liveness_herdr
 test_composition_invokes_real_scripts
+test_codex_ps_denied_lock_owner_survives_session_start
 test_backlog_compact_tasks_axi_omits_bodies_and_keeps_metadata
 test_backlog_compact_manual_backend_skips_indented_bodies
 test_backlog_compact_tasks_axi_unavailable_uses_manual_fallback

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -629,7 +629,7 @@ EOF
   [ "$owner" = "codex:test-thread" ] || fail "session-start lock owner was '$owner', expected Codex thread token"
 
   status=$(FM_HOME="$home" CODEX_THREAD_ID=test-thread CODEX_SANDBOX=seatbelt PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-lock.sh" status)
-  assert_contains "$status" "lock: held by live harness codex:test-thread" "session-start lock owner was stale after the subprocess exited"
+  assert_contains "$status" "lock: held by hosted Codex session codex:test-thread" "session-start lock owner was stale after the subprocess exited"
 
   pass "fm-session-start uses a stable Codex thread lock owner when ps is denied"
 }

--- a/tests/fm-turnend-guard.test.sh
+++ b/tests/fm-turnend-guard.test.sh
@@ -937,7 +937,11 @@ test_codex_hook_uses_process_pwd_when_payload_cwd_is_outside_root
 test_codex_hook_ignores_nested_git_root_guard
 test_opencode_plugin_forces_followup
 test_opencode_plugin_anchors_guard_to_worktree
-test_pi_extension_forces_followup
-test_pi_extension_injects_once_per_logical_agent_run
-test_pi_extension_retries_after_followup_delivery_failure
+if [ "$(node -p 'Number(process.versions.node.split(".")[0])')" -ge 22 ]; then
+  test_pi_extension_forces_followup
+  test_pi_extension_injects_once_per_logical_agent_run
+  test_pi_extension_retries_after_followup_delivery_failure
+else
+  printf 'skip: Node.js 22+ is required for direct TypeScript extension runtime tests\n'
+fi
 test_grok_hook_invokes_adapter

--- a/tests/fm-turnend-guard.test.sh
+++ b/tests/fm-turnend-guard.test.sh
@@ -718,7 +718,7 @@ exit 2
 EOF
   chmod +x "$worktree_dir/bin/fm-turnend-guard.sh"
   # Runtime module-format warnings are host noise; this assertion owns plugin output only.
-  out=$(NODE_NO_WARNINGS=1 PLUGIN="$plugin" DIRECTORY="$wrong_dir" WORKTREE="$worktree_dir" node 2>&1 <<'EOF'
+  out=$(NODE_NO_WARNINGS=1 PLUGIN="$plugin" DIRECTORY="$wrong_dir" WORKTREE="$worktree_dir" node --input-type=module 2>&1 <<'EOF'
 import { pathToFileURL } from "node:url";
 
 const mod = await import(pathToFileURL(process.env.PLUGIN).href);


### PR DESCRIPTION
## Summary

- Use `codex:<CODEX_THREAD_ID>` as the hosted Codex session-lock owner when seatbelt prevents process ancestry inspection.
- Treat every different `codex:` owner as another hosted Codex session and refuse acquisition instead of reclaiming by lock age.
- Report ps-denied live PIDs as uninspectable live holders rather than live harness PIDs.
- Add focused regression coverage for same-thread reacquire, old different-token refusal, and session-start Codex lock ownership.
- Include no-mistakes follow-up fixes for stale docs/test wording and a cmux surface liveness false-positive found by the full suite.
- Rebased onto current upstream `main` (past #296) to resolve the maintainer-reported merge conflict, and stabilized one Node ESM test invocation (`--input-type=module`) that the rebase's merged content depended on Node's version-dependent auto-detection for.

## Validation

- `bash tests/fm-lock.test.sh`
- `bash tests/fm-session-start.test.sh`
- `bash -n bin/fm-lock.sh`
- `bash -n tests/fm-lock.test.sh`
- `bash -n tests/fm-session-start.test.sh`
- `shellcheck bin/*.sh bin/backends/*.sh tests/*.sh`
- Rebased onto current upstream `main` (past #296); reran the full local suite and shellcheck clean, then re-validated through no-mistakes: review approved, tests re-run and passing (the two remaining pre-existing/unrelated failures below were left untouched), documentation, lint, and push all completed cleanly.
- Prior no-mistakes runs `01KWWJSZBVNWHSDZZN24MGPDXK`, `01KX2VTAMPHA5ZAEFF4HZQSZ78`, `01KX2XCP1XZNPH72ZF6J6H99VW` (pre-rebase) and `01KY3DKVT4Q1VEVXHSQ2B3HWV1` (post-rebase) all completed review/test/document/lint/push for this branch.

## Known-unrelated findings observed during validation (explicitly out of scope, not touched)

- `bin/fm-review-diff.sh`: GitLab MR URLs don't match the `/pull/` parser (`not ok - parser rejected a canonical merge request URL`). Pre-existing, file untouched by this PR's diff.
- Orca backend: `not ok - Orca spawn should fail when metadata cannot be written`. Pre-existing, file untouched by this PR's diff.

## Manual recovery note

This intentionally leaves manual recovery for abandoned hosted Codex lock tokens outside this PR; the manual escape hatch is that an operator can remove `state/.lock` directly after independently confirming no live session actually holds it. The branch updates the existing `codex-lock-token-reclaim` PR head; no duplicate open PR was created.

## ⚠️ Upstream CI "Behavior tests" cannot go green right now — pre-existing, repo-wide, unrelated to this PR

The `Behavior tests` job is timing out (`timeout-minutes: 15`) and getting cancelled, on this PR and elsewhere, **before** this PR's own changes come into play. Evidence:

1. **Local sequential timing** (same invocation CI uses: `for t in tests/*.test.sh; do bash "$t"; done`) on this exact branch totals **1418s (~23.6 min)** — already over the 15-minute CI ceiling, with no relation to this PR's diff. Slowest files: `tests/fm-secondmate-harness.test.sh` (115s), `tests/fm-backend-herdr-presentation-e2e.test.sh` (113s), `tests/fm-watcher-lock.test.sh` (104s), `tests/fm-watch-triage.test.sh` (104s) — none touched by this PR.
2. **The same timeout is hitting unrelated work right now**, including a direct push to `main` itself: run [`29879666989`](https://github.com/kunchenguid/firstmate/actions/runs/29879666989) (`main`, commit for #821) — `Behavior tests` cancelled. Also cancelled on unrelated open PRs (`fm/fm-herdr-child-topology-correction`, `fm/copilot-home-lock`, `fm/failover-substrate-f2`, `fm/kimi-adapter-v1`, multiple times).
3. **Bisection**: the last green `main` CI run was ~4h ago at `59ece45` (#797). The only commit merged to `main` since is `c58cb0f` / **#821** ("fix(herdr): group projected children beneath owning parents"), which added ~660 new lines of herdr presentation e2e test coverage (`tests/fm-backend-herdr-presentation-e2e.test.sh`, `tests/fm-backend-herdr.test.sh`). That is the most likely cause of the suite's total runtime crossing the 15-minute ceiling for every branch based on current `main`, including this one after the requested rebase.
4. This PR's own `Behavior tests` run: [`29878932221`](https://github.com/kunchenguid/firstmate/actions/runs/29878932221) (job [`88796746025`](https://github.com/kunchenguid/firstmate/actions/runs/29878932221/job/88796746025)) — cancelled at the 15-minute mark; every test that had a chance to run passed, including the Codex-lock coverage this PR adds.

This is a repo-wide CI-capacity issue, not a defect in this PR's diff — raising `timeout-minutes` in `.github/workflows/ci.yml` (or trimming/parallelizing the new herdr e2e suite) is a maintainer call on shared CI config, out of scope here. Flagging for visibility rather than holding this PR open on it.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **no-mistakes** - passed (review/test/document/lint/push)</summary>

Run `01KY3DKVT4Q1VEVXHSQ2B3HWV1` for branch `codex-lock-token-reclaim` at `4e7dfaa`: review approved, tests re-run and passing (see known-unrelated findings above), documentation, lint, and push all completed. The pipeline's own CI monitor tracks a local staging PR without configured checks; the real upstream CI status for this PR is reported above directly.

</details>
