### PR TITLE
feat(pr-check): make the per-PR poll comment-aware

### DIFF
--- a/bin/fm-pr-check.sh
+++ b/bin/fm-pr-check.sh
@@ -1,8 +1,21 @@
 #!/usr/bin/env bash
 # Record a PR-ready task: appends pr=<url> and GitHub's pr_head=<sha> to
-# state/<id>.meta when available, then arms the watcher's merge poll by writing
-# state/<id>.check.sh, which prints one line iff the PR is merged (the watcher's
-# check contract: output = wake firstmate, silence = keep sleeping).
+# state/<id>.meta when available, then arms the watcher's PR poll by writing
+# state/<id>.check.sh (the watcher's check contract: one line of output = wake
+# firstmate, silence = keep sleeping).
+#
+# The generated poll wakes firstmate on two things: the PR merging (echoes
+# "merged"), and any new review activity - a review, a PR issue comment, or an
+# inline review comment - since the last poll (echoes "new-review-activity: +N
+# on <url>"). Merge wins: a merged PR echoes only "merged" and skips activity,
+# so each fire prints exactly one line. Activity counts are the reviews +
+# comments totals from gh pr view --json, persisted in state/<id>.pr-activity;
+# the first poll records the baseline silently so activity predating the arm
+# never wakes firstmate, and a gh error stays silent without touching the
+# marker. We deliberately do NOT classify bots: any new activity wakes
+# firstmate, who triages - cheaper than getting bot-detection wrong.
+# fm-teardown.sh removes state/<id>.pr-activity alongside the other per-task
+# state files.
 # Usage: fm-pr-check.sh <task-id> <pr-url>
 set -eu
 
@@ -33,8 +46,34 @@ if [ -f "$META" ]; then
   fi
 fi
 
-cat > "$STATE/$ID.check.sh" <<EOF
-state=\$(gh pr view "$URL" --json state -q .state 2>/dev/null)
-[ "\$state" = "MERGED" ] && echo "merged"
+ACT="$STATE/$ID.pr-activity"
+# Inject the URL and marker path as %q-quoted assignments, then a quoted heredoc
+# for the poll logic, so nothing in the body expands at generation time.
+{
+  printf 'url=%q\n' "$URL"
+  printf 'act=%q\n' "$ACT"
+  cat <<'EOF'
+# Merge wins: a merged PR wakes for the merge and skips the activity check, so
+# each fire prints exactly one line.
+state=$(gh pr view "$url" --json state -q .state 2>/dev/null)
+[ "$state" = "MERGED" ] && { echo "merged"; exit 0; }
+
+# Review activity = reviews + PR comments, counted with gh's built-in jq.
+count=$(gh pr view "$url" --json reviews,comments -q '(.reviews|length)+(.comments|length)' 2>/dev/null)
+# A gh error (empty) or any non-integer stays silent and leaves the marker alone.
+case "$count" in ''|*[!0-9]*) exit 0 ;; esac
+
+last=
+[ -f "$act" ] && last=$(cat "$act" 2>/dev/null)
+# First poll (no marker) or a corrupt marker: record the baseline silently.
+case "$last" in ''|*[!0-9]*) printf '%s\n' "$count" > "$act"; exit 0 ;; esac
+
+if [ "$count" -gt "$last" ]; then
+  printf '%s\n' "$count" > "$act"
+  echo "new-review-activity: +$((count - last)) on $url"
+elif [ "$count" -ne "$last" ]; then
+  printf '%s\n' "$count" > "$act"  # count fell (rare): resync the marker, no wake
+fi
 EOF
