### PR TITLE
feat(bin): add capacity failover substrate with shared GitHub quota guard

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -25,7 +25,7 @@ If `config/crew-harness` is unset or `default`, there is no concrete value to in
 Inheritance also copies the literal `config/crew-dispatch.json` file, so secondmates apply the same best-fit profile rules for their own crewmates.
 
 Each adapter splits into mechanics and knowledge.
-The per-task mechanics, including launch command, autonomy flag, and crewmate turn-end hook, live in `bin/fm-spawn.sh`.
+The per-task mechanics, including launch command, autonomy flag, and crewmate turn-end hook, live in `bin/fm-harness-launch-lib.sh`, which `bin/fm-spawn.sh` and `bin/fm-rehome-quota-wall.sh` both source so every launch path uses the same verified templates.
 The primary-session "no turn ends blind" guard contract and harness hook installation paths live in `docs/turnend-guard.md`.
 The primary-session watcher wake protocols are rendered from `docs/supervision-protocols/` by `bin/fm-supervision-instructions.sh`.
 The supervision knowledge lives here: busy signature, exit command, interrupt, dialogs, resume behavior, skill invocation, and quirks.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,7 @@ bin/                 helper scripts, committed; read each script's header before
 config/crew-harness  crewmate harness override; LOCAL, gitignored; absent or "default" = same as firstmate. Inherited as the literal file: a concrete primary adapter value also controls a secondmate home's own crewmates (section 4)
 config/crew-dispatch.json  optional crewmate dispatch profiles; LOCAL, gitignored; firstmate-maintained but human-editable natural-language rules that choose a per-task harness/model/effort profile (section 4). Inherited by secondmate homes
 config/secondmate-harness  harness the PRIMARY uses to launch SECONDMATE agents, optionally followed by a model and effort token on the same line ("<harness> [<model>] [<effort>]"; section 4); LOCAL, gitignored; absent or "default" harness falls back to config/crew-harness then firstmate's own. The primary's own setting; NOT inherited into secondmate homes (secondmates do not spawn secondmates)
+config/capacity-failover  optional capacity-failover substrate controls; LOCAL, gitignored; absent = no spawn or dispatch behavior change. `host-pressure=on` enables bounded memory, disk-floor, and active-task spawn backpressure; `route=` lines feed the manual capacity route selector; details live in docs/capacity-failover.md
 config/backlog-backend  backlog backend override; LOCAL, gitignored; absent or "tasks-axi" = default tasks-axi backend, "manual" = force routine backlog updates to hand-editing; inherited by secondmate homes (section 10)
 config/backend  runtime session-provider backend override for new tasks; LOCAL, gitignored; absent = falls through to runtime auto-detection (the runtime firstmate itself is executing inside), then tmux; tmux is the verified reference backend (docs/tmux-backend.md), while herdr, zellij, orca, and cmux are experimental spawn backends (docs/herdr-backend.md, docs/zellij-backend.md, docs/orca-backend.md, docs/cmux-backend.md) - herdr and cmux can also be selected by runtime auto-detection, zellij and orca never are (always explicit), and codex-app is not accepted; see docs/codex-app-backend.md; not inherited into secondmate homes
 config/herdr-presentation-spaces  optional presence flag for Herdr's default-off disposable single-task visual projection; LOCAL, gitignored; inherited by secondmate homes; see docs/herdr-backend.md "Optional disposable single-task presentation spaces"
@@ -235,7 +236,7 @@ Implementation requires a separate request or other clear implementation scope.
 Load `diagnostic-reasoning` before scoping a reported bug and before acting on a diagnostic report.
 
 Classify work as dispatchable when it does not overlap work under way, or queued and blocked when it touches the same project subsystem or depends on unlanded work.
-Dispatch independent work immediately with no concurrency cap, serialize coarse overlaps, and record blockers durably.
+Dispatch independent work immediately with no concurrency cap unless opt-in `config/capacity-failover` host-pressure backpressure refuses a new spawn, serialize coarse overlaps, and record blockers durably.
 Write the task-specific brief under section 11 before spawning.
 
 ### Dispatch and supervision handoff

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,8 @@ state/               volatile runtime signals; gitignored
   .pr-check-quarantine/  private non-runnable storage for checks neutralized by the non-executing migration
   .pr-check-migration.log  private per-task outcomes distinguishing rebuilt or canonically registered replacement polls, quarantined unarmed polls, and incomplete migrations
   .pr-check-migration-scan-v1  private marker proving the non-executing scan disabled every unsafe legacy check; .pr-check-migration-v1 separately records completed private repairs
+  capacity-cooldowns/  passive per-(harness, account, profile) capacity cooldown records; written and expired by bin/fm-capacity-cooldown.sh (docs/capacity-failover.md)
+  .host-pressure-*   opt-in host-pressure disk hysteresis and bounded alert-cooldown markers; never touch (docs/capacity-failover.md)
   x-watch.check.sh   generated X-mode relay poll shim; present only when opted in (section 14)
   pending-replies/   parent-owned secondmate pending-reply records (correlation id, delivery vs reply, recovery, escalation); fm-pending-reply-lib.sh
   x-inbox/           generated X-mode pending mention payloads; fmx-respond drains it (section 14)

--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ Firstmate's skills live in two separate places with different audiences:
 - [docs/architecture.md](docs/architecture.md) - how the crew, supervision, worktrees, secondmates, and project modes work.
 - [docs/configuration.md](docs/configuration.md) - environment variables, `FM_HOME`, runtime backend selection, optional X mode, the files you set, and harness support.
 - [docs/wedge-alarm.md](docs/wedge-alarm.md) - configure the active alert for an away-mode escalation delivery that gets stuck.
+- [docs/capacity-failover.md](docs/capacity-failover.md) - the opt-in capacity substrate: quota/auth wall classification, cooldowns, manual rehoming, host-pressure backpressure, and the shared GitHub quota guard.
 - [docs/tmux-backend.md](docs/tmux-backend.md) - setup guide for the tmux reference backend: prerequisites, attaching, and watching crew windows.
 - [docs/herdr-backend.md](docs/herdr-backend.md) - setup guide for the experimental herdr backend, plus its verification notes and known gaps.
 - [docs/zellij-backend.md](docs/zellij-backend.md) - setup guide for the experimental zellij backend, plus its verification notes and known gaps.

--- a/bin/fm-bearings-snapshot.sh
+++ b/bin/fm-bearings-snapshot.sh
@@ -73,6 +73,8 @@ FM_BEARINGS_UNHEALTHY=${FM_BEARINGS_UNHEALTHY:-20}
 FM_BEARINGS_PR_REPOS=${FM_BEARINGS_PR_REPOS:-10}
 FM_BEARINGS_PR_LIMIT=${FM_BEARINGS_PR_LIMIT:-20}
 FM_BEARINGS_PR_TIMEOUT=${FM_BEARINGS_PR_TIMEOUT:-20}
+GITHUB_ACCOUNT=${FM_GITHUB_ACCOUNT_ID:-94498628}
+GITHUB_ROUTE=${FM_GITHUB_ROUTE:-default}
 case "$FM_BEARINGS_PR_TIMEOUT" in ''|*[!0-9]*|0) FM_BEARINGS_PR_TIMEOUT=20 ;; esac
 validate_bound() {  # <name> <value>
   case "$2" in ''|*[!0-9]*|0) echo "fm-bearings-snapshot: $1 must be a positive integer" >&2; exit 2 ;; esac
@@ -200,8 +202,22 @@ gh_bounded() {  # <args...>
   fi
 }
 
+github_quota_deferred_status() {
+  local out state account reset_at reset_epoch
+  out=$("$SCRIPT_DIR/fm-shared-github-quota.sh" check --provider github --account "$GITHUB_ACCOUNT" --route "$GITHUB_ROUTE" 2>/dev/null || true)
+  state=$(printf '%s\n' "$out" | sed -n 's/^state=//p' | tail -1)
+  [ "$state" = defer ] || return 1
+  account=$(printf '%s\n' "$out" | sed -n 's/^account=//p' | tail -1)
+  reset_at=$(printf '%s\n' "$out" | sed -n 's/^reset_at=//p' | tail -1)
+  reset_epoch=$(printf '%s\n' "$out" | sed -n 's/^reset_epoch=//p' | tail -1)
+  PR_STATUS="deferred (github account ${account:-$GITHUB_ACCOUNT} rate-limited until ${reset_at:-reset_epoch:$reset_epoch})"
+  return 0
+}
+
 if [ "$INCLUDE_PRS" = 1 ]; then
-  if ! command -v gh >/dev/null 2>&1; then
+  if github_quota_deferred_status; then
+    :
+  elif ! command -v gh >/dev/null 2>&1; then
     PR_STATUS='unavailable (gh not found)'
   else
     # Candidate repos: recorded pr= URLs plus live worktree origins. Deduped.

--- a/bin/fm-bearings-snapshot.sh
+++ b/bin/fm-bearings-snapshot.sh
@@ -73,7 +73,6 @@ FM_BEARINGS_UNHEALTHY=${FM_BEARINGS_UNHEALTHY:-20}
 FM_BEARINGS_PR_REPOS=${FM_BEARINGS_PR_REPOS:-10}
 FM_BEARINGS_PR_LIMIT=${FM_BEARINGS_PR_LIMIT:-20}
 FM_BEARINGS_PR_TIMEOUT=${FM_BEARINGS_PR_TIMEOUT:-20}
-GITHUB_ACCOUNT=${FM_GITHUB_ACCOUNT_ID:-94498628}
 GITHUB_ROUTE=${FM_GITHUB_ROUTE:-default}
 case "$FM_BEARINGS_PR_TIMEOUT" in ''|*[!0-9]*|0) FM_BEARINGS_PR_TIMEOUT=20 ;; esac
 validate_bound() {  # <name> <value>
@@ -204,13 +203,13 @@ gh_bounded() {  # <args...>
 
 github_quota_deferred_status() {
   local out state account reset_at reset_epoch
-  out=$("$SCRIPT_DIR/fm-shared-github-quota.sh" check --provider github --account "$GITHUB_ACCOUNT" --route "$GITHUB_ROUTE" 2>/dev/null || true)
+  out=$("$SCRIPT_DIR/fm-shared-github-quota.sh" check --provider github --route "$GITHUB_ROUTE" 2>/dev/null || true)
   state=$(printf '%s\n' "$out" | sed -n 's/^state=//p' | tail -1)
   [ "$state" = defer ] || return 1
   account=$(printf '%s\n' "$out" | sed -n 's/^account=//p' | tail -1)
   reset_at=$(printf '%s\n' "$out" | sed -n 's/^reset_at=//p' | tail -1)
   reset_epoch=$(printf '%s\n' "$out" | sed -n 's/^reset_epoch=//p' | tail -1)
-  PR_STATUS="deferred (github account ${account:-$GITHUB_ACCOUNT} rate-limited until ${reset_at:-reset_epoch:$reset_epoch})"
+  PR_STATUS="deferred (github account ${account:-unknown} rate-limited until ${reset_at:-reset_epoch:$reset_epoch})"
   return 0
 }
 

--- a/bin/fm-bearings-snapshot.sh
+++ b/bin/fm-bearings-snapshot.sh
@@ -203,7 +203,8 @@ gh_bounded() {  # <args...>
 
 github_quota_deferred_status() {
   local out state account reset_at reset_epoch
-  out=$("$SCRIPT_DIR/fm-shared-github-quota.sh" check --provider github --route "$GITHUB_ROUTE" 2>/dev/null || true)
+  out=$(FM_SHARED_GITHUB_QUOTA_DERIVE_ACCOUNT=0 \
+    "$SCRIPT_DIR/fm-shared-github-quota.sh" check --provider github --route "$GITHUB_ROUTE" 2>/dev/null || true)
   state=$(printf '%s\n' "$out" | sed -n 's/^state=//p' | tail -1)
   [ "$state" = defer ] || return 1
   account=$(printf '%s\n' "$out" | sed -n 's/^account=//p' | tail -1)

--- a/bin/fm-capacity-classify.sh
+++ b/bin/fm-capacity-classify.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Classify observed harness/proxy failure text into quota/auth/other.
+# Usage:
+#   fm-capacity-classify.sh [--file <path>]
+#
+# Output is key=value lines:
+#   class=quota|auth|other
+#   reason=<stable signature name>
+#   reset_at=<raw reset text>          # when observable
+#   reset_epoch=<epoch seconds>        # when parseable
+#   cooldown_ttl_secs=<seconds>        # when reset_epoch is in the future
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=bin/fm-capacity-lib.sh
+. "$SCRIPT_DIR/fm-capacity-lib.sh"
+
+FILE=
+
+usage() {
+  sed -n '2,12p' "$0" >&2
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --file)
+      [ "$#" -gt 1 ] || { echo "error: --file requires a path" >&2; exit 2; }
+      FILE=$2
+      shift 2
+      ;;
+    --file=*)
+      FILE=${1#--file=}
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if [ -n "$FILE" ]; then
+  TEXT=$(cat "$FILE")
+else
+  TEXT=$(cat)
+fi
+
+fm_capacity_classify_text "$TEXT"

--- a/bin/fm-capacity-cooldown.sh
+++ b/bin/fm-capacity-cooldown.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Manage passive capacity cooldown records under state/capacity-cooldowns/.
+# Usage:
+#   fm-capacity-cooldown.sh mark --harness <h> --profile <p> [--account <a>] (--reset-epoch <n>|--ttl-secs <n>) [--class quota] [--reason <r>] [--source-task <id>]
+#   fm-capacity-cooldown.sh mark-from-text --harness <h> --profile <p> [--account <a>] [--source-task <id>] [--file <path>]
+#   fm-capacity-cooldown.sh active --harness <h> --profile <p> [--account <a>]
+#
+# The helper never fabricates TTLs.
+# mark-from-text writes only when the classified text carries an observed reset
+# epoch; otherwise it exits non-zero after printing the classification.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+# shellcheck source=bin/fm-capacity-lib.sh
+. "$SCRIPT_DIR/fm-capacity-lib.sh"
+
+usage() {
+  sed -n '2,10p' "$0" >&2
+}
+
+need_value() {
+  [ "$#" -gt 1 ] || { echo "error: $1 requires a value" >&2; exit 2; }
+}
+
+cmd=${1:-}
+[ -n "$cmd" ] || { usage; exit 2; }
+shift || true
+
+HARNESS=
+PROFILE=
+ACCOUNT=
+RESET_EPOCH=
+TTL_SECS=
+CLASS=quota
+REASON=manual
+SOURCE_TASK=
+FILE=
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --harness) need_value "$@"; HARNESS=$2; shift 2 ;;
+    --harness=*) HARNESS=${1#--harness=}; shift ;;
+    --profile) need_value "$@"; PROFILE=$2; shift 2 ;;
+    --profile=*) PROFILE=${1#--profile=}; shift ;;
+    --account) need_value "$@"; ACCOUNT=$2; shift 2 ;;
+    --account=*) ACCOUNT=${1#--account=}; shift ;;
+    --reset-epoch) need_value "$@"; RESET_EPOCH=$2; shift 2 ;;
+    --reset-epoch=*) RESET_EPOCH=${1#--reset-epoch=}; shift ;;
+    --ttl-secs) need_value "$@"; TTL_SECS=$2; shift 2 ;;
+    --ttl-secs=*) TTL_SECS=${1#--ttl-secs=}; shift ;;
+    --class) need_value "$@"; CLASS=$2; shift 2 ;;
+    --class=*) CLASS=${1#--class=}; shift ;;
+    --reason) need_value "$@"; REASON=$2; shift 2 ;;
+    --reason=*) REASON=${1#--reason=}; shift ;;
+    --source-task) need_value "$@"; SOURCE_TASK=$2; shift 2 ;;
+    --source-task=*) SOURCE_TASK=${1#--source-task=}; shift ;;
+    --file) need_value "$@"; FILE=$2; shift 2 ;;
+    --file=*) FILE=${1#--file=}; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "error: unknown argument $1" >&2; usage; exit 2 ;;
+  esac
+done
+
+case "$cmd" in
+  mark|mark-from-text|active) ;;
+  *) echo "error: unknown command '$cmd'" >&2; usage; exit 2 ;;
+esac
+
+[ -n "$HARNESS" ] || { echo "error: --harness is required" >&2; exit 2; }
+[ -n "$PROFILE" ] || { echo "error: --profile is required" >&2; exit 2; }
+
+case "$cmd" in
+  active)
+    fm_capacity_cooldown_active "$STATE" "$HARNESS" "$ACCOUNT" "$PROFILE"
+    ;;
+  mark)
+    if [ -n "$TTL_SECS" ]; then
+      case "$TTL_SECS" in ''|*[!0-9]*) echo "error: --ttl-secs must be numeric" >&2; exit 2 ;; esac
+      RESET_EPOCH=$(( $(fm_capacity_now_epoch) + TTL_SECS ))
+    fi
+    [ -n "$RESET_EPOCH" ] || { echo "error: mark requires --reset-epoch or --ttl-secs" >&2; exit 2; }
+    fm_capacity_mark_cooldown "$STATE" "$HARNESS" "$ACCOUNT" "$PROFILE" "$RESET_EPOCH" "$CLASS" "$REASON" "$SOURCE_TASK"
+    ;;
+  mark-from-text)
+    if [ -n "$FILE" ]; then
+      TEXT=$(cat "$FILE")
+    else
+      TEXT=$(cat)
+    fi
+    CLASSIFIED=$(fm_capacity_classify_text "$TEXT")
+    printf '%s\n' "$CLASSIFIED"
+    RESET_EPOCH=$(printf '%s\n' "$CLASSIFIED" | sed -n 's/^reset_epoch=//p' | tail -1)
+    CLASS=$(printf '%s\n' "$CLASSIFIED" | sed -n 's/^class=//p' | tail -1)
+    REASON=$(printf '%s\n' "$CLASSIFIED" | sed -n 's/^reason=//p' | tail -1)
+    [ -n "$RESET_EPOCH" ] || { echo "error: classified wall has no observed reset epoch; not writing cooldown" >&2; exit 1; }
+    fm_capacity_mark_cooldown "$STATE" "$HARNESS" "$ACCOUNT" "$PROFILE" "$RESET_EPOCH" "$CLASS" "$REASON" "$SOURCE_TASK"
+    ;;
+esac

--- a/bin/fm-capacity-lib.sh
+++ b/bin/fm-capacity-lib.sh
@@ -1,0 +1,257 @@
+#!/usr/bin/env bash
+# Evidence-backed capacity classification and cooldown-cache helpers.
+#
+# This substrate is deliberately passive.
+# Nothing here changes dispatch or spawn behavior by itself; callers must opt in
+# by invoking the helpers or future feature-gated code.
+
+fm_capacity_now_epoch() {
+  if [ -n "${FM_CAPACITY_NOW_EPOCH:-}" ]; then
+    printf '%s\n' "$FM_CAPACITY_NOW_EPOCH"
+  else
+    date +%s
+  fi
+}
+
+fm_capacity_iso_now() {
+  node -e 'console.log(new Date().toISOString())'
+}
+
+fm_capacity_reset_fields() {  # <text>
+  FM_CAPACITY_TEXT=$1 FM_CAPACITY_NOW=$(fm_capacity_now_epoch) node <<'NODE'
+const text = process.env.FM_CAPACITY_TEXT || "";
+const nowEpoch = Number(process.env.FM_CAPACITY_NOW || Math.floor(Date.now() / 1000));
+const now = new Date(nowEpoch * 1000);
+const candidates = [
+  /\bretry-after\s*[:=]\s*([0-9]+)\b/i,
+  /\bretry after\s+([0-9]+)\s*(?:seconds?|secs?)\b/i,
+  /\b(20\d\d-\d\d-\d\dT\d\d:\d\d(?::\d\d)?(?:\.\d+)?(?:Z|[+-]\d\d:?\d\d)?)\b/i,
+  /\b(?:try again at|resets? at|resets?)\s+([0-9]{1,2}:[0-9]{2}\s*(?:am|pm)?\s*(?:pt|pst|pdt)?)\b/i,
+];
+
+function parseTime(raw) {
+  if (/^[0-9]+$/.test(raw)) return nowEpoch + Number(raw);
+  const iso = Date.parse(raw);
+  if (Number.isFinite(iso)) return Math.floor(iso / 1000);
+  const m = raw.match(/([0-9]{1,2}):([0-9]{2})\s*(am|pm)?/i);
+  if (!m) return 0;
+  let hour = Number(m[1]);
+  const minute = Number(m[2]);
+  const ampm = (m[3] || "").toLowerCase();
+  if (ampm === "pm" && hour < 12) hour += 12;
+  if (ampm === "am" && hour === 12) hour = 0;
+  if (hour > 23 || minute > 59) return 0;
+  const d = new Date(now.getTime());
+  d.setHours(hour, minute, 0, 0);
+  if (Math.floor(d.getTime() / 1000) <= nowEpoch) {
+    d.setDate(d.getDate() + 1);
+  }
+  return Math.floor(d.getTime() / 1000);
+}
+
+for (const re of candidates) {
+  const m = text.match(re);
+  if (!m) continue;
+  const raw = m[1].trim();
+  const epoch = parseTime(raw);
+  if (epoch > 0) {
+    console.log(`reset_at=${/^[0-9]+$/.test(raw) ? `retry-after:${raw}s` : raw}`);
+    console.log(`reset_epoch=${epoch}`);
+    process.exit(0);
+  }
+}
+NODE
+}
+
+fm_capacity_classify_text() {  # <text>
+  local text=$1 lower class reason reset_fields reset_epoch now ttl provider model
+  lower=$(printf '%s' "$text" | tr '[:upper:]' '[:lower:]')
+  class=other
+  reason=unclassified
+
+  case "$lower" in
+    *auth_unavailable*no\ auth\ available*)
+      class=auth
+      reason=proxy_auth_unavailable
+      ;;
+    *unknown\ provider\ for\ model*)
+      class=other
+      reason=proxy_unknown_model
+      ;;
+    *session\ limit*reset*)
+      class=quota
+      reason=claude_session_limit
+      ;;
+    *usage\ limit*try\ again*|*usage\ limit*reset*|*usage\ cap*reset*)
+      class=quota
+      reason=codex_usage_limit
+      ;;
+    *rate\ limit*not\ your\ usage\ limit*)
+      class=other
+      reason=transient_rate_limit
+      ;;
+    *rate\ limit*|*429\ too\ many\ requests*|*too\ many\ requests*)
+      class=quota
+      reason=rate_limit
+      ;;
+    *not\ logged\ in*|*please\ run\ /login*|*login\ required*)
+      class=auth
+      reason=login_required
+      ;;
+    *unauthorized*|*authentication*|*forbidden*)
+      class=auth
+      reason=auth_error
+      ;;
+  esac
+
+  printf 'class=%s\nreason=%s\n' "$class" "$reason"
+  case "$reason" in
+    proxy_auth_unavailable)
+      provider=$(printf '%s\n' "$text" | sed -n 's/.*providers=\([^,)]*\).*/\1/p' | head -1)
+      model=$(printf '%s\n' "$text" | sed -n 's/.*model=\([^)]*\).*/\1/p' | head -1)
+      [ -z "$provider" ] || printf 'provider=%s\n' "$provider"
+      [ -z "$model" ] || printf 'model=%s\n' "$model"
+      ;;
+    login_required)
+      provider=$(printf '%s\n' "$text" | sed -n 's/.*provider \([A-Za-z0-9_.@:-]*\).*/\1/p' | head -1)
+      [ -z "$provider" ] || printf 'provider=%s\n' "$provider"
+      ;;
+  esac
+  reset_fields=$(fm_capacity_reset_fields "$text")
+  if [ -n "$reset_fields" ]; then
+    printf '%s\n' "$reset_fields"
+    reset_epoch=$(printf '%s\n' "$reset_fields" | sed -n 's/^reset_epoch=//p' | tail -1)
+    now=$(fm_capacity_now_epoch)
+    if [ -n "$reset_epoch" ] && [ "$reset_epoch" -gt "$now" ] 2>/dev/null; then
+      ttl=$((reset_epoch - now))
+      printf 'cooldown_ttl_secs=%s\n' "$ttl"
+    fi
+  fi
+}
+
+fm_capacity_safe_fragment() {
+  printf '%s' "$1" | tr -c 'A-Za-z0-9_.@:-' '_'
+}
+
+fm_capacity_key_hash() {  # <harness> <account> <profile>
+  printf '%s\t%s\t%s' "$1" "$2" "$3" | cksum | awk '{print $1}'
+}
+
+fm_capacity_cooldown_dir() {  # <state-dir>
+  printf '%s/capacity-cooldowns\n' "$1"
+}
+
+fm_capacity_cooldown_file() {  # <state-dir> <harness> <account> <profile>
+  local state=$1 harness=$2 account=$3 profile=$4 hash safe_harness
+  hash=$(fm_capacity_key_hash "$harness" "$account" "$profile")
+  safe_harness=$(fm_capacity_safe_fragment "$harness")
+  printf '%s/%s-%s.env\n' "$(fm_capacity_cooldown_dir "$state")" "$safe_harness" "$hash"
+}
+
+fm_capacity_write_atomic() {  # <path> <content>
+  local path=$1 content=$2 dir tmp old_umask
+  dir=$(dirname "$path")
+  mkdir -p "$dir"
+  old_umask=$(umask)
+  umask 077
+  tmp=$(mktemp "$dir/.tmp.XXXXXXXX") || { umask "$old_umask"; return 1; }
+  umask "$old_umask"
+  printf '%s\n' "$content" > "$tmp"
+  mv "$tmp" "$path"
+}
+
+fm_capacity_mark_cooldown() {
+  local state=$1 harness=$2 account=$3 profile=$4 reset_epoch=$5 class=$6 reason=$7 source_task=${8:-}
+  local now file created content key
+  now=$(fm_capacity_now_epoch)
+  case "$reset_epoch" in
+    ''|*[!0-9]*) echo "error: reset epoch must be numeric" >&2; return 2 ;;
+  esac
+  if [ "$reset_epoch" -le "$now" ]; then
+    echo "error: reset epoch is not in the future" >&2
+    return 2
+  fi
+  file=$(fm_capacity_cooldown_file "$state" "$harness" "$account" "$profile")
+  created=$(fm_capacity_iso_now)
+  key=$(printf '%s/%s/%s' "$harness" "${account:-default}" "${profile:-default}")
+  content=$(cat <<EOF
+schema=fm-capacity-cooldown.v1
+key=$key
+harness=$harness
+account=$account
+profile=$profile
+class=$class
+reason=$reason
+created_at=$created
+created_epoch=$now
+reset_epoch=$reset_epoch
+source_task=$source_task
+EOF
+)
+  fm_capacity_write_atomic "$file" "$content"
+  printf '%s\n' "$file"
+}
+
+fm_capacity_mark_exhaustion() {
+  local state=$1 harness=$2 account=$3 profile=$4 class=$5 reason=$6 source_task=${7:-} action=${8:-interactive_auth_required}
+  local now file created content key
+  now=$(fm_capacity_now_epoch)
+  file=$(fm_capacity_cooldown_file "$state" "$harness" "$account" "$profile")
+  created=$(fm_capacity_iso_now)
+  key=$(printf '%s/%s/%s' "$harness" "${account:-default}" "${profile:-default}")
+  content=$(cat <<EOF
+schema=fm-capacity-cooldown.v1
+key=$key
+harness=$harness
+account=$account
+profile=$profile
+class=$class
+reason=$reason
+created_at=$created
+created_epoch=$now
+reset_epoch=manual
+requires_action=$action
+source_task=$source_task
+EOF
+)
+  fm_capacity_write_atomic "$file" "$content"
+  printf '%s\n' "$file"
+}
+
+fm_capacity_cooldown_active() {  # <state-dir> <harness> <account> <profile>
+  local state=$1 harness=$2 account=$3 profile=$4 file reset_epoch now remaining
+  file=$(fm_capacity_cooldown_file "$state" "$harness" "$account" "$profile")
+  [ -f "$file" ] || return 1
+  reset_epoch=$(sed -n 's/^reset_epoch=//p' "$file" | tail -1)
+  if [ "$reset_epoch" = manual ]; then
+    cat "$file"
+    printf 'remaining_secs=manual\n'
+    return 0
+  fi
+  case "$reset_epoch" in
+    ''|*[!0-9]*)
+      rm -f "$file"
+      return 1
+      ;;
+  esac
+  now=$(fm_capacity_now_epoch)
+  if [ "$reset_epoch" -le "$now" ]; then
+    rm -f "$file"
+    return 1
+  fi
+  remaining=$((reset_epoch - now))
+  cat "$file"
+  printf 'remaining_secs=%s\n' "$remaining"
+}
+
+fm_capacity_opposite_harness_ok() {  # <meta-file> <candidate-harness>
+  local meta=$1 candidate=$2 forbidden
+  [ -f "$meta" ] || return 0
+  forbidden=$(grep '^opposite_harness_must_differ_from=' "$meta" 2>/dev/null | tail -1 | cut -d= -f2- || true)
+  [ -n "$forbidden" ] || return 0
+  if [ "$candidate" = "$forbidden" ]; then
+    echo "error: candidate harness '$candidate' violates opposite_harness_must_differ_from=$forbidden in $meta" >&2
+    return 1
+  fi
+  return 0
+}

--- a/bin/fm-capacity-lib.sh
+++ b/bin/fm-capacity-lib.sh
@@ -218,10 +218,28 @@ EOF
   printf '%s\n' "$file"
 }
 
+fm_capacity_cooldown_record_matches() {  # <file> <harness> <account> <profile>
+  local file=$1 harness=$2 account=$3 profile=$4 rec
+  rec=$(sed -n 's/^harness=//p' "$file" | tail -1)
+  [ "$rec" = "$harness" ] || return 1
+  rec=$(sed -n 's/^account=//p' "$file" | tail -1)
+  [ "$rec" = "$account" ] || return 1
+  rec=$(sed -n 's/^profile=//p' "$file" | tail -1)
+  [ "$rec" = "$profile" ] || return 1
+  return 0
+}
+
 fm_capacity_cooldown_active() {  # <state-dir> <harness> <account> <profile>
   local state=$1 harness=$2 account=$3 profile=$4 file reset_epoch now remaining
   file=$(fm_capacity_cooldown_file "$state" "$harness" "$account" "$profile")
   [ -f "$file" ] || return 1
+  # The filename is only a CRC32 of the key, so the record's own identity
+  # fields decide whether it really describes this route. A collided or
+  # hand-copied record is ignored rather than applied to a different route,
+  # and it is left in place because it may still be another route's wall.
+  if ! fm_capacity_cooldown_record_matches "$file" "$harness" "$account" "$profile"; then
+    return 1
+  fi
   reset_epoch=$(sed -n 's/^reset_epoch=//p' "$file" | tail -1)
   if [ "$reset_epoch" = manual ]; then
     cat "$file"

--- a/bin/fm-capacity-lib.sh
+++ b/bin/fm-capacity-lib.sh
@@ -244,6 +244,25 @@ fm_capacity_cooldown_active() {  # <state-dir> <harness> <account> <profile>
   printf 'remaining_secs=%s\n' "$remaining"
 }
 
+fm_capacity_cooldown_active_for_route() {  # <state-dir> <harness> <account> <profile>
+  local state=$1 harness=$2 account=$3 profile=$4 dir file rec_harness rec_account rec_profile
+  if fm_capacity_cooldown_active "$state" "$harness" "$account" "$profile"; then
+    return 0
+  fi
+  dir=$(fm_capacity_cooldown_dir "$state")
+  [ -d "$dir" ] || return 1
+  for file in "$dir"/*.env; do
+    [ -f "$file" ] || continue
+    rec_harness=$(sed -n 's/^harness=//p' "$file" | tail -1)
+    [ "$rec_harness" = "$harness" ] || continue
+    rec_account=$(sed -n 's/^account=//p' "$file" | tail -1)
+    rec_profile=$(sed -n 's/^profile=//p' "$file" | tail -1)
+    [ -z "$rec_account" ] || [ -z "$rec_profile" ] || [ "$rec_profile" = default ] || continue
+    fm_capacity_cooldown_active "$state" "$rec_harness" "$rec_account" "$rec_profile" && return 0
+  done
+  return 1
+}
+
 fm_capacity_opposite_harness_ok() {  # <meta-file> <candidate-harness>
   local meta=$1 candidate=$2 forbidden
   [ -f "$meta" ] || return 0

--- a/bin/fm-capacity-route.sh
+++ b/bin/fm-capacity-route.sh
@@ -148,6 +148,9 @@ handle_wall() {
   local blocked_reset_epoch blocked_requires_action
   [ -n "$TASK_ID" ] || { echo "error: handle-wall requires --task" >&2; exit 2; }
   [ -n "$HARNESS" ] || { echo "error: handle-wall requires --harness" >&2; exit 2; }
+  # Refuse before any cooldown record is written; select_route runs inside a
+  # command substitution, where its own backstop could only abort that subshell.
+  dispatch_backstop
   if [ -n "$FILE" ]; then
     text=$(cat "$FILE")
   else

--- a/bin/fm-capacity-route.sh
+++ b/bin/fm-capacity-route.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+# Select conservative capacity routes and turn classified walls into rehome work.
+# Usage:
+#   fm-capacity-route.sh select [--routes-file <path>] [--dispatch-approved]
+#   fm-capacity-route.sh handle-wall --task <id> --harness <h> [--account <a>] [--profile <p>] [--routes-file <path>] [--file <path>] [--dispatch-approved]
+#
+# Routes are read from key-value config lines:
+#   route=<harness>|<account-or-provider>|<profile>|<model>|<effort>
+#
+# The helper never edits dispatch config, never creates a new task id, and never
+# chooses an unverified harness.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
+
+# shellcheck source=bin/fm-capacity-lib.sh
+. "$SCRIPT_DIR/fm-capacity-lib.sh"
+# shellcheck source=bin/fm-harness-launch-lib.sh
+. "$SCRIPT_DIR/fm-harness-launch-lib.sh"
+
+usage() {
+  sed -n '2,10p' "$0" >&2
+}
+
+need_value() {
+  [ "$#" -gt 1 ] || { echo "error: $1 requires a value" >&2; exit 2; }
+}
+
+cmd=${1:-}
+[ -n "$cmd" ] || { usage; exit 2; }
+shift || true
+
+ROUTES_FILE="$CONFIG/capacity-failover"
+DISPATCH_APPROVED=0
+TASK_ID=
+HARNESS=
+ACCOUNT=
+PROFILE=
+FILE=
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --routes-file) need_value "$@"; ROUTES_FILE=$2; shift 2 ;;
+    --routes-file=*) ROUTES_FILE=${1#--routes-file=}; shift ;;
+    --dispatch-approved) DISPATCH_APPROVED=1; shift ;;
+    --task) need_value "$@"; TASK_ID=$2; shift 2 ;;
+    --task=*) TASK_ID=${1#--task=}; shift ;;
+    --harness) need_value "$@"; HARNESS=$2; shift 2 ;;
+    --harness=*) HARNESS=${1#--harness=}; shift ;;
+    --account) need_value "$@"; ACCOUNT=$2; shift 2 ;;
+    --account=*) ACCOUNT=${1#--account=}; shift ;;
+    --profile) need_value "$@"; PROFILE=$2; shift 2 ;;
+    --profile=*) PROFILE=${1#--profile=}; shift ;;
+    --file) need_value "$@"; FILE=$2; shift 2 ;;
+    --file=*) FILE=${1#--file=}; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "error: unknown argument $1" >&2; usage; exit 2 ;;
+  esac
+done
+
+dispatch_backstop() {
+  if [ -f "$CONFIG/crew-dispatch.json" ] && [ "$DISPATCH_APPROVED" -ne 1 ]; then
+    echo "error: config/crew-dispatch.json is active; consult it first, then rerun with --dispatch-approved" >&2
+    exit 1
+  fi
+}
+
+routes() {
+  [ -f "$ROUTES_FILE" ] || return 0
+  awk -F= '
+    /^[[:space:]]*#/ || /^[[:space:]]*$/ { next }
+    {
+      k=$1
+      sub(/^[[:space:]]+/, "", k)
+      sub(/[[:space:]]+$/, "", k)
+      if (k == "route") {
+        v=$0
+        sub(/^[^=]*=/, "", v)
+        sub(/^[[:space:]]+/, "", v)
+        sub(/[[:space:]]+$/, "", v)
+        print v
+      }
+    }
+  ' "$ROUTES_FILE"
+}
+
+route_field() {  # <line> <index>
+  printf '%s\n' "$1" | awk -F'|' -v n="$2" '{ print $n }'
+}
+
+select_route() {
+  local line idx harness account profile model effort selected=0 exhausted=0 active_out
+  dispatch_backstop
+  idx=0
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    idx=$((idx + 1))
+    harness=$(route_field "$line" 1)
+    account=$(route_field "$line" 2)
+    profile=$(route_field "$line" 3)
+    model=$(route_field "$line" 4)
+    effort=$(route_field "$line" 5)
+    [ -n "$profile" ] || profile=${model:-default}
+    if ! fm_launch_template "$harness" ship >/dev/null 2>&1; then
+      printf 'route_%s_status=unverified_harness\n' "$idx"
+      printf 'route_%s_harness=%s\n' "$idx" "$harness"
+      continue
+    fi
+    if active_out=$(fm_capacity_cooldown_active "$STATE" "$harness" "$account" "$profile" 2>/dev/null); then
+      exhausted=$((exhausted + 1))
+      printf 'route_%s_status=blocked\n' "$idx"
+      printf 'route_%s_harness=%s\n' "$idx" "$harness"
+      printf 'route_%s_account=%s\n' "$idx" "$account"
+      printf 'route_%s_profile=%s\n' "$idx" "$profile"
+      printf 'route_%s_model=%s\n' "$idx" "${model:-$profile}"
+      printf 'route_%s_reason=%s\n' "$idx" "$(printf '%s\n' "$active_out" | sed -n 's/^reason=//p' | tail -1)"
+      printf 'route_%s_reset_epoch=%s\n' "$idx" "$(printf '%s\n' "$active_out" | sed -n 's/^reset_epoch=//p' | tail -1)"
+      printf 'route_%s_requires_action=%s\n' "$idx" "$(printf '%s\n' "$active_out" | sed -n 's/^requires_action=//p' | tail -1)"
+      continue
+    fi
+    selected=1
+    printf 'selected_harness=%s\n' "$harness"
+    printf 'selected_account=%s\n' "$account"
+    printf 'selected_profile=%s\n' "$profile"
+    printf 'selected_model=%s\n' "${model:-$profile}"
+    printf 'selected_effort=%s\n' "${effort:-default}"
+    return 0
+  done <<EOF
+$(routes)
+EOF
+  if [ "$idx" -eq 0 ]; then
+    printf 'escalation=capacity_routes_missing\n'
+    printf 'needed_action=configure verified noninteractive route in %s\n' "$ROUTES_FILE"
+  elif [ "$selected" -eq 0 ]; then
+    printf 'escalation=every_verified_route_exhausted\n'
+    printf 'exhausted_routes=%s\n' "$exhausted"
+    printf 'needed_action=wait for reset or complete the listed interactive auth/account action\n'
+  fi
+  return 1
+}
+
+handle_wall() {
+  local text classified class reason reset_epoch provider model account profile record selection status selected_harness selected_model selected_effort
+  local blocked_reset_epoch blocked_requires_action
+  [ -n "$TASK_ID" ] || { echo "error: handle-wall requires --task" >&2; exit 2; }
+  [ -n "$HARNESS" ] || { echo "error: handle-wall requires --harness" >&2; exit 2; }
+  if [ -n "$FILE" ]; then
+    text=$(cat "$FILE")
+  else
+    text=$(cat)
+  fi
+  classified=$(fm_capacity_classify_text "$text")
+  printf '%s\n' "$classified"
+  class=$(printf '%s\n' "$classified" | sed -n 's/^class=//p' | tail -1)
+  reason=$(printf '%s\n' "$classified" | sed -n 's/^reason=//p' | tail -1)
+  reset_epoch=$(printf '%s\n' "$classified" | sed -n 's/^reset_epoch=//p' | tail -1)
+  provider=$(printf '%s\n' "$classified" | sed -n 's/^provider=//p' | tail -1)
+  model=$(printf '%s\n' "$classified" | sed -n 's/^model=//p' | tail -1)
+  account=${ACCOUNT:-$provider}
+  profile=${PROFILE:-${model:-default}}
+  case "$class" in
+    quota)
+      [ -n "$reset_epoch" ] || { echo "error: quota wall has no observed reset; refusing to invent cooldown" >&2; exit 1; }
+      record=$(fm_capacity_mark_cooldown "$STATE" "$HARNESS" "$account" "$profile" "$reset_epoch" "$class" "$reason" "$TASK_ID")
+      blocked_reset_epoch=$reset_epoch
+      blocked_requires_action=
+      ;;
+    auth)
+      record=$(fm_capacity_mark_exhaustion "$STATE" "$HARNESS" "$account" "$profile" "$class" "$reason" "$TASK_ID" interactive_auth_required)
+      blocked_reset_epoch=manual
+      blocked_requires_action=interactive_auth_required
+      ;;
+    *)
+      echo "error: wall class '$class' is not reroutable capacity/auth exhaustion" >&2
+      exit 1
+      ;;
+  esac
+  printf 'recorded_route_block=%s\n' "$record"
+  if selection=$(select_route); then
+    printf '%s\n' "$selection"
+    selected_harness=$(printf '%s\n' "$selection" | sed -n 's/^selected_harness=//p' | tail -1)
+    selected_model=$(printf '%s\n' "$selection" | sed -n 's/^selected_model=//p' | tail -1)
+    selected_effort=$(printf '%s\n' "$selection" | sed -n 's/^selected_effort=//p' | tail -1)
+    printf 'action=rehome_same_owner\n'
+    printf 'task=%s\n' "$TASK_ID"
+    printf 'rehome_command=%s/fm-rehome-quota-wall.sh %s --harness %s --model %s --effort %s --dispatch-approved\n' \
+      "$SCRIPT_DIR" "$TASK_ID" "$selected_harness" "$selected_model" "$selected_effort"
+    return 0
+  else
+    status=$?
+    printf '%s\n' "$selection"
+    printf 'action=escalate\n'
+    printf 'task=%s\n' "$TASK_ID"
+    printf 'blocked_harness=%s\n' "$HARNESS"
+    printf 'blocked_account=%s\n' "$account"
+    printf 'blocked_profile=%s\n' "$profile"
+    printf 'blocked_model=%s\n' "${model:-$profile}"
+    printf 'blocked_reset_epoch=%s\n' "$blocked_reset_epoch"
+    printf 'blocked_requires_action=%s\n' "$blocked_requires_action"
+    printf 'blocked_reason=%s\n' "$reason"
+    return "$status"
+  fi
+}
+
+case "$cmd" in
+  select)
+    select_route
+    ;;
+  handle-wall)
+    handle_wall
+    ;;
+  *)
+    echo "error: unknown command '$cmd'" >&2
+    usage
+    exit 2
+    ;;
+esac

--- a/bin/fm-capacity-route.sh
+++ b/bin/fm-capacity-route.sh
@@ -110,7 +110,7 @@ select_route() {
       printf 'route_%s_harness=%s\n' "$idx" "$harness"
       continue
     fi
-    if active_out=$(fm_capacity_cooldown_active "$STATE" "$harness" "$account" "$profile" 2>/dev/null); then
+    if active_out=$(fm_capacity_cooldown_active_for_route "$STATE" "$harness" "$account" "$profile" 2>/dev/null); then
       exhausted=$((exhausted + 1))
       printf 'route_%s_status=blocked\n' "$idx"
       printf 'route_%s_harness=%s\n' "$idx" "$harness"

--- a/bin/fm-harness-launch-lib.sh
+++ b/bin/fm-harness-launch-lib.sh
@@ -142,9 +142,14 @@ EOF
       fm_launch_exclude_path "$wt" '.opencode/plugins/fm-turn-end.js'
       ;;
     pi*)
+      # Written OUTSIDE the worktree: pi's project-trust gate fires on any extension
+      # loaded from inside the project (verified live), but an explicit -e path
+      # elsewhere loads without a dialog. Lives in state/, cleaned by teardown.
       cat > "$state/$id.pi-ext.ts" <<EOF
 // Firstmate turn-end signal; written by fm-spawn/fm-rehome-quota-wall.
-// Use "turn_end" so the watcher sees every completed agent turn.
+// Use "turn_end" (fires after each turn the agent finishes), not "agent_end"
+// (fires once, only when the whole run exits): the watcher needs a signal at
+// every turn boundary so an idle crewmate is surfaced, not just at shutdown.
 import { execFile } from "node:child_process";
 export default function (pi: any) {
   pi.on("turn_end", () => execFile("touch", ["$turnend"]));

--- a/bin/fm-harness-launch-lib.sh
+++ b/bin/fm-harness-launch-lib.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# Shared harness launch templates, profile flags, shell quoting, and turn-end
+# hook installation.
+#
+# fm-spawn.sh and fm-rehome-quota-wall.sh both need to launch a verified
+# harness in a firstmate-owned task endpoint.
+# This file is the single owner of the launch-command fragments and the
+# worktree/state hook files required for turn-end signaling.
+
+fm_launch_shell_quote() {
+  printf "'"
+  printf '%s' "$1" | sed "s/'/'\\\\''/g"
+  printf "'"
+}
+
+fm_launch_json_escape() {
+  printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+
+fm_launch_template() {
+  local harness=$1 kind=${2:-ship}
+  # shellcheck disable=SC2016
+  case "$harness" in
+    claude) printf '%s' 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions __MODELFLAG____EFFORTFLAG__"$(cat __BRIEF__)"' ;;
+    codex)
+      if [ "$kind" = secondmate ]; then
+        printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox "$(cat __BRIEF__)"'
+      else
+        printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch __TURNEND__\"]" "$(cat __BRIEF__)"'
+      fi
+      ;;
+    opencode) printf '%s' 'OPENCODE_CONFIG_CONTENT='\''{"permission":{"*":"allow"}}'\'' opencode __MODELFLAG__--prompt "$(cat __BRIEF__)"' ;;
+    pi)
+      if [ "$kind" = secondmate ]; then
+        printf '%s' 'pi __MODELFLAG____EFFORTFLAG__-e __PITURNEND__ -e __PIWATCH__ "$(cat __BRIEF__)"'
+      else
+        printf '%s' 'pi __MODELFLAG____EFFORTFLAG__-e __PIEXT__ "$(cat __BRIEF__)"'
+      fi
+      ;;
+    grok) printf '%s' 'grok --always-approve __MODELFLAG____EFFORTFLAG__"$(cat __BRIEF__)"' ;;
+    *) return 1 ;;
+  esac
+}
+
+fm_launch_model_flag_for_harness() {
+  local harness=$1 model=$2
+  [ -n "$model" ] && [ "$model" != default ] || return 0
+  case "$harness" in
+    claude|codex|opencode|pi|grok)
+      printf -- '--model %s ' "$(fm_launch_shell_quote "$model")"
+      ;;
+  esac
+}
+
+fm_launch_effort_flag_for_harness() {
+  local harness=$1 effort=$2
+  [ -n "$effort" ] && [ "$effort" != default ] || return 0
+  case "$harness" in
+    claude)
+      case "$effort" in
+        low|medium|high|xhigh|max) printf -- '--effort %s ' "$(fm_launch_shell_quote "$effort")" ;;
+      esac
+      ;;
+    codex)
+      # The installed codex config schema uses model_reasoning_effort, and the
+      # bundled model catalog advertises low|medium|high|xhigh. Omit max rather
+      # than passing an unsupported value.
+      case "$effort" in
+        low|medium|high|xhigh) printf -- '-c %s ' "$(fm_launch_shell_quote "model_reasoning_effort=\"$effort\"")" ;;
+      esac
+      ;;
+    grok)
+      # grok exposes both --effort and --reasoning-effort; firstmate's profile
+      # axis is the reasoning knob. As of grok 0.2.99, --reasoning-effort accepts
+      # only low|medium|high and rejects both xhigh and max, so omit those rather
+      # than passing a known-bad value.
+      case "$effort" in
+        low|medium|high) printf -- '--reasoning-effort %s ' "$(fm_launch_shell_quote "$effort")" ;;
+      esac
+      ;;
+    pi)
+      # Pi 0.80.6 accepts the full shared effort vocabulary, including max, through
+      # its --thinking flag.
+      case "$effort" in
+        low|medium|high|xhigh|max) printf -- '--thinking %s ' "$(fm_launch_shell_quote "$effort")" ;;
+      esac
+      ;;
+    # opencode's interactive `opencode --prompt` launch has a verified --model
+    # flag but no verified effort flag. Its `opencode run --variant` flag belongs
+    # to a different, non-interactive launch mode, so fm-spawn does not pass it.
+  esac
+}
+
+fm_launch_exclude_path() {
+  local wt=$1 rel=$2 excl
+  excl=$(git -C "$wt" rev-parse --git-path info/exclude 2>/dev/null || true)
+  [ -n "$excl" ] || return 0
+  mkdir -p "$(dirname "$excl")"
+  grep -qxF "$rel" "$excl" 2>/dev/null || echo "$rel" >> "$excl"
+}
+
+fm_launch_install_turn_end_hook() {
+  local harness=$1 kind=$2 wt=$3 state=$4 id=$5 turnend=$6 project_abs=$7
+  local grok_hooks_dir grok_auth_dir old_umask auth_file sq_grok_auth_dir hook_command
+  [ "$kind" != secondmate ] || return 0
+  case "$harness" in
+    claude*)
+      mkdir -p "$wt/.claude"
+      cat > "$wt/.claude/settings.local.json" <<EOF
+{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"touch '$turnend'"}]}]}}
+EOF
+      fm_launch_exclude_path "$wt" '.claude/settings.local.json'
+      ;;
+    opencode*)
+      mkdir -p "$wt/.opencode/plugins"
+      cat > "$wt/.opencode/plugins/fm-turn-end.js" <<EOF
+export const FmTurnEnd = async ({ \$ }) => ({
+  event: async ({ event }) => {
+    if (event.type === "session.idle") await \$\`touch $turnend\`
+  },
+})
+EOF
+      fm_launch_exclude_path "$wt" '.opencode/plugins/fm-turn-end.js'
+      ;;
+    pi*)
+      cat > "$state/$id.pi-ext.ts" <<EOF
+// Firstmate turn-end signal; written by fm-spawn/fm-rehome-quota-wall.
+// Use "turn_end" so the watcher sees every completed agent turn.
+import { execFile } from "node:child_process";
+export default function (pi: any) {
+  pi.on("turn_end", () => execFile("touch", ["$turnend"]));
+}
+EOF
+      ;;
+    codex*)
+      ;;
+    grok*)
+      grok_hooks_dir="${GROK_HOME:-$HOME/.grok}/hooks"
+      grok_auth_dir="$grok_hooks_dir/fm-turn-end.d"
+      mkdir -p "$grok_auth_dir"
+      old_umask=$(umask)
+      umask 077
+      auth_file=$(mktemp "$grok_auth_dir/fm.XXXXXXXXXXXX")
+      umask "$old_umask"
+      printf '%s\n' "$turnend" > "$auth_file"
+      printf '%s\n' "${auth_file##*/}" > "$state/$id.grok-turnend-token"
+      sq_grok_auth_dir=$(fm_launch_shell_quote "$grok_auth_dir")
+      cat > "$grok_hooks_dir/fm-turn-end.sh" <<EOF
+#!/usr/bin/env bash
+set -u
+auth_dir=$sq_grok_auth_dir
+workspace=\${GROK_WORKSPACE_ROOT:-}
+[ -n "\$workspace" ] || exit 0
+p="\$workspace/.fm-grok-turnend"
+[ -f "\$p" ] || exit 0
+first=
+IFS= read -r -n 256 first < "\$p" 2>/dev/null || [ -n "\$first" ] || exit 0
+case "\$first" in token=*) token=\${first#token=} ;; *) exit 0 ;; esac
+case "\$token" in fm.????????????) : ;; *) exit 0 ;; esac
+case "\$token" in *[!A-Za-z0-9._-]*) exit 0 ;; esac
+t=\$(cat "\$auth_dir/\$token" 2>/dev/null) || exit 0
+case "\$t" in /*.turn-ended) : ;; *) exit 0 ;; esac
+touch "\$t" 2>/dev/null || true
+exit 0
+EOF
+      chmod +x "$grok_hooks_dir/fm-turn-end.sh"
+      hook_command=$(fm_launch_json_escape "bash $(fm_launch_shell_quote "$grok_hooks_dir/fm-turn-end.sh")")
+      printf '{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"%s"}]}]}}\n' "$hook_command" > "$grok_hooks_dir/fm-turn-end.json"
+      printf 'token=%s\n' "${auth_file##*/}" > "$wt/.fm-grok-turnend"
+      fm_launch_exclude_path "$wt" '.fm-grok-turnend'
+      ;;
+  esac
+  : "$project_abs"
+}

--- a/bin/fm-harness-launch-lib.sh
+++ b/bin/fm-harness-launch-lib.sh
@@ -119,7 +119,7 @@ fm_launch_exclude_path() {
 }
 
 fm_launch_install_turn_end_hook() {
-  local harness=$1 kind=$2 wt=$3 state=$4 id=$5 turnend=$6 project_abs=$7
+  local harness=$1 kind=$2 wt=$3 state=$4 id=$5 turnend=$6
   local grok_hooks_dir grok_auth_dir old_umask auth_file sq_grok_auth_dir hook_command prior_token
   [ "$kind" != secondmate ] || return 0
   case "$harness" in
@@ -216,5 +216,4 @@ EOF
       fm_launch_exclude_path "$wt" '.fm-grok-turnend'
       ;;
   esac
-  : "$project_abs"
 }

--- a/bin/fm-harness-launch-lib.sh
+++ b/bin/fm-harness-launch-lib.sh
@@ -17,10 +17,21 @@ fm_launch_json_escape() {
   printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
 }
 
+# The verified launch command per adapter. The knowledge half of each adapter
+# (busy signature, exit command, dialogs, quirks) lives in the harness-adapters skill.
 fm_launch_template() {
   local harness=$1 kind=${2:-ship}
-  # shellcheck disable=SC2016
+  # shellcheck disable=SC2016  # single quotes are deliberate: $(cat ...) expands in the crewmate pane, not here
   case "$harness" in
+    # CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false disables claude's interactive
+    # predicted-next-prompt ghost text, which renders as dim/faint text inside an
+    # otherwise-empty composer and would otherwise read like real typed input when
+    # firstmate captures the pane (see the harness-adapters skill). It is a per-launch env
+    # prefix scoped to this firstmate-launched agent; it never touches the captain's
+    # global config. The CLI's --prompt-suggestions flag is print/SDK-mode only and
+    # does NOT suppress the interactive ghost text (verified empirically), so the env
+    # var is the correct control. The dim-aware composer reader in fm-tmux-lib.sh is
+    # the defense-in-depth backstop for any pane this flag cannot reach.
     claude) printf '%s' 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions __MODELFLAG____EFFORTFLAG__"$(cat __BRIEF__)"' ;;
     codex)
       if [ "$kind" = secondmate ]; then
@@ -37,6 +48,14 @@ fm_launch_template() {
         printf '%s' 'pi __MODELFLAG____EFFORTFLAG__-e __PIEXT__ "$(cat __BRIEF__)"'
       fi
       ;;
+    # grok (Grok Build TUI): a positional prompt starts the supervised interactive
+    # session. --always-approve auto-approves every tool execution (verified: the
+    # crewmate runs fully autonomously, no permission gate), which an unattended
+    # crewmate needs; it is the targeted equivalent of claude's
+    # --dangerously-skip-permissions. grok's turn-end signal does NOT ride the
+    # launch command - it is a Stop-event hook installed by
+    # fm_launch_install_turn_end_hook (global hook + per-task pointer), so the
+    # template is identical for ship/scout/secondmate.
     grok) printf '%s' 'grok --always-approve __MODELFLAG____EFFORTFLAG__"$(cat __BRIEF__)"' ;;
     *) return 1 ;;
   esac
@@ -101,7 +120,7 @@ fm_launch_exclude_path() {
 
 fm_launch_install_turn_end_hook() {
   local harness=$1 kind=$2 wt=$3 state=$4 id=$5 turnend=$6 project_abs=$7
-  local grok_hooks_dir grok_auth_dir old_umask auth_file sq_grok_auth_dir hook_command
+  local grok_hooks_dir grok_auth_dir old_umask auth_file sq_grok_auth_dir hook_command prior_token
   [ "$kind" != secondmate ] || return 0
   case "$harness" in
     claude*)
@@ -133,11 +152,33 @@ export default function (pi: any) {
 EOF
       ;;
     codex*)
+      # codex: turn-end rides the launch command via -c notify=[...] and __TURNEND__.
       ;;
     grok*)
+      # grok fires a Stop hook at every turn boundary (verified, grok 0.2.73), the
+      # clean equivalent of codex's notify= and pi's turn_end. But grok only loads
+      # PROJECT hooks (<worktree>/.grok/hooks/, <worktree>/.claude/settings.local.json)
+      # after the folder is granted hook-trust, which is not automatic and which
+      # firstmate cannot establish at launch without editing grok's own managed
+      # trust store (a high-blast-radius write). GLOBAL hooks in ~/.grok/hooks/ are
+      # always trusted and load on first launch with no gate. So the turn-end hook
+      # lives OUTSIDE the worktree as a single firstmate-owned global hook that is a
+      # guarded no-op for every non-firstmate grok session: it fires only when the
+      # current workspace holds a .fm-grok-turnend token pointer that matches the
+      # firstmate-owned hook registry. firstmate then drops that per-task pointer
+      # (gitignored, like the other harnesses' worktree hook files).
+      # Result: the hook is outside the worktree, needs no trust grant, and never
+      # touches grok's managed config - only firstmate-owned files.
       grok_hooks_dir="${GROK_HOME:-$HOME/.grok}/hooks"
       grok_auth_dir="$grok_hooks_dir/fm-turn-end.d"
       mkdir -p "$grok_auth_dir"
+      # A relaunch (rehome) re-mints the token, and teardown only removes the
+      # currently recorded one, so retire the previous auth file here.
+      prior_token=$(cat "$state/$id.grok-turnend-token" 2>/dev/null || true)
+      case "$prior_token" in
+        ''|*[!A-Za-z0-9._-]*) ;;
+        *) rm -f "$grok_auth_dir/$prior_token" ;;
+      esac
       old_umask=$(umask)
       umask 077
       auth_file=$(mktemp "$grok_auth_dir/fm.XXXXXXXXXXXX")

--- a/bin/fm-host-pressure.sh
+++ b/bin/fm-host-pressure.sh
@@ -116,11 +116,6 @@ emit_check() {
   MIN_DISK=$(fm_pressure_config_value "$CFG" min_disk_available_mb 10240)
   WARN_DISK=$(fm_pressure_config_value "$CFG" warn_disk_available_mb 20480)
   disk_floor=$(fm_pressure_config_value "$CFG" disk_floor_mb "$MIN_DISK")
-  disk_default_clear=$WARN_DISK
-  if [ -n "$disk_floor" ] && [ -n "$disk_default_clear" ] && [ "$disk_default_clear" -lt "$disk_floor" ]; then
-    disk_default_clear=$disk_floor
-  fi
-  disk_clear=$(fm_pressure_config_value "$CFG" disk_clear_mb "$disk_default_clear")
   MAX_RUNNING=$(fm_pressure_config_value "$CFG" max_running_tasks 30)
 
   fm_pressure_numeric_or_empty "$MIN_MEM" min_memory_available_mb || return 2
@@ -128,8 +123,14 @@ emit_check() {
   fm_pressure_numeric_or_empty "$MIN_DISK" min_disk_available_mb || return 2
   fm_pressure_numeric_or_empty "$WARN_DISK" warn_disk_available_mb || return 2
   fm_pressure_numeric_or_empty "$disk_floor" disk_floor_mb || return 2
-  fm_pressure_numeric_or_empty "$disk_clear" disk_clear_mb || return 2
   fm_pressure_numeric_or_empty "$MAX_RUNNING" max_running_tasks || return 2
+
+  disk_default_clear=$WARN_DISK
+  if [ -n "$disk_floor" ] && [ -n "$disk_default_clear" ] && [ "$disk_default_clear" -lt "$disk_floor" ]; then
+    disk_default_clear=$disk_floor
+  fi
+  disk_clear=$(fm_pressure_config_value "$CFG" disk_clear_mb "$disk_default_clear")
+  fm_pressure_numeric_or_empty "$disk_clear" disk_clear_mb || return 2
 
   MEM_AVAILABLE=$(fm_pressure_memory_available_mb)
   DISK_AVAILABLE=$(fm_pressure_disk_available_mb "$HOME_PATH")

--- a/bin/fm-host-pressure.sh
+++ b/bin/fm-host-pressure.sh
@@ -1,0 +1,261 @@
+#!/usr/bin/env bash
+# Report bounded host pressure for optional capacity-failover backpressure.
+# Usage:
+#   fm-host-pressure.sh check [--config <path>] [--home <path>] [--state <path>]
+#   fm-host-pressure.sh gate --kind <spawn|test> [--config <path>] [--home <path>] [--state <path>]
+#   fm-host-pressure.sh periodic-alert [--config <path>] [--home <path>] [--state <path>]
+#   fm-host-pressure.sh classify-shed --command <command-line>
+#
+# The check/gate commands print key=value evidence lines.
+# Exit code 0 means the launch may continue.
+# Exit code 1 means a critical threshold was crossed and a caller should apply
+# backpressure by refusing a new heavy launch.
+# Exit code 2 means usage or config error.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
+
+# shellcheck source=bin/fm-pressure-lib.sh
+. "$SCRIPT_DIR/fm-pressure-lib.sh"
+
+usage() {
+  sed -n '2,11p' "$0" >&2
+}
+
+need_value() {
+  [ "$#" -gt 1 ] || { echo "error: $1 requires a value" >&2; exit 2; }
+}
+
+cmd=${1:-}
+[ -n "$cmd" ] || { usage; exit 2; }
+shift || true
+
+CFG="$CONFIG/capacity-failover"
+HOME_PATH="$FM_HOME"
+STATE_PATH="$STATE"
+GATE_KIND=
+COMMAND_LINE=
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --config) need_value "$@"; CFG=$2; shift 2 ;;
+    --config=*) CFG=${1#--config=}; shift ;;
+    --home) need_value "$@"; HOME_PATH=$2; shift 2 ;;
+    --home=*) HOME_PATH=${1#--home=}; shift ;;
+    --state) need_value "$@"; STATE_PATH=$2; shift 2 ;;
+    --state=*) STATE_PATH=${1#--state=}; shift ;;
+    --kind) need_value "$@"; GATE_KIND=$2; shift 2 ;;
+    --kind=*) GATE_KIND=${1#--kind=}; shift ;;
+    --command) need_value "$@"; COMMAND_LINE=$2; shift 2 ;;
+    --command=*) COMMAND_LINE=${1#--command=}; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "error: unknown argument $1" >&2; usage; exit 2 ;;
+  esac
+done
+
+append_reason() {
+  if [ -z "$REASONS" ]; then
+    REASONS=$1
+  else
+    REASONS="$REASONS,$1"
+  fi
+}
+
+mark_warn() {
+  [ "$STATE_VALUE" = critical ] || STATE_VALUE=warn
+  append_reason "$1"
+}
+
+mark_critical() {
+  STATE_VALUE=critical
+  append_reason "$1"
+}
+
+disk_hysteresis_state() {  # <available> <floor> <clear>
+  local available=$1 floor=$2 clear=$3 marker active
+  marker="$STATE_PATH/.host-pressure-disk-floor"
+  [ "$available" != unknown ] || { printf 'unknown\n'; return 0; }
+  [ -n "$floor" ] || { rm -f "$marker"; printf 'inactive\n'; return 0; }
+  active=0
+  [ -f "$marker" ] && active=1
+  if [ "$available" -lt "$floor" ]; then
+    mkdir -p "$STATE_PATH"
+    {
+      printf 'state=critical\n'
+      printf 'entered_epoch=%s\n' "$(fm_pressure_now_epoch)"
+      printf 'disk_available_mb=%s\n' "$available"
+      printf 'disk_floor_mb=%s\n' "$floor"
+      printf 'disk_clear_mb=%s\n' "$clear"
+    } > "$marker"
+    printf 'entered\n'
+    return 0
+  fi
+  if [ "$active" -eq 1 ] && [ -n "$clear" ] && [ "$available" -lt "$clear" ]; then
+    printf 'held\n'
+    return 0
+  fi
+  rm -f "$marker"
+  printf 'inactive\n'
+}
+
+emit_check() {
+  local disk_hysteresis disk_floor disk_clear disk_default_clear
+  if ! fm_pressure_enabled "$CFG"; then
+    printf 'state=off\n'
+    printf 'reason=host_pressure_not_enabled\n'
+    return 0
+  fi
+
+  MIN_MEM=$(fm_pressure_config_value "$CFG" min_memory_available_mb 2048)
+  WARN_MEM=$(fm_pressure_config_value "$CFG" warn_memory_available_mb 4096)
+  MIN_DISK=$(fm_pressure_config_value "$CFG" min_disk_available_mb 10240)
+  WARN_DISK=$(fm_pressure_config_value "$CFG" warn_disk_available_mb 20480)
+  disk_floor=$(fm_pressure_config_value "$CFG" disk_floor_mb "$MIN_DISK")
+  disk_default_clear=$WARN_DISK
+  if [ -n "$disk_floor" ] && [ -n "$disk_default_clear" ] && [ "$disk_default_clear" -lt "$disk_floor" ]; then
+    disk_default_clear=$disk_floor
+  fi
+  disk_clear=$(fm_pressure_config_value "$CFG" disk_clear_mb "$disk_default_clear")
+  MAX_RUNNING=$(fm_pressure_config_value "$CFG" max_running_tasks 30)
+
+  fm_pressure_numeric_or_empty "$MIN_MEM" min_memory_available_mb || return 2
+  fm_pressure_numeric_or_empty "$WARN_MEM" warn_memory_available_mb || return 2
+  fm_pressure_numeric_or_empty "$MIN_DISK" min_disk_available_mb || return 2
+  fm_pressure_numeric_or_empty "$WARN_DISK" warn_disk_available_mb || return 2
+  fm_pressure_numeric_or_empty "$disk_floor" disk_floor_mb || return 2
+  fm_pressure_numeric_or_empty "$disk_clear" disk_clear_mb || return 2
+  fm_pressure_numeric_or_empty "$MAX_RUNNING" max_running_tasks || return 2
+
+  MEM_AVAILABLE=$(fm_pressure_memory_available_mb)
+  DISK_AVAILABLE=$(fm_pressure_disk_available_mb "$HOME_PATH")
+  RUNNING=$(fm_pressure_running_tasks "$STATE_PATH")
+
+  STATE_VALUE=ok
+  REASONS=
+
+  if [ "$MEM_AVAILABLE" != unknown ]; then
+    fm_pressure_numeric_or_empty "$MEM_AVAILABLE" memory_available_mb || return 2
+    if [ -n "$MIN_MEM" ] && [ "$MEM_AVAILABLE" -lt "$MIN_MEM" ]; then
+      mark_critical memory_available_below_min
+    elif [ -n "$WARN_MEM" ] && [ "$MEM_AVAILABLE" -lt "$WARN_MEM" ]; then
+      mark_warn memory_available_below_warn
+    fi
+  else
+    mark_warn memory_available_unknown
+  fi
+
+  if [ "$DISK_AVAILABLE" != unknown ]; then
+    fm_pressure_numeric_or_empty "$DISK_AVAILABLE" disk_available_mb || return 2
+    disk_hysteresis=$(disk_hysteresis_state "$DISK_AVAILABLE" "$disk_floor" "$disk_clear")
+    case "$disk_hysteresis" in
+      entered) mark_critical disk_floor_below_min ;;
+      held) mark_critical disk_floor_hysteresis_active ;;
+      inactive)
+        if [ -n "$WARN_DISK" ] && [ "$DISK_AVAILABLE" -lt "$WARN_DISK" ]; then
+          mark_warn disk_available_below_warn
+        fi
+        ;;
+    esac
+  else
+    disk_hysteresis=unknown
+    mark_warn disk_available_unknown
+  fi
+
+  fm_pressure_numeric_or_empty "$RUNNING" running_tasks || return 2
+  if [ -n "$MAX_RUNNING" ] && [ "$RUNNING" -ge "$MAX_RUNNING" ]; then
+    mark_critical running_tasks_at_or_above_max
+  fi
+
+  printf 'state=%s\n' "$STATE_VALUE"
+  printf 'reason=%s\n' "${REASONS:-none}"
+  [ -z "$GATE_KIND" ] || printf 'gate_kind=%s\n' "$GATE_KIND"
+  printf 'memory_available_mb=%s\n' "$MEM_AVAILABLE"
+  printf 'min_memory_available_mb=%s\n' "$MIN_MEM"
+  printf 'warn_memory_available_mb=%s\n' "$WARN_MEM"
+  printf 'disk_available_mb=%s\n' "$DISK_AVAILABLE"
+  printf 'disk_floor_mb=%s\n' "$disk_floor"
+  printf 'disk_clear_mb=%s\n' "$disk_clear"
+  printf 'disk_hysteresis=%s\n' "$disk_hysteresis"
+  printf 'min_disk_available_mb=%s\n' "$MIN_DISK"
+  printf 'warn_disk_available_mb=%s\n' "$WARN_DISK"
+  printf 'running_tasks=%s\n' "$RUNNING"
+  printf 'max_running_tasks=%s\n' "$MAX_RUNNING"
+
+  if [ "$STATE_VALUE" = critical ]; then
+    fm_pressure_safe_transient_candidates "$HOME_PATH"
+    return 1
+  fi
+  return 0
+}
+
+periodic_alert() {
+  local out status state reason available floor clear cooldown marker now last
+  if out=$(emit_check); then
+    status=0
+  else
+    status=$?
+  fi
+  state=$(printf '%s\n' "$out" | sed -n 's/^state=//p' | tail -1)
+  case "$state" in
+    critical) ;;
+    *) return 0 ;;
+  esac
+  reason=$(printf '%s\n' "$out" | sed -n 's/^reason=//p' | tail -1)
+  case "$reason" in
+    *disk_floor*) ;;
+    *) return "$status" ;;
+  esac
+  cooldown=$(fm_pressure_config_value "$CFG" disk_alert_cooldown_secs 900)
+  fm_pressure_numeric_or_empty "$cooldown" disk_alert_cooldown_secs || return 2
+  marker="$STATE_PATH/.host-pressure-disk-alert"
+  now=$(fm_pressure_now_epoch)
+  last=$(sed -n 's/^last_alert_epoch=//p' "$marker" 2>/dev/null | tail -1)
+  if [ -n "$last" ] && [ "$((now - last))" -lt "$cooldown" ] 2>/dev/null; then
+    return 0
+  fi
+  mkdir -p "$STATE_PATH"
+  printf 'last_alert_epoch=%s\n' "$now" > "$marker"
+  available=$(printf '%s\n' "$out" | sed -n 's/^disk_available_mb=//p' | tail -1)
+  floor=$(printf '%s\n' "$out" | sed -n 's/^disk_floor_mb=//p' | tail -1)
+  clear=$(printf '%s\n' "$out" | sed -n 's/^disk_clear_mb=//p' | tail -1)
+  printf 'alert=disk_pressure\n'
+  printf 'state=critical\n'
+  printf 'reason=%s\n' "$reason"
+  printf 'disk_available_mb=%s\n' "$available"
+  printf 'disk_floor_mb=%s\n' "$floor"
+  printf 'disk_clear_mb=%s\n' "$clear"
+  printf 'cooldown_secs=%s\n' "$cooldown"
+  return 0
+}
+
+case "$cmd" in
+  check)
+    emit_check
+    exit "$?"
+    ;;
+  gate)
+    case "$GATE_KIND" in
+      spawn|test) ;;
+      *) echo "error: gate requires --kind spawn|test" >&2; exit 2 ;;
+    esac
+    emit_check
+    exit "$?"
+    ;;
+  periodic-alert)
+    periodic_alert
+    exit "$?"
+    ;;
+  classify-shed)
+    [ -n "$COMMAND_LINE" ] || { echo "error: classify-shed requires --command" >&2; exit 2; }
+    fm_pressure_shed_classify_command "$COMMAND_LINE"
+    ;;
+  *)
+    echo "error: unknown command '$cmd'" >&2
+    usage
+    exit 2
+    ;;
+esac

--- a/bin/fm-host-pressure.sh
+++ b/bin/fm-host-pressure.sh
@@ -193,11 +193,22 @@ emit_check() {
 }
 
 periodic_alert() {
-  local out status state reason available floor clear cooldown marker now last
+  local out status state reason available floor clear cooldown marker now last detail
   if out=$(emit_check); then
     status=0
   else
     status=$?
+  fi
+  # A malformed config/capacity-failover makes emit_check exit 2 with its
+  # message on stderr and nothing on stdout. The watcher reads this command's
+  # stdout and discards its stderr, so surface the refusal as an alert record
+  # rather than letting a broken threshold read as "nothing to alert".
+  if [ "$status" -eq 2 ]; then
+    detail=$(emit_check 2>&1 >/dev/null | tail -1)
+    printf 'alert=host_pressure_config_invalid\n'
+    printf 'state=error\n'
+    printf 'reason=%s\n' "${detail:-invalid capacity-failover configuration}"
+    return 2
   fi
   state=$(printf '%s\n' "$out" | sed -n 's/^state=//p' | tail -1)
   case "$state" in

--- a/bin/fm-host-pressure.sh
+++ b/bin/fm-host-pressure.sh
@@ -39,6 +39,7 @@ HOME_PATH="$FM_HOME"
 STATE_PATH="$STATE"
 GATE_KIND=
 COMMAND_LINE=
+CONFIG_ALERT_COOLDOWN_SECS=3600
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -193,7 +194,7 @@ emit_check() {
 }
 
 periodic_alert() {
-  local out status state reason available floor clear cooldown marker now last detail errfile
+  local out status state reason available floor clear cooldown marker now last detail errfile last_detail
   # emit_check rewrites the disk-hysteresis marker, so it is evaluated exactly
   # once and its stderr is captured alongside its stdout instead of being
   # recovered by a second run.
@@ -207,14 +208,34 @@ periodic_alert() {
   # message on stderr and nothing on stdout. The watcher reads this command's
   # stdout and discards its stderr, so surface the refusal as an alert record
   # rather than letting a broken threshold read as "nothing to alert".
+  # A broken threshold is only fixed by a human editing the file, so the alert
+  # is bounded by its own marker with a fixed cooldown - the configured cooldown
+  # cannot be trusted while the config is refused - and re-alerts immediately
+  # when the refusal message itself changes.
   if [ "$status" -eq 2 ]; then
     detail=$(tail -1 "$errfile")
     rm -f "$errfile"
+    detail=${detail:-invalid capacity-failover configuration}
+    marker="$STATE_PATH/.host-pressure-config-alert"
+    now=$(fm_pressure_now_epoch)
+    last=$(sed -n 's/^last_alert_epoch=//p' "$marker" 2>/dev/null | tail -1)
+    last_detail=$(sed -n 's/^reason=//p' "$marker" 2>/dev/null | tail -1)
+    if [ -n "$last" ] && [ "$last_detail" = "$detail" ] &&
+      [ "$((now - last))" -lt "$CONFIG_ALERT_COOLDOWN_SECS" ] 2>/dev/null; then
+      return 0
+    fi
+    mkdir -p "$STATE_PATH"
+    {
+      printf 'last_alert_epoch=%s\n' "$now"
+      printf 'reason=%s\n' "$detail"
+    } > "$marker"
     printf 'alert=host_pressure_config_invalid\n'
     printf 'state=error\n'
-    printf 'reason=%s\n' "${detail:-invalid capacity-failover configuration}"
+    printf 'reason=%s\n' "$detail"
+    printf 'cooldown_secs=%s\n' "$CONFIG_ALERT_COOLDOWN_SECS"
     return 2
   fi
+  rm -f "$STATE_PATH/.host-pressure-config-alert"
   cat "$errfile" >&2
   rm -f "$errfile"
   state=$(printf '%s\n' "$out" | sed -n 's/^state=//p' | tail -1)

--- a/bin/fm-host-pressure.sh
+++ b/bin/fm-host-pressure.sh
@@ -193,8 +193,12 @@ emit_check() {
 }
 
 periodic_alert() {
-  local out status state reason available floor clear cooldown marker now last detail
-  if out=$(emit_check); then
+  local out status state reason available floor clear cooldown marker now last detail errfile
+  # emit_check rewrites the disk-hysteresis marker, so it is evaluated exactly
+  # once and its stderr is captured alongside its stdout instead of being
+  # recovered by a second run.
+  errfile=$(mktemp "${TMPDIR:-/tmp}/fm-host-pressure.XXXXXXXX")
+  if out=$(emit_check 2>"$errfile"); then
     status=0
   else
     status=$?
@@ -204,12 +208,15 @@ periodic_alert() {
   # stdout and discards its stderr, so surface the refusal as an alert record
   # rather than letting a broken threshold read as "nothing to alert".
   if [ "$status" -eq 2 ]; then
-    detail=$(emit_check 2>&1 >/dev/null | tail -1)
+    detail=$(tail -1 "$errfile")
+    rm -f "$errfile"
     printf 'alert=host_pressure_config_invalid\n'
     printf 'state=error\n'
     printf 'reason=%s\n' "${detail:-invalid capacity-failover configuration}"
     return 2
   fi
+  cat "$errfile" >&2
+  rm -f "$errfile"
   state=$(printf '%s\n' "$out" | sed -n 's/^state=//p' | tail -1)
   case "$state" in
     critical) ;;

--- a/bin/fm-pr-check.sh
+++ b/bin/fm-pr-check.sh
@@ -12,6 +12,17 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+GITHUB_ACCOUNT=${FM_GITHUB_ACCOUNT_ID:-94498628}
+GITHUB_ROUTE=${FM_GITHUB_ROUTE:-default}
+
+# Skip a GitHub read while the shared quota guard says this account/route is in
+# a cooldown, so a walled account is not hammered for optional PR head data.
+github_quota_deferred() {
+  local out state
+  out=$("$SCRIPT_DIR/fm-shared-github-quota.sh" check --provider github --account "$GITHUB_ACCOUNT" --route "$GITHUB_ROUTE" 2>/dev/null || true)
+  state=$(printf '%s\n' "$out" | sed -n 's/^state=//p' | tail -1)
+  [ "$state" = defer ]
+}
 
 # shellcheck source=bin/fm-pr-lib.sh
 . "$SCRIPT_DIR/fm-pr-lib.sh"
@@ -63,11 +74,15 @@ fi
 # bin/fm-review-diff.sh resolves the head from the remote when none is recorded.
 WT=$(grep '^worktree=' "$META" | tail -1 | cut -d= -f2- || true)
 PR_HEAD=
-if [ "$PROVIDER" = github ] && [ -n "$WT" ] && [ -d "$WT" ] && command -v gh >/dev/null 2>&1; then
-  if REMOTE_HEAD=$(cd "$WT" && gh pr view "$URL" --json headRefOid -q .headRefOid 2>/dev/null) \
+if [ "$PROVIDER" = github ] && [ -n "$WT" ] && [ -d "$WT" ] && ! github_quota_deferred && command -v gh >/dev/null 2>&1; then
+  GH_ERR=$(mktemp "${TMPDIR:-/tmp}/fm-gh-head.XXXXXXXX") || exit 1
+  if REMOTE_HEAD=$(cd "$WT" && gh pr view "$URL" --json headRefOid -q .headRefOid 2>"$GH_ERR") \
     && fm_pr_head_valid "$REMOTE_HEAD"; then
     PR_HEAD=$REMOTE_HEAD
+  else
+    "$SCRIPT_DIR/fm-shared-github-quota.sh" mark-from-text --provider github --route "$GITHUB_ROUTE" --source "fm-pr-check:$URL head" --file "$GH_ERR" >/dev/null 2>&1 || true
   fi
+  rm -f "$GH_ERR"
 fi
 
 META_TMP=

--- a/bin/fm-pr-check.sh
+++ b/bin/fm-pr-check.sh
@@ -12,16 +12,21 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
-GITHUB_ACCOUNT=${FM_GITHUB_ACCOUNT_ID:-94498628}
 GITHUB_ROUTE=${FM_GITHUB_ROUTE:-default}
 
 # Skip a GitHub read while the shared quota guard says this account/route is in
 # a cooldown, so a walled account is not hammered for optional PR head data.
 github_quota_deferred() {
   local out state
-  out=$("$SCRIPT_DIR/fm-shared-github-quota.sh" check --provider github --account "$GITHUB_ACCOUNT" --route "$GITHUB_ROUTE" 2>/dev/null || true)
+  out=$("$SCRIPT_DIR/fm-shared-github-quota.sh" check --provider github --route "$GITHUB_ROUTE" 2>/dev/null || true)
   state=$(printf '%s\n' "$out" | sed -n 's/^state=//p' | tail -1)
   [ "$state" = defer ]
+}
+
+mark_github_quota_from_file() {
+  local source=$1 file=$2
+  "$SCRIPT_DIR/fm-shared-github-quota.sh" mark-from-text --provider github --route "$GITHUB_ROUTE" \
+    --source "$source" --file "$file" >/dev/null 2>&1 || true
 }
 
 # shellcheck source=bin/fm-pr-lib.sh
@@ -74,15 +79,18 @@ fi
 # bin/fm-review-diff.sh resolves the head from the remote when none is recorded.
 WT=$(grep '^worktree=' "$META" | tail -1 | cut -d= -f2- || true)
 PR_HEAD=
-if [ "$PROVIDER" = github ] && [ -n "$WT" ] && [ -d "$WT" ] && ! github_quota_deferred && command -v gh >/dev/null 2>&1; then
-  GH_ERR=$(mktemp "${TMPDIR:-/tmp}/fm-gh-head.XXXXXXXX") || exit 1
-  if REMOTE_HEAD=$(cd "$WT" && gh pr view "$URL" --json headRefOid -q .headRefOid 2>"$GH_ERR") \
-    && fm_pr_head_valid "$REMOTE_HEAD"; then
-    PR_HEAD=$REMOTE_HEAD
-  else
-    "$SCRIPT_DIR/fm-shared-github-quota.sh" mark-from-text --provider github --route "$GITHUB_ROUTE" --source "fm-pr-check:$URL head" --file "$GH_ERR" >/dev/null 2>&1 || true
+if [ "$PROVIDER" = github ] && [ -n "$WT" ] && [ -d "$WT" ] && command -v gh >/dev/null 2>&1; then
+  if ! github_quota_deferred; then
+    GH_ERR=$(mktemp "${TMPDIR:-/tmp}/fm-gh-head.XXXXXXXX") || exit 1
+    if REMOTE_HEAD=$(cd "$WT" && gh pr view "$URL" --json headRefOid -q .headRefOid 2>"$GH_ERR"); then
+      if fm_pr_head_valid "$REMOTE_HEAD"; then
+        PR_HEAD=$REMOTE_HEAD
+      fi
+    else
+      mark_github_quota_from_file "fm-pr-check:$URL head" "$GH_ERR"
+    fi
+    rm -f "$GH_ERR"
   fi
-  rm -f "$GH_ERR"
 fi
 
 META_TMP=

--- a/bin/fm-pr-check.sh
+++ b/bin/fm-pr-check.sh
@@ -26,7 +26,8 @@ github_quota_deferred() {
 
 mark_github_quota_from_file() {
   local source=$1 file=$2
-  "$SCRIPT_DIR/fm-shared-github-quota.sh" mark-from-text --provider github --route "$GITHUB_ROUTE" \
+  FM_SHARED_GITHUB_QUOTA_DERIVE_ACCOUNT=0 \
+    "$SCRIPT_DIR/fm-shared-github-quota.sh" mark-from-text --provider github --route "$GITHUB_ROUTE" \
     --source "$source" --file "$file" >/dev/null 2>&1 || true
 }
 

--- a/bin/fm-pr-check.sh
+++ b/bin/fm-pr-check.sh
@@ -18,7 +18,8 @@ GITHUB_ROUTE=${FM_GITHUB_ROUTE:-default}
 # a cooldown, so a walled account is not hammered for optional PR head data.
 github_quota_deferred() {
   local out state
-  out=$("$SCRIPT_DIR/fm-shared-github-quota.sh" check --provider github --route "$GITHUB_ROUTE" 2>/dev/null || true)
+  out=$(FM_SHARED_GITHUB_QUOTA_DERIVE_ACCOUNT=0 \
+    "$SCRIPT_DIR/fm-shared-github-quota.sh" check --provider github --route "$GITHUB_ROUTE" 2>/dev/null || true)
   state=$(printf '%s\n' "$out" | sed -n 's/^state=//p' | tail -1)
   [ "$state" = defer ]
 }

--- a/bin/fm-pr-merge.sh
+++ b/bin/fm-pr-merge.sh
@@ -41,12 +41,14 @@ shift 2
 [ "${1:-}" = "--" ] && shift
 
 github_quota_check() {
-  "$SCRIPT_DIR/fm-shared-github-quota.sh" check --provider github --route "$GITHUB_ROUTE" 2>/dev/null || true
+  FM_SHARED_GITHUB_QUOTA_DERIVE_ACCOUNT=0 \
+    "$SCRIPT_DIR/fm-shared-github-quota.sh" check --provider github --route "$GITHUB_ROUTE" 2>/dev/null || true
 }
 
 mark_github_quota_from_file() {
   local source=$1 file=$2
-  "$SCRIPT_DIR/fm-shared-github-quota.sh" mark-from-text --provider github --route "$GITHUB_ROUTE" \
+  FM_SHARED_GITHUB_QUOTA_DERIVE_ACCOUNT=0 \
+    "$SCRIPT_DIR/fm-shared-github-quota.sh" mark-from-text --provider github --route "$GITHUB_ROUTE" \
     --source "$source" --file "$file" >/dev/null 2>&1 || true
 }
 

--- a/bin/fm-pr-merge.sh
+++ b/bin/fm-pr-merge.sh
@@ -38,6 +38,8 @@ PR_REPO=$FM_PR_REPO
 PR_NUMBER=$FM_PR_NUMBER
 shift 2
 [ "${1:-}" = "--" ] && shift
+GITHUB_ACCOUNT=${FM_GITHUB_ACCOUNT_ID:-94498628}
+GITHUB_ROUTE=${FM_GITHUB_ROUTE:-default}
 
 caller_has_merge_method() {
   local arg
@@ -76,9 +78,34 @@ grep -qxF "pr=$URL" "$META" || {
   exit 1
 }
 
+quota_out=$("$SCRIPT_DIR/fm-shared-github-quota.sh" check --provider github --account "$GITHUB_ACCOUNT" --route "$GITHUB_ROUTE" 2>/dev/null || true)
+quota_state=$(printf '%s\n' "$quota_out" | sed -n 's/^state=//p' | tail -1)
+if [ "$quota_state" = defer ]; then
+  echo "error: GitHub shared quota cooldown is active; refusing gh-axi pr merge before reset" >&2
+  printf 'escalation=github_shared_quota\n' >&2
+  printf 'provider=github\n' >&2
+  printf 'account=%s\n' "$(printf '%s\n' "$quota_out" | sed -n 's/^account=//p' | tail -1)" >&2
+  printf 'route=%s\n' "$(printf '%s\n' "$quota_out" | sed -n 's/^route=//p' | tail -1)" >&2
+  printf 'reset_at=%s\n' "$(printf '%s\n' "$quota_out" | sed -n 's/^reset_at=//p' | tail -1)" >&2
+  printf 'reset_epoch=%s\n' "$(printf '%s\n' "$quota_out" | sed -n 's/^reset_epoch=//p' | tail -1)" >&2
+  printf 'operation=pr merge %s --repo %s/%s\n' "$PR_NUMBER" "$PR_OWNER" "$PR_REPO" >&2
+  printf 'needed_action=wait until reset or use an alternate verified GitHub account/route with headroom\n' >&2
+  exit 1
+fi
+
 merge_args=()
 if ! caller_has_merge_method "$@"; then
   merge_args=(--squash)
 fi
 
-gh-axi pr merge "$PR_NUMBER" --repo "$PR_OWNER/$PR_REPO" "${merge_args[@]+"${merge_args[@]}"}" "$@"
+merge_err=$(mktemp "${TMPDIR:-/tmp}/fm-gh-merge.XXXXXXXX") || exit 1
+if gh-axi pr merge "$PR_NUMBER" --repo "$PR_OWNER/$PR_REPO" "${merge_args[@]+"${merge_args[@]}"}" "$@" 2>"$merge_err"; then
+  [ ! -s "$merge_err" ] || cat "$merge_err" >&2
+  rm -f "$merge_err"
+else
+  status=$?
+  [ ! -s "$merge_err" ] || cat "$merge_err" >&2
+  "$SCRIPT_DIR/fm-shared-github-quota.sh" mark-from-text --provider github --route "$GITHUB_ROUTE" --source "fm-pr-merge:$URL" --file "$merge_err" >/dev/null 2>&1 || true
+  rm -f "$merge_err"
+  exit "$status"
+fi

--- a/bin/fm-pr-merge.sh
+++ b/bin/fm-pr-merge.sh
@@ -14,6 +14,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+GITHUB_ROUTE=${FM_GITHUB_ROUTE:-default}
 
 # shellcheck source=bin/fm-pr-lib.sh
 . "$SCRIPT_DIR/fm-pr-lib.sh"
@@ -38,8 +39,17 @@ PR_REPO=$FM_PR_REPO
 PR_NUMBER=$FM_PR_NUMBER
 shift 2
 [ "${1:-}" = "--" ] && shift
-GITHUB_ACCOUNT=${FM_GITHUB_ACCOUNT_ID:-94498628}
 GITHUB_ROUTE=${FM_GITHUB_ROUTE:-default}
+
+github_quota_check() {
+  "$SCRIPT_DIR/fm-shared-github-quota.sh" check --provider github --route "$GITHUB_ROUTE" 2>/dev/null || true
+}
+
+mark_github_quota_from_file() {
+  local source=$1 file=$2
+  "$SCRIPT_DIR/fm-shared-github-quota.sh" mark-from-text --provider github --route "$GITHUB_ROUTE" \
+    --source "$source" --file "$file" >/dev/null 2>&1 || true
+}
 
 caller_has_merge_method() {
   local arg
@@ -78,7 +88,7 @@ grep -qxF "pr=$URL" "$META" || {
   exit 1
 }
 
-quota_out=$("$SCRIPT_DIR/fm-shared-github-quota.sh" check --provider github --account "$GITHUB_ACCOUNT" --route "$GITHUB_ROUTE" 2>/dev/null || true)
+quota_out=$(github_quota_check)
 quota_state=$(printf '%s\n' "$quota_out" | sed -n 's/^state=//p' | tail -1)
 if [ "$quota_state" = defer ]; then
   echo "error: GitHub shared quota cooldown is active; refusing gh-axi pr merge before reset" >&2
@@ -105,7 +115,7 @@ if gh-axi pr merge "$PR_NUMBER" --repo "$PR_OWNER/$PR_REPO" "${merge_args[@]+"${
 else
   status=$?
   [ ! -s "$merge_err" ] || cat "$merge_err" >&2
-  "$SCRIPT_DIR/fm-shared-github-quota.sh" mark-from-text --provider github --route "$GITHUB_ROUTE" --source "fm-pr-merge:$URL" --file "$merge_err" >/dev/null 2>&1 || true
+  mark_github_quota_from_file "fm-pr-merge:$URL" "$merge_err"
   rm -f "$merge_err"
   exit "$status"
 fi

--- a/bin/fm-pr-merge.sh
+++ b/bin/fm-pr-merge.sh
@@ -39,7 +39,6 @@ PR_REPO=$FM_PR_REPO
 PR_NUMBER=$FM_PR_NUMBER
 shift 2
 [ "${1:-}" = "--" ] && shift
-GITHUB_ROUTE=${FM_GITHUB_ROUTE:-default}
 
 github_quota_check() {
   "$SCRIPT_DIR/fm-shared-github-quota.sh" check --provider github --route "$GITHUB_ROUTE" 2>/dev/null || true

--- a/bin/fm-pr-merge.sh
+++ b/bin/fm-pr-merge.sh
@@ -7,6 +7,10 @@
 # Merge method defaults to --squash when the caller passes none of --squash,
 # --merge, --rebase, or --method after the optional -- separator. Extra args
 # must not include --repo or -R because the repository comes only from the URL.
+#
+# A known shared GitHub cooldown (bin/fm-shared-github-quota.sh) refuses the merge
+# with structured escalation evidence instead of calling gh; a gh rate-limit
+# failure records that cooldown for the rest of the fleet (docs/capacity-failover.md).
 # Usage: fm-pr-merge.sh <task-id> <pr-url> [-- <extra gh-axi pr merge args>]
 set -eu
 

--- a/bin/fm-pr-poll.sh
+++ b/bin/fm-pr-poll.sh
@@ -87,10 +87,12 @@ case "$provider" in
     if quota_bin=$(find_quota_bin 2>/dev/null); then
       github_route=${FM_GITHUB_ROUTE:-default}
       cache_key="pr-state:$url"
-      quota_out=$("$quota_bin" check --provider github --route "$github_route" 2>/dev/null || true)
+      quota_out=$(FM_SHARED_GITHUB_QUOTA_DERIVE_ACCOUNT=0 \
+        "$quota_bin" check --provider github --route "$github_route" 2>/dev/null || true)
       quota_state=$(printf '%s\n' "$quota_out" | sed -n 's/^state=//p' | tail -1)
       if [ "$quota_state" = defer ]; then
-        state=$("$quota_bin" cache-get --provider github --route "$github_route" --key "$cache_key" \
+        state=$(FM_SHARED_GITHUB_QUOTA_DERIVE_ACCOUNT=0 \
+          "$quota_bin" cache-get --provider github --route "$github_route" --key "$cache_key" \
           --max-age-secs "${FM_GITHUB_QUOTA_DEFER_CACHE_MAX_AGE_SECS:-86400}" 2>/dev/null || true)
       else
         gh_err=$(mktemp "${TMPDIR:-/tmp}/fm-gh-pr.XXXXXXXX") || exit 0

--- a/bin/fm-pr-poll.sh
+++ b/bin/fm-pr-poll.sh
@@ -97,10 +97,12 @@ case "$provider" in
       else
         gh_err=$(mktemp "${TMPDIR:-/tmp}/fm-gh-pr.XXXXXXXX") || exit 0
         if state=$(gh pr view "$url" --json state -q .state 2>"$gh_err"); then
-          printf '%s\n' "$state" | "$quota_bin" cache-put --provider github --route "$github_route" \
+          printf '%s\n' "$state" | FM_SHARED_GITHUB_QUOTA_DERIVE_ACCOUNT=0 \
+            "$quota_bin" cache-put --provider github --route "$github_route" \
             --key "$cache_key" >/dev/null 2>&1 || true
         else
-          "$quota_bin" mark-from-text --provider github --route "$github_route" \
+          FM_SHARED_GITHUB_QUOTA_DERIVE_ACCOUNT=0 \
+            "$quota_bin" mark-from-text --provider github --route "$github_route" \
             --source "fm-pr-poll:$url" --file "$gh_err" >/dev/null 2>&1 || true
           state=
         fi

--- a/bin/fm-pr-poll.sh
+++ b/bin/fm-pr-poll.sh
@@ -45,6 +45,25 @@ case "$number" in
   *[!0-9]*) exit 0 ;;
 esac
 
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# The published poll is a link into the state directory, so the shared quota
+# guard is located from the candidates that can name a firstmate bin directory.
+find_quota_bin() {
+  local candidate
+  for candidate in \
+    "$script_dir/fm-shared-github-quota.sh" \
+    "${FM_ROOT_OVERRIDE:-}/bin/fm-shared-github-quota.sh" \
+    "${FM_HOME:-}/bin/fm-shared-github-quota.sh" \
+    "$script_dir/../bin/fm-shared-github-quota.sh"; do
+    [ -n "$candidate" ] || continue
+    [ -x "$candidate" ] || continue
+    printf '%s\n' "$candidate"
+    return 0
+  done
+  return 1
+}
+
 # Every component is revalidated here rather than trusted from the sidecar, and
 # the stored URL must then be exactly reconstructible from those components, so
 # a doctored sidecar cannot redirect this poll at another host or project.
@@ -62,7 +81,32 @@ case "$provider" in
       .|..|*[!A-Za-z0-9._-]*) exit 0 ;;
     esac
     [ "$url" = "https://github.com/$owner/$repo/pull/$number" ] || exit 0
-    state=$(gh pr view "$url" --json state -q .state 2>/dev/null) || exit 0
+    # A GitHub read goes through the shared quota guard: while the account is
+    # walled the last cached state answers instead of another rejected call.
+    state=
+    if quota_bin=$(find_quota_bin 2>/dev/null); then
+      github_route=${FM_GITHUB_ROUTE:-default}
+      cache_key="pr-state:$url"
+      quota_out=$("$quota_bin" check --provider github --route "$github_route" 2>/dev/null || true)
+      quota_state=$(printf '%s\n' "$quota_out" | sed -n 's/^state=//p' | tail -1)
+      if [ "$quota_state" = defer ]; then
+        state=$("$quota_bin" cache-get --provider github --route "$github_route" --key "$cache_key" \
+          --max-age-secs "${FM_GITHUB_QUOTA_DEFER_CACHE_MAX_AGE_SECS:-86400}" 2>/dev/null || true)
+      else
+        gh_err=$(mktemp "${TMPDIR:-/tmp}/fm-gh-pr.XXXXXXXX") || exit 0
+        if state=$(gh pr view "$url" --json state -q .state 2>"$gh_err"); then
+          printf '%s\n' "$state" | "$quota_bin" cache-put --provider github --route "$github_route" \
+            --key "$cache_key" >/dev/null 2>&1 || true
+        else
+          "$quota_bin" mark-from-text --provider github --route "$github_route" \
+            --source "fm-pr-poll:$url" --file "$gh_err" >/dev/null 2>&1 || true
+          state=
+        fi
+        rm -f "$gh_err"
+      fi
+    else
+      state=$(gh pr view "$url" --json state -q .state 2>/dev/null) || exit 0
+    fi
     [ "$state" = MERGED ] && printf '%s\n' merged
     ;;
   gitlab)

--- a/bin/fm-pr-poll.sh
+++ b/bin/fm-pr-poll.sh
@@ -6,6 +6,10 @@
 # interpolated into this source: these bytes are identical for every task.
 # Each provider is read through its own standard CLI, gh for GitHub and glab
 # for GitLab, so an upstream checkout needs no extra tooling to follow either.
+# During a known shared GitHub cooldown (bin/fm-shared-github-quota.sh) the
+# GitHub read makes no gh call and answers only from the small cached PR state;
+# a successful live read refreshes that cache and a rate-limit failure records
+# the cooldown for the rest of the fleet (docs/capacity-failover.md).
 set -u
 LC_ALL=C
 export LC_ALL

--- a/bin/fm-pressure-lib.sh
+++ b/bin/fm-pressure-lib.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# Passive host pressure and spawn-backpressure helpers.
+#
+# This library is substrate only.
+# Nothing here changes spawn behavior unless a caller explicitly consults it.
+
+fm_pressure_config_value() {  # <config-file> <key> [default]
+  local cfg=$1 key=$2 default=${3:-} value
+  [ -f "$cfg" ] || { printf '%s\n' "$default"; return 0; }
+  value=$(awk -F= -v key="$key" '
+    /^[[:space:]]*#/ || /^[[:space:]]*$/ { next }
+    {
+      k=$1
+      sub(/^[[:space:]]+/, "", k)
+      sub(/[[:space:]]+$/, "", k)
+      if (k == key) {
+        v=$0
+        sub(/^[^=]*=/, "", v)
+        sub(/^[[:space:]]+/, "", v)
+        sub(/[[:space:]]+$/, "", v)
+        found=1
+      }
+    }
+    END { if (found) print v }
+  ' "$cfg")
+  printf '%s\n' "${value:-$default}"
+}
+
+fm_pressure_enabled() {  # <config-file>
+  local value
+  value=$(fm_pressure_config_value "$1" host-pressure off)
+  case "$value" in
+    on|true|yes|1) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+fm_pressure_numeric_or_empty() {  # <value> <label>
+  local value=$1 label=$2
+  case "$value" in
+    ''|*[!0-9]*)
+      [ -z "$value" ] || echo "error: $label must be a non-negative integer" >&2
+      [ -z "$value" ]
+      ;;
+    *) return 0 ;;
+  esac
+}
+
+fm_pressure_now_epoch() {
+  if [ -n "${FM_PRESSURE_NOW_EPOCH:-}" ]; then
+    printf '%s\n' "$FM_PRESSURE_NOW_EPOCH"
+  else
+    date +%s
+  fi
+}
+
+fm_pressure_memory_available_mb() {
+  if [ -n "${FM_PRESSURE_MEMORY_AVAILABLE_MB:-}" ]; then
+    printf '%s\n' "$FM_PRESSURE_MEMORY_AVAILABLE_MB"
+    return 0
+  fi
+
+  if [ -r /proc/meminfo ]; then
+    awk '/^MemAvailable:/ { print int($2 / 1024); found=1 } END { exit found ? 0 : 1 }' /proc/meminfo && return 0
+  fi
+
+  if command -v vm_stat >/dev/null 2>&1 && command -v sysctl >/dev/null 2>&1; then
+    vm_stat | awk '
+      /page size of/ {
+        page=$8
+        gsub(/\./, "", page)
+      }
+      /^Pages free:/ {
+        v=$3
+        gsub(/\./, "", v)
+        free=v
+      }
+      /^Pages inactive:/ {
+        v=$3
+        gsub(/\./, "", v)
+        inactive=v
+      }
+      /^Pages speculative:/ {
+        v=$3
+        gsub(/\./, "", v)
+        speculative=v
+      }
+      END {
+        if (page > 0) {
+          print int(((free + inactive + speculative) * page) / 1048576)
+        } else {
+          exit 1
+        }
+      }
+    ' && return 0
+  fi
+
+  printf 'unknown\n'
+}
+
+fm_pressure_disk_available_mb() {  # <path>
+  local path=$1
+  if [ -n "${FM_PRESSURE_DISK_AVAILABLE_MB:-}" ]; then
+    printf '%s\n' "$FM_PRESSURE_DISK_AVAILABLE_MB"
+    return 0
+  fi
+  df -Pk "$path" 2>/dev/null | awk 'NR == 2 { print int($4 / 1024); found=1 } END { exit found ? 0 : 1 }' || printf 'unknown\n'
+}
+
+fm_pressure_running_tasks() {  # <state-dir>
+  local state=$1 meta count
+  if [ -n "${FM_PRESSURE_RUNNING_TASKS:-}" ]; then
+    printf '%s\n' "$FM_PRESSURE_RUNNING_TASKS"
+    return 0
+  fi
+  count=0
+  for meta in "$state"/*.meta; do
+    [ -e "$meta" ] || continue
+    grep -q '^window=' "$meta" 2>/dev/null || continue
+    count=$((count + 1))
+  done
+  printf '%s\n' "$count"
+}
+
+fm_pressure_safe_transient_candidates() {  # <home>
+  local home=$1
+  printf 'transient_candidate=%s\n' "${TMPDIR:-/tmp}/fm-*"
+  printf 'transient_candidate=%s\n' "$home/state/.watch-triage.log"
+  printf 'transient_candidate=%s\n' "$home/.no-mistakes/"
+}
+
+fm_pressure_shed_classify_command() {  # <command-line>
+  local cmd=$1
+  case "$cmd" in
+    *"bash tests/"*.test.sh*|*"for test_script in tests/"*.test.sh*|*"bin/fm-lint.sh"*|*"shellcheck "*)
+      printf 'eligible=restartable_compute\n'
+      printf 'reason=validation_or_test_process\n'
+      ;;
+    *)
+      printf 'eligible=no\n'
+      printf 'reason=not_known_restartable_compute\n'
+      ;;
+  esac
+}

--- a/bin/fm-rehome-quota-wall.sh
+++ b/bin/fm-rehome-quota-wall.sh
@@ -121,6 +121,7 @@ fi
 HEAD=$(git -C "$WT" rev-parse HEAD)
 BRANCH=$(git -C "$WT" rev-parse --abbrev-ref HEAD 2>/dev/null || printf 'HEAD')
 PR_URL=$(fm_meta_get "$META" pr)
+PR_HEAD=$(fm_meta_get "$META" pr_head)
 
 if [ -n "$OLD_TARGET" ] && fm_backend_target_exists "$OLD_BACKEND" "$OLD_TARGET"; then
   ALIVE=$(fm_backend_agent_alive "$OLD_BACKEND" "$OLD_TARGET")
@@ -193,6 +194,7 @@ awk -F= '
     skip["terminal"]=1; skip["herdr_session"]=1; skip["herdr_workspace_id"]=1; skip["herdr_tab_id"]=1; skip["herdr_pane_id"]=1;
     skip["zellij_session"]=1; skip["zellij_tab_id"]=1; skip["zellij_pane_id"]=1;
     skip["orca_worktree_id"]=1; skip["cmux_workspace_id"]=1; skip["cmux_surface_id"]=1;
+    skip["pr"]=1; skip["pr_head"]=1;
   }
   /^[A-Za-z_][A-Za-z0-9_]*=/ {
     if (skip[$1]) next;
@@ -210,6 +212,12 @@ awk -F= '
   printf 'rehome_from_window=%s\n' "${OLD_TARGET:-none}"
   printf 'rehome_continuation=%s\n' "$CONT_BRIEF"
 } >> "$META_TMP"
+# The armed merge poll only accepts metadata whose pr=/pr_head= lines are last,
+# so recorded PR identity is re-appended after every rehome key.
+if [ -n "$PR_URL" ]; then
+  printf 'pr=%s\n' "$PR_URL" >> "$META_TMP"
+  [ -z "$PR_HEAD" ] || printf 'pr_head=%s\n' "$PR_HEAD" >> "$META_TMP"
+fi
 mv "$META_TMP" "$META"
 
 SQ_BRIEF=$(fm_launch_shell_quote "$CONT_BRIEF")

--- a/bin/fm-rehome-quota-wall.sh
+++ b/bin/fm-rehome-quota-wall.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+# Safely rehome one quota-wedged task to a different explicit harness.
+# Usage:
+#   fm-rehome-quota-wall.sh <task-id> --harness <verified-harness> [--model <name>] [--effort <level>] [--dispatch-approved] [--force-dirty]
+#
+# Contract:
+#   - Manual substrate only; no dispatch or spawn path calls this automatically.
+#   - Requires an explicit verified harness and never chooses a harness itself.
+#   - When config/crew-dispatch.json exists, refuses unless the operator passes
+#     --dispatch-approved after consulting the dispatch rules.
+#   - Supports the evidence-backed tmux same-worktree relaunch path only.
+#   - Refuses dirty uncommitted work unless --force-dirty is explicit.
+#   - Preserves task identity by reusing state/<id>.meta, data/<id>/, the same
+#     worktree, current branch, and recorded PR metadata.
+#   - Refuses if opposite_harness_must_differ_from=<harness> in task meta would
+#     be violated by the requested target harness.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
+CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
+
+# shellcheck source=bin/fm-backend.sh
+. "$SCRIPT_DIR/fm-backend.sh"
+# shellcheck source=bin/fm-harness-launch-lib.sh
+. "$SCRIPT_DIR/fm-harness-launch-lib.sh"
+# shellcheck source=bin/fm-capacity-lib.sh
+. "$SCRIPT_DIR/fm-capacity-lib.sh"
+
+usage() {
+  sed -n '2,18p' "$0" >&2
+}
+
+need_value() {
+  [ "$#" -gt 1 ] || { echo "error: $1 requires a value" >&2; exit 2; }
+}
+
+[ "${1:-}" != "-h" ] && [ "${1:-}" != "--help" ] || { usage; exit 0; }
+ID=${1:-}
+[ -n "$ID" ] || { usage; exit 2; }
+shift || true
+
+HARNESS=
+MODEL=default
+EFFORT=default
+BACKEND=tmux
+DISPATCH_APPROVED=0
+FORCE_DIRTY=0
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --harness) need_value "$@"; HARNESS=$2; shift 2 ;;
+    --harness=*) HARNESS=${1#--harness=}; shift ;;
+    --model) need_value "$@"; MODEL=$2; shift 2 ;;
+    --model=*) MODEL=${1#--model=}; shift ;;
+    --effort) need_value "$@"; EFFORT=$2; shift 2 ;;
+    --effort=*) EFFORT=${1#--effort=}; shift ;;
+    --backend) need_value "$@"; BACKEND=$2; shift 2 ;;
+    --backend=*) BACKEND=${1#--backend=}; shift ;;
+    --dispatch-approved) DISPATCH_APPROVED=1; shift ;;
+    --force-dirty) FORCE_DIRTY=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "error: unknown argument $1" >&2; usage; exit 2 ;;
+  esac
+done
+
+[ -n "$HARNESS" ] || { echo "error: --harness is required; rehome never picks a harness itself" >&2; exit 2; }
+case "$EFFORT" in
+  default|low|medium|high|xhigh|max) ;;
+  *) echo "error: --effort must be one of low, medium, high, xhigh, max" >&2; exit 2 ;;
+esac
+fm_launch_template "$HARNESS" ship >/dev/null \
+  || { echo "error: unknown or unverified harness '$HARNESS'" >&2; exit 2; }
+[ "$BACKEND" = tmux ] || { echo "error: fm-rehome-quota-wall currently supports --backend tmux only" >&2; exit 2; }
+
+if [ -f "$CONFIG/crew-dispatch.json" ] && [ "$DISPATCH_APPROVED" -ne 1 ]; then
+  echo "error: config/crew-dispatch.json is active; consult it first, then rerun with --dispatch-approved" >&2
+  exit 1
+fi
+
+META="$STATE/$ID.meta"
+[ -f "$META" ] || { echo "error: no meta for task $ID at $META" >&2; exit 1; }
+fm_capacity_opposite_harness_ok "$META" "$HARNESS" || exit 1
+
+OLD_BACKEND=$(fm_backend_of_meta "$META")
+[ "$OLD_BACKEND" = tmux ] || { echo "error: current task backend '$OLD_BACKEND' is not supported by this tmux-only rehome helper" >&2; exit 1; }
+OLD_TARGET=$(fm_backend_target_of_meta "$META")
+OLD_HARNESS=$(fm_meta_get "$META" harness)
+KIND=$(fm_meta_get "$META" kind)
+[ -n "$KIND" ] || KIND=ship
+[ "$KIND" != secondmate ] || { echo "error: secondmate rehome is not supported; use the secondmate recovery path" >&2; exit 1; }
+WT=$(fm_meta_get "$META" worktree)
+PROJ=$(fm_meta_get "$META" project)
+TASK_TMP=$(fm_meta_get "$META" tasktmp)
+[ -n "$TASK_TMP" ] || TASK_TMP="/tmp/fm-$ID"
+[ -n "$WT" ] && [ -d "$WT" ] || { echo "error: recorded worktree is missing: ${WT:-<empty>}" >&2; exit 1; }
+[ -n "$PROJ" ] || PROJ="$WT"
+ORIG_BRIEF="$DATA/$ID/brief.md"
+[ -f "$ORIG_BRIEF" ] || { echo "error: original brief missing at $ORIG_BRIEF" >&2; exit 1; }
+
+WT_REAL=$(cd "$WT" && pwd -P)
+WT_TOP=$(git -C "$WT" rev-parse --show-toplevel 2>/dev/null || true)
+[ -n "$WT_TOP" ] || { echo "error: $WT is not a git worktree" >&2; exit 1; }
+WT_TOP_REAL=$(cd "$WT_TOP" && pwd -P)
+[ "$WT_REAL" = "$WT_TOP_REAL" ] || { echo "error: recorded worktree is not its git top-level: $WT" >&2; exit 1; }
+
+DIRTY_RAW=$(git -C "$WT" status --porcelain)
+DIRTY=$(printf '%s\n' "$DIRTY_RAW" | grep -vE '^[?][?] (\.claude/|\.opencode/|\.fm-grok-turnend$)' | head -1 || true)
+if [ -n "$DIRTY" ] && [ "$FORCE_DIRTY" -ne 1 ]; then
+  echo "REFUSED: worktree $WT has uncommitted changes; commit/stash them or rerun with --force-dirty." >&2
+  printf '%s\n' "$DIRTY_RAW" >&2
+  exit 1
+fi
+if [ -n "$DIRTY" ]; then
+  echo "warning: --force-dirty set; rehoming with uncommitted work present" >&2
+fi
+
+HEAD=$(git -C "$WT" rev-parse HEAD)
+BRANCH=$(git -C "$WT" rev-parse --abbrev-ref HEAD 2>/dev/null || printf 'HEAD')
+PR_URL=$(fm_meta_get "$META" pr)
+
+if [ -n "$OLD_TARGET" ] && fm_backend_target_exists "$OLD_BACKEND" "$OLD_TARGET"; then
+  ALIVE=$(fm_backend_agent_alive "$OLD_BACKEND" "$OLD_TARGET")
+  case "$ALIVE" in
+    alive)
+      if FM_HOME="$FM_HOME" FM_STATE_OVERRIDE="$STATE" "$SCRIPT_DIR/fm-send.sh" "$ID" /exit >/dev/null 2>&1; then
+        :
+      else
+        echo "warning: /exit send to old endpoint failed; waiting for liveness anyway" >&2
+      fi
+      for _ in $(seq 1 "${FM_REHOME_EXIT_POLLS:-20}"); do
+        sleep "${FM_REHOME_EXIT_SLEEP:-0.5}"
+        ALIVE=$(fm_backend_agent_alive "$OLD_BACKEND" "$OLD_TARGET")
+        [ "$ALIVE" = dead ] && break
+      done
+      [ "$ALIVE" = dead ] || { echo "error: old endpoint still reports agent_alive=$ALIVE after /exit; refusing duplicate ownership" >&2; exit 1; }
+      ;;
+    dead)
+      ;;
+    *)
+      echo "error: old endpoint liveness is '$ALIVE'; refusing duplicate ownership" >&2
+      exit 1
+      ;;
+  esac
+  fm_backend_kill "$OLD_BACKEND" "$OLD_TARGET" >/dev/null 2>&1 || true
+fi
+
+STAMP=$(date -u +%Y%m%dT%H%M%SZ)
+ISO=$(fm_capacity_iso_now)
+mkdir -p "$DATA/$ID"
+CONT_BRIEF="$DATA/$ID/rehome-$STAMP.md"
+cat > "$CONT_BRIEF" <<EOF
+# Rehome Continuation for $ID
+
+This is the same firstmate task, not a helper lane.
+Continue in the existing worktree and current branch.
+Do not create a new branch, new task id, or child PR.
+
+- Rehome reason: quota wall / capacity failover.
+- Previous harness: ${OLD_HARNESS:-unknown}
+- New harness: $HARNESS
+- Worktree: $WT
+- Branch: $BRANCH
+- Head at rehome: $HEAD
+- Recorded PR: ${PR_URL:-none}
+- Rehomed at: $ISO
+
+Before changing code, run \`git status --short\` and confirm you are still in this worktree.
+Preserve the recorded PR/session identity; push ordinary commits to this branch if the task already has a PR.
+
+## Original Brief
+
+$(cat "$ORIG_BRIEF")
+EOF
+
+SES=$(fm_backend_tmux_container_ensure)
+W="fm-$ID"
+T="$SES:$W"
+fm_backend_tmux_create_task "$SES" "$W" "$WT" >/dev/null
+
+mkdir -p "$TASK_TMP/gotmp" "$STATE"
+STATE_REAL=$(cd "$STATE" && pwd -P)
+TURNEND="$STATE_REAL/$ID.turn-ended"
+fm_launch_install_turn_end_hook "$HARNESS" "$KIND" "$WT" "$STATE" "$ID" "$TURNEND" "$PROJ"
+
+META_TMP=$(mktemp "$STATE/$ID.meta.XXXXXXXX")
+awk -F= '
+  BEGIN {
+    skip["window"]=1; skip["harness"]=1; skip["model"]=1; skip["effort"]=1; skip["backend"]=1;
+    skip["terminal"]=1; skip["herdr_session"]=1; skip["herdr_workspace_id"]=1; skip["herdr_tab_id"]=1; skip["herdr_pane_id"]=1;
+    skip["zellij_session"]=1; skip["zellij_tab_id"]=1; skip["zellij_pane_id"]=1;
+    skip["orca_worktree_id"]=1; skip["cmux_workspace_id"]=1; skip["cmux_surface_id"]=1;
+  }
+  /^[A-Za-z_][A-Za-z0-9_]*=/ {
+    if (skip[$1]) next;
+  }
+  { print }
+' "$META" > "$META_TMP"
+{
+  printf 'window=%s\n' "$T"
+  printf 'harness=%s\n' "$HARNESS"
+  printf 'model=%s\n' "$MODEL"
+  printf 'effort=%s\n' "$EFFORT"
+  printf 'backend=tmux\n'
+  printf 'rehome_at=%s\n' "$ISO"
+  printf 'rehome_from_harness=%s\n' "${OLD_HARNESS:-unknown}"
+  printf 'rehome_from_window=%s\n' "${OLD_TARGET:-none}"
+  printf 'rehome_continuation=%s\n' "$CONT_BRIEF"
+} >> "$META_TMP"
+mv "$META_TMP" "$META"
+
+SQ_BRIEF=$(fm_launch_shell_quote "$CONT_BRIEF")
+SQ_TURNEND=$(fm_launch_shell_quote "$TURNEND")
+SQ_PIEXT=$(fm_launch_shell_quote "$STATE/$ID.pi-ext.ts")
+MODELFLAG=$(fm_launch_model_flag_for_harness "$HARNESS" "$MODEL")
+EFFORTFLAG=$(fm_launch_effort_flag_for_harness "$HARNESS" "$EFFORT")
+LAUNCH=$(fm_launch_template "$HARNESS" "$KIND")
+LAUNCH=${LAUNCH//__MODELFLAG__/$MODELFLAG}
+LAUNCH=${LAUNCH//__EFFORTFLAG__/$EFFORTFLAG}
+LAUNCH=${LAUNCH//__BRIEF__/$SQ_BRIEF}
+LAUNCH=${LAUNCH//__TURNEND__/$SQ_TURNEND}
+LAUNCH=${LAUNCH//__PIEXT__/$SQ_PIEXT}
+LAUNCH=${LAUNCH//__PITURNEND__/}
+LAUNCH=${LAUNCH//__PIWATCH__/}
+
+fm_backend_tmux_send_text_line "$T" "export GOTMPDIR=$TASK_TMP/gotmp"
+sleep 0.3
+fm_backend_tmux_send_literal "$T" "$LAUNCH"
+sleep 0.3
+fm_backend_tmux_send_key "$T" Enter
+
+printf 'rehomed %s from %s to %s window=%s worktree=%s continuation=%s\n' "$ID" "${OLD_HARNESS:-unknown}" "$HARNESS" "$T" "$WT" "$CONT_BRIEF"

--- a/bin/fm-rehome-quota-wall.sh
+++ b/bin/fm-rehome-quota-wall.sh
@@ -93,11 +93,9 @@ KIND=$(fm_meta_get "$META" kind)
 [ -n "$KIND" ] || KIND=ship
 [ "$KIND" != secondmate ] || { echo "error: secondmate rehome is not supported; use the secondmate recovery path" >&2; exit 1; }
 WT=$(fm_meta_get "$META" worktree)
-PROJ=$(fm_meta_get "$META" project)
 TASK_TMP=$(fm_meta_get "$META" tasktmp)
 [ -n "$TASK_TMP" ] || TASK_TMP="/tmp/fm-$ID"
 [ -n "$WT" ] && [ -d "$WT" ] || { echo "error: recorded worktree is missing: ${WT:-<empty>}" >&2; exit 1; }
-[ -n "$PROJ" ] || PROJ="$WT"
 ORIG_BRIEF="$DATA/$ID/brief.md"
 [ -f "$ORIG_BRIEF" ] || { echo "error: original brief missing at $ORIG_BRIEF" >&2; exit 1; }
 
@@ -185,7 +183,7 @@ fm_backend_tmux_create_task "$SES" "$W" "$WT" >/dev/null
 mkdir -p "$TASK_TMP/gotmp" "$STATE"
 STATE_REAL=$(cd "$STATE" && pwd -P)
 TURNEND="$STATE_REAL/$ID.turn-ended"
-fm_launch_install_turn_end_hook "$HARNESS" "$KIND" "$WT" "$STATE" "$ID" "$TURNEND" "$PROJ"
+fm_launch_install_turn_end_hook "$HARNESS" "$KIND" "$WT" "$STATE" "$ID" "$TURNEND"
 
 META_TMP=$(mktemp "$STATE/$ID.meta.XXXXXXXX")
 awk -F= '

--- a/bin/fm-shared-github-quota.sh
+++ b/bin/fm-shared-github-quota.sh
@@ -126,6 +126,7 @@ cached_account() {  # <provider>
 derive_account() {  # <provider>
   local provider=$1 account
   [ "$provider" = github ] || return 1
+  [ "${FM_SHARED_GITHUB_QUOTA_DERIVE_ACCOUNT:-1}" != 0 ] || return 1
   command -v gh >/dev/null 2>&1 || return 1
   account=$(GH_PROMPT_DISABLED=1 GH_NO_UPDATE_NOTIFIER=1 gh api user --jq .id 2>/dev/null) || return 1
   account_valid "$account" || return 1

--- a/bin/fm-shared-github-quota.sh
+++ b/bin/fm-shared-github-quota.sh
@@ -197,7 +197,7 @@ NODE
 }
 
 extract_github_rate_limit() {  # <text>
-  FM_GITHUB_QUOTA_TEXT=$1 node <<'NODE'
+  FM_GITHUB_QUOTA_TEXT=$1 FM_SHARED_QUOTA_NOW=$(now_epoch) node <<'NODE'
 const text = process.env.FM_GITHUB_QUOTA_TEXT || "";
 if (!/rate[- ]?limit/i.test(text)) process.exit(1);
 // Only a clearly labeled account id is reported, and it is evidence rather
@@ -208,6 +208,13 @@ let account = "";
   const m = text.match(/(?:user|account)(?:\s+id)?\s*[:#]?\s*([0-9]{4,})/i);
   if (m) account = m[1];
 }
+// Live gh stderr rarely carries a timestamp: a primary limit reports the reset
+// only through the x-ratelimit-reset header epoch, and a secondary limit only
+// through retry-after seconds. Both labels are accepted, but a bare number
+// never is, so an unlabeled id or epoch still cannot become reset evidence.
+const nowEpoch = Number(process.env.FM_SHARED_QUOTA_NOW || 0) ||
+  Math.floor(Date.now() / 1000);
+let ms = NaN;
 let resetAt = "";
 for (const re of [
   /(20\d\d-\d\d-\d\dT\d\d:\d\d:\d\d(?:\.\d+)?Z)/i,
@@ -216,11 +223,20 @@ for (const re of [
   const m = text.match(re);
   if (m) { resetAt = m[1]; break; }
 }
-if (!resetAt) process.exit(1);
-let ms = Date.parse(resetAt);
+if (resetAt) {
+  ms = Date.parse(resetAt);
+  if (!Number.isFinite(ms)) {
+    const m = resetAt.match(/^(\d{4}-\d{2}-\d{2})[ T](\d{2}:\d{2}:\d{2})\s+UTC$/i);
+    if (m) ms = Date.parse(`${m[1]}T${m[2]}Z`);
+  }
+}
 if (!Number.isFinite(ms)) {
-  const m = resetAt.match(/^(\d{4}-\d{2}-\d{2})[ T](\d{2}:\d{2}:\d{2})\s+UTC$/i);
-  if (m) ms = Date.parse(`${m[1]}T${m[2]}Z`);
+  const m = text.match(/\bx-rate-?limit-reset\s*[:=]\s*([0-9]{9,})\b/i);
+  if (m) ms = Number(m[1]) * 1000;
+}
+if (!Number.isFinite(ms)) {
+  const m = text.match(/\bretry[- ]after\s*[:=]?\s*([0-9]{1,7})\b/i);
+  if (m) ms = (nowEpoch + Number(m[1])) * 1000;
 }
 if (!Number.isFinite(ms)) process.exit(1);
 if (account) console.log(`observed_account=${account}`);
@@ -258,11 +274,30 @@ observed_account=$(one_line "$observed")"
   printf '%s\n' "$file"
 }
 
+record_matches_key() {  # <file> <provider> <account> <route>
+  local file=$1 provider=$2 account=$3 route=$4 rec
+  rec=$(field_value "$file" provider)
+  [ "$rec" = "$provider" ] || return 1
+  rec=$(field_value "$file" account)
+  [ "$rec" = "$account" ] || return 1
+  rec=$(field_value "$file" route)
+  [ "$rec" = "$route" ] || return 1
+  return 0
+}
+
 check_quota() {
   local provider=$1 account=$2 route=$3 file reset_epoch now remaining
   file=$(quota_file "$provider" "$account" "$route")
   if [ ! -f "$file" ]; then
     printf 'state=allow\nprovider=%s\naccount=%s\nroute=%s\n' "$provider" "$account" "$route"
+    return 0
+  fi
+  # The path only encodes a CRC32 of the key, so the record's own identity
+  # fields must agree before its wall - and its account/route, which the merge
+  # escalation prints - are applied to this key. A mismatched record is left in
+  # place because it may still be the record another key legitimately owns.
+  if ! record_matches_key "$file" "$provider" "$account" "$route"; then
+    printf 'state=allow\nprovider=%s\naccount=%s\nroute=%s\nmismatched_record=1\n' "$provider" "$account" "$route"
     return 0
   fi
   reset_epoch=$(field_value "$file" reset_epoch)
@@ -424,12 +459,15 @@ case "$cmd" in
     ;;
   cache-get)
     [ -n "$KEY" ] || { echo "error: cache-get requires --key" >&2; exit 2; }
-    resolve_account "$PROVIDER" || exit $?
+    # One key policy across every subcommand: the cached read must stay
+    # reachable under exactly the key the cooldown that deferred it was
+    # written under, including the account-agnostic one.
+    resolve_account_or_agnostic "$PROVIDER" || exit $?
     cache_get "$PROVIDER" "$ACCOUNT" "$ROUTE" "$KEY" "$MAX_AGE_SECS"
     ;;
   cache-put)
     [ -n "$KEY" ] || { echo "error: cache-put requires --key" >&2; exit 2; }
-    resolve_account "$PROVIDER" || exit $?
+    resolve_account_or_agnostic "$PROVIDER" || exit $?
     cache_put "$PROVIDER" "$ACCOUNT" "$ROUTE" "$KEY"
     ;;
   *)

--- a/bin/fm-shared-github-quota.sh
+++ b/bin/fm-shared-github-quota.sh
@@ -283,7 +283,7 @@ observed_account=$(one_line "$observed")"
   printf '%s\n' "$file"
 }
 
-record_matches_key() {  # <file> <provider> <account> <route>
+record_matches_key() {  # <file> <provider> <account> <route> [key]
   local file=$1 provider=$2 account=$3 route=$4 rec
   rec=$(field_value "$file" provider)
   [ "$rec" = "$provider" ] || return 1
@@ -291,6 +291,10 @@ record_matches_key() {  # <file> <provider> <account> <route>
   [ "$rec" = "$account" ] || return 1
   rec=$(field_value "$file" route)
   [ "$rec" = "$route" ] || return 1
+  if [ "$#" -ge 5 ]; then
+    rec=$(field_value "$file" key)
+    [ "$rec" = "$(one_line "$5")" ] || return 1
+  fi
   return 0
 }
 
@@ -353,6 +357,11 @@ cache_get() {
   meta="$dir/meta.env"
   body="$dir/body"
   [ -f "$meta" ] && [ -f "$body" ] || return 1
+  # The directory name only encodes a CRC32 of the key, so the entry's own
+  # identity fields must agree before its body is served as this key's value.
+  # A mismatched entry is a miss, not an error: it may legitimately belong to
+  # another key, and the caller's fallback key must still be tried.
+  record_matches_key "$meta" "$provider" "$account" "$route" "$key" || return 1
   created=$(field_value "$meta" created_epoch)
   case "$created" in ''|*[!0-9]*) rm -rf "$dir"; return 1 ;; esac
   now=$(now_epoch)
@@ -467,11 +476,7 @@ case "$cmd" in
     # An account read out of an error body is evidence, never the cooldown key:
     # only an explicit, cached, or derived account keys the record, and any
     # other case keys the account-agnostic record that check also consults.
-    if [ -n "$ACCOUNT" ]; then
-      resolve_account "$PROVIDER" || exit $?
-    else
-      resolve_account_or_agnostic "$PROVIDER"
-    fi
+    resolve_account_or_agnostic "$PROVIDER" || exit $?
     RESET_AT=$(printf '%s\n' "$EXTRACTED" | sed -n 's/^reset_at=//p' | tail -1)
     RESET_EPOCH=$(printf '%s\n' "$EXTRACTED" | sed -n 's/^reset_epoch=//p' | tail -1)
     printf 'provider=%s\naccount=%s\nroute=%s\nreset_at=%s\nreset_epoch=%s\n' "$PROVIDER" "$ACCOUNT" "$ROUTE" "$RESET_AT" "$RESET_EPOCH"

--- a/bin/fm-shared-github-quota.sh
+++ b/bin/fm-shared-github-quota.sh
@@ -210,34 +210,43 @@ let account = "";
 }
 // Live gh stderr rarely carries a timestamp: a primary limit reports the reset
 // only through the x-ratelimit-reset header epoch, and a secondary limit only
-// through retry-after seconds. Both labels are accepted, but a bare number
-// never is, so an unlabeled id or epoch still cannot become reset evidence.
+// through retry-after seconds. Both labels are accepted, and the header
+// separator is required so prose like "retry after 15 minutes" - whose number
+// is not seconds - can never be read as a reset. A bare number is never reset
+// evidence, so an unlabeled id or epoch cannot create a cooldown.
 const nowEpoch = Number(process.env.FM_SHARED_QUOTA_NOW || 0) ||
   Math.floor(Date.now() / 1000);
-let ms = NaN;
-let resetAt = "";
-for (const re of [
-  /(20\d\d-\d\d-\d\dT\d\d:\d\d:\d\d(?:\.\d+)?Z)/i,
-  /(20\d\d-\d\d-\d\d[ T]\d\d:\d\d:\d\d\s+UTC)/i,
-]) {
-  const m = text.match(re);
-  if (m) { resetAt = m[1]; break; }
-}
-if (resetAt) {
-  ms = Date.parse(resetAt);
+function scrapedTimestampMs() {
+  let resetAt = "";
+  for (const re of [
+    /(20\d\d-\d\d-\d\dT\d\d:\d\d:\d\d(?:\.\d+)?Z)/i,
+    /(20\d\d-\d\d-\d\d[ T]\d\d:\d\d:\d\d\s+UTC)/i,
+  ]) {
+    const m = text.match(re);
+    if (m) { resetAt = m[1]; break; }
+  }
+  if (!resetAt) return NaN;
+  let ms = Date.parse(resetAt);
   if (!Number.isFinite(ms)) {
     const m = resetAt.match(/^(\d{4}-\d{2}-\d{2})[ T](\d{2}:\d{2}:\d{2})\s+UTC$/i);
     if (m) ms = Date.parse(`${m[1]}T${m[2]}Z`);
   }
+  return ms;
 }
-if (!Number.isFinite(ms)) {
-  const m = text.match(/\bx-rate-?limit-reset\s*[:=]\s*([0-9]{9,})\b/i);
-  if (m) ms = Number(m[1]) * 1000;
+function labeledHeaderMs() {
+  let m = text.match(/\bx-rate-?limit-reset\s*[:=]\s*([0-9]{9,})\b/i);
+  if (m) return Number(m[1]) * 1000;
+  m = text.match(/\bretry[- ]after\s*[:=]\s*([0-9]{1,7})\b/i);
+  if (m) return (nowEpoch + Number(m[1])) * 1000;
+  return NaN;
 }
-if (!Number.isFinite(ms)) {
-  const m = text.match(/\bretry[- ]after\s*[:=]?\s*([0-9]{1,7})\b/i);
-  if (m) ms = (nowEpoch + Number(m[1])) * 1000;
-}
+// A labeled header is the limit's own statement of its reset, while an
+// unlabeled timestamp anywhere in the body is often just a log prefix. Prefer
+// whichever candidate is actually in the future, labeled first, so a stale log
+// timestamp cannot shadow usable header evidence.
+const candidates = [labeledHeaderMs(), scrapedTimestampMs()].filter(Number.isFinite);
+let ms = candidates.find((c) => Math.floor(c / 1000) > nowEpoch);
+if (ms === undefined) ms = candidates.length ? candidates[0] : NaN;
 if (!Number.isFinite(ms)) process.exit(1);
 if (account) console.log(`observed_account=${account}`);
 console.log(`reset_at=${new Date(ms).toISOString().replace(/\.000Z$/, "Z")}`);
@@ -355,6 +364,18 @@ cache_get() {
   cat "$body"
 }
 
+# The deferred read must stay reachable under every key a cooldown for it could
+# have been written under, exactly like check_quota_resolved: an entry cached
+# before any account resolved lives under the account-agnostic key.
+cache_get_resolved() {  # <provider> <account> <route> <key> <max-age>
+  local provider=$1 account=$2 route=$3 key=$4 max_age=$5 status
+  cache_get "$provider" "$account" "$route" "$key" "$max_age" && return 0
+  status=$?
+  [ "$status" = 1 ] || return "$status"
+  [ -n "$account" ] || return 1
+  cache_get "$provider" "" "$route" "$key" "$max_age"
+}
+
 cache_put() {
   local provider=$1 account=$2 route=$3 key=$4 dir now meta_content
   dir=$(cache_dir "$provider" "$account" "$route" "$key")
@@ -463,7 +484,7 @@ case "$cmd" in
     # reachable under exactly the key the cooldown that deferred it was
     # written under, including the account-agnostic one.
     resolve_account_or_agnostic "$PROVIDER" || exit $?
-    cache_get "$PROVIDER" "$ACCOUNT" "$ROUTE" "$KEY" "$MAX_AGE_SECS"
+    cache_get_resolved "$PROVIDER" "$ACCOUNT" "$ROUTE" "$KEY" "$MAX_AGE_SECS"
     ;;
   cache-put)
     [ -n "$KEY" ] || { echo "error: cache-put requires --key" >&2; exit 2; }

--- a/bin/fm-shared-github-quota.sh
+++ b/bin/fm-shared-github-quota.sh
@@ -155,6 +155,14 @@ resolve_account() {  # <provider>
   return 2
 }
 
+# Cooldowns must stay readable by every later reader, so an unresolvable
+# account falls back to one account-agnostic key instead of an unverified
+# identity that no other call would ever reconstruct.
+resolve_account_or_agnostic() {  # <provider>
+  local provider=$1
+  resolve_account "$provider" 2>/dev/null || ACCOUNT=
+}
+
 parse_reset_epoch() {  # <reset-at-or-epoch>
   RESET_RAW=$1 node <<'NODE'
 const raw = (process.env.RESET_RAW || "").trim();
@@ -185,13 +193,13 @@ extract_github_rate_limit() {  # <text>
   FM_GITHUB_QUOTA_TEXT=$1 node <<'NODE'
 const text = process.env.FM_GITHUB_QUOTA_TEXT || "";
 if (!/rate[- ]?limit/i.test(text)) process.exit(1);
+// Only a clearly labeled account id is reported, and it is evidence rather
+// than identity: an unlabeled long number in a rate-limit body is far more
+// often a reset epoch or a repository id than an account.
 let account = "";
-for (const re of [
-  /(?:user|account)(?:\s+id)?\s*[:#]?\s*([0-9]{4,})/i,
-  /\b([0-9]{6,})\b/,
-]) {
-  const m = text.match(re);
-  if (m) { account = m[1]; break; }
+{
+  const m = text.match(/(?:user|account)(?:\s+id)?\s*[:#]?\s*([0-9]{4,})/i);
+  if (m) account = m[1];
 }
 let resetAt = "";
 for (const re of [
@@ -201,21 +209,21 @@ for (const re of [
   const m = text.match(re);
   if (m) { resetAt = m[1]; break; }
 }
-if (!account || !resetAt) process.exit(1);
+if (!resetAt) process.exit(1);
 let ms = Date.parse(resetAt);
 if (!Number.isFinite(ms)) {
   const m = resetAt.match(/^(\d{4}-\d{2}-\d{2})[ T](\d{2}:\d{2}:\d{2})\s+UTC$/i);
   if (m) ms = Date.parse(`${m[1]}T${m[2]}Z`);
 }
 if (!Number.isFinite(ms)) process.exit(1);
-console.log(`account=${account}`);
+if (account) console.log(`observed_account=${account}`);
 console.log(`reset_at=${new Date(ms).toISOString().replace(/\.000Z$/, "Z")}`);
 console.log(`reset_epoch=${Math.floor(ms / 1000)}`);
 NODE
 }
 
 mark_quota() {
-  local provider=$1 account=$2 route=$3 reset_epoch=$4 reset_at=$5 source=$6 file now content
+  local provider=$1 account=$2 route=$3 reset_epoch=$4 reset_at=$5 source=$6 observed=${7:-} file now content
   case "$reset_epoch" in ''|*[!0-9]*) echo "error: reset epoch must be numeric" >&2; return 2 ;; esac
   now=$(now_epoch)
   if [ "$reset_epoch" -le "$now" ]; then
@@ -237,6 +245,8 @@ reset_epoch=$reset_epoch
 source=$(one_line "$source")
 EOF
 )
+  [ -z "$observed" ] || content="$content
+observed_account=$(one_line "$observed")"
   write_atomic "$file" "$content"
   printf '%s\n' "$file"
 }
@@ -266,6 +276,23 @@ check_quota() {
   printf 'state=defer\n'
   cat "$file"
   printf 'remaining_secs=%s\n' "$remaining"
+}
+
+check_quota_resolved() {  # <provider> <account> <route>
+  local provider=$1 account=$2 route=$3 keyed agnostic
+  if [ -z "$account" ]; then
+    check_quota "$provider" "" "$route"
+    return 0
+  fi
+  keyed=$(check_quota "$provider" "$account" "$route")
+  case "$keyed" in
+    state=defer*) printf '%s\n' "$keyed"; return 0 ;;
+  esac
+  agnostic=$(check_quota "$provider" "" "$route")
+  case "$agnostic" in
+    state=defer*) printf '%s\n' "$agnostic"; return 0 ;;
+  esac
+  printf '%s\n' "$keyed"
 }
 
 cache_get() {
@@ -354,8 +381,8 @@ done
 
 case "$cmd" in
   check)
-    resolve_account "$PROVIDER" || exit $?
-    check_quota "$PROVIDER" "$ACCOUNT" "$ROUTE"
+    resolve_account_or_agnostic "$PROVIDER"
+    check_quota_resolved "$PROVIDER" "$ACCOUNT" "$ROUTE"
     ;;
   mark)
     resolve_account "$PROVIDER" || exit $?
@@ -372,21 +399,21 @@ case "$cmd" in
     else
       TEXT=$(cat)
     fi
-    EXTRACTED=$(extract_github_rate_limit "$TEXT") || { echo "error: no GitHub rate-limit reset/account found" >&2; exit 1; }
-    EXTRACTED_ACCOUNT=$(printf '%s\n' "$EXTRACTED" | sed -n 's/^account=//p' | tail -1)
-    # The account scraped out of an error body is a heuristic, never durable
-    # identity: an explicit, cached, or derived account always wins, and the
-    # scraped value is used only as a last resort and never remembered.
+    EXTRACTED=$(extract_github_rate_limit "$TEXT") || { echo "error: no GitHub rate-limit reset found" >&2; exit 1; }
+    OBSERVED_ACCOUNT=$(printf '%s\n' "$EXTRACTED" | sed -n 's/^observed_account=//p' | tail -1)
+    # An account read out of an error body is evidence, never the cooldown key:
+    # only an explicit, cached, or derived account keys the record, and any
+    # other case keys the account-agnostic record that check also consults.
     if [ -n "$ACCOUNT" ]; then
       resolve_account "$PROVIDER" || exit $?
-    elif ! resolve_account "$PROVIDER" 2>/dev/null; then
-      account_valid "$EXTRACTED_ACCOUNT" || { echo "error: --account or FM_GITHUB_ACCOUNT_ID required; could not derive GitHub account id" >&2; exit 2; }
-      ACCOUNT=$EXTRACTED_ACCOUNT
+    else
+      resolve_account_or_agnostic "$PROVIDER"
     fi
     RESET_AT=$(printf '%s\n' "$EXTRACTED" | sed -n 's/^reset_at=//p' | tail -1)
     RESET_EPOCH=$(printf '%s\n' "$EXTRACTED" | sed -n 's/^reset_epoch=//p' | tail -1)
     printf 'provider=%s\naccount=%s\nroute=%s\nreset_at=%s\nreset_epoch=%s\n' "$PROVIDER" "$ACCOUNT" "$ROUTE" "$RESET_AT" "$RESET_EPOCH"
-    mark_quota "$PROVIDER" "$ACCOUNT" "$ROUTE" "$RESET_EPOCH" "$RESET_AT" "$SOURCE" >/dev/null
+    [ -z "$OBSERVED_ACCOUNT" ] || printf 'observed_account=%s\n' "$OBSERVED_ACCOUNT"
+    mark_quota "$PROVIDER" "$ACCOUNT" "$ROUTE" "$RESET_EPOCH" "$RESET_AT" "$SOURCE" "$OBSERVED_ACCOUNT" >/dev/null
     ;;
   cache-get)
     [ -n "$KEY" ] || { echo "error: cache-get requires --key" >&2; exit 2; }

--- a/bin/fm-shared-github-quota.sh
+++ b/bin/fm-shared-github-quota.sh
@@ -160,6 +160,13 @@ resolve_account() {  # <provider>
 # identity that no other call would ever reconstruct.
 resolve_account_or_agnostic() {  # <provider>
   local provider=$1
+  # An explicitly supplied account is caller input: a malformed one is an error
+  # every command reports the same way, never a silent fall back to a different
+  # key. Only a genuinely unresolvable account becomes account-agnostic.
+  if [ -n "$ACCOUNT" ]; then
+    resolve_account "$provider" || return $?
+    return 0
+  fi
   resolve_account "$provider" 2>/dev/null || ACCOUNT=
 }
 

--- a/bin/fm-shared-github-quota.sh
+++ b/bin/fm-shared-github-quota.sh
@@ -3,7 +3,7 @@
 # Usage:
 #   fm-shared-github-quota.sh check [--provider github] [--account <id>] [--route <name>]
 #   fm-shared-github-quota.sh mark [--provider github] [--account <id>] [--route <name>] (--reset-at <iso>|--reset-epoch <n>) [--source <label>]
-#   fm-shared-github-quota.sh mark-from-text [--provider github] [--route <name>] [--source <label>] [--file <path>]
+#   fm-shared-github-quota.sh mark-from-text [--provider github] [--account <id>] [--route <name>] [--source <label>] [--file <path>]
 #   fm-shared-github-quota.sh cache-get --key <key> [--provider github] [--account <id>] [--route <name>] [--max-age-secs <n>]
 #   fm-shared-github-quota.sh cache-put --key <key> [--provider github] [--account <id>] [--route <name>]
 #
@@ -53,6 +53,12 @@ cache_dir() {  # <provider> <account> <route> <key>
   printf '%s/cache/%s-%s\n' "$root" "$(safe_fragment "$provider")" "$hash"
 }
 
+account_file() {  # <provider>
+  local root provider=$1
+  root=$(shared_state_root)
+  printf '%s/accounts/%s.env\n' "$root" "$(safe_fragment "$provider")"
+}
+
 write_atomic() {  # <path> <content>
   local path=$1 content=$2 dir tmp old_umask
   dir=$(dirname "$path")
@@ -79,6 +85,73 @@ write_stdin_atomic() {  # <path>
 
 one_line() {
   printf '%s' "$1" | tr '\n\r\t' '   ' | sed 's/[[:cntrl:]]//g'
+}
+
+field_value() {  # <file> <field>
+  sed -n "s/^$2=//p" "$1" 2>/dev/null | tail -1
+}
+
+account_valid() {
+  case "$1" in
+    ''|*[!A-Za-z0-9_.@:-]*) return 1 ;;
+  esac
+}
+
+remember_account() {  # <provider> <account> <source>
+  local provider=$1 account=$2 source=$3 file now content
+  account_valid "$account" || return 1
+  file=$(account_file "$provider")
+  now=$(now_epoch)
+  content=$(cat <<EOF
+schema=fm-shared-github-account.v1
+provider=$provider
+account=$account
+source=$(one_line "$source")
+updated_at=$(iso_now)
+updated_epoch=$now
+EOF
+)
+  write_atomic "$file" "$content"
+}
+
+cached_account() {  # <provider>
+  local provider=$1 file account
+  file=$(account_file "$provider")
+  [ -f "$file" ] || return 1
+  account=$(field_value "$file" account)
+  account_valid "$account" || return 1
+  printf '%s\n' "$account"
+}
+
+derive_account() {  # <provider>
+  local provider=$1 account
+  [ "$provider" = github ] || return 1
+  command -v gh >/dev/null 2>&1 || return 1
+  account=$(GH_PROMPT_DISABLED=1 GH_NO_UPDATE_NOTIFIER=1 gh api user --jq .id 2>/dev/null) || return 1
+  account_valid "$account" || return 1
+  printf '%s\n' "$account"
+}
+
+resolve_account() {  # <provider>
+  local provider=$1 account
+  if [ -n "$ACCOUNT" ]; then
+    account_valid "$ACCOUNT" || { echo "error: invalid GitHub account id" >&2; return 2; }
+    remember_account "$provider" "$ACCOUNT" env >/dev/null 2>&1 || true
+    return 0
+  fi
+  account=$(cached_account "$provider" 2>/dev/null || true)
+  if [ -n "$account" ]; then
+    ACCOUNT=$account
+    return 0
+  fi
+  account=$(derive_account "$provider" 2>/dev/null || true)
+  if [ -n "$account" ]; then
+    ACCOUNT=$account
+    remember_account "$provider" "$ACCOUNT" derived >/dev/null 2>&1 || true
+    return 0
+  fi
+  echo "error: --account or FM_GITHUB_ACCOUNT_ID required; could not derive GitHub account id" >&2
+  return 2
 }
 
 parse_reset_epoch() {  # <reset-at-or-epoch>
@@ -138,10 +211,6 @@ console.log(`account=${account}`);
 console.log(`reset_at=${new Date(ms).toISOString().replace(/\.000Z$/, "Z")}`);
 console.log(`reset_epoch=${Math.floor(ms / 1000)}`);
 NODE
-}
-
-field_value() {  # <file> <field>
-  sed -n "s/^$2=//p" "$1" 2>/dev/null | tail -1
 }
 
 mark_quota() {
@@ -248,7 +317,7 @@ cmd=${1:-}
 shift || true
 
 PROVIDER=github
-ACCOUNT=${FM_GITHUB_ACCOUNT_ID:-94498628}
+ACCOUNT=${FM_GITHUB_ACCOUNT_ID:-}
 ROUTE=${FM_GITHUB_ROUTE:-default}
 RESET_AT=
 RESET_EPOCH=
@@ -284,9 +353,11 @@ done
 
 case "$cmd" in
   check)
+    resolve_account "$PROVIDER" || exit $?
     check_quota "$PROVIDER" "$ACCOUNT" "$ROUTE"
     ;;
   mark)
+    resolve_account "$PROVIDER" || exit $?
     if [ -z "$RESET_EPOCH" ]; then
       [ -n "$RESET_AT" ] || { echo "error: mark requires --reset-at or --reset-epoch" >&2; exit 2; }
       RESET_EPOCH=$(parse_reset_epoch "$RESET_AT") || { echo "error: could not parse --reset-at" >&2; exit 2; }
@@ -301,7 +372,9 @@ case "$cmd" in
       TEXT=$(cat)
     fi
     EXTRACTED=$(extract_github_rate_limit "$TEXT") || { echo "error: no GitHub rate-limit reset/account found" >&2; exit 1; }
-    ACCOUNT=$(printf '%s\n' "$EXTRACTED" | sed -n 's/^account=//p' | tail -1)
+    EXTRACTED_ACCOUNT=$(printf '%s\n' "$EXTRACTED" | sed -n 's/^account=//p' | tail -1)
+    [ -n "$ACCOUNT" ] || ACCOUNT=$EXTRACTED_ACCOUNT
+    resolve_account "$PROVIDER" || exit $?
     RESET_AT=$(printf '%s\n' "$EXTRACTED" | sed -n 's/^reset_at=//p' | tail -1)
     RESET_EPOCH=$(printf '%s\n' "$EXTRACTED" | sed -n 's/^reset_epoch=//p' | tail -1)
     printf 'provider=%s\naccount=%s\nroute=%s\nreset_at=%s\nreset_epoch=%s\n' "$PROVIDER" "$ACCOUNT" "$ROUTE" "$RESET_AT" "$RESET_EPOCH"
@@ -309,10 +382,12 @@ case "$cmd" in
     ;;
   cache-get)
     [ -n "$KEY" ] || { echo "error: cache-get requires --key" >&2; exit 2; }
+    resolve_account "$PROVIDER" || exit $?
     cache_get "$PROVIDER" "$ACCOUNT" "$ROUTE" "$KEY" "$MAX_AGE_SECS"
     ;;
   cache-put)
     [ -n "$KEY" ] || { echo "error: cache-put requires --key" >&2; exit 2; }
+    resolve_account "$PROVIDER" || exit $?
     cache_put "$PROVIDER" "$ACCOUNT" "$ROUTE" "$KEY"
     ;;
   *)

--- a/bin/fm-shared-github-quota.sh
+++ b/bin/fm-shared-github-quota.sh
@@ -1,0 +1,323 @@
+#!/usr/bin/env bash
+# Coordinate fleet-wide GitHub API quota and cached gh-heavy reads.
+# Usage:
+#   fm-shared-github-quota.sh check [--provider github] [--account <id>] [--route <name>]
+#   fm-shared-github-quota.sh mark [--provider github] [--account <id>] [--route <name>] (--reset-at <iso>|--reset-epoch <n>) [--source <label>]
+#   fm-shared-github-quota.sh mark-from-text [--provider github] [--route <name>] [--source <label>] [--file <path>]
+#   fm-shared-github-quota.sh cache-get --key <key> [--provider github] [--account <id>] [--route <name>] [--max-age-secs <n>]
+#   fm-shared-github-quota.sh cache-put --key <key> [--provider github] [--account <id>] [--route <name>]
+#
+# Shared state is intentionally home-independent.
+# Override with FM_SHARED_STATE_OVERRIDE in tests or unusual deployments.
+set -eu
+
+default_shared_state() {
+  printf '%s/firstmate\n' "${XDG_STATE_HOME:-$HOME/.local/state}"
+}
+
+shared_state_root() {
+  printf '%s/shared-github-quota\n' "${FM_SHARED_STATE_OVERRIDE:-${FM_SHARED_STATE:-$(default_shared_state)}}"
+}
+
+now_epoch() {
+  if [ -n "${FM_SHARED_QUOTA_NOW_EPOCH:-}" ]; then
+    printf '%s\n' "$FM_SHARED_QUOTA_NOW_EPOCH"
+  else
+    date +%s
+  fi
+}
+
+iso_now() {
+  node -e 'console.log(new Date().toISOString())'
+}
+
+safe_fragment() {
+  printf '%s' "$1" | tr -c 'A-Za-z0-9_.@:-' '_'
+}
+
+hash_key() {
+  printf '%s\t%s\t%s\t%s' "$1" "$2" "$3" "${4:-}" | cksum | awk '{print $1}'
+}
+
+quota_file() {  # <provider> <account> <route>
+  local root provider=$1 account=$2 route=$3 hash
+  root=$(shared_state_root)
+  hash=$(hash_key "$provider" "$account" "$route")
+  printf '%s/cooldowns/%s-%s.env\n' "$root" "$(safe_fragment "$provider")" "$hash"
+}
+
+cache_dir() {  # <provider> <account> <route> <key>
+  local root provider=$1 account=$2 route=$3 key=$4 hash
+  root=$(shared_state_root)
+  hash=$(hash_key "$provider" "$account" "$route" "$key")
+  printf '%s/cache/%s-%s\n' "$root" "$(safe_fragment "$provider")" "$hash"
+}
+
+write_atomic() {  # <path> <content>
+  local path=$1 content=$2 dir tmp old_umask
+  dir=$(dirname "$path")
+  mkdir -p "$dir"
+  old_umask=$(umask)
+  umask 077
+  tmp=$(mktemp "$dir/.tmp.XXXXXXXX") || { umask "$old_umask"; return 1; }
+  umask "$old_umask"
+  printf '%s\n' "$content" > "$tmp"
+  mv "$tmp" "$path"
+}
+
+write_stdin_atomic() {  # <path>
+  local path=$1 dir tmp old_umask
+  dir=$(dirname "$path")
+  mkdir -p "$dir"
+  old_umask=$(umask)
+  umask 077
+  tmp=$(mktemp "$dir/.tmp.XXXXXXXX") || { umask "$old_umask"; return 1; }
+  umask "$old_umask"
+  cat > "$tmp"
+  mv "$tmp" "$path"
+}
+
+one_line() {
+  printf '%s' "$1" | tr '\n\r\t' '   ' | sed 's/[[:cntrl:]]//g'
+}
+
+parse_reset_epoch() {  # <reset-at-or-epoch>
+  RESET_RAW=$1 node <<'NODE'
+const raw = (process.env.RESET_RAW || "").trim();
+if (/^[0-9]+$/.test(raw)) {
+  console.log(raw);
+  process.exit(0);
+}
+let s = raw;
+let ms = Date.parse(s);
+if (!Number.isFinite(ms)) {
+  const m = raw.match(/^(\d{4}-\d{2}-\d{2})[ T](\d{2}:\d{2}:\d{2})\s+UTC$/i);
+  if (m) ms = Date.parse(`${m[1]}T${m[2]}Z`);
+}
+if (!Number.isFinite(ms)) process.exit(1);
+console.log(Math.floor(ms / 1000));
+NODE
+}
+
+epoch_to_iso() {  # <epoch>
+  RESET_EPOCH=$1 node <<'NODE'
+const epoch = Number(process.env.RESET_EPOCH || 0);
+if (!Number.isFinite(epoch) || epoch <= 0) process.exit(1);
+console.log(new Date(epoch * 1000).toISOString().replace(/\.000Z$/, "Z"));
+NODE
+}
+
+extract_github_rate_limit() {  # <text>
+  FM_GITHUB_QUOTA_TEXT=$1 node <<'NODE'
+const text = process.env.FM_GITHUB_QUOTA_TEXT || "";
+if (!/rate[- ]?limit/i.test(text)) process.exit(1);
+let account = "";
+for (const re of [
+  /(?:user|account)(?:\s+id)?\s*[:#]?\s*([0-9]{4,})/i,
+  /\b([0-9]{6,})\b/,
+]) {
+  const m = text.match(re);
+  if (m) { account = m[1]; break; }
+}
+let resetAt = "";
+for (const re of [
+  /(20\d\d-\d\d-\d\dT\d\d:\d\d:\d\d(?:\.\d+)?Z)/i,
+  /(20\d\d-\d\d-\d\d[ T]\d\d:\d\d:\d\d\s+UTC)/i,
+]) {
+  const m = text.match(re);
+  if (m) { resetAt = m[1]; break; }
+}
+if (!account || !resetAt) process.exit(1);
+let ms = Date.parse(resetAt);
+if (!Number.isFinite(ms)) {
+  const m = resetAt.match(/^(\d{4}-\d{2}-\d{2})[ T](\d{2}:\d{2}:\d{2})\s+UTC$/i);
+  if (m) ms = Date.parse(`${m[1]}T${m[2]}Z`);
+}
+if (!Number.isFinite(ms)) process.exit(1);
+console.log(`account=${account}`);
+console.log(`reset_at=${new Date(ms).toISOString().replace(/\.000Z$/, "Z")}`);
+console.log(`reset_epoch=${Math.floor(ms / 1000)}`);
+NODE
+}
+
+field_value() {  # <file> <field>
+  sed -n "s/^$2=//p" "$1" 2>/dev/null | tail -1
+}
+
+mark_quota() {
+  local provider=$1 account=$2 route=$3 reset_epoch=$4 reset_at=$5 source=$6 file now content
+  case "$reset_epoch" in ''|*[!0-9]*) echo "error: reset epoch must be numeric" >&2; return 2 ;; esac
+  now=$(now_epoch)
+  if [ "$reset_epoch" -le "$now" ]; then
+    echo "error: reset epoch is not in the future" >&2
+    return 2
+  fi
+  file=$(quota_file "$provider" "$account" "$route")
+  content=$(cat <<EOF
+schema=fm-shared-github-quota.v1
+provider=$provider
+account=$account
+route=$route
+class=quota
+reason=github_rate_limit
+created_at=$(iso_now)
+created_epoch=$now
+reset_at=$reset_at
+reset_epoch=$reset_epoch
+source=$(one_line "$source")
+EOF
+)
+  write_atomic "$file" "$content"
+  printf '%s\n' "$file"
+}
+
+check_quota() {
+  local provider=$1 account=$2 route=$3 file reset_epoch now remaining
+  file=$(quota_file "$provider" "$account" "$route")
+  if [ ! -f "$file" ]; then
+    printf 'state=allow\nprovider=%s\naccount=%s\nroute=%s\n' "$provider" "$account" "$route"
+    return 0
+  fi
+  reset_epoch=$(field_value "$file" reset_epoch)
+  case "$reset_epoch" in
+    ''|*[!0-9]*)
+      rm -f "$file"
+      printf 'state=allow\nprovider=%s\naccount=%s\nroute=%s\nexpired_record=invalid\n' "$provider" "$account" "$route"
+      return 0
+      ;;
+  esac
+  now=$(now_epoch)
+  if [ "$reset_epoch" -le "$now" ]; then
+    rm -f "$file"
+    printf 'state=allow\nprovider=%s\naccount=%s\nroute=%s\nexpired_reset_epoch=%s\n' "$provider" "$account" "$route" "$reset_epoch"
+    return 0
+  fi
+  remaining=$((reset_epoch - now))
+  printf 'state=defer\n'
+  cat "$file"
+  printf 'remaining_secs=%s\n' "$remaining"
+}
+
+cache_get() {
+  local provider=$1 account=$2 route=$3 key=$4 max_age=$5 dir meta body created now age
+  case "$max_age" in ''|*[!0-9]*) echo "error: --max-age-secs must be numeric" >&2; return 2 ;; esac
+  dir=$(cache_dir "$provider" "$account" "$route" "$key")
+  meta="$dir/meta.env"
+  body="$dir/body"
+  [ -f "$meta" ] && [ -f "$body" ] || return 1
+  created=$(field_value "$meta" created_epoch)
+  case "$created" in ''|*[!0-9]*) rm -rf "$dir"; return 1 ;; esac
+  now=$(now_epoch)
+  age=$((now - created))
+  if [ "$age" -gt "$max_age" ]; then
+    rm -rf "$dir"
+    return 1
+  fi
+  cat "$body"
+}
+
+cache_put() {
+  local provider=$1 account=$2 route=$3 key=$4 dir now meta_content
+  dir=$(cache_dir "$provider" "$account" "$route" "$key")
+  now=$(now_epoch)
+  mkdir -p "$dir"
+  write_stdin_atomic "$dir/body"
+  meta_content=$(cat <<EOF
+schema=fm-shared-github-cache.v1
+provider=$provider
+account=$account
+route=$route
+key=$(one_line "$key")
+created_at=$(iso_now)
+created_epoch=$now
+EOF
+)
+  write_atomic "$dir/meta.env" "$meta_content"
+}
+
+usage() {
+  sed -n '2,10p' "$0" >&2
+}
+
+need_value() {
+  [ "$#" -gt 1 ] || { echo "error: $1 requires a value" >&2; exit 2; }
+}
+
+cmd=${1:-}
+[ -n "$cmd" ] || { usage; exit 2; }
+shift || true
+
+PROVIDER=github
+ACCOUNT=${FM_GITHUB_ACCOUNT_ID:-94498628}
+ROUTE=${FM_GITHUB_ROUTE:-default}
+RESET_AT=
+RESET_EPOCH=
+SOURCE=manual
+FILE=
+KEY=
+MAX_AGE_SECS=60
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --provider) need_value "$@"; PROVIDER=$2; shift 2 ;;
+    --provider=*) PROVIDER=${1#--provider=}; shift ;;
+    --account) need_value "$@"; ACCOUNT=$2; shift 2 ;;
+    --account=*) ACCOUNT=${1#--account=}; shift ;;
+    --route) need_value "$@"; ROUTE=$2; shift 2 ;;
+    --route=*) ROUTE=${1#--route=}; shift ;;
+    --reset-at) need_value "$@"; RESET_AT=$2; shift 2 ;;
+    --reset-at=*) RESET_AT=${1#--reset-at=}; shift ;;
+    --reset-epoch) need_value "$@"; RESET_EPOCH=$2; shift 2 ;;
+    --reset-epoch=*) RESET_EPOCH=${1#--reset-epoch=}; shift ;;
+    --source) need_value "$@"; SOURCE=$2; shift 2 ;;
+    --source=*) SOURCE=${1#--source=}; shift ;;
+    --file) need_value "$@"; FILE=$2; shift 2 ;;
+    --file=*) FILE=${1#--file=}; shift ;;
+    --key) need_value "$@"; KEY=$2; shift 2 ;;
+    --key=*) KEY=${1#--key=}; shift ;;
+    --max-age-secs) need_value "$@"; MAX_AGE_SECS=$2; shift 2 ;;
+    --max-age-secs=*) MAX_AGE_SECS=${1#--max-age-secs=}; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "error: unknown argument $1" >&2; usage; exit 2 ;;
+  esac
+done
+
+case "$cmd" in
+  check)
+    check_quota "$PROVIDER" "$ACCOUNT" "$ROUTE"
+    ;;
+  mark)
+    if [ -z "$RESET_EPOCH" ]; then
+      [ -n "$RESET_AT" ] || { echo "error: mark requires --reset-at or --reset-epoch" >&2; exit 2; }
+      RESET_EPOCH=$(parse_reset_epoch "$RESET_AT") || { echo "error: could not parse --reset-at" >&2; exit 2; }
+    fi
+    [ -n "$RESET_AT" ] || RESET_AT=$(epoch_to_iso "$RESET_EPOCH")
+    mark_quota "$PROVIDER" "$ACCOUNT" "$ROUTE" "$RESET_EPOCH" "$RESET_AT" "$SOURCE"
+    ;;
+  mark-from-text)
+    if [ -n "$FILE" ]; then
+      TEXT=$(cat "$FILE")
+    else
+      TEXT=$(cat)
+    fi
+    EXTRACTED=$(extract_github_rate_limit "$TEXT") || { echo "error: no GitHub rate-limit reset/account found" >&2; exit 1; }
+    ACCOUNT=$(printf '%s\n' "$EXTRACTED" | sed -n 's/^account=//p' | tail -1)
+    RESET_AT=$(printf '%s\n' "$EXTRACTED" | sed -n 's/^reset_at=//p' | tail -1)
+    RESET_EPOCH=$(printf '%s\n' "$EXTRACTED" | sed -n 's/^reset_epoch=//p' | tail -1)
+    printf 'provider=%s\naccount=%s\nroute=%s\nreset_at=%s\nreset_epoch=%s\n' "$PROVIDER" "$ACCOUNT" "$ROUTE" "$RESET_AT" "$RESET_EPOCH"
+    mark_quota "$PROVIDER" "$ACCOUNT" "$ROUTE" "$RESET_EPOCH" "$RESET_AT" "$SOURCE" >/dev/null
+    ;;
+  cache-get)
+    [ -n "$KEY" ] || { echo "error: cache-get requires --key" >&2; exit 2; }
+    cache_get "$PROVIDER" "$ACCOUNT" "$ROUTE" "$KEY" "$MAX_AGE_SECS"
+    ;;
+  cache-put)
+    [ -n "$KEY" ] || { echo "error: cache-put requires --key" >&2; exit 2; }
+    cache_put "$PROVIDER" "$ACCOUNT" "$ROUTE" "$KEY"
+    ;;
+  *)
+    echo "error: unknown command '$cmd'" >&2
+    usage
+    exit 2
+    ;;
+esac

--- a/bin/fm-shared-github-quota.sh
+++ b/bin/fm-shared-github-quota.sh
@@ -374,8 +374,15 @@ case "$cmd" in
     fi
     EXTRACTED=$(extract_github_rate_limit "$TEXT") || { echo "error: no GitHub rate-limit reset/account found" >&2; exit 1; }
     EXTRACTED_ACCOUNT=$(printf '%s\n' "$EXTRACTED" | sed -n 's/^account=//p' | tail -1)
-    [ -n "$ACCOUNT" ] || ACCOUNT=$EXTRACTED_ACCOUNT
-    resolve_account "$PROVIDER" || exit $?
+    # The account scraped out of an error body is a heuristic, never durable
+    # identity: an explicit, cached, or derived account always wins, and the
+    # scraped value is used only as a last resort and never remembered.
+    if [ -n "$ACCOUNT" ]; then
+      resolve_account "$PROVIDER" || exit $?
+    elif ! resolve_account "$PROVIDER" 2>/dev/null; then
+      account_valid "$EXTRACTED_ACCOUNT" || { echo "error: --account or FM_GITHUB_ACCOUNT_ID required; could not derive GitHub account id" >&2; exit 2; }
+      ACCOUNT=$EXTRACTED_ACCOUNT
+    fi
     RESET_AT=$(printf '%s\n' "$EXTRACTED" | sed -n 's/^reset_at=//p' | tail -1)
     RESET_EPOCH=$(printf '%s\n' "$EXTRACTED" | sed -n 's/^reset_epoch=//p' | tail -1)
     printf 'provider=%s\naccount=%s\nroute=%s\nreset_at=%s\nreset_epoch=%s\n' "$PROVIDER" "$ACCOUNT" "$ROUTE" "$RESET_AT" "$RESET_EPOCH"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1093,7 +1093,13 @@ META_WINDOW=$T
     echo "home=$PROJ_ABS"
     echo "projects=$SECONDMATE_PROJECTS"
   fi
-} > "$STATE/$ID.meta"
+} > "$STATE/$ID.meta" || {
+  # Checked explicitly: stock macOS bash 3.2 does not honor `set -e` for a
+  # redirection failure on a compound command, so an unwritable meta path would
+  # otherwise silently continue into launch with no durable task record.
+  echo "error: failed to write task metadata $STATE/$ID.meta" >&2
+  exit 1
+}
 [ "$BACKEND" = orca ] && ORCA_ABORT_CLEANUP=0
 
 sq_brief=$(fm_launch_shell_quote "$BRIEF")

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -74,6 +74,9 @@
 #   secondmate receives the primary's read-only shared captain-preference file
 #   (fm-config-inherit-lib.sh). A successful launch clears pending inherited
 #   config reread generations because the new agent reads the converged files.
+#   config/capacity-failover is inert by default. When it contains
+#   `host-pressure=on`, spawn runs the bounded host-pressure preflight from
+#   fm-host-pressure.sh and refuses only critical memory/disk/concurrency pressure.
 #   --scout records kind=scout in the task's meta (report deliverable, scratch worktree;
 #   see AGENTS.md task lifecycle); --secondmate records kind=secondmate and launches in a
 #   provisioned firstmate home; the default is kind=ship.
@@ -134,6 +137,8 @@ SUB_HOME_MARKER=".fm-secondmate-home"
 . "$SCRIPT_DIR/fm-gate-refuse-lib.sh"
 # shellcheck source=bin/fm-pr-lib.sh
 . "$SCRIPT_DIR/fm-pr-lib.sh"
+# shellcheck source=bin/fm-harness-launch-lib.sh
+. "$SCRIPT_DIR/fm-harness-launch-lib.sh"
 # Fail closed before any fleet mutation: a no-mistakes gate agent must never spawn
 # a direct report (see bin/fm-gate-refuse-lib.sh).
 fm_refuse_if_gate_agent
@@ -404,47 +409,12 @@ else
 fi
 [ -z "$HARNESS_ARG" ] || ARG3=$HARNESS_ARG
 
-# The verified launch command per adapter. The knowledge half of each adapter
-# (busy signature, exit command, dialogs, quirks) lives in the harness-adapters skill.
 launch_template() {
-  local harness=$1 kind=${2:-ship}
-  # shellcheck disable=SC2016  # single quotes are deliberate: $(cat ...) expands in the crewmate pane, not here
-  case "$harness" in
-    # CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false disables claude's interactive
-    # predicted-next-prompt ghost text, which renders as dim/faint text inside an
-    # otherwise-empty composer and would otherwise read like real typed input when
-    # firstmate captures the pane (see the harness-adapters skill). It is a per-launch env
-    # prefix scoped to this firstmate-launched agent; it never touches the captain's
-    # global config. The CLI's --prompt-suggestions flag is print/SDK-mode only and
-    # does NOT suppress the interactive ghost text (verified empirically), so the env
-    # var is the correct control. The dim-aware composer reader in fm-tmux-lib.sh is
-    # the defense-in-depth backstop for any pane this flag cannot reach.
-    claude) printf '%s' 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions __MODELFLAG____EFFORTFLAG__"$(cat __BRIEF__)"' ;;
-    codex)
-      if [ "$kind" = secondmate ]; then
-        printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox "$(cat __BRIEF__)"'
-      else
-        printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch __TURNEND__\"]" "$(cat __BRIEF__)"'
-      fi
-      ;;
-    opencode) printf '%s' 'OPENCODE_CONFIG_CONTENT='\''{"permission":{"*":"allow"}}'\'' opencode __MODELFLAG__--prompt "$(cat __BRIEF__)"' ;;
-    pi)
-      if [ "$kind" = secondmate ]; then
-        printf '%s' 'pi __MODELFLAG____EFFORTFLAG__-e __PITURNEND__ -e __PIWATCH__ "$(cat __BRIEF__)"'
-      else
-        printf '%s' 'pi __MODELFLAG____EFFORTFLAG__-e __PIEXT__ "$(cat __BRIEF__)"'
-      fi
-      ;;
-    # grok (Grok Build TUI): a positional prompt starts the supervised interactive
-    # session. --always-approve auto-approves every tool execution (verified: the
-    # crewmate runs fully autonomously, no permission gate), which an unattended
-    # crewmate needs; it is the targeted equivalent of claude's
-    # --dangerously-skip-permissions. grok's turn-end signal does NOT ride the
-    # launch command - it is a Stop-event hook installed below (global hook +
-    # per-task pointer), so the template is identical for ship/scout/secondmate.
-    grok) printf '%s' 'grok --always-approve __MODELFLAG____EFFORTFLAG__"$(cat __BRIEF__)"' ;;
-    *) return 1 ;;
-  esac
+  fm_launch_template "$@"
+}
+
+shell_quote() {
+  fm_launch_shell_quote "$@"
 }
 
 case "$ARG3" in
@@ -520,63 +490,45 @@ secondmate_registry_value() {
   printf '%s\n' "$value"
 }
 
-shell_quote() {
-  printf "'"
-  printf '%s' "$1" | sed "s/'/'\\\\''/g"
-  printf "'"
-}
-
 model_flag_for_harness() {
-  local harness=$1 model=$2
-  [ -n "$model" ] && [ "$model" != default ] || return 0
-  case "$harness" in
-    claude|codex|opencode|pi|grok)
-      printf -- '--model %s ' "$(shell_quote "$model")"
-      ;;
-  esac
+  fm_launch_model_flag_for_harness "$@"
 }
 
 effort_flag_for_harness() {
-  local harness=$1 effort=$2
-  [ -n "$effort" ] && [ "$effort" != default ] || return 0
-  case "$harness" in
-    claude)
-      case "$effort" in
-        low|medium|high|xhigh|max) printf -- '--effort %s ' "$(shell_quote "$effort")" ;;
-      esac
-      ;;
-    codex)
-      # The installed codex config schema uses model_reasoning_effort, and the
-      # bundled model catalog advertises low|medium|high|xhigh. Omit max rather
-      # than passing an unsupported value.
-      case "$effort" in
-        low|medium|high|xhigh) printf -- '-c %s ' "$(shell_quote "model_reasoning_effort=\"$effort\"")" ;;
-      esac
-      ;;
-    grok)
-      # grok exposes both --effort and --reasoning-effort; firstmate's profile
-      # axis is the reasoning knob. As of grok 0.2.99, --reasoning-effort accepts
-      # only low|medium|high and rejects both xhigh and max, so omit those rather
-      # than passing a known-bad value.
-      case "$effort" in
-        low|medium|high) printf -- '--reasoning-effort %s ' "$(shell_quote "$effort")" ;;
-      esac
-      ;;
-    pi)
-      # Pi 0.80.6 accepts the full shared effort vocabulary, including max, through
-      # its --thinking flag.
-      case "$effort" in
-        low|medium|high|xhigh|max) printf -- '--thinking %s ' "$(shell_quote "$effort")" ;;
-      esac
-      ;;
-    # opencode's interactive `opencode --prompt` launch has a verified --model
-    # flag but no verified effort flag. Its `opencode run --variant` flag belongs
-    # to a different, non-interactive launch mode, so fm-spawn does not pass it.
-  esac
+  fm_launch_effort_flag_for_harness "$@"
 }
 
-json_escape() {
-  printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+capacity_failover_pressure_check() {
+  local cfg out status pressure_state
+  cfg="$CONFIG/capacity-failover"
+  [ -f "$cfg" ] || return 0
+
+  if out=$("$SCRIPT_DIR/fm-host-pressure.sh" gate --kind spawn --config "$cfg" --home "$FM_HOME" --state "$STATE" 2>&1); then
+    status=0
+  else
+    status=$?
+  fi
+
+  pressure_state=$(printf '%s\n' "$out" | sed -n 's/^state=//p' | tail -1)
+  case "$pressure_state" in
+    off|ok|'')
+      ;;
+    warn)
+      echo "warning: capacity failover host-pressure warning before spawning $ID; continuing" >&2
+      printf '%s\n' "$out" >&2
+      ;;
+    critical)
+      printf '%s\n' "$out" >&2
+      echo "error: capacity failover host-pressure backpressure refused spawn of $ID; existing task ownership is preserved" >&2
+      exit 1
+      ;;
+  esac
+
+  if [ "$status" -ne 0 ]; then
+    printf '%s\n' "$out" >&2
+    echo "error: capacity failover host-pressure check failed before spawning $ID" >&2
+    exit "$status"
+  fi
 }
 
 resolved_existing_dir() {
@@ -697,6 +649,8 @@ if [ "$KIND" = secondmate ]; then
     FIRSTMATE_HOME=$(secondmate_registry_value "$ID" home || true)
   fi
 fi
+
+capacity_failover_pressure_check
 
 if [ "$KIND" = secondmate ]; then
   [ -n "$FIRSTMATE_HOME" ] || { echo "error: no firstmate home supplied or registered for $ID" >&2; exit 1; }
@@ -1096,102 +1050,7 @@ mkdir -p "$TASK_TMP/gotmp"
 mkdir -p "$STATE"
 STATE_REAL=$(cd "$STATE" && pwd -P)
 TURNEND="$STATE_REAL/$ID.turn-ended"
-exclude_path() {
-  local rel=$1 EXCL
-  EXCL=$(git -C "$WT" rev-parse --git-path info/exclude 2>/dev/null || true)
-  [ -n "$EXCL" ] || return 0
-  mkdir -p "$(dirname "$EXCL")"
-  grep -qxF "$rel" "$EXCL" 2>/dev/null || echo "$rel" >> "$EXCL"
-}
-if [ "$KIND" != secondmate ]; then
-  case "$HARNESS" in
-    claude*)
-      mkdir -p "$WT/.claude"
-      cat > "$WT/.claude/settings.local.json" <<EOF
-{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"touch '$TURNEND'"}]}]}}
-EOF
-      exclude_path '.claude/settings.local.json'
-      ;;
-    opencode*)
-      mkdir -p "$WT/.opencode/plugins"
-      cat > "$WT/.opencode/plugins/fm-turn-end.js" <<EOF
-export const FmTurnEnd = async ({ \$ }) => ({
-  event: async ({ event }) => {
-    if (event.type === "session.idle") await \$\`touch $TURNEND\`
-  },
-})
-EOF
-      exclude_path '.opencode/plugins/fm-turn-end.js'
-      ;;
-    pi*)
-      # Written OUTSIDE the worktree: pi's project-trust gate fires on any extension
-      # loaded from inside the project (verified live), but an explicit -e path
-      # elsewhere loads without a dialog. Lives in state/, cleaned by teardown.
-      cat > "$STATE/$ID.pi-ext.ts" <<EOF
-// Firstmate turn-end signal; written by fm-spawn.
-// Use "turn_end" (fires after each turn the agent finishes), not "agent_end"
-// (fires once, only when the whole run exits): the watcher needs a signal at
-// every turn boundary so an idle crewmate is surfaced, not just at shutdown.
-import { execFile } from "node:child_process";
-export default function (pi: any) {
-  pi.on("turn_end", () => execFile("touch", ["$TURNEND"]));
-}
-EOF
-      ;;
-    codex*)
-      # codex: turn-end rides the launch command via -c notify=[...] and __TURNEND__.
-      ;;
-    grok*)
-      # grok fires a Stop hook at every turn boundary (verified, grok 0.2.73), the
-      # clean equivalent of codex's notify= and pi's turn_end. But grok only loads
-      # PROJECT hooks (<worktree>/.grok/hooks/, <worktree>/.claude/settings.local.json)
-      # after the folder is granted hook-trust, which is not automatic and which
-      # firstmate cannot establish at launch without editing grok's own managed
-      # trust store (a high-blast-radius write). GLOBAL hooks in ~/.grok/hooks/ are
-      # always trusted and load on first launch with no gate. So the turn-end hook
-      # lives OUTSIDE the worktree as a single firstmate-owned global hook that is a
-      # guarded no-op for every non-firstmate grok session: it fires only when the
-      # current workspace holds a .fm-grok-turnend token pointer that matches the
-      # firstmate-owned hook registry. firstmate then drops that per-task pointer
-      # (gitignored, like the other harnesses' worktree hook files).
-      # Result: the hook is outside the worktree, needs no trust grant, and never
-      # touches grok's managed config - only firstmate-owned files.
-      GROK_HOOKS_DIR="${GROK_HOME:-$HOME/.grok}/hooks"
-      GROK_AUTH_DIR="$GROK_HOOKS_DIR/fm-turn-end.d"
-      mkdir -p "$GROK_AUTH_DIR"
-      old_umask=$(umask)
-      umask 077
-      auth_file=$(mktemp "$GROK_AUTH_DIR/fm.XXXXXXXXXXXX")
-      umask "$old_umask"
-      printf '%s\n' "$TURNEND" > "$auth_file"
-      printf '%s\n' "${auth_file##*/}" > "$STATE/$ID.grok-turnend-token"
-      sq_grok_auth_dir=$(shell_quote "$GROK_AUTH_DIR")
-      cat > "$GROK_HOOKS_DIR/fm-turn-end.sh" <<EOF
-#!/usr/bin/env bash
-set -u
-auth_dir=$sq_grok_auth_dir
-workspace=\${GROK_WORKSPACE_ROOT:-}
-[ -n "\$workspace" ] || exit 0
-p="\$workspace/.fm-grok-turnend"
-[ -f "\$p" ] || exit 0
-first=
-IFS= read -r -n 256 first < "\$p" 2>/dev/null || [ -n "\$first" ] || exit 0
-case "\$first" in token=*) token=\${first#token=} ;; *) exit 0 ;; esac
-case "\$token" in fm.????????????) : ;; *) exit 0 ;; esac
-case "\$token" in *[!A-Za-z0-9._-]*) exit 0 ;; esac
-t=\$(cat "\$auth_dir/\$token" 2>/dev/null) || exit 0
-case "\$t" in /*.turn-ended) : ;; *) exit 0 ;; esac
-touch "\$t" 2>/dev/null || true
-exit 0
-EOF
-      chmod +x "$GROK_HOOKS_DIR/fm-turn-end.sh"
-      hook_command=$(json_escape "bash $(shell_quote "$GROK_HOOKS_DIR/fm-turn-end.sh")")
-      printf '{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"%s"}]}]}}\n' "$hook_command" > "$GROK_HOOKS_DIR/fm-turn-end.json"
-      printf 'token=%s\n' "${auth_file##*/}" > "$WT/.fm-grok-turnend"
-      exclude_path '.fm-grok-turnend'
-      ;;
-  esac
-fi
+fm_launch_install_turn_end_hook "$HARNESS" "$KIND" "$WT" "$STATE" "$ID" "$TURNEND" "$PROJ_ABS"
 
 # Per-project delivery mode + yolo flag (bin/fm-project-mode.sh; the project-management skill and AGENTS.md task lifecycle).
 # Recorded in meta so fm-teardown's safety check and the validate/merge stages can

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1035,7 +1035,7 @@ mkdir -p "$TASK_TMP/gotmp"
 mkdir -p "$STATE"
 STATE_REAL=$(cd "$STATE" && pwd -P)
 TURNEND="$STATE_REAL/$ID.turn-ended"
-fm_launch_install_turn_end_hook "$HARNESS" "$KIND" "$WT" "$STATE" "$ID" "$TURNEND" "$PROJ_ABS"
+fm_launch_install_turn_end_hook "$HARNESS" "$KIND" "$WT" "$STATE" "$ID" "$TURNEND"
 
 # Per-project delivery mode + yolo flag (bin/fm-project-mode.sh; the project-management skill and AGENTS.md task lifecycle).
 # Recorded in meta so fm-teardown's safety check and the validate/merge stages can

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -92,7 +92,8 @@
 #   and scout batches. The loop lives here, in bash, so callers never hand-write a
 #   multi-task shell loop (the tool shell is zsh, which does not word-split unquoted
 #   $vars and silently breaks ad-hoc `for ... in $pairs` loops).
-#   Launch templates live in launch_template() below; placeholders replaced before launch:
+#   Launch templates live in fm_launch_template() in bin/fm-harness-launch-lib.sh;
+#   placeholders replaced before launch:
 #     __BRIEF__    absolute path to data/<task-id>/brief.md
 #     __TURNEND__  absolute path to state/<task-id>.turn-ended (for harnesses whose
 #                  turn-end signal rides the launch command, e.g. codex -c notify=[...])
@@ -409,14 +410,6 @@ else
 fi
 [ -z "$HARNESS_ARG" ] || ARG3=$HARNESS_ARG
 
-launch_template() {
-  fm_launch_template "$@"
-}
-
-shell_quote() {
-  fm_launch_shell_quote "$@"
-}
-
 case "$ARG3" in
   *' '*)  # raw launch command (unverified-adapter escape hatch)
     LAUNCH=$ARG3
@@ -432,7 +425,7 @@ case "$ARG3" in
     # active. Resolving here on every spawn is what makes the split DURABLE - a
     # respawn (recovery, /updatefirstmate, restart) re-resolves, so
     # config/secondmate-harness keeps governing secondmate launches across restarts.
-    # The launch_template lookup below is the unverified-adapter guard for both
+    # The fm_launch_template lookup below is the unverified-adapter guard for both
     # kinds: a harness with no template aborts the spawn.
     if [ "$KIND" = secondmate ]; then
       HARNESS=$("$FM_ROOT/bin/fm-harness.sh" secondmate)
@@ -445,11 +438,11 @@ case "$ARG3" in
       HARNESS=$("$FM_ROOT/bin/fm-harness.sh" crew)
       harness_src='config/crew-harness'
     fi
-    LAUNCH=$(launch_template "$HARNESS" "$KIND") || { echo "error: no launch template for harness '$HARNESS' (from $harness_src or detection); pass a raw launch command to use an unverified adapter" >&2; exit 1; }
+    LAUNCH=$(fm_launch_template "$HARNESS" "$KIND") || { echo "error: no launch template for harness '$HARNESS' (from $harness_src or detection); pass a raw launch command to use an unverified adapter" >&2; exit 1; }
     ;;
   *)
     HARNESS=$ARG3
-    LAUNCH=$(launch_template "$HARNESS" "$KIND") || { echo "error: unknown harness '$HARNESS'; pass a raw launch command to use an unverified adapter" >&2; exit 1; }
+    LAUNCH=$(fm_launch_template "$HARNESS" "$KIND") || { echo "error: unknown harness '$HARNESS'; pass a raw launch command to use an unverified adapter" >&2; exit 1; }
     ;;
 esac
 
@@ -488,14 +481,6 @@ secondmate_registry_value() {
   esac
   [ -n "$value" ] || return 1
   printf '%s\n' "$value"
-}
-
-model_flag_for_harness() {
-  fm_launch_model_flag_for_harness "$@"
-}
-
-effort_flag_for_harness() {
-  fm_launch_effort_flag_for_harness "$@"
 }
 
 capacity_failover_pressure_check() {
@@ -1111,13 +1096,13 @@ META_WINDOW=$T
 } > "$STATE/$ID.meta"
 [ "$BACKEND" = orca ] && ORCA_ABORT_CLEANUP=0
 
-sq_brief=$(shell_quote "$BRIEF")
-sq_turnend=$(shell_quote "$TURNEND")
-sq_piext=$(shell_quote "$STATE/$ID.pi-ext.ts")
-sq_piturnend=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-turnend-guard.ts")
-sq_piwatch=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-pi-watch.ts")
-MODELFLAG=$(model_flag_for_harness "$HARNESS" "$MODEL")
-EFFORTFLAG=$(effort_flag_for_harness "$HARNESS" "$EFFORT")
+sq_brief=$(fm_launch_shell_quote "$BRIEF")
+sq_turnend=$(fm_launch_shell_quote "$TURNEND")
+sq_piext=$(fm_launch_shell_quote "$STATE/$ID.pi-ext.ts")
+sq_piturnend=$(fm_launch_shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-turnend-guard.ts")
+sq_piwatch=$(fm_launch_shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-pi-watch.ts")
+MODELFLAG=$(fm_launch_model_flag_for_harness "$HARNESS" "$MODEL")
+EFFORTFLAG=$(fm_launch_effort_flag_for_harness "$HARNESS" "$EFFORT")
 LAUNCH=${LAUNCH//__MODELFLAG__/$MODELFLAG}
 LAUNCH=${LAUNCH//__EFFORTFLAG__/$EFFORTFLAG}
 LAUNCH=${LAUNCH//__BRIEF__/$sq_brief}
@@ -1126,7 +1111,7 @@ LAUNCH=${LAUNCH//__PIEXT__/$sq_piext}
 LAUNCH=${LAUNCH//__PITURNEND__/$sq_piturnend}
 LAUNCH=${LAUNCH//__PIWATCH__/$sq_piwatch}
 if [ "$KIND" = secondmate ]; then
-  sq_home=$(shell_quote "$PROJ_ABS")
+  sq_home=$(fm_launch_shell_quote "$PROJ_ABS")
   LAUNCH="FM_ROOT_OVERRIDE= FM_STATE_OVERRIDE= FM_DATA_OVERRIDE= FM_PROJECTS_OVERRIDE= FM_CONFIG_OVERRIDE= FM_HOME=$sq_home $LAUNCH"
 fi
 # Export GOTMPDIR into the crewmate's pane shell so the agent and every child

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -21,6 +21,10 @@
 # by itself causes a false refusal of landed work.
 # A gh lookup error falls back to the content check; if that is also inconclusive,
 # teardown refuses rather than risk discarding unlanded work.
+# A known shared GitHub cooldown (bin/fm-shared-github-quota.sh) skips the PR
+# lookups entirely for the same reason, leaving the content check as the only
+# proof; a gh failure on that path also records the observed rate-limit evidence
+# for the rest of the fleet (docs/capacity-failover.md).
 # Uncommitted changes are never landed.
 # local-only projects additionally accept work merged into the local default
 # branch (firstmate performs that merge after configured approval) as a fallback

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -269,7 +269,8 @@ remove_pr_poll_artifacts() {
 
 github_quota_deferred() {
   local out state
-  out=$("$SCRIPT_DIR/fm-shared-github-quota.sh" check --provider github --route "$GITHUB_ROUTE" 2>/dev/null || true)
+  out=$(FM_SHARED_GITHUB_QUOTA_DERIVE_ACCOUNT=0 \
+    "$SCRIPT_DIR/fm-shared-github-quota.sh" check --provider github --route "$GITHUB_ROUTE" 2>/dev/null || true)
   state=$(printf '%s\n' "$out" | sed -n 's/^state=//p' | tail -1)
   [ "$state" = defer ]
 }

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -96,7 +96,6 @@ DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
 SECONDMATE_REG="$DATA/secondmates.md"
 SUB_HOME_MARKER=".fm-secondmate-home"
-GITHUB_ACCOUNT=${FM_GITHUB_ACCOUNT_ID:-94498628}
 GITHUB_ROUTE=${FM_GITHUB_ROUTE:-default}
 # shellcheck source=bin/fm-tasks-axi-lib.sh
 . "$SCRIPT_DIR/fm-tasks-axi-lib.sh"
@@ -270,9 +269,15 @@ remove_pr_poll_artifacts() {
 
 github_quota_deferred() {
   local out state
-  out=$("$SCRIPT_DIR/fm-shared-github-quota.sh" check --provider github --account "$GITHUB_ACCOUNT" --route "$GITHUB_ROUTE" 2>/dev/null || true)
+  out=$("$SCRIPT_DIR/fm-shared-github-quota.sh" check --provider github --route "$GITHUB_ROUTE" 2>/dev/null || true)
   state=$(printf '%s\n' "$out" | sed -n 's/^state=//p' | tail -1)
   [ "$state" = defer ]
+}
+
+mark_github_quota_from_file() {
+  local source=$1 file=$2
+  "$SCRIPT_DIR/fm-shared-github-quota.sh" mark-from-text --provider github --route "$GITHUB_ROUTE" \
+    --source "$source" --file "$file" >/dev/null 2>&1 || true
 }
 
 # Resolve the PR number for a worktree branch via gh-axi. Echoes the number on a
@@ -352,7 +357,7 @@ EOF
 # current work is not contained in the PR head, no PR is found, or any gh error
 # occurs - the caller then falls back to the content check.
 pr_is_merged() {
-  local branch=$1 target view state head current
+  local branch=$1 target view state head current gh_err
   github_quota_deferred && return 1
   if [ -n "$PR_URL" ]; then
     target=$PR_URL
@@ -360,7 +365,13 @@ pr_is_merged() {
     target=$(pr_number_from_branch "$branch") || return 1
   fi
   [ -n "$target" ] || return 1
-  view=$(cd "$WT" && gh pr view "$target" --json state,headRefOid -q '.state + "\t" + .headRefOid' 2>/dev/null) || return 1
+  gh_err=$(mktemp "${TMPDIR:-/tmp}/fm-gh-teardown-pr.XXXXXXXX") || return 1
+  if ! view=$(cd "$WT" && gh pr view "$target" --json state,headRefOid -q '.state + "\t" + .headRefOid' 2>"$gh_err"); then
+    mark_github_quota_from_file "fm-teardown:$ID pr_is_merged" "$gh_err"
+    rm -f "$gh_err"
+    return 1
+  fi
+  rm -f "$gh_err"
   state=${view%%$'\t'*}
   head=${view#*$'\t'}
   [ "$state" != "$view" ] || return 1

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -96,6 +96,8 @@ DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
 SECONDMATE_REG="$DATA/secondmates.md"
 SUB_HOME_MARKER=".fm-secondmate-home"
+GITHUB_ACCOUNT=${FM_GITHUB_ACCOUNT_ID:-94498628}
+GITHUB_ROUTE=${FM_GITHUB_ROUTE:-default}
 # shellcheck source=bin/fm-tasks-axi-lib.sh
 . "$SCRIPT_DIR/fm-tasks-axi-lib.sh"
 # shellcheck source=bin/fm-backend.sh
@@ -266,12 +268,20 @@ remove_pr_poll_artifacts() {
   fi
 }
 
+github_quota_deferred() {
+  local out state
+  out=$("$SCRIPT_DIR/fm-shared-github-quota.sh" check --provider github --account "$GITHUB_ACCOUNT" --route "$GITHUB_ROUTE" 2>/dev/null || true)
+  state=$(printf '%s\n' "$out" | sed -n 's/^state=//p' | tail -1)
+  [ "$state" = defer ]
+}
+
 # Resolve the PR number for a worktree branch via gh-axi. Echoes the number on a
 # single match and returns 0; returns non-zero on no match or any lookup failure,
 # so the caller treats it as "no PR found" (fail-safe).
 pr_number_from_branch() {
   local branch=$1 out n
   [ -n "$branch" ] && [ "$branch" != HEAD ] || return 1
+  github_quota_deferred && return 1
   out=$( cd "$WT" && gh-axi pr list --state all --head "$branch" --limit 1 2>/dev/null ) || return 1
   n=$(printf '%s\n' "$out" | sed -n 's/^[[:space:]]*\([0-9][0-9]*\),.*/\1/p' | head -1)
   [ -n "$n" ] || return 1
@@ -343,6 +353,7 @@ EOF
 # occurs - the caller then falls back to the content check.
 pr_is_merged() {
   local branch=$1 target view state head current
+  github_quota_deferred && return 1
   if [ -n "$PR_URL" ]; then
     target=$PR_URL
   else

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -277,7 +277,8 @@ github_quota_deferred() {
 
 mark_github_quota_from_file() {
   local source=$1 file=$2
-  "$SCRIPT_DIR/fm-shared-github-quota.sh" mark-from-text --provider github --route "$GITHUB_ROUTE" \
+  FM_SHARED_GITHUB_QUOTA_DERIVE_ACCOUNT=0 \
+    "$SCRIPT_DIR/fm-shared-github-quota.sh" mark-from-text --provider github --route "$GITHUB_ROUTE" \
     --source "$source" --file "$file" >/dev/null 2>&1 || true
 }
 

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -159,7 +159,7 @@ default_branch() {
 
 meta_value() {
   local meta=$1 key=$2
-  fm_meta_get "$meta" "$key"
+  fm_meta_get "$meta" "$key" || true
 }
 
 require_orca_worktree_id() {

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -45,6 +45,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
 mkdir -p "$STATE"
 
 # shellcheck source=bin/fm-wake-lib.sh
@@ -112,6 +113,7 @@ HEARTBEAT=${FM_HEARTBEAT:-600}        # base seconds between heartbeat scans
 HEARTBEAT_MAX=${FM_HEARTBEAT_MAX:-7200}  # heartbeat backoff cap
 CHECK_INTERVAL=${FM_CHECK_INTERVAL:-300}  # seconds between *.check.sh sweeps
 CHECK_TIMEOUT=${FM_CHECK_TIMEOUT:-30}     # seconds allowed per *.check.sh
+HOST_PRESSURE_INTERVAL=${FM_HOST_PRESSURE_INTERVAL:-300}  # seconds between opt-in disk-pressure alerts
 SIGNAL_GRACE=${FM_SIGNAL_GRACE:-30}   # seconds to linger after a signal so trailing
                                       # signals (a status write, then the same turn's
                                       # turn-end hook) coalesce into one wake
@@ -536,6 +538,15 @@ run_check_capture() {
   fm_check_output_cleanup
 }
 
+run_host_pressure_alert() {
+  local cfg out
+  cfg="$CONFIG/capacity-failover"
+  [ -f "$cfg" ] || return 0
+  out=$("$SCRIPT_DIR/fm-host-pressure.sh" periodic-alert --config "$cfg" --home "$FM_HOME" --state "$STATE" 2>/dev/null || true)
+  [ -n "$out" ] || return 0
+  printf '%s\n' "$out"
+}
+
 # Surfaced-marker bookkeeping for the heartbeat backstop. The watcher records the
 # captain-relevant status line it SURFACED (woke firstmate for) in
 # .hb-surfaced-<task>, the watcher's analogue of the daemon's
@@ -821,6 +832,19 @@ while :; do
       wake "$reason"
     fi
     touch "$STATE/.last-check"
+  fi
+
+  # Opt-in host-pressure alerting: config/capacity-failover with host-pressure=on
+  # may emit a bounded disk-floor alert. It never kills work or mutates task owner
+  # metadata; the helper's own cooldown/hysteresis markers prevent alert flapping.
+  if [ "$(age_of "$STATE/.last-host-pressure-alert")" -ge "$HOST_PRESSURE_INTERVAL" ]; then
+    out=$(run_host_pressure_alert)
+    touch "$STATE/.last-host-pressure-alert"
+    if [ -n "$out" ]; then
+      reason="check: host-pressure: $out"
+      fm_wake_append check host-pressure "$reason" || exit 1
+      wake "$reason"
+    fi
   fi
 
   # On the first changed signal, linger one grace period and re-scan before

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,7 +9,7 @@ firstmate's always-loaded operating contract and routing index for conditional p
 ## Event-driven supervision
 
 A zero-token bash watcher (`bin/fm-watch.sh`) sleeps on the fleet, classifies detected wakes in bash, and wakes the first mate only when something is actionable.
-Actionable wakes include captain-relevant status signals, no-verb signals whose crew is not provably working, authenticated check output such as PR merge polling or an X-mode mention, stale panes whose crew is not provably working whether their status log looks terminal or non-terminal, provably-working stale panes that persist past `FM_STALE_ESCALATE_SECS`, declared external waits that remain paused past `FM_PAUSE_RESURFACE_SECS`, and heartbeat backstop hits.
+Actionable wakes include captain-relevant status signals, no-verb signals whose crew is not provably working, authenticated check output such as PR merge polling, an X-mode mention, or an opt-in host-pressure alert, stale panes whose crew is not provably working whether their status log looks terminal or non-terminal, provably-working stale panes that persist past `FM_STALE_ESCALATE_SECS`, declared external waits that remain paused past `FM_PAUSE_RESURFACE_SECS`, and heartbeat backstop hits.
 Repeated provably-working stale escalations on the same unchanged pane add an escalation count to the wake reason and, at `FM_WEDGE_DEMAND_INSPECT_COUNT`, a `demand-deep-inspection` marker.
 Those actionable wakes are written to a durable local queue (`state/.wake-queue`) before detector state advances, so a missed process exit can be recovered by draining the queue.
 No-verb wakes, such as `working:` notes and bare turn-ended signals, are benign only when `bin/fm-crew-state.sh` reports positive evidence that the crew is still working: an actively running no-mistakes step attributed to that crew's current code or a backend busy signature.
@@ -139,6 +139,16 @@ When the file exists, `fm-spawn.sh` refuses crewmate and scout launches without 
 Secondmate launches are exempt because they resolve the secondmate harness and any optional secondmate model or effort tokens instead.
 Unsupported effort values are still recorded in task meta when passed to `fm-spawn.sh`, but the launch template omits any effort flag that the selected harness does not accept.
 That keeps spawn launch compatible across claude, codex, grok, pi, and opencode while preserving the requested profile for later audit.
+The verified launch templates themselves live in `bin/fm-harness-launch-lib.sh`, shared by `fm-spawn.sh` and the manual rehome helper so both launch a harness exactly the same way.
+
+## Optional capacity failover
+
+Quota walls, auth exhaustion, and host pressure have a passive substrate that changes nothing until a home opts in with `config/capacity-failover`.
+`bin/fm-capacity-classify.sh` turns observed wall text into `quota`, `auth`, or `other` with an observed reset when the text carries one, `bin/fm-capacity-cooldown.sh` records the resulting per-harness cooldowns under `state/capacity-cooldowns/`, and `bin/fm-capacity-route.sh` selects a verified route that is not cooling down or prints the exact escalation evidence instead.
+`bin/fm-rehome-quota-wall.sh` is the manual same-worktree relaunch path for a wedged tmux task: it never picks a harness itself, refuses to relaunch while the old agent may still be alive, and preserves the task id, worktree, branch, and recorded PR metadata.
+With `host-pressure=on`, `fm-spawn.sh` runs a bounded memory/disk/active-task preflight and refuses only critical pressure, and the watcher surfaces a bounded disk-pressure alert as an ordinary check wake.
+Independently of any home, `bin/fm-shared-github-quota.sh` records fleet-wide GitHub cooldowns so the PR pollers, merge helper, teardown proofs, and bearings PR view defer to cached reads or a structured refusal instead of hammering a rate-limited account.
+[`docs/capacity-failover.md`](capacity-failover.md) owns the signatures, record formats, thresholds, and the opposite-harness constraint that keeps cross-harness review lanes from collapsing onto one harness.
 
 ## Optional secondmates
 

--- a/docs/capacity-failover.md
+++ b/docs/capacity-failover.md
@@ -92,7 +92,7 @@ It is passive unless `config/capacity-failover` contains `host-pressure=on`.
 When that opt-in is present, `fm-spawn.sh` runs the check before creating task ownership metadata.
 Warnings are surfaced and the spawn continues.
 Critical pressure refuses the new spawn and leaves existing task ownership untouched.
-`bin/fm-host-pressure.sh gate --kind test` gives the same disk-floor decision to validation/test launch wrappers.
+`bin/fm-host-pressure.sh gate --kind test` returns that same full memory, disk, and active-task verdict, available to future validation/test launch wrappers; the kind is recorded as `gate_kind=` and never narrows the decision.
 
 The file supports these optional thresholds:
 

--- a/docs/capacity-failover.md
+++ b/docs/capacity-failover.md
@@ -123,12 +123,15 @@ Its state is intentionally independent of any one `FM_HOME`.
 By default it uses `${XDG_STATE_HOME:-$HOME/.local/state}/firstmate/shared-github-quota/`; tests and unusual deployments can set `FM_SHARED_STATE_OVERRIDE`.
 
 Cooldown records are keyed by `(provider, account, route)`.
-The account comes from `--account`, `FM_GITHUB_ACCOUNT_ID`, a locally cached account learned from prior rate-limit evidence, or a best-effort `gh api user` derivation.
+The account comes from `--account`, `FM_GITHUB_ACCOUNT_ID`, a locally cached account, or a best-effort `gh api user` derivation.
+An account id read out of a rate-limit body is evidence only: it is recorded as `observed_account=` and never keys a record or replaces the cached account.
+When no account resolves, `mark-from-text` writes one account-agnostic record, and `check` consults that record in addition to the keyed one, so a cooldown observed before any account is known is still read back.
 `mark` and `mark-from-text` write the cooldown.
 `check` prints `state=allow` or `state=defer` with provider, account, route, reset time, and remaining seconds.
 Expired records are removed by `check`, so polling resumes only at or after the recorded reset time.
 
 `fm-pr-check.sh` uses this guard when it records PR metadata and in the static `fm-pr-poll.sh` poller.
+Those read-only guard checks, and the one in `fm-teardown.sh`, set `FM_SHARED_GITHUB_QUOTA_DERIVE_ACCOUNT=0` so the guard never spends a GitHub API call of its own.
 During a shared cooldown, PR pollers do not call `gh`.
 They return silence unless a cached PR state already proves `MERGED`; that preserves local ownership and avoids repeated wake spam while GitHub is cooling down.
 When no cooldown is active, the poller keeps the existing live `gh pr view` behavior and refreshes the small cache after a successful read.

--- a/docs/capacity-failover.md
+++ b/docs/capacity-failover.md
@@ -1,0 +1,126 @@
+# Capacity Failover Substrate
+
+This document records the passive capacity/failover substrate added from the 2026-07-12 evidence pass.
+It does not define a standing dispatch policy.
+It does not enable automatic account rotation.
+It does not change `fm-spawn.sh` or `fm-dispatch-select.sh` while `config/capacity-failover` is absent.
+It does not clean disk or kill agents.
+
+## Evidence Scope
+
+The implemented signatures are only the observed ones.
+Codex quota walls are recognized from `usage limit` text that carries an observed reset such as `resets 2:42PT` or `try again at 11:41 PM`.
+Claude quota walls are recognized from `session limit` text that carries an observed reset such as `session limit, resets 10:50pm PT`.
+VibeProxy auth exhaustion is recognized from `auth_unavailable: no auth available (providers=..., model=...)`.
+Explicit provider rate limits are recognized from `rate limit`, `too many requests`, or HTTP 429 text.
+`Retry-After: <seconds>` is treated as observed reset evidence.
+Login-required output such as `Not logged in - Please run /login` is recognized as auth exhaustion.
+Unknown model and transient provider throttles classify as `other`, not quota.
+
+## Classification
+
+`bin/fm-capacity-classify.sh` reads failure text from stdin or `--file`.
+It prints key-value lines with `class=quota|auth|other` and a stable `reason=`.
+When the text includes an observed reset time, it also prints `reset_at=`, `reset_epoch=`, and `cooldown_ttl_secs=`.
+The helper is intentionally conservative.
+It does not invent reset times or cooldown TTLs for auth failures.
+
+## Cooldown Records
+
+`bin/fm-capacity-cooldown.sh` writes records under `state/capacity-cooldowns/`.
+The key is the tuple `(harness, account, profile)`.
+`account` may be empty when the account is unknown or not exposed.
+Records carry no tokens or secrets.
+They store `reset_epoch=`, the classification class and reason, the selected harness/profile/account labels, and an optional source task id.
+Auth exhaustion records created by `bin/fm-capacity-route.sh handle-wall` use `reset_epoch=manual` with `requires_action=interactive_auth_required`.
+That is a durable manual block, not an invented TTL.
+
+Use `mark` when the caller already has a reset epoch or explicit TTL.
+Use `mark-from-text` when the observed wall text includes a parseable reset.
+Use `active` to read a live cooldown and get `remaining_secs=`.
+Expired records are removed by `active`.
+
+## Route Selection
+
+`bin/fm-capacity-route.sh` is the conservative route helper for quota/auth walls.
+It is deterministic and does not change standing dispatch by itself.
+Routes are read from `config/capacity-failover` unless `--routes-file` is passed.
+
+Route lines use this format:
+
+```text
+route=<harness>|<account-or-provider>|<profile>|<model>|<effort>
+```
+
+Selection skips routes with active cooldown or manual auth-exhaustion records.
+It refuses unverified harnesses.
+When `config/crew-dispatch.json` exists, it refuses route selection unless the caller passes `--dispatch-approved` after consulting the dispatch rules.
+
+`handle-wall` classifies wall text, records the current route block, then either prints a same-owner `fm-rehome-quota-wall.sh` command for the next verified route with headroom or prints an escalation.
+The escalation includes the exhausted harness, account/provider, model/profile, reset epoch when known, and any required interactive auth/account action.
+The helper never creates a new task id and never discards dirty work.
+
+## Rehome Helper
+
+`bin/fm-rehome-quota-wall.sh <task-id> --harness <verified-harness>` performs the manual same-worktree rehome procedure used for quota-wedged work.
+The helper currently supports only the evidence-backed tmux path.
+It refuses non-tmux task metadata instead of guessing a backend-specific recovery path.
+
+The helper requires a clean worktree by default.
+Use `--force-dirty` only when the operator intentionally accepts relaunching with uncommitted changes present.
+It attempts to preserve task identity by keeping the same `state/<id>.meta`, `data/<id>/`, worktree, branch, and recorded `pr=` / `pr_head=` lines.
+It writes a `data/<id>/rehome-<timestamp>.md` continuation brief and launches the new harness against that brief.
+The continuation brief explicitly tells the replacement agent not to create a helper branch, helper task id, or child PR.
+
+When the old endpoint still reports a live agent process, the helper sends `/exit` and waits for a confirmed dead agent before killing the endpoint container.
+If liveness remains `alive` or is `unknown`, the helper refuses to relaunch.
+This fail-closed behavior prevents duplicate task ownership.
+
+## Dispatch Backstop
+
+The rehome helper never chooses a harness.
+The caller must pass a verified target harness explicitly.
+When `config/crew-dispatch.json` exists, the helper refuses unless `--dispatch-approved` is also passed.
+That flag means firstmate has already consulted the dispatch rules and is not letting the helper bypass them.
+
+## Host Pressure Backpressure
+
+`bin/fm-host-pressure.sh check` reports bounded memory, disk, and active-task pressure as key-value evidence.
+It is passive unless `config/capacity-failover` contains `host-pressure=on`.
+When that opt-in is present, `fm-spawn.sh` runs the check before creating task ownership metadata.
+Warnings are surfaced and the spawn continues.
+Critical pressure refuses the new spawn and leaves existing task ownership untouched.
+`bin/fm-host-pressure.sh gate --kind test` gives the same disk-floor decision to validation/test launch wrappers.
+
+The file supports these optional thresholds:
+
+```text
+host-pressure=on
+min_memory_available_mb=2048
+warn_memory_available_mb=4096
+disk_floor_mb=10240
+disk_clear_mb=20480
+disk_alert_cooldown_secs=900
+max_running_tasks=30
+```
+
+The default thresholds above apply only after `host-pressure=on`.
+`disk_floor_mb` is the hard floor.
+Once entered, disk pressure remains active until free space reaches `disk_clear_mb`; this hysteresis prevents repeated enter/exit flapping.
+Absent `config/capacity-failover`, or with `host-pressure` off, spawn behavior is unchanged.
+Disk pressure output reports safe transient cleanup candidates such as `/tmp/fm-*` and local firstmate logs.
+The helper never deletes those candidates.
+`classify-shed --command <line>` only marks restartable validation/test/lint commands as eligible restartable compute.
+It does not kill those processes; callers own any stop/retry policy.
+`periodic-alert` emits a bounded disk-pressure alert for supervision and applies its own cooldown marker.
+
+## Opposite-Harness Constraint
+
+Adversarial review lanes can add this line to their task meta:
+
+```text
+opposite_harness_must_differ_from=<harness>
+```
+
+`fm-rehome-quota-wall.sh` and future automatic failover code must refuse any candidate harness equal to that value.
+This preserves the cross-harness review property that a reviewer must not collapse onto the same harness as the author lane.

--- a/docs/capacity-failover.md
+++ b/docs/capacity-failover.md
@@ -115,6 +115,7 @@ The helper never deletes those candidates.
 `classify-shed --command <line>` only marks restartable validation/test/lint commands as eligible restartable compute.
 It does not kill those processes; callers own any stop/retry policy.
 `periodic-alert` emits a bounded disk-pressure alert for supervision and applies its own cooldown marker.
+A refused (malformed) `config/capacity-failover` is reported as `alert=host_pressure_config_invalid` under its own marker with a fixed one-hour cooldown, so a broken threshold is surfaced once per window instead of on every watcher cycle; a changed refusal message re-alerts immediately.
 
 ## Shared GitHub Quota
 

--- a/docs/capacity-failover.md
+++ b/docs/capacity-failover.md
@@ -121,15 +121,15 @@ Its state is intentionally independent of any one `FM_HOME`.
 By default it uses `${XDG_STATE_HOME:-$HOME/.local/state}/firstmate/shared-github-quota/`; tests and unusual deployments can set `FM_SHARED_STATE_OVERRIDE`.
 
 Cooldown records are keyed by `(provider, account, route)`.
-For the 2026-07-13 incident the provider/account key is `github` / `94498628`, with reset evidence `2026-07-13T02:23:23Z`.
+The account comes from `--account`, `FM_GITHUB_ACCOUNT_ID`, a locally cached account learned from prior rate-limit evidence, or a best-effort `gh api user` derivation.
 `mark` and `mark-from-text` write the cooldown.
 `check` prints `state=allow` or `state=defer` with provider, account, route, reset time, and remaining seconds.
 Expired records are removed by `check`, so polling resumes only at or after the recorded reset time.
 
-`fm-pr-check.sh` uses this guard when it records PR metadata and in the generated `state/<id>.check.sh` poller.
-During a shared cooldown, generated PR pollers do not call `gh`.
+`fm-pr-check.sh` uses this guard when it records PR metadata and in the static `fm-pr-poll.sh` poller.
+During a shared cooldown, PR pollers do not call `gh`.
 They return silence unless a cached PR state already proves `MERGED`; that preserves local ownership and avoids repeated wake spam while GitHub is cooling down.
-When no cooldown is active, the generated poller keeps the existing live `gh pr view` behavior and refreshes the small cache after a successful read.
+When no cooldown is active, the poller keeps the existing live `gh pr view` behavior and refreshes the small cache after a successful read.
 
 `fm-pr-merge.sh` refuses an explicit merge during a known shared cooldown.
 That refusal is a structured escalation naming the provider, account, route, reset time, attempted operation, and required action.

--- a/docs/capacity-failover.md
+++ b/docs/capacity-failover.md
@@ -126,16 +126,17 @@ Cooldown records are keyed by `(provider, account, route)`.
 The account comes from `--account`, `FM_GITHUB_ACCOUNT_ID`, a locally cached account, or a best-effort `gh api user` derivation.
 An account id read out of a rate-limit body is evidence only: it is recorded as `observed_account=` and never keys a record or replaces the cached account.
 When no account resolves, `mark-from-text` writes one account-agnostic record, and `check` consults that record in addition to the keyed one, so a cooldown observed before any account is known is still read back.
-`cache-get` and `cache-put` follow the same key policy, so a cached read stays reachable under the key its cooldown was written under.
+`cache-put` writes under the resolved key, and `cache-get` consults the account-agnostic entry in addition to the keyed one exactly as `check` does, so a read cached before any account was known stays reachable afterwards.
 `mark` and `mark-from-text` write the cooldown.
 `mark-from-text` accepts the reset forms real `gh` stderr carries: an ISO-8601 or `UTC` timestamp, a labeled `x-ratelimit-reset: <epoch>` header from a primary limit, or a labeled `Retry-After: <seconds>` from a secondary limit.
+The labeled header separator is required, so prose such as `retry after 15 minutes` is not read as seconds, and a labeled header is preferred over an unlabeled timestamp that is already in the past, so a log-line timestamp cannot shadow real header evidence.
 A bare number is never reset evidence, so an unlabeled id or epoch in an error body cannot create a cooldown.
 `check` prints `state=allow` or `state=defer` with provider, account, route, reset time, and remaining seconds.
 Because a record's path only encodes a hash of its key, a record whose own `provider=`/`account=`/`route=` fields disagree with the key it was found under is reported as `state=allow` with `mismatched_record=1` and left in place; capacity cooldowns apply the same rule to `harness=`/`account=`/`profile=`.
 Expired records are removed by `check`, so polling resumes only at or after the recorded reset time.
 
 `fm-pr-check.sh` uses this guard when it records PR metadata and in the static `fm-pr-poll.sh` poller.
-Those read-only guard checks, and the one in `fm-teardown.sh`, set `FM_SHARED_GITHUB_QUOTA_DERIVE_ACCOUNT=0` so the guard never spends a GitHub API call of its own.
+Every guard call on those paths - the checks, the cached reads and writes, and the `mark-from-text` handlers in `fm-pr-check.sh`, `fm-pr-poll.sh`, `fm-pr-merge.sh`, and `fm-teardown.sh` - sets `FM_SHARED_GITHUB_QUOTA_DERIVE_ACCOUNT=0`, so the guard never spends a GitHub API call of its own and one key policy holds across the whole path.
 During a shared cooldown, PR pollers do not call `gh`.
 They return silence unless a cached PR state already proves `MERGED`; that preserves local ownership and avoids repeated wake spam while GitHub is cooling down.
 When no cooldown is active, the poller keeps the existing live `gh pr view` behavior and refreshes the small cache after a successful read.

--- a/docs/capacity-failover.md
+++ b/docs/capacity-failover.md
@@ -100,6 +100,8 @@ The file supports these optional thresholds:
 host-pressure=on
 min_memory_available_mb=2048
 warn_memory_available_mb=4096
+min_disk_available_mb=10240
+warn_disk_available_mb=20480
 disk_floor_mb=10240
 disk_clear_mb=20480
 disk_alert_cooldown_secs=900
@@ -107,6 +109,7 @@ max_running_tasks=30
 ```
 
 The default thresholds above apply only after `host-pressure=on`.
+`disk_floor_mb` defaults to `min_disk_available_mb`, and `disk_clear_mb` defaults to `warn_disk_available_mb` raised to at least the floor, so setting only the `min_`/`warn_` pair still yields a coherent floor and clear point.
 `disk_floor_mb` is the hard floor.
 Once entered, disk pressure remains active until free space reaches `disk_clear_mb`; this hysteresis prevents repeated enter/exit flapping.
 Absent `config/capacity-failover`, or with `host-pressure` off, spawn behavior is unchanged.
@@ -115,7 +118,9 @@ The helper never deletes those candidates.
 `classify-shed --command <line>` only marks restartable validation/test/lint commands as eligible restartable compute.
 It does not kill those processes; callers own any stop/retry policy.
 `periodic-alert` emits a bounded disk-pressure alert for supervision and applies its own cooldown marker.
-A refused (malformed) `config/capacity-failover` is reported as `alert=host_pressure_config_invalid` under its own marker with a fixed one-hour cooldown, so a broken threshold is surfaced once per window instead of on every watcher cycle; a changed refusal message re-alerts immediately.
+`bin/fm-watch.sh` runs it every `FM_HOST_PRESSURE_INTERVAL` seconds (default 300) whenever `config/capacity-failover` exists, and any printed alert becomes one `check: host-pressure: ...` wake; the watcher never kills work or touches task ownership metadata on that path.
+With `host-pressure` off, the helper reports `state=off` without evaluating any threshold and the watcher stays silent.
+While the opt-in is on, a refused (malformed) `config/capacity-failover` is reported as `alert=host_pressure_config_invalid` under its own marker with a fixed one-hour cooldown, so a broken threshold is surfaced once per window instead of on every watcher cycle; a changed refusal message re-alerts immediately.
 
 ## Shared GitHub Quota
 

--- a/docs/capacity-failover.md
+++ b/docs/capacity-failover.md
@@ -126,8 +126,12 @@ Cooldown records are keyed by `(provider, account, route)`.
 The account comes from `--account`, `FM_GITHUB_ACCOUNT_ID`, a locally cached account, or a best-effort `gh api user` derivation.
 An account id read out of a rate-limit body is evidence only: it is recorded as `observed_account=` and never keys a record or replaces the cached account.
 When no account resolves, `mark-from-text` writes one account-agnostic record, and `check` consults that record in addition to the keyed one, so a cooldown observed before any account is known is still read back.
+`cache-get` and `cache-put` follow the same key policy, so a cached read stays reachable under the key its cooldown was written under.
 `mark` and `mark-from-text` write the cooldown.
+`mark-from-text` accepts the reset forms real `gh` stderr carries: an ISO-8601 or `UTC` timestamp, a labeled `x-ratelimit-reset: <epoch>` header from a primary limit, or a labeled `Retry-After: <seconds>` from a secondary limit.
+A bare number is never reset evidence, so an unlabeled id or epoch in an error body cannot create a cooldown.
 `check` prints `state=allow` or `state=defer` with provider, account, route, reset time, and remaining seconds.
+Because a record's path only encodes a hash of its key, a record whose own `provider=`/`account=`/`route=` fields disagree with the key it was found under is reported as `state=allow` with `mismatched_record=1` and left in place; capacity cooldowns apply the same rule to `harness=`/`account=`/`profile=`.
 Expired records are removed by `check`, so polling resumes only at or after the recorded reset time.
 
 `fm-pr-check.sh` uses this guard when it records PR metadata and in the static `fm-pr-poll.sh` poller.

--- a/docs/capacity-failover.md
+++ b/docs/capacity-failover.md
@@ -53,6 +53,8 @@ route=<harness>|<account-or-provider>|<profile>|<model>|<effort>
 ```
 
 Selection skips routes with active cooldown or manual auth-exhaustion records.
+A cooldown recorded with a partial key - no account, or a `default`/empty profile - is treated as a wall on the whole harness, so it blocks every route for that harness rather than only the exactly-matching one.
+Record a wall with both `--account` and a concrete `--profile` when only that one route should be skipped.
 It refuses unverified harnesses.
 When `config/crew-dispatch.json` exists, it refuses route selection unless the caller passes `--dispatch-approved` after consulting the dispatch rules.
 

--- a/docs/capacity-failover.md
+++ b/docs/capacity-failover.md
@@ -114,6 +114,28 @@ The helper never deletes those candidates.
 It does not kill those processes; callers own any stop/retry policy.
 `periodic-alert` emits a bounded disk-pressure alert for supervision and applies its own cooldown marker.
 
+## Shared GitHub Quota
+
+`bin/fm-shared-github-quota.sh` coordinates GitHub API quota as a fleet-wide shared resource.
+Its state is intentionally independent of any one `FM_HOME`.
+By default it uses `${XDG_STATE_HOME:-$HOME/.local/state}/firstmate/shared-github-quota/`; tests and unusual deployments can set `FM_SHARED_STATE_OVERRIDE`.
+
+Cooldown records are keyed by `(provider, account, route)`.
+For the 2026-07-13 incident the provider/account key is `github` / `94498628`, with reset evidence `2026-07-13T02:23:23Z`.
+`mark` and `mark-from-text` write the cooldown.
+`check` prints `state=allow` or `state=defer` with provider, account, route, reset time, and remaining seconds.
+Expired records are removed by `check`, so polling resumes only at or after the recorded reset time.
+
+`fm-pr-check.sh` uses this guard when it records PR metadata and in the generated `state/<id>.check.sh` poller.
+During a shared cooldown, generated PR pollers do not call `gh`.
+They return silence unless a cached PR state already proves `MERGED`; that preserves local ownership and avoids repeated wake spam while GitHub is cooling down.
+When no cooldown is active, the generated poller keeps the existing live `gh pr view` behavior and refreshes the small cache after a successful read.
+
+`fm-pr-merge.sh` refuses an explicit merge during a known shared cooldown.
+That refusal is a structured escalation naming the provider, account, route, reset time, attempted operation, and required action.
+`fm-teardown.sh` skips GitHub PR lookup proofs during a shared cooldown and falls back to the existing content-in-default proof; if neither proof can establish landed work, teardown still refuses fail-safe.
+`fm-bearings-snapshot.sh --include-prs` reports a bounded deferred PR status during cooldown, while the default bearings path remains local-only.
+
 ## Opposite-Harness Constraint
 
 Adversarial review lanes can add this line to their task meta:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,6 +13,7 @@ The tracked code root contains the shared instruction, skill, documentation, wor
 `data/` holds durable private fleet records such as the project and secondmate registries, captain preferences, optional shared captain preferences, learnings, backlog, briefs, and scout reports.
 `state/` holds volatile runtime records such as task metadata, append-only status events, endpoint signals, watcher and wake-queue coordination, away-mode state, generated X-mode artifacts, private secondmate config-reread generations with their retry and quarantine state, and parent-owned secondmate pending-reply records under `state/pending-replies/` (`bin/fm-pending-reply-lib.sh`).
 `config/` holds local gitignored operating choices, and `projects/` holds the local project clones that Firstmate reads but changes only through the guarded exceptions in `AGENTS.md`.
+The one deliberate exception to that per-home layout is the shared GitHub quota state, which is fleet-wide by design and lives under `${XDG_STATE_HOME:-$HOME/.local/state}/firstmate/shared-github-quota/` instead of any `FM_HOME` ([`docs/capacity-failover.md`](capacity-failover.md)).
 
 `bin/fm-spawn.sh` owns the base task-metadata fields it emits, while the runtime-backend section below owns backend-specific fields and selector interpretation.
 The producing PR and X helpers own the fields they append, `bin/fm-classify-lib.sh` owns status-event vocabulary, and `bin/fm-crew-state.sh` owns current-state reconciliation.
@@ -390,6 +391,14 @@ FM_HEARTBEAT=600        # base seconds between heartbeat scans; no-change heartb
 FM_HEARTBEAT_MAX=7200   # heartbeat backoff cap
 FM_CHECK_INTERVAL=300   # seconds between slow checks (authenticated merge polls, custom checks, or X-mode dispatch)
 FM_CHECK_TIMEOUT=30     # seconds allowed per slow check script
+FM_HOST_PRESSURE_INTERVAL=300   # seconds between opt-in host-pressure alert runs; only alerts when config/capacity-failover exists (docs/capacity-failover.md)
+FM_GITHUB_ROUTE=default   # shared GitHub quota route label used by the PR, teardown, and bearings guard calls
+FM_GITHUB_ACCOUNT_ID=     # explicit GitHub account key for shared quota records; otherwise a cached or derived account is used
+FM_SHARED_GITHUB_QUOTA_DERIVE_ACCOUNT=1   # set to 0 to forbid the guard from spending a `gh api user` call to derive the account; firstmate's own guard calls always set 0
+FM_GITHUB_QUOTA_DEFER_CACHE_MAX_AGE_SECS=86400   # max age of a cached PR state the merge poll may trust during a shared GitHub cooldown
+FM_SHARED_STATE_OVERRIDE=   # alternate home-independent shared-quota state root (FM_SHARED_STATE is consulted next when it is unset), mainly for tests
+FM_REHOME_EXIT_POLLS=20   # liveness polls fm-rehome-quota-wall.sh makes after sending /exit before refusing to relaunch
+FM_REHOME_EXIT_SLEEP=0.5  # seconds between those polls
 FM_CODEX_WATCH_CHECKPOINT=180   # seconds per foreground watcher checkpoint in Codex primary supervision
 FM_CREW_STATE_NM_TIMEOUT=10   # seconds allowed per no-mistakes query inside fm-crew-state.sh
 FM_CREW_STATE_RUNS_LIMIT=200  # recent no-mistakes run rows scanned when axi status cannot be attributed to the current code

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -236,10 +236,10 @@ Secondmate homes inherit this file from the primary, so a secondmate's own crewm
 
 `config/capacity-failover` is reserved for future opt-in automatic capacity failover.
 Absent this file, spawn and dispatch behavior is unchanged.
-The current implementation is substrate only: `bin/fm-capacity-classify.sh`, `bin/fm-capacity-cooldown.sh`, `bin/fm-capacity-route.sh`, `bin/fm-rehome-quota-wall.sh`, and `bin/fm-host-pressure.sh`.
+The current implementation is substrate only: `bin/fm-capacity-classify.sh`, `bin/fm-capacity-cooldown.sh`, `bin/fm-capacity-route.sh`, `bin/fm-rehome-quota-wall.sh`, `bin/fm-host-pressure.sh`, and `bin/fm-shared-github-quota.sh`.
 `host-pressure=on` enables bounded memory, disk-floor, and active-task spawn backpressure; without that line, even a present config file does not change spawn pressure behavior.
 `route=<harness>|<account-or-provider>|<profile>|<model>|<effort>` lines define optional verified routes for the manual route selector.
-See [`docs/capacity-failover.md`](capacity-failover.md) for the classifier signatures, cooldown record format, route-selection contract, manual rehome contract, host-pressure thresholds, and opposite-harness constraint.
+See [`docs/capacity-failover.md`](capacity-failover.md) for the classifier signatures, cooldown record format, route-selection contract, manual rehome contract, host-pressure thresholds, shared GitHub quota guard, and opposite-harness constraint.
 
 ## Toolchain
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -232,6 +232,15 @@ Malformed JSON, an empty or malformed rule/default array, an unverified harness,
 Because the spawn backstop is gated by file presence, any fallback path after a missing match, validation error, or missing `jq` still passes a resolved harness explicitly until the file is fixed or removed.
 Secondmate homes inherit this file from the primary, so a secondmate's own crewmates apply the same dispatch profile behavior.
 
+## Capacity failover (config/capacity-failover)
+
+`config/capacity-failover` is reserved for future opt-in automatic capacity failover.
+Absent this file, spawn and dispatch behavior is unchanged.
+The current implementation is substrate only: `bin/fm-capacity-classify.sh`, `bin/fm-capacity-cooldown.sh`, `bin/fm-capacity-route.sh`, `bin/fm-rehome-quota-wall.sh`, and `bin/fm-host-pressure.sh`.
+`host-pressure=on` enables bounded memory, disk-floor, and active-task spawn backpressure; without that line, even a present config file does not change spawn pressure behavior.
+`route=<harness>|<account-or-provider>|<profile>|<model>|<effort>` lines define optional verified routes for the manual route selector.
+See [`docs/capacity-failover.md`](capacity-failover.md) for the classifier signatures, cooldown record format, route-selection contract, manual rehome contract, host-pressure thresholds, and opposite-harness constraint.
+
 ## Toolchain
 
 On session start the first mate detects what its required toolchain is missing or too old and lists each problem with either an exact install command or manual instructions.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -43,6 +43,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-capacity-cooldown.sh` | Write and read passive per-harness/account/profile cooldown records under state/ |
 | `fm-capacity-route.sh` | Record classified route walls, select a verified non-cooled route, or print exact escalation evidence |
 | `fm-host-pressure.sh`    | Report opt-in memory, disk, and active-task pressure for capacity-failover spawn backpressure |
+| `fm-shared-github-quota.sh` | Coordinate fleet-wide GitHub API cooldowns and cached gh-heavy reads across homes |
 | `fm-backend.sh`          | Runtime-backend selection, meta helpers, selector resolution, and operation dispatch |
 | `fm-backend-hometag-lib.sh` | Shared per-installation home-tag derivation for zellij tab and cmux workspace titles |
 | `fm-composer-lib.sh`     | Single fleet-wide owner of composer-content classification for all backends          |

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -37,7 +37,12 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-supervision-instructions.sh` | Render the session-start primary-harness supervision block or the one-line repair instruction |
 | `fm-home-seed.sh`        | Transactionally provision a secondmate home and maintain `data/secondmates.md`       |
 | `fm-spawn.sh`            | Spawn crewmates, scouts, `id=repo` batches, and secondmates on the resolved harness and runtime backend |
+| `fm-rehome-quota-wall.sh` | Manually rehome a quota-wedged tmux task to an explicit harness while preserving task and PR identity |
 | `fm-dispatch-select.sh`  | Resolve a dispatch rule/default to one profile, owning quota-aware arrays and random fallback |
+| `fm-capacity-classify.sh` | Classify observed harness/proxy capacity walls into quota, auth, or other from evidence-backed signatures |
+| `fm-capacity-cooldown.sh` | Write and read passive per-harness/account/profile cooldown records under state/ |
+| `fm-capacity-route.sh` | Record classified route walls, select a verified non-cooled route, or print exact escalation evidence |
+| `fm-host-pressure.sh`    | Report opt-in memory, disk, and active-task pressure for capacity-failover spawn backpressure |
 | `fm-backend.sh`          | Runtime-backend selection, meta helpers, selector resolution, and operation dispatch |
 | `fm-backend-hometag-lib.sh` | Shared per-installation home-tag derivation for zellij tab and cmux workspace titles |
 | `fm-composer-lib.sh`     | Single fleet-wide owner of composer-content classification for all backends          |
@@ -68,6 +73,9 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-ff-lib.sh`           | Shared guarded fast-forward helper for origin pulls and local secondmate syncs       |
 | `fm-lock-lib.sh`         | Shared "is this git lock provably abandoned?" proof used by teardown and fleet-sync   |
 | `fm-config-inherit-lib.sh` | Shared primary-to-secondmate inherited local-material propagation and config-reread delivery |
+| `fm-harness-launch-lib.sh` | Shared verified harness launch templates, profile flags, and turn-end hook installation |
+| `fm-capacity-lib.sh`    | Shared passive capacity classification, cooldown, and opposite-harness guard helpers |
+| `fm-pressure-lib.sh`    | Shared passive host-pressure detection and config parsing helpers |
 | `fm-tasks-axi-lib.sh`    | Shared backlog-backend selector and `tasks-axi` compatibility probe                  |
 | `fm-wake-drain.sh`       | Atomically drain queued watcher wakes, emit bounded best-effort status-event annotations, then assert watcher liveness |
 | `fm-wake-lib.sh`         | Shared durable wake queue, portable locks, and watcher identity/health helpers       |

--- a/tests/fixtures/capacity-walls/claude-session-limit.txt
+++ b/tests/fixtures/capacity-walls/claude-session-limit.txt
@@ -1,0 +1,1 @@
+DIED at launch on the subscription session limit (8/342 agents done, 334 errored 'session limit, resets 10:50pm PT') and returned 0 usable verdicts.

--- a/tests/fixtures/capacity-walls/codex-usage-limit.txt
+++ b/tests/fixtures/capacity-walls/codex-usage-limit.txt
@@ -1,0 +1,1 @@
+The original codex lane hit its usage limit mid-turn (resets 2:42PT), so per no-parking the fix moved to another lane.

--- a/tests/fixtures/capacity-walls/login-required.txt
+++ b/tests/fixtures/capacity-walls/login-required.txt
@@ -1,0 +1,1 @@
+Not logged in - Please run /login for provider claude before continuing.

--- a/tests/fixtures/capacity-walls/proxy-auth-unavailable.json
+++ b/tests/fixtures/capacity-walls/proxy-auth-unavailable.json
@@ -1,0 +1,1 @@
+{"error":{"message":"auth_unavailable: no auth available (providers=codex, model=gpt-5.6-luna)","type":"server_error","code":"internal_server_error"}}

--- a/tests/fixtures/capacity-walls/rate-limit-retry-after.txt
+++ b/tests/fixtures/capacity-walls/rate-limit-retry-after.txt
@@ -1,0 +1,3 @@
+HTTP 429 Too Many Requests
+rate limit exceeded for provider codex
+Retry-After: 120

--- a/tests/fm-backend-autodetect-smoke.test.sh
+++ b/tests/fm-backend-autodetect-smoke.test.sh
@@ -51,6 +51,12 @@ export FM_GATE_REFUSE_BYPASS=1
 # The dedicated regression is
 # tests/fm-backend.test.sh:test_spawn_symlinked_project_prefix_avoids_false_refusal.
 TMP_ROOT=$(mktemp -d "$(cd "${TMPDIR:-/tmp}" && pwd -P)/fm-backend-autodetect-smoke.XXXXXX")
+# This suite drives the real bin/fm-teardown.sh, which consults the shared
+# GitHub quota store. That store is deliberately FM_HOME-independent, so
+# without this it would prune the operator's real state and take its result
+# from the developer's live GitHub quota. tests/lib.sh does the same for the
+# suites that source it; this one does not.
+export FM_SHARED_STATE_OVERRIDE="$TMP_ROOT/fm-shared-quota"
 HERDR_LAB_HELPER="$ROOT/bin/fm-herdr-lab.sh"
 HERDR_LAB_SESSION=$("$HERDR_LAB_HELPER" name fm-autodetect-smoke-concurrency-h3) || {
   rm -rf "$TMP_ROOT"

--- a/tests/fm-backend-herdr-presentation-e2e.test.sh
+++ b/tests/fm-backend-herdr-presentation-e2e.test.sh
@@ -21,6 +21,12 @@ REAL_HERDR=$(command -v herdr)
 REAL_TREEHOUSE=$(command -v treehouse)
 HERDR_ORIGINAL_PATH=$PATH
 TMP_ROOT=$(mktemp -d "$(cd "${TMPDIR:-/tmp}" && pwd -P)/fm-herdr-presentation.XXXXXX")
+# This suite drives the real bin/fm-teardown.sh, which consults the shared
+# GitHub quota store. That store is deliberately FM_HOME-independent, so
+# without this it would prune the operator's real state and take its result
+# from the developer's live GitHub quota. tests/lib.sh does the same for the
+# suites that source it; this one does not.
+export FM_SHARED_STATE_OVERRIDE="$TMP_ROOT/fm-shared-quota"
 FAKEBIN="$TMP_ROOT/fakebin"
 HERDR_CALL_LOG="$TMP_ROOT/herdr-calls.log"
 TREEHOUSE_CALL_LOG="$TMP_ROOT/treehouse-calls.log"

--- a/tests/fm-backend-herdr-workspace-per-home-e2e.test.sh
+++ b/tests/fm-backend-herdr-workspace-per-home-e2e.test.sh
@@ -61,6 +61,12 @@ command -v treehouse >/dev/null 2>&1 || { echo "skip: treehouse not found (requi
 # canonicalized project and backend cwd comparisons in the worktree-discovery
 # poll.
 TMP_ROOT=$(mktemp -d "$(cd "${TMPDIR:-/tmp}" && pwd -P)/fm-herdr-e2e.XXXXXX")
+# This suite drives the real bin/fm-teardown.sh, which consults the shared
+# GitHub quota store. That store is deliberately FM_HOME-independent, so
+# without this it would prune the operator's real state and take its result
+# from the developer's live GitHub quota. tests/lib.sh does the same for the
+# suites that source it; this one does not.
+export FM_SHARED_STATE_OVERRIDE="$TMP_ROOT/fm-shared-quota"
 SESSION="fm-lab-herdr-e2e-$$"
 export HERDR_SESSION="$SESSION"
 WT1=; WT2=

--- a/tests/fm-bearings-snapshot.test.sh
+++ b/tests/fm-bearings-snapshot.test.sh
@@ -162,7 +162,7 @@ EOF
 
 run() {  # <home> <fakebin> <args...>
   local home=$1 fakebin=$2; shift 2
-  PATH="$fakebin:$PATH" FM_HOME="$home" FM_BEARINGS_NOW=2026-07-11T18:00:00Z NET_LOG="$home/net.log" "$BEARINGS" "$@"
+  PATH="$fakebin:$PATH" FM_HOME="$home" FM_SHARED_STATE_OVERRIDE="$home/shared-quota" FM_BEARINGS_NOW=2026-07-11T18:00:00Z NET_LOG="$home/net.log" "$BEARINGS" "$@"
 }
 
 # End-to-end Domain Alpha regression fixture.
@@ -950,7 +950,7 @@ test_perl_fallback_bounds_github_call() {
     ln -s "$(command -v "$cmd")" "$toolbin/$cmd"
   done
   started=$(date +%s)
-  json=$(PATH="$fakebin:$toolbin" FM_HOME="$home" FM_BEARINGS_NOW=2026-07-11T18:00:00Z \
+  json=$(PATH="$fakebin:$toolbin" FM_HOME="$home" FM_SHARED_STATE_OVERRIDE="$home/shared-quota" FM_BEARINGS_NOW=2026-07-11T18:00:00Z \
     FM_BEARINGS_PR_TIMEOUT=1 NET_LOG="$home/net.log" FAKE_GH_SLEEP=1 "$BEARINGS" --include-prs --json)
   elapsed=$(( $(date +%s) - started ))
   [ "$elapsed" -lt 10 ] || fail "Perl fallback did not bound a stalled gh call (${elapsed}s)"

--- a/tests/fm-capacity-route.test.sh
+++ b/tests/fm-capacity-route.test.sh
@@ -44,6 +44,34 @@ test_quota_wall_records_cooldown_and_selects_alternate_route() {
   pass "quota output records cooldown and selects another verified route with headroom"
 }
 
+test_partial_wall_key_blocks_every_route_for_same_harness() {
+  local home routes out status active
+  home="$TMP_ROOT/partial/home"
+  routes="$home/config/capacity-failover"
+  mkdir -p "$home/state" "$home/config"
+  write_routes "$routes" \
+    "route=codex|acct-a|gpt-5.5|gpt-5.5|xhigh" \
+    "route=codex|acct-b|gpt-5.6|gpt-5.6|high" \
+    "route=claude|acct-c|sonnet|sonnet|high"
+
+  out=$(FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" FM_CONFIG_OVERRIDE="$home/config" FM_CAPACITY_NOW_EPOCH=2000 \
+    "$ROUTE" handle-wall --task task-rate --harness codex \
+    --routes-file "$routes" --file "$FIXTURES/rate-limit-retry-after.txt")
+  status=$?
+
+  expect_code 0 "$status" "partial quota wall should still select an alternate route"
+  assert_contains "$out" "route_1_status=blocked" "first codex route should be blocked by partial key"
+  assert_contains "$out" "route_2_status=blocked" "second codex route should be blocked by partial key"
+  assert_contains "$out" "selected_harness=claude" "partial codex wall should not reselect another codex route"
+  assert_not_contains "$out" "selected_harness=codex" "partial codex wall should block every codex route"
+
+  active=$(FM_STATE_OVERRIDE="$home/state" FM_CAPACITY_NOW_EPOCH=2001 "$COOLDOWN" active \
+    --harness codex --profile default)
+  assert_contains "$active" "account=" "partial cooldown should record the omitted account as empty"
+  assert_contains "$active" "profile=default" "partial cooldown should record the default profile"
+  pass "partial wall keys block every route for the walled harness"
+}
+
 test_expired_cooldown_route_becomes_selectable() {
   local home routes out status
   home="$TMP_ROOT/expiry/home"
@@ -182,6 +210,7 @@ test_dispatch_profile_backstop_blocks_unapproved_selection() {
 }
 
 test_quota_wall_records_cooldown_and_selects_alternate_route
+test_partial_wall_key_blocks_every_route_for_same_harness
 test_expired_cooldown_route_becomes_selectable
 test_auth_wall_records_manual_block_and_escalates_without_route
 test_login_required_records_provider_action_and_escalates_without_route

--- a/tests/fm-capacity-route.test.sh
+++ b/tests/fm-capacity-route.test.sh
@@ -209,6 +209,28 @@ test_dispatch_profile_backstop_blocks_unapproved_selection() {
   pass "route selection never bypasses active dispatch rules without approval"
 }
 
+test_dispatch_profile_backstop_blocks_wall_before_recording() {
+  local home routes out status records
+  home="$TMP_ROOT/dispatch-wall/home"
+  routes="$home/config/capacity-failover"
+  mkdir -p "$home/state" "$home/config"
+  write_routes "$routes" "route=pi|acct-b|default|default|high"
+  printf '{"rules":[{"when":"anything","use":{"harness":"codex"}}]}\n' > "$home/config/crew-dispatch.json"
+
+  set +e
+  out=$(printf 'You have hit your usage limit. Try again after 2026-07-13T02:23:23Z.\n' \
+    | FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" FM_CONFIG_OVERRIDE="$home/config" \
+      "$ROUTE" handle-wall --task task-x1 --harness codex --routes-file "$routes" 2>&1)
+  status=$?
+  set +e
+
+  expect_code 1 "$status" "handle-wall should refuse an unapproved dispatch profile"
+  assert_contains "$out" "consult it first" "handle-wall refusal should name the dispatch approval requirement"
+  records=$(find "$home/state/capacity-cooldowns" -name '*.env' -print 2>/dev/null | wc -l | tr -d ' ')
+  [ "$records" = 0 ] || fail "handle-wall must refuse before writing any cooldown record"
+  pass "handle-wall refuses unapproved dispatch rules before recording a wall"
+}
+
 test_quota_wall_records_cooldown_and_selects_alternate_route
 test_partial_wall_key_blocks_every_route_for_same_harness
 test_expired_cooldown_route_becomes_selectable
@@ -216,5 +238,6 @@ test_auth_wall_records_manual_block_and_escalates_without_route
 test_login_required_records_provider_action_and_escalates_without_route
 test_every_route_exhausted_reports_reset_and_login_action
 test_dispatch_profile_backstop_blocks_unapproved_selection
+test_dispatch_profile_backstop_blocks_wall_before_recording
 
 echo "# all fm-capacity-route tests passed"

--- a/tests/fm-capacity-route.test.sh
+++ b/tests/fm-capacity-route.test.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# Behavior tests for capacity route cooldown selection and wall handling.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+ROUTE="$ROOT/bin/fm-capacity-route.sh"
+COOLDOWN="$ROOT/bin/fm-capacity-cooldown.sh"
+FIXTURES="$ROOT/tests/fixtures/capacity-walls"
+TMP_ROOT=$(fm_test_tmproot fm-capacity-route)
+
+write_routes() {
+  local file=$1
+  shift
+  mkdir -p "$(dirname "$file")"
+  printf '%s\n' "$@" > "$file"
+}
+
+test_quota_wall_records_cooldown_and_selects_alternate_route() {
+  local home routes out status active
+  home="$TMP_ROOT/quota/home"
+  routes="$home/config/capacity-failover"
+  mkdir -p "$home/state" "$home/config"
+  write_routes "$routes" \
+    "route=codex|acct-a|gpt-5.5|gpt-5.5|xhigh" \
+    "route=claude|acct-b|sonnet|sonnet|high"
+
+  out=$(FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" FM_CONFIG_OVERRIDE="$home/config" FM_CAPACITY_NOW_EPOCH=2000 \
+    "$ROUTE" handle-wall --task task-rate --harness codex --account acct-a --profile gpt-5.5 \
+    --routes-file "$routes" --file "$FIXTURES/rate-limit-retry-after.txt")
+  status=$?
+
+  expect_code 0 "$status" "quota wall should record and select an alternate route"
+  assert_contains "$out" "recorded_route_block=" "quota wall should record the blocked route"
+  assert_contains "$out" "selected_harness=claude" "cooled-down codex route should be skipped"
+  assert_contains "$out" "action=rehome_same_owner" "handle-wall should request same-owner rehome"
+  assert_contains "$out" "task=task-rate" "handle-wall should preserve the task id"
+
+  active=$(FM_STATE_OVERRIDE="$home/state" FM_CAPACITY_NOW_EPOCH=2001 "$COOLDOWN" active \
+    --harness codex --account acct-a --profile gpt-5.5)
+  assert_contains "$active" "reset_epoch=2120" "quota route should stay blocked until retry-after reset"
+  assert_contains "$active" "remaining_secs=119" "quota route should expose remaining TTL"
+  pass "quota output records cooldown and selects another verified route with headroom"
+}
+
+test_expired_cooldown_route_becomes_selectable() {
+  local home routes out status
+  home="$TMP_ROOT/expiry/home"
+  routes="$home/config/capacity-failover"
+  mkdir -p "$home/state" "$home/config"
+  write_routes "$routes" \
+    "route=codex|acct-a|gpt-5.5|gpt-5.5|xhigh" \
+    "route=claude|acct-b|sonnet|sonnet|high"
+  FM_STATE_OVERRIDE="$home/state" FM_CAPACITY_NOW_EPOCH=1000 "$COOLDOWN" mark \
+    --harness codex --account acct-a --profile gpt-5.5 --reset-epoch 1100 \
+    --class quota --reason rate_limit >/dev/null
+
+  out=$(FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" FM_CONFIG_OVERRIDE="$home/config" FM_CAPACITY_NOW_EPOCH=1100 \
+    "$ROUTE" select --routes-file "$routes")
+  status=$?
+
+  expect_code 0 "$status" "expired cooldown should not block route selection"
+  assert_contains "$out" "selected_harness=codex" "expired cooldown route should be selectable again"
+  pass "route selection skips cooled-down routes only until expiry"
+}
+
+test_auth_wall_records_manual_block_and_escalates_without_route() {
+  local home routes out status active
+  home="$TMP_ROOT/auth/home"
+  routes="$home/config/capacity-failover"
+  mkdir -p "$home/state" "$home/config"
+  write_routes "$routes" "route=pi|codex|gpt-5.6-luna|gpt-5.6-luna|high"
+
+  set +e
+  out=$(FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" FM_CONFIG_OVERRIDE="$home/config" \
+    "$ROUTE" handle-wall --task task-auth --harness pi --routes-file "$routes" \
+    --file "$FIXTURES/proxy-auth-unavailable.json" 2>&1)
+  status=$?
+  set +e
+
+  expect_code 1 "$status" "auth-unavailable with no alternate route should escalate"
+  assert_contains "$out" "reason=proxy_auth_unavailable" "auth wall should be classified"
+  assert_contains "$out" "action=escalate" "no noninteractive route should escalate"
+  assert_contains "$out" "blocked_account=codex" "escalation should include provider/account identity"
+  assert_contains "$out" "blocked_profile=gpt-5.6-luna" "escalation should include model/profile"
+  assert_contains "$out" "needed_action=wait for reset or complete the listed interactive auth/account action" \
+    "escalation should name the required account action class"
+
+  active=$(FM_STATE_OVERRIDE="$home/state" "$COOLDOWN" active \
+    --harness pi --account codex --profile gpt-5.6-luna)
+  assert_contains "$active" "reset_epoch=manual" "auth exhaustion should be a manual block, not invented TTL"
+  assert_contains "$active" "requires_action=interactive_auth_required" "auth exhaustion should record the required login action"
+  pass "auth-unavailable records auth exhaustion and escalates when no alternate route exists"
+}
+
+test_login_required_records_provider_action_and_escalates_without_route() {
+  local home routes out status active
+  home="$TMP_ROOT/login/home"
+  routes="$home/config/capacity-failover"
+  mkdir -p "$home/state" "$home/config"
+  write_routes "$routes" "route=claude|claude|sonnet|sonnet|high"
+
+  set +e
+  out=$(FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" FM_CONFIG_OVERRIDE="$home/config" \
+    "$ROUTE" handle-wall --task task-login --harness claude --profile sonnet --routes-file "$routes" \
+    --file "$FIXTURES/login-required.txt" 2>&1)
+  status=$?
+  set +e
+
+  expect_code 1 "$status" "login-required with no alternate route should escalate"
+  assert_contains "$out" "reason=login_required" "login-required should be classified"
+  assert_contains "$out" "action=escalate" "no noninteractive route should escalate"
+  assert_contains "$out" "blocked_harness=claude" "escalation should include exact harness"
+  assert_contains "$out" "blocked_account=claude" "escalation should include extracted provider/account"
+  assert_contains "$out" "blocked_model=sonnet" "escalation should include exact selected model/profile"
+  assert_contains "$out" "blocked_reset_epoch=manual" "auth escalation should make the manual block explicit"
+  assert_contains "$out" "blocked_requires_action=interactive_auth_required" "escalation should include the needed login action"
+
+  active=$(FM_STATE_OVERRIDE="$home/state" "$COOLDOWN" active \
+    --harness claude --account claude --profile sonnet)
+  assert_contains "$active" "reset_epoch=manual" "login-required should be a manual auth block"
+  assert_contains "$active" "requires_action=interactive_auth_required" "login-required should record the auth action"
+  pass "login-required records provider-scoped auth exhaustion and exact escalation action"
+}
+
+test_every_route_exhausted_reports_reset_and_login_action() {
+  local home routes out status
+  home="$TMP_ROOT/exhausted/home"
+  routes="$home/config/capacity-failover"
+  mkdir -p "$home/state" "$home/config"
+  write_routes "$routes" \
+    "route=codex|acct-a|gpt-5.5|gpt-5.5|xhigh" \
+    "route=pi|codex|gpt-5.6-luna|gpt-5.6-luna|high"
+  FM_STATE_OVERRIDE="$home/state" FM_CAPACITY_NOW_EPOCH=3000 "$COOLDOWN" mark \
+    --harness codex --account acct-a --profile gpt-5.5 --reset-epoch 3600 \
+    --class quota --reason rate_limit >/dev/null
+  FM_STATE_OVERRIDE="$home/state" "$ROOT/bin/fm-capacity-classify.sh" \
+    --file "$FIXTURES/proxy-auth-unavailable.json" >/dev/null
+  # Source the lib through the route helper path by recording the manual block via handle-wall's public behavior.
+  set +e
+  FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" FM_CONFIG_OVERRIDE="$home/config" FM_CAPACITY_NOW_EPOCH=3000 \
+    "$ROUTE" handle-wall --task task-luna --harness pi --routes-file "$routes" \
+    --file "$FIXTURES/proxy-auth-unavailable.json" >/dev/null 2>&1
+  set +e
+
+  set +e
+  out=$(FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" FM_CONFIG_OVERRIDE="$home/config" FM_CAPACITY_NOW_EPOCH=3000 \
+    "$ROUTE" select --routes-file "$routes" 2>&1)
+  status=$?
+  set +e
+
+  expect_code 1 "$status" "every exhausted route should return non-zero"
+  assert_contains "$out" "escalation=every_verified_route_exhausted" "selection should escalate when no route has headroom"
+  assert_contains "$out" "route_1_harness=codex" "escalation should include exact first harness"
+  assert_contains "$out" "route_1_account=acct-a" "escalation should include exact first account"
+  assert_contains "$out" "route_1_model=gpt-5.5" "escalation should include exact first model"
+  assert_contains "$out" "route_1_reset_epoch=3600" "escalation should include known reset time"
+  assert_contains "$out" "route_2_harness=pi" "escalation should include exact second harness"
+  assert_contains "$out" "route_2_account=codex" "escalation should include exact provider identity"
+  assert_contains "$out" "route_2_requires_action=interactive_auth_required" "escalation should include login/account action"
+  pass "every-route-exhausted escalation includes exact route, reset, and login action"
+}
+
+test_dispatch_profile_backstop_blocks_unapproved_selection() {
+  local home routes out status
+  home="$TMP_ROOT/dispatch/home"
+  routes="$home/config/capacity-failover"
+  mkdir -p "$home/state" "$home/config"
+  write_routes "$routes" "route=codex|acct-a|gpt-5.5|gpt-5.5|xhigh"
+  printf '{"rules":[{"when":"anything","use":{"harness":"codex"}}]}\n' > "$home/config/crew-dispatch.json"
+
+  set +e
+  out=$(FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" FM_CONFIG_OVERRIDE="$home/config" \
+    "$ROUTE" select --routes-file "$routes" 2>&1)
+  status=$?
+  set +e
+
+  expect_code 1 "$status" "active dispatch profile should require approval"
+  assert_contains "$out" "consult it first" "route helper should not bypass crew-dispatch rules"
+  pass "route selection never bypasses active dispatch rules without approval"
+}
+
+test_quota_wall_records_cooldown_and_selects_alternate_route
+test_expired_cooldown_route_becomes_selectable
+test_auth_wall_records_manual_block_and_escalates_without_route
+test_login_required_records_provider_action_and_escalates_without_route
+test_every_route_exhausted_reports_reset_and_login_action
+test_dispatch_profile_backstop_blocks_unapproved_selection
+
+echo "# all fm-capacity-route tests passed"

--- a/tests/fm-capacity.test.sh
+++ b/tests/fm-capacity.test.sh
@@ -93,6 +93,29 @@ test_cooldown_persists_and_expires() {
   pass "cooldown records persist while active and expire at reset_epoch"
 }
 
+test_cooldown_record_must_match_the_route_it_is_found_for() {
+  local state file out status
+  state="$TMP_ROOT/cooldown-key-mismatch/state"
+  mkdir -p "$state"
+
+  FM_STATE_OVERRIDE="$state" FM_CAPACITY_NOW_EPOCH=1000 "$COOLDOWN" mark \
+    --harness codex --profile gpt-5.5/xhigh --account acct-a --reset-epoch 1600 \
+    --class quota --reason codex_usage_limit --source-task task-a >/dev/null
+  file=$(ls "$state"/capacity-cooldowns/*.env)
+  sed 's|^profile=gpt-5.5/xhigh|profile=gpt-5.6/xhigh|' "$file" > "$file.tmp"
+  mv "$file.tmp" "$file"
+
+  set +e
+  out=$(FM_STATE_OVERRIDE="$state" FM_CAPACITY_NOW_EPOCH=1000 "$COOLDOWN" active \
+    --harness codex --profile gpt-5.5/xhigh --account acct-a 2>&1)
+  status=$?
+  set -e
+  expect_code 1 "$status" "a record whose own identity disagrees must not block this route"
+  [ -z "$out" ] || fail "a mismatched record should not be printed as this route's wall: $out"
+  [ -f "$file" ] || fail "a mismatched record must be left in place for its real owner"
+  pass "capacity cooldowns are honored only when their own fields match the route"
+}
+
 test_mark_from_text_never_invents_auth_ttl() {
   local state out status
   state="$TMP_ROOT/no-auth-ttl/state"
@@ -117,6 +140,7 @@ test_classifies_proxy_auth_unavailable
 test_classifies_rate_limit_retry_after
 test_classifies_login_required
 test_cooldown_persists_and_expires
+test_cooldown_record_must_match_the_route_it_is_found_for
 test_mark_from_text_never_invents_auth_ttl
 
 echo "# all fm-capacity tests passed"

--- a/tests/fm-capacity.test.sh
+++ b/tests/fm-capacity.test.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Behavior tests for passive capacity classification and cooldown records.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+CLASSIFY="$ROOT/bin/fm-capacity-classify.sh"
+COOLDOWN="$ROOT/bin/fm-capacity-cooldown.sh"
+FIXTURES="$ROOT/tests/fixtures/capacity-walls"
+TMP_ROOT=$(fm_test_tmproot fm-capacity)
+
+test_classifies_codex_usage_limit_with_reset() {
+  local out
+  out=$(FM_CAPACITY_NOW_EPOCH=1783818000 "$CLASSIFY" --file "$FIXTURES/codex-usage-limit.txt")
+
+  assert_contains "$out" "class=quota" "codex usage wall should classify as quota"
+  assert_contains "$out" "reason=codex_usage_limit" "codex usage wall should name its signature"
+  assert_contains "$out" "reset_at=2:42PT" "codex usage wall should preserve observed reset text"
+  assert_contains "$out" "reset_epoch=" "codex usage wall should parse a reset epoch"
+  assert_contains "$out" "cooldown_ttl_secs=" "codex usage wall should expose a TTL from the reset"
+  pass "codex usage-limit fixture classifies as a quota wall with reset TTL"
+}
+
+test_classifies_claude_session_limit_with_reset() {
+  local out
+  out=$(FM_CAPACITY_NOW_EPOCH=1783818000 "$CLASSIFY" --file "$FIXTURES/claude-session-limit.txt")
+
+  assert_contains "$out" "class=quota" "claude session wall should classify as quota"
+  assert_contains "$out" "reason=claude_session_limit" "claude session wall should name its signature"
+  assert_contains "$out" "reset_at=10:50pm PT" "claude session wall should preserve observed reset text"
+  assert_contains "$out" "cooldown_ttl_secs=" "claude session wall should expose a TTL from the reset"
+  pass "claude session-limit fixture classifies as a quota wall with reset TTL"
+}
+
+test_classifies_proxy_auth_unavailable() {
+  local out
+  out=$("$CLASSIFY" --file "$FIXTURES/proxy-auth-unavailable.json")
+
+  assert_contains "$out" "class=auth" "proxy auth_unavailable should classify as auth"
+  assert_contains "$out" "reason=proxy_auth_unavailable" "proxy auth wall should name its signature"
+  assert_contains "$out" "provider=codex" "proxy auth wall should extract provider"
+  assert_contains "$out" "model=gpt-5.6-luna" "proxy auth wall should extract model"
+  assert_not_contains "$out" "cooldown_ttl_secs=" "auth_unavailable has no observed reset TTL"
+  pass "proxy auth_unavailable fixture classifies as auth without invented cooldown"
+}
+
+test_classifies_rate_limit_retry_after() {
+  local out
+  out=$(FM_CAPACITY_NOW_EPOCH=2000 "$CLASSIFY" --file "$FIXTURES/rate-limit-retry-after.txt")
+
+  assert_contains "$out" "class=quota" "explicit rate limit should classify as quota"
+  assert_contains "$out" "reason=rate_limit" "explicit rate limit should name its signature"
+  assert_contains "$out" "reset_at=retry-after:120s" "retry-after should be preserved as reset evidence"
+  assert_contains "$out" "reset_epoch=2120" "retry-after should be converted into a reset epoch"
+  assert_contains "$out" "cooldown_ttl_secs=120" "retry-after should expose the TTL"
+  pass "explicit rate-limit fixture classifies as quota with Retry-After TTL"
+}
+
+test_classifies_login_required() {
+  local out
+  out=$("$CLASSIFY" --file "$FIXTURES/login-required.txt")
+
+  assert_contains "$out" "class=auth" "login-required should classify as auth"
+  assert_contains "$out" "reason=login_required" "login-required should name its signature"
+  assert_contains "$out" "provider=claude" "login-required should extract the observable provider"
+  assert_not_contains "$out" "cooldown_ttl_secs=" "login-required has no observed reset TTL"
+  pass "login-required fixture classifies as auth without invented cooldown"
+}
+
+test_cooldown_persists_and_expires() {
+  local state out status
+  state="$TMP_ROOT/cooldown/state"
+  mkdir -p "$state"
+
+  out=$(FM_STATE_OVERRIDE="$state" FM_CAPACITY_NOW_EPOCH=1000 "$COOLDOWN" mark \
+    --harness codex --profile gpt-5.5/xhigh --account acct-a --reset-epoch 1600 \
+    --class quota --reason codex_usage_limit --source-task task-a)
+  assert_present "$out" "cooldown mark should write a record"
+
+  out=$(FM_STATE_OVERRIDE="$state" FM_CAPACITY_NOW_EPOCH=1000 "$COOLDOWN" active \
+    --harness codex --profile gpt-5.5/xhigh --account acct-a)
+  assert_contains "$out" "schema=fm-capacity-cooldown.v1" "active cooldown should print the persisted record"
+  assert_contains "$out" "remaining_secs=600" "active cooldown should report remaining TTL"
+
+  set +e
+  out=$(FM_STATE_OVERRIDE="$state" FM_CAPACITY_NOW_EPOCH=1600 "$COOLDOWN" active \
+    --harness codex --profile gpt-5.5/xhigh --account acct-a 2>&1)
+  status=$?
+  set -e
+  expect_code 1 "$status" "expired cooldown should return non-zero"
+  [ -z "$out" ] || fail "expired cooldown should not print stale data: $out"
+  pass "cooldown records persist while active and expire at reset_epoch"
+}
+
+test_mark_from_text_never_invents_auth_ttl() {
+  local state out status
+  state="$TMP_ROOT/no-auth-ttl/state"
+  mkdir -p "$state"
+
+  set +e
+  out=$(FM_STATE_OVERRIDE="$state" "$COOLDOWN" mark-from-text \
+    --harness pi --profile gpt-5.6-luna --file "$FIXTURES/proxy-auth-unavailable.json" 2>&1)
+  status=$?
+  set -e
+
+  expect_code 1 "$status" "auth_unavailable without reset should not write cooldown"
+  assert_contains "$out" "class=auth" "mark-from-text should still print classification"
+  assert_contains "$out" "no observed reset epoch" "mark-from-text should explain refusal"
+  assert_absent "$state/capacity-cooldowns" "auth_unavailable without reset must not create cooldown dir"
+  pass "mark-from-text refuses to invent TTLs for auth_unavailable"
+}
+
+test_classifies_codex_usage_limit_with_reset
+test_classifies_claude_session_limit_with_reset
+test_classifies_proxy_auth_unavailable
+test_classifies_rate_limit_retry_after
+test_classifies_login_required
+test_cooldown_persists_and_expires
+test_mark_from_text_never_invents_auth_ttl
+
+echo "# all fm-capacity tests passed"

--- a/tests/fm-gotmp.test.sh
+++ b/tests/fm-gotmp.test.sh
@@ -142,7 +142,7 @@ test_teardown_removes_tasktmp_dir() {
   # Sanity: dir + contents exist before teardown.
   [ -d "$task_tmp/gotmp" ] || fail "precondition: gotmp missing before teardown"
   # Run the REAL teardown against the fake root.
-  FM_HOME="$fake" bash "$fake/bin/fm-teardown.sh" "$id" >/dev/null 2>&1 \
+  PATH="$fake/bin:$PATH" FM_HOME="$fake" bash "$fake/bin/fm-teardown.sh" "$id" >/dev/null 2>&1 \
     || fail "teardown exited non-zero with a valid tasktmp"
   [ ! -e "$task_tmp" ] \
     || fail "teardown did not remove the tasktmp dir ($task_tmp still exists)"
@@ -175,6 +175,11 @@ SH
 exit 0
 SH
   chmod +x "$fake/bin/fm-fleet-sync.sh"
+  cat > "$fake/bin/tmux" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  chmod +x "$fake/bin/tmux"
   cat > "$fake/bin/fm-tasks-axi-lib.sh" <<'SH'
 fm_tasks_axi_backend_available() { return 1; }
 SH
@@ -188,7 +193,7 @@ kind=ship
 mode=no-mistakes
 yolo=off
 META
-  FM_HOME="$fake" bash "$fake/bin/fm-teardown.sh" "$id" >/dev/null 2>&1 \
+  PATH="$fake/bin:$PATH" FM_HOME="$fake" bash "$fake/bin/fm-teardown.sh" "$id" >/dev/null 2>&1 \
     || fail "teardown exited non-zero when tasktmp= was absent"
   pass "fm-teardown skips gracefully when tasktmp= is absent (backward compat)"
 }
@@ -201,7 +206,7 @@ test_teardown_skips_gracefully_when_dir_missing() {
   [ ! -e "$task_tmp" ] || fail "precondition: task_tmp should not exist yet"
   local fake
   fake=$(make_fake_root "$id" "$task_tmp")
-  FM_HOME="$fake" bash "$fake/bin/fm-teardown.sh" "$id" >/dev/null 2>&1 \
+  PATH="$fake/bin:$PATH" FM_HOME="$fake" bash "$fake/bin/fm-teardown.sh" "$id" >/dev/null 2>&1 \
     || fail "teardown exited non-zero when tasktmp dir was missing"
   [ ! -e "$task_tmp" ] || fail "teardown created/left the tasktmp dir unexpectedly"
   pass "fm-teardown skips gracefully when tasktmp= points to a nonexistent dir"

--- a/tests/fm-grok-harness.test.sh
+++ b/tests/fm-grok-harness.test.sh
@@ -117,6 +117,28 @@ EOF
   pass "grok teardown removes pointer and token state"
 }
 
+test_grok_relaunch_retires_prior_auth_token() {
+  local root grok_home state wt id first second
+  root="$TMP_ROOT/relaunch"
+  grok_home="$root/grok"
+  state="$root/state"
+  wt="$root/wt"
+  id=rehome-g1
+  mkdir -p "$grok_home" "$state" "$wt"
+
+  # shellcheck source=bin/fm-harness-launch-lib.sh
+  . "$ROOT/bin/fm-harness-launch-lib.sh"
+  GROK_HOME="$grok_home" fm_launch_install_turn_end_hook grok ship "$wt" "$state" "$id" "$state/$id.turn-ended" "$wt"
+  first=$(cat "$state/$id.grok-turnend-token")
+  GROK_HOME="$grok_home" fm_launch_install_turn_end_hook grok ship "$wt" "$state" "$id" "$state/$id.turn-ended" "$wt"
+  second=$(cat "$state/$id.grok-turnend-token")
+
+  [ "$first" != "$second" ] || fail "relaunch should mint a fresh grok auth token"
+  assert_absent "$grok_home/hooks/fm-turn-end.d/$first" "prior grok auth file orphaned by relaunch"
+  [ -f "$grok_home/hooks/fm-turn-end.d/$second" ] || fail "current grok auth file missing after relaunch"
+  pass "grok relaunch retires the prior auth token file"
+}
+
 test_fm_lock_recognizes_grok_holder() {
   local home fakebin out
   home="$TMP_ROOT/lock-home"
@@ -139,4 +161,5 @@ SH
 
 test_grok_hook_requires_registered_token
 test_grok_teardown_removes_pointer_and_token
+test_grok_relaunch_retires_prior_auth_token
 test_fm_lock_recognizes_grok_holder

--- a/tests/fm-grok-harness.test.sh
+++ b/tests/fm-grok-harness.test.sh
@@ -128,9 +128,9 @@ test_grok_relaunch_retires_prior_auth_token() {
 
   # shellcheck source=bin/fm-harness-launch-lib.sh
   . "$ROOT/bin/fm-harness-launch-lib.sh"
-  GROK_HOME="$grok_home" fm_launch_install_turn_end_hook grok ship "$wt" "$state" "$id" "$state/$id.turn-ended" "$wt"
+  GROK_HOME="$grok_home" fm_launch_install_turn_end_hook grok ship "$wt" "$state" "$id" "$state/$id.turn-ended"
   first=$(cat "$state/$id.grok-turnend-token")
-  GROK_HOME="$grok_home" fm_launch_install_turn_end_hook grok ship "$wt" "$state" "$id" "$state/$id.turn-ended" "$wt"
+  GROK_HOME="$grok_home" fm_launch_install_turn_end_hook grok ship "$wt" "$state" "$id" "$state/$id.turn-ended"
   second=$(cat "$state/$id.grok-turnend-token")
 
   [ "$first" != "$second" ] || fail "relaunch should mint a fresh grok auth token"

--- a/tests/fm-host-pressure.test.sh
+++ b/tests/fm-host-pressure.test.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# Behavior tests for optional host-pressure alerting/backpressure substrate.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+PRESSURE="$ROOT/bin/fm-host-pressure.sh"
+TMP_ROOT=$(fm_test_tmproot fm-host-pressure)
+
+write_pressure_config() {
+  local path=$1
+  shift
+  mkdir -p "$(dirname "$path")"
+  printf '%s\n' "$@" > "$path"
+}
+
+test_absent_config_is_feature_off() {
+  local home state out status
+  home="$TMP_ROOT/off/home"
+  state="$home/state"
+  mkdir -p "$state"
+
+  out=$("$PRESSURE" check --config "$home/config/capacity-failover" --home "$home" --state "$state")
+  status=$?
+
+  expect_code 0 "$status" "absent capacity-failover config should be off"
+  assert_contains "$out" "state=off" "absent config should report feature off"
+  assert_contains "$out" "reason=host_pressure_not_enabled" "off state should explain why"
+  pass "host-pressure check is feature-off when config/capacity-failover is absent"
+}
+
+test_warning_reports_but_allows_spawn() {
+  local home state cfg out status
+  home="$TMP_ROOT/warn/home"
+  state="$home/state"
+  cfg="$home/config/capacity-failover"
+  mkdir -p "$state"
+  write_pressure_config "$cfg" \
+    "host-pressure=on" \
+    "min_memory_available_mb=1000" \
+    "warn_memory_available_mb=2000" \
+    "min_disk_available_mb=1000" \
+    "warn_disk_available_mb=2000" \
+    "max_running_tasks=10"
+
+  out=$(FM_PRESSURE_MEMORY_AVAILABLE_MB=1500 FM_PRESSURE_DISK_AVAILABLE_MB=2500 FM_PRESSURE_RUNNING_TASKS=1 \
+    "$PRESSURE" check --config "$cfg" --home "$home" --state "$state")
+  status=$?
+
+  expect_code 0 "$status" "warning pressure should allow the caller to continue"
+  assert_contains "$out" "state=warn" "memory below warn threshold should warn"
+  assert_contains "$out" "reason=memory_available_below_warn" "warning reason should cite memory"
+  pass "host-pressure warning reports pressure without applying backpressure"
+}
+
+test_critical_pressure_returns_nonzero_and_reports_cleanup_candidates() {
+  local home state cfg out status
+  home="$TMP_ROOT/critical/home"
+  state="$home/state"
+  cfg="$home/config/capacity-failover"
+  mkdir -p "$state"
+  write_pressure_config "$cfg" \
+    "host-pressure=on" \
+    "min_memory_available_mb=1000" \
+    "warn_memory_available_mb=2000" \
+    "disk_floor_mb=1000" \
+    "disk_clear_mb=2000" \
+    "max_running_tasks=2"
+
+  out=$(FM_PRESSURE_MEMORY_AVAILABLE_MB=500 FM_PRESSURE_DISK_AVAILABLE_MB=700 FM_PRESSURE_RUNNING_TASKS=2 \
+    "$PRESSURE" check --config "$cfg" --home "$home" --state "$state" 2>&1)
+  status=$?
+
+  expect_code 1 "$status" "critical pressure should return non-zero"
+  assert_contains "$out" "state=critical" "critical pressure should report critical state"
+  assert_contains "$out" "memory_available_below_min" "critical reason should include memory"
+  assert_contains "$out" "disk_floor_below_min" "critical reason should include disk floor"
+  assert_contains "$out" "running_tasks_at_or_above_max" "critical reason should include concurrency"
+  assert_contains "$out" "transient_candidate=" "critical disk pressure should report cleanup candidates"
+  pass "host-pressure critical state applies bounded backpressure evidence"
+}
+
+test_active_task_count_reads_meta_records() {
+  local home state cfg out status
+  home="$TMP_ROOT/count/home"
+  state="$home/state"
+  cfg="$home/config/capacity-failover"
+  mkdir -p "$state"
+  write_pressure_config "$cfg" \
+    "host-pressure=on" \
+    "min_memory_available_mb=1000" \
+    "warn_memory_available_mb=2000" \
+    "min_disk_available_mb=1000" \
+    "warn_disk_available_mb=2000" \
+    "max_running_tasks=3"
+  fm_write_meta "$state/a.meta" "window=firstmate:fm-a" "kind=ship"
+  fm_write_meta "$state/b.meta" "window=firstmate:fm-b" "kind=scout"
+  fm_write_meta "$state/c.meta" "kind=ship"
+
+  out=$(FM_PRESSURE_MEMORY_AVAILABLE_MB=5000 FM_PRESSURE_DISK_AVAILABLE_MB=5000 \
+    "$PRESSURE" check --config "$cfg" --home "$home" --state "$state")
+  status=$?
+
+  expect_code 0 "$status" "active count below max should pass"
+  assert_contains "$out" "running_tasks=2" "running task count should use meta records with window="
+  pass "host-pressure concurrency count is derived from firstmate task ownership meta"
+}
+
+test_disk_floor_gate_blocks_heavy_test_launch() {
+  local home state cfg out status
+  home="$TMP_ROOT/disk-gate/home"
+  state="$home/state"
+  cfg="$home/config/capacity-failover"
+  mkdir -p "$state"
+  write_pressure_config "$cfg" \
+    "host-pressure=on" \
+    "disk_floor_mb=9000" \
+    "disk_clear_mb=12000" \
+    "max_running_tasks=99"
+
+  out=$(FM_PRESSURE_MEMORY_AVAILABLE_MB=5000 FM_PRESSURE_DISK_AVAILABLE_MB=8200 FM_PRESSURE_RUNNING_TASKS=0 \
+    "$PRESSURE" gate --kind test --config "$cfg" --home "$home" --state "$state" 2>&1)
+  status=$?
+
+  expect_code 1 "$status" "disk below hard floor should block heavy test launches"
+  assert_contains "$out" "gate_kind=test" "gate output should record the gated launch kind"
+  assert_contains "$out" "disk_floor_below_min" "disk floor should be the blocking reason"
+  assert_contains "$out" "disk_available_mb=8200" "gate should include exact available disk evidence"
+  pass "hard disk floor blocks heavy test launches below threshold"
+}
+
+test_disk_floor_hysteresis_holds_until_clear_threshold() {
+  local home state cfg out status
+  home="$TMP_ROOT/hysteresis/home"
+  state="$home/state"
+  cfg="$home/config/capacity-failover"
+  mkdir -p "$state"
+  write_pressure_config "$cfg" \
+    "host-pressure=on" \
+    "disk_floor_mb=9000" \
+    "disk_clear_mb=12000" \
+    "max_running_tasks=99"
+
+  out=$(FM_PRESSURE_MEMORY_AVAILABLE_MB=5000 FM_PRESSURE_DISK_AVAILABLE_MB=8500 FM_PRESSURE_RUNNING_TASKS=0 \
+    "$PRESSURE" check --config "$cfg" --home "$home" --state "$state" 2>&1)
+  status=$?
+  expect_code 1 "$status" "below floor should enter pressure"
+  assert_contains "$out" "disk_hysteresis=entered" "first below-floor check should enter hysteresis"
+
+  out=$(FM_PRESSURE_MEMORY_AVAILABLE_MB=5000 FM_PRESSURE_DISK_AVAILABLE_MB=10000 FM_PRESSURE_RUNNING_TASKS=0 \
+    "$PRESSURE" check --config "$cfg" --home "$home" --state "$state" 2>&1)
+  status=$?
+  expect_code 1 "$status" "between floor and clear should stay blocked"
+  assert_contains "$out" "disk_hysteresis=held" "disk floor should not flap clear below disk_clear_mb"
+
+  out=$(FM_PRESSURE_MEMORY_AVAILABLE_MB=5000 FM_PRESSURE_DISK_AVAILABLE_MB=13000 FM_PRESSURE_RUNNING_TASKS=0 \
+    "$PRESSURE" check --config "$cfg" --home "$home" --state "$state")
+  status=$?
+  expect_code 0 "$status" "above clear threshold should release pressure"
+  assert_contains "$out" "disk_hysteresis=inactive" "disk floor should clear only above disk_clear_mb"
+  pass "disk floor hysteresis prevents repeated enter/exit flapping"
+}
+
+test_periodic_disk_alert_is_bounded_by_cooldown() {
+  local home state cfg out status
+  home="$TMP_ROOT/alert/home"
+  state="$home/state"
+  cfg="$home/config/capacity-failover"
+  mkdir -p "$state"
+  write_pressure_config "$cfg" \
+    "host-pressure=on" \
+    "disk_floor_mb=9000" \
+    "disk_clear_mb=12000" \
+    "disk_alert_cooldown_secs=300" \
+    "max_running_tasks=99"
+
+  out=$(FM_PRESSURE_NOW_EPOCH=1000 FM_PRESSURE_MEMORY_AVAILABLE_MB=5000 FM_PRESSURE_DISK_AVAILABLE_MB=8200 FM_PRESSURE_RUNNING_TASKS=0 \
+    "$PRESSURE" periodic-alert --config "$cfg" --home "$home" --state "$state")
+  status=$?
+  expect_code 0 "$status" "first disk alert should return zero after emitting"
+  assert_contains "$out" "alert=disk_pressure" "periodic alert should emit bounded alert signal"
+  assert_contains "$out" "disk_available_mb=8200" "periodic alert should include exact disk evidence"
+
+  out=$(FM_PRESSURE_NOW_EPOCH=1100 FM_PRESSURE_MEMORY_AVAILABLE_MB=5000 FM_PRESSURE_DISK_AVAILABLE_MB=8100 FM_PRESSURE_RUNNING_TASKS=0 \
+    "$PRESSURE" periodic-alert --config "$cfg" --home "$home" --state "$state")
+  status=$?
+  expect_code 0 "$status" "cooldown-suppressed disk alert should still return zero"
+  [ -z "$out" ] || fail "disk alert should be suppressed during cooldown: $out"
+  pass "periodic disk-pressure alert emits bounded signals with cooldown"
+}
+
+test_shed_classifier_allows_only_restartable_compute() {
+  local out
+  out=$("$PRESSURE" classify-shed --command "bash tests/fm-capacity.test.sh")
+  assert_contains "$out" "eligible=restartable_compute" "test process should be eligible for safe shedding"
+  assert_contains "$out" "reason=validation_or_test_process" "restartable compute should name its class"
+
+  out=$("$PRESSURE" classify-shed --command "codex --dangerously-bypass-approvals-and-sandbox")
+  assert_contains "$out" "eligible=no" "agent pane processes must not be shed by pressure helper"
+  assert_contains "$out" "not_known_restartable_compute" "non-restartable refusal should be explicit"
+  pass "pressure shedding only classifies restartable validation compute as eligible"
+}
+
+test_absent_config_is_feature_off
+test_warning_reports_but_allows_spawn
+test_critical_pressure_returns_nonzero_and_reports_cleanup_candidates
+test_active_task_count_reads_meta_records
+test_disk_floor_gate_blocks_heavy_test_launch
+test_disk_floor_hysteresis_holds_until_clear_threshold
+test_periodic_disk_alert_is_bounded_by_cooldown
+test_shed_classifier_allows_only_restartable_compute
+
+echo "# all fm-host-pressure tests passed"

--- a/tests/fm-host-pressure.test.sh
+++ b/tests/fm-host-pressure.test.sh
@@ -190,6 +190,52 @@ test_periodic_disk_alert_is_bounded_by_cooldown() {
   pass "periodic disk-pressure alert emits bounded signals with cooldown"
 }
 
+test_periodic_config_error_alert_is_bounded_by_cooldown() {
+  local home state cfg out status
+  home="$TMP_ROOT/cfgalert/home"
+  state="$home/state"
+  cfg="$home/config/capacity-failover"
+  mkdir -p "$state"
+  write_pressure_config "$cfg" \
+    "host-pressure=on" \
+    "disk_floor_mb=10G"
+
+  out=$(FM_PRESSURE_NOW_EPOCH=1000 FM_PRESSURE_MEMORY_AVAILABLE_MB=5000 FM_PRESSURE_DISK_AVAILABLE_MB=50000 FM_PRESSURE_RUNNING_TASKS=0 \
+    "$PRESSURE" periodic-alert --config "$cfg" --home "$home" --state "$state" 2>/dev/null)
+  status=$?
+  expect_code 2 "$status" "invalid config should be reported as a refusal"
+  assert_contains "$out" "alert=host_pressure_config_invalid" "config refusal should surface as an alert record"
+  assert_contains "$out" "disk_floor_mb" "config refusal should name the offending key"
+
+  out=$(FM_PRESSURE_NOW_EPOCH=1600 FM_PRESSURE_MEMORY_AVAILABLE_MB=5000 FM_PRESSURE_DISK_AVAILABLE_MB=50000 FM_PRESSURE_RUNNING_TASKS=0 \
+    "$PRESSURE" periodic-alert --config "$cfg" --home "$home" --state "$state" 2>/dev/null)
+  status=$?
+  expect_code 0 "$status" "cooldown-suppressed config alert should return zero"
+  [ -z "$out" ] || fail "repeated config refusal should be suppressed during cooldown: $out"
+
+  write_pressure_config "$cfg" \
+    "host-pressure=on" \
+    "max_running_tasks=lots"
+  out=$(FM_PRESSURE_NOW_EPOCH=1700 FM_PRESSURE_MEMORY_AVAILABLE_MB=5000 FM_PRESSURE_DISK_AVAILABLE_MB=50000 FM_PRESSURE_RUNNING_TASKS=0 \
+    "$PRESSURE" periodic-alert --config "$cfg" --home "$home" --state "$state" 2>/dev/null)
+  status=$?
+  expect_code 2 "$status" "a different config refusal should re-alert inside the cooldown"
+  assert_contains "$out" "max_running_tasks" "changed refusal should report the new offending key"
+
+  write_pressure_config "$cfg" \
+    "host-pressure=on" \
+    "disk_floor_mb=9000" \
+    "disk_clear_mb=12000" \
+    "max_running_tasks=99"
+  out=$(FM_PRESSURE_NOW_EPOCH=1800 FM_PRESSURE_MEMORY_AVAILABLE_MB=5000 FM_PRESSURE_DISK_AVAILABLE_MB=50000 FM_PRESSURE_RUNNING_TASKS=0 \
+    "$PRESSURE" periodic-alert --config "$cfg" --home "$home" --state "$state" 2>/dev/null)
+  status=$?
+  expect_code 0 "$status" "repaired config should stop alerting"
+  [ -z "$out" ] || fail "healthy config should emit no alert: $out"
+  [ ! -f "$state/.host-pressure-config-alert" ] || fail "repaired config should clear the config-alert marker"
+  pass "periodic config-refusal alert is cooldown-bounded and re-alerts on a changed refusal"
+}
+
 test_shed_classifier_allows_only_restartable_compute() {
   local out
   out=$("$PRESSURE" classify-shed --command "bash tests/fm-capacity.test.sh")
@@ -209,6 +255,7 @@ test_active_task_count_reads_meta_records
 test_disk_floor_gate_blocks_heavy_test_launch
 test_disk_floor_hysteresis_holds_until_clear_threshold
 test_periodic_disk_alert_is_bounded_by_cooldown
+test_periodic_config_error_alert_is_bounded_by_cooldown
 test_shed_classifier_allows_only_restartable_compute
 
 echo "# all fm-host-pressure tests passed"

--- a/tests/fm-pi-watch-extension.test.sh
+++ b/tests/fm-pi-watch-extension.test.sh
@@ -68,13 +68,14 @@ test_tracked_extension_present_and_self_hashing() {
 }
 
 test_spawn_template_mentions_pi_watch_placeholder() {
-  local text
-  text=$(cat "$ROOT/bin/fm-spawn.sh")
-  assert_contains "$text" "-e __PITURNEND__ -e __PIWATCH__" "Pi secondmate launch template does not include both primary extensions"
-  assert_contains "$text" "\$PROJ_ABS/.pi/extensions/fm-primary-pi-watch.ts" "fm-spawn does not point the Pi secondmate watch placeholder at the tracked extension"
-  assert_not_contains "$text" "fm-pi-watch-extension.sh" "fm-spawn should no longer generate the Pi watch extension before launch"
-  assert_contains "$text" "__PITURNEND__" "fm-spawn does not replace the Pi turn-end guard extension placeholder"
-  assert_contains "$text" "__PIWATCH__" "fm-spawn does not replace the Pi watch extension placeholder"
+  local spawn_text launch_text
+  spawn_text=$(cat "$ROOT/bin/fm-spawn.sh")
+  launch_text=$(cat "$ROOT/bin/fm-harness-launch-lib.sh")
+  assert_contains "$launch_text" "-e __PITURNEND__ -e __PIWATCH__" "Pi secondmate launch template does not include both primary extensions"
+  assert_contains "$spawn_text" "\$PROJ_ABS/.pi/extensions/fm-primary-pi-watch.ts" "fm-spawn does not point the Pi secondmate watch placeholder at the tracked extension"
+  assert_not_contains "$spawn_text" "fm-pi-watch-extension.sh" "fm-spawn should no longer generate the Pi watch extension before launch"
+  assert_contains "$spawn_text" "__PITURNEND__" "fm-spawn does not replace the Pi turn-end guard extension placeholder"
+  assert_contains "$spawn_text" "__PIWATCH__" "fm-spawn does not replace the Pi watch extension placeholder"
   pass "Pi secondmate launch wiring includes both tracked primary extensions"
 }
 

--- a/tests/fm-pr-merge.test.sh
+++ b/tests/fm-pr-merge.test.sh
@@ -88,6 +88,7 @@ run_pr_merge() {
   local case_dir=$1 rc; shift
   FM_ROOT_OVERRIDE="$ROOT" \
   FM_STATE_OVERRIDE="$case_dir/state" \
+  FM_SHARED_STATE_OVERRIDE="$case_dir/shared-quota" \
   FM_TEST_GH_AXI_LOG="$case_dir/gh-axi.log" \
   PATH="$case_dir/fakebin:$PATH" \
     "$PR_MERGE" "$@"

--- a/tests/fm-rehome-quota-wall.test.sh
+++ b/tests/fm-rehome-quota-wall.test.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+# Behavior tests for safe same-worktree quota-wall rehome.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+REHOME="$ROOT/bin/fm-rehome-quota-wall.sh"
+TMP_ROOT=$(fm_test_tmproot fm-rehome-quota-wall)
+
+make_rehome_fakebin() {
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+log=${FM_FAKE_TMUX_LOG:-/dev/null}
+printf '%s\n' "$*" >> "$log"
+
+if [ "${1:-}" = display-message ]; then
+  case "$*" in
+    *"#{pane_current_command}"*) printf '%s\n' "${FM_FAKE_OLD_COMMAND:-zsh}"; exit 0 ;;
+    *"#{pane_id}"*)
+      printf '%%pane\n'
+      exit 0
+      ;;
+    *"#S"*) printf 'firstmate\n'; exit 0 ;;
+  esac
+fi
+
+case "${1:-}" in
+  has-session|set-window-option) exit 0 ;;
+  list-windows)
+    if [ -n "${FM_FAKE_OLD_EXISTS:-}" ] && [ -f "$FM_FAKE_OLD_EXISTS" ]; then
+      printf 'other-window\n'
+    fi
+    exit 0
+    ;;
+  new-window)
+    printf '@new\n'
+    exit 0
+    ;;
+  kill-window)
+    [ -n "${FM_FAKE_OLD_EXISTS:-}" ] && rm -f "$FM_FAKE_OLD_EXISTS"
+    exit 0
+    ;;
+  send-keys)
+    if [ -n "${FM_FAKE_LAUNCH_LOG:-}" ]; then
+      prev=
+      for a in "$@"; do
+        if [ "$prev" = "-l" ]; then
+          printf '%s\n' "$a" >> "$FM_FAKE_LAUNCH_LOG"
+        fi
+        prev=$a
+      done
+    fi
+    exit 0
+    ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+  printf '%s\n' "$fakebin"
+}
+
+make_case() {
+  local name=$1 case_dir home proj wt fakebin launchlog tmuxlog oldexists id
+  id=${2:-task-x1}
+  case_dir="$TMP_ROOT/$name"
+  home="$case_dir/home"
+  proj="$case_dir/project"
+  wt="$case_dir/wt"
+  fakebin=$(make_rehome_fakebin "$case_dir/fake")
+  launchlog="$case_dir/launch.log"
+  tmuxlog="$case_dir/tmux.log"
+  oldexists="$case_dir/old-exists"
+  mkdir -p "$home/data/$id" "$home/state" "$home/config"
+  printf 'original brief for %s\n' "$id" > "$home/data/$id/brief.md"
+  fm_git_worktree "$proj" "$wt" "fm/$id"
+  touch "$oldexists"
+  fm_write_meta "$home/state/$id.meta" \
+    "window=firstmate:fm-$id" \
+    "worktree=$wt" \
+    "project=$proj" \
+    "harness=codex" \
+    "kind=ship" \
+    "mode=no-mistakes" \
+    "yolo=off" \
+    "tasktmp=$case_dir/tasktmp" \
+    "model=gpt-5.5" \
+    "effort=xhigh" \
+    "pr=https://github.com/example/repo/pull/7" \
+    "pr_head=$(git -C "$wt" rev-parse HEAD)"
+  printf '%s|%s|%s|%s|%s|%s|%s|%s\n' "$case_dir" "$home" "$proj" "$wt" "$fakebin" "$launchlog" "$tmuxlog" "$oldexists"
+}
+
+read_case() {
+  IFS='|' read -r _ HOME_DIR _ WT_DIR FAKEBIN_DIR LAUNCH_LOG TMUX_LOG OLD_EXISTS <<EOF
+$1
+EOF
+}
+
+run_rehome() {
+  local home=$1 fakebin=$2 launchlog=$3 tmuxlog=$4 oldexists=$5
+  shift 5
+  : > "$launchlog"
+  : > "$tmuxlog"
+  FM_ROOT_OVERRIDE='' FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" FM_CONFIG_OVERRIDE="$home/config" \
+    FM_FAKE_LAUNCH_LOG="$launchlog" FM_FAKE_TMUX_LOG="$tmuxlog" FM_FAKE_OLD_EXISTS="$oldexists" \
+    FM_FAKE_OLD_COMMAND="${FM_FAKE_OLD_COMMAND:-zsh}" \
+    TMUX="fake,1,0" PATH="$fakebin:$PATH" "$REHOME" "$@" 2>&1
+}
+
+test_rehome_reuses_task_identity_and_worktree() {
+  local rec out status meta continuation launch meta_count
+  rec=$(make_case happy task-x1)
+  read_case "$rec"
+
+  out=$(run_rehome "$HOME_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$TMUX_LOG" "$OLD_EXISTS" \
+    task-x1 --harness claude --model sonnet --effort high)
+  status=$?
+  expect_code 0 "$status" "happy rehome should succeed"
+  assert_contains "$out" "rehomed task-x1 from codex to claude" "rehome summary should name old and new harness"
+  assert_absent "$OLD_EXISTS" "old endpoint marker should be killed before relaunch"
+
+  meta="$HOME_DIR/state/task-x1.meta"
+  assert_grep "worktree=$WT_DIR" "$meta" "rehome must preserve the same worktree"
+  assert_grep "pr=https://github.com/example/repo/pull/7" "$meta" "rehome must preserve recorded PR URL"
+  assert_grep "harness=claude" "$meta" "meta should record new harness"
+  assert_grep "model=sonnet" "$meta" "meta should record new model"
+  assert_grep "effort=high" "$meta" "meta should record new effort"
+  [ "$(grep -c '^window=' "$meta")" = 1 ] || fail "rehome should rewrite meta to one window= owner"
+  meta_count=$(find "$HOME_DIR/state" -maxdepth 1 -name 'task-x1*.meta' -print | wc -l | tr -d ' ')
+  [ "$meta_count" = 1 ] || fail "rehome should not create duplicate task meta records"
+
+  continuation=$(sed -n 's/^rehome_continuation=//p' "$meta" | tail -1)
+  assert_present "$continuation" "rehome should write a continuation brief"
+  assert_grep "This is the same firstmate task" "$continuation" "continuation should preserve task identity"
+  assert_grep "Recorded PR: https://github.com/example/repo/pull/7" "$continuation" "continuation should carry PR identity"
+
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "claude --dangerously-skip-permissions --model 'sonnet' --effort 'high'" \
+    "rehome launch should use the requested harness profile"
+  pass "rehome preserves task/PR identity while relaunching the same worktree"
+}
+
+test_dirty_worktree_refuses_without_override() {
+  local rec out status
+  rec=$(make_case dirty task-dirty)
+  read_case "$rec"
+  printf '%s\n' dirty > "$WT_DIR/dirty.txt"
+
+  set +e
+  out=$(run_rehome "$HOME_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$TMUX_LOG" "$OLD_EXISTS" \
+    task-dirty --harness claude)
+  status=$?
+  set -e
+
+  expect_code 1 "$status" "dirty worktree should refuse"
+  assert_contains "$out" "REFUSED: worktree" "dirty refusal should be explicit"
+  assert_present "$OLD_EXISTS" "dirty refusal must not kill the old endpoint"
+  pass "rehome refuses dirty uncommitted work unless explicitly overridden"
+}
+
+test_dispatch_profile_requires_approval_flag() {
+  local rec out status
+  rec=$(make_case dispatch task-dispatch)
+  read_case "$rec"
+  printf '{"rules":[{"when":"reviews","use":{"harness":"claude"}}]}\n' > "$HOME_DIR/config/crew-dispatch.json"
+
+  set +e
+  out=$(run_rehome "$HOME_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$TMUX_LOG" "$OLD_EXISTS" \
+    task-dispatch --harness claude)
+  status=$?
+  set -e
+
+  expect_code 1 "$status" "active dispatch profile should require explicit approval"
+  assert_contains "$out" "consult it first" "dispatch-profile refusal should explain the backstop"
+  assert_present "$OLD_EXISTS" "dispatch-profile refusal must not kill the old endpoint"
+  pass "rehome refuses to bypass active crew-dispatch rules"
+}
+
+test_opposite_harness_constraint_refuses_same_harness() {
+  local rec out status
+  rec=$(make_case opposite task-opposite)
+  read_case "$rec"
+  printf '%s\n' 'opposite_harness_must_differ_from=codex' >> "$HOME_DIR/state/task-opposite.meta"
+
+  set +e
+  out=$(run_rehome "$HOME_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$TMUX_LOG" "$OLD_EXISTS" \
+    task-opposite --harness codex)
+  status=$?
+  set -e
+
+  expect_code 1 "$status" "opposite-harness violation should refuse"
+  assert_contains "$out" "violates opposite_harness_must_differ_from=codex" \
+    "opposite-harness refusal should cite the constraint"
+  assert_present "$OLD_EXISTS" "opposite-harness refusal must not kill the old endpoint"
+  pass "rehome preserves adversarial-review opposite-harness constraints"
+}
+
+test_alive_old_endpoint_refuses_duplicate_owner() {
+  local rec out status
+  rec=$(make_case alive task-alive)
+  read_case "$rec"
+
+  set +e
+  out=$(FM_FAKE_OLD_COMMAND=codex run_rehome "$HOME_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$TMUX_LOG" "$OLD_EXISTS" \
+    task-alive --harness claude)
+  status=$?
+  set -e
+
+  expect_code 1 "$status" "alive old endpoint should refuse duplicate ownership"
+  assert_contains "$out" "old endpoint still reports agent_alive=alive" \
+    "alive refusal should cite duplicate ownership"
+  assert_present "$OLD_EXISTS" "alive refusal must not kill the old endpoint"
+  pass "rehome refuses to duplicate ownership when the old agent is still alive"
+}
+
+test_rehome_reuses_task_identity_and_worktree
+test_dirty_worktree_refuses_without_override
+test_dispatch_profile_requires_approval_flag
+test_opposite_harness_constraint_refuses_same_harness
+test_alive_old_endpoint_refuses_duplicate_owner
+
+echo "# all fm-rehome-quota-wall tests passed"

--- a/tests/fm-rehome-quota-wall.test.sh
+++ b/tests/fm-rehome-quota-wall.test.sh
@@ -127,6 +127,10 @@ test_rehome_reuses_task_identity_and_worktree() {
   meta="$HOME_DIR/state/task-x1.meta"
   assert_grep "worktree=$WT_DIR" "$meta" "rehome must preserve the same worktree"
   assert_grep "pr=https://github.com/example/repo/pull/7" "$meta" "rehome must preserve recorded PR URL"
+  bash -c '. "$1/bin/fm-pr-lib.sh" && fm_pr_metadata_identity_parse "$2"' _ "$ROOT" "$meta" \
+    || fail "rehome must leave meta parseable as canonical PR identity for the armed merge poll"
+  [ "$(sed -n '$p' "$meta" | cut -d= -f1)" = pr_head ] \
+    || fail "rehome must re-append PR identity after every rewritten key"
   assert_grep "harness=claude" "$meta" "meta should record new harness"
   assert_grep "model=sonnet" "$meta" "meta should record new model"
   assert_grep "effort=high" "$meta" "meta should record new effort"

--- a/tests/fm-shared-github-quota.test.sh
+++ b/tests/fm-shared-github-quota.test.sh
@@ -11,6 +11,7 @@ PR_MERGE="$ROOT/bin/fm-pr-merge.sh"
 WATCH="$ROOT/bin/fm-watch.sh"
 TMP_ROOT=$(fm_test_tmproot fm-shared-github-quota)
 PR_URL=https://github.com/example/repo/pull/9
+TEST_ACCOUNT=12345678
 
 make_fakebin() {
   local dir=$1 fakebin
@@ -54,6 +55,7 @@ arm_check() {
   FM_CONFIG_OVERRIDE="$home/config" \
   FM_SHARED_STATE_OVERRIDE="$shared" \
   FM_SHARED_QUOTA_NOW_EPOCH="$now" \
+  FM_GITHUB_ACCOUNT_ID="$TEST_ACCOUNT" \
   FM_TEST_GH_LOG="$home/gh.log" \
   PATH="$fakebin:$PATH" \
     "$PR_CHECK" task-x1 "$PR_URL" >/dev/null 2>"$home/pr-check.err"
@@ -61,8 +63,11 @@ arm_check() {
 
 run_check_script() {
   local home=$1 fakebin=$2 shared=$3 now=$4
+  FM_ROOT_OVERRIDE="$ROOT" \
+  FM_HOME="$home" \
   FM_SHARED_STATE_OVERRIDE="$shared" \
   FM_SHARED_QUOTA_NOW_EPOCH="$now" \
+  FM_GITHUB_ACCOUNT_ID="$TEST_ACCOUNT" \
   FM_TEST_GH_LOG="$home/gh.log" \
   PATH="$fakebin:$PATH" \
     bash "$home/state/task-x1.check.sh"
@@ -71,21 +76,21 @@ run_check_script() {
 mark_cooldown() {
   local shared=$1 reset=$2 now=$3
   FM_SHARED_STATE_OVERRIDE="$shared" FM_SHARED_QUOTA_NOW_EPOCH="$now" \
-    "$QUOTA" mark --provider github --account 94498628 --route default --reset-epoch "$reset" --source test >/dev/null
+    "$QUOTA" mark --provider github --account "$TEST_ACCOUNT" --route default --reset-epoch "$reset" --source test >/dev/null
 }
 
 test_mark_from_text_records_observed_account_and_reset() {
   local shared out active
   shared="$TMP_ROOT/shared-text"
-  out=$(printf '%s\n' 'GitHub user/account 94498628 is rate-limited until 2026-07-13T02:23:23Z.' \
+  out=$(printf 'GitHub user/account %s is rate-limited until 2026-07-13T02:23:23Z.\n' "$TEST_ACCOUNT" \
     | FM_SHARED_STATE_OVERRIDE="$shared" FM_SHARED_QUOTA_NOW_EPOCH=1000 \
       "$QUOTA" mark-from-text --provider github --route default --source incident)
   assert_contains "$out" "provider=github" "mark-from-text should preserve provider"
-  assert_contains "$out" "account=94498628" "mark-from-text should extract the GitHub account"
+  assert_contains "$out" "account=$TEST_ACCOUNT" "mark-from-text should extract the GitHub account"
   assert_contains "$out" "reset_at=2026-07-13T02:23:23Z" "mark-from-text should preserve observed reset time"
 
   active=$(FM_SHARED_STATE_OVERRIDE="$shared" FM_SHARED_QUOTA_NOW_EPOCH=1000 \
-    "$QUOTA" check --provider github --account 94498628 --route default)
+    "$QUOTA" check --provider github --account "$TEST_ACCOUNT" --route default)
   assert_contains "$active" "state=defer" "observed GitHub cooldown should be active"
   assert_contains "$active" "reset_at=2026-07-13T02:23:23Z" "active cooldown should report reset evidence"
   pass "observed GitHub account/reset text records a shared cooldown"
@@ -162,7 +167,7 @@ test_cached_read_is_used_during_cooldown_without_gh() {
   home=$(make_home cache-home)
   : > "$home/gh.log"
   printf '%s\n' MERGED | FM_SHARED_STATE_OVERRIDE="$shared" FM_SHARED_QUOTA_NOW_EPOCH=900 \
-    "$QUOTA" cache-put --provider github --account 94498628 --route default --key "pr-state:$PR_URL"
+    "$QUOTA" cache-put --provider github --account "$TEST_ACCOUNT" --route default --key "pr-state:$PR_URL"
   mark_cooldown "$shared" 2000 1000
   arm_check "$home" "$fakebin" "$shared" 1000
 
@@ -182,11 +187,11 @@ test_merge_escalates_with_exact_account_and_reset() {
   home=$(make_home merge-home)
   : > "$home/gh.log"
   FM_SHARED_STATE_OVERRIDE="$shared" FM_SHARED_QUOTA_NOW_EPOCH=1000 \
-    "$QUOTA" mark --provider github --account 94498628 --route default --reset-at 2026-07-13T02:23:23Z --source test >/dev/null
+    "$QUOTA" mark --provider github --account "$TEST_ACCOUNT" --route default --reset-at 2026-07-13T02:23:23Z --source test >/dev/null
 
   set +e
   FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" FM_CONFIG_OVERRIDE="$home/config" \
-    FM_SHARED_STATE_OVERRIDE="$shared" FM_SHARED_QUOTA_NOW_EPOCH=1000 \
+    FM_SHARED_STATE_OVERRIDE="$shared" FM_SHARED_QUOTA_NOW_EPOCH=1000 FM_GITHUB_ACCOUNT_ID="$TEST_ACCOUNT" \
     FM_TEST_GH_LOG="$home/gh.log" PATH="$fakebin:$PATH" \
     "$PR_MERGE" task-x1 "$PR_URL" > "$home/merge.out" 2> "$home/merge.err"
   status=$?
@@ -196,7 +201,7 @@ test_merge_escalates_with_exact_account_and_reset() {
   err=$(cat "$home/merge.err")
   assert_contains "$err" "escalation=github_shared_quota" "merge refusal should be a structured escalation"
   assert_contains "$err" "provider=github" "merge escalation should name provider"
-  assert_contains "$err" "account=94498628" "merge escalation should name account"
+  assert_contains "$err" "account=$TEST_ACCOUNT" "merge escalation should name account"
   assert_contains "$err" "reset_at=2026-07-13T02:23:23Z" "merge escalation should name reset time"
   assert_contains "$err" "needed_action=wait until reset" "merge escalation should name the required action"
   calls=$(grep -c '^gh-axi pr merge' "$home/gh.log" || true)

--- a/tests/fm-shared-github-quota.test.sh
+++ b/tests/fm-shared-github-quota.test.sh
@@ -167,6 +167,42 @@ test_live_gh_rate_limit_evidence_records_cooldown() {
   pass "real gh rate-limit evidence records cooldowns without trusting bare numbers"
 }
 
+test_labeled_header_wins_over_stale_scraped_timestamp() {
+  local shared out status
+  shared="$TMP_ROOT/shared-live-shadowed"
+  out=$(printf '2026-07-13T02:23:23Z gh: HTTP 403: API rate limit exceeded for user ID 55.\nX-RateLimit-Reset: 1799999999\n' \
+    | FM_SHARED_STATE_OVERRIDE="$shared" FM_SHARED_QUOTA_NOW_EPOCH=1799000000 \
+      FM_GITHUB_ACCOUNT_ID="$TEST_ACCOUNT" \
+      "$QUOTA" mark-from-text --provider github --route default --source incident)
+  assert_contains "$out" "reset_epoch=1799999999" \
+    "a past log timestamp must not shadow labeled header evidence"
+
+  shared="$TMP_ROOT/shared-live-prose"
+  set +e
+  printf 'You have exceeded a secondary rate limit; please retry after 15 minutes.\n' \
+    | FM_SHARED_STATE_OVERRIDE="$shared" FM_SHARED_QUOTA_NOW_EPOCH=1000 \
+      FM_GITHUB_ACCOUNT_ID="$TEST_ACCOUNT" \
+      "$QUOTA" mark-from-text --provider github --route default >/dev/null 2>&1
+  status=$?
+  set -e
+  expect_code 1 "$status" "unlabeled retry-after prose must not be read as seconds"
+  pass "labeled reset evidence is preferred and prose retry-after is refused"
+}
+
+test_cache_written_before_an_account_resolves_is_read_back() {
+  local shared body
+  shared="$TMP_ROOT/shared-cache-agnostic"
+  printf 'MERGED\n' | FM_SHARED_STATE_OVERRIDE="$shared" FM_SHARED_QUOTA_NOW_EPOCH=1000 \
+    FM_SHARED_GITHUB_QUOTA_DERIVE_ACCOUNT=0 \
+    "$QUOTA" cache-put --provider github --route default --key pr-state
+  body=$(FM_SHARED_STATE_OVERRIDE="$shared" FM_SHARED_QUOTA_NOW_EPOCH=1000 \
+    "$QUOTA" cache-get --provider github --account "$TEST_ACCOUNT" --route default \
+    --key pr-state --max-age-secs 600)
+  assert_contains "$body" "MERGED" \
+    "a later resolved read should still reach the account-agnostic cache entry"
+  pass "cached reads survive an account resolving after the entry was written"
+}
+
 test_cache_uses_the_same_key_policy_as_cooldowns() {
   local shared body
   shared="$TMP_ROOT/shared-cache-key"
@@ -358,7 +394,9 @@ test_mark_from_text_never_overwrites_remembered_account
 test_unresolvable_account_cooldown_is_read_back
 test_reset_without_account_text_still_records_cooldown
 test_live_gh_rate_limit_evidence_records_cooldown
+test_labeled_header_wins_over_stale_scraped_timestamp
 test_cache_uses_the_same_key_policy_as_cooldowns
+test_cache_written_before_an_account_resolves_is_read_back
 test_cooldown_record_must_match_the_key_it_was_found_under
 test_shared_cooldown_blocks_polling_across_homes
 test_local_status_supervision_continues_during_cooldown

--- a/tests/fm-shared-github-quota.test.sh
+++ b/tests/fm-shared-github-quota.test.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+# Behavior tests for fleet-wide shared GitHub quota coordination.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+QUOTA="$ROOT/bin/fm-shared-github-quota.sh"
+PR_CHECK="$ROOT/bin/fm-pr-check.sh"
+PR_MERGE="$ROOT/bin/fm-pr-merge.sh"
+WATCH="$ROOT/bin/fm-watch.sh"
+TMP_ROOT=$(fm_test_tmproot fm-shared-github-quota)
+PR_URL=https://github.com/example/repo/pull/9
+
+make_fakebin() {
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/gh" <<'SH'
+#!/usr/bin/env bash
+printf 'gh %s\n' "$*" >> "$FM_TEST_GH_LOG"
+case " $* " in
+  *" --json headRefOid "*) printf '%s\n' deadbeefcafefeed0000000000000000deadbeef; exit 0 ;;
+  *" --json state "*) printf '%s\n' "${FM_FAKE_PR_STATE:-OPEN}"; exit 0 ;;
+esac
+exit 0
+SH
+  cat > "$fakebin/gh-axi" <<'SH'
+#!/usr/bin/env bash
+printf 'gh-axi %s\n' "$*" >> "$FM_TEST_GH_LOG"
+exit 0
+SH
+  chmod +x "$fakebin/gh" "$fakebin/gh-axi"
+  printf '%s\n' "$fakebin"
+}
+
+make_home() {
+  local name=$1 home
+  home="$TMP_ROOT/$name/home"
+  mkdir -p "$home/state" "$home/config" "$home/wt"
+  fm_write_meta "$home/state/task-x1.meta" \
+    "window=fm-task-x1" \
+    "worktree=$home/wt" \
+    "project=$home/project" \
+    "kind=ship" \
+    "mode=no-mistakes"
+  printf '%s\n' "$home"
+}
+
+arm_check() {
+  local home=$1 fakebin=$2 shared=$3 now=$4
+  FM_ROOT_OVERRIDE="$ROOT" \
+  FM_HOME="$home" \
+  FM_STATE_OVERRIDE="$home/state" \
+  FM_CONFIG_OVERRIDE="$home/config" \
+  FM_SHARED_STATE_OVERRIDE="$shared" \
+  FM_SHARED_QUOTA_NOW_EPOCH="$now" \
+  FM_TEST_GH_LOG="$home/gh.log" \
+  PATH="$fakebin:$PATH" \
+    "$PR_CHECK" task-x1 "$PR_URL" >/dev/null 2>"$home/pr-check.err"
+}
+
+run_check_script() {
+  local home=$1 fakebin=$2 shared=$3 now=$4
+  FM_SHARED_STATE_OVERRIDE="$shared" \
+  FM_SHARED_QUOTA_NOW_EPOCH="$now" \
+  FM_TEST_GH_LOG="$home/gh.log" \
+  PATH="$fakebin:$PATH" \
+    bash "$home/state/task-x1.check.sh"
+}
+
+mark_cooldown() {
+  local shared=$1 reset=$2 now=$3
+  FM_SHARED_STATE_OVERRIDE="$shared" FM_SHARED_QUOTA_NOW_EPOCH="$now" \
+    "$QUOTA" mark --provider github --account 94498628 --route default --reset-epoch "$reset" --source test >/dev/null
+}
+
+test_mark_from_text_records_observed_account_and_reset() {
+  local shared out active
+  shared="$TMP_ROOT/shared-text"
+  out=$(printf '%s\n' 'GitHub user/account 94498628 is rate-limited until 2026-07-13T02:23:23Z.' \
+    | FM_SHARED_STATE_OVERRIDE="$shared" FM_SHARED_QUOTA_NOW_EPOCH=1000 \
+      "$QUOTA" mark-from-text --provider github --route default --source incident)
+  assert_contains "$out" "provider=github" "mark-from-text should preserve provider"
+  assert_contains "$out" "account=94498628" "mark-from-text should extract the GitHub account"
+  assert_contains "$out" "reset_at=2026-07-13T02:23:23Z" "mark-from-text should preserve observed reset time"
+
+  active=$(FM_SHARED_STATE_OVERRIDE="$shared" FM_SHARED_QUOTA_NOW_EPOCH=1000 \
+    "$QUOTA" check --provider github --account 94498628 --route default)
+  assert_contains "$active" "state=defer" "observed GitHub cooldown should be active"
+  assert_contains "$active" "reset_at=2026-07-13T02:23:23Z" "active cooldown should report reset evidence"
+  pass "observed GitHub account/reset text records a shared cooldown"
+}
+
+test_shared_cooldown_blocks_polling_across_homes() {
+  local shared fakebin home_a home_b out
+  shared="$TMP_ROOT/shared-a"
+  fakebin=$(make_fakebin "$TMP_ROOT/fake-a")
+  home_a=$(make_home home-a)
+  home_b=$(make_home home-b)
+  : > "$home_a/gh.log"
+  : > "$home_b/gh.log"
+  mark_cooldown "$shared" 2000 1000
+
+  arm_check "$home_a" "$fakebin" "$shared" 1000
+  arm_check "$home_b" "$fakebin" "$shared" 1000
+  out=$(run_check_script "$home_a" "$fakebin" "$shared" 1000)
+  [ -z "$out" ] || fail "cooldown check should not wake from home A: $out"
+  out=$(run_check_script "$home_b" "$fakebin" "$shared" 1000)
+  [ -z "$out" ] || fail "cooldown check should not wake from home B: $out"
+  [ ! -s "$home_a/gh.log" ] || fail "home A burned gh quota during shared cooldown: $(cat "$home_a/gh.log")"
+  [ ! -s "$home_b/gh.log" ] || fail "home B burned gh quota during shared cooldown: $(cat "$home_b/gh.log")"
+  pass "fleet-wide GitHub cooldown blocks gh-heavy polling across simulated homes"
+}
+
+test_local_status_supervision_continues_during_cooldown() {
+  local shared home out pid i
+  shared="$TMP_ROOT/shared-local"
+  home=$(make_home local-supervision)
+  mark_cooldown "$shared" 2000 1000
+  printf 'done: local status still works\n' > "$home/state/task-x1.status"
+
+  FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" FM_SHARED_STATE_OVERRIDE="$shared" \
+    FM_POLL=1 FM_SIGNAL_GRACE=0 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 \
+    "$WATCH" > "$home/watch.out" &
+  pid=$!
+  i=0
+  while kill -0 "$pid" 2>/dev/null && [ "$i" -lt 50 ]; do
+    sleep 0.1
+    i=$((i + 1))
+  done
+  kill "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+  out=$(cat "$home/watch.out")
+  assert_contains "$out" "signal:" "local status wake should still surface during GitHub cooldown"
+  pass "local status/file supervision continues during shared GitHub cooldown"
+}
+
+test_reset_time_is_honored_before_polling_resumes() {
+  local shared fakebin home out calls
+  shared="$TMP_ROOT/shared-reset"
+  fakebin=$(make_fakebin "$TMP_ROOT/fake-reset")
+  home=$(make_home reset-home)
+  : > "$home/gh.log"
+  mark_cooldown "$shared" 2000 1000
+  arm_check "$home" "$fakebin" "$shared" 1000
+
+  out=$(FM_FAKE_PR_STATE=MERGED run_check_script "$home" "$fakebin" "$shared" 1999)
+  [ -z "$out" ] || fail "polling resumed before reset: $out"
+  [ ! -s "$home/gh.log" ] || fail "gh was called before reset: $(cat "$home/gh.log")"
+
+  out=$(FM_FAKE_PR_STATE=MERGED run_check_script "$home" "$fakebin" "$shared" 2000)
+  assert_contains "$out" "merged" "polling should resume at reset and see merged state"
+  calls=$(grep -c -- '--json state' "$home/gh.log" || true)
+  [ "$calls" = 1 ] || fail "expected one gh state call after reset, got $calls"
+  pass "GitHub cooldown reset time is honored before polling resumes"
+}
+
+test_cached_read_is_used_during_cooldown_without_gh() {
+  local shared fakebin home out calls
+  shared="$TMP_ROOT/shared-cache"
+  fakebin=$(make_fakebin "$TMP_ROOT/fake-cache")
+  home=$(make_home cache-home)
+  : > "$home/gh.log"
+  printf '%s\n' MERGED | FM_SHARED_STATE_OVERRIDE="$shared" FM_SHARED_QUOTA_NOW_EPOCH=900 \
+    "$QUOTA" cache-put --provider github --account 94498628 --route default --key "pr-state:$PR_URL"
+  mark_cooldown "$shared" 2000 1000
+  arm_check "$home" "$fakebin" "$shared" 1000
+
+  out=$(run_check_script "$home" "$fakebin" "$shared" 1000)
+  assert_contains "$out" "merged" "cached merged state should still wake during cooldown"
+  out=$(run_check_script "$home" "$fakebin" "$shared" 1000)
+  assert_contains "$out" "merged" "duplicate cached request should reuse the same cached state"
+  calls=$(grep -c -- '--json state' "$home/gh.log" || true)
+  [ "$calls" = 0 ] || fail "cached cooldown reads should not call gh, got $calls"
+  pass "duplicate GitHub read requests use cached state during cooldown"
+}
+
+test_merge_escalates_with_exact_account_and_reset() {
+  local shared fakebin home status err calls
+  shared="$TMP_ROOT/shared-merge"
+  fakebin=$(make_fakebin "$TMP_ROOT/fake-merge")
+  home=$(make_home merge-home)
+  : > "$home/gh.log"
+  FM_SHARED_STATE_OVERRIDE="$shared" FM_SHARED_QUOTA_NOW_EPOCH=1000 \
+    "$QUOTA" mark --provider github --account 94498628 --route default --reset-at 2026-07-13T02:23:23Z --source test >/dev/null
+
+  set +e
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" FM_CONFIG_OVERRIDE="$home/config" \
+    FM_SHARED_STATE_OVERRIDE="$shared" FM_SHARED_QUOTA_NOW_EPOCH=1000 \
+    FM_TEST_GH_LOG="$home/gh.log" PATH="$fakebin:$PATH" \
+    "$PR_MERGE" task-x1 "$PR_URL" > "$home/merge.out" 2> "$home/merge.err"
+  status=$?
+  set +e
+
+  expect_code 1 "$status" "merge should refuse during shared GitHub cooldown"
+  err=$(cat "$home/merge.err")
+  assert_contains "$err" "escalation=github_shared_quota" "merge refusal should be a structured escalation"
+  assert_contains "$err" "provider=github" "merge escalation should name provider"
+  assert_contains "$err" "account=94498628" "merge escalation should name account"
+  assert_contains "$err" "reset_at=2026-07-13T02:23:23Z" "merge escalation should name reset time"
+  assert_contains "$err" "needed_action=wait until reset" "merge escalation should name the required action"
+  calls=$(grep -c '^gh-axi pr merge' "$home/gh.log" || true)
+  [ "$calls" = 0 ] || fail "merge called gh-axi despite cooldown"
+  pass "shared GitHub quota escalation names provider, account, reset, and action"
+}
+
+test_no_cooldown_preserves_existing_polling_semantics() {
+  local shared fakebin home calls
+  shared="$TMP_ROOT/shared-none"
+  fakebin=$(make_fakebin "$TMP_ROOT/fake-none")
+  home=$(make_home no-cooldown)
+  : > "$home/gh.log"
+  arm_check "$home" "$fakebin" "$shared" 1000
+  FM_FAKE_PR_STATE=OPEN run_check_script "$home" "$fakebin" "$shared" 1000 >/dev/null
+  FM_FAKE_PR_STATE=OPEN run_check_script "$home" "$fakebin" "$shared" 1000 >/dev/null
+  calls=$(grep -c -- '--json state' "$home/gh.log" || true)
+  [ "$calls" = 2 ] || fail "no-cooldown polling should call gh each time, got $calls"
+  pass "default no-cooldown path preserves existing polling behavior"
+}
+
+test_mark_from_text_records_observed_account_and_reset
+test_shared_cooldown_blocks_polling_across_homes
+test_local_status_supervision_continues_during_cooldown
+test_reset_time_is_honored_before_polling_resumes
+test_cached_read_is_used_during_cooldown_without_gh
+test_merge_escalates_with_exact_account_and_reset
+test_no_cooldown_preserves_existing_polling_semantics
+
+echo "# all fm-shared-github-quota tests passed"

--- a/tests/fm-shared-github-quota.test.sh
+++ b/tests/fm-shared-github-quota.test.sh
@@ -87,7 +87,7 @@ test_mark_from_text_records_observed_account_and_reset() {
       FM_SHARED_GITHUB_QUOTA_DERIVE_ACCOUNT=0 \
       "$QUOTA" mark-from-text --provider github --route default --source incident)
   assert_contains "$out" "provider=github" "mark-from-text should preserve provider"
-  assert_contains "$out" "account=$TEST_ACCOUNT" "mark-from-text should extract the GitHub account"
+  assert_contains "$out" "observed_account=$TEST_ACCOUNT" "mark-from-text should report the observed GitHub account"
   assert_contains "$out" "reset_at=2026-07-13T02:23:23Z" "mark-from-text should preserve observed reset time"
 
   active=$(FM_SHARED_STATE_OVERRIDE="$shared" FM_SHARED_QUOTA_NOW_EPOCH=1000 \
@@ -95,6 +95,45 @@ test_mark_from_text_records_observed_account_and_reset() {
   assert_contains "$active" "state=defer" "observed GitHub cooldown should be active"
   assert_contains "$active" "reset_at=2026-07-13T02:23:23Z" "active cooldown should report reset evidence"
   pass "observed GitHub account/reset text records a shared cooldown"
+}
+
+test_unresolvable_account_cooldown_is_read_back() {
+  local shared out active resolved
+  shared="$TMP_ROOT/shared-agnostic"
+  out=$(printf 'API rate limit exceeded; x-ratelimit-reset 1799999999 until 2026-07-13T02:23:23Z.\n' \
+    | FM_SHARED_STATE_OVERRIDE="$shared" FM_SHARED_QUOTA_NOW_EPOCH=1000 \
+      FM_SHARED_GITHUB_QUOTA_DERIVE_ACCOUNT=0 \
+      "$QUOTA" mark-from-text --provider github --route default --source incident)
+  printf '%s\n' "$out" | grep -qx 'account=' \
+    || fail "an unresolvable account should key the account-agnostic record: $out"
+  case "$out" in
+    *observed_account=*) fail "unlabeled digits must not be reported as an observed account" ;;
+  esac
+
+  active=$(FM_SHARED_STATE_OVERRIDE="$shared" FM_SHARED_QUOTA_NOW_EPOCH=1000 \
+    FM_SHARED_GITHUB_QUOTA_DERIVE_ACCOUNT=0 "$QUOTA" check --provider github --route default)
+  assert_contains "$active" "state=defer" "an unresolvable check should read back its own cooldown"
+
+  resolved=$(FM_SHARED_STATE_OVERRIDE="$shared" FM_SHARED_QUOTA_NOW_EPOCH=1000 \
+    "$QUOTA" check --provider github --account "$TEST_ACCOUNT" --route default)
+  assert_contains "$resolved" "state=defer" "a later resolved check should still see the account-agnostic cooldown"
+  pass "cooldowns recorded without a resolvable account are read back by later checks"
+}
+
+test_reset_without_account_text_still_records_cooldown() {
+  local shared out active
+  shared="$TMP_ROOT/shared-no-account-text"
+  out=$(printf 'HTTP 403: API rate limit exceeded; resets at 2026-07-13T02:23:23Z\n' \
+    | FM_SHARED_STATE_OVERRIDE="$shared" FM_SHARED_QUOTA_NOW_EPOCH=1000 \
+      FM_GITHUB_ACCOUNT_ID="$TEST_ACCOUNT" \
+      "$QUOTA" mark-from-text --provider github --route default --source incident)
+  assert_contains "$out" "account=$TEST_ACCOUNT" "a resolved account should key the record without account text"
+  assert_contains "$out" "reset_at=2026-07-13T02:23:23Z" "reset extraction should not require account text"
+
+  active=$(FM_SHARED_STATE_OVERRIDE="$shared" FM_SHARED_QUOTA_NOW_EPOCH=1000 \
+    "$QUOTA" check --provider github --account "$TEST_ACCOUNT" --route default)
+  assert_contains "$active" "state=defer" "account-free rate-limit text should still record a cooldown"
+  pass "rate-limit text without an account still records a keyed cooldown"
 }
 
 test_mark_from_text_never_overwrites_remembered_account() {
@@ -247,6 +286,8 @@ test_no_cooldown_preserves_existing_polling_semantics() {
 
 test_mark_from_text_records_observed_account_and_reset
 test_mark_from_text_never_overwrites_remembered_account
+test_unresolvable_account_cooldown_is_read_back
+test_reset_without_account_text_still_records_cooldown
 test_shared_cooldown_blocks_polling_across_homes
 test_local_status_supervision_continues_during_cooldown
 test_reset_time_is_honored_before_polling_resumes

--- a/tests/fm-shared-github-quota.test.sh
+++ b/tests/fm-shared-github-quota.test.sh
@@ -136,6 +136,75 @@ test_reset_without_account_text_still_records_cooldown() {
   pass "rate-limit text without an account still records a keyed cooldown"
 }
 
+test_live_gh_rate_limit_evidence_records_cooldown() {
+  local shared out active
+  shared="$TMP_ROOT/shared-live-primary"
+  out=$(printf 'HTTP 403: API rate limit exceeded for user ID 55.\nX-RateLimit-Reset: 1799999999\n' \
+    | FM_SHARED_STATE_OVERRIDE="$shared" FM_SHARED_QUOTA_NOW_EPOCH=1000 \
+      FM_GITHUB_ACCOUNT_ID="$TEST_ACCOUNT" \
+      "$QUOTA" mark-from-text --provider github --route default --source incident)
+  assert_contains "$out" "reset_epoch=1799999999" "a labeled x-ratelimit-reset header is observed reset evidence"
+  active=$(FM_SHARED_STATE_OVERRIDE="$shared" FM_SHARED_QUOTA_NOW_EPOCH=1000 \
+    "$QUOTA" check --provider github --account "$TEST_ACCOUNT" --route default)
+  assert_contains "$active" "state=defer" "a primary rate-limit body should record a cooldown"
+
+  shared="$TMP_ROOT/shared-live-secondary"
+  out=$(printf 'You have exceeded a secondary rate limit.\nRetry-After: 120\n' \
+    | FM_SHARED_STATE_OVERRIDE="$shared" FM_SHARED_QUOTA_NOW_EPOCH=1000 \
+      FM_GITHUB_ACCOUNT_ID="$TEST_ACCOUNT" \
+      "$QUOTA" mark-from-text --provider github --route default --source incident)
+  assert_contains "$out" "reset_epoch=1120" "a labeled retry-after is observed reset evidence"
+
+  shared="$TMP_ROOT/shared-live-bare"
+  set +e
+  printf 'API rate limit exceeded 1799999999 for 4242424242.\n' \
+    | FM_SHARED_STATE_OVERRIDE="$shared" FM_SHARED_QUOTA_NOW_EPOCH=1000 \
+      FM_GITHUB_ACCOUNT_ID="$TEST_ACCOUNT" \
+      "$QUOTA" mark-from-text --provider github --route default >/dev/null 2>&1
+  status=$?
+  set -e
+  expect_code 1 "$status" "an unlabeled bare number must never become reset evidence"
+  pass "real gh rate-limit evidence records cooldowns without trusting bare numbers"
+}
+
+test_cache_uses_the_same_key_policy_as_cooldowns() {
+  local shared body
+  shared="$TMP_ROOT/shared-cache-key"
+  printf 'MERGED\n' | FM_SHARED_STATE_OVERRIDE="$shared" FM_SHARED_QUOTA_NOW_EPOCH=1000 \
+    FM_SHARED_GITHUB_QUOTA_DERIVE_ACCOUNT=0 \
+    "$QUOTA" cache-put --provider github --route default --key pr-state
+  body=$(FM_SHARED_STATE_OVERRIDE="$shared" FM_SHARED_QUOTA_NOW_EPOCH=1000 \
+    FM_SHARED_GITHUB_QUOTA_DERIVE_ACCOUNT=0 \
+    "$QUOTA" cache-get --provider github --route default --key pr-state --max-age-secs 600)
+  assert_contains "$body" "MERGED" "an unresolvable account must reach its own account-agnostic cache"
+
+  set +e
+  FM_SHARED_STATE_OVERRIDE="$shared" "$QUOTA" cache-get --provider github --route default \
+    --key pr-state --account 'bad value' >/dev/null 2>&1
+  status=$?
+  set -e
+  expect_code 2 "$status" "an explicitly invalid account is still a caller error"
+  pass "cache reads follow the cooldown key policy while rejecting invalid input"
+}
+
+test_cooldown_record_must_match_the_key_it_was_found_under() {
+  local shared file active
+  shared="$TMP_ROOT/shared-key-mismatch"
+  FM_SHARED_STATE_OVERRIDE="$shared" FM_SHARED_QUOTA_NOW_EPOCH=1000 \
+    "$QUOTA" mark --provider github --account "$TEST_ACCOUNT" --route default \
+    --reset-epoch 1799999999 >/dev/null
+  file=$(ls "$shared"/shared-github-quota/cooldowns/*.env)
+  sed 's/^route=default/route=some-other-route/' "$file" > "$file.tmp"
+  mv "$file.tmp" "$file"
+
+  active=$(FM_SHARED_STATE_OVERRIDE="$shared" FM_SHARED_QUOTA_NOW_EPOCH=1000 \
+    "$QUOTA" check --provider github --account "$TEST_ACCOUNT" --route default)
+  assert_contains "$active" "state=allow" "a record whose own identity disagrees must not block this key"
+  assert_contains "$active" "mismatched_record=1" "the mismatch should be reported"
+  [ -f "$file" ] || fail "a mismatched record must be left in place for its real owner"
+  pass "cooldown records are honored only when their own fields match the key"
+}
+
 test_mark_from_text_never_overwrites_remembered_account() {
   local shared out remembered active
   shared="$TMP_ROOT/shared-text-poison"
@@ -288,6 +357,9 @@ test_mark_from_text_records_observed_account_and_reset
 test_mark_from_text_never_overwrites_remembered_account
 test_unresolvable_account_cooldown_is_read_back
 test_reset_without_account_text_still_records_cooldown
+test_live_gh_rate_limit_evidence_records_cooldown
+test_cache_uses_the_same_key_policy_as_cooldowns
+test_cooldown_record_must_match_the_key_it_was_found_under
 test_shared_cooldown_blocks_polling_across_homes
 test_local_status_supervision_continues_during_cooldown
 test_reset_time_is_honored_before_polling_resumes

--- a/tests/fm-shared-github-quota.test.sh
+++ b/tests/fm-shared-github-quota.test.sh
@@ -84,6 +84,7 @@ test_mark_from_text_records_observed_account_and_reset() {
   shared="$TMP_ROOT/shared-text"
   out=$(printf 'GitHub user/account %s is rate-limited until 2026-07-13T02:23:23Z.\n' "$TEST_ACCOUNT" \
     | FM_SHARED_STATE_OVERRIDE="$shared" FM_SHARED_QUOTA_NOW_EPOCH=1000 \
+      FM_SHARED_GITHUB_QUOTA_DERIVE_ACCOUNT=0 \
       "$QUOTA" mark-from-text --provider github --route default --source incident)
   assert_contains "$out" "provider=github" "mark-from-text should preserve provider"
   assert_contains "$out" "account=$TEST_ACCOUNT" "mark-from-text should extract the GitHub account"
@@ -94,6 +95,27 @@ test_mark_from_text_records_observed_account_and_reset() {
   assert_contains "$active" "state=defer" "observed GitHub cooldown should be active"
   assert_contains "$active" "reset_at=2026-07-13T02:23:23Z" "active cooldown should report reset evidence"
   pass "observed GitHub account/reset text records a shared cooldown"
+}
+
+test_mark_from_text_never_overwrites_remembered_account() {
+  local shared out remembered active
+  shared="$TMP_ROOT/shared-text-poison"
+  FM_SHARED_STATE_OVERRIDE="$shared" FM_SHARED_QUOTA_NOW_EPOCH=1000 \
+    "$QUOTA" check --provider github --account "$TEST_ACCOUNT" --route default >/dev/null
+
+  out=$(printf 'API rate limit exceeded; x-ratelimit-reset 1799999999 until 2026-07-13T02:23:23Z.\n' \
+    | FM_SHARED_STATE_OVERRIDE="$shared" FM_SHARED_QUOTA_NOW_EPOCH=1000 \
+      FM_SHARED_GITHUB_QUOTA_DERIVE_ACCOUNT=0 \
+      "$QUOTA" mark-from-text --provider github --route default --source incident)
+  assert_contains "$out" "account=$TEST_ACCOUNT" "mark-from-text should prefer the remembered account over scraped digits"
+
+  remembered=$(cat "$shared/shared-github-quota/accounts/github.env")
+  assert_contains "$remembered" "account=$TEST_ACCOUNT" "scraped digits must not replace the remembered account"
+
+  active=$(FM_SHARED_STATE_OVERRIDE="$shared" FM_SHARED_QUOTA_NOW_EPOCH=1000 \
+    "$QUOTA" check --provider github --account "$TEST_ACCOUNT" --route default)
+  assert_contains "$active" "state=defer" "the cooldown should key to the remembered account"
+  pass "text-scraped account digits never poison the remembered GitHub account"
 }
 
 test_shared_cooldown_blocks_polling_across_homes() {
@@ -224,6 +246,7 @@ test_no_cooldown_preserves_existing_polling_semantics() {
 }
 
 test_mark_from_text_records_observed_account_and_reset
+test_mark_from_text_never_overwrites_remembered_account
 test_shared_cooldown_blocks_polling_across_homes
 test_local_status_supervision_continues_during_cooldown
 test_reset_time_is_honored_before_polling_resumes

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -123,6 +123,63 @@ test_no_profile_keeps_claude_launch_unchanged() {
   pass "no --model/--effort records defaults and keeps the claude launch byte-identical"
 }
 
+test_capacity_failover_absent_keeps_spawn_unchanged() {
+  local rec id out status expected launch state_real
+  id=capacity-off-z16
+  rec=$(make_spawn_case capacity-off codex "$id")
+  read_case_record "$rec"
+  mkdir -p "$HOME_DIR/state/capacity-cooldowns"
+  printf '%s\n' \
+    'schema=fm-capacity-cooldown.v1' \
+    'harness=codex' \
+    'profile=gpt-5.5' \
+    'reset_epoch=9999999999' \
+    > "$HOME_DIR/state/capacity-cooldowns/ignored.env"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR")
+  status=$?
+  expect_code 0 "$status" "spawn should ignore capacity cooldowns when config/capacity-failover is absent"
+  assert_contains "$out" "spawned $id harness=codex" "spawn did not report codex"
+  assert_meta_profile "$HOME_DIR/state/$id.meta" codex default default
+  assert_absent "$HOME_DIR/config/capacity-failover" "test setup should leave capacity failover disabled"
+
+  state_real=$(cd "$HOME_DIR/state" && pwd -P)
+  launch=$(cat "$LAUNCH_LOG")
+  expected="codex --dangerously-bypass-approvals-and-sandbox -c \"notify=[\\\"bash\\\",\\\"-c\\\",\\\"touch '$state_real/$id.turn-ended'\\\"]\" \"\$(cat '$HOME_DIR/data/$id/brief.md')\""
+  [ "$launch" = "$expected" ] || fail "capacity-off codex launch changed"$'\n'"expected: $expected"$'\n'"actual:   $launch"
+  pass "absent config/capacity-failover keeps spawn behavior byte-identical even with cooldown records present"
+}
+
+test_capacity_failover_host_pressure_opt_in_refuses_spawn() {
+  local rec id out status errexit_was_set
+  id=capacity-pressure-z17
+  rec=$(make_spawn_case capacity-pressure codex "$id")
+  read_case_record "$rec"
+  printf '%s\n' \
+    'host-pressure=on' \
+    'disk_floor_mb=9000' \
+    'disk_clear_mb=12000' \
+    'max_running_tasks=10' \
+    > "$HOME_DIR/config/capacity-failover"
+
+  export FM_PRESSURE_MEMORY_AVAILABLE_MB=5000
+  export FM_PRESSURE_DISK_AVAILABLE_MB=8200
+  export FM_PRESSURE_RUNNING_TASKS=0
+  case $- in *e*) errexit_was_set=1 ;; *) errexit_was_set=0 ;; esac
+  set +e
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR")
+  status=$?
+  if [ "$errexit_was_set" -eq 1 ]; then set -e; else set +e; fi
+  unset FM_PRESSURE_MEMORY_AVAILABLE_MB FM_PRESSURE_DISK_AVAILABLE_MB FM_PRESSURE_RUNNING_TASKS
+
+  expect_code 1 "$status" "critical host pressure should refuse spawn when explicitly enabled"
+  assert_contains "$out" "state=critical" "host-pressure refusal should print pressure evidence"
+  assert_contains "$out" "disk_floor_below_min" "spawn refusal should be caused by hard disk floor"
+  assert_contains "$out" "backpressure refused spawn of $id" "spawn refusal should explain ownership-preserving backpressure"
+  assert_absent "$HOME_DIR/state/$id.meta" "pressure refusal should happen before task meta ownership is created"
+  pass "opt-in disk-floor backpressure refuses new spawn before ownership metadata changes"
+}
+
 test_active_dispatch_profile_requires_explicit_harness_for_ship() {
   local rec id out status
   id=profile-required-ship-z11
@@ -419,6 +476,8 @@ test_active_dispatch_profile_does_not_block_secondmate_launch() {
 }
 
 test_no_profile_keeps_claude_launch_unchanged
+test_capacity_failover_absent_keeps_spawn_unchanged
+test_capacity_failover_host_pressure_opt_in_refuses_spawn
 test_active_dispatch_profile_requires_explicit_harness_for_ship
 test_active_dispatch_profile_requires_explicit_harness_for_scout
 test_active_dispatch_profile_allows_explicit_harness

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -493,6 +493,7 @@ run_teardown() {
   FM_ROOT_OVERRIDE="$ROOT" \
   FM_STATE_OVERRIDE="$case_dir/state" \
   FM_CONFIG_OVERRIDE="$case_dir/config" \
+  FM_SHARED_STATE_OVERRIDE="$case_dir/shared-quota" \
   PATH="$case_dir/fakebin:$PATH" \
     "$TEARDOWN" task-x1 "$@"
 }
@@ -755,6 +756,7 @@ test_pr_check_does_not_refresh_stale_pr_head() {
 
   FM_ROOT_OVERRIDE="$ROOT" \
   FM_STATE_OVERRIDE="$case_dir/state" \
+  FM_SHARED_STATE_OVERRIDE="$case_dir/shared-quota" \
   PATH="$case_dir/fakebin:$PATH" \
     "$PR_CHECK" task-x1 https://github.com/example/repo/pull/7 >/dev/null
 
@@ -763,6 +765,7 @@ test_pr_check_does_not_refresh_stale_pr_head() {
 
   FM_ROOT_OVERRIDE="$ROOT" \
   FM_STATE_OVERRIDE="$case_dir/state" \
+  FM_SHARED_STATE_OVERRIDE="$case_dir/shared-quota" \
   PATH="$case_dir/fakebin:$PATH" \
     "$PR_CHECK" task-x1 https://github.com/example/repo/pull/7 >/dev/null
 
@@ -792,6 +795,7 @@ test_pr_check_records_remote_head_when_local_lags() {
 
   FM_ROOT_OVERRIDE="$ROOT" \
   FM_STATE_OVERRIDE="$case_dir/state" \
+  FM_SHARED_STATE_OVERRIDE="$case_dir/shared-quota" \
   PATH="$case_dir/fakebin:$PATH" \
     "$PR_CHECK" task-x1 https://github.com/example/repo/pull/7 >/dev/null
 

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -50,6 +50,20 @@ wait_live() {
   return 0
 }
 
+# Wait up to <limit> 0.1s ticks for <file> to hold exactly <expected>. wait_live's
+# dwell only proves the watcher stayed alive and silent; on a loaded host its first
+# poll can still be mid-flight when the dwell ends, so an absorb's suppressor write
+# must be waited for rather than assumed. 0 once it matches, 1 on timeout.
+wait_file_content() {  # <file> <expected> [limit]
+  local file=$1 expected=$2 limit=${3:-100} i=0
+  while [ "$i" -lt "$limit" ]; do
+    [ "$(cat "$file" 2>/dev/null || true)" = "$expected" ] && return 0
+    sleep 0.1
+    i=$((i + 1))
+  done
+  return 1
+}
+
 wait_numeric_file() {
   local file=$1 limit=${2:-30} i=0 value
   while [ "$i" -lt "$limit" ]; do
@@ -460,9 +474,9 @@ test_stale_terminal_status_overridden_by_active_run() {
   if ! wait_live "$pid" 30; then
     reap "$pid"; fail "watcher exited for a stale terminal-looking status the run-step overrides (should absorb): $(cat "$out")"
   fi
+  wait_file_content "$state/.stale-$key" "$pane_hash" || { reap "$pid"; fail "stale suppressor not advanced on absorb"; }
   [ ! -s "$out" ] || fail "the overridden stale terminal status printed a wake reason during absorb"
   [ ! -s "$state/.wake-queue" ] || fail "the overridden stale terminal status enqueued a wake during absorb"
-  [ "$(cat "$state/.stale-$key" 2>/dev/null || true)" = "$pane_hash" ] || fail "stale suppressor not advanced on absorb"
   [ -s "$state/.stale-since-$key" ] || fail "stale-since escalation timer was not recorded on absorb"
   [ ! -e "$state/.hb-surfaced-validating" ] || fail "an absorbed wake must not mark the status line as surfaced"
   reap "$pid"
@@ -513,9 +527,9 @@ test_nonterminal_stale_provably_working_absorbed_then_escalated() {
   if ! wait_live "$pid" 30; then
     reap "$pid"; fail "watcher exited for a fresh provably-working non-terminal stale (should absorb): $(cat "$out")"
   fi
+  wait_file_content "$state/.stale-$key" "$pane_hash" || { reap "$pid"; fail "stale suppressor not advanced on absorb"; }
   [ ! -s "$out" ] || fail "fresh provably-working stale printed a wake reason during absorb"
   [ ! -s "$state/.wake-queue" ] || fail "fresh provably-working stale enqueued a wake during absorb"
-  [ "$(cat "$state/.stale-$key" 2>/dev/null || true)" = "$pane_hash" ] || fail "stale suppressor not advanced on absorb"
   [ -s "$state/.stale-since-$key" ] || fail "stale-since escalation timer was not recorded on absorb"
   reap "$pid"
 
@@ -612,9 +626,9 @@ test_nonterminal_stale_paused_absorbed_then_resurfaced() {
   if ! wait_live "$pid" 30; then
     reap "$pid"; fail "watcher exited for a fresh declared pause (should absorb): $(cat "$out")"
   fi
+  wait_file_content "$state/.stale-$key" "$pane_hash" || { reap "$pid"; fail "stale suppressor not advanced on paused absorb"; }
   [ ! -s "$out" ] || fail "fresh paused stale printed a wake reason during absorb"
   [ ! -s "$state/.wake-queue" ] || fail "fresh paused stale enqueued a wake during absorb"
-  [ "$(cat "$state/.stale-$key" 2>/dev/null || true)" = "$pane_hash" ] || fail "stale suppressor not advanced on paused absorb"
   [ -e "$state/.paused-$key" ] || fail "paused flag not recorded on absorb"
   [ ! -e "$state/.stale-since-$key" ] || fail "a paused absorb must not start the wedge timer"
   reap "$pid"

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -76,6 +76,17 @@ fm_test_tmproot() {
   printf '%s\n' "$root"
 }
 
+# The shared GitHub quota store (bin/fm-shared-github-quota.sh) is deliberately
+# FM_HOME-independent, so it resolves to the operator's real
+# ${XDG_STATE_HOME:-$HOME/.local/state}/firstmate tree unless redirected. That
+# store is now read and pruned from fm-pr-check, fm-pr-poll, fm-pr-merge,
+# fm-teardown and fm-bearings-snapshot, so any test driving those scripts would
+# mutate real state and take its result from the developer's live GitHub quota.
+# Redirect it once here so no test can regress by omission; a test that wants
+# its own store still overrides this per invocation.
+FM_SHARED_STATE_OVERRIDE=$(fm_test_tmproot fm-shared-quota)
+export FM_SHARED_STATE_OVERRIDE
+
 # --- fakebin / PATH shims ---------------------------------------------------
 #
 # fm_fakebin <dir> creates <dir>/fakebin and echoes it; prepend it to PATH to


### PR DESCRIPTION
## Intent

Rework the failover-substrate change on current origin/main and drive it to merge-ready without merging. The branch was rebased from the old 5a18630 base onto current main and keeps the failover/capacity substrate. The captain approved exactly three review fixes for this run: missing-poller-quota-guard (PR pollers must use the shared GitHub quota guard and cached reads during cooldowns), hardcoded-github-account-default (remove the personal GitHub account fallback and make mark/check use the same account key), and wall-key-mismatch-reselects-walled-harness (partial cooldown keys must block every route for the walled harness). The no-cooldown-clear-command finding is deliberately deferred as backlog cooldown-clear-cmd-c4 and must not be implemented here. Validate the committed rebased branch, allow the pipeline to apply the approved fixes if it still finds them, approve/proceed past the deferred cooldown-clear follow-up, push/open or update the PR, and stop at CI green without merging because the merge window is closed.

## What Changed

- Added a capacity-failover substrate: `bin/fm-capacity-lib.sh`, `fm-capacity-classify.sh`, `fm-capacity-cooldown.sh`, and `fm-capacity-route.sh` classify provider/auth wall text, record per-(harness, account, profile) cooldowns, and select a non-exhausted route, with `bin/fm-rehome-quota-wall.sh` moving a walled task onto a new route. A partially-keyed wall (unknown account or `default` profile) blocks every route for that harness, and cooldown records are only honored when their own identity fields match the requested key.
- Added `bin/fm-shared-github-quota.sh`, a fleet-wide GitHub quota guard with keyed/account-agnostic cooldown records and a PR-state cache; `fm-pr-check.sh`, `fm-pr-poll.sh`, `fm-pr-merge.sh`, `fm-teardown.sh`, and `fm-bearings-snapshot.sh` now defer their GitHub reads during an active cooldown, serve cached PR state, and record cooldowns from labeled `x-ratelimit-reset` / `Retry-After` evidence.
- Added opt-in host-pressure backpressure (`bin/fm-host-pressure.sh`, `bin/fm-pressure-lib.sh`) gating spawns on memory, a disk floor with hysteresis, and a running-task cap, wired into `fm-spawn.sh` and a cooldown-bounded `fm-watch.sh` alert; extracted harness launch templates and turn-end hook installation into `bin/fm-harness-launch-lib.sh`, made `fm-spawn.sh` fail when task metadata cannot be written, and documented the whole substrate in `docs/capacity-failover.md` plus updates to `AGENTS.md`, `docs/architecture.md`, `docs/configuration.md`, and `docs/scripts.md`.
- Added test suites for capacity classification/routing, rehoming, host pressure, and the shared quota guard, and sandboxed shared quota state per test run so suites no longer touch the operator's real state tree.

## Risk Assessment

⚠️ Medium: The substrate is large (~3900 lines) and now sits on critical paths - spawn refusal, PR merge refusal, and teardown's landed-work proof - but eight prior fix rounds resolved every substantiated correctness defect, the remaining findings are cosmetic/hygiene, and the whole feature stays inert until config/capacity-failover exists.

## Testing

Baseline full suite was already green; I additionally ran the seven test files touching the capacity/quota substrate and all passed, then produced an operator-level CLI transcript proving the three approved behaviors as an end user experiences them — merge polling that makes zero GitHub calls and serves cached PR state while a quota cooldown is active and resumes to report the merge after reset, quota records keyed without any personal-account fallback and read back identically whether or not an account resolves, and a partial-key harness wall blocking every route for that harness before falling through to the next harness and finally escalating when all routes are exhausted. The deferred cooldown-clear follow-up is confirmed unimplemented, and the working tree is clean with evidence written only to the dedicated evidence directory.

<details>
<summary>Evidence: Failover-substrate end-to-end operator demo transcript</summary>

```text

============================================================
SCENARIO 1 - PR merge polling honors the shared GitHub quota guard
============================================================
Operator arms the merge watch for https://github.com/example/repo/pull/9, then GitHub rate-limits the account.

--- arm the merge poll (fm-pr-check.sh)
  ●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  ●  WATCHER DOWN - SUPERVISION IS OFF
  ●  1 task(s) in flight, but no watcher has a fresh beacon (last beat: never, grace 300s).
  ●  Trust the emitted supervision protocol for this harness; do not use shell & for watcher repair.
  ●  This is a supervision warning only; the guarded operation WILL still run.
  ●  repair missing watcher supervision with bin/fm-watch-arm.sh as its own Claude Code background task, never shell &.
  ●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  armed: state/task-demo.check.sh
  armed poll: task-demo.check.sh task-demo.meta task-demo.pr-poll task-demo.pr-poll-registration 

--- poll #1 - no cooldown: real GitHub read happens, result is cached
  watcher output: <silent, PR still open>
  gh calls made: 1
    gh pr view https://github.com/example/repo/pull/9 --json state -q .state

--- poll #2 - GitHub returns a real rate-limit error: cooldown is recorded from the evidence
  gh calls made: 1
  shared quota state as the guard now sees it:
    state=defer
    schema=fm-shared-github-quota.v1
    provider=github
    account=
    route=default
    class=quota
    reason=github_rate_limit
    created_at=2026-07-21T08:39:56.679Z
    created_epoch=1000
    reset_at=2027-01-01T00:00:00Z
    reset_epoch=1798761600
    source=fm-pr-poll:https://github.com/example/repo/pull/9
    observed_account=12345678
    remaining_secs=1798760599

--- poll #3 - during the cooldown: NO GitHub call, cached PR state is reused
  watcher output: <silent, cached state is still OPEN>
  gh calls made during cooldown: 0  <-- guard suppressed the API read

--- poll #4 - the PR merges while still cooled down; cache says OPEN so no false wake
  watcher output: <silent — deferring to cache instead of burning quota>
  gh calls made: 0

--- poll #5 - after the reset epoch passes: polling resumes and the merge is reported
  watcher output: merged  <-- firstmate wakes on the merge
  gh calls made: 1

============================================================
SCENARIO 2 - no hardcoded GitHub account fallback; mark and check share one key
============================================================
With no account supplied and no way to derive one, the guard must key an
account-agnostic record instead of guessing a personal account.

--- mark a cooldown from rate-limit text with no resolvable account
  provider=github
  account=
  route=default
  reset_at=2027-01-01T00:00:00Z
  reset_epoch=1798761600

--- the recorded file's own identity fields (note: no personal account baked in)
  /var/folders/3b/9kjwhxp50j36ftjmfm3f1lm80000gn/T//fm-demo.glhqeLpP/shared2/shared-github-quota/cooldowns/github-2218976994.env
    schema=fm-shared-github-quota.v1
    provider=github
    account=
    route=default
    reset_at=2027-01-01T00:00:00Z

--- a later check with no account reads back the same record
  state=defer
  schema=fm-shared-github-quota.v1
  provider=github
  account=
  route=default
  class=quota
  reason=github_rate_limit
  created_at=2026-07-21T08:39:57.170Z
  created_epoch=1000
  reset_at=2027-01-01T00:00:00Z
  reset_epoch=1798761600
  source=demo
  remaining_secs=1798760599

--- a later check that CAN resolve an account still sees the same cooldown
  state=defer
  schema=fm-shared-github-quota.v1
  provider=github
  account=
  route=default
  class=quota
  reason=github_rate_limit
  created_at=2026-07-21T08:39:57.170Z
  created_epoch=1000
  reset_at=2027-01-01T00:00:00Z
  reset_epoch=1798761600
  source=demo
  remaining_secs=1798760599

--- source scan: no personal GitHub account literal remains in the guard
  none found in bin/fm-shared-github-quota.sh

============================================================
SCENARIO 3 - a partial cooldown key blocks EVERY route for the walled harness
============================================================
A wall recorded with only a partial key (no account/profile) must not leave
a more specific route selectable on the same walled harness.

--- routes configured by the operator
  route=claude|acct-a|opus|opus|high
  route=claude|acct-b|sonnet|sonnet|medium
  route=codex|acct-c|gpt|gpt|medium

--- before any wall: the first route is selected
  selected_harness=claude
  selected_account=acct-a
  selected_profile=opus
  selected_model=opus
  selected_effort=high

--- record a claude quota wall with a PARTIAL key (account and profile unknown)
  recorded: /var/folders/3b/9kjwhxp50j36ftjmfm3f1lm80000gn/T//fm-demo.glhqeLpP/home3/state/capacity-cooldowns/claude-72028641.env

--- select again: BOTH claude routes are blocked, and codex is chosen instead
  route_1_status=blocked
  route_1_harness=claude
  route_1_account=acct-a
  route_1_profile=opus
  route_1_model=opus
  route_1_reason=claude_session_limit
  route_1_reset_epoch=1799999999
  route_1_requires_action=
  route_2_status=blocked
  route_2_harness=claude
  route_2_account=acct-b
  route_2_profile=sonnet
  route_2_model=sonnet
  route_2_reason=claude_session_limit
  route_2_reset_epoch=1799999999
  route_2_requires_action=
  selected_harness=codex
  selected_account=acct-c
  selected_profile=gpt
  selected_model=gpt
  selected_effort=medium

--- wall codex too: every verified route is exhausted and firstmate escalates
  route_1_status=blocked
  route_1_harness=claude
  route_1_account=acct-a
  route_1_profile=opus
  route_1_model=opus
  route_1_reason=claude_session_limit
  route_1_reset_epoch=1799999999
  route_1_requires_action=
  route_2_status=blocked
  route_2_harness=claude
  route_2_account=acct-b
  route_2_profile=sonnet
  route_2_model=sonnet
  route_2_reason=claude_session_limit
  route_2_reset_epoch=1799999999
  route_2_requires_action=
  route_3_status=blocked
  route_3_harness=codex
  route_3_account=acct-c
  route_3_profile=gpt
  route_3_model=gpt
  route_3_reason=codex_usage_limit
  route_3_reset_epoch=1799999999
  route_3_requires_action=
  escalation=every_verified_route_exhausted
  exhausted_routes=3
  needed_action=wait for reset or complete the listed interactive auth/account action

--- after the reset epoch, routes are live again
  selected_harness=claude
  selected_account=acct-a
  selected_profile=opus
  selected_model=opus
  selected_effort=high

============================================================
SCENARIO 4 - the deferred finding stays deferred
============================================================

--- no cooldown-clear subcommand exists (backlog cooldown-clear-cmd-c4)
  error: unknown command 'clear'
  # Manage passive capacity cooldown records under state/capacity-cooldowns/.
  # Usage:
  #   fm-capacity-cooldown.sh mark --harness <h> --profile <p> [--account <a>] (--reset-epoch <n>|--ttl-secs <n>) [--class quota] [--reason <r>] [--source-task <id>]
  #   fm-capacity-cooldown.sh mark-from-text --harness <h> --profile <p> [--account <a>] [--source-task <id>] [--file <path>]
  #   fm-capacity-cooldown.sh active --harness <h> --profile <p> [--account <a>]
  #
  # The helper never fabricates TTLs.
  # mark-from-text writes only when the classified text carries an observed reset
  # epoch; otherwise it exits non-zero after printing the classification.

=== demo complete ===
```
</details>
<details>
<summary>Evidence: Demo driver script (reproducible)</summary>

```text
#!/usr/bin/env bash
# End-to-end operator demo of the three approved failover-substrate fixes.
# Runs entirely in a disposable sandbox with a fake `gh` on PATH.
set -u

ROOT=${FM_DEMO_ROOT:?set FM_DEMO_ROOT to the firstmate checkout}
SANDBOX=$(mktemp -d "${TMPDIR:-/tmp}/fm-demo.XXXXXXXX")
trap 'rm -rf "$SANDBOX"' EXIT

HOME_DIR="$SANDBOX/home"
SHARED="$SANDBOX/shared"
FAKEBIN="$SANDBOX/bin"
GH_LOG="$SANDBOX/gh.log"
mkdir -p "$HOME_DIR/state" "$HOME_DIR/config" "$HOME_DIR/wt" "$FAKEBIN"
: > "$GH_LOG"

PR_URL=https://github.com/example/repo/pull/9

# Fake GitHub CLI: logs every invocation so we can prove when it is NOT called.
cat > "$FAKEBIN/gh" <<'SH'
#!/usr/bin/env bash
printf 'gh %s\n' "$*" >> "$FM_TEST_GH_LOG"
if [ -n "${FM_FAKE_GH_FAIL:-}" ]; then
  printf '%s\n' "$FM_FAKE_GH_FAIL" >&2
  exit 1
fi
case " $* " in
  *" --json headRefOid "*) printf '%s\n' deadbeefcafefeed0000000000000000deadbeef; exit 0 ;;
  *" --json state "*) printf '%s\n' "${FM_FAKE_PR_STATE:-OPEN}"; exit 0 ;;
esac
exit 0
SH
cat > "$FAKEBIN/gh-axi" <<'SH'
#!/usr/bin/env bash
printf 'gh-axi %s\n' "$*" >> "$FM_TEST_GH_LOG"
exit 0
SH
chmod +x "$FAKEBIN/gh" "$FAKEBIN/gh-axi"

cat > "$HOME_DIR/state/task-demo.meta" <<EOF
window=fm-task-demo
worktree=$HOME_DIR/wt
project=$HOME_DIR/project
kind=ship
mode=no-mistakes
EOF

hdr() { printf '\n============================================================\n%s\n============================================================\n' "$1"; }
step() { printf '\n--- %s\n' "$1"; }

QUOTA="$ROOT/bin/fm-shared-github-quota.sh"

hdr "SCENARIO 1 - PR merge polling honors the shared GitHub quota guard"
printf 'Operator arms the merge watch for %s, then GitHub rate-limits the account.\n' "$PR_URL"

step "arm the merge poll (fm-pr-check.sh)"
FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$HOME_DIR" \
  FM_STATE_OVERRIDE="$HOME_DIR/state" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
  FM_SHARED_STATE_OVERRIDE="$SHARED" FM_SHARED_QUOTA_NOW_EPOCH=1000 \
  FM_TEST_GH_LOG="$GH_LOG" PATH="$FAKEBIN:$PATH" \
  "$ROOT/bin/fm-pr-check.sh" task-demo "$PR_URL" 2>&1 | sed 's/^/  /'
printf '  armed poll: %s\n' "$(ls "$HOME_DIR/state" | tr '\n' ' ')"

run_poll() {
  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$HOME_DIR" \
    FM_SHARED_STATE_OVERRIDE="$SHARED" FM_SHARED_QUOTA_NOW_EPOCH="$1" \
    FM_CAPACITY_NOW_EPOCH="$1" \
    FM_TEST_GH_LOG="$GH_LOG" PATH="$FAKEBIN:$PATH" \
    FM_FAKE_PR_STATE="${2:-OPEN}" FM_FAKE_GH_FAIL="${3:-}" \
    bash "$HOME_DIR/state/task-demo.check.sh"
}

step "poll #1 - no cooldown: real GitHub read happens, result is cached"
: > "$GH_LOG"
out=$(run_poll 1000 OPEN)
printf '  watcher output: %s\n' "${out:-<silent, PR still open>}"
printf '  gh calls made: %s\n' "$(wc -l < "$GH_LOG" | tr -d ' ')"
sed 's/^/    /' "$GH_LOG"

step "poll #2 - GitHub returns a real rate-limit error: cooldown is recorded from the evidence"
: > "$GH_LOG"
run_poll 1000 OPEN 'gh: API rate limit exceeded for user ID 12345678. x-ratelimit-reset 1799999999 (2027-01-01T00:00:00Z)' \
  | sed 's/^/  watcher output: /'
printf '  gh calls made: %s\n' "$(wc -l < "$GH_LOG" | tr -d ' ')"
printf '  shared quota state as the guard now sees it:\n'
FM_SHARED_STATE_OVERRIDE="$SHARED" FM_SHARED_QUOTA_NOW_EPOCH=1001 \
  FM_SHARED_GITHUB_QUOTA_DERIVE_ACCOUNT=0 \
  "$QUOTA" check --provider github --route default 2>&1 | sed 's/^/    /'

step "poll #3 - during the cooldown: NO GitHub call, cached PR state is reused"
: > "$GH_LOG"
out=$(run_poll 1002 OPEN)
printf '  watcher output: %s\n' "${out:-<silent, cached state is still OPEN>}"
printf '  gh calls made during cooldown: %s  <-- guard suppressed the API read\n' "$(wc -l < "$GH_LOG" | tr -d ' ')"

step "poll #4 - the PR merges while still cooled down; cache says OPEN so no false wake"
: > "$GH_LOG"
out=$(run_poll 1003 MERGED)
printf '  watcher output: %s\n' "${out:-<silent — deferring to cache instead of burning quota>}"
printf '  gh calls made: %s\n' "$(wc -l < "$GH_LOG" | tr -d ' ')"

step "poll #5 - after the reset epoch passes: polling resumes and the merge is reported"
: > "$GH_LOG"
out=$(run_poll 1800000000 MERGED)
printf '  watcher output: %s  <-- firstmate wakes on the merge\n' "${out:-<silent>}"
printf '  gh calls made: %s\n' "$(wc -l < "$GH_LOG" | tr -d ' ')"

hdr "SCENARIO 2 - no hardcoded GitHub account fallback; mark and check share one key"
printf 'With no account supplied and no way to derive one, the guard must key an\n'
printf 'account-agnostic record instead of guessing a personal account.\n'

SHARED2="$SANDBOX/shared2"
step "mark a cooldown from rate-limit text with no resolvable account"
printf 'API rate limit exceeded; x-ratelimit-reset 1799999999 (2027-01-01T00:00:00Z)\n' \
  | FM_SHARED_STATE_OVERRIDE="$SHARED2" FM_SHARED_QUOTA_NOW_EPOCH=1000 \
    FM_SHARED_GITHUB_QUOTA_DERIVE_ACCOUNT=0 \
    "$QUOTA" mark-from-text --provider github --route default --source demo 2>&1 | sed 's/^/  /'

step "the recorded file's own identity fields (note: no personal account baked in)"
find "$SHARED2" -name '*.env' -print0 | while IFS= read -r -d '' f; do
  printf '  %s\n' "$f"
  grep -E '^(schema|provider|account|route|reset_at)=' "$f" | sed 's/^/    /'
done

step "a later check with no account reads back the same record"
FM_SHARED_STATE_OVERRIDE="$SHARED2" FM_SHARED_QUOTA_NOW_EPOCH=1001 \
  FM_SHARED_GITHUB_QUOTA_DERIVE_ACCOUNT=0 \
  "$QUOTA" check --provider github --route default 2>&1 | sed 's/^/  /'

step "a later check that CAN resolve an account still sees the same cooldown"
FM_SHARED_STATE_OVERRIDE="$SHARED2" FM_SHARED_QUOTA_NOW_EPOCH=1001 \
  "$QUOTA" check --provider github --account 12345678 --route default 2>&1 | sed 's/^/  /'

step "source scan: no personal GitHub account literal remains in the guard"
if grep -nE 'FM_GITHUB_ACCOUNT_ID:-[0-9]|account=[0-9]{5,}' "$QUOTA"; then
  printf '  FOUND a hardcoded account default (regression)\n'
else
  printf '  none found in bin/fm-shared-github-quota.sh\n'
fi

hdr "SCENARIO 3 - a partial cooldown key blocks EVERY route for the walled harness"
printf 'A wall recorded with only a partial key (no account/profile) must not leave\n'
printf 'a more specific route selectable on the same walled harness.\n'

HOME3="$SANDBOX/home3"
mkdir -p "$HOME3/state" "$HOME3/config"
cat > "$HOME3/config/capacity-failover" <<'EOF'
route=claude|acct-a|opus|opus|high
route=claude|acct-b|sonnet|sonnet|medium
route=codex|acct-c|gpt|gpt|medium
EOF

step "routes configured by the operator"
sed 's/^/  /' "$HOME3/config/capacity-failover"

step "before any wall: the first route is selected"
FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$HOME3" \
  FM_STATE_OVERRIDE="$HOME3/state" FM_CONFIG_OVERRIDE="$HOME3/config" \
  FM_CAPACITY_NOW_EPOCH=1000 \
  "$ROOT/bin/fm-capacity-route.sh" select 2>&1 | sed 's/^/  /'

step "record a claude quota wall with a PARTIAL key (account and profile unknown)"
FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$HOME3" \
  FM_STATE_OVERRIDE="$HOME3/state" FM_CAPACITY_NOW_EPOCH=1000 \
  "$ROOT/bin/fm-capacity-cooldown.sh" mark --harness claude --profile default \
    --reset-epoch 1799999999 --reason claude_session_limit 2>&1 | sed 's/^/  recorded: /'

step "select again: BOTH claude routes are blocked, and codex is chosen instead"
FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$HOME3" \
  FM_STATE_OVERRIDE="$HOME3/state" FM_CONFIG_OVERRIDE="$HOME3/config" \
  FM_CAPACITY_NOW_EPOCH=1000 \
  "$ROOT/bin/fm-capacity-route.sh" select 2>&1 | sed 's/^/  /'

step "wall codex too: every verified route is exhausted and firstmate escalates"
FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$HOME3" \
  FM_STATE_OVERRIDE="$HOME3/state" FM_CAPACITY_NOW_EPOCH=1000 \
  "$ROOT/bin/fm-capacity-cooldown.sh" mark --harness codex --profile default \
    --reset-epoch 1799999999 --reason codex_usage_limit >/dev/null 2>&1
FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$HOME3" \
  FM_STATE_OVERRIDE="$HOME3/state" FM_CONFIG_OVERRIDE="$HOME3/config" \
  FM_CAPACITY_NOW_EPOCH=1000 \
  "$ROOT/bin/fm-capacity-route.sh" select 2>&1 | sed 's/^/  /'

step "after the reset epoch, routes are live again"
FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$HOME3" \
  FM_STATE_OVERRIDE="$HOME3/state" FM_CONFIG_OVERRIDE="$HOME3/config" \
  FM_CAPACITY_NOW_EPOCH=1800000000 \
  "$ROOT/bin/fm-capacity-route.sh" select 2>&1 | sed 's/^/  /'

hdr "SCENARIO 4 - the deferred finding stays deferred"
step "no cooldown-clear subcommand exists (backlog cooldown-clear-cmd-c4)"
FM_ROOT_OVERRIDE="$ROOT" "$ROOT/bin/fm-capacity-cooldown.sh" clear --harness claude --profile default 2>&1 | sed 's/^/  /'

printf '\n=== demo complete ===\n'
```
</details>
<details>
<summary>Evidence: Quota-guarded merge polling: gh call counts across cooldown</summary>

```text
--- poll #1 - no cooldown: real GitHub read happens, result is cached
gh calls made: 1
gh pr view https://github.com/example/repo/pull/9 --json state -q .state

--- poll #2 - GitHub returns a real rate-limit error: cooldown is recorded from the evidence
shared quota state as the guard now sees it:
state=defer
reason=github_rate_limit
reset_at=2027-01-01T00:00:00Z
source=fm-pr-poll:https://github.com/example/repo/pull/9

--- poll #3 - during the cooldown: NO GitHub call, cached PR state is reused
gh calls made during cooldown: 0 <-- guard suppressed the API read

--- poll #5 - after the reset epoch passes: polling resumes and the merge is reported
watcher output: merged <-- firstmate wakes on the merge
gh calls made: 1
```
</details>
<details>
<summary>Evidence: Partial cooldown key blocks every route for the walled harness</summary>

```text
--- record a claude quota wall with a PARTIAL key (account and profile unknown)
recorded: .../state/capacity-cooldowns/claude-72028641.env

--- select again: BOTH claude routes are blocked, and codex is chosen instead
route_1_status=blocked route_1_harness=claude route_1_account=acct-a route_1_profile=opus
route_2_status=blocked route_2_harness=claude route_2_account=acct-b route_2_profile=sonnet
selected_harness=codex selected_account=acct-c selected_profile=gpt

--- wall codex too: every verified route is exhausted and firstmate escalates
escalation=every_verified_route_exhausted
exhausted_routes=3
```
</details>
- Outcome: 🔧 1 issue found → auto-fixed (2) ✅ across 3 runs (1h54m42s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Rebase** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-spawn.sh` - merge conflict rebasing onto refs/remotes/no-mistakes-push/fm/failover-substrate-f2

🔧 Fix applied.
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Review** - 3 infos</summary>

- ⚠️ `bin/fm-shared-github-quota.sh:377` - bin/fm-shared-github-quota.sh:377 sets ACCOUNT from text heuristically scraped out of gh stderr, and resolve_account (line 140) then persists that value as the fleet-wide remembered GitHub account with source=env. The extractor&#39;s fallback pattern is a bare `\b([0-9]{6,})\b`, so any long number in the error body (an epoch, an x-ratelimit-reset value, a repo/installation id) becomes the durable account identity for the whole shared-state tree, silently replacing a previously derived real account id. Fix: in mark-from-text, only use the extracted account when no cached/derived account resolves, and never call remember_account with a text-extracted value.
- ⚠️ `bin/fm-capacity-lib.sh:260` - fm_capacity_cooldown_active_for_route (bin/fm-capacity-lib.sh:260) only widens a cooldown to the whole harness when the record&#39;s key is partial (empty account, or empty/`default` profile). A fully-keyed wall - e.g. `codex|acct-a|gpt-5.5` recorded by `handle-wall --account acct-a --profile gpt-5.5` - leaves `route=codex|acct-a|gpt-5.6` selectable, even though harness quota walls are normally per-account, not per-model. The selector will happily rehome the task straight back into the same exhausted account. Consider also blocking every route whose harness+account matches an active record.
- ℹ️ `bin/fm-harness-launch-lib.sh:146` - fm_launch_install_turn_end_hook mints a fresh auth file under ~/.grok/hooks/fm-turn-end.d/ and overwrites state/&lt;id&gt;.grok-turnend-token (bin/fm-harness-launch-lib.sh:146). fm-teardown only removes the auth file named by the currently recorded token, so a grok-&gt;grok rehome via fm-rehome-quota-wall.sh permanently orphans the prior auth file in the global grok hook registry. Remove any previously recorded token&#39;s auth file before writing the new one.
- ℹ️ `bin/fm-spawn.sh:354` - After the extraction, launch_template (354), shell_quote (358), model_flag_for_harness (435), and effort_flag_for_harness (439) in bin/fm-spawn.sh are pure `fm_launch_*` pass-throughs. Calling the library functions directly removes four indirection layers; the header comment at line 82 (&#34;Launch templates live in launch_template() below&#34;) is now stale and should point at bin/fm-harness-launch-lib.sh.
- ℹ️ `bin/fm-harness-launch-lib.sh:21` - The move of launch_template into bin/fm-harness-launch-lib.sh dropped the verified adapter rationale that lived beside it in fm-spawn.sh: why CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false is the correct control (and why --prompt-suggestions is not), the grok --always-approve justification, and the ~20-line explanation of why grok&#39;s turn-end hook must be a guarded global hook rather than a project hook. That is empirically verified knowledge with no other owner in the repo; carry the comments into the new library.
- ℹ️ `bin/fm-pr-merge.sh:38` - GITHUB_ROUTE is assigned identically at bin/fm-pr-merge.sh:17 and again at line 38 with no intervening use or mutation. Drop one.
- ℹ️ `docs/capacity-failover.md:57` - docs/capacity-failover.md&#39;s Route Selection section says only that &#34;Selection skips routes with active cooldown or manual auth-exhaustion records&#34;. It does not document the new rule that a partially-keyed wall (unknown account or default profile) blocks every route for that harness, which is the behavior operators will need to reason about when a route they configured is unexpectedly skipped.

🔧 Fix: fix: harden quota account resolution and grok hook cleanup
6 issues (1 error, 2 warnings, 3 infos) still open:
- 🚨 `bin/fm-rehome-quota-wall.sh:202` - bin/fm-rehome-quota-wall.sh:202-213 rewrites state/&lt;id&gt;.meta by copying the original lines (which end with the `pr=`/`pr_head=` lines appended by bin/fm-pr-check.sh:97-98) and then appending window=/harness=/model=/effort=/backend=/rehome_* lines at the end. fm_pr_metadata_identity_parse (bin/fm-pr-lib.sh:186-191) fails on ANY line that is not pr_head= or an x_* key once `pr=` has been seen. So after rehoming a task that already has an armed merge poll, fm_pr_poll_artifacts_valid fails, the watcher classifies state/&lt;id&gt;.check.sh as a rejected unauthenticated state check (bin/fm-watch.sh:804-819) and raises that alarm, and the next session-start PR-check migration quarantines the poll as ambiguous because metadata_pr_is_canonical also fails - merge detection for the rehomed task is permanently lost. Fix: also strip pr=/pr_head= in the awk filter and re-append them AFTER the new keys (or re-run fm-pr-check.sh &lt;id&gt; &lt;pr-url&gt; after the meta rewrite). tests/fm-rehome-quota-wall.test.sh:129 only asserts the pr= line survives, so it does not catch this.
- ⚠️ `bin/fm-shared-github-quota.sh:382` - bin/fm-shared-github-quota.sh:380-385 now uses the text-scraped account only as a last resort and never remembers it. But cooldown files are keyed by (provider, account, route) (quota_file, line 42). In the exact scenario the guard exists for - a home that has never cached an account hits its first rate limit - derive_account&#39;s `gh api user` (line 131) is itself rate-limited and fails, so mark-from-text falls back to the scraped digits (whose fallback pattern `\b([0-9]{6,})\b` at line 191 commonly matches an x-ratelimit-reset epoch) and writes the cooldown under that bogus key. Every later `check` resolves a different account (empty cache -&gt; derive succeeds after reset, or exits 2 while still limited), so the record is never read and the guard stays inert for that whole episode while a stale file is orphaned in the shared tree. Consider writing the record under the account-agnostic key (empty account) when the account cannot be resolved, and having check consult that key too, rather than keying on unverified scraped digits.
- ⚠️ `bin/fm-shared-github-quota.sh:204` - extract_github_rate_limit exits 1 unless BOTH an account and a reset timestamp are found (bin/fm-shared-github-quota.sh:204). Now that the account is resolved independently of the text (line 380-385), a rate-limit body that carries a usable reset time but no long digit run - e.g. `HTTP 403: API rate limit exceeded ... resets at 2026-07-13T02:23:23Z` - makes mark-from-text fail with `no GitHub rate-limit reset/account found` and no cooldown is recorded at all, even though the caller has a perfectly good cached/derived account. Make the account optional in the extractor and require only reset_at/reset_epoch.
- ℹ️ `bin/fm-pr-check.sh:19` - The new github_quota_deferred helpers in bin/fm-pr-check.sh:19, bin/fm-teardown.sh:267 and bin/fm-pr-poll.sh:71 call `check`, which runs resolve_account -&gt; derive_account -&gt; `gh api user` whenever no account is cached, and a failed derivation is never negatively cached. So on an unauthenticated or not-yet-cached home each poll cycle and each teardown (which checks twice, via pr_is_merged and pr_number_from_branch) spends extra GitHub API calls inside the very guard meant to conserve quota. bin/fm-bearings-snapshot.sh:197 already sets FM_SHARED_GITHUB_QUOTA_DERIVE_ACCOUNT=0 for its read-only check; do the same on these read-only defer checks.
- ℹ️ `bin/fm-capacity-route.sh:183` - dispatch_backstop&#39;s `exit 1` (bin/fm-capacity-route.sh:66-69) is reached from handle_wall only through `selection=$(select_route)` at line 183, so it aborts the command substitution, not the script. The result is that handle-wall has already written the cooldown record and then reports a generic `action=escalate` / `every_verified_route_exhausted`-shaped failure instead of the intended loud refusal about config/crew-dispatch.json. Call dispatch_backstop at the top of handle_wall, before any state is written.
- ℹ️ `bin/fm-host-pressure.sh:134` - The disk floor is measured on FM_HOME&#39;s filesystem (bin/fm-host-pressure.sh:134, fm_pressure_disk_available_mb). Task worktrees, TMPDIR/GOTMPDIR, and build caches frequently live on a different volume, so the spawn backpressure can pass while the volume the crew actually fills is out of space (or refuse spawns for a volume nothing writes to). Worth deciding whether the floor should also sample the projects/worktree and TMPDIR paths.

🔧 Fix: fix: preserve PR meta on rehome and harden quota keying
6 issues (1 warning, 5 infos) still open:
- ⚠️ `tests/lib.sh:35` - The shared quota store is deliberately FM_HOME-independent: shared_state_root() (bin/fm-shared-github-quota.sh:18) resolves to the operator&#39;s real ${XDG_STATE_HOME:-$HOME/.local/state}/firstmate/shared-github-quota. The new guard is now reached from fm-pr-check.sh, fm-teardown.sh, fm-pr-merge.sh, fm-pr-poll.sh and fm-bearings-snapshot.sh, and the branch handled this by adding FM_SHARED_STATE_OVERRIDE to five test files individually. tests/lib.sh does not export it, so tests that were not patched still hit real state: tests/fm-pr-check-security.test.sh runs the real bin/fm-pr-check.sh (SCRIPT_DIR is the real bin/, so the real quota script is invoked) with no override across ~2200 lines of cases. Effects: check_quota rm -f&#39;s expired records in the operator&#39;s real shared tree, and if a real cooldown happens to be active on the machine, github_quota_deferred returns true and fm-pr-check silently skips the head read - making that suite&#39;s result depend on the developer&#39;s live GitHub quota. Fix: export FM_SHARED_STATE_OVERRIDE to a per-run sandbox in tests/lib.sh alongside the existing FM_GATE_REFUSE_BYPASS export, so no new test can regress this by omission.
- ℹ️ `bin/fm-capacity-cooldown.sh:99` - fm-capacity-cooldown.sh mark-from-text writes a cooldown record whenever a reset epoch parsed, regardless of the classified class. fm-capacity-route.sh:180-183 explicitly refuses class=other as &#34;not reroutable capacity/auth exhaustion&#34;, and fm_capacity_classify_text deliberately classifies transient_rate_limit and proxy_unknown_model as other - yet this CLI records them as route blocks, and fm_capacity_cooldown_active_for_route (bin/fm-capacity-lib.sh:247) does not filter on class. So marking a transient provider throttle through the standalone helper blocks the whole harness for the parsed TTL. Consider refusing (or requiring an explicit flag for) a non-quota/non-auth class here, matching handle-wall.
- ℹ️ `bin/fm-host-pressure.sh:197` - emit_check returns 2 with its message on stderr for an invalid config/capacity-failover threshold. periodic_alert calls it as out=$(emit_check), so out is empty, state parses to empty, and the case at line 203 falls through to `return 0`. fm-watch.sh&#39;s run_host_pressure_alert additionally discards stderr, so a malformed capacity-failover file is completely silent on the watcher path even though `check` and `gate` exit 2 loudly. Propagate the status-2 case out of periodic_alert instead of treating it as &#34;nothing to alert&#34;.
- ℹ️ `bin/fm-shared-github-quota.sh:161` - resolve_account_or_agnostic swallows resolve_account&#39;s return 2 for both failure modes. One of those is &#34;invalid GitHub account id&#34; (line 139), raised for an explicit --account/FM_GITHUB_ACCOUNT_ID that fails account_valid. So `check --account &#39;&lt;bad value&gt;&#39;` now silently reports on the account-agnostic key instead of erroring, while mark, cache-get and cache-put still reject the same input with exit 2. Distinguish the two: fall back to the agnostic key only when the account is unresolvable, and keep propagating the invalid-input error.
- ℹ️ `bin/fm-harness-launch-lib.sh:144` - The round-2 fix restored the claude and grok adapter rationale into the extracted library but not pi&#39;s. The removed fm-spawn.sh block carried two empirically verified facts with no other owner in the repo: the extension is written OUTSIDE the worktree because pi&#39;s project-trust gate fires on any extension loaded from inside the project (verified live) while an explicit -e path elsewhere loads with no dialog, and it lives in state/ so teardown cleans it; and turn_end is used rather than agent_end because agent_end fires only once at run exit, which would leave an idle crewmate unsurfaced. The replacement comment keeps only a one-line paraphrase of the second. Carry both back.
- ℹ️ `bin/fm-pressure-lib.sh:117` - fm_pressure_running_tasks counts every state/*.meta containing a window= line. Metadata persists until teardown, which happens only after landing is confirmed, so tasks parked awaiting merge approval and tasks whose endpoint is already dead are all counted as &#34;running&#34;. With host-pressure=on and max_running_tasks (default 30) that concurrency backstop can refuse a spawn on stale ownership records rather than live load. Worth deciding whether the count should consult live endpoint liveness (fm_backend_agent_alive) rather than metadata presence.

🔧 Fix: fix: isolate test quota state and surface config errors
5 issues (1 warning, 4 infos) still open:
- ⚠️ `bin/fm-shared-github-quota.sh:212` - extract_github_rate_limit only accepts a reset expressed as an ISO-8601 timestamp (`20\d\d-\d\d-\d\dT..Z`) or a `YYYY-MM-DD HH:MM:SS UTC` string, and exits 1 otherwise (line 219). Live `gh` rate-limit stderr does not carry either form: the primary-limit body is `HTTP 403: API rate limit exceeded for user ID &lt;n&gt;.` with the reset only in the `X-RateLimit-Reset: &lt;epoch&gt;` header, and secondary limits surface `Retry-After: &lt;seconds&gt;` with no timestamp at all. Every caller wired in this branch (bin/fm-pr-check.sh:26, bin/fm-pr-poll.sh:84, bin/fm-pr-merge.sh:46, bin/fm-teardown.sh:276) feeds exactly that stderr into `mark-from-text` and swallows the failure with `|| true`, so no cooldown is ever recorded from a real wall and the guard only ever defers after a manual `mark --reset-epoch`. Note fm-capacity-lib.sh:26 already parses `Retry-After`, so the two extractors disagree about what counts as observed reset evidence. Suggest accepting a labeled `x-ratelimit-reset[:=] &lt;epoch&gt;` and `Retry-After[:=] &lt;secs&gt;` in this extractor (labeled only, so the round-1 bare-digit poisoning rule still holds).
- ℹ️ `bin/fm-shared-github-quota.sh:427` - `check` and `mark-from-text` fall back to the account-agnostic key via resolve_account_or_agnostic (lines 391, 417), but `cache-get`/`cache-put` still call the strict resolve_account (lines 427, 432), which exits 2 when no account resolves. With FM_SHARED_GITHUB_QUOTA_DERIVE_ACCOUNT=0 set on the poller&#39;s cache-get (bin/fm-pr-poll.sh:75) and no accounts/github.env yet written, cache-get errors out while the cooldown that triggered the defer was written under the agnostic key - so the deferred-read cache is unreachable in exactly the state where the cooldown is readable, and merge detection is blind for the whole cooldown instead of serving the cached MERGED proof docs/capacity-failover.md:136 promises. Making cache-get/cache-put use the same agnostic fallback keeps one key policy across all four subcommands.
- ℹ️ `bin/fm-capacity-lib.sh:225` - Cooldown lookups trust the CRC32 filename alone. fm_capacity_cooldown_active (bin/fm-capacity-lib.sh:225) and check_quota (bin/fm-shared-github-quota.sh:268) read reset_epoch out of the file located by cksum(harness,account,profile) / cksum(provider,account,route) without ever comparing the record&#39;s own harness=/account=/profile= (or provider=/account=/route=) fields to the key that was asked for. A CRC32 collision, or a hand-edited/copied record, silently applies one route&#39;s wall to a different route, and check_quota even echoes the mismatched record&#39;s account/route straight into the escalation that fm-pr-merge.sh:88-97 prints. The fields are already in the file; comparing them before honoring the record is a cheap consistency check.
- ℹ️ `bin/fm-host-pressure.sh:207` - periodic_alert calls emit_check a second time purely to recover its stderr message (`detail=$(emit_check 2&gt;&amp;1 &gt;/dev/null | tail -1)`). emit_check is not side-effect free - disk_hysteresis_state writes or removes $STATE_PATH/.host-pressure-disk-floor and rewrites entered_epoch on every entered reading - so the config-error path re-runs that state mutation for no reason. Capturing stderr to a temp file (or a separate fd) in the single first call gives the same message with one evaluation.
- ℹ️ `bin/fm-harness-launch-lib.sh:219` - fm_launch_install_turn_end_hook takes a 7th parameter project_abs that no branch uses; it is consumed only by the no-op `: &#34;$project_abs&#34;` at line 219. Both call sites plumb it through (bin/fm-spawn.sh:955 passes $PROJ_ABS, bin/fm-rehome-quota-wall.sh:188 invents `[ -n &#34;$PROJ&#34; ] || PROJ=&#34;$WT&#34;` at line 100 solely to have something to pass). Dropping the parameter removes that fabricated fallback and one argument from both callers.

🔧 Fix: fix: parse real gh rate-limit evidence and verify cooldown keys
5 issues (2 warnings, 3 infos) still open:
- ⚠️ `bin/fm-shared-github-quota.sh:340` - `check` resolves through check_quota_resolved (line 323), which consults BOTH the account-keyed record and the account-agnostic one. `cache_get`/`cache_put` (lines 340, 358) only ever touch the single resolved key — resolve_account_or_agnostic gives them a fallback key but no dual lookup. Concrete blindness: a home with no accounts/github.env hits a wall; fm-pr-poll&#39;s mark-from-text cannot derive an account, so the cooldown is written agnostic. Later some other path that does not set FM_SHARED_GITHUB_QUOTA_DERIVE_ACCOUNT=0 (fm-pr-merge.sh:38 github_quota_check, or fm-pr-check.sh:27 mark_github_quota_from_file) successfully derives and remembers the account. Now fm-pr-poll&#39;s check resolves the account, finds nothing keyed, falls back to the agnostic record and correctly defers — but cache-get (bin/fm-pr-poll.sh:75) resolves the same account and looks in the KEYED cache dir, missing the agnostic entry written before the wall. Merge detection is then silent for the whole cooldown, which is exactly what docs/capacity-failover.md:136-138 promises against, and docs/capacity-failover.md:129 currently overclaims that cache-get/cache-put follow the same key policy. Fix: give cache_get the same keyed-then-agnostic fallback that check_quota_resolved has (and update the doc line).
- ⚠️ `bin/fm-shared-github-quota.sh:238` - The new Retry-After branch matches `/\bretry[- ]after\s*[:=]?\s*([0-9]{1,7})\b/i` — the separator is optional, so prose forms match too. `You have exceeded a secondary rate limit; please retry after 15 minutes.` yields reset_epoch = now+15 SECONDS, so the cooldown expires almost immediately and the pollers resume hammering a still-walled account, while the recorded reset_at misreports the wall to the merge escalation in bin/fm-pr-merge.sh:88-97. fm_capacity_reset_fields (bin/fm-capacity-lib.sh:26) already requires `[:=]` for exactly this reason, and the branch&#39;s own doc (docs/capacity-failover.md:133) describes only the labeled header form. Require the `:`/`=` separator (header form), or parse the trailing unit when it is present.
- ℹ️ `bin/fm-shared-github-quota.sh:219` - extract_github_rate_limit scans the whole body for an ISO-8601 / `UTC` timestamp first (lines 219-232) and only falls through to the labeled `x-ratelimit-reset` / `Retry-After` evidence when Date.parse produced a non-finite value — never when it produced a value in the PAST. Real gh stderr that carries both a log-style timestamp prefix and `X-RateLimit-Reset: &lt;epoch&gt;` therefore resolves to the log timestamp; mark_quota then refuses it with `reset epoch is not in the future` (line 252) and mark-from-text exits non-zero, so no cooldown is recorded at all even though usable header evidence was present. Every caller swallows that with `|| true`. Fall through to the labeled forms when the scraped timestamp is not in the future, or prefer the labeled header over an unlabeled scraped timestamp.
- ℹ️ `bin/fm-pr-poll.sh:81` - Round 2 set FM_SHARED_GITHUB_QUOTA_DERIVE_ACCOUNT=0 on the read-only `check`/`cache-get` calls, but the sibling calls on the same paths still omit it: cache-put (bin/fm-pr-poll.sh:81), mark-from-text (bin/fm-pr-poll.sh:84, bin/fm-pr-check.sh:27, bin/fm-teardown.sh:277, bin/fm-pr-merge.sh:45) and fm-pr-merge&#39;s github_quota_check (bin/fm-pr-merge.sh:37). mark-from-text runs precisely when a GitHub call just failed — most often because the account is rate-limited — so resolve_account fires another `gh api user` against the walled account from inside the handler whose job is to conserve quota, and a failed derivation is never negatively cached, so it repeats every poll cycle. It also silently changes the key policy: a successful derive here writes accounts/github.env and remembers the account, which is what strands the agnostic cache in the finding above. Set the flag on cache-put and on all the mark-from-text/check invocations so one key policy holds across the whole poller path.
- ℹ️ `bin/fm-pr-poll.sh:50` - state/&lt;id&gt;.check.sh is a byte-for-byte copy of bin/fm-pr-poll.sh, and fm_pr_poll_artifacts_valid enforces that with `cmp -s &#34;$template&#34; &#34;$check&#34;` plus a sha256 template_hash (bin/fm-pr-lib.sh:443,455). This branch rewrites fm-pr-poll.sh, so after a home fast-forwards bin/, every already-armed merge poll fails validation: fm-watch.sh:804-819 falls through to the custom-check path, finds no .check-trust binding, and raises `check: rejected unauthenticated state checks` every CHECK_INTERVAL (300s) for each armed task, waking firstmate repeatedly. It self-heals — migration_needed (bin/fm-pr-check-migrate.sh:368) is content-based, not marker-gated, so the next session-start migration rebuilds any poll whose meta pr= is canonical — but the window between the update and the next session start is noisy and merge detection is paused for those tasks. Worth a line in the release note / update path so the alarm is not misread as tampering.

🔧 Fix: fix: align quota cache keys and reset-evidence parsing
4 issues (2 warnings, 2 infos) still open:
- ⚠️ `bin/fm-host-pressure.sh:210` - periodic_alert&#39;s new status-2 branch (bin/fm-host-pressure.sh:210-217) prints `alert=host_pressure_config_invalid` and returns before reaching the `.host-pressure-disk-alert` cooldown marker that bounds the disk alert (lines 230-239). bin/fm-watch.sh:824-833 runs periodic-alert every HOST_PRESSURE_INTERVAL (default 300s) and raises a wake for any non-empty output, so a single typo in config/capacity-failover (e.g. `disk_floor_mb=10G`) wakes firstmate every five minutes indefinitely, with no way to suppress it short of fixing or deleting the file. The disk alert this branch sits next to is explicitly cooldown-bounded for exactly this reason; the config-error alert should reuse the same marker (or its own) so a broken threshold is reported once per cooldown window rather than forever.
- ⚠️ `bin/fm-shared-github-quota.sh:261` - mark_quota only rejects a reset epoch that is not in the future (bin/fm-shared-github-quota.sh:261); it accepts any magnitude. The reset now comes from text parsing: `x-ratelimit-reset` accepts `[0-9]{9,}` with no upper bound (line 237) and `Retry-After` accepts up to `[0-9]{7}` seconds (line 239, ~115 days). A single malformed/proxied/truncated error body — or a legitimate header from a non-GitHub proxy in the same stderr — can therefore write a cooldown lasting months. That cooldown makes bin/fm-pr-merge.sh:90-100 refuse every task PR merge, makes fm-pr-poll go silent, and makes fm-teardown drop its GitHub landed-work proof, and by design there is no clear command (deferred as cooldown-clear-cmd-c4), so the only recovery is hand-deleting a CRC32-named file under XDG state that no script names to the operator. Real GitHub primary limits reset within an hour and secondary limits within minutes; clamping the accepted TTL (e.g. 24h) would bound the blast radius without touching the deferred clear-command decision.
- ℹ️ `bin/fm-shared-github-quota.sh:129` - Every wired caller now sets FM_SHARED_GITHUB_QUOTA_DERIVE_ACCOUNT=0 (bin/fm-pr-check.sh:19,27; bin/fm-pr-poll.sh:71,75,81,85; bin/fm-pr-merge.sh:40,46; bin/fm-teardown.sh:269,277; bin/fm-bearings-snapshot.sh:200), and nothing in the repo sets FM_GITHUB_ACCOUNT_ID or passes --account, so accounts/github.env is never populated and derive_account (line 129) is dead on all fleet paths. Consequence: every cooldown and cache entry is written and read under the account-agnostic key, and because the store is deliberately FM_HOME-independent, one home hitting a limit on account A blocks PR merges, pollers and teardown proofs for every home and every GitHub account sharing the machine. That may be the intended fleet-wide conservatism, but docs/capacity-failover.md:126 still advertises `gh api user` derivation as a live key source, which no path can now reach — worth either dropping that claim or giving operators a documented way to opt into per-account keying.
- ℹ️ `bin/fm-pressure-lib.sh:26` - fm_pressure_config_value returns the built-in default for an explicitly empty value (`printf &#39;%s\n&#39; &#34;${value:-$default}&#34;`, bin/fm-pressure-lib.sh:26), so `disk_floor_mb=` or `max_running_tasks=` in config/capacity-failover silently re-enables the default threshold instead of disabling that dimension. Because every default in emit_check is a non-empty number, the `[ -n &#34;$MIN_MEM&#34; ]`, `[ -n &#34;$WARN_DISK&#34; ]`, `[ -n &#34;$disk_floor&#34; ]` and `[ -n &#34;$MAX_RUNNING&#34; ]` guards (bin/fm-host-pressure.sh:119, 142-158, 169) and disk_hysteresis_state&#39;s empty-floor branch (line 82) are all unreachable. Either honour an explicitly empty value as &#34;this threshold is off&#34; or drop the dead empty-value handling so the config contract and the code agree.

🔧 Fix: fix: bound repeated host-pressure config-invalid alerts
3 issues (1 warning, 2 infos) still open:
- ⚠️ `tests/fm-backend-autodetect-smoke.test.sh:148` - The round-3 fix exported FM_SHARED_STATE_OVERRIDE from tests/lib.sh &#34;so no new test can regress this by omission&#34;, but three suites source neither tests/lib.sh nor tests/secondmate-helpers.sh and still drive the real bin/fm-teardown.sh: tests/fm-backend-autodetect-smoke.test.sh:148, tests/fm-backend-herdr-presentation-e2e.test.sh:149, and tests/fm-backend-herdr-workspace-per-home-e2e.test.sh:205 (grep confirms zero FM_SHARED_STATE_OVERRIDE occurrences in all three). Because shared_state_root() (bin/fm-shared-github-quota.sh:18) is deliberately FM_HOME-independent, teardown&#39;s new github_quota_deferred (bin/fm-teardown.sh:267) resolves to the operator&#39;s real ${XDG_STATE_HOME:-$HOME/.local/state}/firstmate/shared-github-quota. Effects: check_quota rm -f&#39;s expired records in that real tree (bin/fm-shared-github-quota.sh:315,322), and if a real cooldown happens to be active on the developer&#39;s machine, pr_is_merged and pr_number_from_branch both short-circuit, so teardown silently falls back to the content-in-default proof and the suite&#39;s result depends on live GitHub quota. Fix: export FM_SHARED_STATE_OVERRIDE to a per-run sandbox in each of these three suites (or have them source tests/lib.sh).
- ℹ️ `bin/fm-shared-github-quota.sh:349` - Rounds 4-5 added record_matches_key (bin/fm-shared-github-quota.sh:286) and fm_capacity_cooldown_record_matches (bin/fm-capacity-lib.sh:221) so a cooldown found under a CRC32-derived path is only honored when its own identity fields agree with the requested key. The cache path was not given the same guard: cache_dir() hashes (provider, account, route, key) with cksum (line 52), and cache_get (line 349) reads only created_epoch from meta.env before cat-ing the body. cache_put already writes provider=/account=/route=/key= into that meta (lines 385-395), so a CRC32 collision or a hand-copied/restored cache directory would serve another PR&#39;s stored state - and since the only cached value is the PR state consumed as merge proof by bin/fm-pr-poll.sh:76, a stale/foreign MERGED body would emit a merged wake for the wrong task. Compare the meta&#39;s own provider/account/route/key to the requested key before returning the body, exactly as check_quota does.
- ℹ️ `bin/fm-shared-github-quota.sh:470` - mark-from-text&#39;s account resolution (bin/fm-shared-github-quota.sh:470-474) reimplements resolve_account_or_agnostic&#39;s own first branch: `if [ -n &#34;$ACCOUNT&#34; ]; then resolve_account ... else resolve_account_or_agnostic ...; fi`, while resolve_account_or_agnostic (line 161-171) already does exactly `if [ -n &#34;$ACCOUNT&#34; ]; then resolve_account || return $?; return 0; fi` before falling back. Under set -eu the two forms propagate identically, so the whole block collapses to a single `resolve_account_or_agnostic &#34;$PROVIDER&#34;` - matching how check (line 447), cache-get (line 486) and cache-put (line 491) already call it, and removing the second place where the key policy has to be kept in sync.

🔧 Fix: fix: sandbox e2e quota state and verify cache keys
4 issues (1 warning, 3 infos) still open:
- ⚠️ `bin/fm-spawn.sh:456` - With `host-pressure=on`, a single malformed threshold in config/capacity-failover takes the whole home&#39;s dispatch offline, not just &#34;critical pressure&#34;. emit_check (bin/fm-host-pressure.sh:126-132) returns 2 for any non-numeric value (e.g. `disk_floor_mb=10G`, `max_running_tasks=thirty`); `gate` propagates 2; capacity_failover_pressure_check falls past the `off|ok|&#39;&#39;|warn|critical` case (pressure_state is empty because the message went to stderr) and hits `exit &#34;$status&#34;` at bin/fm-spawn.sh:452-457. Every subsequent spawn - ship, scout, secondmate, recovery relaunch - refuses until a human edits the file, and the only surfacing is the once-per-hour `host_pressure_config_invalid` watcher alert. docs/capacity-failover.md:88-118 and docs/configuration.md&#39;s new section describe only &#34;critical pressure refuses the new spawn&#34;; neither says a config typo refuses all spawns. If total fail-closed is intended, document it; otherwise treat a config-parse failure as warn-and-continue (the thresholds were never applied, so there is no measured pressure to back a refusal).
- ℹ️ `bin/fm-host-pressure.sh:120` - bin/fm-host-pressure.sh:120 runs `[ &#34;$disk_default_clear&#34; -lt &#34;$disk_floor&#34; ]` before the fm_pressure_numeric_or_empty validation block at lines 126-132. With a non-numeric `warn_disk_available_mb` or `disk_floor_mb`, bash emits a raw `[: 10G: integer expression expected` line on stderr ahead of the intended `error: disk_floor_mb must be a non-negative integer`. periodic_alert survives it only because it takes `tail -1` of the stderr file (line 216), but fm-spawn&#39;s capacity_failover_pressure_check captures `2&gt;&amp;1` wholesale and prints both lines to the operator. Move the disk_default_clear clamp below the validation block so only the intended message is ever produced.
- ℹ️ `docs/capacity-failover.md:95` - docs/capacity-failover.md:95 says `bin/fm-host-pressure.sh gate --kind test` &#34;gives the same disk-floor decision to validation/test launch wrappers&#34;. Two inaccuracies: GATE_KIND is only validated at bin/fm-host-pressure.sh:280-283 and echoed as `gate_kind=` (line 176) - it never narrows the verdict, so `--kind test` returns the full memory + disk + max_running_tasks decision, not a disk-floor decision; and no caller in the repo invokes `gate --kind test` (grep finds only the `--kind spawn` call in bin/fm-spawn.sh:433). Reword to describe it as the same full pressure verdict, available to future test wrappers.
- ℹ️ `bin/fm-shared-github-quota.sh:140` - resolve_account (bin/fm-shared-github-quota.sh:136-142) calls remember_account for every subcommand that supplies an explicit account, including the read-only `check` and `cache-get` paths. So a one-off `FM_GITHUB_ACCOUNT_ID=999 fm-shared-github-quota.sh check` - or a stale export left in a shell - permanently rewrites accounts/github.env in the FM_HOME-independent shared tree, and every later DERIVE_ACCOUNT=0 caller in fm-pr-check/fm-pr-poll/fm-pr-merge/fm-teardown then resolves 999 and keys its lookups there. The dual keyed-then-agnostic lookup added in rounds 5-6 keeps existing records readable, so the blast radius is bounded, but a read-only query mutating durable fleet-wide identity state is the same class of problem the round-1 fix removed for text-scraped accounts. Persist the account only from the mutating paths (mark/mark-from-text/cache-put), or gate it behind an explicit flag.

🔧 Fix: fix: validate disk thresholds before numeric comparison
3 infos still open:
- ℹ️ `bin/fm-rehome-quota-wall.sh:34` - Several new/edited scripts have hardcoded usage() sed ranges that no longer match their header block. bin/fm-rehome-quota-wall.sh:34 uses `sed -n &#39;2,18p&#39;`, but the comment header ends at line 16 - so `--help` prints the literal `set -eu` (line 17) and a blank line as part of the usage text. Three others truncate mid-sentence instead: bin/fm-host-pressure.sh:26 (`2,11p` cuts &#34;...a caller should apply&#34; before &#34;backpressure by refusing a new heavy launch.&#34; and drops the exit-code-2 line entirely), bin/fm-shared-github-quota.sh:408 (`2,10p` drops line 11, the only place FM_SHARED_STATE_OVERRIDE is documented in the help), and bin/fm-capacity-route.sh:26 (`2,10p` cuts &#34;never edits dispatch config... and never&#34; before &#34;chooses an unverified harness.&#34;). Since AGENTS.md section 4 tells agents to consult current --help rather than memorize flags, these ranges should cover exactly the header comment block.
- ℹ️ `bin/fm-rehome-quota-wall.sh:191` - The meta-rewrite awk skip list (bin/fm-rehome-quota-wall.sh:191-195) removes window/harness/model/effort/backend, the backend-specific ids, and pr/pr_head, but not the rehome_* keys the same block appends at lines 208-211. A second rehome of the same task therefore copies the previous rehome_at=, rehome_from_harness=, rehome_from_window= and rehome_continuation= lines and appends a new set after them, so state/&lt;id&gt;.meta accumulates one duplicate set per rehome. fm_meta_get (bin/fm-backend.sh:341) takes tail -1 so the resolved values stay correct and PR identity still parses, but the record grows unboundedly and reads ambiguously. Add rehome_at/rehome_from_harness/rehome_from_window/rehome_continuation to the skip list.
- ℹ️ `bin/fm-shared-github-quota.sh:388` - cache_put (bin/fm-shared-github-quota.sh:388) creates one directory per (provider, account, route, key) under the FM_HOME-independent shared store, and the only pruning is inside cache_get (lines 366, 369-372), which removes an entry solely when that same key is read back after expiry. bin/fm-pr-poll.sh:79-83 writes a `pr-state:&lt;url&gt;` entry on every successful poll, but once the task lands, fm-teardown removes state/&lt;id&gt;.check.sh and nothing ever reads that key again - so the directory survives forever in ${XDG_STATE_HOME:-$HOME/.local/state}/firstmate/shared-github-quota/cache/. Each entry is tiny, but the set grows monotonically with every PR the fleet has ever polled and no command names or clears it. A max-age sweep of the cache directory on cache_put (or removal of the task&#39;s cache key from teardown&#39;s remove_pr_poll_artifacts) would bound it.

</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed (2) ✅</summary>

- 🚨 tests failed with exit code 1
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`

🔧 Fix: fail spawn when task metadata write fails
1 error still open:
- 🚨 tests failed with exit code 1
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`

🔧 Fix: wait for stale suppressor write in watch-triage absorb tests
✅ Re-checked - no issues remain.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- `bash tests/fm-shared-github-quota.test.sh`
- `bash tests/fm-capacity.test.sh`
- `bash tests/fm-capacity-route.test.sh`
- `bash tests/fm-rehome-quota-wall.test.sh`
- `bash tests/fm-host-pressure.test.sh`
- `bash tests/fm-pr-check-security.test.sh`
- `bash tests/fm-pr-merge.test.sh`
- <code>Manual end-to-end demo in a disposable sandbox with a fake `gh`: `FM_DEMO_ROOT=$PWD bash /var/folders/3b/9kjwhxp50j36ftjmfm3f1lm80000gn/T/no-mistakes-evidence/01KY1C6AHBMB2XMGYVMD8R5KWQ/demo-failover-substrate.sh` — arms a real merge poll via `bin/fm-pr-check.sh`, runs the generated `state/&lt;id&gt;.check.sh` across no-cooldown / rate-limit / during-cooldown / post-reset phases counting actual `gh` invocations</code>
- <code>Manual account-keying check: `bin/fm-shared-github-quota.sh mark-from-text` with no resolvable account, then `check` with and without `--account`, plus a source scan for hardcoded account defaults</code>
- <code>Manual route-selection check: `bin/fm-capacity-cooldown.sh mark` with a partial key followed by `bin/fm-capacity-route.sh select` before, during, and after the wall</code>
- <code>Manual deferral check: `bin/fm-capacity-cooldown.sh clear ...` confirms no cooldown-clear subcommand exists</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
