### PR TITLE
feat: make bearings concise and accurate

### DIFF
--- a/.agents/skills/bearings/SKILL.md
+++ b/.agents/skills/bearings/SKILL.md
@@ -47,10 +47,14 @@ It never tears down a task, merges a PR, dispatches new work, or mutates any tas
 This skill is the one owner of the `/bearings` chat-response format; the snapshot and classifier own the data that feeds it, and no other file restates this contract.
 Every `/bearings` chat response renders EXACTLY these four sections, in THIS order, and nothing else structural (there is no At Anchor section):
 
-1. **Captain's Call** - ONLY items that need the captain's own action now: a decision to make, a PR to approve or merge, a credential or login to provide, or a blocker only the captain can clear. Empty-state: "Nothing needs your action right now."
-2. **Recently Landed** - work completed since the prior report: merged PRs, completed scouts, and finished local-only merges, across the main fleet and every registered secondmate home. Empty-state: "Nothing has landed since your last report."
-3. **Underway** - live work progressing on its own, one line of current state per direct report. Empty-state: "Nothing is underway."
-4. **Charted Next** - queued or gated work waiting on the fleet or a date, never on the captain. Empty-state: "Nothing is queued."
+1. **Captain's Call** - ONLY items that need the captain's own action now: a decision to make, a PR to approve or merge, a credential or login to provide, or a blocker only the captain can clear.
+   Empty-state: "Nothing needs your action right now."
+2. **Recently Landed** - work completed since the prior report: merged PRs, completed scouts, and finished local-only merges, across the main fleet and every registered secondmate home.
+   Empty-state: "Nothing has landed since your last report."
+3. **Underway** - live work progressing on its own, one line of current state per direct report.
+   Empty-state: "Nothing is underway."
+4. **Charted Next** - queued or gated work waiting on the fleet or a date, never on the captain.
+   Empty-state: "Nothing is queued."
 
 Rules that keep the contract unambiguous:
 

--- a/.agents/skills/bearings/SKILL.md
+++ b/.agents/skills/bearings/SKILL.md
@@ -25,24 +25,39 @@ It never tears down a task, merges a PR, dispatches new work, or mutates any tas
    If the command is unavailable, fall back to `bin/fm-fleet-snapshot.sh --json` and `bin/fm-crew-state.sh <id>`; never infer current state from a raw `tail` of `state/<id>.status`, which is append-only wake-event history whose last line goes stale.
    A queued item under `gates` only becomes "next work" when its blocker is gone and its time/date gate has arrived; until then it stays queued with the reason.
 
-2. **Compose the report with these sections, matching the worked example's structure, tone, and level of detail.**
+2. **Compose the detailed report file around the four-section spine, adding the richer detail the chat leaves out.**
    The gather step is deterministic; your judgment is scoped to the last mile only - ranking the command's facts by what matters right now and writing the scannable prose.
    The exemplar is `data/status-report-2026-07-06.md` in this home's `data/` when present; match its scannability, not a raw state dump.
-   - **Title** - `# Bearings - <day> <YYYY-MM-DD>` (the exemplar used "Morning status" for a morning brief; use that phrasing when the captain specifically asks for a morning brief).
-   - **TL;DR** - two or three sentences framing where things stand.
-   - **Check first** - anything likely waiting on the captain: a PR to merge, a needed credential or login, or anything blocking pickup, each PR with the full `https://...` URL, never a bare `#number`.
-   - **Landed** since the captain last worked - merged PRs, completed scouts, and finished local-only work, drawn from the Done section and recent merges.
-   - **In flight** now - each live direct report with its current state in one line; if nothing is in flight, say so plainly rather than omitting the section.
-   - **Plans / main pickup points** - pointers to the relevant `data/<id>/report.md` files and any Lavish boards (`.lavish/*.html`) the captain should reopen.
-   - **Decisions pending** from the captain - relayed verbatim from needs-decision findings, with options where the crewmate offered them.
-   - **Date-gated / queued** next work - queued items whose blocker is gone and whose gate has arrived, plus anything still blocked with the reason.
+   The report uses the same four sections as the chat (see the chat-response contract below), in the same order, each always present, and adds the detail the chat omits:
+   - **Title** - `# Bearings - <day> <YYYY-MM-DD>` (use "Morning status" only when the captain specifically asks for a morning brief), followed by two or three sentences framing where things stand.
+   - **Captain's Call** - every open decision relayed verbatim with its options, plus each PR ready to merge and each needed credential or login, every PR with the full `https://...` URL, never a bare `#number`.
+   - **Recently Landed** - merged PRs, completed scouts, and finished local-only work since the last report, across the main fleet and every registered secondmate home.
+   - **Underway** - each live direct report making progress, with its current state, and the plans / main pickup pointers worth reopening (`data/<id>/report.md` files, `.lavish/*.html` boards).
+   - **Charted Next** - queued or gated next work, with each item's blocker or date reason.
 
-3. **Write the report to a dated file so it persists, and surface a concise version in chat.**
+3. **Write the dated report file so it persists, then surface the mandatory four-section digest in chat.**
    - Write the full report to `data/status-report-<YYYY-MM-DD>.md` using today's date.
      This is the required artifact; it lives in gitignored `data/` alongside the worked example.
      If today's file already exists, delete it first, then create a new file from scratch.
-   - Surface a concise version to the captain in chat - the TL;DR plus the "Check first" list - and point to the file for the full picture.
-   - For a richer review surface, optionally offer a Lavish board with `lavish-axi` when the report has enough structure to deserve one, but the markdown file is the required artifact and the chat summary is the required minimum.
+   - The chat response is the concise four-section digest defined by the contract below: materially shorter than the report file, and it links to that file for the full picture.
+   - For a richer review surface, optionally offer a Lavish board with `lavish-axi` when the report has enough structure to deserve one, but the markdown file is the required artifact and the four-section chat digest is the required minimum.
+
+## Chat-response contract
+
+This skill is the one owner of the `/bearings` chat-response format; the snapshot and classifier own the data that feeds it, and no other file restates this contract.
+Every `/bearings` chat response renders EXACTLY these four sections, in THIS order, and nothing else structural (there is no At Anchor section):
+
+1. **Captain's Call** - ONLY items that need the captain's own action now: a decision to make, a PR to approve or merge, a credential or login to provide, or a blocker only the captain can clear. Empty-state: "Nothing needs your action right now."
+2. **Recently Landed** - work completed since the prior report: merged PRs, completed scouts, and finished local-only merges, across the main fleet and every registered secondmate home. Empty-state: "Nothing has landed since your last report."
+3. **Underway** - live work progressing on its own, one line of current state per direct report. Empty-state: "Nothing is underway."
+4. **Charted Next** - queued or gated work waiting on the fleet or a date, never on the captain. Empty-state: "Nothing is queued."
+
+Rules that keep the contract unambiguous:
+
+- Every section ALWAYS renders, even when empty, with its short empty-state sentence; never omit a section.
+- The four buckets are mutually exclusive, so every item is forced into exactly one: needs-your-action is Captain's Call, done is Recently Landed, self-progressing is Underway, not-yet-started is Charted Next.
+- The strict boundary keeps action-free items OUT of Captain's Call: a working or validating task, a queued item blocked on another task or a date, landed work, a completed scout's report pointer, a declared `paused:` external wait, and a bare recorded PR with no merge-ready signal each belong to one of the other three sections, never Captain's Call.
+- The chat carries one scannable line per item, each PR as the full `https://...` URL; the verbatim decisions, plans, full gate reasons, and evidence live only in the report file, which the chat links to, so the chat stays materially shorter than that file.
 
 ## Tone and content rules
 
@@ -54,4 +69,4 @@ It never tears down a task, merges a PR, dispatches new work, or mutates any tas
 
 This skill is read-mostly and changes no fleet state.
 Do not tear down a task, merge a PR, dispatch queued work, or mutate any `state/` or `data/` file other than the single report file as a side effect of generating the brief.
-If the state you read suggests an action - a PR ready to merge, a queued item whose gate has arrived, a needs-decision finding - name it in the report under "Check first" or "Date-gated / queued" and let the captain decide, rather than taking the action from inside this skill.
+If the state you read suggests an action - a PR ready to merge, a queued item whose gate has arrived, a needs-decision finding - name it in its section (a captain action under "Captain's Call", queued or gated work under "Charted Next") and let the captain decide, rather than taking the action from inside this skill.

