### PR TITLE
feat: add Windows platform detection seam

### DIFF
--- a/bin/fm-platform-lib.sh
+++ b/bin/fm-platform-lib.sh
@@ -67,12 +67,20 @@ fm_platform_home_dir() {
 }
 
 fm_platform_ps_fixed_line() {  # <pid>
-  local pid=$1 line first
+  local pid=$1 line first second
   case "$pid" in ''|*[!0-9]*) return 1 ;; esac
   while IFS= read -r line || [ -n "$line" ]; do
     line=${line#"${line%%[![:space:]]*}"}
     [ -n "$line" ] || continue
     first=${line%%[[:space:]]*}
+    case "$first" in
+      I|S|O)
+        line=${line#"$first"}
+        line=${line#"${line%%[![:space:]]*}"}
+        second=${line%%[[:space:]]*}
+        first=$second
+        ;;
+    esac
     [ "$first" = "$pid" ] || continue
     printf '%s\n' "$line"
     return 0
@@ -85,12 +93,21 @@ EOF
 # Parse MSYS/Cygwin fixed-column ps output:
 # PID PPID PGID WINPID TTY UID STIME COMMAND
 fm_platform_ps_fixed_field() {  # <pid> <field>
-  local pid=$1 field=$2 line pid_f ppid _pgid _winpid _tty _uid stime command
+  local pid=$1 field=$2 line pid_f ppid _pgid _winpid _tty _uid stime command next
   line=$(fm_platform_ps_fixed_line "$pid") || return 1
   read -r pid_f ppid _pgid _winpid _tty _uid stime command <<EOF
 $line
 EOF
   [ "$pid_f" = "$pid" ] || return 1
+  case "$stime" in
+    Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)
+      next=${command%%[[:space:]]*}
+      [ "$next" != "$command" ] || return 1
+      stime="$stime $next"
+      command=${command#"$next"}
+      command=${command#"${command%%[![:space:]]*}"}
+      ;;
+  esac
   case "$field" in
     pid) printf '%s\n' "$pid_f" ;;
     ppid) printf '%s\n' "$ppid" ;;
@@ -120,7 +137,7 @@ fm_platform_ps_field() {  # <pid> <field>
 }
 
 fm_platform_pid_identity() {  # <pid>
-  local pid=$1 out rest starttime cmd stime command
+  local pid=$1 out rest starttime cmd
   case "$pid" in ''|*[!0-9]*) return 1 ;; esac
   out=$(LC_ALL=C ps -p "$pid" -o lstart= -o command= 2>/dev/null)
   if [ -n "$out" ]; then
@@ -141,8 +158,5 @@ fm_platform_pid_identity() {  # <pid>
       return 0
     fi
   fi
-  stime=$(fm_platform_ps_fixed_field "$pid" stime) || return 1
-  command=$(fm_platform_ps_fixed_field "$pid" command) || return 1
-  [ -n "$command" ] || return 1
-  printf '%s %s\n' "$stime" "$command"
+  return 1
 }

--- a/bin/fm-platform-lib.sh
+++ b/bin/fm-platform-lib.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Small platform seam for OS checks and Windows/Git-Bash substrate helpers.
+
+FM_PLATFORM_UNAME="${FM_PLATFORM_UNAME:-}"
+fm_platform_uname() {
+  if [ -z "$FM_PLATFORM_UNAME" ]; then
+    FM_PLATFORM_UNAME=$(uname -s 2>/dev/null || echo unknown)
+  fi
+  printf '%s\n' "$FM_PLATFORM_UNAME"
+}
+
+FM_PLATFORM_IS_WINDOWS="${FM_PLATFORM_IS_WINDOWS:-${FM_IS_WINDOWS:-}}"
+fm_platform_is_windows() {
+  if [ -z "$FM_PLATFORM_IS_WINDOWS" ]; then
+    case "$(fm_platform_uname)" in
+      CYGWIN*|MINGW*|MSYS*) FM_PLATFORM_IS_WINDOWS=yes ;;
+      *) FM_PLATFORM_IS_WINDOWS=no ;;
+    esac
+  fi
+  [ "$FM_PLATFORM_IS_WINDOWS" = yes ]
+}
+
+fm_platform_is_macos() {
+  [ "$(fm_platform_uname)" = Darwin ]
+}
+
+fm_platform_temp_root() {
+  if fm_platform_is_windows; then
+    printf '%s\n' "${TMPDIR:-/tmp}"
+  else
+    printf '%s\n' /tmp
+  fi
+}
+
+fm_platform_userprofile_to_posix() {
+  local p=$1 drive rest
+  if command -v cygpath >/dev/null 2>&1; then
+    cygpath -u "$p" 2>/dev/null && return 0
+  fi
+  case "$p" in
+    [A-Za-z]:\\*)
+      drive=$(printf '%s' "${p%%:*}" | tr '[:upper:]' '[:lower:]')
+      rest=${p#?:\\}
+      rest=${rest//\\//}
+      printf '/%s/%s\n' "$drive" "$rest"
+      ;;
+    *) printf '%s\n' "$p" ;;
+  esac
+}
+
+fm_platform_home_dir() {
+  if [ -n "${HOME:-}" ]; then
+    printf '%s\n' "$HOME"
+    return 0
+  fi
+  if fm_platform_is_windows && [ -n "${USERPROFILE:-}" ]; then
+    fm_platform_userprofile_to_posix "$USERPROFILE"
+    return 0
+  fi
+  return 1
+}
+
+fm_platform_ps_fixed_line() {  # <pid>
+  local pid=$1 line first
+  case "$pid" in ''|*[!0-9]*) return 1 ;; esac
+  while IFS= read -r line || [ -n "$line" ]; do
+    line=${line#"${line%%[![:space:]]*}"}
+    [ -n "$line" ] || continue
+    first=${line%%[[:space:]]*}
+    [ "$first" = "$pid" ] || continue
+    printf '%s\n' "$line"
+    return 0
+  done <<EOF
+$(ps -p "$pid" 2>/dev/null || true)
+EOF
+  return 1
+}
+
+# Parse MSYS/Cygwin fixed-column ps output:
+# PID PPID PGID WINPID TTY UID STIME COMMAND
+fm_platform_ps_fixed_field() {  # <pid> <field>
+  local pid=$1 field=$2 line pid_f ppid _pgid _winpid _tty _uid stime command
+  line=$(fm_platform_ps_fixed_line "$pid") || return 1
+  read -r pid_f ppid _pgid _winpid _tty _uid stime command <<EOF
+$line
+EOF
+  [ "$pid_f" = "$pid" ] || return 1
+  case "$field" in
+    pid) printf '%s\n' "$pid_f" ;;
+    ppid) printf '%s\n' "$ppid" ;;
+    comm) printf '%s\n' "$command" ;;
+    args|command) printf '%s\n' "$command" ;;
+    stime) printf '%s\n' "$stime" ;;
+    *) return 1 ;;
+  esac
+}
+
+fm_platform_ps_field() {  # <pid> <field>
+  local pid=$1 field=$2 out
+  case "$pid" in ''|*[!0-9]*) return 1 ;; esac
+  case "$field" in
+    ppid) out=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d '[:space:]') ;;
+    comm) out=$(ps -o comm= -p "$pid" 2>/dev/null) ;;
+    args) out=$(ps -o args= -p "$pid" 2>/dev/null) ;;
+    *) return 1 ;;
+  esac
+  if [ -n "$out" ]; then
+    case "$field:$out" in
+      ppid:*[!0-9]*|*:*$'\n'*) : ;;
+      *) printf '%s\n' "$out"; return 0 ;;
+    esac
+  fi
+  fm_platform_ps_fixed_field "$pid" "$field"
+}
+
+fm_platform_pid_identity() {  # <pid>
+  local pid=$1 out rest starttime cmd stime command
+  case "$pid" in ''|*[!0-9]*) return 1 ;; esac
+  out=$(ps -p "$pid" -o lstart= -o command= 2>/dev/null)
+  if [ -n "$out" ]; then
+    case "$out" in
+      *$'\n'*|PID[[:space:]]*) : ;;
+      *) printf '%s\n' "$out" | sed 's/^[[:space:]]*//'; return 0 ;;
+    esac
+  fi
+  if [ -r "/proc/$pid/stat" ]; then
+    IFS= read -r out < "/proc/$pid/stat" 2>/dev/null || return 1
+    rest=${out##*) }
+    # shellcheck disable=SC2086 # deliberate word-splitting to index stat fields.
+    set -- $rest
+    starttime=${20:-}
+    if [ -n "$starttime" ]; then
+      cmd=$(tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null)
+      printf '%s %s\n' "$starttime" "$cmd"
+      return 0
+    fi
+  fi
+  stime=$(fm_platform_ps_fixed_field "$pid" stime) || return 1
+  command=$(fm_platform_ps_fixed_field "$pid" command) || return 1
+  [ -n "$command" ] || return 1
+  printf '%s %s\n' "$stime" "$command"
+}

