### PR TITLE
fix(fm-lock): harness-pid discovery works when ps is blind

### DIFF
--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -3,6 +3,12 @@
 # Writes the harness (agent) process PID found by walking the shell's ancestry,
 # which lives as long as the firstmate session - unlike the transient subshell
 # PID of any one tool call, which is dead moments after it is written.
+# The harness PID is resolved, in order: an explicit FM_HARNESS_PID override
+# (liveness-verified via kill -0), an ancestry walk via ps, or - when ps cannot
+# see the shell's own ancestry but a verified harness env marker is present
+# (e.g. Claude Code's sandboxed Bash tool, which reports "no such process" for
+# its own $$) - the shell's own $$, trusted via the marker since ps cannot
+# confirm it. Liveness is checked with kill -0, which works where ps is blind.
 # Usage: fm-lock.sh           acquire; exit 1 if another live session holds it
 #        fm-lock.sh status    print holder and liveness; always exits 0
 set -u
@@ -15,12 +21,43 @@ LOCK="$STATE/.lock"
 mkdir -p "$STATE"
 
 # Known harness command names; extend when a new adapter is verified.
+# ^pi$ matches the bare basename "pi" exactly; the unanchored alternatives
+# match claude/codex/opencode/grok as substrings of a basename (e.g. codex-cli).
 HARNESS_RE='claude|codex|opencode|grok|^pi$'
+
+# True if $1 is a positive integer naming a live process. Uses kill -0, not ps,
+# so it works where ps cannot see the process (e.g. Claude Code's Bash tool,
+# whose sandbox reports "no such process" for its own $$).
+live_pid() {
+  case "${1:-}" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+  [ "$1" -gt 0 ] 2>/dev/null || return 1
+  kill -0 "$1" 2>/dev/null
+}
+
+# True if a verified harness environment marker is present. Mirrors the
+# env-marker layer of bin/fm-harness.sh's detect_own; extend both in lockstep
+# when a new adapter gains a marker.
+harness_env_marker() {
+  [ "${CLAUDECODE:-}" = "1" ] && return 0
+  [ "${PI_CODING_AGENT:-}" = "true" ] && return 0
+  [ "${GROK_AGENT:-}" = "1" ] && return 0
+  return 1
+}
 
 harness_pid() {
   local pid=$$ comm args
+  # Escape hatch for a harness whose bash sandbox cannot traverse its own
+  # ancestry via ps (Claude Code's Bash tool reports "no such process" for $$
+  # itself): the operator or a harness adapter may set FM_HARNESS_PID to a live
+  # process id trusted as the session's harness. Verified only by liveness; the
+  # setter vouches for the identity ps cannot confirm.
+  if [ -n "${FM_HARNESS_PID:-}" ] && live_pid "$FM_HARNESS_PID"; then
+    echo "$FM_HARNESS_PID"; return 0
+  fi
   for _ in 1 2 3 4 5 6 7 8; do
-    comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
+    comm=$(ps -o comm= -p "$pid" 2>/dev/null) || break
     args=$(ps -o args= -p "$pid" 2>/dev/null)
     if printf '%s' "$(basename "$comm")" | grep -qE "$HARNESS_RE"; then
       echo "$pid"; return 0
@@ -30,16 +67,42 @@ harness_pid() {
       *node*|*python*) printf '%s' "$args" | grep -qE "$HARNESS_RE" && { echo "$pid"; return 0; } ;;
     esac
     pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
-    [ -n "$pid" ] && [ "$pid" -gt 1 ] || return 1
+    [ -n "$pid" ] && [ "$pid" -gt 1 ] || break
   done
+  # Fallback when ps cannot see our own ancestry but a verified harness env
+  # marker confirms we run inside a harness anyway. bash's $$ is the long-lived
+  # main shell (durable across tool calls for a persistent-shell harness; for a
+  # per-command shell it is transient, but the next acquire re-verifies liveness
+  # via kill -0 and re-acquires harmlessly). This unblocks a ps-blind session
+  # that would otherwise leave session-start stuck in read-only mode.
+  if harness_env_marker && live_pid "$$"; then
+    echo "$$"; return 0
+  fi
   return 1
 }
 
 holder_alive() {  # true if $1 is a live process that looks like a harness
-  local pid=$1 comm
-  kill -0 "$pid" 2>/dev/null || return 1
-  comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
-  printf '%s' "$(basename "$comm") $(ps -o args= -p "$pid" 2>/dev/null)" | grep -qE "$HARNESS_RE"
+  local pid=$1 comm base args
+  live_pid "$pid" || return 1
+  comm=$(ps -o comm= -p "$pid" 2>/dev/null) || {
+    # ps cannot inspect the holder (e.g. a ps-blind sandbox session that wrote
+    # its own $$): kill -0 says it is live, so fail safe - treat an
+    # uninspectable live holder as held rather than let a second session steal
+    # the lock based on our own blindness.
+    return 0
+  }
+  # Match the basename exactly as harness_pid does, so a pi-held lock (basename
+  # "pi") is recognized. The prior "<basename> <args>" concatenation grepped
+  # with ^pi$ against "pi pi" and never matched, so a second pi session could
+  # clobber a live one.
+  base=$(basename "$comm")
+  printf '%s' "$base" | grep -qE "$HARNESS_RE" && return 0
+  case "$comm" in
+    *node*|*python*)
+      args=$(ps -o args= -p "$pid" 2>/dev/null)
+      printf '%s' "$args" | grep -qE "$HARNESS_RE" && return 0 ;;
+  esac
+  return 1
 }
 
 if [ "${1:-}" = "status" ]; then

