### PR TITLE
refactor(x-mode): consolidate meta-rewrite helpers into one primitive

### DIFF
--- a/bin/fm-x-lib.sh
+++ b/bin/fm-x-lib.sh
@@ -507,6 +507,30 @@ fmx_meta_tmp() {
   mktemp "$dir/.${base}.fm-x.XXXXXX"
 }
 
+# All X-mode link keys, as one grep -E strip pattern shared by link_set and
+# link_clear. Includes the optional reply-platform context keys so a re-link or
+# clear drops them along with the core binding.
+FMX_META_LINK_KEYS='^x_request=|^x_request_ts=|^x_followups=|^x_platform=|^x_reply_max_chars='
+
+# _fmx_meta_rewrite <meta> <strip-pattern> [line ...]: atomically rewrite <meta>,
+# dropping every line matching <strip-pattern> (a grep -E alternation) and
+# appending the given literal lines, preserving all other lines. The temp file is
+# a sibling of <meta> so the final mv is atomic and TMPDIR-independent. Returns
+# non-zero on any rewrite failure. Callers own the <meta>-exists precheck, which
+# is where missing-file policy (hard error vs. no-op) differs between helpers.
+_fmx_meta_rewrite() {
+  local meta=$1 strip=$2 tmp line
+  shift 2
+  tmp=$(fmx_meta_tmp "$meta") || return 1
+  if ! { grep -vE "$strip" "$meta" || true; } > "$tmp"; then
+    rm -f "$tmp"; return 1
+  fi
+  for line in "$@"; do
+    printf '%s\n' "$line" >> "$tmp" || { rm -f "$tmp"; return 1; }
+  done
+  mv -f "$tmp" "$meta" || { rm -f "$tmp"; return 1; }
+}
+
 # fmx_meta_link_set <meta> <request_id> <epoch> [followups] [platform] [max]:
 # atomically (re)write the x_request/x_request_ts/x_followups lines plus optional
 # reply-platform context, dropping any prior link and preserving every other meta
@@ -515,37 +539,27 @@ fmx_meta_tmp() {
 # budget against a binding the relay already knows about. Returns non-zero if
 # <meta> is missing or the rewrite fails.
 fmx_meta_link_set() {
-  local meta=$1 rid=$2 ts=$3 followups=${4:-0} platform=${5:-} reply_max=${6:-} tmp
+  local meta=$1 rid=$2 ts=$3 followups=${4:-0} platform=${5:-} reply_max=${6:-}
+  local -a lines
   [ -f "$meta" ] || return 1
-  tmp=$(fmx_meta_tmp "$meta") || return 1
-  if ! { grep -vE '^x_request=|^x_request_ts=|^x_followups=|^x_platform=|^x_reply_max_chars=' "$meta" || true; } > "$tmp"; then
-    rm -f "$tmp"; return 1
-  fi
-  printf 'x_request=%s\n' "$rid" >> "$tmp" || { rm -f "$tmp"; return 1; }
-  printf 'x_request_ts=%s\n' "$ts" >> "$tmp" || { rm -f "$tmp"; return 1; }
-  printf 'x_followups=%s\n' "$followups" >> "$tmp" || { rm -f "$tmp"; return 1; }
+  lines=("x_request=$rid" "x_request_ts=$ts" "x_followups=$followups")
   if [ -n "$platform" ]; then
-    printf 'x_platform=%s\n' "$platform" >> "$tmp" || { rm -f "$tmp"; return 1; }
+    lines+=("x_platform=$platform")
   fi
   case "$reply_max" in
     ''|*[!0-9]*) ;;
-    *) printf 'x_reply_max_chars=%s\n' "$reply_max" >> "$tmp" || { rm -f "$tmp"; return 1; } ;;
+    *) lines+=("x_reply_max_chars=$reply_max") ;;
   esac
