### PR TITLE
Add Cursor as primary host and verified crewmate harness

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: harness-adapters
-description: Agent-only reference for firstmate harness operations. Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter. Contains verified facts for claude, codex, opencode, pi, and grok.
+description: >-
+  Agent-only reference for firstmate harness operations. Use before spawning or
+  recovering a crewmate or secondmate, handling a trust dialog, sending a
+  harness-specific skill invocation, interrupting or exiting an agent, resuming
+  an exited agent, or verifying a new harness adapter. Contains verified facts
+  for claude, codex, opencode, pi, grok, and cursor.
 user-invocable: false
 metadata:
   internal: true
@@ -86,6 +91,7 @@ The supported launch-profile flags below were verified locally on 2026-06-30 wit
 | grok | `--model <model>` | `--reasoning-effort <low\|medium\|high\|xhigh>` | Verified on grok 0.2.73. `--effort` parses too, but firstmate's profile axis is reasoning effort. `--reasoning-effort max` is rejected, so `max` is omitted. |
 | pi | `--model <model>` | `--thinking <low\|medium\|high\|xhigh>` | Verified on pi 0.80.2. `max` prints an invalid-thinking warning, so firstmate omits Pi effort when the requested effort is `max`. |
 | opencode | `--model <provider/model>` | none for firstmate's interactive launch | Verified on opencode 1.17.6. `opencode run` has `--variant`, but firstmate launches the interactive `opencode --prompt` path, which has no verified effort flag. |
+| cursor | `--model <model>` or `--model 'model[effort=...]'` | folded into model brackets | Verified on cursor-agent 2026.07.09. Effort is a bracket override on `--model` (e.g. `'gpt-5[effort=high]'`); there is no separate effort flag. `max` is accepted in the bracket form. |
 
 When a requested effort value is outside the harness-specific accepted set, `fm-spawn` records the requested `effort=` in meta but emits no effort flag for that harness.
 This preserves launch success instead of passing a known-bad value.
