### PR TITLE
feat(context-handoff): swap context-heavy crewmate for a fresh agent

### DIFF
--- a/.agents/skills/context-handoff/SKILL.md
+++ b/.agents/skills/context-handoff/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: context-handoff
+description: Agent-only playbook for handing a context-heavy crewmate's work to a fresh agent instead of /compact. Use when the watcher flags a task at >=60% of its context window (via state/<id>.context). Orchestrates the swap with existing tools - old crewmate dumps resume-context to data/<id>/handoff.md, fm-spawn --reuse-worktree relaunches a fresh agent on the same worktree/branch seeded with that dump, then the old agent is retired. Preferred over /compact for large multi-phase tasks.
+user-invocable: false
+metadata:
+  internal: true
+---
+
+# context-handoff
+
+Use this playbook when the watcher flags a live crewmate at **>=60%** of its context window.
+The flag is harness-truth, not a model self-report: the crewmate's per-turn `Stop` hook writes `state/<id>.context` (context tokens summed from the transcript's last `usage` record), and the watcher fleet-scan reads it against the window implied by `state/<id>.meta` `model=` (1M for Opus/Sonnet, 200k for smaller-context models).
+
+**Why a fresh agent, not `/compact`.**
+`/compact` is lossy in-place summarization that degrades further on every re-compact.
+A fresh agent starts at 0% context, deterministic, and is reseeded by a dump the crewmate *deliberately authored* (it chooses what matters, unlike an auto-summarizer).
+One dump-and-reload turn is worth it for large, multi-phase tasks; it is overkill for small ones, so this only fires at the 60% threshold.
+The in-progress diff is never discarded: the handoff reuses the crewmate's existing worktree and branch.
+
+## Applicability by harness
+
+- **claude** (default): full support. The `Stop` hook writes `state/<id>.context` every turn, so detection is exact.
+- **codex / grok / opencode**: no equivalent transcript/hook shape. Detection falls back to the idle-pane footer scrape where available, or is skipped. Do not force a handoff on a harness with no honest context signal.
+
+## When to execute
+
+Flag at 60%, but **execute at the crewmate's next idle turn-boundary** - never mid no-mistakes validation run. Let an in-flight pipeline finish first; a swap during validation would strand the run.
+
+**Auto vs ask (default auto).** Perform the handoff autonomously and send the captain a one-line FYI. Escalate to the captain *before* swapping only if the crewmate is mid-critical (e.g. a delicate uncommitted state that the dump may not fully capture). This default is captain-configurable.
+
+## Steps
+
+1. **Steer the old crewmate to dump (one `fm-send` line).** Instruct it to write all resume-context to `data/<id>/handoff.md`, then stop. The dump must cover:
+   - task state and current goal,
+   - decisions made and why,
+   - files touched and why,
+   - a diff summary (what is committed vs working-tree),
+   - what is done and what remains,
+   - repro / test commands,
+   - gotchas and dead-ends already ruled out.
+
+   `data/<id>/handoff.md` lives **outside** the worktree, so it survives the swap and never dirties the branch. Send exactly one line via `bin/fm-send.sh`; anything longer belongs in a file.
+
+2. **Wait for the dump.** Wait for the crewmate's turn-end signal AND for `data/<id>/handoff.md` to exist and be non-trivial. If the crewmate stalls or the file is missing, fall back to `stuck-crewmate-recovery` rather than swapping on an empty dump.
+
+3. **Relaunch a fresh agent on the same worktree.**
+   ```sh
+   bin/fm-spawn.sh --reuse-worktree <id>
+   ```
+   This skips `treehouse get`, reuses the crewmate's existing worktree from `state/<id>.meta`, keeps the same task id and `fm/<id>` branch, re-installs the turn-end/context hook, updates the meta window/pane target, and launches the harness seeded with **the original brief + `data/<id>/handoff.md` + "resume from here."** It is the agent swap; it is NOT `fm-teardown` (which destroys the worktree).
+
+4. **Retire the old agent.** Kill only its pane (`tmux kill-pane` for tmux, or the harness's exit for others). Keep the same task id and worktree. The new agent is now the crewmate of record for `<id>`.
+
+5. **Note the swap to the captain (FYI) and continue normal supervision.** One outcome line: the task was handed to a fresh agent to keep context healthy; work and diff are intact. Re-arm the watcher as usual.
+
+## Guardrails
+
+- Never discard the worktree or its uncommitted diff - the whole point is that the in-progress work carries over.
+- Never swap mid no-mistakes validation; wait for the idle turn-boundary.
+- If the dump is missing or empty after the crewmate stops, do not proceed - recover the crewmate instead.
+- The reused worktree keeps the same branch, so the eventual PR is unaffected.

--- a/.agents/skills/context-handoff/SKILL.md
+++ b/.agents/skills/context-handoff/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: context-handoff
-description: Agent-only playbook for handing a context-heavy crewmate's work to a fresh agent instead of /compact. Use when the watcher flags a task at >=60% of its context window (via state/<id>.context). Orchestrates the swap with existing tools - old crewmate dumps resume-context to data/<id>/handoff.md, fm-spawn --reuse-worktree relaunches a fresh agent on the same worktree/branch seeded with that dump, then the old agent is retired. Preferred over /compact for large multi-phase tasks.
+description: Agent-only playbook for handing a context-heavy crewmate's work to a fresh agent instead of /compact. Use when the heartbeat context check (bin/fm-context.sh) flags a task at >=60% of its context window (via state/<id>.context). Orchestrates the swap with existing tools - old crewmate dumps resume-context to data/<id>/handoff.md, fm-spawn --reuse-worktree retires the old endpoint and relaunches a fresh agent on the same worktree/branch seeded with that dump. Preferred over /compact for large multi-phase tasks.
 user-invocable: false
 metadata:
   internal: true
@@ -8,8 +8,9 @@ metadata:
 
 # context-handoff
 
-Use this playbook when the watcher flags a live crewmate at **>=60%** of its context window.
-The flag is harness-truth, not a model self-report: the crewmate's per-turn `Stop` hook writes `state/<id>.context` (context tokens summed from the transcript's last `usage` record), and the watcher fleet-scan reads it against the window implied by `state/<id>.meta` `model=` (1M for Opus/Sonnet, 200k for smaller-context models).
+Use this playbook when the heartbeat context check flags a live crewmate at **>=60%** of its context window.
+The flag is harness-truth, not a model self-report: the crewmate's per-turn `Stop` hook writes `state/<id>.context` (context tokens summed from the transcript's last `usage` record), and firstmate reads it with `bin/fm-context.sh` during the section 8 heartbeat fleet review against the window implied by `state/<id>.meta` `model=` (1M for Opus/Sonnet, 200k for smaller-context models).
+The watcher (`bin/fm-watch.sh`) is deliberately not involved: `state/<id>.context` is not a `*.status`/`*.turn-ended` file, so it never wakes firstmate on its own; detection happens only at heartbeat time.
 
 **Why a fresh agent, not `/compact`.**
 `/compact` is lossy in-place summarization that degrades further on every re-compact.
@@ -20,7 +21,7 @@ The in-progress diff is never discarded: the handoff reuses the crewmate's exist
 ## Applicability by harness
 
 - **claude** (default): full support. The `Stop` hook writes `state/<id>.context` every turn, so detection is exact.
-- **codex / grok / opencode**: no equivalent transcript/hook shape. Detection falls back to the idle-pane footer scrape where available, or is skipped. Do not force a handoff on a harness with no honest context signal.
+- **codex / grok / opencode**: no equivalent transcript/hook shape, so no `state/<id>.context` is written; `bin/fm-context.sh` reports `no-data` and never flags them. Detection is effectively skipped for these harnesses today. Do not force a handoff on a harness with no honest context signal.
 
 ## When to execute
 
@@ -43,15 +44,14 @@ Flag at 60%, but **execute at the crewmate's next idle turn-boundary** - never m
 
 2. **Wait for the dump.** Wait for the crewmate's turn-end signal AND for `data/<id>/handoff.md` to exist and be non-trivial. If the crewmate stalls or the file is missing, fall back to `stuck-crewmate-recovery` rather than swapping on an empty dump.
 