-  mv -f "$tmp" "$meta" || { rm -f "$tmp"; return 1; }
+  _fmx_meta_rewrite "$meta" "$FMX_META_LINK_KEYS" "${lines[@]}"
 }
 
 # fmx_meta_followups_set <meta> <n>: atomically rewrite just the x_followups
 # line, preserving every other meta line including link and reply context.
 # Returns non-zero if <meta> is missing or the rewrite fails.
 fmx_meta_followups_set() {
-  local meta=$1 n=$2 tmp
+  local meta=$1 n=$2
   [ -f "$meta" ] || return 1
-  tmp=$(fmx_meta_tmp "$meta") || return 1
-  if ! { grep -vE '^x_followups=' "$meta" || true; } > "$tmp"; then
-    rm -f "$tmp"; return 1
-  fi
-  printf 'x_followups=%s\n' "$n" >> "$tmp" || { rm -f "$tmp"; return 1; }
-  mv -f "$tmp" "$meta" || { rm -f "$tmp"; return 1; }
+  _fmx_meta_rewrite "$meta" '^x_followups=' "x_followups=$n"
 }
 
 # fmx_meta_link_clear <meta>: atomically remove the x_request/x_request_ts/
@@ -553,11 +567,7 @@ fmx_meta_followups_set() {
 # succeeds whether or not a link is present, and is a no-op when <meta> is
 # missing.
 fmx_meta_link_clear() {
-  local meta=$1 tmp
+  local meta=$1
   [ -f "$meta" ] || return 0
-  tmp=$(fmx_meta_tmp "$meta") || return 1
-  if ! { grep -vE '^x_request=|^x_request_ts=|^x_followups=|^x_platform=|^x_reply_max_chars=' "$meta" || true; } > "$tmp"; then
-    rm -f "$tmp"; return 1
-  fi
-  mv -f "$tmp" "$meta" || { rm -f "$tmp"; return 1; }
+  _fmx_meta_rewrite "$meta" "$FMX_META_LINK_KEYS"
 }


### PR DESCRIPTION
## Intent

Refactor the X-mode meta-link helpers in bin/fm-x-lib.sh to reduce duplicated complexity introduced by commit a80b62d (multiple X-mode follow-ups), while keeping behavior byte-identical. The three state/<id>.meta rewriters (fmx_meta_link_set, fmx_meta_followups_set, fmx_meta_link_clear) each repeated the same temp-file/grep-strip/append/mv atomic-rewrite dance with identical 'rm -f tmp; return 1' cleanup boilerplate on every step, and duplicated the link-key strip regex '^x_request=|^x_request_ts=|^x_followups='. I extracted a private _fmx_meta_rewrite primitive that takes a strip pattern and literal lines to append, plus a FMX_META_LINK_KEYS constant as the single source of truth for the strip pattern; each public helper now expresses only its distinct part while keeping its own <meta>-exists precheck (which intentionally differs: link_set/followups_set hard-return 1 on a missing meta, link_clear returns 0). This is a pure quality refactor, no functional change; the full X-mode test suite (tests/fm-x-mode.test.sh), including the TMPDIR-independence and preserve-other-lines cases, passes unchanged.

## What Changed

- Extracted a private `_fmx_meta_rewrite` primitive in `bin/fm-x-lib.sh` that performs the shared atomic temp-file/strip/append/`mv` rewrite of `state/<id>.meta`, replacing the duplicated cleanup boilerplate previously repeated across each rewriter.
- Introduced a `FMX_META_LINK_KEYS` constant as the single source of truth for the link-key strip pattern (`x_request=`/`x_request_ts=`/`x_followups=`).
- Reworked `fmx_meta_link_set`, `fmx_meta_followups_set`, and `fmx_meta_link_clear` to delegate to the primitive while keeping their distinct meta-exists prechecks (link/followups hard-return 1 on a missing meta, clear returns 0); behavior is unchanged.

## Risk Assessment

✅ Low: A well-bounded, behavior-preserving refactor that deduplicates three atomic meta-rewrite helpers into one primitive; each code path was verified equivalent to the original, including strip patterns, the numeric guard, and the intentional missing-meta precheck divergence.

## Testing

Completed 1 recorded test check.

- Outcome: ⚠️ 1 error across 4 runs (37m24s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Rebase** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-x-lib.sh` - merge conflict rebasing onto origin/main

🔧 Fix applied.
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Test** - 1 error</summary>

- 🚨 tests failed with exit code 1
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`

🔧 Fix: x-mode meta-rewrite refactor verified; remaining failures pre-existing environment issues
1 error still open:
- 🚨 tests failed with exit code 1
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`

🔧 Fix: verify x-mode meta-rewrite refactor; failures are pre-existing environment
1 error still open:
- 🚨 tests failed with exit code 1
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`

🔧 Fix: verify x-mode meta-helper refactor; remaining failures are environmental
1 error still open:
- 🚨 tests failed with exit code 1
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
