### PR TITLE
fix(snapshot): assign newline to var before case pattern to avoid tokenize-time split

### DIFF
--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -686,8 +686,9 @@ registry_secondmates_json() {
     if [ "$bytes" -gt "$max_bytes" ]; then
       byte_truncated=true
       content=$(printf "%s" "$content" | LC_ALL=C head -c "$max_bytes")
+      nl=$'\n'
       case "$content" in
-        *$'\n'*) content=${content%$'\n'*} ;;
+        *"$nl"*) content=${content%"$nl"*} ;;
         *) content= ;;
       esac
     fi
@@ -783,8 +784,9 @@ bounded_parent_activities_json() {  # <status-file>
     byte_truncated=false
     if [ "$size" -gt "$max_bytes" ]; then
       byte_truncated=true
+      nl=$'\n'
       case "$content" in
-        *$'\n'*) content=${content#*$'\n'} ;;
+        *"$nl"*) content=${content#*"$nl"} ;;
         *) content= ;;
       esac
     fi


### PR DESCRIPTION
Put back into draft as i think this fix isnt proper. double checking it on my local

## Problem

`$'\n'` inside a `case` pattern expands to a literal newline at tokenize time, splitting the case branch across lines so `;;` becomes an unexpected token:

```
fm-fleet-snapshot.sh: line 690: syntax error near unexpected token `;;
```

1. bash -n syntax check passed
2. fm-bearings-snapshot.sh runs clean (exit 0)
3. fm-fleet-snapshot.sh --json runs clean (exit 0)
4. All 12 tests in tests/fm-fleet-snapshot-view.test.sh pass


Edit: forgot to mention I'm on macOS 