### PR TITLE
fix: suppress stale churn during legitimate idle waits

### DIFF
--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -739,7 +739,7 @@ FM_BACKEND_HERDR_IDLE_RE=${FM_BACKEND_HERDR_IDLE_RE:-'^Type a message\.\.\.$'}
 # Known bare (unbordered) prompt glyphs a composer row may start with: ❯
 # (claude) and › (codex) only. Generic shell-style glyphs > $ % # are still
 # recognized after a bordered composer row has already been structurally found.
-FM_BACKEND_HERDR_BARE_PROMPT_RE=${FM_BACKEND_HERDR_BARE_PROMPT_RE:-'^[❯›]'}
+FM_BACKEND_HERDR_BARE_PROMPT_RE=${FM_BACKEND_HERDR_BARE_PROMPT_RE:-'^(❯|›)'}
 # Pi allows a multi-line composer between its horizontal separators. Bound the
 # structural candidate so two unrelated transcript rules with an arbitrarily
 # large region between them can never be promoted into a composer.
@@ -903,7 +903,7 @@ EOF
   fi
   # Delegate the empty/pending/unknown decision to the shared owner. The bare
   # shape only ever starts with an AGENT glyph (FM_BACKEND_HERDR_BARE_PROMPT_RE
-  # is '^[❯›]'), so a bare shell prompt never reaches here - it stays 'unknown'
+  # is '^(❯|›)'), so a bare shell prompt never reaches here - it stays 'unknown'
   # via the no-composer-row path above, exactly as before.
   fm_composer_classify_content "$bordered" "$stripped" "$FM_BACKEND_HERDR_IDLE_RE"
 }

--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -312,21 +312,22 @@ crew_absorb_class() {  # <id>
   line=$("$FM_CREW_STATE_BIN" "$id" 2>/dev/null) || true
   case "$line" in state:*) ;; *) printf 'none'; return ;; esac
   state=${line#state: }; state=${state%% *}
+  src=${line#*source: }; src=${src%% *}
   if [ "$state" = working ]; then
-    src=${line#*source: }; src=${src%% *}
     case "$src" in run-step|pane) printf 'working'; return ;; esac
   fi
+  if [ "$state" = paused ]; then printf 'paused'; return; fi
   status_dir=${STATE:-${FM_STATE_OVERRIDE:-}}
   if [ -n "$status_dir" ]; then
     last=$(last_status_line "$status_dir/$id.status")
-    if status_is_paused "$last"; then printf 'paused'; return; fi
+    if status_is_paused "$last" && [ "$state:$src:${line##* · }" = "failed:run-step:run cancelled" ]; then
+      printf 'paused'
+      return
+    fi
   fi
-  if [ "$state" = paused ]; then printf 'paused'; return; fi
   if [ "$state" = "done" ]; then
-    src=${line#*source: }; src=${src%% *}
-    case "$src:$line" in
-      run-step:*"checks green: PR ready for review"*) printf 'merge-wait'; return ;;
-      status-log:*"checks green"*"run still monitoring PR"*) printf 'merge-wait'; return ;;
+    case "$line" in
+      *"(still monitoring for merge/close)") printf 'merge-wait'; return ;;
     esac
   fi
   printf 'none'

--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -325,7 +325,7 @@ crew_absorb_class() {  # <id>
       return
     fi
   fi
-  if [ "$state" = "done" ]; then
+  if [ "$state" = "done" ] && [ "$src" = run-step ]; then
     case "$line" in
       *"(still monitoring for merge/close)") printf 'merge-wait'; return ;;
     esac

--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -293,26 +293,41 @@ signal_reason_is_actionable() {  # <file> ...
 #   working - an actively-running no-mistakes step (running/fixing/ci) or a busy
 #             pane; the crew is legitimately mid-work on a static-looking pane
 #             (e.g. waiting on CI);
-#   paused  - the crew's authoritative current state is a declared external-wait
-#             pause (paused:), which is EXPECTED to idle;
+#   paused  - the status log's trailing verb declares an external wait, and no
+#             active run or busy pane supersedes it;
+#   merge-wait - checks are green and the run is terminal-done only because it
+#             is monitoring the PR for merge/close;
 #   none    - neither, so the wake must surface (a stopped/finished/parked/failed/
 #             torn-down/unknown crew, or an unreadable verdict).
 # One fm-crew-state.sh read serves BOTH absorb reasons at once. Reading the state
-# authoritatively (not the status log) is what keeps run-step precedence: a crew
-# that appended paused: but then STARTED a run reports working, never paused.
+# authoritatively is what keeps active-work precedence: a crew that appended
+# paused: but then STARTED a run reports working, while a terminal run no longer
+# masks the trailing pause declaration.
 # NOT a pure read: fm-crew-state.sh may make a bounded no-mistakes call, so callers
 # run it only on no-verb signal and first-sighting stale paths, never every wake.
 # FM_CREW_STATE_BIN lets tests stub the verdict.
 crew_absorb_class() {  # <id>
-  local id=$1 line state src
+  local id=$1 line state src status_dir last
   [ -n "$id" ] || { printf 'none'; return; }
   line=$("$FM_CREW_STATE_BIN" "$id" 2>/dev/null) || true
   case "$line" in state:*) ;; *) printf 'none'; return ;; esac
   state=${line#state: }; state=${state%% *}
-  if [ "$state" = paused ]; then printf 'paused'; return; fi
   if [ "$state" = working ]; then
     src=${line#*source: }; src=${src%% *}
     case "$src" in run-step|pane) printf 'working'; return ;; esac
+  fi
+  status_dir=${STATE:-${FM_STATE_OVERRIDE:-}}
+  if [ -n "$status_dir" ]; then
+    last=$(last_status_line "$status_dir/$id.status")
+    if status_is_paused "$last"; then printf 'paused'; return; fi
+  fi
+  if [ "$state" = paused ]; then printf 'paused'; return; fi
+  if [ "$state" = "done" ]; then
+    src=${line#*source: }; src=${src%% *}
+    case "$src:$line" in
+      run-step:*"checks green: PR ready for review"*) printf 'merge-wait'; return ;;
+      status-log:*"checks green"*"run still monitoring PR"*) printf 'merge-wait'; return ;;
+    esac
   fi
   printf 'none'
 }

--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Shared wake classifier: the common source of truth for captain-relevant status
-# tests, declared-external-wait vocabulary, and the working/paused absorb
-# classification that makes no-verb signal and stale-pane wakes safe to absorb.
+# tests, declared-external-wait vocabulary, and the working/idle-wait
+# classification used in no-verb signal and stale-pane triage.
 # Sourced by BOTH the always-on watcher
 # (bin/fm-watch.sh) and the away-mode daemon (bin/fm-supervise-daemon.sh) so the
 # overlapping triage policy lives in one place instead of two copies that can
@@ -17,9 +17,9 @@
 # working/paused wrappers). It is NOT a pure status-file read: it reuses
 # bin/fm-crew-state.sh, which may make a bounded no-mistakes call, to decide
 # whether a crew that just stopped its turn or went stale is working, deliberately
-# paused, or neither. Callers run it ONLY on no-verb signal handling and first
-# sighting of a stale hash, never on every wake, so the per-wake triage stays
-# cheap.
+# paused, monitoring a checks-green PR, or none of those. Callers run it ONLY on
+# no-verb signal handling and first sighting of a stale hash, never on every wake,
+# so the per-wake triage stays cheap.
 
 # Directory of this library, used to locate the sibling fm-crew-state.sh reader.
 # Resolved at source time from BASH_SOURCE so it works whether sourced by a
@@ -51,12 +51,13 @@ FM_CLASSIFY_CAPTAIN_RE_DEFAULT='done:|needs-decision:|blocked:|failed:|PR ready|
 # drift between the two consumers. FM_CLASSIFY_PAUSED_VERB overrides it.
 FM_CLASSIFY_PAUSED_VERB_DEFAULT='paused'
 
-# Bounded re-surface cadence for a declared pause or a dead-agent captain hold.
-# Far longer than the wedge threshold (FM_STALE_ESCALATE_SECS, default 240s), it
-# avoids nagging a deliberate wait while ensuring a forgotten hold cannot rot
-# invisibly - it re-surfaces once for a recheck every window. One hour by default;
-# both consumers read FM_PAUSE_RESURFACE_SECS with this default so the cadence has
-# one owner.
+# Bounded re-surface cadence for a legitimate idle wait. Far longer than the wedge
+# threshold (FM_STALE_ESCALATE_SECS, default 240s) so a deliberate wait is not
+# nagged like a wedge, yet finite so it cannot rot invisibly - it re-surfaces once
+# for a recheck every window. One hour by default; both consumers read
+# FM_PAUSE_RESURFACE_SECS with this default so the cadence has one owner, although
+# the away-mode daemon currently applies it only to declared pauses and the
+# normal-mode watcher also applies it to a dead-agent captain hold.
 # shellcheck disable=SC2034 # Read by the watcher and daemon (fm-watch.sh, fm-supervise-daemon.sh), not this lib.
 FM_PAUSE_RESURFACE_SECS_DEFAULT=3600
 
