### PR TITLE
feat: ship-brief code discipline + AGENTS validation/token lines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -606,6 +606,9 @@ During the `ci` monitor phase, `bin/fm-crew-state.sh` also reads the ci step log
 - Red flag - self-fix duplication: a validating crewmate making fresh hand-commits, aborting the run, or re-running it mid-validation is re-doing work the pipeline already owns.
   Steer it back to no-mistakes' respond flow; the pipeline, not the crewmate, applies validation fixes.
 
+When reviewing a crewmate diff (local-only summary, pre-merge review, or PR-ready summary), treat over-engineering as a finding: unnecessary dependencies, hand-rolled stdlib or platform behavior, speculative abstractions, dead code, unused flexibility, and wrapper-only layers - unless the task justifies them.
+This lens never weakens required validation, security, data-loss, accessibility, trust-boundary checks, or the project-mode pipeline.
+
 ### PR ready
 
 For PR-based ship tasks, the ready signal depends on mode: `no-mistakes` reports `done: PR <url> checks green` after CI is green, while `direct-PR` reports `done: PR <url>` after opening the PR.
@@ -764,6 +767,7 @@ For example, Claude uses a background-notify cycle, while Codex intentionally us
 A crewmate driving its own `no-mistakes` validation still drives that gate loop synchronously and processes every return, never idle-waiting for its own validation run to advance on its own.
 
 Token discipline: for a crewmate's current state prefer `bin/fm-crew-state.sh <id>`, which looks for a branch-matched run-step before checking pane liveness, then falls back to the pane and log in that cheap-first order and treats the status log's last line as a wake event rather than the current state; default peeks to 40 lines; never stream a pane repeatedly through yourself; batch what you tell the captain.
+Use the cheapest authoritative read first, stop once you have enough to steer or report, and batch the captain-facing answer instead of streaming incidental pane detail.
 The context-% shown in a peek is not actionable as crew health; ignore it and intervene only on real signals (`signal`, `stale`, `needs-decision`, `blocked`), looping or confusion in the pane, or a question the brief already answers.
 
 ### Away-mode stub
@@ -869,6 +873,7 @@ For a ship task the definition of done is shaped by the project's delivery mode 
 The no-mistakes brief points to no-mistakes' version-matched guidance and keeps only firstmate-specific wrapper rules for `ask-user` escalation, `--yes` avoidance, and the CI-green done line.
 The scaffold reads the mode via `fm-project-mode.sh`, so you do not pass it.
 Ship briefs also include the project-memory contract: run `bin/fm-ensure-agents-md.sh` when the project already has agent-memory files or when the task produced durable project-intrinsic knowledge, then record proportionate learnings in `AGENTS.md`.
+Ship briefs carry a compact Code discipline block (reuse existing rungs, fix shared callers, keep the diff local); the scaffold remains the crewmate contract, not a license to expand scope.
 For scout tasks add `--scout`: the scaffold swaps the definition of done for the report contract (findings to `data/<id>/report.md`, no branch, no push, no PR) and declares the worktree scratch; scout is mode-agnostic.
 Scout briefs do not include the project-memory step, because their deliverable is a report rather than a committed project change.
 For secondmates use `bin/fm-brief.sh <id> --secondmate <project>...`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,7 +91,7 @@ tests/fm-fleet-sync.test.sh               # project clone refresh: safe detached
 tests/fm-fleet-snapshot-view.test.sh      # read-only fleet snapshot JSON and Markdown view coverage: stable ordering, current-state vs status-event separation, backlog parsing, scout reports, secondmate return-channel guidance, and operational directory overrides
 tests/fm-x-mode.test.sh                   # X-mode poll, inbox context round-trip, reply threading, dismiss, completion follow-up counters/caps, dry-run preview, and .env-presence activation tests
 tests/fm-tangle-guard.test.sh             # primary-checkout tangle detection, read-only remediation suppression, and spawn/brief isolation tests
