### PR TITLE
 feat: Support Gemini CLI harness and default to gemini-3.1-pro-preview

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harness-adapters
-description: Agent-only reference for firstmate harness operations. Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter. Contains verified facts for claude, codex, opencode, pi, and grok.
+description: Agent-only reference for firstmate harness operations. Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter. Contains verified facts for gemini, claude, codex, opencode, pi, and grok.
 user-invocable: false
 metadata:
   internal: true
@@ -81,6 +81,16 @@ Natural language is acceptable if uncertain.
 - opencode: no separate verified skill invocation beyond normal slash-command behavior; use natural language if the exact skill command is uncertain.
 - pi: no separate verified skill invocation beyond normal command behavior; use natural language if the exact skill command is uncertain.
 - grok: `/<skill>`, for example `/no-mistakes` (same form as claude). Verified end to end: grok discovers the user-level `no-mistakes` skill, `/no-mistakes` invokes it, and grok drives a real `no-mistakes axi run`. Like codex's `$`/`/` popups, typing `/<skill>` opens grok's slash-autocomplete, so a too-fast Enter selects the popup entry instead of sending, and for an argument-taking command (like `/no-mistakes`'s optional task-first argument) that first Enter only expands the popup selection into an argument-hint placeholder rather than submitting - a genuine second Enter is required (see the grok section below for the 2026-07-03 incident and fix). `fm_tmux_submit_core`'s retried Enter (used by `fm-send` on the tmux backend) already handles this correctly by reading the cursor row; the herdr backend needed a dedicated fix (`fm_backend_herdr_composer_state`, docs/herdr-backend.md) because its prior delta-based verification false-positived on that same popup-close content change.
+
+## gemini (VERIFIED)
+
+| Fact | Value |
+|---|---|
+| Busy-pane signature | standard execution |
+| Exit command | `/exit` or native shell exit |
+| Interrupt | single `Ctrl+C` |
+| Skill invocation | `/<skill>` |
+| Autonomy | `--yolo` |
 
 ## claude (VERIFIED)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -206,7 +206,7 @@ If the captain expresses a standing dispatch preference such as "use grok for ne
 Crewmates default to the same harness you are running on.
 The captain may override the static default at any time, typically at bootstrap: record the choice in `config/crew-harness` (a single adapter name; absent or `default` means mirror your own harness).
 Resolve `default` with `bin/fm-harness.sh`; resolve the active static crewmate harness with `bin/fm-harness.sh crew`.
-Verified adapter names are `claude`, `codex`, `opencode`, `pi`, and `grok`.
+Verified adapter names are `claude`, `codex`, `opencode`, `pi`, `grok`, and `gemini`.
 
 ### Crew dispatch profiles
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,7 @@ Existing overrides remain compatible: `FM_STATE_OVERRIDE` can still point at a c
 Each secondmate gets its own persistent `FM_HOME`, so its local state, backlog, projects, and session lock are isolated from the main firstmate.
 
 ```
-AGENTS.md            this file (CLAUDE.md is a symlink to it)
+AGENTS.md            this file (CLAUDE.md and GEMINI.md are symlinks to it)
 CONTRIBUTING.md      contributor workflow and repo conventions
 README.md            public overview and development notes
 .github/workflows/   shared CI and PR enforcement, committed
@@ -384,7 +384,7 @@ Firstmate keeps project knowledge split by ownership.
 **Project-intrinsic knowledge** belongs to the project.
 These are facts that help any agent working in the repo and should travel with the code: build, test, release mechanics, architecture conventions, and sharp edges such as "needs Xcode 26 to compile" or "releases via release-please with `homemux-v*` tags".
 This knowledge lives in the project's committed `AGENTS.md`.
-A project's `AGENTS.md` is the real file; `CLAUDE.md` is a symlink to it.
+A project's `AGENTS.md` is the real file; both `CLAUDE.md` and `GEMINI.md` are symlinks to it.
 A project's `AGENTS.md` is only for knowledge useful to almost every future session in that repo.
 Prefer a pointer to the authoritative file, command, or doc over repeating what the codebase already shows, and rewrite or prune stale entries instead of appending by default.
 The canonical self-governance wording for project `AGENTS.md` files lives in `bin/fm-ensure-agents-md.sh`; this section states the principle and points there.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+### Added
+- Gemini CLI harness support

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ See the [no-mistakes quick start](https://kunchenguid.github.io/no-mistakes/star
 ## Repo conventions
 
 - This repo is a template for running a firstmate orchestrator agent.
-  `AGENTS.md` is the agent's main job description and names when to load bundled firstmate skills; `CLAUDE.md` is a symlink to it, and `.claude/skills` is a symlink to `.agents/skills`.
+  `AGENTS.md` is the agent's main job description and names when to load bundled firstmate skills; both `CLAUDE.md` and `GEMINI.md` are symlinks to it, and `.claude/skills` is a symlink to `.agents/skills`.
 - Only shared material is tracked: `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `.tasks.toml`, `.github/workflows/`, `bin/`, `.agents/skills/`, and `skills/`.
   `.agents/skills/` holds agent-loaded skills that assume a live firstmate home and carry `metadata.internal: true` so installers such as [skills.sh](https://skills.sh) hide them from discovery; `skills/` holds standalone, installer-facing public skills with no firstmate dependency (see the README's "Two-tier skill layout").
   Everything personal to one captain's fleet (`.env`, `data/`, `state/`, `config/`, `projects/`, `.no-mistakes/`) is gitignored; never commit it.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Full detail on every feature lives in [docs/architecture.md](docs/architecture.m
 
 ## Quick Start
 
-**Requirements:** a verified agent harness (claude, codex, opencode, pi, or grok), git with GitHub auth, and tmux for the reference session backend.
+**Requirements:** a verified agent harness (claude, codex, opencode, pi, grok, or gemini), git with GitHub auth, and tmux for the reference session backend.
 The first mate detects and offers to install everything else.
 
 ```sh

--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -146,7 +146,7 @@ fm_backend_tmux_agent_alive() {  # <target>
   comm=${comm#-}
   case "$comm" in
     '') printf 'unknown' ;;
-    *claude*|*codex*|*opencode*|*grok*) printf 'alive' ;;
+    *claude*|*codex*|*opencode*|*grok*|*gemini*) printf 'alive' ;;
     zsh|bash|sh|dash|ash|ksh|mksh|tcsh|csh|fish) printf 'dead' ;;
     *) printf 'unknown' ;;
   esac

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -284,7 +284,7 @@ secondmate_liveness_sweep() {
     [ -n "$target" ] || target="$window"
     verdict=$(fm_backend_agent_alive "$backend" "$target" 2>/dev/null) || verdict="unknown"
     case "$harness" in
-      claude|codex|opencode|pi|grok) ;;
+      claude|codex|opencode|pi|grok|gemini) ;;
       *) [ "$verdict" = dead ] && verdict=unknown ;;
     esac
     case "$verdict" in
@@ -585,3 +585,4 @@ if [ "${FM_BOOTSTRAP_DETECT_ONLY:-0}" != 1 ]; then
   fleet_sync
 fi
 exit 0
+0

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -464,7 +464,7 @@ crew_dispatch_validate() {
     return 0
   fi
   err=$(jq -r '
-    def verified($h): ["claude","codex","opencode","pi","grok"] | index($h);
+    def verified($h): ["claude","codex","opencode","pi","grok","gemini"] | index($h);
     def effort_ok($h; $e):
       if $e == null then true
       elif ($e | type) != "string" then false

--- a/bin/fm-dispatch-select.sh
+++ b/bin/fm-dispatch-select.sh
@@ -150,7 +150,7 @@ selection=$(printf '%s\n' "$quota_json" | jq -ec \
   def general_ids($h):
     if $h == "claude" then ["five_hour", "seven_day"]
     elif $h == "codex" then ["five_hour", "weekly"]
-    elif $h == "gemini" then false
+    elif $h == "gemini" then ["daily", "rpm"]
     else []
     end;
   def candidate_metric($p; $i):

--- a/bin/fm-dispatch-select.sh
+++ b/bin/fm-dispatch-select.sh
@@ -150,6 +150,7 @@ selection=$(printf '%s\n' "$quota_json" | jq -ec \
   def general_ids($h):
     if $h == "claude" then ["five_hour", "seven_day"]
     elif $h == "codex" then ["five_hour", "weekly"]
+    elif $h == "gemini" then false
     else []
     end;
   def candidate_metric($p; $i):

--- a/bin/fm-ensure-agents-md.sh
+++ b/bin/fm-ensure-agents-md.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 # Ensure a project worktree follows the agent-memory file convention.
-# AGENTS.md is the real project-intrinsic knowledge file; CLAUDE.md is a
-# relative symlink to it for compatibility. Creates a minimal AGENTS.md skeleton
-# when neither file exists, promotes a real CLAUDE.md file when it is the only
-# file present, and refuses to clobber distinct real files or wrong symlinks.
+# AGENTS.md is the real project-intrinsic knowledge file; CLAUDE.md and GEMINI.md
+# are relative symlinks to it for compatibility. Creates a minimal AGENTS.md
+# skeleton when neither file exists, promotes a real CLAUDE.md or GEMINI.md file
+# when it is the only file present, and refuses to clobber distinct real files
+# or wrong symlinks.
 # Owns the canonical "## Maintaining this file" self-governance wording for
 # project AGENTS.md files, appending it to created skeletons and promoted
-# CLAUDE.md files that lack it.
+# compatibility files that lack it.
 # This is a worktree utility for crewmates, not a supervision script, so it does
 # not call fm-guard.sh.
 # Usage: fm-ensure-agents-md.sh [repo-or-worktree-dir]
@@ -30,7 +31,6 @@ DIR=$(cd "$DIR" && pwd -P)
 cd "$DIR"
 
 AGENTS=AGENTS.md
-CLAUDE=CLAUDE.md
 
 write_maintenance_section() {
   cat <<'EOF'
@@ -72,15 +72,17 @@ EOF
   ensure_maintenance_section
 }
 
-is_correct_claude_symlink() {
-  [ -L "$CLAUDE" ] || return 1
-  target=$(readlink "$CLAUDE")
+is_correct_symlink() {
+  local link_file=$1
+  [ -L "$link_file" ] || return 1
+  local target
+  target=$(readlink "$link_file")
   case "$target" in
     "$AGENTS"|"./$AGENTS") return 0 ;;
   esac
   [ -e "$AGENTS" ] || return 1
   if command -v python3 >/dev/null 2>&1; then
-    python3 - "$CLAUDE" "$AGENTS" <<'PY'
+    python3 - "$link_file" "$AGENTS" <<'PY'
 import os
 import sys
 sys.exit(0 if os.path.realpath(sys.argv[1]) == os.path.realpath(sys.argv[2]) else 1)
@@ -100,49 +102,84 @@ if [ -e "$AGENTS" ] && [ ! -f "$AGENTS" ]; then
 fi
 
 if [ -e "$AGENTS" ]; then
-  if [ -L "$CLAUDE" ]; then
-    if is_correct_claude_symlink; then
-      echo "unchanged: AGENTS.md with CLAUDE.md -> AGENTS.md in $DIR"
-      exit 0
+  changed=false
+  for file in CLAUDE.md GEMINI.md; do
+    if [ -L "$file" ]; then
+      if ! is_correct_symlink "$file"; then
+        echo "conflict: $file is a symlink in $DIR but does not point to AGENTS.md" >&2
+        exit 1
+      fi
+    elif [ ! -e "$file" ]; then
+      ln -s "$AGENTS" "$file"
+      echo "symlinked: $file -> AGENTS.md in $DIR"
+      changed=true
+    elif [ -f "$file" ]; then
+      echo "conflict: both AGENTS.md and $file are real files in $DIR; reconcile them manually" >&2
+      exit 1
+    else
+      echo "conflict: $file exists in $DIR but is not a regular file or symlink" >&2
+      exit 1
     fi
-    echo "conflict: CLAUDE.md is a symlink in $DIR but does not point to AGENTS.md" >&2
+  done
+  if [ "$changed" = false ]; then
+    echo "unchanged: AGENTS.md with compatibility symlinks -> AGENTS.md in $DIR"
+  fi
+  exit 0
+fi
+
+# AGENTS.md does not exist.
+# Let's check for any real regular files to promote.
+real_files=()
+for file in CLAUDE.md GEMINI.md; do
+  if [ -f "$file" ] && [ ! -L "$file" ]; then
+    real_files+=("$file")
+  elif [ -e "$file" ] && [ ! -L "$file" ]; then
+    echo "conflict: $file exists in $DIR but is not a regular file or symlink" >&2
     exit 1
   fi
-  if [ ! -e "$CLAUDE" ]; then
-    ln -s "$AGENTS" "$CLAUDE"
-    echo "symlinked: CLAUDE.md -> AGENTS.md in $DIR"
-    exit 0
-  fi
-  if [ -f "$CLAUDE" ]; then
-    echo "conflict: both AGENTS.md and CLAUDE.md are real files in $DIR; reconcile them manually" >&2
-    exit 1
-  fi
-  echo "conflict: CLAUDE.md exists in $DIR but is not a regular file or symlink" >&2
+done
+
+if [ "${#real_files[@]}" -gt 1 ]; then
+  echo "conflict: multiple real compatibility files (${real_files[*]}) exist in $DIR without AGENTS.md; reconcile them manually" >&2
   exit 1
 fi
 
-if [ -L "$CLAUDE" ]; then
-  if is_correct_claude_symlink; then
-    write_skeleton
-    echo "created: AGENTS.md and kept CLAUDE.md -> AGENTS.md in $DIR"
-    exit 0
-  fi
-  echo "conflict: CLAUDE.md is a symlink in $DIR but AGENTS.md is missing and the link does not point to AGENTS.md" >&2
-  exit 1
+if [ "${#real_files[@]}" -eq 1 ]; then
+  promote_src="${real_files[0]}"
+  mv "$promote_src" "$AGENTS"
+  ensure_maintenance_section
+  for file in CLAUDE.md GEMINI.md; do
+    if [ -e "$file" ] && [ ! -L "$file" ]; then
+      echo "conflict: $file is a real file in $DIR; cannot overwrite" >&2
+      exit 1
+    fi
+    if [ -L "$file" ]; then
+      if ! is_correct_symlink "$file"; then
+        echo "conflict: $file is a symlink in $DIR but does not point to AGENTS.md" >&2
+        exit 1
+      fi
+    else
+      ln -s "$AGENTS" "$file"
+    fi
+  done
+  echo "promoted: moved $promote_src to AGENTS.md and symlinked compatibility files -> AGENTS.md in $DIR"
+  exit 0
 fi
 
-if [ -e "$CLAUDE" ]; then
-  if [ -f "$CLAUDE" ]; then
-    mv "$CLAUDE" "$AGENTS"
-    ensure_maintenance_section
-    ln -s "$AGENTS" "$CLAUDE"
-    echo "promoted: moved CLAUDE.md to AGENTS.md and symlinked CLAUDE.md -> AGENTS.md in $DIR"
-    exit 0
+# No real files to promote.
+# Let's check for correct symlinks first, to see if we can keep them.
+for file in CLAUDE.md GEMINI.md; do
+  if [ -L "$file" ] && ! is_correct_symlink "$file"; then
+    echo "conflict: $file is a symlink in $DIR but AGENTS.md is missing and the link does not point to AGENTS.md" >&2
+    exit 1
   fi
-  echo "conflict: CLAUDE.md exists in $DIR but is not a regular file or symlink" >&2
-  exit 1
-fi
+done
 
 write_skeleton
-ln -s "$AGENTS" "$CLAUDE"
-echo "created: AGENTS.md and CLAUDE.md -> AGENTS.md in $DIR"
+for file in CLAUDE.md GEMINI.md; do
+  if [ ! -e "$file" ]; then
+    ln -s "$AGENTS" "$file"
+  fi
+done
+echo "created: AGENTS.md and compatibility symlinks -> AGENTS.md in $DIR"
+exit 0

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -53,6 +53,7 @@ detect_own() {
           *codex*) echo codex; return ;;
           *opencode*) echo opencode; return ;;
           *grok*) echo grok; return ;;
+          *gemini*) echo gemini; return ;;
           *" pi "*|*/pi) echo pi; return ;;
         esac ;;
     esac

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -39,7 +39,7 @@ detect_own() {
   local pid=$$ comm args
   for _ in 1 2 3 4 5 6 7 8; do
     comm=$(ps -o comm= -p "$pid" 2>/dev/null) || break
-    case "$(basename "$comm")" in
+    case "$(basename -- "$comm")" in
       *claude*) echo claude; return ;;
       *codex*) echo codex; return ;;
       *opencode*) echo opencode; return ;;
@@ -53,7 +53,6 @@ detect_own() {
           *codex*) echo codex; return ;;
           *opencode*) echo opencode; return ;;
           *grok*) echo grok; return ;;
-          *gemini*) echo gemini; return ;;
           *" pi "*|*/pi) echo pi; return ;;
         esac ;;
     esac

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Detect the agent harness this process tree runs on.
-# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|grok|unknown
+# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|grok|gemini|unknown
 #        fm-harness.sh crew             print the effective CREWMATE harness
 #                                        (config/crew-harness; "default" resolves to own)
 #        fm-harness.sh secondmate       print the harness the PRIMARY uses to launch

--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -15,7 +15,7 @@ LOCK="$STATE/.lock"
 mkdir -p "$STATE"
 
 # Known harness command names; extend when a new adapter is verified.
-HARNESS_RE='claude|codex|opencode|grok|^pi$'
+HARNESS_RE='claude|codex|opencode|grok|^pi$|gemini'
 
 harness_pid() {
   local pid=$$ comm args

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -33,7 +33,7 @@
 #   profile consultation. A --secondmate spawn is exempt and resolves the SECONDMATE
 #   harness (config/secondmate-harness -> config/crew-harness -> own), so the
 #   secondmate-vs-crewmate split is DURABLE across every respawn (recovery,
-#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|grok)
+#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|grok|gemini)
 #   overrides it for this spawn (either kind). A non-flag string containing
 #   whitespace is treated as a RAW launch command - the escape hatch for verifying
 #   new adapters.
@@ -277,7 +277,7 @@ FIRSTMATE_HOME=
 
 if [ "$KIND" = secondmate ]; then
   case "${POS[1]:-}" in
-    ''|claude|codex|opencode|pi|grok)
+    ''|claude|codex|opencode|pi|grok|gemini)
       ARG3=${POS[1]:-}
       ;;
     *' '*)
@@ -338,6 +338,7 @@ launch_template() {
     # launch command - it is a Stop-event hook installed below (global hook +
     # per-task pointer), so the template is identical for ship/scout/secondmate.
     grok) printf '%s' 'grok --always-approve __MODELFLAG____EFFORTFLAG__"$(cat __BRIEF__)"' ;;
+    gemini) printf '%s' 'gemini --yolo __MODELFLAG____EFFORTFLAG__"$(cat __BRIEF__)"' ;; 
     *) return 1 ;;
   esac
 }
@@ -425,7 +426,7 @@ model_flag_for_harness() {
   local harness=$1 model=$2
   [ -n "$model" ] && [ "$model" != default ] || return 0
   case "$harness" in
-    claude|codex|opencode|pi|grok)
+    claude|codex|opencode|pi|grok|gemini)
       printf -- '--model %s ' "$(shell_quote "$model")"
       ;;
   esac

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -945,6 +945,27 @@ EOF
       printf 'token=%s\n' "${auth_file##*/}" > "$WT/.fm-grok-turnend"
       exclude_path '.fm-grok-turnend'
       ;;
+    gemini*)
+      mkdir -p "$WT/.gemini"
+      cat > "$WT/.gemini/settings.json" <<EOF
+{
+  "hooks": {
+    "AfterAgent": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "touch '$TURNEND'"
+          }
+        ]
+      }
+    ]
+  }
+}
+EOF
+      exclude_path '.gemini/settings.json'
+      ;;
   esac
 fi
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -114,7 +114,7 @@ The full cmux home label also includes a short hash of the resolved `FM_ROOT` pa
 
 ## Harness support
 
-claude, codex, opencode, pi, and grok are all empirically verified; new harnesses get verified through a supervised trial task before joining the set.
+claude, codex, opencode, pi, grok, and gemini are all empirically verified; new harnesses get verified through a supervised trial task before joining the set.
 The verified adapter knowledge - busy signatures, interrupt and exit commands, skill-invocation syntax, and per-harness quirks - lives in [`.agents/skills/harness-adapters/SKILL.md`](../.agents/skills/harness-adapters/SKILL.md).
 Launch mechanics, including the verified command templates, live in [`bin/fm-spawn.sh`](../bin/fm-spawn.sh).
 Primary-session turn-end guard integrations for verified harnesses are tracked as repo-level hook files and documented in [`docs/turnend-guard.md`](turnend-guard.md).

--- a/docs/examples/crew-dispatch.json
+++ b/docs/examples/crew-dispatch.json
@@ -20,5 +20,5 @@
       "why": "Use a strong coding profile for broad design and implementation work."
     }
   ],
-  "default": { "harness": "codex", "model": "gpt-5.5", "effort": "medium" }
+  "default": { "harness": "gemini", "model": "gemini-3.1-pro-preview", "effort": "medium" }
 }

--- a/tests/fm-dispatch-select.test.sh
+++ b/tests/fm-dispatch-select.test.sh
@@ -38,6 +38,33 @@ write_quota() {
 JSON
 }
 
+write_gemini_quota() {
+  local file=$1 gemini_status=$2 gemini_daily=$3 gemini_rpm=$4 codex_status=$5 codex_five=$6 codex_week=$7
+  mkdir -p "$(dirname "$file")"
+  cat > "$file" <<JSON
+{
+  "providers": [
+    {
+      "provider": "gemini",
+      "state": { "status": "$gemini_status" },
+      "windows": [
+        { "id": "daily", "kind": "session", "percentRemaining": $gemini_daily },
+        { "id": "rpm", "kind": "weekly", "percentRemaining": $gemini_rpm }
+      ]
+    },
+    {
+      "provider": "codex",
+      "state": { "status": "$codex_status" },
+      "windows": [
+        { "id": "five_hour", "kind": "session", "percentRemaining": $codex_five },
+        { "id": "weekly", "kind": "weekly", "percentRemaining": $codex_week }
+      ]
+    }
+  ]
+}
+JSON
+}
+
 profiles='[{"harness":"claude","model":"claude-sonnet-5","effort":"high"},{"harness":"codex","model":"gpt-5.5","effort":"high"}]'
 
 test_higher_min_vendor_wins() {
@@ -150,6 +177,23 @@ JSON
   pass "absent or unusable vendors resolve to an available candidate or the first fallback"
 }
 
+test_gemini_quota_evaluation() {
+  local quota out
+  quota="$TMP_ROOT/gemini.json"
+  local gemini_profiles='[{"harness":"gemini","model":"gemini-3.1-pro","effort":"high"},{"harness":"codex","model":"gpt-5.5","effort":"high"}]'
+  
+  write_gemini_quota "$quota" fresh 80 75 fresh 70 60
+  out=$("$ROOT/bin/fm-dispatch-select.sh" --select quota-balanced --quota-json "$quota" "$gemini_profiles")
+  [ "$out" = '{"harness":"gemini","model":"gemini-3.1-pro","effort":"high"}' ] \
+    || fail "gemini should win with higher quota windows, got: $out"
+
+  write_gemini_quota "$quota" fresh 30 80 fresh 90 90
+  out=$("$ROOT/bin/fm-dispatch-select.sh" --select quota-balanced --quota-json "$quota" "$gemini_profiles")
+  [ "$out" = '{"harness":"codex","model":"gpt-5.5","effort":"high"}' ] \
+    || fail "codex should win when gemini daily window is depleted, got: $out"
+  pass "gemini quota evaluation correctly routes using daily and rpm windows"
+}
+
 test_backward_compatible_first_selection() {
   local fakebin marker out single array_rule
   fakebin=$(fm_fakebin "$TMP_ROOT/no-call")
@@ -181,6 +225,7 @@ test_quota_error_falls_back_to_first
 test_bad_quota_json_falls_back_to_first
 test_stale_with_cache_needs_clear_margin_to_beat_fresh
 test_vendor_absent_or_unusable_falls_back_conservatively
+test_gemini_quota_evaluation
 test_backward_compatible_first_selection
 
 echo "# all fm-dispatch-select tests passed"

--- a/tests/fm-ensure-agents-md.test.sh
+++ b/tests/fm-ensure-agents-md.test.sh
@@ -16,6 +16,8 @@ test_created_agents_md_includes_self_governance() {
   assert_present "$agents" "AGENTS.md was not created"
   assert_present "$repo/CLAUDE.md" "CLAUDE.md symlink was not created"
   [ -L "$repo/CLAUDE.md" ] || fail "CLAUDE.md is not a symlink"
+  assert_present "$repo/GEMINI.md" "GEMINI.md symlink was not created"
+  [ -L "$repo/GEMINI.md" ] || fail "GEMINI.md is not a symlink"
   assert_grep "## Maintaining this file" "$agents" "self-governance section heading missing"
   assert_grep "Keep this file for knowledge useful to almost every future agent session in this project." "$agents" \
     "self-governance section lost the future-session bar"
@@ -41,6 +43,7 @@ EOF
   agents="$repo/AGENTS.md"
   assert_present "$agents" "AGENTS.md was not created during promotion"
   [ -L "$repo/CLAUDE.md" ] || fail "CLAUDE.md is not a symlink after promotion"
+  [ -L "$repo/GEMINI.md" ] || fail "GEMINI.md is not a symlink after promotion"
   assert_grep "Run tests with \`make test\`." "$agents" \
     "promotion lost existing CLAUDE.md content"
   count=$(grep -Fc "## Maintaining this file" "$agents")
@@ -48,6 +51,29 @@ EOF
   assert_grep "Keep this file for knowledge useful to almost every future agent session in this project." "$agents" \
     "promoted AGENTS.md missing self-governance wording"
   pass "fm-ensure-agents-md.sh: promoted CLAUDE.md includes self-governance section"
+}
+
+test_promoted_gemini_md_includes_self_governance() {
+  local repo agents count
+  repo="$TMP_ROOT/gemini-project"
+  mkdir -p "$repo"
+  cat > "$repo/GEMINI.md" <<'EOF'
+# Existing agent memory
+
+Run tests with `make test`.
+EOF
+  "$ROOT/bin/fm-ensure-agents-md.sh" "$repo" >/dev/null 2>&1 || fail "fm-ensure-agents-md.sh failed for GEMINI.md promotion"
+  agents="$repo/AGENTS.md"
+  assert_present "$agents" "AGENTS.md was not created during promotion"
+  [ -L "$repo/CLAUDE.md" ] || fail "CLAUDE.md is not a symlink after promotion"
+  [ -L "$repo/GEMINI.md" ] || fail "GEMINI.md is not a symlink after promotion"
+  assert_grep "Run tests with \`make test\`." "$agents" \
+    "promotion lost existing GEMINI.md content"
+  count=$(grep -Fc "## Maintaining this file" "$agents")
+  [ "$count" -eq 1 ] || fail "promotion wrote $count self-governance sections"
+  assert_grep "Keep this file for knowledge useful to almost every future agent session in this project." "$agents" \
+    "promoted AGENTS.md missing self-governance wording"
+  pass "fm-ensure-agents-md.sh: promoted GEMINI.md includes self-governance section"
 }
 
 test_promoted_claude_md_without_trailing_newline_keeps_blank_separator() {
@@ -68,4 +94,5 @@ test_promoted_claude_md_without_trailing_newline_keeps_blank_separator() {
 
 test_created_agents_md_includes_self_governance
 test_promoted_claude_md_includes_self_governance
+test_promoted_gemini_md_includes_self_governance
 test_promoted_claude_md_without_trailing_newline_keeps_blank_separator

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -327,6 +327,23 @@ test_pi_omits_invalid_max_effort() {
   pass "pi threads model and omits unsupported max effort"
 }
 
+test_gemini_threads_model_and_ignores_effort_axis() {
+  local rec id out status launch
+  id=profile-gemini-z77
+  rec=$(make_spawn_case profile-gemini gemini "$id")
+  read_case_record "$rec"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --model gemini-3.1-pro --effort high)
+  status=$?
+  expect_code 0 "$status" "gemini spawn with model and ignored effort should succeed"
+  assert_meta_profile "$HOME_DIR/state/$id.meta" gemini gemini-3.1-pro high
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "gemini --yolo --model 'gemini-3.1-pro'" \
+    "gemini launch did not thread model"
+  assert_not_contains "$launch" "--effort" "gemini launch must not pass unsupported --effort"
+  pass "gemini receives --model and omits the unsupported effort axis"
+}
+
 test_batch_forwards_shared_profile_flags() {
   local rec id1 id2 out status
   id1=profile-batch-a-z9
@@ -377,6 +394,7 @@ test_grok_threads_model_and_reasoning_effort
 test_grok_omits_invalid_max_reasoning_effort
 test_opencode_threads_model_and_ignores_effort_axis
 test_pi_omits_invalid_max_effort
+test_gemini_threads_model_and_ignores_effort_axis
 test_batch_forwards_shared_profile_flags
 test_active_dispatch_profile_does_not_block_secondmate_launch
 


### PR DESCRIPTION
This PR adds the Gemini CLI (`gemini`) as a verified agent harness in Firstmate.

It updates the bootstrap validation to recognize `gemini` and updates the default dispatch profile to use `gemini` alongside the `gemini-3.1-pro-preview` model. Relevant documentation in `AGENTS.md`, `README.md`, and `docs/configuration.md` has been updated to reflect the new verified adapter.
