### PR TITLE
feat(usage): add fm-claude-usage.sh plan-window/overage reporter

### DIFF
--- a/bin/fm-claude-usage.sh
+++ b/bin/fm-claude-usage.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# fm-claude-usage.sh - report the Claude subscription plan's rate-limit state and
+# a routing verdict for the in-plan-vs-overage dispatch split.
+#
+# It reads the Claude Code OAuth access token, calls Anthropic's usage endpoint,
+# and reports whether the account is still inside its weekly plan window
+# (in-plan) or has reached the threshold where new usage spills into paid extra
+# usage (overage). Firstmate consults the verdict before dispatching an
+# Opus/Fable-tier task: in-plan routes that tier to Claude Code (plan-covered),
+# overage routes it to the Cursor-gateway fallback. The concrete per-tier
+# harness/model strings live in config/crew-dispatch.json, not here.
+#
+# The verdict is driven by the 7-day (weekly, all-models) window utilization,
+# which is where usage crosses into extra usage. The threshold is configurable:
+#   config/claude-plan-budget (a single integer percent), or
+#   FM_CLAUDE_WEEKLY_OVERAGE_PCT (env), default 95.
+#
+# Usage:
+#   fm-claude-usage.sh            one machine-readable line (default), exit-coded
+#   fm-claude-usage.sh --verdict  print only: in-plan | overage | unknown
+#   fm-claude-usage.sh --human    a readable summary with the window numbers
+#   fm-claude-usage.sh --json     the raw usage JSON from the endpoint
+#   fm-claude-usage.sh --refresh  bypass the response cache for this call
+#
+# Exit codes: 0 verdict in-plan, 10 verdict overage, 3 unknown (could not
+# determine - no credentials, endpoint error, or unparseable response). A caller
+# that only needs a safe boolean should treat any non-zero (overage OR unknown)
+# as "do not spend Claude overage - use the fallback".
+#
+# Token source, in order: $CLAUDE_CONFIG_DIR/.credentials.json (or
+# ~/.claude/.credentials.json) for a file-based install, else the macOS Keychain
+# generic password under service "Claude Code-credentials". The token is the
+# .claudeAiOauth.accessToken field. Claude Code keeps that token fresh; this
+# script never writes or refreshes credentials.
+#
+# Endpoint: GET https://api.anthropic.com/api/oauth/usage with the OAuth bearer
+# token and header "anthropic-beta: oauth-2025-04-20". See docs/claude-usage.md.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+
+USAGE_URL="${FM_CLAUDE_USAGE_URL:-https://api.anthropic.com/api/oauth/usage}"
+BETA_HEADER="anthropic-beta: oauth-2025-04-20"
+CACHE="$STATE/.claude-usage-cache.json"
+TTL="${FM_CLAUDE_USAGE_TTL:-60}"
+
+die_unknown() {
+  # Print the machine line (or bare verdict) for an indeterminate result and exit 3.
+  case "$MODE" in
+    verdict) printf 'unknown\n' ;;
+    json) printf '%s\n' "${1:-{\}}" ;;
+    human) printf 'Claude plan usage: UNKNOWN (%s)\n' "${2:-no detail}" ;;
+    *) printf 'state=unknown weekly= extra= reason=%s\n' "${2:-unknown}" ;;
+  esac
+  exit 3
+}
+
+# --- credentials ------------------------------------------------------------
+
+creds_json() {
+  local f="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/.credentials.json"
+  if [ -r "$f" ]; then
+    cat "$f"
+    return 0
+  fi
+  if command -v security >/dev/null 2>&1; then
+    security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null && return 0
+  fi
+  return 1
+}
+
+# --- threshold --------------------------------------------------------------
+
+resolve_threshold() {
+  local t="${FM_CLAUDE_WEEKLY_OVERAGE_PCT:-}"
+  if [ -z "$t" ] && [ -r "$CONFIG/claude-plan-budget" ]; then
+    t="$(grep -vE '^[[:space:]]*(#|$)' "$CONFIG/claude-plan-budget" 2>/dev/null | head -1 | tr -d '[:space:]')"
+  fi
+  [ -z "$t" ] && t=95
+  # Guard against a non-numeric config value.
+  case "$t" in
+    '' | *[!0-9.]*) t=95 ;;
+  esac
+  printf '%s' "$t"
+}
+
+# --- fetch (with short-TTL cache) -------------------------------------------
+
+cache_fresh() {
+  [ -s "$CACHE" ] || return 1
+  local now mtime age
+  now="$(date +%s)"
+  mtime="$(stat -f %m "$CACHE" 2>/dev/null || stat -c %Y "$CACHE" 2>/dev/null || echo 0)"
+  age=$((now - mtime))
+  [ "$age" -ge 0 ] && [ "$age" -lt "$TTL" ]
+}
+
+fetch_usage() {
+  # Echo the usage JSON body on success; return non-zero with a reason on stderr.
+  if [ "$REFRESH" -eq 0 ] && cache_fresh; then
+    cat "$CACHE"
+    return 0
+  fi
+  local token body http tmp
+  token="$(creds_json | jq -r '.claudeAiOauth.accessToken // empty' 2>/dev/null)"
+  if [ -z "$token" ]; then
+    echo "no-credentials" >&2
+    return 1
+  fi
+  tmp="$(mktemp "${TMPDIR:-/tmp}/fm-claude-usage.XXXXXX")" || {
+    echo "mktemp-failed" >&2
+    return 1
+  }
+  http="$(curl -sS --max-time 15 -o "$tmp" -w '%{http_code}' "$USAGE_URL" \
+    -H "Authorization: Bearer $token" -H "$BETA_HEADER" 2>/dev/null)" || {
+    rm -f "$tmp"
+    echo "curl-failed" >&2
+    return 1
+  }
+  if [ "$http" != "200" ]; then
+    rm -f "$tmp"
+    echo "api-$http" >&2
+    return 1
+  fi
+  if ! jq -e . "$tmp" >/dev/null 2>&1; then
+    rm -f "$tmp"
+    echo "bad-json" >&2
+    return 1
+  fi
+  mkdir -p "$STATE" 2>/dev/null || true
+  if mv "$tmp" "$CACHE" 2>/dev/null; then
+    cat "$CACHE"
+  else
+    cat "$tmp"
+    rm -f "$tmp"
+  fi
+  return 0
+}
+
+# --- main -------------------------------------------------------------------
+
+MODE=line
+REFRESH=0
+for arg in "$@"; do
+  case "$arg" in
+    --verdict) MODE=verdict ;;
+    --human) MODE=human ;;
+    --json) MODE=json ;;
+    --refresh) REFRESH=1 ;;
+    -h | --help)
+      sed -n '2,32p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "fm-claude-usage.sh: unknown argument: $arg" >&2
+      exit 2
+      ;;
+  esac
+done
+
+command -v jq >/dev/null 2>&1 || die_unknown '{}' "jq-not-installed"
+command -v curl >/dev/null 2>&1 || die_unknown '{}' "curl-not-installed"
+
+reason=""
+if ! body="$(fetch_usage 2>/tmp/fm-claude-usage-reason.$$)"; then
+  reason="$(cat /tmp/fm-claude-usage-reason.$$ 2>/dev/null)"
+  rm -f /tmp/fm-claude-usage-reason.$$
+  die_unknown '{}' "${reason:-fetch-failed}"
+fi
+rm -f /tmp/fm-claude-usage-reason.$$
+
+if [ "$MODE" = json ]; then
+  printf '%s\n' "$body"
+  exit 0
+fi
+
+# Weekly-all utilization: prefer the self-describing limits[] entry, fall back to
+# the flat seven_day field for older response shapes.
+weekly="$(printf '%s' "$body" | jq -r '
+  ((.limits // []) | map(select(.kind == "weekly_all")) | .[0].percent)
+  // .seven_day.utilization // empty' 2>/dev/null)"
+
+if [ -z "$weekly" ] || [ "$weekly" = null ]; then
+  die_unknown "$body" "no-weekly-window"
+fi
+
+extra_used="$(printf '%s' "$body" | jq -r '.extra_usage.used_credits // 0' 2>/dev/null)"
+extra_limit="$(printf '%s' "$body" | jq -r '.extra_usage.monthly_limit // 0' 2>/dev/null)"
+
+threshold="$(resolve_threshold)"
+
+# Float-safe comparison: overage when weekly >= threshold.
+verdict="$(awk -v w="$weekly" -v t="$threshold" 'BEGIN { print (w + 0 >= t + 0) ? "overage" : "in-plan" }')"
+
+case "$MODE" in
+  verdict)
+    printf '%s\n' "$verdict"
+    ;;
+  human)
+    printf 'Claude plan usage: %s\n' "$verdict"
+    printf '  weekly (7d, all models): %s%% (overage threshold %s%%)\n' "$weekly" "$threshold"
+    printf '  extra usage: %s / %s\n' "$extra_used" "$extra_limit"
+    ;;
+  *)
+    printf 'state=%s weekly=%s threshold=%s extra=%s/%s\n' \
+      "$verdict" "$weekly" "$threshold" "$extra_used" "$extra_limit"
+    ;;
+esac
+
+[ "$verdict" = overage ] && exit 10
+exit 0

