### PR TITLE
fix: enforce deterministic ShellCheck parity

### DIFF
--- a/.agents/skills/firstmate-coding-guidelines/SKILL.md
+++ b/.agents/skills/firstmate-coding-guidelines/SKILL.md
@@ -73,7 +73,7 @@ Firstmate adds this skill's load instruction to firstmate-repo briefs by hand in
 - Plain dash `-`, never an em dash.
 - Never add an agent name as a commit co-author.
 - `bin/*.sh` and `bin/backends/*.sh` must pass `shellcheck`.
-- Run `shellcheck bin/*.sh bin/backends/*.sh tests/*.sh` before treating a script change as done.
+- Run `bin/fm-lint.sh` before treating a script change as done; it is the single owner of the lint definition (file set, config, and pinned shellcheck version) that CI and the no-mistakes pre-push gate both invoke, and it refuses to run under any other shellcheck version.
 - Colocate tests with the existing pattern in `tests/`, name them `<subject>.test.sh`, and extend an existing script rather than inventing a new runner.
 - A backend-verification doc (`docs/*-backend.md`) records empirical facts, not assumptions.
 - Include the date, version, exact commands run, and exact output.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - run: shellcheck bin/*.sh bin/backends/*.sh tests/*.sh
+      # Pin ShellCheck to the exact version bin/fm-lint.sh requires (it prints it
+      # via --required-version), instead of floating with the runner image, so CI
+      # and local resolve the identical rule set. The version lives once, in
+      # bin/fm-lint.sh; this step just installs whatever it names and logs it.
+      - name: Install pinned ShellCheck
+        run: |
+          set -eu
+          version="$(bin/fm-lint.sh --required-version)"
+          url="https://github.com/koalaman/shellcheck/releases/download/v${version}/shellcheck-v${version}.linux.x86_64.tar.xz"
+          curl -fsSL "$url" -o /tmp/shellcheck.tar.xz
+          tar -xJf /tmp/shellcheck.tar.xz -C /tmp
+          sudo install -m 0755 "/tmp/shellcheck-v${version}/shellcheck" /usr/local/bin/shellcheck
+          shellcheck --version
+      # Single owner of the lint definition (file set + config + version). Do not
+      # re-spell the shellcheck command here; keep CI and the pre-push gate on it.
+      - run: bin/fm-lint.sh
 
   tests:
     name: Behavior tests
@@ -27,6 +42,17 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+      # Same pinned ShellCheck as the lint job so tests/fm-lint.test.sh exercises
+      # the one owner against the version it enforces, not the runner default.
+      - name: Install pinned ShellCheck
+        run: |
+          set -eu
+          version="$(bin/fm-lint.sh --required-version)"
+          url="https://github.com/koalaman/shellcheck/releases/download/v${version}/shellcheck-v${version}.linux.x86_64.tar.xz"
+          curl -fsSL "$url" -o /tmp/shellcheck.tar.xz
+          tar -xJf /tmp/shellcheck.tar.xz -C /tmp
+          sudo install -m 0755 "/tmp/shellcheck-v${version}/shellcheck" /usr/local/bin/shellcheck
+          shellcheck --version
       - name: Require tmux for e2e tests
         run: |
           set -eu

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,19 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      # Pin ShellCheck to the exact version bin/fm-lint.sh requires (it prints it
-      # via --required-version), instead of floating with the runner image, so CI
-      # and local resolve the identical rule set. The version lives once, in
-      # bin/fm-lint.sh; this step just installs whatever it names and logs it.
       - name: Install pinned ShellCheck
         run: |
           set -eu
-          version="$(bin/fm-lint.sh --required-version)"
-          url="https://github.com/koalaman/shellcheck/releases/download/v${version}/shellcheck-v${version}.linux.x86_64.tar.xz"
-          curl -fsSL "$url" -o /tmp/shellcheck.tar.xz
-          tar -xJf /tmp/shellcheck.tar.xz -C /tmp
-          sudo install -m 0755 "/tmp/shellcheck-v${version}/shellcheck" /usr/local/bin/shellcheck
-          shellcheck --version
+          bin/fm-install-shellcheck.sh "$RUNNER_TEMP/bin"
+          echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
       # Single owner of the lint definition (file set + config + version). Do not
       # re-spell the shellcheck command here; keep CI and the pre-push gate on it.
       - run: bin/fm-lint.sh
@@ -42,17 +34,11 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      # Same pinned ShellCheck as the lint job so tests/fm-lint.test.sh exercises
-      # the one owner against the version it enforces, not the runner default.
       - name: Install pinned ShellCheck
         run: |
           set -eu
-          version="$(bin/fm-lint.sh --required-version)"
-          url="https://github.com/koalaman/shellcheck/releases/download/v${version}/shellcheck-v${version}.linux.x86_64.tar.xz"
-          curl -fsSL "$url" -o /tmp/shellcheck.tar.xz
-          tar -xJf /tmp/shellcheck.tar.xz -C /tmp
-          sudo install -m 0755 "/tmp/shellcheck-v${version}/shellcheck" /usr/local/bin/shellcheck
-          shellcheck --version
+          bin/fm-install-shellcheck.sh "$RUNNER_TEMP/bin"
+          echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
       - name: Require tmux for e2e tests
         run: |
           set -eu

--- a/.no-mistakes.yaml
+++ b/.no-mistakes.yaml
@@ -1,11 +1,19 @@
 # Per-repo no-mistakes overrides.
 
-# Run the firstmate bash behavior suite deterministically as the test-step
-# baseline, instead of delegating to an agent (an agent-driven test step has
-# crashed the daemon). Mirrors .github/workflows/ci.yml: iterate every
-# tests/*.test.sh, run each, and fail the step if any one exits non-zero. The
-# e2e tests need tmux on PATH, which the firstmate environment provides.
+# Pin lint and test to the SAME deterministic commands CI runs, instead of
+# leaving them to no-mistakes' default handling. Without a configured
+# commands.lint, the gate's lint step never ran the deterministic
+# `shellcheck bin/*.sh bin/backends/*.sh tests/*.sh` that CI runs, so info-level
+# ShellCheck findings (e.g. SC2015) were not surfaced locally before CI rejected
+# them. commands.lint delegates to bin/fm-lint.sh, the single owner of the lint
+# definition that .github/workflows/ci.yml also invokes, so local can never
+# diverge from CI again (parity asserted by tests/fm-lint.test.sh).
+# The test command mirrors .github/workflows/ci.yml: iterate every
+# tests/*.test.sh, run each, and fail the step if any one exits non-zero (an
+# agent-driven test step has crashed the daemon). The e2e tests need tmux on
+# PATH, which the firstmate environment provides.
 commands:
+  lint: 'bin/fm-lint.sh'
   test: 'command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"'
 
 # Keep test evidence out of this repo; it stays in a temp dir instead.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,8 @@ See the [no-mistakes quick start](https://kunchenguid.github.io/no-mistakes/star
 - Helper scripts in `bin/` are plain bash.
   Each starts with a usage header comment; keep it accurate when you change behavior.
   Test scripts and helpers in `tests/` are plain bash too.
-  `shellcheck bin/*.sh bin/backends/*.sh tests/*.sh` must pass, and CI enforces it.
+  `bin/fm-lint.sh` must pass: it is the single owner of the lint definition (the shellcheck file set, config, and pinned shellcheck version), and both CI and the no-mistakes pre-push gate run it, so local and CI can never diverge.
+  It pins one exact shellcheck version and refuses to run under any other; print it with `bin/fm-lint.sh --required-version` and install that build locally.
 - Changes to harness adapters (detection in `bin/fm-harness.sh`, launch and hook mechanics in `bin/fm-spawn.sh`, busy signatures in `bin/fm-watch.sh` and `bin/fm-tmux-lib.sh`, cleanup in `bin/fm-teardown.sh`, and facts in `.agents/skills/harness-adapters/SKILL.md`) must be verified empirically against the real harness, never written from documentation alone.
 - Changes to runtime session backends (`bin/fm-backend.sh`, `bin/backends/`, and the scripts that dispatch through them) need empirical adapter notes in the relevant backend guide: `docs/tmux-backend.md`, `docs/herdr-backend.md`, `docs/zellij-backend.md`, `docs/orca-backend.md`, `docs/cmux-backend.md`, or `docs/codex-app-backend.md` for blocked Codex App transport work.
 - In Markdown, put each full sentence on its own line.
@@ -61,14 +62,14 @@ A crewmate picking up such a brief should load the skill even if the brief preda
 When supervising live crewmates, keep firstmate's own long validation or build commands in the background so watcher wakes can still be handled.
 Crewmate validation follows the installed no-mistakes version's SKILL.md and live `axi` help instead of duplicating gate mechanics in firstmate docs.
 Firstmate's wrapper still matters: `ask-user` findings route to the captain through firstmate, and crewmates avoid `--yes` because it silently resolves captain-owned decisions without escalation.
-Local `.no-mistakes/` state and test evidence stay out of this repo; `.no-mistakes.yaml` keeps evidence in a temp directory and pins the gate's test command to the same bash behavior suite as CI.
+Local `.no-mistakes/` state and test evidence stay out of this repo; `.no-mistakes.yaml` keeps evidence in a temp directory and pins the gate's lint and test commands to the same `bin/fm-lint.sh` and bash behavior suite as CI, so the pre-push gate runs the exact checks CI enforces.
 That is firstmate-specific; do not commit `.no-mistakes/evidence/` here even when another no-mistakes-managed target project keeps committed PR evidence.
 
 Check and test the toolbelt before pushing:
 
 ```sh
 for script in bin/*.sh bin/backends/*.sh; do bash -n "$script"; done   # syntax-check the toolbelt
-shellcheck bin/*.sh bin/backends/*.sh tests/*.sh   # lint the toolbelt and behavior tests; CI enforces this
+bin/fm-lint.sh   # lint the toolbelt and behavior tests; the single owner CI and the no-mistakes gate both run
 for test_script in tests/*.test.sh; do bash "$test_script"; done   # behavior tests, matching CI and no-mistakes commands.test
 [ "$(readlink CLAUDE.md)" = "AGENTS.md" ]
 [ "$(readlink .claude/skills)" = "../.agents/skills" ]

--- a/bin/fm-install-shellcheck.sh
+++ b/bin/fm-install-shellcheck.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# fm-install-shellcheck.sh - install CI's pinned, verified ShellCheck build.
+#
+# Usage:
+#   fm-install-shellcheck.sh <destination-directory>
+set -eu
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VERSION="$("$ROOT/bin/fm-lint.sh" --required-version)"
+SHA256=8c3be12b05d5c177a04c29e3c78ce89ac86f1595681cab149b65b97c4e227198
+ARCHIVE="shellcheck-v${VERSION}.linux.x86_64.tar.xz"
+URL="https://github.com/koalaman/shellcheck/releases/download/v${VERSION}/${ARCHIVE}"
+DESTINATION=${1:?usage: fm-install-shellcheck.sh <destination-directory>}
+TMP=$(mktemp -d "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/fm-shellcheck.XXXXXX")
+trap 'rm -rf "$TMP"' EXIT
+
+curl -fsSL "$URL" -o "$TMP/$ARCHIVE"
+ACTUAL_SHA256=$(sha256sum "$TMP/$ARCHIVE" | awk '{print $1}')
+[ "$ACTUAL_SHA256" = "$SHA256" ] || {
+  printf 'fm-install-shellcheck.sh: checksum mismatch for %s\n' "$ARCHIVE" >&2
+  exit 1
+}
+tar -xJf "$TMP/$ARCHIVE" -C "$TMP"
+mkdir -p "$DESTINATION"
+install -m 0755 "$TMP/shellcheck-v${VERSION}/shellcheck" "$DESTINATION/shellcheck"
+"$DESTINATION/shellcheck" --version

--- a/bin/fm-lint.sh
+++ b/bin/fm-lint.sh
@@ -57,6 +57,7 @@ if ! command -v shellcheck >/dev/null 2>&1; then
     "$REQUIRED_SHELLCHECK" >&2
   exit 127
 fi
+unset SHELLCHECK_OPTS
 resolved=$(shellcheck --version | awk '/^version:/ {print $2; exit}')
 # Log the resolved version to stderr so both CI and local runs record it.
 printf 'fm-lint.sh: ShellCheck %s (pinned %s)\n' "$resolved" "$REQUIRED_SHELLCHECK" >&2

--- a/bin/fm-lint.sh
+++ b/bin/fm-lint.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# fm-lint.sh - the single owner of firstmate's shell-lint definition.
+#
+# Runs ShellCheck over firstmate's tracked shell scripts at ShellCheck's default
+# severity (which reports info, warning, and error - the levels CI fails on).
+# The lint command, the file set, the config, AND the pinned ShellCheck version
+# live here and ONLY here, so the gates cannot drift apart: both invoke this
+# script with no arguments.
+#   - CI:       .github/workflows/ci.yml installs the version this script prints
+#               via `--required-version`, then runs `bin/fm-lint.sh`.
+#   - Pre-push: .no-mistakes.yaml `commands.lint` runs `bin/fm-lint.sh`, so the
+#               no-mistakes gate runs the SAME shellcheck as CI. Without a
+#               configured commands.lint, that gate step never ran this
+#               deterministic shellcheck, so info-level findings were not
+#               surfaced locally before CI rejected them.
+#
+# Version parity: CI's ShellCheck used to float with the runner image, and
+# ShellCheck retired SC2015 in 0.11.0, so an older CI ShellCheck rejected an
+# SC2015 that a newer local one no longer emits. This script pins one exact
+# version (REQUIRED_SHELLCHECK) and asserts the resolved `shellcheck` matches it,
+# so CI and local run the identical rule set. This is not a CI relaxation: it
+# adopts one upstream release consistently; the only difference from the old
+# floating CI is dropping the upstream-retired, false-positive-prone SC2015.
+# No severity downgrade and no blanket exclude of checks - every still-supported
+# finding at default severity is enforced.
+# The local == CI parity contract is asserted by tests/fm-lint.test.sh.
+#
+# Usage:
+#   fm-lint.sh                    lint the canonical file set (what both gates run)
+#   fm-lint.sh <path>...          lint only the given paths with the same config
+#                                  (developer convenience; the gates never pass args)
+#   fm-lint.sh --required-version print the pinned ShellCheck version and exit
+#                                  (CI reads this to install the exact same one)
+#
+# Exit status is ShellCheck's own on a lint run, so a caller (CI or the gate)
+# fails exactly when ShellCheck reports a finding; a version mismatch or a
+# missing ShellCheck fails before linting with a distinct message.
+set -eu
+
+# The single source of the pinned ShellCheck version. Bump here and CI follows
+# automatically via `--required-version`; the test suite reads it the same way.
+REQUIRED_SHELLCHECK=0.11.0
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT" || exit 1
+
+# Expose the pinned version without needing ShellCheck installed, so CI can read
+# it to install the exact same build before any lint runs.
+if [ "${1:-}" = "--required-version" ]; then
+  printf '%s\n' "$REQUIRED_SHELLCHECK"
+  exit 0
+fi
+
+# Enforce the pin so local and CI resolve the identical rule set.
+if ! command -v shellcheck >/dev/null 2>&1; then
+  printf 'fm-lint.sh: ShellCheck not found; install ShellCheck %s for CI parity.\n' \
+    "$REQUIRED_SHELLCHECK" >&2
+  exit 127
+fi
+resolved=$(shellcheck --version | awk '/^version:/ {print $2; exit}')
+# Log the resolved version to stderr so both CI and local runs record it.
+printf 'fm-lint.sh: ShellCheck %s (pinned %s)\n' "$resolved" "$REQUIRED_SHELLCHECK" >&2
+if [ "$resolved" != "$REQUIRED_SHELLCHECK" ]; then
+  printf 'fm-lint.sh: ShellCheck %s required for CI parity, found %s. Install %s.\n' \
+    "$REQUIRED_SHELLCHECK" "$resolved" "$REQUIRED_SHELLCHECK" >&2
+  exit 1
+fi
+
+if [ "$#" -gt 0 ]; then
+  exec shellcheck "$@"
+fi
+
+# Canonical file set: the ONE authoritative definition. Callers reference this
+# script; they never re-spell these globs.
+exec shellcheck bin/*.sh bin/backends/*.sh tests/*.sh

--- a/bin/fm-lint.sh
+++ b/bin/fm-lint.sh
@@ -67,9 +67,9 @@ if [ "$resolved" != "$REQUIRED_SHELLCHECK" ]; then
 fi
 
 if [ "$#" -gt 0 ]; then
-  exec shellcheck "$@"
+  exec shellcheck --norc "$@"
 fi
 
 # Canonical file set: the ONE authoritative definition. Callers reference this
 # script; they never re-spell these globs.
-exec shellcheck bin/*.sh bin/backends/*.sh tests/*.sh
+exec shellcheck --norc bin/*.sh bin/backends/*.sh tests/*.sh

--- a/tests/fm-lint.test.sh
+++ b/tests/fm-lint.test.sh
@@ -20,8 +20,9 @@ set -u
 LINT="$ROOT/bin/fm-lint.sh"
 CI="$ROOT/.github/workflows/ci.yml"
 NM="$ROOT/.no-mistakes.yaml"
+INSTALLER="$ROOT/bin/fm-install-shellcheck.sh"
 # The authoritative file set the one owner must run.
-CANON='shellcheck bin/*.sh bin/backends/*.sh tests/*.sh'
+CANON='shellcheck --norc bin/*.sh bin/backends/*.sh tests/*.sh'
 # The pinned version, read from the single source (the one owner itself).
 REQUIRED=$("$LINT" --required-version)
 
@@ -44,11 +45,12 @@ test_owner_defines_canonical_set() {
   # that would hide findings CI fails on.
   assert_no_grep '--severity' "$LINT" "fm-lint.sh must not lower severity below the CI default"
   assert_no_grep '--exclude' "$LINT" "fm-lint.sh must not blanket-exclude checks CI enforces"
+  [ "$(grep -Fc 'exec shellcheck --norc' "$LINT")" -eq 2 ] || fail "both lint modes must ignore ambient ShellCheck configuration"
   pass "fm-lint.sh is the sole authoritative definition at CI-default severity"
 }
 
 test_ci_invokes_the_owner() {
-  assert_grep 'bin/fm-lint.sh' "$CI" "CI lint job must invoke the one-owner script"
+  grep -Eq '^      - run: bin/fm-lint\.sh$' "$CI" || fail "CI lint job must invoke the one-owner script as a run step"
   # Guard against regression to an inline re-spelling of the command.
   assert_no_grep 'run: shellcheck' "$CI" "CI must call fm-lint.sh, not re-spell shellcheck inline"
   pass "CI lint job calls the one-owner script, not an inline command"
@@ -71,8 +73,11 @@ test_pins_an_explicit_version() {
 test_ci_installs_and_logs_the_pinned_version() {
   # CI must derive the version from the one owner (never hardcode a divergent
   # number) and log the resolved version as parity evidence.
-  assert_grep 'bin/fm-lint.sh --required-version' "$CI" "CI must install the version fm-lint.sh pins, read via --required-version"
-  assert_grep 'shellcheck --version' "$CI" "CI must log the resolved ShellCheck version as evidence"
+  assert_grep "VERSION=\"\$(\"\$ROOT/bin/fm-lint.sh\" --required-version)\"" "$INSTALLER" "installer must read the version fm-lint.sh pins"
+  [ "$(grep -Fc "bin/fm-install-shellcheck.sh \"\$RUNNER_TEMP/bin\"" "$CI")" -eq 2 ] || fail "both CI jobs must use the shared ShellCheck installer"
+  assert_grep "ACTUAL_SHA256=\$(sha256sum" "$INSTALLER" "installer must calculate the ShellCheck archive checksum"
+  assert_grep "[ \"\$ACTUAL_SHA256\" = \"\$SHA256\" ]" "$INSTALLER" "installer must verify the ShellCheck archive checksum"
+  assert_grep "\"\$DESTINATION/shellcheck\" --version" "$INSTALLER" "installer must log the resolved ShellCheck version as evidence"
   pass "CI installs and logs the pinned ShellCheck version from the one owner"
 }
 

--- a/tests/fm-lint.test.sh
+++ b/tests/fm-lint.test.sh
@@ -57,8 +57,7 @@ test_ci_invokes_the_owner() {
 }
 
 test_nomistakes_invokes_the_owner() {
-  assert_grep 'bin/fm-lint.sh' "$NM" "no-mistakes commands.lint must invoke the one-owner script"
-  assert_grep 'lint:' "$NM" "no-mistakes config must set a commands.lint key"
+  grep -Fqx "  lint: 'bin/fm-lint.sh'" "$NM" || fail "no-mistakes commands.lint must map exactly to the one-owner script"
   pass "no-mistakes pre-push lint calls the one-owner script"
 }
 
@@ -135,6 +134,30 @@ SH
   pass "fm-lint.sh catches a real lint defect the old no-op gate passed"
 }
 
+test_ignores_ambient_shellcheck_opts() {
+  if ! pinned_ready; then
+    pass "SKIP (ShellCheck $REQUIRED not resolved): ambient options regression check"
+    return
+  fi
+  local tmp bad out rc
+  tmp=$(fm_test_tmproot fm-lint-opts)
+  mkdir -p "$tmp"
+  bad="$tmp/bad.sh"
+  cat > "$bad" <<'SH'
+#!/usr/bin/env bash
+foo() {
+  local a= b=
+  echo "$a$b"
+}
+foo
+SH
+  rc=0
+  out=$(SHELLCHECK_OPTS='--exclude=SC1007' "$LINT" "$bad" 2>&1) || rc=$?
+  [ "$rc" -ne 0 ] || fail "fm-lint.sh allowed ambient SHELLCHECK_OPTS to hide a finding"$'\n'"$out"
+  assert_contains "$out" "SC1007" "fm-lint.sh did not neutralize ambient SHELLCHECK_OPTS"
+  pass "fm-lint.sh ignores ambient ShellCheck options"
+}
+
 test_clean_fixture_passes() {
   if ! pinned_ready; then
     pass "SKIP (ShellCheck $REQUIRED not resolved): clean fixture check"
@@ -165,4 +188,5 @@ test_pins_an_explicit_version
 test_ci_installs_and_logs_the_pinned_version
 test_rejects_wrong_shellcheck_version
 test_catches_a_real_lint_defect
+test_ignores_ambient_shellcheck_opts
 test_clean_fixture_passes

--- a/tests/fm-lint.test.sh
+++ b/tests/fm-lint.test.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# Parity guard for firstmate's shell-lint definition.
+#
+# bin/fm-lint.sh must be the single owner that BOTH CI
+# (.github/workflows/ci.yml) and the pre-push gate (.no-mistakes.yaml
+# commands.lint) invoke, so the local lint can never diverge from CI again.
+# Regression origin: with no commands.lint configured, the local no-mistakes
+# lint step never ran the deterministic
+# `shellcheck bin/*.sh bin/backends/*.sh tests/*.sh`, so PRs passed local
+# validation yet failed that exact check in CI on info/warning findings such as
+# SC2015, SC1007, and SC2034. A second axis was tool-version skew: CI's
+# ShellCheck floated with the runner image and still emitted SC2015, which
+# ShellCheck retired in 0.11.0. fm-lint.sh now pins one exact version and both
+# gates resolve it, so command, file set, config, AND version all match.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+LINT="$ROOT/bin/fm-lint.sh"
+CI="$ROOT/.github/workflows/ci.yml"
+NM="$ROOT/.no-mistakes.yaml"
+# The authoritative file set the one owner must run.
+CANON='shellcheck bin/*.sh bin/backends/*.sh tests/*.sh'
+# The pinned version, read from the single source (the one owner itself).
+REQUIRED=$("$LINT" --required-version)
+
+# True only when the resolved shellcheck is exactly the pinned version, so the
+# lint-running tests below match what CI enforces instead of a runner default.
+pinned_ready() {
+  command -v shellcheck >/dev/null 2>&1 || return 1
+  [ "$(shellcheck --version | awk '/^version:/ {print $2; exit}')" = "$REQUIRED" ]
+}
+
+test_owner_exists_and_executable() {
+  assert_present "$LINT" "bin/fm-lint.sh is missing"
+  [ -x "$LINT" ] || fail "bin/fm-lint.sh must be executable so CI/gate can run it directly"
+  pass "one-owner lint script exists and is executable"
+}
+
+test_owner_defines_canonical_set() {
+  assert_grep "$CANON" "$LINT" "fm-lint.sh must run the canonical shellcheck file set"
+  # It must not weaken CI: no severity downgrade and no blanket disable/exclude
+  # that would hide findings CI fails on.
+  assert_no_grep '--severity' "$LINT" "fm-lint.sh must not lower severity below the CI default"
+  assert_no_grep '--exclude' "$LINT" "fm-lint.sh must not blanket-exclude checks CI enforces"
+  pass "fm-lint.sh is the sole authoritative definition at CI-default severity"
+}
+
+test_ci_invokes_the_owner() {
+  assert_grep 'bin/fm-lint.sh' "$CI" "CI lint job must invoke the one-owner script"
+  # Guard against regression to an inline re-spelling of the command.
+  assert_no_grep 'run: shellcheck' "$CI" "CI must call fm-lint.sh, not re-spell shellcheck inline"
+  pass "CI lint job calls the one-owner script, not an inline command"
+}
+
+test_nomistakes_invokes_the_owner() {
+  assert_grep 'bin/fm-lint.sh' "$NM" "no-mistakes commands.lint must invoke the one-owner script"
+  assert_grep 'lint:' "$NM" "no-mistakes config must set a commands.lint key"
+  pass "no-mistakes pre-push lint calls the one-owner script"
+}
+
+test_pins_an_explicit_version() {
+  [ -n "$REQUIRED" ] || fail "fm-lint.sh --required-version printed nothing"
+  # The captain-agreed pin: adopt ShellCheck 0.11.0's rule set consistently,
+  # which is also what drops the upstream-retired, false-positive-prone SC2015.
+  assert_contains "$REQUIRED" "0.11.0" "fm-lint.sh must pin ShellCheck 0.11.0"
+  pass "fm-lint.sh pins an explicit ShellCheck version ($REQUIRED)"
+}
+
+test_ci_installs_and_logs_the_pinned_version() {
+  # CI must derive the version from the one owner (never hardcode a divergent
+  # number) and log the resolved version as parity evidence.
+  assert_grep 'bin/fm-lint.sh --required-version' "$CI" "CI must install the version fm-lint.sh pins, read via --required-version"
+  assert_grep 'shellcheck --version' "$CI" "CI must log the resolved ShellCheck version as evidence"
+  pass "CI installs and logs the pinned ShellCheck version from the one owner"
+}
+
+test_rejects_wrong_shellcheck_version() {
+  # Version-independent: a fake shellcheck reporting a different version must be
+  # refused before any lint, proving local and CI cannot silently diverge.
+  local tmp fakebin out rc
+  tmp=$(fm_test_tmproot fm-lint-ver)
+  fakebin=$(fm_fakebin "$tmp")
+  cat > "$fakebin/shellcheck" <<'SH'
+#!/usr/bin/env bash
+if [ "$1" = "--version" ]; then
+  printf 'ShellCheck - shell script analysis tool\nversion: 0.9.9\nlicense: x\nwebsite: y\n'
+  exit 0
+fi
+exit 0
+SH
+  chmod +x "$fakebin/shellcheck"
+  rc=0
+  out=$(PATH="$fakebin:$PATH" "$LINT" 2>&1) || rc=$?
+  [ "$rc" -ne 0 ] || fail "fm-lint.sh accepted a shellcheck version other than the pin"$'\n'"$out"
+  assert_contains "$out" "$REQUIRED" "fm-lint.sh did not name the required version on mismatch"
+  assert_contains "$out" "0.9.9" "fm-lint.sh did not report the resolved (wrong) version"
+  pass "fm-lint.sh refuses to lint under a non-pinned ShellCheck version"
+}
+
+test_catches_a_real_lint_defect() {
+  if ! pinned_ready; then
+    pass "SKIP (ShellCheck $REQUIRED not resolved): lint-defect regression check"
+    return
+  fi
+  # A script with a genuine ShellCheck finding must make the one owner exit
+  # non-zero, proving local now runs real shellcheck instead of the old no-op
+  # lint step. We deliberately do NOT assert SC2015 (PR 475's actual failure):
+  # ShellCheck removed SC2015 in the pinned 0.11.0, so asserting it would make
+  # this test itself version-fragile - the very trap being fixed. SC1007 is a
+  # warning present at default severity (and is itself one of the recurring
+  # classes that slipped through, PR 474).
+  local tmp bad out rc
+  tmp=$(fm_test_tmproot fm-lint-bad)
+  mkdir -p "$tmp"
+  bad="$tmp/bad.sh"
+  cat > "$bad" <<'SH'
+#!/usr/bin/env bash
+foo() {
+  local a= b=
+  echo "$a$b"
+}
+foo
+SH
+  rc=0
+  out=$("$LINT" "$bad" 2>&1) || rc=$?
+  [ "$rc" -ne 0 ] || fail "fm-lint.sh passed a known-bad fixture"$'\n'"$out"
+  assert_contains "$out" "SC1007" "fm-lint.sh did not report the expected ShellCheck finding"
+  pass "fm-lint.sh catches a real lint defect the old no-op gate passed"
+}
+
+test_clean_fixture_passes() {
+  if ! pinned_ready; then
+    pass "SKIP (ShellCheck $REQUIRED not resolved): clean fixture check"
+    return
+  fi
+  local tmp good rc
+  tmp=$(fm_test_tmproot fm-lint-good)
+  mkdir -p "$tmp"
+  good="$tmp/good.sh"
+  cat > "$good" <<'SH'
+#!/usr/bin/env bash
+set -eu
+if [ -n "${1:-}" ] && [ -d "$1" ]; then
+  printf 'ok\n'
+fi
+SH
+  rc=0
+  "$LINT" "$good" >/dev/null 2>&1 || rc=$?
+  [ "$rc" -eq 0 ] || fail "fm-lint.sh flagged a clean fixture (exit $rc)"
+  pass "fm-lint.sh passes a clean fixture"
+}
+
+test_owner_exists_and_executable
+test_owner_defines_canonical_set
+test_ci_invokes_the_owner
+test_nomistakes_invokes_the_owner
+test_pins_an_explicit_version
+test_ci_installs_and_logs_the_pinned_version
+test_rejects_wrong_shellcheck_version
+test_catches_a_real_lint_defect
+test_clean_fixture_passes


### PR DESCRIPTION
## Intent

Fix a systemic shell-lint parity defect: firstmate PRs passed local no-mistakes validation but then failed CI's "Lint shell scripts" job, which runs shellcheck over bin/*.sh bin/backends/*.sh tests/*.sh at default severity, on findings like SC2015, SC1007, and SC2034. Root cause, confirmed from the no-mistakes state.sqlite agent_invocations and step_results: the no-mistakes gate had no commands.lint configured, so its lint step never ran that deterministic shellcheck (lint step_result recorded findings:null with no lint agent invocation); and separately CI's shellcheck floated with the runner image while local ran a newer build, and shellcheck retired SC2015 in 0.11.0, so an older CI shellcheck rejected an SC2015 that the newer local one no longer emits.

The fix establishes bin/fm-lint.sh as the single owner of the lint definition: the file set, the config, and the pinned shellcheck version 0.11.0 which it prints via --required-version. Both CI (.github/workflows/ci.yml) and the no-mistakes gate (.no-mistakes.yaml commands.lint) invoke that one script; CI installs the exact version it names and logs the resolved version, and fm-lint.sh refuses to lint under any other shellcheck version.

Deliberate decisions the captain explicitly approved: this is intentionally NOT a CI weakening - it adopts shellcheck 0.11.0's rule set consistently and drops only the upstream-retired, false-positive-prone SC2015; default severity and every still-supported finding stay enforced, with no severity downgrade and no excludes or suppressions. fm-lint.sh keeps an optional path-arguments mode as a developer convenience, but both gates call it with no arguments so their invocation is identical. The CI lint and tests jobs both install the pinned shellcheck by reading the version from bin/fm-lint.sh --required-version, so the version lives in exactly one place.

Added colocated tests/fm-lint.test.sh asserting both gates invoke the one owner, that CI installs and logs the pinned version via --required-version, that the owner rejects a non-pinned shellcheck version, and that it catches a real lint defect (SC1007) that the old no-op lint step passed. Updated CONTRIBUTING.md and the firstmate-coding-guidelines skill to cross-reference the one owner per the repo's one-owner rule. Scope is deliberately limited to shell-lint parity; PR 475's specific SC2015 line is being fixed separately in its own run and is not touched here.

## What Changed

Captain, the full branch delta:

- Centralize the canonical shell lint file set, configuration, and pinned ShellCheck 0.11.0 version in `bin/fm-lint.sh`, neutralizing ambient overrides and rejecting version drift.
- Route CI and the no-mistakes lint gate through the shared lint owner, with checksum-verified installation of the pinned ShellCheck release.
- Add parity and regression coverage for gate wiring, version enforcement, ambient configuration isolation, and real lint failures, plus update contributor guidance.

## Risk Assessment

✅ Low: Captain, the prior findings are resolved, the lint-parity implementation is well bounded, and the full updated range contains no remaining material risks.

## Testing

The complete behavior-test baseline had already passed; focused automated and manual CLI checks then demonstrated that both gates share the lint owner, pinned ShellCheck 0.11.0 accepts clean input, rejects SC1007, and refuses a mismatched version, with the resulting transcript preserved as reviewer-visible evidence.

<details>
<summary>Evidence: Shell-lint parity end-to-end transcript</summary>

```text
# Shell-lint parity end-to-end evidence

## Required version
$ bin/fm-lint.sh --required-version
0.11.0

## Installed version
$ shellcheck --version
ShellCheck - shell script analysis tool
version: 0.11.0
license: GNU General Public License, version 3
website: https://www.shellcheck.net

## Known-bad developer fixture
$ bin/fm-lint.sh <bad-sc1007.sh>
fm-lint.sh: ShellCheck 0.11.0 (pinned 0.11.0)

In /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KX9MSDAF5K9982ASPW25DXSE/bad-sc1007.sh line 3:
  local a= b=
          ^-- SC1007 (warning): Remove space after = if trying to assign a value (for empty string, use var='' ... ).

For more information:
  https://www.shellcheck.net/wiki/SC1007 -- Remove space after = if trying to...
exit=1

## Clean developer fixture
$ bin/fm-lint.sh <clean.sh>
fm-lint.sh: ShellCheck 0.11.0 (pinned 0.11.0)
exit=0

## Gate wiring
.no-mistakes.yaml:   lint: 'bin/fm-lint.sh'
.github/workflows/ci.yml lint calls:
      - run: bin/fm-lint.sh

## Version drift refusal
$ PATH=<fake-shellcheck-0.9.9> bin/fm-lint.sh <clean.sh>
fm-lint.sh: ShellCheck 0.9.9 (pinned 0.11.0)
fm-lint.sh: ShellCheck 0.11.0 required for CI parity, found 0.9.9. Install 0.11.0.
exit=1
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 4 issues found → auto-fixed (2) ✅</summary>

- ⚠️ `bin/fm-lint.sh:75` - Both lint paths invoke ShellCheck without `--norc` or an explicit `--rcfile`. A contributor&#39;s parent or user-level `.shellcheckrc` can therefore change enabled checks, exclusions, or severity locally while CI uses a clean environment, breaking the intended parity guarantee.
- ⚠️ `tests/fm-lint.test.sh:51` - The test only searches the workflow for `bin/fm-lint.sh`, which also appears in comments and installer logic. Removing the actual lint execution step would not fail this test. Assert the command-bearing YAML structurally or match the exact step.
- ⚠️ `.github/workflows/ci.yml:27` - CI downloads, extracts, and executes a ShellCheck release artifact without verifying a checksum or signature. Pin and verify its SHA-256 digest before extraction and installation.
- ℹ️ `.github/workflows/ci.yml:22` - The ShellCheck download, installation, and version logging block is duplicated across the lint and tests jobs. Move it into one tracked helper or local composite action so integrity and platform changes cannot drift.

🔧 Fix: Captain, harden deterministic ShellCheck parity
2 warnings still open:
- ⚠️ `bin/fm-lint.sh:70` - `--norc` disables rc-file discovery but ShellCheck still reads inherited `SHELLCHECK_OPTS`. Values such as `--exclude=SC1007` or a severity override can therefore weaken local no-mistakes lint while clean CI rejects the same code. Unset `SHELLCHECK_OPTS` before invoking ShellCheck.
- ⚠️ `tests/fm-lint.test.sh:60` - The no-mistakes wiring test searches independently for `bin/fm-lint.sh` and `lint:`, but both strings already occur in comments. Removing the actual `commands.lint` mapping would leave the test green. Assert the exact mapping or parse the YAML structurally.

🔧 Fix: Captain, neutralize ambient ShellCheck overrides
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- <code>Baseline previously passed: `command -v tmux &gt;/dev/null || { echo &#34;tmux is required for e2e tests&#34; &gt;&amp;2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo &#34;== $t ==&#34;; bash &#34;$t&#34; || rc=1; done; exit &#34;$rc&#34;`</code>
- <code>Focused regression suite: `bash tests/fm-lint.test.sh`</code>
- <code>Ran `bin/fm-lint.sh --required-version` and verified the installed ShellCheck resolves to `0.11.0`</code>
- <code>Ran `bin/fm-lint.sh` against a real SC1007 fixture and confirmed it reported SC1007 with exit 1</code>
- <code>Ran `bin/fm-lint.sh` against a clean fixture and confirmed exit 0</code>
- <code>Placed a fake ShellCheck 0.9.9 first on `PATH` and confirmed `bin/fm-lint.sh` refused version drift with exit 1</code>
- <code>Captured `.no-mistakes.yaml` and CI workflow wiring showing both gates invoke `bin/fm-lint.sh`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
