### PR TITLE
feat(bin): encode project AGENTS.md authoring bar with canonical self-governance section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -354,6 +354,9 @@ Firstmate keeps project knowledge split by ownership.
 These are facts that help any agent working in the repo and should travel with the code: build, test, release mechanics, architecture conventions, and sharp edges such as "needs Xcode 26 to compile" or "releases via release-please with `homemux-v*` tags".
 This knowledge lives in the project's committed `AGENTS.md`.
 A project's `AGENTS.md` is the real file; `CLAUDE.md` is a symlink to it.
+A project's `AGENTS.md` is only for knowledge useful to almost every future session in that repo.
+Prefer a pointer to the authoritative file, command, or doc over repeating what the codebase already shows, and rewrite or prune stale entries instead of appending by default.
+The canonical self-governance wording for project `AGENTS.md` files lives in `bin/fm-ensure-agents-md.sh`; this section states the principle and points there.
 
 **Fleet and captain-private knowledge** belongs to firstmate.
 Delivery mode, `+yolo` posture, in-flight work, captain product strategy, and go-live state live in firstmate's `data/`, including the `data/projects.md` registry line and any planning docs.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -27,7 +27,10 @@
 # Ship briefs begin with a worktree-isolation assertion before the branch step.
 # Scout tasks ignore mode - their deliverable is a report, not a merge.
 # Ship tasks include a project-memory section so durable project-intrinsic
