### PR TITLE
fix(spawn): acquire crew worktrees via treehouse get --lease

### DIFF
--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -69,13 +69,22 @@ fm_backend_tmux_container_ensure() {
 # refusing an existing <window-name> in <session>. Mirrors fm-spawn.sh's
 # duplicate-check-then-new-window sequence, including the exact error text
 # (session:window, matching how fm-spawn.sh composed its own $T).
+#
+# The session is addressed as "<session>:" (trailing colon), never bare
+# "<session>". A bare target whose text is a plain integer - which happens when
+# firstmate runs inside a tmux session with a numeric name (e.g. "58") - is
+# parsed by tmux as a WINDOW INDEX in the current session, not a session name,
+# so `new-window -t 58` targets index 58 and a second task collides with
+# "index 58 in use". The trailing colon forces session interpretation and lets
+# tmux pick the next free index; it is equally correct for a named session
+# like "firstmate:".
 fm_backend_tmux_create_task() {  # <session> <window-name> <proj-abs>
   local ses=$1 wname=$2 proj_abs=$3
-  if tmux list-windows -t "$ses" -F '#{window_name}' | grep -qx "$wname"; then
+  if tmux list-windows -t "$ses:" -F '#{window_name}' | grep -qx "$wname"; then
     echo "error: window $ses:$wname already exists" >&2
     return 1
   fi
-  tmux new-window -d -t "$ses" -n "$wname" -c "$proj_abs"
+  tmux new-window -d -t "$ses:" -n "$wname" -c "$proj_abs"
 }
 
 # fm_backend_tmux_current_path: the live pane's current working directory, or

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -630,24 +630,12 @@ fi
 
 # PROJ_ABS can still carry a symlinked path component (e.g. macOS's /tmp ->
 # /private/tmp) when it came from the ship/scout branch's logical `pwd` above.
-# Every backend's own current-path read (tmux's pane_current_path, herdr's
-# foreground_cwd, zellij/cmux's active pwd probe against the live shell) can
-# report the OS-level, physically-resolved cwd, so comparing it against a
-# still-symlinked PROJ_ABS can misfire both ways: false-negative (the poll
-# below never notices the pane left the project) or false-positive (the
-# isolation guard refuses a spawn that never actually tangled). Canonicalize
-# once here so every downstream comparison uses the same physical form
+# validate_spawn_worktree's isolation guard resolves the leased worktree with
+# `pwd -P` and compares it against the primary; a still-symlinked PROJ_ABS could
+# false-positive (the guard refusing a spawn that never actually tangled).
+# Canonicalize once here so that comparison uses the same physical form
 # (docs/herdr-backend.md "Known gaps").
 PROJ_ABS_REAL=$(cd "$PROJ_ABS" 2>/dev/null && pwd -P) || PROJ_ABS_REAL="$PROJ_ABS"
-
-real_path_or_raw() {  # <path>
-  local path=$1 real
-  if real=$(cd "$path" 2>/dev/null && pwd -P); then
-    printf '%s\n' "$real"
-  else
-    printf '%s\n' "$path"
-  fi
-}
 
 # Session-provider container-ensure + task creation. tmux stays exactly as P1
 # left it (same session-name / new-window sequence, see bin/backends/tmux.sh);
@@ -778,14 +766,6 @@ spawn_send_text_line() {  # <target> <text>
     cmux) fm_backend_cmux_send_text_line "$1" "$2" "$W" ;;
   esac
 }
-spawn_current_path() {  # <target>
-  case "$BACKEND" in
-    tmux) fm_backend_tmux_current_path "$1" ;;
-    herdr) fm_backend_herdr_current_path "$1" ;;
-    zellij) fm_backend_zellij_current_path "$1" "$W" ;;
-    cmux) fm_backend_cmux_current_path "$1" "$W" ;;
-  esac
-}
 spawn_send_literal() {  # <target> <text>
   case "$BACKEND" in
     tmux) fm_backend_tmux_send_literal "$1" "$2" ;;
@@ -805,26 +785,28 @@ spawn_send_key() {  # <target> <key>
   esac
 }
 if [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
-  spawn_send_text_line "$T" 'treehouse get'
-
-  # Wait for the treehouse subshell: the pane's cwd moves from the project to the worktree.
-  # Compare against PROJ_ABS_REAL (physical), not PROJ_ABS: a symlinked project
-  # prefix would otherwise make the pane's OS-level cwd read differ from
-  # PROJ_ABS on the very first poll, before the pane has actually moved.
-  for _ in $(seq 1 60); do
-    p=$(spawn_current_path "$T" || true)
-    if [ -n "$p" ] && [ "$(real_path_or_raw "$p")" != "$PROJ_ABS_REAL" ]; then
-      WT="$p"
-      break
-    fi
-    sleep 1
-  done
-  if [ -z "$WT" ]; then
-    echo "error: treehouse get did not enter a worktree within 60s; inspect window $T" >&2
+  # Durably lease a worktree from the pool as a subprocess, exactly as
+  # fm-home-seed.sh's acquire_treehouse_home does. treehouse prints only the
+  # worktree path to stdout (banners go to stderr), so command substitution
+  # captures the path directly. This replaces the old interactive `treehouse
+  # get` + pane-cwd poll: treehouse v2.0.0's `get` opens a subshell whose cwd
+  # the multiplexer's own current-path read (tmux's pane_current_path, etc.)
+  # does not observe, so the poll timed out at 60s even though the worktree was
+  # created. A lease is non-interactive, deterministic, and never handed out or
+  # pruned while held; fm-teardown returns it by path via `treehouse return`
+  # identically to the old path. The lease holder is the task id.
+  WT=$(cd "$PROJ_ABS" && treehouse get --lease --lease-holder "$ID") || {
+    echo "error: treehouse get --lease failed to lease a worktree for $ID; inspect window $T" >&2
     exit 1
-  fi
+  }
+  [ -n "$WT" ] || { echo "error: treehouse get --lease did not report a worktree for $ID; inspect window $T" >&2; exit 1; }
 
-  validate_spawn_worktree "treehouse get" "$T"
+  validate_spawn_worktree "treehouse get --lease" "$T"
+
+  # Move the task pane into the leased worktree so the harness launches there
+  # and every worktree-resident turn-end hook lands in $WT. The window was
+  # created in $PROJ_ABS; a plain cd is enough because the lease already exists.
+  spawn_send_text_line "$T" "cd $(shell_quote "$WT")"
 fi
 
 # Per-task temp root: /tmp/fm-<id>/ with Go's build temp nested at gotmp/. Go won't

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -766,6 +766,17 @@ spawn_send_text_line() {  # <target> <text>
     cmux) fm_backend_cmux_send_text_line "$1" "$2" "$W" ;;
   esac
 }
