### PR TITLE
feat(git-host): add git-host classification and PR/MR URL parsing library

### DIFF
--- a/bin/fm-git-host-lib.sh
+++ b/bin/fm-git-host-lib.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# fm-git-host-lib.sh - git-host classification and PR/MR URL parsing.
+#
+# firstmate's PR/merge/teardown machinery is GitHub-only today: it shells out to
+# gh/gh-axi, parses https://github.com/<owner>/<repo>/pull/<n> URLs, and fetches
+# refs/pull/<n>/head. This library is the foundation increment for adding GitLab
+# support: it centralizes the two host-dependent primitives every later increment
+# needs, so the merge/check path (increment #2) and the teardown landed-work path
+# (increment #3) each consume ONE parser instead of re-spelling host-detection and
+# URL-shape logic. The rationale (host inferred from a project's `origin` remote
+# rather than a registry field; the `pr=`/`pr_head=` meta contract staying
+# host-agnostic; `glab` called directly like fm-pr-check.sh already calls raw gh)
+# is recorded in docs/glab-backend.md.
+#
+# Two host kinds are recognized, `github` and `gitlab`; anything else is
+# `unknown`. GitLab covers gitlab.com AND self-hosted gitlab.* hostnames, so the
+# classifier stays general even though the captain's projects are on gitlab.com.
+#
+# Sourced by later bin/ scripts and by the tests. No side effects on source, no
+# network, no globals written. set -u / set -e safe. Pure string functions.
+#
+# ---------------------------------------------------------------------------
+# Output contract (stable; increments #2/#3 parse this):
+#
+#   fm_git_remote_host <remote-url>
+#     Prints the bare hostname of a git remote URL (as produced by
+#     `git remote get-url origin`) on stdout, no trailing path/port/user, then a
+#     newline. Handles scp-like SSH (git@host:path), scheme SSH
+#     (ssh://[user@]host[:port]/path), and https/http/git URLs. Returns non-zero
+#     and prints nothing for a URL with no recognizable host (e.g. a local path).
+#
+#   fm_git_host_classify <remote-url>
+#     Prints exactly one token - `github`, `gitlab`, or `unknown` - and a
+#     newline. Always returns 0: an unparseable or unrecognized URL classifies as
+#     `unknown`, never an error. Tolerates a trailing `.git` and trailing slashes
+#     because those live in the path, which host extraction discards.
+#
+#   fm_pr_url_parse <pr-or-mr-url>
+#     Parses a PR or MR web URL. On a recognized URL, prints ONE tab-separated
+#     record and a newline:
+#         <kind>\t<host>\t<path>\t<number>
+#       kind   - `github` or `gitlab`
+#       host   - the hostname (e.g. github.com, gitlab.com, gitlab.example.com)
+#       path   - the repo/namespace path: exactly `<owner>/<repo>` for GitHub;
+#                the full variable-depth namespace for GitLab (one or more
+#                segments, e.g. goosehead-insurance/custom-dev/goosehead-apps),
+#                captured greedily up to the `/-/merge_requests/` marker.
+#       number - the PR number or MR iid.
+#     Returns 0 on a match. On any malformed/unrecognized URL it returns non-zero
+#     and prints NOTHING to stdout (no partial garbage), mirroring the reject
+#     discipline of bin/fm-pr-merge.sh's parse_pr_url. Recognized shapes:
+#       GitHub: https://github.com/<owner>/<repo>/pull/<n>   (path = 2 segments)
+#       GitLab: https://<host>/<namespace>/-/merge_requests/<iid>
+#     A trailing slash is tolerated on both shapes.
+# ---------------------------------------------------------------------------
+
+# fm_git_remote_host <remote-url> -> hostname on stdout (no newline-only path),
+# non-zero when no host can be extracted.
+fm_git_remote_host() {  # <remote-url>
+  local url=$1 host
+  case "$url" in
+    ssh://*|https://*|http://*|git://*)
+      # scheme://[user@]host[:port]/path
+      host=${url#*://}     # strip scheme
+      host=${host#*@}      # strip optional user@ (unchanged when absent)
+      host=${host%%/*}     # strip path
+      host=${host%%:*}     # strip optional :port
+      ;;
+    *:*)
+      # scp-like SSH: [user@]host:path (the case that has no scheme)
+      host=${url%%:*}      # host part before the first colon
+      host=${host#*@}      # strip optional user@
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+  [ -n "$host" ] || return 1
+  printf '%s\n' "$host"
+}
+
+# fm_git_host_classify <remote-url> -> github|gitlab|unknown (always returns 0).
+fm_git_host_classify() {  # <remote-url>
+  local host
+  host=$(fm_git_remote_host "$1") || { printf 'unknown\n'; return 0; }
+  case "$host" in
+    github.com|*.github.com) printf 'github\n' ;;
+    gitlab.com|gitlab.*|*.gitlab.com) printf 'gitlab\n' ;;
+    *) printf 'unknown\n' ;;
+  esac
+  return 0
+}
+
+# fm_pr_url_parse <pr-or-mr-url> -> "<kind>\t<host>\t<path>\t<number>" on stdout,
+# non-zero with empty stdout on any malformed URL.
+fm_pr_url_parse() {  # <pr-or-mr-url>
+  local url=$1
+  # GitLab MR: https://<host>/<namespace>/-/merge_requests/<iid>. The namespace
+  # is variable-depth (one or more segments), captured greedily up to the single
+  # /-/merge_requests/ marker. Restricted char classes reject spaces and shell
+  # metacharacters, so a crafted URL fails to match rather than yielding garbage.
+  if [[ "$url" =~ ^https://([A-Za-z0-9._-]+)/([A-Za-z0-9._/-]+)/-/merge_requests/([0-9]+)/?$ ]]; then
+    printf 'gitlab\t%s\t%s\t%s\n' \
+      "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}" "${BASH_REMATCH[3]}"
+    return 0
+  fi
+  # GitHub PR: https://github.com/<owner>/<repo>/pull/<n>, exactly two path
+  # segments before /pull/. Mirrors bin/fm-pr-merge.sh's owner/repo grammar.
+  if [[ "$url" =~ ^https://(github\.com)/([A-Za-z0-9][A-Za-z0-9-]{0,38})/([A-Za-z0-9._-]+)/pull/([0-9]+)/?$ ]]; then
+    if [[ "${BASH_REMATCH[2]}" != *- ]]; then
+      printf 'github\t%s\t%s/%s\t%s\n' \
+        "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}" "${BASH_REMATCH[3]}" "${BASH_REMATCH[4]}"
+      return 0
+    fi
+  fi
+  return 1
+}

--- a/docs/glab-backend.md
+++ b/docs/glab-backend.md
@@ -1,0 +1,89 @@
+# GitLab (`glab`) ship-delivery support (verification record)
+
+This is a backend-verification doc: the empirical evidence behind adding GitLab support to firstmate's ship-delivery machinery, which is GitHub-only today.
+It records exact tools, commands, and output captured against a real merge request, so the later increments have verified field names rather than guesses.
+It is a verification record, not a contract restatement: the delivery-mode, `pr=`/`pr_head=` meta, and landed-work rules stay owned by `AGENTS.md` and the relevant `bin/` script headers, cross-referenced below.
+
+## Increment map
+
+GitLab support lands in three separate increments.
+
+1. **Foundation (this increment).** `bin/fm-git-host-lib.sh` centralizes git-host classification and PR/MR URL parsing, with `tests/fm-git-host-lib.test.sh` and this doc.
+   Pure addition, zero behavior change: the library has no in-repo caller yet.
+   It lands first so increments #2 and #3 each consume ONE verified parser instead of re-spelling host detection and URL-shape logic.
+2. **Merge/check.** Teach `bin/fm-pr-merge.sh` and `bin/fm-pr-check.sh` to route a GitLab MR URL through `glab` (merge, `pr_head=` recording, CI-green poll) instead of `gh`/`gh-axi`.
+3. **Teardown.** Teach `bin/fm-teardown.sh`'s landed-work fallback to verify a GitLab MR the way it verifies a GitHub PR, using `refs/merge-requests/<iid>/head`.
+   `bin/fm-review-diff.sh` and `bin/fm-project-mode.sh` are reviewed in the same increment.
+
+## Design decisions this evidence supports
+
+- **Host inferred from the `origin` remote, not a registry field.** A project's host is derived by classifying `git remote get-url origin` (`fm_git_host_classify` in `bin/fm-git-host-lib.sh`), so no new `data/projects.md` field is added and GitLab support needs no per-project configuration.
+- **The `pr=`/`pr_head=` meta contract stays host-agnostic and is NOT renamed.** A GitLab MR URL is a valid `pr=` value; the MR head SHA is a valid `pr_head=` value. The `state/<id>.meta` schema owned by `AGENTS.md` section 2 is unchanged.
+- **`glab` is called directly.** No wrapper is added: increment #2 calls raw `glab` the same way `bin/fm-pr-check.sh` already calls raw `gh` directly (as opposed to `gh-axi`).
+- **The URL carries the host.** Even though the captain is on gitlab.com (no self-hosted/ambient-host complexity in their case), the parser and classifier keep host detection driven by the URL/remote so self-hosted `gitlab.*` instances work unchanged.
+
+## Environment
+
+- Date: 2026-07-13.
+- Tool: `glab` v1.86.0 (Homebrew, `/opt/homebrew/bin/glab`).
+- Auth: logged in to gitlab.com; API calls over https, git operations over ssh.
+- MR probed read-only and left completely untouched (no merge, comment, approve, or edit): `https://gitlab.com/goosehead-insurance/custom-dev/goosehead-apps/-/merge_requests/5924`.
+  Host `gitlab.com`, namespace `goosehead-insurance/custom-dev/goosehead-apps` (three segments), iid `5924`.
+
+## MR JSON field mapping (`glab mr view <iid> -R <namespace> -F json`)
+
+Verified live against MR 5924. The GitHub equivalents are the fields the GitHub-only path uses today.
+
+| GitLab field | Value observed (open MR 5924) | GitHub equivalent | Use |
+| --- | --- | --- | --- |
+| `.sha` | `73d3dc700a717a8f0f60266348ece41a30f1758d` | `headRefOid` | head SHA; the `pr_head=` meta value. Equal to `.diff_refs.head_sha`; use `.sha`. |
+| `.diff_refs.head_sha` | `73d3dc700a717a8f0f60266348ece41a30f1758d` | - | Confirmed equal to `.sha`. |
+| `.state` | `opened` | `MERGED` etc. | MR state, **lowercase** one of `opened`/`closed`/`locked`/`merged`. GitHub uses UPPERCASE. Do NOT blindly case-fold: the eventual merge-poll must compare against lowercase `merged`. |
+| `.merge_commit_sha` | `""` (empty until merged) | - | Populated on a plain merge. |
+| `.squash_commit_sha` | `""` (empty until merged) | - | Populated on a squash merge. Both are `""` while the MR is open. |
+| `.iid` | `5924` | PR number | The MR identifier used with `-R <namespace>`. |
+| `.head_pipeline.status` | `success` | check-suite status | CI/pipeline status (e.g. `running`/`success`/`failed`). |
+| `.references.full` | `goosehead-insurance/custom-dev/goosehead-apps!5924` | `owner/repo#n` | Full namespace reference. |
+
+Exact command shape used:
+
+```sh
+glab mr view 5924 -R goosehead-insurance/custom-dev/goosehead-apps -F json
+```
+
+## Merge-request refs (`git ls-remote`)
+
+Confirmed present on gitlab.com:
+
+```sh
+git ls-remote git@gitlab.com:goosehead-insurance/custom-dev/goosehead-apps.git \
+  refs/merge-requests/5924/head refs/merge-requests/5924/merge
+```
+
+Output:
+
+```
+73d3dc700a717a8f0f60266348ece41a30f1758d	refs/merge-requests/5924/head
+279e3c087385233e9e731181833473c8ea46a0ad	refs/merge-requests/5924/merge
+```
+
+`refs/merge-requests/<iid>/head` is the source-branch head (equal to `.sha`) and is the GitLab equivalent of GitHub's `refs/pull/<n>/head` used by teardown's landed-work fallback.
+Use `/head`, not `/merge` (the latter is GitLab's synthesized merge preview, not the branch head).
+
+## CI status
+
+Either read `.head_pipeline.status` from the single `glab mr view ... -F json` call above, or:
+
+```sh
+glab ci status -R <namespace> --branch <source-branch>
+```
+
+which prints per-job lines plus a final `Pipeline state: <status>`.
+The one-call JSON read is preferred for the merge-poll since it also yields state and head SHA at once.
+
+## URL shapes (parsed by `bin/fm-git-host-lib.sh`)
+
+- GitHub PR: `https://github.com/<owner>/<repo>/pull/<n>` - path is exactly `<owner>/<repo>`.
+- GitLab MR: `https://<host>/<namespace>/-/merge_requests/<iid>` - `<namespace>` is one or more path segments (three for MR 5924), captured greedily up to the `/-/merge_requests/` marker; `<host>` may be self-hosted.
+
+The parser's stdout contract (`<kind>\t<host>\t<path>\t<number>`) and the classifier's `github`/`gitlab`/`unknown` tokens are documented in `bin/fm-git-host-lib.sh`'s header; increments #2/#3 parse that contract.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -63,6 +63,7 @@ The shared no-mistakes gate refusal used by `fm-spawn.sh`, `fm-send.sh`, and `fm
 | `fm-peek.sh`             | Print a bounded tail of a crewmate endpoint                                          |
 | `fm-pr-check.sh`         | Record `pr=` and `pr_head=` for a PR-ready task, then arm the watcher's merge poll   |
 | `fm-pr-merge.sh`         | Record PR metadata, then merge a task's PR from its full GitHub URL                  |
+| `fm-git-host-lib.sh`     | Shared git-host classification and PR/MR URL parsing for GitHub and GitLab ship delivery |
 | `fm-promote.sh`          | Promote a scout task in place to a protected ship task                               |
 | `fm-teardown.sh`         | Fail-closed teardown: return landed ship worktrees, require scout reports, retire secondmate homes |
 | `fm-harness.sh`          | Detect the running harness and resolve crew or secondmate harness, model, and effort |

--- a/tests/fm-git-host-lib.test.sh
+++ b/tests/fm-git-host-lib.test.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Tests for bin/fm-git-host-lib.sh: git-host classification and PR/MR URL
+# parsing, the foundation increment for GitLab support consumed by the later
+# merge/check (#2) and teardown (#3) increments.
+#
+# All fixtures are static strings; the suite hits NO network and needs no git
+# repo, harness, or external tool.
+#
+# Matrix:
+#   classify: github SSH + HTTPS, gitlab.com SSH + HTTPS, self-hosted gitlab
+#             (gitlab.example.com) SSH + HTTPS, .git-suffix and trailing-slash
+#             tolerance, ssh:// scheme form, an unknown host (bitbucket), and a
+#             non-URL local path.
+#   parse:    a GitHub pull URL, a GitLab MR URL with a THREE-segment namespace,
+#             a single-segment-namespace GitLab MR URL, trailing-slash tolerance,
+#             and several malformed URLs that must be rejected with empty stdout.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+# shellcheck source=bin/fm-git-host-lib.sh
+. "$ROOT/bin/fm-git-host-lib.sh"
+
+# --- host classification ----------------------------------------------------
+
+# expect_classify <remote-url> <expected-token>
+expect_classify() {
+  local url=$1 want=$2 got
+  got=$(fm_git_host_classify "$url")
+  [ "$got" = "$want" ] \
+    || fail "classify '$url': expected '$want', got '$got'"
+}
+
+test_classify_github() {
+  expect_classify 'git@github.com:owner/repo.git' github
+  expect_classify 'https://github.com/owner/repo.git' github
+  expect_classify 'https://github.com/owner/repo' github
+  pass "classifies GitHub SSH and HTTPS remotes as github"
+}
+
+test_classify_gitlab_dotcom() {
+  expect_classify 'git@gitlab.com:group/subgroup/repo.git' gitlab
+  expect_classify 'https://gitlab.com/group/repo.git' gitlab
+  expect_classify 'https://gitlab.com/goosehead-insurance/custom-dev/goosehead-apps.git' gitlab
+  pass "classifies gitlab.com SSH and HTTPS remotes as gitlab"
+}
+
+test_classify_gitlab_self_hosted() {
+  expect_classify 'git@gitlab.example.com:group/subgroup/repo.git' gitlab
+  expect_classify 'https://gitlab.example.com/group/repo' gitlab
+  pass "classifies self-hosted gitlab.* SSH and HTTPS remotes as gitlab"
+}
+
+test_classify_tolerates_suffix_and_slash() {
+  expect_classify 'https://github.com/owner/repo.git/' github
+  expect_classify 'https://gitlab.com/group/repo/' gitlab
+  expect_classify 'ssh://git@gitlab.example.com:2222/group/repo.git' gitlab
+  pass "classification tolerates .git suffix, trailing slash, and ssh:// with a port"
+}
+
+test_classify_unknown() {
+  expect_classify 'git@bitbucket.org:owner/repo.git' unknown
+  expect_classify 'https://bitbucket.org/owner/repo.git' unknown
+  expect_classify '/local/path/to/repo' unknown
+  pass "classifies an unknown host and a non-URL path as unknown"
+}
+
+# --- PR/MR URL parsing ------------------------------------------------------
+
+# expect_parse <url> <kind> <host> <path> <number>
+expect_parse() {
+  local url=$1 kind=$2 host=$3 path=$4 num=$5 got want
+  want="$kind"$'\t'"$host"$'\t'"$path"$'\t'"$num"
+  got=$(fm_pr_url_parse "$url") \
+    || fail "parse '$url': expected success, got non-zero exit"
+  [ "$got" = "$want" ] \
+    || fail "parse '$url': expected '$want', got '$got'"
+}
+
+# expect_reject <url>: must fail non-zero AND print nothing to stdout.
+expect_reject() {
+  local url=$1 got rc
+  set +e
+  got=$(fm_pr_url_parse "$url")
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "parse '$url': expected rejection, but it succeeded"
+  [ -z "$got" ] || fail "parse '$url': rejected URL emitted stdout garbage: '$got'"
+}
+
+test_parse_github_pull() {
+  expect_parse 'https://github.com/example/repo/pull/9' \
+    github github.com example/repo 9
+  expect_parse 'https://github.com/my-org/my-repo/pull/126/' \
+    github github.com my-org/my-repo 126
+  pass "parses a GitHub pull URL into kind/host/owner-repo/number"
+}
+
+test_parse_gitlab_deep_namespace() {
+  # The real captain-facing shape: a three-segment namespace.
+  expect_parse 'https://gitlab.com/goosehead-insurance/custom-dev/goosehead-apps/-/merge_requests/5924' \
+    gitlab gitlab.com goosehead-insurance/custom-dev/goosehead-apps 5924
+  pass "parses a GitLab MR URL with a three-segment namespace greedily"
+}
+
+test_parse_gitlab_single_namespace() {
+  expect_parse 'https://gitlab.com/mygroup/-/merge_requests/3' \
+    gitlab gitlab.com mygroup 3
+  expect_parse 'https://gitlab.example.com/group/subgroup/proj/-/merge_requests/42/' \
+    gitlab gitlab.example.com group/subgroup/proj 42
+  pass "parses single-segment and self-hosted GitLab MR URLs, tolerating a trailing slash"
+}
+
+test_parse_rejects_malformed() {
+  set -e
+  expect_reject 'https://github.com/owner/repo/pull/'          # no number
+  expect_reject 'https://github.com/owner/pull/1'              # missing repo segment
+  expect_reject 'https://github.com/owner/repo/pull/abc'       # non-numeric
+  expect_reject 'https://bitbucket.org/owner/repo/pull/1'      # wrong host for /pull/
+  expect_reject 'https://gitlab.com/group/merge_requests/5'    # missing /-/ marker
+  expect_reject 'https://gitlab.com/group/-/merge_requests/'   # no iid
+  expect_reject 'not a url at all'                             # not a URL
+  expect_reject ''                                             # empty
+  pass "rejects malformed PR/MR URLs non-zero with no stdout garbage"
+}
+
+test_classify_github
+test_classify_gitlab_dotcom
+test_classify_gitlab_self_hosted
+test_classify_tolerates_suffix_and_slash
+test_classify_unknown
+test_parse_github_pull
+test_parse_gitlab_deep_namespace
+test_parse_gitlab_single_namespace
+test_parse_rejects_malformed


### PR DESCRIPTION
Thank you for your helpful videos — I'm contributing the groundwork for GitLab support.

This is the foundation increment for adding GitLab support to firstmate's ship-delivery machinery, which is GitHub-only today. It adds a small, side-effect-free shell library (`bin/fm-git-host-lib.sh`) that classifies a repo's git host (GitHub vs GitLab) from its `origin` remote and parses both GitHub PR URLs and GitLab MR URLs into a stable `kind/host/path/number` contract — GitLab namespaces are variable-depth, captured greedily up to the `/-/merge_requests/` marker. It ships with a 9-case offline test suite (`tests/fm-git-host-lib.test.sh`, no network) and a backend-verification doc (`docs/glab-backend.md`) whose field names and refs were confirmed against a live GitLab merge request. No existing script is modified — this is foundation only; the merge/check and teardown paths that will consume the library are separate follow-up increments.
