### PR TITLE
feat(harness): wire cursor and agy as verified crew adapters

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harness-adapters
-description: Agent-only reference for firstmate harness operations. Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter. Contains verified facts for claude, codex, opencode, pi, and grok.
+description: Agent-only reference for firstmate harness operations. Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter. Contains verified facts for claude, codex, opencode, pi, grok, cursor, and agy.
 user-invocable: false
 metadata:
   internal: true
@@ -86,6 +86,8 @@ The supported launch-profile flags below were verified locally on 2026-06-30 wit
 | grok | `--model <model>` | `--reasoning-effort <low\|medium\|high\|xhigh>` | Verified on grok 0.2.73. `--effort` parses too, but firstmate's profile axis is reasoning effort. `--reasoning-effort max` is rejected, so `max` is omitted. |
 | pi | `--model <model>` | `--thinking <low\|medium\|high\|xhigh>` | Verified on pi 0.80.2. `max` prints an invalid-thinking warning, so firstmate omits Pi effort when the requested effort is `max`. |
 | opencode | `--model <provider/model>` | none for firstmate's interactive launch | Verified on opencode 1.17.6. `opencode run` has `--variant`, but firstmate launches the interactive `opencode --prompt` path, which has no verified effort flag. |
+| cursor | `--model <id>` | none (effort is a suffix in the id) | Verified on cursor-agent 2026.07.09. The id carries the effort, e.g. `gpt-5.6-sol-medium` (suffixes `-none\|-low\|-medium\|-high\|-xhigh\|-max`). The documented `<model>[effort=<level>]` bracket form is rejected by the installed CLI, so firstmate passes the full suffixed id and emits no effort flag. |
+| agy | `--model <name>` | none (effort is baked into the name) | Verified on agy 1.1.1. `--model` takes a display name from `agy models`, e.g. `'Gemini 3.1 Pro (High)'` or `'Claude Opus 4.6 (Thinking)'`, whose effort is part of the name. No separate effort flag. |
 
 When a requested effort value is outside the harness-specific accepted set, `fm-spawn` records the requested `effort=` in meta but emits no effort flag for that harness.
 This preserves launch success instead of passing a known-bad value.
@@ -99,6 +101,8 @@ Natural language is acceptable if uncertain.
 - codex: `$<skill>`, for example `$no-mistakes`; `/<skill>` is claude-only and codex rejects it as "Unrecognized command".
 - opencode: no separate verified skill invocation beyond normal slash-command behavior; use natural language if the exact skill command is uncertain.
 - pi: no separate verified skill invocation beyond normal command behavior; use natural language if the exact skill command is uncertain.
