### PR TITLE
feat: add deterministic bounded bearings snapshots

### DIFF
--- a/.agents/skills/bearings/SKILL.md
+++ b/.agents/skills/bearings/SKILL.md
@@ -16,19 +16,20 @@ It never tears down a task, merges a PR, dispatches new work, or mutates any tas
 
 ## What it does
 
-1. **Gather live fleet state, cheaply and in this order.**
-   Read each source once and do not re-derive what a script already reports.
-   - `bin/fm-fleet-snapshot.sh --json` - the deterministic fleet source for backlog rows, task metadata, current state, endpoint facts, PR/report pointers, scout report paths, status-event hints, and secondmate return-channel guidance.
-     Its schema is owned by the script header; consume those structured fields before rereading raw fleet files.
-   - If the snapshot command is unavailable or its JSON is invalid, fall back to `data/backlog.md`, each `state/<id>.meta`, and each task's live state via `bin/fm-crew-state.sh <id>`.
-     Never infer current state from a raw `tail` of `state/<id>.status`: that log is an append-only wake-event history and its last line goes stale the moment a resolved gate lets a run resume, while `bin/fm-crew-state.sh` reconciles the authoritative run-step over the stale log line - which is exactly what a catch-up report needs.
-   - Open PRs awaiting the captain's merge, via `gh-axi` per repo touched by in-flight or recent tasks.
-     A PR-based ship task records `pr=` in `state/<id>.meta`; collect those repos, list their open PRs, and cross-reference each task's recorded PR.
-   - Recent scout deliverables at `data/<id>/report.md` and any planning docs the captain should pick up from.
-   - Pending human decisions (needs-decision findings), needed credentials or logins (such as an SSO re-auth), and date-gated queued items.
-     A queued item only becomes "next work" when its blocker is gone and its time/date gate has arrived; until then it stays queued with the reason.
+1. **Gather live fleet state with one deterministic command.**
+   Run `bin/fm-bearings-snapshot.sh` and read its compact output.
+   It is the single bounded, deterministic source for this report: it projects the canonical `bin/fm-fleet-snapshot.sh` down to the fields a catch-up read needs and renders TOON by default (add `--json` for the same model as JSON).
+   Do not hand-probe the snapshot schema and do not make ad-hoc `gh-axi`/`gh` calls to assemble fleet facts; this command already assembles them.
+   Its sections are `in_flight`, `decisions_open`, `landed`, `gates`, `reports`, `recorded_prs`, `unhealthy_endpoints` (only when non-empty), and `omitted` (the surfaces it deliberately dropped, each with the flag that reveals it).
+   The `decisions_open` set is the durable keyed open-decision set, so a decision the captain still owes never gets masked by a later unrelated event.
+   The default is LOCAL-ONLY and makes no network call; it surfaces already-recorded local PR URLs in `recorded_prs` and states in the `prs:` line that live checks were not requested.
+   When the captain asks for PRs (`/bearings include PRs`), run `bin/fm-bearings-snapshot.sh --include-prs` instead: that is the only path that does live open-PR discovery and checks, adding a `candidate_prs` section; a partial PR-fetch failure degrades gracefully and still returns the rest.
+   Opt into a dropped surface only when a specific read needs it (`--fields bodies|paths|actions|endpoints`, `--all-reports`, `--all-queued`).
+   If the command is unavailable, fall back to `bin/fm-fleet-snapshot.sh --json` and `bin/fm-crew-state.sh <id>`; never infer current state from a raw `tail` of `state/<id>.status`, which is append-only wake-event history whose last line goes stale.
+   A queued item under `gates` only becomes "next work" when its blocker is gone and its time/date gate has arrived; until then it stays queued with the reason.
 
 2. **Compose the report with these sections, matching the worked example's structure, tone, and level of detail.**
+   The gather step is deterministic; your judgment is scoped to the last mile only - ranking the command's facts by what matters right now and writing the scannable prose.
    The exemplar is `data/status-report-2026-07-06.md` in this home's `data/` when present; match its scannability, not a raw state dump.
    - **Title** - `# Bearings - <day> <YYYY-MM-DD>` (the exemplar used "Morning status" for a morning brief; use that phrasing when the captain specifically asks for a morning brief).
    - **TL;DR** - two or three sentences framing where things stand.

--- a/.agents/skills/bearings/SKILL.md
+++ b/.agents/skills/bearings/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bearings
-description: Generate a "pick up where I left off" status report from firstmate's live fleet state. Use when the captain invokes /bearings or asks for a bearings report, morning brief, status report, catch-up, "where did I leave off", or "what's in the works". Reads live fleet state cheaply (backlog, per-task crew state, open PRs, scout reports, pending decisions, date-gated queued work), composes a scannable dated report to data/status-report-<YYYY-MM-DD>.md, and surfaces a concise version in chat; it is read-mostly and must not tear down, merge, or mutate task state as a side effect of producing the brief.
+description: Generate a "pick up where I left off" status report from firstmate's live fleet state. Use when the captain invokes /bearings or asks for a bearings report, morning brief, status report, catch-up, "where did I leave off", or "what's in the works". Reads bounded local fleet state cheaply, optionally checks open PRs when requested, composes a scannable dated report to data/status-report-<YYYY-MM-DD>.md, and surfaces a concise version in chat; it is read-mostly and must not tear down, merge, or mutate task state as a side effect of producing the brief.
 user-invocable: true
 metadata:
   internal: true
@@ -18,13 +18,10 @@ It never tears down a task, merges a PR, dispatches new work, or mutates any tas
 
 1. **Gather live fleet state with one deterministic command.**
    Run `bin/fm-bearings-snapshot.sh` and read its compact output.
-   It is the single bounded, deterministic source for this report: it projects the canonical `bin/fm-fleet-snapshot.sh` down to the fields a catch-up read needs and renders TOON by default (add `--json` for the same model as JSON).
+   It is the single bounded, deterministic source for this report and renders TOON by default.
    Do not hand-probe the snapshot schema and do not make ad-hoc `gh-axi`/`gh` calls to assemble fleet facts; this command already assembles them.
-   Its sections are `in_flight`, `decisions_open`, `landed`, `gates`, `reports`, `recorded_prs`, `unhealthy_endpoints` (only when non-empty), and `omitted` (the surfaces it deliberately dropped, each with the flag that reveals it).
-   The `decisions_open` set is the durable keyed open-decision set, so a decision the captain still owes never gets masked by a later unrelated event.
-   The default is LOCAL-ONLY and makes no network call; it surfaces already-recorded local PR URLs in `recorded_prs` and states in the `prs:` line that live checks were not requested.
-   When the captain asks for PRs (`/bearings include PRs`), run `bin/fm-bearings-snapshot.sh --include-prs` instead: that is the only path that does live open-PR discovery and checks, adding a `candidate_prs` section; a partial PR-fetch failure degrades gracefully and still returns the rest.
-   Opt into a dropped surface only when a specific read needs it (`--fields bodies|paths|actions|endpoints`, `--all-reports`, `--all-queued`).
+   The command's header and `--help` output own its exact fields, bounds, opt-ins, and output contract.
+   When the captain asks to include PRs, use the command's live-PR opt-in; otherwise keep the default local-only read.
    If the command is unavailable, fall back to `bin/fm-fleet-snapshot.sh --json` and `bin/fm-crew-state.sh <id>`; never infer current state from a raw `tail` of `state/<id>.status`, which is append-only wake-event history whose last line goes stale.
    A queued item under `gates` only becomes "next work" when its blocker is gone and its time/date gate has arrived; until then it stays queued with the reason.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -740,7 +740,8 @@ If you scaffold without `FM_SECONDMATE_CHARTER`, replace the `{TASK}` placeholde
 Keep the charter focused on persistent responsibility, available project clones, escalation back to the main firstmate status file, and the idle-by-default contract: reconcile only its own in-flight work and then wait, never self-initiating a survey or audit.
 Preserve the requests-from-main-firstmate contract in the charter: marked requests return via status or a doc pointer, while unmarked direct captain messages stay conversational.
 Before seeding, launching, recovering, or handing backlog to a secondmate home, load `secondmate-provisioning`.
-The status-reporting protocol is intentionally sparse: crewmates append status only for supervisor-actionable phase changes or `needs-decision`/`blocked`/`paused`/`done`/`failed`, because every append wakes firstmate.
+The status-reporting protocol is intentionally sparse: crewmates append status only for supervisor-actionable phase changes, `needs-decision`/`blocked`/`paused`/`done`/`failed`, or the `resolved` line that closes a previously reported decision or blocker, because every append wakes firstmate.
+`bin/fm-classify-lib.sh` owns the keyed open/resolved status contract.
 For any generated brief that still contains `{TASK}`, replace it with a clear task description, acceptance criteria, and any constraints or context the crewmate needs before spawning or seeding.
 Adjust the other sections only when the task genuinely deviates from the standard ship-a-new-PR shape (e.g. fixing an existing external PR); the scaffold is the contract, not a suggestion.
 

--- a/bin/fm-bearings-snapshot.sh
+++ b/bin/fm-bearings-snapshot.sh
@@ -165,7 +165,8 @@ if [ "$INCLUDE_PRS" = 1 ]; then
 $(printf '%s' "$SNAP" | jq -r '.tasks[].pr.url // empty')
 EOF
     while IFS= read -r wt; do
-      [ -n "$wt" ] && [ -d "$wt" ] || continue
+      [ -n "$wt" ] || continue
+      [ -d "$wt" ] || continue
       u=$(git -C "$wt" remote get-url origin 2>/dev/null) || continue
       s=$(repo_slug "$u"); [ -n "$s" ] || continue
       case " $repos " in *" $s "*) : ;; *) repos="$repos $s" ;; esac

--- a/bin/fm-bearings-snapshot.sh
+++ b/bin/fm-bearings-snapshot.sh
@@ -87,6 +87,7 @@ Default fields: schema, home, generated, prs, in_flight{id,kind,state,doing},
 Opt-in surfaces: --fields bodies|paths|actions|endpoints, --all-in-flight,
   --all-decisions, --all-reports, --all-queued, --all-recorded-prs,
   --all-unhealthy, --all-pr-repos, --include-prs (adds candidate_prs).
+Raise FM_BEARINGS_PR_LIMIT to expand per-repository open-PR results.
 EOF
 }
 
@@ -131,6 +132,8 @@ PR_STATUS='not_requested (run: /bearings include PRs)'
 CANDIDATE_PRS='[]'
 PR_REPOS_TOTAL=0
 PR_REPOS_SHOWN=0
