### PR TITLE
feat(harness): add cursor (Cursor CLI) as a verified adapter

### DIFF
--- a/.agents/skills/afk/SKILL.md
+++ b/.agents/skills/afk/SKILL.md
@@ -82,7 +82,7 @@ separator, 0x1f), invisible and untypable. This is how firstmate tells a
 daemon escalation apart from a real message in the same pane. The marker
 travels with the message text; it does not rely on harness-level
 typed-vs-injected detection (which is not portable across claude, codex,
-opencode, pi, and grok).
+opencode, pi, grok, and cursor).
 
 ## Busy-guard and composer guard
 

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harness-adapters
-description: Agent-only reference for firstmate harness operations. Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter. Contains verified facts for claude, codex, opencode, pi, and grok.
+description: Agent-only reference for firstmate harness operations. Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter. Contains verified facts for claude, codex, opencode, pi, grok, and cursor.
 user-invocable: false
 metadata:
   internal: true
@@ -86,6 +86,7 @@ The supported launch-profile flags below were verified locally on 2026-06-30 wit
 | grok | `--model <model>` | `--reasoning-effort <low\|medium\|high\|xhigh>` | Verified on grok 0.2.73. `--effort` parses too, but firstmate's profile axis is reasoning effort. `--reasoning-effort max` is rejected, so `max` is omitted. |
 | pi | `--model <model>` | `--thinking <low\|medium\|high\|xhigh>` | Verified on pi 0.80.2. `max` prints an invalid-thinking warning, so firstmate omits Pi effort when the requested effort is `max`. |
 | opencode | `--model <provider/model>` | none for firstmate's interactive launch | Verified on opencode 1.17.6. `opencode run` has `--variant`, but firstmate launches the interactive `opencode --prompt` path, which has no verified effort flag. |
+| cursor | `--model <id>` | none - effort is baked into the model id | Verified on cursor-agent 2026.07.09. Cursor model ids carry their own reasoning tier, so pick effort by picking the id; a separate effort axis in a dispatch profile is invalid for cursor. Naming quirks and the id catalog: see the cursor section below. |
 
 When a requested effort value is outside the harness-specific accepted set, `fm-spawn` records the requested `effort=` in meta but emits no effort flag for that harness.
 This preserves launch success instead of passing a known-bad value.