--- a/docs/claude-usage.md
+++ b/docs/claude-usage.md
@@ -1,0 +1,84 @@
+# Claude plan usage reporting (`bin/fm-claude-usage.sh`)
+
+`bin/fm-claude-usage.sh` reports whether the Claude subscription plan is still inside its weekly window (in-plan) or has reached the point where new usage spills into paid extra usage (overage).
+It exists so a fleet that routes an Opus/Fable-tier task to Claude Code while in-plan can fall back to a paid gateway (for example the Cursor gateway) once the plan window is exhausted, instead of silently spending Claude overage.
+The routing policy that consumes the verdict is per-fleet and lives in local config (for this fleet, `config/crew-dispatch.json`); this tool only reports state.
+
+## Data source
+
+Claude Code does not persist the `/usage` window percentages to any local file.
+That data comes from Anthropic's OAuth usage endpoint, which returns the same numbers the `/usage` screen shows, including a dedicated extra-usage (overage) field.
+
+```
+GET https://api.anthropic.com/api/oauth/usage
+Authorization: Bearer <oauth-access-token>
+anthropic-beta: oauth-2025-04-20
+```
+
+The OAuth access token is the `.claudeAiOauth.accessToken` field of the Claude Code credentials.
+On a file-based install the credentials live at `$CLAUDE_CONFIG_DIR/.credentials.json` (default `~/.claude/.credentials.json`).
+On macOS they live in the login Keychain as a generic password under service `Claude Code-credentials`; the script reads it with `security find-generic-password -s "Claude Code-credentials" -w`.
+Claude Code keeps that token fresh (it refreshes roughly hourly while running); the script only reads the token and never writes or refreshes credentials.
+
+## Response shape
+
+The fields the tool reads:
+
+- `limits[]` - a self-describing array; the entry with `kind == "weekly_all"` carries the 7-day all-models window `percent` and `severity`.
+- `seven_day.utilization` - the flat 7-day utilization, used as a fallback when `limits[]` is absent.
+- `extra_usage` - `is_enabled`, `used_credits`, `monthly_limit`, and `utilization` for the overage budget (surfaced in output; not part of the verdict by default).
+
+## Verdict
+
+The verdict is driven by the 7-day (weekly, all-models) window utilization, because that is the window whose exhaustion pushes usage into extra usage.
+
+- `in-plan` - weekly utilization is below the overage threshold.
+- `overage` - weekly utilization is at or above the threshold.
+- `unknown` - the state could not be determined (no credentials, endpoint error, or an unparseable response).
+
+The threshold is the percentage at which the tool declares overage, so a fleet can glide off the plan just before it starts costing extra.
+It resolves from `FM_CLAUDE_WEEKLY_OVERAGE_PCT` (env), then `config/claude-plan-budget` (a single integer percent), then the default `95`.
+
+A caller that only needs a safe boolean should treat any non-zero exit (overage or unknown) as "do not spend Claude overage - use the fallback".
+
+## Output modes and exit codes
+
+| Invocation | Output | Exit |
+| --- | --- | --- |
+| `fm-claude-usage.sh` | `state=<verdict> weekly=<pct> threshold=<pct> extra=<used>/<limit>` | 0 in-plan, 10 overage, 3 unknown |
+| `fm-claude-usage.sh --verdict` | `in-plan` / `overage` / `unknown` | same |
+| `fm-claude-usage.sh --human` | readable summary with the window numbers | same |
+| `fm-claude-usage.sh --json` | the raw usage JSON from the endpoint | 0, or 3 on failure |
+| `fm-claude-usage.sh --refresh` | as default, bypassing the response cache | same |
+
+Responses are cached under `state/.claude-usage-cache.json` for `FM_CLAUDE_USAGE_TTL` seconds (default 60) so repeated dispatch-time checks do not hammer the endpoint.
+`--refresh` forces a fresh call.
+
+## Verification
+
+Verified 2026-07-07 against the live endpoint on macOS (token read from the login Keychain), Claude Max 20x plan.
+
+Live call returned the expected shape and the tool reported overage while the weekly window was full:
+
+```
+$ bin/fm-claude-usage.sh --human
+Claude plan usage: overage
+  weekly (7d, all models): 100% (overage threshold 95%)
+  extra usage: 90369.0 / 100000
+```
+
+The hermetic suite (`tests/fm-claude-usage.test.sh`) fakes `curl`, `security`, and the credentials file to cover in-plan, overage, config and env thresholds, missing credentials, endpoint error, the `seven_day` fallback shape, response caching plus `--refresh`, and the `--verdict`/`--json` modes.
+
+```
+$ bash tests/fm-claude-usage.test.sh
+ok - A in-plan below threshold -> state=in-plan exit 0
+ok - B weekly at 100% -> state=overage exit 10
+ok - C config/claude-plan-budget threshold honored
+ok - D FM_CLAUDE_WEEKLY_OVERAGE_PCT overrides config file
+ok - E missing credentials -> state=unknown exit 3
+ok - F non-200 endpoint -> state=unknown exit 3
+ok - G seven_day fallback used when limits[] absent
+ok - H response cached within TTL; --refresh bypasses it
+ok - I --verdict and --json modes
+# all fm-claude-usage tests passed
+```