--- a/tests/fm-lock.test.sh
+++ b/tests/fm-lock.test.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# tests/fm-lock.test.sh - per-home session lock: harness-pid discovery and
+# holder liveness. Covers the ps-walk ancestry path, the FM_HARNESS_PID override
+# for a harness whose bash sandbox cannot traverse its own ancestry via ps
+# (Claude Code's Bash tool reports "no such process" for its own $$), the
+# env-marker fallback that unblocks such a ps-blind session, and the holder
+# liveness checks - the pi basename match (the prior "<basename> <args>" + ^pi$
+# concatenation never matched a live pi holder, so a second pi session could
+# clobber a live one) and the ps-blind fail-safe (an uninspectable live holder
+# is treated as held rather than stolen). These are safety-critical process
+# invariants, so they run against real live PIDs and a fake ps.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+LOCK="$ROOT/bin/fm-lock.sh"
+TMP=$(fm_test_tmproot fm-lock-tests)
+
+# fake ps that always fails (simulates a sandbox blind to every process, as
+# Claude Code's Bash tool reports "no such process" for its own $$).
+fakebin_ps_fail() {
+  local fb; fb=$(fm_fakebin "$1")
+  cat > "$fb/ps" <<'SH'
+#!/usr/bin/env bash
+exit 1
+SH
+  chmod +x "$fb/ps"
+  printf '%s\n' "$fb"
+}
+
+# fake ps that reports comm "pi" / args "pi" for the pid in FM_FAKE_PS_PID
+# (a real pi harness process has basename "pi"); every other pid is invisible.
+fakebin_ps_pi() {
+  local fb; fb=$(fm_fakebin "$1")
+  cat > "$fb/ps" <<'SH'
+#!/usr/bin/env bash
+fmt= p=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) fmt=$2; shift 2 ;;
+    -p) p=$2; shift 2 ;;
+    *) shift ;;
+  esac
+done
+[ "$p" = "${FM_FAKE_PS_PID:-}" ] || exit 1
+case "$fmt" in
+  comm=) printf 'pi\n' ;;
+  args=) printf 'pi\n' ;;
+  *) exit 1 ;;
+esac
+SH
+  chmod +x "$fb/ps"
+  printf '%s\n' "$fb"
+}
+
+test_holder_pi_basename_recognized() {
+  local dir fb state child out
+  dir="$TMP/holder-pi"
+  state="$dir/state"; mkdir -p "$state"
+  fb=$(fakebin_ps_pi "$dir/fb")
+  sleep 30 & child=$!
+  printf '%s\n' "$child" > "$state/.lock"
+  out=$(env PATH="$fb:$PATH" FM_FAKE_PS_PID="$child" FM_STATE_OVERRIDE="$state" \
+        "$LOCK" status 2>&1)
+  kill "$child" 2>/dev/null; wait "$child" 2>/dev/null || true
+  [ "$out" = "lock: held by live harness pid $child" ] \
+    || fail "pi holder misreported: '$out' (expected held)"
+  pass "pi holder recognized via basename (was 'stale' before fix)"
+}
+
+test_env_marker_fallback_acquires_when_ps_blind() {
+  local dir fb state out rc
+  dir="$TMP/env-fallback"
+  state="$dir/state"; mkdir -p "$state"
+  fb=$(fakebin_ps_fail "$dir/fb")
+  out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
+        CLAUDECODE=1 PI_CODING_AGENT= GROK_AGENT= \
+        PATH="$fb:$PATH" FM_STATE_OVERRIDE="$state" "$LOCK" 2>&1); rc=$?
+  [ "$rc" -eq 0 ] || fail "env-marker fallback did not acquire (exit $rc): $out"
+  case "$out" in
+    "lock acquired: harness pid "*) ;;
+    *) fail "env-marker fallback wrong output: '$out'" ;;
+  esac
+  pass "env-marker fallback acquires when ps is blind (claude unblocked)"
+}
+
+test_harness_pid_override_acquires_when_ps_blind() {
+  local dir fb state child out rc
+  dir="$TMP/override"
+  state="$dir/state"; mkdir -p "$state"
+  fb=$(fakebin_ps_fail "$dir/fb")
+  sleep 30 & child=$!
+  out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
+        CLAUDECODE= PI_CODING_AGENT= GROK_AGENT= \
+        PATH="$fb:$PATH" FM_STATE_OVERRIDE="$state" FM_HARNESS_PID="$child" \
+        "$LOCK" 2>&1); rc=$?
+  kill "$child" 2>/dev/null; wait "$child" 2>/dev/null || true
+  [ "$rc" -eq 0 ] || fail "FM_HARNESS_PID override did not acquire (exit $rc): $out"
+  [ "$out" = "lock acquired: harness pid $child" ] \
+    || fail "override wrong output: '$out'"
+  pass "FM_HARNESS_PID override acquires when ps is blind"
+}
+
+test_ps_blind_live_holder_not_stolen() {
+  local dir fb state child out rc
+  dir="$TMP/ps-blind-held"
+  state="$dir/state"; mkdir -p "$state"
+  fb=$(fakebin_ps_fail "$dir/fb")
+  sleep 30 & child=$!
+  printf '%s\n' "$child" > "$state/.lock"
+  out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
+        CLAUDECODE= PI_CODING_AGENT= GROK_AGENT= \
+        PATH="$fb:$PATH" FM_STATE_OVERRIDE="$state" FM_HARNESS_PID="$$" \
+        "$LOCK" 2>&1); rc=$?
+  kill "$child" 2>/dev/null; wait "$child" 2>/dev/null || true
+  [ "$rc" -eq 1 ] || fail "ps-blind live holder was stolen (exit $rc): $out"
+  case "$out" in
+    *"another live firstmate session holds the lock"*) ;;
+    *) fail "ps-blind holder refusal wrong output: '$out'" ;;
+  esac
+  pass "ps-blind live holder is not stolen (fail-safe held)"
+}
+
+test_holder_dead_pid_is_stale() {
+  local dir fb state out dead
+  dir="$TMP/holder-dead"
+  state="$dir/state"; mkdir -p "$state"
+  fb=$(fm_fakebin "$dir/fb")
+  dead=999999
+  while kill -0 "$dead" 2>/dev/null; do dead=$((dead + 1)); done
+  printf '%s\n' "$dead" > "$state/.lock"
+  out=$(env PATH="$fb:$PATH" FM_STATE_OVERRIDE="$state" "$LOCK" status 2>&1)
+  [ "$out" = "lock: stale (pid $dead dead or not a harness)" ] \
+    || fail "dead holder misreported: '$out'"
+  pass "dead holder pid is stale"
+}
+
+test_harness_pid_override_rejects_dead() {
+  # A dead FM_HARNESS_PID must not be used; harness_pid falls through. With ps
+  # also blind and no env marker, acquire must fail rather than write a dead pid.
+  local dir fb state dead out rc
+  dir="$TMP/override-dead"
+  state="$dir/state"; mkdir -p "$state"
+  fb=$(fakebin_ps_fail "$dir/fb")
+  dead=999998
+  while kill -0 "$dead" 2>/dev/null; do dead=$((dead + 1)); done
+  out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
+        CLAUDECODE= PI_CODING_AGENT= GROK_AGENT= \
+        PATH="$fb:$PATH" FM_STATE_OVERRIDE="$state" FM_HARNESS_PID="$dead" \
+        "$LOCK" 2>&1); rc=$?
+  [ "$rc" -eq 1 ] || fail "dead FM_HARNESS_PID was accepted (exit $rc): $out"
+  case "$out" in
+    *"cannot locate harness process in ancestry"*) ;;
+    *) fail "dead override wrong output: '$out'" ;;
+  esac
+  pass "dead FM_HARNESS_PID rejected, acquire falls through and fails"
+}
+
+test_holder_dead_pid_is_stale
+test_holder_pi_basename_recognized
+test_env_marker_fallback_acquires_when_ps_blind
+test_harness_pid_override_acquires_when_ps_blind
+test_harness_pid_override_rejects_dead
+test_ps_blind_live_holder_not_stolen


