### PR TITLE
feat(bin): add amend briefs for existing PR fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -827,6 +827,7 @@ The scaffold reads the mode via `fm-project-mode.sh`, so you do not pass it.
 Ship briefs also include the project-memory contract: run `bin/fm-ensure-agents-md.sh` when the project already has agent-memory files or when the task produced durable project-intrinsic knowledge, then record proportionate learnings in `AGENTS.md`.
 For scout tasks add `--scout`: the scaffold swaps the definition of done for the report contract (findings to `data/<id>/report.md`, no branch, no push, no PR) and declares the worktree scratch; scout is mode-agnostic.
 Scout briefs do not include the project-memory step, because their deliverable is a report rather than a committed project change.
+For amending an already-open PR instead of shipping a new one, add `--amend <pr-url> --head <sha>`: the scaffold swaps in a checkout-the-existing-branch setup and a done contract that requires a new pushed head different from `<sha>`, because a fresh crew handed only "amend this PR" has repeatedly read the branch's already-finished diff and declared done without pushing anything.
 For secondmates use `bin/fm-brief.sh <id> --secondmate <project>...`.
 The scaffold writes a charter brief instead of a task brief.
 Set `FM_SECONDMATE_CHARTER='<charter>'` to fill the charter text and `FM_SECONDMATE_SCOPE='<scope>'` when the routing scope differs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -827,7 +827,7 @@ The scaffold reads the mode via `fm-project-mode.sh`, so you do not pass it.
 Ship briefs also include the project-memory contract: run `bin/fm-ensure-agents-md.sh` when the project already has agent-memory files or when the task produced durable project-intrinsic knowledge, then record proportionate learnings in `AGENTS.md`.
 For scout tasks add `--scout`: the scaffold swaps the definition of done for the report contract (findings to `data/<id>/report.md`, no branch, no push, no PR) and declares the worktree scratch; scout is mode-agnostic.
 Scout briefs do not include the project-memory step, because their deliverable is a report rather than a committed project change.
-For amending an already-open PR instead of shipping a new one, add `--amend <pr-url> --head <sha>`: the scaffold swaps in a checkout-the-existing-branch setup and a done contract that requires a new pushed head different from `<sha>`, because a fresh crew handed only "amend this PR" has repeatedly read the branch's already-finished diff and declared done without pushing anything.
+For amending an already-open PR instead of shipping a new one, add `--amend <pr-url> --head <sha>`; the scaffold sets up the existing-branch checkout and a done contract requiring a new pushed head different from `<sha>` (full contract in the scaffold).
 For secondmates use `bin/fm-brief.sh <id> --secondmate <project>...`.
 The scaffold writes a charter brief instead of a task brief.
 Set `FM_SECONDMATE_CHARTER='<charter>'` to fill the charter text and `FM_SECONDMATE_SCOPE='<scope>'` when the routing scope differs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -503,7 +503,7 @@ If that pre-launch fast-forward is skipped, `fm-spawn.sh` prints a concise warni
 The spawn also propagates the primary's inheritable config into the secondmate home's `config/`, mirroring the bootstrap sweep (section 3).
 No nudge is needed at spawn because the agent reads `AGENTS.md` fresh on launch.
 For already-live secondmates, use `bin/fm-config-push.sh` when only this inherited config needs to be pushed.
-Project worktrees start at detached HEAD on a clean default branch; ship briefs tell the crewmate to create its branch, while scout briefs keep the worktree scratch.
+Project worktrees start at detached HEAD on a clean default branch; ordinary ship briefs tell the crewmate to create its branch, amend briefs tell it to check out the existing PR branch, and scout briefs keep the worktree scratch.
 After spawning, peek the endpoint to confirm the crewmate is processing the brief and handle any trust dialog with `harness-adapters`.
 Add the task to `data/backlog.md` under In flight.
 
@@ -517,7 +517,8 @@ Because `fm-send` to a `kind=secondmate` target marks the request as from-firstm
 
 ### Delivery modes and yolo
 
-A ship task's path from `done` to landed on `main` is set by the project's `mode` (recorded in meta; section 6); `yolo` decides who approves. The Validate / PR ready / Ship teardown stages below are written for the `no-mistakes` path; the other modes diverge:
+An ordinary ship task's path from `done` to landed on `main` is set by the project's `mode` (recorded in meta; section 6); `yolo` decides who approves.
+The Validate / PR ready / Ship teardown stages below are written for the `no-mistakes` path; the other modes diverge:
 
 - **no-mistakes** - the stages below as written: no-mistakes validation pipeline -> PR -> captain merge.
 - **direct-PR** - no pipeline. The crewmate pushes and opens the PR itself (its brief says so) and reports `done: PR <url>`. Skip the Validate step and go straight to PR ready (run `fm-pr-check`, relay the PR). Teardown uses the normal landed-work check.
