### PR TITLE
fix(fm-spawn): capture only a project-repo worktree

### DIFF
--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -663,6 +663,41 @@ real_path_or_raw() {  # <path>
   fi
 }
 
+# Resolve a directory's git common-dir to a physical absolute path, or fail
+# (non-zero, no output) when <dir> is not inside a git working tree. All
+# treehouse worktrees of a project share ONE common-dir (object store) with the
+# primary checkout, so this is the identity that says "belongs to the same
+# repository". `rev-parse --git-common-dir` can return a path relative to <dir>
+# (e.g. ".git"), so resolve it against <dir> before canonicalizing.
+git_common_dir_real() {  # <dir>
+  local dir=$1 cdir
+  cdir=$(git -C "$dir" rev-parse --git-common-dir 2>/dev/null) || return 1
+  [ -n "$cdir" ] || return 1
+  case "$cdir" in
+    /*) : ;;
+    *) cdir="$dir/$cdir" ;;
+  esac
+  (cd "$cdir" 2>/dev/null && pwd -P) || return 1
+}
+
+# The project repository's common-dir, resolved once. A polled candidate cwd is
+# accepted as the worktree only when it shares this common-dir, which rejects a
+# transient unrelated git repo (e.g. ~/.oh-my-zsh that a shell rc briefly cd's
+# into while treehouse's fresh subshell sources ~/.zshrc). Empty when it can't
+# be resolved (e.g. a non-git PROJ_ABS), in which case the checks below fall
+# back to the prior differs-from-primary behavior alone.
+PROJ_COMMON_DIR=$(git_common_dir_real "$PROJ_ABS" 2>/dev/null || true)
+
+# A polled candidate cwd belongs to the project's repository when its git
+# common-dir matches the project's. When the project common-dir is unknown, the
+# guard can't be applied, so accept (prior behavior).
+candidate_is_project_worktree() {  # <candidate-path>
+  local cand=$1 cand_common
+  [ -n "$PROJ_COMMON_DIR" ] || return 0
+  cand_common=$(git_common_dir_real "$cand" 2>/dev/null) || return 1
+  [ "$cand_common" = "$PROJ_COMMON_DIR" ]
+}
+
 # Session-provider container-ensure + task creation. tmux stays exactly as P1
 # left it (same session-name / new-window sequence, see bin/backends/tmux.sh);
 # a herdr spawn goes through the version-gated, workspace-per-HOME,
@@ -672,7 +707,7 @@ real_path_or_raw() {  # <path>
 # that every downstream operation (send/capture/kill) already treats as opaque
 # per-backend routing (fm_backend_resolve_selector).
 validate_spawn_worktree() {  # <source> <inspect-target>
-  local source=$1 inspect_target=$2 wt_real proj_real wt_top wt_top_real
+  local source=$1 inspect_target=$2 wt_real proj_real wt_top wt_top_real wt_common
   wt_real=
   if ! wt_real=$(cd "$WT" 2>/dev/null && pwd -P); then
     wt_real=
@@ -686,6 +721,18 @@ validate_spawn_worktree() {  # <source> <inspect-target>
   if [ -z "$wt_real" ] || [ -z "$wt_top_real" ] || [ "$wt_real" != "$wt_top_real" ] || [ "$wt_real" = "$proj_real" ]; then
     echo "error: $source did not yield an isolated worktree (resolved '$WT'; worktree root '${wt_top:-none}'; primary '$PROJ_ABS'); refusing to launch to avoid tangling the primary checkout. Inspect target $inspect_target" >&2
     exit 1
+  fi
+  # Defense-in-depth: the worktree must belong to the project's repository
+  # (shared git common-dir), so even a capture that was fooled into recording
+  # an unrelated git repo is rejected here rather than launched. Scoped to the
+  # treehouse path; the orca path owns its own worktree handling. Skipped when
+  # the project common-dir can't be resolved.
+  if [ "$BACKEND" != orca ] && [ -n "$PROJ_COMMON_DIR" ]; then
+    wt_common=$(git_common_dir_real "$WT" 2>/dev/null || true)
+    if [ "$wt_common" != "$PROJ_COMMON_DIR" ]; then
+      echo "error: $source resolved a worktree outside the project's repository (worktree common-dir '${wt_common:-none}'; project common-dir '$PROJ_COMMON_DIR'); refusing to launch. Inspect target $inspect_target" >&2
+      exit 1
+    fi
   fi
 }
 
@@ -825,16 +872,27 @@ if [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   # Compare against PROJ_ABS_REAL (physical), not PROJ_ABS: a symlinked project
   # prefix would otherwise make the pane's OS-level cwd read differ from
   # PROJ_ABS on the very first poll, before the pane has actually moved.
-  for _ in $(seq 1 60); do
+  # Accept only a candidate that is a worktree OF THE PROJECT'S repository:
+  # treehouse's fresh subshell sources ~/.zshrc, and an rc that momentarily
+  # cd's elsewhere (oh-my-zsh's update check runs `cd "$ZSH"` = ~/.oh-my-zsh)
+  # can be sampled by this poll. Such a cwd differs from the project yet is an
+  # unrelated git repo, so it would pass the differs-from-primary test alone and
+  # be recorded as WT, breaking teardown and isolation. Requiring the shared
+  # project common-dir skips it and keeps polling for the real worktree.
+  # Poll budget defaults to 60 tries at 1s (unchanged); the knobs exist only so
+  # tests can exercise the timeout path fast.
+  WT_POLL_TRIES=${FM_SPAWN_WT_POLL_TRIES:-60}
+  WT_POLL_SLEEP=${FM_SPAWN_WT_POLL_SLEEP:-1}
+  for _ in $(seq 1 "$WT_POLL_TRIES"); do
     p=$(spawn_current_path "$T" || true)
-    if [ -n "$p" ] && [ "$(real_path_or_raw "$p")" != "$PROJ_ABS_REAL" ]; then
+    if [ -n "$p" ] && [ "$(real_path_or_raw "$p")" != "$PROJ_ABS_REAL" ] && candidate_is_project_worktree "$p"; then
       WT="$p"
       break
     fi
-    sleep 1
+    [ "$WT_POLL_SLEEP" = 0 ] || sleep "$WT_POLL_SLEEP"
   done
   if [ -z "$WT" ]; then
-    echo "error: treehouse get did not enter a worktree within 60s; inspect window $T" >&2
+    echo "error: treehouse get did not enter a worktree within ${WT_POLL_TRIES}x${WT_POLL_SLEEP}s; inspect window $T" >&2
     exit 1
   fi
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -73,7 +73,8 @@ Codex App support is recorded in `docs/codex-app-backend.md`; it is not selectab
 ## Worktrees, not branches in your checkout
 
 Crewmates never intentionally touch your project clone; [treehouse](https://github.com/kunchenguid/treehouse) pools clean worktrees for tmux, herdr, zellij, and cmux tasks, while Orca creates its own worktrees for `backend=orca`.
-For ship and scout work, `fm-spawn.sh` refuses to launch unless the resolved task path is a real git worktree root that is distinct from the project primary checkout.
+For ship and scout work, `fm-spawn.sh` refuses to launch unless the resolved task path is a real git worktree root that is distinct from the project primary checkout and belongs to the project's own repository (a shared git common-dir).
+For treehouse-backed tasks it also caps worktree discovery to that same test while polling: it accepts a sampled pane cwd only when the cwd shares the project's common-dir, so a transient unrelated git repo a shell rc briefly enters (for example oh-my-zsh's update check running `cd "$ZSH"`) is skipped rather than recorded as the worktree.
 
 The firstmate repo has one extra exposure because it can dispatch crewmates to work on itself.
 Its operating checkout (`FM_ROOT`) and the disposable crewmate worktrees are all linked git worktrees of the same repository, so the valid discriminator is branch state, not whether the checkout is linked.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -298,6 +298,8 @@ GROK_HOME=              # optional Grok config home for firstmate's global grok 
 FM_SEND_RETRIES=3       # fm-send Enter-retry attempts after typing the line once
 FM_SEND_SLEEP=0.4       # seconds between fm-send submit checks
 FM_SEND_SETTLE=1        # seconds fm-send waits after a successful text submit; 0 disables
+FM_SPAWN_WT_POLL_TRIES=60   # fm-spawn polls for the treehouse worktree cwd this many times, accepting only a cwd that shares the project's git common-dir; exists so tests can exercise the timeout path fast
+FM_SPAWN_WT_POLL_SLEEP=1    # seconds fm-spawn waits between worktree-cwd polls; 0 disables the sleep
 # sub-supervisor (bin/fm-supervise-daemon.sh); presence-gated via /afk
 FM_SUPERVISOR_BACKEND=             # optional supervisor pane backend override; tmux/herdr only, otherwise detects $TMUX_PANE then HERDR_ENV/HERDR_PANE_ID before tmux fallback
 FM_SUPERVISOR_TARGET=              # optional supervisor pane target override; tmux target or herdr <session>:<pane-id>, otherwise auto-detected

--- a/tests/fm-spawn-worktree-capture.test.sh
+++ b/tests/fm-spawn-worktree-capture.test.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# Behavior tests for fm-spawn.sh treehouse worktree capture.
+#
+# Regression coverage for the intermittent bad-worktree bug: the pane's cwd is
+# polled after `treehouse get`, and treehouse's fresh subshell sources ~/.zshrc.
+# An rc that momentarily cd's elsewhere (oh-my-zsh's update check runs
+# `cd "$ZSH"` = ~/.oh-my-zsh) can be sampled by that poll. Such a cwd is a real
+# git repo distinct from the project, so the old differs-from-primary check
+# accepted it and recorded worktree=~/.oh-my-zsh, breaking teardown and defeating
+# isolation. The fix requires a captured cwd to share the project repository's
+# git common-dir; an unrelated repo is skipped and polling continues.
+#
+# These drive fm-spawn through meta writing with a fake tmux pane whose
+# pane_current_path first returns an unrelated git repo (the transient capture),
+# then the genuine project worktree. A real isolated worktree via fm_git_worktree
+# gives the accept case; a separate `git init` repo gives the reject case.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SPAWN="$ROOT/bin/fm-spawn.sh"
+TMP_ROOT=$(fm_test_tmproot fm-spawn-worktree-capture)
+
+# Fake tmux: pane_current_path returns FM_FAKE_TRANSIENT_PATH for the first
+# FM_FAKE_TRANSIENT_COUNT reads (an unrelated repo, simulating the ~/.oh-my-zsh
+# capture), then FM_FAKE_PANE_PATH (the real worktree). A per-run counter file
+# makes the sequence stateful across the capture loop's polls.
+make_capture_fakebin() {
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  *"#{pane_current_path}"*)
+    n=0
+    if [ -n "${FM_FAKE_PANE_COUNTER:-}" ]; then
+      [ -f "$FM_FAKE_PANE_COUNTER" ] && n=$(cat "$FM_FAKE_PANE_COUNTER")
+      printf '%s\n' "$((n + 1))" > "$FM_FAKE_PANE_COUNTER"
+    fi
+    if [ "$n" -lt "${FM_FAKE_TRANSIENT_COUNT:-0}" ]; then
+      printf '%s\n' "${FM_FAKE_TRANSIENT_PATH:-}"
+    else
+      printf '%s\n' "${FM_FAKE_PANE_PATH:-}"
+    fi
+    exit 0
+    ;;
+esac
+case "${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+  list-windows) exit 0 ;;
+  has-session|new-session|new-window|kill-window|send-keys) exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" treehouse
+  printf '%s\n' "$fakebin"
+}
+
+# make_capture_case <name> <id> sets CASE_DIR/HOME_DIR/PROJ_DIR/WT_DIR/
+# UNREL_DIR/FAKEBIN_DIR/COUNTER_FILE for one spawn. PROJ_DIR + WT_DIR are a real
+# repo and its worktree (same common-dir); UNREL_DIR is a separate git repo
+# standing in for the transient ~/.oh-my-zsh cwd (different common-dir).
+make_capture_case() {
+  local name=$1 id=$2
+  CASE_DIR="$TMP_ROOT/$name"
+  HOME_DIR="$CASE_DIR/home"
+  PROJ_DIR="$CASE_DIR/project"
+  WT_DIR="$CASE_DIR/wt"
+  UNREL_DIR="$CASE_DIR/unrelated"
+  COUNTER_FILE="$CASE_DIR/pane-counter"
+  FAKEBIN_DIR=$(make_capture_fakebin "$CASE_DIR/fake")
+  mkdir -p "$HOME_DIR/data/$id" "$HOME_DIR/state" "$HOME_DIR/config"
+  printf 'claude\n' > "$HOME_DIR/config/crew-harness"
+  printf 'brief for %s\n' "$id" > "$HOME_DIR/data/$id/brief.md"
+  touch "$HOME_DIR/state/.last-watcher-beat"
+  fm_git_worktree "$PROJ_DIR" "$WT_DIR" "wt-$name"
+  fm_git_init_commit "$UNREL_DIR"
+}
+
+run_capture_spawn() {
+  local transient_path=$1 transient_count=$2 id=$3
+  : > "$COUNTER_FILE"
+  FM_ROOT_OVERRIDE='' FM_HOME="$HOME_DIR" \
+    FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
+    FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
+    FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" GROK_HOME="$HOME_DIR/grok-home" \
+    FM_FAKE_PANE_PATH="$WT_DIR" FM_FAKE_PANE_COUNTER="$COUNTER_FILE" \
+    FM_FAKE_TRANSIENT_PATH="$transient_path" FM_FAKE_TRANSIENT_COUNT="$transient_count" \
+    PATH="$FAKEBIN_DIR:$PATH" \
+    "$SPAWN" "$id" "$PROJ_DIR" 2>&1
+}
+
+# The transient unrelated repo is sampled first, then the genuine worktree. The
+# capture must skip the unrelated repo and record the worktree, not the first
+# differs-from-primary cwd it sees.
+test_transient_unrelated_cwd_is_skipped() {
+  local id out status meta
+  id=capture-transient-z1
+  make_capture_case capture-transient "$id"
+
+  out=$(run_capture_spawn "$UNREL_DIR" 1 "$id")
+  status=$?
+  expect_code 0 "$status" "spawn should succeed after skipping a transient unrelated cwd"
+  meta="$HOME_DIR/state/$id.meta"
+  assert_grep "worktree=$WT_DIR" "$meta" "capture recorded a worktree other than the real project worktree"
+  assert_no_grep "worktree=$UNREL_DIR" "$meta" "capture wrongly recorded the transient unrelated repo as the worktree"
+  pass "a transient unrelated git repo is skipped and the real project worktree is captured"
+}
+
+# A cwd that never leaves an unrelated repo is never accepted: the capture times
+# out and refuses rather than launching against a foreign worktree. A short
+# poll budget keeps the timeout path fast without changing the default.
+test_persistent_unrelated_cwd_refuses() {
+  local id out status
+  id=capture-persistent-z2
+  make_capture_case capture-persistent "$id"
+
+  # FM_FAKE_TRANSIENT_COUNT larger than the poll budget => every poll returns the
+  # unrelated repo. FM_SPAWN_WT_POLL_TRIES/SLEEP keep the timeout path quick.
+  : > "$COUNTER_FILE"
+  out=$(FM_ROOT_OVERRIDE='' FM_HOME="$HOME_DIR" \
+    FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
+    FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
+    FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" GROK_HOME="$HOME_DIR/grok-home" \
+    FM_FAKE_PANE_PATH="$UNREL_DIR" FM_FAKE_PANE_COUNTER="$COUNTER_FILE" \
+    FM_FAKE_TRANSIENT_PATH="$UNREL_DIR" FM_FAKE_TRANSIENT_COUNT=999 \
+    FM_SPAWN_WT_POLL_TRIES=3 FM_SPAWN_WT_POLL_SLEEP=0 \
+    PATH="$FAKEBIN_DIR:$PATH" \
+    "$SPAWN" "$id" "$PROJ_DIR" 2>&1)
+  status=$?
+  expect_code 1 "$status" "spawn should refuse when only an unrelated repo is ever the pane cwd"
+  assert_contains "$out" "did not enter a worktree" "refusal did not report the capture timeout"
+  pass "a cwd that never becomes a project worktree is refused, not launched"
+}
+
+# The genuine worktree from the first poll (no transient) is accepted unchanged,
+# guarding against a regression that would reject real treehouse worktrees.
+test_genuine_worktree_captured() {
+  local id out status meta
+  id=capture-genuine-z3
+  make_capture_case capture-genuine "$id"
+
+  out=$(run_capture_spawn "$UNREL_DIR" 0 "$id")
+  status=$?
+  expect_code 0 "$status" "spawn should succeed on a genuine project worktree from the first poll"
+  meta="$HOME_DIR/state/$id.meta"
+  assert_grep "worktree=$WT_DIR" "$meta" "genuine project worktree was not captured on the first poll"
+  pass "a genuine project worktree is accepted on the first poll"
+}
+
+test_transient_unrelated_cwd_is_skipped
+test_persistent_unrelated_cwd_refuses
+test_genuine_worktree_captured
+
+echo "# all fm-spawn-worktree-capture tests passed"

--- a/tests/fm-spawn-worktree-capture.test.sh
+++ b/tests/fm-spawn-worktree-capture.test.sh
@@ -36,7 +36,7 @@ case "$*" in
   *"#{pane_current_path}"*)
     n=0
     if [ -n "${FM_FAKE_PANE_COUNTER:-}" ]; then
-      [ -f "$FM_FAKE_PANE_COUNTER" ] && n=$(cat "$FM_FAKE_PANE_COUNTER")
+      [ -s "$FM_FAKE_PANE_COUNTER" ] && n=$(cat "$FM_FAKE_PANE_COUNTER")
       printf '%s\n' "$((n + 1))" > "$FM_FAKE_PANE_COUNTER"
     fi
     if [ "$n" -lt "${FM_FAKE_TRANSIENT_COUNT:-0}" ]; then

--- a/tests/fm-tangle-guard.test.sh
+++ b/tests/fm-tangle-guard.test.sh
@@ -181,6 +181,7 @@ run_spawn() {
     FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
     FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
     FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$pane" TMUX="fake,1,0" \
+    FM_SPAWN_WT_POLL_TRIES=3 FM_SPAWN_WT_POLL_SLEEP=0 \
     PATH="$fakebin:$PATH" \
     "$ROOT/bin/fm-spawn.sh" "$id" "$proj" codex 2>&1
 }
@@ -196,9 +197,11 @@ test_spawn_isolation_abort() {
   mkdir -p "$TMP_ROOT/spawn-notgit" "$proj/sub"
 
   # Abort: the pane resolves to a plain non-git directory (not a worktree at all).
+  # A non-git cwd never becomes a worktree of the project, so the capture loop
+  # keeps polling and times out rather than recording it as WT.
   out=$(run_spawn "$home" abort-notgit-dd4 "$proj" "$TMP_ROOT/spawn-notgit" "$fakebin"); status=$?
   expect_code 1 "$status" "spawn into a non-worktree dir should abort"
-  assert_contains "$out" "did not yield an isolated worktree" "non-worktree spawn lacked the isolation error"
+  assert_contains "$out" "did not enter a worktree" "non-worktree spawn lacked the capture timeout"
   assert_absent "$home/state/abort-notgit-dd4.meta" "aborted spawn must not record meta"
 
   # Abort: the pane resolves INTO the primary checkout (a subdir of PROJ_ABS).


### PR DESCRIPTION
## Intent

Fix intermittent fm-spawn.sh worktree-capture bug where a task's meta sometimes recorded worktree=~/.oh-my-zsh (or another transient dir) though the crew launched in the correct treehouse worktree, breaking teardown and defeating isolation. Root cause: the capture loop accepted the first polled pane cwd that merely differed from the primary checkout; treehouse's fresh shell sources ~/.zshrc and oh-my-zsh's update check momentarily runs cd $ZSH (=~/.oh-my-zsh), and a poll sampling that instant recorded it. validate_spawn_worktree missed it because ~/.oh-my-zsh is a real git repo distinct from the project. Fix (robust for any transient cwd): the capture loop now accepts a candidate only if it shares the project repository's git common-dir (all treehouse worktrees share one object store with the primary; unrelated repos do not), and validate_spawn_worktree gained the same assertion as defense-in-depth, scoped to the treehouse path (orca owns its own worktree handling, untouched). Physical paths (pwd -P) preserve symlink handling. Added defaulted poll knobs FM_SPAWN_WT_POLL_TRIES/SLEEP purely so tests exercise the timeout path fast; default 60x1s behavior unchanged. New tests/fm-spawn-worktree-capture.test.sh reproduces the bug end-to-end: a transient unrelated repo sampled first is skipped and the real worktree captured, a cwd that never becomes a project worktree is refused, and a genuine worktree is accepted. A non-git or unrelated-repo cwd now aborts via the capture-loop timeout instead of validate_spawn_worktree - same safe outcome (exit 1, no meta recorded); the existing tangle-guard test was aligned to that. firstmate's own shared/tracked material; shellcheck clean across bin and tests.

## What Changed

- `bin/fm-spawn.sh` now accepts a polled pane cwd as the task worktree only when it shares the project repository's git common-dir, so a transient cwd (e.g. oh-my-zsh's `cd $ZSH` during `~/.zshrc` sourcing) is skipped instead of being recorded as `worktree=`; `validate_spawn_worktree` gained the same common-dir assertion as defense-in-depth, scoped to the treehouse path and leaving Orca's own worktree handling untouched.
- Added defaulted poll knobs `FM_SPAWN_WT_POLL_TRIES`/`FM_SPAWN_WT_POLL_SLEEP` (default 60x1s, behavior unchanged) so tests can exercise the capture-timeout path quickly; a cwd that never becomes a project worktree now aborts via the capture-loop timeout rather than `validate_spawn_worktree`, same safe outcome (exit 1, no meta recorded).
- Added `tests/fm-spawn-worktree-capture.test.sh` covering transient-skip, persistent-unrelated refusal via timeout, and genuine-worktree accept; realigned `tests/fm-tangle-guard.test.sh` to the timeout path; documented the common-dir check and poll knobs in `docs/architecture.md` and `docs/configuration.md`.

## Risk Assessment

✅ Low: A well-bounded defense-in-depth fix that only tightens worktree acceptance, rests on a confirmed repo invariant (treehouse worktrees share the project's git common-dir), leaves the happy path and orca/secondmate paths untouched, and ships with end-to-end regression tests; the only concerns are a minor consistency/robustness nit and a documented error-path latency tradeoff.

## Testing

`Baseline configured suite had already run green. I ran the two directly-affected test files (the new fm-spawn-worktree-capture.test.sh and the realigned fm-tangle-guard.test.sh), both pass. For product-level evidence I reproduced the intermittent bug end-to-end: driving bin/fm-spawn.sh with a fake tmux that reports a transient unrelated git repo (~/.oh-my-zsh stand-in) on the first pane-cwd poll and the real worktree afterward. On the target commit fm-spawn skips the transient repo and records the correct worktree= in the task meta (exit 0); the base commit's capture loop accepts the first differing cwd and does not cleanly produce the correct spawn on the same input, confirming the fix changes behavior. UI evidence is not applicable - this is a shell/CLI worktree-capture change whose end-user surface is the recorded state/<id>.meta worktree= line, captured in the transcript artifact.`

<details>
<summary>Evidence: fm-spawn worktree-capture reproduction (fix vs base)</summary>

<code>SCENARIO: pane cwd poll samples the transient ~/.oh-my-zsh dir first, then the real worktree.&#10;--- WITHOUT FIX (base af5361e) --- exit=1, recorded: (no meta written)&#10;--- WITH FIX (target) --- exit=0, recorded: worktree=&lt;real project worktree&gt; (transient oh-my-zsh skipped)</code>

```text
SCENARIO: pane cwd poll samples the transient ~/.oh-my-zsh dir first, then the real worktree.
  correct project worktree : /var/folders/8p/st8ljpz15750xhwk4jn4jtyw0000gr/T/tmp.MG8inlkRYq/wt
  transient oh-my-zsh cwd  : /var/folders/8p/st8ljpz15750xhwk4jn4jtyw0000gr/T/tmp.MG8inlkRYq/oh-my-zsh

--- WITHOUT FIX (base commit af5361e capture loop) ---
mkdir: .git: Not a directory
exit=1
>> recorded: (no meta written)

--- WITH FIX (target commit capture loop) ---
warn: no registry at /var/folders/8p/st8ljpz15750xhwk4jn4jtyw0000gr/T/tmp.MG8inlkRYq/home/data/projects.md; defaulting project to no-mistakes off
spawned demo-x1 harness=claude kind=ship mode=no-mistakes yolo=off window=firstmate:fm-demo-x1 worktree=/var/folders/8p/st8ljpz15750xhwk4jn4jtyw0000gr/T/tmp.MG8inlkRYq/wt
exit=0
>> recorded: worktree=/var/folders/8p/st8ljpz15750xhwk4jn4jtyw0000gr/T/tmp.MG8inlkRYq/wt
```
</details>
<details>
<summary>Evidence: New regression test output</summary>

```text
ok - a transient unrelated git repo is skipped and the real project worktree is captured
ok - a cwd that never becomes a project worktree is refused, not launched
ok - a genuine project worktree is accepted on the first poll
# all fm-spawn-worktree-capture tests passed
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ℹ️ `bin/fm-spawn.sh:674` - git_common_dir_real reinvents git-common-dir resolution with a manual relative-path join (case &#39;*) cdir=&#34;$dir/$cdir&#34;&#39;), but the repo already has this exact need solved in bin/fm-ff-lib.sh:192 via `git -C &#34;$dir&#34; rev-parse --path-format=absolute --git-common-dir`. Using --path-format=absolute here would delete the whole case/join block, match the existing convention, and remove a fragile assumption (that git returns the common-dir relative to the -C directory rather than the worktree top). In practice the polled candidate is always a worktree root so the manual join resolves correctly, but the absolute form is strictly more robust and consistent.
- ℹ️ `bin/fm-spawn.sh:894` - A pane that permanently enters a foreign cwd (non-git dir or unrelated repo) now waits the full poll budget (default 60x1s) before failing with &#39;did not enter a worktree&#39;, whereas previously it was captured on the first differing poll and rejected quickly by validate_spawn_worktree (~1s). Same safe outcome (exit 1, no meta), but a genuinely misconfigured spawn now blocks dispatch for ~60s instead of failing fast. This is an intentional, documented tradeoff (the fm-tangle-guard spawn-notgit test was aligned to the timeout path) and only affects the error path; the happy path default is unchanged.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- <code>`bash tests/fm-spawn-worktree-capture.test.sh` (new: transient-skip, persistent-unrelated refusal via timeout, genuine-worktree accept) - all pass</code>
- <code>`bash tests/fm-tangle-guard.test.sh` (realigned to the capture-timeout path) - all pass</code>
- <code>End-to-end reproduction driving `bin/fm-spawn.sh` with a fake tmux whose first pane-cwd poll returns a transient unrelated git repo (~/.oh-my-zsh stand-in) then the real worktree; verified the recorded `worktree=` in state/&lt;id&gt;.meta is the correct project worktree (exit 0), and contrasted against the base commit af5361e capture loop on the identical input</code>
- <code>Full suite `for t in tests/*.test.sh` had run green as the configured baseline; a re-run confirmed passing tests before the 2m harness timeout (suite is slow, not failing)</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
