### PR TITLE
feat(pi): inject Axi SessionStart context

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -70,7 +70,7 @@ Do not substitute another harness's wait shape when resuming supervision.
 Claude and Grok use tracked background-notify cycles around `bin/fm-watch-arm.sh`.
 Codex uses bounded foreground checkpoints through `bin/fm-watch-checkpoint.sh` because Codex cannot reason while a foreground tool call is running.
 OpenCode uses `.opencode/plugins/fm-primary-watch-arm.js`, which coordinates with the turn-end guard plugin and wakes the TUI with `client.session.promptAsync`.
-Pi uses the tracked `.pi/extensions/fm-primary-turnend-guard.ts` plus the tracked `.pi/extensions/fm-primary-pi-watch.ts`, both project-local extensions Pi auto-discovers once trusted.
+Pi uses the tracked `.pi/extensions/fm-primary-turnend-guard.ts`, `.pi/extensions/fm-primary-pi-watch.ts`, and `.pi/extensions/fm-primary-session-context.ts`, which Pi auto-discovers once the project is trusted.
 When changing any primary watcher adapter, update `docs/supervision-protocols/`, `docs/turnend-guard.md` if a shared idle or turn-end hook changed, and the relevant concise fact below.
 
 ## Launch profile axes
@@ -207,7 +207,7 @@ Without `deliverAs: "followUp"`, Pi rejects the send while the agent is still pr
 Pi's primary watcher protocol also requires the tracked `.pi/extensions/fm-primary-pi-watch.ts` extension, same trust-once discovery as the turn-end guard.
 The model arms through `fm_watch_arm_pi`, never a foreground bash arm; the watcher tool result and clean-exit fallback are owned by `docs/supervision-protocols/pi.md`.
 `bin/fm-session-start.sh` reports when the live Pi session has not loaded both the turn-end guard and watcher extensions, and points at plain `pi` after project trust as the fix, with `-e` as a trust-free fallback.
-When a secondmate is launched on Pi, `fm-spawn.sh --secondmate` launches Pi with both `-e .pi/extensions/fm-primary-turnend-guard.ts` and `-e .pi/extensions/fm-primary-pi-watch.ts`, both already present in the secondmate home's git worktree.
+When a secondmate is launched on Pi, `fm-spawn.sh --secondmate` launches Pi with explicit `-e` paths for all three tracked primary extensions already present in the secondmate home's git worktree.
 
 ## grok (VERIFIED 2026-06-29, grok 0.2.73; slash-submit behavior re-verified 2026-07-03, grok 0.2.82)
 

--- a/.pi/extensions/fm-primary-session-context.ts
+++ b/.pi/extensions/fm-primary-session-context.ts
@@ -1,0 +1,110 @@
+// Firstmate-owned Pi equivalent of the supported Codex SessionStart CLI hooks.
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+const CONTEXT_TYPE = "firstmate-axi-session-context";
+const COMMAND_TIMEOUT_MS = 10_000;
+const MAX_TOOL_BYTES = 12_000;
+const MAX_TOOL_LINES = 160;
+
+const CONTEXT_COMMANDS = [
+  "tasks-axi",
+  "gh-axi",
+  "lavish-axi",
+  "chrome-devtools-axi",
+] as const;
+
+type ExecResult = {
+  stdout?: string;
+  stderr?: string;
+  code?: number | null;
+  killed?: boolean;
+};
+
+function cleanOutput(value: string): string {
+  return value
+    .replace(/\x1b\[[0-?]*[ -\/]*[@-~]/g, "")
+    .replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g, "")
+    .replace(/\r\n?/g, "\n")
+    .trim();
+}
+
+export function truncateContext(value: string): { text: string; truncated: boolean } {
+  const lines = cleanOutput(value).split("\n");
+  let text = lines.slice(0, MAX_TOOL_LINES).join("\n");
+  let truncated = lines.length > MAX_TOOL_LINES;
+  const bytes = Buffer.from(text);
+  if (bytes.byteLength > MAX_TOOL_BYTES) {
+    text = bytes.subarray(0, MAX_TOOL_BYTES).toString("utf8").replace(/\ufffd$/, "");
+    truncated = true;
+  }
+  return { text, truncated };
+}
+
+function sessionHasContext(ctx: any): boolean {
+  return ctx.sessionManager.getBranch().some((entry: any) =>
+    entry?.type === "message" && entry?.message?.customType === CONTEXT_TYPE,
+  );
+}
+
+async function commandContext(pi: ExtensionAPI, command: string): Promise<string> {
+  let result: ExecResult;
+  try {
+    result = await pi.exec(command, [], { timeout: COMMAND_TIMEOUT_MS });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return `### ${command}\nUnavailable: ${cleanOutput(message) || "command failed"}`;
+  }
+
+  const combined = [result.stdout, result.stderr].filter(Boolean).join("\n");
+  const output = truncateContext(combined);
+  if (result.killed) return `### ${command}\nUnavailable: timed out after ${COMMAND_TIMEOUT_MS}ms`;
+  if (result.code !== 0) {
+    const detail = output.text ? `\n${output.text}` : "";
+    return `### ${command}\nUnavailable: exited ${result.code ?? "without a status"}${detail}`;
+  }
+  if (!output.text) return `### ${command}\nAvailable, but returned no startup guidance.`;
+  return `### ${command}\n${output.text}${output.truncated ? "\n[Startup guidance truncated by Firstmate.]" : ""}`;
+}
+
+export default function (pi: ExtensionAPI) {
+  let context = "";
+  let injected = false;
+
+  pi.on("session_start", async (_event, ctx) => {
+    injected = sessionHasContext(ctx);
+    context = "";
+    if (injected) return;
+
+    const blocks: string[] = [];
+    for (const command of CONTEXT_COMMANDS) {
+      blocks.push(await commandContext(pi, command));
+    }
+    context = [
+      "Firstmate Pi startup context",
+      "These are CLI guidance blocks, not Pi tool registrations or MCP servers.",
+      "Call the named programs through Pi's bash tool.",
+      ...blocks,
+      "### Related interfaces",
+      "- quota-axi is a read-only, on-demand quota CLI with no SessionStart contract; use `quota-axi --help` before calling it.",
+      "- axi is the shared SDK/runtime used by the *-axi CLIs and does not expose an `axi` executable.",
+      "- treehouse is an independent worktree lifecycle CLI; use `treehouse --help` and follow Firstmate's lifecycle rules.",
+    ].join("\n\n");
+  });
+
+  pi.on("before_agent_start", () => {
+    if (injected || !context) return;
+    injected = true;
+    return {
+      message: {
+        customType: CONTEXT_TYPE,
+        content: context,
+        display: false,
+      },
+    };
+  });
+
+  pi.on("session_shutdown", () => {
+    context = "";
+    injected = false;
+  });
+}

