### PR TITLE
fix(afk): confirm herdr supervisor-pane submit for claude composer

### DIFF
--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -794,22 +794,28 @@ fm_backend_herdr_composer_state() {  # <target> -> empty|pending|unknown
 # backend; how each backend confirms it is an internal decision - herdr's is
 # no longer literally "the composer read empty").
 fm_backend_herdr_send_text_submit() {  # <target> <text> <retries> <enter-sleep> <settle>
-  local target=$1 text=$2 retries=$3 sleep_s=$4 settle=$5 i=0 verdict baseline confirm_sleep
+  local target=$1 text=$2 retries=$3 sleep_s=$4 settle=$5 i=0 verdict raw_baseline confirm_sleep
   fm_backend_herdr_parse_target "$target" || { printf 'unknown'; return 0; }
   fm_backend_herdr_send_literal "$target" "$text" || { printf 'send-failed'; return 0; }
   sleep "$settle"
-  baseline=$(fm_backend_herdr_classify_submit_agent_status \
-    "$(fm_backend_herdr_agent_status_raw "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE")")
+  raw_baseline=$(fm_backend_herdr_agent_status_raw "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE")
   confirm_sleep=$(fm_backend_herdr_submit_confirm_budget "$sleep_s")
   while :; do
     fm_backend_herdr_send_key "$target" Enter || true
-    if [ "$baseline" = idle ]; then
-      verdict=$(fm_backend_herdr_wait_for_working "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE" \
-        "$confirm_sleep" "$FM_BACKEND_HERDR_SUBMIT_POLLS")
-    else
-      sleep "$sleep_s"
-      verdict=$(fm_backend_herdr_composer_state "$target")
-    fi
+    case "$raw_baseline" in
+      idle|done)
+        verdict=$(fm_backend_herdr_wait_for_working "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE" \
+          "$confirm_sleep" "$FM_BACKEND_HERDR_SUBMIT_POLLS") ;;
+      blocked)
+        # A blocked baseline already reads submit-active, so only a
+        # blocked->working transition proves this Enter started a turn; confirm
+        # on working only, never composer content - 2026-07-08 incident (docs).
+        verdict=$(fm_backend_herdr_wait_for_working "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE" \
+          "$confirm_sleep" "$FM_BACKEND_HERDR_SUBMIT_POLLS" 1) ;;
+      *)
+        sleep "$sleep_s"
+        verdict=$(fm_backend_herdr_composer_state "$target") ;;
+    esac
     case "$verdict" in
       busy) printf 'empty'; return 0 ;;
       empty) printf 'empty'; return 0 ;;
@@ -932,8 +938,8 @@ fm_backend_herdr_submit_confirm_budget() {  # <caller-budget-seconds>
   }' 2>/dev/null || printf '%s' "${1:-0}"
 }
 
-fm_backend_herdr_wait_for_working() {  # <session> <pane_id> <budget-seconds> <polls>
-  local session=$1 pane_id=$2 budget=$3 polls=${4:-1} i interval raw bs saw_idle=0
+fm_backend_herdr_wait_for_working() {  # <session> <pane_id> <budget-seconds> <polls> [working-only]
+  local session=$1 pane_id=$2 budget=$3 polls=${4:-1} working_only=${5:-0} i interval raw bs saw_idle=0
   case "$polls" in ''|*[!0-9]*|0) polls=1 ;; esac
   interval=$(awk -v b="$budget" -v p="$polls" 'BEGIN { d = p - 1; if (d < 1) d = 1; v = b / d; if (v < 0) v = 0; printf "%.4f", v }' 2>/dev/null)
   case "$interval" in ''|*[!0-9.]*) interval=0 ;; esac
@@ -942,7 +948,13 @@ fm_backend_herdr_wait_for_working() {  # <session> <pane_id> <budget-seconds> <p
       sleep "$interval"
     fi
     raw=$(fm_backend_herdr_agent_status_raw "$session" "$pane_id")
-    bs=$(fm_backend_herdr_classify_submit_agent_status "$raw")
+    # working-only maps blocked->idle so only a real working turn confirms;
+    # default maps blocked->busy (see the two classifiers).
+    if [ "$working_only" = 1 ]; then
+      bs=$(fm_backend_herdr_classify_agent_status "$raw")
+    else
+      bs=$(fm_backend_herdr_classify_submit_agent_status "$raw")
+    fi
     case "$bs" in
       busy) printf 'busy'; return 0 ;;
       idle) saw_idle=1 ;;