### PR DESCRIPTION
## Problem

`bin/fm-lock.sh` could not acquire the per-home session lock from a harness whose bash sandbox cannot traverse its own ancestry via `ps`. Reported from Claude Code (Sonnet 5): `fm-lock.sh` always exited 1 with `error: cannot locate harness process in ancestry`, regardless of lock state (absent, stale, or held). This left `fm-session-start.sh` stuck in read-only mode, so the locked bootstrap sweeps (fleet sync, wake-drain) never ran.

Reproduced identically:
- Inside Claude Code's sandboxed Bash tool.
- Via Claude Code's `!` direct-shell passthrough.

Root cause: `harness_pid()` walked 8 ancestors from `\$\$` using `ps -o comm=`, but `ps -p \$\$` reported `no such process` in that session's shell context - the script's own PID was invisible to `ps`.

A second, pre-existing bug in `holder_alive()` meant a pi-held lock was always reported `stale`: it built `"<basename(comm)> <args>"` = `"pi pi"` and grepped with `^pi\$`, which requires the whole line to be `pi`. The concatenation never matched, so a second pi session could clobber a live one.

## Fix

`harness_pid()` now resolves the harness PID in order:
1. `FM_HARNESS_PID` env override - liveness-verified via `kill -0` (works where `ps` is blind). Escape hatch for any harness whose bash sandbox breaks `ps` ancestry.
2. The existing `ps` ancestry walk - unchanged for harnesses where `ps` works (pi in a normal terminal, etc.).
3. Env-marker fallback - when `ps` cannot see our own ancestry but a verified harness marker is present (`CLAUDECODE=1`, `PI_CODING_AGENT=true`, `GROK_AGENT=1`), trust `\$\$` via the marker. `kill -0` confirms liveness.

