### PR TITLE
codex: bypass hook trust in spawn template

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -25,7 +25,7 @@ If `config/crew-harness` is unset or `default`, there is no concrete value to in
 Inheritance also copies the literal `config/crew-dispatch.json` file, so secondmates apply the same best-fit profile rules for their own crewmates.
 
 Each adapter splits into mechanics and knowledge.
-The per-task mechanics, including launch command, autonomy flag, and crewmate turn-end hook, live in `bin/fm-spawn.sh`.
+The per-task mechanics, including launch command, autonomy flags, and crewmate turn-end hook, live in `bin/fm-spawn.sh`.
 The primary-session "no turn ends blind" guard contract and harness hook installation paths live in `docs/turnend-guard.md`.
 The supervision knowledge lives here: busy signature, exit command, interrupt, dialogs, resume behavior, skill invocation, and quirks.
 
@@ -128,6 +128,9 @@ This is why the validation trigger (`$no-mistakes`) to a codex crew now lands on
 Directory trust dialog on first run per repo root: "Do you trust the contents of this directory?"
 Accept with Enter.
 The decision persists for the repo, so later worktrees of the same project skip it.
+`fm-spawn.sh` includes Codex's hook-trust bypass in its verified launch template, so hook-trust prompts should not stop firstmate-spawned Codex workers.
+If one does, treat it as a launch-template regression and check `bin/fm-spawn.sh`.
+This does not replace the directory trust dialog above.
 
 Resume after exit with `codex resume <session-id>`.
 The session id is printed on quit.

--- a/.opencode/plugins/fm-primary-turnend-guard.js
+++ b/.opencode/plugins/fm-primary-turnend-guard.js
@@ -4,6 +4,12 @@ let skipNextIdle = false;
 
 function runProcess(command, args, input = "") {
   return new Promise((resolve) => {
+    let settled = false;
+    const finish = (result) => {
+      if (settled) return;
+      settled = true;
+      resolve(result);
+    };
     const child = spawn(command, args, {
       stdio: ["pipe", "pipe", "pipe"],
     });
@@ -15,8 +21,9 @@ function runProcess(command, args, input = "") {
     child.stderr.on("data", (chunk) => {
       stderr += chunk.toString();
     });
-    child.on("error", () => resolve({ code: 0, stdout: "", stderr: "" }));
-    child.on("close", (code) => resolve({ code: code ?? 0, stdout, stderr }));
+    child.stdin.on("error", () => {});
+    child.on("error", () => finish({ code: 0, stdout: "", stderr: "" }));
+    child.on("close", (code) => finish({ code: code ?? 0, stdout, stderr }));
     child.stdin.end(input);
   });
 }

--- a/.opencode/plugins/package.json
+++ b/.opencode/plugins/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -302,7 +302,7 @@ Inheritance copies the literal `config/crew-harness` file, so a secondmate's own
 Propagation timing, mechanism, and `bin/fm-config-push.sh` are section 3's canonical statement.
 
 Each adapter splits into mechanics and knowledge.
-The per-task mechanics (launch command, autonomy flag, crewmate turn-end hook) live in `bin/fm-spawn.sh`; the primary-session turn-end guard lives in `docs/turnend-guard.md`; the knowledge you need while supervising (busy signature, exit, interrupt, dialogs, quirks, skill invocation, resume) lives in the agent-only `harness-adapters` skill.
+The per-task mechanics (launch command, autonomy flags, crewmate turn-end hook) live in `bin/fm-spawn.sh`; the primary-session turn-end guard lives in `docs/turnend-guard.md`; the knowledge you need while supervising (busy signature, exit, interrupt, dialogs, quirks, skill invocation, resume) lives in the agent-only `harness-adapters` skill.
 **Never dispatch a crewmate or secondmate on an unverified adapter.**
 If `config/crew-harness` or `config/secondmate-harness` names an unverified one, tell the captain and fall back to your own harness until it is verified.
 If the captain asks for a new harness, load `harness-adapters`, verify it empirically with a trivial supervised task, then commit the script and knowledge changes.

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -87,11 +87,11 @@ DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 PROJECTS="${FM_PROJECTS_OVERRIDE:-$FM_HOME/projects}"
 CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
 SUB_HOME_MARKER=".fm-secondmate-home"
-# shellcheck source=bin/fm-ff-lib.sh
+# shellcheck source=bin/fm-ff-lib.sh disable=SC1091
 . "$SCRIPT_DIR/fm-ff-lib.sh"
-# shellcheck source=bin/fm-config-inherit-lib.sh
+# shellcheck source=bin/fm-config-inherit-lib.sh disable=SC1091
 . "$SCRIPT_DIR/fm-config-inherit-lib.sh"
-# shellcheck source=bin/fm-backend.sh
+# shellcheck source=bin/fm-backend.sh disable=SC1091
 . "$SCRIPT_DIR/fm-backend.sh"
 # Skip the watcher guard when re-exec'd for one pair of a batch (FM_SPAWN_NO_GUARD is
 # set by the batch loop below), so the guard runs once for the batch, not once per pair.

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -308,9 +308,9 @@ launch_template() {
     claude) printf '%s' 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions __MODELFLAG____EFFORTFLAG__"$(cat __BRIEF__)"' ;;
     codex)
       if [ "$kind" = secondmate ]; then
