### PR TITLE
fix(bearings): recreate today's status report file

### DIFF
--- a/.agents/skills/bearings/SKILL.md
+++ b/.agents/skills/bearings/SKILL.md
@@ -41,7 +41,7 @@ It never tears down a task, merges a PR, dispatches new work, or mutates any tas
 3. **Write the report to a dated file so it persists, and surface a concise version in chat.**
    - Write the full report to `data/status-report-<YYYY-MM-DD>.md` using today's date.
      This is the required artifact; it lives in gitignored `data/` alongside the worked example.
-     If the file already exists for today, overwrite it with the fresh snapshot rather than appending.
+     If today's file already exists, delete it first, then create a new file from scratch.
    - Surface a concise version to the captain in chat - the TL;DR plus the "Check first" list - and point to the file for the full picture.
    - For a richer review surface, optionally offer a Lavish board with `lavish-axi` when the report has enough structure to deserve one, but the markdown file is the required artifact and the chat summary is the required minimum.
 


### PR DESCRIPTION
## Intent

Tweak the bearings skill wording so a future agent deletes today's existing report file before creating the fresh report, instead of overwriting or modifying it in place. Replace the overwrite-in-place instruction with explicit delete-then-create wording. Keep the change tiny: preserve the contract that the full report is written to data/status-report-<YYYY-MM-DD>.md and a concise summary is surfaced in chat; do not broaden the skill or alter the report format.

## What Changed
- Updated the bearings skill instruction so today's existing `data/status-report-<YYYY-MM-DD>.md` is deleted before the fresh report is created.
- Preserved the existing bearings contract: write the full report to the dated status-report path and surface a concise summary in chat.

## Risk Assessment

✅ Low: Captain, this is a tightly scoped one-line wording change in a skill document, and it preserves the dated report path plus concise chat-summary contract while clarifying delete-then-create behavior.

## Testing

Captain, the full configured shell test suite had already passed as baseline; I then verified the actual future-agent-facing bearings skill text end to end by capturing the changed instruction excerpt and contract checks in the evidence file, with no whitespace-check issues and no working-tree artifacts left behind.

<details>
<summary>Evidence: bearings skill delete-then-create evidence</summary>

`Contract checks passed: required dated report path preserved, delete-then-create wording present, concise chat summary preserved, stale overwrite wording absent.`

```text
Evidence: bearings skill existing-report behavior
Worktree: /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KWZZSZE7XQSYAH95195A2JKV

Changed file and patch:

Target commit patch from base:
diff --git a/.agents/skills/bearings/SKILL.md b/.agents/skills/bearings/SKILL.md
index bd38167..8f061ca 100644
--- a/.agents/skills/bearings/SKILL.md
+++ b/.agents/skills/bearings/SKILL.md
@@ -41,7 +41,7 @@ It never tears down a task, merges a PR, dispatches new work, or mutates any tas
 3. **Write the report to a dated file so it persists, and surface a concise version in chat.**
    - Write the full report to `data/status-report-<YYYY-MM-DD>.md` using today's date.
      This is the required artifact; it lives in gitignored `data/` alongside the worked example.
-     If the file already exists for today, overwrite it with the fresh snapshot rather than appending.
+     If today's file already exists, delete it first, then create a new file from scratch.
    - Surface a concise version to the captain in chat - the TL;DR plus the "Check first" list - and point to the file for the full picture.
    - For a richer review surface, optionally offer a Lavish board with `lavish-axi` when the report has enough structure to deserve one, but the markdown file is the required artifact and the chat summary is the required minimum.
 

Future-agent-facing instruction excerpt:

3. **Write the report to a dated file so it persists, and surface a concise version in chat.**
   - Write the full report to `data/status-report-<YYYY-MM-DD>.md` using today's date.
     This is the required artifact; it lives in gitignored `data/` alongside the worked example.
     If today's file already exists, delete it first, then create a new file from scratch.
   - Surface a concise version to the captain in chat - the TL;DR plus the "Check first" list - and point to the file for the full picture.
   - For a richer review surface, optionally offer a Lavish board with `lavish-axi` when the report has enough structure to deserve one, but the markdown file is the required artifact and the chat summary is the required minimum.


Contract checks:
PASS required dated report path is preserved
PASS existing report instruction is delete-then-create
PASS concise chat summary contract is preserved
PASS stale overwrite-in-place wording is absent
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- <code>Baseline already ran successfully before this validation: `command -v tmux &gt;/dev/null || { echo &#34;tmux is required for e2e tests&#34; &gt;&amp;2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo &#34;== $t ==&#34;; bash &#34;$t&#34; || rc=1; done; exit &#34;$rc&#34;`</code>
- <code>Inspected the target patch with `git diff 121b9029c08a88c78a63efc81e0bda11016a2dd2..f70b34e7da886d67fd320bacd2f631d952f48687 -- .agents/skills/bearings/SKILL.md`.</code>
- <code>Generated reviewer evidence by extracting `sed -n &#39;40,47p&#39; .agents/skills/bearings/SKILL.md` and checking the required path, delete-then-create wording, chat-summary wording, and absence of stale overwrite wording.</code>
- <code>Ran `git diff --check 121b9029c08a88c78a63efc81e0bda11016a2dd2..f70b34e7da886d67fd320bacd2f631d952f48687 -- .agents/skills/bearings/SKILL.md`.</code>
- <code>Ran `git status --short` to confirm no transient working-tree artifacts remained.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
