### PR TITLE
fix: watcher pause absorbs historical failed runs; loud arm-cycle death

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,8 @@ state/               volatile runtime signals; gitignored
   x-outbox/          generated X-mode dry-run reply and dismiss previews; inspect it when FMX_DRY_RUN is set (section 14)
   x-poll.error       generated X-mode relay diagnostic dedupe marker
   .wake-queue        durable queued wakes: epoch<TAB>seq<TAB>kind<TAB>key<TAB>payload
+  .wake-queue.seq    monotonic wake sequence used to distinguish a normal watcher wake handoff from a silent arm-cycle death
+  .watcher-arm-dead  durable alarm from an arm cycle that ended without a wake handoff or healthy successor while tasks remain; cleared by a confirmed healthy arm or normal handoff
   .afk               durable away-mode flag; present = sub-supervisor may inject escalations (set by /afk, cleared on user return)
   .watch.lock .wake-queue.lock watcher singleton and queue serialization locks
   .hash-* .count-* .stale-* .stale-since-* .paused-* .wedge-escalations-* .seen-* .hb-surfaced-* .last-* .heartbeat-streak   watcher internals; never touch
@@ -477,7 +479,8 @@ That checks-green status is owed at the CI-ready return point, when `/no-mistake
 Use chat for yes/no decisions; use lavish-axi when there are multiple findings or options to triage.
 
 Judge a validating crewmate by the run's step status, never by whether its shell is still running.
-Read its current state with `bin/fm-crew-state.sh <id>`: a deterministic, token-tight one-line read that takes the matching no-mistakes run-step as the source of truth and reconciles it against the crewmate's `state/<id>.status` log.
+Read its current state with `bin/fm-crew-state.sh <id>`: a deterministic, token-tight one-line read that takes a matching live no-mistakes run-step as the source of truth and reconciles it against the crewmate's `state/<id>.status` log.
+For a terminal historical run only, a trailing `paused:` declaration wins when its status-file mtime is strictly newer than the run's parseable terminal timestamp; the terminal run remains authoritative when ordering is unavailable or the pause is not newer.
 Because the run-step is authoritative before pane liveness, a crewmate whose window closed after or during validation can still report `done` or `working` from its run; a missing pane becomes `unknown` only when no matching run exists.
 That log is an append-only wake-*event* log, not a current-state field, and it goes stale the moment a resolved gate lets the run resume: after you answer a `needs-decision`/`blocked` and the crewmate silently resumes (responds to the gate, the pipeline fixes, it re-validates), the log's last line still reads `needs-decision`/`blocked` while the run-step has moved on.
 So never infer current state from a `tail` of that log; `bin/fm-crew-state.sh` reports the live run-step state and explicitly flags the stale log line superseded, where a raw `tail` would mislead you into re-escalating settled work.

--- a/bin/fm-bearings-snapshot.sh
+++ b/bin/fm-bearings-snapshot.sh
@@ -276,7 +276,10 @@ MODEL=$(printf '%s' "$SNAP" | jq \
   | (($fl | index("endpoints")) != null) as $f_endpoints
   | ([ .backlog.records[] | select(.state == "done" and .structured)
        | {id, title, pr_url, report_path, local_note, completion, home:"(main)", home_id:"(main)"} ]) as $main_done
-  | ((.secondmate_landed.records) // []) as $mate_done
+  | ((.secondmate_landed.records) // []
+     | map(if (.report_path // "") != "" and (.report_path | startswith("/") | not)
+           then .report_path = (.home + "/" + .report_path)
+           else . end)) as $mate_done
   | ($main_done + $mate_done) as $all_landed_rows
   | ([ $all_landed_rows | group_by(.home_id)[]
        | sort_by([(.completion.date // ""), .id]) | reverse

--- a/bin/fm-bearings-snapshot.sh
+++ b/bin/fm-bearings-snapshot.sh
@@ -27,6 +27,8 @@
 # recorded in ITS OWN backlog, never the main one - are visible. It stays bounded by
 # a per-home cap and an overall cap, with omitted[] disclosure of both and of any
 # secondmate home whose backlog was unreadable; no GitHub/network call is involved.
+# Relative report paths in those secondmate records are resolved against that
+# secondmate's home before they are emitted as landed artifacts.
 #
 # Flags:
 #   (default)        compact projection, TOON, local-only

--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -235,11 +235,14 @@ signal_reason_is_actionable() {  # <file> ...
 #   none    - neither, so the wake must surface (a stopped/finished/parked/failed/
 #             torn-down/unknown crew, or an unreadable verdict).
 # One fm-crew-state.sh read serves BOTH absorb reasons at once. Reading the state
-# authoritatively (not the status log) is what keeps run-step precedence: a crew
-# that appended paused: but then STARTED a run reports working, never paused.
-# NOT a pure read: fm-crew-state.sh may make a bounded no-mistakes call, so callers
-# run it only on no-verb signal and first-sighting stale paths, never every wake.
-# FM_CREW_STATE_BIN lets tests stub the verdict.
+# authoritatively (not the status log) is what keeps live run-step precedence: a
+# crew that appended paused: but then STARTED a run reports working, never paused.
+# A trailing paused: with only a terminal historical run (failed/done) is reported
+# as paused by fm-crew-state.sh, so this class returns paused and the watcher
+# absorbs on the long recheck cadence. NOT a pure read: fm-crew-state.sh may make
+# a bounded no-mistakes call, so callers run it only on no-verb signal and
+# first-sighting stale paths, never every wake. FM_CREW_STATE_BIN lets tests stub
+# the verdict.
 crew_absorb_class() {  # <id>
   local id=$1 line state src
   [ -n "$id" ] || { printf 'none'; return; }

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -21,13 +21,16 @@
 #   1. Resolve worktree + backend target + kind from state/<id>.meta.
 #   2. Matching no-mistakes run for this crew's branch, active or terminal
 #      (from `axi status`, or the coarse `no-mistakes runs` fallback)?
-#      The run-step is AUTHORITATIVE: running/fixing -> working, ci -> working,
+#      A live run-step is AUTHORITATIVE: running/fixing -> working, ci -> working,
 #      awaiting_approval/fix_review -> parked (with gate findings), terminal
 #      passed/checks-passed -> done, failed/cancelled -> failed. EXCEPT: while
 #      the active step is ci, `axi status` alone cannot tell "still waiting on
 #      checks" from "checks green, waiting on merge" (see nm_ci_checks_state) -
 #      a ci-step log-tail check overrides working -> done once checks read
 #      green, so a green PR is never silently read as still-validating.
+#      A second exception: a deliberate trailing paused: status outranks a
+#      terminal historical run (failed/done) - a past failed run is not evidence
+#      the pane needs attention; a live working/parked run still wins over paused.
 #   3. Reconcile the status log: if its last line says needs-decision/blocked but
 #      the run-step shows the run moved on, the log is deterministically stale and
 #      is flagged superseded. A genuinely parked run plus a needs-decision log
@@ -538,6 +541,21 @@ if [ "$HAVE_RUN" = 1 ]; then
       fi
       ;;
   esac
+
+  # A deliberate trailing paused: declaration outranks a terminal historical
+  # run-step. A failed/done past run is not evidence the pane needs attention;
+  # the watcher absorbs that stale on the long pause-recheck cadence instead of
+  # resurfacing every poll. A live working or parked run still wins (checked by
+  # falling through only for failed|done). Without this, crew_absorb_class
+  # returns none on a failed historical run and the pause declaration makes
+  # noise strictly worse than a terminal done: line (surfaced once).
+  if status_is_paused "$LOG_LINE"; then
+    case "$RUN_STATE" in
+      failed|done)
+        emit paused status-log "$(status_line_note "$LOG_LINE")${SEP}historical run $RUN_STATE"
+        ;;
+    esac
+  fi
 
   emit "$RUN_STATE" run-step "$RUN_DETAIL"
 fi

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -129,6 +129,14 @@ map_log_state() {  # <line>
 LOG_LINE=$(log_last_line || true)
 LOG_VERB=$(status_line_verb "$LOG_LINE")
 
+file_mtime() {  # <path>
+  if [ "$(uname)" = Darwin ]; then
+    stat -f %m "$1" 2>/dev/null
+  else
+    stat -c %Y "$1" 2>/dev/null
+  fi
+}
+
 # pane_readable is consulted ONLY in the no-run fallback below. The run-step path
 # stays authoritative regardless of pane liveness - judge by the run-step, not the
 # shell - so a finished crew whose endpoint has closed still reports its run-step
@@ -222,6 +230,27 @@ nm_run() {  # <args...>
 RUN_OUT=""
 nm_field() {  # <key>
   printf '%s\n' "$RUN_OUT" | sed -n "s/^[[:space:]]*$1:[[:space:]]*\(.*\)/\1/p" | head -1
+}
+
+run_terminal_epoch() {
+  local key value
+  for key in completed_at ended_at updated_at updated; do
+    value=$(strip_quotes "$(nm_field "$key")")
+    [ -n "$value" ] || continue
+    case "$value" in
+      *[!0-9]*) ;;
+      *) printf '%s' "$value"; return 0 ;;
+    esac
+    if date -j -f '%Y-%m-%dT%H:%M:%SZ' "$value" +%s >/dev/null 2>&1; then
+      date -j -f '%Y-%m-%dT%H:%M:%SZ' "$value" +%s 2>/dev/null
+      return 0
+    fi
+    if date -d "$value" +%s >/dev/null 2>&1; then
+      date -d "$value" +%s 2>/dev/null
+      return 0
+    fi
+  done
+  return 1
 }
 # Finding count from a findings[N]{...} table header; empty when none.
 nm_findings_count() {
@@ -543,16 +572,16 @@ if [ "$HAVE_RUN" = 1 ]; then
   esac
 
   # A deliberate trailing paused: declaration outranks a terminal historical
-  # run-step. A failed/done past run is not evidence the pane needs attention;
-  # the watcher absorbs that stale on the long pause-recheck cadence instead of
-  # resurfacing every poll. A live working or parked run still wins (checked by
-  # falling through only for failed|done). Without this, crew_absorb_class
-  # returns none on a failed historical run and the pause declaration makes
-  # noise strictly worse than a terminal done: line (surfaced once).
+  # run-step only when durable ordering proves the pause is newer.
   if status_is_paused "$LOG_LINE"; then
     case "$RUN_STATE" in
       failed|done)
-        emit paused status-log "$(status_line_note "$LOG_LINE")${SEP}historical run $RUN_STATE"
+        RUN_TERMINAL_EPOCH=$(run_terminal_epoch || true)
+        LOG_EPOCH=$(file_mtime "$LOG" || true)
+        if [ -n "$RUN_TERMINAL_EPOCH" ] && [ -n "$LOG_EPOCH" ] \
+          && [ "$LOG_EPOCH" -gt "$RUN_TERMINAL_EPOCH" ]; then
+          emit paused status-log "$(status_line_note "$LOG_LINE")${SEP}historical run $RUN_STATE"
+        fi
         ;;
     esac
   fi

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -241,8 +241,8 @@ run_terminal_epoch() {
       *[!0-9]*) ;;
       *) printf '%s' "$value"; return 0 ;;
     esac
-    if date -j -f '%Y-%m-%dT%H:%M:%SZ' "$value" +%s >/dev/null 2>&1; then
-      date -j -f '%Y-%m-%dT%H:%M:%SZ' "$value" +%s 2>/dev/null
+    if date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$value" +%s >/dev/null 2>&1; then
+      date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$value" +%s 2>/dev/null
       return 0
     fi
     if date -d "$value" +%s >/dev/null 2>&1; then

--- a/bin/fm-guard.sh
+++ b/bin/fm-guard.sh
@@ -33,6 +33,8 @@ CONTINUE_LINE=${FM_GUARD_CONTINUE_LINE:-This is a supervision warning only; the 
 # shellcheck source=bin/fm-supervision-lib.sh
 . "$SCRIPT_DIR/fm-supervision-lib.sh"
 
+WATCH="$SCRIPT_DIR/fm-watch.sh"
+
 # Worktree-tangle alarm, checked FIRST and independent of in-flight tasks: the
 # firstmate PRIMARY checkout (FM_ROOT) must stay on its default branch. If a
 # crewmate's branch/commits landed here instead of in its own isolated worktree,
@@ -70,11 +72,17 @@ watcher_fresh=$FM_SUP_WATCHER_FRESH
 beacon_desc=$FM_SUP_BEACON_DESC
 [ "$in_flight" -eq 0 ] && exit 0
 
+arm_dead=false
+if [ -f "$STATE/.watcher-arm-dead" ] \
+  && ! fm_watcher_healthy "$STATE" "$WATCH" "$GRACE" "$FM_HOME"; then
+  arm_dead=true
+fi
+
 [ -s "$FM_WAKE_QUEUE" ] && queue_pending=true
 
 # No fresh watcher with tasks in flight is the dangerous state: emit a prominent,
 # bordered banner FIRST so it reads as an alarm, not a buried stderr line.
-if [ "$watcher_fresh" = false ]; then
+if [ "$watcher_fresh" = false ] || [ "$arm_dead" = true ]; then
   afk=0
   [ -e "$STATE/.afk" ] && afk=1
   queue_arg=0
@@ -91,7 +99,11 @@ if [ "$watcher_fresh" = false ]; then
   {
     printf '●%s\n' "$rule"
     printf '●  WATCHER DOWN - SUPERVISION IS OFF\n'
-    printf '●  %s task(s) in flight, but no watcher has a fresh beacon (last beat: %s, grace %ss).\n' "$in_flight" "$beacon_desc" "$GRACE"
+    if [ "$watcher_fresh" = false ]; then
+      printf '●  %s task(s) in flight, but no watcher has a fresh beacon (last beat: %s, grace %ss).\n' "$in_flight" "$beacon_desc" "$GRACE"
+    else
+      printf '●  %s task(s) in flight; the beacon is fresh-looking but no independently healthy watcher holds this home.\n' "$in_flight"
+    fi
     if [ -f "$STATE/.watcher-arm-dead" ]; then
       arm_dead_detail=$(grep '^detail=' "$STATE/.watcher-arm-dead" 2>/dev/null | head -1 | sed 's/^detail=//')
       [ -n "$arm_dead_detail" ] || arm_dead_detail='arm cycle died without a successor'

--- a/bin/fm-guard.sh
+++ b/bin/fm-guard.sh
@@ -92,6 +92,11 @@ if [ "$watcher_fresh" = false ]; then
     printf '●%s\n' "$rule"
     printf '●  WATCHER DOWN - SUPERVISION IS OFF\n'
     printf '●  %s task(s) in flight, but no watcher has a fresh beacon (last beat: %s, grace %ss).\n' "$in_flight" "$beacon_desc" "$GRACE"
+    if [ -f "$STATE/.watcher-arm-dead" ]; then
+      arm_dead_detail=$(grep '^detail=' "$STATE/.watcher-arm-dead" 2>/dev/null | head -1 | sed 's/^detail=//')
+      [ -n "$arm_dead_detail" ] || arm_dead_detail='arm cycle died without a successor'
+      printf '●  Last arm death: %s (state/.watcher-arm-dead).\n' "$arm_dead_detail"
+    fi
     if [ "$READ_ONLY" -eq 1 ]; then
       printf '●  This read-only session should report the lapse, not repair it.\n'
     else

--- a/bin/fm-watch-arm.sh
+++ b/bin/fm-watch-arm.sh
@@ -29,15 +29,22 @@
 #   watcher: healthy pid=<N> (beacon <age>s)             - restart mode found a live+fresh
 #                                                          watcher it did not own
 #   watcher: FAILED - no live watcher with a fresh beacon  - could not confirm one
+#   watcher: FAILED - arm cycle ended with no live successor while tasks are in flight
+#                                                     - cycle died without a wake
+#                                                       handoff and no healthy peer
 # It NEVER reports started/attached/healthy off a stale beacon or a dead/reused pid: a
 # stale-beacon or dead-pid holder either self-heals (the fresh child steals the
 # dead lock per the singleton self-eviction/steal path and is confirmed) or this
 # returns the FAILED line. On started it waits the child and propagates the wake
 # reason; on attached it stays live until the identity-matched holder is no longer
-# healthy, then exits zero so the harness background-notify fires then (not as a
-# false empty wake). On restart-only healthy it exits zero after the duplicate
-# child stands down. On FAILED it exits non-zero so the failure is loud. A live
-# cycle already present means re-arm attaches - do not start a second watcher.
+# healthy, then exits zero when idle (no tasks) so the harness background-notify
+# fires then (not as a false empty wake). When an arm cycle ends without a
+# successor, without a wake handoff, and with tasks still in flight, it prints a
+# FAILED line, writes state/.watcher-arm-dead for the guard to name, and exits
+# non-zero so the death is loud (provider-outage gaps must not be silent). On
+# restart-only healthy it exits zero after the duplicate child stands down. On
+# FAILED it exits non-zero so the failure is loud. A live cycle already present
+# means re-arm attaches - do not start a second watcher.
 #
 # --restart: stop ONLY this FM_HOME's watcher (the pid recorded in THIS home's
 # state/.watch.lock) and own a fresh cycle, or report restart-only healthy if a
@@ -56,6 +63,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WATCH="$SCRIPT_DIR/fm-watch.sh"
 WATCH_LOCK="$STATE/.watch.lock"
 BEAT="$STATE/.last-watcher-beat"
+ARM_DEAD_MARKER="$STATE/.watcher-arm-dead"
 # "Fresh" reuses the guard's threshold so there is one definition of liveness.
 GRACE=${FM_GUARD_GRACE:-300}
 # How long to wait for a freshly forked watcher to acquire the lock and beat.
@@ -86,22 +94,76 @@ healthy_watcher() {
   HEALTHY_PID=$FM_WATCHER_HEALTHY_PID
 }
 
+# 0 when any state/<id>.meta exists (work is still in flight for this home).
+tasks_in_flight() {
+  local meta
+  for meta in "$STATE"/*.meta; do
+    [ -e "$meta" ] || continue
+    return 0
+  done
+  return 1
+}
+
+clear_arm_death_marker() {
+  rm -f "$ARM_DEAD_MARKER"
+}
+
+# Durable marker the guard can name on the next fleet action. Best-effort write;
+# a full disk must not mask the stdout FAILED line.
+write_arm_death_marker() {  # <detail>
+  {
+    printf 'ts=%s\n' "$(date +%s)"
+    printf 'detail=%s\n' "$1"
+  } > "$ARM_DEAD_MARKER" 2>/dev/null || true
+}
+
+report_arm_death() {  # <detail>
+  local detail=${1:-arm cycle ended with no live successor while tasks are in flight}
+  echo "watcher: FAILED - $detail"
+  write_arm_death_marker "$detail"
+}
+
+# End this arm cycle. A wake handoff (watcher printed signal/stale/check/heartbeat)
+# is healthy: the primary re-arms on that notify. A silent end with tasks still in
+# flight and no healthy successor is the 2026-07-12 provider-outage gap - fail loud.
+# Does not return.
+finalize_arm_cycle() {  # <wake_handoff 0|1> [preferred_rc]
+  local handoff=${1:-0} rc=${2:-0}
+  if healthy_watcher; then
+    clear_arm_death_marker
+    exit 0
+  fi
+  if [ "$handoff" = 1 ]; then
+    clear_arm_death_marker
+    exit 0
+  fi
+  if tasks_in_flight; then
+    report_arm_death "arm cycle ended with no live successor while tasks are in flight"
+    exit 1
+  fi
+  clear_arm_death_marker
+  exit "$rc"
+}
+
 report_attached() {
   local age
   age=$(fm_path_age "$BEAT")
+  clear_arm_death_marker
   echo "watcher: attached pid=$HEALTHY_PID (beacon ${age}s)"
 }
 
 report_healthy() {
   local age
   age=$(fm_path_age "$BEAT")
+  clear_arm_death_marker
   echo "watcher: healthy pid=$HEALTHY_PID (beacon ${age}s)"
 }
 
 # Stay alive until the attached identity-matched healthy holder is gone.
 # If a different healthy watcher appears mid-attach (rare steal), re-attach.
-# Does not reprint the starter arm's wake reason line; exit 0 lets the harness
-# notify, and firstmate drains state/.wake-queue on background completion.
+# Does not reprint the starter arm's wake reason line; a clean end (no tasks, or
+# a healthy peer) exits 0 so the harness notify fires for re-arm. A silent end
+# with tasks still in flight fails loud via finalize_arm_cycle.
 attach_and_wait() {
   local attached_pid=$1
   while :; do
@@ -114,7 +176,7 @@ attach_and_wait() {
       continue
     fi
     # Attached cycle ended (pid gone, identity mismatch, or beacon no longer fresh).
-    exit 0
+    finalize_arm_cycle 0 0
   done
 }
 
@@ -178,11 +240,29 @@ cleanup_child() {
     rm -f "$child_out" 2>/dev/null || true
   fi
 }
-trap 'cleanup_child; exit 129' HUP
-trap 'cleanup_child; exit 143' TERM INT
+# Signal exits that leave tasks unsupervised must still print FAILED and write
+# the arm-death marker (same trail as a silent cycle end).
+# shellcheck disable=SC2317,SC2329 # Invoked by trap handlers below.
+arm_on_hup() {
+  cleanup_child
+  if tasks_in_flight && ! healthy_watcher; then
+    report_arm_death "arm cycle received HUP with no live successor while tasks are in flight"
+  fi
+  exit 129
+}
+# shellcheck disable=SC2317,SC2329 # Invoked by trap handlers below.
+arm_on_term() {
+  cleanup_child
+  if tasks_in_flight && ! healthy_watcher; then
+    report_arm_death "arm cycle received TERM/INT with no live successor while tasks are in flight"
+  fi
+  exit 143
+}
+trap arm_on_hup HUP
+trap arm_on_term TERM INT
 
 child_out=$(mktemp "$STATE/.watch-arm-output.XXXXXX") || {
-  echo "watcher: FAILED - no live watcher with a fresh beacon"
+  report_arm_death "no live watcher with a fresh beacon"
   exit 1
 }
 "$WATCH" >"$child_out" &
@@ -196,12 +276,17 @@ deadline=$(( $(date +%s) + CONFIRM_TIMEOUT ))
 while :; do
   if healthy_watcher; then
     if [ "$HEALTHY_PID" = "$child" ]; then
+      clear_arm_death_marker
       echo "watcher: started pid=$child (beacon fresh)"
       wait "$child"
       rc=$?
+      handoff=0
+      watch_output_has_wake "$child_out" && handoff=1
       print_watch_output "$child_out"
       rm -f "$child_out" 2>/dev/null || true
-      exit "$rc"
+      child=
+      child_out=
+      finalize_arm_cycle "$handoff" "$rc"
     fi
     # Another watcher won the singleton; our child stood down.
     if [ "$mode" = arm ]; then
@@ -223,9 +308,12 @@ while :; do
     rc=$?
     child_done=1
     if [ "$rc" -eq 0 ] && watch_output_has_wake "$child_out"; then
+      handoff=1
       print_watch_output "$child_out"
       rm -f "$child_out" 2>/dev/null || true
-      exit 0
+      child=
+      child_out=
+      finalize_arm_cycle 1 0
     fi
   fi
   [ "$(date +%s)" -ge "$deadline" ] && break
@@ -233,7 +321,7 @@ while :; do
 done
 
 trap - HUP TERM INT
-echo "watcher: FAILED - no live watcher with a fresh beacon"
+report_arm_death "no live watcher with a fresh beacon"
 cleanup_child
 wait "$child" 2>/dev/null || true
 exit 1

--- a/bin/fm-watch-arm.sh
+++ b/bin/fm-watch-arm.sh
@@ -235,6 +235,11 @@ child_out=
 cleanup_child() {
   if [ -n "$child" ] && fm_pid_alive "$child"; then
     kill -TERM "$child" 2>/dev/null || true
+    i=0
+    while [ "$i" -lt 20 ] && fm_pid_alive "$child"; do
+      sleep 0.1
+      i=$((i + 1))
+    done
   fi
   if [ -n "$child_out" ]; then
     rm -f "$child_out" 2>/dev/null || true

--- a/bin/fm-watch-arm.sh
+++ b/bin/fm-watch-arm.sh
@@ -64,6 +64,9 @@ WATCH="$SCRIPT_DIR/fm-watch.sh"
 WATCH_LOCK="$STATE/.watch.lock"
 BEAT="$STATE/.last-watcher-beat"
 ARM_DEAD_MARKER="$STATE/.watcher-arm-dead"
+# Monotonic wake counter (fm_wake_append bumps it on every enqueue; never reset by
+# a drain). An attached arm reads it to tell a normal wake handoff from a silent death.
+WAKE_SEQ="$STATE/.wake-queue.seq"
 # "Fresh" reuses the guard's threshold so there is one definition of liveness.
 GRACE=${FM_GUARD_GRACE:-300}
 # How long to wait for a freshly forked watcher to acquire the lock and beat.
@@ -106,6 +109,14 @@ tasks_in_flight() {
 
 clear_arm_death_marker() {
   rm -f "$ARM_DEAD_MARKER"
+}
+
+# Current durable wake sequence, floored at 0 on a missing/garbage counter.
+read_wake_seq() {
+  local s
+  s=$(cat "$WAKE_SEQ" 2>/dev/null || echo 0)
+  case "$s" in ''|*[!0-9]*) s=0 ;; esac
+  printf '%s' "$s"
 }
 
 # Durable marker the guard can name on the next fleet action. Best-effort write;
@@ -162,20 +173,37 @@ report_healthy() {
 # Stay alive until the attached identity-matched healthy holder is gone.
 # If a different healthy watcher appears mid-attach (rare steal), re-attach.
 # Does not reprint the starter arm's wake reason line; a clean end (no tasks, or
-# a healthy peer) exits 0 so the harness notify fires for re-arm. A silent end
-# with tasks still in flight fails loud via finalize_arm_cycle.
+# a healthy peer) exits 0 so the harness notify fires for re-arm.
+#
+# An attached arm does NOT own the watcher child, so it cannot read the watcher's
+# wake output to set handoff=1 the way the started path does. Distinguishing a
+# normal wake handoff from a silent orphan death would otherwise be impossible,
+# and a bare finalize_arm_cycle 0 0 would falsely declare arm-death every time an
+# owner watcher woke normally while this arm was also attached. Instead it reads
+# the durable wake counter: the watched holder BLOCKS without enqueuing until its
+# single terminal wake, so any advance of the counter since we began watching THIS
+# holder is that wake being delivered (the primary re-arms on the notify) - a
+# healthy handoff, ended quiet. Only a holder that vanished with no wake enqueued
+# is a genuine orphan; that falls through to finalize_arm_cycle, which fails loud
+# when tasks are in flight and no healthy successor exists.
 attach_and_wait() {
-  local attached_pid=$1
+  local attached_pid=$1 seq_at_attach
+  seq_at_attach=$(read_wake_seq)
   while :; do
     if healthy_watcher; then
       if [ "$HEALTHY_PID" != "$attached_pid" ]; then
         attached_pid=$HEALTHY_PID
+        seq_at_attach=$(read_wake_seq)
         report_attached
       fi
       sleep "$ATTACH_POLL"
       continue
     fi
     # Attached cycle ended (pid gone, identity mismatch, or beacon no longer fresh).
+    if [ "$(read_wake_seq)" != "$seq_at_attach" ]; then
+      clear_arm_death_marker
+      exit 0
+    fi
     finalize_arm_cycle 0 0
   done
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,7 +22,8 @@ After each drain, `fm-wake-drain.sh` runs the same liveness guard as the supervi
 Routine watcher polling, supervision no-ops, elapsed waiting time, and absorbed benign wakes stay silent.
 A declared external wait trades that silence for one bounded recheck per pause window, so a forgotten pause cannot remain invisible indefinitely.
 Crew status files are append-only wake-event logs, not current-state fields.
-`bin/fm-crew-state.sh <id>` is the cheap current-state read for an actionable heartbeat review: it attributes the matching no-mistakes run, active or terminal, to the crew's own branch and keeps that run-step authoritative even if the pane has closed.
+`bin/fm-crew-state.sh <id>` is the cheap current-state read for an actionable heartbeat review: it attributes the matching no-mistakes run, active or terminal, to the crew's own branch and keeps a live run-step authoritative even if the pane has closed.
+For a terminal historical run only, a trailing `paused:` declaration wins when its status-file mtime is strictly newer than the run's parseable terminal timestamp; unavailable or non-newer ordering leaves the terminal run authoritative.
 During no-mistakes' `ci` monitor phase, it also reads the ci step log tail because `axi status` reports both "still waiting on checks" and "checks green, waiting on merge" as `ci,running`.
 The most recent recognized ci log marker wins, so checks-green monitoring reports done while a later re-arm, failed-check, or issue marker returns the crew to working.
 Only when no matching run exists does it fall back to the pane busy-signature and then a status-log event whose verb maps to a recognized run-state; a dead pane without a run reports unknown instead of trusting a stale log.
@@ -36,10 +37,12 @@ Optional X mode rides the same check path: the locked session-start bootstrap st
 
 At session start, `bin/fm-session-start.sh` emits exactly one primary-harness supervision block rendered by `bin/fm-supervision-instructions.sh` from `docs/supervision-protocols/`.
 That block owns the live wait shape for the running primary harness: Claude and Grok use background-notify cycles, Codex uses bounded foreground checkpoints, Pi uses its two tracked primary extensions, and OpenCode uses its TUI plugin.
-`bin/fm-watch-arm.sh` remains the verified arm wrapper for protocols that call it; it forks the watcher as a tracked child, verifies it is genuinely alive with a fresh liveness beacon, and prints exactly one honest status line (`started` / `attached` / restart-only `healthy` / `FAILED`, the last exiting non-zero).
+`bin/fm-watch-arm.sh` remains the verified arm wrapper for protocols that call it; it forks the watcher as a tracked child, verifies it is genuinely alive with a fresh liveness beacon, and reports honest `started`, `attached`, restart-only `healthy`, wake, or `FAILED` output.
 On `attached` it stays live until that existing cycle ends so background-notify harnesses do not get an empty false wake from a healthy no-op exit.
+A normal wake handoff stays quiet because the durable wake sequence advanced; if an owned or attached arm cycle instead ends without a handoff or healthy successor while tasks remain, it exits non-zero, prints `FAILED`, and writes `state/.watcher-arm-dead`.
 Its `--restart` mode signals only the watcher recorded in the current home's `state/.watch.lock`, so restarting one home cannot kill sibling secondmate watchers.
 A pull-based guard (`bin/fm-guard.sh`) warns through supervision tool output if the primary checkout is tangled, or if tasks are in flight and that watcher stops running or queued wakes are waiting to be drained.
+An arm-death marker also forces that warning inside the normal beacon grace unless an independently healthy watcher is confirmed.
 The drain script calls that guard after emptying the queue, which avoids repeating the queued-wakes warning for records it just consumed while still warning on stale watcher liveness.
 It leads with prominent bordered banners for the tangle and no-watcher cases so they cannot be skimmed past.
 On every verified primary harness, tracked hook integration gives the primary session a push-based backstop: when work is in flight and no identity-matched watcher lock with a fresh beacon is live, direct Stop hooks block and passive turn-end hooks force one bounded follow-up.

--- a/docs/supervision-protocols/claude.md
+++ b/docs/supervision-protocols/claude.md
@@ -9,7 +9,7 @@ When this session owns supervision and away mode is not active:
    A shell `&`, a truncating pipe, or bundling is denied automatically by the PreToolUse seatbelt (`bin/fm-arm-pretool-check.sh`) registered in `.claude/settings.json`.
 6. Treat `watcher: started ...` and `watcher: attached ...` as proof that one live cycle exists.
    On attach, the background task stays live until that existing cycle ends; it does not exit immediately.
-7. Treat `watcher: FAILED - no live watcher with a fresh beacon` as an alarm and repair it before ending the turn.
+7. Treat any `watcher: FAILED ...` line as an alarm and repair it before ending the turn.
 8. When the background task completes with `signal:`, `stale:`, `check:`, or `heartbeat`, drain queued wakes, handle them, then start exactly one fresh background task.
    Do not invent a wake from an attach-status line alone; drain and act only on real wake records or a real watcher reason line.
 9. If a forced restart is genuinely needed, run `bin/fm-watch-arm.sh --restart` through the same Claude background task mechanism.

--- a/tests/fm-bearings-snapshot.test.sh
+++ b/tests/fm-bearings-snapshot.test.sh
@@ -433,6 +433,21 @@ test_landed_includes_secondmate_home_merges() {
   pass "landed includes secondmate-managed merges alongside main-home merges"
 }
 
+test_secondmate_landed_report_path_uses_secondmate_home() {
+  local home fakebin json expected
+  home=$(make_home mate-report-path); write_fixture "$home"
+  cat >> "$home/secondmate-home/data/backlog.md" <<'EOF'
+- [x] mate-scout - Secondmate scout data/mate-scout/report.md (repo: firstmate) (kind: scout) (completed 2026-07-12)
+EOF
+  fakebin=$(make_fakebin "$home")
+  json=$(run "$home" "$fakebin" --json)
+  expected="$home/secondmate-home/data/mate-scout/report.md"
+  printf '%s' "$json" | jq -e --arg expected "$expected" '
+    .landed | any(.[]; .id == "mate-scout" and .artifact == $expected)
+  ' >/dev/null || fail "secondmate report artifact must resolve against its home: $json"
+  pass "secondmate landed report paths resolve against the secondmate home"
+}
+
 # The roll-up stays bounded: a per-home cap and an overall cap, both disclosed in
 # omitted[], with --all-landed as the counted expansion knob. This also covers the
 # previously-silent main-home landed truncation.
@@ -521,6 +536,7 @@ test_chat_contract_four_sections() {
 test_default_is_bounded_and_local_only
 test_toon_json_parity
 test_landed_includes_secondmate_home_merges
+test_secondmate_landed_report_path_uses_secondmate_home
 test_landed_bounded_and_disclosed
 test_captains_call_anti_leak
 test_chat_contract_four_sections

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -280,6 +280,16 @@ outcome: failed
 EOF
 }
 
+run_failed_at() {  # <branch> <epoch>
+  run_failed "$1"
+  printf 'updated_at: %s\n' "$2"
+}
+
+run_passed_at() {  # <branch> <epoch>
+  run_passed "$1"
+  printf 'updated_at: %s\n' "$2"
+}
+
 run_ci_monitoring() {  # <branch>
   cat <<EOF
 run:
@@ -684,7 +694,7 @@ test_paused_outranks_terminal_failed_run() {
   make_fakebin "$d" >/dev/null
   fm_write_meta "$d/state/feat-pause-fail.meta" "window=fm:fm-feat-pause-fail" "worktree=$d/wt" "kind=ship"
   printf 'paused: holding for provider recovery\n' > "$d/state/feat-pause-fail.status"
-  FM_FAKE_AXI_STATUS="$(run_failed fm/feat-pause-fail)"
+  FM_FAKE_AXI_STATUS="$(run_failed_at fm/feat-pause-fail 1)"
   FM_FAKE_BUSY=0
   local out; out=$(run_crew_state "$d" feat-pause-fail)
   assert_contains "$out" "state: paused" "trailing paused outranks terminal failed run"
@@ -702,7 +712,7 @@ test_paused_outranks_terminal_passed_run() {
   make_fakebin "$d" >/dev/null
   fm_write_meta "$d/state/feat-pause-pass.meta" "window=fm:fm-feat-pause-pass" "worktree=$d/wt" "kind=ship"
   printf 'paused: waiting on an upstream release\n' > "$d/state/feat-pause-pass.status"
-  FM_FAKE_AXI_STATUS="$(run_passed fm/feat-pause-pass)"
+  FM_FAKE_AXI_STATUS="$(run_passed_at fm/feat-pause-pass 1)"
   FM_FAKE_BUSY=0
   local out; out=$(run_crew_state "$d" feat-pause-pass)
   assert_contains "$out" "state: paused" "trailing paused outranks terminal passed run"
@@ -710,6 +720,36 @@ test_paused_outranks_terminal_passed_run() {
   assert_contains "$out" "historical run done" "detail notes the historical done run"
   assert_not_contains "$out" "state: done" "must not report done over trailing paused"
   pass "trailing paused: outranks a terminal passed historical run-step"
+}
+
+
+test_newer_terminal_run_outranks_older_pause() {
+  reset_fakes
+  local d; d=$(new_case newer-failure-over-pause)
+  make_repo_on_branch "$d/wt" fm/feat-new-fail
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-new-fail.meta" "window=fm:fm-feat-new-fail" "worktree=$d/wt" "kind=ship"
+  printf 'paused: old provider wait\n' > "$d/state/feat-new-fail.status"
+  FM_FAKE_AXI_STATUS="$(run_failed_at fm/feat-new-fail 4102444800)"
+  local out; out=$(run_crew_state "$d" feat-new-fail)
+  assert_contains "$out" "state: failed" "newer terminal failure outranks older pause"
+  assert_contains "$out" "source: run-step" "newer failure remains run-step sourced"
+  assert_not_contains "$out" "state: paused" "older pause must not hide newer failure"
+  pass "a newer terminal run outranks an older pause declaration"
+}
+
+test_unordered_terminal_run_outranks_pause() {
+  reset_fakes
+  local d; d=$(new_case unordered-failure-over-pause)
+  make_repo_on_branch "$d/wt" fm/feat-unordered-fail
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-unordered-fail.meta" "window=fm:fm-feat-unordered-fail" "worktree=$d/wt" "kind=ship"
+  printf 'paused: provider wait with unknown ordering\n' > "$d/state/feat-unordered-fail.status"
+  FM_FAKE_AXI_STATUS="$(run_failed fm/feat-unordered-fail)"
+  local out; out=$(run_crew_state "$d" feat-unordered-fail)
+  assert_contains "$out" "state: failed" "terminal run wins when ordering is unavailable"
+  assert_not_contains "$out" "state: paused" "unproven pause must not hide failure"
+  pass "an unordered terminal run outranks a pause declaration"
 }
 
 # Live run-step still beats a trailing paused: declaration (run-step precedence).
@@ -1241,6 +1281,8 @@ test_terminal_passed
 test_terminal_failed
 test_paused_outranks_terminal_failed_run
 test_paused_outranks_terminal_passed_run
+test_newer_terminal_run_outranks_older_pause
+test_unordered_terminal_run_outranks_pause
 test_running_run_outranks_paused_status
 test_terminal_failed_last_line_unchanged_with_failed_run
 test_terminal_done_last_line_unchanged_with_passed_run

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -285,6 +285,17 @@ run_failed_at() {  # <branch> <epoch>
   printf 'updated_at: %s\n' "$2"
 }
 
+# Format a Unix epoch as an ISO-8601 UTC instant (trailing Z), portably.
+iso_utc() {  # <epoch>
+  date -u -r "$1" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+    || date -u -d "@$1" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null
+}
+
+run_failed_iso() {  # <branch> <iso-utc>
+  run_failed "$1"
+  printf 'updated_at: %s\n' "$2"
+}
+
 run_passed_at() {  # <branch> <epoch>
   run_passed "$1"
   printf 'updated_at: %s\n' "$2"
@@ -703,6 +714,30 @@ test_paused_outranks_terminal_failed_run() {
   assert_contains "$out" "historical run failed" "detail notes the historical failed run"
   assert_not_contains "$out" "state: failed" "must not report failed over trailing paused"
   pass "trailing paused: outranks a terminal failed historical run-step"
+}
+
+# The pause-strictly-newer comparison parses an ISO-8601 Z run timestamp into a
+# Unix epoch and compares it against the pause file's real mtime. That parse must
+# treat the trailing Z as UTC regardless of the machine's local timezone; a
+# west-of-UTC parse that ignores Z shifts the run epoch forward by the local
+# offset and can flip a genuinely-older run into a spuriously-newer one, wrongly
+# suppressing the pause. Pin a west-of-UTC zone and place the run two hours before
+# the fresh pause file: the correct UTC parse keeps the run older (pause wins),
+# while an offset-skewed parse would push it past the pause and report failed.
+test_paused_outranks_terminal_failed_run_iso_ts_tz() {
+  reset_fakes
+  local d; d=$(new_case paused-over-failed-iso-tz)
+  make_repo_on_branch "$d/wt" fm/feat-pause-iso
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-pause-iso.meta" "window=fm:fm-feat-pause-iso" "worktree=$d/wt" "kind=ship"
+  printf 'paused: holding for provider recovery\n' > "$d/state/feat-pause-iso.status"
+  local now iso; now=$(date +%s); iso=$(iso_utc "$((now - 7200))")
+  FM_FAKE_AXI_STATUS="$(run_failed_iso fm/feat-pause-iso "$iso")"
+  FM_FAKE_BUSY=0
+  local out; out=$(TZ=America/New_York run_crew_state "$d" feat-pause-iso)
+  assert_contains "$out" "state: paused" "trailing paused outranks older ISO-Z failed run under west-of-UTC tz"
+  assert_not_contains "$out" "state: failed" "west-of-UTC Z parse must not flip an older run into a newer one"
+  pass "trailing paused: outranks an older ISO-Z terminal run regardless of local timezone"
 }
 
 test_paused_outranks_terminal_passed_run() {
@@ -1280,6 +1315,7 @@ test_top_level_fixing_done_log_stays_working
 test_terminal_passed
 test_terminal_failed
 test_paused_outranks_terminal_failed_run
+test_paused_outranks_terminal_failed_run_iso_ts_tz
 test_paused_outranks_terminal_passed_run
 test_newer_terminal_run_outranks_older_pause
 test_unordered_terminal_run_outranks_pause

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -673,6 +673,90 @@ test_terminal_failed() {
   pass "terminal failed run is authoritative"
 }
 
+# Trailing paused: outranks a terminal historical run-step. A failed past run is
+# not evidence the pane needs attention; without this override the watcher treats
+# absorb class as none and resurfaces the idle pane on every poll (worse than a
+# terminal done: line, which at least takes the surfaced-once path).
+test_paused_outranks_terminal_failed_run() {
+  reset_fakes
+  local d; d=$(new_case paused-over-failed)
+  make_repo_on_branch "$d/wt" fm/feat-pause-fail
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-pause-fail.meta" "window=fm:fm-feat-pause-fail" "worktree=$d/wt" "kind=ship"
+  printf 'paused: holding for provider recovery\n' > "$d/state/feat-pause-fail.status"
+  FM_FAKE_AXI_STATUS="$(run_failed fm/feat-pause-fail)"
+  FM_FAKE_BUSY=0
+  local out; out=$(run_crew_state "$d" feat-pause-fail)
+  assert_contains "$out" "state: paused" "trailing paused outranks terminal failed run"
+  assert_contains "$out" "source: status-log" "pause-over-failed uses status-log source"
+  assert_contains "$out" "holding for provider recovery" "pause reason is preserved"
+  assert_contains "$out" "historical run failed" "detail notes the historical failed run"
+  assert_not_contains "$out" "state: failed" "must not report failed over trailing paused"
+  pass "trailing paused: outranks a terminal failed historical run-step"
+}
+
+test_paused_outranks_terminal_passed_run() {
+  reset_fakes
+  local d; d=$(new_case paused-over-passed)
+  make_repo_on_branch "$d/wt" fm/feat-pause-pass
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-pause-pass.meta" "window=fm:fm-feat-pause-pass" "worktree=$d/wt" "kind=ship"
+  printf 'paused: waiting on an upstream release\n' > "$d/state/feat-pause-pass.status"
+  FM_FAKE_AXI_STATUS="$(run_passed fm/feat-pause-pass)"
+  FM_FAKE_BUSY=0
+  local out; out=$(run_crew_state "$d" feat-pause-pass)
+  assert_contains "$out" "state: paused" "trailing paused outranks terminal passed run"
+  assert_contains "$out" "source: status-log" "pause-over-passed uses status-log source"
+  assert_contains "$out" "historical run done" "detail notes the historical done run"
+  assert_not_contains "$out" "state: done" "must not report done over trailing paused"
+  pass "trailing paused: outranks a terminal passed historical run-step"
+}
+
+# Live run-step still beats a trailing paused: declaration (run-step precedence).
+test_running_run_outranks_paused_status() {
+  reset_fakes
+  local d; d=$(new_case running-over-paused)
+  make_repo_on_branch "$d/wt" fm/feat-run-pause
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-run-pause.meta" "window=fm:fm-feat-run-pause" "worktree=$d/wt" "kind=ship"
+  printf 'paused: holding for the upstream tool release\n' > "$d/state/feat-run-pause.status"
+  FM_FAKE_AXI_STATUS="$(run_running fm/feat-run-pause)"
+  local out; out=$(run_crew_state "$d" feat-run-pause)
+  assert_contains "$out" "state: working" "active run outranks trailing paused"
+  assert_contains "$out" "source: run-step" "active run stays run-step sourced"
+  assert_not_contains "$out" "state: paused" "must not report paused over a live run"
+  pass "live running run-step outranks trailing paused: status"
+}
+
+# Terminal done:/failed: last lines (no trailing pause) keep run-step authority.
+test_terminal_failed_last_line_unchanged_with_failed_run() {
+  reset_fakes
+  local d; d=$(new_case failed-last-line)
+  make_repo_on_branch "$d/wt" fm/feat-fail-line
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-fail-line.meta" "window=fm:fm-feat-fail-line" "worktree=$d/wt" "kind=ship"
+  printf 'failed: validation crashed\n' > "$d/state/feat-fail-line.status"
+  FM_FAKE_AXI_STATUS="$(run_failed fm/feat-fail-line)"
+  local out; out=$(run_crew_state "$d" feat-fail-line)
+  assert_contains "$out" "state: failed" "failed: last line + failed run stays failed"
+  assert_contains "$out" "source: run-step" "failed last line still run-step sourced"
+  pass "terminal failed: last line behavior unchanged with a failed run-step"
+}
+
+test_terminal_done_last_line_unchanged_with_passed_run() {
+  reset_fakes
+  local d; d=$(new_case done-last-line)
+  make_repo_on_branch "$d/wt" fm/feat-done-line
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-done-line.meta" "window=fm:fm-feat-done-line" "worktree=$d/wt" "kind=ship"
+  printf 'done: PR https://example.test/pr/1 checks green\n' > "$d/state/feat-done-line.status"
+  FM_FAKE_AXI_STATUS="$(run_passed fm/feat-done-line)"
+  local out; out=$(run_crew_state "$d" feat-done-line)
+  assert_contains "$out" "state: done" "done: last line + passed run stays done"
+  assert_contains "$out" "source: run-step" "done last line still run-step sourced"
+  pass "terminal done: last line behavior unchanged with a passed run-step"
+}
+
 # (e) cross-branch attribution: `axi status` returns ANOTHER branch's run (the
 # routine case once more than one crew validates the same underlying repo
 # concurrently - they share ONE no-mistakes repo registration), so the helper
@@ -1155,6 +1239,11 @@ test_top_level_fixing_ci_running_after_green_stays_working
 test_top_level_fixing_done_log_stays_working
 test_terminal_passed
 test_terminal_failed
+test_paused_outranks_terminal_failed_run
+test_paused_outranks_terminal_passed_run
+test_running_run_outranks_paused_status
+test_terminal_failed_last_line_unchanged_with_failed_run
+test_terminal_done_last_line_unchanged_with_passed_run
 test_cross_branch_attribution_via_runs_list
 test_cross_branch_attribution_picks_most_recent_row
 test_coarse_run_does_not_probe_other_branch_ci_log_for_ready_status

--- a/tests/fm-gotmp.test.sh
+++ b/tests/fm-gotmp.test.sh
@@ -58,6 +58,9 @@ make_fake_root() {
   ln -s "$ROOT/bin/fm-backend.sh" "$fake/bin/fm-backend.sh"
   ln -s "$ROOT/bin/backends/tmux.sh" "$fake/bin/backends/tmux.sh"
   ln -s "$ROOT/bin/fm-tmux-lib.sh" "$fake/bin/fm-tmux-lib.sh"
+  # fm-composer-lib.sh: fm-tmux-lib.sh sources it relative to its own path, so it
+  # must sit beside the fm-tmux-lib.sh symlink or the lazy tmux-adapter source fails.
+  ln -s "$ROOT/bin/fm-composer-lib.sh" "$fake/bin/fm-composer-lib.sh"
   # fm-lock-lib.sh: teardown sources it for the shared lock-staleness proof.
   ln -s "$ROOT/bin/fm-lock-lib.sh" "$fake/bin/fm-lock-lib.sh"
   # fm-gate-refuse-lib.sh: teardown sources it before any fleet mutation.
@@ -156,6 +159,7 @@ test_teardown_skips_gracefully_without_tasktmp() {
   ln -s "$ROOT/bin/fm-backend.sh" "$fake/bin/fm-backend.sh"
   ln -s "$ROOT/bin/backends/tmux.sh" "$fake/bin/backends/tmux.sh"
   ln -s "$ROOT/bin/fm-tmux-lib.sh" "$fake/bin/fm-tmux-lib.sh"
+  ln -s "$ROOT/bin/fm-composer-lib.sh" "$fake/bin/fm-composer-lib.sh"
   ln -s "$ROOT/bin/fm-lock-lib.sh" "$fake/bin/fm-lock-lib.sh"
   # fm-gate-refuse-lib.sh: teardown sources it before any fleet mutation.
   ln -s "$ROOT/bin/fm-gate-refuse-lib.sh" "$fake/bin/fm-gate-refuse-lib.sh"

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -213,6 +213,11 @@ test_crew_absorb_class_classifier() {
   [ "$(crew_absorb_class a)" = paused ] || fail "declared pause not classed paused"
   crew_is_paused a || fail "crew_is_paused did not recognize a paused verdict"
   ! crew_is_provably_working a || fail "a paused crew was treated as provably working"
+  # Post-fix contract from fm-crew-state.sh: trailing paused + terminal historical
+  # run reports paused (not failed), so absorb class is paused not none.
+  FM_FAKE_CREW_STATE='state: paused · source: status-log · holding for provider recovery · historical run failed'
+  [ "$(crew_absorb_class a)" = paused ] || fail "paused-over-historical-failed not classed paused"
+  crew_is_paused a || fail "crew_is_paused missed paused-over-historical-failed"
   FM_FAKE_CREW_STATE='state: working · source: status-log · working: compiling'
   [ "$(crew_absorb_class a)" = none ] || fail "stale working: status-log classed absorbable"
   FM_FAKE_CREW_STATE='state: unknown · source: none · worktree gone'
@@ -588,6 +593,43 @@ test_nonterminal_stale_paused_absorbed_then_resurfaced() {
   FM_STATE_OVERRIDE="$state" "$DRAIN" > "$drain_out" 2>/dev/null || fail "drain after the paused re-surface failed"
   grep "$(printf '\tstale\t')" "$drain_out" | grep -F "$window" >/dev/null || fail "paused re-surface was not queued"
   pass "a declared pause is absorbed on first sight, then re-surfaced as a recheck past the threshold, never wedge-escalated"
+}
+
+# Regression for 2026-07-12: trailing paused: + failed historical run-step used to
+# make crew_absorb_class return none (fm-crew-state reported failed from the dead
+# run), so the idle pane re-surfaced every poll. Fixed crew-state reports paused
+# with a historical-run note; the watcher must absorb that on the long recheck
+# cadence exactly like any other declared pause.
+test_nonterminal_stale_paused_over_historical_failed_absorbed() {
+  local dir state fakebin out capture_file window key pane_hash sig pid statusf
+  dir=$(make_case nonterminal-stale-paused-hist-fail); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"; capture_file="$dir/pane.txt"
+  window="test:fm-held-hist-fail"
+  printf 'idle, holding after a failed validation\n' > "$capture_file"
+  printf 'window=%s\nkind=ship\n' "$window" > "$state/held-hist.meta"
+  statusf="$state/held-hist.status"
+  printf 'paused: holding for provider recovery\n' > "$statusf"
+  sig=$(seen_sig "$statusf"); printf '%s' "$sig" > "$state/.seen-held-hist_status"
+  key=$(printf '%s' "$window" | tr ':/.' '___')
+  pane_hash=$(hash_text "idle, holding after a failed validation")
+  printf '%s' "$pane_hash" > "$state/.hash-$key"
+  printf '1\n' > "$state/.count-$key"
+  export FM_FAKE_CREW_STATE='state: paused · source: status-log · holding for provider recovery · historical run failed'
+
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
+    FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_PAUSE_RESURFACE_SECS=999 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  if ! wait_live "$pid" 30; then
+    reap "$pid"; fail "watcher surfaced paused-over-historical-failed instead of absorbing: $(cat "$out")"
+  fi
+  [ ! -s "$out" ] || fail "paused-over-historical-failed printed a wake during absorb: $(cat "$out")"
+  [ ! -s "$state/.wake-queue" ] || fail "paused-over-historical-failed enqueued a wake during absorb"
+  [ -e "$state/.paused-$key" ] || fail "paused flag not recorded for paused-over-historical-failed"
+  [ ! -e "$state/.stale-since-$key" ] || fail "paused-over-historical-failed must not start the wedge timer"
+  reap "$pid"
+  unset FM_FAKE_CREW_STATE
+  pass "trailing paused: over a historical failed run-step is absorbed on the long recheck cadence"
 }
 
 test_secondmate_paused_resurfaces_in_normal_mode() {
@@ -1116,6 +1158,7 @@ test_wedge_escalation_marks_demand_deep_inspection_after_threshold
 test_wedge_escalation_resets_when_pane_becomes_active
 test_nonterminal_stale_not_working_surfaced
 test_nonterminal_stale_paused_absorbed_then_resurfaced
+test_nonterminal_stale_paused_over_historical_failed_absorbed
 test_secondmate_paused_resurfaces_in_normal_mode
 test_secondmate_nonpaused_stale_remains_suppressed
 test_secondmate_unpause_clears_pause_tracking

--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -741,6 +741,50 @@ test_arm_attached_death_loud_when_tasks_in_flight() {
   pass "attached arm cycle death is loud when tasks are in flight (FAILED + marker + non-zero)"
 }
 
+# An attached arm cannot read the watcher's wake output, so it must NOT mistake a
+# NORMAL wake handoff (the watched holder enqueued an actionable wake and exited,
+# which the primary re-arms on) for a silent orphan death - even with tasks in
+# flight and no successor yet. The distinguishing signal is the durable wake
+# counter advancing since the arm began watching that holder.
+test_arm_attached_wake_handoff_is_quiet_when_tasks_in_flight() {
+  local dir state fakebin out armout i wpid armpid status
+  dir=$(make_case arm-attach-handoff-quiet)
+  state="$dir/state"
+  fakebin="$dir/fakebin"
+  out="$dir/watch.out"
+  armout="$dir/arm.out"
+  printf 'window=test:fm-live\nkind=ship\n' > "$state/live-task.meta"
+  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  wpid=$!
+  i=0
+  while [ "$i" -lt 60 ]; do
+    [ "$(cat "$state/.watch.lock/pid" 2>/dev/null || true)" = "$wpid" ] && [ -e "$state/.last-watcher-beat" ] && break
+    sleep 0.1
+    i=$((i + 1))
+  done
+  [ "$(cat "$state/.watch.lock/pid" 2>/dev/null || true)" = "$wpid" ] || fail "seed watcher did not take the lock"
+  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_ARM_ATTACH_POLL=0.1 "$WATCH_ARM" > "$armout" &
+  armpid=$!
+  i=0
+  while [ "$i" -lt 80 ]; do
+    grep -qF "watcher: attached pid=$wpid" "$armout" 2>/dev/null && break
+    sleep 0.1
+    i=$((i + 1))
+  done
+  grep -qF "watcher: attached pid=$wpid" "$armout" || fail "arm did not report attach: $(cat "$armout")"
+  # The holder delivers a normal wake: it enqueues an actionable wake (bumping the
+  # durable counter) and then exits, exactly as fm-watch.sh's wake() does.
+  append_wake "$state" stale "test:fm-live" "stale: test:fm-live" || fail "handoff wake append failed"
+  kill "$wpid" 2>/dev/null || true
+  wait "$wpid" 2>/dev/null || true
+  wait_for_exit "$armpid" 80
+  status=$?
+  [ "$status" -eq 0 ] || fail "attached arm did not exit zero on a normal wake handoff (status $status): $(cat "$armout")"
+  ! grep -qF 'watcher: FAILED' "$armout" || fail "attached arm falsely reported arm-death on a normal wake handoff: $(cat "$armout")"
+  [ ! -e "$state/.watcher-arm-dead" ] || fail "attached arm wrote arm-death marker on a normal wake handoff"
+  pass "attached arm stays quiet on a normal wake handoff while tasks are in flight"
+}
+
 test_pid_identity_is_locale_invariant() {
   # The watcher records its process identity under one locale; arm/guard/turn-end
   # re-read it under the machine's ambient locale. ps's lstart date format follows
@@ -787,3 +831,4 @@ test_arm_propagates_immediate_wake_before_confirmation
 test_arm_waits_for_peer_beacon_after_child_stands_down
 test_arm_fails_loud_when_no_fresh_watcher_confirmable
 test_arm_attached_death_loud_when_tasks_in_flight
+test_arm_attached_wake_handoff_is_quiet_when_tasks_in_flight

--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -155,6 +155,13 @@ test_guard_warnings() {
   # total silence" stays a pure assertion about watcher state.
   FM_ROOT_OVERRIDE="$dir" FM_STATE_OVERRIDE="$state" FM_GUARD_GRACE=300 "$ROOT/bin/fm-guard.sh" 2> "$err" >/dev/null || fail "guard failed"
   [ ! -s "$err" ] || fail "guard warned with a fresh watcher and no queued wakes: $(cat "$err")"
+
+  printf 'ts=1\ndetail=arm cycle received TERM with no live successor\n' > "$state/.watcher-arm-dead"
+  FM_ROOT_OVERRIDE="$dir" FM_STATE_OVERRIDE="$state" FM_GUARD_GRACE=300 "$ROOT/bin/fm-guard.sh" 2> "$err" >/dev/null || fail "guard failed"
+  grep -F 'fresh-looking but no independently healthy watcher' "$err" >/dev/null \
+    || fail "fresh beacon hid an explicit arm-death marker: $(cat "$err")"
+  grep -F 'Last arm death: arm cycle received TERM with no live successor' "$err" >/dev/null \
+    || fail "fresh-marker warning omitted arm-death detail: $(cat "$err")"
   pass "guard banner leads when down with pending wakes (re-arm-after-drain) and stays silent when fresh"
 }
 
@@ -568,6 +575,7 @@ test_arm_hup_cleans_child_and_temp_output() {
   state="$dir/state"
   fakebin="$dir/fakebin"
   armout="$dir/arm.out"
+  printf 'window=test:fm-live\nkind=ship\n' > "$state/live-task.meta"
   PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH_ARM" > "$armout" &
   armpid=$!
   i=0
@@ -589,6 +597,9 @@ test_arm_hup_cleans_child_and_temp_output() {
   done
   ! is_live_non_zombie "$lock_pid" || fail "HUP cleanup left watcher child running"
   ! ls "$state"/.watch-arm-output.* >/dev/null 2>&1 || fail "HUP cleanup left temp output behind"
+  grep -F 'watcher: FAILED - arm cycle received HUP with no live successor while tasks are in flight' "$armout" >/dev/null \
+    || fail "dying watcher child suppressed the HUP arm-death report: $(cat "$armout")"
+  [ -f "$state/.watcher-arm-dead" ] || fail "HUP arm death did not write its marker"
   pass "arm cleans child watcher and temp output on HUP"
 }
 

--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -106,11 +106,12 @@ test_guard_warnings() {
   state="$dir/state"
   err="$dir/guard.err"
 
-  # (1) watcher down (no beacon) + two in-flight tasks + a queued wake.
-  # FM_ROOT_OVERRIDE points the worktree-tangle check at a non-git dir so it stays
-  # inert here; this case is about the watcher-down banner, not the tangle guard.
+  # (1) watcher down (no beacon) + two in-flight tasks + a queued wake + an
+  # arm-death marker from a prior silent cycle death. FM_ROOT_OVERRIDE points the
+  # worktree-tangle check at a non-git dir so it stays inert here.
   printf 'project=x\n' > "$state/task.meta"
   printf 'project=y\n' > "$state/task2.meta"
+  printf 'ts=1\ndetail=arm cycle ended with no live successor while tasks are in flight\n' > "$state/.watcher-arm-dead"
   append_wake "$state" heartbeat heartbeat heartbeat || fail "guard heartbeat append failed"
   FM_ROOT_OVERRIDE="$dir" FM_STATE_OVERRIDE="$state" FM_GUARD_GRACE=1 "$ROOT/bin/fm-guard.sh" 2> "$err" >/dev/null || fail "guard failed"
   first=$(grep -v '^[[:space:]]*$' "$err" | head -1)
@@ -121,6 +122,9 @@ test_guard_warnings() {
   grep -F 'WATCHER DOWN - SUPERVISION IS OFF' "$err" >/dev/null || fail "guard banner missing the alarm title"
   grep -F '2 task(s) in flight' "$err" >/dev/null || fail "guard banner missing the in-flight count"
   grep -F 'last beat: never' "$err" >/dev/null || fail "guard banner missing the beacon age"
+  grep -F 'Last arm death: arm cycle ended with no live successor while tasks are in flight' "$err" >/dev/null \
+    || fail "guard banner did not name the arm-death marker: $(cat "$err")"
+  grep -F 'state/.watcher-arm-dead' "$err" >/dev/null || fail "guard banner omitted the arm-death marker path"
   grep -F 'guarded operation WILL still run' "$err" >/dev/null || fail "guard banner missing generic continuation wording"
   ! grep -F 'requested message WILL still be sent' "$err" >/dev/null || fail "shared guard used send-specific continuation wording"
   grep -F 'resume supervision' "$err" >/dev/null || fail "guard banner missing the harness-aware fix command"
@@ -672,12 +676,58 @@ test_arm_fails_loud_when_no_fresh_watcher_confirmable() {
   [ "$status" -ne 124 ] || fail "arm never returned for an unconfirmable watcher"
   [ "$status" -ne 0 ] || fail "arm exited zero when no fresh watcher could be confirmed"
   grep -F 'watcher: FAILED - no live watcher with a fresh beacon' "$armout" >/dev/null || fail "arm did not print the FAILED line"
+  [ -f "$state/.watcher-arm-dead" ] || fail "FAILED path did not write the arm-death marker"
+  grep -F 'detail=no live watcher with a fresh beacon' "$state/.watcher-arm-dead" >/dev/null \
+    || fail "arm-death marker missing detail: $(cat "$state/.watcher-arm-dead" 2>/dev/null || true)"
   ! grep -qE 'watcher: (healthy|attached)' "$armout" || fail "arm reported attached/healthy off a stale beacon"
   ! grep -qF 'watcher: started' "$armout" || fail "arm falsely reported started"
   is_live_non_zombie "$live" || fail "arm killed the unrelated live lock holder"
   kill "$live" 2>/dev/null || true
   wait "$live" 2>/dev/null || true
   pass "arm reports FAILED and exits non-zero when no fresh watcher can be confirmed"
+}
+
+# When an attached arm cycle ends with tasks still in flight and no healthy
+# successor, the death must be loud (FAILED line + durable marker + non-zero).
+# Idle homes (no .meta) still exit 0 so empty-fleet attach teardown stays quiet.
+test_arm_attached_death_loud_when_tasks_in_flight() {
+  local dir state fakebin out armout i wpid armpid status
+  dir=$(make_case arm-attach-death-loud)
+  state="$dir/state"
+  fakebin="$dir/fakebin"
+  out="$dir/watch.out"
+  armout="$dir/arm.out"
+  printf 'window=test:fm-live\nkind=ship\n' > "$state/live-task.meta"
+  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  wpid=$!
+  i=0
+  while [ "$i" -lt 60 ]; do
+    [ "$(cat "$state/.watch.lock/pid" 2>/dev/null || true)" = "$wpid" ] && [ -e "$state/.last-watcher-beat" ] && break
+    sleep 0.1
+    i=$((i + 1))
+  done
+  [ "$(cat "$state/.watch.lock/pid" 2>/dev/null || true)" = "$wpid" ] || fail "seed watcher did not take the lock"
+  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_ARM_ATTACH_POLL=0.1 "$WATCH_ARM" > "$armout" &
+  armpid=$!
+  i=0
+  while [ "$i" -lt 80 ]; do
+    grep -qF "watcher: attached pid=$wpid" "$armout" 2>/dev/null && break
+    sleep 0.1
+    i=$((i + 1))
+  done
+  grep -qF "watcher: attached pid=$wpid" "$armout" || fail "arm did not report attach: $(cat "$armout")"
+  [ ! -e "$state/.watcher-arm-dead" ] || fail "successful attach left a stale arm-death marker"
+  kill "$wpid" 2>/dev/null || true
+  wait "$wpid" 2>/dev/null || true
+  wait_for_exit "$armpid" 80
+  status=$?
+  [ "$status" -ne 0 ] || fail "attached arm exited zero with tasks in flight after seed died: $(cat "$armout")"
+  grep -F 'watcher: FAILED - arm cycle ended with no live successor while tasks are in flight' "$armout" >/dev/null \
+    || fail "attached arm death was not loud: $(cat "$armout")"
+  [ -f "$state/.watcher-arm-dead" ] || fail "loud arm death did not write state/.watcher-arm-dead"
+  grep -F 'detail=arm cycle ended with no live successor while tasks are in flight' "$state/.watcher-arm-dead" >/dev/null \
+    || fail "arm-death marker missing expected detail: $(cat "$state/.watcher-arm-dead")"
+  pass "attached arm cycle death is loud when tasks are in flight (FAILED + marker + non-zero)"
 }
 
 test_pid_identity_is_locale_invariant() {
@@ -725,3 +775,4 @@ test_arm_hup_cleans_child_and_temp_output
 test_arm_propagates_immediate_wake_before_confirmation
 test_arm_waits_for_peer_beacon_after_child_stands_down
 test_arm_fails_loud_when_no_fresh_watcher_confirmable
+test_arm_attached_death_loud_when_tasks_in_flight


### PR DESCRIPTION
## Intent

Fix two watcher supervision defects observed live on 2026-07-12:

1. Trailing `paused:` absorbs a historical failed/done run-step only when the pause is strictly newer (UTC-safe ISO-Z timestamps); a live running/parked run still wins; bare terminal `done:`/`failed:` last-line behavior is unchanged.
2. Owned arm cycles that end without a successor or wake handoff while tasks are in flight fail loudly (`watcher: FAILED` + `state/.watcher-arm-dead`). Concurrently attached arms stay quiet on a normal owner wake handoff. The guard surfaces the arm-death marker even within beacon grace unless a live watcher is confirmed. Secondmate scout `report_path` values resolve against the secondmate home in bearings.

## Scope (task-only)

Rebuilt on current `main` by cherry-picking only watcher commits. Dropped contamination from a stale fork/`main` base and pipeline doc/lint commits that pulled in afk/cd-guard/bootstrap/handoff work.

**13 files / +566 −30** vs `kunchenguid/main`:
- `bin/fm-crew-state.sh`, `bin/fm-classify-lib.sh`, `bin/fm-watch-arm.sh`, `bin/fm-guard.sh`, `bin/fm-bearings-snapshot.sh`
- colocated tests + short watcher docs (`AGENTS.md`, architecture, claude protocol)

## Local validation

All task-scoped suites green (fixture homes only; no fleet-wide process kills):
- `tests/fm-crew-state.test.sh` (51)
- `tests/fm-watch-triage.test.sh` (34)
- `tests/fm-watcher-lock.test.sh` (24)
- `tests/fm-bearings-snapshot.test.sh` (18)
- `tests/fm-gotmp.test.sh` (4)
- `bin/fm-lint.sh` (ShellCheck 0.11.0)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

Task-only tip: `9b0fe04`.