@@ -299,7 +300,7 @@ signal_reason_is_actionable() {  # <file> ...
 #             is monitoring the PR for merge/close;
 #   none    - neither, so the wake must surface (a stopped/finished/parked/failed/
 #             torn-down/unknown crew, or an unreadable verdict).
-# One fm-crew-state.sh read serves BOTH absorb reasons at once. Reading the state
+# One fm-crew-state.sh read serves every absorb class at once. Reading the state
 # authoritatively is what keeps active-work precedence: a crew that appended
 # paused: but then STARTED a run reports working, while a terminal run no longer
 # masks the trailing pause declaration.
@@ -339,7 +340,7 @@ crew_absorb_class() {  # <id>
 # ONLY when this returns 0, and SURFACED otherwise (the crew may be done, waiting
 # on a decision, or wedged). For stale panes it is checked before trusting the
 # status log so a pre-validation captain-relevant line does not override an active
-# run. See crew_absorb_class for the exact working/paused/none decision.
+# run. See crew_absorb_class for the exact decision.
 crew_is_provably_working() {  # <id>
   [ "$(crew_absorb_class "$1")" = working ]
 }

--- a/bin/fm-composer-lib.sh
+++ b/bin/fm-composer-lib.sh
@@ -207,8 +207,18 @@ fm_composer_classify_content() {  # <bordered> <content> [idle_re] [idle_case] [
   fi
   # Strip a leading prompt glyph, then re-judge the remainder.
   case "$content" in
-    '❯ '*|'› '*|'> '*|'$ '*|'% '*|'# '*) content=${content#??} ;;
-    '❯'*|'›'*|'>'*|'$'*|'%'*|'#'*) content=${content#?} ;;
+    '❯ '*) content=${content#'❯ '} ;;
+    '› '*) content=${content#'› '} ;;
+    '> '*) content=${content#'> '} ;;
+    '$ '*) content=${content#'$ '} ;;
+    '% '*) content=${content#'% '} ;;
+    '# '*) content=${content#'# '} ;;
+    '❯'*) content=${content#'❯'} ;;
+    '›'*) content=${content#'›'} ;;
+    '>'*) content=${content#'>'} ;;
+    '$'*) content=${content#'$'} ;;
+    '%'*) content=${content#'%'} ;;
+    '#'*) content=${content#'#'} ;;
   esac
   content="${content#"${content%%[![:space:]]*}"}"
   content="${content%"${content##*[![:space:]]}"}"

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -377,7 +377,7 @@ idle_marker_class() {  # <window-key>
 }
 
 pause_state_class() {  # <window> <task>
-  local win=$1 task=$2 key last recheck_file class agent_alive line state src
+  local win=$1 task=$2 key last recheck_file class agent_alive line src
   key=${win//:/_}
   key=${key//\//_}
   key=${key//./_}
@@ -401,6 +401,23 @@ pause_state_class() {  # <window> <task>
     printf '%s' "$class"
     return
   fi
+  line=$("$FM_CREW_STATE_BIN" "$task" 2>/dev/null) || true
+  if [ "$class" = paused ] && [ "${line##* · }" = "run cancelled" ]; then
+    date +%s > "$recheck_file"
+    printf 'paused'
+    return
+  fi
+  case "$line" in
+    state:*)
+      src=${line#*source: }; src=${src%% *}
+      ;;
+    *) src=none ;;
+  esac
+  if [ "$class" = none ] && [ "$src" = run-step ]; then
+    rm -f "$recheck_file"
+    printf 'none'
+    return
+  fi
   agent_alive=$(fm_backend_agent_alive "$(window_backend "$win")" "$win" 2>/dev/null) || agent_alive=unknown
   if [ "$agent_alive" != dead ]; then
     rm -f "$recheck_file"
@@ -410,19 +427,6 @@ pause_state_class() {  # <window> <task>
   if [ "$class" = paused ]; then
     date +%s > "$recheck_file"
     printf 'paused'
-    return
-  fi
-  line=$("$FM_CREW_STATE_BIN" "$task" 2>/dev/null) || true
-  case "$line" in
-    state:*)
-      state=${line#state: }; state=${state%% *}
-      src=${line#*source: }; src=${src%% *}
-      ;;
-    *) state=unknown; src=none ;;
-  esac
-  if [ "$src" = run-step ] && [ "$state" != paused ]; then
-    rm -f "$recheck_file"
-    printf 'none'
     return
   fi
   date +%s > "$recheck_file"
@@ -1037,8 +1041,14 @@ EOF
                 ;;
               paused) handle_idle_stale "$w" "$task" "$h" paused ;;
               merge-wait) handle_idle_stale "$w" "$task" "$h" merge-wait ;;
-              *)
+              live-hold)
                 surface_nonterminal_stale "$w" "$h"
+                ;;
+              *)
+                clear_pause_tracking "$w"
+                fm_wake_append stale "$w" "stale: $w" || exit 1
+                printf '%s' "$h" > "$sf"
+                wake "stale: $w"
                 ;;
             esac
           else
@@ -1047,11 +1057,15 @@ EOF
               case "$(pause_state_class "$w" "$task")" in
                 paused)  handle_idle_stale "$w" "$task" "$h" paused ;;
                 merge-wait) handle_idle_stale "$w" "$task" "$h" merge-wait ;;
+                live-hold) handle_idle_stale "$w" "$task" "$h" paused ;;
                 working) clear_pause_state "$w"
                          printf '%s' "$h" > "$sf"
                          wedge_timer_check "$w" "$ssf" "non-terminal stale (provably working after a declared pause)" "$ewf"
                          triage_log "absorbed non-terminal stale (provably working): $w" ;;
-                *)       handle_paused_stale "$w" "$task" "$h" ;;
+                *)       clear_pause_tracking "$w"
+                         fm_wake_append stale "$w" "stale: $w" || exit 1
+                         printf '%s' "$h" > "$sf"
+                         wake "stale: $w" ;;
               esac
             else
               if [ "$(age_of "$ssf")" -ge "$STALE_ESCALATE_SECS" ]; then

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -1049,7 +1049,15 @@ EOF
                 *)       handle_paused_stale "$w" "$task" "$h" ;;
               esac
             else
-              wedge_timer_check "$w" "$ssf" "non-terminal stale" "$ewf"
+              if [ "$(age_of "$ssf")" -ge "$STALE_ESCALATE_SECS" ]; then
+                case "$(crew_absorb_class "$task")" in
+                  paused) handle_idle_stale "$w" "$task" "$h" paused ;;
+                  merge-wait) handle_idle_stale "$w" "$task" "$h" merge-wait ;;
+                  *) wedge_timer_check "$w" "$ssf" "non-terminal stale" "$ewf" ;;
+                esac
+              else
+                wedge_timer_check "$w" "$ssf" "non-terminal stale" "$ewf"
+              fi
             fi
           fi
         fi
@@ -1065,7 +1073,8 @@ EOF
       echo 0 > "$cf"
       rm -f "$ssf" "$ewf"
       task=$(window_to_task "$w" "$STATE")
-      if ! afk_present && status_is_paused_or_captain_held "$(last_status_line "$STATE/$task.status")" && ! window_is_busy "$w" "$tail40"; then
+      if ! afk_present && ! window_is_busy "$w" "$tail40" \
+        && { [ -e "$pf" ] || status_is_paused_or_captain_held "$(last_status_line "$STATE/$task.status")"; }; then
         case "$(pause_state_class "$w" "$task")" in
           paused) handle_idle_stale "$w" "$task" "$h" paused ;;
           merge-wait) handle_idle_stale "$w" "$task" "$h" merge-wait ;;

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -309,13 +309,12 @@ wedge_timer_check() {  # <window> <since-file> <triage-label> <escalation-count-
 # a dead-agent captain-held transfer, or checks-green PR merge monitoring.
 # Re-surface it once every PAUSE_RESURFACE_SECS for a recheck so it cannot rot
 # invisibly.
-# Called on any stale poll once pause_state_class permits the bounded cadence, so
-# it must be cheap and never re-read crew state.
-# The re-surface age is anchored on the wait's status file mtime, not a per-hash
-# marker, so a churny idle pane cannot keep resetting the cadence.
-# A .paused-resurfaced-<key> throttle marker records the last
+# Called after crew_absorb_class authoritatively confirms the idle state.
+# A declared pause is aged from its status-file mtime, while merge monitoring is
+# aged from the idle marker's first sighting because validation may postdate the
+# latest status. A .paused-resurfaced-<key> throttle marker records the last
 # re-surface epoch so, once past the window, it fires once per window rather than
-# every poll. Advances the stale suppressor to <hash> and flags the key paused.
+# every poll. Advances the stale suppressor to <hash> and records the idle class.
 handle_idle_stale() {  # <window> <task> <hash> <paused|merge-wait>
   local win=$1 task=$2 h=$3 class=$4 key marker marked statusf mtime age rf rf_age reason detail
   key=$(printf '%s' "$win" | tr ':/.' '___')
@@ -326,9 +325,14 @@ handle_idle_stale() {  # <window> <task> <hash> <paused|merge-wait>
     printf '%s\n' "$class" > "$marker"
   fi
   rm -f "$STATE/.stale-since-$key" "$STATE/.wedge-escalations-$key"
-  statusf="$STATE/$task.status"
-  mtime=$(stat_mtime "$statusf")
-  case "$mtime" in ''|*[!0-9]*) mtime=$(stat_mtime "$marker") ;; esac
+  case "$class" in
+    paused)
+      statusf="$STATE/$task.status"
+      mtime=$(stat_mtime "$statusf")
+      case "$mtime" in ''|*[!0-9]*) mtime=$(stat_mtime "$marker") ;; esac
+      ;;
+    merge-wait) mtime=$(stat_mtime "$marker") ;;
+  esac
   case "$mtime" in ''|*[!0-9]*) mtime=$(date +%s) ;; esac
   age=$(( $(date +%s) - mtime ))
   rf="$STATE/.paused-resurfaced-$key"