-3. **Relaunch a fresh agent on the same worktree.**
+3. **Swap in a fresh agent on the same worktree.**
    ```sh
    bin/fm-spawn.sh --reuse-worktree <id>
    ```
-   This skips `treehouse get`, reuses the crewmate's existing worktree from `state/<id>.meta`, keeps the same task id and `fm/<id>` branch, re-installs the turn-end/context hook, updates the meta window/pane target, and launches the harness seeded with **the original brief + `data/<id>/handoff.md` + "resume from here."** It is the agent swap; it is NOT `fm-teardown` (which destroys the worktree).
+   This retires the previous agent's endpoint, then relaunches on the same worktree. It skips `treehouse get`, reuses the crewmate's existing worktree from `state/<id>.meta`, keeps the same task id and `fm/<id>` branch, re-installs the turn-end/context hook, updates the meta window/pane target, resets `state/<id>.context` + `state/<id>.turn-ended`, and launches the harness seeded with **the original brief + `data/<id>/handoff.md` + "resume from here."**
+   It retires the old endpoint itself because the new endpoint reuses the same `fm-<id>` window name, which a backend such as tmux will not let it duplicate; you do NOT kill the old pane in a separate step. It is the agent swap; it is NOT `fm-teardown` (which destroys the worktree).
 
-4. **Retire the old agent.** Kill only its pane (`tmux kill-pane` for tmux, or the harness's exit for others). Keep the same task id and worktree. The new agent is now the crewmate of record for `<id>`.
-
-5. **Note the swap to the captain (FYI) and continue normal supervision.** One outcome line: the task was handed to a fresh agent to keep context healthy; work and diff are intact. Re-arm the watcher as usual.
+4. **Note the swap to the captain (FYI) and continue normal supervision.** One outcome line: the task was handed to a fresh agent to keep context healthy; work and diff are intact. The new agent is now the crewmate of record for `<id>`. Re-arm the watcher as usual.
 
 ## Guardrails
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,7 @@ projects/            cloned repos; gitignored; READ-ONLY for you
 state/               volatile runtime signals; gitignored
   <id>.status        appended by crewmates: "<state>: <note>" wake-event lines, not current-state truth
   <id>.turn-ended    touched by turn-end hooks
+  <id>.context       per-turn context token count for a claude crewmate, written by the fm-ctx-hook.sh Stop hook; not a *.status/*.turn-ended file, so it never wakes firstmate; read by fm-context.sh on a heartbeat for context-handoff (section 8); removed by teardown
   <id>.grok-turnend-token   firstmate-owned grok hook registry token for the task; removed by teardown
   <id>.meta          written by fm-spawn: window=, worktree=, project=, harness=, model=, effort=, kind=, mode=, yolo=, tasktmp=; kind=secondmate also records home= and projects=; a non-default runtime backend records further backend-specific fields (docs/configuration.md "Runtime backend"; bin/fm-backend.sh, section 8); fm-pr-check, including through fm-pr-merge, appends pr= and GitHub's pr_head= when available; fm-x-link appends x_request=, x_request_ts=, and x_followups= for an X-mention-originated task (section 14)
   <id>.check.sh      optional slow poll you write per task (e.g. merged-PR check)
@@ -678,6 +679,7 @@ On wake, in order of cheapness:
 4. `check:` a per-task poll fired (usually a merge, or X mode when enabled); act on it.
 5. `heartbeat:` a heartbeat wake now reaches you only when the watcher's bash fleet-scan caught a captain-relevant status the per-wake path missed (no-change heartbeats are absorbed in bash, never surfaced), so treat it as "something turned up" and review the whole fleet: read each crewmate's current state with `bin/fm-crew-state.sh <id>` (the cheap first read - it reconciles the authoritative run-step over a possibly-stale status-log line, so a crewmate whose gate you already resolved no longer reads as still parked), peek panes that look off, check PR-ready tasks for merge, reconcile data/backlog.md, then re-arm the watcher.
    Do not report that the fleet is unchanged.
+   As part of that fleet review, run `bin/fm-context.sh` to size crewmate context: any task it flags at `>=60%` of its context window is a context-handoff candidate, so load the `context-handoff` skill and swap that crewmate for a fresh agent at its next idle turn-boundary (never mid no-mistakes validation).
 
 When a task reaches a terminal state on any of these wakes (a `done`/merge `check:`, a `failed` signal, a scout report, a local-only merge), and X mode is enabled, load `fmx-respond` (section 13) and post the X-mention's **final** completion follow-up if that task is X-linked: `bin/fm-x-followup.sh --check <id>` then `bin/fm-x-followup.sh <id> --final --text-file <path>`, so the link always clears here regardless of how many of the up-to-three follow-ups were already spent on earlier milestones.
 
@@ -851,6 +853,7 @@ These skills are not captain-invocable; they are conditional operating reference
 
 - `harness-adapters` - load before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter.
 - `stuck-crewmate-recovery` - load after a stale wake, looping pane, repeated confusion, an answered-by-brief question, an unresponsive crewmate, or a failed steer.
+- `context-handoff` - load when `bin/fm-context.sh` flags a crewmate at `>=60%` of its context window on a heartbeat, to swap it for a fresh agent on the same worktree (dump to handoff, `fm-spawn --reuse-worktree`, retire the old agent) instead of a lossy `/compact`.
 - `secondmate-provisioning` - load before creating, seeding, validating, launching, handing backlog to, recovering, pushing inherited config into, or retiring a secondmate home, and before editing `data/secondmates.md`.
 - `fmx-respond` - load on an `x-mention <request_id>` `check:` wake to handle the mention, on an `x-mode-error ...` `check:` wake to report the X-mode configuration blocker, and on any milestone or terminal wake for an X-linked task before posting its completion follow-up; relevant only when X mode is on.
 - `firstmate-coding-guidelines` - load before changing firstmate's shared, tracked material, as defined by section 1's list, whether editing directly or briefing a crewmate for a firstmate-repo task.

--- a/bin/fm-context.sh
+++ b/bin/fm-context.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# fm-context.sh [<id> ...]
+#
+# Read-only monitor of crewmate context size. Prints one line per task:
+#   <id>  <tokens>/<window>  <pct>%  [FLAG >=<threshold>%]
+# and exits non-zero if ANY listed task is at or over the handoff threshold, so a
+# caller can branch on `if ! fm-context.sh; then ...` to trigger context-handoff.
+#
+# Source of truth is state/<id>.context, written every turn by the claude Stop
+# hook (fm-ctx-hook.sh) - harness-truth, not a model self-report. A task with no
+# .context file (non-claude harness, or no turn completed yet) prints "no-data"
+# and is not flagged.
+#
+# With no args, scans every task that has a state/<id>.context file.
+#
+# Env:
+#   FM_CTX_THRESHOLD   handoff threshold percent (default 60)
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+
+THRESHOLD=${FM_CTX_THRESHOLD:-60}
+case "$THRESHOLD" in ''|*[!0-9]*) THRESHOLD=60 ;; esac
+
+# Context window implied by the crewmate's model. Opus/Sonnet (and the "default"
+# placeholder meta writes when no --model was given) are 1M; the small-context
+# models (haiku) are 200k. Keep this list in step with the harness model catalog.
+window_for_model() {
+  case "$1" in
+    *haiku*) echo 200000 ;;
+    *)       echo 1000000 ;;
+  esac
+}
+
+meta_field() {  # <meta-file> <key>
+  grep "^$2=" "$1" 2>/dev/null | head -n1 | cut -d= -f2- || true
+}
+
+ids=("$@")
+if [ "${#ids[@]}" -eq 0 ]; then
+  for c in "$STATE"/*.context; do
+    [ -e "$c" ] || continue
+    b=${c##*/}
+    ids+=("${b%.context}")
+  done
+fi
+
+[ "${#ids[@]}" -gt 0 ] || { echo "no tasks with context data"; exit 0; }
+
+over=0
+for id in "${ids[@]}"; do
+  ctx="$STATE/$id.context"
+  meta="$STATE/$id.meta"
+  if [ ! -f "$ctx" ]; then
+    printf '%s\tno-data\n' "$id"
+    continue
+  fi
+  tokens=$(cat "$ctx" 2>/dev/null || echo 0)
+  case "$tokens" in ''|*[!0-9]*) tokens=0 ;; esac
+  model=$(meta_field "$meta" model)
+  [ -n "$model" ] || model=default
+  window=$(window_for_model "$model")
+  pct=$(( tokens * 100 / window ))
+  flag=""
+  if [ "$pct" -ge "$THRESHOLD" ]; then flag="  FLAG >=${THRESHOLD}%"; over=1; fi
+  printf '%s\t%s/%s\t%s%%%s\n' "$id" "$tokens" "$window" "$pct" "$flag"
+done
+
+[ "$over" -eq 0 ]