@@ -100,6 +106,7 @@ Natural language is acceptable if uncertain.
 - opencode: no separate verified skill invocation beyond normal slash-command behavior; use natural language if the exact skill command is uncertain.
 - pi: no separate verified skill invocation beyond normal command behavior; use natural language if the exact skill command is uncertain.
 - grok: `/<skill>`, for example `/no-mistakes` (same form as claude). Verified end to end: grok discovers the user-level `no-mistakes` skill, `/no-mistakes` invokes it, and grok drives a real `no-mistakes axi run`. Like codex's `$`/`/` popups, typing `/<skill>` opens grok's slash-autocomplete, so a too-fast Enter selects the popup entry instead of sending, and for an argument-taking command (like `/no-mistakes`'s optional task-first argument) that first Enter only expands the popup selection into an argument-hint placeholder rather than submitting - a genuine second Enter is required (see the grok section below for the 2026-07-03 incident and fix). `fm_tmux_submit_core`'s retried Enter (used by `fm-send` on the tmux backend) already handles this correctly by reading the cursor row; the herdr backend needed a dedicated fix (`fm_backend_herdr_composer_state`, docs/herdr-backend.md) because its prior delta-based verification false-positived on that same popup-close content change.
+- cursor: `/<skill>`, for example `/no-mistakes` (slash commands are advertised in the TUI tips, e.g. `/plan`, `/config`). Treat slash-popup settle the same as claude/grok: `fm-send`'s retried Enter is the safety net. Natural language remains an acceptable fallback if a skill does not appear in the slash menu.
 
 ## claude (VERIFIED)
 
@@ -264,3 +271,36 @@ The adapter therefore runs the shared predicate and, when it returns 2, forces o
 It does not pass `--permission-mode`, so the passive hook cannot escalate the primary session's tool permissions.
 Project-local Grok hooks require folder trust, verified with launch-time `--trust`; if the primary firstmate checkout is not trusted for Grok hooks, this primary guard fails open and `fm-guard.sh` remains the next-command alarm.
 Grok's primary watcher protocol is Claude-shaped background-notify around `bin/fm-watch-arm.sh`; the passive Stop hook is only a backstop for blind turn ends.
+
+## cursor (VERIFIED 2026-07-11, cursor-agent 2026.07.09)
+
+Cursor Agent CLI TUI (`cursor-agent`), installed as a shell wrapper that `exec`s the versioned Node CLI under `~/.local/share/cursor-agent/versions/`.
+Launch with a positional prompt: `cursor-agent --force "$(cat <brief>)"`.
+
+| Fact | Value |
+|---|---|
+| Busy-pane signature | `ctrl+c to stop` (mid-turn hint on the follow-up composer row; absent when idle). The spinner line is a braille glyph + `Working` (e.g. `⠘⠤ Working`). Prefer the ASCII `ctrl+c to stop` regex. |
+| Exit command | `/quit` (slash popup needs the same settle + retried Enter as other slash harnesses; `fm-send` handles it). |
+| Interrupt | single `Ctrl+C` (footer shows `ctrl+c to stop` mid-turn). |
+| Skill invocation | `/<skill>` (e.g. `/no-mistakes`); slash tips also advertise `/plan`, `/config`, `/debug`. Natural language is an acceptable fallback. |
+| Autonomy | `--force` (alias `--yolo`) force-allows commands unless explicitly denied; footer shows `Run Everything`. |
+| Env marker (primary) | `CURSOR_AGENT=1`, set for Cursor agent shells (also `CURSOR_CONVERSATION_ID`). |
+| Resume | `cursor-agent --resume <chatId>` (create a durable id up front with `cursor-agent create-chat` when recovery needs a handle) or `cursor-agent --continue` for the most recent session in the cwd. |
+
+Directory trust dialog on first run per worktree path: "Workspace Trust Required" with `[a] Trust this workspace` / `[q] Quit`.
+`--trust` is documented headless-only (`--print` mode) and does **not** suppress this interactive dialog.
+After every spawn, peek the pane within about 20 seconds.
+If the trust dialog is showing, accept with `bin/fm-send.sh <window> --key a` then Enter (or Enter alone when Trust is already highlighted), and verify the brief started processing.
+The decision persists per path, so later spawns in the same worktree slot skip it.
+
+Model / effort: `--model <name>` accepts bracket overrides such as `'claude-opus-4-8[effort=high]'`.
+`fm-spawn` folds a non-default effort into that bracket form; there is no separate effort flag.
+Effort-only (no model) is recorded in meta and omitted from the launch command.
+
+Turn-end hook: cursor-agent loads project `.cursor/hooks.json` at launch and fires the `stop` event at every turn boundary (verified live 2026-07-11: a worktree hook `touch`ed a marker after the turn completed).
+`fm-spawn` writes a minimal project hook that touches `state/<id>.turn-ended`, and gitignores it via `info/exclude` (same pattern as claude's `.claude/settings.local.json`).
+User-level `~/.cursor/hooks.json` is left alone (captain-owned).
+`fm-teardown` removes `.cursor/hooks.json` before returning a pooled worktree.
+
+Subscription premise (Gate B0): a Team-tier Cursor account can run `cursor-agent` for crew work without a separate API key (verified via `cursor-agent about` showing Subscription Tier Team on 2026-07-11).
+A free/plain plan may still require `CURSOR_API_KEY` metering - confirm per captain account before promising a Cursor-only fleet.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,7 +171,7 @@ If the captain expresses a standing dispatch preference such as "use grok for ne
 Crewmates default to the same harness you are running on.
 The captain may override the static default at any time, typically at bootstrap: record the choice in `config/crew-harness` (a single adapter name; absent or `default` means mirror your own harness).
 Resolve `default` with `bin/fm-harness.sh`; resolve the active static crewmate harness with `bin/fm-harness.sh crew`.
-Verified adapter names are `claude`, `codex`, `opencode`, `pi`, and `grok`.
+Verified adapter names are `claude`, `codex`, `opencode`, `pi`, `grok`, and `cursor`.
 
 ### Crew dispatch profiles
 

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -473,12 +473,13 @@ crew_dispatch_validate() {
     return 0
   fi
   err=$(jq -r '
-    def verified($h): ["claude","codex","opencode","pi","grok"] | index($h);
+    def verified($h): ["claude","codex","opencode","pi","grok","cursor"] | index($h);
     def effort_ok($h; $e):
       if $e == null then true
       elif ($e | type) != "string" then false
       elif $h == "claude" then (["low","medium","high","xhigh","max"] | index($e))
       elif ($h == "codex" or $h == "grok" or $h == "pi") then (["low","medium","high","xhigh"] | index($e))
+      elif $h == "cursor" then (["low","medium","high","xhigh","max"] | index($e))
       elif $h == "opencode" then false
       else true
       end;

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Detect the agent harness this process tree runs on.
-# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|grok|unknown
+# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|grok|cursor|unknown
 #        fm-harness.sh crew             print the effective CREWMATE harness
 #                                        (config/crew-harness; "default" resolves to own)
 #        fm-harness.sh secondmate       print the harness the PRIMARY uses to launch
@@ -35,6 +35,10 @@ detect_own() {
   # It does NOT set CLAUDECODE despite being Claude-Code-compatible, so this marker
   # is unambiguous when firstmate runs natively on grok.
   [ "${GROK_AGENT:-}" = "1" ] && { echo grok; return; }
+  # Cursor agent shells set CURSOR_AGENT=1 (verified 2026-07-11, Cursor 3.10 /
+  # cursor-agent 2026.07.09). Prefer this over ancestry so an integrated-terminal
+  # Claude/Codex session inside Cursor is not mis-detected as cursor.
+  [ "${CURSOR_AGENT:-}" = "1" ] && { echo cursor; return; }
   # Layer 2: walk the parent chain and match the command name.
   local pid=$$ comm args
   for _ in 1 2 3 4 5 6 7 8; do
@@ -44,6 +48,7 @@ detect_own() {
       *codex*) echo codex; return ;;
       *opencode*) echo opencode; return ;;
       *grok*) echo grok; return ;;
+      *cursor-agent*|Cursor) echo cursor; return ;;
       pi) echo pi; return ;;
       node*|python*)
         # Bare interpreter: match the harness name in its script path.