@@ -100,6 +101,7 @@ Natural language is acceptable if uncertain.
 - opencode: no separate verified skill invocation beyond normal slash-command behavior; use natural language if the exact skill command is uncertain.
 - pi: no separate verified skill invocation beyond normal command behavior; use natural language if the exact skill command is uncertain.
 - grok: `/<skill>`, for example `/no-mistakes` (same form as claude). Verified end to end: grok discovers the user-level `no-mistakes` skill, `/no-mistakes` invokes it, and grok drives a real `no-mistakes axi run`. Like codex's `$`/`/` popups, typing `/<skill>` opens grok's slash-autocomplete, so a too-fast Enter selects the popup entry instead of sending, and for an argument-taking command (like `/no-mistakes`'s optional task-first argument) that first Enter only expands the popup selection into an argument-hint placeholder rather than submitting - a genuine second Enter is required (see the grok section below for the 2026-07-03 incident and fix). `fm_tmux_submit_core`'s retried Enter (used by `fm-send` on the tmux backend) already handles this correctly by reading the cursor row; the herdr backend needed a dedicated fix (`fm_backend_herdr_composer_state`, docs/herdr-backend.md) because its prior delta-based verification false-positived on that same popup-close content change.
+- cursor: `/<command>` opens a slash-autocomplete popup (verified with `/exit`; the popup also lists the captain's user-level claude-style commands, so discovery of `/no-mistakes` is plausible but NOT yet verified end to end). Same too-fast-Enter hazard as codex/grok; `fm-send`'s slash settle plus retried Enter lands it. Use natural language if the skill invocation is uncertain.
 
 ## claude (VERIFIED)
 
@@ -264,3 +266,37 @@ The adapter therefore runs the shared predicate and, when it returns 2, forces o
 It does not pass `--permission-mode`, so the passive hook cannot escalate the primary session's tool permissions.
 Project-local Grok hooks require folder trust, verified with launch-time `--trust`; if the primary firstmate checkout is not trusted for Grok hooks, this primary guard fails open and `fm-guard.sh` remains the next-command alarm.
 Grok's primary watcher protocol is Claude-shaped background-notify around `bin/fm-watch-arm.sh`; the passive Stop hook is only a backstop for blind turn ends.
+
+## cursor (VERIFIED 2026-07-11, cursor-agent 2026.07.09-a3815c0)
+
+Cursor CLI (`cursor-agent`, also invocable as `agent`), Anysphere's terminal agent.
+It reaches the captain's Cursor-subscription model catalog (Grok 4.5, Codex/GPT tiers, Sonnet, Gemini, and more via `cursor-agent --list-models`), which makes it the route to models the captain has no direct subscription for.
+Launch with a positional prompt: `cursor-agent --force --model <id> "$(cat <brief>)"`.
+
+Scope: cursor is verified as a CREWMATE/SECONDMATE adapter only.
+Running the PRIMARY firstmate session on cursor is NOT verified: it has no tracked turn-end guard, no PreToolUse seatbelt, and no watcher wake adapter, so a cursor primary falls back to the unknown-harness supervision snippet by design.
+
+| Fact | Value |
+|---|---|
+| Busy-pane signature | `ctrl+c to stop` at end of line (shown right of the composer line iff a turn is running; absent when idle). The spinner word varies (`Working`, `Running`), so the cancel hint is the stable ASCII signature; the busy regex end-anchors it because it is generic English a transcript could contain mid-line. |
+| Exit command | `/exit` or `/quit` (both listed; typing opens the slash-autocomplete popup, so a too-fast Enter is the usual hazard - `fm-send`'s retried Enter lands it). |
+| Interrupt | single `Ctrl+C` (cancels the running turn; the transcript shows `Cancelled`). |
+| Skill invocation | `/<command>` with popup; `/no-mistakes` discovery not yet verified end to end - prefer natural language when uncertain. |
+| Autonomy | `--force` (auto-approves command execution; file edits and shell commands verified to run fully unattended). `/run-everything` is the in-session equivalent. |
+| Env marker | `CURSOR_AGENT=1`, set for child/tool processes. The runtime reports `AI_AGENT=claude-code_*` (claude-code-derived) but does NOT set `CLAUDECODE`, so the marker is unambiguous. |
+| Resume | `cursor-agent --continue` resumes the most recent chat (verified 2026-07-12: a headless `--continue` recalled the prior chat's content after `/quit`); `--resume [chatId]` targets a specific chat. |
+
+Trust dialog: "Workspace Trust Required" appears on the first launch in a not-yet-trusted directory; accept with Enter (or `a`).
+The decision persists per directory, so later spawns in the same worktree slot skip it.
+After every spawn, peek the pane within about 20 seconds and accept it if showing, exactly like claude's flow.
+
+Model ids bake reasoning effort into the name (`grok-4.5-xhigh`, `gpt-5.3-codex-high`), so there is no effort flag; `fm-spawn` records a requested `effort=` in meta but never passes it.
+Display names are shifted one tier below the id (`grok-4.5-xhigh` displays "Cursor Grok 4.5", `grok-4.5-high` displays "Cursor Grok 4.5 Medium"); trust the id suffix.
+
+No verified turn-end hook: despite the claude-code-derived runtime, a Claude-style `.claude/settings.local.json` Stop hook did NOT fire (tested 2026-07-11), so `fm-spawn` writes no hook file and the watcher supervises cursor crewmates through busy-regex stale-pane detection only.
+
+Idle composer shows placeholder ghost text (`Plan, search, build anything` on a fresh session, `Add a follow-up` after a turn), rendered dim (SGR 2, verified 2026-07-12 via raw styled capture), so the generic ghost-stripper drops it and no `FM_COMPOSER_IDLE_RE` override is needed.
+`fm_tmux_composer_state` was verified live against an idle cursor pane (`empty`), a mid-turn pane (`empty`, busy footer correctly ignored), and `fm_pane_is_busy` fires mid-turn and stays quiet when idle.
+
+Composer quirk: an Enter arriving in the same keystroke burst as the message text can be swallowed, leaving the text unsubmitted in the composer (observed live with raw `tmux send-keys 'text' Enter`).
+`fm-send`'s settle-then-retried-Enter submit path handles this; do not raw-send text+Enter to a cursor pane in one burst.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,7 +172,7 @@ If the captain expresses a standing dispatch preference such as "use grok for ne
 Crewmates default to the same harness you are running on.
 The captain may override the static default at any time, typically at bootstrap: record the choice in `config/crew-harness` (a single adapter name; absent or `default` means mirror your own harness).
 Resolve `default` with `bin/fm-harness.sh`; resolve the active static crewmate harness with `bin/fm-harness.sh crew`.
-Verified adapter names are `claude`, `codex`, `opencode`, `pi`, and `grok`.
+Verified adapter names are `claude`, `codex`, `opencode`, `pi`, `grok`, and `cursor` (the Cursor CLI, binary `cursor-agent`).
 
 ### Crew dispatch profiles
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Full detail on every feature lives in [docs/architecture.md](docs/architecture.m
 
 ### Requirements
 
-- A verified agent harness: Claude Code, Grok, Pi, Codex, or OpenCode.
+- A verified agent harness: Claude Code, Grok, Pi, Codex, OpenCode, or Cursor.
 - Git and the GitHub CLI, authenticated through `gh auth login`.
 - tmux, for the reference session backend.
 

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -288,7 +288,7 @@ secondmate_liveness_sweep() {
     [ -n "$target" ] || target="$window"
     verdict=$(fm_backend_agent_alive "$backend" "$target" 2>/dev/null) || verdict="unknown"
     case "$harness" in
-      claude|codex|opencode|pi|grok) ;;
+      claude|codex|opencode|pi|grok|cursor) ;;
       *) [ "$verdict" = dead ] && verdict=unknown ;;
     esac
     case "$verdict" in
@@ -500,13 +500,13 @@ crew_dispatch_validate() {
     return 0
   fi
   err=$(jq -r '
-    def verified($h): ["claude","codex","opencode","pi","grok"] | index($h);
+    def verified($h): ["claude","codex","opencode","pi","grok","cursor"] | index($h);
     def effort_ok($h; $e):
       if $e == null then true
       elif ($e | type) != "string" then false
       elif $h == "claude" then (["low","medium","high","xhigh","max"] | index($e))
       elif ($h == "codex" or $h == "grok" or $h == "pi") then (["low","medium","high","xhigh"] | index($e))
-      elif $h == "opencode" then false
+      elif ($h == "opencode" or $h == "cursor") then false
       else true
       end;
     def use_profiles($u):

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Detect the agent harness this process tree runs on.
-# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|grok|unknown
+# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|grok|cursor|unknown
 #        fm-harness.sh crew             print the effective CREWMATE harness
 #                                        (config/crew-harness; "default" resolves to own)
 #        fm-harness.sh secondmate       print the harness the PRIMARY uses to launch
@@ -35,11 +35,21 @@ detect_own() {
   # It does NOT set CLAUDECODE despite being Claude-Code-compatible, so this marker
   # is unambiguous when firstmate runs natively on grok.
   [ "${GROK_AGENT:-}" = "1" ] && { echo grok; return; }
+  # cursor (Cursor CLI, binary cursor-agent) sets CURSOR_AGENT=1 for its child/tool
+  # processes (verified, cursor-agent 2026.07.09). Its runtime reports
+  # AI_AGENT=claude-code_* but does NOT set CLAUDECODE, so this marker is unambiguous.
+  [ "${CURSOR_AGENT:-}" = "1" ] && { echo cursor; return; }
   # Layer 2: walk the parent chain and match the command name.
   local pid=$$ comm args
   for _ in 1 2 3 4 5 6 7 8; do
     comm=$(ps -o comm= -p "$pid" 2>/dev/null) || break
     case "$(basename "$comm")" in
+      # cursor-agent BEFORE claude: cursor's runtime is claude-code-derived, so a
+      # cursor process path could plausibly contain "claude", but never vice versa.
+      # The token is the full binary name, NOT *cursor*: the Cursor IDE's own
+      # processes (binary "cursor" on Linux, "Cursor" helpers on macOS) would match
+      # a bare *cursor* glob when firstmate runs in the IDE's integrated terminal.
+      *cursor-agent*) echo cursor; return ;;
       *claude*) echo claude; return ;;
       *codex*) echo codex; return ;;
       *opencode*) echo opencode; return ;;
@@ -49,6 +59,7 @@ detect_own() {
         # Bare interpreter: match the harness name in its script path.
         args=$(ps -o args= -p "$pid" 2>/dev/null)
         case "$args" in
+          *cursor-agent*) echo cursor; return ;;
           *claude*) echo claude; return ;;
           *codex*) echo codex; return ;;
           *opencode*) echo opencode; return ;;

