### PR TITLE
feat: support Codex max reasoning profiles

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -91,13 +91,16 @@ The supported launch-profile flags below are verified locally; each row records 
 | Harness | Model flag | Effort flag | Notes |
 |---|---|---|---|
 | claude | `--model <model>` | `--effort <low\|medium\|high\|xhigh\|max>` | Verified on Claude Code 2.1.196. |
-| codex | `--model <model>` | `-c 'model_reasoning_effort="<low\|medium\|high\|xhigh>"'` | Verified on codex-cli 0.142.1. The installed binary schema contains `model_reasoning_effort`, the active config uses it, and the bundled model catalog advertises only low/medium/high/xhigh. `max` is omitted. |
+| codex | `--model <model>` | `-c 'model_reasoning_effort="<low\|medium\|high\|xhigh\|max>"'` | Verified on codex-cli 0.144.4 (2026-07-14), where `max` is a distinct accepted value and is not an alias for `xhigh`. |
 | grok | `--model <model>` | `--reasoning-effort <low\|medium\|high>` | Verified on grok 0.2.99 (2026-07-13). `--effort` is an alias, but firstmate's profile axis is reasoning effort. As of 0.2.99 the ceiling is `high`; both `xhigh` and `max` are rejected with `use one of: high, medium, low`, so firstmate omits them. |
 | pi | `--model <model>` | `--thinking <low\|medium\|high\|xhigh\|max>` | Verified 2026-07-13 on Pi 0.80.6. `pi --help` advertises `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`; `pi --print --model openai-codex/gpt-5.6-sol --thinking max 'Reply with exactly OK.'` completed successfully. |
 | opencode | `--model <provider/model>` | none for firstmate's interactive launch | Verified on opencode 1.17.6. `opencode run` has `--variant`, but firstmate launches the interactive `opencode --prompt` path, which has no verified effort flag. |
 
 When a requested effort value is outside the harness-specific accepted set, `fm-spawn` records the requested `effort=` in meta but emits no effort flag for that harness.
 This preserves launch success instead of passing a known-bad value.
