### PR TITLE
fix: preserve Pi watcher supervision across reloads

### DIFF
--- a/.pi/extensions/fm-primary-pi-watch.ts
+++ b/.pi/extensions/fm-primary-pi-watch.ts
@@ -185,24 +185,26 @@ export default function (pi: ExtensionAPI) {
   }
 
   async function reportPriorRestart(): Promise<void> {
+    if (!sessionOwnsLock()) return;
     const deadline = Date.now() + 5000;
     let handoff = readRestartHandoff();
     if (!handoff) return;
-    while (!handoff.complete && apiActive && Date.now() < deadline) {
+    while (!handoff.complete && apiActive && sessionOwnsLock() && Date.now() < deadline) {
       await new Promise((resolvePromise) => setTimeout(resolvePromise, 100));
       handoff = readRestartHandoff() || handoff;
     }
-    if (!handoff.complete || !apiActive) return;
+    if (!handoff.complete || !apiActive || !sessionOwnsLock()) return;
     if (handoff.reason) {
-      if (await sendWake(handoff.reason)) clearRestartHandoff();
+      if (await sendWake(handoff.reason) && sessionOwnsLock()) clearRestartHandoff();
       return;
     }
     if (handoff.code === 143 && await replacementWatcherIsHealthy(handoff.previousPid)) {
-      clearRestartHandoff();
+      if (sessionOwnsLock()) clearRestartHandoff();
       return;
     }
+    if (!sessionOwnsLock()) return;
     const failure = failureLine(handoff.stdout, handoff.stderr, handoff.code);
-    if (failure && await sendWake(failure)) clearRestartHandoff();
+    if (failure && await sendWake(failure) && sessionOwnsLock()) clearRestartHandoff();
   }
 
   function startArm(): ArmResult {

--- a/.pi/extensions/fm-primary-pi-watch.ts
+++ b/.pi/extensions/fm-primary-pi-watch.ts
@@ -1,7 +1,7 @@
 // Firstmate primary watcher bridge for Pi.
 import { spawn, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
@@ -14,6 +14,15 @@ type ArmResult = {
 
 type LockOwnership = "owned" | "missing" | "other";
 
+type RestartHandoff = {
+  previousPid: string;
+  complete: boolean;
+  stdout: string;
+  stderr: string;
+  code: number | null;
+  reason: string;
+};
+
 const extensionFile = fileURLToPath(import.meta.url);
 const extensionDir = dirname(extensionFile);
 const root = resolve(extensionDir, "../..");
@@ -25,13 +34,9 @@ const armScript = `${fmRoot}/bin/fm-watch-arm.sh`;
 const watchScript = `${fmRoot}/bin/fm-watch.sh`;
 const wakeLib = `${fmRoot}/bin/fm-wake-lib.sh`;
 const marker = `${state}/.pi-watch-extension-loaded`;
+const restartHandoffFile = `${state}/.pi-watch-restart-handoff`;
 const watcherToolName = "fm_watch_arm_pi";
 const extensionVersion = `sha256:${createHash("sha256").update(readFileSync(extensionFile)).digest("hex")}`;
-
-let child: any = null;
-let seq = 0;
-let stoppingForSessionShutdown = false;
-let replacedWatcherPid = "";
 
 function parentPid(pid: string): string {
   const result = spawnSync("ps", ["-o", "ppid=", "-p", pid], { encoding: "utf8" });
@@ -117,6 +122,25 @@ async function replacementWatcherIsHealthy(previousPid: string): Promise<boolean
   return false;
 }
 
+function readRestartHandoff(): RestartHandoff | null {
+  try {
+    return JSON.parse(readFileSync(restartHandoffFile, "utf8")) as RestartHandoff;
+  } catch {
+    return null;
+  }
+}
+
+function writeRestartHandoff(handoff: RestartHandoff): void {
+  mkdirSync(state, { recursive: true });
+  writeFileSync(restartHandoffFile, `${JSON.stringify(handoff)}\n`);
+}
+
+function clearRestartHandoff(): void {
+  try {
+    unlinkSync(restartHandoffFile);
+  } catch {}
+}
+
 function failureLine(stdout: string, stderr: string, code: number | null): string {
   const combined = `${stdout}\n${stderr}`.trim();
   const healthy = combined.split(/\r?\n/).find((line) => /^watcher: healthy\b/.test(line));
@@ -128,7 +152,14 @@ function failureLine(stdout: string, stderr: string, code: number | null): strin
 }
 
 export default function (pi: ExtensionAPI) {
+  let child: any = null;
+  let seq = 0;
+  let apiActive = true;
+  let stoppingForReload = false;
+  let replacedWatcherPid = "";
+
   function keepWatcherToolActive(): void {
+    if (!apiActive) return;
     const activeTools = pi.getActiveTools();
     if (activeTools.includes(watcherToolName)) return;
     pi.setActiveTools([...activeTools, watcherToolName]);
@@ -144,11 +175,34 @@ export default function (pi: ExtensionAPI) {
   };
   process.once("exit", cleanupOnProcessExit);
 
-  async function sendWake(message: string) {
+  async function sendWake(message: string): Promise<boolean> {
+    if (!apiActive) return false;
     await pi.sendUserMessage(
       `FIRSTMATE WATCHER WAKE: ${message}\n\nRun bin/fm-wake-drain.sh first, handle the queued wake, then resume Pi supervision.`,
       { deliverAs: "followUp" },
     );
+    return true;
+  }
+
+  async function reportPriorRestart(): Promise<void> {
+    const deadline = Date.now() + 5000;
+    let handoff = readRestartHandoff();
+    if (!handoff) return;
+    while (!handoff.complete && apiActive && Date.now() < deadline) {
+      await new Promise((resolvePromise) => setTimeout(resolvePromise, 100));
+      handoff = readRestartHandoff() || handoff;
+    }
+    if (!handoff.complete || !apiActive) return;
+    if (handoff.reason) {
+      if (await sendWake(handoff.reason)) clearRestartHandoff();
+      return;
+    }
+    if (handoff.code === 143 && await replacementWatcherIsHealthy(handoff.previousPid)) {
+      clearRestartHandoff();
+      return;
+    }
+    const failure = failureLine(handoff.stdout, handoff.stderr, handoff.code);
+    if (failure && await sendWake(failure)) clearRestartHandoff();
   }
 
   function startArm(): ArmResult {
@@ -179,10 +233,11 @@ export default function (pi: ExtensionAPI) {
     child.on("close", async (code: number | null) => {
       child = null;
       const reason = actionableLine(`${stdout}\n${stderr}`);
-      const expectedRestart = !reason && code === 143 && stoppingForSessionShutdown
-        ? await replacementWatcherIsHealthy(replacedWatcherPid)
-        : false;
-      const failure = reason || expectedRestart ? "" : failureLine(stdout, stderr, code);
+      if (stoppingForReload) {
+        writeRestartHandoff({ previousPid: replacedWatcherPid, complete: true, stdout, stderr, code, reason });
+        return;
+      }
+      const failure = reason ? "" : failureLine(stdout, stderr, code);
       if (!reason && !failure) return;
       try {
         await sendWake(reason || failure);
@@ -192,8 +247,13 @@ export default function (pi: ExtensionAPI) {
     });
     child.on("error", async (error: Error) => {
       child = null;
+      const failure = `watcher: FAILED - Pi extension arm child ${id} failed: ${error.message}`;
+      if (stoppingForReload) {
+        writeRestartHandoff({ previousPid: replacedWatcherPid, complete: true, stdout, stderr: failure, code: null, reason: "" });
+        return;
+      }
       try {
-        await sendWake(`watcher: FAILED - Pi extension arm child ${id} failed: ${error.message}`);
+        await sendWake(failure);
       } catch {
         // Fail open.
       }
@@ -209,9 +269,13 @@ export default function (pi: ExtensionAPI) {
     // have selected their safety-scoped tool surface.
     keepWatcherToolActive();
   });
-  pi.on?.("session_shutdown", () => {
-    stoppingForSessionShutdown = true;
-    replacedWatcherPid = recordedWatcherPid();
+  pi.on?.("session_shutdown", (event: { reason?: string }) => {
+    apiActive = false;
+    stoppingForReload = event?.reason === "reload";
+    if (stoppingForReload && child) {
+      replacedWatcherPid = recordedWatcherPid();
+      writeRestartHandoff({ previousPid: replacedWatcherPid, complete: false, stdout: "", stderr: "", code: null, reason: "" });
+    }
     stopArm();
     process.off("exit", cleanupOnProcessExit);
   });
@@ -243,4 +307,5 @@ export default function (pi: ExtensionAPI) {
   });
 
   markLoaded();
+  void reportPriorRestart().catch(() => {});
 }

--- a/.pi/extensions/fm-primary-pi-watch.ts
+++ b/.pi/extensions/fm-primary-pi-watch.ts
@@ -113,6 +113,7 @@ function healthyHomeWatcherPid(): string {
 }
 
 async function replacementWatcherIsHealthy(previousPid: string): Promise<boolean> {
+  if (!/^[1-9][0-9]*$/.test(previousPid) || previousPid === "1") return false;
   const deadline = Date.now() + 5000;
   while (Date.now() < deadline) {
     const healthyPid = healthyHomeWatcherPid();

--- a/.pi/extensions/fm-primary-pi-watch.ts
+++ b/.pi/extensions/fm-primary-pi-watch.ts
@@ -22,11 +22,16 @@ const fmRoot = process.env.FM_ROOT_OVERRIDE || root;
 const state = process.env.FM_STATE_OVERRIDE || `${fmHome}/state`;
 const config = process.env.FM_CONFIG_OVERRIDE || `${fmHome}/config`;
 const armScript = `${fmRoot}/bin/fm-watch-arm.sh`;
+const watchScript = `${fmRoot}/bin/fm-watch.sh`;
+const wakeLib = `${fmRoot}/bin/fm-wake-lib.sh`;
 const marker = `${state}/.pi-watch-extension-loaded`;
+const watcherToolName = "fm_watch_arm_pi";
 const extensionVersion = `sha256:${createHash("sha256").update(readFileSync(extensionFile)).digest("hex")}`;
 
 let child: any = null;
 let seq = 0;
+let stoppingForSessionShutdown = false;
+let replacedWatcherPid = "";
 
 function parentPid(pid: string): string {
   const result = spawnSync("ps", ["-o", "ppid=", "-p", pid], { encoding: "utf8" });
@@ -75,6 +80,43 @@ function actionableLine(output: string): string {
   return lines.find((line) => /^(signal:|stale:|check:|heartbeat($|:))/.test(line)) || "";
 }
 
+function recordedWatcherPid(): string {
+  try {
+    return readFileSync(`${state}/.watch.lock/pid`, "utf8").trim();
+  } catch {
+    return "";
+  }
+}
+
+function healthyHomeWatcherPid(): string {
+  const grace = process.env.FM_GUARD_GRACE || "300";
+  const result = spawnSync(
+    "bash",
+    [
+      "-c",
+      '. "$1"; if fm_watcher_healthy "$2" "$3" "$4" "$5"; then printf "%s" "$FM_WATCHER_HEALTHY_PID"; fi',
+      "_",
+      wakeLib,
+      state,
+      watchScript,
+      grace,
+      fmHome,
+    ],
+    { encoding: "utf8" },
+  );
+  return result.status === 0 ? result.stdout.trim() : "";
+}
+
+async function replacementWatcherIsHealthy(previousPid: string): Promise<boolean> {
+  const deadline = Date.now() + 5000;
+  while (Date.now() < deadline) {
+    const healthyPid = healthyHomeWatcherPid();
+    if (healthyPid && healthyPid !== previousPid) return true;
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, 100));
+  }
+  return false;
+}
+
 function failureLine(stdout: string, stderr: string, code: number | null): string {
   const combined = `${stdout}\n${stderr}`.trim();
   const healthy = combined.split(/\r?\n/).find((line) => /^watcher: healthy\b/.test(line));
@@ -86,6 +128,12 @@ function failureLine(stdout: string, stderr: string, code: number | null): strin
 }
 
 export default function (pi: ExtensionAPI) {
+  function keepWatcherToolActive(): void {
+    const activeTools = pi.getActiveTools();
+    if (activeTools.includes(watcherToolName)) return;
+    pi.setActiveTools([...activeTools, watcherToolName]);
+  }
+
   function stopArm(): void {
     if (child) child.kill("SIGTERM");
     child = null;
@@ -131,7 +179,10 @@ export default function (pi: ExtensionAPI) {
     child.on("close", async (code: number | null) => {
       child = null;
       const reason = actionableLine(`${stdout}\n${stderr}`);
-      const failure = reason ? "" : failureLine(stdout, stderr, code);
+      const expectedRestart = !reason && code === 143 && stoppingForSessionShutdown
+        ? await replacementWatcherIsHealthy(replacedWatcherPid)
+        : false;
+      const failure = reason || expectedRestart ? "" : failureLine(stdout, stderr, code);
       if (!reason && !failure) return;
       try {
         await sendWake(reason || failure);
@@ -153,7 +204,14 @@ export default function (pi: ExtensionAPI) {
   pi.on?.("session_start", () => {
     markLoaded();
   });
+  pi.on?.("resources_discover", () => {
+    // This event follows every startup/reload session_start, after mode extensions
+    // have selected their safety-scoped tool surface.
+    keepWatcherToolActive();
+  });
   pi.on?.("session_shutdown", () => {
+    stoppingForSessionShutdown = true;
+    replacedWatcherPid = recordedWatcherPid();
     stopArm();
     process.off("exit", cleanupOnProcessExit);
   });
@@ -167,7 +225,7 @@ export default function (pi: ExtensionAPI) {
   });
 
   pi.registerTool?.({
-    name: "fm_watch_arm_pi",
+    name: watcherToolName,
     label: "Arm firstmate watcher",
     description: "Arm Pi watcher supervision. Always use this tool instead of running bin/fm-watch-arm.sh through bash.",
     promptSnippet: "Arm firstmate watcher supervision through Pi without a foreground bash arm.",

--- a/.pi/extensions/fm-primary-pi-watch.ts
+++ b/.pi/extensions/fm-primary-pi-watch.ts
@@ -1,6 +1,6 @@
 // Firstmate primary watcher bridge for Pi.
 import { spawn, spawnSync } from "node:child_process";
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -15,6 +15,7 @@ type ArmResult = {
 type LockOwnership = "owned" | "missing" | "other";
 
 type RestartHandoff = {
+  generation: string;
   previousPid: string;
   complete: boolean;
   stdout: string;
@@ -136,7 +137,19 @@ function writeRestartHandoff(handoff: RestartHandoff): void {
   writeFileSync(restartHandoffFile, `${JSON.stringify(handoff)}\n`);
 }
 
-function clearRestartHandoff(): void {
+function completeRestartHandoff(generation: string, update: Omit<RestartHandoff, "generation" | "previousPid" | "complete">): void {
+  const current = readRestartHandoff();
+  if (!current || current.generation !== generation || current.complete) return;
+  writeRestartHandoff({ ...current, ...update, complete: true });
+}
+
+function sameRestartHandoff(left: RestartHandoff, right: RestartHandoff): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function clearRestartHandoff(expected: RestartHandoff): void {
+  const current = readRestartHandoff();
+  if (!current || !sameRestartHandoff(current, expected)) return;
   try {
     unlinkSync(restartHandoffFile);
   } catch {}
@@ -158,6 +171,8 @@ export default function (pi: ExtensionAPI) {
   let apiActive = true;
   let stoppingForReload = false;
   let replacedWatcherPid = "";
+  let toolSurfaceGuardRegistered = false;
+  const generation = randomUUID();
 
   function keepWatcherToolActive(): void {
     if (!apiActive) return;
@@ -190,22 +205,30 @@ export default function (pi: ExtensionAPI) {
     const deadline = Date.now() + 5000;
     let handoff = readRestartHandoff();
     if (!handoff) return;
+    const priorGeneration = handoff.generation;
     while (!handoff.complete && apiActive && sessionOwnsLock() && Date.now() < deadline) {
       await new Promise((resolvePromise) => setTimeout(resolvePromise, 100));
-      handoff = readRestartHandoff() || handoff;
+      const current = readRestartHandoff();
+      if (!current || current.generation !== priorGeneration) return;
+      handoff = current;
     }
-    if (!handoff.complete || !apiActive || !sessionOwnsLock()) return;
+    if (!apiActive || !sessionOwnsLock()) return;
+    if (!handoff.complete) {
+      const failure = "watcher: FAILED - Pi reload arm handoff remained incomplete after 5s";
+      if (await sendWake(failure) && sessionOwnsLock()) clearRestartHandoff(handoff);
+      return;
+    }
     if (handoff.reason) {
-      if (await sendWake(handoff.reason) && sessionOwnsLock()) clearRestartHandoff();
+      if (await sendWake(handoff.reason) && sessionOwnsLock()) clearRestartHandoff(handoff);
       return;
     }
     if (handoff.code === 143 && await replacementWatcherIsHealthy(handoff.previousPid)) {
-      if (sessionOwnsLock()) clearRestartHandoff();
+      if (apiActive && sessionOwnsLock()) clearRestartHandoff(handoff);
       return;
     }
-    if (!sessionOwnsLock()) return;
+    if (!apiActive || !sessionOwnsLock()) return;
     const failure = failureLine(handoff.stdout, handoff.stderr, handoff.code);
-    if (failure && await sendWake(failure) && sessionOwnsLock()) clearRestartHandoff();
+    if (failure && await sendWake(failure) && sessionOwnsLock()) clearRestartHandoff(handoff);
   }
 
   function startArm(): ArmResult {
@@ -237,7 +260,7 @@ export default function (pi: ExtensionAPI) {
       child = null;
       const reason = actionableLine(`${stdout}\n${stderr}`);
       if (stoppingForReload) {
-        writeRestartHandoff({ previousPid: replacedWatcherPid, complete: true, stdout, stderr, code, reason });
+        completeRestartHandoff(generation, { stdout, stderr, code, reason });
         return;
       }
       const failure = reason ? "" : failureLine(stdout, stderr, code);
@@ -252,7 +275,7 @@ export default function (pi: ExtensionAPI) {
       child = null;
       const failure = `watcher: FAILED - Pi extension arm child ${id} failed: ${error.message}`;
       if (stoppingForReload) {
-        writeRestartHandoff({ previousPid: replacedWatcherPid, complete: true, stdout, stderr: failure, code: null, reason: "" });
+        completeRestartHandoff(generation, { stdout, stderr: failure, code: null, reason: "" });
         return;
       }
       try {
@@ -268,16 +291,18 @@ export default function (pi: ExtensionAPI) {
     markLoaded();
   });
   pi.on?.("resources_discover", () => {
-    // This event follows every startup/reload session_start, after mode extensions
-    // have selected their safety-scoped tool surface.
     keepWatcherToolActive();
+    if (!toolSurfaceGuardRegistered) {
+      toolSurfaceGuardRegistered = true;
+      pi.on?.("before_agent_start", keepWatcherToolActive);
+    }
   });
   pi.on?.("session_shutdown", (event: { reason?: string }) => {
     apiActive = false;
     stoppingForReload = event?.reason === "reload";
     if (stoppingForReload && child) {
       replacedWatcherPid = recordedWatcherPid();
-      writeRestartHandoff({ previousPid: replacedWatcherPid, complete: false, stdout: "", stderr: "", code: null, reason: "" });
+      writeRestartHandoff({ generation, previousPid: replacedWatcherPid, complete: false, stdout: "", stderr: "", code: null, reason: "" });
     }
     stopArm();
     process.off("exit", cleanupOnProcessExit);

--- a/docs/supervision-protocols/pi.md
+++ b/docs/supervision-protocols/pi.md
@@ -27,13 +27,14 @@ Observed output: `ok - Pi 0.80.5 live E2E rendered the tool, guarded once, woke,
 Command run for the installed-type contract: `tests/fm-pi-primary-types.test.sh`.
 Observed output: `ok - Pi primary extensions pass strict no-emit typecheck against Pi 0.80.5`.
 
-Reload verification on 2026-07-13 used Pi 0.80.6, an isolated `PI_CODING_AGENT_DIR`, an isolated `FM_HOME`, a private tmux socket, and a later-loaded fixture extension that selected only `read` and `bash` during `session_start`.
+Reload and Workflow Suite verification on 2026-07-13 used Pi 0.80.6 with `@mediadatafusion/pi-workflow-suite` 0.0.25, an isolated `PI_CODING_AGENT_DIR` with its copied authentication held in a mode-700 temporary directory outside the source tree, an isolated `FM_HOME`, and a private tmux socket.
 Command run for the complete interactive regression: `FM_PI_LIVE_E2E=1 tests/fm-pi-primary-live-e2e.test.sh`.
-Observed output: `ok - Pi 0.80.6 kept the watcher tool active after a late /reload reset, guarded once, woke, re-armed, and cleaned up on exit`.
-The test ran `/reload` and proved the first post-reload model turn could call `fm_watch_arm_pi` without widening the fixture extension's selected tool allowlist.
+Observed output: `ok - Pi 0.80.6 with Workflow Suite 0.0.25 kept the watcher tool active after /reload, guarded once, woke, re-armed, and cleaned up on exit`.
+The test loaded the watcher extension before Workflow Suite, ran `/reload`, and proved the first post-reload model turn could call `fm_watch_arm_pi` without widening Workflow Suite's selected tool allowlist.
 Command run for deterministic lifecycle and restart coverage: `tests/fm-pi-watch-extension.test.sh`.
 Observed output included `ok - Pi watcher tool survives a late reload active-tool reset without widening the mode surface`, `ok - Pi suppresses restart exit 143 only after a fresh home-scoped replacement is verified`, and `ok - Pi keeps restart exit 143 actionable when no fresh home-scoped replacement exists`.
 The lifecycle fixture invalidated the captured extension API after resource discovery and would have thrown `extension ctx is stale` from any delayed `getActiveTools` or `setActiveTools` callback, proving the restoration does not rely on a post-handler timer.
-The restart fixture reproduced `watcher: FAILED - fm-watch-arm.sh exited 143` from the replaced arm and `watcher: started pid=222 (beacon fresh)` from its successor; exit 143 was suppressed only when the canonical home-scoped watcher-health predicate confirmed a different live watcher with a fresh beacon.
+The restart fixture invalidated every captured Pi API from the shutting-down generation, reproduced `watcher: FAILED - fm-watch-arm.sh exited 143` from the replaced arm, and reproduced `watcher: started pid=222 (beacon fresh)` from its successor.
+The current extension generation delivered genuine exit-143 failures, while suppression occurred only when the canonical home-scoped watcher-health predicate confirmed a different live watcher with a fresh beacon.
 Command run for the installed-type contract: `PATH="$HOME/.npm/_npx/9ca470fa61f45e06/node_modules/.bin:$PATH" tests/fm-pi-primary-types.test.sh`.
 Observed output: `ok - Pi primary extensions pass strict no-emit typecheck against Pi 0.80.6`.

--- a/docs/supervision-protocols/pi.md
+++ b/docs/supervision-protocols/pi.md
@@ -26,3 +26,14 @@ Command run for the complete interactive regression: `FM_PI_LIVE_E2E=1 tests/fm-
 Observed output: `ok - Pi 0.80.5 live E2E rendered the tool, guarded once, woke, re-armed, and cleaned up on exit`.
 Command run for the installed-type contract: `tests/fm-pi-primary-types.test.sh`.
 Observed output: `ok - Pi primary extensions pass strict no-emit typecheck against Pi 0.80.5`.
+
+Reload and Workflow Suite verification on 2026-07-13 used Pi 0.80.6 with `@mediadatafusion/pi-workflow-suite` 0.0.25, an isolated `PI_CODING_AGENT_DIR`, an isolated `FM_HOME`, and a private tmux socket.
+Command run for the complete interactive regression: `FM_PI_LIVE_E2E=1 tests/fm-pi-primary-live-e2e.test.sh`.
+Observed output: `ok - Pi 0.80.6 with Workflow Suite 0.0.25 kept the watcher tool active after /reload, guarded once, woke, re-armed, and cleaned up on exit`.
+The test loaded the watcher extension before Workflow Suite, ran `/reload`, and proved the first post-reload model turn could call `fm_watch_arm_pi` without widening Workflow Suite's selected tool allowlist.
+Command run for deterministic lifecycle and restart coverage: `tests/fm-pi-watch-extension.test.sh`.
+Observed output included `ok - Pi watcher tool survives a late reload active-tool reset without widening the mode surface`, `ok - Pi suppresses restart exit 143 only after a fresh home-scoped replacement is verified`, and `ok - Pi keeps restart exit 143 actionable when no fresh home-scoped replacement exists`.
+The lifecycle fixture invalidated the captured extension API after resource discovery and would have thrown `extension ctx is stale` from any delayed `getActiveTools` or `setActiveTools` callback, proving the restoration does not rely on a post-handler timer.
+The restart fixture reproduced `watcher: FAILED - fm-watch-arm.sh exited 143` from the replaced arm and `watcher: started pid=222 (beacon fresh)` from its successor; exit 143 was suppressed only when the canonical home-scoped watcher-health predicate confirmed a different live watcher with a fresh beacon.
+Command run for the installed-type contract: `PATH="$HOME/.npm/_npx/9ca470fa61f45e06/node_modules/.bin:$PATH" tests/fm-pi-primary-types.test.sh`.
+Observed output: `ok - Pi primary extensions pass strict no-emit typecheck against Pi 0.80.6`.

--- a/docs/supervision-protocols/pi.md
+++ b/docs/supervision-protocols/pi.md
@@ -27,10 +27,10 @@ Observed output: `ok - Pi 0.80.5 live E2E rendered the tool, guarded once, woke,
 Command run for the installed-type contract: `tests/fm-pi-primary-types.test.sh`.
 Observed output: `ok - Pi primary extensions pass strict no-emit typecheck against Pi 0.80.5`.
 
-Reload and Workflow Suite verification on 2026-07-13 used Pi 0.80.6 with `@mediadatafusion/pi-workflow-suite` 0.0.25, an isolated `PI_CODING_AGENT_DIR`, an isolated `FM_HOME`, and a private tmux socket.
+Reload verification on 2026-07-13 used Pi 0.80.6, an isolated `PI_CODING_AGENT_DIR`, an isolated `FM_HOME`, a private tmux socket, and a later-loaded fixture extension that selected only `read` and `bash` during `session_start`.
 Command run for the complete interactive regression: `FM_PI_LIVE_E2E=1 tests/fm-pi-primary-live-e2e.test.sh`.
-Observed output: `ok - Pi 0.80.6 with Workflow Suite 0.0.25 kept the watcher tool active after /reload, guarded once, woke, re-armed, and cleaned up on exit`.
-The test loaded the watcher extension before Workflow Suite, ran `/reload`, and proved the first post-reload model turn could call `fm_watch_arm_pi` without widening Workflow Suite's selected tool allowlist.
+Observed output: `ok - Pi 0.80.6 kept the watcher tool active after a late /reload reset, guarded once, woke, re-armed, and cleaned up on exit`.
+The test ran `/reload` and proved the first post-reload model turn could call `fm_watch_arm_pi` without widening the fixture extension's selected tool allowlist.
 Command run for deterministic lifecycle and restart coverage: `tests/fm-pi-watch-extension.test.sh`.
 Observed output included `ok - Pi watcher tool survives a late reload active-tool reset without widening the mode surface`, `ok - Pi suppresses restart exit 143 only after a fresh home-scoped replacement is verified`, and `ok - Pi keeps restart exit 143 actionable when no fresh home-scoped replacement exists`.
 The lifecycle fixture invalidated the captured extension API after resource discovery and would have thrown `extension ctx is stale` from any delayed `getActiveTools` or `setActiveTools` callback, proving the restoration does not rely on a post-handler timer.

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -96,7 +96,7 @@ Command used to fire the watcher: `printf 'done: pi e2e watcher fire\n' > "$FM_H
 Observed output after the wake: Pi ran `bin/fm-wake-drain.sh`, read the terminal status, called `fm_watch_arm_pi`, and rendered `watcher: started Pi extension arm child 2`.
 The complete pane contained one guard message and zero foreground `bin/fm-watch-arm.sh` bash calls.
 `/quit` printed `PI_EXIT=0`, and the second arm process plus its watcher child were both gone afterward.
-Pi 0.80.6 with Workflow Suite 0.0.25 was re-validated across `/reload` on 2026-07-13; the exact command, outputs, active-tool lifecycle proof, and restart-SIGTERM evidence are recorded in `docs/supervision-protocols/pi.md`.
+Pi 0.80.6 was re-validated across a later-loaded active-tool reset and `/reload` on 2026-07-13; the exact command, outputs, lifecycle proof, and restart-SIGTERM evidence are recorded in `docs/supervision-protocols/pi.md`.
 
 Grok 0.2.91 was validated with a scratch `GROK_HOME` and symlinked auth/config.
 Hook file used for tracked project-hook loading: `<scratch-project>/.grok/hooks/fm-smoke.json`, matching the tracked `.grok/hooks/fm-primary-turnend-guard.json` location.

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -96,6 +96,7 @@ Command used to fire the watcher: `printf 'done: pi e2e watcher fire\n' > "$FM_H
 Observed output after the wake: Pi ran `bin/fm-wake-drain.sh`, read the terminal status, called `fm_watch_arm_pi`, and rendered `watcher: started Pi extension arm child 2`.
 The complete pane contained one guard message and zero foreground `bin/fm-watch-arm.sh` bash calls.
 `/quit` printed `PI_EXIT=0`, and the second arm process plus its watcher child were both gone afterward.
+Pi 0.80.6 with Workflow Suite 0.0.25 was re-validated across `/reload` on 2026-07-13; the exact command, outputs, active-tool lifecycle proof, and restart-SIGTERM evidence are recorded in `docs/supervision-protocols/pi.md`.
 
 Grok 0.2.91 was validated with a scratch `GROK_HOME` and symlinked auth/config.
 Hook file used for tracked project-hook loading: `<scratch-project>/.grok/hooks/fm-smoke.json`, matching the tracked `.grok/hooks/fm-primary-turnend-guard.json` location.

--- a/tests/fm-pi-primary-live-e2e.test.sh
+++ b/tests/fm-pi-primary-live-e2e.test.sh
@@ -19,13 +19,6 @@ PROJECT="$LAB/project"
 HOME_DIR="$LAB/fmhome"
 PI_DIR="$LAB/pi-agent"
 PI_VERSION=$(pi --version)
-WORKFLOW_PACKAGE_DIR=${FM_PI_WORKFLOW_SUITE_DIR:-"$HOME/.pi/agent/npm/node_modules/@mediadatafusion/pi-workflow-suite"}
-WORKFLOW_EXTENSION="$WORKFLOW_PACKAGE_DIR/extensions/workflow-modes.ts"
-if [ ! -f "$WORKFLOW_EXTENSION" ] || [ ! -f "$WORKFLOW_PACKAGE_DIR/package.json" ]; then
-  echo "skip: installed @mediadatafusion/pi-workflow-suite package not found"
-  exit 0
-fi
-WORKFLOW_VERSION=$(node -e 'const fs=require("node:fs"); const p=JSON.parse(fs.readFileSync(process.argv[1], "utf8")); process.stdout.write(p.version)' "$WORKFLOW_PACKAGE_DIR/package.json")
 PI_AUTH_FILE=${FM_PI_AUTH_FILE:-"$HOME/.pi/agent/auth.json"}
 if [ ! -f "$PI_AUTH_FILE" ]; then
   echo "skip: Pi auth file not found for live model calls"
@@ -118,17 +111,26 @@ git clone -q "$ROOT" "$PROJECT"
 cp "$ROOT/.pi/extensions/fm-primary-pi-watch.ts" "$PROJECT/.pi/extensions/fm-primary-pi-watch.ts"
 cp "$ROOT/.pi/extensions/fm-primary-turnend-guard.ts" "$PROJECT/.pi/extensions/fm-primary-turnend-guard.ts"
 cp "$ROOT/bin/fm-supervision-instructions.sh" "$PROJECT/bin/fm-supervision-instructions.sh"
+cat > "$PROJECT/.pi/extensions/fm-late-active-reset.ts" <<'TS'
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+export default function (pi: ExtensionAPI) {
+  pi.on("session_start", () => {
+    pi.setActiveTools(["read", "bash"]);
+  });
+}
+TS
 mkdir -p "$HOME_DIR/state" "$HOME_DIR/config" "$PI_DIR"
 cp "$PI_AUTH_FILE" "$PI_DIR/auth.json"
 chmod 600 "$PI_DIR/auth.json"
 
 "$TMUX" -L "$SOCKET" new-session -d -s "$SESSION" -c "$PROJECT" \
-  "env PI_CODING_AGENT_DIR='$PI_DIR' FM_HOME='$HOME_DIR' FM_ROOT_OVERRIDE='$PROJECT' FM_POLL=1 FM_SIGNAL_GRACE=0 FM_HEARTBEAT=600 PI_OFFLINE=1 bash -lc 'printf \"%s\\n\" \"\$\$\" > \"\$FM_HOME/state/.lock\"; pi --no-extensions -e \"$PROJECT/.pi/extensions/fm-primary-pi-watch.ts\" -e \"$PROJECT/.pi/extensions/fm-primary-turnend-guard.ts\" -e \"$WORKFLOW_EXTENSION\"; rc=\$?; printf \"PI_EXIT=%s\\n\" \"\$rc\"; sleep 300'"
+  "env PI_CODING_AGENT_DIR='$PI_DIR' FM_HOME='$HOME_DIR' FM_ROOT_OVERRIDE='$PROJECT' FM_POLL=1 FM_SIGNAL_GRACE=0 FM_HEARTBEAT=600 PI_OFFLINE=1 bash -lc 'printf \"%s\\n\" \"\$\$\" > \"\$FM_HOME/state/.lock\"; pi --no-extensions -e \"$PROJECT/.pi/extensions/fm-primary-pi-watch.ts\" -e \"$PROJECT/.pi/extensions/fm-primary-turnend-guard.ts\" -e \"$PROJECT/.pi/extensions/fm-late-active-reset.ts\"; rc=\$?; printf \"PI_EXIT=%s\\n\" \"\$rc\"; sleep 300'"
 
 wait_for_text "Trust project folder?" 40 || fail "Pi trust prompt did not appear"
 "$TMUX" -L "$SOCKET" send-keys -t "$SESSION" Enter
 wait_for_text "fm-primary-turnend-guard.ts" 60 || fail "Pi primary extensions did not load"
-wait_for_text "workflow-modes.ts" 60 || fail "Workflow Suite extension did not load"
+wait_for_text "fm-late-active-reset.ts" 60 || fail "late active-tool reset extension did not load"
 
 send_prompt "Use the bash tool to run printf PI_E2E_BASH_ONE. Then reply exactly BASH-ONE."
 wait_for_exact_line "BASH-ONE" || fail "first bash turn did not complete"
@@ -170,4 +172,4 @@ wait_for_text "PI_EXIT=0" 60 || fail "Pi did not exit cleanly"
 wait_pid_dead "$watcher_pid" || fail "watcher child survived clean Pi exit"
 wait_pid_dead "$arm_pid" || fail "arm child survived clean Pi exit"
 
-printf 'ok - Pi %s with Workflow Suite %s kept the watcher tool active after /reload, guarded once, woke, re-armed, and cleaned up on exit\n' "$PI_VERSION" "$WORKFLOW_VERSION"
+printf 'ok - Pi %s kept the watcher tool active after a late /reload reset, guarded once, woke, re-armed, and cleaned up on exit\n' "$PI_VERSION"

--- a/tests/fm-pi-primary-live-e2e.test.sh
+++ b/tests/fm-pi-primary-live-e2e.test.sh
@@ -19,6 +19,18 @@ PROJECT="$LAB/project"
 HOME_DIR="$LAB/fmhome"
 PI_DIR="$LAB/pi-agent"
 PI_VERSION=$(pi --version)
+WORKFLOW_PACKAGE_DIR=${FM_PI_WORKFLOW_SUITE_DIR:-"$HOME/.pi/agent/npm/node_modules/@mediadatafusion/pi-workflow-suite"}
+WORKFLOW_EXTENSION="$WORKFLOW_PACKAGE_DIR/extensions/workflow-modes.ts"
+if [ ! -f "$WORKFLOW_EXTENSION" ] || [ ! -f "$WORKFLOW_PACKAGE_DIR/package.json" ]; then
+  echo "skip: installed @mediadatafusion/pi-workflow-suite package not found"
+  exit 0
+fi
+WORKFLOW_VERSION=$(node -e 'const fs=require("node:fs"); const p=JSON.parse(fs.readFileSync(process.argv[1], "utf8")); process.stdout.write(p.version)' "$WORKFLOW_PACKAGE_DIR/package.json")
+PI_AUTH_FILE=${FM_PI_AUTH_FILE:-"$HOME/.pi/agent/auth.json"}
+if [ ! -f "$PI_AUTH_FILE" ]; then
+  echo "skip: Pi auth file not found for live model calls"
+  exit 0
+fi
 
 fail() {
   printf 'not ok - %s\n' "$1" >&2
@@ -107,13 +119,16 @@ cp "$ROOT/.pi/extensions/fm-primary-pi-watch.ts" "$PROJECT/.pi/extensions/fm-pri
 cp "$ROOT/.pi/extensions/fm-primary-turnend-guard.ts" "$PROJECT/.pi/extensions/fm-primary-turnend-guard.ts"
 cp "$ROOT/bin/fm-supervision-instructions.sh" "$PROJECT/bin/fm-supervision-instructions.sh"
 mkdir -p "$HOME_DIR/state" "$HOME_DIR/config" "$PI_DIR"
+cp "$PI_AUTH_FILE" "$PI_DIR/auth.json"
+chmod 600 "$PI_DIR/auth.json"
 
 "$TMUX" -L "$SOCKET" new-session -d -s "$SESSION" -c "$PROJECT" \
-  "env PI_CODING_AGENT_DIR='$PI_DIR' FM_HOME='$HOME_DIR' FM_ROOT_OVERRIDE='$PROJECT' FM_POLL=1 FM_SIGNAL_GRACE=0 FM_HEARTBEAT=600 PI_OFFLINE=1 bash -lc 'printf \"%s\\n\" \"\$\$\" > \"\$FM_HOME/state/.lock\"; pi; rc=\$?; printf \"PI_EXIT=%s\\n\" \"\$rc\"; sleep 300'"
+  "env PI_CODING_AGENT_DIR='$PI_DIR' FM_HOME='$HOME_DIR' FM_ROOT_OVERRIDE='$PROJECT' FM_POLL=1 FM_SIGNAL_GRACE=0 FM_HEARTBEAT=600 PI_OFFLINE=1 bash -lc 'printf \"%s\\n\" \"\$\$\" > \"\$FM_HOME/state/.lock\"; pi --no-extensions -e \"$PROJECT/.pi/extensions/fm-primary-pi-watch.ts\" -e \"$PROJECT/.pi/extensions/fm-primary-turnend-guard.ts\" -e \"$WORKFLOW_EXTENSION\"; rc=\$?; printf \"PI_EXIT=%s\\n\" \"\$rc\"; sleep 300'"
 
 wait_for_text "Trust project folder?" 40 || fail "Pi trust prompt did not appear"
 "$TMUX" -L "$SOCKET" send-keys -t "$SESSION" Enter
 wait_for_text "fm-primary-turnend-guard.ts" 60 || fail "Pi primary extensions did not load"
+wait_for_text "workflow-modes.ts" 60 || fail "Workflow Suite extension did not load"
 
 send_prompt "Use the bash tool to run printf PI_E2E_BASH_ONE. Then reply exactly BASH-ONE."
 wait_for_exact_line "BASH-ONE" || fail "first bash turn did not complete"
@@ -121,6 +136,10 @@ send_prompt "Use the read tool to read the first five lines of README.md. Then r
 wait_for_exact_line "READ-ONE" || fail "read turn did not complete"
 send_prompt "Use the bash tool to run printf PI_E2E_BASH_TWO. Then reply exactly BASH-TWO."
 wait_for_exact_line "BASH-TWO" || fail "second bash turn did not complete"
+sleep 2
+
+send_prompt "/reload"
+wait_for_text "Reloaded keybindings, extensions" 60 || fail "Pi /reload did not complete"
 
 : > "$HOME_DIR/state/pi-e2e.meta"
 send_prompt "Reply exactly GUARD-TRIGGER with no tools. When the guard follow-up arrives, use fm_watch_arm_pi and never use bash to arm supervision. After any FIRSTMATE WATCHER WAKE, run bin/fm-wake-drain.sh, read the signaled status, call fm_watch_arm_pi to re-arm, and finish exactly REARMED."
@@ -151,4 +170,4 @@ wait_for_text "PI_EXIT=0" 60 || fail "Pi did not exit cleanly"
 wait_pid_dead "$watcher_pid" || fail "watcher child survived clean Pi exit"
 wait_pid_dead "$arm_pid" || fail "arm child survived clean Pi exit"
 
-printf 'ok - Pi %s live E2E rendered the tool, guarded once, woke, re-armed, and cleaned up on exit\n' "$PI_VERSION"
+printf 'ok - Pi %s with Workflow Suite %s kept the watcher tool active after /reload, guarded once, woke, re-armed, and cleaned up on exit\n' "$PI_VERSION" "$WORKFLOW_VERSION"

--- a/tests/fm-pi-primary-live-e2e.test.sh
+++ b/tests/fm-pi-primary-live-e2e.test.sh
@@ -17,8 +17,16 @@ SESSION=pi-live-e2e
 LAB="$ROOT/.pi-live-e2e.$$"
 PROJECT="$LAB/project"
 HOME_DIR="$LAB/fmhome"
-PI_DIR="$LAB/pi-agent"
+AUTH_LAB=
+PI_DIR=
 PI_VERSION=$(pi --version)
+WORKFLOW_PACKAGE_DIR=${FM_PI_WORKFLOW_SUITE_DIR:-"$HOME/.pi/agent/npm/node_modules/@mediadatafusion/pi-workflow-suite"}
+WORKFLOW_EXTENSION="$WORKFLOW_PACKAGE_DIR/extensions/workflow-modes.ts"
+if [ ! -f "$WORKFLOW_EXTENSION" ] || [ ! -f "$WORKFLOW_PACKAGE_DIR/package.json" ]; then
+  echo "skip: installed @mediadatafusion/pi-workflow-suite package not found"
+  exit 0
+fi
+WORKFLOW_VERSION=$(node -e 'const fs=require("node:fs"); const p=JSON.parse(fs.readFileSync(process.argv[1], "utf8")); process.stdout.write(p.version)' "$WORKFLOW_PACKAGE_DIR/package.json")
 PI_AUTH_FILE=${FM_PI_AUTH_FILE:-"$HOME/.pi/agent/auth.json"}
 if [ ! -f "$PI_AUTH_FILE" ]; then
   echo "skip: Pi auth file not found for live model calls"
@@ -87,8 +95,14 @@ cleanup() {
     kill -TERM "$arm_pid" 2>/dev/null || true
   fi
   rm -rf "$LAB"
+  if [ -n "$AUTH_LAB" ]; then
+    rm -rf "$AUTH_LAB"
+  fi
 }
 trap cleanup EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 send_prompt() {
   local prompt=$1
@@ -111,26 +125,20 @@ git clone -q "$ROOT" "$PROJECT"
 cp "$ROOT/.pi/extensions/fm-primary-pi-watch.ts" "$PROJECT/.pi/extensions/fm-primary-pi-watch.ts"
 cp "$ROOT/.pi/extensions/fm-primary-turnend-guard.ts" "$PROJECT/.pi/extensions/fm-primary-turnend-guard.ts"
 cp "$ROOT/bin/fm-supervision-instructions.sh" "$PROJECT/bin/fm-supervision-instructions.sh"
-cat > "$PROJECT/.pi/extensions/fm-late-active-reset.ts" <<'TS'
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-
-export default function (pi: ExtensionAPI) {
-  pi.on("session_start", () => {
-    pi.setActiveTools(["read", "bash"]);
-  });
-}
-TS
-mkdir -p "$HOME_DIR/state" "$HOME_DIR/config" "$PI_DIR"
-cp "$PI_AUTH_FILE" "$PI_DIR/auth.json"
-chmod 600 "$PI_DIR/auth.json"
+mkdir -p "$HOME_DIR/state" "$HOME_DIR/config"
+AUTH_LAB=$(mktemp -d "${TMPDIR:-/tmp}/fm-pi-live-e2e-auth.XXXXXX") || fail "could not create isolated Pi auth directory"
+chmod 700 "$AUTH_LAB"
+PI_DIR="$AUTH_LAB/pi-agent"
+mkdir -m 700 "$PI_DIR"
+install -m 600 "$PI_AUTH_FILE" "$PI_DIR/auth.json"
 
 "$TMUX" -L "$SOCKET" new-session -d -s "$SESSION" -c "$PROJECT" \
-  "env PI_CODING_AGENT_DIR='$PI_DIR' FM_HOME='$HOME_DIR' FM_ROOT_OVERRIDE='$PROJECT' FM_POLL=1 FM_SIGNAL_GRACE=0 FM_HEARTBEAT=600 PI_OFFLINE=1 bash -lc 'printf \"%s\\n\" \"\$\$\" > \"\$FM_HOME/state/.lock\"; pi --no-extensions -e \"$PROJECT/.pi/extensions/fm-primary-pi-watch.ts\" -e \"$PROJECT/.pi/extensions/fm-primary-turnend-guard.ts\" -e \"$PROJECT/.pi/extensions/fm-late-active-reset.ts\"; rc=\$?; printf \"PI_EXIT=%s\\n\" \"\$rc\"; sleep 300'"
+  "env PI_CODING_AGENT_DIR='$PI_DIR' FM_HOME='$HOME_DIR' FM_ROOT_OVERRIDE='$PROJECT' FM_POLL=1 FM_SIGNAL_GRACE=0 FM_HEARTBEAT=600 PI_OFFLINE=1 bash -lc 'printf \"%s\\n\" \"\$\$\" > \"\$FM_HOME/state/.lock\"; pi --no-extensions -e \"$PROJECT/.pi/extensions/fm-primary-pi-watch.ts\" -e \"$PROJECT/.pi/extensions/fm-primary-turnend-guard.ts\" -e \"$WORKFLOW_EXTENSION\"; rc=\$?; printf \"PI_EXIT=%s\\n\" \"\$rc\"; sleep 300'"
 
 wait_for_text "Trust project folder?" 40 || fail "Pi trust prompt did not appear"
 "$TMUX" -L "$SOCKET" send-keys -t "$SESSION" Enter
 wait_for_text "fm-primary-turnend-guard.ts" 60 || fail "Pi primary extensions did not load"
-wait_for_text "fm-late-active-reset.ts" 60 || fail "late active-tool reset extension did not load"
+wait_for_text "workflow-modes.ts" 60 || fail "Workflow Suite extension did not load"
 
 send_prompt "Use the bash tool to run printf PI_E2E_BASH_ONE. Then reply exactly BASH-ONE."
 wait_for_exact_line "BASH-ONE" || fail "first bash turn did not complete"
@@ -172,4 +180,4 @@ wait_for_text "PI_EXIT=0" 60 || fail "Pi did not exit cleanly"
 wait_pid_dead "$watcher_pid" || fail "watcher child survived clean Pi exit"
 wait_pid_dead "$arm_pid" || fail "arm child survived clean Pi exit"
 
-printf 'ok - Pi %s kept the watcher tool active after a late /reload reset, guarded once, woke, re-armed, and cleaned up on exit\n' "$PI_VERSION"
+printf 'ok - Pi %s with Workflow Suite %s kept the watcher tool active after /reload, guarded once, woke, re-armed, and cleaned up on exit\n' "$PI_VERSION" "$WORKFLOW_VERSION"

--- a/tests/fm-pi-watch-extension.test.sh
+++ b/tests/fm-pi-watch-extension.test.sh
@@ -256,6 +256,13 @@ for (const handler of handlers.get("resources_discover") ?? []) {
 if (JSON.stringify(activeTools) !== JSON.stringify(["read", "fm_watch_arm_pi"])) {
   throw new Error(`watcher restoration changed the selected mode surface: ${JSON.stringify(activeTools)}`);
 }
+pi.setActiveTools(["read", "edit"]);
+for (const handler of handlers.get("before_agent_start") ?? []) {
+  await handler({}, {});
+}
+if (JSON.stringify(activeTools) !== JSON.stringify(["read", "edit", "fm_watch_arm_pi"])) {
+  throw new Error(`runtime mode transition dropped or widened the watcher surface: ${JSON.stringify(activeTools)}`);
+}
 // Pi invalidates the captured extension API at shutdown. A post-handler timer
 // using getAllTools/setActiveTools would throw here, so prove no such callback remains.
 apiActive = false;
@@ -541,6 +548,109 @@ EOF
   expect_code 0 "$status" "Pi restart handoff processing and deletion must require session lock ownership"
   [ -z "$out" ] || fail "Pi restart-handoff lock test printed output: $out"
   pass "Pi restart handoff remains reserved for the session-lock owner"
+}
+
+test_pi_restart_handoff_generation_is_compare_and_swap_owned() {
+  local repo home plugin out status
+  repo="$TMP_ROOT/pi-restart-handoff-generation-root"
+  home="$TMP_ROOT/pi-restart-handoff-generation-home"
+  mkdir -p "$repo/bin" "$home/state" "$home/config"
+  install_pi_watch_extension_fixture "$repo"
+  plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
+  cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
+#!/usr/bin/env bash
+trap 'sleep 0.3; exit 143' TERM INT
+: > "${FM_ARM_STARTED:?}"
+while :; do sleep 1; done
+SH
+  chmod +x "$repo/bin/fm-watch-arm.sh"
+  out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" FM_ARM_STARTED="$repo/arm-started" node --input-type=module 2>&1 <<'EOF'
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const handoffFile = `${process.env.FM_HOME}/state/.pi-watch-restart-handoff`;
+const prompts = [];
+const mod = await import(pathToFileURL(process.env.PLUGIN).href);
+function loadExtension() {
+  const handlers = new Map();
+  let tool = null;
+  const pi = {
+    on(event, handler) { handlers.set(event, handler); },
+    registerCommand() {},
+    registerTool(candidate) {
+      if (candidate.name === "fm_watch_arm_pi") tool = candidate;
+    },
+    sendUserMessage: async (message) => prompts.push(message),
+  };
+  mod.default(pi);
+  return { handlers, getTool: () => tool };
+}
+writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
+const oldGeneration = loadExtension();
+await oldGeneration.getTool().execute("before-generation-race", {}, undefined, undefined, {});
+for (let i = 0; i < 50 && !existsSync(process.env.FM_ARM_STARTED); i += 1) {
+  await new Promise((resolve) => setTimeout(resolve, 20));
+}
+if (!existsSync(process.env.FM_ARM_STARTED)) throw new Error("old generation arm did not start");
+await oldGeneration.handlers.get("session_shutdown")?.({ reason: "reload" }, {});
+const newer = { generation: "newer-generation", previousPid: "222", complete: true, stdout: "", stderr: "", code: 2, reason: "" };
+writeFileSync(handoffFile, `${JSON.stringify(newer)}\n`);
+await new Promise((resolve) => setTimeout(resolve, 700));
+const retained = JSON.parse(readFileSync(handoffFile, "utf8"));
+if (JSON.stringify(retained) !== JSON.stringify(newer)) {
+  throw new Error(`old generation overwrote newer handoff: ${JSON.stringify(retained)}`);
+}
+loadExtension();
+for (let i = 0; i < 50 && existsSync(handoffFile); i += 1) {
+  await new Promise((resolve) => setTimeout(resolve, 20));
+}
+if (existsSync(handoffFile)) throw new Error("current generation did not clear its delivered handoff");
+if (prompts.length !== 1 || !prompts[0].includes("fm-watch-arm.sh exited 2")) {
+  throw new Error(`unexpected generation-owned handoff delivery: ${prompts.join("\n")}`);
+}
+EOF
+)
+  status=$?
+  expect_code 0 "$status" "Pi restart handoffs must use generation-owned compare-and-swap updates and clears"
+  [ -z "$out" ] || fail "Pi restart-handoff generation test printed output: $out"
+  pass "Pi restart handoffs are generation-owned compare-and-swap state"
+}
+
+test_pi_incomplete_restart_handoff_is_actionable() {
+  local repo home plugin out status
+  repo="$TMP_ROOT/pi-incomplete-restart-handoff-root"
+  home="$TMP_ROOT/pi-incomplete-restart-handoff-home"
+  mkdir -p "$repo/bin" "$home/state" "$home/config"
+  install_pi_watch_extension_fixture "$repo"
+  plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
+  out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" node --input-type=module 2>&1 <<'EOF'
+import { existsSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const handoff = `${process.env.FM_HOME}/state/.pi-watch-restart-handoff`;
+let prompt = "";
+writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
+writeFileSync(handoff, `${JSON.stringify({ generation: "incomplete-generation", previousPid: "111", complete: false, stdout: "", stderr: "", code: null, reason: "" })}\n`);
+const mod = await import(pathToFileURL(process.env.PLUGIN).href);
+mod.default({
+  on() {},
+  registerCommand() {},
+  registerTool() {},
+  sendUserMessage: async (message) => { prompt = message; },
+});
+for (let i = 0; i < 70 && !prompt; i += 1) {
+  await new Promise((resolve) => setTimeout(resolve, 100));
+}
+if (!prompt.includes("watcher: FAILED - Pi reload arm handoff remained incomplete after 5s")) {
+  throw new Error(`incomplete handoff was not actionable: ${prompt}`);
+}
+if (existsSync(handoff)) throw new Error("delivered incomplete handoff was not compare-and-swap cleared");
+EOF
+)
+  status=$?
+  expect_code 0 "$status" "Pi incomplete restart handoffs must become actionable at the deadline"
+  [ -z "$out" ] || fail "Pi incomplete restart-handoff test printed output: $out"
+  pass "Pi reports incomplete restart handoffs through the current generation"
 }
 
 test_pi_process_exit_cleanup_listener_lifecycle() {
@@ -1068,6 +1178,8 @@ test_pi_reload_restart_sigterm_is_benign_only_after_verified_replacement
 test_pi_reload_restart_sigterm_without_replacement_stays_failed
 test_pi_reload_restart_sigterm_requires_valid_previous_pid
 test_pi_restart_handoff_requires_session_lock_ownership
+test_pi_restart_handoff_generation_is_compare_and_swap_owned
+test_pi_incomplete_restart_handoff_is_actionable
 test_pi_process_exit_cleanup_listener_lifecycle
 test_pi_process_exit_cleanup_stops_arm_child
 test_opencode_primary_watch_plugin_static_wiring

--- a/tests/fm-pi-watch-extension.test.sh
+++ b/tests/fm-pi-watch-extension.test.sh
@@ -193,6 +193,232 @@ EOF
   pass "Pi custom tool returns text content and structured details"
 }
 
+test_pi_tool_survives_late_reload_active_tool_reset() {
+  local repo home plugin out status
+  repo="$TMP_ROOT/pi-reload-active-root"
+  home="$TMP_ROOT/pi-reload-active-home"
+  mkdir -p "$repo/bin" "$home/state" "$home/config"
+  install_pi_watch_extension_fixture "$repo"
+  plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
+  cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  chmod +x "$repo/bin/fm-watch-arm.sh"
+  out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" node --input-type=module 2>&1 <<'EOF'
+import { writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const handlers = new Map();
+let activeTools = ["read", "bash", "edit"];
+let apiActive = true;
+let tool = null;
+const pi = {
+  on(event, handler) {
+    const registered = handlers.get(event) ?? [];
+    registered.push(handler);
+    handlers.set(event, registered);
+  },
+  registerCommand() {},
+  registerTool(candidate) {
+    if (candidate.name === "fm_watch_arm_pi") tool = candidate;
+    activeTools = [...new Set([...activeTools, candidate.name])];
+  },
+  getActiveTools() {
+    if (!apiActive) throw new Error("extension ctx is stale");
+    return [...activeTools];
+  },
+  getAllTools() {
+    if (!apiActive) throw new Error("extension ctx is stale");
+    return tool ? [tool] : [];
+  },
+  setActiveTools(names) {
+    if (!apiActive) throw new Error("extension ctx is stale");
+    activeTools = [...names];
+  },
+  sendUserMessage: async () => {},
+};
+writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
+const mod = await import(pathToFileURL(process.env.PLUGIN).href);
+mod.default(pi);
+for (const handler of handlers.get("session_start") ?? []) {
+  await handler({ reason: "reload" }, {});
+}
+
+// Reproduce a later-loaded mode extension replacing the active safety allowlist.
+pi.setActiveTools(["read"]);
+if (activeTools.includes("fm_watch_arm_pi")) {
+  throw new Error("late active-tool reset did not reproduce the missing watcher tool");
+}
+for (const handler of handlers.get("resources_discover") ?? []) {
+  await handler({ reason: "reload" }, {});
+}
+if (JSON.stringify(activeTools) !== JSON.stringify(["read", "fm_watch_arm_pi"])) {
+  throw new Error(`watcher restoration changed the selected mode surface: ${JSON.stringify(activeTools)}`);
+}
+// Pi invalidates the captured extension API at shutdown. A post-handler timer
+// using getAllTools/setActiveTools would throw here, so prove no such callback remains.
+apiActive = false;
+await new Promise((resolve) => setTimeout(resolve, 50));
+if (!tool) throw new Error("Pi watch tool was not registered after reload");
+const result = await tool.execute("tool-call-after-reload", {}, undefined, undefined, {});
+if (!result.content[0]?.text.includes("started Pi extension arm child")) {
+  throw new Error(`watcher tool was not callable after reload: ${JSON.stringify(result)}`);
+}
+for (const handler of handlers.get("session_shutdown") ?? []) {
+  await handler({ reason: "quit" }, {});
+}
+EOF
+)
+  status=$?
+  expect_code 0 "$status" "Pi watcher tool must remain callable after a late reload active-tool reset"
+  [ -z "$out" ] || fail "Pi reload active-tool test printed output: $out"
+  pass "Pi watcher tool survives a late reload active-tool reset without widening the mode surface"
+}
+
+test_pi_reload_restart_sigterm_is_benign_only_after_verified_replacement() {
+  local repo home plugin out status
+  repo="$TMP_ROOT/pi-reload-restart-root"
+  home="$TMP_ROOT/pi-reload-restart-home"
+  mkdir -p "$repo/bin" "$home/state/.watch.lock" "$home/config"
+  install_pi_watch_extension_fixture "$repo"
+  plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
+  cat > "$repo/bin/fm-wake-lib.sh" <<'SH'
+fm_watcher_healthy() {
+  [ -f "${FM_REPLACEMENT_HEALTHY:?}" ] || return 1
+  FM_WATCHER_HEALTHY_PID=222
+}
+SH
+  : > "$repo/bin/fm-watch.sh"
+  cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
+#!/usr/bin/env bash
+if [ ! -f "${FM_FIRST_ARM_STARTED:?}" ]; then
+  : > "$FM_FIRST_ARM_STARTED"
+  trap 'exit 143' TERM INT
+  while :; do sleep 1; done
+fi
+printf 'watcher: started pid=222 (beacon fresh)\n' > "${FM_RESTART_LOG:?}"
+: > "${FM_REPLACEMENT_HEALTHY:?}"
+SH
+  chmod +x "$repo/bin/fm-watch-arm.sh"
+  out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" FM_FIRST_ARM_STARTED="$repo/first-arm" FM_REPLACEMENT_HEALTHY="$repo/replacement-healthy" FM_RESTART_LOG="$repo/restart.log" node --input-type=module 2>&1 <<'EOF'
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const mod = await import(pathToFileURL(process.env.PLUGIN).href);
+const prompts = [];
+function loadExtension() {
+  const handlers = new Map();
+  let tool = null;
+  const pi = {
+    on(event, handler) { handlers.set(event, handler); },
+    registerCommand() {},
+    registerTool(candidate) {
+      if (candidate.name === "fm_watch_arm_pi") tool = candidate;
+    },
+    getActiveTools() { return ["read", "fm_watch_arm_pi"]; },
+    setActiveTools() {},
+    sendUserMessage: async (message) => { prompts.push(message); },
+  };
+  mod.default(pi);
+  return { handlers, getTool: () => tool };
+}
+
+writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
+writeFileSync(`${process.env.FM_HOME}/state/.watch.lock/pid`, "111\n");
+const beforeReload = loadExtension();
+await beforeReload.getTool().execute("before-reload", {}, undefined, undefined, {});
+for (let i = 0; i < 50 && !existsSync(process.env.FM_FIRST_ARM_STARTED); i += 1) {
+  await new Promise((resolve) => setTimeout(resolve, 20));
+}
+if (!existsSync(process.env.FM_FIRST_ARM_STARTED)) throw new Error("initial arm did not start");
+await beforeReload.handlers.get("session_shutdown")?.({ reason: "reload" }, {});
+await new Promise((resolve) => setTimeout(resolve, 1200));
+const afterReload = loadExtension();
+const result = await afterReload.getTool().execute("after-reload", {}, undefined, undefined, {});
+if (!result.content[0]?.text.includes("started Pi extension arm child")) {
+  throw new Error(`replacement arm did not take ownership: ${JSON.stringify(result)}`);
+}
+for (let i = 0; i < 100 && !existsSync(process.env.FM_RESTART_LOG); i += 1) {
+  await new Promise((resolve) => setTimeout(resolve, 20));
+}
+if (!existsSync(process.env.FM_RESTART_LOG)) throw new Error("replacement arm did not start");
+const restart = readFileSync(process.env.FM_RESTART_LOG, "utf8").trim();
+if (!/^watcher: started pid=222 \(beacon fresh\)$/.test(restart)) {
+  throw new Error(`replacement was not verified fresh: ${restart}`);
+}
+await new Promise((resolve) => setTimeout(resolve, 300));
+if (prompts.some((message) => message.includes("fm-watch-arm.sh exited 143"))) {
+  throw new Error(`expected restart SIGTERM was reported as failure: ${prompts.join("\n")}`);
+}
+await afterReload.handlers.get("session_shutdown")?.({ reason: "quit" }, {});
+EOF
+)
+  status=$?
+  expect_code 0 "$status" "Pi reload restart SIGTERM must be benign after a verified fresh home watcher replaces it"
+  [ -z "$out" ] || fail "Pi verified-replacement test printed output: $out"
+  pass "Pi suppresses restart exit 143 only after a fresh home-scoped replacement is verified"
+}
+
+test_pi_reload_restart_sigterm_without_replacement_stays_failed() {
+  local repo home plugin out status
+  repo="$TMP_ROOT/pi-reload-no-replacement-root"
+  home="$TMP_ROOT/pi-reload-no-replacement-home"
+  mkdir -p "$repo/bin" "$home/state/.watch.lock" "$home/config"
+  install_pi_watch_extension_fixture "$repo"
+  plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
+  cat > "$repo/bin/fm-wake-lib.sh" <<'SH'
+fm_watcher_healthy() { return 1; }
+SH
+  : > "$repo/bin/fm-watch.sh"
+  cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
+#!/usr/bin/env bash
+trap 'exit 143' TERM INT
+: > "${FM_ARM_STARTED:?}"
+while :; do sleep 1; done
+SH
+  chmod +x "$repo/bin/fm-watch-arm.sh"
+  out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" FM_ARM_STARTED="$repo/arm-started" node --input-type=module 2>&1 <<'EOF'
+import { existsSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const handlers = new Map();
+let tool = null;
+let prompt = "";
+const pi = {
+  on(event, handler) { handlers.set(event, handler); },
+  registerCommand() {},
+  registerTool(candidate) {
+    if (candidate.name === "fm_watch_arm_pi") tool = candidate;
+  },
+  getActiveTools() { return ["read", "fm_watch_arm_pi"]; },
+  setActiveTools() {},
+  sendUserMessage: async (message) => { prompt = message; },
+};
+writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
+writeFileSync(`${process.env.FM_HOME}/state/.watch.lock/pid`, "111\n");
+const mod = await import(pathToFileURL(process.env.PLUGIN).href);
+mod.default(pi);
+await tool.execute("before-failed-reload", {}, undefined, undefined, {});
+for (let i = 0; i < 50 && !existsSync(process.env.FM_ARM_STARTED); i += 1) {
+  await new Promise((resolve) => setTimeout(resolve, 20));
+}
+if (!existsSync(process.env.FM_ARM_STARTED)) throw new Error("failed arm did not start");
+await handlers.get("session_shutdown")?.({ reason: "reload" }, {});
+for (let i = 0; i < 100 && !prompt; i += 1) {
+  await new Promise((resolve) => setTimeout(resolve, 100));
+}
+if (!prompt.includes("watcher: FAILED - fm-watch-arm.sh exited 143")) {
+  throw new Error(`missing real restart failure: ${prompt}`);
+}
+EOF
+)
+  status=$?
+  expect_code 0 "$status" "Pi reload restart SIGTERM must remain a failure without a verified replacement"
+  [ -z "$out" ] || fail "Pi missing-replacement test printed output: $out"
+  pass "Pi keeps restart exit 143 actionable when no fresh home-scoped replacement exists"
+}
+
 test_pi_process_exit_cleanup_listener_lifecycle() {
   local repo home plugin out status
   repo="$TMP_ROOT/pi-exit-listener-root"
@@ -713,6 +939,9 @@ test_tracked_extension_present_and_self_hashing
 test_spawn_template_mentions_pi_watch_placeholder
 test_pi_extension_reports_external_healthy_watcher
 test_pi_tool_returns_agent_tool_result
+test_pi_tool_survives_late_reload_active_tool_reset
+test_pi_reload_restart_sigterm_is_benign_only_after_verified_replacement
+test_pi_reload_restart_sigterm_without_replacement_stays_failed
 test_pi_process_exit_cleanup_listener_lifecycle
 test_pi_process_exit_cleanup_stops_arm_child
 test_opencode_primary_watch_plugin_static_wiring

--- a/tests/fm-pi-watch-extension.test.sh
+++ b/tests/fm-pi-watch-extension.test.sh
@@ -310,18 +310,27 @@ const prompts = [];
 function loadExtension() {
   const handlers = new Map();
   let tool = null;
+  let apiActive = true;
   const pi = {
     on(event, handler) { handlers.set(event, handler); },
     registerCommand() {},
     registerTool(candidate) {
       if (candidate.name === "fm_watch_arm_pi") tool = candidate;
     },
-    getActiveTools() { return ["read", "fm_watch_arm_pi"]; },
-    setActiveTools() {},
-    sendUserMessage: async (message) => { prompts.push(message); },
+    getActiveTools() {
+      if (!apiActive) throw new Error("extension ctx is stale");
+      return ["read", "fm_watch_arm_pi"];
+    },
+    setActiveTools() {
+      if (!apiActive) throw new Error("extension ctx is stale");
+    },
+    sendUserMessage: async (message) => {
+      if (!apiActive) throw new Error("extension ctx is stale");
+      prompts.push(message);
+    },
   };
   mod.default(pi);
-  return { handlers, getTool: () => tool };
+  return { handlers, getTool: () => tool, invalidate: () => { apiActive = false; } };
 }
 
 writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
@@ -333,6 +342,7 @@ for (let i = 0; i < 50 && !existsSync(process.env.FM_FIRST_ARM_STARTED); i += 1)
 }
 if (!existsSync(process.env.FM_FIRST_ARM_STARTED)) throw new Error("initial arm did not start");
 await beforeReload.handlers.get("session_shutdown")?.({ reason: "reload" }, {});
+beforeReload.invalidate();
 await new Promise((resolve) => setTimeout(resolve, 1200));
 const afterReload = loadExtension();
 const result = await afterReload.getTool().execute("after-reload", {}, undefined, undefined, {});
@@ -382,29 +392,44 @@ SH
 import { existsSync, writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
-const handlers = new Map();
-let tool = null;
 let prompt = "";
-const pi = {
-  on(event, handler) { handlers.set(event, handler); },
-  registerCommand() {},
-  registerTool(candidate) {
-    if (candidate.name === "fm_watch_arm_pi") tool = candidate;
-  },
-  getActiveTools() { return ["read", "fm_watch_arm_pi"]; },
-  setActiveTools() {},
-  sendUserMessage: async (message) => { prompt = message; },
-};
+const mod = await import(pathToFileURL(process.env.PLUGIN).href);
+function loadExtension() {
+  const handlers = new Map();
+  let tool = null;
+  let apiActive = true;
+  const pi = {
+    on(event, handler) { handlers.set(event, handler); },
+    registerCommand() {},
+    registerTool(candidate) {
+      if (candidate.name === "fm_watch_arm_pi") tool = candidate;
+    },
+    getActiveTools() {
+      if (!apiActive) throw new Error("extension ctx is stale");
+      return ["read", "fm_watch_arm_pi"];
+    },
+    setActiveTools() {
+      if (!apiActive) throw new Error("extension ctx is stale");
+    },
+    sendUserMessage: async (message) => {
+      if (!apiActive) throw new Error("extension ctx is stale");
+      prompt = message;
+    },
+  };
+  mod.default(pi);
+  return { handlers, getTool: () => tool, invalidate: () => { apiActive = false; } };
+}
 writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
 writeFileSync(`${process.env.FM_HOME}/state/.watch.lock/pid`, "111\n");
-const mod = await import(pathToFileURL(process.env.PLUGIN).href);
-mod.default(pi);
-await tool.execute("before-failed-reload", {}, undefined, undefined, {});
+const beforeReload = loadExtension();
+await beforeReload.getTool().execute("before-failed-reload", {}, undefined, undefined, {});
 for (let i = 0; i < 50 && !existsSync(process.env.FM_ARM_STARTED); i += 1) {
   await new Promise((resolve) => setTimeout(resolve, 20));
 }
 if (!existsSync(process.env.FM_ARM_STARTED)) throw new Error("failed arm did not start");
-await handlers.get("session_shutdown")?.({ reason: "reload" }, {});
+await beforeReload.handlers.get("session_shutdown")?.({ reason: "reload" }, {});
+beforeReload.invalidate();
+loadExtension();
 for (let i = 0; i < 100 && !prompt; i += 1) {
   await new Promise((resolve) => setTimeout(resolve, 100));
 }

--- a/tests/fm-pi-watch-extension.test.sh
+++ b/tests/fm-pi-watch-extension.test.sh
@@ -444,6 +444,52 @@ EOF
   pass "Pi keeps restart exit 143 actionable when no fresh home-scoped replacement exists"
 }
 
+test_pi_reload_restart_sigterm_requires_valid_previous_pid() {
+  local repo home plugin out status
+  repo="$TMP_ROOT/pi-reload-invalid-previous-pid-root"
+  home="$TMP_ROOT/pi-reload-invalid-previous-pid-home"
+  mkdir -p "$repo/bin" "$home/state" "$home/config"
+  install_pi_watch_extension_fixture "$repo"
+  plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
+  cat > "$repo/bin/fm-wake-lib.sh" <<'SH'
+fm_watcher_healthy() {
+  FM_WATCHER_HEALTHY_PID=222
+}
+SH
+  : > "$repo/bin/fm-watch.sh"
+  out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" node --input-type=module 2>&1 <<'EOF'
+import { existsSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const handoff = `${process.env.FM_HOME}/state/.pi-watch-restart-handoff`;
+const prompts = [];
+const mod = await import(pathToFileURL(process.env.PLUGIN).href);
+writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
+
+for (const previousPid of ["", "invalid", "0", "1"]) {
+  writeFileSync(handoff, `${JSON.stringify({ previousPid, complete: true, stdout: "", stderr: "", code: 143, reason: "" })}\n`);
+  mod.default({
+    on() {},
+    registerCommand() {},
+    registerTool() {},
+    sendUserMessage: async (message) => prompts.push(message),
+  });
+  for (let i = 0; i < 50 && existsSync(handoff); i += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  if (existsSync(handoff)) throw new Error(`invalid previous PID handoff was not delivered: ${JSON.stringify(previousPid)}`);
+}
+if (prompts.length !== 4 || prompts.some((message) => !message.includes("fm-watch-arm.sh exited 143"))) {
+  throw new Error(`invalid previous PIDs suppressed restart failures: ${prompts.join("\n")}`);
+}
+EOF
+)
+  status=$?
+  expect_code 0 "$status" "Pi reload restart SIGTERM suppression must require a valid previous watcher PID"
+  [ -z "$out" ] || fail "Pi invalid-previous-PID test printed output: $out"
+  pass "Pi keeps restart exit 143 actionable without a valid previous watcher PID"
+}
+
 test_pi_restart_handoff_requires_session_lock_ownership() {
   local repo home plugin out status
   repo="$TMP_ROOT/pi-restart-handoff-lock-root"
@@ -1020,6 +1066,7 @@ test_pi_tool_returns_agent_tool_result
 test_pi_tool_survives_late_reload_active_tool_reset
 test_pi_reload_restart_sigterm_is_benign_only_after_verified_replacement
 test_pi_reload_restart_sigterm_without_replacement_stays_failed
+test_pi_reload_restart_sigterm_requires_valid_previous_pid
 test_pi_restart_handoff_requires_session_lock_ownership
 test_pi_process_exit_cleanup_listener_lifecycle
 test_pi_process_exit_cleanup_stops_arm_child

--- a/tests/fm-pi-watch-extension.test.sh
+++ b/tests/fm-pi-watch-extension.test.sh
@@ -444,6 +444,59 @@ EOF
   pass "Pi keeps restart exit 143 actionable when no fresh home-scoped replacement exists"
 }
 
+test_pi_restart_handoff_requires_session_lock_ownership() {
+  local repo home plugin out status
+  repo="$TMP_ROOT/pi-restart-handoff-lock-root"
+  home="$TMP_ROOT/pi-restart-handoff-lock-home"
+  mkdir -p "$repo/bin" "$home/state" "$home/config"
+  install_pi_watch_extension_fixture "$repo"
+  plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
+  out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" node --input-type=module 2>&1 <<'EOF'
+import { spawn } from "node:child_process";
+import { existsSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const handoff = `${process.env.FM_HOME}/state/.pi-watch-restart-handoff`;
+const prompts = [];
+const mod = await import(pathToFileURL(process.env.PLUGIN).href);
+function loadExtension() {
+  mod.default({
+    on() {},
+    registerCommand() {},
+    registerTool() {},
+    sendUserMessage: async (message) => prompts.push(message),
+  });
+}
+
+const otherSession = spawn("sleep", ["30"]);
+writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${otherSession.pid}\n`);
+writeFileSync(handoff, `${JSON.stringify({ previousPid: "111", complete: true, stdout: "", stderr: "", code: 2, reason: "" })}\n`);
+loadExtension();
+await new Promise((resolve) => setTimeout(resolve, 200));
+if (prompts.length !== 0) throw new Error("read-only Pi session reported another session's restart handoff");
+if (!existsSync(handoff)) throw new Error("read-only Pi session deleted another session's restart handoff");
+
+writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
+loadExtension();
+for (let i = 0; i < 50 && prompts.length === 0; i += 1) {
+  await new Promise((resolve) => setTimeout(resolve, 20));
+}
+if (!prompts.some((message) => message.includes("fm-watch-arm.sh exited 2"))) {
+  throw new Error(`owning Pi session did not report restart handoff: ${prompts.join("\n")}`);
+}
+for (let i = 0; i < 50 && existsSync(handoff); i += 1) {
+  await new Promise((resolve) => setTimeout(resolve, 20));
+}
+if (existsSync(handoff)) throw new Error("owning Pi session did not clear restart handoff after delivery");
+otherSession.kill("SIGTERM");
+EOF
+)
+  status=$?
+  expect_code 0 "$status" "Pi restart handoff processing and deletion must require session lock ownership"
+  [ -z "$out" ] || fail "Pi restart-handoff lock test printed output: $out"
+  pass "Pi restart handoff remains reserved for the session-lock owner"
+}
+
 test_pi_process_exit_cleanup_listener_lifecycle() {
   local repo home plugin out status
   repo="$TMP_ROOT/pi-exit-listener-root"
@@ -967,6 +1020,7 @@ test_pi_tool_returns_agent_tool_result
 test_pi_tool_survives_late_reload_active_tool_reset
 test_pi_reload_restart_sigterm_is_benign_only_after_verified_replacement
 test_pi_reload_restart_sigterm_without_replacement_stays_failed
+test_pi_restart_handoff_requires_session_lock_ownership
 test_pi_process_exit_cleanup_listener_lifecycle
 test_pi_process_exit_cleanup_stops_arm_child
 test_opencode_primary_watch_plugin_static_wiring


### PR DESCRIPTION
## Intent

Fix the Firstmate Pi primary watcher tool disappearing after /reload when a later-loaded extension resets the active tool list. Keep only fm_watch_arm_pi active alongside the current selected safety allowlist, without reactivating unrelated tools or weakening plan/review/validation restrictions, and avoid delayed callbacks that use stale extension APIs. Preserve the human command, tool API, attached process wake delivery, and clean shutdown. Treat restart exit 143 as benign only after the canonical home-scoped health predicate verifies a different watcher with a fresh beacon, while retaining genuine failure reporting. Add deterministic and isolated live reload coverage and record exact empirical evidence in the Pi supervision documentation.

## What Changed

- Captain, keep only `fm_watch_arm_pi` active alongside Pi’s current safety allowlist after reloads and later tool-surface resets.
- Transfer watcher restart outcomes safely between extension generations, suppressing exit 143 only when a different healthy watcher is verified and retaining genuine failure delivery.
- Add deterministic lifecycle tests, isolated Workflow Suite live-reload coverage, and documented empirical evidence.

## Risk Assessment

✅ Low: The change is well-bounded, preserves the selected tool allowlist, avoids stale Pi API calls after shutdown, and safely scopes restart handoff handling.

## Testing

Completed 1 recorded test check.

- Outcome: ⚠️ 1 error across 1 run (12m23s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (4) ✅</summary>

- 🚨 `.pi/extensions/fm-primary-pi-watch.ts:183` - The required criterion says to “avoid delayed callbacks that use stale extension APIs.” After session shutdown, this handler waits up to five seconds for replacement health and may then call sendWake() through the old captured pi.sendUserMessage API. If that API is invalidated during reload, genuine exit-143 failure reporting is silently lost by the catch block. Move verification and failure delivery to the current extension generation or otherwise avoid using the unloaded API.
- ⚠️ `tests/fm-pi-primary-live-e2e.test.sh:124` - The live test copies the user&#39;s long-lived Pi auth file beneath the repository in an unignored .pi-live-e2e.* directory. An abrupt termination can leave credentials exposed to git status or accidental staging. Use a restrictive temporary directory outside the source tree or avoid materializing the credential under the repository.

🔧 Fix: Captain, preserve Pi reload wake delivery safely
1 error still open:
- 🚨 `.pi/extensions/fm-primary-pi-watch.ts:310` - reportPriorRestart() runs unconditionally without verifying session-lock ownership. A read-only Pi session sharing the same FM_HOME can consume and delete the owning session&#39;s restart handoff, contradicting the requirement to retain genuine exit-143 failure reporting. Gate handoff processing and deletion against the existing ownership predicate.

🔧 Fix: Captain, gate Pi restart handoffs by session ownership
1 error still open:
- 🚨 `.pi/extensions/fm-primary-pi-watch.ts:201` - The required criterion says exit 143 is benign only after verifying a different watcher. If reload occurs before the arm child records `.watch.lock/pid`, `previousPid` is empty; this check then accepts any briefly healthy PID, including the old watcher still shutting down, as “different.” Do not suppress exit 143 unless a valid prior watcher PID was captured and the canonical predicate returns another PID.

🔧 Fix: Captain, require valid prior Pi watcher PID
3 errors still open:
- 🚨 `.pi/extensions/fm-primary-pi-watch.ts:270` - The requirement says to keep `fm_watch_arm_pi` active “alongside the current selected safety allowlist.” Restoration runs only during `resources_discover`, which Pi emits at startup/reload. Workflow Suite calls `setActiveTools(...)` during later plan/review/validation transitions, so the watcher tool disappears again until another reload. Reassert it after runtime tool-surface changes without restoring any unrelated tools.
- 🚨 `.pi/extensions/fm-primary-pi-watch.ts:202` - The fixed, unversioned handoff file can be cleared or overwritten by an older generation&#39;s delayed health check during a rapid second reload. That can delete the newer reload&#39;s handoff and contradict the requirement to retain genuine failure reporting. Add generation ownership/CAS and clear only the exact handoff originally read.
- 🚨 `.pi/extensions/fm-primary-pi-watch.ts:197` - If reload writes `complete:false` but the prior child never records its close result, every subsequent generation waits five seconds and returns without reporting or clearing the handoff. Treat an owned handoff that remains incomplete at the deadline as an actionable failure so genuine shutdown failures are retained.

🔧 Fix: Captain, preserve Pi watcher runtime and restart handoffs
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Test** - 1 error</summary>

- 🚨 tests failed with exit code 1
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