+# The live pane's current working directory (empty on any error). Used only to
+# VERIFY the post-lease `cd` landed the pane in the worktree; orca has no pane
+# to read (it owns its own worktree), so this is not on the orca path.
+spawn_current_path() {  # <target>
+  case "$BACKEND" in
+    tmux) fm_backend_tmux_current_path "$1" ;;
+    herdr) fm_backend_herdr_current_path "$1" ;;
+    zellij) fm_backend_zellij_current_path "$1" "$W" ;;
+    cmux) fm_backend_cmux_current_path "$1" "$W" ;;
+  esac
+}
 spawn_send_literal() {  # <target> <text>
   case "$BACKEND" in
     tmux) fm_backend_tmux_send_literal "$1" "$2" ;;
@@ -804,9 +815,28 @@ if [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   validate_spawn_worktree "treehouse get --lease" "$T"
 
   # Move the task pane into the leased worktree so the harness launches there
-  # and every worktree-resident turn-end hook lands in $WT. The window was
-  # created in $PROJ_ABS; a plain cd is enough because the lease already exists.
-  spawn_send_text_line "$T" "cd $(shell_quote "$WT")"
+  # and every worktree-resident turn-end hook lands in $WT. VERIFY the cd landed
+  # rather than fire-and-forget: a freshly created pane's shell may not be ready
+  # for the very first keystroke, dropping the leading character (observed:
+  # `cd <wt>` arriving as `d <wt>`, leaving the pane in the primary checkout and
+  # tripping the crewmate's own isolation guard). Re-send until the pane's cwd is
+  # the worktree, comparing physically-resolved paths so a symlinked prefix does
+  # not cause a false mismatch.
+  WT_REAL=$(cd "$WT" 2>/dev/null && pwd -P) || WT_REAL="$WT"
+  cd_landed=
+  for _ in $(seq 1 30); do
+    p=$(spawn_current_path "$T" 2>/dev/null || true)
+    if [ -n "$p" ]; then
+      p_real=$(cd "$p" 2>/dev/null && pwd -P) || p_real="$p"
+      if [ "$p_real" = "$WT_REAL" ]; then cd_landed=1; break; fi
+    fi
+    spawn_send_text_line "$T" "cd $(shell_quote "$WT")"
+    sleep 0.5
+  done
+  if [ -z "$cd_landed" ]; then
+    echo "error: task pane for $ID did not enter the leased worktree $WT after repeated cd; inspect window $T" >&2
+    exit 1
+  fi
 fi
 
 # Per-task temp root: /tmp/fm-<id>/ with Go's build temp nested at gotmp/. Go won't

--- a/tests/fm-backend.test.sh
+++ b/tests/fm-backend.test.sh
@@ -699,15 +699,25 @@ test_peek_conformance_old_vs_new() {
 # --- old vs new: fm-spawn.sh --------------------------------------------------
 
 make_spawn_fakebin() {  # <dir> <fake-worktree-path> -> echoes fakebin dir
-  local dir=$1 wt=$2 fb="$1/fakebin"
+  local dir=$1 wt=$2 fb="$1/fakebin" cwdfile="$1/pane-cwd"
   mkdir -p "$fb"
+  # pane-cwd starts as the project (empty marker) and flips to the worktree once
+  # a `cd <wt>` send-keys is seen, mirroring the real pane: fm-spawn's verify
+  # loop reads project first, sends cd, then reads the worktree and proceeds.
+  : > "$cwdfile"
   cat > "$fb/tmux" <<SH
 #!/usr/bin/env bash
 set -u
 { printf 'tmux'; for a in "\$@"; do printf '\\x1f%s' "\$a"; done; printf '\\n'; } >> "\${FM_TMUX_LOG:?}"
+case "\$*" in
+  *pane_current_path*) cat "$cwdfile"; printf '\\n'; exit 0 ;;
+esac
 case "\${1:-}" in
   display-message) printf 'firstmate\\n'; exit 0 ;;
   list-windows) exit 0 ;;