+- cursor: no separate verified skill invocation for `no-mistakes`; use natural language. cursor has its own `/`-style slash commands and a distinct skills store, but its discovery of the user-level `no-mistakes` skill is unverified.
+- agy: no separate verified skill invocation for `no-mistakes`; use natural language.
 - grok: `/<skill>`, for example `/no-mistakes` (same form as claude). Verified end to end: grok discovers the user-level `no-mistakes` skill, `/no-mistakes` invokes it, and grok drives a real `no-mistakes axi run`. Like codex's `$`/`/` popups, typing `/<skill>` opens grok's slash-autocomplete, so a too-fast Enter selects the popup entry instead of sending, and for an argument-taking command (like `/no-mistakes`'s optional task-first argument) that first Enter only expands the popup selection into an argument-hint placeholder rather than submitting - a genuine second Enter is required (see the grok section below for the 2026-07-03 incident and fix). `fm_tmux_submit_core`'s retried Enter (used by `fm-send` on the tmux backend) already handles this correctly by reading the cursor row; the herdr backend needed a dedicated fix (`fm_backend_herdr_composer_state`, docs/herdr-backend.md) because its prior delta-based verification false-positived on that same popup-close content change.
 
 ## claude (VERIFIED)
@@ -264,3 +268,65 @@ The adapter therefore runs the shared predicate and, when it returns 2, forces o
 It does not pass `--permission-mode`, so the passive hook cannot escalate the primary session's tool permissions.
 Project-local Grok hooks require folder trust, verified with launch-time `--trust`; if the primary firstmate checkout is not trusted for Grok hooks, this primary guard fails open and `fm-guard.sh` remains the next-command alarm.
 Grok's primary watcher protocol is Claude-shaped background-notify around `bin/fm-watch-arm.sh`; the passive Stop hook is only a backstop for blind turn ends.
+
+## cursor (VERIFIED 2026-07-12, cursor-agent 2026.07.09-a3815c0)
+
+Cursor Agent CLI (`cursor-agent`), verified as a CREW and secondmate adapter, not as the firstmate primary.
+Launch with a positional prompt: `cursor-agent --force --model <id> "$(cat <brief>)"`.
+The `cursor-agent` binary is a bash launcher that execs Node with `exec -a "$0"`, so the pane command and process name stay `cursor-agent` (not a bare `node`).
+
+| Fact | Value |
+|---|---|
+| Busy-pane signature | `ctrl+c to stop` (footer stop hint shown iff a turn is running; the spinner line reads `⠘⠣ Working`). Idle footer shows only the placeholder `→ Add a follow-up`. The ASCII `ctrl+c to stop` is the busy regex (avoids the braille spinner glyph). |
+| Exit command | double `Ctrl+C` within ~1s (`Press Ctrl+C again to exit`). Prints `To resume this session: agent --resume=<conversationId>`. |
+| Interrupt | single `Ctrl+C` (cancels the current turn; footer shows `ctrl+c to stop` mid-turn). |
+| Skill invocation | no separate verified `no-mistakes` invocation; use natural language (cursor has its own slash commands and skills store). |
+| Autonomy | `--force` (alias `--yolo`); auto-approves every tool execution, footer shows `Run Everything`. Verified to run fully unattended. |
+| Env marker | `CURSOR_AGENT=1`, set for child/tool processes (also `CURSOR_INVOKED_AS=cursor-agent`). It does NOT set `CLAUDECODE`. |
+| Resume | `cursor-agent --resume=<conversationId>` (id printed on exit and exported as `CURSOR_CONVERSATION_ID`), `--continue` (most recent for the cwd), or bare `--resume` (session picker). |
+
+Model and effort: `--model <id>` where the id carries the effort as a suffix, e.g. `gpt-5.6-sol-medium` (`-none`/`-low`/`-medium`/`-high`/`-xhigh`/`-max`).
+The documented `<model>[effort=<level>]` bracket-override form is rejected by this CLI (`Cannot use this model`), and the rejection prints the full accepted id set.
+So firstmate folds the requested effort into the model id and passes no separate effort flag.
+
+Trust dialog on first launch in a not-yet-trusted directory: `⚠ Workspace Trust Required ... ▶ [a] Trust this workspace / [q] Quit`.
+Accept from an active firstmate session with `FM_HOME=<this-firstmate-home> bin/fm-send.sh <window> --key Enter` (Enter selects the highlighted Trust option; `a` also works).
+The `--trust` flag is print/headless-mode only, so it cannot pre-trust the interactive crew launch; accept the dialog after spawn instead.
+The decision persists per directory, so later launches in the same worktree skip it.
+
+Composer: an idle cursor composer shows the placeholder `→ Add a follow-up` rendered dim (SGR 2), which the shared `fm_composer_strip_ghost` strips, so `fm_tmux_composer_state` reads it as `empty` (verified live). No `FM_COMPOSER_IDLE_RE` override is needed.
+
+Turn-end hook: cursor fires a `stop` hook at every turn boundary once the workspace is trusted, the clean equivalent of claude's Stop hook.
+`fm-spawn` installs a per-worktree `.cursor/hooks.json` (`{"version":1,"hooks":{"stop":[{"command":"touch <turnend>"}]}}`) that touches the task's `state/<id>.turn-ended`; it is gitignore-excluded via git info/exclude and removed by `fm-teardown`, exactly like the other harnesses' worktree hook files.
+Verified live: the inline single-file form touches the marker when the agent completes a turn.
+
+## agy (VERIFIED 2026-07-12, agy 1.1.1)
+
+Antigravity CLI (`agy`), a native binary, verified as a CREW and secondmate adapter, not as the firstmate primary.
+Launch with an initial interactive prompt: `agy --dangerously-skip-permissions --model <name> -i "$(cat <brief>)"` (`-i` is `--prompt-interactive`; the non-interactive `-p`/`--print`/`--prompt` is NOT for a crew pane).
+
+| Fact | Value |
+|---|---|
+| Busy-pane signature | `esc to cancel` (footer cancel hint shown iff a turn is running; the verb line reads `Working...` or `Generating...`). Idle footer shows `? for shortcuts`. `esc to cancel` is the busy regex because it is stable across agy's changing verb lines. |
+| Exit command | double `Ctrl+C` within ~1s (`press ctrl+c again to exit`). Prints `Resume with -c (or command below): agy --conversation=<id>`. |
+| Interrupt | single `Escape` (`⎿ Interrupted · What should Antigravity CLI do instead?`). `Ctrl+C` is the exit key, not the interrupt. |
+| Skill invocation | no separate verified `no-mistakes` invocation; use natural language. |
+| Autonomy | `--dangerously-skip-permissions`; auto-approves every tool request. Verified to run fully unattended. |
+| Env marker | `ANTIGRAVITY_AGENT=1`, set for child/tool processes (also `ANTIGRAVITY_CONVERSATION_ID`). |
+| Resume | `agy -c` / `--continue` (most recent) or `agy --conversation=<id>` (id printed on exit and exported as `ANTIGRAVITY_CONVERSATION_ID`). |
+
+Model and effort: `--model <name>` where `<name>` is a display string from `agy models`, e.g. `'Gemini 3.1 Pro (High)'` or `'Claude Opus 4.6 (Thinking)'`.
+The effort is baked into the name (`(High)`/`(Medium)`/`(Low)`/`(Thinking)`), so there is no separate effort flag; firstmate quotes the whole name into `--model`.
+
+Trust dialog on first launch in a not-yet-trusted project: `Do you trust the contents of this project? ... > Yes, I trust this folder / No, exit. ↑/↓ Navigate · enter Confirm`.
+Accept with Enter (the highlighted option is Trust).
+
+Composer: an idle agy composer is a lone `> ` prompt glyph (a 256-colour, not dim, foreground) drawn inside a box whose top and bottom are horizontal `───` rule rows, with no side border on the input row.
+A single-row read of that bare `>` would classify as a dead-shell `unknown`, so the tmux composer reader (`fm_tmux_composer_state`) treats a lone shell-prompt glyph flanked by pure horizontal-rule rows as a genuine composer box and reads it as `empty` (`fm_tmux_row_is_rule` in `bin/fm-tmux-lib.sh`).
+A real dead-shell prompt is not flanked by rule rows, so its unsafe-to-inject `unknown` verdict is preserved.
+Residual gap (unfixed, low-impact): if agy ever renders the cursor on a border row instead of the `>` row (a pristine pre-typing quirk seen on other harnesses), the content row would be a rule and read `pending`; a live crew launched with the brief is past that state.
+
+Turn-end hook: agy exposes no verified trust-free per-turn turn-end hook.
+Its `hooks.json` / `mcp_config.json` system surfaces only internal framework hooks (`captureUserRequests`, `generateContextSummary`, `PreInvocation`, `OnShellCommandFinished`), no confirmed trust-free per-turn `stop` event, and writing into `~/.gemini` is high blast radius.
+So `fm-spawn` installs no hook for agy and the watcher relies on stale-pane detection driven by the `esc to cancel` busy signature disappearing at turn end.
+This is coarser than a precise per-turn hook but is the same busy-signature mechanism the watcher already uses fleet-wide.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,7 +171,7 @@ If the captain expresses a standing dispatch preference such as "use grok for ne
 Crewmates default to the same harness you are running on.
 The captain may override the static default at any time, typically at bootstrap: record the choice in `config/crew-harness` (a single adapter name; absent or `default` means mirror your own harness).
 Resolve `default` with `bin/fm-harness.sh`; resolve the active static crewmate harness with `bin/fm-harness.sh crew`.
-Verified adapter names are `claude`, `codex`, `opencode`, `pi`, and `grok`.
+Verified adapter names are `claude`, `codex`, `opencode`, `pi`, `grok`, `cursor`, and `agy`; `cursor` and `agy` are verified as crewmate and secondmate adapters, not yet as the firstmate primary.
 
 ### Crew dispatch profiles
 

--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -143,8 +143,10 @@ fm_backend_tmux_current_command() {  # <target>
 # AGENTS.md's session-start guarantee closes). See docs/tmux-backend.md
 # "Agent liveness probe" for the empirical basis. Prints one of:
 #   alive   - the foreground command is one of the verified harness binaries
-#             (claude, codex, opencode, grok - each confirmed to run as its
-#             own process name, never wrapped by a generic interpreter).
+#             (claude, codex, opencode, grok, cursor-agent, agy - each confirmed
+#             to run as its own process name, never wrapped by a generic
+#             interpreter: cursor-agent's node launcher execs with `exec -a "$0"`
+#             so the pane command stays "cursor-agent", and agy is a native binary).
 #   dead    - the foreground command is a bare shell: nothing is running in
 #             the pane, so a prior agent process has exited.
 #   unknown - anything else, INCLUDING a bare "node"/"python" interpreter
@@ -160,7 +162,7 @@ fm_backend_tmux_agent_alive() {  # <target>
   comm=${comm#-}
   case "$comm" in
     '') printf 'unknown' ;;
-    *claude*|*codex*|*opencode*|*grok*) printf 'alive' ;;
+    *claude*|*codex*|*opencode*|*grok*|*cursor*|agy) printf 'alive' ;;
     zsh|bash|sh|dash|ash|ksh|mksh|tcsh|csh|fish) printf 'dead' ;;
     *) printf 'unknown' ;;
   esac

