### PR TITLE
feat(harness): add Kimi CLI as a verified crewmate harness

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -192,3 +192,21 @@ The hook reads `$GROK_WORKSPACE_ROOT`, which is always set for hooks and equals 
 This keeps the hook outside the worktree, needs no trust grant, and writes only firstmate-owned files.
 `fm-teardown` removes the worktree pointer before returning a pooled worktree.
 Secondmate spawns skip the pointer (idle panes are healthy, no stale-pane detection for them).
+
+## kimi / kimi-cli (VERIFIED 2026-06-28)
+
+| Fact | Value |
+|---|---|
+| Launch binary | `kimi-cli` |
+| Launch flags | `--afk --print --mcp-config-file <empty-config> --prompt "$(cat <brief>)"` |
+| Busy-pane signature | `TurnBegin(...)` / `StepBegin(n=...)` output streaming; idle when shell prompt returns |
+| Exit command | n/a (exits automatically when the prompt finishes) |
+| Interrupt | Ctrl-C in the pane, or `tmux send-keys C-c` |
+| Turn-end signal | `fm-spawn` appends `; touch <turnend>` to the launch command; marker written after `kimi-cli` exits |
+
+Kimi CLI runs the prompt in non-interactive `--print` mode and exits once it believes the task is done.
+`--afk` auto-dismisses `AskUserQuestion` and auto-approves tool calls, so the crewmate can run unattended.
+`--mcp-config-file` is pointed at an empty MCP config to prevent a broken server in the user's default `~/.kimi/mcp.json` from blocking launch; the agent still has the built-in shell and file tools.
+If you want Stripe / Playwright / Umami MCP tools available, fix or remove the broken server in `~/.kimi/mcp.json` first, then update `config/kimi-empty-mcp.json` or remove the `--mcp-config-file` override.
+
+Firstmate detects the current harness as `kimi` when the process ancestry contains `kimi`, `kimi-cli`, or `kimi-code`.

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -45,6 +45,7 @@ detect_own() {
       *opencode*) echo opencode; return ;;
       *grok*) echo grok; return ;;
       pi) echo pi; return ;;
+      kimi|kimi-cli|kimi-code) echo kimi; return ;;
       node*|python*)
         # Bare interpreter: match the harness name in its script path.
         args=$(ps -o args= -p "$pid" 2>/dev/null)
@@ -54,6 +55,7 @@ detect_own() {
           *opencode*) echo opencode; return ;;
           *grok*) echo grok; return ;;
           *" pi "*|*/pi) echo pi; return ;;
+          *kimi-cli*|*/kimi-cli|*kimi-code*|*/kimi-code) echo kimi; return ;;
         esac ;;
     esac
     pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -33,7 +33,7 @@
 #   profile consultation. A --secondmate spawn is exempt and resolves the SECONDMATE
 #   harness (config/secondmate-harness -> config/crew-harness -> own), so the
 #   secondmate-vs-crewmate split is DURABLE across every respawn (recovery,
-#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|grok)
+#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|grok|kimi)
 #   overrides it for this spawn (either kind). A non-flag string containing
 #   whitespace is treated as a RAW launch command - the escape hatch for verifying
 #   new adapters.
@@ -268,7 +268,7 @@ FIRSTMATE_HOME=
 
 if [ "$KIND" = secondmate ]; then
   case "${POS[1]:-}" in
-    ''|claude|codex|opencode|pi|grok)
+    ''|claude|codex|opencode|pi|grok|kimi)
       ARG3=${POS[1]:-}
       ;;
     *' '*)
@@ -329,6 +329,13 @@ launch_template() {
     # launch command - it is a Stop-event hook installed below (global hook +
     # per-task pointer), so the template is identical for ship/scout/secondmate.
     grok) printf '%s' 'grok --always-approve __MODELFLAG____EFFORTFLAG__"$(cat __BRIEF__)"' ;;
+    kimi)
+      # kimi-cli --afk --print runs the prompt non-interactively and exits when done.
+      # --mcp-config-file points to an empty MCP config so a broken server in the user's
+      # default ~/.kimi/mcp.json cannot block launch; the agent still has the built-in shell
+      # and file tools. The trailing '; touch __TURNEND__' signals the watcher after exit.
+      printf '%s' "kimi-cli --afk --print --mcp-config-file '$FM_HOME/config/kimi-empty-mcp.json' --prompt \"\$(cat __BRIEF__)\"; touch __TURNEND__"
+      ;;
     *) return 1 ;;
   esac
 }
@@ -680,7 +687,12 @@ case "$BACKEND" in
   tmux)
     SES=$(fm_backend_tmux_container_ensure)
     T="$SES:$W"
-    fm_backend_tmux_create_task "$SES" "$W" "$PROJ_ABS" || exit 1
+    if [ "$KIND" != secondmate ]; then
+      # Disable oh-my-zsh auto-update prompts that can swallow/mangle the typed command.
+      fm_backend_tmux_send_text_line "$T" 'DISABLE_AUTO_UPDATE=true ZSH_DISABLE_COMPFIX=true treehouse get'
+    else
+      fm_backend_tmux_create_task "$SES" "$W" "$PROJ_ABS" || exit 1
+    fi
     ;;
   herdr)
     # fm_backend_herdr_workspace_label resolves the target workspace from
@@ -935,6 +947,11 @@ EOF
       printf 'token=%s\n' "${auth_file##*/}" > "$WT/.fm-grok-turnend"
       exclude_path '.fm-grok-turnend'
       ;;
+    kimi*)
+      # kimi-cli exits after the prompt finishes; the '; touch __TURNEND__' in the
+      # launch template writes the marker without needing a project-local hook.
+      ;;
+    ;;
   esac
 fi
 

--- a/config/kimi-empty-mcp.json
+++ b/config/kimi-empty-mcp.json
@@ -1,0 +1,1 @@
+{"mcpServers": {}}


### PR DESCRIPTION
- Detect kimi/kimi-cli/kimi-code in fm-harness.sh process ancestry
- Add kimi launch template to fm-spawn.sh using kimi-cli --afk --print
- Use empty MCP config to avoid broken servers in ~/.kimi/mcp.json blocking launch
- Document Kimi CLI harness facts in harness-adapters skill
- Fix fm-brief.sh shell-parse error from apostrophe inside heredoc
- Fix fm-spawn.sh oh-my-zsh auto-update prompt mangling treehouse get