--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -15,7 +15,7 @@ LOCK="$STATE/.lock"
 mkdir -p "$STATE"
 
 # Known harness command names; extend when a new adapter is verified.
-HARNESS_RE='claude|codex|opencode|grok|^pi$'
+HARNESS_RE='claude|codex|cursor-agent|opencode|grok|^pi$'
 
 harness_pid() {
   local pid=$$ comm args

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -33,7 +33,7 @@
 #   profile consultation. A --secondmate spawn is exempt and resolves the SECONDMATE
 #   harness (config/secondmate-harness -> config/crew-harness -> own), so the
 #   secondmate-vs-crewmate split is DURABLE across every respawn (recovery,
-#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|grok)
+#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|grok|cursor)
 #   overrides it for this spawn (either kind). A non-flag string containing
 #   whitespace is treated as a RAW launch command - the escape hatch for verifying
 #   new adapters.
@@ -284,7 +284,7 @@ FIRSTMATE_HOME=
 
 if [ "$KIND" = secondmate ]; then
   case "${POS[1]:-}" in
-    ''|claude|codex|opencode|pi|grok)
+    ''|claude|codex|opencode|pi|grok|cursor)
       ARG3=${POS[1]:-}
       ;;
     *' '*)
@@ -345,6 +345,14 @@ launch_template() {
     # launch command - it is a Stop-event hook installed below (global hook +
     # per-task pointer), so the template is identical for ship/scout/secondmate.
     grok) printf '%s' 'grok --always-approve __MODELFLAG____EFFORTFLAG__"$(cat __BRIEF__)"' ;;
