### PR TITLE
fix(cmux): close last workspace during teardown

### DIFF
--- a/bin/backends/cmux.sh
+++ b/bin/backends/cmux.sh
@@ -63,10 +63,11 @@
 #      herdr (auto-closes the workspace) nor zellij (leaves a ghost tab):
 #      `close-surface` REFUSES outright with a typed error
 #      (`invalid_state: Cannot close the last surface`), leaving both the
-#      surface and the workspace untouched. `close-workspace` cleanly removes
-#      the whole workspace (surface included) in one call with no ghost left
-#      behind. Kill therefore closes the whole workspace directly, which also
-#      reclaims any extra surfaces inside the task workspace.
+#      surface and the workspace untouched. `close-workspace` removes the
+#      whole workspace (surface included) only when it is not the last
+#      workspace in its window. `fm_backend_cmux_kill` handles the documented
+#      last-in-window exception below, while still reclaiming every surface in
+#      the task workspace.
 #   5. Workspace ids do NOT survive an app relaunch - verified via source
 #      (`Sources/Workspace.swift`'s only initializer unconditionally sets
 #      `self.id = UUID()`, with no restored-id parameter, unlike surfaces'

--- a/bin/backends/cmux.sh
+++ b/bin/backends/cmux.sh
@@ -596,17 +596,56 @@ fm_backend_cmux_send_text_submit() {  # <target> <text> <retries> <enter-sleep> 
   done
 }
 
+# fm_backend_cmux_window_of_workspace: echo "<window_id> <workspace_count>" for
+# the window that contains <workspace_id>, or nothing if it is not found live.
+# `workspace list --json` with no `--window` is scoped to the CURRENT window
+# only (verified live), so the containing window is found by walking every
+# window from `list-windows --json` and asking each for its own scoped list.
+# The count comes straight from that window's `workspace_count` field.
+fm_backend_cmux_window_of_workspace() {  # <workspace_id> -> "<window_id> <count>"
+  local wsid=$1 wins wid cnt
+  wins=$(fm_backend_cmux_cli list-windows --json --id-format uuids 2>/dev/null) || return 0
+  while IFS=$'\t' read -r wid cnt; do
+    [ -n "$wid" ] || continue
+    if fm_backend_cmux_cli workspace list --json --id-format uuids --window "$wid" 2>/dev/null \
+        | jq -e --arg id "$wsid" '[.workspaces[]? | select(.id == $id)] | length > 0' >/dev/null 2>&1; then
+      printf '%s %s' "$wid" "$cnt"
+      return 0
+    fi
+  done < <(printf '%s' "$wins" | jq -r '.[]? | "\(.id)\t\(.workspace_count)"' 2>/dev/null)
+}
+
 # fm_backend_cmux_kill: remove the task's whole workspace, best-effort (mirrors
 # every other backend's `kill` `|| true` contract). A cmux task owns one
 # workspace, so teardown reclaims that workspace and all of its surfaces.
