### PR TITLE
Fix Codex Stop hook session corruption

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -50,7 +50,8 @@ Use that value for interrupt, exit, resume, and skill-invocation facts.
 ## Primary turn-end guard
 
 Every verified primary harness has an empirically validated hook path for the "no turn ends blind" guard.
-`claude` and `codex` block directly through Stop hooks that preserve exit status 2 and stderr from `bin/fm-turnend-guard.sh`.
+`claude` blocks directly through a Stop hook that preserves exit status 2 and stderr from `bin/fm-turnend-guard.sh`.
+`codex` temporarily returns a non-blocking `systemMessage` and durable wake because openai/codex#20783 makes its blocking Stop continuation corrupt later Desktop follow-ups.
 `opencode`, `pi`, and `grok` expose passive lifecycle callbacks for this purpose, so their tracked primary adapters force one bounded follow-up or resume when the shared predicate blocks.
 The exact hook files, commands, validation transcripts, scoping rules, and fail-open tradeoffs are owned by `docs/turnend-guard.md`.
 When changing any primary turn-end hook, validate the real harness behavior in a scratch project or throwaway home before trusting it, then update that doc and the relevant concise fact below.

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -153,12 +153,13 @@ The decision persists for the repo, so later worktrees of the same project skip 
 Resume after exit with `codex resume <session-id>`.
 The session id is printed on quit.
 
-**Primary-session guard fact (verified 2026-07-08, codex-cli 0.142.1).**
-The firstmate PRIMARY's own `.codex/hooks.json` registers a Stop hook that pipes Codex's Stop payload to `bin/fm-turnend-guard.sh`.
-Codex Stop hooks block on exit 2 and expose `stop_hook_active` for the same one-block loop safety Claude uses.
+**Primary-session guard fact (verified 2026-07-10, codex-cli 0.144.1).**
+The firstmate PRIMARY's own `.codex/hooks.json` pipes Codex's Stop payload through `bin/fm-turnend-guard-codex.sh`, which runs the shared predicate, returns a non-blocking `systemMessage`, durably queues an unhealthy-watcher alarm, and always exits 0.
+Blocking Codex Stop continuations are disabled because [openai/codex#20783](https://github.com/openai/codex/issues/20783) persists their synthetic `<hook_prompt>` with a bare UUID and later Desktop follow-ups fail `invalid_id_prefix` instead of accepting the required `msg_` id.
+Codex Stop hooks expose `stop_hook_active`, but the adapter does not propagate the shared predicate's exit 2 while the upstream bug is unresolved.
 Codex's Stop payload includes `cwd`, but the tracked primary hook does not use it to choose the guard executable.
 Verified on 2026-07-08: Codex runs the Stop hook command with process PWD set to the hook-loaded project root, and no `CODEX_PROJECT_DIR`, `CODEX_WORKSPACE_ROOT`, or `CODEX_CWD` root variable is set.
-The tracked hook anchors to `pwd -P`, verifies that root is firstmate-shaped and hook-bearing, and then invokes `bin/fm-turnend-guard.sh` with the original payload.
+The tracked hook anchors to `pwd -P`, verifies that root is firstmate-shaped and hook-bearing, and then invokes `bin/fm-turnend-guard-codex.sh` with the original payload.
 Codex's primary watcher protocol is `bin/fm-watch-checkpoint.sh --seconds "${FM_CODEX_WATCH_CHECKPOINT:-180}"`, not `bin/fm-watch-arm.sh`.
 The checkpoint is deliberately foreground and bounded so Codex regains control regularly to process user messages and queued wakes.
 

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -lc 'payload=$(cat 2>/dev/null || true); [ -n \"$payload\" ] || exit 0; command -v jq >/dev/null 2>&1 || exit 0; root=$(pwd -P) || exit 0; [ -x \"$root/bin/fm-turnend-guard.sh\" ] || exit 0; [ -f \"$root/AGENTS.md\" ] || exit 0; [ -f \"$root/.codex/hooks.json\" ] || exit 0; jq -e \"any(.hooks.Stop[]?.hooks[]?.command?; type == \\\"string\\\" and contains(\\\"fm-turnend-guard.sh\\\"))\" \"$root/.codex/hooks.json\" >/dev/null 2>&1 || exit 0; printf \"%s\" \"$payload\" | \"$root/bin/fm-turnend-guard.sh\"'",
+            "command": "bash -lc 'payload=$(cat 2>/dev/null || true); [ -n \"$payload\" ] || exit 0; command -v jq >/dev/null 2>&1 || exit 0; root=$(pwd -P) || exit 0; [ -x \"$root/bin/fm-turnend-guard-codex.sh\" ] || exit 0; [ -f \"$root/AGENTS.md\" ] || exit 0; [ -f \"$root/.codex/hooks.json\" ] || exit 0; jq -e \"any(.hooks.Stop[]?.hooks[]?.command?; type == \\\"string\\\" and contains(\\\"fm-turnend-guard-codex.sh\\\"))\" \"$root/.codex/hooks.json\" >/dev/null 2>&1 || exit 0; printf \"%s\" \"$payload\" | \"$root/bin/fm-turnend-guard-codex.sh\"'",
             "timeout": 30
           }
         ]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -613,7 +613,8 @@ If a crewmate sent to work firstmate-on-itself branches or commits in the primar
 Only a named non-default branch checked out in the primary alarms: detached HEAD (the legitimate resting state of crewmate worktrees and secondmate homes) and the default branch never do.
 The same assertion runs at session start as the bootstrap `TANGLE:` line (handled via `bootstrap-diagnostics`), and two upstream guards prevent the tangle: `fm-spawn`'s isolated-worktree assertion and the ship brief's opening isolation check (section 11).
 
-On every verified primary harness, "no turn ends blind" has a structural backstop beyond the pull-based banner: `bin/fm-turnend-guard.sh` blocks the turn end (or forces one bounded follow-up on passive harnesses) when tasks are in flight without a live identity-matched watcher lock and fresh beacon, fires only in the actual primary checkout, and stays silent when supervision is healthy.
+On every verified primary harness, "no turn ends blind" has a structural backstop beyond the pull-based banner: `bin/fm-turnend-guard.sh` checks for tasks in flight without a live identity-matched watcher lock and fresh beacon, fires only in the actual primary checkout, and stays silent when supervision is healthy.
+Claude blocks the turn end, Codex records a durable non-blocking alarm while openai/codex#20783 is unresolved, and passive harnesses force one bounded follow-up.
 `docs/turnend-guard.md` owns the per-harness hook mechanisms, empirical validation, scoping details, and documented fail-open tradeoffs.
 Watcher liveness is harness-aware.
 Do not assume one primary harness can use another harness's foreground or background shape.

--- a/bin/fm-turnend-guard-codex.sh
+++ b/bin/fm-turnend-guard-codex.sh
@@ -20,7 +20,7 @@ PAYLOAD=$(cat 2>/dev/null || true)
 ERR=$(mktemp "${TMPDIR:-/tmp}/fm-turnend-codex.XXXXXX") || exit 0
 trap 'rm -f "$ERR"' EXIT
 