+    # cursor (Cursor CLI, binary cursor-agent): a positional prompt starts the
+    # supervised interactive session. --force auto-approves command execution
+    # (verified 2026-07-11: file edits and shell commands ran fully unattended),
+    # the targeted equivalent of claude's --dangerously-skip-permissions.
+    # __EFFORTFLAG__ is deliberately absent (see effort_flag_for_harness), and
+    # cursor has no turn-end hook (see the hook block below), so the template is
+    # identical for ship/scout/secondmate.
+    cursor) printf '%s' 'cursor-agent --force __MODELFLAG__"$(cat __BRIEF__)"' ;;
     *) return 1 ;;
   esac
 }
@@ -432,7 +440,7 @@ model_flag_for_harness() {
   local harness=$1 model=$2
   [ -n "$model" ] && [ "$model" != default ] || return 0
   case "$harness" in
-    claude|codex|opencode|pi|grok)
+    claude|codex|opencode|pi|grok|cursor)
       printf -- '--model %s ' "$(shell_quote "$model")"
       ;;
   esac
@@ -473,6 +481,9 @@ effort_flag_for_harness() {
     # opencode's interactive `opencode --prompt` launch has a verified --model
     # flag but no verified effort flag. Its `opencode run --variant` flag belongs
     # to a different, non-interactive launch mode, so fm-spawn does not pass it.
+    # cursor has no effort flag either: Cursor model ids bake reasoning effort
+    # into the name (grok-4.5-xhigh, gpt-5.3-codex-high), so effort is chosen by
+    # picking the right model id and a separate effort axis is never passed.
   esac
 }
 
