### PR TITLE
feat(skills): add public visual-qa skill for web UI review

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,8 +134,10 @@ Firstmate's skills live in two separate places with different audiences:
 - `.agents/skills/` - agent-loaded skills (this section's table, plus firstmate's agent-only reference skills). Every one of these assumes a live firstmate home and is meaningless, or actively misleading, installed anywhere else, so each carries `metadata.internal: true` in its frontmatter. That flag hides them from installer discovery (tools like the [skills.sh](https://skills.sh) `npx skills add` installer) without affecting how firstmate itself loads them - frontmatter metadata is inert to the agent's own skill loader.
 - `skills/` - public, installer-facing skills meant to be installed standalone into any project, independent of firstmate.
   Each one is a self-contained skill with no dependency on firstmate's paths, tools, or vocabulary.
-  Today that is `skills/stow`, a generic session-knowledge-sweep skill that routes findings by explicit instruction first, then existing local conventions, then a private `.stow-notes.md` fallback in the current directory, and closes with a resume pointer for the next session.
+  Today that is `skills/stow` and `skills/visual-qa`.
+  `skills/stow` is a generic session-knowledge-sweep skill that routes findings by explicit instruction first, then existing local conventions, then a private `.stow-notes.md` fallback in the current directory, and closes with a resume pointer for the next session.
   It intentionally shares no code with the firstmate-internal `.agents/skills/stow` it is named after, so the two can evolve independently.
+  `skills/visual-qa` is a web-UI review procedure: a breakpoint matrix, a hover/interactive/empty/success state checklist, a table for translating subjective feedback into actionable design language, and a closing report format that tells a human where to see the change and what to verify.
 
 ## Documentation
 

--- a/skills/visual-qa/SKILL.md
+++ b/skills/visual-qa/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: visual-qa
+description: Review web UI work for visual quality before calling it done - a breakpoint matrix, a state checklist covering hover/interactive/empty/success states, a table for translating subjective feedback ("feels weird", "too corporate") into actionable design language, and a closing report format that tells a human where to see the change and what to verify. Use when building or reviewing any user-facing web UI change, when a user gives subjective visual feedback, or before declaring frontend work complete.
+user-invocable: true
+---
+
+<!-- maintainers: this is the public, installer-facing skill. Keep it standalone, with no private project paths, tool assumptions, or environment branching. -->
+
+# visual-qa
+
+Passing tests does not imply good visual quality.
+A UI change that compiles, type-checks, and passes every automated test can still be visually broken: overflowing at one width, missing a hover state, or collapsing into an empty screen with no message.
+This skill is the procedure for catching that before a human does: check the change at a fixed set of widths and states, translate any subjective feedback into concrete design dimensions, and close with a report that makes the change easy for a human to verify.
+
+## Breakpoint matrix
+
+Verify every UI change at each of these widths, using real rendering (a browser or browser automation), not intuition about how CSS should behave:
+
+| Width | Represents |
+| --- | --- |
+| 1440px | Desktop |
+| 1280px | Laptop |
+| 768px | Tablet |
+| 375px | Mobile |
+
+If the project documents its own breakpoints (a Tailwind config, a design-tokens file, a documented breakpoint scale), use those instead - the four widths above are the default when the project defines none.
+Do not verify only the width you developed at: most visual regressions live at the widths nobody was looking at.
+
+## State checklist
+
+At each width, check:
+
+- Layout integrity - nothing overlapping, clipped, or misaligned.
+- Visual hierarchy - the most important element reads as the most important; secondary content does not compete with it.
+- Hover states - every interactive element visibly responds to hover.
+- Interactive states - focus, active, disabled, and loading states exist and look intentional.
+- Overflow and wrapping - long text, long unbreakable strings, and large datasets wrap or truncate deliberately instead of breaking the layout.
+- Spacing consistency - gaps, padding, and margins follow one rhythm rather than ad hoc per-element values.
+- Accessibility - contrast is sufficient, interactive elements are reachable by keyboard, and images and controls have accessible names.
+- Empty states - the UI says something useful when there is no data, not a blank region.
+- Success and error states - the result of an action is visible, not inferable only from the absence of failure.
+- Project-specific variants - if the project has themes, locales, or a language toggle, check the change under each variant it affects.
+
+## Translating subjective feedback
+
+Human subjective reactions are first-class input, and the human is not required to use design terminology.
+Never dismiss feedback for being vague; translate it into an actionable design dimension, asking one clarifying question when the mapping is genuinely ambiguous.
+
+| Feedback | Translate into |
+| --- | --- |
+| "I don't like this." | Ask why once - corporate, crowded, generic, too playful - then map the answer using this table. |
+| "This feels weird." | Determine which dimension is off: hierarchy, spacing, contrast, copy, affordance, density, or consistency. |
+| "This feels too corporate." | Adjust tone: copy, placeholder text, imagery, and visual styling. |
+| "This feels cluttered / busy." | Reduce density: fewer competing elements, more whitespace, clearer hierarchy. |
+| "This looks generic / like a template." | Add a deliberate point of view: typography, color, and layout choices that are decisions rather than defaults. |
+
+Two rules that keep this loop productive:
+
+- Do not require a complete design system before making iterative improvements; act on the translated feedback now.
+- When feedback concerns wording - labels, buttons, headings, placeholders - treat it as audience architecture, not copyediting: identify who the language is for and what mental model it creates, then explain why the proposed wording is better.
+
+## Closing report
+
+A UI change is not complete until a human can easily verify it.
+End every UI change with a short report answering:
+
+1. Where to see it - the URL or route, and whether it is local only, committed, pushed, in a deploy preview, or in production.
+2. What visually changed - a plain-language description of the intended difference, with screenshots when you produced them.
+3. What to verify - which interactions to try and which of the widths and states above matter most for this change.
+4. What is already verified - which checks from this skill you completed, and which still need human eyes (subjective tone and taste always do).


### PR DESCRIPTION
## Intent

The developer (acting as a firstmate crewmate on firstmate's own repo) tasked the agent with creating a new public, installer-facing skill at skills/visual-qa/SKILL.md that distills UI-review knowledge currently duplicated in two lower-fidelity places: an exhortation in the global CLAUDE.md and a concrete checklist in trashtalknyc-website's docs/agent-protocol.md. Requirements: base the work on an existing scout audit report (candidate #2) as rationale/content source; include the breakpoint matrix (1440/1280/768/375px), an interactive/hover/empty/success state checklist, the "passing tests does not imply visual quality" framing, a subjective-feedback translation table, and a DX-report closing format; keep it project-agnostic (not trashtalknyc-specific) and placed in public skills/ (not agent-only .agents/skills/), matching the skills/stow precedent, with no "internal" metadata and a clear trigger/description. The developer explicitly said not to touch the trashtalknyc-website repo/clone from this worktree — that doc-shrinking follow-up should just be noted for a separate task. Work had to follow firstmate-coding-guidelines (knowledge placement, shellcheck, one-sentence-per-line markdown, plain dash, no co-author), be committed on a dedicated branch, and pushed/validated through the no-mistakes pipeline; a GitHub push-permission blocker was resolved by the developer configuring a fork, after which they asked the agent to rerun the pipeline from the failed push step.

## What Changed

- Add `skills/visual-qa/SKILL.md`, a new public, project-agnostic skill for reviewing web UI changes: a breakpoint matrix (1440/1280/768/375px), an interactive/hover/empty/success state checklist, a "passing tests does not imply visual quality" framing, a subjective-feedback translation table, and a structured closing report format.
- Update `README.md` to reference the new skill alongside existing public skills.

## Risk Assessment

✅ Low: The change is documentation-only (a new public, installer-facing SKILL.md plus a two-line README update), closely mirrors the existing skills/stow precedent in frontmatter shape, style, and public/agent-only placement, stays project-agnostic as required, and does not touch any project clone or executable code.

## Testing

The baseline shell test suite (47 tests/*.test.sh files covering bin/ scripts) already passed and is unaffected by this change, since the diff only touches README.md and a new public skill document. Since this is a documentation/content change with no runtime or rendered UI surface of its own, I verified the actual deliverable directly: the SKILL.md frontmatter parses correctly and matches the skills/stow public-skill precedent (no internal metadata, user-invocable), and the body contains every required element from the intent (breakpoint matrix, state checklist, "passing tests does not imply visual quality" framing, subjective-feedback translation table, closing report format), is project-agnostic, and correctly lives in public skills/ rather than .agents/skills/. Confirmed trashtalknyc-website was not touched and the working tree is clean. No issues found.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- <code>`git diff 2061c37..e77af1c --stat` — confirmed only `README.md` and `skills/visual-qa/SKILL.md` changed; `projects/trashtalknyc-website` untouched as required</code>
- <code>Parsed the SKILL.md YAML frontmatter — valid, matches the `skills/stow` public-skill precedent exactly (`name`, `description`, `user-invocable: true`, no `metadata.internal`)</code>
- `Grepped file content for required elements: breakpoint matrix (1440/1280/768/375px), the 'passing tests does not imply visual quality' framing, hover/interactive/empty/success state checklist items, the subjective-feedback translation table, and the 4-part closing report format — all present`
- <code>Confirmed the skill is project-agnostic (no trashtalknyc references) and correctly placed under public `skills/` rather than agent-only `.agents/skills/`</code>
- `Checked README.md diff for consistency with the new skill and one-sentence-per-line markdown style`
- <code>`bash tests/*.test.sh` baseline suite (already run per task setup) — unrelated to this diff since no `bin/` scripts changed</code>
- <code>`git status --porcelain` — working tree clean, no stray artifacts</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
