### PR TITLE
feat(spawn): name claude crewmate sessions fm-<id> for agent-view readability

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -82,6 +82,9 @@ Natural language is acceptable if uncertain.
 | Interrupt | single Escape |
 | Skill invocation | `/<skill>` (e.g. `/no-mistakes`) |
 
+fm-spawn names every claude session `fm-<id>` (the window name) via `-n`, so crewmates are readable in Claude Code's agent view (`claude agents`).
+The launch template also clears `CLAUDE_JOB_DIR`, which otherwise leaks from a captain-side `claude --bg` job through the tmux server environment and silently overrides `-n` with the parent job's name (verified empirically on 2.1.201).
+
 First launch in a fresh worktree, or first ever on a machine, may show a trust or bypass-permissions confirmation.
 After every spawn, peek the pane within about 20 seconds.
 If such a dialog is showing, accept it with `bin/fm-send.sh <window> --key Enter`, or the choice the dialog requires, and verify the brief started processing.

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -70,6 +70,8 @@
 #                  turn-end signal rides the launch command, e.g. codex -c notify=[...])
 #     __PIEXT__    absolute path to state/<task-id>.pi-ext.ts (pi turn-end extension,
 #                  written by this script; outside the worktree to avoid pi's trust gate)
+#     __TASKID__   fm-<task-id>, the window name; names the claude session so it is
+#                  readable in Claude Code's agent view (claude template only)
 # Per-harness turn-end hooks are installed automatically; some live outside the worktree.
 # grok uses a firstmate-owned global hook under ${GROK_HOME:-$HOME/.grok}/hooks
 # plus a gitignored .fm-grok-turnend worktree pointer and a state token.
@@ -304,7 +306,16 @@ launch_template() {
     # does NOT suppress the interactive ghost text (verified empirically), so the env
     # var is the correct control. The dim-aware composer reader in fm-tmux-lib.sh is
     # the defense-in-depth backstop for any pane this flag cannot reach.
-    claude) printf '%s' 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions __MODELFLAG____EFFORTFLAG__"$(cat __BRIEF__)"' ;;
+    # -n __TASKID__ names the session fm-<id> (matching the window name) so
+    # crewmates are readable in Claude Code's agent view (`claude agents`)
+    # instead of all sharing an auto-generated name. Claude-harness only.
+    # CLAUDE_JOB_DIR= is required for -n to take effect: when firstmate's tmux
+    # server was started from inside a `claude --bg` job, that job's
+    # CLAUDE_JOB_DIR leaks into every pane via the server environment and the
+    # nested claude silently adopts the parent job's name, overriding -n
+    # (verified empirically on claude 2.1.201; clearing this one var restores
+    # -n, and an empty value is treated as unset).
+    claude) printf '%s' 'CLAUDE_JOB_DIR= CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude -n __TASKID__ --dangerously-skip-permissions __MODELFLAG____EFFORTFLAG__"$(cat __BRIEF__)"' ;;
     codex)
       if [ "$kind" = secondmate ]; then
         printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox "$(cat __BRIEF__)"'
@@ -978,6 +989,7 @@ META_WINDOW=$T
 sq_brief=$(shell_quote "$BRIEF")
 sq_turnend=$(shell_quote "$TURNEND")
 sq_piext=$(shell_quote "$STATE/$ID.pi-ext.ts")
