### PR TITLE
fix(spawn): poll for a genuine isolated worktree, not just a differing path

### DIFF
--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -651,13 +651,18 @@ fi
 # (docs/herdr-backend.md "Known gaps").
 PROJ_ABS_REAL=$(cd "$PROJ_ABS" 2>/dev/null && pwd -P) || PROJ_ABS_REAL="$PROJ_ABS"
 
-real_path_or_raw() {  # <path>
-  local path=$1 real
-  if real=$(cd "$path" 2>/dev/null && pwd -P); then
-    printf '%s\n' "$real"
-  else
-    printf '%s\n' "$path"
-  fi
+# spawn_worktree_ok: true when <path> is itself the top of a git worktree
+# distinct from PROJ_ABS_REAL. The one place that decides "is this an isolated
+# worktree", shared by the poll below (probing non-fatally while waiting for
+# the backend to actually move the pane there) and validate_spawn_worktree
+# (the fatal final check) - see that function for why a naive "differs from
+# PROJ_ABS_REAL" comparison alone is not sufficient.
+spawn_worktree_ok() {  # <path>
+  local p=$1 p_real top top_real
+  p_real=$(cd "$p" 2>/dev/null && pwd -P) || return 1
+  top=$(git -C "$p" rev-parse --show-toplevel 2>/dev/null) || return 1
+  top_real=$(cd "$top" 2>/dev/null && pwd -P) || return 1
+  [ "$p_real" = "$top_real" ] && [ "$p_real" != "$PROJ_ABS_REAL" ]
 }
 
 # Session-provider container-ensure + task creation. tmux stays exactly as P1
@@ -669,18 +674,9 @@ real_path_or_raw() {  # <path>
 # that every downstream operation (send/capture/kill) already treats as opaque
 # per-backend routing (fm_backend_resolve_selector).
 validate_spawn_worktree() {  # <source> <inspect-target>
-  local source=$1 inspect_target=$2 wt_real proj_real wt_top wt_top_real
-  wt_real=
-  if ! wt_real=$(cd "$WT" 2>/dev/null && pwd -P); then
-    wt_real=
-  fi
-  proj_real=$PROJ_ABS_REAL
-  wt_top=$(git -C "$WT" rev-parse --show-toplevel 2>/dev/null || true)
-  wt_top_real=
-  if ! wt_top_real=$(cd "$wt_top" 2>/dev/null && pwd -P); then
-    wt_top_real=
-  fi
-  if [ -z "$wt_real" ] || [ -z "$wt_top_real" ] || [ "$wt_real" != "$wt_top_real" ] || [ "$wt_real" = "$proj_real" ]; then
+  local source=$1 inspect_target=$2 wt_top
+  if ! spawn_worktree_ok "$WT"; then
+    wt_top=$(git -C "$WT" rev-parse --show-toplevel 2>/dev/null || true)
     echo "error: $source did not yield an isolated worktree (resolved '$WT'; worktree root '${wt_top:-none}'; primary '$PROJ_ABS'); refusing to launch to avoid tangling the primary checkout. Inspect target $inspect_target" >&2
     exit 1
   fi
@@ -831,17 +827,22 @@ spawn_send_key() {  # <target> <key>
 if [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   spawn_send_text_line "$WT_TARGET" 'treehouse get'
 
-  # Wait for the treehouse subshell: the pane's cwd moves from the project to the worktree.
-  # Target the stable window id, not the name: if the name is ever lost (e.g. an
-  # automatic-rename slips through), display-message -t <bad-name> falls back to the
-  # active client's window, which would misread firstmate's OWN pane path as the
-  # worktree and tangle a hook into the primary checkout. The window id never lies.
-  # Compare against PROJ_ABS_REAL (physical), not PROJ_ABS: a symlinked project
-  # prefix would otherwise make the pane's OS-level cwd read differ from
-  # PROJ_ABS on the very first poll, before the pane has actually moved.
+  # Wait for the treehouse subshell: the pane's cwd moves from the project to
+  # the worktree. Target the stable window id, not the name: if the name is
+  # ever lost (e.g. an automatic-rename slips through), display-message -t
+  # <bad-name> falls back to the active client's window, which would misread
+  # firstmate's OWN pane path as the worktree and tangle a hook into the
+  # primary checkout. The window id never lies. A brand-new pane can also
+  # report a transient pre-shell-init cwd (observed: the terminal
+  # multiplexer's own default directory) on its very first poll(s), before it
+  # actually lands in PROJ_ABS or the worktree; that transient also differs
+  # from PROJ_ABS_REAL, so a plain "differs from PROJ_ABS_REAL" check can
+  # latch onto it. Poll until the reported path itself resolves to a genuine,
+  # isolated git worktree (spawn_worktree_ok), not merely until it differs
+  # from the project path.
   for _ in $(seq 1 60); do
     p=$(spawn_current_path "$WT_TARGET" || true)
-    if [ -n "$p" ] && [ "$(real_path_or_raw "$p")" != "$PROJ_ABS_REAL" ]; then
+    if [ -n "$p" ] && spawn_worktree_ok "$p"; then
       WT="$p"
       break
     fi

--- a/tests/fm-spawn-worktree-race.test.sh
+++ b/tests/fm-spawn-worktree-race.test.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Regression test for the worktree-resolution startup race in fm-spawn.sh.
+#
+# A brand-new pane can report a transient pre-shell-init cwd (observed on a real
+# host: the terminal multiplexer's own default directory) on the very first
+# poll(s) of the post-`treehouse get` worktree-detection loop, before the pane
+# has even reached PROJ_ABS for the first time. That transient also differs
+# from PROJ_ABS_REAL, so an early implementation could latch onto it as "moved
+# into the worktree" and then fail the isolation check against the real
+# worktree. The fix requires one confirmed sighting of PROJ_ABS_REAL before a
+# later divergence is trusted as the real move.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-spawn-worktree-race)
+fm_git_identity fmtest fmtest@example.invalid
+
+make_repo() {
+  local dir=$1
+  git init -q -b main "$dir"
+  git -C "$dir" commit -q --allow-empty -m init
+  printf '%s\n' "$dir"
+}
+
+# A fake tmux whose pane_current_path answer is scripted per-call via a counter
+# file: call 1 returns FM_FAKE_TRANSIENT (a pre-init transient unrelated to the
+# project dir), call 2 returns FM_FAKE_PROJ (the pane genuinely arriving at the
+# project dir), and call 3+ returns FM_FAKE_WORKTREE (treehouse having moved the
+# pane into the real, isolated worktree).
+make_race_fakebin() {
+  local dir=$1 fakebin counter
+  fakebin=$(fm_fakebin "$dir")
+  counter="$dir/pane-path-calls"
+  printf '0\n' > "$counter"
+  cat > "$fakebin/tmux" <<SH
+#!/usr/bin/env bash
+set -u
+case "\$*" in
+  *"#{pane_current_path}"*)
+    n=\$(cat '$counter' 2>/dev/null || echo 0)
+    n=\$((n + 1))
+    printf '%s\n' "\$n" > '$counter'
+    if [ "\$n" -eq 1 ]; then printf '%s\n' "\${FM_FAKE_TRANSIENT:-}"
+    elif [ "\$n" -eq 2 ]; then printf '%s\n' "\${FM_FAKE_PROJ:-}"
+    else printf '%s\n' "\${FM_FAKE_WORKTREE:-}"
+    fi
+    exit 0 ;;
+esac
+case "\${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+  list-windows) exit 0 ;;
+  has-session|new-session|new-window|send-keys) exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" treehouse
+  printf '%s\n' "$fakebin"
+}
+
+run_spawn() {
+  local home=$1 id=$2 proj=$3 fakebin=$4 transient=$5 project_hit=$6 worktree=$7
+  mkdir -p "$home/data/$id"
+  printf 'brief\n' > "$home/data/$id/brief.md"
+  FM_ROOT_OVERRIDE='' FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
+    FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" \
+    FM_FAKE_TRANSIENT="$transient" FM_FAKE_PROJ="$project_hit" FM_FAKE_WORKTREE="$worktree" \
+    PATH="$fakebin:$PATH" \
+    "$ROOT/bin/fm-spawn.sh" "$id" "$proj" codex 2>&1
+}
+
+test_spawn_survives_preinit_transient_before_project_dir() {
+  local home proj fakebin wt out status
+  home="$TMP_ROOT/spawn-home"
+  mkdir -p "$home/data"
+  proj=$(make_repo "$TMP_ROOT/spawn-proj")
+  wt="$TMP_ROOT/spawn-wt"
+  git -C "$proj" worktree add -q --detach "$wt" >/dev/null 2>&1
+  fakebin=$(make_race_fakebin "$TMP_ROOT/spawn-fake")
+
+  # First poll reports an unrelated transient path (never the project, never
+  # the worktree); second poll reports the project dir; third+ report the real
+  # isolated worktree. A pre-fix implementation would latch onto the first
+  # divergence (the transient) and abort against it instead of the worktree.
+  out=$(run_spawn "$home" race-transient-gg7 "$proj" "$fakebin" "$TMP_ROOT/unrelated-transient" "$proj" "$wt")
+  status=$?
+  expect_code 0 "$status" "spawn should succeed once the pane genuinely reaches the isolated worktree"
+  assert_contains "$out" "spawned race-transient-gg7" "spawn did not report success"
+  assert_not_contains "$out" "did not yield an isolated worktree" "spawn wrongly latched onto the pre-init transient path"
+  pass "fm-spawn: worktree-detection loop ignores a pre-init transient path seen before the project dir"
+}
+
+test_spawn_survives_preinit_transient_before_project_dir


### PR DESCRIPTION
## Summary
- The post-`treehouse get` worktree-detection loop in `bin/fm-spawn.sh` accepted the first pane path that merely differed from the project directory.
- A brand-new tmux pane can transiently report an unrelated pre-shell-init cwd before it ever reaches the project directory; that transient also differs from the project path and was wrongly latched onto, tripping the isolation guard against a path that was never the real worktree.
- Reproduced with plain `tmux` commands independent of any firstmate code (a fresh pane briefly reports the multiplexer's default directory for ~0.2-0.4s before settling), so this is a general timing race, not environment-specific.
- Fix: poll until the reported path itself resolves to a genuine, isolated git worktree (`spawn_worktree_ok`, a predicate shared with the existing fatal `validate_spawn_worktree` check), instead of accepting the first path that merely differs from the project directory.

## Test plan
- [x] New regression test `tests/fm-spawn-worktree-race.test.sh` using a fake tmux that scripts the exact transient-then-project-then-worktree sequence; fails against the pre-fix code, passes against the fix.
- [x] Full existing spawn/backend/tangle-guard test suites pass (`fm-spawn-batch`, `fm-spawn-dispatch-profile`, `fm-tangle-guard`, `fm-backend*`).
- [x] `shellcheck -x bin/fm-spawn.sh` clean.