-printf '%s' "$PAYLOAD" | "$GUARD" 2>"$ERR"
+printf '%s' "$PAYLOAD" | FM_CODEX_TURNEND_ADAPTER_ACTIVE=1 "$GUARD" 2>"$ERR"
 RC=$?
 [ "$RC" -eq 2 ] || exit 0
 

--- a/bin/fm-turnend-guard-codex.sh
+++ b/bin/fm-turnend-guard-codex.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Codex Stop-hook adapter for the firstmate PRIMARY turn-end guard.
+#
+# Codex currently persists a blocking Stop continuation as a synthetic
+# <hook_prompt> item with a bare UUID, then rejects that id on a later Desktop
+# follow-up because Responses API item ids must begin with msg_ (openai/codex#20783).
+# Keep using the shared primary-scoped predicate, but fail open at the Codex hook
+# boundary until upstream fixes the serialization bug. When the predicate says
+# the primary would end blind, return a non-blocking systemMessage and enqueue the
+# warning so the next supervision checkpoint or session start sees durable evidence.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GUARD="$SCRIPT_DIR/fm-turnend-guard.sh"
+[ -x "$GUARD" ] || exit 0
+
+PAYLOAD=$(cat 2>/dev/null || true)
+[ -n "$PAYLOAD" ] || exit 0
+
+ERR=$(mktemp "${TMPDIR:-/tmp}/fm-turnend-codex.XXXXXX") || exit 0
+trap 'rm -f "$ERR"' EXIT
+
+printf '%s' "$PAYLOAD" | "$GUARD" 2>"$ERR"
+RC=$?
+[ "$RC" -eq 2 ] || exit 0
+
+REASON=$(cat "$ERR" 2>/dev/null || true)
+[ -n "$REASON" ] || REASON='TURN WOULD END BLIND - tasks are in flight without a live watcher.'
+
+# shellcheck source=bin/fm-wake-lib.sh
+. "$SCRIPT_DIR/fm-wake-lib.sh"
+fm_wake_append check codex-turnend-guard \
+  'check: Codex turn-end guard allowed the stop to protect session history; resume the foreground supervision checkpoint.' \
+  >/dev/null 2>&1 || true
+
+WARNING=$(printf '%s\n\n%s' "$REASON" 'Codex workaround: stop allowed and warning queued durably because openai/codex#20783 makes blocking Stop continuations corrupt later Desktop follow-ups.')
+jq -cn --arg warning "$WARNING" '{continue:true,systemMessage:$warning}' 2>/dev/null || true
+exit 0

--- a/bin/fm-turnend-guard.sh
+++ b/bin/fm-turnend-guard.sh
@@ -7,9 +7,9 @@
 # fleet-touching command itself, can sit blind for hours.
 # This script is push-based: verified harness turn-end hooks invoke it every time
 # the primary is about to end a turn.
-# Claude and codex can block directly by preserving exit status 2 and stderr.
-# OpenCode, pi, and grok adapters use the same predicate and force one bounded
-# follow-up because their turn-end events are passive.
+# Claude blocks directly by preserving exit status 2 and stderr.
+# Codex fails open through a durable-warning adapter while openai/codex#20783 is
+# unresolved, and OpenCode, pi, and grok force one bounded passive follow-up.
 # See docs/turnend-guard.md for the per-harness mechanics, validation evidence,
 # and fail-open tradeoffs.
 #
@@ -20,12 +20,12 @@
 # (treehouse-leased or git-cloned). It must therefore scope itself to the
 # PRIMARY at runtime and stay a silent, fast no-op everywhere else.
 #
-# Loop-guard: never block twice in the same turn. Claude Code and codex Stop
+# Loop-guard: never block twice in the same turn. Claude Code and Codex Stop
 # payloads carry stop_hook_active=true when the CURRENT stop attempt was itself
 # already forced by an earlier block this turn; on that signal we always allow
-# the stop, whether or not watcher supervision actually got resumed. Passive
-# harness adapters provide their own one-follow-up guard before calling this
-# script.
+# the stop, whether or not watcher supervision actually got resumed. The Codex
+# adapter currently never propagates a block, and passive harness adapters
+# provide their own one-follow-up guard before calling this script.
 # That bounds this to at most one forced continuation per turn - never a wedged,
 # un-endable session - while still nagging again on a later turn if the problem
 # persists.

--- a/bin/fm-turnend-guard.sh
+++ b/bin/fm-turnend-guard.sh
@@ -55,6 +55,20 @@ command -v jq >/dev/null 2>&1 || exit 0
 STOP_HOOK_ACTIVE=$(printf '%s' "$PAYLOAD" | jq -r '.stop_hook_active // false' 2>/dev/null) || exit 0
 [ "$STOP_HOOK_ACTIVE" = "true" ] && exit 0
 
+# Compatibility for Codex sessions that cached the former hook command before
+# .codex/hooks.json was changed to call the fail-open adapter. Codex's generated
+# Stop schema requires turn_id and documents it as a Codex extension; Claude's
+# direct blocking Stop payload and the passive harness adapters do not carry it.
+# Route only that exact Codex-shaped payload, and mark the adapter's call back
+# into this shared predicate so it cannot recurse.
+if [ "${FM_CODEX_TURNEND_ADAPTER_ACTIVE:-0}" != "1" ] \
+  && printf '%s' "$PAYLOAD" | jq -e \
+    '.hook_event_name == "Stop" and (.turn_id | type == "string" and length > 0)' \
+    >/dev/null 2>&1; then
+  printf '%s' "$PAYLOAD" | "$SCRIPT_DIR/fm-turnend-guard-codex.sh" || true
+  exit 0
+fi
+
 # --- scope precisely to the PRIMARY checkout --------------------------------
 # Excludes secondmate homes (the .fm-secondmate-home marker is written at seed
 # time regardless of whether the home was treehouse-leased or git-cloned; see

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -18,7 +18,7 @@ If you have changed away from the firstmate home in an interactive shell, invoke
 | `fm-ensure-agents-md.sh` | Ensure a project's real `AGENTS.md`, its `CLAUDE.md` symlink, and the canonical self-governance section |
 | `fm-guard.sh`            | Warn on primary-checkout tangles, pending queued wakes, and stale watcher liveness   |
 | `fm-turnend-guard.sh`    | Shared primary turn-end guard predicate so no turn ends blind (docs/turnend-guard.md) |
-| `fm-turnend-guard-codex.sh` | Protect Codex history with a non-blocking warning and durable wake when supervision is absent |
+| `fm-turnend-guard-codex.sh` | Codex Stop-hook adapter that records non-blocking wake evidence without corrupting Desktop history |
 | `fm-turnend-guard-grok.sh` | Grok Stop-hook adapter for the primary turn-end guard                              |
 | `fm-arm-pretool-check.sh` | Stable PreToolUse transport for the watcher-arm command policy (docs/arm-pretool-check.md) |
 | `fm-arm-command-policy.mjs` | Semantic owner of the watcher-arm PreToolUse policy (docs/arm-pretool-check.md)   |

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -18,6 +18,7 @@ If you have changed away from the firstmate home in an interactive shell, invoke
 | `fm-ensure-agents-md.sh` | Ensure a project's real `AGENTS.md`, its `CLAUDE.md` symlink, and the canonical self-governance section |
 | `fm-guard.sh`            | Warn on primary-checkout tangles, pending queued wakes, and stale watcher liveness   |
 | `fm-turnend-guard.sh`    | Shared primary turn-end guard predicate so no turn ends blind (docs/turnend-guard.md) |