@@ -373,59 +377,56 @@ idle_marker_class() {  # <window-key>
 }
 
 pause_state_class() {  # <window> <task>
-  local win=$1 task=$2 key last recheck_file class marked agent_alive
+  local win=$1 task=$2 key last recheck_file class agent_alive line state src
   key=${win//:/_}
   key=${key//\//_}
   key=${key//./_}
   last=$(last_status_line "$STATE/$task.status")
   recheck_file="$STATE/.paused-rechecked-$key"
+  class=$(crew_absorb_class "$task")
+  case "$class" in
+    working|merge-wait)
+      rm -f "$recheck_file"
+      printf '%s' "$class"
+      return
+      ;;
+  esac
   if ! status_is_paused_or_captain_held "$last"; then
     rm -f "$recheck_file"
-    crew_absorb_class "$task"
+    printf 'none'
     return
   fi
-  marked=$(idle_marker_class "$key")
-  if [ -e "$STATE/.paused-$key" ] && [ "$(age_of "$recheck_file")" -lt "$STALE_ESCALATE_SECS" ]; then
-    if [ "$marked" = merge-wait ]; then
-      printf 'merge-wait'
-      return
-    fi
-    if [ "$(window_kind "$win")" != secondmate ]; then
-      agent_alive=$(fm_backend_agent_alive "$(window_backend "$win")" "$win" 2>/dev/null) || agent_alive=unknown
-      if [ "$agent_alive" != dead ]; then
-        rm -f "$recheck_file"
-        printf 'none'
-        return
-      fi
-    fi
+  if [ "$(window_kind "$win")" = secondmate ]; then
+    case "$class" in paused) date +%s > "$recheck_file" ;; *) rm -f "$recheck_file" ;; esac
+    printf '%s' "$class"
+    return
+  fi
+  agent_alive=$(fm_backend_agent_alive "$(window_backend "$win")" "$win" 2>/dev/null) || agent_alive=unknown
+  if [ "$agent_alive" != dead ]; then
+    rm -f "$recheck_file"
+    printf 'live-hold'
+    return
+  fi
+  if [ "$class" = paused ]; then
+    date +%s > "$recheck_file"
     printf 'paused'
     return
   fi
-  class=$(crew_absorb_class "$task")
-  if [ "$class" = working ]; then
-    rm -f "$recheck_file"
-    printf 'working'
-    return
-  fi
-  if [ "$class" = merge-wait ]; then
-    date +%s > "$recheck_file"
-    printf 'merge-wait'
-    return
-  fi
-  if [ "$(window_kind "$win")" != secondmate ]; then
-    agent_alive=$(fm_backend_agent_alive "$(window_backend "$win")" "$win" 2>/dev/null) || agent_alive=unknown
-    if [ "$agent_alive" != dead ]; then
-      rm -f "$recheck_file"
-      printf 'none'
-      return
-    fi
-  fi
-  [ "$class" = none ] && [ "${agent_alive:-unknown}" = dead ] && class=paused
-  case "$class" in
-    paused|merge-wait) date +%s > "$recheck_file" ;;
-    *) rm -f "$recheck_file" ;;
+  line=$("$FM_CREW_STATE_BIN" "$task" 2>/dev/null) || true
+  case "$line" in
+    state:*)
+      state=${line#state: }; state=${state%% *}
+      src=${line#*source: }; src=${src%% *}
+      ;;
+    *) state=unknown; src=none ;;
   esac
-  printf '%s' "$class"
+  if [ "$src" = run-step ] && [ "$state" != paused ]; then
+    rm -f "$recheck_file"
+    printf 'none'
+    return
+  fi
+  date +%s > "$recheck_file"
+  printf 'paused'
 }
 
 surface_nonterminal_stale() {  # <window> <hash>

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -317,13 +317,18 @@ wedge_timer_check() {  # <window> <since-file> <triage-label> <escalation-count-
 # re-surface epoch so, once past the window, it fires once per window rather than
 # every poll. Advances the stale suppressor to <hash> and flags the key paused.
 handle_idle_stale() {  # <window> <task> <hash> <paused|merge-wait>
-  local win=$1 task=$2 h=$3 class=$4 key statusf mtime age rf rf_age reason detail
+  local win=$1 task=$2 h=$3 class=$4 key marker marked statusf mtime age rf rf_age reason detail
   key=$(printf '%s' "$win" | tr ':/.' '___')
   printf '%s' "$h" > "$STATE/.stale-$key"
-  printf '%s\n' "$class" > "$STATE/.paused-$key"
+  marker="$STATE/.paused-$key"
+  marked=$(cat "$marker" 2>/dev/null || true)
+  if [ "$marked" != "$class" ]; then
+    printf '%s\n' "$class" > "$marker"
+  fi
   rm -f "$STATE/.stale-since-$key" "$STATE/.wedge-escalations-$key"
   statusf="$STATE/$task.status"
   mtime=$(stat_mtime "$statusf")
+  case "$mtime" in ''|*[!0-9]*) mtime=$(stat_mtime "$marker") ;; esac
   case "$mtime" in ''|*[!0-9]*) mtime=$(date +%s) ;; esac
   age=$(( $(date +%s) - mtime ))
   rf="$STATE/.paused-resurfaced-$key"

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -1008,16 +1008,21 @@ EOF
           # unmodified terminal-status behavior).
         else
           # Non-terminal stale: a crew gone quiet without a captain-relevant status.
-          # Decided once per distinct stale hash (the costly state reads run only
-          # on first sight, never every poll) via pause_state_class, which returns:
+          # Decided via pause_state_class, which revalidates authoritative state
+          # before returning an absorb class:
           #   - working: an actively-running pipeline legitimately sits on a static
           #     pane (e.g. waiting on CI), so absorb and start the wedge timer so a
           #     genuinely frozen run still escalates past STALE_ESCALATE_SECS;
           #   - paused: the crew declared an external wait, or a declared pause or
           #     captain hold is paired with a confidently dead agent, so absorb on
           #     the long PAUSE_RESURFACE_SECS cadence instead of wedge-escalating;
-          #   - none: no running pipeline, idle pane, no busy signature, no declared
-          #     pause - the crew has STOPPED. Surface immediately so firstmate peeks
+          #   - merge-wait: checks are green and the run is monitoring the PR for
+          #     merge or close, so use the same bounded idle cadence;
+          #   - live-hold: an ordinary crew still has a live or inconclusive agent,
+          #     so surface its first stale sighting before using the bounded cadence;
+          #   - none: no running pipeline, idle pane, no busy signature, and no
+          #     legitimate idle wait - the crew has STOPPED. Surface immediately so
+          #     firstmate peeks
           #     (it may be done via an interactive menu that wrote no done: status,
           #     waiting on a decision, or wedged) instead of leaving the finish to
           #     wait out the timer.

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -6,9 +6,9 @@
 # is absorbed only when the crew shows POSITIVE evidence it is still working (an
 # actively-running no-mistakes step, or a backend busy signal), and surfaced
 # otherwise, so a crew that finishes (or stops and waits) without a current
-# working signal is never silently swallowed. A declared external-wait pause is
-# the separate idle absorb case and re-surfaces only on its long bounded cadence,
-# although its initial no-verb status signal still surfaces in normal mode.
+# working signal is never silently swallowed. Declared external pauses and
+# checks-green merge monitoring are separate idle absorb cases that re-surface
+# only on the long bounded cadence.
 # While state/.afk exists, the daemon owns triage and this watcher queues and exits
 # on every wake. Printed reason lines:
 #   signal: <file>...      status/turn-end signals, surfaced when a listed status
@@ -18,9 +18,9 @@
 #                          timer) regardless of what the status log says - an active
 #                          run-step or busy pane outranks even a captain-relevant log
 #                          line, since the crew's own log gets no new entry once
-#                          firstmate hands it to a no-mistakes validation. A declared
-#                          external-wait pause is absorbed instead with its own long
-#                          re-surface cadence, never as a wedge. Only when neither
+#                          firstmate hands it to a no-mistakes validation. Declared
+#                          pauses and checks-green merge monitoring are absorbed on
+#                          the shared long re-surface cadence, never as wedges. When no
 #                          absorb class applies does the log's last line decide:
 #                          terminal (captain-relevant) or non-terminal (no verb),
 #                          both surfaced at once. A provably-working stale past the
@@ -135,12 +135,12 @@ BUSY_REGEX=${FM_BUSY_REGEX:-'esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel'}
 # daemon owns triage, so this watcher reverts to one-shot (enqueue + exit on every
 # wake) and never double-triages - and never runs the costly provably-working read.
 STALE_ESCALATE_SECS=${FM_STALE_ESCALATE_SECS:-240}  # idle secs before a provably-working stale escalates as a possible wedge
-# A crew that declared a pause is idling on a known external wait, so its stale
-# pane is absorbed rather than wedge-escalated.
-# A captain-held or paused crew whose agent has confidently exited uses the same
-# bounded cadence, while a live or ambiguously read agent still surfaces once.
-# These cases re-surface once for a recheck every PAUSE_RESURFACE_SECS - far
-# longer than the wedge threshold, but finite so a forgotten hold cannot rot invisibly.
+# A legitimate idle wait is a declared pause, a dead-agent captain-held transfer,
+# or a checks-green run still monitoring its PR for merge or close.
+# These cases use a bounded cadence rather than wedge escalation.
+# A live or ambiguously read agent at a declared pause or captain-held transfer
+# still surfaces once, while every idle wait re-surfaces once for a recheck every
+# PAUSE_RESURFACE_SECS so a forgotten wait cannot rot invisibly.
 PAUSE_RESURFACE_SECS=${FM_PAUSE_RESURFACE_SECS:-$FM_PAUSE_RESURFACE_SECS_DEFAULT}
 TRIAGE_LOG="$STATE/.watch-triage.log"
 TRIAGE_LOG_MAX_BYTES=${FM_WATCH_TRIAGE_LOG_MAX_BYTES:-262144}
@@ -305,21 +305,22 @@ wedge_timer_check() {  # <window> <since-file> <triage-label> <escalation-count-
   esac
 }
 
-# Absorb a stale pane under a declared external-wait pause (paused:) or a
-# dead-agent captain-held transfer, and re-surface it once every
-# PAUSE_RESURFACE_SECS for a recheck so it cannot rot invisibly. Called on any
-# stale poll once pause_state_class permits the bounded cadence, so it must be
-# cheap: it NEVER re-reads crew state. The re-surface age is anchored on the
-# status file mtime, not a per-hash marker, so a churny idle pane (a ticking
-# clock, a token counter) cannot keep resetting the cadence the way a hash-tied
-# timer would. A .paused-resurfaced-<key> throttle marker records the last
+# Absorb a stale pane whose crew is in a legitimate idle wait: a declared pause,
+# a dead-agent captain-held transfer, or checks-green PR merge monitoring.
+# Re-surface it once every PAUSE_RESURFACE_SECS for a recheck so it cannot rot
+# invisibly.
+# Called on any stale poll once pause_state_class permits the bounded cadence, so
+# it must be cheap and never re-read crew state.
+# The re-surface age is anchored on the wait's status file mtime, not a per-hash
+# marker, so a churny idle pane cannot keep resetting the cadence.
+# A .paused-resurfaced-<key> throttle marker records the last
 # re-surface epoch so, once past the window, it fires once per window rather than
 # every poll. Advances the stale suppressor to <hash> and flags the key paused.
-handle_paused_stale() {  # <window> <task> <hash>
-  local win=$1 task=$2 h=$3 key statusf mtime age rf rf_age reason
+handle_idle_stale() {  # <window> <task> <hash> <paused|merge-wait>
+  local win=$1 task=$2 h=$3 class=$4 key statusf mtime age rf rf_age reason detail
   key=$(printf '%s' "$win" | tr ':/.' '___')
   printf '%s' "$h" > "$STATE/.stale-$key"
-  : > "$STATE/.paused-$key"
+  printf '%s\n' "$class" > "$STATE/.paused-$key"
   rm -f "$STATE/.stale-since-$key" "$STATE/.wedge-escalations-$key"
   statusf="$STATE/$task.status"
   mtime=$(stat_mtime "$statusf")
@@ -328,12 +329,16 @@ handle_paused_stale() {  # <window> <task> <hash>
   rf="$STATE/.paused-resurfaced-$key"
   rf_age=$(age_of "$rf")   # 999999 when no prior re-surface
   if [ "$age" -ge "$PAUSE_RESURFACE_SECS" ] && [ "$rf_age" -ge "$PAUSE_RESURFACE_SECS" ]; then
-    reason="stale: $win (paused ${age}s, awaiting external - declared pause, rechecked on a long cadence not a wedge; confirm the wait still holds)"
+    case "$class" in
+      paused) detail="paused ${age}s, awaiting external - declared pause" ;;
+      merge-wait) detail="merge-wait ${age}s, checks green - still monitoring for merge/close" ;;
+    esac
+    reason="stale: $win ($detail, rechecked on a long cadence not a wedge; confirm the wait still holds)"
     fm_wake_append stale "$win" "$reason" || exit 1
     date +%s > "$rf"
     wake "$reason"
   fi
-  triage_log "absorbed stale (paused, awaiting external, age ${age}s): $win"
+  triage_log "absorbed stale ($class, legitimate idle wait, age ${age}s): $win"
 }
 
 clear_pause_state() {  # <window>
@@ -356,8 +361,14 @@ clear_pause_tracking() {  # <window>
 # Reconcile a declared pause or captain-held status with authoritative crew state.
 # Only a confidently dead ordinary crew may recover paused classification after
 # fm-crew-state has fallen back to stopped or unknown.
+idle_marker_class() {  # <window-key>
+  local class
+  class=$(cat "$STATE/.paused-$1" 2>/dev/null || true)
+  case "$class" in paused|merge-wait) printf '%s' "$class" ;; *) printf 'paused' ;; esac
+}
+
 pause_state_class() {  # <window> <task>
-  local win=$1 task=$2 key last recheck_file class agent_alive
+  local win=$1 task=$2 key last recheck_file class marked agent_alive
   key=${win//:/_}
   key=${key//\//_}
   key=${key//./_}
@@ -368,7 +379,12 @@ pause_state_class() {  # <window> <task>
     crew_absorb_class "$task"
     return
   fi
+  marked=$(idle_marker_class "$key")
   if [ -e "$STATE/.paused-$key" ] && [ "$(age_of "$recheck_file")" -lt "$STALE_ESCALATE_SECS" ]; then
+    if [ "$marked" = merge-wait ]; then
+      printf 'merge-wait'
+      return
+    fi
     if [ "$(window_kind "$win")" != secondmate ]; then
       agent_alive=$(fm_backend_agent_alive "$(window_backend "$win")" "$win" 2>/dev/null) || agent_alive=unknown
       if [ "$agent_alive" != dead ]; then
@@ -386,6 +402,11 @@ pause_state_class() {  # <window> <task>
     printf 'working'
     return
   fi
+  if [ "$class" = merge-wait ]; then
+    date +%s > "$recheck_file"
+    printf 'merge-wait'
+    return
+  fi
   if [ "$(window_kind "$win")" != secondmate ]; then
     agent_alive=$(fm_backend_agent_alive "$(window_backend "$win")" "$win" 2>/dev/null) || agent_alive=unknown
     if [ "$agent_alive" != dead ]; then
@@ -396,7 +417,7 @@ pause_state_class() {  # <window> <task>
   fi
   [ "$class" = none ] && [ "${agent_alive:-unknown}" = dead ] && class=paused
   case "$class" in
-    paused) date +%s > "$recheck_file" ;;
+    paused|merge-wait) date +%s > "$recheck_file" ;;
     *) rm -f "$recheck_file" ;;
   esac
   printf '%s' "$class"
@@ -879,7 +900,7 @@ EOF
     key=${key//./_}
     last=$(last_status_line "$STATE/$task.status")
     if ! status_is_paused_or_captain_held "$last" && [ -e "$STATE/.paused-$key" ]; then
-      clear_pause_tracking "$w"
+      [ "$(idle_marker_class "$key")" = paused ] && clear_pause_tracking "$w"
     fi
     if [ "$kind" = secondmate ] && ! status_is_paused "$last"; then
       continue
@@ -892,7 +913,7 @@ EOF
     sf="$STATE/.stale-$key"
     ssf="$STATE/.stale-since-$key"
     ewf="$STATE/.wedge-escalations-$key"
-    pf="$STATE/.paused-$key"   # flag: this key's stale is using the bounded pause cadence
+    pf="$STATE/.paused-$key"   # marker: this key's stale is a legitimate idle wait
     prev=$(cat "$hf" 2>/dev/null || true)
     if [ "$h" = "$prev" ]; then
       n=$(( $(cat "$cf" 2>/dev/null || echo 0) + 1 ))
@@ -905,8 +926,9 @@ EOF
         # The pane is idle/stale at hash $h. Triage decides whether this wakes
         # firstmate. Detection itself is unchanged from above.
         if [ "$kind" = secondmate ]; then
-          case "$(pause_state_class "$w" "$task")" in
-            paused) handle_paused_stale "$w" "$task" "$h" ;;
+          class=$(pause_state_class "$w" "$task")
+          case "$class" in
+            paused|merge-wait) handle_idle_stale "$w" "$task" "$h" "$class" ;;
             *)      clear_pause_tracking "$w" ;;
           esac
         elif afk_present; then
@@ -932,23 +954,48 @@ EOF
           # authoritative source fm-crew-state.sh itself already prioritizes
           # over the log) a chance to override before trusting the log.
           if [ "$(cat "$sf" 2>/dev/null || true)" != "$h" ]; then
-            if crew_is_provably_working "$(window_to_task "$w" "$STATE")"; then
-              printf '%s' "$h" > "$sf"
-              date +%s > "$ssf"
-              triage_log "absorbed stale (provably working, overriding a stale captain-relevant status): $w"
-            else
-              fm_wake_append stale "$w" "stale: $w" || exit 1
-              printf '%s' "$h" > "$sf"
-              rm -f "$ssf"
-              mark_surfaced "$STATE/$(window_to_task "$w" "$STATE").status"
-              wake "stale: $w"
-            fi
+            task=$(window_to_task "$w" "$STATE")
+            case "$(crew_absorb_class "$task")" in
+              working)
+                printf '%s' "$h" > "$sf"
+                date +%s > "$ssf"
+                triage_log "absorbed stale (provably working, overriding a stale captain-relevant status): $w"
+                ;;
+              paused) handle_idle_stale "$w" "$task" "$h" paused ;;
+              merge-wait) handle_idle_stale "$w" "$task" "$h" merge-wait ;;
+              *)
+                fm_wake_append stale "$w" "stale: $w" || exit 1
+                printf '%s' "$h" > "$sf"
+                rm -f "$ssf"
+                mark_surfaced "$STATE/$task.status"
+                wake "stale: $w"
+                ;;
+            esac
+          elif [ -e "$pf" ]; then
+            case "$(pause_state_class "$w" "$task")" in
+              paused) handle_idle_stale "$w" "$task" "$h" paused ;;
+              merge-wait) handle_idle_stale "$w" "$task" "$h" merge-wait ;;
+              working) clear_pause_state "$w"; wedge_timer_check "$w" "$ssf" "stale (overridden terminal status)" "$ewf" ;;
+              *) clear_pause_tracking "$w"
+                 fm_wake_append stale "$w" "stale: $w" || exit 1
+                 printf '%s' "$h" > "$sf"
+                 mark_surfaced "$STATE/$task.status"
+                 wake "stale: $w" ;;
+            esac
           elif [ -e "$ssf" ]; then
             # This exact hash was already overridden as provably-working (a
             # wedge timer is running for it) - keep treating it that way
             # without re-reading the crew state every poll, and without
             # letting the still-captain-relevant log line re-surface it.
