### PR TITLE
fix: harden away-mode daemon lifecycle

### DIFF
--- a/.agents/skills/afk/SKILL.md
+++ b/.agents/skills/afk/SKILL.md
@@ -23,16 +23,28 @@ batched digest rather than per-wake injections.
    This file survives a firstmate restart: recovery re-enters afk if the
    flag is present.
 
-2. **Ensure the sub-supervisor daemon is running.** Start the helper as its own
-   tracked background terminal/session:
-   ```sh
-   bin/fm-afk-start.sh
-   ```
-   The helper sets or refreshes `state/.afk`, exits immediately if the identity-backed daemon lock already names a live process, and otherwise execs `bin/fm-supervise-daemon.sh` in the foreground.
-   Do not wrap this in `nohup ... &`.
-   Codex/herdr can reap fire-and-forget shell children after a tool call
-   returns; a tracked background terminal/session keeps the daemon attached to
-   the harness lifecycle and survived the real incident reproduction.
+2. **Ensure the sub-supervisor daemon is running, in a NON-VISIBLE terminal.**
+   The daemon must run as a tracked background process, and getting one differs
+   by harness. Pick the right path:
+   - **Harness WITH a native in-pane tracked-background tool** (e.g. claude's
+     background bash, grok's background tool): run `bin/fm-afk-start.sh` through
+     that tool. The daemon inherits the captain pane's env and auto-discovers
+     it. Do not wrap it in `nohup ... &` (Codex/herdr can reap fire-and-forget
+     shell children after a tool call returns).
+   - **Harness WITHOUT one** (e.g. pi): run `bin/fm-afk-launch.sh start`. It is
+     the single owner of the daemon terminal: it creates a NON-VISIBLE tracked
+     terminal for the current backend (a herdr dedicated `--no-focus` workspace,
+     a detached tmux session), records its exact id, and passes the captain pane
+     in as `FM_SUPERVISOR_TARGET` so the daemon injects into the captain, not its
+     own new pane. **Never manufacture a terminal by splitting the captain's
+     active pane** (`herdr pane split`): a split co-tenants the tab and visibly
+     shrinks the captain's pane (docs/herdr-backend.md "Away-mode daemon terminal
+     launch").
+   Both paths share `bin/fm-afk-start.sh` as the daemon entry: it sets or
+   refreshes `state/.afk`, exits immediately if the identity-backed daemon lock
+   already names a live process, otherwise clears the previous away session's
+   stale escalation artifacts (see "Stale-artifact lifecycle" below) and execs
+   `bin/fm-supervise-daemon.sh` in the foreground.
    The daemon is **presence-gated**: it injects escalations only while
    `state/.afk` exists, and stays quiet otherwise.
 
@@ -47,7 +59,8 @@ batched digest rather than per-wake injections.
 No `/back` is needed. The first genuine message is the return signal:
 
 - A message **without** the sentinel marker and **not** starting with `/afk` -> the captain is back.
-  Clear `state/.afk`, stop the daemon, flush one distilled "while you were out" catch-up (drain `state/.wake-queue`, summarize any pending escalations from `state/.subsuper-escalations` and any `state/.subsuper-inject-wedged` marker), and resume full per-wake responsiveness through the emitted primary-harness supervision protocol from session start.
+  Run `bin/fm-afk-launch.sh stop`: it stops the daemon in the correct order - it SIGTERMs the daemon so its shutdown flush runs **while `state/.afk` is still present** (clearing the flag first makes that flush a no-op via the daemon's presence gate, stranding undelivered escalations), then closes the daemon's own terminal by exact id, then clears `state/.afk` last.
+  Then flush one distilled "while you were out" catch-up (drain `state/.wake-queue`, summarize any pending escalations from `state/.subsuper-escalations` and any `state/.subsuper-inject-wedged` marker), and resume full per-wake responsiveness through the emitted primary-harness supervision protocol from session start.
 - A message **with** the sentinel marker (`FM_INJECT_MARK`, ASCII 0x1f) -> it
   is a daemon escalation; stay afk and process it.
 - Re-invoking `/afk` while already away -> stay afk (refresh the flag); this
@@ -197,6 +210,33 @@ the marker lets firstmate distinguish it from a real captain message.
   supervisor backends; the daemon refuses loudly at startup instead of
   misapplying tmux primitives to a pane that isn't one
   (docs/herdr-backend.md "Away-mode daemon: herdr supervisor-pane support").
+
+## Stale-artifact lifecycle
+
+`state/.subsuper-escalations` (plus its `.since` sidecar) and
+`state/.subsuper-inject-wedged` are the daemon's transient escalation-DELIVERY
+cache, not the durable record of pending work (that is `state/.wake-queue` plus
+each crew's `state/<id>.status`). They are cleared only on a successful flush,
+so an away session that ended with anything undelivered - the common case, since
+the captain returning makes their pane busy and the exit flush can defer - used
+to leave them on disk, and the NEXT away session's daemon surfaced them as stale
+escalations from an old session.
+
+Two fixes close that leak, and they compose:
+
+- **Correct exit ordering** (`bin/fm-afk-launch.sh stop`, above): the daemon is
+  stopped while `state/.afk` is still present, so its shutdown flush is actually
+  attempted instead of being a structural no-op.
+- **Session-scoped clear on a fresh entry** (`fm_afk_clear_stale_artifacts` in
+  `bin/fm-afk-start.sh`): when the daemon is not already running, a fresh entry
+  removes any leftover `state/.subsuper-escalations`, its `.since` sidecar, and
+  `state/.subsuper-inject-wedged` before the new daemon starts. This is
+  session-scoped by timing - the new daemon has produced nothing yet, so anything
+  present belongs to a prior session - and it is NOT done on a refresh (daemon
+  already alive), so the current session's own buffer is preserved. It never
+  drops a genuinely-pending escalation: any condition still true is re-derived
+  and re-escalated by the daemon's heartbeat catch-all scan and the durable
+  `state/.wake-queue` replay.
 
 ## Reliability properties
 

--- a/.agents/skills/afk/SKILL.md
+++ b/.agents/skills/afk/SKILL.md
@@ -16,21 +16,22 @@ batched digest rather than per-wake injections.
 
 ## What it does
 
-1. **Set the durable away-mode flag:**
-   ```sh
-   date '+%s' > state/.afk
-   ```
-   This file survives a firstmate restart: recovery re-enters afk if the
-   flag is present.
+1. **Enter the lifecycle through `bin/fm-afk-launch.sh`.**
+   This owns the durable state write, session-scoped stale-artifact clearing,
+   terminal record, and rollback.
+   The flag survives a firstmate restart, so recovery re-enters afk when it is present.
 
-2. **Ensure the sub-supervisor daemon is running, in a NON-VISIBLE terminal.**
-   The daemon must run as a tracked background process, and getting one differs
+2. **Ensure the sub-supervisor daemon is running as a tracked background process.**
+   Its hosting differs
    by harness. Pick the right path:
    - **Harness WITH a native in-pane tracked-background tool** (e.g. claude's
-     background bash, grok's background tool): run `bin/fm-afk-start.sh` through
-     that tool. The daemon inherits the captain pane's env and auto-discovers
-     it. Do not wrap it in `nohup ... &` (Codex/herdr can reap fire-and-forget
-     shell children after a tool call returns).
+     background bash, grok's background tool): first run
+     `bin/fm-afk-launch.sh start-native`, then run
+     `FM_AFK_STATE_PREPARED=1 bin/fm-afk-start.sh` through that native tool.
+     This is a deliberate no-separate-terminal exception because the harness-hosted job creates no terminal or layout mutation, and a shell launcher cannot invoke a harness-native background tool.
+     The launcher still owns lifecycle state and records the no-terminal mode, while the daemon inherits and auto-discovers the captain pane.
+     If the native launch fails, run `bin/fm-afk-launch.sh stop` to roll back the prepared lifecycle.
+     Do not wrap it in `nohup ... &` (Codex/herdr can reap fire-and-forget shell children after a tool call returns).
    - **Harness WITHOUT one** (e.g. pi): run `bin/fm-afk-launch.sh start`. It is
      the single owner of the daemon terminal: it creates a NON-VISIBLE tracked
      terminal for the current backend (a herdr dedicated `--no-focus` workspace,
@@ -40,11 +41,9 @@ batched digest rather than per-wake injections.
      active pane** (`herdr pane split`): a split co-tenants the tab and visibly
      shrinks the captain's pane (docs/herdr-backend.md "Away-mode daemon terminal
      launch").
-   Both paths share `bin/fm-afk-start.sh` as the daemon entry: it sets or
-   refreshes `state/.afk`, exits immediately if the identity-backed daemon lock
-   already names a live process, otherwise clears the previous away session's
-   stale escalation artifacts (see "Stale-artifact lifecycle" below) and execs
-   `bin/fm-supervise-daemon.sh` in the foreground.
+   Both paths share `bin/fm-afk-start.sh` as the daemon entry.
+   The native path tells it that the launcher already prepared lifecycle state; the terminal-backed path lets the entry perform its existing state setup inside the new terminal.
+   It exits immediately if the identity-backed daemon lock already names a live process, otherwise it execs `bin/fm-supervise-daemon.sh` in the foreground.
    The daemon is **presence-gated**: it injects escalations only while
    `state/.afk` exists, and stays quiet otherwise.
 

--- a/.agents/skills/afk/SKILL.md
+++ b/.agents/skills/afk/SKILL.md
@@ -22,8 +22,8 @@ batched digest rather than per-wake injections.
    The flag survives a firstmate restart, so recovery re-enters afk when it is present.
 
 2. **Ensure the sub-supervisor daemon is running as a tracked background process.**
-   Its hosting differs
-   by harness. Pick the right path:
+   Its hosting differs by harness.
+   Pick the right path:
    - **Harness WITH a native in-pane tracked-background tool** (e.g. claude's
      background bash, grok's background tool): first run
      `bin/fm-afk-launch.sh start-native`, then run
@@ -212,30 +212,10 @@ the marker lets firstmate distinguish it from a real captain message.
 
 ## Stale-artifact lifecycle
 
-`state/.subsuper-escalations` (plus its `.since` sidecar) and
-`state/.subsuper-inject-wedged` are the daemon's transient escalation-DELIVERY
-cache, not the durable record of pending work (that is `state/.wake-queue` plus
-each crew's `state/<id>.status`). They are cleared only on a successful flush,
-so an away session that ended with anything undelivered - the common case, since
-the captain returning makes their pane busy and the exit flush can defer - used
-to leave them on disk, and the NEXT away session's daemon surfaced them as stale
-escalations from an old session.
-
-Two fixes close that leak, and they compose:
-
-- **Correct exit ordering** (`bin/fm-afk-launch.sh stop`, above): the daemon is
-  stopped while `state/.afk` is still present, so its shutdown flush is actually
-  attempted instead of being a structural no-op.
-- **Session-scoped clear on a fresh entry** (`fm_afk_clear_stale_artifacts` in
-  `bin/fm-afk-start.sh`): when the daemon is not already running, a fresh entry
-  removes any leftover `state/.subsuper-escalations`, its `.since` sidecar, and
-  `state/.subsuper-inject-wedged` before the new daemon starts. This is
-  session-scoped by timing - the new daemon has produced nothing yet, so anything
-  present belongs to a prior session - and it is NOT done on a refresh (daemon
-  already alive), so the current session's own buffer is preserved. It never
-  drops a genuinely-pending escalation: any condition still true is re-derived
-  and re-escalated by the daemon's heartbeat catch-all scan and the durable
-  `state/.wake-queue` replay.
+Treat `state/.subsuper-escalations`, its `.since` sidecar, and `state/.subsuper-inject-wedged` as session-scoped delivery artifacts, not as the durable work record.
+Always enter through `bin/fm-afk-launch.sh`, which clears prior-session artifacts only for a fresh entry and preserves the current session's buffer on refresh.
+Always exit through `bin/fm-afk-launch.sh stop`, which keeps `state/.afk` present through the daemon's shutdown flush and clears it last.
+`docs/herdr-backend.md` "Stale-artifact lifecycle fix" owns the mechanism and verification evidence.
 
 ## Reliability properties
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -785,3 +785,10 @@ On an `x-mention <request_id>` or `x-mode-error ...` `check:` wake, load `fmx-re
 It owns mention classification, acting on the request, reply composition, voice, thread-splitting, image attachments, dry-run preview, and the completion-follow-up procedure in full, including what an `x-mode-error` wake means instead.
 `docs/configuration.md` "X mode (.env)" has the wire-protocol reference.
 The one fact that must survive here because it fires on a generic terminal wake, not the mention wake itself: when an X-mode-linked task reaches a terminal state, post its final completion follow-up per section 8's wake-handling step before tearing down.
+
+## Maintaining this file
+
+Keep this file for knowledge useful to almost every future agent session in this project.
+Do not repeat what the codebase already shows; point to the authoritative file or command instead.
+Prefer rewriting or pruning existing entries over appending new ones.
+When updating this file, preserve this bar for all agents and keep entries concise.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -633,7 +633,7 @@ Inline facts that must survive without a loaded skill:
 - While `state/.afk` exists, the daemon owns the watcher; do not separately arm `fm-watch-arm.sh` or `fm-watch.sh`.
 - If firstmate receives a marked message while afk is active, it is an internal escalation: stay afk and process it.
 - If the message starts with `/afk`, stay afk and refresh the flag.
-- Any other unmarked message means the captain is back: clear `state/.afk`, stop the daemon, flush catch-up from `state/.wake-queue`, `state/.subsuper-escalations`, and `state/.subsuper-inject-wedged`, then resume the emitted primary-harness supervision protocol.
+- Any other unmarked message means the captain is back: stop the daemon so its shutdown flush runs while `state/.afk` is still set and clear `state/.afk` last (the `/afk` skill owns this ordering, via `bin/fm-afk-launch.sh stop`; clearing the flag first would make the flush a no-op), flush catch-up from `state/.wake-queue`, `state/.subsuper-escalations`, and `state/.subsuper-inject-wedged`, then resume the emitted primary-harness supervision protocol.
 - Afk never changes approval authority; PR merges, ask-user findings, destructive actions, irreversible actions, and security-sensitive choices still require the same approval they required before.
 - Bias ambiguous cases toward exit because a present captain beats token savings and a false exit is self-correcting.
 

--- a/bin/fm-afk-launch.sh
+++ b/bin/fm-afk-launch.sh
@@ -47,6 +47,7 @@ FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$FM_AFK_LAUNCH_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 FM_AFK_LAUNCH_STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 FM_AFK_LAUNCH_RECORD="$FM_AFK_LAUNCH_STATE/.afk-daemon-terminal"
+FM_AFK_LAUNCH_LOCK="$FM_AFK_LAUNCH_STATE/.afk-launch.lock"
 FM_AFK_LAUNCH_WS_LABEL="firstmate-afk-daemon"
 
 # shellcheck source=bin/fm-backend.sh
@@ -62,6 +63,40 @@ FM_AFK_LAUNCH_WS_LABEL="firstmate-afk-daemon"
 set +e
 
 fm_afk_launch_log() { printf 'fm-afk-launch: %s\n' "$*" >&2; }
+
+fm_afk_launch_lock_owned() {
+  local pid expected actual
+  [ -d "$FM_AFK_LAUNCH_LOCK" ] || return 1
+  pid=$(cat "$FM_AFK_LAUNCH_LOCK/pid" 2>/dev/null) || return 1
+  expected=$(cat "$FM_AFK_LAUNCH_LOCK/pid-identity" 2>/dev/null) || return 1
+  actual=$(fm_pid_identity "$pid" 2>/dev/null) || return 1
+  [ -n "$expected" ] && [ "$actual" = "$expected" ]
+}
+
+fm_afk_launch_lock_acquire() {
+  local i
+  mkdir -p "$FM_AFK_LAUNCH_STATE"
+  for i in $(seq 1 200); do
+    if mkdir "$FM_AFK_LAUNCH_LOCK" 2>/dev/null; then
+      printf '%s' "$$" > "$FM_AFK_LAUNCH_LOCK/pid"
+      fm_pid_identity "$$" > "$FM_AFK_LAUNCH_LOCK/pid-identity" 2>/dev/null || true
+      return 0
+    fi
+    if ! fm_afk_launch_lock_owned; then
+      rm -rf "$FM_AFK_LAUNCH_LOCK" 2>/dev/null || true
+      continue
+    fi
+    sleep 0.05
+  done
+  fm_afk_launch_log "timed out waiting for launcher lock"
+  return 1
+}
+
+fm_afk_launch_lock_release() {
+  local pid
+  pid=$(cat "$FM_AFK_LAUNCH_LOCK/pid" 2>/dev/null || true)
+  [ "$pid" = "$$" ] && rm -rf "$FM_AFK_LAUNCH_LOCK" 2>/dev/null || true
+}
 
 fm_afk_launch_usage() {
   sed -n '2,34p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
@@ -179,35 +214,48 @@ fm_afk_launch_create_tmux() {  # <captain-target> <captain-backend>
 }
 
 fm_afk_launch_start() {
-  local captain_target captain_backend
+  local captain_target captain_backend backup artifact had_afk=0 result
   # Capture the captain pane FIRST, before creating anything.
   captain_target=$(discover_supervisor_target) || {
     fm_afk_launch_log "could not resolve the captain supervisor pane (set FM_SUPERVISOR_TARGET)"; return 1; }
   captain_backend=$(discover_supervisor_backend) || {
     fm_afk_launch_log "could not resolve the captain supervisor backend (set FM_SUPERVISOR_BACKEND)"; return 1; }
 
-  # Away mode is active immediately and deterministically.
   mkdir -p "$FM_AFK_LAUNCH_STATE"
-  date '+%s' > "$FM_AFK_LAUNCH_STATE/.afk"
 
   if daemon_lock_held_by_live_daemon; then
+    date '+%s' > "$FM_AFK_LAUNCH_STATE/.afk"
     fm_afk_launch_log "daemon already running; refreshed away-mode flag (no new terminal)"
     return 0
   fi
 
-  # Fresh entry: reconcile a leaked prior terminal, then clear the previous
-  # away session's stale artifacts before a new daemon can surface them.
+  backup=$(mktemp -d "$FM_AFK_LAUNCH_STATE/.afk-launch-backup.XXXXXX") || return 1
+  [ -f "$FM_AFK_LAUNCH_STATE/.afk" ] && had_afk=1 && cp "$FM_AFK_LAUNCH_STATE/.afk" "$backup/.afk"
+  for artifact in .subsuper-escalations .subsuper-escalations.since .subsuper-inject-wedged; do
+    [ -e "$FM_AFK_LAUNCH_STATE/$artifact" ] && cp -p "$FM_AFK_LAUNCH_STATE/$artifact" "$backup/$artifact"
+  done
   fm_afk_launch_reconcile
   fm_afk_clear_stale_artifacts "$FM_AFK_LAUNCH_STATE"
+  date '+%s' > "$FM_AFK_LAUNCH_STATE/.afk"
 
   case "$captain_backend" in
-    herdr) fm_afk_launch_create_herdr "$captain_target" "$captain_backend" ;;
-    tmux)  fm_afk_launch_create_tmux "$captain_target" "$captain_backend" ;;
+    herdr) fm_afk_launch_create_herdr "$captain_target" "$captain_backend"; result=$? ;;
+    tmux)  fm_afk_launch_create_tmux "$captain_target" "$captain_backend"; result=$? ;;
     *)
       fm_afk_launch_log "no non-visible daemon-launch primitive for backend '$captain_backend' yet (supported: herdr, tmux)"
-      return 1
+      result=1
       ;;
   esac
+  if [ "$result" -ne 0 ]; then
+    rm -f "$FM_AFK_LAUNCH_STATE/.afk" "$FM_AFK_LAUNCH_STATE/.subsuper-escalations" \
+      "$FM_AFK_LAUNCH_STATE/.subsuper-escalations.since" "$FM_AFK_LAUNCH_STATE/.subsuper-inject-wedged"
+    [ "$had_afk" -eq 1 ] && cp "$backup/.afk" "$FM_AFK_LAUNCH_STATE/.afk"
+    for artifact in .subsuper-escalations .subsuper-escalations.since .subsuper-inject-wedged; do
+      [ -e "$backup/$artifact" ] && cp -p "$backup/$artifact" "$FM_AFK_LAUNCH_STATE/$artifact"
+    done
+  fi
+  rm -rf "$backup"
+  return "$result"
 }
 
 fm_afk_launch_stop() {
@@ -215,8 +263,11 @@ fm_afk_launch_stop() {
   # (1) SIGTERM the daemon so its cleanup trap flushes buffered escalations
   # WHILE state/.afk is still present (the exit-ordering fix: clearing .afk
   # first would make that flush a no-op via inject_msg's presence gate).
-  pid=$(daemon_lock_pid 2>/dev/null || true)
-  if [ -n "$pid" ] && fm_pid_alive "$pid"; then
+  pid=""
+  if daemon_lock_held_by_live_daemon; then
+    pid=$(daemon_lock_pid 2>/dev/null || true)
+  fi
+  if [ -n "$pid" ]; then
     kill -TERM "$pid" 2>/dev/null || true
     for i in $(seq 1 40); do
       fm_pid_alive "$pid" || break
@@ -234,6 +285,8 @@ fm_afk_launch_stop() {
 }
 
 fm_afk_launch_main() {
+  fm_afk_launch_lock_acquire || return 1
+  trap fm_afk_launch_lock_release EXIT INT TERM
   case "${1:-start}" in
     start) fm_afk_launch_start ;;
     stop) fm_afk_launch_stop ;;
@@ -241,6 +294,10 @@ fm_afk_launch_main() {
     -h|--help|help) fm_afk_launch_usage ;;
     *) fm_afk_launch_usage >&2; return 2 ;;
   esac
+  local result=$?
+  fm_afk_launch_lock_release
+  trap - EXIT INT TERM
+  return "$result"
 }
 
 if [ "${BASH_SOURCE[0]}" = "${0}" ]; then

--- a/bin/fm-afk-launch.sh
+++ b/bin/fm-afk-launch.sh
@@ -74,7 +74,7 @@ fm_afk_launch_lock_owned() {
 }
 
 fm_afk_launch_lock_acquire() {
-  local i
+  local i incomplete=0
   mkdir -p "$FM_AFK_LAUNCH_STATE"
   for i in $(seq 1 200); do
     if mkdir "$FM_AFK_LAUNCH_LOCK" 2>/dev/null; then
@@ -82,8 +82,18 @@ fm_afk_launch_lock_acquire() {
       fm_pid_identity "$$" > "$FM_AFK_LAUNCH_LOCK/pid-identity" 2>/dev/null || true
       return 0
     fi
+    if [ ! -s "$FM_AFK_LAUNCH_LOCK/pid" ] || [ ! -s "$FM_AFK_LAUNCH_LOCK/pid-identity" ]; then
+      incomplete=$((incomplete + 1))
+      if [ "$incomplete" -lt 20 ]; then
+        sleep 0.05
+        continue
+      fi
+    else
+      incomplete=0
+    fi
     if ! fm_afk_launch_lock_owned; then
       rm -rf "$FM_AFK_LAUNCH_LOCK" 2>/dev/null || true
+      incomplete=0
       continue
     fi
     sleep 0.05
@@ -165,7 +175,7 @@ fm_afk_launch_reconcile() {
 # dedicated background workspace (--no-focus) holds exactly one tab/pane; it
 # never touches the captain's active tab. Prints the record line on success.
 fm_afk_launch_create_herdr() {  # <captain-target> <captain-backend>
-  local captain_target=$1 captain_backend=$2 session out wsid pane entry cmd
+  local captain_target=$1 captain_backend=$2 session out wsid pane entry cmd pane_list pane_count
   session=${captain_target%%:*}
   if [ -z "$session" ] || [ "$session" = "$captain_target" ]; then
     fm_afk_launch_log "cannot derive herdr session from captain target '$captain_target'"
@@ -179,6 +189,16 @@ fm_afk_launch_create_herdr() {  # <captain-target> <captain-backend>
   pane=$(printf '%s' "$out" | jq -r '.result.root_pane.pane_id // empty' 2>/dev/null)
   if [ -z "$wsid" ] || [ -z "$pane" ]; then
     fm_afk_launch_log "could not parse workspace/pane id from herdr workspace create"
+    if [ -n "$pane" ]; then
+      fm_backend_herdr_kill "$session:$pane"
+    elif [ -n "$wsid" ]; then
+      pane_list=$(fm_backend_herdr_cli "$session" pane list --workspace "$wsid" 2>/dev/null || true)
+      pane_count=$(printf '%s' "$pane_list" | jq '[.result.panes[]?] | length' 2>/dev/null || true)
+      if [ "$pane_count" = 1 ]; then
+        pane=$(printf '%s' "$pane_list" | jq -r '.result.panes[0].pane_id // empty' 2>/dev/null)
+        [ -n "$pane" ] && fm_backend_herdr_kill "$session:$pane"
+      fi
+    fi
     return 1
   fi
   entry=$(fm_afk_launch_entry_cmd)
@@ -285,8 +305,11 @@ fm_afk_launch_stop() {
 }
 
 fm_afk_launch_main() {
+  local result
   fm_afk_launch_lock_acquire || return 1
-  trap fm_afk_launch_lock_release EXIT INT TERM
+  trap fm_afk_launch_lock_release EXIT
+  trap 'exit 130' INT
+  trap 'exit 143' TERM
   case "${1:-start}" in
     start) fm_afk_launch_start ;;
     stop) fm_afk_launch_stop ;;
@@ -294,7 +317,7 @@ fm_afk_launch_main() {
     -h|--help|help) fm_afk_launch_usage ;;
     *) fm_afk_launch_usage >&2; return 2 ;;
   esac
-  local result=$?
+  result=$?
   fm_afk_launch_lock_release
   trap - EXIT INT TERM
   return "$result"

--- a/bin/fm-afk-launch.sh
+++ b/bin/fm-afk-launch.sh
@@ -395,19 +395,34 @@ fm_afk_launch_create_herdr() {  # <captain-target> <captain-backend>
 # captain's window). tmux pane ids are server-global, so the daemon reaches the
 # captain pane by its %id from this separate session.
 fm_afk_launch_create_tmux() {  # <captain-target> <captain-backend>
-  local captain_target=$1 captain_backend=$2 session entry cmd hash
+  local captain_target=$1 captain_backend=$2 session entry cmd hash probe_result probe_out
   hash=$(printf '%s' "$FM_HOME" | cksum | cut -d' ' -f1)
   session="fm-afk-daemon-$hash"
-  # Drop any leaked same-named daemon session first (exact id only).
-  tmux kill-session -t "$session" 2>/dev/null || true
+  probe_out=$(tmux has-session -t "$session" 2>&1)
+  probe_result=$?
+  if [ "$probe_result" -eq 0 ]; then
+    fm_afk_launch_log "unrecorded tmux session '$session' already exists; refusing to replace it"
+    return 1
+  fi
+  if [ "$probe_result" -ne 1 ] || ! printf '%s' "$probe_out" | grep -Eq "can't find session"; then
+    fm_afk_launch_log "could not confirm tmux session '$session' is absent"
+    return 1
+  fi
   entry=$(fm_afk_launch_entry_cmd)
   cmd=$(printf 'exec env FM_HOME=%q FM_SUPERVISOR_TARGET=%q FM_SUPERVISOR_BACKEND=%q %q' \
     "$FM_HOME" "$captain_target" "$captain_backend" "$entry")
-  if ! tmux new-session -d -s "$session" "$cmd" 2>/dev/null; then
-    fm_afk_launch_log "failed to create detached tmux daemon session '$session'"
+  if ! fm_afk_launch_record_write tmux "$session" ""; then
+    fm_afk_launch_log "failed to persist planned tmux daemon session '$session'"
     return 1
   fi
-  fm_afk_launch_commit_terminal tmux "$session" "" || return 1
+  if ! tmux new-session -d -s "$session" "$cmd" 2>/dev/null; then
+    fm_afk_launch_log "failed to create detached tmux daemon session '$session'"
+    FM_AFK_REC_BACKEND=tmux
+    FM_AFK_REC_TARGET=$session
+    fm_afk_launch_close_recorded || true
+    return 1
+  fi
+  fm_afk_launch_commit_terminal tmux "$session" "" 1 || return 1
   fm_afk_launch_log "daemon launched in detached tmux session '$session', supervising $captain_target"
 }
 
@@ -443,8 +458,12 @@ fm_afk_launch_start() {
   if ! fm_afk_launch_reconcile; then
     result=1
   else
-    fm_afk_clear_stale_artifacts "$FM_AFK_LAUNCH_STATE"
-    result=0
+    if fm_afk_clear_stale_artifacts "$FM_AFK_LAUNCH_STATE"; then
+      result=0
+    else
+      fm_afk_launch_log "failed to clear stale away-mode artifacts"
+      result=1
+    fi
   fi
   if [ "$result" -eq 0 ]; then
     if ! fm_afk_launch_flag_write; then
@@ -491,8 +510,12 @@ fm_afk_launch_start_native() {
   done
   fm_afk_launch_reconcile || result=1
   if [ "$result" -eq 0 ]; then
-    fm_afk_clear_stale_artifacts "$FM_AFK_LAUNCH_STATE"
-    fm_afk_launch_flag_write || result=1
+    if ! fm_afk_clear_stale_artifacts "$FM_AFK_LAUNCH_STATE"; then
+      fm_afk_launch_log "failed to clear stale away-mode artifacts"
+      result=1
+    elif ! fm_afk_launch_flag_write; then
+      result=1
+    fi
   fi
   if [ "$result" -eq 0 ]; then
     fm_afk_launch_record_write none - native || result=1
@@ -506,7 +529,7 @@ fm_afk_launch_start_native() {
 }
 
 fm_afk_launch_stop() {
-  local pid result=0
+  local pid result=0 read_result
   # (1) SIGTERM the daemon so its cleanup trap flushes buffered escalations
   # WHILE state/.afk is still present (the exit-ordering fix: clearing .afk
   # first would make that flush a no-op via inject_msg's presence gate).
@@ -522,8 +545,13 @@ fm_afk_launch_stop() {
     done
   fi
   # (2) Close the daemon's own terminal by exact id.
-  if fm_afk_launch_record_read; then
+  fm_afk_launch_record_read
+  read_result=$?
+  if [ "$read_result" -eq 0 ]; then
     fm_afk_launch_close_recorded || result=1
+  elif [ "$read_result" -eq 2 ]; then
+    fm_afk_launch_log "malformed daemon terminal record; refusing to stop away mode"
+    return 1
   fi
   # (3) Clear the away-mode flag LAST.
   rm -f "$FM_AFK_LAUNCH_STATE/.afk" 2>/dev/null || true

--- a/bin/fm-afk-launch.sh
+++ b/bin/fm-afk-launch.sh
@@ -119,7 +119,7 @@ fm_afk_launch_entry_cmd() {
 }
 
 fm_afk_launch_record_write() {  # <backend> <target> <extra>
-  mkdir -p "$FM_AFK_LAUNCH_STATE"
+  mkdir -p "$FM_AFK_LAUNCH_STATE" || return 1
   printf '%s\t%s\t%s\n' "$1" "$2" "$3" > "$FM_AFK_LAUNCH_RECORD"
 }
 
@@ -157,6 +157,80 @@ fm_afk_launch_close_terminal() {  # <backend> <target>
   esac
 }
 
+fm_afk_launch_terminal_alive() {  # <backend> <target>
+  local backend=$1 target=$2 session pane
+  case "$backend" in
+    herdr)
+      session=${target%%:*}
+      pane=${target#*:}
+      [ -n "$session" ] && [ -n "$pane" ] && [ "$pane" != "$target" ] || return 1
+      fm_backend_herdr_cli "$session" pane get "$pane" >/dev/null 2>&1
+      ;;
+    tmux)
+      tmux has-session -t "$target" 2>/dev/null
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+fm_afk_launch_wait_ready() {  # <backend> <target>
+  local backend=$1 target=$2 i
+  if [ -n "${FM_AFK_LAUNCH_ENTRY:-}" ]; then
+    fm_afk_launch_terminal_alive "$backend" "$target"
+    return
+  fi
+  for i in $(seq 1 100); do
+    daemon_lock_held_by_live_daemon && return 0
+    fm_afk_launch_terminal_alive "$backend" "$target" || return 1
+    sleep 0.05
+  done
+  return 1
+}
+
+fm_afk_launch_commit_terminal() {  # <backend> <target> <extra>
+  local backend=$1 target=$2 extra=$3
+  if ! fm_afk_launch_record_write "$backend" "$target" "$extra"; then
+    fm_afk_launch_log "failed to persist daemon terminal record; closing $backend:$target"
+    fm_afk_launch_close_terminal "$backend" "$target"
+    return 1
+  fi
+  if ! fm_afk_launch_wait_ready "$backend" "$target"; then
+    fm_afk_launch_log "daemon did not become ready; closing $backend:$target"
+    fm_afk_launch_close_terminal "$backend" "$target"
+    rm -f "$FM_AFK_LAUNCH_RECORD" 2>/dev/null || true
+    return 1
+  fi
+}
+
+fm_afk_launch_herdr_recover_created() {  # <session> <label>
+  local session=$1 label=$2 workspaces ws_count wsid panes pane_count pane i
+  for i in $(seq 1 20); do
+    workspaces=$(fm_backend_herdr_cli "$session" workspace list 2>/dev/null) || { sleep 0.05; continue; }
+    ws_count=$(printf '%s' "$workspaces" | jq --arg want "$label" \
+      '[.result.workspaces[]? | select(.label == $want)] | length' 2>/dev/null) || { sleep 0.05; continue; }
+    if [ "$ws_count" = 0 ]; then
+      sleep 0.05
+      continue
+    fi
+    [ "$ws_count" = 1 ] || return 1
+    wsid=$(printf '%s' "$workspaces" | jq -r --arg want "$label" \
+      '.result.workspaces[]? | select(.label == $want) | .workspace_id' 2>/dev/null) || return 1
+    [ -n "$wsid" ] || return 1
+    panes=$(fm_backend_herdr_cli "$session" pane list --workspace "$wsid" 2>/dev/null) || { sleep 0.05; continue; }
+    pane_count=$(printf '%s' "$panes" | jq '[.result.panes[]?] | length' 2>/dev/null) || { sleep 0.05; continue; }
+    if [ "$pane_count" = 0 ]; then
+      sleep 0.05
+      continue
+    fi
+    [ "$pane_count" = 1 ] || return 1
+    pane=$(printf '%s' "$panes" | jq -r '.result.panes[0].pane_id // empty' 2>/dev/null) || return 1
+    [ -n "$pane" ] || return 1
+    printf '%s\t%s' "$wsid" "$pane"
+    return 0
+  done
+  return 1
+}
+
 # Reconcile a recorded-but-dead terminal: if a record exists and no live daemon
 # owns it, close the leaked terminal by exact id and drop the record.
 fm_afk_launch_reconcile() {
@@ -175,7 +249,7 @@ fm_afk_launch_reconcile() {
 # dedicated background workspace (--no-focus) holds exactly one tab/pane; it
 # never touches the captain's active tab. Prints the record line on success.
 fm_afk_launch_create_herdr() {  # <captain-target> <captain-backend>
-  local captain_target=$1 captain_backend=$2 session out wsid pane entry cmd pane_list pane_count
+  local captain_target=$1 captain_backend=$2 session out wsid pane entry cmd label recovered create_result
   session=${captain_target%%:*}
   if [ -z "$session" ] || [ "$session" = "$captain_target" ]; then
     fm_afk_launch_log "cannot derive herdr session from captain target '$captain_target'"
@@ -183,23 +257,17 @@ fm_afk_launch_create_herdr() {  # <captain-target> <captain-backend>
   fi
   fm_backend_source herdr || return 1
   fm_backend_herdr_server_ensure "$session" || { fm_afk_launch_log "herdr server not ready for session '$session'"; return 1; }
-  out=$(fm_backend_herdr_cli "$session" workspace create --cwd "$FM_HOME" --label "$FM_AFK_LAUNCH_WS_LABEL" --no-focus 2>/dev/null) || {
-    fm_afk_launch_log "herdr workspace create failed in session '$session'"; return 1; }
+  label=${FM_AFK_LAUNCH_LABEL:-"$FM_AFK_LAUNCH_WS_LABEL-$$-${RANDOM:-0}-$(date '+%s')"}
+  out=$(fm_backend_herdr_cli "$session" workspace create --cwd "$FM_HOME" --label "$label" --no-focus 2>/dev/null)
+  create_result=$?
   wsid=$(printf '%s' "$out" | jq -r '.result.workspace.workspace_id // empty' 2>/dev/null)
   pane=$(printf '%s' "$out" | jq -r '.result.root_pane.pane_id // empty' 2>/dev/null)
-  if [ -z "$wsid" ] || [ -z "$pane" ]; then
-    fm_afk_launch_log "could not parse workspace/pane id from herdr workspace create"
-    if [ -n "$pane" ]; then
-      fm_backend_herdr_kill "$session:$pane"
-    elif [ -n "$wsid" ]; then
-      pane_list=$(fm_backend_herdr_cli "$session" pane list --workspace "$wsid" 2>/dev/null || true)
-      pane_count=$(printf '%s' "$pane_list" | jq '[.result.panes[]?] | length' 2>/dev/null || true)
-      if [ "$pane_count" = 1 ]; then
-        pane=$(printf '%s' "$pane_list" | jq -r '.result.panes[0].pane_id // empty' 2>/dev/null)
-        [ -n "$pane" ] && fm_backend_herdr_kill "$session:$pane"
-      fi
-    fi
-    return 1
+  if [ "$create_result" -ne 0 ] || [ -z "$wsid" ] || [ -z "$pane" ]; then
+    recovered=$(fm_afk_launch_herdr_recover_created "$session" "$label") || {
+      fm_afk_launch_log "herdr create did not yield a recoverable exact workspace/pane id"
+      return 1
+    }
+    IFS=$'\t' read -r wsid pane <<< "$recovered"
   fi
   entry=$(fm_afk_launch_entry_cmd)
   cmd=$(printf 'exec env FM_HOME=%q FM_SUPERVISOR_TARGET=%q FM_SUPERVISOR_BACKEND=%q %q' \
@@ -209,7 +277,7 @@ fm_afk_launch_create_herdr() {  # <captain-target> <captain-backend>
     fm_backend_herdr_kill "$session:$pane"
     return 1
   fi
-  fm_afk_launch_record_write herdr "$session:$pane" "$wsid"
+  fm_afk_launch_commit_terminal herdr "$session:$pane" "$wsid" || return 1
   fm_afk_launch_log "daemon launched in non-visible herdr workspace $wsid (pane $session:$pane), supervising $captain_target"
 }
 
@@ -229,7 +297,7 @@ fm_afk_launch_create_tmux() {  # <captain-target> <captain-backend>
     fm_afk_launch_log "failed to create detached tmux daemon session '$session'"
     return 1
   fi
-  fm_afk_launch_record_write tmux "$session" ""
+  fm_afk_launch_commit_terminal tmux "$session" "" || return 1
   fm_afk_launch_log "daemon launched in detached tmux session '$session', supervising $captain_target"
 }
 

--- a/bin/fm-afk-launch.sh
+++ b/bin/fm-afk-launch.sh
@@ -169,6 +169,13 @@ fm_afk_launch_record_read() {
   esac || { fm_afk_launch_log "daemon terminal record is malformed; refusing to act on it"; return 2; }
 }
 
+fm_afk_launch_record_validate_if_present() {
+  local result
+  fm_afk_launch_record_read
+  result=$?
+  [ "$result" -ne 2 ]
+}
+
 # Close a recorded terminal by EXACT id (never a broad sweep). The
 # recorded workspace id (herdr) needs no separate close: closing the pane takes
 # its single-tab dedicated workspace with it.
@@ -439,6 +446,7 @@ fm_afk_launch_start() {
   mkdir -p "$FM_AFK_LAUNCH_STATE"
 
   if daemon_lock_held_by_live_daemon; then
+    fm_afk_launch_record_validate_if_present || return 1
     if ! fm_afk_launch_flag_write; then
       fm_afk_launch_log "failed to refresh away-mode flag"
       return 1
@@ -496,6 +504,7 @@ fm_afk_launch_start_native() {
   local backup artifact had_afk=0 result=0
   mkdir -p "$FM_AFK_LAUNCH_STATE" || return 1
   if daemon_lock_held_by_live_daemon; then
+    fm_afk_launch_record_validate_if_present || return 1
     fm_afk_launch_flag_write || return 1
     fm_afk_launch_log "daemon already running; refreshed away-mode flag"
     return 0
@@ -554,6 +563,10 @@ fm_afk_launch_stop() {
       fm_pid_alive "$pid" || break
       sleep 0.25
     done
+  fi
+  if daemon_lock_held_by_live_daemon; then
+    fm_afk_launch_log "away-mode daemon did not exit after SIGTERM; preserving lifecycle state"
+    return 1
   fi
   # (2) Close the daemon's own terminal by exact id.
   if [ "$read_result" -eq 0 ]; then

--- a/bin/fm-afk-launch.sh
+++ b/bin/fm-afk-launch.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+# fm-afk-launch.sh - the single owner of the away-mode daemon TERMINAL lifecycle:
+# launch it in a NON-VISIBLE tracked terminal per backend, record its exact id,
+# tear it down by that exact id, and reconcile a leaked one after a crash.
+#
+# Why this exists (docs/herdr-backend.md "Away-mode daemon terminal launch"):
+# bin/fm-afk-start.sh execs the supervise daemon in the FOREGROUND of whatever
+# terminal it is already in. Harnesses with a native in-pane tracked-background
+# tool (claude, grok) run it there directly and it is fine. A harness with NO
+# native background mechanism (pi) has to manufacture a terminal, and doing that
+# by SPLITTING the captain's active pane visibly shrinks it - the regression this
+# script fixes. Instead this creates a non-visible tracked terminal (a herdr tab/
+# workspace with --no-focus, or a detached tmux session) that never touches the
+# captain's active tab, and NEVER uses shell `&` (which herdr/codex can reap).
+#
+# Correct supervisor targeting: the daemon finds the captain pane to inject into
+# from its OWN inherited env (discover_supervisor_target). Running it in a
+# separate terminal would make it discover its OWN pane, so this captures the
+# captain pane FIRST (from the pane this script runs in) and passes it in as
+# FM_SUPERVISOR_TARGET/FM_SUPERVISOR_BACKEND explicitly.
+#
+# Usage:
+#   fm-afk-launch.sh start     Capture the captain pane, then (unless the daemon
+#                              is already running) launch the daemon in a fresh
+#                              non-visible terminal for the detected backend and
+#                              record it. Idempotent: an already-running daemon
+#                              just refreshes state/.afk; a recorded-but-dead
+#                              terminal is reconciled (closed by id) first.
+#   fm-afk-launch.sh stop      Correct-ordered exit: SIGTERM the daemon so its
+#                              cleanup flushes WHILE state/.afk is still present,
+#                              wait for it, close the recorded terminal by exact
+#                              id, then clear state/.afk last.
+#   fm-afk-launch.sh reconcile Close a recorded-but-dead daemon terminal by exact
+#                              id and drop the record (recovery after a crash).
+#
+# Supported backends: herdr, tmux. Others (zellij, orca, cmux) have no verified
+# non-visible-launch primitive here yet and refuse loudly.
+#
+# Test seam: FM_AFK_LAUNCH_ENTRY overrides the command run in the created
+# terminal (default bin/fm-afk-start.sh), so a topology test can run a harmless
+# placeholder instead of a real daemon. FM_SUPERVISOR_TARGET/FM_SUPERVISOR_BACKEND
+# override the captured captain pane/backend (an isolated lab pane in tests).
+set -u
+
+FM_AFK_LAUNCH_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$FM_AFK_LAUNCH_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+FM_AFK_LAUNCH_STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+FM_AFK_LAUNCH_RECORD="$FM_AFK_LAUNCH_STATE/.afk-daemon-terminal"
+FM_AFK_LAUNCH_WS_LABEL="firstmate-afk-daemon"
+
+# shellcheck source=bin/fm-backend.sh
+. "$FM_AFK_LAUNCH_DIR/fm-backend.sh"
+# shellcheck source=bin/fm-supervisor-target-lib.sh
+. "$FM_AFK_LAUNCH_DIR/fm-supervisor-target-lib.sh"
+# fm-afk-start.sh provides the daemon-lock liveness helpers and
+# fm_afk_clear_stale_artifacts; it is sourceable (BASH_SOURCE guard) and its
+# main does not run on source. It sets `set -eu`, so turn errexit back off for
+# this script's best-effort flow immediately after.
+# shellcheck source=bin/fm-afk-start.sh
+. "$FM_AFK_LAUNCH_DIR/fm-afk-start.sh"
+set +e
+
+fm_afk_launch_log() { printf 'fm-afk-launch: %s\n' "$*" >&2; }
+
+fm_afk_launch_usage() {
+  sed -n '2,34p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+# The command run inside the created terminal. Real launch runs the shared
+# daemon entry; a test overrides it with a harmless placeholder.
+fm_afk_launch_entry_cmd() {
+  printf '%s' "${FM_AFK_LAUNCH_ENTRY:-$FM_ROOT/bin/fm-afk-start.sh}"
+}
+
+fm_afk_launch_record_write() {  # <backend> <target> <extra>
+  mkdir -p "$FM_AFK_LAUNCH_STATE"
+  printf '%s\t%s\t%s\n' "$1" "$2" "$3" > "$FM_AFK_LAUNCH_RECORD"
+}
+
+# Read the recorded terminal into FM_AFK_REC_BACKEND/FM_AFK_REC_TARGET. The third
+# field (a herdr workspace id, kept for the record's own documentation) is not
+# needed to close by id, so it is discarded. Returns 1 when no record exists.
+fm_afk_launch_record_read() {
+  FM_AFK_REC_BACKEND=""; FM_AFK_REC_TARGET=""
+  [ -f "$FM_AFK_LAUNCH_RECORD" ] || return 1
+  IFS=$'\t' read -r FM_AFK_REC_BACKEND FM_AFK_REC_TARGET _ \
+    < "$FM_AFK_LAUNCH_RECORD"
+  [ -n "$FM_AFK_REC_BACKEND" ] && [ -n "$FM_AFK_REC_TARGET" ]
+}
+
+# Close a recorded terminal by EXACT id (never a broad sweep). Best-effort. The
+# recorded workspace id (herdr) needs no separate close: closing the pane takes
+# its single-tab dedicated workspace with it.
+fm_afk_launch_close_terminal() {  # <backend> <target>
+  local backend=$1 target=$2
+  case "$backend" in
+    herdr)
+      fm_backend_source herdr || return 0
+      # pane close removes the pane; its tab (and this daemon's dedicated
+      # single-tab workspace) go with it. Exact pane id only.
+      fm_backend_herdr_kill "$target"
+      ;;
+    tmux)
+      # target is the dedicated daemon session name - kill exactly it.
+      tmux kill-session -t "$target" 2>/dev/null || true
+      ;;
+    *)
+      fm_afk_launch_log "cannot close unknown recorded backend '$backend'"
+      return 0
+      ;;
+  esac
+}
+
+# Reconcile a recorded-but-dead terminal: if a record exists and no live daemon
+# owns it, close the leaked terminal by exact id and drop the record.
+fm_afk_launch_reconcile() {
+  if daemon_lock_held_by_live_daemon; then
+    return 0
+  fi
+  if fm_afk_launch_record_read; then
+    fm_afk_launch_log "reconciling leaked daemon terminal ${FM_AFK_REC_BACKEND}:${FM_AFK_REC_TARGET}"
+    fm_afk_launch_close_terminal "$FM_AFK_REC_BACKEND" "$FM_AFK_REC_TARGET"
+    rm -f "$FM_AFK_LAUNCH_RECORD" 2>/dev/null || true
+  fi
+}
+
+# Launch the daemon in a non-visible herdr terminal in the CAPTAIN's session
+# (so the daemon can inject into the captain pane, which lives there). A
+# dedicated background workspace (--no-focus) holds exactly one tab/pane; it
+# never touches the captain's active tab. Prints the record line on success.
+fm_afk_launch_create_herdr() {  # <captain-target> <captain-backend>
+  local captain_target=$1 captain_backend=$2 session out wsid pane entry cmd
+  session=${captain_target%%:*}
+  if [ -z "$session" ] || [ "$session" = "$captain_target" ]; then
+    fm_afk_launch_log "cannot derive herdr session from captain target '$captain_target'"
+    return 1
+  fi
+  fm_backend_source herdr || return 1
+  fm_backend_herdr_server_ensure "$session" || { fm_afk_launch_log "herdr server not ready for session '$session'"; return 1; }
+  out=$(fm_backend_herdr_cli "$session" workspace create --cwd "$FM_HOME" --label "$FM_AFK_LAUNCH_WS_LABEL" --no-focus 2>/dev/null) || {
+    fm_afk_launch_log "herdr workspace create failed in session '$session'"; return 1; }
+  wsid=$(printf '%s' "$out" | jq -r '.result.workspace.workspace_id // empty' 2>/dev/null)
+  pane=$(printf '%s' "$out" | jq -r '.result.root_pane.pane_id // empty' 2>/dev/null)
+  if [ -z "$wsid" ] || [ -z "$pane" ]; then
+    fm_afk_launch_log "could not parse workspace/pane id from herdr workspace create"
+    return 1
+  fi
+  entry=$(fm_afk_launch_entry_cmd)
+  cmd=$(printf 'exec env FM_HOME=%q FM_SUPERVISOR_TARGET=%q FM_SUPERVISOR_BACKEND=%q %q' \
+    "$FM_HOME" "$captain_target" "$captain_backend" "$entry")
+  if ! fm_backend_herdr_cli "$session" pane run "$pane" "$cmd" >/dev/null 2>&1; then
+    fm_afk_launch_log "failed to run daemon in herdr pane $session:$pane; closing it"
+    fm_backend_herdr_kill "$session:$pane"
+    return 1
+  fi
+  fm_afk_launch_record_write herdr "$session:$pane" "$wsid"
+  fm_afk_launch_log "daemon launched in non-visible herdr workspace $wsid (pane $session:$pane), supervising $captain_target"
+}
+
+# Launch the daemon in a detached tmux session (never a split-window in the
+# captain's window). tmux pane ids are server-global, so the daemon reaches the
+# captain pane by its %id from this separate session.
+fm_afk_launch_create_tmux() {  # <captain-target> <captain-backend>
+  local captain_target=$1 captain_backend=$2 session entry cmd hash
+  hash=$(printf '%s' "$FM_HOME" | cksum | cut -d' ' -f1)
+  session="fm-afk-daemon-$hash"
+  # Drop any leaked same-named daemon session first (exact id only).
+  tmux kill-session -t "$session" 2>/dev/null || true
+  entry=$(fm_afk_launch_entry_cmd)
+  cmd=$(printf 'exec env FM_HOME=%q FM_SUPERVISOR_TARGET=%q FM_SUPERVISOR_BACKEND=%q %q' \
+    "$FM_HOME" "$captain_target" "$captain_backend" "$entry")
+  if ! tmux new-session -d -s "$session" "$cmd" 2>/dev/null; then
+    fm_afk_launch_log "failed to create detached tmux daemon session '$session'"
+    return 1
+  fi
+  fm_afk_launch_record_write tmux "$session" ""
+  fm_afk_launch_log "daemon launched in detached tmux session '$session', supervising $captain_target"
+}
+
+fm_afk_launch_start() {
+  local captain_target captain_backend
+  # Capture the captain pane FIRST, before creating anything.
+  captain_target=$(discover_supervisor_target) || {
+    fm_afk_launch_log "could not resolve the captain supervisor pane (set FM_SUPERVISOR_TARGET)"; return 1; }
+  captain_backend=$(discover_supervisor_backend) || {
+    fm_afk_launch_log "could not resolve the captain supervisor backend (set FM_SUPERVISOR_BACKEND)"; return 1; }
+
+  # Away mode is active immediately and deterministically.
+  mkdir -p "$FM_AFK_LAUNCH_STATE"
+  date '+%s' > "$FM_AFK_LAUNCH_STATE/.afk"
+
+  if daemon_lock_held_by_live_daemon; then
+    fm_afk_launch_log "daemon already running; refreshed away-mode flag (no new terminal)"
+    return 0
+  fi
+
+  # Fresh entry: reconcile a leaked prior terminal, then clear the previous
+  # away session's stale artifacts before a new daemon can surface them.
+  fm_afk_launch_reconcile
+  fm_afk_clear_stale_artifacts "$FM_AFK_LAUNCH_STATE"
+
+  case "$captain_backend" in
+    herdr) fm_afk_launch_create_herdr "$captain_target" "$captain_backend" ;;
+    tmux)  fm_afk_launch_create_tmux "$captain_target" "$captain_backend" ;;
+    *)
+      fm_afk_launch_log "no non-visible daemon-launch primitive for backend '$captain_backend' yet (supported: herdr, tmux)"
+      return 1
+      ;;
+  esac
+}
+
+fm_afk_launch_stop() {
+  local pid i
+  # (1) SIGTERM the daemon so its cleanup trap flushes buffered escalations
+  # WHILE state/.afk is still present (the exit-ordering fix: clearing .afk
+  # first would make that flush a no-op via inject_msg's presence gate).
+  pid=$(daemon_lock_pid 2>/dev/null || true)
+  if [ -n "$pid" ] && fm_pid_alive "$pid"; then
+    kill -TERM "$pid" 2>/dev/null || true
+    for i in $(seq 1 40); do
+      fm_pid_alive "$pid" || break
+      sleep 0.25
+    done
+  fi
+  # (2) Close the daemon's own terminal by exact id.
+  if fm_afk_launch_record_read; then
+    fm_afk_launch_close_terminal "$FM_AFK_REC_BACKEND" "$FM_AFK_REC_TARGET"
+    rm -f "$FM_AFK_LAUNCH_RECORD" 2>/dev/null || true
+  fi
+  # (3) Clear the away-mode flag LAST.
+  rm -f "$FM_AFK_LAUNCH_STATE/.afk" 2>/dev/null || true
+  fm_afk_launch_log "away mode stopped; daemon terminal torn down and .afk cleared"
+}
+
+fm_afk_launch_main() {
+  case "${1:-start}" in
+    start) fm_afk_launch_start ;;
+    stop) fm_afk_launch_stop ;;
+    reconcile) fm_afk_launch_reconcile ;;
+    -h|--help|help) fm_afk_launch_usage ;;
+    *) fm_afk_launch_usage >&2; return 2 ;;
+  esac
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  fm_afk_launch_main "$@"
+fi

--- a/bin/fm-afk-launch.sh
+++ b/bin/fm-afk-launch.sh
@@ -122,8 +122,11 @@ fm_afk_launch_entry_cmd() {
 }
 
 fm_afk_launch_record_write() {  # <backend> <target> <extra>
+  local pending
   mkdir -p "$FM_AFK_LAUNCH_STATE" || return 1
-  printf '%s\t%s\t%s\n' "$1" "$2" "$3" > "$FM_AFK_LAUNCH_RECORD"
+  pending=$(mktemp "$FM_AFK_LAUNCH_STATE/.afk-daemon-terminal.pending.XXXXXX") || return 1
+  printf '%s\t%s\t%s\n' "$1" "$2" "$3" > "$pending" || { rm -f "$pending"; return 1; }
+  mv "$pending" "$FM_AFK_LAUNCH_RECORD" || { rm -f "$pending"; return 1; }
 }
 
 fm_afk_launch_flag_write() {
@@ -136,11 +139,23 @@ fm_afk_launch_flag_write() {
 # field (a herdr workspace id, kept for the record's own documentation) is not
 # needed to close by id, so it is discarded. Returns 1 when no record exists.
 fm_afk_launch_record_read() {
-  FM_AFK_REC_BACKEND=""; FM_AFK_REC_TARGET=""
+  local extra record
+  FM_AFK_REC_BACKEND=""; FM_AFK_REC_TARGET=""; extra=""
   [ -f "$FM_AFK_LAUNCH_RECORD" ] || return 1
-  IFS=$'\t' read -r FM_AFK_REC_BACKEND FM_AFK_REC_TARGET _ \
-    < "$FM_AFK_LAUNCH_RECORD"
-  [ -n "$FM_AFK_REC_BACKEND" ] && [ -n "$FM_AFK_REC_TARGET" ]
+  record=$(cat "$FM_AFK_LAUNCH_RECORD" 2>/dev/null) || record=""
+  IFS=$'\t' read -r FM_AFK_REC_BACKEND FM_AFK_REC_TARGET extra \
+    < "$FM_AFK_LAUNCH_RECORD" || true
+  if ! printf '%s\n' "$record" | awk -F '\t' 'NF != 3 { bad=1 } END { exit !(NR == 1 && !bad) }' \
+    || [ -z "$FM_AFK_REC_BACKEND" ] || [ -z "$FM_AFK_REC_TARGET" ]; then
+    fm_afk_launch_log "daemon terminal record is malformed; refusing to act on it"
+    return 2
+  fi
+  case "$FM_AFK_REC_BACKEND" in
+    herdr) [ -n "$extra" ] ;;
+    tmux) : ;;
+    none) [ "$FM_AFK_REC_TARGET" = - ] && [ "$extra" = native ] ;;
+    *) return 2 ;;
+  esac || { fm_afk_launch_log "daemon terminal record is malformed; refusing to act on it"; return 2; }
 }
 
 # Close a recorded terminal by EXACT id (never a broad sweep). The
@@ -200,7 +215,8 @@ fm_afk_launch_close_recorded() {
   fm_afk_launch_close_terminal "$FM_AFK_REC_BACKEND" "$FM_AFK_REC_TARGET" || close_result=$?
   if fm_afk_launch_terminal_absent "$FM_AFK_REC_BACKEND" "$FM_AFK_REC_TARGET"; then
     rm -f "$FM_AFK_LAUNCH_RECORD" || return 1
-    return "$close_result"
+    [ "$close_result" -eq 0 ] || fm_afk_launch_log "terminal close command failed, but exact absence was confirmed"
+    return 0
   fi
   fm_afk_launch_log "recorded terminal teardown is unconfirmed; preserving exact id"
   return 1
@@ -284,13 +300,40 @@ fm_afk_launch_herdr_recover_created() {  # <session> <label>
 # Reconcile a recorded-but-dead terminal: if a record exists and no live daemon
 # owns it, close the leaked terminal by exact id and drop the record.
 fm_afk_launch_reconcile() {
+  local read_result
   if daemon_lock_held_by_live_daemon; then
     return 0
   fi
-  if fm_afk_launch_record_read; then
+  fm_afk_launch_record_read
+  read_result=$?
+  if [ "$read_result" -eq 0 ]; then
     fm_afk_launch_log "reconciling leaked daemon terminal ${FM_AFK_REC_BACKEND}:${FM_AFK_REC_TARGET}"
     fm_afk_launch_close_recorded
+  elif [ "$read_result" -eq 2 ]; then
+    return 1
   fi
+}
+
+fm_afk_launch_restore_backup() {  # <backup> <had-afk>
+  local backup=$1 had_afk=$2 artifact result=0
+  rm -f "$FM_AFK_LAUNCH_STATE/.afk" \
+    "$FM_AFK_LAUNCH_STATE/.subsuper-escalations" \
+    "$FM_AFK_LAUNCH_STATE/.subsuper-escalations.since" \
+    "$FM_AFK_LAUNCH_STATE/.subsuper-inject-wedged" || result=1
+  if [ "$had_afk" -eq 1 ]; then
+    cp "$backup/.afk" "$FM_AFK_LAUNCH_STATE/.afk" || result=1
+  fi
+  for artifact in .subsuper-escalations .subsuper-escalations.since .subsuper-inject-wedged; do
+    if [ -e "$backup/$artifact" ]; then
+      cp -p "$backup/$artifact" "$FM_AFK_LAUNCH_STATE/$artifact" || result=1
+    fi
+  done
+  if [ "$result" -eq 0 ]; then
+    rm -rf "$backup" || return 1
+  else
+    fm_afk_launch_log "rollback restoration incomplete; backup retained at $backup"
+  fi
+  return "$result"
 }
 
 # Launch the daemon in a non-visible herdr terminal in the CAPTAIN's session
@@ -421,14 +464,10 @@ fm_afk_launch_start() {
     esac
   fi
   if [ "$result" -ne 0 ]; then
-    rm -f "$FM_AFK_LAUNCH_STATE/.afk" "$FM_AFK_LAUNCH_STATE/.subsuper-escalations" \
-      "$FM_AFK_LAUNCH_STATE/.subsuper-escalations.since" "$FM_AFK_LAUNCH_STATE/.subsuper-inject-wedged"
-    [ "$had_afk" -eq 1 ] && cp "$backup/.afk" "$FM_AFK_LAUNCH_STATE/.afk"
-    for artifact in .subsuper-escalations .subsuper-escalations.since .subsuper-inject-wedged; do
-      [ -e "$backup/$artifact" ] && cp -p "$backup/$artifact" "$FM_AFK_LAUNCH_STATE/$artifact"
-    done
+    fm_afk_launch_restore_backup "$backup" "$had_afk" || result=1
+  else
+    rm -rf "$backup" || result=1
   fi
-  rm -rf "$backup"
   return "$result"
 }
 
@@ -459,15 +498,10 @@ fm_afk_launch_start_native() {
     fm_afk_launch_record_write none - native || result=1
   fi
   if [ "$result" -ne 0 ]; then
-    rm -f "$FM_AFK_LAUNCH_STATE/.afk" \
-      "$FM_AFK_LAUNCH_STATE/.subsuper-escalations" "$FM_AFK_LAUNCH_STATE/.subsuper-escalations.since" \
-      "$FM_AFK_LAUNCH_STATE/.subsuper-inject-wedged"
-    [ "$had_afk" -eq 1 ] && cp "$backup/.afk" "$FM_AFK_LAUNCH_STATE/.afk"
-    for artifact in .subsuper-escalations .subsuper-escalations.since .subsuper-inject-wedged; do
-      [ -e "$backup/$artifact" ] && cp -p "$backup/$artifact" "$FM_AFK_LAUNCH_STATE/$artifact"
-    done
+    fm_afk_launch_restore_backup "$backup" "$had_afk" || result=1
+  else
+    rm -rf "$backup" || result=1
   fi
-  rm -rf "$backup"
   return "$result"
 }
 

--- a/bin/fm-afk-launch.sh
+++ b/bin/fm-afk-launch.sh
@@ -26,6 +26,9 @@
 #                              record it. Idempotent: an already-running daemon
 #                              just refreshes state/.afk; a recorded-but-dead
 #                              terminal is reconciled (closed by id) first.
+#   fm-afk-launch.sh start-native
+#                              Prepare lifecycle state for a harness-native
+#                              background job and record that no terminal exists.
 #   fm-afk-launch.sh stop      Correct-ordered exit: SIGTERM the daemon so its
 #                              cleanup flushes WHILE state/.afk is still present,
 #                              wait for it, close the recorded terminal by exact
@@ -123,6 +126,12 @@ fm_afk_launch_record_write() {  # <backend> <target> <extra>
   printf '%s\t%s\t%s\n' "$1" "$2" "$3" > "$FM_AFK_LAUNCH_RECORD"
 }
 
+fm_afk_launch_flag_write() {
+  local pending="$FM_AFK_LAUNCH_STATE/.afk.pending.$$"
+  date '+%s' > "$pending" || { rm -f "$pending"; return 1; }
+  mv "$pending" "$FM_AFK_LAUNCH_STATE/.afk" || { rm -f "$pending"; return 1; }
+}
+
 # Read the recorded terminal into FM_AFK_REC_BACKEND/FM_AFK_REC_TARGET. The third
 # field (a herdr workspace id, kept for the record's own documentation) is not
 # needed to close by id, so it is discarded. Returns 1 when no record exists.
@@ -134,27 +143,63 @@ fm_afk_launch_record_read() {
   [ -n "$FM_AFK_REC_BACKEND" ] && [ -n "$FM_AFK_REC_TARGET" ]
 }
 
-# Close a recorded terminal by EXACT id (never a broad sweep). Best-effort. The
+# Close a recorded terminal by EXACT id (never a broad sweep). The
 # recorded workspace id (herdr) needs no separate close: closing the pane takes
 # its single-tab dedicated workspace with it.
 fm_afk_launch_close_terminal() {  # <backend> <target>
   local backend=$1 target=$2
   case "$backend" in
     herdr)
-      fm_backend_source herdr || return 0
-      # pane close removes the pane; its tab (and this daemon's dedicated
-      # single-tab workspace) go with it. Exact pane id only.
-      fm_backend_herdr_kill "$target"
+      fm_backend_source herdr || return 1
+      local session=${target%%:*} pane=${target#*:}
+      [ -n "$session" ] && [ -n "$pane" ] && [ "$pane" != "$target" ] || return 1
+      fm_backend_herdr_cli "$session" pane close "$pane" >/dev/null 2>&1
       ;;
     tmux)
       # target is the dedicated daemon session name - kill exactly it.
-      tmux kill-session -t "$target" 2>/dev/null || true
+      tmux kill-session -t "$target" 2>/dev/null
+      ;;
+    none)
+      return 0
       ;;
     *)
       fm_afk_launch_log "cannot close unknown recorded backend '$backend'"
-      return 0
+      return 1
       ;;
   esac
+}
+
+fm_afk_launch_terminal_absent() {  # <backend> <target>
+  local backend=$1 target=$2 session pane out result code
+  case "$backend" in
+    herdr)
+      session=${target%%:*}
+      pane=${target#*:}
+      [ -n "$session" ] && [ -n "$pane" ] && [ "$pane" != "$target" ] || return 1
+      out=$(fm_backend_herdr_cli "$session" pane get "$pane" 2>&1)
+      result=$?
+      [ "$result" -ne 0 ] || return 1
+      code=$(printf '%s' "$out" | jq -r '.error.code // empty' 2>/dev/null) || return 1
+      [ "$code" = pane_not_found ]
+      ;;
+    tmux)
+      ! tmux has-session -t "$target" 2>/dev/null
+      ;;
+    none)
+      return 0
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+fm_afk_launch_close_recorded() {
+  fm_afk_launch_close_terminal "$FM_AFK_REC_BACKEND" "$FM_AFK_REC_TARGET" || true
+  if fm_afk_launch_terminal_absent "$FM_AFK_REC_BACKEND" "$FM_AFK_REC_TARGET"; then
+    rm -f "$FM_AFK_LAUNCH_RECORD"
+    return 0
+  fi
+  fm_afk_launch_log "recorded terminal teardown is unconfirmed; preserving exact id"
+  return 1
 }
 
 fm_afk_launch_terminal_alive() {  # <backend> <target>
@@ -239,8 +284,7 @@ fm_afk_launch_reconcile() {
   fi
   if fm_afk_launch_record_read; then
     fm_afk_launch_log "reconciling leaked daemon terminal ${FM_AFK_REC_BACKEND}:${FM_AFK_REC_TARGET}"
-    fm_afk_launch_close_terminal "$FM_AFK_REC_BACKEND" "$FM_AFK_REC_TARGET"
-    rm -f "$FM_AFK_LAUNCH_RECORD" 2>/dev/null || true
+    fm_afk_launch_close_recorded
   fi
 }
 
@@ -262,7 +306,12 @@ fm_afk_launch_create_herdr() {  # <captain-target> <captain-backend>
   create_result=$?
   wsid=$(printf '%s' "$out" | jq -r '.result.workspace.workspace_id // empty' 2>/dev/null)
   pane=$(printf '%s' "$out" | jq -r '.result.root_pane.pane_id // empty' 2>/dev/null)
-  if [ "$create_result" -ne 0 ] || [ -z "$wsid" ] || [ -z "$pane" ]; then
+  if [ "$create_result" -ne 0 ] && [ -n "$wsid" ] && [ -n "$pane" ]; then
+    fm_afk_launch_log "herdr create failed after returning exact ids; closing $session:$pane"
+    fm_backend_herdr_kill "$session:$pane"
+    return 1
+  fi
+  if [ -z "$wsid" ] || [ -z "$pane" ]; then
     recovered=$(fm_afk_launch_herdr_recover_created "$session" "$label") || {
       fm_afk_launch_log "herdr create did not yield a recoverable exact workspace/pane id"
       return 1
@@ -312,7 +361,10 @@ fm_afk_launch_start() {
   mkdir -p "$FM_AFK_LAUNCH_STATE"
 
   if daemon_lock_held_by_live_daemon; then
-    date '+%s' > "$FM_AFK_LAUNCH_STATE/.afk"
+    if ! fm_afk_launch_flag_write; then
+      fm_afk_launch_log "failed to refresh away-mode flag"
+      return 1
+    fi
     fm_afk_launch_log "daemon already running; refreshed away-mode flag (no new terminal)"
     return 0
   fi
@@ -322,18 +374,29 @@ fm_afk_launch_start() {
   for artifact in .subsuper-escalations .subsuper-escalations.since .subsuper-inject-wedged; do
     [ -e "$FM_AFK_LAUNCH_STATE/$artifact" ] && cp -p "$FM_AFK_LAUNCH_STATE/$artifact" "$backup/$artifact"
   done
-  fm_afk_launch_reconcile
-  fm_afk_clear_stale_artifacts "$FM_AFK_LAUNCH_STATE"
-  date '+%s' > "$FM_AFK_LAUNCH_STATE/.afk"
-
-  case "$captain_backend" in
-    herdr) fm_afk_launch_create_herdr "$captain_target" "$captain_backend"; result=$? ;;
-    tmux)  fm_afk_launch_create_tmux "$captain_target" "$captain_backend"; result=$? ;;
-    *)
-      fm_afk_launch_log "no non-visible daemon-launch primitive for backend '$captain_backend' yet (supported: herdr, tmux)"
+  if ! fm_afk_launch_reconcile; then
+    result=1
+  else
+    fm_afk_clear_stale_artifacts "$FM_AFK_LAUNCH_STATE"
+    result=0
+  fi
+  if [ "$result" -eq 0 ]; then
+    if ! fm_afk_launch_flag_write; then
+      fm_afk_launch_log "failed to write away-mode flag"
       result=1
-      ;;
-  esac
+    fi
+  fi
+
+  if [ "$result" -eq 0 ]; then
+    case "$captain_backend" in
+      herdr) fm_afk_launch_create_herdr "$captain_target" "$captain_backend"; result=$? ;;
+      tmux)  fm_afk_launch_create_tmux "$captain_target" "$captain_backend"; result=$? ;;
+      *)
+        fm_afk_launch_log "no non-visible daemon-launch primitive for backend '$captain_backend' yet (supported: herdr, tmux)"
+        result=1
+        ;;
+    esac
+  fi
   if [ "$result" -ne 0 ]; then
     rm -f "$FM_AFK_LAUNCH_STATE/.afk" "$FM_AFK_LAUNCH_STATE/.subsuper-escalations" \
       "$FM_AFK_LAUNCH_STATE/.subsuper-escalations.since" "$FM_AFK_LAUNCH_STATE/.subsuper-inject-wedged"
@@ -346,8 +409,42 @@ fm_afk_launch_start() {
   return "$result"
 }
 
+fm_afk_launch_start_native() {
+  local backup artifact had_afk=0 result=0
+  mkdir -p "$FM_AFK_LAUNCH_STATE" || return 1
+  if daemon_lock_held_by_live_daemon; then
+    fm_afk_launch_flag_write || return 1
+    fm_afk_launch_log "daemon already running; refreshed away-mode flag"
+    return 0
+  fi
+  backup=$(mktemp -d "$FM_AFK_LAUNCH_STATE/.afk-launch-backup.XXXXXX") || return 1
+  [ -f "$FM_AFK_LAUNCH_STATE/.afk" ] && had_afk=1 && cp "$FM_AFK_LAUNCH_STATE/.afk" "$backup/.afk"
+  for artifact in .subsuper-escalations .subsuper-escalations.since .subsuper-inject-wedged; do
+    [ -e "$FM_AFK_LAUNCH_STATE/$artifact" ] && cp -p "$FM_AFK_LAUNCH_STATE/$artifact" "$backup/$artifact"
+  done
+  fm_afk_launch_reconcile || result=1
+  if [ "$result" -eq 0 ]; then
+    fm_afk_clear_stale_artifacts "$FM_AFK_LAUNCH_STATE"
+    fm_afk_launch_flag_write || result=1
+  fi
+  if [ "$result" -eq 0 ]; then
+    fm_afk_launch_record_write none - native || result=1
+  fi
+  if [ "$result" -ne 0 ]; then
+    rm -f "$FM_AFK_LAUNCH_STATE/.afk" "$FM_AFK_LAUNCH_RECORD" \
+      "$FM_AFK_LAUNCH_STATE/.subsuper-escalations" "$FM_AFK_LAUNCH_STATE/.subsuper-escalations.since" \
+      "$FM_AFK_LAUNCH_STATE/.subsuper-inject-wedged"
+    [ "$had_afk" -eq 1 ] && cp "$backup/.afk" "$FM_AFK_LAUNCH_STATE/.afk"
+    for artifact in .subsuper-escalations .subsuper-escalations.since .subsuper-inject-wedged; do
+      [ -e "$backup/$artifact" ] && cp -p "$backup/$artifact" "$FM_AFK_LAUNCH_STATE/$artifact"
+    done
+  fi
+  rm -rf "$backup"
+  return "$result"
+}
+
 fm_afk_launch_stop() {
-  local pid i
+  local pid result=0
   # (1) SIGTERM the daemon so its cleanup trap flushes buffered escalations
   # WHILE state/.afk is still present (the exit-ordering fix: clearing .afk
   # first would make that flush a no-op via inject_msg's presence gate).
@@ -357,19 +454,23 @@ fm_afk_launch_stop() {
   fi
   if [ -n "$pid" ]; then
     kill -TERM "$pid" 2>/dev/null || true
-    for i in $(seq 1 40); do
+    for _ in $(seq 1 40); do
       fm_pid_alive "$pid" || break
       sleep 0.25
     done
   fi
   # (2) Close the daemon's own terminal by exact id.
   if fm_afk_launch_record_read; then
-    fm_afk_launch_close_terminal "$FM_AFK_REC_BACKEND" "$FM_AFK_REC_TARGET"
-    rm -f "$FM_AFK_LAUNCH_RECORD" 2>/dev/null || true
+    fm_afk_launch_close_recorded || result=1
   fi
   # (3) Clear the away-mode flag LAST.
   rm -f "$FM_AFK_LAUNCH_STATE/.afk" 2>/dev/null || true
-  fm_afk_launch_log "away mode stopped; daemon terminal torn down and .afk cleared"
+  if [ "$result" -eq 0 ]; then
+    fm_afk_launch_log "away mode stopped; daemon terminal torn down and .afk cleared"
+  else
+    fm_afk_launch_log "away mode stopped; terminal teardown remains recorded for retry"
+  fi
+  return "$result"
 }
 
 fm_afk_launch_main() {
@@ -380,6 +481,7 @@ fm_afk_launch_main() {
   trap 'exit 143' TERM
   case "${1:-start}" in
     start) fm_afk_launch_start ;;
+    start-native) fm_afk_launch_start_native ;;
     stop) fm_afk_launch_stop ;;
     reconcile) fm_afk_launch_reconcile ;;
     -h|--help|help) fm_afk_launch_usage ;;

--- a/bin/fm-afk-launch.sh
+++ b/bin/fm-afk-launch.sh
@@ -77,12 +77,22 @@ fm_afk_launch_lock_owned() {
 }
 
 fm_afk_launch_lock_acquire() {
-  local i incomplete=0
-  mkdir -p "$FM_AFK_LAUNCH_STATE"
+  local i incomplete=0 identity
+  mkdir -p "$FM_AFK_LAUNCH_STATE" || return 1
   for i in $(seq 1 200); do
     if mkdir "$FM_AFK_LAUNCH_LOCK" 2>/dev/null; then
-      printf '%s' "$$" > "$FM_AFK_LAUNCH_LOCK/pid"
-      fm_pid_identity "$$" > "$FM_AFK_LAUNCH_LOCK/pid-identity" 2>/dev/null || true
+      if ! printf '%s' "$$" > "$FM_AFK_LAUNCH_LOCK/pid"; then
+        rm -rf "$FM_AFK_LAUNCH_LOCK"
+        return 1
+      fi
+      identity=$(fm_pid_identity "$$" 2>/dev/null) || {
+        rm -rf "$FM_AFK_LAUNCH_LOCK"
+        return 1
+      }
+      if [ -z "$identity" ] || ! printf '%s' "$identity" > "$FM_AFK_LAUNCH_LOCK/pid-identity"; then
+        rm -rf "$FM_AFK_LAUNCH_LOCK"
+        return 1
+      fi
       return 0
     fi
     if [ ! -s "$FM_AFK_LAUNCH_LOCK/pid" ] || [ ! -s "$FM_AFK_LAUNCH_LOCK/pid-identity" ]; then
@@ -95,7 +105,7 @@ fm_afk_launch_lock_acquire() {
       incomplete=0
     fi
     if ! fm_afk_launch_lock_owned; then
-      rm -rf "$FM_AFK_LAUNCH_LOCK" 2>/dev/null || true
+      rm -rf "$FM_AFK_LAUNCH_LOCK" 2>/dev/null || return 1
       incomplete=0
       continue
     fi
@@ -108,7 +118,8 @@ fm_afk_launch_lock_acquire() {
 fm_afk_launch_lock_release() {
   local pid
   pid=$(cat "$FM_AFK_LAUNCH_LOCK/pid" 2>/dev/null || true)
-  [ "$pid" = "$$" ] && rm -rf "$FM_AFK_LAUNCH_LOCK" 2>/dev/null || true
+  [ "$pid" = "$$" ] || return 0
+  rm -rf "$FM_AFK_LAUNCH_LOCK"
 }
 
 fm_afk_launch_usage() {
@@ -395,19 +406,10 @@ fm_afk_launch_create_herdr() {  # <captain-target> <captain-backend>
 # captain's window). tmux pane ids are server-global, so the daemon reaches the
 # captain pane by its %id from this separate session.
 fm_afk_launch_create_tmux() {  # <captain-target> <captain-backend>
-  local captain_target=$1 captain_backend=$2 session entry cmd hash probe_result probe_out
+  local captain_target=$1 captain_backend=$2 session entry cmd hash nonce
   hash=$(printf '%s' "$FM_HOME" | cksum | cut -d' ' -f1)
-  session="fm-afk-daemon-$hash"
-  probe_out=$(tmux has-session -t "$session" 2>&1)
-  probe_result=$?
-  if [ "$probe_result" -eq 0 ]; then
-    fm_afk_launch_log "unrecorded tmux session '$session' already exists; refusing to replace it"
-    return 1
-  fi
-  if [ "$probe_result" -ne 1 ] || ! printf '%s' "$probe_out" | grep -Eq "can't find session"; then
-    fm_afk_launch_log "could not confirm tmux session '$session' is absent"
-    return 1
-  fi
+  nonce="$$-${RANDOM:-0}-$(date '+%s')"
+  session="fm-afk-daemon-$hash-$nonce"
   entry=$(fm_afk_launch_entry_cmd)
   cmd=$(printf 'exec env FM_HOME=%q FM_SUPERVISOR_TARGET=%q FM_SUPERVISOR_BACKEND=%q %q' \
     "$FM_HOME" "$captain_target" "$captain_backend" "$entry")
@@ -417,9 +419,9 @@ fm_afk_launch_create_tmux() {  # <captain-target> <captain-backend>
   fi
   if ! tmux new-session -d -s "$session" "$cmd" 2>/dev/null; then
     fm_afk_launch_log "failed to create detached tmux daemon session '$session'"
-    FM_AFK_REC_BACKEND=tmux
-    FM_AFK_REC_TARGET=$session
-    fm_afk_launch_close_recorded || true
+    if ! rm -f "$FM_AFK_LAUNCH_RECORD"; then
+      fm_afk_launch_log "failed to remove planned tmux daemon record after creation failure"
+    fi
     return 1
   fi
   fm_afk_launch_commit_terminal tmux "$session" "" 1 || return 1
@@ -530,31 +532,38 @@ fm_afk_launch_start_native() {
 
 fm_afk_launch_stop() {
   local pid result=0 read_result
+  fm_afk_launch_record_read
+  read_result=$?
+  if [ "$read_result" -eq 2 ]; then
+    fm_afk_launch_log "malformed daemon terminal record; refusing to stop away mode"
+    return 1
+  fi
   # (1) SIGTERM the daemon so its cleanup trap flushes buffered escalations
   # WHILE state/.afk is still present (the exit-ordering fix: clearing .afk
   # first would make that flush a no-op via inject_msg's presence gate).
   pid=""
   if daemon_lock_held_by_live_daemon; then
-    pid=$(daemon_lock_pid 2>/dev/null || true)
+    pid=$(daemon_lock_pid 2>/dev/null) || return 1
   fi
   if [ -n "$pid" ]; then
-    kill -TERM "$pid" 2>/dev/null || true
+    if ! kill -TERM "$pid" 2>/dev/null; then
+      fm_afk_launch_log "failed to signal away-mode daemon pid=$pid"
+      result=1
+    fi
     for _ in $(seq 1 40); do
       fm_pid_alive "$pid" || break
       sleep 0.25
     done
   fi
   # (2) Close the daemon's own terminal by exact id.
-  fm_afk_launch_record_read
-  read_result=$?
   if [ "$read_result" -eq 0 ]; then
     fm_afk_launch_close_recorded || result=1
-  elif [ "$read_result" -eq 2 ]; then
-    fm_afk_launch_log "malformed daemon terminal record; refusing to stop away mode"
-    return 1
   fi
   # (3) Clear the away-mode flag LAST.
-  rm -f "$FM_AFK_LAUNCH_STATE/.afk" 2>/dev/null || true
+  if ! rm -f "$FM_AFK_LAUNCH_STATE/.afk"; then
+    fm_afk_launch_log "failed to clear away-mode flag"
+    result=1
+  fi
   if [ "$result" -eq 0 ]; then
     fm_afk_launch_log "away mode stopped; daemon terminal torn down and .afk cleared"
   else
@@ -578,7 +587,7 @@ fm_afk_launch_main() {
     *) fm_afk_launch_usage >&2; return 2 ;;
   esac
   result=$?
-  fm_afk_launch_lock_release
+  fm_afk_launch_lock_release || result=1
   trap - EXIT INT TERM
   return "$result"
 }

--- a/bin/fm-afk-launch.sh
+++ b/bin/fm-afk-launch.sh
@@ -540,7 +540,7 @@ fm_afk_launch_start_native() {
 }
 
 fm_afk_launch_stop() {
-  local pid result=0 read_result
+  local pid pid_identity current_identity result=0 read_result
   fm_afk_launch_record_read
   read_result=$?
   if [ "$read_result" -eq 2 ]; then
@@ -551,8 +551,10 @@ fm_afk_launch_stop() {
   # WHILE state/.afk is still present (the exit-ordering fix: clearing .afk
   # first would make that flush a no-op via inject_msg's presence gate).
   pid=""
+  pid_identity=""
   if daemon_lock_held_by_live_daemon; then
     pid=$(daemon_lock_pid 2>/dev/null) || return 1
+    pid_identity=$(fm_pid_identity "$pid" 2>/dev/null) || return 1
   fi
   if [ -n "$pid" ]; then
     if ! kill -TERM "$pid" 2>/dev/null; then
@@ -564,9 +566,15 @@ fm_afk_launch_stop() {
       sleep 0.25
     done
   fi
-  if daemon_lock_held_by_live_daemon; then
-    fm_afk_launch_log "away-mode daemon did not exit after SIGTERM; preserving lifecycle state"
-    return 1
+  if [ -n "$pid" ] && fm_pid_alive "$pid"; then
+    current_identity=$(fm_pid_identity "$pid" 2>/dev/null) || {
+      fm_afk_launch_log "could not confirm away-mode daemon exit; preserving lifecycle state"
+      return 1
+    }
+    if [ "$current_identity" = "$pid_identity" ]; then
+      fm_afk_launch_log "away-mode daemon did not exit after SIGTERM; preserving lifecycle state"
+      return 1
+    fi
   fi
   # (2) Close the daemon's own terminal by exact id.
   if [ "$read_result" -eq 0 ]; then

--- a/bin/fm-afk-launch.sh
+++ b/bin/fm-afk-launch.sh
@@ -183,7 +183,10 @@ fm_afk_launch_terminal_absent() {  # <backend> <target>
       [ "$code" = pane_not_found ]
       ;;
     tmux)
-      ! tmux has-session -t "$target" 2>/dev/null
+      out=$(tmux has-session -t "$target" 2>&1)
+      result=$?
+      [ "$result" -eq 1 ] || return 1
+      printf '%s' "$out" | grep -Eq "can't find session"
       ;;
     none)
       return 0
@@ -193,10 +196,11 @@ fm_afk_launch_terminal_absent() {  # <backend> <target>
 }
 
 fm_afk_launch_close_recorded() {
-  fm_afk_launch_close_terminal "$FM_AFK_REC_BACKEND" "$FM_AFK_REC_TARGET" || true
+  local close_result=0
+  fm_afk_launch_close_terminal "$FM_AFK_REC_BACKEND" "$FM_AFK_REC_TARGET" || close_result=$?
   if fm_afk_launch_terminal_absent "$FM_AFK_REC_BACKEND" "$FM_AFK_REC_TARGET"; then
-    rm -f "$FM_AFK_LAUNCH_RECORD"
-    return 0
+    rm -f "$FM_AFK_LAUNCH_RECORD" || return 1
+    return "$close_result"
   fi
   fm_afk_launch_log "recorded terminal teardown is unconfirmed; preserving exact id"
   return 1
@@ -232,17 +236,18 @@ fm_afk_launch_wait_ready() {  # <backend> <target>
   return 1
 }
 
-fm_afk_launch_commit_terminal() {  # <backend> <target> <extra>
-  local backend=$1 target=$2 extra=$3
-  if ! fm_afk_launch_record_write "$backend" "$target" "$extra"; then
+fm_afk_launch_commit_terminal() {  # <backend> <target> <extra> [already-recorded]
+  local backend=$1 target=$2 extra=$3 already_recorded=${4:-0}
+  if [ "$already_recorded" -ne 1 ] && ! fm_afk_launch_record_write "$backend" "$target" "$extra"; then
     fm_afk_launch_log "failed to persist daemon terminal record; closing $backend:$target"
     fm_afk_launch_close_terminal "$backend" "$target"
     return 1
   fi
   if ! fm_afk_launch_wait_ready "$backend" "$target"; then
     fm_afk_launch_log "daemon did not become ready; closing $backend:$target"
-    fm_afk_launch_close_terminal "$backend" "$target"
-    rm -f "$FM_AFK_LAUNCH_RECORD" 2>/dev/null || true
+    FM_AFK_REC_BACKEND=$backend
+    FM_AFK_REC_TARGET=$target
+    fm_afk_launch_close_recorded
     return 1
   fi
 }
@@ -308,7 +313,13 @@ fm_afk_launch_create_herdr() {  # <captain-target> <captain-backend>
   pane=$(printf '%s' "$out" | jq -r '.result.root_pane.pane_id // empty' 2>/dev/null)
   if [ "$create_result" -ne 0 ] && [ -n "$wsid" ] && [ -n "$pane" ]; then
     fm_afk_launch_log "herdr create failed after returning exact ids; closing $session:$pane"
-    fm_backend_herdr_kill "$session:$pane"
+    if fm_afk_launch_record_write herdr "$session:$pane" "$wsid"; then
+      FM_AFK_REC_BACKEND=herdr
+      FM_AFK_REC_TARGET="$session:$pane"
+      fm_afk_launch_close_recorded || true
+    else
+      fm_afk_launch_log "failed to persist exact id for failed herdr create"
+    fi
     return 1
   fi
   if [ -z "$wsid" ] || [ -z "$pane" ]; then
@@ -321,12 +332,19 @@ fm_afk_launch_create_herdr() {  # <captain-target> <captain-backend>
   entry=$(fm_afk_launch_entry_cmd)
   cmd=$(printf 'exec env FM_HOME=%q FM_SUPERVISOR_TARGET=%q FM_SUPERVISOR_BACKEND=%q %q' \
     "$FM_HOME" "$captain_target" "$captain_backend" "$entry")
-  if ! fm_backend_herdr_cli "$session" pane run "$pane" "$cmd" >/dev/null 2>&1; then
-    fm_afk_launch_log "failed to run daemon in herdr pane $session:$pane; closing it"
-    fm_backend_herdr_kill "$session:$pane"
+  if ! fm_afk_launch_record_write herdr "$session:$pane" "$wsid"; then
+    fm_afk_launch_log "failed to persist herdr daemon terminal record; closing $session:$pane"
+    fm_afk_launch_close_terminal herdr "$session:$pane"
     return 1
   fi
-  fm_afk_launch_commit_terminal herdr "$session:$pane" "$wsid" || return 1
+  if ! fm_backend_herdr_cli "$session" pane run "$pane" "$cmd" >/dev/null 2>&1; then
+    fm_afk_launch_log "failed to run daemon in herdr pane $session:$pane; closing it"
+    FM_AFK_REC_BACKEND=herdr
+    FM_AFK_REC_TARGET="$session:$pane"
+    fm_afk_launch_close_recorded || true
+    return 1
+  fi
+  fm_afk_launch_commit_terminal herdr "$session:$pane" "$wsid" 1 || return 1
   fm_afk_launch_log "daemon launched in non-visible herdr workspace $wsid (pane $session:$pane), supervising $captain_target"
 }
 
@@ -370,9 +388,14 @@ fm_afk_launch_start() {
   fi
 
   backup=$(mktemp -d "$FM_AFK_LAUNCH_STATE/.afk-launch-backup.XXXXXX") || return 1
-  [ -f "$FM_AFK_LAUNCH_STATE/.afk" ] && had_afk=1 && cp "$FM_AFK_LAUNCH_STATE/.afk" "$backup/.afk"
+  if [ -f "$FM_AFK_LAUNCH_STATE/.afk" ]; then
+    had_afk=1
+    cp "$FM_AFK_LAUNCH_STATE/.afk" "$backup/.afk" || { rm -rf "$backup"; return 1; }
+  fi
   for artifact in .subsuper-escalations .subsuper-escalations.since .subsuper-inject-wedged; do
-    [ -e "$FM_AFK_LAUNCH_STATE/$artifact" ] && cp -p "$FM_AFK_LAUNCH_STATE/$artifact" "$backup/$artifact"
+    if [ -e "$FM_AFK_LAUNCH_STATE/$artifact" ]; then
+      cp -p "$FM_AFK_LAUNCH_STATE/$artifact" "$backup/$artifact" || { rm -rf "$backup"; return 1; }
+    fi
   done
   if ! fm_afk_launch_reconcile; then
     result=1
@@ -418,9 +441,14 @@ fm_afk_launch_start_native() {
     return 0
   fi
   backup=$(mktemp -d "$FM_AFK_LAUNCH_STATE/.afk-launch-backup.XXXXXX") || return 1
-  [ -f "$FM_AFK_LAUNCH_STATE/.afk" ] && had_afk=1 && cp "$FM_AFK_LAUNCH_STATE/.afk" "$backup/.afk"
+  if [ -f "$FM_AFK_LAUNCH_STATE/.afk" ]; then
+    had_afk=1
+    cp "$FM_AFK_LAUNCH_STATE/.afk" "$backup/.afk" || { rm -rf "$backup"; return 1; }
+  fi
   for artifact in .subsuper-escalations .subsuper-escalations.since .subsuper-inject-wedged; do
-    [ -e "$FM_AFK_LAUNCH_STATE/$artifact" ] && cp -p "$FM_AFK_LAUNCH_STATE/$artifact" "$backup/$artifact"
+    if [ -e "$FM_AFK_LAUNCH_STATE/$artifact" ]; then
+      cp -p "$FM_AFK_LAUNCH_STATE/$artifact" "$backup/$artifact" || { rm -rf "$backup"; return 1; }
+    fi
   done
   fm_afk_launch_reconcile || result=1
   if [ "$result" -eq 0 ]; then
@@ -431,7 +459,7 @@ fm_afk_launch_start_native() {
     fm_afk_launch_record_write none - native || result=1
   fi
   if [ "$result" -ne 0 ]; then
-    rm -f "$FM_AFK_LAUNCH_STATE/.afk" "$FM_AFK_LAUNCH_RECORD" \
+    rm -f "$FM_AFK_LAUNCH_STATE/.afk" \
       "$FM_AFK_LAUNCH_STATE/.subsuper-escalations" "$FM_AFK_LAUNCH_STATE/.subsuper-escalations.since" \
       "$FM_AFK_LAUNCH_STATE/.subsuper-inject-wedged"
     [ "$had_afk" -eq 1 ] && cp "$backup/.afk" "$FM_AFK_LAUNCH_STATE/.afk"

--- a/bin/fm-afk-start.sh
+++ b/bin/fm-afk-start.sh
@@ -3,12 +3,19 @@
 # foreground process when one is not already alive.
 #
 # Usage: fm-afk-start.sh
-#   Sets state/.afk, checks state/.supervise-daemon.lock, and:
+#   Sets state/.afk unless FM_AFK_STATE_PREPARED=1, checks
+#   state/.supervise-daemon.lock, and:
 #     - prints "afk: daemon already running pid=<pid>" then exits 0 when that
 #       lock is held by a live daemon (a REFRESH: no stale-artifact clear);
 #     - otherwise clears any prior away session's stale escalation artifacts
-#       (fm_afk_clear_stale_artifacts) and execs bin/fm-supervise-daemon.sh in
-#       the foreground.
+#       (fm_afk_clear_stale_artifacts) for a direct, non-prepared start, then
+#       execs bin/fm-supervise-daemon.sh in the foreground. A prepared start was
+#       already cleared transactionally by bin/fm-afk-launch.sh.
+#
+# This file is sourceable: its BASH_SOURCE guard keeps main from running, while
+# exposing the daemon-lock helpers and fm_afk_clear_stale_artifacts. Sourcing it
+# enables nounset and errexit; callers that need different shell options must
+# restore them explicitly.
 #
 # This is the COMMON daemon entry for every backend. HOW it becomes a tracked
 # background process differs by harness/backend and is owned elsewhere:

--- a/bin/fm-afk-start.sh
+++ b/bin/fm-afk-start.sh
@@ -111,7 +111,11 @@ fm_afk_start_main() {
   esac
 
   mkdir -p "$FM_AFK_STATE"
-  date '+%s' > "$FM_AFK_STATE/.afk"
+  if [ "${FM_AFK_STATE_PREPARED:-0}" = 1 ]; then
+    [ -f "$FM_AFK_STATE/.afk" ] || { echo "afk: launcher-prepared state is missing" >&2; return 1; }
+  else
+    date '+%s' > "$FM_AFK_STATE/.afk"
+  fi
 
   local pid
   pid=$(daemon_lock_pid 2>/dev/null || true)
@@ -126,7 +130,9 @@ fm_afk_start_main() {
 
   # Fresh start: clear the previous away session's stale delivery artifacts
   # before the new daemon can surface them (fix for the leaked-artifact defect).
-  fm_afk_clear_stale_artifacts "$FM_AFK_STATE"
+  if [ "${FM_AFK_STATE_PREPARED:-0}" != 1 ]; then
+    fm_afk_clear_stale_artifacts "$FM_AFK_STATE"
+  fi
 
   echo "afk: starting supervise daemon in foreground; keep this command as a tracked background session"
   exec "$FM_AFK_DAEMON"

--- a/bin/fm-afk-start.sh
+++ b/bin/fm-afk-start.sh
@@ -56,7 +56,7 @@ fm_afk_clear_stale_artifacts() {  # <state-dir>
   local state=$1
   rm -f "$state/.subsuper-escalations" \
         "$state/.subsuper-escalations.since" \
-        "$state/.subsuper-inject-wedged" 2>/dev/null || true
+        "$state/.subsuper-inject-wedged" 2>/dev/null
 }
 
 daemon_lock_owner() {

--- a/bin/fm-afk-start.sh
+++ b/bin/fm-afk-start.sh
@@ -5,51 +5,73 @@
 # Usage: fm-afk-start.sh
 #   Sets state/.afk, checks state/.supervise-daemon.lock, and:
 #     - prints "afk: daemon already running pid=<pid>" then exits 0 when that
-#       lock is held by a live daemon;
-#     - otherwise execs bin/fm-supervise-daemon.sh in the foreground.
+#       lock is held by a live daemon (a REFRESH: no stale-artifact clear);
+#     - otherwise clears any prior away session's stale escalation artifacts
+#       (fm_afk_clear_stale_artifacts) and execs bin/fm-supervise-daemon.sh in
+#       the foreground.
 #
-# Run this command as its own tracked background terminal/session.
-# Do not wrap it in `nohup ... &`: Codex/herdr can reap fire-and-forget shell
-# children after the tool call returns, while a tracked background command stays
-# attached to the harness and has a real lifecycle.
+# This is the COMMON daemon entry for every backend. HOW it becomes a tracked
+# background process differs by harness/backend and is owned elsewhere:
+#   - Harnesses with a native in-pane tracked-background tool (e.g. claude, grok)
+#     run this directly via that tool, so the daemon inherits the captain pane's
+#     env and auto-discovers it.
+#   - Harnesses with NO native background mechanism (e.g. pi) run this THROUGH
+#     bin/fm-afk-launch.sh, which creates a non-visible tracked terminal per
+#     backend (herdr tab/workspace, tmux detached session) and passes the
+#     captain pane in as FM_SUPERVISOR_TARGET so injection targets it, not the
+#     daemon's own new pane.
+# Do not wrap this in `nohup ... &`: Codex/herdr can reap fire-and-forget shell
+# children after the tool call returns, while a tracked background terminal stays
+# attached and has a real lifecycle.
 set -eu
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_AFK_START_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$FM_AFK_START_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
-STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
-LOCK="$STATE/.supervise-daemon.lock"
-DAEMON="$SCRIPT_DIR/fm-supervise-daemon.sh"
-
-usage() {
-  sed -n '2,14p' "$0" | sed 's/^# \{0,1\}//'
-}
-
-case "${1:-}" in
-  '' ) ;;
-  -h|--help) usage; exit 0 ;;
-  * ) echo "usage: $(basename "$0")" >&2; exit 2 ;;
-esac
-
-mkdir -p "$STATE"
-date '+%s' > "$STATE/.afk"
+FM_AFK_STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+FM_AFK_LOCK="$FM_AFK_STATE/.supervise-daemon.lock"
+FM_AFK_DAEMON="$FM_AFK_START_DIR/fm-supervise-daemon.sh"
 
 # shellcheck source=bin/fm-wake-lib.sh
-. "$SCRIPT_DIR/fm-wake-lib.sh"
+. "$FM_AFK_START_DIR/fm-wake-lib.sh"
+
+fm_afk_start_usage() {
+  sed -n '2,14p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+# fm_afk_clear_stale_artifacts: on a FRESH away-session entry (the daemon is not
+# already running), drop the previous away session's leftover escalation-delivery
+# artifacts so they cannot surface as stale escalations under the new session.
+# These are session-scoped by timing: a fresh entry owns a new supervision
+# session and the new daemon has not produced anything yet, so anything present
+# here belongs to a PRIOR session. This never drops a genuinely-pending
+# escalation - the delivery buffer is a transient cache, and any condition still
+# true (a crew still blocked, a check still firing) is re-derived and re-escalated
+# fresh by the daemon's heartbeat catch-all scan and the durable
+# state/.wake-queue replay (see docs/herdr-backend.md "Away-mode stale-artifact
+# lifecycle" and bin/fm-supervise-daemon.sh's escalate_add/inject_wedge_alarm).
+# NOT called on a refresh (daemon already alive), so the current session's own
+# buffered escalations are preserved.
+fm_afk_clear_stale_artifacts() {  # <state-dir>
+  local state=$1
+  rm -f "$state/.subsuper-escalations" \
+        "$state/.subsuper-escalations.since" \
+        "$state/.subsuper-inject-wedged" 2>/dev/null || true
+}
 
 daemon_lock_owner() {
   local owner
-  if [ -L "$LOCK" ]; then
-    owner=$(readlink "$LOCK" 2>/dev/null) || return 1
+  if [ -L "$FM_AFK_LOCK" ]; then
+    owner=$(readlink "$FM_AFK_LOCK" 2>/dev/null) || return 1
     [ -n "$owner" ] || return 1
     case "$owner" in
       /*) printf '%s\n' "$owner" ;;
-      *) printf '%s/%s\n' "$(dirname "$LOCK")" "$owner" ;;
+      *) printf '%s/%s\n' "$(dirname "$FM_AFK_LOCK")" "$owner" ;;
     esac
     return 0
   fi
-  [ -d "$LOCK" ] || return 1
-  printf '%s\n' "$LOCK"
+  [ -d "$FM_AFK_LOCK" ] || return 1
+  printf '%s\n' "$FM_AFK_LOCK"
 }
 
 daemon_pid_matches() {
@@ -62,7 +84,7 @@ daemon_pid_matches() {
   fi
   command=$(ps -p "$pid" -o command= 2>/dev/null || true)
   case "$command" in
-    *"$DAEMON"*|*"fm-supervise-daemon.sh"*) return 0 ;;
+    *"$FM_AFK_DAEMON"*|*"fm-supervise-daemon.sh"*) return 0 ;;
   esac
   return 1
 }
@@ -81,15 +103,37 @@ daemon_lock_held_by_live_daemon() {
   daemon_pid_matches "$pid" "$owner"
 }
 
-pid=$(daemon_lock_pid 2>/dev/null || true)
-if daemon_lock_held_by_live_daemon; then
-  echo "afk: daemon already running pid=$pid"
-  exit 0
-fi
+fm_afk_start_main() {
+  case "${1:-}" in
+    '' ) ;;
+    -h|--help) fm_afk_start_usage; return 0 ;;
+    * ) echo "usage: $(basename "${BASH_SOURCE[1]:-fm-afk-start.sh}")" >&2; return 2 ;;
+  esac
 
-if fm_pid_alive "$pid" && [ -n "$pid" ]; then
-  fm_lock_remove_path "$LOCK" 2>/dev/null || true
-fi
+  mkdir -p "$FM_AFK_STATE"
+  date '+%s' > "$FM_AFK_STATE/.afk"
 
-echo "afk: starting supervise daemon in foreground; keep this command as a tracked background session"
-exec "$DAEMON"
+  local pid
+  pid=$(daemon_lock_pid 2>/dev/null || true)
+  if daemon_lock_held_by_live_daemon; then
+    echo "afk: daemon already running pid=$pid"
+    return 0
+  fi
+
+  if fm_pid_alive "$pid" && [ -n "$pid" ]; then
+    fm_lock_remove_path "$FM_AFK_LOCK" 2>/dev/null || true
+  fi
+
+  # Fresh start: clear the previous away session's stale delivery artifacts
+  # before the new daemon can surface them (fix for the leaked-artifact defect).
+  fm_afk_clear_stale_artifacts "$FM_AFK_STATE"
+
+  echo "afk: starting supervise daemon in foreground; keep this command as a tracked background session"
+  exec "$FM_AFK_DAEMON"
+}
+
+# Run only when executed, not when sourced (tests source fm_afk_clear_stale_artifacts
+# and the lock helpers directly).
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  fm_afk_start_main "$@"
+fi

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -160,13 +160,14 @@ FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 # shellcheck source=bin/fm-classify-lib.sh
 . "$FM_DAEMON_DIR/fm-classify-lib.sh"
 
+# Supervisor-pane discovery (FM_SUPERVISOR_TARGET_DEFAULT,
+# FM_SUPERVISOR_BACKEND_DEFAULT, discover_supervisor_target,
+# discover_supervisor_backend). Shared with the script-owned away launcher
+# (bin/fm-afk-launch.sh) so the captain-pane resolution has exactly one owner.
+# shellcheck source=bin/fm-supervisor-target-lib.sh
+. "$FM_DAEMON_DIR/fm-supervisor-target-lib.sh"
+
 # --- tunables ---------------------------------------------------------------
-FM_SUPERVISOR_TARGET_DEFAULT="firstmate:0"
-# Fallback BACKEND paired with the fallback target above: "firstmate:0" is a
-# tmux session:window name, so the bare fallback (nothing configured, nothing
-# detected) assumes tmux - matching this daemon's pre-herdr-support behavior
-# byte-for-byte when run outside both tmux and herdr.
-FM_SUPERVISOR_BACKEND_DEFAULT="tmux"
 # Supervisor backends this daemon knows how to inject into today. zellij, orca,
 # and cmux are real backends elsewhere in firstmate (bin/fm-backend.sh) but this
 # daemon has no verified composer/busy primitives wired up for them yet - see
@@ -302,65 +303,10 @@ _collapse_newlines() {  # <text>
   printf '%s' "$s"
 }
 
-# Auto-discover the supervisor pane at startup. Priority:
-#   1. FM_SUPERVISOR_TARGET env (explicit override) — caller passes it in;
-#      may be a tmux target or a herdr "<session>:<pane-id>" target (paired
-#      with discover_supervisor_backend, below, to know which).
-#   2. $TMUX_PANE — tmux sets this in every pane's environment; inherited by
-#      the daemon when the /afk skill launches it from firstmate's own pane.
-#   3. $HERDR_ENV=1 + $HERDR_PANE_ID — herdr injects both into every process
-#      it manages a pane for (docs/herdr-backend.md); the daemon composes the
-#      "<session>:<pane-id>" target string the herdr adapter expects from
-#      $HERDR_SESSION (defaulting to "default", mirroring
-#      bin/backends/herdr.sh's fm_backend_herdr_session) and $HERDR_PANE_ID.
-#      Checked after $TMUX_PANE so a tmux pane nested inside herdr still
-#      resolves to tmux, matching fm_backend_detect's innermost-first rule.
-#   4. firstmate:0 — legacy tmux fallback (may not resolve if the session is
-#      named differently). The caller logs a warning in that case.
-# Returns the resolved target on stdout; returns 1 if only the fallback is left
-# AND the fallback does not resolve to a live pane.
-discover_supervisor_target() {
-  if [ -n "${FM_SUPERVISOR_TARGET:-}" ]; then
-    printf '%s' "$FM_SUPERVISOR_TARGET"
-    return 0
-  fi
-  if [ -n "${TMUX_PANE:-}" ]; then
-    printf '%s' "$TMUX_PANE"
-    return 0
-  fi
-  if [ "${HERDR_ENV:-}" = "1" ] && [ -n "${HERDR_PANE_ID:-}" ]; then
-    printf '%s:%s' "${HERDR_SESSION:-default}" "$HERDR_PANE_ID"
-    return 0
-  fi
-  printf '%s' "$FM_SUPERVISOR_TARGET_DEFAULT"
-  return 1
-}
-
-# Auto-discover the supervisor's BACKEND at startup - independent of the
-# target string above, so an explicit FM_SUPERVISOR_TARGET override still
-# needs to know which primitives (tmux vs herdr) to dispatch through. Priority
-# mirrors discover_supervisor_target and bin/fm-backend.sh's fm_backend_detect:
-#   1. FM_SUPERVISOR_BACKEND env (explicit override).
-#   2. $TMUX_PANE set — tmux.
-#   3. $HERDR_ENV=1 (with $HERDR_PANE_ID present) — herdr.
-#   4. FM_SUPERVISOR_BACKEND_DEFAULT (tmux) — matches the target fallback above.
-# Returns the resolved backend on stdout; returns 1 if only the fallback is left.
-discover_supervisor_backend() {
-  if [ -n "${FM_SUPERVISOR_BACKEND:-}" ]; then
-    printf '%s' "$FM_SUPERVISOR_BACKEND"
-    return 0
-  fi
-  if [ -n "${TMUX_PANE:-}" ]; then
-    printf 'tmux'
-    return 0
-  fi
-  if [ "${HERDR_ENV:-}" = "1" ] && [ -n "${HERDR_PANE_ID:-}" ]; then
-    printf 'herdr'
-    return 0
-  fi
-  printf '%s' "$FM_SUPERVISOR_BACKEND_DEFAULT"
-  return 1
-}
+# discover_supervisor_target / discover_supervisor_backend are owned by
+# bin/fm-supervisor-target-lib.sh (sourced above). fm_super_main below calls
+# them exactly as before; the away launcher reuses the identical resolution to
+# pass the captain pane in as FM_SUPERVISOR_TARGET.
 
 # --- classification helpers (PURE: no side effects, testable) ---------------
 # last_status_line, status_is_captain_relevant, window_to_task, and

--- a/bin/fm-supervisor-target-lib.sh
+++ b/bin/fm-supervisor-target-lib.sh
@@ -18,8 +18,8 @@
 # "firstmate:0" is a tmux session:window name, so the bare fallback (nothing
 # configured, nothing detected) assumes tmux - matching the daemon's pre-herdr
 # behavior byte-for-byte when run outside both tmux and herdr.
-: "${FM_SUPERVISOR_TARGET_DEFAULT:=firstmate:0}"
-: "${FM_SUPERVISOR_BACKEND_DEFAULT:=tmux}"
+FM_SUPERVISOR_TARGET_DEFAULT="firstmate:0"
+FM_SUPERVISOR_BACKEND_DEFAULT="tmux"
 
 # discover_supervisor_target: resolve the pane running firstmate. Priority:
 #   1. FM_SUPERVISOR_TARGET env (explicit override) - may be a tmux target or a

--- a/bin/fm-supervisor-target-lib.sh
+++ b/bin/fm-supervisor-target-lib.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# fm-supervisor-target-lib.sh - the single owner of supervisor-pane discovery.
+#
+# The away-mode daemon (bin/fm-supervise-daemon.sh) must know which pane runs
+# firstmate itself, both to inject escalations into it and, for the daemon, to
+# validate that target at startup. The script-owned away launcher
+# (bin/fm-afk-launch.sh) must resolve the SAME captain pane BEFORE it creates a
+# separate, non-visible terminal for the daemon, so it can pass that pane in as
+# FM_SUPERVISOR_TARGET (otherwise the daemon, running in its own terminal, would
+# auto-discover its OWN pane and inject there instead of into the captain's).
+#
+# Because both callers need the identical resolution, it lives here once. The
+# function names and precedence are unchanged from when this logic lived inline
+# in bin/fm-supervise-daemon.sh, so its unit tests (tests/fm-daemon.test.sh)
+# keep exercising the same names after the daemon sources this file.
+
+# Default supervisor pane target/backend when nothing is configured or detected.
+# "firstmate:0" is a tmux session:window name, so the bare fallback (nothing
+# configured, nothing detected) assumes tmux - matching the daemon's pre-herdr
+# behavior byte-for-byte when run outside both tmux and herdr.
+: "${FM_SUPERVISOR_TARGET_DEFAULT:=firstmate:0}"
+: "${FM_SUPERVISOR_BACKEND_DEFAULT:=tmux}"
+
+# discover_supervisor_target: resolve the pane running firstmate. Priority:
+#   1. FM_SUPERVISOR_TARGET env (explicit override) - may be a tmux target or a
+#      herdr "<session>:<pane-id>" target (paired with discover_supervisor_backend
+#      to know which).
+#   2. $TMUX_PANE - tmux sets this in every pane's environment; inherited by a
+#      process launched from firstmate's own pane.
+#   3. $HERDR_ENV=1 + $HERDR_PANE_ID - herdr injects both into every process it
+#      manages a pane for; compose the "<session>:<pane-id>" target from
+#      $HERDR_SESSION (defaulting to "default", mirroring bin/backends/herdr.sh's
+#      fm_backend_herdr_session) and $HERDR_PANE_ID. Checked after $TMUX_PANE so a
+#      tmux pane nested inside herdr still resolves to tmux, matching
+#      fm_backend_detect's innermost-first rule.
+#   4. FM_SUPERVISOR_TARGET_DEFAULT - legacy tmux fallback (may not resolve if the
+#      session is named differently). Returns 1 so the caller can warn.
+discover_supervisor_target() {
+  if [ -n "${FM_SUPERVISOR_TARGET:-}" ]; then
+    printf '%s' "$FM_SUPERVISOR_TARGET"
+    return 0
+  fi
+  if [ -n "${TMUX_PANE:-}" ]; then
+    printf '%s' "$TMUX_PANE"
+    return 0
+  fi
+  if [ "${HERDR_ENV:-}" = "1" ] && [ -n "${HERDR_PANE_ID:-}" ]; then
+    printf '%s:%s' "${HERDR_SESSION:-default}" "$HERDR_PANE_ID"
+    return 0
+  fi
+  printf '%s' "$FM_SUPERVISOR_TARGET_DEFAULT"
+  return 1
+}
+
+# discover_supervisor_backend: resolve the supervisor pane's BACKEND, independent
+# of the target string so an explicit FM_SUPERVISOR_TARGET override still knows
+# which primitives (tmux vs herdr) to dispatch through. Priority mirrors
+# discover_supervisor_target and bin/fm-backend.sh's fm_backend_detect:
+#   1. FM_SUPERVISOR_BACKEND env (explicit override).
+#   2. $TMUX_PANE set - tmux.
+#   3. $HERDR_ENV=1 (with $HERDR_PANE_ID present) - herdr.
+#   4. FM_SUPERVISOR_BACKEND_DEFAULT (tmux) - matches the target fallback. Returns 1.
+discover_supervisor_backend() {
+  if [ -n "${FM_SUPERVISOR_BACKEND:-}" ]; then
+    printf '%s' "$FM_SUPERVISOR_BACKEND"
+    return 0
+  fi
+  if [ -n "${TMUX_PANE:-}" ]; then
+    printf 'tmux'
+    return 0
+  fi
+  if [ "${HERDR_ENV:-}" = "1" ] && [ -n "${HERDR_PANE_ID:-}" ]; then
+    printf 'herdr'
+    return 0
+  fi
+  printf '%s' "$FM_SUPERVISOR_BACKEND_DEFAULT"
+  return 1
+}

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -685,6 +685,44 @@ ok - real herdr: the watcher fast-path enqueues a stale wake naming the task win
 The subscriber returned the `blocked` transition in **0.129s** and the watcher fast-path enqueued a durable `stale` wake naming the task window - versus up to `FM_POLL` (15s) plus `FM_STALE_ESCALATE_SECS` (240s) on the poll path this shortcuts.
 Dedupe (one wake per `->blocked` edge, marker cleared when the pane returns to `working`), subscribe-then-reconcile ordering (an already-blocked pane enqueued exactly once while newer edges buffer in the active stream), the `kind=secondmate`/`paused:` exemptions, and the three fail-closed fallbacks are covered by the fake-CLI unit tests in `tests/fm-backend-herdr.test.sh` (the `wait_transition`/`apply_transition` cases), `tests/fm-transition-lib.test.sh`, and `tests/fm-supervision-events.test.sh`.
 
+## Away-mode daemon terminal launch (2026-07-12, herdr 0.7.3, protocol 16, macOS aarch64)
+
+`bin/fm-afk-start.sh` execs the supervise daemon in the FOREGROUND of whatever terminal it is already in.
+Harnesses with a native in-pane tracked-background tool (claude, grok) run it there and the daemon inherits the captain pane's env.
+A harness with NO native background mechanism (pi) has no place to run it, and manufacturing one by SPLITTING the captain's active pane visibly shrinks it: `herdr pane split <pane> --direction down --ratio 0.20 --no-focus` creates a second pane whose `tab_id` equals the captain pane's, so the two co-tenant one tab's viewport.
+`--no-focus` does not prevent this - it governs focus, not geometry.
+
+`bin/fm-afk-launch.sh` is the single owner of the daemon TERMINAL lifecycle for that case.
+On herdr it creates a dedicated background workspace (`workspace create --no-focus`, label `firstmate-afk-daemon`) in the captain's session, runs the daemon in its pane via `pane run` with `FM_SUPERVISOR_TARGET`/`FM_SUPERVISOR_BACKEND` set to the captain pane (so injection targets the captain, not the daemon's own pane), records the exact pane id in `state/.afk-daemon-terminal`, and on `stop` closes exactly that pane (which takes its single-tab workspace with it).
+No shell `&` is used.
+Recovery reconciles a recorded-but-dead terminal by exact id.
+
+Verified in an isolated lab session (`bin/fm-herdr-lab.sh`, fleet-state tripwire armed; `default` byte-identical before/after). A workspace `w1`/tab `w1:t1`/pane `w1:p1` stood in for the captain's primary pane:
+
+```
+# start (FM_SUPERVISOR_TARGET=<lab>:w1:p1, FM_SUPERVISOR_BACKEND=herdr)
+fm-afk-launch: daemon launched in non-visible herdr workspace w2 (pane <lab>:w2:p1), supervising <lab>:w1:p1
+record: herdr <TAB> <lab>:w2:p1 <TAB> w2
+captain-tab (w1:t1) pane count: BEFORE=1  DURING=1   # unchanged: NOT a split
+workspace count:                BEFORE=1  DURING=2   # daemon in a separate space
+daemon pane w2:p1 tab_id = w2:t1                     # NOT the captain tab w1:t1
+
+# stop
+captain-tab (w1:t1) pane count: AFTER=1             # restored/unchanged
+workspace count:                AFTER=1             # daemon workspace removed by exact id
+record removed, state/.afk cleared last
+```
+
+The topology invariant (entering AND exiting away mode leaves the captain's active tab pane set unchanged), the separate-terminal placement, and the exact-id teardown are covered per backend (herdr and tmux) by `tests/fm-afk-launch.test.sh`.
+
+### Stale-artifact lifecycle fix (same change)
+
+The away daemon's `state/.subsuper-escalations` (+ `.since`) and `state/.subsuper-inject-wedged` are a transient delivery cache, cleared only on a successful flush.
+Two ordering/scoping bugs leaked them into the next away session: on a clean exit the `/afk` skill cleared `state/.afk` BEFORE stopping the daemon, so the daemon's shutdown flush hit its own presence gate (`inject_msg`: `afk_active || return 1`) and was a no-op; and nothing cleared them on entry.
+The fix: `bin/fm-afk-launch.sh stop` SIGTERMs the daemon while `state/.afk` is still present (flush can run), then clears `state/.afk` last; and `fm_afk_clear_stale_artifacts` (`bin/fm-afk-start.sh`) drops the prior session's artifacts on a FRESH entry (daemon not already running), never on a refresh.
+This never drops a genuinely-pending escalation: the durable record is `state/.wake-queue` plus each crew's `state/<id>.status`, and any still-true condition is re-escalated by the daemon's heartbeat catch-all scan.
+Covered by the unit cases in `tests/fm-afk-launch.test.sh` (clear-on-fresh-entry vs refresh, and the stop ordering asserting the daemon saw `state/.afk` present at SIGTERM).
+
 ## Known gaps and follow-up notes
 
 - **Backend-specific bootstrap detection is absent.** `bin/fm-bootstrap.sh` still requires `tmux` outside Orca mode, and does not yet conditionally add `herdr` and `jq` when a backend selection resolves to herdr.

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -693,9 +693,10 @@ A harness with NO native background mechanism (pi) has no place to run it, and m
 `--no-focus` does not prevent this - it governs focus, not geometry.
 
 `bin/fm-afk-launch.sh` is the single owner of the daemon TERMINAL lifecycle for that case.
-On herdr it creates a dedicated background workspace (`workspace create --no-focus`, label `firstmate-afk-daemon`) in the captain's session, runs the daemon in its pane via `pane run` with `FM_SUPERVISOR_TARGET`/`FM_SUPERVISOR_BACKEND` set to the captain pane (so injection targets the captain, not the daemon's own pane), records the exact pane id in `state/.afk-daemon-terminal`, and on `stop` closes exactly that pane (which takes its single-tab workspace with it).
+On herdr it creates a dedicated background workspace with `workspace create --no-focus` and a unique `firstmate-afk-daemon-*` label in the captain's session, runs the daemon in its pane via `pane run` with `FM_SUPERVISOR_TARGET` and `FM_SUPERVISOR_BACKEND` set to the captain pane, records the exact pane id in `state/.afk-daemon-terminal`, and on `stop` closes exactly that pane, which takes its single-tab workspace with it.
+The explicit target and backend make injection reach the captain rather than the daemon's own pane.
 No shell `&` is used.
-Recovery reconciles a recorded-but-dead terminal by exact id.
+Recovery reconciles a recorded-but-dead terminal by exact id, never by enumerating or matching other Herdr workspaces.
 
 Verified in an isolated lab session (`bin/fm-herdr-lab.sh`, fleet-state tripwire armed; `default` byte-identical before/after). A workspace `w1`/tab `w1:t1`/pane `w1:p1` stood in for the captain's primary pane:
 
@@ -719,7 +720,8 @@ The topology invariant (entering AND exiting away mode leaves the captain's acti
 
 The away daemon's `state/.subsuper-escalations` (+ `.since`) and `state/.subsuper-inject-wedged` are a transient delivery cache, cleared only on a successful flush.
 Two ordering/scoping bugs leaked them into the next away session: on a clean exit the `/afk` skill cleared `state/.afk` BEFORE stopping the daemon, so the daemon's shutdown flush hit its own presence gate (`inject_msg`: `afk_active || return 1`) and was a no-op; and nothing cleared them on entry.
-The fix: `bin/fm-afk-launch.sh stop` SIGTERMs the daemon while `state/.afk` is still present (flush can run), then clears `state/.afk` last; and `fm_afk_clear_stale_artifacts` (`bin/fm-afk-start.sh`) drops the prior session's artifacts on a FRESH entry (daemon not already running), never on a refresh.
+The fix: `bin/fm-afk-launch.sh stop` SIGTERMs the daemon while `state/.afk` is still present so the flush can run, closes its recorded terminal by exact id, and then clears `state/.afk` last.
+On entry the launcher drops the prior session's artifacts when the daemon is not already running, never on a refresh; the sourceable `bin/fm-afk-start.sh` exposes the shared clearing helper and also applies it for a direct, non-prepared fresh start.
 This never drops a genuinely-pending escalation: the durable record is `state/.wake-queue` plus each crew's `state/<id>.status`, and any still-true condition is re-escalated by the daemon's heartbeat catch-all scan.
 Covered by the unit cases in `tests/fm-afk-launch.test.sh` (clear-on-fresh-entry vs refresh, and the stop ordering asserting the daemon saw `state/.afk` present at SIGTERM).
 

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -42,7 +42,9 @@ If you have changed away from the firstmate home in an interactive shell, invoke
 | `fm-watch-arm.sh`        | Verified home-scoped watcher arm wrapper with honest status reporting                |
 | `fm-watch-checkpoint.sh` | Run one bounded foreground watcher checkpoint for Codex-style supervision            |
 | `fm-watch.sh`            | Singleton-safe always-on watcher: absorb benign wakes, queue and exit on actionable ones |
-| `fm-afk-start.sh`        | Enter away mode and run the sub-supervisor daemon as a tracked foreground process    |
+| `fm-afk-start.sh`        | Common away-mode daemon entry: set `state/.afk`, clear a prior session's stale artifacts on a fresh start, exec the daemon in the foreground |
+| `fm-afk-launch.sh`       | Own the away-daemon terminal per backend: launch it in a non-visible tracked terminal (never a captain-pane split), record its exact id, and stop/reconcile by that id |
+| `fm-supervisor-target-lib.sh` | Shared supervisor-pane discovery (target + backend) for the daemon and the away launcher |
 | `fm-supervise-daemon.sh` | Presence-gated away-mode sub-supervisor: self-handle routine wakes, escalate batched digests, alert on failed delivery |
 | `fm-crew-state.sh`       | Print one deterministic current-state line for a crew                                |
 | `fm-tangle-lib.sh`       | Shared default-branch resolution and primary-checkout tangle classification          |

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -42,9 +42,9 @@ If you have changed away from the firstmate home in an interactive shell, invoke
 | `fm-watch-arm.sh`        | Verified home-scoped watcher arm wrapper with honest status reporting                |
 | `fm-watch-checkpoint.sh` | Run one bounded foreground watcher checkpoint for Codex-style supervision            |
 | `fm-watch.sh`            | Singleton-safe always-on watcher: absorb benign wakes, queue and exit on actionable ones |
-| `fm-afk-start.sh`        | Common away-mode daemon entry: set `state/.afk`, clear a prior session's stale artifacts on a fresh start, exec the daemon in the foreground |
-| `fm-afk-launch.sh`       | Own the away-daemon terminal per backend: launch it in a non-visible tracked terminal (never a captain-pane split), record its exact id, and stop/reconcile by that id |
-| `fm-supervisor-target-lib.sh` | Shared supervisor-pane discovery (target + backend) for the daemon and the away launcher |
+| `fm-afk-start.sh`        | Run the common sourceable away-mode daemon entry in the foreground                      |
+| `fm-afk-launch.sh`       | Own away-mode entry, exit, rollback, and any backend terminal lifecycle                 |
+| `fm-supervisor-target-lib.sh` | Resolve the shared supervisor target and backend for the daemon and launcher       |
 | `fm-supervise-daemon.sh` | Presence-gated away-mode sub-supervisor: self-handle routine wakes, escalate batched digests, alert on failed delivery |
 | `fm-crew-state.sh`       | Print one deterministic current-state line for a crew                                |
 | `fm-tangle-lib.sh`       | Shared default-branch resolution and primary-checkout tangle classification          |

--- a/tests/fm-afk-launch.test.sh
+++ b/tests/fm-afk-launch.test.sh
@@ -536,41 +536,102 @@ unit_stop_malformed_record_fails_closed() {
 }
 
 unit_tmux_planned_record_and_collision() {
-  local st
+  local st first second
   st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-tmux-plan.XXXXXX")
   mkdir -p "$st/state"
   if FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" bash -c '
     . "$1"
     tmux() {
-      if [ "$1" = has-session ]; then printf "can\\x27t find session\\n" >&2; return 1; fi
       if [ "$1" = new-session ]; then
         [ -s "$FM_AFK_LAUNCH_RECORD" ] || return 9
+        printf "%s" "$4" > "$FM_HOME/created-name"
         return 1
       fi
+      [ "$1" != kill-session ] || : > "$FM_HOME/killed"
       return 1
     }
     ! fm_afk_launch_create_tmux captain:0 tmux
-  ' _ "$LAUNCH"; then
-    pass "tmux launch: planned exact target is recorded before creation"
+  ' _ "$LAUNCH" && [ ! -e "$st/state/.afk-daemon-terminal" ] && [ ! -e "$st/killed" ]; then
+    pass "tmux launch: planned exact target is recorded before creation and removed on failure"
   else
     fail "tmux launch: creation began before exact target publication"
   fi
+  first=$(cat "$st/created-name")
   rm -rf "$st"
 
-  st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-tmux-collision.XXXXXX")
+  st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-tmux-unique.XXXXXX")
   mkdir -p "$st/state"
   if FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" bash -c '
     . "$1"
     tmux() {
-      [ "$1" = has-session ] && return 0
+      [ "$1" != new-session ] || { printf "%s" "$4" > "$FM_HOME/created-name"; return 1; }
       [ "$1" != kill-session ] || : > "$FM_HOME/killed"
-      return 0
+      return 1
     }
     ! fm_afk_launch_create_tmux captain:0 tmux
   ' _ "$LAUNCH" && [ ! -e "$st/killed" ]; then
-    pass "tmux launch: unowned same-name session fails closed without teardown"
+    second=$(cat "$st/created-name")
+    if [ "$first" != "$second" ]; then
+      pass "tmux launch: unique names eliminate collision teardown"
+    else
+      fail "tmux launch: consecutive launches reused a session name"
+    fi
   else
-    fail "tmux launch: unowned same-name session was replaced"
+    fail "tmux launch: creation failure attempted session teardown"
+  fi
+  rm -rf "$st"
+}
+
+unit_stop_validates_before_signal() {
+  local st sleeper_pid
+  st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-stop-validate.XXXXXX")
+  mkdir -p "$st/state"
+  : > "$st/state/.afk"
+  printf 'tmux\tonly-two-fields\n' > "$st/state/.afk-daemon-terminal"
+  sleep 30 & sleeper_pid=$!
+  mkdir -p "$st/state/.supervise-daemon.lock"
+  printf '%s' "$sleeper_pid" > "$st/state/.supervise-daemon.lock/pid"
+  ( . "$ROOT/bin/fm-wake-lib.sh"; fm_pid_identity "$sleeper_pid" > "$st/state/.supervise-daemon.lock/pid-identity" )
+  FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" "$LAUNCH" stop >/dev/null 2>&1 || true
+  if kill -0 "$sleeper_pid" 2>/dev/null && [ -e "$st/state/.afk" ]; then
+    pass "stop validation: malformed record causes no daemon or state side effects"
+  else
+    fail "stop validation: malformed record signaled daemon or cleared state"
+  fi
+  kill "$sleeper_pid" 2>/dev/null || true
+  wait "$sleeper_pid" 2>/dev/null || true
+  rm -rf "$st"
+}
+
+unit_lock_requires_complete_metadata() {
+  local st
+  st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-lock-metadata.XXXXXX")
+  mkdir -p "$st/state"
+  if FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" bash -c '
+    . "$1"
+    fm_pid_identity() { return 1; }
+    ! fm_afk_launch_lock_acquire
+  ' _ "$LAUNCH" && [ ! -e "$st/state/.afk-launch.lock" ]; then
+    pass "launcher lock: incomplete metadata fails acquisition and releases lock"
+  else
+    fail "launcher lock: incomplete metadata was accepted"
+  fi
+  rm -rf "$st"
+}
+
+unit_stop_surfaces_afk_removal_failure() {
+  local st
+  st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-stop-remove.XXXXXX")
+  mkdir -p "$st/state"
+  : > "$st/state/.afk"
+  if FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" bash -c '
+    . "$1"
+    rm() { local last=${!#}; [ "$last" != "$FM_AFK_LAUNCH_STATE/.afk" ]; }
+    ! fm_afk_launch_stop
+  ' _ "$LAUNCH"; then
+    pass "stop state: away-flag removal failure is surfaced"
+  else
+    fail "stop state: away-flag removal failure reported success"
   fi
   rm -rf "$st"
 }
@@ -765,6 +826,9 @@ unit_record_publication_atomic
 unit_malformed_record_fails_closed
 unit_stop_malformed_record_fails_closed
 unit_tmux_planned_record_and_collision
+unit_stop_validates_before_signal
+unit_lock_requires_complete_metadata
+unit_stop_surfaces_afk_removal_failure
 unit_clear_failure_aborts_entry
 unit_confirmed_absence_succeeds
 unit_incomplete_restore_retains_backup

--- a/tests/fm-afk-launch.test.sh
+++ b/tests/fm-afk-launch.test.sh
@@ -636,6 +636,54 @@ unit_stop_surfaces_afk_removal_failure() {
   rm -rf "$st"
 }
 
+unit_stop_confirms_daemon_exit() {
+  local st daemon_pid
+  st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-stop-live.XXXXXX")
+  mkdir -p "$st/state/.supervise-daemon.lock"
+  : > "$st/state/.afk"
+  printf 'none\t-\tnative\n' > "$st/state/.afk-daemon-terminal"
+  bash -c 'trap "" TERM; while :; do sleep 1; done' &
+  daemon_pid=$!
+  printf '%s' "$daemon_pid" > "$st/state/.supervise-daemon.lock/pid"
+  ( . "$ROOT/bin/fm-wake-lib.sh"; fm_pid_identity "$daemon_pid" > "$st/state/.supervise-daemon.lock/pid-identity" )
+  if FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" bash -c '
+    . "$1"
+    seq() { printf "1\n"; }
+    sleep() { :; }
+    ! fm_afk_launch_stop
+  ' _ "$LAUNCH" && kill -0 "$daemon_pid" 2>/dev/null \
+    && [ -e "$st/state/.afk" ] && [ -e "$st/state/.afk-daemon-terminal" ]; then
+    pass "stop liveness: live daemon preserves lifecycle state and fails closed"
+  else
+    fail "stop liveness: live daemon was reported stopped or lost lifecycle state"
+  fi
+  kill -KILL "$daemon_pid" 2>/dev/null || true
+  wait "$daemon_pid" 2>/dev/null || true
+  rm -rf "$st"
+}
+
+unit_refresh_validates_record() {
+  local st daemon_pid
+  st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-refresh-record.XXXXXX")
+  mkdir -p "$st/state/.supervise-daemon.lock"
+  printf 'tmux\tonly-two-fields\n' > "$st/state/.afk-daemon-terminal"
+  sleep 30 & daemon_pid=$!
+  printf '%s' "$daemon_pid" > "$st/state/.supervise-daemon.lock/pid"
+  ( . "$ROOT/bin/fm-wake-lib.sh"; fm_pid_identity "$daemon_pid" > "$st/state/.supervise-daemon.lock/pid-identity" )
+  if FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" FM_SUPERVISOR_TARGET=unused \
+    FM_SUPERVISOR_BACKEND=tmux bash -c '
+      . "$1"
+      ! fm_afk_launch_start && ! fm_afk_launch_start_native
+    ' _ "$LAUNCH" && [ ! -e "$st/state/.afk" ]; then
+    pass "refresh record: malformed terminal identity fails closed"
+  else
+    fail "refresh record: malformed terminal identity was accepted"
+  fi
+  kill "$daemon_pid" 2>/dev/null || true
+  wait "$daemon_pid" 2>/dev/null || true
+  rm -rf "$st"
+}
+
 unit_clear_failure_aborts_entry() {
   local st
   st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-clear-fail.XXXXXX")
@@ -829,6 +877,8 @@ unit_tmux_planned_record_and_collision
 unit_stop_validates_before_signal
 unit_lock_requires_complete_metadata
 unit_stop_surfaces_afk_removal_failure
+unit_stop_confirms_daemon_exit
+unit_refresh_validates_record
 unit_clear_failure_aborts_entry
 unit_confirmed_absence_succeeds
 unit_incomplete_restore_retains_backup

--- a/tests/fm-afk-launch.test.sh
+++ b/tests/fm-afk-launch.test.sh
@@ -465,7 +465,7 @@ unit_close_failure_preserves_record() {
   local st
   st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-close-fail.XXXXXX")
   mkdir -p "$st/state"
-  printf 'tmux\texact-session\t\n' > "$st/state/.afk-daemon-terminal"
+  printf 'tmux\texact-session\towned\n' > "$st/state/.afk-daemon-terminal"
   FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" bash -c '
     . "$1"
     fm_afk_launch_close_terminal() { return 1; }
@@ -476,6 +476,80 @@ unit_close_failure_preserves_record() {
     pass "teardown failure: exact terminal record is preserved"
   else
     fail "teardown failure: exact terminal record was discarded"
+  fi
+  rm -rf "$st"
+}
+
+unit_record_publication_atomic() {
+  local st
+  st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-record-atomic.XXXXXX")
+  mkdir -p "$st/state"
+  printf 'tmux\told-session\towned\n' > "$st/state/.afk-daemon-terminal"
+  if FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" bash -c '
+    . "$1"
+    mv() { return 1; }
+    ! fm_afk_launch_record_write tmux new-session owned
+  ' _ "$LAUNCH" \
+    && [ "$(cat "$st/state/.afk-daemon-terminal")" = $'tmux\told-session\towned' ] \
+    && ! find "$st/state" -name '.afk-daemon-terminal.pending.*' -print -quit | grep -q .; then
+    pass "record publication: failed atomic rename preserves the complete prior record"
+  else
+    fail "record publication: failed write truncated or replaced the prior record"
+  fi
+  rm -rf "$st"
+}
+
+unit_malformed_record_fails_closed() {
+  local st acted
+  st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-record-malformed.XXXXXX")
+  mkdir -p "$st/state"
+  printf 'tmux\tonly-two-fields\n' > "$st/state/.afk-daemon-terminal"
+  acted="$st/acted"
+  if FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" ACTED="$acted" bash -c '
+    . "$1"
+    fm_afk_launch_close_terminal() { : > "$ACTED"; }
+    ! fm_afk_launch_reconcile
+  ' _ "$LAUNCH" \
+    && [ ! -e "$acted" ] && [ -e "$st/state/.afk-daemon-terminal" ]; then
+    pass "record read: malformed record fails closed without acting on a partial id"
+  else
+    fail "record read: malformed record was acted on or discarded"
+  fi
+  rm -rf "$st"
+}
+
+unit_confirmed_absence_succeeds() {
+  local st
+  st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-confirmed-absent.XXXXXX")
+  mkdir -p "$st/state"
+  printf 'tmux\texact-session\towned\n' > "$st/state/.afk-daemon-terminal"
+  if FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" bash -c '
+    . "$1"
+    fm_afk_launch_close_terminal() { return 1; }
+    fm_afk_launch_terminal_absent() { return 0; }
+    fm_afk_launch_reconcile
+  ' _ "$LAUNCH" && [ ! -e "$st/state/.afk-daemon-terminal" ]; then
+    pass "confirmed absence: cleanup succeeds and removes the stale record"
+  else
+    fail "confirmed absence: close error incorrectly failed reconciliation"
+  fi
+  rm -rf "$st"
+}
+
+unit_incomplete_restore_retains_backup() {
+  local st backup
+  st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-restore-fail.XXXXXX")
+  mkdir -p "$st/state"
+  backup=$(mktemp -d "$st/state/.afk-launch-backup.XXXXXX")
+  printf 'prior\n' > "$backup/.afk"
+  if FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" bash -c '
+    . "$1"
+    cp() { return 1; }
+    ! fm_afk_launch_restore_backup "$2" 1
+  ' _ "$LAUNCH" "$backup" && [ -d "$backup" ] && [ -e "$backup/.afk" ]; then
+    pass "rollback restore: incomplete restoration retains its recovery backup"
+  else
+    fail "rollback restore: incomplete restoration discarded its backup"
   fi
   rm -rf "$st"
 }
@@ -612,6 +686,10 @@ unit_tmux_absence_distinguishes_probe_failure
 unit_native_lifecycle
 unit_native_entry_preserves_prepared_state
 unit_close_failure_preserves_record
+unit_record_publication_atomic
+unit_malformed_record_fails_closed
+unit_confirmed_absence_succeeds
+unit_incomplete_restore_retains_backup
 unit_flag_write_failure_aborts
 e2e_herdr
 e2e_tmux

--- a/tests/fm-afk-launch.test.sh
+++ b/tests/fm-afk-launch.test.sh
@@ -119,8 +119,7 @@ unit_stop_ordering() {
   mkdir -p "$lock"
   printf '%s' "$daemon_pid" > "$lock/pid"
   ( . "$ROOT/bin/fm-wake-lib.sh"; fm_pid_identity "$daemon_pid" > "$lock/pid-identity" 2>/dev/null ) || true
-  # A recorded terminal (harmless: a non-existent tmux session name -> no-op close).
-  printf 'tmux\tfm-afk-nonexistent-%s\t\n' "$$" > "$st/state/.afk-daemon-terminal"
+  printf 'none\t-\tnative\n' > "$st/state/.afk-daemon-terminal"
   FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" "$LAUNCH" stop >/dev/null 2>&1
   if [ "$(cat "$marker" 2>/dev/null || echo missing)" = present ]; then
     pass "stop-ordering: daemon SIGTERM'd while .afk still present (flush is not a no-op)"
@@ -294,10 +293,9 @@ unit_herdr_partial_create_recovery() {
 }
 
 unit_herdr_error_with_exact_ids_closes_exact() {
-  local st closed
+  local st
   st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-herdr-error-exact.XXXXXX")
-  closed="$st/closed"
-  FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" CLOSED="$closed" bash -c '
+  FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" bash -c '
     . "$1"
     fm_backend_source() { return 0; }
     fm_backend_herdr_server_ensure() { return 0; }
@@ -305,16 +303,47 @@ unit_herdr_error_with_exact_ids_closes_exact() {
       if [ "$2 $3" = "workspace create" ]; then
         printf %s '\''{"result":{"workspace":{"workspace_id":"ws-exact"},"root_pane":{"pane_id":"pane-exact"}}}'\''
         return 1
+      elif [ "$2 $3" = "pane get" ]; then
+        printf %s '\''{"error":{"code":"transport_error"}}'\''
+        return 2
       fi
-      return 1
+      return 2
     }
-    fm_backend_herdr_kill() { printf "%s" "$1" > "$CLOSED"; }
     ! fm_afk_launch_create_herdr lab:captain herdr
   ' _ "$LAUNCH"
-  if [ "$(cat "$closed" 2>/dev/null || true)" = "lab:pane-exact" ]; then
-    pass "herdr create error: returned exact id is retained for cleanup"
+  if [ "$(cut -f2 "$st/state/.afk-daemon-terminal" 2>/dev/null || true)" = "lab:pane-exact" ]; then
+    pass "herdr create error: unconfirmed exact id is persisted for reconciliation"
   else
-    fail "herdr create error: exact cleanup id was discarded"
+    fail "herdr create error: unconfirmed exact cleanup id was discarded"
+  fi
+  rm -rf "$st"
+}
+
+unit_herdr_run_failure_preserves_unconfirmed_record() {
+  local st
+  st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-herdr-run-fail.XXXXXX")
+  FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" bash -c '
+    . "$1"
+    fm_backend_source() { return 0; }
+    fm_backend_herdr_server_ensure() { return 0; }
+    fm_backend_herdr_cli() {
+      if [ "$2 $3" = "workspace create" ]; then
+        printf %s '\''{"result":{"workspace":{"workspace_id":"ws-exact"},"root_pane":{"pane_id":"pane-exact"}}}'\''
+        return 0
+      elif [ "$2 $3" = "pane run" ]; then
+        return 1
+      elif [ "$2 $3" = "pane get" ]; then
+        printf %s '\''{"error":{"code":"transport_error"}}'\''
+        return 2
+      fi
+      return 2
+    }
+    ! fm_afk_launch_create_herdr lab:captain herdr
+  ' _ "$LAUNCH"
+  if [ "$(cut -f2 "$st/state/.afk-daemon-terminal" 2>/dev/null || true)" = "lab:pane-exact" ]; then
+    pass "herdr run failure: unconfirmed exact id remains reconcilable"
+  else
+    fail "herdr run failure: unconfirmed exact id was discarded"
   fi
   rm -rf "$st"
 }
@@ -352,6 +381,41 @@ unit_readiness_failure_rolls_back_terminal() {
     pass "readiness failure: exact terminal and durable record roll back"
   else
     fail "readiness failure: terminal or record survived"
+  fi
+  rm -rf "$st"
+}
+
+unit_readiness_failure_preserves_unconfirmed_record() {
+  local st
+  st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-not-ready-unconfirmed.XXXXXX")
+  FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" bash -c '
+    . "$1"
+    fm_afk_launch_wait_ready() { return 1; }
+    fm_afk_launch_close_terminal() { return 1; }
+    fm_afk_launch_terminal_absent() { return 1; }
+    ! fm_afk_launch_commit_terminal tmux exact-session ""
+  ' _ "$LAUNCH"
+  if [ "$(cut -f2 "$st/state/.afk-daemon-terminal" 2>/dev/null || true)" = exact-session ]; then
+    pass "readiness failure: unconfirmed terminal retains its reconciliation id"
+  else
+    fail "readiness failure: unconfirmed terminal lost its reconciliation id"
+  fi
+  rm -rf "$st"
+}
+
+unit_tmux_absence_distinguishes_probe_failure() {
+  local st
+  st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-tmux-probe.XXXXXX")
+  if FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" bash -c '
+    . "$1"
+    tmux() { printf "%s" "can'\''t find session: exact-session" >&2; return 1; }
+    fm_afk_launch_terminal_absent tmux exact-session
+    tmux() { printf "%s" "error connecting to /tmp/tmux.sock" >&2; return 1; }
+    ! fm_afk_launch_terminal_absent tmux exact-session
+  ' _ "$LAUNCH"; then
+    pass "tmux absence: clean missing differs from transport probe failure"
+  else
+    fail "tmux absence: probe failure was treated as confirmed absence"
   fi
   rm -rf "$st"
 }
@@ -540,8 +604,11 @@ unit_lock_initialization_grace
 unit_signal_exits_with_lock_cleanup
 unit_herdr_partial_create_recovery
 unit_herdr_error_with_exact_ids_closes_exact
+unit_herdr_run_failure_preserves_unconfirmed_record
 unit_record_failure_closes_terminal
 unit_readiness_failure_rolls_back_terminal
+unit_readiness_failure_preserves_unconfirmed_record
+unit_tmux_absence_distinguishes_probe_failure
 unit_native_lifecycle
 unit_native_entry_preserves_prepared_state
 unit_close_failure_preserves_record

--- a/tests/fm-afk-launch.test.sh
+++ b/tests/fm-afk-launch.test.sh
@@ -263,28 +263,69 @@ unit_signal_exits_with_lock_cleanup() {
   rm -rf "$st"
 }
 
-unit_herdr_partial_create_cleanup() {
-  local st killed
+unit_herdr_partial_create_recovery() {
+  local st recorded
   st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-herdr-partial.XXXXXX")
-  killed="$st/killed"
-  FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" KILLED="$killed" bash -c '
+  recorded="$st/recorded"
+  FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" FM_AFK_LAUNCH_ENTRY=/bin/true \
+    FM_AFK_LAUNCH_LABEL=afk-exact-label RECORDED="$recorded" bash -c '
     . "$1"
     fm_backend_source() { return 0; }
     fm_backend_herdr_server_ensure() { return 0; }
     fm_backend_herdr_cli() {
       if [ "$2 $3" = "workspace create" ]; then
-        printf %s '\''{"result":{"workspace":{"workspace_id":"ws-partial"},"root_pane":{}}}'\''
+        printf %s '\''truncated'\''
+        return 1
+      elif [ "$2 $3" = "workspace list" ]; then
+        printf %s '\''{"result":{"workspaces":[{"workspace_id":"ws-partial","label":"afk-exact-label"}]}}'\''
       else
         printf %s '\''{"result":{"panes":[{"pane_id":"pane-exact"}]}}'\''
       fi
     }
-    fm_backend_herdr_kill() { printf %s "$1" > "$KILLED"; }
-    ! fm_afk_launch_create_herdr lab:captain herdr
+    fm_afk_launch_record_write() { printf "%s:%s:%s" "$1" "$2" "$3" > "$RECORDED"; }
+    fm_afk_launch_create_herdr lab:captain herdr
   ' _ "$LAUNCH"
-  if [ "$(cat "$killed" 2>/dev/null || true)" = "lab:pane-exact" ]; then
-    pass "herdr create: partial response cleanup uses exact workspace pane"
+  if [ "$(cat "$recorded" 2>/dev/null || true)" = "herdr:lab:pane-exact:ws-partial" ]; then
+    pass "herdr create: malformed response recovers durable exact ownership"
   else
-    fail "herdr create: partial response leaked its created workspace"
+    fail "herdr create: malformed response left terminal ownership unknown"
+  fi
+  rm -rf "$st"
+}
+
+unit_record_failure_closes_terminal() {
+  local st closed
+  st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-record-fail.XXXXXX")
+  closed="$st/closed"
+  FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" CLOSED="$closed" bash -c '
+    . "$1"
+    fm_afk_launch_record_write() { return 1; }
+    fm_afk_launch_close_terminal() { printf "%s:%s" "$1" "$2" > "$CLOSED"; }
+    ! fm_afk_launch_commit_terminal tmux exact-session ""
+  ' _ "$LAUNCH"
+  if [ "$(cat "$closed" 2>/dev/null || true)" = "tmux:exact-session" ]; then
+    pass "record failure: newly created terminal is closed by exact id"
+  else
+    fail "record failure: newly created terminal leaked"
+  fi
+  rm -rf "$st"
+}
+
+unit_readiness_failure_rolls_back_terminal() {
+  local st closed
+  st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-not-ready.XXXXXX")
+  closed="$st/closed"
+  FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" CLOSED="$closed" bash -c '
+    . "$1"
+    fm_afk_launch_wait_ready() { return 1; }
+    fm_afk_launch_close_terminal() { printf "%s:%s" "$1" "$2" > "$CLOSED"; }
+    ! fm_afk_launch_commit_terminal tmux exact-session ""
+  ' _ "$LAUNCH"
+  if [ "$(cat "$closed" 2>/dev/null || true)" = "tmux:exact-session" ] \
+    && [ ! -e "$st/state/.afk-daemon-terminal" ]; then
+    pass "readiness failure: exact terminal and durable record roll back"
+  else
+    fail "readiness failure: terminal or record survived"
   fi
   rm -rf "$st"
 }
@@ -394,7 +435,9 @@ unit_failed_start_rolls_back_state
 unit_concurrent_start_serialized
 unit_lock_initialization_grace
 unit_signal_exits_with_lock_cleanup
-unit_herdr_partial_create_cleanup
+unit_herdr_partial_create_recovery
+unit_record_failure_closes_terminal
+unit_readiness_failure_rolls_back_terminal
 e2e_herdr
 e2e_tmux
 

--- a/tests/fm-afk-launch.test.sh
+++ b/tests/fm-afk-launch.test.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+# tests/fm-afk-launch.test.sh - the script-owned, backend-aware away-daemon
+# launch (bin/fm-afk-launch.sh) and the away-mode stale-artifact lifecycle fixes
+# (bin/fm-afk-start.sh). Two layers:
+#
+#   UNIT (always run, no backend): the session-scoped stale-artifact clear on a
+#   fresh entry vs a refresh, and the correct-ordered stop (daemon SIGTERM'd
+#   while state/.afk is still present, .afk cleared last).
+#
+#   E2E TOPOLOGY (per backend, skipped when its tool is absent): the anti-
+#   regression for the pane split/shrink - entering AND exiting away mode leaves
+#   the captain's active tab topology UNCHANGED, because the daemon lands in a
+#   NON-VISIBLE separate terminal (a herdr dedicated workspace, a detached tmux
+#   session), never a split of the captain's pane. The herdr path runs on a
+#   throwaway, NEVER-default HERDR_SESSION and asserts the default session is
+#   byte-identical via the fm-herdr-lab.sh fleet-state tripwire; the tmux path
+#   uses uniquely-named throwaway sessions killed by exact name. A harmless
+#   sleeper replaces the real daemon (FM_AFK_LAUNCH_ENTRY) so the test observes
+#   only the terminal lifecycle.
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LAUNCH="$ROOT/bin/fm-afk-launch.sh"
+START="$ROOT/bin/fm-afk-start.sh"
+
+FAILED=0
+fail() { printf 'not ok - %s\n' "$1" >&2; FAILED=1; }
+pass() { printf 'ok - %s\n' "$1"; }
+
+SLEEPER=$(mktemp "${TMPDIR:-/tmp}/fm-afk-sleeper.XXXXXX")
+printf '#!/usr/bin/env bash\nexec sleep 600\n' > "$SLEEPER"
+chmod +x "$SLEEPER"
+TRACK_TMUX_SESSIONS=""
+GLOBAL_CLEANUP() {
+  rm -f "$SLEEPER" 2>/dev/null || true
+  local s
+  for s in $TRACK_TMUX_SESSIONS; do
+    tmux kill-session -t "$s" 2>/dev/null || true
+  done
+}
+trap GLOBAL_CLEANUP EXIT
+
+# ---------------------------------------------------------------------------
+# UNIT 1: fm_afk_clear_stale_artifacts removes exactly the three stale artifacts.
+# ---------------------------------------------------------------------------
+unit_clear_stale() {
+  local st
+  st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-clear.XXXXXX")
+  mkdir -p "$st/state"
+  : > "$st/state/.subsuper-escalations"
+  : > "$st/state/.subsuper-escalations.since"
+  : > "$st/state/.subsuper-inject-wedged"
+  : > "$st/state/.wake-queue"          # durable queue must be untouched
+  # Source fm-afk-start.sh inside a child bash (it sets `set -eu` and would
+  # otherwise leak that into this test shell) and call the clear helper.
+  FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" \
+    bash -c '. "$1"; fm_afk_clear_stale_artifacts "$2"' _ "$START" "$st/state"
+  if [ ! -e "$st/state/.subsuper-escalations" ] \
+     && [ ! -e "$st/state/.subsuper-escalations.since" ] \
+     && [ ! -e "$st/state/.subsuper-inject-wedged" ]; then
+    pass "clear-stale: removes escalations buffer, sidecar, and wedge marker"
+  else
+    fail "clear-stale: stale artifacts survived"
+  fi
+  if [ -e "$st/state/.wake-queue" ]; then
+    pass "clear-stale: leaves the durable wake-queue intact (no pending work dropped)"
+  else
+    fail "clear-stale: removed the durable wake-queue"
+  fi
+  rm -rf "$st"
+}
+
+# ---------------------------------------------------------------------------
+# UNIT 2: a FRESH entry clears; a REFRESH (daemon already alive) preserves the
+# current session's buffered escalations.
+# ---------------------------------------------------------------------------
+unit_fresh_vs_refresh() {
+  local st sleep_pid lock
+  st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-refresh.XXXXXX")
+  mkdir -p "$st/state"
+  : > "$st/state/.subsuper-escalations"
+  : > "$st/state/.subsuper-inject-wedged"
+  # A live "daemon": a real process whose identity the lock records, so
+  # daemon_lock_held_by_live_daemon returns true (a refresh).
+  sleep 600 &
+  sleep_pid=$!
+  lock="$st/state/.supervise-daemon.lock"
+  mkdir -p "$lock"
+  printf '%s' "$sleep_pid" > "$lock/pid"
+  ( . "$ROOT/bin/fm-wake-lib.sh"; fm_pid_identity "$sleep_pid" > "$lock/pid-identity" 2>/dev/null ) || true
+  FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" "$START" >/dev/null 2>&1
+  if [ -e "$st/state/.subsuper-escalations" ] && [ -e "$st/state/.subsuper-inject-wedged" ]; then
+    pass "refresh: daemon already alive - stale artifacts preserved (current session's buffer kept)"
+  else
+    fail "refresh: incorrectly cleared the current session's buffered escalations"
+  fi
+  kill "$sleep_pid" 2>/dev/null || true
+  wait "$sleep_pid" 2>/dev/null || true
+  rm -rf "$st"
+}
+
+# ---------------------------------------------------------------------------
+# UNIT 3: exit ordering - fm_afk_launch_stop SIGTERMs the daemon WHILE .afk is
+# still present (so its flush is not a no-op), and clears .afk last.
+# ---------------------------------------------------------------------------
+unit_stop_ordering() {
+  local st lock marker daemon_pid
+  st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-stop.XXXXXX")
+  mkdir -p "$st/state"
+  date '+%s' > "$st/state/.afk"
+  marker="$st/afk-at-term"
+  # A fake daemon: on SIGTERM, record whether .afk was still present, then exit.
+  bash -c '
+    trap "if [ -f \"$1/state/.afk\" ]; then echo present > \"$2\"; else echo absent > \"$2\"; fi; exit 0" TERM
+    while :; do sleep 0.2; done
+  ' _ "$st" "$marker" &
+  daemon_pid=$!
+  lock="$st/state/.supervise-daemon.lock"
+  mkdir -p "$lock"
+  printf '%s' "$daemon_pid" > "$lock/pid"
+  # A recorded terminal (harmless: a non-existent tmux session name -> no-op close).
+  printf 'tmux\tfm-afk-nonexistent-%s\t\n' "$$" > "$st/state/.afk-daemon-terminal"
+  FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" "$LAUNCH" stop >/dev/null 2>&1
+  if [ "$(cat "$marker" 2>/dev/null || echo missing)" = present ]; then
+    pass "stop-ordering: daemon SIGTERM'd while .afk still present (flush is not a no-op)"
+  else
+    fail "stop-ordering: .afk was already cleared when the daemon got SIGTERM"
+  fi
+  if [ ! -e "$st/state/.afk" ]; then
+    pass "stop-ordering: .afk cleared last"
+  else
+    fail "stop-ordering: .afk not cleared"
+  fi
+  if [ ! -e "$st/state/.afk-daemon-terminal" ]; then
+    pass "stop-ordering: daemon-terminal record removed"
+  else
+    fail "stop-ordering: record not removed"
+  fi
+  kill "$daemon_pid" 2>/dev/null || true
+  wait "$daemon_pid" 2>/dev/null || true
+  rm -rf "$st"
+}
+
+# ---------------------------------------------------------------------------
+# E2E herdr: topology invariant.
+# ---------------------------------------------------------------------------
+e2e_herdr() {
+  command -v herdr >/dev/null 2>&1 || { echo "skip: herdr not found (herdr e2e)"; return 0; }
+  command -v jq >/dev/null 2>&1 || { echo "skip: jq not found (herdr e2e)"; return 0; }
+  # shellcheck source=tests/herdr-test-safety.sh
+  . "$ROOT/tests/herdr-test-safety.sh"
+  # shellcheck source=bin/fm-backend.sh
+  . "$ROOT/bin/fm-backend.sh"
+
+  local SESSION home_tmp cap_ws cap_tab cap_pane target
+  local before during after ws_before ws_during ws_after out dtgt dtab
+  SESSION="fm-lab-afk-launch-e2e-$$"
+  export HERDR_SESSION="$SESSION"
+  home_tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-e2e-home.XXXXXX")
+  E2E_HERDR_CLEANUP() {
+    FM_HOME="$home_tmp" FM_STATE_OVERRIDE="$home_tmp/state" \
+      FM_SUPERVISOR_TARGET="$target" FM_SUPERVISOR_BACKEND=herdr "$LAUNCH" stop >/dev/null 2>&1 || true
+    herdr_safe_stop_and_delete "$SESSION" >/dev/null 2>&1 || true
+    rm -rf "$home_tmp" 2>/dev/null || true
+  }
+  fm_herdr_lab_prepare "$SESSION" || { fail "herdr e2e: could not prepare isolated lab session"; return 0; }
+  fm_backend_source herdr || { E2E_HERDR_CLEANUP; fail "herdr e2e: fm_backend_source herdr failed"; return 0; }
+  fm_backend_herdr_server_ensure "$SESSION" || { E2E_HERDR_CLEANUP; fail "herdr e2e: lab server did not start"; return 0; }
+
+  out=$(fm_backend_herdr_cli "$SESSION" workspace create --cwd "$ROOT" --label captain --no-focus 2>/dev/null)
+  cap_ws=$(printf '%s' "$out" | jq -r '.result.workspace.workspace_id // empty')
+  cap_tab=$(printf '%s' "$out" | jq -r '.result.tab.tab_id // empty')
+  cap_pane=$(printf '%s' "$out" | jq -r '.result.root_pane.pane_id // empty')
+  if [ -z "$cap_ws" ] || [ -z "$cap_pane" ]; then E2E_HERDR_CLEANUP; fail "herdr e2e: could not create captain workspace"; return 0; fi
+  target="$SESSION:$cap_pane"
+  before=$(fm_backend_herdr_cli "$SESSION" pane list --workspace "$cap_ws" 2>/dev/null | jq --arg t "$cap_tab" '[.result.panes[]?|select(.tab_id==$t)]|length')
+  ws_before=$(fm_backend_herdr_cli "$SESSION" workspace list 2>/dev/null | jq '[.result.workspaces[]?]|length')
+
+  FM_HOME="$home_tmp" FM_STATE_OVERRIDE="$home_tmp/state" \
+    FM_SUPERVISOR_TARGET="$target" FM_SUPERVISOR_BACKEND=herdr FM_AFK_LAUNCH_ENTRY="$SLEEPER" \
+    "$LAUNCH" start >/dev/null 2>&1
+
+  during=$(fm_backend_herdr_cli "$SESSION" pane list --workspace "$cap_ws" 2>/dev/null | jq --arg t "$cap_tab" '[.result.panes[]?|select(.tab_id==$t)]|length')
+  ws_during=$(fm_backend_herdr_cli "$SESSION" workspace list 2>/dev/null | jq '[.result.workspaces[]?]|length')
+  dtgt=$(cut -f2 "$home_tmp/state/.afk-daemon-terminal" 2>/dev/null || true)
+  dtab=$(fm_backend_herdr_cli "$SESSION" pane get "${dtgt#*:}" 2>/dev/null | jq -r '.result.pane.tab_id // empty')
+
+  if [ "$before" = "$during" ]; then pass "herdr e2e: captain tab pane count unchanged after start (no split)"; else fail "herdr e2e: captain tab pane count changed ($before -> $during)"; fi
+  if [ "$ws_during" -gt "$ws_before" ]; then pass "herdr e2e: daemon launched in a separate non-visible workspace"; else fail "herdr e2e: no separate daemon workspace created"; fi
+  if [ -n "$dtab" ] && [ "$dtab" != "$cap_tab" ]; then pass "herdr e2e: daemon pane is NOT in the captain's tab"; else fail "herdr e2e: daemon pane shares the captain tab ($dtab)"; fi
+  case "$dtgt" in "$SESSION":*) pass "herdr e2e: daemon terminal scoped to the lab session" ;; *) fail "herdr e2e: daemon terminal not in the lab session ($dtgt)" ;; esac
+
+  FM_HOME="$home_tmp" FM_STATE_OVERRIDE="$home_tmp/state" \
+    FM_SUPERVISOR_TARGET="$target" FM_SUPERVISOR_BACKEND=herdr "$LAUNCH" stop >/dev/null 2>&1
+
+  after=$(fm_backend_herdr_cli "$SESSION" pane list --workspace "$cap_ws" 2>/dev/null | jq --arg t "$cap_tab" '[.result.panes[]?|select(.tab_id==$t)]|length')
+  ws_after=$(fm_backend_herdr_cli "$SESSION" workspace list 2>/dev/null | jq '[.result.workspaces[]?]|length')
+  if [ "$after" = "$before" ]; then pass "herdr e2e: captain tab pane count restored after stop"; else fail "herdr e2e: captain tab pane count not restored ($before -> $after)"; fi
+  if [ "$ws_after" = "$ws_before" ]; then pass "herdr e2e: daemon workspace removed by exact id on stop"; else fail "herdr e2e: daemon workspace leaked ($ws_before -> $ws_after)"; fi
+  if [ ! -e "$home_tmp/state/.afk-daemon-terminal" ] && [ ! -e "$home_tmp/state/.afk" ]; then pass "herdr e2e: record + .afk cleared on stop"; else fail "herdr e2e: record or .afk not cleared"; fi
+
+  E2E_HERDR_CLEANUP
+}
+
+# ---------------------------------------------------------------------------
+# E2E tmux: topology invariant (captain window untouched; daemon in a separate
+# detached session).
+# ---------------------------------------------------------------------------
+e2e_tmux() {
+  command -v tmux >/dev/null 2>&1 || { echo "skip: tmux not found (tmux e2e)"; return 0; }
+  local cap_session home_tmp cap_pane before during after rec
+  cap_session="fm-afk-launch-cap-$$"
+  home_tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-tmux-home.XXXXXX")
+  tmux new-session -d -s "$cap_session" 2>/dev/null || { fail "tmux e2e: could not create captain session"; rm -rf "$home_tmp"; return 0; }
+  TRACK_TMUX_SESSIONS="$TRACK_TMUX_SESSIONS $cap_session"
+  cap_pane=$(tmux display-message -p -t "$cap_session" '#{pane_id}')
+  before=$(tmux list-panes -t "$cap_session" | wc -l | tr -d ' ')
+
+  FM_HOME="$home_tmp" FM_STATE_OVERRIDE="$home_tmp/state" \
+    FM_SUPERVISOR_TARGET="$cap_pane" FM_SUPERVISOR_BACKEND=tmux FM_AFK_LAUNCH_ENTRY="$SLEEPER" \
+    "$LAUNCH" start >/dev/null 2>&1
+
+  during=$(tmux list-panes -t "$cap_session" | wc -l | tr -d ' ')
+  rec=$(cut -f2 "$home_tmp/state/.afk-daemon-terminal" 2>/dev/null || true)
+  TRACK_TMUX_SESSIONS="$TRACK_TMUX_SESSIONS $rec"
+  if [ "$before" = "$during" ]; then pass "tmux e2e: captain window pane count unchanged after start (no split-window)"; else fail "tmux e2e: captain window pane count changed ($before -> $during)"; fi
+  if [ -n "$rec" ] && tmux has-session -t "$rec" 2>/dev/null && [ "$rec" != "$cap_session" ]; then pass "tmux e2e: daemon launched in a separate detached session"; else fail "tmux e2e: no separate daemon session ($rec)"; fi
+
+  FM_HOME="$home_tmp" FM_STATE_OVERRIDE="$home_tmp/state" \
+    FM_SUPERVISOR_TARGET="$cap_pane" FM_SUPERVISOR_BACKEND=tmux "$LAUNCH" stop >/dev/null 2>&1
+
+  after=$(tmux list-panes -t "$cap_session" | wc -l | tr -d ' ')
+  if [ "$after" = "$before" ]; then pass "tmux e2e: captain window pane count unchanged after stop"; else fail "tmux e2e: captain window changed ($before -> $after)"; fi
+  if [ -n "$rec" ] && ! tmux has-session -t "$rec" 2>/dev/null; then pass "tmux e2e: daemon session killed by exact id on stop"; else fail "tmux e2e: daemon session leaked ($rec)"; fi
+  if [ ! -e "$home_tmp/state/.afk-daemon-terminal" ] && [ ! -e "$home_tmp/state/.afk" ]; then pass "tmux e2e: record + .afk cleared on stop"; else fail "tmux e2e: record or .afk not cleared"; fi
+
+  tmux kill-session -t "$cap_session" 2>/dev/null || true
+  rm -rf "$home_tmp" 2>/dev/null || true
+}
+
+unit_clear_stale
+unit_fresh_vs_refresh
+unit_stop_ordering
+e2e_herdr
+e2e_tmux
+
+[ "$FAILED" -eq 0 ] || exit 1

--- a/tests/fm-afk-launch.test.sh
+++ b/tests/fm-afk-launch.test.sh
@@ -374,6 +374,7 @@ unit_readiness_failure_rolls_back_terminal() {
     . "$1"
     fm_afk_launch_wait_ready() { return 1; }
     fm_afk_launch_close_terminal() { printf "%s:%s" "$1" "$2" > "$CLOSED"; }
+    fm_afk_launch_terminal_absent() { [ -e "$CLOSED" ]; }
     ! fm_afk_launch_commit_terminal tmux exact-session ""
   ' _ "$LAUNCH"
   if [ "$(cat "$closed" 2>/dev/null || true)" = "tmux:exact-session" ] \

--- a/tests/fm-afk-launch.test.sh
+++ b/tests/fm-afk-launch.test.sh
@@ -293,6 +293,32 @@ unit_herdr_partial_create_recovery() {
   rm -rf "$st"
 }
 
+unit_herdr_error_with_exact_ids_closes_exact() {
+  local st closed
+  st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-herdr-error-exact.XXXXXX")
+  closed="$st/closed"
+  FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" CLOSED="$closed" bash -c '
+    . "$1"
+    fm_backend_source() { return 0; }
+    fm_backend_herdr_server_ensure() { return 0; }
+    fm_backend_herdr_cli() {
+      if [ "$2 $3" = "workspace create" ]; then
+        printf %s '\''{"result":{"workspace":{"workspace_id":"ws-exact"},"root_pane":{"pane_id":"pane-exact"}}}'\''
+        return 1
+      fi
+      return 1
+    }
+    fm_backend_herdr_kill() { printf "%s" "$1" > "$CLOSED"; }
+    ! fm_afk_launch_create_herdr lab:captain herdr
+  ' _ "$LAUNCH"
+  if [ "$(cat "$closed" 2>/dev/null || true)" = "lab:pane-exact" ]; then
+    pass "herdr create error: returned exact id is retained for cleanup"
+  else
+    fail "herdr create error: exact cleanup id was discarded"
+  fi
+  rm -rf "$st"
+}
+
 unit_record_failure_closes_terminal() {
   local st closed
   st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-record-fail.XXXXXX")
@@ -326,6 +352,83 @@ unit_readiness_failure_rolls_back_terminal() {
     pass "readiness failure: exact terminal and durable record roll back"
   else
     fail "readiness failure: terminal or record survived"
+  fi
+  rm -rf "$st"
+}
+
+unit_native_lifecycle() {
+  local st
+  st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-native.XXXXXX")
+  mkdir -p "$st/state"
+  : > "$st/state/.subsuper-escalations"
+  if FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" "$LAUNCH" start-native >/dev/null 2>&1 \
+    && [ "$(cut -f1 "$st/state/.afk-daemon-terminal")" = none ] \
+    && [ -e "$st/state/.afk" ] \
+    && [ ! -e "$st/state/.subsuper-escalations" ]; then
+    pass "native lifecycle: launcher owns state with no terminal"
+  else
+    fail "native lifecycle: state preparation or no-terminal record failed"
+  fi
+  FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" "$LAUNCH" stop >/dev/null 2>&1
+  if [ ! -e "$st/state/.afk" ] && [ ! -e "$st/state/.afk-daemon-terminal" ]; then
+    pass "native lifecycle: uniform stop clears state without closing a terminal"
+  else
+    fail "native lifecycle: uniform stop retained state"
+  fi
+  rm -rf "$st"
+}
+
+unit_native_entry_preserves_prepared_state() {
+  local st
+  st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-native-entry.XXXXXX")
+  mkdir -p "$st/state"
+  : > "$st/state/.afk"
+  : > "$st/state/.subsuper-escalations"
+  FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" FM_AFK_STATE_PREPARED=1 bash -c '
+    . "$1"
+    FM_AFK_DAEMON=/bin/true
+    fm_afk_start_main
+  ' _ "$START" >/dev/null 2>&1
+  if [ -e "$st/state/.afk" ] && [ -e "$st/state/.subsuper-escalations" ]; then
+    pass "native entry: launcher-prepared lifecycle state is not rewritten"
+  else
+    fail "native entry: launcher-prepared lifecycle state was mutated"
+  fi
+  rm -rf "$st"
+}
+
+unit_close_failure_preserves_record() {
+  local st
+  st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-close-fail.XXXXXX")
+  mkdir -p "$st/state"
+  printf 'tmux\texact-session\t\n' > "$st/state/.afk-daemon-terminal"
+  FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" bash -c '
+    . "$1"
+    fm_afk_launch_close_terminal() { return 1; }
+    fm_afk_launch_terminal_absent() { return 1; }
+    ! fm_afk_launch_reconcile
+  ' _ "$LAUNCH"
+  if [ -e "$st/state/.afk-daemon-terminal" ]; then
+    pass "teardown failure: exact terminal record is preserved"
+  else
+    fail "teardown failure: exact terminal record was discarded"
+  fi
+  rm -rf "$st"
+}
+
+unit_flag_write_failure_aborts() {
+  local st
+  st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-flag-fail.XXXXXX")
+  mkdir -p "$st/state"
+  FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" bash -c '
+    . "$1"
+    fm_afk_launch_flag_write() { return 1; }
+    ! fm_afk_launch_start_native
+  ' _ "$LAUNCH"
+  if [ ! -e "$st/state/.afk" ] && [ ! -e "$st/state/.afk-daemon-terminal" ]; then
+    pass "flag failure: lifecycle aborts without active state"
+  else
+    fail "flag failure: lifecycle reported active state"
   fi
   rm -rf "$st"
 }
@@ -436,8 +539,13 @@ unit_concurrent_start_serialized
 unit_lock_initialization_grace
 unit_signal_exits_with_lock_cleanup
 unit_herdr_partial_create_recovery
+unit_herdr_error_with_exact_ids_closes_exact
 unit_record_failure_closes_terminal
 unit_readiness_failure_rolls_back_terminal
+unit_native_lifecycle
+unit_native_entry_preserves_prepared_state
+unit_close_failure_preserves_record
+unit_flag_write_failure_aborts
 e2e_herdr
 e2e_tmux
 

--- a/tests/fm-afk-launch.test.sh
+++ b/tests/fm-afk-launch.test.sh
@@ -518,6 +518,81 @@ unit_malformed_record_fails_closed() {
   rm -rf "$st"
 }
 
+unit_stop_malformed_record_fails_closed() {
+  local st
+  st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-stop-malformed.XXXXXX")
+  mkdir -p "$st/state"
+  : > "$st/state/.afk"
+  printf 'tmux\tonly-two-fields\n' > "$st/state/.afk-daemon-terminal"
+  if FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" bash -c '
+    . "$1"
+    ! fm_afk_launch_stop
+  ' _ "$LAUNCH" && [ -e "$st/state/.afk" ] && [ -e "$st/state/.afk-daemon-terminal" ]; then
+    pass "stop: malformed terminal record preserves away state and fails closed"
+  else
+    fail "stop: malformed terminal record cleared protected lifecycle state"
+  fi
+  rm -rf "$st"
+}
+
+unit_tmux_planned_record_and_collision() {
+  local st
+  st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-tmux-plan.XXXXXX")
+  mkdir -p "$st/state"
+  if FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" bash -c '
+    . "$1"
+    tmux() {
+      if [ "$1" = has-session ]; then printf "can\\x27t find session\\n" >&2; return 1; fi
+      if [ "$1" = new-session ]; then
+        [ -s "$FM_AFK_LAUNCH_RECORD" ] || return 9
+        return 1
+      fi
+      return 1
+    }
+    ! fm_afk_launch_create_tmux captain:0 tmux
+  ' _ "$LAUNCH"; then
+    pass "tmux launch: planned exact target is recorded before creation"
+  else
+    fail "tmux launch: creation began before exact target publication"
+  fi
+  rm -rf "$st"
+
+  st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-tmux-collision.XXXXXX")
+  mkdir -p "$st/state"
+  if FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" bash -c '
+    . "$1"
+    tmux() {
+      [ "$1" = has-session ] && return 0
+      [ "$1" != kill-session ] || : > "$FM_HOME/killed"
+      return 0
+    }
+    ! fm_afk_launch_create_tmux captain:0 tmux
+  ' _ "$LAUNCH" && [ ! -e "$st/killed" ]; then
+    pass "tmux launch: unowned same-name session fails closed without teardown"
+  else
+    fail "tmux launch: unowned same-name session was replaced"
+  fi
+  rm -rf "$st"
+}
+
+unit_clear_failure_aborts_entry() {
+  local st
+  st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-clear-fail.XXXXXX")
+  mkdir -p "$st/state"
+  : > "$st/state/.subsuper-escalations"
+  if FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" bash -c '
+    . "$1"
+    fm_afk_launch_reconcile() { return 0; }
+    fm_afk_clear_stale_artifacts() { return 1; }
+    ! fm_afk_launch_start_native
+  ' _ "$LAUNCH" && [ ! -e "$st/state/.afk" ] && [ -e "$st/state/.subsuper-escalations" ]; then
+    pass "clear failure: native entry aborts and restores prior state"
+  else
+    fail "clear failure: native entry proceeded or lost prior state"
+  fi
+  rm -rf "$st"
+}
+
 unit_confirmed_absence_succeeds() {
   local st
   st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-confirmed-absent.XXXXXX")
@@ -688,6 +763,9 @@ unit_native_entry_preserves_prepared_state
 unit_close_failure_preserves_record
 unit_record_publication_atomic
 unit_malformed_record_fails_closed
+unit_stop_malformed_record_fails_closed
+unit_tmux_planned_record_and_collision
+unit_clear_failure_aborts_entry
 unit_confirmed_absence_succeeds
 unit_incomplete_restore_retains_backup
 unit_flag_write_failure_aborts

--- a/tests/fm-afk-launch.test.sh
+++ b/tests/fm-afk-launch.test.sh
@@ -650,12 +650,19 @@ unit_stop_confirms_daemon_exit() {
     . "$1"
     seq() { printf "1\n"; }
     sleep() { :; }
+    kill() {
+      command kill "$@"
+      if [ "$1" = -TERM ]; then
+        rm -rf "$FM_AFK_LAUNCH_STATE/.supervise-daemon.lock"
+      fi
+    }
     ! fm_afk_launch_stop
   ' _ "$LAUNCH" && kill -0 "$daemon_pid" 2>/dev/null \
+    && [ ! -e "$st/state/.supervise-daemon.lock" ] \
     && [ -e "$st/state/.afk" ] && [ -e "$st/state/.afk-daemon-terminal" ]; then
-    pass "stop liveness: live daemon preserves lifecycle state and fails closed"
+    pass "stop liveness: captured live daemon preserves lifecycle state after lock release"
   else
-    fail "stop liveness: live daemon was reported stopped or lost lifecycle state"
+    fail "stop liveness: lock release was mistaken for captured daemon exit"
   fi
   kill -KILL "$daemon_pid" 2>/dev/null || true
   wait "$daemon_pid" 2>/dev/null || true

--- a/tests/fm-afk-launch.test.sh
+++ b/tests/fm-afk-launch.test.sh
@@ -209,6 +209,86 @@ unit_concurrent_start_serialized() {
   rm -rf "$st"
 }
 
+unit_lock_initialization_grace() {
+  local st marker initializer
+  st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-lock-init.XXXXXX")
+  marker="$st/initialized"
+  mkdir -p "$st/state/.afk-launch.lock"
+  (
+    sleep 0.15
+    if [ -d "$st/state/.afk-launch.lock" ]; then
+      printf '%s' "$$" > "$st/state/.afk-launch.lock/pid"
+      ( . "$ROOT/bin/fm-wake-lib.sh"; fm_pid_identity "$$" > "$st/state/.afk-launch.lock/pid-identity" 2>/dev/null ) || true
+      : > "$marker"
+      sleep 0.15
+      rm -rf "$st/state/.afk-launch.lock"
+    fi
+  ) &
+  initializer=$!
+  if FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" bash -c '
+    . "$1"
+    fm_afk_launch_lock_acquire
+    fm_afk_launch_lock_release
+  ' _ "$LAUNCH" && [ -e "$marker" ]; then
+    pass "launcher lock: incomplete publication receives initialization grace"
+  else
+    fail "launcher lock: contender removed a lock during initialization"
+  fi
+  wait "$initializer" 2>/dev/null || true
+  rm -rf "$st"
+}
+
+unit_signal_exits_with_lock_cleanup() {
+  local st marker child
+  st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-signal.XXXXXX")
+  marker="$st/resumed"
+  FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" bash -c '
+    . "$1"
+    fm_afk_launch_start() { sleep 30; }
+    fm_afk_launch_main start
+    : > "$2"
+  ' _ "$LAUNCH" "$marker" &
+  child=$!
+  for _ in $(seq 1 40); do
+    [ -d "$st/state/.afk-launch.lock" ] && break
+    sleep 0.05
+  done
+  kill -TERM "$child" 2>/dev/null || true
+  wait "$child" 2>/dev/null || true
+  if [ ! -e "$marker" ] && [ ! -e "$st/state/.afk-launch.lock" ]; then
+    pass "launcher signal: TERM exits and releases the lifecycle lock"
+  else
+    fail "launcher signal: interrupted lifecycle resumed or retained its lock"
+  fi
+  rm -rf "$st"
+}
+
+unit_herdr_partial_create_cleanup() {
+  local st killed
+  st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-herdr-partial.XXXXXX")
+  killed="$st/killed"
+  FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" KILLED="$killed" bash -c '
+    . "$1"
+    fm_backend_source() { return 0; }
+    fm_backend_herdr_server_ensure() { return 0; }
+    fm_backend_herdr_cli() {
+      if [ "$2 $3" = "workspace create" ]; then
+        printf %s '\''{"result":{"workspace":{"workspace_id":"ws-partial"},"root_pane":{}}}'\''
+      else
+        printf %s '\''{"result":{"panes":[{"pane_id":"pane-exact"}]}}'\''
+      fi
+    }
+    fm_backend_herdr_kill() { printf %s "$1" > "$KILLED"; }
+    ! fm_afk_launch_create_herdr lab:captain herdr
+  ' _ "$LAUNCH"
+  if [ "$(cat "$killed" 2>/dev/null || true)" = "lab:pane-exact" ]; then
+    pass "herdr create: partial response cleanup uses exact workspace pane"
+  else
+    fail "herdr create: partial response leaked its created workspace"
+  fi
+  rm -rf "$st"
+}
+
 # ---------------------------------------------------------------------------
 # E2E herdr: topology invariant.
 # ---------------------------------------------------------------------------
@@ -312,6 +392,9 @@ unit_stop_ordering
 unit_stop_rejects_reused_pid
 unit_failed_start_rolls_back_state
 unit_concurrent_start_serialized
+unit_lock_initialization_grace
+unit_signal_exits_with_lock_cleanup
+unit_herdr_partial_create_cleanup
 e2e_herdr
 e2e_tmux
 

--- a/tests/fm-afk-launch.test.sh
+++ b/tests/fm-afk-launch.test.sh
@@ -118,6 +118,7 @@ unit_stop_ordering() {
   lock="$st/state/.supervise-daemon.lock"
   mkdir -p "$lock"
   printf '%s' "$daemon_pid" > "$lock/pid"
+  ( . "$ROOT/bin/fm-wake-lib.sh"; fm_pid_identity "$daemon_pid" > "$lock/pid-identity" 2>/dev/null ) || true
   # A recorded terminal (harmless: a non-existent tmux session name -> no-op close).
   printf 'tmux\tfm-afk-nonexistent-%s\t\n' "$$" > "$st/state/.afk-daemon-terminal"
   FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" "$LAUNCH" stop >/dev/null 2>&1
@@ -138,6 +139,73 @@ unit_stop_ordering() {
   fi
   kill "$daemon_pid" 2>/dev/null || true
   wait "$daemon_pid" 2>/dev/null || true
+  rm -rf "$st"
+}
+
+unit_stop_rejects_reused_pid() {
+  local st lock sleeper_pid
+  st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-pid-reuse.XXXXXX")
+  mkdir -p "$st/state"
+  date '+%s' > "$st/state/.afk"
+  sleep 600 &
+  sleeper_pid=$!
+  lock="$st/state/.supervise-daemon.lock"
+  mkdir -p "$lock"
+  printf '%s' "$sleeper_pid" > "$lock/pid"
+  printf 'different-process-identity' > "$lock/pid-identity"
+  FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" "$LAUNCH" stop >/dev/null 2>&1
+  if kill -0 "$sleeper_pid" 2>/dev/null; then
+    pass "stop identity: stale lock cannot signal an unrelated live process"
+  else
+    fail "stop identity: stale lock signaled an unrelated live process"
+  fi
+  kill "$sleeper_pid" 2>/dev/null || true
+  wait "$sleeper_pid" 2>/dev/null || true
+  rm -rf "$st"
+}
+
+unit_failed_start_rolls_back_state() {
+  local st
+  st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-failed-start.XXXXXX")
+  mkdir -p "$st/state"
+  printf 'pending\n' > "$st/state/.subsuper-escalations"
+  printf 'wedged\n' > "$st/state/.subsuper-inject-wedged"
+  if FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" FM_SUPERVISOR_TARGET=unused \
+    FM_SUPERVISOR_BACKEND=unsupported "$LAUNCH" start >/dev/null 2>&1; then
+    fail "failed start: unsupported backend unexpectedly succeeded"
+  elif [ ! -e "$st/state/.afk" ] \
+    && [ "$(cat "$st/state/.subsuper-escalations")" = pending ] \
+    && [ "$(cat "$st/state/.subsuper-inject-wedged")" = wedged ]; then
+    pass "failed start: away flag and delivery artifacts roll back"
+  else
+    fail "failed start: left false away state or discarded delivery artifacts"
+  fi
+  rm -rf "$st"
+}
+
+unit_concurrent_start_serialized() {
+  command -v tmux >/dev/null 2>&1 || { echo "skip: tmux not found (concurrent start)"; return 0; }
+  local st cap_session cap_pane first second rec count
+  st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-concurrent.XXXXXX")
+  cap_session="fm-afk-concurrent-cap-$$"
+  tmux new-session -d -s "$cap_session" 2>/dev/null || { fail "concurrent start: captain session creation failed"; rm -rf "$st"; return 0; }
+  TRACK_TMUX_SESSIONS="$TRACK_TMUX_SESSIONS $cap_session"
+  cap_pane=$(tmux display-message -p -t "$cap_session" '#{pane_id}')
+  FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" FM_SUPERVISOR_TARGET="$cap_pane" \
+    FM_SUPERVISOR_BACKEND=tmux FM_AFK_LAUNCH_ENTRY="$SLEEPER" "$LAUNCH" start >/dev/null 2>&1 & first=$!
+  FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" FM_SUPERVISOR_TARGET="$cap_pane" \
+    FM_SUPERVISOR_BACKEND=tmux FM_AFK_LAUNCH_ENTRY="$SLEEPER" "$LAUNCH" start >/dev/null 2>&1 & second=$!
+  wait "$first"; wait "$second"
+  rec=$(cut -f2 "$st/state/.afk-daemon-terminal" 2>/dev/null || true)
+  count=$(tmux list-sessions -F '#{session_name}' 2>/dev/null | awk -v expected="$rec" '$0 == expected {n++} END{print n+0}')
+  TRACK_TMUX_SESSIONS="$TRACK_TMUX_SESSIONS $rec"
+  if [ -n "$rec" ] && tmux has-session -t "$rec" 2>/dev/null && [ "$count" -eq 1 ]; then
+    pass "concurrent start: one serialized daemon terminal remains tracked"
+  else
+    fail "concurrent start: leaked or lost daemon terminal (count $count, record $rec)"
+  fi
+  FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" "$LAUNCH" stop >/dev/null 2>&1
+  tmux kill-session -t "$cap_session" 2>/dev/null || true
   rm -rf "$st"
 }
 
@@ -241,6 +309,9 @@ e2e_tmux() {
 unit_clear_stale
 unit_fresh_vs_refresh
 unit_stop_ordering
+unit_stop_rejects_reused_pid
+unit_failed_start_rolls_back_state
+unit_concurrent_start_serialized
 e2e_herdr
 e2e_tmux
 


### PR DESCRIPTION
## Intent

Fix, in firstmate's own repo, the Herdr away-mode pane-layout regression plus a separate stale-artifact leak, per an approved scout diagnosis.

Regression root cause: the /afk entry path (bin/fm-afk-start.sh) execs the supervise daemon in the FOREGROUND and left 'make it a tracked background terminal' to the operator. On a Pi/herdr primary with no native background mechanism, the operator manufactured a terminal by SPLITTING the captain's active herdr pane, which visibly shrank it (an in-tab split co-tenants the tab viewport; --no-focus does not prevent it).

Fix 1 - add bin/fm-afk-launch.sh as the single owner of the daemon-TERMINAL lifecycle: capture the captain pane first, launch the daemon in a NON-VISIBLE tracked terminal per backend (herdr dedicated --no-focus workspace via workspace create + pane run; detached tmux session via new-session -d), never a split, NO shell &, pass FM_SUPERVISOR_TARGET/FM_SUPERVISOR_BACKEND explicitly (otherwise the daemon auto-discovers its OWN new pane), record the exact terminal id in state/.afk-daemon-terminal, and tear down / reconcile a leaked one by that exact id (never a broad sweep). Deliberate design choice: a dedicated background workspace (not a tab in the home workspace) for clean single-id teardown. One-owner rule: discover_supervisor_target/backend were extracted verbatim from bin/fm-supervise-daemon.sh into a new shared lib bin/fm-supervisor-target-lib.sh sourced by both; the daemon's self-lifecycle (singleton lock, crash-loop backoff, wedge alarm) is otherwise unchanged and its 95-test suite still passes. bin/fm-afk-start.sh was intentionally restructured to be sourceable (BASH_SOURCE guard) so tests can call its helpers.

Fix 2 (separate defect) - the daemon's escalation-delivery artifacts (state/.subsuper-escalations + .since, state/.subsuper-inject-wedged) leaked into the next away session: nothing cleared them on entry, and on exit the /afk skill cleared state/.afk BEFORE stopping the daemon, making its shutdown flush a no-op via the daemon's own presence gate. Fix: clear the prior session's artifacts on a FRESH entry only (fm_afk_clear_stale_artifacts, gated on daemon-not-already-running so a refresh preserves the current buffer), and reverse the exit ordering in fm-afk-launch.sh stop (SIGTERM the daemon while state/.afk is still present so its flush runs, clear state/.afk last). This deliberately never drops a genuinely-pending escalation: the durable record is state/.wake-queue plus each crew's state/<id>.status, which the daemon's heartbeat catch-all re-derives; the buffer is only a transient delivery cache.

Tests: tests/fm-afk-launch.test.sh - per-backend topology invariant (entering AND exiting afk leaves the captain's active tab pane set unchanged), herdr in an isolated fm-herdr-lab non-default --session with the fleet-state tripwire asserting the default session byte-identical, tmux in throwaway sessions killed by exact name, plus unit tests for clear-on-entry-vs-refresh and the stop ordering. A harmless sleeper (FM_AFK_LAUNCH_ENTRY test seam) replaces the real daemon in topology tests so they observe only the terminal lifecycle. Docs: /afk SKILL.md (script-owned launch, explicit never-split rule, stale-artifact section, corrected exit order), docs/herdr-backend.md (dated 2026-07-12 evidence), AGENTS.md away-mode exit stub, docs/scripts.md.

Hard constraint honored: the live Herdr server and default session were never touched; all Herdr testing ran on non-default lab sessions. firstmate's own .no-mistakes/ stays gitignored (CI rejects tracked .no-mistakes paths), so no evidence files are committed.

## What Changed

- Centralizes away-mode lifecycle management in a launcher that uses a dedicated non-visible Herdr workspace or detached tmux session, records the exact terminal identity, and preserves the captain pane layout.
- Clears stale escalation-delivery artifacts only on fresh entry, preserves active-session buffers during refresh, and flushes the daemon before clearing the AFK flag on exit.
- Shares supervisor-target discovery between the launcher and daemon, makes AFK startup helpers sourceable, and adds backend lifecycle regression coverage and documentation.

## Risk Assessment

⚠️ Medium: Captain, static review found no remaining material issue, though this is a substantial backend-sensitive shell lifecycle change whose runtime validation is deferred to the dedicated test step.

## Testing

The supplied full-suite baseline passed, focused AFK launcher and daemon lifecycle E2E tests passed, and reviewer-visible transcripts demonstrate unchanged captain pane topology for isolated Herdr and tmux, an untouched default Herdr session, exact-ID cleanup, and correct stale-artifact behavior. This is CLI lifecycle behavior, so transcripts are the appropriate visible evidence rather than screenshots.

<details>
<summary>Evidence: AFK launcher E2E transcript</summary>

```text
ok - clear-stale: removes escalations buffer, sidecar, and wedge marker
ok - clear-stale: leaves the durable wake-queue intact (no pending work dropped)
ok - refresh: daemon already alive - stale artifacts preserved (current session's buffer kept)
ok - stop-ordering: daemon SIGTERM'd while .afk still present (flush is not a no-op)
ok - stop-ordering: .afk cleared last
ok - stop-ordering: daemon-terminal record removed
ok - stop identity: stale lock cannot signal an unrelated live process
ok - failed start: away flag and delivery artifacts roll back
ok - concurrent start: one serialized daemon terminal remains tracked
ok - launcher lock: incomplete publication receives initialization grace
ok - launcher signal: TERM exits and releases the lifecycle lock
fm-afk-launch: daemon launched in non-visible herdr workspace ws-partial (pane lab:pane-exact), supervising lab:captain
ok - herdr create: malformed response recovers durable exact ownership
fm-afk-launch: herdr create failed after returning exact ids; closing lab:pane-exact
fm-afk-launch: recorded terminal teardown is unconfirmed; preserving exact id
ok - herdr create error: unconfirmed exact id is persisted for reconciliation
fm-afk-launch: failed to run daemon in herdr pane lab:pane-exact; closing it
fm-afk-launch: recorded terminal teardown is unconfirmed; preserving exact id
ok - herdr run failure: unconfirmed exact id remains reconcilable
fm-afk-launch: failed to persist daemon terminal record; closing tmux:exact-session
ok - record failure: newly created terminal is closed by exact id
fm-afk-launch: daemon did not become ready; closing tmux:exact-session
ok - readiness failure: exact terminal and durable record roll back
fm-afk-launch: daemon did not become ready; closing tmux:exact-session
fm-afk-launch: recorded terminal teardown is unconfirmed; preserving exact id
ok - readiness failure: unconfirmed terminal retains its reconciliation id
ok - tmux absence: clean missing differs from transport probe failure
ok - native lifecycle: launcher owns state with no terminal
ok - native lifecycle: uniform stop clears state without closing a terminal
ok - native entry: launcher-prepared lifecycle state is not rewritten
fm-afk-launch: reconciling leaked daemon terminal tmux:exact-session
fm-afk-launch: recorded terminal teardown is unconfirmed; preserving exact id
ok - teardown failure: exact terminal record is preserved
ok - record publication: failed atomic rename preserves the complete prior record
fm-afk-launch: daemon terminal record is malformed; refusing to act on it
ok - record read: malformed record fails closed without acting on a partial id
fm-afk-launch: daemon terminal record is malformed; refusing to act on it
fm-afk-launch: malformed daemon terminal record; refusing to stop away mode
ok - stop: malformed terminal record preserves away state and fails closed
fm-afk-launch: failed to create detached tmux daemon session 'fm-afk-daemon-3051734935-89418-18844-1783852306'
ok - tmux launch: planned exact target is recorded before creation and removed on failure
fm-afk-launch: failed to create detached tmux daemon session 'fm-afk-daemon-2339715877-89447-25045-1783852306'
ok - tmux launch: unique names eliminate collision teardown
ok - stop validation: malformed record causes no daemon or state side effects
ok - launcher lock: incomplete metadata fails acquisition and releases lock
fm-afk-launch: failed to clear away-mode flag
fm-afk-launch: away mode stopped; terminal teardown remains recorded for retry
ok - stop state: away-flag removal failure is surfaced
fm-afk-launch: away-mode daemon did not exit after SIGTERM; preserving lifecycle state
ok - stop liveness: captured live daemon preserves lifecycle state after lock release
fm-afk-launch: daemon terminal record is malformed; refusing to act on it
fm-afk-launch: daemon terminal record is malformed; refusing to act on it
ok - refresh record: malformed terminal identity fails closed
fm-afk-launch: failed to clear stale away-mode artifacts
ok - clear failure: native entry aborts and restores prior state
fm-afk-launch: reconciling leaked daemon terminal tmux:exact-session
fm-afk-launch: terminal close command failed, but exact absence was confirmed
ok - confirmed absence: cleanup succeeds and removes the stale record
fm-afk-launch: rollback restoration incomplete; backup retained at /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T//fm-afk-restore-fail.bH6tO4/state/.afk-launch-backup.3sBr0k
ok - rollback restore: incomplete restoration retains its recovery backup
ok - flag failure: lifecycle aborts without active state
ok - herdr e2e: captain tab pane count unchanged after start (no split)
ok - herdr e2e: daemon launched in a separate non-visible workspace
ok - herdr e2e: daemon pane is NOT in the captain's tab
ok - herdr e2e: daemon terminal scoped to the lab session
ok - herdr e2e: captain tab pane count restored after stop
ok - herdr e2e: daemon workspace removed by exact id on stop
ok - herdr e2e: record + .afk cleared on stop
ok - tmux e2e: captain window pane count unchanged after start (no split-window)
ok - tmux e2e: daemon launched in a separate detached session
ok - tmux e2e: captain window pane count unchanged after stop
ok - tmux e2e: daemon session killed by exact id on stop
ok - tmux e2e: record + .afk cleared on stop
```
</details>
<details>
<summary>Evidence: Daemon lifecycle E2E transcript</summary>

```text
ok - lifecycle: routine self-handles, terminal survives a watcher restart, buffers once, no dup, injects once
ok - lifecycle: stale pane transient self-handles, persistent escalates once and clears, resumed clears quietly
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 4 issues found → auto-fixed (10) ✅</summary>

- 🚨 `bin/fm-afk-launch.sh:218` - Captain, `stop` checks only that the lock PID is alive before sending SIGTERM. A stale lock with a reused PID can terminate an unrelated process. Verify process identity with `daemon_lock_held_by_live_daemon` before signaling; otherwise only reconcile the recorded terminal.
- 🚨 `bin/fm-afk-launch.sh:193` - Concurrent `start` calls can both create Herdr workspaces before either records its terminal. The single record then overwrites one exact pane ID, leaking the other workspace. Serialize start, stop, and reconciliation with a launcher-level lock and recheck state while holding it.
- ⚠️ `bin/fm-afk-launch.sh:189` - A fresh start creates `.afk` and clears prior delivery artifacts before terminal launch succeeds. Unsupported backends or creation failures therefore leave a false active-away state and discard transient context. Commit fresh-entry state only after successful launch, or roll back a newly created flag on failure.
- ⚠️ `.agents/skills/afk/SKILL.md:29` - The authoritative intent requires `fm-afk-launch.sh` to be the single terminal lifecycle owner using a dedicated Herdr workspace or detached tmux session. The skill instead directs Claude and Grok to run `fm-afk-start.sh` through harness-owned background jobs, which bypass exact-ID recording and the required topology. Confirm whether this is an intentional exception; otherwise route every entry through the launcher.

🔧 Fix: Captain, serialize AFK launcher lifecycle safely
5 issues (2 errors, 3 warnings) still open:
- 🚨 `bin/fm-afk-launch.sh:85` - Captain, the lock directory is published by `mkdir` before `pid` and `pid-identity` are written. A concurrent caller can treat this partially initialized live lock as stale, remove it, and enter the lifecycle concurrently. Publish complete metadata atomically or allow incomplete locks a bounded initialization grace.
- 🚨 `bin/fm-afk-launch.sh:289` - The `INT`/`TERM` trap releases the launcher lock but does not exit. Bash can resume the interrupted lifecycle without serialization while another caller acquires the lock. Use EXIT cleanup plus signal handlers that terminate after cleanup.
- ⚠️ `bin/fm-afk-launch.sh:180` - If Herdr `workspace create` succeeds but its response is malformed, the function returns before recording or closing the workspace. This leaves an untracked workspace that exact-ID reconciliation cannot remove. Clean up using any recovered exact ID or retain cleanup metadata before parsing can fail.
- ⚠️ `.agents/skills/afk/SKILL.md:29` - The required criterion says `bin/fm-afk-launch.sh` is the single owner of the daemon-terminal lifecycle, but this hunk directs Claude and Grok to run `bin/fm-afk-start.sh` through harness-owned background tools. That bypasses exact-ID recording and launcher-owned entry; the preceding manual `.afk` write also prevents failure rollback from clearing a fresh flag. Confirm this exception or route every entry through `fm-afk-launch.sh start`.
- ⚠️ `bin/fm-supervisor-target-lib.sh:22` - The required criterion says `discover_supervisor_target/backend were extracted verbatim`, but the library changes their former unconditional defaults to environment-preserving `:=` assignments. Pre-set values can now alter daemon fallback behavior where the previous implementation overwrote them. Confirm this behavior change or restore the original assignments.

🔧 Fix: Captain, harden AFK launcher lifecycle races
4 issues (1 error, 3 warnings) still open:
- 🚨 `bin/fm-afk-launch.sh:212` - Captain, terminal creation succeeds before `fm_afk_launch_record_write` is called, but its result is unchecked. With `set +e`, a permissions or disk failure can still return success with `.afk` active and an unrecorded terminal that exact-ID stop cannot remove. Check the write and close the newly created exact pane or session on failure.
- ⚠️ `bin/fm-afk-launch.sh:228` - Herdr `pane run` and `tmux new-session` confirm command acceptance, not that the daemon successfully acquired its live lock. Immediate daemon startup failure can therefore leave `.afk` active while the launcher reports success and no supervision exists. Wait boundedly for `daemon_lock_held_by_live_daemon`, rolling back if the terminal exits or readiness is not reached.
- ⚠️ `bin/fm-afk-launch.sh:190` - The parse-failure cleanup works only when malformed Herdr output still contains a pane or workspace ID. If creation succeeded but truncated output contains neither, the workspace remains unrecorded and cannot be reconciled by exact ID. Use a creation/response contract that reliably captures cleanup identity before treating creation as successful.
- ⚠️ `.agents/skills/afk/SKILL.md:29` - The authoritative criterion says `fm-afk-launch.sh` is “the single owner of the daemon-TERMINAL lifecycle,” but this hunk directs Claude and Grok to launch `fm-afk-start.sh` through harness-owned background tools and manually writes `.afk`. This bypasses exact-ID recording and launcher-owned rollback. Confirm this exception or route every entry through `fm-afk-launch.sh start`.

🔧 Fix: Captain, ensure AFK daemon launch readiness
4 issues (1 error, 3 warnings) still open:
- 🚨 `bin/fm-afk-launch.sh:367` - Captain, the required criterion says the launcher must “tear down / reconcile a leaked one by that exact id,” but the close helpers mask backend errors and `stop` then unconditionally deletes `.afk-daemon-terminal`. A transient teardown failure can leave the terminal alive while destroying its only reconciliation ID. Preserve the record until exact target absence is confirmed.
- ⚠️ `bin/fm-afk-launch.sh:315` - The script uses `set +e`, but both essential `.afk` writes are unchecked. Refresh can report success without updating the marker, while fresh entry can create and record a daemon with `.afk` absent, disabling presence-gated delivery. Check these writes and abort or restore prior state before reporting success.
- ⚠️ `bin/fm-afk-launch.sh:265` - A nonzero Herdr workspace-create result discards parsed exact workspace and pane IDs and forces label recovery. If listing is temporarily unavailable, the function leaks an untracked workspace despite already possessing cleanup identity. Retain and use parsed exact IDs for cleanup when present, regardless of command status.
- ⚠️ `.agents/skills/afk/SKILL.md:29` - The authoritative criterion says `fm-afk-launch.sh` is “the single owner of the daemon-TERMINAL lifecycle,” but this hunk still directs Claude and Grok to manually write `.afk` and launch `fm-afk-start.sh` through harness-owned background jobs. This bypasses exact-ID recording and launcher rollback. Confirm the exception or route every entry through the launcher.

🔧 Fix: Captain, unify AFK lifecycle ownership and teardown
6 issues (3 errors, 3 warnings) still open:
- 🚨 `bin/fm-afk-launch.sh:434` - Captain, `start-native` treats reconciliation failure as an error, but rollback unconditionally removes `.afk-daemon-terminal`. This contradicts the captain-directed requirement to preserve the exact ID after unconfirmed teardown. Retain or restore the pre-existing record when reconciliation fails.
- 🚨 `bin/fm-afk-launch.sh:244` - After readiness failure, the launcher attempts one close and then unconditionally deletes the persisted terminal record. A transient close failure can leave the terminal alive without its reconciliation ID. Preserve the record unless exact absence is verified.
- 🚨 `bin/fm-afk-launch.sh:186` - Any nonzero `tmux has-session` result is treated as confirmed absence, including socket, permission, or communication errors. This can delete the only exact ID without confirmed teardown, contrary to the captain-directed requirement. Distinguish missing-session status from probe failure.
- ⚠️ `bin/fm-afk-launch.sh:311` - The nonzero Herdr create path retains parsed IDs but sends them to a best-effort kill helper that masks failures, then returns without recording them. A transient close failure still leaves an unreconcilable workspace. Confirm absence or persist the exact ID for retry.
- ⚠️ `bin/fm-supervisor-target-lib.sh:22` - The authoritative criterion requires the discovery helpers to be extracted verbatim, but former unconditional default assignments became environment-preserving `:=` assignments. Pre-set defaults can now change fallback behavior. Confirm this change or restore the original assignments.
- ⚠️ `bin/fm-afk-launch.sh:375` - Artifact and prior `.afk` backup copies are unchecked before originals are cleared. If a copy fails, later rollback can silently lose prior state. Verify every required backup before clearing; apply the same fix to the native path.

🔧 Fix: Captain, preserve AFK reconciliation records uniformly
3 issues (1 error, 2 warnings) still open:
- 🚨 `bin/fm-afk-launch.sh:126` - Captain, `.afk-daemon-terminal` is the sole reconciliation identity, but it is truncated and rewritten in place. A crash, signal, or short write after terminal creation can leave an empty or partial record and an untracked terminal. Publish a complete temporary file with atomic rename, and fail closed when an existing record is malformed.
- ⚠️ `bin/fm-afk-launch.sh:203` - After exact absence is positively confirmed, `close_recorded` deletes the record but still returns the earlier close error. An already-absent stale target therefore makes the first reconciliation and start fail despite successful cleanup. Confirm whether the close error should be logged while confirmed absence makes reconciliation successful.
- ⚠️ `bin/fm-afk-launch.sh:426` - Backup creation is checked, but rollback restoration copies are not, and the backup directory is then deleted unconditionally. A permission or disk failure during restore can silently lose prior `.afk` or delivery artifacts. Validate restoration and retain the backup when restoration is incomplete, including in the native path.

🔧 Fix: Captain, harden AFK recovery state durability
3 issues (2 errors, 1 warning) still open:
- 🚨 `bin/fm-afk-launch.sh:402` - Captain, the authoritative criterion requires teardown and reconciliation by the exact recorded terminal ID, but tmux startup unconditionally kills the deterministic session name before establishing recorded ownership. This can terminate an unrelated same-named session and leaves a crash window because the replacement is recorded only after creation. Fail closed if an unrecorded target exists and persist the planned exact target before creation.
- 🚨 `bin/fm-afk-launch.sh:525` - Stop uses the record reader as a boolean, so malformed-record status 2 is treated like no record. It then clears `.afk` and reports success while retaining an unusable sole reconciliation record. Distinguish missing from malformed and fail closed on malformed records.
- ⚠️ `bin/fm-afk-start.sh:57` - Fresh-entry artifact clearing masks every removal failure with `|| true`, allowing the daemon to start with prior-session `.subsuper-*` delivery artifacts still present. Return failure and make terminal and native launch paths abort and roll back when clearing is incomplete.

🔧 Fix: Captain, harden AFK tmux ownership checks
4 issues (3 errors, 1 warning) still open:
- 🚨 `bin/fm-afk-launch.sh:418` - Captain, a TOCTOU remains after the absence probe. If another actor creates the deterministic tmux session before `new-session`, creation fails and cleanup kills that foreign session through the planned record. Do not close a present target after creation failure unless ownership is proven.
- 🚨 `bin/fm-afk-launch.sh:548` - Stop SIGTERMs the daemon before validating the terminal record. A malformed record therefore leaves `.afk` present but its daemon stopped, despite reporting that stop was refused. Validate the record before signaling and return immediately when malformed.
- 🚨 `bin/fm-afk-launch.sh:84` - Lock acquisition ignores the PID write result and masks PID-identity failure, then returns success with incomplete metadata. Another caller can later remove that live lock as stale and enter concurrently. Require complete, nonempty metadata before accepting the lock.
- ⚠️ `bin/fm-afk-launch.sh:557` - The final `.afk` removal masks errors, so stop can report success after tearing down supervision while the durable away flag remains and later recovery re-enters away mode. Surface removal failure.

🔧 Fix: Captain, simplify AFK lifecycle failure handling
2 issues (1 error, 1 warning) still open:
- 🚨 `bin/fm-afk-launch.sh:553` - Captain, after the bounded SIGTERM wait, stop never verifies that the daemon exited. In the native `none` path, terminal teardown always succeeds, so the record and `.afk` are removed and success is reported even if cleanup hung and the process remains alive. Recheck identity-backed liveness and preserve lifecycle state on failure.
- ⚠️ `bin/fm-afk-launch.sh:441` - The live-daemon refresh path returns success without validating an existing terminal record. A malformed sole reconciliation ID is silently accepted until stop later fails closed, leaving no clean teardown path. Validate any present record before refreshing.

🔧 Fix: Captain, require confirmed AFK daemon shutdown
1 error still open:
- 🚨 `bin/fm-afk-launch.sh:567` - Captain, the post-wait check only tests whether the daemon still owns its lock, not whether the captured identity-backed PID exited. Cleanup releases `.supervise-daemon.lock` before the process exits, so stop can delete the native record and `.afk` while that daemon is still alive. Capture PID identity before SIGTERM and confirm that exact process is gone or changed afterward.

🔧 Fix: Captain, confirm AFK exit by process identity
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- <code>Baseline supplied as passing: `command -v tmux &gt;/dev/null || { echo &#34;tmux is required for e2e tests&#34; &gt;&amp;2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo &#34;== $t ==&#34;; bash &#34;$t&#34; || rc=1; done; exit &#34;$rc&#34;`</code>
- `tests/fm-afk-launch.test.sh`
- `tests/fm-wake-daemon-lifecycle-e2e.test.sh`
- <code>Inspected `9ecd7c43ad7d866a54c3332e97e4b2744e589a2e..657575f1cc0d9cbdf90662391f54849b6316b358` and relevant launcher, daemon, skill, documentation, and test paths</code>
- <code>Verified Herdr in an isolated `fm-lab-*` session: captain pane count stayed unchanged before, during, and after AFK; the default-session snapshot remained byte-identical</code>
- `Verified tmux captain pane count stayed unchanged and the detached daemon session was removed by exact recorded identity`
- `Verified fresh-entry cleanup, refresh preservation, wake-queue preservation, stop ordering, failed-launch rollback, concurrent-start serialization, reused-PID rejection, malformed-record handling, and exact-ID cleanup`
- <code>Verified no tracked `.no-mistakes` paths and no transient AFK, subsupervisor, or sleeper artifacts remained in the test worktree</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