-        printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox "$(cat __BRIEF__)"'
+        printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust "$(cat __BRIEF__)"'
       else
-        printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch __TURNEND__\"]" "$(cat __BRIEF__)"'
+        printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust -c "notify=[\"bash\",\"-c\",\"touch __TURNEND__\"]" "$(cat __BRIEF__)"'
       fi
       ;;
     opencode) printf '%s' 'OPENCODE_CONFIG_CONTENT='\''{"permission":{"*":"allow"}}'\'' opencode __MODELFLAG__--prompt "$(cat __BRIEF__)"' ;;

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -307,6 +307,11 @@ launch_template() {
     # the defense-in-depth backstop for any pane this flag cannot reach.
     claude) printf '%s' 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions __MODELFLAG____EFFORTFLAG__"$(cat __BRIEF__)"' ;;
     codex)
+      # Codex needs both dangerous automation bypasses in unattended firstmate
+      # sessions: tool approval/sandbox bypass for autonomous work, and hook
+      # trust bypass so a repo-local hook prompt cannot stop a worker before it
+      # reads the brief. Ship/scout launches still carry notify= for the
+      # per-task turn-end marker; secondmate launches intentionally do not.
       if [ "$kind" = secondmate ]; then
         printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust "$(cat __BRIEF__)"'
       else

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -37,7 +37,7 @@ All verified primary harnesses have a tracked integration:
 
 - `claude`: `.claude/settings.json` registers a `Stop` hook command anchored through `"$CLAUDE_PROJECT_DIR"/bin/fm-turnend-guard.sh`.
 - `codex`: `.codex/hooks.json` registers a `Stop` hook that reads the hook payload once, anchors the executable to the hook command process working directory, verifies that root is firstmate-shaped and hook-bearing, and pipes the original payload to that checkout's `bin/fm-turnend-guard.sh`.
-- `opencode`: `.opencode/plugins/fm-primary-turnend-guard.js` listens for `session.idle`, runs the shared guard, and uses `client.session.promptAsync` to force one follow-up prompt when the guard returns 2.
+- `opencode`: `.opencode/plugins/package.json` declares ESM loading for `.opencode/plugins/fm-primary-turnend-guard.js`, which listens for `session.idle`, runs the shared guard, and uses `client.session.promptAsync` to force one follow-up prompt when the guard returns 2.
 - `pi`: `.pi/extensions/fm-primary-turnend-guard.ts` listens for `turn_end`, runs the shared guard, and uses `pi.sendUserMessage(..., { deliverAs: "followUp" })` to force one follow-up prompt when the guard returns 2.
 - `grok`: `.grok/hooks/fm-primary-turnend-guard.json` registers a `Stop` hook that invokes `bin/fm-turnend-guard-grok.sh`.
   The adapter runs the shared guard and, when it returns 2, invokes `grok --resume <sessionId> -p <guard-reason>` with `GROK_TURNEND_GUARD_ACTIVE=1`.
@@ -50,7 +50,7 @@ Both payloads include `stop_hook_active`; when it is true, the shared guard exit
 OpenCode, Pi, and Grok expose passive turn-end events for this purpose.
 Their adapters fail open at the hook boundary to avoid corrupting a user session, but they force one follow-up turn when the shared predicate blocks.
 Each adapter carries its own in-process or environment loop guard so the forced follow-up does not recursively schedule another follow-up.
