### PR TITLE
test: isolate session-start suite from ambient harness markers

### DIFF
--- a/docs/tmux-backend.md
+++ b/docs/tmux-backend.md
@@ -114,7 +114,7 @@ The classifier (`fm_backend_tmux_agent_alive`) maps the observed name to `alive`
 Since `node` is also the generic name for a plain interpreter session, any future JS-based harness, or someone's unrelated node script, there is no way to attribute a bare `node` foreground process back to `pi` specifically from outside the pane without deeper (and fragile) argument introspection.
 The classifier deliberately reports `unknown` for `node`/`python`/`python3` rather than guess - per the secondmate-liveness sweep's correctness bar, a wrong `alive` is harmless but a wrong `dead` spins up a duplicate agent, so an unresolvable case must never be treated as confidently dead.
 Practical effect: a dead `pi` secondmate is not auto-healed by the liveness sweep today; it is reported as `skipped: liveness probe inconclusive` instead, which still surfaces it for a human to act on.
-Resolving this would need either a `pi`-specific env marker inspectable from outside the process (mirroring `PI_CODING_AGENT=1`, which `bin/fm-harness.sh` already uses for self-detection but which is not readable from a different process without deeper introspection) or accepting the argument-inspection fragility - not attempted here.
+Resolving this would need either a `pi`-specific env marker inspectable from outside the process (mirroring `PI_CODING_AGENT=true`, which `bin/fm-harness.sh` already uses for self-detection but which is not readable from a different process without deeper introspection) or accepting the argument-inspection fragility - not attempted here.
 
 ## Limitations
 

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -184,9 +184,18 @@ SH
   chmod +x "$fakebin/herdr"
 }
 