--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -162,7 +162,7 @@ fm_backend_tmux_agent_alive() {  # <target>
   comm=${comm#-}
   case "$comm" in
     '') printf 'unknown' ;;
-    *claude*|*codex*|*opencode*|*grok*|*cursor*|agy) printf 'alive' ;;
+    *claude*|*codex*|*opencode*|*grok*|*cursor-agent*|agy) printf 'alive' ;;
     zsh|bash|sh|dash|ash|ksh|mksh|tcsh|csh|fish) printf 'dead' ;;
     *) printf 'unknown' ;;
   esac

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -286,7 +286,7 @@ secondmate_liveness_sweep() {
     [ -n "$target" ] || target="$window"
     verdict=$(fm_backend_agent_alive "$backend" "$target" 2>/dev/null) || verdict="unknown"
     case "$harness" in
-      claude|codex|opencode|pi|grok) ;;
+      claude|codex|opencode|pi|grok|cursor|agy) ;;
       *) [ "$verdict" = dead ] && verdict=unknown ;;
     esac
     case "$verdict" in

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Detect the agent harness this process tree runs on.
-# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|grok|unknown
+# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|grok|cursor|agy|unknown
 #        fm-harness.sh crew             print the effective CREWMATE harness
 #                                        (config/crew-harness; "default" resolves to own)
 #        fm-harness.sh secondmate       print the harness the PRIMARY uses to launch
@@ -35,6 +35,11 @@ detect_own() {
   # It does NOT set CLAUDECODE despite being Claude-Code-compatible, so this marker
   # is unambiguous when firstmate runs natively on grok.
   [ "${GROK_AGENT:-}" = "1" ] && { echo grok; return; }
+  # cursor-agent sets CURSOR_AGENT=1 for its child/tool processes (verified,
+  # cursor-agent 2026.07.09); it does NOT set CLAUDECODE. agy (Antigravity CLI)
+  # sets ANTIGRAVITY_AGENT=1 the same way (verified, agy 1.1.1).
+  [ "${CURSOR_AGENT:-}" = "1" ] && { echo cursor; return; }
+  [ "${ANTIGRAVITY_AGENT:-}" = "1" ] && { echo agy; return; }
   # Layer 2: walk the parent chain and match the command name.
   local pid=$$ comm args
   for _ in 1 2 3 4 5 6 7 8; do
@@ -44,6 +49,11 @@ detect_own() {
       *codex*) echo codex; return ;;
       *opencode*) echo opencode; return ;;
       *grok*) echo grok; return ;;
+      # cursor-agent's interactive pane runs as "cursor-agent" (its bash launcher
+      # execs node with `exec -a "$0"`, so argv[0] carries the cursor-agent path);
+      # agy is a native binary named "agy".
+      *cursor-agent*|*cursor*) echo cursor; return ;;
+      agy) echo agy; return ;;
       pi) echo pi; return ;;
       node*|python*)
         # Bare interpreter: match the harness name in its script path.
@@ -53,6 +63,7 @@ detect_own() {
           *codex*) echo codex; return ;;
           *opencode*) echo opencode; return ;;
           *grok*) echo grok; return ;;
+          *cursor-agent*|*cursor*) echo cursor; return ;;
           *" pi "*|*/pi) echo pi; return ;;
         esac ;;
     esac

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -52,7 +52,7 @@ detect_own() {
       # cursor-agent's interactive pane runs as "cursor-agent" (its bash launcher
       # execs node with `exec -a "$0"`, so argv[0] carries the cursor-agent path);
       # agy is a native binary named "agy".
-      *cursor-agent*|*cursor*) echo cursor; return ;;
+      *cursor-agent*) echo cursor; return ;;
       agy) echo agy; return ;;
       pi) echo pi; return ;;
       node*|python*)
@@ -63,7 +63,7 @@ detect_own() {
           *codex*) echo codex; return ;;
           *opencode*) echo opencode; return ;;
           *grok*) echo grok; return ;;
-          *cursor-agent*|*cursor*) echo cursor; return ;;
+          *cursor-agent*) echo cursor; return ;;
           *" pi "*|*/pi) echo pi; return ;;
         esac ;;
     esac

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -33,7 +33,7 @@
 #   profile consultation. A --secondmate spawn is exempt and resolves the SECONDMATE
 #   harness (config/secondmate-harness -> config/crew-harness -> own), so the
 #   secondmate-vs-crewmate split is DURABLE across every respawn (recovery,
-#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|grok)
+#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|grok|cursor|agy)
 #   overrides it for this spawn (either kind). A non-flag string containing
 #   whitespace is treated as a RAW launch command - the escape hatch for verifying
 #   new adapters.
@@ -279,7 +279,7 @@ FIRSTMATE_HOME=
 
 if [ "$KIND" = secondmate ]; then
   case "${POS[1]:-}" in
-    ''|claude|codex|opencode|pi|grok)
+    ''|claude|codex|opencode|pi|grok|cursor|agy)
       ARG3=${POS[1]:-}
       ;;
     *' '*)
@@ -340,6 +340,24 @@ launch_template() {
     # launch command - it is a Stop-event hook installed below (global hook +
     # per-task pointer), so the template is identical for ship/scout/secondmate.
     grok) printf '%s' 'grok --always-approve __MODELFLAG____EFFORTFLAG__"$(cat __BRIEF__)"' ;;
+    # cursor (Cursor Agent CLI, `cursor-agent`): a positional prompt starts the
+    # supervised interactive session. --force (alias --yolo) auto-approves every
+    # tool execution so the crewmate runs fully unattended (footer "Run
+    # Everything"), the targeted equivalent of claude's
+    # --dangerously-skip-permissions. Effort is embedded in the model id (e.g.
+    # gpt-5.6-sol-medium), so cursor has no separate effort flag - __EFFORTFLAG__
+    # is intentionally absent. cursor's turn-end signal does NOT ride the launch
+    # command - it is a `stop` hook installed below in a per-worktree
+    # .cursor/hooks.json, so the template is identical for ship/scout/secondmate.
+    cursor) printf '%s' 'cursor-agent --force __MODELFLAG__"$(cat __BRIEF__)"' ;;
+    # agy (Antigravity CLI): -i (--prompt-interactive) starts a supervised session
+    # from an initial prompt. --dangerously-skip-permissions auto-approves every
+    # tool request so the crewmate runs unattended. Effort is baked into the model
+    # display name (e.g. "Gemini 3.1 Pro (High)"), so agy has no separate effort
+    # flag. agy exposes no verified trust-free per-turn turn-end hook, so firstmate
+    # relies on stale-pane detection (the "esc to cancel" busy signature); no hook
+    # is installed and the template is identical for ship/scout/secondmate.
+    agy) printf '%s' 'agy --dangerously-skip-permissions __MODELFLAG__-i "$(cat __BRIEF__)"' ;;
     *) return 1 ;;
   esac
 }
@@ -427,7 +445,11 @@ model_flag_for_harness() {
   local harness=$1 model=$2
   [ -n "$model" ] && [ "$model" != default ] || return 0
   case "$harness" in
-    claude|codex|opencode|pi|grok)
+    # cursor takes --model with effort embedded in the id (gpt-5.6-sol-medium);
+    # agy takes --model with a display name whose effort is baked in ("... (High)").
+    # Both are model-flag-only: their effort axis lives inside the model string,
+    # so effort_flag_for_harness deliberately emits nothing for them.
+    claude|codex|opencode|pi|grok|cursor|agy)
       printf -- '--model %s ' "$(shell_quote "$model")"
       ;;
   esac
