### PR TITLE
feat(project-memory): split situation-specific AGENTS.md detail into project skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -355,6 +355,13 @@ These are facts that help any agent working in the repo and should travel with t
 This knowledge lives in the project's committed `AGENTS.md`.
 A project's `AGENTS.md` is the real file; `CLAUDE.md` is a symlink to it.
 
+Project-intrinsic knowledge splits by whether every agent needs it on every spawn, because the project `AGENTS.md` is auto-loaded into every crewmate's context for that project.
+Always-needed operating facts (build, test, release, cross-cutting conventions, sharp edges) stay inline in `AGENTS.md`.
+Situation-specific detail - a single subsystem, script, or screen contract that only matters when working that area - belongs in a project skill under the project's own `.agents/skills/<name>/SKILL.md` (`user-invocable: false`, with a `.claude/skills` symlink), mirroring firstmate's own `.agents/skills/` pattern, and is surfaced by a one-line entry under a `## Skills` index in `AGENTS.md`.
+The trigger is size or specificity: once `AGENTS.md` grows past ~300 lines / ~10k tokens, or the new knowledge is a self-contained subsystem contract, route it to a skill instead of appending inline.
+Crewmates create these skills through the brief's project-memory contract (section 11) via `bin/fm-ensure-agents-md.sh --skill <name>`; firstmate never hand-writes them, exactly as with `AGENTS.md` itself.
+The mechanism, threshold rationale, and precedent live in `docs/project-skills.md`.
+
 **Fleet and captain-private knowledge** belongs to firstmate.
 Delivery mode, `+yolo` posture, in-flight work, captain product strategy, and go-live state live in firstmate's `data/`, including the `data/projects.md` registry line and any planning docs.
 Do not put that knowledge in the project.
@@ -377,7 +384,8 @@ Route each piece of durable knowledge to its most specific home:
 | Kind of knowledge | Home |
 | --- | --- |
 | Captain preferences and working style | `data/captain.md` |
-| Project-intrinsic knowledge | that project's own `AGENTS.md`, via normal crewmate delivery, never hand-written by firstmate |
+| Project-intrinsic knowledge (always-needed operating facts) | that project's own `AGENTS.md`, via normal crewmate delivery, never hand-written by firstmate |
+| Project-intrinsic knowledge (situation-specific subsystem/script/screen contract, or `AGENTS.md` past ~300 lines / ~10k tokens) | that project's own `.agents/skills/<name>/SKILL.md`, indexed by one line in the project `AGENTS.md`, via normal crewmate delivery (`bin/fm-ensure-agents-md.sh --skill`); see `docs/project-skills.md` |
 | Fleet-local operational facts and gotchas | `data/learnings.md` |
 | Knowledge generalizable to every firstmate user | the shared `AGENTS.md`, shipped via PR through the pipeline |
 | Task-scoped notes | backlog item notes (`tasks-axi update <id> --append "<note>"`, or hand-edit per the active backend) |
@@ -824,7 +832,7 @@ The ship-brief Setup opens with a worktree-isolation assertion ahead of the bran
 For a ship task the definition of done is shaped by the project's delivery mode (section 6): `no-mistakes` stops after the implementation commit, then firstmate triggers the harness-appropriate no-mistakes validation pipeline; `direct-PR` has the crewmate push and open the PR itself, and `local-only` has it stop at "ready in branch" for firstmate to review and merge locally.
 The no-mistakes brief points to no-mistakes' version-matched guidance and keeps only firstmate-specific wrapper rules for `ask-user` escalation, `--yes` avoidance, and the CI-green done line.
 The scaffold reads the mode via `fm-project-mode.sh`, so you do not pass it.
-Ship briefs also include the project-memory contract: run `bin/fm-ensure-agents-md.sh` when the project already has agent-memory files or when the task produced durable project-intrinsic knowledge, then record proportionate learnings in `AGENTS.md`.
+Ship briefs also include the project-memory contract: run `bin/fm-ensure-agents-md.sh` when the project already has agent-memory files or when the task produced durable project-intrinsic knowledge, then record proportionate learnings routed by the section 6 split - always-needed operating facts inline in `AGENTS.md`, situation-specific subsystem contracts (or any growth past the size threshold) into a project skill via `bin/fm-ensure-agents-md.sh --skill <name>`.
 For scout tasks add `--scout`: the scaffold swaps the definition of done for the report contract (findings to `data/<id>/report.md`, no branch, no push, no PR) and declares the worktree scratch; scout is mode-agnostic.
 Scout briefs do not include the project-memory step, because their deliverable is a report rather than a committed project change.
 For secondmates use `bin/fm-brief.sh <id> --secondmate <project>...`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,7 @@ tests/fm-fleet-sync.test.sh               # project clone refresh: safe detached
 tests/fm-x-mode.test.sh                   # X-mode poll, inbox context round-trip, reply threading, dismiss, completion follow-up counters/caps, dry-run preview, and .env-presence activation tests
 tests/fm-tangle-guard.test.sh             # primary-checkout tangle detection, read-only remediation suppression, and spawn/brief isolation tests
 tests/fm-brief.test.sh                    # fm-brief.sh bash -n parse regression guard (issue #166) and clean no-mistakes/direct-PR/local-only brief generation tests
