### PR TITLE
fix(tmux): defer sends during codex boot screens

### DIFF
--- a/.agents/skills/afk/SKILL.md
+++ b/.agents/skills/afk/SKILL.md
@@ -109,6 +109,11 @@ For tmux that confirmation is a cleared composer, using the same corrected,
 border-aware detector as the composer guard.
 For herdr, normal idle-baseline submits are confirmed by native agent-state showing a real turn started; the ANSI-aware composer classifier remains the affirmative-empty pre-injection guard and conservative fallback for non-idle or unreadable baselines.
 A bordered-empty or ghost-only composer is recognized as empty where that backend uses composer confirmation, rather than mistaken for a swallowed Enter.
+On tmux, the submit core first waits out known codex pre-composer boot/update
+screens (docs/tmux-backend.md "Codex boot guard"); a screen that never clears
+returns `send-deferred` with nothing typed, and the daemon defers the injection
+(logged as "target pane still booting") with the buffered escalation retried
+later, exactly like any other non-`empty` verdict.
 `fm-send.sh` uses the same primitive and exits non-zero
 when a steer's Enter is positively swallowed, so firstmate learns an instruction
 did not land instead of leaving it unsubmitted.

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -150,6 +150,9 @@ Directory trust dialog on first run per repo root: "Do you trust the contents of
 Accept with Enter.
 The decision persists for the repo, so later worktrees of the same project skip it.
 
+Boot screens: a freshly launched codex pane can show an "Update available!" / "Press enter to continue" prompt or an "OpenAI Codex" banner with `model: loading` before its composer exists, and typing then is swallowed by the boot UI.
+The tmux submit core waits these screens out automatically before typing (docs/tmux-backend.md "Codex boot guard"); a `send-deferred` verdict or `fm-send` exit 2 (`send-deferred: pane booting`) means the pane never left that boot screen within the wait window and nothing was typed - peek the pane and retry once it is ready.
+
 Resume after exit with `codex resume <session-id>`.
 The session id is printed on quit.
 

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -511,7 +511,7 @@ fm_backend_send_key() {  # <backend> <target> <key> [expected-label]
 
 # fm_backend_send_text_submit: type text once, then submit and verify,
 # retrying only the submission (never retyping). Echoes the verdict
-# (empty|pending|unknown|send-failed for submit-verifying adapters).
+# (empty|pending|unknown|send-failed|send-deferred for submit-verifying adapters).
 fm_backend_send_text_submit() {  # <backend> <target> <text> <retries> <enter-sleep> <settle> [expected-label]
   local backend=$1
   shift

--- a/bin/fm-send.sh
+++ b/bin/fm-send.sh
@@ -15,6 +15,8 @@
 # submit or reports an inconclusive send. If a swallowed Enter is positively
 # confirmed, fm-send exits NON-ZERO so the caller knows the steer did not land
 # instead of silently leaving an unsubmitted instruction.
+# For tmux/codex, a pre-composer boot/update screen is also deferred before any
+# typing; if it persists, fm-send exits NON-ZERO instead of injecting into boot UI.
 # Submission dispatches through the target's recorded backend; the tmux adapter
 # shares its composer/submit core with the away-mode daemon via bin/fm-tmux-lib.sh.
 # Tune with FM_SEND_RETRIES (default 3) / FM_SEND_SLEEP (0.4).
@@ -234,6 +236,10 @@ else
     send-failed)
       echo "error: text not sent to $T ($TARGET_BACKEND send failed; tried $RESOLUTION_TRIED)" >&2
       exit 1
+      ;;
+    send-deferred)
+      echo "send-deferred: pane booting" >&2
+      exit 2
       ;;
   esac
   # Submit landed (verdict was not pending/send-failed). Confirmation only proves

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -1178,7 +1178,11 @@ inject_msg() {  # <message> [state]
   if [ "$verdict" = empty ]; then
     return 0  # Backend confirmed the submit.
   fi
-  log "inject failed: submit unconfirmed after $retries retries (verdict=$verdict, text may be in composer)"
+  if [ "$verdict" = send-deferred ]; then
+    log "inject failed: target pane still booting after boot-wait window (verdict=$verdict, nothing typed)"
+  else
+    log "inject failed: submit unconfirmed after $retries retries (verdict=$verdict, text may be in composer)"
+  fi
   return 1
 }
 

