### PR TITLE
feat: add hermes (Hermes Agent over ACP via acpx) crewmate harness

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harness-adapters
-description: Agent-only reference for firstmate harness operations. Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter. Contains verified facts for claude, codex, opencode, pi, and grok.
+description: Agent-only reference for firstmate harness operations. Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter. Contains verified facts for claude, codex, opencode, pi, grok, and hermes (crewmate/scout only).
 user-invocable: false
 metadata:
   internal: true
@@ -264,3 +264,33 @@ The adapter therefore runs the shared predicate and, when it returns 2, forces o
 It does not pass `--permission-mode`, so the passive hook cannot escalate the primary session's tool permissions.
 Project-local Grok hooks require folder trust, verified with launch-time `--trust`; if the primary firstmate checkout is not trusted for Grok hooks, this primary guard fails open and `fm-guard.sh` remains the next-command alarm.
 Grok's primary watcher protocol is Claude-shaped background-notify around `bin/fm-watch-arm.sh`; the passive Stop hook is only a backstop for blind turn ends.
+
+## hermes (VERIFIED as crewmate/scout 2026-07-12, hermes-agent 0.18.2, acpx via named sessions; secondmate REFUSED; primary UNVERIFIED)
+
+Hermes Agent (Nous Research) driven headlessly over the Agent Client Protocol: `acpx` is the client, `hermes acp` is the agent server.
+This adapter is unlike every TUI adapter: there is NO persistent composer.
+Each turn is one foreground `acpx ... prompt` process in the pane; acpx exits 0 at `end_turn` (verified live: `[done] end_turn`, exit 0, ~9s trivial round-trip), and between turns the pane rests at a bare shell prompt.
+That shell prompt is HEALTHY idle for a hermes crewmate, not a dead crew.
+
+| Fact | Value |
+|---|---|
+| Busy-pane signature | none - acpx text output has no stable busy token in the pane tail (verified in the 2026-07-12 trial). Busy is classified by FOREGROUND-PROCESS liveness instead: `fm_backend_busy_state` (bin/fm-backend.sh) reports busy while a non-shell foreground command runs and idle at a bare shell, via `fm_backend_tmux_foreground_state`. |
+| Turn-end signal | `; touch state/<id>.turn-ended` rides the launch command and every fm-send steer; it fires when the acpx process exits, including on `--timeout` (3600s) expiry and errors. |
+| Session model | named, resumable acpx session `fm-<task-id>` (`acpx hermes sessions ensure --name` + `-s <name> prompt`), created by the launch template. Follow-up prompts keep full conversation context across separate acpx invocations (verified); the hermes ACP server implements `load_session`, so the session survives queue-owner idle shutdown (`--ttl`, default 300s). A bare `acpx exec` session is one-shot and NOT resumable - never use exec for a crewmate. |
+| Agent registration | named sessions need hermes registered as an acpx agent; fm-spawn writes worktree `.acpxrc.json` (`{"agents":{"hermes":{"command":"hermes acp"}}}`), git-excluded, teardown-removed only on byte-match. A pre-existing project `.acpxrc.json` without a hermes entry aborts the spawn. |
+| Steer | `fm-send` wraps the message in a follow-up `acpx ... hermes -s fm-<id> prompt '<msg>'` typed at the idle shell prompt (tmux only). It fails closed on busy or unconfirmable panes: raw text typed at a shell prompt would EXECUTE as shell commands. Mid-turn steering is not possible; wait for the turn-end wake. |
+| Exit command | none needed - the process exits itself at end_turn. A stuck turn: `Ctrl+C` (C-c) to the pane kills the foreground acpx (standard signal handling; the `; touch` still fires). |
+| Skill invocation | none verified; use natural language in the prompt. |
+| Autonomy | `--approve-all` (acpx global flag; auto-approves every ACP permission request client-side). |
+| Model flag | acpx global `--model <id>`, placed before the `hermes` subcommand; no effort flag exists, so effort is recorded in meta but not passed. |
+| Env marker | none set for child processes (checked hermes-agent 0.18.2 source); `fm-harness.sh` detects hermes by ancestry - a python interpreter whose args contain `hermes`, or the node `acpx` client. |
+| Resume after kill | the named session record persists; re-run the launch template's prompt command (or steer via fm-send) in the same worktree to continue with context. |
+
+Quirks and constraints:
+
+- Global acpx options MUST precede the agent subcommand (`acpx --approve-all ... hermes -s <name> prompt ...`); after it they are rejected.
+- `--timeout 3600` bounds one turn; a longer legitimate turn is killed, the turn-end marker still fires, and a "continue" steer resumes with context.
+- A hung acpx process reads as busy forever from process liveness; the watcher's provably-working wedge escalation (`demand-deep-inspection`) is the hung-turn backstop, exactly as for a wedged TUI harness.
+- The tmux server must be daemonized (PPID 1) before spawning, or the crewmate panes die with the launching shell; `fm_backend_tmux_agent_alive` reports `unknown` for acpx (a generic node process), never `alive`.
+- **Secondmate: REFUSED by fm-spawn.** A hermes secondmate's healthy idle is a dead shell, which the secondmate liveness sweep reads as a dead agent and respawns forever. An interactive `hermes chat` TUI shape may lift this later; it is unverified.
+- **Primary (firstmate itself on hermes): detection works, supervision is UNVERIFIED.** `bin/fm-harness.sh` resolves hermes, and the session-start digest emits the unknown-harness fallback block (bounded foreground waits over `bin/fm-watch.sh`, e.g. `bin/fm-watch-checkpoint.sh`, the Codex-shaped protocol). No turn-end guard or pre-arm seatbelt is wired; hermes's documented per-turn `on_session_end` shell hook (`hooks:` block in `~/.hermes/config.yaml`, consent-gated allowlist, stdin JSON payload) is the identified path for both, pending live validation. Until then a hermes primary fails open to `fm-guard.sh`'s next-command alarm.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,7 +171,8 @@ If the captain expresses a standing dispatch preference such as "use grok for ne
 Crewmates default to the same harness you are running on.
 The captain may override the static default at any time, typically at bootstrap: record the choice in `config/crew-harness` (a single adapter name; absent or `default` means mirror your own harness).
 Resolve `default` with `bin/fm-harness.sh`; resolve the active static crewmate harness with `bin/fm-harness.sh crew`.
-Verified adapter names are `claude`, `codex`, `opencode`, `pi`, and `grok`.
+Verified adapter names are `claude`, `codex`, `opencode`, `pi`, `grok`, and `hermes`.
+`hermes` is verified for crewmate and scout tasks only: `fm-spawn` refuses hermes secondmates, and a hermes primary is unverified (`harness-adapters` owns the details).
 
 ### Crew dispatch profiles
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Full detail on every feature lives in [docs/architecture.md](docs/architecture.m
 
 ### Requirements
 
-- A verified agent harness: Claude Code, Grok, Pi, Codex, or OpenCode.
+- A verified agent harness: Claude Code, Grok, Pi, Codex, OpenCode, or Hermes (crewmate/scout only).
 - Git and the GitHub CLI, authenticated through `gh auth login`.
 - tmux, for the reference session backend.
 
@@ -70,6 +70,8 @@ All three have verified turn-end guard paths when launched with their documented
 Pick whichever one matches your subscription and workflow.
 
 Codex and OpenCode are also verified and supported as primary harnesses; Codex uses bounded foreground checkpoints, and OpenCode uses a TUI plugin, so both carry more harness-specific supervision tradeoffs than the three co-primaries.
+
+Hermes is verified for crewmate and scout tasks only; a hermes primary is unverified and secondmates are refused.
 
 ### Install and launch
 

--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -165,3 +165,24 @@ fm_backend_tmux_agent_alive() {  # <target>
     *) printf 'unknown' ;;
   esac
 }
