### PR TITLE
feat(codex): add deep-link helper for Codex app task context

### DIFF
--- a/.agents/skills/firstmate-codexapp/SKILL.md
+++ b/.agents/skills/firstmate-codexapp/SKILL.md
@@ -22,6 +22,7 @@ Read `docs/codex-app-backend.md` when it exists in this checkout; that document 
 
 If local helper scripts exist for Codex App work, use only helpers explicitly provided by the operator or maintained by Firstmate.
 For helpers outside `bin/`, inspect the source or header before running `--help`.
+The one Firstmate-maintained `bin/` helper is `bin/fm-codex-link.sh`, a read-only printer of `codex://new` deep links for task worktrees, scout reports, and project directories; it is a captain convenience, not a backend (see `docs/codex-app-backend.md`).
 
 ## Preflight
 

--- a/.opencode/.gitignore
+++ b/.opencode/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+/package.json
+/package-lock.json
+/bun.lock

--- a/.opencode/plugins/package.json
+++ b/.opencode/plugins/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Firstmate's skills live in two separate places with different audiences:
 - [docs/zellij-backend.md](docs/zellij-backend.md) - setup guide for the experimental zellij backend, plus its verification notes and known gaps.
 - [docs/orca-backend.md](docs/orca-backend.md) - setup guide for the experimental Orca backend, plus its lifecycle notes and known gaps.
 - [docs/cmux-backend.md](docs/cmux-backend.md) - setup guide for the experimental cmux backend, plus its verification notes and known gaps.
-- [docs/codex-app-backend.md](docs/codex-app-backend.md) - Codex App backend boundary, evidence, and rollout contract.
+- [docs/codex-app-backend.md](docs/codex-app-backend.md) - Codex App backend boundary, deep-link helper, evidence, and rollout contract.
 - [docs/turnend-guard.md](docs/turnend-guard.md) - the primary session's structural "no turn ends blind" backstop: verified per-harness hook mechanisms, scoping, loop safety, and fail-open tradeoffs.
 - [docs/supervision-protocols/](docs/supervision-protocols/) - rendered primary-harness watcher protocols for Claude, Codex, OpenCode, Pi, Grok, and unknown harness fallback.
 - [docs/scripts.md](docs/scripts.md) - the `bin/` toolbelt reference.

