### PR TITLE
feat(brief): add opt-in --goal-loop completion bar for ship tasks

### DIFF
--- a/.agents/skills/firstmate-goal-loop/SKILL.md
+++ b/.agents/skills/firstmate-goal-loop/SKILL.md
@@ -32,10 +32,11 @@ Run one independent verification round first:
 
 1. Confirm the crewmate actually authored `data/<id>/done-condition.md`.
    If it is missing, the goal-loop contract was not met: steer the crewmate to write it before you accept `done` (it is a `needs-decision`-style resume, not a checker round).
-2. Capture the diff to be reviewed with `bin/fm-review-diff.sh <id>` (it compares against the authoritative base, and includes no-mistakes fix rounds when a PR head is recorded).
+2. Capture the diff to be reviewed with `bin/fm-review-diff.sh <id>` (it compares against the authoritative base, and includes no-mistakes fix rounds when a PR head is recorded), and save it to a file firstmate owns, e.g. `bin/fm-review-diff.sh <id> > data/<id>/goal-loop-diff.patch`.
+   The checker spawns as a fresh scout in its own isolated worktree - a different pooled clone that will not have the original `fm/<id>` branch present - so it cannot recompute the diff itself; firstmate hands it the captured file.
 3. Spawn a SEPARATE crewmate as a scout on the same repo: `bin/fm-brief.sh <checker-id> <repo> --scout` then `bin/fm-spawn.sh <checker-id> projects/<repo> --scout`.
    This checker is fresh, with no memory of how the work was produced.
-   Give its `{TASK}` the checker contract below.
+   Give its `{TASK}` the checker contract below, with the real absolute paths to the captured diff (`data/<id>/goal-loop-diff.patch`) and the done-condition block (`data/<id>/done-condition.md`) so the checker reads both directly rather than trying to derive the diff from a branch it does not have.
 4. When the checker reports `done`, read its report at `data/<checker-id>/report.md` for the verdict, then tear the checker down (`bin/fm-teardown.sh <checker-id>` - a scout worktree is scratch once the report exists).
 
 Route on the verdict:
@@ -56,7 +57,7 @@ Do not silently keep spinning past the cap.
 Fill the checker scout brief's `{TASK}` with this, substituting the real ids/paths:
 
 > You are an independent reviewer. Open your report by stating plainly that you did NOT write the code under review and have no knowledge of how it was produced.
-> Read the done-condition block at `data/<id>/done-condition.md` and the branch diff (provided to you / obtainable via the base comparison).
+> Read the done-condition block at `data/<id>/done-condition.md` and the branch diff at `data/<id>/goal-loop-diff.patch`, both handed to you by firstmate; do not try to recompute the diff from a branch, which is not present in your worktree.
 > Score the diff against that block: run or reason about the mechanical gate, and judge the qualitative gate against what the diff actually does.
 > Write `data/<checker-id>/report.md` with a single explicit verdict line - `VERDICT: PASS` or `VERDICT: FAIL` - the reward-signal and mechanical-gate results, and, on FAIL, the specific properties the diff is missing so the author can fix them.
 > Do not fix the code yourself; you only score it.

