### PR TITLE
fix(bootstrap): pin + checksum-verify no-mistakes install

### DIFF
--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -179,7 +179,12 @@ install_cmd() {
   case "$1" in
     tmux|node|gh|curl|jq|orca) echo "brew install $1  # or the platform's package manager" ;;
     treehouse) echo "curl -fsSL https://kunchenguid.github.io/treehouse/install.sh | sh" ;;
-    no-mistakes) echo "curl -fsSL https://raw.githubusercontent.com/kunchenguid/no-mistakes/main/docs/install.sh | sh" ;;
+    # Pinned + checksum-verified install of a specific no-mistakes release,
+    # replacing the former unversioned, unverified `curl .../main/docs/install.sh
+    # | sh`. The version pin, per-platform SHA256s, and fail-closed verification
+    # live in fm-install-no-mistakes.sh; a FUTURE step will mirror the artifact to
+    # our own storage and later replace the engine with our own squared-away.
+    no-mistakes) echo "$SCRIPT_DIR/fm-install-no-mistakes.sh" ;;
     gh-axi|chrome-devtools-axi|lavish-axi) echo "npm install -g $1 && $1 setup hooks" ;;
     tasks-axi) echo "npm install -g tasks-axi" ;;
     *) return 1 ;;

--- a/bin/fm-install-no-mistakes.sh
+++ b/bin/fm-install-no-mistakes.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# Pinned, checksum-verified installer for the no-mistakes engine.
+#
+# This replaces the former bootstrap install path
+#   curl -fsSL https://raw.githubusercontent.com/kunchenguid/no-mistakes/main/docs/install.sh | sh
+# which was a supply-chain + integrity risk: it fetched an installer from a third
+# party's MAIN branch (unversioned, so it silently drifted) and that installer
+# then downloaded an UNSIGNED, UN-CHECKSUMMED release tarball. Here we instead
+# download a PINNED release asset from the tagged GitHub release and VERIFY its
+# SHA256 against a checksum pinned in this script before installing. There is no
+# trust-on-first-use and no fallback to the old curl|sh: a checksum mismatch or a
+# missing asset FAILS CLOSED (nothing is installed).
+#
+# FUTURE WORK (tracked, deliberately NOT done here): a later step will
+#   (a) MIRROR the artifact to our own storage so bootstrap no longer depends on
+#       the third party's GitHub staying up (availability-independence; the
+#       FM_NO_MISTAKES_BASE_URL override below is the seam for that), and
+#   (b) ultimately REPLACE this third-party engine with our own from-scratch
+#       `squared-away` engine.
+# This task removes only the unversioned/unverified INTEGRITY risk. The
+# AVAILABILITY dependency on upstream GitHub remains until step (a).
+#
+# Install layout mirrors the upstream installer it replaces, so re-installing
+# over an existing setup is seamless:
+#   binary  -> $NO_MISTAKES_INSTALL_DIR (default $HOME/.no-mistakes/bin)/no-mistakes
+#   symlink -> $NO_MISTAKES_LINK_DIR (default $HOME/.local/bin when on PATH, else
+#              /usr/local/bin)/no-mistakes
+#
+# Usage: fm-install-no-mistakes.sh
+#   Env overrides:
+#     NO_MISTAKES_INSTALL_DIR, NO_MISTAKES_LINK_DIR - install/symlink locations
+#       (same names the upstream installer honored).
+#     FM_NO_MISTAKES_BASE_URL - override the release-download base URL. Defaults
+#       to GitHub release assets; the seam for future artifact mirroring and for
+#       hermetic tests.
+#     FM_NO_MISTAKES_SKIP_DAEMON=1 - skip the post-install `daemon restart`.
+
+REPO="kunchenguid/no-mistakes"
+
+# Pinned release. Do NOT drop this below fm-bootstrap.sh's no_mistakes_compatible()
+# minimum (NO_MISTAKES_MIN_* = 1.31.2). v1.31.2 is the current minimum gate and a
+# proper (non-prerelease) release with downloadable assets. When bumping, refresh
+# EVERY checksum in pinned_sha256() from the tagged release's own checksums.txt /
+# the release-asset `digest` field, never a placeholder.
+NO_MISTAKES_PINNED_VERSION="v1.31.2"
+
+# SHA256 of each pinned release asset, keyed "<os>-<arch>". Verified 2026-07-05,
+# read-only, three ways that all agreed: the release's own checksums.txt asset,
+# the GitHub API release-asset `digest` field, and a locally recomputed sha256 of
+# the downloaded linux-amd64 asset. The upstream installer supports linux/darwin
+# on amd64/arm64, so those four are covered here.
+pinned_sha256() {
+  case "$1" in
+    linux-amd64)  echo "e3009fe9986c51ca59ddb0152e127bb245858efe03dc84842138c0f192ff7f8b" ;;
+    linux-arm64)  echo "b73d01abeb48dd11cbacecdeeccc92120aa241e7acc48e55b3e3f3331d1b011a" ;;
+    darwin-amd64) echo "9e18e38fbc4f989d2dc2e3d4d3dafb8e1ffd7691dc351273668439d4c7bfb9eb" ;;
+    darwin-arm64) echo "beefec1cf6a0280fba5e4bb795c49c655dbb1cb7f1960949f2434d02f7245fff" ;;
+    *) return 1 ;;
+  esac
+}
+
+nm_fail() { echo "no-mistakes install: $*" >&2; exit 1; }
+
+# Echo the normalized "<os>-<arch>" platform, or fail on an unsupported one.
+nm_platform() {
+  local os arch
+  os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+  arch="$(uname -m)"
+  case "$os" in
+    darwin|linux) ;;
+    *) nm_fail "unsupported OS: $os (pinned installer supports linux and darwin)" ;;
+  esac
+  case "$arch" in
+    x86_64|amd64) arch="amd64" ;;
+    arm64|aarch64) arch="arm64" ;;
+    *) nm_fail "unsupported architecture: $arch (pinned installer supports amd64 and arm64)" ;;
+  esac
+  echo "$os-$arch"
+}
+
+# Echo the sha256 of a file using whichever tool is available.
+nm_sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  else
+    return 1
+  fi
+}
+
+# nm_verify_sha256 <file> <expected>: succeed only when <file>'s sha256 equals
+# <expected>. Returns non-zero on mismatch or when no sha256 tool is available -
+# the caller MUST treat a non-zero return as "do not install".
+nm_verify_sha256() {
+  local file=$1 expected=$2 actual
+  actual="$(nm_sha256_of "$file")" || return 2
+  [ "$actual" = "$expected" ]
+}
+
+nm_install_main() {
+  set -eu
+
+  local platform version expected_sha filename base_url url
+  local install_dir link_dir bin_path link_path work
+  local real_install_dir real_link_dir
+
+  command -v curl >/dev/null 2>&1 || nm_fail "curl is required"
+  command -v tar >/dev/null 2>&1 || nm_fail "tar is required"
+
+  platform="$(nm_platform)"
+  version="$NO_MISTAKES_PINNED_VERSION"
+  expected_sha="$(pinned_sha256 "$platform")" || nm_fail "no pinned checksum for $platform"
+
+  filename="no-mistakes-${version}-${platform}.tar.gz"
+  base_url="${FM_NO_MISTAKES_BASE_URL:-https://github.com/${REPO}/releases/download}"
+  url="${base_url}/${version}/${filename}"
+
+  install_dir="${NO_MISTAKES_INSTALL_DIR:-$HOME/.no-mistakes/bin}"
+  link_dir="${NO_MISTAKES_LINK_DIR:-}"
+  if [ -z "$link_dir" ]; then
+    case ":$PATH:" in
+      *":$HOME/.local/bin:"*) link_dir="$HOME/.local/bin" ;;
+      *) link_dir="/usr/local/bin" ;;
+    esac
+  fi
+  bin_path="$install_dir/no-mistakes"
+  link_path="$link_dir/no-mistakes"
+
+  work="$(mktemp -d "${TMPDIR:-/tmp}/fm-no-mistakes-install.XXXXXX")" || nm_fail "cannot create temp dir"
+  # shellcheck disable=SC2064
+  trap "rm -rf '$work'" EXIT
+
+  echo "Downloading no-mistakes ${version} for ${platform}..."
+  curl -fsSL "$url" -o "$work/$filename" || nm_fail "download failed: $url"
+
+  if ! nm_verify_sha256 "$work/$filename" "$expected_sha"; then
+    nm_fail "checksum verification FAILED for $filename
+  expected sha256 $expected_sha
+  got      sha256 $(nm_sha256_of "$work/$filename" 2>/dev/null || echo '<no sha256 tool>')
+Refusing to install an unverified binary. Either the pinned checksum is wrong,
+the download was corrupted, or the artifact was tampered with. Nothing was
+installed; the existing install (if any) is untouched."
+  fi
+
+  tar xzf "$work/$filename" -C "$work" || nm_fail "failed to extract $filename"
+  [ -f "$work/no-mistakes" ] || nm_fail "archive did not contain a no-mistakes binary"
+
+  mkdir -p "$install_dir" || nm_fail "cannot create install dir: $install_dir"
+  mv "$work/no-mistakes" "$bin_path" || nm_fail "cannot install binary to $bin_path"
+  chmod 755 "$bin_path" 2>/dev/null || true
+
+  # Symlink, mirroring the upstream installer (skip when link and install dirs
+  # resolve to the same path).
+  real_install_dir="$( (cd "$install_dir" 2>/dev/null && pwd -P) || true)"
+  real_link_dir="$( (cd "$link_dir" 2>/dev/null && pwd -P) || true)"
+  if [ -n "$real_install_dir" ] && [ "$real_install_dir" = "$real_link_dir" ]; then
+    echo "Install dir and link dir resolve to the same path; skipping symlink."
+  elif [ -w "$link_dir" ] || (mkdir -p "$link_dir" 2>/dev/null && [ -w "$link_dir" ]); then
+    rm -f "$link_path"
+    ln -s "$bin_path" "$link_path"
+  else
+    echo "Linking ${link_path} to ${bin_path} (requires sudo)..."
+    sudo mkdir -p "$link_dir"
+    sudo rm -f "$link_path"
+    sudo ln -s "$bin_path" "$link_path"
+  fi
+
+  echo "no-mistakes ${version} installed to ${bin_path}"
+  echo "Command path: ${link_path} -> ${bin_path}"
+
+  if [ "${FM_NO_MISTAKES_SKIP_DAEMON:-0}" != 1 ]; then
+    "$bin_path" daemon restart >/dev/null 2>&1 || true
+  fi
+
+  case ":$PATH:" in
+    *":$link_dir:"*) ;;
+    *) echo "Add ${link_dir} to your PATH and restart your terminal." ;;
+  esac
+}
+
+# Run only when executed directly, not when sourced (the colocated test sources
+# this file to exercise nm_verify_sha256 and nm_install_main against a local,
+# non-live artifact).
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  nm_install_main "$@"
+fi

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -127,7 +127,10 @@ ROWS
 
 test_no_mistakes_min_version() {
   local label version mode case_dir fakebin out missing n
-  missing='MISSING: no-mistakes (install: curl -fsSL https://raw.githubusercontent.com/kunchenguid/no-mistakes/main/docs/install.sh | sh)'
+  # The no-mistakes install command is now the pinned, checksum-verified helper
+  # (fm-install-no-mistakes.sh) rather than the former unversioned curl|sh; the
+  # helper path is absolute (SCRIPT_DIR = "$ROOT/bin").
+  missing="MISSING: no-mistakes (install: $ROOT/bin/fm-install-no-mistakes.sh)"
   n=0
   while IFS='^' read -r label version mode; do
     [ -n "$label" ] || continue

--- a/tests/fm-install-no-mistakes.test.sh
+++ b/tests/fm-install-no-mistakes.test.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# Behavior tests for fm-install-no-mistakes.sh, the pinned + checksum-verified
+# no-mistakes installer that replaced the unversioned `curl .../main | sh`.
+#
+# The security-critical contract is FAIL CLOSED: a downloaded artifact whose
+# SHA256 does not match the pinned checksum must NOT be installed, and a matching
+# artifact installs to the expected location/symlink. These tests source the
+# installer (its BASH_SOURCE guard keeps main from running on source), stub the
+# download with a local `curl` shim, and point the install/symlink dirs at temp
+# dirs so the LIVE ~/.no-mistakes install is never touched.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+BASE_PATH=${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin}
+TMP_ROOT=$(fm_test_tmproot fm-install-no-mistakes-tests)
+
+# Source the installer for its functions; the guard keeps nm_install_main from
+# running here.
+# shellcheck source=bin/fm-install-no-mistakes.sh
+. "$ROOT/bin/fm-install-no-mistakes.sh"
+
+# A fake `curl` that "downloads" by copying a local file (our base URL is a local
+# dir), plus real tar/sha256sum from the system. Fails like curl -f on a missing
+# source so the installer's download-failure path is exercised too.
+make_fakebin() {
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/curl" <<'SH'
+#!/usr/bin/env bash
+dest=""; src=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -o) dest="$2"; shift 2 ;;
+    -*) shift ;;
+    *) src="$1"; shift ;;
+  esac
+done
+[ -n "$src" ] || exit 2
+[ -f "$src" ] || exit 22
+cp "$src" "$dest"
+SH
+  chmod +x "$fakebin/curl"
+  printf '%s\n' "$fakebin"
+}
+
+# Build a fake release tarball (containing a stub `no-mistakes` binary) for the
+# current platform under <artifacts>/<version>/, echo the tarball path.
+build_fake_tarball() {
+  local artifacts=$1 platform version pkg tarball
+  version="$NO_MISTAKES_PINNED_VERSION"
+  platform="$(nm_platform)"
+  pkg="$artifacts/pkgroot"
+  mkdir -p "$pkg" "$artifacts/$version"
+  cat > "$pkg/no-mistakes" <<'SH'
+#!/usr/bin/env bash
+echo "fake no-mistakes ${*}"
+SH
+  chmod +x "$pkg/no-mistakes"
+  tarball="$artifacts/$version/no-mistakes-${version}-${platform}.tar.gz"
+  tar czf "$tarball" -C "$pkg" no-mistakes
+  printf '%s\n' "$tarball"
+}
+
+# --- nm_verify_sha256: correct passes, wrong fails --------------------------
+test_verify_sha256_both_directions() {
+  local dir file correct wrong
+  dir="$TMP_ROOT/verify"
+  mkdir -p "$dir"
+  file="$dir/blob"
+  printf 'squared-away pinned artifact\n' > "$file"
+  correct=$(nm_sha256_of "$file")
+  wrong="0000000000000000000000000000000000000000000000000000000000000000"
+
+  nm_verify_sha256 "$file" "$correct" || fail "verify: a correct SHA256 must pass"
+  if nm_verify_sha256 "$file" "$wrong"; then
+    fail "verify: a wrong SHA256 must fail closed"
+  fi
+  pass "nm_verify_sha256 passes the correct checksum and rejects a wrong one"
+}
+
+# --- end-to-end: a checksum MISMATCH fails closed, installs nothing ---------
+# Uses the REAL pinned checksum table (not overridden), so the fake tarball's
+# sha cannot match: proves the pinned checksum is actually consulted and that a
+# non-matching artifact never lands.
+test_install_rejects_mismatched_artifact() {
+  local case_dir fakebin artifacts idir ldir out rc
+  case_dir="$TMP_ROOT/mismatch"
+  mkdir -p "$case_dir"
+  fakebin=$(make_fakebin "$case_dir")
+  artifacts="$case_dir/artifacts"
+  build_fake_tarball "$artifacts" >/dev/null
+  idir="$case_dir/install"; ldir="$case_dir/link"
+  mkdir -p "$idir" "$ldir"
+
+  out=$(
+    PATH="$fakebin:$BASE_PATH"; export PATH
+    HOME="$case_dir/fakehome"; export HOME
+    NO_MISTAKES_INSTALL_DIR="$idir"; export NO_MISTAKES_INSTALL_DIR
+    NO_MISTAKES_LINK_DIR="$ldir"; export NO_MISTAKES_LINK_DIR
+    FM_NO_MISTAKES_BASE_URL="$artifacts"; export FM_NO_MISTAKES_BASE_URL
+    FM_NO_MISTAKES_SKIP_DAEMON=1; export FM_NO_MISTAKES_SKIP_DAEMON
+    nm_install_main 2>&1
+  )
+  rc=$?
+
+  [ "$rc" -ne 0 ] || fail "mismatch: installer must exit non-zero on checksum mismatch (got 0)"$'\n'"$out"
+  assert_contains "$out" "checksum verification FAILED" "mismatch: should report a checksum failure"
+  assert_absent "$idir/no-mistakes" "mismatch: no binary may be installed on a checksum failure"
+  assert_absent "$ldir/no-mistakes" "mismatch: no symlink may be created on a checksum failure"
+  pass "installer fails closed on a checksum mismatch and installs nothing"
+}
+
+# --- end-to-end: a MATCHING artifact installs to the expected layout --------
+# Overrides pinned_sha256 (inside the subshell only) to the fake tarball's real
+# sha, proving the download -> verify -> install -> symlink mechanism end to end.
+test_install_accepts_verified_artifact() {
+  local case_dir fakebin artifacts tarball fake_sha idir ldir out rc
+  case_dir="$TMP_ROOT/match"
+  mkdir -p "$case_dir"
+  fakebin=$(make_fakebin "$case_dir")
+  artifacts="$case_dir/artifacts"
+  tarball=$(build_fake_tarball "$artifacts")
+  fake_sha=$(nm_sha256_of "$tarball")
+  idir="$case_dir/install"; ldir="$case_dir/link"
+  mkdir -p "$idir" "$ldir"
+
+  out=$(
+    PATH="$fakebin:$BASE_PATH"; export PATH
+    HOME="$case_dir/fakehome"; export HOME
+    NO_MISTAKES_INSTALL_DIR="$idir"; export NO_MISTAKES_INSTALL_DIR
+    NO_MISTAKES_LINK_DIR="$ldir"; export NO_MISTAKES_LINK_DIR
+    FM_NO_MISTAKES_BASE_URL="$artifacts"; export FM_NO_MISTAKES_BASE_URL
+    FM_NO_MISTAKES_SKIP_DAEMON=1; export FM_NO_MISTAKES_SKIP_DAEMON
+    # shellcheck disable=SC2317 # Invoked indirectly by nm_install_main below.
+    pinned_sha256() { echo "$fake_sha"; }
+    nm_install_main 2>&1
+  )
+  rc=$?
+
+  [ "$rc" -eq 0 ] || fail "match: verified install must succeed (rc=$rc)"$'\n'"$out"
+  assert_present "$idir/no-mistakes" "match: binary must be installed"
+  [ -x "$idir/no-mistakes" ] || fail "match: installed binary must be executable"
+  [ -L "$ldir/no-mistakes" ] || fail "match: a symlink must be created at the link path"
+  [ "$(readlink "$ldir/no-mistakes")" = "$idir/no-mistakes" ] \
+    || fail "match: symlink must point at the installed binary"
+  assert_contains "$out" "installed to" "match: should confirm the install"
+  pass "installer verifies and installs a matching artifact to the expected layout"
+}
+
+test_verify_sha256_both_directions
+test_install_rejects_mismatched_artifact
+test_install_accepts_verified_artifact


### PR DESCRIPTION
Replaces the unversioned, unverified supply-chain install path (`curl .../no-mistakes/main/docs/install.sh | sh`) with a pinned, checksum-verified install of a specific release.

`bin/fm-install-no-mistakes.sh` downloads the tagged v1.31.2 release asset for the host os/arch from GitHub release assets (not raw `main`) and verifies its SHA256 against a checksum pinned in the script before installing. It fails closed on a mismatch or missing asset and never falls back to the old `curl|sh`. Install location and symlink target, the version gate, and the MISSING/consent flow are unchanged.

Pinned SHA256s (linux/darwin x amd64/arm64) were verified read-only three ways that agreed: the release's checksums.txt, the GitHub API asset digest, and a locally recomputed sha256 of the linux-amd64 asset.

Folded and live-verified in a downstream runtime for several days before this upstream submission.