+#
+# The selected-workspace teardown bug (docs/cmux-backend.md "Closing the last
+# workspace in a window"): cmux keeps every window at >=1 workspace, so
+# `close-workspace` on the ONLY workspace in its window silently no-ops - it
+# still returns `OK`, but the workspace stays, which is exactly what left a
+# selected task workspace open at teardown (the last workspace in a window is
+# always the selected one). `close-window`/`window.close` cannot rescue it
+# either: a window holding a live terminal session cannot be closed over the
+# control socket (verified: returns success-shaped output, closes nothing).
+# The reliable primitive is close-workspace on a NON-last workspace, so when the
+# target is the last one in its window a throwaway sibling is created first,
+# leaving that window a fresh default workspace (never an fm-<home>- title, so
+# recovery/list_live ignore it) - cmux's own "closed the last tab" outcome.
 fm_backend_cmux_kill() {  # <target> [unused] [expected-label]
-  local expected_label=${3:-}
+  local expected_label=${3:-} wsid wininfo win count
   if [ -n "$expected_label" ]; then
     fm_backend_cmux_target_ready "$1" "$expected_label" || return 0
   else
     fm_backend_cmux_parse_target "$1" || return 0
   fi
-  fm_backend_cmux_cli close-workspace --workspace "$FM_BACKEND_CMUX_WORKSPACE" >/dev/null 2>&1 || true
+  wsid=$FM_BACKEND_CMUX_WORKSPACE
+  wininfo=$(fm_backend_cmux_window_of_workspace "$wsid")
+  win=${wininfo%% *}
+  count=${wininfo##* }
+  if [ -n "$win" ] && [ "$count" = 1 ]; then
+    fm_backend_cmux_cli new-workspace --window "$win" --focus false --id-format uuids >/dev/null 2>&1 || true
+  fi
+  fm_backend_cmux_cli close-workspace --workspace "$wsid" >/dev/null 2>&1 || true
 }
 
 # fm_backend_cmux_list_live: recovery/orphan discovery. Lists every workspace

--- a/bin/backends/cmux.sh
+++ b/bin/backends/cmux.sh
@@ -601,18 +601,21 @@ fm_backend_cmux_send_text_submit() {  # <target> <text> <retries> <enter-sleep> 
 # `workspace list --json` with no `--window` is scoped to the CURRENT window
 # only (verified live), so the containing window is found by walking every
 # window from `list-windows --json` and asking each for its own scoped list.
-# The count comes straight from that window's `workspace_count` field.
+# The count comes from the same scoped workspace list that confirms membership.
 fm_backend_cmux_window_of_workspace() {  # <workspace_id> -> "<window_id> <count>"
-  local wsid=$1 wins wid cnt
+  local wsid=$1 wins wid wss count
   wins=$(fm_backend_cmux_cli list-windows --json --id-format uuids 2>/dev/null) || return 0
-  while IFS=$'\t' read -r wid cnt; do
+  while IFS= read -r wid; do
     [ -n "$wid" ] || continue
-    if fm_backend_cmux_cli workspace list --json --id-format uuids --window "$wid" 2>/dev/null \
-        | jq -e --arg id "$wsid" '[.workspaces[]? | select(.id == $id)] | length > 0' >/dev/null 2>&1; then
-      printf '%s %s' "$wid" "$cnt"
-      return 0
-    fi
-  done < <(printf '%s' "$wins" | jq -r '.[]? | "\(.id)\t\(.workspace_count)"' 2>/dev/null)
+    wss=$(fm_backend_cmux_cli workspace list --json --id-format uuids --window "$wid" 2>/dev/null) || continue
+    count=$(printf '%s' "$wss" | jq -er --arg id "$wsid" '
+      (.workspaces // []) as $workspaces
+      | select(any($workspaces[]?; .id == $id))
+      | ($workspaces | length)
+    ' 2>/dev/null) || continue
+    printf '%s %s' "$wid" "$count"
+    return 0
+  done < <(printf '%s' "$wins" | jq -r '.[]? | .id' 2>/dev/null)
 }
 
 # fm_backend_cmux_kill: remove the task's whole workspace, best-effort (mirrors

--- a/docs/cmux-backend.md
+++ b/docs/cmux-backend.md
@@ -280,7 +280,7 @@ $ cmux rpc window.close '{"window_id":"<win>"}'
 Exiting the surface's shell does not help either: cmux immediately respawns a fresh shell in a new surface (the surface id changes), so the last workspace/window is never left empty to collapse on its own.
 
 The reliable primitive is `close-workspace` on a workspace that is NOT the last in its window, so `fm_backend_cmux_kill` makes the target non-last first.
-`fm_backend_cmux_window_of_workspace` walks `list-windows --json` and each window's own `workspace list --json --window <id>` to find the target's window and that window's `workspace_count`.
+`fm_backend_cmux_window_of_workspace` walks `list-windows --json` and each window's own `workspace list --json --window <id>` to find the target's window and count the membership-confirming workspace-list response.
 When the count is one (last in window), kill creates a throwaway sibling in that same window - `new-workspace --window <win> --focus false`, an unnamed default that never carries an `fm-<home>-` title, so recovery and `list_live` ignore it - and only then closes the target.
 When the count is greater than one, kill closes the target directly, exactly as before, with no sibling.
 

--- a/docs/cmux-backend.md
+++ b/docs/cmux-backend.md
@@ -179,7 +179,7 @@ No session field is needed - unlike herdr/zellij there is no session layer to re
 | Bounded capture | `cmux read-screen --workspace <id> --surface <id> --scrollback --lines <N> --json`, trimmed locally with `tail` | No herdr-style small-N empty-result bug: N=1..10 all verified to return correctly-clamped, non-empty content on an already-interacted-with surface. A single call is still bounded by the surface's actual current viewport height regardless of the requested `--lines` value (verified: capped at 16 rows in a headless/no-attached-window test run), so "fetch generous, trim locally" is kept for consistency even though the specific herdr bug does not reproduce. |
 | Worktree-path discovery | marked active cwd probe + capture-scrape (`fm_backend_cmux_current_path`), NOT `current_directory` | `current_directory` DOES reflect a `cd` run directly in the surface's own top-level shell, but stays FROZEN at wherever that shell was when it launched a foreground subshell (exactly what `treehouse get` does) - zellij-shape, not herdr-shape. See "Worktree-path discovery: current_directory does not track a subshell" below. |
 | Busy state | *(no native primitive)* | cmux has agent-awareness elsewhere (Claude Code hooks integration, session-resume tokens) but exposes nothing over the socket API for generic busy/idle classification; `surface.health`/`surface-health` is render health, not agent status. `fm_backend_busy_state`'s dispatcher (`bin/fm-backend.sh`) falls through to `unknown` for cmux via its wildcard case, exactly like tmux/zellij/Orca - the watcher's existing pane-hash + regex path is the only busy-state source for this backend. |
-| Kill | `cmux close-workspace --workspace <id>` | See "Closing the last surface: a third shape" below. The backend owns the whole task workspace, so kill closes the whole workspace directly, best-effort (`\|\| true`), matching every other backend's `kill` contract. |
+| Kill | `cmux close-workspace --workspace <id>`, preceded by a throwaway `new-workspace --window <win> --focus false` when the target is the only workspace in its window | See "Closing the last workspace in a window" below. The backend owns the whole task workspace; kill closes it best-effort (`\|\| true`), but cmux silently refuses to close the LAST workspace in a window, so kill first detects that case (`fm_backend_cmux_window_of_workspace`) and adds a throwaway sibling before closing, matching every other backend's `kill` contract. |
 | Recovery / list-live | `cmux workspace list --json --id-format uuids`, filter titles starting with this home's `fm-<home-label>-`, then `list-panes` per match for the surface id | Title-based, never trusts a stored workspace uuid blindly - ids do NOT survive an app relaunch (see "Workspace ids do not survive a relaunch" below), so this is the only safe recovery posture. The adapter prints the plain `fm-<id>` label back to callers after stripping the readable home tag and `FM_ROOT` hash. |
 
 ## Socket control modes: the full matrix (default `cmuxOnly` rejects external CLIs)
@@ -237,8 +237,71 @@ Verified live: `cmux close-surface --workspace <id> --surface <id>` against a wo
 `cmux close-workspace --workspace <id>` against that same workspace succeeds cleanly, removing the whole workspace (surface included) in one call, verified with no ghost left behind afterward.
 
 Since every firstmate cmux task uses exactly one owned workspace, `close-workspace` is the correct teardown primitive.
-The no-mistakes review gate follow-up was captain-directed here too: `fm_backend_cmux_kill` now calls `close-workspace` directly and best-effort, reclaiming the whole task workspace and any surfaces inside it.
+The no-mistakes review gate follow-up was captain-directed here too: `fm_backend_cmux_kill` reclaims the whole task workspace and any surfaces inside it via `close-workspace`, best-effort.
 That matches the backend ownership invariant more closely than preserving user-added surfaces in a task workspace that firstmate is about to forget.
+There is one important caveat this section's "cleanly removes the whole workspace in one call" claim glosses over: `close-workspace` does that only when the target is NOT the last workspace in its window - the next section ("Closing the last workspace in a window") owns that case and the teardown fix it required.
+
+## Closing the last workspace in a window (the selected-workspace teardown fix)
+
+Verified live 2026-07-10 against the installed cmux 0.64.17 (build 97), macOS aarch64, socket in `automation` mode; the captain's app was not modified, relaunched, or reconfigured, and only `fm-test-` task workspaces and throwaway default workspaces were touched.
+
+The incident this fixes: a cmux-backed task's teardown left its workspace open because it was the currently selected workspace, and the crew closed it by hand.
+`close-workspace` cleanly removes a workspace ONLY when that workspace is not the last one in its window.
+cmux keeps every window at one or more workspaces, so `close-workspace` against the ONLY workspace in a window silently no-ops: it still prints `OK`, but the workspace stays.
+The last workspace in a window is always the selected one, so from the outside this reads as "the selected task workspace would not close" - but being selected is not itself the trigger.
+A workspace that is selected while sharing its window with another workspace closes normally (verified); being the last workspace in its window is the actual trigger.
+
+Evidence (workspace refs are session-relative, shown as observed):
+
+```
+# control: a NON-last workspace (its window holds another workspace too) closes cleanly
+$ cmux close-workspace --workspace <ws-A>
+OK workspace:2
+# -> <ws-A> gone from `workspace list`
+
+# the bug: the LAST/ONLY workspace in its window
+$ cmux close-workspace --workspace <ws-B>
+OK workspace:7
+# -> <ws-B> STILL PRESENT; its window still reports workspace_count=1 (silent no-op)
+```
+
+Neither window-closing primitive rescues it, because a window holding a live terminal session cannot be closed over the control socket:
+
+```
+$ cmux close-window --window <win>
+OK
+# -> <win> and its workspace STILL PRESENT
+
+$ cmux rpc window.close '{"window_id":"<win>"}'
+{ "window_id" : "<win>", "window_ref" : "window:2" }
+# -> STILL PRESENT
+```
+
+Exiting the surface's shell does not help either: cmux immediately respawns a fresh shell in a new surface (the surface id changes), so the last workspace/window is never left empty to collapse on its own.
+
+The reliable primitive is `close-workspace` on a workspace that is NOT the last in its window, so `fm_backend_cmux_kill` makes the target non-last first.
+`fm_backend_cmux_window_of_workspace` walks `list-windows --json` and each window's own `workspace list --json --window <id>` to find the target's window and that window's `workspace_count`.
+When the count is one (last in window), kill creates a throwaway sibling in that same window - `new-workspace --window <win> --focus false`, an unnamed default that never carries an `fm-<home>-` title, so recovery and `list_live` ignore it - and only then closes the target.
+When the count is greater than one, kill closes the target directly, exactly as before, with no sibling.
+
+```
+# the fix, end to end: real fm_backend_cmux_kill on a SELECTED, last-in-window fm-test task workspace
+$ fm_backend_cmux_window_of_workspace <ws-B>
+<win> 1
+$ cmux new-workspace --window <win> --focus false --id-format uuids
+OK workspace:9
+$ cmux close-workspace --workspace <ws-B>
+OK workspace:8
+# -> <ws-B> GONE; <win> survives with a fresh default workspace (title "zsh"/"~", never fm-*)
+```
+
+The window keeping a fresh default workspace is cmux's own "closed the last tab" outcome, not extra firstmate state; it is the closest reachable result to removing the task's workspace, given a window cannot be socket-closed.
+The branch logic (sibling-then-close when last, close-directly otherwise) is pinned in `tests/fm-backend-cmux.test.sh`; the live `window_of_workspace` window/count detection is pinned in `tests/fm-backend-cmux-smoke.test.sh`.
+The last-in-window path is not driven end to end in the automated smoke suite because closing the last workspace inherently leaves a window cmux cannot close over the socket, so a live end-to-end run cannot self-clean; the manual run recorded above is its empirical proof instead.
+
+Related current-window scoping, observed during this work and left out of scope for this fix: `workspace list --json` WITHOUT `--window` is scoped to the CURRENT window only (verified live).
+`fm_backend_cmux_window_of_workspace` passes `--window` per window and is unaffected, but `fm_backend_cmux_workspace_id_for_label` and `fm_backend_cmux_list_live` see only the current window's workspaces, and `fm_backend_cmux_target_ready`'s label recovery inherits that scope.
+That is correct for the selected-workspace teardown case (a selected workspace is in the current window) but is a known limitation for a task workspace parked in a non-current window.
 
 ## Workspace ids do not survive a relaunch (verified from source, not a live restart)
 
@@ -309,3 +372,4 @@ All three tasks' cmux workspaces and worktrees were confirmed fully cleaned up a
 - **The one-time socket-access setup is a real, undocumented-by-upstream onboarding step.** A captain who selects `backend=cmux` without first switching `automation.socketControlMode` away from its `cmuxOnly` default to a viable mode (Automation mode recommended; see "Setup") will see every spawn fail with an actionable error naming the viable modes and pointing back to this document, but there is no way for firstmate to complete that GUI-only setup step on the captain's behalf.
 - **Backend-specific bootstrap detection is absent** - `bin/fm-bootstrap.sh` does not conditionally add `cmux` and `jq` when a backend selection resolves to cmux, mirroring the same accepted gap already documented for herdr/zellij; the version/tool/reachability gate happens at spawn time instead and refuses loudly.
 - **A surface can still die in the brief window between `target_ready` succeeding and the operation's own call running.** That remaining race degrades to "the operation quietly did nothing" - the same class of gap firstmate already tolerates for an unverified send on any backend, caught downstream by `fm-spawn.sh`'s worktree-discovery poll timing out, `fm_backend_cmux_send_text_submit`'s retry loop (which reports `send-failed`/`pending`/`unknown` rather than a false "sent"), or the watcher's stale-pane detection.
+- **Windows cannot be closed over the control socket, and label lookup is current-window scoped** - both owned by "Closing the last workspace in a window" above. Teardown of a last-in-window task workspace therefore leaves that window a fresh default workspace rather than closing it, and `fm_backend_cmux_workspace_id_for_label`/`fm_backend_cmux_list_live` only see the current window, so a task workspace parked in a non-current window is a known blind spot for label-based recovery.

--- a/docs/cmux-backend.md
+++ b/docs/cmux-backend.md
@@ -6,7 +6,8 @@ It is the cmux equivalent of the tmux facts recorded in the `harness-adapters` s
 cmux is [a Ghostty-based macOS terminal](https://cmux.com) built for AI coding agents, with vertical tabs, notifications, and a CLI/socket JSON-RPC control API (`cmux <verb> ...`).
 Verified against the real installed app: cmux 0.64.17 (build 97), macOS aarch64.
 The feasibility investigation that preceded this build (`data/cmux-backend-feasibility-c7/report.md`) verified the app's CLI surface from source only, flagging a live install-and-poke pass as the remaining gate; that pass is what this document and `tests/fm-backend-cmux-smoke.test.sh` record.
-All real-cmux verification here and in the smoke test creates only `fm-test-`-prefixed workspaces, touches and closes only what it created, never enumerates-and-closes, and never quits or relaunches the app - the same discipline `tests/herdr-test-safety.sh`/`tests/zellij-test-safety.sh` established for their backends, adapted in `tests/cmux-test-safety.sh` to cmux's shape (there is no isolated, throwaway session to spin up - cmux is one shared, GUI-first app instance, the same posture as Orca).
+All real-cmux verification here and in the smoke test creates only `fm-test-`-prefixed task workspaces, with one documented exception: the manual last-in-window verification also creates the unnamed default sibling cmux requires to close that task workspace.
+It never enumerates-and-closes, touches no existing workspace, closes only its own `fm-test-` task workspaces, and never quits or relaunches the app - the same discipline `tests/herdr-test-safety.sh`/`tests/zellij-test-safety.sh` established for their backends, adapted in `tests/cmux-test-safety.sh` to cmux's shape (there is no isolated, throwaway session to spin up - cmux is one shared, GUI-first app instance, the same posture as Orca).
 
 ## Setup
 
@@ -179,7 +180,7 @@ No session field is needed - unlike herdr/zellij there is no session layer to re
 | Bounded capture | `cmux read-screen --workspace <id> --surface <id> --scrollback --lines <N> --json`, trimmed locally with `tail` | No herdr-style small-N empty-result bug: N=1..10 all verified to return correctly-clamped, non-empty content on an already-interacted-with surface. A single call is still bounded by the surface's actual current viewport height regardless of the requested `--lines` value (verified: capped at 16 rows in a headless/no-attached-window test run), so "fetch generous, trim locally" is kept for consistency even though the specific herdr bug does not reproduce. |
 | Worktree-path discovery | marked active cwd probe + capture-scrape (`fm_backend_cmux_current_path`), NOT `current_directory` | `current_directory` DOES reflect a `cd` run directly in the surface's own top-level shell, but stays FROZEN at wherever that shell was when it launched a foreground subshell (exactly what `treehouse get` does) - zellij-shape, not herdr-shape. See "Worktree-path discovery: current_directory does not track a subshell" below. |
 | Busy state | *(no native primitive)* | cmux has agent-awareness elsewhere (Claude Code hooks integration, session-resume tokens) but exposes nothing over the socket API for generic busy/idle classification; `surface.health`/`surface-health` is render health, not agent status. `fm_backend_busy_state`'s dispatcher (`bin/fm-backend.sh`) falls through to `unknown` for cmux via its wildcard case, exactly like tmux/zellij/Orca - the watcher's existing pane-hash + regex path is the only busy-state source for this backend. |
-| Kill | `cmux close-workspace --workspace <id>`, preceded by a throwaway `new-workspace --window <win> --focus false` when the target is the only workspace in its window | See "Closing the last workspace in a window" below. The backend owns the whole task workspace; kill closes it best-effort (`\|\| true`), but cmux silently refuses to close the LAST workspace in a window, so kill first detects that case (`fm_backend_cmux_window_of_workspace`) and adds a throwaway sibling before closing, matching every other backend's `kill` contract. |
+| Kill | `cmux close-workspace --workspace <id>`, preceded by a throwaway `new-workspace --window <win> --focus false --id-format uuids` when the target is the only workspace in its window | See "Closing the last workspace in a window" below. The backend owns the whole task workspace; kill closes it best-effort (`\|\| true`), but cmux silently refuses to close the LAST workspace in a window, so kill first detects that case (`fm_backend_cmux_window_of_workspace`) and adds a throwaway sibling before closing, matching every other backend's `kill` contract. |
 | Recovery / list-live | `cmux workspace list --json --id-format uuids`, filter titles starting with this home's `fm-<home-label>-`, then `list-panes` per match for the surface id | Title-based, never trusts a stored workspace uuid blindly - ids do NOT survive an app relaunch (see "Workspace ids do not survive a relaunch" below), so this is the only safe recovery posture. The adapter prints the plain `fm-<id>` label back to callers after stripping the readable home tag and `FM_ROOT` hash. |
 
 ## Socket control modes: the full matrix (default `cmuxOnly` rejects external CLIs)
@@ -234,12 +235,10 @@ Verified against the real binary in both shapes: a direct `cd` in the surface's 
 The design sketch anticipated two possibilities for closing a workspace's last surface - herdr-shape (auto-closes the whole workspace) or zellij-shape (leaves an empty "ghost" workspace) - and planned to verify which one live.
 Neither turned out to be correct: cmux implements a **third** shape.
 Verified live: `cmux close-surface --workspace <id> --surface <id>` against a workspace's LAST remaining surface **refuses outright** with a typed error, `Error: invalid_state: Cannot close the last surface`, leaving both the surface and the workspace completely untouched - no partial state, no ghost.
-`cmux close-workspace --workspace <id>` against that same workspace succeeds cleanly, removing the whole workspace (surface included) in one call, verified with no ghost left behind afterward.
+`cmux close-workspace --workspace <id>` against that same workspace succeeds cleanly, removing the whole workspace (surface included) in one call, only when it is not the last workspace in its window.
 
-Since every firstmate cmux task uses exactly one owned workspace, `close-workspace` is the correct teardown primitive.
-The no-mistakes review gate follow-up was captain-directed here too: `fm_backend_cmux_kill` reclaims the whole task workspace and any surfaces inside it via `close-workspace`, best-effort.
-That matches the backend ownership invariant more closely than preserving user-added surfaces in a task workspace that firstmate is about to forget.
-There is one important caveat this section's "cleanly removes the whole workspace in one call" claim glosses over: `close-workspace` does that only when the target is NOT the last workspace in its window - the next section ("Closing the last workspace in a window") owns that case and the teardown fix it required.
+Since every firstmate cmux task uses exactly one owned workspace, `close-workspace` remains the correct teardown primitive.
+The next section ("Closing the last workspace in a window") owns the last-in-window exception and `fm_backend_cmux_kill`'s best-effort workaround, which still reclaims every surface in the task workspace.
 
 ## Closing the last workspace in a window (the selected-workspace teardown fix)
 
@@ -281,7 +280,7 @@ Exiting the surface's shell does not help either: cmux immediately respawns a fr
 
 The reliable primitive is `close-workspace` on a workspace that is NOT the last in its window, so `fm_backend_cmux_kill` makes the target non-last first.
 `fm_backend_cmux_window_of_workspace` walks `list-windows --json` and each window's own `workspace list --json --window <id>` to find the target's window and count the membership-confirming workspace-list response.
-When the count is one (last in window), kill creates a throwaway sibling in that same window - `new-workspace --window <win> --focus false`, an unnamed default that never carries an `fm-<home>-` title, so recovery and `list_live` ignore it - and only then closes the target.
+When the count is one (last in window), kill creates a throwaway sibling in that same window - `new-workspace --window <win> --focus false --id-format uuids`, an unnamed default that never carries an `fm-<home>-` title, so recovery and `list_live` ignore it - and only then closes the target.
 When the count is greater than one, kill closes the target directly, exactly as before, with no sibling.
 
 ```
@@ -296,7 +295,8 @@ OK workspace:8
 ```
 
 The window keeping a fresh default workspace is cmux's own "closed the last tab" outcome, not extra firstmate state; it is the closest reachable result to removing the task's workspace, given a window cannot be socket-closed.
-The branch logic (sibling-then-close when last, close-directly otherwise) is pinned in `tests/fm-backend-cmux.test.sh`; the live `window_of_workspace` window/count detection is pinned in `tests/fm-backend-cmux-smoke.test.sh`.
+The helper and both branches are pinned in `tests/fm-backend-cmux.test.sh` by `test_window_of_workspace_finds_window_and_count`, `test_window_of_workspace_empty_when_not_found`, `test_kill_closes_workspace_directly_when_not_last`, and `test_kill_adds_sibling_when_last_in_window`.
+The live `window_of_workspace` window/count detection is pinned in `tests/fm-backend-cmux-smoke.test.sh`.
 The last-in-window path is not driven end to end in the automated smoke suite because closing the last workspace inherently leaves a window cmux cannot close over the socket, so a live end-to-end run cannot self-clean; the manual run recorded above is its empirical proof instead.
 
 Related current-window scoping, observed during this work and left out of scope for this fix: `workspace list --json` WITHOUT `--window` is scoped to the CURRENT window only (verified live).

--- a/tests/fm-backend-cmux-smoke.test.sh
+++ b/tests/fm-backend-cmux-smoke.test.sh
@@ -139,6 +139,26 @@ bs=$(fm_backend_busy_state cmux "$TARGET")
 [ "$bs" = unknown ] || fail "fm_backend_busy_state should report unknown for cmux (no native primitive), got '$bs'"
 pass "real cmux: fm_backend_busy_state reports unknown (watcher falls back to pane-regex, same as tmux/zellij/orca)"
 
+# --- window_of_workspace: real-cmux window/count detection -------------------
+# The last-workspace-in-a-window teardown fix (docs/cmux-backend.md "Closing the
+# last workspace in a window") pivots on window_of_workspace reading the live
+# `list-windows` / `workspace list --window` JSON correctly (the version-fragile
+# part the fake-CLI suite cannot prove). This task workspace shares its window
+# with at least the app's own workspace, so it reports "<window_id> <count>"
+# with a count of two or more. The last-in-window branch itself is proven end to
+# end in the fake-CLI suite and in this document's manual verification record;
+# it is not driven live here because closing the last workspace inherently
+# leaves a window cmux cannot close over the control socket.
+WININFO=$(fm_backend_cmux_window_of_workspace "$WS1")
+case "$WININFO" in
+  *' '[0-9]*) : ;;
+  *) fail "window_of_workspace did not report '<window_id> <count>' for a live task workspace, got '$WININFO'" ;;
+esac
+WCOUNT=${WININFO##* }
+[ "$WCOUNT" -ge 2 ] 2>/dev/null \
+  || fail "task workspace shares its window with the app default, so the count should be >= 2, got '$WININFO'"
+pass "real cmux: window_of_workspace locates a task workspace's window and counts its workspaces"
+
 # --- kill: whole-workspace close ----------------------------------------------
 
 fm_backend_cmux_kill "$TARGET"

--- a/tests/fm-backend-cmux.test.sh
+++ b/tests/fm-backend-cmux.test.sh
@@ -848,7 +848,7 @@ test_window_of_workspace_finds_window_and_count() {
   local dir fb out
   dir="$TMP_ROOT/win-of-ws"; mkdir -p "$dir/responses"
   # 1: list-windows --json -> two windows
-  cmux_windows_response "$dir" 1 "e1111111-0000-0000-0000-000000000000" 2 "e2222222-0000-0000-0000-000000000000" 1
+  cmux_windows_response "$dir" 1 "e1111111-0000-0000-0000-000000000000" 2 "e2222222-0000-0000-0000-000000000000" 2
   # 2: workspace list --window e1111111 -> does NOT contain the target
   cmux_workspace_list_response "$dir" 2 "ffffffff-0000-0000-0000-000000000000" "other"
   # 3: workspace list --window e2222222 -> contains the target
@@ -857,10 +857,10 @@ test_window_of_workspace_finds_window_and_count() {
   out=$( PATH="$fb:$PATH" FM_CMUX_LOG="$dir/log" FM_CMUX_RESPONSES="$dir/responses" \
     bash -c '. "$0/bin/backends/cmux.sh"; fm_backend_cmux_window_of_workspace "aaaaaaaa-0000-0000-0000-000000000000"' "$ROOT" )
   [ "$out" = "e2222222-0000-0000-0000-000000000000 1" ] \
-    || fail "window_of_workspace should echo '<window_id> <count>' for the owning window, got '$out'"
+    || fail "window_of_workspace should echo the owning window and its matched-list count, got '$out'"
   cmux_assert_call_order "$dir/log" $'\x1f''list-windows' $'\x1f''workspace'$'\x1f''list'$'\x1f''--json'$'\x1f''--id-format'$'\x1f''uuids'$'\x1f''--window'$'\x1f''e1111111-0000-0000-0000-000000000000' \
     "window_of_workspace did not list windows before scanning per-window workspaces"
-  pass "fm_backend_cmux_window_of_workspace: walks windows and reports the owner window id plus its workspace count"
+  pass "fm_backend_cmux_window_of_workspace: walks windows and counts the membership-confirming workspace list"
 }
 
 test_window_of_workspace_empty_when_not_found() {
@@ -885,7 +885,7 @@ test_kill_closes_workspace_directly_when_not_last() {
   # 1: list-windows -> the owning window has 2 workspaces (target is NOT last)
   cmux_windows_response "$dir" 1 "eeeeeeee-0000-0000-0000-000000000000" 2
   # 2: workspace list --window eeeeeeee -> contains the target
-  cmux_workspace_list_response "$dir" 2 "aaaaaaaa-0000-0000-0000-000000000000" "the-task"
+  cmux_workspace_list_response "$dir" 2 "aaaaaaaa-0000-0000-0000-000000000000" "the-task" "ffffffff-0000-0000-0000-000000000000" "other"
   fb=$(make_cmux_fakebin "$dir")
   PATH="$fb:$PATH" FM_CMUX_LOG="$dir/log" FM_CMUX_RESPONSES="$dir/responses" \
     bash -c '. "$0/bin/backends/cmux.sh"; fm_backend_cmux_kill "aaaaaaaa-0000-0000-0000-000000000000:bbbbbbbb-1111-1111-1111-111111111111"' "$ROOT"
@@ -904,8 +904,7 @@ test_kill_closes_workspace_directly_when_not_last() {
 test_kill_adds_sibling_when_last_in_window() {
   local dir fb
   dir="$TMP_ROOT/kill-last-in-window"; mkdir -p "$dir/responses"
-  # 1: list-windows -> the owning window has exactly 1 workspace (target IS last)
-  cmux_windows_response "$dir" 1 "eeeeeeee-0000-0000-0000-000000000000" 1
+  cmux_windows_response "$dir" 1 "eeeeeeee-0000-0000-0000-000000000000" 2
   # 2: workspace list --window eeeeeeee -> contains the target
   cmux_workspace_list_response "$dir" 2 "aaaaaaaa-0000-0000-0000-000000000000" "the-task"
   fb=$(make_cmux_fakebin "$dir")
@@ -929,7 +928,7 @@ test_kill_is_best_effort_when_close_workspace_fails() {
   dir="$TMP_ROOT/kill-workspace-fail"; mkdir -p "$dir/responses"
   # 1: list-windows (not last), 2: workspace list --window, 3: close-workspace fails
   cmux_windows_response "$dir" 1 "eeeeeeee-0000-0000-0000-000000000000" 2
-  cmux_workspace_list_response "$dir" 2 "aaaaaaaa-0000-0000-0000-000000000000" "the-task"
+  cmux_workspace_list_response "$dir" 2 "aaaaaaaa-0000-0000-0000-000000000000" "the-task" "ffffffff-0000-0000-0000-000000000000" "other"
   printf '1\n' > "$dir/responses/3.exit"
   fb=$(make_cmux_fakebin "$dir")
   PATH="$fb:$PATH" FM_CMUX_LOG="$dir/log" FM_CMUX_RESPONSES="$dir/responses" \
@@ -953,7 +952,7 @@ test_kill_recovers_stale_target_by_label() {
   cmux_panes_response "$dir" 3 "dddddddd-3333-3333-3333-333333333333"
   # window_of_workspace on the REFRESHED id: 4 list-windows (not last), 5 workspace list --window.
   cmux_windows_response "$dir" 4 "eeeeeeee-0000-0000-0000-000000000000" 2
-  cmux_workspace_list_response "$dir" 5 "cccccccc-2222-2222-2222-222222222222" "$title"
+  cmux_workspace_list_response "$dir" 5 "cccccccc-2222-2222-2222-222222222222" "$title" "ffffffff-0000-0000-0000-000000000000" "other"
   fb=$(make_cmux_fakebin "$dir")
   PATH="$fb:$PATH" FM_CMUX_LOG="$dir/log" FM_CMUX_RESPONSES="$dir/responses" \
     bash -c '. "$0/bin/backends/cmux.sh"; fm_backend_cmux_kill "aaaaaaaa-0000-0000-0000-000000000000:bbbbbbbb-1111-1111-1111-111111111111" "" fm-label' "$ROOT"

--- a/tests/fm-backend-cmux.test.sh
+++ b/tests/fm-backend-cmux.test.sh
@@ -83,6 +83,20 @@ cmux_panes_response() {  # <dir> <n> <surface_id>
   printf '{"panes":[{"selected_surface_id":"%s","surface_ids":["%s"]}]}' "$3" "$3" > "$1/responses/$2.out"
 }
 
+cmux_windows_response() {  # <dir> <n> <window_id1> <count1> [<window_id2> <count2> ...]
+  local dir=$1 n=$2 json first=1
+  shift 2
+  json='['
+  while [ $# -ge 2 ]; do
+    [ "$first" -eq 1 ] || json="$json,"
+    json="$json{\"id\":\"$1\",\"workspace_count\":$2}"
+    first=0
+    shift 2
+  done
+  json="$json]"
+  printf '%s' "$json" > "$dir/responses/$n.out"
+}
+
 cmux_panes_empty_response() {  # <dir> <n>
   printf '{"panes":[]}' > "$1/responses/$2.out"
 }
@@ -828,25 +842,95 @@ test_send_text_submit_send_failed_when_target_absent() {
   pass "fm_backend_cmux_send_text_submit: reports 'send-failed' when the target workspace/surface is absent"
 }
 
-# --- kill: close whole workspace ---------------------------------------------
+# --- window_of_workspace: which window holds a workspace, and its count ------
 
-test_kill_closes_workspace_directly() {
+test_window_of_workspace_finds_window_and_count() {
+  local dir fb out
+  dir="$TMP_ROOT/win-of-ws"; mkdir -p "$dir/responses"
+  # 1: list-windows --json -> two windows
+  cmux_windows_response "$dir" 1 "e1111111-0000-0000-0000-000000000000" 2 "e2222222-0000-0000-0000-000000000000" 1
+  # 2: workspace list --window e1111111 -> does NOT contain the target
+  cmux_workspace_list_response "$dir" 2 "ffffffff-0000-0000-0000-000000000000" "other"
+  # 3: workspace list --window e2222222 -> contains the target
+  cmux_workspace_list_response "$dir" 3 "aaaaaaaa-0000-0000-0000-000000000000" "the-task"
+  fb=$(make_cmux_fakebin "$dir")
+  out=$( PATH="$fb:$PATH" FM_CMUX_LOG="$dir/log" FM_CMUX_RESPONSES="$dir/responses" \
+    bash -c '. "$0/bin/backends/cmux.sh"; fm_backend_cmux_window_of_workspace "aaaaaaaa-0000-0000-0000-000000000000"' "$ROOT" )
+  [ "$out" = "e2222222-0000-0000-0000-000000000000 1" ] \
+    || fail "window_of_workspace should echo '<window_id> <count>' for the owning window, got '$out'"
+  cmux_assert_call_order "$dir/log" $'\x1f''list-windows' $'\x1f''workspace'$'\x1f''list'$'\x1f''--json'$'\x1f''--id-format'$'\x1f''uuids'$'\x1f''--window'$'\x1f''e1111111-0000-0000-0000-000000000000' \
+    "window_of_workspace did not list windows before scanning per-window workspaces"
+  pass "fm_backend_cmux_window_of_workspace: walks windows and reports the owner window id plus its workspace count"
+}
+
+test_window_of_workspace_empty_when_not_found() {
+  local dir fb out
+  dir="$TMP_ROOT/win-of-ws-none"; mkdir -p "$dir/responses"
+  cmux_windows_response "$dir" 1 "e1111111-0000-0000-0000-000000000000" 1
+  cmux_workspace_list_response "$dir" 2 "ffffffff-0000-0000-0000-000000000000" "other"
+  fb=$(make_cmux_fakebin "$dir")
+  out=$( PATH="$fb:$PATH" FM_CMUX_LOG="$dir/log" FM_CMUX_RESPONSES="$dir/responses" \
+    bash -c '. "$0/bin/backends/cmux.sh"; fm_backend_cmux_window_of_workspace "aaaaaaaa-0000-0000-0000-000000000000"' "$ROOT" )
+  [ -z "$out" ] || fail "window_of_workspace should echo nothing when the workspace is not found, got '$out'"
+  pass "fm_backend_cmux_window_of_workspace: echoes nothing when no window holds the workspace"
+}
+
+# --- kill: close the task workspace, adding a sibling when it is the last one -
+
+# The common case: the task workspace shares its window with at least one other
+# workspace, so cmux closes it directly with no sibling dance.
+test_kill_closes_workspace_directly_when_not_last() {
   local dir fb
   dir="$TMP_ROOT/kill-workspace"; mkdir -p "$dir/responses"
+  # 1: list-windows -> the owning window has 2 workspaces (target is NOT last)
+  cmux_windows_response "$dir" 1 "eeeeeeee-0000-0000-0000-000000000000" 2
+  # 2: workspace list --window eeeeeeee -> contains the target
+  cmux_workspace_list_response "$dir" 2 "aaaaaaaa-0000-0000-0000-000000000000" "the-task"
   fb=$(make_cmux_fakebin "$dir")
   PATH="$fb:$PATH" FM_CMUX_LOG="$dir/log" FM_CMUX_RESPONSES="$dir/responses" \
     bash -c '. "$0/bin/backends/cmux.sh"; fm_backend_cmux_kill "aaaaaaaa-0000-0000-0000-000000000000:bbbbbbbb-1111-1111-1111-111111111111"' "$ROOT"
   assert_contains "$(cat "$dir/log")" $'\x1f''close-workspace'$'\x1f''--workspace'$'\x1f''aaaaaaaa-0000-0000-0000-000000000000' \
     "kill did not close the task workspace"
+  assert_not_contains "$(cat "$dir/log")" $'\x1f''new-workspace' \
+    "kill should not add a sibling workspace when the target is not the last one in its window"
   assert_not_contains "$(cat "$dir/log")" $'\x1f''close-surface' \
     "kill should close the whole workspace directly"
-  pass "fm_backend_cmux_kill: closes the whole task workspace directly"
+  pass "fm_backend_cmux_kill: closes the task workspace directly when it is not the last in its window"
+}
+
+# The selected-workspace teardown bug: cmux refuses to close the only workspace
+# in a window (returns OK but no-ops), so kill first creates a throwaway sibling
+# and only then closes the target - which now succeeds.
+test_kill_adds_sibling_when_last_in_window() {
+  local dir fb
+  dir="$TMP_ROOT/kill-last-in-window"; mkdir -p "$dir/responses"
+  # 1: list-windows -> the owning window has exactly 1 workspace (target IS last)
+  cmux_windows_response "$dir" 1 "eeeeeeee-0000-0000-0000-000000000000" 1
+  # 2: workspace list --window eeeeeeee -> contains the target
+  cmux_workspace_list_response "$dir" 2 "aaaaaaaa-0000-0000-0000-000000000000" "the-task"
+  fb=$(make_cmux_fakebin "$dir")
+  PATH="$fb:$PATH" FM_CMUX_LOG="$dir/log" FM_CMUX_RESPONSES="$dir/responses" \
+    bash -c '. "$0/bin/backends/cmux.sh"; fm_backend_cmux_kill "aaaaaaaa-0000-0000-0000-000000000000:bbbbbbbb-1111-1111-1111-111111111111"' "$ROOT"
+  assert_contains "$(cat "$dir/log")" $'\x1f''new-workspace'$'\x1f''--window'$'\x1f''eeeeeeee-0000-0000-0000-000000000000'$'\x1f''--focus'$'\x1f''false' \
+    "kill did not add a throwaway sibling in the target's own window before closing the last workspace"
+  assert_not_contains "$(cat "$dir/log")" $'\x1f''new-workspace'$'\x1f''--name' \
+    "the throwaway sibling must stay an unnamed default workspace, never an fm- task title"
+  assert_contains "$(cat "$dir/log")" $'\x1f''close-workspace'$'\x1f''--workspace'$'\x1f''aaaaaaaa-0000-0000-0000-000000000000' \
+    "kill did not close the target workspace after adding the sibling"
+  cmux_assert_call_order "$dir/log" $'\x1f''new-workspace'$'\x1f''--window' $'\x1f''close-workspace'$'\x1f''--workspace'$'\x1f''aaaaaaaa-0000-0000-0000-000000000000' \
+    "kill must add the sibling BEFORE closing the last workspace, or the close still no-ops"
+  assert_not_contains "$(cat "$dir/log")" $'\x1f''close-surface' \
+    "kill should not call close-surface"
+  pass "fm_backend_cmux_kill: adds a throwaway sibling then closes the target when it is the last workspace in its window"
 }
 
 test_kill_is_best_effort_when_close_workspace_fails() {
   local dir fb
   dir="$TMP_ROOT/kill-workspace-fail"; mkdir -p "$dir/responses"
-  printf '1\n' > "$dir/responses/1.exit"
+  # 1: list-windows (not last), 2: workspace list --window, 3: close-workspace fails
+  cmux_windows_response "$dir" 1 "eeeeeeee-0000-0000-0000-000000000000" 2
+  cmux_workspace_list_response "$dir" 2 "aaaaaaaa-0000-0000-0000-000000000000" "the-task"
+  printf '1\n' > "$dir/responses/3.exit"
   fb=$(make_cmux_fakebin "$dir")
   PATH="$fb:$PATH" FM_CMUX_LOG="$dir/log" FM_CMUX_RESPONSES="$dir/responses" \
     bash -c '. "$0/bin/backends/cmux.sh"; fm_backend_cmux_kill "aaaaaaaa-0000-0000-0000-000000000000:bbbbbbbb-1111-1111-1111-111111111111"' "$ROOT"
@@ -862,9 +946,14 @@ test_kill_recovers_stale_target_by_label() {
   local dir fb title
   dir="$TMP_ROOT/kill-stale-target"; mkdir -p "$dir/responses"
   title=$(cmux_expected_scoped_title fm-label)
+  # target_ready label recovery: 1 workspace list (title lookup, misses stale id),
+  # 2 workspace list (id-for-label -> refreshed id), 3 list-panes (surface id).
   cmux_workspace_list_response "$dir" 1 "cccccccc-2222-2222-2222-222222222222" "$title"
   cmux_workspace_list_response "$dir" 2 "cccccccc-2222-2222-2222-222222222222" "$title"
   cmux_panes_response "$dir" 3 "dddddddd-3333-3333-3333-333333333333"
+  # window_of_workspace on the REFRESHED id: 4 list-windows (not last), 5 workspace list --window.
+  cmux_windows_response "$dir" 4 "eeeeeeee-0000-0000-0000-000000000000" 2
+  cmux_workspace_list_response "$dir" 5 "cccccccc-2222-2222-2222-222222222222" "$title"
   fb=$(make_cmux_fakebin "$dir")
   PATH="$fb:$PATH" FM_CMUX_LOG="$dir/log" FM_CMUX_RESPONSES="$dir/responses" \
     bash -c '. "$0/bin/backends/cmux.sh"; fm_backend_cmux_kill "aaaaaaaa-0000-0000-0000-000000000000:bbbbbbbb-1111-1111-1111-111111111111" "" fm-label' "$ROOT"
@@ -965,7 +1054,10 @@ test_send_text_submit_detects_landed_send
 test_send_text_submit_detects_swallowed_enter
 test_send_text_submit_popup_autocomplete_requires_second_enter
 test_send_text_submit_send_failed_when_target_absent
-test_kill_closes_workspace_directly
+test_window_of_workspace_finds_window_and_count
+test_window_of_workspace_empty_when_not_found
+test_kill_closes_workspace_directly_when_not_last
+test_kill_adds_sibling_when_last_in_window
 test_kill_is_best_effort_when_close_workspace_fails
 test_kill_recovers_stale_target_by_label
 test_list_live_filters_by_title_prefix


### PR DESCRIPTION
## Intent

Fix fm-teardown.sh failing to close a cmux workspace when it is the currently SELECTED workspace in the cmux app.

Root cause, reproduced live against real cmux 0.64.17: cmux keeps every window at >=1 workspace, so close-workspace on the ONLY workspace in a window silently no-ops (returns OK but the workspace stays). The last workspace in a window is always the selected one, which is why this presented as 'the selected workspace will not close'; a merely-selected workspace that shares its window with another closes fine. close-window and raw window.close also no-op for a window holding a live terminal session (cmux cannot close such a window over the control socket), and exiting the shell just makes cmux respawn a surface, so none of those are viable rescues.

Chosen fix in bin/backends/cmux.sh: add fm_backend_cmux_window_of_workspace, which walks list-windows --json plus each window's own 'workspace list --window' (because 'workspace list' without --window is scoped to the current window only), to detect when the target is the last workspace in its window. fm_backend_cmux_kill then creates a throwaway DEFAULT sibling workspace (new-workspace --window <win> --focus false, deliberately UNNAMED so it never carries an fm-<home>- title and recovery/list_live ignore it) before closing the target, so the close lands. The window keeps a fresh default workspace, which is cmux's own 'closed the last tab' outcome and the closest reachable result given a window cannot be socket-closed. Non-last teardown closes directly, exactly as before, with no sibling.

Deliberate scope decisions a diff-only reviewer would not know: (1) the guarded-cleanup safety contract in tests/cmux-test-safety.sh is intentionally left UNCHANGED - the fix only ever closes the target task workspace and never enumerates or closes non-target workspaces; the created sibling is a new default workspace, not a close. (2) The last-in-window path is covered by fake-CLI unit tests (both branches + the helper) plus a manual real-cmux verification recorded in docs/cmux-backend.md, but intentionally NOT by an automated real-cmux smoke test, because closing the last workspace inherently leaves a window cmux cannot socket-close, so a live end-to-end test cannot self-clean; the smoke test instead covers the version-fragile window/count detection primitive residue-free. (3) A related current-window-scoping limitation of 'workspace list' (affecting label-based recovery only for a task parked in a NON-current window) was observed and documented as out-of-scope rather than fixed, to keep the change tight.

This is a firstmate-repo change following the firstmate coding guidelines: the durable backend knowledge is placed in docs/cmux-backend.md (not the top-level AGENTS.md operating contract), with one-owner cross-references; scripts stay shellcheck-clean; tracked Markdown is one-sentence-per-line with plain dashes.

## What Changed

- Locate a task workspace's containing cmux window and count its member workspaces from the same per-window response.
- During teardown, add an unfocused unnamed sibling before closing a task workspace that is last in its window, while retaining direct closure for other workspaces.
- Document cmux's last-workspace behavior, including the retained default workspace after teardown and current-window discovery limitations.

## Risk Assessment

✅ Low: Captain, the change is narrowly scoped to cmux teardown and now derives the workspace count from the membership-confirming response.

## Testing

The supplied full-suite baseline passed; targeted cmux tests passed; a controlled end-to-end adapter transcript exercised last and shared-window teardown paths; and live cmux 0.64.17 answered PONG. No UI screenshot applies to this shell-backend change, and no lint or static analysis was run per instruction.

<details>
<summary>Evidence: cmux teardown behavior transcript</summary>

`Last-workspace teardown creates an unnamed sibling before closing only the task workspace; shared-window teardown closes directly without a sibling.`

```text

Scenario: last workspace in its cmux window
Adapter exit: 0
Observed cmux control-socket calls:
  list-windows --json --id-format uuids
  workspace list --json --id-format uuids --window window-last
  new-workspace --window window-last --focus false --id-format uuids
  close-workspace --workspace workspace-task
Result: unnamed sibling created before closing only the task workspace.

Scenario: shared workspace in its cmux window
Adapter exit: 0
Observed cmux control-socket calls:
  list-windows --json --id-format uuids
  workspace list --json --id-format uuids --window window-shared
  close-workspace --workspace workspace-task
Result: task workspace closed directly; no sibling was created.
```
</details>
<details>
<summary>Evidence: targeted cmux unit-test log</summary>

```text
ok - fm_backend_cmux_version_check: accepts the verified minimum (0.64.17)
ok - fm_backend_cmux_version_check: accepts a newer version (0.70.0)
ok - fm_backend_cmux_version_check: refuses an old version loudly
ok - fm_backend_cmux_version_check: refuses loudly when cmux is not found on PATH or at the bundle path
ok - fm_backend_cmux_password: reads the first non-empty line of config/cmux-socket-password
ok - fm_backend_cmux_password: preserves spaces and tabs in config/cmux-socket-password
ok - fm_backend_cmux_password: respects FM_CONFIG_OVERRIDE
ok - fm_backend_cmux_password: empty when config/cmux-socket-password is absent
ok - fm_backend_cmux_cli: exports CMUX_SOCKET_PASSWORD when config/cmux-socket-password is set
ok - fm_backend_cmux_parse_target: splits '<workspace_uuid>:<surface_uuid>' on the first colon
ok - fm_backend_cmux_normalize_key: Enter/Escape/C-c map to cmux's verified enter/escape/ctrl-c
ok - fm_backend_cmux_scoped_title: scopes a primary task title with firstmate plus root hash
ok - fm_backend_cmux_scoped_title: scopes a secondmate task title with the home marker plus root hash
ok - fm_backend_cmux_scoped_title: includes the resolved FM_ROOT hash in the home label
ok - fm_backend_validate: cmux is a known backend
ok - fm_backend_busy_state: cmux (no native primitive) always reports unknown, same as tmux/zellij/orca
ok - fm_backend_composer_state: routes cmux to the cmux composer classifier
ok - fm_backend_cmux_ping_state: reports 'ok' on PONG
ok - fm_backend_cmux_ping_state: reports 'denied' when socketControlMode=cmuxOnly rejects the connection
ok - fm_backend_cmux_ping_state: reports 'unauth' when password mode rejects a missing/wrong password
ok - fm_backend_cmux_ping_state: reports 'unauth' when password mode rejects a wrong password (Invalid password)
ok - fm_backend_cmux_ping_state: reports 'down' when the app is not running yet
ok - fm_backend_cmux_ensure_running: returns immediately when cmux is already reachable
ok - fm_backend_cmux_ensure_running: fails fast on a denied socket without attempting to launch, naming every viable mode
ok - fm_backend_cmux_ensure_running: fails fast on an unauthenticated socket, naming the password config and the Automation mode alternative
ok - fm_backend_cmux_create_task: refuses a duplicate workspace title (cmux's own new-workspace has no uniqueness check)
ok - fm_backend_cmux_create_task: creates a workspace and parses workspace_id/surface_id from list responses
ok - fm_backend_cmux_target_ready: fails when the workspace/surface is not found (list-panes structural check)
ok - fm_backend_cmux_target_ready: verifies the workspace title against the expected label first
ok - fm_backend_cmux_target_ready: rejects a workspace id reused under a different title
ok - fm_backend_cmux_capture: fetches generously and trims to N lines locally
ok - fm_backend_cmux_capture: propagates a read-screen failure even when stdout is empty
ok - fm_backend_cmux_capture: fails when the target surface is absent
ok - fm_backend_cmux_send_key: normalizes the key (Escape -> escape) and targets the explicit workspace/surface
ok - fm_backend_cmux_send_key: recovers stale workspace/surface ids by expected label
ok - fm_backend_cmux_send_literal: calls send with an explicit workspace/surface and a -- separator
ok - fm_backend_cmux_current_path: actively probes with marked begin/end lines (zellij-shape frozen cwd)
ok - fm_backend_cmux_composer_state: a bare '❯' composer row reads empty
ok - fm_backend_cmux_composer_state: the ghost placeholder text reads empty, not pending
ok - fm_backend_cmux_composer_state: real composer text reads pending
ok - fm_backend_cmux_composer_state: a slash-command popup's argument-hint placeholder still reads pending (the incident fix)
ok - fm_backend_cmux_composer_state: reports unknown when the surface cannot be captured
ok - fm_backend_cmux_composer_state: reports unknown when no border-delimited composer row is found
ok - fm_backend_cmux_send_text_submit: reports 'empty' once the composer row reads empty after one Enter
ok - fm_backend_cmux_send_text_submit: reports 'pending' when the composer never clears after retried Enters (swallowed)
ok - fm_backend_cmux_send_text_submit: retries past a popup-placeholder-fill Enter and lands the real second Enter (the incident fix)
ok - fm_backend_cmux_send_text_submit: reports 'send-failed' when the target workspace/surface is absent
ok - fm_backend_cmux_window_of_workspace: walks windows and counts the membership-confirming workspace list
ok - fm_backend_cmux_window_of_workspace: echoes nothing when no window holds the workspace
ok - fm_backend_cmux_kill: closes the task workspace directly when it is not the last in its window
ok - fm_backend_cmux_kill: adds a throwaway sibling then closes the target when it is the last workspace in its window
ok - fm_backend_cmux_kill: never fails even when close-workspace fails
ok - fm_backend_cmux_kill: recovers stale workspace/surface ids by expected label
ok - fm_backend_cmux_list_live: lists only this home's scoped task workspaces using plain fm-<id> labels
ok - fm-spawn.sh: refuses backend=cmux for --secondmate spawns (mirrors Orca's refusal; no secondmate launch design exists yet)
```
</details>
<details>
<summary>Evidence: live cmux socket reachability</summary>

`PONG`

```text
PONG
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (16m59s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `bin/backends/cmux.sh:612` - The count is taken from the earlier `list-windows` snapshot rather than the per-window response that just proved target membership. If another workspace closes between those calls, a stale count of 2 skips sibling creation even though the target is now last, so `close-workspace` silently no-ops and teardown deletes task state. Derive the count from that same `workspace list --window` response.

🔧 Fix: Derive cmux count from membership snapshot
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ `tests/fm-backend-cmux-smoke.test.sh:142` - A live last-workspace teardown was not run. It necessarily creates and leaves a real cmux window workspace, which would modify app state outside the permitted worktree boundary. The controlled CLI fixture verifies the adapter call sequence, and the live cmux socket is reachable, but explicit authorization is needed for that destructive end-to-end check.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- <code>Baseline already completed: `command -v tmux &gt;/dev/null || { echo &#34;tmux is required for e2e tests&#34; &gt;&amp;2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo &#34;== $t ==&#34;; bash &#34;$t&#34; || rc=1; done; exit &#34;$rc&#34;`</code>
- `bash tests/fm-backend-cmux.test.sh`
- `bash /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KX7CD80Z3NMRZ1R01KSXXBZG/cmux-teardown-fixture.sh`
- `/Applications/cmux.app/Contents/Resources/bin/cmux version`
- `/Applications/cmux.app/Contents/Resources/bin/cmux ping`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
