### PR TITLE
fix(composer): normalize NO-BREAK SPACE so fm-send verifies claude submits

### DIFF
--- a/.agents/skills/afk/SKILL.md
+++ b/.agents/skills/afk/SKILL.md
@@ -94,7 +94,7 @@ backend (tmux or herdr; see "Auto-discovered supervisor pane" below):
 - **Composer-state guard** - `inject_msg` reads the full `empty`/`pending`/`unknown` verdict from `fm_backend_composer_state` and injects only when it is affirmatively `empty`.
   `pending` means real unsubmitted text, while `unknown` includes an unreadable pane and a bare shell prompt left after the agent exits, so both defer.
   The shared `bin/fm-composer-lib.sh` owns the content decision after each backend captures and structurally identifies its own composer row.
-  It preserves idle bordered composers such as claude's `│ > … │` and bare agent glyphs as empty, but a bare shell glyph is unknown unless inside a genuine bordered composer box; see `docs/herdr-backend.md` "Composer-emptiness safety" for the complete contract.
+  It preserves idle bordered composers such as an older claude's `│ > … │` and bare agent glyphs as empty (including claude's current unbordered `❯` prompt, whose trailing NO-BREAK SPACE the owner normalizes away), but a bare shell glyph is unknown unless inside a genuine bordered composer box; see `docs/herdr-backend.md` "Composer-emptiness safety" for the complete contract.
   `pane_input_pending` remains the tested predicate for callers that only need to know whether real unsubmitted text is present, but it is insufficient for an injection-safety decision because it cannot distinguish `empty` from `unknown`.
 
 Either condition, or any composer verdict other than `empty`, defers the injection; the buffered escalation survives in `state/.subsuper-escalations` and is retried on the next housekeeping tick.
@@ -170,7 +170,8 @@ the marker lets firstmate distinguish it from a real captain message.
 - The shared composer classifier receives a candidate row only after the active backend performs its own capture and structural row recognition.
   tmux and herdr route their raw styled candidate rows through the shared `fm_composer_strip_ghost` extractor, which removes dim/faint and dark-TRUECOLOR ghost/placeholder text before classification.
   They read the composer shape from a separately ANSI-stripped plain row because a dark TRUECOLOR border can be stripped with ghost content.
-  A ghost-only or idle bordered composer such as claude's `│ > ... │` therefore reads empty without allowing an unbordered shell prompt to do the same.
+  A ghost-only or idle bordered composer such as an older claude's `│ > ... │` therefore reads empty without allowing an unbordered shell prompt to do the same.
+  The shared owner also normalizes NO-BREAK SPACE (U+00A0) to a plain space before matching, so claude's current unbordered `❯<NBSP>` prompt reads empty instead of pending.
   `FM_COMPOSER_IDLE_RE` still overrides tmux empty-composer matching after shared ghost and border stripping, and `FM_BUSY_REGEX` overrides busy footers.
 - **Max-defer escape** - the daemon must never silently wedge. If anything stays
   buffered past `FM_MAX_DEFER_SECS` (default 300s), the daemon attempts one

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -123,6 +123,12 @@ Its broader dark-TRUECOLOR placeholder handling and dark-theme tradeoff are docu
 That styled capture is internal to the boolean detector only.
 `fm-peek` and every other human or LLM-facing capture path stays plain `tmux capture-pane` with no escape codes.
 
