### PR TITLE
feat(deploy): verify Render deploys reach Live after merge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ config/backend
 config/x-mode.env
 config/cmux-socket-password
 config/wedge-alarm
+config/render-services.map

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,8 +95,9 @@ state/               volatile runtime signals; gitignored
   <id>.status        appended by crewmates: "<state>: <note>" wake-event lines, not current-state truth
   <id>.turn-ended    touched by turn-end hooks
   <id>.grok-turnend-token   firstmate-owned grok hook registry token for the task; removed by teardown
-  <id>.meta          written by fm-spawn: window=, worktree=, project=, harness=, model=, effort=, kind=, mode=, yolo=, tasktmp=; kind=secondmate also records home= and projects=; a non-default runtime backend records further backend-specific fields (docs/configuration.md "Runtime backend"; bin/fm-backend.sh, section 8); fm-pr-check, including through fm-pr-merge, appends pr= and GitHub's pr_head= when available; fm-x-link appends x_request=, x_request_ts=, x_followups=, and optional x_platform=/x_reply_max_chars= for an X-mode-originated task (section 14)
-  <id>.check.sh      optional slow poll you write per task (e.g. merged-PR check)
+  <id>.meta          written by fm-spawn: window=, worktree=, project=, harness=, model=, effort=, kind=, mode=, yolo=, tasktmp=; kind=secondmate also records home= and projects=; a non-default runtime backend records further backend-specific fields (docs/configuration.md "Runtime backend"; bin/fm-backend.sh, section 8); fm-pr-check, including through fm-pr-merge, appends pr= and GitHub's pr_head= when available; fm-deploy-check --arm appends deploy_service=, deploy_sha=, and deploy_armed_at= when a merged project maps to a Render service (docs/render-deploy-verification.md); fm-x-link appends x_request=, x_request_ts=, x_followups=, and optional x_platform=/x_reply_max_chars= for an X-mode-originated task (section 14)
+  <id>.check.sh      optional slow poll you write per task (e.g. merged-PR check, or the post-merge Render deploy-Live verification armed by fm-deploy-check)
+  <id>.deploy-log    boot log captured on a failed Render deploy by fm-deploy-check --once; read on a deploy-FAILED wake, removed by teardown
   x-watch.check.sh   generated X-mode relay poll shim; present only when opted in (section 14)
   x-inbox/           generated X-mode pending mention payloads; fmx-respond drains it (section 14)
   x-outbox/          generated X-mode dry-run reply and dismiss previews; inspect it when FMX_DRY_RUN is set (section 14)
@@ -510,7 +511,8 @@ bin/fm-teardown.sh <id>
 
 The script refuses if the worktree holds uncommitted changes or committed work that has not landed; treat a refusal as a stop-and-investigate, not an obstacle.
 For a Render-deployed project the merge poll does not stop at `merged`: it wakes you with `merged, now verifying deploy ...`, then automatically watches the merge commit until it reaches Live, because a merge is not shipped until its deploy goes Live (`docs/render-deploy-verification.md`).