+| `fm-turnend-guard-codex.sh` | Protect Codex history with a non-blocking warning and durable wake when supervision is absent |
 | `fm-turnend-guard-grok.sh` | Grok Stop-hook adapter for the primary turn-end guard                              |
 | `fm-arm-pretool-check.sh` | Stable PreToolUse transport for the watcher-arm command policy (docs/arm-pretool-check.md) |
 | `fm-arm-command-policy.mjs` | Semantic owner of the watcher-arm PreToolUse policy (docs/arm-pretool-check.md)   |

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -77,8 +77,9 @@ The persisted UUID mapped exactly to the earlier blocking Stop continuation, mat
 Current upstream source and the available `0.145` alpha remained unfixed on 2026-07-10.
 The tracked Codex adapter therefore records the alarm durably and exits 0 until upstream fixes the item-id serialization path.
 Command run for the isolated live adapter regression on 2026-07-10 with `codex-cli 0.144.1`: `FM_CODEX_LIVE_E2E=1 node tests/fm-codex-turnend-live-e2e.mjs`.
-Observed output: `FIRST_TURN_COMPLETED`, `NO_HOOK_PROMPT_PERSISTED`, `DURABLE_WAKE_QUEUED`, and `SECOND_DESKTOP_STYLE_FOLLOWUP_COMPLETED`.
+Observed output: `FIRST_TURN_COMPLETED`, `SYSTEM_MESSAGE_WARNING_OBSERVED`, `NO_HOOK_PROMPT_PERSISTED`, `DURABLE_WAKE_QUEUED`, `SECOND_DESKTOP_STYLE_FOLLOWUP_COMPLETED`, and `SECOND_AGENT_MESSAGE_OBSERVED`.
 The live regression uses `codex app-server --stdio`, a temporary plain Git project, temporary `CODEX_HOME` and `FM_HOME`, copied runtime auth files without printing them, `bypass_hook_trust=true`, `features.item_ids=true`, an unhealthy watcher fixture, and two `turn/start` calls.
+It requires both turn notifications to report `status=completed` with no turn error, requires a nonempty agent message from each turn, and requires the Stop-hook notification to contain the openai/codex#20783 system warning.
 It never opens or modifies the live Codex session directory, and it deletes the temporary fixture on exit.
 The Stop payload included `cwd`.
 Command run for root-signal probe: `codex exec --ephemeral --json --dangerously-bypass-hook-trust --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check --output-last-message last.txt 'Use the shell tool to run mkdir -p outside && cd outside && pwd, then use the shell tool again to run pwd. Your final answer must include the two observed outputs.'`.

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -37,16 +37,17 @@ If `jq` is missing or hook stdin is empty, the guard fails open and exits 0 beca
 All verified primary harnesses have a tracked integration:
 
 - `claude`: `.claude/settings.json` registers a `Stop` hook command anchored through `"$CLAUDE_PROJECT_DIR"/bin/fm-turnend-guard.sh`.
-- `codex`: `.codex/hooks.json` registers a `Stop` hook that reads the hook payload once, anchors the executable to the hook command process working directory, verifies that root is firstmate-shaped and hook-bearing, and pipes the original payload to that checkout's `bin/fm-turnend-guard.sh`.
+- `codex`: `.codex/hooks.json` registers a `Stop` hook that reads the hook payload once, anchors the executable to the hook command process working directory, verifies that root is firstmate-shaped and hook-bearing, and pipes the original payload to that checkout's `bin/fm-turnend-guard-codex.sh` adapter.
 - `opencode`: `.opencode/plugins/fm-primary-turnend-guard.js` listens for `session.idle`, lets the watcher-arm coordinator handle normal idle supervision first, runs the shared guard only when that coordinator does not act, and uses `client.session.promptAsync` to force one follow-up prompt when the guard returns 2.
 - `pi`: `.pi/extensions/fm-primary-turnend-guard.ts` listens for `agent_settled`, marks the extension version loaded for session-start checks, runs the shared guard once per logical agent run, and uses `pi.sendUserMessage(..., { deliverAs: "followUp" })` to force one follow-up prompt when the guard returns 2.
 - `grok`: `.grok/hooks/fm-primary-turnend-guard.json` registers a `Stop` hook that invokes `bin/fm-turnend-guard-grok.sh`.
   The adapter runs the shared guard and, when it returns 2, invokes `grok --resume <sessionId> -p <guard-reason>` with `GROK_TURNEND_GUARD_ACTIVE=1`.
   It does not pass `--permission-mode`, so the passive Stop hook cannot grant stronger tool permissions than Grok's resumed-session default.
 
-Claude and Codex support a direct blocking Stop hook.
-For those harnesses, exit status 2 plus stderr from `bin/fm-turnend-guard.sh` blocks the stop and feeds the reason back into the model.
-Both payloads include `stop_hook_active`; when it is true, the shared guard exits 0 so the harness can end after one forced continuation.
+Claude supports a direct blocking Stop hook, where exit status 2 plus stderr from `bin/fm-turnend-guard.sh` blocks the stop and feeds the reason back into the model.
+Codex's blocking Stop path is disabled while openai/codex#20783 is unresolved because the generated continuation corrupts later Desktop follow-ups.
+The Codex adapter still runs the shared predicate, returns its warning as a valid `{continue:true,systemMessage:<warning>}` result, appends a durable `codex-turnend-guard` wake, and always exits 0 without spawning or resuming Codex.
+Claude and Codex payloads include `stop_hook_active`; when it is true, the shared guard exits 0.
 
 OpenCode, Pi, and Grok expose passive lifecycle callbacks for this purpose.
 Their adapters fail open at the hook boundary to avoid corrupting a user session, but they force one follow-up turn when the shared predicate blocks.
@@ -69,6 +70,11 @@ Codex `codex-cli 0.142.1` was validated with a scratch `.codex/hooks.json` Stop 
 Hook file used: `.codex/hooks.json`.
 Command run: `codex exec --dangerously-bypass-hook-trust --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check --output-last-message last.txt 'Say hi in exactly one word.'`.
 Observed output: the first model output was `Hi`, the Stop hook exited 2, Codex logged `hook: Stop Blocked`, the model continued with `CODEXHOOK`, and the second hook call had `stop_hook_active=true`.
