### PR TITLE
feat(skills): add captain-invocable bearings status-report skill

### DIFF
--- a/.agents/skills/bearings/SKILL.md
+++ b/.agents/skills/bearings/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: bearings
+description: Generate a "pick up where I left off" status report from firstmate's live fleet state. Use when the captain invokes /bearings or asks for a bearings report, morning brief, status report, catch-up, "where did I leave off", or "what's in the works". Reads live fleet state cheaply (backlog, per-task crew state, open PRs, scout reports, pending decisions, date-gated queued work), composes a scannable dated report to data/status-report-<YYYY-MM-DD>.md, and surfaces a concise version in chat; it is read-mostly and must not tear down, merge, or mutate task state as a side effect of producing the brief.
+user-invocable: true
+metadata:
+  internal: true
+---
+
+# bearings
+
+Generate a "pick up where I left off" report from the fleet's live state, so the captain can resume in one read after a break, a night, or a context reset.
+The deliverable is a dated markdown file plus a concise chat summary; this is the reusable version of the worked example at `data/status-report-2026-07-06.md` when that file is present in this home.
+This skill is read-mostly.
+It reads fleet state and writes exactly one report file.
+It never tears down a task, merges a PR, dispatches new work, or mutates any task state as a side effect of producing the brief - those belong to the captain's explicit word and the normal task lifecycle.
+
+## What it does
+
+1. **Gather live fleet state, cheaply and in this order.**
+   Read each source once and do not re-derive what a script already reports.
+   - `data/backlog.md` - the In flight / Queued / Done sections are the spine of the report; the active backend edits this file in place, so reading it directly is always correct.
+   - Each `state/<id>.meta` for the current direct-report set, then each task's live state via `bin/fm-crew-state.sh <id>`.
+     Never infer current state from a raw `tail` of `state/<id>.status`: that log is an append-only wake-event history and its last line goes stale the moment a resolved gate lets a run resume, while `bin/fm-crew-state.sh` reconciles the authoritative run-step over the stale log line - which is exactly what a catch-up report needs.
+   - Open PRs awaiting the captain's merge, via `gh-axi` per repo touched by in-flight or recent tasks.
+     A PR-based ship task records `pr=` in `state/<id>.meta`; collect those repos, list their open PRs, and cross-reference each task's recorded PR.
+   - Recent scout deliverables at `data/<id>/report.md` and any planning docs the captain should pick up from.
+   - Pending human decisions (needs-decision findings), needed credentials or logins (such as an SSO re-auth), and date-gated queued items.
+     A queued item only becomes "next work" when its blocker is gone and its time/date gate has arrived; until then it stays queued with the reason.
+
+2. **Compose the report with these sections, matching the worked example's structure, tone, and level of detail.**
+   The exemplar is `data/status-report-2026-07-06.md` in this home's `data/` when present; match its scannability, not a raw state dump.
+   - **Title** - `# Bearings - <day> <YYYY-MM-DD>` (the exemplar used "Morning status" for a morning brief; use that phrasing when the captain specifically asks for a morning brief).
+   - **TL;DR** - two or three sentences framing where things stand.
+   - **Check first** - anything likely waiting on the captain: a PR to merge, a needed credential or login, or anything blocking pickup, each PR with the full `https://...` URL, never a bare `#number`.
+   - **Landed** since the captain last worked - merged PRs, completed scouts, and finished local-only work, drawn from the Done section and recent merges.
+   - **In flight** now - each live direct report with its current state in one line; if nothing is in flight, say so plainly rather than omitting the section.
+   - **Plans / main pickup points** - pointers to the relevant `data/<id>/report.md` files and any Lavish boards (`.lavish/*.html`) the captain should reopen.
+   - **Decisions pending** from the captain - relayed verbatim from needs-decision findings, with options where the crewmate offered them.
+   - **Date-gated / queued** next work - queued items whose blocker is gone and whose gate has arrived, plus anything still blocked with the reason.
+
+3. **Write the report to a dated file so it persists, and surface a concise version in chat.**
+   - Write the full report to `data/status-report-<YYYY-MM-DD>.md` using today's date.
+     This is the required artifact; it lives in gitignored `data/` alongside the worked example.
+     If the file already exists for today, overwrite it with the fresh snapshot rather than appending.
+   - Surface a concise version to the captain in chat - the TL;DR plus the "Check first" list - and point to the file for the full picture.
+   - For a richer review surface, optionally offer a Lavish board with `lavish-axi` when the report has enough structure to deserve one, but the markdown file is the required artifact and the chat summary is the required minimum.
+
+## Tone and content rules
+
+- This report is a private, captain-facing internal artifact that lives in gitignored `data/`, so unlike normal captain chat it MAY reference task ids, PR URLs, and repo names - the captain works with these directly and needs them to resume; keep it organized and scannable, not a raw dump.
+- Every PR reference is a full `https://...` URL, never a bare `#number`; a shorthand `#number` is fine only as a back-reference after the full URL has already appeared in the same report.
+- Never include PHI or secret values; the report is an operational artifact, but it is still subject to the same security and compliance rules that govern everything else in this fleet.
+
+## Supervision discipline
+
+This skill is read-mostly and changes no fleet state.
+Do not tear down a task, merge a PR, dispatch queued work, or mutate any `state/` or `data/` file other than the single report file as a side effect of generating the brief.
+If the state you read suggests an action - a PR ready to merge, a queued item whose gate has arrived, a needs-decision finding - name it in the report under "Check first" or "Date-gated / queued" and let the captain decide, rather than taking the action from inside this skill.

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Claude and grok use the slash form shown here; codex uses the same names with `$
 | Skill              | What it does                                                                                                                                  |
 | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
 | `/afk`             | Enter away-mode supervision: the sub-supervisor self-handles routine wakes in bash and escalates only captain-relevant events as one batched digest, cutting supervision cost while you step away |
+| `/bearings`        | Generate a "pick up where I left off" status report from live fleet state - backlog, per-task crew state, open PRs, scout reports, pending decisions, and date-gated queued work - written to a dated file in `data/` and surfaced concisely in chat; read-mostly, mutates no task state |
 | `/updatefirstmate` | Self-update the running firstmate and its secondmates to the latest from origin with fast-forward-only pulls, then re-read instructions and nudge secondmates |
 | `/stow`            | Sweep the session for uncaptured durable knowledge, route each finding to its disk home per AGENTS.md, file undone next steps to the backlog, and report what is now safe to reset |
 


### PR DESCRIPTION
## Intent

Create captain-invocable firstmate skill bearings (.agents/skills/bearings/SKILL.md) that generates a pick-up-where-I-left-off status report from live fleet state; the reusable version of data/status-report-2026-07-06.md. Procedure reads backlog, state/*.meta plus bin/fm-crew-state.sh per task (never a raw status-log tail), open PRs via gh-axi, scout reports, pending decisions and date-gated queued work; composes exemplar sections (TL;DR, Check first, Landed, In flight, Plans, Decisions pending, Date-gated/queued); writes data/status-report-DATE.md plus a concise chat summary, optional Lavish board. Deliberate constraints: create ONLY the skill file; do NOT edit AGENTS.md (captain-invocable skills are auto-discovered by the harness; concurrent crewmates edit AGENTS.md so a pointer would conflict and is not needed); no helper script - the report is agent composition work, not a deterministic script; renamed from morning-brief to bearings per captain. Read-mostly: must not tear down, merge, or mutate task state. Report is private captain-facing in gitignored data/ and may reference task ids, PR URLs, repo names; every PR a full https URL; no PHI or secrets. House style matches updatefirstmate and afk: user-invocable true, metadata internal true, one sentence per line, plain dash not em dash.

## What Changed

- Added `.agents/skills/bearings/SKILL.md`, a captain-invocable skill that composes a pick-up-where-I-left-off status report from live fleet state - reading the backlog, per-task `state/*.meta` reconciled via `bin/fm-crew-state.sh` (never a raw status-log tail), open PRs through `gh-axi`, scout reports, pending decisions, and date-gated queued work.
- The procedure writes a private report to `data/status-report-DATE.md` with exemplar sections (TL;DR, Check first, Landed, In flight, Plans, Decisions pending, Date-gated/queued) plus a concise chat summary and optional Lavish board, and is read-mostly (no teardown, merge, or task-state mutation), with every PR rendered as a full https URL.
- Listed the new `/bearings` skill in the README built-in skills table; frontmatter matches house style (`user-invocable: true`, `metadata.internal: true`) alongside `updatefirstmate` and `afk`.

## Risk Assessment

✅ Low: The change adds a single, self-contained, read-mostly documentation skill file that matches sibling-skill conventions and AGENTS.md invariants, references only existing or correctly-guarded resources, and introduces no executable code or product-behavior change.

## Testing

The configured e2e suite already passed at baseline, and this change adds only a markdown skill definition with no executable code, so the suite is unaffected. I validated the intent directly: the diff adds exactly the one skill file (no AGENTS.md edit, no helper script), the frontmatter and body follow the updatefirstmate/afk house style (user-invocable true, metadata.internal true, valid YAML, no em dashes, full https PR URLs), and the harness auto-discovers the skill. For product-level evidence I built a synthetic fleet state and drove the skill's own procedure end-to-end - `fm-crew-state.sh` correctly reported parked/done states via run-step reconciliation, and the composition produced a dated `data/status-report-2026-07-06.md` with all seven exemplar sections while mutating no task state. No visual surface is involved; the end-user artifact is the generated markdown report, which is captured below. All checks pass.

<details>
<summary>Evidence: Generated bearings report (end-to-end run of the skill procedure)</summary>

<code># Bearings - Monday 2026-07-06&#10;&#10;## TL;DR&#10;One login fix is parked waiting on a routing decision from you; the auth-flow audit finished and flagged a token-leak risk worth acting on.&#10;Nothing is merged-ready right now, and one queued item unblocks the moment the login fix lands.&#10;&#10;## Check first&#10;- Decision needed on the login fix before it can ship (see Decisions pending).&#10;- Auth audit surfaced refresh tokens logged at DEBUG - a security finding to triage.&#10;&#10;## Landed since you last worked&#10;- Cache warmup on deploy - https://github.com/acme/yourapp/pull/812 (merged 2026-07-05)&#10;- Header typo fix - https://github.com/acme/yourapp/pull/809 (merged 2026-07-04)&#10;&#10;## In flight now&#10;- fix-login-k3 (yourapp) - repairing the OAuth redirect; parked awaiting your decision. PR https://github.com/acme/yourapp/pull/815&#10;- audit-authflow-r4 (yourapp) - auth-flow audit; done, report ready.&#10;&#10;## Plans / main pickup points&#10;- Auth audit findings: data/audit-authflow-r4/report.md (refresh tokens logged at DEBUG in auth.py:212).&#10;&#10;## Decisions pending&#10;- fix-login-k3: keep the legacy /callback route or drop it?&#10;- (a) keep for back-compat&#10;- (b) drop and 301&#10;&#10;## Date-gated / queued&#10;- add-rate-limit-m8 (yourapp) - blocked-by fix-login-k3 (shares auth middleware); unblocks when the login fix lands.&#10;- rotate-certs-p2 (infra) - gated until 2026-07-10; not yet due.</code>

```text
# Bearings - Monday 2026-07-06

## TL;DR
One login fix is parked waiting on a routing decision from you; the auth-flow audit finished and flagged a token-leak risk worth acting on.
Nothing is merged-ready right now, and one queued item unblocks the moment the login fix lands.

## Check first
- Decision needed on the login fix before it can ship (see Decisions pending).
- Auth audit surfaced refresh tokens logged at DEBUG - a security finding to triage.

## Landed since you last worked
- Cache warmup on deploy - https://github.com/acme/yourapp/pull/812 (merged 2026-07-05)
- Header typo fix - https://github.com/acme/yourapp/pull/809 (merged 2026-07-04)

## In flight now
- fix-login-k3 (yourapp) - repairing the OAuth redirect; parked awaiting your decision. PR https://github.com/acme/yourapp/pull/815
- audit-authflow-r4 (yourapp) - auth-flow audit; done, report ready.

## Plans / main pickup points
- Auth audit findings: data/audit-authflow-r4/report.md (refresh tokens logged at DEBUG in auth.py:212).

## Decisions pending
- fix-login-k3: keep the legacy /callback route or drop it?
  - (a) keep for back-compat
  - (b) drop and 301

## Date-gated / queued
- add-rate-limit-m8 (yourapp) - blocked-by fix-login-k3 (shares auth middleware); unblocks when the login fix lands.
- rotate-certs-p2 (infra) - gated until 2026-07-10; not yet due.
```
</details>
<details>
<summary>Evidence: fm-crew-state.sh live-state reads driving the report (skill step 1)</summary>

```text
fix-login-k3 -> state: parked · source: status-log · keep legacy /callback route or drop it? options: (a) keep for back-compat, (b) drop and 301
audit-authflow-r4 -> state: done · source: status-log · report ready at data/audit-authflow-r4/report.md
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- <code>`git diff --name-status 678f2b5 7fea26f` confirmed exactly one added file (`.agents/skills/bearings/SKILL.md`) - no AGENTS.md edit, no helper script, matching the intent&#39;s deliberate constraints</code>
- <code>Compared frontmatter against sibling skills `updatefirstmate` and `afk`: `user-invocable: true` and `metadata.internal: true` match house style</code>
- <code>`grep -n &#34;—&#34;` on SKILL.md: no em dashes (plain-dash rule satisfied)</code>
- <code>Parsed the YAML frontmatter with `python3`/`yaml.safe_load` - valid, keys name/description/user-invocable/metadata</code>
- <code>Confirmed harness auto-discovery: `bearings` appears in the session&#39;s available-skills list, validating the intent&#39;s claim that no AGENTS.md pointer is needed</code>
- <code>Verified referenced tooling exists: `bin/fm-crew-state.sh`</code>
- <code>Built a synthetic fleet state (backlog with In flight/Queued/Done, meta+status for a parked ship task and a done scout, a scout report) and ran `FM_HOME=... bin/fm-crew-state.sh` per task - correctly surfaced `parked` (needs-decision with options) and `done` via the run-step/status-log reconciliation the skill mandates (not a raw tail)</code>
- <code>Executed the skill&#39;s compose+write procedure end-to-end, producing `data/status-report-2026-07-06.md` with all seven exemplar sections (TL;DR, Check first, Landed, In flight, Plans, Decisions pending, Date-gated/queued), each PR as a full https URL; confirmed read-mostly discipline held (only the single report file written, no state/ file mutated)</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
