### PR TITLE
fix(composer): treat claude's non-breaking-space empty composer as empty

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -123,6 +123,9 @@ Its broader dark-TRUECOLOR placeholder handling and dark-theme tradeoff are docu
 That styled capture is internal to the boolean detector only.
 `fm-peek` and every other human or LLM-facing capture path stays plain `tmux capture-pane` with no escape codes.
 
+Claude (v2.1.x, verified against a live pane) also renders its EMPTY composer prompt as the agent glyph `❯` followed by a NON-BREAKING space (U+00A0) and then a regular space, which bash's `[:space:]` trim never matches.
+That stray NBSP once made an empty composer read as pending text, so every `fm-send` steer to a claude tmux pane falsely failed with "Enter swallowed" even though the message had submitted; the shared classifier `fm_composer_classify_content` (`bin/fm-composer-lib.sh`) now folds NBSP to a plain space before classifying, so NBSP-only spacing reads empty while real typed text containing an NBSP stays pending - see `docs/herdr-backend.md`'s "Composer-emptiness safety" NBSP-normalization record (task fix-fmsend-falsefail).
+
 **Primary-session guard fact (verified 2026-07-04, Claude Code 2.1.201; preserved 2026-07-08, Claude Code 2.1.204).**
 This is separate from the per-task crewmate turn-end hook above (that one just `touch`es a marker file in a task's own `.claude/settings.local.json`).
 The firstmate PRIMARY's own `.claude/settings.json` registers `bin/fm-turnend-guard.sh` as a Stop hook, and exiting with status 2 plus stderr reliably forces the model to continue.

--- a/bin/fm-composer-lib.sh
+++ b/bin/fm-composer-lib.sh
@@ -180,8 +180,25 @@ fm_composer_idle_matches() {
 }
 
 fm_composer_classify_content() {  # <bordered> <content> [idle_re] [idle_case] [plain_content]
-  local bordered=$1 content=$2 idle_re=${3:-} idle_case=${4:-sensitive} plain_content
+  local bordered=$1 content=$2 idle_re=${3:-} idle_case=${4:-sensitive} plain_content nbsp
   plain_content=${5:-$content}
+  # claude (v2.1.x) draws its empty composer prompt as the agent
+  # glyph followed by a NON-BREAKING space (U+00A0) and then a regular space.
+  # bash's [:space:] class never matches U+00A0, so the caller's trim leaves a lone NBSP
+  # behind; after the leading glyph is stripped that stray NBSP survives and an
+  # empty composer misreads as pending real text - the false "Enter swallowed"
+  # steer failure (task fix-fmsend-falsefail). Fold every NBSP to a plain space
+  # and re-trim both inputs so NBSP-only spacing classifies as empty. This is a
+  # no-op for content that carries no NBSP, and real typed text around an NBSP
+  # still survives the fold (only pure whitespace collapses), so pending stays
+  # pending. Applied here, the ONE owner, so every backend adapter benefits.
+  nbsp=$(printf '\302\240')
+  content=${content//"$nbsp"/ }
+  content="${content#"${content%%[![:space:]]*}"}"
+  content="${content%"${content##*[![:space:]]}"}"
+  plain_content=${plain_content//"$nbsp"/ }
+  plain_content="${plain_content#"${plain_content%%[![:space:]]*}"}"
+  plain_content="${plain_content%"${plain_content##*[![:space:]]}"}"
   if [ "$bordered" != 1 ] && [ -z "$content" ] && [ -n "$plain_content" ]; then
     case "$plain_content" in
       '❯'|'›') printf 'empty'; return 0 ;;

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -596,6 +596,12 @@ The agent prompt glyphs `❯` (claude) and `›` (codex) read `empty` either way
 Per-backend dead-shell coverage: `tests/fm-daemon.test.sh`'s `test_tmux_composer_state_bare_shell_is_unknown` and `test_inject_msg_defers_on_dead_shell_unknown` (tmux + the injector), `tests/fm-backend-herdr.test.sh`'s `test_composer_state_unknown_when_no_composer_row_found`, `tests/fm-backend-orca.test.sh`'s `test_composer_state_bare_shell_prompt_is_unknown`, and `tests/fm-backend-cmux.test.sh`'s `test_composer_state_unknown_when_no_composer_row_found`.
 The herdr incident regressions (`tests/fm-backend-herdr.test.sh`'s composer-state, wait-for-working, and send-text-submit sections) stay green, and `shellcheck bin/*.sh bin/backends/*.sh tests/*.sh` passes clean.
 
+**NBSP normalization (2026-07-11, task fix-fmsend-falsefail).** claude (v2.1.x) draws its EMPTY composer prompt as the agent glyph followed by a NON-BREAKING space (U+00A0) and then a regular space, verified empirically against a live claude tmux pane.
+bash's `[:space:]` class never matches U+00A0, so the caller's whitespace trim left that lone NBSP behind after the leading glyph was stripped, and an empty claude composer misclassified as `pending` - `bin/fm-send.sh` then exited non-zero with a false "text not submitted (Enter swallowed)" error on every claude tmux steer even though the message had actually submitted, inviting a dangerous double-send.
+`fm_composer_classify_content` now folds every NBSP to a regular space and re-trims both inputs before classifying, so NBSP-only spacing reads `empty` while real typed text that merely contains an NBSP still reads `pending`; the fold lives in this shared owner, so every backend adapter benefits.
+Verified against the same live claude pane after the fix: the real `bin/fm-send.sh` exits 0 where it previously exited 1.
+Regression coverage: `tests/fm-composer-lib.test.sh` (`test_nbsp_empty_composer_is_empty`, `test_nbsp_does_not_swallow_real_text`) at the classifier unit level, and `tests/fm-composer-ghost.test.sh` (`test_nbsp_empty_claude_composer_is_not_pending`, `test_nbsp_with_real_text_still_pending`) end-to-end through `fm_pane_input_pending` and `fm_tmux_composer_state` using claude's real cursor-row bytes.
+
 ## Incident (2026-07-10): away-mode injection wedged all night on the primary claude-on-herdr composer's ghost text
 
 The captain woke to find away-mode had never injected: 20 escalations buffered, the max-defer wedge marker at 30623s undelivered, the wake queue at 65.

--- a/tests/fm-composer-ghost.test.sh
+++ b/tests/fm-composer-ghost.test.sh
@@ -236,6 +236,43 @@ test_dark_truecolor_bare_shell_prompt_is_unknown() {
   pass "fm_tmux_composer_state: dark truecolor shell prompts read unknown"
 }
 
+test_nbsp_empty_claude_composer_is_not_pending() {
+  local dir fb capture
+  dir="$TMP_ROOT/nbsp-composer"; mkdir -p "$dir"
+  fb=$(make_fake_tmux "$dir")
+  capture="$dir/styled.txt"
+  # The exact empty-composer row claude v2.1.x leaves on the cursor line right
+  # after a submit lands: the agent glyph, a NON-BREAKING space (U+00A0, the
+  # \xc2\xa0 bytes), then a regular space. bash's [:space:] trim does not match
+  # the NBSP, so before the fix an empty composer read as pending real text and
+  # fm-send falsely reported "Enter swallowed" on every claude steer
+  # (task fix-fmsend-falsefail). It must read NOT pending.
+  printf '\xe2\x9d\xaf\xc2\xa0 \n' > "$capture"
+  if PATH="$fb:$PATH" FM_FAKE_STYLED="$capture" FM_FAKE_CY=0 \
+     fm_pane_input_pending "fakepane"; then
+    fail "claude's NBSP empty composer falsely read as pending (the false Enter-swallowed steer failure)"
+  fi
+  # And the same row must classify as empty (the positive submit acknowledgement).
+  local st
+  st=$(PATH="$fb:$PATH" FM_FAKE_STYLED="$capture" FM_FAKE_CY=0 fm_tmux_composer_state "fakepane")
+  [ "$st" = empty ] || fail "claude's NBSP empty composer should read empty, got '$st'"
+  pass "fm_pane_input_pending: claude's non-breaking-space empty composer is NOT pending (submit confirmed)"
+}
+
+test_nbsp_with_real_text_still_pending() {
+  local dir fb capture
+  dir="$TMP_ROOT/nbsp-real"; mkdir -p "$dir"
+  fb=$(make_fake_tmux "$dir")
+  capture="$dir/styled.txt"
+  # Real typed text that merely contains an NBSP must still read pending - the
+  # NBSP fold collapses only pure whitespace, never real input.
+  printf '\xe2\x9d\xaf\xc2\xa0fix findings 1 and 3\n' > "$capture"
+  PATH="$fb:$PATH" FM_FAKE_STYLED="$capture" FM_FAKE_CY=0 \
+    fm_pane_input_pending "fakepane" \
+    || fail "real text following an NBSP was not detected as pending"
+  pass "fm_pane_input_pending: real typed text after an NBSP is still pending"
+}
+
 test_real_text_with_trailing_ghost_is_pending() {
   local dir fb capture
   dir="$TMP_ROOT/mixed"; mkdir -p "$dir"
@@ -286,5 +323,7 @@ test_normal_text_still_pending
 test_colored_text_with_2_payload_still_pending
 test_dark_truecolor_ghost_only_composer_is_not_pending
 test_dark_truecolor_bare_shell_prompt_is_unknown
+test_nbsp_empty_claude_composer_is_not_pending
+test_nbsp_with_real_text_still_pending
 test_real_text_with_trailing_ghost_is_pending
 test_peek_output_is_escape_free

--- a/tests/fm-composer-lib.test.sh
+++ b/tests/fm-composer-lib.test.sh
@@ -114,6 +114,38 @@ test_idle_placeholder_case_mode_is_explicit() {
   pass "fm_composer_classify_content: idle matching preserves the caller's case mode"
 }
 
+# --- claude's non-breaking-space empty composer -----------------------------
+
+test_nbsp_empty_composer_is_empty() {
+  local nbsp out row
+  nbsp=$(printf '\302\240')   # U+00A0 NON-BREAKING SPACE
+  # claude (v2.1.x) renders its EMPTY composer prompt as "❯" + NBSP + " ". The
+  # caller trims with bash's [:space:] class, which does NOT match NBSP, so it
+  # hands the classifier a value with a trailing (or lone, post-glyph-strip)
+  # NBSP. Every such empty shape must read empty, never pending - the false
+  # "Enter swallowed" steer failure (task fix-fmsend-falsefail).
+  for row in "❯${nbsp} " "❯${nbsp}" "❯${nbsp}${nbsp}" "${nbsp}❯${nbsp}"; do
+    out=$(classify 0 "$row")
+    [ "$out" = empty ] \
+      || fail "claude's NBSP empty composer '$(printf '%s' "$row" | od -An -tx1)' must read empty, got '$out'"
+  done
+  # A lone NBSP with no glyph is still just spacing, i.e. empty.
+  out=$(classify 0 "$nbsp"); [ "$out" = empty ] || fail "a lone NBSP should read empty, got '$out'"
+  pass "fm_composer_classify_content: claude's non-breaking-space empty composer reads empty, not pending"
+}
+
+test_nbsp_does_not_swallow_real_text() {
+  local nbsp out
+  nbsp=$(printf '\302\240')
+  # Folding NBSP to a space must not erase real typed content: a message that
+  # merely contains an NBSP is still unsubmitted text -> pending.
+  out=$(classify 0 "❯${nbsp}fix findings 1 and 3")
+  [ "$out" = pending ] || fail "real text after an NBSP must stay pending, got '$out'"
+  out=$(classify 0 "deploy${nbsp}staging now")
+  [ "$out" = pending ] || fail "real text around an NBSP must stay pending, got '$out'"
+  pass "fm_composer_classify_content: an NBSP inside real typed text stays pending (fold collapses only pure whitespace)"
+}
+
 # --- Real text is pending ---------------------------------------------------
 
 test_real_text_is_pending() {
@@ -126,6 +158,8 @@ test_real_text_is_pending() {
 }
 
 test_bare_shell_glyphs_are_unknown
+test_nbsp_empty_composer_is_empty
+test_nbsp_does_not_swallow_real_text
 test_stripped_unbordered_content_uses_plain_content
 test_bare_shell_prompt_with_command_is_not_empty
 test_bordered_shell_glyph_is_empty

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -349,8 +349,9 @@ $rec
 EOF
   make_fake_toolchain "$fakebin"
   make_fake_ps_claude "$fakebin"
-  # Force a MISSING diagnostic line so the bootstrap section is non-trivial.
-  rm -f "$fakebin/node"
+  # make_fake_toolchain deliberately omits tasks-axi, so the bootstrap section
+  # is non-trivial: its MISSING line appears regardless of what the host system
+  # ships on the base PATH (a host /usr/bin/node would mask a removed fake).
 
   printf 'window=fm-sess:w1\nkind=ship\n' > "$home/state/task-a.meta"
 
@@ -373,7 +374,7 @@ EOF
   [ "$context_line" -lt "$fleet_line" ] || fail "CONTEXT did not precede FLEET STATE"
   [ "$fleet_line" -lt "$next_line" ] || fail "FLEET STATE did not precede NEXT STEP"
 
-  missing_line=$(printf '%s\n' "$out" | grep -n 'MISSING: node' | head -1 | cut -d: -f1)
+  missing_line=$(printf '%s\n' "$out" | grep -n 'MISSING: tasks-axi' | head -1 | cut -d: -f1)
   [ -n "$missing_line" ] || fail "MISSING diagnostic did not appear at all"
   [ "$missing_line" -lt "$fleet_line" ] || fail "actionable MISSING diagnostic was buried after the bulk fleet-state digest"
 
@@ -493,7 +494,6 @@ $rec
 EOF
   make_fake_toolchain "$fakebin"
   make_fake_ps_claude "$fakebin"
-  rm -f "$fakebin/node"
 
   append_wake "$home/state" signal task-z "needs-decision: pick a library"
 
@@ -501,8 +501,9 @@ EOF
 
   # fm-lock.sh's own exact success text.
   assert_contains "$out" "lock acquired: harness pid" "fm-lock.sh's real output did not appear (composition, not reimplementation)"
-  # fm-bootstrap.sh's own exact MISSING-tool line format.
-  assert_contains "$out" "MISSING: node (install:" "fm-bootstrap.sh's real detect line did not appear verbatim"
+  # fm-bootstrap.sh's own exact MISSING-tool line format (tasks-axi is never
+  # faked and never on the base system PATH, unlike a host-installed node).
+  assert_contains "$out" "MISSING: tasks-axi (install:" "fm-bootstrap.sh's real detect line did not appear verbatim"
   # fm-wake-drain.sh's real drained record (raw tab-separated queue line).
   assert_contains "$out" "$(printf 'signal\ttask-z\tneeds-decision: pick a library')" "fm-wake-drain.sh's real drained record did not appear"
 


### PR DESCRIPTION
## Problem

`bin/fm-send.sh` consistently exited non-zero with a false `text not submitted (Enter swallowed; text left in composer)` error when steering a **claude** crewmate tmux pane, even though the message had actually submitted and the crewmate was already processing it. The false failure invites a dangerous double-send.

## Root cause

Reproduced empirically against a live claude v2.1.x pane: claude renders its **empty** composer prompt as the agent glyph `❯` followed by a **non-breaking space (U+00A0)** and then a regular space.

bash's `[:space:]` character class does not match U+00A0, so the caller's whitespace trim leaves a lone NBSP behind. After the leading prompt glyph is stripped, that stray NBSP survives as apparent content, and `fm_composer_classify_content` classifies an empty composer as `pending` (unsubmitted text). `fm-send` reads that as a swallowed Enter and exits non-zero.

## Fix

Fold every NBSP to a regular space and re-trim inside `fm_composer_classify_content` in `bin/fm-composer-lib.sh` — the single fleet-wide owner of the `empty|pending|unknown` verdict — so NBSP-only spacing classifies as `empty`, while real typed text that merely contains an NBSP still stays `pending` (the fold collapses only pure whitespace). Placing the fix at the one owner rather than per-adapter is intentional per the repo's one-owner rule, so every backend adapter benefits.

Genuinely-unsubmitted detection is deliberately preserved: the grok/codex slash- and dollar-popup placeholder cases, dead-shell `unknown`, and real-text `pending` all continue to work. Verification was not loosened.

## Evidence

- Drove the real `bin/fm-send.sh` against a live claude tmux pane: the idle composer now reads `empty` (was `pending`), and `fm-send` exits `0` where it previously exited `1` and fired extra retry Enters. Real unsubmitted text on the same live pane still reads `pending`.

## Tests

Regression tests added by extending existing scripts (no new runner):

- `tests/fm-composer-lib.test.sh` — classifier-level NBSP cases: an NBSP empty composer reads `empty`; real text around an NBSP stays `pending`.
- `tests/fm-composer-ghost.test.sh` — end-to-end through `fm_pane_input_pending` / `fm_tmux_composer_state` with claude's real cursor-row bytes (`❯` + U+00A0 + space).

`shellcheck bin/*.sh bin/backends/*.sh tests/*.sh` passes.