--- a/bin/fm-tmux-lib.sh
+++ b/bin/fm-tmux-lib.sh
@@ -133,11 +133,42 @@ fm_pane_is_busy() {  # <target>
     | grep -qiE "${FM_BUSY_REGEX:-$FM_TMUX_BUSY_REGEX_DEFAULT}"
 }
 
+# fm_tmux_pane_boot_state: classify known pre-composer codex screens as booting.
+# A codex pane can briefly show an update prompt or model-loading banner before
+# its real composer is ready. Typing during that window can be swallowed by the
+# boot UI, so submit callers wait until these codex-specific screens clear.
+fm_tmux_pane_boot_state() {  # <target> -> booting|ready|unknown
+  local target=$1 tail40
+  tail40=$(tmux capture-pane -p -t "$target" -S -40 2>/dev/null) || { printf 'unknown'; return 0; }
+  if printf '%s\n' "$tail40" | grep -qiE 'Update available!' \
+     && printf '%s\n' "$tail40" | grep -qiE 'Press enter to continue'; then
+    printf 'booting'; return 0
+  fi
+  if printf '%s\n' "$tail40" | grep -qiE 'OpenAI Codex' \
+     && printf '%s\n' "$tail40" | grep -qiE 'model:[[:space:]]+loading'; then
+    printf 'booting'; return 0
+  fi
+  printf 'ready'; return 0
+}
+
+fm_tmux_wait_until_not_booting() {  # <target> -> ready|unknown|send-deferred
+  local target=$1 max_s=${FM_TMUX_BOOT_WAIT_SECS:-20} poll_s=${FM_TMUX_BOOT_POLL_SLEEP:-1}
+  local elapsed=0 state
+  while :; do
+    state=$(fm_tmux_pane_boot_state "$target")
+    [ "$state" = booting ] || { printf '%s' "$state"; return 0; }
+    [ "$elapsed" -lt "$max_s" ] || { printf 'send-deferred'; return 0; }
+    sleep "$poll_s"
+    elapsed=$((elapsed + poll_s))
+  done
+}
+
 # fm_tmux_submit_core: type <text> into <target> ONCE, then submit with Enter,
 # verifying the composer cleared. Retries Enter ONLY — never retypes, because a
 # swallowed Enter leaves our text in the composer and retyping would duplicate
-# it. Echoes the final verdict on stdout (empty|pending|unknown|send-failed) so callers can
-# pick their own success policy:
+# it. Echoes the final verdict on stdout
+# (empty|pending|unknown|send-failed|send-deferred) so callers can pick their own
+# success policy:
 #   - the daemon clears its buffer only on "empty" (strict: an unknown pane must
 #     not be mistaken for a delivered escalation).
 #   - fm-send fails only on "pending" (lenient: a positively-confirmed swallow),