@@ -468,6 +490,10 @@ effort_flag_for_harness() {
     # opencode's interactive `opencode --prompt` launch has a verified --model
     # flag but no verified effort flag. Its `opencode run --variant` flag belongs
     # to a different, non-interactive launch mode, so fm-spawn does not pass it.
+    # cursor and agy have no separate effort flag: effort is part of the model id
+    # (cursor: gpt-5.6-sol-medium; agy: "Gemini 3.1 Pro (High)"), so firstmate
+    # folds the requested effort into the model string it chooses at intake and
+    # emits no effort flag here.
   esac
 }
 
@@ -962,6 +988,24 @@ EOF
       printf '{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"%s"}]}]}}\n' "$hook_command" > "$GROK_HOOKS_DIR/fm-turn-end.json"
       printf 'token=%s\n' "${auth_file##*/}" > "$WT/.fm-grok-turnend"
       exclude_path '.fm-grok-turnend'
+      ;;
+    cursor*)
+      # cursor fires a `stop` hook at every turn boundary once the workspace is
+      # trusted (verified, cursor-agent 2026.07.09), the clean equivalent of
+      # claude's Stop hook. A per-worktree .cursor/hooks.json touches the task's
+      # turn-end file; it is gitignore-excluded (git info/exclude) exactly like the
+      # other harnesses' worktree hook files and removed by fm-teardown. The inline
+      # `touch` command needs no helper script (verified: the single-file inline
+      # form fires the marker).
+      mkdir -p "$WT/.cursor"
+      printf '{"version":1,"hooks":{"stop":[{"command":"touch %s"}]}}\n' "$(shell_quote "$TURNEND")" > "$WT/.cursor/hooks.json"
+      exclude_path '.cursor/hooks.json'
+      ;;
+    agy*)
+      # agy exposes no verified trust-free per-turn turn-end hook (its hooks.json
+      # system surfaces only internal framework hooks), so firstmate installs no
+      # hook and relies on stale-pane detection driven by agy's "esc to cancel"
+      # busy signature. No worktree file to exclude or clean up.
       ;;
   esac
 fi

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -566,7 +566,7 @@ validate_worktree_teardown_safety() {
     echo "Restore the git index state, or get the captain's explicit OK to discard, then --force." >&2
     return 1
   fi
-  dirty=$(printf '%s\n' "$dirty_raw" | grep -vE '^\?\? (\.claude/|\.fm-grok-turnend$)' | head -1 || true)
+  dirty=$(printf '%s\n' "$dirty_raw" | grep -vE '^\?\? (\.claude/|\.cursor/|\.fm-grok-turnend$)' | head -1 || true)
 
   if ! unpushed_raw=$(git -C "$WT" log --oneline HEAD --not --remotes -- 2>/dev/null); then
     if worktree_safety_blocked_by_lock "commits not on a remote"; then
@@ -895,12 +895,12 @@ cleanup_firstmate_home_children() {
     elif [ "$child_backend" = orca ]; then
       if [ -n "$child_wt" ] && [ -d "$child_wt" ]; then
         validate_child_worktree_for_removal "$child_wt" "$child_proj" >/dev/null || return 1
-        rm -f "$child_wt/.claude/settings.local.json" "$child_wt/.opencode/plugins/fm-turn-end.js" "$child_wt/.fm-grok-turnend"
+        rm -f "$child_wt/.claude/settings.local.json" "$child_wt/.opencode/plugins/fm-turn-end.js" "$child_wt/.fm-grok-turnend" "$child_wt/.cursor/hooks.json"
       fi
       fm_backend_remove_worktree "$child_backend" "$child_orca_worktree_id" || return 1
     elif [ -n "$child_wt" ] && [ -d "$child_wt" ]; then
       validate_child_worktree_for_removal "$child_wt" "$child_proj" >/dev/null || return 1
-      rm -f "$child_wt/.claude/settings.local.json" "$child_wt/.opencode/plugins/fm-turn-end.js" "$child_wt/.fm-grok-turnend"
+      rm -f "$child_wt/.claude/settings.local.json" "$child_wt/.opencode/plugins/fm-turn-end.js" "$child_wt/.fm-grok-turnend" "$child_wt/.cursor/hooks.json"
       if [ -n "$child_proj" ] && [ -d "$child_proj" ] && command -v treehouse >/dev/null 2>&1; then
         if teardown_treehouse_return "$child_wt" "$child_proj" "child worktree"; then
           :
@@ -1010,7 +1010,7 @@ elif [ -d "$WT" ] && [ "$KIND" != secondmate ]; then
     fi
   fi
   # Remove our hook file so a reused pool worktree cannot fire signals for a dead task.
-  rm -f "$WT/.claude/settings.local.json" "$WT/.opencode/plugins/fm-turn-end.js" "$WT/.fm-grok-turnend"
+  rm -f "$WT/.claude/settings.local.json" "$WT/.opencode/plugins/fm-turn-end.js" "$WT/.fm-grok-turnend" "$WT/.cursor/hooks.json"
   # Kills remaining processes in the worktree (including the agent), resets, returns
   # to pool. treehouse resolves the pool from the working directory, so run it from
   # the project. teardown_treehouse_return tolerates transient and stale git locks

--- a/bin/fm-tmux-lib.sh
+++ b/bin/fm-tmux-lib.sh
@@ -48,8 +48,10 @@
 
 # Busy footers per harness (mirror fm-watch.sh). claude/codex: "esc to
 # interrupt"; opencode: "esc interrupt"; pi: "Working..."; grok: "Ctrl+c:cancel"
-# (grok's mid-turn cancel hint, shown iff a turn is running - verified grok 0.2.73).
-FM_TMUX_BUSY_REGEX_DEFAULT='esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel'
+# (grok's mid-turn cancel hint, shown iff a turn is running - verified grok 0.2.73);
+# cursor: "ctrl+c to stop" (footer stop hint - verified cursor-agent 2026.07.09);
+# agy: "esc to cancel" (footer cancel hint - verified agy 1.1.1).
+FM_TMUX_BUSY_REGEX_DEFAULT='esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel|ctrl\+c to stop|esc to cancel'
 
 # fm_tmux_strip_ghost: thin adapter over the shared, fleet-wide ghost extractor
 # fm_composer_strip_ghost (bin/fm-composer-lib.sh). It drops de-emphasised
@@ -59,6 +61,24 @@ FM_TMUX_BUSY_REGEX_DEFAULT='esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel'
 # tmux entry point (and for existing callers/tests) but owns no logic of its own,
 # so the tmux and herdr adapters cannot drift apart on what counts as ghost text.
 fm_tmux_strip_ghost() { fm_composer_strip_ghost; }
+
+# fm_tmux_row_is_rule: 0 iff the plain (ANSI-stripped) row on stdin is a pure
+# horizontal-rule border - only box-drawing/block horizontal characters and
+# whitespace, with a run of at least three. Used to recognize a composer box that
+# draws horizontal top/bottom rules around its input row (e.g. agy's "───" box
+# around a lone "> " prompt) rather than the vertical side borders the composer
+# reader detects on the content row itself. The literal rule characters are
+# matched/stripped byte-wise (LC_ALL=C), so this stays locale-independent.
+fm_tmux_row_is_rule() {
+  local row rest
+  row=$(cat)
+  case "$row" in
+    *───*|*━━━*|*▀▀▀*|*▄▄▄*) : ;;
+    *) return 1 ;;
+  esac
+  rest=$(printf '%s' "$row" | LC_ALL=C sed 's/─//g; s/━//g; s/▀//g; s/▄//g' | tr -d '[:space:]')
+  [ -z "$rest" ]
+}
 
 # fm_tmux_composer_state: classify the cursor/composer line of <target> as
 #   empty   - no pending input (blank, a busy footer, an empty agent composer, or
