### PR TITLE
feat(brief): add project mind-map reference section to scaffolded briefs

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -6,6 +6,10 @@
 # description, acceptance criteria, and context, and may adjust other sections
 # when the task genuinely deviates (e.g. working an existing external PR instead
 # of shipping a new one).
+# Ordinary ship and scout briefs open with a project mind-map reference section:
+# when the newest data/<repo>-mind-map-*/report.md exists under the active home,
+# it points the crewmate at that whole-repo map to read first; otherwise the
+# section notes that none exists yet. Secondmate charters have no such section.
 # Usage: fm-brief.sh <task-id> <repo-name> [--scout]
 #        fm-brief.sh <task-id> --secondmate <project>...
 #   --scout writes the scout contract instead: the deliverable is a report at

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -69,11 +69,13 @@ shell_quote() {
 fm_brief_mind_map_ref() {
   local repo=$1
   local latest
+  # shellcheck disable=SC2012  # ls -t is deliberate: portable newest-by-mtime pick (find -printf is GNU-only; firstmate also runs on macOS), and timestamped report.md paths carry no newlines.
   latest=$(ls -t "$FM_HOME/data/${repo}-mind-map-"*/report.md 2>/dev/null | head -1)
   if [ -z "$latest" ]; then
     printf '_(No project mind map exists yet.)_\n'
     return
   fi
+  # shellcheck disable=SC2016  # single quotes are deliberate: the backticks are literal markdown and %s is the printf directive for "$latest".
   printf 'Before touching any file, read `%s` — a one-page map of the whole repo. It answers "where does X live?" faster than exploring the tree.\n' "$latest"
 }
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -62,6 +62,18 @@ shell_quote() {
   printf "'"
 }
 
+fm_brief_mind_map_ref() {
+  local repo=$1
+  local latest
+  latest=$(ls -t "$FM_HOME/data/${repo}-mind-map-"*/report.md 2>/dev/null | head -1)
+  if [ -z "$latest" ]; then
+    printf '_(No project mind map exists yet.)_\n'
+    return
+  fi
+  local rel="${latest#$FM_HOME/}"
+  printf 'Before touching any file, read `%s` — a one-page map of the whole repo. It answers "where does X live?" faster than exploring the tree.\n' "$rel"
+}
+
 STATUS_FILE=$(shell_quote "$STATE/$ID.status")
 
 if [ "$KIND" = secondmate ]; then
@@ -134,6 +146,10 @@ REPO=${POS[1]}
 if [ "$KIND" = scout ]; then
 cat > "$BRIEF" <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
+
+## Reference — project mind map
+
+$(fm_brief_mind_map_ref "$REPO")
 
 # Task
 {TASK}
@@ -227,6 +243,10 @@ esac
 
 cat > "$BRIEF" <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
+
+## Reference — project mind map
+
+$(fm_brief_mind_map_ref "$REPO")
 
 # Task
 {TASK}

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -70,8 +70,7 @@ fm_brief_mind_map_ref() {
     printf '_(No project mind map exists yet.)_\n'
     return
   fi
-  local rel="${latest#$FM_HOME/}"
-  printf 'Before touching any file, read `%s` — a one-page map of the whole repo. It answers "where does X live?" faster than exploring the tree.\n' "$rel"
+  printf 'Before touching any file, read `%s` — a one-page map of the whole repo. It answers "where does X live?" faster than exploring the tree.\n' "$latest"
 }
 
 STATUS_FILE=$(shell_quote "$STATE/$ID.status")

--- a/tests/fm-backend-orca.test.sh
+++ b/tests/fm-backend-orca.test.sh
@@ -673,7 +673,9 @@ test_spawn_releases_orca_resources_when_metadata_write_fails() {
     "$ROOT/bin/fm-spawn.sh" "$id" "$proj" claude --backend orca 2>&1 )
   status=$?
   [ "$status" -ne 0 ] || fail "Orca spawn should fail when metadata cannot be written"
-  assert_contains "$out" "File exists" "spawn should fail at the state directory creation point"
+  # Match mkdir's failure rather than a coreutils-specific phrasing: GNU prints
+  # "cannot create directory ...: File exists", uutils prints "Already exists".
+  assert_contains "$out" "mkdir:" "spawn should fail at the state directory creation point"
   assert_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''close'$'\x1f''--terminal'$'\x1f''term-meta-fail'$'\x1f''--json' \
     "Orca spawn should close the recorded terminal when a later abort occurs"
   assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:wt-meta-fail'$'\x1f''--force'$'\x1f''--json' \

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -257,7 +257,9 @@ EOF
   make_fake_toolchain "$fakebin"
   make_fake_ps_claude "$fakebin"
   # Force a MISSING diagnostic line so the bootstrap section is non-trivial.
-  rm -f "$fakebin/node"
+  # Use an axi tool rather than node: node may be installed on the base PATH,
+  # whereas the axi tools live only in the fake toolchain here.
+  rm -f "$fakebin/chrome-devtools-axi"
 
   printf 'window=fm-sess:w1\nkind=ship\n' > "$home/state/task-a.meta"
 
@@ -280,7 +282,7 @@ EOF
   [ "$context_line" -lt "$fleet_line" ] || fail "CONTEXT did not precede FLEET STATE"
   [ "$fleet_line" -lt "$next_line" ] || fail "FLEET STATE did not precede NEXT STEP"
 
-  missing_line=$(printf '%s\n' "$out" | grep -n 'MISSING: node' | head -1 | cut -d: -f1)
+  missing_line=$(printf '%s\n' "$out" | grep -n 'MISSING: chrome-devtools-axi' | head -1 | cut -d: -f1)
   [ -n "$missing_line" ] || fail "MISSING diagnostic did not appear at all"
   [ "$missing_line" -lt "$fleet_line" ] || fail "actionable MISSING diagnostic was buried after the bulk fleet-state digest"
 
@@ -400,7 +402,9 @@ $rec
 EOF
   make_fake_toolchain "$fakebin"
   make_fake_ps_claude "$fakebin"
-  rm -f "$fakebin/node"
+  # Drop an axi tool rather than node: node may be installed on the base PATH,
+  # whereas the axi tools live only in the fake toolchain here.
+  rm -f "$fakebin/chrome-devtools-axi"
 
   append_wake "$home/state" signal task-z "needs-decision: pick a library"
 
@@ -409,7 +413,7 @@ EOF
   # fm-lock.sh's own exact success text.
   assert_contains "$out" "lock acquired: harness pid" "fm-lock.sh's real output did not appear (composition, not reimplementation)"
   # fm-bootstrap.sh's own exact MISSING-tool line format.
-  assert_contains "$out" "MISSING: node (install:" "fm-bootstrap.sh's real detect line did not appear verbatim"
+  assert_contains "$out" "MISSING: chrome-devtools-axi (install:" "fm-bootstrap.sh's real detect line did not appear verbatim"
   # fm-wake-drain.sh's real drained record (raw tab-separated queue line).
   assert_contains "$out" "$(printf 'signal\ttask-z\tneeds-decision: pick a library')" "fm-wake-drain.sh's real drained record did not appear"
 


### PR DESCRIPTION
## Intent

Add a helper to bin/fm-brief.sh that injects a Reference — project mind map section into scaffolded briefs when a mind map exists for the project

## What Changed

- Added a `fm_brief_mind_map_ref` helper to `bin/fm-brief.sh` that scans `$FM_HOME/data/<repo>-mind-map-*/report.md`, selects the newest by mtime, and injects a "Reference — project mind map" section into both ship and scout brief templates; when no mind map exists the section renders a graceful placeholder. The emitted path is absolute so a crewmate reading it from its project worktree resolves it correctly.
- Made `tests/fm-backend-orca.test.sh` and `tests/fm-session-start.test.sh` portable across differing coreutils and preinstalled node environments so the e2e suite passes cleanly.
- Documented the mind-map reference section in the `fm-brief.sh` header and silenced deliberate shellcheck info findings in the new helper.

## Risk Assessment

✅ Low: A small, well-bounded helper with a graceful fallback whose one real bug (relative path) was already fixed to emit the absolute $latest; remaining items are non-blocking observations.

## Testing

Baseline configured test command passed; the three files the change touches (fm-brief, fm-session-start, fm-backend-orca tests) each pass in isolation, and the earlier full-suite run only hit the 2-minute wall on unrelated e2e tests rather than failing. I exercised the actual feature by scaffolding real briefs with FM_HOME fixtures: with no mind map the new section shows the placeholder, and with two mind-map reports present it injects the absolute path to the newest report.md into both ship and scout briefs — captured as rendered brief markdown artifacts, the product-level surface for this CLI change (no screenshot applies since the output is generated markdown files).

<details>
<summary>Evidence: Ship brief — no mind map (placeholder fallback)</summary>

<code>## Reference — project mind map&#10;&#10;_(No project mind map exists yet.)_</code>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

## Reference — project mind map

_(No project mind map exists yet.)_

# Task
{TASK}

# Setup
You are in a disposable git worktree of myapp, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/demo-ship-a1`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/tmp.heKLwcyLyB/state/demo-ship-a1.status'`
   States: working, needs-decision, blocked, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs to a human (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/home/dep/.no-mistakes/worktrees/e00b1803cc5b/01KWYX00CAC20DQ9WVXRKVHC1K/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/home/dep/.no-mistakes/worktrees/e00b1803cc5b/01KWYX00CAC20DQ9WVXRKVHC1K/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are not yours to answer: escalate to firstmate (rule 6) and stop.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: the captain, not you, owns the ask-user decisions it would silently auto-resolve.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
```
</details>
<details>
<summary>Evidence: Ship brief — mind map present (absolute path to latest report)</summary>

<code>## Reference — project mind map&#10;&#10;Before touching any file, read `/tmp/.../data/myapp-mind-map-2026-07-07/report.md` — a one-page map of the whole repo. It answers &#34;where does X live?&#34; faster than exploring the tree.</code>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

## Reference — project mind map

Before touching any file, read `/tmp/tmp.heKLwcyLyB/data/myapp-mind-map-2026-07-07/report.md` — a one-page map of the whole repo. It answers "where does X live?" faster than exploring the tree.

# Task
{TASK}

# Setup
You are in a disposable git worktree of myapp, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/demo-ship-b1`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/tmp.heKLwcyLyB/state/demo-ship-b1.status'`
   States: working, needs-decision, blocked, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs to a human (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/home/dep/.no-mistakes/worktrees/e00b1803cc5b/01KWYX00CAC20DQ9WVXRKVHC1K/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/home/dep/.no-mistakes/worktrees/e00b1803cc5b/01KWYX00CAC20DQ9WVXRKVHC1K/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are not yours to answer: escalate to firstmate (rule 6) and stop.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: the captain, not you, owns the ask-user decisions it would silently auto-resolve.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
```
</details>
<details>
<summary>Evidence: Scout brief — mind map section also injected</summary>

<code>## Reference — project mind map&#10;&#10;Before touching any file, read `/tmp/.../data/myapp-mind-map-2026-07-07/report.md` — a one-page map of the whole repo.</code>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

## Reference — project mind map

Before touching any file, read `/tmp/tmp.heKLwcyLyB/data/myapp-mind-map-2026-07-07/report.md` — a one-page map of the whole repo. It answers "where does X live?" faster than exploring the tree.

# Task
{TASK}

# Setup
You are in a disposable git worktree of myapp, at a detached HEAD on a clean default branch.
This is a SCOUT task: the deliverable is a written report, not a PR.
The worktree is your laboratory - install, run, edit, and make scratch commits freely; all of it is discarded at teardown.
The report is the only thing that survives, so anything worth keeping must be in it.

# Rules
1. Never push to any remote and never open a PR.
2. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/tmp.heKLwcyLyB/state/demo-scout-c1.status'`
   States: working, needs-decision, blocked, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on and the needs-decision/blocked/done/failed states. No step-by-step
   FYI progress lines; firstmate reads your pane for that.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs to a human (product choices, destructive actions),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.

# Definition of done
Write your findings to `/tmp/tmp.heKLwcyLyB/data/demo-scout-c1/report.md`.
The report must stand alone: what you did, what you found, the evidence (commands run, output, file:line references), and what you recommend.
When the report is complete, append `done: {one-line conclusion}` to the status file and stop.
If your findings reveal work that should ship (e.g. you reproduced a bug and the fix is clear), say so in the report; firstmate may promote this task in place, and you would then receive mode-specific ship instructions as a follow-up message.
```
</details>
- Outcome: 🔧 1 issue found → auto-fixed ✅ across 2 runs (26m57s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ⚠️ `bin/fm-brief.sh:73` - fm_brief_mind_map_ref strips $FM_HOME/ to emit a RELATIVE path (`data/&lt;repo&gt;-mind-map-&lt;id&gt;/report.md`), but the crewmate&#39;s cwd is the disposable project worktree, not the firstmate home. $latest is already absolute (from `ls &#34;$FM_HOME/data/...&#34;`), and every other crewmate-facing path in this brief ($STATUS_FILE, $DATA/$ID/report.md, $FM_ROOT/bin/...) is emitted absolute for exactly this reason. As written, the crewmate reads the path against its project worktree, gets file-not-found, and the mind-map feature silently no-ops. Fix: use $latest directly instead of the stripped rel. (Also: the `${latest#$FM_HOME/}` pattern uses $FM_HOME unquoted as a glob — moot once the path stays absolute.)

🔧 Fix: emit absolute mind-map path in scaffolded briefs
2 infos still open:
- ℹ️ `bin/fm-brief.sh:68` - fm_brief_mind_map_ref keys off an implicit convention: mind-map reports must live at $FM_HOME/data/&lt;repo&gt;-mind-map-&lt;id&gt;/report.md. No code in this repo creates such directories, so until a mind map is produced out-of-band the section always renders the &#39;_(No project mind map exists yet.)_&#39; placeholder in every brief. Consistent with the stated intent (inject the reference only when a map exists) and the fallback is graceful, but the naming contract is undocumented and has no producer here.
- ℹ️ `bin/fm-brief.sh:65` - The new fm_brief_mind_map_ref helper&#39;s two branches (match and empty-glob no-op) are not exercised by tests/fm-brief.test.sh, while the repo convention is colocated tests for bin/ scripts. A targeted case asserting both the placeholder output and an absolute-path emission when a matching report.md exists would lock in the previously-fixed absolute-path behavior.

</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed ✅</summary>

- 🚨 tests failed with exit code 1
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`

🔧 Fix: make orca/session-start tests portable across coreutils and preinstalled node
✅ Re-checked - no issues remain.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- <code>`bash tests/fm-brief.test.sh` — all 4 cases pass</code>
- <code>`bash tests/fm-session-start.test.sh` — all 11 cases pass</code>
- <code>`bash tests/fm-backend-orca.test.sh` — all cases pass</code>
- <code>Manual E2E: ran `bin/fm-brief.sh demo-ship-a1 myapp` with no mind map → section renders `_(No project mind map exists yet.)_`</code>
- <code>Manual E2E: created `data/myapp-mind-map-2026-07-05` and `-2026-07-07` report.md files, ran `bin/fm-brief.sh demo-ship-b1 myapp` → section points at the newest report&#39;s absolute path</code>
- <code>Manual E2E: ran `bin/fm-brief.sh demo-scout-c1 myapp --scout` → scout brief also carries the mind-map reference section</code>
- `Verified latest-by-mtime selection chose myapp-mind-map-2026-07-07 over the older 2026-07-05`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
