### PR TITLE
test: run Pi extension behavior tests under Node

### DIFF
--- a/tests/fm-pi-watch-extension.test.sh
+++ b/tests/fm-pi-watch-extension.test.sh
@@ -12,6 +12,7 @@ install_pi_watch_extension_fixture() {
   local repo=$1
   mkdir -p "$repo/.pi/extensions" "$repo/node_modules/typebox"
   cp "$EXT" "$repo/.pi/extensions/fm-primary-pi-watch.ts"
+  write_pi_watch_extension_runtime_copy "$EXT" "$repo/.pi/extensions/fm-primary-pi-watch.mjs"
   cat > "$repo/node_modules/typebox/package.json" <<'JSON'
 {"name":"typebox","type":"module","exports":"./index.js"}
 JSON
@@ -22,6 +23,31 @@ export const Type = {
   },
 };
 JS
+}
+
+write_pi_watch_extension_runtime_copy() {
+  local src=$1 dest=$2
+  # These behavior tests run under plain Node, while Pi itself loads the tracked TypeScript extension.
+  perl -0pe '
+    s/^import type .*\n//m;
+    s/^type ArmResult = \{\n  ok: boolean;\n  message: string;\n\};\n\n//m;
+    s/^type LockOwnership = [^\n]+;\n\n//m;
+    s/let child: any = null;/let child = null;/;
+    s/function parentPid\(pid: string\): string/function parentPid(pid)/;
+    s/function pidAlive\(pid: string\): boolean/function pidAlive(pid)/;
+    s/function lockOwnership\(\): LockOwnership/function lockOwnership()/;
+    s/function sessionOwnsLock\(\): boolean/function sessionOwnsLock()/;
+    s/function markLoaded\(\): void/function markLoaded()/;
+    s/function actionableLine\(output: string\): string/function actionableLine(output)/;
+    s/function failureLine\(stdout: string, stderr: string, code: number \| null\): string/function failureLine(stdout, stderr, code)/;
+    s/export default function \(pi: ExtensionAPI\)/export default function (pi)/;
+    s/function stopArm\(\): void/function stopArm()/;
+    s/async function sendWake\(message: string\)/async function sendWake(message)/;
+    s/function startArm\(\): ArmResult/function startArm()/;
+    s/\(chunk: Buffer\)/(chunk)/g;
+    s/\(code: number \| null\)/(code)/g;
+    s/\(error: Error\)/(error)/g;
+  ' "$src" > "$dest"
 }
 
 test_tracked_extension_present_and_self_hashing() {
@@ -76,7 +102,7 @@ test_pi_extension_reports_external_healthy_watcher() {
   home="$TMP_ROOT/pi-external-healthy-home"
   mkdir -p "$repo/bin" "$home/state" "$home/config"
   install_pi_watch_extension_fixture "$repo"
-  plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
+  plugin="$repo/.pi/extensions/fm-primary-pi-watch.mjs"
   cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
 #!/usr/bin/env bash
 printf 'watcher: healthy pid=1 (beacon 0s)\n'
@@ -150,7 +176,7 @@ test_pi_tool_returns_agent_tool_result() {
   home="$TMP_ROOT/pi-tool-result-home"
   mkdir -p "$repo/bin" "$home/state" "$home/config"
   install_pi_watch_extension_fixture "$repo"
-  plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
+  plugin="$repo/.pi/extensions/fm-primary-pi-watch.mjs"
   cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
 #!/usr/bin/env bash
 exit 0
@@ -199,7 +225,7 @@ test_pi_process_exit_cleanup_listener_lifecycle() {
   home="$TMP_ROOT/pi-exit-listener-home"
   mkdir -p "$repo/bin" "$home/state" "$home/config"
   install_pi_watch_extension_fixture "$repo"
-  plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
+  plugin="$repo/.pi/extensions/fm-primary-pi-watch.mjs"
   : > "$repo/bin/fm-watch-arm.sh"
   chmod +x "$repo/bin/fm-watch-arm.sh"
   out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" node --input-type=module 2>&1 <<'EOF'
@@ -240,7 +266,7 @@ test_pi_process_exit_cleanup_stops_arm_child() {
   pid_file="$TMP_ROOT/pi-process-exit-child.pid"
   mkdir -p "$repo/bin" "$home/state" "$home/config"
   install_pi_watch_extension_fixture "$repo"
-  plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
+  plugin="$repo/.pi/extensions/fm-primary-pi-watch.mjs"
   cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
 #!/usr/bin/env bash
 trap 'printf "cleaned\n" > "$FM_CLEANUP_LOG"; exit 0' TERM

--- a/tests/fm-turnend-guard.test.sh
+++ b/tests/fm-turnend-guard.test.sh
@@ -592,14 +592,31 @@ test_pi_extension_forces_followup() {
   pass ".pi primary extension: agent_settled forces one follow-up through the shared guard"
 }
 
+write_pi_extension_runtime_copy() {
+  local src=$1 dest=$2
+  # These behavior tests run under plain Node, while Pi itself loads the tracked TypeScript extension.
+  perl -0pe '
+    s/^import type .*\n//m;
+    s/^type LockOwnership = [^\n]+;\n\n//m;
+    s/function parentPid\(pid: string\): string/function parentPid(pid)/;
+    s/function pidAlive\(pid: string\): boolean/function pidAlive(pid)/;
+    s/function lockOwnership\(\): LockOwnership/function lockOwnership()/;
+    s/function markLoaded\(\): void/function markLoaded()/;
+    s/function runGuard\(\): Promise<\{ code: number; stderr: string \}>/function runGuard()/;
+    s/function runPretoolCheck\(command: string\): Promise<\{ code: number; stderr: string \}>/function runPretoolCheck(command)/;
+    s/export default function \(pi: ExtensionAPI\)/export default function (pi)/;
+    s/\(event\.input as \{ command\?: unknown \}\)\?\.command/event.input?.command/;
+  ' "$src" > "$dest"
+}
+
 test_pi_extension_injects_once_per_logical_agent_run() {
   local repo home ext log out status
   repo="$TMP_ROOT/pi-logical-run-root"
   home="$TMP_ROOT/pi-logical-run-home"
-  ext="$repo/.pi/extensions/fm-primary-turnend-guard.ts"
+  ext="$repo/.pi/extensions/fm-primary-turnend-guard.mjs"
   log="$TMP_ROOT/pi-logical-run-guard.log"
   mkdir -p "$repo/.pi/extensions" "$repo/bin" "$home/state"
-  cp "$ROOT/.pi/extensions/fm-primary-turnend-guard.ts" "$ext"
+  write_pi_extension_runtime_copy "$ROOT/.pi/extensions/fm-primary-turnend-guard.ts" "$ext"
   cat > "$repo/bin/fm-turnend-guard.sh" <<'SH'
 #!/usr/bin/env bash
 cat >/dev/null
@@ -658,9 +675,9 @@ test_pi_extension_retries_after_followup_delivery_failure() {
   local repo home ext out status
   repo="$TMP_ROOT/pi-delivery-failure-root"
   home="$TMP_ROOT/pi-delivery-failure-home"
-  ext="$repo/.pi/extensions/fm-primary-turnend-guard.ts"
+  ext="$repo/.pi/extensions/fm-primary-turnend-guard.mjs"
   mkdir -p "$repo/.pi/extensions" "$repo/bin" "$home/state"
-  cp "$ROOT/.pi/extensions/fm-primary-turnend-guard.ts" "$ext"
+  write_pi_extension_runtime_copy "$ROOT/.pi/extensions/fm-primary-turnend-guard.ts" "$ext"
   cat > "$repo/bin/fm-turnend-guard.sh" <<'SH'
 #!/usr/bin/env bash
 cat >/dev/null


### PR DESCRIPTION
## Summary
- Fix the base-branch Pi extension test failures by generating plain `.mjs` runtime copies of the tracked TypeScript Pi extensions for Node-based behavior tests.
- The product extension code is unchanged; Pi itself loads the tracked `.ts` extensions, while these tests run under plain Node without a TypeScript loader.
- This keeps the behavior coverage intact for the Pi turn-end guard and Pi watcher bridge.

## Diagnosis
The failing Pi guard base test was a stale/incorrect test harness, not a functional guard bug or product/design issue.
The test copied `.pi/extensions/fm-primary-turnend-guard.ts` and imported it directly with plain Node via `pathToFileURL(...)`; Node failed before exercising the guard behavior with `ERR_UNKNOWN_FILE_EXTENSION: Unknown file extension ".ts"`.
The neighboring Pi watcher extension tests had the same plain-Node import problem for `.pi/extensions/fm-primary-pi-watch.ts`.

## Validation
- PASS: `tests/fm-turnend-guard.test.sh`
- PASS: `tests/fm-pi-watch-extension.test.sh`
- PASS: `bash -n tests/fm-pi-watch-extension.test.sh tests/fm-turnend-guard.test.sh`
- PASS: `git diff --check`
- NOTE: `shellcheck` is not installed in this local environment, so shellcheck could not be run here.

## Full-suite note
This PR fixes the genuinely broken Pi base failures.
The env-specific cmux placeholder failure from the previous no-mistakes run is intentionally left alone; targeted `tests/fm-backend-cmux.test.sh` passed manually on both base and the prior branch in this shell.
Other base full-suite failures observed earlier, such as `tasks-axi` version-dependent backlog handoff failures, are separate repo-health/environment issues and are outside this PR.