-            wedge_timer_check "$w" "$ssf" "stale (overridden terminal status)" "$ewf"
+            if [ "$(age_of "$ssf")" -ge "$STALE_ESCALATE_SECS" ]; then
+              case "$(crew_absorb_class "$task")" in
+                paused) handle_idle_stale "$w" "$task" "$h" paused ;;
+                merge-wait) handle_idle_stale "$w" "$task" "$h" merge-wait ;;
+                *) wedge_timer_check "$w" "$ssf" "stale (overridden terminal status)" "$ewf" ;;
+              esac
+            else
+              wedge_timer_check "$w" "$ssf" "stale (overridden terminal status)" "$ewf"
+            fi
           fi
           # else: already surfaced as genuinely terminal on a prior poll of
           # this same hash - nothing left to do (matches the original,
@@ -977,9 +1024,8 @@ EOF
                 date +%s > "$ssf"
                 triage_log "absorbed non-terminal stale (provably working): $w"
                 ;;
-              paused)
-                handle_paused_stale "$w" "$task" "$h"
-                ;;
+              paused) handle_idle_stale "$w" "$task" "$h" paused ;;
+              merge-wait) handle_idle_stale "$w" "$task" "$h" merge-wait ;;
               *)
                 surface_nonterminal_stale "$w" "$h"
                 ;;
@@ -988,7 +1034,8 @@ EOF
             task=$(window_to_task "$w" "$STATE")
             if [ -e "$pf" ] || status_is_paused_or_captain_held "$(last_status_line "$STATE/$task.status")"; then
               case "$(pause_state_class "$w" "$task")" in
-                paused)  handle_paused_stale "$w" "$task" "$h" ;;
+                paused)  handle_idle_stale "$w" "$task" "$h" paused ;;
+                merge-wait) handle_idle_stale "$w" "$task" "$h" merge-wait ;;
                 working) clear_pause_state "$w"
                          printf '%s' "$h" > "$sf"
                          wedge_timer_check "$w" "$ssf" "non-terminal stale (provably working after a declared pause)" "$ewf"
@@ -1014,7 +1061,8 @@ EOF
       task=$(window_to_task "$w" "$STATE")
       if ! afk_present && status_is_paused_or_captain_held "$(last_status_line "$STATE/$task.status")" && ! window_is_busy "$w" "$tail40"; then
         case "$(pause_state_class "$w" "$task")" in