-Hold teardown until that deploy wake resolves: a `deploy live:` wake clears it for teardown, while a `deploy FAILED:` wake is a captain-facing blocker whose boot log is at the path named in the wake line.
+That verification wakes you exactly once and then disarms: a `deploy live:` wake clears the task for teardown, a `deploy FAILED:` wake is a captain-facing blocker whose boot log is at the path named in the wake line, and a `deploy verification TIMED OUT:` wake (the deploy never appeared within the bounded window) means check the service by hand rather than holding teardown open indefinitely.
+Hold teardown until one of those three wakes arrives.
 `bin/fm-teardown.sh`'s header owns the full landed-work definition (remote-reachable, merged-PR-head containment for the squash-merge-then-delete-branch flow, content already in the default branch, local-only merges) and the `pr=` discovery fallback for merges that skipped `bin/fm-pr-check.sh`.
 Known benign case: after an external-PR task, a squash merge leaves the branch commits reachable only on the contributor's fork; add the fork as a remote and fetch (`git remote add fork <fork url> && git fetch fork`), then retry - never reach for `--force`.
 A successful PR-based teardown also refreshes that project's clone through `bin/fm-fleet-sync.sh`, best-effort.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -509,6 +509,8 @@ bin/fm-teardown.sh <id>
 ```
 
 The script refuses if the worktree holds uncommitted changes or committed work that has not landed; treat a refusal as a stop-and-investigate, not an obstacle.
+For a Render-deployed project the merge poll does not stop at `merged`: it wakes you with `merged, now verifying deploy ...`, then automatically watches the merge commit until it reaches Live, because a merge is not shipped until its deploy goes Live (`docs/render-deploy-verification.md`).
+Hold teardown until that deploy wake resolves: a `deploy live:` wake clears it for teardown, while a `deploy FAILED:` wake is a captain-facing blocker whose boot log is at the path named in the wake line.
 `bin/fm-teardown.sh`'s header owns the full landed-work definition (remote-reachable, merged-PR-head containment for the squash-merge-then-delete-branch flow, content already in the default branch, local-only merges) and the `pr=` discovery fallback for merges that skipped `bin/fm-pr-check.sh`.
 Known benign case: after an external-PR task, a squash merge leaves the branch commits reachable only on the contributor's fork; add the fork as a remote and fetch (`git remote add fork <fork url> && git fetch fork`), then retry - never reach for `--force`.
 A successful PR-based teardown also refreshes that project's clone through `bin/fm-fleet-sync.sh`, best-effort.

--- a/bin/fm-deploy-check.sh
+++ b/bin/fm-deploy-check.sh
@@ -23,19 +23,25 @@
 #   fm-deploy-check.sh --once <service|project> <sha>
 #       Single non-blocking probe for the watcher check contract
 #       (state/<id>.check.sh): prints exactly one line iff the deploy reached a
-#       terminal state firstmate should wake on (Live or failed), and stays
-#       silent (no output) while the deploy is still pending or not yet created.
-#       On a failure it also writes the boot log to $FM_DEPLOY_LOG_OUT when set.
+#       terminal state firstmate should wake on (Live, failed, or - on the wired
+#       path past its deadline - timed out), and stays silent (no output) while
+#       the deploy is still pending or not yet created. On a failure it also
+#       writes the boot log to $FM_DEPLOY_LOG_OUT when set. When wired by --arm
+#       it reads $FM_DEPLOY_ARMED_AT (bounded-deadline reference) and
+#       $FM_DEPLOY_DISARM_PATH (its own check.sh): a terminal wake removes that
+#       file so the probe fires exactly once - the watcher captures and durably
+#       enqueues the line before the next sweep, so removing it mid-run is safe.
 #       Always exits 0 so a transient CLI/network hiccup never wakes firstmate.
 #
 #   fm-deploy-check.sh --resolve <project>
 #       Print the resolved Render service id for a project name and exit.
 #
 #   fm-deploy-check.sh --arm <task-id> <service|project> <sha>
-#       Resolve the service once (loudly, now), record deploy_service=/deploy_sha=
-#       into state/<id>.meta, and write state/<id>.check.sh so the watcher polls
-#       the deploy on its normal cadence. This replaces the merge poll's single
-#       check slot with the post-merge deploy verification.
+#       Resolve the service once (loudly, now), record deploy_service=/
+#       deploy_sha=/deploy_armed_at= into state/<id>.meta, and write
+#       state/<id>.check.sh so the watcher polls the deploy on its normal
+#       cadence. This replaces the merge poll's single check slot with the
+#       post-merge deploy verification.
 #
 # Service resolution order for the <service|project> argument:
 #   1. A literal Render service id (matches ^srv-...) is used as-is.
@@ -52,10 +58,14 @@
 #   success  - any deploy for <sha> reached live or inactive (both built and
 #              served; inactive just means a newer deploy has since replaced it)
 #   failed   - newest deploy for <sha> is build_failed/update_failed/
-#              pre_deploy_failed/canceled and none reached a served state
+#              pre_deploy_failed and none reached a served state
 #   pending  - newest deploy is created/queued/*_in_progress, or no deploy for
 #              <sha> exists yet (not created)
-#   other    - any other status (e.g. deactivated); surfaced, never silently Live
+#   other    - any other status; includes 'canceled' (Render cancels a queued
+#              deploy when a newer one supersedes it, so treating it as a hard
+#              failure would false-alarm on two close merges) and 'deactivated'.
+#              Surfaced, never silently Live, but not a hard failure; the wired
+#              path's bounded deadline is what terminates a never-resolving sha.
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -67,6 +77,12 @@ RENDER_BIN="${FM_RENDER_BIN:-render}"
 POLL_INTERVAL="${FM_DEPLOY_POLL_INTERVAL:-15}"
 POLL_TIMEOUT="${FM_DEPLOY_TIMEOUT:-900}"
 LOG_LINES="${FM_DEPLOY_LOG_LINES:-50}"
+# Bounded deadline for the wired watcher path (--once with FM_DEPLOY_ARMED_AT):
+# how long to keep silently waiting for a deploy of the exact sha before
+# emitting a terminal "verification timed out" wake and disarming, so a deploy
+# that is never created (autodeploy off, or superseded before creation) can
+# never hold teardown open forever.
+VERIFY_DEADLINE="${FM_DEPLOY_VERIFY_DEADLINE:-1800}"
 
 usage() {
   echo "usage: fm-deploy-check.sh [--once|--resolve|--arm] <service|project> <sha> ..." >&2
@@ -126,7 +142,7 @@ probe_status() {
       elif any($m[]; .status == "live" or .status == "inactive") then "live"
       else ($m | sort_by(.createdAt) | last) as $n
         | ($n.status // "unknown") as $s | ($n.id // "?") as $id
-        | if ($s | IN("build_failed","update_failed","pre_deploy_failed","canceled"))
+        | if ($s | IN("build_failed","update_failed","pre_deploy_failed"))
             then "failed \($s) \($id)"
           elif ($s | IN("created","queued","build_in_progress","update_in_progress","pre_deploy_in_progress"))
             then "pending"
@@ -156,15 +172,21 @@ if [ "${1:-}" = "--arm" ]; then
   id=$2
   service=$(resolve_service "$3") || exit 4
   sha=$4
+  armed_at=$(date +%s)
   meta="$STATE/$id.meta"
   if [ -f "$meta" ]; then
     grep -qxF "deploy_service=$service" "$meta" || echo "deploy_service=$service" >> "$meta"
     grep -qxF "deploy_sha=$sha" "$meta" || echo "deploy_sha=$sha" >> "$meta"
+    grep -q '^deploy_armed_at=' "$meta" || echo "deploy_armed_at=$armed_at" >> "$meta"
   fi
   # The generated check runs --once every watcher check sweep; the watcher's
   # cadence is the poll loop, so this stays a single cheap probe per sweep.
+  # It carries the arm time (bounded-deadline reference) and its own path, so
+  # --once can disarm after a terminal wake and fire exactly once.
   cat > "$STATE/$id.check.sh" <<EOF
 FM_DEPLOY_LOG_OUT="$STATE/$id.deploy-log" \\
+FM_DEPLOY_ARMED_AT="$armed_at" \\
+FM_DEPLOY_DISARM_PATH="$STATE/$id.check.sh" \\
   "$SCRIPT_DIR/fm-deploy-check.sh" --once "$service" "$sha"
 EOF
   echo "armed: state/$id.check.sh verifies $sha reaches Live on $service"
@@ -179,9 +201,15 @@ if [ "${1:-}" = "--once" ]; then
   read -r kind status depid <<EOF
 $(probe_status "$service" "$sha")
 EOF
+  # A terminal wake (live, failed, or timed-out) fires exactly once: after
+  # emitting it, disarm by removing the check.sh so the watcher never runs it
+  # again. The watcher captures and durably enqueues this run's output before
+  # the next sweep, so removing the file mid-run does not lose the wake.
+  terminal=0
   case "$kind" in
     live)
       echo "deploy live: $sha on $service"
+      terminal=1
       ;;
     failed)
       if [ -n "${FM_DEPLOY_LOG_OUT:-}" ]; then
@@ -190,11 +218,23 @@ EOF
       else
         echo "deploy FAILED: $sha on $service ($status, $depid)"
       fi
+      terminal=1
       ;;
     *)
-      : # pending / other / none: stay silent, keep sleeping
+      # pending / other (incl. superseded 'canceled') / none: still waiting.
+      # Stay silent unless the bounded deadline has passed, in which case wake
+      # once with a distinct timed-out line so a never-created deploy cannot
+      # hold teardown open forever.
+      if [ -n "${FM_DEPLOY_ARMED_AT:-}" ] \
+        && [ "$(( $(date +%s) - FM_DEPLOY_ARMED_AT ))" -ge "$VERIFY_DEADLINE" ]; then
+        echo "deploy verification TIMED OUT: $sha on $service after ${VERIFY_DEADLINE}s (last: $kind $status) - verify by hand"
+        terminal=1
+      fi
       ;;
   esac
+  if [ "$terminal" -eq 1 ] && [ -n "${FM_DEPLOY_DISARM_PATH:-}" ]; then
+    rm -f "$FM_DEPLOY_DISARM_PATH"
+  fi
   exit 0
 fi
 

--- a/bin/fm-deploy-check.sh
+++ b/bin/fm-deploy-check.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# fm-deploy-check.sh - verify that a merged commit actually reached Live on its
+# Render service, instead of assuming a merged PR is shipped.
+#
+# Why this exists: a merge is not shipped until its deploy goes Live. A Render
+# service keeps serving the last good build when a new deploy fails, so nothing
+# LOOKS broken - mattmccarthy.dev served a stale build for 5 days across 10
+# consecutive silently-failed deploys (data/learnings.md "Render - deploys can
+# fail silently for days"). The merge poll only watches the PR, never the
+# deploy. This helper closes that gap, read-only: it never triggers a deploy or
+# changes service state, it only lists deploys and reads boot logs.
+#
+# Requires the Render CLI (v2.5.0+, logged in) and jq on PATH.
+#
+# Modes:
+#   fm-deploy-check.sh <service|project> <sha>
+#       Blocking poll until the deploy for <sha> reaches Live, fails, or a
+#       bounded timeout elapses. Prints progress to stderr. On a failed deploy
+#       it prints the recent service boot log to stdout so the failure cause
+#       (e.g. a missing env var boot guard) is visible. Exit: 0 Live, 3 failed,
+#       2 timeout, 4 resolve/usage error.
+#
+#   fm-deploy-check.sh --once <service|project> <sha>
+#       Single non-blocking probe for the watcher check contract
+#       (state/<id>.check.sh): prints exactly one line iff the deploy reached a
+#       terminal state firstmate should wake on (Live or failed), and stays
+#       silent (no output) while the deploy is still pending or not yet created.
+#       On a failure it also writes the boot log to $FM_DEPLOY_LOG_OUT when set.
+#       Always exits 0 so a transient CLI/network hiccup never wakes firstmate.
+#
+#   fm-deploy-check.sh --resolve <project>
+#       Print the resolved Render service id for a project name and exit.
+#
+#   fm-deploy-check.sh --arm <task-id> <service|project> <sha>
+#       Resolve the service once (loudly, now), record deploy_service=/deploy_sha=
+#       into state/<id>.meta, and write state/<id>.check.sh so the watcher polls
+#       the deploy on its normal cadence. This replaces the merge poll's single
+#       check slot with the post-merge deploy verification.
+#
+# Service resolution order for the <service|project> argument:
+#   1. A literal Render service id (matches ^srv-...) is used as-is.
+#   2. A line "<project> <srv-id>" in the local map file
+#      ($FM_RENDER_SERVICES_MAP, else $FM_HOME/config/render-services.map). This
+#      is the override path; the map is local and gitignored per fleet. See
+#      docs/examples/render-services.map for the format.
+#   3. Otherwise `render services -o json` is queried and matched by name. IDs
+#      drift, so verifying against the live service list at runtime is the cheap
+#      fallback when the map has no entry.
+# Resolution failure exits 4; it never guesses a service.
+#
+# Deploy classification (docs/render-deploy-verification.md owns the full table):
+#   success  - any deploy for <sha> reached live or inactive (both built and
+#              served; inactive just means a newer deploy has since replaced it)
+#   failed   - newest deploy for <sha> is build_failed/update_failed/
+#              pre_deploy_failed/canceled and none reached a served state
+#   pending  - newest deploy is created/queued/*_in_progress, or no deploy for
+#              <sha> exists yet (not created)
+#   other    - any other status (e.g. deactivated); surfaced, never silently Live
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+
+RENDER_BIN="${FM_RENDER_BIN:-render}"
+POLL_INTERVAL="${FM_DEPLOY_POLL_INTERVAL:-15}"
+POLL_TIMEOUT="${FM_DEPLOY_TIMEOUT:-900}"
+LOG_LINES="${FM_DEPLOY_LOG_LINES:-50}"
+
+usage() {
+  echo "usage: fm-deploy-check.sh [--once|--resolve|--arm] <service|project> <sha> ..." >&2
+  exit 4
+}
+
+# resolve_service <service-or-project> -> prints a srv- id or exits 4.
+resolve_service() {
+  local arg=$1 map line name id
+  case "$arg" in
+    srv-*)
+      printf '%s\n' "$arg"
+      return 0
+      ;;
+  esac
+
+  map="${FM_RENDER_SERVICES_MAP:-$FM_HOME/config/render-services.map}"
+  if [ -f "$map" ]; then
+    # Lines: "<project> <srv-id>"; '#' comments and blanks ignored.
+    while read -r name id _rest; do
+      case "$name" in ''|'#'*) continue ;; esac
+      if [ "$name" = "$arg" ] && [ -n "$id" ]; then
+        printf '%s\n' "$id"
+        return 0
+      fi
+    done < "$map"
+  fi
+
+  # Runtime fallback: match the live service list by name. `render services
+  # -o json` wraps each resource under a type key, so a web service's name/id
+  # live under .service.
+  if command -v "$RENDER_BIN" >/dev/null 2>&1; then
+    line=$("$RENDER_BIN" services -o json --confirm 2>/dev/null \
+      | jq -r --arg n "$arg" 'map(select(.service.name == $n)) | .[0].service.id // empty' 2>/dev/null || true)
+    if [ -n "$line" ] && [ "$line" != "null" ]; then
+      printf '%s\n' "$line"
+      return 0
+    fi
+  fi
+
+  echo "error: no Render service mapped for '$arg' (add it to ${map} or pass a srv- id)" >&2
+  return 4
+}
+
+# probe_status <service> <sha> -> one classification word plus optional detail:
+#   live | failed <status> <depid> | pending | other <status> <depid> | none
+# Any CLI/jq failure degrades to "pending" so callers keep waiting rather than
+# treating a transient hiccup as terminal.
+probe_status() {
+  local service=$1 sha=$2 json result
+  json=$("$RENDER_BIN" deploys list "$service" -o json --confirm 2>/dev/null || true)
+  [ -n "$json" ] || { echo pending; return 0; }
+  result=$(printf '%s' "$json" | jq -r --arg sha "$sha" '
+    ( if type == "array" then . else [] end )
+    | [ .[] | select((.commit.id // "") | startswith($sha)) ] as $m
+    | if ($m | length) == 0 then "none"
+      elif any($m[]; .status == "live" or .status == "inactive") then "live"
+      else ($m | sort_by(.createdAt) | last) as $n
+        | ($n.status // "unknown") as $s | ($n.id // "?") as $id
+        | if ($s | IN("build_failed","update_failed","pre_deploy_failed","canceled"))
+            then "failed \($s) \($id)"
+          elif ($s | IN("created","queued","build_in_progress","update_in_progress","pre_deploy_in_progress"))
+            then "pending"
+          else "other \($s) \($id)" end
+      end' 2>/dev/null || true)
+  [ -n "$result" ] || result=pending
+  printf '%s\n' "$result"
+}
+
+# fetch_boot_log <service> -> recent service logs, best-effort (never fatal).
+fetch_boot_log() {
+  local service=$1
+  "$RENDER_BIN" logs -r "$service" -o text --limit "$LOG_LINES" --direction backward --confirm 2>/dev/null \
+    || echo "(boot log unavailable; run: $RENDER_BIN logs -r $service -o text --limit $LOG_LINES)"
+}
+
+# --- mode: --resolve --------------------------------------------------------
+if [ "${1:-}" = "--resolve" ]; then
+  [ $# -eq 2 ] || usage
+  resolve_service "$2"
+  exit $?
+fi
+
+# --- mode: --arm ------------------------------------------------------------
+if [ "${1:-}" = "--arm" ]; then
+  [ $# -eq 4 ] || usage
+  id=$2
+  service=$(resolve_service "$3") || exit 4
+  sha=$4
+  meta="$STATE/$id.meta"
+  if [ -f "$meta" ]; then
+    grep -qxF "deploy_service=$service" "$meta" || echo "deploy_service=$service" >> "$meta"
+    grep -qxF "deploy_sha=$sha" "$meta" || echo "deploy_sha=$sha" >> "$meta"
+  fi
+  # The generated check runs --once every watcher check sweep; the watcher's
+  # cadence is the poll loop, so this stays a single cheap probe per sweep.
+  cat > "$STATE/$id.check.sh" <<EOF
+FM_DEPLOY_LOG_OUT="$STATE/$id.deploy-log" \\
+  "$SCRIPT_DIR/fm-deploy-check.sh" --once "$service" "$sha"
+EOF
+  echo "armed: state/$id.check.sh verifies $sha reaches Live on $service"
+  exit 0
+fi
+
+# --- mode: --once (watcher check contract) ----------------------------------
+if [ "${1:-}" = "--once" ]; then
+  [ $# -eq 3 ] || usage
+  service=$(resolve_service "$2" 2>/dev/null) || exit 0
+  sha=$3
+  read -r kind status depid <<EOF
+$(probe_status "$service" "$sha")
+EOF
+  case "$kind" in
+    live)
+      echo "deploy live: $sha on $service"
+      ;;
+    failed)
+      if [ -n "${FM_DEPLOY_LOG_OUT:-}" ]; then
+        fetch_boot_log "$service" > "$FM_DEPLOY_LOG_OUT" 2>/dev/null || true
+        echo "deploy FAILED: $sha on $service ($status, $depid) - boot log: $FM_DEPLOY_LOG_OUT"
+      else
+        echo "deploy FAILED: $sha on $service ($status, $depid)"
+      fi
+      ;;
+    *)
+      : # pending / other / none: stay silent, keep sleeping
+      ;;
+  esac
+  exit 0
+fi
+
+# --- default mode: blocking poll --------------------------------------------
+[ $# -eq 2 ] || usage
+service=$(resolve_service "$1") || exit 4
+sha=$2
+deadline=$(( $(date +%s) + POLL_TIMEOUT ))
+echo "polling $service for deploy of $sha (timeout ${POLL_TIMEOUT}s)..." >&2
+while :; do
+  read -r kind status depid <<EOF
+$(probe_status "$service" "$sha")
+EOF
+  case "$kind" in
+    live)
+      echo "Live: $sha is serving on $service" >&2
+      exit 0
+      ;;
+    failed)
+      echo "FAILED: deploy $depid for $sha is $status on $service" >&2
+      echo "--- recent boot log ($service) ---"
+      fetch_boot_log "$service"
+      exit 3
+      ;;
+    none)
+      echo "  no deploy for $sha yet; waiting..." >&2
+      ;;
+    pending)
+      echo "  deploy in progress; waiting..." >&2
+      ;;
+    *)
+      echo "  status $status ($depid); waiting..." >&2
+      ;;
+  esac
+  if [ "$(date +%s)" -ge "$deadline" ]; then
+    echo "TIMEOUT: $sha did not reach Live on $service within ${POLL_TIMEOUT}s (last: $kind $status)" >&2
+    exit 2
+  fi
+  sleep "$POLL_INTERVAL"
+done

--- a/bin/fm-deploy-check.sh
+++ b/bin/fm-deploy-check.sh
@@ -83,10 +83,31 @@ LOG_LINES="${FM_DEPLOY_LOG_LINES:-50}"
 # that is never created (autodeploy off, or superseded before creation) can
 # never hold teardown open forever.
 VERIFY_DEADLINE="${FM_DEPLOY_VERIFY_DEADLINE:-1800}"
+# Hard bound on the `render services -o json` resolution fallback: the merge
+# poll calls --arm inside the watcher's FM_CHECK_TIMEOUT (default 30s) budget,
+# and a hanging render CLI must fail fast enough that the poll's plain
+# "merged" fallback wake is still reachable within that budget.
+SERVICES_TIMEOUT="${FM_RENDER_SERVICES_TIMEOUT:-10}"
 
 usage() {
   echo "usage: fm-deploy-check.sh [--once|--resolve|--arm] <service|project> <sha> ..." >&2
   exit 4
+}
+
+# run_bounded <seconds> <cmd...>: run cmd under a hard process-group-killing
+# timeout (same GNU timeout / gtimeout / perl fallback chain as the watcher's
+# run_check) so a wedged network call can never hang the caller.
+run_bounded() {
+  local t=$1
+  shift
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$t" "$@"
+  elif command -v gtimeout >/dev/null 2>&1; then
+    gtimeout "$t" "$@"
+  else
+    # shellcheck disable=SC2016  # single quotes are deliberate: Perl expands its own variables.
+    perl -e 'my $t = shift; my $pid = fork; die "fork failed" unless defined $pid; if (!$pid) { setpgrp(0, 0); exec @ARGV } local $SIG{ALRM} = sub { kill "TERM", -$pid; select undef, undef, undef, 0.2; kill "KILL", -$pid; exit 124 }; alarm $t; waitpid $pid, 0; exit($? >> 8)' "$t" "$@"
+  fi
 }
 
 # resolve_service <service-or-project> -> prints a srv- id or exits 4.
@@ -113,9 +134,10 @@ resolve_service() {
 
   # Runtime fallback: match the live service list by name. `render services
   # -o json` wraps each resource under a type key, so a web service's name/id
-  # live under .service.
+  # live under .service. Bounded so a hanging CLI can never starve the merge
+  # poll's fallback wake.
   if command -v "$RENDER_BIN" >/dev/null 2>&1; then
-    line=$("$RENDER_BIN" services -o json --confirm 2>/dev/null \
+    line=$(run_bounded "$SERVICES_TIMEOUT" "$RENDER_BIN" services -o json --confirm 2>/dev/null \
       | jq -r --arg n "$arg" 'map(select(.service.name == $n)) | .[0].service.id // empty' 2>/dev/null || true)
     if [ -n "$line" ] && [ "$line" != "null" ]; then
       printf '%s\n' "$line"
@@ -175,20 +197,32 @@ if [ "${1:-}" = "--arm" ]; then
   armed_at=$(date +%s)
   meta="$STATE/$id.meta"
   if [ -f "$meta" ]; then
-    grep -qxF "deploy_service=$service" "$meta" || echo "deploy_service=$service" >> "$meta"
-    grep -qxF "deploy_sha=$sha" "$meta" || echo "deploy_sha=$sha" >> "$meta"
-    grep -q '^deploy_armed_at=' "$meta" || echo "deploy_armed_at=$armed_at" >> "$meta"
+    # A re-arm (e.g. re-verification after a timed-out wake) replaces the
+    # deploy_* lines with fresh values rather than skipping or duplicating.
+    metatmp=$(mktemp "$STATE/.$id.meta.tmp.XXXXXX")
+    grep -v -e '^deploy_service=' -e '^deploy_sha=' -e '^deploy_armed_at=' "$meta" > "$metatmp" || true
+    {
+      echo "deploy_service=$service"
+      echo "deploy_sha=$sha"
+      echo "deploy_armed_at=$armed_at"
+    } >> "$metatmp"
+    mv -f "$metatmp" "$meta"
   fi
   # The generated check runs --once every watcher check sweep; the watcher's
   # cadence is the poll loop, so this stays a single cheap probe per sweep.
   # It carries the arm time (bounded-deadline reference) and its own path, so
   # --once can disarm after a terminal wake and fire exactly once.
-  cat > "$STATE/$id.check.sh" <<EOF
+  # Written via temp-then-mv so a watcher process-group kill landing while the
+  # merge poll self-rewrites into this probe can never leave check.sh empty or
+  # partial; the running bash keeps the old inode open, so mv-over-path is safe.
+  checktmp=$(mktemp "$STATE/.$id.check.tmp.XXXXXX")
+  cat > "$checktmp" <<EOF
 FM_DEPLOY_LOG_OUT="$STATE/$id.deploy-log" \\
 FM_DEPLOY_ARMED_AT="$armed_at" \\
 FM_DEPLOY_DISARM_PATH="$STATE/$id.check.sh" \\
   "$SCRIPT_DIR/fm-deploy-check.sh" --once "$service" "$sha"
 EOF
+  mv -f "$checktmp" "$STATE/$id.check.sh"
   echo "armed: state/$id.check.sh verifies $sha reaches Live on $service"
   exit 0
 fi

--- a/bin/fm-pr-check.sh
+++ b/bin/fm-pr-check.sh
@@ -3,6 +3,13 @@
 # state/<id>.meta when available, then arms the watcher's merge poll by writing
 # state/<id>.check.sh, which prints one line iff the PR is merged (the watcher's
 # check contract: output = wake firstmate, silence = keep sleeping).
+#
+# The merge poll does not stop at "merged": a merge is not shipped until its
+# deploy goes Live. When the merged PR's project maps to a Render service, the
+# poll hands its single check slot off to bin/fm-deploy-check.sh --arm, which
+# rewrites state/<id>.check.sh to verify the merge commit reaches Live (see
+# docs/render-deploy-verification.md). A project with no mapped service keeps the
+# plain "merged" wake, unchanged.
 # Usage: fm-pr-check.sh <task-id> <pr-url>
 set -eu
 
@@ -35,6 +42,18 @@ fi
 
 cat > "$STATE/$ID.check.sh" <<EOF
 state=\$(gh pr view "$URL" --json state -q .state 2>/dev/null)
-[ "\$state" = "MERGED" ] && echo "merged"
+[ "\$state" = "MERGED" ] || exit 0
+# Merged. Hand off to deploy verification when this project maps to a Render
+# service - the deploy, not the merge, is the real ship signal. fm-deploy-check
+# --arm resolves the service and, on success, overwrites this check.sh with the
+# deploy probe. If no service maps or the merge commit can't be read, fall back
+# to the plain merged wake exactly as before.
+proj=\$(basename "\$(sed -n 's/^project=//p' "$META" 2>/dev/null | tail -1)" 2>/dev/null)
+sha=\$(gh pr view "$URL" --json mergeCommit -q .mergeCommit.oid 2>/dev/null)
+if [ -n "\$sha" ] && [ -n "\$proj" ] && "$SCRIPT_DIR/fm-deploy-check.sh" --arm "$ID" "\$proj" "\$sha" >/dev/null 2>&1; then
+  echo "merged, now verifying deploy of \$sha reaches Live"
+else
+  echo "merged"
+fi
 EOF
 echo "armed: state/$ID.check.sh polls $URL"

--- a/bin/fm-pr-check.sh
+++ b/bin/fm-pr-check.sh
@@ -40,7 +40,10 @@ if [ -f "$META" ]; then
   fi
 fi
 
-cat > "$STATE/$ID.check.sh" <<EOF
+# Written via temp-then-mv so a kill mid-write can never leave check.sh empty
+# or partial (an empty check silently loses the merged wake with no retry).
+TMPCHECK=$(mktemp "$STATE/.$ID.check.tmp.XXXXXX")
+cat > "$TMPCHECK" <<EOF
 state=\$(gh pr view "$URL" --json state -q .state 2>/dev/null)
 [ "\$state" = "MERGED" ] || exit 0
 # Merged. Hand off to deploy verification when this project maps to a Render
@@ -56,4 +59,5 @@ else
   echo "merged"
 fi
 EOF
+mv -f "$TMPCHECK" "$STATE/$ID.check.sh"
 echo "armed: state/$ID.check.sh polls $URL"

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -916,7 +916,7 @@ cleanup_firstmate_home_children() {
       fi
     fi
     remove_grok_turnend_auth "$sub_state" "$child_id"
-    rm -f "$sub_state/$child_id.status" "$sub_state/$child_id.turn-ended" "$sub_state/$child_id.check.sh" "$sub_state/$child_id.meta" "$sub_state/$child_id.pi-ext.ts" "$sub_state/$child_id.grok-turnend-token"
+    rm -f "$sub_state/$child_id.status" "$sub_state/$child_id.turn-ended" "$sub_state/$child_id.check.sh" "$sub_state/$child_id.meta" "$sub_state/$child_id.pi-ext.ts" "$sub_state/$child_id.grok-turnend-token" "$sub_state/$child_id.deploy-log"
   done
 }
 
@@ -1037,7 +1037,7 @@ remove_grok_turnend_auth "$STATE" "$ID"
 # Remove the per-task temp root (/tmp/fm-<id>/, incl. its gotmp/) recorded by spawn.
 # Read before the state-file rm below; empty (pre-fix tasks without tasktmp=) is a no-op.
 [ -n "$TASK_TMP" ] && rm -rf "$TASK_TMP"
-rm -f "$STATE/$ID.status" "$STATE/$ID.turn-ended" "$STATE/$ID.check.sh" "$STATE/$ID.meta" "$STATE/$ID.pi-ext.ts" "$STATE/$ID.grok-turnend-token"
+rm -f "$STATE/$ID.status" "$STATE/$ID.turn-ended" "$STATE/$ID.check.sh" "$STATE/$ID.meta" "$STATE/$ID.pi-ext.ts" "$STATE/$ID.grok-turnend-token" "$STATE/$ID.deploy-log"
 if [ "$KIND" != scout ] && [ "$KIND" != secondmate ] && [ "$MODE" != local-only ]; then
   "$FM_ROOT/bin/fm-fleet-sync.sh" "$PROJ" || true
 fi

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -85,6 +85,14 @@ An absent file means `auto`, i.e. default-on on macOS: the alarm exists precisel
 A missing or failing channel logs and falls through to the next, never crashing the daemon.
 See [`wedge-alarm.md`](wedge-alarm.md) for the channel reference and macOS verification evidence, and [`examples/wedge-alarm`](examples/wedge-alarm) for a copyable config.
 
+## Render deploy verification (config/render-services.map)
+
+A merge is not shipped until its deploy reaches Live, and a Render service keeps serving its last good build when a new deploy fails, so a silent deploy failure looks like nothing is wrong.
+When a merged PR's project maps to a Render web-service, the merge poll hands its check slot to `bin/fm-deploy-check.sh`, which verifies the merge commit reaches Live and surfaces the boot log on failure.
+`config/render-services.map` (local, gitignored) maps a project name to its Render service id, one `<project> <service-id>` entry per non-comment line.
+It is the override path; a project absent from the map falls back to matching `render services -o json` by name at runtime.
+See [`render-deploy-verification.md`](render-deploy-verification.md) for the classification table and Render CLI evidence, and [`examples/render-services.map`](examples/render-services.map) for a copyable config.
+
 ## Gate defaults (.no-mistakes.yaml)
 
 The tracked `.no-mistakes.yaml` keeps test evidence outside the repo and defines `commands.test` so no-mistakes runs firstmate's bash behavior suite directly.

--- a/docs/examples/render-services.map
+++ b/docs/examples/render-services.map
@@ -1,0 +1,17 @@
+# render-services.map - project -> Render service id for deploy verification.
+#
+# Copy to config/render-services.map (local, gitignored) and edit for this
+# fleet. bin/fm-deploy-check.sh reads it to map a project name to the Render
+# web-service whose deploy verifies a merge actually reached Live.
+#
+# Format: one entry per line, "<project> <service-id>", '#' starts a comment.
+# The <project> key is the project directory name under projects/ (the basename
+# fm-spawn records in state/<id>.meta as project=). The <service-id> is a Render
+# web-service id (srv-...).
+#
+# This map is the override path. When a project is absent here, the helper falls
+# back to `render services -o json` and matches by name at runtime. Verify ids
+# against `render services -o text` before relying on them; Render ids drift.
+
+astroai      srv-d49b37c9c44c73bj0j70
+mtmccarthy   srv-d4v2k4ur433s73dti20g

--- a/docs/examples/render-services.map
+++ b/docs/examples/render-services.map
@@ -13,5 +13,5 @@
 # back to `render services -o json` and matches by name at runtime. Verify ids
 # against `render services -o text` before relying on them; Render ids drift.
 
-astroai      srv-d49b37c9c44c73bj0j70
-mtmccarthy   srv-d4v2k4ur433s73dti20g
+astroai      srv-xxxxxxxxxxxxxxxxxxxx
+mtmccarthy   srv-xxxxxxxxxxxxxxxxxxxx

--- a/docs/render-deploy-verification.md
+++ b/docs/render-deploy-verification.md
@@ -60,28 +60,28 @@ If any deploy for the sha reached a served state, the commit is Live even when a
 - `fm-deploy-check.sh --resolve <project>` - print the resolved service id.
 - `fm-deploy-check.sh --arm <id> <service|project> <sha>` - resolve once, record meta (including `deploy_armed_at=`), write the deploy probe check.sh wired with the arm time and disarm path.
 
-Cadence, timeout, and deadline are env-overridable: `FM_DEPLOY_POLL_INTERVAL` (default 15s), `FM_DEPLOY_TIMEOUT` (default 900s, the blocking poll's bound), `FM_DEPLOY_VERIFY_DEADLINE` (default 1800s, the wired watcher path's bound before a timed-out wake), `FM_DEPLOY_LOG_LINES` (default 50), `FM_RENDER_BIN` (default `render`).
+Cadence, timeout, and deadline are env-overridable: `FM_DEPLOY_POLL_INTERVAL` (default 15s), `FM_DEPLOY_TIMEOUT` (default 900s, the blocking poll's bound), `FM_DEPLOY_VERIFY_DEADLINE` (default 1800s, the wired watcher path's bound before a timed-out wake), `FM_DEPLOY_LOG_LINES` (default 50), `FM_RENDER_BIN` (default `render`), `FM_RENDER_SERVICES_TIMEOUT` (default 10s, the hard bound on the `render services` resolution fallback so a hanging CLI can never starve the merge poll's fallback wake inside the watcher's check budget).
 
 ## Evidence
 
 2026-07-11, Render CLI v2.5.0, logged in as captain, on macOS (Darwin 25.4.0).
 
-`render deploys list srv-d4v2k4ur433s73dti20g -o json --confirm` returned an array of deploys, each with `.commit.id`, `.status` (lowercase, e.g. `live`, `update_failed`, `inactive`), `.id` (`dep-...`), and `.createdAt`.
+`render deploys list srv-xxxx... -o json --confirm` (service id redacted; the real ids live only in the local gitignored `config/render-services.map`) returned an array of deploys, each with `.commit.id`, `.status` (lowercase, e.g. `live`, `update_failed`, `inactive`), `.id` (`dep-...`), and `.createdAt`.
 The mtmccarthy history showed the exact silent-failure shape: commit `c40669d3...` had both a `live` deploy (trigger `api`) and an `update_failed` deploy (trigger `new_commit`), and the surrounding history was a wall of `Update Failed`.
 
 `render services -o json --confirm` returned an array where each element wraps one resource under a type key (`service`, `postgres`, `project`, `environment`); web-service name and id live under `.service.name` / `.service.id`.
-Verified ids at runtime: `astroai` = `srv-d49b37c9c44c73bj0j70`, `mtmccarthy` = `srv-d4v2k4ur433s73dti20g`.
+Verified at runtime that both `astroai` and `mtmccarthy` resolved to their live `srv-xxxx... (redacted)` ids by name.
 
-Helper behavior verified against that live data (read-only):
+Helper behavior verified against that live data (read-only, service id redacted):
 
 ```
-$ fm-deploy-check.sh --once srv-d4v2k4ur433s73dti20g c40669d37b624e2d2cfae12b89902217ba849d8b
-deploy live: c40669d3... on srv-d4v2k4ur433s73dti20g
+$ fm-deploy-check.sh --once srv-xxxx... c40669d37b624e2d2cfae12b89902217ba849d8b
+deploy live: c40669d3... on srv-xxxx...
 
-$ FM_DEPLOY_LOG_OUT=/tmp/log fm-deploy-check.sh --once srv-d4v2k4ur433s73dti20g 5e2a4271103aac22b099d2ebb2695c3885afa3d6
-deploy FAILED: 5e2a4271... on srv-d4v2k4ur433s73dti20g (update_failed, dep-d92tq5favr4c73bhkjmg) - boot log: /tmp/log
+$ FM_DEPLOY_LOG_OUT=/tmp/log fm-deploy-check.sh --once srv-xxxx... 5e2a4271103aac22b099d2ebb2695c3885afa3d6
+deploy FAILED: 5e2a4271... on srv-xxxx... (update_failed, dep-d92tq5favr4c73bhkjmg) - boot log: /tmp/log
 
-$ fm-deploy-check.sh --once srv-d4v2k4ur433s73dti20g deadbeefdeadbeef
+$ fm-deploy-check.sh --once srv-xxxx... deadbeefdeadbeef
 $   # (silent: no deploy for that sha)
 ```
 

--- a/docs/render-deploy-verification.md
+++ b/docs/render-deploy-verification.md
@@ -1,0 +1,83 @@
+# Render deploy verification
+
+This documents `bin/fm-deploy-check.sh` and its wiring into the merge path.
+It exists because a merge is not shipped until its deploy reaches Live.
+
+## The failure it prevents
+
+mattmccarthy.dev served a July-1 build for 5 days across 10 consecutive silently-failed deploys (`data/learnings.md`, "Render - deploys can fail silently for days").
+A Render service keeps serving its last good build when a new deploy fails, so nothing looks broken from the outside.
+Firstmate's merge poll only watched the PR, so a merged-but-never-deployed change read as shipped.
+This verification closes that gap by watching the deploy, not just the merge.
+
+## What runs, and when
+
+When the merge poll (`state/<id>.check.sh`, written by `bin/fm-pr-check.sh`) detects the PR merged, it reads the merge commit and the task's project.
+If the project maps to a Render service, it calls `bin/fm-deploy-check.sh --arm <id> <project> <merge-sha>`, which rewrites `state/<id>.check.sh` to probe the deploy and records `deploy_service=`/`deploy_sha=` into the meta.
+The watcher then polls that probe on its normal check cadence: it stays silent while the deploy is pending and wakes firstmate once with `deploy live:` or `deploy FAILED:`.
+On failure the probe writes the recent service boot log to `state/<id>.deploy-log` and names it in the wake line.
+A project with no mapped service keeps the plain `merged` wake, unchanged.
+This transition fires for every merge path, because both a captain merge on GitHub and a `bin/fm-pr-merge.sh` self-merge are observed by the same merge poll.
+
+## Read-only
+
+The helper only lists deploys and reads logs.
+It never triggers a deploy, restarts, or changes service state.
+Read-only Render checks are standing-authorized (`data/learnings.md`, "Render - CLI authorized, service map").
+
+## Service resolution
+
+`bin/fm-deploy-check.sh` resolves its `<service|project>` argument in this order:
+
+1. A literal `srv-...` service id is used as-is.
+2. A `<project> <srv-id>` entry in `config/render-services.map` (local, gitignored; `$FM_RENDER_SERVICES_MAP` overrides the path). This is the override path.
+3. Otherwise `render services -o json` is queried and matched by name (`.service.name`), because ids drift and the live list is the cheap source of truth.
+
+Resolution never guesses; an unmapped, unmatched project exits non-zero.
+
+## Deploy classification
+
+A single commit can have several deploys (for example an `api`-triggered redeploy alongside a `new_commit` one), so the probe examines every deploy whose `commit.id` starts with the target sha.
+
+| Bucket | Render status | Meaning |
+| --- | --- | --- |
+| success (Live) | `live`, `inactive` | The commit built and served; `inactive` just means a newer deploy has since replaced it. |
+| failed | `build_failed`, `update_failed`, `pre_deploy_failed`, `canceled` | Newest deploy for the sha failed and none reached a served state. |
+| pending | `created`, `queued`, `build_in_progress`, `update_in_progress`, `pre_deploy_in_progress`, or no deploy for the sha yet | Keep polling. |
+| other | anything else (e.g. `deactivated`) | Surfaced, never silently reported Live. |
+
+If any deploy for the sha reached a served state, the commit is Live even when an earlier deploy of the same commit failed.
+
+## Modes
+
+- `fm-deploy-check.sh <service|project> <sha>` - blocking poll until Live (exit 0), failed (exit 3, prints boot log), or timeout (exit 2). For manual/direct use.
+- `fm-deploy-check.sh --once <service|project> <sha>` - single probe for the watcher check contract: one line iff terminal (Live or failed), silent otherwise, always exit 0.
+- `fm-deploy-check.sh --resolve <project>` - print the resolved service id.
+- `fm-deploy-check.sh --arm <id> <service|project> <sha>` - resolve once, record meta, write the deploy probe check.sh.
+
+Cadence and timeout are env-overridable: `FM_DEPLOY_POLL_INTERVAL` (default 15s), `FM_DEPLOY_TIMEOUT` (default 900s), `FM_DEPLOY_LOG_LINES` (default 50), `FM_RENDER_BIN` (default `render`).
+
+## Evidence
+
+2026-07-11, Render CLI v2.5.0, logged in as captain, on macOS (Darwin 25.4.0).
+
+`render deploys list srv-d4v2k4ur433s73dti20g -o json --confirm` returned an array of deploys, each with `.commit.id`, `.status` (lowercase, e.g. `live`, `update_failed`, `inactive`), `.id` (`dep-...`), and `.createdAt`.
+The mtmccarthy history showed the exact silent-failure shape: commit `c40669d3...` had both a `live` deploy (trigger `api`) and an `update_failed` deploy (trigger `new_commit`), and the surrounding history was a wall of `Update Failed`.
+
+`render services -o json --confirm` returned an array where each element wraps one resource under a type key (`service`, `postgres`, `project`, `environment`); web-service name and id live under `.service.name` / `.service.id`.
+Verified ids at runtime: `astroai` = `srv-d49b37c9c44c73bj0j70`, `mtmccarthy` = `srv-d4v2k4ur433s73dti20g`.
+
+Helper behavior verified against that live data (read-only):
+
+```
+$ fm-deploy-check.sh --once srv-d4v2k4ur433s73dti20g c40669d37b624e2d2cfae12b89902217ba849d8b
+deploy live: c40669d3... on srv-d4v2k4ur433s73dti20g
+
+$ FM_DEPLOY_LOG_OUT=/tmp/log fm-deploy-check.sh --once srv-d4v2k4ur433s73dti20g 5e2a4271103aac22b099d2ebb2695c3885afa3d6
+deploy FAILED: 5e2a4271... on srv-d4v2k4ur433s73dti20g (update_failed, dep-d92tq5favr4c73bhkjmg) - boot log: /tmp/log
+
+$ fm-deploy-check.sh --once srv-d4v2k4ur433s73dti20g deadbeefdeadbeef
+$   # (silent: no deploy for that sha)
+```
+
+`render logs -r <service> -o text --limit <n> --direction backward --confirm` supplies the boot log; it is best-effort and never fatal to the check.

--- a/docs/render-deploy-verification.md
+++ b/docs/render-deploy-verification.md
@@ -13,9 +13,12 @@ This verification closes that gap by watching the deploy, not just the merge.
 ## What runs, and when
 
 When the merge poll (`state/<id>.check.sh`, written by `bin/fm-pr-check.sh`) detects the PR merged, it reads the merge commit and the task's project.
-If the project maps to a Render service, it calls `bin/fm-deploy-check.sh --arm <id> <project> <merge-sha>`, which rewrites `state/<id>.check.sh` to probe the deploy and records `deploy_service=`/`deploy_sha=` into the meta.
-The watcher then polls that probe on its normal check cadence: it stays silent while the deploy is pending and wakes firstmate once with `deploy live:` or `deploy FAILED:`.
+If the project maps to a Render service, it calls `bin/fm-deploy-check.sh --arm <id> <project> <merge-sha>`, which rewrites `state/<id>.check.sh` to probe the deploy and records `deploy_service=`/`deploy_sha=`/`deploy_armed_at=` into the meta.
+The watcher then polls that probe on its normal check cadence: it stays silent while the deploy is pending and wakes firstmate exactly once, with `deploy live:`, `deploy FAILED:`, or (if no deploy for the sha appears within the bounded deadline) `deploy verification TIMED OUT:`.
+That single wake is durable: after emitting it the probe disarms by removing its own `state/<id>.check.sh`, so a held-teardown failure never re-wakes firstmate every check interval.
+Removing the file mid-run is safe because the watcher captures and durably enqueues the emitted line before the next sweep.
 On failure the probe writes the recent service boot log to `state/<id>.deploy-log` and names it in the wake line.
+The bounded deadline (`FM_DEPLOY_VERIFY_DEADLINE`, default 1800s, measured from `deploy_armed_at`) exists so a deploy that is never created - autodeploy off, or superseded before creation - cannot hold teardown open forever.
 A project with no mapped service keeps the plain `merged` wake, unchanged.
 This transition fires for every merge path, because both a captain merge on GitHub and a `bin/fm-pr-merge.sh` self-merge are observed by the same merge poll.
 
@@ -42,20 +45,22 @@ A single commit can have several deploys (for example an `api`-triggered redeplo
 | Bucket | Render status | Meaning |
 | --- | --- | --- |
 | success (Live) | `live`, `inactive` | The commit built and served; `inactive` just means a newer deploy has since replaced it. |
-| failed | `build_failed`, `update_failed`, `pre_deploy_failed`, `canceled` | Newest deploy for the sha failed and none reached a served state. |
+| failed | `build_failed`, `update_failed`, `pre_deploy_failed` | Newest deploy for the sha failed and none reached a served state; a hard captain-facing blocker. |
 | pending | `created`, `queued`, `build_in_progress`, `update_in_progress`, `pre_deploy_in_progress`, or no deploy for the sha yet | Keep polling. |
-| other | anything else (e.g. `deactivated`) | Surfaced, never silently reported Live. |
+| other | `canceled`, `deactivated`, anything else | Surfaced, never silently reported Live, but not a hard failure. |
 
+`canceled` is deliberately not a failure: Render cancels a queued or in-progress deploy when a newer deploy supersedes it, so two merges landing close together on the same service would otherwise make the first task falsely report `deploy FAILED (canceled)` even though the newer live deploy contains the first merge's content.
+An `other`/`canceled` sha that never resolves is terminated by the bounded deadline's timed-out wake, not by a false failure.
 If any deploy for the sha reached a served state, the commit is Live even when an earlier deploy of the same commit failed.
 
 ## Modes
 
 - `fm-deploy-check.sh <service|project> <sha>` - blocking poll until Live (exit 0), failed (exit 3, prints boot log), or timeout (exit 2). For manual/direct use.
-- `fm-deploy-check.sh --once <service|project> <sha>` - single probe for the watcher check contract: one line iff terminal (Live or failed), silent otherwise, always exit 0.
+- `fm-deploy-check.sh --once <service|project> <sha>` - single probe for the watcher check contract: one line iff terminal (Live, failed, or timed out), silent otherwise, always exit 0. On the wired path it reads `FM_DEPLOY_ARMED_AT` (deadline reference) and `FM_DEPLOY_DISARM_PATH` (its own check.sh, removed after a terminal wake so it fires once).
 - `fm-deploy-check.sh --resolve <project>` - print the resolved service id.
-- `fm-deploy-check.sh --arm <id> <service|project> <sha>` - resolve once, record meta, write the deploy probe check.sh.
+- `fm-deploy-check.sh --arm <id> <service|project> <sha>` - resolve once, record meta (including `deploy_armed_at=`), write the deploy probe check.sh wired with the arm time and disarm path.
 
-Cadence and timeout are env-overridable: `FM_DEPLOY_POLL_INTERVAL` (default 15s), `FM_DEPLOY_TIMEOUT` (default 900s), `FM_DEPLOY_LOG_LINES` (default 50), `FM_RENDER_BIN` (default `render`).
+Cadence, timeout, and deadline are env-overridable: `FM_DEPLOY_POLL_INTERVAL` (default 15s), `FM_DEPLOY_TIMEOUT` (default 900s, the blocking poll's bound), `FM_DEPLOY_VERIFY_DEADLINE` (default 1800s, the wired watcher path's bound before a timed-out wake), `FM_DEPLOY_LOG_LINES` (default 50), `FM_RENDER_BIN` (default `render`).
 
 ## Evidence
 

--- a/tests/fm-deploy-check.test.sh
+++ b/tests/fm-deploy-check.test.sh
@@ -86,6 +86,20 @@ pass "resolve: runtime services fallback"
 FM_RENDER_SERVICES_MAP=/dev/null run 4 "resolve: unknown project errors" -- "$DEPLOY_CHECK" --resolve nosuchproj
 pass "resolve: unknown project errors"
 
+# A hanging render CLI must not hang resolution: the runtime services fallback
+# runs under FM_RENDER_SERVICES_TIMEOUT so the merge poll's --arm always fails
+# within the watcher's check budget and the plain merged wake stays reachable.
+HANGBIN="$TMP_ROOT/hangbin"
+mkdir -p "$HANGBIN"
+printf '#!/usr/bin/env bash\nsleep 300\n' > "$HANGBIN/render"
+chmod +x "$HANGBIN/render"
+HANG_START=$(date +%s)
+FM_RENDER_SERVICES_MAP=/dev/null FM_RENDER_BIN="$HANGBIN/render" FM_RENDER_SERVICES_TIMEOUT=1 \
+  run 4 "resolve: hanging render CLI is bounded" -- "$DEPLOY_CHECK" --resolve astroai
+HANG_ELAPSED=$(( $(date +%s) - HANG_START ))
+[ "$HANG_ELAPSED" -lt 10 ] || fail "bounded resolve took ${HANG_ELAPSED}s"
+pass "resolve: hanging render CLI is bounded"
+
 # --- --once classification (watcher check contract) -------------------------
 
 run 0 "once: live wins over a same-sha failure" -- "$DEPLOY_CHECK" --once srv-x 1111111111111111
@@ -179,6 +193,31 @@ assert_contains "$ARMOUT" "deploy live" "armed check.sh probes the deploy"
 assert_absent "$STATE/armtask.check.sh" "armed probe disarms after the terminal wake"
 pass "arm: resolves + writes check.sh"
 
+# --- --arm atomic write + re-arm meta replacement ----------------------------
+
+RSTATE="$TMP_ROOT/rstate"
+mkdir -p "$RSTATE"
+printf 'project=/repos/mtmccarthy\n' > "$RSTATE/rearm.meta"
+FM_STATE_OVERRIDE="$RSTATE" FM_RENDER_SERVICES_MAP="$MAP" \
+  run 0 "arm: first arm succeeds" -- "$DEPLOY_CHECK" --arm rearm mtmccarthy 1111111111111111
+[ -s "$RSTATE/rearm.check.sh" ] || fail "armed check.sh is empty"
+# Re-arm with a different sha (e.g. re-verification after a timed-out wake):
+# the deploy_* meta lines are replaced with fresh values, never skipped stale
+# or appended as duplicates, and unrelated meta lines survive.
+FM_STATE_OVERRIDE="$RSTATE" FM_RENDER_SERVICES_MAP="$MAP" \
+  run 0 "arm: re-arm succeeds" -- "$DEPLOY_CHECK" --arm rearm mtmccarthy 2222222222222222
+[ "$(grep -c '^deploy_sha=' "$RSTATE/rearm.meta")" = 1 ] || fail "re-arm duplicated deploy_sha lines"
+assert_grep "deploy_sha=2222222222222222" "$RSTATE/rearm.meta" "re-arm records the fresh sha"
+assert_no_grep "deploy_sha=1111111111111111" "$RSTATE/rearm.meta" "re-arm drops the stale sha"
+[ "$(grep -c '^deploy_service=' "$RSTATE/rearm.meta")" = 1 ] || fail "re-arm duplicated deploy_service lines"
+[ "$(grep -c '^deploy_armed_at=' "$RSTATE/rearm.meta")" = 1 ] || fail "re-arm duplicated deploy_armed_at lines"
+assert_grep "project=/repos/mtmccarthy" "$RSTATE/rearm.meta" "re-arm preserves unrelated meta lines"
+[ -s "$RSTATE/rearm.check.sh" ] || fail "re-armed check.sh is empty"
+# The temp-then-mv writes leave no stray temp files behind (and their dotfile
+# names can never match the watcher's *.check.sh glob mid-write).
+if ls "$RSTATE"/.rearm.* >/dev/null 2>&1; then fail "arm left temp files behind"; fi
+pass "arm: atomic write + re-arm replaces meta lines"
+
 # --- merge-path wiring: fm-pr-check transitions merge -> deploy --------------
 
 # Fake gh: PR is MERGED, merge commit is a Live sha.
@@ -203,6 +242,8 @@ assert_present "$WSTATE/wtask.check.sh" "merge poll written"
 POLLOUT=$(FM_STATE_OVERRIDE="$WSTATE" FM_RENDER_SERVICES_MAP="$MAP" bash "$WSTATE/wtask.check.sh" 2>/dev/null)
 assert_contains "$POLLOUT" "verifying deploy" "merge poll hands off to deploy verify"
 assert_grep "--once" "$WSTATE/wtask.check.sh" "check.sh replaced by deploy probe"
+[ -s "$WSTATE/wtask.check.sh" ] || fail "handed-off check.sh is empty"
+if ls "$WSTATE"/.wtask.* >/dev/null 2>&1; then fail "handoff left temp files behind"; fi
 pass "wiring: merged PR with a mapped service transitions to deploy verify"
 
 # Same merge, but no service maps (empty map, services fixture lacks the name):

--- a/tests/fm-deploy-check.test.sh
+++ b/tests/fm-deploy-check.test.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# Tests for bin/fm-deploy-check.sh and its merge-path wiring in
+# bin/fm-pr-check.sh. A merge is not shipped until its deploy goes Live; these
+# tests exercise service resolution, deploy classification, the --once watcher
+# check contract, the --arm handoff, the blocking poll, and the merge poll's
+# automatic transition to deploy verification. The Render CLI and gh are mocked.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+DEPLOY_CHECK="$ROOT/bin/fm-deploy-check.sh"
+PR_CHECK="$ROOT/bin/fm-pr-check.sh"
+TMP_ROOT=$(fm_test_tmproot fm-deploy-check-tests)
+mkdir -p "$TMP_ROOT"
+
+# A deploys fixture reproducing the real silent-failure shape: commit LIVESHA
+# has both a live deploy and an older update_failed one; FAILSHA has only a
+# failed deploy; PENDSHA is still building; no deploy exists for any other sha.
+DEPLOYS_JSON="$TMP_ROOT/deploys.json"
+cat > "$DEPLOYS_JSON" <<'JSON'
+[
+  {"commit":{"id":"1111111111111111"},"status":"update_failed","id":"dep-oldfail","createdAt":"2026-07-06T13:32:49Z"},
+  {"commit":{"id":"1111111111111111"},"status":"live","id":"dep-livewin","createdAt":"2026-07-06T13:46:56Z"},
+  {"commit":{"id":"2222222222222222"},"status":"update_failed","id":"dep-fail","createdAt":"2026-07-05T23:37:34Z"},
+  {"commit":{"id":"3333333333333333"},"status":"build_in_progress","id":"dep-pending","createdAt":"2026-07-07T10:00:00Z"}
+]
+JSON
+
+# A services fixture in Render's real wrapped shape (name/id under .service).
+SERVICES_JSON="$TMP_ROOT/services.json"
+cat > "$SERVICES_JSON" <<'JSON'
+[
+  {"postgres":{"id":"dpg-x","name":"astrology_insights"}},
+  {"service":{"name":"mtmccarthy","id":"srv-realmtm","type":"web_service"}},
+  {"service":{"name":"astroai","id":"srv-realastro","type":"web_service"}}
+]
+JSON
+
+LOGS_TXT="$TMP_ROOT/logs.txt"
+printf 'boot: SECRET_KEY environment variable is not set\n' > "$LOGS_TXT"
+
+# Fake render CLI: branches on the subcommand and echoes the fixtures. Reads the
+# fixture paths from the environment so tests can vary them per case.
+FAKEBIN=$(fm_fakebin "$TMP_ROOT")
+cat > "$FAKEBIN/render" <<'SH'
+#!/usr/bin/env bash
+case "$1" in
+  deploys) cat "${RENDER_DEPLOYS_JSON:-/dev/null}" ;;
+  services) cat "${RENDER_SERVICES_JSON:-/dev/null}" ;;
+  logs) cat "${RENDER_LOGS_TXT:-/dev/null}" ;;
+  *) exit 1 ;;
+esac
+SH
+chmod +x "$FAKEBIN/render"
+export PATH="$FAKEBIN:$PATH"
+export RENDER_DEPLOYS_JSON="$DEPLOYS_JSON" RENDER_SERVICES_JSON="$SERVICES_JSON" RENDER_LOGS_TXT="$LOGS_TXT"
+
+# run <expected-exit> <label> -- <cmd...>: run cmd, capture stdout, check exit.
+# Sets OUT to captured stdout for follow-up assertions.
+run() {
+  local expected=$1 label=$2 code
+  shift 3  # drop expected, label, and the literal --
+  OUT=$("$@" 2>/dev/null) && code=0 || code=$?
+  expect_code "$expected" "$code" "$label"
+}
+
+# --- service resolution -----------------------------------------------------
+
+run 0 "resolve: srv- id passes through" -- "$DEPLOY_CHECK" --resolve srv-abc123
+[ "$OUT" = "srv-abc123" ] || fail "srv- passthrough: got '$OUT'"
+pass "resolve: srv- id passes through"
+
+MAP="$TMP_ROOT/map.txt"
+printf '# comment\n\nmtmccarthy srv-frommap\n' > "$MAP"
+FM_RENDER_SERVICES_MAP="$MAP" run 0 "resolve: map file wins" -- "$DEPLOY_CHECK" --resolve mtmccarthy
+[ "$OUT" = "srv-frommap" ] || fail "map resolve: got '$OUT'"
+pass "resolve: map file wins"
+
+# Empty map -> runtime `render services` fallback by name.
+FM_RENDER_SERVICES_MAP=/dev/null run 0 "resolve: runtime services fallback" -- "$DEPLOY_CHECK" --resolve astroai
+[ "$OUT" = "srv-realastro" ] || fail "runtime resolve: got '$OUT'"
+pass "resolve: runtime services fallback"
+
+FM_RENDER_SERVICES_MAP=/dev/null run 4 "resolve: unknown project errors" -- "$DEPLOY_CHECK" --resolve nosuchproj
+pass "resolve: unknown project errors"
+
+# --- --once classification (watcher check contract) -------------------------
+
+run 0 "once: live wins over a same-sha failure" -- "$DEPLOY_CHECK" --once srv-x 1111111111111111
+assert_contains "$OUT" "deploy live" "once live output"
+pass "once: live wins over a same-sha failure"
+
+LOGOUT="$TMP_ROOT/task.deploy-log"
+FM_DEPLOY_LOG_OUT="$LOGOUT" run 0 "once: failed emits one line + boot log" -- "$DEPLOY_CHECK" --once srv-x 2222222222222222
+assert_contains "$OUT" "deploy FAILED" "once failed output"
+assert_contains "$OUT" "update_failed" "once failed status"
+assert_contains "$OUT" "dep-fail" "once failed deploy id"
+[ -s "$LOGOUT" ] || fail "boot log not written"
+assert_grep "SECRET_KEY" "$LOGOUT" "boot log content captured"
+pass "once: failed emits one line + boot log"
+
+run 0 "once: pending is silent" -- "$DEPLOY_CHECK" --once srv-x 3333333333333333
+[ -z "$OUT" ] || fail "pending should be silent, got '$OUT'"
+pass "once: pending is silent"
+
+run 0 "once: unknown sha is silent" -- "$DEPLOY_CHECK" --once srv-x deadbeef
+[ -z "$OUT" ] || fail "no-deploy should be silent, got '$OUT'"
+pass "once: unknown sha is silent"
+
+# --- blocking poll ----------------------------------------------------------
+
+FM_DEPLOY_POLL_INTERVAL=0 FM_DEPLOY_TIMEOUT=0 run 0 "poll: live exits 0" -- "$DEPLOY_CHECK" srv-x 1111111111111111
+pass "poll: live exits 0"
+
+FM_DEPLOY_POLL_INTERVAL=0 FM_DEPLOY_TIMEOUT=0 run 3 "poll: failed exits 3 with boot log" -- "$DEPLOY_CHECK" srv-x 2222222222222222
+assert_contains "$OUT" "SECRET_KEY" "poll failed prints boot log"
+pass "poll: failed exits 3 with boot log"
+
+# Unknown sha never reaches Live -> bounded timeout exit 2.
+FM_DEPLOY_POLL_INTERVAL=0 FM_DEPLOY_TIMEOUT=0 run 2 "poll: timeout exits 2" -- "$DEPLOY_CHECK" srv-x deadbeef
+pass "poll: timeout exits 2"
+
+# --- --arm writes meta + a deploy probe check.sh ----------------------------
+
+STATE="$TMP_ROOT/state"
+mkdir -p "$STATE"
+printf 'project=/repos/mtmccarthy\n' > "$STATE/armtask.meta"
+FM_STATE_OVERRIDE="$STATE" FM_RENDER_SERVICES_MAP="$MAP" \
+  run 0 "arm: resolves + writes check.sh" -- "$DEPLOY_CHECK" --arm armtask mtmccarthy 1111111111111111
+assert_grep "deploy_service=srv-frommap" "$STATE/armtask.meta" "arm records service"
+assert_grep "deploy_sha=1111111111111111" "$STATE/armtask.meta" "arm records sha"
+assert_present "$STATE/armtask.check.sh" "arm wrote check.sh"
+assert_grep "--once" "$STATE/armtask.check.sh" "armed check.sh is a deploy probe"
+# The armed check.sh, run under the watcher contract, reports live for this sha.
+ARMOUT=$(FM_STATE_OVERRIDE="$STATE" bash "$STATE/armtask.check.sh" 2>/dev/null)
+assert_contains "$ARMOUT" "deploy live" "armed check.sh probes the deploy"
+pass "arm: resolves + writes check.sh"
+
+# --- merge-path wiring: fm-pr-check transitions merge -> deploy --------------
+
+# Fake gh: PR is MERGED, merge commit is a Live sha.
+cat > "$FAKEBIN/gh" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *"--json state"*) echo MERGED ;;
+  *"--json mergeCommit"*) echo 1111111111111111 ;;
+  *"--json headRefOid"*) echo 1111111111111111 ;;
+esac
+SH
+chmod +x "$FAKEBIN/gh"
+
+WSTATE="$TMP_ROOT/wstate"
+mkdir -p "$WSTATE"
+printf 'project=/repos/mtmccarthy\n' > "$WSTATE/wtask.meta"
+FM_STATE_OVERRIDE="$WSTATE" run 0 "wiring: pr-check arms merge poll" -- \
+  "$PR_CHECK" wtask https://github.com/o/mtmccarthy/pull/7
+assert_present "$WSTATE/wtask.check.sh" "merge poll written"
+
+# Run the merge poll with a mapped service: it must hand off to deploy verify.
+POLLOUT=$(FM_STATE_OVERRIDE="$WSTATE" FM_RENDER_SERVICES_MAP="$MAP" bash "$WSTATE/wtask.check.sh" 2>/dev/null)
+assert_contains "$POLLOUT" "verifying deploy" "merge poll hands off to deploy verify"
+assert_grep "--once" "$WSTATE/wtask.check.sh" "check.sh replaced by deploy probe"
+pass "wiring: merged PR with a mapped service transitions to deploy verify"
+
+# Same merge, but no service maps (empty map, services fixture lacks the name):
+# the poll must fall back to the plain "merged" wake and NOT rewrite check.sh.
+NSTATE="$TMP_ROOT/nstate"
+mkdir -p "$NSTATE"
+printf 'project=/repos/unmappedproj\n' > "$NSTATE/ntask.meta"
+FM_STATE_OVERRIDE="$NSTATE" run 0 "wiring: pr-check arms (no service)" -- \
+  "$PR_CHECK" ntask https://github.com/o/unmappedproj/pull/9
+NPOLLOUT=$(FM_STATE_OVERRIDE="$NSTATE" FM_RENDER_SERVICES_MAP=/dev/null bash "$NSTATE/ntask.check.sh" 2>/dev/null)
+[ "$NPOLLOUT" = "merged" ] || fail "no-service poll should emit plain 'merged', got '$NPOLLOUT'"
+assert_no_grep "--once" "$NSTATE/ntask.check.sh" "no-service check.sh stays the merge poll"
+pass "wiring: merged PR with no mapped service keeps the plain merged wake"
+
+echo "# all fm-deploy-check tests passed"