+tests/fm-ensure-agents-md.test.sh         # fm-ensure-agents-md.sh AGENTS.md/CLAUDE.md reconciliation plus --skill project-skills scaffolding: layout creation, idempotence, clobber refusal, and slug validation
 tests/fm-spawn-batch.test.sh              # batch dispatch and FM_HOME project-path scoping tests
 tests/fm-spawn-dispatch-profile.test.sh   # concrete dispatch profile flags: active-profile backstop, harness/model/effort meta, launch templates, batch forwarding, and secondmate exemption
 tests/fm-update.test.sh                   # fast-forward-only self-update, reread, nudge, dedup, and skip-safety tests

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Firstmate's skills live in two separate places with different audiences:
 - [docs/orca-backend.md](docs/orca-backend.md) - setup guide for the experimental Orca backend, plus its lifecycle notes and known gaps.
 - [docs/cmux-backend.md](docs/cmux-backend.md) - setup guide for the experimental cmux backend, plus its verification notes and known gaps.
 - [docs/turnend-guard.md](docs/turnend-guard.md) - the primary session's structural "no turn ends blind" backstop: verified Claude Code Stop-hook mechanism, scoping, and known gaps.
+- [docs/project-skills.md](docs/project-skills.md) - keeping project `AGENTS.md` context-cheap by splitting situation-specific detail into on-demand project skills.
 - [docs/scripts.md](docs/scripts.md) - the `bin/` toolbelt reference.
 - [`AGENTS.md`](AGENTS.md) - firstmate's full operating manual for the orchestrator agent.
 - [CONTRIBUTING.md](CONTRIBUTING.md) - how to contribute, including the dev/test commands.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -27,7 +27,10 @@
 # Ship briefs begin with a worktree-isolation assertion before the branch step.
 # Scout tasks ignore mode - their deliverable is a report, not a merge.
 # Ship tasks include a project-memory section so durable project-intrinsic
-# learnings can be committed to AGENTS.md through the project's delivery path.
+# learnings can be committed through the project's delivery path: general
+# operating facts go inline in AGENTS.md, while situation-specific subsystem
+# contracts (or any growth past the size threshold) route into project skills
+# via `fm-ensure-agents-md.sh --skill` (see docs/project-skills.md).
 # Refuses to overwrite an existing brief.
 set -eu
 
