### PR TITLE
fix: make watcher pid identity clock-independent on procfs platforms

### DIFF
--- a/bin/fm-afk-start.sh
+++ b/bin/fm-afk-start.sh
@@ -82,11 +82,10 @@ daemon_lock_owner() {
 }
 
 daemon_pid_matches() {
-  local pid=$1 owner=$2 identity current command
+  local pid=$1 owner=$2 identity command
   identity=$(cat "$owner/pid-identity" 2>/dev/null || true)
   if [ -n "$identity" ]; then
-    current=$(fm_pid_identity "$pid") || return 1
-    [ "$current" = "$identity" ]
+    fm_pid_identity_matches "$pid" "$identity"
     return
   fi
   command=$(ps -p "$pid" -o command= 2>/dev/null || true)

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Shared durable wake queue and portable lock helpers.
+# Shared durable wake queue, portable lock, and watcher pid-identity/health helpers.
 
 FM_WAKE_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FM_WAKE_DEFAULT_ROOT="$(cd "$FM_WAKE_LIB_DIR/.." && pwd)"

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -23,17 +23,75 @@ fm_pid_alive() {
   kill -0 "$pid" 2>/dev/null
 }
 
+# Recycled-pid guard identity. On procfs platforms the identity is
+# "procfs:<starttime>:<command>", where starttime is /proc/<pid>/stat field 22
+# in clock ticks since boot: constant for the life of a process and immune to
+# wall-clock slew. ps's lstart is re-rendered from the current clock on every
+# read, so on hosts whose clock drifts (WSL2 after host sleep/resume) it changes
+# for the SAME live process and a healthy watcher reads as a recycled pid.
+# Platforms without procfs (macOS) fall back to the lstart form, which remains
+# drift-sensitive there. Compare recorded identities with
+# fm_pid_identity_matches, never with raw string equality, so locks recorded in
+# the old lstart-only format keep matching a live watcher (compat path).
 fm_pid_identity() {
-  local pid=$1 out
+  local pid=$1
   case "$pid" in
     ''|*[!0-9]*) return 1 ;;
   esac
+  if [ -r "/proc/$pid/stat" ]; then
+    fm_pid_identity_procfs "$pid"
+  else
+    fm_pid_identity_lstart "$pid"
+  fi
+}
+
+fm_pid_identity_procfs() {
+  local pid=$1 stat rest starttime cmd
+  stat=$(cat "/proc/$pid/stat" 2>/dev/null) || return 1
+  case "$stat" in
+    *')'*) ;;
+    *) return 1 ;;
+  esac
+  # Field 2 is "(comm)" and comm may itself contain spaces or parens, so split
+  # only after the LAST ')' - the remainder holds fields 3 onward at fixed
+  # positions, putting starttime (overall field 22) at position 20.
+  rest=${stat##*)}
+  starttime=$(printf '%s\n' "$rest" | awk '{ print $20 }')
+  case "$starttime" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+  cmd=$(LC_ALL=C ps -p "$pid" -o command= 2>/dev/null) || return 1
+  [ -n "$cmd" ] || return 1
+  printf 'procfs:%s:%s\n' "$starttime" "$cmd"
+}
+
+fm_pid_identity_lstart() {
+  local pid=$1 out
   # Pin LC_ALL=C so lstart's date format is locale-invariant: the identity is
   # written under one locale but re-read under the machine's ambient locale, which
   # would otherwise mismatch on a non-C locale (e.g. ko_KR) and reject a live watcher.
   out=$(LC_ALL=C ps -p "$pid" -o lstart= -o command= 2>/dev/null) || return 1
   [ -n "$out" ] || return 1
   printf '%s\n' "$out" | sed 's/^[[:space:]]*//'
+}
+
+# fm_pid_identity_matches <pid> <recorded>: compare a recorded lock identity
+# against the live process. A "procfs:" recording compares against the current
+# clock-independent form. Anything else was recorded before the procfs format
+# landed (or on a procfs-less platform), so compare with the lstart read - a
+# live watcher must not be treated as recycled by a mid-flight upgrade. The
+# lock converges to the new format on its next natural re-acquisition.
+fm_pid_identity_matches() {
+  local pid=$1 recorded=$2 current
+  case "$pid" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+  [ -n "$recorded" ] || return 1
+  case "$recorded" in
+    procfs:*) current=$(fm_pid_identity "$pid") || return 1 ;;
+    *) current=$(fm_pid_identity_lstart "$pid") || return 1 ;;
+  esac
+  [ "$current" = "$recorded" ]
 }
 
 fm_path_mtime() {
@@ -51,16 +109,14 @@ fm_path_age() {
 }
 
 fm_watcher_lock_matches_pid() {
-  local state=$1 watch_path=$2 pid=$3 home=${4:-$FM_HOME} lockdir lock_home lock_path lock_identity current_identity
+  local state=$1 watch_path=$2 pid=$3 home=${4:-$FM_HOME} lockdir lock_home lock_path lock_identity
   lockdir="$state/.watch.lock"
   lock_home=$(cat "$lockdir/fm-home" 2>/dev/null || true)
   lock_path=$(cat "$lockdir/watcher-path" 2>/dev/null || true)
   lock_identity=$(cat "$lockdir/pid-identity" 2>/dev/null || true)
   [ "$lock_home" = "$home" ] || return 1
   [ "$lock_path" = "$watch_path" ] || return 1
-  [ -n "$lock_identity" ] || return 1
-  current_identity=$(fm_pid_identity "$pid") || return 1
-  [ "$current_identity" = "$lock_identity" ]
+  fm_pid_identity_matches "$pid" "$lock_identity"
 }
 
 FM_WATCHER_HEALTHY_PID=

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -224,5 +224,5 @@ Use `/stow` before an intentional reset when the conversation may hold durable k
 
 ## Development notes
 
-The current watcher reliability work combines always-on bash triage with a durable queue for actionable wakes, a race-proof singleton lock, duplicate self-eviction, drain-time liveness assertion, and a self-verifying tracked-child arm wrapper.
+The current watcher reliability work combines always-on bash triage with a durable queue for actionable wakes, a race-proof singleton lock with a clock-independent recycled-pid identity on procfs platforms (`bin/fm-wake-lib.sh`), duplicate self-eviction, drain-time liveness assertion, and a self-verifying tracked-child arm wrapper.
 The presence-gated sub-supervisor (`bin/fm-supervise-daemon.sh`) provides walk-away supervision via the `/afk` skill while reusing the same shared wake classifier as the always-on watcher.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -54,7 +54,7 @@ If you have changed away from the firstmate home in an interactive shell, invoke
 | `fm-config-inherit-lib.sh` | Shared primary-to-secondmate inheritable-config propagation                        |
 | `fm-tasks-axi-lib.sh`    | Shared backlog-backend selector and `tasks-axi` compatibility probe                  |
 | `fm-wake-drain.sh`       | Atomically drain queued watcher wakes, then assert watcher liveness                  |
-| `fm-wake-lib.sh`         | Shared durable wake queue, portable locks, and watcher identity/health helpers       |
+| `fm-wake-lib.sh`         | Shared durable wake queue, portable locks, and watcher identity/health helpers (clock-independent procfs pid identity, drift-sensitive lstart fallback, old-format lock compat) |
 | `fm-classify-lib.sh`     | Shared captain-relevant and declared-external-wait wake classification vocabulary    |
 | `fm-send.sh`             | Send one verified literal line or supported key through the target's recorded backend |
 | `fm-tmux-lib.sh`         | Shared tmux pane primitives for busy detection, composer capture, and verified submit |

--- a/tests/fm-backlog-handoff.test.sh
+++ b/tests/fm-backlog-handoff.test.sh
@@ -10,8 +10,13 @@ set -u
 . "$(dirname "${BASH_SOURCE[0]}")/secondmate-helpers.sh"
 
 # The move is delegated to `tasks-axi mv`, so this suite exercises the real
-# binary. Skip cleanly when it is absent (matching the backend smoke suites).
+# binary. Skip cleanly when it is absent or older than the delegated handoff
+# requires (matching the backend smoke suites' version-gated skips), using the
+# same shared probe fm-backlog-handoff.sh itself gates on.
 command -v tasks-axi >/dev/null 2>&1 || { echo "skip: tasks-axi not found (required by the delegated handoff path)"; exit 0; }
+# shellcheck source=bin/fm-tasks-axi-lib.sh disable=SC1091
+. "$ROOT/bin/fm-tasks-axi-lib.sh"
+fm_tasks_axi_compatible || { echo "skip: installed tasks-axi lacks atomic multi-ID mv (0.2.2+ required by the delegated handoff path)"; exit 0; }
 
 TMP_ROOT=$(fm_test_tmproot fm-backlog-handoff)
 

--- a/tests/fm-pi-watch-extension.test.sh
+++ b/tests/fm-pi-watch-extension.test.sh
@@ -82,7 +82,7 @@ test_pi_extension_reports_external_healthy_watcher() {
 printf 'watcher: healthy pid=1 (beacon 0s)\n'
 SH
   chmod +x "$repo/bin/fm-watch-arm.sh"
-  out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" node --input-type=module 2>&1 <<'EOF'
+  out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" fm_node_ts --input-type=module 2>&1 <<'EOF'
 import { writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
@@ -156,7 +156,7 @@ test_pi_tool_returns_agent_tool_result() {
 exit 0
 SH
   chmod +x "$repo/bin/fm-watch-arm.sh"
-  out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" node --input-type=module 2>&1 <<'EOF'
+  out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" fm_node_ts --input-type=module 2>&1 <<'EOF'
 import { writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
@@ -202,7 +202,7 @@ test_pi_process_exit_cleanup_listener_lifecycle() {
   plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
   : > "$repo/bin/fm-watch-arm.sh"
   chmod +x "$repo/bin/fm-watch-arm.sh"
-  out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" node --input-type=module 2>&1 <<'EOF'
+  out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" fm_node_ts --input-type=module 2>&1 <<'EOF'
 import { pathToFileURL } from "node:url";
 
 const handlers = new Map();
@@ -248,7 +248,7 @@ printf '%s\n' "$$" > "$FM_CHILD_PID_FILE"
 while :; do sleep 1; done
 SH
   chmod +x "$repo/bin/fm-watch-arm.sh"
-  out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" FM_CLEANUP_LOG="$cleanup_log" FM_CHILD_PID_FILE="$pid_file" node --input-type=module 2>&1 <<'EOF'
+  out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" FM_CLEANUP_LOG="$cleanup_log" FM_CHILD_PID_FILE="$pid_file" fm_node_ts --input-type=module 2>&1 <<'EOF'
 import { existsSync, writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
@@ -321,7 +321,7 @@ printf 'home=%s root=%s\n' "${FM_HOME:-}" "${FM_ROOT_OVERRIDE:-}" >> "${FM_ARM_L
 printf 'watcher: healthy pid=1 (beacon 0s)\n'
 SH
   chmod +x "$repo/bin/fm-watch-arm.sh"
-  out=$(PLUGIN="$plugin" WORKTREE="$repo" FM_HOME="$home" FM_ARM_LOG="$log" node 2>&1 <<'EOF'
+  out=$(PLUGIN="$plugin" WORKTREE="$repo" FM_HOME="$home" FM_ARM_LOG="$log" fm_node_ts 2>&1 <<'EOF'
 import { existsSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
@@ -371,7 +371,7 @@ printf 'poll=%s\n' "${FM_POLL:-missing}" >> "${FM_ARM_LOG:?}"
 printf 'watcher: healthy pid=1 (beacon 0s)\n'
 SH
   chmod +x "$repo/bin/fm-watch-arm.sh"
-  out=$(PLUGIN="$plugin" WORKTREE="$repo" FM_HOME="$home" FM_ARM_LOG="$log" node 2>&1 <<'EOF'
+  out=$(PLUGIN="$plugin" WORKTREE="$repo" FM_HOME="$home" FM_ARM_LOG="$log" fm_node_ts 2>&1 <<'EOF'
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
@@ -420,7 +420,7 @@ printf 'arm\n' >> "${FM_ARM_LOG:?}"
 printf 'watcher: healthy pid=1 (beacon 0s)\n'
 SH
   chmod +x "$repo/bin/fm-watch-arm.sh"
-  out=$(PLUGIN="$plugin" WORKTREE="$repo" FM_HOME="$home" FM_ARM_LOG="$log" node 2>&1 <<'EOF'
+  out=$(PLUGIN="$plugin" WORKTREE="$repo" FM_HOME="$home" FM_ARM_LOG="$log" fm_node_ts 2>&1 <<'EOF'
 import { existsSync, writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
@@ -473,7 +473,7 @@ printf 'arm\n' >> "${FM_ARM_LOG:?}"
 printf 'watcher: healthy pid=1 (beacon 0s)\n'
 SH
   chmod +x "$repo/bin/fm-watch-arm.sh"
-  out=$(PLUGIN="$plugin" WORKTREE="$repo" FM_HOME="$home" FM_ARM_LOG="$log" node 2>&1 <<'EOF'
+  out=$(PLUGIN="$plugin" WORKTREE="$repo" FM_HOME="$home" FM_ARM_LOG="$log" fm_node_ts 2>&1 <<'EOF'
 import { existsSync, writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
@@ -519,7 +519,7 @@ printf 'arm\n' >> "${FM_ARM_LOG:?}"
 printf 'signal: synthetic wake\n'
 SH
   chmod +x "$repo/bin/fm-watch-arm.sh"
-  out=$(PLUGIN="$plugin" WORKTREE="$repo" FM_HOME="$home" FM_ARM_LOG="$log" node 2>&1 <<'EOF'
+  out=$(PLUGIN="$plugin" WORKTREE="$repo" FM_HOME="$home" FM_ARM_LOG="$log" fm_node_ts 2>&1 <<'EOF'
 import { writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
@@ -583,7 +583,7 @@ printf 'guard should not run\n' >&2
 exit 2
 SH
   chmod +x "$repo/bin/fm-watch-arm.sh" "$repo/bin/fm-turnend-guard.sh"
-  out=$(ARM_PLUGIN="$arm_plugin" GUARD_PLUGIN="$guard_plugin" WORKTREE="$repo" FM_HOME="$home" FM_ARM_LOG="$log" FM_GUARD_LOG="$guard_log" node 2>&1 <<'EOF'
+  out=$(ARM_PLUGIN="$arm_plugin" GUARD_PLUGIN="$guard_plugin" WORKTREE="$repo" FM_HOME="$home" FM_ARM_LOG="$log" FM_GUARD_LOG="$guard_log" fm_node_ts 2>&1 <<'EOF'
 import { existsSync, writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
@@ -656,7 +656,7 @@ printf 'guard ran after external healthy watcher\n' >&2
 exit 2
 SH
   chmod +x "$repo/bin/fm-watch-arm.sh" "$repo/bin/fm-turnend-guard.sh"
-  out=$(ARM_PLUGIN="$arm_plugin" GUARD_PLUGIN="$guard_plugin" WORKTREE="$repo" FM_HOME="$home" FM_ARM_LOG="$log" FM_GUARD_LOG="$guard_log" node 2>&1 <<'EOF'
+  out=$(ARM_PLUGIN="$arm_plugin" GUARD_PLUGIN="$guard_plugin" WORKTREE="$repo" FM_HOME="$home" FM_ARM_LOG="$log" FM_GUARD_LOG="$guard_log" fm_node_ts 2>&1 <<'EOF'
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 

--- a/tests/fm-secondmate-lifecycle-e2e.test.sh
+++ b/tests/fm-secondmate-lifecycle-e2e.test.sh
@@ -151,10 +151,18 @@ phase_send() {
 }
 
 phase_handoff() {
-  # The move is delegated to `tasks-axi mv`; skip cleanly when it is absent (the
-  # downstream recovery and teardown phases do not depend on this phase).
+  # The move is delegated to `tasks-axi mv`; skip cleanly when it is absent or
+  # older than the delegated handoff requires, using the same shared probe
+  # fm-backlog-handoff.sh itself gates on (the downstream recovery and teardown
+  # phases do not depend on this phase).
   if ! command -v tasks-axi >/dev/null 2>&1; then
     echo "skip: tasks-axi not found (backlog handoff delegates to it)"
+    return 0
+  fi
+  # shellcheck source=bin/fm-tasks-axi-lib.sh disable=SC1091
+  . "$ROOT/bin/fm-tasks-axi-lib.sh"
+  if ! fm_tasks_axi_compatible; then
+    echo "skip: installed tasks-axi lacks atomic multi-ID mv (0.2.2+ required by the delegated handoff path)"
     return 0
   fi
   cat > "$HOME_DIR/data/backlog.md" <<'EOF'

--- a/tests/fm-turnend-guard.test.sh
+++ b/tests/fm-turnend-guard.test.sh
@@ -612,7 +612,7 @@ SH
 exit 0
 SH
   chmod +x "$repo/bin/fm-turnend-guard.sh" "$repo/bin/fm-arm-pretool-check.sh"
-  out=$(PLUGIN="$ext" FM_HOME="$home" FM_GUARD_LOG="$log" node --input-type=module 2>&1 <<'EOF'
+  out=$(PLUGIN="$ext" FM_HOME="$home" FM_GUARD_LOG="$log" fm_node_ts --input-type=module 2>&1 <<'EOF'
 import { readFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
@@ -672,7 +672,7 @@ SH
 exit 0
 SH
   chmod +x "$repo/bin/fm-turnend-guard.sh" "$repo/bin/fm-arm-pretool-check.sh"
-  out=$(PLUGIN="$ext" FM_HOME="$home" node --input-type=module 2>&1 <<'EOF'
+  out=$(PLUGIN="$ext" FM_HOME="$home" fm_node_ts --input-type=module 2>&1 <<'EOF'
 import { pathToFileURL } from "node:url";
 
 const handlers = new Map();

--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -703,8 +703,104 @@ test_pid_identity_is_locale_invariant() {
   pass "fm_pid_identity is locale-invariant across LC_ALL/LC_TIME"
 }
 
+test_pid_identity_is_clock_independent() {
+  # The identity is the recycled-pid guard: fm-watch/fm-supervise-daemon record
+  # it at lock acquisition and every later health check re-reads it live. ps's
+  # lstart is re-rendered from the current wall clock on each read, so on hosts
+  # whose clock slews (WSL2 after host sleep/resume) the SAME live process
+  # yields a different identity over time and a healthy watcher reads as a
+  # recycled pid. The procfs form must therefore contain no wall-clock-rendered
+  # component: assert the procfs:<ticks>:<command> format and that the bytes are
+  # invariant under a timezone change, which shifts any rendered wall-clock time
+  # but can never move clock-ticks-since-boot. POSIX TZ strings keep this
+  # deterministic without tzdata. Skipped where procfs is absent (macOS keeps
+  # the documented drift-sensitive lstart fallback).
+  local live utc jst
+  if [ ! -r /proc/self/stat ]; then
+    pass "pid identity clock-independence skipped: no procfs on this platform"
+    return 0
+  fi
+  sleep 300 &
+  live=$!
+  utc=$(TZ=UTC0 bash -c '. "$1"; fm_pid_identity "$2"' _ "$LIB" "$live" 2>/dev/null)
+  jst=$(TZ=JST-9 bash -c '. "$1"; fm_pid_identity "$2"' _ "$LIB" "$live" 2>/dev/null)
+  kill "$live" 2>/dev/null || true
+  wait "$live" 2>/dev/null || true
+  printf '%s\n' "$utc" | grep -Eq '^procfs:[0-9]+:.' \
+    || fail "pid identity is not procfs:<ticks>:<command> on a procfs platform (got '$utc')"
+  [ "$jst" = "$utc" ] || fail "pid identity varied with TZ, so it still renders wall-clock time (TZ=UTC0 '$utc' vs TZ=JST-9 '$jst')"
+  pass "fm_pid_identity is clock-independent on procfs platforms"
+}
+
+test_pid_identity_distinguishes_recycled_pid() {
+  # Two different processes must never share an identity even when the command
+  # line is identical: a recycled pid is a NEW process, so its start tick
+  # differs. Start two same-command sleepers a few clock ticks apart (USER_HZ is
+  # 100, so 0.3s is ~30 ticks) and require distinct identities, then require the
+  # comparator to reject one process's recorded identity against the other.
+  local p1 p2 id1 id2 status
+  if [ ! -r /proc/self/stat ]; then
+    pass "recycled-pid identity distinction skipped: no procfs on this platform"
+    return 0
+  fi
+  sleep 300 &
+  p1=$!
+  sleep 0.3
+  sleep 300 &
+  p2=$!
+  id1=$(bash -c '. "$1"; fm_pid_identity "$2"' _ "$LIB" "$p1" 2>/dev/null)
+  id2=$(bash -c '. "$1"; fm_pid_identity "$2"' _ "$LIB" "$p2" 2>/dev/null)
+  status=0
+  bash -c '. "$1"; fm_pid_identity_matches "$2" "$3"' _ "$LIB" "$p1" "$id2" || status=$?
+  kill "$p1" "$p2" 2>/dev/null || true
+  wait "$p1" 2>/dev/null || true
+  wait "$p2" 2>/dev/null || true
+  [ -n "$id1" ] || fail "no identity for first process"
+  [ -n "$id2" ] || fail "no identity for second process"
+  [ "$id1" != "$id2" ] || fail "two distinct same-command processes share an identity ('$id1')"
+  [ "$status" -ne 0 ] || fail "comparator accepted a different process's identity"
+  pass "distinct processes with identical commands yield distinct identities"
+}
+
+test_pid_identity_matches_accepts_old_format_lock() {
+  # A lock recorded before the procfs identity format landed holds
+  # "<lstart> <command>". A mid-flight upgrade must not turn that live watcher
+  # into a "recycled pid": fm_pid_identity_matches routes non-procfs recordings
+  # through the old lstart comparison. The lstart read is shimmed here because
+  # on clock-drift hosts (the WSL2 bug this all guards) two REAL lstart reads of
+  # the same pid can disagree, which would make this test flaky - the routing is
+  # what is under test, not lstart stability.
+  local dir state fakebin live old_identity status
+  dir=$(make_case old-identity-compat)
+  state="$dir/state"
+  fakebin="$dir/fakebin"
+  old_identity='Fri Jul 10 11:54:03 2026 sleep 300'
+  cat > "$fakebin/ps" <<SH
+#!/usr/bin/env bash
+printf '%s\n' '$old_identity'
+SH
+  chmod +x "$fakebin/ps"
+  sleep 300 &
+  live=$!
+  mkdir "$state/.watch.lock"
+  printf '%s\n' "$live" > "$state/.watch.lock/pid"
+  printf '%s\n' "$dir" > "$state/.watch.lock/fm-home"
+  printf '%s\n' "$WATCH" > "$state/.watch.lock/watcher-path"
+  printf '%s\n' "$old_identity" > "$state/.watch.lock/pid-identity"
+  status=0
+  PATH="$fakebin:$PATH" bash -c '. "$1"; fm_watcher_lock_matches_pid "$2" "$3" "$4" "$5"' \
+    _ "$LIB" "$state" "$WATCH" "$live" "$dir" || status=$?
+  kill "$live" 2>/dev/null || true
+  wait "$live" 2>/dev/null || true
+  [ "$status" -eq 0 ] || fail "old-format recorded identity made a live matching watcher read as dead (status $status)"
+  pass "old lstart-format lock identity still matches its live watcher"
+}
+
 test_singleton_start
 test_pid_identity_is_locale_invariant
+test_pid_identity_is_clock_independent
+test_pid_identity_distinguishes_recycled_pid
+test_pid_identity_matches_accepts_old_format_lock
 test_stale_watch_lock_reclaimed
 test_live_stale_watch_lock_is_actionable
 test_guard_warnings

--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -422,13 +422,23 @@ test_watch_restart_rejects_reused_pid() {
 }
 
 test_watch_restart_reports_healthy_peer_without_attaching() {
-  local dir state fakebin out peer identity armpid status
+  local dir state fakebin out peer identity armpid status i
   dir=$(make_case restart-healthy-peer)
   state="$dir/state"
   fakebin="$dir/fakebin"
   out="$dir/restart.out"
-  node -e 'process.on("SIGTERM", () => {}); setTimeout(() => {}, 300000)' &
+  # The peer must ignore the restart's TERM, but node registers the handler only
+  # once its -e script runs, tens of ms after fork. Have the peer signal
+  # readiness after registering and wait for it, or an early-enough arm TERM
+  # kills the peer and the child legitimately reclaims the dead-pid lock.
+  node -e 'process.on("SIGTERM", () => {}); require("fs").writeFileSync(process.argv[1], ""); setTimeout(() => {}, 300000)' "$dir/peer-ready" &
   peer=$!
+  i=0
+  while [ "$i" -lt 100 ] && [ ! -e "$dir/peer-ready" ]; do
+    sleep 0.1
+    i=$((i + 1))
+  done
+  [ -e "$dir/peer-ready" ] || fail "peer never registered its SIGTERM handler"
   identity=$(FM_STATE_OVERRIDE="$state" bash -c '. "$1"; fm_pid_identity "$2"' _ "$LIB" "$peer") || fail "could not identify peer pid"
   mkdir "$state/.watch.lock"
   printf '%s\n' "$peer" > "$state/.watch.lock/pid"

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -6,8 +6,9 @@
 #   . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 #
 # It provides the boilerplate every test file used to re-roll: ok/not-ok
-# reporters, a self-cleaning temp root, fakebin/PATH-shim helpers, deterministic
-# git identity and fixture builders, state/<id>.meta writers, and the common
+# reporters, a self-cleaning temp root, fakebin/PATH-shim helpers, a node
+# runner that probes for .ts import support, deterministic git identity and
+# fixture builders, state/<id>.meta writers, and the common
 # string/exit-code/file assertions. It deliberately does NOT bundle the
 # behavior-specific fake tmux/treehouse/no-mistakes mocks: those encode terminal
 # and lifecycle assumptions that differ per suite and belong with the tests that

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -91,6 +91,47 @@ SH
   done
 }
 
+# --- node .ts imports ---------------------------------------------------------
+#
+# Suites exercising the tracked Pi extensions import .ts files from node. Type
+# stripping is default-on only from node 22.18/23.6 onward; older nodes need
+# --experimental-strip-types (plus --no-warnings so the experimental notice does
+# not pollute empty-output assertions). fm_node_ts probes once per test process
+# and runs node with whatever flags this node version needs.
+
+FM_NODE_TS_FLAGS=
+FM_NODE_TS_PROBED=
+
+fm_node_ts_probe() {
+  # Self-contained temp handling: fm_test_tmproot is not used here because a
+  # probe may run inside a command substitution, and the probe cleans up its
+  # one dir immediately rather than deferring to the EXIT trap.
+  local dir probe script rc
+  dir=$(mktemp -d "${TMPDIR:-/tmp}/fm-node-ts-probe.XXXXXX") || return 1
+  probe="$dir/probe.ts"
+  printf 'export const ok: number = 1;\n' > "$probe"
+  script='import { pathToFileURL } from "node:url"; await import(pathToFileURL(process.argv[1]).href);'
+  FM_NODE_TS_PROBED=1
+  rc=1
+  if node --input-type=module -e "$script" "$probe" >/dev/null 2>&1; then
+    FM_NODE_TS_FLAGS=
+    rc=0
+  elif node --experimental-strip-types --no-warnings --input-type=module -e "$script" "$probe" >/dev/null 2>&1; then
+    FM_NODE_TS_FLAGS='--experimental-strip-types --no-warnings'
+    rc=0
+  fi
+  rm -rf "$dir"
+  return "$rc"
+}
+
+fm_node_ts() {
+  if [ -z "$FM_NODE_TS_PROBED" ]; then
+    fm_node_ts_probe || fail "node $(node --version 2>/dev/null || echo '(missing)') cannot import .ts modules even with --experimental-strip-types"
+  fi
+  # shellcheck disable=SC2086 # deliberate word-split of the probed flag string
+  node $FM_NODE_TS_FLAGS "$@"
+}
+
 # --- deterministic git identity and fixtures --------------------------------
 
 # fm_git_identity [name] [email]: export a fixed author/committer identity so


### PR DESCRIPTION
## Intent

Land the already-validated watcher PID-identity fix onto current firstmate main so the watcher stops self-evicting on WSL2.

**Root cause.** `fm_pid_identity` in `bin/fm-wake-lib.sh` derived the recycled-pid guard identity from `ps -o lstart`, which is re-rendered from the wall clock on every read. On WSL2 the host clock slews after sleep/resume, so the SAME live watcher's identity changed over time and it failed its own singleton honesty check within ~30-60s (false "TURN WOULD END BLIND" alarms, `fm-watch-arm` reporting FAILED beside a live watcher).

**The fix.**

- The identity becomes `procfs:<starttime>:<command>`, using `/proc/<pid>/stat` field 22 (clock ticks since boot - constant for the life of a process, drift-immune), parsed by splitting after the LAST `)` so spaces/parens in comm cannot misalign fields.
- Platforms without procfs (macOS) deliberately keep the drift-sensitive lstart form.
- All comparisons go through the new `fm_pid_identity_matches`, so a lock recorded in the old lstart format before the upgrade still matches its live watcher. Both comparison sites use it: `fm_watcher_lock_matches_pid` and `fm-afk-start`'s `daemon_pid_matches`.

**Provenance.** This is a re-application: the fix was authored and validated on branch `fm/pid-identity-drift-g2` against an older main (it has an open superseded upstream PR #434); the fix commit was cherry-picked clean onto current main.

**Deliberate scoping decisions.**

- Of the upstream branch's supporting commits, only two are included, because the test suite on current main genuinely fails without them in this environment (verified pre-existing on a clean main export):
  - a node `.ts`-import probe in `tests/lib.sh` (`fm_node_ts`; node <22.18 needs `--experimental-strip-types` for the Pi extension suites, this box runs node 22.15), and
  - a tasks-axi 0.2.2+ compatibility skip gate for the two handoff suites (this box has 0.1.2; the gate uses the same shared `fm_tasks_axi_compatible` probe the handoff script itself gates on).
- The upstream test-timing-margin widenings were deliberately dropped (both affected suites pass without them on current main).
- The upstream CONTRIBUTING.md test-roster edits were deliberately dropped as obsolete (current main deleted that roster in favor of per-test header comments, which already carry the coverage descriptions).
- One `docs/scripts.md` roster row for `fm-wake-lib.sh` was updated to note the clock-independent identity, folded into current main's compact table style.
- The branch also carries a prior run's document-step commit (`fm-wake-lib.sh` header line and one `docs/architecture.md` sentence syncing the watcher-reliability paragraph), fast-forwarded in after that run failed only at push due to a then-unconfigured fork URL.

**Validation.** New test coverage extends `tests/fm-watcher-lock.test.sh`: the procfs form contains no wall-clock component (TZ invariance), distinct same-command processes yield distinct identities, and an old lstart-format lock still matches its live watcher. Full suite 72/72 files green locally and `bin/fm-lint.sh` green under pinned ShellCheck 0.11.0.

**Push route.** Push goes to the fork remote (maafk/firstmate, SSH URL because the local OAuth token lacks the workflow scope the https push of upstream workflow-touching ancestor commits would require) with the PR against origin main, per this repo's fork-contribution workflow.

## What Changed

- `fm_pid_identity` in `bin/fm-wake-lib.sh` now builds the recycled-pid guard identity as `procfs:<starttime>:<command>` from `/proc/<pid>/stat` field 22 (clock ticks since boot, constant for the life of a process), splitting after the last `)` so spaces or parens in the comm field cannot misalign fields. The previous `ps -o lstart` form is re-rendered from the wall clock on every read, so on hosts with clock slew (WSL2 after sleep/resume) the same live watcher's identity changed over time and it failed its own singleton lock check, causing false self-eviction. Platforms without procfs (macOS) keep the lstart form.
- Both identity comparison sites, `fm_watcher_lock_matches_pid` and `bin/fm-afk-start.sh`'s daemon lock check, now go through a new `fm_pid_identity_matches`, which compares a pre-upgrade lstart-format lock recording against a fresh lstart read so locks written before the upgrade still match their live watcher; the lock converges to the procfs format on its next natural re-acquisition.
- Test and docs support: `tests/fm-watcher-lock.test.sh` adds coverage for TZ-invariance of the procfs form, distinct identities for recycled pids, and old-format lock compatibility (a TERM-handler race in the new healthy-peer restart test was caught by the pipeline's test step and fixed in-branch); `tests/lib.sh` adds a node `--experimental-strip-types` probe so the Pi extension suites run on node <22.18 and a tasks-axi version-compat gate that skips the handoff suites on incompatible installs; `docs/architecture.md` and `docs/scripts.md` note the clock-independent identity.

## Risk Assessment

✅ **Low.** The change is a well-bounded, backward-compatible fix to the watcher pid-identity check with verifiably correct `/proc/<pid>/stat` parsing, an old-format compat comparator applied at both long-lived lock comparison sites, focused new unit tests covering clock-independence, recycled-pid distinctness, and old-format lock compat. The remaining diff is test-environment gating (node .ts probe, tasks-axi version skips) that mirrors the runtime probes it references.

## Testing

Beyond the already-green baseline full suite, I re-ran the five suites touched by this change (all green, with the tasks-axi and node-version gates behaving as designed on this box's tasks-axi 0.1.2 and node 22.15), confirmed the round-1 flaky healthy-peer restart test stays green across 5 repeated runs, and captured an end-to-end CLI transcript on the actual WSL2 target environment showing the real watcher recording a procfs-based lock identity that survives a rendered-clock shift which demonstrably breaks the old lstart identity, plus backward compatibility with pre-upgrade lstart-format locks; no visual evidence applies since the change has no UI surface.

<details>
<summary>Evidence: End-to-end WSL2 PID-identity demo transcript (bug mechanism, fix via real fm-watch.sh lock + health check under clock shift, old-format lock compat)</summary>

```text
### Environment
kernel: 6.6.87.2-microsoft-standard-WSL2

### 1. The bug mechanism: the OLD identity basis (ps lstart) is re-rendered from the
###    current wall clock on every read. A rendered-clock shift (here: TZ change,
###    same mechanism as WSL2 clock slew after host sleep/resume) changes the
###    identity of the SAME live process, so raw equality declared it recycled.
same live pid 40324, lstart identity read 1 (TZ=UTC0):  Sun Jul 12 11:51:11 2026 sleep 300
same live pid 40324, lstart identity read 2 (TZ=JST-9): Sun Jul 12 20:51:11 2026 sleep 300
=> identities DIFFER for the same live process: the old raw-equality check
   would read this healthy watcher as a recycled pid (the WSL2 self-eviction).

### 2. The fix, end-to-end: launch the REAL watcher (bin/fm-watch.sh); it records
###    its lock identity via fm_pid_identity at acquisition (fm-watch.sh:610).
live watcher pid: 40343 (lock pid file: 40343)
recorded lock identity: procfs:257869360:bash /home/taylor/.no-mistakes/worktrees/d5188f6655a7/01KXB05PEN6B446RQDXX1R29QS/bin/fm-watch.sh
=> procfs:<start-ticks>:<command> - clock ticks since boot, no wall-clock component.

###    Health-check the live watcher through the REAL comparison path
###    (fm_watcher_lock_matches_pid, used by fm-watch-arm.sh:142) under two
###    different rendered clocks:
TZ=UTC0 : lock matches live watcher (healthy)
TZ=JST-9 : lock matches live watcher (healthy)
=> watcher pid 40343 still alive and healthy across the clock shift: no self-eviction.

### 3. Mid-flight upgrade compat: a lock recorded BEFORE the upgrade holds the old
###    '<lstart> <command>' format. fm_pid_identity_matches must route it through
###    the lstart comparison so the live watcher is not evicted by the upgrade.
lock rewritten with pre-upgrade identity: Sun Jul 12 07:51:11 2026 bash /home/taylor/.no-mistakes/worktrees/d5188f6655a7/01KXB05PEN6B446RQDXX1R29QS/bin/fm-watch.sh
=> old-format lock still matches its live watcher: upgrade does not evict it.

ALL DEMO CHECKS PASSED
```

</details>

<details>
<summary>Evidence: Reproducible demo script</summary>

```bash
#!/usr/bin/env bash
# End-to-end demo of the clock-independent watcher pid identity on a real WSL2 box.
# Runs the REAL bin/fm-watch.sh and the REAL comparison path (fm_watcher_lock_matches_pid,
# the health check fm-watch-arm.sh and the guard use).
set -u
ROOT=$1
LIB="$ROOT/bin/fm-wake-lib.sh"
WATCH="$ROOT/bin/fm-watch.sh"
work=$(mktemp -d /tmp/fm-pidid-demo.XXXXXX)
state="$work/state"; fakebin="$work/fakebin"; mkdir -p "$state" "$fakebin"
printf '#!/usr/bin/env bash\nexit 0\n' > "$fakebin/tmux"; chmod +x "$fakebin/tmux"
# One shared FM_HOME for the watcher and every health check, exactly as
# fm-watch-arm.sh runs with the same FM_HOME as the watcher it supervises.
export FM_ROOT_OVERRIDE="$work/notgit"; mkdir -p "$FM_ROOT_OVERRIDE"
export FM_HOME="$work/home"; mkdir -p "$FM_HOME"
cleanup() { [ -n "${wpid:-}" ] && kill "$wpid" 2>/dev/null; rm -rf "$work"; }
trap cleanup EXIT

echo "### Environment"
echo "kernel: $(uname -r)"
echo

echo "### 1. The bug mechanism: the OLD identity basis (ps lstart) is re-rendered from the"
echo "###    current wall clock on every read. A rendered-clock shift (here: TZ change,"
echo "###    same mechanism as WSL2 clock slew after host sleep/resume) changes the"
echo "###    identity of the SAME live process, so raw equality declared it recycled."
sleep 300 & standin=$!
old_a=$(TZ=UTC0  bash -c '. "$1"; fm_pid_identity_lstart "$2"' _ "$LIB" "$standin")
old_b=$(TZ=JST-9 bash -c '. "$1"; fm_pid_identity_lstart "$2"' _ "$LIB" "$standin")
echo "same live pid $standin, lstart identity read 1 (TZ=UTC0):  $old_a"
echo "same live pid $standin, lstart identity read 2 (TZ=JST-9): $old_b"
if [ "$old_a" = "$old_b" ]; then echo "UNEXPECTED: lstart identity did not shift"; else
  echo "=> identities DIFFER for the same live process: the old raw-equality check"
  echo "   would read this healthy watcher as a recycled pid (the WSL2 self-eviction)."
fi
kill "$standin" 2>/dev/null; wait "$standin" 2>/dev/null
echo

echo "### 2. The fix, end-to-end: launch the REAL watcher (bin/fm-watch.sh); it records"
echo "###    its lock identity via fm_pid_identity at acquisition (fm-watch.sh:610)."
PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_POLL=5 FM_SIGNAL_GRACE=1 \
  FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$work/watch.out" &
wpid=$!
i=0; while [ "$i" -lt 100 ] && [ ! -s "$state/.watch.lock/pid-identity" ]; do sleep 0.1; i=$((i+1)); done
[ -s "$state/.watch.lock/pid-identity" ] || { echo "FAIL: watcher never recorded lock identity"; exit 1; }
echo "live watcher pid: $wpid (lock pid file: $(cat "$state/.watch.lock/pid"))"
echo "recorded lock identity: $(cat "$state/.watch.lock/pid-identity")"
grep -Eq '^procfs:[0-9]+:' "$state/.watch.lock/pid-identity" \
  && echo "=> procfs:<start-ticks>:<command> - clock ticks since boot, no wall-clock component." \
  || { echo "FAIL: lock identity is not the procfs form"; exit 1; }
echo
echo "###    Health-check the live watcher through the REAL comparison path"
echo "###    (fm_watcher_lock_matches_pid, used by fm-watch-arm.sh:142) under two"
echo "###    different rendered clocks:"
for tz in UTC0 JST-9; do
  if TZ=$tz bash -c '. "$1"; fm_watcher_lock_matches_pid "$2" "$3" "$4" "$5"' _ "$LIB" "$state" "$WATCH" "$wpid" "$FM_HOME"; then
    echo "TZ=$tz : lock matches live watcher (healthy)"
  else
    echo "TZ=$tz : MISMATCH - watcher would self-evict"; exit 1
  fi
done
kill -0 "$wpid" 2>/dev/null && echo "=> watcher pid $wpid still alive and healthy across the clock shift: no self-eviction." \
  || { echo "FAIL: watcher died"; exit 1; }
echo

echo "### 3. Mid-flight upgrade compat: a lock recorded BEFORE the upgrade holds the old"
echo "###    '<lstart> <command>' format. fm_pid_identity_matches must route it through"
echo "###    the lstart comparison so the live watcher is not evicted by the upgrade."
oldfmt=$(bash -c '. "$1"; fm_pid_identity_lstart "$2"' _ "$LIB" "$wpid")
printf '%s\n' "$oldfmt" > "$state/.watch.lock/pid-identity"
echo "lock rewritten with pre-upgrade identity: $oldfmt"
if bash -c '. "$1"; fm_watcher_lock_matches_pid "$2" "$3" "$4" "$5"' _ "$LIB" "$state" "$WATCH" "$wpid" "$FM_HOME"; then
  echo "=> old-format lock still matches its live watcher: upgrade does not evict it."
else
  echo "FAIL: old-format lock rejected the live watcher"; exit 1
fi
kill "$wpid" 2>/dev/null; wait "$wpid" 2>/dev/null; wpid=
echo
echo "ALL DEMO CHECKS PASSED"
```

</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

Outcome: 🔧 1 issue found → auto-fixed ✅ across 2 runs (35m26s)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ℹ️ `tests/lib.sh:100` - fm_node_ts&#39;s once-per-process probe cache never takes effect: every call site invokes the function inside a command substitution (out=$(... fm_node_ts ...)), so FM_NODE_TS_PROBED=1 is set only in the subshell and the probe (mktemp + 1-2 node startups) re-runs on each of the ~13 invocations across the Pi extension and turnend-guard suites. Correctness is unaffected, but the comment &#39;probes once per test process&#39; is inaccurate and the suite pays a small repeated startup cost. Fix by correcting the comment, or by persisting the probed flags (e.g. probe eagerly at first top-level use or cache to a file under the temp root).
- ℹ️ `bin/fm-afk-launch.sh:75` - fm_afk_launch_lock_owned in bin/fm-afk-launch.sh still compares the recorded pid-identity with raw string equality against a live fm_pid_identity read, rather than fm_pid_identity_matches. This is safe in practice: the launch lock is ephemeral (held only for the seconds-long launch by the same process generation, so recorded and live formats always agree except across an in-flight upgrade), and the failure direction (treating a live holder as stale) is serialized by the daemon lock, which was converted to the compat comparator. Noting it so a future &#39;convert all comparison sites&#39; pass knows this one was deliberately left as-is.

</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed ✅</summary>

- 🚨 tests failed with exit code 1
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`

🔧 Fix: fix TERM-handler race in watcher restart healthy-peer test
✅ Re-checked - no issues remain.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- <code>Baseline (pre-run): full configured suite `for t in tests/*.test.sh; do bash &#34;$t&#34;; done` on tmux-equipped WSL2 - green</code>
- <code>`bash tests/fm-watcher-lock.test.sh` - 26 tests green, including the 3 new ones: clock-independence (TZ invariance of procfs identity), recycled-pid distinction, old lstart-format lock compatibility</code>
- <code>`bash tests/fm-pi-watch-extension.test.sh` - green on node 22.15 via the new fm_node_ts strip-types probe</code>
- <code>`bash tests/fm-backlog-handoff.test.sh` and `bash tests/fm-secondmate-lifecycle-e2e.test.sh` - handoff coverage skips cleanly on installed tasks-axi 0.1.2 (&lt;0.2.2), rest green</code>
- <code>`bash tests/fm-turnend-guard.test.sh` - green</code>
- <code>Flake check: `tests/fm-watcher-lock.test.sh` run 5 consecutive times - all green (round-1 TERM-handler race fixed by b046093 did not reproduce)</code>
- <code>Manual end-to-end demo `demo-pid-identity.sh` on WSL2 kernel 6.6.87.2-microsoft-standard-WSL2: (1) same live pid yields different lstart identities under TZ=UTC0 vs TZ=JST-9 (the old-format drift bug); (2) real `bin/fm-watch.sh` records `procfs:&lt;ticks&gt;:&lt;command&gt;` in .watch.lock/pid-identity and real `fm_watcher_lock_matches_pid` matches the live watcher under both TZs with no self-eviction; (3) a lock rewritten with the pre-upgrade lstart format still matches its live watcher</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