--- a/tests/fm-deploy-check.test.sh
+++ b/tests/fm-deploy-check.test.sh
@@ -23,7 +23,8 @@ cat > "$DEPLOYS_JSON" <<'JSON'
   {"commit":{"id":"1111111111111111"},"status":"update_failed","id":"dep-oldfail","createdAt":"2026-07-06T13:32:49Z"},
   {"commit":{"id":"1111111111111111"},"status":"live","id":"dep-livewin","createdAt":"2026-07-06T13:46:56Z"},
   {"commit":{"id":"2222222222222222"},"status":"update_failed","id":"dep-fail","createdAt":"2026-07-05T23:37:34Z"},
-  {"commit":{"id":"3333333333333333"},"status":"build_in_progress","id":"dep-pending","createdAt":"2026-07-07T10:00:00Z"}
+  {"commit":{"id":"3333333333333333"},"status":"build_in_progress","id":"dep-pending","createdAt":"2026-07-07T10:00:00Z"},
+  {"commit":{"id":"4444444444444444"},"status":"canceled","id":"dep-canceled","createdAt":"2026-07-07T11:00:00Z"}
 ]
 JSON
 
@@ -108,6 +109,42 @@ run 0 "once: unknown sha is silent" -- "$DEPLOY_CHECK" --once srv-x deadbeef
 [ -z "$OUT" ] || fail "no-deploy should be silent, got '$OUT'"
 pass "once: unknown sha is silent"
 
