### PR TITLE
docs: position firstmate as an agent distro

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,12 @@ But the moment you want three project tasks done in parallel - fixes, investigat
 firstmate flips the model.
 You talk to a single agent - the first mate - and it runs the crew for you: spawning autonomous agents in a visible session backend, giving each a clean git worktree, supervising them to completion, and handing you finished PRs, approved local merges, or standalone investigation reports.
 For larger fleets, you can opt in to persistent secondmates: domain supervisors that are still ordinary direct reports, but run from their own isolated firstmate homes.
-There is no app to install; the orchestrator is `AGENTS.md`, bundled firstmate skills, and helper scripts that any terminal coding agent can follow.
 
-This is not an agent harness. This is not a single skill. This is not a CLI.
-This is.. a directory that turns any agent into your firstmate, and you the captain.
+firstmate is not a model, not a harness, not a skill, not an MCP server, and not a CLI.
+firstmate is an agent distro for running a crew of agents.
+An agent distro is a portable directory of instructions, skills, tooling, policies, and state conventions that turns a general-purpose agent into a specialized one.
+There is no app to install: the cloned repo is the distro - `AGENTS.md`, bundled firstmate skills, and helper scripts that any terminal coding agent can follow.
+Launching a supported harness inside it instantiates your first mate - and makes you the captain.
 
 ## Features
 
@@ -192,7 +194,7 @@ Firstmate's skills live in two separate places with different audiences:
 - [docs/turnend-guard.md](docs/turnend-guard.md) - the primary session's structural "no turn ends blind" backstop: verified per-harness hook mechanisms, scoping, loop safety, and fail-open tradeoffs.
 - [docs/supervision-protocols/](docs/supervision-protocols/) - rendered primary-harness watcher protocols for Claude, Codex, OpenCode, Pi, Grok, and unknown harness fallback.
 - [docs/scripts.md](docs/scripts.md) - the `bin/` toolbelt reference.
-- [`AGENTS.md`](AGENTS.md) - firstmate's full operating manual for the orchestrator agent.
+- [`AGENTS.md`](AGENTS.md) - the distro's core instruction file and the first mate's full operating manual.
 - [CONTRIBUTING.md](CONTRIBUTING.md) - how to contribute, including the dev/test commands.
 
 ## Contributing


### PR DESCRIPTION
## Intent