@@ -108,6 +128,28 @@ fm_tmux_composer_state() {  # <target> -> empty|pending|unknown
   esac
   stripped="${stripped#"${stripped%%[![:space:]]*}"}"
   stripped="${stripped%"${stripped##*[![:space:]]}"}"
+  # Horizontal-rule composer box (e.g. agy's "───" rules above and below a lone
+  # "> " prompt): the box draws no side border on the content row, so the
+  # side-border check above left bordered=0 and a bare shell-prompt glyph would
+  # misclassify as a dead shell (unknown, unsafe to inject). When the content is a
+  # lone shell-prompt glyph and BOTH adjacent rows are pure horizontal rules, the
+  # glyph sits inside a genuine agent composer: set bordered=1 so it reads empty. A
+  # real dead-shell prompt is not flanked by rule rows, so its unsafe-to-inject
+  # verdict is preserved. The extra reads fire only in this bare-glyph case (agy
+  # idle or a dead shell), so claude/codex/cursor/grok panes still read one row.
+  # Verified against agy 1.1.1.
+  if [ "$bordered" = 0 ] && [ "$cy" -ge 1 ]; then
+    case "$stripped" in
+      '>'|'$'|'%'|'#')
+        local above below
+        above=$(tmux capture-pane -p -t "$target" -S "$((cy - 1))" -E "$((cy - 1))" 2>/dev/null | fm_composer_strip_ansi)
+        below=$(tmux capture-pane -p -t "$target" -S "$((cy + 1))" -E "$((cy + 1))" 2>/dev/null | fm_composer_strip_ansi)
+        if printf '%s' "$above" | fm_tmux_row_is_rule && printf '%s' "$below" | fm_tmux_row_is_rule; then
+          bordered=1
+        fi
+        ;;
+    esac
+  fi
   # A busy footer landing on the cursor line is not pending input (tmux-specific:
   # only tmux captures the raw cursor row, which may BE the footer).
   if [ -n "$stripped" ] \

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -107,7 +107,10 @@ SIGNAL_GRACE=${FM_SIGNAL_GRACE:-30}   # seconds to linger after a signal so trai
 # grok: "Ctrl+c:cancel" (the mid-turn cancel hint in grok's keybind bar, shown iff a
 # turn is running; absent when idle - verified grok 0.2.73, ASCII to avoid the
 # locale fragility of matching grok's braille spinner glyph directly).
-BUSY_REGEX=${FM_BUSY_REGEX:-'esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel'}
+# cursor: "ctrl+c to stop" (footer stop hint while a turn runs - verified
+# cursor-agent 2026.07.09). agy: "esc to cancel" (footer cancel hint while a turn
+# runs, stable across agy's "Working..."/"Generating..." verb lines - verified agy 1.1.1).
+BUSY_REGEX=${FM_BUSY_REGEX:-'esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel|ctrl\+c to stop|esc to cancel'}
 # Always-on wake triage: most wakes during a long crew validation are benign (a
 # working: note or turn-end while a pipeline runs, a no-change heartbeat). Rather
 # than wake firstmate's LLM for each, this watcher classifies every wake in bash

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -107,7 +107,7 @@ The session-start bootstrap step surfaces either the active rule block or a conc
 When the file exists, `fm-spawn.sh` refuses crewmate and scout launches without an explicit harness, so `config/crew-harness` is only automatic when no dispatch profile file is active.
 Secondmate launches are exempt because they resolve the secondmate harness and any optional secondmate model or effort tokens instead.
 Unsupported effort values are still recorded in task meta when passed to `fm-spawn.sh`, but the launch template omits any effort flag that the selected harness does not accept.
-That keeps spawn launch compatible across claude, codex, grok, pi, and opencode while preserving the requested profile for later audit.
+That keeps spawn launch compatible across claude, codex, grok, pi, opencode, cursor, and agy while preserving the requested profile for later audit.
 
 ## Optional secondmates
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -140,7 +140,8 @@ The full cmux home label also includes a short hash of the resolved `FM_ROOT` pa
 
 ## Harness support
 
-claude, codex, opencode, pi, and grok are all empirically verified; new harnesses get verified through a supervised trial task before joining the set.
+claude, codex, opencode, pi, grok, cursor, and agy are all empirically verified; new harnesses get verified through a supervised trial task before joining the set.
+cursor (`cursor-agent`) and agy (Antigravity CLI) are verified as crewmate and secondmate adapters, not yet as the firstmate primary.
 The verified adapter knowledge - busy signatures, interrupt and exit commands, skill-invocation syntax, and per-harness quirks - lives in [`.agents/skills/harness-adapters/SKILL.md`](../.agents/skills/harness-adapters/SKILL.md).
 Launch mechanics, including the verified command templates, live in [`bin/fm-spawn.sh`](../bin/fm-spawn.sh).
 Primary-session turn-end guard integrations for verified harnesses are tracked as repo-level hook files and documented in [`docs/turnend-guard.md`](turnend-guard.md).

--- a/docs/orca-backend.md
+++ b/docs/orca-backend.md
@@ -1,7 +1,7 @@
 # Orca Backend
 
 Orca is an experimental runtime backend for firstmate.
-It is distinct from the crewmate harness: the harness is the agent process firstmate launches (`claude`, `codex`, `opencode`, `pi`, or `grok`), while Orca owns the task worktree and terminal endpoint underneath that process.
+It is distinct from the crewmate harness: the harness is the agent process firstmate launches (`claude`, `codex`, `opencode`, `pi`, `grok`, `cursor`, or `agy`), while Orca owns the task worktree and terminal endpoint underneath that process.
 Firstmate agents operating this backend should load the agent-only [`firstmate-orca`](../.agents/skills/firstmate-orca/SKILL.md) checklist before switching to Orca, spawning or supervising Orca-backed work, smoke-testing, debugging task state, or reconciling Orca metadata.
 
 ## Setup

--- a/docs/tmux-backend.md
+++ b/docs/tmux-backend.md
@@ -99,7 +99,7 @@ Verified the same session: a persisting parent process running a child command (
 
 The classifier (`fm_backend_tmux_agent_alive`) maps the observed name to `alive`, `dead`, or `unknown`:
 
-- `alive` - the name contains `claude`, `codex`, `opencode`, or `grok`. All four were confirmed to run as their own literal process name (`ps -ef`, 2026-07-07): `claude` and `codex` and `opencode` are each a native compiled binary (`file` reports Mach-O), so their `comm` is their own binary name with no interpreter wrapper to hide behind.
+- `alive` - the name contains `claude`, `codex`, `opencode`, `grok`, `cursor`, or is exactly `agy`. All were confirmed to run as their own literal process name (`ps -ef`, 2026-07-07): `claude` and `codex` and `opencode` are each a native compiled binary (`file` reports Mach-O), so their `comm` is their own binary name with no interpreter wrapper to hide behind. `cursor-agent` is a bash launcher that execs Node with `exec -a "$0"`, so its `pane_current_command` stays `cursor-agent` rather than a bare `node` (verified 2026-07-12, cursor-agent 2026.07.09); `agy` is a native ELF binary named `agy` (verified 2026-07-12, agy 1.1.1). A pane that exits to a login shell reports `bash`/`zsh` and classifies `dead`, so a torn-down cursor/agy crew reads `dead`, not `alive`.
 - `dead` - the name is a bare shell (`zsh`, `bash`, `sh`, `dash`, `ash`, `ksh`, `mksh`, `tcsh`, `csh`, `fish`).
 - `unknown` - anything else, including an unreadable pane.
 

--- a/docs/tmux-backend.md
+++ b/docs/tmux-backend.md
@@ -76,6 +76,7 @@ It reads tmux's own `#{pane_current_command}`, which reports the pane's live for
 
 Agent liveness and composer safety are separate checks.
 During away-mode escalation delivery, `fm_tmux_composer_state` sends a bare shell glyph on an unbordered row to the shared composer classifier as `unknown`, and the daemon injects only into an affirmatively `empty` composer; see [Composer-emptiness safety](herdr-backend.md#composer-emptiness-safety-2026-07-10-fleet-wide-across-all-four-backends).
+The one structural exception is agy's composer box, whose lone `> ` glyph draws no side border but is flanked by horizontal-rule rows (`fm_tmux_row_is_rule`, `bin/fm-tmux-lib.sh`): a bare shell-prompt glyph flanked above and below by pure rule rows reads `empty`, while a real dead-shell prompt (no rule rows) keeps its `unknown` verdict.
 
 Verified empirically with real tmux 3.6a on macOS (Darwin 25.5.0), 2026-07-07:
 

--- a/tests/fm-cursor-agy-harness.test.sh
+++ b/tests/fm-cursor-agy-harness.test.sh
@@ -1,0 +1,278 @@
+#!/usr/bin/env bash
+# Behavior tests for the cursor (cursor-agent) and agy (Antigravity) harness
+# adapters: launch-command threading, turn-end hook install/exclude/teardown,
+# harness detection, tmux agent-liveness classification, busy signatures, and the
+# horizontal-rule composer-box classification agy's "> " prompt needs.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SPAWN="$ROOT/bin/fm-spawn.sh"
+TEARDOWN="$ROOT/bin/fm-teardown.sh"
+TMP_ROOT=$(fm_test_tmproot fm-cursor-agy-harness)
+
+# --- spawn harness (fake tmux logs the -l launch command) -------------------
+
+make_spawn_fakebin() {
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+esac
+case "${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+  list-windows) exit 0 ;;
+  send-keys)
+    prev=
+    for a in "$@"; do
+      [ "$prev" = "-l" ] && printf '%s\n' "$a" >> "${FM_FAKE_SENDKEYS_LOG:-/dev/null}"
+      prev=$a
+    done
+    exit 0 ;;
+  has-session|new-session|new-window|kill-window) exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" treehouse gh-axi gh
+  printf '%s\n' "$fakebin"
+}
+
+# make_spawn_case <name> -> "case_dir|home|proj|wt|fakebin|id|launchlog"
+make_spawn_case() {
+  local name=$1 case_dir home proj wt fakebin id launchlog
+  case_dir="$TMP_ROOT/$name"
+  home="$case_dir/home"
+  proj="$case_dir/project"
+  wt="$case_dir/wt"
+  fakebin=$(make_spawn_fakebin "$case_dir/fake")
+  id="$name-x1"
+  launchlog="$case_dir/launch.log"
+  mkdir -p "$home/data/$id" "$home/projects" "$home/state" "$home/config"
+  printf 'brief\n' > "$home/data/$id/brief.md"
+  fm_git_worktree "$proj" "$wt" "fm/$id"
+  touch "$home/state/.last-watcher-beat"
+  printf '%s\n' "$case_dir|$home|$proj|$wt|$fakebin|$id|$launchlog"
+}
+
+run_spawn() {  # <home> <proj> <wt> <fakebin> <id> <launchlog> <harness> [extra args...]
+  local home=$1 proj=$2 wt=$3 fakebin=$4 id=$5 launchlog=$6 harness=$7
+  shift 7
+  FM_ROOT_OVERRIDE='' FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
+    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" FM_FAKE_SENDKEYS_LOG="$launchlog" \
+    TMUX="fake,1,0" PATH="$fakebin:$PATH" \
+    "$SPAWN" "$id" "$proj" --harness "$harness" "$@" 2>&1
+}
+
+test_cursor_spawn_launch_and_stop_hook() {
+  local rec case_dir home proj wt fakebin id launchlog out status excl
+  rec=$(make_spawn_case cursor-spawn)
+  IFS='|' read -r case_dir home proj wt fakebin id launchlog <<EOF
+$rec
+EOF
+  out=$(run_spawn "$home" "$proj" "$wt" "$fakebin" "$id" "$launchlog" cursor --model gpt-5.6-sol-medium)
+  status=$?
+  expect_code 0 "$status" "cursor spawn should succeed"
+  assert_contains "$out" "spawned $id harness=cursor" "cursor spawn did not report success"
+
+  # Launch command threads --force and --model, and no separate effort flag.
+  assert_grep 'cursor-agent --force' "$launchlog" "cursor launch missing autonomy flag"
+  assert_grep "--model 'gpt-5.6-sol-medium'" "$launchlog" "cursor launch did not thread --model"
+  assert_no_grep '--effort' "$launchlog" "cursor launch must not pass a separate --effort flag"
+  assert_no_grep '--thinking' "$launchlog" "cursor launch must not pass --thinking"
+
+  # Per-worktree stop hook installed, points at the turn-end file, and is excluded.
+  assert_present "$wt/.cursor/hooks.json" "cursor stop hook was not installed"
+  assert_grep '"stop"' "$wt/.cursor/hooks.json" "cursor hook is not a stop hook"
+  assert_grep "$home/state/$id.turn-ended" "$wt/.cursor/hooks.json" "cursor hook does not touch the turn-end file"
+  excl=$(git -C "$wt" rev-parse --git-path info/exclude)
+  assert_grep '.cursor/hooks.json' "$excl" "cursor hook was not git-excluded"
+  pass "cursor spawn threads --force/--model and installs an excluded stop hook"
+}
+
+test_cursor_teardown_removes_hook() {
+  local rec case_dir home proj wt fakebin id launchlog
+  rec=$(make_spawn_case cursor-teardown)
+  IFS='|' read -r case_dir home proj wt fakebin id launchlog <<EOF
+$rec
+EOF
+  run_spawn "$home" "$proj" "$wt" "$fakebin" "$id" "$launchlog" cursor >/dev/null 2>&1
+  assert_present "$wt/.cursor/hooks.json" "cursor hook missing before teardown"
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    PATH="$fakebin:$PATH" "$TEARDOWN" "$id" --force >/dev/null 2>&1 \
+    || fail "cursor teardown failed"
+  assert_absent "$wt/.cursor/hooks.json" "cursor hook survived teardown"
+  pass "cursor teardown removes the stop hook"
+}
+
+test_agy_spawn_launch_and_no_hook() {
+  local rec case_dir home proj wt fakebin id launchlog out status
+  rec=$(make_spawn_case agy-spawn)
+  IFS='|' read -r case_dir home proj wt fakebin id launchlog <<EOF
+$rec
+EOF
+  out=$(run_spawn "$home" "$proj" "$wt" "$fakebin" "$id" "$launchlog" agy --model 'Gemini 3.1 Pro (High)')
+  status=$?
+  expect_code 0 "$status" "agy spawn should succeed"
+  assert_contains "$out" "spawned $id harness=agy" "agy spawn did not report success"
+
+  assert_grep 'agy --dangerously-skip-permissions' "$launchlog" "agy launch missing autonomy flag"
+  assert_grep "--model 'Gemini 3.1 Pro (High)'" "$launchlog" "agy launch did not thread --model"
+  # The launch string embeds the literal `-i "$(cat <brief>)"`; match it verbatim.
+  # shellcheck disable=SC2016
+  assert_grep '-i "$(cat' "$launchlog" "agy launch did not use interactive -i for the brief"
+  assert_no_grep '--effort' "$launchlog" "agy launch must not pass --effort"
+
+  # agy uses stale-pane detection, so no per-worktree turn-end hook file exists.
+  assert_absent "$wt/.cursor/hooks.json" "agy must not install a cursor hook"
+  assert_absent "$wt/.claude/settings.local.json" "agy must not install a claude hook"
+  pass "agy spawn threads autonomy/-i/--model and installs no turn-end hook"
+}
+
+# --- harness detection ------------------------------------------------------
+
+test_harness_detection_env_markers() {
+  local out
+  # Unset any earlier-precedence markers (this suite may run under a real harness).
+  out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT CURSOR_AGENT=1 "$ROOT/bin/fm-harness.sh")
+  [ "$out" = cursor ] || fail "CURSOR_AGENT=1 should detect cursor, got '$out'"
+  out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT -u CURSOR_AGENT ANTIGRAVITY_AGENT=1 "$ROOT/bin/fm-harness.sh")
+  [ "$out" = agy ] || fail "ANTIGRAVITY_AGENT=1 should detect agy, got '$out'"
+  pass "fm-harness detects cursor and agy from their env markers"
+}
+
+# --- tmux agent-liveness ----------------------------------------------------
+
+test_agent_alive_classifies_cursor_agy() {
+  local fakebin verdict
+  fakebin=$(fm_fakebin "$TMP_ROOT/alive-fake")
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+# pane_current_command comes from FM_FAKE_COMMAND.
+printf '%s\n' "${FM_FAKE_COMMAND:-}"
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+  # Load the tmux backend the supported way (fm_backend_source sets the lib dir
+  # and pulls in fm-tmux-lib.sh / fm-composer-lib.sh transitively).
+  # shellcheck source=bin/fm-backend.sh
+  . "$ROOT/bin/fm-backend.sh"
+  fm_backend_source tmux
+  verdict=$(PATH="$fakebin:$PATH" FM_FAKE_COMMAND=cursor-agent fm_backend_tmux_agent_alive fake:1)
+  [ "$verdict" = alive ] || fail "cursor-agent should be alive, got '$verdict'"
+  verdict=$(PATH="$fakebin:$PATH" FM_FAKE_COMMAND=agy fm_backend_tmux_agent_alive fake:1)
+  [ "$verdict" = alive ] || fail "agy should be alive, got '$verdict'"
+  verdict=$(PATH="$fakebin:$PATH" FM_FAKE_COMMAND=bash fm_backend_tmux_agent_alive fake:1)
+  [ "$verdict" = dead ] || fail "bash should be dead, got '$verdict'"
+  pass "tmux agent-liveness classifies cursor-agent/agy alive and bash dead"
+}
+
+# --- busy signatures --------------------------------------------------------
+
+test_busy_regex_matches_cursor_agy() {
+  # shellcheck source=bin/fm-composer-lib.sh
+  . "$ROOT/bin/fm-composer-lib.sh"
+  # shellcheck source=bin/fm-tmux-lib.sh
+  . "$ROOT/bin/fm-tmux-lib.sh"
+  local re="$FM_TMUX_BUSY_REGEX_DEFAULT"
+  printf '%s' ' → Add a follow-up            ctrl+c to stop' | grep -qiE "$re" \
+    || fail "cursor busy footer 'ctrl+c to stop' not matched"
+  printf '%s' 'esc to cancel                 Gemini 3.1 Pro (High)' | grep -qiE "$re" \
+    || fail "agy busy footer 'esc to cancel' not matched"
+  printf '%s' '  → Add a follow-up' | grep -qiE "$re" \
+    && fail "cursor idle footer must not match busy regex"
+  printf '%s' '? for shortcuts' | grep -qiE "$re" \
+    && fail "agy idle footer must not match busy regex"
+  pass "busy regex matches cursor/agy busy footers, not their idle footers"
+}
+
+# --- composer classification ------------------------------------------------
+
+test_row_is_rule() {
+  # shellcheck source=bin/fm-composer-lib.sh
+  . "$ROOT/bin/fm-composer-lib.sh"
+  # shellcheck source=bin/fm-tmux-lib.sh
+  . "$ROOT/bin/fm-tmux-lib.sh"
+  printf '%s' '────────────────────' | fm_tmux_row_is_rule || fail "a box-drawing rule row should be a rule"
+  printf '%s' '  ▀▀▀▀▀▀▀▀▀▀  ' | fm_tmux_row_is_rule || fail "a block rule row should be a rule"
+  printf '%s' '> some real text' | fm_tmux_row_is_rule && fail "a text row must not be a rule"
+  printf '%s' '──── heading ────' | fm_tmux_row_is_rule && fail "a rule with embedded text must not be a pure rule"
+  printf '%s' '' | fm_tmux_row_is_rule && fail "a blank row must not be a rule"
+  pass "fm_tmux_row_is_rule recognizes pure horizontal-rule rows only"
+}
+
+# A fake tmux whose capture-pane returns a different row per -S value, so the
+# 3-row composer read (content at cy, borders at cy-1/cy+1) can be exercised
+# hermetically. Rows are supplied via FM_ROW_<n> env vars (n = the -S value).
+make_composer_tmux() {
+  local fakebin=$1
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  *cursor_y*) printf '%s\n' "${FM_CURSOR_Y:-10}"; exit 0 ;;
+esac
+case "${1:-}" in
+  capture-pane)
+    s=
+    prev=
+    for a in "$@"; do [ "$prev" = "-S" ] && s=$a; prev=$a; done
+    var="FM_ROW_$s"
+    printf '%b\n' "${!var:-}"
+    exit 0 ;;
+  display-message) printf '0\n'; exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+}
+
+test_composer_agy_box_is_empty() {
+  local fakebin state rule glyph
+  fakebin=$(fm_fakebin "$TMP_ROOT/composer-agy")
+  make_composer_tmux "$fakebin"
+  # shellcheck source=bin/fm-composer-lib.sh
+  . "$ROOT/bin/fm-composer-lib.sh"
+  # shellcheck source=bin/fm-tmux-lib.sh
+  . "$ROOT/bin/fm-tmux-lib.sh"
+  rule='────────────────────'
+  glyph='\033[38;5;111m>\033[39m'   # agy's 256-colour ">" prompt (not dim, not stripped)
+  state=$(PATH="$fakebin:$PATH" \
+    FM_CURSOR_Y=10 FM_ROW_10="$glyph" FM_ROW_9="$rule" FM_ROW_11="$rule" \
+    fm_tmux_composer_state fake:1)
+  [ "$state" = empty ] || fail "agy '> ' inside a rule box should read empty, got '$state'"
+  pass "agy horizontal-rule composer box classifies as empty"
+}
+
+test_composer_bare_prompt_without_rules_is_unknown() {
+  local fakebin state glyph
+  fakebin=$(fm_fakebin "$TMP_ROOT/composer-bare")
+  make_composer_tmux "$fakebin"
+  # shellcheck source=bin/fm-composer-lib.sh
+  . "$ROOT/bin/fm-composer-lib.sh"
+  # shellcheck source=bin/fm-tmux-lib.sh
+  . "$ROOT/bin/fm-tmux-lib.sh"
+  glyph='\033[38;5;111m>\033[39m'
+  # No rule rows around the glyph: a real dead-shell prompt, must stay unknown.
+  state=$(PATH="$fakebin:$PATH" \
+    FM_CURSOR_Y=10 FM_ROW_10="$glyph" FM_ROW_9="some command output" FM_ROW_11="" \
+    fm_tmux_composer_state fake:1)
+  [ "$state" = unknown ] || fail "a bare '>' not flanked by rules must read unknown, got '$state'"
+  pass "a bare prompt glyph without rule borders stays unknown (dead-shell safety)"
+}
+
+test_cursor_spawn_launch_and_stop_hook
+test_cursor_teardown_removes_hook
+test_agy_spawn_launch_and_no_hook
+test_harness_detection_env_markers
+test_agent_alive_classifies_cursor_agy
+test_busy_regex_matches_cursor_agy
+test_row_is_rule
+test_composer_agy_box_is_empty
+test_composer_bare_prompt_without_rules_is_unknown


