### PR TITLE
fix(watcher): classify acknowledged parked gates as paused

### DIFF
--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -322,25 +322,34 @@ signal_reason_is_actionable() {  # <file> ...
 #             pane; the crew is legitimately mid-work on a static-looking pane
 #             (e.g. waiting on CI);
 #   paused  - the crew's authoritative current state is a declared external-wait
-#             pause (paused:), which is EXPECTED to idle;
+#             pause (paused:), or an authoritative parked run has a latest
+#             explicit paused: acknowledgement; either is EXPECTED to idle;
 #   none    - neither, so the wake must surface (a stopped/finished/parked/failed/
 #             torn-down/unknown crew, or an unreadable verdict).
-# One fm-crew-state.sh read serves BOTH absorb reasons at once. Reading the state
-# authoritatively (not the status log) is what keeps run-step precedence: a crew
-# that appended paused: but then STARTED a run reports working, never paused.
+# One fm-crew-state.sh read serves BOTH absorb reasons at once. Active working
+# evidence is checked before the narrow parked-plus-latest-pause exception, so a
+# crew that appended paused: but then STARTED a run reports working, never paused.
+# A parked run without that latest explicit acknowledgement remains none, keeping
+# its first gate wake actionable; the status stream itself is never changed, so
+# status_open_decisions continues to own the durable open decision.
 # NOT a pure read: fm-crew-state.sh may make a bounded no-mistakes call, so callers
 # run it only on no-verb signal and first-sighting stale paths, never every wake.
 # FM_CREW_STATE_BIN lets tests stub the verdict.
 crew_absorb_class() {  # <id>
-  local id=$1 line state src
+  local id=$1 line state src status_dir last
   [ -n "$id" ] || { printf 'none'; return; }
   line=$("$FM_CREW_STATE_BIN" "$id" 2>/dev/null) || true
   case "$line" in state:*) ;; *) printf 'none'; return ;; esac
   state=${line#state: }; state=${state%% *}
   if [ "$state" = paused ]; then printf 'paused'; return; fi
+  src=${line#*source: }; src=${src%% *}
   if [ "$state" = working ]; then
-    src=${line#*source: }; src=${src%% *}
     case "$src" in run-step|pane) printf 'working'; return ;; esac
+  fi
+  if [ "$state" = parked ] && [ "$src" = run-step ]; then
+    status_dir=${STATE:-${FM_STATE_OVERRIDE:-${FM_HOME:-$_FM_CLASSIFY_LIB_DIR/..}/state}}
+    last=$(last_status_line "$status_dir/$id.status")
+    if status_is_paused "$last"; then printf 'paused'; return; fi
   fi
   printf 'none'
 }

--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -365,8 +365,8 @@ crew_is_provably_working() {  # <id>
   [ "$(crew_absorb_class "$1")" = working ]
 }
 
-# 0 if crew <id>'s authoritative current state is a declared external-wait pause.
-# The stale path absorbs such a crew (on a long re-surface cadence) instead of
+# 0 if crew <id> has the paused absorb classification defined by crew_absorb_class.
+# The stale path absorbs that class on a long re-surface cadence instead of
 # escalating a possible wedge.
 crew_is_paused() {  # <id>
   [ "$(crew_absorb_class "$1")" = paused ]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,6 +19,9 @@ A concurrent replacement remains armed, every non-merged or invalid observation 
 `bin/fm-pr-lib.sh` owns the receipt format and strict identity mechanics, while `bin/fm-watch.sh` owns queue-before-retirement ordering.
 No-verb wakes, such as `working:` notes and bare turn-ended signals, are benign only when `bin/fm-crew-state.sh` reports positive evidence that the crew is still working: an actively running no-mistakes step attributed to that crew's current code or a backend busy signature.
 A crew that declares `paused:` for a known external wait is separately absorbed while idle and re-surfaced only on the longer pause cadence, rather than being treated as a possible wedge.
+For an authoritative `parked` run-step, the watcher applies that same pause classification only when the latest status line is an explicit `paused:` acknowledgement; without it, the first unacknowledged gate remains actionable.
+Active `running`, `fixing`, or `ci` run-step evidence and a busy-pane verdict retain working precedence, while a later non-pause status clears the parked-run exception.
+The pause acknowledgement changes only stale-wake cadence; `status_open_decisions` in `bin/fm-classify-lib.sh` remains the owner of durable decision state.
 For an ordinary crew that has stopped, the normal-mode watcher first surfaces one stale wake, then applies that same cadence to an unchanged `paused:` or durable `captain-held` endpoint only when the backend confidently reports its agent dead.
 Live or inconclusive liveness remains fail-open at that initial surface, and the secondmate idle-endpoint exemption is unchanged.
 Its initial normal-mode status signal still surfaces through the no-verb path, while away mode self-handles that routine signal and owns the later recheck.

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -279,8 +279,9 @@ test_status_is_paused_classifier() {
 # (surface it) - so the watcher's stale path gets both for one bounded call.
 # crew_is_paused delegates to it exactly as crew_is_provably_working does.
 test_crew_absorb_class_classifier() {
-  local dir fakebin
-  dir=$(make_case absorb-class); fakebin="$dir/fakebin"
+  local dir fakebin state open FM_STATE_OVERRIDE
+  dir=$(make_case absorb-class); fakebin="$dir/fakebin"; state="$dir/state"
+  FM_STATE_OVERRIDE=$state
   export FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh"
   export FM_FAKE_CREW_STATE
   FM_FAKE_CREW_STATE='state: working · source: run-step · validating (running)'
@@ -291,6 +292,21 @@ test_crew_absorb_class_classifier() {
   [ "$(crew_absorb_class a)" = paused ] || fail "declared pause not classed paused"
   crew_is_paused a || fail "crew_is_paused did not recognize a paused verdict"
   ! crew_is_provably_working a || fail "a paused crew was treated as provably working"
+  printf 'needs-decision [key=review]: choose a remediation\npaused: gate acknowledged; awaiting captain response\n' > "$state/a.status"
+  FM_FAKE_CREW_STATE='state: parked · source: run-step · parked at review (ask-user: captain decision)'
+  [ "$(crew_absorb_class a)" = paused ] || fail "parked ask-user gate with latest paused: not classed paused"
+  open=$(status_open_decisions "$state/a.status")
+  printf '%s' "$open" | grep -F $'review\tneeds-decision\tchoose a remediation' >/dev/null \
+    || fail "trailing paused: masked the earlier open needs-decision"
+  printf 'needs-decision [key=review]: choose a remediation\n' > "$state/a.status"
+  [ "$(crew_absorb_class a)" = none ] || fail "unacknowledged parked gate was absorbed"
+  signal_reason_is_actionable "$state/a.status" || fail "unacknowledged parked gate wake was not actionable"
+  printf 'needs-decision [key=review]: choose a remediation\npaused: gate acknowledged; awaiting captain response\n' > "$state/a.status"
+  FM_FAKE_CREW_STATE='state: working · source: run-step · validating (fixing)'
+  [ "$(crew_absorb_class a)" = working ] || fail "active run-step did not outrank a trailing paused: line"
+  FM_FAKE_CREW_STATE='state: parked · source: run-step · parked at review (ask-user: captain decision)'
+  printf 'working: later non-pause event\n' >> "$state/a.status"
+  [ "$(crew_absorb_class a)" = none ] || fail "later non-pause line did not clear the parked pause exemption"
   FM_FAKE_CREW_STATE='state: working · source: status-log · working: compiling'
   [ "$(crew_absorb_class a)" = none ] || fail "stale working: status-log classed absorbable"
   FM_FAKE_CREW_STATE='state: unknown · source: none · worktree gone'
@@ -298,7 +314,7 @@ test_crew_absorb_class_classifier() {
   ! crew_is_paused a || fail "unknown crew classed paused"
   [ "$(crew_absorb_class "")" = none ] || fail "empty id not classed none"
   unset FM_FAKE_CREW_STATE
-  pass "crew_absorb_class: working/paused/none from one read; crew_is_paused and crew_is_provably_working agree"
+  pass "crew_absorb_class: parked gates require a latest pause, active runs win, and open decisions remain durable"
 }
 
 # signal_crew_provably_working: a no-verb "signal:" wake is benign ONLY when EVERY
@@ -609,7 +625,7 @@ test_nonterminal_stale_not_working_surfaced() {
 # uses the wedge timer; it re-surfaces once past PAUSE_RESURFACE_SECS (anchored on
 # the pause's own status-file age, so a churny idle pane cannot reset the cadence)
 # for a recheck, so a forgotten pause cannot rot invisibly.
-test_nonterminal_stale_paused_absorbed_then_resurfaced() {
+test_parked_gate_latest_pause_absorbed_then_resurfaced() {
   local dir state fakebin out drain_out capture_file window key pane_hash sig pid back statusf
   dir=$(make_case nonterminal-stale-paused); state="$dir/state"; fakebin="$dir/fakebin"
   out="$dir/watch.out"; drain_out="$dir/drain.out"; capture_file="$dir/pane.txt"
@@ -619,14 +635,15 @@ test_nonterminal_stale_paused_absorbed_then_resurfaced() {
   statusf="$state/held.status"
   # A DECLARED pause (not captain-relevant), .seen-* primed so the signal scan does
   # not pre-empt the stale path.
-  printf 'paused: holding for the upstream tool release\n' > "$statusf"
+  printf 'needs-decision [key=review]: choose a remediation\npaused: gate acknowledged; awaiting captain response\n' > "$statusf"
   sig=$(seen_sig "$statusf"); printf '%s' "$sig" > "$state/.seen-held_status"
   key=$(printf '%s' "$window" | tr ':/.' '___')
   pane_hash=$(hash_text "idle, holding for upstream")
   printf '%s' "$pane_hash" > "$state/.hash-$key"
   printf '1\n' > "$state/.count-$key"
-  # crew_absorb_class reads the declared pause from fm-crew-state.sh.
-  export FM_FAKE_CREW_STATE='state: paused · source: status-log · holding for the upstream tool release'
+  # crew_absorb_class combines the authoritative parked gate with the latest
+  # explicit pause without closing the earlier durable decision.
+  export FM_FAKE_CREW_STATE='state: parked · source: run-step · parked at review (ask-user: captain decision)'
 
   # Phase A: a fresh pause (status file just written) under a high re-surface
   # threshold is absorbed - no wake, no wedge timer.
@@ -667,7 +684,7 @@ test_nonterminal_stale_paused_absorbed_then_resurfaced() {
   [ ! -e "$state/.stale-since-$key" ] || fail "a paused re-surface must not use the wedge timer"
   FM_STATE_OVERRIDE="$state" "$DRAIN" > "$drain_out" 2>/dev/null || fail "drain after the paused re-surface failed"
   grep "$(printf '\tstale\t')" "$drain_out" | grep -F "$window" >/dev/null || fail "paused re-surface was not queued"
-  pass "a declared pause is absorbed on first sight, then re-surfaced as a recheck past the threshold, never wedge-escalated"
+  pass "an acknowledged parked gate enters the existing long-cadence pause path without closing its decision"
 }
 
 # A captain-held crew can leave a stable backend endpoint after its agent exits.
@@ -1564,7 +1581,7 @@ test_busy_pane_turn_end_touch_resets_age
 test_busy_pane_repeated_escalation_reaches_demand_deep_inspection
 test_busy_pane_default_turn_age_bound_is_3600s
 test_nonterminal_stale_not_working_surfaced
-test_nonterminal_stale_paused_absorbed_then_resurfaced
+test_parked_gate_latest_pause_absorbed_then_resurfaced
 test_exited_declared_pause_is_bounded_but_live_gate_surfaces
 test_secondmate_paused_resurfaces_in_normal_mode
 test_secondmate_nonpaused_stale_remains_suppressed

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -274,10 +274,8 @@ test_status_is_paused_classifier() {
   pass "status_is_paused: only the leading paused verb matches, and paused is not captain-relevant"
 }
 
-# crew_absorb_class: the single fm-crew-state.sh read that returns BOTH absorb
-# reasons - working (active run/busy pane), paused (declared external wait), or none
-# (surface it) - so the watcher's stale path gets both for one bounded call.
-# crew_is_paused delegates to it exactly as crew_is_provably_working does.
+# crew_absorb_class owns the exact working/paused/none decision; this test covers
+# its projections, parked-gate exception, precedence, and durable-decision boundary.
 test_crew_absorb_class_classifier() {
   local dir fakebin state open FM_STATE_OVERRIDE
   dir=$(make_case absorb-class); fakebin="$dir/fakebin"; state="$dir/state"
@@ -617,14 +615,10 @@ test_nonterminal_stale_not_working_surfaced() {
   pass "a not-provably-working non-terminal stale is surfaced immediately (never left to wait out the timer)"
 }
 
-# --- non-terminal stale, crew DECLARED a pause: absorbed, re-surfaced on a long
-#     cadence, never wedge-escalated ------------------------------------------
-# The live 2026-07-09/10 case: a crew intentionally held awaiting an upstream tool
-# release (paused: ...) whose idle pane tripped repeated possible-wedge escalations
-# all day. With the paused verb, its stale is absorbed like a working crew but never
-# uses the wedge timer; it re-surfaces once past PAUSE_RESURFACE_SECS (anchored on
-# the pause's own status-file age, so a churny idle pane cannot reset the cadence)
-# for a recheck, so a forgotten pause cannot rot invisibly.
+# --- parked gate plus latest pause: long-cadence recheck, never a wedge ------
+# An unacknowledged needs-decision remains actionable; once a latest explicit
+# paused: acknowledges the authoritative parked run, stale handling uses the
+# existing PAUSE_RESURFACE_SECS cadence without closing the durable decision.
 test_parked_gate_latest_pause_absorbed_then_resurfaced() {
   local dir state fakebin out drain_out capture_file window key pane_hash sig pid back statusf
   dir=$(make_case nonterminal-stale-paused); state="$dir/state"; fakebin="$dir/fakebin"


### PR DESCRIPTION
## Intent

Correct Firstmate's parked-gate pause classification so the first unacknowledged no-mistakes ask-user gate remains actionable, while an authoritative parked run-step plus a latest explicit paused status classifies as paused and follows the existing long recheck cadence. Preserve active working, fixing, and CI run-step precedence; require a latest pause so a later non-pause clears the exemption; keep the durable needs-decision open; and do not add timers or change unrelated signal, terminal, secondmate, AFK, backend, or wedge behavior.

## What Changed

- Classify authoritative parked run steps as paused only when their latest status is an explicit `paused:` acknowledgement, keeping unacknowledged gates actionable and allowing a later non-pause status to clear the exemption.
- Preserve active run-step and busy-pane working precedence while leaving durable `needs-decision` tracking intact and using the existing long pause recheck cadence.
- Expand watcher triage coverage and architecture documentation for parked-gate pause handling.

## Risk Assessment

✅ Low: The change is narrowly scoped and satisfies the parked-gate pause criteria without altering unrelated supervision paths.

## Testing

Completed 1 recorded test check.

The changed `tests/fm-watch-triage.test.sh` suite passed. The full-suite failures were independently classified as pre-existing/environmental and unrelated: seven recur in prior run `01KXCHRM01K15MHTV2QPH7EG0W`, and the eighth standalone watcher case passes.

- Outcome: ⚠️ 1 error across 1 run (11m9s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Test** - 1 error</summary>

- 🚨 tests failed with exit code 1
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
