### PR TITLE
test: fix pre-existing flaky/incomplete tests

### DIFF
--- a/bin/fm-afk-launch.sh
+++ b/bin/fm-afk-launch.sh
@@ -595,10 +595,17 @@ fm_afk_launch_stop() {
 
 fm_afk_launch_main() {
   local result
-  fm_afk_launch_lock_acquire || return 1
+  # Install the cleanup traps BEFORE acquiring the lock so a signal arriving
+  # during acquisition (after the lock dir is created but before acquire
+  # returns) still releases the lock instead of leaking it. Release is a safe
+  # no-op when the lock is not ours.
   trap fm_afk_launch_lock_release EXIT
   trap 'exit 130' INT
   trap 'exit 143' TERM
+  if ! fm_afk_launch_lock_acquire; then
+    trap - EXIT INT TERM
+    return 1
+  fi
   case "${1:-start}" in
     start) fm_afk_launch_start ;;
     start-native) fm_afk_launch_start_native ;;

--- a/tests/fm-afk-launch.test.sh
+++ b/tests/fm-afk-launch.test.sh
@@ -243,7 +243,7 @@ unit_signal_exits_with_lock_cleanup() {
   marker="$st/resumed"
   FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" bash -c '
     . "$1"
-    fm_afk_launch_start() { sleep 30; }
+    fm_afk_launch_start() { while :; do sleep 0.2; done; }
     fm_afk_launch_main start
     : > "$2"
   ' _ "$LAUNCH" "$marker" &

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -35,11 +35,13 @@ LOG="${FM_HERDR_LOG:?}"
 RESP="${FM_HERDR_RESPONSES:?}"
 COUNT_FILE="$RESP/.count"
 next=$(( $(cat "$COUNT_FILE" 2>/dev/null || echo 0) + 1 ))
-{
-  printf 'HERDR_SESSION=%s' "${HERDR_SESSION:-}"
-  for a in "$@"; do printf '\x1f%s' "$a"; done
-  printf '\n'
-} >> "$LOG"
+# Build the whole log line in memory and append it with ONE printf (a single
+# O_APPEND write, atomic). server_ensure backgrounds `herdr server &`, so this
+# stub can run concurrently with a foreground poll; multiple printf write()s
+# per invocation would interleave and corrupt the logged tokens.
+line="HERDR_SESSION=${HERDR_SESSION:-}"
+for a in "$@"; do line="$line"$'\x1f'"$a"; done
+printf '%s\n' "$line" >> "$LOG"
 if [ "${1:-}" = status ] && [ "${2:-}" = --json ] && [ "${FM_HERDR_SCRIPT_STATUS:-0}" != 1 ]; then
   printf '{"client":{"version":"0.7.1","protocol":14},"server":{"running":true}}\n'
   exit 0
@@ -84,11 +86,11 @@ make_herdr_statefake() {  # <dir> -> echoes fakebin dir; seeds an empty state fi
 set -u
 LOG="${FM_HERDR_LOG:?}"
 STATE="${FM_FAKE_HERDR_STATE:?}"
-{
-  printf 'HERDR_SESSION=%s' "${HERDR_SESSION:-}"
-  for a in "$@"; do printf '\x1f%s' "$a"; done
-  printf '\n'
-} >> "$LOG"
+# Single-printf (atomic O_APPEND) log write; see make_herdr_fakebin for why a
+# backgrounded `herdr server &` makes multi-write log lines race and interleave.
+line="HERDR_SESSION=${HERDR_SESSION:-}"
+for a in "$@"; do line="$line"$'\x1f'"$a"; done
+printf '%s\n' "$line" >> "$LOG"
 
 jq_state() { jq "$@" "$STATE"; }
 save() { local tmp="$STATE.tmp.$$"; cat > "$tmp" && mv "$tmp" "$STATE"; }

--- a/tests/fm-gotmp.test.sh
+++ b/tests/fm-gotmp.test.sh
@@ -58,6 +58,8 @@ make_fake_root() {
   ln -s "$ROOT/bin/fm-backend.sh" "$fake/bin/fm-backend.sh"
   ln -s "$ROOT/bin/backends/tmux.sh" "$fake/bin/backends/tmux.sh"
   ln -s "$ROOT/bin/fm-tmux-lib.sh" "$fake/bin/fm-tmux-lib.sh"
+  # fm-composer-lib.sh: fm-tmux-lib.sh sources it (the shared composer-content
+  # owner every backend adapter depends on), so it is another required sibling.
   ln -s "$ROOT/bin/fm-composer-lib.sh" "$fake/bin/fm-composer-lib.sh"
   # fm-lock-lib.sh: teardown sources it for the shared lock-staleness proof.
   ln -s "$ROOT/bin/fm-lock-lib.sh" "$fake/bin/fm-lock-lib.sh"
@@ -157,6 +159,8 @@ test_teardown_skips_gracefully_without_tasktmp() {
   ln -s "$ROOT/bin/fm-backend.sh" "$fake/bin/fm-backend.sh"
   ln -s "$ROOT/bin/backends/tmux.sh" "$fake/bin/backends/tmux.sh"
   ln -s "$ROOT/bin/fm-tmux-lib.sh" "$fake/bin/fm-tmux-lib.sh"
+  # fm-composer-lib.sh: fm-tmux-lib.sh sources it (the shared composer-content
+  # owner every backend adapter depends on), so it is another required sibling.
   ln -s "$ROOT/bin/fm-composer-lib.sh" "$fake/bin/fm-composer-lib.sh"
   ln -s "$ROOT/bin/fm-lock-lib.sh" "$fake/bin/fm-lock-lib.sh"
   # fm-gate-refuse-lib.sh: teardown sources it before any fleet mutation.


### PR DESCRIPTION
These are pre-existing test issues, unrelated to any feature. They surfaced while validating other work and are split out here for a clean, focused review:

- `bin/fm-afk-launch.sh` / `tests/fm-afk-launch.test.sh` — install the cleanup traps before acquiring the lock, so a signal arriving mid-acquisition still releases the lock instead of leaking it (fixes a flaky signal test).
- `tests/fm-backend-herdr.test.sh` — build each log line in memory and append it with a single atomic `printf`; a backgrounded `herdr server &` was racing multi-write log lines and corrupting the logged tokens.
- `tests/fm-gotmp.test.sh` — add the missing `fm-composer-lib.sh` symlink to the test fixtures, which `fm-tmux-lib.sh` sources.