@@ -707,7 +708,7 @@ Firstmate is a treehouse-pooled git repo of itself - the primary checkout (the r
 If a crewmate sent to work firstmate-on-itself branches or commits in the primary instead of its own isolated worktree, the primary is stranded on a feature branch (the failure this guards against); the guard names the offending branch and prints the non-destructive restore (`git -C <root> checkout <default>`), so the tangle surfaces on the very next fleet action.
 The check is scoped precisely to the primary: detached HEAD (the legitimate resting state of crewmate worktrees and secondmate homes on the default branch) and the default branch itself never alarm; only a named non-default branch checked out in the primary does.
 The same assertion runs at session start as the bootstrap `TANGLE:` line inside the `bin/fm-session-start.sh` digest (section 3), with read-only wording when this session does not hold the fleet lock.
-Two further guards prevent the tangle upstream: `fm-spawn` refuses to launch unless treehouse or Orca yields a genuine isolated worktree distinct from the primary checkout, and every ship brief's first instruction has the crewmate verify it is in its own worktree before branching (section 11).
+Two further guards prevent the tangle upstream: `fm-spawn` refuses to launch unless treehouse or Orca yields a genuine isolated worktree distinct from the primary checkout, and every ship brief's first instruction has the crewmate verify it is in its own worktree before branch or PR checkout work (section 11).
 
 On the `claude` harness, "no turn ends blind" has a structural backstop beyond the pull-based `fm-guard.sh` banner: `bin/fm-turnend-guard.sh`, a Claude Code Stop hook registered in the tracked `.claude/settings.json`, fires on every primary turn end and, when tasks are in flight without a live identity-matched watcher lock and fresh beacon, blocks the stop (exit 2 with a reason) so the turn cannot end without acting on it first.
 It shares status fields with `fm-guard.sh` via `bin/fm-supervision-lib.sh`, uses `bin/fm-wake-lib.sh` for live watcher lock health, and never blocks more than once per turn (Claude Code's own `stop_hook_active` loop-guard field lets it always allow the retry).
@@ -820,14 +821,14 @@ Correct or delete stale free-form notes the moment you catch them, and put durab
 ## 11. Crewmate briefs
 
 Scaffold with `bin/fm-brief.sh <id> <repo-name>` - it writes `data/<id>/brief.md` with the standard contract (branch setup, status-reporting protocol, push/merge rules, definition of done) and all paths filled in.
-The ship-brief Setup opens with a worktree-isolation assertion ahead of the branch step: the crewmate confirms it is in its own disposable task worktree, not the primary checkout, and stops with `blocked: launched in primary checkout, not an isolated worktree` if not - the upstream half of the worktree-tangle guard (section 8).
-For a ship task the definition of done is shaped by the project's delivery mode (section 6): `no-mistakes` stops after the implementation commit, then firstmate triggers the harness-appropriate no-mistakes validation pipeline; `direct-PR` has the crewmate push and open the PR itself, and `local-only` has it stop at "ready in branch" for firstmate to review and merge locally.
+The ship-brief Setup opens with a worktree-isolation assertion ahead of the branch or PR checkout step: the crewmate confirms it is in its own disposable task worktree, not the primary checkout, and stops with `blocked: launched in primary checkout, not an isolated worktree` if not - the upstream half of the worktree-tangle guard (section 8).
+For an ordinary ship task the definition of done is shaped by the project's delivery mode (section 6): `no-mistakes` stops after the implementation commit, then firstmate triggers the harness-appropriate no-mistakes validation pipeline; `direct-PR` has the crewmate push and open the PR itself, and `local-only` has it stop at "ready in branch" for firstmate to review and merge locally.
 The no-mistakes brief points to no-mistakes' version-matched guidance and keeps only firstmate-specific wrapper rules for `ask-user` escalation, `--yes` avoidance, and the CI-green done line.
 The scaffold reads the mode via `fm-project-mode.sh`, so you do not pass it.
-Ship briefs also include the project-memory contract: run `bin/fm-ensure-agents-md.sh` when the project already has agent-memory files or when the task produced durable project-intrinsic knowledge, then record proportionate learnings in `AGENTS.md`.
+Ordinary ship briefs also include the project-memory contract: run `bin/fm-ensure-agents-md.sh` when the project already has agent-memory files or when the task produced durable project-intrinsic knowledge, then record proportionate learnings in `AGENTS.md`.
 For scout tasks add `--scout`: the scaffold swaps the definition of done for the report contract (findings to `data/<id>/report.md`, no branch, no push, no PR) and declares the worktree scratch; scout is mode-agnostic.
 Scout briefs do not include the project-memory step, because their deliverable is a report rather than a committed project change.
-For amending an already-open PR instead of shipping a new one, add `--amend <pr-url> --head <sha>`; the scaffold sets up the existing-branch checkout and a done contract requiring a new pushed head different from `<sha>` (full contract in the scaffold).
+For amending an already-open PR, use `--amend <pr-url> --head <sha>`; the full contract and head-resolution guidance live in `bin/fm-brief.sh` and the generated scaffold.
 For secondmates use `bin/fm-brief.sh <id> --secondmate <project>...`.
 The scaffold writes a charter brief instead of a task brief.
 Set `FM_SECONDMATE_CHARTER='<charter>'` to fill the charter text and `FM_SECONDMATE_SCOPE='<scope>'` when the routing scope differs.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,7 +88,7 @@ tests/fm-grok-harness.test.sh             # grok adapter spawn hook, token guard
 tests/fm-fleet-sync.test.sh               # project clone refresh: safe detached recovery, STUCK drift reports, benign skips, and bootstrap relay
 tests/fm-x-mode.test.sh                   # X-mode poll, inbox context round-trip, reply threading, dismiss, completion follow-up counters/caps, dry-run preview, and .env-presence activation tests
 tests/fm-tangle-guard.test.sh             # primary-checkout tangle detection, read-only remediation suppression, and spawn/brief isolation tests
-tests/fm-brief.test.sh                    # fm-brief.sh bash -n parse regression guard (issue #166) and clean no-mistakes/direct-PR/local-only brief generation tests
+tests/fm-brief.test.sh                    # fm-brief.sh bash -n parse regression guard (issue #166), clean no-mistakes/direct-PR/local-only generation, and existing-PR amend contract tests
 tests/fm-spawn-batch.test.sh              # batch dispatch and FM_HOME project-path scoping tests
 tests/fm-spawn-dispatch-profile.test.sh   # concrete dispatch profile flags: active-profile backstop, harness/model/effort meta, launch templates, batch forwarding, and secondmate exemption
 tests/fm-update.test.sh                   # fast-forward-only self-update, reread, nudge, dedup, and skip-safety tests

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -15,10 +15,10 @@
 #   deliverable is a NEW pushed head on the EXISTING PR <pr-url>, different from
 #   <sha>, not a new branch or PR. <sha> is a required parameter rather than a
 #   gh lookup performed by this script, because fm-brief.sh does no network I/O
-#   anywhere else - firstmate resolves it once, e.g. via
-#   `gh-axi pr view <pr-url> --json headRefOid`, before scaffolding; the crew
-#   then resolves the PR head repository and branch and fetches from that remote,
-#   so same-repo and fork PRs both work. This exists
+#   anywhere else - firstmate resolves it once, e.g. via `git ls-remote <remote>
+#   <branch>`, or `gh-axi pr checkout <number>` followed by `git rev-parse HEAD`,
+#   before scaffolding; the crew then checks out the existing PR branch with
+#   `gh-axi pr checkout <number>`, so same-repo and fork PRs both work. This exists
 #   because a fresh crew handed only "amend this PR" repeatedly read the
 #   branch's already-finished-looking diff and declared done without pushing
 #   anything; the contract now requires the crew to prove the remote head moved.
@@ -194,13 +194,13 @@ You are in a disposable git worktree of $REPO, at a detached HEAD on a clean def
 The path check is authoritative: \`git rev-parse --git-dir\` and \`git rev-parse --git-common-dir\` can help inspect the repo, but they do not prove you are outside the primary checkout.
 If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not check out anything here - append \`blocked: launched in primary checkout, not an isolated worktree\` to the status file and stop.
 
-1. Resolve the PR's head repository and branch: \`gh-axi pr view $AMEND_PR --json headRepositoryOwner,headRepository,headRefName,headRefOid\`.
-2. Add or refresh a remote that points at the resolved head repository, then fetch and check out that EXISTING branch - do NOT create a new \`fm/$ID\` branch: \`git remote remove amend-head 2>/dev/null || true; git remote add amend-head https://github.com/<owner>/<repo>.git; git fetch amend-head <branch>; git checkout -B <branch> amend-head/<branch>\`.
-3. Verify the checked-out head is \`$AMEND_HEAD\`. If \`git rev-parse HEAD\` disagrees, someone already pushed a new head since this brief was written - append \`blocked: PR head moved to {actual sha}, expected $AMEND_HEAD\` to the status file and stop.
+1. Check out the PR with \`gh-axi pr checkout <number>\`, where \`<number>\` is the trailing digits of \`$AMEND_PR\`; this works for same-repo and fork PRs alike.
+2. Verify the checked-out head is \`$AMEND_HEAD\`. If \`git rev-parse HEAD\` disagrees, someone already pushed a new head since this brief was written - append \`blocked: PR head moved to {actual sha}, expected $AMEND_HEAD\` to the status file and stop.
+3. Record the original head with \`git rev-parse HEAD\`; it must equal \`$AMEND_HEAD\`.
 4. Rebase policy: do not rebase onto the default branch and do not force-push unless the task above explicitly asks for it; add new commits on top of the existing head.
 
 # Rules
-1. Never push to the default branch, and never create a new branch for this work - push only to the existing PR branch on the head remote you checked out in Setup. Never merge a PR.
+1. Never push to the default branch, and never create a new branch for this work - push only to the existing PR branch you checked out in Setup. Never merge a PR.
 2. Stay inside this worktree; modify nothing outside it.
 3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
 4. Report status by appending one line:
@@ -215,8 +215,8 @@ If the top-level path is the primary checkout or not the worktree you were launc
    append \`needs-decision: {summary of options}\` and stop. Firstmate will reply with the decision.
 
 # Definition of done
-Implement the requested change as new commits on top of the branch you checked out, then push to the SAME branch on the resolved head remote for $AMEND_PR - no new branch, no new PR.
-Before reporting done, confirm the new remote head differs from $AMEND_HEAD: re-run \`gh-axi pr view $AMEND_PR --json headRefOid\`, or compare \`git rev-parse HEAD\` before and after your push.
+Implement the requested change as new commits on top of the branch you checked out, then push to the SAME branch for $AMEND_PR - no new branch, no new PR.
+Before reporting done, confirm \`git rev-parse HEAD\` differs from $AMEND_HEAD after your successful push.
 A local commit that was never pushed is NOT done - the deliverable is a new pushed head, not a commit.
 When the new head is pushed and confirmed different from $AMEND_HEAD, append \`done: PR $AMEND_PR new head {sha}\` to the status file and stop.
 EOF

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -32,16 +32,16 @@
 #   home's status file.
 #   Set FM_SECONDMATE_CHARTER='<charter>' to fill the charter text.
 #   Set FM_SECONDMATE_SCOPE='<scope>' to write a routing scope distinct from the charter text.
-# For ship tasks, the definition of done is shaped by the project's delivery mode
+# For ordinary ship tasks, the definition of done is shaped by the project's delivery mode
 # (data/projects.md via fm-project-mode.sh; see AGENTS.md project management
 # and task lifecycle):
 #   no-mistakes  implement -> /no-mistakes pipeline -> PR -> captain merge (default)
 #   direct-PR    implement -> push + open PR via gh-axi (no pipeline) -> captain merge
 #   local-only   implement on branch, stop and report "ready in branch" (no push/PR);
 #                firstmate reviews, captain approves, firstmate merges to local main
-# Ship briefs begin with a worktree-isolation assertion before the branch step.
+# Ship briefs begin with a worktree-isolation assertion before the branch or PR checkout step.
 # Scout tasks ignore mode - their deliverable is a report, not a merge.
-# Ship tasks include a project-memory section so durable project-intrinsic
+# Ordinary ship tasks include a project-memory section so durable project-intrinsic
 # learnings can be committed to AGENTS.md through the project's delivery path.
 # Refuses to overwrite an existing brief.
 set -eu

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -7,9 +7,22 @@
 # when the task genuinely deviates (e.g. working an existing external PR instead
 # of shipping a new one).
 # Usage: fm-brief.sh <task-id> <repo-name> [--scout]
+#        fm-brief.sh <task-id> <repo-name> --amend <pr-url> --head <sha>
 #        fm-brief.sh <task-id> --secondmate <project>...
 #   --scout writes the scout contract instead: the deliverable is a report at
 #   data/<task-id>/report.md (no branch, no push, no PR) and the worktree is scratch.
+#   --amend <pr-url> --head <sha> writes the amendment contract instead: the
+#   deliverable is a NEW pushed head on the EXISTING PR <pr-url>, different from
+#   <sha>, not a new branch or PR. <sha> is a required parameter rather than a
+#   gh lookup performed by this script, because fm-brief.sh does no network I/O
+#   anywhere else - firstmate resolves it once, e.g. via
+#   `gh-axi pr view <pr-url> --json headRefOid`, before scaffolding. This exists
+#   because a fresh crew handed only "amend this PR" repeatedly read the
+#   branch's already-finished-looking diff and declared done without pushing
+#   anything; the contract now requires the crew to prove the remote head moved.
+#   Mode-agnostic: skips the delivery-mode lookup, since the only thing that
+#   matters is a new head on the branch that already exists. Incompatible with
+#   --scout/--secondmate.
 #   --secondmate writes a persistent secondmate charter. The project list
 #   is cloned into the secondmate home, while the natural-language scope
 #   tells the main firstmate when to route work there; routine churn stays in its own home;
@@ -39,14 +52,45 @@ FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 KIND=ship
+AMEND_PR=
+AMEND_HEAD=
+AMEND_SET=0
+HEAD_SET=0
 POS=()
+want_value=
 for a in "$@"; do
+  if [ -n "$want_value" ]; then
+    case "$a" in
+      --*) echo "error: --$want_value requires a value" >&2; exit 1 ;;
+    esac
+    case "$want_value" in
+      amend) AMEND_PR=$a; AMEND_SET=1 ;;
+      head) AMEND_HEAD=$a; HEAD_SET=1 ;;
+      *) echo "error: internal parser state for --$want_value" >&2; exit 1 ;;
+    esac
+    want_value=
+    continue
+  fi
   case "$a" in
     --scout) KIND=scout ;;
     --secondmate) KIND=secondmate ;;
+    --amend) want_value=amend ;;
+    --amend=*) AMEND_PR=${a#--amend=}; AMEND_SET=1 ;;
+    --head) want_value="head" ;;
+    --head=*) AMEND_HEAD=${a#--head=}; HEAD_SET=1 ;;
     *) POS+=("$a") ;;
   esac
 done
+[ -z "$want_value" ] || { echo "error: --$want_value requires a value" >&2; exit 1; }
+[ "$AMEND_SET" -eq 0 ] || [ -n "$AMEND_PR" ] || { echo "error: --amend requires a non-empty PR URL" >&2; exit 1; }
+[ "$HEAD_SET" -eq 0 ] || [ -n "$AMEND_HEAD" ] || { echo "error: --head requires a non-empty sha" >&2; exit 1; }
+if [ "$AMEND_SET" -eq 1 ]; then
+  [ "$KIND" = ship ] || { echo "error: --amend is incompatible with --scout/--secondmate" >&2; exit 1; }
+  [ "$HEAD_SET" -eq 1 ] || { echo "error: --amend requires --head <sha>" >&2; exit 1; }
+elif [ "$HEAD_SET" -eq 1 ]; then
+  echo "error: --head requires --amend" >&2
+  exit 1
+fi
 ID=${POS[0]}
 
 BRIEF="$DATA/$ID/brief.md"
@@ -127,6 +171,56 @@ exit 0
 fi
 
 REPO=${POS[1]}
+
+if [ "$AMEND_SET" -eq 1 ]; then
+cat > "$BRIEF" <<EOF
+You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
+
+# Task
+{TASK}
+
+# Amendment contract
+THE ONLY DELIVERABLE IS A NEW PUSHED HEAD ON $AMEND_PR, DIFFERENT FROM $AMEND_HEAD.
+This is not a new PR: $AMEND_PR already exists and its current head is $AMEND_HEAD.
+A finished-looking branch, a local commit, a passing test, or a written summary do NOT count as done.
+If the remote head of $AMEND_PR is still $AMEND_HEAD when you stop, you have not completed this task.
+
+# Setup
+You are in a disposable git worktree of $REPO, at a detached HEAD on a clean default branch.
+
+**Verify isolation before anything else.** Run \`pwd -P\` and \`git rev-parse --show-toplevel\`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
+The path check is authoritative: \`git rev-parse --git-dir\` and \`git rev-parse --git-common-dir\` can help inspect the repo, but they do not prove you are outside the primary checkout.
+If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not check out anything here - append \`blocked: launched in primary checkout, not an isolated worktree\` to the status file and stop.
+
+1. Look up the PR's branch: \`gh-axi pr view $AMEND_PR --json headRefName,headRefOid\`.
+2. Fetch and check out that EXISTING branch - do NOT create a new \`fm/$ID\` branch: \`git fetch origin <branch> && git checkout <branch>\`.
+3. Verify the checked-out head is \`$AMEND_HEAD\`. If \`git rev-parse HEAD\` disagrees, someone already pushed a new head since this brief was written - append \`blocked: PR head moved to {actual sha}, expected $AMEND_HEAD\` to the status file and stop.
+4. Rebase policy: do not rebase onto the default branch and do not force-push unless the task above explicitly asks for it; add new commits on top of the existing head.
+
+# Rules
+1. Never push to the default branch, and never create a new branch for this work - push only to the existing PR branch you checked out in Setup. Never merge a PR.
+2. Stay inside this worktree; modify nothing outside it.
+3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
+4. Report status by appending one line:
+   \`echo "{state}: {one short line}" >> $STATUS_FILE\`
+   States: working, needs-decision, blocked, done, failed.
+   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
+   would act on (setup done, fix implemented, new head pushed) and the
+   needs-decision/blocked/done/failed states. No step-by-step FYI progress lines;
+   firstmate reads your pane for that.
+5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
+6. If a decision belongs to a human (product choices, destructive actions, ask-user findings),
+   append \`needs-decision: {summary of options}\` and stop. Firstmate will reply with the decision.
+
+# Definition of done
+Implement the requested change as new commits on top of the branch you checked out, then push to the SAME branch on $AMEND_PR - no new branch, no new PR.
+Before reporting done, confirm the new remote head differs from $AMEND_HEAD: re-run \`gh-axi pr view $AMEND_PR --json headRefOid\`, or compare \`git rev-parse HEAD\` before and after your push.
+A local commit that was never pushed is NOT done - the deliverable is a new pushed head, not a commit.
+When the new head is pushed and confirmed different from $AMEND_HEAD, append \`done: PR $AMEND_PR new head {sha}\` to the status file and stop.
+EOF
+echo "scaffolded: $BRIEF (ship, amend $AMEND_PR from $AMEND_HEAD)"
+exit 0
+fi
 
 if [ "$KIND" = scout ]; then
 cat > "$BRIEF" <<EOF

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -16,7 +16,9 @@
 #   <sha>, not a new branch or PR. <sha> is a required parameter rather than a
 #   gh lookup performed by this script, because fm-brief.sh does no network I/O
 #   anywhere else - firstmate resolves it once, e.g. via
-#   `gh-axi pr view <pr-url> --json headRefOid`, before scaffolding. This exists
+#   `gh-axi pr view <pr-url> --json headRefOid`, before scaffolding; the crew
+#   then resolves the PR head repository and branch and fetches from that remote,
+#   so same-repo and fork PRs both work. This exists
 #   because a fresh crew handed only "amend this PR" repeatedly read the
 #   branch's already-finished-looking diff and declared done without pushing
 #   anything; the contract now requires the crew to prove the remote head moved.
@@ -192,13 +194,13 @@ You are in a disposable git worktree of $REPO, at a detached HEAD on a clean def
 The path check is authoritative: \`git rev-parse --git-dir\` and \`git rev-parse --git-common-dir\` can help inspect the repo, but they do not prove you are outside the primary checkout.
 If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not check out anything here - append \`blocked: launched in primary checkout, not an isolated worktree\` to the status file and stop.
 
-1. Look up the PR's branch: \`gh-axi pr view $AMEND_PR --json headRefName,headRefOid\`.
-2. Fetch and check out that EXISTING branch - do NOT create a new \`fm/$ID\` branch: \`git fetch origin <branch> && git checkout <branch>\`.
+1. Resolve the PR's head repository and branch: \`gh-axi pr view $AMEND_PR --json headRepositoryOwner,headRepository,headRefName,headRefOid\`.
+2. Add or refresh a remote that points at the resolved head repository, then fetch and check out that EXISTING branch - do NOT create a new \`fm/$ID\` branch: \`git remote remove amend-head 2>/dev/null || true; git remote add amend-head https://github.com/<owner>/<repo>.git; git fetch amend-head <branch>; git checkout -B <branch> amend-head/<branch>\`.
 3. Verify the checked-out head is \`$AMEND_HEAD\`. If \`git rev-parse HEAD\` disagrees, someone already pushed a new head since this brief was written - append \`blocked: PR head moved to {actual sha}, expected $AMEND_HEAD\` to the status file and stop.
 4. Rebase policy: do not rebase onto the default branch and do not force-push unless the task above explicitly asks for it; add new commits on top of the existing head.
 
 # Rules
-1. Never push to the default branch, and never create a new branch for this work - push only to the existing PR branch you checked out in Setup. Never merge a PR.
+1. Never push to the default branch, and never create a new branch for this work - push only to the existing PR branch on the head remote you checked out in Setup. Never merge a PR.
 2. Stay inside this worktree; modify nothing outside it.
 3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
 4. Report status by appending one line:
@@ -213,7 +215,7 @@ If the top-level path is the primary checkout or not the worktree you were launc
    append \`needs-decision: {summary of options}\` and stop. Firstmate will reply with the decision.
 
 # Definition of done
-Implement the requested change as new commits on top of the branch you checked out, then push to the SAME branch on $AMEND_PR - no new branch, no new PR.
+Implement the requested change as new commits on top of the branch you checked out, then push to the SAME branch on the resolved head remote for $AMEND_PR - no new branch, no new PR.
 Before reporting done, confirm the new remote head differs from $AMEND_HEAD: re-run \`gh-axi pr view $AMEND_PR --json headRefOid\`, or compare \`git rev-parse HEAD\` before and after your push.
 A local commit that was never pushed is NOT done - the deliverable is a new pushed head, not a commit.
 When the new head is pushed and confirmed different from $AMEND_HEAD, append \`done: PR $AMEND_PR new head {sha}\` to the status file and stop.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -73,11 +73,12 @@ Only a named non-default branch checked out in `FM_ROOT` is a worktree tangle.
 `fm-tangle-lib.sh` resolves the default branch from `origin/HEAD`, then local `main` or `master`, and classifies that named non-default primary branch as the tangle.
 `fm-guard.sh` prints the repair command on the next mutable fleet action, while `bin/fm-session-start.sh` reports the same condition through bootstrap as a `TANGLE:` line at session start.
 If another live session holds the fleet lock, both surfaces keep the alarm but switch to read-only wording with no repair command.
-Ship briefs also tell the crewmate to verify `pwd -P` and `git rev-parse --show-toplevel` before creating `fm/<id>`, then stop with a blocked status if it landed in the primary checkout.
+Ship briefs also tell the crewmate to verify `pwd -P` and `git rev-parse --show-toplevel` before creating `fm/<id>` or checking out an existing PR branch, then stop with a blocked status if it landed in the primary checkout.
 
 ## Two task shapes
 
-Ship tasks change projects and ship by project mode (`no-mistakes`, `direct-PR`, or `local-only`); scout tasks investigate, plan, reproduce bugs, or audit, then leave a report at `data/<id>/report.md` and never push.
+Ordinary ship tasks change projects and ship by project mode (`no-mistakes`, `direct-PR`, or `local-only`); amend briefs are a ship-only variant for pushing a new head to an already-open PR.
+Scout tasks investigate, plan, reproduce bugs, or audit, then leave a report at `data/<id>/report.md` and never push.
 
 ## Dispatch profiles
 

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -11,7 +11,7 @@ If you have changed away from the firstmate home in an interactive shell, invoke
 | `fm-fleet-sync.sh`       | Fetch clones, fast-forward safe default-branch states, self-heal clean detached ancestor drift, report unsafe drift as `STUCK:`, and safely prune branches whose remote is gone |
 | `fm-update.sh`           | Self-update the running firstmate repo and registered secondmate homes with fast-forward-only pulls from origin     |
 | `fm-backlog-handoff.sh`  | Move already-judged in-scope queued backlog items from the main home into a seeded secondmate home                 |
-| `fm-brief.sh`            | Scaffold a ship brief with a worktree-isolation assertion, a report-only scout brief with `--scout`, or a secondmate charter with `--secondmate` |
+| `fm-brief.sh`            | Scaffold a ship brief with a worktree-isolation assertion, an existing-PR amendment brief with `--amend <pr-url> --head <sha>`, a report-only scout brief with `--scout`, or a secondmate charter with `--secondmate` |
 | `fm-ensure-agents-md.sh` | Ensure project `AGENTS.md` is the real memory file and `CLAUDE.md` symlinks to it                                   |
 | `fm-guard.sh`            | Warn when the primary checkout is tangled, when queued wakes are pending, or when a stale or missing watcher needs a prominent banner; `FM_GUARD_READ_ONLY=1` keeps the alarms but suppresses drain, arm, and checkout repair commands |
 | `fm-turnend-guard.sh`    | Claude Code Stop hook, primary-scoped only: blocks (exit 2, exact reason) a primary turn end when work is in flight without a live identity-matched watcher lock and fresh beacon, using Claude Code's own `stop_hook_active` field so it never blocks twice in one turn (docs/turnend-guard.md) |

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -94,6 +94,12 @@ test_amend_brief_renders_contract() {
   assert_grep "THE ONLY DELIVERABLE IS A NEW PUSHED HEAD ON https://github.com/kunchenguid/firstmate/pull/999, DIFFERENT FROM deadbeef1234." "$brief" \
     "amend brief missing the loud new-head statement"
   assert_grep "deadbeef1234" "$brief" "amend brief lost the required head sha"
+  assert_grep "headRepositoryOwner,headRepository,headRefName,headRefOid" "$brief" \
+    "amend brief must resolve the PR head repository, branch, and sha"
+  assert_grep "git remote add amend-head https://github.com/<owner>/<repo>.git" "$brief" \
+    "amend brief must fetch from the resolved PR head repository"
+  assert_no_grep "git fetch origin <branch>" "$brief" \
+    "amend brief must not assume the PR branch lives on origin"
   assert_grep "do NOT create a new \`fm/$id\` branch" "$brief" "amend brief must check out the existing PR branch, not create fm/<id>"
   assert_no_grep "no-mistakes" "$brief" "amend brief should not carry the standard no-mistakes Definition of done"
   assert_no_grep "EOF" "$brief" "amend brief leaked a heredoc EOF marker (unterminated heredoc)"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -94,13 +94,21 @@ test_amend_brief_renders_contract() {
   assert_grep "THE ONLY DELIVERABLE IS A NEW PUSHED HEAD ON https://github.com/kunchenguid/firstmate/pull/999, DIFFERENT FROM deadbeef1234." "$brief" \
     "amend brief missing the loud new-head statement"
   assert_grep "deadbeef1234" "$brief" "amend brief lost the required head sha"
-  assert_grep "headRepositoryOwner,headRepository,headRefName,headRefOid" "$brief" \
-    "amend brief must resolve the PR head repository, branch, and sha"
-  assert_grep "git remote add amend-head https://github.com/<owner>/<repo>.git" "$brief" \
-    "amend brief must fetch from the resolved PR head repository"
+  assert_grep "gh-axi pr checkout <number>" "$brief" \
+    "amend brief must check out the PR through gh-axi"
+  assert_grep "where \`<number>\` is the trailing digits of \`https://github.com/kunchenguid/firstmate/pull/999\`" "$brief" \
+    "amend brief must explain how to derive the PR number"
+  assert_grep "Record the original head with \`git rev-parse HEAD\`" "$brief" \
+    "amend brief must record the local original head"
+  assert_grep "confirm \`git rev-parse HEAD\` differs from deadbeef1234 after your successful push" "$brief" \
+    "amend brief must verify the new head locally after push"
+  assert_no_grep "gh-axi pr view .*--json" "$brief" \
+    "amend brief must not rely on unsupported gh-axi pr view --json"
+  assert_no_grep "git remote add amend-head" "$brief" \
+    "amend brief must not hand-roll a PR head remote"
   assert_no_grep "git fetch origin <branch>" "$brief" \
     "amend brief must not assume the PR branch lives on origin"
-  assert_grep "do NOT create a new \`fm/$id\` branch" "$brief" "amend brief must check out the existing PR branch, not create fm/<id>"
+  assert_grep "never create a new branch for this work" "$brief" "amend brief must check out the existing PR branch, not create a new branch"
   assert_no_grep "no-mistakes" "$brief" "amend brief should not carry the standard no-mistakes Definition of done"
   assert_no_grep "EOF" "$brief" "amend brief leaked a heredoc EOF marker (unterminated heredoc)"
   pass "fm-brief.sh: --amend renders the amendment contract with PR url and sha"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -76,6 +76,82 @@ test_no_mistakes_dod_wording() {
   pass "fm-brief.sh: no-mistakes DOD wording avoids the apostrophe regression"
 }
 
+# The amendment contract exists so a fresh crew handed "amend this PR" cannot
+# anchor on the branch's already-finished-looking diff and declare done without
+# ever pushing (the misfire this scaffold flag fixes). Pin the loud deliverable
+# statement, both the PR URL and sha landing in the text, and that the standard
+# ship Setup/Definition-of-done sections are swapped out rather than merged in.
+test_amend_brief_renders_contract() {
+  local home id brief
+  home="$TMP_ROOT/amend-home"
+  id="brief-amend-c1"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj \
+    --amend https://github.com/kunchenguid/firstmate/pull/999 --head deadbeef1234 \
+    >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_present "$brief" "amend brief was not scaffolded"
+  assert_grep "# Amendment contract" "$brief" "amend brief missing the Amendment contract section"
+  assert_grep "THE ONLY DELIVERABLE IS A NEW PUSHED HEAD ON https://github.com/kunchenguid/firstmate/pull/999, DIFFERENT FROM deadbeef1234." "$brief" \
+    "amend brief missing the loud new-head statement"
+  assert_grep "deadbeef1234" "$brief" "amend brief lost the required head sha"
+  assert_grep "do NOT create a new \`fm/$id\` branch" "$brief" "amend brief must check out the existing PR branch, not create fm/<id>"
+  assert_no_grep "no-mistakes" "$brief" "amend brief should not carry the standard no-mistakes Definition of done"
+  assert_no_grep "EOF" "$brief" "amend brief leaked a heredoc EOF marker (unterminated heredoc)"
+  pass "fm-brief.sh: --amend renders the amendment contract with PR url and sha"
+}
+
+# --amend without --head (and --head without --amend) must refuse rather than
+# scaffold a brief with an unenforceable contract.
+test_amend_requires_head() {
+  local home
+  home="$TMP_ROOT/amend-missing-head-home"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" amend-missing-head some-proj --amend https://x/1 \
+    >/dev/null 2>&1
+  expect_code 1 "$?" "fm-brief.sh --amend without --head should refuse"
+  assert_absent "$home/data/amend-missing-head/brief.md" "--amend without --head must not scaffold a brief"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" head-without-amend some-proj --head deadbeef \
+    >/dev/null 2>&1
+  expect_code 1 "$?" "fm-brief.sh --head without --amend should refuse"
+  assert_absent "$home/data/head-without-amend/brief.md" "--head without --amend must not scaffold a brief"
+  pass "fm-brief.sh: --amend and --head are refused unless paired"
+}
+
+# --amend is a ship-only flag; combined with --scout or --secondmate it must
+# refuse instead of silently picking one contract over the other.
+test_amend_incompatible_with_scout_and_secondmate() {
+  local home
+  home="$TMP_ROOT/amend-incompatible-home"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" amend-scout some-proj --scout \
+    --amend https://x/1 --head deadbeef >/dev/null 2>&1
+  expect_code 1 "$?" "fm-brief.sh --amend with --scout should refuse"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" amend-second --secondmate some-proj \
+    --amend https://x/1 --head deadbeef >/dev/null 2>&1
+  expect_code 1 "$?" "fm-brief.sh --amend with --secondmate should refuse"
+  pass "fm-brief.sh: --amend refuses to combine with --scout/--secondmate"
+}
+
+# A non-amend call must be entirely unaffected: the standard ship contract
+# (branch-creation Setup, mode-specific Definition of done) stays intact and
+# no Amendment contract section leaks in.
+test_non_amend_calls_keep_standard_sections() {
+  local home id brief
+  home="$TMP_ROOT/non-amend-home"
+  id="brief-non-amend-d1"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_present "$brief" "non-amend brief was not scaffolded"
+  assert_grep "git checkout -b fm/$id" "$brief" "non-amend brief lost the standard new-branch Setup step"
+  assert_grep "# Definition of done" "$brief" "non-amend brief lost the standard Definition of done section"
+  assert_no_grep "# Amendment contract" "$brief" "non-amend brief must not carry the Amendment contract section"
+  pass "fm-brief.sh: a plain ship call keeps the standard Setup/Definition-of-done sections"
+}
+
 test_script_parses
 test_ship_modes_generate_clean_briefs
 test_no_mistakes_dod_wording
+test_amend_brief_renders_contract
+test_amend_requires_head
+test_amend_incompatible_with_scout_and_secondmate
+test_non_amend_calls_keep_standard_sections

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -257,7 +257,9 @@ EOF
   make_fake_toolchain "$fakebin"
   make_fake_ps_claude "$fakebin"
   # Force a MISSING diagnostic line so the bootstrap section is non-trivial.
-  rm -f "$fakebin/node"
+  # Use gh-axi instead of node so the fixture stays independent of host tools
+  # commonly present under /usr/bin.
+  rm -f "$fakebin/gh-axi"
 
   printf 'window=fm-sess:w1\nkind=ship\n' > "$home/state/task-a.meta"
 
@@ -280,7 +282,7 @@ EOF
   [ "$context_line" -lt "$fleet_line" ] || fail "CONTEXT did not precede FLEET STATE"
   [ "$fleet_line" -lt "$next_line" ] || fail "FLEET STATE did not precede NEXT STEP"
 
-  missing_line=$(printf '%s\n' "$out" | grep -n 'MISSING: node' | head -1 | cut -d: -f1)
+  missing_line=$(printf '%s\n' "$out" | grep -n 'MISSING: gh-axi' | head -1 | cut -d: -f1)
   [ -n "$missing_line" ] || fail "MISSING diagnostic did not appear at all"
   [ "$missing_line" -lt "$fleet_line" ] || fail "actionable MISSING diagnostic was buried after the bulk fleet-state digest"
 
@@ -400,7 +402,7 @@ $rec
 EOF
   make_fake_toolchain "$fakebin"
   make_fake_ps_claude "$fakebin"
-  rm -f "$fakebin/node"
+  rm -f "$fakebin/gh-axi"
 
   append_wake "$home/state" signal task-z "needs-decision: pick a library"
 
@@ -409,7 +411,7 @@ EOF
   # fm-lock.sh's own exact success text.
   assert_contains "$out" "lock acquired: harness pid" "fm-lock.sh's real output did not appear (composition, not reimplementation)"
   # fm-bootstrap.sh's own exact MISSING-tool line format.
-  assert_contains "$out" "MISSING: node (install:" "fm-bootstrap.sh's real detect line did not appear verbatim"
+  assert_contains "$out" "MISSING: gh-axi (install:" "fm-bootstrap.sh's real detect line did not appear verbatim"
   # fm-wake-drain.sh's real drained record (raw tab-separated queue line).
   assert_contains "$out" "$(printf 'signal\ttask-z\tneeds-decision: pick a library')" "fm-wake-drain.sh's real drained record did not appear"
 


### PR DESCRIPTION
## Intent

Amend already-open PR #287 (fm/fm-brief-amend-contract-q4): fix the failing 'PR must be raised via no-mistakes' CI check by driving this branch through the no-mistakes pipeline (it was originally opened directly, skipping the pipeline), and tighten the AGENTS.md section-11 line the PR added for the --amend flag to a one-line pointer per the one-owner/size-discipline rule, since the full --amend contract already lives in bin/fm-brief.sh's header comment and generated brief template. No functional code change, only doc tightening.

## What Changed
- Adds `fm-brief.sh --amend <pr-url> --head <sha>` to scaffold an existing-PR amendment contract that checks out the PR with `gh-axi`, refuses incompatible flag combinations, and requires a pushed head different from the supplied SHA.
- Updates firstmate docs to distinguish ordinary ship briefs from amend briefs and point durable `--amend` details to `fm-brief.sh`.
- Expands `fm-brief` coverage for amend brief rendering, required arguments, incompatible modes, non-amend behavior, and stabilizes session-start missing-tool fixtures.

## Risk Assessment

✅ Low: Captain, the change is narrow, replaces the broken amend-PR checkout guidance with a supported `gh-axi pr checkout` flow, and keeps non-amend behavior covered by focused tests.

## Testing

The previously successful baseline was accounted for, I reran the focused changed tests, generated a real `fm-brief.sh --amend` brief as reviewer-visible CLI evidence, reran the full configured shell test sweep successfully, and confirmed the working tree was clean afterward; this was not a UI-facing change, so no screenshot was applicable.

<details>
<summary>Evidence: Generated --amend brief showing end-user contract for amending PR #287</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Amendment contract
THE ONLY DELIVERABLE IS A NEW PUSHED HEAD ON https://github.com/kunchenguid/firstmate/pull/287, DIFFERENT FROM 1234567890abcdef1234567890abcdef12345678.
This is not a new PR: https://github.com/kunchenguid/firstmate/pull/287 already exists and its current head is 1234567890abcdef1234567890abcdef12345678.
A finished-looking branch, a local commit, a passing test, or a written summary do NOT count as done.
If the remote head of https://github.com/kunchenguid/firstmate/pull/287 is still 1234567890abcdef1234567890abcdef12345678 when you stop, you have not completed this task.

# Setup
You are in a disposable git worktree of firstmate, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not check out anything here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. Check out the PR with `gh-axi pr checkout <number>`, where `<number>` is the trailing digits of `https://github.com/kunchenguid/firstmate/pull/287`; this works for same-repo and fork PRs alike.
2. Verify the checked-out head is `1234567890abcdef1234567890abcdef12345678`. If `git rev-parse HEAD` disagrees, someone already pushed a new head since this brief was written - append `blocked: PR head moved to {actual sha}, expected 1234567890abcdef1234567890abcdef12345678` to the status file and stop.
3. Record the original head with `git rev-parse HEAD`; it must equal `1234567890abcdef1234567890abcdef12345678`.
4. Rebase policy: do not rebase onto the default branch and do not force-push unless the task above explicitly asks for it; add new commits on top of the existing head.

# Rules
1. Never push to the default branch, and never create a new branch for this work - push only to the existing PR branch you checked out in Setup. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/no-mistakes-evidence/01KWVJ05V4FPZ2J32M4VXYXCKV/amend-home/state/amend-pr-287.status'`
   States: working, needs-decision, blocked, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, fix implemented, new head pushed) and the
   needs-decision/blocked/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs to a human (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.

# Definition of done
Implement the requested change as new commits on top of the branch you checked out, then push to the SAME branch for https://github.com/kunchenguid/firstmate/pull/287 - no new branch, no new PR.
Before reporting done, confirm `git rev-parse HEAD` differs from 1234567890abcdef1234567890abcdef12345678 after your successful push.
A local commit that was never pushed is NOT done - the deliverable is a new pushed head, not a commit.
When the new head is pushed and confirmed different from 1234567890abcdef1234567890abcdef12345678, append `done: PR https://github.com/kunchenguid/firstmate/pull/287 new head {sha}` to the status file and stop.
```
</details>
- Outcome: 🔧 1 issue found → auto-fixed ✅ across 2 runs (21m52s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (2) ✅</summary>

- ⚠️ `bin/fm-brief.sh:196` - The amend brief accepts any PR URL but tells the crewmate to fetch `headRefName` from `origin`; that fails for cross-repository/fork PRs because the head branch lives in the contributor repo, not `origin`. Either constrain `--amend` to same-repo PRs in the contract or include/fetch the head repository explicitly.

🔧 Fix: Captain, fix amend PR head fetch
1 error still open:
- 🚨 `bin/fm-brief.sh:197` - The generated amend setup tells the crew to resolve fork metadata with `gh-axi pr view ... --json ...`, but `gh-axi pr view` does not emit those JSON fields here; it exits successfully while returning only its normal summary, so the crew still has no reliable owner/repo/branch/oid to add the correct head remote. Use a command that actually returns the requested structured fields, or add equivalent gh-axi support before relying on this in the brief.

🔧 Fix: Captain, use gh-axi checkout for amend briefs
✅ Re-checked - no issues remain.

</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed ✅</summary>

- 🚨 tests failed with exit code 1
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`

🔧 Fix: Captain, stabilize session-start missing-tool fixture
✅ Re-checked - no issues remain.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- <code>Baseline command had already passed before this validation round: `command -v tmux &gt;/dev/null || { echo &#34;tmux is required for e2e tests&#34; &gt;&amp;2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo &#34;== $t ==&#34;; bash &#34;$t&#34; || rc=1; done; exit &#34;$rc&#34;`</code>
- `bash tests/fm-brief.test.sh`
- `bash tests/fm-session-start.test.sh`
- `env FM_HOME=/tmp/no-mistakes-evidence/01KWVJ05V4FPZ2J32M4VXYXCKV/amend-home bin/fm-brief.sh amend-pr-287 firstmate --amend https://github.com/kunchenguid/firstmate/pull/287 --head 1234567890abcdef1234567890abcdef12345678`
- `sed -n '1,90p' /tmp/no-mistakes-evidence/01KWVJ05V4FPZ2J32M4VXYXCKV/amend-brief.md`
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- `git status --short`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