+# 'canceled' is a superseded deploy, not a hard failure: it must NOT emit a
+# 'deploy FAILED' blocker and stays silent (no deadline set here).
+run 0 "once: canceled is not a failure (silent)" -- "$DEPLOY_CHECK" --once srv-x 4444444444444444
+[ -z "$OUT" ] || fail "canceled should be silent (not FAILED), got '$OUT'"
+pass "once: canceled is not a failure (silent)"
+
+# --- --once bounded deadline + disarm ---------------------------------------
+
+# Past the deadline with no deploy for the sha, --once emits a timed-out wake
+# (so a never-created deploy cannot hold teardown open forever) and disarms.
+DISARM1="$TMP_ROOT/timeout.check.sh"
+touch "$DISARM1"
+FM_DEPLOY_ARMED_AT=1 FM_DEPLOY_VERIFY_DEADLINE=0 FM_DEPLOY_DISARM_PATH="$DISARM1" \
+  run 0 "once: deadline emits timed-out wake" -- "$DEPLOY_CHECK" --once srv-x deadbeef
+assert_contains "$OUT" "TIMED OUT" "deadline timed-out wake"
+assert_absent "$DISARM1" "timed-out wake disarms (removes check.sh)"
+pass "once: deadline emits timed-out wake and disarms"
+
+# Before the deadline, a pending sha stays silent and stays armed.
+DISARM2="$TMP_ROOT/pending.check.sh"
+touch "$DISARM2"
+FM_DEPLOY_ARMED_AT=9999999999 FM_DEPLOY_VERIFY_DEADLINE=1800 FM_DEPLOY_DISARM_PATH="$DISARM2" \
+  run 0 "once: pre-deadline pending stays armed" -- "$DEPLOY_CHECK" --once srv-x 3333333333333333
+[ -z "$OUT" ] || fail "pre-deadline pending should be silent, got '$OUT'"
+assert_present "$DISARM2" "pre-deadline pending stays armed (check.sh kept)"
+pass "once: pre-deadline pending stays silent and armed"
+
+# A terminal Live wake disarms the wired probe so it fires exactly once.
+DISARM3="$TMP_ROOT/live.check.sh"
+touch "$DISARM3"
+FM_DEPLOY_DISARM_PATH="$DISARM3" \
+  run 0 "once: terminal live disarms" -- "$DEPLOY_CHECK" --once srv-x 1111111111111111
+assert_contains "$OUT" "deploy live" "terminal live wake"
+assert_absent "$DISARM3" "live wake disarms (removes check.sh)"
+pass "once: terminal live wake disarms"
+
 # --- blocking poll ----------------------------------------------------------
 
 FM_DEPLOY_POLL_INTERVAL=0 FM_DEPLOY_TIMEOUT=0 run 0 "poll: live exits 0" -- "$DEPLOY_CHECK" srv-x 1111111111111111