+} > "$STATE/$ID.check.sh"
 echo "armed: state/$ID.check.sh polls $URL"

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -920,7 +920,7 @@ cleanup_firstmate_home_children() {
       fi
     fi
     remove_grok_turnend_auth "$sub_state" "$child_id"
-    rm -f "$sub_state/$child_id.status" "$sub_state/$child_id.turn-ended" "$sub_state/$child_id.check.sh" "$sub_state/$child_id.meta" "$sub_state/$child_id.pi-ext.ts" "$sub_state/$child_id.grok-turnend-token"
+    rm -f "$sub_state/$child_id.status" "$sub_state/$child_id.turn-ended" "$sub_state/$child_id.check.sh" "$sub_state/$child_id.pr-activity" "$sub_state/$child_id.meta" "$sub_state/$child_id.pi-ext.ts" "$sub_state/$child_id.grok-turnend-token"
   done
 }
 
@@ -1041,7 +1041,7 @@ remove_grok_turnend_auth "$STATE" "$ID"
 # Remove the per-task temp root (/tmp/fm-<id>/, incl. its gotmp/) recorded by spawn.
 # Read before the state-file rm below; empty (pre-fix tasks without tasktmp=) is a no-op.
 [ -n "$TASK_TMP" ] && rm -rf "$TASK_TMP"
-rm -f "$STATE/$ID.status" "$STATE/$ID.turn-ended" "$STATE/$ID.check.sh" "$STATE/$ID.meta" "$STATE/$ID.pi-ext.ts" "$STATE/$ID.grok-turnend-token"
+rm -f "$STATE/$ID.status" "$STATE/$ID.turn-ended" "$STATE/$ID.check.sh" "$STATE/$ID.pr-activity" "$STATE/$ID.meta" "$STATE/$ID.pi-ext.ts" "$STATE/$ID.grok-turnend-token"
 if [ "$KIND" != scout ] && [ "$KIND" != secondmate ] && [ "$MODE" != local-only ]; then
   "$FM_ROOT/bin/fm-fleet-sync.sh" "$PROJ" || true
 fi