--- a/bin/backends/cmux.sh
+++ b/bin/backends/cmux.sh
@@ -397,9 +397,9 @@ fm_backend_cmux_parse_target() {  # <target>
 # (fm_backend_zellij_pane_exists) rather than the design sketch's original
 # read-screen-based suggestion.
 fm_backend_cmux_surface_exists() {  # <workspace_id> <surface_id>
-  local wsid=$1 sfid=$2
-  fm_backend_cmux_cli list-panes --workspace "$wsid" --json --id-format uuids 2>/dev/null \
-    | jq -e --arg s "$sfid" '[.panes[]? | select(.surface_ids // [] | index($s))] | length > 0' >/dev/null 2>&1
+  local wsid=$1 sfid=$2 raw
+  raw=$(fm_backend_cmux_cli list-panes --workspace "$wsid" --json --id-format uuids 2>/dev/null) || return 1
+  printf '%s' "$raw" | jq -e --arg s "$sfid" '[.panes[]? | select(.surface_ids // [] | index($s))] | length > 0' >/dev/null 2>&1
 }
 
 # fm_backend_cmux_target_ready: parse the target and verify it is live via

--- a/bin/fm-codex-link.sh
+++ b/bin/fm-codex-link.sh
@@ -10,6 +10,7 @@
 #   fm-codex-link.sh task <task-id>
 #   fm-codex-link.sh report <task-id-or-report-path>
 #   fm-codex-link.sh project <absolute-project-dir> [prompt]
+#   fm-codex-link.sh <task-id>                     (shorthand for: task <task-id>)
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -19,7 +20,7 @@ STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 
 usage() {
-  sed -n '2,12p' "$0" >&2
+  sed -n '2,13p' "$0" >&2
   exit 2
 }
 

--- a/bin/fm-codex-link.sh
+++ b/bin/fm-codex-link.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# fm-codex-link.sh - print safe Codex app deep links for firstmate task context.
+#
+# The Codex app supports codex://new?path=<absolute-dir>&prompt=<text>.
+# This helper never opens links or mutates state; it resolves known task/report
+# paths and prints both the deep link and the raw local path so the captain has
+# a fallback if the app is not registered on the current device.
+#
+# Usage:
+#   fm-codex-link.sh task <task-id>
+#   fm-codex-link.sh report <task-id-or-report-path>
+#   fm-codex-link.sh project <absolute-project-dir> [prompt]
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
+
+usage() {
+  sed -n '2,12p' "$0" >&2
+  exit 2
+}
+
+meta_value() {  # <meta-file> <key>
+  local meta=$1 key=$2
+  [ -f "$meta" ] || return 0
+  grep "^$key=" "$meta" 2>/dev/null | tail -1 | cut -d= -f2- || true
+}
+
+urlencode() {
+  local LC_ALL=C s=${1:-} i c hex out=
+  for ((i = 0; i < ${#s}; i++)); do
+    c=${s:i:1}
+    case "$c" in
+      [a-zA-Z0-9.~_-]) out+="$c" ;;
+      *) printf -v hex '%02X' "'$c"; out+="%$hex" ;;
+    esac
+  done
+  printf '%s' "$out"
+}
+
+abs_dir() {
+  local path=$1
+  [ -d "$path" ] || { echo "error: not a directory: $path" >&2; return 1; }
+  cd "$path" && pwd -P
+}
+
+link_for_dir() {
+  local label=$1 dir=$2 prompt=${3:-} abs qpath qprompt
+  abs=$(abs_dir "$dir") || return 1
+  qpath=$(urlencode "$abs")
+  qprompt=$(urlencode "$prompt")
+  printf '%s path: %s\n' "$label" "$abs"
+  if [ -n "$prompt" ]; then
+    printf '%s codex: codex://new?path=%s&prompt=%s\n' "$label" "$qpath" "$qprompt"
+  else
+    printf '%s codex: codex://new?path=%s\n' "$label" "$qpath"
+  fi
+}
+
+report_path_for() {
+  local arg=$1
+  if [ -f "$arg" ]; then
+    printf '%s' "$arg"
+    return 0
+  fi
+  if [ -f "$DATA/$arg/report.md" ]; then
+    printf '%s' "$DATA/$arg/report.md"
+    return 0
+  fi
+  echo "error: no report found for $arg (expected file or $DATA/$arg/report.md)" >&2
+  return 1
+}
+
+task_links() {
+  local id=$1 meta wt project report
+  meta="$STATE/$id.meta"
+  [ -f "$meta" ] || { echo "error: no metadata for task $id in $STATE" >&2; return 1; }
+  wt=$(meta_value "$meta" worktree)
+  project=$(meta_value "$meta" project)
+  report="$DATA/$id/report.md"
+  printf 'task: %s\n' "$id"
+  if [ -n "$wt" ] && [ -d "$wt" ]; then
+    link_for_dir "worktree" "$wt" "Review firstmate task $id in this worktree. Summarize status, diff, blockers, and next steps."
+  elif [ -n "$project" ] && [ -d "$project" ]; then
+    link_for_dir "project" "$project" "Review firstmate task $id for this project. Summarize status, blockers, and next steps."
+  else
+    printf 'worktree path: %s\n' "${wt:--}"
+    printf 'worktree codex: -\n'
+  fi
+  if [ -f "$report" ]; then
+    link_for_dir "report" "$(dirname "$report")" "Review report $report for firstmate task $id. Summarize the conclusion and recommended next action."
+  else
+    printf 'report path: -\n'
+    printf 'report codex: -\n'
+  fi
+}
+
+[ "$#" -ge 1 ] || usage
+
+case "$1" in
+  task)
+    [ "$#" -eq 2 ] || usage
+    task_links "$2"
+    ;;
+  report)
+    [ "$#" -eq 2 ] || usage
+    report=$(report_path_for "$2") || exit 1
+    link_for_dir "report" "$(dirname "$report")" "Review report $report. Summarize the conclusion and recommended next action."
+    ;;
+  project)
+    if [ "$#" -lt 2 ] || [ "$#" -gt 3 ]; then
+      usage
+    fi
+    link_for_dir "project" "$2" "${3:-}"
+    ;;
+  *)
+    if [ "$#" -eq 1 ]; then
+      task_links "$1"
+    else
+      usage
+    fi
+    ;;
+esac