@@ -130,11 +167,16 @@ FM_STATE_OVERRIDE="$STATE" FM_RENDER_SERVICES_MAP="$MAP" \
   run 0 "arm: resolves + writes check.sh" -- "$DEPLOY_CHECK" --arm armtask mtmccarthy 1111111111111111
 assert_grep "deploy_service=srv-frommap" "$STATE/armtask.meta" "arm records service"
 assert_grep "deploy_sha=1111111111111111" "$STATE/armtask.meta" "arm records sha"
+assert_grep "deploy_armed_at=" "$STATE/armtask.meta" "arm records the arm timestamp"
 assert_present "$STATE/armtask.check.sh" "arm wrote check.sh"
 assert_grep "--once" "$STATE/armtask.check.sh" "armed check.sh is a deploy probe"
-# The armed check.sh, run under the watcher contract, reports live for this sha.
+assert_grep "FM_DEPLOY_ARMED_AT=" "$STATE/armtask.check.sh" "armed check.sh carries the arm time"
+assert_grep "FM_DEPLOY_DISARM_PATH=" "$STATE/armtask.check.sh" "armed check.sh carries its disarm path"
+# The armed check.sh, run under the watcher contract, reports live for this sha
+# and then disarms itself so the terminal wake fires exactly once.
 ARMOUT=$(FM_STATE_OVERRIDE="$STATE" bash "$STATE/armtask.check.sh" 2>/dev/null)
 assert_contains "$ARMOUT" "deploy live" "armed check.sh probes the deploy"
