### PR TITLE
Fix fm-spawn help parsing

### DIFF
--- a/.opencode/package.json
+++ b/.opencode/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/.opencode/plugins/fm-primary-turnend-guard.js
+++ b/.opencode/plugins/fm-primary-turnend-guard.js
@@ -35,7 +35,7 @@ function runGuard(root) {
 }
 
 export const FmPrimaryTurnendGuard = async ({ client, directory, worktree }) => {
-  const root = await resolveRoot(worktree ?? directory);
+  const root = worktree ?? (await resolveRoot(directory));
 
   return {
     event: async ({ event }) => {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,7 +92,7 @@ tests/fm-x-mode.test.sh                   # X-mode poll, inbox context round-tri
 tests/fm-tangle-guard.test.sh             # primary-checkout tangle detection, read-only remediation suppression, and spawn/brief isolation tests
 tests/fm-brief.test.sh                    # fm-brief.sh bash -n parse regression guard (issue #166) and clean no-mistakes/direct-PR/local-only brief generation tests
 tests/fm-dispatch-select.test.sh          # deterministic crew-dispatch profile selection, quota-balanced tie/stale/fallback behavior, and backward-compatible first-profile selection tests
-tests/fm-spawn-batch.test.sh              # batch dispatch and FM_HOME project-path scoping tests
+tests/fm-spawn-batch.test.sh              # spawn help, missing-positional usage, batch dispatch, and FM_HOME project-path scoping tests
 tests/fm-spawn-dispatch-profile.test.sh   # concrete dispatch profile flags: active-profile backstop, harness/model/effort meta, launch templates, batch forwarding, and secondmate exemption
 tests/fm-update.test.sh                   # fast-forward-only self-update, reread, nudge, dedup, and skip-safety tests
 tests/fm-secondmate-sync.test.sh          # local-HEAD secondmate sync, no-fetch, bootstrap nudge gating, stable nudge selectors after respawn, and spawn hook tests

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -164,6 +164,80 @@ case "$EFFORT" in
   *) echo "error: --effort must be one of low, medium, high, xhigh, max" >&2; exit 1 ;;
 esac
 
+# Batch dispatch (see header): when the first positional is an `id=repo` pair, treat every
+# positional as one and spawn each by re-execing this script in single-task mode. We use
+# the FM_ROOT path (not $0) so it works whatever cwd or relative path invoked us, and reuse
+# the single path verbatim. A failed pair is reported and skipped; the rest still launch;
+# exit is non-zero if any pair failed. Single-task invocations never carry an '=' in arg
+# one (task ids are bare slugs), so they fall straight through to the logic below.
+idpart=${POS[0]:-}
+idpart=${idpart%%=*}
+if [ "${#POS[@]}" -gt 0 ] && [ "${POS[0]}" != "$idpart" ] && case "$idpart" in */*) false ;; *) true ;; esac; then
+  if [ "$KIND" != secondmate ] && [ -z "$HARNESS_ARG" ] && [ -f "$CONFIG/crew-dispatch.json" ]; then
+    echo "error: config/crew-dispatch.json is active - pass an explicit harness resolved from the dispatch rules (the consultation backstop, so the rules are never silently skipped)." >&2
+    exit 1
+  fi
+  rc=0
+  shared_args=()
+  [ -z "$HARNESS_ARG" ] || shared_args+=(--harness "$HARNESS_ARG")
+  [ -z "$MODEL" ] || shared_args+=(--model "$MODEL")
+  [ -z "$EFFORT" ] || shared_args+=(--effort "$EFFORT")
+  [ -z "$BACKEND_ARG" ] || shared_args+=(--backend "$BACKEND_ARG")
+  for pair in "${POS[@]}"; do
+    case "$pair" in
+      *=*) : ;;
+      *) echo "error: batch dispatch expects every argument as id=repo; got '$pair'" >&2; rc=2; continue ;;
+    esac
+    if [ "$KIND" = secondmate ]; then
+      echo "error: batch dispatch does not support --secondmate; spawn each secondmate explicitly" >&2
+      rc=2
+      continue
+    elif [ "$KIND" = scout ]; then
+      if FM_SPAWN_NO_GUARD=1 "$FM_ROOT/bin/fm-spawn.sh" "${pair%%=*}" "${pair#*=}" ${shared_args[@]+"${shared_args[@]}"} --scout; then :; else echo "batch: FAILED to spawn ${pair%%=*} (${pair#*=})" >&2; rc=1; fi
+    else
+      if FM_SPAWN_NO_GUARD=1 "$FM_ROOT/bin/fm-spawn.sh" "${pair%%=*}" "${pair#*=}" ${shared_args[@]+"${shared_args[@]}"}; then :; else echo "batch: FAILED to spawn ${pair%%=*} (${pair#*=})" >&2; rc=1; fi
+    fi
+  done
+  exit "$rc"
+fi
+if [ "${#POS[@]}" -eq 0 ]; then
+  usage >&2
+  exit 2
+fi
+ID=${POS[0]}
+PROJ=
+ARG3=
+FIRSTMATE_HOME=
+
+if [ "$KIND" = secondmate ]; then
+  case "${POS[1]:-}" in
+    ''|claude|codex|opencode|pi|grok)
+      ARG3=${POS[1]:-}
+      ;;
+    *' '*)
+      if [ "${#POS[@]}" -gt 2 ] || [ -d "${POS[1]}" ]; then
+        FIRSTMATE_HOME=${POS[1]}
+        ARG3=${POS[2]:-}
+      else
+        ARG3=${POS[1]}
+      fi
+      ;;
+    *)
+      FIRSTMATE_HOME=${POS[1]}
+      ARG3=${POS[2]:-}
+      ;;
+  esac
+else
+  if [ "${#POS[@]}" -lt 2 ]; then
+    echo "error: missing project-dir for $ID" >&2
+    usage >&2
+    exit 2
+  fi
+  PROJ=${POS[1]}
+  ARG3=${POS[2]:-}
+fi
+[ -z "$HARNESS_ARG" ] || ARG3=$HARNESS_ARG
+
 # Backend selection (data/fm-backend-design-d7): explicit --backend, else
 # FM_BACKEND env, else config/backend, else runtime auto-detection, else
 # default tmux (fm_backend_name). fm_backend_validate_spawn refuses unknown or
@@ -242,80 +316,6 @@ orca_spawn_abort_cleanup() {
   return "$status"
 }
 trap orca_spawn_abort_cleanup EXIT
-
-# Batch dispatch (see header): when the first positional is an `id=repo` pair, treat every
-# positional as one and spawn each by re-execing this script in single-task mode. We use
-# the FM_ROOT path (not $0) so it works whatever cwd or relative path invoked us, and reuse
-# the single path verbatim. A failed pair is reported and skipped; the rest still launch;
-# exit is non-zero if any pair failed. Single-task invocations never carry an '=' in arg
-# one (task ids are bare slugs), so they fall straight through to the logic below.
-idpart=${POS[0]:-}
-idpart=${idpart%%=*}
-if [ "${#POS[@]}" -gt 0 ] && [ "${POS[0]}" != "$idpart" ] && case "$idpart" in */*) false ;; *) true ;; esac; then
-  if [ "$KIND" != secondmate ] && [ -z "$HARNESS_ARG" ] && [ -f "$CONFIG/crew-dispatch.json" ]; then
-    echo "error: config/crew-dispatch.json is active - pass an explicit harness resolved from the dispatch rules (the consultation backstop, so the rules are never silently skipped)." >&2
-    exit 1
-  fi
-  rc=0
-  shared_args=()
-  [ -z "$HARNESS_ARG" ] || shared_args+=(--harness "$HARNESS_ARG")
-  [ -z "$MODEL" ] || shared_args+=(--model "$MODEL")
-  [ -z "$EFFORT" ] || shared_args+=(--effort "$EFFORT")
-  [ -z "$BACKEND_ARG" ] || shared_args+=(--backend "$BACKEND_ARG")
-  for pair in "${POS[@]}"; do
-    case "$pair" in
-      *=*) : ;;
-      *) echo "error: batch dispatch expects every argument as id=repo; got '$pair'" >&2; rc=2; continue ;;
-    esac
-    if [ "$KIND" = secondmate ]; then
-      echo "error: batch dispatch does not support --secondmate; spawn each secondmate explicitly" >&2
-      rc=2
-      continue
-    elif [ "$KIND" = scout ]; then
-      if FM_SPAWN_NO_GUARD=1 "$FM_ROOT/bin/fm-spawn.sh" "${pair%%=*}" "${pair#*=}" ${shared_args[@]+"${shared_args[@]}"} --scout; then :; else echo "batch: FAILED to spawn ${pair%%=*} (${pair#*=})" >&2; rc=1; fi
-    else
-      if FM_SPAWN_NO_GUARD=1 "$FM_ROOT/bin/fm-spawn.sh" "${pair%%=*}" "${pair#*=}" ${shared_args[@]+"${shared_args[@]}"}; then :; else echo "batch: FAILED to spawn ${pair%%=*} (${pair#*=})" >&2; rc=1; fi
-    fi
-  done
-  exit "$rc"
-fi
-if [ "${#POS[@]}" -eq 0 ]; then
-  usage >&2
-  exit 2
-fi
-ID=${POS[0]}
-PROJ=
-ARG3=
-FIRSTMATE_HOME=
-
-if [ "$KIND" = secondmate ]; then
-  case "${POS[1]:-}" in
-    ''|claude|codex|opencode|pi|grok)
-      ARG3=${POS[1]:-}
-      ;;
-    *' '*)
-      if [ "${#POS[@]}" -gt 2 ] || [ -d "${POS[1]}" ]; then
-        FIRSTMATE_HOME=${POS[1]}
-        ARG3=${POS[2]:-}
-      else
-        ARG3=${POS[1]}
-      fi
-      ;;
-    *)
-      FIRSTMATE_HOME=${POS[1]}
-      ARG3=${POS[2]:-}
-      ;;
-  esac
-else
-  if [ "${#POS[@]}" -lt 2 ]; then
-    echo "error: missing project-dir for $ID" >&2
-    usage >&2
-    exit 2
-  fi
-  PROJ=${POS[1]}
-  ARG3=${POS[2]:-}
-fi
-[ -z "$HARNESS_ARG" ] || ARG3=$HARNESS_ARG
 
 # The verified launch command per adapter. The knowledge half of each adapter
 # (busy signature, exit command, dialogs, quirks) lives in the harness-adapters skill.

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -3,6 +3,7 @@
 # secondmate in its isolated firstmate home.
 # Usage: fm-spawn.sh <task-id> <project-dir> [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] [--scout]
 #        fm-spawn.sh <task-id> [<firstmate-home>] [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] --secondmate