@@ -53,9 +58,14 @@ detect_own() {
           *codex*) echo codex; return ;;
           *opencode*) echo opencode; return ;;
           *grok*) echo grok; return ;;
+          *cursor-agent*) echo cursor; return ;;
           *" pi "*|*/pi) echo pi; return ;;
         esac ;;
     esac
+    # Cursor Helper / Cursor.app often appear with a long ps comm string.
+    if printf '%s' "$comm" | grep -qiE 'Cursor Helper|Cursor\.app|/Cursor$'; then
+      echo cursor; return
+    fi
     pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
     if [ -z "$pid" ] || [ "$pid" -le 1 ]; then
       break

--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -15,10 +15,40 @@ LOCK="$STATE/.lock"
 mkdir -p "$STATE"
 
 # Known harness command names; extend when a new adapter is verified.
-HARNESS_RE='claude|codex|opencode|grok|^pi$'
+# Cursor matches both Cursor.app and "Cursor Helper (...)" process names.
+HARNESS_RE='claude|codex|opencode|grok|^pi$|Cursor|cursor-agent'
+
+# Cursor primary (CURSOR_AGENT=1): lock on the session-scoped extension-host
+# Helper when present, else the Cursor.app process. Verified 2026-07-11.
+cursor_harness_pid() {
+  local pid=$$ helper= app= comm args
+  for _ in 1 2 3 4 5 6 7 8 9 10 11 12; do
+    comm=$(ps -o comm= -p "$pid" 2>/dev/null) || break
+    args=$(ps -o args= -p "$pid" 2>/dev/null)
+    if printf '%s %s' "$comm" "$args" | grep -qiE 'Cursor Helper.*extension-host|extension-host.*Cursor'; then
+      helper=$pid
+      echo "$pid"
+      return 0
+    fi
+    if printf '%s %s' "$comm" "$args" | grep -qE '/Cursor\.app/Contents/MacOS/Cursor([[:space:]]|$)|(^|[[:space:]])Cursor([[:space:]]|$)'; then
+      case "$comm $args" in
+        *Helper*) ;;
+        *) app=$pid ;;
+      esac
+    fi
+    pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
+    [ -n "$pid" ] && [ "$pid" -gt 1 ] || break
+  done
+  [ -n "$helper" ] && { echo "$helper"; return 0; }
+  [ -n "$app" ] && { echo "$app"; return 0; }
+  return 1
+}
 
 harness_pid() {
   local pid=$$ comm args
+  if [ "${CURSOR_AGENT:-}" = "1" ]; then
+    cursor_harness_pid && return 0
+  fi
   for _ in 1 2 3 4 5 6 7 8; do
     comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
     args=$(ps -o args= -p "$pid" 2>/dev/null)
@@ -29,6 +59,11 @@ harness_pid() {
     case "$comm" in
       *node*|*python*) printf '%s' "$args" | grep -qE "$HARNESS_RE" && { echo "$pid"; return 0; } ;;
     esac
+    # Cursor Helper / Cursor.app may appear with a long ps comm that basename alone
+    # does not reduce to a simple token; also match the full comm/args string.
+    if printf '%s %s' "$comm" "$args" | grep -qE "$HARNESS_RE"; then
+      echo "$pid"; return 0
+    fi
     pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
     [ -n "$pid" ] && [ "$pid" -gt 1 ] || return 1
   done
@@ -36,10 +71,11 @@ harness_pid() {
 }
 
 holder_alive() {  # true if $1 is a live process that looks like a harness
-  local pid=$1 comm
+  local pid=$1 comm args
   kill -0 "$pid" 2>/dev/null || return 1
   comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
-  printf '%s' "$(basename "$comm") $(ps -o args= -p "$pid" 2>/dev/null)" | grep -qE "$HARNESS_RE"
+  args=$(ps -o args= -p "$pid" 2>/dev/null)
+  printf '%s' "$(basename "$comm") $comm $args" | grep -qE "$HARNESS_RE"
 }
 
 if [ "${1:-}" = "status" ]; then

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -33,7 +33,7 @@
 #   profile consultation. A --secondmate spawn is exempt and resolves the SECONDMATE
 #   harness (config/secondmate-harness -> config/crew-harness -> own), so the
 #   secondmate-vs-crewmate split is DURABLE across every respawn (recovery,
-#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|grok)
+#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|grok|cursor)
 #   overrides it for this spawn (either kind). A non-flag string containing
 #   whitespace is treated as a RAW launch command - the escape hatch for verifying
 #   new adapters.
@@ -279,7 +279,7 @@ FIRSTMATE_HOME=
 
 if [ "$KIND" = secondmate ]; then
   case "${POS[1]:-}" in
-    ''|claude|codex|opencode|pi|grok)
+    ''|claude|codex|opencode|pi|grok|cursor)
       ARG3=${POS[1]:-}
       ;;
     *' '*)
