### PR TITLE
fix: absorb declared pause on a parked gate instead of wedge-nagging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,8 +81,8 @@ jobs:
           snapshot_output=$(/bin/bash tests/fm-fleet-snapshot-view.test.sh)
           printf '%s\n' "$snapshot_output"
           snapshot_count=$(printf '%s\n' "$snapshot_output" | grep -c '^ok - ')
-          [ "$snapshot_count" -eq 13 ] || {
-            echo "::error::expected 13 snapshot/fleet-view tests, got $snapshot_count"
+          [ "$snapshot_count" -eq 14 ] || {
+            echo "::error::expected 14 snapshot/fleet-view tests, got $snapshot_count"
             exit 1
           }
 

--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -280,9 +280,12 @@ signal_reason_is_actionable() {  # <file> ...
 #             pane; the crew is legitimately mid-work on a static-looking pane
 #             (e.g. waiting on CI);
 #   paused  - the crew's authoritative current state is a declared external-wait
-#             pause (paused:), which is EXPECTED to idle;
-#   none    - neither, so the wake must surface (a stopped/finished/parked/failed/
-#             torn-down/unknown crew, or an unreadable verdict).
+#             pause (paused:), which is EXPECTED to idle; fm-crew-state.sh also
+#             reconciles a genuinely parked run plus a declared pause to paused
+#             (a deliberate hold at a gate, e.g. a relayed captain decision);
+#   none    - neither, so the wake must surface (a stopped/finished/failed/
+#             torn-down/unknown crew, a run parked with no declared pause, or an
+#             unreadable verdict).
 # One fm-crew-state.sh read serves BOTH absorb reasons at once. Reading the state
 # authoritatively (not the status log) is what keeps run-step precedence: a crew
 # that appended paused: but then STARTED a run reports working, never paused.

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -31,7 +31,10 @@
 #   3. Reconcile the status log: if its last line says needs-decision/blocked but
 #      the run-step shows the run moved on, the log is deterministically stale and
 #      is flagged superseded. A genuinely parked run plus a needs-decision log
-#      agree, and are reported as parked.
+#      agree, and are reported as parked. A genuinely parked run plus a declared
+#      pause (paused:) also agree, and are reported as paused with the gate
+#      detail preserved, so a deliberate hold at an ask-user gate absorbs on the
+#      pause cadence instead of wedge-nagging.
 #   4. No run for this crew (pre-validation, or kind=scout): fall back to the
 #      recorded backend's pane busy state, then the status log's last line only
 #      when its verb maps to a recognized run-state. Decision-only events such as
@@ -478,6 +481,21 @@ if [ "$HAVE_RUN" = 1 ]; then
       [ -n "$fcount" ] && RUN_DETAIL="$RUN_DETAIL: $fcount finding(s)"
       if printf '%s\n' "$RUN_OUT" | grep -q 'ask-user'; then
         RUN_DETAIL="$RUN_DETAIL (ask-user: captain decision)"
+      fi
+      # A genuinely parked run plus a declared pause AGREE, the same way the
+      # parked+needs-decision pair below agrees: the crew is deliberately
+      # holding the gate open on a known external wait (typically a relayed
+      # captain decision), so the current state is the declared pause, with
+      # the gate detail preserved for the supervisor. Without this, the
+      # absorb classifier (fm-classify-lib.sh crew_absorb_class) reads
+      # parked as none and the watcher wedge-nags the deliberate hold every
+      # poll. Working runs keep precedence over a stale pause line (the
+      # running/fixing branches above never reach here), and a stale pause
+      # masking a gate the crew itself owes is bounded by the pause
+      # re-surface cadence (FM_PAUSE_RESURFACE_SECS).
+      if status_is_paused "$LOG_LINE"; then
+        RUN_STATE=paused
+        RUN_DETAIL="$RUN_DETAIL${SEP}declared pause: $(status_line_note "$LOG_LINE")"
       fi
     else
       case "$status" in

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -411,13 +411,16 @@ task_json_lines() {
     #     report POINTER, never as a reopened pending decision.
     # Secondmates are excluded from lifecycle clearing: they are persistent and
     # multiplex many concerns onto one stream, so activity on one concern must
-    # never clear another concern's keyed decision. A parked/blocked state, or a
+    # never clear another concern's keyed decision. A parked/paused/blocked state
+    # (paused includes fm-crew-state.sh's parked-run+declared-pause reconciliation,
+    # where the crew still holds the gate and its decision is still open), or a
     # non-authoritative status-log/none read on a still-live task, keeps the fold's
     # open decision surfacing.
     open_decisions_tsv=$(status_open_decisions "$status_log")
     if [ "$kind" != secondmate ] && \
        { { { [ "$current_source" = run-step ] || [ "$current_source" = pane ]; } \
-           && [ "$current_state" != parked ] && [ "$current_state" != blocked ]; } \
+           && [ "$current_state" != parked ] && [ "$current_state" != paused ] \
+           && [ "$current_state" != blocked ]; } \
          || { [ "$current_state" = "done" ] || [ "$current_state" = "failed" ]; }; }; then
       open_decisions_tsv=""
     fi

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,6 +25,7 @@ Crew status files are append-only wake-event logs, not current-state fields.
 `bin/fm-crew-state.sh <id>` is the cheap current-state read for an actionable heartbeat review: it attributes the matching no-mistakes run, active or terminal, to the crew's own branch and keeps that run-step authoritative even if the pane has closed.
 During no-mistakes' `ci` monitor phase, it also reads the ci step log tail because `axi status` reports both "still waiting on checks" and "checks green, waiting on merge" as `ci,running`.
 The most recent recognized ci log marker wins, so checks-green monitoring reports done while a later re-arm, failed-check, or issue marker returns the crew to working.
+A genuinely parked run whose status log ends in a declared `paused:` external wait agrees with that log and reports `paused` with the gate detail preserved, so a deliberate hold at an ask-user gate (typically a relayed captain decision) is absorbed on the pause cadence rather than treated as a possible wedge every poll; a parked run without a declared pause still surfaces.
 Only when no matching run exists does it fall back to the pane busy-signature and then a status-log event whose verb maps to a recognized run-state; a dead pane without a run reports unknown instead of trusting a stale log.
 Decision-only events such as `resolved` never become current state or leak their prose into the current-state detail.
 In that status-log fallback, a declared external wait reports the distinct `paused` state with its reason.

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -413,6 +413,55 @@ test_scalar_gate_parked_not_superseded() {
   pass "scalar gate parked run is not flagged superseded"
 }
 
+# genuine parked run + declared pause AGREE -> paused, gate detail preserved.
+# The regression pair for the 2026-07-14 review-gate wedge-nag incident: a crew
+# deliberately holding an ask-user gate for a relayed captain decision declared
+# paused:, but the parked run-step overrode the pause to none in
+# crew_absorb_class, so the watcher surfaced a plain stale every poll for the
+# whole wait.
+test_parked_run_with_declared_pause_is_paused() {
+  reset_fakes
+  local d; d=$(new_case parked-paused)
+  make_repo_on_branch "$d/wt" fm/feat-cp
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-cp.meta" "window=fm:fm-feat-cp" "worktree=$d/wt" "kind=ship"
+  printf 'working: validating\npaused: holding review gate for captain decision [key=gate-hold]\n' > "$d/state/feat-cp.status"
+  FM_FAKE_AXI_STATUS="$(run_parked fm/feat-cp)"
+  local out; out=$(run_crew_state "$d" feat-cp)
+  assert_contains "$out" "state: paused" "parked run + declared pause -> paused"
+  assert_contains "$out" "source: run-step" "parked+pause -> run-step source"
+  assert_contains "$out" "parked at review" "pause keeps the gate detail"
+  assert_contains "$out" "declared pause: holding review gate" "pause note surfaces in detail"
+  # The absorb classifier must read this as paused (absorb on the pause
+  # cadence), never none (wedge-nag): the watcher-facing half of the fix.
+  local cls
+  cls=$(FM_CREW_STATE_BIN="$CREW_STATE" \
+        PATH="$d/fakebin:$PATH" FM_STATE_OVERRIDE="$d/state" \
+        bash -c '. "'"$ROOT"'/bin/fm-classify-lib.sh"; crew_absorb_class feat-cp')
+  [ "$cls" = paused ] || fail "crew_absorb_class on parked+pause: want paused, got $cls"
+  pass "parked run with declared pause classifies paused"
+}
+
+# a parked run with a NON-pause last log line still surfaces as parked (none in
+# the absorb classifier); the pause reconciliation must not widen absorption.
+test_parked_run_without_pause_stays_parked() {
+  reset_fakes
+  local d; d=$(new_case parked-no-pause)
+  make_repo_on_branch "$d/wt" fm/feat-cq
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-cq.meta" "window=fm:fm-feat-cq" "worktree=$d/wt" "kind=ship"
+  printf 'working: validating\n' > "$d/state/feat-cq.status"
+  FM_FAKE_AXI_STATUS="$(run_parked fm/feat-cq)"
+  local out; out=$(run_crew_state "$d" feat-cq)
+  assert_contains "$out" "state: parked" "parked run without pause stays parked"
+  local cls
+  cls=$(FM_CREW_STATE_BIN="$CREW_STATE" \
+        PATH="$d/fakebin:$PATH" FM_STATE_OVERRIDE="$d/state" \
+        bash -c '. "'"$ROOT"'/bin/fm-classify-lib.sh"; crew_absorb_class feat-cq')
+  [ "$cls" = none ] || fail "crew_absorb_class on parked without pause: want none, got $cls"
+  pass "parked run without declared pause still surfaces"
+}
+
 test_gate_block_parked_not_superseded() {
   reset_fakes
   local d; d=$(new_case parked-gate-block)
@@ -1140,6 +1189,8 @@ test_stale_needs_decision_superseded
 test_stale_blocked_superseded
 test_genuine_parked_not_superseded
 test_scalar_gate_parked_not_superseded
+test_parked_run_with_declared_pause_is_paused
+test_parked_run_without_pause_stays_parked
 test_gate_block_parked_not_superseded
 test_ci_ready_done_log_beats_monitoring_run
 test_ci_monitoring_checks_green_surfaces_done

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -560,6 +560,60 @@ test_completed_scout_report_is_pointer_not_pending() {
   pass "a completed scout's stale decision surfaces as a report pointer, not pending"
 }
 
+# A run-step-sourced PAUSED state (fm-crew-state.sh's parked-run+declared-pause
+# reconciliation: the crew deliberately holds an ask-user gate while waiting on a
+# relayed captain decision) must NOT trigger the lifecycle clear: the crew has not
+# moved past the gate, so its keyed decision stays open and captain-visible.
+test_paused_gate_hold_keeps_open_decision() {
+  local home fakebin out
+  home=$(make_home paused-gate-hold)
+  fm_git_identity
+  mkdir -p "$home/projects/gate-hold"
+  git -C "$home/projects/gate-hold" init -q
+  git -C "$home/projects/gate-hold" commit -q --allow-empty -m init
+  git -C "$home/projects/gate-hold" checkout -q -b fm/gate-hold
+  fm_write_meta "$home/state/gate-hold.meta" \
+    "window=firstmate:fm-gate-hold" \
+    "worktree=$home/projects/gate-hold" \
+    "project=alpha" \
+    "harness=codex" \
+    "kind=ship" \
+    "mode=ship"
+  printf 'needs-decision [key=gate-hold]: approve product behavior change\n' > "$home/state/gate-hold.status"
+  printf 'paused: holding review gate for captain decision\n' >> "$home/state/gate-hold.status"
+  fakebin=$(make_fakebin "$home")
+  cat > "$fakebin/no-mistakes" <<'SH'
+#!/usr/bin/env bash
+set -u
+if [ "${1:-}" = axi ] && [ "${2:-}" = status ]; then
+  cat <<'TOON'
+run:
+  id: "01RUN"
+  branch: fm/gate-hold
+  status: awaiting_approval
+  awaiting_agent: parked 2m10s
+  head: "abc1234"
+  pr: ""
+  findings[1]{id,severity,file,line,action,description}:
+    r1,error,b.go,,ask-user,changes product behavior
+gate: review
+TOON
+fi
+exit 0
+SH
+  chmod +x "$fakebin/no-mistakes"
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$SNAPSHOT" --json)
+  printf '%s' "$out" | jq -e '
+    .tasks[] | select(.id == "gate-hold")
+    | .current_state.state == "paused"
+      and .current_state.source == "run-step"
+      and .hints.pending_decision == true
+      and (.hints.open_decisions | length) == 1
+      and .hints.open_decisions[0].key == "gate-hold"
+  ' >/dev/null || fail "a paused gate hold must keep its open decision captain-visible: $out"
+  pass "a run-step paused gate hold keeps its keyed decision open"
+}
+
 # The complementary safety property: a scout still PARKED at a decision (its last
 # event is the needs-decision, it has not finished) DOES stay pending. The terminal
 # clear must not over-fire on a live, undecided scout.
@@ -594,6 +648,7 @@ test_secondmate_open_decision_survives_live_endpoint
 test_open_decision_transfers_to_captain_hold
 test_open_decision_clears_on_keyed_resolution
 test_completed_scout_report_is_pointer_not_pending
+test_paused_gate_hold_keeps_open_decision
 test_parked_scout_decision_stays_pending
 test_scout_reports_include_teardown_reports
 test_backlog_tasks_axi_forms_and_overrides


### PR DESCRIPTION
## Intent

Fix the parked-gate declared-pause wedge (absorb a declared pause on a parked run instead of wedge-nagging, keep open decisions visible during paused gate holds, document the reconciliation) on branch fm/fix-watch-parked-pause. This is a rebase-and-fix pass onto current upstream main for existing PR #572: the branch was rebased cleanly onto origin/main with no conflicts, and one additional fix commit was added to correct the 'Stock macOS Bash snapshot compatibility' CI job, which hard-asserts an exact count of fleet-snapshot/fleet-view tests. That job is new upstream (added by the fleet-snapshot rework in commit eb9ee2f, PR #578) and this branch's own fix commits legitimately add a 13th snapshot/fleet-view test as additional coverage, so the hardcoded count assertion of 12 was tripping even though there is no real bash-3.2 incompatibility - the fix bumps the expected count from 12 to 13 to match. This was independently confirmed by running the exact stock-bash job commands locally with real stock macOS Bash 3.2.57, observing 13 passing snapshot/fleet-view tests and 30 passing bearings tests, matching the new assertions. No other behavior changed.

## What Changed

- `bin/fm-crew-state.sh` now reconciles a genuinely parked run with a trailing declared `paused:` status-log line into a single `paused` state (gate detail preserved), instead of reporting `none` and triggering repeated wedge-nag wakes; `bin/fm-classify-lib.sh`'s absorb-class comments are updated to describe this new agreement case.
- `bin/fm-fleet-snapshot.sh` keeps a fold's open decision visible when the current state is `paused` (in addition to the existing `parked`/`blocked` cases), so a paused gate hold doesn't prematurely clear an unresolved decision.
- `docs/architecture.md` documents the parked-run-plus-declared-pause reconciliation and its pause-cadence absorb behavior.
- `.github/workflows/ci.yml`'s stock macOS Bash snapshot job assertion is bumped from 13 to 14 to match the new `fm-fleet-snapshot-view.test.sh` coverage (`test_paused_gate_hold_keeps_open_decision`) added alongside the `fm-crew-state.test.sh` coverage for the new reconciliation path.

## Risk Assessment

✅ Low: The only outstanding issue from the prior round (CI stock-bash test count hardcoded at 13 vs actual 14) was fixed exactly as instructed in commit 1dfdf75, a minimal two-line change to .github/workflows/ci.yml with no other behavior touched, and the fix now matches the intent's acceptance criteria.

## Testing

Completed 1 recorded test check.

- Outcome: ⏭️ skipped across 1 run (16m53s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `.github/workflows/ci.yml:84` - This branch&#39;s own change adds a 14th passing test to tests/fm-fleet-snapshot-view.test.sh (test_paused_gate_hold_keeps_open_decision, confirmed via `pass` call count: 13 at base cd218f2, 14 at target 353bb1a), but .github/workflows/ci.yml&#39;s &#39;Stock macOS Bash snapshot compatibility&#39; job still hard-asserts snapshot_count -eq 13 unchanged from base. The user intent explicitly states this branch includes an additional fix commit that &#39;bumps the expected count from 12 to 13 to match&#39; and was &#39;independently confirmed by running the exact stock-bash job commands locally with real stock macOS Bash 3.2.57, observing 13 passing snapshot/fleet-view tests&#39; - but the reviewed diff (base cd218f2 to target 353bb1a) contains no change to ci.yml at all, and the actual post-branch test count is 14, not 13. As given, this target commit will make the stock-bash CI job fail with &#39;expected 13 snapshot/fleet-view tests, got 14&#39;. A commit titled &#39;fix: bump stock-bash snapshot count assertion to match added test&#39; (fe2494e) exists in the repository but is not an ancestor of either the stated base or target commit of this review, so it is absent from the reviewed range.

🔧 Fix: Bump stock-bash CI snapshot test count assertion from 13 to 14
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⏭️ **Test** - skipped</summary>

- 🚨 tests failed with exit code 1
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