+#        fm-spawn.sh [--help]
 #   --harness <name> is the explicit per-spawn harness/profile adapter. The old
 #   positional harness arg still works for back-compat.
 #   --model <name> and --effort <low|medium|high|xhigh|max> are concrete profile
@@ -87,6 +88,23 @@ DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 PROJECTS="${FM_PROJECTS_OVERRIDE:-$FM_HOME/projects}"
 CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
 SUB_HOME_MARKER=".fm-secondmate-home"
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  fm-spawn.sh <task-id> <project-dir> [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] [--scout]
+  fm-spawn.sh <task-id> [<firstmate-home>] [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] --secondmate
+  fm-spawn.sh <id=repo> [<id=repo> ...] [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] [--scout]
+  fm-spawn.sh [--help]
+USAGE
+}
+
+for a in "$@"; do
+  case "$a" in
+    -h|--help) usage; exit 0 ;;
+  esac
+done
+
 # shellcheck source=bin/fm-ff-lib.sh
 . "$SCRIPT_DIR/fm-ff-lib.sh"
 # shellcheck source=bin/fm-config-inherit-lib.sh
@@ -261,6 +279,10 @@ if [ "${#POS[@]}" -gt 0 ] && [ "${POS[0]}" != "$idpart" ] && case "$idpart" in *
   done
   exit "$rc"
 fi