--- a/bin/fm-platform-lib.sh
+++ b/bin/fm-platform-lib.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 # Small platform seam for OS checks and Windows/Git-Bash substrate helpers.
+#
+# Source this leaf helper when code needs OS detection, HOME/TMPDIR resolution,
+# or process-table fields that must tolerate MSYS/Cygwin fixed-column `ps`.
+# `fm_platform_is_windows` is the one narrow Windows branch point.
+# `FM_PLATFORM_UNAME`, `FM_PLATFORM_IS_WINDOWS`, and legacy `FM_IS_WINDOWS`
+# are test seams; production callers should leave them unset.
 
 FM_PLATFORM_UNAME="${FM_PLATFORM_UNAME:-}"
 fm_platform_uname() {

--- a/bin/fm-platform-lib.sh
+++ b/bin/fm-platform-lib.sh
@@ -116,7 +116,7 @@ fm_platform_ps_field() {  # <pid> <field>
 fm_platform_pid_identity() {  # <pid>
   local pid=$1 out rest starttime cmd stime command
   case "$pid" in ''|*[!0-9]*) return 1 ;; esac
-  out=$(ps -p "$pid" -o lstart= -o command= 2>/dev/null)
+  out=$(LC_ALL=C ps -p "$pid" -o lstart= -o command= 2>/dev/null)
   if [ -n "$out" ]; then
     case "$out" in
       *$'\n'*|PID[[:space:]]*) : ;;

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -60,6 +60,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-ff-lib.sh`           | Shared guarded fast-forward helper for origin pulls and local secondmate syncs       |
 | `fm-lock-lib.sh`         | Shared "is this git lock provably abandoned?" proof used by teardown and fleet-sync   |
 | `fm-config-inherit-lib.sh` | Shared primary-to-secondmate inherited local-material propagation and config-reread delivery |
+| `fm-platform-lib.sh`     | Shared OS detection, home/temp path fallbacks, and process-table helpers             |
 | `fm-tasks-axi-lib.sh`    | Shared backlog-backend selector and `tasks-axi` compatibility probe                  |
 | `fm-wake-drain.sh`       | Atomically drain queued watcher wakes, emit bounded best-effort status-event annotations, then assert watcher liveness |
 | `fm-wake-lib.sh`         | Shared durable wake queue, portable locks, and watcher identity/health helpers       |

--- a/tests/fm-platform-lib.test.sh
+++ b/tests/fm-platform-lib.test.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# tests/fm-platform-lib.test.sh - unit tests for the shared platform seam:
+# Windows detection overrides, HOME/TMPDIR fallbacks, locale-stable process
+# identity, and MSYS/Cygwin fixed-column `ps` parsing.
 set -u
 
 # shellcheck disable=SC1091

--- a/tests/fm-platform-lib.test.sh
+++ b/tests/fm-platform-lib.test.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -u
+
+# shellcheck disable=SC1091
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-platform-lib)
+LIB="$ROOT/bin/fm-platform-lib.sh"
+
+test_msys_fixed_ps_fields() {
+  local dir fakebin out
+  dir="$TMP_ROOT/msys-ps"
+  fakebin=$(fm_fakebin "$dir")
+cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *" -o "*) exit 1 ;;
+  *"-p 4321"*)
+    printf '      PID    PPID    PGID     WINPID   TTY         UID    STIME COMMAND\n'
+    printf '     4321    1234    4321      98765  pty0      197609 12:34:56 /usr/bin/bash\n'
+    ;;
+  *) exit 1 ;;
+esac
+SH
+  chmod +x "$fakebin/ps"
+
+  out=$(PATH="$fakebin:$PATH" bash -c '. "$1"; fm_platform_ps_field 4321 ppid' _ "$LIB")
+  [ "$out" = 1234 ] || fail "fixed-column ps ppid parse returned '$out'"
+
+  out=$(PATH="$fakebin:$PATH" bash -c '. "$1"; fm_platform_ps_field 4321 comm' _ "$LIB")
+  [ "$out" = /usr/bin/bash ] || fail "fixed-column ps command parse returned '$out'"
+
+  out=$(PATH="$fakebin:$PATH" bash -c '. "$1"; fm_platform_pid_identity 4321' _ "$LIB")
+  [ "$out" = "12:34:56 /usr/bin/bash" ] || fail "fixed-column ps identity returned '$out'"
+
+  pass "fm-platform-lib parses MSYS fixed-column ps output for ppid, command, and identity"
+}
+
+test_windows_userprofile_home_fallback() {
+  local out
+  # shellcheck disable=SC2016  # single quotes are deliberate: $1 expands inside bash -c.
+  out=$(env HOME='' USERPROFILE='C:\Users\Captain' FM_PLATFORM_IS_WINDOWS=yes bash -c '. "$1"; fm_platform_home_dir' _ "$LIB")
+  case "$out" in
+    /c/Users/Captain|/cygdrive/c/Users/Captain) ;;
+    *) fail "USERPROFILE fallback did not produce a POSIX-ish Windows home path: '$out'" ;;
+  esac
+  pass "fm-platform-lib falls back from HOME to USERPROFILE on Windows"
+}
+
+test_temp_root_windows_honors_tmpdir() {
+  local out
+  # shellcheck disable=SC2016  # single quotes are deliberate: $1 expands inside bash -c.
+  out=$(env TMPDIR="$TMP_ROOT/custom-tmp" FM_PLATFORM_IS_WINDOWS=yes bash -c '. "$1"; fm_platform_temp_root' _ "$LIB")
+  [ "$out" = "$TMP_ROOT/custom-tmp" ] || fail "Windows temp root should honor TMPDIR (got '$out')"
+  pass "fm-platform-lib temp root honors TMPDIR on Windows"
+}
+
+test_temp_root_posix_is_tmp() {
+  local out
+  # shellcheck disable=SC2016  # single quotes are deliberate: $1 expands inside bash -c.
+  out=$(env TMPDIR="$TMP_ROOT/custom-tmp" FM_PLATFORM_IS_WINDOWS=no bash -c '. "$1"; fm_platform_temp_root' _ "$LIB")
+  [ "$out" = /tmp ] || fail "POSIX temp root should stay /tmp regardless of TMPDIR (got '$out')"
+  pass "fm-platform-lib temp root stays /tmp on POSIX regardless of TMPDIR"
+}
+
+test_msys_fixed_ps_fields
+test_windows_userprofile_home_fallback
+test_temp_root_windows_honors_tmpdir
+test_temp_root_posix_is_tmp

--- a/tests/fm-platform-lib.test.sh
+++ b/tests/fm-platform-lib.test.sh
@@ -21,7 +21,7 @@ case "$*" in
   *" -o "*) exit 1 ;;
   *"-p 4321"*)
     printf '      PID    PPID    PGID     WINPID   TTY         UID    STIME COMMAND\n'
-    printf '     4321    1234    4321      98765  pty0      197609 12:34:56 /usr/bin/bash\n'
+    printf 'S    4321    1234    4321      98765  pty0      197609 Jan 29 /usr/bin/bash --login\n'
     ;;
   *) exit 1 ;;
 esac
@@ -32,12 +32,16 @@ SH
   [ "$out" = 1234 ] || fail "fixed-column ps ppid parse returned '$out'"
 
   out=$(PATH="$fakebin:$PATH" bash -c '. "$1"; fm_platform_ps_field 4321 comm' _ "$LIB")
-  [ "$out" = /usr/bin/bash ] || fail "fixed-column ps command parse returned '$out'"
+  [ "$out" = "/usr/bin/bash --login" ] || fail "fixed-column ps command parse returned '$out'"
 
-  out=$(PATH="$fakebin:$PATH" bash -c '. "$1"; fm_platform_pid_identity 4321' _ "$LIB")
-  [ "$out" = "12:34:56 /usr/bin/bash" ] || fail "fixed-column ps identity returned '$out'"
+  out=$(PATH="$fakebin:$PATH" bash -c '. "$1"; fm_platform_ps_fixed_field 4321 stime' _ "$LIB")
+  [ "$out" = "Jan 29" ] || fail "fixed-column ps start time parse returned '$out'"
 
-  pass "fm-platform-lib parses MSYS fixed-column ps output for ppid, command, and identity"
+  if PATH="$fakebin:$PATH" bash -c '. "$1"; fm_platform_pid_identity 4321' _ "$LIB"; then
+    fail "fixed-column ps identity should fail without a stable creation token"
+  fi
+
+  pass "fm-platform-lib parses status-prefixed MSYS ps output and rejects unstable identity"
 }
 
 test_windows_userprofile_home_fallback() {

--- a/tests/fm-platform-lib.test.sh
+++ b/tests/fm-platform-lib.test.sh
@@ -64,7 +64,29 @@ test_temp_root_posix_is_tmp() {
   pass "fm-platform-lib temp root stays /tmp on POSIX regardless of TMPDIR"
 }
 
+test_pid_identity_pins_lc_all_for_lstart() {
+  local dir fakebin out
+  dir="$TMP_ROOT/pid-identity-locale"
+  fakebin=$(fm_fakebin "$dir")
+cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *"-p 4321 -o lstart= -o command="*)
+    printf '%s /usr/bin/bash\n' "${LC_ALL:-unset}"
+    ;;
+  *) exit 1 ;;
+esac
+SH
+  chmod +x "$fakebin/ps"
+
+  out=$(PATH="$fakebin:$PATH" LC_ALL=C.utf8 bash -c '. "$1"; fm_platform_pid_identity 4321' _ "$LIB")
+  [ "$out" = "C /usr/bin/bash" ] || fail "pid identity did not pin LC_ALL=C for lstart ps (got '$out')"
+
+  pass "fm-platform-lib pid identity pins LC_ALL for lstart ps"
+}
+
 test_msys_fixed_ps_fields
 test_windows_userprofile_home_fallback
 test_temp_root_windows_honors_tmpdir
 test_temp_root_posix_is_tmp
+test_pid_identity_pins_lc_all_for_lstart


### PR DESCRIPTION
## Intent

Add bin/fm-platform-lib.sh: a self-contained platform-detection seam (fm_platform_is_windows, uname, HOME/USERPROFILE and TMPDIR fallbacks, MSYS ps parsing) that later Windows work sits behind. Inert on POSIX.

## What Changed

- Add a shared platform seam for Windows, macOS, and POSIX detection with HOME and temporary-directory fallbacks.
- Support native and MSYS/Cygwin process-table parsing with locale-stable PID identity checks.
- Document the helper and add focused coverage for Windows path fallbacks, POSIX behavior, and process parsing.

## Risk Assessment

✅ Low: The new platform seam is self-contained and inert until sourced, with conservative Windows fallbacks and no material correctness risks found in the reviewed changes.

## Testing

The successful baseline full shell suite was supplemented by a focused platform-library rerun and an end-to-end native POSIX/simulated MSYS transcript; all expected platform detection, fallback, and process-parsing behavior worked, and the worktree remained clean.

<details>
<summary>Evidence: POSIX and simulated MSYS platform-seam transcript</summary>

```text
POSIX uname: Linux
POSIX is_windows: no
POSIX home: /home/viktor
POSIX temp with TMPDIR override: /tmp
POSIX current-shell ppid: 674011
MSYS uname (from uname command): MSYS_NT-10.0
MSYS is_windows: yes
MSYS home fallback: /c/Users/Captain
MSYS configured temp: C:\Temp
MSYS default temp: /tmp
MSYS fixed-ps ppid: 1234
MSYS fixed-ps command: /usr/bin/bash --login
MSYS fixed-ps stime: Jan 29
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- <code>Baseline previously completed: `command -v tmux &gt;/dev/null || { echo &#34;tmux is required for e2e tests&#34; &gt;&amp;2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo &#34;== $t ==&#34;; bash &#34;$t&#34; || rc=1; done; exit &#34;$rc&#34;`</code>
- <code>Focused test: `bash tests/fm-platform-lib.test.sh`</code>
- <code>Manual evidence check: sourced `bin/fm-platform-lib.sh` in native Linux and simulated MSYS shells with fake `uname` and fixed-column `ps`, recording detection, HOME/TMPDIR resolution, and process fields in `platform-seam-transcript.txt`</code>
- <code>Cleanup verification: `git status --short`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
