### PR TITLE
fix: clean up AFK launcher lock on signal

### DIFF
--- a/bin/fm-afk-launch.sh
+++ b/bin/fm-afk-launch.sh
@@ -595,10 +595,10 @@ fm_afk_launch_stop() {
 
 fm_afk_launch_main() {
   local result
-  fm_afk_launch_lock_acquire || return 1
   trap fm_afk_launch_lock_release EXIT
   trap 'exit 130' INT
   trap 'exit 143' TERM
+  fm_afk_launch_lock_acquire || return 1
   case "${1:-start}" in
     start) fm_afk_launch_start ;;
     start-native) fm_afk_launch_start_native ;;

--- a/bin/fm-afk-launch.sh
+++ b/bin/fm-afk-launch.sh
@@ -39,6 +39,11 @@
 # Supported backends: herdr, tmux. Others (zellij, orca, cmux) have no verified
 # non-visible-launch primitive here yet and refuse loudly.
 #
+# Lifecycle lock signal safety: this script arms EXIT/INT/TERM traps before it
+# attempts state/.afk-launch.lock acquisition, so a signal during lock-directory
+# publication exits with the signal status and still releases any lock owned by
+# this process.
+#
 # Test seam: FM_AFK_LAUNCH_ENTRY overrides the command run in the created
 # terminal (default bin/fm-afk-start.sh), so a topology test can run a harmless
 # placeholder instead of a real daemon. FM_SUPERVISOR_TARGET/FM_SUPERVISOR_BACKEND

--- a/bin/fm-afk-launch.sh
+++ b/bin/fm-afk-launch.sh
@@ -594,11 +594,21 @@ fm_afk_launch_stop() {
 }
 
 fm_afk_launch_main() {
-  local result
+  local result signal=
   trap fm_afk_launch_lock_release EXIT
+  trap 'signal=130' INT
+  trap 'signal=143' TERM
+  if ! fm_afk_launch_lock_acquire; then
+    if [ -n "$signal" ]; then
+      exit "$signal"
+    fi
+    return 1
+  fi
+  if [ -n "$signal" ]; then
+    exit "$signal"
+  fi
   trap 'exit 130' INT
   trap 'exit 143' TERM
-  fm_afk_launch_lock_acquire || return 1
   case "${1:-start}" in
     start) fm_afk_launch_start ;;
     start-native) fm_afk_launch_start_native ;;

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -725,6 +725,13 @@ On entry the launcher drops the prior session's artifacts when the daemon is not
 This never drops a genuinely-pending escalation: the durable record is `state/.wake-queue` plus each crew's `state/<id>.status`, and any still-true condition is re-escalated by the daemon's heartbeat catch-all scan.
 Covered by the unit cases in `tests/fm-afk-launch.test.sh` (clear-on-fresh-entry vs refresh, and the stop ordering asserting the daemon saw `state/.afk` present at SIGTERM).
 
+### Launcher-lock signal race fix (2026-07-13)
+
+`bin/fm-afk-launch.sh` serializes away-mode lifecycle entry and exit with `state/.afk-launch.lock`.
+The launcher now arms its EXIT/INT/TERM traps before attempting that lock acquisition, so an INT or TERM delivered while the lock directory is being published exits with the signal status and still runs the pid-guarded lock release path.
+This prevents an orphaned lifecycle lock without changing backend behavior.
+Covered by `tests/fm-afk-launch.test.sh`'s signal cases, including a TERM injected immediately after lock-directory creation.
+
 ## Known gaps and follow-up notes
 
 - **Backend-specific bootstrap detection is absent.** `bin/fm-bootstrap.sh` still requires `tmux` outside Orca mode, and does not yet conditionally add `herdr` and `jq` when a backend selection resolves to herdr.

--- a/tests/fm-afk-launch.test.sh
+++ b/tests/fm-afk-launch.test.sh
@@ -262,6 +262,30 @@ unit_signal_exits_with_lock_cleanup() {
   rm -rf "$st"
 }
 