+if [ "${#POS[@]}" -eq 0 ]; then
+  usage >&2
+  exit 2
+fi
 ID=${POS[0]}
 PROJ=
 ARG3=
@@ -285,6 +307,11 @@ if [ "$KIND" = secondmate ]; then
       ;;
   esac
 else
+  if [ "${#POS[@]}" -lt 2 ]; then
+    echo "error: missing project-dir for $ID" >&2
+    usage >&2
+    exit 2
+  fi
   PROJ=${POS[1]}
   ARG3=${POS[2]:-}
 fi

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -3,7 +3,8 @@
 # secondmate in its isolated firstmate home.
 # Usage: fm-spawn.sh <task-id> <project-dir> [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] [--scout]
 #        fm-spawn.sh <task-id> [<firstmate-home>] [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] --secondmate
-#        fm-spawn.sh [--help]
+#        fm-spawn.sh <id=repo> [<id=repo> ...] [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] [--scout]
+#        fm-spawn.sh [-h|--help]
 #   --harness <name> is the explicit per-spawn harness/profile adapter. The old
 #   positional harness arg still works for back-compat.
 #   --model <name> and --effort <low|medium|high|xhigh|max> are concrete profile
@@ -95,7 +96,7 @@ Usage:
   fm-spawn.sh <task-id> <project-dir> [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] [--scout]
   fm-spawn.sh <task-id> [<firstmate-home>] [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] --secondmate
   fm-spawn.sh <id=repo> [<id=repo> ...] [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] [--scout]