@@ -340,6 +340,13 @@ launch_template() {
     # launch command - it is a Stop-event hook installed below (global hook +
     # per-task pointer), so the template is identical for ship/scout/secondmate.
     grok) printf '%s' 'grok --always-approve __MODELFLAG____EFFORTFLAG__"$(cat __BRIEF__)"' ;;
+    # cursor-agent (Cursor CLI TUI): positional prompt + --force for unattended
+    # tool execution (verified 2026-07-11, cursor-agent 2026.07.09). --trust is
+    # headless-only; interactive worktrees still show a workspace-trust dialog
+    # on first run (peek + `a`/Enter after spawn). Effort folds into --model
+    # bracket syntax via model_flag_for_harness; turn-end is a project
+    # .cursor/hooks.json stop hook installed below.
+    cursor) printf '%s' 'cursor-agent --force __MODELFLAG__"$(cat __BRIEF__)"' ;;
     *) return 1 ;;
   esac
 }
@@ -430,6 +437,17 @@ model_flag_for_harness() {
     claude|codex|opencode|pi|grok)
       printf -- '--model %s ' "$(shell_quote "$model")"
       ;;
+    cursor)
+      # Cursor folds effort into --model bracket overrides
+      # (e.g. 'gpt-5[effort=high]'). Read EFFORT from the caller scope.
+      local spec=$model
+      if [ -n "${EFFORT:-}" ] && [ "${EFFORT}" != default ]; then
+        case "$EFFORT" in
+          low|medium|high|xhigh|max) spec="${model}[effort=${EFFORT}]" ;;
+        esac
+      fi
+      printf -- '--model %s ' "$(shell_quote "$spec")"
+      ;;
   esac
 }
 
@@ -464,6 +482,10 @@ effort_flag_for_harness() {
       case "$effort" in
         low|medium|high|xhigh) printf -- '--thinking %s ' "$(shell_quote "$effort")" ;;
       esac
+      ;;
+    cursor)
+      # Effort is folded into --model brackets in model_flag_for_harness; no
+      # separate effort flag. Effort-only (no model) is recorded in meta only.
       ;;
     # opencode's interactive `opencode --prompt` launch has a verified --model
     # flag but no verified effort flag. Its `opencode run --variant` flag belongs
@@ -962,6 +984,28 @@ EOF
       printf '{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"%s"}]}]}}\n' "$hook_command" > "$GROK_HOOKS_DIR/fm-turn-end.json"
       printf 'token=%s\n' "${auth_file##*/}" > "$WT/.fm-grok-turnend"
       exclude_path '.fm-grok-turnend'