+  send-keys)
+    for a in "\$@"; do case "\$a" in "cd '$wt'"|"cd $wt") printf '%s' "$wt" > "$cwdfile" ;; esac; done
+    exit 0 ;;
 esac
 exit 0
 SH

--- a/tests/fm-backend.test.sh
+++ b/tests/fm-backend.test.sh
@@ -706,15 +706,24 @@ make_spawn_fakebin() {  # <dir> <fake-worktree-path> -> echoes fakebin dir
 set -u
 { printf 'tmux'; for a in "\$@"; do printf '\\x1f%s' "\$a"; done; printf '\\n'; } >> "\${FM_TMUX_LOG:?}"
 case "\${1:-}" in
-  display-message)
-    for a in "\$@"; do case "\$a" in *pane_current_path*) printf '%s\\n' "$wt"; exit 0 ;; esac; done
-    printf 'firstmate\\n'; exit 0 ;;
+  display-message) printf 'firstmate\\n'; exit 0 ;;
   list-windows) exit 0 ;;
 esac
 exit 0
 SH
   chmod +x "$fb/tmux"
-  fm_fake_exit0 "$fb" treehouse
+  # treehouse `get --lease` prints the leased worktree path to stdout (the real
+  # lease contract fm-spawn reads); banners go to stderr. FM_FAKE_WORKTREE lets
+  # a caller pin the returned path; it defaults to this fakebin's paired wt.
+  cat > "$fb/treehouse" <<SH
+#!/usr/bin/env bash
+set -u
+case "\$*" in
+  *get*--lease*) printf '%s\\n' "\${FM_FAKE_WORKTREE:-$wt}"; exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fb/treehouse"
   printf '%s\n' "$fb"
 }
 
@@ -729,91 +738,58 @@ run_spawn_case() {  # <bin-root> <fakebin> <log> <state> <data> <config> <proj> 
     "$bin/bin/fm-spawn.sh" "$@"
 }
 
