### PR TITLE
fix: prevent no-mistakes gate agents from driving the fleet

### DIFF
--- a/.no-mistakes.yaml
+++ b/.no-mistakes.yaml
@@ -1,5 +1,14 @@
 # Per-repo no-mistakes overrides.
 
+# firstmate is an agent-orchestration repo: its AGENTS.md installs a fleet-captain
+# identity. Disable project-level agent settings/instructions for gate agents so a
+# no-mistakes review/fix/document/test/lint/pr/rebase/ci agent never adopts that
+# identity or drives the fleet. Trusted-only: a pushed branch cannot turn this off,
+# so it is honored only from the default-branch copy of this file. Layered above
+# the NO_MISTAKES_GATE lifecycle refusal (bin/fm-gate-refuse-lib.sh) and the
+# HEAD-continuity guard; see data/nm-gate-ambient-authority-containment-c3/.
+disable_project_settings: true
+
 # Pin lint and test to the SAME deterministic commands CI runs, instead of
 # leaving them to no-mistakes' default handling. Without a configured
 # commands.lint, the gate's lint step never ran the deterministic

--- a/.no-mistakes.yaml
+++ b/.no-mistakes.yaml
@@ -6,7 +6,7 @@
 # identity or drives the fleet. Trusted-only: a pushed branch cannot turn this off,
 # so it is honored only from the default-branch copy of this file. Layered above
 # the NO_MISTAKES_GATE lifecycle refusal (bin/fm-gate-refuse-lib.sh) and the
-# HEAD-continuity guard; see data/nm-gate-ambient-authority-containment-c3/.
+# HEAD-continuity guard; see docs/architecture.md "No-mistakes gate authority boundary."
 disable_project_settings: true
 
 # Pin lint and test to the SAME deterministic commands CI runs, instead of