--- a/tests/fm-pr-check.test.sh
+++ b/tests/fm-pr-check.test.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# Tests for bin/fm-pr-check.sh's generated PR poll (state/<id>.check.sh), the
+# comment-aware watcher check. The generator arms a poll that must honor the
+# check contract - one line of stdout only when firstmate should wake, silence
+# otherwise - across:
+#   (a) first poll records the review-activity baseline silently (no wake)
+#   (b) new activity since the baseline wakes with one "new-review-activity" line
+#   (c) unchanged activity stays silent
+#   (d) a merged PR wins: only "merged", never the activity line, one line total
+#   (e) a gh error stays silent and never corrupts the marker (existing or first)
+#   (f) a fallen count resyncs the marker silently (no spurious wake)
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+PR_CHECK="$ROOT/bin/fm-pr-check.sh"
+TMP_ROOT=$(fm_test_tmproot fm-pr-check-tests)
+URL="https://github.com/example/repo/pull/7"
+
+# A gh mock the generated check drives. It answers the state and the
+# reviews+comments count from env, and fails outright when FM_TEST_GH_FAIL is
+# set so the check exercises its error path. Any other call (e.g. the arm-time
+# headRefOid lookup) is a no-op exit 0.
+make_case() {
+  local name=$1 case_dir fakebin
+  case_dir="$TMP_ROOT/$name"
+  fakebin="$case_dir/fakebin"
+  mkdir -p "$case_dir/state" "$fakebin"
+  cat > "$fakebin/gh" <<'SH'
+#!/usr/bin/env bash
+[ -n "${FM_TEST_GH_FAIL:-}" ] && exit 1
+case " $* " in
+  *" --json state "*) printf '%s\n' "${FM_TEST_PR_STATE:-OPEN}"; exit 0 ;;
+  *"reviews,comments"*) printf '%s\n' "${FM_TEST_PR_COUNT:-0}"; exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/gh"
+  printf '%s\n' "$case_dir"
+}
+
+arm_check() {
+  local case_dir=$1
+  FM_ROOT_OVERRIDE="$ROOT" \
+  FM_STATE_OVERRIDE="$case_dir/state" \
+  PATH="$case_dir/fakebin:$PATH" \
+    "$PR_CHECK" pr-x1 "$URL" >/dev/null
+}
+
+# Run the generated check once with the given state/count/fail env, echoing its
+# stdout (what the watcher would treat as the wake reason).
+poll() {
+  local case_dir=$1 state=$2 count=$3 fail=${4:-}
+  FM_TEST_PR_STATE="$state" \
+  FM_TEST_PR_COUNT="$count" \
+  FM_TEST_GH_FAIL="$fail" \
+  PATH="$case_dir/fakebin:$PATH" \
+    bash "$case_dir/state/pr-x1.check.sh"
+}
+
+ACT_PATH() { printf '%s/state/pr-x1.pr-activity' "$1"; }
+
+test_generated_check_is_valid_bash() {
+  local case_dir
+  case_dir=$(make_case valid-bash)
+  arm_check "$case_dir"
+  bash -n "$case_dir/state/pr-x1.check.sh" \
+    || fail "valid-bash: generated check.sh is not valid bash"
+  pass "generated check.sh parses as valid bash"
+}
+
+test_baseline_init_is_silent() {
+  local case_dir out
+  case_dir=$(make_case baseline)
+  arm_check "$case_dir"
+  assert_absent "$(ACT_PATH "$case_dir")" "baseline: marker existed before first poll"
+
+  out=$(poll "$case_dir" OPEN 3)
+  [ -z "$out" ] || fail "baseline: first poll woke firstmate (output: '$out')"
+  assert_present "$(ACT_PATH "$case_dir")" "baseline: marker not created on first poll"
+  assert_grep "3" "$(ACT_PATH "$case_dir")" "baseline: marker did not record the current count"
+  pass "first poll records the review-activity baseline silently"
+}
+
+test_wake_on_increase() {
+  local case_dir out
+  case_dir=$(make_case increase)
+  arm_check "$case_dir"
+  poll "$case_dir" OPEN 3 >/dev/null   # baseline
+
+  out=$(poll "$case_dir" OPEN 5)
+  assert_contains "$out" "new-review-activity: +2 on $URL" \
+    "increase: activity wake line missing or malformed"
+  [ "$(printf '%s\n' "$out" | wc -l | tr -d ' ')" = 1 ] \
+    || fail "increase: check emitted more than one line ('$out')"
+  assert_grep "5" "$(ACT_PATH "$case_dir")" "increase: marker not advanced to the new count"
+  pass "new activity since the baseline wakes with one delta line and advances the marker"
+}
+
+test_silence_on_no_change() {
+  local case_dir out
+  case_dir=$(make_case no-change)
+  arm_check "$case_dir"
+  poll "$case_dir" OPEN 5 >/dev/null   # baseline
+
+  out=$(poll "$case_dir" OPEN 5)
+  [ -z "$out" ] || fail "no-change: unchanged activity woke firstmate (output: '$out')"
+  assert_grep "5" "$(ACT_PATH "$case_dir")" "no-change: marker drifted off the count"
+  pass "unchanged activity stays silent"
+}
+
+test_merged_beats_activity() {
+  local case_dir out
+  case_dir=$(make_case merged-wins)
+  arm_check "$case_dir"
+  poll "$case_dir" OPEN 5 >/dev/null   # baseline
+
+  # A merged PR that also gained activity: merged must win with exactly one line.
+  out=$(poll "$case_dir" MERGED 9)
+  assert_contains "$out" "merged" "merged-wins: merge was not reported"
+  assert_not_contains "$out" "new-review-activity" \
+    "merged-wins: activity line leaked alongside merged"
+  [ "$(printf '%s\n' "$out" | wc -l | tr -d ' ')" = 1 ] \
+    || fail "merged-wins: check emitted more than one line ('$out')"
+  assert_grep "5" "$(ACT_PATH "$case_dir")" \
+    "merged-wins: activity marker was touched despite merge winning"
+  pass "a merged PR wins with only the merged line and leaves the activity marker untouched"
+}
+
+test_api_error_is_silent_and_preserves_marker() {
+  local case_dir out
+  case_dir=$(make_case api-error)
+  arm_check "$case_dir"
+  poll "$case_dir" OPEN 5 >/dev/null   # baseline
+
+  out=$(poll "$case_dir" OPEN 99 fail)
+  [ -z "$out" ] || fail "api-error: gh failure produced a wake line (output: '$out')"
+  assert_grep "5" "$(ACT_PATH "$case_dir")" \
+    "api-error: gh failure corrupted the existing marker"
+  pass "a gh error stays silent and preserves the existing marker"
+}
+
+test_api_error_on_first_poll_writes_no_marker() {
+  local case_dir out
+  case_dir=$(make_case api-error-first)
+  arm_check "$case_dir"
+
+  out=$(poll "$case_dir" OPEN 99 fail)
+  [ -z "$out" ] || fail "api-error-first: gh failure produced a wake line (output: '$out')"
+  assert_absent "$(ACT_PATH "$case_dir")" \
+    "api-error-first: gh failure created a baseline marker from a failed read"
+  pass "a gh error on the first poll writes no marker"
+}
+
+test_fallen_count_resyncs_silently() {
+  local case_dir out
+  case_dir=$(make_case fell)
+  arm_check "$case_dir"
+  poll "$case_dir" OPEN 5 >/dev/null   # baseline
+
+  out=$(poll "$case_dir" OPEN 2)
+  [ -z "$out" ] || fail "fell: a fallen count woke firstmate (output: '$out')"
+  assert_grep "2" "$(ACT_PATH "$case_dir")" "fell: marker did not resync to the lower count"
+  pass "a fallen count resyncs the marker silently"
+}
+
+test_generated_check_is_valid_bash
+test_baseline_init_is_silent
+test_wake_on_increase
+test_silence_on_no_change
+test_merged_beats_activity
+test_api_error_is_silent_and_preserves_marker
+test_api_error_on_first_poll_writes_no_marker
+test_fallen_count_resyncs_silently