`holder_alive()` now:
- Matches the basename exactly (as `harness_pid` does), so a pi-held lock (basename `pi`) is recognized. The prior `"<basename> <args>"` + `^pi\$` concatenation never matched.
- Fails safe when `ps` cannot inspect the holder: `kill -0` says live, so treat an uninspectable live holder as held rather than let a second session steal the lock based on our own blindness.

## Verification (empirical, per CONTRIBUTING harness-detection rule)

- `bash -n` syntax check on the whole toolbelt: clean.
- `bin/fm-lint.sh` canonical set (ShellCheck 0.11.0, pinned): exit 0.
- `bash tests/fm-lock.test.sh`: 6/6 pass.
- `holder_alive` against a real pi process (PID of a live `pi` harness): now reports `held by live harness` (was `stale` before fix).
- env-marker fallback with a ps-blind fake `ps` + `CLAUDECODE=1`: acquires (was `cannot locate harness`).
- `FM_HARNESS_PID` override with a ps-blind fake `ps` + a live child PID: acquires.
- Dead `FM_HARNESS_PID` rejected; acquire falls through and fails (no dead PID written to the lock).
- ps-blind live holder not stolen: a second acquire against a ps-blind held lock refuses with `another live firstmate session holds the lock`.
- Symlink checks: `CLAUDE.md -> AGENTS.md`, `.claude/skills -> ../.agents/skills` OK.

## Scope

Only `bin/fm-lock.sh` (session lock) plus a colocated `tests/fm-lock.test.sh`. No changes to spawn, watcher, or harness-detection mechanics. The env-marker list mirrors `bin/fm-harness.sh`'s `detect_own` layer 1; extend both in lockstep when a new adapter gains a marker.