--- a/bin/fm-ctx-hook.sh
+++ b/bin/fm-ctx-hook.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# fm-ctx-hook.sh <turnend-file> <context-file>
+#
+# Claude Stop-hook helper installed by fm-spawn.sh. Does two things every turn:
+#   1. touch <turnend-file>  - preserves the existing turn-end signal the watcher
+#      relies on (this REPLACES the bare `touch` the hook used to run).
+#   2. record the crewmate's current context size to <context-file> - harness-truth
+#      from the transcript, NOT a model self-report. Used by fm-context.sh and the
+#      heartbeat fleet review to flag a >=60% context-handoff (see the
+#      context-handoff skill).
+#
+# The Stop hook delivers its payload as JSON on stdin, including .transcript_path.
+# <context-file> is state/<id>.context - deliberately NOT a *.status or
+# *.turn-ended file, so writing it never trips the watcher's signal scan
+# (fm-watch.sh scan_signals globs only *.status and *.turn-ended). Detection is
+# therefore silent: it never wakes firstmate on its own.
+set -u
+
+TURNEND=${1:?turnend path required}
+CTX=${2:?context path required}
+
+# 1. Turn-end signal first, unconditionally - context recording must never be able
+#    to swallow the turn-end the watcher needs.
+touch "$TURNEND" 2>/dev/null || true
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+payload=$(cat)
+tp=$(printf '%s' "$payload" | jq -r '.transcript_path // empty' 2>/dev/null || true)
+[ -n "$tp" ] && [ -f "$tp" ] || exit 0
+
+# Last transcript record carrying usage. tac + head -n1 walks from the end and
+# stops at the first (=newest) match, so a large transcript is never fully
+# slurped. usage lives at .message.usage on assistant records.
+usage=$(tac "$tp" 2>/dev/null \
+  | jq -c 'select(.message.usage != null) | .message.usage' 2>/dev/null \
+  | head -n1)
+[ -n "$usage" ] || exit 0
+
+tokens=$(printf '%s' "$usage" \
+  | jq -r '(.input_tokens // 0) + (.cache_creation_input_tokens // 0) + (.cache_read_input_tokens // 0)' 2>/dev/null || true)
+case "$tokens" in ''|*[!0-9]*) exit 0 ;; esac
+
+# Atomic-ish write so a monitor never reads a half-written value.
+if printf '%s\n' "$tokens" > "$CTX.tmp" 2>/dev/null; then
+  mv -f "$CTX.tmp" "$CTX" 2>/dev/null || true
+fi
+exit 0

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -104,6 +104,7 @@ HARNESS_SET=0
 MODEL_SET=0
 EFFORT_SET=0
 BACKEND_SET=0
+REUSE_WORKTREE=0
 POS=()
 want_value=
 for a in "$@"; do
@@ -124,6 +125,7 @@ for a in "$@"; do
   case "$a" in
     --scout) KIND=scout ;;
     --secondmate) KIND=secondmate ;;
+    --reuse-worktree) REUSE_WORKTREE=1 ;;
     --harness) want_value=harness ;;
     --harness=*) HARNESS_ARG=${a#--harness=}; HARNESS_SET=1 ;;
     --model) want_value=model ;;
@@ -144,6 +146,64 @@ case "$EFFORT" in
   ''|low|medium|high|xhigh|max) ;;
   *) echo "error: --effort must be one of low, medium, high, xhigh, max" >&2; exit 1 ;;
 esac
+
+# --reuse-worktree: relaunch a FRESH agent on the EXISTING worktree/branch recorded
+# in state/<id>.meta, seeded with data/<id>/handoff.md. This is the agent-swap half
+# of the context-handoff skill (AGENTS.md section 8): it keeps the id, worktree,
+# branch, kind, mode, yolo, and project, skips `treehouse get` and the isolated-
+# worktree assertion (the worktree already exists and was proven isolated at first
+# spawn), stands up a NEW backend endpoint, re-installs the turn-end/context hook,
+# rewrites meta window=, and resets state/<id>.context + state/<id>.turn-ended so
+# the fresh agent starts from a clean context signal. It does NOT run treehouse get,
+# does NOT kill the old pane (the skill retires it), and does NOT destroy the
+# worktree (that is teardown). Missing meta, a vanished worktree, or a missing
+# handoff dump abort rather than launching blind. project/harness/model/effort/
+# backend are recovered from meta unless the caller overrode them on this spawn.
+REUSE_WT=
+REUSE_PROJECT=
+REUSE_MODE=
+REUSE_YOLO=
+REUSE_HANDOFF=
+if [ "$REUSE_WORKTREE" -eq 1 ]; then
+  [ "$KIND" != secondmate ] || { echo "error: --reuse-worktree cannot be combined with --secondmate" >&2; exit 1; }
+  RID=${POS[0]:-}
+  [ -n "$RID" ] || { echo "error: --reuse-worktree requires a task id" >&2; exit 1; }
+  [ "${#POS[@]}" -eq 1 ] || { echo "error: --reuse-worktree takes only <id>; project/harness come from state/$RID.meta" >&2; exit 1; }
+  R_META="$STATE/$RID.meta"
+  [ -f "$R_META" ] || { echo "error: --reuse-worktree: no meta for $RID at $R_META" >&2; exit 1; }
+  reuse_meta_field() { grep "^$1=" "$R_META" 2>/dev/null | head -n1 | cut -d= -f2- || true; }
+  R_KIND=$(reuse_meta_field kind)
+  case "$R_KIND" in
+    secondmate) echo "error: --reuse-worktree: $RID is a secondmate; not supported" >&2; exit 1 ;;
+    ship|scout) KIND=$R_KIND ;;
+  esac
+  REUSE_WT=$(reuse_meta_field worktree)
+  [ -n "$REUSE_WT" ] || { echo "error: --reuse-worktree: state/$RID.meta has no worktree=" >&2; exit 1; }
+  [ -d "$REUSE_WT" ] || { echo "error: --reuse-worktree: recorded worktree is gone: $REUSE_WT" >&2; exit 1; }
+  REUSE_PROJECT=$(reuse_meta_field project)
+  [ -n "$REUSE_PROJECT" ] || { echo "error: --reuse-worktree: state/$RID.meta has no project=" >&2; exit 1; }
+  REUSE_HANDOFF="$DATA/$RID/handoff.md"
+  [ -f "$REUSE_HANDOFF" ] || { echo "error: --reuse-worktree: no handoff dump at $REUSE_HANDOFF (steer the old agent to write it first)" >&2; exit 1; }
+  [ -s "$REUSE_HANDOFF" ] || { echo "error: --reuse-worktree: handoff dump is empty: $REUSE_HANDOFF" >&2; exit 1; }
+  REUSE_MODE=$(reuse_meta_field mode)
+  REUSE_YOLO=$(reuse_meta_field yolo)
+  if [ "$HARNESS_SET" -eq 0 ]; then
+    R_HARNESS=$(reuse_meta_field harness)
+    [ -n "$R_HARNESS" ] && { HARNESS_ARG=$R_HARNESS; HARNESS_SET=1; }
+  fi
+  if [ "$MODEL_SET" -eq 0 ]; then
+    R_MODEL=$(reuse_meta_field model)
+    [ -n "$R_MODEL" ] && [ "$R_MODEL" != default ] && MODEL=$R_MODEL
+  fi
+  if [ "$EFFORT_SET" -eq 0 ]; then
+    R_EFFORT=$(reuse_meta_field effort)
+    case "$R_EFFORT" in low|medium|high|xhigh|max) EFFORT=$R_EFFORT ;; esac
+  fi
+  if [ "$BACKEND_SET" -eq 0 ]; then
+    R_BACKEND=$(reuse_meta_field backend)
+    [ -n "$R_BACKEND" ] && { BACKEND_ARG=$R_BACKEND; BACKEND_SET=1; }
+  fi
+fi
 
 # Backend selection (data/fm-backend-design-d7): explicit --backend, else
 # FM_BACKEND env, else config/backend, else runtime auto-detection, else
