### PR TITLE
feat: guard primary shells from persistent cd commands

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,6 +7,10 @@
           {
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/bin/fm-arm-pretool-check.sh --claude"
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/bin/fm-cd-pretool-check.sh --claude"
           }
         ]
       }

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -8,6 +8,11 @@
             "type": "command",
             "command": "bash -lc 'payload=$(cat 2>/dev/null || true); [ -n \"$payload\" ] || exit 0; command -v jq >/dev/null 2>&1 || exit 0; root=$(pwd -P) || exit 0; [ -x \"$root/bin/fm-arm-pretool-check.sh\" ] || exit 0; [ -f \"$root/AGENTS.md\" ] || exit 0; [ -f \"$root/.codex/hooks.json\" ] || exit 0; jq -e \"any(.hooks.PreToolUse[]?.hooks[]?.command?; type == \\\"string\\\" and contains(\\\"fm-arm-pretool-check.sh\\\"))\" \"$root/.codex/hooks.json\" >/dev/null 2>&1 || exit 0; printf \"%s\" \"$payload\" | \"$root/bin/fm-arm-pretool-check.sh\"'",
             "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "bash -lc 'payload=$(cat 2>/dev/null || true); [ -n \"$payload\" ] || exit 0; command -v jq >/dev/null 2>&1 || exit 0; root=$(pwd -P) || exit 0; [ -x \"$root/bin/fm-cd-pretool-check.sh\" ] || exit 0; [ -f \"$root/AGENTS.md\" ] || exit 0; [ -f \"$root/.codex/hooks.json\" ] || exit 0; jq -e \"any(.hooks.PreToolUse[]?.hooks[]?.command?; type == \\\"string\\\" and contains(\\\"fm-cd-pretool-check.sh\\\"))\" \"$root/.codex/hooks.json\" >/dev/null 2>&1 || exit 0; printf \"%s\" \"$payload\" | \"$root/bin/fm-cd-pretool-check.sh\"'",
+            "timeout": 10
           }
         ]
       }

--- a/.grok/hooks/fm-primary-cd-check.json
+++ b/.grok/hooks/fm-primary-cd-check.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -lc '[ -n \"${GROK_WORKSPACE_ROOT:-}\" ] || exit 0; exec \"${GROK_WORKSPACE_ROOT:-}/bin/fm-cd-pretool-check.sh\"'",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.opencode/plugins/fm-primary-cd-check.js
+++ b/.opencode/plugins/fm-primary-cd-check.js
@@ -1,0 +1,64 @@
+import { realpathSync } from "node:fs";
+import { resolve } from "node:path";
+import { spawn } from "node:child_process";
+
+// PreToolUse seatbelt for OpenCode: block a stray persistent top-level `cd` in
+// the primary firstmate checkout before the agent's bash tool relocates the
+// shell out of the home (see bin/fm-cd-pretool-check.sh and docs/cd-guard.md).
+// This mirrors fm-primary-pretool-check.js, calling the cd-guard owner instead
+// of the watcher-arm one. tool.execute.before can block by throwing (verified
+// 2026-07-09 against OpenCode 1.17.15 for the watcher-arm plugin; the same
+// mechanism carries this guard). The owner script is itself inert outside the
+// real primary checkout, so a crewmate/scout worktree is never affected.
+
+function runProcess(command, args) {
+  return new Promise((resolvePromise) => {
+    const child = spawn(command, args, { stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on("error", () => resolvePromise({ code: 0, stdout: "", stderr: "" }));
+    child.on("close", (code) => resolvePromise({ code: code ?? 0, stdout, stderr }));
+  });
+}
+
+async function resolveRoot(anchor) {
+  if (!anchor) return "";
+  const result = await runProcess("git", ["-C", anchor, "rev-parse", "--show-toplevel"]);
+  const root = result.stdout.trim();
+  if (result.code === 0 && root) return root;
+  try {
+    return realpathSync(anchor);
+  } catch {
+    return resolve(anchor);
+  }
+}
+
+export const FmPrimaryCdCheck = async ({ directory, worktree }) => {
+  const root = worktree ? (() => {
+    try {
+      return realpathSync(worktree);
+    } catch {
+      return resolve(worktree);
+    }
+  })() : await resolveRoot(directory);
+
+  return {
+    "tool.execute.before": async (input, output) => {
+      if (!root || input?.tool !== "bash") return;
+      const command = output?.args?.command;
+      if (!command || typeof command !== "string") return;
+
+      const result = await runProcess(`${root}/bin/fm-cd-pretool-check.sh`, ["--command", command]);
+      if (result.code !== 2) return;
+
+      const reason = result.stderr.trim() || "denied by the cd-guard PreToolUse seatbelt";
+      throw new Error(reason);
+    },
+  };
+};

--- a/.pi/extensions/fm-primary-turnend-guard.ts
+++ b/.pi/extensions/fm-primary-turnend-guard.ts
@@ -70,15 +70,16 @@ function runGuard(): Promise<{ code: number; stderr: string }> {
   });
 }
 
