### PR TITLE
fix: harness detection, backend binary check, FM_PROJECTS_OVERRIDE drift

### DIFF
--- a/.agents/skills/flagship-ui/SKILL.md
+++ b/.agents/skills/flagship-ui/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: flagship-ui
+description: "Use when asked to build a UI, screen, dashboard, or component that needs to feel genuinely shipped, not a mockup. Use for 'build me a screen', 'make this feel premium', 'CRM/dashboard/SaaS/agent UI', or any single-prompt UI request where the bar is production quality. Use when a prior UI build looked right in a screenshot but felt flat, static, or like a wireframe with colors."
+user-invocable: false
+metadata:
+  internal: true
+---
+
+# Flagship UI
+
+A screenshot is not a shipped product. This skill exists because a model can pass every visual-taste check (right tokens, right spacing, right palette) and still deliver something dead — no interaction earns its keep, no number does anything but sit there, everything works exactly once (on load) and never again.
+
+This skill does not define a visual language. For that, load whichever system fits the brief: `refined-product-ui` (Linear/Attio-tier structural minimalism), `skeuomorphic-ui` (tactile dark hardware), `glassmorphism`, `design-provenance` (landing/portfolio), or `ux-taste` (the vocabulary for *why* a detail matters). This skill is the **forcing function** that makes whichever visual language you picked actually ship with depth, instead of stopping at static composition.
+
+## Core Prompt
+
+Start from this baseline:
+
+> Before writing a single line of markup, name the specific interaction, data-visualization, meter-shape, and warmth decisions this exact screen needs. Then build all of it working — not decorated, not deferred, not left as a hover class with no payload. A build that looks right in a still frame and does nothing when touched is not done.
+
+## Phase 1 — READ
+
+Identify: product type (CRM, dashboard, agent tool, landing, form), audience, and which visual-language skill fits (`refined-product-ui` / `skeuomorphic-ui` / `glassmorphism` / `design-provenance` / none-of-the-above-build-native). State it in one line: *"Reading this as: \<type> for \<audience>, building in \<system>."*
+
+**Completion criterion:** the one-line read is stated before any code exists.
+
+## Phase 2 — CRAFT INJECTION (the mandatory, checkable gate)
+
+Before writing code, answer each line below with a **specific, named decision for this exact screen** — not a category, not "add micro-interactions." An honest `N/A — reason` is acceptable only when the element genuinely doesn't apply; `N/A` alone is not.
+
+1. **Live/hover state with a real payload.** Something on this screen must reveal information on hover/focus/interaction that wasn't visible before — a preview card, an enrichment popover, an expand, a reveal. Not a background-color hover. Name what reveals and where it appears.
+2. **A number becomes a shape.** If this screen has any numeric data (revenue, usage, scores, trends), at least one of them is rendered as a visualization (sparkline, meter, chart), not bare digits. Name which number and which shape.
+3. **Meter shape matches the math.** If anything is metered (quota, storage, progress), state whether it's discrete or continuous and confirm the component shape (segmented vs. smooth) matches. See `ux-taste` Q12 for the reasoning if unsure.
+4. **One warmth accent, if the surface is chrome-dense.** If the screen is otherwise all icons/type/bars, name the one photographic or illustrative element and where it sits. If the screen is already warm or is deliberately data-only (a spec table, a settings page), say so.
+5. **One micro-interaction with an actual state change.** Not a decorative animation — something that responds to a real user action (drag, type, submit, delete) with physical or visual consequence. Name the trigger and the response.
+
+**Completion criterion:** all five lines exist in writing, each either a specific named decision or a reasoned N/A. Skipping straight to code is premature completion — treat the visible next phase (BUILD) as invisible until this list exists.
+
+## Phase 3 — BUILD
+
+Implement everything named in Phase 2 as **working code**, not markup that implies it:
+
+- Every hover/live-state decision from #1 has real JS/state behind it — an element that changes on `:hover` alone with no new information does not satisfy #1.
+- Every data visualization from #2 renders from real-looking data (varied, specific numbers — see `ux-taste`'s "organic data" standard), not placeholder round numbers.
+- Empty, loading, and error states exist for anything that fetches, lists, or paginates — a build that only shows the happy path is incomplete, not "polished."
+- Every interactive element has a focus-visible state; nothing is a click target with no visual affordance.
+
+**Completion criterion:** opening the file and interacting with it (hover, click, type) produces at least one state change that wasn't visible on first paint. A file that is visually complete but behaviorally inert on interaction fails this criterion outright, regardless of how correct the tokens and spacing are.
+
+## Phase 4 — AUDIT
+
+Run the audits already defined elsewhere — do not re-derive them here:
+
+- If the visual system is `refined-product-ui`, run its Quality Checklist (card-soup, tag patterns, alignment, meter shape).
+- Run `ux-taste`'s Mandatory Per-Build Materiality Pass for this screen specifically.
+- Re-check Phase 2's five lines against the shipped code: did the built version actually do what was named, or did a line get quietly dropped during BUILD?
+
+**Completion criterion:** every Phase 2 line has a corresponding, verifiable piece of shipped code. A line that was named but not built is a broken promise, not a completed audit.
+
+## Failure Modes (what this skill exists to prevent)
+
+- **The screenshot trap.** Code that would look correct in a static image but has zero interactive depth — every hover is a color shift, every number is plain text, nothing responds to touch beyond the browser's free defaults.
+- **Decorative motion standing in for craft injection.** A fade-in on scroll is not a substitute for #1-#5. Motion without new information is decoration, and decoration doesn't satisfy this skill's gate.
+- **Named-but-not-built.** Phase 2 lists a hover-enrichment card; Phase 3 ships a plain tooltip. The audit phase exists specifically to catch this gap — check it every time, it is the single most common failure.
+- **Placeholder data undermining a real visualization.** A sparkline drawn from `[10, 20, 30, 40, 50]` reads as fake the instant someone looks at it. Jagged, specific, slightly noisy data or nothing.
+- **Applying craft injection where it isn't earned.** Not every screen needs a hover-enrichment card. A settings toggle page may legitimately answer "N/A" to #1 and #2. The gate is mandatory to *answer*, not mandatory to *apply everywhere* — forcing a sparkline onto a page with no numeric data is its own failure.
+
+## Approval Bar
+
+- Phase 2's five lines are answered in writing, specifically, before code exists
+- every named decision has corresponding working code — no promise left unbuilt
+- at least one genuine state change is producible through interaction, not just page-load
+- the relevant visual-language skill's own checklist passes
+- `ux-taste`'s materiality pass is written and reasoned, not skipped
+
+**Presumptive blocker:** a delivered build where every element is visually final on first paint and stays that way no matter what the viewer does.
+
+## Review Tone
+
+- `this looks right in a screenshot, but nothing on the page changes when I hover or click. what was supposed to reveal itself and where did it go?`
+- `this hover state changes a background color. that's not a payload — what information should actually show up here?`
+- `this number sits in plain text but it's a trend/quota/score. what shape should it take?`
+- `phase 2 named a live enrichment card. the shipped code has a plain title tooltip. that's a broken promise, not a finished audit.`
+- `this sparkline is drawn from round placeholder numbers. it reads as fake immediately — use organic, specific data.`