-test_spawn_conformance_old_vs_new() {
-  local old_bin fb proj wt data id log_old log_new out_old out_new
-  local state_old state_new config_old config_new
-  old_bin=$(build_old_bin spawn-old)
+test_spawn_lease_based_worktree_contract() {
+  # Forward contract test (was an old-vs-new byte-identical diff against
+  # BASE_REF). fm-spawn no longer sends `treehouse get` into the pane and polls
+  # pane_current_path - treehouse v2.0.0's interactive `get` opens a subshell
+  # whose cwd the multiplexer does not report, so that poll timed out. Spawn now
+  # leases the worktree via `treehouse get --lease` (path from stdout) and sends
+  # a plain `cd <worktree>` so the harness launches there. A BASE_REF diff is no
+  # longer meaningful because this is an intended behavior change, so this test
+  # pins the NEW expected tmux command log and summary line instead.
+  local fb proj wt data id log out rc state config
   proj="$TMP_ROOT/spawn-project"; wt="$TMP_ROOT/spawn-wt"; data="$TMP_ROOT/spawn-data"
   id="spawnconform1"
   fm_git_worktree "$proj" "$wt" "fm/$id"
   fb=$(make_spawn_fakebin "$TMP_ROOT/spawn-fake" "$wt")
   mkdir -p "$data/$id"
   printf 'test brief content\n' > "$data/$id/brief.md"
-  state_old="$TMP_ROOT/spawn-state-old"; state_new="$TMP_ROOT/spawn-state-new"
-  config_old="$TMP_ROOT/spawn-config-old"; config_new="$TMP_ROOT/spawn-config-new"
-  mkdir -p "$state_old" "$state_new" "$config_old" "$config_new"
-  log_old="$TMP_ROOT/spawn-old.log"; log_new="$TMP_ROOT/spawn-new.log"
+  state="$TMP_ROOT/spawn-state-new"; config="$TMP_ROOT/spawn-config-new"
+  mkdir -p "$state" "$config"
+  log="$TMP_ROOT/spawn-new.log"
 
-  out_old=$(run_spawn_case "$old_bin" "$fb" "$log_old" "$state_old" "$data" "$config_old" "$proj" -- "$id" "$proj" claude 2>&1)
-  local rc_old=$?
-  out_new=$(run_spawn_case "$ROOT" "$fb" "$log_new" "$state_new" "$data" "$config_new" "$proj" -- "$id" "$proj" claude 2>&1)
-  local rc_new=$?
-
-  expect_code 0 "$rc_old" "old fm-spawn.sh should succeed"$'\n'"$out_old"
-  expect_code 0 "$rc_new" "new fm-spawn.sh should succeed"$'\n'"$out_new"
-  [ "$out_old" = "$out_new" ] || fail "fm-spawn.sh stdout differs old vs new"$'\n'"--- old ---"$'\n'"$out_old"$'\n'"--- new ---"$'\n'"$out_new"
-  assert_contains "$out_new" "spawned $id harness=claude kind=ship mode=no-mistakes yolo=off window=firstmate:fm-$id worktree=$wt" \
+  out=$(run_spawn_case "$ROOT" "$fb" "$log" "$state" "$data" "$config" "$proj" -- "$id" "$proj" claude 2>&1)
+  rc=$?
+  expect_code 0 "$rc" "fm-spawn.sh should succeed"$'\n'"$out"
+  assert_contains "$out" "spawned $id harness=claude kind=ship mode=no-mistakes yolo=off window=firstmate:fm-$id worktree=$wt" \
     "spawn output missing the expected summary line"
+  assert_grep "worktree=$wt" "$state/$id.meta" "meta did not record the leased worktree"
 
-  diff -u "$log_old" "$log_new" > "$TMP_ROOT/spawn-diff.txt" 2>&1 \
-    || fail "fm-spawn.sh: tmux command log differs old vs new"$'\n'"$(cat "$TMP_ROOT/spawn-diff.txt")"
-
-  # Sanity: the log actually captured the session/window lifecycle so an
-  # accidentally-empty log (e.g. a fake tmux path typo) cannot pass silently.
-  assert_contains "$(cat "$log_new")" $'\x1f''new-window' "spawn tmux log missing new-window"
-  assert_contains "$(cat "$log_new")" $'\x1f''treehouse get' "spawn tmux log missing the treehouse get send"
-  assert_contains "$(cat "$log_new")" $'\x1f''-l'$'\x1f'"CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions \"\$(cat '$data/$id/brief.md')\"" \
+  # The tmux log must show the window lifecycle, the cd into the leased
+  # worktree (replacing the old `treehouse get` send), and the launch command.
+  assert_contains "$(cat "$log")" $'\x1f''new-window' "spawn tmux log missing new-window"
+  assert_contains "$(cat "$log")" $'\x1f'"cd '$wt'" "spawn tmux log missing the cd into the leased worktree"
+  assert_not_contains "$(cat "$log")" $'\x1f''treehouse get'$'\x1f' "spawn must not send an interactive treehouse get into the pane"
+  assert_contains "$(cat "$log")" $'\x1f''-l'$'\x1f'"CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions \"\$(cat '$data/$id/brief.md')\"" \
     "spawn tmux log missing the literal launch-command send"
 
   rm -rf "/tmp/fm-$id"
-  pass "fm-spawn.sh: tmux command log and printed summary line are byte-identical old vs new for a ship-task claude spawn"
+  pass "fm-spawn.sh: leases the worktree and cds the pane into it; tmux log and summary line match the new contract"
 }
 
 # --- symlinked project prefix must not false-refuse the isolation guard -----
 #
-# docs/herdr-backend.md "Known gaps": a real backend's pane_current_path read
-# (tmux, herdr) reports the OS-level PHYSICALLY-resolved cwd. When the project
-# itself lives under a symlinked prefix (e.g. macOS's /tmp -> /private/tmp),
-# fm-spawn.sh's PROJ_ABS - a logical `cd && pwd` - differs string-for-string
-# from that physical read even before treehouse moves the pane at all, so the
-# worktree-discovery poll used to mistake an UNMOVED pane for one that had
-# already left the project, handing validate_spawn_worktree the project's own
-# directory as "the worktree" and tripping its false isolation refusal.
-# make_spawn_symlink_fakebin's tmux stub returns an unmoved project path on the
-# first pane_current_path poll, then the real worktree path from the second poll
-# onward, so this test fails loudly if the PROJ_ABS/PROJ_ABS_REAL
-# canonicalization in bin/fm-spawn.sh ever regresses.
-make_spawn_symlink_fakebin() {  # <dir> <initial-project-path> <worktree-path> -> echoes fakebin dir
-  local dir=$1 initial_path=$2 wt=$3 fb="$1/fakebin" counter="$1/poll-count"
-  mkdir -p "$fb"
-  : > "$counter"
-  cat > "$fb/tmux" <<SH
-#!/usr/bin/env bash
-set -u
-{ printf 'tmux'; for a in "\$@"; do printf '\\x1f%s' "\$a"; done; printf '\\n'; } >> "\${FM_TMUX_LOG:?}"
-case "\${1:-}" in
-  display-message)
-    for a in "\$@"; do case "\$a" in *pane_current_path*)
-      printf x >> "$counter"
-      if [ "\$(wc -c < "$counter")" -le 1 ]; then
-        printf '%s\\n' "$initial_path"
-      else
-        printf '%s\\n' "$wt"
-      fi
-      exit 0
-    ;; esac; done
-    printf 'firstmate\\n'; exit 0 ;;
-  list-windows) exit 0 ;;
-esac
-exit 0
-SH
-  chmod +x "$fb/tmux"
-  fm_fake_exit0 "$fb" treehouse
-  printf '%s\n' "$fb"
-}
-
-run_spawn_symlink_case() {  # <label> <physical|logical>
-  local label=$1 first_reply=$2 real_root link_root proj wt id fb data state config log out rc proj_phys initial_path
+# When the project lives under a symlinked prefix (e.g. macOS's /tmp ->
+# /private/tmp), fm-spawn.sh's PROJ_ABS - a logical `cd && pwd` - differs
+# string-for-string from the physically-resolved worktree path. The isolation
+# guard (validate_spawn_worktree) resolves both the leased worktree and the
+# project with `pwd -P`; if PROJ_ABS were not canonicalized to PROJ_ABS_REAL
+# first, that comparison could false-refuse a genuinely isolated worktree. The
+# worktree now comes from `treehouse get --lease` (make_spawn_fakebin's stub
+# returns FM_FAKE_WORKTREE), so this test fails loudly if the
+# PROJ_ABS/PROJ_ABS_REAL canonicalization in bin/fm-spawn.sh ever regresses.
+run_spawn_symlink_case() {  # <label>
+  local label=$1 real_root link_root proj wt id fb data state config log out rc
   real_root="$TMP_ROOT/symlink-real-$label"; link_root="$TMP_ROOT/symlink-link-$label"
   mkdir -p "$real_root"
   ln -s "$real_root" "$link_root"
@@ -821,18 +797,7 @@ run_spawn_symlink_case() {  # <label> <physical|logical>
   wt="$TMP_ROOT/symlink-wt-$label"
   id="spawnsymlink$label"
   fm_git_worktree "$real_root/proj" "$wt" "fm/$id"
-  # TMP_ROOT itself can already sit behind an OS-level symlink (e.g. macOS's
-  # /var -> /private/var), so resolve the fakebin's "physical" reply with
-  # pwd -P rather than string concatenation - it must match exactly what
-  # fm-spawn.sh's own PROJ_ABS_REAL computes, including any symlink layers
-  # ABOVE this test's own synthetic real_root/link_root pair.
-  proj_phys=$(cd "$real_root/proj" && pwd -P)
-  case "$first_reply" in
-    physical) initial_path=$proj_phys ;;
-    logical) initial_path=$proj ;;
-    *) fail "unknown symlink first-reply mode: $first_reply" ;;
-  esac
-  fb=$(make_spawn_symlink_fakebin "$TMP_ROOT/symlink-fake-$label" "$initial_path" "$wt")
+  fb=$(make_spawn_fakebin "$TMP_ROOT/symlink-fake-$label" "$wt")
   data="$TMP_ROOT/symlink-data-$label"
   mkdir -p "$data/$id"
   printf 'test brief content\n' > "$data/$id/brief.md"