-# learnings can be committed to AGENTS.md through the project's delivery path.
+# learnings can be committed to AGENTS.md through the project's delivery path;
+# it carries the AGENTS.md authoring bar (widely useful knowledge only, pointers
+# over copied detail) and has the crewmate add the fm-ensure-agents-md.sh
+# self-governance section when a touched project AGENTS.md lacks it.
 # Refuses to overwrite an existing brief.
 set -eu
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -254,7 +254,9 @@ $RULE1
 
 # Project memory
 If \`AGENTS.md\` or \`CLAUDE.md\` already exists, or if this task produced durable project-intrinsic knowledge, run \`$FM_ROOT/bin/fm-ensure-agents-md.sh .\` in the worktree.
-If this task produced durable project-intrinsic knowledge, record it in \`AGENTS.md\` as part of your change.
+Record only project knowledge useful to almost every future session.
+For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
+If you touch a project \`AGENTS.md\` that lacks \`## Maintaining this file\`, add that short self-governance section from \`$FM_ROOT/bin/fm-ensure-agents-md.sh\` in the same pass.
 Keep it proportionate: skip \`AGENTS.md\` edits for trivial tasks that produced no durable project knowledge.
 
 $DOD

--- a/bin/fm-ensure-agents-md.sh
+++ b/bin/fm-ensure-agents-md.sh
@@ -36,6 +36,13 @@ write_skeleton() {
 This file is the project's committed home for project-intrinsic agent knowledge: build, test, release, architecture, and sharp-edge notes that should travel with the code.
 
 - Add durable project-specific notes here as they are discovered through real work.
+
+## Maintaining this file
+
+Keep this file for knowledge useful to almost every future agent session in this project.
+Do not repeat what the codebase already shows; point to the authoritative file or command instead.
+Prefer rewriting or pruning existing entries over appending new ones.
+When updating this file, preserve this bar for all agents and keep entries concise.
 EOF
 }
 

--- a/bin/fm-ensure-agents-md.sh
+++ b/bin/fm-ensure-agents-md.sh
@@ -44,8 +44,16 @@ ensure_maintenance_section() {
   if grep -Fqx '## Maintaining this file' "$AGENTS"; then
     return 0
   fi
+  sep=''
+  if [ -s "$AGENTS" ]; then
+    if [ -n "$(tail -c 1 "$AGENTS")" ]; then
+      sep=$'\n\n'
+    else
+      sep=$'\n'
+    fi
+  fi
   {
-    printf '\n'
+    printf '%s' "$sep"
     write_maintenance_section
   } >> "$AGENTS"
 }

--- a/bin/fm-ensure-agents-md.sh
+++ b/bin/fm-ensure-agents-md.sh
@@ -42,13 +42,12 @@ EOF
 
 ensure_maintenance_section() {
   if grep -Fqx '## Maintaining this file' "$AGENTS"; then
-    return 1
+    return 0
   fi
   {
     printf '\n'
     write_maintenance_section
   } >> "$AGENTS"
-  return 0
 }
 
 write_skeleton() {
@@ -59,7 +58,7 @@ This file is the project's committed home for project-intrinsic agent knowledge:
 
 - Add durable project-specific notes here as they are discovered through real work.
 EOF
-  ensure_maintenance_section || true
+  ensure_maintenance_section
 }
 
 is_correct_claude_symlink() {
@@ -124,7 +123,7 @@ fi
 if [ -e "$CLAUDE" ]; then
   if [ -f "$CLAUDE" ]; then
     mv "$CLAUDE" "$AGENTS"
-    ensure_maintenance_section || true
+    ensure_maintenance_section
     ln -s "$AGENTS" "$CLAUDE"
     echo "promoted: moved CLAUDE.md to AGENTS.md and symlinked CLAUDE.md -> AGENTS.md in $DIR"
     exit 0

--- a/bin/fm-ensure-agents-md.sh
+++ b/bin/fm-ensure-agents-md.sh
@@ -4,6 +4,9 @@
 # relative symlink to it for compatibility. Creates a minimal AGENTS.md skeleton
 # when neither file exists, promotes a real CLAUDE.md file when it is the only
 # file present, and refuses to clobber distinct real files or wrong symlinks.
+# Owns the canonical "## Maintaining this file" self-governance wording for
+# project AGENTS.md files, appending it to created skeletons and promoted
+# CLAUDE.md files that lack it.
 # This is a worktree utility for crewmates, not a supervision script, so it does
 # not call fm-guard.sh.
 # Usage: fm-ensure-agents-md.sh [repo-or-worktree-dir]

--- a/bin/fm-ensure-agents-md.sh
+++ b/bin/fm-ensure-agents-md.sh
@@ -29,14 +29,8 @@ cd "$DIR"
 AGENTS=AGENTS.md
 CLAUDE=CLAUDE.md
 
-write_skeleton() {
-  cat > "$AGENTS" <<'EOF'
-# Project agent memory
-
-This file is the project's committed home for project-intrinsic agent knowledge: build, test, release, architecture, and sharp-edge notes that should travel with the code.
-
-- Add durable project-specific notes here as they are discovered through real work.
-
+write_maintenance_section() {
+  cat <<'EOF'
 ## Maintaining this file
 
 Keep this file for knowledge useful to almost every future agent session in this project.
@@ -44,6 +38,28 @@ Do not repeat what the codebase already shows; point to the authoritative file o
 Prefer rewriting or pruning existing entries over appending new ones.
 When updating this file, preserve this bar for all agents and keep entries concise.
 EOF
+}
+
+ensure_maintenance_section() {
+  if grep -Fqx '## Maintaining this file' "$AGENTS"; then
+    return 1
+  fi
+  {
+    printf '\n'
+    write_maintenance_section
+  } >> "$AGENTS"
+  return 0
+}
+
+write_skeleton() {
+  cat > "$AGENTS" <<'EOF'
+# Project agent memory
+
+This file is the project's committed home for project-intrinsic agent knowledge: build, test, release, architecture, and sharp-edge notes that should travel with the code.
+
+- Add durable project-specific notes here as they are discovered through real work.
+EOF
+  ensure_maintenance_section || true
 }
 
 is_correct_claude_symlink() {
@@ -108,6 +124,7 @@ fi
 if [ -e "$CLAUDE" ]; then
   if [ -f "$CLAUDE" ]; then
     mv "$CLAUDE" "$AGENTS"
+    ensure_maintenance_section || true
     ln -s "$AGENTS" "$CLAUDE"
     echo "promoted: moved CLAUDE.md to AGENTS.md and symlinked CLAUDE.md -> AGENTS.md in $DIR"
     exit 0

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -180,6 +180,7 @@ The watcher, wake queue, arm wrapper, and afk daemon are unchanged; X mode is la
 
 Durable project-intrinsic agent knowledge lives in each project's committed `AGENTS.md`, with `CLAUDE.md` as a symlink.
 Ship briefs prompt crewmates to create or update those files through the normal delivery path; `data/projects.md` stays a thin private registry.
+Each project `AGENTS.md` carries a short `## Maintaining this file` self-governance section; `bin/fm-ensure-agents-md.sh` owns the canonical wording and appends it when creating the skeleton or promoting an existing `CLAUDE.md`.
 The full ownership rule - what is project-intrinsic versus fleet-private, and how firstmate keeps the two apart without writing into project clones - is owned by firstmate's operating manual in [`AGENTS.md`](../AGENTS.md) (project memory ownership).
 
 ## Operational memory routing

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -12,7 +12,7 @@ If you have changed away from the firstmate home in an interactive shell, invoke
 | `fm-update.sh`           | Self-update the running firstmate repo and registered secondmate homes with fast-forward-only pulls from origin     |
 | `fm-backlog-handoff.sh`  | Move already-judged in-scope queued backlog items from the main home into a seeded secondmate home                 |
 | `fm-brief.sh`            | Scaffold a ship brief with a worktree-isolation assertion, a report-only scout brief with `--scout`, or a secondmate charter with `--secondmate` |