-run_session_start() {  # <home> <root> <path>
+# run_session_start <home> <root> <path>
+# Drop every harness env marker from bin/fm-harness.sh detect_own so the
+# surrounding interactive shell cannot leak past the suite's fake ps harness.
+# Markers today: CLAUDECODE (claude), PI_CODING_AGENT (pi), GROK_AGENT (grok).
+# codex and opencode have no env markers (ancestry only). Without this, a local
+# claude/pi/grok session fails cases that pin a different fake harness while CI
+# (no ambient markers) still passes.
+run_session_start() {
   local home=$1 root=$2 path=$3
-  FM_HOME="$home" FM_ROOT_OVERRIDE="$root" PATH="$path" "$SESSION_START"
+  env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
+    FM_HOME="$home" FM_ROOT_OVERRIDE="$root" PATH="$path" \
+    "$SESSION_START"
 }
 
 hash_file_for_test() {


### PR DESCRIPTION
## Intent

Fix the fake-harness env leak in tests/fm-session-start.test.sh so the pi supervision-block case (and the rest of the suite) passes under an interactive claude/pi/grok session the same way it does in CI.

Root cause: CLAUDECODE=1 (and sibling harness markers PI_CODING_AGENT, GROK_AGENT from bin/fm-harness.sh detect_own) leak from the surrounding interactive shell past the suite's fake ps harness, so harness detection returns the ambient harness instead of the faked one. CI has no ambient markers, so the same test passed there - a local-vs-CI split, not a product bug.

Fix (test hygiene only, no product code): neutralize CLAUDECODE, PI_CODING_AGENT, and GROK_AGENT inside run_session_start (the shared suite entry point) via env -u so every case in the file is isolated once. codex and opencode have no env markers (ancestry only). Deliberately fixed at the shared runner rather than per-case.

## What Changed

- Captain, isolate session-start test runs from ambient Claude, Pi, and Grok harness environment markers so mocked harness cases remain deterministic.
- Correct the documented Pi self-detection marker value to `PI_CODING_AGENT=true`.

## Risk Assessment

✅ Low: Captain, this is a bounded test-hygiene change that correctly clears the ambient harness markers used by detection.

## Testing

The supplied full-suite baseline had passed; focused end-to-end runs then passed with each interactive harness marker isolated, including the Pi supervision-block case, with the captured CLI transcript demonstrating the intended local-versus-CI isolation behavior. The worktree remained unchanged.

<details>
<summary>Evidence: Ambient harness-marker end-to-end transcript</summary>

```text
End-to-end ambient harness-marker regression verification
Each invocation runs the complete focused session-start behavior suite with exactly one interactive harness marker present.

== ambient claude marker ==
ok - context digest distinguishes ABSENT, empty-but-present, and populated files
ok - a lock refusal prints a loud read-only banner, skips every mutating step, and still completes the digest
ok - digest sections are ordered diagnostics-first, bulk-context-last
ok - status tail is bounded to the configured line count, with the full log path always printed
ok - orphan status logs are printed once with bounded tails
ok - tmux endpoint liveness is reported per task: alive for a live window, dead for a gone one
ok - herdr endpoint liveness is reported per task: alive for a live pane, dead for a gone one
ok - fm-session-start.sh composes the real fm-lock.sh, fm-bootstrap.sh, and fm-wake-drain.sh output verbatim
ok - an empty fleet reports (none) for in-flight tasks and an absent AFK flag
ok - session start emits X-mode cadence guidance in the harness supervision block
ok - next step delegates watcher ownership to the AFK daemon
ok - session start emits exactly one detected harness block and reports Pi extension load state
ok - session start rejects stale Pi loaded markers
ok - session start accepts current Pi markers written before lock acquisition
ok - session start rejects Pi sessions missing the turn-end guard marker
ok - session start rejects Pi loaded markers from previous sessions
result: pass (claude marker isolated)

== ambient pi marker ==
ok - context digest distinguishes ABSENT, empty-but-present, and populated files
ok - a lock refusal prints a loud read-only banner, skips every mutating step, and still completes the digest
ok - digest sections are ordered diagnostics-first, bulk-context-last
ok - status tail is bounded to the configured line count, with the full log path always printed
ok - orphan status logs are printed once with bounded tails
ok - tmux endpoint liveness is reported per task: alive for a live window, dead for a gone one
ok - herdr endpoint liveness is reported per task: alive for a live pane, dead for a gone one
ok - fm-session-start.sh composes the real fm-lock.sh, fm-bootstrap.sh, and fm-wake-drain.sh output verbatim
ok - an empty fleet reports (none) for in-flight tasks and an absent AFK flag
ok - session start emits X-mode cadence guidance in the harness supervision block
ok - next step delegates watcher ownership to the AFK daemon
ok - session start emits exactly one detected harness block and reports Pi extension load state
ok - session start rejects stale Pi loaded markers
ok - session start accepts current Pi markers written before lock acquisition
ok - session start rejects Pi sessions missing the turn-end guard marker
ok - session start rejects Pi loaded markers from previous sessions
result: pass (pi marker isolated)

== ambient grok marker ==
ok - context digest distinguishes ABSENT, empty-but-present, and populated files
ok - a lock refusal prints a loud read-only banner, skips every mutating step, and still completes the digest
ok - digest sections are ordered diagnostics-first, bulk-context-last
ok - status tail is bounded to the configured line count, with the full log path always printed
ok - orphan status logs are printed once with bounded tails
ok - tmux endpoint liveness is reported per task: alive for a live window, dead for a gone one
ok - herdr endpoint liveness is reported per task: alive for a live pane, dead for a gone one
ok - fm-session-start.sh composes the real fm-lock.sh, fm-bootstrap.sh, and fm-wake-drain.sh output verbatim
ok - an empty fleet reports (none) for in-flight tasks and an absent AFK flag
ok - session start emits X-mode cadence guidance in the harness supervision block
ok - next step delegates watcher ownership to the AFK daemon
ok - session start emits exactly one detected harness block and reports Pi extension load state
ok - session start rejects stale Pi loaded markers
ok - session start accepts current Pi markers written before lock acquisition
ok - session start rejects Pi sessions missing the turn-end guard marker
ok - session start rejects Pi loaded markers from previous sessions
result: pass (grok marker isolated)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- <code>Baseline previously completed: `command -v tmux &gt;/dev/null || { echo &#34;tmux is required for e2e tests&#34; &gt;&amp;2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo &#34;== $t ==&#34;; bash &#34;$t&#34; || rc=1; done; exit &#34;$rc&#34;`</code>
- `env -u PI_CODING_AGENT -u GROK_AGENT CLAUDECODE=1 bash tests/fm-session-start.test.sh`
- `env -u CLAUDECODE -u GROK_AGENT PI_CODING_AGENT=true bash tests/fm-session-start.test.sh`
- `env -u CLAUDECODE -u PI_CODING_AGENT GROK_AGENT=1 bash tests/fm-session-start.test.sh`
- `git status --short`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