@@ -254,8 +257,10 @@ $RULE1
 
 # Project memory
 If \`AGENTS.md\` or \`CLAUDE.md\` already exists, or if this task produced durable project-intrinsic knowledge, run \`$FM_ROOT/bin/fm-ensure-agents-md.sh .\` in the worktree.
-If this task produced durable project-intrinsic knowledge, record it in \`AGENTS.md\` as part of your change.
-Keep it proportionate: skip \`AGENTS.md\` edits for trivial tasks that produced no durable project knowledge.
+If this task produced durable project-intrinsic knowledge, record it as part of your change, routed by size and specificity:
+- A general, always-needed operating fact (build, test, release, a cross-cutting convention, a sharp edge) while \`AGENTS.md\` is still small (under ~300 lines / ~10k tokens): record it inline in \`AGENTS.md\`.
+- A situation-specific subsystem/script/screen contract, OR \`AGENTS.md\` already over that threshold: do NOT append to \`AGENTS.md\`. Run \`$FM_ROOT/bin/fm-ensure-agents-md.sh . --skill <subsystem>\`, write the contract into \`.agents/skills/<subsystem>/SKILL.md\` (\`user-invocable: false\`), and add or keep a one-line entry for it under a \`## Skills\` index in \`AGENTS.md\` (one line stating when to load it). See \`$FM_ROOT/docs/project-skills.md\`.
+Keep it proportionate: skip project-memory edits for trivial tasks that produced no durable project knowledge.
 
 $DOD
 EOF

--- a/bin/fm-ensure-agents-md.sh
+++ b/bin/fm-ensure-agents-md.sh
@@ -24,6 +24,7 @@ usage() {
 
 SKILL_NAME=""
 DIR="."
+DIR_SET=0
 while [ "$#" -gt 0 ]; do
   case "$1" in
     -h|--help)
@@ -37,6 +38,7 @@ while [ "$#" -gt 0 ]; do
       ;;
     --skill=*)
       SKILL_NAME=${1#--skill=}
+      [ -n "$SKILL_NAME" ] || { echo "error: --skill requires a name" >&2; usage; exit 1; }
       ;;
     -*)
       echo "error: unknown flag: $1" >&2
@@ -44,7 +46,9 @@ while [ "$#" -gt 0 ]; do
       exit 1
       ;;
     *)
+      [ "$DIR_SET" -eq 0 ] || { echo "error: unexpected argument: $1" >&2; usage; exit 1; }
       DIR=$1
+      DIR_SET=1
       ;;
   esac
   shift
@@ -168,7 +172,7 @@ ensure_skill() {
   if [ -L ".claude/skills" ]; then
     target=$(readlink ".claude/skills")
     case "$target" in
-      "../.agents/skills"|".agents/skills") : ;;
+      "../.agents/skills") : ;;
       *)
         echo "conflict: .claude/skills is a symlink in $DIR but does not point to ../.agents/skills" >&2
         exit 1

--- a/bin/fm-ensure-agents-md.sh
+++ b/bin/fm-ensure-agents-md.sh
@@ -4,24 +4,61 @@
 # relative symlink to it for compatibility. Creates a minimal AGENTS.md skeleton
 # when neither file exists, promotes a real CLAUDE.md file when it is the only
 # file present, and refuses to clobber distinct real files or wrong symlinks.
+#
+# With --skill <name>, it also scaffolds the project skills layout, mirroring
+# firstmate's own pattern: a `.agents/skills/` directory with a
+# `.claude/skills -> ../.agents/skills` symlink, plus a
+# `.agents/skills/<name>/SKILL.md` stub (user-invocable: false) when absent.
+# This is how situation-specific subsystem contracts move out of a growing
+# AGENTS.md and into on-demand skills (see docs/project-skills.md). It refuses
+# to clobber an existing SKILL.md or a wrong .claude/skills symlink.
+#
 # This is a worktree utility for crewmates, not a supervision script, so it does
 # not call fm-guard.sh.
-# Usage: fm-ensure-agents-md.sh [repo-or-worktree-dir]
+# Usage: fm-ensure-agents-md.sh [--skill <name>] [repo-or-worktree-dir]
 set -eu
 
 usage() {
-  echo "usage: fm-ensure-agents-md.sh [repo-or-worktree-dir]" >&2
+  echo "usage: fm-ensure-agents-md.sh [--skill <name>] [repo-or-worktree-dir]" >&2
 }
 
-case "${1:-}" in
-  -h|--help)
-    usage
-    exit 0
-    ;;
-esac
-[ "$#" -le 1 ] || { usage; exit 1; }
+SKILL_NAME=""
+DIR="."
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --skill)
+      shift
+      [ "$#" -ge 1 ] || { echo "error: --skill requires a name" >&2; usage; exit 1; }
+      SKILL_NAME=$1
+      ;;
+    --skill=*)
+      SKILL_NAME=${1#--skill=}
+      ;;
+    -*)
+      echo "error: unknown flag: $1" >&2
+      usage
+      exit 1
+      ;;
+    *)
+      DIR=$1
+      ;;
+  esac
+  shift
+done
 
-DIR=${1:-.}
+if [ -n "$SKILL_NAME" ]; then
+  case "$SKILL_NAME" in
+    *[!a-z0-9-]*|-*|*-)
+      echo "error: --skill name must be a lowercase kebab slug (a-z, 0-9, dashes; no leading/trailing dash): $SKILL_NAME" >&2
+      exit 1
+      ;;
+  esac
+fi
+
 [ -d "$DIR" ] || { echo "error: not a directory: $DIR" >&2; exit 1; }
 DIR=$(cd "$DIR" && pwd -P)
 cd "$DIR"
@@ -57,58 +94,121 @@ PY
   return 1
 }
 
-if [ -L "$AGENTS" ]; then
-  echo "conflict: AGENTS.md is a symlink in $DIR; expected AGENTS.md to be the real file" >&2
-  exit 1
-fi
-if [ -e "$AGENTS" ] && [ ! -f "$AGENTS" ]; then
-  echo "conflict: AGENTS.md exists in $DIR but is not a regular file" >&2
-  exit 1
-fi
+# Reconcile AGENTS.md / CLAUDE.md. Prints exactly one status line on success and
+# returns 0; prints an error and exits non-zero on an unrecoverable conflict.
+ensure_agents_claude() {
+  if [ -L "$AGENTS" ]; then
+    echo "conflict: AGENTS.md is a symlink in $DIR; expected AGENTS.md to be the real file" >&2
+    exit 1
+  fi
+  if [ -e "$AGENTS" ] && [ ! -f "$AGENTS" ]; then
+    echo "conflict: AGENTS.md exists in $DIR but is not a regular file" >&2
+    exit 1
+  fi
 
-if [ -e "$AGENTS" ]; then
+  if [ -e "$AGENTS" ]; then
+    if [ -L "$CLAUDE" ]; then
+      if is_correct_claude_symlink; then
+        echo "unchanged: AGENTS.md with CLAUDE.md -> AGENTS.md in $DIR"
+        return 0
+      fi
+      echo "conflict: CLAUDE.md is a symlink in $DIR but does not point to AGENTS.md" >&2
+      exit 1
+    fi
+    if [ ! -e "$CLAUDE" ]; then
+      ln -s "$AGENTS" "$CLAUDE"
+      echo "symlinked: CLAUDE.md -> AGENTS.md in $DIR"
+      return 0
+    fi
+    if [ -f "$CLAUDE" ]; then
+      echo "conflict: both AGENTS.md and CLAUDE.md are real files in $DIR; reconcile them manually" >&2
+      exit 1
+    fi
+    echo "conflict: CLAUDE.md exists in $DIR but is not a regular file or symlink" >&2
+    exit 1
+  fi
+
   if [ -L "$CLAUDE" ]; then
     if is_correct_claude_symlink; then
-      echo "unchanged: AGENTS.md with CLAUDE.md -> AGENTS.md in $DIR"
-      exit 0
+      write_skeleton
+      echo "created: AGENTS.md and kept CLAUDE.md -> AGENTS.md in $DIR"
+      return 0
     fi
-    echo "conflict: CLAUDE.md is a symlink in $DIR but does not point to AGENTS.md" >&2
+    echo "conflict: CLAUDE.md is a symlink in $DIR but AGENTS.md is missing and the link does not point to AGENTS.md" >&2
     exit 1
   fi
-  if [ ! -e "$CLAUDE" ]; then
-    ln -s "$AGENTS" "$CLAUDE"
-    echo "symlinked: CLAUDE.md -> AGENTS.md in $DIR"
-    exit 0
-  fi
-  if [ -f "$CLAUDE" ]; then
-    echo "conflict: both AGENTS.md and CLAUDE.md are real files in $DIR; reconcile them manually" >&2
+
+  if [ -e "$CLAUDE" ]; then
+    if [ -f "$CLAUDE" ]; then
+      mv "$CLAUDE" "$AGENTS"
+      ln -s "$AGENTS" "$CLAUDE"
+      echo "promoted: moved CLAUDE.md to AGENTS.md and symlinked CLAUDE.md -> AGENTS.md in $DIR"
+      return 0
+    fi
+    echo "conflict: CLAUDE.md exists in $DIR but is not a regular file or symlink" >&2
     exit 1
   fi
-  echo "conflict: CLAUDE.md exists in $DIR but is not a regular file or symlink" >&2
-  exit 1
-fi
 
-if [ -L "$CLAUDE" ]; then
-  if is_correct_claude_symlink; then
-    write_skeleton
-    echo "created: AGENTS.md and kept CLAUDE.md -> AGENTS.md in $DIR"
-    exit 0
+  write_skeleton
+  ln -s "$AGENTS" "$CLAUDE"
+  echo "created: AGENTS.md and CLAUDE.md -> AGENTS.md in $DIR"
+}
+
+# Scaffold the project skills layout and a SKILL.md stub for <name>. Mirrors
+# firstmate's own `.agents/skills/` with `.claude/skills -> ../.agents/skills`.
+ensure_skill() {
+  skill_name=$1
+
+  mkdir -p ".agents/skills"
+
+  if [ -e ".claude" ] && [ ! -d ".claude" ] && [ ! -L ".claude" ]; then
+    echo "conflict: .claude exists in $DIR but is not a directory" >&2
+    exit 1
   fi
-  echo "conflict: CLAUDE.md is a symlink in $DIR but AGENTS.md is missing and the link does not point to AGENTS.md" >&2
-  exit 1
-fi
-
-if [ -e "$CLAUDE" ]; then
-  if [ -f "$CLAUDE" ]; then
-    mv "$CLAUDE" "$AGENTS"
-    ln -s "$AGENTS" "$CLAUDE"
-    echo "promoted: moved CLAUDE.md to AGENTS.md and symlinked CLAUDE.md -> AGENTS.md in $DIR"
-    exit 0
+  if [ -L ".claude/skills" ]; then
+    target=$(readlink ".claude/skills")
+    case "$target" in
+      "../.agents/skills"|".agents/skills") : ;;
+      *)
+        echo "conflict: .claude/skills is a symlink in $DIR but does not point to ../.agents/skills" >&2
+        exit 1
+        ;;
+    esac
+  elif [ -e ".claude/skills" ]; then
+    echo "conflict: .claude/skills exists in $DIR but is not the expected symlink" >&2
+    exit 1
+  else
+    mkdir -p ".claude"
+    ln -s "../.agents/skills" ".claude/skills"
+    echo "symlinked: .claude/skills -> ../.agents/skills in $DIR"
   fi
-  echo "conflict: CLAUDE.md exists in $DIR but is not a regular file or symlink" >&2
-  exit 1
-fi
 
-write_skeleton
-ln -s "$AGENTS" "$CLAUDE"
-echo "created: AGENTS.md and CLAUDE.md -> AGENTS.md in $DIR"
+  skill_dir=".agents/skills/$skill_name"
+  skill_file="$skill_dir/SKILL.md"
+  if [ -L "$skill_dir" ] || { [ -e "$skill_dir" ] && [ ! -d "$skill_dir" ]; }; then
+    echo "conflict: $skill_dir exists in $DIR but is not a directory" >&2
+    exit 1
+  fi
+  if [ -e "$skill_file" ]; then
+    echo "unchanged: $skill_file already exists in $DIR"
+    return 0
+  fi
+  mkdir -p "$skill_dir"
+  cat > "$skill_file" <<EOF
+---
+name: $skill_name
+description: TODO one-line load trigger stating the subsystem this covers and when to load it, e.g. load before touching $skill_name.
+user-invocable: false
+---
+
+# $skill_name
+
+TODO: move the situation-specific contract for this subsystem out of AGENTS.md into this skill, and leave a one-line entry in the AGENTS.md skills index pointing here (see docs/project-skills.md).
+EOF
+  echo "scaffolded: $skill_file in $DIR"
+}
+
+ensure_agents_claude
+if [ -n "$SKILL_NAME" ]; then
+  ensure_skill "$SKILL_NAME"
+fi

--- a/docs/project-skills.md
+++ b/docs/project-skills.md
@@ -1,0 +1,66 @@
+# Project skills: keeping project `AGENTS.md` context-cheap
+
+## Why this exists
+
+A project's `AGENTS.md` (with `CLAUDE.md` symlinked to it) is auto-loaded into the context window of every crewmate that works that project, on every spawn, whether or not that crewmate ever touches the area a given section describes.
+Its token cost is therefore paid by every session, every time.
+When `AGENTS.md` accumulates situation-specific detail - a full contract per subsystem, per script, or per screen - a crewmate fixing one area still carries all the others as dead weight.
+Left unchecked this is a large, silent context tax: audited project `AGENTS.md` files reached 488-538 lines (~12k-20k tokens) almost entirely from inlined per-subsystem contracts.
+
+Project skills fix this by moving the sometimes-relevant detail out of `AGENTS.md` and into on-demand skills, leaving `AGENTS.md` as always-needed operating facts plus a compact index of what skills exist and when to load them.
+The situation-specific contract still exists and is still committed with the code; it just loads only in the sessions that actually need it.
+
+## The layout
+
+This mirrors firstmate's own `.agents/skills/` pattern, one level down in each project:
+
+```
+projects/<name>/            # the project repo
+  AGENTS.md                 # always-needed operating facts + a `## Skills` index
+  CLAUDE.md                 # symlink -> AGENTS.md (unchanged)
+  .agents/skills/
+    <subsystem-a>/SKILL.md   # situation-specific contract, user-invocable: false
+    <subsystem-b>/SKILL.md
+  .claude/skills            # symlink -> ../.agents/skills
+```
+
+`AGENTS.md` keeps: stack, build/test/release mechanics, cross-cutting conventions, sharp edges, and a `## Skills` index with one line per skill stating its load trigger, for example:
+
+```markdown
+## Skills (load before the matching work)
+- `flow-sheet` - load before touching the flow-sheet document, columns, canvas, or round lifecycle.
+- `block-file` - load before touching the block-file schema, section nodes, or argument queries.
+- `editor` - load before changing the Tiptap/Yjs editor core, marks, or the outline seam.
+```
+
+Each `SKILL.md` carries frontmatter with `name`, a `description` whose text doubles as the load trigger, and `user-invocable: false` (these are agent-only references, not captain commands), then the full subsystem contract in its body.
+
+## Precedent
+
+`consider-it-done` already ships this exact structure: `projects/consider-it-done/.agents/skills/consider-it-done/SKILL.md` with `.claude/skills -> ../.agents/skills` and `user-invocable: false`.
+firstmate's own repo uses the identical layout for its agent-only reference skills.
+Project skills generalize that precedent to every project.
+
+## The trigger (when to split instead of append)
+
+The ship-brief project-memory contract (`bin/fm-brief.sh`, and section 11 of the root `AGENTS.md`) directs a crewmate to route durable project-intrinsic knowledge by size and specificity:
+
+- **Record inline in `AGENTS.md`** when the knowledge is a general, always-needed operating fact AND `AGENTS.md` is still small (under the threshold below).
+- **Split into a project skill** when the knowledge is a situation-specific subsystem/script/screen contract, OR `AGENTS.md` is already over the threshold.
+
+Threshold (tunable): **`AGENTS.md` over ~300 lines or ~10k tokens (~40k bytes)**.
+The line/token figures are a heuristic, not a hard gate; the underlying rule is the knowledge-placement decision tree in the `firstmate-coding-guidelines` skill - always-needed-every-session facts stay inline, nameable-situation facts move to a skill.
+
+## How a crewmate does the split
+
+1. Run `bin/fm-ensure-agents-md.sh . --skill <subsystem>` in the worktree.
+   This ensures `AGENTS.md`/`CLAUDE.md` exist, creates `.agents/skills/` with the `.claude/skills -> ../.agents/skills` symlink if absent, and scaffolds `.agents/skills/<subsystem>/SKILL.md` as a stub (refusing to clobber an existing skill or a wrong symlink).
+2. Write the situation-specific contract into that `SKILL.md` body and fill in its `description` load trigger.
+3. Add or keep a one-line entry for it under the `## Skills` index in `AGENTS.md`.
+4. Commit all of it through the project's normal delivery pipeline.
+
+Firstmate never hand-writes project skills or project `AGENTS.md`, exactly as prime directive #1 requires; crewmates create and commit them inside their worktrees through the project's delivery mode.
+
+## Payoff
+
+Splitting a fat catalog-style `AGENTS.md` down to an operating core plus a skills index plausibly cuts the always-loaded cost from ~12k-20k tokens to ~4k-6k tokens per spawn for that project, with the moved detail one skill-load away in the sessions that need it.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -12,7 +12,7 @@ If you have changed away from the firstmate home in an interactive shell, invoke
 | `fm-update.sh`           | Self-update the running firstmate repo and registered secondmate homes with fast-forward-only pulls from origin     |
 | `fm-backlog-handoff.sh`  | Move already-judged in-scope queued backlog items from the main home into a seeded secondmate home                 |
 | `fm-brief.sh`            | Scaffold a ship brief with a worktree-isolation assertion, a report-only scout brief with `--scout`, or a secondmate charter with `--secondmate` |