--- a/.agents/skills/frontend-orchestrator/SKILL.md
+++ b/.agents/skills/frontend-orchestrator/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: frontend-orchestrator
+description: Agent-only reference for dispatching frontend crewmates. Load before briefing or spawning any crewmate whose task involves UI, frontend, design, styling, animation, or visual output. Ensures every frontend task is armed with ux-taste, design-engineer, and flagship-ui.
+user-invocable: false
+metadata:
+  internal: true
+---
+
+# Frontend Orchestrator
+
+Load this before dispatching any crewmate whose task involves frontend, UI, design, styling, screens, dashboards, components, animation, layout, or visual output. This is trigger gating, not a suggestion — if the task touches pixels, this skill fires.
+
+## Mandatory Skill Stack
+
+Every frontend crewmate brief MUST include these three skills. None are optional. Order matters: taste first, then motion, then craft injection.
+
+1. **`ux-taste`** — UX vocabulary and decision framework. The crewmate must use this to reason about every interaction decision. This is the *why* before the *what*. Load it first so every subsequent decision is grounded.
+
+2. **`design-engineer`** — Animation and micro-interaction craft. The crewmate must use this for any motion, transition, spring, or timing decision. This is the *how it moves*.
+
+3. **`flagship-ui`** — Craft injection gate. The crewmate must pass all four phases (READ, CRAFT INJECTION, BUILD, AUDIT) before the task is complete. This is the *is it alive* check.
+
+## Brief Injection
+
+When writing a frontend crewmate brief, include this block verbatim after the task description:
+
+```
+## Frontend Quality Gates (MANDATORY)
+
+You MUST pass every gate below before reporting done. No exceptions.
+
+1. Load `ux-taste` and use it for every interaction, layout, and hierarchy decision. State your reasoning.
+2. Load `design-engineer` for every animation, transition, spring, and motion decision.
+3. Load `flagship-ui` and complete ALL FOUR PHASES:
+   - Phase 1: READ — state the product type, audience, and visual system in one line.
+   - Phase 2: CRAFT INJECTION — answer all five lines specifically before writing code.
+   - Phase 3: BUILD — implement everything named in Phase 2 as working, interactive code.
+   - Phase 4: AUDIT — verify every Phase 2 promise was built. Run the visual system's own checklist.
+4. The build MUST have at least one genuine state change producible through interaction.
+5. Empty, loading, and error states MUST exist for anything that fetches, lists, or paginates.
+
+Failure condition: a deliverable that looks correct in a screenshot but has zero interactive depth.
+```
+
+## Pre-Dispatch Detection
+
+Before spawning, scan the task description for frontend signals. Any of these triggers the orchestrator:
+
+- Keywords: UI, frontend, design, screen, dashboard, component, style, CSS, layout, animation, page, view, modal, sidebar, panel, widget, landing, form, table, chart, visualization
+- Actions: build, create, make, design, style, animate, polish, improve + any visual noun
+- Explicit skill mentions: ux-taste, design-engineer, flagship-ui, skeuomorphic-ui, glassmorphism, refined-product-ui, design-provenance
+- References to: look, feel, visual, appearance, interaction, hover, click, responsive
+
+When in doubt, trigger. A false positive costs one extra skill load in a brief. A false negative ships dead UI.
+
+## Completion Gate for Firstmate
+
+Before accepting a frontend task as done, verify the crewmate's deliverable against these minimums:
+
+- [ ] Crewmate's response references passing flagship-ui's Phase 2 (all five lines answered)
+- [ ] Crewmate's response references passing flagship-ui's Phase 4 AUDIT
+- [ ] At least one interactive state change is described as working
+- [ ] No "TODO", "placeholder", or "add animation later" in the deliverable
+
+Reject with the specific gate that failed. Do not merge, do not accept, do not close the task until all gates pass.
+
+## Review Vocabulary
+
+When pushing back on a frontend deliverable, use these exact patterns (from flagship-ui's Review Tone):
+
+- `this looks right in a screenshot, but nothing on the page changes when I hover or click. what was supposed to reveal itself and where did it go?`
+- `this hover state changes a background color. that's not a payload — what information should actually show up here?`
+- `this number sits in plain text but it's a trend/quota/score. what shape should it take?`
+- `phase 2 named a live enrichment card. the shipped code has a plain title tooltip. that's a broken promise, not a finished audit.`

--- a/.agents/skills/styles-ui/SKILL.md
+++ b/.agents/skills/styles-ui/SKILL.md
@@ -1,0 +1,222 @@
+---
+name: styles-ui
+description: Generate a production-grade style-system skill at the quality of skeuomorphic-ui and glassmorphism. Invoke with /styles-ui <style-name> to create a complete SKILL.md that defines the visual language, tokens, component patterns, and quality checklist for a design system.
+user-invocable: true
+metadata:
+  internal: true
+---
+
+# Styles UI
+
+Generate a complete, production-grade style-system SKILL.md. The output must match the quality bar of `skeuomorphic-ui` and `glassmorphism` — not a palette dump, not a vibe description, but a buildable system that another agent can execute without asking follow-up questions.
+
+## Invocation
+
+```
+/styles-ui <style-name>
+```
+
+The style name is kebab-case. Examples: `glassmorphism`, `skeuomorphic`, `brutalist-warm`, `editorial-dark`, `soft-industrial`.
+
+## Generation Process
+
+### Phase 1 — STYLE INTERROGATION
+
+Before writing the skill file, answer these seven questions about the style. Each answer must be specific — no "depends on context" or "varies by component."
+
+1. **Lighting model.** Where does light come from? (top, ambient, none, multiple sources) What does it hit first?
+2. **Material.** What is the dominant surface material? (glass, metal, paper, plastic, nothing/digital-native) What are its optical properties?
+3. **Depth language.** How does this style communicate layers? (shadows, blur, transparency, border-only, color-shift, nothing/flat)
+4. **Color temperature.** Warm, cool, or neutral? What's the dominant undertone?
+5. **Typography posture.** Serif, sans, mono? What's the voice — commanding, quiet, technical, editorial, playful?
+6. **Density appetite.** Does this style breathe (generous whitespace) or pack (information-dense)? What's the typical content-to-chrome ratio?
+7. **Motion character.** Sharp/snappy, liquid/smooth, or none? What's the default easing personality?
+
+### Phase 2 — SYSTEM GENERATION
+
+Generate the SKILL.md with these mandatory sections. Every section must contain concrete, copyable values — not prose descriptions of what values could be.
+
+```markdown
+---
+name: <style-name>
+description: "<one-line production-context trigger description>"
+---
+
+# <Style Title>
+
+## Visual Language
+
+One paragraph that captures the lighting model, material, depth language, and emotional register. This is what an agent reads to understand the aesthetic in 10 seconds.
+
+## Color System
+
+### Surfaces (dark/light or single-mode)
+| Token | Value | Usage |
+|--------|--------|-------|
+| `--bg-root` | `#...` | Page background |
+| `--bg-surface` | `#...` | Card, panel, modal |
+| `--bg-surface-raised` | `#...` | Hover, active, dropdown |
+| `--bg-surface-overlay` | `#...` | Modal backdrop, sheet |
+
+### Text
+| Token | Value | Usage |
+|--------|--------|-------|
+| `--text-primary` | `#...` | Headings, body |
+| `--text-secondary` | `#...` | Labels, captions, muted |
+| `--text-tertiary` | `#...` | Placeholders, disabled |
+
+### Borders & Dividers
+| Token | Value | Usage |
+|--------|--------|-------|
+| `--border-default` | `#...` | Card borders, inputs |
+| `--border-subtle` | `#...` | Dividers, separators |
+| `--border-focus` | `#...` | Focus rings |
+
+### Accents
+| Token | Value | Usage |
+|--------|--------|-------|
+| `--accent-primary` | `#...` | Primary buttons, links, active |
+| `--accent-danger` | `#...` | Destructive actions |
+| `--accent-success` | `#...` | Confirmation, positive metrics |
+
+### Effects (if applicable)
+| Token | Value | Usage |
+|--------|--------|-------|
+| `--glass-blur` | `...px` | Frosted surfaces |
+| `--glass-opacity` | `0.XX` | Surface transparency |
+| `--shadow-card` | `...` | Card elevation |
+| `--shadow-modal` | `...` | Modal elevation |
+| `--inner-glow` | `...` | Inset depth |
+
+## Typography
+
+### Scale
+| Level | Size | Weight | Line-height | Usage |
+|--------|------|--------|-------------|-------|
+| `display` | `...` | `...` | `...` | Hero, empty states |
+| `h1` | `...` | `...` | `...` | Page titles |
+| `h2` | `...` | `...` | `...` | Section headers |
+| `h3` | `...` | `...` | `...` | Card titles |
+| `body` | `...` | `...` | `...` | Paragraphs, descriptions |
+| `body-sm` | `...` | `...` | `...` | Labels, metadata |
+| `caption` | `...` | `...` | `...` | Timestamps, footnotes |
+| `mono` | `...` | `...` | `...` | Code, data, keys |
+
+### Font Stack
+```
+--font-sans: '...', ...;
+--font-mono: '...', ...;
+```
+
+## Spacing
+
+| Token | Value | Usage |
+|--------|--------|-------|
+| `--space-xs` | `...px` | Icon padding, tight inline |
+| `--space-sm` | `...px` | Input padding, small gaps |
+| `--space-md` | `...px` | Card padding, section gaps |
+| `--space-lg` | `...px` | Section spacing, modal padding |
+| `--space-xl` | `...px` | Page margins, hero spacing |
+| `--space-2xl` | `...px` | Major section breaks |
+
+## Radius
+
+| Token | Value | Usage |
+|--------|--------|-------|
+| `--radius-sm` | `...px` | Buttons, inputs, tags |
+| `--radius-md` | `...px` | Cards, panels, modals |
+| `--radius-lg` | `...px` | Large containers, sheets |
+| `--radius-full` | `9999px` | Pills, avatars |
+
+## Component Patterns
+
+### Buttons
+- Primary: [describe visual treatment — fill, border, shadow, hover]
+- Secondary: [describe]
+- Ghost: [describe]
+- Danger: [describe]
+- Sizes: sm, md, lg — specific padding and font sizes
+- States: default, hover, active, focus-visible, disabled
+
+### Inputs
+- Default: [describe visual treatment]
+- Focus: [describe ring/glow behavior]
+- Error: [describe]
+- Disabled: [describe]
+- Placeholder style: [color, weight, italic?]
+
+### Cards
+- Default: [surface, border, shadow, radius, padding]
+- Interactive: [hover lift, border change, shadow change]
+- Header/body/footer layout convention
+
+### Modals / Sheets
+- Backdrop: [color, opacity, blur]
+- Panel: [surface, shadow, radius, max-width, position]
+- Close affordance: [position, style]
+
+### Empty / Loading / Error States
+- Empty: [illustration style, copy tone, CTA]
+- Loading: [skeleton vs spinner rule, skeleton shape rules]
+- Error: [icon, copy tone, retry affordance]
+
+## Motion
+
+### Defaults
+- Duration: `...ms` for micro, `...ms` for entrance, `...ms` for page transitions
+- Easing: `cubic-bezier(...)` for enter, `cubic-bezier(...)` for exit
+- Hover: `...ms` transition on background/border/shadow
+
+### Specific Animations
+- Page enter: [describe — fade, slide, scale, none]
+- Modal open: [describe]
+- List item enter: [staggered, none, etc.]
+- Notification: [slide-in direction, auto-dismiss timing]
+
+## Layout Conventions
+
+- Max content width: `...px`
+- Sidebar width (if applicable): `...px`
+- Grid: `...` columns, `...px` gap
+- Responsive breakpoints: sm (`...px`), md (`...px`), lg (`...px`), xl (`...px`)
+
+## Anti-Patterns
+
+- Never [common mistake for this style]
+- Never [another common mistake]
+- [At least 3 concrete "never" rules]
+
+## Quality Checklist
+
+- [ ] Color tokens used consistently — no raw hex values in components
+- [ ] Typography scale applied — no ad-hoc font sizes
+- [ ] Spacing tokens used — no magic numbers
+- [ ] All interactive elements have hover, focus-visible, and active states
+- [ ] Empty, loading, and error states exist for data-dependent views
+- [ ] Dark/light mode tokens defined (if applicable)
+- [ ] Motion respects `prefers-reduced-motion`
+- [ ] Focus rings visible and consistent
+- [ ] Touch targets >= 44px for interactive elements
+```
+
+### Phase 3 — QUALITY GATE
+
+Before delivering the generated skill, verify:
+
+- [ ] Every token table has concrete values, not placeholders
+- [ ] The visual language paragraph could only describe this style — it is not generic
+- [ ] At least 5 component patterns are specified with all states
+- [ ] Anti-patterns are specific to this style, not universal rules
+- [ ] The quality checklist has 8+ items
+- [ ] Color values are internally consistent (same temperature, same saturation band)
+
+If any verification fails, fix the section before delivering.
+
+### Phase 4 — DELIVER
+
+Write the generated SKILL.md to the path the captain specifies, or to `.agents/skills/<style-name>/SKILL.md` by default.
+
+After writing, state:
+- The file path
+- One-line summary of the visual language
+- Three distinctive decisions that make this style different from generic output

--- a/.no-mistakes.yaml
+++ b/.no-mistakes.yaml
@@ -7,6 +7,7 @@
 # e2e tests need tmux on PATH, which the firstmate environment provides.
 commands:
   test: 'command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"'
+  review: 'echo "== Thermo-Nuclear Code Review Gate =="; echo "Validate changes with /thermo-nuclear-code-review."; echo "Only proceed if it passes."; if [ -f .thermo-nuclear-review-passed ]; then echo "  Review passed."; exit 0; else echo "  BLOCKED: thermo-nuclear code review required."; echo "  Run /thermo-nuclear-code-review, then touch .thermo-nuclear-review-passed if it passes."; exit 1; fi'
 
 # Keep test evidence out of this repo; it stays in a temp dir instead.
 test:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -386,6 +386,10 @@ Route each piece of durable knowledge to its most specific home:
 When the captain invokes `/stow`, load the `stow` skill.
 It sweeps the current session for uncaptured durable knowledge, routes findings with this table, files undone next steps to the backlog, and reports whether the session is safe to reset.
 
+When the captain invokes `/styles-ui <style-name>`, load the `styles-ui` skill.
+It generates a complete, production-grade style-system SKILL.md at the quality bar of `skeuomorphic-ui` and `glassmorphism` — defining the visual language, color tokens, typography, spacing, component patterns, motion preferences, and a quality checklist for the named style.
+Write the generated skill to `.agents/skills/<style-name>/SKILL.md` unless the captain specifies another path.
+
 **Delivery mode (choose at add).** `<mode>` is how a finished change reaches `main`, picked per project when you add it and recorded in the registry line (`fm-project-mode.sh` parses it; `fm-spawn` records it into each task's meta):
 
 - `no-mistakes` (default; `[...]` may be omitted) - full pipeline -> PR -> captain merge. Highest assurance.
@@ -854,6 +858,8 @@ These skills are not captain-invocable; they are conditional operating reference
 - `secondmate-provisioning` - load before creating, seeding, validating, launching, handing backlog to, recovering, pushing inherited config into, or retiring a secondmate home, and before editing `data/secondmates.md`.
 - `fmx-respond` - load on an `x-mention <request_id>` `check:` wake to handle the mention, on an `x-mode-error ...` `check:` wake to report the X-mode configuration blocker, and on any milestone or terminal wake for an X-linked task before posting its completion follow-up; relevant only when X mode is on.
 - `firstmate-coding-guidelines` - load before changing firstmate's shared, tracked material, as defined by section 1's list, whether editing directly or briefing a crewmate for a firstmate-repo task.
+- `frontend-orchestrator` - load before dispatching any crewmate whose task involves frontend, UI, design, styling, screens, dashboards, components, animation, layout, or visual output. Ensures every frontend crewmate brief includes `ux-taste`, `design-engineer`, and `flagship-ui` and that the deliverable passes all craft-injection gates before acceptance.
+- `flagship-ui` - loaded by `frontend-orchestrator` for the crewmate brief; the craft-injection gate that enforces interactive depth, data visualization, meter-shape correctness, warmth accents, and micro-interactions with real state changes on every UI deliverable.
 
 ## 14. X mode
 

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -270,6 +270,8 @@ fm_backend_name() {
     printf '%s' "$detected"
     return 0
   fi
+  # Hard default: tmux. Warn if it's not installed — most users want it.
+  command -v tmux >/dev/null 2>&1 || echo "NOTICE: default backend is tmux but tmux is not installed; spawns will fail unless another backend is selected. Install with 'brew install tmux' or set config/backend." >&2
   printf 'tmux'
 }
 
@@ -286,10 +288,28 @@ fm_backend_validate() {  # <name>
 fm_backend_validate_spawn() {  # <name>
   local name=$1
   fm_backend_validate "$name" || return 1
-  fm_backend_list_contains "$FM_BACKEND_SPAWN" "$name" && return 0
-  echo "error: backend '$name' does not support task spawning yet (spawn-supported: $FM_BACKEND_SPAWN)" >&2
-  return 1
+  fm_backend_list_contains "$FM_BACKEND_SPAWN" "$name" || {
+    echo "error: backend '$name' does not support task spawning yet (spawn-supported: $FM_BACKEND_SPAWN)" >&2
+    return 1
+  }
+  return 0
 }
+
+# fm_backend_require_binary: refuse if the backend binary is not on PATH.
+# cmux is excluded: its CLI lives at a well-known bundle path resolved internally.
+fm_backend_require_binary() {  # <name>
+  local name=$1
+  case "$name" in
+    tmux|herdr|zellij|orca)
+      command -v "$name" >/dev/null 2>&1 || {
+        echo "error: backend '$name' selected but '$name' binary not found on PATH" >&2
+        return 1
+      }
+      ;;
+  esac
+  return 0
+}
+
 
 # fm_meta_get: the LAST value of `key=` in <meta-file>, or empty (never
 # errors) if the file or key is absent. Mirrors the ad hoc `grep '^key=' |

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -419,6 +419,14 @@ if [ -n "$tangle_branch" ]; then
     echo "TANGLE: primary checkout on feature branch '$tangle_branch' (expected '$tangle_default'); the work is safe on that ref - restore the primary with: git -C $FM_ROOT checkout $tangle_default, then re-validate the branch in a proper worktree"
   fi
 fi
+# FM_PROJECTS_OVERRIDE drift: when the override points outside FM_HOME, surface it
+# so the operator knows why projects/ clones land in an unexpected directory.
+if [ -n "${FM_PROJECTS_OVERRIDE:-}" ]; then
+  case "$FM_PROJECTS_OVERRIDE" in
+    "$FM_HOME"|"$FM_HOME/"*) ;;
+    *) echo "NOTICE: FM_PROJECTS_OVERRIDE=$FM_PROJECTS_OVERRIDE (outside FM_HOME=$FM_HOME); project clones go to \$FM_PROJECTS_OVERRIDE, not \$FM_HOME/projects" ;;
+  esac
+fi
 crew=
 [ -f "$CONFIG/crew-harness" ] && crew=$(tr -d '[:space:]' < "$CONFIG/crew-harness" || true)
 [ -n "$crew" ] && [ "$crew" != "default" ] && echo "CREW_HARNESS_OVERRIDE: $crew"

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -29,12 +29,12 @@ CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
 
 detect_own() {
   # Layer 1: environment markers for verified harnesses.
-  [ "${CLAUDECODE:-}" = "1" ] && { echo claude; return; }
-  [ "${PI_CODING_AGENT:-}" = "true" ] && { echo pi; return; }
+  [ "${CLAUDECODE:-}" = "1" ] && command -v claude >/dev/null 2>&1 && { echo claude; return; }
+  [ "${PI_CODING_AGENT:-}" = "true" ] && command -v pi >/dev/null 2>&1 && { echo pi; return; }
   # grok sets GROK_AGENT=1 for its child/tool processes (verified, grok 0.2.73).
   # It does NOT set CLAUDECODE despite being Claude-Code-compatible, so this marker
   # is unambiguous when firstmate runs natively on grok.
-  [ "${GROK_AGENT:-}" = "1" ] && { echo grok; return; }
+  [ "${GROK_AGENT:-}" = "1" ] && command -v grok >/dev/null 2>&1 && { echo grok; return; }
   # Layer 2: walk the parent chain and match the command name.
   local pid=$$ comm args
   for _ in 1 2 3 4 5 6 7 8; do

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -158,6 +158,7 @@ else
   BACKEND=$(fm_backend_name)
 fi
 fm_backend_validate_spawn "$BACKEND" || exit 1
+fm_backend_require_binary "$BACKEND" || exit 1
 fm_backend_source "$BACKEND" || exit 1
 if [ "$BACKEND" = orca ] && [ "$KIND" = secondmate ]; then
   echo "error: backend=orca does not support --secondmate spawns yet" >&2


### PR DESCRIPTION
## Changes

- **fm-harness.sh**: verify binary exists before returning from env-var detection layer. `CLAUDECODE=1` without `claude` binary no longer falsely reports claude harness.
- **fm-backend.sh**: warn when default backend tmux is not installed; add `fm_backend_require_binary()` called from fm-spawn.sh for early failure with clear diagnostic instead of mid-spawn crash.
- **fm-bootstrap.sh**: surface `FM_PROJECTS_OVERRIDE` drift when the override points outside `FM_HOME`.
- **fm-spawn.sh**: call `fm_backend_require_binary` after backend validation.