@@ -918,6 +929,12 @@ EOF
       ;;
     codex*)
       # codex: turn-end rides the launch command via -c notify=[...] and __TURNEND__.
+      ;;
+    cursor*)
+      # cursor: no verified turn-end hook. Its runtime is claude-code-derived but a
+      # .claude/settings.local.json Stop hook did NOT fire (tested 2026-07-11,
+      # cursor-agent 2026.07.09), so no hook file is written and the watcher falls
+      # back to busy-regex stale-pane detection for cursor crewmates.
       ;;
     grok*)
       # grok fires a Stop hook at every turn boundary (verified, grok 0.2.73), the

--- a/bin/fm-tmux-lib.sh
+++ b/bin/fm-tmux-lib.sh
@@ -48,8 +48,14 @@
 
 # Busy footers per harness (mirror fm-watch.sh). claude/codex: "esc to
 # interrupt"; opencode: "esc interrupt"; pi: "Working..."; grok: "Ctrl+c:cancel"
-# (grok's mid-turn cancel hint, shown iff a turn is running - verified grok 0.2.73).
-FM_TMUX_BUSY_REGEX_DEFAULT='esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel'
+# (grok's mid-turn cancel hint, shown iff a turn is running - verified grok 0.2.73);
+# cursor: "ctrl+c to stop" (right of the composer line iff a turn is running; the
+# spinner word varies Working/Running so it is not the signature - verified
+# cursor-agent 2026.07.09). End-anchored because unlike the other tokens it is
+# generic English an agent transcript could contain mid-line, and cursor renders
+# it at the end of the composer line. Matching is case-insensitive everywhere
+# this is used.
+FM_TMUX_BUSY_REGEX_DEFAULT='esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel|ctrl\+c to stop[[:space:]]*$'
 
 # fm_tmux_strip_ghost: thin adapter over the shared, fleet-wide ghost extractor
 # fm_composer_strip_ghost (bin/fm-composer-lib.sh). It drops de-emphasised

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -106,8 +106,12 @@ SIGNAL_GRACE=${FM_SIGNAL_GRACE:-30}   # seconds to linger after a signal so trai
 # claude/codex: "esc to interrupt"; opencode: "esc interrupt"; pi: "Working...";
 # grok: "Ctrl+c:cancel" (the mid-turn cancel hint in grok's keybind bar, shown iff a
 # turn is running; absent when idle - verified grok 0.2.73, ASCII to avoid the
-# locale fragility of matching grok's braille spinner glyph directly).
-BUSY_REGEX=${FM_BUSY_REGEX:-'esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel'}
+# locale fragility of matching grok's braille spinner glyph directly);
+# cursor: "ctrl+c to stop" (shown right of the composer line iff a turn is running;
+# absent when idle - verified cursor-agent 2026.07.09; the spinner word varies
+# Working/Running so the cancel hint is the stable signature; end-anchored because
+# it is generic English a transcript could contain mid-line).
+BUSY_REGEX=${FM_BUSY_REGEX:-'esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel|ctrl\+c to stop[[:space:]]*$'}
 # Always-on wake triage: most wakes during a long crew validation are benign (a
 # working: note or turn-end while a pipeline runs, a no-change heartbeat). Rather
 # than wake firstmate's LLM for each, this watcher classifies every wake in bash

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -115,7 +115,7 @@ The session-start bootstrap step surfaces either the active rule block or a conc
 When the file exists, `fm-spawn.sh` refuses crewmate and scout launches without an explicit harness, so `config/crew-harness` is only automatic when no dispatch profile file is active.
 Secondmate launches are exempt because they resolve the secondmate harness and any optional secondmate model or effort tokens instead.
 Unsupported effort values are still recorded in task meta when passed to `fm-spawn.sh`, but the launch template omits any effort flag that the selected harness does not accept.
