### PR TITLE
feat(skills): add captain-invocable plan and deck skills

### DIFF
--- a/.agents/skills/deck/SKILL.md
+++ b/.agents/skills/deck/SKILL.md
@@ -39,7 +39,8 @@ If ground truth disagrees with itself - a backlog story with no meta, a meta who
 
 Write the artifact to `.lavish/deck.html` for the whole fleet or `.lavish/deck-<project>.html` for one project (gitignored scratch, never committed).
 Run `lavish-axi design` for the CDN snippets and use the Tailwind v4 + DaisyUI v5 stack; keep every nesting level free of horizontal overflow.
-Imitate the visual structure of the live-deck prototype (plan reference `.lavish/firstmate-deck-live.html`), but populate it entirely from step 2's data - no remembered, sample, or placeholder content:
+If a live-deck prototype happens to exist at `.lavish/firstmate-deck-live.html` (captain-local gitignored scratch, absent on most installs), it may serve as an optional visual reference.
+Either way, the numbered structure below is the authoritative template; populate it entirely from step 2's data - no remembered, sample, or placeholder content:
 
 1. **Status strip** - counts across the rendered scope: needs-you, building (in-flight and working), queued, projects tracked.
 2. **One section per project with stories** - heading with project name, mode badge, and one-line identity; then story cards ordered needs-you → building → queued → recent done.

--- a/.agents/skills/deck/SKILL.md
+++ b/.agents/skills/deck/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: deck
+description: Generate the "where are we" deck - a per-project or whole-fleet HTML summary rendered on demand from live ground truth (the project registry, the backlog, task meta, and live crew state), never hardcoded and never hand-maintained. Use when the captain invokes /deck (e.g. "/deck", "/deck <project>") or asks "where are we", "where are we on <project>", or wants a glanceable picture of a project's stories and what is waiting on them.
+user-invocable: true
+metadata:
+  internal: true
+---
+
+# deck
+
+Answer "where are we" with a generated visual summary instead of a from-memory prose reconstruction.
+The deck is a **map, not a cockpit**: it shows each project's story backlog, what is waiting on the captain, and a jump pointer to each live session - and nothing on it is a control.
+Review, dialogue, and approvals stay in the harness.
+
+Every deck is generated from ground truth at generation time and thrown away.
+Never reuse, hand-edit, or incrementally patch a previously generated deck, and never invent a store, daemon, or refresh loop for it: the next "where are we" simply regenerates from current state.
+
+## Step 1 - Resolve the scope
+
+`/deck <project>` or "where are we on <project>" scopes to one project; resolve the name with the normal intake rules (AGENTS.md section 7) and ask a one-line question on ambiguity.
+Bare `/deck` or a general "where are we" means the whole fleet, grouped per project.
+
+## Step 2 - Gather ground truth (all reads, gathered fresh this run)
+
+- **What each project is**: its registry line in `data/projects.md` (name, delivery mode, `+yolo` posture, one-line description), plus a one-line identity from the project's own `README.md` or `AGENTS.md` when the registry line alone is too thin.
+- **Stories, two levels (project → story)**: from the backlog - `tasks-axi list --state in_flight`, `tasks-axi list --state queued --fields blocked_by`, and `tasks-axi list --state done` (or read `data/backlog.md` directly per the AGENTS.md section 10 format when the tasks-axi backend is unavailable or opted out), then group the stories by project yourself from each item's `repo:` field.
+  Do not scope the deck with `--repo` filtering: the section 10 line forms can carry extra text inside the repo parens (in-flight lines append `, since <date>`) or no repo field at all (done lines), so a `--repo` filter silently drops stories; grouping in your own read keeps every story on the deck, and a per-project deck simply renders only that project's group.
+  Attribute an item whose line carries no clean `repo:` field (done lines usually do not) by its PR URL, report path, or task meta `project=`.
+- **Live state per in-flight story**: `state/<id>.meta` (`window=`, `kind=`, `mode=`, `pr=` when present), then `bin/fm-crew-state.sh <id>` for the current state line.
+- **Needs-you is derived, never stored**: mark a story needs-you when its live state or latest captain-relevant verb says the captain owns the next move - `needs-decision`, `blocked`, `failed`, a parked validation gate, `done: PR <url> checks green` awaiting merge, or `ready in branch` awaiting local review.
+  The backlog file never carries a needs-you state; recompute it every generation.
+- **Jump-to-session pointer**: from the task meta's `window=` value.
+  When meta records no `backend=` (the tmux default), the pointer is the one-liner `tmux select-window -t <window>`.
+  For a non-tmux `backend=`, show the backend name and recorded target as a label instead of a tmux command.
+
+If ground truth disagrees with itself - a backlog story with no meta, a meta whose endpoint is dead, a registry project missing from `projects/` - show the drift honestly on the deck rather than papering over it; surfacing that drift is half the deck's value.
+
+## Step 3 - Render
+
+Write the artifact to `.lavish/deck.html` for the whole fleet or `.lavish/deck-<project>.html` for one project (gitignored scratch, never committed).
+Run `lavish-axi design` for the CDN snippets and use the Tailwind v4 + DaisyUI v5 stack; keep every nesting level free of horizontal overflow.
+Imitate the visual structure of the live-deck prototype (plan reference `.lavish/firstmate-deck-live.html`), but populate it entirely from step 2's data - no remembered, sample, or placeholder content:
+
+1. **Status strip** - counts across the rendered scope: needs-you, building (in-flight and working), queued, projects tracked.
+2. **One section per project with stories** - heading with project name, mode badge, and one-line identity; then story cards ordered needs-you → building → queued → recent done.
+   Each card: status badge, story title, a one-line situation note, `blocked-by` when set, and for live stories the crew-state detail plus the jump pointer rendered as copyable code text.
+3. **Idle tracked projects** - a compact grid of registry projects with no active stories, so the fleet's full breadth stays visible on a fleet deck.
+4. **Honest footer** - generation time and any drift found in step 2.
+
+Buttons and links that pretend to act are forbidden: the only bridge from deck to cockpit is the jump pointer, and annotations are the only input surface.
+
+## Step 4 - Open, no loop
+
+Open it with `lavish-axi .lavish/deck.html` (or the per-project filename).
+The deck is read-mostly, so no `lavish-axi poll` loop is required; do not hold the turn waiting on it.
+If the captain reacts, they will do it in chat - or with Lavish annotations, which arrive like any other session feedback and are handled in conversation, not by adding interaction to the deck.
+End or abandon the session freely; the file is disposable and the next ask regenerates it.

