### PR TITLE
feat(fm-spawn): load project .claude/skills for pi crewmates

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -196,6 +196,7 @@ Project trust dialog can appear on the first pi run in any not-yet-trusted direc
 Accept with Enter.
 The decision persists per path in `~/.pi/agent/trust.json`, so later spawns in the same worktree slot skip it.
 
+Pi does not auto-discover a project's own skills (verified: it ignores `.claude/skills` and `.pi/skills` at the project root) but accepts `--skill <dir>`, so `fm-spawn` passes `--skill <worktree>/.claude/skills` on crewmate and scout launches whose worktree has that directory; non-pi harnesses, skill-less worktrees, and pi secondmates get nothing.
 `fm-spawn` keeps the turn-end extension in `state/`, outside the worktree, because project-local extension files make the trust gate strictly worse and pollute the project.
 The extension must listen for pi's `turn_end` event, not `agent_end`, so the watcher wakes after each completed turn instead of only when the whole agent run exits.
 Pi sets `PI_CODING_AGENT=true` for its children; this is its harness-detection env marker.

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -73,6 +73,10 @@
 #                  written by this script; outside the worktree to avoid pi's trust gate)
 #     __PITURNEND__ absolute path to .pi/extensions/fm-primary-turnend-guard.ts in a pi secondmate home
 #     __PIWATCH__   absolute path to .pi/extensions/fm-primary-pi-watch.ts in a pi secondmate home
+#     __PISKILL__  '--skill <abs-worktree>/.claude/skills ' for pi crewmate/scout
+#                  spawns whose worktree has a .claude/skills directory; empty otherwise
+#                  (non-pi harnesses, skill-less projects, and pi secondmates get nothing).
+#                  pi does not auto-discover project skills, so the flag loads them explicitly.
 # Per-harness turn-end hooks are installed automatically; some live outside the worktree.
 # grok uses a firstmate-owned global hook under ${GROK_HOME:-$HOME/.grok}/hooks
 # plus a gitignored .fm-grok-turnend worktree pointer and a state token.