-| `fm-ensure-agents-md.sh` | Ensure project `AGENTS.md` is the real memory file and `CLAUDE.md` symlinks to it                                   |
+| `fm-ensure-agents-md.sh` | Ensure project `AGENTS.md` is the real memory file and `CLAUDE.md` symlinks to it; owns the canonical `## Maintaining this file` self-governance wording and appends it when creating the skeleton or promoting a real `CLAUDE.md` |
 | `fm-guard.sh`            | Warn when the primary checkout is tangled, when queued wakes are pending, or when a stale or missing watcher needs a prominent banner; `FM_GUARD_READ_ONLY=1` keeps the alarms but suppresses drain, arm, and checkout repair commands |
 | `fm-turnend-guard.sh`    | Claude Code Stop hook, primary-scoped only: blocks (exit 2, exact reason) a primary turn end when work is in flight without a live identity-matched watcher lock and fresh beacon, using Claude Code's own `stop_hook_active` field so it never blocks twice in one turn (docs/turnend-guard.md) |
 | `fm-home-seed.sh`        | Lease/provision a secondmate home transactionally, clone projects, initialize gates, and maintain `data/secondmates.md` |

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -76,6 +76,24 @@ test_no_mistakes_dod_wording() {
   pass "fm-brief.sh: no-mistakes DOD wording avoids the apostrophe regression"
 }
 
+test_ship_project_memory_wording() {
+  local home id brief
+  home="$TMP_ROOT/project-memory-home"
+  mkdir -p "$home/data"
+  id="brief-memory-c1"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_present "$brief" "brief was not scaffolded"
+  assert_grep "Record only project knowledge useful to almost every future session." "$brief" \
+    "project-memory contract lost the durable-knowledge bar"
+  assert_grep "prefer a pointer to the authoritative file, command, or doc over copying the detail" "$brief" \
+    "project-memory contract lost pointer-over-copy guidance"
+  assert_grep "lacks \`## Maintaining this file\`, add that short self-governance section" "$brief" \
+    "project-memory contract lost the self-governance add-in-same-pass rule"
+  pass "fm-brief.sh: ship project-memory wording carries the AGENTS.md authoring bar"
+}
+
 test_script_parses
 test_ship_modes_generate_clean_briefs
 test_no_mistakes_dod_wording
+test_ship_project_memory_wording

--- a/tests/fm-ensure-agents-md.test.sh
+++ b/tests/fm-ensure-agents-md.test.sh
@@ -50,5 +50,20 @@ EOF
   pass "fm-ensure-agents-md.sh: promoted CLAUDE.md includes self-governance section"
 }
 