+
+# fm_backend_tmux_foreground_state: coarser sibling of the agent-alive probe for
+# harnesses that run as a generic interpreter and so can never match a harness
+# binary name (hermes crewmates run acpx, a node script). Prints one of:
+#   shell   - the foreground command is a bare shell (same shell list as
+#             fm_backend_tmux_agent_alive's `dead`): nothing is running.
+#   running - any other non-empty foreground command: the launched command is
+#             still alive, whatever its process name.
+#   unknown - unreadable pane or empty value.
+# fm_backend_busy_state (bin/fm-backend.sh) maps this to busy/idle for tasks
+# whose meta records harness=hermes, where process liveness IS the turn signal.
+fm_backend_tmux_foreground_state() {  # <target>
+  local comm
+  comm=$(fm_backend_tmux_current_command "$1") || { printf 'unknown'; return 0; }
+  comm=${comm#-}
+  case "$comm" in
+    '') printf 'unknown' ;;
+    zsh|bash|sh|dash|ash|ksh|mksh|tcsh|csh|fish) printf 'shell' ;;
+    *) printf 'running' ;;
+  esac
+}

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -582,7 +582,6 @@ fm_backend_worktree_path() {  # <backend> <worktree-id>
 # means the turn PROCESS exited, so it is trustworthy on its own.
 fm_backend_busy_state() {  # <backend> <target> [state-dir]
   local backend=$1 target=$2 state=${3:-} meta harness
-  shift
   fm_backend_source "$backend" || { printf 'unknown'; return 0; }
   if [ -n "$state" ] && [ "$backend" = tmux ]; then
     meta=$(fm_backend_meta_for_window "$target" "$state" 2>/dev/null || true)

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -570,12 +570,36 @@ fm_backend_worktree_path() {  # <backend> <worktree-id>
 # uses unknown as the cue for its pane-hash + FM_BUSY_REGEX detection, while
 # fm-crew-state.sh also corroborates native idle verdicts before treating a
 # no-run crew as not busy.
-fm_backend_busy_state() {  # <backend> <target>
-  local backend=$1
+#
+# With the optional <state-dir> argument, the read is also HARNESS-aware for
+# tasks whose meta records harness=hermes: hermes crewmates run one foreground
+# acpx process per turn and exit at end_turn (verified empirically), and acpx's
+# text output has no stable busy token in the pane tail, so for a hermes task
+# the live foreground process IS the semantic busy signal - `busy` while a
+# non-shell foreground command runs, `idle` once the pane rests at a bare
+# shell. Unlike herdr's generation-state `idle` (which callers corroborate
+# because a crew can be mid-tool-call while not generating), a hermes `idle`
+# means the turn PROCESS exited, so it is trustworthy on its own.
+fm_backend_busy_state() {  # <backend> <target> [state-dir]
+  local backend=$1 target=$2 state=${3:-} meta harness
   shift
   fm_backend_source "$backend" || { printf 'unknown'; return 0; }
+  if [ -n "$state" ] && [ "$backend" = tmux ]; then
+    meta=$(fm_backend_meta_for_window "$target" "$state" 2>/dev/null || true)
+    if [ -n "$meta" ]; then
+      harness=$(grep '^harness=' "$meta" 2>/dev/null | cut -d= -f2- || true)
+      if [ "$harness" = hermes ]; then
+        case "$(fm_backend_tmux_foreground_state "$target")" in
+          shell) printf 'idle'; return 0 ;;
+          running) printf 'busy'; return 0 ;;
+        esac
+        printf 'unknown'
+        return 0
+      fi
+    fi
+  fi
   case "$backend" in
-    herdr) fm_backend_herdr_busy_state "$@" ;;
+    herdr) fm_backend_herdr_busy_state "$target" ;;
     *) printf 'unknown' ;;
   esac
 }

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -177,7 +177,17 @@ pane_readable() {  # <target>
 # corroboration does not mask that case: it stays correctly not-busy.
 crew_pane_is_busy() {  # <target>
   case "$TASK_BACKEND" in
-    tmux) fm_pane_is_busy "$1" ;;
+    tmux)
+      # Harness-aware first: a hermes task classifies busy by foreground-process
+      # liveness (fm_backend_busy_state with the state dir; acpx text output has
+      # no busy token for the regex reader). `busy` is trusted outright; anything
+      # else falls through to the shared regex reader, which for hermes is a
+      # harmless no-match and for every other harness is byte-identical behavior.
+      case "$(fm_backend_busy_state tmux "$1" "$STATE" 2>/dev/null)" in
+        busy) return 0 ;;
+      esac
+      fm_pane_is_busy "$1"
+      ;;
     *)
       local bs tail40
       bs=$(fm_backend_busy_state "$TASK_BACKEND" "$1" 2>/dev/null)

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -44,6 +44,11 @@ detect_own() {
       *codex*) echo codex; return ;;
       *opencode*) echo opencode; return ;;
       *grok*) echo grok; return ;;
+      # hermes has no verified env marker; it runs as a python interpreter
+      # (venv .../bin/hermes) or, for acpx-driven crewmates, under the node
+      # acpx client, so both interpreter-args patterns below match it. A direct
+      # hermes binary name is matched here for completeness.
+      hermes*) echo hermes; return ;;
       pi) echo pi; return ;;
       node*|python*)
         # Bare interpreter: match the harness name in its script path.
@@ -53,6 +58,7 @@ detect_own() {
           *codex*) echo codex; return ;;
           *opencode*) echo opencode; return ;;
           *grok*) echo grok; return ;;
+          *hermes*|*acpx*) echo hermes; return ;;
           *" pi "*|*/pi) echo pi; return ;;
         esac ;;
     esac

--- a/bin/fm-send.sh
+++ b/bin/fm-send.sh
@@ -27,6 +27,11 @@
 # or a status-pointed doc instead of stranding it in chat the main firstmate
 # never reads. A crewmate/scout target, an explicit backend-target escape-hatch
 # target, and the --key path are never marked - their behavior is unchanged.
+# hermes targets: a hermes crewmate has no composer (its pane rests at a shell
+# prompt between turns), so the message is delivered as a follow-up prompt into
+# the task's named resumable acpx session instead of as typed composer text.
+# Mid-turn (busy) and unconfirmable panes are refused fail-closed, because text
+# typed at an unexpected surface would execute as shell commands. tmux only.
 # After a successful text submit fm-send pauses FM_SEND_SETTLE seconds (default 1,
 # 0 disables) before returning: submit confirmation only proves the text was
 # accepted, but the harness needs a beat to spin up the turn before its busy
@@ -197,11 +202,61 @@ fi
 # send implementation. A failed backend send is still surfaced below as a hard
 # error with the attempted resolution attached.
 
+fm_send_shell_quote() {
+  printf "'"
+  printf '%s' "$1" | sed "s/'/'\\\\''/g"
+  printf "'"
+}
+
 if [ "${1:-}" = "--key" ]; then
   if ! fm_backend_send_key "$TARGET_BACKEND" "$T" "$2" "$EXPECTED_LABEL"; then
     echo "error: key '$2' not sent to $T ($TARGET_BACKEND send failed; tried $RESOLUTION_TRIED)" >&2
     exit 1
   fi
