### PR TITLE
fix: watcher ended-without-status handling for idle turn-ended

### DIFF
--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -406,6 +406,92 @@ scan_signals() {
   return 0
 }
 
+# 0 if any .turn-ended wake in the changed-file set is both:
+#   - unaccompanied by a same-task .status change (no structured status delta),
+#   - likely idle in its pane,
+#   - and not a secondmate.
+#
+# This is a fail-closed guard for the exact "turn ended with no status" case
+# where the status log has no captain-relevant verb for us to inspect. In that
+# case, pane idleness is the practical signal that the task may have finished or
+# waited on an interactive request and needs firstmate eyes; a live busy pane and
+# secondmate are treated as non-actionable.
+signal_ended_without_status_idle() {  # <file> ...
+  local f base task meta kind window backend tail has_status_delta g
+  [ $# -eq 0 ] && return 1
+
+  f=$1
+  [ -e "$f" ] || return 1
+  base=${f##*/}
+  case "$base" in
+    *.turn-ended) task=${base%.turn-ended} ;;
+    *) return 1 ;;
+  esac
+  [ -n "$task" ] || return 1
+
+  # Ignore explicit ended-without-status candidates that also wrote a same-task
+  # .status delta in this coalesced wake batch.
+  has_status_delta=0
+  for g in "$@"; do
+    [ "${g##*/}" = "$task.status" ] && has_status_delta=1 && break
+  done
+  [ "$has_status_delta" -eq 1 ] && return 1
+
+  meta="$STATE/$task.meta"
+  if [ -e "$meta" ]; then
+    kind=$(grep '^kind=' "$meta" 2>/dev/null | tail -1 | cut -d= -f2- || true)
+    [ "$kind" = secondmate ] && return 1
+
+    window=$(fm_backend_target_of_meta "$meta")
+    if [ -n "$window" ]; then
+      backend=$(fm_backend_of_meta "$meta")
+      [ -n "$backend" ] || backend=tmux
+      tail=$(fm_backend_capture "$backend" "$window" 40 "$(window_label "$window")" 2>/dev/null)
+      if [ -n "$tail" ]; then
+        if window_is_busy "$window" "$tail"; then
+          return 1
+        fi
+        crew_is_provably_working "$task" && return 1
+        return 0
+      fi
+    fi
+  fi
+
+  # Fallback to authoritative state in the absence of an active window capture.
+  crew_is_provably_working "$task" && return 1
+  return 0
+}
+
+# 0 if every task referenced by a no-verb signal is clearly provable for the
+# watcher. This is the watcher-local variant of signal_crew_provably_working with
+# one additional secondmate override: secondmate task markers are suppressed in the
+# no-verb signal path (direct secondmate wakeups are handled by its own status
+# lifecycle and explicit status signals).
+watch_signal_crew_provably_working() {  # <file> ...
+  local f base task seen="" meta kind
+  for f in "$@"; do
+    base=${f##*/}
+    case "$base" in
+      *.status) task=${base%.status} ;;
+      *.turn-ended) task=${base%.turn-ended} ;;
+      *) continue ;;
+    esac
+    [ -n "$task" ] || continue
+    case " $seen " in *" $task "*) continue ;; esac
+    seen="$seen $task"
+
+    meta="$STATE/$task.meta"
+    if [ -f "$meta" ]; then
+      kind=$(grep '^kind=' "$meta" 2>/dev/null | tail -1 | cut -d= -f2- || true)
+      [ "$kind" = secondmate ] && continue
+    fi
+
+    crew_is_provably_working "$task" || return 1
+  done
+  [ -n "$seen" ] || return 1
+  return 0
+}
+
 run_check() {
   local c=$1
   if command -v timeout >/dev/null 2>&1; then
@@ -665,6 +751,8 @@ $pending
 EOF
     reason="signal:$files"
     # Triage: a signal is ACTIONABLE when any of these holds (cheapest first):
+    #   - a turn-ended wake with no corresponding status delta for that same task
+    #     and an idle pane (ended-without-status);
     #   - the away-mode daemon owns triage (afk) and wants every wake;
     #   - any status file carries a captain-relevant verb;
     #   - or it is a no-verb wake (a bare turn-end, a working: note) whose crew is
@@ -678,29 +766,59 @@ EOF
     # check is the only costly one (it may run a bounded no-mistakes call), so the ||
     # ordering evaluates it ONLY for a non-afk, no-captain-verb signal.
     # shellcheck disable=SC2086  # $files is a space-separated status-path list (ids carry no spaces)
-    if afk_present || signal_reason_is_actionable $files || ! signal_crew_provably_working $files; then
-      while IFS=$(printf '\t') read -r sf sig f; do
-        [ -n "$sf" ] || continue
-        fm_wake_append signal "$(basename "$f")" "$reason" || exit 1
-      done <<EOF
+    ended_without_status=0
+    ended_without_status_files=""
+    for f in $files; do
+      signal_ended_without_status_idle "$f" $files && ended_without_status_files="$ended_without_status_files $f"
+    done
+    [ -n "$ended_without_status_files" ] && ended_without_status=1
+    batch_reason=""
+    for f in $files; do
+      if [ -n "$batch_reason" ]; then
+        batch_reason="$batch_reason "
+      fi
+        case " $ended_without_status_files " in
+        *" $f "*) batch_reason="${batch_reason}ended-without-status: $f" ;;
+        *) batch_reason="${batch_reason}signal: $f" ;;
+      esac
+    done
+    if afk_present || [ "$ended_without_status" -eq 1 ] || signal_reason_is_actionable $files || ! watch_signal_crew_provably_working $files; then
+      if [ "$ended_without_status" -eq 1 ] && [ "$ended_without_status_files" = "$files" ]; then
+        batch_reason="ended-without-status:$ended_without_status_files"
+      fi
+      for f in $files; do
+        sf=""
+        sig=""
+        while IFS=$(printf '\t') read -r sf_line sig_line path; do
+          [ -n "$sf_line" ] || continue
+          [ "$path" = "$f" ] || continue
+          sf=$sf_line
+          sig=$sig_line
+        done <<EOF
 $pending
 EOF
