### PR TITLE
feat: add rovo (Atlassian Rovo Dev CLI) as a verified crewmate harness

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -264,3 +264,26 @@ The adapter therefore runs the shared predicate and, when it returns 2, forces o
 It does not pass `--permission-mode`, so the passive hook cannot escalate the primary session's tool permissions.
 Project-local Grok hooks require folder trust, verified with launch-time `--trust`; if the primary firstmate checkout is not trusted for Grok hooks, this primary guard fails open and `fm-guard.sh` remains the next-command alarm.
 Grok's primary watcher protocol is Claude-shaped background-notify around `bin/fm-watch-arm.sh`; the passive Stop hook is only a backstop for blind turn ends.
+
+## rovo (VERIFIED 2026-07-13, Rovo CLI 202607.8.1)
+
+Atlassian Rovo Dev CLI: the standalone `rovo` binary at `~/.local/bin/rovo`, distinct from `acli rovodev`.
+Verified as a CREWMATE/scout harness only.
+Secondmate use is UNVERIFIED: rovo's `#{pane_current_command}` was not confirmed, so `bin/backends/tmux.sh`'s agent-liveness match deliberately omits rovo and the session-start liveness sweep reads a rovo pane as `unknown`, never a confident `dead`, so do not rely on secondmate respawn for rovo until that is verified.
+
+| Fact | Value |
+|---|---|
+| Launch | `rovo run --yolo -i "$(cat <brief>)"` (positional message = initial instruction; `-i` forces the interactive TUI to stay live even when a message is passed) |
+| Autonomy | `--yolo` (alias `--disable-permission-checks`): auto-approves file CRUD and bash. Atlassian-data and user-MCP tools STILL prompt, so a task depending on those can stall - keep rovo crews on file/bash work or expect a gate |
+| Busy-pane signature | `Rovo is thinking` (also `Starting Rovo` at startup), preceded by a ⬡ glyph. Idle shows a Tip line plus `? for shortcuts` and no "thinking" |
+| Interrupt | single Escape (pane shows `Agent cancelled`) |
+| Exit command | `/exit` (opens a slash-autocomplete popup, the same submit hazard as claude/codex/grok - give the popup a settle before Enter) |
+| Resume | `rovo run --resume [<session-id>]` (no id restores the most recent session) |
+| Env marker | `ROVODEV_CLI=1` (also `AGENT=rovodev_cli`, `ATLASSIAN_AGENT_TYPE=rovo`); `bin/fm-harness.sh` keys on `ROVODEV_CLI` |
+| Model/effort | `rovo run` exposes no `--model` or effort flag; the model is env/config-driven (`ROVODEV_MODEL_ID`, `anthropic:claude-opus-4-8` in this build). `fm-spawn` passes no model/effort flag for rovo, and dispatch validation treats any effort for rovo as unsupported |
+| Turn-end | no verified firstmate turn-end hook. Supervision relies on the crewmate status-file protocol (signal wakes) plus the busy-signature/stale detection above. rovo exposes a `/hooks` capability, but a firstmate-compatible turn-end hook is unverified/future work |
+
+Trust dialog: none observed - a fresh `rovo run` inside a git repo launches straight into work (verified in a scratch repo; the project-picker gate seen with `acli rovodev` did not appear for the standalone `rovo` launched inside a repo).
+Steering while busy: the composer footer reads `Enter to queue, Ctrl+Enter to steer` - a plain Enter QUEUES the message for after the current turn, Ctrl+Enter steers mid-turn.
+`fm-send` on tmux sends plain Enter, so a steer to a busy rovo crew lands as a queued follow-up (fine for most steers); type into the pane directly if an immediate mid-turn steer is required.
+rovo is NOT a verified PRIMARY firstmate harness: it has no supervision-protocol or primary turn-end-guard adapter, so firstmate itself keeps running on claude/codex/opencode/pi/grok.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,7 +171,7 @@ If the captain expresses a standing dispatch preference such as "use grok for ne
 Crewmates default to the same harness you are running on.
 The captain may override the static default at any time, typically at bootstrap: record the choice in `config/crew-harness` (a single adapter name; absent or `default` means mirror your own harness).
 Resolve `default` with `bin/fm-harness.sh`; resolve the active static crewmate harness with `bin/fm-harness.sh crew`.