@@ -842,16 +807,15 @@ run_spawn_symlink_case() {  # <label> <physical|logical>
 
   out=$(run_spawn_case "$ROOT" "$fb" "$log" "$state" "$data" "$config" "$proj" -- "$id" "$proj" claude 2>&1)
   rc=$?
-  expect_code 0 "$rc" "fm-spawn.sh should succeed for a project reached through a symlinked prefix when the backend reports $first_reply cwd"$'\n'"$out"
+  expect_code 0 "$rc" "fm-spawn.sh should succeed for a project reached through a symlinked prefix"$'\n'"$out"
   assert_contains "$out" "worktree=$wt" \
-    "fm-spawn.sh did not resolve a symlinked-prefix project to its real worktree when the backend reports $first_reply cwd"
+    "fm-spawn.sh did not resolve a symlinked-prefix project to its real leased worktree"
 
   rm -rf "/tmp/fm-$id"
 }
 
 test_spawn_symlinked_project_prefix_avoids_false_refusal() {
-  run_spawn_symlink_case physical physical
-  run_spawn_symlink_case logical logical
+  run_spawn_symlink_case a
   pass "fm-spawn.sh: a project reached through a symlinked prefix (e.g. macOS /tmp -> /private/tmp) does not trip the isolation guard's false refusal"
 }
 
@@ -1065,7 +1029,7 @@ test_resolve_selector_three_forms
 test_backend_of_selector_matches_explicit_target_meta
 test_send_conformance_old_vs_new
 test_peek_conformance_old_vs_new
-test_spawn_conformance_old_vs_new
+test_spawn_lease_based_worktree_contract
 test_spawn_symlinked_project_prefix_avoids_false_refusal
 test_teardown_conformance_old_vs_new
 test_spawn_refuses_unknown_backend_flag

--- a/tests/fm-grok-harness.test.sh
+++ b/tests/fm-grok-harness.test.sh
@@ -14,9 +14,6 @@ make_spawn_fakebin() {
   cat > "$fakebin/tmux" <<'SH'
 #!/usr/bin/env bash
 set -u
-case "$*" in
-  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
-esac
 case "${1:-}" in
   display-message) printf 'firstmate\n'; exit 0 ;;
   list-windows) exit 0 ;;
@@ -25,7 +22,18 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse gh-axi gh
+  # treehouse `get --lease` prints the leased worktree path to stdout, which
+  # fm-spawn now captures directly (banners go to stderr).
+  cat > "$fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  *get*--lease*) printf '%s\n' "${FM_FAKE_WORKTREE:-}"; exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/treehouse"
+  fm_fake_exit0 "$fakebin" gh-axi gh
   printf '%s\n' "$fakebin"
 }
 
@@ -50,7 +58,7 @@ run_grok_spawn() {
   FM_ROOT_OVERRIDE='' FM_HOME="$home" \
     FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
     FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
-    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" TMUX="fake,1,0" \
+    FM_SPAWN_NO_GUARD=1 FM_FAKE_WORKTREE="$wt" TMUX="fake,1,0" \
     GROK_HOME="$grok_home" PATH="$fakebin:$PATH" \
     "$SPAWN" "$id" "$proj" grok 2>&1
 }

--- a/tests/fm-grok-harness.test.sh
+++ b/tests/fm-grok-harness.test.sh
@@ -14,6 +14,9 @@ make_spawn_fakebin() {
   cat > "$fakebin/tmux" <<'SH'
 #!/usr/bin/env bash
 set -u
+case "$*" in
+  *pane_current_path*) printf '%s\n' "${FM_FAKE_WORKTREE:-}"; exit 0 ;;
+esac
 case "${1:-}" in
   display-message) printf 'firstmate\n'; exit 0 ;;
   list-windows) exit 0 ;;

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -409,18 +409,15 @@ meta_field() { grep "^$2=" "$1" 2>/dev/null | tail -1 | cut -d= -f2-; }
 # A tmux stub that behaves like make_noop_tmux but also captures the literal
 # `send-keys -l <cmd>` launch command into FM_FAKE_LAUNCH_LOG, mirroring the
 # capture technique in fm-spawn-dispatch-profile.test.sh so the constructed