+assert_absent "$STATE/armtask.check.sh" "armed probe disarms after the terminal wake"
 pass "arm: resolves + writes check.sh"
 
 # --- merge-path wiring: fm-pr-check transitions merge -> deploy --------------

--- a/tests/fm-gotmp.test.sh
+++ b/tests/fm-gotmp.test.sh
@@ -52,6 +52,7 @@ make_fake_root() {
   ln -s "$ROOT/bin/fm-backend.sh" "$fake/bin/fm-backend.sh"
   ln -s "$ROOT/bin/backends/tmux.sh" "$fake/bin/backends/tmux.sh"
   ln -s "$ROOT/bin/fm-tmux-lib.sh" "$fake/bin/fm-tmux-lib.sh"
+  ln -s "$ROOT/bin/fm-composer-lib.sh" "$fake/bin/fm-composer-lib.sh"
   # fm-lock-lib.sh: teardown sources it for the shared lock-staleness proof.
   ln -s "$ROOT/bin/fm-lock-lib.sh" "$fake/bin/fm-lock-lib.sh"
   # fm-guard.sh: stub (teardown calls it with `|| true`).
@@ -148,6 +149,7 @@ test_teardown_skips_gracefully_without_tasktmp() {
   ln -s "$ROOT/bin/fm-backend.sh" "$fake/bin/fm-backend.sh"
   ln -s "$ROOT/bin/backends/tmux.sh" "$fake/bin/backends/tmux.sh"
   ln -s "$ROOT/bin/fm-tmux-lib.sh" "$fake/bin/fm-tmux-lib.sh"
+  ln -s "$ROOT/bin/fm-composer-lib.sh" "$fake/bin/fm-composer-lib.sh"
   ln -s "$ROOT/bin/fm-lock-lib.sh" "$fake/bin/fm-lock-lib.sh"
   cat > "$fake/bin/fm-guard.sh" <<'SH'
 #!/usr/bin/env bash

--- a/tests/fm-pi-watch-extension.test.sh
+++ b/tests/fm-pi-watch-extension.test.sh
@@ -7,6 +7,7 @@ set -u
 
 TMP_ROOT=$(fm_test_tmproot fm-pi-watch-extension)
 EXT="$ROOT/.pi/extensions/fm-primary-pi-watch.ts"
+NODE_TS_MODULE=(node --experimental-strip-types --no-warnings --input-type=module)
 
 install_pi_watch_extension_fixture() {
   local repo=$1
@@ -82,7 +83,7 @@ test_pi_extension_reports_external_healthy_watcher() {
 printf 'watcher: healthy pid=1 (beacon 0s)\n'
 SH
   chmod +x "$repo/bin/fm-watch-arm.sh"
-  out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" node --input-type=module 2>&1 <<'EOF'
+  out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" "${NODE_TS_MODULE[@]}" 2>&1 <<'EOF'
 import { writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
@@ -156,7 +157,7 @@ test_pi_tool_returns_agent_tool_result() {
 exit 0
 SH
   chmod +x "$repo/bin/fm-watch-arm.sh"
-  out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" node --input-type=module 2>&1 <<'EOF'
+  out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" "${NODE_TS_MODULE[@]}" 2>&1 <<'EOF'
 import { writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
@@ -202,7 +203,7 @@ test_pi_process_exit_cleanup_listener_lifecycle() {
   plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
   : > "$repo/bin/fm-watch-arm.sh"
   chmod +x "$repo/bin/fm-watch-arm.sh"
-  out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" node --input-type=module 2>&1 <<'EOF'
+  out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" "${NODE_TS_MODULE[@]}" 2>&1 <<'EOF'
 import { pathToFileURL } from "node:url";
 
 const handlers = new Map();
@@ -248,7 +249,7 @@ printf '%s\n' "$$" > "$FM_CHILD_PID_FILE"
 while :; do sleep 1; done
 SH
   chmod +x "$repo/bin/fm-watch-arm.sh"
-  out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" FM_CLEANUP_LOG="$cleanup_log" FM_CHILD_PID_FILE="$pid_file" node --input-type=module 2>&1 <<'EOF'
+  out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" FM_CLEANUP_LOG="$cleanup_log" FM_CHILD_PID_FILE="$pid_file" "${NODE_TS_MODULE[@]}" 2>&1 <<'EOF'
 import { existsSync, writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 

--- a/tests/fm-turnend-guard.test.sh
+++ b/tests/fm-turnend-guard.test.sh
@@ -20,6 +20,7 @@ TMP_ROOT=$(fm_test_tmproot fm-turnend-guard)
 fm_git_identity fmtest fmtest@example.invalid
 
 REQUIRED_REASON='resume supervision with bin/fm-watch-arm.sh as its own Claude Code background task'
+NODE_TS_MODULE=(node --experimental-strip-types --no-warnings --input-type=module)
 
 # --- PREDICATE: bin/fm-supervision-lib.sh -----------------------------------
 
@@ -612,7 +613,7 @@ SH
 exit 0
 SH
   chmod +x "$repo/bin/fm-turnend-guard.sh" "$repo/bin/fm-arm-pretool-check.sh"
-  out=$(PLUGIN="$ext" FM_HOME="$home" FM_GUARD_LOG="$log" node --input-type=module 2>&1 <<'EOF'
+  out=$(PLUGIN="$ext" FM_HOME="$home" FM_GUARD_LOG="$log" "${NODE_TS_MODULE[@]}" 2>&1 <<'EOF'
 import { readFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
@@ -672,7 +673,7 @@ SH
 exit 0
 SH
   chmod +x "$repo/bin/fm-turnend-guard.sh" "$repo/bin/fm-arm-pretool-check.sh"
-  out=$(PLUGIN="$ext" FM_HOME="$home" node --input-type=module 2>&1 <<'EOF'
+  out=$(PLUGIN="$ext" FM_HOME="$home" "${NODE_TS_MODULE[@]}" 2>&1 <<'EOF'
 import { pathToFileURL } from "node:url";
 
 const handlers = new Map();


### PR DESCRIPTION
## Summary

- Add a read-only Render deploy checker that resolves configured services, polls a target commit to Live within a bounded deadline, and captures boot logs for failed deploys.
- Arm per-task post-merge checks automatically for mapped Render projects while preserving the one-line wake contract and disarming terminal checks.
- Add data-driven configuration guidance, focused mocked-CLI coverage, and validation-fixture repairs required by the current test suite.

## Test plan

- `shellcheck bin/*.sh bin/backends/*.sh tests/*.sh`
- Full `tests/*.test.sh` suite with `tasks-axi@0.2.2` on `PATH`
- no-mistakes review, test, document, and lint gates