### PR TITLE
fix: enforce LF line endings via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
## Summary
- `core.autocrlf=true` in an operator's git config converts checked-out shell scripts to CRLF on checkout, which breaks their `#!/usr/bin/env bash` shebang (`env` looks for a `bash\r` executable and fails).
- This surfaced as a `Stop` hook failure running `bin/fm-turnend-guard.sh`.
- Added `.gitattributes` (`* text=auto eol=lf`) so the repo enforces LF regardless of the operator's `core.autocrlf` setting, and renormalized the working tree accordingly (no blob content changed - only the checkout representation).

## Test plan
- [x] Verified `bin/fm-turnend-guard.sh` no longer has a CRLF shebang after re-checkout.
- [x] Confirmed no tracked file remains with CRLF line endings (`file` scan across all `git ls-files`).
- [ ] `shellcheck` not available locally; relying on repo CI (`no-mistakes-required.yml`) to verify.