-Verified adapter names are `claude`, `codex`, `opencode`, `pi`, and `grok`.
+Verified adapter names are `claude`, `codex`, `opencode`, `pi`, `grok`, and `rovo` (`rovo` is verified for crewmate/scout work only; secondmate use is unverified).
 
 ### Crew dispatch profiles
 

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -473,13 +473,13 @@ crew_dispatch_validate() {
     return 0
   fi
   err=$(jq -r '
-    def verified($h): ["claude","codex","opencode","pi","grok"] | index($h);
+    def verified($h): ["claude","codex","opencode","pi","grok","rovo"] | index($h);
     def effort_ok($h; $e):
       if $e == null then true
       elif ($e | type) != "string" then false
       elif $h == "claude" then (["low","medium","high","xhigh","max"] | index($e))
       elif ($h == "codex" or $h == "grok" or $h == "pi") then (["low","medium","high","xhigh"] | index($e))
-      elif $h == "opencode" then false
+      elif ($h == "opencode" or $h == "rovo") then false
       else true
       end;
     def use_profiles($u):

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Detect the agent harness this process tree runs on.
-# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|grok|unknown
+# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|grok|rovo|unknown
 #        fm-harness.sh crew             print the effective CREWMATE harness
 #                                        (config/crew-harness; "default" resolves to own)
 #        fm-harness.sh secondmate       print the harness the PRIMARY uses to launch
@@ -35,6 +35,10 @@ detect_own() {
   # It does NOT set CLAUDECODE despite being Claude-Code-compatible, so this marker
   # is unambiguous when firstmate runs natively on grok.
   [ "${GROK_AGENT:-}" = "1" ] && { echo grok; return; }
+  # rovo (Atlassian Rovo Dev CLI) sets ROVODEV_CLI=1 for its child/tool processes
+  # (verified 2026-07-13, Rovo CLI 202607.8.1); it also sets AGENT=rovodev_cli and
+  # ATLASSIAN_AGENT_TYPE=rovo. ROVODEV_CLI is the unambiguous marker.
+  [ "${ROVODEV_CLI:-}" = "1" ] && { echo rovo; return; }
   # Layer 2: walk the parent chain and match the command name.
   local pid=$$ comm args
   for _ in 1 2 3 4 5 6 7 8; do
@@ -44,6 +48,7 @@ detect_own() {
       *codex*) echo codex; return ;;
       *opencode*) echo opencode; return ;;
       *grok*) echo grok; return ;;
+      *rovo*) echo rovo; return ;;
       pi) echo pi; return ;;
       node*|python*)
         # Bare interpreter: match the harness name in its script path.
@@ -53,6 +58,7 @@ detect_own() {
           *codex*) echo codex; return ;;
           *opencode*) echo opencode; return ;;
           *grok*) echo grok; return ;;
+          *rovo*) echo rovo; return ;;
           *" pi "*|*/pi) echo pi; return ;;
         esac ;;
     esac

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -279,7 +279,7 @@ FIRSTMATE_HOME=
 
 if [ "$KIND" = secondmate ]; then
   case "${POS[1]:-}" in
-    ''|claude|codex|opencode|pi|grok)
+    ''|claude|codex|opencode|pi|grok|rovo)
       ARG3=${POS[1]:-}
       ;;
     *' '*)
@@ -340,6 +340,14 @@ launch_template() {
     # launch command - it is a Stop-event hook installed below (global hook +
     # per-task pointer), so the template is identical for ship/scout/secondmate.
     grok) printf '%s' 'grok --always-approve __MODELFLAG____EFFORTFLAG__"$(cat __BRIEF__)"' ;;
+    # rovo (Atlassian Rovo Dev CLI): a positional message is the initial instruction;
+    # --yolo (aka --disable-permission-checks) auto-approves file CRUD + bash so an
+    # unattended crewmate runs without prompts (Atlassian-data/MCP tools still gate;
+    # verified 2026-07-13, Rovo CLI 202607.8.1). -i forces the interactive TUI to stay
+    # live for supervision even though a message is passed. rovo takes no firstmate
+    # model/effort flag, and its turn-end has no verified firstmate hook - the watcher
+    # uses the crewmate status-file signals plus busy-signature/stale detection.
+    rovo) printf '%s' 'rovo run --yolo -i "$(cat __BRIEF__)"' ;;
     *) return 1 ;;
   esac
 }
@@ -962,6 +970,12 @@ EOF
       printf '{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"%s"}]}]}}\n' "$hook_command" > "$GROK_HOOKS_DIR/fm-turn-end.json"
       printf 'token=%s\n' "${auth_file##*/}" > "$WT/.fm-grok-turnend"
       exclude_path '.fm-grok-turnend'