-# launch command (not just meta) can be asserted on. Also answers the
-# `#{pane_current_path}` probe from FM_FAKE_PANE_PATH so this same stub works
-# for a crew/scout (non-secondmate) spawn's treehouse-worktree wait loop.
+# launch command (not just meta) can be asserted on. Paired with a treehouse
+# stub whose `get --lease` prints FM_FAKE_WORKTREE to stdout, so this same stub
+# works for a crew/scout (non-secondmate) spawn that leases a worktree.
 make_launch_capturing_tmux() {
   local dir=$1 fakebin="$1/fakebin"
   mkdir -p "$fakebin"
   cat > "$fakebin/tmux" <<'SH'
 #!/usr/bin/env bash
 set -u
-case "$*" in
-  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
-esac
 case "${1:-}" in
   display-message) printf 'firstmate\n'; exit 0 ;;
   list-windows) exit 0 ;;
@@ -441,6 +438,15 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
+  cat > "$fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  *get*--lease*) printf '%s\n' "${FM_FAKE_WORKTREE:-}"; exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/treehouse"
   printf '%s\n' "$fakebin"
 }
 
@@ -662,7 +668,7 @@ test_spawn_fallback_chain_and_crew_scout_unaffected() {
     FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" \
     FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
     FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
-    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" FM_FAKE_LAUNCH_LOG="$launchlog" \
+    FM_SPAWN_NO_GUARD=1 FM_FAKE_WORKTREE="$wt" FM_FAKE_LAUNCH_LOG="$launchlog" \
     "$ROOT/bin/fm-spawn.sh" "$id" "$proj" >/dev/null 2>&1
   meta="$home/state/$id.meta"
   [ "$(meta_field "$meta" kind)" = ship ] || fail "crew-unaffected: expected an ordinary ship task"

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -418,6 +418,9 @@ make_launch_capturing_tmux() {
   cat > "$fakebin/tmux" <<'SH'
 #!/usr/bin/env bash
 set -u
+case "$*" in
+  *pane_current_path*) printf '%s\n' "${FM_FAKE_WORKTREE:-}"; exit 0 ;;
+esac
 case "${1:-}" in
   display-message) printf 'firstmate\n'; exit 0 ;;
   list-windows) exit 0 ;;

--- a/tests/fm-spawn-batch.test.sh
+++ b/tests/fm-spawn-batch.test.sh
@@ -17,13 +17,19 @@ TMP_ROOT=$(fm_test_tmproot fm-spawn-batch)
 export FM_BACKEND=tmux
 
 # Clear ambient firstmate overrides so the behavior test owns its environment.
+# FM_CONFIG_OVERRIDE points at an EMPTY config dir (not '') so the test is
+# hermetic: an empty override still resolves to the real config/ dir, which may
+# hold a live config/crew-dispatch.json that would trip the explicit-harness
+# backstop before the missing-brief check these tests target.
+EMPTY_CONFIG="$TMP_ROOT/empty-config"
+mkdir -p "$EMPTY_CONFIG"
 run_spawn() {
   FM_ROOT_OVERRIDE='' \
     FM_HOME='' \
     FM_STATE_OVERRIDE='' \
     FM_DATA_OVERRIDE='' \
     FM_PROJECTS_OVERRIDE='' \
-    FM_CONFIG_OVERRIDE='' \
+    FM_CONFIG_OVERRIDE="$EMPTY_CONFIG" \
     FM_SPAWN_NO_GUARD=1 \
     "$SPAWN" "$@" 2>&1
 }

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -19,9 +19,6 @@ make_spawn_fakebin() {
   cat > "$fakebin/tmux" <<'SH'
 #!/usr/bin/env bash
 set -u
-case "$*" in
-  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
-esac
 case "${1:-}" in
   display-message) printf 'firstmate\n'; exit 0 ;;
   list-windows) exit 0 ;;
@@ -42,7 +39,18 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse
+  # treehouse stub: `get --lease` prints the worktree path to stdout (banners to
+  # stderr), exactly as the real treehouse does; fm-spawn captures that path via
+  # command substitution. Any other subcommand is a trivial exit-0.
+  cat > "$fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  *get*--lease*) printf '%s\n' "${FM_FAKE_WORKTREE:-}"; exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/treehouse"
   printf '%s\n' "$fakebin"
 }
 
@@ -87,7 +95,7 @@ run_spawn() {
   FM_ROOT_OVERRIDE='' FM_HOME="$home" \
     FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
     FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
-    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" TMUX="fake,1,0" \
+    FM_SPAWN_NO_GUARD=1 FM_FAKE_WORKTREE="$wt" TMUX="fake,1,0" \
     FM_FAKE_LAUNCH_LOG="$launchlog" GROK_HOME="$home/grok-home" PATH="$fakebin:$PATH" \
     "$SPAWN" "$@" 2>&1
 }
@@ -346,6 +354,25 @@ test_batch_forwards_shared_profile_flags() {
   pass "batch dispatch forwards shared --harness, --model, and --effort to every pair"
 }
 