--- a/.pi/extensions/fm-primary-session-context.ts
+++ b/.pi/extensions/fm-primary-session-context.ts
@@ -75,10 +75,9 @@ export default function (pi: ExtensionAPI) {
     context = "";
     if (injected) return;
 
-    const blocks: string[] = [];
-    for (const command of CONTEXT_COMMANDS) {
-      blocks.push(await commandContext(pi, command));
-    }
+    const blocks = await Promise.all(
+      CONTEXT_COMMANDS.map((command) => commandContext(pi, command)),
+    );
     context = [
       "Firstmate Pi startup context",
       "These are CLI guidance blocks, not Pi tool registrations or MCP servers.",

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ pi
 ```
 
 For Grok, `--trust` is needed once per clone so project hooks and the turn-end guard load; `/hooks-trust` inside Grok works too.
-For Pi, approve the project trust prompt once per clone on first launch so both tracked `.pi/extensions/*.ts` files auto-load.
+For Pi, approve the project trust prompt once per clone on first launch so the tracked `.pi/extensions/*.ts` files auto-load.
 
 ### Talk to it
 
@@ -193,6 +193,7 @@ Firstmate's skills live in two separate places with different audiences:
 - [docs/codex-app-backend.md](docs/codex-app-backend.md) - Codex App backend boundary, evidence, and rollout contract.
 - [docs/turnend-guard.md](docs/turnend-guard.md) - the primary session's structural "no turn ends blind" backstop: verified per-harness hook mechanisms, scoping, loop safety, and fail-open tradeoffs.
 - [docs/supervision-protocols/](docs/supervision-protocols/) - rendered primary-harness watcher protocols for Claude, Codex, OpenCode, Pi, Grok, and unknown harness fallback.
+- [docs/pi-session-context.md](docs/pi-session-context.md) - verified Pi parity for Firstmate's supported local SessionStart CLI guidance.
 - [docs/scripts.md](docs/scripts.md) - the `bin/` toolbelt reference.
 - [`AGENTS.md`](AGENTS.md) - the distro's core instruction file and the first mate's full operating manual.
 - [CONTRIBUTING.md](CONTRIBUTING.md) - how to contribute, including the dev/test commands.

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -73,6 +73,7 @@
 #                  written by this script; outside the worktree to avoid pi's trust gate)
 #     __PITURNEND__ absolute path to .pi/extensions/fm-primary-turnend-guard.ts in a pi secondmate home
 #     __PIWATCH__   absolute path to .pi/extensions/fm-primary-pi-watch.ts in a pi secondmate home
+#     __PICONTEXT__ absolute path to .pi/extensions/fm-primary-session-context.ts in a pi secondmate home
 # Per-harness turn-end hooks are installed automatically; some live outside the worktree.
 # grok uses a firstmate-owned global hook under ${GROK_HOME:-$HOME/.grok}/hooks
 # plus a gitignored .fm-grok-turnend worktree pointer and a state token.
@@ -327,7 +328,7 @@ launch_template() {
     opencode) printf '%s' 'OPENCODE_CONFIG_CONTENT='\''{"permission":{"*":"allow"}}'\'' opencode __MODELFLAG__--prompt "$(cat __BRIEF__)"' ;;
     pi)
       if [ "$kind" = secondmate ]; then
-        printf '%s' 'pi __MODELFLAG____EFFORTFLAG__-e __PITURNEND__ -e __PIWATCH__ "$(cat __BRIEF__)"'
+        printf '%s' 'pi __MODELFLAG____EFFORTFLAG__-e __PITURNEND__ -e __PIWATCH__ -e __PICONTEXT__ "$(cat __BRIEF__)"'
       else
         printf '%s' 'pi __MODELFLAG____EFFORTFLAG__-e __PIEXT__ "$(cat __BRIEF__)"'
       fi
@@ -1030,6 +1031,7 @@ sq_turnend=$(shell_quote "$TURNEND")
 sq_piext=$(shell_quote "$STATE/$ID.pi-ext.ts")
 sq_piturnend=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-turnend-guard.ts")
 sq_piwatch=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-pi-watch.ts")
+sq_picontext=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-session-context.ts")
 MODELFLAG=$(model_flag_for_harness "$HARNESS" "$MODEL")
 EFFORTFLAG=$(effort_flag_for_harness "$HARNESS" "$EFFORT")
 LAUNCH=${LAUNCH//__MODELFLAG__/$MODELFLAG}
@@ -1039,6 +1041,7 @@ LAUNCH=${LAUNCH//__TURNEND__/$sq_turnend}
 LAUNCH=${LAUNCH//__PIEXT__/$sq_piext}
 LAUNCH=${LAUNCH//__PITURNEND__/$sq_piturnend}
 LAUNCH=${LAUNCH//__PIWATCH__/$sq_piwatch}
+LAUNCH=${LAUNCH//__PICONTEXT__/$sq_picontext}
 if [ "$KIND" = secondmate ]; then
   sq_home=$(shell_quote "$PROJ_ABS")
   LAUNCH="FM_ROOT_OVERRIDE= FM_STATE_OVERRIDE= FM_DATA_OVERRIDE= FM_PROJECTS_OVERRIDE= FM_CONFIG_OVERRIDE= FM_HOME=$sq_home $LAUNCH"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,7 +35,7 @@ The script header owns the exact JSON schema.
 Optional X mode rides the same check path: the locked session-start bootstrap step drops a local `state/x-watch.check.sh` shim only after the user opts in with `FMX_PAIRING_TOKEN`, and non-X homes keep the default watcher behavior.
 
 At session start, `bin/fm-session-start.sh` emits exactly one primary-harness supervision block rendered by `bin/fm-supervision-instructions.sh` from `docs/supervision-protocols/`.
-That block owns the live wait shape for the running primary harness: Claude and Grok use background-notify cycles, Codex uses bounded foreground checkpoints, Pi uses its two tracked primary extensions, and OpenCode uses its TUI plugin.
+That block owns the live wait shape for the running primary harness: Claude and Grok use background-notify cycles, Codex uses bounded foreground checkpoints, Pi uses tracked primary extensions, and OpenCode uses its TUI plugin.
 `bin/fm-watch-arm.sh` remains the verified arm wrapper for protocols that call it; it forks the watcher as a tracked child, verifies it is genuinely alive with a fresh liveness beacon, and prints exactly one honest status line (`started` / `attached` / restart-only `healthy` / `FAILED`, the last exiting non-zero).
 On `attached` it stays live until that existing cycle ends so background-notify harnesses do not get an empty false wake from a healthy no-op exit.
 Its `--restart` mode signals only the watcher recorded in the current home's `state/.watch.lock`, so restarting one home cannot kill sibling secondmate watchers.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -145,7 +145,7 @@ The verified adapter knowledge - busy signatures, interrupt and exit commands, s
 Launch mechanics, including the verified command templates, live in [`bin/fm-spawn.sh`](../bin/fm-spawn.sh).
 Primary-session turn-end guard integrations for verified harnesses are tracked as repo-level hook files and documented in [`docs/turnend-guard.md`](turnend-guard.md).
 Primary-session watcher wake protocols are rendered at session start by [`bin/fm-supervision-instructions.sh`](../bin/fm-supervision-instructions.sh) from [`docs/supervision-protocols/`](supervision-protocols/).
-Claude and Grok use background-notify cycles, Codex uses bounded foreground checkpoints, Pi uses its two tracked primary extensions, and OpenCode uses its TUI plugin.
+Claude and Grok use background-notify cycles, Codex uses bounded foreground checkpoints, Pi uses tracked primary extensions, and OpenCode uses its TUI plugin.
 `config/crew-harness` is a local, gitignored file containing one adapter name for crewmate and scout launches.
 When it is absent or contains `default`, crewmates mirror the firstmate's own harness.
 `config/secondmate-harness` is a separate local, gitignored file containing the adapter the primary uses to launch secondmate agents, optionally followed by model and effort tokens on the same line.
@@ -159,7 +159,7 @@ When `config/crew-dispatch.json` exists, crewmate and scout spawns require an ex
 The primary propagates `config/crew-dispatch.json`, `config/crew-harness`, and `config/backlog-backend` into secondmate homes at secondmate spawn, during the locked session-start bootstrap secondmate sweep, and during explicit `bin/fm-config-push.sh` runs, so a secondmate's own crewmates, dispatch profiles, and backlog backend use the primary values.
 `config/secondmate-harness` is not inherited because secondmates do not launch secondmates.
 For grok, `fm-spawn.sh` installs one firstmate-owned global turn-end hook under `$GROK_HOME/hooks/`, or `~/.grok/hooks/` when `GROK_HOME` is unset, and drops a per-task `.fm-grok-turnend` pointer in the worktree, with teardown removing the task token and pointer.
-For Pi secondmate launches, `fm-spawn.sh` starts Pi with `-e` pointed at the secondmate home's own tracked `.pi/extensions/fm-primary-pi-watch.ts` and `.pi/extensions/fm-primary-turnend-guard.ts`, both already present from the secondmate home's git worktree.
+For Pi secondmate launches, `fm-spawn.sh` starts Pi with `-e` pointed at the secondmate home's tracked watcher, turn-end guard, and SessionStart-context extensions already present from the secondmate home's git worktree.
 
 ## Crew dispatch profiles (config/crew-dispatch.json)
 

--- a/docs/pi-session-context.md
+++ b/docs/pi-session-context.md
@@ -1,0 +1,47 @@
+# Pi SessionStart context compatibility
+
+## Contract
+
+Firstmate owns Pi startup-context parity in `.pi/extensions/fm-primary-session-context.ts`.
+Pi loads this project extension only after project trust, or through an explicit `-e` path used for secondmate launches.
+The extension runs supported CLI context producers in deterministic order with a 10-second timeout per command, bounded output, control-character cleanup, and per-command failure isolation.
+It injects one hidden persistent model-context message per Pi session and does not reinject that message on `/reload`.
+Session replacement creates a new extension instance and receives a fresh context message after the previous instance handles `session_shutdown`.
+The context is guidance for Pi's built-in `bash` tool and does not register the CLIs as first-class Pi tools or MCP servers.
+Codex MCP servers, plugins, skills, and built-in capabilities are separate from `~/.codex/hooks.json` and are not inherited by Pi.
+
+## Compatibility matrix
+
+| Component | Audited `origin/main` | Pi integration | Verified interface |
+| --- | --- | --- | --- |
+| `tasks-axi` | `78389b5b87ebf3db805a4e873fcd03f71a084e09` | Startup context | No-argument CLI through Pi `bash` |
+| `quota-axi` | `187a9bc7b5125e68c9d3abab2e25ebb393e78ddf` | On demand | `quota-axi --help` through Pi `bash` |
+| `lavish-axi` | `ab31405882f950696a2ddc79deb90d4caada7543` | Startup context | No-argument CLI through Pi `bash` |
+| `chrome-devtools-axi` | `cc740e87c02590fdb63b235f2dc584801f514e8c` | Startup context | No-argument CLI and documented commands through Pi `bash` |
+| `axi` | `d51c90b2efaed48eed9a6a9e876afc940571ec0c` | Shared runtime only | `axi-sdk-js` used by the named Node CLIs, with no `axi` executable |
+| `gh-axi` | `e8533b554e3a64fdabc6090ac61507e6c654a914` | Startup context | No-argument CLI through Pi `bash` |
+| `treehouse` | `81cc00172b3615cde67ff6fb0f99679a1274210e` | On demand | `treehouse --help` through Pi `bash` |
+
+`quota-axi` deliberately has no SessionStart hook because its `origin/main` contract is read-only quota data requested on demand.
+The shared `axi` repository is an SDK and specification repository rather than a user-facing executable.
+Treehouse remains a separate lifecycle CLI governed by Firstmate's worktree safety rules.
+No external tool repository required a compatibility patch for this integration.
+
+## Evidence recorded 2026-07-12
+
+The installed Pi version was `0.80.6`.
+The remote audit command was `git -C <repo> ls-remote origin refs/heads/main` for every matrix row.
+Local `origin/main` matched for `tasks-axi` and `quota-axi`.
+Read-only temporary shallow clones of remote `main` were used for the other five repositories because their local remote-tracking refs were stale.
+Each audit read the repository instructions, README, executable entrypoint, help and SessionStart contract, environment detection, and relevant tests from the audited commit.
+The active Codex hook audit command was `jq '{SessionStart: [.hooks.SessionStart[]? | {matcher, hooks: [.hooks[]? | {type, command, timeout}]}]}' ~/.codex/hooks.json`.
+That audit found 10-second no-argument SessionStart commands for `tasks-axi`, `gh-axi`, `lavish-axi`, and `chrome-devtools-axi`, plus an unrelated local Herdr state hook.
+The pre-change isolated Pi probe used `PI_CODING_AGENT_DIR`, `FM_HOME`, `PI_OFFLINE=1`, `--approve`, `--no-session`, and explicit `-e` paths for the tracked Firstmate extensions.
+The probe observed all four dynamic Codex hook payload signatures absent from the Pi model prompt while normal project context was present.
+The post-change probe observed all four dynamic payload signatures in the model-visible injected context without launching the Codex harness or loading Codex hooks.
+The exact post-change model response was `tasks yes,github yes,lavish yes,chrome yes,quota-role yes,axi-runtime-role yes,treehouse-role yes`.
+`tests/fm-pi-session-context.test.sh` covers ordering, once-per-session injection, timeout and failure isolation, truncation, reload deduplication, session replacement, missing binaries, and current output headings.
+`tests/fm-pi-primary-types.test.sh` covers strict TypeScript compatibility against the installed Pi package when `tsc` is installed.
+The live interface checks were `tasks-axi`, `quota-axi --help`, `lavish-axi`, `chrome-devtools-axi`, `gh-axi`, and `treehouse --help` from the Pi environment.
+The Pi model used its built-in `bash` tool for that combined interface check and returned `INTERFACES_OK` with no stderr.
+The `axi` interface check was its audited root `package.json`, which has no `bin` entry, and `packages/axi-sdk-js`, which owns the shared SessionStart hook implementation.

--- a/docs/pi-session-context.md
+++ b/docs/pi-session-context.md
@@ -4,7 +4,8 @@
 
 Firstmate owns Pi startup-context parity in `.pi/extensions/fm-primary-session-context.ts`.
 Pi loads this project extension only after project trust, or through an explicit `-e` path used for secondmate launches.
-The extension runs supported CLI context producers in deterministic order with a 10-second timeout per command, bounded output, control-character cleanup, and per-command failure isolation.
+The extension starts all supported CLI context producers concurrently and renders their results in deterministic contract order with a 10-second timeout per command, bounded output, control-character cleanup, and per-command failure isolation.
+Concurrent collection reduces the four-command timeout ceiling from approximately 40 seconds to approximately 10 seconds without allowing one producer to reorder or block another producer's result.
 It injects one hidden persistent model-context message per Pi session and does not reinject that message on `/reload`.
 Session replacement creates a new extension instance and receives a fresh context message after the previous instance handles `session_shutdown`.
 The context is guidance for Pi's built-in `bash` tool and does not register the CLIs as first-class Pi tools or MCP servers.
@@ -40,8 +41,15 @@ The pre-change isolated Pi probe used `PI_CODING_AGENT_DIR`, `FM_HOME`, `PI_OFFL
 The probe observed all four dynamic Codex hook payload signatures absent from the Pi model prompt while normal project context was present.
 The post-change probe observed all four dynamic payload signatures in the model-visible injected context without launching the Codex harness or loading Codex hooks.
 The exact post-change model response was `tasks yes,github yes,lavish yes,chrome yes,quota-role yes,axi-runtime-role yes,treehouse-role yes`.
-`tests/fm-pi-session-context.test.sh` covers ordering, once-per-session injection, timeout and failure isolation, truncation, reload deduplication, session replacement, missing binaries, and current output headings.
+`tests/fm-pi-session-context.test.sh` covers concurrent collection, deterministic ordering, once-per-session injection, timeout and failure isolation, truncation, reload deduplication, session replacement, missing binaries, and current output headings.
 `tests/fm-pi-primary-types.test.sh` covers strict TypeScript compatibility against the installed Pi package when `tsc` is installed.
 The live interface checks were `tasks-axi`, `quota-axi --help`, `lavish-axi`, `chrome-devtools-axi`, `gh-axi`, and `treehouse --help` from the Pi environment.
 The Pi model used its built-in `bash` tool for that combined interface check and returned `INTERFACES_OK` with no stderr.
 The `axi` interface check was its audited root `package.json`, which has no `bin` entry, and `packages/axi-sdk-js`, which owns the shared SessionStart hook implementation.
+The 2026-07-12 concurrency revalidation ran every Pi-specific suite and the isolated live E2E against Pi `0.80.6`.
+The focused context suite reported `ok - Pi session context is concurrent, ordered, bounded, isolated, and once per session`.
+The strict installed-package typecheck reported `ok - Pi primary extensions pass strict no-emit typecheck against Pi 0.80.6` using an already-present TypeScript `5.9.3` binary.
+The repo-owned lint command reported `fm-lint.sh: ShellCheck 0.11.0 (pinned 0.11.0)` using an already-present Nix-store binary.
+The live suite reported `ok - Pi 0.80.6 live E2E rendered the tool, guarded once, woke, re-armed, and cleaned up on exit`.
+The live suite used optional read-only auth and settings links inside its isolated `PI_CODING_AGENT_DIR` and a temporary PATH wrapper around the existing tmux binary with already-cached libraries.
+No package, global configuration, credential file, or external tool repository was installed or modified during revalidation.

--- a/tests/fm-pi-primary-live-e2e.test.sh
+++ b/tests/fm-pi-primary-live-e2e.test.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # Opt-in interactive Pi primary regression on a private tmux socket and isolated homes.
+# FM_PI_AUTH_FILE and FM_PI_SETTINGS_FILE may link existing read-only Pi configuration into the isolated agent directory.
 set -u
 
 if [ "${FM_PI_LIVE_E2E:-0}" != 1 ]; then
@@ -45,7 +46,7 @@ wait_for_text() {
 wait_for_exact_line() {
   local expected=$1 attempts=${2:-120} i=0
   while [ "$i" -lt "$attempts" ]; do
-    if capture | grep -Fxq " $expected"; then
+    if capture | grep -Fxq "$expected" || capture | grep -Fxq " $expected"; then
       return 0
     fi
     sleep 0.5
@@ -107,6 +108,14 @@ cp "$ROOT/.pi/extensions/fm-primary-pi-watch.ts" "$PROJECT/.pi/extensions/fm-pri
 cp "$ROOT/.pi/extensions/fm-primary-turnend-guard.ts" "$PROJECT/.pi/extensions/fm-primary-turnend-guard.ts"
 cp "$ROOT/bin/fm-supervision-instructions.sh" "$PROJECT/bin/fm-supervision-instructions.sh"
 mkdir -p "$HOME_DIR/state" "$HOME_DIR/config" "$PI_DIR"
+if [ -n "${FM_PI_AUTH_FILE:-}" ]; then
+  [ -f "$FM_PI_AUTH_FILE" ] || fail "FM_PI_AUTH_FILE does not name a readable file"
+  ln -s "$FM_PI_AUTH_FILE" "$PI_DIR/auth.json"
+fi
+if [ -n "${FM_PI_SETTINGS_FILE:-}" ]; then
+  [ -f "$FM_PI_SETTINGS_FILE" ] || fail "FM_PI_SETTINGS_FILE does not name a readable file"
+  ln -s "$FM_PI_SETTINGS_FILE" "$PI_DIR/settings.json"
+fi
 
 "$TMUX" -L "$SOCKET" new-session -d -s "$SESSION" -c "$PROJECT" \
   "env PI_CODING_AGENT_DIR='$PI_DIR' FM_HOME='$HOME_DIR' FM_ROOT_OVERRIDE='$PROJECT' FM_POLL=1 FM_SIGNAL_GRACE=0 FM_HEARTBEAT=600 PI_OFFLINE=1 bash -lc 'printf \"%s\\n\" \"\$\$\" > \"\$FM_HOME/state/.lock\"; pi; rc=\$?; printf \"PI_EXIT=%s\\n\" \"\$rc\"; sleep 300'"

--- a/tests/fm-pi-primary-types.test.sh
+++ b/tests/fm-pi-primary-types.test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Strict no-emit contract check for both tracked Pi primary extensions.
+# Strict no-emit contract check for the tracked Pi primary extensions.
 set -u
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -26,6 +26,7 @@ trap cleanup EXIT
 mkdir -p "$TMP_ROOT/node_modules/@earendil-works" "$TMP_ROOT/node_modules/@types"
 cp "$ROOT/.pi/extensions/fm-primary-pi-watch.ts" "$TMP_ROOT/fm-primary-pi-watch.ts"
 cp "$ROOT/.pi/extensions/fm-primary-turnend-guard.ts" "$TMP_ROOT/fm-primary-turnend-guard.ts"
+cp "$ROOT/.pi/extensions/fm-primary-session-context.ts" "$TMP_ROOT/fm-primary-session-context.ts"
 ln -s "$PI_PACKAGE_DIR" "$TMP_ROOT/node_modules/@earendil-works/pi-coding-agent"
 ln -s "$PI_PACKAGE_DIR/node_modules/typebox" "$TMP_ROOT/node_modules/typebox"
 ln -s "$PI_PACKAGE_DIR/node_modules/@types/node" "$TMP_ROOT/node_modules/@types/node"

--- a/tests/fm-pi-session-context.test.sh
+++ b/tests/fm-pi-session-context.test.sh
@@ -5,7 +5,6 @@ set -u
 # shellcheck source=tests/lib.sh
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
-TMP_ROOT=$(fm_test_tmproot fm-pi-session-context)
 EXT="$ROOT/.pi/extensions/fm-primary-session-context.ts"
 
 run_fixture() {
@@ -15,6 +14,8 @@ import { pathToFileURL } from "node:url";
 
 const handlers = new Map();
 const calls = [];
+let active = 0;
+let maxActive = 0;
 const outputs = {
   "tasks-axi": { stdout: "bin: ~/.npm-global/bin/tasks-axi\ndescription: task manager\nin_flight: 0 tasks\u0000", stderr: "", code: 0, killed: false },
   "gh-axi": { stdout: "bin: ~/.npm-global/bin/gh-axi\ndescription: GitHub wrapper\nrepo: owner/name", stderr: "", code: 0, killed: false },
@@ -25,6 +26,13 @@ const pi = {
   on(name, handler) { handlers.set(name, handler); },
   async exec(command, args, options) {
     calls.push({ command, args, options });
+    if (process.env.SCENARIO === "concurrent") {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      const delay = { "tasks-axi": 40, "gh-axi": 30, "lavish-axi": 20, "chrome-devtools-axi": 10 }[command];
+      await new Promise((resolve) => setTimeout(resolve, delay));
+      active -= 1;
+    }
     if (process.env.SCENARIO === "fail" && command === "gh-axi") throw new Error("missing binary");
     if (process.env.SCENARIO === "timeout" && command === "lavish-axi") return { stdout: "", stderr: "", code: null, killed: true };
     if (process.env.SCENARIO === "truncate" && command === "tasks-axi") return { stdout: "x\n".repeat(300), stderr: "", code: 0, killed: false };
@@ -59,6 +67,12 @@ if (!first.message.content.includes("quota-axi") || !first.message.content.inclu
 if (process.env.SCENARIO === "fail" && !first.message.content.includes("Unavailable: missing binary")) throw new Error("missing binary was not isolated");
 if (process.env.SCENARIO === "timeout" && !first.message.content.includes("timed out after 10000ms")) throw new Error("timeout was not isolated");
 if (process.env.SCENARIO === "truncate" && !first.message.content.includes("Startup guidance truncated by Firstmate")) throw new Error("truncation marker missing");
+if (process.env.SCENARIO === "concurrent") {
+  if (maxActive !== 4) throw new Error(`expected four concurrent probes, observed ${maxActive}`);
+  const headings = ["### tasks-axi", "### gh-axi", "### lavish-axi", "### chrome-devtools-axi"];
+  const positions = headings.map((heading) => first.message.content.indexOf(heading));
+  if (positions.some((position) => position < 0) || positions.some((position, index) => index > 0 && position < positions[index - 1])) throw new Error("concurrent results rendered out of order");
+}
 
 await handlers.get("session_shutdown")({ reason: "new" }, ctx);
 await handlers.get("session_start")({ reason: "new" }, { sessionManager: { getBranch: () => [] } });
@@ -72,5 +86,6 @@ run_fixture normal || fail "Pi session context normal lifecycle failed"
 run_fixture fail || fail "Pi session context missing-binary isolation failed"
 run_fixture timeout || fail "Pi session context timeout isolation failed"
 run_fixture truncate || fail "Pi session context truncation failed"
+run_fixture concurrent || fail "Pi session context concurrency or deterministic ordering failed"
 run_fixture existing || fail "Pi session context reload deduplication failed"
-pass "Pi session context is ordered, bounded, isolated, and once per session"
+pass "Pi session context is concurrent, ordered, bounded, isolated, and once per session"

--- a/tests/fm-pi-session-context.test.sh
+++ b/tests/fm-pi-session-context.test.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Tests for Pi startup context ordering, isolation, and session lifecycle.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-pi-session-context)
+EXT="$ROOT/.pi/extensions/fm-primary-session-context.ts"
+
+run_fixture() {
+  local scenario=$1
+  NODE_NO_WARNINGS=1 SCENARIO="$scenario" EXT="$EXT" node --experimental-strip-types --input-type=module <<'EOF'
+import { pathToFileURL } from "node:url";
+
+const handlers = new Map();
+const calls = [];
+const outputs = {
+  "tasks-axi": { stdout: "bin: ~/.npm-global/bin/tasks-axi\ndescription: task manager\nin_flight: 0 tasks\u0000", stderr: "", code: 0, killed: false },
+  "gh-axi": { stdout: "bin: ~/.npm-global/bin/gh-axi\ndescription: GitHub wrapper\nrepo: owner/name", stderr: "", code: 0, killed: false },
+  "lavish-axi": { stdout: "bin: ~/.npm-global/bin/lavish-axi\ndescription: review surface\nsessions[0]:", stderr: "", code: 0, killed: false },
+  "chrome-devtools-axi": { stdout: "bin: /path/chrome-devtools-axi.js\ndescription: browser control\nbrowser: no active session", stderr: "", code: 0, killed: false },
+};
+const pi = {
+  on(name, handler) { handlers.set(name, handler); },
+  async exec(command, args, options) {
+    calls.push({ command, args, options });
+    if (process.env.SCENARIO === "fail" && command === "gh-axi") throw new Error("missing binary");
+    if (process.env.SCENARIO === "timeout" && command === "lavish-axi") return { stdout: "", stderr: "", code: null, killed: true };
+    if (process.env.SCENARIO === "truncate" && command === "tasks-axi") return { stdout: "x\n".repeat(300), stderr: "", code: 0, killed: false };
+    return outputs[command];
+  },
+};
+const mod = await import(pathToFileURL(process.env.EXT).href);
+mod.default(pi);
+const existing = process.env.SCENARIO === "existing"
+  ? [{ type: "message", message: { customType: "firstmate-axi-session-context" } }]
+  : [];
+const ctx = { sessionManager: { getBranch: () => existing } };
+await handlers.get("session_start")({ reason: "startup" }, ctx);
+const first = await handlers.get("before_agent_start")({}, ctx);
+const second = await handlers.get("before_agent_start")({}, ctx);
+
+if (process.env.SCENARIO === "existing") {
+  if (calls.length !== 0 || first !== undefined) throw new Error("reload duplicated existing session context");
+  process.exit(0);
+}
+if (calls.map((call) => call.command).join(",") !== "tasks-axi,gh-axi,lavish-axi,chrome-devtools-axi") throw new Error("command ordering changed");
+if (calls.some((call) => call.options.timeout !== 10000)) throw new Error("command timeout missing");
+if (!first?.message?.content || first.message.display !== false) throw new Error("hidden context message missing");
+if (second !== undefined) throw new Error("context injected more than once");
+if (process.env.SCENARIO === "normal") {
+  for (const shape of ["in_flight: 0 tasks", "repo: owner/name", "sessions[0]:", "browser: no active session"]) {
+    if (!first.message.content.includes(shape)) throw new Error(`current CLI output shape missing: ${shape}`);
+  }
+  if (first.message.content.includes("\u0000")) throw new Error("control character reached model context");
+}
+if (!first.message.content.includes("quota-axi") || !first.message.content.includes("shared SDK/runtime") || !first.message.content.includes("treehouse")) throw new Error("related interface roles missing");
+if (process.env.SCENARIO === "fail" && !first.message.content.includes("Unavailable: missing binary")) throw new Error("missing binary was not isolated");
+if (process.env.SCENARIO === "timeout" && !first.message.content.includes("timed out after 10000ms")) throw new Error("timeout was not isolated");
+if (process.env.SCENARIO === "truncate" && !first.message.content.includes("Startup guidance truncated by Firstmate")) throw new Error("truncation marker missing");
+
+await handlers.get("session_shutdown")({ reason: "new" }, ctx);
+await handlers.get("session_start")({ reason: "new" }, { sessionManager: { getBranch: () => [] } });
+const replacement = await handlers.get("before_agent_start")({}, ctx);
+if (!replacement?.message?.content) throw new Error("replacement session did not receive context");
+EOF
+}
+
+assert_present "$EXT" "tracked Pi session context extension is missing"
+run_fixture normal || fail "Pi session context normal lifecycle failed"
+run_fixture fail || fail "Pi session context missing-binary isolation failed"
+run_fixture timeout || fail "Pi session context timeout isolation failed"
+run_fixture truncate || fail "Pi session context truncation failed"
+run_fixture existing || fail "Pi session context reload deduplication failed"
+pass "Pi session context is ordered, bounded, isolated, and once per session"

--- a/tests/fm-pi-watch-extension.test.sh
+++ b/tests/fm-pi-watch-extension.test.sh
@@ -5,6 +5,10 @@ set -u
 # shellcheck source=tests/lib.sh
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
+# The plugin fixtures set their own effective homes and roots.
+# Do not let a supervising Firstmate session's overrides redirect them back to the primary checkout.
+unset FM_ROOT_OVERRIDE FM_STATE_OVERRIDE FM_CONFIG_OVERRIDE
+
 TMP_ROOT=$(fm_test_tmproot fm-pi-watch-extension)
 EXT="$ROOT/.pi/extensions/fm-primary-pi-watch.ts"
 
@@ -69,7 +73,7 @@ test_spawn_template_mentions_pi_watch_placeholder() {
   assert_contains "$text" "__PIWATCH__" "fm-spawn does not replace the Pi watch extension placeholder"
   assert_contains "$text" "\$PROJ_ABS/.pi/extensions/fm-primary-session-context.ts" "fm-spawn does not point the Pi session-context placeholder at the tracked extension"
   assert_contains "$text" "__PICONTEXT__" "fm-spawn does not replace the Pi session-context extension placeholder"
-  pass "Pi secondmate launch wiring includes both tracked primary extensions"
+  pass "Pi secondmate launch wiring includes all tracked primary extensions"
 }
 
 test_pi_extension_reports_external_healthy_watcher() {

--- a/tests/fm-pi-watch-extension.test.sh
+++ b/tests/fm-pi-watch-extension.test.sh
@@ -62,11 +62,13 @@ test_tracked_extension_present_and_self_hashing() {
 test_spawn_template_mentions_pi_watch_placeholder() {
   local text
   text=$(cat "$ROOT/bin/fm-spawn.sh")
-  assert_contains "$text" "-e __PITURNEND__ -e __PIWATCH__" "Pi secondmate launch template does not include both primary extensions"
+  assert_contains "$text" "-e __PITURNEND__ -e __PIWATCH__ -e __PICONTEXT__" "Pi secondmate launch template does not include all primary extensions"
   assert_contains "$text" "\$PROJ_ABS/.pi/extensions/fm-primary-pi-watch.ts" "fm-spawn does not point the Pi secondmate watch placeholder at the tracked extension"
   assert_not_contains "$text" "fm-pi-watch-extension.sh" "fm-spawn should no longer generate the Pi watch extension before launch"
   assert_contains "$text" "__PITURNEND__" "fm-spawn does not replace the Pi turn-end guard extension placeholder"
   assert_contains "$text" "__PIWATCH__" "fm-spawn does not replace the Pi watch extension placeholder"
+  assert_contains "$text" "\$PROJ_ABS/.pi/extensions/fm-primary-session-context.ts" "fm-spawn does not point the Pi session-context placeholder at the tracked extension"
+  assert_contains "$text" "__PICONTEXT__" "fm-spawn does not replace the Pi session-context extension placeholder"
   pass "Pi secondmate launch wiring includes both tracked primary extensions"
 }
 


### PR DESCRIPTION
## Summary

- add a trusted Pi lifecycle extension that injects bounded, once-per-session context from the four supported Axi SessionStart CLIs
- collect all four context producers concurrently while preserving deterministic rendered order, reducing the timeout ceiling from approximately 40 seconds to approximately 10 seconds
- keep quota-axi, axi-sdk-js, and Treehouse roles explicit without claiming tool or MCP registration
- wire the context extension into Pi secondmate launches and cover concurrency, ordering, failure, timeout, truncation, reload, replacement, and current output shapes
- record the 2026-07-12 origin/main compatibility audit and isolated Pi 0.80.6 E2E evidence

## Validation

- `NODE_NO_WARNINGS=1 tests/fm-pi-session-context.test.sh` - passed
- `NODE_NO_WARNINGS=1 tests/fm-pi-watch-extension.test.sh` - passed
- `tests/fm-pi-primary-types.test.sh` with already-present TypeScript 5.9.3 - passed against Pi 0.80.6
- `bin/fm-lint.sh` with already-present pinned ShellCheck 0.11.0 - passed
- `FM_PI_LIVE_E2E=1 tests/fm-pi-primary-live-e2e.test.sh` with read-only existing Pi auth/settings links and cached tmux libraries - passed through tool rendering, guard, wake, re-arm, and cleanup
- `bash -n` on changed shell tests - passed
- `git diff --check` - passed

## Environment

- no packages were installed
- no global Pi or Codex configuration was modified
- no credentials were copied or printed
- no external tool repository was modified

## Remaining blockers

- none