### PR DESCRIPTION
## Summary

Wire `cursor` (Cursor Agent CLI, `cursor-agent`) and `agy` (Antigravity CLI) as verified, selectable firstmate **crew and secondmate** harness adapters, alongside `claude`/`codex`/`opencode`/`pi`/`grok`. After this change, `bin/fm-spawn.sh --harness cursor` and `--harness agy` launch a real autonomous crew that firstmate can supervise, steer, interrupt, exit, and tear down.

Both adapters are verified empirically against the live CLIs — **cursor-agent 2026.07.09** and **agy 1.1.1** — in scratch tmux panes (per `CONTRIBUTING.md`: harness facts are never written from documentation alone). The full verification evidence is recorded in the `harness-adapters` skill.

## Adapter facts (verified)

| | cursor | agy |
|---|---|---|
| Launch | `cursor-agent --force --model <id> "<brief>"` | `agy --dangerously-skip-permissions --model <name> -i "<brief>"` |
| Autonomy | `--force` (alias `--yolo`) | `--dangerously-skip-permissions` |
| Busy signature | `ctrl+c to stop` | `esc to cancel` |
| Interrupt | single `Ctrl+C` | single `Escape` |
| Exit | double `Ctrl+C` | double `Ctrl+C` |
| Resume | `cursor-agent --resume=<id>` / `--continue` | `agy --conversation=<id>` / `-c` |
| Env marker | `CURSOR_AGENT=1` | `ANTIGRAVITY_AGENT=1` |
| Turn-end | per-worktree `.cursor/hooks.json` `stop` hook | stale-pane detection (no verified trust-free per-turn hook) |
| Trust dialog | Workspace Trust prompt, accept with Enter | Project Trust prompt, accept with Enter |

