### PR TITLE
test: cover numeric tmux session targeting

### DIFF
--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -88,6 +88,10 @@ fm_backend_tmux_create_task() {  # <session> <window-name> <proj-abs> -> prints 
     echo "error: window $ses:$wname already exists" >&2
     return 1
   fi
+  # The trailing colon makes this unambiguously a session target. Without it,
+  # a numeric session name such as "0" is parsed as window index 0 and every
+  # later spawn collides with the first task window instead of allocating the
+  # next free index.
   wid=$(tmux new-window -dP -F '#{window_id}' -t "$ses:" -n "$wname" -c "$proj_abs") || return 1
   tmux set-window-option -t "$wid" automatic-rename off 2>/dev/null || true
   tmux set-window-option -t "$wid" allow-rename off 2>/dev/null || true

--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -76,7 +76,8 @@ fm_backend_tmux_container_ensure() {
 # Robustness (fm-spawn tmux window handling under a non-default captain config):
 #   - Capture a STABLE window id with -P -F '#{window_id}', and let tmux append
 #     at the next free index by targeting the session with a trailing colon
-#     ("$ses:"), so a non-default base-index (e.g. base-index 1) cannot collide.
+#     ("$ses:"), so a numeric session name is not parsed as a window index and
+#     a non-default base-index (e.g. base-index 1) cannot collide.
 #   - PIN the window name by disabling automatic-rename and allow-rename on the
 #     new window: the captain's tmux may rename the window away from fm-<id> once
 #     treehouse cd's into the worktree, which would break name-based targeting.
@@ -88,10 +89,6 @@ fm_backend_tmux_create_task() {  # <session> <window-name> <proj-abs> -> prints 
     echo "error: window $ses:$wname already exists" >&2
     return 1
   fi
-  # The trailing colon makes this unambiguously a session target. Without it,
-  # a numeric session name such as "0" is parsed as window index 0 and every
-  # later spawn collides with the first task window instead of allocating the
-  # next free index.
   wid=$(tmux new-window -dP -F '#{window_id}' -t "$ses:" -n "$wname" -c "$proj_abs") || return 1
   tmux set-window-option -t "$wid" automatic-rename off 2>/dev/null || true
   tmux set-window-option -t "$wid" allow-rename off 2>/dev/null || true

--- a/docs/tmux-backend.md
+++ b/docs/tmux-backend.md
@@ -71,6 +71,42 @@ tmux list-windows -t <session-name>
 Use the current tmux session name for the run-inside-tmux path, or `firstmate` for the detached outside-tmux path.
 You should see a `fm-<id>` window for the task, live and updating as the crewmate works.
 
+## Numeric session target verification
+
+Verified empirically with real tmux 3.7b on Linux 6.6.87.2-microsoft-standard-WSL2, 2026-07-10, using a private tmux socket:
+
+```sh
+$ tmux -V
+tmux 3.7b
+$ uname -sr
+Linux 6.6.87.2-microsoft-standard-WSL2
+$ tmux -L <private-socket> new-session -d -s 0 -n shell
+$ tmux -L <private-socket> new-window -dP -F '#{session_name}:#{window_index}:#{window_name}' -t 0 -n bare
+0:0:bare
+$ tmux -L <private-socket> new-window -dP -F '#{session_name}:#{window_index}:#{window_name}' -t '0:' -n qualified
+0:2:qualified
+$ tmux -L <private-socket> list-windows -t 0 -F '#{window_index}:#{window_name}'
+0:bare
+1:shell
+2:qualified
+```
+
+The bare numeric target selected window index 0 and inserted the new window there, while the session-qualified `0:` target allocated the next free window index.
+The adapter therefore uses `"$ses:"` so numeric session names remain unambiguous and repeated spawns append instead of colliding with or displacing an existing window.
+The repository regression ran against another private socket and produced:
+
+```text
+$ tests/fm-backend-tmux-smoke.test.sh
+@1
+ok - real tmux: fm_backend_tmux_create_task creates a window and refuses a duplicate
+ok - real tmux: fm_backend_tmux_send_text_line sends literal text and submits with Enter
+ok - real tmux: fm_backend_tmux_send_literal + fm_backend_tmux_send_key Enter submit as two separate steps
+ok - real tmux: fm_backend_tmux_capture's -S -N bound trims old history for a small window and reaches it for a large one
+ok - real tmux: fm_backend_tmux_resolve_bare_selector (list-live) finds the created window by name
+ok - real tmux: fm_backend_tmux_resolve_bare_selector fails for a window that does not exist
+ok - real tmux: fm_backend_tmux_kill removes the window and is idempotent/best-effort
+```
+
 ## Agent liveness probe
 
 `fm_backend_target_exists` (`bin/fm-backend.sh`) only checks that a window's pane still exists.

--- a/docs/tmux-backend.md
+++ b/docs/tmux-backend.md
@@ -98,7 +98,8 @@ The repository regression ran against another private socket and produced:
 ```text
 $ tests/fm-backend-tmux-smoke.test.sh
 @1
-ok - real tmux: fm_backend_tmux_create_task creates a window and refuses a duplicate
+@2
+ok - real tmux: fm_backend_tmux_create_task preserves existing indexes, appends windows, and refuses a duplicate
 ok - real tmux: fm_backend_tmux_send_text_line sends literal text and submits with Enter
 ok - real tmux: fm_backend_tmux_send_literal + fm_backend_tmux_send_key Enter submit as two separate steps
 ok - real tmux: fm_backend_tmux_capture's -S -N bound trims old history for a small window and reaches it for a large one

--- a/tests/fm-backend-tmux-smoke.test.sh
+++ b/tests/fm-backend-tmux-smoke.test.sh
@@ -40,7 +40,9 @@ export PATH
 . "$ROOT/bin/fm-backend.sh"
 fm_backend_source tmux || fail "fm_backend_source tmux failed"
 
-SESSION="smoke"
+# Use a numeric session name to cover tmux's ambiguous bare-target parsing.
+# fm_backend_tmux_create_task must qualify it as a session, not window index 0.
+SESSION="0"
 WINDOW="fm-smoke1"
 TARGET="$SESSION:$WINDOW"
 

--- a/tests/fm-backend-tmux-smoke.test.sh
+++ b/tests/fm-backend-tmux-smoke.test.sh
@@ -44,23 +44,32 @@ fm_backend_source tmux || fail "fm_backend_source tmux failed"
 # fm_backend_tmux_create_task must qualify it as a session, not window index 0.
 SESSION="0"
 WINDOW="fm-smoke1"
+WINDOW2="fm-smoke2"
 TARGET="$SESSION:$WINDOW"
 
 # --- create session ----------------------------------------------------------
 
-tmux new-session -d -s "$SESSION" -x 200 -y 50 \
+tmux new-session -d -s "$SESSION" -n initial -x 200 -y 50 \
   || fail "real tmux: new-session failed"
+tmux set-option -t "$SESSION" base-index 0 \
+  || fail "real tmux: setting base-index failed"
+tmux move-window -r -t "$SESSION:" \
+  || fail "real tmux: renumbering the initial window failed"
 fm_backend_tmux_create_task "$SESSION" "$WINDOW" "$HOME" \
   || fail "fm_backend_tmux_create_task failed to create the task window"
-tmux list-windows -t "$SESSION" -F '#{window_name}' | grep -qx "$WINDOW" \
-  || fail "created window is not visible in the real session"
+fm_backend_tmux_create_task "$SESSION" "$WINDOW2" "$HOME" \
+  || fail "fm_backend_tmux_create_task failed to create the second task window"
+windows=$(tmux list-windows -t "$SESSION" -F '#{window_index}:#{window_name}') \
+  || fail "real tmux: list-windows failed after task creation"
+[ "$windows" = $'0:initial\n1:fm-smoke1\n2:fm-smoke2' ] \
+  || fail "task windows did not use successive free indexes without displacing the initial window"$'\n'"$windows"
 
 # A second create for the SAME window name must refuse (mirrors fm-spawn.sh's
 # duplicate-window guard).
 if fm_backend_tmux_create_task "$SESSION" "$WINDOW" "$HOME" 2>/dev/null; then
   fail "fm_backend_tmux_create_task should refuse an existing window name"
 fi
-pass "real tmux: fm_backend_tmux_create_task creates a window and refuses a duplicate"
+pass "real tmux: fm_backend_tmux_create_task preserves existing indexes, appends windows, and refuses a duplicate"
 
 # --- send text + Enter -------------------------------------------------------
 

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -349,8 +349,8 @@ $rec
 EOF
   make_fake_toolchain "$fakebin"
   make_fake_ps_claude "$fakebin"
-  # Force a MISSING diagnostic line so the bootstrap section is non-trivial.
-  rm -f "$fakebin/node"
+  # tasks-axi is deliberately absent from the fixture PATH, so bootstrap's
+  # required-tool diagnostic makes this section non-trivial.
 
   printf 'window=fm-sess:w1\nkind=ship\n' > "$home/state/task-a.meta"
 
@@ -373,7 +373,7 @@ EOF
   [ "$context_line" -lt "$fleet_line" ] || fail "CONTEXT did not precede FLEET STATE"
   [ "$fleet_line" -lt "$next_line" ] || fail "FLEET STATE did not precede NEXT STEP"
 
-  missing_line=$(printf '%s\n' "$out" | grep -n 'MISSING: node' | head -1 | cut -d: -f1)
+  missing_line=$(printf '%s\n' "$out" | grep -n 'MISSING: tasks-axi' | head -1 | cut -d: -f1)
   [ -n "$missing_line" ] || fail "MISSING diagnostic did not appear at all"
   [ "$missing_line" -lt "$fleet_line" ] || fail "actionable MISSING diagnostic was buried after the bulk fleet-state digest"
 
@@ -493,8 +493,6 @@ $rec
 EOF
   make_fake_toolchain "$fakebin"
   make_fake_ps_claude "$fakebin"
-  rm -f "$fakebin/node"
-
   append_wake "$home/state" signal task-z "needs-decision: pick a library"
 
   out=$(run_session_start "$home" "$root" "$fakebin:$BASE_PATH")
@@ -502,7 +500,7 @@ EOF
   # fm-lock.sh's own exact success text.
   assert_contains "$out" "lock acquired: harness pid" "fm-lock.sh's real output did not appear (composition, not reimplementation)"
   # fm-bootstrap.sh's own exact MISSING-tool line format.
-  assert_contains "$out" "MISSING: node (install:" "fm-bootstrap.sh's real detect line did not appear verbatim"
+  assert_contains "$out" "MISSING: tasks-axi (install:" "fm-bootstrap.sh's real detect line did not appear verbatim"
   # fm-wake-drain.sh's real drained record (raw tab-separated queue line).
   assert_contains "$out" "$(printf 'signal\ttask-z\tneeds-decision: pick a library')" "fm-wake-drain.sh's real drained record did not appear"
 

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -48,12 +48,13 @@ new_world() {
   printf '%s|%s|%s\n' "$root" "$home" "$fakebin"
 }
 
-# make_fake_toolchain <fakebin>: every tool fm-bootstrap.sh detects, present
-# and compatible, so its own detect-only section stays quiet except where a
-# test deliberately breaks one. Mirrors fm-bootstrap.test.sh's fixture.
+# make_fake_toolchain <fakebin>: every tool fm-bootstrap.sh detects is
+# controlled, so its own detect-only section stays quiet except for the
+# deliberately incompatible tasks-axi diagnostic. Mirrors
+# fm-bootstrap.test.sh's fixture.
 make_fake_toolchain() {
   local fakebin=$1
-  fm_fake_exit0 "$fakebin" tmux node gh-axi chrome-devtools-axi lavish-axi
+  fm_fake_exit0 "$fakebin" tmux node gh-axi chrome-devtools-axi lavish-axi tasks-axi
   cat > "$fakebin/gh" <<'SH'
 #!/usr/bin/env bash
 exit 0


### PR DESCRIPTION
## Intent

Repair Firstmate's tmux backend so numeric tmux session names are targeted unambiguously during crewmate spawning, preventing repeated spawn collisions. Preserve existing behavior for non-numeric sessions, include a real-tmux regression test, and keep shell scripts shellcheck-clean.

## What Changed

- Strengthens the real-tmux smoke test to verify repeated task-window creation in a numeric session preserves existing indexes and rejects duplicates.
- Documents why tmux session targets require a trailing colon and records the numeric-session verification evidence.
- Makes session-start missing-tool tests deterministic by controlling the `tasks-axi` fixture instead of relying on the host environment.

Captain, this covers the full base-to-target delta.

## Risk Assessment

✅ Low: Captain, the change is narrowly scoped to regression coverage, documentation, and deterministic test-fixture behavior; the full diff revealed no material correctness, security, performance, compatibility, or simplification concerns.

## Testing

The configured full suite had already passed; focused real-tmux regression and manual end-to-end checks also passed. Numeric session `0` preserved its existing window, appended two crewmate windows without collision, rejected a repeated spawn, and retained normal behavior for a named session.

<details>
<summary>Evidence: Real tmux numeric-session end-to-end transcript</summary>

<code>Session `0` preserved `captain` at index 0, created `fm-crew-a` and `fm-crew-b` at indexes 1 and 2, and safely rejected a duplicate. Named session `ordinary` also behaved normally.</code>

```text
User scenario: spawn two task windows in numeric tmux session 0
Before spawn:
session=0 index=0 name=captain
Created stable targets: @1 @2
After two spawns:
session=0 index=0 name=captain
session=0 index=1 name=fm-crew-a
session=0 index=2 name=fm-crew-b
Repeated spawn safely rejected: error: window 0:fm-crew-a already exists

Compatibility scenario: ordinary named session
Created stable target: @4
session=ordinary index=1 name=captain
session=ordinary index=2 name=fm-crew-c

RESULT: numeric and non-numeric session spawning behaved correctly.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `tests/fm-session-start.test.sh:352` - The fixture assumes `tasks-axi` is absent, but each test runs with `PATH=&#34;$fakebin:$BASE_PATH&#34;`, and `FM_TEST_BASE_PATH` may expose an installed compatible binary. This makes assertions for `MISSING: tasks-axi` host-dependent. Shadow it with a controlled incompatible fake executable or otherwise guarantee its absence.

🔧 Fix: Captain, make tasks-axi fixture deterministic
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- <code>Configured baseline: `command -v tmux &gt;/dev/null || { echo &#34;tmux is required for e2e tests&#34; &gt;&amp;2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo &#34;== $t ==&#34;; bash &#34;$t&#34; || rc=1; done; exit &#34;$rc&#34;` (already completed successfully)</code>
- `bash tests/fm-backend-tmux-smoke.test.sh`
- <code>Private real-tmux scenario using `fm_backend_tmux_create_task`: created numeric session `0`, spawned two task windows, inspected actual indexes, verified duplicate rejection, and repeated creation in named session `ordinary`</code>
- <code>`git status --short` to confirm testing left the worktree unchanged</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
