### PR TITLE
fix: recover orphaned packed-refs locks during fleet sync

### DIFF
--- a/bin/fm-fleet-sync.sh
+++ b/bin/fm-fleet-sync.sh
@@ -15,6 +15,10 @@
 # and fetch failures.
 # Pruning never deletes the checked-out branch or a branch that still has a
 # worktree, so it cannot discard unlanded work; set FM_FLEET_PRUNE=0 to disable it.
+# When the fetch fails on an orphaned .git/packed-refs.lock (left by a ref rewrite
+# killed mid-write - e.g. a timed-out bootstrap sync or a teardown process kill),
+# it is retried with a bounded wait and removed only when provably stale; see
+# fetch_with_packed_refs_lock_guard and the FM_FLEET_SYNC_PACKED_REFS_LOCK_* knobs.
 # Usage: fm-fleet-sync.sh [<project-dir-or-name>]
 # The single-project form accepts either a path (absolute, or relative to the
 # caller's cwd) or a bare "<name>"/"projects/<name>" form, resolved against
@@ -29,7 +33,26 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 PROJECTS="${FM_PROJECTS_OVERRIDE:-$FM_HOME/projects}"
+# shellcheck source=bin/fm-lock-lib.sh
+. "$SCRIPT_DIR/fm-lock-lib.sh"
+FM_LOCK_LOG_PREFIX=fleet-sync
 "$FM_ROOT/bin/fm-guard.sh" || true