-// PreToolUse seatbelt (bin/fm-arm-pretool-check.sh; docs/arm-pretool-check.md).
-// Piggybacks on this same extension file rather than a separate one so no
-// second Pi -e flag is needed at launch - the primary already loads this
-// file for the turn-end guard, and pi.on("tool_call", ...) can block
-// (verified 2026-07-09 against pi 0.80.5: returning {block: true} prevents
-// the bash command from running).
-function runPretoolCheck(command: string): Promise<{ code: number; stderr: string }> {
+// PreToolUse seatbelts (bin/fm-arm-pretool-check.sh, docs/arm-pretool-check.md;
+// bin/fm-cd-pretool-check.sh, docs/cd-guard.md). Both piggyback on this same
+// extension file rather than separate ones so no extra Pi -e flag is needed at
+// launch - the primary already loads this file for the turn-end guard, and
+// pi.on("tool_call", ...) can block (verified 2026-07-09 against pi 0.80.5:
+// returning {block: true} prevents the bash command from running). Each owner
+// script owns its own decision and is inert outside the real primary checkout.
+function runChecker(script: string, command: string): Promise<{ code: number; stderr: string }> {
   return new Promise((resolveResult) => {
-    const child = spawn(`${root}/bin/fm-arm-pretool-check.sh`, ["--command", command], {
+    const child = spawn(`${root}/bin/${script}`, ["--command", command], {
       stdio: ["ignore", "ignore", "pipe"],
     });
     let stderr = "";
@@ -90,6 +91,14 @@ function runPretoolCheck(command: string): Promise<{ code: number; stderr: strin
   });
 }
 
+function runPretoolCheck(command: string): Promise<{ code: number; stderr: string }> {
+  return runChecker("fm-arm-pretool-check.sh", command);
+}
+
+function runCdCheck(command: string): Promise<{ code: number; stderr: string }> {
+  return runChecker("fm-cd-pretool-check.sh", command);
+}
+
 export default function (pi: ExtensionAPI) {
   pi.on?.("session_start", () => {
     markLoaded();
@@ -99,6 +108,10 @@ export default function (pi: ExtensionAPI) {
     if (event.type !== "tool_call" || event.toolName !== "bash") return {};
     const command = String((event.input as { command?: unknown })?.command ?? "");
     if (!command) return {};
+    const cdResult = await runCdCheck(command);
+    if (cdResult.code === 2) {
+      return { block: true, reason: cdResult.stderr.trim() || "denied by the cd-guard PreToolUse seatbelt" };
+    }
     const result = await runPretoolCheck(command);
     if (result.code !== 2) return {};
     return { block: true, reason: result.stderr.trim() || "denied by the watcher-arm PreToolUse seatbelt" };

--- a/bin/fm-arm-command-policy.mjs
+++ b/bin/fm-arm-command-policy.mjs
@@ -4,8 +4,18 @@
 // This parser is deliberately narrow.
 // It recognizes executed command positions without evaluating, expanding,
 // sourcing, or running any byte of the submitted command.
+//
+// This file is the sole owner of firstmate's shell command classification.
+// The tokenizer and command-position analysis (Lexer, splitProgram,
+// commandPosition, basename) are exported so the sibling cd-guard policy
+// (bin/fm-cd-command-policy.mjs) reuses the same proven parser instead of
+// duplicating shell lexing; see docs/cd-guard.md. The watcher-arm decision
+// procedure below stays private to this file. The CLI entry point at the bottom
+// runs only when this module is invoked directly, never on import.
 
 import path from "node:path";
+import { realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 const REASONS = {
   "watcher-background": "a protected watcher command cannot run in an asynchronous shell list or through nohup/disown",
@@ -46,7 +56,7 @@ function normalizeLineContinuations(source) {
   return source.replace(/\\\r?\n/g, "");
 }
 
-function basename(value) {
+export function basename(value) {
   return value.split("/").filter(Boolean).at(-1) || value;
 }
 
@@ -167,7 +177,7 @@ function decodeAnsiCQuoted(source, start) {
   return null;
 }
 
-class Lexer {
+export class Lexer {
   constructor(source) {
     this.source = source;
     this.index = 0;
@@ -422,7 +432,7 @@ class Lexer {
   }
 }
 
-function splitProgram(tokens) {
+export function splitProgram(tokens) {
   const nodes = [];
   const separators = [];
   let current = [];
@@ -532,7 +542,7 @@ function consumeWrapperOptions(name, words, index) {
   return { index: next, unresolved: false, embeddedPayloads };
 }
 
-function commandPosition(tokens) {
+export function commandPosition(tokens) {
   const words = wordsInNode(tokens);
   let index = 0;
   while (index < words.length && isAssignment(words[index].value)) index += 1;
@@ -916,20 +926,35 @@ function deny(code) {
   return { decision: "deny", code, reason: REASONS[code] };
 }
 
-try {
-  const args = parseArguments(process.argv.slice(2));
-  if (!args.root || !args.home) throw new Error("--root and --home are required");
-  if (!args.command) {
-    process.stdout.write("allow\n");
-  } else {
-    const result = decision(args.command, args.root, args.home);
-    if (result.decision === "allow") {
+// Run the CLI only when invoked directly (node fm-arm-command-policy.mjs ...),
+// never when imported by a sibling policy such as bin/fm-cd-command-policy.mjs.
+function invokedDirectly() {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  const self = fileURLToPath(import.meta.url);
+  try {
+    return realpathSync(entry) === realpathSync(self);
+  } catch {
+    return entry === self;
+  }
+}
+
+if (invokedDirectly()) {
+  try {
+    const args = parseArguments(process.argv.slice(2));
+    if (!args.root || !args.home) throw new Error("--root and --home are required");
+    if (!args.command) {
       process.stdout.write("allow\n");
     } else {
-      process.stdout.write(`deny\t${result.code}\t${result.reason}\n`);
+      const result = decision(args.command, args.root, args.home);
+      if (result.decision === "allow") {
+        process.stdout.write("allow\n");
+      } else {
+        process.stdout.write(`deny\t${result.code}\t${result.reason}\n`);
+      }
     }
+  } catch (error) {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
   }
-} catch (error) {
-  process.stderr.write(`${error.message}\n`);
-  process.exitCode = 1;
 }

--- a/bin/fm-arm-command-policy.mjs
+++ b/bin/fm-arm-command-policy.mjs
@@ -7,7 +7,7 @@
 //
 // This file is the sole owner of firstmate's shell command classification.
 // The tokenizer and command-position analysis (Lexer, splitProgram,
-// commandPosition, basename) are exported so the sibling cd-guard policy
+// commandPosition) are exported so the sibling cd-guard policy
 // (bin/fm-cd-command-policy.mjs) reuses the same proven parser instead of
 // duplicating shell lexing; see docs/cd-guard.md. The watcher-arm decision
 // procedure below stays private to this file. The CLI entry point at the bottom
@@ -56,7 +56,7 @@ function normalizeLineContinuations(source) {
   return source.replace(/\\\r?\n/g, "");
 }
 
-export function basename(value) {
+function basename(value) {
   return value.split("/").filter(Boolean).at(-1) || value;
 }
 

--- a/bin/fm-cd-command-policy.mjs
+++ b/bin/fm-cd-command-policy.mjs
@@ -15,7 +15,7 @@
 // never evaluates, expands, sources, or runs any byte of the submitted command;
 // it inspects lexical command positions only.
 
-import { Lexer, splitProgram, commandPosition, basename } from "./fm-arm-command-policy.mjs";
+import { Lexer, splitProgram, commandPosition } from "./fm-arm-command-policy.mjs";
 import { realpathSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
@@ -65,8 +65,14 @@ function decision(command) {
     // substitutions (they contribute no top-level command word), and skips
     // leading assignments and wrappers to find the executed command word.
     const position = commandPosition(nodes[index]);
-    if (!position.command) continue;
-    if (!CD_BUILTINS.has(basename(position.command.value))) continue;
+    let command = position.command;
+    let wordIndex = position.index;
+    while (command && (command.value === "builtin" || command.value === "command")) {
+      wordIndex += 1;
+      command = position.words[wordIndex];
+    }
+    if (!command) continue;
+    if (!CD_BUILTINS.has(command.value)) continue;
     if (position.wrappers.some((wrapper) => FORKING_WRAPPERS.has(wrapper))) continue;
     return deny("persistent-cd");
   }

--- a/bin/fm-cd-command-policy.mjs
+++ b/bin/fm-cd-command-policy.mjs
@@ -20,10 +20,8 @@ import { realpathSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
 const REASONS = {
-  // "Address the target by absolute path" means passing an absolute target to
-  // the intended command, not running `cd /absolute/path`, which remains denied.
   "persistent-cd":
-    "a persistent top-level directory change in the primary firstmate checkout is blocked; it would move the shell out of the home so a later firstmate-owned command runs inside a project clone. Address files or repositories directly, for example with an absolute-path operand or git -C <dir>, or scope the change to a subshell like (cd <dir> && ...).",
+    "a persistent top-level directory change in the primary firstmate checkout is blocked; it would move the shell out of the home so a later firstmate-owned command runs inside a project clone. Reach the target without moving the shell - use git -C <dir> or an absolute path on the command itself - or scope the cd to a subshell like (cd <dir> && ...).",
 };
 
 // Directory-changing builtins that mutate the calling shell's own cwd.

--- a/bin/fm-cd-command-policy.mjs
+++ b/bin/fm-cd-command-policy.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+// Semantic policy for the cd-guard: does a shell command persistently change the
+// PRIMARY firstmate shell's own working directory?
+//
+// A stray persistent top-level `cd projects/<clone>` silently relocates the
+// primary shell, so the next firstmate-owned command (a backlog write, an
+// fm-* lifecycle call, tasks-axi) runs inside a project clone instead of the
+// home. This policy blocks exactly that class of command; the environmental
+// scoping to the real primary checkout lives in the bin/fm-cd-pretool-check.sh
+// transport, not here. See docs/cd-guard.md for the full contract.
+//
+// The shell tokenizer and command-position analysis are imported from
+// bin/fm-arm-command-policy.mjs, the sole owner of firstmate's shell
+// classification, so this guard never duplicates shell lexing. This policy
+// never evaluates, expands, sources, or runs any byte of the submitted command;
+// it inspects lexical command positions only.
+
+import { Lexer, splitProgram, commandPosition, basename } from "./fm-arm-command-policy.mjs";
+import { realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const REASONS = {
+  "persistent-cd":
+    "a persistent top-level directory change in the primary firstmate checkout is blocked; it would move the shell out of the home so a later firstmate-owned command runs inside a project clone. Address the target by absolute path or git -C <dir>, or scope the change to a subshell like (cd <dir> && ...).",
+};
+
+// Directory-changing builtins that mutate the calling shell's own cwd.
+const CD_BUILTINS = new Set(["cd", "pushd", "popd"]);
+
+// Wrappers that fork or exec a child before reaching the builtin, so a cd behind
+// them never persists to the parent shell (and generally just fails, since cd is
+// a builtin with no external program). `command` is deliberately NOT here: it
+// runs the builtin in the current shell, so `command cd x` still persists.
+const FORKING_WRAPPERS = new Set(["env", "sudo", "nohup", "timeout", "gtimeout", "exec"]);
+
+function isPipe(separator) {
+  return separator === "|" || separator === "|&";
+}
+
+// A top-level command-list node persists its cwd change to the parent shell
+// unless it runs in a subshell context: backgrounded with a trailing `&`, or a
+// stage of a pipeline (bash runs every pipeline stage in a subshell).
+function nodePersists(separators, index) {
+  if (separators[index] === "&") return false;
+  if (isPipe(separators[index]) || isPipe(separators[index - 1])) return false;
+  return true;
+}
+
+function deny(code) {
+  return { decision: "deny", code, reason: REASONS[code] };
+}
+
+function decision(command) {
+  const lexed = new Lexer(command).tokenize();
+  // Fail open on syntax this classifier cannot tokenize. The cd-guard's threat
+  // model is agent mistakes - an accidental bare `cd projects/foo` always
+  // tokenizes - so we prioritize zero false blocks over catching malformed or
+  // deliberately obfuscated bypasses, which stay out of scope by design.
+  if (lexed.error) return { decision: "allow" };
+
+  const { nodes, separators } = splitProgram(lexed.tokens);
+  for (let index = 0; index < nodes.length; index += 1) {
+    if (!nodePersists(separators, index)) continue;
+    // commandPosition ignores subshell/brace groups, quoted data, comments, and
+    // substitutions (they contribute no top-level command word), and skips
+    // leading assignments and wrappers to find the executed command word.
+    const position = commandPosition(nodes[index]);
+    if (!position.command) continue;
+    if (!CD_BUILTINS.has(basename(position.command.value))) continue;
+    if (position.wrappers.some((wrapper) => FORKING_WRAPPERS.has(wrapper))) continue;
+    return deny("persistent-cd");
+  }
+  return { decision: "allow" };
+}
+
+function parseArguments(argv) {
+  const result = { command: "", commandSet: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const name = argv[i];
+    if (name === "--command") {
+      if (i + 1 >= argv.length) throw new Error("--command requires a value");
+      result.command = argv[i + 1];
+      result.commandSet = true;
+      i += 1;
+      continue;
+    }
+    if (name.startsWith("--command=")) {
+      result.command = name.slice("--command=".length);
+      result.commandSet = true;
+      continue;
+    }
+    throw new Error(`unknown argument: ${name}`);
+  }
+  return result;
+}
+
+function invokedDirectly() {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  const self = fileURLToPath(import.meta.url);
+  try {
+    return realpathSync(entry) === realpathSync(self);
+  } catch {
+    return entry === self;
+  }
+}
+
+if (invokedDirectly()) {
+  try {
+    const args = parseArguments(process.argv.slice(2));
+    if (!args.commandSet || !args.command) {
+      process.stdout.write("allow\n");
+    } else {
+      const result = decision(args.command);
+      if (result.decision === "allow") {
+        process.stdout.write("allow\n");
+      } else {
+        process.stdout.write(`deny\t${result.code}\t${result.reason}\n`);
+      }
+    }
+  } catch (error) {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
+  }
+}
+
+export { decision };

--- a/bin/fm-cd-command-policy.mjs
+++ b/bin/fm-cd-command-policy.mjs
@@ -20,6 +20,8 @@ import { realpathSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
 const REASONS = {
+  // "Address the target by absolute path" means passing an absolute target to
+  // the intended command, not running `cd /absolute/path`, which remains denied.
   "persistent-cd":
     "a persistent top-level directory change in the primary firstmate checkout is blocked; it would move the shell out of the home so a later firstmate-owned command runs inside a project clone. Address files or repositories directly, for example with an absolute-path operand or git -C <dir>, or scope the change to a subshell like (cd <dir> && ...).",
 };

--- a/bin/fm-cd-command-policy.mjs
+++ b/bin/fm-cd-command-policy.mjs
@@ -56,6 +56,18 @@ function hasPathQualifiedCommandPrefix(position) {
     .some((word) => word.value.includes("/") && word.value.split("/").at(-1) === "command");
 }
 
+function hasCommandQueryPrefix(position) {
+  let commandPrefix = false;
+  for (const word of position.words.slice(position.prefixAssignments, position.index)) {
+    if (word.value === "command") {
+      commandPrefix = true;
+      continue;
+    }
+    if (commandPrefix && /^-[^-]*[vV]/.test(word.value)) return true;
+  }
+  return false;
+}
+
 function decision(command) {
   const lexed = new Lexer(command).tokenize();
   // Fail open on syntax this classifier cannot tokenize. The cd-guard's threat
@@ -72,6 +84,7 @@ function decision(command) {
     // leading assignments and wrappers to find the executed command word.
     const position = commandPosition(nodes[index]);
     if (hasPathQualifiedCommandPrefix(position)) continue;
+    if (hasCommandQueryPrefix(position)) continue;
     let command = position.command;
     let wordIndex = position.index;
     while (command && (command.value === "builtin" || command.value === "command")) {

--- a/bin/fm-cd-command-policy.mjs
+++ b/bin/fm-cd-command-policy.mjs
@@ -50,6 +50,12 @@ function deny(code) {
   return { decision: "deny", code, reason: REASONS[code] };
 }
 
+function hasPathQualifiedCommandPrefix(position) {
+  return position.words
+    .slice(position.prefixAssignments, position.index)
+    .some((word) => word.value.includes("/") && word.value.split("/").at(-1) === "command");
+}
+
 function decision(command) {
   const lexed = new Lexer(command).tokenize();
   // Fail open on syntax this classifier cannot tokenize. The cd-guard's threat
@@ -65,6 +71,7 @@ function decision(command) {
     // substitutions (they contribute no top-level command word), and skips
     // leading assignments and wrappers to find the executed command word.
     const position = commandPosition(nodes[index]);
+    if (hasPathQualifiedCommandPrefix(position)) continue;
     let command = position.command;
     let wordIndex = position.index;
     while (command && (command.value === "builtin" || command.value === "command")) {

--- a/bin/fm-cd-command-policy.mjs
+++ b/bin/fm-cd-command-policy.mjs
@@ -21,7 +21,7 @@ import { fileURLToPath } from "node:url";
 
 const REASONS = {
   "persistent-cd":
-    "a persistent top-level directory change in the primary firstmate checkout is blocked; it would move the shell out of the home so a later firstmate-owned command runs inside a project clone. Address the target by absolute path or git -C <dir>, or scope the change to a subshell like (cd <dir> && ...).",
+    "a persistent top-level directory change in the primary firstmate checkout is blocked; it would move the shell out of the home so a later firstmate-owned command runs inside a project clone. Address files or repositories directly, for example with an absolute-path operand or git -C <dir>, or scope the change to a subshell like (cd <dir> && ...).",
 };
 
 // Directory-changing builtins that mutate the calling shell's own cwd.

--- a/bin/fm-cd-pretool-check.sh
+++ b/bin/fm-cd-pretool-check.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# Stable PreToolUse transport for the cd-guard command policy.
+#
+# A stray persistent top-level `cd projects/<clone>` in the PRIMARY firstmate
+# shell silently relocates the shell, so a later firstmate-owned command (a
+# backlog write, an fm-* lifecycle call, tasks-axi) runs inside a project clone
+# instead of the home. This seatbelt denies such a command before it runs.
+# bin/fm-cd-command-policy.mjs is the sole owner of the block/allow decision; it
+# reuses the shell classifier owned by bin/fm-arm-command-policy.mjs. This
+# wrapper only scopes the guard to the real primary checkout, acquires the
+# harness payload, invokes that policy, and renders the established harness
+# responses. It never executes, sources, evaluates, or expands the command.
+# See docs/cd-guard.md for the complete contract and validation record.
+#
+# Usage:
+#   <PreToolUse JSON on stdin> | bin/fm-cd-pretool-check.sh
+#   bin/fm-cd-pretool-check.sh --command '<cmd>'
+#
+# Stdin mode extracts .toolInput.command for Grok or .tool_input.command for
+# Claude and Codex. CLI mode is used by OpenCode and Pi after their adapters
+# extract the exact command string.
+#
+# Exit/output contract (identical shape to bin/fm-arm-pretool-check.sh):
+#   ALLOW - exit 0 and no output.
+#   DENY - exit 2, a Claude-shaped deny object on stderr, and a Grok-shaped
+#          deny object on stdout unless --claude was supplied.
+#   INERT - not the real primary checkout (a crewmate/scout task worktree or a
+#           non-firstmate repo): exit 0 with no output, exactly like ALLOW.
+#   FAIL OPEN - malformed or empty stdin, missing jq for stdin transport,
+#               missing Node or policy owner, or an invalid policy response.
+#
+# Claude requires stdout to remain empty on deny.
+# Codex blocks on exit 2 and displays stderr.
+# Grok consumes the stdout decision object.
+# OpenCode and Pi consume exit 2 plus stderr.
+set -u
+
+CMD=""
+CMD_SET=0
+CLAUDE_MODE=0
+
+usage() {
+  cat <<'EOF'
+Usage: fm-cd-pretool-check.sh [--command <cmd>] [--claude]
+
+With no --command, reads a PreToolUse-style JSON payload on stdin (Grok
+toolInput.command, or Claude/Codex tool_input.command).
+Fires only in the real primary firstmate checkout; it is a silent no-op in a
+crewmate/scout task worktree or any non-firstmate repo.
+Exits 0 to allow and 2 to deny a persistent top-level cwd change.
+The deny reason is written to stderr, with a Grok decision object on stdout
+unless --claude is supplied.
+Malformed transport and an unavailable classifier runtime fail open.
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --command)
+      [ "$#" -gt 1 ] || { echo "error: --command requires a value" >&2; exit 2; }
+      CMD=$2
+      CMD_SET=1
+      shift 2
+      ;;
+    --command=*)
+      CMD=${1#--command=}
+      CMD_SET=1
+      shift
+      ;;
+    --claude)
+      CLAUDE_MODE=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ "$CMD_SET" -eq 0 ]; then
+  PAYLOAD=$(cat 2>/dev/null || true)
+  [ -n "$PAYLOAD" ] || exit 0
+  command -v jq >/dev/null 2>&1 || exit 0
+  CMD=$(printf '%s' "$PAYLOAD" | jq -r '(.toolInput.command // .tool_input.command // empty)' 2>/dev/null) || exit 0
+fi
+
+[ -n "$CMD" ] || exit 0
+
+# Strict-superset prefilter (transport only; owns zero classification
+# semantics). Every persistent cd/pushd/popd command carries one of those
+# literal substrings, so a command that carries none of them can never be a
+# deniable cwd change and is fast-allowed without the Node policy owner or the
+# git scoping calls. A quoting-decoder marker - a $ immediately followed by a
+# single quote (ANSI-C $'...') or a double quote (bash locale $"...") - delegates
+# too, because the classifier decodes those and can reconstruct cd from bytes
+# this substring test cannot see. This marker set is COUPLED to the classifier's
+# decoder set in bin/fm-arm-command-policy.mjs: adding any new quote/expansion
+# form the classifier decodes REQUIRES extending it here in the same change, or
+# the prefilter stops being a strict superset. Deliberate deeper obfuscation is
+# out of scope by the same agent-mistake threat model the policy uses.
+case "$CMD" in
+  *"\$'"*|*'$"'*) ;;
+  *cd*|*pushd*|*popd*) ;;
+  *) exit 0 ;;
+esac
+
+SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" 2>/dev/null && pwd -P) || exit 0
+FM_ROOT=${FM_ROOT_OVERRIDE:-$(CDPATH='' cd -- "$SCRIPT_DIR/.." 2>/dev/null && pwd -P)} || exit 0
+
+# Scope to the ACTUAL primary firstmate checkout. This reuses the turn-end
+# guard's primary detection (docs/turnend-guard.md): a plain, non-worktree
+# checkout has git-dir equal to git-common-dir, while a crewmate/scout task
+# worktree - the shape bin/fm-spawn.sh always hands out - is a linked git
+# worktree where the two differ. Unlike the turn-end guard, the cd-guard does
+# NOT exclude secondmate homes (the .fm-secondmate-home marker): a secondmate's
+# OWN primary session is a primary and must be guarded too; only its child
+# crew/scout worktrees are exempt, and they are exempt here by the same
+# linked-worktree test. Any failure to confirm the primary is inert (exit 0),
+# never a block, so a broken environment never denies a shell command.
+[ -f "$FM_ROOT/AGENTS.md" ] || exit 0
+[ -d "$FM_ROOT/bin" ] || exit 0
+command -v git >/dev/null 2>&1 || exit 0
+GIT_DIR=$(git -C "$FM_ROOT" rev-parse --git-dir 2>/dev/null) || exit 0
+GIT_COMMON_DIR=$(git -C "$FM_ROOT" rev-parse --git-common-dir 2>/dev/null) || exit 0
+[ "$GIT_DIR" = "$GIT_COMMON_DIR" ] || exit 0
+
+POLICY="$FM_ROOT/bin/fm-cd-command-policy.mjs"
+command -v node >/dev/null 2>&1 || exit 0
+[ -f "$POLICY" ] || exit 0
+
+POLICY_OUTPUT=$(node "$POLICY" --command "$CMD" 2>/dev/null) || exit 0
+[ -n "$POLICY_OUTPUT" ] || exit 0
+
+TAB=$(printf '\t')
+DECISION=${POLICY_OUTPUT%%"$TAB"*}
+[ "$DECISION" = "deny" ] || exit 0
+REST=${POLICY_OUTPUT#*"$TAB"}
+[ "$REST" != "$POLICY_OUTPUT" ] || exit 0
+CODE=${REST%%"$TAB"*}
+REASON=${REST#*"$TAB"}
+[ -n "$CODE" ] && [ -n "$REASON" ] && [ "$REASON" != "$REST" ] || exit 0
+
+json_escape() {
+  printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' | tr '\n' ' '
+}
+
+DETAIL="[$CODE] $REASON"
+ESCAPED=$(json_escape "$DETAIL")
+printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"},"systemMessage":"%s"}\n' "$ESCAPED" >&2
+[ "$CLAUDE_MODE" -eq 1 ] || printf '{"decision":"deny","reason":"%s"}\n' "$ESCAPED"
+exit 2

--- a/bin/fm-cd-pretool-check.sh
+++ b/bin/fm-cd-pretool-check.sh
@@ -93,10 +93,10 @@ fi
 [ -n "$CMD" ] || exit 0
 
 # Strict-superset prefilter (transport only; owns zero classification
-# semantics). Every persistent cd/pushd/popd command carries one of those
-# literal substrings, so a command that carries none of them can never be a
-# deniable cwd change and is fast-allowed without the Node policy owner or the
-# git scoping calls. A quoting-decoder marker - a $ immediately followed by a
+# semantics). Strip syntax bytes that the classifier joins within a shell word
+# before looking for cd/pushd/popd, so ordinary quoted or escaped fragments
+# cannot hide a deniable cwd change from the policy owner. A quoting-decoder
+# marker - a $ immediately followed by a
 # single quote (ANSI-C $'...') or a double quote (bash locale $"...") - delegates
 # too, because the classifier decodes those and can reconstruct cd from bytes
 # this substring test cannot see. This marker set is COUPLED to the classifier's
@@ -104,10 +104,20 @@ fi
 # form the classifier decodes REQUIRES extending it here in the same change, or
 # the prefilter stops being a strict superset. Deliberate deeper obfuscation is
 # out of scope by the same agent-mistake threat model the policy uses.
+PREFILTER=$CMD
+PREFILTER=${PREFILTER//\\/}
+PREFILTER=${PREFILTER//\"/}
+PREFILTER=${PREFILTER//\'/}
+PREFILTER=${PREFILTER//$'\n'/}
+PREFILTER=${PREFILTER//$'\r'/}
 case "$CMD" in
   *"\$'"*|*'$"'*) ;;
-  *cd*|*pushd*|*popd*) ;;
-  *) exit 0 ;;
+  *)
+    case "$PREFILTER" in
+      *cd*|*pushd*|*popd*) ;;
+      *) exit 0 ;;
+    esac
+    ;;
 esac
 
 SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" 2>/dev/null && pwd -P) || exit 0

--- a/docs/arm-pretool-check.md
+++ b/docs/arm-pretool-check.md
@@ -4,6 +4,7 @@ This document is the authoritative human-readable contract for the watcher arm P
 `bin/fm-arm-command-policy.mjs` is the single semantic owner.
 `bin/fm-arm-pretool-check.sh` is only the stable harness transport and output renderer.
 The tracked harness adapters forward command text without classifying it.
+`bin/fm-arm-command-policy.mjs` is also the sole owner of firstmate's shell classification: it exports the tokenizer and command-position analysis, which the sibling cd-guard seatbelt (`bin/fm-cd-pretool-check.sh`, `docs/cd-guard.md`) reuses instead of duplicating shell lexing.
 
 ## Purpose and boundary
 

--- a/docs/cd-guard.md
+++ b/docs/cd-guard.md
@@ -38,13 +38,14 @@ Only a secondmate's child crew and scout worktrees are exempt, and they are exem
 The discriminator is persistence to the parent shell's cwd, not the mere presence of the token `cd`.
 
 The guard **blocks** a `cd`, `pushd`, or `popd` builtin that runs in an executed top-level position in the parent shell, because such a command persistently changes the primary shell's own working directory.
-This covers a bare `cd projects/foo`, `cd ..`, `cd`, `cd -`, an absolute `cd /some/path` (still a persistent relocation of the parent shell), `pushd <dir>`, `popd`, a leading-assignment form such as `X=1 cd foo`, and any list form where the builtin runs in the parent shell (`cd x && cmd`, `cmd; cd x`, `cmd || cd x`, `command cd x`, `cd x >/dev/null`, and newline-separated lists).
+This covers a bare `cd projects/foo`, `cd ..`, `cd`, `cd -`, an absolute `cd /some/path` (still a persistent relocation of the parent shell), `pushd <dir>`, `popd`, a leading-assignment form such as `X=1 cd foo`, quoted or escaped command-word fragments that cook to a bare builtin, and any list form where the builtin runs in the parent shell (`cd x && cmd`, `cmd; cd x`, `cmd || cd x`, `command cd x`, `builtin cd x`, `command builtin cd x`, `cd x >/dev/null`, and newline-separated lists).
 
 The guard **allows** everything else, including these safe scoped forms that must never be blocked:
 
 - A command that only addresses a target by path without changing the shell's own cwd: `git -C <dir> ...`, `make -C <dir> ...`, any command reading or writing an absolute path.
 - A directory change that does not persist to the parent shell: a subshell `(cd x && ...)`, a `bash -c 'cd ...'` / `sh -c` / `zsh -c` payload, an `env -C <dir> ...`, a `find ... -execdir` runner, a pipeline stage (`cd x | cmd`), or a backgrounded `cd x &`.
 - A `cd` behind a forking or exec'ing wrapper (`env`, `sudo`, `nohup`, `timeout`, `gtimeout`, `exec`), which runs in a child and never persists (and generally just fails, since `cd` is a builtin with no external program).
+- A path-qualified external command named `cd` or `builtin`, such as `./cd`, `/tmp/cd`, `/usr/bin/cd`, or `./builtin`, because it runs as a child process and cannot change the parent shell's cwd.
 - The token `cd` appearing as data: quoted text (`echo "cd projects/foo"`), a comment, a substring of another word (`cdk`, `abcd`, `record`), a `printf` payload, or any later argument word.
 
 An absolute-path `cd` is blocked on purpose: the ALLOW carve-out for absolute paths is for commands that address a target by absolute path, not for `cd`, which relocates the shell itself regardless of whether its argument is relative or absolute.
@@ -79,7 +80,7 @@ The reason text names the safe alternatives (absolute path, `git -C <dir>`, or a
 - `--claude` to preserve Claude's stderr-only deny requirement.
 
 Processing order is cheapest-first: a strict-superset prefilter, then the primary-checkout scope, then the Node policy owner.
-The prefilter fast-allows any command that carries no `cd`, `pushd`, or `popd` substring and no quoting-decoder marker (`$'` ANSI-C or `$"` locale), so most commands never pay for the git scoping calls or the Node process.
+The prefilter removes ordinary single quotes, double quotes, backslashes, carriage returns, and newlines before fast-allowing any command that carries no `cd`, `pushd`, or `popd` substring and no quoting-decoder marker (`$'` ANSI-C or `$"` locale), so quoted or escaped command-word fragments delegate to the policy while most commands never pay for the git scoping calls or the Node process.
 The quoting-decoder marker set is coupled to the classifier's decoder set in `bin/fm-arm-command-policy.mjs`: adding any new quote or expansion form the classifier decodes requires extending the prefilter marker set in the same change, or it stops being a strict superset.
 
 Empty stdin, unparseable JSON, missing `jq` on the stdin path, missing Node, a missing policy owner, or an invalid policy response all fail open with exit 0 and no output.

--- a/docs/cd-guard.md
+++ b/docs/cd-guard.md
@@ -69,16 +69,19 @@ Every deny carries one stable code in square brackets before its prose reason.
 | --- | --- |
 | `persistent-cd` | A top-level `cd`/`pushd`/`popd` would persistently change the primary shell's own working directory. |
 
-The reason text names the safe alternatives (absolute path, `git -C <dir>`, or a subshell) so the block is self-documenting at the point of use.
+In the reason text, "Address the target by absolute path" means invoking the intended command with an absolute target argument, such as `touch /home/state/file` or `git -C /home/project status`.
+It never means `cd /home/project`, because an absolute-path `cd` remains a persistent directory change and is denied.
+The other safe alternative is to scope the directory change to a subshell.
 
 ## Transport and fail-open behavior
 
-`bin/fm-cd-pretool-check.sh` supports the same entry forms as the watcher-arm transport:
+`bin/fm-cd-pretool-check.sh` supports all five harness entry shapes used by the tracked adapters:
 
-- Stdin JSON at `.tool_input.command` for Claude and Codex.
-- Stdin JSON at `.toolInput.command` for Grok.
-- `--command <exact string>` for OpenCode and Pi.
-- `--claude` to preserve Claude's stderr-only deny requirement.
+- Claude sends stdin JSON at `.tool_input.command` and adds `--claude` to preserve Claude's stderr-only deny requirement.
+- Codex sends stdin JSON at `.tool_input.command` without `--claude`.
+- Grok sends stdin JSON at `.toolInput.command`.
+- OpenCode sends the exact command string through `--command <exact string>`.
+- Pi sends the exact command string through `--command <exact string>`.
 
 Processing order is cheapest-first: a strict-superset prefilter, then the primary-checkout scope, then the Node policy owner.
 The prefilter removes ordinary single quotes, double quotes, backslashes, carriage returns, and newlines before fast-allowing any command that carries no `cd`, `pushd`, or `popd` substring and no quoting-decoder marker (`$'` ANSI-C or `$"` locale), so quoted or escaped command-word fragments delegate to the policy while most commands never pay for the git scoping calls or the Node process.

--- a/docs/cd-guard.md
+++ b/docs/cd-guard.md
@@ -45,7 +45,7 @@ The guard **allows** everything else, including these safe scoped forms that mus
 - A command that only addresses a target by path without changing the shell's own cwd: `git -C <dir> ...`, `make -C <dir> ...`, any command reading or writing an absolute path.
 - A directory change that does not persist to the parent shell: a subshell `(cd x && ...)`, a `bash -c 'cd ...'` / `sh -c` / `zsh -c` payload, an `env -C <dir> ...`, a `find ... -execdir` runner, a pipeline stage (`cd x | cmd`), or a backgrounded `cd x &`.
 - A `cd` behind a forking or exec'ing wrapper (`env`, `sudo`, `nohup`, `timeout`, `gtimeout`, `exec`), which runs in a child and never persists (and generally just fails, since `cd` is a builtin with no external program).
-- A path-qualified external command named `cd` or `builtin`, such as `./cd`, `/tmp/cd`, `/usr/bin/cd`, or `./builtin`, because it runs as a child process and cannot change the parent shell's cwd.
+- A path-qualified external command named `cd`, `command`, or `builtin`, such as `./cd`, `/usr/bin/cd`, `./command`, `/usr/bin/command`, or `./builtin`, because it runs as a child process and cannot change the parent shell's cwd.
 - The token `cd` appearing as data: quoted text (`echo "cd projects/foo"`), a comment, a substring of another word (`cdk`, `abcd`, `record`), a `printf` payload, or any later argument word.
 
 An absolute-path `cd` is blocked on purpose: the ALLOW carve-out for absolute paths is for commands that address a target by absolute path, not for `cd`, which relocates the shell itself regardless of whether its argument is relative or absolute.
@@ -100,7 +100,8 @@ Identical in shape to `docs/arm-pretool-check.md`:
 
 ## Shared classifier ownership
 
-`bin/fm-cd-command-policy.mjs` imports the shell tokenizer and command-position analysis (`Lexer`, `splitProgram`, `commandPosition`, `basename`) from `bin/fm-arm-command-policy.mjs`, the sole owner of firstmate's shell classification.
+`bin/fm-cd-command-policy.mjs` imports the shell tokenizer and command-position analysis (`Lexer`, `splitProgram`, `commandPosition`) from `bin/fm-arm-command-policy.mjs`, the sole owner of firstmate's shell classification.
+`basename` remains a private helper of the shared arm classifier because the cd policy identifies shell builtins by exact cooked-word identity.
 The cd-guard never duplicates shell lexing; it adds only the cd-specific decision on top of that shared classifier.
 `bin/fm-arm-command-policy.mjs` runs its own CLI entry point only when invoked directly, never on import, so the two policies stay independent CLIs over one parser.
 

--- a/docs/cd-guard.md
+++ b/docs/cd-guard.md
@@ -38,7 +38,7 @@ Only a secondmate's child crew and scout worktrees are exempt, and they are exem
 The discriminator is persistence to the parent shell's cwd, not the mere presence of the token `cd`.
 
 The guard **blocks** a `cd`, `pushd`, or `popd` builtin that runs in an executed top-level position in the parent shell, because such a command persistently changes the primary shell's own working directory.
-This covers a bare `cd projects/foo`, `cd ..`, `cd`, `cd -`, an absolute `cd /some/path` (still a persistent relocation of the parent shell), `pushd <dir>`, `popd`, a leading-assignment form such as `X=1 cd foo`, quoted or escaped command-word fragments that cook to a bare builtin, and any list form where the builtin runs in the parent shell (`cd x && cmd`, `cmd; cd x`, `cmd || cd x`, `command cd x`, `builtin cd x`, `command builtin cd x`, `cd x >/dev/null`, and newline-separated lists).
+This covers a bare `cd projects/foo`, `cd ..`, `cd`, `cd -`, an absolute `cd /some/path` (still a persistent relocation of the parent shell), `pushd <dir>`, `popd`, a leading-assignment form such as `X=1 cd foo`, quoted or escaped command-word fragments that cook to a bare builtin, and any list form where the builtin runs in the parent shell (`cd x && cmd`, `cmd; cd x`, `cmd || cd x`, `command cd x`, `command -p cd x`, `command -- cd x`, `builtin cd x`, `command builtin cd x`, `cd x >/dev/null`, and newline-separated lists).
 
 The guard **allows** everything else, including these safe scoped forms that must never be blocked:
 
@@ -46,6 +46,7 @@ The guard **allows** everything else, including these safe scoped forms that mus
 - A directory change that does not persist to the parent shell: a subshell `(cd x && ...)`, a `bash -c 'cd ...'` / `sh -c` / `zsh -c` payload, an `env -C <dir> ...`, a `find ... -execdir` runner, a pipeline stage (`cd x | cmd`), or a backgrounded `cd x &`.
 - A `cd` behind a forking or exec'ing wrapper (`env`, `sudo`, `nohup`, `timeout`, `gtimeout`, `exec`), which runs in a child and never persists (and generally just fails, since `cd` is a builtin with no external program).
 - A path-qualified external command named `cd`, `command`, or `builtin`, such as `./cd`, `/usr/bin/cd`, `./command`, `/usr/bin/command`, or `./builtin`, because it runs as a child process and cannot change the parent shell's cwd.
+- A `command` query such as `command -v cd`, `command -V cd`, or a clustered form such as `command -pv cd`, because it reports command resolution without executing the named builtin.
 - The token `cd` appearing as data: quoted text (`echo "cd projects/foo"`), a comment, a substring of another word (`cdk`, `abcd`, `record`), a `printf` payload, or any later argument word.
 
 An absolute-path `cd` is blocked on purpose: the ALLOW carve-out for absolute paths is for commands that address a target by absolute path, not for `cd`, which relocates the shell itself regardless of whether its argument is relative or absolute.

--- a/docs/cd-guard.md
+++ b/docs/cd-guard.md
@@ -1,0 +1,158 @@
+# cd-guard PreToolUse seatbelt
+
+This document is the authoritative human-readable contract for the cd-guard PreToolUse seatbelt.
+`bin/fm-cd-command-policy.mjs` is the single decision owner.
+`bin/fm-cd-pretool-check.sh` is the stable harness transport, primary-checkout scope, and output renderer.
+The tracked harness adapters forward command text without classifying it.
+
+It is the third member of a family of primary-session guards that share the same cross-harness hook machinery:
+the watcher-arm PreToolUse seatbelt (`bin/fm-arm-pretool-check.sh`, `docs/arm-pretool-check.md`) and the turn-end supervision guard (`bin/fm-turnend-guard.sh`, `docs/turnend-guard.md`).
+
+## Purpose and boundary
+
+The primary firstmate shell persists its working directory across tool calls (AGENTS.md section 2: "The shell working directory persists between commands").
+A stray persistent top-level `cd projects/<clone>` therefore silently relocates the shell, so the next firstmate-owned command - a backlog write, an `fm-*` lifecycle call, `tasks-axi` - runs inside a project clone instead of the home.
+That has actually happened: a persistent top-level `cd` caused a firstmate-owned backlog write to execute inside a project clone rather than the home.
+The seatbelt denies exactly that command shape - a cwd change that persists to the primary shell - before it runs.
+
+This guard is not a general sandbox.
+It classifies shell command positions only; it never evaluates, expands, sources, or runs any byte of the submitted command.
+Its threat model is agent mistakes, the same as the watcher-arm seatbelt: an accidental bare `cd projects/foo`, not a deliberately obfuscated bypass.
+
+## Scope: the real primary checkout only
+
+The guard fires only in the actual primary firstmate checkout.
+It is a silent no-op (exit 0, no output) everywhere else, so it never interferes with a crewmate or scout that legitimately works inside its own project or firstmate task worktree.
+
+`bin/fm-cd-pretool-check.sh` reuses the turn-end guard's primary detection (`docs/turnend-guard.md`).
+A plain, non-worktree checkout has `git rev-parse --git-dir` equal to `git rev-parse --git-common-dir`.
+A crewmate or scout task worktree - the shape `bin/fm-spawn.sh` always hands out - is a linked git worktree where the two differ, so the guard is inert there.
+The checkout must also carry `AGENTS.md` and `bin/`, and any failure to confirm the primary is treated as inert, never as a block.
+
+The one deliberate difference from the turn-end guard: the cd-guard does **not** exclude secondmate homes.
+A secondmate is a firstmate in its own home, so its own primary session is a primary and its firstmate-owned commands must stay in its home too; the guard applies there.
+Only a secondmate's child crew and scout worktrees are exempt, and they are exempt automatically by the same linked-worktree test.
+
+## Block vs allow
+
+The discriminator is persistence to the parent shell's cwd, not the mere presence of the token `cd`.
+
+The guard **blocks** a `cd`, `pushd`, or `popd` builtin that runs in an executed top-level position in the parent shell, because such a command persistently changes the primary shell's own working directory.
+This covers a bare `cd projects/foo`, `cd ..`, `cd`, `cd -`, an absolute `cd /some/path` (still a persistent relocation of the parent shell), `pushd <dir>`, `popd`, a leading-assignment form such as `X=1 cd foo`, and any list form where the builtin runs in the parent shell (`cd x && cmd`, `cmd; cd x`, `cmd || cd x`, `command cd x`, `cd x >/dev/null`, and newline-separated lists).
+
+The guard **allows** everything else, including these safe scoped forms that must never be blocked:
+
+- A command that only addresses a target by path without changing the shell's own cwd: `git -C <dir> ...`, `make -C <dir> ...`, any command reading or writing an absolute path.
+- A directory change that does not persist to the parent shell: a subshell `(cd x && ...)`, a `bash -c 'cd ...'` / `sh -c` / `zsh -c` payload, an `env -C <dir> ...`, a `find ... -execdir` runner, a pipeline stage (`cd x | cmd`), or a backgrounded `cd x &`.
+- A `cd` behind a forking or exec'ing wrapper (`env`, `sudo`, `nohup`, `timeout`, `gtimeout`, `exec`), which runs in a child and never persists (and generally just fails, since `cd` is a builtin with no external program).
+- The token `cd` appearing as data: quoted text (`echo "cd projects/foo"`), a comment, a substring of another word (`cdk`, `abcd`, `record`), a `printf` payload, or any later argument word.
+
+An absolute-path `cd` is blocked on purpose: the ALLOW carve-out for absolute paths is for commands that address a target by absolute path, not for `cd`, which relocates the shell itself regardless of whether its argument is relative or absolute.
+Blocking a top-level `cd` is safe in the strong sense: the guard's steady state is "always at the home", so a return-to-home `cd` is redundant rather than necessary, and the block never causes a wrong-directory write.
+
+### Accepted non-goals
+
+Consistent with the agent-mistake threat model, the guard deliberately does not chase every obfuscated bypass:
+
+- A `cd` reconstructed by a command substitution (`$(echo c)d x`) or hidden inside a brace group (`{ cd x; }`) is not blocked. Brace-group recursion is avoided because this classifier cannot reliably tell a brace group `{ cd; }` from brace expansion `{cd,foo}`, and a false block there is worse than the missed exotic bypass.
+- Malformed or untokenizable syntax fails open (allow). Unlike the watcher-arm seatbelt, which fails closed on unclassifiable protected commands, the cd-guard prioritizes zero false blocks over catching a malformed bypass, because a blocked backlog write is a correctness hazard while a missed exotic `cd` is only the pre-existing status quo.
+
+If a genuinely ambiguous command shape is found that risks a false block, the guard is not extended by guesswork; the ambiguity is escalated and the guard stays precise rather than over-eager.
+
+## Stable reason code
+
+Every deny carries one stable code in square brackets before its prose reason.
+
+| Code | Meaning |
+| --- | --- |
+| `persistent-cd` | A top-level `cd`/`pushd`/`popd` would persistently change the primary shell's own working directory. |
+
+The reason text names the safe alternatives (absolute path, `git -C <dir>`, or a subshell) so the block is self-documenting at the point of use.
+
+## Transport and fail-open behavior
+
+`bin/fm-cd-pretool-check.sh` supports the same entry forms as the watcher-arm transport:
+
+- Stdin JSON at `.tool_input.command` for Claude and Codex.
+- Stdin JSON at `.toolInput.command` for Grok.
+- `--command <exact string>` for OpenCode and Pi.
+- `--claude` to preserve Claude's stderr-only deny requirement.
+
+Processing order is cheapest-first: a strict-superset prefilter, then the primary-checkout scope, then the Node policy owner.
+The prefilter fast-allows any command that carries no `cd`, `pushd`, or `popd` substring and no quoting-decoder marker (`$'` ANSI-C or `$"` locale), so most commands never pay for the git scoping calls or the Node process.
+The quoting-decoder marker set is coupled to the classifier's decoder set in `bin/fm-arm-command-policy.mjs`: adding any new quote or expansion form the classifier decodes requires extending the prefilter marker set in the same change, or it stops being a strict superset.
+
+Empty stdin, unparseable JSON, missing `jq` on the stdin path, missing Node, a missing policy owner, or an invalid policy response all fail open with exit 0 and no output.
+A broken hook must never deny every shell tool call.
+
+## Output contract
+
+Identical in shape to `docs/arm-pretool-check.md`:
+
+- Allow (and inert-outside-primary) returns exit 0 with both streams empty.
+- Deny returns exit 2 and writes `{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"},"systemMessage":"[persistent-cd] reason"}` to stderr.
+- Default deny mode also writes `{"decision":"deny","reason":"[persistent-cd] reason"}` to stdout for Grok.
+- `--claude` suppresses stdout completely because Claude ignores a PreToolUse deny when stdout is nonempty.
+- Codex blocks on exit 2 and displays stderr.
+- OpenCode throws only when the checker exits 2.
+- Pi returns `{block: true}` only when the checker exits 2.
+
+## Shared classifier ownership
+
+`bin/fm-cd-command-policy.mjs` imports the shell tokenizer and command-position analysis (`Lexer`, `splitProgram`, `commandPosition`, `basename`) from `bin/fm-arm-command-policy.mjs`, the sole owner of firstmate's shell classification.
+The cd-guard never duplicates shell lexing; it adds only the cd-specific decision on top of that shared classifier.
+`bin/fm-arm-command-policy.mjs` runs its own CLI entry point only when invoked directly, never on import, so the two policies stay independent CLIs over one parser.
+
+## Harness wiring
+
+| Harness | Entry | Adapter behavior on checker exit 2 |
+| --- | --- | --- |
+| Claude | `.claude/settings.json` PreToolUse Bash hook forwarding stdin with `--claude` | Blocks the tool call; stderr deny object, stdout empty. |
+| Codex | `.codex/hooks.json` PreToolUse hook that anchors from `pwd -P`, verifies the hook-loaded firstmate root, and forwards the payload | Blocks on exit 2 and displays stderr. |
+| Grok | `.grok/hooks/fm-primary-cd-check.json` PreToolUse hook anchored on `${GROK_WORKSPACE_ROOT:-}` | Consumes the stdout `decision=deny` object. |
+| OpenCode | `.opencode/plugins/fm-primary-cd-check.js` `tool.execute.before` | Throws, which surfaces as the failed tool result. |
+| Pi | `.pi/extensions/fm-primary-turnend-guard.ts` `tool_call` handler | Returns `{block: true}`; piggybacks on the already-loaded primary extension so no extra `-e` flag is needed. |
+
+Each harness runs the cd-guard alongside the watcher-arm seatbelt; the two are independent checks, and either deny blocks the command.
+Every shell variable reference in the Grok hook command carries an inline default (`${GROK_WORKSPACE_ROOT:-}`) because Grok expands the raw hook command before `bash -lc` runs it, the same requirement documented in `docs/arm-pretool-check.md`.
+
+## Automated validation
+
+`tests/fm-cd-pretool-check.test.sh` owns the acceptance matrix.
+Every block and allow case runs through Codex-shaped stdin, Claude-shaped stdin, Grok-shaped stdin, OpenCode-shaped CLI, and Pi-shaped CLI entry forms.
+The suite also proves the end-to-end cwd-leak regression (a firstmate-owned backlog write leaking into a project clone, then denied at the exact command), the primary-checkout scoping (fires in a secondmate home, inert in a crewmate/scout linked worktree, inert outside a firstmate checkout, inert outside a git repo), the fail-open transport behavior, the prefilter fast path, the policy CLI output contract, and the per-harness wiring.
+
+Run:
+
+```sh
+bash -n bin/fm-cd-pretool-check.sh
+shellcheck bin/fm-cd-pretool-check.sh tests/fm-cd-pretool-check.test.sh
+node --check bin/fm-cd-command-policy.mjs
+node --check bin/fm-arm-command-policy.mjs
+tests/fm-cd-pretool-check.test.sh
+tests/fm-arm-pretool-check.test.sh
+```
+
+## Live validation record, 2026-07-11
+
+Each harness ran against a scratch primary-shaped firstmate checkout: a plain git repo with `AGENTS.md`, `bin/` holding the real `fm-cd-pretool-check.sh`, `fm-cd-command-policy.mjs`, and `fm-arm-command-policy.mjs` plus a no-op dummy `fm-arm-pretool-check.sh`, a `projects/foo/` stand-in clone, and the tracked harness hook config.
+No live watcher, fleet state, or the captain's real primary checkout was involved.
+Each harness was told to run, as separate tool calls, a top-level `cd projects/foo && touch <abs>/BLOCKED` (must be denied) and a subshell `(cd projects/foo && touch <abs>/ALLOWED)` (must run), with the sentinel files as the observable.
+
+Harness versions and outcomes:
+
+- **Claude Code 2.1.207** - blocked. Claude reported the top-level command "denied by the `PreToolUse` hook (`fm-cd-pretool-check.sh`)", the `BLOCKED` sentinel was absent, and the subshell form was permitted to run. A prior control `touch` proved the harness executed commands.
+- **codex-cli 0.144.0** - blocked. Codex logged `error=Command blocked by PreToolUse hook: {"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"},"systemMessage":"[persistent-cd] a persistent top-level directory change ..."}`, the `BLOCKED` sentinel was absent, and the subshell `ALLOWED` sentinel was created. Both the arm and cd PreToolUse hooks ran per command (two `hook: PreToolUse Completed` lines), confirming Codex re-feeds the payload to each hook in the array.
+- **OpenCode 1.17.18** - blocked. `opencode run` printed `✗ cd projects/foo && touch ... failed` with `Error: {"hookSpecificOutput":...,"permissionDecision":"deny"},"systemMessage":"[persistent-cd] ..."}`, the `BLOCKED` sentinel was absent, and the subshell `ALLOWED` sentinel was created.
+- **Pi 0.80.6** - blocked. The `BLOCKED` sentinel was absent while the subshell `ALLOWED` sentinel was created; that differential (top-level denied, subshell run, in the same session) can only come from the guard.
+- **grok 0.2.93** - inconclusive live run: the Grok Build API returned `402 Payment Required: Grok Build usage balance exhausted`, so the model never issued the probe commands. The grok cd hook (`.grok/hooks/fm-primary-cd-check.json`) is structurally identical to the arm-seatbelt grok hook already live-validated on 2026-07-09 (`docs/arm-pretool-check.md`) - same `${GROK_WORKSPACE_ROOT:-}` anchoring and same PreToolUse deny consumption - and the grok-shaped stdin path (`.toolInput.command` in, `{"decision":"deny"}` out) is covered by `tests/fm-cd-pretool-check.test.sh`. Re-run once the Grok balance is restored to close the live gap.
+
+The launch commands mirrored `docs/arm-pretool-check.md`'s validation:
+
+```sh
+claude -p "$PROMPT" --dangerously-skip-permissions --output-format text
+codex exec --dangerously-bypass-hook-trust --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check "$PROMPT"
+OPENCODE_CONFIG_CONTENT='{"permission":{"*":"allow"}}' opencode run --print-logs --log-level INFO "$PROMPT"
+pi -p -e .pi/extensions/fm-primary-turnend-guard.ts --no-context-files --no-session "$PROMPT"
+grok --trust -p "$PROMPT" --permission-mode bypassPermissions --output-format plain
+```

--- a/docs/cd-guard.md
+++ b/docs/cd-guard.md
@@ -42,7 +42,7 @@ This covers a bare `cd projects/foo`, `cd ..`, `cd`, `cd -`, an absolute `cd /so
 
 The guard **allows** everything else, including these safe scoped forms that must never be blocked:
 
-- A command that only addresses a target by path without changing the shell's own cwd: `git -C <dir> ...`, `make -C <dir> ...`, any command reading or writing an absolute path.
+- A command that reaches a target without changing the shell's own cwd: `git -C <dir> ...`, `make -C <dir> ...`, or an absolute path on the command itself.
 - A directory change that does not persist to the parent shell: a subshell `(cd x && ...)`, a `bash -c 'cd ...'` / `sh -c` / `zsh -c` payload, an `env -C <dir> ...`, a `find ... -execdir` runner, a pipeline stage (`cd x | cmd`), or a backgrounded `cd x &`.
 - A `cd` behind a forking or exec'ing wrapper (`env`, `sudo`, `nohup`, `timeout`, `gtimeout`, `exec`), which runs in a child and never persists (and generally just fails, since `cd` is a builtin with no external program).
 - A path-qualified external command named `cd`, `command`, or `builtin`, such as `./cd`, `/usr/bin/cd`, `./command`, `/usr/bin/command`, or `./builtin`, because it runs as a child process and cannot change the parent shell's cwd.
@@ -69,9 +69,8 @@ Every deny carries one stable code in square brackets before its prose reason.
 | --- | --- |
 | `persistent-cd` | A top-level `cd`/`pushd`/`popd` would persistently change the primary shell's own working directory. |
 
-In the reason text, "Address the target by absolute path" means invoking the intended command with an absolute target argument, such as `touch /home/state/file` or `git -C /home/project status`.
-It never means `cd /home/project`, because an absolute-path `cd` remains a persistent directory change and is denied.
-The other safe alternative is to scope the directory change to a subshell.
+The reason directs the caller to reach the target without moving the shell by using `git -C <dir>`, placing an absolute path on the intended command itself, or scoping the `cd` to a subshell.
+It does not permit `cd /home/project`, because an absolute-path `cd` remains a persistent directory change and is denied.
 
 ## Transport and fail-open behavior
 

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -3,7 +3,7 @@
 This is the authoritative contract for the "no turn ends blind" primary guard referenced from AGENTS.md section 8.
 The shared predicate lives in `bin/fm-turnend-guard.sh`.
 Harness-specific tracked hook files only adapt each verified harness's real turn-end mechanism to that shared predicate.
-A related but separate guard, the pre-arm PreToolUse seatbelt (`bin/fm-arm-pretool-check.sh`, `docs/arm-pretool-check.md`), denies a bad watcher-arm command shape before it runs rather than detecting a blind turn end afterward.
+Two related but separate PreToolUse seatbelts deny a bad command shape before it runs rather than detecting a blind turn end afterward: the watcher-arm seatbelt (`bin/fm-arm-pretool-check.sh`, `docs/arm-pretool-check.md`) and the cd-guard (`bin/fm-cd-pretool-check.sh`, `docs/cd-guard.md`), which reuses this guard's primary-checkout scoping.
 
 ## Gap Closed
 

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -3,7 +3,7 @@
 This is the authoritative contract for the "no turn ends blind" primary guard referenced from AGENTS.md section 8.
 The shared predicate lives in `bin/fm-turnend-guard.sh`.
 Harness-specific tracked hook files only adapt each verified harness's real turn-end mechanism to that shared predicate.
-Two related but separate PreToolUse seatbelts deny a bad command shape before it runs rather than detecting a blind turn end afterward: the watcher-arm seatbelt (`bin/fm-arm-pretool-check.sh`, `docs/arm-pretool-check.md`) and the cd-guard (`bin/fm-cd-pretool-check.sh`, `docs/cd-guard.md`), which reuses this guard's primary-checkout scoping.
+Two related but separate PreToolUse seatbelts deny a bad command shape before it runs rather than detecting a blind turn end afterward: the watcher-arm seatbelt (`bin/fm-arm-pretool-check.sh`, `docs/arm-pretool-check.md`) and the cd-guard (`bin/fm-cd-pretool-check.sh`, `docs/cd-guard.md`), which reuses this guard's linked-worktree exemption but deliberately remains active in secondmate homes.
 
 ## Gap Closed
 

--- a/tests/fm-cd-pretool-check.test.sh
+++ b/tests/fm-cd-pretool-check.test.sh
@@ -1,0 +1,440 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC1091,SC2016
+# Behavior tests for the cd-guard PreToolUse seatbelt (docs/cd-guard.md).
+#
+# bin/fm-cd-command-policy.mjs is the single owner of the block/allow decision;
+# it reuses the shell classifier owned by bin/fm-arm-command-policy.mjs.
+# bin/fm-cd-pretool-check.sh is the stable transport: it scopes the guard to the
+# real primary checkout, then drives all five harness entry forms. This suite
+# proves the decision matrix, the harness-output shaping, the primary-checkout
+# scoping (including the deliberate secondmate-home difference from the turn-end
+# guard), the fail-open transport behavior, the prefilter fast path, the
+# end-to-end cwd-leak regression, and the per-harness wiring. No harness is
+# spawned; live per-harness evidence lives in docs/cd-guard.md.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+fm_git_identity fmtest fmtest@example.invalid
+TMP_ROOT=$(fm_test_tmproot fm-cd-pretool-check)
+
+# A primary-shaped checkout: plain (non-worktree) git repo, AGENTS.md, bin/ with
+# the transport plus both policy files (fm-cd-command-policy.mjs imports the
+# shared classifier from fm-arm-command-policy.mjs). This is what the transport's
+# scoping treats as the real primary firstmate checkout.
+install_cd_scripts() {
+  local dir=$1
+  mkdir -p "$dir/bin"
+  cp "$ROOT/bin/fm-cd-pretool-check.sh" "$dir/bin/fm-cd-pretool-check.sh"
+  cp "$ROOT/bin/fm-cd-command-policy.mjs" "$dir/bin/fm-cd-command-policy.mjs"
+  cp "$ROOT/bin/fm-arm-command-policy.mjs" "$dir/bin/fm-arm-command-policy.mjs"
+  chmod +x "$dir/bin/fm-cd-pretool-check.sh" "$dir/bin/fm-cd-command-policy.mjs"
+}
+
+make_primary_fixture() {
+  local dir=$1
+  git init -q "$dir"
+  git -C "$dir" commit -q --allow-empty -m init
+  : > "$dir/AGENTS.md"
+  install_cd_scripts "$dir"
+  printf '%s\n' "$dir"
+}
+
+# Same shape as primary plus the .fm-secondmate-home marker: a secondmate's own
+# primary session, which the cd-guard DOES guard (unlike the turn-end guard).
+make_secondmate_fixture() {
+  local dir=$1
+  make_primary_fixture "$dir" >/dev/null
+  printf 'sm-cd-1\n' > "$dir/.fm-secondmate-home"
+  printf '%s\n' "$dir"
+}
+
+# A genuine linked git worktree - the shape bin/fm-spawn.sh hands crewmate/scout
+# tasks. git-dir and git-common-dir differ, so the guard must be inert.
+make_child_worktree_fixture() {
+  local base=$1 dir=$2
+  fm_git_worktree "$base" "$dir" fm/cd-guard-test-branch
+  : > "$dir/AGENTS.md"
+  install_cd_scripts "$dir"
+  printf '%s\n' "$dir"
+}
+
+PRIMARY=$(make_primary_fixture "$TMP_ROOT/primary")
+CHECK="$PRIMARY/bin/fm-cd-pretool-check.sh"
+
+# --- full cross-harness acceptance matrix ----------------------------------
+
+MATRIX_IDS=()
+MATRIX_EXPECTED=()
+MATRIX_COMMANDS=()
+
+matrix_case() {
+  MATRIX_IDS+=("$1")
+  MATRIX_EXPECTED+=("$2")
+  MATRIX_COMMANDS+=("$3")
+}
+
+# BLOCK: a persistent top-level cwd change in the parent shell.
+matrix_case B01 deny 'cd projects/foo'
+matrix_case B02 deny 'cd ..'
+matrix_case B03 deny 'cd'
+matrix_case B04 deny 'cd -'
+matrix_case B05 deny 'cd /abs/path'
+matrix_case B06 deny 'pushd projects/foo'
+matrix_case B07 deny 'popd'
+matrix_case B08 deny 'X=1 cd projects/foo'
+matrix_case B09 deny 'cd projects/foo && tasks-axi add x'
+matrix_case B10 deny 'echo before; cd projects/foo'
+matrix_case B11 deny 'true && cd projects/foo'
+matrix_case B12 deny 'tasks-axi done x || cd projects/foo'
+matrix_case B13 deny 'cd "projects/foo"'
+matrix_case B14 deny '"cd" projects/foo'
+matrix_case B15 deny 'sleep 1 & cd projects/foo'
+matrix_case B16 deny 'command cd projects/foo'
+matrix_case B17 deny 'cd projects/foo >/dev/null'
+matrix_case B18 deny $'cd projects/foo\necho done'
+matrix_case B19 deny "\$'\\143d' projects/foo"
+
+# ALLOW: not a persistent top-level cwd change (scoped, data, or non-cd).
+matrix_case A01 allow 'git -C projects/foo status'
+matrix_case A02 allow 'cat /abs/path/file'
+matrix_case A03 allow 'ls projects/foo'
+matrix_case A04 allow 'echo "cd projects/foo"'
+matrix_case A05 allow 'grep cd file'
+matrix_case A06 allow '(cd projects/foo && pwd)'
+matrix_case A07 allow "bash -c 'cd projects/foo'"
+matrix_case A08 allow 'env -C projects/foo make'
+matrix_case A09 allow 'make -C projects/foo build'
+matrix_case A10 allow 'find . -execdir cd {} \;'
+matrix_case A11 allow 'cd projects/foo | cat'
+matrix_case A12 allow 'cat foo | cd bar'
+matrix_case A13 allow 'cd projects/foo &'
+matrix_case A14 allow 'abcd project'
+matrix_case A15 allow 'cdk deploy'
+matrix_case A16 allow 'env cd projects/foo'
+matrix_case A17 allow 'sudo cd projects/foo'
+matrix_case A18 allow 'x=$(cd foo && pwd)'
+matrix_case A19 allow 'dirs'
+matrix_case A20 allow "echo 'pushd x'"
+matrix_case A21 allow 'git checkout main'
+matrix_case A22 allow "sh -c 'cd projects/foo && ls'"
+matrix_case A23 allow "printf '%s\\n' 'cd projects/foo'"
+matrix_case A24 allow 'ls -la'
+
+MATRIX_TMP=$(mktemp -d "${TMPDIR:-/tmp}/fm-cd-policy-matrix.XXXXXX")
+FM_TEST_CLEANUP_DIRS+=("$MATRIX_TMP")
+
+run_matrix_entry() {
+  local id=$1 expected=$2 entry=$3 cmd=$4 payload out_file err_file rc
+  out_file="$MATRIX_TMP/$id-$entry.out"
+  err_file="$MATRIX_TMP/$id-$entry.err"
+
+  case "$entry" in
+    codex)
+      payload=$(jq -cn --arg command "$cmd" '{tool_name:"Bash",tool_input:{command:$command}}')
+      printf '%s' "$payload" | "$CHECK" >"$out_file" 2>"$err_file"
+      rc=$?
+      ;;
+    claude)
+      payload=$(jq -cn --arg command "$cmd" '{tool_name:"Bash",tool_input:{command:$command}}')
+      printf '%s' "$payload" | "$CHECK" --claude >"$out_file" 2>"$err_file"
+      rc=$?
+      ;;
+    grok)
+      payload=$(jq -cn --arg command "$cmd" '{toolName:"run_terminal_command",toolInput:{command:$command}}')
+      printf '%s' "$payload" | "$CHECK" >"$out_file" 2>"$err_file"
+      rc=$?
+      ;;
+    opencode|pi)
+      "$CHECK" --command "$cmd" >"$out_file" 2>"$err_file"
+      rc=$?
+      ;;
+    *)
+      fail "unknown matrix entry form: $entry"
+      ;;
+  esac
+
+  if [ "$expected" = allow ]; then
+    [ "$rc" -eq 0 ] || fail "$id via $entry must allow, got exit $rc: $(cat "$err_file")"
+    [ ! -s "$out_file" ] || fail "$id via $entry allow must leave stdout empty: $(cat "$out_file")"
+    [ ! -s "$err_file" ] || fail "$id via $entry allow must leave stderr empty: $(cat "$err_file")"
+    return
+  fi
+
+  [ "$rc" -eq 2 ] || fail "$id via $entry must deny, got exit $rc"
+  jq -e '.hookSpecificOutput.permissionDecision == "deny" and (.systemMessage | test("\\[persistent-cd\\]"))' "$err_file" >/dev/null 2>&1 \
+    || fail "$id via $entry deny must carry the persistent-cd reason code on stderr: $(cat "$err_file")"
+  if [ "$entry" = claude ]; then
+    [ ! -s "$out_file" ] || fail "$id via claude deny must leave stdout empty: $(cat "$out_file")"
+  elif [ "$entry" = grok ]; then
+    jq -e '.decision == "deny"' "$out_file" >/dev/null 2>&1 \
+      || fail "$id via grok deny must carry decision=deny on stdout: $(cat "$out_file")"
+  fi
+}
+
+test_full_acceptance_matrix() {
+  local i entry
+  for ((i = 0; i < ${#MATRIX_IDS[@]}; i++)); do
+    for entry in codex claude grok opencode pi; do
+      run_matrix_entry "${MATRIX_IDS[$i]}" "${MATRIX_EXPECTED[$i]}" "$entry" "${MATRIX_COMMANDS[$i]}"
+    done
+  done
+  pass "cd-guard acceptance matrix: ${#MATRIX_IDS[@]} cases x 5 harness entry forms, block/allow all correct"
+}
+
+# --- primary-checkout scoping ----------------------------------------------
+
+test_fires_in_secondmate_home() {
+  local dir out rc
+  dir=$(make_secondmate_fixture "$TMP_ROOT/secondmate")
+  out=$("$dir/bin/fm-cd-pretool-check.sh" --claude --command 'cd projects/foo' 2>&1); rc=$?
+  expect_code 2 "$rc" "cd-guard must fire in a secondmate's own primary session (unlike the turn-end guard)"
+  assert_contains "$out" '[persistent-cd]' "secondmate-home block must carry the reason code"
+  pass "cd-guard: fires in a secondmate home (its own primary session is a primary)"
+}
+
+test_inert_in_child_worktree() {
+  local base dir out rc
+  base="$TMP_ROOT/child-base"
+  dir="$TMP_ROOT/child-wt"
+  make_child_worktree_fixture "$base" "$dir" >/dev/null
+  out=$("$dir/bin/fm-cd-pretool-check.sh" --claude --command 'cd projects/foo' 2>&1); rc=$?
+  expect_code 0 "$rc" "cd-guard must be inert in a crewmate/scout linked worktree"
+  [ -z "$out" ] || fail "cd-guard produced output in a child worktree: $out"
+  pass "cd-guard: inert in a crewmate/scout task worktree (linked git worktree)"
+}
+
+test_inert_when_not_firstmate_repo() {
+  local dir out rc
+  dir="$TMP_ROOT/not-firstmate"
+  git init -q "$dir"
+  git -C "$dir" commit -q --allow-empty -m init
+  install_cd_scripts "$dir"   # bin/ present but no AGENTS.md
+  out=$("$dir/bin/fm-cd-pretool-check.sh" --claude --command 'cd projects/foo' 2>&1); rc=$?
+  expect_code 0 "$rc" "cd-guard must be inert without AGENTS.md (not a firstmate checkout)"
+  [ -z "$out" ] || fail "cd-guard produced output outside a firstmate checkout: $out"
+  pass "cd-guard: inert in a non-firstmate repo (no AGENTS.md)"
+}
+
+test_inert_when_not_a_git_repo() {
+  local dir out rc
+  dir="$TMP_ROOT/no-git"
+  mkdir -p "$dir"
+  : > "$dir/AGENTS.md"
+  install_cd_scripts "$dir"   # AGENTS.md + bin/ but no git repo
+  out=$("$dir/bin/fm-cd-pretool-check.sh" --claude --command 'cd projects/foo' 2>&1); rc=$?
+  expect_code 0 "$rc" "cd-guard must be inert when the checkout is not a git repo"
+  [ -z "$out" ] || fail "cd-guard produced output in a non-git dir: $out"
+  pass "cd-guard: inert when not inside a git repo"
+}
+
+# --- end-to-end cwd-leak regression ----------------------------------------
+
+test_e2e_cwd_leak_regression() {
+  local sandbox home home_updated leaked out rc
+  sandbox="$TMP_ROOT/e2e"
+  home="$sandbox/home"
+  mkdir -p "$home/data" "$home/projects/clone/data"
+  printf '## In flight\n' > "$home/data/backlog.md"
+
+  # Without the guard, the persistent primary shell's cwd leaks: a stray
+  # `cd projects/clone` makes the next firstmate-owned backlog write land in the
+  # clone, and the home backlog is never updated.
+  (
+    cd "$home" || fail "cannot enter home"
+    cd projects/clone || fail "cannot enter clone"
+    printf -- '- [x] demo done\n' >> data/backlog.md
+  )
+  home_updated=0
+  grep -q 'demo done' "$home/data/backlog.md" && home_updated=1
+  leaked=0
+  grep -q 'demo done' "$home/projects/clone/data/backlog.md" 2>/dev/null && leaked=1
+  [ "$home_updated" -eq 0 ] || fail "baseline: home backlog was updated, cwd leak did not reproduce"
+  [ "$leaked" -eq 1 ] || fail "baseline: backlog write did not leak into the clone"
+
+  # With the guard, the exact stray command is denied before it can run, so the
+  # real harness never lets cwd leave the home.
+  out=$("$CHECK" --claude --command 'cd projects/clone' 2>&1); rc=$?
+  expect_code 2 "$rc" "guard must deny the stray persistent cd that caused the leak"
+  assert_contains "$out" '[persistent-cd]' "leak-preventing block must carry the reason code"
+  pass "cd-guard: reproduces the cwd leak and denies the exact command that causes it"
+}
+
+# --- fail-open transport behavior ------------------------------------------
+
+test_fail_open_empty_stdin() {
+  local out rc
+  out=$("$CHECK" < /dev/null 2>&1); rc=$?
+  expect_code 0 "$rc" "transport must exit 0 on empty stdin"
+  [ -z "$out" ] || fail "transport produced output on empty stdin: $out"
+  pass "cd-guard: fails open on empty stdin"
+}
+
+test_fail_open_unparseable_json() {
+  local out rc
+  out=$(printf 'not json at all' | "$CHECK" 2>&1); rc=$?
+  expect_code 0 "$rc" "transport must exit 0 on unparseable stdin JSON"
+  [ -z "$out" ] || fail "transport produced output on unparseable JSON: $out"
+  pass "cd-guard: fails open on unparseable stdin JSON"
+}
+
+test_fail_open_missing_node() {
+  local fakebin tool tool_path out rc
+  fakebin=$(fm_fakebin "$TMP_ROOT/nonode")
+  for tool in bash sh git dirname cat printf sed tr jq; do
+    tool_path=$(command -v "$tool") || continue
+    ln -s "$tool_path" "$fakebin/$tool"
+  done
+  # node deliberately absent from this PATH.
+  out=$(PATH="$fakebin" "$CHECK" --command 'cd projects/foo' 2>&1); rc=$?
+  expect_code 0 "$rc" "transport must fail open when node is unavailable"
+  [ -z "$out" ] || fail "transport produced output without node: $out"
+  pass "cd-guard: fails open (never blocks) when node is missing"
+}
+
+test_fail_open_missing_jq_on_stdin() {
+  local fakebin tool tool_path out rc
+  fakebin=$(fm_fakebin "$TMP_ROOT/nojq")
+  for tool in bash sh git dirname cat printf sed tr node; do
+    tool_path=$(command -v "$tool") || continue
+    ln -s "$tool_path" "$fakebin/$tool"
+  done
+  # jq deliberately absent: the stdin transport cannot extract the command.
+  out=$(printf '{"tool_input":{"command":"cd projects/foo"}}' | PATH="$fakebin" "$CHECK" 2>&1); rc=$?
+  expect_code 0 "$rc" "stdin transport must fail open when jq is unavailable"
+  [ -z "$out" ] || fail "transport produced output without jq on the stdin path: $out"
+  pass "cd-guard: fails open on the stdin path when jq is missing"
+}
+
+# --- prefilter fast path ----------------------------------------------------
+
+test_prefilter_skips_node_without_cd_substring() {
+  local dir fakebin marker tool tool_path out rc
+  dir="$TMP_ROOT/prefilter"
+  make_primary_fixture "$dir" >/dev/null
+  fakebin=$(fm_fakebin "$TMP_ROOT/prefilter-fake")
+  marker="$TMP_ROOT/prefilter-node-called"
+  for tool in bash sh git dirname cat printf sed tr jq; do
+    tool_path=$(command -v "$tool") || continue
+    ln -s "$tool_path" "$fakebin/$tool"
+  done
+  cat > "$fakebin/node" <<EOF
+#!/usr/bin/env bash
+: > "$marker"
+exit 0
+EOF
+  chmod +x "$fakebin/node"
+  # No cd/pushd/popd substring: the prefilter must fast-allow before scoping or
+  # the policy runtime is ever consulted.
+  out=$(PATH="$fakebin" "$dir/bin/fm-cd-pretool-check.sh" --command 'git status' 2>&1); rc=$?
+  expect_code 0 "$rc" "prefilter must fast-allow a command with no cd/pushd/popd substring"
+  [ -z "$out" ] || fail "prefilter fast-allow produced output: $out"
+  [ ! -e "$marker" ] || fail "prefilter fast-allow still invoked the node policy owner"
+  pass "cd-guard: prefilter fast-allows (skips node) when no cd/pushd/popd substring is present"
+}
+
+# --- policy CLI contract ----------------------------------------------------
+
+test_policy_cli_direct() {
+  local policy
+  policy="$ROOT/bin/fm-cd-command-policy.mjs"
+  [ "$(node "$policy" --command 'cd projects/foo' | cut -f1)" = deny ] \
+    || fail "policy CLI must deny a bare top-level cd"
+  [ "$(node "$policy" --command 'git -C projects/foo status')" = allow ] \
+    || fail "policy CLI must allow git -C"
+  [ "$(node "$policy" --command '(cd projects/foo && pwd)')" = allow ] \
+    || fail "policy CLI must allow a subshell-local cd"
+  [ "$(node "$policy")" = allow ] \
+    || fail "policy CLI must allow when no command is supplied"
+  pass "cd-guard: fm-cd-command-policy.mjs CLI honors the deny/allow output contract"
+}
+
+# --- per-harness wiring -----------------------------------------------------
+
+test_claude_wiring() {
+  local settings n
+  settings="$ROOT/.claude/settings.json"
+  [ -f "$settings" ] || fail "tracked .claude/settings.json is missing"
+  n=$(jq -r '[.hooks.PreToolUse[0].hooks[].command | select(contains("fm-cd-pretool-check.sh"))] | length' "$settings")
+  [ "$n" = 1 ] || fail "claude PreToolUse must invoke fm-cd-pretool-check.sh exactly once"
+  jq -e '[.hooks.PreToolUse[0].hooks[].command | select(contains("fm-cd-pretool-check.sh") and contains("--claude") and contains("CLAUDE_PROJECT_DIR"))] | length == 1' "$settings" >/dev/null \
+    || fail "claude cd hook must use CLAUDE_PROJECT_DIR and --claude"
+  jq -e '[.hooks.PreToolUse[0].hooks[].command | select(contains("fm-arm-pretool-check.sh"))] | length == 1' "$settings" >/dev/null \
+    || fail "claude cd hook must not displace the watcher-arm hook"
+  pass ".claude/settings.json: PreToolUse invokes the cd-guard alongside the arm guard"
+}
+
+test_codex_wiring() {
+  local settings command
+  settings="$ROOT/.codex/hooks.json"
+  [ -f "$settings" ] || fail "tracked .codex/hooks.json is missing"
+  command=$(jq -r '[.hooks.PreToolUse[0].hooks[].command | select(contains("fm-cd-pretool-check.sh"))][0] // empty' "$settings")
+  [ -n "$command" ] || fail "codex PreToolUse must invoke fm-cd-pretool-check.sh"
+  assert_contains "$command" 'pwd -P' "codex cd hook must anchor from the hook process working directory"
+  assert_contains "$command" 'fm-cd-pretool-check.sh' "codex cd hook must invoke the cd-guard"
+  jq -e '[.hooks.PreToolUse[0].hooks[].command | select(contains("fm-arm-pretool-check.sh"))] | length == 1' "$settings" >/dev/null \
+    || fail "codex cd hook must not displace the watcher-arm hook"
+  pass ".codex/hooks.json: PreToolUse invokes the cd-guard alongside the arm guard"
+}
+
+test_grok_wiring() {
+  local settings command
+  settings="$ROOT/.grok/hooks/fm-primary-cd-check.json"
+  [ -f "$settings" ] || fail "tracked grok cd hook config is missing"
+  command=$(jq -r '.hooks.PreToolUse[0].hooks[0].command // empty' "$settings")
+  [ -n "$command" ] || fail "grok cd hook command is missing"
+  assert_contains "$command" 'GROK_WORKSPACE_ROOT' "grok cd hook must anchor from GROK_WORKSPACE_ROOT"
+  assert_contains "$command" 'fm-cd-pretool-check.sh' "grok cd hook must invoke the cd-guard"
+  assert_contains "$command" '${GROK_WORKSPACE_ROOT:-}' "grok cd hook must default-guard the workspace var"
+  pass ".grok primary cd hook: PreToolUse invokes the cd-guard"
+}
+
+test_opencode_wiring() {
+  local plugin content
+  plugin="$ROOT/.opencode/plugins/fm-primary-cd-check.js"
+  [ -f "$plugin" ] || fail "tracked OpenCode cd plugin is missing"
+  content=$(cat "$plugin")
+  assert_contains "$content" 'tool.execute.before' "OpenCode cd plugin must run before tool execution"
+  assert_contains "$content" 'fm-cd-pretool-check.sh' "OpenCode cd plugin must invoke the cd-guard"
+  assert_contains "$content" 'throw new Error' "OpenCode cd plugin must block by throwing"
+  assert_contains "$content" 'worktree' "OpenCode cd plugin must anchor from the git worktree path"
+  pass ".opencode cd plugin: tool.execute.before invokes the cd-guard and blocks by throwing"
+}
+
+test_pi_wiring() {
+  local ext content
+  ext="$ROOT/.pi/extensions/fm-primary-turnend-guard.ts"
+  [ -f "$ext" ] || fail "tracked pi primary extension is missing"
+  content=$(cat "$ext")
+  assert_contains "$content" 'runCdCheck(command)' "pi extension must run the cd check in tool_call"
+  assert_contains "$content" 'fm-cd-pretool-check.sh' "pi extension must invoke the cd-guard owner"
+  assert_contains "$content" 'runPretoolCheck(command)' "pi extension must keep running the watcher-arm check"
+  assert_contains "$content" 'return { block: true, reason:' "pi extension must block on a checker exit 2"
+  pass ".pi primary extension: tool_call runs the cd-guard alongside the watcher-arm check"
+}
+
+test_scripts_are_shellcheck_clean() {
+  shellcheck "$ROOT/bin/fm-cd-pretool-check.sh" >/dev/null 2>&1 \
+    || fail "bin/fm-cd-pretool-check.sh is not shellcheck-clean"
+  pass "bin/fm-cd-pretool-check.sh is shellcheck-clean"
+}
+
+test_full_acceptance_matrix
+test_fires_in_secondmate_home
+test_inert_in_child_worktree
+test_inert_when_not_firstmate_repo
+test_inert_when_not_a_git_repo
+test_e2e_cwd_leak_regression
+test_fail_open_empty_stdin
+test_fail_open_unparseable_json
+test_fail_open_missing_node
+test_fail_open_missing_jq_on_stdin
+test_prefilter_skips_node_without_cd_substring
+test_policy_cli_direct
+test_claude_wiring
+test_codex_wiring
+test_grok_wiring
+test_opencode_wiring
+test_pi_wiring
+test_scripts_are_shellcheck_clean

--- a/tests/fm-cd-pretool-check.test.sh
+++ b/tests/fm-cd-pretool-check.test.sh
@@ -101,6 +101,8 @@ matrix_case B22 deny 'c\d projects/foo'
 matrix_case B23 deny 'builtin cd projects/foo'
 matrix_case B24 deny 'command builtin cd projects/foo'
 matrix_case B25 deny 'builtin command cd projects/foo'
+matrix_case B26 deny 'command -p cd projects/foo'
+matrix_case B27 deny 'command -- cd projects/foo'
 
 # ALLOW: not a persistent top-level cwd change (scoped, data, or non-cd).
 matrix_case A01 allow 'git -C projects/foo status'
@@ -135,6 +137,10 @@ matrix_case A29 allow 'c\d\ projects/foo'
 matrix_case A30 allow './command cd projects/foo'
 matrix_case A31 allow '/usr/bin/command cd projects/foo'
 matrix_case A32 allow '/tmp/builtin cd projects/foo'
+matrix_case A33 allow 'command -v cd'
+matrix_case A34 allow 'command -V cd'
+matrix_case A35 allow 'command -pv cd'
+matrix_case A36 allow 'command -vp cd'
 
 MATRIX_TMP=$(mktemp -d "${TMPDIR:-/tmp}/fm-cd-policy-matrix.XXXXXX")
 FM_TEST_CLEANUP_DIRS+=("$MATRIX_TMP")

--- a/tests/fm-cd-pretool-check.test.sh
+++ b/tests/fm-cd-pretool-check.test.sh
@@ -132,6 +132,9 @@ matrix_case A26 allow '/tmp/cd projects/foo'
 matrix_case A27 allow '/usr/bin/cd projects/foo'
 matrix_case A28 allow './builtin cd projects/foo'
 matrix_case A29 allow 'c\d\ projects/foo'
+matrix_case A30 allow './command cd projects/foo'
+matrix_case A31 allow '/usr/bin/command cd projects/foo'
+matrix_case A32 allow '/tmp/builtin cd projects/foo'
 
 MATRIX_TMP=$(mktemp -d "${TMPDIR:-/tmp}/fm-cd-policy-matrix.XXXXXX")
 FM_TEST_CLEANUP_DIRS+=("$MATRIX_TMP")

--- a/tests/fm-cd-pretool-check.test.sh
+++ b/tests/fm-cd-pretool-check.test.sh
@@ -95,6 +95,12 @@ matrix_case B16 deny 'command cd projects/foo'
 matrix_case B17 deny 'cd projects/foo >/dev/null'
 matrix_case B18 deny $'cd projects/foo\necho done'
 matrix_case B19 deny "\$'\\143d' projects/foo"
+matrix_case B20 deny "c'd' projects/foo"
+matrix_case B21 deny 'c"d" projects/foo'
+matrix_case B22 deny 'c\d projects/foo'
+matrix_case B23 deny 'builtin cd projects/foo'
+matrix_case B24 deny 'command builtin cd projects/foo'
+matrix_case B25 deny 'builtin command cd projects/foo'
 
 # ALLOW: not a persistent top-level cwd change (scoped, data, or non-cd).
 matrix_case A01 allow 'git -C projects/foo status'
@@ -121,6 +127,11 @@ matrix_case A21 allow 'git checkout main'
 matrix_case A22 allow "sh -c 'cd projects/foo && ls'"
 matrix_case A23 allow "printf '%s\\n' 'cd projects/foo'"
 matrix_case A24 allow 'ls -la'
+matrix_case A25 allow './cd projects/foo'
+matrix_case A26 allow '/tmp/cd projects/foo'
+matrix_case A27 allow '/usr/bin/cd projects/foo'
+matrix_case A28 allow './builtin cd projects/foo'
+matrix_case A29 allow 'c\d\ projects/foo'
 
 MATRIX_TMP=$(mktemp -d "${TMPDIR:-/tmp}/fm-cd-policy-matrix.XXXXXX")
 FM_TEST_CLEANUP_DIRS+=("$MATRIX_TMP")


### PR DESCRIPTION
## Intent

Add a cd-guard: a shared-owner PreToolUse-equivalent seatbelt that blocks a persistent, top-level, cwd-changing shell command in the ACTUAL primary firstmate checkout, so a stray persistent cd (e.g. cd projects/<clone>) can never leave the primary shell inside a project clone where a later firstmate-owned command (a backlog write, an fm-* lifecycle call, tasks-axi) would then run. It mirrors the existing watcher-arm PreToolUse seatbelt (bin/fm-arm-pretool-check.sh + docs/arm-pretool-check.md) and reuses the turn-end guard scoping (bin/fm-turnend-guard.sh + docs/turnend-guard.md).

Architecture, deliberately one-owner: bin/fm-cd-command-policy.mjs holds the sole block/allow decision and REUSES the shell classifier (Lexer, splitProgram, commandPosition, basename) exported from bin/fm-arm-command-policy.mjs instead of duplicating shell lexing. The edits to bin/fm-arm-command-policy.mjs are intentional and behavior-preserving: add export to those four parser functions, add the two node:url/node:fs imports, and wrap its CLI entry in an invokedDirectly() is-main guard so importing it does not run its CLI. The full existing tests/fm-arm-pretool-check.test.sh (152 checks) still passes. bin/fm-cd-pretool-check.sh is the transport: a strict-superset prefilter (cd/pushd/popd substring plus the $-quote decoder markers coupled to the classifier), then primary-checkout scoping, then the policy, then harness-shaped deny rendering identical to the arm seatbelt.

Block/allow discriminator is PERSISTENCE to the parent shell cwd, not the token cd. Deliberate decisions a diff reader would not infer: (1) a top-level cd to an ABSOLUTE path is blocked on purpose - it still relocates the parent shell; the allow-list absolute-path carve-out is for target-addressing commands (git -C, cat /abs), not for cd itself. (2) command cd is blocked (command is non-forking, cd persists) while env cd / sudo cd / timeout cd / exec cd are allowed (forking/exec wrappers, cd never persists and generally just fails). (3) subshell (cd x && ...), bash -c/sh -c/zsh -c payloads, env -C, make -C, find -execdir, pipeline stages (cd x | y), and backgrounded (cd x &) are all allowed because the cd does not persist to the parent shell. (4) cd appearing as data (echo "cd x", quoted, comment, printf payload, or a substring like cdk/abcd/record) is allowed. (5) malformed/untokenizable syntax FAILS OPEN (allow) - unlike the arm seatbelt which fails closed - because the cd-guard prioritizes zero false blocks over catching obfuscated bypasses; its threat model is agent mistakes. (6) brace-group { cd; } and substitution-obfuscated cd are accepted non-goals, specifically to avoid brace-expansion false positives like echo {cd}.

Scoping: fires ONLY in the real primary checkout (git-dir == git-common-dir, AGENTS.md, bin/). Unlike the turn-end guard it deliberately does NOT exclude secondmate homes: a secondmate is a firstmate in its own home, so its own primary session must be guarded too; only crew/scout child linked worktrees are exempt, automatically, by the linked-worktree test. Any failure to confirm primary is inert (allow), never a block.

Wiring: added to all five verified primary harness PreToolUse-equivalents (claude .claude/settings.json, codex .codex/hooks.json, grok .grok/hooks/fm-primary-cd-check.json, opencode .opencode/plugins/fm-primary-cd-check.js, pi .pi/extensions/fm-primary-turnend-guard.ts) alongside the arm seatbelt; per-harness hooks only call the owner. In the pi extension the cd check intentionally runs BEFORE the arm check so the existing arm test assertions (const result = await runPretoolCheck(command); / if (result.code !== 2) return {};) stay verbatim; a shared runChecker helper backs both.

Verification: tests/fm-cd-pretool-check.test.sh (43-case x 5-harness-entry-form matrix, E2E cwd-leak regression, scoping incl. the secondmate-home difference, fail-open, prefilter fast-path, policy CLI, wiring); shellcheck-clean; docs/cd-guard.md with dated live per-harness evidence (claude/codex/opencode/pi block-and-allow verified end-to-end; grok live run blocked by an external API balance limit, with mechanism parity to the already-validated arm grok hook plus deterministic grok-shaped coverage). This is firstmate tracked material shipped no-mistakes mode. Pre-existing, unrelated env test noise (opencode .js MODULE_TYPELESS on node24; bootstrap fleet-sync timing) is out of scope for this change.

## What Changed

Captain, this branch:

- Adds a primary-checkout cd guard that blocks persistent top-level `cd`, `pushd`, and `popd` commands while allowing non-persistent forms and failing open when safety cannot be confirmed.
- Reuses the existing shell command classifier and wires the guard into the Claude, Codex, Grok, OpenCode, and Pi pre-tool hooks.
- Documents the guard and adds cross-harness coverage for command classification, checkout scoping, fail-open behavior, wiring, and the cwd-leak regression.

## Risk Assessment

✅ Low: Captain, the query-mode correction is precise, preserves the required executing forms, and the full guard remains well-bounded with consistent documentation and coverage.

## Testing

The pre-supplied full baseline was green; both focused regression suites passed at the exact target, and a fresh Codex hook transcript demonstrated the intended block/allow behavior plus the corrected remediation text.

<details>
<summary>Evidence: Codex PreToolUse cd-guard E2E transcript at target commit</summary>

```text
TARGET: daf3dfe11ec289ef913f7e18175c1a845ebbe0aa
SURFACE: tracked .codex/hooks.json PreToolUse command

COMMAND: cd projects/foo
EXIT: 2
STDOUT: {"decision":"deny","reason":"[persistent-cd] a persistent top-level directory change in the primary firstmate checkout is blocked; it would move the shell out of the home so a later firstmate-owned command runs inside a project clone. Address files or repositories directly, for example with an absolute-path operand or git -C <dir>, or scope the change to a subshell like (cd <dir> && ...)."}
STDERR: {"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"},"systemMessage":"[persistent-cd] a persistent top-level directory change in the primary firstmate checkout is blocked; it would move the shell out of the home so a later firstmate-owned command runs inside a project clone. Address files or repositories directly, for example with an absolute-path operand or git -C <dir>, or scope the change to a subshell like (cd <dir> && ...)."}

COMMAND: cd /tmp
EXIT: 2
STDOUT: {"decision":"deny","reason":"[persistent-cd] a persistent top-level directory change in the primary firstmate checkout is blocked; it would move the shell out of the home so a later firstmate-owned command runs inside a project clone. Address files or repositories directly, for example with an absolute-path operand or git -C <dir>, or scope the change to a subshell like (cd <dir> && ...)."}
STDERR: {"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"},"systemMessage":"[persistent-cd] a persistent top-level directory change in the primary firstmate checkout is blocked; it would move the shell out of the home so a later firstmate-owned command runs inside a project clone. Address files or repositories directly, for example with an absolute-path operand or git -C <dir>, or scope the change to a subshell like (cd <dir> && ...)."}

COMMAND: command cd projects/foo
EXIT: 2
STDOUT: {"decision":"deny","reason":"[persistent-cd] a persistent top-level directory change in the primary firstmate checkout is blocked; it would move the shell out of the home so a later firstmate-owned command runs inside a project clone. Address files or repositories directly, for example with an absolute-path operand or git -C <dir>, or scope the change to a subshell like (cd <dir> && ...)."}
STDERR: {"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"},"systemMessage":"[persistent-cd] a persistent top-level directory change in the primary firstmate checkout is blocked; it would move the shell out of the home so a later firstmate-owned command runs inside a project clone. Address files or repositories directly, for example with an absolute-path operand or git -C <dir>, or scope the change to a subshell like (cd <dir> && ...)."}

COMMAND: git -C projects/foo status
EXIT: 0
STDOUT: 
STDERR: 

COMMAND: (cd projects/foo && pwd)
EXIT: 0
STDOUT: 
STDERR: 

COMMAND: cd 'unterminated
EXIT: 0
STDOUT: 
STDERR: 
```
</details>
- Outcome: 🔧 1 issue found → auto-fixed ✅ across 2 runs (41m44s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed (3) ✅</summary>

- 🚨 `bin/fm-cd-pretool-check.sh:107` - The required &#34;strict-superset prefilter&#34; is not a superset of the classifier. The lexer concatenates quoted fragments, so `c&#39;d&#39; projects/foo` and `c&#34;d&#34; projects/foo` become executed `cd` commands, but this prefilter sees neither a literal `cd` nor a `$&#39;`/`$&#34;` marker and allows them without invoking the policy. Captain, confirm whether ordinary quote concatenation should remain an accepted bypass or extend the prefilter to cover every form the classifier decodes.
- 🚨 `bin/fm-cd-command-policy.mjs:69` - Using `basename()` treats path-qualified external commands such as `./cd projects/foo` and `/tmp/cd projects/foo` as the shell builtin. Those child processes cannot change the parent shell cwd, contradicting the required &#34;PERSISTENCE to the parent shell cwd&#34; discriminator and zero-false-block priority. Distinguish literal builtin invocation from path-qualified executables.
- 🚨 `bin/fm-cd-command-policy.mjs:69` - The persistent `builtin cd projects/foo` form bypasses the guard because `commandPosition()` does not recognize the non-forking `builtin` prefix; `command builtin cd ...` is likewise allowed. This contradicts the required guard against top-level persistent cwd changes. Recognize the `builtin` prefix or explicitly confirm it as another non-goal.

🔧 Fix: Captain, fix cd-guard classification and prefilter coverage
2 errors still open:
- 🚨 `bin/fm-cd-command-policy.mjs:67` - `commandPosition()` still recognizes wrappers using `basename()`, so `./command cd projects/foo` is peeled as though `./command` were the non-forking shell builtin. The policy then denies `cd`, although the external process cannot change its parent cwd. This violates the required persistence discriminator and zero-false-block priority. Preserve wrapper token identity and only treat a bare cooked `command` word as non-forking; add an allow case.
- 🚨 `bin/fm-cd-command-policy.mjs:18` - The authoritative architecture requires importing and reusing `Lexer`, `splitProgram`, `commandPosition`, and `basename`, but this import omits `basename`, while `docs/cd-guard.md:103` still claims all four are imported. Captain, reconcile the acceptance criterion and documentation with the exact-word correction, likely by documenting that `basename` remains shared/exported but is intentionally not used for cd builtin identity.

🔧 Fix: Captain, allow path-qualified command wrappers
1 error still open:
- 🚨 `bin/fm-cd-command-policy.mjs:77` - `commandPosition()` consumes `command -v` and `command -V` as wrapper options and returns the following `cd`, after which this loop treats it like executed `command cd`. In Bash, these forms only report command resolution and never execute `cd`, so denying them violates the required persistence discriminator and zero-false-block priority. Detect query mode, including clustered options containing `v` or `V`, while preserving blocks for `command cd` and `command -p cd`; add matrix cases.

🔧 Fix: Captain, allow non-executing command queries
✅ Re-checked - no issues remain.

</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-cd-command-policy.mjs:24` - The denial advises users to &#34;Address the target by absolute path,&#34; but absolute-path cd is intentionally denied. Clarify that files or repositories should be addressed directly, for example with `git -C /absolute/path`, so the suggested remedy cannot be mistaken for `cd /absolute/path`.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- <code>Baseline supplied by the gate: `command -v tmux &gt;/dev/null || { echo &#34;tmux is required for e2e tests&#34; &gt;&amp;2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo &#34;== $t ==&#34;; bash &#34;$t&#34; || rc=1; done; exit &#34;$rc&#34;`</code>
- `bash tests/fm-cd-pretool-check.test.sh`
- `bash tests/fm-arm-pretool-check.test.sh`
- <code>Manual Codex PreToolUse entry verification in a primary-checkout-shaped temporary git checkout: denied `cd projects/foo`, `cd /tmp`, and `command cd projects/foo`; allowed `git -C projects/foo status`, `env cd projects/foo`, `(cd projects/foo &amp;&amp; pwd)`, malformed syntax, and linked-worktree `cd projects/foo`</code>
- <code>`git status --short` after testing to confirm no transient working-tree artifacts remained</code>

🔧 Fix: Captain, clarify cd-guard safe-path remediation
✅ Re-checked - no issues remain.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- <code>Pre-supplied baseline: `command -v tmux &gt;/dev/null || { echo &#34;tmux is required for e2e tests&#34; &gt;&amp;2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo &#34;== $t ==&#34;; bash &#34;$t&#34; || rc=1; done; exit &#34;$rc&#34;`</code>
- `bash tests/fm-cd-pretool-check.test.sh`
- `bash tests/fm-arm-pretool-check.test.sh`
- <code>Executed the tracked `.codex/hooks.json` PreToolUse command from a firstmate-shaped primary checkout at `daf3dfe11ec289ef913f7e18175c1a845ebbe0aa` against persistent relative, persistent absolute, `command cd`, target-addressing, subshell, and malformed commands.</code>
- <code>`git status --short` after evidence cleanup</code>

</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-cd-command-policy.mjs:27` - The executable denial text remains mildly ambiguous: “Address the target by absolute path” could be mistaken for recommending an absolute-path cd, which is denied. Rewording it requires a behavior-authorized follow-up.

🔧 Fix: Clarify cd-guard safe target guidance
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