+That blocking behavior is no longer safe for a Desktop-resumable primary session.
+On 2026-07-10, Codex `0.144.1` persisted the synthetic `<hook_prompt>` continuation with a bare UUID and a later Codex Desktop follow-up failed with `[invalid_id_prefix] Expected an ID that begins with 'msg'`.
+The persisted UUID mapped exactly to the earlier blocking Stop continuation, matching upstream issue [openai/codex#20783](https://github.com/openai/codex/issues/20783).
+Current upstream source and the available `0.145` alpha remained unfixed on 2026-07-10.
+The tracked Codex adapter therefore records the alarm durably and exits 0 until upstream fixes the item-id serialization path.
 The Stop payload included `cwd`.
 Command run for root-signal probe: `codex exec --ephemeral --json --dangerously-bypass-hook-trust --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check --output-last-message last.txt 'Use the shell tool to run mkdir -p outside && cd outside && pwd, then use the shell tool again to run pwd. Your final answer must include the two observed outputs.'`.
 Observed output: the first command printed `<scratch>/outside`, the second command printed `<scratch>`, the Stop hook process `pwd -P` printed `<scratch>`, payload `cwd` printed `<scratch>`, and `CODEX_PROJECT_DIR`, `CODEX_WORKSPACE_ROOT`, and `CODEX_CWD` were empty.
@@ -114,6 +120,8 @@ See `docs/arm-pretool-check.md`'s "Harness wiring" section for the same Grok exp
 
 ## Tests
 
-`tests/fm-turnend-guard.test.sh` covers the shared predicate, primary scoping, `FM_HOME` and `FM_STATE_OVERRIDE` precedence, Pi logical-run latch behavior for no-tool and multi-tool runs, fail-open behavior without `jq`, tracked hook registration for all five harnesses, and the Grok adapter's forced-resume loop guard and permission-mode regression.
+`tests/fm-turnend-guard.test.sh` covers the shared predicate, primary scoping, `FM_HOME` and `FM_STATE_OVERRIDE` precedence, the Codex adapter's non-blocking durable warning, Pi logical-run latch behavior for no-tool and multi-tool runs, fail-open behavior without `jq`, tracked hook registration for all five harnesses, and the Grok adapter's forced-resume loop guard and permission-mode regression.
+Command run on 2026-07-10: `tests/fm-turnend-guard.test.sh`.
+Observed Codex regression output: `ok - .codex/hooks.json: unhealthy watcher returns systemMessage JSON and queues durably without blocking Codex`.
 The default behavior suite does not invoke live language-model harnesses.
 `FM_PI_LIVE_E2E=1 tests/fm-pi-primary-live-e2e.test.sh` opts into the isolated interactive Pi regression recorded above.

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -12,7 +12,8 @@ The primary can otherwise end a turn after handling wakes without resuming super
 On 2026-07-04, that exact gap left a parked no-mistakes gate unwatched for about nine hours.
 
 `bin/fm-turnend-guard.sh` closes the gap by checking the primary's own turn-end path.
-When tasks are in flight and there is no live identity-matched watcher with a fresh beacon, a harness hook must either block the turn end or force a bounded follow-up turn that tells the primary to resume the session-start supervision protocol for its harness.
+When tasks are in flight and there is no live identity-matched watcher with a fresh beacon, Claude blocks the turn end and the passive harness adapters force a bounded follow-up turn that tells the primary to resume supervision.
+Codex is the temporary fail-open exception while openai/codex#20783 is unresolved: its adapter returns a visible non-blocking warning and records a durable wake for the next foreground checkpoint or session start.
 
 ## Shared Predicate
 
@@ -75,6 +76,10 @@ On 2026-07-10, Codex `0.144.1` persisted the synthetic `<hook_prompt>` continuat
 The persisted UUID mapped exactly to the earlier blocking Stop continuation, matching upstream issue [openai/codex#20783](https://github.com/openai/codex/issues/20783).
 Current upstream source and the available `0.145` alpha remained unfixed on 2026-07-10.
 The tracked Codex adapter therefore records the alarm durably and exits 0 until upstream fixes the item-id serialization path.
+Command run for the isolated live adapter regression on 2026-07-10 with `codex-cli 0.144.1`: `FM_CODEX_LIVE_E2E=1 node tests/fm-codex-turnend-live-e2e.mjs`.
+Observed output: `FIRST_TURN_COMPLETED`, `NO_HOOK_PROMPT_PERSISTED`, `DURABLE_WAKE_QUEUED`, and `SECOND_DESKTOP_STYLE_FOLLOWUP_COMPLETED`.
+The live regression uses `codex app-server --stdio`, a temporary plain Git project, temporary `CODEX_HOME` and `FM_HOME`, copied runtime auth files without printing them, `bypass_hook_trust=true`, `features.item_ids=true`, an unhealthy watcher fixture, and two `turn/start` calls.
+It never opens or modifies the live Codex session directory, and it deletes the temporary fixture on exit.
 The Stop payload included `cwd`.
 Command run for root-signal probe: `codex exec --ephemeral --json --dangerously-bypass-hook-trust --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check --output-last-message last.txt 'Use the shell tool to run mkdir -p outside && cd outside && pwd, then use the shell tool again to run pwd. Your final answer must include the two observed outputs.'`.
 Observed output: the first command printed `<scratch>/outside`, the second command printed `<scratch>`, the Stop hook process `pwd -P` printed `<scratch>`, payload `cwd` printed `<scratch>`, and `CODEX_PROJECT_DIR`, `CODEX_WORKSPACE_ROOT`, and `CODEX_CWD` were empty.
@@ -124,4 +129,5 @@ See `docs/arm-pretool-check.md`'s "Harness wiring" section for the same Grok exp
 Command run on 2026-07-10: `tests/fm-turnend-guard.test.sh`.
 Observed Codex regression output: `ok - .codex/hooks.json: unhealthy watcher returns systemMessage JSON and queues durably without blocking Codex`.
 The default behavior suite does not invoke live language-model harnesses.
+`FM_CODEX_LIVE_E2E=1 node tests/fm-codex-turnend-live-e2e.mjs` opts into the isolated Codex app-server regression recorded above and fails clearly when Codex auth is unavailable.
 `FM_PI_LIVE_E2E=1 tests/fm-pi-primary-live-e2e.test.sh` opts into the isolated interactive Pi regression recorded above.

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -48,6 +48,7 @@ All verified primary harnesses have a tracked integration:
 Claude supports a direct blocking Stop hook, where exit status 2 plus stderr from `bin/fm-turnend-guard.sh` blocks the stop and feeds the reason back into the model.
 Codex's blocking Stop path is disabled while openai/codex#20783 is unresolved because the generated continuation corrupts later Desktop follow-ups.
 The Codex adapter still runs the shared predicate, returns its warning as a valid `{continue:true,systemMessage:<warning>}` result, appends a durable `codex-turnend-guard` wake, and always exits 0 without spawning or resuming Codex.
+Long-lived Codex sessions may retain the former command that invokes the shared predicate directly. The shared guard recognizes Codex's required `turn_id` Stop-payload extension and self-routes those cached calls through the same fail-open adapter; Claude payloads do not carry that field and retain direct blocking semantics.
 Claude and Codex payloads include `stop_hook_active`; when it is true, the shared guard exits 0.
 
 OpenCode, Pi, and Grok expose passive lifecycle callbacks for this purpose.
@@ -78,7 +79,7 @@ Current upstream source and the available `0.145` alpha remained unfixed on 2026
 The tracked Codex adapter therefore records the alarm durably and exits 0 until upstream fixes the item-id serialization path.
 Command run for the isolated live adapter regression on 2026-07-10 with `codex-cli 0.144.1`: `FM_CODEX_LIVE_E2E=1 node tests/fm-codex-turnend-live-e2e.mjs`.
 Observed output: `FIRST_TURN_COMPLETED`, `SYSTEM_MESSAGE_WARNING_OBSERVED`, `NO_HOOK_PROMPT_PERSISTED`, `DURABLE_WAKE_QUEUED`, `SECOND_DESKTOP_STYLE_FOLLOWUP_COMPLETED`, and `SECOND_AGENT_MESSAGE_OBSERVED`.
-The live regression uses `codex app-server --stdio`, a temporary plain Git project, temporary `CODEX_HOME` and `FM_HOME`, copied runtime auth files without printing them, `bypass_hook_trust=true`, `features.item_ids=true`, an unhealthy watcher fixture, and two `turn/start` calls.
+The live regression uses `codex app-server --stdio`, a temporary plain Git project, temporary `CODEX_HOME` and `FM_HOME`, copied runtime auth files without printing them, the literal pre-adapter Stop command that calls `fm-turnend-guard.sh` directly, `bypass_hook_trust=true`, `features.item_ids=true`, an unhealthy watcher fixture, and two `turn/start` calls.
 It requires both turn notifications to report `status=completed` with no turn error, requires a nonempty agent message from each turn, and requires the Stop-hook notification to contain the openai/codex#20783 system warning.
 It never opens or modifies the live Codex session directory, and it deletes the temporary fixture on exit.
 The Stop payload included `cwd`.

--- a/tests/fm-codex-turnend-live-e2e.mjs
+++ b/tests/fm-codex-turnend-live-e2e.mjs
@@ -93,6 +93,17 @@ try {
     fs.chmodSync(path.join(project, "bin", name), 0o755);
   }
 
+  // Exercise the exact pre-adapter command shape a long-lived Codex session
+  // can retain after deployment. The shared guard must recognize Codex's
+  // turn_id extension and self-route without persisting a blocking hook prompt.
+  const legacyStopCommand = `bash -lc 'payload=$(cat 2>/dev/null || true); [ -n "$payload" ] || exit 0; command -v jq >/dev/null 2>&1 || exit 0; root=$(pwd -P) || exit 0; [ -x "$root/bin/fm-turnend-guard.sh" ] || exit 0; [ -f "$root/AGENTS.md" ] || exit 0; [ -f "$root/.codex/hooks.json" ] || exit 0; jq -e "any(.hooks.Stop[]?.hooks[]?.command?; type == \\"string\\" and contains(\\"fm-turnend-guard.sh\\"))" "$root/.codex/hooks.json" >/dev/null 2>&1 || exit 0; printf "%s" "$payload" | "$root/bin/fm-turnend-guard.sh"'`;
+  fs.writeFileSync(
+    path.join(project, ".codex", "hooks.json"),
+    `${JSON.stringify({
+      hooks: { Stop: [{ hooks: [{ type: "command", command: legacyStopCommand, timeout: 30 }] }] },
+    })}\n`,
+  );
+
   const gitInit = spawnSync("git", ["init", "-q", project], { encoding: "utf8" });
   if (gitInit.error || gitInit.status !== 0) {
     throw new Error(`could not initialize the disposable project: ${gitInit.stderr.trim()}`);

--- a/tests/fm-codex-turnend-live-e2e.mjs
+++ b/tests/fm-codex-turnend-live-e2e.mjs
@@ -108,6 +108,7 @@ try {
   let stderr = "";
   let activeTurn;
   const pending = new Map();
+  const hookWarnings = [];
 
   child.stderr.setEncoding("utf8");
   child.stderr.on("data", (chunk) => {
@@ -137,7 +138,7 @@ try {
         activeTurn = undefined;
         reject(new Error("turn timed out after 40 seconds"));
       }, 40000);
-      activeTurn = { resolve, reject, timer };
+      activeTurn = { resolve, reject, timer, agentOutput: "" };
     });
   }
 
@@ -171,12 +172,31 @@ try {
       else waiter.resolve(message.result);
       return;
     }
+    if (message.method === "hook/completed") {
+      const run = message.params?.run;
+      if (run?.eventName === "stop") {
+        for (const entry of run.entries || []) {
+          if (typeof entry?.text === "string") hookWarnings.push(entry.text);
+        }
+        if (typeof run.statusMessage === "string") hookWarnings.push(run.statusMessage);
+      }
+    }
     if (!activeTurn) return;
-    if (message.method === "turn/completed") {
+    if (message.method === "item/completed" && message.params?.item?.type === "agentMessage") {
+      const text = message.params.item.text;
+      if (typeof text === "string") activeTurn.agentOutput += text;
+    } else if (message.method === "turn/completed") {
       const waiter = activeTurn;
       activeTurn = undefined;
       clearTimeout(waiter.timer);
-      waiter.resolve(message.params);
+      const turn = message.params?.turn;
+      if (turn?.status !== "completed" || turn.error != null) {
+        waiter.reject(new Error(`turn ended as ${turn?.status || "unknown"}: ${JSON.stringify(turn?.error ?? null)}`));
+      } else if (!waiter.agentOutput.trim()) {
+        waiter.reject(new Error("completed turn emitted no nonempty agent message"));
+      } else {
+        waiter.resolve({ turn, agentOutput: waiter.agentOutput });
+      }
     } else if (message.method === "error") {
       const waiter = activeTurn;
       activeTurn = undefined;
@@ -218,6 +238,11 @@ try {
   await runTurn("msg_e2e_first");
   console.log("FIRST_TURN_COMPLETED");
 
+  if (!hookWarnings.some((warning) => warning.includes("openai/codex#20783"))) {
+    throw new Error("Codex app-server emitted no Stop-hook warning containing openai/codex#20783");
+  }
+  console.log("SYSTEM_MESSAGE_WARNING_OBSERVED");
+
   const persisted = sessionFiles(path.join(codexHome, "sessions"))
     .map((file) => fs.readFileSync(file, "utf8"))
     .join("\n");
@@ -234,6 +259,7 @@ try {
 
   await runTurn("msg_e2e_second");
   console.log("SECOND_DESKTOP_STYLE_FOLLOWUP_COMPLETED");
+  console.log("SECOND_AGENT_MESSAGE_OBSERVED");
 } finally {
   await stopChild(child);
   fs.rmSync(tempRoot, { recursive: true, force: true });

--- a/tests/fm-codex-turnend-live-e2e.mjs
+++ b/tests/fm-codex-turnend-live-e2e.mjs
@@ -1,0 +1,240 @@
+#!/usr/bin/env node
+
+import { spawn, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import readline from "node:readline";
+import { fileURLToPath } from "node:url";
+
+if (process.env.FM_CODEX_LIVE_E2E !== "1") {
+  console.log("skip: set FM_CODEX_LIVE_E2E=1 to run the isolated Codex app-server regression");
+  process.exit(0);
+}
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const versionProbe = spawnSync("codex", ["--version"], { encoding: "utf8" });
+if (versionProbe.error || versionProbe.status !== 0) {
+  throw new Error("codex is required on PATH for FM_CODEX_LIVE_E2E=1");
+}
+
+const realCodexHome = process.env.CODEX_HOME || path.join(os.homedir(), ".codex");
+const authCandidates = ["auth.json", ".credentials.json"];
+if (!authCandidates.some((name) => fs.existsSync(path.join(realCodexHome, name)))) {
+  throw new Error(`Codex auth is missing from ${realCodexHome}; refusing the live E2E`);
+}
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "fm-codex-turnend-live-"));
+const codexHome = path.join(tempRoot, "codex-home");
+const fmHome = path.join(tempRoot, "fm-home");
+const project = path.join(tempRoot, "project");
+let child;
+
+function copyFile(relative) {
+  const source = path.join(root, relative);
+  const target = path.join(project, relative);
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.copyFileSync(source, target);
+}
+
+function copyTree(relative) {
+  const source = path.join(root, relative);
+  const target = path.join(project, relative);
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.cpSync(source, target, { recursive: true });
+}
+
+function sessionFiles(directory) {
+  if (!fs.existsSync(directory)) return [];
+  return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) return sessionFiles(entryPath);
+    return entry.isFile() && entry.name.endsWith(".jsonl") ? [entryPath] : [];
+  });
+}
+
+async function stopChild(processHandle) {
+  if (!processHandle || processHandle.exitCode !== null) return;
+  const closed = new Promise((resolve) => processHandle.once("close", resolve));
+  processHandle.kill("SIGTERM");
+  const timer = new Promise((resolve) => setTimeout(resolve, 1000));
+  await Promise.race([closed, timer]);
+  if (processHandle.exitCode === null) processHandle.kill("SIGKILL");
+}
+
+try {
+  fs.mkdirSync(codexHome, { recursive: true, mode: 0o700 });
+  fs.mkdirSync(path.join(fmHome, "state"), { recursive: true });
+  fs.mkdirSync(path.join(fmHome, "config"), { recursive: true });
+  fs.mkdirSync(project, { recursive: true });
+  fs.writeFileSync(path.join(fmHome, "state", "task.meta"), "");
+
+  for (const name of ["auth.json", ".credentials.json", "config.toml", "installation_id", "models_cache.json"]) {
+    const source = path.join(realCodexHome, name);
+    if (fs.existsSync(source) && fs.statSync(source).isFile()) {
+      fs.copyFileSync(source, path.join(codexHome, name));
+    }
+  }
+
+  for (const relative of [
+    "AGENTS.md",
+    ".codex/hooks.json",
+    "bin/fm-turnend-guard-codex.sh",
+    "bin/fm-turnend-guard.sh",
+    "bin/fm-wake-lib.sh",
+    "bin/fm-supervision-lib.sh",
+    "bin/fm-supervision-instructions.sh",
+    "bin/fm-harness.sh",
+  ]) {
+    copyFile(relative);
+  }
+  copyTree("docs/supervision-protocols");
+  for (const name of fs.readdirSync(path.join(project, "bin"))) {
+    fs.chmodSync(path.join(project, "bin", name), 0o755);
+  }
+
+  const gitInit = spawnSync("git", ["init", "-q", project], { encoding: "utf8" });
+  if (gitInit.error || gitInit.status !== 0) {
+    throw new Error(`could not initialize the disposable project: ${gitInit.stderr.trim()}`);
+  }
+
+  child = spawn("codex", ["app-server", "--stdio"], {
+    cwd: project,
+    env: { ...process.env, CODEX_HOME: codexHome, FM_HOME: fmHome },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+
+  let nextId = 1;
+  let stderr = "";
+  let activeTurn;
+  const pending = new Map();
+
+  child.stderr.setEncoding("utf8");
+  child.stderr.on("data", (chunk) => {
+    stderr = `${stderr}${chunk}`.slice(-8000);
+  });
+
+  function send(message) {
+    child.stdin.write(`${JSON.stringify(message)}\n`);
+  }
+
+  function request(method, params, timeoutMs = 20000) {
+    const id = nextId++;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        pending.delete(id);
+        reject(new Error(`${method} timed out`));
+      }, timeoutMs);
+      pending.set(id, { resolve, reject, timer });
+      send({ jsonrpc: "2.0", id, method, params });
+    });
+  }
+
+  function waitForTurn() {
+    if (activeTurn) throw new Error("only one turn may be active in the live E2E");
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        activeTurn = undefined;
+        reject(new Error("turn timed out after 40 seconds"));
+      }, 40000);
+      activeTurn = { resolve, reject, timer };
+    });
+  }
+
+  function rejectAll(error) {
+    for (const waiter of pending.values()) {
+      clearTimeout(waiter.timer);
+      waiter.reject(error);
+    }
+    pending.clear();
+    if (activeTurn) {
+      clearTimeout(activeTurn.timer);
+      activeTurn.reject(error);
+      activeTurn = undefined;
+    }
+  }
+
+  const lines = readline.createInterface({ input: child.stdout });
+  lines.on("line", (line) => {
+    let message;
+    try {
+      message = JSON.parse(line);
+    } catch {
+      return;
+    }
+    if (Object.hasOwn(message, "id")) {
+      const waiter = pending.get(message.id);
+      if (!waiter) return;
+      pending.delete(message.id);
+      clearTimeout(waiter.timer);
+      if (message.error) waiter.reject(new Error(message.error.message || JSON.stringify(message.error)));
+      else waiter.resolve(message.result);
+      return;
+    }
+    if (!activeTurn) return;
+    if (message.method === "turn/completed") {
+      const waiter = activeTurn;
+      activeTurn = undefined;
+      clearTimeout(waiter.timer);
+      waiter.resolve(message.params);
+    } else if (message.method === "error") {
+      const waiter = activeTurn;
+      activeTurn = undefined;
+      clearTimeout(waiter.timer);
+      waiter.reject(new Error(message.params?.error?.message || message.params?.message || "Codex turn failed"));
+    }
+  });
+
+  child.once("error", (error) => rejectAll(error));
+  child.once("exit", (code, signal) => {
+    rejectAll(new Error(`codex app-server exited early (${code ?? signal})${stderr ? `: ${stderr.trim()}` : ""}`));
+  });
+
+  await request("initialize", {
+    clientInfo: { name: "firstmate-stop-e2e", version: "1.0.0" },
+    capabilities: { experimentalApi: true },
+  });
+  send({ jsonrpc: "2.0", method: "initialized" });
+
+  const started = await request("thread/start", {
+    cwd: project,
+    config: { bypass_hook_trust: true, features: { item_ids: true } },
+    developerInstructions: "Reply with OK only. Do not use tools.",
+  });
+  const threadId = started?.thread?.id;
+  if (!threadId) throw new Error("thread/start returned no thread id");
+
+  async function runTurn(clientUserMessageId) {
+    const completed = waitForTurn();
+    await request("turn/start", {
+      threadId,
+      clientUserMessageId,
+      input: [{ type: "text", text: "Reply with OK only. Do not use tools." }],
+      effort: "low",
+    });
+    await completed;
+  }
+
+  await runTurn("msg_e2e_first");
+  console.log("FIRST_TURN_COMPLETED");
+
+  const persisted = sessionFiles(path.join(codexHome, "sessions"))
+    .map((file) => fs.readFileSync(file, "utf8"))
+    .join("\n");
+  if (persisted.includes("<hook_prompt>")) {
+    throw new Error("blocking <hook_prompt> persisted in the isolated Codex session");
+  }
+  console.log("NO_HOOK_PROMPT_PERSISTED");
+
+  const wakeQueue = path.join(fmHome, "state", ".wake-queue");
+  if (!fs.existsSync(wakeQueue) || !fs.readFileSync(wakeQueue, "utf8").includes("codex-turnend-guard")) {
+    throw new Error("Codex adapter did not queue its durable supervision wake");
+  }
+  console.log("DURABLE_WAKE_QUEUED");
+
+  await runTurn("msg_e2e_second");
+  console.log("SECOND_DESKTOP_STYLE_FOLLOWUP_COMPLETED");
+} finally {
+  await stopChild(child);
+  fs.rmSync(tempRoot, { recursive: true, force: true });
+}