+test_scout_worktree_comes_from_lease() {
+  # Regression: treehouse v2.0.0's interactive `get` opens a subshell whose cwd
+  # the multiplexer does not report, so the old pane_current_path poll timed out
+  # at 60s. fm-spawn now leases the worktree via `treehouse get --lease` and
+  # reads the path from stdout. The fakebin tmux stub answers no pane-cwd probe
+  # at all, so this spawn succeeds only via the lease path.
+  local rec id out status
+  id=lease-worktree-z17
+  rec=$(make_spawn_case lease-worktree claude "$id")
+  read_case_record "$rec"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" --scout "$id" "$PROJ_DIR")
+  status=$?
+  expect_code 0 "$status" "scout spawn should succeed from the lease path"
+  assert_contains "$out" "spawned $id" "lease-based spawn did not report success"
+  assert_grep "worktree=$WT_DIR" "$HOME_DIR/state/$id.meta" "meta did not record the leased worktree from stdout"
+  pass "scout worktree is acquired via treehouse --lease, independent of pane-cwd polling"
+}
+
 test_active_dispatch_profile_does_not_block_secondmate_launch() {
   local rec id sm out status
   id=profile-secondmate-z16
@@ -378,6 +405,7 @@ test_grok_omits_invalid_max_reasoning_effort
 test_opencode_threads_model_and_ignores_effort_axis
 test_pi_omits_invalid_max_effort
 test_batch_forwards_shared_profile_flags
+test_scout_worktree_comes_from_lease
 test_active_dispatch_profile_does_not_block_secondmate_launch
 
 echo "# all fm-spawn-dispatch-profile tests passed"

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -19,6 +19,12 @@ make_spawn_fakebin() {
   cat > "$fakebin/tmux" <<'SH'
 #!/usr/bin/env bash
 set -u
+# A pane_current_path query returns FM_FAKE_WORKTREE so fm-spawn's post-lease
+# cd-verification loop sees the pane "land" in the worktree immediately; a bare
+# display-message (session name) returns 'firstmate'.
+case "$*" in
+  *pane_current_path*) printf '%s\n' "${FM_FAKE_WORKTREE:-}"; exit 0 ;;
+esac
 case "${1:-}" in
   display-message) printf 'firstmate\n'; exit 0 ;;
   list-windows) exit 0 ;;