-  fm-spawn.sh [--help]
+  fm-spawn.sh [-h|--help]
 USAGE
 }
 

--- a/tests/fm-backend.test.sh
+++ b/tests/fm-backend.test.sh
@@ -650,7 +650,7 @@ test_send_conformance_old_vs_new() {
   expect_code "$rc_old" "$rc_new" "fm-send --key: old vs new exit code"
   assert_contains "$(cat "$log_new")" $'\x1f''display-message'$'\x1f''-p'$'\x1f''-t'$'\x1f''sess:win'$'\x1f''#{pane_id}' \
     "fm-send --key did not verify the explicit tmux target before sending"
-  cp "$log_old" "$filtered_old"
+  strip_send_preflight "$log_old" > "$filtered_old"
   strip_send_preflight "$log_new" > "$filtered_new"
   diff -u "$filtered_old" "$filtered_new" > "$TMP_ROOT/send-diff-key.txt" 2>&1 \
     || fail "fm-send --key: tmux command log differs old vs new"$'\n'"$(cat "$TMP_ROOT/send-diff-key.txt")"
@@ -662,7 +662,7 @@ test_send_conformance_old_vs_new() {
   run_send_case "$ROOT" "$fb" "$log_new" "$home" -- "sess:win" hello captain
   rc_new=$?
   expect_code "$rc_old" "$rc_new" "fm-send plain text: old vs new exit code"
-  cp "$log_old" "$filtered_old"
+  strip_send_preflight "$log_old" > "$filtered_old"
   strip_send_preflight "$log_new" > "$filtered_new"
   diff -u "$filtered_old" "$filtered_new" > "$TMP_ROOT/send-diff-plain.txt" 2>&1 \
     || fail "fm-send plain text: tmux command log differs old vs new"$'\n'"$(cat "$TMP_ROOT/send-diff-plain.txt")"
@@ -678,7 +678,7 @@ test_send_conformance_old_vs_new() {
   run_send_case "$ROOT" "$fb" "$log_new" "$home" -- "sess:win" /some-skill
   rc_new=$?
   expect_code "$rc_old" "$rc_new" "fm-send /skill: old vs new exit code"
-  cp "$log_old" "$filtered_old"
+  strip_send_preflight "$log_old" > "$filtered_old"
   strip_send_preflight "$log_new" > "$filtered_new"
   diff -u "$filtered_old" "$filtered_new" > "$TMP_ROOT/send-diff-slash.txt" 2>&1 \
     || fail "fm-send /skill: tmux command log differs old vs new"$'\n'"$(cat "$TMP_ROOT/send-diff-slash.txt")"

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -20,6 +20,18 @@ set -u
 BASE_PATH=${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin}
 TMP_ROOT=$(fm_test_tmproot fm-bootstrap-tests)
 
+make_base_path_without() {
+  local dir=$1 skip=$2 src name
+  mkdir -p "$dir"
+  for src in /usr/bin/*; do
+    [ -x "$src" ] || continue
+    name=${src##*/}
+    [ "$name" = "$skip" ] && continue
+    [ -e "$dir/$name" ] || ln -s "$src" "$dir/$name"
+  done
+  printf '%s\n' "$dir"
+}
+
 # A fake toolchain where every required tool is present and gh is authenticated.
 # treehouse's `get --help` advertises --lease only when FM_FAKE_TREEHOUSE_LEASE_HELP=1.
 make_fake_toolchain() {
@@ -269,16 +281,17 @@ ROWS
 }
 
 test_orca_backend_gates_orca_tool_only_when_selected() {
-  local case_dir fakebin out missing_orca
+  local case_dir fakebin out missing_orca core_path
   missing_orca="MISSING: orca (install: brew install orca  # or the platform's package manager)"
+  core_path=$(make_base_path_without "$TMP_ROOT/no-orca-bin" orca)
 
   case_dir="$TMP_ROOT/orca-backend-selected"
   mkdir -p "$case_dir/home/config"
   printf '%s\n' manual > "$case_dir/home/config/backlog-backend"
   printf '%s\n' orca > "$case_dir/home/config/backend"
   fakebin=$(make_fake_toolchain "$case_dir")
-  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
-    FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
+  out=$(PATH="$fakebin:$core_path" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+    FM_FAKE_TREEHOUSE_LEASE_HELP=1 bash "$ROOT/bin/fm-bootstrap.sh")
   [ "$out" = "$missing_orca" ] || fail "backend=orca should require only the Orca-specific missing tool, got: $out"
 
   case_dir="$TMP_ROOT/orca-backend-not-selected"

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -21,14 +21,20 @@ BASE_PATH=${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin}
 TMP_ROOT=$(fm_test_tmproot fm-bootstrap-tests)
 
 make_base_path_without() {
-  local dir=$1 skip=$2 src name
+  local dir=$1 skip=$2 old_ifs path_dir src name
   mkdir -p "$dir"
-  for src in /usr/bin/*; do
-    [ -x "$src" ] || continue
-    name=${src##*/}
-    [ "$name" = "$skip" ] && continue
-    [ -e "$dir/$name" ] || ln -s "$src" "$dir/$name"
+  old_ifs=$IFS
+  IFS=:
+  for path_dir in $BASE_PATH; do
+    [ -d "$path_dir" ] || continue
+    for src in "$path_dir"/*; do
+      [ -x "$src" ] || continue
+      name=${src##*/}
+      [ "$name" = "$skip" ] && continue
+      [ -e "$dir/$name" ] || ln -s "$src" "$dir/$name"
+    done
   done
+  IFS=$old_ifs
   printf '%s\n' "$dir"
 }
 

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -31,14 +31,20 @@ TMP_ROOT=$(fm_test_tmproot fm-session-start-tests)
 fm_git_identity fmtest fmtest@example.invalid
 
 make_base_path_without() {
-  local dir=$1 skip=$2 src name
+  local dir=$1 skip=$2 old_ifs path_dir src name
   mkdir -p "$dir"
-  for src in /usr/bin/*; do
-    [ -x "$src" ] || continue
-    name=${src##*/}
-    [ "$name" = "$skip" ] && continue
-    [ -e "$dir/$name" ] || ln -s "$src" "$dir/$name"
+  old_ifs=$IFS
+  IFS=:
+  for path_dir in $BASE_PATH; do
+    [ -d "$path_dir" ] || continue
+    for src in "$path_dir"/*; do
+      [ -x "$src" ] || continue
+      name=${src##*/}
+      [ "$name" = "$skip" ] && continue
+      [ -e "$dir/$name" ] || ln -s "$src" "$dir/$name"
+    done
   done
