### PR TITLE
feat: notify captain about blockers requiring action

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -659,6 +659,9 @@ Reaches the captain immediately:
 - Anything destructive, irreversible, or security-sensitive.
 - A needed credential or login.
 
+When work is genuinely blocked and requires the captain's action, run `~/.local/bin/notify "the message"` once, replacing `the message` with a concise blocker and required action.
+Do not send this notification for routine progress, recoverable errors, or repeated reminders.
+
 Does not reach the captain: auto-fixes, retries, routine progress, or firstmate's internal vocabulary and machinery.
 Batch non-urgent updates into your next natural reply.
 Use lavish-axi for multi-option decisions and structured reports worth a visual; plain chat for yes/no.


### PR DESCRIPTION
## Intent

Add a concise durable rule to Firstmate's tracked AGENTS.md so one WhatsApp notification reaches the captain when work is genuinely blocked and needs the captain's action. Keep the exact command ~/.local/bin/notify "the message", tell the agent to replace the placeholder with a concise blocker and required action, trigger it once only for genuine blockers requiring captain action, and exclude routine progress, recoverable errors, and repeated reminders. Apply the knowledge-placement decision tree and one-owner rule, change only the smallest tracked documentation surface, preserve one sentence per Markdown line and plain dashes, do not add or modify tests, and do not merge the PR. The preceding gate run completed review, attempted the full existing test suite, and was cancelled when its repair agent began changing unrelated tests; local lint is unavailable because the required ShellCheck 0.11.0 binary is not installed, so CI must perform the pinned lint and test checks on the unchanged one-file branch.

## What Changed

- Captain, Firstmate now runs `~/.local/bin/notify "the message"` once when work is genuinely blocked and requires your action.
- Require `the message` to state the blocker and required action concisely.
- Skip notifications for routine progress, recoverable errors, and repeated reminders.

## Testing

- ⏭️ **Test** - skipped

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⏭️ **Review** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>⏭️ **Test** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>⏭️ **Document** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>⏭️ **Lint** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