-          paused) handle_paused_stale "$w" "$task" "$h" ;;
+          paused) handle_idle_stale "$w" "$task" "$h" paused ;;
+          merge-wait) handle_idle_stale "$w" "$task" "$h" merge-wait ;;
           *)      clear_pause_tracking "$w" ;;
         esac
       else

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,8 +15,8 @@ Those actionable wakes are written to a durable local queue (`state/.wake-queue`
 No-verb wakes, such as `working:` notes and bare turn-ended signals, are benign only when `bin/fm-crew-state.sh` reports positive evidence that the crew is still working: an actively running no-mistakes step for that crew's branch or a backend busy signature.
 A crew is classified as a legitimate idle wait when its trailing verb declares `paused:` and no active work supersedes that declaration, or when its matching no-mistakes run reports checks green while monitoring the PR for merge or close.
 A cancelled terminal run does not mask a trailing pause because cancelling validation is a normal part of entering an external wait; failed runs and parked gates still surface immediately.
-In normal mode, both idle-wait forms are absorbed and re-surfaced only on the longer pause cadence, while their stale and wedge-escalation counters are cleared.
-The task check script remains the immediate wake path when a monitored PR actually merges or closes.
+In normal mode, stale-pane churn from either idle-wait form is absorbed and re-surfaced only on the longer pause cadence, while its stale and wedge-escalation counters are cleared.
+The task's `state/<id>.check.sh` remains the immediate wake path when a monitored PR actually merges or closes.
 For an ordinary crew that has stopped, the normal-mode watcher first surfaces one stale wake, then applies that same cadence to an unchanged `paused:` or durable `captain-held` endpoint only when the backend confidently reports its agent dead.
 Live or inconclusive liveness remains fail-open at that initial surface, and the secondmate idle-endpoint exemption is unchanged.
 A declared pause's initial normal-mode status signal still surfaces through the no-verb path.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,14 +9,17 @@ firstmate's always-loaded operating contract and routing index for conditional p
 ## Event-driven supervision
 
 A zero-token bash watcher (`bin/fm-watch.sh`) sleeps on the fleet, classifies detected wakes in bash, and wakes the first mate only when something is actionable.
-Actionable wakes include captain-relevant status signals, no-verb signals whose crew is not provably working, authenticated check output such as PR merge polling or an X-mode mention, stale panes whose crew is not provably working whether their status log looks terminal or non-terminal, provably-working stale panes that persist past `FM_STALE_ESCALATE_SECS`, declared external waits that remain paused past `FM_PAUSE_RESURFACE_SECS`, and heartbeat backstop hits.
+Actionable wakes include captain-relevant status signals, no-verb signals whose crew is not provably working, authenticated check output such as PR merge polling or an X-mode mention, stale panes whose crew is neither provably working nor in a legitimate idle wait whether their status log looks terminal or non-terminal, provably-working stale panes that persist past `FM_STALE_ESCALATE_SECS`, legitimate idle waits that persist past `FM_PAUSE_RESURFACE_SECS`, and heartbeat backstop hits.
 Repeated provably-working stale escalations on the same unchanged pane add an escalation count to the wake reason and, at `FM_WEDGE_DEMAND_INSPECT_COUNT`, a `demand-deep-inspection` marker.
 Those actionable wakes are written to a durable local queue (`state/.wake-queue`) before detector state advances, so a missed process exit can be recovered by draining the queue.
 No-verb wakes, such as `working:` notes and bare turn-ended signals, are benign only when `bin/fm-crew-state.sh` reports positive evidence that the crew is still working: an actively running no-mistakes step for that crew's branch or a backend busy signature.
-A crew that declares `paused:` for a known external wait is separately absorbed while idle and re-surfaced only on the longer pause cadence, rather than being treated as a possible wedge.
+A crew is classified as a legitimate idle wait when its trailing verb declares `paused:` and no active work supersedes that declaration, or when its matching no-mistakes run reports checks green while monitoring the PR for merge or close.
+Terminal run metadata does not mask a trailing pause because cancelling validation is a normal part of entering an external wait.
+Both idle-wait forms are absorbed and re-surfaced only on the longer pause cadence, while their stale and wedge-escalation counters are cleared.
+The task check script remains the immediate wake path when a monitored PR actually merges or closes.
 For an ordinary crew that has stopped, the normal-mode watcher first surfaces one stale wake, then applies that same cadence to an unchanged `paused:` or durable `captain-held` endpoint only when the backend confidently reports its agent dead.
 Live or inconclusive liveness remains fail-open at that initial surface, and the secondmate idle-endpoint exemption is unchanged.
-Its initial normal-mode status signal still surfaces through the no-verb path, while away mode self-handles that routine signal and owns the later recheck.
+A declared pause's initial normal-mode status signal still surfaces through the no-verb path, while away mode self-handles that routine signal and owns the later recheck.
 Fresh stale panes use the same current-state read before trusting the status log, so an active run or busy pane outranks an old captain-relevant status-log line left behind before validation.
 No-change heartbeats are also benign.
 Absorbed wakes advance their suppression markers, log to `state/.watch-triage.log`, and keep the watcher blocking without a queue record or LLM turn.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,7 +14,7 @@ Repeated provably-working stale escalations on the same unchanged pane add an es
 Those actionable wakes are written to a durable local queue (`state/.wake-queue`) before detector state advances, so a missed process exit can be recovered by draining the queue.
 No-verb wakes, such as `working:` notes and bare turn-ended signals, are benign only when `bin/fm-crew-state.sh` reports positive evidence that the crew is still working: an actively running no-mistakes step for that crew's branch or a backend busy signature.
 A crew is classified as a legitimate idle wait when its trailing verb declares `paused:` and no active work supersedes that declaration, or when its matching no-mistakes run reports checks green while monitoring the PR for merge or close.
-Terminal run metadata does not mask a trailing pause because cancelling validation is a normal part of entering an external wait.
+A cancelled terminal run does not mask a trailing pause because cancelling validation is a normal part of entering an external wait; failed runs and parked gates still surface immediately.
 Both idle-wait forms are absorbed and re-surfaced only on the longer pause cadence, while their stale and wedge-escalation counters are cleared.
 The task check script remains the immediate wake path when a monitored PR actually merges or closes.
 For an ordinary crew that has stopped, the normal-mode watcher first surfaces one stale wake, then applies that same cadence to an unchanged `paused:` or durable `captain-held` endpoint only when the backend confidently reports its agent dead.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,11 +15,13 @@ Those actionable wakes are written to a durable local queue (`state/.wake-queue`
 No-verb wakes, such as `working:` notes and bare turn-ended signals, are benign only when `bin/fm-crew-state.sh` reports positive evidence that the crew is still working: an actively running no-mistakes step for that crew's branch or a backend busy signature.
 A crew is classified as a legitimate idle wait when its trailing verb declares `paused:` and no active work supersedes that declaration, or when its matching no-mistakes run reports checks green while monitoring the PR for merge or close.
 A cancelled terminal run does not mask a trailing pause because cancelling validation is a normal part of entering an external wait; failed runs and parked gates still surface immediately.
-Both idle-wait forms are absorbed and re-surfaced only on the longer pause cadence, while their stale and wedge-escalation counters are cleared.
+In normal mode, both idle-wait forms are absorbed and re-surfaced only on the longer pause cadence, while their stale and wedge-escalation counters are cleared.
 The task check script remains the immediate wake path when a monitored PR actually merges or closes.
 For an ordinary crew that has stopped, the normal-mode watcher first surfaces one stale wake, then applies that same cadence to an unchanged `paused:` or durable `captain-held` endpoint only when the backend confidently reports its agent dead.
 Live or inconclusive liveness remains fail-open at that initial surface, and the secondmate idle-endpoint exemption is unchanged.
-A declared pause's initial normal-mode status signal still surfaces through the no-verb path, while away mode self-handles that routine signal and owns the later recheck.
+A declared pause's initial normal-mode status signal still surfaces through the no-verb path.
+In AFK mode, the watcher surfaces every wake without applying merge-wait absorption because the daemon remains the sole triage authority.
+If merge-wait churn appears in AFK mode, the daemon should adopt the same predicate through the shared classifier library as a separate change.
 Fresh stale panes use the same current-state read before trusting the status log, so an active run or busy pane outranks an old captain-relevant status-log line left behind before validation.
 No-change heartbeats are also benign.
 Absorbed wakes advance their suppression markers, log to `state/.watch-triage.log`, and keep the watcher blocking without a queue record or LLM turn.

--- a/tests/fm-backlog-handoff.test.sh
+++ b/tests/fm-backlog-handoff.test.sh
@@ -10,8 +10,11 @@ set -u
 . "$(dirname "${BASH_SOURCE[0]}")/secondmate-helpers.sh"
 
 # The move is delegated to `tasks-axi mv`, so this suite exercises the real
-# binary. Skip cleanly when it is absent (matching the backend smoke suites).
-command -v tasks-axi >/dev/null 2>&1 || { echo "skip: tasks-axi not found (required by the delegated handoff path)"; exit 0; }
+# binary. Skip cleanly when the installed binary lacks the required atomic
+# multi-ID move support (matching the backend smoke suites).
+# shellcheck source=bin/fm-tasks-axi-lib.sh disable=SC1091
+. "$ROOT/bin/fm-tasks-axi-lib.sh"
+fm_tasks_axi_compatible || { echo "skip: compatible tasks-axi not found (atomic multi-ID mv required)"; exit 0; }
 
 TMP_ROOT=$(fm_test_tmproot fm-backlog-handoff)
 

--- a/tests/fm-secondmate-lifecycle-e2e.test.sh
+++ b/tests/fm-secondmate-lifecycle-e2e.test.sh
@@ -151,10 +151,11 @@ phase_send() {
 }
 
 phase_handoff() {
-  # The move is delegated to `tasks-axi mv`; skip cleanly when it is absent (the
-  # downstream recovery and teardown phases do not depend on this phase).
-  if ! command -v tasks-axi >/dev/null 2>&1; then
-    echo "skip: tasks-axi not found (backlog handoff delegates to it)"
+  # The move is delegated to `tasks-axi mv`; skip cleanly when the installed
+  # binary lacks atomic multi-ID support. The downstream phases do not depend
+  # on this phase.
+  if ! ( . "$ROOT/bin/fm-tasks-axi-lib.sh"; fm_tasks_axi_compatible ); then
+    echo "skip: compatible tasks-axi not found (atomic multi-ID mv required)"
     return 0
   fi
   cat > "$HOME_DIR/data/backlog.md" <<'EOF'

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -254,8 +254,8 @@ test_crew_absorb_class_classifier() {
   [ "$(crew_absorb_class a)" = merge-wait ] || fail "checks-green merge monitoring not classed as an idle wait"
   FM_FAKE_CREW_STATE='state: done · source: run-step · checks green: PR ready for review'
   [ "$(crew_absorb_class a)" = none ] || fail "bare checks-passed run classed as a merge wait"
-  FM_FAKE_CREW_STATE='state: done · source: status-log · PR checks green · run still monitoring PR'
-  [ "$(crew_absorb_class a)" = none ] || fail "coarse checks-green detail without the explicit suffix classed as a merge wait"
+  FM_FAKE_CREW_STATE='state: done · source: status-log · checks green: PR ready for review (still monitoring for merge/close)'
+  [ "$(crew_absorb_class a)" = none ] || fail "status-log detail with the monitoring suffix classed as a merge wait"
   printf 'failed: validation failed\n' > "$state/a.status"
   FM_FAKE_CREW_STATE='state: failed · source: run-step · run failed'
   [ "$(crew_absorb_class a)" = none ] || fail "real terminal failure was classed absorbable"
@@ -787,6 +787,9 @@ test_checks_green_merge_wait_absorbs_then_rechecks() {
   printf 'checks green, monitoring merge\n' > "$capture_file"
   printf 'window=%s\nkind=ship\n' "$window" > "$state/merge-wait.meta"
   printf 'done: PR checks green, monitoring for merge/close\n' > "$statusf"
+  back=$(( $(date +%s) - 500 ))
+  if [ "$(uname)" = Darwin ]; then touch -mt "$(date -r "$back" '+%Y%m%d%H%M.%S')" "$statusf"
+  else touch -m -d "@$back" "$statusf"; fi
   sig=$(seen_sig "$statusf"); printf '%s' "$sig" > "$state/.seen-merge-wait_status"
   key=$(printf '%s' "$window" | tr ':/.' '___')
   pane_hash=$(hash_text "checks green, monitoring merge")
@@ -796,7 +799,7 @@ test_checks_green_merge_wait_absorbs_then_rechecks() {
   export FM_FAKE_CREW_STATE='state: done · source: run-step · checks green: PR ready for review (still monitoring for merge/close)'
 
   PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
-    FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_PAUSE_RESURFACE_SECS=999 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_PAUSE_RESURFACE_SECS=240 FM_POLL=1 FM_SIGNAL_GRACE=1 \
     FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
   pid=$!
   if ! wait_live "$pid" 30; then
@@ -807,10 +810,8 @@ test_checks_green_merge_wait_absorbs_then_rechecks() {
   [ ! -e "$state/.wedge-escalations-$key" ] || { reap "$pid"; fail "merge wait retained accumulated wedge escalations"; }
   reap "$pid"
 
-  back=$(( $(date +%s) - 500 ))
-  if [ "$(uname)" = Darwin ]; then touch -mt "$(date -r "$back" '+%Y%m%d%H%M.%S')" "$statusf"
-  else touch -m -d "@$back" "$statusf"; fi
-  sig=$(seen_sig "$statusf"); printf '%s' "$sig" > "$state/.seen-merge-wait_status"
+  if [ "$(uname)" = Darwin ]; then touch -mt "$(date -r "$back" '+%Y%m%d%H%M.%S')" "$state/.paused-$key"
+  else touch -m -d "@$back" "$state/.paused-$key"; fi
   : > "$out"
   PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
     FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_PAUSE_RESURFACE_SECS=240 FM_POLL=1 FM_SIGNAL_GRACE=1 \
@@ -822,6 +823,47 @@ test_checks_green_merge_wait_absorbs_then_rechecks() {
   [ ! -e "$state/.stale-since-$key" ] || fail "merge-wait recheck started a wedge timer"
   unset FM_FAKE_CREW_STATE
   pass "checks-green merge monitoring absorbs stale churn and re-surfaces only on the bounded long cadence"
+}
+
+test_cached_idle_classes_revalidate_authoritative_state() {
+  local class dir state fakebin out capture_file task window key pane_hash sig pid verdict status
+  for class in paused merge-wait; do
+    dir=$(make_case "cached-$class-transition"); state="$dir/state"; fakebin="$dir/fakebin"
+    out="$dir/watch.out"; capture_file="$dir/pane.txt"; task="cached-$class"
+    window="test:fm-$task"
+    printf 'idle state became terminal\n' > "$capture_file"
+    printf 'window=%s\nkind=ship\n' "$window" > "$state/$task.meta"
+    case "$class" in
+      paused)
+        status='paused: awaiting upstream'
+        verdict='state: failed · source: run-step · run failed'
+        ;;
+      merge-wait)
+        status='done: PR checks green, monitoring for merge/close'
+        verdict='state: parked · source: run-step · parked at awaiting_approval'
+        ;;
+    esac
+    printf '%s\n' "$status" > "$state/$task.status"
+    sig=$(seen_sig "$state/$task.status"); printf '%s' "$sig" > "$state/.seen-${task}_status"
+    key=$(printf '%s' "$window" | tr ':/.' '___')
+    pane_hash=$(hash_text "idle state became terminal")
+    printf '%s' "$pane_hash" > "$state/.hash-$key"
+    printf '%s' "$pane_hash" > "$state/.stale-$key"
+    printf '1\n' > "$state/.count-$key"
+    printf '%s\n' "$class" > "$state/.paused-$key"
+    date +%s > "$state/.paused-rechecked-$key"
+    export FM_FAKE_CREW_STATE="$verdict"
+
+    PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
+      FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_STALE_ESCALATE_SECS=999 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+      FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+    pid=$!
+    wait_for_exit "$pid" 40 || fail "cached $class suppressed its authoritative terminal transition"
+    grep -Fx "stale: $window" "$out" >/dev/null || fail "cached $class transition did not surface as stale"
+    [ ! -e "$state/.paused-$key" ] || fail "cached $class marker survived its authoritative terminal transition"
+  done
+  unset FM_FAKE_CREW_STATE
+  pass "cached idle markers revalidate failed and parked authoritative transitions immediately"
 }
 
 test_merge_wait_without_status_uses_idle_marker_cadence() {
@@ -1402,6 +1444,7 @@ test_nonterminal_stale_paused_absorbed_then_resurfaced
 test_exited_declared_pause_is_bounded_but_live_gate_surfaces
 test_paused_terminal_run_absorbs_without_wedge_churn
 test_checks_green_merge_wait_absorbs_then_rechecks
+test_cached_idle_classes_revalidate_authoritative_state
 test_merge_wait_without_status_uses_idle_marker_cadence
 test_real_terminal_failure_still_surfaces
 test_secondmate_paused_resurfaces_in_normal_mode

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -229,9 +229,10 @@ test_status_is_paused_classifier() {
 # (surface it) - so the watcher's stale path gets both for one bounded call.
 # crew_is_paused delegates to it exactly as crew_is_provably_working does.
 test_crew_absorb_class_classifier() {
-  local dir fakebin
-  dir=$(make_case absorb-class); fakebin="$dir/fakebin"
+  local dir state fakebin
+  dir=$(make_case absorb-class); state="$dir/state"; fakebin="$dir/fakebin"
   export FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh"
+  export FM_STATE_OVERRIDE="$state"
   export FM_FAKE_CREW_STATE
   FM_FAKE_CREW_STATE='state: working · source: run-step · validating (running)'
   [ "$(crew_absorb_class a)" = working ] || fail "active run-step not classed working"
@@ -241,14 +242,26 @@ test_crew_absorb_class_classifier() {
   [ "$(crew_absorb_class a)" = paused ] || fail "declared pause not classed paused"
   crew_is_paused a || fail "crew_is_paused did not recognize a paused verdict"
   ! crew_is_provably_working a || fail "a paused crew was treated as provably working"
+  printf 'paused: waiting out upstream capacity\n' > "$state/a.status"
+  FM_FAKE_CREW_STATE='state: failed · source: run-step · run cancelled'
+  [ "$(crew_absorb_class a)" = paused ] || fail "terminal cancelled run masked a trailing pause"
+  printf 'done: PR checks green\n' > "$state/a.status"
+  FM_FAKE_CREW_STATE='state: done · source: run-step · checks green: PR ready for review (still monitoring for merge/close)'
+  [ "$(crew_absorb_class a)" = merge-wait ] || fail "checks-green merge monitoring not classed as an idle wait"
+  FM_FAKE_CREW_STATE='state: done · source: status-log · PR checks green · run still monitoring PR'
+  [ "$(crew_absorb_class a)" = merge-wait ] || fail "coarse checks-green merge monitoring not classed as an idle wait"
+  printf 'failed: validation failed\n' > "$state/a.status"
+  FM_FAKE_CREW_STATE='state: failed · source: run-step · run failed'
+  [ "$(crew_absorb_class a)" = none ] || fail "real terminal failure was classed absorbable"
+  rm -f "$state/a.status"
   FM_FAKE_CREW_STATE='state: working · source: status-log · working: compiling'
   [ "$(crew_absorb_class a)" = none ] || fail "stale working: status-log classed absorbable"
   FM_FAKE_CREW_STATE='state: unknown · source: none · worktree gone'
   [ "$(crew_absorb_class a)" = none ] || fail "unknown crew classed absorbable"
   ! crew_is_paused a || fail "unknown crew classed paused"
   [ "$(crew_absorb_class "")" = none ] || fail "empty id not classed none"
-  unset FM_FAKE_CREW_STATE
-  pass "crew_absorb_class: working/paused/none from one read; crew_is_paused and crew_is_provably_working agree"
+  unset FM_FAKE_CREW_STATE FM_STATE_OVERRIDE
+  pass "crew_absorb_class: active work, terminal pauses, merge waits, and failures preserve the safety boundary"
 }
 
 # signal_crew_provably_working: a no-verb "signal:" wake is benign ONLY when EVERY
@@ -727,6 +740,107 @@ test_exited_declared_pause_is_bounded_but_live_gate_surfaces() {
   [ "$wakes" -eq 1 ] || fail "live external-decision gate should surface once, got $wakes wakes"
   [ "$bare" -eq 1 ] || fail "live external-decision gate lost its immediate bare stale surface"
   pass "exited declared-pause and captain-held panes use bounded pause cadence while a live decision gate still surfaces once"
+}
+
+test_paused_terminal_run_absorbs_without_wedge_churn() {
+  local dir state fakebin out capture_file window key pane_hash sig pid
+  dir=$(make_case paused-terminal-run); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"; capture_file="$dir/pane.txt"; window="test:fm-paused-terminal"
+  printf 'idle after cancelled validation\n' > "$capture_file"
+  printf 'window=%s\nkind=ship\n' "$window" > "$state/paused-terminal.meta"
+  printf 'paused: waiting out upstream capacity\n' > "$state/paused-terminal.status"
+  sig=$(seen_sig "$state/paused-terminal.status"); printf '%s' "$sig" > "$state/.seen-paused-terminal_status"
+  key=$(printf '%s' "$window" | tr ':/.' '___')
+  pane_hash=$(hash_text "idle after cancelled validation")
+  printf '%s' "$pane_hash" > "$state/.hash-$key"
+  printf '1\n' > "$state/.count-$key"
+  printf '83\n' > "$state/.wedge-escalations-$key"
+  export FM_FAKE_CREW_STATE='state: failed · source: run-step · run cancelled'
+
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
+    FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_PAUSE_RESURFACE_SECS=999 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  if ! wait_live "$pid" 30; then
+    reap "$pid"; fail "watcher surfaced a declared pause because its matching run was terminal: $(cat "$out")"
+  fi
+  [ -e "$state/.paused-$key" ] || { reap "$pid"; fail "terminal-run pause did not enter idle tracking"; }
+  [ ! -e "$state/.stale-since-$key" ] || { reap "$pid"; fail "terminal-run pause retained a wedge timer"; }
+  [ ! -e "$state/.wedge-escalations-$key" ] || { reap "$pid"; fail "terminal-run pause retained accumulated wedge escalations"; }
+  [ ! -s "$state/.wake-queue" ] || { reap "$pid"; fail "terminal-run pause enqueued an immediate stale wake"; }
+  reap "$pid"
+  unset FM_FAKE_CREW_STATE
+  pass "a trailing paused verb absorbs a stale pane even when its matching run is terminal"
+}
+
+test_checks_green_merge_wait_absorbs_then_rechecks() {
+  local dir state fakebin out capture_file statusf window key pane_hash sig pid back
+  dir=$(make_case checks-green-merge-wait); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"; capture_file="$dir/pane.txt"; statusf="$state/merge-wait.status"
+  window="test:fm-merge-wait"
+  printf 'checks green, monitoring merge\n' > "$capture_file"
+  printf 'window=%s\nkind=ship\n' "$window" > "$state/merge-wait.meta"
+  printf 'done: PR checks green, monitoring for merge/close\n' > "$statusf"
+  sig=$(seen_sig "$statusf"); printf '%s' "$sig" > "$state/.seen-merge-wait_status"
+  key=$(printf '%s' "$window" | tr ':/.' '___')
+  pane_hash=$(hash_text "checks green, monitoring merge")
+  printf '%s' "$pane_hash" > "$state/.hash-$key"
+  printf '1\n' > "$state/.count-$key"
+  printf '83\n' > "$state/.wedge-escalations-$key"
+  export FM_FAKE_CREW_STATE='state: done · source: run-step · checks green: PR ready for review (still monitoring for merge/close)'
+
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
+    FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_PAUSE_RESURFACE_SECS=999 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  if ! wait_live "$pid" 30; then
+    reap "$pid"; fail "watcher surfaced a fresh checks-green merge wait: $(cat "$out")"
+  fi
+  [ "$(cat "$state/.paused-$key" 2>/dev/null || true)" = merge-wait ] || { reap "$pid"; fail "merge wait did not enter bounded idle tracking"; }
+  [ ! -e "$state/.stale-since-$key" ] || { reap "$pid"; fail "merge wait retained a wedge timer"; }
+  [ ! -e "$state/.wedge-escalations-$key" ] || { reap "$pid"; fail "merge wait retained accumulated wedge escalations"; }
+  reap "$pid"
+
+  back=$(( $(date +%s) - 500 ))
+  if [ "$(uname)" = Darwin ]; then touch -mt "$(date -r "$back" '+%Y%m%d%H%M.%S')" "$statusf"
+  else touch -m -d "@$back" "$statusf"; fi
+  sig=$(seen_sig "$statusf"); printf '%s' "$sig" > "$state/.seen-merge-wait_status"
+  : > "$out"
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
+    FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_PAUSE_RESURFACE_SECS=240 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  wait_for_exit "$pid" 40 || fail "watcher did not recheck a checks-green merge wait on the bounded cadence"
+  grep -F "merge-wait" "$out" >/dev/null || fail "merge-wait recheck omitted its classification"
+  grep -F "possible wedge" "$out" >/dev/null && fail "merge wait was mislabeled a possible wedge"
+  [ ! -e "$state/.stale-since-$key" ] || fail "merge-wait recheck started a wedge timer"
+  unset FM_FAKE_CREW_STATE
+  pass "checks-green merge monitoring absorbs stale churn and re-surfaces only on the bounded long cadence"
+}
+
+test_real_terminal_failure_still_surfaces() {
+  local dir state fakebin out capture_file window key pane_hash sig pid
+  dir=$(make_case real-terminal-failure); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"; capture_file="$dir/pane.txt"; window="test:fm-real-failure"
+  printf 'validation failed\n' > "$capture_file"
+  printf 'window=%s\nkind=ship\n' "$window" > "$state/real-failure.meta"
+  printf 'failed: no-mistakes validation failed\n' > "$state/real-failure.status"
+  sig=$(seen_sig "$state/real-failure.status"); printf '%s' "$sig" > "$state/.seen-real-failure_status"
+  key=$(printf '%s' "$window" | tr ':/.' '___')
+  pane_hash=$(hash_text "validation failed")
+  printf '%s' "$pane_hash" > "$state/.hash-$key"
+  printf '1\n' > "$state/.count-$key"
+  export FM_FAKE_CREW_STATE='state: failed · source: run-step · run failed'
+
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
+    FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  wait_for_exit "$pid" 40 || fail "watcher absorbed a real terminal failure"
+  grep -Fx "stale: $window" "$out" >/dev/null || fail "real terminal failure did not surface as stale"
+  [ ! -e "$state/.paused-$key" ] || fail "real terminal failure entered idle tracking"
+  unset FM_FAKE_CREW_STATE
+  pass "a real terminal failure still surfaces immediately"
 }
 
 test_secondmate_paused_resurfaces_in_normal_mode() {
@@ -1257,6 +1371,9 @@ test_wedge_escalation_resets_when_pane_becomes_active
 test_nonterminal_stale_not_working_surfaced
 test_nonterminal_stale_paused_absorbed_then_resurfaced
 test_exited_declared_pause_is_bounded_but_live_gate_surfaces
+test_paused_terminal_run_absorbs_without_wedge_churn
+test_checks_green_merge_wait_absorbs_then_rechecks
+test_real_terminal_failure_still_surfaces
 test_secondmate_paused_resurfaces_in_normal_mode
 test_secondmate_nonpaused_stale_remains_suppressed
 test_secondmate_unpause_clears_pause_tracking

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -1480,7 +1480,7 @@ test_afk_paused_changed_pane_hands_off_plain_stale() {
   key=$(printf '%s' "$window" | tr '.:/' '___')
 
   # Deliberately do not seed .hash-*: this is the changed-pane path that used to
-  # call handle_paused_stale before AFK's one-shot daemon handoff.
+  # call handle_idle_stale before AFK's one-shot daemon handoff.
   PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
     FM_FAKE_CREW_STATE='state: paused · source: status-log · awaiting the upstream tool release' \
     FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_PAUSE_RESURFACE_SECS=240 FM_POLL=1 FM_SIGNAL_GRACE=1 \

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -64,6 +64,16 @@ wait_numeric_file() {
   return 1
 }
 
+wait_file_value() {
+  local file=$1 expected=$2 limit=${3:-30} i=0
+  while [ "$i" -lt "$limit" ]; do
+    [ "$(cat "$file" 2>/dev/null || true)" = "$expected" ] && return 0
+    sleep 0.1
+    i=$((i + 1))
+  done
+  return 1
+}
+
 # Portable mtime in epoch seconds. Platform-detected, never the `stat -f || stat -c`
 # fallback (which writes a partial filesystem dump on Linux; see fm-watch.sh).
 file_mtime() {
@@ -889,6 +899,71 @@ test_merge_wait_without_status_uses_idle_marker_cadence() {
   pass "a status-less merge wait anchors its bounded recheck to the idle marker's first sighting"
 }
 
+test_working_stale_reclassifies_merge_wait_when_wedge_due() {
+  local dir state fakebin out capture_file window key pane_hash sig pid back
+  dir=$(make_case working-to-merge-wait); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"; capture_file="$dir/pane.txt"; window="test:fm-working-to-merge-wait"
+  printf 'validation pane remains idle\n' > "$capture_file"
+  printf 'window=%s\nkind=ship\n' "$window" > "$state/working-to-merge-wait.meta"
+  printf 'working: validating pull request\n' > "$state/working-to-merge-wait.status"
+  sig=$(seen_sig "$state/working-to-merge-wait.status"); printf '%s' "$sig" > "$state/.seen-working-to-merge-wait_status"
+  key=$(printf '%s' "$window" | tr ':/.' '___')
+  pane_hash=$(hash_text "validation pane remains idle")
+  printf '%s' "$pane_hash" > "$state/.hash-$key"
+  printf '%s' "$pane_hash" > "$state/.stale-$key"
+  printf '1\n' > "$state/.count-$key"
+  back=$(( $(date +%s) - 500 ))
+  : > "$state/.stale-since-$key"
+  if [ "$(uname)" = Darwin ]; then touch -mt "$(date -r "$back" '+%Y%m%d%H%M.%S')" "$state/.stale-since-$key"
+  else touch -m -d "@$back" "$state/.stale-since-$key"; fi
+  export FM_FAKE_CREW_STATE='state: done · source: run-step · checks green: PR ready for review (still monitoring for merge/close)'
+
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
+    FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_STALE_ESCALATE_SECS=240 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  wait_file_value "$state/.paused-$key" merge-wait 30 || { reap "$pid"; fail "due working stale did not reclassify as merge-wait"; }
+  if ! wait_live "$pid" 10; then
+    reap "$pid"; fail "due working stale surfaced a wedge instead of entering merge-wait: $(cat "$out")"
+  fi
+  [ "$(cat "$state/.paused-$key" 2>/dev/null || true)" = merge-wait ] || { reap "$pid"; fail "due working stale recorded the wrong idle class"; }
+  [ ! -e "$state/.stale-since-$key" ] || { reap "$pid"; fail "merge-wait transition retained its wedge timer"; }
+  [ ! -s "$state/.wake-queue" ] || { reap "$pid"; fail "merge-wait transition enqueued a wedge wake"; }
+  reap "$pid"
+  unset FM_FAKE_CREW_STATE
+  pass "a due working stale revalidates and transitions to merge-wait without wedge churn"
+}
+
+test_merge_wait_hash_churn_preserves_first_sighting() {
+  local dir state fakebin out capture_file window key old_hash back sig pid
+  dir=$(make_case merge-wait-hash-churn); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"; capture_file="$dir/pane.txt"; window="test:fm-merge-wait-hash-churn"
+  printf 'merge monitor pane changed\n' > "$capture_file"
+  printf 'window=%s\nkind=ship\n' "$window" > "$state/merge-wait-hash-churn.meta"
+  printf 'done: PR checks green, monitoring for merge/close\n' > "$state/merge-wait-hash-churn.status"
+  sig=$(seen_sig "$state/merge-wait-hash-churn.status"); printf '%s' "$sig" > "$state/.seen-merge-wait-hash-churn_status"
+  key=$(printf '%s' "$window" | tr ':/.' '___')
+  old_hash=$(hash_text "older merge monitor pane")
+  printf '%s' "$old_hash" > "$state/.hash-$key"
+  printf '4\n' > "$state/.count-$key"
+  printf 'merge-wait\n' > "$state/.paused-$key"
+  back=$(( $(date +%s) - 500 ))
+  if [ "$(uname)" = Darwin ]; then touch -mt "$(date -r "$back" '+%Y%m%d%H%M.%S')" "$state/.paused-$key"
+  else touch -m -d "@$back" "$state/.paused-$key"; fi
+  export FM_FAKE_CREW_STATE='state: done · source: run-step · checks green: PR ready for review (still monitoring for merge/close)'
+
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
+    FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_PAUSE_RESURFACE_SECS=240 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  wait_for_exit "$pid" 40 || fail "hash-churned merge wait lost its bounded first-sighting recheck"
+  grep -F "merge-wait" "$out" >/dev/null || fail "hash-churned merge wait did not preserve its classification"
+  grep -F "possible wedge" "$out" >/dev/null && fail "hash-churned merge wait was mislabeled a wedge"
+  [ -e "$state/.paused-resurfaced-$key" ] || fail "hash-churned merge wait did not retain its first-sighting cadence"
+  unset FM_FAKE_CREW_STATE
+  pass "merge-wait hash churn preserves the durable first-sighting cadence"
+}
+
 test_real_terminal_failure_still_surfaces() {
   local dir state fakebin out capture_file window key pane_hash sig pid
   dir=$(make_case real-terminal-failure); state="$dir/state"; fakebin="$dir/fakebin"
@@ -1446,6 +1521,8 @@ test_paused_terminal_run_absorbs_without_wedge_churn
 test_checks_green_merge_wait_absorbs_then_rechecks
 test_cached_idle_classes_revalidate_authoritative_state
 test_merge_wait_without_status_uses_idle_marker_cadence
+test_working_stale_reclassifies_merge_wait_when_wedge_due
+test_merge_wait_hash_churn_preserves_first_sighting
 test_real_terminal_failure_still_surfaces
 test_secondmate_paused_resurfaces_in_normal_mode
 test_secondmate_nonpaused_stale_remains_suppressed

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -245,11 +245,17 @@ test_crew_absorb_class_classifier() {
   printf 'paused: waiting out upstream capacity\n' > "$state/a.status"
   FM_FAKE_CREW_STATE='state: failed · source: run-step · run cancelled'
   [ "$(crew_absorb_class a)" = paused ] || fail "terminal cancelled run masked a trailing pause"
+  FM_FAKE_CREW_STATE='state: failed · source: run-step · run failed'
+  [ "$(crew_absorb_class a)" = none ] || fail "trailing pause masked a failed terminal run"
+  FM_FAKE_CREW_STATE='state: parked · source: run-step · parked at fix_review: 1 finding(s)'
+  [ "$(crew_absorb_class a)" = none ] || fail "trailing pause masked a parked review gate"
   printf 'done: PR checks green\n' > "$state/a.status"
   FM_FAKE_CREW_STATE='state: done · source: run-step · checks green: PR ready for review (still monitoring for merge/close)'
   [ "$(crew_absorb_class a)" = merge-wait ] || fail "checks-green merge monitoring not classed as an idle wait"
+  FM_FAKE_CREW_STATE='state: done · source: run-step · checks green: PR ready for review'
+  [ "$(crew_absorb_class a)" = none ] || fail "bare checks-passed run classed as a merge wait"
   FM_FAKE_CREW_STATE='state: done · source: status-log · PR checks green · run still monitoring PR'
-  [ "$(crew_absorb_class a)" = merge-wait ] || fail "coarse checks-green merge monitoring not classed as an idle wait"
+  [ "$(crew_absorb_class a)" = none ] || fail "coarse checks-green detail without the explicit suffix classed as a merge wait"
   printf 'failed: validation failed\n' > "$state/a.status"
   FM_FAKE_CREW_STATE='state: failed · source: run-step · run failed'
   [ "$(crew_absorb_class a)" = none ] || fail "real terminal failure was classed absorbable"
@@ -818,13 +824,36 @@ test_checks_green_merge_wait_absorbs_then_rechecks() {
   pass "checks-green merge monitoring absorbs stale churn and re-surfaces only on the bounded long cadence"
 }
 
+test_merge_wait_without_status_uses_idle_marker_cadence() {
+  local dir state fakebin out capture_file window key pane_hash pid
+  dir=$(make_case merge-wait-no-status); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"; capture_file="$dir/pane.txt"; window="test:fm-merge-wait-no-status"
+  printf 'checks green, monitoring merge\n' > "$capture_file"
+  printf 'window=%s\nkind=ship\n' "$window" > "$state/merge-wait-no-status.meta"
+  key=$(printf '%s' "$window" | tr ':/.' '___')
+  pane_hash=$(hash_text "checks green, monitoring merge")
+  printf '%s' "$pane_hash" > "$state/.hash-$key"
+  printf '1\n' > "$state/.count-$key"
+  export FM_FAKE_CREW_STATE='state: done · source: run-step · checks green: PR ready for review (still monitoring for merge/close)'
+
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
+    FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_PAUSE_RESURFACE_SECS=2 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  wait_for_exit "$pid" 60 || fail "status-less merge wait never reached its bounded recheck"
+  grep -F "merge-wait" "$out" >/dev/null || fail "status-less merge-wait recheck omitted its classification"
+  [ -e "$state/.paused-resurfaced-$key" ] || fail "status-less merge wait did not record its bounded recheck"
+  unset FM_FAKE_CREW_STATE
+  pass "a status-less merge wait anchors its bounded recheck to the idle marker's first sighting"
+}
+
 test_real_terminal_failure_still_surfaces() {
   local dir state fakebin out capture_file window key pane_hash sig pid
   dir=$(make_case real-terminal-failure); state="$dir/state"; fakebin="$dir/fakebin"
   out="$dir/watch.out"; capture_file="$dir/pane.txt"; window="test:fm-real-failure"
   printf 'validation failed\n' > "$capture_file"
   printf 'window=%s\nkind=ship\n' "$window" > "$state/real-failure.meta"
-  printf 'failed: no-mistakes validation failed\n' > "$state/real-failure.status"
+  printf 'paused: waiting out upstream capacity\n' > "$state/real-failure.status"
   sig=$(seen_sig "$state/real-failure.status"); printf '%s' "$sig" > "$state/.seen-real-failure_status"
   key=$(printf '%s' "$window" | tr ':/.' '___')
   pane_hash=$(hash_text "validation failed")
@@ -840,7 +869,7 @@ test_real_terminal_failure_still_surfaces() {
   grep -Fx "stale: $window" "$out" >/dev/null || fail "real terminal failure did not surface as stale"
   [ ! -e "$state/.paused-$key" ] || fail "real terminal failure entered idle tracking"
   unset FM_FAKE_CREW_STATE
-  pass "a real terminal failure still surfaces immediately"
+  pass "a real terminal failure still surfaces immediately despite a trailing paused verb"
 }
 
 test_secondmate_paused_resurfaces_in_normal_mode() {
@@ -1373,6 +1402,7 @@ test_nonterminal_stale_paused_absorbed_then_resurfaced
 test_exited_declared_pause_is_bounded_but_live_gate_surfaces
 test_paused_terminal_run_absorbs_without_wedge_churn
 test_checks_green_merge_wait_absorbs_then_rechecks
+test_merge_wait_without_status_uses_idle_marker_cadence
 test_real_terminal_failure_still_surfaces
 test_secondmate_paused_resurfaces_in_normal_mode
 test_secondmate_nonpaused_stale_remains_suppressed


### PR DESCRIPTION
## Intent

Fix the watcher's idle-crew stale-churn gap. A trailing paused: status must absorb stale wakes on the existing bounded long recheck cadence even when the latest matching no-mistakes run is terminal, because a cancelled run is normal for an external wait. A done/checks-passed run that is still monitoring a checks-green PR for merge or close must use the same bounded idle cadence, leaving state/<id>.check.sh as the actual merge wake path. Entering either legitimate idle state must clear or suppress wedge-escalation accumulation. Preserve the safety boundary: silent mid-work stops and real terminal failures must still surface. Extend colocated watcher/classifier regression tests, keep touched scripts shellcheck-clean, and update only the authoritative Event-driven supervision contract in docs/architecture.md.

## What Changed

- Classify cancelled-run pauses and checks-green PR monitoring as legitimate idle waits, absorbing stale-pane churn on the bounded recheck cadence while clearing wedge state.
- Preserve captain-visible safety signals by revalidating cached idle states so failed runs, parked gates, and silent stops surface immediately, while merge-wait cadence survives missing status files and pane-hash churn.
- Expand regression coverage and supervision documentation, make prompt-glyph parsing locale-safe, and refresh affected compatibility fixtures.

## Risk Assessment

✅ Low: Captain, the change is bounded to watcher idle-state classification and cadence, fails closed on failed and parked runs, and its state transitions and regression coverage are internally consistent.

## Testing

The successful full-suite baseline was supplemented with focused watcher and wake-queue tests plus a production-watcher CLI fixture: legitimate idle states stayed quiet until bounded recheck, merge checks remained actionable, wedge state cleared, and unsafe stops surfaced; reviewer-visible CLI evidence was captured and the worktree stayed clean.

<details>
<summary>Evidence: End-to-end watcher behavior transcript</summary>

```text
Firstmate watcher end-to-end evidence
Production entrypoint: bin/fm-watch.sh
Hermetic user-facing surfaces: tmux pane + fm-crew-state verdict + state/*.status/check.sh

SCENARIO 1 — paused trailing status + cancelled terminal run
status: paused: waiting out upstream capacity
watcher current-state verdict: state: failed · source: run-step · run cancelled
watcher wake output during fresh idle window: <none; stale wake absorbed>
idle class marker: paused
wedge escalation marker: <absent; prior count cleared>
queued wake: <none>

SCENARIO 2 — checks-passed/done PR monitor
status: done: PR checks green, monitoring for merge/close
watcher current-state verdict: state: done · source: run-step · checks green: PR ready for review (still monitoring for merge/close)
idle class marker: merge-wait
bounded long-cadence watcher output: stale: test:fm-merge-wait (merge-wait 505s, checks green - still monitoring for merge/close, rechecked on a long cadence not a wedge; confirm the wait still holds)
wedge escalation marker: <absent; prior count cleared>

SCENARIO 3 — actual merge remains state/<id>.check.sh wake path
check script output surfaced by watcher: check: /var/folders/7t/7s3dd555217fnnjq46z87qvc0000gn/T//fm-wake-tests.mJDqNM/check/state/task.check.sh: merged: https://example.test/pr/1
durable drained queue record: 1783794489	1	check	/var/folders/7t/7s3dd555217fnnjq46z87qvc0000gn/T//fm-wake-tests.mJDqNM/check/state/task.check.sh	check: /var/folders/7t/7s3dd555217fnnjq46z87qvc0000gn/T//fm-wake-tests.mJDqNM/check/state/task.check.sh: merged: https://example.test/pr/1

SCENARIO 4 — safety boundary: silent mid-work stop
status: working: implementing
watcher current-state verdict: state: unknown · source: none · no current-state source available
watcher output: stale: test:fm-stopped

SCENARIO 5 — safety boundary: real terminal failure despite trailing paused verb
status: paused: waiting out upstream capacity
watcher current-state verdict: state: failed · source: run-step · run failed
watcher output: stale: test:fm-real-failure
idle class marker: <absent; failure not absorbed>

SCENARIO 1B — cancelled terminal run reaches bounded paused recheck
watcher output: stale: test:fm-paused-terminal (paused 501s, awaiting external - declared pause, rechecked on a long cadence not a wedge; confirm the wait still holds)
wedge escalation marker: <absent>
bounded recheck marker: <present>
```
</details>
<details>
<summary>Evidence: Cancelled terminal pause bounded recheck</summary>

```text
stale: test:fm-paused-terminal (paused 501s, awaiting external - declared pause, rechecked on a long cadence not a wedge; confirm the wait still holds)
```
</details>
<details>
<summary>Evidence: Focused watcher regression suite</summary>

```text
ok - signal_reason_is_actionable: benign absorbed, captain verbs and coalesced batches surfaced
ok - stale_is_terminal: terminal status surfaces, non-terminal and no-status are benign
ok - scan_captain_relevant_statuses lists only captain-relevant statuses
ok - classifier primitives: last line, captain-relevance, window->task, FM_CAPTAIN_RE override
ok - crew_is_provably_working: only working+run-step/pane is provable; idle/finished/parked/failed/unknown surface
ok - status_is_paused: only the leading paused verb matches, and paused is not captain-relevant
ok - crew_absorb_class: active work, terminal pauses, merge waits, and failures preserve the safety boundary
ok - signal_crew_provably_working: benign only when every referenced crew is provably working
ok - a no-verb signal whose crew is provably working is absorbed (no exit, no queue, suppressor advanced, beacon present)
ok - a bare turn-end whose crew is provably working (busy pane) is absorbed
ok - a bare turn-end whose crew is not provably working is surfaced (the swallowed-finish fix)
ok - a no-verb working: note whose crew is idle with no running pipeline is surfaced
ok - captain-relevant signal is surfaced (queue + exit) and marked surfaced
ok - a stale pane sitting on a terminal status is surfaced (queue + exit)
ok - a stale terminal-looking status is overridden and absorbed while a run is actively working, then wedge-escalated
ok - provably-working non-terminal stale is absorbed on first sight, then wedge-escalated past the threshold
ok - consecutive wedge escalations on the same pane accumulate and demand deep inspection at the threshold
ok - a pane becoming active again resets the consecutive wedge-escalation counter
ok - a not-provably-working non-terminal stale is surfaced immediately (never left to wait out the timer)
ok - a declared pause is absorbed on first sight, then re-surfaced as a recheck past the threshold, never wedge-escalated
ok - a trailing paused verb absorbs a stale pane even when its matching run is terminal
ok - checks-green merge monitoring absorbs stale churn and re-surfaces only on the bounded long cadence
ok - cached idle markers revalidate failed and parked authoritative transitions immediately
ok - a status-less merge wait anchors its bounded recheck to the idle marker's first sighting
ok - a due working stale revalidates and transitions to merge-wait without wedge churn
ok - merge-wait hash churn preserves the durable first-sighting cadence
ok - a real terminal failure still surfaces immediately despite a trailing paused verb
ok - a declared paused secondmate re-surfaces on the bounded normal-mode cadence
ok - a non-paused secondmate retains normal stale suppression
ok - a resumed secondmate clears pause and stale tracking before stale exemption
ok - unchanged stale hashes reclassify when a crew enters or leaves pause
ok - a declared pause is periodically rechecked against authoritative active-run state
ok - a paused status overridden by authoritative working preserves its wedge timer and escalates
ok - matching non-terminal stale suppressors repair missing or corrupt stale-since timers
ok - triage log capping handles wc byte counts with leading spaces
ok - a heartbeat with no captain-relevant change is absorbed and backs off the cadence
ok - heartbeat backstop fail-safe surfaces a captain-relevant status the per-wake path missed
ok - the liveness beacon stays fresh while the watcher absorbs benign wakes (fm-guard never false-alarms)
ok - with .afk present the watcher reverts to one-shot so the daemon owns triage (no double-triage)
ok - AFK changed paused panes hand off plain stale identities for daemon-owned pause triage
```
</details>
- Outcome: 🔧 1 issue found → auto-fixed (3) ✅ across 4 runs (1h14m10s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 4 issues found → auto-fixed (3) ✅</summary>

- 🚨 `bin/fm-classify-lib.sh:159` - The trailing `paused:` check overrides every non-working run state, not just cancellation. If a crew pauses, resumes validation, and the run later fails or parks at `awaiting_approval`/`fix_review` without appending another status, the old pause absorbs the stale pane for up to the 1-hour recheck window. Restrict this override to cancelled terminal runs so real failures and parked gates surface immediately.
- ⚠️ `bin/fm-classify-lib.sh:165` - This broad pattern also matches the terminal `checks-passed` detail without the `(still monitoring for merge/close)` suffix. A crew that silently stops after checks pass can therefore enter `merge-wait` even when no PR check script is armed. Require the monitoring suffix or explicitly accept the delayed discovery.
- ⚠️ `bin/fm-watch.sh:320` - When a metadata-derived `merge-wait` has no status file, the fallback resets `mtime` to the current time on every poll, so `age` never reaches the supposedly bounded recheck threshold. Anchor the cadence to the idle marker&#39;s first-seen mtime when the status file is absent.
- ℹ️ `bin/fm-watch.sh:365` - `pause_state_class` still reads the last status line into `last`, but the refactor removed every use of it. Remove the variable and filesystem read.

🔧 Fix: Captain: tighten watcher idle-state classification and cadence
3 issues (1 error, 2 warnings) still open:
- 🚨 `bin/fm-watch.sh:373` - The cached idle-marker fast path returns `paused` or `merge-wait` for up to `FM_STALE_ESCALATE_SECS` without re-reading `fm-crew-state.sh`. Run state can independently transition to `failed` or `parked` while the idle pane and status log remain unchanged, causing the watcher to suppress a real failure for up to 240 seconds. Revalidate the authoritative run state before reusing an idle classification.
- ⚠️ `bin/fm-watch.sh:323` - A merge wait uses the status-file mtime even though the latest status can predate validation and CI becoming green. A newly detected merge wait may therefore immediately exceed the one-hour threshold. Anchor `merge-wait` to the idle marker&#39;s first-sighting mtime; reserve status mtime for declared `paused:` waits.
- ⚠️ `bin/fm-classify-lib.sh:167` - The explicit monitoring-suffix matcher does not also require `source: run-step`. A `done:` status-log note containing that suffix can therefore become `merge-wait` without an authoritative matching run, suppressing a stopped crew. Require both the suffix and `src=run-step`.

🔧 Fix: Captain: fail closed on stale idle-state transitions
3 warnings still open:
- ⚠️ `bin/fm-watch.sh:724` - A stale hash initially classified `working` is not revalidated on this repeat path. If its run becomes checks-green merge monitoring without a pane or status change, the watcher emits a possible-wedge wake instead of entering `merge-wait`. Revalidate when the wedge timer becomes due.
- ⚠️ `bin/fm-watch.sh:747` - Any pane-hash change clears the merge-wait marker whose mtime anchors the bounded recheck. A periodically changing idle pane can therefore reset the one-hour clock indefinitely. Preserve a durable first-sighting anchor across hash churn while revalidating authoritative state.
- ⚠️ `bin/fm-classify-lib.sh:167` - The new `merge-wait` class is consumed only by normal-mode supervision. Switching to AFK clears a migrated merge marker because its status is not `paused:`, and the daemon does not apply the promised long cadence. Confirm normal-mode-only scope and narrow the documentation, or extend AFK classification and migration.

🔧 Fix: Captain, preserve merge-wait cadence across stale transitions
✅ Re-checked - no issues remain.

</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed (3) ✅</summary>

- 🚨 tests failed with exit code 1
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`

🔧 Fix: Captain, repair stale test fixtures and compatibility skips
1 error still open:
- 🚨 tests failed with exit code 1
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`

🔧 Fix: Captain, make composer glyph parsing locale-safe
1 error still open:
- 🚨 tests failed with exit code 1
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`

🔧 Fix: Captain, stabilize bootstrap timeout test scheduling
✅ Re-checked - no issues remain.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- <code>Baseline (previously successful): `command -v tmux &gt;/dev/null || { echo &#34;tmux is required for e2e tests&#34; &gt;&amp;2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo &#34;== $t ==&#34;; bash &#34;$t&#34; || rc=1; done; exit &#34;$rc&#34;`</code>
- `bash tests/fm-watch-triage.test.sh`
- `bash tests/fm-wake-queue.test.sh`
- <code>Manual production `bin/fm-watch.sh` fixture covering cancelled terminal pause absorption and bounded recheck, checks-green merge-wait cadence, `state/&lt;id&gt;.check.sh` merge wake, wedge-counter clearing, silent mid-work stop, and real terminal failure</code>
- <code>`git status --short` and `git rev-parse HEAD`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