@@ -329,7 +333,7 @@ launch_template() {
       if [ "$kind" = secondmate ]; then
         printf '%s' 'pi __MODELFLAG____EFFORTFLAG__-e __PITURNEND__ -e __PIWATCH__ "$(cat __BRIEF__)"'
       else
-        printf '%s' 'pi __MODELFLAG____EFFORTFLAG__-e __PIEXT__ "$(cat __BRIEF__)"'
+        printf '%s' 'pi __MODELFLAG____EFFORTFLAG____PISKILL__-e __PIEXT__ "$(cat __BRIEF__)"'
       fi
       ;;
     # grok (Grok Build TUI): a positional prompt starts the supervised interactive
@@ -1015,8 +1019,18 @@ sq_piturnend=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-turnend-guard.ts
 sq_piwatch=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-pi-watch.ts")
 MODELFLAG=$(model_flag_for_harness "$HARNESS" "$MODEL")
 EFFORTFLAG=$(effort_flag_for_harness "$HARNESS" "$EFFORT")
+# pi crewmate/scout only: load the project's own .claude/skills at launch. pi does
+# not auto-discover project skills (verified: it ignores .claude/skills and
+# .pi/skills at the project root) but accepts --skill <dir>. Empty for non-pi
+# harnesses, skill-less worktrees, and pi secondmates; the secondmate template
+# carries no __PISKILL__ token, so the substitution below is a no-op for it.
+sq_piskill=
+if [ "$HARNESS" = pi ] && [ "$KIND" != secondmate ] && [ -d "$WT/.claude/skills" ]; then
+  sq_piskill="--skill $(shell_quote "$(cd "$WT/.claude/skills" && pwd -P)") "
+fi
 LAUNCH=${LAUNCH//__MODELFLAG__/$MODELFLAG}
 LAUNCH=${LAUNCH//__EFFORTFLAG__/$EFFORTFLAG}
+LAUNCH=${LAUNCH//__PISKILL__/$sq_piskill}
 LAUNCH=${LAUNCH//__BRIEF__/$sq_brief}
 LAUNCH=${LAUNCH//__TURNEND__/$sq_turnend}
 LAUNCH=${LAUNCH//__PIEXT__/$sq_piext}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -143,6 +143,7 @@ The primary propagates `config/crew-dispatch.json`, `config/crew-harness`, and `
 `config/secondmate-harness` is not inherited because secondmates do not launch secondmates.
 For grok, `fm-spawn.sh` installs one firstmate-owned global turn-end hook under `$GROK_HOME/hooks/`, or `~/.grok/hooks/` when `GROK_HOME` is unset, and drops a per-task `.fm-grok-turnend` pointer in the worktree, with teardown removing the task token and pointer.
 For Pi secondmate launches, `fm-spawn.sh` starts Pi with `-e` pointed at the secondmate home's own tracked `.pi/extensions/fm-primary-pi-watch.ts` and `.pi/extensions/fm-primary-turnend-guard.ts`, both already present from the secondmate home's git worktree.
+For Pi crewmate and scout launches, `fm-spawn.sh` also passes `--skill <worktree>/.claude/skills` when that directory exists, because Pi does not auto-discover a project's own skills; non-pi harnesses, skill-less worktrees, and pi secondmates get no such flag.
 
 ## Crew dispatch profiles (config/crew-dispatch.json)
 

--- a/tests/fm-backlog-handoff.test.sh
+++ b/tests/fm-backlog-handoff.test.sh
@@ -10,8 +10,14 @@ set -u
 . "$(dirname "${BASH_SOURCE[0]}")/secondmate-helpers.sh"
 
 # The move is delegated to `tasks-axi mv`, so this suite exercises the real
-# binary. Skip cleanly when it is absent (matching the backend smoke suites).
-command -v tasks-axi >/dev/null 2>&1 || { echo "skip: tasks-axi not found (required by the delegated handoff path)"; exit 0; }
+# binary. Skip cleanly when it is absent OR too old for atomic multi-ID mv
+# (matching the backend smoke suites; the handoff path requires tasks-axi 0.2.2+).
+# shellcheck source=bin/fm-tasks-axi-lib.sh disable=SC1091
+. "$ROOT/bin/fm-tasks-axi-lib.sh"
+if ! command -v tasks-axi >/dev/null 2>&1 || ! fm_tasks_axi_compatible; then
+  echo "skip: compatible tasks-axi not found (required by the delegated handoff path)"
+  exit 0
+fi
 
 TMP_ROOT=$(fm_test_tmproot fm-backlog-handoff)
 

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -19,7 +19,8 @@ set -u
 # shellcheck source=tests/lib.sh disable=SC1091
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
-BASE_PATH=${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin}
+fm_sanitized_base_path
+BASE_PATH=${FM_TEST_BASE_PATH:-$FM_SANITIZED_BASE_PATH}
 TMP_ROOT=$(fm_test_tmproot fm-bootstrap-tests)
 
 # A fake toolchain where every required tool is present and gh is authenticated.

--- a/tests/fm-secondmate-lifecycle-e2e.test.sh
+++ b/tests/fm-secondmate-lifecycle-e2e.test.sh
@@ -26,6 +26,8 @@ set -u
 
 # shellcheck source=tests/secondmate-helpers.sh disable=SC1091
 . "$(dirname "${BASH_SOURCE[0]}")/secondmate-helpers.sh"
+# shellcheck source=bin/fm-tasks-axi-lib.sh disable=SC1091
+. "$ROOT/bin/fm-tasks-axi-lib.sh"
 
 TMP_ROOT=$(fm_test_tmproot fm-secondmate-lifecycle)
 export FM_BACKEND=tmux
@@ -151,10 +153,11 @@ phase_send() {
 }
 
 phase_handoff() {
-  # The move is delegated to `tasks-axi mv`; skip cleanly when it is absent (the
-  # downstream recovery and teardown phases do not depend on this phase).
-  if ! command -v tasks-axi >/dev/null 2>&1; then
-    echo "skip: tasks-axi not found (backlog handoff delegates to it)"
+  # The move is delegated to `tasks-axi mv`; skip cleanly when it is absent or
+  # too old for atomic multi-ID mv (the downstream recovery and teardown phases
+  # do not depend on this phase; the handoff path requires tasks-axi 0.2.2+).
+  if ! command -v tasks-axi >/dev/null 2>&1 || ! fm_tasks_axi_compatible; then
+    echo "skip: compatible tasks-axi not found (backlog handoff delegates to it)"
     return 0
   fi
   cat > "$HOME_DIR/data/backlog.md" <<'EOF'

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -26,7 +26,8 @@ set -u
 . "$(dirname "${BASH_SOURCE[0]}")/wake-helpers.sh"
 
 SESSION_START="$ROOT/bin/fm-session-start.sh"
-BASE_PATH=${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin}
+fm_sanitized_base_path
+BASE_PATH=${FM_TEST_BASE_PATH:-$FM_SANITIZED_BASE_PATH}
 TMP_ROOT=$(fm_test_tmproot fm-session-start-tests)
 fm_git_identity fmtest fmtest@example.invalid
 
@@ -186,7 +187,13 @@ SH
 
 run_session_start() {  # <home> <root> <path>
   local home=$1 root=$2 path=$3
-  FM_HOME="$home" FM_ROOT_OVERRIDE="$root" PATH="$path" "$SESSION_START"
+  # These tests simulate the primary harness through the fake `ps` stub, so any
+  # real harness env marker inherited from a shell that is itself a coding agent
+  # (e.g. CLAUDECODE=1 under Claude Code) must be cleared - otherwise fm-harness.sh's
+  # Layer-1 env detection short-circuits before the fake `ps` and the wrong
+  # supervision block renders (e.g. claude instead of the faked pi).
+  FM_HOME="$home" FM_ROOT_OVERRIDE="$root" PATH="$path" \
+    env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT "$SESSION_START"
 }
 
 hash_file_for_test() {

--- a/tests/fm-spawn-piskill.test.sh
+++ b/tests/fm-spawn-piskill.test.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# Behavior tests for fm-spawn.sh pi project-skill loading (`__PISKILL__`).
+#
+# pi does not auto-discover project skills (it ignores .claude/skills and
+# .pi/skills at the project root) but accepts `--skill <dir>`. fm-spawn threads
+# `--skill <worktree>/.claude/skills` into the pi CREWMATE/SCOUT launch template
+# only, and only when the resolved worktree actually has a .claude/skills
+# directory. These tests pin that contract by capturing the literal launch
+# command sent through a fake tmux pane, mirroring fm-spawn-dispatch-profile's
+# launch-capture mechanism.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SPAWN="$ROOT/bin/fm-spawn.sh"
+TMP_ROOT=$(fm_test_tmproot fm-spawn-piskill)
+
+make_spawn_fakebin() {
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+esac
+case "${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+  list-windows) exit 0 ;;
+  has-session|new-session|new-window|kill-window) exit 0 ;;
+  send-keys)
+    if [ -n "${FM_FAKE_LAUNCH_LOG:-}" ]; then
+      prev=
+      for a in "$@"; do
+        if [ "$prev" = "-l" ]; then
+          printf '%s\n' "$a" >> "$FM_FAKE_LAUNCH_LOG"
+        fi
+        prev=$a
+      done
+    fi
+    exit 0
+    ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" treehouse
+  printf '%s\n' "$fakebin"
+}
+
+# make_spawn_case <name> <harness> <id...>: echoes a |delimited| record of the
+# case dirs. Mirrors fm-spawn-dispatch-profile's helper, kept local so this
+# suite owns its own assumptions.
+make_spawn_case() {
+  local name=$1 harness=$2 case_dir home proj wt fakebin launchlog id
+  shift 2
+  case_dir="$TMP_ROOT/$name"
+  home="$case_dir/home"
+  proj="$case_dir/project"
+  wt="$case_dir/wt"
+  launchlog="$case_dir/launch.log"
+  fakebin=$(make_spawn_fakebin "$case_dir/fake")
+  mkdir -p "$home/data" "$home/projects" "$home/state" "$home/config"
+  printf '%s\n' "$harness" > "$home/config/crew-harness"
+  fm_git_worktree "$proj" "$wt" "wt-$name"
+  touch "$home/state/.last-watcher-beat"
+  for id in "$@"; do
+    mkdir -p "$home/data/$id"
+    printf 'brief for %s\n' "$id" > "$home/data/$id/brief.md"
+  done
+  printf '%s\n' "$case_dir|$home|$proj|$wt|$fakebin|$launchlog"
+}
+
+read_case_record() {
+  IFS='|' read -r CASE_DIR HOME_DIR PROJ_DIR WT_DIR FAKEBIN_DIR LAUNCH_LOG <<EOF
+$1
+EOF
+}
+
+make_seeded_secondmate_home() {
+  local home=$1 id=$2
+  mkdir -p "$home/bin" "$home/data"
+  printf '# Firstmate\n' > "$home/AGENTS.md"
+  printf '%s\n' "$id" > "$home/.fm-secondmate-home"
+  printf 'charter for %s\n' "$id" > "$home/data/charter.md"
+}
+
+run_spawn() {
+  local home=$1 wt=$2 fakebin=$3 launchlog=$4
+  shift 4
+  : > "$launchlog"
+  FM_ROOT_OVERRIDE='' FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
+    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" TMUX="fake,1,0" \
+    FM_FAKE_LAUNCH_LOG="$launchlog" GROK_HOME="$home/grok-home" PATH="$fakebin:$PATH" \
+    "$SPAWN" "$@" 2>&1
+}
+
+# Resolve the canonical .claude/skills path the same way fm-spawn does
+# (cd + pwd -P), so the assertion is robust to /tmp -> /private/tmp symlinks.
+abs_skills() {
+  (cd "$1/.claude/skills" && pwd -P)
+}
+
+# pi crewmate spawn on a worktree that HAS .claude/skills must thread
+# `--skill <abs>/.claude/skills` into the launch, with correct spacing so the
+# following `-e` flag stays separated.
+test_pi_crewmate_gets_skill_when_dir_present() {
+  local rec id out status launch meta expected_skill
+  id=piskill-on-z1
+  rec=$(make_spawn_case piskill-on pi "$id")
+  read_case_record "$rec"
+  mkdir -p "$WT_DIR/.claude/skills"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR")
+  status=$?
+  expect_code 0 "$status" "pi crewmate spawn with .claude/skills should succeed"
+  meta="$HOME_DIR/state/$id.meta"
+  assert_grep "harness=pi" "$meta" "meta missing harness=pi"
+
+  launch=$(cat "$LAUNCH_LOG")
+  abs_skill_skills=$(abs_skills "$WT_DIR")
+  assert_contains "$launch" "--skill '$abs_skill_skills' -e " \
+    "pi launch did not thread --skill '<abspath>/.claude/skills' with correct spacing before -e"
+  pass "pi crewmate threads --skill when the worktree has .claude/skills"
+}
+
+# pi crewmate spawn on a worktree WITHOUT .claude/skills must add no --skill
+# flag, leaving the launch byte-identical to the pre-change pi crewmate template.
+test_pi_crewmate_no_skill_when_dir_absent() {
+  local rec id out status launch
+  id=piskill-off-z2
+  rec=$(make_spawn_case piskill-off pi "$id")
+  read_case_record "$rec"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR")
+  status=$?
+  expect_code 0 "$status" "pi crewmate spawn without .claude/skills should succeed"
+  launch=$(cat "$LAUNCH_LOG")
+  assert_not_contains "$launch" "--skill" "pi launch must not pass --skill when .claude/skills is absent"
+  assert_contains "$launch" "pi -e " "pi launch without skills should still have its bare -e flag"
+  pass "pi crewmate omits --skill when the worktree has no .claude/skills"
+}
+
+# Non-pi harnesses never get --skill even when .claude/skills exists, because
+# the flag is pi-specific and their templates carry no __PISKILL__ token.
+test_non_pi_crewmate_never_gets_skill() {
+  local harness rec id out status launch
+  for harness in codex claude; do
+    id="piskill-$harness-z3"
+    rec=$(make_spawn_case "piskill-$harness" "$harness" "$id")
+    read_case_record "$rec"
+    mkdir -p "$WT_DIR/.claude/skills"
+
+    out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR")
+    status=$?
+    expect_code 0 "$status" "$harness crewmate spawn should succeed"
+    assert_contains "$out" "spawned $id harness=$harness kind=ship" "$harness spawn did not report a ship crewmate"
+    launch=$(cat "$LAUNCH_LOG")
+    assert_not_contains "$launch" "--skill" "$harness launch must never carry the pi-only --skill flag"
+  done
+  pass "codex and claude crewmate launches never receive --skill"
+}
+
+# A pi --secondmate launch must never receive --skill: secondmates are
+# supervisors in a firstmate home, not project workers. The .claude/skills dir is
+# created in the secondmate home too, proving the KIND != secondmate guard (and
+# the tokenless secondmate template) hold even when the directory exists.
+test_pi_secondmate_never_gets_skill() {
+  local rec id sm out status launch
+  id=piskill-secondmate-z4
+  rec=$(make_spawn_case piskill-sm pi "$id")
+  read_case_record "$rec"
+  sm="$CASE_DIR/secondmate-home"
+  make_seeded_secondmate_home "$sm" "$id"
+  mkdir -p "$sm/.claude/skills"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$sm" --secondmate)
+  status=$?
+  expect_code 0 "$status" "pi secondmate spawn should succeed"
+  assert_contains "$out" "harness=pi kind=secondmate" "secondmate spawn did not resolve to a pi secondmate launch"
+  launch=$(cat "$LAUNCH_LOG")
+  assert_not_contains "$launch" "--skill" "pi secondmate launch must never carry --skill"
+  pass "pi --secondmate launch never receives --skill"
+}
+
+test_pi_crewmate_gets_skill_when_dir_present
+test_pi_crewmate_no_skill_when_dir_absent
+test_non_pi_crewmate_never_gets_skill
+test_pi_secondmate_never_gets_skill
+
+echo "# all fm-spawn-piskill tests passed"

--- a/tests/fm-spawn-piskill.test.sh
+++ b/tests/fm-spawn-piskill.test.sh
@@ -108,7 +108,7 @@ abs_skills() {
 # `--skill <abs>/.claude/skills` into the launch, with correct spacing so the
 # following `-e` flag stays separated.
 test_pi_crewmate_gets_skill_when_dir_present() {
-  local rec id out status launch meta expected_skill
+  local rec id out status launch meta
   id=piskill-on-z1
   rec=$(make_spawn_case piskill-on pi "$id")
   read_case_record "$rec"

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -91,6 +91,40 @@ SH
   done
 }
 
+# fm_sanitized_base_path populates FM_SANITIZED_BASE_PATH with a directory of
+# symlinks to the real system tools in /usr/bin and /usr/sbin, MINUS the
+# firstmate-managed toolset that the fakebin stubs are meant to own. Tool-
+# detection tests build a fakebin and prepend it to a base PATH; a host that
+# ships a same-named binary (e.g. /usr/bin/orca, the GNOME screen reader, or a
+# system /usr/bin/node) would otherwise leak through the base PATH and satisfy a
+# MISSING-tool assertion the fakebin controls. Every managed tool is already
+# stubbed by the suite's fake toolchain when a test needs it present, so
+# excluding them from the base is safe. Built once per process.
+#
+# Call it as a bare statement (not in a command substitution) so its temp-dir
+# cleanup registers in the caller's shell rather than a subshell that exits and
+# deletes the dir immediately; read the result from FM_SANITIZED_BASE_PATH.
+fm_sanitized_base_path() {
+  [ -n "${FM_SANITIZED_BASE_PATH:-}" ] && return 0
+  local dir base src name
+  local blocklist=" tmux node gh gh-axi chrome-devtools-axi lavish-axi orca treehouse no-mistakes tasks-axi quota-axi "
+  dir=$(mktemp -d "${TMPDIR:-/tmp}/fm-base-path.XXXXXX")
+  if [ "${#FM_TEST_CLEANUP_DIRS[@]}" -eq 0 ]; then
+    trap fm_test_cleanup EXIT
+  fi
+  FM_TEST_CLEANUP_DIRS+=("$dir")
+  for base in /usr/bin /usr/sbin; do
+    [ -d "$base" ] || continue
+    for src in "$base"/*; do
+      name=${src##*/}
+      case "$blocklist" in *" $name "*) continue ;; esac
+      [ -e "$dir/$name" ] && continue
+      ln -s "$src" "$dir/$name" 2>/dev/null || true
+    done
+  done
+  FM_SANITIZED_BASE_PATH=$dir
+}
+
 # --- deterministic git identity and fixtures --------------------------------
 
 # fm_git_identity [name] [email]: export a fixed author/committer identity so


### PR DESCRIPTION
## Intent

Make firstmate's pi crewmates load their project's own skills at launch by threading --skill <worktree>/.claude/skills into the pi crewmate/scout launch template in bin/fm-spawn.sh, only when the worktree has a .claude/skills directory, leaving non-pi harnesses, skill-less projects, and pi secondmates unaffected

## What Changed

- `bin/fm-spawn.sh` now threads a `--skill <worktree>/.claude/skills` flag into the pi crewmate/scout launch template (via a new `__PISKILL__` token), but only when the harness is pi, the task is not a secondmate, and the worktree actually has a `.claude/skills` directory — so pi crewmates load their project's own skills at launch since pi does not auto-discover them. Non-pi harnesses, skill-less worktrees, and pi secondmates get nothing.
- Documented the behavior in `docs/configuration.md` and the `harness-adapters` skill, noting pi ignores `.claude/skills`/`.pi/skills` at the project root but accepts `--skill <dir>`.
- Added `tests/fm-spawn-piskill.test.sh` (4 behavior tests) plus shared helpers in `tests/lib.sh`, and hardened existing tool-detection tests (bootstrap, session-start, backlog-handoff, secondmate-lifecycle) against host environment leakage.

## Risk Assessment

✅ Low: The change is minimal, tightly guarded (harness/kind/dir checks), leaves all other harnesses and secondmates byte-identical, uses the same safe shell_quote + pattern-substitution idiom as existing flags, and is covered by four targeted behavior tests.

## Testing

<code>The configured full e2e suite passed as baseline; I additionally ran the new pi-skill behavior test plus every other test touched by the change (backlog-handoff, bootstrap, secondmate-lifecycle-e2e, session-start) and all pass. To show the intent working the way a firstmate operator would experience it, I captured the actual launch command pi is handed via a fake-tmux capture harness: a pi crewmate whose worktree has .claude/skills gets `pi --skill &#39;&lt;abs&gt;/.claude/skills&#39; -e ...`, a pi crewmate without the dir stays byte-identical to the old template, and both a codex crewmate (dir present) and a pi secondmate (dir present in home) receive no --skill flag. Round 1&#39;s generic exit-1 failure no longer reproduces and was addressed by the final commit hardening tool-detection tests against host env leakage.</code>

<details>
<summary>Evidence: Captured pi/codex/secondmate launch commands across four scenarios</summary>

<code>=== pi crewmate, worktree HAS .claude/skills ===&#10;pi --skill &#39;&lt;wt&gt;/.claude/skills&#39; -e &#39;&lt;...&gt;.pi-ext.ts&#39; &#34;$(cat &#39;&lt;brief&gt;&#39;)&#34;&#10;&#10;=== pi crewmate, NO .claude/skills ===&#10;pi -e &#39;&lt;...&gt;.pi-ext.ts&#39; &#34;$(cat &#39;&lt;brief&gt;&#39;)&#34;&#10;&#10;=== codex crewmate, HAS .claude/skills (no --skill) ===&#10;codex --dangerously-bypass-approvals-and-sandbox ... &#34;$(cat &#39;&lt;brief&gt;&#39;)&#34;&#10;&#10;=== pi SECONDMATE, home HAS .claude/skills (no --skill) ===&#10;... pi -e &#39;&lt;...&gt;fm-primary-turnend-guard.ts&#39; -e &#39;&lt;...&gt;fm-primary-pi-watch.ts&#39; &#34;$(cat &#39;&lt;charter&gt;&#39;)&#34;</code>

```text
=== Scenario 1: pi crewmate, worktree HAS .claude/skills ===
pi --skill '/tmp/piskill-demo.zu81nl/s1/wt/.claude/skills' -e '/tmp/piskill-demo.zu81nl/s1/home/state/j1.pi-ext.ts' "$(cat '/tmp/piskill-demo.zu81nl/s1/home/data/j1/brief.md')"

=== Scenario 2: pi crewmate, worktree has NO .claude/skills ===
pi -e '/tmp/piskill-demo.zu81nl/s2/home/state/j2.pi-ext.ts' "$(cat '/tmp/piskill-demo.zu81nl/s2/home/data/j2/brief.md')"

=== Scenario 3: codex crewmate, worktree HAS .claude/skills (must NOT get --skill) ===
codex --dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch '/tmp/piskill-demo.zu81nl/s3/home/state/j3.turn-ended'\"]" "$(cat '/tmp/piskill-demo.zu81nl/s3/home/data/j3/brief.md')"

=== Scenario 4: pi SECONDMATE, home HAS .claude/skills (must NOT get --skill) ===
FM_ROOT_OVERRIDE= FM_STATE_OVERRIDE= FM_DATA_OVERRIDE= FM_PROJECTS_OVERRIDE= FM_CONFIG_OVERRIDE= FM_HOME='/tmp/piskill-demo.zu81nl/s4/sm' pi -e '/tmp/piskill-demo.zu81nl/s4/sm/.pi/extensions/fm-primary-turnend-guard.ts' -e '/tmp/piskill-demo.zu81nl/s4/sm/.pi/extensions/fm-primary-pi-watch.ts' "$(cat '/tmp/piskill-demo.zu81nl/s4/sm/data/charter.md')"
```
</details>
- Outcome: 🔧 1 issue found → auto-fixed ✅ across 2 runs (2h35m16s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `bin/fm-spawn.sh:1028` - In this repo, .claude/skills is a symlink to .agents/skills (firstmate&#39;s internal operational skills, all marked metadata.internal=true). Because pwd -P resolves the symlink, a pi crewmate/scout spawned on a firstmate-on-itself worktree will now auto-load firstmate&#39;s own internal skills (harness-adapters, secondmate-provisioning, etc.) via --skill. This is within the literal &#39;load the project&#39;s own skills&#39; intent and is benign (skills are only surfaced, not forced), but it&#39;s a non-obvious consequence specific to this self-pooled repo. No action needed unless you want firstmate-repo tasks excluded.

</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed ✅</summary>

- 🚨 tests failed with exit code 1
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`

🔧 Fix: test: harden tool-detection tests against host env leakage
✅ Re-checked - no issues remain.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- <code>`bash tests/fm-spawn-piskill.test.sh` (4 behavior tests, all pass)</code>
- <code>`bash tests/fm-backlog-handoff.test.sh` (pass)</code>
- <code>`bash tests/fm-bootstrap.test.sh` (pass)</code>
- <code>`bash tests/fm-secondmate-lifecycle-e2e.test.sh` (pass)</code>
- <code>`bash tests/fm-session-start.test.sh` (pass)</code>
- `Manual launch-command capture harness printing the real pi/codex/secondmate launch strings for all four scenarios`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