+
+Codex `max` evidence was collected on 2026-07-14 with codex-cli 0.144.4 using `codex exec --ephemeral --ignore-user-config --ignore-rules --sandbox read-only --model gpt-5.6-sol -c 'model_reasoning_effort="max"' 'Reply with exactly OK. Do not use tools.'`.
+The command exited 0 and its startup summary reported `model: gpt-5.6-sol`, `reasoning effort: max`, and the final response `OK`.
 
 ## no-mistakes skill invocation
 

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -505,7 +505,7 @@ crew_dispatch_validate() {
       if $e == null then true
       elif ($e | type) != "string" then false
       elif $h == "claude" then (["low","medium","high","xhigh","max"] | index($e))
-      elif $h == "codex" then (["low","medium","high","xhigh"] | index($e))
+      elif $h == "codex" then (["low","medium","high","xhigh","max"] | index($e))
       elif $h == "grok" then (["low","medium","high"] | index($e))
       elif $h == "pi" then (["low","medium","high","xhigh","max"] | index($e))
       elif $h == "opencode" then false

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -670,7 +670,7 @@ registry_secondmates_json() {
       '{present:true,available:false,complete:false,reason:$reason,provenance:"registered-table",path:$path,freshness:{status:"unavailable",observed_at:$observed},records:[],input_truncated:false,records_truncated:false,reasons:[$reason],lines_in_window:0,records_in_window:0}'
     return 0
   fi
-  script=$(cat <<'BASH'
+  IFS= read -r -d '' script <<'BASH' || true
     f=$1
     max_lines=$2
     max_bytes=$3
@@ -719,7 +719,6 @@ registry_secondmates_json() {
       --argjson records_in_window "$records_in_window" \
       --argjson max_records "$max_records" "$output_filter"
 BASH
-  )
   parse_filter=$(cat <<'JQ'
       [ inputs
         | select(startswith("- "))
@@ -768,7 +767,7 @@ bounded_parent_activities_json() {  # <status-file>
     jq -n '{records:[],available:true,input_truncated:false,retained_truncated:false,reasons:[],lines_in_window:0,records_in_window:0}'
     return 0
   fi
-  script=$(cat <<'BASH'
+  IFS= read -r -d '' script <<'BASH' || true
     classify=$1
     f=$2
     max_lines=$3
@@ -831,7 +830,6 @@ bounded_parent_activities_json() {  # <status-file>
          lines_in_window:$lines_in_window,
          records_in_window:$records_in_window}'
 BASH
-  )
   out=$(run_timed "$FM_SNAPSHOT_PARENT_ACTIVITY_TIMEOUT" bash -c "$script" \
     fm-parent-activities "$SCRIPT_DIR/fm-classify-lib.sh" "$f" \
     "$FM_SNAPSHOT_PARENT_ACTIVITY_LINES" "$FM_SNAPSHOT_PARENT_ACTIVITY_BYTES" \

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -448,11 +448,10 @@ effort_flag_for_harness() {
       esac
       ;;
     codex)
-      # The installed codex config schema uses model_reasoning_effort, and the
-      # bundled model catalog advertises low|medium|high|xhigh. Omit max rather
-      # than passing an unsupported value.
+      # Codex accepts max as its own model_reasoning_effort value, distinct from
+      # xhigh; pass the requested value through without aliasing either one.
       case "$effort" in
-        low|medium|high|xhigh) printf -- '-c %s ' "$(shell_quote "model_reasoning_effort=\"$effort\"")" ;;
+        low|medium|high|xhigh|max) printf -- '-c %s ' "$(shell_quote "model_reasoning_effort=\"$effort\"")" ;;
       esac
       ;;
     grok)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -210,7 +210,7 @@ Absent `select` means use the first array element, or the only object in the sin
 `default` is optional.
 An omitted model or effort means the selected harness uses its own default for that axis.
 If a selected profile carries an effort value the chosen harness does not accept, `fm-spawn.sh` records the requested `effort=` in task meta for traceability but omits the launch flag, and bootstrap reports the invalid harness/effort pair as a `CREW_DISPATCH` diagnostic when it is visible in the file.
-Codex supports `low`, `medium`, `high`, `xhigh`, and the distinct `max` reasoning effort; `fm-spawn.sh` passes each accepted value through as `-c 'model_reasoning_effort="<value>"'` without aliasing `max` to `xhigh`.
+Codex supports `low`, `medium`, `high`, `xhigh`, and the distinct `max` reasoning effort; `max` is empirically verified with `gpt-5.6-sol`, and `fm-spawn.sh` passes each accepted value through as `-c 'model_reasoning_effort="<value>"'` without aliasing `max` to `xhigh`.
 `quota-balanced` selection is deterministic and implemented by `bin/fm-dispatch-select.sh`, whose header owns the general-window rules, the 20 point stale-clear freshness margin, vendor-availability handling, and the degrade-to-first-element fallbacks; quota trouble never blocks dispatch.
 See [`docs/examples/crew-dispatch.json`](examples/crew-dispatch.json) for a starting point to copy into local `config/crew-dispatch.json`.
 When the file exists, bootstrap validates it with `jq`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -210,6 +210,7 @@ Absent `select` means use the first array element, or the only object in the sin
 `default` is optional.
 An omitted model or effort means the selected harness uses its own default for that axis.
 If a selected profile carries an effort value the chosen harness does not accept, `fm-spawn.sh` records the requested `effort=` in task meta for traceability but omits the launch flag, and bootstrap reports the invalid harness/effort pair as a `CREW_DISPATCH` diagnostic when it is visible in the file.
+Codex supports `low`, `medium`, `high`, `xhigh`, and the distinct `max` reasoning effort; `fm-spawn.sh` passes each accepted value through as `-c 'model_reasoning_effort="<value>"'` without aliasing `max` to `xhigh`.
 `quota-balanced` selection is deterministic and implemented by `bin/fm-dispatch-select.sh`, whose header owns the general-window rules, the 20 point stale-clear freshness margin, vendor-availability handling, and the degrade-to-first-element fallbacks; quota trouble never blocks dispatch.
 See [`docs/examples/crew-dispatch.json`](examples/crew-dispatch.json) for a starting point to copy into local `config/crew-dispatch.json`.
 When the file exists, bootstrap validates it with `jq`.

--- a/docs/examples/crew-dispatch.json
+++ b/docs/examples/crew-dispatch.json
@@ -11,14 +11,19 @@
       "why": "Use the cheapest fast profile when the task is narrow and low ambiguity."
     },
     {
+      "when": "The task is planning, architecture, or design work that benefits from the deepest Codex reasoning profile.",
+      "use": { "harness": "codex", "model": "gpt-5.6-sol", "effort": "max" },
+      "why": "Use Codex max as its own reasoning level for planning work; do not rewrite it to xhigh."
+    },
+    {
       "when": "The task is a big or ambiguous multi-file feature, a risky refactor, or work that requires holding many moving parts in mind.",
       "use": [
         { "harness": "claude", "model": "claude-sonnet-5", "effort": "high" },
-        { "harness": "codex", "model": "gpt-5.5", "effort": "high" }
+        { "harness": "codex", "model": "gpt-5.6-sol", "effort": "medium" }
       ],
       "select": "quota-balanced",
       "why": "Use a strong coding profile for broad design and implementation work."
     }
   ],
