### PR TITLE
feat(brief): instruct crews to format --intent as structured markdown

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -311,7 +311,9 @@ You drive no-mistakes by responding to its gates, not by implementing fixes.
 Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.
 Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.
 
-Two firstmate-specific rules layer on top of that guidance:
+Three firstmate-specific rules layer on top of that guidance:
+- When you start the run with \`no-mistakes axi run --intent "..."\`, write the intent string as structured markdown, not a run-on paragraph: one short lead sentence, a blank line, then a numbered or bulleted list of the distinct changes (one line per item).
+  no-mistakes renders \`--intent\` verbatim as the PR's \`## Intent\` section, so the intent string's readability IS the PR's readability.
 - ask-user findings are not yours to answer: escalate to firstmate (rule 6) and stop.
   When the decision comes back, feed it to the gate with \`no-mistakes axi respond\` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
 - Avoid \`--yes\`: the captain, not you, owns the ask-user decisions it would silently auto-resolve.

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -83,6 +83,25 @@ test_no_mistakes_dod_wording() {
   pass "fm-brief.sh: no-mistakes DOD wording avoids the apostrophe regression"
 }
 
+test_no_mistakes_intent_formatting_bullet() {
+  local home id brief
+  home="$TMP_ROOT/intent-fmt-home"
+  mkdir -p "$home/data"
+  id="brief-intent-fmt-e1"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_present "$brief" "brief was not scaffolded"
+  assert_grep "Three firstmate-specific rules" "$brief" \
+    "no-mistakes DOD still says Two instead of Three after intent bullet was added"
+  assert_grep "no-mistakes axi run --intent" "$brief" \
+    "no-mistakes DOD missing the intent-formatting bullet"
+  assert_grep "intent string as structured markdown" "$brief" \
+    "intent-formatting bullet missing structured-markdown instruction"
+  assert_grep "readability IS the PR" "$brief" \
+    "intent-formatting bullet missing the why: renders verbatim as PR Intent section"
+  pass "fm-brief.sh: no-mistakes DOD carries the intent-formatting bullet"
+}
+
 test_ship_project_memory_wording() {
   local home id brief
   home="$TMP_ROOT/project-memory-home"
@@ -264,6 +283,7 @@ test_script_parses
 test_help_includes_entire_header
 test_ship_modes_generate_clean_briefs
 test_no_mistakes_dod_wording
+test_no_mistakes_intent_formatting_bullet
 test_ship_project_memory_wording
 test_herdr_lab_contract_is_explicit_and_complete
 test_herdr_lab_contract_quotes_foreign_firstmate_path


### PR DESCRIPTION
## Intent

Instruct crews to write the `--intent` string as structured markdown when starting a no-mistakes run.

- Add a third bullet to the no-mistakes definition of done in `bin/fm-brief.sh` requiring: one short lead sentence, a blank line, then a numbered or bulleted list of distinct changes (one line per item)
- Update the "Two firstmate-specific rules" lead-in to "Three firstmate-specific rules" to match the new count
- Add a new test in `tests/fm-brief.test.sh` asserting the bullet, count wording, and why-clause all render in a generated no-mistakes ship brief

## What Changed

- `bin/fm-brief.sh`: added intent-formatting bullet to the no-mistakes DOD; updated count from Two to Three
- `tests/fm-brief.test.sh`: added `test_no_mistakes_intent_formatting_bullet` asserting the new bullet renders correctly; all 12 brief tests pass

## Risk

Low. Scaffold-only change: adds a rule to generated briefs, touches no runtime logic or state.