--- a/.agents/skills/plan/SKILL.md
+++ b/.agents/skills/plan/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: plan
+description: Plan a feature or change with the captain before it becomes work - resolve the target project, match ceremony to the size of the change, shape the spec (plain chat for tiny changes, a Lavish surface with clickable design forks for medium and large ones), then on approval turn the spec into a tracked backlog story, a crewmate brief, and a normal firstmate dispatch. Use when the captain invokes /plan (e.g. "/plan <feature> [project]") or says "let's plan X", "plan this feature", or wants to think a change through before building it.
+user-invocable: true
+metadata:
+  internal: true
+---
+
+# plan
+
+Turn a fuzzy intent into an approved spec, then into a tracked story that flows through firstmate's normal delivery machinery.
+This is a supervisor-side skill: firstmate plans, the captain steers, and a crewmate builds.
+A sharp spec buys a silent run - every ambiguity left here becomes either a mid-run interruption or a wrong thing caught late at review, so resolve it here.
+
+Prime directive #1 holds throughout: reading the project to plan concretely is what read access is for, but never edit, commit to, or run state-changing commands in anything under `projects/`.
+Do not start implementing here: the plan is this skill's product, and the dispatched crewmate builds it.
+All clarifying dialogue stays in the harness chat; the Lavish surface exists only for fork-clicking and annotation.
+
+## Step 1 - Resolve the target project
+
+Use the normal intake rules (AGENTS.md section 7): an explicit project name wins, a clear follow-up inherits its referent's project, and otherwise match the message content against `data/projects.md`, in-flight backlog items, and the projects' own code and READMEs.
+One confident match: proceed, stating the project in plain outcome language so a wrong guess costs one correction.
+More than one plausible match, or none: ask a one-line question.
+Give the change a short kebab `<slug>`; it seeds the story id in step 5.
+
+## Step 2 - Weigh the ceremony
+
+Match planning weight to the change; do not give every request the full treatment.
+
+- **Tiny** (a copy fix, a config flip, a one-file tweak): a one-line goal plus acceptance criteria, confirmed in chat.
+  No Lavish artifact.
+  On the captain's yes, go straight to step 5.
+- **Medium** (a feature, a multi-file change, anything with a real design choice): the full four-field spec, shaped on a Lavish surface with clickable forks via steps 3 and 4.
+- **Large** (a new subsystem, an architecture-level change): draft a short design note and review it with the captain in chat first, then run steps 3 and 4 to settle the spec.
+- **Bug**: plan the reproduction explicitly at whatever size the fix warrants - the repro becomes the regression test, recorded in the spec's verification field.
+
+The four-field spec, at every size that reaches step 5: Goal & why · Acceptance criteria · Out of scope · Verification.
+
+## Step 3 - Read the ground, then build the plan surface
+
+Do not plan blind: read enough of the target project to plan concretely - entry points, the modules the change touches, existing patterns, tests, and how it builds and ships.
+Real constraints and sharp edges you find become forks and open questions.
+
+Open the relevant Lavish playbooks before writing any HTML - they are the contract, not a suggestion:
+
+```sh
+lavish-axi playbook plan        # overall structure
+lavish-axi playbook diagram     # Mermaid architecture/flow/sequence
+lavish-axi playbook input       # the clickable design forks
+lavish-axi design               # design source + CDN snippets (Mermaid, Tailwind/DaisyUI)
+```
+
+Match the target project's design system when it has one; otherwise use the Lavish-recommended Tailwind/DaisyUI CDN, and state which you used.
+Write the artifact to `.lavish/plan-<slug>.html` under this firstmate home (`.lavish/` is gitignored scratch - the surface is never committed anywhere).
+Structure it, top to bottom, so decisions and risks are obvious at a glance:
+
+1. **Intent** - one line: what we are building and why.
+2. **Architecture** - Mermaid diagram(s) of the target state; add a current-vs-target view when it clarifies.
+3. **Design forks** - each branch point rendered as a clickable choice (Lavish `input` playbook) with 2-4 options, a terse tradeoff per option, and your recommended option marked.
+4. **Open questions** - unknowns that block or shape the work but are not clean either/or forks.
+5. **Step plan** - ordered implementation steps concrete enough that a crewmate can execute without guessing, scoped to the chosen fork branches.
+
+## Step 4 - Review loop
+
+Open the surface and long-poll for the captain's steer:
+
+```sh
+lavish-axi .lavish/plan-<slug>.html
+lavish-axi poll .lavish/plan-<slug>.html   # run as a harness-tracked background task; never kill it
+```
+
+On each round of feedback: lock in the fork options the captain clicked, fold in annotations and queued prompts, answer clarifying questions in chat, and revise the artifact so diagrams and steps reflect the chosen branches; then re-poll.
+Fix fresh error-severity `layout_warnings` before looping back to the captain.
+Converge on explicit approval ("looks good", "ship it", "go") or the captain ending the session.
+A plan with unresolved forks is not settled - surface what is still open rather than guessing.
+
+## Step 5 - Approval becomes a story, a brief, and a dispatch
+
+Once the captain approves:
+
+1. **Mint the story id**: the kebab `<slug>` plus a short random suffix, e.g. `add-alerts-k3` (the AGENTS.md section 2 task-id form).
+2. **Track the story**: `tasks-axi add <id> "<title>" --kind ship --repo <project> --start`.
+   Omit `--start` and add `--blocked-by <other-id>` (repeatable) when the story must queue behind in-flight work per the normal readiness classification.
+   When the tasks-axi backend is unavailable or opted out, hand-edit `data/backlog.md` per AGENTS.md section 10 instead.
+3. **Fill the brief**: `bin/fm-brief.sh <id> <project>`, then replace the `{TASK}` placeholder in `data/<id>/brief.md` with the approved spec in the four-field form (Goal & why · Acceptance criteria · Out of scope · Verification).
+   The brief is the spec's durable home; the Lavish surface stays disposable.
+4. **Dispatch** (only when the story starts now): `bin/fm-spawn.sh <id> projects/<project>`, through the normal spawn discipline - load `harness-adapters` first, and when `config/crew-dispatch.json` exists consult it and pass an explicit `--harness`.
+   The story then flows through the project's recorded delivery mode and gate exactly like any other ship task, and supervision is the normal AGENTS.md section 8 protocol.
+5. **Close out**: end the Lavish session with `lavish-axi end .lavish/plan-<slug>.html` once the spec is captured in the brief, and report the handoff to the captain in plain outcomes - the project, the forks as resolved, and that the work is now building toward a review.
+
+## Principles
+
+- Front-load the thinking: ten minutes sharper on a fork saves an hour of wrong build.
+- Never inline the captain's browser feedback text into a shell command; pass artifact content through files.
+- Keep the surface scannable: diagrams and clickable forks over walls of prose.
+- The captain stays the trigger for merge; the dispatched story stops at its mode's normal approval gate.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -419,6 +419,10 @@ If `no-mistakes doctor` reports problems, fix the environment (auth, daemon) bef
 
 ### Intake
 