-If a passive adapter cannot call its SDK method, cannot find `grok`, or cannot recover the Grok session id, it fails open and relies on the pull-based `fm-guard.sh` warning at the next fleet command.
+If a passive adapter cannot run its guard subprocess, call its SDK method, find `grok`, or recover the Grok session id, it fails open and relies on the pull-based `fm-guard.sh` warning at the next fleet command.
 
 ## Empirical Validation
 
@@ -73,12 +73,13 @@ The tracked command therefore treats hook process PWD as the hook-loaded firstma
 It still passes the original payload to `bin/fm-turnend-guard.sh`, so the shared loop guard reads `stop_hook_active`.
 
 OpenCode 1.17.6 was validated with project plugins under scratch `.opencode/plugins/`.
-Hook file used: `.opencode/plugins/fm-smoke.js` for throw testing and `.opencode/plugins/fm-primary-turnend-guard.js` for follow-up testing.
+Hook files used: `.opencode/plugins/package.json` for ESM loading, `.opencode/plugins/fm-smoke.js` for throw testing, and `.opencode/plugins/fm-primary-turnend-guard.js` for follow-up testing.
 Command run for passive behavior: `opencode run --print-logs --log-level DEBUG --dangerously-skip-permissions 'Say hi in exactly one word.'`.
 Observed output: the plugin received `session.idle`, threw an error, and `opencode run` still exited 0 with `Hi`, proving `session.idle` cannot block directly.
 Command run for follow-up behavior: `OPENCODE_CONFIG_CONTENT='{"permission":{"*":"allow"}}' opencode --prompt 'Say hi in exactly one word.' --print-logs --log-level INFO`.
 Observed output: the plugin called `client.session.promptAsync`, the TUI ran a second turn, and the second model output contained `OPENCODEHOOK`.
 In noninteractive `opencode run`, `promptAsync` returned successfully but the process exited before displaying the follow-up, so this adapter is trusted for primary TUI sessions and documented as passive/fail-open in headless mode.
