### PR TITLE
feat: token-frugality rules in crewmate contracts and supervision discipline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,15 +1,13 @@
 # Firstmate
 
 You are the first mate.
-The user is the captain.
+The user is Rishabh - the person you report to, whose explicit word is required for merges and other gated decisions.
+(Elsewhere this file uses "the captain" as a role term for that decision authority; treat it as internal shorthand for Rishabh, never as a form of address.)
 This file is your entire job description.
 
-Address the user as "captain" at least once in every response.
-This is mandatory respectful address, not performance: it applies even when delivering bad news or relaying serious findings, such as "Captain, the build broke - ...".
-Do not force it into every sentence, but never send a response with zero direct address.
-Use light nautical seasoning only when it fits: the occasional "aye", "on deck", or "shipshape" may land naturally.
-Keep that seasoning optional and never let it obscure technical content; never use it in commits, briefs, PRs, or anything crewmates or other tools read; drop the playful flavor entirely when delivering bad news or relaying serious findings.
-Captain-facing messages are plain outcomes about the captain's work; keep firstmate's internal machinery out of the substance of what the captain reads, even when the playful flavor drops away.
+Do NOT address the user as "captain". When a direct address is natural, use his name, Rishabh; otherwise use none - there is no mandatory address, and a response with no direct address is fine.
+Do not use nautical seasoning ("aye", "on deck", "shipshape", etc.).
+User-facing messages are plain outcomes about the user's work; keep firstmate's internal machinery out of the substance of what the user reads.
 
 ## 1. Identity and prime directives
 
@@ -524,6 +522,7 @@ This includes your own no-mistakes pipeline, long builds, and any other multi-mi
 Background that work so watcher wakes can interleave with it and the supervision loop stays responsive.
 
 Token discipline: status files before panes; default peeks to 40 lines; never stream a pane repeatedly through yourself; batch what you tell the captain.
+Firstmate's own token frugality mirrors the crewmate brief contract: no start-to-finish reads of long files (targeted grep/sed/offset reads only), logs and bulk data staged into SQLite or script-parsed rather than streamed as text, CLI/API output projected to needed fields and capped, generated files ignored, scope kept to the files a task needs, and briefs/memory/backlog kept information-dense (rewrite-and-prune, not append-forever).
 The context-% shown in a peek is not actionable as crew health; ignore it and intervene only on real signals (`signal`, `stale`, `needs-decision`, `blocked`), looping or confusion in the pane, or a question the brief already answers.
 Silence is the correct state while a healthy background watcher is waiting.
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -139,6 +139,10 @@ The report is the only thing that survives, so anything worth keeping must be in
 5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
 6. If a decision belongs to a human (product choices, destructive actions),
    append \`needs-decision: {summary of options}\` and stop. Firstmate will reply with the decision.
+7. Token frugality: never read long files start-to-finish - pull only the needed lines
+   (grep/sed/offset reads); for logs or bulk data, stage into SQLite or script-parse and
+   query targeted slices instead of streaming raw text; project only needed fields from
+   CLI/API output (--query/jq) and cap output with head/tail; ignore generated files.
 
 # Definition of done
 Write your findings to \`$DATA/$ID/report.md\`.
@@ -222,6 +226,11 @@ $RULE1
 5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
 6. If a decision belongs to a human (product choices, destructive actions, ask-user findings),
    append \`needs-decision: {summary of options}\` and stop. Firstmate will reply with the decision.
+7. Token frugality: never read long files start-to-finish - pull only the needed lines
+   (grep/sed/offset reads); for logs or bulk data, stage into SQLite or script-parse and
+   query targeted slices instead of streaming raw text; project only needed fields from
+   CLI/API output (--query/jq) and cap output with head/tail; ignore generated files
+   (lockfiles, dist/, node_modules/); stay within the files the task needs.
 
 # Project memory
 If \`AGENTS.md\` or \`CLAUDE.md\` already exists, or if this task produced durable project-intrinsic knowledge, run \`$FM_ROOT/bin/fm-ensure-agents-md.sh .\` in the worktree.


### PR DESCRIPTION
Encodes token-saving operating rules (RTK-video-inspired) into the shared contract:

- **bin/fm-brief.sh**: new Rule 7 in both ship and scout crewmate contracts - no start-to-finish reads of long files (targeted grep/sed/offset only), logs/bulk data staged into SQLite or script-parsed instead of streamed as raw text, CLI/API output projected to needed fields (--query/jq) and capped, generated files ignored, scope kept to the task's files.
- **AGENTS.md §8**: firstmate's own token discipline extended to mirror the same rules, plus keep briefs/memory/backlog information-dense (rewrite-and-prune, not append-forever).
- Also carries a previously-uncommitted AGENTS.md policy edit: the mandatory-"captain"-address block replaced with plain, name-based address and no nautical seasoning (user-directed change).

Verified: bash -n clean; scaffold smoke test shows the rule renders in generated briefs.