+      ;;
+    rovo*)
+      # rovo (Atlassian Rovo Dev CLI) has no verified firstmate turn-end hook. The
+      # crewmate reports phase changes via the status-file protocol (echo >> status),
+      # which drives signal wakes, and the watcher's busy-signature/stale detection
+      # catches an idle pane. No worktree or global hook is installed.
       ;;
   esac
 fi

--- a/bin/fm-tmux-lib.sh
+++ b/bin/fm-tmux-lib.sh
@@ -48,8 +48,10 @@
 
 # Busy footers per harness (mirror fm-watch.sh). claude/codex: "esc to
 # interrupt"; opencode: "esc interrupt"; pi: "Working..."; grok: "Ctrl+c:cancel"
-# (grok's mid-turn cancel hint, shown iff a turn is running - verified grok 0.2.73).
-FM_TMUX_BUSY_REGEX_DEFAULT='esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel'
+# (grok's mid-turn cancel hint, shown iff a turn is running - verified grok 0.2.73);
+# rovo: "Rovo is thinking" (its mid-turn status line - verified 2026-07-13, Rovo CLI
+# 202607.8.1).
+FM_TMUX_BUSY_REGEX_DEFAULT='esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel|Rovo is thinking'
 
 # fm_tmux_strip_ghost: thin adapter over the shared, fleet-wide ghost extractor
 # fm_composer_strip_ghost (bin/fm-composer-lib.sh). It drops de-emphasised

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -106,8 +106,10 @@ SIGNAL_GRACE=${FM_SIGNAL_GRACE:-30}   # seconds to linger after a signal so trai
 # claude/codex: "esc to interrupt"; opencode: "esc interrupt"; pi: "Working...";
 # grok: "Ctrl+c:cancel" (the mid-turn cancel hint in grok's keybind bar, shown iff a
 # turn is running; absent when idle - verified grok 0.2.73, ASCII to avoid the
-# locale fragility of matching grok's braille spinner glyph directly).
-BUSY_REGEX=${FM_BUSY_REGEX:-'esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel'}
+# locale fragility of matching grok's braille spinner glyph directly);
+# rovo: "Rovo is thinking" (its mid-turn status line, absent when idle - verified
+# 2026-07-13, Rovo CLI 202607.8.1; ASCII, avoids the braille spinner glyph).
+BUSY_REGEX=${FM_BUSY_REGEX:-'esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel|Rovo is thinking'}
 # Always-on wake triage: most wakes during a long crew validation are benign (a
 # working: note or turn-end while a pipeline runs, a no-change heartbeat). Rather
 # than wake firstmate's LLM for each, this watcher classifies every wake in bash


### PR DESCRIPTION
Adds `rovo` (Atlassian Rovo Dev CLI, the standalone `rovo` binary) as a verified **crewmate/scout** harness adapter.

## What changed
- **Detection** (`bin/fm-harness.sh`): `ROVODEV_CLI=1` env marker + `*rovo*` process-ancestry match.
- **Launch** (`bin/fm-spawn.sh`): `rovo run --yolo -i "$(cat <brief>)"`; turn-end is a documented no-op (no verified hook — supervision uses the status-file protocol + stale detection).
- **Busy signature** (`bin/fm-watch.sh`, `bin/fm-tmux-lib.sh`): `Rovo is thinking`.
- **Dispatch validation** (`bin/fm-bootstrap.sh`): accepts `rovo`; no effort flag (validated like opencode).
- **Knowledge**: full verified facts in the `harness-adapters` skill; `rovo` added to the AGENTS.md verified-adapter list.

## Verification
Empirically verified 2026-07-13 (Rovo CLI 202607.8.1): launch, `--yolo` autonomy, busy signature, single-Escape interrupt, `/exit`, `--resume`, env markers, and no trust dialog. Then exercised end-to-end on a real scout task (twg-cli JSM subcommand enumeration), which completed cleanly.

## Scope / caveats
- **Crewmate/scout only** — secondmate use is unverified (`pane_current_command` liveness not confirmed), so `bin/backends/tmux.sh` deliberately omits rovo.
- `--yolo` auto-approves file/bash but NOT Atlassian-data/MCP tools (those still prompt).
- No firstmate turn-end hook yet.
- ShellCheck lint was not run locally (not installed); relying on CI.