--- a/docs/codex-app-backend.md
+++ b/docs/codex-app-backend.md
@@ -20,6 +20,8 @@ bin/fm-codex-link.sh report <task-id-or-report-path>
 bin/fm-codex-link.sh project <absolute-project-dir> [prompt]
 ```
 
+A bare task id without a subcommand is accepted as shorthand for `task <task-id>`.
+
 The helper reads only this firstmate home's `state/<id>.meta` and `data/<id>/report.md`.
 It never opens the app, sends a task, starts a backend, writes state, or changes supervision.
 The generated link uses the documented Codex Desktop deep-link shape `codex://new?path=<absolute-dir>&prompt=<text>`.

--- a/docs/codex-app-backend.md
+++ b/docs/codex-app-backend.md
@@ -6,6 +6,29 @@ The Codex Desktop host-tool loop works, including status-file writes, but Firstm
 This document replaces the earlier passive visible-thread ledger shape.
 A manual ledger is not a backend.
 
+## Deep-link helper
+
+`bin/fm-codex-link.sh` is a captain-facing convenience helper, not a runtime backend.
+It prints local `codex://new` links for opening a task worktree, scout report directory, or project directory in a new Codex task.
+It also prints the raw local path beside each link so the captain can fall back to normal copy/open behavior if the current device does not register the Codex URL scheme.
+
+Use it from the firstmate home:
+
+```sh
+bin/fm-codex-link.sh task <task-id>
+bin/fm-codex-link.sh report <task-id-or-report-path>
+bin/fm-codex-link.sh project <absolute-project-dir> [prompt]
+```
+
+The helper reads only this firstmate home's `state/<id>.meta` and `data/<id>/report.md`.
+It never opens the app, sends a task, starts a backend, writes state, or changes supervision.
+The generated link uses the documented Codex Desktop deep-link shape `codex://new?path=<absolute-dir>&prompt=<text>`.
+Query values are URL-encoded, and the `path` is resolved to an absolute existing local directory before a link is emitted.
+
+For task links, the worktree path wins when it exists.
+If a task has no existing `worktree=`, the helper falls back to an existing `project=` path.
+For report links, the Codex task opens in the report directory and the prompt names the exact report file to review.
+
 ## Backend acceptance contract
 
 A Codex App backend must satisfy the same lifecycle contract as the terminal-backed adapters:

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -12,6 +12,7 @@ If you have changed away from the firstmate home in an interactive shell, invoke
 | `fm-fleet-snapshot.sh`   | Print the read-only structured fleet snapshot JSON (schema `fm-fleet-snapshot.v1`)   |
 | `fm-fleet-view.sh`       | Render the fleet snapshot as a human Markdown view                                   |
 | `fm-bearings-snapshot.sh` | Project the fleet snapshot to the compact TOON bearings view; local-only unless `--include-prs` |
+| `fm-codex-link.sh`       | Print Codex app deep links plus raw paths for task worktrees, reports, and project dirs |
 | `fm-update.sh`           | Fast-forward-only self-update of firstmate and secondmate homes from origin          |
 | `fm-backlog-handoff.sh`  | Validate and delegate queued backlog-item moves into a secondmate home               |
 | `fm-brief.sh`            | Scaffold ship, scout, secondmate-charter, and Herdr-lab briefs                       |