+PR_ROWS_CAPPED=0
+PR_ROWS_MIN_TOTAL=0
 
 # Parse owner/repo from an https or ssh GitHub remote/PR URL; empty if not GitHub.
 repo_slug() {  # <url>
@@ -173,15 +176,16 @@ $(printf '%s' "$SNAP" | jq -r '.tasks[] | select(.kind != "secondmate") | .paths
 EOF
 
     for repo in $repos; do PR_REPOS_TOTAL=$((PR_REPOS_TOTAL + 1)); done
-    nrepos=0; npr=0; nwarn=0; rows='[]'
+    nrepos=0; npr=0; nwarn=0; ncapped=0; rows='[]'
+    pr_fetch_limit=$((FM_BEARINGS_PR_LIMIT + 1))
     for repo in $repos; do
       if [ "$ALL_PR_REPOS" != 1 ] && [ "$nrepos" -ge "$FM_BEARINGS_PR_REPOS" ]; then break; fi
       nrepos=$((nrepos + 1))
-      out=$(gh_bounded pr list --repo "$repo" --state open --limit "$FM_BEARINGS_PR_LIMIT" \
+      out=$(gh_bounded pr list --repo "$repo" --state open --limit "$pr_fetch_limit" \
         --json number,title,url,headRefName,reviewDecision,mergeable,statusCheckRollup 2>/dev/null) \
         || { nwarn=$((nwarn + 1)); continue; }
       [ -n "$out" ] || out='[]'
-      repo_rows=$(printf '%s' "$out" | jq --arg repo "$repo" --argjson limit "$FM_BEARINGS_PR_LIMIT" '
+      repo_result=$(printf '%s' "$out" | jq --arg repo "$repo" --argjson limit "$FM_BEARINGS_PR_LIMIT" '
         [ .[] | {
           num:(.number|tostring),
           repo:$repo,
@@ -195,16 +199,27 @@ EOF
               elif any($c[]; (.conclusion // .state // "") as $s | ($s=="FAILURE" or $s=="ERROR" or $s=="TIMED_OUT" or $s=="CANCELLED" or $s=="ACTION_REQUIRED")) then "failing"
               elif any($c[]; ((.status // "") != "COMPLETED") and ((.state // "") != "SUCCESS")) then "pending"
               else "passing" end)
-        } ][:$limit]') || { nwarn=$((nwarn + 1)); continue; }
+        } ] as $rows | {returned:($rows | length), rows:$rows[:$limit]}') || { nwarn=$((nwarn + 1)); continue; }
+      returned=$(printf '%s' "$repo_result" | jq '.returned')
+      repo_rows=$(printf '%s' "$repo_result" | jq '.rows')
       cnt=$(printf '%s' "$repo_rows" | jq 'length')
+      [ "$returned" -gt "$FM_BEARINGS_PR_LIMIT" ] && ncapped=$((ncapped + 1))
       npr=$((npr + cnt))
       rows=$(jq -n --argjson a "$rows" --argjson b "$repo_rows" '$a + $b')
     done
     PR_REPOS_SHOWN=$nrepos
+    PR_ROWS_CAPPED=$ncapped
+    PR_ROWS_MIN_TOTAL=$((npr + ncapped))
     CANDIDATE_PRS=$rows
     warnnote=""
     [ "$nwarn" -gt 0 ] && warnnote="; ${nwarn} repo(s) unavailable"
-    PR_STATUS="checked (${nrepos} repos, ${npr} open${warnnote})"
+    cappednote=""
+    [ "$ncapped" -gt 0 ] && cappednote="; ${npr} shown, at least ${PR_ROWS_MIN_TOTAL} open; capped in ${ncapped} repo(s)"
+    if [ "$ncapped" -gt 0 ]; then
+      PR_STATUS="checked (${nrepos} repos${cappednote}${warnnote})"
+    else
+      PR_STATUS="checked (${nrepos} repos, ${npr} open${warnnote})"
+    fi
   fi
 fi
 
@@ -230,6 +245,8 @@ MODEL=$(printf '%s' "$SNAP" | jq \
   --argjson all_unhealthy "$ALL_UNHEALTHY" \
   --argjson pr_repos_total "$PR_REPOS_TOTAL" \
   --argjson pr_repos_shown "$PR_REPOS_SHOWN" \
+  --argjson pr_rows_capped "$PR_ROWS_CAPPED" \
+  --argjson pr_rows_min_total "$PR_ROWS_MIN_TOTAL" \
   --argjson candidate_prs "$CANDIDATE_PRS" '
   def trunc($n): if . == null then null else
     (tostring | gsub("\\s+"; " ") | if (length > $n) then (.[:$n] + "…") else . end) end;
@@ -300,6 +317,7 @@ MODEL=$(printf '%s' "$SNAP" | jq \
         (if $all_recorded_prs == 0 and ($recorded_prs_all | length) > $recorded_prs_n then {surface:("recorded_prs showing \($recorded_prs_n) of \($recorded_prs_all | length)"), reveal:"--all-recorded-prs"} else empty end),
         (if $all_unhealthy == 0 and ($unhealthy_all | length) > $unhealthy_n then {surface:("unhealthy_endpoints showing \($unhealthy_n) of \($unhealthy_all | length)"), reveal:"--all-unhealthy"} else empty end),
         (if $include_prs == 1 and $pr_repos_total > $pr_repos_shown then {surface:("PR repositories showing \($pr_repos_shown) of \($pr_repos_total)"), reveal:"--all-pr-repos"} else empty end),
+        (if $include_prs == 1 and $pr_rows_capped > 0 then {surface:("candidate_prs showing \($candidate_prs | length) of at least \($pr_rows_min_total); capped in \($pr_rows_capped) repo(s)"), reveal:"raise FM_BEARINGS_PR_LIMIT"} else empty end),
         (if $include_prs == 1 then empty else {surface:"live PR discovery + checks", reveal:"--include-prs"} end) ]) }
 ') || { echo "fm-bearings-snapshot: projection failed" >&2; exit 1; }
 

--- a/bin/fm-bearings-snapshot.sh
+++ b/bin/fm-bearings-snapshot.sh
@@ -1,0 +1,271 @@
+#!/usr/bin/env bash
+# fm-bearings-snapshot.sh - compact, bounded, TOON-by-default bearings projection.
+#
+# A thin wrapper OVER the canonical bin/fm-fleet-snapshot.sh. It does not parse
+# fleet state itself: it shells out to `fm-fleet-snapshot.sh --json`, projects that
+# complete structured contract down to the small set of fields a "pick up where I
+# left off" read needs, and renders TOON at the output boundary. The internal data
+# model stays JSON (`--json` prints it verbatim); TOON is the default agent-facing
+# format per the AXI standard, and TOON/JSON are parity representations of the same
+# projected model. The projection is view-specific: it DROPS fields from the bearings
+# output, it never removes them from - or otherwise weakens - the canonical snapshot,
+# which stays complete.
+#
+# LOCAL-ONLY by default: a normal invocation makes ZERO GitHub/network/auth calls.
+# It MAY surface PR URLs already recorded locally in task meta (recorded_prs), but it
+# performs no live discovery or checks. Live PR discovery/checks happen ONLY under
+# --include-prs, which is the sole path that touches the network; all gh coupling
+# lives in that branch and never in the canonical snapshot. The default output states
+# explicitly (the prs: line and the omitted[] surfaces) what was not requested, so an
+# absence is never ambiguous.
+#
+# The durable keyed unresolved-decision model lives in the canonical layer
+# (fm-classify-lib.sh's status_open_decisions, surfaced as hints.open_decisions):
+# this wrapper only aggregates that already-correct open set. A later unrelated done
+# can never mask a still-open captain decision.
+#
+# Flags:
+#   (default)        compact projection, TOON, local-only
+#   --json           the same projected model as JSON (machine/debug; parity form)
+#   --include-prs    ALSO do live open-PR discovery + checks (the only network path)
+#   --fields <list>  opt in to dropped surfaces: bodies,paths,actions,endpoints
+#   --all-reports    include the full scout-report inventory (default: relevant only)
+#   --all-queued     include superseded/held queued items (default: dropped)
+#   -h,--help        usage
+#
+# Output contract: `fm-bearings.v1`. Read-only; no locks, no mutation, no reports.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FLEET="$SCRIPT_DIR/fm-fleet-snapshot.sh"
+
+# Bounds (overridable for tests / large fleets).
+FM_BEARINGS_LANDED=${FM_BEARINGS_LANDED:-6}
+FM_BEARINGS_PR_LIMIT=${FM_BEARINGS_PR_LIMIT:-20}
+FM_BEARINGS_PR_TIMEOUT=${FM_BEARINGS_PR_TIMEOUT:-20}
+
+usage() {
+  cat <<'EOF'
+usage: fm-bearings-snapshot.sh [--json] [--include-prs] [--fields <list>]
+                               [--all-reports] [--all-queued]
+
+Compact bearings projection over fm-fleet-snapshot.sh. TOON by default.
+Default is LOCAL-ONLY (no network); --include-prs is the only path that fetches.
+
+Default fields: schema, home, generated, prs, in_flight{id,kind,state,doing},
+  decisions_open{id,key,verb,summary}, landed{id,what,artifact},
+  gates{id,title,blocked_by,reason}, reports{id,path}, recorded_prs{id,url},
+  unhealthy_endpoints{...} (only when non-empty), omitted{surface,reveal}.
+Opt-in surfaces: --fields bodies|paths|actions|endpoints, --all-reports,
+  --all-queued, --include-prs (adds candidate_prs).
+EOF
+}
+
+FORMAT=toon
+INCLUDE_PRS=0
+ALL_REPORTS=0
+ALL_QUEUED=0
+FIELDS=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --json) FORMAT=json ;;
+    --include-prs) INCLUDE_PRS=1 ;;
+    --all-reports) ALL_REPORTS=1 ;;
+    --all-queued) ALL_QUEUED=1 ;;
+    --fields) shift; FIELDS=${1:-} ;;
+    --fields=*) FIELDS=${1#--fields=} ;;
+    -h|--help) usage; exit 0 ;;
+    *) usage >&2; exit 2 ;;
+  esac
+  shift
+done
+
+command -v jq >/dev/null 2>&1 || { echo "fm-bearings-snapshot: jq not found" >&2; exit 1; }
+
+SNAP=$("$FLEET" --json) || exit $?
+HOME_LABEL=$(printf '%s' "$SNAP" | jq -r '.fm_home | split("/") | (.[-2:] | join("/"))')
+NOW=${FM_BEARINGS_NOW:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}
+
+# --- optional live PR enrichment (the ONLY network path) --------------------
+PR_STATUS='not_requested (run: /bearings include PRs)'
+CANDIDATE_PRS='[]'
+
+# Parse owner/repo from an https or ssh GitHub remote/PR URL; empty if not GitHub.
+repo_slug() {  # <url>
+  printf '%s' "$1" | sed -n 's#.*github\.com[:/]\([^/]*/[^/]*\)#\1#p' | sed 's#\.git$##; s#/pull/.*$##; s#/$##'
+}
+
+# Bounded gh call; prints stdout, non-zero on timeout/failure. gh only.
+gh_bounded() {  # <args...>
+  if command -v timeout >/dev/null 2>&1; then
+    GH_PROMPT_DISABLED=1 GH_NO_UPDATE_NOTIFIER=1 timeout "$FM_BEARINGS_PR_TIMEOUT" gh "$@"
+  elif command -v gtimeout >/dev/null 2>&1; then
+    GH_PROMPT_DISABLED=1 GH_NO_UPDATE_NOTIFIER=1 gtimeout "$FM_BEARINGS_PR_TIMEOUT" gh "$@"
+  else
+    GH_PROMPT_DISABLED=1 GH_NO_UPDATE_NOTIFIER=1 gh "$@"
+  fi
+}
+
+if [ "$INCLUDE_PRS" = 1 ]; then
+  if ! command -v gh >/dev/null 2>&1; then
+    PR_STATUS='unavailable (gh not found)'
+  else
+    # Candidate repos: recorded pr= URLs plus live worktree origins. Deduped.
+    repos=""
+    while IFS= read -r u; do
+      [ -n "$u" ] || continue
+      s=$(repo_slug "$u"); [ -n "$s" ] || continue
+      case " $repos " in *" $s "*) : ;; *) repos="$repos $s" ;; esac
+    done <<EOF
+$(printf '%s' "$SNAP" | jq -r '.tasks[].pr.url // empty')
+EOF
+    while IFS= read -r wt; do
+      [ -n "$wt" ] && [ -d "$wt" ] || continue
+      u=$(git -C "$wt" remote get-url origin 2>/dev/null) || continue
+      s=$(repo_slug "$u"); [ -n "$s" ] || continue
+      case " $repos " in *" $s "*) : ;; *) repos="$repos $s" ;; esac
+    done <<EOF
+$(printf '%s' "$SNAP" | jq -r '.tasks[] | select(.kind != "secondmate") | .paths.worktree.path // empty')
+EOF
+
+    nrepos=0; npr=0; nwarn=0; rows='[]'
+    for repo in $repos; do
+      nrepos=$((nrepos + 1))
+      out=$(gh_bounded pr list --repo "$repo" --state open --limit "$FM_BEARINGS_PR_LIMIT" \
+        --json number,title,url,headRefName,reviewDecision,mergeable,statusCheckRollup 2>/dev/null) \
+        || { nwarn=$((nwarn + 1)); continue; }
+      [ -n "$out" ] || out='[]'
+      repo_rows=$(printf '%s' "$out" | jq --arg repo "$repo" '
+        [ .[] | {
+          num:(.number|tostring),
+          repo:$repo,
+          task:(if (.headRefName // "" | startswith("fm/")) then (.headRefName | ltrimstr("fm/")) else "-" end),
+          url:(.url // "-"),
+          review:(.reviewDecision // "none"),
+          mergeable:(.mergeable // "UNKNOWN"),
+          checks:(
+            (.statusCheckRollup // []) as $c
+            | if ($c|length) == 0 then "none"
+              elif any($c[]; (.conclusion // .state // "") as $s | ($s=="FAILURE" or $s=="ERROR" or $s=="TIMED_OUT" or $s=="CANCELLED" or $s=="ACTION_REQUIRED")) then "failing"
+              elif any($c[]; ((.status // "") != "COMPLETED") and ((.state // "") != "SUCCESS")) then "pending"
+              else "passing" end)
+        } ]') || { nwarn=$((nwarn + 1)); continue; }
+      cnt=$(printf '%s' "$repo_rows" | jq 'length')
+      npr=$((npr + cnt))
+      rows=$(jq -n --argjson a "$rows" --argjson b "$repo_rows" '$a + $b')
+    done
+    CANDIDATE_PRS=$rows
+    warnnote=""
+    [ "$nwarn" -gt 0 ] && warnnote="; ${nwarn} repo(s) unavailable"
+    PR_STATUS="checked (${nrepos} repos, ${npr} open${warnnote})"
+  fi
+fi
+
+# --- projection: canonical snapshot -> fm-bearings.v1 model (JSON) ----------
+MODEL=$(printf '%s' "$SNAP" | jq \
+  --arg home "$HOME_LABEL" \
+  --arg now "$NOW" \
+  --arg prs "$PR_STATUS" \
+  --arg fields "$FIELDS" \
+  --argjson landed_n "$FM_BEARINGS_LANDED" \
+  --argjson include_prs "$INCLUDE_PRS" \
+  --argjson all_reports "$ALL_REPORTS" \
+  --argjson all_queued "$ALL_QUEUED" \
+  --argjson candidate_prs "$CANDIDATE_PRS" '
+  def trunc($n): if . == null then null else
+    (tostring | gsub("\\s+"; " ") | if (length > $n) then (.[:$n] + "…") else . end) end;
+  ($fields | split(",") | map(gsub("^\\s+|\\s+$"; "")) | map(select(. != ""))) as $fl
+  | (($fl | index("bodies")) != null) as $f_bodies
+  | (($fl | index("paths")) != null) as $f_paths
+  | (($fl | index("actions")) != null) as $f_actions
+  | (($fl | index("endpoints")) != null) as $f_endpoints
+  | ([ .backlog.records[] | select(.state == "done" and .structured) ][:$landed_n]) as $done
+  | ($done | map(.id)) as $done_ids
+  | (.tasks | map(.id)) as $live_ids
+  | ($live_ids + $done_ids) as $rel_ids
+  | ([ .tasks[]
+       | select(.endpoint.exists == false or .endpoint.agent_alive == "dead")
+       | {id, backend, target:(.endpoint.target // "-"), exists:.endpoint.exists, agent:.endpoint.agent_alive} ]) as $unhealthy
+  | . as $snap
+  | {
+      schema: "fm-bearings.v1",
+      home: $home,
+      generated: $now,
+      prs: $prs,
+      in_flight: [ .tasks[] | {
+        id, kind,
+        state: .current_state.state,
+        doing: ((.current_state.detail // "") as $d
+                | (if $d != "" then $d else (.hints.last_event_text // "") end) | trunc(90))
+      } ],
+      decisions_open: [ .tasks[] as $t | ($t.hints.open_decisions // [])[]
+                        | {id:$t.id, key, verb, summary:(.summary | trunc(90))} ],
+      landed: ($done | map({id, what:(.title | trunc(70)),
+                            artifact:(.pr_url // .report_path // .local_note // "-")})),
+      gates: [ .backlog.records[]
+               | select(.state == "queued" and .structured)
+               | select(($all_queued == 1)
+                        or (((.body_excerpt // "") | test("SUPERSEDED|NOT REQUIRED|NOT-REQUIRED|DEFERRED"; "i")) | not))
+               | {id, title:(.title | trunc(60)), blocked_by:(.blocked_by // "-"),
+                  reason:((.blocked_reason // "-") | trunc(40))} ],
+      reports: [ .scout_reports[]
+                 | . as $r
+                 | select(($all_reports == 1) or (($rel_ids | index($r.id)) != null))
+                 | {id, path} ],
+      recorded_prs: [ .tasks[] | select(.pr.url != null and .pr.source == "meta") | {id, url:.pr.url} ]
+    }
+  | . + (if ($unhealthy | length) > 0 then {unhealthy_endpoints:$unhealthy} else {} end)
+  | . + (if $include_prs == 1 then {candidate_prs:$candidate_prs} else {} end)
+  | . + (if $f_bodies then {bodies:[ $snap.backlog.records[] | select(.structured and (.state == "queued" or .state == "done")) | {id, body:((.body_excerpt // .raw // "-") | trunc(200))} ]} else {} end)
+  | . + (if $f_paths then {paths:[ $snap.tasks[] | {id, worktree:(.paths.worktree.path // "-"), home:(.paths.home.path // "-"), status:.paths.status_log.path, report:.paths.report.path} ]} else {} end)
+  | . + (if $f_actions then {actions:[ $snap.tasks[] | {id, watch:(.actions.watch // .actions.send // "-"), steer:(.actions.steer // .actions.send // "-")} ]} else {} end)
+  | . + (if $f_endpoints then {endpoints:[ $snap.tasks[] | {id, backend, target:(.endpoint.target // "-"), exists:.endpoint.exists, agent:.endpoint.agent_alive} ]} else {} end)
+  | . + {omitted: (
+      [ (if $f_bodies then empty else {surface:"backlog item bodies", reveal:"--fields bodies"} end),
+        (if $f_paths then empty else {surface:"task paths", reveal:"--fields paths"} end),
+        (if $f_actions then empty else {surface:"watch/steer actions", reveal:"--fields actions"} end),
+        (if $f_endpoints then empty else {surface:"healthy endpoint detail", reveal:"--fields endpoints"} end),
+        (if $all_reports == 1 then empty else {surface:"full scout-report inventory", reveal:"--all-reports"} end),
+        (if $all_queued == 1 then empty else {surface:"superseded/held queued items", reveal:"--all-queued"} end),
+        (if $include_prs == 1 then empty else {surface:"live PR discovery + checks", reveal:"--include-prs"} end) ]) }
+')
+
+if [ "$FORMAT" = json ]; then
+  printf '%s\n' "$MODEL"
+  exit 0
+fi
+
+# --- TOON renderer (output boundary; parity with the JSON model) ------------
+# The model is a flat object of scalar fields plus arrays of uniform scalar
+# objects, so the encoder only needs object scalars, the tabular array form
+# (key[N]{fields}: + comma rows at +2 indent), and the empty-array form (key: []),
+# per the TOON spec. Quoting follows the spec exactly.
+printf '%s\n' "$MODEL" | jq -r '
+  def q:
+    tostring
+    | if (. == "")
+        or test("^\\s|\\s$")
+        or (. == "true" or . == "false" or . == "null")
+        or test("^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$")
+        or test("[:\"\\\\\\[\\]{},]")
+        or test("[[:cntrl:]]")
+        or test("^-")
+      then "\"" + (gsub("\\\\"; "\\\\") | gsub("\""; "\\\"") | gsub("\n"; "\\n") | gsub("\r"; "\\r") | gsub("\t"; "\\t")) + "\""
+      else . end;
+  def scal:
+    if . == null then "null"
+    elif type == "boolean" then (if . then "true" else "false" end)
+    elif type == "number" then tostring
+    else q end;
+  def emit($k; $v):
+    if ($v | type) == "array" then
+      if ($v | length) == 0 then "\($k): []"
+      else
+        ($v[0] | keys_unsorted) as $ks
+        | ( "\($k)[\($v | length)]{\($ks | map(q) | join(","))}:",
+            ($v[] as $row | "  " + ([ $ks[] as $kk | ($row[$kk] | scal) ] | join(","))) )
+      end
+    else "\($k): " + ($v | scal)
+    end;
+  [ to_entries[] | emit(.key; .value) ] | join("\n")
+'

--- a/bin/fm-bearings-snapshot.sh
+++ b/bin/fm-bearings-snapshot.sh
@@ -43,6 +43,7 @@ FLEET="$SCRIPT_DIR/fm-fleet-snapshot.sh"
 FM_BEARINGS_LANDED=${FM_BEARINGS_LANDED:-6}
 FM_BEARINGS_PR_LIMIT=${FM_BEARINGS_PR_LIMIT:-20}
 FM_BEARINGS_PR_TIMEOUT=${FM_BEARINGS_PR_TIMEOUT:-20}
+case "$FM_BEARINGS_PR_TIMEOUT" in ''|*[!0-9]*|0) FM_BEARINGS_PR_TIMEOUT=20 ;; esac
 
 usage() {
   cat <<'EOF'
@@ -101,8 +102,10 @@ gh_bounded() {  # <args...>
     GH_PROMPT_DISABLED=1 GH_NO_UPDATE_NOTIFIER=1 timeout "$FM_BEARINGS_PR_TIMEOUT" gh "$@"
   elif command -v gtimeout >/dev/null 2>&1; then
     GH_PROMPT_DISABLED=1 GH_NO_UPDATE_NOTIFIER=1 gtimeout "$FM_BEARINGS_PR_TIMEOUT" gh "$@"
+  elif command -v perl >/dev/null 2>&1; then
+    GH_PROMPT_DISABLED=1 GH_NO_UPDATE_NOTIFIER=1 perl -e 'my $t = shift; my $pid = fork; die "fork failed" unless defined $pid; if (!$pid) { setpgrp(0, 0); exec @ARGV } local $SIG{ALRM} = sub { kill "TERM", -$pid; select undef, undef, undef, 0.2; kill "KILL", -$pid; exit 124 }; alarm $t; waitpid $pid, 0; exit($? >> 8)' "$FM_BEARINGS_PR_TIMEOUT" gh "$@"
   else
-    GH_PROMPT_DISABLED=1 GH_NO_UPDATE_NOTIFIER=1 gh "$@"
+    return 124
   fi
 }
 

--- a/bin/fm-bearings-snapshot.sh
+++ b/bin/fm-bearings-snapshot.sh
@@ -19,10 +19,8 @@
 # explicitly (the prs: line and the omitted[] surfaces) what was not requested, so an
 # absence is never ambiguous.
 #
-# The durable keyed unresolved-decision model lives in the canonical layer
-# (fm-classify-lib.sh's status_open_decisions, surfaced as hints.open_decisions):
-# this wrapper only aggregates that already-correct open set. A later unrelated done
-# can never mask a still-open captain decision.
+# This wrapper consumes the canonical snapshot's hints.open_decisions field.
+# fm-classify-lib.sh owns the durable keyed-decision contract.
 #
 # Flags:
 #   (default)        compact projection, TOON, local-only

--- a/bin/fm-bearings-snapshot.sh
+++ b/bin/fm-bearings-snapshot.sh
@@ -29,8 +29,13 @@
 #   --json           the same projected model as JSON (machine/debug; parity form)
 #   --include-prs    ALSO do live open-PR discovery + checks (the only network path)
 #   --fields <list>  opt in to dropped surfaces: bodies,paths,actions,endpoints
+#   --all-in-flight  include every in-flight task
+#   --all-decisions  include every open decision
 #   --all-reports    include the full scout-report inventory (default: relevant only)
 #   --all-queued     include superseded/held queued items (default: dropped)
+#   --all-recorded-prs include every locally recorded PR
+#   --all-unhealthy  include every unhealthy endpoint
+#   --all-pr-repos   query every discovered repository under --include-prs
 #   -h,--help        usage
 #
 # Output contract: `fm-bearings.v1`. Read-only; no locks, no mutation, no reports.
@@ -41,14 +46,36 @@ FLEET="$SCRIPT_DIR/fm-fleet-snapshot.sh"
 
 # Bounds (overridable for tests / large fleets).
 FM_BEARINGS_LANDED=${FM_BEARINGS_LANDED:-6}
+FM_BEARINGS_IN_FLIGHT=${FM_BEARINGS_IN_FLIGHT:-20}
+FM_BEARINGS_DECISIONS=${FM_BEARINGS_DECISIONS:-20}
+FM_BEARINGS_GATES=${FM_BEARINGS_GATES:-20}
+FM_BEARINGS_REPORTS=${FM_BEARINGS_REPORTS:-20}
+FM_BEARINGS_RECORDED_PRS=${FM_BEARINGS_RECORDED_PRS:-20}
+FM_BEARINGS_UNHEALTHY=${FM_BEARINGS_UNHEALTHY:-20}
+FM_BEARINGS_PR_REPOS=${FM_BEARINGS_PR_REPOS:-10}
 FM_BEARINGS_PR_LIMIT=${FM_BEARINGS_PR_LIMIT:-20}
 FM_BEARINGS_PR_TIMEOUT=${FM_BEARINGS_PR_TIMEOUT:-20}
 case "$FM_BEARINGS_PR_TIMEOUT" in ''|*[!0-9]*|0) FM_BEARINGS_PR_TIMEOUT=20 ;; esac
+validate_bound() {  # <name> <value>
+  case "$2" in ''|*[!0-9]*|0) echo "fm-bearings-snapshot: $1 must be a positive integer" >&2; exit 2 ;; esac
+}
+validate_bound FM_BEARINGS_LANDED "$FM_BEARINGS_LANDED"
+validate_bound FM_BEARINGS_IN_FLIGHT "$FM_BEARINGS_IN_FLIGHT"
+validate_bound FM_BEARINGS_DECISIONS "$FM_BEARINGS_DECISIONS"
+validate_bound FM_BEARINGS_GATES "$FM_BEARINGS_GATES"
+validate_bound FM_BEARINGS_REPORTS "$FM_BEARINGS_REPORTS"
+validate_bound FM_BEARINGS_RECORDED_PRS "$FM_BEARINGS_RECORDED_PRS"
+validate_bound FM_BEARINGS_UNHEALTHY "$FM_BEARINGS_UNHEALTHY"
+validate_bound FM_BEARINGS_PR_REPOS "$FM_BEARINGS_PR_REPOS"
+validate_bound FM_BEARINGS_PR_LIMIT "$FM_BEARINGS_PR_LIMIT"
 
 usage() {
   cat <<'EOF'
 usage: fm-bearings-snapshot.sh [--json] [--include-prs] [--fields <list>]
+                               [--all-in-flight] [--all-decisions]
                                [--all-reports] [--all-queued]
+                               [--all-recorded-prs] [--all-unhealthy]
+                               [--all-pr-repos]
 
 Compact bearings projection over fm-fleet-snapshot.sh. TOON by default.
 Default is LOCAL-ONLY (no network); --include-prs is the only path that fetches.
@@ -57,8 +84,9 @@ Default fields: schema, home, generated, prs, in_flight{id,kind,state,doing},
   decisions_open{id,key,verb,summary}, landed{id,what,artifact},
   gates{id,title,blocked_by,reason}, reports{id,path}, recorded_prs{id,url},
   unhealthy_endpoints{...} (only when non-empty), omitted{surface,reveal}.
-Opt-in surfaces: --fields bodies|paths|actions|endpoints, --all-reports,
-  --all-queued, --include-prs (adds candidate_prs).
+Opt-in surfaces: --fields bodies|paths|actions|endpoints, --all-in-flight,
+  --all-decisions, --all-reports, --all-queued, --all-recorded-prs,
+  --all-unhealthy, --all-pr-repos, --include-prs (adds candidate_prs).
 EOF
 }
 
@@ -66,6 +94,11 @@ FORMAT=toon
 INCLUDE_PRS=0
 ALL_REPORTS=0
 ALL_QUEUED=0
+ALL_IN_FLIGHT=0
+ALL_DECISIONS=0
+ALL_RECORDED_PRS=0
+ALL_UNHEALTHY=0
+ALL_PR_REPOS=0
 FIELDS=""
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -73,6 +106,11 @@ while [ $# -gt 0 ]; do
     --include-prs) INCLUDE_PRS=1 ;;
     --all-reports) ALL_REPORTS=1 ;;
     --all-queued) ALL_QUEUED=1 ;;
+    --all-in-flight) ALL_IN_FLIGHT=1 ;;
+    --all-decisions) ALL_DECISIONS=1 ;;
+    --all-recorded-prs) ALL_RECORDED_PRS=1 ;;
+    --all-unhealthy) ALL_UNHEALTHY=1 ;;
+    --all-pr-repos) ALL_PR_REPOS=1 ;;
     --fields) shift; FIELDS=${1:-} ;;
     --fields=*) FIELDS=${1#--fields=} ;;
     -h|--help) usage; exit 0 ;;
@@ -84,12 +122,15 @@ done
 command -v jq >/dev/null 2>&1 || { echo "fm-bearings-snapshot: jq not found" >&2; exit 1; }
 
 SNAP=$("$FLEET" --json) || exit $?
-HOME_LABEL=$(printf '%s' "$SNAP" | jq -r '.fm_home | split("/") | (.[-2:] | join("/"))')
+HOME_LABEL=$(printf '%s' "$SNAP" | jq -er '.fm_home | strings | split("/") | (.[-2:] | join("/"))') \
+  || { echo "fm-bearings-snapshot: invalid canonical snapshot" >&2; exit 1; }
 NOW=${FM_BEARINGS_NOW:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}
 
 # --- optional live PR enrichment (the ONLY network path) --------------------
 PR_STATUS='not_requested (run: /bearings include PRs)'
 CANDIDATE_PRS='[]'
+PR_REPOS_TOTAL=0
+PR_REPOS_SHOWN=0
 
 # Parse owner/repo from an https or ssh GitHub remote/PR URL; empty if not GitHub.
 repo_slug() {  # <url>
@@ -131,14 +172,16 @@ EOF
 $(printf '%s' "$SNAP" | jq -r '.tasks[] | select(.kind != "secondmate") | .paths.worktree.path // empty')
 EOF
 
+    for repo in $repos; do PR_REPOS_TOTAL=$((PR_REPOS_TOTAL + 1)); done
     nrepos=0; npr=0; nwarn=0; rows='[]'
     for repo in $repos; do
+      if [ "$ALL_PR_REPOS" != 1 ] && [ "$nrepos" -ge "$FM_BEARINGS_PR_REPOS" ]; then break; fi
       nrepos=$((nrepos + 1))
       out=$(gh_bounded pr list --repo "$repo" --state open --limit "$FM_BEARINGS_PR_LIMIT" \
         --json number,title,url,headRefName,reviewDecision,mergeable,statusCheckRollup 2>/dev/null) \
         || { nwarn=$((nwarn + 1)); continue; }
       [ -n "$out" ] || out='[]'
-      repo_rows=$(printf '%s' "$out" | jq --arg repo "$repo" '
+      repo_rows=$(printf '%s' "$out" | jq --arg repo "$repo" --argjson limit "$FM_BEARINGS_PR_LIMIT" '
         [ .[] | {
           num:(.number|tostring),
           repo:$repo,
@@ -152,11 +195,12 @@ EOF
               elif any($c[]; (.conclusion // .state // "") as $s | ($s=="FAILURE" or $s=="ERROR" or $s=="TIMED_OUT" or $s=="CANCELLED" or $s=="ACTION_REQUIRED")) then "failing"
               elif any($c[]; ((.status // "") != "COMPLETED") and ((.state // "") != "SUCCESS")) then "pending"
               else "passing" end)
-        } ]') || { nwarn=$((nwarn + 1)); continue; }
+        } ][:$limit]') || { nwarn=$((nwarn + 1)); continue; }
       cnt=$(printf '%s' "$repo_rows" | jq 'length')
       npr=$((npr + cnt))
       rows=$(jq -n --argjson a "$rows" --argjson b "$repo_rows" '$a + $b')
     done
+    PR_REPOS_SHOWN=$nrepos
     CANDIDATE_PRS=$rows
     warnnote=""
     [ "$nwarn" -gt 0 ] && warnnote="; ${nwarn} repo(s) unavailable"
@@ -171,9 +215,21 @@ MODEL=$(printf '%s' "$SNAP" | jq \
   --arg prs "$PR_STATUS" \
   --arg fields "$FIELDS" \
   --argjson landed_n "$FM_BEARINGS_LANDED" \
+  --argjson in_flight_n "$FM_BEARINGS_IN_FLIGHT" \
+  --argjson decisions_n "$FM_BEARINGS_DECISIONS" \
+  --argjson gates_n "$FM_BEARINGS_GATES" \
+  --argjson reports_n "$FM_BEARINGS_REPORTS" \
+  --argjson recorded_prs_n "$FM_BEARINGS_RECORDED_PRS" \
+  --argjson unhealthy_n "$FM_BEARINGS_UNHEALTHY" \
   --argjson include_prs "$INCLUDE_PRS" \
+  --argjson all_in_flight "$ALL_IN_FLIGHT" \
+  --argjson all_decisions "$ALL_DECISIONS" \
   --argjson all_reports "$ALL_REPORTS" \
   --argjson all_queued "$ALL_QUEUED" \
+  --argjson all_recorded_prs "$ALL_RECORDED_PRS" \
+  --argjson all_unhealthy "$ALL_UNHEALTHY" \
+  --argjson pr_repos_total "$PR_REPOS_TOTAL" \
+  --argjson pr_repos_shown "$PR_REPOS_SHOWN" \
   --argjson candidate_prs "$CANDIDATE_PRS" '
   def trunc($n): if . == null then null else
     (tostring | gsub("\\s+"; " ") | if (length > $n) then (.[:$n] + "…") else . end) end;
@@ -188,36 +244,43 @@ MODEL=$(printf '%s' "$SNAP" | jq \
   | ($live_ids + $done_ids) as $rel_ids
   | ([ .tasks[]
        | select(.endpoint.exists == false or .endpoint.agent_alive == "dead")
-       | {id, backend, target:(.endpoint.target // "-"), exists:.endpoint.exists, agent:.endpoint.agent_alive} ]) as $unhealthy
+       | {id, backend, target:(.endpoint.target // "-"), exists:.endpoint.exists, agent:.endpoint.agent_alive} ]) as $unhealthy_all
+  | ([ .tasks[] | {
+        id, kind,
+        state: .current_state.state,
+        doing: ((.current_state.detail // "") as $d
+                | (if $d != "" then $d else (.hints.last_event_text // "") end) | trunc(90))
+      } ]) as $in_flight_all
+  | ([ .tasks[] as $t | ($t.hints.open_decisions // [])[]
+       | {id:$t.id, key, verb, summary:(.summary | trunc(90))} ]) as $decisions_all
+  | ([ .backlog.records[]
+       | select(.state == "queued" and .structured)
+       | select(($all_queued == 1)
+                or (((.body_excerpt // "") | test("SUPERSEDED|NOT REQUIRED|NOT-REQUIRED|DEFERRED"; "i")) | not))
+       | {id, title:(.title | trunc(60)), blocked_by:(.blocked_by // "-"),
+          reason:((.blocked_reason // "-") | trunc(40))} ]) as $gates_all
+  | ([ .scout_reports[]
+       | . as $r
+       | select(($all_reports == 1) or (($rel_ids | index($r.id)) != null))
+       | {id, path} ]) as $reports_all
+  | ([ .tasks[] | select(.pr.url != null and .pr.source == "meta") | {id, url:.pr.url} ]) as $recorded_prs_all
   | . as $snap
   | {
       schema: "fm-bearings.v1",
       home: $home,
       generated: $now,
       prs: $prs,
-      in_flight: [ .tasks[] | {
-        id, kind,
-        state: .current_state.state,
-        doing: ((.current_state.detail // "") as $d
-                | (if $d != "" then $d else (.hints.last_event_text // "") end) | trunc(90))
-      } ],
-      decisions_open: [ .tasks[] as $t | ($t.hints.open_decisions // [])[]
-                        | {id:$t.id, key, verb, summary:(.summary | trunc(90))} ],
+      in_flight: (if $all_in_flight == 1 then $in_flight_all else $in_flight_all[:$in_flight_n] end),
+      decisions_open: (if $all_decisions == 1 then $decisions_all else $decisions_all[:$decisions_n] end),
       landed: ($done | map({id, what:(.title | trunc(70)),
                             artifact:(.pr_url // .report_path // .local_note // "-")})),
-      gates: [ .backlog.records[]
-               | select(.state == "queued" and .structured)
-               | select(($all_queued == 1)
-                        or (((.body_excerpt // "") | test("SUPERSEDED|NOT REQUIRED|NOT-REQUIRED|DEFERRED"; "i")) | not))
-               | {id, title:(.title | trunc(60)), blocked_by:(.blocked_by // "-"),
-                  reason:((.blocked_reason // "-") | trunc(40))} ],
-      reports: [ .scout_reports[]
-                 | . as $r
-                 | select(($all_reports == 1) or (($rel_ids | index($r.id)) != null))
-                 | {id, path} ],
-      recorded_prs: [ .tasks[] | select(.pr.url != null and .pr.source == "meta") | {id, url:.pr.url} ]
+      gates: (if $all_queued == 1 then $gates_all else $gates_all[:$gates_n] end),
+      reports: (if $all_reports == 1 then $reports_all else $reports_all[:$reports_n] end),
+      recorded_prs: (if $all_recorded_prs == 1 then $recorded_prs_all else $recorded_prs_all[:$recorded_prs_n] end)
     }
-  | . + (if ($unhealthy | length) > 0 then {unhealthy_endpoints:$unhealthy} else {} end)
+  | . + (if ($unhealthy_all | length) > 0 then
+           {unhealthy_endpoints:(if $all_unhealthy == 1 then $unhealthy_all else $unhealthy_all[:$unhealthy_n] end)}
+         else {} end)
   | . + (if $include_prs == 1 then {candidate_prs:$candidate_prs} else {} end)
   | . + (if $f_bodies then {bodies:[ $snap.backlog.records[] | select(.structured and (.state == "queued" or .state == "done")) | {id, body:((.body_excerpt // .raw // "-") | trunc(200))} ]} else {} end)
   | . + (if $f_paths then {paths:[ $snap.tasks[] | {id, worktree:(.paths.worktree.path // "-"), home:(.paths.home.path // "-"), status:.paths.status_log.path, report:.paths.report.path} ]} else {} end)
@@ -230,8 +293,15 @@ MODEL=$(printf '%s' "$SNAP" | jq \
         (if $f_endpoints then empty else {surface:"healthy endpoint detail", reveal:"--fields endpoints"} end),
         (if $all_reports == 1 then empty else {surface:"full scout-report inventory", reveal:"--all-reports"} end),
         (if $all_queued == 1 then empty else {surface:"superseded/held queued items", reveal:"--all-queued"} end),
+        (if $all_in_flight == 0 and ($in_flight_all | length) > $in_flight_n then {surface:("in_flight showing \($in_flight_n) of \($in_flight_all | length)"), reveal:"--all-in-flight"} else empty end),
+        (if $all_decisions == 0 and ($decisions_all | length) > $decisions_n then {surface:("decisions_open showing \($decisions_n) of \($decisions_all | length)"), reveal:"--all-decisions"} else empty end),
+        (if $all_queued == 0 and ($gates_all | length) > $gates_n then {surface:("gates showing \($gates_n) of \($gates_all | length)"), reveal:"--all-queued"} else empty end),
+        (if $all_reports == 0 and ($reports_all | length) > $reports_n then {surface:("reports showing \($reports_n) of \($reports_all | length)"), reveal:"--all-reports"} else empty end),
+        (if $all_recorded_prs == 0 and ($recorded_prs_all | length) > $recorded_prs_n then {surface:("recorded_prs showing \($recorded_prs_n) of \($recorded_prs_all | length)"), reveal:"--all-recorded-prs"} else empty end),
+        (if $all_unhealthy == 0 and ($unhealthy_all | length) > $unhealthy_n then {surface:("unhealthy_endpoints showing \($unhealthy_n) of \($unhealthy_all | length)"), reveal:"--all-unhealthy"} else empty end),
+        (if $include_prs == 1 and $pr_repos_total > $pr_repos_shown then {surface:("PR repositories showing \($pr_repos_shown) of \($pr_repos_total)"), reveal:"--all-pr-repos"} else empty end),
         (if $include_prs == 1 then empty else {surface:"live PR discovery + checks", reveal:"--include-prs"} end) ]) }
-')
+') || { echo "fm-bearings-snapshot: projection failed" >&2; exit 1; }
 
 if [ "$FORMAT" = json ]; then
   printf '%s\n' "$MODEL"
@@ -243,7 +313,7 @@ fi
 # objects, so the encoder only needs object scalars, the tabular array form
 # (key[N]{fields}: + comma rows at +2 indent), and the empty-array form (key: []),
 # per the TOON spec. Quoting follows the spec exactly.
-printf '%s\n' "$MODEL" | jq -r '
+TOON=$(printf '%s\n' "$MODEL" | jq -r '
   def q:
     tostring
     | if (. == "")
@@ -271,4 +341,5 @@ printf '%s\n' "$MODEL" | jq -r '
     else "\($k): " + ($v | scal)
     end;
   [ to_entries[] | emit(.key; .value) ] | join("\n")
-'
+') || { echo "fm-bearings-snapshot: TOON rendering failed" >&2; exit 1; }
+printf '%s\n' "$TOON"

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -166,6 +166,7 @@ States: working, needs-decision, blocked, $PAUSED_VERB, done, failed.
 Use \`$PAUSED_VERB: {why}\` (distinct from \`blocked:\`) only when your domain is deliberately idling on a known external wait you expect to clear on its own; use \`blocked:\` when you are stuck and need firstmate to act.
 Use this only for material phase changes, a captain decision, a real blocker, a failure, or work ready for review.
 This is also how you return the answer to a marked from-firstmate request above.
+When a decision you escalated is answered and your domain resumes, append \`resolved: {how it was decided}\` (keyed with \`[key=<slug>]\` if you opened it with one) so it is durably closed instead of resurfacing behind later unrelated events.
 Routine internal supervision, heartbeats, retries, and crewmate churn stay inside your own home and must not touch that status file.
 
 # Definition of done
@@ -249,6 +250,7 @@ The report is the only thing that survives, so anything worth keeping must be in
 5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
 6. If a decision belongs to a human (product choices, destructive actions),
    append \`needs-decision: {summary of options}\` and stop. Firstmate will reply with the decision.
+   When firstmate replies and you resume, append \`resolved: {how it was decided}\` (add the same \`[key=<slug>]\` if you opened it with one) so the decision is durably closed and does not keep resurfacing.
 
 # Definition of done
 Write your findings to \`$DATA/$ID/report.md\`.
@@ -352,6 +354,7 @@ $RULE1
 5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
 6. If a decision belongs to a human (product choices, destructive actions, ask-user findings),
    append \`needs-decision: {summary of options}\` and stop. Firstmate will reply with the decision.
+   When firstmate replies and you resume, append \`resolved: {how it was decided}\` (add the same \`[key=<slug>]\` if you opened it with one) so the decision is durably closed and does not keep resurfacing.
 
 # Project memory
 If \`AGENTS.md\` or \`CLAUDE.md\` already exists, or if this task produced durable project-intrinsic knowledge, run \`$FM_ROOT/bin/fm-ensure-agents-md.sh .\` in the worktree.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -166,7 +166,7 @@ States: working, needs-decision, blocked, $PAUSED_VERB, done, failed.
 Use \`$PAUSED_VERB: {why}\` (distinct from \`blocked:\`) only when your domain is deliberately idling on a known external wait you expect to clear on its own; use \`blocked:\` when you are stuck and need firstmate to act.
 Use this only for material phase changes, a captain decision, a real blocker, a failure, or work ready for review.
 This is also how you return the answer to a marked from-firstmate request above.
-When a decision you escalated is answered and your domain resumes, append \`resolved: {how it was decided}\` (keyed with \`[key=<slug>]\` if you opened it with one) so it is durably closed instead of resurfacing behind later unrelated events.
+When a decision you escalated is answered or a blocker clears and your domain resumes, append \`resolved: {how it was decided or unblocked}\` (keyed with \`[key=<slug>]\` if you opened it with one) so it is durably closed instead of resurfacing behind later unrelated events.
 Routine internal supervision, heartbeats, retries, and crewmate churn stay inside your own home and must not touch that status file.
 
 # Definition of done
@@ -250,7 +250,7 @@ The report is the only thing that survives, so anything worth keeping must be in
 5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
 6. If a decision belongs to a human (product choices, destructive actions),
    append \`needs-decision: {summary of options}\` and stop. Firstmate will reply with the decision.
-   When firstmate replies and you resume, append \`resolved: {how it was decided}\` (add the same \`[key=<slug>]\` if you opened it with one) so the decision is durably closed and does not keep resurfacing.
+   When firstmate replies or a blocker clears and you resume, append \`resolved: {how it was decided or unblocked}\` (add the same \`[key=<slug>]\` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
 
 # Definition of done
 Write your findings to \`$DATA/$ID/report.md\`.
@@ -354,7 +354,7 @@ $RULE1
 5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
 6. If a decision belongs to a human (product choices, destructive actions, ask-user findings),
    append \`needs-decision: {summary of options}\` and stop. Firstmate will reply with the decision.
-   When firstmate replies and you resume, append \`resolved: {how it was decided}\` (add the same \`[key=<slug>]\` if you opened it with one) so the decision is durably closed and does not keep resurfacing.
+   When firstmate replies or a blocker clears and you resume, append \`resolved: {how it was decided or unblocked}\` (add the same \`[key=<slug>]\` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
 
 # Project memory
 If \`AGENTS.md\` or \`CLAUDE.md\` already exists, or if this task produced durable project-intrinsic knowledge, run \`$FM_ROOT/bin/fm-ensure-agents-md.sh .\` in the worktree.

--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -59,6 +59,11 @@ FM_CLASSIFY_PAUSED_VERB_DEFAULT='paused'
 # shellcheck disable=SC2034 # Read by the watcher and daemon (fm-watch.sh, fm-supervise-daemon.sh), not this lib.
 FM_PAUSE_RESURFACE_SECS_DEFAULT=3600
 
+# The resolution verb that CLOSES a keyed decision opened by needs-decision or
+# blocked. See status_open_decisions below for the full durable-decision contract;
+# this is the one owner of the verb literal, overridable via FM_CLASSIFY_RESOLVE_VERB.
+FM_CLASSIFY_RESOLVE_VERB_DEFAULT='resolved'
+
 # Return the last non-blank line of a status file (empty if missing/blank).
 last_status_line() {
   local f=$1
@@ -85,6 +90,87 @@ status_is_paused() {  # <status-line>
   verb=${verb#"${verb%%[![:space:]]*}"}
   verb=${verb%"${verb##*[![:space:]]}"}
   [ "$verb" = "${FM_CLASSIFY_PAUSED_VERB:-$FM_CLASSIFY_PAUSED_VERB_DEFAULT}" ]
+}
+
+# --- durable keyed decisions ------------------------------------------------
+#
+# The status stream is an append-only EVENT log. Reading it last-event-wins
+# (last_status_line above) cannot represent "an earlier decision is still open
+# after a later, unrelated event": a subsequent done/paused/working line silently
+# masks a still-open needs-decision. status_open_decisions is the ONE authoritative
+# statement of the contract that fixes this - a needs-decision/blocked line OPENS a
+# keyed decision, and ONLY an explicit resolution referencing that key CLOSES it; a
+# later unrelated terminal line never clears an open captain decision.
+#
+# Decision key grammar (backward-compatible with the existing "<verb>: <note>"
+# format): an OPTIONAL "[key=<slug>]" token sits between the verb and the colon,
+#   needs-decision [key=api-shape]: <summary>
+#   resolved       [key=api-shape]: <how it was decided>
+# A line with no token uses the key "default", preserving the historical
+# one-open-decision-per-task behavior (a bare "resolved:" closes "default").
+# The three parsers are pure reads of a single line; the verb parser strips any
+# key token before the colon so the leading word is recovered cleanly.
+_fm_decision_verb() {  # <status-line> -> leading verb word
+  local v=${1%%:*}
+  v=${v%%\[key=*}
+  v=${v#"${v%%[![:space:]]*}"}
+  v=${v%"${v##*[![:space:]]}"}
+  printf '%s' "$v"
+}
+_fm_decision_key() {  # <status-line> -> key slug, or "default" when no token
+  case "$1" in
+    *\[key=*\]*) local k=${1#*\[key=}; printf '%s' "${k%%\]*}" ;;
+    *) printf 'default' ;;
+  esac
+}
+_fm_decision_note() {  # <status-line> -> text after the first colon, trimmed
+  case "$1" in
+    *:*) local n=${1#*:}; printf '%s' "${n#"${n%%[![:space:]]*}"}" ;;
+    *) printf '' ;;
+  esac
+}
+# Drop the record for <key> from a newline-terminated "<key>\t<verb>\t<note>" set.
+# Portable (no associative arrays) so the fold runs on bash 3.2 as well as 4+.
+_fm_decision_drop() {  # <open-set> <key>
+  local set=$1 key=$2 line out=''
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    case "$line" in
+      "$key"$'\t'*) : ;;
+      *) out="${out}${line}"$'\n' ;;
+    esac
+  done <<EOF
+$set
+EOF
+  printf '%s' "$out"
+}
+# Fold the WHOLE status stream into the set of decisions still open. Prints one
+# TAB-separated "<key>\t<verb>\t<summary>" line per still-open decision, in
+# most-recently-opened-last order; prints nothing when none are open. Pure read of
+# the file, no globals beyond the optional FM_CLASSIFY_RESOLVE_VERB override. This
+# is the durable open-set the fleet snapshot and any point-in-time consumer must use
+# instead of trusting the last status line.
+status_open_decisions() {  # <status-file>
+  local f=$1 line verb key note resolve open='' stripped
+  [ -f "$f" ] || return 0
+  resolve=${FM_CLASSIFY_RESOLVE_VERB:-$FM_CLASSIFY_RESOLVE_VERB_DEFAULT}
+  while IFS= read -r line || [ -n "$line" ]; do
+    stripped=${line//[[:space:]]/}
+    [ -n "$stripped" ] || continue
+    verb=$(_fm_decision_verb "$line")
+    key=$(_fm_decision_key "$line")
+    case "$verb" in
+      needs-decision|blocked)
+        note=$(_fm_decision_note "$line")
+        open=$(_fm_decision_drop "$open" "$key")
+        open="${open}${key}"$'\t'"${verb}"$'\t'"${note}"$'\n'
+        ;;
+      "$resolve")
+        open=$(_fm_decision_drop "$open" "$key")
+        ;;
+    esac
+  done < "$f"
+  printf '%s' "$open"
 }
 
 # task id from a recorded window target, falling back to the tmux-shaped

--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -73,9 +73,15 @@ last_status_line() {
 
 # 0 if the given (last) status line matches a captain-relevant verb.
 status_is_captain_relevant() {
-  local line=$1
+  local line=$1 verb
   [ -n "$line" ] || return 1
   status_is_paused "$line" && return 1
+  if [ -z "${FM_CAPTAIN_RE+x}" ]; then
+    verb=$(status_line_verb "$line")
+    case "$verb" in
+      done|needs-decision|blocked|failed) return 0 ;;
+    esac
+  fi
   printf '%s' "$line" | grep -qiE "${FM_CAPTAIN_RE:-$FM_CLASSIFY_CAPTAIN_RE_DEFAULT}"
 }
 
@@ -86,9 +92,7 @@ status_is_captain_relevant() {
 status_is_paused() {  # <status-line>
   local line=$1 verb
   [ -n "$line" ] || return 1
-  verb=${line%%:*}
-  verb=${verb#"${verb%%[![:space:]]*}"}
-  verb=${verb%"${verb##*[![:space:]]}"}
+  verb=$(status_line_verb "$line")
   [ "$verb" = "${FM_CLASSIFY_PAUSED_VERB:-$FM_CLASSIFY_PAUSED_VERB_DEFAULT}" ]
 }
 
@@ -110,23 +114,23 @@ status_is_paused() {  # <status-line>
 # one-open-decision-per-task behavior (a bare "resolved:" closes "default").
 # The three parsers are pure reads of a single line; the verb parser strips any
 # key token before the colon so the leading word is recovered cleanly.
-_fm_decision_verb() {  # <status-line> -> leading verb word
+status_line_verb() {  # <status-line> -> leading verb word
   local v=${1%%:*}
   v=${v%%\[key=*}
   v=${v#"${v%%[![:space:]]*}"}
   v=${v%"${v##*[![:space:]]}"}
   printf '%s' "$v"
 }
+status_line_note() {  # <status-line> -> text after the first colon, trimmed
+  case "$1" in
+    *:*) local n=${1#*:}; printf '%s' "${n#"${n%%[![:space:]]*}"}" ;;
+    *) printf '%s' "$1" ;;
+  esac
+}
 _fm_decision_key() {  # <status-line> -> key slug, or "default" when no token
   case "$1" in
     *\[key=*\]*) local k=${1#*\[key=}; printf '%s' "${k%%\]*}" ;;
     *) printf 'default' ;;
-  esac
-}
-_fm_decision_note() {  # <status-line> -> text after the first colon, trimmed
-  case "$1" in
-    *:*) local n=${1#*:}; printf '%s' "${n#"${n%%[![:space:]]*}"}" ;;
-    *) printf '' ;;
   esac
 }
 # Drop the record for <key> from a newline-terminated "<key>\t<verb>\t<note>" set.
@@ -157,11 +161,11 @@ status_open_decisions() {  # <status-file>
   while IFS= read -r line || [ -n "$line" ]; do
     stripped=${line//[[:space:]]/}
     [ -n "$stripped" ] || continue
-    verb=$(_fm_decision_verb "$line")
+    verb=$(status_line_verb "$line")
     key=$(_fm_decision_key "$line")
     case "$verb" in
       needs-decision|blocked)
-        note=$(_fm_decision_note "$line")
+        note=$(status_line_note "$line")
         open=$(_fm_decision_drop "$open" "$key")
         open="${open}${key}"$'\t'"${verb}"$'\t'"${note}"$'\n'
         ;;

--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -128,8 +128,16 @@ status_line_note() {  # <status-line> -> text after the first colon, trimmed
   esac
 }
 _fm_decision_key() {  # <status-line> -> key slug, or "default" when no token
-  case "$1" in
-    *\[key=*\]*) local k=${1#*\[key=}; printf '%s' "${k%%\]*}" ;;
+  local prefix=${1%%:*} k
+  case "$prefix" in
+    *\[key=*\]*)
+      k=${prefix#*\[key=}
+      k=${k%%\]*}
+      case "$k" in
+        ''|*[!A-Za-z0-9._-]*) return 1 ;;
+        *) printf '%s' "$k" ;;
+      esac
+      ;;
     *) printf 'default' ;;
   esac
 }
@@ -162,15 +170,17 @@ status_open_decisions() {  # <status-file>
     stripped=${line//[[:space:]]/}
     [ -n "$stripped" ] || continue
     verb=$(status_line_verb "$line")
-    key=$(_fm_decision_key "$line")
+    key=$(_fm_decision_key "$line") || continue
     case "$verb" in
       needs-decision|blocked)
         note=$(status_line_note "$line")
         open=$(_fm_decision_drop "$open" "$key")
+        [ -n "$open" ] && open="${open}"$'\n'
         open="${open}${key}"$'\t'"${verb}"$'\t'"${note}"$'\n'
         ;;
       "$resolve")
         open=$(_fm_decision_drop "$open" "$key")
+        [ -n "$open" ] && open="${open}"$'\n'
         ;;
     esac
   done < "$f"

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -101,18 +101,6 @@ log_last_line() {
   [ -f "$LOG" ] || return 1
   grep -v '^[[:space:]]*$' "$LOG" 2>/dev/null | tail -1
 }
-log_verb_of() {  # <line>
-  local v=${1%%:*}
-  v="${v#"${v%%[![:space:]]*}"}"
-  v="${v%"${v##*[![:space:]]}"}"
-  printf '%s' "$v"
-}
-log_note_of() {  # <line>
-  case "$1" in
-    *:*) local n=${1#*:}; printf '%s' "${n#"${n%%[![:space:]]*}"}" ;;
-    *)   printf '%s' "$1" ;;
-  esac
-}
 # Map a status-log verb onto a canonical state for the fallback path. `paused` is
 # the deliberate-external-wait verb (fm-classify-lib.sh's FM_CLASSIFY_PAUSED_VERB):
 # a crew with no active run and an idle pane that declared a known external wait
@@ -123,7 +111,7 @@ map_log_state() {  # <line>
     echo paused
     return
   fi
-  case "$(log_verb_of "$1")" in
+  case "$(status_line_verb "$1")" in
     working)        echo working ;;
     needs-decision) echo parked ;;
     blocked)        echo blocked ;;
@@ -134,7 +122,7 @@ map_log_state() {  # <line>
 }
 
 LOG_LINE=$(log_last_line || true)
-LOG_VERB=$(log_verb_of "$LOG_LINE")
+LOG_VERB=$(status_line_verb "$LOG_LINE")
 
 # pane_readable is consulted ONLY in the no-run fallback below. The run-step path
 # stays authoritative regardless of pane liveness - judge by the run-step, not the
@@ -289,7 +277,7 @@ nm_gate_findings_count() {
 }
 log_reports_ci_ready() {
   [ "$LOG_VERB" = "done" ] || return 1
-  case "$(log_note_of "$LOG_LINE")" in
+  case "$(status_line_note "$LOG_LINE")" in
     *PR*"checks green"*|*"checks green"*PR*) return 0 ;;
     *) return 1 ;;
   esac
@@ -519,7 +507,7 @@ if [ "$HAVE_RUN" = 1 ]; then
 
   if [ "$RUN_STATE" = working ] && log_reports_ci_ready; then
     if [ "$RUN_SOURCE" = coarse ]; then
-      emit "done" status-log "$(log_note_of "$LOG_LINE")${SEP}run still monitoring PR"
+      emit "done" status-log "$(status_line_note "$LOG_LINE")${SEP}run still monitoring PR"
     fi
     [ -n "$CI_STEP_STATUS" ] || CI_STEP_STATUS=$(nm_effective_ci_step_status)
     if [ "$RUN_STATUS" = fixing ]; then
@@ -530,7 +518,7 @@ if [ "$HAVE_RUN" = 1 ]; then
       CI_LOG_STATE=not-ready
     fi
     if [ "$CI_LOG_STATE" != not-ready ]; then
-      emit "done" status-log "$(log_note_of "$LOG_LINE")${SEP}run still monitoring PR"
+      emit "done" status-log "$(status_line_note "$LOG_LINE")${SEP}run still monitoring PR"
     fi
   fi
 
@@ -567,7 +555,7 @@ if [ "$KIND" != secondmate ] && crew_pane_is_busy "$BACKEND_TARGET"; then
 fi
 
 if [ -n "$LOG_VERB" ]; then
-  emit "$(map_log_state "$LOG_LINE")" status-log "$(log_note_of "$LOG_LINE")"
+  emit "$(map_log_state "$LOG_LINE")" status-log "$(status_line_note "$LOG_LINE")"
 fi
 
 emit unknown none "no current-state source available"

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -320,15 +320,27 @@ task_json_lines() {
 
     # Durable keyed open-decision set: fold the WHOLE status stream
     # (fm-classify-lib.sh's status_open_decisions) so a later unrelated event can
-    # never mask a still-open captain decision. Reconcile against the authoritative
-    # current state: an activity read (run-step or busy pane) showing the crew
-    # working/done/failed means it moved past any decision, so clear the set; a
-    # parked/blocked state, or a non-authoritative status-log/none read (as for a
-    # secondmate, which has no run-step to reconcile against) trusts the fold so the
-    # open decision keeps surfacing.
+    # never mask a still-open captain decision. The set is derived purely from the
+    # keyed fold - never from report bodies or decision-like prose - and then
+    # reconciled against the crew LIFECYCLE, which only clears a stale decision the
+    # crew has provably moved past. Two lifecycle signals clear it, neither of which
+    # reads any report content:
+    #   - a live activity read (run-step or busy pane) that is working/done, so a
+    #     crew that resumed past a gate is not still reported as parked; and
+    #   - a TERMINAL done/failed state on a single-owner task (scout or ship), whose
+    #     deliverable is its report or PR, so a COMPLETED scout surfaces only as a
+    #     report POINTER, never as a reopened pending decision.
+    # Secondmates are excluded from the terminal case: they are persistent and
+    # multiplex many concerns onto one stream, so a per-concern done must never
+    # clear another concern's keyed decision - that exclusion is what keeps the
+    # unrelated-event masking fix intact. A parked/blocked state, or a
+    # non-authoritative status-log/none read on a still-live task, keeps the fold's
+    # open decision surfacing.
     open_decisions_tsv=$(status_open_decisions "$status_log")
-    if { [ "$current_source" = run-step ] || [ "$current_source" = pane ]; } \
-       && [ "$current_state" != parked ] && [ "$current_state" != blocked ]; then
+    if { { [ "$current_source" = run-step ] || [ "$current_source" = pane ]; } \
+           && [ "$current_state" != parked ] && [ "$current_state" != blocked ]; } \
+       || { [ "$kind" != secondmate ] \
+           && { [ "$current_state" = "done" ] || [ "$current_state" = "failed" ]; }; }; then
       open_decisions_tsv=""
     fi
     open_decisions_json=$(printf '%s' "$open_decisions_tsv" | jq -R -s '

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -19,6 +19,11 @@
 #     state, source, detail, and raw line separately.
 #     paths.status_log.last_event is historical wake-event data only, never
 #     current state.
+#     hints.open_decisions is the DURABLE keyed open-decision set, folded from the
+#     whole status stream by fm-classify-lib.sh's status_open_decisions and
+#     reconciled against the authoritative current_state, so a later unrelated
+#     event cannot mask a still-open decision; hints.pending_decision and
+#     hints.blocked_event are booleans derived from that set.
 #     endpoint.exists is the cheap backend endpoint-presence read.
 #     endpoint.agent_alive is populated for secondmates only, where it is useful
 #     return-channel supervision data; other tasks use "not_checked".
@@ -41,6 +46,9 @@ BACKLOG="$DATA/backlog.md"
 # shellcheck source=bin/fm-backend.sh
 # shellcheck disable=SC1091
 . "$SCRIPT_DIR/fm-backend.sh"
+# shellcheck source=bin/fm-classify-lib.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/fm-classify-lib.sh"
 
 usage() {
   cat <<'EOF'
@@ -274,7 +282,8 @@ backlog_json() {
 task_json_lines() {
   local meta id kind harness mode yolo project worktree home projects backend target status_log report_path
   local pr pr_source event_json current_json endpoint_exists agent_alive meta_json status_json report_json worktree_json home_json
-  local last_event_raw last_event_verb current_state pending_decision blocked_event report_present=0 pr_from_status
+  local last_event_raw current_state current_source pending_decision blocked_event report_present=0 pr_from_status
+  local open_decisions_tsv open_decisions_json
 
   for meta in "$STATE"/*.meta; do
     [ -e "$meta" ] || continue
@@ -306,12 +315,28 @@ task_json_lines() {
     current_json=$(crew_state_json "$id")
     event_json=$(status_event_json "$status_log")
     last_event_raw=$(printf '%s' "$event_json" | jq -r '.last_event.raw // ""')
-    last_event_verb=$(printf '%s' "$event_json" | jq -r '.last_event.state // ""')
     current_state=$(printf '%s' "$current_json" | jq -r '.state // ""')
-    pending_decision=0
-    blocked_event=0
-    [ "$last_event_verb" = needs-decision ] && [ "$current_state" = parked ] && pending_decision=1
-    [ "$last_event_verb" = blocked ] && [ "$current_state" = blocked ] && blocked_event=1
+    current_source=$(printf '%s' "$current_json" | jq -r '.source // ""')
+
+    # Durable keyed open-decision set: fold the WHOLE status stream
+    # (fm-classify-lib.sh's status_open_decisions) so a later unrelated event can
+    # never mask a still-open captain decision. Reconcile against the authoritative
+    # current state: an activity read (run-step or busy pane) showing the crew
+    # working/done/failed means it moved past any decision, so clear the set; a
+    # parked/blocked state, or a non-authoritative status-log/none read (as for a
+    # secondmate, which has no run-step to reconcile against) trusts the fold so the
+    # open decision keeps surfacing.
+    open_decisions_tsv=$(status_open_decisions "$status_log")
+    if { [ "$current_source" = run-step ] || [ "$current_source" = pane ]; } \
+       && [ "$current_state" != parked ] && [ "$current_state" != blocked ]; then
+      open_decisions_tsv=""
+    fi
+    open_decisions_json=$(printf '%s' "$open_decisions_tsv" | jq -R -s '
+      [ splits("\n") | select(length > 0)
+        | (capture("^(?<key>[^\t]*)\t(?<verb>[^\t]*)\t(?<summary>.*)$")?)
+        | select(. != null) ]')
+    pending_decision=$(printf '%s' "$open_decisions_json" | jq 'if any(.[]; .verb == "needs-decision") then 1 else 0 end')
+    blocked_event=$(printf '%s' "$open_decisions_json" | jq 'if any(.[]; .verb == "blocked") then 1 else 0 end')
 
     endpoint_exists=null
     if [ -n "$target" ]; then
@@ -356,6 +381,7 @@ task_json_lines() {
       --argjson worktree_path "$worktree_json" \
       --argjson home_path "$home_json" \
       --argjson endpoint_exists "$endpoint_exists" \
+      --argjson open_decisions "$open_decisions_json" \
       --argjson pending_decision "$(bool_json "$pending_decision")" \
       --argjson blocked_event "$(bool_json "$blocked_event")" \
       --argjson report_present "$(bool_json "$report_present")" \
@@ -381,6 +407,7 @@ task_json_lines() {
         hints:{
           pending_decision:$pending_decision,
           blocked_event:$blocked_event,
+          open_decisions:$open_decisions,
           scout_report_present:$report_present,
           last_event_text:$last_event_raw
         },

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -87,24 +87,6 @@ last_nonempty_line() {  # <file>
   grep -v '^[[:space:]]*$' "$1" 2>/dev/null | tail -1
 }
 
-line_verb() {  # <line>
-  local v=${1%%:*}
-  v="${v#"${v%%[![:space:]]*}"}"
-  v="${v%"${v##*[![:space:]]}"}"
-  printf '%s' "$v"
-}
-
-line_note() {  # <line>
-  local n
-  case "$1" in
-    *:*) n=${1#*:} ;;
-    *) n=$1 ;;
-  esac
-  n="${n#"${n%%[![:space:]]*}"}"
-  n="${n%"${n##*[![:space:]]}"}"
-  printf '%s' "$n"
-}
-
 crew_state_json() {  # <id>
   local id=$1 raw rest state source detail sep
   raw=$(
@@ -141,8 +123,8 @@ status_event_json() {  # <status-log>
   if [ -f "$log" ]; then
     present=1
     raw=$(last_nonempty_line "$log" || true)
-    verb=$(line_verb "$raw")
-    note=$(line_note "$raw")
+    verb=$(status_line_verb "$raw")
+    note=$(status_line_note "$raw")
   fi
   jq -n \
     --arg path "$log" \
@@ -330,17 +312,16 @@ task_json_lines() {
     #   - a TERMINAL done/failed state on a single-owner task (scout or ship), whose
     #     deliverable is its report or PR, so a COMPLETED scout surfaces only as a
     #     report POINTER, never as a reopened pending decision.
-    # Secondmates are excluded from the terminal case: they are persistent and
-    # multiplex many concerns onto one stream, so a per-concern done must never
-    # clear another concern's keyed decision - that exclusion is what keeps the
-    # unrelated-event masking fix intact. A parked/blocked state, or a
+    # Secondmates are excluded from lifecycle clearing: they are persistent and
+    # multiplex many concerns onto one stream, so activity on one concern must
+    # never clear another concern's keyed decision. A parked/blocked state, or a
     # non-authoritative status-log/none read on a still-live task, keeps the fold's
     # open decision surfacing.
     open_decisions_tsv=$(status_open_decisions "$status_log")
-    if { { [ "$current_source" = run-step ] || [ "$current_source" = pane ]; } \
+    if [ "$kind" != secondmate ] && \
+       { { { [ "$current_source" = run-step ] || [ "$current_source" = pane ]; } \
            && [ "$current_state" != parked ] && [ "$current_state" != blocked ]; } \
-       || { [ "$kind" != secondmate ] \
-           && { [ "$current_state" = "done" ] || [ "$current_state" = "failed" ]; }; }; then
+         || { [ "$current_state" = "done" ] || [ "$current_state" = "failed" ]; }; }; then
       open_decisions_tsv=""
     fi
     open_decisions_json=$(printf '%s' "$open_decisions_tsv" | jq -R -s '

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -19,11 +19,10 @@
 #     state, source, detail, and raw line separately.
 #     paths.status_log.last_event is historical wake-event data only, never
 #     current state.
-#     hints.open_decisions is the DURABLE keyed open-decision set, folded from the
-#     whole status stream by fm-classify-lib.sh's status_open_decisions and
-#     reconciled against the authoritative current_state, so a later unrelated
-#     event cannot mask a still-open decision; hints.pending_decision and
-#     hints.blocked_event are booleans derived from that set.
+#     hints.open_decisions is the keyed open-decision set returned by
+#     fm-classify-lib.sh's authoritative status_open_decisions fold and reconciled
+#     against current_state; hints.pending_decision and hints.blocked_event are
+#     booleans derived from that set.
 #     endpoint.exists is the cheap backend endpoint-presence read.
 #     endpoint.agent_alive is populated for secondmates only, where it is useful
 #     return-channel supervision data; other tasks use "not_checked".

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -29,7 +29,7 @@ Only when no matching run exists does it fall back to the pane busy-signature an
 In that status-log fallback, a declared external wait reports the distinct `paused` state with its reason.
 For herdr, that pane fallback trusts a native `busy` verdict outright, but corroborates native `idle` or unknown verdicts against the rendered busy signature before deciding the crew is not working.
 For whole-fleet read-only review, `bin/fm-fleet-snapshot.sh --json` emits schema `fm-fleet-snapshot.v1` from the backlog, task metadata, current crew state, endpoint probes, PR/report pointers, scout reports, and secondmate return-channel guidance.
-`bin/fm-fleet-view.sh` renders that snapshot as Markdown for humans, so bearings and manual fleet reviews consume one structured contract instead of reparsing raw fleet files.
+`bin/fm-fleet-view.sh` renders that snapshot as Markdown for humans, while `bin/fm-bearings-snapshot.sh` provides the bounded bearings projection, so both views consume one structured contract instead of reparsing raw fleet files.
 The script header owns the exact JSON schema.
 Optional X mode rides the same check path: the locked session-start bootstrap step drops a local `state/x-watch.check.sh` shim only after the user opts in with `FMX_PAIRING_TOKEN`, and non-X homes keep the default watcher behavior.
 

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -11,6 +11,7 @@ If you have changed away from the firstmate home in an interactive shell, invoke
 | `fm-fleet-sync.sh`       | Refresh project clones with safe fast-forwards, self-heals, `STUCK:` reports, branch pruning, and bounded recovery from an orphaned `.git/packed-refs.lock` |
 | `fm-fleet-snapshot.sh`   | Print the read-only structured fleet snapshot JSON (schema `fm-fleet-snapshot.v1`)   |
 | `fm-fleet-view.sh`       | Render the fleet snapshot as a human Markdown view                                   |
+| `fm-bearings-snapshot.sh` | Project the fleet snapshot to the compact TOON bearings view; local-only unless `--include-prs` |
 | `fm-update.sh`           | Fast-forward-only self-update of firstmate and secondmate homes from origin          |
 | `fm-backlog-handoff.sh`  | Validate and delegate queued backlog-item moves into a secondmate home               |
 | `fm-brief.sh`            | Scaffold ship, scout, secondmate-charter, and Herdr-lab briefs                       |

--- a/tests/fm-bearings-snapshot.test.sh
+++ b/tests/fm-bearings-snapshot.test.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+# Behavior tests for the bearings projection wrapper over fm-fleet-snapshot.sh.
+# Covers the output/token bound, TOON/JSON parity, the local-only default (zero
+# GitHub/network calls), the --include-prs opt-in path, graceful degradation on a
+# partial PR-fetch failure, end-to-end unresolved-decision durability, and current
+# report pointers.
+set -u
+
+# shellcheck source=tests/lib.sh
+# shellcheck disable=SC1091
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+BEARINGS="$ROOT/bin/fm-bearings-snapshot.sh"
+TMP_ROOT=$(fm_test_tmproot fm-bearings)
+
+command -v jq >/dev/null 2>&1 || { echo "skip: jq not found"; exit 0; }
+
+# A fakebin that stubs the local tools the canonical snapshot may reach for, plus a
+# gh/gh-axi that RECORDS every call to $NET_LOG so a test can prove the default path
+# makes no network call. gh returns one fixture open PR keyed to the ship task.
+make_fakebin() {  # <dir>
+  local fb
+  fb=$(fm_fakebin "$1")
+  cat > "$fb/no-mistakes" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  cat > "$fb/tmux" <<'SH'
+#!/usr/bin/env bash
+case "${1:-}" in
+  display-message) printf '%%1\n' ;;
+  capture-pane) printf 'all quiet\n> \n' ;;
+esac
+exit 0
+SH
+  cat > "$fb/gh" <<'SH'
+#!/usr/bin/env bash
+echo "gh $*" >> "$NET_LOG"
+if [ "${FAKE_GH_FAIL:-0}" = 1 ]; then exit 1; fi
+cat <<'JSON'
+[{"number":9,"title":"Ship the thing","url":"https://github.com/kunchenguid/firstmate/pull/9","headRefName":"fm/ship-task","reviewDecision":"APPROVED","mergeable":"MERGEABLE","statusCheckRollup":[{"conclusion":"SUCCESS","status":"COMPLETED"}]}]
+JSON
+SH
+  cat > "$fb/gh-axi" <<'SH'
+#!/usr/bin/env bash
+echo "gh-axi $*" >> "$NET_LOG"
+exit 0
+SH
+  chmod +x "$fb/no-mistakes" "$fb/tmux" "$fb/gh" "$fb/gh-axi"
+  printf '%s\n' "$fb"
+}
+
+make_home() {  # <name>
+  local home=$TMP_ROOT/$1
+  mkdir -p "$home/state" "$home/data" "$home/projects" "$home/config" "$home/secondmate-home"
+  printf '%s\n' "$home"
+}
+
+# Standard fixture: a ship task with a recorded PR, a scout task with a report, a
+# secondmate with a MASKED open decision (needs-decision then a later unrelated
+# done), and a backlog with a superseded queued item.
+write_fixture() {  # <home>
+  local home=$1
+  mkdir -p "$home/projects/ship-wt" "$home/data/scout-x"
+  cat > "$home/data/backlog.md" <<EOF
+## In flight
+- [ ] ship-task - Ship the thing (repo: firstmate) (kind: ship) (since 2026-07-11)
+- [ ] scout-x - Investigate the thing data/scout-x/report.md (repo: firstmate) (kind: scout) (since 2026-07-11)
+
+## Queued
+- [ ] live-gate - Real queued work blocked-by: ship-task (repo: firstmate) (kind: ship)
+- [ ] dead-gate - Old conditional work (repo: firstmate) (kind: scout)
+  NOT REQUIRED - superseded 2026-07-11; kept as reference only.
+
+## Done
+- [x] done-a - Landed thing https://github.com/kunchenguid/firstmate/pull/7 (repo: firstmate) (kind: ship) (merged 2026-07-10)
+EOF
+  printf '# Scout X\n' > "$home/data/scout-x/report.md"
+  fm_write_meta "$home/state/ship-task.meta" \
+    "window=firstmate:fm-ship-task" \
+    "worktree=$home/projects/ship-wt" \
+    "project=firstmate" \
+    "harness=codex" \
+    "kind=ship" \
+    "mode=no-mistakes" \
+    "pr=https://github.com/kunchenguid/firstmate/pull/9"
+  printf 'working: building the thing\n' > "$home/state/ship-task.status"
+  fm_write_meta "$home/state/scout-x.meta" \
+    "window=firstmate:fm-scout-x" \
+    "worktree=$home/projects/ship-wt" \
+    "project=firstmate" \
+    "harness=codex" \
+    "kind=scout" \
+    "mode=scout"
+  printf 'done: report ready\n' > "$home/state/scout-x.status"
+  fm_write_meta "$home/state/mate.meta" \
+    "window=firstmate:fm-mate" \
+    "worktree=$home/secondmate-home" \
+    "project=$home/secondmate-home" \
+    "harness=codex" \
+    "kind=secondmate" \
+    "mode=secondmate" \
+    "home=$home/secondmate-home" \
+    "projects=firstmate"
+  printf 'needs-decision [key=race]: pick subscribe order\n' > "$home/state/mate.status"
+  printf 'done: an unrelated subtask finished\n' >> "$home/state/mate.status"
+}
+
+run() {  # <home> <fakebin> <args...>
+  local home=$1 fakebin=$2; shift 2
+  PATH="$fakebin:$PATH" FM_HOME="$home" FM_BEARINGS_NOW=2026-07-11T18:00:00Z NET_LOG="$home/net.log" "$BEARINGS" "$@"
+}
+
+test_default_is_bounded_and_local_only() {
+  local home fakebin toon json
+  home=$(make_home bounded); write_fixture "$home"
+  fakebin=$(make_fakebin "$home"); : > "$home/net.log"
+  toon=$(run "$home" "$fakebin")
+  json=$(run "$home" "$fakebin" --json)
+  # Bound: well under the ~50 KB tool-display limit.
+  [ "${#toon}" -lt 50000 ] || fail "default TOON must stay under the display bound, got ${#toon}"
+  # TOON is materially smaller than the canonical snapshot it projects.
+  local canon; canon=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$ROOT/bin/fm-fleet-snapshot.sh" --json)
+  [ "${#toon}" -lt "${#canon}" ] || fail "projection must be smaller than the canonical snapshot"
+  # Local-only: no GitHub/network call on the default path.
+  [ ! -s "$home/net.log" ] || fail "default run must make no gh/gh-axi call, got: $(cat "$home/net.log")"
+  # Definitive not-requested PR state, never a silent omission.
+  assert_contains "$toon" 'prs: "not_requested' "default must state PR checks were not requested"
+  assert_contains "$toon" "live PR discovery + checks,\"--include-prs\"" "omitted must mark the dropped live-PR surface"
+  # Valid JSON, correct schema.
+  printf '%s' "$json" | jq -e '.schema == "fm-bearings.v1"' >/dev/null || fail "json schema wrong"
+  pass "default output is bounded, local-only, and marks omitted surfaces"
+}
+
+test_toon_json_parity() {
+  local home fakebin toon json keys k
+  home=$(make_home parity); write_fixture "$home"
+  fakebin=$(make_fakebin "$home")
+  toon=$(run "$home" "$fakebin")
+  json=$(run "$home" "$fakebin" --json)
+  # Same top-level keys in both representations.
+  keys=$(printf '%s' "$json" | jq -r 'keys_unsorted[]')
+  for k in $keys; do
+    if printf '%s' "$json" | jq -e --arg k "$k" '.[$k] | type == "array"' >/dev/null; then
+      local n hdr
+      n=$(printf '%s' "$json" | jq --arg k "$k" '.[$k] | length')
+      if [ "$n" = 0 ]; then
+        assert_contains "$toon" "$k: []" "empty array $k must render as 'key: []'"
+      else
+        # Header must declare the same count and the same field set.
+        hdr=$(printf '%s' "$toon" | grep -E "^$k\[[0-9]+\]\{" || true)
+        [ -n "$hdr" ] || fail "TOON missing tabular header for $k"
+        assert_contains "$hdr" "[$n]" "TOON $k row count must equal JSON length $n"
+        local jfields tfields
+        jfields=$(printf '%s' "$json" | jq -r --arg k "$k" '.[$k][0] | keys_unsorted | join(",")')
+        tfields=$(printf '%s' "$hdr" | sed -E 's/^[^{]*\{//; s/\}:.*$//; s/"//g')
+        [ "$jfields" = "$tfields" ] || fail "TOON $k fields ($tfields) must equal JSON fields ($jfields)"
+      fi
+    else
+      # Scalar: the key must appear as a "key: value" line.
+      assert_contains "$toon" "$k: " "TOON must carry scalar field $k"
+    fi
+  done
+  pass "TOON and JSON are parity representations of the same model"
+}
+
+test_open_decision_surfaces_end_to_end() {
+  local home fakebin json
+  home=$(make_home e2e-decision); write_fixture "$home"
+  fakebin=$(make_fakebin "$home")
+  json=$(run "$home" "$fakebin" --json)
+  printf '%s' "$json" | jq -e '
+    .decisions_open | any(.[]; .id == "mate" and .key == "race" and .verb == "needs-decision")
+  ' >/dev/null || fail "a still-open decision masked by a later done must surface in decisions_open: $json"
+  pass "an open decision masked by a later event surfaces end-to-end"
+}
+
+test_report_pointers_surface() {
+  local home fakebin json
+  home=$(make_home reports); write_fixture "$home"
+  fakebin=$(make_fakebin "$home")
+  json=$(run "$home" "$fakebin" --json)
+  printf '%s' "$json" | jq -e --arg p "$home/data/scout-x/report.md" '
+    .reports | any(.[]; .id == "scout-x" and .path == $p)
+  ' >/dev/null || fail "current scout report pointer must surface: $json"
+  pass "current report pointers surface"
+}
+
+test_superseded_queued_item_dropped_by_default() {
+  local home fakebin json
+  home=$(make_home superseded); write_fixture "$home"
+  fakebin=$(make_fakebin "$home")
+  json=$(run "$home" "$fakebin" --json)
+  printf '%s' "$json" | jq -e '
+    (.gates | any(.[]; .id == "live-gate")) and (.gates | any(.[]; .id == "dead-gate") | not)
+  ' >/dev/null || fail "default gates must include live and drop superseded: $json"
+  json=$(run "$home" "$fakebin" --json --all-queued)
+  printf '%s' "$json" | jq -e '.gates | any(.[]; .id == "dead-gate")' >/dev/null \
+    || fail "--all-queued must restore the superseded item"
+  pass "superseded queued items are dropped by default and restored with --all-queued"
+}
+
+test_include_prs_is_the_only_fetch_path() {
+  local home fakebin json
+  home=$(make_home prs); write_fixture "$home"
+  fakebin=$(make_fakebin "$home"); : > "$home/net.log"
+  json=$(run "$home" "$fakebin" --include-prs --json)
+  # Now gh WAS called, exactly for pr list.
+  grep -q '^gh pr list ' "$home/net.log" || fail "--include-prs must call gh pr list"
+  printf '%s' "$json" | jq -e '
+    .prs | startswith("checked")
+  ' >/dev/null || fail "--include-prs must report checked PR state"
+  printf '%s' "$json" | jq -e '
+    .candidate_prs | any(.[]; .num == "9" and .task == "ship-task" and .checks == "passing" and .review == "APPROVED")
+  ' >/dev/null || fail "candidate_prs must carry the fetched PR cross-referenced to its task: $json"
+  pass "--include-prs is the only path that fetches, and it enriches correctly"
+}
+
+test_partial_github_failure_degrades() {
+  local home fakebin json rc
+  home=$(make_home partial); write_fixture "$home"
+  fakebin=$(make_fakebin "$home")
+  json=$(FAKE_GH_FAIL=1 run "$home" "$fakebin" --include-prs --json); rc=$?
+  expect_code 0 "$rc" "a PR-fetch failure must not crash the view"
+  printf '%s' "$json" | jq -e '
+    .schema == "fm-bearings.v1"
+      and (.candidate_prs | length) == 0
+      and (.prs | test("unavailable"))
+      and (.in_flight | length) > 0
+  ' >/dev/null || fail "on gh failure the view must still emit, with an unavailable note: $json"
+  pass "a partial GitHub failure degrades gracefully"
+}
+
+test_default_is_bounded_and_local_only
+test_toon_json_parity
+test_open_decision_surfaces_end_to_end
+test_report_pointers_surface
+test_superseded_queued_item_dropped_by_default
+test_include_prs_is_the_only_fetch_path
+test_partial_github_failure_degrades

--- a/tests/fm-bearings-snapshot.test.sh
+++ b/tests/fm-bearings-snapshot.test.sh
@@ -231,8 +231,36 @@ test_partial_github_failure_degrades() {
   pass "a partial GitHub failure degrades gracefully"
 }
 
+# The Lavish-103 defect, end to end: a COMPLETED scout that raised a decision and
+# then finished (done), whose report body reads like that decision, must surface as
+# a report POINTER only - never in decisions_open. Report prose must never open or
+# reopen a pending decision; only the keyed durable state does.
+test_completed_scout_report_not_pending() {
+  local home fakebin json
+  home=$(make_home completed-scout); write_fixture "$home"
+  fakebin=$(make_fakebin "$home")
+  mkdir -p "$home/projects/lav-wt" "$home/data/lavish-103"
+  fm_write_meta "$home/state/lavish-103.meta" \
+    "window=firstmate:fm-lavish-103" \
+    "worktree=$home/projects/lav-wt" \
+    "project=firstmate" \
+    "harness=codex" \
+    "kind=scout" \
+    "mode=scout"
+  printf 'needs-decision: adopt approach A or B for Lavish issue 103\n' > "$home/state/lavish-103.status"
+  printf 'done: report ready at data/lavish-103/report.md\n' >> "$home/state/lavish-103.status"
+  printf '# Lavish 103\nThe open question is whether to adopt approach A or B; this needs a captain decision.\n' > "$home/data/lavish-103/report.md"
+  json=$(run "$home" "$fakebin" --json)
+  printf '%s' "$json" | jq -e '
+    (.decisions_open | any(.[]; .id == "lavish-103") | not)
+      and (.reports | any(.[]; .id == "lavish-103"))
+  ' >/dev/null || fail "completed scout must be a report pointer, never a pending decision: $json"
+  pass "a completed scout with decision-like report prose is a pointer, not pending"
+}
+
 test_default_is_bounded_and_local_only
 test_toon_json_parity
+test_completed_scout_report_not_pending
 test_open_decision_surfaces_end_to_end
 test_report_pointers_surface
 test_superseded_queued_item_dropped_by_default

--- a/tests/fm-bearings-snapshot.test.sh
+++ b/tests/fm-bearings-snapshot.test.sh
@@ -38,6 +38,12 @@ SH
 echo "gh $*" >> "$NET_LOG"
 if [ "${FAKE_GH_FAIL:-0}" = 1 ]; then exit 1; fi
 if [ "${FAKE_GH_SLEEP:-0}" = 1 ]; then sleep 30; fi
+if [ "${FAKE_GH_MANY:-0}" = 1 ]; then
+  cat <<'JSON'
+[{"number":1,"title":"One","url":"https://github.com/acme/repo/pull/1","headRefName":"fm/one","reviewDecision":"","mergeable":"MERGEABLE","statusCheckRollup":[]},{"number":2,"title":"Two","url":"https://github.com/acme/repo/pull/2","headRefName":"fm/two","reviewDecision":"","mergeable":"MERGEABLE","statusCheckRollup":[]},{"number":3,"title":"Three","url":"https://github.com/acme/repo/pull/3","headRefName":"fm/three","reviewDecision":"","mergeable":"MERGEABLE","statusCheckRollup":[]}]
+JSON
+  exit 0
+fi
 cat <<'JSON'
 [{"number":9,"title":"Ship the thing","url":"https://github.com/kunchenguid/firstmate/pull/9","headRefName":"fm/ship-task","reviewDecision":"APPROVED","mergeable":"MERGEABLE","statusCheckRollup":[{"conclusion":"SUCCESS","status":"COMPLETED"}]}]
 JSON
@@ -319,6 +325,21 @@ test_pr_repository_cap_and_expansion() {
   pass "live PR enrichment caps repositories with counted expansion"
 }
 
+test_per_repository_pr_cap_is_disclosed() {
+  local home fakebin json toon
+  home=$(make_home pr-row-cap); write_fixture "$home"
+  fakebin=$(make_fakebin "$home")
+  json=$(FM_BEARINGS_PR_LIMIT=2 FAKE_GH_MANY=1 run "$home" "$fakebin" --include-prs --json)
+  toon=$(FM_BEARINGS_PR_LIMIT=2 FAKE_GH_MANY=1 run "$home" "$fakebin" --include-prs)
+  printf '%s' "$json" | jq -e '
+    (.candidate_prs | length) == 2
+    and (.prs | test("2 shown, at least 3 open; capped in 1 repo"))
+    and ([.omitted[] | select(.surface == "candidate_prs showing 2 of at least 3; capped in 1 repo(s)" and .reveal == "raise FM_BEARINGS_PR_LIMIT")] | length) == 1
+  ' >/dev/null || fail "per-repository PR truncation was not disclosed: $json"
+  assert_contains "$toon" 'candidate_prs showing 2 of at least 3' "TOON did not preserve PR truncation disclosure"
+  pass "per-repository open-PR caps are disclosed with an expansion knob"
+}
+
 install_failing_jq() {  # <fakebin> <model|toon>
   local fakebin=$1 phase=$2 real
   real=$(command -v jq)
@@ -390,4 +411,5 @@ test_partial_github_failure_degrades
 test_perl_fallback_bounds_github_call
 test_section_caps_and_expansion_flags
 test_pr_repository_cap_and_expansion
+test_per_repository_pr_cap_is_disclosed
 test_projection_and_toon_fail_closed

--- a/tests/fm-bearings-snapshot.test.sh
+++ b/tests/fm-bearings-snapshot.test.sh
@@ -37,6 +37,7 @@ SH
 #!/usr/bin/env bash
 echo "gh $*" >> "$NET_LOG"
 if [ "${FAKE_GH_FAIL:-0}" = 1 ]; then exit 1; fi
+if [ "${FAKE_GH_SLEEP:-0}" = 1 ]; then sleep 30; fi
 cat <<'JSON'
 [{"number":9,"title":"Ship the thing","url":"https://github.com/kunchenguid/firstmate/pull/9","headRefName":"fm/ship-task","reviewDecision":"APPROVED","mergeable":"MERGEABLE","statusCheckRollup":[{"conclusion":"SUCCESS","status":"COMPLETED"}]}]
 JSON
@@ -231,6 +232,25 @@ test_partial_github_failure_degrades() {
   pass "a partial GitHub failure degrades gracefully"
 }
 
+test_perl_fallback_bounds_github_call() {
+  local home fakebin toolbin cmd json started elapsed
+  home=$(make_home perl-timeout); write_fixture "$home"
+  fakebin=$(make_fakebin "$home")
+  toolbin="$home/toolbin"
+  mkdir -p "$toolbin"
+  for cmd in bash dirname basename jq date sed git grep tail cut tr head sort wc perl sleep cat find; do
+    ln -s "$(command -v "$cmd")" "$toolbin/$cmd"
+  done
+  started=$(date +%s)
+  json=$(PATH="$fakebin:$toolbin" FM_HOME="$home" FM_BEARINGS_NOW=2026-07-11T18:00:00Z \
+    FM_BEARINGS_PR_TIMEOUT=1 NET_LOG="$home/net.log" FAKE_GH_SLEEP=1 "$BEARINGS" --include-prs --json)
+  elapsed=$(( $(date +%s) - started ))
+  [ "$elapsed" -lt 10 ] || fail "Perl fallback did not bound a stalled gh call (${elapsed}s)"
+  printf '%s' "$json" | jq -e '.prs | test("unavailable")' >/dev/null \
+    || fail "timed-out gh call did not fail soft: $json"
+  pass "Perl fallback bounds stalled GitHub calls without coreutils timeout"
+}
+
 # The Lavish-103 defect, end to end: a COMPLETED scout that raised a decision and
 # then finished (done), whose report body reads like that decision, must surface as
 # a report POINTER only - never in decisions_open. Report prose must never open or
@@ -266,3 +286,4 @@ test_report_pointers_surface
 test_superseded_queued_item_dropped_by_default
 test_include_prs_is_the_only_fetch_path
 test_partial_github_failure_degrades
+test_perl_fallback_bounds_github_call

--- a/tests/fm-bearings-snapshot.test.sh
+++ b/tests/fm-bearings-snapshot.test.sh
@@ -28,7 +28,7 @@ SH
   cat > "$fb/tmux" <<'SH'
 #!/usr/bin/env bash
 case "${1:-}" in
-  display-message) printf '%%1\n' ;;
+  display-message) case "$*" in *dead-*) exit 1 ;; *) printf '%%1\n' ;; esac ;;
   capture-pane) printf 'all quiet\n> \n' ;;
 esac
 exit 0
@@ -251,6 +251,107 @@ test_perl_fallback_bounds_github_call() {
   pass "Perl fallback bounds stalled GitHub calls without coreutils timeout"
 }
 
+write_large_fixture() {  # <home> <count>
+  local home=$1 count=$2 i id
+  : > "$home/data/backlog.md"
+  printf '## Queued\n' >> "$home/data/backlog.md"
+  i=1
+  while [ "$i" -le "$count" ]; do
+    id="dead-$i"
+    mkdir -p "$home/projects/$id" "$home/data/$id"
+    printf '# Report\n' > "$home/data/$id/report.md"
+    printf -- '- [ ] gate-%s - Gate %s blocked-by: task-%s (repo: repo-%s) (kind: ship)\n' "$i" "$i" "$i" "$i" >> "$home/data/backlog.md"
+    fm_write_meta "$home/state/$id.meta" \
+      "window=firstmate:fm-$id" \
+      "worktree=$home/projects/$id" \
+      "project=repo-$i" \
+      "harness=codex" \
+      "kind=scout" \
+      "mode=scout" \
+      "pr=https://github.com/acme/repo-$i/pull/$i"
+    printf 'needs-decision [key=q%s]: choose %s\n' "$i" "$i" > "$home/state/$id.status"
+    i=$((i + 1))
+  done
+}
+
+test_section_caps_and_expansion_flags() {
+  local home fakebin json expanded
+  home=$(make_home caps); write_large_fixture "$home" 5
+  fakebin=$(make_fakebin "$home")
+  json=$(FM_BEARINGS_IN_FLIGHT=2 FM_BEARINGS_DECISIONS=2 FM_BEARINGS_GATES=2 \
+    FM_BEARINGS_REPORTS=2 FM_BEARINGS_RECORDED_PRS=2 FM_BEARINGS_UNHEALTHY=2 \
+    run "$home" "$fakebin" --json)
+  printf '%s' "$json" | jq -e '
+    (.in_flight|length) == 2 and (.decisions_open|length) == 2 and (.gates|length) == 2
+    and (.reports|length) == 2 and (.recorded_prs|length) == 2 and (.unhealthy_endpoints|length) == 2
+    and ([.omitted[].surface] | index("in_flight showing 2 of 5") != null)
+    and ([.omitted[].surface] | index("decisions_open showing 2 of 5") != null)
+    and ([.omitted[].surface] | index("gates showing 2 of 5") != null)
+    and ([.omitted[].surface] | index("reports showing 2 of 5") != null)
+    and ([.omitted[].surface] | index("recorded_prs showing 2 of 5") != null)
+    and ([.omitted[].surface] | index("unhealthy_endpoints showing 2 of 5") != null)
+  ' >/dev/null || fail "section caps or counted omissions are wrong: $json"
+  expanded=$(FM_BEARINGS_IN_FLIGHT=2 FM_BEARINGS_DECISIONS=2 FM_BEARINGS_GATES=2 \
+    FM_BEARINGS_REPORTS=2 FM_BEARINGS_RECORDED_PRS=2 FM_BEARINGS_UNHEALTHY=2 \
+    run "$home" "$fakebin" --json --all-in-flight --all-decisions --all-queued \
+      --all-reports --all-recorded-prs --all-unhealthy)
+  printf '%s' "$expanded" | jq -e '
+    (.in_flight|length) == 5 and (.decisions_open|length) == 5 and (.gates|length) == 5
+    and (.reports|length) == 5 and (.recorded_prs|length) == 5 and (.unhealthy_endpoints|length) == 5
+  ' >/dev/null || fail "section expansion flags did not reveal full sets: $expanded"
+  pass "all fleet-sized sections are capped with counted opt-in expansion"
+}
+
+test_pr_repository_cap_and_expansion() {
+  local home fakebin json expanded
+  home=$(make_home repo-caps); write_large_fixture "$home" 5
+  fakebin=$(make_fakebin "$home"); : > "$home/net.log"
+  json=$(FM_BEARINGS_PR_REPOS=2 run "$home" "$fakebin" --include-prs --json)
+  [ "$(grep -c '^gh pr list ' "$home/net.log")" = 2 ] || fail "default PR repository cap was not enforced"
+  printf '%s' "$json" | jq -e '
+    [.omitted[] | select(.surface == "PR repositories showing 2 of 5" and .reveal == "--all-pr-repos")] | length == 1
+  ' >/dev/null || fail "PR repository truncation was not recorded: $json"
+  : > "$home/net.log"
+  expanded=$(FM_BEARINGS_PR_REPOS=2 run "$home" "$fakebin" --include-prs --all-pr-repos --json)
+  [ "$(grep -c '^gh pr list ' "$home/net.log")" = 5 ] || fail "--all-pr-repos did not reveal every repository"
+  printf '%s' "$expanded" | jq -e '.candidate_prs | length == 5' >/dev/null \
+    || fail "expanded PR repository set did not enrich every repository: $expanded"
+  pass "live PR enrichment caps repositories with counted expansion"
+}
+
+install_failing_jq() {  # <fakebin> <model|toon>
+  local fakebin=$1 phase=$2 real
+  real=$(command -v jq)
+  cat > "$fakebin/jq" <<SH
+#!/usr/bin/env bash
+case "\$*" in
+  *'def trunc'*) [ "$phase" = model ] && exit 9 ;;
+  *'def q:'*) [ "$phase" = toon ] && exit 9 ;;
+esac
+exec "$real" "\$@"
+SH
+  chmod +x "$fakebin/jq"
+}
+
+test_projection_and_toon_fail_closed() {
+  local home fakebin out err rc
+  home=$(make_home fail-closed); write_fixture "$home"
+  fakebin=$(make_fakebin "$home")
+  install_failing_jq "$fakebin" model
+  err="$home/model.err"
+  out=$(run "$home" "$fakebin" --json 2> "$err"); rc=$?
+  [ "$rc" -ne 0 ] || fail "projection failure exited successfully"
+  [ -z "$out" ] || fail "projection failure emitted output"
+  grep -F 'projection failed' "$err" >/dev/null || fail "projection failure lacked a diagnostic"
+  install_failing_jq "$fakebin" toon
+  err="$home/toon.err"
+  out=$(run "$home" "$fakebin" 2> "$err"); rc=$?
+  [ "$rc" -ne 0 ] || fail "TOON rendering failure exited successfully"
+  [ -z "$out" ] || fail "TOON rendering failure emitted output"
+  grep -F 'TOON rendering failed' "$err" >/dev/null || fail "TOON failure lacked a diagnostic"
+  pass "projection and TOON rendering failures exit nonzero with diagnostics"
+}
+
 # The Lavish-103 defect, end to end: a COMPLETED scout that raised a decision and
 # then finished (done), whose report body reads like that decision, must surface as
 # a report POINTER only - never in decisions_open. Report prose must never open or
@@ -287,3 +388,6 @@ test_superseded_queued_item_dropped_by_default
 test_include_prs_is_the_only_fetch_path
 test_partial_github_failure_degrades
 test_perl_fallback_bounds_github_call
+test_section_caps_and_expansion_flags
+test_pr_repository_cap_and_expansion
+test_projection_and_toon_fail_closed

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -254,6 +254,8 @@ test_pause_verb_override_renders_all_brief_scaffolds() {
     # shellcheck disable=SC2016 # Literal backticks and braces must remain unexpanded.
     assert_no_grep '`paused: {why}`' "$brief" \
       "$kind brief still instructs the default paused status"
+    assert_grep 'or a blocker clears' "$brief" \
+      "$kind brief did not require durable resolution when a blocker clears"
   done
   pass "fm-brief.sh: custom pause verb renders in every scaffold"
 }

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -871,6 +871,21 @@ test_no_run_idle_pane_uses_log() {
   pass "no run + idle pane uses the status-log verb"
 }
 
+test_no_run_idle_pane_uses_keyed_log() {
+  reset_fakes
+  local d; d=$(new_case keyed-idle)
+  make_repo_on_branch "$d/wt" fm/feat-keyed
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-keyed.meta" "window=fm:fm-feat-keyed" "worktree=$d/wt" "kind=ship"
+  printf 'needs-decision [key=q1]: which database?\n' > "$d/state/feat-keyed.status"
+  FM_FAKE_AXI_STATUS=""
+  FM_FAKE_BUSY=0
+  local out; out=$(run_crew_state "$d" feat-keyed)
+  assert_contains "$out" "state: parked" "keyed needs-decision log -> parked"
+  assert_contains "$out" "which database?" "key token is excluded from status detail"
+  pass "no run + idle pane parses keyed status syntax"
+}
+
 # (g') no run + idle pane on a DECLARED external-wait pause -> state: paused, so a
 # supervisor reading the crew sees a distinct pause (and its reason) rather than a
 # wedge-suspect idle. This is the reader half the watcher/daemon build on.
@@ -1115,6 +1130,7 @@ test_no_run_herdr_unknown_uses_backend_capture
 test_no_run_herdr_idle_agent_status_corroborated_by_busy_pane
 test_no_run_herdr_idle_agent_status_and_idle_pane_stays_idle
 test_no_run_idle_pane_uses_log
+test_no_run_idle_pane_uses_keyed_log
 test_no_run_idle_pane_paused
 test_no_run_idle_pane_custom_paused_verb
 test_dead_window_ignores_stale_status_log

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -465,11 +465,75 @@ test_open_decision_clears_on_keyed_resolution() {
   pass "durable fold clears a decision only on a keyed resolution"
 }
 
+# A COMPLETED scout report must never be read as a pending decision. A scout that
+# raised a needs-decision and then finished (done) - its report delivered, its
+# decision either answered or captured in the report for the captain - must surface
+# only as a report POINTER, not a reopened pending decision, even when the report
+# body and the stale status line contain decision-like prose. This is the Lavish-103
+# defect: a terminal single-owner task's stale, never-keyed-resolved needs-decision
+# must not linger as pending. Decisions come purely from the keyed fold reconciled
+# against the crew lifecycle; report prose never opens or reopens a decision.
+test_completed_scout_report_is_pointer_not_pending() {
+  local home fakebin out
+  home=$(make_home completed-scout)
+  mkdir -p "$home/projects/scout-wt" "$home/data/lavish-103"
+  fm_write_meta "$home/state/lavish-103.meta" \
+    "window=firstmate:fm-lavish-103" \
+    "worktree=$home/projects/scout-wt" \
+    "project=firstmate" \
+    "harness=codex" \
+    "kind=scout" \
+    "mode=scout"
+  # Stale needs-decision, then the scout finished (done). No keyed resolution.
+  printf 'needs-decision: adopt approach A or B for Lavish issue 103\n' > "$home/state/lavish-103.status"
+  printf 'done: report ready at data/lavish-103/report.md\n' >> "$home/state/lavish-103.status"
+  # Completed report whose PROSE reads like the decision.
+  printf '# Lavish 103\nThe open question is whether to adopt approach A or B.\nThis needs a captain decision. Recommendation: A.\n' > "$home/data/lavish-103/report.md"
+  fakebin=$(make_fakebin "$home")
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$SNAPSHOT" --json)
+  printf '%s' "$out" | jq -e '
+    .tasks[] | select(.id == "lavish-103")
+    | .current_state.state == "done"
+      and .hints.pending_decision == false
+      and (.hints.open_decisions | length) == 0
+      and .hints.scout_report_present == true
+  ' >/dev/null || fail "a completed scout report must be a pointer, not a pending decision: $out"
+  pass "a completed scout's stale decision surfaces as a report pointer, not pending"
+}
+
+# The complementary safety property: a scout still PARKED at a decision (its last
+# event is the needs-decision, it has not finished) DOES stay pending. The terminal
+# clear must not over-fire on a live, undecided scout.
+test_parked_scout_decision_stays_pending() {
+  local home fakebin out
+  home=$(make_home parked-scout)
+  mkdir -p "$home/projects/scout-wt2"
+  fm_write_meta "$home/state/parked-scout.meta" \
+    "window=firstmate:fm-parked-scout" \
+    "worktree=$home/projects/scout-wt2" \
+    "project=firstmate" \
+    "harness=codex" \
+    "kind=scout" \
+    "mode=scout"
+  printf 'needs-decision [key=q1]: adopt approach A or B\n' > "$home/state/parked-scout.status"
+  fakebin=$(make_fakebin "$home")
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$SNAPSHOT" --json)
+  printf '%s' "$out" | jq -e '
+    .tasks[] | select(.id == "parked-scout")
+    | .hints.pending_decision == true
+      and (.hints.open_decisions | length) == 1
+      and .hints.open_decisions[0].key == "q1"
+  ' >/dev/null || fail "a scout still parked at a decision must stay pending: $out"
+  pass "a scout still parked at a decision stays pending (terminal clear does not over-fire)"
+}
+
 test_empty_fleet_json
 test_fixture_snapshot_json
 test_event_hints_follow_reconciled_current_state
 test_open_decision_survives_later_unrelated_event
 test_open_decision_clears_on_keyed_resolution
+test_completed_scout_report_is_pointer_not_pending
+test_parked_scout_decision_stays_pending
 test_scout_reports_include_teardown_reports
 test_backlog_tasks_axi_forms_and_overrides
 test_view_renders_snapshot

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -404,9 +404,72 @@ test_view_renders_dead_secondmate_agent_status() {
   pass "fleet view renders secondmate agent liveness"
 }
 
+# A still-open decision must survive a LATER, UNRELATED terminal event on the same
+# append-only stream. This is the fmdev masking bug: last-event-wins read the trailing
+# `done` and reported pending_decision=false while a needs-decision was still open. The
+# durable keyed fold (fm-classify-lib.sh) keeps it open until an explicit resolution.
+test_open_decision_survives_later_unrelated_event() {
+  local home fakebin out
+  home=$(make_home masking)
+  mkdir -p "$home/secondmate-home"
+  fm_write_meta "$home/state/masked-decision.meta" \
+    "window=firstmate:fm-masked-decision" \
+    "worktree=$home/secondmate-home" \
+    "project=$home/secondmate-home" \
+    "harness=codex" \
+    "kind=secondmate" \
+    "mode=secondmate" \
+    "home=$home/secondmate-home" \
+    "projects=alpha"
+  # needs-decision opened, then two LATER unrelated events (no resolution).
+  printf 'needs-decision [key=race]: fix the reconcile-before-subscribe race\n' > "$home/state/masked-decision.status"
+  printf 'working: implementing an unrelated subsystem\n' >> "$home/state/masked-decision.status"
+  printf 'done: an unrelated subtask finished\n' >> "$home/state/masked-decision.status"
+  fakebin=$(make_fakebin "$home")
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$SNAPSHOT" --json)
+  printf '%s' "$out" | jq -e '
+    .tasks[] | select(.id == "masked-decision")
+    | .hints.pending_decision == true
+      and (.hints.open_decisions | length) == 1
+      and .hints.open_decisions[0].key == "race"
+      and .hints.open_decisions[0].verb == "needs-decision"
+  ' >/dev/null || fail "later unrelated done must not mask an open needs-decision: $out"
+  pass "durable fold keeps an open decision past a later unrelated event"
+}
+
+# An open decision clears ONLY on an explicit resolution referencing its key, never
+# on an unrelated terminal line.
+test_open_decision_clears_on_keyed_resolution() {
+  local home fakebin out
+  home=$(make_home resolution)
+  mkdir -p "$home/secondmate-home"
+  fm_write_meta "$home/state/resolved-decision.meta" \
+    "window=firstmate:fm-resolved-decision" \
+    "worktree=$home/secondmate-home" \
+    "project=$home/secondmate-home" \
+    "harness=codex" \
+    "kind=secondmate" \
+    "mode=secondmate" \
+    "home=$home/secondmate-home" \
+    "projects=alpha"
+  printf 'needs-decision [key=race]: fix the reconcile-before-subscribe race\n' > "$home/state/resolved-decision.status"
+  printf 'done: an unrelated subtask finished\n' >> "$home/state/resolved-decision.status"
+  printf 'resolved [key=race]: captain chose subscribe-then-reconcile\n' >> "$home/state/resolved-decision.status"
+  fakebin=$(make_fakebin "$home")
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$SNAPSHOT" --json)
+  printf '%s' "$out" | jq -e '
+    .tasks[] | select(.id == "resolved-decision")
+    | .hints.pending_decision == false
+      and (.hints.open_decisions | length) == 0
+  ' >/dev/null || fail "keyed resolution must clear the open decision: $out"
+  pass "durable fold clears a decision only on a keyed resolution"
+}
+
 test_empty_fleet_json
 test_fixture_snapshot_json
 test_event_hints_follow_reconciled_current_state
+test_open_decision_survives_later_unrelated_event
+test_open_decision_clears_on_keyed_resolution
 test_scout_reports_include_teardown_reports
 test_backlog_tasks_axi_forms_and_overrides
 test_view_renders_snapshot

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -42,7 +42,7 @@ case "${1:-}" in
     ;;
   capture-pane)
     case "$target" in
-      *ship-task*) printf 'work in progress\nesc to interrupt\n' ;;
+      *ship-task*|*active-secondmate*) printf 'work in progress\nesc to interrupt\n' ;;
       *) printf 'all quiet\n> \n' ;;
     esac
     ;;
@@ -437,6 +437,31 @@ test_open_decision_survives_later_unrelated_event() {
   pass "durable fold keeps an open decision past a later unrelated event"
 }
 
+test_secondmate_open_decision_survives_live_endpoint() {
+  local home fakebin out
+  home=$(make_home active-secondmate)
+  mkdir -p "$home/secondmate-home"
+  fm_write_meta "$home/state/active-secondmate.meta" \
+    "window=firstmate:fm-active-secondmate" \
+    "worktree=$home/secondmate-home" \
+    "project=$home/secondmate-home" \
+    "harness=codex" \
+    "kind=secondmate" \
+    "mode=secondmate" \
+    "home=$home/secondmate-home" \
+    "projects=alpha"
+  printf 'needs-decision [key=race]: choose ordering\n' > "$home/state/active-secondmate.status"
+  fakebin=$(make_fakebin "$home")
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$SNAPSHOT" --json)
+  printf '%s' "$out" | jq -e '
+    .tasks[] | select(.id == "active-secondmate")
+    | .endpoint.agent_alive == "alive"
+      and .hints.pending_decision == true
+      and (.hints.open_decisions | length) == 1
+  ' >/dev/null || fail "a live secondmate endpoint must not clear an unrelated keyed decision: $out"
+  pass "a live secondmate endpoint preserves unrelated open decisions"
+}
+
 # An open decision clears ONLY on an explicit resolution referencing its key, never
 # on an unrelated terminal line.
 test_open_decision_clears_on_keyed_resolution() {
@@ -531,6 +556,7 @@ test_empty_fleet_json
 test_fixture_snapshot_json
 test_event_hints_follow_reconciled_current_state
 test_open_decision_survives_later_unrelated_event
+test_secondmate_open_decision_survives_live_endpoint
 test_open_decision_clears_on_keyed_resolution
 test_completed_scout_report_is_pointer_not_pending
 test_parked_scout_decision_stays_pending

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -122,7 +122,7 @@ test_scan_captain_relevant_statuses_classifier() {
 }
 
 test_classifier_primitives() {
-  local dir state
+  local dir state open
   dir=$(make_case classify-primitives); state="$dir/state"
   printf 'working: a\n\ndone: b\n\n' > "$state/x.status"
   [ "$(last_status_line "$state/x.status")" = "done: b" ] || fail "last_status_line did not return the last non-blank line"
@@ -134,6 +134,14 @@ test_classifier_primitives() {
   [ "$(window_to_task "default:w1:p2" "$state")" = "herdr-task" ] || fail "window_to_task did not resolve opaque backend target through metadata"
   FM_CAPTAIN_RE='custom-verb:' status_is_captain_relevant "custom-verb: x" || fail "FM_CAPTAIN_RE override not honored"
   FM_CAPTAIN_RE='custom-verb:' status_is_captain_relevant "done: x" && fail "FM_CAPTAIN_RE override did not replace the default verb set"
+  printf 'needs-decision: should docs mention [key=prose]?\nneeds-decision [key=q1]: real choice\nresolved: docs still mention [key=q1]\nneeds-decision [key=bad key]: malformed\n' > "$state/keys.status"
+  open=$(status_open_decisions "$state/keys.status")
+  printf '%s' "$open" | grep -F $'q1\t' >/dev/null \
+    || fail "a key token in resolved note prose closed the keyed decision"
+  printf '%s' "$open" | grep -F $'prose\t' >/dev/null \
+    && fail "a key token in note prose changed the decision key"
+  printf '%s' "$open" | grep -F $'bad key\t' >/dev/null \
+    && fail "an invalid key slug entered the open-decision set"
   pass "classifier primitives: last line, captain-relevance, window->task, FM_CAPTAIN_RE override"
 }
 

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -127,6 +127,7 @@ test_classifier_primitives() {
   printf 'working: a\n\ndone: b\n\n' > "$state/x.status"
   [ "$(last_status_line "$state/x.status")" = "done: b" ] || fail "last_status_line did not return the last non-blank line"
   status_is_captain_relevant "done: b" || fail "done: not recognized as captain-relevant"
+  status_is_captain_relevant "needs-decision [key=q1]: b" || fail "keyed needs-decision not recognized as captain-relevant"
   status_is_captain_relevant "working: b" && fail "working: wrongly recognized as captain-relevant"
   [ "$(window_to_task "sess:fm-fix-login-k3")" = "fix-login-k3" ] || fail "window_to_task did not strip session+fm- prefix"
   fm_write_meta "$state/herdr-task.meta" "window=default:w1:p2" "backend=herdr"


### PR DESCRIPTION
## Intent

Add a deterministic, bounded /bearings data-gathering command so the captain's catch-up briefing runs through one path instead of hand-probing schema and ad-hoc gh calls. Deliberate design: a thin wrapper bin/fm-bearings-snapshot.sh OVER the canonical bin/fm-fleet-snapshot.sh, NOT enrichment added to the canonical snapshot - the canonical snapshot stays pure, offline, read-only, and COMPLETE (fields are dropped only from the bearings PROJECTION, never removed from the canonical schema). TOON is the default agent-facing output at the boundary with --json retained for machine/debug (they are parity representations of one JSON model); this follows the AXI standard. The default is LOCAL-ONLY and makes zero network/auth calls; live open-PR discovery/checks happen ONLY behind --include-prs, which fails soft per repo (a gh failure degrades, never crashes); it uses 'gh --json' for the deterministic read, matching existing precedent in fm-pr-check.sh/fm-teardown.sh. Every deliberately dropped surface is marked in an omitted[] section with the flag that reveals it, and the prs: line states when checks were not requested, so absence is never silent. Core correctness change: fix a last-event-wins masking bug where a later unrelated status event hid a still-open captain decision. fm-classify-lib.sh gains status_open_decisions, the one authoritative keyed open/resolved fold over the whole status stream (needs-decision/blocked opens a keyed entry; only an explicit keyed 'resolved' closes it), and fm-fleet-snapshot.sh surfaces hints.open_decisions and derives pending_decision from it, reconciled against the crew lifecycle. Second, a defect fix: a COMPLETED scout (terminal done/failed, single-owner task) must surface as a report POINTER, not a reopened pending decision, so the reconciliation also clears the keyed set on a terminal state for non-secondmate tasks; secondmates are deliberately EXCLUDED from that terminal clear because they are persistent and multiplex many concerns onto one stream, which is exactly what keeps the unrelated-event masking fix intact. The decision set is derived purely from the keyed fold plus lifecycle reconciliation - never from report body/prose. The /bearings skill now consumes the one command; ship/scout/secondmate briefs gained a 'resolved:' writer line; docs/scripts.md registers the new script. All bin/*.sh are shellcheck-clean and regression tests are colocated in tests/. Per the captain: do NOT merge; the captain merges on green.

## What Changed

- Captain, adds a bounded, deterministic `fm-bearings-snapshot.sh` projection with TOON and JSON output, local-only defaults, explicit omission markers, and opt-in fail-soft PR enrichment.
- Introduces durable keyed decision tracking so unrelated status events cannot hide open decisions, while completed single-owner tasks surface report pointers instead of stale decisions.
- Updates crew brief protocols, `/bearings` guidance, architecture and script documentation, plus regression coverage for snapshot, decision, and status behavior.

## Risk Assessment

✅ Low: Captain, the change is well-bounded and the cumulative implementation resolves all prior findings, including accurate disclosed per-repository PR truncation and JSON/TOON parity.

## Testing

The previously green full baseline suite was supplemented with focused snapshot and related regression suites plus a public-command end-to-end fixture; default TOON, JSON parity, zero-network local mode, explicit omissions, decision lifecycle reconciliation, completed-scout handling, and opt-in PR failure degradation all behaved as intended.

<details>
<summary>Evidence: Default end-user TOON snapshot</summary>

```text
schema: fm-bearings.v1
home: 1/01KX9DBX849AHCDYFBP4J207ZT
generated: "2026-07-11T18:00:00Z"
prs: "not_requested (run: /bearings include PRs)"
in_flight: []
decisions_open: []
landed: []
gates: []
reports: []
recorded_prs: []
omitted[7]{surface,reveal}:
  backlog item bodies,"--fields bodies"
  task paths,"--fields paths"
  watch/steer actions,"--fields actions"
  healthy endpoint detail,"--fields endpoints"
  full scout-report inventory,"--all-reports"
  superseded/held queued items,"--all-queued"
  live PR discovery + checks,"--include-prs"
```
</details>
<details>
<summary>Evidence: JSON parity snapshot</summary>

```text
{
  "schema": "fm-bearings.v1",
  "home": "1/01KX9DBX849AHCDYFBP4J207ZT",
  "generated": "2026-07-11T18:00:00Z",
  "prs": "not_requested (run: /bearings include PRs)",
  "in_flight": [],
  "decisions_open": [],
  "landed": [],
  "gates": [],
  "reports": [],
  "recorded_prs": [],
  "omitted": [
    {
      "surface": "backlog item bodies",
      "reveal": "--fields bodies"
    },
    {
      "surface": "task paths",
      "reveal": "--fields paths"
    },
    {
      "surface": "watch/steer actions",
      "reveal": "--fields actions"
    },
    {
      "surface": "healthy endpoint detail",
      "reveal": "--fields endpoints"
    },
    {
      "surface": "full scout-report inventory",
      "reveal": "--all-reports"
    },
    {
      "surface": "superseded/held queued items",
      "reveal": "--all-queued"
    },
    {
      "surface": "live PR discovery + checks",
      "reveal": "--include-prs"
    }
  ]
}
```
</details>
<details>
<summary>Evidence: End-to-end lifecycle and fail-soft transcript</summary>

```text
true
true
true
e2e assertions passed
```
</details>
<details>
<summary>Evidence: Reproducible end-to-end fixture</summary>

```text
#!/usr/bin/env bash
set -eu
ROOT=/Users/kunchen/.treehouse/01KX9DBX849AHCDYFBP4J207ZT-b8697d/1/01KX9DBX849AHCDYFBP4J207ZT
EVIDENCE=/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KX9DBX849AHCDYFBP4J207ZT
HOME_FIXTURE="$EVIDENCE/e2e-home"
FAKEBIN="$EVIDENCE/e2e-fakebin"
NET_LOG="$EVIDENCE/e2e-network.log"
rm -rf "$HOME_FIXTURE" "$FAKEBIN"
mkdir -p "$HOME_FIXTURE/state" "$HOME_FIXTURE/data/scout-done" "$HOME_FIXTURE/projects/live" "$HOME_FIXTURE/projects/scout" "$FAKEBIN"
cat > "$FAKEBIN/tmux" <<'SH'
#!/usr/bin/env bash
case "${1:-}" in
  display-message) printf '%%1\n' ;;
  capture-pane) printf 'waiting for input\n> \n' ;;
esac
SH
cat > "$FAKEBIN/gh" <<'SH'
#!/usr/bin/env bash
printf 'gh %s\n' "$*" >> "$NET_LOG"
exit 7
SH
chmod +x "$FAKEBIN/tmux" "$FAKEBIN/gh"
cat > "$HOME_FIXTURE/data/backlog.md" <<'EOF'
## In flight
- [ ] live-task - Continue live work (repo: firstmate) (kind: secondmate) (since 2026-07-11)
- [ ] scout-done - Completed investigation data/scout-done/report.md (repo: firstmate) (kind: scout) (since 2026-07-11)

## Queued
- [ ] next-task - Follow-up blocked-by: live-task (repo: firstmate) (kind: ship)
- [ ] old-task - Superseded follow-up (repo: firstmate) (kind: scout)
  NOT REQUIRED - superseded.

## Done
- [x] landed-task - Landed change https://github.com/acme/firstmate/pull/7 (repo: firstmate) (kind: ship) (merged 2026-07-10)
EOF
cat > "$HOME_FIXTURE/state/live-task.meta" <<EOF
window=firstmate:fm-live-task
worktree=$HOME_FIXTURE/projects/live
project=firstmate
harness=codex
kind=secondmate
mode=secondmate
home=$HOME_FIXTURE/projects/live
projects=firstmate
pr=https://github.com/acme/firstmate/pull/9
EOF
cat > "$HOME_FIXTURE/state/live-task.status" <<'EOF'
needs-decision [key=route]: choose route A or B
done: unrelated substep completed
EOF
cat > "$HOME_FIXTURE/state/scout-done.meta" <<EOF
window=firstmate:fm-scout-done
worktree=$HOME_FIXTURE/projects/scout
project=firstmate
harness=codex
kind=scout
mode=scout
EOF
cat > "$HOME_FIXTURE/state/scout-done.status" <<'EOF'
needs-decision [key=approach]: choose approach A or B
done: report ready
EOF
cat > "$HOME_FIXTURE/data/scout-done/report.md" <<'EOF'
# Completed scout
The report discusses whether approach A or B is preferable.
EOF
: > "$NET_LOG"
export NET_LOG
PATH="$FAKEBIN:$PATH" FM_HOME="$HOME_FIXTURE" FM_BEARINGS_NOW=2026-07-11T18:00:00Z "$ROOT/bin/fm-bearings-snapshot.sh" > "$EVIDENCE/06-e2e-open.toon"
PATH="$FAKEBIN:$PATH" FM_HOME="$HOME_FIXTURE" FM_BEARINGS_NOW=2026-07-11T18:00:00Z "$ROOT/bin/fm-bearings-snapshot.sh" --json > "$EVIDENCE/07-e2e-open.json"
test ! -s "$NET_LOG"
jq -e '(.decisions_open | any(.[]; .id=="live-task" and .key=="route")) and (.decisions_open | any(.[]; .id=="scout-done") | not) and (.reports | any(.[]; .id=="scout-done")) and (.gates | any(.[]; .id=="next-task")) and (.gates | any(.[]; .id=="old-task") | not)' "$EVIDENCE/07-e2e-open.json"
printf 'resolved [key=route]: route A selected\n' >> "$HOME_FIXTURE/state/live-task.status"
PATH="$FAKEBIN:$PATH" FM_HOME="$HOME_FIXTURE" FM_BEARINGS_NOW=2026-07-11T18:01:00Z "$ROOT/bin/fm-bearings-snapshot.sh" --json > "$EVIDENCE/08-e2e-resolved.json"
jq -e '(.decisions_open | any(.[]; .id=="live-task" and .key=="route") | not)' "$EVIDENCE/08-e2e-resolved.json"
PATH="$FAKEBIN:$PATH" FM_HOME="$HOME_FIXTURE" FM_BEARINGS_NOW=2026-07-11T18:02:00Z "$ROOT/bin/fm-bearings-snapshot.sh" --include-prs --json > "$EVIDENCE/09-e2e-pr-failsoft.json"
jq -e '(.schema=="fm-bearings.v1") and (.prs | test("unavailable")) and (.candidate_prs|length==0)' "$EVIDENCE/09-e2e-pr-failsoft.json"
grep -q '^gh pr list ' "$NET_LOG"
printf 'e2e assertions passed\n'
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed (5) ✅</summary>

- 🚨 `bin/fm-fleet-snapshot.sh:340` - Unrelated secondmate activity clears every open keyed decision. The activity-based clearing condition applies to all task kinds, contradicting the multiplexed secondmate invariant and recreating the masking bug this change intends to fix. Exclude secondmates from activity-based clearing so only explicit keyed resolution closes their decisions.
- 🚨 `bin/fm-classify-lib.sh:115` - The new keyed status syntax is not understood by the canonical current-state reader. `fm-crew-state.sh` matches the complete pre-colon text as an exact verb, so `needs-decision [key=q1]: ...` and keyed `blocked` statuses become `unknown` on idle or no-run paths. Reuse the shared keyed-status parser across status consumers.
- ⚠️ `bin/fm-bearings-snapshot.sh:195` - The default bearings projection lacks a deterministic overall output bound. `in_flight`, `decisions_open`, `gates`, relevant `reports`, `recorded_prs`, and unhealthy endpoints can grow without limit. Captain, define caps with explicit omitted counts or opt-in expansion flags to preserve the intended bounded-output contract.

🔧 Fix: Captain, preserve keyed decisions across shared status parsing
3 issues (1 error, 2 warnings) still open:
- 🚨 `bin/fm-brief.sh:169` - The durable fold opens entries for both `needs-decision` and `blocked`, while secondmates are exempt from lifecycle clearing. This new instruction only requires `resolved:` when a decision is answered, so a cleared ordinary blocker can remain permanently visible in `decisions_open`. Tell secondmates to resolve both answered decisions and cleared blockers using the original key.
- ⚠️ `bin/fm-classify-lib.sh:132` - `_fm_decision_key` searches the entire status line for `[key=...]`, although the grammar permits it only before the colon. Note prose such as `needs-decision: should docs mention [key=q1]?` is therefore assigned to the wrong key, and analogous `resolved:` prose can close the wrong entry. Parse and validate the optional key only from the pre-colon segment.
- ⚠️ `bin/fm-bearings-snapshot.sh:195` - The bearings projection still lacks a deterministic fleet-size bound: `in_flight`, `decisions_open`, `gates`, relevant `reports`, `recorded_prs`, and unhealthy endpoints are uncapped. `--include-prs` caps results per repository but not repository count or total rows. Captain, define per-section caps with explicit omitted counts or expansion flags.

🔧 Fix: Captain, close blockers and harden keyed decision parsing
2 warnings still open:
- ⚠️ `bin/fm-bearings-snapshot.sh:195` - The default projection is still not deterministically bounded by fleet size: `in_flight`, `decisions_open`, `gates`, relevant `reports`, `recorded_prs`, and unhealthy endpoints are uncapped. The 50 KB test uses one small fixture, while `--include-prs` caps rows per repository but not repository count or total rows. Captain, define per-section caps with explicit omitted counts or expansion flags.
- ⚠️ `bin/fm-bearings-snapshot.sh:105` - `gh_bounded` invokes plain `gh` without a deadline when neither `timeout` nor `gtimeout` is installed. Consequently, `FM_BEARINGS_PR_TIMEOUT` is ignored on stock macOS and `/bearings --include-prs` can hang indefinitely during a stalled network or GitHub call. Use the existing Perl process-group timeout fallback or fail soft when no bounded runner exists.

🔧 Fix: Captain, bound GitHub enrichment without coreutils timeout
2 warnings still open:
- ⚠️ `bin/fm-bearings-snapshot.sh:198` - The projection remains unbounded by fleet size: `in_flight`, `decisions_open`, `gates`, relevant `reports`, `recorded_prs`, and unhealthy endpoints have no caps. The PR path caps only each repository&#39;s rows and call duration, not repository count, aggregate rows, or total runtime. Captain, define per-section and repository caps with explicit omitted counts or expansion flags.
- ⚠️ `bin/fm-bearings-snapshot.sh:168` - The `MODEL=$(...jq...)` assignment does not propagate a projection failure under `set -u`. A malformed canonical snapshot, incompatible schema, or invalid `--argjson` value can therefore make `--json` print blank output and exit successfully. Check the assignment status and exit nonzero with a diagnostic.

🔧 Fix: Captain, bound bearings sections and fail closed
1 warning still open:
- ⚠️ `bin/fm-bearings-snapshot.sh:180` - `gh pr list --limit &#34;$FM_BEARINGS_PR_LIMIT&#34;` silently truncates open PRs within each repository, while the `prs` summary reports the returned count as `N open`. `--all-pr-repos` expands only the repository set, so a repository with more than the default 20 open PRs produces an incomplete catch-up without an `omitted[]` disclosure or a flag that reveals the remainder. Add pagination or a per-repository expansion flag, or explicitly report the result as capped or possibly incomplete.

🔧 Fix: Captain, disclose capped per-repository PR results
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- <code>Baseline supplied by the validation context: `command -v tmux &gt;/dev/null || { echo &#34;tmux is required for e2e tests&#34; &gt;&amp;2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo &#34;== $t ==&#34;; bash &#34;$t&#34; || rc=1; done; exit &#34;$rc&#34;`</code>
- `bash tests/fm-bearings-snapshot.test.sh`
- `bash tests/fm-fleet-snapshot-view.test.sh`
- `bash tests/fm-crew-state.test.sh`
- `bash tests/fm-brief.test.sh`
- `bash tests/fm-watch-triage.test.sh`
- `FM_HOME="$PWD" FM_BEARINGS_NOW=2026-07-11T18:00:00Z bin/fm-bearings-snapshot.sh`
- <code>`FM_HOME=&#34;$PWD&#34; FM_BEARINGS_NOW=2026-07-11T18:00:00Z bin/fm-bearings-snapshot.sh --json` plus a `jq` schema, PR-state, and omission-marker contract assertion</code>
- <code>`run-e2e.sh` fixture verifying zero default GitHub calls, TOON/JSON behavior, keyed decisions surviving unrelated events, explicit resolution, completed-scout report pointers, gate reconciliation, and `--include-prs` fail-soft behavior</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