## Decisions a diff-only review would miss

- **Effort is folded into the model string** for both, so they take `--model` only and have **no separate effort flag**. cursor uses suffixed model ids (e.g. `gpt-5.6-sol-medium`); agy uses display names (e.g. `Gemini 3.1 Pro (High)`). The documented cursor `<model>[effort=...]` bracket-override form was tested live and **rejected** by the installed CLI, so the suffixed id is the correct form.
- **cursor turn-end** rides a per-worktree `.cursor/hooks.json` `stop` hook (verified it fires and touches the marker), mirroring claude's Stop hook — gitignore-excluded and removed by teardown.
- **agy turn-end** has no verified trust-free per-turn hook (its `hooks.json` surfaces only internal framework hooks, and `~/.gemini` is high blast radius), so it installs no hook and relies on stale-pane detection driven by its `esc to cancel` busy signature — the same busy-signature mechanism the watcher already uses fleet-wide.
- **agy composer classification**: an idle agy composer is a lone `>` prompt inside a horizontal-rule box. A single-row read would misclassify it as a dead-shell `unknown`, so `fm_tmux_composer_state` now treats a lone prompt glyph flanked by pure horizontal-rule rows as a genuine composer box (reads `empty`), while a bare prompt with **no** rule borders still reads `unknown` — preserving dead-shell injection safety. This lives in the tmux adapter's structural row-finding (`fm-tmux-lib.sh`), not the shared classifier, per the one-owner rule.
- **Scope**: both are verified as crew/secondmate adapters, **not** as the firstmate primary, so primary-only surfaces (e.g. `fm-lock.sh` lock-holder detection, supervision protocols) are deliberately left untouched.

## Touchpoints

`bin/fm-harness.sh` (detection: env markers + ancestry), `bin/fm-spawn.sh` (launch templates, `--model` threading, cursor stop-hook install), `bin/fm-watch.sh` + `bin/fm-tmux-lib.sh` (busy signatures + agy composer-box recognition), `bin/fm-teardown.sh` (cursor hook cleanup), `bin/backends/tmux.sh` (agent-process liveness), `bin/fm-bootstrap.sh` (secondmate-liveness allow-list), and the `harness-adapters` skill + `AGENTS.md` + docs (verified fact sections, profile-axis rows, verified-adapter lists).

## Tests

Colocated hermetic tests in `tests/fm-cursor-agy-harness.test.sh` (9 cases): launch-command threading, cursor stop-hook install/exclude/teardown, harness detection, tmux agent-liveness, busy signatures, and the composer-box classification (empty for agy's box, unknown for a bare prompt without rules — the dead-shell safety case). All pass; `shellcheck` clean at the pinned 0.11.0.