--- a/tests/fm-claude-usage.test.sh
+++ b/tests/fm-claude-usage.test.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# tests/fm-claude-usage.test.sh - hermetic tests for fm-claude-usage.sh, the
+# Claude plan usage/overage reporter that drives the in-plan-vs-overage dispatch
+# split.
+#
+# Everything external is faked: `curl` is shimmed to return a canned usage JSON
+# body and a chosen HTTP code (no network), `security` is shimmed to fail (no
+# Keychain), and credentials come from a temp CLAUDE_CONFIG_DIR/.credentials.json
+# so the file path is exercised. jq/awk/date/stat are the real tools. The cache
+# and threshold config live under per-case FM_STATE_OVERRIDE / FM_CONFIG_OVERRIDE
+# dirs, so nothing touches the live home.
+#
+# Coverage:
+#   A) weekly below threshold -> state=in-plan, exit 0
+#   B) weekly at/above threshold -> state=overage, exit 10
+#   C) threshold from config/claude-plan-budget is honored
+#   D) FM_CLAUDE_WEEKLY_OVERAGE_PCT overrides the config file
+#   E) missing credentials -> state=unknown, exit 3
+#   F) non-200 endpoint -> state=unknown, exit 3
+#   G) limits[] weekly_all is preferred; seven_day is the fallback shape
+#   H) response cache: a second call within TTL does not re-invoke curl;
+#      --refresh forces a re-fetch
+#   I) --verdict and --json output modes
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SCRIPT="$ROOT/bin/fm-claude-usage.sh"
+TMP_ROOT=$(fm_test_tmproot fm-claude-usage)
+
+# Build a per-case sandbox: a fakebin with curl+security shims, a credentials
+# dir, and empty state/config override dirs. Echoes the case dir.
+make_case() {
+  local name=$1 body=$2 http=${3:-200} creds=${4:-yes}
+  local dir="$TMP_ROOT/$name"
+  local fakebin="$dir/fakebin"
+  mkdir -p "$fakebin" "$dir/state" "$dir/config" "$dir/cfgdir"
+  printf '%s' "$body" >"$dir/body.json"
+
+  cat >"$fakebin/curl" <<EOF
+#!/usr/bin/env bash
+[ -n "\${FAKE_CURL_COUNT:-}" ] && printf 'x' >>"\$FAKE_CURL_COUNT"
+out=""; prev=""
+for a in "\$@"; do [ "\$prev" = "-o" ] && out="\$a"; prev="\$a"; done
+[ -n "\$out" ] && cp "$dir/body.json" "\$out"
+printf '%s' "$http"
+EOF
+  chmod +x "$fakebin/curl"
+
+  # security shim: always fail, so the Keychain path yields nothing.
+  cat >"$fakebin/security" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+  chmod +x "$fakebin/security"
+
+  if [ "$creds" = yes ]; then
+    printf '%s' '{"claudeAiOauth":{"accessToken":"sk-fake-token"}}' >"$dir/cfgdir/.credentials.json"
+  fi
+  printf '%s\n' "$dir"
+}
+
+# Run the script in a case sandbox. Extra env assignments come as KEY=VAL args
+# after the mode flag.
+run_case() {
+  local dir=$1 flag=$2
+  shift 2
+  env -i \
+    PATH="$dir/fakebin:$PATH" \
+    HOME="$dir" \
+    CLAUDE_CONFIG_DIR="$dir/cfgdir" \
+    FM_STATE_OVERRIDE="$dir/state" \
+    FM_CONFIG_OVERRIDE="$dir/config" \
+    "$@" \
+    bash "$SCRIPT" ${flag:+"$flag"}
+}
+
+OVERAGE_BODY='{"seven_day":{"utilization":100.0},"limits":[{"kind":"weekly_all","percent":100}],"extra_usage":{"used_credits":90000,"monthly_limit":100000}}'
+INPLAN_BODY='{"seven_day":{"utilization":40.0},"limits":[{"kind":"weekly_all","percent":40}],"extra_usage":{"used_credits":0,"monthly_limit":100000}}'
+FALLBACK_BODY='{"seven_day":{"utilization":42.0},"extra_usage":{"used_credits":0,"monthly_limit":100000}}'
+
+# A) in-plan
+test_inplan() {
+  local dir out rc
+  dir=$(make_case inplan "$INPLAN_BODY")
+  out=$(run_case "$dir" "") ; rc=$?
+  case "$out" in *"state=in-plan"*) : ;; *) fail "A in-plan: unexpected line: $out" ;; esac
+  [ "$rc" -eq 0 ] || fail "A in-plan: expected exit 0, got $rc"
+  pass "A in-plan below threshold -> state=in-plan exit 0"
+}
+
+# B) overage
+test_overage() {
+  local dir out rc
+  dir=$(make_case overage "$OVERAGE_BODY")
+  out=$(run_case "$dir" "") ; rc=$?
+  case "$out" in *"state=overage"*) : ;; *) fail "B overage: unexpected line: $out" ;; esac
+  [ "$rc" -eq 10 ] || fail "B overage: expected exit 10, got $rc"
+  pass "B weekly at 100% -> state=overage exit 10"
+}
+
+# C) threshold from config file (set 30 -> weekly 40 becomes overage)
+test_config_threshold() {
+  local dir out
+  dir=$(make_case cfgthresh "$INPLAN_BODY")
+  printf '30\n' >"$dir/config/claude-plan-budget"
+  out=$(run_case "$dir" "")
+  case "$out" in *"state=overage"*"threshold=30"*) : ;; *) fail "C config threshold: $out" ;; esac
+  pass "C config/claude-plan-budget threshold honored"
+}
+
+# D) env overrides config
+test_env_overrides_config() {
+  local dir out
+  dir=$(make_case envthresh "$INPLAN_BODY")
+  printf '30\n' >"$dir/config/claude-plan-budget"
+  out=$(run_case "$dir" "" FM_CLAUDE_WEEKLY_OVERAGE_PCT=50)
+  case "$out" in *"state=in-plan"*"threshold=50"*) : ;; *) fail "D env override: $out" ;; esac
+  pass "D FM_CLAUDE_WEEKLY_OVERAGE_PCT overrides config file"
+}
+
+# E) no credentials -> unknown
+test_no_creds() {
+  local dir out rc
+  dir=$(make_case nocreds "$INPLAN_BODY" 200 no)
+  out=$(run_case "$dir" "") ; rc=$?
+  case "$out" in *"state=unknown"*"no-credentials"*) : ;; *) fail "E no-creds line: $out" ;; esac
+  [ "$rc" -eq 3 ] || fail "E no-creds: expected exit 3, got $rc"
+  pass "E missing credentials -> state=unknown exit 3"
+}
+
+# F) endpoint error -> unknown
+test_api_error() {
+  local dir out rc
+  dir=$(make_case apierr "$INPLAN_BODY" 401)
+  out=$(run_case "$dir" "") ; rc=$?
+  case "$out" in *"state=unknown"*"api-401"*) : ;; *) fail "F api-error line: $out" ;; esac
+  [ "$rc" -eq 3 ] || fail "F api-error: expected exit 3, got $rc"
+  pass "F non-200 endpoint -> state=unknown exit 3"
+}
+
+# G) fallback to seven_day when limits[] absent
+test_fallback_shape() {
+  local dir out
+  dir=$(make_case fallback "$FALLBACK_BODY")
+  out=$(run_case "$dir" "" FM_CLAUDE_WEEKLY_OVERAGE_PCT=95)
+  case "$out" in *"state=in-plan"*"weekly=42"*) : ;; *) fail "G fallback shape: $out" ;; esac
+  pass "G seven_day fallback used when limits[] absent"
+}
+
+# H) cache: 2 calls -> 1 curl; --refresh forces a second
+test_cache() {
+  local dir n
+  dir=$(make_case cache "$INPLAN_BODY")
+  local counter="$dir/curlcount"
+  run_case "$dir" "" FAKE_CURL_COUNT="$counter" FM_CLAUDE_USAGE_TTL=300 >/dev/null
+  run_case "$dir" "" FAKE_CURL_COUNT="$counter" FM_CLAUDE_USAGE_TTL=300 >/dev/null
+  n=$(wc -c <"$counter" | tr -d ' ')
+  [ "$n" -eq 1 ] || fail "H cache: expected 1 curl call, got $n"
+  run_case "$dir" --refresh FAKE_CURL_COUNT="$counter" FM_CLAUDE_USAGE_TTL=300 >/dev/null
+  n=$(wc -c <"$counter" | tr -d ' ')
+  [ "$n" -eq 2 ] || fail "H cache: --refresh should re-fetch, count=$n"
+  pass "H response cached within TTL; --refresh bypasses it"
+}
+
+# I) output modes
+test_output_modes() {
+  local dir out
+  dir=$(make_case modes "$OVERAGE_BODY")
+  out=$(run_case "$dir" --verdict)
+  [ "$out" = overage ] || fail "I --verdict: got '$out'"
+  out=$(run_case "$dir" --json)
+  case "$out" in *'"weekly_all"'*'"extra_usage"'*) : ;; *) fail "I --json passthrough: $out" ;; esac
+  pass "I --verdict and --json modes"
+}
+
+test_inplan
+test_overage
+test_config_threshold
+test_env_overrides_config
+test_no_creds
+test_api_error
+test_fallback_shape
+test_cache
+test_output_modes
+
+echo "# all fm-claude-usage tests passed"