@@ -283,6 +343,11 @@ if [ "$KIND" = secondmate ]; then
       ARG3=${POS[2]:-}
       ;;
   esac
+elif [ "$REUSE_WORKTREE" -eq 1 ]; then
+  # A reuse spawn carries no positional project (validated to a single <id> arg
+  # above); project and harness come from meta, not POS[1].
+  PROJ=$REUSE_PROJECT
+  ARG3=${POS[2]:-}
 else
   PROJ=${POS[1]}
   ARG3=${POS[2]:-}
@@ -620,6 +685,24 @@ if [ "$KIND" = secondmate ]; then
   else
     BRIEF="$DATA/$ID/brief.md"
   fi
+elif [ "$REUSE_WORKTREE" -eq 1 ]; then
+  PROJ_ABS="$(cd "$(resolve_project_dir_arg "$PROJ")" && pwd)"
+  WT="$REUSE_WT"
+  # Compose the fresh agent's launch brief: the original task brief + the previous
+  # agent's handoff dump + a "resume from here" preamble. Written OUTSIDE the
+  # worktree (state/), so it never dirties the branch; teardown removes it.
+  ORIG_BRIEF="$DATA/$ID/brief.md"
+  [ -f "$ORIG_BRIEF" ] || { echo "error: --reuse-worktree: no original brief at $ORIG_BRIEF" >&2; exit 1; }
+  mkdir -p "$STATE"
+  BRIEF="$STATE/$ID.reuse-brief.md"
+  {
+    cat "$ORIG_BRIEF"
+    printf '\n\n---\n\n# Context handoff - resume from here\n\n'
+    printf 'You are a FRESH agent taking over task %s on the SAME worktree and branch as the previous agent, which hit its context limit.\n' "$ID"
+    printf 'The worktree and its in-progress diff are intact: do NOT re-clone, reset, or recreate the branch. Read the handoff dump below, reconcile it against the live working tree with git status and git diff, then continue the task from where it left off. The original brief above is still the source of truth for the definition of done.\n\n'
+    printf -- '---\n\n# Handoff dump (data/%s/handoff.md), written by the previous agent\n\n' "$ID"
+    cat "$REUSE_HANDOFF"
+  } > "$BRIEF"
 else
   PROJ_ABS="$(cd "$(resolve_project_dir_arg "$PROJ")" && pwd)"
   WT=""
@@ -657,11 +740,22 @@ validate_spawn_worktree() {  # <source> <inspect-target>
 }
 
 W="fm-$ID"
+# --reuse-worktree reuses an existing worktree, so it is incompatible with orca,
+# whose backend owns the worktree lifecycle (it creates a fresh one per spawn).
+if [ "$REUSE_WORKTREE" -eq 1 ] && [ "$BACKEND" = orca ]; then
+  echo "error: --reuse-worktree is not supported on the orca backend (Orca owns worktree lifecycle)" >&2
+  exit 1
+fi
+# Task-pane start directory. Normally the project checkout, then `treehouse get`
+# moves the pane into the worktree. A reuse spawn skips treehouse get, so the pane
+# must open directly in the existing worktree, WT.
+PANE_DIR="$PROJ_ABS"
+[ "$REUSE_WORKTREE" -eq 1 ] && PANE_DIR="$WT"
 case "$BACKEND" in
   tmux)
     SES=$(fm_backend_tmux_container_ensure)
     T="$SES:$W"
-    fm_backend_tmux_create_task "$SES" "$W" "$PROJ_ABS" || exit 1
+    fm_backend_tmux_create_task "$SES" "$W" "$PANE_DIR" || exit 1
     ;;
   herdr)
     # fm_backend_herdr_workspace_label resolves the target workspace from
@@ -690,7 +784,7 @@ case "$BACKEND" in
     HERDR_SEEDED_DEFAULT_TAB_ID=${HERDR_CONTAINER_RAW#*$'\t'}
     HERDR_SES=${CONTAINER%%:*}
     HERDR_WORKSPACE_ID=${CONTAINER#*:}
-    HERDR_TASK_IDS=$(FM_HOME="$HERDR_LABEL_HOME" fm_backend_herdr_create_task "$CONTAINER" "$W" "$PROJ_ABS" "$HERDR_SEEDED_DEFAULT_TAB_ID") || exit 1
+    HERDR_TASK_IDS=$(FM_HOME="$HERDR_LABEL_HOME" fm_backend_herdr_create_task "$CONTAINER" "$W" "$PANE_DIR" "$HERDR_SEEDED_DEFAULT_TAB_ID") || exit 1
     read -r HERDR_TAB_ID HERDR_PANE_ID <<EOF
 $HERDR_TASK_IDS
 EOF
@@ -702,7 +796,7 @@ EOF
     ;;
   zellij)
     ZELLIJ_SES=$(fm_backend_zellij_container_ensure) || exit 1
-    ZELLIJ_TASK_IDS=$(fm_backend_zellij_create_task "$ZELLIJ_SES" "$W" "$PROJ_ABS") || exit 1
+    ZELLIJ_TASK_IDS=$(fm_backend_zellij_create_task "$ZELLIJ_SES" "$W" "$PANE_DIR") || exit 1
     read -r ZELLIJ_TAB_ID ZELLIJ_PANE_ID <<EOF
 $ZELLIJ_TASK_IDS
 EOF
@@ -714,7 +808,7 @@ EOF
     ;;
   cmux)
     fm_backend_cmux_container_ensure || exit 1
-    CMUX_TASK_IDS=$(fm_backend_cmux_create_task "$W" "$PROJ_ABS") || exit 1
+    CMUX_TASK_IDS=$(fm_backend_cmux_create_task "$W" "$PANE_DIR") || exit 1
     read -r CMUX_WORKSPACE_ID CMUX_SURFACE_ID <<EOF
 $CMUX_TASK_IDS
 EOF
@@ -785,7 +879,7 @@ spawn_send_key() {  # <target> <key>
     cmux) fm_backend_cmux_send_key "$1" "$2" "$W" ;;
   esac
 }
-if [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
+if [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ] && [ "$REUSE_WORKTREE" -ne 1 ]; then
   spawn_send_text_line "$T" 'treehouse get'
 
   # Wait for the treehouse subshell: the pane's cwd moves from the project to the worktree.
@@ -830,9 +924,15 @@ if [ "$KIND" != secondmate ]; then
   case "$HARNESS" in
     claude*)
       mkdir -p "$WT/.claude"