+**Composer quirk (verified 2026-07-12, Claude Code v2.1.207, tmux 3.4).**
+Claude's composer is UNBORDERED - horizontal rules above and below, no `│ ... │` side borders - and its prompt renders as `❯` followed by a NO-BREAK SPACE (U+00A0, bytes `c2 a0`), not a plain space.
+No `[[:space:]]` trim removes that NBSP, so before normalization an EMPTY composer row read as `❯<NBSP>` classified `pending`, and every `fm-send` text submit to a claude pane false-failed with "Enter swallowed" while the message had actually landed (observed 2026-07-11; a blind retry would have double-submitted).
+A text send to a BUSY claude pane queues and leaves `❯<NBSP>` plus a DIM "Press up to edit queued messages" hint on the cursor row; the hint strips as ghost, so that row also reads empty (submitted).
+The shared classifier `fm_composer_classify_content` (`bin/fm-composer-lib.sh`) now normalizes NBSP to a plain space before glyph matching; regression fixtures live in `tests/fm-composer-lib.test.sh` and `tests/fm-composer-ghost.test.sh` (the `claude_nbsp` tests).
+
 **Primary-session guard fact (verified 2026-07-04, Claude Code 2.1.201; preserved 2026-07-08, Claude Code 2.1.204).**
 This is separate from the per-task crewmate turn-end hook above (that one just `touch`es a marker file in a task's own `.claude/settings.local.json`).
 The firstmate PRIMARY's own `.claude/settings.json` registers `bin/fm-turnend-guard.sh` as a Stop hook, and exiting with status 2 plus stderr reliably forces the model to continue.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,8 @@ tmp=$(mktemp -d) && printf 'done: smoke\n' > "$tmp/smoke.status" && FM_STATE_OVE
 
 Discover tests by listing `tests/*.test.sh`: each is a self-contained bash script named `<subject>.test.sh`, and its header comment describes what it covers, so run one directly to focus on a subject.
 Tests that need a real optional backend or an explicit opt-in (real herdr/zellij/cmux smoke tests, the live Pi regression) skip themselves and print the tool or environment gate needed to enable them, so the run-all loop above is always safe.
+A suite that exercises missing-tool detection must build its `PATH` from `tests/lib.sh`'s `fm_test_base_path` (which sets `FM_TEST_BASE_PATH_DIR`) rather than from the real system dirs, so a tool the suite deliberately omits cannot be satisfied by whatever the developer's machine happens to have installed - `/usr/bin/orca` (the GNOME screen reader, unrelated to firstmate's Orca backend) and `/usr/bin/node` both collided this way, and `FM_TEST_BASE_PATH` still overrides the whole thing.
+That helper derives the tools it withholds from `bin/fm-bootstrap.sh`'s own `TOOLS="..."` lists, so keep those a literal name list with no substitutions: the derivation fails the suite loudly rather than silently running the missing-tool cases against a partial blocklist.
 
 ## Questions
 

--- a/bin/fm-composer-lib.sh
+++ b/bin/fm-composer-lib.sh
@@ -49,6 +49,12 @@
 # below. Re-sourcing is a cheap idempotent redefinition, so this file needs no
 # include guard (matching bin/fm-tmux-lib.sh).
 
+# The NO-BREAK SPACE (U+00A0) claude draws after its composer prompt glyph. Set
+# once at source time, not per classifier call: the classifier runs on every
+# composer-state read, including fm_tmux_submit_core's Enter-retry loop and the
+# away-mode daemon's per-pane poll.
+FM_COMPOSER_NBSP=$'\xc2\xa0'
+
 # fm_composer_strip_ansi: drop every CSI escape sequence, leaving plain text.
 # Used for STRUCTURAL row/shape detection, where ghost text must be KEPT so the
 # composer box border or bare prompt glyph is still visible; content extraction
@@ -180,7 +186,7 @@ fm_composer_idle_matches() {
 }
 
 fm_composer_classify_content() {  # <bordered> <content> [idle_re] [idle_case] [plain_content]
-  local bordered=$1 content=$2 idle_re=${3:-} idle_case=${4:-sensitive} plain_content nbsp
+  local bordered=$1 content=$2 idle_re=${3:-} idle_case=${4:-sensitive} plain_content
   plain_content=${5:-$content}
   # NO-BREAK SPACE normalization (task fmsend-verify-l2): claude >= 2.1.x draws
   # its composer prompt as "❯" + U+00A0, which no [[:space:]] trim removes, so an
@@ -189,9 +195,8 @@ fm_composer_classify_content() {  # <bordered> <content> [idle_re] [idle_case] [
   # swallowed". Normalize NBSP to a plain space and re-trim both views before any
   # matching; a row of only NBSPs is visually empty, so this cannot promote real
   # pending text to empty.
-  nbsp=$(printf '\302\240')
-  content=${content//"$nbsp"/ }
-  plain_content=${plain_content//"$nbsp"/ }
+  content=${content//"$FM_COMPOSER_NBSP"/ }
+  plain_content=${plain_content//"$FM_COMPOSER_NBSP"/ }
   content="${content#"${content%%[![:space:]]*}"}"
   content="${content%"${content##*[![:space:]]}"}"
   plain_content="${plain_content#"${plain_content%%[![:space:]]*}"}"

--- a/bin/fm-composer-lib.sh
+++ b/bin/fm-composer-lib.sh
@@ -38,6 +38,15 @@
 # byte-pattern check missed claude's own dim ghost (its prompt glyph is not
 # bold-wrapped) and no adapter covered grok's truecolor placeholder at all.
 #
+# WHITESPACE NORMALIZATION is the third thing this owner does (task
+# fmsend-verify-l2): claude draws its composer prompt as `❯` followed by a
+# NO-BREAK SPACE (U+00A0), which no [[:space:]] trim removes, so an EMPTY claude
+# composer read as `❯<NBSP>` fell through every glyph match to `pending` and
+# every fm-send text submit to a claude pane false-failed with "Enter
+# swallowed". fm_composer_classify_content normalizes NBSP to a plain space and
+# re-trims before matching, so all four adapters inherit the fix; see
+# docs/tmux-backend.md's "Incident (2026-07-11)".
+#
 # Each adapter still owns its own CAPTURE and structural row-finding, because
 # those use genuinely different primitives (tmux's cursor-row read, herdr's ANSI
 # tail scan, orca/cmux's plain read-screen). Once an adapter has a candidate

--- a/bin/fm-composer-lib.sh
+++ b/bin/fm-composer-lib.sh
@@ -180,8 +180,22 @@ fm_composer_idle_matches() {
 }
 
 fm_composer_classify_content() {  # <bordered> <content> [idle_re] [idle_case] [plain_content]
-  local bordered=$1 content=$2 idle_re=${3:-} idle_case=${4:-sensitive} plain_content
+  local bordered=$1 content=$2 idle_re=${3:-} idle_case=${4:-sensitive} plain_content nbsp
   plain_content=${5:-$content}
+  # NO-BREAK SPACE normalization (task fmsend-verify-l2): claude >= 2.1.x draws
+  # its composer prompt as "❯" + U+00A0, which no [[:space:]] trim removes, so an
+  # EMPTY composer read as "❯<NBSP>" fell through every glyph match to `pending`
+  # and every fm-send text submit to a claude pane false-failed with "Enter
+  # swallowed". Normalize NBSP to a plain space and re-trim both views before any
+  # matching; a row of only NBSPs is visually empty, so this cannot promote real
+  # pending text to empty.
+  nbsp=$(printf '\302\240')
+  content=${content//"$nbsp"/ }
+  plain_content=${plain_content//"$nbsp"/ }
+  content="${content#"${content%%[![:space:]]*}"}"
+  content="${content%"${content##*[![:space:]]}"}"
+  plain_content="${plain_content#"${plain_content%%[![:space:]]*}"}"
+  plain_content="${plain_content%"${plain_content##*[![:space:]]}"}"
   if [ "$bordered" != 1 ] && [ -z "$content" ] && [ -n "$plain_content" ]; then
     case "$plain_content" in
       '❯'|'›') printf 'empty'; return 0 ;;

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -528,10 +528,12 @@ mark_escalated_seen() {  # <kind> <arg> <state>
 #
 # pane_input_pending returns 0 (pending) when the cursor line holds real
 # unsubmitted text - a human's half-typed line (the return race) or a previous
-# injection whose Enter was swallowed. The detector drops dim/faint ghost text and
-# strips the harness's composer box borders, so a ghost-only or idle bordered
-# claude composer ("│ > … │") is correctly read as empty, not pending (incidents
-# afk-invx-i5 and composer-robust).
+# injection whose Enter was swallowed. The detector drops dim/faint ghost text,
+# strips the harness's composer box borders, and normalizes the NO-BREAK SPACE
+# claude draws after its `❯` prompt glyph, so a ghost-only composer, an older
+# claude's bordered one ("│ > … │"), and today's unbordered `❯ ` one are all
+# correctly read as empty, not pending (incidents afk-invx-i5, composer-robust,
+# and fmsend-verify-l2).
 # pane_is_busy / pane_input_pending: BACKEND-AWARE now (previously tmux-only
 # direct calls). <backend> defaults to tmux when omitted, so every existing
 # caller/test that passes only <target> is unaffected. Dispatch goes through

--- a/bin/fm-tmux-lib.sh
+++ b/bin/fm-tmux-lib.sh
@@ -7,9 +7,9 @@
 # logic cannot drift between the two.
 #
 # Why this exists (incident afk-invx-i5): the daemon's old composer check only
-# recognized a BARE prompt glyph ("> ") as an empty composer. claude draws its
-# input box with box-drawing borders ("│ > … │"), so every idle claude pane read
-# as "pending input" and the away-mode daemon deferred 100% of escalations for
+# recognized a BARE prompt glyph ("> ") as an empty composer. claude then drew
+# its input box with box-drawing borders ("│ > … │"), so every idle claude pane
+# read as "pending input" and the away-mode daemon deferred 100% of escalations for
 # 9.5 hours with no escape. The detector below strips the box borders before
 # deciding, so a bordered-but-empty composer is correctly seen as empty. The same
 # corrected detector backs the submit acknowledgement (a submit "landed" iff the
@@ -83,8 +83,11 @@ fm_tmux_strip_ghost() { fm_composer_strip_ghost; }
 # no multibyte character classes), and delegates the empty/pending/unknown
 # decision to the shared owner fm_composer_classify_content
 # (bin/fm-composer-lib.sh). The bordered flag is what lets a bordered `│ > │`
-# (claude's own idle composer) read empty while a bare, unbordered `$ ` dead-shell
-# prompt reads unknown.
+# (an older claude's idle composer) read empty while a bare, unbordered `$ `
+# dead-shell prompt reads unknown. Today's claude composer is UNBORDERED and
+# draws `❯` followed by a NO-BREAK SPACE; the shared owner normalizes that NBSP
+# before matching, so the row reads empty (docs/tmux-backend.md, "Incident
+# (2026-07-11)").
 fm_tmux_composer_state() {  # <target> -> empty|pending|unknown
   local target=$1 cy raw plain stripped bordered=0
   cy=$(tmux display-message -p -t "$target" '#{cursor_y}' 2>/dev/null) || { printf 'unknown'; return 0; }

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -592,7 +592,11 @@ On a bare, unstructured row it is a dead-shell prompt and reads `unknown` (not a
 The agent prompt glyphs `❯` (claude) and `›` (codex) read `empty` either way.
 `inject_msg` was hardened to match: its composer-guard now reads `fm_backend_composer_state` directly and defers on anything that is not affirmatively `empty` (`pending` real text, or `unknown` for a dead shell or an unreadable pane), instead of only deferring on `pending`.
 
-**Regression coverage.** `tests/fm-composer-lib.test.sh` pins the shared owner directly (bare shell glyph -> `unknown`, the same glyph bordered -> `empty`, agent glyphs -> `empty` bordered or bare, idle placeholder, real text -> `pending`).
+**Whitespace normalization (added 2026-07-12).** Before any glyph matching, the shared owner normalizes NO-BREAK SPACE (U+00A0) to a plain space and re-trims, because claude draws its composer prompt as `❯` followed by an NBSP that no `[[:space:]]` trim removes, so an empty composer read as `❯<NBSP>` fell through every glyph match to `pending`.
+All four adapters inherit that normalization from the owner; the incident it fixed (every `fm-send` text submit to a claude pane false-failing with "Enter swallowed") is written up in [`docs/tmux-backend.md`](tmux-backend.md) under "Incident (2026-07-11)".
+The safety rule is unchanged by it: a dead-shell `$<NBSP>` row still reads `unknown`, and `❯<NBSP><text>` still reads `pending`.
+
+**Regression coverage.** `tests/fm-composer-lib.test.sh` pins the shared owner directly (bare shell glyph -> `unknown`, the same glyph bordered -> `empty`, agent glyphs -> `empty` bordered or bare, NBSP-suffixed prompt glyphs, idle placeholder, real text -> `pending`).
 Per-backend dead-shell coverage: `tests/fm-daemon.test.sh`'s `test_tmux_composer_state_bare_shell_is_unknown` and `test_inject_msg_defers_on_dead_shell_unknown` (tmux + the injector), `tests/fm-backend-herdr.test.sh`'s `test_composer_state_unknown_when_no_composer_row_found`, `tests/fm-backend-orca.test.sh`'s `test_composer_state_bare_shell_prompt_is_unknown`, and `tests/fm-backend-cmux.test.sh`'s `test_composer_state_unknown_when_no_composer_row_found`.
 The herdr incident regressions (`tests/fm-backend-herdr.test.sh`'s composer-state, wait-for-working, and send-text-submit sections) stay green, and `shellcheck bin/*.sh bin/backends/*.sh tests/*.sh` passes clean.
 

--- a/docs/tmux-backend.md
+++ b/docs/tmux-backend.md
@@ -111,6 +111,29 @@ The classifier deliberately reports `unknown` for `node`/`python`/`python3` rath
 Practical effect: a dead `pi` secondmate is not auto-healed by the liveness sweep today; it is reported as `skipped: liveness probe inconclusive` instead, which still surfaces it for a human to act on.
 Resolving this would need either a `pi`-specific env marker inspectable from outside the process (mirroring `PI_CODING_AGENT=true`, which `bin/fm-harness.sh` already uses for self-detection but which is not readable from a different process without deeper introspection) or accepting the argument-inspection fragility - not attempted here.
 
+## Incident (2026-07-11): false "Enter swallowed" on every claude text send
+
+Symptom: every multi-word `bin/fm-send.sh <task-id> "<text>"` to a Claude Code crewmate pane exited 1 with `error: text not submitted ... (Enter swallowed; text left in composer)` while the message had in fact submitted - the pane went busy immediately and the crew acted on it.
+`--key` sends were unaffected because they skip submit verification.
+The danger was a blind retry after the false error, which would have double-submitted the steer.
+
+Root cause, reproduced 2026-07-12 against a live Claude Code v2.1.207 pane in a scratch tmux 3.4 session: claude's composer renders its prompt as `❯` followed by a NO-BREAK SPACE (U+00A0), and the composer is unbordered (horizontal rules above and below, no `│ ... │` side borders).
+Capturing the cursor row after a verified-clean submit and hex-dumping the ghost-stripped content showed exactly `e2 9d af c2 a0` (`❯` + NBSP):
+
+```sh
+cy=$(tmux display-message -p -t fmrepro '#{cursor_y}')
+tmux capture-pane -e -p -t fmrepro -S "$cy" -E "$cy" | fm_composer_strip_ghost | hexdump -C
+# 00000000  e2 9d af c2 a0 0a
+```
+
+No `[[:space:]]` trim removes U+00A0, so the empty-composer row `❯<NBSP>` fell through every glyph match in `fm_composer_classify_content` to `pending`, and `fm_tmux_submit_core` exhausted its Enter retries against a composer that was already empty.
+A send landing as a queued message on a busy pane showed `❯<NBSP>` plus a dim `Press up to edit queued messages` hint on the cursor row; the hint strips as ghost, leaving the same misread `❯<NBSP>`.
+
+Fix: `fm_composer_classify_content` (`bin/fm-composer-lib.sh`, the one fleet-wide classification owner) normalizes NBSP to a plain space and re-trims before any matching, so all backend adapters inherit the fix.
+A genuinely stuck composer (`❯<NBSP><text>`, Enter withheld) still classifies `pending`, verified live with a raw-tty pane that swallows Enter (`fm-send` exited 1) and an idle claude pane (`fm-send` exited 0, message processed).
+Regression fixtures: `tests/fm-composer-lib.test.sh` (NBSP classification) and `tests/fm-composer-ghost.test.sh` (the exact captured claude rows through `fm_tmux_composer_state`).
+The harness-facing quirk note lives in the `harness-adapters` skill's claude section.
+
 ## Limitations
 
 None specific to tmux for the reference path itself - it is the fully verified reference backend, while Orca and cmux are the backends without secondmate support.

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -23,7 +23,12 @@ set -u
 # tool this suite controls through its own fakebin, so a case that omits a tool
 # to assert "MISSING: <tool>" genuinely runs without it no matter what the
 # developer's machine has installed (fm_test_base_path, tests/lib.sh).
-BASE_PATH=${FM_TEST_BASE_PATH:-$(fm_test_base_path)}
+if [ -n "${FM_TEST_BASE_PATH:-}" ]; then
+  BASE_PATH=$FM_TEST_BASE_PATH
+else
+  fm_test_base_path
+  BASE_PATH=$FM_TEST_BASE_PATH_DIR
+fi
 TMP_ROOT=$(fm_test_tmproot fm-bootstrap-tests)
 
 # A fake toolchain where every required tool is present and gh is authenticated.

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -19,7 +19,11 @@ set -u
 # shellcheck source=tests/lib.sh disable=SC1091
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
-BASE_PATH=${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin}
+# The base PATH is HERMETIC: it mirrors the real system dirs but withholds every
+# tool this suite controls through its own fakebin, so a case that omits a tool
+# to assert "MISSING: <tool>" genuinely runs without it no matter what the
+# developer's machine has installed (fm_test_base_path, tests/lib.sh).
+BASE_PATH=${FM_TEST_BASE_PATH:-$(fm_test_base_path)}
 TMP_ROOT=$(fm_test_tmproot fm-bootstrap-tests)
 
 # A fake toolchain where every required tool is present and gh is authenticated.

--- a/tests/fm-composer-ghost.test.sh
+++ b/tests/fm-composer-ghost.test.sh
@@ -250,6 +250,58 @@ test_real_text_with_trailing_ghost_is_pending() {
   pass "fm_pane_input_pending: real text plus a trailing ghost run is still pending"
 }
 
+# --- claude 2.1.x unbordered NBSP composer rows (task fmsend-verify-l2) -----
+
+test_claude_nbsp_empty_composer_reads_empty() {
+  local dir fb capture out
+  dir="$TMP_ROOT/claude-nbsp-empty"; mkdir -p "$dir"
+  fb=$(make_fake_tmux "$dir")
+  capture="$dir/styled.txt"
+  # The exact cursor row Claude Code v2.1.207 leaves after a submitted text send
+  # (captured live 2026-07-12, tmux 3.4): an UNBORDERED row, a 256-color grey
+  # prompt glyph, and a U+00A0 NO-BREAK SPACE separator. This row read `pending`
+  # before NBSP normalization, so EVERY fm-send text submit to a claude pane
+  # false-failed with "Enter swallowed".
+  printf '\033[38;5;246m\xe2\x9d\xaf\xc2\xa0\033[39m\n' > "$capture"
+  out=$(PATH="$fb:$PATH" FM_FAKE_STYLED="$capture" FM_FAKE_CY=0 \
+    fm_tmux_composer_state "fakepane")
+  [ "$out" = empty ] \
+    || fail "claude 2.1.x empty composer row ('❯' + NBSP) must read empty, got '$out'"
+  pass "fm_tmux_composer_state: claude 2.1.x unbordered '❯' + NBSP empty composer reads empty"
+}
+
+test_claude_nbsp_queued_hint_reads_empty() {
+  local dir fb capture out
+  dir="$TMP_ROOT/claude-nbsp-queued"; mkdir -p "$dir"
+  fb=$(make_fake_tmux "$dir")
+  capture="$dir/styled.txt"
+  # The exact cursor row after a text send lands as a QUEUED message on a busy
+  # claude pane (captured live 2026-07-12, Claude Code v2.1.207): the NBSP glyph
+  # plus a DIM "Press up to edit queued messages" hint. The submit landed, so
+  # this must read empty (the hint is ghost, the NBSP is separator).
+  printf '\033[38;5;246m\xe2\x9d\xaf\xc2\xa0\033[2m\033[39mPress up to edit queued messages\033[0m\n' > "$capture"
+  out=$(PATH="$fb:$PATH" FM_FAKE_STYLED="$capture" FM_FAKE_CY=0 \
+    fm_tmux_composer_state "fakepane")
+  [ "$out" = empty ] \
+    || fail "claude queued-message hint row must read empty (submit landed), got '$out'"
+  pass "fm_tmux_composer_state: claude's queued-message hint row reads empty (submit landed)"
+}
+
+test_claude_nbsp_typed_text_still_pending() {
+  local dir fb capture out
+  dir="$TMP_ROOT/claude-nbsp-typed"; mkdir -p "$dir"
+  fb=$(make_fake_tmux "$dir")
+  capture="$dir/styled.txt"
+  # The same layout with real typed-but-unsubmitted text after the NBSP (captured
+  # live 2026-07-12): a genuinely stuck composer must still read pending.
+  printf '\033[38;5;246m\xe2\x9d\xaf\xc2\xa0\033[39malso please summarize what you did when finished\n' > "$capture"
+  out=$(PATH="$fb:$PATH" FM_FAKE_STYLED="$capture" FM_FAKE_CY=0 \
+    fm_tmux_composer_state "fakepane")
+  [ "$out" = pending ] \
+    || fail "claude 2.1.x typed-text row must still read pending, got '$out'"
+  pass "fm_tmux_composer_state: claude 2.1.x typed text after the NBSP separator is still pending"
+}
+
 # --- fm-peek.sh stays escape-free (LLM-facing path) -------------------------
 
 test_peek_output_is_escape_free() {
@@ -287,4 +339,7 @@ test_colored_text_with_2_payload_still_pending
 test_dark_truecolor_ghost_only_composer_is_not_pending
 test_dark_truecolor_bare_shell_prompt_is_unknown
 test_real_text_with_trailing_ghost_is_pending
+test_claude_nbsp_empty_composer_reads_empty
+test_claude_nbsp_queued_hint_reads_empty
+test_claude_nbsp_typed_text_still_pending
 test_peek_output_is_escape_free

--- a/tests/fm-composer-lib.test.sh
+++ b/tests/fm-composer-lib.test.sh
@@ -82,6 +82,34 @@ test_agent_glyphs_are_empty_bordered_and_bare() {
   pass "fm_composer_classify_content: agent prompt glyphs (❯ claude, › codex) read empty bordered or bare"
 }
 
+# --- claude >= 2.1.x NBSP glyph separator (task fmsend-verify-l2) ------------
+
+test_nbsp_glyph_separator_reads_empty() {
+  local nbsp out
+  nbsp=$(printf '\302\240')
+  # claude 2.1.207 draws its composer prompt as "❯" + U+00A0 NO-BREAK SPACE,
+  # which no [[:space:]] trim removes, so an EMPTY composer read "❯<NBSP>" and
+  # classified pending - every fm-send text submit to a claude pane false-failed
+  # with "Enter swallowed" (observed 2026-07-11, fixed by NBSP normalization).
+  out=$(classify 0 "❯${nbsp}")
+  [ "$out" = empty ] || fail "bare '❯<NBSP>' (claude 2.1.x empty composer) must read empty, got '$out'"
+  out=$(classify 0 '' '' sensitive "❯${nbsp}")
+  [ "$out" = empty ] || fail "stripped '❯<NBSP>' plain-content fallback must read empty, got '$out'"
+  pass "fm_composer_classify_content: claude's '❯' + NO-BREAK SPACE empty composer reads empty"
+}
+
+test_nbsp_normalization_keeps_pending_and_safety_verdicts() {
+  local nbsp out
+  nbsp=$(printf '\302\240')
+  # Real text after the NBSP separator is still unsubmitted -> pending.
+  out=$(classify 0 "❯${nbsp}fix findings 1 and 3")
+  [ "$out" = pending ] || fail "'❯<NBSP><text>' must stay pending, got '$out'"
+  # The dead-shell safety verdict survives NBSP normalization.
+  out=$(classify 0 "\$${nbsp}")
+  [ "$out" = unknown ] || fail "bare '\$<NBSP>' must stay unknown (dead shell), got '$out'"
+  pass "fm_composer_classify_content: NBSP normalization never promotes pending text or a dead shell to empty"
+}
+
 # --- Empty content and idle placeholder -------------------------------------
 
 test_empty_content_is_empty() {
@@ -130,6 +158,8 @@ test_stripped_unbordered_content_uses_plain_content
 test_bare_shell_prompt_with_command_is_not_empty
 test_bordered_shell_glyph_is_empty
 test_agent_glyphs_are_empty_bordered_and_bare
+test_nbsp_glyph_separator_reads_empty
+test_nbsp_normalization_keeps_pending_and_safety_verdicts
 test_empty_content_is_empty
 test_idle_placeholder_is_empty
 test_idle_placeholder_case_mode_is_explicit

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -30,7 +30,12 @@ SESSION_START="$ROOT/bin/fm-session-start.sh"
 # tool this suite controls through its own fakebin, so a case that omits a tool
 # to assert "MISSING: <tool>" genuinely runs without it no matter what the
 # developer's machine has installed (fm_test_base_path, tests/lib.sh).
-BASE_PATH=${FM_TEST_BASE_PATH:-$(fm_test_base_path)}
+if [ -n "${FM_TEST_BASE_PATH:-}" ]; then
+  BASE_PATH=$FM_TEST_BASE_PATH
+else
+  fm_test_base_path
+  BASE_PATH=$FM_TEST_BASE_PATH_DIR
+fi
 TMP_ROOT=$(fm_test_tmproot fm-session-start-tests)
 fm_git_identity fmtest fmtest@example.invalid
 

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -26,7 +26,11 @@ set -u
 . "$(dirname "${BASH_SOURCE[0]}")/wake-helpers.sh"
 
 SESSION_START="$ROOT/bin/fm-session-start.sh"
-BASE_PATH=${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin}
+# The base PATH is HERMETIC: it mirrors the real system dirs but withholds every
+# tool this suite controls through its own fakebin, so a case that omits a tool
+# to assert "MISSING: <tool>" genuinely runs without it no matter what the
+# developer's machine has installed (fm_test_base_path, tests/lib.sh).
+BASE_PATH=${FM_TEST_BASE_PATH:-$(fm_test_base_path)}
 TMP_ROOT=$(fm_test_tmproot fm-session-start-tests)
 fm_git_identity fmtest fmtest@example.invalid
 

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -44,28 +44,41 @@ pass() {
 # --- self-cleaning temp root ------------------------------------------------
 #
 # fm_test_tmproot <prefix> echoes a fresh temp dir and registers it for removal
-# on EXIT. The first call installs the cleanup trap. A test file that needs
-# extra teardown (e.g. killing a daemon) should define its own EXIT trap and
-# call fm_test_cleanup from inside it so registered dirs are still removed.
+# on EXIT. A test file that needs extra teardown (e.g. killing a daemon) should
+# define its own EXIT trap and call fm_test_cleanup from inside it so registered
+# dirs are still removed.
+#
+# Callers use it as TMP_ROOT=$(fm_test_tmproot ...), so the registration happens
+# in a command-substitution subshell: an in-memory array would be discarded with
+# that subshell, and a trap installed there would fire on subshell exit and wipe
+# the dir the caller just asked for. So registrations go to a file, and the EXIT
+# trap is installed here, at source time, in the sourcing shell - bash resets
+# caught traps in subshells, so it fires exactly once, when the test process
+# exits.
 
 FM_TEST_CLEANUP_DIRS=()
+FM_TEST_CLEANUP_REGISTRY=$(mktemp "${TMPDIR:-/tmp}/fm-test-cleanup.XXXXXX")
 
 fm_test_cleanup() {
   local d
   for d in "${FM_TEST_CLEANUP_DIRS[@]:-}"; do
     [ -n "$d" ] && rm -rf "$d"
   done
+  if [ -f "$FM_TEST_CLEANUP_REGISTRY" ]; then
+    while IFS= read -r d; do
+      [ -n "$d" ] && rm -rf "$d"
+    done < "$FM_TEST_CLEANUP_REGISTRY"
+    rm -f "$FM_TEST_CLEANUP_REGISTRY"
+  fi
 }
 
-# fm_test_register_cleanup <dir>: record <dir> for removal on EXIT, installing
-# the trap on the first registration. Call it from the shell that must own the
-# cleanup - a registration made inside a command-substitution subshell is
-# discarded with that subshell.
+trap fm_test_cleanup EXIT
+
+# fm_test_register_cleanup <dir>: record <dir> for removal on EXIT. Safe to call
+# from a subshell: the record is appended to the registry file the sourcing
+# shell's trap reads.
 fm_test_register_cleanup() {
-  if [ "${#FM_TEST_CLEANUP_DIRS[@]}" -eq 0 ]; then
-    trap fm_test_cleanup EXIT
-  fi
-  FM_TEST_CLEANUP_DIRS+=("$1")
+  printf '%s\n' "$1" >> "$FM_TEST_CLEANUP_REGISTRY"
 }
 
 fm_test_tmproot() {
@@ -117,13 +130,12 @@ SH
 # executables EXCEPT the tools these suites control through their own fakebin,
 # and sets FM_TEST_BASE_PATH_DIR to it. It writes that variable instead of
 # echoing a path so the caller invokes it directly (NOT in a command
-# substitution): a subshell would discard both the cache and fm_test_tmproot's
-# cleanup registration, leaking the mirror dir and rebuilding its ~2000 symlinks
-# on every call. The ambient machine therefore can never satisfy a firstmate tool
-# probe, so a case that omits a tool genuinely runs without it and the assertion
-# tests what it was written to test. Everything else - git, jq, and the coreutils
-# the scripts really call - is mirrored through untouched, because the suites
-# need real ones. The dir is built once per test process and cached.
+# substitution): a subshell would discard the cache, rebuilding the mirror's
+# ~2000 symlinks on every call. The ambient machine therefore can never satisfy a
+# firstmate tool probe, so a case that omits a tool genuinely runs without it and
+# the assertion tests what it was written to test. Everything else - git, jq, and
+# the coreutils the scripts really call - is mirrored through untouched, because
+# the suites need real ones. The dir is built once per test process and cached.
 #
 # FM_TEST_BASE_PATH still overrides the whole thing, unchanged.
 
@@ -134,22 +146,44 @@ SH
 # bootstrap's lists. `git` is deliberately exempt: the suites need a real git, and
 # their missing-git case shadows it with a shell function instead of relying on
 # PATH.
+#
+# The derivation only understands literal `TOOLS="a b c"` assignments. It is
+# validated before use against FM_TEST_TOOL_REQUIRED - the names the missing-tool
+# suites actually shadow through their own fakebin - and a derivation that cannot
+# be trusted FAILS the suite loudly rather than falling back to a partial
+# blocklist, because a partial blocklist means a green suite that tests nothing.
 FM_TEST_TOOL_EXEMPT="git"
 FM_TEST_TOOL_EXTRA="herdr zellij cmux"
+FM_TEST_TOOL_REQUIRED="tmux node gh treehouse no-mistakes gh-axi chrome-devtools-axi lavish-axi tasks-axi quota-axi orca"
 FM_TEST_TOOL_BLOCKLIST=""
 FM_TEST_BASE_PATH_DIR=""
 
 fm_test_tool_blocklist() {
-  local declared name
+  local declared name missing=""
   [ -z "$FM_TEST_TOOL_BLOCKLIST" ] || return 0
   declared=$(grep -o 'TOOLS="[^"]*"' "$ROOT/bin/fm-bootstrap.sh" | sed -e 's/^TOOLS="//' -e 's/"$//')
-  [ -n "$declared" ] || fail "tests/lib.sh: could not derive the tool list from bin/fm-bootstrap.sh"
+  [ -n "$declared" ] || fail "tests/lib.sh: could not derive the tool list from bin/fm-bootstrap.sh; its TOOLS shape changed and fm_test_tool_blocklist must be updated"
+  case "$declared" in
+    *'$'* | *'`'*)
+      fail "tests/lib.sh: bin/fm-bootstrap.sh's TOOLS list is no longer a literal name list (it contains a substitution); fm_test_tool_blocklist must be updated or the missing-tool suites will be satisfied by the ambient toolchain"
+      ;;
+  esac
   for name in $declared $FM_TEST_TOOL_EXTRA; do
     case " $FM_TEST_TOOL_EXEMPT " in *" $name "*) continue ;; esac
     case " $FM_TEST_TOOL_BLOCKLIST " in *" $name "*) continue ;; esac
     FM_TEST_TOOL_BLOCKLIST="$FM_TEST_TOOL_BLOCKLIST $name"
   done
   FM_TEST_TOOL_BLOCKLIST=${FM_TEST_TOOL_BLOCKLIST# }
+  for name in $FM_TEST_TOOL_REQUIRED; do
+    case " $FM_TEST_TOOL_BLOCKLIST " in
+      *" $name "*) ;;
+      *) missing="$missing $name" ;;
+    esac
+  done
+  if [ -n "$missing" ]; then
+    FM_TEST_TOOL_BLOCKLIST=""
+    fail "tests/lib.sh: tool blocklist derived from bin/fm-bootstrap.sh is missing:$missing - its TOOLS shape changed and fm_test_tool_blocklist must be updated; refusing to run the missing-tool suites against a partial blocklist"
+  fi
 }
 
 fm_test_base_path() {
@@ -158,11 +192,7 @@ fm_test_base_path() {
     return 0
   fi
   fm_test_tool_blocklist
-  # mktemp directly, then register in THIS shell: fm_test_tmproot echoes its dir,
-  # so calling it in a command substitution would strand the registration (and the
-  # dir) in the subshell.
-  root=$(mktemp -d "${TMPDIR:-/tmp}/fm-base-path.XXXXXX")
-  fm_test_register_cleanup "$root"
+  root=$(fm_test_tmproot fm-base-path)
   dir="$root/bin"
   mkdir -p "$dir"
   for src in /usr/bin /bin /usr/sbin /sbin; do

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -57,13 +57,21 @@ fm_test_cleanup() {
   done
 }
 
-fm_test_tmproot() {
-  local prefix=${1:-fm-test} root
-  root=$(mktemp -d "${TMPDIR:-/tmp}/${prefix}.XXXXXX")
+# fm_test_register_cleanup <dir>: record <dir> for removal on EXIT, installing
+# the trap on the first registration. Call it from the shell that must own the
+# cleanup - a registration made inside a command-substitution subshell is
+# discarded with that subshell.
+fm_test_register_cleanup() {
   if [ "${#FM_TEST_CLEANUP_DIRS[@]}" -eq 0 ]; then
     trap fm_test_cleanup EXIT
   fi
-  FM_TEST_CLEANUP_DIRS+=("$root")
+  FM_TEST_CLEANUP_DIRS+=("$1")
+}
+
+fm_test_tmproot() {
+  local prefix=${1:-fm-test} root
+  root=$(mktemp -d "${TMPDIR:-/tmp}/${prefix}.XXXXXX")
+  fm_test_register_cleanup "$root"
   printf '%s\n' "$root"
 }
 
@@ -105,30 +113,56 @@ SH
 # CI stayed green only because its runners happen to lack both, which made this
 # a local-only failure that blocked the gate for any developer who had them.
 #
-# fm_test_base_path echoes a sanitized bin dir mirroring the real base dirs'
-# executables EXCEPT the tools these suites control through their own fakebin
-# (FM_TEST_TOOL_BLOCKLIST). The ambient machine therefore can never satisfy a
-# firstmate tool probe, so a case that omits a tool genuinely runs without it and
-# the assertion tests what it was written to test. Everything else - git, jq, and
-# the coreutils the scripts really call - is mirrored through untouched, because
-# the suites need real ones. The dir is built once per test process and cached.
+# fm_test_base_path builds a sanitized bin dir mirroring the real base dirs'
+# executables EXCEPT the tools these suites control through their own fakebin,
+# and sets FM_TEST_BASE_PATH_DIR to it. It writes that variable instead of
+# echoing a path so the caller invokes it directly (NOT in a command
+# substitution): a subshell would discard both the cache and fm_test_tmproot's
+# cleanup registration, leaking the mirror dir and rebuilding its ~2000 symlinks
+# on every call. The ambient machine therefore can never satisfy a firstmate tool
+# probe, so a case that omits a tool genuinely runs without it and the assertion
+# tests what it was written to test. Everything else - git, jq, and the coreutils
+# the scripts really call - is mirrored through untouched, because the suites
+# need real ones. The dir is built once per test process and cached.
 #
 # FM_TEST_BASE_PATH still overrides the whole thing, unchanged.
 
-# The tools firstmate probes for AND these suites control via fakebin. `git` is
-# deliberately NOT here: the suites need a real git, and their missing-git case
-# shadows it with a shell function instead of relying on PATH.
-FM_TEST_TOOL_BLOCKLIST="tmux node gh gh-axi chrome-devtools-axi lavish-axi treehouse no-mistakes tasks-axi quota-axi orca herdr zellij cmux"
-
+# The tools these suites control via fakebin are DERIVED from bootstrap's own
+# TOOLS lists (every backend branch) rather than duplicated here, so a newly
+# required tool cannot silently reintroduce the ambient-toolchain false-pass.
+# FM_TEST_TOOL_EXTRA covers the backend binaries other scripts probe for outside
+# bootstrap's lists. `git` is deliberately exempt: the suites need a real git, and
+# their missing-git case shadows it with a shell function instead of relying on
+# PATH.
+FM_TEST_TOOL_EXEMPT="git"
+FM_TEST_TOOL_EXTRA="herdr zellij cmux"
+FM_TEST_TOOL_BLOCKLIST=""
 FM_TEST_BASE_PATH_DIR=""
+
+fm_test_tool_blocklist() {
+  local declared name
+  [ -z "$FM_TEST_TOOL_BLOCKLIST" ] || return 0
+  declared=$(grep -o 'TOOLS="[^"]*"' "$ROOT/bin/fm-bootstrap.sh" | sed -e 's/^TOOLS="//' -e 's/"$//')
+  [ -n "$declared" ] || fail "tests/lib.sh: could not derive the tool list from bin/fm-bootstrap.sh"
+  for name in $declared $FM_TEST_TOOL_EXTRA; do
+    case " $FM_TEST_TOOL_EXEMPT " in *" $name "*) continue ;; esac
+    case " $FM_TEST_TOOL_BLOCKLIST " in *" $name "*) continue ;; esac
+    FM_TEST_TOOL_BLOCKLIST="$FM_TEST_TOOL_BLOCKLIST $name"
+  done
+  FM_TEST_TOOL_BLOCKLIST=${FM_TEST_TOOL_BLOCKLIST# }
+}
 
 fm_test_base_path() {
   local root dir src entry name
   if [ -n "$FM_TEST_BASE_PATH_DIR" ] && [ -d "$FM_TEST_BASE_PATH_DIR" ]; then
-    printf '%s\n' "$FM_TEST_BASE_PATH_DIR"
     return 0
   fi
-  root=$(fm_test_tmproot fm-base-path)
+  fm_test_tool_blocklist
+  # mktemp directly, then register in THIS shell: fm_test_tmproot echoes its dir,
+  # so calling it in a command substitution would strand the registration (and the
+  # dir) in the subshell.
+  root=$(mktemp -d "${TMPDIR:-/tmp}/fm-base-path.XXXXXX")
+  fm_test_register_cleanup "$root"
   dir="$root/bin"
   mkdir -p "$dir"
   for src in /usr/bin /bin /usr/sbin /sbin; do
@@ -145,7 +179,6 @@ fm_test_base_path() {
     done
   done
   FM_TEST_BASE_PATH_DIR=$dir
-  printf '%s\n' "$dir"
 }
 
 # --- deterministic git identity and fixtures --------------------------------

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -91,6 +91,63 @@ SH
   done
 }
 
+# --- hermetic base PATH -----------------------------------------------------
+#
+# Why this exists (task fmsend-verify-l2): the suites that exercise firstmate's
+# missing-tool detection build a fakebin that deliberately OMITS a tool, then
+# assert bootstrap prints "MISSING: <tool>". They prepended that fakebin to the
+# REAL system dirs, so an omitted tool that happened to exist on the developer's
+# machine silently satisfied the probe and the assertion failed. Two collisions
+# were real and are the reason this helper exists: /usr/bin/orca is the GNOME
+# screen reader (unrelated to firstmate's Orca backend - it merely shares the
+# name) and /usr/bin/node is an ordinary Node install. `/bin` is a usrmerge
+# symlink to `/usr/bin`, so no reordering of the real dirs could dodge either.
+# CI stayed green only because its runners happen to lack both, which made this
+# a local-only failure that blocked the gate for any developer who had them.
+#
+# fm_test_base_path echoes a sanitized bin dir mirroring the real base dirs'
+# executables EXCEPT the tools these suites control through their own fakebin
+# (FM_TEST_TOOL_BLOCKLIST). The ambient machine therefore can never satisfy a
+# firstmate tool probe, so a case that omits a tool genuinely runs without it and
+# the assertion tests what it was written to test. Everything else - git, jq, and
+# the coreutils the scripts really call - is mirrored through untouched, because
+# the suites need real ones. The dir is built once per test process and cached.
+#
+# FM_TEST_BASE_PATH still overrides the whole thing, unchanged.
+
+# The tools firstmate probes for AND these suites control via fakebin. `git` is
+# deliberately NOT here: the suites need a real git, and their missing-git case
+# shadows it with a shell function instead of relying on PATH.
+FM_TEST_TOOL_BLOCKLIST="tmux node gh gh-axi chrome-devtools-axi lavish-axi treehouse no-mistakes tasks-axi quota-axi orca herdr zellij cmux"
+
+FM_TEST_BASE_PATH_DIR=""
+
+fm_test_base_path() {
+  local root dir src entry name
+  if [ -n "$FM_TEST_BASE_PATH_DIR" ] && [ -d "$FM_TEST_BASE_PATH_DIR" ]; then
+    printf '%s\n' "$FM_TEST_BASE_PATH_DIR"
+    return 0
+  fi
+  root=$(fm_test_tmproot fm-base-path)
+  dir="$root/bin"
+  mkdir -p "$dir"
+  for src in /usr/bin /bin /usr/sbin /sbin; do
+    [ -d "$src" ] || continue
+    for entry in "$src"/*; do
+      [ -f "$entry" ] && [ -x "$entry" ] || continue
+      name=${entry##*/}
+      case " $FM_TEST_TOOL_BLOCKLIST " in
+        *" $name "*) continue ;;
+      esac
+      # First dir wins, mirroring real PATH precedence (and /bin == /usr/bin
+      # under usrmerge, so this also dedupes the symlinked duplicates).
+      [ -e "$dir/$name" ] || ln -s "$entry" "$dir/$name"
+    done
+  done
+  FM_TEST_BASE_PATH_DIR=$dir
+  printf '%s\n' "$dir"
+}
+
 # --- deterministic git identity and fixtures --------------------------------
 
 # fm_git_identity [name] [email]: export a fixed author/committer identity so


### PR DESCRIPTION
## Summary

`bin/fm-send.sh` reported every multi-word text send to a Claude Code pane as a failure, even though the message had actually been delivered.

On the tmux backend against Claude Code 2.1.x, each text send exited 1 with `error: text not submitted (Enter swallowed; text left in composer)` while the target pane went busy immediately and acted on the message. `--key` sends were unaffected. The false error is worse than cosmetic: a caller that retries on it would double-submit the message.

The cause is a whitespace byte, not the cursor-row quirk I first suspected. Claude Code's composer is unbordered and draws its prompt as `❯` (U+276F) followed by a NO-BREAK SPACE (U+00A0). No `[[:space:]]` trim removes an NBSP, so an *empty* composer row read as `❯<NBSP>` fell through every glyph match in the shared classifier and came out as `pending` — "text still unsubmitted". `fm_tmux_submit_core` then exhausted its Enter-retry loop against a composer that was already empty, firing stray submits along the way, and finally reported failure. Reproduced against a live Claude Code v2.1.207 pane in a scratch tmux 3.4 session and confirmed by hexdumping the ghost-stripped cursor row after a verified-clean submit: `e2 9d af c2 a0`.

The fix goes in `fm_composer_classify_content` (`bin/fm-composer-lib.sh`), the single fleet-wide owner of composer classification: normalize NBSP to a plain space and re-trim both content views before any glyph matching. Putting it there fixes all four backend adapters (tmux, herdr, orca, cmux) at once instead of patching the tmux path alone.

Two properties are deliberately preserved, and both are pinned by fixtures: a bare shell prompt followed by an NBSP still classifies `unknown` (never a safe injection target), and genuinely pending text (`❯<NBSP>text`) still classifies `pending`. Normalization is kept to the empirically observed NBSP rather than speculatively handling other Unicode spaces.

## Also included: making two test suites hermetic

This branch carries a second, self-contained change, committed separately (`fix(tests): make missing-tool suites hermetic against ambient toolchains`). It is not part of the composer fix, and it is honest to call it out rather than bury it.

`tests/fm-bootstrap.test.sh` and `tests/fm-session-start.test.sh` check missing-tool detection by building a fakebin that deliberately omits a tool and asserting the bootstrap prints `MISSING: <tool>`. But they prepended that fakebin to the *real* system directories, so an omitted tool that happens to exist on the developer's machine silently satisfied the probe and the assertion failed. Two real collisions: `/usr/bin/orca` is the GNOME screen reader (unrelated to the Orca backend — it merely shares the name), and `/usr/bin/node` is an ordinary Node install. Because `/bin` is a usrmerge symlink to `/usr/bin`, the suites' own `FM_TEST_BASE_PATH` escape hatch could not dodge them.

These suites therefore fail on unmodified `main` for any contributor whose machine has either tool; CI stays green only because its runners happen to have neither. `tests/lib.sh` gains `fm_test_base_path`, a sanitized bin dir that mirrors the real base dirs' executables *except* the tools these suites supply through their own fakebin, so the ambient machine can never satisfy a probe the test means to see fail. The withheld set is derived from the bootstrap's own `TOOLS` lists and validated before use, failing loudly rather than silently degrading to a partial blocklist. No assertion was deleted or weakened.

Why it rides along here rather than landing separately: it is what lets the composer suite pass locally on a machine with those tools present, so the two changes were developed and verified together. Reviewers who prefer it split out should say so and I'll happily separate it.

## Verification

Shellcheck clean over `bin/*.sh bin/backends/*.sh tests/*.sh`, `bin/fm-lint.sh` clean under pinned ShellCheck 0.11.0, and the full `tests/*.test.sh` sweep green.

Contributed from a fork (`lmansf/firstmate`) with the PR opened against `kunchenguid/firstmate`, per CONTRIBUTING.md's documented fork flow.

## What Changed

- `fm_composer_classify_content` in `bin/fm-composer-lib.sh` now normalizes U+00A0 (NO-BREAK SPACE) to a plain space and re-trims both content views before any glyph matching, with the byte hoisted into a source-time `FM_COMPOSER_NBSP` constant. Claude Code 2.1.x draws its unbordered composer prompt as `❯` + NBSP, which no `[[:space:]]` trim removes, so an empty composer classified as `pending` and every multi-word `bin/fm-send.sh` text send to a claude pane exhausted the Enter-retry loop and exited 1 even though the text had submitted. Fixing it in the single shared classifier fixes all four backend adapters (tmux, herdr, orca, cmux) at once; the dead-shell `unknown` verdict and genuinely-pending text are preserved.
- `tests/lib.sh` gains `fm_test_base_path`, a cached sanitized bin dir that mirrors the real base dirs' executables except the tools `tests/fm-bootstrap.test.sh` and `tests/fm-session-start.test.sh` supply through their own fakebin. The withheld set is derived from bootstrap's own `TOOLS` lists and validated before use. Previously an ambient `/usr/bin/orca` (the GNOME screen reader) or `/usr/bin/node` silently satisfied a probe the suite meant to see fail, breaking those suites on any contributor machine that has them.
- New regression fixtures in `tests/fm-composer-lib.test.sh` and `tests/fm-composer-ghost.test.sh` cover the `❯`+NBSP empty row, the queued-message hint row, and NBSP-plus-typed-text still reading `pending`; the incident is written up in `docs/tmux-backend.md` and the claude composer quirk recorded in the `harness-adapters` skill.

Review flagged four informational items only (a now-obsolete trap workaround in `tests/wake-helpers.sh`, the mirror-dir fork cost, a repeated trim idiom, and the intentional NBSP-only-is-empty tradeoff); tests, lint, and document all passed.

## Risk Assessment

✅ Low: The behavior change is a narrow, empirically-grounded NBSP normalization in the single shared classifier, with regression fixtures pinning both the fixed case and the preserved pending/unknown safety verdicts; the test-only changes fix real hermeticity and temp-root cleanup bugs without weakening any assertion, and the residual findings are cosmetic or informational.

## Testing

The already-green baseline sweep covers the suite; on top of it I reproduced the reported bug live and proved the fix end-to-end. Against a real tmux pane drawing Claude Code's actual `❯`+NBSP composer (bytes confirmed by hexdump), the base-commit fm-send.sh exits 1 with "Enter swallowed" even though the pane transcript shows the steer submitted — and its Enter-retry loop fires stray empty submits at the already-clean composer — while the branch exits 0 with exactly one submit and still exits 1 against a pane that genuinely withholds Enter. Separately, this machine has the ambient /usr/bin/orca and /usr/bin/node collisions, so the bootstrap and session-start suites demonstrably fail at the base commit and pass on the branch, confirming the hermetic-PATH change fixes a real contributor-facing failure. This is a terminal/CLI surface, so the reviewer-visible evidence is a CLI transcript rather than a screenshot. No findings; worktree left clean and scratch tmux sessions removed.

<details>
<summary>Evidence: Live fm-send e2e transcript vs a Claude-style NBSP composer (base false-failure → branch exit 0 → genuine-swallow still exit 1)</summary>

<code>fm-send submit verification vs a live Claude-Code-style composer (tmux 3.4, real tmux session)&#10;Pane draws claude 2.1.x&#39;s unbordered prompt: U+276F + U+00A0 (bytes e2 9d af c2 a0)&#10;&#10;$ tmux capture-pane -p -S $cy -E $cy | hexdump -C # empty composer row&#10;00000000 e2 9d af c2 a0 0a |......|&#10;&#10;[1/3] BASE ad9f3a7 (pre-fix) -- $ fm-send.sh steer-l2 &#39;fix findings 1 and 3&#39;&#10;error: text not submitted to fmnbsp:fm-steer-l2 (Enter swallowed; text left in composer; ...)&#10;exit: 1 &lt;-- FALSE FAILURE&#10;pane, however, shows the send landed (and the Enter-retry loop fired 2 stray empty submits):&#10;&gt;&gt; SUBMITTED TO AGENT: fix findings 1 and 3&#10;&gt;&gt; SUBMITTED TO AGENT:&#10;&gt;&gt; SUBMITTED TO AGENT:&#10;&#10;[2/3] BRANCH de71d7b (NBSP fix) -- same pane, same send&#10;exit: 0 &lt;-- correct&#10;pane: exactly one submit, composer back to empty:&#10;fake claude pane (mode=accept)&#10;&gt;&gt; SUBMITTED TO AGENT: fix findings 1 and 3&#10;❯&#10;&#10;[3/3] BRANCH de71d7b -- pane that GENUINELY swallows Enter (regression guard)&#10;error: text not submitted to fmnbsp2:fm-steer-l2 (Enter swallowed; text left in composer; ...)&#10;exit: 1 &lt;-- real swallow still reported&#10;fake claude pane (mode=swallow)&#10;❯ fix findings 1 and 3</code>

```text
fm-send submit verification vs a live Claude-Code-style composer (tmux 3.4, real tmux session)
Pane draws claude 2.1.x's unbordered prompt: U+276F + U+00A0 (bytes e2 9d af c2 a0)

$ tmux capture-pane -p -S $cy -E $cy | hexdump -C     # empty composer row
00000000  e2 9d af c2 a0 0a                                 |......|

[1/3] BASE ad9f3a7 (pre-fix) -- $ fm-send.sh steer-l2 'fix findings 1 and 3'
error: text not submitted to fmnbsp:fm-steer-l2 (Enter swallowed; text left in composer; tried meta=/tmp/no-mistakes-evidence/01KXB5DE247KM64KGNKWZ5S5S1/fmhome/state/steer-l2.meta; backend=from-meta)
  exit: 1   <-- FALSE FAILURE
  pane, however, shows the send landed (and the Enter-retry loop fired 2 stray empty submits):
    >> SUBMITTED TO AGENT: fix findings 1 and 3
    >> SUBMITTED TO AGENT:
    >> SUBMITTED TO AGENT:

[2/3] BRANCH de71d7b (NBSP fix) -- same pane, same send
  exit: 0   <-- correct
  pane: exactly one submit, composer back to empty:
   fake claude pane (mode=accept)
    >> SUBMITTED TO AGENT: fix findings 1 and 3
  ❯ 

[3/3] BRANCH de71d7b -- pane that GENUINELY swallows Enter (regression guard)
error: text not submitted to fmnbsp2:fm-steer-l2 (Enter swallowed; text left in composer; tried meta=/tmp/no-mistakes-evidence/01KXB5DE247KM64KGNKWZ5S5S1/fmhome/state/steer-l2.meta; backend=from-meta)
  exit: 1   <-- real swallow still reported
   fake claude pane (mode=swallow)
  ❯ fix findings 1 and 3
```
</details>
<details>
<summary>Evidence: Hermetic-PATH fix: same two suites at base commit vs branch, on a machine with ambient orca + node</summary>

<code>### ON BASE ad9f3a7 (before the hermetic-PATH fix), same machine (/usr/bin/orca + /usr/bin/node present)&#10;== tests/fm-bootstrap.test.sh ==&#10;not ok - backend=orca should require only the Orca-specific missing tool, got:&#10;-- exit: 1&#10;== tests/fm-session-start.test.sh ==&#10;not ok - MISSING diagnostic did not appear at all&#10;-- exit: 1&#10;&#10;### ON BRANCH fm/fmsend-verify-l2 (with the hermetic-PATH fix), same machine&#10;== tests/fm-bootstrap.test.sh ==&#10;-- exit: 0&#10;== tests/fm-session-start.test.sh ==&#10;-- exit: 0</code>

```text
### ON BASE ad9f3a7 (before the hermetic-PATH fix), same machine (/usr/bin/orca + /usr/bin/node present)
== tests/fm-bootstrap.test.sh ==
not ok - backend=orca should require only the Orca-specific missing tool, got: 
-- exit: 1
== tests/fm-session-start.test.sh ==
not ok - MISSING diagnostic did not appear at all
-- exit: 1
```
</details>
<details>
<summary>Evidence: Claude-composer pane emulator used to drive the live e2e (draws U+276F + U+00A0; accept/swallow modes)</summary>

```text
#!/usr/bin/env bash
# Minimal stand-in for a Claude Code 2.1.x pane: UNBORDERED composer whose
# prompt glyph is U+276F followed by a NO-BREAK SPACE (U+00A0), exactly the
# bytes (e2 9d af c2 a0) captured live from claude v2.1.207.
#   $1 = accept  -> Enter submits and clears the composer (normal claude)
#   $1 = swallow -> Enter is ignored, text stays in the composer (raw-tty pane)
mode=${1:-accept}
buf=""
draw() { printf '\r\033[2K\033[38;5;246m\xe2\x9d\xaf\xc2\xa0\033[39m%s' "$buf"; }
printf '\033[2J\033[H fake claude pane (mode=%s)\n' "$mode"
draw
while IFS= read -rsn1 c; do
  if [ -z "$c" ]; then
    if [ "$mode" = accept ]; then
      printf '\r\033[2K  >> SUBMITTED TO AGENT: %s\n' "$buf"; buf=""; draw
    fi
  else
    buf="$buf$c"; draw
  fi
done
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 4 infos</summary>

- ℹ️ `tests/wake-helpers.sh:40` - tests/wake-helpers.sh still carries the workaround this branch obsoleted: it hand-rolls `mktemp -d` plus `if [ &#34;${#FM_TEST_CLEANUP_DIRS[@]}&#34; -eq 0 ]; then trap fm_test_cleanup EXIT; fi` with a comment describing the old subshell-trap hazard that lib.sh now fixes with the registry file. Because `fm_test_tmproot` no longer appends to `FM_TEST_CLEANUP_DIRS`, that array is now always empty at source time, so the condition is always true and wake-helpers unconditionally re-installs the EXIT trap. It is harmless today (every consumer sources it immediately after lib.sh, before installing its own trap), but it would silently clobber a caller-installed EXIT trap if any future suite sources wake-helpers later. It can now simply call `fm_test_tmproot` and drop the trap line and the stale comment.
- ℹ️ `tests/lib.sh:190` - fm_test_base_path mirrors every executable in /usr/bin, /bin, /usr/sbin, /sbin with one `ln -s` process each, which is on the order of two thousand forks per test process, paid by both fm-bootstrap.test.sh and fm-session-start.test.sh even for cases that do not exercise missing-tool detection. It is cached per process so this is bounded, but the same hermetic guarantee could be had far more cheaply by keeping the real dirs on PATH and prepending a shim dir that shadows each blocklisted name with a non-executable placeholder or a `exit 127` stub — worth considering if the suites&#39; runtime becomes noticeable.
- ℹ️ `bin/fm-composer-lib.sh:208` - The whitespace-trim idiom (`${v#&#34;${v%%[![:space:]]*}&#34;}` / `${v%&#34;${v##*[![:space:]]}&#34;}`) is now repeated six times inside fm_composer_classify_content and again in each adapter&#39;s row extraction. A small `fm_composer_trim &lt;var&gt;` helper in the shared owner would remove the duplication without changing behavior; the adapters could reuse it too.
- ℹ️ `bin/fm-composer-lib.sh:205` - A composer whose only unsubmitted content is NBSP whitespace now classifies `empty` rather than `pending`, so a submit-verification against such a row would report success. This is an intentional, documented tradeoff (the comment states a row of only NBSPs is visually empty) and the scenario is not reachable from firstmate&#39;s own sends, which never type a bare NBSP. Noting it only so the tradeoff is visible in review.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- <code>Live tmux e2e: real tmux 3.4 session running a Claude-2.1.x-style composer pane (`❯` + U+00A0, hexdump-confirmed as `e2 9d af c2 a0`), driving `FM_HOME=... bin/fm-send.sh steer-l2 &#39;fix findings 1 and 3&#39;` from the BASE commit (exit 1, false failure, text nonetheless submitted) and from the BRANCH (exit 0, single submit)</code>
- <code>Live tmux e2e regression guard: branch `bin/fm-send.sh` against a pane that genuinely swallows Enter — still exits 1 with text correctly reported left in the composer</code>
- <code>`bash tests/fm-bootstrap.test.sh` and `bash tests/fm-session-start.test.sh` on branch (pass) vs. at base commit ad9f3a7 on the same machine with ambient /usr/bin/orca and /usr/bin/node present (both fail: &#34;backend=orca should require only the Orca-specific missing tool&#34;, &#34;MISSING diagnostic did not appear at all&#34;)</code>
- <code>`bash tests/fm-composer-lib.test.sh` (incl. new `❯`+NBSP empty and NBSP-normalization safety cases)</code>
- <code>`bash tests/fm-composer-ghost.test.sh` (incl. new claude NBSP empty / queued-hint / typed-text-still-pending fixtures)</code>
- <code>`bash tests/fm-send-strict.test.sh`, `bash tests/fm-send-settle.test.sh`</code>
- <code>`bash tests/fm-daemon.test.sh`, `bash tests/fm-crew-state.test.sh`, `bash tests/fm-backend.test.sh` (composer-lib consumers)</code>
- <code>Baseline (pre-run): full `tests/*.test.sh` sweep green</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

