### PR TITLE
feat(skills): add no-mistakes-gate-recovery crewmate skill

### DIFF
--- a/.agents/skills/no-mistakes-gate-recovery/SKILL.md
+++ b/.agents/skills/no-mistakes-gate-recovery/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: no-mistakes-gate-recovery
+description: >-
+  Agent-only recovery reference for crewmates whose no-mistakes gate or push step fails inside a firstmate task worktree.
+  Load when a no-mistakes push, gate, or pipeline step errors before debugging by hand.
+user-invocable: false
+metadata:
+  internal: true
+---
+
+# no-mistakes-gate-recovery
+
+Check this list before hand-debugging a no-mistakes failure.
+Apply the matching fix, resume the run, and escalate `blocked:` only if the fix fails a second time.
+This is a narrow list of confirmed recoveries, not a general troubleshooting guide: a failure mode is added only after it has actually been observed and its fix verified.
+
+## "invalid gate path: ." on the pipeline's first push
+
+The pipeline's first push to its internal gate repo fails with `invalid gate path: .` from inside a treehouse task worktree.
+Observed twice on trashtalknyc-website against no-mistakes v1.31.2, 2026-07, by different crews with the identical resolution (tasks revamp-about-x4 / PR #15 and revamp-home-q2 / PR #16).
+
+1. Delete the branch ref on the internal no-mistakes remote: `git push no-mistakes :refs/heads/<your-branch>`.
+2. Re-push the branch: `git push no-mistakes <your-branch>`.
+3. Resume the run; the pipeline's own version-matched guidance (`no-mistakes axi run --help` and the `help` lines in each `axi` response) is authoritative for the resume mechanics.
+
+Do not modify the code change, do not abort the run, and do not re-validate by hand.
+If the push fails again after the ref re-push, append `blocked: no-mistakes gate push failing after ref re-push` to your status file and stop.
+
+The durable fix belongs upstream in no-mistakes and is tracked with root-cause analysis at https://github.com/kunchenguid/no-mistakes/issues/420; this recovery exists so a crewmate is not stranded while that lands.
+
+## Anything else
+
+Follow the pipeline's own version-matched guidance (`no-mistakes axi run --help`, per-response `help` lines).
+Escalate through `needs-decision:`/`blocked:` per your brief rather than inventing a workaround.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -896,6 +896,7 @@ These skills are not captain-invocable; they are conditional operating reference
 - `fmx-respond` - load on an `x-mention <request_id>` `check:` wake to handle the mention, on an `x-mode-error ...` `check:` wake to report the X-mode configuration blocker, and on any milestone or terminal wake for an X-linked task before posting its completion follow-up; relevant only when X mode is on.
 - `firstmate-codexapp` - load before coordinating a visible Codex Desktop thread, evaluating a Codex App backend request, or reconciling Codex Desktop host-tool smoke evidence for Firstmate work.
 - `firstmate-coding-guidelines` - load before changing firstmate's shared, tracked material, as defined by section 1's list, whether editing directly or briefing a crewmate for a firstmate-repo task.
+- `no-mistakes-gate-recovery` - load by a crewmate when a no-mistakes push, gate, or pipeline step errors inside its task worktree, before debugging by hand.
 
 ## 14. X mode
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -213,6 +213,7 @@ Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
 You drive no-mistakes by responding to its gates, not by implementing fixes.
 Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.
 Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.
+If a no-mistakes push, gate, or pipeline step errors, read \`$FM_ROOT/.agents/skills/no-mistakes-gate-recovery/SKILL.md\` before debugging by hand.
 
 Two firstmate-specific rules layer on top of that guidance:
 - ask-user findings are not yours to answer: escalate to firstmate (rule 6) and stop.

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -76,6 +76,22 @@ test_no_mistakes_dod_wording() {
   pass "fm-brief.sh: no-mistakes DOD wording avoids the apostrophe regression"
 }
 
+# The no-mistakes DOD must point crewmates at the gate-recovery skill by
+# absolute path, because crewmates in project worktrees cannot load firstmate
+# skills by slash-name (same mechanism as the fm-ensure-agents-md.sh pointer).
+test_no_mistakes_gate_recovery_pointer() {
+  local home id brief
+  home="$TMP_ROOT/gate-recovery-home"
+  mkdir -p "$home/data"
+  id="brief-gaterec-d1"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_present "$brief" "brief was not scaffolded"
+  assert_grep "$ROOT/.agents/skills/no-mistakes-gate-recovery/SKILL.md" "$brief" \
+    "no-mistakes DOD lost the absolute-path gate-recovery skill pointer"
+  pass "fm-brief.sh: no-mistakes DOD points at the gate-recovery skill by absolute path"
+}
+
 test_ship_project_memory_wording() {
   local home id brief
   home="$TMP_ROOT/project-memory-home"
@@ -96,4 +112,5 @@ test_ship_project_memory_wording() {
 test_script_parses
 test_ship_modes_generate_clean_briefs
 test_no_mistakes_dod_wording
+test_no_mistakes_gate_recovery_pointer
 test_ship_project_memory_wording


### PR DESCRIPTION
## Intent

The developer (via a crewmate agent operating in firstmate's own repo) was tasked with adding a new agent-only skill, `.agents/skills/no-mistakes-gate-recovery/SKILL.md`, documenting a recovery procedure for the recurring `invalid gate path: .` failure seen twice on trashtalknyc-website when no-mistakes' pipeline first pushes to its internal gate repo from a treehouse worktree. The fix: delete and re-push the branch ref on the no-mistakes remote, then resume the run, escalating only if it fails a second time. Requirements: base the skill on an existing scout-audit draft (candidate #1) rather than re-deriving it, keep the skill narrow and evidence-backed (no speculative failure modes), add a one-line absolute-path pointer to this skill in `bin/fm-brief.sh`'s no-mistakes-mode brief scaffold (mirroring the existing `fm-ensure-agents-md.sh` pointer), and follow the `firstmate-coding-guidelines` skill's rules (shellcheck-clean, one-sentence-per-line markdown, plain dash, no co-author). It also asked to file an upstream no-mistakes issue with two reproduction PRs as evidence if a sensible venue existed, or skip and note it otherwise — the agent found a duplicate upstream issue (#420) already filed and instead added a corroborating comment rather than filing a new one. Work was committed on branch `fm/no-mistakes-gate-recovery-skill` and the no-mistakes validation pipeline was subsequently run, hitting an `ask-user` review finding (about whether the new skill needs registration in AGENTS.md section 13) that was escalated rather than decided unilaterally.

## What Changed

- Added `.agents/skills/no-mistakes-gate-recovery/SKILL.md`, an agent-only recovery reference documenting how to handle a no-mistakes gate/push `invalid gate path: .` failure (delete and re-push the branch ref on the no-mistakes remote, resume the run, escalate only on a second failure).
- Registered the new skill in `AGENTS.md` section 13 alongside the other agent-only reference skills.
- Added a one-line absolute-path pointer to the new skill in `bin/fm-brief.sh`'s no-mistakes-mode brief scaffold (mirroring the existing `fm-ensure-agents-md.sh` pointer), with a corresponding assertion added to `tests/fm-brief.test.sh`.

## Risk Assessment

✅ Low: Small, additive, well-scoped change: a new agent-only skill doc, one AGENTS.md registration line, one pointer line added to the no-mistakes-mode brief scaffold (correctly placed inside the unquoted heredoc so $FM_ROOT expands to an absolute path, verified against the existing fm-ensure-agents-md.sh pattern), and a matching test; the cited upstream issue #420 was confirmed to exist and match the documented symptom.

## Testing

The configured baseline test command already passed; I additionally ran the targeted tests/fm-brief.test.sh suite (all green, including the new pointer-assertion test) and manually generated an end-to-end crewmate brief to confirm the absolute-path pointer to .agents/skills/no-mistakes-gate-recovery/SKILL.md is present, resolves to a real file, and that file's content matches the intended narrow, evidence-backed recovery procedure with the AGENTS.md section 13 registration also in place. A full-repo test-suite re-run timed out after 2 minutes on unrelated backend (cmux/zellij/herdr) test files, which is a pre-existing suite-size/runtime characteristic unrelated to this change, not a regression it introduced.

<details>
<summary>Evidence: Generated crewmate brief showing the gate-recovery pointer line in context</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Setup
You are in a disposable git worktree of some-project, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/demo-brief-1`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/kt/xcbd1ss945n6p2w0ltqcrwzh0000gn/T/tmp.bKOjE27QIi/state/demo-brief-1.status'`
   States: working, needs-decision, blocked, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs to a human (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/Users/fabiolavillatoro/.no-mistakes/worktrees/16b19a21922d/01KX059DV2XMYN1SJCYVV6ATD7/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/Users/fabiolavillatoro/.no-mistakes/worktrees/16b19a21922d/01KX059DV2XMYN1SJCYVV6ATD7/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.
If a no-mistakes push, gate, or pipeline step errors, read `/Users/fabiolavillatoro/.no-mistakes/worktrees/16b19a21922d/01KX059DV2XMYN1SJCYVV6ATD7/.agents/skills/no-mistakes-gate-recovery/SKILL.md` before debugging by hand.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are not yours to answer: escalate to firstmate (rule 6) and stop.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: the captain, not you, owns the ask-user decisions it would silently auto-resolve.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- `bash tests/fm-brief.test.sh (all 5 assertions pass, including the new test_no_mistakes_gate_recovery_pointer)`
- <code>Manually generated a real ship brief via `FM_HOME=&lt;tmp&gt; bash bin/fm-brief.sh demo-brief-1 some-project` and inspected the emitted pointer line</code>
- <code>Verified the emitted absolute path (`$FM_ROOT/.agents/skills/no-mistakes-gate-recovery/SKILL.md`) resolves to an existing, readable file with the expected recovery content</code>
- `grep for em-dash/en-dash characters across the changed files (none found, per firstmate-coding-guidelines style)`
- `git log inspection of both new commits to confirm no co-author trailer was added`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