-      while IFS=$(printf '\t') read -r sf sig f; do
-        [ -n "$sf" ] || continue
-        printf '%s' "$sig" > "$sf"
+        file_reason="signal:$f"
+        case " $ended_without_status_files " in *" $f "* ) file_reason="ended-without-status:$f" ;; esac
+        fm_wake_append signal "$(basename "$f")" "$file_reason" || exit 1
+        [ -n "$sig" ] && printf '%s' "$sig" > "$sf"
         mark_surfaced "$f"
-      done <<EOF
-$pending
-EOF
-      wake "$reason"
+      done
+      wake "$batch_reason"
     else
-      while IFS=$(printf '\t') read -r sf sig f; do
-        [ -n "$sf" ] || continue
-        printf '%s' "$sig" > "$sf"
-      done <<EOF
+      for f in $files; do
+        sf=""
+        sig=""
+        while IFS=$(printf '\t') read -r sf_line sig_line path; do
+          [ -n "$sf_line" ] || continue
+          [ "$path" = "$f" ] || continue
+          sf=$sf_line
+          sig=$sig_line
+        done <<EOF
 $pending
 EOF
-      triage_log "absorbed benign $reason"
+        [ -n "$sf" ] && printf '%s' "$sig" > "$sf"
+      done
+      triage_log "absorbed benign $batch_reason"
     fi
   fi
 

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -304,10 +304,85 @@ test_turn_ended_not_working_surfaced() {
   watch_bg "$state" "$fakebin" "$out"
   pid=$!
   wait_for_exit "$pid" 40 || fail "watcher did not surface a turn-end whose crew is not provably working"
-  grep -F "signal: $state/task.turn-ended" "$out" >/dev/null || fail "watcher did not print the surfaced turn-end signal"
+  grep -F "ended-without-status: $state/task.turn-ended" "$out" >/dev/null || fail "watcher did not print the surfaced ended-without-status turn-ended"
   FM_STATE_OVERRIDE="$state" "$DRAIN" > "$drain_out" 2>/dev/null || fail "drain after the surfaced turn-end failed"
   grep "$(printf '\tsignal\t')" "$drain_out" | grep -F "$state/task.turn-ended" >/dev/null || fail "surfaced turn-end was not queued"
   pass "a bare turn-end whose crew is not provably working is surfaced (the swallowed-finish fix)"
+}
+
+test_turn_ended_no_status_idle_blackbox() {
+  local dir state fakebin out capture_file window drain_out pid
+  dir=$(make_case ended-without-status-blackbox); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"; capture_file="$dir/pane.txt"; drain_out="$dir/drain.out"
+  window="test:fm-personal-brain-redesign-k7"
+  printf 'window=%s\nkind=ship\n' "$window" > "$state/task.meta"
+  printf 'idle: waiting for captain in the pane\n' > "$capture_file"
+  : > "$state/task.turn-ended"
+  export FM_FAKE_CREW_STATE='state: unknown · source: none · no current-state source available'
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
+    FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  wait_for_exit "$pid" 80 || fail "watcher did not surface the bare turn-ended idle event"
+  grep -F "ended-without-status: $state/task.turn-ended" "$out" >/dev/null || fail "watcher did not emit an ended-without-status reason: $(cat "$out")"
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$drain_out" 2>/dev/null || fail "drain after the ended-without-status event failed"
+  grep "$(printf '\tsignal\t')" "$drain_out" | grep -F "ended-without-status" | grep -F "$state/task.turn-ended" >/dev/null || fail "ended-without-status event was not queued"
+  pass "a bare turn-ended with no status and idle pane surfaces as ended-without-status (black-box)"
+}
+
+test_turn_ended_capture_running_runstep_is_absorbed_blackbox() {
+  local dir state fakebin out capture_file window drain_out pid
+  dir=$(make_case ended-runstep-capture-absorbed); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"; capture_file="$dir/pane.txt"; drain_out="$dir/drain.out"
+  window="test:fm-personal-brain-redesign-k7"
+  printf 'window=%s\nkind=ship\n' "$window" > "$state/task.meta"
+  printf 'idle: waiting for completion\n' > "$capture_file"
+  : > "$state/task.turn-ended"
+  export FM_FAKE_CREW_STATE='state: working · source: run-step · validation still running'
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
+    FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  if ! wait_live "$pid" 30; then
+    reap "$pid"; fail "turn-ended with active run-step and idle pane surfaced instead of being absorbed: $(cat "$out")"
+  fi
+  i=0
+  while [ "$i" -lt 160 ]; do
+    [ -s "$state/.seen-task_turn-ended" ] && break
+    sleep 0.1
+    i=$((i + 1))
+  done
+  if [ ! -s "$state/.seen-task_turn-ended" ]; then
+    reap "$pid"; fail "an absorbed turn-ended did not advance its .seen-* suppressor in time"
+  fi
+  [ ! -s "$out" ] || { reap "$pid"; fail "active run-step with idle pane printed an actionable wake: $(cat "$out")"; }
+  [ ! -s "$state/.wake-queue" ] || { reap "$pid"; fail "active run-step turn-ended queued an unwanted wake: $(cat "$out")"; }
+  [ -e "$state/.last-watcher-beat" ] || { reap "$pid"; fail "watcher beacon was not touched while absorbing"; }
+  reap "$pid"
+  pass "a turn-ended with capture-only idle pane and run-step state is still absorbed"
+}
+
+test_turn_ended_and_status_coalesced_reason_split_blackbox() {
+  local dir state fakebin out capture_file window drain_out pid
+  dir=$(make_case coalesced-ended-status-reason-split); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"; capture_file="$dir/pane.txt"; drain_out="$dir/drain.out"
+  window="test:fm-personal-brain-redesign-k7"
+  printf 'window=%s\nkind=ship\n' "$window" > "$state/ended.meta"
+  printf 'idle: waiting for captain\n' > "$capture_file"
+  printf 'needs-decision: confirm the rollback path\n' > "$state/status.status"
+  : > "$state/ended.turn-ended"
+  export FM_FAKE_CREW_STATE='state: unknown · source: none · no current-state source available'
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
+    FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  wait_for_exit "$pid" 80 || fail "watcher did not exit for a coalesced ended-without-status + actionable status batch"
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$drain_out" 2>/dev/null || fail "drain after the coalesced batch failed"
+  grep "$(printf '\tsignal\t')" "$drain_out" | grep -F "$state/ended.turn-ended" | grep -F "ended-without-status:$state/ended.turn-ended" >/dev/null \
+    || fail "ended-without-status turn-end did not keep its per-task reason in coalesced queue payload"
+  grep "$(printf '\tsignal\t')" "$drain_out" | grep -F "$state/status.status" | grep -F "signal:$state/status.status" >/dev/null \
+    || fail "coalesced actionable status was wrongly tagged as ended-without-status"
+  pass "coalesced no-status turn-end and actionable status wake in one batch keeps per-task reason labels"
 }
 
 test_working_note_not_working_surfaced() {
@@ -1107,6 +1182,9 @@ test_signal_crew_provably_working_classifier
 test_provably_working_signal_absorbed
 test_turn_ended_provably_working_absorbed
 test_turn_ended_not_working_surfaced
+test_turn_ended_no_status_idle_blackbox
+test_turn_ended_capture_running_runstep_is_absorbed_blackbox
+test_turn_ended_and_status_coalesced_reason_split_blackbox
 test_working_note_not_working_surfaced
 test_actionable_signal_surfaced
 test_terminal_stale_surfaced


### PR DESCRIPTION
## Root cause fix
- A direct `.turn-ended` wake without a same-task `.status` delta was being absorbed incorrectly in some idle run-step/idle-capture cases.
- Coalesced wake queues could also hide actionable `ended-without-status` tasks with mixed signal types.

## Fix implemented
- `bin/fm-watch.sh`: add explicit ended-without-status detection for idle `.turn-ended` when no same-task status exists, with authoritative state/stateful pane checks.
- Exclude `secondmate` from this no-verb signal path.
- Preserve per-task reason attribution in coalesced batches (`ended-without-status:<path>` / `signal:<path>`).
- `tests/fm-watch-triage.test.sh`: add 3 black-box regressions for the above scenarios.

## Validation
- Shellcheck: pass for changed files.
- Bounded triage suite pass for all high-model 3-item cases.
- Known remaining baseline issue (outside this scope): `test_terminal_stale_surfaced`.