-      cat > "$WT/.claude/settings.local.json" <<EOF
-{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"touch '$TURNEND'"}]}]}}
-EOF
+      CTXFILE="$STATE_REAL/$ID.context"
+      # The Stop hook runs fm-ctx-hook.sh, which touches $TURNEND (the unchanged
+      # turn-end signal the watcher relies on) AND records the crewmate's context
+      # tokens to state/<id>.context. state/<id>.context is deliberately not a
+      # *.status/*.turn-ended file, so writing it never trips the watcher's signal
+      # scan; the context-handoff skill reads it on a heartbeat. json_escape +
+      # shell_quote are the same helpers the grok hook install below uses.
+      hook_cmd=$(json_escape "bash $(shell_quote "$FM_ROOT/bin/fm-ctx-hook.sh") $(shell_quote "$TURNEND") $(shell_quote "$CTXFILE")")
+      printf '{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"%s"}]}]}}\n' "$hook_cmd" > "$WT/.claude/settings.local.json"
       exclude_path '.claude/settings.local.json'
       ;;
     opencode*)
@@ -925,6 +1025,19 @@ if [ "$KIND" = secondmate ]; then
   MODE=secondmate
   YOLO=off
   SECONDMATE_PROJECTS=$(secondmate_registry_value "$ID" projects || true)
+elif [ "$REUSE_WORKTREE" -eq 1 ]; then
+  # A reuse spawn keeps the original task's delivery mode and yolo posture verbatim
+  # from meta; the swap changes the agent, not the task's landing contract.
+  MODE=$REUSE_MODE
+  YOLO=$REUSE_YOLO
+  PROJ_NAME=$(basename "$PROJ_ABS")
+  if [ -z "$MODE" ] || [ -z "$YOLO" ]; then
+    read -r RM RY <<EOF
+$("$FM_ROOT/bin/fm-project-mode.sh" "$PROJ_NAME")
+EOF
+    [ -n "$MODE" ] || MODE=$RM
+    [ -n "$YOLO" ] || YOLO=$RY
+  fi
 else
   PROJ_NAME=$(basename "$PROJ_ABS")
   read -r MODE YOLO <<EOF
@@ -974,6 +1087,13 @@ META_WINDOW=$T
   fi
 } > "$STATE/$ID.meta"
 [ "$BACKEND" = orca ] && ORCA_ABORT_CLEANUP=0
+
+# A reuse spawn hands the worktree to a FRESH agent, so clear the previous agent's
+# context signal and its last turn-end marker; the new agent's Stop hook rewrites
+# both from a clean slate on its first turn.
+if [ "$REUSE_WORKTREE" -eq 1 ]; then
+  rm -f "$STATE_REAL/$ID.context" "$TURNEND"
+fi
 
 sq_brief=$(shell_quote "$BRIEF")
 sq_turnend=$(shell_quote "$TURNEND")

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -164,6 +164,9 @@ REUSE_PROJECT=
 REUSE_MODE=
 REUSE_YOLO=
 REUSE_HANDOFF=
+REUSE_OLD_WINDOW=
+REUSE_OLD_BACKEND=
+REUSE_OLD_ZELLIJ_TAB=
 if [ "$REUSE_WORKTREE" -eq 1 ]; then
   [ "$KIND" != secondmate ] || { echo "error: --reuse-worktree cannot be combined with --secondmate" >&2; exit 1; }
   RID=${POS[0]:-}
@@ -187,6 +190,12 @@ if [ "$REUSE_WORKTREE" -eq 1 ]; then
   [ -s "$REUSE_HANDOFF" ] || { echo "error: --reuse-worktree: handoff dump is empty: $REUSE_HANDOFF" >&2; exit 1; }
   REUSE_MODE=$(reuse_meta_field mode)
   REUSE_YOLO=$(reuse_meta_field yolo)
+  # The previous agent's endpoint, so it can be retired before the new one is
+  # created (they share the fm-<id> window name; see the kill step below).
+  REUSE_OLD_WINDOW=$(reuse_meta_field window)
+  REUSE_OLD_ZELLIJ_TAB=$(reuse_meta_field zellij_tab_id)
+  REUSE_OLD_BACKEND=$(reuse_meta_field backend)
+  [ -n "$REUSE_OLD_BACKEND" ] || REUSE_OLD_BACKEND=tmux
   if [ "$HARNESS_SET" -eq 0 ]; then
     R_HARNESS=$(reuse_meta_field harness)
     [ -n "$R_HARNESS" ] && { HARNESS_ARG=$R_HARNESS; HARNESS_SET=1; }
@@ -751,6 +760,16 @@ fi
 # must open directly in the existing worktree, WT.
 PANE_DIR="$PROJ_ABS"
 [ "$REUSE_WORKTREE" -eq 1 ] && PANE_DIR="$WT"
+# A reuse spawn retires the previous agent's endpoint BEFORE creating the new one:
+# the new endpoint reuses the same task window name (fm-<id>), and backends such as
+# tmux refuse a duplicate window name, so the swap must free it first. Best-effort -
+# an already-gone or crashed endpoint just no-ops - and the worktree is untouched
+# (killing a window is not fm-teardown). This is why the context-handoff skill does
+# not retire the old pane separately.
+if [ "$REUSE_WORKTREE" -eq 1 ] && [ -n "$REUSE_OLD_WINDOW" ]; then
+  fm_backend_kill "$REUSE_OLD_BACKEND" "$REUSE_OLD_WINDOW" "$REUSE_OLD_ZELLIJ_TAB" "$W" 2>/dev/null || true
+  sleep 0.5
+fi
 case "$BACKEND" in
   tmux)
     SES=$(fm_backend_tmux_container_ensure)

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -654,7 +654,7 @@ cleanup_firstmate_home_children() {
       fi
     fi
     remove_grok_turnend_auth "$sub_state" "$child_id"
-    rm -f "$sub_state/$child_id.status" "$sub_state/$child_id.turn-ended" "$sub_state/$child_id.check.sh" "$sub_state/$child_id.meta" "$sub_state/$child_id.pi-ext.ts" "$sub_state/$child_id.grok-turnend-token"
+    rm -f "$sub_state/$child_id.status" "$sub_state/$child_id.turn-ended" "$sub_state/$child_id.context" "$sub_state/$child_id.check.sh" "$sub_state/$child_id.meta" "$sub_state/$child_id.pi-ext.ts" "$sub_state/$child_id.grok-turnend-token" "$sub_state/$child_id.reuse-brief.md"
   done
 }
 
@@ -809,7 +809,7 @@ remove_grok_turnend_auth "$STATE" "$ID"
 # Remove the per-task temp root (/tmp/fm-<id>/, incl. its gotmp/) recorded by spawn.
 # Read before the state-file rm below; empty (pre-fix tasks without tasktmp=) is a no-op.
 [ -n "$TASK_TMP" ] && rm -rf "$TASK_TMP"
-rm -f "$STATE/$ID.status" "$STATE/$ID.turn-ended" "$STATE/$ID.check.sh" "$STATE/$ID.meta" "$STATE/$ID.pi-ext.ts" "$STATE/$ID.grok-turnend-token"
+rm -f "$STATE/$ID.status" "$STATE/$ID.turn-ended" "$STATE/$ID.context" "$STATE/$ID.check.sh" "$STATE/$ID.meta" "$STATE/$ID.pi-ext.ts" "$STATE/$ID.grok-turnend-token" "$STATE/$ID.reuse-brief.md"
 if [ "$KIND" != scout ] && [ "$KIND" != secondmate ] && [ "$MODE" != local-only ]; then
   "$FM_ROOT/bin/fm-fleet-sync.sh" "$PROJ" || true
 fi