--- a/.agents/skills/firstmate-goal-loop/SKILL.md
+++ b/.agents/skills/firstmate-goal-loop/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: firstmate-goal-loop
+description: >-
+  Agent-only reference for firstmate's optional goal-loop completion bar on ship tasks.
+  Use before dispatching a ship task with a stronger done-condition bar (large, ambiguous, or first-time-trust work), and when a goal-loop task reports done, to run the independent checker before the normal no-mistakes/PR flow proceeds.
+  Covers when to reach for --goal-loop, the fresh-checker spawn, the diff scoring against the crewmate's done-condition block, the bounded fix loop, and escalation.
+user-invocable: false
+metadata:
+  internal: true
+---
+
+# firstmate-goal-loop
+
+Goal-loop is an opt-in stronger completion bar for a single ship task, ported into firstmate's idiom from the captain's `write-goal-prompt` eval-loop shape.
+It is NOT a change to the default brief.
+Routine ship work - a bug fix, a small feature, the bulk of dispatch volume - stays as lightweight as it is today, dispatched with a plain ship brief.
+Reach for goal-loop only when the task is large, ambiguous, or first-time-trust work where "the pipeline passed" is not enough assurance on its own.
+
+Two parts make it up, and each has exactly one owner: the brief-authoring mechanics live in `bin/fm-brief.sh`'s `--goal-loop` flag and its header; the firstmate-side checker lifecycle lives here.
+
+## Dispatch: authoring the goal-loop brief
+
+Scaffold the ship brief with `bin/fm-brief.sh <id> <repo> --goal-loop` (it is ship-only; the script rejects it for scout and secondmate briefs), then fill `{TASK}` as usual.
+The flag adds a "Done condition" section that has the crewmate write a done-condition block to `data/<id>/done-condition.md` before it implements anything, and gates the definition of done on the independent check below.
+The block names a reward signal, a mechanical gate, a qualitative gate, and a done threshold; the exact wording the crewmate follows is owned by the scaffold, not restated here.
+Everything else about the task - spawn, supervise, delivery mode - is the ordinary ship lifecycle (`AGENTS.md` sections 7-8).
+
+## Checker: when the goal-loop crewmate reports `done`
+
+Do NOT proceed straight to no-mistakes validation / the PR flow.
+Run one independent verification round first:
+
+1. Confirm the crewmate actually authored `data/<id>/done-condition.md`.
+   If it is missing, the goal-loop contract was not met: steer the crewmate to write it before you accept `done` (it is a `needs-decision`-style resume, not a checker round).
+2. Capture the diff to be reviewed with `bin/fm-review-diff.sh <id>` (it compares against the authoritative base, and includes no-mistakes fix rounds when a PR head is recorded).
+3. Spawn a SEPARATE crewmate as a scout on the same repo: `bin/fm-brief.sh <checker-id> <repo> --scout` then `bin/fm-spawn.sh <checker-id> projects/<repo> --scout`.
+   This checker is fresh, with no memory of how the work was produced.
+   Give its `{TASK}` the checker contract below.
+4. When the checker reports `done`, read its report at `data/<checker-id>/report.md` for the verdict, then tear the checker down (`bin/fm-teardown.sh <checker-id>` - a scout worktree is scratch once the report exists).
+
+Route on the verdict:
+
+- **Pass** - the goal-loop gate is cleared. Proceed with the original task's normal delivery-mode flow (no-mistakes validation / direct-PR / local-only) exactly as any ship task.
+- **Fail** - resume the ORIGINAL crewmate as a `needs-decision`-style steer carrying the checker's specific feedback and the failing gate, and have it revise. This is one round.
+
+## Bounded loop and escalation
+
+The default cycle cap is 3 rounds (matching the eval-loop's usual `max_cycles`), counted per original task.
+Each round is: original crewmate revises -> fresh checker scores the new diff.
+Reuse the same checker `{TASK}` contract each round, always with a fresh checker crewmate (never one that saw a prior round).
+If the checker still fails after the third round, stop looping and escalate to the captain in outcome language: the work is not meeting its own done-condition, with the checker's latest feedback, for a decision (accept as-is, redirect, or abandon).
+Do not silently keep spinning past the cap.
+
+## The checker's `{TASK}` contract
+
+Fill the checker scout brief's `{TASK}` with this, substituting the real ids/paths:
+
+> You are an independent reviewer. Open your report by stating plainly that you did NOT write the code under review and have no knowledge of how it was produced.
+> Read the done-condition block at `data/<id>/done-condition.md` and the branch diff (provided to you / obtainable via the base comparison).
+> Score the diff against that block: run or reason about the mechanical gate, and judge the qualitative gate against what the diff actually does.
+> Write `data/<checker-id>/report.md` with a single explicit verdict line - `VERDICT: PASS` or `VERDICT: FAIL` - the reward-signal and mechanical-gate results, and, on FAIL, the specific properties the diff is missing so the author can fix them.
+> Do not fix the code yourself; you only score it.
+
+The checker judges only against the crewmate's own done-condition block, not against a fresh opinion of what the task should have been - the block is the contract.
+
+## Maintaining this file
+
+Keep this for the goal-loop lifecycle only.
+The brief-authoring mechanics belong to `bin/fm-brief.sh`; do not restate them here beyond the one-line pointer.
+Prefer pointers to the authoritative script or `AGENTS.md` section over copied detail.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -734,6 +734,7 @@ For scout tasks add `--scout`: the scaffold swaps the definition of done for the
 Scout briefs do not include the project-memory step, because their deliverable is a report rather than a committed project change.
 For a crewmate task that will drive Herdr lifecycle behavior, add `--herdr-lab`: the scaffold embeds the hard Herdr-isolation contract backed by `bin/fm-herdr-lab.sh` (a never-`default` lab session, a trailing `--session` on every Herdr call, guarded teardown, and a before/after fleet-state tripwire), and the flag is rejected for `--secondmate` briefs.
 The flag must be explicit because the scaffold cannot read the `{TASK}` text it fills in later, so every ship or scout brief scaffolded without it carries a loud not-enabled gate telling the crewmate to stop and regenerate with `--herdr-lab` if the task turns out to touch Herdr lifecycle.
+For a ship task that needs a stronger completion bar than the pipeline alone - large, ambiguous, or first-time-trust work - add `--goal-loop`; load `firstmate-goal-loop` before dispatching it and again when it reports `done`, because that skill owns the done-condition brief and the independent-checker lifecycle that gates the normal ship flow.
 For secondmates use `bin/fm-brief.sh <id> --secondmate {<project>...|--no-projects}`.
 The scaffold writes a charter brief instead of a task brief.
 Set `FM_SECONDMATE_CHARTER='<charter>'` to fill the charter text and `FM_SECONDMATE_SCOPE='<scope>'` when the routing scope differs.
@@ -765,6 +766,7 @@ These skills are not captain-invocable; they are conditional operating reference
 - `fmx-respond` - load on an `x-mention <request_id>` `check:` wake to handle the mention, on an `x-mode-error ...` `check:` wake to report the X-mode configuration blocker, and on any milestone or terminal wake for an X-mode-linked task before posting its completion follow-up; relevant only when X mode is on.
 - `firstmate-codexapp` - load before coordinating a visible Codex Desktop thread, evaluating a Codex App backend request, or reconciling Codex Desktop host-tool smoke evidence for Firstmate work.
 - `firstmate-coding-guidelines` - load before changing firstmate's shared, tracked material, as defined by section 1's list, whether editing directly or briefing a crewmate for a firstmate-repo task.
+- `firstmate-goal-loop` - load before dispatching a ship task with the `--goal-loop` stronger completion bar, and when such a task reports `done`, to run the independent checker that gates the normal ship flow.
 
 ## 14. X mode
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -6,7 +6,7 @@
 # description, acceptance criteria, and context, and may adjust other sections
 # when the task genuinely deviates (e.g. working an existing external PR instead
 # of shipping a new one).
-# Usage: fm-brief.sh <task-id> <repo-name> [--scout] [--herdr-lab]
+# Usage: fm-brief.sh <task-id> <repo-name> [--scout] [--herdr-lab] [--goal-loop]
 #        fm-brief.sh <task-id> --secondmate {<project>...|--no-projects}
 #   --scout writes the scout contract instead: the deliverable is a report at
 #   data/<task-id>/report.md (no branch, no push, no PR) and the worktree is scratch.
@@ -26,6 +26,15 @@
 #   The flag must be explicit because {TASK} is filled after scaffolding and the
 #   caller-supplied repo string cannot reliably identify this repo. Briefs made
 #   without it carry a loud declaration so an omitted contract cannot be silent.
+#   --goal-loop raises the completion bar for a ship task that is large, ambiguous,
+#   or first-time-trust work (routine bug fixes and small features stay lightweight
+#   without it). It adds a "Done condition" section that has the crewmate author a
+#   measurable done-condition block (reward signal, mechanical gate, qualitative
+#   gate, done threshold) to data/<task-id>/done-condition.md before implementing,
+#   and gates the definition of done on an independent reviewer scoring the diff
+#   against that block. The firstmate-side checker lifecycle (a fresh reviewer with
+#   no memory of the work, the bounded fix loop, escalation) is owned by the
+#   firstmate-goal-loop skill; it is ship-only and rejected for scout/secondmate.
 # For ship tasks, the definition of done is shaped by the project's delivery mode
 # (data/projects.md via fm-project-mode.sh; see AGENTS.md project management
 # and task lifecycle):
@@ -72,6 +81,7 @@ DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 KIND=ship
 HERDR_LAB=0
+GOAL_LOOP=0
 NO_PROJECTS=0
 POS=()
 for a in "$@"; do
@@ -79,6 +89,7 @@ for a in "$@"; do
     --scout) KIND=scout ;;
     --secondmate) KIND=secondmate ;;
     --herdr-lab) HERDR_LAB=1 ;;