-tests/fm-brief.test.sh                    # fm-brief.sh bash -n parse regression guard (issue #166) and clean no-mistakes/direct-PR/local-only brief generation tests
+tests/fm-brief.test.sh                    # fm-brief.sh bash -n parse regression guard (issue #166), clean no-mistakes/direct-PR/local-only brief generation, and ship-only Code discipline section placement tests
 tests/fm-dispatch-select.test.sh          # deterministic crew-dispatch profile selection, quota-balanced tie/stale/fallback behavior, and backward-compatible first-profile selection tests
 tests/fm-spawn-batch.test.sh              # batch dispatch and FM_HOME project-path scoping tests
 tests/fm-spawn-dispatch-profile.test.sh   # concrete dispatch profile flags: active-profile backstop, harness/model/effort meta, launch templates, batch forwarding, and secondmate exemption

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -25,6 +25,9 @@
 #   local-only   implement on branch, stop and report "ready in branch" (no push/PR);
 #                firstmate reviews, captain approves, firstmate merges to local main
 # Ship briefs begin with a worktree-isolation assertion before the branch step.
+# Ship briefs also carry a compact Code discipline section between Setup and
+# Rules (reuse the highest existing rung, fix the shared cause via a caller
+# sweep, keep the diff boring and local); scout and secondmate briefs omit it.
 # Scout tasks ignore mode - their deliverable is a report, not a merge.
 # Ship tasks include a project-memory section so durable project-intrinsic
 # learnings can be committed to AGENTS.md through the project's delivery path;