--- a/tests/fm-context.test.sh
+++ b/tests/fm-context.test.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Behavior tests for bin/fm-context.sh - the read-only crewmate context monitor.
+# It reads state/<id>.context (written by the claude Stop hook), divides by the
+# window implied by the task's meta model= (1M default, 200k for haiku), prints one
+# line per task, and exits non-zero if ANY listed task is at/over the handoff
+# threshold (default 60%, override FM_CTX_THRESHOLD) so a heartbeat can branch on it.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+CTX="$ROOT/bin/fm-context.sh"
+TMP=$(fm_test_tmproot fm-context)
+STATE="$TMP/state"
+mkdir -p "$STATE"
+
+# seed <id> <tokens> <model>: write a task's .context + .meta pair.
+seed() {
+  local id=$1 tokens=$2 model=${3:-default}
+  printf '%s\n' "$tokens" > "$STATE/$id.context"
+  fm_write_meta "$STATE/$id.meta" \
+    "window=firstmate:fm-$id" "worktree=/tmp/$id" "project=/tmp/$id" \
+    "harness=claude" "kind=ship" "mode=no-mistakes" "yolo=off" \
+    "model=$model" "effort=default"
+}
+
+run() {  # <args...> -> sets OUT and RC
+  OUT=$(FM_STATE_OVERRIDE="$STATE" "$CTX" "$@"); RC=$?
+  return 0
+}
+
+# --- below threshold: exit 0, no FLAG ---------------------------------------
+seed below 500000 default          # 50% of 1M
+run below
+expect_code 0 "$RC" "below-threshold task exits 0"
+assert_contains "$OUT" "500000/1000000" "prints tokens/window"
+assert_not_contains "$OUT" "FLAG" "below threshold is not flagged"
+pass "below threshold (50%): exit 0, no FLAG"
+
+# --- at/over threshold: exit 1, FLAG ----------------------------------------
+seed over 700000 default           # 70% of 1M
+run over
+expect_code 1 "$RC" "over-threshold task exits 1"
+assert_contains "$OUT" "FLAG >=60%" "over threshold is flagged"
+pass "over threshold (70%): exit 1, FLAG"
+
+# --- exactly at threshold is flagged (>= not >) -----------------------------
+seed exact 600000 default          # 60% of 1M
+run exact
+expect_code 1 "$RC" "exactly-at-threshold task exits 1"
+assert_contains "$OUT" "FLAG >=60%" "exactly at threshold is flagged (>=)"
+pass "exactly at threshold (60%): flagged"
+
+# --- haiku uses the 200k window ---------------------------------------------
+seed hk 130000 claude-haiku-4-5    # 65% of 200k
+run hk
+expect_code 1 "$RC" "haiku task over 200k window exits 1"
+assert_contains "$OUT" "130000/200000" "haiku window is 200k"
+assert_contains "$OUT" "FLAG" "haiku 65% is flagged"
+pass "haiku model: 200k window, 65% flagged"
+
+# --- custom threshold via FM_CTX_THRESHOLD ----------------------------------
+OUT=$(FM_STATE_OVERRIDE="$STATE" FM_CTX_THRESHOLD=40 "$CTX" below); RC=$?
+expect_code 1 "$RC" "50% task exits 1 under a 40% threshold"
+assert_contains "$OUT" "FLAG >=40%" "custom threshold shown in FLAG"
+pass "FM_CTX_THRESHOLD=40: a 50% task now flags"
+
+# --- a task with no .context is no-data and not flagged ----------------------
+fm_write_meta "$STATE/nod.meta" \
+  "window=firstmate:fm-nod" "worktree=/tmp/nod" "project=/tmp/nod" \
+  "harness=codex" "kind=ship" "mode=no-mistakes" "yolo=off" \
+  "model=default" "effort=default"
+OUT=$(FM_STATE_OVERRIDE="$STATE" "$CTX" nod); RC=$?
+expect_code 0 "$RC" "no-data task does not force a non-zero exit"
+assert_contains "$OUT" "no-data" "missing .context reports no-data"
+pass "no .context file: no-data, not flagged"
+
+# --- scan-all mode: exits 1 because at least one flagged task exists ----------
+OUT=$(FM_STATE_OVERRIDE="$STATE" "$CTX"); RC=$?
+expect_code 1 "$RC" "scan-all exits 1 when any task is flagged"
+assert_contains "$OUT" "below" "scan-all includes the below task"
+assert_contains "$OUT" "over" "scan-all includes the over task"
+pass "scan-all (no args): reports every context task, exits 1 on any flag"
+
+pass "fm-context: all cases"

--- a/tests/fm-ctx-hook.test.sh
+++ b/tests/fm-ctx-hook.test.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Behavior tests for bin/fm-ctx-hook.sh - the claude Stop-hook helper installed by
+# fm-spawn.sh. Every turn it must do two independent things:
+#   1. touch <turnend-file>  - the unchanged turn-end signal the watcher relies on;
+#      this must happen even when context recording cannot (no jq, no transcript).
+#   2. record the crewmate's context tokens to <context-file>, summed from the
+#      transcript's LAST usage record as
+#      input_tokens + cache_creation_input_tokens + cache_read_input_tokens.
+# The Stop payload arrives as JSON on stdin carrying .transcript_path.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+HOOK="$ROOT/bin/fm-ctx-hook.sh"
+TMP=$(fm_test_tmproot fm-ctx-hook)
+mkdir -p "$TMP"
+
+# fire <transcript-path-or-empty> -> sets TE/CTX to fresh paths and runs the hook
+# with a synthetic Stop payload naming the transcript.
+fire() {
+  local tp=$1 payload
+  TE="$TMP/turnend.$RANDOM"
+  CTX="$TMP/context.$RANDOM"
+  if [ -n "$tp" ]; then
+    payload=$(printf '{"transcript_path":"%s"}' "$tp")
+  else
+    payload='{}'
+  fi
+  printf '%s' "$payload" | bash "$HOOK" "$TE" "$CTX"
+}
+
+# --- last usage record wins, formula sums the three input axes ----------------
+tr1="$TMP/tr1.jsonl"
+cat > "$tr1" <<'EOF'
+{"type":"assistant","message":{"usage":{"input_tokens":100,"cache_creation_input_tokens":200,"cache_read_input_tokens":300,"output_tokens":50}}}
+{"type":"user","message":{"role":"user","content":"hi"}}
+{"type":"assistant","message":{"usage":{"input_tokens":1000,"cache_creation_input_tokens":2000,"cache_read_input_tokens":30000,"output_tokens":77}}}
+EOF
+fire "$tr1"
+assert_present "$TE" "turn-end file touched on a normal fire"
+[ "$(cat "$CTX")" = 33000 ] || fail "context = last-record sum: got $(cat "$CTX"), want 33000"
+pass "records last usage record's summed context (1000+2000+30000)"
+
+# --- output_tokens is NOT counted (context = input side only) -----------------
+tr2="$TMP/tr2.jsonl"
+cat > "$tr2" <<'EOF'
+{"type":"assistant","message":{"usage":{"input_tokens":5,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":999999}}}
+EOF
+fire "$tr2"
+[ "$(cat "$CTX")" = 5 ] || fail "output_tokens must be excluded: got $(cat "$CTX"), want 5"
+pass "excludes output_tokens from the context total"
+
+# --- missing cache fields default to 0 ---------------------------------------
+tr3="$TMP/tr3.jsonl"
+cat > "$tr3" <<'EOF'
+{"type":"assistant","message":{"usage":{"input_tokens":42}}}
+EOF
+fire "$tr3"
+[ "$(cat "$CTX")" = 42 ] || fail "absent cache fields default to 0: got $(cat "$CTX"), want 42"
+pass "treats absent cache_* fields as 0"
+
+# --- no transcript_path: turn-end still fires, no context written ------------
+fire ""
+assert_present "$TE" "turn-end file touched even with no transcript_path"
+assert_absent "$CTX" "no context file written when payload lacks transcript_path"
+pass "no transcript_path: turn-end fires, context is not written"
+
+# --- transcript_path points at a missing file -------------------------------
+fire "$TMP/does-not-exist.jsonl"
+assert_present "$TE" "turn-end file touched even when transcript file is missing"
+assert_absent "$CTX" "no context file written when transcript file is missing"
+pass "missing transcript file: turn-end fires, context is not written"
+
+# --- transcript with no usage records at all --------------------------------
+tr4="$TMP/tr4.jsonl"
+cat > "$tr4" <<'EOF'
+{"type":"user","message":{"role":"user","content":"hi"}}
+{"type":"summary","summary":"nothing"}
+EOF
+fire "$tr4"
+assert_present "$TE" "turn-end file touched even when transcript has no usage"
+assert_absent "$CTX" "no context file written when transcript has no usage record"
+pass "transcript with no usage record: turn-end fires, context is not written"
+
+pass "fm-ctx-hook: all cases"

--- a/tests/fm-spawn-reuse-worktree.test.sh
+++ b/tests/fm-spawn-reuse-worktree.test.sh
@@ -70,6 +70,7 @@ case "$1" in
   has-session) exit 1 ;;
   new-session) exit 0 ;;
   list-windows) exit 0 ;;