--- a/bin/fm-gate-refuse-lib.sh
+++ b/bin/fm-gate-refuse-lib.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# fm-gate-refuse-lib.sh - fail-closed refusal that keeps a no-mistakes GATE agent
+# out of firstmate's fleet lifecycle.
+#
+# The hazard (data/nm-gate-ambient-authority-containment-c3/report.md): a
+# no-mistakes gate agent runs inside a firstmate checkout with a free shell, so
+# it auto-loads firstmate's AGENTS.md, adopts the captain identity, and - seeing
+# crew "in flight" - reaches for fm-spawn.sh/fm-send.sh/fm-teardown.sh to
+# "delegate" and "reconcile" the shared worktree. It has real capability because
+# those entrypoints self-locate their home and never knew a gate context existed.
+#
+# no-mistakes owns the authority-removal half (it neutralizes the project
+# instructions and stamps NO_MISTAKES_GATE into the gate agent's environment).
+# THIS is the firstmate capability-removal half: an enforceable script refusal,
+# not a prose rule the neutralized agent would never read. It is sourced at the
+# top of the three fleet-lifecycle entrypoints and called before any fleet
+# mutation, so a gate agent that still reaches for the fleet is stopped cold.
+#
+# Two independent signals, either of which refuses (fail closed):
+#
+#   1. NO_MISTAKES_GATE set - the durable env marker no-mistakes stamps into every
+#      gate agent. This is the primary signal and covers a relocated NM_HOME.
+#   2. The current worktree's git-common-dir resolves under a no-mistakes gate
+#      repo (.../.no-mistakes/repos/*.git) - the UNSPOOFABLE backstop. It derives
+#      from the checkout's real filesystem location, which the agent cannot
+#      relocate without breaking the gate's own git operations, so it still
+#      refuses even if the agent tampered NO_MISTAKES_GATE away. Its limit: the
+#      literal-path match only fires for the default NM_HOME (~/.no-mistakes); a
+#      relocated NM_HOME is covered by signal 1.
+#
+# A NORMAL firstmate session - a real primary checkout, a real treehouse/Orca
+# crew worktree - has NEITHER signal and is COMPLETELY unaffected: the function
+# returns 0 and the lifecycle proceeds exactly as before.
+#
+# This mirrors the unspoofable-marker precedent in bin/fm-marker-lib.sh: a signal
+# the agent cannot forge, keyed on at a chokepoint, keeping the pattern familiar
+# to firstmate maintainers. It layers ABOVE no-mistakes' separately-shipping
+# HEAD-continuity guard, which remains the adversarial/residual backstop.
+#
+# TEST-HARNESS ESCAPE HATCH (FM_GATE_REFUSE_BYPASS=1): firstmate's own test suite
+# must exercise the REAL fm-spawn/fm-send/fm-teardown, but the no-mistakes gate
+# runs that suite FROM a gate worktree (cwd git-common-dir under
+# .no-mistakes/repos/*.git, and possibly NO_MISTAKES_GATE set) - the exact
+# environment this guard refuses. So both signals would fire during firstmate's
+# own validation and break unrelated tests. FM_GATE_REFUSE_BYPASS=1 makes the
+# guard a no-op; firstmate's shared test helpers (tests/lib.sh and the backend
+# safety helpers) export it, so every test that drives these scripts against its
+# temp-sandbox fleet is exempt. This does NOT weaken the boundary against the
+# real hazard: the threat is a CONFUSED-not-adversarial gate agent that runs
+# bin/fm-spawn.sh directly after adopting firstmate's identity - it never sources
+# firstmate's test helpers, so it never carries the bypass; and the adversarial
+# case (an agent that would deliberately set it) is covered by no-mistakes'
+# neutral-execution-context and the HEAD-continuity guard. The dedicated
+# tests/fm-gate-refuse.test.sh strips the bypass so it still verifies real refusal.
+#
+# Sourced by bin/fm-spawn.sh, bin/fm-send.sh, bin/fm-teardown.sh, and the tests.
+# No side effects on source. set -u / set -e safe. The refusal is a hard exit,
+# not a return, because there is no safe way to continue a fleet mutation from a
+# gate context.
+
+# The exit code every refusal uses, distinct enough to recognize in a caller or
+# test as "the gate refusal fired" rather than an ordinary usage error.
+FM_GATE_REFUSE_EXIT=3
+
+# fm_refuse_if_gate_agent: exit FM_GATE_REFUSE_EXIT with a clear stderr message if
+# this process looks like a no-mistakes gate agent. Call before any fleet
+# mutation. No-ops (returns 0) for a normal firstmate session, or when firstmate's
+# own test harness sets FM_GATE_REFUSE_BYPASS=1 (see the header).
+fm_refuse_if_gate_agent() {
+  if [ "${FM_GATE_REFUSE_BYPASS:-}" = 1 ]; then
+    return 0
+  fi
+  if [ -n "${NO_MISTAKES_GATE:-}" ]; then
+    echo "error: no-mistakes gate agent must not drive the fleet (NO_MISTAKES_GATE set)" >&2
+    exit "$FM_GATE_REFUSE_EXIT"
+  fi
+  local common
+  common=$(cd "$(git rev-parse --git-common-dir 2>/dev/null || echo /nonexistent)" 2>/dev/null && pwd -P || true)
+  case "$common" in
+    */.no-mistakes/repos/*.git)
+      echo "error: refusing fleet lifecycle from inside a no-mistakes gate worktree ($common)" >&2
+      exit "$FM_GATE_REFUSE_EXIT" ;;
+  esac
+}

--- a/bin/fm-gate-refuse-lib.sh
+++ b/bin/fm-gate-refuse-lib.sh
@@ -70,7 +70,7 @@ fm_refuse_if_gate_agent() {
   if [ "${FM_GATE_REFUSE_BYPASS:-}" = 1 ]; then
     return 0
   fi
-  if [ -n "${NO_MISTAKES_GATE:-}" ]; then
+  if [ "${NO_MISTAKES_GATE+x}" = x ]; then
     echo "error: no-mistakes gate agent must not drive the fleet (NO_MISTAKES_GATE set)" >&2
     exit "$FM_GATE_REFUSE_EXIT"
   fi

--- a/bin/fm-send.sh
+++ b/bin/fm-send.sh
@@ -38,6 +38,12 @@ set -eu
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 
+# shellcheck source=bin/fm-gate-refuse-lib.sh
+. "$SCRIPT_DIR/fm-gate-refuse-lib.sh"
+# Fail closed before any fleet mutation: a no-mistakes gate agent must never steer
+# a crewmate (see bin/fm-gate-refuse-lib.sh).
+fm_refuse_if_gate_agent
+
 if [ -z "${FM_HOME+x}" ] || [ -z "${FM_HOME:-}" ]; then
   echo "error: FM_HOME is not set; fm-send refuses to resolve targets without an explicit firstmate home" >&2
   exit 1

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -104,6 +104,11 @@ SUB_HOME_MARKER=".fm-secondmate-home"
 . "$SCRIPT_DIR/fm-config-inherit-lib.sh"
 # shellcheck source=bin/fm-backend.sh
 . "$SCRIPT_DIR/fm-backend.sh"
+# shellcheck source=bin/fm-gate-refuse-lib.sh
+. "$SCRIPT_DIR/fm-gate-refuse-lib.sh"
+# Fail closed before any fleet mutation: a no-mistakes gate agent must never spawn
+# a direct report (see bin/fm-gate-refuse-lib.sh).
+fm_refuse_if_gate_agent
 # Skip the watcher guard when re-exec'd for one pair of a batch (FM_SPAWN_NO_GUARD is
 # set by the batch loop below), so the guard runs once for the batch, not once per pair.
 [ -n "${FM_SPAWN_NO_GUARD:-}" ] || "$FM_ROOT/bin/fm-guard.sh" || true

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -88,6 +88,11 @@ SUB_HOME_MARKER=".fm-secondmate-home"
 . "$SCRIPT_DIR/fm-backend.sh"
 # shellcheck source=bin/fm-lock-lib.sh
 . "$SCRIPT_DIR/fm-lock-lib.sh"
+# shellcheck source=bin/fm-gate-refuse-lib.sh
+. "$SCRIPT_DIR/fm-gate-refuse-lib.sh"
+# Fail closed before any fleet mutation: a no-mistakes gate agent must never tear
+# down a worktree (see bin/fm-gate-refuse-lib.sh).
+fm_refuse_if_gate_agent
 FM_LOCK_LOG_PREFIX=teardown
 "$FM_ROOT/bin/fm-guard.sh" || true
 ID=$1

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -94,6 +94,14 @@ Only a named non-default branch checked out in `FM_ROOT` is a worktree tangle.
 If another live session holds the fleet lock, both surfaces keep the alarm but switch to read-only wording with no repair command.
 Ship briefs also tell the crewmate to verify `pwd -P` and `git rev-parse --show-toplevel` before creating `fm/<id>`, then stop with a blocked status if it landed in the primary checkout.
 
+## No-mistakes gate authority boundary
+
+Firstmate's own no-mistakes gate runs agents inside a checkout that also contains the fleet-captain identity in `AGENTS.md`, so gate execution needs an authority boundary separate from ordinary crewmate worktree isolation.
+The tracked `.no-mistakes.yaml` sets `disable_project_settings: true`; no-mistakes honors that setting only from the trusted default-branch copy, so a pushed branch cannot enable its own project instructions during validation.
+Independently, `fm-spawn.sh`, `fm-send.sh`, and `fm-teardown.sh` source `bin/fm-gate-refuse-lib.sh` and exit with status 3 before fleet mutation when the gate environment marker is present or the current checkout matches the default no-mistakes gate-repository topology.
+A normal primary checkout or crewmate worktree has neither signal and remains unaffected.
+The helper's header owns the exact signal detection, relocated-home limitation, test-harness bypass, and relationship to no-mistakes' HEAD-continuity guard.
+
 ## Two task shapes
 
 Ship tasks change projects and ship by project mode (`no-mistakes`, `direct-PR`, or `local-only`); scout tasks investigate, plan, reproduce bugs, or audit, then leave a report at `data/<id>/report.md` and never push.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -3,6 +3,7 @@
 The first mate drives these; interactive entrypoints work by hand too, while `*-lib.sh` files are sourced helpers.
 Each row is one purpose clause only: the script's own header comment is the authoritative description of its behavior, flags, and contracts, so read the header before first use.
 If you have changed away from the firstmate home in an interactive shell, invoke these scripts by absolute path through the repo's `bin/` directory; the scripts self-locate internally after they start.
+The shared no-mistakes gate refusal used by `fm-spawn.sh`, `fm-send.sh`, and `fm-teardown.sh` is summarized in [architecture.md](architecture.md#no-mistakes-gate-authority-boundary); `fm-gate-refuse-lib.sh`'s header owns its exact contract.
 
 | Script                   | Purpose                                                                              |
 | ------------------------ | ------------------------------------------------------------------------------------ |
@@ -39,6 +40,7 @@ If you have changed away from the firstmate home in an interactive shell, invoke
 | `fm-merge-local.sh`      | Fast-forward a `local-only` project's local default branch after approval            |
 | `fm-review-diff.sh`      | Review a crewmate branch or recorded PR head against the authoritative base          |
 | `fm-marker-lib.sh`       | Shared from-firstmate request marker and detector                                    |
+| `fm-gate-refuse-lib.sh`  | Shared no-mistakes gate-context refusal for fleet lifecycle entrypoints               |
 | `fm-watch-arm.sh`        | Verified home-scoped watcher arm wrapper with honest status reporting                |
 | `fm-watch-checkpoint.sh` | Run one bounded foreground watcher checkpoint for Codex-style supervision            |
 | `fm-watch.sh`            | Singleton-safe always-on watcher: absorb benign wakes, queue and exit on actionable ones |

--- a/tests/fm-gate-refuse.test.sh
+++ b/tests/fm-gate-refuse.test.sh
@@ -14,7 +14,7 @@
 # signal and is completely unaffected.
 #
 # Each entrypoint is exercised in three scenarios, isolating exactly ONE signal:
-#   - env-marker refuse : neutral cwd + NO_MISTAKES_GATE=1        -> exit 3, no mutation
+#   - env-marker refuse : neutral cwd + NO_MISTAKES_GATE set      -> exit 3, no mutation
 #   - path-backstop refuse: gate-worktree cwd + marker UNSET      -> exit 3, no mutation
 #   - no-regression      : neutral cwd + marker UNSET             -> succeeds, no gate error
 # The marker is UNSET explicitly in the no-regression/backstop runs (env -u) and
@@ -77,7 +77,7 @@ NORMAL_CWD=$(make_normal_repo "$TMP/normal-cwd")
 
 # --- the shared helper, tested directly -------------------------------------
 
-# run_guard_lib <cwd> [set] : from <cwd>, source the lib and call the guard under
+# run_guard_lib <cwd> [set|empty] : from <cwd>, source the lib and call the guard under
 # set -eu in a subshell (proving set -eu safety). NO_MISTAKES_GATE is unset first;
 # a literal "set" second argument re-exports it, so callers pick the signal under
 # test. Echoes combined output; the guard's exit is the caller's $?.
@@ -86,7 +86,10 @@ run_guard_lib() {
   (
     cd "$cwd" || exit 111
     unset NO_MISTAKES_GATE FM_GATE_REFUSE_BYPASS
-    [ "$marker" = set ] && export NO_MISTAKES_GATE=1
+    case "$marker" in
+      set) export NO_MISTAKES_GATE=1 ;;
+      empty) export NO_MISTAKES_GATE= ;;
+    esac
     set -eu
     # shellcheck source=bin/fm-gate-refuse-lib.sh
     . "$GATE_LIB"
@@ -100,6 +103,14 @@ test_helper_env_marker_refuses() {
   expect_code 3 "$rc" "helper: env marker must exit 3"
   assert_contains "$out" "$ENV_MSG" "helper: env-marker refusal message"
   pass "fm-gate-refuse-lib: refuses when NO_MISTAKES_GATE is set"
+}
+
+test_helper_empty_env_marker_refuses() {
+  local out rc
+  out=$(run_guard_lib "$NORMAL_CWD" empty); rc=$?
+  expect_code 3 "$rc" "helper: empty env marker must exit 3"
+  assert_contains "$out" "$ENV_MSG" "helper: empty env-marker refusal message"
+  pass "fm-gate-refuse-lib: refuses when NO_MISTAKES_GATE is set empty"
 }
 
 test_helper_path_backstop_refuses() {
@@ -378,6 +389,7 @@ test_no_mistakes_yaml_disables_project_settings() {
 }
 
 test_helper_env_marker_refuses
+test_helper_empty_env_marker_refuses
 test_helper_path_backstop_refuses
 test_helper_normal_is_noop
 test_spawn_refuses_and_admits

--- a/tests/fm-gate-refuse.test.sh
+++ b/tests/fm-gate-refuse.test.sh
@@ -1,0 +1,386 @@
+#!/usr/bin/env bash
+# Behavior tests for the no-mistakes GATE-agent fleet-lifecycle refusal.
+#
+# A confused no-mistakes gate agent runs inside a firstmate checkout, adopts the
+# captain identity from AGENTS.md, and reaches for fm-spawn/fm-send/fm-teardown.
+# bin/fm-gate-refuse-lib.sh is the firstmate capability-removal half: sourced at
+# the top of those three entrypoints and called before any fleet mutation, it
+# fails closed on either of two independent signals:
+#   1. NO_MISTAKES_GATE set in the environment (the marker no-mistakes stamps);
+#   2. the current worktree's git-common-dir resolves under a no-mistakes gate
+#      repo (.../.no-mistakes/repos/*.git) - the unspoofable backstop, which
+#      still refuses even if the marker was tampered/unset.
+# A normal firstmate session (real primary, real crew worktree) has NEITHER
+# signal and is completely unaffected.
+#
+# Each entrypoint is exercised in three scenarios, isolating exactly ONE signal:
+#   - env-marker refuse : neutral cwd + NO_MISTAKES_GATE=1        -> exit 3, no mutation
+#   - path-backstop refuse: gate-worktree cwd + marker UNSET      -> exit 3, no mutation
+#   - no-regression      : neutral cwd + marker UNSET             -> succeeds, no gate error
+# The marker is UNSET explicitly in the no-regression/backstop runs (env -u) and
+# those runs stand in a controlled NON-gate repo, so the suite is hermetic even
+# when it is itself executed inside the real no-mistakes gate (whose process has
+# NO_MISTAKES_GATE=1 and a gate-worktree cwd).
+#
+# Finally, assert firstmate's TRACKED .no-mistakes.yaml parses and sets
+# disable_project_settings: true (the trusted-only opt-out that neutralizes gate
+# agents' project instructions on the no-mistakes side).
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+GATE_LIB="$ROOT/bin/fm-gate-refuse-lib.sh"
+SPAWN="$ROOT/bin/fm-spawn.sh"
+SEND="$ROOT/bin/fm-send.sh"
+TEARDOWN="$ROOT/bin/fm-teardown.sh"
+
+TMP=$(fm_test_tmproot fm-gate-refuse)
+fm_git_identity fmtest fmtest@example.invalid
+
+# The env marker's exact stderr fragment (the primary signal).
+ENV_MSG='NO_MISTAKES_GATE set'
+# The git-common-dir backstop's exact stderr fragment (the unspoofable signal).
+PATH_MSG='no-mistakes gate worktree'
+
+# --- shared fixtures --------------------------------------------------------
+
+# make_gate_worktree <root> -> echoes a worktree whose git-common-dir is
+# <root>/.no-mistakes/repos/<id>.git, reproducing no-mistakes' gate topology
+# (<NM_HOME>/repos/<id>.git + <NM_HOME>/worktrees/<id>/<run>).
+make_gate_worktree() {
+  local root=$1 id=016d88035d58 run=01KXC3SD5NZYMERGDS68Z1C8ER seed
+  mkdir -p "$root/.no-mistakes/repos"
+  git init -q --bare "$root/origin.git"
+  seed=$(mktemp -d "$TMP/gate-seed.XXXXXX")
+  git init -q -b main "$seed"
+  git -C "$seed" commit -q --allow-empty -m init
+  git -C "$seed" push -q "$root/origin.git" HEAD:refs/heads/main
+  rm -rf "$seed"
+  git clone -q --bare "$root/origin.git" "$root/.no-mistakes/repos/$id.git"
+  git -C "$root/.no-mistakes/repos/$id.git" worktree add --detach \
+    "$root/.no-mistakes/worktrees/$id/$run" main >/dev/null 2>&1
+  printf '%s\n' "$root/.no-mistakes/worktrees/$id/$run"
+}
+
+# make_normal_repo <dir> -> echoes a plain (non-gate) git repo to stand in for a
+# normal primary/crew checkout: its git-common-dir is <dir>/.git, never a gate.
+make_normal_repo() {
+  local dir=$1
+  git init -q -b main "$dir"
+  git -C "$dir" commit -q --allow-empty -m init
+  printf '%s\n' "$dir"
+}
+
+GATE_WT=$(make_gate_worktree "$TMP/gate")
+NORMAL_CWD=$(make_normal_repo "$TMP/normal-cwd")
+
+# --- the shared helper, tested directly -------------------------------------
+
+# run_guard_lib <cwd> [set] : from <cwd>, source the lib and call the guard under
+# set -eu in a subshell (proving set -eu safety). NO_MISTAKES_GATE is unset first;
+# a literal "set" second argument re-exports it, so callers pick the signal under
+# test. Echoes combined output; the guard's exit is the caller's $?.
+run_guard_lib() {
+  local cwd=$1 marker=${2:-unset}
+  (
+    cd "$cwd" || exit 111
+    unset NO_MISTAKES_GATE FM_GATE_REFUSE_BYPASS
+    [ "$marker" = set ] && export NO_MISTAKES_GATE=1
+    set -eu
+    # shellcheck source=bin/fm-gate-refuse-lib.sh
+    . "$GATE_LIB"
+    fm_refuse_if_gate_agent
+  ) 2>&1
+}
+
+test_helper_env_marker_refuses() {
+  local out rc
+  out=$(run_guard_lib "$NORMAL_CWD" set); rc=$?
+  expect_code 3 "$rc" "helper: env marker must exit 3"
+  assert_contains "$out" "$ENV_MSG" "helper: env-marker refusal message"
+  pass "fm-gate-refuse-lib: refuses when NO_MISTAKES_GATE is set"
+}
+
+test_helper_path_backstop_refuses() {
+  local out rc
+  # Marker UNSET: only the git-common-dir backstop can fire here.
+  out=$(run_guard_lib "$GATE_WT"); rc=$?
+  expect_code 3 "$rc" "helper: gate worktree must exit 3 even with the marker unset"
+  assert_contains "$out" "$PATH_MSG" "helper: path-backstop refusal message"
+  assert_not_contains "$out" "$ENV_MSG" "helper: backstop must not be attributed to the env marker"
+  pass "fm-gate-refuse-lib: refuses from a gate worktree via git-common-dir (marker unset)"
+}
+
+test_helper_normal_is_noop() {
+  local out rc
+  out=$(run_guard_lib "$NORMAL_CWD"); rc=$?
+  expect_code 0 "$rc" "helper: a normal session (neither signal) must not refuse"
+  [ -z "$out" ] || fail "helper: normal session printed output: $out"
+  pass "fm-gate-refuse-lib: no-op for a normal session (neither signal, set -eu clean)"
+}
+
+# --- fm-spawn ---------------------------------------------------------------
+
+# A fake tmux/treehouse so fm-spawn resolves the crew worktree from a controlled
+# pane path and completes without a live terminal (mirrors tests/fm-tangle-guard).
+make_spawn_fakebin() {
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+esac
+case "${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+  list-windows) exit 0 ;;
+  has-session|new-session|new-window|send-keys|set-window-option) exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" treehouse
+  printf '%s\n' "$fakebin"
+}
+
+# run_spawn <cwd> <home> <id> <proj> <pane> <fakebin> [ASSIGN...] -> combined output
+run_spawn() {
+  local cwd=$1 home=$2 id=$3 proj=$4 pane=$5 fakebin=$6; shift 6
+  mkdir -p "$home/data/$id"
+  printf 'brief\n' > "$home/data/$id/brief.md"
+  ( cd "$cwd" && env -u NO_MISTAKES_GATE -u FM_GATE_REFUSE_BYPASS \
+      "FM_ROOT_OVERRIDE=" "FM_HOME=$home" \
+      "FM_STATE_OVERRIDE=$home/state" "FM_DATA_OVERRIDE=$home/data" \
+      "FM_PROJECTS_OVERRIDE=$home/projects" "FM_CONFIG_OVERRIDE=$home/config" \
+      "FM_SPAWN_NO_GUARD=1" "FM_FAKE_PANE_PATH=$pane" "TMUX=fake,1,0" \
+      "PATH=$fakebin:$PATH" "$@" \
+      "$SPAWN" "$id" "$proj" codex ) 2>&1
+}
+
+test_spawn_refuses_and_admits() {
+  local home proj fakebin wt out rc
+  home="$TMP/spawn-home"; mkdir -p "$home/data"
+  proj=$(make_normal_repo "$TMP/spawn-proj")
+  fakebin=$(make_spawn_fakebin "$TMP/spawn-fake")
+  wt="$TMP/spawn-wt"
+  git -C "$proj" worktree add -q --detach "$wt" >/dev/null 2>&1
+
+  # env-marker refuse: neutral cwd, marker set.
+  out=$(run_spawn "$NORMAL_CWD" "$home" spawn-envmark "$proj" "$wt" "$fakebin" NO_MISTAKES_GATE=1); rc=$?
+  expect_code 3 "$rc" "spawn: NO_MISTAKES_GATE must refuse"
+  assert_contains "$out" "$ENV_MSG" "spawn: env-marker refusal message"
+  assert_absent "$home/state/spawn-envmark.meta" "spawn: refused env-marker launch must not record meta"
+
+  # path-backstop refuse: gate-worktree cwd, marker UNSET.
+  out=$(run_spawn "$GATE_WT" "$home" spawn-backstop "$proj" "$wt" "$fakebin"); rc=$?
+  expect_code 3 "$rc" "spawn: gate-worktree cwd must refuse with the marker unset"
+  assert_contains "$out" "$PATH_MSG" "spawn: path-backstop refusal message"
+  assert_absent "$home/state/spawn-backstop.meta" "spawn: refused backstop launch must not record meta"
+
+  # no-regression: neutral cwd, marker UNSET, genuine isolated worktree.
+  out=$(run_spawn "$NORMAL_CWD" "$home" spawn-ok "$proj" "$wt" "$fakebin"); rc=$?
+  expect_code 0 "$rc" "spawn: a normal session must still spawn"
+  assert_contains "$out" "spawned spawn-ok" "spawn: normal launch should report success"
+  assert_not_contains "$out" "$ENV_MSG" "spawn: normal launch must not print the gate refusal"
+  assert_not_contains "$out" "$PATH_MSG" "spawn: normal launch must not print the backstop refusal"
+  assert_present "$home/state/spawn-ok.meta" "spawn: normal launch should record meta"
+  pass "fm-spawn: refuses on marker and gate-worktree backstop; a normal crew spawn is unaffected"
+}
+
+# --- fm-send ----------------------------------------------------------------
+
+# A fake tmux that logs send-keys to FM_TMUX_LOG and reports live endpoints
+# (mirrors tests/fm-send-strict), so a successful send is observable and a
+# refused one leaves an empty log (proving no message was typed).
+make_send_fakebin() {
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "${1:-}" in
+  send-keys)
+    shift; literal=0; target=
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        -t) target=$2; shift 2 ;;
+        -l) literal=1; shift ;;
+        *) break ;;
+      esac
+    done
+    printf 'send-keys target=%s literal=%s arg=%s\n' "$target" "$literal" "${1:-}" >> "$FM_TMUX_LOG"
+    exit 0 ;;
+  display-message) printf '%%1\n'; exit 0 ;;
+  capture-pane) printf '\xe2\x94\x82 \xe2\x94\x82\n'; exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$fakebin/sleep"
+  chmod +x "$fakebin/sleep"
+  printf '%s\n' "$fakebin"
+}
+
+# run_send <cwd> <home> <fakebin> <log> <target> <text> [ASSIGN...] -> combined output
+run_send() {
+  local cwd=$1 home=$2 fakebin=$3 log=$4 target=$5 text=$6; shift 6
+  ( cd "$cwd" && env -u NO_MISTAKES_GATE -u FM_GATE_REFUSE_BYPASS \
+      "PATH=$fakebin:$PATH" "FM_HOME=$home" "FM_ROOT_OVERRIDE=$home" \
+      "FM_TMUX_LOG=$log" "FM_SEND_SETTLE=0" "$@" \
+      "$SEND" "$target" "$text" ) 2>&1
+}
+
+test_send_refuses_and_admits() {
+  local home fakebin log out rc
+  home="$TMP/send-home"; mkdir -p "$home/state"
+  fakebin=$(make_send_fakebin "$TMP/send-fake")
+  log="$TMP/send-tmux.log"
+  fm_write_meta "$home/state/lane-ok.meta" "window=sess:fm-lane-ok" "kind=ship" "harness=codex"
+
+  # env-marker refuse.
+  : > "$log"
+  out=$(run_send "$NORMAL_CWD" "$home" "$fakebin" "$log" fm-lane-ok "hello captain" NO_MISTAKES_GATE=1); rc=$?
+  expect_code 3 "$rc" "send: NO_MISTAKES_GATE must refuse"
+  assert_contains "$out" "$ENV_MSG" "send: env-marker refusal message"
+  [ ! -s "$log" ] || fail "send: refused env-marker send still typed to the endpoint"$'\n'"$(cat "$log")"
+
+  # path-backstop refuse (marker UNSET).
+  : > "$log"
+  out=$(run_send "$GATE_WT" "$home" "$fakebin" "$log" fm-lane-ok "hello captain"); rc=$?
+  expect_code 3 "$rc" "send: gate-worktree cwd must refuse with the marker unset"
+  assert_contains "$out" "$PATH_MSG" "send: path-backstop refusal message"
+  [ ! -s "$log" ] || fail "send: refused backstop send still typed to the endpoint"$'\n'"$(cat "$log")"
+
+  # no-regression.
+  : > "$log"
+  out=$(run_send "$NORMAL_CWD" "$home" "$fakebin" "$log" fm-lane-ok "hello captain"); rc=$?
+  expect_code 0 "$rc" "send: a normal session must still send"
+  assert_not_contains "$out" "$ENV_MSG" "send: normal send must not print the gate refusal"
+  assert_not_contains "$out" "$PATH_MSG" "send: normal send must not print the backstop refusal"
+  assert_contains "$(cat "$log")" "target=sess:fm-lane-ok literal=1 arg=hello captain" "send: normal send should type the text"
+  pass "fm-send: refuses on marker and gate-worktree backstop; a normal steer is unaffected"
+}
+
+# --- fm-teardown ------------------------------------------------------------
+
+# make_teardown_case <name> -> echoes a case dir holding a LANDED no-mistakes ship
+# task (HEAD reachable from origin), so a normal teardown genuinely succeeds and a
+# refused one leaves the task untouched (mirrors tests/fm-teardown make_case).
+make_teardown_case() {
+  local name=$1 case_dir fakebin t
+  case_dir="$TMP/$name"; fakebin="$case_dir/fakebin"
+  mkdir -p "$case_dir/state" "$case_dir/config" "$fakebin"
+  for t in treehouse tmux; do
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$fakebin/$t"
+    chmod +x "$fakebin/$t"
+  done
+  cat > "$fakebin/gh-axi" <<'SH'
+#!/usr/bin/env bash
+case "${1:-} ${2:-}" in
+  "pr list") printf '%s\n' "count: 0 (showing first 0)" "pull_requests[]: []"; exit 0 ;;
+  "pr view") echo "error: pull request not found" >&2; exit 1 ;;
+esac
+exit 0
+SH
+  cat > "$fakebin/gh" <<'SH'
+#!/usr/bin/env bash
+case "${1:-} ${2:-}" in
+  "pr view") echo "error: pull request not found" >&2; exit 1 ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/gh-axi" "$fakebin/gh"
+  git init -q --bare "$case_dir/origin.git"
+  git -C "$case_dir/origin.git" symbolic-ref HEAD refs/heads/main
+  git clone -q "$case_dir/origin.git" "$case_dir/_seed" 2>/dev/null
+  git -C "$case_dir/_seed" commit -q --allow-empty -m "origin baseline"
+  git -C "$case_dir/_seed" push -q origin main
+  rm -rf "$case_dir/_seed"
+  git clone -q "$case_dir/origin.git" "$case_dir/project"
+  git -C "$case_dir/project" remote set-head origin main 2>/dev/null || true
+  git -C "$case_dir/project" worktree add -q -b fm/task-x1 "$case_dir/wt" main
+  git -C "$case_dir/wt" commit -q --allow-empty -m "shippable work"
+  git -C "$case_dir/wt" push -q origin fm/task-x1
+  git -C "$case_dir/project" fetch -q origin
+  fm_write_meta "$case_dir/state/task-x1.meta" \
+    "window=fm-task-x1" "worktree=$case_dir/wt" "project=$case_dir/project" \
+    "kind=ship" "mode=no-mistakes"
+  touch "$case_dir/state/.last-watcher-beat"
+  printf '%s\n' "$case_dir"
+}
+
+# run_teardown <cwd> <case_dir> [ASSIGN...] -> combined output
+run_teardown() {
+  local cwd=$1 case_dir=$2; shift 2
+  ( cd "$cwd" && env -u NO_MISTAKES_GATE -u FM_GATE_REFUSE_BYPASS \
+      "FM_ROOT_OVERRIDE=$ROOT" "FM_STATE_OVERRIDE=$case_dir/state" \
+      "FM_CONFIG_OVERRIDE=$case_dir/config" "PATH=$case_dir/fakebin:$PATH" "$@" \
+      "$TEARDOWN" task-x1 ) 2>&1
+}
+
+test_teardown_refuses_and_admits() {
+  local case_dir out rc
+
+  # env-marker refuse: a genuinely-landed task is still refused; nothing is torn down.
+  case_dir=$(make_teardown_case teardown-envmark)
+  out=$(run_teardown "$NORMAL_CWD" "$case_dir" NO_MISTAKES_GATE=1); rc=$?
+  expect_code 3 "$rc" "teardown: NO_MISTAKES_GATE must refuse"
+  assert_contains "$out" "$ENV_MSG" "teardown: env-marker refusal message"
+  assert_present "$case_dir/state/task-x1.meta" "teardown: refused env-marker teardown must leave the task"
+
+  # path-backstop refuse (marker UNSET).
+  case_dir=$(make_teardown_case teardown-backstop)
+  out=$(run_teardown "$GATE_WT" "$case_dir"); rc=$?
+  expect_code 3 "$rc" "teardown: gate-worktree cwd must refuse with the marker unset"
+  assert_contains "$out" "$PATH_MSG" "teardown: path-backstop refusal message"
+  assert_present "$case_dir/state/task-x1.meta" "teardown: refused backstop teardown must leave the task"
+
+  # no-regression: a normal session tears down the landed task.
+  case_dir=$(make_teardown_case teardown-ok)
+  out=$(run_teardown "$NORMAL_CWD" "$case_dir"); rc=$?
+  expect_code 0 "$rc" "teardown: a normal session must still tear down landed work"
+  assert_not_contains "$out" "$ENV_MSG" "teardown: normal teardown must not print the gate refusal"
+  assert_not_contains "$out" "$PATH_MSG" "teardown: normal teardown must not print the backstop refusal"
+  assert_not_contains "$out" "REFUSED" "teardown: normal teardown of landed work must not refuse"
+  pass "fm-teardown: refuses on marker and gate-worktree backstop; a normal teardown is unaffected"
+}
+
+# --- tracked .no-mistakes.yaml ----------------------------------------------
+
+test_no_mistakes_yaml_disables_project_settings() {
+  local file="$ROOT/.no-mistakes.yaml" val tab
+  assert_present "$file" "tracked .no-mistakes.yaml is missing"
+  git -C "$ROOT" ls-files --error-unmatch .no-mistakes.yaml >/dev/null 2>&1 \
+    || fail ".no-mistakes.yaml is not tracked by git"
+
+  # Parse with a real YAML loader and assert the field is boolean true, so a
+  # malformed file or a stringy "true" fails where a naive grep would pass.
+  if command -v python3 >/dev/null 2>&1 && python3 -c 'import yaml' >/dev/null 2>&1; then
+    val=$(python3 -c 'import yaml,sys; print(yaml.safe_load(open(sys.argv[1])).get("disable_project_settings"))' "$file") \
+      || fail ".no-mistakes.yaml did not parse as YAML (python3)"
+    [ "$val" = "True" ] || fail "disable_project_settings is not boolean true (python3 read: $val)"
+  elif command -v ruby >/dev/null 2>&1; then
+    ruby -ryaml -e 'exit((YAML.safe_load(File.read(ARGV[0]))["disable_project_settings"] == true) ? 0 : 1)' "$file" \
+      || fail ".no-mistakes.yaml did not parse or disable_project_settings != true (ruby)"
+  else
+    # No YAML loader: fall back to a strict structural check - no tab indentation
+    # (YAML forbids it) and the top-level key mapped to the bare boolean true.
+    tab=$(printf '\t')
+    case "$(cat "$file")" in
+      *"$tab"*) fail ".no-mistakes.yaml uses a tab (invalid YAML indentation)" ;;
+    esac
+    grep -qxE 'disable_project_settings:[[:space:]]+true' "$file" \
+      || fail "top-level 'disable_project_settings: true' not found in .no-mistakes.yaml"
+  fi
+  pass ".no-mistakes.yaml parses and sets disable_project_settings: true (trusted-only gate opt-out)"
+}
+
+test_helper_env_marker_refuses
+test_helper_path_backstop_refuses
+test_helper_normal_is_noop
+test_spawn_refuses_and_admits
+test_send_refuses_and_admits
+test_teardown_refuses_and_admits
+test_no_mistakes_yaml_disables_project_settings

--- a/tests/fm-gotmp.test.sh
+++ b/tests/fm-gotmp.test.sh
@@ -11,6 +11,12 @@
 # the contract lines) and behaviorally (the mkdir + meta-write pattern it uses).
 set -u
 
+# This suite does not source tests/lib.sh, so exempt its teardown subprocess from
+# the gate-lifecycle refusal (bin/fm-gate-refuse-lib.sh) the way lib.sh does for
+# the rest of the suite: the no-mistakes gate runs this suite from a gate worktree,
+# which the guard would otherwise refuse.
+export FM_GATE_REFUSE_BYPASS=1
+
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SPAWN="$ROOT/bin/fm-spawn.sh"
 TEARDOWN="$ROOT/bin/fm-teardown.sh"
@@ -54,6 +60,8 @@ make_fake_root() {
   ln -s "$ROOT/bin/fm-tmux-lib.sh" "$fake/bin/fm-tmux-lib.sh"
   # fm-lock-lib.sh: teardown sources it for the shared lock-staleness proof.
   ln -s "$ROOT/bin/fm-lock-lib.sh" "$fake/bin/fm-lock-lib.sh"
+  # fm-gate-refuse-lib.sh: teardown sources it before any fleet mutation.
+  ln -s "$ROOT/bin/fm-gate-refuse-lib.sh" "$fake/bin/fm-gate-refuse-lib.sh"
   # fm-guard.sh: stub (teardown calls it with `|| true`).
   cat > "$fake/bin/fm-guard.sh" <<'SH'
 #!/usr/bin/env bash
@@ -149,6 +157,8 @@ test_teardown_skips_gracefully_without_tasktmp() {
   ln -s "$ROOT/bin/backends/tmux.sh" "$fake/bin/backends/tmux.sh"
   ln -s "$ROOT/bin/fm-tmux-lib.sh" "$fake/bin/fm-tmux-lib.sh"
   ln -s "$ROOT/bin/fm-lock-lib.sh" "$fake/bin/fm-lock-lib.sh"
+  # fm-gate-refuse-lib.sh: teardown sources it before any fleet mutation.
+  ln -s "$ROOT/bin/fm-gate-refuse-lib.sh" "$fake/bin/fm-gate-refuse-lib.sh"
   cat > "$fake/bin/fm-guard.sh" <<'SH'
 #!/usr/bin/env bash
 exit 0

--- a/tests/herdr-test-safety.sh
+++ b/tests/herdr-test-safety.sh
@@ -4,6 +4,12 @@
 # fleet-state tripwire contract is bin/fm-herdr-lab.sh.
 set -u
 
+# Herdr backend tests drive the real fm-spawn/fm-teardown but do not source
+# tests/lib.sh, so exempt them from the gate-lifecycle refusal here too (see
+# tests/lib.sh and bin/fm-gate-refuse-lib.sh for why firstmate's own suite,
+# which the no-mistakes gate runs from a gate worktree, must be exempt).
+export FM_GATE_REFUSE_BYPASS=1
+
 HERDR_TEST_SAFETY_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # shellcheck source=bin/fm-herdr-lab.sh
 . "$HERDR_TEST_SAFETY_DIR/bin/fm-herdr-lab.sh"

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -25,6 +25,15 @@ if [ -n "${FM_TEST_LIB_SOURCED:-}" ]; then
 fi
 FM_TEST_LIB_SOURCED=1
 
+# Exempt firstmate's own test suite from the gate-lifecycle refusal
+# (bin/fm-gate-refuse-lib.sh). The no-mistakes gate runs this suite FROM a gate
+# worktree - the exact environment that guard refuses - so without this every
+# test that drives the real fm-spawn/fm-send/fm-teardown would be refused during
+# firstmate's own validation. A confused gate agent never sources this helper, so
+# the boundary against the real hazard is unaffected. tests/fm-gate-refuse.test.sh
+# strips this to verify real refusal.
+export FM_GATE_REFUSE_BYPASS=1
+
 # Resolve the repo root from this library's own location. Consumed by sourcing
 # test files, not by this library, so it reads as "unused" here.
 # shellcheck disable=SC2034


### PR DESCRIPTION
## Intent

Ship the firstmate side (capability-removal half) of the no-mistakes gate ambient-authority containment (c3 design): make a confused no-mistakes gate agent unable to drive the firstmate fleet after it adopts firstmate's captain identity from AGENTS.md. Two deliverables in one change.

(1) New shared helper bin/fm-gate-refuse-lib.sh, sourced at the TOP of bin/fm-spawn.sh, bin/fm-send.sh, and bin/fm-teardown.sh before any fleet mutation, each with a one-line source + fm_refuse_if_gate_agent call (one owner: the guard logic lives once in the lib). It FAILS CLOSED (exit 3) when NO_MISTAKES_GATE is set, and via an UNSPOOFABLE backstop when the current worktree's git rev-parse --git-common-dir resolves under a no-mistakes gate repo (.../.no-mistakes/repos/*.git) even if the marker was tampered/unset. A normal firstmate session (real primary checkout, real treehouse/Orca crew worktree) has NEITHER signal and is completely unaffected. It intentionally mirrors the existing unspoofable-marker precedent in bin/fm-marker-lib.sh.

(2) Set disable_project_settings: true in firstmate's TRACKED .no-mistakes.yaml so the installed v1.37.0 pipeline neutralizes gate agents' project instructions for this repo. It is honored trusted-only from the default branch, so it does not take effect for this very PR (not yet on the default branch) - this PR is instead validated under the stamped NO_MISTAKES_GATE marker + the HEAD-continuity guard.

Key decision a reviewer cannot see from the diff: firstmate's OWN test suite runs from INSIDE a no-mistakes gate worktree during validation (cwd git-common-dir under .no-mistakes/repos/*.git, and possibly NO_MISTAKES_GATE set) - the exact environment this guard refuses. A naive guard would therefore refuse ~30 existing tests (fm-tangle-guard, fm-send-strict, fm-teardown, fm-spawn-*, etc.) during this PR's own validation; I reproduced that breakage empirically. To resolve it WITHOUT weakening the boundary, the guard honors a documented test-harness escape hatch FM_GATE_REFUSE_BYPASS=1, exported ONLY by firstmate's shared test helpers (tests/lib.sh and tests/herdr-test-safety.sh) and by tests/fm-gotmp.test.sh (which does not source lib.sh and, being a fake-bin fixture, also newly symlinks the lib teardown now sources). The actual threat is a CONFUSED-not-adversarial gate agent that runs bin/fm-spawn.sh directly; it never sources firstmate's test helpers, so it never carries the bypass. The adversarial case is covered by no-mistakes' neutral-execution-context and the HEAD-continuity guard. The dedicated tests/fm-gate-refuse.test.sh strips the bypass so it still verifies REAL refusal: marker refuse, git-common-dir backstop refuse with the marker unset, and the no-regression success case, across fm-spawn/fm-send/fm-teardown plus a direct helper unit test, and it asserts the tracked .no-mistakes.yaml parses and sets disable_project_settings: true.

Constraints honored: firstmate never hand-edits project code (this is firstmate's own repo, shipped through its own gate); one-owner wiring; full bin/fm-lint.sh (pinned ShellCheck 0.11.0) is clean; colocated tests follow the existing tests/*.test.sh pattern; Markdown/scripts follow repo style.

Note for the reviewer: two suite tests (fm-pi-watch-extension, fm-turnend-guard) fail on the current default branch too - a Node MODULE_TYPELESS_PACKAGE_JSON warning on the committed .opencode/plugins/*.js files - and are unrelated to this change (confirmed identical with these edits reverted); they are not introduced here.

## What Changed

- Captain, add a shared fail-closed guard to spawn, send, and teardown commands that exits with status 3 when the gate marker is present, including empty values, or the checkout matches the no-mistakes gate repository topology.
- Disable project settings for trusted no-mistakes gate runs and document the resulting authority boundary.
- Add lifecycle coverage for marker and path-based refusals, unaffected normal sessions, tracked configuration, and the test-harness bypass.

## Risk Assessment

✅ Low: Captain, the change is narrowly scoped, fixes the prior empty-marker issue, enforces both required refusal signals before fleet mutation, and preserves normal lifecycle behavior.

## Testing

The supplied full-suite baseline passed, focused refusal and lifecycle regression tests passed, and the captured end-user CLI transcript demonstrates both refusal signals returning exit 3 before any fleet state was created.

<details>
<summary>Evidence: Gate refusal CLI transcript</summary>

```text
Gate-worktree product-level refusal transcript
cwd=/Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KXD6XS1KD7VEYG9SQ2NE6B6D
git-common-dir=/Users/kunchen/.no-mistakes/repos/016d88035d58.git

$ bin/fm-spawn.sh probe-task .  # NO_MISTAKES_GATE deliberately unset
error: refusing fleet lifecycle from inside a no-mistakes gate worktree (/Users/kunchen/.no-mistakes/repos/016d88035d58.git)
exit=3

$ bin/fm-send.sh probe-task must-not-send  # NO_MISTAKES_GATE deliberately unset
error: refusing fleet lifecycle from inside a no-mistakes gate worktree (/Users/kunchen/.no-mistakes/repos/016d88035d58.git)
exit=3

$ bin/fm-teardown.sh probe-task  # NO_MISTAKES_GATE deliberately unset
error: refusing fleet lifecycle from inside a no-mistakes gate worktree (/Users/kunchen/.no-mistakes/repos/016d88035d58.git)
exit=3

$ find fleet-home -mindepth 1 -print
(no output: no fleet files were created)

$ NO_MISTAKES_GATE=1 bin/fm-send.sh probe-task must-not-send  # marker path
error: no-mistakes gate agent must not drive the fleet (NO_MISTAKES_GATE set)
exit=3
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `bin/fm-gate-refuse-lib.sh:73` - Captain, the required behavior says the helper must &#34;FAILS CLOSED (exit 3) when NO_MISTAKES_GATE is set,&#34; but `if [ -n &#34;${NO_MISTAKES_GATE:-}&#34; ]` rejects only nonempty values. An explicitly set empty value can therefore bypass this signal, and a relocated gate repository may also evade the path backstop. Detect variable presence instead, such as with `${NO_MISTAKES_GATE+x}`, and cover the empty-value case.

🔧 Fix: Captain, refuse empty no-mistakes gate markers
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- <code>Pre-run baseline: `command -v tmux &gt;/dev/null || { echo &#34;tmux is required for e2e tests&#34; &gt;&amp;2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo &#34;== $t ==&#34;; bash &#34;$t&#34; || rc=1; done; exit &#34;$rc&#34;`</code>
- `bash tests/fm-gate-refuse.test.sh`
- `bash tests/fm-send-strict.test.sh`
- `bash tests/fm-spawn-batch.test.sh`
- `bash tests/fm-teardown.test.sh`
- `bash tests/fm-gotmp.test.sh`
- <code>Directly invoked `bin/fm-spawn.sh`, `bin/fm-send.sh`, and `bin/fm-teardown.sh` from the real gate worktree with `NO_MISTAKES_GATE` unset; each refused with exit 3</code>
- <code>Invoked `bin/fm-send.sh` with `NO_MISTAKES_GATE=1`; it independently refused with exit 3</code>
- `Verified the evidence sandbox remained empty after all refused lifecycle calls`
- <code>Verified `git status --short` was clean and HEAD matched the supplied target commit</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