@@ -155,7 +186,9 @@ fm_tmux_submit_enter_core() {  # <target> <retries> <enter-sleep>
 }
 
 fm_tmux_submit_core() {  # <target> <text> <retries> <enter-sleep> <settle>
-  local target=$1 text=$2 retries=$3 sleep_s=$4 settle=$5
+  local target=$1 text=$2 retries=$3 sleep_s=$4 settle=$5 boot_state
+  boot_state=$(fm_tmux_wait_until_not_booting "$target")
+  [ "$boot_state" != send-deferred ] || { printf 'send-deferred'; return 0; }
   tmux send-keys -t "$target" -l "$text" 2>/dev/null || { printf 'send-failed'; return 0; }
   sleep "$settle"
   fm_tmux_submit_enter_core "$target" "$retries" "$sleep_s"

--- a/bin/fm-tmux-lib.sh
+++ b/bin/fm-tmux-lib.sh
@@ -153,6 +153,8 @@ fm_tmux_pane_boot_state() {  # <target> -> booting|ready|unknown
 
 fm_tmux_wait_until_not_booting() {  # <target> -> ready|unknown|send-deferred
   local target=$1 max_s=${FM_TMUX_BOOT_WAIT_SECS:-20} poll_s=${FM_TMUX_BOOT_POLL_SLEEP:-1}
+  case $max_s in '' | *[!0-9]*) max_s=20 ;; esac
+  case $poll_s in '' | *[!0-9]* | 0) poll_s=1 ;; esac
   local elapsed=0 state
   while :; do
     state=$(fm_tmux_pane_boot_state "$target")

--- a/docs/cmux-backend.md
+++ b/docs/cmux-backend.md
@@ -334,7 +334,7 @@ Per this build task's explicit direction, `fm_backend_cmux_composer_state` is ad
 After that adapter-owned row finding, cmux delegates the shared `empty`/`pending`/`unknown` decision to `bin/fm-composer-lib.sh`; a bare shell prompt with no boxed composer row reads `unknown`, not empty.
 This directly defends against the same class of incident herdr hit on 2026-07-03: a slash-command popup's first Enter can close the popup and fill an argument-hint placeholder into the composer rather than submitting, which a raw pane-content-diff check (zellij's approach) would misread as "submitted".
 `tests/fm-backend-cmux.test.sh` pins this exact regression shape (`test_send_text_submit_popup_autocomplete_requires_second_enter`), verifying the adapter retries a genuine second Enter rather than declaring victory after the first one closes a popup.