+  kill-window) echo "kill-window $*" >> "$STUB_TMUX_LOG"; exit 0 ;;
   new-window) echo "new-window $*" >> "$STUB_TMUX_LOG"; exit 0 ;;
   send-keys) echo "send-keys $*" >> "$STUB_SEND_LOG"; exit 0 ;;
   display-message) echo "firstmate" ;;
@@ -157,6 +158,17 @@ assert_contains "$OUT" "spawned $ID" "prints the spawned line"
 # treehouse get is NEVER used
 assert_absent "$STUB_TREEHOUSE_LOG" "treehouse binary is never invoked on reuse"
 assert_no_grep "treehouse get" "$STUB_SEND_LOG" "'treehouse get' is never sent to the pane"
+
+# the old endpoint is retired BEFORE the new one is created: the fresh endpoint
+# reuses the same fm-<id> window name, which tmux refuses to duplicate, so the swap
+# must free it first (regression for the code-review finding on step ordering).
+assert_grep "kill-window" "$STUB_TMUX_LOG" "old endpoint is retired via kill-window"
+assert_grep "firstmate:fm-$ID" "$STUB_TMUX_LOG" "kill-window targets the previous fm-<id> window"
+kill_ln=$(grep -n 'kill-window' "$STUB_TMUX_LOG" | head -1 | cut -d: -f1)
+new_ln=$(grep -n 'new-window' "$STUB_TMUX_LOG" | head -1 | cut -d: -f1)
+if [ -z "$kill_ln" ] || [ -z "$new_ln" ] || [ "$kill_ln" -ge "$new_ln" ]; then
+  fail "kill-window (line ${kill_ln:-none}) must precede new-window (line ${new_ln:-none})"
+fi
 
 # the new pane opens directly in the existing worktree (no treehouse get to move it)
 assert_grep "$WT" "$STUB_TMUX_LOG" "new-window opens in the existing worktree"

--- a/tests/fm-spawn-reuse-worktree.test.sh
+++ b/tests/fm-spawn-reuse-worktree.test.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# Behavior tests for `fm-spawn.sh --reuse-worktree <id>` - the agent-swap half of
+# the context-handoff feature. It relaunches a FRESH agent on the EXISTING
+# worktree/branch recorded in state/<id>.meta, seeded with data/<id>/handoff.md,
+# WITHOUT running treehouse get and WITHOUT destroying the worktree.
+#
+# The happy path runs the real fm-spawn.sh over a throwaway home with a stubbed
+# tmux (records what would be sent to the pane) and a `treehouse` stub that screams
+# if ever called, so the "never runs treehouse get" guarantee is proven, not
+# assumed. No real tmux/treehouse/harness is launched.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SPAWN="$ROOT/bin/fm-spawn.sh"
+TMP=$(fm_test_tmproot fm-spawn-reuse)
+fm_git_identity fmtest fmtest@example.invalid
+
+HOME_DIR="$TMP/home"
+STATE="$HOME_DIR/state"
+DATA="$HOME_DIR/data"
+PROJ="$TMP/proj"
+WT="$TMP/wt"
+ID=reuse-demo-k9
+mkdir -p "$TMP" "$STATE" "$DATA"
+# WT is a real LINKED worktree of PROJ on the task branch, exactly like a live
+# crewmate worktree: fm-spawn's exclude_path relies on git returning an absolute
+# git-path, which only holds for a linked worktree (not a standalone repo).
+fm_git_init_commit "$PROJ"
+git -C "$PROJ" worktree add --quiet -b "fm/$ID" "$WT"
+
+# Fresh, valid meta + brief + handoff for the happy-path and most error cases.
+write_meta() {  # [worktree-override] [kind-override]
+  local wt=${1:-$WT} kind=${2:-ship}
+  fm_write_meta "$STATE/$ID.meta" \
+    "window=firstmate:fm-$ID" \
+    "worktree=$wt" \
+    "project=$PROJ" \
+    "harness=claude" \
+    "kind=$kind" \
+    "mode=no-mistakes" \
+    "yolo=off" \
+    "tasktmp=/tmp/fm-$ID" \
+    "model=default" \
+    "effort=default"
+}
+mkdir -p "$DATA/$ID"
+printf '# Original brief\nShip the feature.\n' > "$DATA/$ID/brief.md"
+
+run_reuse() {  # <extra-args...> -> sets OUT/RC; runs with the temp home + PATH stubs
+  OUT=$(cd "$ROOT" && FM_SPAWN_NO_GUARD=1 \
+    FM_HOME="$HOME_DIR" FM_STATE_OVERRIDE="$STATE" FM_DATA_OVERRIDE="$DATA" FM_PROJECTS_OVERRIDE="$PROJ" \
+    PATH="$STUBBIN:$PATH" \
+    "$SPAWN" "$ID" --reuse-worktree "$@" 2>&1); RC=$?
+  return 0
+}
+
+# --- PATH stubs: a screaming treehouse + a scriptable tmux -------------------
+STUBBIN="$TMP/stubbin"
+mkdir -p "$STUBBIN"
+cat > "$STUBBIN/treehouse" <<'SH'
+#!/usr/bin/env bash
+echo "TREEHOUSE-CALLED: $*" >> "$STUB_TREEHOUSE_LOG"
+exit 0
+SH
+cat > "$STUBBIN/tmux" <<'SH'
+#!/usr/bin/env bash
+case "$1" in
+  has-session) exit 1 ;;
+  new-session) exit 0 ;;
+  list-windows) exit 0 ;;
+  new-window) echo "new-window $*" >> "$STUB_TMUX_LOG"; exit 0 ;;
+  send-keys) echo "send-keys $*" >> "$STUB_SEND_LOG"; exit 0 ;;
+  display-message) echo "firstmate" ;;
+  *) : ;;
+esac
+exit 0
+SH
+chmod +x "$STUBBIN/treehouse" "$STUBBIN/tmux"
+export STUB_TMUX_LOG="$TMP/tmux.log" STUB_SEND_LOG="$TMP/send.log" STUB_TREEHOUSE_LOG="$TMP/treehouse.log"
+export TMUX=  # force the dedicated-session container path in the stub
+unset TMUX
+
+# ============================ error paths ===================================
+
+# no meta
+rm -f "$STATE/$ID.meta"
+run_reuse
+expect_code 1 "$RC" "missing meta aborts"
+assert_contains "$OUT" "no meta for $ID" "missing-meta error names the id"
+pass "error: missing meta"
+
+# recorded worktree gone
+write_meta "$TMP/gone-wt"
+printf 'dump\n' > "$DATA/$ID/handoff.md"
+run_reuse
+expect_code 1 "$RC" "vanished worktree aborts"
+assert_contains "$OUT" "worktree is gone" "vanished-worktree error is explicit"
+pass "error: recorded worktree gone"
+
+# no handoff dump
+write_meta
+rm -f "$DATA/$ID/handoff.md"
+run_reuse
+expect_code 1 "$RC" "missing handoff dump aborts"
+assert_contains "$OUT" "no handoff dump" "missing-handoff error is explicit"
+pass "error: missing handoff dump"
+
+# empty handoff dump
+: > "$DATA/$ID/handoff.md"
+run_reuse
+expect_code 1 "$RC" "empty handoff dump aborts"
+assert_contains "$OUT" "handoff dump is empty" "empty-handoff error is explicit"
+pass "error: empty handoff dump"
+
+# extra positional
+printf 'dump\n' > "$DATA/$ID/handoff.md"
+run_reuse projects/proj
+expect_code 1 "$RC" "extra positional aborts"
+assert_contains "$OUT" "takes only <id>" "extra-positional error is explicit"
+pass "error: extra positional rejected"
+
+# secondmate meta
+write_meta "$WT" secondmate
+run_reuse
+expect_code 1 "$RC" "secondmate task rejected"
+assert_contains "$OUT" "is a secondmate" "secondmate reuse is refused"
+pass "error: secondmate meta rejected"
+
+# --secondmate combined with --reuse-worktree
+write_meta
+run_reuse_secondmate() {
+  OUT=$(cd "$ROOT" && FM_SPAWN_NO_GUARD=1 \
+    FM_HOME="$HOME_DIR" FM_STATE_OVERRIDE="$STATE" FM_DATA_OVERRIDE="$DATA" FM_PROJECTS_OVERRIDE="$PROJ" \
+    PATH="$STUBBIN:$PATH" \
+    "$SPAWN" "$ID" --reuse-worktree --secondmate 2>&1); RC=$?
+}
+run_reuse_secondmate
+expect_code 1 "$RC" "--reuse-worktree + --secondmate rejected"
+assert_contains "$OUT" "cannot be combined with --secondmate" "combo refused"
+pass "error: --reuse-worktree + --secondmate refused"
+
+# ============================ happy path ====================================
+write_meta
+printf 'HANDOFF: decisions D, files F, remaining R\n' > "$DATA/$ID/handoff.md"
+# seed stale signals so we can prove they are reset for the fresh agent
+printf '999999\n' > "$STATE/$ID.context"
+touch "$STATE/$ID.turn-ended"
+: > "$STUB_TMUX_LOG"; : > "$STUB_SEND_LOG"; rm -f "$STUB_TREEHOUSE_LOG"
+rm -f "$WT/.claude/settings.local.json" "$STATE/$ID.reuse-brief.md"
+
+run_reuse
+expect_code 0 "$RC" "happy-path reuse succeeds"
+assert_contains "$OUT" "spawned $ID" "prints the spawned line"
+
+# treehouse get is NEVER used
+assert_absent "$STUB_TREEHOUSE_LOG" "treehouse binary is never invoked on reuse"
+assert_no_grep "treehouse get" "$STUB_SEND_LOG" "'treehouse get' is never sent to the pane"
+
+# the new pane opens directly in the existing worktree (no treehouse get to move it)
+assert_grep "$WT" "$STUB_TMUX_LOG" "new-window opens in the existing worktree"
+
+# the launch is seeded with the composed reuse-brief, not the bare original
+assert_grep "$ID.reuse-brief.md" "$STUB_SEND_LOG" "launch reads the composed reuse-brief"
+assert_present "$STATE/$ID.reuse-brief.md" "composed reuse-brief is written"
+assert_grep "Original brief" "$STATE/$ID.reuse-brief.md" "reuse-brief carries the original brief"
+assert_grep "resume from here" "$STATE/$ID.reuse-brief.md" "reuse-brief has the resume preamble"
+assert_grep "HANDOFF: decisions D" "$STATE/$ID.reuse-brief.md" "reuse-brief carries the handoff dump"
+
+# stale context + turn-ended are reset for the fresh agent
+assert_absent "$STATE/$ID.context" "previous context signal is cleared"
+assert_absent "$STATE/$ID.turn-ended" "previous turn-end marker is cleared"
+
+# meta keeps worktree/project/kind/mode/yolo; window is rewritten
+assert_grep "worktree=$WT" "$STATE/$ID.meta" "meta keeps the worktree"
+assert_grep "project=$PROJ" "$STATE/$ID.meta" "meta keeps the project"
+assert_grep "kind=ship" "$STATE/$ID.meta" "meta keeps the kind"
+assert_grep "mode=no-mistakes" "$STATE/$ID.meta" "meta keeps the delivery mode"
+assert_grep "yolo=off" "$STATE/$ID.meta" "meta keeps the yolo posture"
+
+# the claude Stop hook is wired to fm-ctx-hook.sh (turn-end + context recording)
+assert_present "$WT/.claude/settings.local.json" "claude Stop hook is re-installed"
+assert_grep "fm-ctx-hook.sh" "$WT/.claude/settings.local.json" "Stop hook runs fm-ctx-hook.sh"
+assert_grep "$ID.context" "$WT/.claude/settings.local.json" "Stop hook records to state/<id>.context"
+pass "happy path: fresh agent on same worktree, no treehouse get, brief+context wired"
+
+pass "fm-spawn --reuse-worktree: all cases"