+unit_signal_during_lock_publication_cleans_lock() {
+  local st
+  st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-signal-publish.XXXXXX")
+  FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" bash -c '
+    . "$1"
+    fm_afk_launch_start() { :; }
+    mkdir() {
+      if [ "${1:-}" = "$FM_AFK_LAUNCH_LOCK" ]; then
+        command mkdir "$1" || return 1
+        kill -TERM "$$"
+        return 0
+      fi
+      command mkdir "$@"
+    }
+    fm_afk_launch_main start
+  ' _ "$LAUNCH" >/dev/null 2>&1
+  if [ "$?" -eq 143 ] && [ ! -e "$st/state/.afk-launch.lock" ]; then
+    pass "launcher signal: TERM during lock publication releases the lifecycle lock"
+  else
+    fail "launcher signal: TERM during lock publication retained its lock"
+  fi
+  rm -rf "$st"
+}
+
 unit_herdr_partial_create_recovery() {
   local st recorded
   st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-herdr-partial.XXXXXX")
@@ -868,6 +892,7 @@ unit_failed_start_rolls_back_state
 unit_concurrent_start_serialized
 unit_lock_initialization_grace
 unit_signal_exits_with_lock_cleanup
+unit_signal_during_lock_publication_cleans_lock
 unit_herdr_partial_create_recovery
 unit_herdr_error_with_exact_ids_closes_exact
 unit_herdr_run_failure_preserves_unconfirmed_record

--- a/tests/fm-afk-launch.test.sh
+++ b/tests/fm-afk-launch.test.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 # tests/fm-afk-launch.test.sh - the script-owned, backend-aware away-daemon
-# launch (bin/fm-afk-launch.sh) and the away-mode stale-artifact lifecycle fixes
-# (bin/fm-afk-start.sh). Two layers:
+# launch (bin/fm-afk-launch.sh), launcher-lock signal cleanup, and the away-mode
+# stale-artifact lifecycle fixes (bin/fm-afk-start.sh). Two layers:
 #
 #   UNIT (always run, no backend): the session-scoped stale-artifact clear on a
-#   fresh entry vs a refresh, and the correct-ordered stop (daemon SIGTERM'd
-#   while state/.afk is still present, .afk cleared last).
+#   fresh entry vs a refresh, launcher-lock cleanup when signaled during or after
+#   lock publication, and the correct-ordered stop (daemon SIGTERM'd while
+#   state/.afk is still present, .afk cleared last).
 #
 #   E2E TOPOLOGY (per backend, skipped when its tool is absent): the anti-
 #   regression for the pane split/shrink - entering AND exiting away mode leaves


### PR DESCRIPTION
## Intent

Fix a signal-handling race in the away-mode launcher. fm_afk_launch_main armed its EXIT/INT/TERM traps AFTER calling fm_afk_launch_lock_acquire, so a TERM/INT delivered in that window killed the process by default disposition, the EXIT trap never ran, and the lifecycle lock was orphaned. Move the three trap lines before the lock acquisition; fm_afk_launch_lock_release is already pid-guarded ([ pid = $$ ] || return 0), so arming the EXIT trap before acquisition is a safe no-op if a signal fires pre-acquire and a correct release otherwise. Pure cross-platform bug fix, affects POSIX and Windows equally, not gated. Deflakes tests/fm-afk-launch.test.sh unit_signal_exits_with_lock_cleanup (measured ~40 percent to ~0.4 percent failure).

## What Changed
- Captain, armed the AFK launcher EXIT/INT/TERM traps before lifecycle lock acquisition so interrupted starts release any owned `.afk-launch.lock` and preserve signal exit status.
- Added a regression unit case for TERM delivered during lock-directory publication, alongside the existing launcher signal cleanup coverage.
- Documented the AFK launcher lock signal-safety behavior in the herdr backend notes.

## Risk Assessment

✅ Low: Captain, the change is tightly scoped to AFK launcher signal cleanup, preserves the existing lock ownership guard, and adds a focused regression case for the previously reported publication-window race.

## Testing

The pre-run full baseline was already green; I then ran the relevant AFK launcher suite and a focused signal-window check for TERM and INT, both of which demonstrated correct signal exit and lock cleanup with evidence saved under `/tmp/no-mistakes-evidence/01KXD28SMG8QQMACD1NKHAA3N9`.

<details>
<summary>Evidence: AFK launcher test log</summary>

```text
ok - clear-stale: removes escalations buffer, sidecar, and wedge marker
ok - clear-stale: leaves the durable wake-queue intact (no pending work dropped)
ok - refresh: daemon already alive - stale artifacts preserved (current session's buffer kept)
ok - stop-ordering: daemon SIGTERM'd while .afk still present (flush is not a no-op)
ok - stop-ordering: .afk cleared last
ok - stop-ordering: daemon-terminal record removed
ok - stop identity: stale lock cannot signal an unrelated live process
ok - failed start: away flag and delivery artifacts roll back
ok - concurrent start: one serialized daemon terminal remains tracked
ok - launcher lock: incomplete publication receives initialization grace
ok - launcher signal: TERM exits and releases the lifecycle lock
ok - launcher signal: TERM during lock publication releases the lifecycle lock
ok - herdr create: malformed response recovers durable exact ownership
ok - herdr create error: unconfirmed exact id is persisted for reconciliation
ok - herdr run failure: unconfirmed exact id remains reconcilable
ok - record failure: newly created terminal is closed by exact id
ok - readiness failure: exact terminal and durable record roll back
ok - readiness failure: unconfirmed terminal retains its reconciliation id
ok - tmux absence: clean missing differs from transport probe failure
ok - native lifecycle: launcher owns state with no terminal
ok - native lifecycle: uniform stop clears state without closing a terminal
ok - native entry: launcher-prepared lifecycle state is not rewritten
ok - teardown failure: exact terminal record is preserved
ok - record publication: failed atomic rename preserves the complete prior record
ok - record read: malformed record fails closed without acting on a partial id
ok - stop: malformed terminal record preserves away state and fails closed
ok - tmux launch: planned exact target is recorded before creation and removed on failure
ok - tmux launch: unique names eliminate collision teardown
ok - stop validation: malformed record causes no daemon or state side effects
ok - launcher lock: incomplete metadata fails acquisition and releases lock
ok - stop state: away-flag removal failure is surfaced
ok - stop liveness: captured live daemon preserves lifecycle state after lock release
ok - refresh record: malformed terminal identity fails closed
ok - clear failure: native entry aborts and restores prior state
ok - confirmed absence: cleanup succeeds and removes the stale record
ok - rollback restore: incomplete restoration retains its recovery backup
ok - flag failure: lifecycle aborts without active state
ok - herdr e2e: captain tab pane count unchanged after start (no split)
ok - herdr e2e: daemon launched in a separate non-visible workspace
ok - herdr e2e: daemon pane is NOT in the captain's tab
ok - herdr e2e: daemon terminal scoped to the lab session
ok - herdr e2e: captain tab pane count restored after stop
ok - herdr e2e: daemon workspace removed by exact id on stop
ok - herdr e2e: record + .afk cleared on stop
ok - tmux e2e: captain window pane count unchanged after start (no split-window)
ok - tmux e2e: daemon launched in a separate detached session
ok - tmux e2e: captain window pane count unchanged after stop
ok - tmux e2e: daemon session killed by exact id on stop
ok - tmux e2e: record + .afk cleared on stop
```
</details>
<details>
<summary>Evidence: Signal-window transcript</summary>

<code>signal=TERM&#10;exit_code=143 expected=143&#10;lock_exists_after_exit=no&#10;verdict=pass&#10;&#10;signal=INT&#10;exit_code=130 expected=130&#10;lock_exists_after_exit=no&#10;verdict=pass</code>

```text
signal=TERM
home=/tmp/fm-afk-signal-window.GioLbG
exit_code=143 expected=143
lock_exists_after_exit=no
verdict=pass

signal=INT
home=/tmp/fm-afk-signal-window.jZz8Dr
exit_code=130 expected=130
lock_exists_after_exit=no
verdict=pass
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-afk-launch.sh:601` - The remaining lock-acquisition critical section can still orphan `.afk-launch.lock`: the traps now run before `fm_afk_launch_lock_acquire`, but `fm_afk_launch_lock_release` only removes the directory when `pid` already equals `$$`. If TERM/INT lands after `mkdir &#34;$FM_AFK_LAUNCH_LOCK&#34;` succeeds but before `pid`/`pid-identity` are fully written, the EXIT trap sees no matching pid and leaves the just-created lock behind. Make acquisition publish ownership in a signal-safe cleanup path, or let the release path remove an incomplete lock known to be created by this process.

🔧 Fix: Captain, harden AFK lock signal cleanup
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- <code>Baseline already provided as passing: `command -v tmux &gt;/dev/null || { echo &#34;tmux is required for e2e tests&#34; &gt;&amp;2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo &#34;== $t ==&#34;; bash &#34;$t&#34; || rc=1; done; exit &#34;$rc&#34;`</code>
- `bash tests/fm-afk-launch.test.sh | tee /tmp/no-mistakes-evidence/01KXD28SMG8QQMACD1NKHAA3N9/fm-afk-launch-test.log`
- <code>Manual evidence check invoking `fm_afk_launch_main start` with injected `TERM` and `INT` during `mkdir &#34;$FM_AFK_LAUNCH_LOCK&#34;`, recorded in `/tmp/no-mistakes-evidence/01KXD28SMG8QQMACD1NKHAA3N9/afk-launch-signal-window-transcript.log`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