-All implemented submit-verifying backends expose the identical caller-facing verdict vocabulary (`empty`, `pending`, `unknown`, `send-failed`), so `fm-send.sh` needs no cmux-specific branching.
+All implemented submit-verifying backends expose the identical caller-facing verdict vocabulary (`empty`, `pending`, `unknown`, `send-failed`, plus the tmux boot guard's `send-deferred`; docs/tmux-backend.md "Codex boot guard"), so `fm-send.sh` needs no cmux-specific branching.
 
 ## Test safety
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -369,6 +369,8 @@ GROK_HOME=              # optional Grok config home for firstmate's global grok 
 FM_SEND_RETRIES=3       # fm-send Enter-retry attempts after typing the line once
 FM_SEND_SLEEP=0.4       # seconds between fm-send submit checks
 FM_SEND_SETTLE=1        # seconds fm-send waits after a successful text submit; 0 disables
+FM_TMUX_BOOT_WAIT_SECS=20   # max seconds the tmux submit core waits for a known codex pre-composer boot/update screen to clear before deferring the send (verdict send-deferred, nothing typed)
+FM_TMUX_BOOT_POLL_SLEEP=1   # seconds between those boot-state polls
 # sub-supervisor (bin/fm-supervise-daemon.sh); presence-gated via /afk
 FM_SUPERVISOR_BACKEND=             # optional supervisor pane backend override; tmux/herdr only, otherwise detects $TMUX_PANE then HERDR_ENV/HERDR_PANE_ID before tmux fallback
 FM_SUPERVISOR_TARGET=              # optional supervisor pane target override; tmux target or herdr <session>:<pane-id>, otherwise auto-detected

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -264,7 +264,7 @@ That classifier is still the away-mode daemon's affirmative-empty pre-injection 
 Normal idle-baseline submit confirmation now uses herdr's native agent-state instead; see "Native agent-state submit confirmation" for the current submit path.
 A dedicated composer-state or cursor-row/style primitive is still a candidate upstream Herdr feature request; it would let the guard/fallback classifier eventually reach tmux's cursor-row precision instead of relying on a structural approximation over captured tail rows and ANSI style.
 
-All implemented backends expose the identical caller-facing verdict vocabulary (`empty`, `pending`, `unknown`, `send-failed`), so `fm-send.sh` needs no backend-specific branching at all.
+All implemented backends expose the identical caller-facing verdict vocabulary (`empty`, `pending`, `unknown`, `send-failed`, plus the tmux boot guard's `send-deferred`; docs/tmux-backend.md "Codex boot guard"), so `fm-send.sh` needs no backend-specific branching at all.
 
 ## Session targeting: the `--session` flag, not `HERDR_SESSION` alone
 

--- a/docs/tmux-backend.md
+++ b/docs/tmux-backend.md
@@ -77,6 +77,12 @@ It reads tmux's own `#{pane_current_command}`, which reports the pane's live for
 Agent liveness and composer safety are separate checks.
 During away-mode escalation delivery, `fm_tmux_composer_state` sends a bare shell glyph on an unbordered row to the shared composer classifier as `unknown`, and the daemon injects only into an affirmatively `empty` composer; see [Composer-emptiness safety](herdr-backend.md#composer-emptiness-safety-2026-07-10-fleet-wide-across-all-four-backends).
 
+## Codex boot guard
+
+A codex pane can briefly show a pre-composer boot screen - an "Update available!" / "Press enter to continue" prompt or an "OpenAI Codex" banner with `model: loading` - before its real composer exists, and typing during that window is swallowed by the boot UI.
+`fm_tmux_submit_core` (`bin/fm-tmux-lib.sh`) therefore classifies the pane with `fm_tmux_pane_boot_state` before typing anything and waits for those codex-specific screens to clear, polling every `FM_TMUX_BOOT_POLL_SLEEP` seconds (default 1) for up to `FM_TMUX_BOOT_WAIT_SECS` seconds (default 20).
+A screen that never clears yields the verdict `send-deferred` with nothing typed: `fm-send.sh` exits non-zero (`send-deferred: pane booting`) instead of injecting into boot UI, and the away-mode daemon logs the injection as deferred with the buffered escalation retried later.
+
 Verified empirically with real tmux 3.6a on macOS (Darwin 25.5.0), 2026-07-07:
 
 ```sh

--- a/docs/zellij-backend.md
+++ b/docs/zellij-backend.md
@@ -185,7 +185,7 @@ This is why `fm_backend_zellij_kill` resolves the owning tab id from the pane wh
 
 Zellij's CLI exposes no cursor-row/ANSI-only capture primitive (like tmux's), so `fm_backend_zellij_send_text_submit` still uses a content-diff strategy: capture the pane right after typing (the unsubmitted "typed" baseline), then after each Enter attempt capture again - unchanged means retry, changed means submitted.
 This is now zellij-specific; the herdr adapter moved away from content-diff after the 2026-07-03 grok slash-submit incident and now confirms normal idle-baseline submits through native agent-state, retaining structural composer-state for the affirmative-empty injection guard and submit fallback.
-All implemented submit-verifying backends expose the identical caller-facing verdict vocabulary (`empty`, `pending`, `unknown`, `send-failed`), so `fm-send.sh` needs no backend-specific branching.
+All implemented submit-verifying backends expose the identical caller-facing verdict vocabulary (`empty`, `pending`, `unknown`, `send-failed`, plus the tmux boot guard's `send-deferred`; docs/tmux-backend.md "Codex boot guard"), so `fm-send.sh` needs no backend-specific branching.
 
 ## Session safety
 

--- a/tests/fm-backend-tmux-smoke.test.sh
+++ b/tests/fm-backend-tmux-smoke.test.sh
@@ -62,8 +62,18 @@ pass "real tmux: fm_backend_tmux_create_task creates a window and refuses a dupl
 
 # --- send text + Enter -------------------------------------------------------
 
-tmux send-keys -t "$TARGET" "cd /tmp && PS1='smoke\$ '" Enter
-sleep 0.3
+# Keystrokes typed before the pane's shell finishes starting can be flushed by
+# the line editor and never execute, so confirm shell readiness first: retype
+# the (idempotent) prompt setup until the custom prompt actually renders.
+ready=
+for _ in $(seq 1 25); do
+  tmux send-keys -t "$TARGET" "cd /tmp && PS1='smoke\$ '" Enter
+  sleep 0.4
+  case "$(tmux capture-pane -p -t "$TARGET" 2>/dev/null)" in
+    *'smoke$'*) ready=1; break ;;
+  esac
+done
+[ -n "$ready" ] || fail "real tmux: pane shell never became interactive (no smoke\$ prompt)"
 tmux send-keys -t "$TARGET" -l "clear" ; tmux send-keys -t "$TARGET" Enter
 sleep 0.3
 

--- a/tests/fm-backend-tmux-smoke.test.sh
+++ b/tests/fm-backend-tmux-smoke.test.sh
@@ -98,8 +98,18 @@ pass "real tmux: fm_backend_tmux_send_literal + fm_backend_tmux_send_key Enter s
 # earliest lines scroll out of a small window) while a large one reaches back
 # far enough to still see the earliest line - the same -S -N bounding fm-peek.sh
 # and fm-watch.sh rely on for a bounded, cheap pane read.
-fm_backend_tmux_send_text_line "$TARGET" "for i in \$(seq 1 80); do echo tag-line-\$i; done"
-sleep 0.6
+# shellcheck disable=SC2016  # literal shell code typed into the tmux pane
+fm_backend_tmux_send_literal "$TARGET" 'for i in $(seq 1 80); do echo tag-line-$i; done' \
+  || fail "fm_backend_tmux_send_literal failed for numbered output"
+sleep 0.2
+fm_backend_tmux_send_key "$TARGET" Enter || fail "fm_backend_tmux_send_key Enter failed for numbered output"
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+  out=$(fm_backend_tmux_capture "$TARGET" 20) || fail "fm_backend_tmux_capture failed while waiting for numbered output"
+  case "$out" in
+    *tag-line-80*) break ;;
+    *) sleep 0.2 ;;
+  esac
+done
 small=$(fm_backend_tmux_capture "$TARGET" 3) || fail "fm_backend_tmux_capture (small window) failed"
 case "$small" in
   *tag-line-1$'\n'*) fail "a 3-line capture should not still see the very first numbered line"$'\n'"$small" ;;

--- a/tests/fm-backlog-handoff.test.sh
+++ b/tests/fm-backlog-handoff.test.sh
@@ -12,6 +12,9 @@ set -u
 # The move is delegated to `tasks-axi mv`, so this suite exercises the real
 # binary. Skip cleanly when it is absent (matching the backend smoke suites).
 command -v tasks-axi >/dev/null 2>&1 || { echo "skip: tasks-axi not found (required by the delegated handoff path)"; exit 0; }
+# shellcheck source=bin/fm-tasks-axi-lib.sh disable=SC1091
+. "$ROOT/bin/fm-tasks-axi-lib.sh"
+fm_tasks_axi_compatible || { echo "skip: tasks-axi lacks atomic multi-ID mv support (0.2.2+, required by the delegated handoff path)"; exit 0; }
 
 TMP_ROOT=$(fm_test_tmproot fm-backlog-handoff)
 

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -159,7 +159,7 @@ run_bootstrap_timeout_case() {
     sleep() {
       local inc=${1:-1}
       SECONDS=$((SECONDS + inc))
-      if [ "${FM_FAKE_SLEEP_YIELDS:-0}" -lt 5 ]; then
+      if [ "${FM_FAKE_SLEEP_YIELDS:-0}" -lt 20 ]; then
         FM_FAKE_SLEEP_YIELDS=$((${FM_FAKE_SLEEP_YIELDS:-0} + 1))
         command sleep 0.01
       fi

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -396,7 +396,9 @@ test_fleet_sync_timeout_explicit_override_wins() {
 
   out=$(run_bootstrap_timeout_case "$home" "$fake_root" "$fakebin" 7)
 
-  assert_contains "$out" "FLEET_SYNC: fleet: skipped: bootstrap refresh timed out (timeout=7s elapsed=7s)" "explicit timeout override should still win over computed default"
+  # Real wall-clock seconds tick alongside the fake sleep's increments, so
+  # elapsed may overshoot the timeout by a tick; assert only the timeout value.
+  assert_contains "$out" "FLEET_SYNC: fleet: skipped: bootstrap refresh timed out (timeout=7s elapsed=" "explicit timeout override should still win over computed default"
   assert_not_contains "$out" "timeout=59s" "explicit override should not be replaced by the computed timeout"
   pass "bootstrap preserves FM_FLEET_SYNC_BOOTSTRAP_TIMEOUT as an explicit override"
 }

--- a/tests/fm-gotmp.test.sh
+++ b/tests/fm-gotmp.test.sh
@@ -52,6 +52,7 @@ make_fake_root() {
   ln -s "$ROOT/bin/fm-backend.sh" "$fake/bin/fm-backend.sh"
   ln -s "$ROOT/bin/backends/tmux.sh" "$fake/bin/backends/tmux.sh"
   ln -s "$ROOT/bin/fm-tmux-lib.sh" "$fake/bin/fm-tmux-lib.sh"
+  ln -s "$ROOT/bin/fm-composer-lib.sh" "$fake/bin/fm-composer-lib.sh"
   # fm-lock-lib.sh: teardown sources it for the shared lock-staleness proof.
   ln -s "$ROOT/bin/fm-lock-lib.sh" "$fake/bin/fm-lock-lib.sh"
   # fm-guard.sh: stub (teardown calls it with `|| true`).
@@ -148,6 +149,7 @@ test_teardown_skips_gracefully_without_tasktmp() {
   ln -s "$ROOT/bin/fm-backend.sh" "$fake/bin/fm-backend.sh"
   ln -s "$ROOT/bin/backends/tmux.sh" "$fake/bin/backends/tmux.sh"
   ln -s "$ROOT/bin/fm-tmux-lib.sh" "$fake/bin/fm-tmux-lib.sh"
+  ln -s "$ROOT/bin/fm-composer-lib.sh" "$fake/bin/fm-composer-lib.sh"
   ln -s "$ROOT/bin/fm-lock-lib.sh" "$fake/bin/fm-lock-lib.sh"
   cat > "$fake/bin/fm-guard.sh" <<'SH'
 #!/usr/bin/env bash

--- a/tests/fm-pi-watch-extension.test.sh
+++ b/tests/fm-pi-watch-extension.test.sh
@@ -334,7 +334,7 @@ const hooks = await mod.FmPrimaryWatchArm({
 });
 writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
 await hooks.event({ event: { type: "session.idle", properties: { sessionID: "session-test" } } });
-for (let i = 0; i < 50 && !existsSync(process.env.FM_ARM_LOG); i += 1) {
+for (let i = 0; i < 150 && !existsSync(process.env.FM_ARM_LOG); i += 1) {
   await new Promise((resolve) => setTimeout(resolve, 20));
 }
 if (!existsSync(process.env.FM_ARM_LOG)) {
@@ -384,7 +384,7 @@ const hooks = await mod.FmPrimaryWatchArm({
 });
 writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
 await hooks.event({ event: { type: "session.idle", properties: { sessionID: "session-test" } } });
-for (let i = 0; i < 50 && !existsSync(process.env.FM_ARM_LOG); i += 1) {
+for (let i = 0; i < 150 && !existsSync(process.env.FM_ARM_LOG); i += 1) {
   await new Promise((resolve) => setTimeout(resolve, 20));
 }
 if (!existsSync(process.env.FM_ARM_LOG)) {
@@ -441,7 +441,7 @@ if (existsSync(process.env.FM_ARM_LOG)) {
 }
 writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
 await hooks.event(event);
-for (let i = 0; i < 50 && !existsSync(process.env.FM_ARM_LOG); i += 1) {
+for (let i = 0; i < 150 && !existsSync(process.env.FM_ARM_LOG); i += 1) {
   await new Promise((resolve) => setTimeout(resolve, 20));
 }
 if (!existsSync(process.env.FM_ARM_LOG)) {
@@ -526,7 +526,7 @@ import { pathToFileURL } from "node:url";
 const mod = await import(pathToFileURL(process.env.PLUGIN).href);
 let prompts = 0;
 const waitForPrompts = async (expected) => {
-  for (let i = 0; i < 50; i += 1) {
+  for (let i = 0; i < 150; i += 1) {
     if (prompts >= expected) return;
     await new Promise((resolve) => setTimeout(resolve, 20));
   }
@@ -609,7 +609,7 @@ const guardHooks = await guardMod.FmPrimaryTurnendGuard({
 });
 writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
 await guardHooks.event({ event: { type: "session.idle", properties: { sessionID: "session-test" } } });
-for (let i = 0; i < 50 && !existsSync(process.env.FM_ARM_LOG); i += 1) {
+for (let i = 0; i < 150 && !existsSync(process.env.FM_ARM_LOG); i += 1) {
   await new Promise((resolve) => setTimeout(resolve, 20));
 }
 if (!existsSync(process.env.FM_ARM_LOG)) {

--- a/tests/fm-secondmate-lifecycle-e2e.test.sh
+++ b/tests/fm-secondmate-lifecycle-e2e.test.sh
@@ -157,6 +157,12 @@ phase_handoff() {
     echo "skip: tasks-axi not found (backlog handoff delegates to it)"
     return 0
   fi
+  # shellcheck source=bin/fm-tasks-axi-lib.sh disable=SC1091
+  . "$ROOT/bin/fm-tasks-axi-lib.sh"
+  if ! fm_tasks_axi_compatible; then
+    echo "skip: tasks-axi lacks atomic multi-ID mv support (0.2.2+, backlog handoff delegates to it)"
+    return 0
+  fi
   cat > "$HOME_DIR/data/backlog.md" <<'EOF'
 ## In flight
 - [ ] live-task - active work (repo: alpha, since 2026-06-20)

--- a/tests/fm-tmux-boot-guard.test.sh
+++ b/tests/fm-tmux-boot-guard.test.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# tmux/codex boot guard.
+#
+# Codex can briefly show pre-composer UI such as an update prompt or a
+# model-loading banner. The tmux send primitive must wait for that state to clear
+# before typing, and must fail distinctly if the pane never becomes ready.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+LIB="$ROOT/bin/fm-tmux-lib.sh"
+# shellcheck source=bin/fm-tmux-lib.sh
+. "$LIB"
+
+TMP_ROOT=$(fm_test_tmproot fm-tmux-boot)
+
+make_fake_tmux() {  # <dir>
+  local dir=$1 fb="$1/fakebin"
+  mkdir -p "$fb"
+  cat > "$fb/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+state="${FM_FAKE_STATE:?FM_FAKE_STATE unset}"
+sent="${FM_FAKE_SENT:-/dev/null}"
+case "${1:-}" in
+  display-message)
+    for a in "$@"; do case "$a" in *cursor_y*) printf '0\n'; exit 0 ;; esac; done
+    printf 'fakepane\n'
+    exit 0 ;;
+  capture-pane)
+    reads=0
+    [ -f "$state.reads" ] && reads=$(cat "$state.reads")
+    reads=$((reads + 1))
+    printf '%s\n' "$reads" > "$state.reads"
+    if [ "${FM_FAKE_ALWAYS_BOOT:-0}" = 1 ]; then
+      cat "$state.boot"
+    elif [ "$reads" -le "${FM_FAKE_BOOT_READS:-0}" ]; then
+      cat "$state.boot"
+    else
+      cat "$state.ready"
+    fi
+    exit 0 ;;
+  send-keys)
+    shift
+    text=""; lit=0; is_enter=0
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        -t) shift ;;
+        -l) lit=1 ;;
+        Enter) is_enter=1 ;;
+        *) [ "$lit" = 1 ] && text="$1" ;;
+      esac
+      shift
+    done
+    if [ "$is_enter" = 1 ]; then
+      printf '[ENTER]\n' >> "$sent"
+    elif [ "$lit" = 1 ]; then
+      printf '%s\n' "$text" >> "$sent"
+    fi
+    exit 0 ;;
+esac
+exit 1
+SH
+  chmod +x "$fb/tmux"
+  printf '%s\n' "$fb"
+}
+
+write_fixture() {  # <dir>
+  local dir=$1
+  cat > "$dir/state.boot" <<'EOF'
+╭──────────────────────────────────────────────────────╮
+│ >_ OpenAI Codex (v0.136.0)                           │
+│                                                      │
+│ model:     loading   /model to change                │
+│ directory: /tmp/firstmate                            │
+╰──────────────────────────────────────────────────────╯
+EOF
+  printf '│ > │\n' > "$dir/state.ready"
+}
+
+test_boot_state_detected_causes_deferred_send() {
+  local dir fb sent verdict
+  dir="$TMP_ROOT/deferred"; mkdir -p "$dir"
+  write_fixture "$dir"
+  fb=$(make_fake_tmux "$dir")
+  sent="$dir/sent.log"; : > "$sent"
+  verdict=$(PATH="$fb:$PATH" FM_FAKE_STATE="$dir/state" FM_FAKE_SENT="$sent" \
+    FM_FAKE_ALWAYS_BOOT=1 FM_TMUX_BOOT_WAIT_SECS=0 \
+    fm_tmux_submit_core "win" "hello captain" 2 0 0)
+  [ "$verdict" = send-deferred ] || fail "booting pane should report send-deferred, got '$verdict'"
+  [ ! -s "$sent" ] || fail "booting pane received typed text"$'\n'"$(cat "$sent")"
+  pass "tmux send: boot-state is detected and the send is deferred before typing"
+}
+
+test_boot_resolves_then_send_proceeds() {
+  local dir fb sent verdict
+  dir="$TMP_ROOT/resolves"; mkdir -p "$dir"
+  write_fixture "$dir"
+  fb=$(make_fake_tmux "$dir")
+  sent="$dir/sent.log"; : > "$sent"
+  verdict=$(PATH="$fb:$PATH" FM_FAKE_STATE="$dir/state" FM_FAKE_SENT="$sent" \
+    FM_FAKE_BOOT_READS=1 FM_TMUX_BOOT_WAIT_SECS=2 FM_TMUX_BOOT_POLL_SLEEP=1 \
+    fm_tmux_submit_core "win" "hello captain" 2 0 0)
+  [ "$verdict" = empty ] || fail "send should proceed after boot clears, got '$verdict'"
+  grep -Fx 'hello captain' "$sent" >/dev/null || fail "text was not typed after boot cleared"
+  grep -Fx '[ENTER]' "$sent" >/dev/null || fail "Enter was not sent after text"
+  pass "tmux send: boot-state clearing lets the send proceed"
+}
+
+test_fm_send_reports_persistent_boot_distinctly() {
+  local dir fb home sent err rc
+  dir="$TMP_ROOT/fm-send"; mkdir -p "$dir"
+  write_fixture "$dir"
+  fb=$(make_fake_tmux "$dir")
+  home="$dir/home"; mkdir -p "$home/state"
+  sent="$dir/sent.log"; err="$dir/send.err"; : > "$sent"
+  PATH="$fb:$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$home" FM_FAKE_STATE="$dir/state" \
+    FM_FAKE_SENT="$sent" FM_FAKE_ALWAYS_BOOT=1 FM_TMUX_BOOT_WAIT_SECS=0 \
+    "$ROOT/bin/fm-send.sh" sess:win "hello captain" >/dev/null 2>"$err"
+  rc=$?
+  expect_code 2 "$rc" "fm-send persistent boot"
+  grep -F 'send-deferred: pane booting' "$err" >/dev/null \
+    || fail "fm-send did not report the distinct booting failure: $(cat "$err")"
+  [ ! -s "$sent" ] || fail "fm-send typed into a persistently booting pane"
+  pass "fm-send: persistent boot exits distinctly without typing"
+}
+
+test_boot_state_detected_causes_deferred_send
+test_boot_resolves_then_send_proceeds
+test_fm_send_reports_persistent_boot_distinctly


### PR DESCRIPTION
## Summary

Defers tmux `send-keys` to a crewmate pane while it is still on an interactive
boot/splash screen (notably codex's startup screens), so keystrokes are not
swallowed or misinterpreted before the shell is ready to receive input.

- `bin/fm-tmux-lib.sh`: adds a boot-state guard that detects when the target
  pane is still rendering a boot/splash screen and polls for shell readiness
  before delivering keys, rather than sending blindly.
- `bin/fm-send.sh`: when the guard determines the pane is not yet ready, the
  send is deferred and the call reports a `send-deferred` verdict (with a clear
  inject log line) instead of silently dropping input.
- `tests/fm-tmux-boot-guard.test.sh`: new colocated test covering the
  boot-state detection and the deferred-send path.

Also includes the pipeline's review/test/doc fix rounds folded in on top of the
core change: hardened boot-guard poll values, a clarified send-deferred inject
log line, tmux smoke test now waits for shell readiness, handoff tests skip on
old tasks-axi, a relaxed bootstrap elapsed assertion, and documentation of the
tmux codex boot guard and send-deferred verdict.

## Validation

- shellcheck clean on the touched `bin/` scripts.
- Full repo test suite green, including the new `tests/fm-tmux-boot-guard.test.sh`.