--- a/bin/backends/orca.sh
+++ b/bin/backends/orca.sh
@@ -51,7 +51,12 @@ fm_backend_orca_json_get() {  # <field> ; fields: worktree-id worktree-path term
   node -e '
 const fs = require("fs");
 const field = process.argv[1];
-const data = JSON.parse(fs.readFileSync(0, "utf8"));
+let data;
+try {
+  data = JSON.parse(fs.readFileSync(0, "utf8"));
+} catch {
+  process.exit(1);
+}
 if (data.ok === false) {
   const msg = data.error && (data.error.message || data.error.code);
   if (msg) console.error(msg);

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -472,6 +472,48 @@ Additional scenarios verified directly against the real binaries:
 The fix: the fixture now registers itself as a real herdr agent via `herdr pane report-agent <pane> --source <id> --agent <label> --state idle|working|blocked|unknown` (herdr's own documented integration-protocol primitive for a non-built-in-harness process to report its own agent state, verified empirically here) and reports an idle->working->idle cycle around each submission, exactly as a real harness would.
 With that fix, all four scenarios (A: partial-input deferral, B: swallowed-Enter retry, C: normal digest, D: max-defer wedge alarm) pass against the real binary.
 
+## Incident (2026-07-08): blocked-baseline submit fell to the composer fallback, redelivery loop returned
+
+The 2026-07-07 native agent-state confirmation above only covers an idle/done pre-Enter baseline.
+A `blocked` baseline still fell through to the composer-clear fallback (line 463 above says so explicitly: "A pre-Enter `working` or `blocked` status now falls back to composer-clear confirmation"), and that reopened the exact redelivery loop the 2026-07-07 fix was meant to close, for a different pre-Enter state.
+
+Observed live on 2026-07-08 (herdr 0.7.1, supervisor pane running claude 2.1.201, away mode set): `bin/fm-supervise-daemon.sh` re-injected one fully-handled escalation three times.
+Daemon log, repeating each housekeeping cycle:
+
+```
+inject failed: submit unconfirmed after 3 retries (verdict=unknown)
+inject deferred: supervisor pane busy (agent mid-turn)
+ERROR away-mode escalation undelivered 311s
+```
+
+The escalation text DID land in the pane each cycle (a turn started), so the Enter submitted - but the daemon read `verdict=unknown`, never cleared `state/.subsuper-escalations`, and retyped the same buffer on the next tick.
+
+Root cause: `blocked` is uniquely the pre-Enter status that both (a) clears the daemon's pre-type busy guard - `fm_backend_herdr_classify_agent_status` maps `blocked -> idle`, so `pane_is_busy` reads not-busy and the daemon injects - AND (b) reads submit-active for confirmation - `fm_backend_herdr_classify_submit_agent_status` maps `blocked -> busy`, so `fm_backend_herdr_send_text_submit` treated the baseline as already-active and routed confirmation to the composer-clear fallback.
+An away-mode supervisor pane parked on a tool/permission prompt (the daemon's normal inject target) reads exactly `blocked`.
+On that screen there is no composer row at all, so `fm_backend_herdr_composer_state` returns `unknown`, and a genuinely landed submit reads as unconfirmed forever.
+
+**Fix:** `fm_backend_herdr_send_text_submit` now branches on the raw pre-Enter status instead of only distinguishing idle/done from everything-else.
+A `blocked` baseline confirms via native agent-state on a `blocked -> working` transition ONLY (a still-`blocked` reading proves nothing, since the pane already read submit-active before the Enter), never composer content - consistent with the 2026-07-07 philosophy of not asking the composer.
+This is the new `working-only` mode of `fm_backend_herdr_wait_for_working`, which classifies through `fm_backend_herdr_classify_agent_status` (`blocked -> idle`) so only a real `working` turn counts.
+The idle/done baseline path is unchanged (any `working`/`blocked` confirms); a `working` or unreadable baseline still uses the composer fallback, because those cannot prove this Enter landed and there is no cleaner native signal for them.
+
+Reproduced end to end against the fake-herdr harness before touching the fix, driving the daemon's real submit-verification call with a `blocked` baseline that transitions to `working`:
+
+```
+$ git stash push -- bin/backends/herdr.sh   # revert the fix
+$ bash tests/fm-backend-herdr.test.sh
+not ok - a blocked baseline that transitions to working after Enter is a confirmed submit, got 'unknown' (before the fix a blocked baseline fell to composer_state, which returns 'unknown' on a claude dialog screen and drove the redelivery loop)
+$ git stash pop                             # restore the fix
+$ bash tests/fm-backend-herdr.test.sh
+ok - fm_backend_herdr_send_text_submit: a blocked baseline confirms on a blocked->working transition via native agent-state, never composer content (2026-07-08 redelivery-loop regression)
+ok - fm_backend_herdr_send_text_submit: a blocked baseline that stays blocked reads pending (buffer preserved), never a false confirm that would drop the escalation
+```
+
+Recovery for a live loop (while the buffer is still redelivering): clear the stale buffer once the content is actioned - `rm -f state/.subsuper-escalations state/.subsuper-inject-wedged` - and do not re-process the already-handled tasks.
+
+**Regression coverage:** `tests/fm-backend-herdr.test.sh`'s "send_text_submit" section adds `test_send_text_submit_blocked_baseline_confirms_on_working_transition` (a blocked->working baseline confirms `empty` via native agent-state and never calls `pane read`) and `test_send_text_submit_blocked_baseline_stays_blocked_is_pending_not_false_confirm` (a baseline that stays blocked reports `pending` so the buffer is preserved, never a false confirm that would silently drop the escalation).
+See `fm_backend_herdr_send_text_submit` and `fm_backend_herdr_wait_for_working` in `bin/backends/herdr.sh` for the implementation.
+
 ## Known gaps and follow-up notes
 
 - **No `events.subscribe` native push.** The busy-state semantic read (`agent.get`) is consumed through the EXISTING `fm-watch.sh` poll loop (same 15-second cadence as every other window), not a persistent async subscriber pushing events directly into the wake queue.

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -210,7 +210,7 @@ test_version_check_refuses_missing_herdr() {
   local dir out status
   dir="$TMP_ROOT/version-missing"; mkdir -p "$dir/empty-fakebin"
   out=$( PATH="$dir/empty-fakebin:/usr/bin:/bin" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_version_check' "$ROOT" 2>&1 )
+    "$BASH" -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_version_check' "$ROOT" 2>&1 )
   status=$?
   [ "$status" -ne 0 ] || fail "version_check should refuse when herdr is not installed"
   assert_contains "$out" "not installed" "version_check did not report herdr as missing"
@@ -1157,6 +1157,57 @@ test_send_text_submit_confirms_blocked_after_enter() {
   pass "fm_backend_herdr_send_text_submit: a post-Enter blocked state confirms delivery without retrying into the prompt"
 }
 
+# Core regression for the 2026-07-08 incident (docs/herdr-backend.md): the
+# away-mode daemon injects into a SUPERVISOR pane that is normally parked on a
+# tool/permission prompt, so its PRE-Enter baseline reads `blocked`. `blocked`
+# uniquely (a) clears the daemon's pane_is_busy inject guard - classify_AGENT
+# maps blocked->idle - yet (b) classifies submit-active - classify_SUBMIT maps
+# blocked->busy - so before the fix it fell to the composer-content path, which
+# returns `unknown` for a claude permission-dialog screen (no composer row).
+# The daemon read that landed injection as unconfirmed and redelivered the same
+# escalation every cycle. The fix confirms a blocked baseline by native
+# agent-state ONLY, on a genuine blocked->working transition, never composer
+# content.
+test_send_text_submit_blocked_baseline_confirms_on_working_transition() {
+  local dir log resp fb out enter_count read_count
+  dir="$TMP_ROOT/submit-blocked-baseline-working"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  # 1: send-text  2: agent get - pre-Enter baseline is BLOCKED (parked pane)
+  # 3: send-keys enter  4: agent get -> working (the injection started a turn)
+  printf '{"result":{"agent":{"agent_status":"blocked"}}}\n' > "$resp/2.out"
+  printf '{"result":{"agent":{"agent_status":"working"}}}\n' > "$resp/4.out"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" FM_BACKEND_HERDR_SUBMIT_POLLS=1 \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_send_text_submit default:w1:p2 "escalation digest" 3 0.01 0.01' "$ROOT" )
+  [ "$out" = empty ] || fail "a blocked baseline that transitions to working after Enter is a confirmed submit, got '$out' (before the fix a blocked baseline fell to composer_state, which returns 'unknown' on a claude dialog screen and drove the redelivery loop)"
+  enter_count=$(grep -c $'\x1f''pane'$'\x1f''send-keys'$'\x1f''w1:p2'$'\x1f''enter' "$log")
+  [ "$enter_count" -eq 1 ] || fail "a confirmed blocked->working transition must not provoke a retry, sent $enter_count Enter(s)"
+  read_count=$(grep -c $'\x1f''pane'$'\x1f''read' "$log")
+  [ "$read_count" -eq 0 ] || fail "a blocked baseline must confirm via native agent-state, never by reading the composer (the path that returns 'unknown' for a claude dialog), made $read_count read(s)"
+  pass "fm_backend_herdr_send_text_submit: a blocked baseline confirms on a blocked->working transition via native agent-state, never composer content (2026-07-08 redelivery-loop regression)"
+}
+
+# The false-positive guard for the same fix: a blocked baseline that STAYS
+# blocked after Enter proves nothing (the pane was already submit-active), so
+# confirmation must NOT fire - the escalation stays unconfirmed (pending) and
+# the daemon keeps the buffer, rather than falsely clearing an undelivered
+# escalation. This is the direction that must never regress: losing an
+# escalation is worse than redelivering one.
+test_send_text_submit_blocked_baseline_stays_blocked_is_pending_not_false_confirm() {
+  local dir log resp fb out enter_count
+  dir="$TMP_ROOT/submit-blocked-baseline-stuck"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  # baseline blocked; every post-Enter poll still blocked (no new turn started)
+  printf '{"result":{"agent":{"agent_status":"blocked"}}}\n' > "$resp/2.out"
+  printf '{"result":{"agent":{"agent_status":"blocked"}}}\n' > "$resp/4.out"
+  printf '{"result":{"agent":{"agent_status":"blocked"}}}\n' > "$resp/6.out"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" FM_BACKEND_HERDR_SUBMIT_POLLS=1 \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_send_text_submit default:w1:p2 "escalation digest" 2 0.01 0.01' "$ROOT" )
+  [ "$out" = pending ] || fail "a blocked baseline that never transitions to working must read pending (unconfirmed), not a false 'empty', got '$out'"
+  enter_count=$(grep -c $'\x1f''pane'$'\x1f''send-keys'$'\x1f''w1:p2'$'\x1f''enter' "$log")
+  [ "$enter_count" -eq 2 ] || fail "an unconfirmed blocked baseline should retry Enter up to the configured count, sent $enter_count Enter(s)"
+  pass "fm_backend_herdr_send_text_submit: a blocked baseline that stays blocked reads pending (buffer preserved), never a false confirm that would drop the escalation"
+}
+
 test_send_text_submit_preexisting_working_does_not_false_confirm_swallowed_enter() {
   local dir log resp fb out enter_count read_count
   dir="$TMP_ROOT/submit-preexisting-working-swallow"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
@@ -1652,6 +1703,8 @@ test_send_text_submit_detects_landed_send
 test_send_text_submit_detects_swallowed_enter
 test_send_text_submit_popup_autocomplete_requires_second_enter
 test_send_text_submit_confirms_blocked_after_enter
+test_send_text_submit_blocked_baseline_confirms_on_working_transition
+test_send_text_submit_blocked_baseline_stays_blocked_is_pending_not_false_confirm
 test_send_text_submit_preexisting_working_does_not_false_confirm_swallowed_enter
 test_send_text_submit_confirms_despite_codex_idle_tip_composer
 test_composer_state_codex_dynamic_idle_tip_still_reads_pending

--- a/tests/fm-backend-zellij.test.sh
+++ b/tests/fm-backend-zellij.test.sh
@@ -185,7 +185,7 @@ test_version_check_refuses_missing_zellij() {
   local dir out status
   dir="$TMP_ROOT/version-missing"; mkdir -p "$dir/empty-fakebin"
   out=$( PATH="$dir/empty-fakebin:/usr/bin:/bin" \
-    bash -c '. "$0/bin/backends/zellij.sh"; fm_backend_zellij_version_check' "$ROOT" 2>&1 )
+    "$BASH" -c '. "$0/bin/backends/zellij.sh"; fm_backend_zellij_version_check' "$ROOT" 2>&1 )
   status=$?
   [ "$status" -ne 0 ] || fail "version_check should refuse when zellij is not installed"
   assert_contains "$out" "not installed" "version_check did not report zellij as missing"

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -17,7 +17,7 @@ set -u
 # shellcheck source=tests/lib.sh disable=SC1091
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
-BASE_PATH=${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin}
+BASE_PATH=$(fm_test_base_path)
 TMP_ROOT=$(fm_test_tmproot fm-bootstrap-tests)
 
 # A fake toolchain where every required tool is present and gh is authenticated.

--- a/tests/fm-dispatch-select.test.sh
+++ b/tests/fm-dispatch-select.test.sh
@@ -5,7 +5,7 @@ set -u
 # shellcheck source=tests/lib.sh
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
-BASE_PATH=${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin}
+BASE_PATH=$(fm_test_base_path)
 TMP_ROOT=$(fm_test_tmproot fm-dispatch-select-tests)
 mkdir -p "$TMP_ROOT"
 

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -37,7 +37,7 @@ set -u
 # shellcheck source=bin/fm-config-inherit-lib.sh
 . "$ROOT/bin/fm-config-inherit-lib.sh"
 
-BASE_PATH=${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin}
+BASE_PATH=$(fm_test_base_path)
 fm_git_identity fmtest fmtest@example.com
 TMP_ROOT=$(fm_test_tmproot fm-secondmate-harness)
 export FM_BACKEND=tmux

--- a/tests/fm-secondmate-liveness.test.sh
+++ b/tests/fm-secondmate-liveness.test.sh
@@ -39,7 +39,7 @@ set -u
 # shellcheck source=tests/lib.sh
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
-BASE_PATH=${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin}
+BASE_PATH=$(fm_test_base_path)
 fm_git_identity fmtest fmtest@example.com
 
 TMP_ROOT=$(fm_test_tmproot fm-secondmate-liveness)

--- a/tests/fm-secondmate-sync.test.sh
+++ b/tests/fm-secondmate-sync.test.sh
@@ -27,7 +27,7 @@ set -u
 # shellcheck source=bin/fm-ff-lib.sh
 . "$ROOT/bin/fm-ff-lib.sh"
 
-BASE_PATH=${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin}
+BASE_PATH=$(fm_test_base_path)
 
 # Deterministic, isolated git identity for fixture commits.
 fm_git_identity fmtest fmtest@example.com

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -26,7 +26,7 @@ set -u
 . "$(dirname "${BASH_SOURCE[0]}")/wake-helpers.sh"
 
 SESSION_START="$ROOT/bin/fm-session-start.sh"
-BASE_PATH=${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin}
+BASE_PATH=$(fm_test_base_path)
 TMP_ROOT=$(fm_test_tmproot fm-session-start-tests)
 fm_git_identity fmtest fmtest@example.invalid
 

--- a/tests/fm-x-mode.test.sh
+++ b/tests/fm-x-mode.test.sh
@@ -1459,12 +1459,13 @@ test_followup_post_failure_keeps_link() {
 }
 
 test_followup_post_record_failure_clears_link() {
-  local home fakebin out rc meta err flag mvflag
+  local home fakebin out rc meta err flag mvflag real_mv
   home="$TMP_ROOT/fu-post-record-fail"; mkdir -p "$home/state"
   fakebin=$(make_fake_curl "$home")
   flag="$home/fail-followups-write"
   mvflag="$home/mv-failed-once"
   err="$home/err.txt"
+  real_mv=$(command -v mv)
   cat > "$fakebin/mv" <<'SH'
 #!/usr/bin/env bash
 if [ -n "${FAKE_MV_FAIL_AFTER_FLAG:-}" ] \
@@ -1474,7 +1475,7 @@ if [ -n "${FAKE_MV_FAIL_AFTER_FLAG:-}" ] \
   : > "$FAKE_MV_FAILED_ONCE"
   exit 2
 fi
-exec /bin/mv "$@"
+exec "$REAL_MV" "$@"
 SH
   chmod +x "$fakebin/mv"
   printf 'FMX_PAIRING_TOKEN=tok-fu\n' > "$home/.env"
@@ -1482,7 +1483,7 @@ SH
   meta="$home/state/task-rf.meta"
   out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$home" FMX_RELAY_URL="https://relay.test" \
     FMX_NOW_OVERRIDE=1700003600 FAKE_FOLLOWUP_CODE=200 FAKE_CURL_TOUCH_AFTER_POST="$flag" \
-    FAKE_MV_FAIL_AFTER_FLAG="$flag" FAKE_MV_FAILED_ONCE="$mvflag" \
+    FAKE_MV_FAIL_AFTER_FLAG="$flag" FAKE_MV_FAILED_ONCE="$mvflag" REAL_MV="$real_mv" \
     "$ROOT/bin/fm-x-followup.sh" task-rf - <<<"posted but local state write fails" 2>"$err"); rc=$?
   expect_code 0 "$rc" "followup post state-record failure exit"
   [ "$out" = "req-rf" ] || fail "posted followup with tombstoned state must echo the request_id (got: $out)"

--- a/tests/fm-x-mode.test.sh
+++ b/tests/fm-x-mode.test.sh
@@ -13,12 +13,7 @@ set -u
 # shellcheck source=tests/lib.sh
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
-BASE_PATH=${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin}
-# The client under test uses the real jq; make it resolvable regardless of where
-# it is installed (Homebrew, Nix profile bins, etc.), which the bare BASE_PATH may
-# not include. Prepended after the fakebin so the fake curl still wins.
-JQ_DIR=$(command -v jq 2>/dev/null) && JQ_DIR=$(dirname "$JQ_DIR") || JQ_DIR=
-[ -n "$JQ_DIR" ] && BASE_PATH="$JQ_DIR:$BASE_PATH"
+BASE_PATH=$(fm_test_base_path)
 TMP_ROOT=$(fm_test_tmproot fm-x-mode-tests)
 
 # A fakebin `curl` that mimics the relay: it reads its behavior from env

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -91,6 +91,21 @@ SH
   done
 }
 
+# fm_test_base_path: a "rest of the system" PATH for tests that restrict PATH
+# to simulate a missing tool. Defaults to the FHS locations, overridable via
+# FM_TEST_BASE_PATH, then prepends the real directories backing bash/coreutils
+# and jq: on a non-FHS host (e.g. NixOS/home-manager) those tools live outside
+# the FHS locations, and not necessarily in the same directory as each other,
+# which breaks every `bash -c`/script-shebang/jq invocation under the
+# restricted PATH regardless of the tool under test.
+fm_test_base_path() {
+  local base=${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin} tool real_bin
+  for tool in jq cat; do
+    real_bin=$(command -v "$tool" 2>/dev/null) && base="$(dirname "$real_bin"):$base"
+  done
+  printf '%s' "$base"
+}
+
 # --- deterministic git identity and fixtures --------------------------------
 
 # fm_git_identity [name] [email]: export a fixed author/committer identity so


### PR DESCRIPTION
## Summary

- The `/afk` supervise daemon on a herdr backend redelivered an already-handled escalation into the supervisor pane every cycle. Root cause: `blocked` is the one pre-Enter agent status that both clears the daemon's pre-type busy guard (`classify_agent_status`: blocked->idle) and reads submit-active (`classify_submit_agent_status`: blocked->busy), so a blocked baseline (a supervisor pane parked on a tool/permission prompt) routed submit-confirmation to the composer-clear fallback, and `fm_backend_herdr_composer_state` returns `unknown` on a claude dialog screen with no composer row - so a landed submit read as unconfirmed and got retyped forever.
- Fix at the shared herdr adapter (not papered over in the daemon): `fm_backend_herdr_send_text_submit` branches on the raw pre-Enter status; a `blocked` baseline confirms via native agent-state on a `blocked->working` transition only (new working-only mode of `fm_backend_herdr_wait_for_working`), never composer content - consistent with the 2026-07-07 native-agent-state approach. idle/done and working/unreadable baselines are unchanged.
- Rode along (pipeline auto-fixes for pre-existing NixOS breakage that blocked the suite): a shared `fm_test_base_path()` test helper for restricted-PATH tests, `"$BASH"` in the herdr/zellij version-check tests, and an `orca.sh` `JSON.parse` guard that exits cleanly on bad stdin.

## Test plan

- Regression: reverted the fix -> `not ok ... got 'unknown'` (the exact misclassification); restored -> both new tests pass. Added to `tests/fm-backend-herdr.test.sh`: a blocked->working baseline confirms `empty` and never calls `pane read`; a stays-blocked baseline reads `pending` so the buffer is preserved (no false confirm that would drop the escalation).
- Full herdr suite green (77 ok / 0 not ok); `bin/backends/herdr.sh` shellcheck-clean.
- Validated end to end through the no-mistakes pipeline (review, test, document, lint all green).