Reposition firstmate's README under the captain's settled category: firstmate is an AGENT DISTRO. This is a copy-only, README-only change implementing an approved scout proposal (data/readme-agent-distro-positioning-r6/report.md) with two exact captain revisions. Change 1: in the 'What it is' section, keep the two opening problem/solution paragraphs byte-identical, and replace the old closing lines (the 'There is no app to install; the orchestrator is...' sentence and the 'This is not an agent harness...' / 'This is.. a directory...' lines) with a five-line positioning block placed immediately after the expanded five-negatives sentence: not a model, not a harness, not a skill, not an MCP server, not a CLI; then 'firstmate is an agent distro for running a crew of agents.' (the captain explicitly revised the proposal's 'software crew' to 'a crew of agents'); then the one authoritative definition of agent distro; then the no-app-to-install/the-cloned-repo-is-the-distro sentence; then the harness-instantiation punchline. Change 2: the Documentation-list AGENTS.md bullet drops 'orchestrator agent' in favor of 'the distro's core instruction file and the first mate's full operating manual'. Deliberate constraints: headline 'Talk to one agent. Ship with a crew.' untouched; all 19 unique facts from the old section preserved (reframing, not a content cut); exactly one full definition of 'agent distro'; both README 'orchestrator' mentions removed; NO other file touched - the 4 out-of-README 'orchestrator' ripples (CONTRIBUTING.md, docs/architecture.md, docs/configuration.md, AGENTS.md section 1) are deliberately deferred to a separate follow-up task, so their absence from this diff is intentional. Repo style followed: one sentence per physical line, plain dashes. Branch was rebased onto origin/main after the Herdr PR #472 landed, per sequencing.

## What Changed

- Captain, this branch repositions firstmate as an agent distro and defines the term through its portable instructions, skills, tooling, policies, and state conventions.
- Clarifies that the cloned repository is the distro, supported harnesses instantiate the first mate, and `AGENTS.md` is the distro’s core instruction file and operating manual.

## Risk Assessment

✅ Low: Captain, this is a well-bounded README-only positioning change with no material correctness, compatibility, security, or maintainability risks identified.

## Testing

Captain, the already-green full shell-test baseline was supplemented with exact copy and scope assertions, semantic preservation review, GFM rendering, and visual screenshot inspection; all checks passed and the worktree remained clean.

- Evidence: Rendered README agent-distro section (local file: <code>/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KX9BEABQM6BC0PJ3CSNFY0HT/readme-agent-distro-rendered.png</code>)
<details>
<summary>Evidence: GFM-rendered README</summary>

```text
<!doctype html><html><head><meta charset="utf-8"><title>firstmate README validation</title><style>body{margin:0;background:#f6f8fa;color:#1f2328;font:16px -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}.markdown-body{box-sizing:border-box;min-width:200px;max-width:980px;margin:32px auto;padding:45px;background:white;border:1px solid #d0d7de;border-radius:6px}.markdown-body h1,.markdown-body h2{border-bottom:1px solid #d8dee4;padding-bottom:.3em}.markdown-body h1{font-size:2em}.markdown-body h2{font-size:1.5em;margin-top:24px}.markdown-body h3{font-size:1.25em}.markdown-body p{line-height:1.5}.markdown-body code{background:#eff1f3;border-radius:4px;padding:.2em .4em}.markdown-body img{max-width:100%}.markdown-body a{color:#0969da}</style></head><body><article class="markdown-body">
<h1 align="center" dir="auto">firstmate</h1>
<p align="center" dir="auto">
  <a href="https://img.shields.io/badge/platform-macOS%20%7C%20Linux-blue?style=flat-square" rel="nofollow"><img alt="Platform" src="https://camo.githubusercontent.com/327833a4b2517f62308828d78f2103971d56414626d5adb1391396278e63eeb6/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f706c6174666f726d2d6d61634f532532302537432532304c696e75782d626c75653f7374796c653d666c61742d737175617265" data-canonical-src="https://img.shields.io/badge/platform-macOS%20%7C%20Linux-blue?style=flat-square" style="max-width: 100%;"></a>
  <a href="https://x.com/kunchenguid" rel="nofollow"><img alt="X" src="https://camo.githubusercontent.com/758198a034b7ac6257103933f6320aab2366ec20e24f6c1dfea5a105eeefd1ce/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f582d406b756e6368656e677569642d626c61636b3f7374796c653d666c61742d737175617265" data-canonical-src="https://img.shields.io/badge/X-@kunchenguid-black?style=flat-square" style="max-width: 100%;"></a>
  <a href="https://discord.gg/Wsy2NpnZDu" rel="nofollow"><img alt="Discord" src="https://camo.githubusercontent.com/3eb64fccfb56bff0f7bcb6f4f7c563d48298802e5ebaab7604de88ba219a3338/68747470733a2f2f696d672e736869656c64732e696f2f646973636f72642f313433393930313833313033383736333039323f7374796c653d666c61742d737175617265266c6162656c3d646973636f7264" data-canonical-src="https://img.shields.io/discord/1439901831038763092?style=flat-square&amp;label=discord" style="max-width: 100%;"></a>
</p>
<h3 align="center" dir="auto">Talk to one agent. Ship with a crew.</h3>
<p align="center" dir="auto">
  <a target="_blank" rel="noopener noreferrer" href="assets/banner.png"><img alt="firstmate - talk to one agent, ship with a crew" src="assets/banner.png" width="100%" style="max-width: 100%;"></a>
</p>
<h2 dir="auto">What it is</h2>
<p dir="auto">You can run one coding agent easily.<br>
But the moment you want three project tasks done in parallel - fixes, investigations, plans, audits - you become a tab-juggler: babysitting sessions, copy-pasting context between repos, forgetting which terminal had the failing test.</p>
<p dir="auto">firstmate flips the model.<br>
You talk to a single agent - the first mate - and it runs the crew for you: spawning autonomous agents in a visible session backend, giving each a clean git worktree, supervising them to completion, and handing you finished PRs, approved local merges, or standalone investigation reports.<br>
For larger fleets, you can opt in to persistent secondmates: domain supervisors that are still ordinary direct reports, but run from their own isolated firstmate homes.</p>
<p dir="auto">firstmate is not a model, not a harness, not a skill, not an MCP server, and not a CLI.<br>
firstmate is an agent distro for running a crew of agents.<br>
An agent distro is a portable directory of instructions, skills, tooling, policies, and state conventions that turns a general-purpose agent into a specialized one.<br>
There is no app to install: the cloned repo is the distro - <code class="notranslate">AGENTS.md</code>, bundled firstmate skills, and helper scripts that any terminal coding agent can follow.<br>
Launching a supported harness inside it instantiates your first mate - and makes you the captain.</p>
<h2 dir="auto">Features</h2>
<ul dir="auto">
<li><strong>One liaison</strong> - you talk only to the first mate; it dispatches, supervises, escalates only real decisions, and reports plain outcomes.</li>
<li><strong>A visible crew</strong> - every crewmate works in its own tmux window, experimental herdr/zellij tab, cmux workspace, or Orca terminal you can watch or type into; the first mate reconciles.</li>
<li><strong>Disposable worktrees</strong> - each task runs in a clean <a href="https://github.com/kunchenguid/treehouse">treehouse</a> git worktree, or an Orca-managed worktree when <code class="notranslate">backend=orca</code>, so parallel work on one repo never collides.</li>
<li><strong>Two task shapes</strong> - ship tasks deliver a change; scout tasks investigate, plan, reproduce, or audit and leave a report.</li>
<li><strong>Explicit project modes</strong> - each project ships via <code class="notranslate">no-mistakes</code>, <code class="notranslate">direct-PR</code>, or <code class="notranslate">local-only</code>, with an optional <code class="notranslate">+yolo</code> autonomy flag.</li>
<li><strong>Optional secondmates</strong> - opt in to persistent domain supervisors that run from isolated firstmate homes with their own <code class="notranslate">FM_HOME</code>, state, projects, and session lock, supervising project clones or a project-less firstmate-repo domain, kept on the primary firstmate version by guarded local fast-forwards and checked for live agent processes at session start.</li>
<li><strong>Event-driven, zero-token supervision</strong> - a bash watcher sleeps on the fleet and wakes the first mate only when something needs you; verified primary harnesses also get a turn-end backstop that blocks or follows up on a blind stop when work is in flight and supervision is not live.</li>
<li><strong>Optional X mode</strong> - opt in with one local <code class="notranslate">.env</code> token so firstmate can answer your public <code class="notranslate">@myfirstmate</code> mentions, act on normal reversible mention requests through the same lifecycle as chat requests, acknowledge spawned work, and post up to three public-safe completion follow-ups within seven days for genuine milestones and the final outcome without changing non-X behavior; dry-run preview records would-be replies and dismissals locally before go-live.</li>
<li><strong>Guarded by construction</strong> - the first mate is read-only over your projects outside guarded clone refreshes, safe branch pruning, and approved <code class="notranslate">local-only</code> fast-forward merges; crewmates make every project change behind your merge approval.</li>
<li><strong>Restart-proof</strong> - all state lives on disk and in the active session backend (tmux by hard default, herdr or cmux when selected or auto-detected, zellij/orca when explicitly selected); kill the session anytime and the next one reconciles, including confirmed-dead secondmate agents, and carries on.</li>
</ul>
<p dir="auto">Full detail on every feature lives in <a href="docs/architecture.md">docs/architecture.md</a>.</p>
<h2 dir="auto">Quick Start</h2>
<h3 dir="auto">Requirements</h3>
<ul dir="auto">
<li>A verified agent harness: Claude Code, Grok, Pi, Codex, or OpenCode.</li>
<li>Git and the GitHub CLI, authenticated through <code class="notranslate">gh auth login</code>.</li>
<li>tmux, for the reference session backend.</li>
</ul>
<p dir="auto">The first mate detects and offers to install everything else.</p>
<h3 dir="auto">Recommended harnesses</h3>
<p dir="auto"><strong>Claude Code, Grok, and Pi are equal co-primary recommendations</strong> for running the primary firstmate session.<br>
Claude Code and Grok use background-notify wake cycles; Pi uses its tracked primary watcher extension.<br>
All three have verified turn-end guard paths when launched with their documented setup.<br>
Pick whichever one matches your subscription and workflow.</p>
<p dir="auto">Codex and OpenCode are also verified and supported as primary harnesses; Codex uses bounded foreground checkpoints, and Open

... [2520 bytes truncated] ...

           you (the captain)
                  │  chat: requests, decisions, "merge it"
                  ▼
 ┌─────────────────────────────────────┐
 │ firstmate            (this repo)    │
 │ reads projects/ + firstmate routes  │
 │ writes guarded backlog/briefs/state │
 └──┬──────────────┬───────────────┬───┘
    │ backend sends / status files │
    ▼              ▼               ▼
 ┌────────┐   ┌────────┐      ┌────────┐
 │fm-task1│   │fm-task2│  ... │fm-taskN│   tmux windows, herdr/zellij tabs, cmux workspaces, or Orca terminals
 │crewmate│   │crewmate│      │crewmate│   one autonomous agent each
 └───┬────┘   └───┬────┘      └───┬────┘
     ▼            ▼               ▼
  treehouse worktree, Orca worktree, or isolated secondmate home
     │
     ├─ ship: project mode ► PR/local merge ► teardown
     │
     └─ scout: report at data/&lt;id&gt;/report.md ► relay findings ► teardown
</code></pre>
<p dir="auto">You chat with the first mate.<br>
It routes each request to a crewmate in its own session endpoint and git worktree, supervises the fleet with a zero-token event-driven watcher, and brings you finished PRs, approved local merges, or investigation reports.<br>
Optional secondmates extend this to persistent domain supervisors, dispatch profiles let you steer which harness handles which task, and an opt-in X mode lets the same fleet answer public mentions.<br>
<code class="notranslate">codex-app</code> is not a runtime backend yet; <a href="docs/codex-app-backend.md">docs/codex-app-backend.md</a> owns the Codex App boundary.</p>
<p dir="auto">Full architecture - the supervision engine, worktree isolation, secondmates, dispatch profiles, project modes, optional X mode, fleet sync, and self-update - is in <a href="docs/architecture.md">docs/architecture.md</a>.</p>
<h2 dir="auto">Built-in skills</h2>
<p dir="auto">Firstmate ships these user-invocable built-in skills.<br>
Claude and grok use the slash form shown here; codex uses the same names with <code class="notranslate">$</code>, such as <code class="notranslate">$afk</code>.</p>
<markdown-accessiblity-table><table role="table">
<thead>
<tr>
<th>Skill</th>
<th>What it does</th>
</tr>
</thead>
<tbody>
<tr>
<td><code class="notranslate">/afk</code></td>
<td>Enter away-mode supervision: the sub-supervisor self-handles routine wakes in bash, escalates captain-relevant events and bounded declared-external-wait rechecks as batched digests, and actively alerts if delivery wedges while you step away</td>
</tr>
<tr>
<td><code class="notranslate">/bearings</code></td>
<td>Generate a "pick up where I left off" status report from the read-only fleet snapshot - backlog, per-task crew state, open PRs, scout reports, pending decisions, and date-gated queued work - written to a dated file in <code class="notranslate">data/</code> and surfaced concisely in chat; read-mostly, mutates no task state</td>
</tr>
<tr>
<td><code class="notranslate">/updatefirstmate</code></td>
<td>Self-update the running firstmate and its secondmates to the latest from origin with fast-forward-only pulls, then re-read instructions and nudge secondmates</td>
</tr>
<tr>
<td><code class="notranslate">/stow</code></td>
<td>Sweep the session for uncaptured durable knowledge, route each finding to its disk home per AGENTS.md, file undone next steps to the backlog, and report what is now safe to reset</td>
</tr>
</tbody>
</table></markdown-accessiblity-table>
<p dir="auto">Agent-only reference skills live under <code class="notranslate">.agents/skills/</code> and are loaded by firstmate at the trigger points named in <a href="AGENTS.md"><code class="notranslate">AGENTS.md</code></a>.</p>
<h3 dir="auto">Two-tier skill layout</h3>
<p dir="auto">Firstmate's skills live in two separate places with different audiences:</p>
<ul dir="auto">
<li><code class="notranslate">.agents/skills/</code> - agent-loaded skills (this section's table, plus firstmate's agent-only reference skills). Every one of these assumes a live firstmate home and is meaningless, or actively misleading, installed anywhere else, so each carries <code class="notranslate">metadata.internal: true</code> in its frontmatter. That flag hides them from installer discovery (tools like the <a href="https://skills.sh" rel="nofollow">skills.sh</a> <code class="notranslate">npx skills add</code> installer) without affecting how firstmate itself loads them - frontmatter metadata is inert to the agent's own skill loader.</li>
<li><code class="notranslate">skills/</code> - public, installer-facing skills meant to be installed standalone into any project, independent of firstmate.<br>
Each one is a self-contained skill with no dependency on firstmate's paths, tools, or vocabulary.<br>
Today that is <code class="notranslate">skills/stow</code>, a generic session-knowledge-sweep skill that routes findings by explicit instruction first, then existing local conventions, then a private <code class="notranslate">.stow-notes.md</code> fallback in the current directory, and closes with a resume pointer for the next session.<br>
It intentionally shares no code with the firstmate-internal <code class="notranslate">.agents/skills/stow</code> it is named after, so the two can evolve independently.</li>
</ul>
<h2 dir="auto">Documentation</h2>
<ul dir="auto">
<li><a href="docs/architecture.md">docs/architecture.md</a> - how the crew, supervision, worktrees, secondmates, and project modes work.</li>
<li><a href="docs/configuration.md">docs/configuration.md</a> - environment variables, <code class="notranslate">FM_HOME</code>, runtime backend selection, optional X mode, the files you set, and harness support.</li>
<li><a href="docs/wedge-alarm.md">docs/wedge-alarm.md</a> - configure the active alert for a wedged away-mode escalation delivery.</li>
<li><a href="docs/tmux-backend.md">docs/tmux-backend.md</a> - setup guide for the tmux reference backend: prerequisites, attaching, and watching crew windows.</li>
<li><a href="docs/herdr-backend.md">docs/herdr-backend.md</a> - setup guide for the experimental herdr backend, plus its verification notes and known gaps.</li>
<li><a href="docs/zellij-backend.md">docs/zellij-backend.md</a> - setup guide for the experimental zellij backend, plus its verification notes and known gaps.</li>
<li><a href="docs/orca-backend.md">docs/orca-backend.md</a> - setup guide for the experimental Orca backend, plus its lifecycle notes and known gaps.</li>
<li><a href="docs/cmux-backend.md">docs/cmux-backend.md</a> - setup guide for the experimental cmux backend, plus its verification notes and known gaps.</li>
<li><a href="docs/codex-app-backend.md">docs/codex-app-backend.md</a> - Codex App backend boundary, evidence, and rollout contract.</li>
<li><a href="docs/turnend-guard.md">docs/turnend-guard.md</a> - the primary session's structural "no turn ends blind" backstop: verified per-harness hook mechanisms, scoping, loop safety, and fail-open tradeoffs.</li>
<li><a href="docs/supervision-protocols/">docs/supervision-protocols/</a> - rendered primary-harness watcher protocols for Claude, Codex, OpenCode, Pi, Grok, and unknown harness fallback.</li>
<li><a href="docs/scripts.md">docs/scripts.md</a> - the <code class="notranslate">bin/</code> toolbelt reference.</li>
<li><a href="AGENTS.md"><code class="notranslate">AGENTS.md</code></a> - the distro's core instruction file and the first mate's full operating manual.</li>
<li><a href="CONTRIBUTING.md">CONTRIBUTING.md</a> - how to contribute, including the dev/test commands.</li>
</ul>
<h2 dir="auto">Contributing</h2>
<p dir="auto">Contributions are welcome - see <a href="CONTRIBUTING.md">CONTRIBUTING.md</a> for the workflow, repo conventions, and how to run the tests.</p>
<h2 dir="auto">License</h2>
<p dir="auto">MIT - see <a href="LICENSE">LICENSE</a>.</p></article></body></html>
```
</details>
<details>
<summary>Evidence: README constraint validation</summary>

```text
README positioning validation

Target: ce812e349caea94deaa701b7f49ac9aa26e8f8a7
Changed files: README.md
PASS: README.md is the only changed file.
PASS: headline is present exactly once and unchanged.
PASS: captain-revised crew positioning appears exactly once.
PASS: one authoritative full agent-distro definition appears.
PASS: all five negatives appear in one sentence.
PASS: no-app distro sentence and harness-instantiation punchline appear.
PASS: Documentation AGENTS.md description uses the requested distro wording.
PASS: README contains zero orchestrator mentions.
PASS: README contains no em dashes.

Rendered positioning block source:
## What it is

You can run one coding agent easily.
But the moment you want three project tasks done in parallel - fixes, investigations, plans, audits - you become a tab-juggler: babysitting sessions, copy-pasting context between repos, forgetting which terminal had the failing test.

firstmate flips the model.
You talk to a single agent - the first mate - and it runs the crew for you: spawning autonomous agents in a visible session backend, giving each a clean git worktree, supervising them to completion, and handing you finished PRs, approved local merges, or standalone investigation reports.
For larger fleets, you can opt in to persistent secondmates: domain supervisors that are still ordinary direct reports, but run from their own isolated firstmate homes.

firstmate is not a model, not a harness, not a skill, not an MCP server, and not a CLI.
firstmate is an agent distro for running a crew of agents.
An agent distro is a portable directory of instructions, skills, tooling, policies, and state conventions that turns a general-purpose agent into a specialized one.
There is no app to install: the cloned repo is the distro - `AGENTS.md`, bundled firstmate skills, and helper scripts that any terminal coding agent can follow.
Launching a supported harness inside it instantiates your first mate - and makes you the captain.

## Features
```
</details>
<details>
<summary>Evidence: Reader-facing excerpt and acceptance transcript</summary>

```text
README positioning acceptance transcript

Changed files:
README.md

Rendered source excerpt (What it is):

## What it is

You can run one coding agent easily.
But the moment you want three project tasks done in parallel - fixes, investigations, plans, audits - you become a tab-juggler: babysitting sessions, copy-pasting context between repos, forgetting which terminal had the failing test.

firstmate flips the model.
You talk to a single agent - the first mate - and it runs the crew for you: spawning autonomous agents in a visible session backend, giving each a clean git worktree, supervising them to completion, and handing you finished PRs, approved local merges, or standalone investigation reports.
For larger fleets, you can opt in to persistent secondmates: domain supervisors that are still ordinary direct reports, but run from their own isolated firstmate homes.

firstmate is not a model, not a harness, not a skill, not an MCP server, and not a CLI.
firstmate is an agent distro for running a crew of agents.
An agent distro is a portable directory of instructions, skills, tooling, policies, and state conventions that turns a general-purpose agent into a specialized one.
There is no app to install: the cloned repo is the distro - `AGENTS.md`, bundled firstmate skills, and helper scripts that any terminal coding agent can follow.
Launching a supported harness inside it instantiates your first mate - and makes you the captain.

## Features

- **One liaison** - you talk only to the first mate; it dispatches, supervises, escalates only real decisions, and reports plain outcomes.
- **A visible crew** - every crewmate works in its own tmux window, experimental herdr/zellij tab, cmux workspace, or Orca terminal you can watch or type into; the first mate reconciles.
- **Disposable worktrees** - each task runs in a clean [treehouse](https://github.com/kunchenguid/treehouse) git worktree, or an Orca-managed worktree when `backend=orca`, so parallel work on one repo never collides.
- **Two task shapes** - ship tasks deliver a change; scout tasks investigate, plan, reproduce, or audit and leave a report.
- **Explicit project modes** - each project ships via `no-mistakes`, `direct-PR`, or `local-only`, with an optional `+yolo` autonomy flag.

Documentation entry:
Agent-only reference skills live under `.agents/skills/` and are loaded by firstmate at the trigger points named in [`AGENTS.md`](AGENTS.md).
- [`AGENTS.md`](AGENTS.md) - the distro's core instruction file and the first mate's full operating manual.

Constraint counts:
full agent distro definitions: 1
README orchestrator mentions: 0
positioning line occurrences: 1
headline occurrences: 1

Opening paragraph identity check:
PASS: lines 29-34 are byte-identical
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- <code>Preconfigured baseline: `command -v tmux &gt;/dev/null || { echo &#34;tmux is required for e2e tests&#34; &gt;&amp;2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo &#34;== $t ==&#34;; bash &#34;$t&#34; || rc=1; done; exit &#34;$rc&#34;`</code>
- `git diff --no-ext-diff --unified=80 1fb1e30d6f827d0b78bfec667b7d458f7bc9447c..ce812e349caea94deaa701b7f49ac9aa26e8f8a7 -- README.md`
- `Targeted shell assertions for changed-file scope, byte-identical opening copy, exact headline, five negatives, revised “crew of agents” wording, unique full definition, install and harness lines, Documentation wording, zero README orchestrator mentions, and no em dash`
- `Rendered README through GitHub's GFM Markdown API and visually inspected the browser screenshot`
- `git diff --check 1fb1e30d6f827d0b78bfec667b7d458f7bc9447c..ce812e349caea94deaa701b7f49ac9aa26e8f8a7`
- `git status --short`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