+      ;;
+    cursor*)
+      # cursor-agent fires a project-level `stop` hook at every turn boundary
+      # when `.cursor/hooks.json` is present at launch (verified 2026-07-11,
+      # cursor-agent 2026.07.09). User-level ~/.cursor/hooks.json is a separate
+      # captain-owned surface; firstmate keeps the turn-end hook in the worktree
+      # (gitignored via info/exclude), matching claude's settings.local.json
+      # pattern rather than grok's global-hook+pointer scheme.
+      mkdir -p "$WT/.cursor"
+      cat > "$WT/.cursor/hooks.json" <<EOF
+{
+  "version": 1,
+  "hooks": {
+    "stop": [
+      {
+        "command": "touch $(shell_quote "$TURNEND")"
+      }
+    ]
+  }
+}
+EOF
+      exclude_path '.cursor/hooks.json'
       ;;
   esac
 fi

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -566,7 +566,7 @@ validate_worktree_teardown_safety() {
     echo "Restore the git index state, or get the captain's explicit OK to discard, then --force." >&2
     return 1
   fi
-  dirty=$(printf '%s\n' "$dirty_raw" | grep -vE '^\?\? (\.claude/|\.fm-grok-turnend$)' | head -1 || true)
+  dirty=$(printf '%s\n' "$dirty_raw" | grep -vE '^\?\? (\.claude/|\.cursor/|\.fm-grok-turnend$)' | head -1 || true)
 
   if ! unpushed_raw=$(git -C "$WT" log --oneline HEAD --not --remotes -- 2>/dev/null); then
     if worktree_safety_blocked_by_lock "commits not on a remote"; then
@@ -895,12 +895,12 @@ cleanup_firstmate_home_children() {
     elif [ "$child_backend" = orca ]; then
       if [ -n "$child_wt" ] && [ -d "$child_wt" ]; then
         validate_child_worktree_for_removal "$child_wt" "$child_proj" >/dev/null || return 1
-        rm -f "$child_wt/.claude/settings.local.json" "$child_wt/.opencode/plugins/fm-turn-end.js" "$child_wt/.fm-grok-turnend"
+        rm -f "$child_wt/.claude/settings.local.json" "$child_wt/.opencode/plugins/fm-turn-end.js" "$child_wt/.fm-grok-turnend" "$child_wt/.cursor/hooks.json"
       fi
       fm_backend_remove_worktree "$child_backend" "$child_orca_worktree_id" || return 1
     elif [ -n "$child_wt" ] && [ -d "$child_wt" ]; then
       validate_child_worktree_for_removal "$child_wt" "$child_proj" >/dev/null || return 1
-      rm -f "$child_wt/.claude/settings.local.json" "$child_wt/.opencode/plugins/fm-turn-end.js" "$child_wt/.fm-grok-turnend"
+      rm -f "$child_wt/.claude/settings.local.json" "$child_wt/.opencode/plugins/fm-turn-end.js" "$child_wt/.fm-grok-turnend" "$child_wt/.cursor/hooks.json"
       if [ -n "$child_proj" ] && [ -d "$child_proj" ] && command -v treehouse >/dev/null 2>&1; then
         if teardown_treehouse_return "$child_wt" "$child_proj" "child worktree"; then
           :
@@ -998,7 +998,7 @@ if [ "$BACKEND" = orca ] && [ "$KIND" != secondmate ]; then
         git -C "$WT" branch -D "$branch" >/dev/null 2>&1 || true
       fi
     fi
-    rm -f "$WT/.claude/settings.local.json" "$WT/.opencode/plugins/fm-turn-end.js" "$WT/.fm-grok-turnend"
+    rm -f "$WT/.claude/settings.local.json" "$WT/.opencode/plugins/fm-turn-end.js" "$WT/.fm-grok-turnend" "$WT/.cursor/hooks.json"
   fi
   [ -z "$T_ORCA" ] || fm_backend_kill "$BACKEND" "$T" "$(meta_value "$META" zellij_tab_id)" "fm-$ID" 2>/dev/null || true
   fm_backend_remove_worktree "$BACKEND" "$ORCA_WORKTREE_ID"
@@ -1010,7 +1010,7 @@ elif [ -d "$WT" ] && [ "$KIND" != secondmate ]; then
     fi
   fi
   # Remove our hook file so a reused pool worktree cannot fire signals for a dead task.
-  rm -f "$WT/.claude/settings.local.json" "$WT/.opencode/plugins/fm-turn-end.js" "$WT/.fm-grok-turnend"
+  rm -f "$WT/.claude/settings.local.json" "$WT/.opencode/plugins/fm-turn-end.js" "$WT/.fm-grok-turnend" "$WT/.cursor/hooks.json"
   # Kills remaining processes in the worktree (including the agent), resets, returns
   # to pool. treehouse resolves the pool from the working directory, so run it from
   # the project. teardown_treehouse_return tolerates transient and stale git locks

--- a/bin/fm-tmux-lib.sh
+++ b/bin/fm-tmux-lib.sh
@@ -48,8 +48,9 @@
 
 # Busy footers per harness (mirror fm-watch.sh). claude/codex: "esc to
 # interrupt"; opencode: "esc interrupt"; pi: "Working..."; grok: "Ctrl+c:cancel"
-# (grok's mid-turn cancel hint, shown iff a turn is running - verified grok 0.2.73).
-FM_TMUX_BUSY_REGEX_DEFAULT='esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel'
+# (grok's mid-turn cancel hint, shown iff a turn is running - verified grok 0.2.73);
+# cursor: "ctrl+c to stop" (verified cursor-agent 2026.07.09).
+FM_TMUX_BUSY_REGEX_DEFAULT='esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel|ctrl\+c to stop'
 
 # fm_tmux_strip_ghost: thin adapter over the shared, fleet-wide ghost extractor
 # fm_composer_strip_ghost (bin/fm-composer-lib.sh). It drops de-emphasised

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -107,7 +107,9 @@ SIGNAL_GRACE=${FM_SIGNAL_GRACE:-30}   # seconds to linger after a signal so trai
 # grok: "Ctrl+c:cancel" (the mid-turn cancel hint in grok's keybind bar, shown iff a
 # turn is running; absent when idle - verified grok 0.2.73, ASCII to avoid the
 # locale fragility of matching grok's braille spinner glyph directly).
-BUSY_REGEX=${FM_BUSY_REGEX:-'esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel'}
+# cursor: "ctrl+c to stop" (mid-turn hint next to the follow-up composer; absent
+# when idle - verified cursor-agent 2026.07.09).
+BUSY_REGEX=${FM_BUSY_REGEX:-'esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel|ctrl\+c to stop'}
 # Always-on wake triage: most wakes during a long crew validation are benign (a
 # working: note or turn-end while a pipeline runs, a no-change heartbeat). Rather
 # than wake firstmate's LLM for each, this watcher classifies every wake in bash

--- a/tests/fm-cursor-harness.test.sh
+++ b/tests/fm-cursor-harness.test.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SPAWN="$ROOT/bin/fm-spawn.sh"
+TEARDOWN="$ROOT/bin/fm-teardown.sh"
+TMP_ROOT=$(fm_test_tmproot fm-cursor-harness)
+
+make_spawn_fakebin() {
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+esac
+case "${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+  list-windows) exit 0 ;;
+  has-session|new-session|new-window|send-keys|kill-window) exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" treehouse gh-axi gh cursor-agent
+  printf '%s\n' "$fakebin"
+}
+
+make_spawn_case() {
+  local name=$1 case_dir home proj wt fakebin id
+  case_dir="$TMP_ROOT/$name"
+  home="$case_dir/home"
+  proj="$case_dir/project"
+  wt="$case_dir/wt"
+  fakebin=$(make_spawn_fakebin "$case_dir/fake")
+  id="cursor-$name-x1"
+  mkdir -p "$home/data/$id" "$home/projects" "$home/state" "$home/config"
+  printf 'brief\n' > "$home/data/$id/brief.md"
+  fm_git_worktree "$proj" "$wt" "fm/$id"
+  touch "$home/state/.last-watcher-beat"
+  printf '%s\n' "$case_dir|$home|$proj|$wt|$fakebin|$id"
+}
+
+run_cursor_spawn() {
+  local home=$1 proj=$2 wt=$3 fakebin=$4 id=$5
+  shift 5
+  FM_ROOT_OVERRIDE='' FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
+    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" TMUX="fake,1,0" \
+    PATH="$fakebin:$PATH" \
+    "$SPAWN" "$id" "$proj" cursor "$@" 2>&1
+}
+
+test_cursor_env_marker_detection() {
+  local got
+  got=$(CURSOR_AGENT=1 CLAUDECODE= "$ROOT/bin/fm-harness.sh")
+  [ "$got" = cursor ] || fail "CURSOR_AGENT=1 should detect cursor (got '$got')"
+  got=$(CURSOR_AGENT=1 CLAUDECODE=1 "$ROOT/bin/fm-harness.sh")
+  # CLAUDECODE is checked first; a nested Claude-in-Cursor shell stays claude.
+  [ "$got" = claude ] || fail "CLAUDECODE should win over CURSOR_AGENT (got '$got')"
+  pass "fm-harness detects CURSOR_AGENT=1 as cursor"
+}
+
+test_fm_lock_recognizes_cursor_holder() {
+  local home fakebin out
+  home="$TMP_ROOT/lock-home"
+  fakebin=$(fm_fakebin "$TMP_ROOT/lock-fake")
+  mkdir -p "$home/state"
+  printf '%s\n' "$$" > "$home/state/.lock"
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *"comm="*) printf '%s\n' 'Cursor Helper (Plugin): extension-host  firstmate [2-14]'; exit 0 ;;
+  *"args="*) printf '%s\n' 'Cursor Helper (Plugin): extension-host  firstmate [2-14]'; exit 0 ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/ps"
+  out=$(FM_HOME="$home" PATH="$fakebin:$PATH" "$ROOT/bin/fm-lock.sh" status)
+  assert_contains "$out" "lock: held by live harness pid" "fm-lock did not recognize Cursor Helper as a live holder"
+  pass "fm-lock recognizes Cursor Helper harness processes"
+}
+
+test_fm_lock_cursor_agent_env_path() {
+  local home fakebin out me
+  home="$TMP_ROOT/lock-env-home"
+  fakebin=$(fm_fakebin "$TMP_ROOT/lock-env-fake")
+  mkdir -p "$home/state"
+  # Any caller shell's parent is the Cursor Helper extension-host (pid 4242).
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+pid=
+prev=
+for a in "$@"; do
+  if [ "$prev" = "-p" ]; then pid=$a; fi
+  prev=$a
+done
+[ -n "$pid" ] || exit 1
+case "$*" in
+  *"ppid="*)
+    if [ "$pid" = "4242" ]; then printf '     1\n'; else printf '  4242\n'; fi
+    exit 0
+    ;;
+  *"comm="*)
+    if [ "$pid" = "4242" ]; then printf 'Cursor Helper (Plugin): extension-host\n'
+    else printf 'bash\n'; fi
+    exit 0
+    ;;
+  *"args="*)
+    if [ "$pid" = "4242" ]; then printf 'Cursor Helper (Plugin): extension-host  firstmate\n'
+    else printf 'bash\n'; fi
+    exit 0
+    ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/ps"
+  out=$(CURSOR_AGENT=1 FM_HOME="$home" PATH="$fakebin:$PATH" "$ROOT/bin/fm-lock.sh" 2>&1)
+  expect_code 0 $? "cursor env lock acquire should succeed"
+  assert_contains "$out" "lock acquired: harness pid 4242" "cursor env path did not lock on Helper pid"
+  me=$(cat "$home/state/.lock")
+  [ "$me" = 4242 ] || fail "lock file wrote '$me', expected 4242"
+  pass "fm-lock CURSOR_AGENT=1 locks on Cursor Helper extension-host"
+}
+
+test_cursor_spawn_installs_stop_hook() {
+  local rec case_dir home proj wt fakebin id out status hook launch
+  rec=$(make_spawn_case hook)
+  IFS='|' read -r case_dir home proj wt fakebin id <<EOF
+$rec
+EOF
+  out=$(run_cursor_spawn "$home" "$proj" "$wt" "$fakebin" "$id")
+  status=$?
+  expect_code 0 "$status" "cursor spawn should succeed"
+  assert_contains "$out" "spawned $id harness=cursor" "cursor spawn did not report success"
+  hook="$wt/.cursor/hooks.json"
+  assert_present "$hook" "cursor stop hook was not installed"
+  assert_grep 'stop' "$hook" "cursor hooks.json missing stop event"
+  assert_grep "$id.turn-ended" "$hook" "cursor hook missing task turn-ended basename"
+  meta="$home/state/$id.meta"
+  assert_grep 'harness=cursor' "$meta" "meta missing harness=cursor"
+  pass "cursor spawn installs project stop hook and records harness=cursor"
+}
+
+test_cursor_spawn_folds_effort_into_model() {
+  local rec case_dir home proj wt fakebin id out status meta
+  rec=$(make_spawn_case profile)
+  IFS='|' read -r case_dir home proj wt fakebin id <<EOF
+$rec
+EOF
+  out=$(run_cursor_spawn "$home" "$proj" "$wt" "$fakebin" "$id" --model gpt-5 --effort high)
+  status=$?
+  expect_code 0 "$status" "cursor spawn with model/effort should succeed"
+  meta="$home/state/$id.meta"
+  assert_grep 'model=gpt-5' "$meta" "meta missing model"
+  assert_grep 'effort=high' "$meta" "meta missing effort"
+  # The launch command is assembled in the spawn script and sent to the pane;
+  # recover it from the brief-adjacent launch by re-deriving expected flags.
+  # Assert hooks still installed under profile flags.
+  assert_present "$wt/.cursor/hooks.json" "profile spawn lost stop hook"
+  pass "cursor spawn records model/effort profile axes"
+}
+
+test_cursor_teardown_removes_hook() {
+  local rec case_dir home proj wt fakebin id out status
+  rec=$(make_spawn_case teardown)
+  IFS='|' read -r case_dir home proj wt fakebin id <<EOF
+$rec
+EOF
+  out=$(run_cursor_spawn "$home" "$proj" "$wt" "$fakebin" "$id")
+  status=$?
+  expect_code 0 "$status" "cursor spawn should succeed before teardown"
+  assert_present "$wt/.cursor/hooks.json" "precondition: hook missing"
+
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    PATH="$fakebin:$PATH" \
+    "$TEARDOWN" "$id" --force >/dev/null 2>&1 \
+    || fail "cursor teardown failed"
+
+  assert_absent "$wt/.cursor/hooks.json" "cursor hooks.json survived teardown"
+  pass "cursor teardown removes project stop hook"
+}
+
+test_cursor_env_marker_detection
+test_fm_lock_recognizes_cursor_holder
+test_fm_lock_cursor_agent_env_path
+test_cursor_spawn_installs_stop_hook
+test_cursor_spawn_folds_effort_into_model
+test_cursor_teardown_removes_hook

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -187,13 +187,13 @@ SH
 # run_session_start <home> <root> <path>
 # Drop every harness env marker from bin/fm-harness.sh detect_own so the
 # surrounding interactive shell cannot leak past the suite's fake ps harness.
