### PR TITLE
feat(bin): add fm-dash.sh live read-only fleet dashboard

### DIFF
--- a/bin/fm-dash.sh
+++ b/bin/fm-dash.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# fm-dash.sh - live, strictly read-only terminal dashboard of in-flight tasks.
+#
+# Usage: fm-dash.sh [--once]
+#   --once   print one snapshot and exit (for scripting and tests)
+#
+# One numbered block per state/<id>.meta in the active home (FM_HOME /
+# FM_STATE_OVERRIDE resolution, same as fm-peek.sh): task id, project, kind,
+# the current-state line from fm-crew-state.sh, the recorded PR URL when
+# pr= is present, the worktree path (home= for kind=secondmate), and - when
+# the pane is cheap to read through fm-peek.sh - its "Usage ...% | Weekly ...%"
+# gauge line. Every per-row helper call is bounded by FM_DASH_STATE_TIMEOUT,
+# so a slow or failing helper degrades that row to a placeholder instead of
+# wedging the render loop.
+#
+# The worktree path renders as an OSC 8 hyperlink to an editor URL
+# (<FM_DASH_EDITOR_SCHEME>://file/<path>, default vscode) when stdout is a
+# terminal, and in live mode pressing a row's number (1-9) opens that
+# worktree via FM_DASH_OPEN_CMD. Live mode re-renders every FM_DASH_INTERVAL
+# seconds (default 5); `q` quits and restores the terminal (alternate
+# screen, cursor, echo).
+#
+# Strictly READ-ONLY on the fleet: captures panes, never sends keys, never
+# writes under state/, never touches worktrees. Like fm-crew-state.sh it
+# skips fm-guard.sh so guard banners never mix into a rendered frame.
+#
+# Environment:
+#   FM_DASH_INTERVAL       live refresh seconds (positive integer), default 5
+#   FM_DASH_EDITOR_SCHEME  hyperlink URL scheme name, default vscode
+#   FM_DASH_OPEN_CMD       number-key open command, run with the worktree path
+#                          appended as one quoted argument; default `code`
+#                          when on PATH, else `open -a "Visual Studio Code"`
+#                          when that app resolves on macOS, else plain `open`
+#   FM_DASH_STATE_TIMEOUT  per-row helper budget in seconds, default 6
+#   FM_DASH_HYPERLINK      force OSC 8 hyperlinks on (1) or off (0); default
+#                          on only when stdout is a terminal
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+
+# shellcheck source=bin/fm-backend.sh
+. "$SCRIPT_DIR/fm-backend.sh"
+
+ONCE=0
+case "${1:-}" in
+  --once) ONCE=1 ;;
+  '') : ;;
+  *) echo 'usage: fm-dash.sh [--once]' >&2; exit 2 ;;
+esac
+
+INTERVAL=${FM_DASH_INTERVAL:-5}
+case "$INTERVAL" in
+  ''|*[!0-9]*|0)
+    echo "error: FM_DASH_INTERVAL must be a positive integer of seconds (got '$INTERVAL')" >&2
+    exit 2
+    ;;
+esac
+STATE_TIMEOUT=${FM_DASH_STATE_TIMEOUT:-6}
+case "$STATE_TIMEOUT" in ''|*[!0-9]*|0) STATE_TIMEOUT=6 ;; esac
+SCHEME=${FM_DASH_EDITOR_SCHEME:-vscode}
+case "${FM_DASH_HYPERLINK:-}" in
+  1|true|yes|on) LINKS=1 ;;
+  0|false|no|off) LINKS=0 ;;
+  *) if [ -t 1 ]; then LINKS=1; else LINKS=0; fi ;;
+esac
+
+# Bounded helper runner: one slow or hung helper (a stuck no-mistakes call
+# inside fm-crew-state.sh, a wedged backend capture inside fm-peek.sh) must
+# cost at most STATE_TIMEOUT seconds and degrade, never wedge the render.
+# Same timeout-tool ladder as fm-crew-state.sh's nm_run.
+HAVE_TIMEOUT=none
+if command -v timeout >/dev/null 2>&1; then HAVE_TIMEOUT=timeout
+elif command -v gtimeout >/dev/null 2>&1; then HAVE_TIMEOUT=gtimeout
+elif command -v perl >/dev/null 2>&1; then HAVE_TIMEOUT=perl
+fi
+run_bounded() {  # <cmd> [args...]
+  case "$HAVE_TIMEOUT" in
+    timeout)  timeout "$STATE_TIMEOUT" "$@" 2>/dev/null || true ;;
+    gtimeout) gtimeout "$STATE_TIMEOUT" "$@" 2>/dev/null || true ;;
+    perl)     perl -e 'my $t = shift; my $pid = fork; die "fork failed" unless defined $pid; if (!$pid) { setpgrp(0, 0); exec @ARGV } local $SIG{ALRM} = sub { kill "TERM", -$pid; select undef, undef, undef, 0.2; kill "KILL", -$pid; exit 124 }; alarm $t; waitpid $pid, 0; exit($? >> 8)' "$STATE_TIMEOUT" "$@" 2>/dev/null || true ;;
+    *)        "$@" 2>/dev/null || true ;;
+  esac
+}
+
+default_open_cmd() {
+  if command -v code >/dev/null 2>&1; then
+    printf 'code'
+  elif [ "$(uname -s)" = Darwin ] && open -Ra 'Visual Studio Code' 2>/dev/null; then
+    printf 'open -a "Visual Studio Code"'
+  else
+    printf 'open'
+  fi
+}
+OPEN_CMD=${FM_DASH_OPEN_CMD:-$(default_open_cmd)}
+
+open_path() {  # <path> - fire-and-forget so a slow opener never blocks the loop
+  [ -n "$1" ] || return 0
+  sh -c "$OPEN_CMD \"\$1\"" fm-dash-open "$1" >/dev/null 2>&1 &
+}
+
+url_encode_path() {  # minimal path encoding for the OSC 8 editor URL
+  local s=$1
+  s=${s//%/%25}
+  s=${s// /%20}
+  printf '%s' "$s"
+}
+
+OSC8_OPEN=$'\033]8;;'
+OSC8_ST=$'\033\\'
+hyperlink() {  # <url> <display-text>
+  if [ "$LINKS" = 1 ]; then
+    printf '%s%s%s%s%s%s' "$OSC8_OPEN" "$1" "$OSC8_ST" "$2" "$OSC8_OPEN" "$OSC8_ST"
+  else
+    printf '%s' "$2"
+  fi
+}
+
+# render_frame: build one full frame into FRAME and map row numbers 1-9 to
+# their worktree paths in ROW_PATHS for the live-mode number keys.
+ROW_PATHS=()
+FRAME=''
+render_frame() {
+  local body='' n=0 meta id kind project_path project path pr state_line gauge disp
+  ROW_PATHS=()
+  for meta in "$STATE"/*.meta; do
+    [ -f "$meta" ] || continue
+    id=$(basename "$meta" .meta)
+    kind=$(fm_meta_get "$meta" kind)
+    [ -n "$kind" ] || kind=ship
+    project_path=$(fm_meta_get "$meta" project)
+    project=${project_path:+$(basename "$project_path")}
+    if [ "$kind" = secondmate ]; then
+      path=$(fm_meta_get "$meta" home)
+    else
+      path=$(fm_meta_get "$meta" worktree)
+    fi
+    pr=$(fm_meta_get "$meta" pr)
+    state_line=$(run_bounded "$SCRIPT_DIR/fm-crew-state.sh" "$id")
+    [ -n "$state_line" ] || state_line='state: ? · source: none · state read slow or failed'
+    state_line=${state_line#state: }
+    gauge=$(run_bounded "$SCRIPT_DIR/fm-peek.sh" "fm-$id" 40 \
+      | grep -oE 'Usage [^|]*% *\| *Weekly [^%]*%' | tail -1)
+    n=$((n + 1))
+    [ "$n" -le 9 ] && ROW_PATHS[n]=$path
+    body+=$(printf ' %2d  %-20s %-16s %-11s %s' "$n" "$id" "${project:--}" "$kind" "$state_line")$'\n'
+    if [ -n "$path" ]; then
+      disp=$path
+      case "$disp" in "$HOME"/*) disp="~${disp#"$HOME"}" ;; esac
+      body+="     $(hyperlink "$SCHEME://file/$(url_encode_path "$path")" "$disp")"$'\n'
+    fi
+    [ -n "$pr" ] && body+="     pr: $pr"$'\n'
+    [ -n "$gauge" ] && body+="     $gauge"$'\n'
+    body+=$'\n'
+  done
+
+  FRAME="firstmate dash · $n in flight · $(date +%H:%M:%S)"
+  if [ "$ONCE" != 1 ]; then
+    FRAME+=" · refresh ${INTERVAL}s · q quit · 1-9 open worktree"
+  fi
+  FRAME+=$'\n\n'
+  if [ "$n" -eq 0 ]; then
+    FRAME+='No tasks in flight - the deck is clear.'$'\n'
+  else
+    FRAME+="$body"
+  fi
+}
+
+if [ "$ONCE" = 1 ]; then
+  render_frame
+  printf '%s' "$FRAME"
+  exit 0
+fi
+
+# --- live mode ---------------------------------------------------------------
+
+# FM_DASH_FORCE_TTY=1 lets the behavior tests drive the live loop through
+# pipes; real interactive use requires a terminal on stdin and stdout.
+if [ "${FM_DASH_FORCE_TTY:-0}" != 1 ] && ! { [ -t 0 ] && [ -t 1 ]; }; then
+  echo 'error: live mode needs a terminal; use --once for a scriptable snapshot' >&2
+  exit 2
+fi
+
+SAVED_STTY=$(stty -g 2>/dev/null || true)
+cleanup() {
+  # Restore cursor, leave the alternate screen, and restore terminal modes.
+  printf '\033[?25h\033[?1049l'
+  [ -n "$SAVED_STTY" ] && stty "$SAVED_STTY" 2>/dev/null
+  return 0
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+printf '\033[?1049h\033[?25l'
+
+while :; do
+  render_frame
+  printf '\033[H\033[2J%s' "$FRAME"
+  key=''
+  if read -rs -n 1 -t "$INTERVAL" key; then
+    case "$key" in
+      q|Q) exit 0 ;;
+      [1-9]) open_path "${ROW_PATHS[$key]:-}" ;;
+    esac
+  else
+    # >128 is the read timeout (normal refresh); anything else is a closed
+    # stdin, so exit instead of spinning on instant EOFs.
+    rc=$?
+    [ "$rc" -gt 128 ] || exit 0
+  fi
+done

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -56,6 +56,7 @@ If you have changed away from the firstmate home in an interactive shell, invoke
 | `fm-send.sh`             | Send one verified literal line or supported key through the target's recorded backend |
 | `fm-tmux-lib.sh`         | Shared tmux pane primitives for busy detection, composer capture, and verified submit |
 | `fm-peek.sh`             | Print a bounded tail of a crewmate endpoint                                          |
+| `fm-dash.sh`             | Live read-only dashboard of in-flight tasks with editor hyperlinks; `--once` snapshots |
 | `fm-pr-check.sh`         | Record `pr=` and `pr_head=` for a PR-ready task, then arm the watcher's merge poll   |
 | `fm-pr-merge.sh`         | Record PR metadata, then merge a task's PR from its full GitHub URL                  |
 | `fm-promote.sh`          | Promote a scout task in place to a protected ship task                               |

--- a/tests/fm-dash.test.sh
+++ b/tests/fm-dash.test.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# Behavior tests for bin/fm-dash.sh - the read-only live fleet dashboard.
+#
+# Hermetic over a throwaway FM_STATE_OVERRIDE with a fake `tmux` (pane source)
+# and fake `no-mistakes` (run-step source) on PATH, mirroring
+# tests/fm-crew-state.test.sh:
+#   (a) empty fleet --once prints the friendly message, not a table
+#   (b) a ship task row renders id, project, kind, state, and pr= URL
+#   (c) kind=secondmate renders home= instead of worktree=
+#   (d) OSC 8 hyperlink: FM_DASH_HYPERLINK=1 emits <scheme>://file/<path> with
+#       percent-encoded spaces; FM_DASH_EDITOR_SCHEME overrides vscode; and
+#       FM_DASH_HYPERLINK=0 (the non-tty default) prints the plain path
+#   (e) a pane printing "Usage ...% | Weekly ...%" surfaces as the row's gauge
+#   (f) resilience: a hanging per-row helper degrades to a placeholder within
+#       FM_DASH_STATE_TIMEOUT instead of wedging the render
+#   (g) live mode: `q` quits cleanly with exit 0 after rendering, and a closed
+#       stdin (EOF) also exits instead of spinning
+#   (h) live mode: pressing a row's number opens that worktree via
+#       FM_DASH_OPEN_CMD
+#   (i) an invalid FM_DASH_INTERVAL is refused with exit 2
+#   (j) read-only: a render creates no files under state/
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+DASH="$ROOT/bin/fm-dash.sh"
+TMP_ROOT=$(fm_test_tmproot fm-dash)
+fm_git_identity fmtest fmtest@example.invalid
+
+# Fake tmux: display-message answers pane liveness, capture-pane serves the
+# pane text (busy footer plus an optional FM_FAKE_GAUGE_LINE). Fake
+# no-mistakes serves FM_FAKE_AXI_STATUS, sleeping FM_FAKE_NM_SLEEP first so
+# the hang case (f) can simulate a wedged helper.
+make_fakebin() {  # <dir> -> echoes fakebin path
+  local fb="$1/fakebin"
+  mkdir -p "$fb"
+  cat > "$fb/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "${1:-}" in
+  display-message)
+    [ "${FM_FAKE_TMUX_MISSING:-0}" = 1 ] && exit 1
+    printf '%%1\n' ;;
+  capture-pane)
+    [ "${FM_FAKE_TMUX_MISSING:-0}" = 1 ] && exit 1
+    if [ "${FM_FAKE_BUSY:-0}" = 1 ]; then printf 'work in progress\nesc to interrupt\n'
+    else printf 'all quiet\n> \n'; fi
+    [ -n "${FM_FAKE_GAUGE_LINE:-}" ] && printf '%s\n' "$FM_FAKE_GAUGE_LINE" ;;
+esac
+exit 0
+SH
+  cat > "$fb/no-mistakes" <<'SH'
+#!/usr/bin/env bash
+set -u
+[ -n "${FM_FAKE_NM_SLEEP:-}" ] && sleep "$FM_FAKE_NM_SLEEP"
+case "${1:-}" in
+  axi) printf '%s\n' "${FM_FAKE_AXI_STATUS:-}" ;;
+  runs) printf '%s\n' "${FM_FAKE_RUNS_LIST:-}" ;;
+esac
+exit 0
+SH
+  cat > "$fb/record-open" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$1" >> "$FM_FAKE_OPEN_LOG"
+SH
+  chmod +x "$fb/tmux" "$fb/no-mistakes" "$fb/record-open"
+  printf '%s\n' "$fb"
+}
+
+FAKEBIN=$(make_fakebin "$TMP_ROOT")
+export PATH="$FAKEBIN:$PATH"
+
+new_state() {  # <name> -> echoes a fresh state dir
+  local d="$TMP_ROOT/$1/state"
+  mkdir -p "$d"
+  printf '%s\n' "$d"
+}
+
+# --- (a) empty fleet ---------------------------------------------------------
+
+STATE_A=$(new_state a)
+out=$(FM_STATE_OVERRIDE="$STATE_A" "$DASH" --once)
+expect_code 0 $? 'empty fleet --once exits 0'
+assert_contains "$out" 'No tasks in flight' 'empty fleet prints the friendly message'
+assert_contains "$out" '0 in flight' 'empty fleet header still shows the count'
+pass '(a) empty fleet --once prints the friendly message'
+
+# --- (b) ship task row: id, project, kind, state, pr -------------------------
+
+STATE_B=$(new_state b)
+fm_write_meta "$STATE_B/fix-login-k3.meta" \
+  'window=firstmate:fm-fix-login-k3' \
+  "worktree=$TMP_ROOT/b/gone-worktree" \
+  'project=projects/yourapp' \
+  'harness=claude' \
+  'kind=ship' \
+  'mode=no-mistakes' \
+  'yolo=off' \
+  'pr=https://github.com/o/r/pull/123'
+out=$(FM_STATE_OVERRIDE="$STATE_B" "$DASH" --once)
+expect_code 0 $? 'ship row --once exits 0'
+assert_contains "$out" '1 in flight' 'header counts the ship task'
+assert_contains "$out" 'fix-login-k3' 'row shows the task id'
+assert_contains "$out" 'yourapp' 'row shows the project basename'
+assert_contains "$out" 'ship' 'row shows the kind'
+assert_contains "$out" 'worktree gone' 'row shows the fm-crew-state current-state line'
+assert_contains "$out" 'https://github.com/o/r/pull/123' 'row shows the recorded PR URL'
+pass '(b) ship task row renders id, project, kind, state, and pr'
+
+# --- (c) secondmate row shows home= ------------------------------------------
+
+STATE_C=$(new_state c)
+mkdir -p "$TMP_ROOT/c/sm-home"
+fm_write_secondmate_meta "$STATE_C/domain-sm.meta" "$TMP_ROOT/c/sm-home"
+out=$(FM_STATE_OVERRIDE="$STATE_C" FM_DASH_HYPERLINK=0 "$DASH" --once)
+assert_contains "$out" 'secondmate' 'row shows kind=secondmate'
+assert_contains "$out" "$TMP_ROOT/c/sm-home" 'secondmate row shows the home= path'
+pass '(c) secondmate row shows home='
+
+# --- (d) hyperlink scheme, encoding, and plain fallback ----------------------
+
+STATE_D=$(new_state d)
+mkdir -p "$TMP_ROOT/d/wt with space"
+fm_write_meta "$STATE_D/enc-x1.meta" \
+  'window=firstmate:fm-enc-x1' \
+  "worktree=$TMP_ROOT/d/wt with space" \
+  'project=projects/alpha' \
+  'kind=scout'
+out=$(FM_STATE_OVERRIDE="$STATE_D" FM_DASH_HYPERLINK=1 "$DASH" --once)
+assert_contains "$out" "vscode://file/$TMP_ROOT/d/wt%20with%20space" \
+  'hyperlink uses the vscode scheme with percent-encoded spaces'
+out=$(FM_STATE_OVERRIDE="$STATE_D" FM_DASH_HYPERLINK=1 FM_DASH_EDITOR_SCHEME=cursor "$DASH" --once)
+assert_contains "$out" "cursor://file/$TMP_ROOT/d/wt%20with%20space" \
+  'FM_DASH_EDITOR_SCHEME overrides the hyperlink scheme'
+out=$(FM_STATE_OVERRIDE="$STATE_D" FM_DASH_HYPERLINK=0 "$DASH" --once)
+assert_not_contains "$out" 'vscode://file/' 'FM_DASH_HYPERLINK=0 emits no OSC 8 URL'
+assert_contains "$out" "$TMP_ROOT/d/wt with space" 'plain mode still prints the worktree path'
+pass '(d) hyperlink scheme, encoding, and plain fallback'
+
+# --- (e) pane gauge line ------------------------------------------------------
+
+out=$(FM_STATE_OVERRIDE="$STATE_D" FM_DASH_HYPERLINK=0 \
+  FM_FAKE_GAUGE_LINE='ctx 12% · Usage 42% | Weekly 12% · main' "$DASH" --once)
+assert_contains "$out" 'Usage 42% | Weekly 12%' 'row surfaces the pane gauge line'
+pass '(e) pane gauge line surfaces on the row'
+
+# --- (f) hanging helper degrades to a placeholder ----------------------------
+
+STATE_F=$(new_state f)
+mkdir -p "$TMP_ROOT/f/wt"
+git -C "$TMP_ROOT/f/wt" init -q
+git -C "$TMP_ROOT/f/wt" -c commit.gpgsign=false commit -q --allow-empty -m init
+git -C "$TMP_ROOT/f/wt" checkout -q -b fm/hang-x1
+fm_write_meta "$STATE_F/hang-x1.meta" \
+  'window=firstmate:fm-hang-x1' \
+  "worktree=$TMP_ROOT/f/wt" \
+  'project=projects/alpha' \
+  'kind=ship'
+start=$(date +%s)
+out=$(FM_STATE_OVERRIDE="$STATE_F" FM_DASH_HYPERLINK=0 FM_DASH_STATE_TIMEOUT=1 \
+  FM_CREW_STATE_NM_TIMEOUT=30 FM_FAKE_NM_SLEEP=30 "$DASH" --once)
+elapsed=$(( $(date +%s) - start ))
+expect_code 0 $? 'hanging helper still exits 0'
+assert_contains "$out" 'hang-x1' 'hanging row still renders its id'
+assert_contains "$out" 'state read slow or failed' 'hanging row degrades to the placeholder'
+[ "$elapsed" -lt 15 ] || fail "render wedged: took ${elapsed}s with a 1s per-row budget"
+pass '(f) hanging helper degrades to a placeholder without wedging'
+
+# --- (g) live mode: q quits cleanly, EOF exits -------------------------------
+
+STATE_G=$(new_state g)
+out=$(printf 'q' | FM_STATE_OVERRIDE="$STATE_G" FM_DASH_FORCE_TTY=1 FM_DASH_INTERVAL=1 "$DASH")
+expect_code 0 $? 'live mode exits 0 on q'
+assert_contains "$out" 'No tasks in flight' 'live mode rendered a frame before quitting'
+out=$(printf '' | FM_STATE_OVERRIDE="$STATE_G" FM_DASH_FORCE_TTY=1 FM_DASH_INTERVAL=1 "$DASH")
+expect_code 0 $? 'live mode exits 0 on stdin EOF instead of spinning'
+pass '(g) live mode q quits cleanly and EOF exits'
+
+# --- (h) number keypress opens the row worktree ------------------------------
+
+export FM_FAKE_OPEN_LOG="$TMP_ROOT/opened.log"
+printf '1' | FM_STATE_OVERRIDE="$STATE_D" FM_DASH_FORCE_TTY=1 FM_DASH_INTERVAL=1 \
+  FM_DASH_OPEN_CMD='record-open' "$DASH" > /dev/null
+expect_code 0 $? 'live mode exits 0 after a number keypress'
+tries=0
+until [ -s "$FM_FAKE_OPEN_LOG" ] || [ "$tries" -ge 20 ]; do sleep 0.1; tries=$((tries + 1)); done
+assert_present "$FM_FAKE_OPEN_LOG" 'number keypress ran FM_DASH_OPEN_CMD'
+assert_grep "$TMP_ROOT/d/wt with space" "$FM_FAKE_OPEN_LOG" \
+  'FM_DASH_OPEN_CMD received the row worktree path'
+pass '(h) number keypress opens the row worktree via FM_DASH_OPEN_CMD'
+
+# --- (i) invalid FM_DASH_INTERVAL refused ------------------------------------
+
+FM_STATE_OVERRIDE="$STATE_G" FM_DASH_INTERVAL=soon "$DASH" --once >/dev/null 2>&1
+expect_code 2 $? 'invalid FM_DASH_INTERVAL exits 2'
+pass '(i) invalid FM_DASH_INTERVAL refused'
+
+# --- (j) read-only: no files created under state/ ----------------------------
+
+before=$(find "$STATE_B" -type f | sort)
+FM_STATE_OVERRIDE="$STATE_B" FM_DASH_HYPERLINK=0 "$DASH" --once > /dev/null
+after=$(find "$STATE_B" -type f | sort)
+[ "$before" = "$after" ] || fail "dashboard wrote under state/: before=[$before] after=[$after]"
+pass '(j) render creates no files under state/'
+
+echo 'fm-dash tests passed'


### PR DESCRIPTION
One numbered block per in-flight state/*.meta: current state via fm-crew-state.sh, recorded PR URL, pane Usage/Weekly gauge, and the worktree path (home= for secondmates) as an OSC 8 editor hyperlink. Live mode refreshes every FM_DASH_INTERVAL seconds, q quits and restores the terminal, and number keys open a row's worktree via FM_DASH_OPEN_CMD; --once prints one scriptable snapshot. Per-row helper calls are bounded so a slow helper degrades to a placeholder instead of wedging the render. Strictly read-only on the fleet.