+Two captain-invocable skills front-run this lifecycle.
+When the captain says `/plan <feature> [project]` or "let's plan X", load the `plan` skill; the approved spec re-enters intake as a tracked story, a brief, and a normal ship dispatch.
+When the captain asks "where are we [on <project>]" or says `/deck [project]`, load the `deck` skill and generate the on-demand summary from live state instead of answering from memory.
+
 **Resolve the project first.**
 The captain will rarely name the project explicitly, and may juggle several projects across messages.
 Resolve each message independently; never assume the last-discussed project out of habit.

--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ Claude and grok use the slash form shown here; codex uses the same names with `$
 
 | Skill              | What it does                                                                                                                                  |
 | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/plan`            | Plan a feature or change before it becomes work: resolve the target project, match ceremony to the size of the change (plain chat for tiny changes, a Lavish surface with clickable design forks for bigger ones), then turn the approved spec into a tracked backlog story, a crewmate brief, and a normal dispatch |
+| `/deck`            | Generate the "where are we" deck: a per-project or whole-fleet HTML status summary rendered on demand from live ground truth (the project registry, the backlog, task meta, and live crew state), never hardcoded and never hand-maintained |
 | `/afk`             | Enter away-mode supervision: the sub-supervisor self-handles routine wakes in bash and escalates only captain-relevant events as one batched digest, cutting supervision cost while you step away |
 | `/updatefirstmate` | Self-update the running firstmate and its secondmates to the latest from origin with fast-forward-only pulls, then re-read instructions and nudge secondmates |
 | `/stow`            | Sweep the session for uncaptured durable knowledge, route each finding to its disk home per AGENTS.md, file undone next steps to the backlog, and report what is now safe to reset |