### PR DESCRIPTION
## What

Adds `bin/fm-claude-usage.sh`, a reporter for the Claude subscription plan's rate-limit state, so dispatch can route an Opus/Fable-tier task to Claude Code while the plan is in-window and fall back to a paid gateway once the weekly window is exhausted - instead of silently spending Claude overage.

## Why

Claude Code never persists the `/usage` window percentages locally; that data lives only in Anthropic's OAuth usage endpoint (`GET /api/oauth/usage`, `anthropic-beta: oauth-2025-04-20`). This wraps that endpoint into a small, cached, machine-readable verdict a fleet can consult before dispatch. The per-fleet routing policy that consumes the verdict stays in local config; this tool only reports state.

## Behavior

- Verdict from the 7-day all-models window: `in-plan` / `overage` / `unknown`.
- Threshold resolves `FM_CLAUDE_WEEKLY_OVERAGE_PCT` -> `config/claude-plan-budget` -> default `95`.
- Token read from `CLAUDE_CONFIG_DIR/.credentials.json` or the macOS Keychain (`Claude Code-credentials`); never writes/refreshes credentials.
- Responses cached under `state/.claude-usage-cache.json` for `FM_CLAUDE_USAGE_TTL` (default 60s); `--refresh` bypasses.
- Modes: default machine line, `--verdict`, `--human`, `--json`. Exit 0 in-plan / 10 overage / 3 unknown.

## Tests / evidence

- `shellcheck bin/*.sh bin/backends/*.sh tests/*.sh` clean.
- Colocated hermetic `tests/fm-claude-usage.test.sh` (fakes curl/security/credentials) - 9/9 pass.
- Live-verified against the real endpoint; see `docs/claude-usage.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)