+test_promoted_claude_md_without_trailing_newline_keeps_blank_separator() {
+  local repo agents before
+  repo="$TMP_ROOT/no-trailing-newline-project"
+  mkdir -p "$repo"
+  printf '# Existing agent memory\n\nRun tests with make test.' > "$repo/CLAUDE.md"
+  "$ROOT/bin/fm-ensure-agents-md.sh" "$repo" >/dev/null 2>&1 || fail "fm-ensure-agents-md.sh failed for newline-less CLAUDE.md promotion"
+  agents="$repo/AGENTS.md"
+  assert_grep "Run tests with make test." "$agents" \
+    "newline-less promotion lost or mangled the last content line"
+  before=$(grep -B1 -Fx '## Maintaining this file' "$agents" | head -n 1)
+  [ -z "$before" ] || fail "self-governance heading not preceded by a blank line (got: $before)"
+  pass "fm-ensure-agents-md.sh: newline-less promotion keeps a blank separator line"
+}
+
 test_created_agents_md_includes_self_governance
 test_promoted_claude_md_includes_self_governance
+test_promoted_claude_md_without_trailing_newline_keeps_blank_separator

--- a/tests/fm-ensure-agents-md.test.sh
+++ b/tests/fm-ensure-agents-md.test.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Behavior tests for bin/fm-ensure-agents-md.sh.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-ensure-agents-md)
+
+test_created_agents_md_includes_self_governance() {
+  local repo agents
+  repo="$TMP_ROOT/new-project"
+  mkdir -p "$repo"
+  "$ROOT/bin/fm-ensure-agents-md.sh" "$repo" >/dev/null 2>&1 || fail "fm-ensure-agents-md.sh failed for empty project"
+  agents="$repo/AGENTS.md"
+  assert_present "$agents" "AGENTS.md was not created"
+  assert_present "$repo/CLAUDE.md" "CLAUDE.md symlink was not created"
+  [ -L "$repo/CLAUDE.md" ] || fail "CLAUDE.md is not a symlink"
+  assert_grep "## Maintaining this file" "$agents" "self-governance section heading missing"
+  assert_grep "Keep this file for knowledge useful to almost every future agent session in this project." "$agents" \
+    "self-governance section lost the future-session bar"
+  assert_grep "Do not repeat what the codebase already shows; point to the authoritative file or command instead." "$agents" \
+    "self-governance section lost pointer-over-copy guidance"
+  assert_grep "Prefer rewriting or pruning existing entries over appending new ones." "$agents" \
+    "self-governance section lost rewrite-or-prune guidance"
+  assert_grep "When updating this file, preserve this bar for all agents and keep entries concise." "$agents" \
+    "self-governance section lost all-agents maintenance guidance"
+  pass "fm-ensure-agents-md.sh: created AGENTS.md includes self-governance section"
+}
+
+test_created_agents_md_includes_self_governance