+sq_taskid=$(shell_quote "fm-$ID")
 MODELFLAG=$(model_flag_for_harness "$HARNESS" "$MODEL")
 EFFORTFLAG=$(effort_flag_for_harness "$HARNESS" "$EFFORT")
 LAUNCH=${LAUNCH//__MODELFLAG__/$MODELFLAG}
@@ -985,6 +997,7 @@ LAUNCH=${LAUNCH//__EFFORTFLAG__/$EFFORTFLAG}
 LAUNCH=${LAUNCH//__BRIEF__/$sq_brief}
 LAUNCH=${LAUNCH//__TURNEND__/$sq_turnend}
 LAUNCH=${LAUNCH//__PIEXT__/$sq_piext}
+LAUNCH=${LAUNCH//__TASKID__/$sq_taskid}
 if [ "$KIND" = secondmate ]; then
   sq_home=$(shell_quote "$PROJ_ABS")
   LAUNCH="FM_ROOT_OVERRIDE= FM_STATE_OVERRIDE= FM_DATA_OVERRIDE= FM_PROJECTS_OVERRIDE= FM_CONFIG_OVERRIDE= FM_HOME=$sq_home $LAUNCH"

--- a/tests/fm-backend-orca.test.sh
+++ b/tests/fm-backend-orca.test.sh
@@ -488,7 +488,7 @@ test_spawn_writes_orca_metadata_and_launches_harness() {
     "spawn should reuse the implicit terminal returned by Orca worktree creation"
   assert_contains "$(cat "$log")" $'orca\x1f''terminal'$'\x1f''send'$'\x1f''--terminal'$'\x1f''term-spawn'$'\x1f''--text'$'\x1f''export GOTMPDIR=/tmp/fm-orcaspawnz1/gotmp'$'\x1f''--enter'$'\x1f''--json' \
     "spawn did not export GOTMPDIR through the Orca terminal"
-  assert_contains "$(cat "$log")" "CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions" \
+  assert_contains "$(cat "$log")" "CLAUDE_JOB_DIR= CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude -n 'fm-$id' --dangerously-skip-permissions" \
     "spawn did not send the selected harness launch command through Orca"
   rm -rf "/tmp/fm-$id"
   pass "fm-spawn.sh --backend orca: reuses implicit terminal, records metadata, launches harness"

--- a/tests/fm-backend.test.sh
+++ b/tests/fm-backend.test.sh
@@ -750,14 +750,20 @@ test_spawn_conformance_old_vs_new() {
   assert_contains "$out_new" "spawned $id harness=claude kind=ship mode=no-mistakes yolo=off window=firstmate:fm-$id worktree=$wt" \
     "spawn output missing the expected summary line"
 
-  diff -u "$log_old" "$log_new" > "$TMP_ROOT/spawn-diff.txt" 2>&1 \
+  # The claude launch template intentionally gained "CLAUDE_JOB_DIR= " and
+  # "-n 'fm-<id>'" after the baseline (agent-view session naming); rewrite the
+  # old log's launch line to the new form so the conformance diff still fails
+  # on any UNINTENDED drift while tolerating that one known delta.
+  sed "s|CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions|CLAUDE_JOB_DIR= CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude -n 'fm-$id' --dangerously-skip-permissions|" \
+    "$log_old" > "$TMP_ROOT/spawn-old-adjusted.log"
+  diff -u "$TMP_ROOT/spawn-old-adjusted.log" "$log_new" > "$TMP_ROOT/spawn-diff.txt" 2>&1 \
     || fail "fm-spawn.sh: tmux command log differs old vs new"$'\n'"$(cat "$TMP_ROOT/spawn-diff.txt")"
 
   # Sanity: the log actually captured the session/window lifecycle so an
   # accidentally-empty log (e.g. a fake tmux path typo) cannot pass silently.
   assert_contains "$(cat "$log_new")" $'\x1f''new-window' "spawn tmux log missing new-window"
   assert_contains "$(cat "$log_new")" $'\x1f''treehouse get' "spawn tmux log missing the treehouse get send"
-  assert_contains "$(cat "$log_new")" $'\x1f''-l'$'\x1f'"CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions \"\$(cat '$data/$id/brief.md')\"" \
+  assert_contains "$(cat "$log_new")" $'\x1f''-l'$'\x1f'"CLAUDE_JOB_DIR= CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude -n 'fm-$id' --dangerously-skip-permissions \"\$(cat '$data/$id/brief.md')\"" \
     "spawn tmux log missing the literal launch-command send"
 
   rm -rf "/tmp/fm-$id"

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -503,7 +503,7 @@ test_spawn_secondmate_harness_model_token() {
   [ "$(meta_field "$meta" model)" = opus ] || fail "model-token: meta model not opus (got '$(meta_field "$meta" model)')"
   [ "$(meta_field "$meta" effort)" = default ] || fail "model-token: meta effort not default (got '$(meta_field "$meta" effort)')"
   launch=$(cat "$launchlog")
-  assert_contains "$launch" "claude --dangerously-skip-permissions --model 'opus'" \
+  assert_contains "$launch" "claude -n 'fm-sm' --dangerously-skip-permissions --model 'opus'" \
     "model-token: launch did not carry --model opus"
   assert_not_contains "$launch" "--effort" "model-token: launch must not carry an --effort flag"
   pass "C3 spawn: config/secondmate-harness's model token threads --model into the launch and meta"
@@ -525,7 +525,7 @@ test_spawn_secondmate_harness_model_and_effort_tokens() {
   [ "$(meta_field "$meta" model)" = opus ] || fail "model-effort-tokens: meta model not opus"
   [ "$(meta_field "$meta" effort)" = high ] || fail "model-effort-tokens: meta effort not high (got '$(meta_field "$meta" effort)')"
   launch=$(cat "$launchlog")
-  assert_contains "$launch" "claude --dangerously-skip-permissions --model 'opus' --effort 'high'" \
+  assert_contains "$launch" "claude -n 'fm-sm' --dangerously-skip-permissions --model 'opus' --effort 'high'" \
     "model-effort-tokens: launch did not carry both --model opus and --effort high"
   pass "C4 spawn: config/secondmate-harness's model+effort tokens thread into the launch and meta"
 }

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -118,7 +118,7 @@ test_no_profile_keeps_claude_launch_unchanged() {
   assert_meta_profile "$HOME_DIR/state/$id.meta" claude default default
 
   launch=$(cat "$LAUNCH_LOG")
-  expected="CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions \"\$(cat '$HOME_DIR/data/$id/brief.md')\""
+  expected="CLAUDE_JOB_DIR= CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude -n 'fm-$id' --dangerously-skip-permissions \"\$(cat '$HOME_DIR/data/$id/brief.md')\""
   [ "$launch" = "$expected" ] || fail "no-profile claude launch changed"$'\n'"expected: $expected"$'\n'"actual:   $launch"
   pass "no --model/--effort records defaults and keeps the claude launch byte-identical"
 }
@@ -219,7 +219,7 @@ test_claude_threads_model_and_effort() {
   expect_code 0 "$status" "claude spawn with profile flags should succeed"
   assert_meta_profile "$HOME_DIR/state/$id.meta" claude sonnet high
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "claude --dangerously-skip-permissions --model 'sonnet' --effort 'high'" \
+  assert_contains "$launch" "claude -n 'fm-$id' --dangerously-skip-permissions --model 'sonnet' --effort 'high'" \
     "claude launch did not thread model and effort flags"
   pass "claude receives --model and --effort profile flags"
 }


### PR DESCRIPTION
## What

Name fm-spawned claude crewmate sessions `fm-<id>` so they are readable in Claude Code's agent view (`claude agents`), instead of all sharing one auto-generated name.

- `bin/fm-spawn.sh`: the claude launch template gains `-n __TASKID__`, wired through a new `__TASKID__` placeholder substituted next to `__BRIEF__`/`__TURNEND__`. The value is `fm-<task-id>`, matching the tmux window name, so agent view and tmux agree on identity. Claude template only; codex/opencode/pi/grok are untouched.
- The template also prefixes `CLAUDE_JOB_DIR=`: verified empirically (claude 2.1.201) that when firstmate's tmux server was started from inside a `claude --bg` job, that job's `CLAUDE_JOB_DIR` leaks into every pane via the tmux server environment and the nested claude silently adopts the parent job's name, defeating `-n`. Bisected to that single variable; an empty value behaves as unset. This is why every session previously showed the same leaked name.
- `.agents/skills/harness-adapters/SKILL.md`: two lines in the claude section documenting the naming and the leak.

## Verification

- `-n` + `CLAUDE_JOB_DIR=` produces a session named `fm-<id>` in `claude agents --json` and the prompt box (verified live in a scratch tmux pane, cleaned up after).
- Busy-pane spinner rendering is identical with and without `-n` (sampled 10x each during live tool runs). The `esc to interrupt` hint not rendering on 2.1.201 is pre-existing version drift, present in the baseline too.
- `fm_tmux_composer_state` reads an idle `-n`-labeled pane as `empty` (the name renders on the border row, not the cursor row).
- zellij/cmux tab naming is unaffected: both match titles they set themselves at creation, never the live terminal title.

## Tests

Five assertion sites pinning the exact claude launch string updated to the new form. The old-vs-new spawn conformance test in `tests/fm-backend.test.sh` rewrites the baseline log's launch line to the new form before diffing - a targeted tolerance for this one intentional delta (a no-op once merged, since the merge-base then contains the new template) that keeps the diff sensitive to unintended drift. All 19 fm-spawn-touching test files pass locally; the full suite passed in the no-mistakes pipeline (review, test, document, lint all green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ESc8CDmc2vPdafGVMd8oft