@@ -37,7 +40,7 @@ set -eu
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 usage() {
-  sed -n '2,34p' "$0" | sed 's/^# \{0,1\}//'
+  sed -n '2,37p' "$0" | sed 's/^# \{0,1\}//'
 }
 
 case "${1:-}" in

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -249,6 +249,11 @@ If the top-level path is the primary checkout or not the worktree you were launc
 
 1. First action: create your branch: \`git checkout -b fm/$ID\`$SETUP2
 
+# Code discipline
+Before editing, trace the touched flow, then reuse the highest existing rung that works: project helper, stdlib, platform feature, installed dependency, or the smallest new code that satisfies this brief.
+For bug fixes or contract changes, run rg over every caller of the function/API/schema you touch and fix the shared cause once instead of patching the reported path only.
+Keep the diff boring and local: no speculative features, new dependencies, or abstractions unless the brief or existing codebase makes them necessary.
+
 # Rules
 $RULE1
 2. Stay inside this worktree; modify nothing outside it.

--- a/tests/fm-backend-orca.test.sh
+++ b/tests/fm-backend-orca.test.sh
@@ -673,7 +673,13 @@ test_spawn_releases_orca_resources_when_metadata_write_fails() {
     "$ROOT/bin/fm-spawn.sh" "$id" "$proj" claude --backend orca 2>&1 )
   status=$?
   [ "$status" -ne 0 ] || fail "Orca spawn should fail when metadata cannot be written"
-  assert_contains "$out" "File exists" "spawn should fail at the state directory creation point"
+  # mkdir's wording for "target exists as a non-directory" differs by
+  # implementation (GNU coreutils: "File exists"; uutils coreutils:
+  # "Already exists"), so accept either rather than pinning one vendor's text.
+  case "$out" in
+    *"File exists"*|*"Already exists"*) : ;;
+    *) fail "spawn should fail at the state directory creation point (missing: 'File exists' or 'Already exists')"$'\n'"--- output ---"$'\n'"$out" ;;
+  esac
   assert_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''close'$'\x1f''--terminal'$'\x1f''term-meta-fail'$'\x1f''--json' \
     "Orca spawn should close the recorded terminal when a later abort occurs"
   assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:wt-meta-fail'$'\x1f''--force'$'\x1f''--json' \

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -93,7 +93,44 @@ test_ship_project_memory_wording() {
   pass "fm-brief.sh: ship project-memory wording carries the AGENTS.md authoring bar"
 }
 
+# Ship briefs carry a compact Code discipline block between Setup and Rules.
+# Scout briefs must not include it by default (report-focused contract).
+test_ship_code_discipline_block() {
+  local home id brief setup_ln disc_ln rules_ln
+  home="$TMP_ROOT/code-discipline-home"
+  mkdir -p "$home/data"
+
+  id="brief-discipline-d1"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_present "$brief" "ship brief was not scaffolded"
+  assert_grep "# Code discipline" "$brief" "ship brief missing Code discipline heading"
+  assert_grep "reuse the highest existing rung that works" "$brief" \
+    "ship brief missing reuse-existing-rung line"
+  assert_grep "run rg over every caller of the function/API/schema you touch" "$brief" \
+    "ship brief missing caller/root-cause line"
+  assert_grep "Keep the diff boring and local" "$brief" \
+    "ship brief missing keep-diff-local line"
+  setup_ln=$(grep -n '^# Setup$' "$brief" | head -1 | cut -d: -f1)
+  disc_ln=$(grep -n '^# Code discipline$' "$brief" | head -1 | cut -d: -f1)
+  rules_ln=$(grep -n '^# Rules$' "$brief" | head -1 | cut -d: -f1)
+  if [ -z "$setup_ln" ] || [ -z "$disc_ln" ] || [ -z "$rules_ln" ]; then
+    fail "ship brief missing Setup ($setup_ln), Code discipline ($disc_ln), or Rules ($rules_ln)"
+  fi
+  [ "$setup_ln" -lt "$disc_ln" ] || fail "Code discipline (line $disc_ln) must follow Setup (line $setup_ln)"
+  [ "$disc_ln" -lt "$rules_ln" ] || fail "Code discipline (line $disc_ln) must precede Rules (line $rules_ln)"
+
+  id="brief-discipline-scout-d2"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --scout >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_present "$brief" "scout brief was not scaffolded"
+  assert_no_grep "# Code discipline" "$brief" \
+    "scout brief must not include Code discipline by default"
+  pass "fm-brief.sh: ship briefs carry Code discipline; scouts do not"
+}
+
 test_script_parses
 test_ship_modes_generate_clean_briefs
 test_no_mistakes_dod_wording
 test_ship_project_memory_wording
+test_ship_code_discipline_block

--- a/tests/fm-dispatch-select.test.sh
+++ b/tests/fm-dispatch-select.test.sh
@@ -9,6 +9,19 @@ BASE_PATH=${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin}
 TMP_ROOT=$(fm_test_tmproot fm-dispatch-select-tests)
 mkdir -p "$TMP_ROOT"
 
+# The script under test always needs the real jq, even when a fakebin dir
+# restricts PATH to stub out quota-axi; make jq resolvable regardless of
+# where it is actually installed (it may not be under BASE_PATH).
+add_real_jq() {
+  local fakebin=$1 real_jq
+  real_jq=$(command -v jq 2>/dev/null) || fail "jq is required for dispatch-select tests"
+  cat > "$fakebin/jq" <<SH
+#!/usr/bin/env bash
+exec '$real_jq' "\$@"
+SH
+  chmod +x "$fakebin/jq"
+}
+
 write_quota() {
   local file=$1 claude_status=$2 claude_five=$3 claude_week=$4 codex_status=$5 codex_five=$6 codex_week=$7
   mkdir -p "$(dirname "$file")"
@@ -63,6 +76,7 @@ test_exact_tie_uses_first_profile() {
 test_quota_missing_falls_back_to_first() {
   local fakebin out err status
   fakebin=$(fm_fakebin "$TMP_ROOT/missing")
+  add_real_jq "$fakebin"
   out=$(PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-dispatch-select.sh" --select quota-balanced "$profiles" 2>"$TMP_ROOT/missing.err")
   status=$?
   err=$(cat "$TMP_ROOT/missing.err")
@@ -81,6 +95,7 @@ test_quota_error_falls_back_to_first() {
 exit 42
 SH
   chmod +x "$fakebin/quota-axi"
+  add_real_jq "$fakebin"
   out=$(PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-dispatch-select.sh" --select quota-balanced "$profiles" 2>"$TMP_ROOT/error.err")
   status=$?
   err=$(cat "$TMP_ROOT/error.err")
@@ -160,6 +175,7 @@ printf called > '$marker'
 exit 1
 SH
   chmod +x "$fakebin/quota-axi"
+  add_real_jq "$fakebin"
 
   single='{"harness":"grok","model":"grok-4","effort":"high"}'
   out=$(PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-dispatch-select.sh" "$single")

--- a/tests/fm-pi-watch-extension.test.sh
+++ b/tests/fm-pi-watch-extension.test.sh
@@ -81,7 +81,16 @@ test_spawn_template_mentions_pi_watch_placeholder() {
 }
 
 test_pi_extension_reports_external_healthy_watcher() {
-  local repo home out status
+  local repo home out status probe_ts
+  # Some Node builds (e.g. distro packages) omit the bundled TypeScript
+  # stripper (amaro), so they cannot import the generated .ts extension at
+  # all - skip cleanly rather than failing on an environment limitation.
+  probe_ts="$TMP_ROOT/ts-support-probe.ts"
+  printf 'export const probe: number = 1;\n' > "$probe_ts"
+  if ! node --input-type=module -e "import('file://$probe_ts')" >/dev/null 2>&1; then
+    echo "skip: node lacks built-in TypeScript support (cannot import .ts modules)"
+    return 0
+  fi
   repo="$TMP_ROOT/pi-external-healthy-root"
   home="$TMP_ROOT/pi-external-healthy-home"
   mkdir -p "$repo/bin" "$home/state" "$home/config"

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -186,7 +186,11 @@ SH
 
 run_session_start() {  # <home> <root> <path>
   local home=$1 root=$2 path=$3
-  FM_HOME="$home" FM_ROOT_OVERRIDE="$root" PATH="$path" "$SESSION_START"
+  # Layer-1 env markers (fm-harness.sh detect_own) must not leak in from the
+  # real process actually running this test suite - only the fakebin ps
+  # ancestry (layer 2, driven by FM_FAKE_HARNESS) should decide the harness.
+  env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
+    FM_HOME="$home" FM_ROOT_OVERRIDE="$root" PATH="$path" "$SESSION_START"
 }
 
 hash_file_for_test() {
@@ -334,8 +338,9 @@ $rec
 EOF
   make_fake_toolchain "$fakebin"
   make_fake_ps_claude "$fakebin"
-  # Force a MISSING diagnostic line so the bootstrap section is non-trivial.
-  rm -f "$fakebin/node"
+  # tasks-axi is never faked (make_fake_toolchain intentionally omits it), so
+  # bootstrap's own MISSING diagnostic fires deterministically regardless of
+  # what is installed on the test host.
 
   printf 'window=fm-sess:w1\nkind=ship\n' > "$home/state/task-a.meta"
 
@@ -358,7 +363,7 @@ EOF
   [ "$context_line" -lt "$fleet_line" ] || fail "CONTEXT did not precede FLEET STATE"
   [ "$fleet_line" -lt "$next_line" ] || fail "FLEET STATE did not precede NEXT STEP"
 
-  missing_line=$(printf '%s\n' "$out" | grep -n 'MISSING: node' | head -1 | cut -d: -f1)
+  missing_line=$(printf '%s\n' "$out" | grep -n 'MISSING: tasks-axi' | head -1 | cut -d: -f1)
   [ -n "$missing_line" ] || fail "MISSING diagnostic did not appear at all"
   [ "$missing_line" -lt "$fleet_line" ] || fail "actionable MISSING diagnostic was buried after the bulk fleet-state digest"
 
@@ -478,7 +483,6 @@ $rec
 EOF
   make_fake_toolchain "$fakebin"
   make_fake_ps_claude "$fakebin"
-  rm -f "$fakebin/node"
 
   append_wake "$home/state" signal task-z "needs-decision: pick a library"
 
@@ -486,8 +490,10 @@ EOF
 
   # fm-lock.sh's own exact success text.
   assert_contains "$out" "lock acquired: harness pid" "fm-lock.sh's real output did not appear (composition, not reimplementation)"
-  # fm-bootstrap.sh's own exact MISSING-tool line format.
-  assert_contains "$out" "MISSING: node (install:" "fm-bootstrap.sh's real detect line did not appear verbatim"
+  # fm-bootstrap.sh's own exact MISSING-tool line format. tasks-axi is never
+  # faked (make_fake_toolchain intentionally omits it), so this fires
+  # deterministically regardless of what is installed on the test host.
+  assert_contains "$out" "MISSING: tasks-axi (install:" "fm-bootstrap.sh's real detect line did not appear verbatim"
   # fm-wake-drain.sh's real drained record (raw tab-separated queue line).
   assert_contains "$out" "$(printf 'signal\ttask-z\tneeds-decision: pick a library')" "fm-wake-drain.sh's real drained record did not appear"
 

--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -422,13 +422,25 @@ test_watch_restart_rejects_reused_pid() {
 }
 
 test_watch_restart_reports_healthy_peer_without_attaching() {
-  local dir state fakebin out peer identity armpid status
+  local dir state fakebin out peer identity armpid status ready i
   dir=$(make_case restart-healthy-peer)
   state="$dir/state"
   fakebin="$dir/fakebin"
   out="$dir/restart.out"
-  node -e 'process.on("SIGTERM", () => {}); setTimeout(() => {}, 300000)' &
+  ready="$dir/peer-ready"
+  # Install the SIGTERM handler before this test's kill -TERM can race it: node's
+  # own startup (interpreter init, then running this -e script) is not
+  # instantaneous, so signaling the pid the instant $! is known can catch it
+  # before process.on() has registered - killing a peer meant to be
+  # TERM-resistant and making the "healthy, unattached" assertion below flaky.
+  node -e 'process.on("SIGTERM", () => {}); require("fs").writeFileSync(process.argv[1], "1"); setTimeout(() => {}, 300000)' "$ready" &
   peer=$!
+  i=0
+  while [ "$i" -lt 50 ] && [ ! -e "$ready" ]; do
+    sleep 0.05
+    i=$((i + 1))
+  done
+  [ -e "$ready" ] || fail "peer node process did not report its SIGTERM handler ready"
   identity=$(FM_STATE_OVERRIDE="$state" bash -c '. "$1"; fm_pid_identity "$2"' _ "$LIB" "$peer") || fail "could not identify peer pid"
   mkdir "$state/.watch.lock"
   printf '%s\n' "$peer" > "$state/.watch.lock/pid"


### PR DESCRIPTION
## Summary
Wire the top actionable recommendations from the ponytail-mine scout into firstmate's own process (own words only; no Ponytail adoption).

- **Ship briefs** (`bin/fm-brief.sh`): compact `# Code discipline` section after Setup / before Rules — reuse highest existing rung, `rg` callers and fix the shared cause, keep diffs boring and local. Scout and secondmate briefs intentionally omit it.
- **AGENTS.md Validate**: over-engineering is a review finding (unnecessary deps, hand-rolled stdlib/platform, speculative abstractions, dead code, unused flexibility, wrapper-only layers) unless justified; never weakens required validation, security, data-loss, accessibility, trust-boundary, or pipeline checks.
- **AGENTS.md token discipline**: cheapest authoritative read first, stop once enough to steer or report, batch captain-facing answers.
- **AGENTS.md §11**: ship briefs carry the code-discipline block; scaffold remains the crewmate contract (no scope expansion).
- Tests cover ship vs scout placement; pipeline also includes env-fragile / flaky-test robustness fixes.

## Test plan
- [x] `tests/fm-brief.test.sh` (including Code discipline placement)
- [x] Full `tests/*.test.sh` suite via no-mistakes
- [x] Smoke: generated ship brief includes three-line block; scout omits it