--- a/tests/fm-ensure-agents-md.test.sh
+++ b/tests/fm-ensure-agents-md.test.sh
@@ -59,6 +59,8 @@ test_promoted_claude_md_without_trailing_newline_keeps_blank_separator() {
   agents="$repo/AGENTS.md"
   assert_grep "Run tests with make test." "$agents" \
     "newline-less promotion lost or mangled the last content line"
+  assert_grep "## Maintaining this file" "$agents" \
+    "newline-less promotion did not append the self-governance section"
   before=$(grep -B1 -Fx '## Maintaining this file' "$agents" | head -n 1)
   [ -z "$before" ] || fail "self-governance heading not preceded by a blank line (got: $before)"
   pass "fm-ensure-agents-md.sh: newline-less promotion keeps a blank separator line"

--- a/tests/fm-ensure-agents-md.test.sh
+++ b/tests/fm-ensure-agents-md.test.sh
@@ -28,4 +28,27 @@ test_created_agents_md_includes_self_governance() {
   pass "fm-ensure-agents-md.sh: created AGENTS.md includes self-governance section"
 }
 
+test_promoted_claude_md_includes_self_governance() {
+  local repo agents count
+  repo="$TMP_ROOT/claude-project"
+  mkdir -p "$repo"
+  cat > "$repo/CLAUDE.md" <<'EOF'
+# Existing agent memory
+
+Run tests with `make test`.
+EOF
+  "$ROOT/bin/fm-ensure-agents-md.sh" "$repo" >/dev/null 2>&1 || fail "fm-ensure-agents-md.sh failed for CLAUDE.md promotion"
+  agents="$repo/AGENTS.md"
+  assert_present "$agents" "AGENTS.md was not created during promotion"
+  [ -L "$repo/CLAUDE.md" ] || fail "CLAUDE.md is not a symlink after promotion"
+  assert_grep "Run tests with \`make test\`." "$agents" \
+    "promotion lost existing CLAUDE.md content"
+  count=$(grep -Fc "## Maintaining this file" "$agents")
+  [ "$count" -eq 1 ] || fail "promotion wrote $count self-governance sections"
+  assert_grep "Keep this file for knowledge useful to almost every future agent session in this project." "$agents" \
+    "promoted AGENTS.md missing self-governance wording"
+  pass "fm-ensure-agents-md.sh: promoted CLAUDE.md includes self-governance section"
+}
+
 test_created_agents_md_includes_self_governance
+test_promoted_claude_md_includes_self_governance


### PR DESCRIPTION
## Intent

Encode the captain's 2026-07-06 AGENTS.md authoring bar into firstmate's shared tracked surfaces so every firstmate user inherits it. The intended contract is that project AGENTS.md files are only for knowledge useful to almost every future session, should not repeat details already discoverable from the codebase except as pointers to authoritative files or commands, should prefer rewriting or pruning over appending, and should instruct all agents how to maintain that bar. Keep the canonical short self-governance wording in bin/fm-ensure-agents-md.sh as the one owner, update bin/fm-brief.sh so ship briefs tell crewmates to apply the bar and add the self-governance section when touching project AGENTS.md files that lack it, and add only a concise principle plus pointer in shared AGENTS.md section 6. Extend colocated tests for fm-ensure-agents-md.sh and fm-brief.sh, keep additions tight, preserve one-sentence-per-line tracked Markdown and plain dashes, and ensure bin/*.sh, bin/backends/*.sh, and tests/*.sh pass shellcheck. This run includes the no-mistakes review fix that promotes existing CLAUDE.md files with the same canonical maintenance section instead of limiting the wording to newly created AGENTS.md files.

## What Changed

- `bin/fm-ensure-agents-md.sh` now owns the canonical `## Maintaining this file` self-governance wording for project `AGENTS.md` files, appending it when creating the skeleton and when promoting an existing `CLAUDE.md`; the append is idempotent (already-present sections succeed as a no-op) and inserts a blank-line separator even when the promoted file lacks a trailing newline.
- `bin/fm-brief.sh` ship briefs' Project memory section now states the authoring bar - record only knowledge useful to almost every future session, prefer pointers to authoritative files or commands over copied detail - and instructs crewmates to add the self-governance section from `fm-ensure-agents-md.sh` when a touched project `AGENTS.md` lacks it.
- Shared `AGENTS.md` section 6, `docs/architecture.md`, and `docs/scripts.md` record the principle and point to the script as the one owner of the wording; new colocated tests cover skeleton creation, CLAUDE.md promotion, the newline-less separator case (asserting the heading is actually present), and the new ship-brief wording.

## Risk Assessment

✅ Low: Well-bounded additive change (docs, one idempotent newline-safe script function, brief wording, colocated tests) already hardened through three review-fix rounds, with no remaining correctness, security, or behavioral risks found.

## Testing

Baseline full test suite passed before this run; I re-ran the two colocated test files for the changed scripts (7 tests, all green) and then exercised the change the way a crewmate would experience it, capturing CLI transcripts: fm-ensure-agents-md.sh creates AGENTS.md with the canonical "## Maintaining this file" section, promotes an existing CLAUDE.md with the section appended (including the newline-less edge case with a proper blank-line separator), and is idempotent on re-run; a freshly scaffolded ship brief carries the authoring-bar and add-the-section-if-lacking wording; and shared AGENTS.md section 6 contains the principle plus pointer. No visual artifact applies since this is a CLI/markdown-contract change with no rendered UI surface; transcripts are the product-level evidence. No failures found.

<details>
<summary>Evidence: fm-ensure-agents-md.sh E2E transcript (create, promote, newline-less separator, idempotency)</summary>

```text
=== E2E demo: bin/fm-ensure-agents-md.sh AGENTS.md authoring bar ===

--- Case 1: empty project (no AGENTS.md, no CLAUDE.md) ---
$ fm-ensure-agents-md.sh /tmp/fm-agents-bar-demo.P4wMh4/new-project
created: AGENTS.md and CLAUDE.md -> AGENTS.md in /private/tmp/fm-agents-bar-demo.P4wMh4/new-project

$ ls -l new-project
total 8
-rw-r--r--@ 1 kunchen  wheel  651 Jul  6 19:20 AGENTS.md
lrwxr-xr-x@ 1 kunchen  wheel    9 Jul  6 19:20 CLAUDE.md -> AGENTS.md

$ cat new-project/AGENTS.md
# Project agent memory

This file is the project's committed home for project-intrinsic agent knowledge: build, test, release, architecture, and sharp-edge notes that should travel with the code.

- Add durable project-specific notes here as they are discovered through real work.

## Maintaining this file

Keep this file for knowledge useful to almost every future agent session in this project.
Do not repeat what the codebase already shows; point to the authoritative file or command instead.
Prefer rewriting or pruning existing entries over appending new ones.
When updating this file, preserve this bar for all agents and keep entries concise.

--- Case 2: existing hand-written CLAUDE.md gets promoted WITH the maintenance section ---
$ cat claude-project/CLAUDE.md (before)
# Existing agent memory

Run tests with `make test`.

$ fm-ensure-agents-md.sh /tmp/fm-agents-bar-demo.P4wMh4/claude-project
promoted: moved CLAUDE.md to AGENTS.md and symlinked CLAUDE.md -> AGENTS.md in /private<scratch>/claude-project

$ ls -l claude-project
total 8
-rw-r--r--@ 1 kunchen  wheel  423 Jul  6 19:20 AGENTS.md
lrwxr-xr-x@ 1 kunchen  wheel    9 Jul  6 19:20 CLAUDE.md -> AGENTS.md

$ cat claude-project/AGENTS.md (after promotion)
# Existing agent memory

Run tests with `make test`.

## Maintaining this file

Keep this file for knowledge useful to almost every future agent session in this project.
Do not repeat what the codebase already shows; point to the authoritative file or command instead.
Prefer rewriting or pruning existing entries over appending new ones.
When updating this file, preserve this bar for all agents and keep entries concise.

--- Case 3: CLAUDE.md WITHOUT trailing newline still gets a clean blank-line separator ---
$ fm-ensure-agents-md.sh /tmp/fm-agents-bar-demo.P4wMh4/no-newline-project
promoted: moved CLAUDE.md to AGENTS.md and symlinked CLAUDE.md -> AGENTS.md in /private<scratch>/no-newline-project

$ cat no-newline-project/AGENTS.md
# Existing agent memory

Run tests with make test.

## Maintaining this file

Keep this file for knowledge useful to almost every future agent session in this project.
Do not repeat what the codebase already shows; point to the authoritative file or command instead.
Prefer rewriting or pruning existing entries over appending new ones.
When updating this file, preserve this bar for all agents and keep entries concise.

--- Case 4: idempotency - re-running on an already-promoted project keeps exactly one section ---
$ fm-ensure-agents-md.sh /tmp/fm-agents-bar-demo.P4wMh4/claude-project  (second run)
unchanged: AGENTS.md with CLAUDE.md -> AGENTS.md in /private<scratch>/claude-project
$ grep -c '## Maintaining this file' claude-project/AGENTS.md
1
```
</details>
<details>
<summary>Evidence: fm-brief.sh generated ship brief Project-memory section + shared AGENTS.md section 6 wording</summary>

```text
=== E2E demo: bin/fm-brief.sh ship brief carries the AGENTS.md authoring bar ===

$ FM_HOME=<scratch>/fmhome fm-brief.sh demo-task-x1 some-proj
warn: no registry at <scratch>/fmhome/data/projects.md; defaulting some-proj to no-mistakes off
scaffolded: <scratch>/fmhome/data/demo-task-x1/brief.md (ship, mode=no-mistakes; replace {TASK})

$ sed -n '/# Project memory/,/^$/p' <scratch>/fmhome/data/demo-task-x1/brief.md
# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `<FM_ROOT>/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `<FM_ROOT>/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.


=== Shared AGENTS.md section 6 principle + pointer (added lines in context) ===

$ grep -n -A2 'only for knowledge useful to almost every future session' AGENTS.md
357:A project's `AGENTS.md` is only for knowledge useful to almost every future session in that repo.
358-Prefer a pointer to the authoritative file, command, or doc over repeating what the codebase already shows, and rewrite or prune stale entries instead of appending by default.
359-The canonical self-governance wording for project `AGENTS.md` files lives in `bin/fm-ensure-agents-md.sh`; this section states the principle and points there.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (3) ✅</summary>

- ℹ️ `bin/fm-brief.sh:259` - The canonical self-governance section is auto-appended only on AGENTS.md creation and CLAUDE.md promotion; for an existing AGENTS.md that lacks it (the most common fleet case), the ship brief tells crewmates to hand-transcribe the wording from the script&#39;s heredoc. There is no script-side append or --print-section accessor for that path, so each manual transcription is a drift vector against the stated one-owner goal. Consider a flag that prints or appends the canonical section so crewmates never copy prose by hand.
- ℹ️ `bin/fm-ensure-agents-md.sh:45` - ensure_maintenance_section returns 1 when the section already exists, but no caller consumes that value - both call sites must add &#39;|| true&#39; to survive set -eu, and a future unguarded call would silently abort the script mid-flow on the benign already-present case. Returning 0 unconditionally removes the set -e trap and the &#39;|| true&#39; noise.

🔧 Fix: make ensure_maintenance_section idempotent-success, drop || true guards
1 info still open:
- ℹ️ `bin/fm-ensure-agents-md.sh:48` - When a promoted CLAUDE.md lacks a trailing newline, the appended section&#39;s `printf &#39;\n&#39;` only terminates the dangling last line, so the `## Maintaining this file` heading is glued directly to the previous content line with no blank separator (verified by running the script on such a file). Still parses as an ATX heading, but produces a malformed-looking committed file. Fix mechanically: if the file is non-empty and its last byte is not a newline, emit two newlines before the section instead of one.

🔧 Fix: separate appended maintenance section on newline-less CLAUDE.md promotion
1 info still open:
- ℹ️ `tests/fm-ensure-agents-md.test.sh:62` - The newline-less-promotion separator test passes vacuously if the maintenance section is never appended: when the heading is absent, `grep -B1 -Fx` produces no output, `before` is empty, and `[ -z &#34;$before&#34; ]` succeeds. Assert the heading is present (e.g. `assert_grep &#39;## Maintaining this file&#39; &#34;$agents&#34; ...`) before the blank-separator check so a section-not-appended regression on this path fails the test instead of slipping through.

🔧 Fix: assert maintenance heading present before separator check in test
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- <code>Baseline (pre-run): full suite `for t in tests/*.test.sh; do bash &#34;$t&#34;; done` passed</code>
- <code>`bash tests/fm-ensure-agents-md.test.sh` - 3 behavior tests for creation, promotion, and newline-less separator, all pass</code>
- <code>`bash tests/fm-brief.test.sh` - 4 tests including the new ship project-memory wording test, all pass</code>
- <code>Manual E2E: ran `bin/fm-ensure-agents-md.sh` against a fresh empty project - AGENTS.md created with the full `## Maintaining this file` section and CLAUDE.md symlink</code>
- `Manual E2E: ran it against a hand-written CLAUDE.md - promoted to AGENTS.md with original content preserved plus exactly one appended maintenance section`
- `Manual E2E: ran it against a CLAUDE.md with no trailing newline - blank-line separator inserted before the maintenance heading`
- <code>Manual E2E: re-ran on the promoted project - reports `unchanged`, section count stays 1 (idempotent)</code>
- <code>Manual E2E: scaffolded a real ship brief via `FM_HOME=&lt;tmp&gt; bin/fm-brief.sh demo-task-x1 some-proj` and inspected its `# Project memory` section for the authoring-bar and add-if-lacking wording</code>
- `Inspected shared AGENTS.md section 6 for the added principle and pointer lines (AGENTS.md:357-359)`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