--- a/tests/fm-turnend-guard.test.sh
+++ b/tests/fm-turnend-guard.test.sh
@@ -87,6 +87,7 @@ install_guard_scripts() {
   local dir=$1
   mkdir -p "$dir/bin"
   cp "$ROOT/bin/fm-turnend-guard.sh" "$dir/bin/fm-turnend-guard.sh"
+  cp "$ROOT/bin/fm-turnend-guard-codex.sh" "$dir/bin/fm-turnend-guard-codex.sh"
   cp "$ROOT/bin/fm-turnend-guard-grok.sh" "$dir/bin/fm-turnend-guard-grok.sh"
   cp "$ROOT/bin/fm-supervision-instructions.sh" "$dir/bin/fm-supervision-instructions.sh"
   cp "$ROOT/bin/fm-harness.sh" "$dir/bin/fm-harness.sh"
@@ -94,13 +95,13 @@ install_guard_scripts() {
   cp "$ROOT/bin/fm-wake-lib.sh" "$dir/bin/fm-wake-lib.sh"
   mkdir -p "$dir/docs"
   cp -R "$ROOT/docs/supervision-protocols" "$dir/docs/supervision-protocols"
-  chmod +x "$dir/bin/fm-turnend-guard.sh" "$dir/bin/fm-turnend-guard-grok.sh" "$dir/bin/fm-supervision-instructions.sh" "$dir/bin/fm-harness.sh"
+  chmod +x "$dir/bin/fm-turnend-guard.sh" "$dir/bin/fm-turnend-guard-codex.sh" "$dir/bin/fm-turnend-guard-grok.sh" "$dir/bin/fm-supervision-instructions.sh" "$dir/bin/fm-harness.sh"
 }
 
 mark_codex_hook_root() {
   local dir=$1
   mkdir -p "$dir/.codex"
-  printf '{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"fm-turnend-guard.sh"}]}]}}\n' > "$dir/.codex/hooks.json"
+  printf '{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"fm-turnend-guard-codex.sh"}]}]}}\n' > "$dir/.codex/hooks.json"
 }
 
 # A primary-shaped checkout: plain (non-worktree) git repo, AGENTS.md, bin/,
@@ -444,9 +445,35 @@ test_codex_hook_invokes_shared_guard() {
   [ -n "$command" ] || fail "Stop hook command is missing from .codex/hooks.json"
   assert_contains "$command" 'pwd -P' "codex hook must anchor from the hook process working directory"
   assert_contains "$command" '.codex/hooks.json' "codex hook must verify the hook-loaded firstmate root"
-  assert_contains "$command" 'fm-turnend-guard.sh' "codex hook must invoke the shared guard"
+  assert_contains "$command" 'fm-turnend-guard-codex.sh' "codex hook must invoke its fail-open adapter"
+  assert_contains "$(cat "$ROOT/bin/fm-turnend-guard-codex.sh")" 'fm-turnend-guard.sh' "codex adapter must invoke the shared guard"
   assert_not_contains "$command" '.cwd' "codex hook must not use payload cwd to select the guard executable"
   pass ".codex/hooks.json: Stop hook invokes the shared primary guard"
+}
+
+test_codex_hook_never_blocks_when_watcher_is_unhealthy() {
+  local settings command dir payload out err status queue
+  settings="$ROOT/.codex/hooks.json"
+  [ -f "$settings" ] || fail "tracked .codex/hooks.json is missing"
+  command=$(jq -r '.hooks.Stop[0].hooks[0].command // empty' "$settings")
+  [ -n "$command" ] || fail "Stop hook command is missing from .codex/hooks.json"
+  dir=$(make_primary_dir "$TMP_ROOT/codex-hook-unhealthy")
+  mkdir -p "$dir/.codex"
+  cp "$settings" "$dir/.codex/hooks.json"
+  : > "$dir/state/task1.meta"
+  payload='{"stop_hook_active":false}'
+  err="$dir/codex-hook.err"
+  out=$(printf '%s' "$payload" | (cd "$dir" && bash -c "$command") 2>"$err"); status=$?
+  expect_code 0 "$status" "Codex Stop adapter must never block when the shared predicate finds an unhealthy watcher"
+  printf '%s' "$out" | jq -e '.continue == true and (.systemMessage | contains("TURN WOULD END BLIND"))' >/dev/null \
+    || fail "Codex adapter must return valid non-blocking JSON with a systemMessage: $out"
+  [ ! -s "$err" ] || fail "Codex adapter must keep stderr clean on the expected unhealthy-watcher path: $(cat "$err")"
+  queue="$dir/state/.wake-queue"
+  [ -s "$queue" ] || fail "Codex adapter must leave a durable wake when it cannot block"
+  assert_contains "$(cat "$queue")" "codex-turnend-guard" "Codex adapter durable wake must identify its source"
+  assert_not_contains "$out" 'decision:block' "Codex adapter output must not request a blocking decision"
+  assert_not_contains "$command" 'decision:block' "Codex Stop adapter must not return a blocking decision"
+  pass ".codex/hooks.json: unhealthy watcher returns systemMessage JSON and queues durably without blocking Codex"
 }
 
 test_codex_hook_uses_process_pwd_when_payload_cwd_is_outside_root() {
@@ -489,7 +516,7 @@ test_codex_hook_ignores_nested_git_root_guard() {
   git -C "$nested" commit -q --allow-empty -m init
   mkdir -p "$nested/bin" "$nested/.codex"
   : > "$nested/AGENTS.md"
-  printf '{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"fm-turnend-guard.sh"}]}]}}\n' > "$nested/.codex/hooks.json"
+  printf '{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"fm-turnend-guard-codex.sh"}]}]}}\n' > "$nested/.codex/hooks.json"
   cat > "$nested/bin/fm-turnend-guard.sh" <<'EOF'
 #!/usr/bin/env bash
 printf 'nested guard executed\n'
@@ -737,6 +764,7 @@ test_grok_adapter_forces_one_resume_when_unhealthy
 test_grok_adapter_loop_guard_skips_resume
 test_settings_hook_uses_claude_project_dir
 test_codex_hook_invokes_shared_guard
+test_codex_hook_never_blocks_when_watcher_is_unhealthy
 test_codex_hook_uses_process_pwd_when_payload_cwd_is_outside_root
 test_codex_hook_ignores_nested_git_root_guard
 test_opencode_plugin_forces_followup

--- a/tests/fm-turnend-guard.test.sh
+++ b/tests/fm-turnend-guard.test.sh
@@ -476,6 +476,55 @@ test_codex_hook_never_blocks_when_watcher_is_unhealthy() {
   pass ".codex/hooks.json: unhealthy watcher returns systemMessage JSON and queues durably without blocking Codex"
 }
 
+test_cached_codex_direct_guard_self_routes_without_blocking() {
+  local command dir payload out err status queue
+  command='bash -lc '\''payload=$(cat 2>/dev/null || true); [ -n "$payload" ] || exit 0; command -v jq >/dev/null 2>&1 || exit 0; root=$(pwd -P) || exit 0; [ -x "$root/bin/fm-turnend-guard.sh" ] || exit 0; [ -f "$root/AGENTS.md" ] || exit 0; [ -f "$root/.codex/hooks.json" ] || exit 0; jq -e "any(.hooks.Stop[]?.hooks[]?.command?; type == \"string\" and contains(\"fm-turnend-guard.sh\"))" "$root/.codex/hooks.json" >/dev/null 2>&1 || exit 0; printf "%s" "$payload" | "$root/bin/fm-turnend-guard.sh"'\'''
+  dir=$(make_primary_dir "$TMP_ROOT/codex-hook-cached-direct")
+  mkdir -p "$dir/.codex"
+  jq -cn --arg command "$command" \
+    '{hooks:{Stop:[{hooks:[{type:"command",command:$command}]}]}}' > "$dir/.codex/hooks.json"
+  : > "$dir/state/task1.meta"
+  payload='{"session_id":"session-test","turn_id":"turn-test","transcript_path":null,"cwd":"/tmp","hook_event_name":"Stop","model":"gpt-test","permission_mode":"bypassPermissions","stop_hook_active":false,"last_assistant_message":"OK"}'
+  err="$dir/cached-codex.err"
+  out=$(printf '%s' "$payload" | (cd "$dir" && bash -c "$command") 2>"$err"); status=$?
+  expect_code 0 "$status" "a cached Codex hook that directly invokes the shared guard must fail open"
+  printf '%s' "$out" | jq -e '.continue == true and (.systemMessage | contains("openai/codex#20783"))' >/dev/null \
+    || fail "cached Codex direct guard must return valid non-blocking warning JSON: $out"
+  [ ! -s "$err" ] || fail "cached Codex direct guard must keep stderr clean: $(cat "$err")"
+  queue="$dir/state/.wake-queue"
+  [ -s "$queue" ] || fail "cached Codex direct guard must leave a durable wake"
+  assert_contains "$(cat "$queue")" "codex-turnend-guard" "cached Codex durable wake must identify its source"
+  pass "fm-turnend-guard: cached Codex direct command self-routes through the fail-open adapter"
+}
+
+test_cached_codex_direct_guard_ignores_adapter_failure() {
+  local dir payload out status
+  dir=$(make_primary_dir "$TMP_ROOT/codex-hook-cached-adapter-failure")
+  cat > "$dir/bin/fm-turnend-guard-codex.sh" <<'EOF'
+#!/usr/bin/env bash
+cat >/dev/null
+exit 2
+EOF
+  chmod +x "$dir/bin/fm-turnend-guard-codex.sh"
+  payload='{"session_id":"session-test","turn_id":"turn-test","transcript_path":null,"cwd":"/tmp","hook_event_name":"Stop","model":"gpt-test","permission_mode":"bypassPermissions","stop_hook_active":false,"last_assistant_message":"OK"}'
+  out=$(printf '%s' "$payload" | bash "$dir/bin/fm-turnend-guard.sh" 2>&1); status=$?
+  expect_code 0 "$status" "cached Codex compatibility boundary must fail open even when its adapter exits 2"
+  [ -z "$out" ] || fail "failing Codex adapter stub unexpectedly produced output: $out"
+  pass "fm-turnend-guard: cached Codex compatibility route ignores adapter failure status"
+}
+
+test_claude_direct_guard_still_blocks_without_codex_turn_id() {
+  local dir payload out status
+  dir=$(make_primary_dir "$TMP_ROOT/claude-hook-direct")
+  : > "$dir/state/task1.meta"
+  payload='{"session_id":"session-test","transcript_path":null,"cwd":"/tmp","hook_event_name":"Stop","permission_mode":"bypassPermissions","stop_hook_active":false,"last_assistant_message":"OK"}'
+  out=$(printf '%s' "$payload" | CLAUDECODE=1 bash "$dir/bin/fm-turnend-guard.sh" 2>&1); status=$?
+  expect_code 2 "$status" "Claude direct Stop guard must retain blocking exit status"
+  assert_contains "$out" "TURN WOULD END BLIND" "Claude direct Stop guard must preserve its continuation reason"
+  assert_not_contains "$out" '"continue":true' "Claude direct Stop guard must not return the Codex fail-open result"
+  pass "fm-turnend-guard: Claude direct command still blocks without Codex's turn_id extension"
+}
+
 test_codex_hook_uses_process_pwd_when_payload_cwd_is_outside_root() {
   local settings command dir expected_root outside payload out status
   settings="$ROOT/.codex/hooks.json"
@@ -765,6 +814,9 @@ test_grok_adapter_loop_guard_skips_resume
 test_settings_hook_uses_claude_project_dir
 test_codex_hook_invokes_shared_guard
 test_codex_hook_never_blocks_when_watcher_is_unhealthy
+test_cached_codex_direct_guard_self_routes_without_blocking
+test_cached_codex_direct_guard_ignores_adapter_failure
+test_claude_direct_guard_still_blocks_without_codex_turn_id
 test_codex_hook_uses_process_pwd_when_payload_cwd_is_outside_root
 test_codex_hook_ignores_nested_git_root_guard
 test_opencode_plugin_forces_followup


### PR DESCRIPTION
## Summary

- route Codex Stop events through a Codex-specific fail-open adapter
- preserve Desktop-resumable session history instead of persisting a malformed synthetic hook continuation
- keep the supervision alarm visible and durable without spawning a competing Codex process
- document the temporary workaround for openai/codex#20783

## Why

A blocking Codex Stop hook persists its synthetic `<hook_prompt>` item with a bare UUID. A later Desktop-style follow-up sends that UUID back to the Responses API, which rejects it with `invalid_id_prefix` because message IDs must begin with `msg_`.

## Validation

- `tests/fm-turnend-guard.test.sh`
- `FM_CODEX_LIVE_E2E=1 node tests/fm-codex-turnend-live-e2e.mjs`

The live app-server regression completed two turns, observed the system warning, verified that no hook prompt was persisted, verified the durable wake, and required a nonempty agent message from both turns.

## Upstream

- openai/codex#20783