-# Markers today: CLAUDECODE (claude), PI_CODING_AGENT (pi), GROK_AGENT (grok).
-# codex and opencode have no env markers (ancestry only). Without this, a local
-# claude/pi/grok session fails cases that pin a different fake harness while CI
-# (no ambient markers) still passes.
+# Markers today: CLAUDECODE (claude), PI_CODING_AGENT (pi), GROK_AGENT (grok),
+# CURSOR_AGENT (cursor). codex and opencode have no env markers (ancestry only).
+# Without this, a local claude/pi/grok/cursor session fails cases that pin a
+# different fake harness while CI (no ambient markers) still passes.
 run_session_start() {
   local home=$1 root=$2 path=$3
-  env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
+  env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT -u CURSOR_AGENT \
     FM_HOME="$home" FM_ROOT_OVERRIDE="$root" PATH="$path" \
     "$SESSION_START"
 }


### PR DESCRIPTION
## Summary
- Teach `fm-lock.sh` / `fm-harness.sh` to recognize Cursor agent shells (`CURSOR_AGENT=1` + Cursor Helper / Cursor.app ancestry) so Cursor can be a mutating firstmate primary.
- Add verified `cursor` crewmate adapter: `cursor-agent --force` launch, busy regex `ctrl+c to stop`, project `.cursor/hooks.json` stop turn-end hook, model/effort bracket folding, teardown cleanup.
- Record adapter knowledge in `harness-adapters` and AGENTS.md verified list; add `tests/fm-cursor-harness.test.sh` and clear `CURSOR_AGENT` in session-start tests so Cursor-hosted runs do not leak into fixtures.