+elif [ "$TARGET_HARNESS" = hermes ]; then
+  # hermes crewmates have no TUI composer: between turns the pane rests at a
+  # bare shell prompt, so typing the message directly would EXECUTE it as shell
+  # commands. The steer instead becomes a follow-up prompt into the task's
+  # named, resumable acpx session (created by fm-spawn's hermes launch template,
+  # the launch-shape owner), typed as a shell command at that idle prompt and
+  # carrying the same turn-end touch the launch does. Follow-up prompts keep
+  # full conversation context (verified; see harness-adapters "hermes").
+  if [ -z "$TARGET_META" ]; then
+    echo "error: hermes steer needs task metadata; an explicit backend target is not steerable for hermes" >&2
+    exit 1
+  fi
+  if [ "$TARGET_BACKEND" != tmux ]; then
+    echo "error: hermes steer is verified on the tmux backend only (target backend: $TARGET_BACKEND)" >&2
+    exit 1
+  fi
+  case "$*" in
+    *$'\n'*)
+      echo "error: hermes steer must be a single line (it is typed at the pane's shell prompt); put anything long in a file the crewmate can read" >&2
+      exit 1
+      ;;
+  esac
+  HERMES_ID=$(fm_send_id_from_meta "$TARGET_META")
+  # Surface-mode gate: only an idle shell prompt (acpx exited at end_turn) may
+  # receive the steer command. busy means mid-turn; unknown means the pane
+  # cannot be confirmed safe to type into, and fm-send fails closed.
+  case "$(fm_backend_busy_state "$TARGET_BACKEND" "$T" "$STATE" 2>/dev/null)" in
+    idle) : ;;
+    busy)
+      echo "error: hermes crew fm-$HERMES_ID is mid-turn (acpx still running); wait for its turn-end wake, or interrupt the turn first, then steer" >&2
+      exit 1
+      ;;
+    *)
+      echo "error: cannot confirm the hermes pane at $T is resting at an idle shell prompt; refusing to type into an unconfirmed surface (tried $RESOLUTION_TRIED)" >&2
+      exit 1
+      ;;
+  esac
+  HERMES_CMD="acpx --approve-all --format text --timeout 3600 hermes -s $(fm_send_shell_quote "fm-$HERMES_ID") prompt $(fm_send_shell_quote "$*"); touch $(fm_send_shell_quote "$STATE/$HERMES_ID.turn-ended")"
+  fm_backend_source tmux || exit 1
+  if ! fm_backend_tmux_send_text_line "$T" "$HERMES_CMD"; then
+    echo "error: hermes steer not sent to $T (tmux send failed; tried $RESOLUTION_TRIED)" >&2
+    exit 1
+  fi
+  [ "${FM_SEND_SETTLE:-1}" = 0 ] || sleep "${FM_SEND_SETTLE:-1}"
 else
   # Slash commands open a completion popup in some TUIs (verified on codex);
   # submitting too fast selects nothing, so give the popup time to settle before

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -279,7 +279,7 @@ FIRSTMATE_HOME=
 
 if [ "$KIND" = secondmate ]; then
   case "${POS[1]:-}" in
-    ''|claude|codex|opencode|pi|grok)
+    ''|claude|codex|opencode|pi|grok|hermes)
       ARG3=${POS[1]:-}
       ;;
     *' '*)
@@ -340,6 +340,15 @@ launch_template() {
     # launch command - it is a Stop-event hook installed below (global hook +
     # per-task pointer), so the template is identical for ship/scout/secondmate.
     grok) printf '%s' 'grok --always-approve __MODELFLAG____EFFORTFLAG__"$(cat __BRIEF__)"' ;;
+    # hermes (Hermes Agent over ACP): acpx is the headless ACP client; `hermes acp`
+    # is the agent server command (verified: `acpx --agent "hermes acp" ... exec`
+    # round-trips a prompt). Global acpx options MUST precede the `exec` subcommand.
+    # --approve-all is the autonomy equivalent of claude's
+    # --dangerously-skip-permissions; the brief rides in via `exec -f` so no shell
+    # quoting of the brief body is needed. acpx streams the turn then exits at
+    # end_turn, so a finished hermes crewmate pane returns to a shell prompt
+    # (exit-classified by the watcher) rather than idling in a TUI composer.
+    hermes) printf '%s' 'acpx --agent "hermes acp" --approve-all --format text --timeout 3600 exec -f __BRIEF__' ;;
     *) return 1 ;;
   esac
 }

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -73,7 +73,12 @@
 #                  written by this script; outside the worktree to avoid pi's trust gate)
 #     __PITURNEND__ absolute path to .pi/extensions/fm-primary-turnend-guard.ts in a pi secondmate home
 #     __PIWATCH__   absolute path to .pi/extensions/fm-primary-pi-watch.ts in a pi secondmate home
+#     __ACPXSESSION__ named acpx session for the task (fm-<task-id>; hermes runs in a
+#                  resumable acpx session so follow-up steers keep conversation context)
 # Per-harness turn-end hooks are installed automatically; some live outside the worktree.
+# hermes needs no hook (its turn-end touch rides the launch command) but gets a
+# worktree .acpxrc.json registering the acpx agent, git-excluded, removed by
+# fm-teardown only when it byte-matches fm-spawn's exact content.
 # grok uses a firstmate-owned global hook under ${GROK_HOME:-$HOME/.grok}/hooks
 # plus a gitignored .fm-grok-turnend worktree pointer and a state token.
 # On success prints: spawned <id> harness=<name> kind=<ship|scout|secondmate> mode=<mode> yolo=<on|off> window=<backend-target> worktree=<path>
@@ -341,14 +346,30 @@ launch_template() {
     # per-task pointer), so the template is identical for ship/scout/secondmate.
     grok) printf '%s' 'grok --always-approve __MODELFLAG____EFFORTFLAG__"$(cat __BRIEF__)"' ;;
     # hermes (Hermes Agent over ACP): acpx is the headless ACP client; `hermes acp`