-  "default": { "harness": "codex", "model": "gpt-5.5", "effort": "medium" }
+  "default": { "harness": "codex", "model": "gpt-5.6-sol", "effort": "medium" }
 }

--- a/docs/examples/crew-dispatch.json
+++ b/docs/examples/crew-dispatch.json
@@ -11,18 +11,18 @@
       "why": "Use the cheapest fast profile when the task is narrow and low ambiguity."
     },
     {
-      "when": "The task is planning, architecture, or design work that benefits from the deepest Codex reasoning profile.",
+      "when": "The task includes planning, architecture, or design work.",
       "use": { "harness": "codex", "model": "gpt-5.6-sol", "effort": "max" },
-      "why": "Use Codex max as its own reasoning level for planning work; do not rewrite it to xhigh."
+      "why": "Always use Codex max as its own reasoning level for planning, architecture, and design work; do not rewrite it to xhigh."
     },
     {
-      "when": "The task is a big or ambiguous multi-file feature, a risky refactor, or work that requires holding many moving parts in mind.",
+      "when": "The task is implementation or verification work with no planning, architecture, or design component, such as a big or ambiguous multi-file feature, a risky refactor, or work that requires holding many moving parts in mind.",
       "use": [
         { "harness": "claude", "model": "claude-sonnet-5", "effort": "high" },
         { "harness": "codex", "model": "gpt-5.6-sol", "effort": "medium" }
       ],
       "select": "quota-balanced",
-      "why": "Use a strong coding profile for broad design and implementation work."
+      "why": "Use a strong coding profile for broad implementation and verification work."
     }
   ],
   "default": { "harness": "codex", "model": "gpt-5.6-sol", "effort": "medium" }

