### PR TITLE
fix(tmux): scope numeric session window creation

### DIFF
--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -72,12 +72,13 @@ fm_backend_tmux_container_ensure() {
 # duplicate-check-then-new-window sequence, including the exact error text
 # (session:window, matching how fm-spawn.sh composed its own $T).
 fm_backend_tmux_create_task() {  # <session> <window-name> <proj-abs>
-  local ses=$1 wname=$2 proj_abs=$3
-  if tmux list-windows -t "$ses" -F '#{window_name}' | grep -qx "$wname"; then
+  local ses=$1 wname=$2 proj_abs=$3 target
+  target="${ses}:"
+  if tmux list-windows -t "$target" -F '#{window_name}' | grep -qx "$wname"; then
     echo "error: window $ses:$wname already exists" >&2
     return 1
   fi
-  tmux new-window -d -t "$ses" -n "$wname" -c "$proj_abs"
+  tmux new-window -d -t "$target" -n "$wname" -c "$proj_abs"
 }
 
 # fm_backend_tmux_current_path: the live pane's current working directory, or

--- a/tests/fm-backend-tmux-smoke.test.sh
+++ b/tests/fm-backend-tmux-smoke.test.sh
@@ -60,6 +60,16 @@ if fm_backend_tmux_create_task "$SESSION" "$WINDOW" "$HOME" 2>/dev/null; then
 fi
 pass "real tmux: fm_backend_tmux_create_task creates a window and refuses a duplicate"
 
+NUMERIC_SESSION="12345"
+NUMERIC_WINDOW="fm-numeric"
+tmux new-session -d -s "$NUMERIC_SESSION" -x 200 -y 50 \
+  || fail "real tmux: numeric new-session failed"
+fm_backend_tmux_create_task "$NUMERIC_SESSION" "$NUMERIC_WINDOW" "$HOME" \
+  || fail "fm_backend_tmux_create_task failed for a purely numeric session name"
+tmux list-windows -t "$NUMERIC_SESSION:" -F '#{window_name}' | grep -qx "$NUMERIC_WINDOW" \
+  || fail "numeric session window is not visible in the real session"
+pass "real tmux: fm_backend_tmux_create_task creates a window in a purely numeric session"
+
 # --- send text + Enter -------------------------------------------------------
 
 tmux send-keys -t "$TARGET" "cd /tmp && PS1='smoke\$ '" Enter

--- a/tests/fm-backend.test.sh
+++ b/tests/fm-backend.test.sh
@@ -598,6 +598,36 @@ test_backend_of_selector_matches_explicit_target_meta() {
   pass "fm_backend_of_selector: exact task ids, legacy fm-<id> labels, and matching explicit targets inherit metadata backend"
 }
 
+test_tmux_create_task_scopes_numeric_session_as_session_target() {
+  local fakebin log log_text
+  fakebin="$TMP_ROOT/tmux-create-task-fakebin"
+  log="$TMP_ROOT/tmux-create-task.log"
+  mkdir -p "$fakebin"
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+{ printf 'tmux'; for a in "$@"; do printf '\x1f%s' "$a"; done; printf '\n'; } >> "${FM_TMUX_LOG:?}"
+case "${1:-}" in
+  list-windows|new-window) exit 0 ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/tmux"
+
+  fm_backend_source tmux || fail "fm_backend_source tmux failed"
+  : > "$log"
+  PATH="$fakebin:$PATH" FM_TMUX_LOG="$log" \
+    fm_backend_tmux_create_task 123 fm-numeric "$TMP_ROOT" \
+    || fail "fm_backend_tmux_create_task should succeed for a numeric session name"
+  log_text=$(cat "$log")
+  assert_contains "$log_text" $'tmux\x1flist-windows\x1f-t\x1f123:\x1f-F\x1f#{window_name}' \
+    "numeric tmux session duplicate check must target the session scope with a trailing colon"
+  assert_contains "$log_text" $'tmux\x1fnew-window\x1f-d\x1f-t\x1f123:\x1f-n\x1ffm-numeric\x1f-c' \
+    "numeric tmux session new-window must target the session scope with a trailing colon"
+
+  pass "fm_backend_tmux_create_task: numeric session names are passed to tmux as session targets"
+}
+
 # --- old vs new: fm-send.sh --------------------------------------------------
 
 make_send_fakebin() {  # <dir> -> echoes fakebin dir; logs every tmux call to $FM_TMUX_LOG
@@ -1103,6 +1133,7 @@ test_backend_validate_spawn_accepts_orca
 test_meta_get_and_backend_of_meta
 test_resolve_selector_three_forms
 test_backend_of_selector_matches_explicit_target_meta
+test_tmux_create_task_scopes_numeric_session_as_session_target
 test_send_conformance_old_vs_new
 test_peek_conformance_old_vs_new
 test_spawn_conformance_old_vs_new


### PR DESCRIPTION
## Summary
- target tmux sessions as `session:` when checking for duplicate windows and creating task windows
- fixes purely numeric session names being interpreted ambiguously by `tmux new-window -t`
- adds fake-tmux command-shape coverage and a real isolated tmux numeric-session smoke regression

## Validation
- bash tests/fm-backend.test.sh
- bash tests/fm-backend-tmux-smoke.test.sh
- shellcheck bin/*.sh bin/backends/*.sh tests/*.sh

## Note
- no-mistakes cannot publish directly from this account: upstream push to kunchenguid/firstmate returns 403 for kfu95, so this PR is from fork kfu95/firstmate.