--- a/bin/backends/cmux.sh
+++ b/bin/backends/cmux.sh
@@ -390,8 +390,12 @@ fm_backend_cmux_parse_target() {  # <target>
 # (fm_backend_zellij_pane_exists) rather than the design sketch's original
 # read-screen-based suggestion.
 fm_backend_cmux_surface_exists() {  # <workspace_id> <surface_id>
-  local wsid=$1 sfid=$2
-  fm_backend_cmux_cli list-panes --workspace "$wsid" --json --id-format uuids 2>/dev/null \
+  local wsid=$1 sfid=$2 panes
+  # Capture first, then classify: a failed list-panes emits nothing, and
+  # jq 1.6's -e exits 0 on empty input (1.7+ exits 4), so piping directly
+  # would misread a dead target as live on older jq.
+  panes=$(fm_backend_cmux_cli list-panes --workspace "$wsid" --json --id-format uuids 2>/dev/null) || return 1
+  printf '%s' "$panes" \
     | jq -e --arg s "$sfid" '[.panes[]? | select(.surface_ids // [] | index($s))] | length > 0' >/dev/null 2>&1
 }
 

--- a/tests/fm-backend-tmux-smoke.test.sh
+++ b/tests/fm-backend-tmux-smoke.test.sh
@@ -48,6 +48,11 @@ TARGET="$SESSION:$WINDOW"
 
 tmux new-session -d -s "$SESSION" -x 200 -y 50 \
   || fail "real tmux: new-session failed"
+# Pin new panes to a bare /bin/sh: the host user's default shell (and its rc
+# files) can hang or never prompt in this detached context, which would stall
+# every command this smoke test types. The adapter under test is shell-agnostic.
+tmux set-option -g default-command /bin/sh \
+  || fail "real tmux: set-option default-command failed"
 fm_backend_tmux_create_task "$SESSION" "$WINDOW" "$HOME" \
   || fail "fm_backend_tmux_create_task failed to create the task window"
 tmux list-windows -t "$SESSION" -F '#{window_name}' | grep -qx "$WINDOW" \


### PR DESCRIPTION
First slice of the firstmate "project home" plan: two captain-invocable procedure skills under `.agents/skills/`, plus a 4-line intake trigger stub in `AGENTS.md`.

## What's included

- **`.agents/skills/plan/SKILL.md`** — `/plan <feature> [project]` / "let's plan X". Resolves the target project through the normal section 7 intake rules, weighs ceremony proportionally (tiny = chat-only confirmation, medium = four-field spec shaped on a Lavish surface with clickable forks, large = design note first; a bug's repro becomes the regression test), and on approval turns the spec into a tracked story (`tasks-axi add --kind ship --repo … --start`), a filled brief (`fm-brief.sh`, spec replaces `{TASK}`), and a normal dispatch (`fm-spawn.sh`) through the project's delivery mode. Clarifying dialogue stays in the harness; the Lavish surface is for fork-clicking and annotation only.
- **`.agents/skills/deck/SKILL.md`** — `/deck [project]` / "where are we [on <project>]". Generates a per-project or whole-fleet HTML summary on demand from ground truth (`data/projects.md`, per-state `tasks-axi` listings, `state/<id>.meta`, `fm-crew-state.sh`); needs-you is derived from captain-relevant verbs, never stored; jump-to-session pointers come from meta `window=` as copyable `tmux select-window` one-liners; no daemon, store, or poll loop, and each deck is disposable (regenerate, never hand-edit).
- **`AGENTS.md`** — a minimal trigger stub at the top of section 7 Intake, per the coding-guidelines knowledge-placement tree.
- **`README.md`** — skills-table rows for the two new skills (added by the validation pipeline's document step).
- **Test-environment fixes** (validation pipeline's test step): jq 1.6-compatible dead-target detection in `bin/backends/cmux.sh`, and a hermetic `/bin/sh` default-command for the tmux smoke test.

## Notes

- The deck skill deliberately lists the backlog per `--state` and groups by project itself instead of using `--repo` filtering: fixture testing showed the documented section 10 line forms parse to inexact repo fields (in-flight lines append `, since <date>`; done lines carry no repo field), so a `--repo` filter silently drops stories.
- The deck procedure was dry-walked against fixture state (sample `projects.md`, `backlog.md`, fake `state/<id>.meta`) with the exact commands the skill names; every referenced command, flag, and path was verified against `bin/*.sh` headers, `tasks-axi` help, and `lavish-axi` help.
- The `plan` name intentionally shadows a user-level skill of the same name in the original author's environment; other installs are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