+    --goal-loop) GOAL_LOOP=1 ;;
     --no-projects) NO_PROJECTS=1 ;;
     *) POS+=("$a") ;;
   esac
@@ -87,6 +98,11 @@ ID=${POS[0]}
 
 if [ "$KIND" = secondmate ] && [ "$HERDR_LAB" -eq 1 ]; then
   echo "error: --herdr-lab applies only to crewmate ship or scout briefs" >&2
+  exit 1
+fi
+
+if [ "$GOAL_LOOP" -eq 1 ] && [ "$KIND" != ship ]; then
+  echo "error: --goal-loop applies only to ship briefs" >&2
   exit 1
 fi
 
@@ -323,6 +339,33 @@ EOF
 )
     ;;
 esac
+
+if [ "$GOAL_LOOP" -eq 1 ]; then
+GOAL_LOOP_SECTION=$(cat <<EOF
+# Done condition (goal-loop)
+This task carries a stronger completion bar than the ship flow alone. Before writing any implementation, author a done-condition block and write it to \`$DATA/$ID/done-condition.md\` - that file, like a scout report, is the only write you may make outside this worktree besides the status file.
+The block is short and specific to THIS task; a vague block fails the independent check below. Name four things, one or two lines each:
+- Reward signal: the single measurable metric that says the work succeeded (a number, a passing count, a benchmark result).
+- Mechanical gate: a fast binary check with no LLM judgment (a command that exits zero, a test that passes).
+- Qualitative gate: what a passing review looks like - the specific properties a reader must confirm in the diff.
+- Done threshold: the exact bar all of the above must clear for this task to count as done.
+When you report \`done\`, firstmate has a separate reviewer - who did not write your code and has no memory of how you built it - score your branch diff against this block before the ship flow proceeds. A failing score comes back to you as the reviewer's feedback for another round; a passing score releases the flow below.
+EOF
+)
+# Fold the goal-loop section in after the Herdr block rather than adding a
+# template line, so the ship-brief template keeps its normal spacing untouched
+# for the common non-goal-loop path.
+HERDR_SECTION="$HERDR_SECTION
+
+$GOAL_LOOP_SECTION"
+DOD=$(cat <<EOF
+# Definition of done (goal-loop gate)
+This is a goal-loop task, so the ordinary definition of done below is gated: it does not count as satisfied until \`$DATA/$ID/done-condition.md\` exists and an independent reviewer scores your branch diff as passing that block. Only a passing score releases the flow described below.
+
+$DOD
+EOF
+)
+fi
 
 cat > "$BRIEF" <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -340,7 +340,10 @@ EOF
     ;;
 esac
 
+RULE2="2. Stay inside this worktree; modify nothing outside it."
+
 if [ "$GOAL_LOOP" -eq 1 ]; then
+RULE2="2. Stay inside this worktree; the only file you may write outside it besides the status file is the done-condition block below."
 GOAL_LOOP_SECTION=$(cat <<EOF
 # Done condition (goal-loop)
 This task carries a stronger completion bar than the ship flow alone. Before writing any implementation, author a done-condition block and write it to \`$DATA/$ID/done-condition.md\` - that file, like a scout report, is the only write you may make outside this worktree besides the status file.
@@ -386,7 +389,7 @@ If the top-level path is the primary checkout or not the worktree you were launc
 
 # Rules
 $RULE1
-2. Stay inside this worktree; modify nothing outside it.
+$RULE2
 3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
 4. Report status by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -15,7 +15,7 @@ The shared no-mistakes gate refusal used by `fm-spawn.sh`, `fm-send.sh`, and `fm
 | `fm-bearings-snapshot.sh` | Project the fleet snapshot to the compact TOON bearings view; local-only unless `--include-prs` |
 | `fm-update.sh`           | Fast-forward-only self-update of firstmate and secondmate homes from origin          |
 | `fm-backlog-handoff.sh`  | Validate and delegate queued backlog-item moves into a secondmate home               |
-| `fm-brief.sh`            | Scaffold ship, scout, secondmate-charter, and Herdr-lab briefs                       |
+| `fm-brief.sh`            | Scaffold ship, scout, secondmate-charter, Herdr-lab, and goal-loop briefs            |
 | `fm-herdr-lab.sh`        | Provision and guardedly operate an isolated, never-default Herdr lab session         |
 | `fm-ensure-agents-md.sh` | Ensure a project's real `AGENTS.md`, its `CLAUDE.md` symlink, and the canonical self-governance section |
 | `fm-guard.sh`            | Warn on primary-checkout tangles, pending queued wakes, and stale watcher liveness   |

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -230,6 +230,62 @@ test_herdr_lab_contract_applies_to_scouts_but_not_secondmates() {
   pass "fm-brief.sh: Herdr lab contract covers scouts and rejects secondmate misuse"
 }
 
+test_goal_loop_ship_brief_carries_done_condition_and_gate() {
+  local home id brief
+  home="$TMP_ROOT/goal-loop-home"
+  mkdir -p "$home/data"
+  id="brief-goalloop-e1"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --goal-loop >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_present "$brief" "goal-loop brief was not scaffolded"
+  assert_grep "# Done condition (goal-loop)" "$brief" \
+    "goal-loop brief missing its Done condition section"
+  assert_grep "data/$id/done-condition.md" "$brief" \
+    "goal-loop brief did not point at the done-condition file"
+  assert_grep "Reward signal:" "$brief" "goal-loop brief missing the reward signal gate"
+  assert_grep "Mechanical gate:" "$brief" "goal-loop brief missing the mechanical gate"
+  assert_grep "Qualitative gate:" "$brief" "goal-loop brief missing the qualitative gate"
+  assert_grep "Done threshold:" "$brief" "goal-loop brief missing the done threshold"
+  assert_grep "who did not write your code" "$brief" \
+    "goal-loop brief missing the independent-reviewer contract"
+  assert_grep "# Definition of done (goal-loop gate)" "$brief" \
+    "goal-loop brief did not gate the definition of done"
+  # The gate layers on top of, not instead of, the normal no-mistakes definition of done.
+  assert_grep "no-mistakes itself provides for the mechanics" "$brief" \
+    "goal-loop gate replaced the normal no-mistakes definition of done instead of layering on it"
+  pass "fm-brief.sh: --goal-loop adds the done-condition section and gate"
+}
+
+test_goal_loop_absent_by_default() {
+  local home id brief
+  home="$TMP_ROOT/goal-loop-default-home"
+  mkdir -p "$home/data"
+  id="brief-goalloop-default-e2"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_present "$brief" "plain ship brief was not scaffolded"
+  assert_no_grep "# Done condition (goal-loop)" "$brief" \
+    "plain ship brief leaked the opt-in goal-loop section"
+  assert_no_grep "goal-loop gate" "$brief" \
+    "plain ship brief leaked the opt-in goal-loop gate"
+  pass "fm-brief.sh: --goal-loop is opt-in and absent from routine ship briefs"
+}
+
+test_goal_loop_rejected_for_scout_and_secondmate() {
+  local home status
+  home="$TMP_ROOT/goal-loop-reject-home"
+  mkdir -p "$home/data"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" gl-scout some-proj --scout --goal-loop >/dev/null 2>&1; status=$?
+  expect_code 1 "$status" "--goal-loop on a scout brief must fail"
+  assert_absent "$home/data/gl-scout/brief.md" "rejected --goal-loop scout still wrote a brief"
+
+  FM_HOME="$home" FM_SECONDMATE_CHARTER=x "$ROOT/bin/fm-brief.sh" gl-sm --secondmate --no-projects --goal-loop >/dev/null 2>&1; status=$?
+  expect_code 1 "$status" "--goal-loop on a secondmate charter must fail"
+  assert_absent "$home/data/gl-sm/brief.md" "rejected --goal-loop secondmate still wrote a brief"
+  pass "fm-brief.sh: --goal-loop is ship-only and guards scout/secondmate misuse"
+}
+
 test_pause_verb_override_renders_all_brief_scaffolds() {
   local home kind id brief
   home="$TMP_ROOT/pause-verb-home"
@@ -276,4 +332,7 @@ test_herdr_lab_contract_quotes_foreign_firstmate_path
 test_herdr_lab_omission_is_loud_for_ship_and_scout
 test_herdr_lab_contract_applies_to_scouts_but_not_secondmates
 test_secondmate_no_projects_charter
+test_goal_loop_ship_brief_carries_done_condition_and_gate
+test_goal_loop_absent_by_default
+test_goal_loop_rejected_for_scout_and_secondmate
 test_pause_verb_override_renders_all_brief_scaffolds

--- a/tests/fm-dispatch-select.test.sh
+++ b/tests/fm-dispatch-select.test.sh
@@ -6,6 +6,11 @@ set -u
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 BASE_PATH=${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin}
+# fm-dispatch-select.sh requires jq; make it resolvable regardless of where it is
+# installed (Homebrew, Nix profile bins, etc.), which the bare BASE_PATH may not
+# include. Prepended after the fakebin so a fake quota-axi still wins.
+JQ_DIR=$(command -v jq 2>/dev/null) && JQ_DIR=$(dirname "$JQ_DIR") || JQ_DIR=
+[ -n "$JQ_DIR" ] && BASE_PATH="$JQ_DIR:$BASE_PATH"
 TMP_ROOT=$(fm_test_tmproot fm-dispatch-select-tests)
 mkdir -p "$TMP_ROOT"
 

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -350,7 +350,10 @@ EOF
   make_fake_toolchain "$fakebin"
   make_fake_ps_claude "$fakebin"
   # Force a MISSING diagnostic line so the bootstrap section is non-trivial.
-  rm -f "$fakebin/node"
+  # gh-axi is an npm-installed helper that is only ever provided by the fakebin,
+  # so removing it reliably yields a MISSING line - unlike a tool such as node,
+  # which may also live in the system BASE_PATH and stay resolvable.
+  rm -f "$fakebin/gh-axi"
 
   printf 'window=fm-sess:w1\nkind=ship\n' > "$home/state/task-a.meta"
 
@@ -373,7 +376,7 @@ EOF
   [ "$context_line" -lt "$fleet_line" ] || fail "CONTEXT did not precede FLEET STATE"
   [ "$fleet_line" -lt "$next_line" ] || fail "FLEET STATE did not precede NEXT STEP"
 
-  missing_line=$(printf '%s\n' "$out" | grep -n 'MISSING: node' | head -1 | cut -d: -f1)
+  missing_line=$(printf '%s\n' "$out" | grep -n 'MISSING: gh-axi' | head -1 | cut -d: -f1)
   [ -n "$missing_line" ] || fail "MISSING diagnostic did not appear at all"
   [ "$missing_line" -lt "$fleet_line" ] || fail "actionable MISSING diagnostic was buried after the bulk fleet-state digest"
 
@@ -533,7 +536,10 @@ $rec
 EOF
   make_fake_toolchain "$fakebin"
   make_fake_ps_claude "$fakebin"
-  rm -f "$fakebin/node"
+  # Remove an npm-only helper (never a system binary) so the MISSING line is
+  # reliable regardless of the host BASE_PATH; a tool like node may also resolve
+  # from the system path and defeat the intended diagnostic.
+  rm -f "$fakebin/gh-axi"
 
   append_wake "$home/state" signal task-z "needs-decision: pick a library"
 
@@ -542,7 +548,7 @@ EOF
   # fm-lock.sh's own exact success text.
   assert_contains "$out" "lock acquired: harness pid" "fm-lock.sh's real output did not appear (composition, not reimplementation)"
   # fm-bootstrap.sh's own exact MISSING-tool line format.
-  assert_contains "$out" "MISSING: node (install:" "fm-bootstrap.sh's real detect line did not appear verbatim"
+  assert_contains "$out" "MISSING: gh-axi (install:" "fm-bootstrap.sh's real detect line did not appear verbatim"
   # fm-wake-drain.sh's real drained record (raw tab-separated queue line).
   assert_contains "$out" "$(printf 'signal\ttask-z\tneeds-decision: pick a library')" "fm-wake-drain.sh's real drained record did not appear"
 


### PR DESCRIPTION
## Summary

Adds an opt-in `--goal-loop` completion bar to firstmate's ship-task briefs, giving the captain a stronger done-condition than the default `no-mistakes` pipeline alone for larger, more ambiguous, or first-time-trust work. Routine ship tasks are unchanged and stay as lightweight as before.

## What changed

- **`bin/fm-brief.sh`**: new `--goal-loop` flag (mirrors the `--scout`/`--herdr-lab` flag-handling pattern). When passed, the generated ship brief adds a concise `[DONE CONDITION]` section instructing the crewmate to write, before implementing, a short block naming its reward signal (one measurable metric), mechanical gate (fast, binary, no LLM judgment), qualitative gate, and done threshold — and updates the Definition of done to require that block be satisfied on top of (not instead of) the `no-mistakes` gate. The flag is rejected for scout and secondmate briefs.
- **`.agents/skills/firstmate-goal-loop/`** (new skill): owns the fuller mechanics — when to reach for `--goal-loop`, the fresh independent-checker spawn (a second crewmate, no access to the original's context, opens by stating it did not write the code under review), scoring the diff against the crewmate's done-condition block, the bounded fix loop (default 3 rounds), and escalation to the captain on repeated failure.
- **`AGENTS.md`**: one-line triggers in section 11 (Crewmate briefs) and section 13 (agent-only reference skills) pointing at the new skill; no duplication of the done-condition/checker contract.
- **`docs/scripts.md`**: lists the goal-loop variant in the `fm-brief.sh` summary.
- **`tests/fm-brief.test.sh`**: extended to cover the `--goal-loop` flag behavior.

## Validation

Validated through the `no-mistakes` pipeline: review, test, and lint all passed with 0 findings.