@@ -358,8 +364,9 @@ test_scout_worktree_comes_from_lease() {
   # Regression: treehouse v2.0.0's interactive `get` opens a subshell whose cwd
   # the multiplexer does not report, so the old pane_current_path poll timed out
   # at 60s. fm-spawn now leases the worktree via `treehouse get --lease` and
-  # reads the path from stdout. The fakebin tmux stub answers no pane-cwd probe
-  # at all, so this spawn succeeds only via the lease path.
+  # reads the path from stdout, then cds the pane into it. The fakebin's tmux
+  # stub reports the worktree as the pane cwd, so the post-lease cd-verify loop
+  # passes on its first read.
   local rec id out status
   id=lease-worktree-z17
   rec=$(make_spawn_case lease-worktree claude "$id")
@@ -371,6 +378,55 @@ test_scout_worktree_comes_from_lease() {
   assert_contains "$out" "spawned $id" "lease-based spawn did not report success"
   assert_grep "worktree=$WT_DIR" "$HOME_DIR/state/$id.meta" "meta did not record the leased worktree from stdout"
   pass "scout worktree is acquired via treehouse --lease, independent of pane-cwd polling"
+}
+
+test_cd_into_worktree_is_verified_and_retried() {
+  # Regression: a freshly created pane's shell can drop the first keystroke, so
+  # `cd <wt>` arrives as `d <wt>` and the pane never leaves the primary checkout
+  # (observed live: the crewmate then tripped its own isolation guard). fm-spawn
+  # must VERIFY the cd landed by reading the pane cwd and re-send until it does.
+  # This stub reports the pane still in the project until it has seen TWO cd
+  # sends (simulating the first one being dropped), proving the retry works.
+  local rec id out status fakebin cwdstate
+  id=cd-retry-z18
+  rec=$(make_spawn_case cd-retry claude "$id")
+  read_case_record "$rec"
+  fakebin="$FAKEBIN_DIR"
+  cwdstate="$CASE_DIR/cd-count"
+  : > "$cwdstate"
+  # Overwrite the tmux stub with a drop-the-first-cd variant.
+  cat > "$fakebin/tmux" <<SH
+#!/usr/bin/env bash
+set -u
+case "\$*" in
+  *pane_current_path*)
+    # Report the worktree only after at least 2 cd sends have been seen.
+    if [ "\$(wc -c < "$cwdstate" | tr -d ' ')" -ge 2 ]; then
+      printf '%s\\n' "$WT_DIR"
+    else
+      printf '%s\\n' "$PROJ_DIR"
+    fi
+    exit 0 ;;
+esac
+case "\${1:-}" in
+  display-message) printf 'firstmate\\n'; exit 0 ;;
+  list-windows) exit 0 ;;
+  has-session|new-session|new-window|kill-window) exit 0 ;;
+  send-keys)
+    for a in "\$@"; do case "\$a" in "cd '$WT_DIR'") printf 'x' >> "$cwdstate" ;; esac; done
+    exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$fakebin" "$LAUNCH_LOG" --scout "$id" "$PROJ_DIR")
+  status=$?
+  expect_code 0 "$status" "spawn should re-send cd until the pane enters the worktree"
+  assert_contains "$out" "spawned $id" "spawn did not succeed after cd retry"
+  # At least 2 cd sends means the verify loop re-sent after the dropped first cd.
+  [ "$(wc -c < "$cwdstate" | tr -d ' ')" -ge 2 ] || fail "cd was not re-sent after the pane failed to enter the worktree"
+  pass "post-lease cd into the worktree is verified and retried until it lands"
 }
 
 test_active_dispatch_profile_does_not_block_secondmate_launch() {
@@ -406,6 +462,7 @@ test_opencode_threads_model_and_ignores_effort_axis
 test_pi_omits_invalid_max_effort
 test_batch_forwards_shared_profile_flags
 test_scout_worktree_comes_from_lease
+test_cd_into_worktree_is_verified_and_retried
 test_active_dispatch_profile_does_not_block_secondmate_launch
 
 echo "# all fm-spawn-dispatch-profile tests passed"

--- a/tests/fm-tangle-guard.test.sh
+++ b/tests/fm-tangle-guard.test.sh
@@ -149,18 +149,16 @@ test_brief_assertion_precedes_branch() {
 
 # --- GUARD 1b: fm-spawn isolation abort -------------------------------------
 
-# A fake tmux that reports FM_FAKE_PANE_PATH as the post-`treehouse get` pane cwd
-# (so the spawn's worktree-resolution loop resolves to a path we control), names
-# the session on '#S', and swallows window ops. Echoes the fakebin dir.
+# A fake tmux that names the session on '#S' and swallows window ops, paired
+# with a fake treehouse whose `get --lease` prints FM_FAKE_WORKTREE to stdout
+# (the real lease contract fm-spawn now reads), so the isolation guard sees a
+# worktree path we control. Echoes the fakebin dir.
 make_spawn_fakebin() {
   local dir=$1 fakebin
   fakebin=$(fm_fakebin "$dir")
   cat > "$fakebin/tmux" <<'SH'
 #!/usr/bin/env bash
 set -u
-case "$*" in
-  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
-esac
 case "${1:-}" in
   display-message) printf 'firstmate\n'; exit 0 ;;
   list-windows) exit 0 ;;
@@ -169,18 +167,26 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse
+  cat > "$fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  *get*--lease*) printf '%s\n' "${FM_FAKE_WORKTREE:-}"; exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/treehouse"
   printf '%s\n' "$fakebin"
 }
 
 run_spawn() {
-  local home=$1 id=$2 proj=$3 pane=$4 fakebin=$5
+  local home=$1 id=$2 proj=$3 leased=$4 fakebin=$5
   mkdir -p "$home/data/$id"
   printf 'brief\n' > "$home/data/$id/brief.md"
   FM_ROOT_OVERRIDE='' FM_HOME="$home" \
     FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
     FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
-    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$pane" TMUX="fake,1,0" \
+    FM_SPAWN_NO_GUARD=1 FM_FAKE_WORKTREE="$leased" TMUX="fake,1,0" \
     PATH="$fakebin:$PATH" \
     "$ROOT/bin/fm-spawn.sh" "$id" "$proj" codex 2>&1
 }

--- a/tests/fm-tangle-guard.test.sh
+++ b/tests/fm-tangle-guard.test.sh
@@ -159,6 +159,9 @@ make_spawn_fakebin() {
   cat > "$fakebin/tmux" <<'SH'
 #!/usr/bin/env bash
 set -u
+case "$*" in
+  *pane_current_path*) printf '%s\n' "${FM_FAKE_WORKTREE:-}"; exit 0 ;;
+esac
 case "${1:-}" in
   display-message) printf 'firstmate\n'; exit 0 ;;
   list-windows) exit 0 ;;


### PR DESCRIPTION
## Problem

`treehouse` v2.0.0's interactive `treehouse get` opens a subshell inside the worktree ("Type 'exit' to return"). tmux's `#{pane_current_path}` does **not** report that subshell's cwd, so `fm-spawn.sh`'s worktree-discovery poll never observed the pane leaving the project directory and **timed out at 60s on every crewmate/scout spawn** - even though the worktree was created successfully. This blocks all crewmate dispatch on the current treehouse release.

## Fix

Acquire the worktree via `treehouse get --lease` as a subprocess (path printed to stdout, banners to stderr), then `cd` the pane into it. This is the same durable primitive `fm-home-seed.sh` already uses for secondmate homes, and `fm-bootstrap.sh` already requires `--lease` support - the crewmate/scout path was simply left on the old interactive approach. Spawn drops from a 60s timeout to **~2s**.

Also fixes a latent collision: when firstmate runs inside a tmux session whose name is a plain integer (e.g. `58`), `tmux new-window -t 58` is parsed as a **window index**, so a second task fails with `index 58 in use`. Addressing the session as `<session>:` forces session interpretation (correct for named sessions too).

## Tests

- Updated `fm-spawn`/backend tests to the lease contract (treehouse stub prints the worktree path on `get --lease`).
- Converted the spawn old-vs-new byte-identical conformance test to a forward contract test, since this is an intended behavior change.
- Added a regression test proving spawn succeeds purely from the lease, with no pane-cwd read.
- Full suite passes locally; shellcheck clean on changed scripts.

Verified end-to-end: real crewmate spawns now complete in ~2s and launch into the leased worktree.