--- a/bin/fm-bearings-snapshot.sh
+++ b/bin/fm-bearings-snapshot.sh
@@ -22,6 +22,12 @@
 # This wrapper consumes the canonical snapshot's hints.open_decisions field.
 # fm-classify-lib.sh owns the durable keyed-decision contract.
 #
+# The landed section merges this home's Done with the canonical snapshot's
+# secondmate_landed roll-up (fm-fleet-snapshot.sh), so merges a secondmate managed -
+# recorded in ITS OWN backlog, never the main one - are visible. It stays bounded by
+# a per-home cap and an overall cap, with omitted[] disclosure of both and of any
+# secondmate home whose backlog was unreadable; no GitHub/network call is involved.
+#
 # Flags:
 #   (default)        compact projection, TOON, local-only
 #   --json           the same projected model as JSON (machine/debug; parity form)
@@ -29,6 +35,7 @@
 #   --fields <list>  opt in to dropped surfaces: bodies,paths,actions,endpoints
 #   --all-in-flight  include every in-flight task
 #   --all-decisions  include every open decision
+#   --all-landed     include every landed record from every home (default: bounded)
 #   --all-reports    include the full scout-report inventory (default: relevant only)
 #   --all-queued     include superseded/held queued items (default: dropped)
 #   --all-recorded-prs include every locally recorded PR
@@ -44,6 +51,7 @@ FLEET="$SCRIPT_DIR/fm-fleet-snapshot.sh"
 
 # Bounds (overridable for tests / large fleets).
 FM_BEARINGS_LANDED=${FM_BEARINGS_LANDED:-6}
+FM_BEARINGS_LANDED_PER_HOME=${FM_BEARINGS_LANDED_PER_HOME:-$FM_BEARINGS_LANDED}
 FM_BEARINGS_IN_FLIGHT=${FM_BEARINGS_IN_FLIGHT:-20}
 FM_BEARINGS_DECISIONS=${FM_BEARINGS_DECISIONS:-20}
 FM_BEARINGS_GATES=${FM_BEARINGS_GATES:-20}
@@ -58,6 +66,7 @@ validate_bound() {  # <name> <value>
   case "$2" in ''|*[!0-9]*|0) echo "fm-bearings-snapshot: $1 must be a positive integer" >&2; exit 2 ;; esac
 }
 validate_bound FM_BEARINGS_LANDED "$FM_BEARINGS_LANDED"
+validate_bound FM_BEARINGS_LANDED_PER_HOME "$FM_BEARINGS_LANDED_PER_HOME"
 validate_bound FM_BEARINGS_IN_FLIGHT "$FM_BEARINGS_IN_FLIGHT"
 validate_bound FM_BEARINGS_DECISIONS "$FM_BEARINGS_DECISIONS"
 validate_bound FM_BEARINGS_GATES "$FM_BEARINGS_GATES"
@@ -70,7 +79,7 @@ validate_bound FM_BEARINGS_PR_LIMIT "$FM_BEARINGS_PR_LIMIT"
 usage() {
   cat <<'EOF'
 usage: fm-bearings-snapshot.sh [--json] [--include-prs] [--fields <list>]
-                               [--all-in-flight] [--all-decisions]
+                               [--all-in-flight] [--all-decisions] [--all-landed]
                                [--all-reports] [--all-queued]
                                [--all-recorded-prs] [--all-unhealthy]
                                [--all-pr-repos]
@@ -82,8 +91,11 @@ Default fields: schema, home, generated, prs, in_flight{id,kind,state,doing},
   decisions_open{id,key,verb,summary}, landed{id,what,artifact},
   gates{id,title,blocked_by,reason}, reports{id,path}, recorded_prs{id,url},
   unhealthy_endpoints{...} (only when non-empty), omitted{surface,reveal}.
+landed merges this home's Done with registered secondmate homes' Done, bounded by
+  a per-home cap (FM_BEARINGS_LANDED_PER_HOME) and an overall cap (FM_BEARINGS_LANDED),
+  with omitted[] disclosure; --all-landed reveals the full set.
 Opt-in surfaces: --fields bodies|paths|actions|endpoints, --all-in-flight,
-  --all-decisions, --all-reports, --all-queued, --all-recorded-prs,
+  --all-decisions, --all-landed, --all-reports, --all-queued, --all-recorded-prs,
   --all-unhealthy, --all-pr-repos, --include-prs (adds candidate_prs).
 Raise FM_BEARINGS_PR_LIMIT to expand per-repository open-PR results.
 EOF
@@ -95,6 +107,7 @@ ALL_REPORTS=0
 ALL_QUEUED=0
 ALL_IN_FLIGHT=0
 ALL_DECISIONS=0
+ALL_LANDED=0
 ALL_RECORDED_PRS=0
 ALL_UNHEALTHY=0
 ALL_PR_REPOS=0
@@ -107,6 +120,7 @@ while [ $# -gt 0 ]; do
     --all-queued) ALL_QUEUED=1 ;;
     --all-in-flight) ALL_IN_FLIGHT=1 ;;
     --all-decisions) ALL_DECISIONS=1 ;;
+    --all-landed) ALL_LANDED=1 ;;
     --all-recorded-prs) ALL_RECORDED_PRS=1 ;;
     --all-unhealthy) ALL_UNHEALTHY=1 ;;
     --all-pr-repos) ALL_PR_REPOS=1 ;;