-That keeps spawn launch compatible across claude, codex, grok, pi, and opencode while preserving the requested profile for later audit.
+That keeps spawn launch compatible across claude, codex, grok, pi, opencode, and cursor while preserving the requested profile for later audit.
 
 ## Optional secondmates
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -140,7 +140,7 @@ The full cmux home label also includes a short hash of the resolved `FM_ROOT` pa
 
 ## Harness support
 
-claude, codex, opencode, pi, and grok are all empirically verified; new harnesses get verified through a supervised trial task before joining the set.
+claude, codex, opencode, pi, grok, and cursor (the Cursor CLI, binary `cursor-agent`) are all empirically verified; new harnesses get verified through a supervised trial task before joining the set.
 The verified adapter knowledge - busy signatures, interrupt and exit commands, skill-invocation syntax, and per-harness quirks - lives in [`.agents/skills/harness-adapters/SKILL.md`](../.agents/skills/harness-adapters/SKILL.md).
 Launch mechanics, including the verified command templates, live in [`bin/fm-spawn.sh`](../bin/fm-spawn.sh).
 Primary-session turn-end guard integrations for verified harnesses are tracked as repo-level hook files and documented in [`docs/turnend-guard.md`](turnend-guard.md).

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -679,6 +679,7 @@ empty array use is flagged^{"rules":[{"when":"big feature","use":[]}]}^exact^CRE
 array profile without harness is flagged^{"rules":[{"when":"big feature","use":[{"model":"gpt-5.5"}]}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - each use profile needs harness
 unknown select is flagged^{"rules":[{"when":"big feature","use":[{"harness":"claude"},{"harness":"codex"}],"select":"mystery"}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - unknown select: mystery
 array profile unsupported effort is flagged^{"rules":[{"when":"big feature","use":[{"harness":"codex","effort":"max"}]}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: codex:max
+unsupported cursor effort is flagged^{"rules":[{"when":"cursor work","use":{"harness":"cursor","model":"grok-4.5-xhigh","effort":"high"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: cursor:high
 ROWS
   pass "bootstrap validates crew-dispatch.json and reports malformed or unverified configs"
 }

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -311,6 +311,25 @@ test_opencode_threads_model_and_ignores_effort_axis() {
   pass "opencode receives --model and omits the unsupported effort axis"
 }
 
+test_cursor_threads_model_and_ignores_effort_axis() {
+  local rec id out status launch
+  id=profile-cursor-q4
+  rec=$(make_spawn_case profile-cursor cursor "$id")
+  read_case_record "$rec"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --model grok-4.5-xhigh --effort high)
+  status=$?
+  expect_code 0 "$status" "cursor spawn with model and ignored effort should succeed"
+  assert_meta_profile "$HOME_DIR/state/$id.meta" cursor grok-4.5-xhigh high
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "cursor-agent --force --model 'grok-4.5-xhigh'" \
+    "cursor launch did not thread model"
+  assert_not_contains "$launch" "--effort" "cursor launch must not pass an effort flag (effort is baked into the model id)"
+  assert_not_contains "$launch" "--reasoning-effort" "cursor launch must not pass grok reasoning effort"
+  assert_not_contains "$launch" "--thinking" "cursor launch must not pass pi thinking flag"
+  pass "cursor receives --model and omits the unsupported effort axis"
+}
+
 test_pi_omits_invalid_max_effort() {
   local rec id out status launch
   id=profile-pi-z8
@@ -376,6 +395,7 @@ test_codex_omits_invalid_max_effort
 test_grok_threads_model_and_reasoning_effort
 test_grok_omits_invalid_max_reasoning_effort
 test_opencode_threads_model_and_ignores_effort_axis
+test_cursor_threads_model_and_ignores_effort_axis
 test_pi_omits_invalid_max_effort
 test_batch_forwards_shared_profile_flags
 test_active_dispatch_profile_does_not_block_secondmate_launch


### PR DESCRIPTION
## What

Adds `cursor` (the Cursor CLI, binary `cursor-agent`) as a sixth verified harness adapter. This opens the Cursor subscription model catalog (Grok 4.5, Codex/GPT tiers, Sonnet, Gemini; enumerable via `cursor-agent --list-models`) as crewmate/secondmate dispatch targets, which is especially useful for captains who reach some of these models only through Cursor.

## Adapter facts (all verified empirically on cursor-agent 2026.07.09-a3815c0, per CONTRIBUTING)

- **Launch:** `cursor-agent --force --model <id> "$(cat <brief>)"`; `--force` auto-approves execution and a crewmate ran fully unattended (file edits + shell commands).
- **Busy signature:** `ctrl+c to stop`, shown iff a turn is running. The spinner word varies (`Working`/`Running`), so the cancel hint is the signature. It is end-anchored in the busy regexes because unlike the other tokens it is generic English a transcript could contain mid-line; verified live both ways (decoy phrase mid-line reads idle, real turn reads busy).
- **Exit/interrupt:** `/exit` or `/quit` (slash popup, the usual too-fast-Enter hazard; `fm-send`'s retried Enter lands it); single `Ctrl+C` cancels a turn.
- **Detection:** `CURSOR_AGENT=1` env marker; ancestry matches the full binary name `*cursor-agent*` (a bare `*cursor*` would match the Cursor IDE's own processes from its integrated terminal) and is ordered before `*claude*` because cursor's runtime is claude-code-derived (`AI_AGENT=claude-code_*`, but no `CLAUDECODE`).
- **Effort axis:** none; Cursor model ids bake reasoning effort into the name (`grok-4.5-xhigh`). The bootstrap validator rejects an effort axis on cursor profiles like it does for opencode, and `fm-spawn` records but never passes it. The SKILL documents Cursor's shifted display names (id `grok-4.5-xhigh` displays as plain "Cursor Grok 4.5").
- **Turn-end:** no hook. A Claude-style `.claude/settings.local.json` Stop hook verifiably does not fire despite the claude-code-derived runtime, so cursor crewmates ride busy-regex stale-pane supervision; the launch template is identical for ship/scout/secondmate.
- **Composer:** placeholder ghost text is dim (SGR 2, verified via raw styled capture), so the generic ghost-stripper handles it with no `FM_COMPOSER_IDLE_RE` override; `fm_tmux_composer_state` and `fm_pane_is_busy` were exercised live against idle and mid-turn panes. One quirk recorded: an Enter in the same keystroke burst as the text can be swallowed; `fm-send`'s settle+retry covers it.
- **Trust dialog:** "Workspace Trust Required" on first launch per directory; accept with Enter; persists.
- **Resume:** `--continue` verified headlessly to restore the prior chat.

## Tests

- New `test_cursor_threads_model_and_ignores_effort_axis` in `tests/fm-spawn-dispatch-profile.test.sh`.
- New invalid-effort row (`cursor:high`) in `tests/fm-bootstrap.test.sh`.
- `fm-spawn-dispatch-profile`, `fm-bootstrap`, `fm-composer-ghost`, `fm-grok-harness`, `fm-secondmate-harness`, and `fm-backend` suites all pass on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)