### PR TITLE
Add summary-first report contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -760,6 +760,12 @@ Reaches the captain immediately:
 
 Does not reach the captain: auto-fixes, retries, routine progress, or firstmate's internal vocabulary and machinery.
 Batch non-urgent updates into your next natural reply.
+
+**Report shape: summary first, detail by reference.**
+A captain-facing report, and any worker report firstmate consumes before relaying, leads with a bounded summary and never a raw dump.
+Keep the default to ~15 lines or fewer, covering the status, what changed (files or components by reference), the tests or checks run and their result, the risks, any decision needed, and evidence by path or URL.
+Full diffs, logs, and file contents are opt-in only: referenced by path, PR URL, or backlog id and fetched on request, never front-loaded into the message or into firstmate's own context.
+firstmate reads the summary first and pulls detail by reference only when a decision actually needs it.
 Use lavish-axi for multi-option decisions and structured reports worth a visual; plain chat for yes/no.
 Whenever you reference a PR to the captain - review-ready work, a requested status answer, or a recent-work summary - give its full `https://...` URL, never a bare `#number`: the captain's terminal makes a full URL clickable.
 A shorthand `#number` is fine only as a back-reference after the full URL has already appeared in the same message.
@@ -835,6 +841,7 @@ Keep the charter focused on persistent responsibility, available project clones,
 Preserve the requests-from-main-firstmate contract in the charter: marked requests return via status or a doc pointer, while unmarked direct captain messages stay conversational.
 Before seeding, launching, recovering, or handing backlog to a secondmate home, load `secondmate-provisioning`.
 The status-reporting protocol is intentionally sparse: crewmates append status only for supervisor-actionable phase changes or `needs-decision`/`blocked`/`done`/`failed`, because every append wakes firstmate.
+The ship and scout briefs also carry the bounded report contract (section 9): a substantial result is reported summary-first (status, changed files, tests or checks and their result, risks, decision needed, evidence paths), with full diffs, logs, and file contents kept opt-in behind a path, PR URL, or the worktree rather than pasted into the pane, so firstmate reads the summary first and pulls detail by reference only when needed.
 For any generated brief that still contains `{TASK}`, replace it with a clear task description, acceptance criteria, and any constraints or context the crewmate needs before spawning or seeding.
 Adjust the other sections only when the task genuinely deviates from the standard ship-a-new-PR shape (e.g. fixing an existing external PR); the scaffold is the contract, not a suggestion.
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -157,7 +157,8 @@ The report is the only thing that survives, so anything worth keeping must be in
 
 # Definition of done
 Write your findings to \`$DATA/$ID/report.md\`.
-The report must stand alone: what you did, what you found, the evidence (commands run, output, file:line references), and what you recommend.
+Lead the report with a bounded summary of ~15 lines or fewer - what you found, the risks, your recommendation, any decision needed, and the evidence paths - so firstmate reads the summary first and drills into detail by reference.
+Below that summary the report must stand alone: what you did, what you found, the evidence (commands run, output, file:line references), and what you recommend.
 When the report is complete, append \`done: {one-line conclusion}\` to the status file and stop.
 If your findings reveal work that should ship (e.g. you reproduced a bug and the fix is clear), say so in the report; firstmate may promote this task in place, and you would then receive mode-specific ship instructions as a follow-up message.
 EOF
@@ -251,6 +252,14 @@ $RULE1
 5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
 6. If a decision belongs to a human (product choices, destructive actions, ask-user findings),
    append \`needs-decision: {summary of options}\` and stop. Firstmate will reply with the decision.
+
+# Reporting results
+When you report a substantial result (a \`done\`, or a \`blocked\`/\`failed\` firstmate must act on), lead with a bounded summary, not raw output. Keep the status line one line and, when the result needs more than a line, write a short summary of ~15 lines or fewer covering:
+- status - \`done\` / \`blocked: {why}\` / \`failed: {why}\`;
+- what changed and why, in plain language;
+- the changed files, the tests or checks you ran and their result, the risks, and any decision needed - each as a short reference, not a dump;
+- evidence by path or URL: the PR, the branch \`fm/$ID\`, or \`file:line\` references.
+Full diffs, logs, and file contents are opt-in only: leave them in the PR, the worktree, or a file firstmate can open on request - never paste them into the pane or the status line. firstmate reads the summary first and pulls detail by reference only when it needs it.
 
 # Project memory
 If \`AGENTS.md\` or \`CLAUDE.md\` already exists, or if this task produced durable project-intrinsic knowledge, run \`$FM_ROOT/bin/fm-ensure-agents-md.sh .\` in the worktree.


### PR DESCRIPTION
- Problem: Main context can get polluted by long reports/logs/diffs.
- Change: Adds bounded captain-facing report shape and summary-first scout/ship scaffolds.
- Safety: Additive prose/template only; no behavior/control-flow change.
- Tests: bash -n bin/fm-brief.sh + throwaway ship/scout brief generation.
- Risk: Low; ~15-line cap is a guideline, not enforcement.