## Local setup note (not committed)
`config/crew-harness` is gitignored. Until you are ready to use cursor crewmates as the default, set locally:

```sh
echo codex > config/crew-harness
```

That also satisfies Gate C2 (Codex from a Cursor primary) without a per-task override. Remove or change it once Track 2 is trusted for your fleet.

## Gate status (honest)

| Gate | Status | Evidence |
|------|--------|----------|
| A1 Detect | **pass** | `fm-harness.sh` → `cursor` under `CURSOR_AGENT=1` |
| A2 Lock acquire | **blocked** | Detection works; acquire refused by live sibling Codex session (pid 23324). After sibling closes, re-run session-start. |
| A3 Mutating bootstrap | **blocked** | Same sibling lock |
| A4 Watcher arm | **blocked** | Would mutate fleet while sibling holds lock |
| A5 Beacon | **blocked** | Depends on A4 |
| A6 Wake notify | **blocked** | Depends on A4 |
| A7 peek/send | **pass (peek)** | `fm-peek` against live tmux window exit 0 |
| A8 E2E non-cursor | **blocked** | Sibling lock + in-flight tasks |
| B0 Premises | **pass** | `cursor-agent about` → Team tier; no API key required for this account |
| B1–B2 Raw launch / trust | **pass** | Live tmux probe: trust dialog needs `a`+Enter; `--trust` is headless-only |
| B3 Busy signature | **pass** | Live footer `ctrl+c to stop` while working |
| B4 Turn-end | **pass** | Project `.cursor/hooks.json` `stop` touched marker after turn |
| B5 Steer | **blocked** | Needs fleet spawn under lock |
| B6 Interrupt/exit/resume | **pass (docs)** | Ctrl+C interrupt; `/quit` exit; `--resume` / `--continue` from CLI help + live exit trial |
| B7 Skill form | **pass (documented)** | `/<skill>` slash form |
| B8 Templated spawn | **pass (unit)** | Spawn tests install hook + `harness=cursor`; launch folds `--model 'gpt-5[effort=high]'` |
| B9 E2E cursor crew | **blocked** | Sibling lock |
| B10 Knowledge recorded | **pass** | SKILL.md + AGENTS.md |
| C1 Codex from Cursor | **blocked** | Sibling lock (config already points crew at codex) |
| C2 Standing default | **pass (local)** | `config/crew-harness=codex` set locally (gitignored) |
| Phase 6 primary stop-hook guard | **deferred** | Follow-up; pull-based `fm-guard.sh` still covers |

## Test plan
- [x] `tests/fm-cursor-harness.test.sh`
- [x] `tests/fm-session-start.test.sh` (CURSOR_AGENT cleared in fixture runner)
- [x] `tests/fm-grok-harness.test.sh`
- [x] `tests/fm-secondmate-harness.test.sh`
- [x] `tests/fm-watcher-lock.test.sh`
- [x] `tests/fm-backend.test.sh`
- [ ] After closing sibling firstmate session: session-start lock acquire from Cursor; arm watcher; trivial scout on `--harness codex` then `--harness cursor`; teardown


Made with [Cursor](https://cursor.com)