### PR TITLE
fix(composer): normalize U+00A0 pad so idle composer reads empty

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -120,6 +120,7 @@ Firstmate launches every claude crewmate and secondmate with `CLAUDE_CODE_ENABLE
 The CLI's `--prompt-suggestions` flag is print/SDK-mode only and does not suppress the interactive composer ghost text, verified empirically on v2.1.186.
 As defense in depth for any pane that flag cannot reach, including the captain's own firstmate composer that away-mode reads, the shared `fm_composer_strip_ghost` extractor in `bin/fm-composer-lib.sh` removes dim/faint SGR 2 ghost runs before pending-input classification on both ANSI-capable readers (tmux and herdr).
 Its broader dark-TRUECOLOR placeholder handling and dark-theme tradeoff are documented in `docs/herdr-backend.md`'s 2026-07-10 incident record.
+Separately, claude 2.1.x pads its idle-empty composer prompt row with a non-breaking space (`❯ `, U+00A0) rather than an ASCII space; `fm_composer_classify_content` normalizes U+00A0 so that idle row reads `empty`, not `pending` (the 2026-07-14 away-mode wedge; see `docs/herdr-backend.md`'s 2026-07-14 incident record).
 That styled capture is internal to the boolean detector only.
 `fm-peek` and every other human or LLM-facing capture path stays plain `tmux capture-pane` with no escape codes.
 

--- a/bin/fm-composer-lib.sh
+++ b/bin/fm-composer-lib.sh
@@ -180,8 +180,21 @@ fm_composer_idle_matches() {
 }
 
 fm_composer_classify_content() {  # <bordered> <content> [idle_re] [idle_case] [plain_content]
-  local bordered=$1 content=$2 idle_re=${3:-} idle_case=${4:-sensitive} plain_content
+  local bordered=$1 content=$2 idle_re=${3:-} idle_case=${4:-sensitive} plain_content nbsp
   plain_content=${5:-$content}
+  # Normalize the non-breaking space (U+00A0, bytes C2 A0) to an ordinary space.
+  # Some harnesses PAD an otherwise-empty composer with it - claude 2.1.x renders
+  # its idle prompt row as "❯ " (verified read-only from a live wedged
+  # primary claude-on-herdr pane, docs/herdr-backend.md 2026-07-14 incident). U+00A0
+  # is NOT in the ASCII [:space:] class the emptiness trims below use, so without
+  # this an idle-empty composer whose only remaining content is that pad trims to a
+  # lone U+00A0 after the prompt glyph is stripped and misreads as 'pending' real
+  # input, deferring away-mode injection forever. Real typed text keeps its own
+  # non-whitespace bytes, so it still reads 'pending'; whitespace-only input already
+  # read 'empty' with an ASCII space, and this only extends that to U+00A0.
+  nbsp=$'\xc2\xa0'
+  content=${content//"$nbsp"/ }
+  plain_content=${plain_content//"$nbsp"/ }
   if [ "$bordered" != 1 ] && [ -z "$content" ] && [ -n "$plain_content" ]; then
     case "$plain_content" in
       '❯'|'›') printf 'empty'; return 0 ;;

--- a/bin/fm-composer-lib.sh
+++ b/bin/fm-composer-lib.sh
@@ -195,6 +195,10 @@ fm_composer_classify_content() {  # <bordered> <content> [idle_re] [idle_case] [
   nbsp=$'\xc2\xa0'
   content=${content//"$nbsp"/ }
   plain_content=${plain_content//"$nbsp"/ }
+  content="${content#"${content%%[![:space:]]*}"}"
+  content="${content%"${content##*[![:space:]]}"}"
+  plain_content="${plain_content#"${plain_content%%[![:space:]]*}"}"
+  plain_content="${plain_content%"${plain_content##*[![:space:]]}"}"
   if [ "$bordered" != 1 ] && [ -z "$content" ] && [ -n "$plain_content" ]; then
     case "$plain_content" in
       '❯'|'›') printf 'empty'; return 0 ;;

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -708,6 +708,40 @@ The luminance rule assumes a dark terminal theme (the fleet reality); the SGR-2 
 **Resolved: backend-independent wedge alarm.** The max-defer wedge alarm (`inject_wedge_alarm`, `bin/fm-supervise-daemon.sh`) formerly alarmed into the void because its only active signal was a tmux client status-line flash, skipped for herdr, leaving only the passive `state/.subsuper-inject-wedged` marker.
 It now also attempts a configurable active alert independent of the supervisor backend; [`wedge-alarm.md`](wedge-alarm.md) owns its channels and verification evidence.
 
+## Incident (2026-07-14): away-mode injection wedged on the primary claude composer's non-breaking-space pad
+
+The captain found away-mode had never injected: the sub-supervisor daemon deferred every escalation and eventually wrote `state/.subsuper-inject-wedged`, while its own target resolution was correct (`FM_SUPERVISOR_TARGET=default:wB:p1`, the firstmate primary's herdr pane).
+The daemon log (`state/.supervise-daemon.log`) repeated on nearly every housekeeping tick:
+
+```
+inject deferred: supervisor composer not confirmed-empty (state=pending: pending input, dead-shell prompt, or unreadable pane)
+```
+
+The `state=pending` verdict means the shared classifier read the idle-empty primary composer as holding unsubmitted text, so `inject_msg`'s "inject only into an affirmatively-`empty` composer" guard deferred forever - the away-mode LLM was never woken and every hand-off stalled until the captain manually poked it.
+
+**Root cause.** claude 2.1.208 pads its idle-empty composer prompt row with a NON-BREAKING SPACE (U+00A0, bytes `C2 A0`), not an ASCII space.
+Captured read-only from the live wedged primary claude-on-herdr pane `default:wB:p1` on 2026-07-14 (no Herdr lifecycle touched):
+
+```
+$ herdr --session default pane read wB:p1 --source recent --lines 30 --format ansi | cat -v
+^[[0m^[[38;5;246mM-bM-^]M-/M-BM-  ^[[0m       # \033[0m\033[38;5;246m❯\302\240 \033[0m  ->  "❯" + U+00A0 + space
+```
+
+The shared classifier (`fm_composer_classify_content`, `bin/fm-composer-lib.sh`) strips the leading prompt glyph and then judges emptiness by trimming the ASCII `[:space:]` class only.
+U+00A0 is not in that class, so after the `❯` glyph is stripped a lone U+00A0 remained and read as real `pending` input.
+The `❯` glyph's 256-colour `38;5;246` styling was NOT the cause - `fm_composer_strip_ghost` correctly keeps a 256-colour foreground (it is palette-dependent, never used for ghost text), so the glyph is kept and correctly recognized; the U+00A0 pad alone was decisive.
+This affects every backend that routes through the shared owner (the same U+00A0 pad appears on the tmux path too), not just herdr.
+
+**Reproduction (deterministic, from the exact captured bytes).**
+Feeding the live composer row through the real `fm_backend_herdr_composer_state` (via the fake-`herdr` capture harness) returned `pending` before the fix and `empty` after, and the direct classifier returned `pending`/`empty` on `❯\302\240` for the same reason.
+
+**Fix (task fm-inject-wedge-fix).** `fm_composer_classify_content` now normalizes U+00A0 to an ordinary space before its emptiness trims, so an idle-empty composer padded with U+00A0 reads `empty` (safe to inject).
+The change is surgical: real typed text keeps its own non-whitespace bytes and still reads `pending` (with or without a leading U+00A0 pad), a bare shell prompt still reads `unknown`, and whitespace-only input - which already read `empty` with an ASCII space - now reads `empty` with U+00A0 too.
+
+**Regression coverage.** `tests/fm-composer-lib.test.sh`'s `test_nbsp_padded_composer_is_empty` pins the shared owner directly (U+00A0-padded idle -> `empty`, U+00A0-only -> `empty`, real text after a U+00A0 pad -> `pending`).
+`tests/fm-backend-herdr.test.sh` feeds the exact captured live bytes through the real reader: `test_composer_state_claude_nbsp_padded_idle_is_empty` (`empty`) and `test_composer_state_claude_nbsp_row_with_real_text_is_pending` (`pending`).
+`bin/fm-lint.sh` passes clean.
+
 ## Native `pane.agent_status_changed` push escalation (immediate blocked wake)
 
 Herdr exposes a native, push-based agent-state event stream, and firstmate folds it into the watcher so a crew entering `blocked` (waiting on the human at a permission/trust dialog, an interactive menu, or a wedged prompt) wakes its supervisor sub-second instead of after the ~240s stale-pane wedge timer.

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -738,7 +738,7 @@ Feeding the live composer row through the real `fm_backend_herdr_composer_state`
 **Fix (task fm-inject-wedge-fix).** `fm_composer_classify_content` now normalizes U+00A0 to an ordinary space before its emptiness trims, so an idle-empty composer padded with U+00A0 reads `empty` (safe to inject).
 The change is surgical: real typed text keeps its own non-whitespace bytes and still reads `pending` (with or without a leading U+00A0 pad), a bare shell prompt still reads `unknown`, and whitespace-only input - which already read `empty` with an ASCII space - now reads `empty` with U+00A0 too.
 
-**Regression coverage.** `tests/fm-composer-lib.test.sh`'s `test_nbsp_padded_composer_is_empty` pins the shared owner directly (U+00A0-padded idle -> `empty`, U+00A0-only -> `empty`, real text after a U+00A0 pad -> `pending`).
+**Regression coverage.** `tests/fm-composer-lib.test.sh`'s `test_nbsp_padded_composer_is_empty` pins the shared owner directly (U+00A0-padded idle -> `empty`, U+00A0-only -> `empty`, real text after a U+00A0 pad -> `pending`, bare U+00A0-padded shell glyph -> `unknown`).
 `tests/fm-backend-herdr.test.sh` feeds the exact captured live bytes through the real reader: `test_composer_state_claude_nbsp_padded_idle_is_empty` (`empty`) and `test_composer_state_claude_nbsp_row_with_real_text_is_pending` (`pending`).
 `bin/fm-lint.sh` passes clean.
 

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -1015,6 +1015,41 @@ test_composer_state_grok_bright_truecolor_real_text_is_pending() {
   pass "fm_backend_herdr_composer_state: grok's real bright typed input still reads pending"
 }
 
+# THE 2026-07-14 away-mode wedge (task fm-inject-wedge-fix). Captured read-only
+# from the live wedged primary claude-on-herdr pane default:wB:p1 on 2026-07-14:
+# claude 2.1.208 renders its idle-empty composer prompt row as
+# "\x1b[0m\x1b[38;5;246m❯\xc2\xa0 \x1b[0m" - the "❯" glyph followed by a
+# NON-BREAKING SPACE (U+00A0, bytes C2 A0) pad, not an ASCII space. herdr's
+# `pane read --format ansi` preserves it. The shared classifier only trimmed the
+# ASCII [:space:] class, so after the "❯" glyph was stripped a lone U+00A0
+# remained and read as real `pending` input - the daemon deferred EVERY away-mode
+# injection ("supervisor composer not confirmed-empty (state=pending...)"),
+# wedging away-mode all night. The fix normalizes U+00A0 to a space in the shared
+# owner so the row reads empty (safe to inject).
+test_composer_state_claude_nbsp_padded_idle_is_empty() {
+  local dir log resp fb out
+  dir="$TMP_ROOT/composer-claude-nbsp-idle"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '\xe2\x9c\xbb Brewed for 2s\n\n\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\n\x1b[0m\x1b[38;5;246m\xe2\x9d\xaf\xc2\xa0 \x1b[0m\n\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\n  Opus 4.8   95%%\n' > "$resp/1.out"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_composer_state default:wB:p1' "$ROOT" )
+  [ "$out" = empty ] || fail "the 2026-07-14 wedge shape - claude's idle '❯' + U+00A0 pad - must read empty, got '$out' (regression: this false-pending wedged away-mode injection)"
+  pass "fm_backend_herdr_composer_state: claude's U+00A0-padded idle composer (the 2026-07-14 wedge shape) reads empty"
+}
+
+# The same idle prompt row, but with REAL typed text after the U+00A0 pad, must
+# still read pending so the fix never weakens captain-input protection.
+test_composer_state_claude_nbsp_row_with_real_text_is_pending() {
+  local dir log resp fb out
+  dir="$TMP_ROOT/composer-claude-nbsp-real"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\n\x1b[0m\x1b[38;5;246m\xe2\x9d\xaf\xc2\xa0land pr 416 now\x1b[0m\n\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\n' > "$resp/1.out"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_composer_state default:wB:p1' "$ROOT" )
+  [ "$out" = pending ] || fail "real typed text after a U+00A0 pad must still read pending, got '$out'"
+  pass "fm_backend_herdr_composer_state: real typed text after a U+00A0 pad still reads pending"
+}
+
 test_composer_state_codex_bare_prompt_glyph_is_empty() {
   local dir log resp fb out
   dir="$TMP_ROOT/composer-codex-bare"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
@@ -2027,6 +2062,8 @@ test_composer_state_claude_dim_prompt_suggestion_ghost_is_empty
 test_composer_state_claude_dim_ghost_row_with_real_text_is_pending
 test_composer_state_grok_dark_truecolor_placeholder_is_empty
 test_composer_state_grok_bright_truecolor_real_text_is_pending
+test_composer_state_claude_nbsp_padded_idle_is_empty
+test_composer_state_claude_nbsp_row_with_real_text_is_pending
 test_composer_state_codex_bare_prompt_glyph_is_empty
 test_composer_state_codex_faint_suggestion_is_empty
 test_composer_state_codex_non_faint_same_text_is_pending

--- a/tests/fm-composer-lib.test.sh
+++ b/tests/fm-composer-lib.test.sh
@@ -114,6 +114,28 @@ test_idle_placeholder_case_mode_is_explicit() {
   pass "fm_composer_classify_content: idle matching preserves the caller's case mode"
 }
 
+# --- Non-breaking-space (U+00A0) composer padding reads empty ---------------
+# THE 2026-07-14 away-mode wedge: claude 2.1.x pads its idle-empty composer row
+# with a non-breaking space ("❯ "), not an ASCII space. U+00A0 is not in the
+# ASCII [:space:] class the emptiness trims use, so before the fix a lone U+00A0
+# left after the prompt glyph was stripped read as `pending` real input and
+# deferred away-mode injection forever. The fix normalizes U+00A0 to a space so an
+# idle-empty composer reads `empty`, while real typed text (with or without a
+# leading U+00A0) still reads `pending`.
+test_nbsp_padded_composer_is_empty() {
+  local nbsp out
+  nbsp=$(printf '\xc2\xa0')
+  # bare claude idle composer: agent glyph + U+00A0 pad, nothing typed.
+  out=$(classify 0 "❯${nbsp}"); [ "$out" = empty ] || fail "an idle '❯'+U+00A0 composer must read empty, got '$out'"
+  # bordered idle composer padded with U+00A0.
+  out=$(classify 1 ">${nbsp}"); [ "$out" = empty ] || fail "an idle bordered '>'+U+00A0 composer must read empty, got '$out'"
+  # U+00A0-only content (all padding, no glyph) is still empty.
+  out=$(classify 1 "${nbsp}"); [ "$out" = empty ] || fail "a U+00A0-only composer must read empty, got '$out'"
+  # SAFETY: real typed text after a U+00A0 pad must still read pending.
+  out=$(classify 0 "❯${nbsp}land pr 416 now"); [ "$out" = pending ] || fail "real text after a U+00A0 pad must stay pending, got '$out'"
+  pass "fm_composer_classify_content: a U+00A0-padded idle composer reads empty, real text after U+00A0 stays pending (2026-07-14 wedge)"
+}
+
 # --- Real text is pending ---------------------------------------------------
 
 test_real_text_is_pending() {
@@ -133,4 +155,5 @@ test_agent_glyphs_are_empty_bordered_and_bare
 test_empty_content_is_empty
 test_idle_placeholder_is_empty
 test_idle_placeholder_case_mode_is_explicit
+test_nbsp_padded_composer_is_empty
 test_real_text_is_pending

--- a/tests/fm-composer-lib.test.sh
+++ b/tests/fm-composer-lib.test.sh
@@ -133,7 +133,15 @@ test_nbsp_padded_composer_is_empty() {
   out=$(classify 1 "${nbsp}"); [ "$out" = empty ] || fail "a U+00A0-only composer must read empty, got '$out'"
   # SAFETY: real typed text after a U+00A0 pad must still read pending.
   out=$(classify 0 "❯${nbsp}land pr 416 now"); [ "$out" = pending ] || fail "real text after a U+00A0 pad must stay pending, got '$out'"
-  pass "fm_composer_classify_content: a U+00A0-padded idle composer reads empty, real text after U+00A0 stays pending (2026-07-14 wedge)"
+  # SAFETY: a BARE shell prompt glyph padded with U+00A0 must read unknown (a
+  # dead shell, never a safe injection target), not empty. The pad must collapse
+  # back to the lone glyph and reach the shell-glyph exact-match branch.
+  for g in '>' '$' '%' '#'; do
+    out=$(classify 0 "${g}${nbsp}")
+    [ "$out" = unknown ] \
+      || fail "a bare shell glyph '$g'+U+00A0 must read unknown (dead shell), got '$out'"
+  done
+  pass "fm_composer_classify_content: a U+00A0-padded idle composer reads empty, real text after U+00A0 stays pending, a bare U+00A0-padded shell glyph stays unknown (2026-07-14 wedge)"
 }
 
 # --- Real text is pending ---------------------------------------------------


### PR DESCRIPTION
## Intent

Fix the away-mode sub-supervisor's broken wake path: the daemon deferred every escalation injection into the firstmate primary because the shared composer-emptiness classifier misread the idle-empty primary Claude composer as 'pending' (unsubmitted input), wedging away-mode autonomy so no task hand-off advanced without the captain manually poking it.

Root cause (verified read-only from the live wedged primary claude-on-herdr pane default:wB:p1 on 2026-07-14): Claude 2.1.x pads its idle-empty composer prompt row with a NON-BREAKING SPACE (U+00A0, bytes C2 A0), not an ASCII space. The shared classifier fm_composer_classify_content (bin/fm-composer-lib.sh) judged emptiness by trimming only the ASCII [:space:] class, so after stripping the leading prompt glyph a lone U+00A0 remained and read as real 'pending' input; the daemon's inject_msg guard requires an affirmatively-'empty' verdict, so it deferred forever. The 256-color glyph styling and prior dim/truecolor-ghost handling were NOT the cause; U+00A0 alone was decisive. The bug affects every backend routing through the shared owner (same pad appears on the tmux path), which is why the fix lives in the one shared classifier, not the herdr adapter.

Fix (deliberately surgical, per the hard safety contract): normalize U+00A0 to an ordinary space in fm_composer_classify_content before its emptiness trims. Chosen over widening the 'empty' match or making strip_ghost drop U+00A0, which risk over-stripping. The safety triad is preserved and proven: idle-empty (incl. U+00A0 pad) -> empty (inject OK); real typed text, even after a U+00A0 pad -> pending (defer); bare shell prompt / unreadable pane -> unknown (defer). A false 'empty' would let the daemon type over the captain's half-typed input, so this only extends the existing ASCII-whitespace-only-is-empty behavior to U+00A0.

Also added: colocated regression tests (tests/fm-composer-lib.test.sh pins the shared owner directly; tests/fm-backend-herdr.test.sh feeds the exact captured live bytes through the real fm_backend_herdr_composer_state), a dated incident record in docs/herdr-backend.md with the exact read-only capture commands/output, and a one-line cross-reference in the harness-adapters skill. Reproduction respected the brief's herdr-lab-not-enabled gate by capturing real bytes read-only rather than driving any herdr lifecycle.

## What Changed

- `fm_composer_classify_content` (`bin/fm-composer-lib.sh`) now normalizes the non-breaking space (U+00A0, bytes C2 A0) that Claude 2.1.x pads its idle-empty composer prompt row with to an ordinary space before its emptiness trims, so an idle-empty composer (including the U+00A0-padded row) reads `empty` instead of `pending`; real typed text after a U+00A0 pad still reads `pending`.
- Added a re-trim of ASCII whitespace immediately after the U+00A0 normalization so a BARE shell prompt glyph (`>`/`$`/`%`/`#`) padded with U+00A0 collapses back to the lone glyph and still reads `unknown` (dead shell, unsafe to inject) instead of falling through to `empty`.
- Added regression tests pinning the shared classifier and the herdr reader against the exact captured live bytes (`tests/fm-composer-lib.test.sh`, `tests/fm-backend-herdr.test.sh`), and recorded the 2026-07-14 away-mode wedge incident in `docs/herdr-backend.md` with a one-line cross-reference in the harness-adapters skill.

## Risk Assessment

✅ Low: The FR-1 safety regression is correctly and completely fixed (re-trim after U+00A0 normalize restores bare-shell-glyph `unknown`), verified empirically across all required safety-triad cases, the `plain_content` branch, and pre-existing cases; the only remaining note is an informational inline-documentation gap on a load-bearing line.

## Testing

Completed 1 recorded test check.

- Outcome: ⚠️ 1 error across 1 run (12m7s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `bin/fm-composer-lib.sh:196` - The U+00A0→space normalization (`content=${content//&#34;$nbsp&#34;/ }` at line 196) runs BEFORE the bare-shell-glyph exact-match branch (lines 205-214), so a BARE (unbordered, bordered=0) shell prompt glyph (`&gt;`/`$`/`%`/`#`) padded with U+00A0 now reads `empty` instead of `unknown`. Pre-fix it read `pending` (verified against base 8c0d9eb: `classify 0 &#39;&gt;$\xc2\xa0&#39;` → pending); post-fix it reads `empty` (verified: `&gt;`/`$`/`%`/`#` + U+00A0 all → empty). Root cause: normalizing turns `&gt;\xc2\xa0` into `&gt; `, which bypasses the exact-match `&#39;&gt;&#39;|&#39;$&#39;|&#39;%&#39;|&#39;#&#39;` (that pattern only matches the lone glyph, and only fires because adapters pre-trim ASCII whitespace) and instead matches the `&#39;&gt; &#39;*` strip branch at line 223, stripping to empty at line 228. This contradicts the file&#39;s load-bearing safety invariant (header lines 17-23: a bare shell prompt is NEVER empty — it is a dead shell, unsafe for injection) and the intent&#39;s stated safety triad: &#34;bare shell prompt / unreadable pane -&gt; unknown (defer)&#34;. The agent-glyph case the fix targets (`❯`+U+00A0 → empty) is correct and is NOT affected; only bare SHELL glyphs regress. Reachable via the tmux adapter (`fm_tmux_composer_state` passes bordered=0 for rows without `│` borders and does not filter by glyph before classify); herdr is safe (its bare regex is `^[❯›]`, so a shell-glyph bare row never reaches classify) and orca/cmux always pass bordered=1. Consequence: if a dead-shell pane&#39;s prompt row is captured with a trailing U+00A0, away-mode could inject/type an escalation into that shell. The narrowness (real shell prompts rarely emit U+00A0) keeps this from being a blocker, but it is a real weakening of a safety guard the author believed was preserved.

🔧 Fix: re-trim after U+00A0 normalize to restore bare-shell unknown verdict
1 info still open:
- ℹ️ `bin/fm-composer-lib.sh:198` - The re-trim added at lines 198-201 (ASCII-whitespace trim of `content`/`plain_content` right after the U+00A0 normalize) is load-bearing: without it, a U+00A0-padded bare shell glyph collapses to `&gt; `/`$ ` etc. and falls through the glyph-strip branch to `empty` (exactly the FR-1 regression). It is non-obvious because content is trimmed again later at lines 230-231, so the early trim can look redundant, and a future &#34;simplification&#34; pass that removes it would silently reintroduce the dead-shell injection hole. The surrounding comment block (185-194) explains only the normalize step and does not mention this trim or its safety role, inconsistent with the file&#39;s otherwise heavy inline commenting on non-obvious safety logic.

</details>

<details>
<summary>⚠️ **Test** - 1 error</summary>

- 🚨 tests failed with exit code 1
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