### PR DESCRIPTION
## What

The per-PR poll generated by `bin/fm-pr-check.sh` (`state/<id>.check.sh`) woke firstmate only when the PR merged. New review activity - an AI or human review, a PR issue comment, an inline review comment - sat unnoticed until someone happened to look.

This extends the poll so new review activity also wakes firstmate, within one poll cycle, while preserving the check contract (one line of stdout only when firstmate should wake, silence otherwise, bounded runtime).

## Behavior

- Each poll counts reviews + comments via `gh pr view --json reviews,comments` (gh's built-in jq), consistent with the existing `gh pr view --json` usage in the script family.
- The last-seen total is persisted in a firstmate-owned marker `state/<id>.pr-activity`, following the naming/lifecycle of sibling per-task state files.
- **First poll** initializes the baseline silently - activity predating the arm never wakes firstmate.
- **Increase** prints exactly one line, `new-review-activity: +<n> on <url>`, and advances the marker.
- **No change** stays silent.
- **Merge wins**: a merged PR echoes only `merged` and skips the activity check, so each fire prints exactly one line.
- **API error**: a `gh` failure (or any non-integer reading) stays silent and never touches the marker - retries next cycle.
- **No bot classification**: any new activity wakes firstmate to triage - cheaper than getting bot-detection wrong. Noted in the script header.

`bin/fm-teardown.sh` removes `state/<id>.pr-activity` alongside its sibling state files (both the main-task and secondmate-child cleanup paths).

## Notes

- `AGENTS.md` untouched: the check-contract sentence ("print one line only when firstmate should wake, print nothing otherwise") still accurately describes the new behavior.
- Mechanics documented in the script header per the coding-guidelines decision tree.

## Tests

New colocated `tests/fm-pr-check.test.sh` covers baseline init, wake-on-increase, silence-on-no-change, merged-beats-activity, API-error silence (existing marker and first poll), and the fallen-count resync. `shellcheck bin/*.sh bin/backends/*.sh tests/*.sh` is clean; `fm-teardown` and `fm-pr-merge` suites still green.