--- a/docs/examples/crew-dispatch.json
+++ b/docs/examples/crew-dispatch.json
@@ -11,12 +11,12 @@
       "why": "Use the cheapest fast profile when the task is narrow and low ambiguity."
     },
     {
-      "when": "The task includes planning, architecture, or design work.",
+      "when": "The task's primary deliverable is a plan, architecture, or design rather than an implementation or verification result.",
       "use": { "harness": "codex", "model": "gpt-5.6-sol", "effort": "max" },
       "why": "Always use Codex max as its own reasoning level for planning, architecture, and design work; do not rewrite it to xhigh."
     },
     {
-      "when": "The task is implementation or verification work with no planning, architecture, or design component, such as a big or ambiguous multi-file feature, a risky refactor, or work that requires holding many moving parts in mind.",
+      "when": "The task's primary deliverable is implementation or verification, including a big or ambiguous multi-file feature, a risky refactor, or work that requires holding many moving parts in mind.",
       "use": [
         { "harness": "claude", "model": "claude-sonnet-5", "effort": "high" },
         { "harness": "codex", "model": "gpt-5.6-sol", "effort": "medium" }

--- a/tests/fm-backend.test.sh
+++ b/tests/fm-backend.test.sh
@@ -110,7 +110,7 @@ BASE_REF=$(resolve_base_ref) \
 # tmux-only conformance run the tmux adapter's behavior is what is under test,
 # and that is unchanged by any later (e.g. non-tmux backend) addition to
 # fm-backend.sh's own dispatch surface.
-OLD_BIN_UNCHANGED_SIBLINGS="fm-gate-refuse-lib.sh fm-guard.sh fm-lock-lib.sh fm-tangle-lib.sh fm-tmux-lib.sh fm-composer-lib.sh fm-marker-lib.sh fm-wake-lib.sh fm-classify-lib.sh fm-ff-lib.sh fm-config-inherit-lib.sh fm-tasks-axi-lib.sh fm-project-mode.sh fm-harness.sh fm-crew-state.sh fm-backend.sh"
+OLD_BIN_UNCHANGED_SIBLINGS="fm-gate-refuse-lib.sh fm-guard.sh fm-supervision-lib.sh fm-lock-lib.sh fm-tangle-lib.sh fm-tmux-lib.sh fm-composer-lib.sh fm-marker-lib.sh fm-wake-lib.sh fm-classify-lib.sh fm-ff-lib.sh fm-config-inherit-lib.sh fm-tasks-axi-lib.sh fm-decision-hold.sh fm-project-mode.sh fm-harness.sh fm-crew-state.sh fm-backend.sh"
 OLD_BIN_REFACTORED="fm-send.sh fm-peek.sh fm-watch.sh fm-spawn.sh fm-teardown.sh"
 
 build_old_bin() {  # <name> -> echoes root dir (root/bin/<script> is the entry point)

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -681,7 +681,7 @@ test_crew_dispatch_validation() {
   done <<'ROWS'
 malformed dispatch config is flagged^{"rules":[^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - malformed JSON
 unverified dispatch harness is flagged^{"rules":[{"when":"anything","use":{"harness":"spaceship"}}],"default":{"harness":"codex"}}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - unverified harness: spaceship
-unsupported codex max effort is flagged^{"rules":[{"when":"big feature","use":{"harness":"codex","model":"gpt-5","effort":"max"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: codex:max
+codex max effort is accepted^{"rules":[{"when":"planning work","use":{"harness":"codex","model":"gpt-5.6-sol","effort":"max"}}]}^grep^CREW_DISPATCH: active config/crew-dispatch.json
 unsupported grok max effort is flagged^{"rules":[{"when":"deep current work","use":{"harness":"grok","model":"grok-4","effort":"max"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: grok:max
 unsupported grok xhigh effort is flagged^{"rules":[{"when":"deep current work","use":{"harness":"grok","model":"grok-4","effort":"xhigh"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: grok:xhigh
 pi max effort is accepted^{"rules":[{"when":"deep coding","use":{"harness":"pi","model":"openai-codex/gpt-5.6-sol","effort":"max"}}]}^grep^  rule: deep coding -> pi/openai-codex/gpt-5.6-sol/max
@@ -691,7 +691,7 @@ array use without select is accepted^{"rules":[{"when":"big feature","use":[{"ha
 empty array use is flagged^{"rules":[{"when":"big feature","use":[]}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - each rule needs at least one use profile
 array profile without harness is flagged^{"rules":[{"when":"big feature","use":[{"model":"gpt-5.5"}]}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - each use profile needs harness
 unknown select is flagged^{"rules":[{"when":"big feature","use":[{"harness":"claude"},{"harness":"codex"}],"select":"mystery"}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - unknown select: mystery
-array profile unsupported effort is flagged^{"rules":[{"when":"big feature","use":[{"harness":"codex","effort":"max"}]}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: codex:max
+array profile codex max effort is accepted^{"rules":[{"when":"planning work","use":[{"harness":"codex","model":"gpt-5.6-sol","effort":"max"}]}]}^grep^CREW_DISPATCH: active config/crew-dispatch.json
 ROWS
   pass "bootstrap validates crew-dispatch.json and reports malformed or unverified configs"
 }

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -240,21 +240,21 @@ test_codex_threads_model_and_effort() {
   pass "codex receives --model and model_reasoning_effort profile flags"
 }
 
-test_codex_omits_invalid_max_effort() {
+test_codex_threads_distinct_max_effort() {
   local rec id out status launch
   id=profile-codex-max-z4
   rec=$(make_spawn_case profile-codex-max codex "$id")
   read_case_record "$rec"
 
-  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --model gpt-5 --effort max)
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --model gpt-5.6-sol --effort max)
   status=$?
-  expect_code 0 "$status" "codex spawn with unsupported max effort should omit the effort flag"
-  assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5 max
+  expect_code 0 "$status" "codex spawn with max effort should succeed"
+  assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5.6-sol max
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "codex --model 'gpt-5' --dangerously-bypass-approvals-and-sandbox" \
-    "codex launch did not preserve the model flag when max effort was omitted"
-  assert_not_contains "$launch" "model_reasoning_effort" "codex launch must omit unsupported max reasoning effort"
-  pass "codex omits unsupported max effort instead of passing a bad config value"
+  assert_contains "$launch" "codex --model 'gpt-5.6-sol' -c 'model_reasoning_effort=\"max\"' --dangerously-bypass-approvals-and-sandbox" \
+    "codex launch did not thread the distinct max reasoning effort config"
+  assert_not_contains "$launch" 'model_reasoning_effort="xhigh"' "codex launch must not rewrite max reasoning effort to xhigh"
+  pass "codex receives the distinct max model_reasoning_effort profile value"
 }
 
 test_grok_threads_model_and_reasoning_effort() {
@@ -392,7 +392,7 @@ test_active_dispatch_profile_allows_positional_harness
 test_active_dispatch_profile_allows_raw_launch_command
 test_claude_threads_model_and_effort
 test_codex_threads_model_and_effort
-test_codex_omits_invalid_max_effort
+test_codex_threads_distinct_max_effort
 test_grok_threads_model_and_reasoning_effort
 test_grok_omits_invalid_max_reasoning_effort
 test_grok_omits_invalid_xhigh_reasoning_effort


### PR DESCRIPTION
## Intent

Add genuine Codex max reasoning support to Firstmate launch profiles. Planning tasks must always use model gpt-5.6-sol with the distinct reasoning effort max, never aliasing max to xhigh; implementation and verification tasks remain medium. Update the single launch-command owner, all validation/schema/help paths that treated Codex max as unsupported, the harness-adapters evidence table, relevant configuration documentation/examples, and focused tests without adding ultra support. Empirically verify Codex CLI accepts model_reasoning_effort="max" with gpt-5.6-sol and record the version, exact command shape, and result. Keep the change narrowly scoped and compatible with the Herdr-default direction. Preserve the pipeline fixes already made: disambiguate planning/design max from implementation/verification medium in the dispatch example, and retain the Bash 3.2 snapshot portability fix discovered by the full suite.

## What Changed

- Add native Codex `max` reasoning support to launch-command generation and dispatch validation without aliasing it to `xhigh`.
- Update dispatch examples and documentation to use `gpt-5.6-sol` with `max` for planning and design, while keeping implementation and verification profiles at `medium`.
- Add focused coverage and empirical CLI evidence for Codex `max`, and retain Bash 3.2-compatible snapshot heredoc handling.

## Risk Assessment

✅ Low: Капитан, изменение узко ограничено, согласовано во всех затронутых путях и полностью соответствует заявленному intent без выявленных существенных рисков.

## Testing

Успешный полный baseline дополнен focused-тестами launch/schema/snapshot на Bash 3.2, реальным Codex CLI 0.144.4 с `gpt-5.6-sol` и отдельным `max`, а также изолированным Firstmate E2E-транскриптом; первоначальная попытка указала несуществующее имя snapshot-теста и была исправлена на два фактических набора, итоговых проблем нет.

<details>
<summary>Evidence: Codex CLI: gpt-5.6-sol с reasoning effort max</summary>

```text
Command: codex --version
codex-cli 0.144.4

Command: codex exec --ephemeral --ignore-user-config --ignore-rules --sandbox read-only --model gpt-5.6-sol -c 'model_reasoning_effort="max"' 'Reply with exactly OK. Do not use tools.'
Reading additional input from stdin...
OpenAI Codex v0.144.4
--------
workdir: /Users/sviridov/.no-mistakes/worktrees/6ac4f1c45c06/01KXGW10R9ZJVGN0RQ8KRFHBMK
model: gpt-5.6-sol
provider: openai
approval: never
sandbox: read-only
reasoning effort: max
reasoning summaries: none
session id: 019f61d5-9eb9-7363-9af7-806caf0ee149
--------
user
Reply with exactly OK. Do not use tools.
codex
OK
tokens used
15,289
OK

Exit status: 0
```
</details>
<details>
<summary>Evidence: Firstmate E2E: сформированная команда и сохранённый профиль планирования</summary>

```text
Firstmate planning profile E2E

Invocation:
bin/fm-spawn.sh plan-max-e2e <project> --harness codex --model gpt-5.6-sol --effort max

Spawn output:
spawned plan-max-e2e harness=codex kind=ship mode=no-mistakes yolo=off window=firstmate:fm-plan-max-e2e worktree=/var/folders/zx/jptv31pd1nz_tb5pcnpp93vh0000gn/T/no-mistakes-evidence/01KXGW10R9ZJVGN0RQ8KRFHBMK/firstmate-planning-profile/wt
warn: no registry at /var/folders/zx/jptv31pd1nz_tb5pcnpp93vh0000gn/T/no-mistakes-evidence/01KXGW10R9ZJVGN0RQ8KRFHBMK/firstmate-planning-profile/home/data/projects.md; defaulting project to no-mistakes off

Generated harness launch command:
codex --model 'gpt-5.6-sol' -c 'model_reasoning_effort="max"' --dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch '/private/var/folders/zx/jptv31pd1nz_tb5pcnpp93vh0000gn/T/no-mistakes-evidence/01KXGW10R9ZJVGN0RQ8KRFHBMK/firstmate-planning-profile/home/state/plan-max-e2e.turn-ended'\"]" "$(cat '/var/folders/zx/jptv31pd1nz_tb5pcnpp93vh0000gn/T/no-mistakes-evidence/01KXGW10R9ZJVGN0RQ8KRFHBMK/firstmate-planning-profile/home/data/plan-max-e2e/brief.md')"

Persisted task profile:
harness=codex
model=gpt-5.6-sol
effort=max

Forbidden alias check:
PASS: max was not rewritten to xhigh
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- <code>Baseline, ранее успешно выполненный: `command -v tmux &gt;/dev/null || { echo &#34;tmux is required for e2e tests&#34; &gt;&amp;2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo &#34;== $t ==&#34;; bash &#34;$t&#34; || rc=1; done; exit &#34;$rc&#34;`</code>
- `bash tests/fm-spawn-dispatch-profile.test.sh`
- `bash tests/fm-bootstrap.test.sh`
- `bash tests/fm-fleet-snapshot-view.test.sh`
- `bash tests/fm-bearings-snapshot.test.sh`
- `codex --version`
- `codex exec --ephemeral --ignore-user-config --ignore-rules --sandbox read-only --model gpt-5.6-sol -c 'model_reasoning_effort="max"' 'Reply with exactly OK. Do not use tools.'`
- <code>Изолированный E2E-вызов `bin/fm-spawn.sh plan-max-e2e &lt;project&gt; --harness codex --model gpt-5.6-sol --effort max` с проверкой launch-команды, task meta и отсутствия подмены на `xhigh`</code>
- `jq -e '<planning=max, implementation/verification=medium, default=medium assertions>' docs/examples/crew-dispatch.json`
- <code>Проверка отсутствия добавленного `ultra` в diff через `rg -i &#39;\bultra\b&#39;`</code>
- <code>`bash --version` — тесты выполнялись на GNU Bash 3.2.57</code>
- <code>`git status --short` и проверка удаления `/tmp/fm-plan-max-e2e`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