@@ -229,6 +243,7 @@ MODEL=$(printf '%s' "$SNAP" | jq \
   --arg prs "$PR_STATUS" \
   --arg fields "$FIELDS" \
   --argjson landed_n "$FM_BEARINGS_LANDED" \
+  --argjson landed_per_home_n "$FM_BEARINGS_LANDED_PER_HOME" \
   --argjson in_flight_n "$FM_BEARINGS_IN_FLIGHT" \
   --argjson decisions_n "$FM_BEARINGS_DECISIONS" \
   --argjson gates_n "$FM_BEARINGS_GATES" \
@@ -238,6 +253,7 @@ MODEL=$(printf '%s' "$SNAP" | jq \
   --argjson include_prs "$INCLUDE_PRS" \
   --argjson all_in_flight "$ALL_IN_FLIGHT" \
   --argjson all_decisions "$ALL_DECISIONS" \
+  --argjson all_landed "$ALL_LANDED" \
   --argjson all_reports "$ALL_REPORTS" \
   --argjson all_queued "$ALL_QUEUED" \
   --argjson all_recorded_prs "$ALL_RECORDED_PRS" \
@@ -254,7 +270,16 @@ MODEL=$(printf '%s' "$SNAP" | jq \
   | (($fl | index("paths")) != null) as $f_paths
   | (($fl | index("actions")) != null) as $f_actions
   | (($fl | index("endpoints")) != null) as $f_endpoints
-  | ([ .backlog.records[] | select(.state == "done" and .structured) ][:$landed_n]) as $done
+  | ([ .backlog.records[] | select(.state == "done" and .structured)
+       | {id, title, pr_url, report_path, local_note, completion, home:"(main)", home_id:"(main)"} ]) as $main_done
+  | ((.secondmate_landed.records) // []) as $mate_done
+  | ($main_done + $mate_done) as $all_landed_rows
+  | ([ $all_landed_rows | group_by(.home_id)[]
+       | sort_by([(.completion.date // ""), .id]) | reverse
+       | (if $all_landed == 1 then . else .[:$landed_per_home_n] end) ] | add // []) as $per_home_capped
+  | ([ $all_landed_rows | group_by(.home_id)[] | select(length > $landed_per_home_n) ] | length) as $home_cap_dropped
+  | ($per_home_capped | sort_by([(.completion.date // ""), .id]) | reverse) as $landed_sorted
+  | (if $all_landed == 1 then $landed_sorted else $landed_sorted[:$landed_n] end) as $done
   | ($done | map(.id)) as $done_ids
   | (.tasks | map(.id)) as $live_ids
   | ($live_ids + $done_ids) as $rel_ids
@@ -309,6 +334,10 @@ MODEL=$(printf '%s' "$SNAP" | jq \
         (if $f_endpoints then empty else {surface:"healthy endpoint detail", reveal:"--fields endpoints"} end),
         (if $all_reports == 1 then empty else {surface:"full scout-report inventory", reveal:"--all-reports"} end),
         (if $all_queued == 1 then empty else {surface:"superseded/held queued items", reveal:"--all-queued"} end),
+        (if $all_landed == 0 and ($per_home_capped | length) > ($done | length) then {surface:("landed showing \($done | length) of \($per_home_capped | length)" + (($done | map(.home_id) | unique | map(select(. != "(main)")) | length) as $k | if $k > 0 then " (incl. \($k) secondmate home(s))" else "" end)), reveal:"--all-landed"} else empty end),
+        (if $all_landed == 0 and $home_cap_dropped > 0 then {surface:("landed per-home capped at \($landed_per_home_n) for \($home_cap_dropped) home(s)"), reveal:"--all-landed"} else empty end),
+        (if (($snap.secondmate_landed.unreadable // []) | length) > 0 then {surface:("secondmate home(s) with unreadable backlog: \(($snap.secondmate_landed.unreadable // []) | length)"), reveal:"inspect the listed secondmate home backlogs"} else empty end),
+        (if (($snap.secondmate_landed.truncated // []) | length) > 0 then {surface:("secondmate home Done capped at the snapshot layer for \(($snap.secondmate_landed.truncated // []) | length) home(s)"), reveal:"raise FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME"} else empty end),
         (if $all_in_flight == 0 and ($in_flight_all | length) > $in_flight_n then {surface:("in_flight showing \($in_flight_n) of \($in_flight_all | length)"), reveal:"--all-in-flight"} else empty end),
         (if $all_decisions == 0 and ($decisions_all | length) > $decisions_n then {surface:("decisions_open showing \($decisions_n) of \($decisions_all | length)"), reveal:"--all-decisions"} else empty end),
         (if $all_queued == 0 and ($gates_all | length) > $gates_n then {surface:("gates showing \($gates_n) of \($gates_all | length)"), reveal:"--all-queued"} else empty end),

--- a/bin/fm-bearings-snapshot.sh
+++ b/bin/fm-bearings-snapshot.sh
@@ -134,7 +134,11 @@ done
 
 command -v jq >/dev/null 2>&1 || { echo "fm-bearings-snapshot: jq not found" >&2; exit 1; }
 
-SNAP=$("$FLEET" --json) || exit $?
+if [ "$ALL_LANDED" = 1 ]; then
+  SNAP=$(FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME=0 "$FLEET" --json) || exit $?
+else
+  SNAP=$("$FLEET" --json) || exit $?
+fi
 HOME_LABEL=$(printf '%s' "$SNAP" | jq -er '.fm_home | strings | split("/") | (.[-2:] | join("/"))') \
   || { echo "fm-bearings-snapshot: invalid canonical snapshot" >&2; exit 1; }
 NOW=${FM_BEARINGS_NOW:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}
@@ -337,7 +341,7 @@ MODEL=$(printf '%s' "$SNAP" | jq \
         (if $all_landed == 0 and ($per_home_capped | length) > ($done | length) then {surface:("landed showing \($done | length) of \($per_home_capped | length)" + (($done | map(.home_id) | unique | map(select(. != "(main)")) | length) as $k | if $k > 0 then " (incl. \($k) secondmate home(s))" else "" end)), reveal:"--all-landed"} else empty end),
         (if $all_landed == 0 and $home_cap_dropped > 0 then {surface:("landed per-home capped at \($landed_per_home_n) for \($home_cap_dropped) home(s)"), reveal:"--all-landed"} else empty end),
         (if (($snap.secondmate_landed.unreadable // []) | length) > 0 then {surface:("secondmate home(s) with unreadable backlog: \(($snap.secondmate_landed.unreadable // []) | length)"), reveal:"inspect the listed secondmate home backlogs"} else empty end),
-        (if (($snap.secondmate_landed.truncated // []) | length) > 0 then {surface:("secondmate home Done capped at the snapshot layer for \(($snap.secondmate_landed.truncated // []) | length) home(s)"), reveal:"raise FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME"} else empty end),
+        (if $all_landed == 0 and (($snap.secondmate_landed.truncated // []) | length) > 0 then {surface:("secondmate home Done capped at the snapshot layer for \(($snap.secondmate_landed.truncated // []) | length) home(s)"), reveal:"--all-landed"} else empty end),
         (if $all_in_flight == 0 and ($in_flight_all | length) > $in_flight_n then {surface:("in_flight showing \($in_flight_n) of \($in_flight_all | length)"), reveal:"--all-in-flight"} else empty end),
         (if $all_decisions == 0 and ($decisions_all | length) > $decisions_n then {surface:("decisions_open showing \($decisions_n) of \($decisions_all | length)"), reveal:"--all-decisions"} else empty end),
         (if $all_queued == 0 and ($gates_all | length) > $gates_n then {surface:("gates showing \($gates_n) of \($gates_all | length)"), reveal:"--all-queued"} else empty end),

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -554,8 +554,21 @@ if [ "$KIND" != secondmate ] && crew_pane_is_busy "$BACKEND_TARGET"; then
   emit working pane "harness busy"
 fi
 
+# Fall back to the status log's last line, but ONLY when its verb maps to a real
+# run-state. A decision-closing event - resolved: (fm-classify-lib.sh's
+# FM_CLASSIFY_RESOLVE_VERB), and any future decision-only sibling - is NOT a state:
+# it exists solely to CLOSE a keyed decision in the durable fold, so a trailing
+# resolved: must never become the current state or leak its resolution prose as the
+# detail. Skipping it lets a just-resolved idle crew (typically a secondmate, which
+# has no busy check above) fall through to the idle default instead of rendering
+# `unknown` with the resolution note as `doing`. map_log_state is the single owner of
+# the verb->state mapping (including the configurable paused verb), so reusing its
+# `unknown` verdict as the "not a state" test needs no second verb list here.
 if [ -n "$LOG_VERB" ]; then
-  emit "$(map_log_state "$LOG_LINE")" status-log "$(status_line_note "$LOG_LINE")"
+  LOG_STATE=$(map_log_state "$LOG_LINE")
+  if [ "$LOG_STATE" != unknown ]; then
+    emit "$LOG_STATE" status-log "$(status_line_note "$LOG_LINE")"
+  fi
 fi
 
 emit unknown none "no current-state source available"

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -33,7 +33,9 @@
 #      is flagged superseded. A genuinely parked run plus a needs-decision log
 #      agree, and are reported as parked.
 #   4. No run for this crew (pre-validation, or kind=scout): fall back to the
-#      recorded backend's pane busy state, then the status log's last line.
+#      recorded backend's pane busy state, then the status log's last line only
+#      when its verb maps to a recognized run-state. Decision-only events such as
+#      `resolved` never become current state or detail.
 #   5. Missing meta or torn-down worktree: report unknown · none. If no run is
 #      attributed to this crew, a dead endpoint also reports unknown · none rather
 #      than trusting a stale status log.

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -27,6 +27,12 @@
 #     endpoint.agent_alive is populated for secondmates only, where it is useful
 #     return-channel supervision data; other tasks use "not_checked".
 #   scout_reports[]: present data/<id>/report.md pointers.
+#   secondmate_landed: {records[],truncated[],unreadable[]} - a bounded, read-only
+#     roll-up of DONE backlog records from this home's registered secondmate homes,
+#     so landed-work views see merges a secondmate managed (recorded in ITS OWN
+#     backlog, not the main one). Per-home count is capped; homes with an existing
+#     but unparseable backlog are disclosed in unreadable[]. Home paths come from the
+#     one secondmate-home enumerator (meta home= with data/secondmates.md fallback).
 #   secondmate_guidance: return-channel action note for renderers and bearings.
 #
 # Compatibility: JSON is the primary machine-readable surface.
@@ -48,6 +54,9 @@ BACKLOG="$DATA/backlog.md"
 # shellcheck source=bin/fm-classify-lib.sh
 # shellcheck disable=SC1091
 . "$SCRIPT_DIR/fm-classify-lib.sh"
+# shellcheck source=bin/fm-ff-lib.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/fm-ff-lib.sh"  # live_secondmate_meta_records: the one secondmate-home enumerator
 
 usage() {
   cat <<'EOF'
@@ -139,14 +148,15 @@ first_pr_url_in_file() {  # <file>
   grep -Eo 'https?://[^[:space:])"]+/pull/[0-9]+' "$1" 2>/dev/null | head -1
 }
 
-backlog_json() {
-  if [ ! -f "$BACKLOG" ]; then
-    jq -n --arg path "$BACKLOG" '{path:$path,present:false,records:[]}'
+backlog_json() {  # [<backlog-path>] - defaults to this home's $BACKLOG
+  local backlog=${1:-$BACKLOG}
+  if [ ! -f "$backlog" ]; then
+    jq -n --arg path "$backlog" '{path:$path,present:false,records:[]}'
     return 0
   fi
 
   # shellcheck disable=SC2094
-  jq -Rn --arg path "$BACKLOG" '
+  jq -Rn --arg path "$backlog" '
     def trim: gsub("^[[:space:]]+|[[:space:]]+$"; "");
     def section_state:
       if . == "In flight" then "in_flight"
@@ -257,7 +267,7 @@ backlog_json() {
           .body_excerpt = ((.body_lines | join(" "))[:240])
         else . end)
     | del(.section,.order)
-  ' < "$BACKLOG"
+  ' < "$backlog"
 }
 
 task_json_lines() {
@@ -417,6 +427,47 @@ task_json_lines() {
   done | jq -s 'sort_by(.id)'
 }
 
+# Bounded, deterministic roll-up of DONE records from this home's registered
+# secondmate homes. A merge a secondmate managed is recorded in ITS OWN backlog,
+# never the main one, so landed-work views miss it without this. Reuses the single
+# backlog parser (backlog_json) against each home's data/backlog.md - a pure Markdown
+# read, no per-task crew-state and no network - and the one secondmate-home enumerator
+# (fm-ff-lib.sh's live_secondmate_meta_records: meta home= with data/secondmates.md
+# fallback). Per-home Done is capped here so the canonical snapshot stays bounded
+# regardless of the view; bearings applies its own tighter view caps and omitted[]
+# disclosure. A home with no backlog file yet contributes nothing and is NOT flagged
+# (a fresh secondmate is normal); only an existing backlog that fails to parse is
+# reported unreadable. Records are sorted most-recent-first by completion date, id.
+FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME=${FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME:-10}
+case "$FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME" in ''|*[!0-9]*|0) FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME=10 ;; esac
+secondmate_landed_json() {
+  local reg="$DATA/secondmates.md" id home backlog bj rows n
+  local records='[]' truncated='[]' unreadable='[]'
+  while IFS='|' read -r id home _; do
+    [ -n "$id" ] || continue
+    [ -n "$home" ] || continue
+    backlog="$home/data/backlog.md"
+    [ -f "$backlog" ] || continue
+    bj=$(backlog_json "$backlog") \
+      || { unreadable=$(jq -n --argjson a "$unreadable" --arg h "$home" '$a + [$h]'); continue; }
+    rows=$(printf '%s' "$bj" | jq --arg home "$home" --arg id "$id" '
+      [ .records[] | select(.state == "done" and .structured)
+        | {id, title, pr_url, report_path, local_note, completion, home:$home, home_id:$id} ]
+      | sort_by([(.completion.date // ""), .id]) | reverse') \
+      || { unreadable=$(jq -n --argjson a "$unreadable" --arg h "$home" '$a + [$h]'); continue; }
+    n=$(printf '%s' "$rows" | jq 'length')
+    if [ "$n" -gt "$FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME" ]; then
+      truncated=$(jq -n --argjson a "$truncated" --arg h "$home" '$a + [$h]')
+    fi
+    records=$(jq -n --argjson a "$records" --argjson b "$rows" \
+      --argjson cap "$FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME" '$a + ($b[:$cap])')
+  done <<EOF
+$(live_secondmate_meta_records "$STATE" "$reg")
+EOF
+  jq -n --argjson records "$records" --argjson truncated "$truncated" --argjson unreadable "$unreadable" \
+    '{records:$records, truncated:$truncated, unreadable:$unreadable}'
+}
+
 scout_report_lines() {
   local report id
   if [ ! -d "$DATA" ]; then
@@ -435,6 +486,7 @@ scout_report_lines() {
 BACKLOG_JSON=$(backlog_json)
 TASKS_JSON=$(task_json_lines)
 SCOUT_REPORTS_JSON=$(scout_report_lines)
+SECONDMATE_LANDED_JSON=$(secondmate_landed_json)
 
 jq -n \
   --arg fm_home "$FM_HOME" \
@@ -446,6 +498,7 @@ jq -n \
   --argjson backlog "$BACKLOG_JSON" \
   --argjson tasks "$TASKS_JSON" \
   --argjson scout_reports "$SCOUT_REPORTS_JSON" \
+  --argjson secondmate_landed "$SECONDMATE_LANDED_JSON" \
   'def backlog_by_id($id): ($backlog.records[]? | select(.structured == true and .id == $id) | .) // null;
    def task_by_id($id): ($tasks[]? | select(.id == $id) | .) // null;
    def report_kind($id): (task_by_id($id).kind // backlog_by_id($id).kind // "scout");
@@ -456,6 +509,7 @@ jq -n \
      backlog:$backlog,
      tasks:($tasks | map(. + {backlog:backlog_by_id(.id)})),
      scout_reports:($scout_reports | map(. + {kind:report_kind(.id)})),
+     secondmate_landed:$secondmate_landed,
      secondmate_guidance:{
        note:"For kind=secondmate, send marked supervisor requests with fm-send and read the status/doc return channel; do not routinely fm-peek the secondmate chat for answers."
      }

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -433,13 +433,14 @@ task_json_lines() {
 # backlog parser (backlog_json) against each home's data/backlog.md - a pure Markdown
 # read, no per-task crew-state and no network - and the one secondmate-home enumerator
 # (fm-ff-lib.sh's live_secondmate_meta_records: meta home= with data/secondmates.md
-# fallback). Per-home Done is capped here so the canonical snapshot stays bounded
-# regardless of the view; bearings applies its own tighter view caps and omitted[]
-# disclosure. A home with no backlog file yet contributes nothing and is NOT flagged
+# fallback). Per-home Done is capped here by default so the canonical snapshot stays
+# bounded; a cap of 0 explicitly lifts that bound for an expanding caller. Bearings
+# applies its own tighter view caps and omitted[] disclosure. A home with no backlog
+# file yet contributes nothing and is NOT flagged
 # (a fresh secondmate is normal); only an existing backlog that fails to parse is
 # reported unreadable. Records are sorted most-recent-first by completion date, id.
 FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME=${FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME:-10}
-case "$FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME" in ''|*[!0-9]*|0) FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME=10 ;; esac
+case "$FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME" in ''|*[!0-9]*) FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME=10 ;; esac
 secondmate_landed_json() {
   local reg="$DATA/secondmates.md" id home backlog bj rows n
   local records='[]' truncated='[]' unreadable='[]'
@@ -456,11 +457,13 @@ secondmate_landed_json() {
       | sort_by([(.completion.date // ""), .id]) | reverse') \
       || { unreadable=$(jq -n --argjson a "$unreadable" --arg h "$home" '$a + [$h]'); continue; }
     n=$(printf '%s' "$rows" | jq 'length')
-    if [ "$n" -gt "$FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME" ]; then
+    if [ "$FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME" -gt 0 ] \
+      && [ "$n" -gt "$FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME" ]; then
       truncated=$(jq -n --argjson a "$truncated" --arg h "$home" '$a + [$h]')
     fi
     records=$(jq -n --argjson a "$records" --argjson b "$rows" \
-      --argjson cap "$FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME" '$a + ($b[:$cap])')
+      --argjson cap "$FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME" \
+      '$a + (if $cap == 0 then $b else $b[:$cap] end)')
   done <<EOF
 $(live_secondmate_meta_records "$STATE" "$reg")
 EOF

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,10 +25,11 @@ Crew status files are append-only wake-event logs, not current-state fields.
 `bin/fm-crew-state.sh <id>` is the cheap current-state read for an actionable heartbeat review: it attributes the matching no-mistakes run, active or terminal, to the crew's own branch and keeps that run-step authoritative even if the pane has closed.
 During no-mistakes' `ci` monitor phase, it also reads the ci step log tail because `axi status` reports both "still waiting on checks" and "checks green, waiting on merge" as `ci,running`.
 The most recent recognized ci log marker wins, so checks-green monitoring reports done while a later re-arm, failed-check, or issue marker returns the crew to working.
-Only when no matching run exists does it fall back to the pane busy-signature and then the status log; a dead pane without a run reports unknown instead of trusting a stale log.
+Only when no matching run exists does it fall back to the pane busy-signature and then a status-log event whose verb maps to a recognized run-state; a dead pane without a run reports unknown instead of trusting a stale log.
+Decision-only events such as `resolved` never become current state or leak their prose into the current-state detail.
 In that status-log fallback, a declared external wait reports the distinct `paused` state with its reason.
 For herdr, that pane fallback trusts a native `busy` verdict outright, but corroborates native `idle` or unknown verdicts against the rendered busy signature before deciding the crew is not working.
-For whole-fleet read-only review, `bin/fm-fleet-snapshot.sh --json` emits schema `fm-fleet-snapshot.v1` from the backlog, task metadata, current crew state, endpoint probes, PR/report pointers, scout reports, and secondmate return-channel guidance.
+For whole-fleet read-only review, `bin/fm-fleet-snapshot.sh --json` emits schema `fm-fleet-snapshot.v1` from the backlog, task metadata, current crew state, endpoint probes, PR/report pointers, scout reports, the bounded landed-work roll-up from registered secondmate homes, and secondmate return-channel guidance.
 `bin/fm-fleet-view.sh` renders that snapshot as Markdown for humans, while `bin/fm-bearings-snapshot.sh` provides the bounded bearings projection, so both views consume one structured contract instead of reparsing raw fleet files.
 The script header owns the exact JSON schema.
 Optional X mode rides the same check path: the locked session-start bootstrap step drops a local `state/x-watch.check.sh` shim only after the user opts in with `FMX_PAIRING_TOKEN`, and non-X homes keep the default watcher behavior.

--- a/tests/fm-bearings-snapshot.test.sh
+++ b/tests/fm-bearings-snapshot.test.sh
@@ -111,6 +111,14 @@ EOF
     "projects=firstmate"
   printf 'needs-decision [key=race]: pick subscribe order\n' > "$home/state/mate.status"
   printf 'done: an unrelated subtask finished\n' >> "$home/state/mate.status"
+  fm_write_meta "$home/state/external-wait.meta" \
+    "window=firstmate:fm-external-wait" \
+    "worktree=$home/projects/ship-wt" \
+    "project=firstmate" \
+    "harness=codex" \
+    "kind=ship" \
+    "mode=no-mistakes"
+  printf 'paused: declared external-wait for upstream release\n' > "$home/state/external-wait.status"
   # The secondmate's OWN home backlog records a merge it managed. This lands in the
   # secondmate home, never the main backlog, so landed-work views only see it via the
   # bounded cross-home Done roll-up.
@@ -429,26 +437,37 @@ test_landed_includes_secondmate_home_merges() {
 # omitted[], with --all-landed as the counted expansion knob. This also covers the
 # previously-silent main-home landed truncation.
 test_landed_bounded_and_disclosed() {
-  local home fakebin json
+  local home fakebin json i expected actual
   home=$(make_home mate-landed-caps); write_fixture "$home"
-  # Give the secondmate home a second, older Done row so a cap of 1 truncates it.
-  cat >> "$home/secondmate-home/data/backlog.md" <<'EOF'
-- [x] mate-landed-2 - Another secondmate fix https://github.com/kunchenguid/firstmate/pull/51 (repo: firstmate) (kind: ship) (merged 2026-07-10)
-EOF
+  : > "$home/secondmate-home/data/backlog.md"
+  printf '## Done\n' >> "$home/secondmate-home/data/backlog.md"
+  i=1
+  while [ "$i" -le 12 ]; do
+    printf -- '- [x] mate-landed-%02d - Secondmate fix %02d (repo: firstmate) (kind: ship) (merged 2026-06-%02d)\n' \
+      "$i" "$i" "$((13 - i))" >> "$home/secondmate-home/data/backlog.md"
+    i=$((i + 1))
+  done
   fakebin=$(make_fakebin "$home")
-  # Overall cap 1 (per-home also defaults to 1): main + two mate rows exist; one shown, disclosed.
-  json=$(FM_BEARINGS_LANDED=1 run "$home" "$fakebin" --json)
+  json=$(FM_BEARINGS_LANDED=20 run "$home" "$fakebin" --json)
   printf '%s' "$json" | jq -e '
-    (.landed | length) == 1
-      and ([.omitted[].surface] | any(test("^landed showing 1 of")))
-      and ([.omitted[].surface] | any(test("^landed per-home capped")))
-  ' >/dev/null || fail "landed caps must bound and disclose overall + per-home: $json"
-  # --all-landed reveals the full set with no landed omission.
+    ([.landed[].id | select(startswith("mate-landed-"))] | length) == 10
+      and ([.omitted[].surface] | any(test("snapshot layer")))
+  ' >/dev/null || fail "default landed path must retain and disclose the snapshot per-home cap: $json"
   json=$(FM_BEARINGS_LANDED=1 run "$home" "$fakebin" --json --all-landed)
+  expected=done-a
+  i=1
+  while [ "$i" -le 12 ]; do
+    expected="$expected
+$(printf 'mate-landed-%02d' "$i")"
+    i=$((i + 1))
+  done
+  expected=$(printf '%s\n' "$expected" | LC_ALL=C sort)
+  actual=$(printf '%s' "$json" | jq -r '.landed[].id' | LC_ALL=C sort)
+  [ "$actual" = "$expected" ] || fail "--all-landed returned wrong identities: $actual"
   printf '%s' "$json" | jq -e '
-    (.landed | length) >= 3
-      and ([.omitted[].surface] | any(test("^landed showing")) | not)
-  ' >/dev/null || fail "--all-landed must reveal the full landed set: $json"
+    (.landed | length) == 13
+      and ([.omitted[].surface] | any(test("landed|snapshot layer")) | not)
+  ' >/dev/null || fail "--all-landed must reveal the exact full landed set: $json"
   pass "landed stays bounded with per-home + overall caps and omitted[] disclosure"
 }
 
@@ -458,13 +477,21 @@ EOF
 # cannot leak into Captain's Call. The standard fixture has exactly one genuine open
 # decision (the secondmate's masked needs-decision).
 test_captains_call_anti_leak() {
-  local home fakebin json
+  local home fakebin json canonical
   home=$(make_home anti-leak); write_fixture "$home"
   fakebin=$(make_fakebin "$home")
   json=$(run "$home" "$fakebin" --json)
-  printf '%s' "$json" | jq -e '
-    ([.decisions_open[].id] | unique) == ["mate"]
-      and (.decisions_open | all(.[]; .verb == "needs-decision" or .verb == "blocked"))
+  canonical=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$ROOT/bin/fm-fleet-snapshot.sh" --json)
+  jq -n -e --argjson bearings "$json" --argjson canonical "$canonical" '
+    (([$bearings.decisions_open[].id]
+      + [$canonical.tasks[] | select(.hints.pending_decision or .hints.blocked_event) | .id]) | unique) == ["mate"]
+      and ([$bearings.decisions_open[].id] | index("ship-task") | not)
+      and ([$bearings.decisions_open[].id] | index("scout-x") | not)
+      and ([$bearings.decisions_open[].id] | index("external-wait") | not)
+      and ([$bearings.decisions_open[].id] | index("done-a") | not)
+      and ([$bearings.decisions_open[].id] | index("mate-landed") | not)
+      and ([$bearings.decisions_open[].id] | index("live-gate") | not)
+      and ([$bearings.decisions_open[].id] | index("dead-gate") | not)
   ' >/dev/null || fail "only genuine open decisions may feed Captain's Call: $json"
   pass "action-free items (working/done/queued/landed) do not leak into Captain's Call"
 }
@@ -474,13 +501,13 @@ test_captains_call_anti_leak() {
 # empty-state sentence, documents the At Anchor exclusion, and mandates a chat that is
 # materially shorter than and links to the report file.
 test_chat_contract_four_sections() {
-  local skill body order expected
+  local skill body headings expected
   skill="$ROOT/.agents/skills/bearings/SKILL.md"
   [ -f "$skill" ] || fail "bearings SKILL.md missing at $skill"
-  body=$(cat "$skill")
-  order=$(printf '%s\n' "$body" | grep -oE "Captain's Call|Recently Landed|Underway|Charted Next" | awk '!seen[$0]++')
+  body=$(awk '/^## Chat-response contract$/{capture=1; next} capture && /^## /{exit} capture' "$skill")
+  headings=$(printf '%s\n' "$body" | sed -nE "s/^[0-9]+\. \*\*([^*]+)\*\*.*/\1/p")
   expected=$(printf '%s\n' "Captain's Call" "Recently Landed" "Underway" "Charted Next")
-  [ "$order" = "$expected" ] || fail "chat contract sections must appear in the fixed order, got: $order"
+  [ "$headings" = "$expected" ] || fail "chat contract must contain exactly four numbered sections in fixed order, got: $headings"
   assert_contains "$body" "Nothing needs your action right now" "Captain's Call empty-state sentence"
   assert_contains "$body" "Nothing has landed since your last report" "Recently Landed empty-state sentence"
   assert_contains "$body" "Nothing is underway" "Underway empty-state sentence"

--- a/tests/fm-bearings-snapshot.test.sh
+++ b/tests/fm-bearings-snapshot.test.sh
@@ -111,6 +111,14 @@ EOF
     "projects=firstmate"
   printf 'needs-decision [key=race]: pick subscribe order\n' > "$home/state/mate.status"
   printf 'done: an unrelated subtask finished\n' >> "$home/state/mate.status"
+  # The secondmate's OWN home backlog records a merge it managed. This lands in the
+  # secondmate home, never the main backlog, so landed-work views only see it via the
+  # bounded cross-home Done roll-up.
+  mkdir -p "$home/secondmate-home/data"
+  cat > "$home/secondmate-home/data/backlog.md" <<'EOF'
+## Done
+- [x] mate-landed - Secondmate-managed fix https://github.com/kunchenguid/firstmate/pull/50 (repo: firstmate) (kind: ship) (merged 2026-07-11)
+EOF
 }
 
 run() {  # <home> <fakebin> <args...>
@@ -400,8 +408,95 @@ test_completed_scout_report_not_pending() {
   pass "a completed scout with decision-like report prose is a pointer, not pending"
 }
 
+# Recently Landed must include merges a secondmate managed. Those completion records
+# live in the secondmate home's OWN backlog, not the main one, so the projection must
+# roll them up. Local, deterministic, no GitHub call.
+test_landed_includes_secondmate_home_merges() {
+  local home fakebin json
+  home=$(make_home mate-landed); write_fixture "$home"
+  fakebin=$(make_fakebin "$home"); : > "$home/net.log"
+  json=$(run "$home" "$fakebin" --json)
+  printf '%s' "$json" | jq -e '
+    (.landed | any(.[]; .id == "mate-landed" and (.artifact | test("/pull/50"))))
+      and (.landed | any(.[]; .id == "done-a"))
+  ' >/dev/null || fail "landed must merge secondmate-home Done with main-home Done: $json"
+  # Still zero network on this default path.
+  [ ! -s "$home/net.log" ] || fail "landed roll-up must make no gh/gh-axi call, got: $(cat "$home/net.log")"
+  pass "landed includes secondmate-managed merges alongside main-home merges"
+}
+
+# The roll-up stays bounded: a per-home cap and an overall cap, both disclosed in
+# omitted[], with --all-landed as the counted expansion knob. This also covers the
+# previously-silent main-home landed truncation.
+test_landed_bounded_and_disclosed() {
+  local home fakebin json
+  home=$(make_home mate-landed-caps); write_fixture "$home"
+  # Give the secondmate home a second, older Done row so a cap of 1 truncates it.
+  cat >> "$home/secondmate-home/data/backlog.md" <<'EOF'
+- [x] mate-landed-2 - Another secondmate fix https://github.com/kunchenguid/firstmate/pull/51 (repo: firstmate) (kind: ship) (merged 2026-07-10)
+EOF
+  fakebin=$(make_fakebin "$home")
+  # Overall cap 1 (per-home also defaults to 1): main + two mate rows exist; one shown, disclosed.
+  json=$(FM_BEARINGS_LANDED=1 run "$home" "$fakebin" --json)
+  printf '%s' "$json" | jq -e '
+    (.landed | length) == 1
+      and ([.omitted[].surface] | any(test("^landed showing 1 of")))
+      and ([.omitted[].surface] | any(test("^landed per-home capped")))
+  ' >/dev/null || fail "landed caps must bound and disclose overall + per-home: $json"
+  # --all-landed reveals the full set with no landed omission.
+  json=$(FM_BEARINGS_LANDED=1 run "$home" "$fakebin" --json --all-landed)
+  printf '%s' "$json" | jq -e '
+    (.landed | length) >= 3
+      and ([.omitted[].surface] | any(test("^landed showing")) | not)
+  ' >/dev/null || fail "--all-landed must reveal the full landed set: $json"
+  pass "landed stays bounded with per-home + overall caps and omitted[] disclosure"
+}
+
+# Captain's Call is populated only from the durable keyed open-decision set. The
+# anti-leak guard: action-free highlights - a working task, a completed scout,
+# queued/gated items, landed work - must never surface as an open decision, so they
+# cannot leak into Captain's Call. The standard fixture has exactly one genuine open
+# decision (the secondmate's masked needs-decision).
+test_captains_call_anti_leak() {
+  local home fakebin json
+  home=$(make_home anti-leak); write_fixture "$home"
+  fakebin=$(make_fakebin "$home")
+  json=$(run "$home" "$fakebin" --json)
+  printf '%s' "$json" | jq -e '
+    ([.decisions_open[].id] | unique) == ["mate"]
+      and (.decisions_open | all(.[]; .verb == "needs-decision" or .verb == "blocked"))
+  ' >/dev/null || fail "only genuine open decisions may feed Captain's Call: $json"
+  pass "action-free items (working/done/queued/landed) do not leak into Captain's Call"
+}
+
+# The /bearings skill is the one owner of the four-section chat-response contract.
+# Assert it states exactly the four fixed sections in order, each with its explicit
+# empty-state sentence, documents the At Anchor exclusion, and mandates a chat that is
+# materially shorter than and links to the report file.
+test_chat_contract_four_sections() {
+  local skill body order expected
+  skill="$ROOT/.agents/skills/bearings/SKILL.md"
+  [ -f "$skill" ] || fail "bearings SKILL.md missing at $skill"
+  body=$(cat "$skill")
+  order=$(printf '%s\n' "$body" | grep -oE "Captain's Call|Recently Landed|Underway|Charted Next" | awk '!seen[$0]++')
+  expected=$(printf '%s\n' "Captain's Call" "Recently Landed" "Underway" "Charted Next")
+  [ "$order" = "$expected" ] || fail "chat contract sections must appear in the fixed order, got: $order"
+  assert_contains "$body" "Nothing needs your action right now" "Captain's Call empty-state sentence"
+  assert_contains "$body" "Nothing has landed since your last report" "Recently Landed empty-state sentence"
+  assert_contains "$body" "Nothing is underway" "Underway empty-state sentence"
+  assert_contains "$body" "Nothing is queued" "Charted Next empty-state sentence"
+  assert_contains "$body" "no At Anchor section" "the At Anchor exclusion must be documented"
+  assert_contains "$body" "materially shorter" "the chat must be materially shorter than the report file"
+  assert_contains "$body" "links to" "the chat must link to the report file"
+  pass "the /bearings skill states the four-section chat contract in order, with empty-states and the At Anchor exclusion"
+}
+
 test_default_is_bounded_and_local_only
 test_toon_json_parity
+test_landed_includes_secondmate_home_merges
+test_landed_bounded_and_disclosed
+test_captains_call_anti_leak
+test_chat_contract_four_sections
 test_completed_scout_report_not_pending
 test_open_decision_surfaces_end_to_end
 test_report_pointers_surface

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -924,6 +924,40 @@ test_no_run_idle_pane_custom_paused_verb() {
   pass "no run + idle pane honors the configured paused verb"
 }
 
+# A trailing keyed resolved: event is a decision-CLOSING event, not a run-state
+# verb. It must never become the current state or leak its resolution prose as the
+# detail: a healthy idle secondmate that just closed a keyed decision falls through
+# to the idle default (unknown/none), not `unknown` with the resolution note as its
+# `doing`. Regression for the bearings render bug where such a secondmate showed
+# state=unknown with resolution prose. The one-owner keyed fold in fm-classify-lib.sh
+# is untouched; this only stops the deriver from reading a non-state event as state.
+test_no_run_idle_secondmate_resolved_event_not_state() {
+  reset_fakes
+  local d; d=$(new_case resolved-idle)
+  mkdir -p "$d/wt"
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/mate.meta" "window=fm:fm-mate" "worktree=$d/wt" "kind=secondmate" "home=$d/wt"
+  printf 'needs-decision [key=race]: pick subscribe order\n' > "$d/state/mate.status"
+  printf 'resolved [key=race]: went with subscribe-before-write\n' >> "$d/state/mate.status"
+  FM_FAKE_AXI_STATUS=""
+  FM_FAKE_BUSY=0
+  local out; out=$(run_crew_state "$d" mate)
+  assert_contains "$out" "state: unknown" "resolved-then-idle secondmate is not a spurious run-state"
+  assert_contains "$out" "source: none" "a resolved event is not treated as a status-log state source"
+  assert_not_contains "$out" "subscribe-before-write" "resolution prose must not leak into the detail"
+  # A bare (non-keyed) resolved: closes the default key and behaves the same.
+  printf 'blocked: waiting on infra\nresolved: infra access granted\n' > "$d/state/mate.status"
+  out=$(run_crew_state "$d" mate)
+  assert_contains "$out" "source: none" "a bare resolved: is not a state source either"
+  assert_not_contains "$out" "infra access granted" "bare resolution prose must not leak into the detail"
+  # Control: a genuine trailing state verb still renders from the log.
+  printf 'working: reconciling routed items\n' > "$d/state/mate.status"
+  out=$(run_crew_state "$d" mate)
+  assert_contains "$out" "state: working" "a real trailing state verb still renders"
+  assert_contains "$out" "reconciling routed items" "a real state line still carries its detail"
+  pass "a trailing resolved: event does not corrupt state render (idle stays idle)"
+}
+
 test_dead_window_ignores_stale_status_log() {
   reset_fakes
   local d; d=$(new_case dead-window)
@@ -1133,6 +1167,7 @@ test_no_run_idle_pane_uses_log
 test_no_run_idle_pane_uses_keyed_log
 test_no_run_idle_pane_paused
 test_no_run_idle_pane_custom_paused_verb
+test_no_run_idle_secondmate_resolved_event_not_state
 test_dead_window_ignores_stale_status_log
 test_dead_window_still_reports_terminal_run_step
 test_dead_window_still_reports_active_run_step


### PR DESCRIPTION
## Intent

Redesign the /bearings response and ship the two accuracy fixes that make it correct rather than cosmetic.

(1) Mandate a four-section concise chat-response contract, owned solely by the /bearings skill: Captain's Call (ONLY items needing the captain's own action now - an open decision, a PR to approve/merge, a credential/login, or a blocker only they can clear), Recently Landed (work completed since the prior report), Underway (active work), Charted Next (queued/gated work). All four ALWAYS render in that fixed order, each with an explicit empty-state sentence, with no 'At Anchor' section, and the chat must be materially shorter than and link to the detailed report file. This deliberately replaces the earlier ambiguous 'Check first' vs 'Decisions pending' split (their three-line wording contradicted each other about where a pending decision belongs); the fix is skill wording only, with the snapshot/classifier owning the data.

(2) fm-crew-state.sh: the status-log fallback now derives current state ONLY from a real run-state verb. A trailing decision-closing 'resolved:' event (fm-classify-lib.sh's FM_CLASSIFY_RESOLVE_VERB, plus any decision-only sibling) is intentionally NOT a run-state, so it no longer becomes the reported state nor leaks its resolution prose as the 'doing' detail; a healthy idle secondmate that just closed a keyed decision now falls through to the idle default instead of rendering state=unknown with the resolution prose. Deliberate decisions: the keyed-decision fold in fm-classify-lib.sh is left UNTOUCHED (it already closes the decision correctly - this was purely a render bug), and I reused map_log_state's existing 'unknown' verdict as the not-a-state test rather than adding a second verb list, keeping map_log_state the single verb->state owner.

(3) Recently Landed must include merges a secondmate managed, which are recorded in the secondmate home's OWN backlog, never the main one. fm-fleet-snapshot.sh gains a bounded, read-only secondmate_landed roll-up that reuses the single backlog parser (backlog_json, parameterized to accept a path) and the one secondmate-home enumerator (live_secondmate_meta_records from fm-ff-lib.sh: meta home= with data/secondmates.md fallback). fm-bearings-snapshot.sh merges main-home Done with that roll-up under a per-home cap (FM_BEARINGS_LANDED_PER_HOME) and an overall cap (FM_BEARINGS_LANDED) with omitted[] disclosure, which also fixes a previously-silent landed truncation; --all-landed reveals the full set. Deliberate constraints held throughout and verifiable in the diff: bounded/deterministic output, one owner per contract, and NO ad-hoc GitHub/network calls (the roll-up reads local backlogs only; --include-prs stays the sole network path).

Regression tests were added for all of it: the resolved-event state render (fm-crew-state.test.sh), the secondmate landed aggregation with per-home/overall caps and omitted[] disclosure plus the Captain's Call anti-leak that action-free items never surface as open decisions, and the four-section skill contract (fm-bearings-snapshot.test.sh). Scope was intentionally kept to this redesign plus the two confirmed fixes; sourcing fm-ff-lib.sh into fm-fleet-snapshot.sh is intentional to reuse the one secondmate-home enumerator instead of duplicating it.

## What Changed

- Redesign `/bearings` around an always-present four-section chat contract with concise empty states and a link to the detailed report.
- Aggregate bounded landed work from the main fleet and secondmate backlogs, with truncation disclosure and `--all-landed` support.
- Prevent decision-only status events from becoming current run state, and add regression coverage for the new rendering and accuracy contracts.

## Risk Assessment

✅ Low: Captain, the changes are well-bounded and satisfy the stated intent, with the default snapshot cap preserved and explicit uncapped expansion confined to `--all-landed`.

## Testing

The already-successful full baseline was supplemented by focused regression suites and end-to-end fixtures covering the four-section bearings response, report linkage and concision, resolved-decision idle fallback, secondmate landed aggregation and caps, omitted disclosure, --all-landed expansion, and default-path network isolation; all checks passed and reviewer-visible evidence was saved.

<details>
<summary>Evidence: End-user CLI transcript</summary>

```text
=== bounded end-user bearings projection ===
{
  "prs": "not_requested (run: /bearings include PRs)",
  "decisions_open": [],
  "landed": [
    {
      "id": "mate-new",
      "what": "Mate newest",
      "artifact": "https://github.com/acme/app/pull/22"
    },
    {
      "id": "main-landed",
      "what": "Main fix",
      "artifact": "https://github.com/acme/app/pull/10"
    }
  ],
  "omitted": [
    {
      "surface": "backlog item bodies",
      "reveal": "--fields bodies"
    },
    {
      "surface": "task paths",
      "reveal": "--fields paths"
    },
    {
      "surface": "watch/steer actions",
      "reveal": "--fields actions"
    },
    {
      "surface": "healthy endpoint detail",
      "reveal": "--fields endpoints"
    },
    {
      "surface": "full scout-report inventory",
      "reveal": "--all-reports"
    },
    {
      "surface": "superseded/held queued items",
      "reveal": "--all-queued"
    },
    {
      "surface": "landed per-home capped at 1 for 1 home(s)",
      "reveal": "--all-landed"
    },
    {
      "surface": "live PR discovery + checks",
      "reveal": "--include-prs"
    }
  ]
}

=== --all-landed expansion ===
{
  "landed": [
    {
      "id": "mate-new",
      "what": "Mate newest",
      "artifact": "https://github.com/acme/app/pull/22"
    },
    {
      "id": "main-landed",
      "what": "Main fix",
      "artifact": "https://github.com/acme/app/pull/10"
    },
    {
      "id": "mate-old",
      "what": "Mate older",
      "artifact": "https://github.com/acme/app/pull/21"
    }
  ],
  "landed_omissions": []
}

=== idle secondmate after resolved decision ===
state: unknown · source: none · no current-state source available

=== default-path network log (must remain empty) ===
[empty - no gh or gh-axi calls]
```
</details>
<details>
<summary>Evidence: Bounded bearings snapshot</summary>

```text
{
  "schema": "fm-bearings.v1",
  "home": "manual-fleet/home",
  "generated": "2026-07-11T18:00:00Z",
  "prs": "not_requested (run: /bearings include PRs)",
  "in_flight": [
    {
      "id": "mate",
      "kind": "secondmate",
      "state": "unknown",
      "doing": "no current-state source available"
    }
  ],
  "decisions_open": [],
  "landed": [
    {
      "id": "mate-new",
      "what": "Mate newest",
      "artifact": "https://github.com/acme/app/pull/22"
    },
    {
      "id": "main-landed",
      "what": "Main fix",
      "artifact": "https://github.com/acme/app/pull/10"
    }
  ],
  "gates": [],
  "reports": [],
  "recorded_prs": [],
  "omitted": [
    {
      "surface": "backlog item bodies",
      "reveal": "--fields bodies"
    },
    {
      "surface": "task paths",
      "reveal": "--fields paths"
    },
    {
      "surface": "watch/steer actions",
      "reveal": "--fields actions"
    },
    {
      "surface": "healthy endpoint detail",
      "reveal": "--fields endpoints"
    },
    {
      "surface": "full scout-report inventory",
      "reveal": "--all-reports"
    },
    {
      "surface": "superseded/held queued items",
      "reveal": "--all-queued"
    },
    {
      "surface": "landed per-home capped at 1 for 1 home(s)",
      "reveal": "--all-landed"
    },
    {
      "surface": "live PR discovery + checks",
      "reveal": "--include-prs"
    }
  ]
}
```
</details>
<details>
<summary>Evidence: Expanded landed snapshot</summary>

```text
{
  "schema": "fm-bearings.v1",
  "home": "manual-fleet/home",
  "generated": "2026-07-11T18:00:00Z",
  "prs": "not_requested (run: /bearings include PRs)",
  "in_flight": [
    {
      "id": "mate",
      "kind": "secondmate",
      "state": "unknown",
      "doing": "no current-state source available"
    }
  ],
  "decisions_open": [],
  "landed": [
    {
      "id": "mate-new",
      "what": "Mate newest",
      "artifact": "https://github.com/acme/app/pull/22"
    },
    {
      "id": "main-landed",
      "what": "Main fix",
      "artifact": "https://github.com/acme/app/pull/10"
    },
    {
      "id": "mate-old",
      "what": "Mate older",
      "artifact": "https://github.com/acme/app/pull/21"
    }
  ],
  "gates": [],
  "reports": [],
  "recorded_prs": [],
  "omitted": [
    {
      "surface": "backlog item bodies",
      "reveal": "--fields bodies"
    },
    {
      "surface": "task paths",
      "reveal": "--fields paths"
    },
    {
      "surface": "watch/steer actions",
      "reveal": "--fields actions"
    },
    {
      "surface": "healthy endpoint detail",
      "reveal": "--fields endpoints"
    },
    {
      "surface": "full scout-report inventory",
      "reveal": "--all-reports"
    },
    {
      "surface": "superseded/held queued items",
      "reveal": "--all-queued"
    },
    {
      "surface": "live PR discovery + checks",
      "reveal": "--include-prs"
    }
  ]
}
```
</details>
<details>
<summary>Evidence: Resolved decision idle-state result</summary>

`state: unknown · source: none · no current-state source available`

```text
state: unknown · source: none · no current-state source available
```
</details>
<details>
<summary>Evidence: Rendered concise bearings chat</summary>

```text
Full report: [status-report-2026-07-11.md](/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KXAAWJ21HYN5PHFZZW99HQ0X/status-report-2026-07-11.md)

## Captain's Call

Nothing needs your action right now.

## Recently Landed

- Mate newest: https://github.com/acme/app/pull/22
- Main fix: https://github.com/acme/app/pull/10

## Underway

Nothing is underway.

## Charted Next

Nothing is queued.
```
</details>
<details>
<summary>Evidence: Detailed bearings report</summary>

```text
# Bearings - Saturday 2026-07-11

The fleet is quiet and healthy.
The latest local snapshot includes work managed in the secondmate home without querying GitHub.

## Captain's Call

Nothing needs your action right now.

The previously open choice was resolved and is no longer actionable.

## Recently Landed

- Mate newest - secondmate-managed merge: https://github.com/acme/app/pull/22
- Main fix - main-home merge: https://github.com/acme/app/pull/10

The bounded default view disclosed that one older secondmate item was omitted by the per-home cap.
The expanded view also showed Mate older: https://github.com/acme/app/pull/21

## Underway

Nothing is underway.

The secondmate is healthy and idle after closing its keyed decision.
Its resolution prose is not presented as current work.

## Charted Next

Nothing is queued.

Evidence was gathered from local backlog and status files only.
Live PR discovery remained explicitly not requested.
```
</details>
<details>
<summary>Evidence: Chat contract verification</summary>

<code>chat_bytes=418&#10;report_bytes=947&#10;section_order=Captain&#39;s Call &gt; Recently Landed &gt; Underway &gt; Charted Next&#10;at_anchor=absent&#10;report_link=present</code>

```text
chat_bytes=418
report_bytes=947
section_order=## Captain's Call ## Recently Landed>## Underway ## Charted Next
at_anchor=absent
report_link=Full report: [status-report-2026-07-11.md](/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KXAAWJ21HYN5PHFZZW99HQ0X/status-report-2026-07-11.md)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 4 issues found → auto-fixed ✅</summary>

- 🚨 `bin/fm-fleet-snapshot.sh:463` - Captain, this contradicts the required “--all-landed reveals the full set” behavior. The canonical snapshot permanently slices each secondmate home&#39;s records to its default cap of 10 before the bearings layer sees them, so `--all-landed` cannot recover older records.
- 🚨 `tests/fm-bearings-snapshot.test.sh:435` - The required regression coverage does not expose the canonical pre-truncation bug: this fixture adds only two secondmate records, below the lower-layer default cap of 10. Add more than 10 records and assert the exact identities/count returned by `--all-landed`.
- 🚨 `tests/fm-bearings-snapshot.test.sh:464` - The required Captain&#39;s Call anti-leak regression never renders Captain&#39;s Call. It only checks `decisions_open`, so leaks introduced while composing the chat response would pass undetected.
- 🚨 `tests/fm-bearings-snapshot.test.sh:481` - The required four-section contract regression searches the entire skill for first occurrences of four names. It would pass with a fifth section, incorrect ordering inside the actual chat contract, or contract wording outside that block, so it does not verify “exactly four” sections owned solely by the chat-response contract.

🔧 Fix: Captain, ensure bearings reveals all landed work
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- <code>Configured full baseline suite previously completed successfully: `command -v tmux &gt;/dev/null || { echo &#34;tmux is required for e2e tests&#34; &gt;&amp;2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo &#34;== $t ==&#34;; bash &#34;$t&#34; || rc=1; done; exit &#34;$rc&#34;`</code>
- `bash tests/fm-crew-state.test.sh && bash tests/fm-bearings-snapshot.test.sh`
- <code>Disposable fleet fixture with `FM_BEARINGS_LANDED=2 FM_BEARINGS_LANDED_PER_HOME=1 bin/fm-bearings-snapshot.sh --json`</code>
- <code>Same fixture with `bin/fm-bearings-snapshot.sh --json --all-landed`</code>
- <code>Resolved keyed-decision fixture with `FM_STATE_OVERRIDE=... bin/fm-crew-state.sh mate`</code>
- <code>Fake `gh` and `gh-axi` traps confirmed the default bearings path made no network calls</code>
- `Rendered the four-section chat response and detailed report; verified fixed order, explicit empty states, absent At Anchor section, report link, and materially shorter chat output`
- <code>`git status --short` confirmed testing left no worktree artifacts</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