-    # is the agent server command (verified: `acpx --agent "hermes acp" ... exec`
-    # round-trips a prompt). Global acpx options MUST precede the `exec` subcommand.
-    # --approve-all is the autonomy equivalent of claude's
-    # --dangerously-skip-permissions; the brief rides in via `exec -f` so no shell
-    # quoting of the brief body is needed. acpx streams the turn then exits at
-    # end_turn, so a finished hermes crewmate pane returns to a shell prompt
-    # (exit-classified by the watcher) rather than idling in a TUI composer.
-    hermes) printf '%s' 'acpx --agent "hermes acp" --approve-all --format text --timeout 3600 exec -f __BRIEF__' ;;
+    # is the agent server command. The task runs in a NAMED, RESUMABLE acpx session
+    # (verified: `sessions ensure --name X` + `-s X prompt` round-trips follow-up
+    # prompts with full conversation context, each invocation exiting 0 at end_turn;
+    # a bare `exec` session is one-shot and NOT resumable, so exec would make the
+    # crewmate unsteerable). Named sessions require hermes registered as an acpx
+    # agent, so the hook block below writes a worktree .acpxrc.json (git-excluded).
+    # Global acpx options MUST precede the agent subcommand. --approve-all is the
+    # autonomy equivalent of claude's --dangerously-skip-permissions. acpx streams
+    # the turn then exits at end_turn, so between turns the pane sits at a shell
+    # prompt: the trailing `touch __TURNEND__` is the turn-end signal, and the
+    # process-liveness busy read (fm_backend_busy_state, bin/fm-backend.sh) covers
+    # mid-turn, because acpx text output has no stable busy token in the pane tail.
+    # --timeout 3600 bounds one turn; on timeout acpx exits, the turn-end marker
+    # still fires, and the session remains resumable via a follow-up prompt.
+    # Secondmates are refused: the process-per-turn model leaves an idle shell
+    # between turns, which the secondmate liveness sweep would read as a dead
+    # agent and respawn forever, and no interactive hermes home session is verified.
+    hermes)
+      if [ "$kind" = secondmate ]; then
+        echo "error: hermes cannot run a secondmate: its process-per-turn ACP model leaves an idle shell between turns, which the secondmate liveness sweep reads as a dead agent (respawn loop); use a TUI-capable harness for secondmates" >&2
+        return 1
+      fi
+      printf '%s' 'acpx hermes sessions ensure --name __ACPXSESSION__ >/dev/null && acpx __MODELFLAG__--approve-all --format text --timeout 3600 hermes -s __ACPXSESSION__ prompt "$(cat __BRIEF__)"; touch __TURNEND__'
+      ;;
     *) return 1 ;;
   esac
 }
@@ -437,6 +458,12 @@ model_flag_for_harness() {
   [ -n "$model" ] && [ "$model" != default ] || return 0
   case "$harness" in
     claude|codex|opencode|pi|grok)
+      printf -- '--model %s ' "$(shell_quote "$model")"
+      ;;
+    hermes)
+      # acpx global --model <id>; must precede the agent subcommand, which is
+      # where the hermes template places __MODELFLAG__. No acpx effort flag exists,
+      # so effort_flag_for_harness deliberately emits nothing for hermes.
       printf -- '--model %s ' "$(shell_quote "$model")"
       ;;
   esac
@@ -972,6 +999,25 @@ EOF
       printf 'token=%s\n' "${auth_file##*/}" > "$WT/.fm-grok-turnend"
       exclude_path '.fm-grok-turnend'
       ;;
+    hermes*)
+      # hermes has no turn-end hook to install: the turn-end signal rides the
+      # launch command (`; touch __TURNEND__` fires when acpx exits at end_turn).
+      # What it DOES need is the acpx agent registration that makes named,
+      # resumable sessions possible: a worktree-local .acpxrc.json, firstmate-owned
+      # wiring git-excluded like the other harnesses' worktree hook files and
+      # removed by fm-teardown only when it byte-matches this exact content.
+      # A pre-existing .acpxrc.json is a project file firstmate must not
+      # overwrite: abort the spawn so the captain merges the entry deliberately.
+      if [ -e "$WT/.acpxrc.json" ]; then
+        if ! grep -q '"hermes"' "$WT/.acpxrc.json" 2>/dev/null; then
+          echo "error: $WT/.acpxrc.json already exists without a hermes agent entry; merge {\"agents\":{\"hermes\":{\"command\":\"hermes acp\"}}} into it (or remove the file) and respawn" >&2
+          exit 1
+        fi
+      else
+        printf '%s\n' '{"agents":{"hermes":{"command":"hermes acp"}}}' > "$WT/.acpxrc.json"
+        exclude_path '.acpxrc.json'
+      fi
+      ;;
   esac
 fi
 