+
+# Bounded recovery for an orphaned .git/packed-refs.lock. A git ref rewrite
+# (fetch --prune, branch -D, pack-refs) killed after creating the lock but before
+# renaming it - e.g. bootstrap's fleet-sync timeout kill, or teardown's process
+# kills - leaves a lock that makes the next sync's fetch fail with Git's
+# "Unable to create '...packed-refs.lock': File exists". These knobs bound the
+# patience-then-provably-stale-clear recovery; see fetch_with_packed_refs_lock_guard.
+FLEET_SYNC_PACKED_REFS_LOCK_RETRIES=${FM_FLEET_SYNC_PACKED_REFS_LOCK_RETRIES:-3}
+FLEET_SYNC_PACKED_REFS_LOCK_RETRY_WAIT_SECS=${FM_FLEET_SYNC_PACKED_REFS_LOCK_RETRY_WAIT_SECS:-1}
+FLEET_SYNC_PACKED_REFS_LOCK_AGE_SECS=${FM_FLEET_SYNC_PACKED_REFS_LOCK_AGE_SECS:-30}
+case "$FLEET_SYNC_PACKED_REFS_LOCK_RETRIES" in ''|*[!0-9]*) FLEET_SYNC_PACKED_REFS_LOCK_RETRIES=3 ;; esac
+case "$FLEET_SYNC_PACKED_REFS_LOCK_AGE_SECS" in ''|*[!0-9]*) FLEET_SYNC_PACKED_REFS_LOCK_AGE_SECS=30 ;; esac
+if ! [[ "$FLEET_SYNC_PACKED_REFS_LOCK_RETRY_WAIT_SECS" =~ ^([0-9]+([.][0-9]*)?|[.][0-9]+)$ ]]; then
+  echo "fleet-sync: invalid packed-refs lock retry wait '$FLEET_SYNC_PACKED_REFS_LOCK_RETRY_WAIT_SECS'; using 1s" >&2
+  FLEET_SYNC_PACKED_REFS_LOCK_RETRY_WAIT_SECS=1
+fi
 
 usage() {
   echo "usage: fm-fleet-sync.sh [<project-dir-or-name>]" >&2
@@ -102,6 +125,89 @@ default_branch() {
 
 first_line() {
   printf '%s\n' "$1" | sed -n '1s/[[:space:]]\{1,\}/ /g;1p'
+}
+
+# True when git stderr shows the packed-refs.lock "File exists" race. The lock
+# path can appear anywhere in the message (git prefixes it with the failed ref op,
+# e.g. "could not delete reference ...:"). Other "File exists" errors must not match.
+is_packed_refs_lock_error() {
+  printf '%s\n' "$1" | grep -Eq "Unable to create ['\"].*packed-refs\\.lock['\"]: File exists"
+}
+
+# Absolute path to $PROJ's packed-refs.lock, or empty when it cannot be resolved.
+packed_refs_lock_path() {
+  local lock abs
+  lock=$(git -C "$PROJ" rev-parse --git-path packed-refs.lock 2>/dev/null) || return 1
+  [ -n "$lock" ] || return 1
+  case "$lock" in
+    /*) printf '%s\n' "$lock" ;;
+    *)
+      abs=$(cd "$PROJ" && pwd -P) || return 1
+      printf '%s/%s\n' "$abs" "$lock"
+      ;;
+  esac
+}
+
+# Run `git -C "$PROJ" fetch origin --prune --quiet`, tolerating an orphaned
+# packed-refs.lock left by a killed ref rewrite. Sets FETCH_OUTPUT to the git
+# command's combined output and returns its exit status. On the packed-refs.lock
+# signature ONLY: retry up to FLEET_SYNC_PACKED_REFS_LOCK_RETRIES times (a
+# transient lock self-clears as the owning process exits), then - only if the lock
+# is provably stale per fm-lock-lib.sh (still present, mtime age past the
+# threshold, no lsof holder of the lock or the clone worktree $PROJ) - remove it
+# and retry once more. A live lock, an unprovable one, or any other failure keeps
+# today's behavior. Every wait, retry, and removal prints to stderr, and a
+# successful recovery also prints one "$label: recovered: ..." summary to stdout so
+# a session-start refresh (which discards fleet-sync stderr) still surfaces it.
+fetch_with_packed_refs_lock_guard() {
+  local rc attempt=0 lock lock_desc
+  FETCH_OUTPUT=$(git -C "$PROJ" fetch origin --prune --quiet 2>&1); rc=$?
+  [ "$rc" -eq 0 ] && return 0
+  is_packed_refs_lock_error "$FETCH_OUTPUT" || return "$rc"
+
+  lock=$(packed_refs_lock_path) || lock=""
+  lock_desc=${lock:-packed-refs.lock}
+  while [ "$attempt" -lt "$FLEET_SYNC_PACKED_REFS_LOCK_RETRIES" ]; do
+    attempt=$(( attempt + 1 ))
+    echo "$label: fetch blocked by packed-refs lock ($lock_desc); waiting ${FLEET_SYNC_PACKED_REFS_LOCK_RETRY_WAIT_SECS}s and retrying ($attempt/${FLEET_SYNC_PACKED_REFS_LOCK_RETRIES}) (owning process may be exiting)" >&2
+    sleep "$FLEET_SYNC_PACKED_REFS_LOCK_RETRY_WAIT_SECS"
+    FETCH_OUTPUT=$(git -C "$PROJ" fetch origin --prune --quiet 2>&1); rc=$?
+    if [ "$rc" -eq 0 ]; then
+      echo "$label: fetch succeeded on retry; packed-refs lock cleared on its own" >&2
+      # One stdout summary so a session-start refresh (which discards fleet-sync
+      # stderr and relays only stdout) still surfaces the recovery.
+      echo "$label: recovered: packed-refs lock cleared on its own during retry"
+      return 0
+    fi
+    is_packed_refs_lock_error "$FETCH_OUTPUT" || return "$rc"
+  done
+
+  # Retries exhausted and still the lock signature. Clear ONLY if provably stale.
+  # The companion liveness dir is $PROJ (the clone worktree): a live `git -C "$PROJ"`
+  # keeps its cwd there even in the narrow window after it closes packed-refs.lock
+  # and before it exits, so lsof on $PROJ still catches a holder the lock-file check
+  # alone would miss.
+  lock=$(packed_refs_lock_path) || lock=""
+  if [ -n "$lock" ] && [ -e "$lock" ]; then
+    if fm_lock_is_provably_stale "$lock" "$PROJ" "$FLEET_SYNC_PACKED_REFS_LOCK_AGE_SECS"; then
+      if ! rm -f "$lock"; then
+        echo "$label: failed to remove provably-stale packed-refs lock $lock; leaving it in place" >&2
+        return "$rc"
+      fi
+      echo "$label: removed provably-stale packed-refs lock $lock (age >= ${FLEET_SYNC_PACKED_REFS_LOCK_AGE_SECS}s, no live holder) and retrying fetch" >&2
+      FETCH_OUTPUT=$(git -C "$PROJ" fetch origin --prune --quiet 2>&1); rc=$?
+      if [ "$rc" -eq 0 ]; then
+        echo "$label: fetch succeeded after stale packed-refs lock cleanup" >&2
+        echo "$label: recovered: removed a stale packed-refs lock (no live holder)"
+        return 0
+      fi
+      return "$rc"
+    fi
+    echo "$label: fetch blocked by packed-refs lock $lock that persisted across ${FLEET_SYNC_PACKED_REFS_LOCK_RETRIES} retries and is not provably stale (may belong to a live process); leaving it in place" >&2
+    return "$rc"
+  fi
+  echo "$label: fetch packed-refs lock signature persisted across ${FLEET_SYNC_PACKED_REFS_LOCK_RETRIES} retries even after the lock file disappeared" >&2
+  return "$rc"
 }
 
 prune_gone_branches() {
@@ -206,10 +312,10 @@ sync_project() {
     return 0
   fi
 
-  if ! fetch_output=$(git -C "$PROJ" fetch origin --prune --quiet 2>&1); then
+  if ! fetch_with_packed_refs_lock_guard; then
     reason="fetch failed"
-    if [ -n "$fetch_output" ]; then
-      reason="$reason: $(first_line "$fetch_output")"
+    if [ -n "$FETCH_OUTPUT" ]; then
+      reason="$reason: $(first_line "$FETCH_OUTPUT")"
     fi
     echo "$label: skipped: $reason"
     return 0

--- a/bin/fm-lock-lib.sh
+++ b/bin/fm-lock-lib.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Shared "is this git lock file provably abandoned?" decision procedure.
+#
+# ONE owner for the staleness proof that fm-teardown.sh (a worktree index.lock)
+# and fm-fleet-sync.sh (a clone's .git/packed-refs.lock) both rely on: a lock is
+# provably stale iff ALL of the following hold -
+#   1. the lock file still exists;
+#   2. no live process holds the lock file open, and none holds a companion
+#      directory (the worktree, or the repo's .git dir) open as cwd or an fd -
+#      a live git process keeps its own lock open for the whole operation, so an
+#      empty lsof result means the file was abandoned, not that no one held it;
+#   3. its mtime age is at least a caller-supplied threshold - a freshly created
+#      lock might belong to a process lsof has not yet reflected.
+# ANY uncertainty - lsof missing, an lsof error, an unreadable mtime - returns
+# non-zero (NOT stale): fail safe, never remove a lock that cannot be proven dead.
+# Diagnostics print to stderr prefixed by ${FM_LOCK_LOG_PREFIX:-fm-lock} so each
+# caller's output stays recognizable.
+
+fm_lock_log() {
+  echo "${FM_LOCK_LOG_PREFIX:-fm-lock}: $*" >&2
+}
+
+# Portable mtime in epoch seconds. Kept self-contained so this leaf lib drags in
+# no wake-queue machinery when a caller only needs the staleness proof.
+fm_lock_path_mtime() {
+  if [ "$(uname)" = Darwin ]; then
+    stat -f %m "$1" 2>/dev/null
+  else
+    stat -c %Y "$1" 2>/dev/null
+  fi
+}
+
+# fm_lock_lsof_holder <target>: 0 a process holds it, 1 provably none, 2 lsof
+# errored (cannot tell). Diagnostics print on the error path only.
+fm_lock_lsof_holder() {
+  local target=$1 output status
+  if output=$(lsof -- "$target" 2>&1); then
+    return 0
+  else
+    status=$?
+  fi
+  if [ "$status" -eq 1 ] && [ -z "$output" ]; then
+    return 1
+  fi
+  if [ -n "$output" ]; then
+    while IFS= read -r line; do
+      fm_lock_log "lsof check failed: $line"
+    done <<< "$output"
+  else
+    fm_lock_log "lsof check failed for $target with exit $status"
+  fi
+  return 2
+}
+
+# fm_lock_has_live_holder <lock> <dir>: 0 if a live process holds $lock or the
+# companion $dir open, OR if the answer is uncertain - a missing lsof or an lsof
+# error is treated as "cannot prove no holder" (fail safe: assume live). Returns
+# 1 only when lsof reports provably no holder on both.
+fm_lock_has_live_holder() {
+  local lock=$1 dir=$2 status
+  command -v lsof >/dev/null 2>&1 || return 0
+  if [ -n "$lock" ]; then
+    if fm_lock_lsof_holder "$lock"; then
+      return 0
+    else
+      status=$?
+      [ "$status" -eq 1 ] || return 0
+    fi
+  fi
+  if [ -n "$dir" ]; then
+    if fm_lock_lsof_holder "$dir"; then
+      return 0
+    else
+      status=$?
+      [ "$status" -eq 1 ] || return 0
+    fi
+  fi
+  return 1
+}
+
+# fm_lock_age <lock>: prints the lock's mtime age in whole seconds, or fails.
+fm_lock_age() {
+  local lock=$1 m now
+  m=$(fm_lock_path_mtime "$lock") || return 1
+  case "$m" in ''|*[!0-9]*) return 1 ;; esac
+  now=$(date +%s) || return 1
+  case "$now" in ''|*[!0-9]*) return 1 ;; esac
+  printf '%s\n' "$(( now - m ))"
+}
+
+# fm_lock_is_provably_stale <lock> <dir> <min_age_secs>: THE proof. Returns 0 iff
+# the lock exists, has no live holder, and its mtime age is at least
+# <min_age_secs>. Returns non-zero on any uncertainty - never remove a lock this
+# returns non-zero for.
+fm_lock_is_provably_stale() {
+  local lock=$1 dir=$2 min_age=$3 age
+  [ -n "$lock" ] && [ -e "$lock" ] || return 1
+  fm_lock_has_live_holder "$lock" "$dir" && return 1
+  if ! age=$(fm_lock_age "$lock"); then
+    fm_lock_log "cannot read mtime for git lock $lock; leaving it in place"
+    return 1
+  fi
+  [ "$age" -ge "$min_age" ]
+}

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -59,17 +59,15 @@
 #      deserves a retry of the return.
 #   2. Other treehouse return failures still abort immediately and loudly (no retry).
 #   3. If every retry still hits the lock signature and the lock remains, it is removed
-#      and the return tried once more ONLY when the lock is provably stale, meaning ALL
-#      of the following hold:
-#        a. the lock file still exists after the retry window;
-#        b. its mtime age is at least FM_STALE_WORKTREE_LOCK_AGE_SECS (default 30s) - a
-#           freshly created lock might belong to a process `lsof` has not yet reflected;
-#        c. `lsof` reports no process holding the lock file open, and no process has the
-#           worktree directory itself open (as cwd or an fd).
+#      and the return tried once more ONLY when the lock is provably stale per
+#      bin/fm-lock-lib.sh's fm_lock_is_provably_stale, passing the worktree dir as the
+#      companion directory and FM_STALE_WORKTREE_LOCK_AGE_SECS (default 30s) as the age
+#      threshold. That shared proof owns the exact lsof-holder, mtime-age, and fail-safe
+#      rules.
 #   4. If retries exhaust and the lock is not provably stale, teardown fails as loudly
 #      as a normal return failure and notes that the lock persisted across the retry
-#      window. A missing `lsof`, or a lock that fails any of the three stale checks, is
-#      treated as NOT provably stale (fail safe): the lock is left untouched.
+#      window. A missing `lsof`, or a lock that fails any stale check, is treated as
+#      NOT provably stale (fail safe): the lock is left untouched.
 # The same proof is used when non-force safety inspection cannot run because the lock
 # is present; teardown clears only a provably stale lock, then re-runs the safety
 # checks before any destructive return. Teardown output notes every wait, retry, and
@@ -90,6 +88,9 @@ SUB_HOME_MARKER=".fm-secondmate-home"
 . "$SCRIPT_DIR/fm-backend.sh"
 # shellcheck source=bin/fm-wake-lib.sh
 . "$SCRIPT_DIR/fm-wake-lib.sh"
+# shellcheck source=bin/fm-lock-lib.sh
+. "$SCRIPT_DIR/fm-lock-lib.sh"
+FM_LOCK_LOG_PREFIX=teardown
 "$FM_ROOT/bin/fm-guard.sh" || true
 ID=$1
 FORCE=${2:-}
@@ -437,70 +438,10 @@ worktree_git_lock_path() {
   esac
 }
 
-lsof_path_has_holder() {
-  local target=$1 output status
-  if output=$(lsof -- "$target" 2>&1); then
-    return 0
-  else
-    status=$?
-  fi
-  if [ "$status" -eq 1 ] && [ -z "$output" ]; then
-    return 1
-  fi
-  if [ -n "$output" ]; then
-    printf '%s\n' "$output" | sed 's/^/teardown: lsof check failed: /' >&2
-  else
-    echo "teardown: lsof check failed for $target with exit $status" >&2
-  fi
-  return 2
-}
-
-# Does any live process hold $lock open, or hold the worktree $dir itself open
-# (as cwd or an fd)? See the script header for why this proves liveness. A
-# missing lsof is treated as "cannot prove no holder" (fail safe: assume live).
-worktree_lock_has_live_holder() {
-  local lock=$1 dir=$2 status
-  command -v lsof >/dev/null 2>&1 || return 0
-  if [ -n "$lock" ]; then
-    if lsof_path_has_holder "$lock"; then
-      return 0
-    else
-      status=$?
-      [ "$status" -eq 1 ] || return 0
-    fi
-  fi
-  if [ -n "$dir" ]; then
-    if lsof_path_has_holder "$dir"; then
-      return 0
-    else
-      status=$?
-      [ "$status" -eq 1 ] || return 0
-    fi
-  fi
-  return 1
-}
-
-worktree_lock_age() {
-  local lock=$1 m now
-  m=$(fm_path_mtime "$lock") || return 1
-  case "$m" in ''|*[!0-9]*) return 1 ;; esac
-  now=$(date +%s) || return 1
-  case "$now" in ''|*[!0-9]*) return 1 ;; esac
-  printf '%s\n' "$(( now - m ))"
-}
-
-# Is $lock provably stale per the header's staleness proof? Returns non-zero
-# (never remove) unless the lock exists, has no live holder, and is old enough.
-worktree_lock_is_provably_stale() {
-  local lock=$1 dir=$2 age
-  [ -n "$lock" ] && [ -e "$lock" ] || return 1
-  worktree_lock_has_live_holder "$lock" "$dir" && return 1
-  if ! age=$(worktree_lock_age "$lock"); then
-    echo "teardown: cannot read mtime for git lock $lock; leaving it in place" >&2
-    return 1
-  fi
-  [ "$age" -ge "$STALE_WORKTREE_LOCK_AGE_SECS" ]
-}
+# The lock-staleness proof (lsof holder check, mtime age, fail-safe defaults)
+# is owned by bin/fm-lock-lib.sh's fm_lock_is_provably_stale, sourced above.
+# Teardown passes the worktree dir as the companion directory and its own
+# STALE_WORKTREE_LOCK_AGE_SECS threshold.
 
 worktree_safety_blocked_by_lock() {
   local reason=$1 lock
@@ -523,7 +464,7 @@ cleanup_stale_lock_for_safety_check() {
     return 0
   fi
 
-  if worktree_lock_is_provably_stale "$lock" "$dir"; then
+  if fm_lock_is_provably_stale "$lock" "$dir" "$STALE_WORKTREE_LOCK_AGE_SECS"; then
     rm -f "$lock"
     echo "teardown: removed provably-stale git lock $lock (age >= ${STALE_WORKTREE_LOCK_AGE_SECS}s, no live holder) and retrying worktree safety checks" >&2
     return 0
@@ -584,7 +525,7 @@ teardown_treehouse_return() {
   lock=$(worktree_git_lock_path "$dir") || lock=""
   if [ -n "$lock" ] && [ -e "$lock" ]; then
     lock_desc=$lock
-    if worktree_lock_is_provably_stale "$lock" "$dir"; then
+    if fm_lock_is_provably_stale "$lock" "$dir" "$STALE_WORKTREE_LOCK_AGE_SECS"; then
       rm -f "$lock"
       echo "teardown: removed provably-stale git lock $lock (age >= ${STALE_WORKTREE_LOCK_AGE_SECS}s, no live holder) and retrying $label return" >&2
       if [ -n "$post_cleanup_check" ]; then

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -86,8 +86,6 @@ SUB_HOME_MARKER=".fm-secondmate-home"
 . "$SCRIPT_DIR/fm-tasks-axi-lib.sh"
 # shellcheck source=bin/fm-backend.sh
 . "$SCRIPT_DIR/fm-backend.sh"
-# shellcheck source=bin/fm-wake-lib.sh
-. "$SCRIPT_DIR/fm-wake-lib.sh"
 # shellcheck source=bin/fm-lock-lib.sh
 . "$SCRIPT_DIR/fm-lock-lib.sh"
 FM_LOCK_LOG_PREFIX=teardown

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -202,6 +202,7 @@ The locked session-start bootstrap step, PR-based teardown, and merged-PR wake h
 Wake-time refreshes can target a single clone by project name, so the primary home also catches up when a secondmate reports a merge from its own home.
 Clean default-branch clones fast-forward to `origin/<default>`, and a clean detached HEAD that holds no unique commits is re-attached to the default branch before the same fast-forward path runs.
 Dirty clones, non-default branches, detached HEADs with unique commits, diverged defaults, and default branches checked out in another worktree are reported as `STUCK:` with their behind count and left untouched.
+Fetches blocked by an orphaned `.git/packed-refs.lock` use bounded retries and remove the lock only when the shared staleness proof can prove it abandoned; [configuration.md](configuration.md#toolchain) owns the recovery details and tuning knobs.
 Local-only projects, clones without an origin remote, and fetch failures remain benign skips.
 The refresh also prunes local branches whose remote is gone and that no worktree still needs.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -220,6 +220,9 @@ The locked session-start bootstrap step also runs a best-effort project clone re
 It emits `FLEET_SYNC:` for skipped refreshes that may matter, recovered self-heals, and `STUCK:` alarms.
 Normal completed runs keep local-only and no-origin skips silent.
 If bootstrap kills a timed-out refresh, it replays any completed `fm-fleet-sync.sh` output before the aggregate timeout skip so no finished result is lost.
+A killed refresh (or a teardown process kill) can leave an orphaned `.git/packed-refs.lock` in a clone, which makes the next refresh's fetch fail with Git's `Unable to create '...packed-refs.lock': File exists`.
+On that signature only, `fm-fleet-sync.sh` retries the fetch with a bounded wait for the lock to self-clear, then removes the lock and retries once more only when it can prove the lock stale, exactly like the `fm-teardown.sh` `index.lock` recovery.
+It never removes a live lock, leaves any other failure shape untouched, and prints every wait, retry, and removal to stderr plus a one-line `recovered:` summary to stdout on success so that this session-start relay still surfaces the recovery.
 The locked session-start bootstrap step also runs the guarded local secondmate sync for recorded live secondmate homes, then propagates declared inheritable local config into each validated live home.
 It emits `SECONDMATE_SYNC:` only when a home was skipped for an actionable sync reason or config inheritance failed, and `NUDGE_SECONDMATES:` only when a running home advanced and its instruction surface (`AGENTS.md`, `bin/`, or `.agents/skills/`) changed.
 `NUDGE_SECONDMATES:` lists stable `fm-<id>` task selectors; the `bootstrap-diagnostics` skill owns the send procedure.
@@ -356,6 +359,9 @@ FM_STALE_WORKTREE_LOCK_AGE_SECS=30       # min mtime age before fm-teardown.sh t
 FM_TREEHOUSE_RETURN_LOCK_RETRIES=3        # retries after a treehouse return fails on the transient git index.lock signature
 FM_TREEHOUSE_RETURN_LOCK_RETRY_WAIT_SECS=1 # seconds fm-teardown.sh waits before each retry after that signature
 FM_STALE_WORKTREE_LOCK_RETRY_WAIT_SECS=   # legacy alias for FM_TREEHOUSE_RETURN_LOCK_RETRY_WAIT_SECS when the new variable is unset
+FM_FLEET_SYNC_PACKED_REFS_LOCK_RETRIES=3        # fetch retries after fm-fleet-sync.sh hits the orphaned .git/packed-refs.lock signature
+FM_FLEET_SYNC_PACKED_REFS_LOCK_RETRY_WAIT_SECS=1 # seconds fm-fleet-sync.sh waits before each of those retries
+FM_FLEET_SYNC_PACKED_REFS_LOCK_AGE_SECS=30       # min mtime age before fm-fleet-sync.sh treats a leftover packed-refs.lock as provably stale
 FM_BUSY_REGEX='esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel'   # busy-pane signatures, shared by watcher, fm-crew-state pane fallback, and tmux helper
 FM_COMPOSER_IDLE_RE=    # optional empty-composer regex, applied after ghost and border stripping
 FM_COMPOSER_GHOST_LUMA_MAX=128   # fleet-wide: max perceived luminance (0.299R+0.587G+0.114B, 0-255) for a TRUECOLOR foreground to count as de-emphasised ghost/placeholder text and be stripped; dim/faint (SGR 2) is stripped regardless. Assumes a dark terminal theme (bin/fm-composer-lib.sh's fm_composer_strip_ghost, shared by the tmux and herdr composer readers)
@@ -391,3 +397,9 @@ FM_LOG_KEEP_LINES=2000             # daemon log lines kept when trimming
 When it is unset or blank, `FM_STALE_WORKTREE_LOCK_RETRY_WAIT_SECS` remains a compatible fallback, and a blank fallback uses the 1-second default.
 An invalid nonblank wait falls back to 1 second rather than interrupting teardown.
 Teardown never removes a lock during the retry window, and after that window it attempts stale-lock cleanup only for a still-present lock that passes the configured age and live-holder checks.
+
+`fm-fleet-sync.sh` applies the same shape to an orphaned `.git/packed-refs.lock`: it retries only Git's `Unable to create '...packed-refs.lock': File exists` fetch failure up to `FM_FLEET_SYNC_PACKED_REFS_LOCK_RETRIES` times (nonnegative integer; unset, blank, or invalid uses the default of 3), waiting `FM_FLEET_SYNC_PACKED_REFS_LOCK_RETRY_WAIT_SECS` seconds (nonnegative whole or fractional; invalid falls back to 1 second) before each.
+Only after those retries exhaust does it remove the lock, and only when it is provably stale - still present, mtime age at least `FM_FLEET_SYNC_PACKED_REFS_LOCK_AGE_SECS` (default 30), and no `lsof` holder of the lock file or of the clone worktree itself (a live `git` keeps that as its cwd even in the window after it closes the lock and before it exits).
+A live lock, a missing `lsof`, any failed check, or any other fetch failure keeps today's behavior.
+Every wait, retry, and removal is printed to stderr, and a successful recovery also prints one `recovered:` summary line to stdout so a session-start refresh - which discards fleet-sync stderr and relays only stdout - still surfaces it.
+The shared staleness proof lives in `bin/fm-lock-lib.sh`, which both `fm-teardown.sh` and `fm-fleet-sync.sh` use.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -8,7 +8,7 @@ If you have changed away from the firstmate home in an interactive shell, invoke
 | ------------------------ | ------------------------------------------------------------------------------------ |
 | `fm-session-start.sh`    | Compose lock, bootstrap, and wake drain into the single ordered session-start digest |
 | `fm-bootstrap.sh`        | Detect toolchain and fleet problems, run the locked session-start sweeps, and install approved tools |
-| `fm-fleet-sync.sh`       | Refresh project clones with safe fast-forwards, self-heals, `STUCK:` reports, and branch pruning |
+| `fm-fleet-sync.sh`       | Refresh project clones with safe fast-forwards, self-heals, `STUCK:` reports, branch pruning, and bounded recovery from an orphaned `.git/packed-refs.lock` |
 | `fm-fleet-snapshot.sh`   | Print the read-only structured fleet snapshot JSON (schema `fm-fleet-snapshot.v1`)   |
 | `fm-fleet-view.sh`       | Render the fleet snapshot as a human Markdown view                                   |
 | `fm-update.sh`           | Fast-forward-only self-update of firstmate and secondmate homes from origin          |
@@ -47,6 +47,7 @@ If you have changed away from the firstmate home in an interactive shell, invoke
 | `fm-tangle-lib.sh`       | Shared default-branch resolution and primary-checkout tangle classification          |
 | `fm-supervision-lib.sh`  | Shared in-flight-work-without-fresh-watcher-beacon predicate                         |
 | `fm-ff-lib.sh`           | Shared guarded fast-forward helper for origin pulls and local secondmate syncs       |
+| `fm-lock-lib.sh`         | Shared "is this git lock provably abandoned?" proof used by teardown and fleet-sync   |
 | `fm-config-inherit-lib.sh` | Shared primary-to-secondmate inheritable-config propagation                        |
 | `fm-tasks-axi-lib.sh`    | Shared backlog-backend selector and `tasks-axi` compatibility probe                  |
 | `fm-wake-drain.sh`       | Atomically drain queued watcher wakes, then assert watcher liveness                  |

--- a/tests/fm-fleet-sync.test.sh
+++ b/tests/fm-fleet-sync.test.sh
@@ -11,6 +11,16 @@
 #     instead of a quiet skip.
 # The pre-existing fast-forward / already-current / local-only / no-origin paths
 # must be unchanged, and bootstrap must relay the new outcomes as FLEET_SYNC lines.
+#
+# It also pins the orphaned .git/packed-refs.lock recovery in the fetch step
+# (fetch_with_packed_refs_lock_guard, backed by bin/fm-lock-lib.sh's shared
+# staleness proof): a provably-stale lock is retried then removed and the clone
+# syncs (with a "recovered:" summary on stdout so a session-start refresh, which
+# discards stderr, still surfaces it); a live lock (fake lsof holder) is never
+# removed and the sync fails loudly; a live process merely holding the clone
+# worktree dir as its cwd also blocks removal (the clone-dir liveness check); a
+# transient lock that self-clears is retried without a force-remove; and any
+# non-packed-refs.lock fetch failure keeps today's behavior with no retry.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -78,6 +88,110 @@ run_sync() {
   local home=$1
   shift
   FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" "$ROOT/bin/fm-fleet-sync.sh" "$@" 2>/dev/null
+}
+
+# --- packed-refs.lock fixtures ----------------------------------------------
+
+# build_packed_prunable <home> <name>: like build_pair, but the clone has PACKED
+# refs plus a local `feature` branch tracking a since-deleted origin/feature, so a
+# fetch --prune must rewrite packed-refs - which an orphaned .git/packed-refs.lock
+# blocks with Git's "Unable to create '...packed-refs.lock': File exists". origin/main
+# is advanced by one commit so a successful sync fast-forwards. Echoes the clone path.
+build_packed_prunable() {
+  local home=$1 name=$2 work remote clone remote_abs
+  work="$home/work-$name"
+  remote="$home/remotes/$name.git"
+  clone="$home/projects/$name"
+  mkdir -p "$home/remotes"
+
+  git init -q "$work"
+  git -C "$work" symbolic-ref HEAD refs/heads/main
+  commit_file "$work" file.txt v0 C0
+  git clone --quiet --bare "$work" "$remote"
+  remote_abs=$(cd "$remote" && pwd)
+  git -C "$work" remote add origin "file://$remote_abs"
+  git -C "$work" push -q -u origin main
+  git -C "$work" push -q origin main:refs/heads/feature
+
+  git clone --quiet "file://$remote_abs" "$clone"
+  git -C "$clone" branch -q feature origin/feature
+  commit_file "$work" file.txt v1 C1
+  git -C "$work" push -q origin main
+  git -C "$work" push -q origin --delete feature
+  git -C "$clone" pack-refs --all
+  printf '%s\n' "$clone"
+}
+
+plant_packed_refs_lock() { : > "$1/.git/packed-refs.lock"; }
+
+# lsof shims mirror tests/fm-teardown.test.sh: no-holder (provably free), a live
+# holder, and an lsof error. Written into a per-home fakebin/ prepended to PATH.
+lsof_no_holder() {
+  cat > "$1/lsof" <<'SH'
+#!/usr/bin/env bash
+exit 1
+SH
+  chmod +x "$1/lsof"
+}
+lsof_live_holder() {
+  cat > "$1/lsof" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  chmod +x "$1/lsof"
+}
+
+# lsof shim: a holder ONLY for $FLEET_TEST_LIVE_DIR (a live `git -C <clone>` keeping
+# its cwd there), and no holder of the lock file itself - the exact window the
+# clone-dir liveness check must cover.
+lsof_holds_only_live_dir() {
+  cat > "$1/lsof" <<'SH'
+#!/usr/bin/env bash
+target=
+for a in "$@"; do case "$a" in --|-*) ;; *) target=$a ;; esac; done
+[ -n "${FLEET_TEST_LIVE_DIR:-}" ] && [ "$target" = "$FLEET_TEST_LIVE_DIR" ] && exit 0
+exit 1
+SH
+  chmod +x "$1/lsof"
+}
+
+# git shim: fail the FIRST `fetch` with the packed-refs.lock signature and drop
+# the lock (simulating the dying ref-rewrite finishing), then delegate every
+# later call - including the retried fetch - to the real git so the sync completes.
+git_transient_packed_refs_lock() {
+  cat > "$1/git" <<'SH'
+#!/usr/bin/env bash
+real=${REAL_GIT_FOR_TEST:?}
+dir=; is_fetch=0
+for a in "$@"; do [ "$a" = fetch ] && is_fetch=1; done
+prev=
+for a in "$@"; do [ "$prev" = -C ] && dir=$a; prev=$a; done
+if [ "$is_fetch" = 1 ]; then
+  n=$(cat "${GIT_FETCH_COUNTER:?}" 2>/dev/null || echo 0); n=$(( n + 1 ))
+  printf '%s\n' "$n" > "$GIT_FETCH_COUNTER"
+  if [ "$n" -eq 1 ]; then
+    lock="$dir/.git/packed-refs.lock"
+    echo "error: could not delete reference refs/remotes/origin/feature: Unable to create '$lock': File exists." >&2
+    rm -f "$lock"
+    exit 1
+  fi
+fi
+exec "$real" "$@"
+SH
+  chmod +x "$1/git"
+}
+
+# run_sync_guarded <home> <fakebin> <outfile> <errfile> [args...]: run fleet-sync
+# with the fakebin on PATH and stdout/stderr captured separately. Per-test knobs
+# (FM_FLEET_SYNC_PACKED_REFS_LOCK_*, GIT_FETCH_COUNTER) are read from the caller's
+# exported environment.
+run_sync_guarded() {
+  local home=$1 fakebin=$2 outf=$3 errf=$4 realgit
+  shift 4
+  realgit=$(command -v git)
+  PATH="$fakebin:$PATH" REAL_GIT_FOR_TEST="$realgit" \
+  FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" \
+    "$ROOT/bin/fm-fleet-sync.sh" "$@" >"$outf" 2>"$errf"
 }
 
 # --- tests ------------------------------------------------------------------
@@ -356,6 +470,139 @@ test_bootstrap_relays_recovered_and_stuck() {
   pass "bootstrap relays recovered: and STUCK: fleet-sync outcomes"
 }
 
+# --- packed-refs.lock guard tests -------------------------------------------
+
+test_orphaned_stale_packed_refs_lock_recovers() {
+  local home fakebin clone out err
+  home=$(new_home)
+  fakebin="$home/fb-lockstale"; rm -rf "$fakebin"; mkdir -p "$fakebin"
+  clone=$(build_packed_prunable "$home" lockstale)
+  plant_packed_refs_lock "$clone"
+  lsof_no_holder "$fakebin"           # provably no live holder
+  out="$home/out-lockstale"; err="$home/err-lockstale"
+
+  set +e
+  FM_FLEET_SYNC_PACKED_REFS_LOCK_RETRIES=2 \
+  FM_FLEET_SYNC_PACKED_REFS_LOCK_RETRY_WAIT_SECS=0 \
+  FM_FLEET_SYNC_PACKED_REFS_LOCK_AGE_SECS=0 \
+    run_sync_guarded "$home" "$fakebin" "$out" "$err" lockstale
+  set -e
+
+  assert_grep "removed provably-stale packed-refs lock" "$err" \
+    "stale lock: guard did not force-remove the provably-stale lock"
+  assert_grep "fetch succeeded after stale packed-refs lock cleanup" "$err" \
+    "stale lock: fetch did not succeed after cleanup"
+  assert_contains "$(cat "$out")" "lockstale: synced" "stale lock: clone did not sync after recovery"
+  assert_grep "recovered: removed a stale packed-refs lock" "$out" \
+    "stale lock: recovery summary not emitted on stdout (bootstrap relays stdout, discards stderr)"
+  assert_absent "$clone/.git/packed-refs.lock" "stale lock: lock should be gone after removal"
+  [ "$(git -C "$clone" rev-parse HEAD)" = "$(git -C "$clone" rev-parse origin/main)" ] \
+    || fail "stale lock: clone HEAD not at origin/main after recovery"
+  pass "orphaned provably-stale packed-refs.lock is cleared and the clone syncs"
+}
+
+test_live_packed_refs_lock_is_never_removed() {
+  local home fakebin clone out err before
+  home=$(new_home)
+  fakebin="$home/fb-locklive"; rm -rf "$fakebin"; mkdir -p "$fakebin"
+  clone=$(build_packed_prunable "$home" locklive)
+  plant_packed_refs_lock "$clone"
+  lsof_live_holder "$fakebin"         # a live process holds the lock/.git open
+  before=$(head_sha "$clone")
+  out="$home/out-locklive"; err="$home/err-locklive"
+
+  set +e
+  FM_FLEET_SYNC_PACKED_REFS_LOCK_RETRIES=2 \
+  FM_FLEET_SYNC_PACKED_REFS_LOCK_RETRY_WAIT_SECS=0 \
+  FM_FLEET_SYNC_PACKED_REFS_LOCK_AGE_SECS=0 \
+    run_sync_guarded "$home" "$fakebin" "$out" "$err" locklive
+  set -e
+
+  assert_grep "is not provably stale" "$err" "live lock: guard did not explain the refusal"
+  assert_no_grep "removed provably-stale packed-refs lock" "$err" \
+    "live lock: guard force-removed a live lock"
+  assert_contains "$(cat "$out")" "locklive: skipped: fetch failed" "live lock: fleet-sync did not skip"
+  assert_present "$clone/.git/packed-refs.lock" "live lock: lock must never be removed"
+  [ "$(head_sha "$clone")" = "$before" ] || fail "live lock: clone was advanced despite the refusal"
+  pass "a live packed-refs.lock is never removed and the sync fails loudly"
+}
+
+test_live_git_cwd_in_clone_dir_blocks_removal() {
+  local home fakebin clone out err before
+  home=$(new_home)
+  fakebin="$home/fb-lockcwd"; rm -rf "$fakebin"; mkdir -p "$fakebin"
+  clone=$(build_packed_prunable "$home" lockcwd)
+  plant_packed_refs_lock "$clone"
+  # Nobody holds the lock file, but a live process holds the clone worktree as its
+  # cwd - the narrow race where git closed packed-refs.lock but has not yet exited.
+  lsof_holds_only_live_dir "$fakebin"
+  before=$(head_sha "$clone")
+  out="$home/out-lockcwd"; err="$home/err-lockcwd"
+
+  set +e
+  FLEET_TEST_LIVE_DIR="$clone" \
+  FM_FLEET_SYNC_PACKED_REFS_LOCK_RETRIES=2 \
+  FM_FLEET_SYNC_PACKED_REFS_LOCK_RETRY_WAIT_SECS=0 \
+  FM_FLEET_SYNC_PACKED_REFS_LOCK_AGE_SECS=0 \
+    run_sync_guarded "$home" "$fakebin" "$out" "$err" lockcwd
+  set -e
+
+  assert_grep "is not provably stale" "$err" "clone-cwd holder: guard did not refuse"
+  assert_no_grep "removed provably-stale packed-refs lock" "$err" \
+    "clone-cwd holder: guard removed a lock while a live process held the clone dir"
+  assert_present "$clone/.git/packed-refs.lock" "clone-cwd holder: lock must not be removed"
+  [ "$(head_sha "$clone")" = "$before" ] || fail "clone-cwd holder: clone was advanced despite the refusal"
+  pass "a live process holding the clone worktree dir blocks lock removal (clone-dir liveness)"
+}
+
+test_transient_packed_refs_lock_self_clears() {
+  local home fakebin clone out err counter
+  home=$(new_home)
+  fakebin="$home/fb-locktrans"; rm -rf "$fakebin"; mkdir -p "$fakebin"
+  clone=$(build_packed_prunable "$home" locktrans)
+  plant_packed_refs_lock "$clone"
+  git_transient_packed_refs_lock "$fakebin"   # fail once + drop lock, then real git
+  counter="$home/git-fetch-count"; : > "$counter"
+  out="$home/out-locktrans"; err="$home/err-locktrans"
+
+  set +e
+  GIT_FETCH_COUNTER="$counter" \
+  FM_FLEET_SYNC_PACKED_REFS_LOCK_RETRIES=3 \
+  FM_FLEET_SYNC_PACKED_REFS_LOCK_RETRY_WAIT_SECS=0 \
+    run_sync_guarded "$home" "$fakebin" "$out" "$err" locktrans
+  set -e
+
+  assert_grep "cleared on its own" "$err" "transient lock: guard did not report the self-clear"
+  assert_no_grep "removed provably-stale packed-refs lock" "$err" \
+    "transient lock: guard force-removed a lock that only needed patience"
+  assert_contains "$(cat "$out")" "locktrans: synced" "transient lock: clone did not sync after self-clear"
+  assert_grep "recovered: packed-refs lock cleared on its own" "$out" \
+    "transient lock: recovery summary not emitted on stdout"
+  assert_absent "$clone/.git/packed-refs.lock" "transient lock: lock should be gone after self-clear"
+  pass "a transient packed-refs.lock that self-clears is retried without a force-remove"
+}
+
+test_non_signature_fetch_failure_is_not_retried() {
+  local home fakebin clone out err
+  home=$(new_home)
+  fakebin="$home/fb-locknonsig"; rm -rf "$fakebin"; mkdir -p "$fakebin"
+  clone=$(build_pair "$home" locknonsig)
+  advance_origin "$home" locknonsig C1
+  git -C "$clone" remote set-url origin "file://$home/remotes/does-not-exist.git"
+  out="$home/out-locknonsig"; err="$home/err-locknonsig"
+
+  set +e
+  FM_FLEET_SYNC_PACKED_REFS_LOCK_RETRIES=3 \
+  FM_FLEET_SYNC_PACKED_REFS_LOCK_RETRY_WAIT_SECS=0 \
+    run_sync_guarded "$home" "$fakebin" "$out" "$err" locknonsig
+  set -e
+
+  assert_contains "$(cat "$out")" "locknonsig: skipped: fetch failed" "non-signature: fleet-sync did not report the fetch failure"
+  assert_no_grep "waiting" "$err" "non-signature: a non-lock failure was wrongly retried"
+  assert_no_grep "packed-refs lock" "$err" "non-signature: a non-lock failure entered the lock guard"
+  pass "a non-packed-refs.lock fetch failure keeps today's behavior (no retry)"
+}
+
 test_detached_clean_ancestor_recovers
 test_detached_unique_commit_is_stuck_untouched
 test_detached_clean_ancestor_with_diverged_local_default_is_stuck_untouched
@@ -373,3 +620,8 @@ test_single_project_by_projects_relative_name_ignores_cwd_shadow
 test_single_project_unresolvable_name_still_skips
 test_whole_fleet_form
 test_bootstrap_relays_recovered_and_stuck
+test_orphaned_stale_packed_refs_lock_recovers
+test_live_packed_refs_lock_is_never_removed
+test_live_git_cwd_in_clone_dir_blocks_removal
+test_transient_packed_refs_lock_self_clears
+test_non_signature_fetch_failure_is_not_retried

--- a/tests/fm-gotmp.test.sh
+++ b/tests/fm-gotmp.test.sh
@@ -52,9 +52,6 @@ make_fake_root() {
   ln -s "$ROOT/bin/fm-backend.sh" "$fake/bin/fm-backend.sh"
   ln -s "$ROOT/bin/backends/tmux.sh" "$fake/bin/backends/tmux.sh"
   ln -s "$ROOT/bin/fm-tmux-lib.sh" "$fake/bin/fm-tmux-lib.sh"
-  # fm-wake-lib.sh: symlink the REAL file (teardown sources it for fm_path_mtime,
-  # used by the stale worktree git-lock cleanup; unchanged by this fixture).
-  ln -s "$ROOT/bin/fm-wake-lib.sh" "$fake/bin/fm-wake-lib.sh"
   # fm-lock-lib.sh: teardown sources it for the shared lock-staleness proof.
   ln -s "$ROOT/bin/fm-lock-lib.sh" "$fake/bin/fm-lock-lib.sh"
   # fm-guard.sh: stub (teardown calls it with `|| true`).
@@ -151,7 +148,6 @@ test_teardown_skips_gracefully_without_tasktmp() {
   ln -s "$ROOT/bin/fm-backend.sh" "$fake/bin/fm-backend.sh"
   ln -s "$ROOT/bin/backends/tmux.sh" "$fake/bin/backends/tmux.sh"
   ln -s "$ROOT/bin/fm-tmux-lib.sh" "$fake/bin/fm-tmux-lib.sh"
-  ln -s "$ROOT/bin/fm-wake-lib.sh" "$fake/bin/fm-wake-lib.sh"
   ln -s "$ROOT/bin/fm-lock-lib.sh" "$fake/bin/fm-lock-lib.sh"
   cat > "$fake/bin/fm-guard.sh" <<'SH'
 #!/usr/bin/env bash

--- a/tests/fm-gotmp.test.sh
+++ b/tests/fm-gotmp.test.sh
@@ -55,6 +55,8 @@ make_fake_root() {
   # fm-wake-lib.sh: symlink the REAL file (teardown sources it for fm_path_mtime,
   # used by the stale worktree git-lock cleanup; unchanged by this fixture).
   ln -s "$ROOT/bin/fm-wake-lib.sh" "$fake/bin/fm-wake-lib.sh"
+  # fm-lock-lib.sh: teardown sources it for the shared lock-staleness proof.
+  ln -s "$ROOT/bin/fm-lock-lib.sh" "$fake/bin/fm-lock-lib.sh"
   # fm-guard.sh: stub (teardown calls it with `|| true`).
   cat > "$fake/bin/fm-guard.sh" <<'SH'
 #!/usr/bin/env bash
@@ -150,6 +152,7 @@ test_teardown_skips_gracefully_without_tasktmp() {
   ln -s "$ROOT/bin/backends/tmux.sh" "$fake/bin/backends/tmux.sh"
   ln -s "$ROOT/bin/fm-tmux-lib.sh" "$fake/bin/fm-tmux-lib.sh"
   ln -s "$ROOT/bin/fm-wake-lib.sh" "$fake/bin/fm-wake-lib.sh"
+  ln -s "$ROOT/bin/fm-lock-lib.sh" "$fake/bin/fm-lock-lib.sh"
   cat > "$fake/bin/fm-guard.sh" <<'SH'
 #!/usr/bin/env bash
 exit 0


### PR DESCRIPTION
## Intent

Make fm-fleet-sync.sh recover fail-safely from an orphaned .git/packed-refs.lock in a project clone, mirroring the PR #435 teardown index.lock pattern.

Root cause (verified empirically): a git ref rewrite (fetch --prune, pack-refs, or branch -D) killed after it creates packed-refs.lock but before it renames the file leaves the lock behind. Candidate killers are bootstrap's bounded fleet-sync timeout (it kills the sync subprocess) and teardown's lingering-process kills. The incident found a 0-byte lock, which is exactly what a SIGKILL between O_CREAT|O_EXCL and the write/rename leaves. That orphaned lock makes the next sync's 'git fetch origin --prune' fail with 'Unable to create ...packed-refs.lock: File exists' (pruning a merged PR's packed remote-tracking ref must rewrite packed-refs), so fm-fleet-sync reports 'skipped: fetch failed' and the clone never syncs.

Fix, on the packed-refs.lock failure signature ONLY: bounded signature-keyed retry first (transient locks self-clear as the owning process exits); if retries exhaust, remove the lock and retry once more ONLY when it is provably stale (still present, mtime age past a threshold, and no lsof holder of the lock or the clone's .git dir). A live lock, a missing lsof, any failed check, or any other fetch failure keeps today's behavior. Every wait/retry/removal is printed. Constants are env-overridable knobs (FM_FLEET_SYNC_PACKED_REFS_LOCK_{RETRIES,RETRY_WAIT_SECS,AGE_SECS}).

Deliberate decisions a diff-only reviewer would not know:
- The guard wraps ONLY the fetch step, not merge/prune. The fetch is the incident's hard-failure surface; merge --ff-only updates a loose ref and does not hard-fail on this lock. Clearing the stale lock during the fetch guard unblocks all downstream ref writes in the same sync, so a single guard point is sufficient.
- To honor firstmate's one-owner rule, the shared 'is this git lock provably abandoned?' staleness proof (lsof holder check, mtime age, fail-safe-on-uncertainty) was extracted into a NEW shared lib bin/fm-lock-lib.sh. fm-teardown.sh was refactored to source and delegate to it (its four inline lock helpers were removed), and fm-fleet-sync.sh uses it too. The teardown changes are this deliberate de-duplication, not scope creep; the full fm-teardown.test.sh suite still passes to prove behavior is preserved. Diagnostics keep a per-caller prefix via FM_LOCK_LOG_PREFIX.
- Tests are colocated in tests/fm-fleet-sync.test.sh (real git repos + fake lsof/git shims, mirroring PR #435's lock-simulation shape): stale lock recovers and syncs, a live lock is never removed and the sync fails loudly, a transient lock that self-clears is retried without a force-remove, and a non-packed-refs.lock fetch failure is not retried. The shared lib's stale/live/lsof-error/mtime-fail branches are additionally exercised through the teardown suite.
- Docs updated: docs/configuration.md (narrative + the three new env knobs + the shared-proof note) and docs/scripts.md (fleet-sync row + new fm-lock-lib.sh row).

RESOLVED REVIEW DECISIONS (a prior no-mistakes round on this change was reviewed; the captain made these calls, so the following are DELIBERATE and should not be re-flagged):
- Bootstrap-visibility (was ask-user): recovery now ALSO prints one "$label: recovered: ..." summary to stdout (in addition to the detailed stderr diagnostics), because session-start bootstrap runs fleet-sync with stderr discarded and relays only stdout. Captain chose to surface recovery at session start; that is the whole point since the incident hit exactly there.
- Live-lock liveness: the staleness proof's companion directory is $PROJ (the clone worktree), NOT the .git dir. A live "git -C $PROJ" keeps its cwd there even in the narrow window after it closes packed-refs.lock and before it exits, so lsof on $PROJ catches a holder the lock-file check alone would miss. The lock file itself is still the primary check. Regression-tested (test_live_git_cwd_in_clone_dir_blocks_removal).
- The unchecked "rm -f" is now "if ! rm -f ...": a permission/IO failure is reported and the lock left in place, never mis-reported as a successful removal.
- SCOPE IS DELIBERATELY MINIMAL ("smallest guarded repair", captain-directed): a previous round's auto-fixes added a per-repo cleanup MUTEX (owner dirs, hard-link claim, PID/process-start-identity tokens) and copied fm_pid_identity into fm-lock-lib.sh. Both were DROPPED on the captain's explicit instruction: the mutex guards a race the mtime age-gate plus the single firstmate session lock already cover, and the fm_pid_identity copy (a) violated the one-owner rule and (b) shadowed fm-wake-lib.sh's real fm_pid_identity in teardown (which sources both), a real regression. Do not reintroduce them.
- Real bug fixed: teardown now sources fm-lock-lib.sh, so tests/fm-gotmp.test.sh (which symlinks teardown's helpers into a fake bin/) gained the fm-lock-lib.sh symlink.

## What Changed

Captain, here is the full branch summary:

- Add bounded, signature-specific recovery when fleet sync encounters an orphaned `.git/packed-refs.lock`, removing it only when it is provably stale and has no live holder.
- Extract the fail-safe Git lock staleness checks into a shared lock library used by fleet sync and teardown.
- Add regression coverage and documentation for transient, stale, live, and unrelated fetch-failure scenarios and the new recovery settings.

## Risk Assessment

✅ Low: Captain, the change is well-bounded, fail-safe on uncertainty, preserves teardown behavior through a shared helper, and adds focused regression coverage for the material lock-recovery paths.

## Testing

The full baseline had already passed; focused fleet-sync, teardown, and gotmp regression suites also passed, and a real-Git end-to-end run visibly demonstrated stale-lock recovery, ref pruning, and fast-forward synchronization while leaving the worktree clean.

<details>
<summary>Evidence: End-to-end stale packed-refs lock recovery transcript</summary>

```text
$ git show-ref refs/remotes/origin/feature
7bc5cffb856c476dfa94dfe01f8821250784e89a refs/remotes/origin/feature
$ test -e .git/packed-refs.lock && echo stale-lock-present
stale-lock-present
$ fm-fleet-sync.sh demo
demo: fetch blocked by packed-refs lock (/private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KX7Y74WG58X1XZCYQ2T6PYKH/home/projects/demo/.git/packed-refs.lock); waiting 0s and retrying (1/1) (owning process may be exiting)
demo: removed provably-stale packed-refs lock /private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KX7Y74WG58X1XZCYQ2T6PYKH/home/projects/demo/.git/packed-refs.lock (age >= 0s, no live holder) and retrying fetch
demo: fetch succeeded after stale packed-refs lock cleanup
demo: recovered: removed a stale packed-refs lock (no live holder)
demo: pruned feature
demo: synced 7bc5cff..9db1940
$ verify post-sync state
lock_present=no
head=9db194015b2f72ace651ca58fde44292b9f09a7e
origin_main=9db194015b2f72ace651ca58fde44292b9f09a7e
head_matches_origin=yes
pruned_feature_ref=yes
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-teardown.sh:89` - Captain, remove the obsolete `fm-wake-lib.sh` dependency after teardown&#39;s only wake-library symbol moved to `fm-lock-lib.sh`; sourcing it unnecessarily initializes the wake subsystem and creates `$STATE`.

🔧 Fix: Captain, remove obsolete teardown wake dependency
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- <code>Baseline previously passed: `command -v tmux &gt;/dev/null || { echo &#34;tmux is required for e2e tests&#34; &gt;&amp;2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo &#34;== $t ==&#34;; bash &#34;$t&#34; || rc=1; done; exit &#34;$rc&#34;`</code>
- `bash tests/fm-fleet-sync.test.sh`
- `bash tests/fm-teardown.test.sh`
- `bash tests/fm-gotmp.test.sh`
- <code>Manual real-Git E2E: created a clone with a packed, deleted remote feature ref and orphaned `.git/packed-refs.lock`; ran `bin/fm-fleet-sync.sh demo` with zero-duration test thresholds; verified the lock was removed, fetch/prune completed, feature ref disappeared, and `HEAD` matched `origin/main`</code>
- `git status --short`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