### PR DESCRIPTION
## Context handoff: swap a context-heavy crewmate for a fresh agent

Replaces a context-heavy crewmate with a **fresh agent on the same worktree/branch** instead of a lossy `/compact`. A fresh agent starts at 0% context and is reseeded by a handoff dump the crewmate deliberately authored; the in-progress diff is never discarded because the swap reuses the existing worktree.

### The six pieces

- **A. Detection** — new `bin/fm-ctx-hook.sh` (claude Stop-hook helper). Every turn it touches `state/<id>.turn-ended` (the unchanged turn-end signal) **and** records the crewmate's context size to `state/<id>.context`, summed from the transcript's last `usage` record as `input_tokens + cache_creation_input_tokens + cache_read_input_tokens`. `bin/fm-spawn.sh`'s claude Stop hook now runs this helper (reusing the existing `json_escape`/`shell_quote` helpers) instead of a bare `touch`. `state/<id>.context` is not a `*.status`/`*.turn-ended` file, so writing it never wakes the watcher.

- **B. Agent swap** — `bin/fm-spawn.sh --reuse-worktree <id>`: relaunches a fresh agent on the existing worktree/branch recorded in meta. It skips `treehouse get` and the isolation assertion, keeps the id/branch/kind/mode/yolo/project, opens the new pane directly in the worktree, re-installs the turn-end/context hook, rewrites `state/<id>.meta` `window=`, resets `state/<id>.context` + `state/<id>.turn-ended`, and launches seeded with the original brief + `data/<id>/handoff.md` + a resume preamble. It does not kill the old pane (the skill does) or destroy the worktree (teardown does). Aborts on missing meta, a vanished worktree, a missing/empty handoff dump, a secondmate task, or the orca backend.

- **C. Skill** — `.agents/skills/context-handoff/SKILL.md` (agent-only, `internal: true`, `user-invocable: false`): the dump → `fm-spawn --reuse-worktree` → retire-old playbook.

- **D. Monitor** — new `bin/fm-context.sh`: read-only, prints `<id> <tokens>/<window> <pct>%` per task (1M window default, 200k for haiku) and exits non-zero if any task is at/over the threshold (default 60%, `FM_CTX_THRESHOLD`), so a heartbeat can branch on it.

- **E. Trigger + teardown cleanup** — `AGENTS.md` §8 heartbeat review runs `bin/fm-context.sh` and loads the `context-handoff` skill on a `>=60%` flag (no `bin/fm-watch.sh` change). `bin/fm-teardown.sh` now removes `state/<id>.context` (and the composed reuse-brief) alongside the other per-task state, for both the main and secondmate-child cleanup paths.

- **F. Wiring** — `AGENTS.md` §13 skill list gains `context-handoff`; §2 layout documents `state/<id>.context`.

### Verification

- `shellcheck bin/*.sh bin/backends/*.sh tests/*.sh` clean.
- New colocated suites: `tests/fm-ctx-hook.test.sh`, `tests/fm-context.test.sh`, `tests/fm-spawn-reuse-worktree.test.sh` (arg parsing, meta reading, every error path, and a stubbed happy path proving `treehouse get` is never invoked, the composed brief is used, and the Stop hook is wired). Existing `fm-teardown`, `fm-spawn-batch`, `fm-tangle-guard`, `fm-turnend-guard`, and the tmux backend smoke suite still pass.
- **Transcript formula confirmed against a real live claude transcript** (read-only): the last `usage` record summed to `186959` (= `2 + 244 + 186713`), matching `fm-ctx-hook.sh` exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