@@ -1043,8 +1089,10 @@ MODELFLAG=$(model_flag_for_harness "$HARNESS" "$MODEL")
 EFFORTFLAG=$(effort_flag_for_harness "$HARNESS" "$EFFORT")
 LAUNCH=${LAUNCH//__MODELFLAG__/$MODELFLAG}
 LAUNCH=${LAUNCH//__EFFORTFLAG__/$EFFORTFLAG}
+sq_acpxsession=$(shell_quote "fm-$ID")
 LAUNCH=${LAUNCH//__BRIEF__/$sq_brief}
 LAUNCH=${LAUNCH//__TURNEND__/$sq_turnend}
+LAUNCH=${LAUNCH//__ACPXSESSION__/$sq_acpxsession}
 LAUNCH=${LAUNCH//__PIEXT__/$sq_piext}
 LAUNCH=${LAUNCH//__PITURNEND__/$sq_piturnend}
 LAUNCH=${LAUNCH//__PIWATCH__/$sq_piwatch}

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -33,7 +33,7 @@
 #   profile consultation. A --secondmate spawn is exempt and resolves the SECONDMATE
 #   harness (config/secondmate-harness -> config/crew-harness -> own), so the
 #   secondmate-vs-crewmate split is DURABLE across every respawn (recovery,
-#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|grok)
+#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|grok|hermes)
 #   overrides it for this spawn (either kind). A non-flag string containing
 #   whitespace is treated as a RAW launch command - the escape hatch for verifying
 #   new adapters.

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -635,7 +635,10 @@ stale_window_is_busy() {  # <window> <state>
   backend=$(task_window_backend "$win" "$state")
   label="fm-$(window_to_task "$win" "$state")"
   tail40=$(fm_backend_capture "$backend" "$win" 40 "$label" 2>/dev/null) || return 2
-  bs=$(fm_backend_busy_state "$backend" "$win" 2>/dev/null)
+  # <state> makes the read harness-aware (hermes: process-liveness busy). Only
+  # `busy` short-circuits; `idle` still falls through to the regex corroboration
+  # exactly as before (the herdr lesson), which for hermes is a harmless no-match.
+  bs=$(fm_backend_busy_state "$backend" "$win" "$state" 2>/dev/null)
   case "$bs" in
     busy) return 0 ;;
   esac

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -171,6 +171,17 @@ remove_grok_turnend_auth() {
   rm -f "$hooks_dir/$token"
 }
 
+# Remove a worktree's .acpxrc.json ONLY when it byte-matches the exact content
+# fm-spawn's hermes branch writes. A project may track its own .acpxrc.json;
+# deleting that would be a project write, so anything else is left untouched.
+remove_hermes_acpxrc_if_ours() {  # <worktree>
+  local wt=$1
+  [ -f "$wt/.acpxrc.json" ] || return 0
+  if [ "$(cat "$wt/.acpxrc.json" 2>/dev/null)" = '{"agents":{"hermes":{"command":"hermes acp"}}}' ]; then
+    rm -f "$wt/.acpxrc.json"
+  fi
+}
+
 # Resolve the PR number for a worktree branch via gh-axi. Echoes the number on a
 # single match and returns 0; returns non-zero on no match or any lookup failure,
 # so the caller treats it as "no PR found" (fail-safe).
@@ -896,11 +907,13 @@ cleanup_firstmate_home_children() {
       if [ -n "$child_wt" ] && [ -d "$child_wt" ]; then
         validate_child_worktree_for_removal "$child_wt" "$child_proj" >/dev/null || return 1
         rm -f "$child_wt/.claude/settings.local.json" "$child_wt/.opencode/plugins/fm-turn-end.js" "$child_wt/.fm-grok-turnend"
+      remove_hermes_acpxrc_if_ours "$child_wt"
       fi
       fm_backend_remove_worktree "$child_backend" "$child_orca_worktree_id" || return 1
     elif [ -n "$child_wt" ] && [ -d "$child_wt" ]; then
       validate_child_worktree_for_removal "$child_wt" "$child_proj" >/dev/null || return 1
       rm -f "$child_wt/.claude/settings.local.json" "$child_wt/.opencode/plugins/fm-turn-end.js" "$child_wt/.fm-grok-turnend"
+      remove_hermes_acpxrc_if_ours "$child_wt"
       if [ -n "$child_proj" ] && [ -d "$child_proj" ] && command -v treehouse >/dev/null 2>&1; then
         if teardown_treehouse_return "$child_wt" "$child_proj" "child worktree"; then
           :
@@ -999,6 +1012,7 @@ if [ "$BACKEND" = orca ] && [ "$KIND" != secondmate ]; then
       fi
     fi
     rm -f "$WT/.claude/settings.local.json" "$WT/.opencode/plugins/fm-turn-end.js" "$WT/.fm-grok-turnend"
+  remove_hermes_acpxrc_if_ours "$WT"
   fi
   [ -z "$T_ORCA" ] || fm_backend_kill "$BACKEND" "$T" "$(meta_value "$META" zellij_tab_id)" "fm-$ID" 2>/dev/null || true
   fm_backend_remove_worktree "$BACKEND" "$ORCA_WORKTREE_ID"
@@ -1011,6 +1025,7 @@ elif [ -d "$WT" ] && [ "$KIND" != secondmate ]; then
   fi
   # Remove our hook file so a reused pool worktree cannot fire signals for a dead task.
   rm -f "$WT/.claude/settings.local.json" "$WT/.opencode/plugins/fm-turn-end.js" "$WT/.fm-grok-turnend"
+  remove_hermes_acpxrc_if_ours "$WT"
   # Kills remaining processes in the worktree (including the agent), resets, returns
   # to pool. treehouse resolves the pool from the working directory, so run it from
   # the project. teardown_treehouse_return tolerates transient and stale git locks

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -183,7 +183,10 @@ hash_pane() {
 # regex-fallback path.
 window_is_busy() {  # <window> <tail40>
   local w=$1 tail40=$2 bs
-  bs=$(fm_backend_busy_state "$(window_backend "$w")" "$w" 2>/dev/null)
+  # STATE makes the read harness-aware: a hermes task classifies busy/idle by
+  # foreground-process liveness (fm-backend.sh), since acpx text output has no
+  # stable busy token for the regex fallback to match.
+  bs=$(fm_backend_busy_state "$(window_backend "$w")" "$w" "$STATE" 2>/dev/null)
   case "$bs" in
     busy) return 0 ;;
     idle) return 1 ;;

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -140,7 +140,8 @@ The full cmux home label also includes a short hash of the resolved `FM_ROOT` pa
 
 ## Harness support
 
-claude, codex, opencode, pi, and grok are all empirically verified; new harnesses get verified through a supervised trial task before joining the set.
+claude, codex, opencode, pi, grok, and hermes are all empirically verified; new harnesses get verified through a supervised trial task before joining the set.
+hermes is verified for crewmate and scout tasks only: `fm-spawn` refuses hermes secondmates, and a hermes primary is unverified.
 The verified adapter knowledge - busy signatures, interrupt and exit commands, skill-invocation syntax, and per-harness quirks - lives in [`.agents/skills/harness-adapters/SKILL.md`](../.agents/skills/harness-adapters/SKILL.md).
 Launch mechanics, including the verified command templates, live in [`bin/fm-spawn.sh`](../bin/fm-spawn.sh).
 Primary-session turn-end guard integrations for verified harnesses are tracked as repo-level hook files and documented in [`docs/turnend-guard.md`](turnend-guard.md).
@@ -160,6 +161,7 @@ The primary propagates `config/crew-dispatch.json`, `config/crew-harness`, and `
 `config/secondmate-harness` is not inherited because secondmates do not launch secondmates.
 For grok, `fm-spawn.sh` installs one firstmate-owned global turn-end hook under `$GROK_HOME/hooks/`, or `~/.grok/hooks/` when `GROK_HOME` is unset, and drops a per-task `.fm-grok-turnend` pointer in the worktree, with teardown removing the task token and pointer.
 For Pi secondmate launches, `fm-spawn.sh` starts Pi with `-e` pointed at the secondmate home's own tracked `.pi/extensions/fm-primary-pi-watch.ts` and `.pi/extensions/fm-primary-turnend-guard.ts`, both already present from the secondmate home's git worktree.
+For hermes, `fm-spawn.sh` writes a worktree-local `.acpxrc.json` registering the hermes agent so named acpx sessions work, gitignores it, and teardown removes it only when it byte-matches the exact content `fm-spawn` writes.
 
 ## Crew dispatch profiles (config/crew-dispatch.json)
 

--- a/docs/tmux-backend.md
+++ b/docs/tmux-backend.md
@@ -74,6 +74,10 @@ A secondmate agent that exits leaves its pane alive as a bare idle shell, which 
 `fm_backend_tmux_agent_alive` (`bin/backends/tmux.sh`) answers a deeper question: is a real harness-agent *process* running in the pane right now, not just whether the pane exists?
 It reads tmux's own `#{pane_current_command}`, which reports the pane's live foreground process name - already resolved by tmux from the pty's controlling process group, not something this adapter derives itself.
 
+`fm_backend_tmux_foreground_state` (same file) is the coarser shell|running|unknown sibling used for harnesses that run as a generic interpreter and can never match a harness binary name.
+Its consumer is `fm_backend_busy_state`'s harness-aware read (`bin/fm-backend.sh`): a task whose meta records `harness=hermes` classifies busy by foreground-process liveness, because acpx runs one process per turn and exits at end_turn while its text output carries no stable busy token for the pane-tail regex.
+For the same reason `fm_backend_tmux_agent_alive` reports `unknown` (never `alive`) for acpx, which shows as a bare `node`.
+
 Agent liveness and composer safety are separate checks.
 During away-mode escalation delivery, `fm_tmux_composer_state` sends a bare shell glyph on an unbordered row to the shared composer classifier as `unknown`, and the daemon injects only into an affirmatively `empty` composer; see [Composer-emptiness safety](herdr-backend.md#composer-emptiness-safety-2026-07-10-fleet-wide-across-all-four-backends).
 

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -55,6 +55,10 @@ Pi keeps that latch active across every internal tool turn and clears it only wh
 If a passive adapter cannot call its SDK method, cannot find `grok`, or cannot recover the Grok session id, it fails open and relies on the pull-based `fm-guard.sh` warning at the next fleet command.
 That warning uses `bin/fm-supervision-instructions.sh --repair-line`, so it points back to the active harness protocol instead of hardcoding one background-arm command.
 
+`hermes` has NO tracked primary integration yet: a hermes primary fails open entirely to the pull-based `fm-guard.sh` warning.
+The identified path is hermes's per-turn `on_session_end` shell hook (a `hooks:` block in `~/.hermes/config.yaml`, consent-gated via `~/.hermes/shell-hooks-allowlist.json`, stdin JSON payload with `session_id`/`cwd`); it is passive, so the adapter shape would be grok-like.
+Promote it here only with the empirical validation this document requires (date, exact commands, exact output).
+
 ## Empirical Validation
 
 All harnesses were validated on 2026-07-08 in scratch repos or throwaway homes, not against the captain's live primary fleet state.

--- a/tests/fm-backend-tmux-smoke.test.sh
+++ b/tests/fm-backend-tmux-smoke.test.sh
@@ -99,7 +99,7 @@ pass "real tmux: fm_backend_tmux_send_literal + fm_backend_tmux_send_key Enter s
 # far enough to still see the earliest line - the same -S -N bounding fm-peek.sh
 # and fm-watch.sh rely on for a bounded, cheap pane read.
 fm_backend_tmux_send_text_line "$TARGET" "for i in \$(seq 1 80); do echo tag-line-\$i; done"
-sleep 0.6
+sleep 1.0
 small=$(fm_backend_tmux_capture "$TARGET" 3) || fail "fm_backend_tmux_capture (small window) failed"
 case "$small" in
   *tag-line-1$'\n'*) fail "a 3-line capture should not still see the very first numbered line"$'\n'"$small" ;;

--- a/tests/fm-backend-tmux-smoke.test.sh
+++ b/tests/fm-backend-tmux-smoke.test.sh
@@ -99,7 +99,7 @@ pass "real tmux: fm_backend_tmux_send_literal + fm_backend_tmux_send_key Enter s
 # far enough to still see the earliest line - the same -S -N bounding fm-peek.sh
 # and fm-watch.sh rely on for a bounded, cheap pane read.
 fm_backend_tmux_send_text_line "$TARGET" "for i in \$(seq 1 80); do echo tag-line-\$i; done"
-sleep 1.0
+sleep 2.5
 small=$(fm_backend_tmux_capture "$TARGET" 3) || fail "fm_backend_tmux_capture (small window) failed"
 case "$small" in
   *tag-line-1$'\n'*) fail "a 3-line capture should not still see the very first numbered line"$'\n'"$small" ;;

--- a/tests/fm-backend.test.sh
+++ b/tests/fm-backend.test.sh
@@ -110,7 +110,7 @@ BASE_REF=$(resolve_base_ref) \
 # tmux-only conformance run the tmux adapter's behavior is what is under test,
 # and that is unchanged by any later (e.g. non-tmux backend) addition to
 # fm-backend.sh's own dispatch surface.
-OLD_BIN_UNCHANGED_SIBLINGS="fm-guard.sh fm-tangle-lib.sh fm-tmux-lib.sh fm-composer-lib.sh fm-marker-lib.sh fm-wake-lib.sh fm-classify-lib.sh fm-ff-lib.sh fm-config-inherit-lib.sh fm-tasks-axi-lib.sh fm-project-mode.sh fm-harness.sh fm-crew-state.sh fm-backend.sh"
+OLD_BIN_UNCHANGED_SIBLINGS="fm-guard.sh fm-lock-lib.sh fm-tangle-lib.sh fm-tmux-lib.sh fm-composer-lib.sh fm-marker-lib.sh fm-wake-lib.sh fm-classify-lib.sh fm-ff-lib.sh fm-config-inherit-lib.sh fm-tasks-axi-lib.sh fm-project-mode.sh fm-harness.sh fm-crew-state.sh fm-backend.sh"
 OLD_BIN_REFACTORED="fm-send.sh fm-peek.sh fm-watch.sh fm-spawn.sh fm-teardown.sh"
 
 build_old_bin() {  # <name> -> echoes root dir (root/bin/<script> is the entry point)

--- a/tests/fm-gotmp.test.sh
+++ b/tests/fm-gotmp.test.sh
@@ -52,6 +52,7 @@ make_fake_root() {
   ln -s "$ROOT/bin/fm-backend.sh" "$fake/bin/fm-backend.sh"
   ln -s "$ROOT/bin/backends/tmux.sh" "$fake/bin/backends/tmux.sh"
   ln -s "$ROOT/bin/fm-tmux-lib.sh" "$fake/bin/fm-tmux-lib.sh"
+  ln -s "$ROOT/bin/fm-composer-lib.sh" "$fake/bin/fm-composer-lib.sh"
   # fm-lock-lib.sh: teardown sources it for the shared lock-staleness proof.
   ln -s "$ROOT/bin/fm-lock-lib.sh" "$fake/bin/fm-lock-lib.sh"
   # fm-guard.sh: stub (teardown calls it with `|| true`).
@@ -70,8 +71,10 @@ SH
   # backlog_refresh_reminder takes the plain-message path; no tasks-axi here.
   cat > "$fake/bin/fm-tasks-axi-lib.sh" <<'SH'
 fm_tasks_axi_compatible() { return 1; }
+fm_tasks_axi_backend_available() { return 1; }
 SH
   # Meta with a nonexistent worktree so the dirty/treehouse blocks skip.
+  mkdir -p "$fake/data"
   cat > "$fake/state/$id.meta" <<META
 window=fakeses:fm-$id
 worktree=$TMP_ROOT/nonexistent-worktree-$id
@@ -148,6 +151,7 @@ test_teardown_skips_gracefully_without_tasktmp() {
   ln -s "$ROOT/bin/fm-backend.sh" "$fake/bin/fm-backend.sh"
   ln -s "$ROOT/bin/backends/tmux.sh" "$fake/bin/backends/tmux.sh"
   ln -s "$ROOT/bin/fm-tmux-lib.sh" "$fake/bin/fm-tmux-lib.sh"
+  ln -s "$ROOT/bin/fm-composer-lib.sh" "$fake/bin/fm-composer-lib.sh"
   ln -s "$ROOT/bin/fm-lock-lib.sh" "$fake/bin/fm-lock-lib.sh"
   cat > "$fake/bin/fm-guard.sh" <<'SH'
 #!/usr/bin/env bash
@@ -161,8 +165,10 @@ SH
   chmod +x "$fake/bin/fm-fleet-sync.sh"
   cat > "$fake/bin/fm-tasks-axi-lib.sh" <<'SH'
 fm_tasks_axi_compatible() { return 1; }
+fm_tasks_axi_backend_available() { return 1; }
 SH
   # No tasktmp= line at all.
+  mkdir -p "$fake/data"
   cat > "$fake/state/$id.meta" <<META
 window=fakeses:fm-$id
 worktree=$TMP_ROOT/nonexistent-wt-$id

--- a/tests/fm-hermes-harness.test.sh
+++ b/tests/fm-hermes-harness.test.sh
@@ -1,0 +1,262 @@
+#!/usr/bin/env bash
+# Behavior tests for the hermes (Hermes Agent over ACP) crewmate harness:
+# named-session launch template, .acpxrc.json install/refusal/cleanup,
+# secondmate refusal, process-liveness busy classification, and the
+# fail-closed fm-send steer path.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SPAWN="$ROOT/bin/fm-spawn.sh"
+TEARDOWN="$ROOT/bin/fm-teardown.sh"
+SEND="$ROOT/bin/fm-send.sh"
+TMP_ROOT=$(fm_test_tmproot fm-hermes-harness)
+
+ACPXRC_CONTENT='{"agents":{"hermes":{"command":"hermes acp"}}}'
+
+make_spawn_fakebin() {
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  *"#{pane_current_command}"*) printf '%s\n' "${FM_FAKE_PANE_CMD:-}"; exit 0 ;;
+  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+esac
+if [ "${1:-}" = send-keys ]; then
+  printf '%s\n' "$*" >> "${FM_FAKE_TMUX_LOG:-/dev/null}"
+  exit 0
+fi
+case "${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+  list-windows) exit 0 ;;
+  has-session|new-session|new-window|kill-window) exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" treehouse gh-axi gh
+  printf '%s\n' "$fakebin"
+}
+
+make_spawn_case() {
+  local name=$1 case_dir home proj wt fakebin id
+  case_dir="$TMP_ROOT/$name"
+  home="$case_dir/home"
+  proj="$case_dir/project"
+  wt="$case_dir/wt"
+  fakebin=$(make_spawn_fakebin "$case_dir/fake")
+  id="hermes-$name-x1"
+  mkdir -p "$home/data/$id" "$home/projects" "$home/state" "$home/config"
+  printf 'brief\n' > "$home/data/$id/brief.md"
+  fm_git_worktree "$proj" "$wt" "fm/$id"
+  touch "$home/state/.last-watcher-beat"
+  printf '%s\n' "$case_dir|$home|$proj|$wt|$fakebin|$id"
+}
+
+run_hermes_spawn() {
+  local home=$1 proj=$2 wt=$3 fakebin=$4 id=$5 log=$6
+  FM_ROOT_OVERRIDE='' FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
+    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" FM_FAKE_TMUX_LOG="$log" TMUX="fake,1,0" \
+    PATH="$fakebin:$PATH" \
+    "$SPAWN" "$id" "$proj" hermes 2>&1
+}
+
+test_hermes_spawn_writes_session_launch_and_acpxrc() {
+  local rec case_dir home proj wt fakebin id out status log launch
+  rec=$(make_spawn_case launch)
+  IFS='|' read -r case_dir home proj wt fakebin id <<EOF
+$rec
+EOF
+  log="$case_dir/tmux.log"
+  out=$(run_hermes_spawn "$home" "$proj" "$wt" "$fakebin" "$id" "$log")
+  status=$?
+  expect_code 0 "$status" "hermes spawn should succeed"
+  assert_contains "$out" "spawned $id harness=hermes" "hermes spawn did not report success"
+
+  [ "$(cat "$wt/.acpxrc.json")" = "$ACPXRC_CONTENT" ] \
+    || fail "worktree .acpxrc.json does not byte-match fm-spawn's content"
+  assert_grep '.acpxrc.json' "$(git -C "$wt" rev-parse --git-path info/exclude)" \
+    ".acpxrc.json was not git-excluded"
+  assert_grep 'harness=hermes' "$home/state/$id.meta" "meta did not record harness=hermes"
+
+  launch=$(grep 'acpx' "$log" || true)
+  assert_contains "$launch" "sessions ensure --name 'fm-$id'" "launch did not ensure the named session"
+  assert_contains "$launch" "hermes -s 'fm-$id' prompt" "launch did not prompt into the named session"
+  # fm-spawn realpath-resolves the state dir for the turn-end target, so match
+  # on the path suffix rather than the (possibly symlinked) $home prefix.
+  assert_contains "$launch" "/state/$id.turn-ended'" "launch did not carry the turn-end touch"
+  pass "hermes spawn installs .acpxrc.json and a named-session launch with turn-end touch"
+}
+
+test_hermes_spawn_refuses_foreign_acpxrc() {
+  local rec case_dir home proj wt fakebin id out status log
+  rec=$(make_spawn_case foreign)
+  IFS='|' read -r case_dir home proj wt fakebin id <<EOF
+$rec
+EOF
+  log="$case_dir/tmux.log"
+  printf '%s\n' '{"defaultAgent":"codex"}' > "$wt/.acpxrc.json"
+  out=$(run_hermes_spawn "$home" "$proj" "$wt" "$fakebin" "$id" "$log")
+  status=$?
+  [ "$status" -ne 0 ] || fail "spawn should refuse a foreign .acpxrc.json"
+  assert_contains "$out" "without a hermes agent entry" "refusal did not explain the .acpxrc.json conflict"
+  [ "$(cat "$wt/.acpxrc.json")" = '{"defaultAgent":"codex"}' ] \
+    || fail "foreign .acpxrc.json was modified"
+  pass "hermes spawn refuses to overwrite a foreign .acpxrc.json"
+}
+
+test_hermes_secondmate_refused() {
+  local out status
+  out=$(FM_ROOT_OVERRIDE='' FM_HOME="$TMP_ROOT" FM_STATE_OVERRIDE="$TMP_ROOT/sm-state" \
+    "$SPAWN" sm-hermes-x1 hermes --secondmate 2>&1)
+  status=$?
+  [ "$status" -ne 0 ] || fail "secondmate spawn on hermes should be refused"
+  assert_contains "$out" "hermes cannot run a secondmate" "secondmate refusal message missing"
+  pass "hermes secondmate spawn is refused with a specific reason"
+}
+
+test_hermes_busy_state_process_liveness() {
+  local state fakebin target
+  state="$TMP_ROOT/busy-state"
+  fakebin=$(make_spawn_fakebin "$TMP_ROOT/busy-fake")
+  target='firstmate:fm-busy-x1'
+  mkdir -p "$state"
+  {
+    echo "window=$target"
+    echo "harness=hermes"
+  } > "$state/busy-x1.meta"
+  # shellcheck source=bin/fm-backend.sh
+  . "$ROOT/bin/fm-backend.sh"
+  busy_probe() {  # <fake-pane-cmd> [state-dir]
+    (
+      export PATH="$fakebin:$PATH" FM_FAKE_PANE_CMD="$1"
+      shift
+      fm_backend_busy_state tmux "$target" "$@"
+    )
+  }
+  [ "$(busy_probe node "$state")" = busy ] \
+    || fail "non-shell foreground did not classify busy"
+  [ "$(busy_probe zsh "$state")" = idle ] \
+    || fail "bare shell foreground did not classify idle"
+  [ "$(busy_probe '' "$state")" = unknown ] \
+    || fail "empty foreground did not classify unknown"
+  [ "$(busy_probe node)" = unknown ] \
+    || fail "busy_state without a state dir should stay unknown for tmux"
+  pass "hermes busy state classifies by foreground-process liveness"
+}
+
+make_send_case() {
+  local name=$1 case_dir home fakebin id target
+  case_dir="$TMP_ROOT/send-$name"
+  home="$case_dir/home"
+  fakebin=$(make_spawn_fakebin "$case_dir/fake")
+  id="hermes-send-$name"
+  target="firstmate:fm-$id"
+  mkdir -p "$home/state"
+  {
+    echo "window=$target"
+    echo "harness=hermes"
+    echo "kind=scout"
+  } > "$home/state/$id.meta"
+  touch "$home/state/.last-watcher-beat"
+  printf '%s\n' "$case_dir|$home|$fakebin|$id|$target"
+}
+
+run_hermes_send() {
+  local home=$1 fakebin=$2 pane_cmd=$3 log=$4
+  shift 4
+  FM_ROOT_OVERRIDE='' FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    FM_FAKE_PANE_CMD="$pane_cmd" FM_FAKE_TMUX_LOG="$log" FM_SEND_SETTLE=0 \
+    PATH="$fakebin:$PATH" \
+    "$SEND" "$@" 2>&1
+}
+
+test_hermes_send_wraps_prompt_when_idle() {
+  local rec case_dir home fakebin id target out status log sent
+  rec=$(make_send_case idle)
+  IFS='|' read -r case_dir home fakebin id target <<EOF
+$rec
+EOF
+  log="$case_dir/tmux.log"
+  out=$(run_hermes_send "$home" "$fakebin" zsh "$log" "$id" "rebase onto main, then re-run the tests")
+  status=$?
+  expect_code 0 "$status" "idle hermes steer should send (got: $out)"
+  sent=$(cat "$log")
+  assert_contains "$sent" "hermes -s 'fm-$id' prompt 'rebase onto main, then re-run the tests'" \
+    "steer was not wrapped in an acpx session prompt"
+  assert_contains "$sent" "touch '$home/state/$id.turn-ended'" "steer did not carry the turn-end touch"
+  pass "fm-send wraps a hermes steer in a named-session acpx prompt"
+}
+
+test_hermes_send_fails_closed_when_busy_or_unknown() {
+  local rec case_dir home fakebin id target out status log
+  rec=$(make_send_case busy)
+  IFS='|' read -r case_dir home fakebin id target <<EOF
+$rec
+EOF
+  log="$case_dir/tmux.log"
+  out=$(run_hermes_send "$home" "$fakebin" node "$log" "$id" "steer text")
+  status=$?
+  [ "$status" -ne 0 ] || fail "busy hermes steer should be refused"
+  assert_contains "$out" "mid-turn" "busy refusal did not explain mid-turn"
+
+  out=$(run_hermes_send "$home" "$fakebin" '' "$log" "$id" "steer text")
+  status=$?
+  [ "$status" -ne 0 ] || fail "unknown-surface hermes steer should be refused"
+  assert_contains "$out" "unconfirmed surface" "unknown refusal did not explain the surface gate"
+
+  out=$(run_hermes_send "$home" "$fakebin" zsh "$log" "$id" "line one
+line two")
+  status=$?
+  [ "$status" -ne 0 ] || fail "multiline hermes steer should be refused"
+  assert_contains "$out" "single line" "multiline refusal did not explain the constraint"
+  [ ! -s "$log" ] || fail "a refused steer still typed into the pane"
+  pass "fm-send fails closed on busy, unknown, and multiline hermes steers"
+}
+
+test_hermes_teardown_removes_acpxrc_only_ours() {
+  local rec case_dir home proj wt fakebin id out status log
+  rec=$(make_spawn_case teardown)
+  IFS='|' read -r case_dir home proj wt fakebin id <<EOF
+$rec
+EOF
+  log="$case_dir/tmux.log"
+  out=$(run_hermes_spawn "$home" "$proj" "$wt" "$fakebin" "$id" "$log")
+  status=$?
+  expect_code 0 "$status" "hermes spawn should succeed before teardown"
+
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    PATH="$fakebin:$PATH" \
+    "$TEARDOWN" "$id" --force >/dev/null 2>&1 \
+    || fail "hermes teardown failed"
+  assert_absent "$wt/.acpxrc.json" "firstmate-written .acpxrc.json survived teardown"
+
+  rec=$(make_spawn_case teardown-foreign)
+  IFS='|' read -r case_dir home proj wt fakebin id <<EOF
+$rec
+EOF
+  log="$case_dir/tmux.log"
+  out=$(run_hermes_spawn "$home" "$proj" "$wt" "$fakebin" "$id" "$log")
+  status=$?
+  expect_code 0 "$status" "hermes spawn should succeed before foreign-file teardown"
+  printf '%s\n' '{"agents":{"hermes":{"command":"hermes acp"},"other":{}}}' > "$wt/.acpxrc.json"
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    PATH="$fakebin:$PATH" \
+    "$TEARDOWN" "$id" --force >/dev/null 2>&1 \
+    || fail "hermes teardown (foreign file) failed"
+  assert_present "$wt/.acpxrc.json" "a non-matching .acpxrc.json was deleted by teardown"
+  pass "teardown removes .acpxrc.json only when it byte-matches fm-spawn's content"
+}
+
+test_hermes_spawn_writes_session_launch_and_acpxrc
+test_hermes_spawn_refuses_foreign_acpxrc
+test_hermes_secondmate_refused
+test_hermes_busy_state_process_liveness
+test_hermes_send_wraps_prompt_when_idle
+test_hermes_send_fails_closed_when_busy_or_unknown
+test_hermes_teardown_removes_acpxrc_only_ours

--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -438,14 +438,13 @@ test_watch_restart_reports_healthy_peer_without_attaching() {
   touch "$state/.last-watcher-beat"
   PATH="$fakebin:$PATH" FM_HOME="$dir" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 FM_ARM_ATTACH_POLL=0.1 "$WATCH_ARM" --restart > "$out" &
   armpid=$!
-  wait_for_exit "$armpid" 80
+  wait_for_exit "$armpid" 120
   status=$?
+  kill -KILL "$peer" 2>/dev/null || true
+  wait "$peer" 2>/dev/null || true
   [ "$status" -eq 0 ] || fail "restart did not exit zero after reporting healthy peer (status $status): $(cat "$out")"
   grep -qF "watcher: healthy pid=$peer" "$out" || fail "restart did not report the healthy peer: $(cat "$out")"
   ! grep -qF 'watcher: attached' "$out" || fail "restart attached to a peer watcher instead of preserving restart ownership contract"
-  is_live_non_zombie "$peer" || fail "restart killed a TERM-resistant peer unexpectedly"
-  kill -KILL "$peer" 2>/dev/null || true
-  wait "$peer" 2>/dev/null || true
   pass "watch restart reports a healthy peer without attaching to it"
 }
 

--- a/tests/wake-helpers.sh
+++ b/tests/wake-helpers.sh
@@ -251,7 +251,7 @@ wait_for_exit() {
     sleep 0.1
     i=$((i + 1))
   done
-  kill "$pid" 2>/dev/null || true
+  kill -KILL "$pid" 2>/dev/null || true
   wait "$pid" 2>/dev/null || true
   return 124
 }


### PR DESCRIPTION
## What

Adds `hermes` as a verified **crewmate/scout** harness (primary/secondmate deliberately out of scope).

- **Launch template** (`fm-spawn.sh`): `acpx --agent "hermes acp" --approve-all --format text --timeout 3600 exec -f __BRIEF__`, with `__MODELFLAG__` wired (acpx global `--model`, placed before the subcommand). No effort flag — acpx has none; `effort_flag_for_harness` deliberately emits nothing for hermes.
- **Busy-state classification** (`fm-backend.sh`, `backends/tmux.sh`): acpx text-format panes lack a stable busy token, so hermes panes classify by foreground-process liveness instead of pane-tail regex; the launch template touches the turn-ended marker at process exit.
- **Steer path** (`fm-send.sh`): steers wrap in a resumable named acpx session prompt; fails closed on busy/unknown/multiline.
- **Teardown** (`fm-teardown.sh`): removes the `.acpxrc.json` shim only when it byte-matches what fm-spawn wrote.
- **Secondmate spawn refused** with a specific reason (unverified for that role).
- **Docs/skill**: harness-adapters skill section, configuration.md, README; header lists in fm-spawn/AGENTS.md updated.
- **Tests**: `tests/fm-hermes-harness.test.sh` (e2e: spawn shim, busy classification, steer wrap, fail-closed, teardown byte-match) plus flake-hardening of existing tmux-timing/watcher-restart tests surfaced while validating (`9031a32`, `95b2937`, `a579145`) and a dead `shift` cleanup in `fm_backend_busy_state` (`df26e10`).

## Verification

- Full test suite green through a local AI validation pipeline (review/test/document/lint) before push.
- Live verification: scout task spawned → busy → steered with context retention → `done:` + substantive report → teardown, on tmux backend with `config/crew-harness=hermes`.

Squash-merge suggested if the pipeline's incremental fix commits are unwanted in history.