--- a/tests/fm-backlog-handoff.test.sh
+++ b/tests/fm-backlog-handoff.test.sh
@@ -10,8 +10,11 @@ set -u
 . "$(dirname "${BASH_SOURCE[0]}")/secondmate-helpers.sh"
 
 # The move is delegated to `tasks-axi mv`, so this suite exercises the real
-# binary. Skip cleanly when it is absent (matching the backend smoke suites).
+# binary. Skip cleanly when it is absent or incompatible (lacks multi-ID mv,
+# introduced in 0.2.2) - matching the backend smoke suites' skip-on-missing.
 command -v tasks-axi >/dev/null 2>&1 || { echo "skip: tasks-axi not found (required by the delegated handoff path)"; exit 0; }
+. "$ROOT/bin/fm-tasks-axi-lib.sh"
+fm_tasks_axi_compatible || { echo "skip: tasks-axi lacks multi-ID mv support (0.2.2+ required)"; exit 0; }
 
 TMP_ROOT=$(fm_test_tmproot fm-backlog-handoff)
 

--- a/tests/fm-codex-link.test.sh
+++ b/tests/fm-codex-link.test.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Behavior tests for bin/fm-codex-link.sh.
+set -u
+
+# shellcheck source=tests/lib.sh
+# shellcheck disable=SC1091
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+CODEX_LINK="$ROOT/bin/fm-codex-link.sh"
+TMP_ROOT=$(fm_test_tmproot fm-codex-link)
+
+new_home() {
+  local d="$TMP_ROOT/$1"
+  mkdir -p "$d/state" "$d/data" "$d/projects"
+  printf '%s\n' "$d"
+}
+
+canonical_dir() {  # <dir>
+  cd "$1" && pwd -P
+}
+
+encoded_path() {  # <path>
+  local LC_ALL=C s=$1 i c hex out=
+  for ((i = 0; i < ${#s}; i++)); do
+    c=${s:i:1}
+    case "$c" in
+      [a-zA-Z0-9.~_-]) out+="$c" ;;
+      *) printf -v hex '%02X' "'$c"; out+="%$hex" ;;
+    esac
+  done
+  printf '%s' "$out"
+}
+
+run_link() {
+  local home=$1
+  shift
+  FM_HOME="$home" "$CODEX_LINK" "$@"
+}
+
+home=$(new_home main)
+mkdir -p "$home/projects/with space" "$home/projects/project only" "$home/data/link-task"
+printf '# Link report\n' > "$home/data/link-task/report.md"
+fm_write_meta "$home/state/link-task.meta" \
+  "window=firstmate:fm-link-task" \
+  "worktree=$home/projects/with space" \
+  "project=$home/projects/project only" \
+  "harness=codex" \
+  "kind=ship" \
+  "mode=direct-PR" \
+  "yolo=off"
+
+worktree_abs=$(canonical_dir "$home/projects/with space")
+report_abs=$(canonical_dir "$home/data/link-task")
+worktree_encoded=$(encoded_path "$worktree_abs")
+report_encoded=$(encoded_path "$report_abs")
+
+links=$(run_link "$home" task link-task)
+assert_contains "$links" "task: link-task" "task link prints task id"
+assert_contains "$links" "worktree path: $worktree_abs" "task link prints canonical worktree path"
+assert_contains "$links" "worktree codex: codex://new?path=$worktree_encoded&prompt=" "task link prints encoded worktree deep link"
+assert_contains "$links" "with%20space" "task link URL-encodes spaces"
+assert_contains "$links" "report path: $report_abs" "task link prints report directory"
+assert_contains "$links" "report codex: codex://new?path=$report_encoded&prompt=Review%20report%20" "task link prints encoded report deep link"
+pass "task links include worktree and report deep links"
+
+short_links=$(run_link "$home" link-task)
+assert_contains "$short_links" "task: link-task" "positional shorthand resolves task id"
+assert_contains "$short_links" "worktree path: $worktree_abs" "positional shorthand prints worktree path"
+pass "task id shorthand works"
+
+report_by_id=$(run_link "$home" report link-task)
+assert_contains "$report_by_id" "report path: $report_abs" "report link resolves task id"
+assert_contains "$report_by_id" "Summarize%20the%20conclusion" "report link includes review prompt"
+pass "report links resolve task ids"
+
+report_by_file=$(run_link "$home" report "$home/data/link-task/report.md")
+assert_contains "$report_by_file" "report path: $report_abs" "report link accepts a file path"
+pass "report links accept explicit report files"
+
+project_abs=$(canonical_dir "$home/projects/project only")
+project_encoded=$(encoded_path "$project_abs")
+project_link=$(run_link "$home" project "$home/projects/project only" "Inspect this repo")
+assert_contains "$project_link" "project path: $project_abs" "project link prints canonical project path"
+assert_contains "$project_link" "project codex: codex://new?path=$project_encoded&prompt=Inspect%20this%20repo" "project link includes encoded prompt"
+pass "project links include optional prompts"
+
+mkdir -p "$home/projects/fallback only"
+fallback_abs=$(canonical_dir "$home/projects/fallback only")
+fm_write_meta "$home/state/project-only.meta" \
+  "window=firstmate:fm-project-only" \
+  "project=$home/projects/fallback only" \
+  "harness=codex" \
+  "kind=ship" \
+  "mode=direct-PR" \
+  "yolo=off"
+fallback=$(run_link "$home" task project-only)
+assert_contains "$fallback" "project path: $fallback_abs" "task link falls back to project path when worktree is absent"
+assert_contains "$fallback" "report codex: -" "task link reports absent report clearly"
+pass "task links fall back to project path"
+
+set +e
+missing_task=$(run_link "$home" task missing 2>&1)
+missing_task_rc=$?
+missing_report=$(run_link "$home" report missing 2>&1)
+missing_report_rc=$?
+missing_dir=$(run_link "$home" project "$home/projects/nope" 2>&1)
+missing_dir_rc=$?
+usage_out=$(run_link "$home" 2>&1)
+usage_rc=$?
+set -e
+
+expect_code 1 "$missing_task_rc" "missing task exits non-zero"
+assert_contains "$missing_task" "no metadata for task missing" "missing task reports clear error"
+expect_code 1 "$missing_report_rc" "missing report exits non-zero"
+assert_contains "$missing_report" "no report found for missing" "missing report reports clear error"
+expect_code 1 "$missing_dir_rc" "missing project dir exits non-zero"
+assert_contains "$missing_dir" "not a directory" "missing project dir reports clear error"
+expect_code 2 "$usage_rc" "no-args usage exits 2"
+assert_contains "$usage_out" "fm-codex-link.sh task <task-id>" "usage prints task form"
+assert_not_contains "$usage_out" "set -u" "usage does not leak live code"
+pass "error and usage paths are stable"

--- a/tests/fm-secondmate-lifecycle-e2e.test.sh
+++ b/tests/fm-secondmate-lifecycle-e2e.test.sh
@@ -151,12 +151,15 @@ phase_send() {
 }
 
 phase_handoff() {
-  # The move is delegated to `tasks-axi mv`; skip cleanly when it is absent (the
-  # downstream recovery and teardown phases do not depend on this phase).
+  # The move is delegated to `tasks-axi mv`; skip cleanly when it is absent or
+  # incompatible (lacks multi-ID mv, introduced in 0.2.2) - the downstream
+  # recovery and teardown phases do not depend on this phase.
   if ! command -v tasks-axi >/dev/null 2>&1; then
     echo "skip: tasks-axi not found (backlog handoff delegates to it)"
     return 0
   fi
+  . "$ROOT/bin/fm-tasks-axi-lib.sh"
+  fm_tasks_axi_compatible || { echo "skip: tasks-axi lacks multi-ID mv support (0.2.2+ required)"; return 0; }
   cat > "$HOME_DIR/data/backlog.md" <<'EOF'
 ## In flight
 - [ ] live-task - active work (repo: alpha, since 2026-06-20)

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -350,7 +350,9 @@ EOF
   make_fake_toolchain "$fakebin"
   make_fake_ps_claude "$fakebin"
   # Force a MISSING diagnostic line so the bootstrap section is non-trivial.
-  rm -f "$fakebin/node"
+  # Remove gh-axi (not on a typical BASE_PATH) rather than node, which may
+  # shadow the fakebin stub from /usr/bin in some environments.
+  rm -f "$fakebin/gh-axi"
 
   printf 'window=fm-sess:w1\nkind=ship\n' > "$home/state/task-a.meta"
 
@@ -373,7 +375,7 @@ EOF
   [ "$context_line" -lt "$fleet_line" ] || fail "CONTEXT did not precede FLEET STATE"
   [ "$fleet_line" -lt "$next_line" ] || fail "FLEET STATE did not precede NEXT STEP"
 
-  missing_line=$(printf '%s\n' "$out" | grep -n 'MISSING: node' | head -1 | cut -d: -f1)
+  missing_line=$(printf '%s\n' "$out" | grep -n 'MISSING: gh-axi' | head -1 | cut -d: -f1)
   [ -n "$missing_line" ] || fail "MISSING diagnostic did not appear at all"
   [ "$missing_line" -lt "$fleet_line" ] || fail "actionable MISSING diagnostic was buried after the bulk fleet-state digest"
 
@@ -493,7 +495,7 @@ $rec
 EOF
   make_fake_toolchain "$fakebin"
   make_fake_ps_claude "$fakebin"
-  rm -f "$fakebin/node"
+  rm -f "$fakebin/gh-axi"
 
   append_wake "$home/state" signal task-z "needs-decision: pick a library"
 
@@ -502,7 +504,7 @@ EOF
   # fm-lock.sh's own exact success text.
   assert_contains "$out" "lock acquired: harness pid" "fm-lock.sh's real output did not appear (composition, not reimplementation)"
   # fm-bootstrap.sh's own exact MISSING-tool line format.
-  assert_contains "$out" "MISSING: node (install:" "fm-bootstrap.sh's real detect line did not appear verbatim"
+  assert_contains "$out" "MISSING: gh-axi (install:" "fm-bootstrap.sh's real detect line did not appear verbatim"
   # fm-wake-drain.sh's real drained record (raw tab-separated queue line).
   assert_contains "$out" "$(printf 'signal\ttask-z\tneeds-decision: pick a library')" "fm-wake-drain.sh's real drained record did not appear"
 


### PR DESCRIPTION
## Intent

Re-enter no-mistakes monitoring for the existing already-green PR https://github.com/kunchenguid/firstmate/pull/502 on the existing fm/codex-link-helper-v2 branch after an intentional daemon restart. Do not redo implementation, do not change code, and do not re-run validation work; restore PR/CI monitoring against the existing pushed head.

## What Changed
- Add `bin/fm-codex-link.sh`, a read-only helper that resolves task/report/project paths and prints safe `codex://new` deep links (plus the raw local path as a fallback), with a positional `<task-id>` shorthand for the `task` subcommand.
- Document the helper across the firstmate-codexapp skill, `docs/codex-app-backend.md`, `docs/scripts.md`, `README.md`, and the script's usage header.
- Fix the cmux backend `surface_exists` pipe-mask so a failed CLI call no longer hides behind the `jq` pipe, anchor the `.opencode` gitignore to unshadow the plugins manifest, and tighten the related test guards.

## Testing

- ⏭️ **Test** - skipped

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⏭️ **Rebase** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>⏭️ **Review** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>⏭️ **Test** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>⏭️ **Document** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>⏭️ **Lint** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>⏭️ **Push** - skipped</summary>

Step was skipped.

</details>