+The tracked plugin also treats guard subprocess spawn and stdin errors as fail-open, matching the passive adapter policy above.
 
 Pi 0.80.2 was validated with a scratch extension.
 Hook file used: a scratch `ext.ts` matching `.pi/extensions/fm-primary-turnend-guard.ts`.

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -269,7 +269,7 @@ ROWS
 }
 
 test_orca_backend_gates_orca_tool_only_when_selected() {
-  local case_dir fakebin out missing_orca
+  local case_dir fakebin masked_path out missing_orca
   missing_orca="MISSING: orca (install: brew install orca  # or the platform's package manager)"
 
   case_dir="$TMP_ROOT/orca-backend-selected"
@@ -277,7 +277,8 @@ test_orca_backend_gates_orca_tool_only_when_selected() {
   printf '%s\n' manual > "$case_dir/home/config/backlog-backend"
   printf '%s\n' orca > "$case_dir/home/config/backend"
   fakebin=$(make_fake_toolchain "$case_dir")
-  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+  masked_path=$(fm_path_without_tools "$case_dir/base-without-orca" "$BASE_PATH" orca)
+  out=$(PATH="$fakebin:$masked_path" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
     FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
   [ "$out" = "$missing_orca" ] || fail "backend=orca should require only the Orca-specific missing tool, got: $out"
 
@@ -285,7 +286,8 @@ test_orca_backend_gates_orca_tool_only_when_selected() {
   mkdir -p "$case_dir/home/config"
   printf '%s\n' manual > "$case_dir/home/config/backlog-backend"
   fakebin=$(make_fake_toolchain "$case_dir")
-  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+  masked_path=$(fm_path_without_tools "$case_dir/base-without-orca" "$BASE_PATH" orca)
+  out=$(PATH="$fakebin:$masked_path" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
     FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
   assert_not_contains "$out" "MISSING: orca" "bootstrap should not require orca unless backend=orca is selected"
   pass "bootstrap: backend=orca gates the Orca CLI without requiring it on the default backend"

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -32,9 +32,9 @@ set -u
 
 # shellcheck source=tests/lib.sh
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
-# shellcheck source=bin/fm-ff-lib.sh
+# shellcheck source=bin/fm-ff-lib.sh disable=SC1091
 . "$ROOT/bin/fm-ff-lib.sh"
-# shellcheck source=bin/fm-config-inherit-lib.sh
+# shellcheck source=bin/fm-config-inherit-lib.sh disable=SC1091
 . "$ROOT/bin/fm-config-inherit-lib.sh"
 
 BASE_PATH=${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin}

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -590,8 +590,8 @@ test_spawn_explicit_harness_does_not_inherit_secondmate_harness_tokens() {
   [ "$(meta_field "$meta" model)" = default ] || fail "explicit-harness-no-tokens: meta model should stay default"
   [ "$(meta_field "$meta" effort)" = default ] || fail "explicit-harness-no-tokens: meta effort should stay default"
   launch=$(cat "$launchlog")
-  assert_contains "$launch" "codex --dangerously-bypass-approvals-and-sandbox" \
-    "explicit-harness-no-tokens: launch did not use codex"
+  assert_contains "$launch" "codex --dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust" \
+    "explicit-harness-no-tokens: codex launch did not include both dangerous automation flags"
   assert_not_contains "$launch" "--model" "explicit-harness-no-tokens: launch must not carry a --model flag"
   assert_not_contains "$launch" "model_reasoning_effort" \
     "explicit-harness-no-tokens: launch must not carry a codex effort flag"

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -22,7 +22,7 @@ set -u
 
 # shellcheck source=tests/lib.sh
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
-# shellcheck source=tests/wake-helpers.sh
+# shellcheck source=tests/wake-helpers.sh disable=SC1091
 . "$(dirname "${BASH_SOURCE[0]}")/wake-helpers.sh"
 
 SESSION_START="$ROOT/bin/fm-session-start.sh"

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -249,7 +249,7 @@ EOF
 # --- output ordering ----------------------------------------------------------
 
 test_output_ordering_diagnostics_lead() {
-  local rec root home fakebin out lock_line boot_line wake_line context_line fleet_line next_line
+  local rec root home fakebin masked_path out lock_line boot_line wake_line context_line fleet_line next_line
   rec=$(new_world ordering)
   IFS='|' read -r root home fakebin <<EOF
 $rec
@@ -258,10 +258,11 @@ EOF
   make_fake_ps_claude "$fakebin"
   # Force a MISSING diagnostic line so the bootstrap section is non-trivial.
   rm -f "$fakebin/node"
+  masked_path=$(fm_path_without_tools "$TMP_ROOT/ordering-base-without-node" "$BASE_PATH" node)
 
   printf 'window=fm-sess:w1\nkind=ship\n' > "$home/state/task-a.meta"
 
-  out=$(run_session_start "$home" "$root" "$fakebin:$BASE_PATH")
+  out=$(run_session_start "$home" "$root" "$fakebin:$masked_path")
 
   lock_line=$(printf '%s\n' "$out" | grep -n '^LOCK$' | head -1 | cut -d: -f1)
   boot_line=$(printf '%s\n' "$out" | grep -n '^BOOTSTRAP$' | head -1 | cut -d: -f1)
@@ -393,7 +394,7 @@ EOF
 # --- composition: real scripts run, not reimplemented ------------------------
 
 test_composition_invokes_real_scripts() {
-  local rec root home fakebin out
+  local rec root home fakebin masked_path out
   rec=$(new_world composition)
   IFS='|' read -r root home fakebin <<EOF
 $rec
@@ -401,10 +402,11 @@ EOF
   make_fake_toolchain "$fakebin"
   make_fake_ps_claude "$fakebin"
   rm -f "$fakebin/node"
+  masked_path=$(fm_path_without_tools "$TMP_ROOT/composition-base-without-node" "$BASE_PATH" node)
 
   append_wake "$home/state" signal task-z "needs-decision: pick a library"
 
-  out=$(run_session_start "$home" "$root" "$fakebin:$BASE_PATH")
+  out=$(run_session_start "$home" "$root" "$fakebin:$masked_path")
 
   # fm-lock.sh's own exact success text.
   assert_contains "$out" "lock acquired: harness pid" "fm-lock.sh's real output did not appear (composition, not reimplementation)"

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -169,7 +169,7 @@ test_active_dispatch_profile_allows_explicit_harness() {
   assert_contains "$out" "spawned $id harness=codex" "spawn did not report explicit codex harness"
   assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5 high
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "codex --model 'gpt-5' -c 'model_reasoning_effort=\"high\"' --dangerously-bypass-approvals-and-sandbox" \
+  assert_contains "$launch" "codex --model 'gpt-5' -c 'model_reasoning_effort=\"high\"' --dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust" \
     "explicit harness launch did not thread model and effort"
   pass "active crew-dispatch profile allows an explicit resolved harness"
 }
@@ -235,9 +235,9 @@ test_codex_threads_model_and_effort() {
   expect_code 0 "$status" "codex spawn with profile flags should succeed"
   assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5 high
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "codex --model 'gpt-5' -c 'model_reasoning_effort=\"high\"' --dangerously-bypass-approvals-and-sandbox" \
-    "codex launch did not thread model and reasoning effort config"
-  pass "codex receives --model and model_reasoning_effort profile flags"
+  assert_contains "$launch" "codex --model 'gpt-5' -c 'model_reasoning_effort=\"high\"' --dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust" \
+    "codex launch did not thread model, reasoning effort config, and dangerous automation flags"
+  pass "codex receives --model, model_reasoning_effort, and automation bypass flags"
 }
 
 test_codex_omits_invalid_max_effort() {
@@ -251,7 +251,7 @@ test_codex_omits_invalid_max_effort() {
   expect_code 0 "$status" "codex spawn with unsupported max effort should omit the effort flag"
   assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5 max
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "codex --model 'gpt-5' --dangerously-bypass-approvals-and-sandbox" \
+  assert_contains "$launch" "codex --model 'gpt-5' --dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust" \
     "codex launch did not preserve the model flag when max effort was omitted"
   assert_not_contains "$launch" "model_reasoning_effort" "codex launch must omit unsupported max reasoning effort"
   pass "codex omits unsupported max effort instead of passing a bad config value"

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -91,6 +91,34 @@ SH
   done
 }
 
+# fm_path_without_tools <dest> <base-path> <tool>...: create a PATH directory
+# mirroring executable names from <base-path> except the named tools.
+# This keeps missing-tool tests deterministic on hosts that have optional tools
+# like node or orca installed in /usr/bin.
+fm_path_without_tools() {
+  local dest=$1 base_path=$2 old_ifs dir path name tool skip
+  shift 2
+  mkdir -p "$dest"
+  old_ifs=$IFS
+  IFS=:
+  for dir in $base_path; do
+    [ -d "$dir" ] || continue
+    for path in "$dir"/*; do
+      [ -e "$path" ] || [ -L "$path" ] || continue
+      [ -x "$path" ] || continue
+      name=${path##*/}
+      skip=0
+      for tool in "$@"; do
+        [ "$name" = "$tool" ] && { skip=1; break; }
+      done
+      [ "$skip" -eq 0 ] || continue
+      [ -e "$dest/$name" ] || [ -L "$dest/$name" ] || ln -s "$path" "$dest/$name" 2>/dev/null || true
+    done
+  done
+  IFS=$old_ifs
+  printf '%s\n' "$dest"
+}
+
 # --- deterministic git identity and fixtures --------------------------------
 
 # fm_git_identity [name] [email]: export a fixed author/committer identity so

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -96,12 +96,12 @@ SH
 # This keeps missing-tool tests deterministic on hosts that have optional tools
 # like node or orca installed in /usr/bin.
 fm_path_without_tools() {
-  local dest=$1 base_path=$2 old_ifs dir path name tool skip
+  local dest=$1 base_path=$2 dir path name tool skip
+  local -a dirs
   shift 2
   mkdir -p "$dest"
-  old_ifs=$IFS
-  IFS=:
-  for dir in $base_path; do
+  IFS=: read -r -a dirs <<< "$base_path"
+  for dir in "${dirs[@]}"; do
     [ -d "$dir" ] || continue
     for path in "$dir"/*; do
       [ -e "$path" ] || [ -L "$path" ] || continue
@@ -115,7 +115,6 @@ fm_path_without_tools() {
       [ -e "$dest/$name" ] || [ -L "$dest/$name" ] || ln -s "$path" "$dest/$name" 2>/dev/null || true
     done
   done
-  IFS=$old_ifs
   printf '%s\n' "$dest"
 }
 


### PR DESCRIPTION
## Summary
- Add `--dangerously-bypass-hook-trust` to Firstmate-spawned Codex launch templates alongside `--dangerously-bypass-approvals-and-sandbox`.
- Cover ordinary ship/scout Codex launches and secondmate Codex launches with focused assertions.
- Include no-mistakes follow-up fixes from the validated gate head for test stability, docs, and shellcheck annotations.

## Validation
- no-mistakes run `01KX0DC7DCQKTNV2RA25SB9926` completed review, test, document, and lint.
- Captain explicitly approved treating project Codex hooks as inside the trusted automation boundary for Firstmate worktrees.
- Direct `shellcheck` 0.11.0 was available for the lint retry.
- Push to upstream failed due permissions, so this PR is opened from the ThomShark fork.