+  IFS=$old_ifs
   printf '%s\n' "$dir"
 }
 

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -30,6 +30,18 @@ BASE_PATH=${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin}
 TMP_ROOT=$(fm_test_tmproot fm-session-start-tests)
 fm_git_identity fmtest fmtest@example.invalid
 
+make_base_path_without() {
+  local dir=$1 skip=$2 src name
+  mkdir -p "$dir"
+  for src in /usr/bin/*; do
+    [ -x "$src" ] || continue
+    name=${src##*/}
+    [ "$name" = "$skip" ] && continue
+    [ -e "$dir/$name" ] || ln -s "$src" "$dir/$name"
+  done
+  printf '%s\n' "$dir"
+}
+
 # --- world builders ----------------------------------------------------------
 
 # new_world <name>: a real, throwaway git repo on `main` (so the worktree-tangle
@@ -249,7 +261,7 @@ EOF
 # --- output ordering ----------------------------------------------------------
 
 test_output_ordering_diagnostics_lead() {
-  local rec root home fakebin out lock_line boot_line wake_line context_line fleet_line next_line
+  local rec root home fakebin out lock_line boot_line wake_line context_line fleet_line next_line core_path
   rec=$(new_world ordering)
   IFS='|' read -r root home fakebin <<EOF
 $rec
@@ -258,10 +270,11 @@ EOF
   make_fake_ps_claude "$fakebin"
   # Force a MISSING diagnostic line so the bootstrap section is non-trivial.
   rm -f "$fakebin/node"
+  core_path=$(make_base_path_without "$TMP_ROOT/no-node-bin" node)
 
   printf 'window=fm-sess:w1\nkind=ship\n' > "$home/state/task-a.meta"
 
-  out=$(run_session_start "$home" "$root" "$fakebin:$BASE_PATH")
+  out=$(run_session_start "$home" "$root" "$fakebin:$core_path")
 
   lock_line=$(printf '%s\n' "$out" | grep -n '^LOCK$' | head -1 | cut -d: -f1)
   boot_line=$(printf '%s\n' "$out" | grep -n '^BOOTSTRAP$' | head -1 | cut -d: -f1)
@@ -393,7 +406,7 @@ EOF
 # --- composition: real scripts run, not reimplemented ------------------------
 
 test_composition_invokes_real_scripts() {
-  local rec root home fakebin out
+  local rec root home fakebin out core_path
   rec=$(new_world composition)
   IFS='|' read -r root home fakebin <<EOF
 $rec
@@ -401,10 +414,11 @@ EOF
   make_fake_toolchain "$fakebin"
   make_fake_ps_claude "$fakebin"
   rm -f "$fakebin/node"
+  core_path=$(make_base_path_without "$TMP_ROOT/no-node-composition-bin" node)
 
   append_wake "$home/state" signal task-z "needs-decision: pick a library"
 
-  out=$(run_session_start "$home" "$root" "$fakebin:$BASE_PATH")
+  out=$(run_session_start "$home" "$root" "$fakebin:$core_path")
 
   # fm-lock.sh's own exact success text.
   assert_contains "$out" "lock acquired: harness pid" "fm-lock.sh's real output did not appear (composition, not reimplementation)"

--- a/tests/fm-spawn-batch.test.sh
+++ b/tests/fm-spawn-batch.test.sh
@@ -14,18 +14,31 @@ set -u
 
 SPAWN="$ROOT/bin/fm-spawn.sh"
 TMP_ROOT=$(fm_test_tmproot fm-spawn-batch)
+RUN_HOME="$TMP_ROOT/run-home"
 export FM_BACKEND=tmux
+mkdir -p "$RUN_HOME/data" "$RUN_HOME/state" "$RUN_HOME/projects" "$RUN_HOME/config"
 
 # Clear ambient firstmate overrides so the behavior test owns its environment.
 run_spawn() {
   FM_ROOT_OVERRIDE='' \
-    FM_HOME='' \
+    FM_HOME="$RUN_HOME" \
     FM_STATE_OVERRIDE='' \
     FM_DATA_OVERRIDE='' \
     FM_PROJECTS_OVERRIDE='' \
     FM_CONFIG_OVERRIDE='' \
     FM_SPAWN_NO_GUARD=1 \
     "$SPAWN" "$@" 2>&1
+}
+
+test_help_exits_before_positional_parsing() {
+  local out status
+  out=$(run_spawn --help k-)
+  status=$?
+  expect_code 0 "$status" "fm-spawn --help should exit successfully"
+  assert_contains "$out" "Usage:" "help output should include usage"
+  assert_contains "$out" "fm-spawn.sh <task-id> <project-dir>" "help output should include ship usage"
+  assert_not_contains "$out" "unbound variable" "help path should not reach positional parsing"
+  pass "fm-spawn --help exits before positional parsing"
 }
 
 # Every pair in a batch is dispatched even though the first one fails; the loop
@@ -102,6 +115,7 @@ ROWS
   pass "projects/ paths are scoped through the firstmate home for single-task spawn"
 }
 
+test_help_exits_before_positional_parsing
 test_batch_dispatches_every_pair
 test_batch_mode_boundaries
 test_projects_path_scoping

--- a/tests/fm-spawn-batch.test.sh
+++ b/tests/fm-spawn-batch.test.sh
@@ -41,6 +41,23 @@ test_help_exits_before_positional_parsing() {
   pass "fm-spawn --help exits before positional parsing"
 }
 
+test_missing_positionals_exit_before_backend_validation() {
+  local out status
+  out=$(FM_BACKEND=missing-backend run_spawn)
+  status=$?
+  expect_code 2 "$status" "fm-spawn with no args should exit with usage"
+  assert_contains "$out" "Usage:" "no-args output should include usage"
+  assert_not_contains "$out" "unknown backend" "no-args path should not validate backend"
+
+  out=$(FM_BACKEND=missing-backend run_spawn nope-no-project-z9)
+  status=$?
+  expect_code 2 "$status" "fm-spawn without project-dir should exit with usage"
+  assert_contains "$out" "error: missing project-dir for nope-no-project-z9" "missing project-dir should be reported"
+  assert_contains "$out" "Usage:" "missing project-dir output should include usage"
+  assert_not_contains "$out" "unknown backend" "missing project-dir path should not validate backend"
+  pass "missing positionals exit before backend validation"
+}
+
 # Every pair in a batch is dispatched even though the first one fails; the loop
 # must not stop early. This is the load-bearing batch guarantee, kept explicit.
 test_batch_dispatches_every_pair() {
@@ -116,6 +133,7 @@ ROWS
 }
 
 test_help_exits_before_positional_parsing
+test_missing_positionals_exit_before_backend_validation
 test_batch_dispatches_every_pair
 test_batch_mode_boundaries
 test_projects_path_scoping


### PR DESCRIPTION
## Summary

- Handle `fm-spawn.sh -h/--help` before guard, backend, or positional parsing side effects.
- Add clean usage errors for missing spawn positionals instead of `set -u` crashes.
- Add regression coverage for `fm-spawn.sh --help k-` and isolate the spawn parser test from local dispatch config.
- Preserve no-mistakes fixes for environment-sensitive tests surfaced by the full validation run.

## Validation

- `bin/fm-spawn.sh --help k-`
- `tests/fm-spawn-batch.test.sh`
- `tests/fm-bootstrap.test.sh`
- `tests/fm-session-start.test.sh`
- `tests/fm-backend.test.sh`
- `shellcheck bin/*.sh bin/backends/*.sh tests/*.sh`
- no-mistakes completed review, test, document, and lint successfully at `1953062d`; upstream push failed with 403 for `ThomShark`, so this branch was pushed to the fork for PR creation.