-| `fm-ensure-agents-md.sh` | Ensure project `AGENTS.md` is the real memory file and `CLAUDE.md` symlinks to it                                   |
+| `fm-ensure-agents-md.sh` | Ensure project `AGENTS.md` is the real memory file and `CLAUDE.md` symlinks to it; with `--skill <name>`, also scaffold the project skills layout (`.agents/skills/` + `.claude/skills` symlink + a `SKILL.md` stub) for splitting situation-specific detail out of `AGENTS.md` (docs/project-skills.md) |
 | `fm-guard.sh`            | Warn when the primary checkout is tangled, when queued wakes are pending, or when a stale or missing watcher needs a prominent banner; `FM_GUARD_READ_ONLY=1` keeps the alarms but suppresses drain, arm, and checkout repair commands |
 | `fm-turnend-guard.sh`    | Claude Code Stop hook, primary-scoped only: blocks (exit 2, exact reason) a primary turn end when work is in flight without a live identity-matched watcher lock and fresh beacon, using Claude Code's own `stop_hook_active` field so it never blocks twice in one turn (docs/turnend-guard.md) |
 | `fm-home-seed.sh`        | Lease/provision a secondmate home transactionally, clone projects, initialize gates, and maintain `data/secondmates.md` |

--- a/tests/fm-afk-inject-e2e.test.sh
+++ b/tests/fm-afk-inject-e2e.test.sh
@@ -54,7 +54,7 @@ cleanup_all() {
     wait "$DAEMON_PID" 2>/dev/null || true
   fi
   if [ -n "${SOCKET:-}" ] && [ -n "${REAL_TMUX:-}" ]; then
-    "$REAL_TMUX" -L "$SOCKET" kill-server 2>/dev/null || true
+    "$REAL_TMUX" -f /dev/null -L "$SOCKET" kill-server 2>/dev/null || true
   fi
   rm -rf "${TMUX_SHIM_DIR:-}" 2>/dev/null || true
   rm -rf "${STATE_DIR:-}" 2>/dev/null || true
@@ -73,8 +73,8 @@ LOG_FILE="$STATE_DIR/submitted.log"
 . "$DAEMON"
 
 # Private tmux server with a supervisor session.
-"$REAL_TMUX" -L "$SOCKET" new-session -d -s supervisor -x 200 -y 50
-SUPERVISOR_PANE=$("$REAL_TMUX" -L "$SOCKET" display-message -p -t supervisor '#{pane_id}')
+"$REAL_TMUX" -f /dev/null -L "$SOCKET" new-session -d -s supervisor -x 200 -y 50
+SUPERVISOR_PANE=$("$REAL_TMUX" -f /dev/null -L "$SOCKET" display-message -p -t supervisor '#{pane_id}')
 
 # Supervisor pane loop: a small deterministic composer that logs each submitted
 # line verbatim (hex + text + classification). It draws the in-progress input
@@ -126,7 +126,7 @@ LOOP
 chmod +x "$LOOP_SCRIPT"
 
 # Start the loop in the supervisor pane.
-"$REAL_TMUX" -L "$SOCKET" send-keys -t "$SUPERVISOR_PANE" \
+"$REAL_TMUX" -f /dev/null -L "$SOCKET" send-keys -t "$SUPERVISOR_PANE" \
   "bash '$LOOP_SCRIPT' '$LOG_FILE'" Enter
 sleep 1  # let the loop start and settle
 
@@ -145,15 +145,15 @@ if [ "\${1:-}" = "send-keys" ] && [ -f "$STATE_DIR/.swallow-enter" ]; then
     fi
     _args+=("\$_arg")
   done
-  exec "$REAL_TMUX" -L "$SOCKET" send-keys "\${_args[@]}"
+  exec "$REAL_TMUX" -f /dev/null -L "$SOCKET" send-keys "\${_args[@]}"
 fi
-exec "$REAL_TMUX" -L "$SOCKET" "\$@"
+exec "$REAL_TMUX" -f /dev/null -L "$SOCKET" "\$@"
 SHIM
 chmod +x "$TMUX_SHIM_DIR/tmux"
 
 # Create a fake crewmate window (the watcher lists fm-* windows for stale
 # detection). The pane is an inert shell — it just needs to exist.
-"$REAL_TMUX" -L "$SOCKET" new-window -d -n fm-fake-c1 -t supervisor
+"$REAL_TMUX" -f /dev/null -L "$SOCKET" new-window -d -n fm-fake-c1 -t supervisor
 
 start_daemon() {
   PATH="$TMUX_SHIM_DIR:$PATH" \
@@ -217,24 +217,24 @@ reset_state() {
 
 selfcheck_pane_input_pending() {
   local check_text="selfcheck-marker-12345"
-  "$REAL_TMUX" -L "$SOCKET" send-keys -t "$SUPERVISOR_PANE" -l "$check_text"
+  "$REAL_TMUX" -f /dev/null -L "$SOCKET" send-keys -t "$SUPERVISOR_PANE" -l "$check_text"
   sleep 0.5
   if PATH="$TMUX_SHIM_DIR:$PATH" pane_input_pending "$SUPERVISOR_PANE"; then
     # Detected — clean up the text and proceed.
-    "$REAL_TMUX" -L "$SOCKET" send-keys -t "$SUPERVISOR_PANE" Enter
+    "$REAL_TMUX" -f /dev/null -L "$SOCKET" send-keys -t "$SUPERVISOR_PANE" Enter
     sleep 0.3
     return 0
   fi
   # Not detected - print diagnostics and fail.
   echo "pane_input_pending cannot detect typed text in this tmux environment" >&2
   local _cy _line
-  _cy=$("$REAL_TMUX" -L "$SOCKET" display-message -p -t "$SUPERVISOR_PANE" '#{cursor_y}' 2>/dev/null)
+  _cy=$("$REAL_TMUX" -f /dev/null -L "$SOCKET" display-message -p -t "$SUPERVISOR_PANE" '#{cursor_y}' 2>/dev/null)
   echo "  cursor_y=$_cy" >&2
   echo "  pane capture (first 10 lines):" >&2
-  "$REAL_TMUX" -L "$SOCKET" capture-pane -p -t "$SUPERVISOR_PANE" 2>/dev/null | head -10 | sed 's/^/    /' >&2
-  _line=$("$REAL_TMUX" -L "$SOCKET" capture-pane -p -t "$SUPERVISOR_PANE" 2>/dev/null | sed -n "$((_cy + 1))p")
+  "$REAL_TMUX" -f /dev/null -L "$SOCKET" capture-pane -p -t "$SUPERVISOR_PANE" 2>/dev/null | head -10 | sed 's/^/    /' >&2
+  _line=$("$REAL_TMUX" -f /dev/null -L "$SOCKET" capture-pane -p -t "$SUPERVISOR_PANE" 2>/dev/null | sed -n "$((_cy + 1))p")
   echo "  cursor line: '$_line'" >&2
-  "$REAL_TMUX" -L "$SOCKET" send-keys -t "$SUPERVISOR_PANE" Enter
+  "$REAL_TMUX" -f /dev/null -L "$SOCKET" send-keys -t "$SUPERVISOR_PANE" Enter
   fail "pane_input_pending self-check failed"
 }
 
@@ -249,7 +249,7 @@ test_scenario_a() {
 
   # Type partial text into the supervisor pane with NO Enter. This simulates the
   # captain returning and starting to type before afk has been cleared.
-  "$REAL_TMUX" -L "$SOCKET" send-keys -t "$SUPERVISOR_PANE" -l "human draft text"
+  "$REAL_TMUX" -f /dev/null -L "$SOCKET" send-keys -t "$SUPERVISOR_PANE" -l "human draft text"
   sleep 0.5
 
   # Write a captain-relevant status to trigger a real escalation through the
@@ -271,7 +271,7 @@ test_scenario_a() {
   fi
 
   # Now submit the human's text (Enter). The pane goes idle.
-  "$REAL_TMUX" -L "$SOCKET" send-keys -t "$SUPERVISOR_PANE" Enter
+  "$REAL_TMUX" -f /dev/null -L "$SOCKET" send-keys -t "$SUPERVISOR_PANE" Enter
   sleep 0.5
 
   # Wait for the daemon to retry injection (housekeeping tick = 1s).

--- a/tests/fm-backend-tmux-smoke.test.sh
+++ b/tests/fm-backend-tmux-smoke.test.sh
@@ -30,7 +30,7 @@ cleanup_all() {
 SHIM_DIR=$(mktemp -d "${TMPDIR:-/tmp}/fm-backend-smoke.XXXXXX")
 cat > "$SHIM_DIR/tmux" <<SH
 #!/usr/bin/env bash
-exec "$REAL_TMUX" -L "$SOCKET" "\$@"
+exec "$REAL_TMUX" -f /dev/null -L "$SOCKET" "\$@"
 SH
 chmod +x "$SHIM_DIR/tmux"
 PATH="$SHIM_DIR:$PATH"

--- a/tests/fm-ensure-agents-md.test.sh
+++ b/tests/fm-ensure-agents-md.test.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Behavior tests for bin/fm-ensure-agents-md.sh.
+#
+# Covers the unchanged AGENTS.md/CLAUDE.md reconciliation plus the --skill
+# project-skills scaffolding: it creates .agents/skills/ with a
+# .claude/skills -> ../.agents/skills symlink and a SKILL.md stub, is
+# idempotent, and refuses to clobber an existing skill or a wrong symlink.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SCRIPT="$ROOT/bin/fm-ensure-agents-md.sh"
+TMP_ROOT=$(fm_test_tmproot fm-ensure-agents-md)
+
+# The script must always parse.
+test_script_parses() {
+  bash -n "$SCRIPT" 2>&1 || fail "bin/fm-ensure-agents-md.sh fails bash -n"
+  pass "fm-ensure-agents-md.sh: bash -n succeeds"
+}
+
+# Default (no --skill) in an empty dir creates AGENTS.md + CLAUDE.md symlink,
+# and must NOT create any skills scaffolding.
+test_default_creates_agents_no_skills() {
+  local d="$TMP_ROOT/default"
+  mkdir -p "$d"
+  "$SCRIPT" "$d" >/dev/null 2>&1 || fail "default run exited non-zero"
+  assert_present "$d/AGENTS.md" "AGENTS.md not created"
+  [ -L "$d/CLAUDE.md" ] || fail "CLAUDE.md not a symlink"
+  assert_absent "$d/.agents/skills" "default run should not scaffold .agents/skills"
+  assert_absent "$d/.claude/skills" "default run should not scaffold .claude/skills"
+  pass "fm-ensure-agents-md.sh: default creates AGENTS.md, no skills layout"
+}
+
+# --skill scaffolds the full skills layout and a SKILL.md stub.
+test_skill_scaffolds_layout() {
+  local d="$TMP_ROOT/skill"
+  mkdir -p "$d"
+  local out
+  out=$("$SCRIPT" --skill flow-sheet "$d" 2>&1) || fail "--skill run exited non-zero: $out"
+  assert_present "$d/AGENTS.md" "AGENTS.md not created by --skill run"
+  [ -d "$d/.agents/skills" ] || fail ".agents/skills dir not created"
+  [ -L "$d/.claude/skills" ] || fail ".claude/skills symlink not created"
+  [ "$(readlink "$d/.claude/skills")" = "../.agents/skills" ] || \
+    fail ".claude/skills points at the wrong target"
+  assert_present "$d/.agents/skills/flow-sheet/SKILL.md" "SKILL.md stub not created"
+  assert_grep "name: flow-sheet" "$d/.agents/skills/flow-sheet/SKILL.md" \
+    "SKILL.md missing name frontmatter"
+  assert_grep "user-invocable: false" "$d/.agents/skills/flow-sheet/SKILL.md" \
+    "SKILL.md missing user-invocable: false"
+  pass "fm-ensure-agents-md.sh: --skill scaffolds layout + stub"
+}
+
+# --skill is idempotent and refuses to clobber an existing SKILL.md body.
+test_skill_idempotent_no_clobber() {
+  local d="$TMP_ROOT/idem"
+  mkdir -p "$d"
+  "$SCRIPT" --skill editor "$d" >/dev/null 2>&1 || fail "first --skill run failed"
+  printf 'CUSTOM BODY\n' > "$d/.agents/skills/editor/SKILL.md"
+  local out
+  out=$("$SCRIPT" --skill editor "$d" 2>&1) || fail "second --skill run should succeed unchanged: $out"
+  assert_contains "$out" "unchanged" "second run should report unchanged for existing SKILL.md"
+  assert_grep "CUSTOM BODY" "$d/.agents/skills/editor/SKILL.md" \
+    "existing SKILL.md was clobbered"
+  pass "fm-ensure-agents-md.sh: --skill idempotent, never clobbers a real SKILL.md"
+}
+
+# A wrong .claude/skills symlink is a refusing conflict, not a silent overwrite.
+test_wrong_claude_skills_symlink_refuses() {
+  local d="$TMP_ROOT/wronglink"
+  mkdir -p "$d/.claude" "$d/elsewhere"
+  ln -s "../elsewhere" "$d/.claude/skills"
+  local out rc
+  out=$("$SCRIPT" --skill x "$d" 2>&1); rc=$?
+  expect_code 1 "$rc" "wrong .claude/skills symlink should refuse"
+  assert_contains "$out" "conflict" "refusal should explain the conflict"
+  pass "fm-ensure-agents-md.sh: refuses a wrong .claude/skills symlink"
+}
+
+# An invalid skill slug is rejected up front.
+test_invalid_slug_rejected() {
+  local d="$TMP_ROOT/badslug"
+  mkdir -p "$d"
+  local rc
+  "$SCRIPT" --skill "Bad Name" "$d" >/dev/null 2>&1; rc=$?
+  expect_code 1 "$rc" "invalid skill slug should be rejected"
+  pass "fm-ensure-agents-md.sh: rejects an invalid skill slug"
+}
+
+test_script_parses
+test_default_creates_agents_no_skills
+test_skill_scaffolds_layout
+test_skill_idempotent_no_clobber
+test_wrong_claude_skills_symlink_refuses
+test_invalid_slug_rejected


### PR DESCRIPTION
## Summary

Adds a firstmate-level mechanism so project `AGENTS.md` files stop accumulating situation-specific detail inline, which bloats every crewmate's spawn context. An audit found project `AGENTS.md` files reaching 488-538 lines (~12k-20k tokens) almost entirely from inlined per-subsystem/per-script contracts that a given crewmate rarely all needs at once - a cost paid on every spawn for that project.

The design splits sometimes-relevant subsystem/script/screen contracts out of `AGENTS.md` into on-demand **project skills** under `.agents/skills/<name>/SKILL.md` (`user-invocable: false`), with a `.claude/skills -> ../.agents/skills` symlink, mirroring firstmate's own skills pattern and the existing `consider-it-done` project-skill precedent. `AGENTS.md` keeps always-needed operating facts plus a compact `## Skills` index (one line per skill stating its load trigger).

## Changes

- **`bin/fm-ensure-agents-md.sh`**: new `--skill <name>` flag that idempotently scaffolds the project skills layout (`.agents/skills/` + `.claude/skills` symlink + a `SKILL.md` stub), refusing to clobber an existing skill or a wrong `.claude/skills` symlink and validating the slug. The existing `AGENTS.md`/`CLAUDE.md` reconciliation is refactored into a function so `--skill` runs after it; behavior is unchanged when `--skill` is absent.
- **`bin/fm-brief.sh`**: the ship-brief project-memory contract is now split-aware - general operating facts stay inline, while situation-specific subsystem contracts (or any growth past ~300 lines / ~10k tokens) route into a project skill via `--skill`. Written self-contained (a project crewmate cannot load firstmate's own skills) and pointing to `docs/project-skills.md`.
- **`AGENTS.md`**: states the routing contract once in section 6 (prose + knowledge-routing table row), with a one-line cross-reference from section 11, honoring the one-owner rule.
- **`docs/project-skills.md`** (new): mechanism, threshold rationale, layout, split procedure, and the `consider-it-done` precedent. Linked from `README.md` and `docs/scripts.md`.
- **`tests/fm-ensure-agents-md.test.sh`** (new): covers scaffolding, idempotency, clobber refusal, wrong-symlink refusal, and slug validation. Registered in `CONTRIBUTING.md`.

The ~300 line / ~10k token figures are deliberate, tunable heuristics, not hard gates; the underlying rule is the knowledge-placement decision tree in the `firstmate-coding-guidelines` skill.

## Test plan

- [x] `shellcheck bin/*.sh bin/backends/*.sh tests/*.sh` clean
- [x] `tests/fm-ensure-agents-md.test.sh` passes (scaffolding, idempotency, clobber/wrong-symlink refusal, slug validation)
- [x] `tests/fm-brief.test.sh` regression passes
- [x] Live `--skill` run produces exactly the `.claude/skills -> ../.agents/skills` structure
- [x] Validated end-to-end through the no-mistakes pipeline (review, test, document, lint all green)
