### PR TITLE
feat(downstream): default firstmate self-changes to local-only on downstream instances

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,7 @@ This repo is a shared template, not the captain's personal project.
 The tracking principle: shared, tracked material is tracked under git; anything personal to this captain's fleet (.env, data/, state/, config/, projects/, .no-mistakes/) is not.
 Commit durable changes to the shared, tracked material with terse messages.
 This repo is itself behind the no-mistakes gate: ship shared, tracked material through the pipeline - branch, commit, run the pipeline, PR - and the captain's merge rule applies here exactly as it does to projects.
+That pipeline-and-PR path is the maintainer path; a downstream instance running a clone of the shared template it does not own must default its own changes to local-only and never auto-PR them to the upstream template (section 12).
 Never add an agent name as co-author.
 
 ## 2. Layout and state
@@ -846,6 +847,16 @@ firstmate is its own repo behind the no-mistakes gate, so improvements to `AGENT
 Only `AGENTS.md`, `bin/`, and `.agents/skills/` are a running firstmate instruction surface; public `skills/` is tracked for installers and is not loaded by firstmate.
 When the captain invokes `/updatefirstmate` or asks to update firstmate, load the `/updatefirstmate` skill.
 It performs only fast-forward self-updates of firstmate and registered secondmate homes, re-reads `AGENTS.md` when needed, nudges updated live secondmates, and never touches anything under `projects/`.
+
+### Downstream instances and self-changes
+
+The firstmate repo is a public template most users clone to *run* firstmate, not to maintain it.
+Such a downstream instance has `origin` pointing at the upstream template it does not own, so firstmate-on-itself changes must never auto-push or auto-PR to `origin` - otherwise the shared repo fills with instance PRs that were never meant as contributions.
+`bin/fm-downstream.sh` decides this from live git/gh identity: origin's GitHub owner versus the authenticated login (a fork you own resolves to owner; unresolvable identity degrades to downstream, the safe default).
+When downstream, a firstmate self-change's effective delivery mode is `local-only`: the crewmate commits on its `fm/<id>` branch, firstmate reviews the diff locally, and the captain decides where it lands - no remote, no PR.
+This resolves automatically wherever the firstmate repo is the task's project: `bin/fm-project-mode.sh --firstmate-self` (used by `bin/fm-spawn.sh`, and by `bin/fm-brief.sh --firstmate-self` for the brief's definition of done), with `bin/fm-pr-check.sh` and `bin/fm-pr-merge.sh` hard-refusing a firstmate self-change PR as the backstop.
+Contributing a self-change upstream is a deliberate, explicit opt-in, never the default: set `FM_CONTRIBUTE=1` to push to your own fork and open the PR yourself.
+An owner/maintainer instance keeps the full no-mistakes pipeline-and-PR path unchanged.
 
 ## 13. Agent-only reference skills
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -6,8 +6,14 @@
 # description, acceptance criteria, and context, and may adjust other sections
 # when the task genuinely deviates (e.g. working an existing external PR instead
 # of shipping a new one).
-# Usage: fm-brief.sh <task-id> <repo-name> [--scout]
+# Usage: fm-brief.sh <task-id> <repo-name> [--scout] [--firstmate-self]
 #        fm-brief.sh <task-id> --secondmate <project>...
+#   --firstmate-self marks a firstmate-on-itself ship task: the effective
+#   delivery mode is resolved through the downstream guard (bin/fm-downstream.sh),
+#   so a downstream instance's own change ships local-only and the brief tells the
+#   crewmate this is a self-change that never auto-PRs upstream. Firstmate passes
+#   this by hand for firstmate-repo briefs, since the caller-supplied repo name
+#   carries no reliable signal that it names firstmate's own repo.
 #   --scout writes the scout contract instead: the deliverable is a report at
 #   data/<task-id>/report.md (no branch, no push, no PR) and the worktree is scratch.
 #   --secondmate writes a persistent secondmate charter. The project list
@@ -39,11 +45,13 @@ FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 KIND=ship
+FIRSTMATE_SELF=0
 POS=()
 for a in "$@"; do
   case "$a" in
     --scout) KIND=scout ;;
     --secondmate) KIND=secondmate ;;
+    --firstmate-self) FIRSTMATE_SELF=1 ;;
     *) POS+=("$a") ;;
   esac
 done
@@ -167,9 +175,17 @@ fi
 
 # Ship task: shape Setup / Rule 1 / Definition of done by the project's delivery mode.
 # yolo does not affect the brief (it governs firstmate's approval behaviour), so discard it.
-read -r MODE _ <<EOF
+# A firstmate-on-itself task resolves through the downstream guard instead of the
+# registry, so a downstream instance's own change ships local-only (AGENTS.md section 12).
+if [ "$FIRSTMATE_SELF" = 1 ]; then
+  read -r MODE _ <<EOF
+$("$FM_ROOT/bin/fm-project-mode.sh" --firstmate-self)
+EOF
+else
+  read -r MODE _ <<EOF
 $("$FM_ROOT/bin/fm-project-mode.sh" "$REPO")
 EOF
+fi
 
 case "$MODE" in
   direct-PR)
@@ -221,6 +237,16 @@ EOF
 )
     ;;
 esac
+
+# For a firstmate-on-itself change on a downstream instance the mode above resolved
+# to local-only; explain WHY so the crewmate never tries to push or PR upstream.
+if [ "$FIRSTMATE_SELF" = 1 ] && [ "$MODE" = local-only ]; then
+  DOD="$DOD
+
+This is a firstmate **self-change** on the shared template this instance was cloned from and does not own.
+That is why it ships local-only: firstmate never auto-pushes or auto-PRs its own changes to the upstream template.
+Contributing this change upstream is a separate, deliberate step the captain opts into explicitly; it is never the default here."
+fi
 
 cat > "$BRIEF" <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

--- a/bin/fm-downstream.sh
+++ b/bin/fm-downstream.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# Decide whether this firstmate instance runs as a DOWNSTREAM user of the shared
+# firstmate template (someone else's tool, cloned to run firstmate) or as the
+# tool's OWNER/maintainer, and gate firstmate self-changes accordingly.
+#
+# The firstmate repo is a public template. A downstream user clones it and runs
+# it; its `origin` points at the upstream template the user does NOT own. Left
+# unchecked, firstmate-on-itself ship tasks (and the tool's own self-ship flow)
+# open PRs against that upstream by accident. The rule this script encodes: a
+# downstream instance's own changes ship LOCAL-ONLY by default and never
+# auto-push or auto-PR to origin; contributing upstream is a deliberate,
+# explicit opt-in (FM_CONTRIBUTE=1).
+#
+# Detection is entirely from live git/gh identity, so nothing user-specific is
+# baked in and it is correct for every clone:
+#   - origin's GitHub owner (parsed from `git remote get-url origin`)
+#   - the authenticated GitHub login (`gh api user`, else `gh auth status`)
+#   - owner == login (case-insensitive) -> OWNER; a fork the user owns has
+#     origin owner == login, so it resolves to OWNER too.
+#   - otherwise, or when either identity cannot be resolved -> DOWNSTREAM, the
+#     safe default that prevents accidental writes to a template the user does
+#     not own.
+#
+# Dual-mode: source it for the functions (fm_downstream_status,
+# fm_block_firstmate_upstream), or execute it as a standalone check.
+#
+# Standalone usage: fm-downstream.sh [<repo-root>]   (default: FM_ROOT)
+#   Prints `owner` (exit 0) or `downstream` (exit 1).
+
+FM_DOWNSTREAM_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=bin/fm-tangle-lib.sh
+. "$FM_DOWNSTREAM_LIB_DIR/fm-tangle-lib.sh"
+
+# Parse the GitHub owner (org/user) from a remote URL of any common form
+# (https://, git@host:, ssh://, git://). Echoes the owner; returns 1 if the URL
+# is not a github.com remote.
+fm_github_owner_from_url() {
+  local url=$1 rest
+  case "$url" in
+    *github.com[:/]*) : ;;
+    *) return 1 ;;
+  esac
+  rest=${url#*github.com}
+  rest=${rest#:}
+  rest=${rest#/}
+  rest=${rest%%/*}
+  [ -n "$rest" ] || return 1
+  printf '%s\n' "$rest"
+}
+
+# Echo origin's GitHub owner for the repo at <root> (default FM_ROOT); returns 1
+# if origin is missing or not a github.com remote.
+fm_origin_owner() {
+  local root=${1:-${FM_ROOT:-.}} url
+  url=$(git -C "$root" remote get-url origin 2>/dev/null) || return 1
+  [ -n "$url" ] || return 1
+  fm_github_owner_from_url "$url"
+}
+
+# Echo the authenticated GitHub login, or return 1 if it cannot be resolved.
+# Prefers `gh api user` (authoritative), then parses `gh auth status`, then
+# tries the gh-axi wrapper. Never hardcodes any name.
+fm_gh_login() {
+  local login
+  if command -v gh >/dev/null 2>&1; then
+    if login=$(gh api user --jq .login 2>/dev/null) && [ -n "$login" ]; then
+      printf '%s\n' "$login"
+      return 0
+    fi
+    if login=$(gh auth status 2>&1 | sed -n -E 's/.*[Ll]ogged in to [^ ]+ (as|account) ([A-Za-z0-9][A-Za-z0-9-]*).*/\2/p' | head -1) && [ -n "$login" ]; then
+      printf '%s\n' "$login"
+      return 0
+    fi
+  fi
+  if command -v gh-axi >/dev/null 2>&1; then
+    if login=$(gh-axi api user --jq .login 2>/dev/null) && [ -n "$login" ]; then
+      printf '%s\n' "$login"
+      return 0
+    fi
+  fi
+  return 1
+}
+
+# Echo "owner" (return 0) or "downstream" (return 1) for the repo at <root>
+# (default FM_ROOT). Unresolvable identity degrades to downstream.
+fm_downstream_status() {
+  local root=${1:-${FM_ROOT:-.}} owner login
+  owner=$(fm_origin_owner "$root" 2>/dev/null || true)
+  login=$(fm_gh_login 2>/dev/null || true)
+  if [ -z "$owner" ] || [ -z "$login" ]; then
+    echo downstream
+    return 1
+  fi
+  if [ "$(printf '%s' "$owner" | tr '[:upper:]' '[:lower:]')" = "$(printf '%s' "$login" | tr '[:upper:]' '[:lower:]')" ]; then
+    echo owner
+    return 0
+  fi
+  echo downstream
+  return 1
+}
+
+# Backstop for firstmate-controlled push/PR seams. Given a task's
+# state/<id>.meta, refuse the operation when the task's project is the firstmate
+# repo itself AND this is a downstream instance AND the caller has not opted into
+# upstream contribution (FM_CONTRIBUTE=1). A no-op for every non-firstmate task,
+# for owner instances, and when FM_CONTRIBUTE=1.
+#   Usage: fm_block_firstmate_upstream <meta-file> <what>   (returns 1 to block)
+fm_block_firstmate_upstream() {
+  local meta=$1 what=${2:-push/PR} proj
+  [ -f "$meta" ] || return 0
+  proj=$(grep '^project=' "$meta" | head -1 | cut -d= -f2- || true)
+  [ -n "$proj" ] || return 0
+  fm_is_firstmate_repo "$proj" || return 0
+  [ "${FM_CONTRIBUTE:-}" = 1 ] && return 0
+  fm_downstream_status "$proj" >/dev/null 2>&1 && return 0
+  cat >&2 <<EOF
+error: refusing to $what for a firstmate self-change on a downstream instance.
+  This firstmate runs from a clone of the shared template it does not own, so its
+  own changes ship LOCAL-ONLY by default and must never auto-PR to the upstream
+  template. To deliberately contribute this change upstream, re-run with
+  FM_CONTRIBUTE=1 (push to your own fork / open the PR yourself).
+EOF
+  return 1
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$FM_DOWNSTREAM_LIB_DIR/.." && pwd)}"
+  root="${1:-$FM_ROOT}"
+  status=$(fm_downstream_status "$root")
+  rc=$?
+  printf '%s\n' "$status"
+  exit "$rc"
+fi

--- a/bin/fm-pr-check.sh
+++ b/bin/fm-pr-check.sh
@@ -10,11 +10,17 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+# shellcheck source=bin/fm-downstream.sh
+. "$SCRIPT_DIR/fm-downstream.sh"
 "$FM_ROOT/bin/fm-guard.sh" || true
 ID=$1
 URL=$2
 
 META="$STATE/$ID.meta"
+# Never arm a merge poll for a firstmate self-change PR on a downstream instance
+# (it would only exist by accident) unless the captain opted into contributing
+# upstream. See bin/fm-downstream.sh and AGENTS.md section 12.
+fm_block_firstmate_upstream "$META" "arm a merge poll" || exit 1
 if [ -f "$META" ]; then
   WT=$(grep '^worktree=' "$META" | tail -1 | cut -d= -f2- || true)
   PR_HEAD=

--- a/bin/fm-pr-merge.sh
+++ b/bin/fm-pr-merge.sh
@@ -38,6 +38,13 @@ FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 META="$STATE/$ID.meta"
 [ -f "$META" ] || { echo "error: no meta for task $ID at $META; refusing to merge without recording pr=" >&2; exit 1; }
+# shellcheck source=bin/fm-downstream.sh
+. "$SCRIPT_DIR/fm-downstream.sh"
+# Never merge a firstmate self-change PR on a downstream instance (it would only
+# exist by accident) unless the captain opted into contributing upstream. Fires
+# before fm-pr-check below, so a blocked merge records nothing and prints one
+# message. See bin/fm-downstream.sh and AGENTS.md section 12.
+fm_block_firstmate_upstream "$META" "merge a PR" || exit 1
 
 caller_has_merge_method() {
   local arg

--- a/bin/fm-project-mode.sh
+++ b/bin/fm-project-mode.sh
@@ -18,7 +18,13 @@
 #
 # An unknown/missing project or unknown mode falls back to "no-mistakes off" and warns
 # to stderr, so a typo never silently drops the gate.
-# Usage: fm-project-mode.sh <project-name>
+#
+# Special project "--firstmate-self": resolve the effective delivery mode for a
+# firstmate-on-itself change. A downstream instance (running a clone of the shared
+# template it does not own) ships its own changes local-only by default so they
+# never auto-PR to the upstream template; an owner/maintainer instance keeps the
+# default no-mistakes pipeline. See bin/fm-downstream.sh and AGENTS.md section 12.
+# Usage: fm-project-mode.sh <project-name>|--firstmate-self
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -26,7 +32,19 @@ FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 REG="$DATA/projects.md"
-NAME=${1:?usage: fm-project-mode.sh <project-name>}
+NAME=${1:?usage: fm-project-mode.sh <project-name>|--firstmate-self}
+
+if [ "$NAME" = "--firstmate-self" ]; then
+  # shellcheck source=bin/fm-downstream.sh
+  . "$SCRIPT_DIR/fm-downstream.sh"
+  self_status=$(fm_downstream_status "$FM_ROOT" || true)
+  if [ "$self_status" = owner ]; then
+    echo "no-mistakes off"
+  else
+    echo "local-only off"
+  fi
+  exit 0
+fi
 
 if [ ! -f "$REG" ]; then
   echo "warn: no registry at $REG; defaulting $NAME to no-mistakes off" >&2

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -92,6 +92,8 @@ SUB_HOME_MARKER=".fm-secondmate-home"
 . "$SCRIPT_DIR/fm-config-inherit-lib.sh"
 # shellcheck source=bin/fm-backend.sh
 . "$SCRIPT_DIR/fm-backend.sh"
+# shellcheck source=bin/fm-tangle-lib.sh
+. "$SCRIPT_DIR/fm-tangle-lib.sh"
 # Skip the watcher guard when re-exec'd for one pair of a batch (FM_SPAWN_NO_GUARD is
 # set by the batch loop below), so the guard runs once for the batch, not once per pair.
 [ -n "${FM_SPAWN_NO_GUARD:-}" ] || "$FM_ROOT/bin/fm-guard.sh" || true
@@ -946,6 +948,15 @@ if [ "$KIND" = secondmate ]; then
   MODE=secondmate
   YOLO=off
   SECONDMATE_PROJECTS=$(secondmate_registry_value "$ID" projects || true)
+elif fm_is_firstmate_repo "$PROJ_ABS"; then
+  # firstmate-on-itself ship/scout task: resolve the effective mode through the
+  # downstream guard, so a downstream instance's own changes default to
+  # local-only instead of the no-mistakes-then-upstream-PR path a project
+  # unknown to the registry would otherwise get (bin/fm-downstream.sh; AGENTS.md
+  # section 12).
+  read -r MODE YOLO <<EOF
+$("$FM_ROOT/bin/fm-project-mode.sh" --firstmate-self)
+EOF
 else
   PROJ_NAME=$(basename "$PROJ_ABS")
   read -r MODE YOLO <<EOF

--- a/bin/fm-tangle-lib.sh
+++ b/bin/fm-tangle-lib.sh
@@ -35,6 +35,35 @@ fm_default_branch() {
   return 1
 }
 
+# Canonical absolute git common dir of the repo at <dir>, or return 1 if <dir>
+# is not a git work tree. The common dir is shared by a repo and all its linked
+# worktrees, so two checkouts of one repo resolve to the same value.
+fm__common_dir_abs() {
+  local dir=$1 common
+  common=$(git -C "$dir" rev-parse --git-common-dir 2>/dev/null) || return 1
+  [ -n "$common" ] || return 1
+  case "$common" in
+    /*) : ;;
+    *) common="$dir/$common" ;;
+  esac
+  (cd "$common" 2>/dev/null && pwd -P) || return 1
+}
+
+# True (return 0) if the git checkout at <dir> belongs to the SAME repository as
+# the firstmate repo <root> (default FM_ROOT) - i.e. <dir> is the firstmate repo
+# itself or one of its linked worktrees, sharing one object store. Used to
+# recognize firstmate-on-itself ship tasks (fm-downstream.sh, fm-project-mode.sh,
+# fm-spawn.sh, the PR seams) so a downstream instance defaults its own changes to
+# local-only. Returns 1 if <dir> is not a git work tree or the repos differ.
+fm_is_firstmate_repo() {
+  local dir=$1 root=${2:-${FM_ROOT:-}} a b
+  [ -n "$dir" ] || return 1
+  [ -n "$root" ] || return 1
+  a=$(fm__common_dir_abs "$dir") || return 1
+  b=$(fm__common_dir_abs "$root") || return 1
+  [ "$a" = "$b" ]
+}
+
 # If the git checkout at <root> is tangled - on a NAMED branch that is not its
 # default branch - echo the offending branch name and return 0. For every healthy
 # state (not a git work tree, detached HEAD, or already on the default branch)

--- a/tests/fm-downstream.test.sh
+++ b/tests/fm-downstream.test.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+# Tests for the downstream-user guard: bin/fm-downstream.sh detection plus the
+# firstmate-self delivery-mode resolution and PR-seam backstop it feeds.
+#
+# The rule under test: a DOWNSTREAM instance (running a clone of the shared
+# firstmate template whose origin owner differs from the authenticated login, or
+# whose identity cannot be resolved) must ship its OWN firstmate changes
+# local-only and never auto-PR them upstream. An OWNER instance keeps the full
+# no-mistakes pipeline-and-PR path. Contributing upstream is an explicit
+# FM_CONTRIBUTE=1 opt-in.
+#
+# Matrix:
+#   (a) fm-downstream.sh: origin owner == login          -> owner (exit 0)
+#   (b) fm-downstream.sh: origin owner != login          -> downstream (exit 1)
+#   (c) fm-downstream.sh: identity unresolvable          -> downstream (exit 1)
+#   (d) fm_github_owner_from_url parses common URL forms
+#   (e) fm-project-mode.sh --firstmate-self: owner -> no-mistakes, downstream -> local-only
+#   (f) fm-brief.sh --firstmate-self on a downstream instance -> local-only DOD + self-change note
+#   (g) fm-pr-check.sh refuses a firstmate self-change PR when downstream, allows with FM_CONTRIBUTE=1
+#   (h) fm-pr-merge.sh refuses a firstmate self-change PR when downstream, allows an owner instance
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+fm_git_identity fmtest fmtest@example.invalid
+
+TMP_ROOT=$(fm_test_tmproot fm-downstream)
+
+# Build a git repo standing in for the firstmate repo, with a github origin owned
+# by <owner> and a bin/ symlink so internal "$FM_ROOT/bin/..." calls resolve to
+# the real toolbelt while origin/identity stay under test control.
+make_fm_home() {  # <dir> <origin-owner>
+  local dir=$1 owner=$2
+  mkdir -p "$dir/data" "$dir/state"
+  fm_git_init_commit "$dir"
+  git -C "$dir" remote add origin "https://github.com/$owner/firstmate"
+  ln -s "$ROOT/bin" "$dir/bin"
+  printf '%s\n' "$dir"
+}
+
+# fakebin with gh/gh-axi stubs. With a non-empty <login>, `gh api user` answers
+# it; with an empty <login>, both wrappers fail so identity is unresolvable.
+make_fakebin() {  # <dir> <login>
+  local dir=$1 login=$2 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  if [ -n "$login" ]; then
+    cat > "$fakebin/gh" <<SH
+#!/usr/bin/env bash
+case "\$*" in
+  "api user --jq .login") printf '%s\n' '$login'; exit 0 ;;
+esac
+exit 1
+SH
+  else
+    cat > "$fakebin/gh" <<'SH'
+#!/usr/bin/env bash
+exit 1
+SH
+  fi
+  cat > "$fakebin/gh-axi" <<'SH'
+#!/usr/bin/env bash
+exit 1
+SH
+  chmod +x "$fakebin/gh" "$fakebin/gh-axi"
+  printf '%s\n' "$fakebin"
+}
+
+test_owner_when_origin_owner_matches_login() {
+  local home out rc
+  home=$(make_fm_home "$TMP_ROOT/owner" acme)
+  out=$(PATH="$(make_fakebin "$home" acme):$PATH" "$ROOT/bin/fm-downstream.sh" "$home"); rc=$?
+  assert_contains "$out" "owner" "owner case should print owner"
+  expect_code 0 "$rc" "owner case should exit 0"
+  pass "fm-downstream: origin owner == login -> owner (exit 0)"
+}
+
+test_downstream_when_origin_owner_differs() {
+  local home out rc
+  home=$(make_fm_home "$TMP_ROOT/downstream" upstream-org)
+  out=$(PATH="$(make_fakebin "$home" someuser):$PATH" "$ROOT/bin/fm-downstream.sh" "$home"); rc=$?
+  assert_contains "$out" "downstream" "mismatched owner/login should print downstream"
+  expect_code 1 "$rc" "downstream case should exit 1"
+  pass "fm-downstream: origin owner != login -> downstream (exit 1)"
+}
+
+test_downstream_when_identity_unresolvable() {
+  local home out rc
+  home=$(make_fm_home "$TMP_ROOT/unresolvable" upstream-org)
+  # Empty login: gh/gh-axi both fail, so login cannot be resolved -> safe default.
+  out=$(PATH="$(make_fakebin "$home" ""):$PATH" "$ROOT/bin/fm-downstream.sh" "$home"); rc=$?
+  assert_contains "$out" "downstream" "unresolvable identity should default to downstream"
+  expect_code 1 "$rc" "unresolvable identity should exit 1 (downstream)"
+  pass "fm-downstream: unresolvable identity -> downstream (safe default)"
+}
+
+test_owner_from_url_parsing() {
+  # shellcheck source=bin/fm-downstream.sh
+  . "$ROOT/bin/fm-downstream.sh"
+  local got
+  got=$(fm_github_owner_from_url "https://github.com/octo/repo.git") || fail "https URL did not parse"
+  [ "$got" = octo ] || fail "https URL owner: expected octo, got $got"
+  got=$(fm_github_owner_from_url "git@github.com:octo/repo.git") || fail "ssh scp URL did not parse"
+  [ "$got" = octo ] || fail "ssh scp URL owner: expected octo, got $got"
+  got=$(fm_github_owner_from_url "ssh://git@github.com/octo/repo") || fail "ssh:// URL did not parse"
+  [ "$got" = octo ] || fail "ssh:// URL owner: expected octo, got $got"
+  if fm_github_owner_from_url "https://gitlab.com/octo/repo" >/dev/null 2>&1; then
+    fail "non-github URL should not parse a github owner"
+  fi
+  pass "fm-downstream: fm_github_owner_from_url parses https/scp/ssh github forms and rejects non-github"
+}
+
+test_project_mode_firstmate_self() {
+  local home out
+  # downstream -> local-only
+  home=$(make_fm_home "$TMP_ROOT/pm-down" up-org)
+  out=$(PATH="$(make_fakebin "$home" me):$PATH" FM_ROOT_OVERRIDE="$home" \
+    "$ROOT/bin/fm-project-mode.sh" --firstmate-self)
+  [ "$out" = "local-only off" ] || fail "downstream firstmate-self: expected 'local-only off', got '$out'"
+  # owner -> no-mistakes
+  home=$(make_fm_home "$TMP_ROOT/pm-owner" me)
+  out=$(PATH="$(make_fakebin "$home" me):$PATH" FM_ROOT_OVERRIDE="$home" \
+    "$ROOT/bin/fm-project-mode.sh" --firstmate-self)
+  [ "$out" = "no-mistakes off" ] || fail "owner firstmate-self: expected 'no-mistakes off', got '$out'"
+  pass "fm-project-mode --firstmate-self: downstream -> local-only, owner -> no-mistakes"
+}
+
+test_brief_firstmate_self_downstream_is_local_only() {
+  local home id brief
+  home=$(make_fm_home "$TMP_ROOT/brief-down" up-org)
+  id="self-b1"
+  PATH="$(make_fakebin "$home" me):$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$home" \
+    "$ROOT/bin/fm-brief.sh" "$id" firstmate --firstmate-self >/dev/null 2>&1 \
+    || fail "fm-brief --firstmate-self failed"
+  brief="$home/data/$id/brief.md"
+  assert_present "$brief" "self brief was not scaffolded"
+  assert_grep "ships **local-only**" "$brief" "downstream self brief should ship local-only"
+  assert_grep "self-change" "$brief" "downstream self brief should explain it is a self-change"
+  assert_grep "FM_CONTRIBUTE" "$home/bin/fm-downstream.sh" "opt-in env should be documented in fm-downstream.sh"
+  assert_no_grep "no-mistakes doctor" "$brief" "downstream self brief must not use the no-mistakes pipeline path"
+  pass "fm-brief --firstmate-self: downstream self-change gets a local-only, self-change-aware brief"
+}
+
+# Arrange a task meta whose project IS the firstmate repo, then exercise the PR
+# seams. gh (used by fm-pr-check for pr_head) is stubbed to fail harmlessly.
+write_self_task_meta() {  # <home> <id>
+  local home=$1 id=$2
+  fm_write_meta "$home/state/$id.meta" \
+    "window=fm-$id" \
+    "worktree=$home/wt" \
+    "project=$home" \
+    "kind=ship" \
+    "mode=local-only"
+}
+
+test_pr_check_refuses_self_downstream_allows_contribute() {
+  local home id fakebin rc
+  home=$(make_fm_home "$TMP_ROOT/prcheck" up-org)
+  fakebin=$(make_fakebin "$home" me)
+  id="self-c1"
+  write_self_task_meta "$home" "$id"
+
+  set +e
+  PATH="$fakebin:$PATH" FM_ROOT_OVERRIDE="$home" FM_STATE_OVERRIDE="$home/state" \
+    "$ROOT/bin/fm-pr-check.sh" "$id" https://github.com/up-org/firstmate/pull/9 \
+    > "$home/prcheck.out" 2> "$home/prcheck.err"
+  rc=$?
+  set -e
+  expect_code 1 "$rc" "downstream self-change PR check should be refused"
+  assert_grep "refusing to arm a merge poll" "$home/prcheck.err" "refusal message missing"
+  assert_absent "$home/state/$id.check.sh" "refused self-change must not arm a merge poll"
+
+  # Explicit opt-in lets it through.
+  set +e
+  PATH="$fakebin:$PATH" FM_CONTRIBUTE=1 FM_ROOT_OVERRIDE="$home" FM_STATE_OVERRIDE="$home/state" \
+    "$ROOT/bin/fm-pr-check.sh" "$id" https://github.com/up-org/firstmate/pull/9 \
+    > "$home/prcheck2.out" 2> "$home/prcheck2.err"
+  rc=$?
+  set -e
+  expect_code 0 "$rc" "FM_CONTRIBUTE=1 should allow the self-change PR check"
+  assert_present "$home/state/$id.check.sh" "FM_CONTRIBUTE=1 should arm the merge poll"
+  pass "fm-pr-check: refuses downstream self-change PR, honors FM_CONTRIBUTE=1 opt-in"
+}
+
+test_pr_merge_refuses_self_downstream_allows_owner() {
+  local home id fakebin rc
+  # downstream -> refuse before any merge/recording.
+  home=$(make_fm_home "$TMP_ROOT/prmerge-down" up-org)
+  fakebin=$(make_fakebin "$home" me)
+  id="self-m1"
+  write_self_task_meta "$home" "$id"
+  set +e
+  PATH="$fakebin:$PATH" FM_ROOT_OVERRIDE="$home" FM_STATE_OVERRIDE="$home/state" \
+    "$ROOT/bin/fm-pr-merge.sh" "$id" https://github.com/up-org/firstmate/pull/9 \
+    > "$home/prmerge.out" 2> "$home/prmerge.err"
+  rc=$?
+  set -e
+  expect_code 1 "$rc" "downstream self-change PR merge should be refused"
+  assert_grep "refusing to merge a PR" "$home/prmerge.err" "merge refusal message missing"
+  assert_no_grep "pr=https://github.com/up-org/firstmate/pull/9" "$home/state/$id.meta" \
+    "refused self-change merge must not record pr="
+
+  # owner instance -> the guard is a no-op (merge proceeds to gh-axi, which is
+  # stubbed to fail; that failure is downstream of the guard, so a non-guard
+  # error message proves the guard let it through).
+  home=$(make_fm_home "$TMP_ROOT/prmerge-owner" me)
+  fakebin=$(make_fakebin "$home" me)
+  write_self_task_meta "$home" "$id"
+  set +e
+  PATH="$fakebin:$PATH" FM_ROOT_OVERRIDE="$home" FM_STATE_OVERRIDE="$home/state" \
+    "$ROOT/bin/fm-pr-merge.sh" "$id" https://github.com/me/firstmate/pull/9 \
+    > "$home/prmerge-owner.out" 2> "$home/prmerge-owner.err"
+  rc=$?
+  set -e
+  assert_no_grep "refusing to merge a PR" "$home/prmerge-owner.err" \
+    "owner instance self-change merge must NOT be guard-refused"
+  pass "fm-pr-merge: refuses downstream self-change PR, lets an owner instance through"
+}
+
+test_owner_when_origin_owner_matches_login
+test_downstream_when_origin_owner_differs
+test_downstream_when_identity_unresolvable
+test_owner_from_url_parsing
+test_project_mode_firstmate_self
+test_brief_firstmate_self_downstream_is_local_only
+test_pr_check_refuses_self_downstream_allows_contribute
+test_pr_merge_refuses_self_downstream_allows_owner


### PR DESCRIPTION
## Summary

Stop firstmate instances that run a *clone* of the shared template from accidentally pushing/PR'ing their own changes back to the upstream template.

A downstream instance has `origin` pointing at the upstream repo it does not own, so firstmate-on-itself changes (and the tool's own self-ship flow) open PRs against the upstream by accident — the public repo fills with instance PRs that were never meant as contributions.

## Approach

Detect downstream-vs-owner from live git/gh identity, and default a downstream instance's own firstmate changes to **local-only** (no remote, no PR). Contributing upstream stays possible but becomes a deliberate, explicit opt-in (`FM_CONTRIBUTE=1`).

## Changes

- **`bin/fm-downstream.sh`** (new): resolves origin's GitHub owner vs the authenticated `gh` login. A fork you own → owner; unresolvable identity → downstream (safe default).
- **`bin/fm-tangle-lib.sh`**: `fm_is_firstmate_repo` — authoritative firstmate-on-itself check via the shared git common dir.
- **`bin/fm-project-mode.sh`**: `--firstmate-self` resolves to `local-only` when downstream, unchanged `no-mistakes` pipeline path when owner/maintainer.
- **`bin/fm-spawn.sh`** / **`bin/fm-brief.sh`**: consume the self-change mode; brief DoD becomes local-only-aware for a downstream self-change.
- **`bin/fm-pr-check.sh`** / **`bin/fm-pr-merge.sh`**: hard-refuse a firstmate self-change PR when downstream unless `FM_CONTRIBUTE=1` (the backstop).
- **`AGENTS.md`** (sections 1, 12): documents the downstream-user model.

## Tests

`shellcheck` clean. New `tests/fm-downstream.test.sh` (8 cases: owner/downstream/unresolvable detection, origin-URL parsing, mode resolution, brief DoD, both PR-seam refusals + opt-in). Existing fm-brief / fm-pr-merge / fm-tangle-guard / fm-spawn suites pass.

Verified live: a downstream instance detects as downstream, resolves self-changes to local-only, and refuses arming a self-change merge poll without the opt-in.
