### PR TITLE
feat: enforce bounded crew permissions and surface them in Fleet

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -26,6 +26,7 @@ Inheritance also copies the literal `config/crew-dispatch.json` file, so secondm
 
 Each adapter splits into mechanics and knowledge.
 The per-task mechanics, including launch command, autonomy flag, and crewmate turn-end hook, live in `bin/fm-spawn.sh`.
+The bounded-by-default launch policy and per-task unrestricted approval rule live in `docs/architecture.md` under "Bounded crew permissions".
 The primary-session "no turn ends blind" guard contract and harness hook installation paths live in `docs/turnend-guard.md`.
 The primary-session watcher wake protocols are rendered from `docs/supervision-protocols/` by `bin/fm-supervision-instructions.sh`.
 The supervision knowledge lives here: busy signature, exit command, interrupt, dialogs, resume behavior, skill invocation, and quirks.
@@ -110,7 +111,7 @@ Natural language is acceptable if uncertain.
 | Interrupt | single Escape |
 | Skill invocation | `/<skill>` (e.g. `/no-mistakes`) |
 
-First launch in a fresh worktree, or first ever on a machine, may show a trust or bypass-permissions confirmation.
+First launch in a fresh worktree, or first ever on a machine, may show a trust confirmation; an explicitly unrestricted launch may additionally show a bypass-permissions confirmation.
 After every spawn, peek the pane within about 20 seconds.
 If such a dialog is showing, accept it from an active firstmate session using `FM_HOME=<this-firstmate-home> bin/fm-send.sh <window> --key Enter`, or the choice the dialog requires, unless `FM_HOME` is already set to the active firstmate home; verify the brief started processing.
 
@@ -189,7 +190,7 @@ The follow-up was verified in the interactive TUI; `opencode run` can exit befor
 | Exit command | `/quit` |
 | Interrupt | single Escape |
 
-Pi has no permission system, so crewmates are always autonomous.
+Pi has no permission system, so it has no verified bounded unattended crew profile; follow the bounded crew permission policy instead of launching it silently.
 Keep the brief as one positional argument.
 Multiple positional args become separate queued messages; `fm-spawn`'s template already does this correctly.
 
@@ -212,7 +213,7 @@ When a secondmate is launched on Pi, `fm-spawn.sh --secondmate` launches Pi with
 ## grok (VERIFIED 2026-06-29, grok 0.2.73; slash-submit re-verified 2026-07-03 on 0.2.82; reasoning-effort ceiling re-verified 2026-07-13 on 0.2.99)
 
 Grok Build TUI (`grok`), a Claude-Code-compatible CLI from xAI.
-Launch with a positional prompt: `grok --always-approve "$(cat <brief>)"`.
+Grok uses a positional prompt, while `fm-spawn.sh` owns its exact launch template and permission gate.
 For Grok's supported reasoning-effort values and omission behavior, see the [launch-profile-axes table](#launch-profile-axes).
 
 | Fact | Value |
@@ -221,7 +222,7 @@ For Grok's supported reasoning-effort values and omission behavior, see the [lau
 | Exit command | `Ctrl+Q` double-press within 1000ms (it is a confirmed destructive action). Prints `Resume this session with: grok --resume <session-id>`. `Ctrl+D` is the quit key in VS Code family terminals. NOT `/exit` and NOT `Ctrl+C`. |
 | Interrupt | single `Ctrl+C` (cancels the current turn; the footer shows `Ctrl+c:cancel` mid-turn). `Esc` only moves focus to the scrollback, it does NOT interrupt. |
 | Skill invocation | `/<skill>` (e.g. `/no-mistakes`), same as claude. Opens a slash-autocomplete popup, so a too-fast Enter selects the popup entry instead of sending. For an argument-taking command that first Enter does not submit at all - it expands the selection into an argument-hint placeholder in the composer (e.g. `/compact` -> `/compact compaction instructions`, live-verified), leaving real text still sitting there unsubmitted; a genuine second Enter is required. `fm-send`'s retried Enter lands it on BOTH backends, but only because each backend's own submit-verification correctly recognizes that placeholder-filled text as still-pending - see the incident below. |
-| Autonomy | `--always-approve` (footer shows `· always-approve`); auto-approves every tool execution, verified to run fully unattended. `--permission-mode bypassPermissions` is the stronger equivalent. |
+| Autonomy | `--always-approve` (footer shows `· always-approve`) auto-approves every tool execution and is verified to run fully unattended, but Firstmate exposes it only through the explicitly approved unrestricted profile. `--permission-mode bypassPermissions` is the stronger equivalent. |
 | Env marker | `GROK_AGENT=1`, set for child/tool processes. grok does NOT set `CLAUDECODE` despite Claude compatibility, so the marker is unambiguous. |
 | Resume | `grok --resume <session-id>` (id printed on exit) or `grok -c` / `--continue` (most recent for the cwd); `--fork-session` branches a new session id. |
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,7 +95,7 @@ state/               volatile runtime signals; gitignored
   <id>.status        appended by crewmates: "<state>: <note>" wake-event lines, not current-state truth
   <id>.turn-ended    touched by turn-end hooks
   <id>.grok-turnend-token   firstmate-owned grok hook registry token for the task; removed by teardown
-  <id>.meta          written by fm-spawn: window=, worktree=, project=, harness=, model=, effort=, kind=, mode=, yolo=, tasktmp=; kind=secondmate also records home= and projects=; a non-default runtime backend records further backend-specific fields (docs/configuration.md "Runtime backend"; bin/fm-backend.sh, section 8); fm-pr-check, including through fm-pr-merge, appends pr= and GitHub's pr_head= when available; fm-x-link appends x_request=, x_request_ts=, x_followups=, and optional x_platform=/x_reply_max_chars= for an X-mode-originated task (section 14)
+  <id>.meta          written by fm-spawn: window=, worktree=, project=, harness=, permissions=, model=, effort=, kind=, mode=, yolo=, tasktmp=; kind=secondmate also records home= and projects=; a non-default runtime backend records further backend-specific fields (docs/configuration.md "Runtime backend"; bin/fm-backend.sh, section 8); fm-pr-check, including through fm-pr-merge, appends pr= and GitHub's pr_head= when available; fm-x-link appends x_request=, x_request_ts=, x_followups=, and optional x_platform=/x_reply_max_chars= for an X-mode-originated task (section 14)
   <id>.check.sh      optional slow poll you write per task (e.g. merged-PR check)
   x-watch.check.sh   generated X-mode relay poll shim; present only when opted in (section 14)
   x-inbox/           generated X-mode pending mention payloads; fmx-respond drains it (section 14)
@@ -421,9 +421,10 @@ bin/fm-spawn.sh <id> [<firstmate-home>] --secondmate   # launch or recover a per
 bin/fm-spawn.sh <id1>=projects/<repo1> <id2>=projects/<repo2> [--scout]   # batch: one call, several tasks
 ```
 
-Batch dispatch spawns each `id=repo` pair through the same single-task path, with shared `--scout`, `--harness`, `--model`, `--effort`, and `--backend` flags applying to all; one failed pair does not stop the rest, and the batch exits non-zero.
+Batch dispatch spawns each `id=repo` pair through the same single-task path, with shared `--scout`, `--harness`, `--model`, `--effort`, `--backend`, and `--unrestricted` flags applying to all; one failed pair does not stop the rest, and the batch exits non-zero.
 When `config/crew-dispatch.json` exists, include an explicit resolved harness for every crewmate or scout spawn or batch after consulting the dispatch rules (section 4).
 `bin/fm-spawn.sh`'s header owns the full resolution contract: harness and runtime-backend resolution order, spawn-capable backends and the `codex-app` rejection, verified launch templates, delivery-mode resolution, recorded meta fields, and per-harness turn-end hook installation.
+Crew launches use verified bounded profiles by default; never pass `--unrestricted` without the captain's explicit approval for that task, and surface a fail-closed adapter instead of weakening its permissions silently.
 A backend spawn refusal - a missing dependency, an unauthenticated socket, or a version gate - must be surfaced to the captain as a blocker; never silently retry the spawn on a different backend to work around it.
 For ship and scout tasks, the script asserts the resolved worktree is a genuine isolated worktree distinct from the primary checkout, aborting the spawn otherwise to prevent the worktree tangle of section 8.
 For `kind=secondmate`, it launches in the registered or explicit firstmate home with the charter brief as the launch prompt, after the guarded home sync and inheritable-config propagation owned by `secondmate-provisioning`.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You can run one coding agent easily.
 But the moment you want three project tasks done in parallel - fixes, investigations, plans, audits - you become a tab-juggler: babysitting sessions, copy-pasting context between repos, forgetting which terminal had the failing test.
 
 firstmate flips the model.
-You talk to a single agent - the first mate - and it runs the crew for you: spawning autonomous agents in a visible session backend, giving each a clean git worktree, supervising them to completion, and handing you finished PRs, approved local merges, or standalone investigation reports.
+You talk to a single agent - the first mate - and it runs the crew for you: spawning bounded-by-default crew agents in a visible session backend, giving each a clean git worktree, supervising them to completion, and handing you finished PRs, approved local merges, or standalone investigation reports.
 For larger fleets, you can opt in to persistent secondmates: domain supervisors that are still ordinary direct reports, but run from their own isolated firstmate homes.
 
 firstmate is not a model, not a harness, not a skill, not an MCP server, and not a CLI.
@@ -140,7 +140,7 @@ Setup guides for tmux (the default) and every other supported backend (herdr, ze
     ▼              ▼               ▼
  ┌────────┐   ┌────────┐      ┌────────┐
  │fm-task1│   │fm-task2│  ... │fm-taskN│   tmux windows, herdr/zellij tabs, cmux workspaces, or Orca terminals
- │crewmate│   │crewmate│      │crewmate│   one autonomous agent each
+ │crewmate│   │crewmate│      │crewmate│   one crew agent each, bounded by default
  └───┬────┘   └───┬────┘      └───┬────┘
      ▼            ▼               ▼
   treehouse worktree, Orca worktree, or isolated secondmate home

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ All three have verified turn-end guard paths when launched with their documented
 Pick whichever one matches your subscription and workflow.
 
 Codex and OpenCode are also verified and supported as primary harnesses; Codex uses bounded foreground checkpoints, and OpenCode uses a TUI plugin, so both carry more harness-specific supervision tradeoffs than the three co-primaries.
+Primary-session support is separate from crew launch permissions: crew launches are bounded by default, and an adapter without a verified bounded profile requires explicit per-task approval as documented in [Bounded crew permissions](docs/architecture.md#bounded-crew-permissions).
 
 ### Install and launch
 

--- a/bin/fm-bearings-snapshot.sh
+++ b/bin/fm-bearings-snapshot.sh
@@ -91,8 +91,8 @@ usage: fm-bearings-snapshot.sh [--json] [--include-prs] [--fields <list>]
 Compact bearings projection over fm-fleet-snapshot.sh. TOON by default.
 Default is LOCAL-ONLY (no network); --include-prs is the only path that fetches.
 
-Default fields: schema, home, generated, prs, in_flight{id,kind,state,doing},
-  secondmates{id,state,doing,provenance,freshness,age_seconds,contradiction,reason},
+Default fields: schema, home, generated, prs, in_flight{id,kind,permissions,state,doing},
+  secondmates{id,state,permissions,doing,provenance,freshness,age_seconds,contradiction,reason},
   decisions_open{id,key,verb,summary,owner}, landed{id,what,artifact,owner},
   gates{id,title,blocked_by,reason,owner}, reports{id,path}, recorded_prs{id,url},
   unhealthy_endpoints{...} (only when non-empty), omitted{surface,reveal}.
@@ -285,6 +285,9 @@ MODEL=$(printf '%s' "$SNAP" | jq \
   --argjson candidate_prs "$CANDIDATE_PRS" '
   def trunc($n): if . == null then null else
     (tostring | gsub("\\s+"; " ") | if (length > $n) then (.[:$n] + "…") else . end) end;
+  def permission_summary($xs):
+    ($xs | map(if . == null or . == "" then "unknown" else . end) | unique) as $p
+    | if ($p | length) == 1 then $p[0] else "unknown" end;
   ($fields | split(",") | map(gsub("^\\s+|\\s+$"; "")) | map(select(. != ""))) as $fl
   | (($fl | index("bodies")) != null) as $f_bodies
   | (($fl | index("paths")) != null) as $f_paths
@@ -310,13 +313,15 @@ MODEL=$(printf '%s' "$SNAP" | jq \
          | select(.endpoint.exists == false or .endpoint.agent_alive == "dead")
          | {id:($m.id + "/" + .id),backend:"secondmate-home",target:(.endpoint.target // "-"),exists:.endpoint.exists,agent:.endpoint.agent_alive} ]) as $unhealthy_all
   | ([ if .secondmate_current.registry.available == false then
-         {id:"(registry)",state:"unknown",doing:(.secondmate_current.registry.reason // "Registered secondmate table unavailable"),
+         {id:"(registry)",state:"unknown",permissions:"unknown",
+          doing:(.secondmate_current.registry.reason // "Registered secondmate table unavailable"),
           provenance:(.secondmate_current.registry.provenance // "registered-table"),
           freshness:(.secondmate_current.registry.freshness.status // "unavailable"),
           age_seconds:null,contradiction:false,reason:(.secondmate_current.registry.reason // "Registered secondmate table unavailable")}
        else empty end ]
      + [ (.secondmate_current.records // [])[]
        | {id,state:.current.state,
+          permissions:(permission_summary([.endpoints[]?.permissions])),
           doing:((if .current.state == "active_child_work" then
                     ([.active_children[] | .id + ": " + (.doing // .state)] | join("; "))
                   elif .current.state == "captain_decision" then
@@ -329,14 +334,16 @@ MODEL=$(printf '%s' "$SNAP" | jq \
           age_seconds:.freshness.age_seconds,contradiction:(.contradiction // false),
           reason:(.current.reason // "-")} ]) as $secondmates_all
   | ([ .tasks[] | select(.kind != "secondmate") | {
-        id, kind,
+        id, kind, permissions:(.permissions // "unknown"),
         state: .current_state.state,
         doing: ((.current_state.detail // "") as $d
                 | (if $d != "" then $d else (.hints.last_event_text // "") end) | trunc(90))
       } ]
      + [ (.secondmate_current.records // [])[]
          | select(.current.state == "active_child_work")
-         | {id,kind:"secondmate",state:.current.state,
+         | {id,kind:"secondmate",
+            permissions:(permission_summary([.active_children[]?.permissions])),
+            state:.current.state,
             doing:([.active_children[] | .id + ": " + (.doing // .state)] | join("; ") | trunc(90))} ]) as $in_flight_all
   | ([ .tasks[] as $t | select($t.kind != "secondmate") | ($t.hints.open_decisions // [])[]
        | {id:$t.id, key, verb, summary:(.summary | trunc(90)),owner:"(main)"} ]

--- a/bin/fm-bearings-snapshot.sh
+++ b/bin/fm-bearings-snapshot.sh
@@ -285,14 +285,12 @@ MODEL=$(printf '%s' "$SNAP" | jq \
   --argjson candidate_prs "$CANDIDATE_PRS" '
   def trunc($n): if . == null then null else
     (tostring | gsub("\\s+"; " ") | if (length > $n) then (.[:$n] + "…") else . end) end;
-  def permission_summary($xs):
-    ($xs | map(if . == null or . == "" then "unknown" else . end) | unique) as $p
-    | if ($p | length) == 1 then $p[0] else "unknown" end;
   ($fields | split(",") | map(gsub("^\\s+|\\s+$"; "")) | map(select(. != ""))) as $fl
   | (($fl | index("bodies")) != null) as $f_bodies
   | (($fl | index("paths")) != null) as $f_paths
   | (($fl | index("actions")) != null) as $f_actions
   | (($fl | index("endpoints")) != null) as $f_endpoints
+  | ([ .tasks[] | select(.kind == "secondmate") | {key:.id, value:(.permissions // "unknown")} ] | from_entries) as $secondmate_permissions
   | ([ .backlog.records[] | select(.state == "done" and .structured)
        | {id, title, pr_url, report_path, local_note, completion, home:"(main)", home_id:"(main)"} ]) as $main_done
   | ((.secondmate_landed.records) // []) as $mate_done
@@ -321,7 +319,7 @@ MODEL=$(printf '%s' "$SNAP" | jq \
        else empty end ]
      + [ (.secondmate_current.records // [])[]
        | {id,state:.current.state,
-          permissions:(permission_summary([.endpoints[]?.permissions])),
+          permissions:($secondmate_permissions[.id] // "unknown"),
           doing:((if .current.state == "active_child_work" then
                     ([.active_children[] | .id + ": " + (.doing // .state)] | join("; "))
                   elif .current.state == "captain_decision" then
@@ -342,7 +340,7 @@ MODEL=$(printf '%s' "$SNAP" | jq \
      + [ (.secondmate_current.records // [])[]
          | select(.current.state == "active_child_work")
          | {id,kind:"secondmate",
-            permissions:(permission_summary([.active_children[]?.permissions])),
+            permissions:($secondmate_permissions[.id] // "unknown"),
             state:.current.state,
             doing:([.active_children[] | .id + ": " + (.doing // .state)] | join("; ") | trunc(90))} ]) as $in_flight_all
   | ([ .tasks[] as $t | select($t.kind != "secondmate") | ($t.hints.open_decisions // [])[]

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -275,7 +275,8 @@ secondmate_liveness_sweep() {
   # MID-SESSION is a harder follow-on needing a periodic liveness beacon -
   # explicitly out of scope here.
   [ -d "$STATE" ] || return 0
-  local meta id window harness backend target verdict out
+  local meta id window harness backend target verdict out permissions
+  local -a respawn_args
   for meta in "$STATE"/*.meta; do
     [ -f "$meta" ] || continue
     grep -q '^kind=secondmate$' "$meta" 2>/dev/null || continue
@@ -296,8 +297,11 @@ secondmate_liveness_sweep() {
         echo "SECONDMATE_LIVENESS: secondmate $id: already-live"
         ;;
       dead)
+        permissions=$(fm_meta_get "$meta" permissions)
+        respawn_args=("$id" --secondmate)
+        [ "$permissions" != unrestricted ] || respawn_args+=(--unrestricted)
         fm_backend_kill "$backend" "$target" 2>/dev/null || true
-        if out=$(FM_SPAWN_NO_GUARD=1 "$FM_ROOT/bin/fm-spawn.sh" "$id" --secondmate 2>&1); then
+        if out=$(FM_SPAWN_NO_GUARD=1 "$FM_ROOT/bin/fm-spawn.sh" "${respawn_args[@]}" 2>&1); then
           echo "SECONDMATE_LIVENESS: secondmate $id: respawned"
         else
           echo "SECONDMATE_LIVENESS: secondmate $id: respawn failed: $(first_line "$out")"

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -33,8 +33,10 @@
 #          distinct from the endpoint pane-presence check): already-live is a
 #          no-op, respawned means a confirmed-dead endpoint (a bare shell left
 #          behind by an exited secondmate agent) was killed and relaunched via
-#          bin/fm-spawn.sh --secondmate, and skipped means the probe could not
-#          confidently classify the endpoint (never acted on - a false-dead
+#          bin/fm-spawn.sh --secondmate, replaying an already-recorded
+#          unrestricted approval only when today's resolved secondmate harness
+#          still matches that approved harness, and skipped means the probe could
+#          not confidently classify the endpoint (never acted on - a false-dead
 #          reading would spin up a duplicate agent). Session-start scope only;
 #          see AGENTS.md "Session start" and docs/tmux-backend.md /
 #          docs/herdr-backend.md "Agent liveness probe" for the empirical basis.
@@ -275,8 +277,10 @@ secondmate_liveness_sweep() {
   # MID-SESSION is a harder follow-on needing a periodic liveness beacon -
   # explicitly out of scope here.
   [ -d "$STATE" ] || return 0
-  local meta id window harness backend target verdict out permissions
+  local meta id window harness backend target verdict out permissions approved_harness
+  local current_secondmate_harness
   local -a respawn_args
+  current_secondmate_harness=
   for meta in "$STATE"/*.meta; do
     [ -f "$meta" ] || continue
     grep -q '^kind=secondmate$' "$meta" 2>/dev/null || continue
@@ -298,8 +302,14 @@ secondmate_liveness_sweep() {
         ;;
       dead)
         permissions=$(fm_meta_get "$meta" permissions)
+        approved_harness=$(fm_meta_get "$meta" approved_harness)
         respawn_args=("$id" --secondmate)
-        [ "$permissions" != unrestricted ] || respawn_args+=(--unrestricted)
+        if [ "$permissions" = unrestricted ] && [ -n "$approved_harness" ]; then
+          if [ -z "$current_secondmate_harness" ]; then
+            current_secondmate_harness=$("$FM_ROOT/bin/fm-harness.sh" secondmate 2>/dev/null || true)
+          fi
+          [ "$approved_harness" != "$current_secondmate_harness" ] || respawn_args+=(--unrestricted)
+        fi
         fm_backend_kill "$backend" "$target" 2>/dev/null || true
         if out=$(FM_SPAWN_NO_GUARD=1 "$FM_ROOT/bin/fm-spawn.sh" "${respawn_args[@]}" 2>&1); then
           echo "SECONDMATE_LIVENESS: secondmate $id: respawned"

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -350,7 +350,7 @@ backlog_json() {  # [<backlog-path>] - defaults to this home's $BACKLOG
 }
 
 task_json_lines() {
-  local meta id kind harness mode yolo project worktree home projects backend target status_log report_path
+  local meta id kind harness permissions mode yolo project worktree home projects backend target status_log report_path
   local pr pr_source event_json current_json endpoint_exists agent_alive meta_json status_json report_json worktree_json home_json
   local last_event_raw current_state current_source pending_decision blocked_event report_present=0 pr_from_status
   local open_decisions_tsv open_decisions_json
@@ -361,6 +361,8 @@ task_json_lines() {
     kind=$(meta_value "$meta" kind)
     [ -n "$kind" ] || kind=ship
     harness=$(meta_value "$meta" harness)
+    permissions=$(meta_value "$meta" permissions)
+    [ -n "$permissions" ] || permissions=unknown
     mode=$(meta_value "$meta" mode)
     yolo=$(meta_value "$meta" yolo)
     project=$(meta_value "$meta" project)
@@ -443,6 +445,7 @@ task_json_lines() {
       --arg id "$id" \
       --arg kind "$kind" \
       --arg harness "$harness" \
+      --arg permissions "$permissions" \
       --arg mode "$mode" \
       --arg yolo "$yolo" \
       --arg project "$project" \
@@ -471,6 +474,7 @@ task_json_lines() {
         id:$id,
         kind:$kind,
         harness:($harness // ""),
+        permissions:$permissions,
         mode:($mode // ""),
         yolo:($yolo // ""),
         project:($project // ""),

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -558,7 +558,7 @@ secondmate_home_summary_json() {  # <backlog-json> <tasks-json>
     | ([ $owned_in_flight[] as $work
          | $tasks[]
          | select(.id == $work.id and .current_state.state == "working")
-         | {id,kind,state:.current_state.state,source:.current_state.source,
+         | {id,kind,permissions:(.permissions // "unknown"),state:.current_state.state,source:.current_state.source,
             doing:((.current_state.detail // "") | trunc(120))} ]) as $active_all
     | ([ $tasks[] as $t | ($t.hints.open_decisions // [])[]
          | {id:$t.id,key,verb,summary:(.summary | trunc(160))} ]) as $decisions_all
@@ -607,7 +607,7 @@ secondmate_home_summary_json() {  # <backlog-json> <tasks-json>
           repo:((.repo // null) | if . == null then null else trunc(120) end),
           kind:((.kind // null) | if . == null then null else trunc(40) end)}][:$queued_n]),
         landed:(if $landed_n == 0 then $landed_all else $landed_all[:$landed_n] end),
-        endpoints:([$tasks[] | {id,state:.current_state.state,source:.current_state.source,
+        endpoints:([$tasks[] | {id,permissions:(.permissions // "unknown"),state:.current_state.state,source:.current_state.source,
           endpoint:(.endpoint + {target:((.endpoint.target // null) | if . == null then null else trunc(240) end)})}][:$child_n]),
         counts:{
           active_children:($active_all | length),

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -16,6 +16,8 @@
 #     Canonical tasks-axi rows are structured; free-form non-empty lines in
 #     those sections are preserved as unstructured records.
 #   tasks[]: one row per state/<id>.meta, sorted by id.
+#     permissions is the recorded bounded, unrestricted, or custom launch profile;
+#     legacy metadata without that field is projected as unknown.
 #     current_state is parsed from bin/fm-crew-state.sh <id> and preserves
 #     state, source, detail, and raw line separately.
 #     paths.status_log.last_event is historical wake-event data only, never
@@ -27,6 +29,8 @@
 #     endpoint.exists is the cheap backend endpoint-presence read.
 #     endpoint.agent_alive is populated for secondmates only, where it is useful
 #     return-channel supervision data; other tasks use "not_checked".
+#     Registered-secondmate active_children and endpoints preserve each nested
+#     task's permissions value for Fleet consumers.
 #   scout_reports[]: present data/<id>/report.md pointers.
 #   secondmate_current: {records[],total,shown,truncated} - bounded current summaries
 #     for registered secondmates, selected from validated structured state inside

--- a/bin/fm-fleet-view.sh
+++ b/bin/fm-fleet-view.sh
@@ -51,7 +51,7 @@ printf '%s\n' "$SNAPSHOT" | jq -r '
     if $t.kind == "secondmate" then "\($t.actions.send) - \($t.actions.watch)"
     else $t.actions.watch end;
   def task_row($t):
-    "| \($t.id) | \($t.current_state.state) / \($t.current_state.source) | \($t.kind) | \(dash($t.backlog.repo // $t.project)) | \($t.backend) | \(endpoint_of($t)) | \(artifact($t)) | \(path_of($t)) | \(action_of($t)) |";
+    "| \($t.id) | \($t.current_state.state) / \($t.current_state.source) | \($t.permissions // "unknown") | \($t.kind) | \(dash($t.backlog.repo // $t.project)) | \($t.backend) | \(endpoint_of($t)) | \(artifact($t)) | \(path_of($t)) | \(action_of($t)) |";
   def blocker($r):
     if ($r.blocked_by // "") == "" then "-"
     elif ($r.blocked_reason // "") == "" then $r.blocked_by
@@ -68,8 +68,8 @@ printf '%s\n' "$SNAPSHOT" | jq -r '
   (if (.tasks | length) == 0 then
     "No live task metadata found."
    else
-    "| ID | Current | Kind | Repo/Project | Backend | Endpoint | Artifact | Path | Watch / return channel |",
-    "| --- | --- | --- | --- | --- | --- | --- | --- | --- |",
+    "| ID | Current | Permissions | Kind | Repo/Project | Backend | Endpoint | Artifact | Path | Watch / return channel |",
+    "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |",
     (.tasks[] | task_row(.))
    end),
   "",

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -9,6 +9,9 @@
 #   one fail closed unless --unrestricted explicitly opts this spawn into the
 #   harness's autonomous mode with the captain's per-task approval. Raw launch
 #   commands are recorded as permissions=custom unless --unrestricted is also present.
+#   An unrestricted secondmate launch also records which harness received that
+#   approval, and bootstrap recovery replays it only when the current resolved
+#   secondmate harness still matches that recorded approval.
 #   --model <name> and --effort <low|medium|high|xhigh|max> are concrete profile
 #   axes chosen by firstmate at intake. They are only threaded into harnesses whose
 #   installed CLIs were verified to support that axis; unsupported axes are omitted
@@ -232,6 +235,7 @@ orca_spawn_abort_cleanup() {
           echo "harness=$HARNESS"
           echo "kind=$KIND"
           echo "permissions=$PERMISSIONS"
+          [ "$PERMISSIONS" != unrestricted ] || echo "approved_harness=$HARNESS"
           echo "mode=${MODE:-no-mistakes}"
           echo "yolo=${YOLO:-off}"
           echo "tasktmp=${TASK_TMP:-}"
@@ -1038,6 +1042,7 @@ META_WINDOW=$T
   echo "harness=$HARNESS"
   echo "kind=$KIND"
   echo "permissions=$PERMISSIONS"
+  [ "$PERMISSIONS" != unrestricted ] || echo "approved_harness=$HARNESS"
   echo "mode=$MODE"
   echo "yolo=$YOLO"
   echo "tasktmp=$TASK_TMP"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -5,10 +5,10 @@
 #        fm-spawn.sh <task-id> [<firstmate-home>] [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] [--unrestricted] --secondmate
 #   --harness <name> is the explicit per-spawn harness/profile adapter. The old
 #   positional harness arg still works for back-compat.
-#   Verified harness launches use bounded permissions by default. --unrestricted
-#   opts this spawn into the harness's permission-bypass mode and requires the
-#   captain's explicit per-task approval. Raw launch commands are recorded as
-#   permissions=custom unless --unrestricted is also present.
+#   Harnesses with verified bounded profiles use them by default. Adapters without
+#   one fail closed unless --unrestricted explicitly opts this spawn into the
+#   harness's autonomous mode with the captain's per-task approval. Raw launch
+#   commands are recorded as permissions=custom unless --unrestricted is also present.
 #   --model <name> and --effort <low|medium|high|xhigh|max> are concrete profile
 #   axes chosen by firstmate at intake. They are only threaded into harnesses whose
 #   installed CLIs were verified to support that axis; unsupported axes are omitted
@@ -354,6 +354,7 @@ launch_template() {
       printf '%s' 'OPENCODE_CONFIG_CONTENT='\''{"permission":{"*":"allow"}}'\'' opencode __MODELFLAG__--prompt "$(cat __BRIEF__)"'
       ;;
     pi)
+      [ "$permissions" = unrestricted ] || return 2
       if [ "$kind" = secondmate ]; then
         printf '%s' 'pi __MODELFLAG____EFFORTFLAG__-e __PITURNEND__ -e __PIWATCH__ "$(cat __BRIEF__)"'
       else

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1,10 +1,14 @@
 #!/usr/bin/env bash
 # Spawn a direct report: a crewmate in a treehouse or Orca worktree, or a
 # secondmate in its isolated firstmate home.
-# Usage: fm-spawn.sh <task-id> <project-dir> [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] [--scout]
-#        fm-spawn.sh <task-id> [<firstmate-home>] [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] --secondmate
+# Usage: fm-spawn.sh <task-id> <project-dir> [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] [--unrestricted] [--scout]
+#        fm-spawn.sh <task-id> [<firstmate-home>] [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] [--unrestricted] --secondmate
 #   --harness <name> is the explicit per-spawn harness/profile adapter. The old
 #   positional harness arg still works for back-compat.
+#   Verified harness launches use bounded permissions by default. --unrestricted
+#   opts this spawn into the harness's permission-bypass mode and requires the
+#   captain's explicit per-task approval. Raw launch commands are recorded as
+#   permissions=custom unless --unrestricted is also present.
 #   --model <name> and --effort <low|medium|high|xhigh|max> are concrete profile
 #   axes chosen by firstmate at intake. They are only threaded into harnesses whose
 #   installed CLIs were verified to support that axis; unsupported axes are omitted
@@ -60,7 +64,7 @@
 # Batch dispatch: pass one or more `id=repo` pairs instead of a single <id> <project>, e.g.
 #     fm-spawn.sh fix-a-k3=projects/foo add-b-q7=projects/bar [--scout]
 #   Each pair re-execs this script in single-task mode, so the single path stays the only
-#   source of truth; shared --scout/--harness/--model/--effort/--backend applies to every pair.
+#   source of truth; shared --scout/--harness/--model/--effort/--backend/--unrestricted applies to every pair.
 #   If config/crew-dispatch.json exists, shared --harness is required for crewmate
 #   and scout batches. The loop lives here, in bash, so callers never hand-write a
 #   multi-task shell loop (the tool shell is zsh, which does not word-split unquoted
@@ -76,7 +80,7 @@
 # Per-harness turn-end hooks are installed automatically; some live outside the worktree.
 # grok uses a firstmate-owned global hook under ${GROK_HOME:-$HOME/.grok}/hooks
 # plus a gitignored .fm-grok-turnend worktree pointer and a state token.
-# On success prints: spawned <id> harness=<name> kind=<ship|scout|secondmate> mode=<mode> yolo=<on|off> window=<backend-target> worktree=<path>
+# On success prints: spawned <id> harness=<name> kind=<ship|scout|secondmate> permissions=<bounded|unrestricted|custom> mode=<mode> yolo=<on|off> window=<backend-target> worktree=<path>
 # mode/yolo are resolved per-project from data/projects.md for ship/scout tasks;
 # secondmate spawns record mode=secondmate, yolo=off, home=, and projects=.
 set -eu
@@ -84,7 +88,7 @@ set -eu
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 usage() {
-  sed -n '2,78p' "$0" | sed 's/^# \{0,1\}//'
+  sed -n '2,85p' "$0" | sed 's/^# \{0,1\}//'
 }
 
 case "${1:-}" in
@@ -117,6 +121,7 @@ HARNESS_ARG=
 MODEL=
 EFFORT=
 BACKEND_ARG=
+PERMISSIONS=bounded
 HARNESS_SET=0
 MODEL_SET=0
 EFFORT_SET=0
@@ -149,6 +154,7 @@ for a in "$@"; do
     --effort=*) EFFORT=${a#--effort=}; EFFORT_SET=1 ;;
     --backend) want_value=backend ;;
     --backend=*) BACKEND_ARG=${a#--backend=}; BACKEND_SET=1 ;;
+    --unrestricted) PERMISSIONS=unrestricted ;;
     *) POS+=("$a") ;;
   esac
 done
@@ -225,6 +231,7 @@ orca_spawn_abort_cleanup() {
           echo "project=$PROJ_ABS"
           echo "harness=$HARNESS"
           echo "kind=$KIND"
+          echo "permissions=$PERMISSIONS"
           echo "mode=${MODE:-no-mistakes}"
           echo "yolo=${YOLO:-off}"
           echo "tasktmp=${TASK_TMP:-}"
@@ -260,6 +267,7 @@ if [ "${#POS[@]}" -gt 0 ] && [ "${POS[0]}" != "$idpart" ] && case "$idpart" in *
   [ -z "$MODEL" ] || shared_args+=(--model "$MODEL")
   [ -z "$EFFORT" ] || shared_args+=(--effort "$EFFORT")
   [ -z "$BACKEND_ARG" ] || shared_args+=(--backend "$BACKEND_ARG")
+  [ "$PERMISSIONS" = bounded ] || shared_args+=(--unrestricted)
   for pair in "${POS[@]}"; do
     case "$pair" in
       *=*) : ;;
@@ -309,7 +317,7 @@ fi
 # The verified launch command per adapter. The knowledge half of each adapter
 # (busy signature, exit command, dialogs, quirks) lives in the harness-adapters skill.
 launch_template() {
-  local harness=$1 kind=${2:-ship}
+  local harness=$1 kind=${2:-ship} permissions=${3:-bounded}
   # shellcheck disable=SC2016  # single quotes are deliberate: $(cat ...) expands in the crewmate pane, not here
   case "$harness" in
     # CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false disables claude's interactive
@@ -321,15 +329,30 @@ launch_template() {
     # does NOT suppress the interactive ghost text (verified empirically), so the env
     # var is the correct control. The dim-aware composer reader in fm-tmux-lib.sh is
     # the defense-in-depth backstop for any pane this flag cannot reach.
-    claude) printf '%s' 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions __MODELFLAG____EFFORTFLAG__"$(cat __BRIEF__)"' ;;
-    codex)
-      if [ "$kind" = secondmate ]; then
-        printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox "$(cat __BRIEF__)"'
+    claude)
+      if [ "$permissions" = unrestricted ]; then
+        printf '%s' 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions __MODELFLAG____EFFORTFLAG__"$(cat __BRIEF__)"'
       else
-        printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch __TURNEND__\"]" "$(cat __BRIEF__)"'
+        printf '%s' 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --permission-mode acceptEdits __MODELFLAG____EFFORTFLAG__"$(cat __BRIEF__)"'
       fi
       ;;
-    opencode) printf '%s' 'OPENCODE_CONFIG_CONTENT='\''{"permission":{"*":"allow"}}'\'' opencode __MODELFLAG__--prompt "$(cat __BRIEF__)"' ;;
+    codex)
+      if [ "$permissions" = unrestricted ]; then
+        if [ "$kind" = secondmate ]; then
+          printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox "$(cat __BRIEF__)"'
+        else
+          printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch __TURNEND__\"]" "$(cat __BRIEF__)"'
+        fi
+      elif [ "$kind" = secondmate ]; then
+        printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--sandbox workspace-write --ask-for-approval on-request -c "approvals_reviewer=\"auto_review\"" "$(cat __BRIEF__)"'
+      else
+        printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--sandbox workspace-write --ask-for-approval on-request -c "approvals_reviewer=\"auto_review\"" -c "notify=[\"bash\",\"-c\",\"touch __TURNEND__\"]" "$(cat __BRIEF__)"'
+      fi
+      ;;
+    opencode)
+      [ "$permissions" = unrestricted ] || return 2
+      printf '%s' 'OPENCODE_CONFIG_CONTENT='\''{"permission":{"*":"allow"}}'\'' opencode __MODELFLAG__--prompt "$(cat __BRIEF__)"'
+      ;;
     pi)
       if [ "$kind" = secondmate ]; then
         printf '%s' 'pi __MODELFLAG____EFFORTFLAG__-e __PITURNEND__ -e __PIWATCH__ "$(cat __BRIEF__)"'
@@ -338,13 +361,13 @@ launch_template() {
       fi
       ;;
     # grok (Grok Build TUI): a positional prompt starts the supervised interactive
-    # session. --always-approve auto-approves every tool execution (verified: the
-    # crewmate runs fully autonomously, no permission gate), which an unattended
-    # crewmate needs; it is the targeted equivalent of claude's
-    # --dangerously-skip-permissions. grok's turn-end signal does NOT ride the
-    # launch command - it is a Stop-event hook installed below (global hook +
-    # per-task pointer), so the template is identical for ship/scout/secondmate.
-    grok) printf '%s' 'grok --always-approve __MODELFLAG____EFFORTFLAG__"$(cat __BRIEF__)"' ;;
+    # session. --always-approve auto-approves every tool execution, so it is only
+    # available through the explicit unrestricted profile. grok's turn-end signal
+    # does NOT ride the launch command - it is a Stop-event hook installed below.
+    grok)
+      [ "$permissions" = unrestricted ] || return 2
+      printf '%s' 'grok --always-approve __MODELFLAG____EFFORTFLAG__"$(cat __BRIEF__)"'
+      ;;
     *) return 1 ;;
   esac
 }
@@ -352,6 +375,7 @@ launch_template() {
 case "$ARG3" in
   *' '*)  # raw launch command (unverified-adapter escape hatch)
     LAUNCH=$ARG3
+    [ "$PERMISSIONS" = unrestricted ] || PERMISSIONS=custom
     HARNESS=""
     for word in $LAUNCH; do
       case "$word" in [A-Za-z_]*=*) continue ;; *) HARNESS=$(basename "$word"); break ;; esac
@@ -377,11 +401,27 @@ case "$ARG3" in
       HARNESS=$("$FM_ROOT/bin/fm-harness.sh" crew)
       harness_src='config/crew-harness'
     fi
-    LAUNCH=$(launch_template "$HARNESS" "$KIND") || { echo "error: no launch template for harness '$HARNESS' (from $harness_src or detection); pass a raw launch command to use an unverified adapter" >&2; exit 1; }
+    launch_status=0
+    LAUNCH=$(launch_template "$HARNESS" "$KIND" "$PERMISSIONS") || launch_status=$?
+    if [ "$launch_status" -eq 2 ]; then
+      echo "error: harness '$HARNESS' has no verified bounded launch profile; pass --unrestricted only with the captain's explicit per-task approval" >&2
+      exit 1
+    elif [ "$launch_status" -ne 0 ]; then
+      echo "error: no launch template for harness '$HARNESS' (from $harness_src or detection); pass a raw launch command to use an unverified adapter" >&2
+      exit 1
+    fi
     ;;
   *)
     HARNESS=$ARG3
-    LAUNCH=$(launch_template "$HARNESS" "$KIND") || { echo "error: unknown harness '$HARNESS'; pass a raw launch command to use an unverified adapter" >&2; exit 1; }
+    launch_status=0
+    LAUNCH=$(launch_template "$HARNESS" "$KIND" "$PERMISSIONS") || launch_status=$?
+    if [ "$launch_status" -eq 2 ]; then
+      echo "error: harness '$HARNESS' has no verified bounded launch profile; pass --unrestricted only with the captain's explicit per-task approval" >&2
+      exit 1
+    elif [ "$launch_status" -ne 0 ]; then
+      echo "error: unknown harness '$HARNESS'; pass a raw launch command to use an unverified adapter" >&2
+      exit 1
+    fi
     ;;
 esac
 
@@ -996,6 +1036,7 @@ META_WINDOW=$T
   echo "project=$PROJ_ABS"
   echo "harness=$HARNESS"
   echo "kind=$KIND"
+  echo "permissions=$PERMISSIONS"
   echo "mode=$MODE"
   echo "yolo=$YOLO"
   echo "tasktmp=$TASK_TMP"
@@ -1058,4 +1099,4 @@ spawn_send_literal "$T" "$LAUNCH"
 sleep 0.3
 spawn_send_key "$T" Enter
 
-echo "spawned $ID harness=$HARNESS kind=$KIND mode=$MODE yolo=$YOLO window=$META_WINDOW worktree=$WT"
+echo "spawned $ID harness=$HARNESS kind=$KIND permissions=$PERMISSIONS mode=$MODE yolo=$YOLO window=$META_WINDOW worktree=$WT"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -130,9 +130,9 @@ That keeps spawn launch compatible across claude, codex, grok, pi, and opencode 
 
 ## Bounded crew permissions
 
-Verified harness launches are bounded by default, and `fm-spawn.sh --help` owns the exact per-harness launch mechanics.
-Claude launches in `acceptEdits` mode, Codex launches with workspace-write sandboxing and on-request auto-reviewed escalation, and Pi keeps its non-bypass launch.
-OpenCode and Grok fail closed by default because Firstmate has not yet verified a bounded unattended contract for those adapters.
+Harnesses with verified bounded profiles launch bounded by default, and `fm-spawn.sh --help` owns the exact per-harness launch mechanics.
+Claude launches in `acceptEdits` mode, and Codex launches with workspace-write sandboxing and on-request auto-reviewed escalation.
+OpenCode, Pi, and Grok fail closed by default because Firstmate has not verified a bounded unattended contract for those adapters.
 `--unrestricted` is the explicit per-spawn escape hatch and must only be used with the captain's approval for that task.
 Raw launch commands remain an adapter-development escape hatch and are classified as custom unless the caller explicitly marks them unrestricted.
 Every new task records `permissions=bounded`, `permissions=unrestricted`, or `permissions=custom` in its meta file, and the Fleet snapshot projects that value for dashboard consumers.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -134,8 +134,9 @@ Harnesses with verified bounded profiles launch bounded by default, and `fm-spaw
 Claude and Codex are the currently verified bounded adapters; OpenCode, Pi, and Grok fail closed by default because Firstmate has not verified a bounded unattended contract for them.
 `--unrestricted` is the explicit per-spawn escape hatch and must only be used with the captain's approval for that task.
 Raw launch commands remain an adapter-development escape hatch and are classified as custom unless the caller explicitly marks them unrestricted.
-Every new task records `permissions=bounded`, `permissions=unrestricted`, or `permissions=custom` in its meta file, and the Fleet snapshot projects that value for dashboard consumers.
+Every new task records `permissions=bounded`, `permissions=unrestricted`, or `permissions=custom` in its meta file, and the Fleet snapshot, Fleet view, and bearings projection surface that value.
 Legacy task metadata without the field is surfaced as `unknown` instead of inferring a safety guarantee.
+For secondmates, bootstrap recovery replays an unrestricted launch only when the current resolved secondmate harness still matches the harness that originally received that explicit approval.
 
 ## Optional secondmates
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -128,6 +128,16 @@ Secondmate launches are exempt because they resolve the secondmate harness and a
 Unsupported effort values are still recorded in task meta when passed to `fm-spawn.sh`, but the launch template omits any effort flag that the selected harness does not accept.
 That keeps spawn launch compatible across claude, codex, grok, pi, and opencode while preserving the requested profile for later audit.
 
+## Bounded crew permissions
+
+Verified harness launches are bounded by default, and `fm-spawn.sh --help` owns the exact per-harness launch mechanics.
+Claude launches in `acceptEdits` mode, Codex launches with workspace-write sandboxing and on-request auto-reviewed escalation, and Pi keeps its non-bypass launch.
+OpenCode and Grok fail closed by default because Firstmate has not yet verified a bounded unattended contract for those adapters.
+`--unrestricted` is the explicit per-spawn escape hatch and must only be used with the captain's approval for that task.
+Raw launch commands remain an adapter-development escape hatch and are classified as custom unless the caller explicitly marks them unrestricted.
+Every new task records `permissions=bounded`, `permissions=unrestricted`, or `permissions=custom` in its meta file, and the Fleet snapshot projects that value for dashboard consumers.
+Legacy task metadata without the field is surfaced as `unknown` instead of inferring a safety guarantee.
+
 ## Optional secondmates
 
 `data/secondmates.md` records persistent domain supervisors with natural-language scopes, project clone lists, and home paths.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -131,8 +131,7 @@ That keeps spawn launch compatible across claude, codex, grok, pi, and opencode 
 ## Bounded crew permissions
 
 Harnesses with verified bounded profiles launch bounded by default, and `fm-spawn.sh --help` owns the exact per-harness launch mechanics.
-Claude launches in `acceptEdits` mode, and Codex launches with workspace-write sandboxing and on-request auto-reviewed escalation.
-OpenCode, Pi, and Grok fail closed by default because Firstmate has not verified a bounded unattended contract for those adapters.
+Claude and Codex are the currently verified bounded adapters; OpenCode, Pi, and Grok fail closed by default because Firstmate has not verified a bounded unattended contract for them.
 `--unrestricted` is the explicit per-spawn escape hatch and must only be used with the captain's approval for that task.
 Raw launch commands remain an adapter-development escape hatch and are classified as custom unless the caller explicitly marks them unrestricted.
 Every new task records `permissions=bounded`, `permissions=unrestricted`, or `permissions=custom` in its meta file, and the Fleet snapshot projects that value for dashboard consumers.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -143,6 +143,7 @@ The full cmux home label also includes a short hash of the resolved `FM_ROOT` pa
 claude, codex, opencode, pi, and grok are all empirically verified; new harnesses get verified through a supervised trial task before joining the set.
 The verified adapter knowledge - busy signatures, interrupt and exit commands, skill-invocation syntax, and per-harness quirks - lives in [`.agents/skills/harness-adapters/SKILL.md`](../.agents/skills/harness-adapters/SKILL.md).
 Launch mechanics, including the verified command templates, live in [`bin/fm-spawn.sh`](../bin/fm-spawn.sh).
+Harness verification does not imply a verified bounded crew profile; the [bounded crew permission policy](architecture.md#bounded-crew-permissions) owns the default launch gate and approval rule.
 Primary-session turn-end guard integrations for verified harnesses are tracked as repo-level hook files and documented in [`docs/turnend-guard.md`](turnend-guard.md).
 Primary-session watcher wake protocols are rendered at session start by [`bin/fm-supervision-instructions.sh`](../bin/fm-supervision-instructions.sh) from [`docs/supervision-protocols/`](supervision-protocols/).
 Claude and Grok use background-notify cycles, Codex uses bounded foreground checkpoints, Pi uses its two tracked primary extensions, and OpenCode uses its TUI plugin.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -156,6 +156,7 @@ When the harness token is absent or `default`, secondmate launch falls back thro
 `fm-harness.sh secondmate-model` and `fm-harness.sh secondmate-effort` expose only the optional tokens from `config/secondmate-harness`; `config/crew-harness` remains a bare adapter-name file.
 An explicit harness argument to `fm-spawn.sh` still overrides either config file for that spawn only.
 An explicit `--model` or `--effort` overrides the matching token from `config/secondmate-harness`; an explicit harness or raw launch command starts with clean model and effort defaults unless those flags are also passed.
+Bootstrap recovery replays a recorded unrestricted secondmate launch only when this file still resolves to the same harness that originally received that explicit approval; a missing or mismatched legacy approval identity falls back to bounded behavior.
 When `config/crew-dispatch.json` exists, crewmate and scout spawns require an explicit resolved harness instead of automatically falling back to `config/crew-harness`.
 The primary propagates `config/crew-dispatch.json`, `config/crew-harness`, and `config/backlog-backend` into secondmate homes at secondmate spawn, during the locked session-start bootstrap secondmate sweep, and during explicit `bin/fm-config-push.sh` runs, so a secondmate's own crewmates, dispatch profiles, and backlog backend use the primary values.
 `config/secondmate-harness` is not inherited because secondmates do not launch secondmates.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -167,6 +167,7 @@ For Pi secondmate launches, `fm-spawn.sh` starts Pi with `-e` pointed at the sec
 
 `config/crew-dispatch.json` is an optional local, gitignored file containing natural-language rules that firstmate reads before dispatching a crewmate or scout.
 The shell scripts do not match those rules; firstmate chooses the best matching rule with judgment, resolves that rule directly or through a supported selector, and passes only concrete `--harness`, `--model`, and `--effort` flags to `fm-spawn.sh`.
+Dispatch profiles do not encode permission overrides; the separate [bounded crew permission policy](architecture.md#bounded-crew-permissions) still decides whether the resolved harness can launch bounded or needs an explicit per-task `--unrestricted` approval.
 When the file exists, `fm-spawn.sh` enforces that contract by refusing crewmate and scout spawns that lack an explicit harness (`--harness`, a positional adapter, or a raw launch command).
 Batch spawns satisfy the same requirement with a shared `--harness`.
 Secondmate spawns are exempt and still resolve through `config/secondmate-harness` and its optional model and effort tokens.

--- a/tests/fm-backend-orca.test.sh
+++ b/tests/fm-backend-orca.test.sh
@@ -491,7 +491,7 @@ test_spawn_writes_orca_metadata_and_launches_harness() {
     FM_PROJECTS_OVERRIDE="$TMP_ROOT/unused-projects" FM_SPAWN_NO_GUARD=1 \
     "$ROOT/bin/fm-spawn.sh" "$id" "$proj" claude --backend orca 2>&1 )
   expect_code 0 $? "fm-spawn.sh --backend orca should succeed with fake Orca"$'\n'"$out"
-  assert_contains "$out" "spawned $id harness=claude kind=ship mode=no-mistakes yolo=off window=fm-$id worktree=$wt" \
+  assert_contains "$out" "spawned $id harness=claude kind=ship permissions=bounded mode=no-mistakes yolo=off window=fm-$id worktree=$wt" \
     "spawn output missing Orca window/worktree summary"
   assert_grep "backend=orca" "$state/$id.meta" "meta missing backend=orca"
   assert_grep "window=fm-$id" "$state/$id.meta" "meta missing stable Orca window alias"
@@ -502,7 +502,7 @@ test_spawn_writes_orca_metadata_and_launches_harness() {
     "spawn should reuse the implicit terminal returned by Orca worktree creation"
   assert_contains "$(cat "$log")" $'orca\x1f''terminal'$'\x1f''send'$'\x1f''--terminal'$'\x1f''term-spawn'$'\x1f''--text'$'\x1f''export GOTMPDIR=/tmp/fm-orcaspawnz1/gotmp'$'\x1f''--enter'$'\x1f''--json' \
     "spawn did not export GOTMPDIR through the Orca terminal"
-  assert_contains "$(cat "$log")" "CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions" \
+  assert_contains "$(cat "$log")" "CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --permission-mode acceptEdits" \
     "spawn did not send the selected harness launch command through Orca"
   rm -rf "/tmp/fm-$id"
   pass "fm-spawn.sh --backend orca: reuses implicit terminal, records metadata, launches harness"
@@ -687,7 +687,7 @@ test_spawn_releases_orca_resources_when_metadata_write_fails() {
     "$ROOT/bin/fm-spawn.sh" "$id" "$proj" claude --backend orca 2>&1 )
   status=$?
   [ "$status" -ne 0 ] || fail "Orca spawn should fail when metadata cannot be written"
-  assert_contains "$out" "File exists" "spawn should fail at the state directory creation point"
+  assert_contains "$out" "exists" "spawn should fail at the state directory creation point"
   assert_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''close'$'\x1f''--terminal'$'\x1f''term-meta-fail'$'\x1f''--json' \
     "Orca spawn should close the recorded terminal when a later abort occurs"
   assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:wt-meta-fail'$'\x1f''--force'$'\x1f''--json' \

--- a/tests/fm-bearings-snapshot.test.sh
+++ b/tests/fm-bearings-snapshot.test.sh
@@ -312,10 +312,11 @@ test_active_child_overrides_old_parent_event() {
   home=$(make_home active-child-parent)
   mate="$TMP_ROOT/active-child-home"
   write_domain_alpha_fixture "$home" "$mate"
-  mkdir -p "$mate/projects/phase8"
+  mkdir -p "$mate/projects/phase8" "$mate/projects/phase9"
   cat > "$mate/data/backlog.md" <<'EOF'
 ## In flight
 - [ ] phase8 - Sample rollout Phase 8 (repo: sample) (kind: ship) (since 2026-07-13)
+- [ ] phase9 - Sample rollout Phase 9 (repo: sample) (kind: ship) (since 2026-07-14)
 
 ## Queued
 
@@ -324,8 +325,12 @@ test_active_child_overrides_old_parent_event() {
 EOF
   fm_write_meta "$mate/state/phase8.meta" \
     "window=firstmate:fm-phase8" "worktree=$mate/projects/phase8" "project=sample" \
-    "harness=codex" "kind=ship" "mode=no-mistakes"
+    "harness=codex" "permissions=bounded" "kind=ship" "mode=no-mistakes"
   printf 'working [key=phase8]: implementing Phase 8 parity\n' > "$mate/state/phase8.status"
+  fm_write_meta "$mate/state/phase9.meta" \
+    "window=firstmate:fm-phase9" "worktree=$mate/projects/phase9" "project=sample" \
+    "harness=codex" "kind=ship" "mode=no-mistakes"
+  printf 'working [key=phase9]: implementing Phase 9 compatibility\n' > "$mate/state/phase9.status"
   fakebin=$(make_fakebin "$home")
   json=$(run "$home" "$fakebin" --json)
   printf '%s' "$json" | jq -e '
@@ -336,12 +341,17 @@ EOF
   canonical=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SNAPSHOT_NOW=2026-07-11T18:00:00Z \
     "$ROOT/bin/fm-fleet-snapshot.sh" --json)
   printf '%s' "$canonical" | jq -e '
-    .secondmate_current.records[] | select(.id == "domain-alpha") | .endpoints[] | select(.id == "phase8")
-    | .endpoint.status == "unknown"
-      and .endpoint.exists == true
-      and .endpoint.freshness == "fresh"
-      and .endpoint.observed_at == "2026-07-11T18:00:00Z"
-  ' >/dev/null || fail "child endpoint observation lacked bounded current freshness: $canonical"
+    .secondmate_current.records[] | select(.id == "domain-alpha")
+    | (.active_children | any(.id == "phase8" and .permissions == "bounded"))
+      and (.active_children | any(.id == "phase9" and .permissions == "unknown"))
+      and (.endpoints | any(.id == "phase8"
+        and .permissions == "bounded"
+        and .endpoint.status == "unknown"
+        and .endpoint.exists == true
+        and .endpoint.freshness == "fresh"
+        and .endpoint.observed_at == "2026-07-11T18:00:00Z"))
+      and (.endpoints | any(.id == "phase9" and .permissions == "unknown"))
+  ' >/dev/null || fail "nested child permission or endpoint evidence was incomplete: $canonical"
   pass "active child work overrides an old parent event with fresh endpoint evidence"
 }
 

--- a/tests/fm-bearings-snapshot.test.sh
+++ b/tests/fm-bearings-snapshot.test.sh
@@ -109,6 +109,7 @@ EOF
     "worktree=$home/projects/ship-wt" \
     "project=firstmate" \
     "harness=codex" \
+    "permissions=bounded" \
     "kind=ship" \
     "mode=no-mistakes" \
     "pr=https://github.com/kunchenguid/firstmate/pull/9"
@@ -811,6 +812,24 @@ EOF
   pass "repeated snapshots keep the same current landed baseline and ignore prior reports"
 }
 
+test_permission_classification_surfaces_in_bearings() {
+  local home fakebin toon json
+  home=$(make_home permissions); write_fixture "$home"
+  fakebin=$(make_fakebin "$home")
+  toon=$(run "$home" "$fakebin")
+  json=$(run "$home" "$fakebin" --json)
+  printf '%s' "$json" | jq -e '
+    (.in_flight | any(.[]; .id == "ship-task" and .permissions == "bounded"))
+      and (.in_flight | any(.[]; .id == "scout-x" and .permissions == "unknown"))
+      and (.secondmates | any(.[]; .id == "mate" and .permissions == "unknown"))
+  ' >/dev/null || fail "bearings did not surface task and secondmate permission classifications: $json"
+  assert_contains "$toon" 'in_flight[3]{id,kind,permissions,state,doing}:' \
+    "TOON bearings output did not expose the in-flight permissions field"
+  assert_contains "$toon" 'secondmates[1]{id,state,permissions,doing,provenance,freshness,age_seconds,contradiction,reason}:' \
+    "TOON bearings output did not expose the secondmate permissions field"
+  pass "bearings surfaces bounded and unknown permission classifications"
+}
+
 test_default_is_bounded_and_local_only() {
   local home fakebin toon json
   home=$(make_home bounded); write_fixture "$home"
@@ -1218,6 +1237,7 @@ test_parent_evidence_reconciles_by_verb_and_key
 test_nonprogressing_child_states_are_explicit
 test_registry_unavailability_and_bounds_are_explicit
 test_current_landed_baseline_is_repeatable_and_prior_report_independent
+test_permission_classification_surfaces_in_bearings
 test_default_is_bounded_and_local_only
 test_toon_json_parity
 test_landed_includes_secondmate_home_merges

--- a/tests/fm-bearings-snapshot.test.sh
+++ b/tests/fm-bearings-snapshot.test.sh
@@ -313,6 +313,7 @@ test_active_child_overrides_old_parent_event() {
   home=$(make_home active-child-parent)
   mate="$TMP_ROOT/active-child-home"
   write_domain_alpha_fixture "$home" "$mate"
+  printf 'permissions=unrestricted\n' >> "$home/state/domain-alpha.meta"
   mkdir -p "$mate/projects/phase8" "$mate/projects/phase9"
   cat > "$mate/data/backlog.md" <<'EOF'
 ## In flight
@@ -336,8 +337,10 @@ EOF
   json=$(run "$home" "$fakebin" --json)
   printf '%s' "$json" | jq -e '
     (.secondmates | any(.[]; .id == "domain-alpha" and .state == "active_child_work"
+      and .permissions == "unrestricted"
       and (.doing | contains("phase8")) and (.doing | contains("Phase 7 started") | not)))
-      and (.in_flight | any(.[]; .id == "domain-alpha" and (.doing | contains("phase8"))))
+      and (.in_flight | any(.[]; .id == "domain-alpha" and .permissions == "unrestricted"
+        and (.doing | contains("phase8"))))
   ' >/dev/null || fail "active child did not override stale parent event: $json"
   canonical=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SNAPSHOT_NOW=2026-07-11T18:00:00Z \
     "$ROOT/bin/fm-fleet-snapshot.sh" --json)

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -82,6 +82,7 @@ EOF
     "worktree=$home/projects/alpha-worktree" \
     "project=alpha" \
     "harness=codex" \
+    "permissions=bounded" \
     "kind=ship" \
     "mode=ship" \
     "yolo=off" \
@@ -141,6 +142,7 @@ test_fixture_snapshot_json() {
     .tasks[] | select(.id == "ship-task")
     | .current_state.state == "working"
       and .current_state.source == "pane"
+      and .permissions == "bounded"
       and .pr.url == "https://github.com/kunchenguid/firstmate/pull/9"
       and .backlog.body_excerpt == "Preserve this detail for bearings."
       and .hints.pending_decision == false
@@ -160,6 +162,7 @@ test_fixture_snapshot_json() {
   printf '%s' "$out" | jq -e '
     .tasks[] | select(.id == "cmux-task")
     | .backend == "cmux"
+      and .permissions == "unknown"
       and .paths.worktree.present == false
       and .current_state.state == "unknown"
   ' >/dev/null || fail "cmux missing-file row missing"

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -354,7 +354,7 @@ EOF
       and .paths.report.present == true
   ' >/dev/null || fail "bold task did not join to override-backed backlog and report"
   view=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_DATA_OVERRIDE="$data" FM_PROJECTS_OVERRIDE="$projects" "$VIEW")
-  assert_contains "$view" "| bold-task | done / status-log | scout | alpha | tmux | present | $data/bold-task/report.md" \
+  assert_contains "$view" "| bold-task | done / status-log | unknown | scout | alpha | tmux | present | $data/bold-task/report.md" \
     "view should render bold in-flight row from snapshot"
   assert_contains "$view" "| blocked-reason | Blocked Reason | beta | ship | queued-comma - waits on queued-comma | - |" \
     "view should render blocked reason without title metadata"
@@ -371,7 +371,7 @@ test_view_renders_snapshot() {
   write_fixture "$home"
   fakebin=$(make_fakebin "$home")
   view=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$VIEW")
-  assert_contains "$view" "| ship-task | working / pane | ship | alpha | tmux | present | https://github.com/kunchenguid/firstmate/pull/9" \
+  assert_contains "$view" "| ship-task | working / pane | bounded | ship | alpha | tmux | present | https://github.com/kunchenguid/firstmate/pull/9" \
     "view should render ship row from snapshot"
   assert_contains "$view" "| queued-task | Queued Task | alpha | ship | ship-task | -" \
     "view should render queued backlog row"
@@ -379,7 +379,7 @@ test_view_renders_snapshot() {
     "view should render done backlog row"
   assert_contains "$view" "bin/fm-send.sh fm-secondmate-task" \
     "view should show secondmate send guidance"
-  assert_contains "$view" "| secondmate-task | working / status-log | secondmate | $home/secondmate-home | tmux | present / alive |" \
+  assert_contains "$view" "| secondmate-task | working / status-log | unknown | secondmate | $home/secondmate-home | tmux | present / alive |" \
     "view should show secondmate endpoint agent liveness"
   assert_not_contains "$view" "fm-peek.sh fm-secondmate-task" \
     "view must not tell firstmate to routinely peek secondmates"
@@ -400,9 +400,9 @@ test_view_renders_dead_secondmate_agent_status() {
   printf 'working: watching delegated scope\n' > "$home/state/dead-secondmate.status"
   fakebin=$(make_fakebin "$home")
   view=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$VIEW")
-  assert_contains "$view" "| dead-secondmate | unknown / none | secondmate | $home/secondmate-home | tmux | present / dead |" \
+  assert_contains "$view" "| dead-secondmate | unknown / none | unknown | secondmate | $home/secondmate-home | tmux | present / dead |" \
     "view should distinguish a present secondmate endpoint from a dead agent"
-  assert_contains "$view" "| dead-secondmate | unknown / none | secondmate | $home/secondmate-home | tmux | present / dead | - | $home/secondmate-home (absent) |" \
+  assert_contains "$view" "| dead-secondmate | unknown / none | unknown | secondmate | $home/secondmate-home | tmux | present / dead | - | $home/secondmate-home (absent) |" \
     "view should show a recorded missing secondmate home path"
   pass "fleet view renders secondmate agent liveness"
 }

--- a/tests/fm-grok-harness.test.sh
+++ b/tests/fm-grok-harness.test.sh
@@ -53,7 +53,7 @@ run_grok_spawn() {
     FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
     FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" TMUX="fake,1,0" \
     GROK_HOME="$grok_home" PATH="$fakebin:$PATH" \
-    "$SPAWN" "$id" "$proj" grok 2>&1
+    "$SPAWN" "$id" "$proj" grok --unrestricted 2>&1
 }
 
 test_grok_hook_requires_registered_token() {

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -503,7 +503,7 @@ test_spawn_secondmate_harness_model_token() {
   [ "$(meta_field "$meta" model)" = opus ] || fail "model-token: meta model not opus (got '$(meta_field "$meta" model)')"
   [ "$(meta_field "$meta" effort)" = default ] || fail "model-token: meta effort not default (got '$(meta_field "$meta" effort)')"
   launch=$(cat "$launchlog")
-  assert_contains "$launch" "claude --dangerously-skip-permissions --model 'opus'" \
+  assert_contains "$launch" "claude --permission-mode acceptEdits --model 'opus'" \
     "model-token: launch did not carry --model opus"
   assert_not_contains "$launch" "--effort" "model-token: launch must not carry an --effort flag"
   pass "C3 spawn: config/secondmate-harness's model token threads --model into the launch and meta"
@@ -525,7 +525,7 @@ test_spawn_secondmate_harness_model_and_effort_tokens() {
   [ "$(meta_field "$meta" model)" = opus ] || fail "model-effort-tokens: meta model not opus"
   [ "$(meta_field "$meta" effort)" = high ] || fail "model-effort-tokens: meta effort not high (got '$(meta_field "$meta" effort)')"
   launch=$(cat "$launchlog")
-  assert_contains "$launch" "claude --dangerously-skip-permissions --model 'opus' --effort 'high'" \
+  assert_contains "$launch" "claude --permission-mode acceptEdits --model 'opus' --effort 'high'" \
     "model-effort-tokens: launch did not carry both --model opus and --effort high"
   pass "C4 spawn: config/secondmate-harness's model+effort tokens thread into the launch and meta"
 }
@@ -590,7 +590,7 @@ test_spawn_explicit_harness_does_not_inherit_secondmate_harness_tokens() {
   [ "$(meta_field "$meta" model)" = default ] || fail "explicit-harness-no-tokens: meta model should stay default"
   [ "$(meta_field "$meta" effort)" = default ] || fail "explicit-harness-no-tokens: meta effort should stay default"
   launch=$(cat "$launchlog")
-  assert_contains "$launch" "codex --dangerously-bypass-approvals-and-sandbox" \
+  assert_contains "$launch" "codex --sandbox workspace-write --ask-for-approval on-request" \
     "explicit-harness-no-tokens: launch did not use codex"
   assert_not_contains "$launch" "--model" "explicit-harness-no-tokens: launch must not carry a --model flag"
   assert_not_contains "$launch" "model_reasoning_effort" \

--- a/tests/fm-secondmate-liveness.test.sh
+++ b/tests/fm-secondmate-liveness.test.sh
@@ -243,7 +243,7 @@ new_world() {
 # worktree; a non-git home just makes the unrelated fast-forward sweep log a
 # harmless "not a git repo" skip.
 add_sm_home() {
-  local w=$1 id=$2 window=$3 harness=${4:-claude} permissions=${5:-}
+  local w=$1 id=$2 window=$3 harness=${4:-claude} permissions=${5:-} approved_harness=${6:-}
   local home="$w/$id"
   mkdir -p "$home/bin" "$home/data" "$home/state" "$home/config" "$home/projects"
   printf '%s\n' "$id" > "$home/.fm-secondmate-home"
@@ -254,6 +254,7 @@ add_sm_home() {
     printf 'kind=secondmate\n'
     printf 'harness=%s\n' "$harness"
     [ -z "$permissions" ] || printf 'permissions=%s\n' "$permissions"
+    [ -z "$approved_harness" ] || printf 'approved_harness=%s\n' "$approved_harness"
     printf 'home=%s\n' "$home"
   } > "$w/home/state/$id.meta"
 }
@@ -355,7 +356,7 @@ test_sweep_replays_recorded_unrestricted_permissions() {
   local w fb tmuxfb log out
   w=$(new_world sweep-unrestricted-replay)
   printf 'pi\n' > "$w/home/config/secondmate-harness"
-  add_sm_home "$w" sm1 firstmate:fm-sm1 pi unrestricted
+  add_sm_home "$w" sm1 firstmate:fm-sm1 pi unrestricted pi
   fb=$(make_toolchain "$w"); tmuxfb=$(make_liveness_tmux "$w")
   log="$w/calls.log"; : > "$log"
 
@@ -365,7 +366,49 @@ test_sweep_replays_recorded_unrestricted_permissions() {
     "a recorded unrestricted secondmate should replay that approval during bootstrap recovery"
   assert_contains "$(cat "$log")" "new-window" \
     "replaying unrestricted permissions should relaunch the dead secondmate"
+  assert_grep "permissions=unrestricted" "$w/home/state/sm1.meta" \
+    "replayed unrestricted recovery should preserve the recorded permission class"
+  assert_grep "approved_harness=pi" "$w/home/state/sm1.meta" \
+    "replayed unrestricted recovery should preserve the approved harness binding"
   pass "sweep: bootstrap replays recorded unrestricted secondmate permissions"
+}
+
+test_sweep_legacy_unrestricted_meta_falls_back_fail_closed() {
+  local w fb tmuxfb log out
+  w=$(new_world sweep-legacy-unrestricted)
+  printf 'pi\n' > "$w/home/config/secondmate-harness"
+  add_sm_home "$w" sm1 firstmate:fm-sm1 pi unrestricted
+  fb=$(make_toolchain "$w"); tmuxfb=$(make_liveness_tmux "$w")
+  log="$w/calls.log"; : > "$log"
+
+  out=$(run_bootstrap "$tmuxfb:$fb" "$w/home" zsh "$log")
+
+  assert_contains "$out" "SECONDMATE_LIVENESS: secondmate sm1: respawn failed: error: harness 'pi' has no verified bounded launch profile" \
+    "legacy unrestricted metadata without an approved-harness binding must fall back to bounded fail-closed recovery"
+  assert_not_contains "$(cat "$log")" "new-window" \
+    "legacy unrestricted metadata must not replay an unrestricted launch without a matching approval binding"
+  pass "sweep: legacy unrestricted metadata falls back to bounded fail-closed recovery"
+}
+
+test_sweep_drops_unrestricted_when_current_harness_changes() {
+  local w fb tmuxfb log out
+  w=$(new_world sweep-unrestricted-mismatch)
+  printf 'claude\n' > "$w/home/config/secondmate-harness"
+  add_sm_home "$w" sm1 firstmate:fm-sm1 pi unrestricted pi
+  fb=$(make_toolchain "$w"); tmuxfb=$(make_liveness_tmux "$w")
+  log="$w/calls.log"; : > "$log"
+
+  out=$(run_bootstrap "$tmuxfb:$fb" "$w/home" zsh "$log")
+
+  assert_contains "$out" "SECONDMATE_LIVENESS: secondmate sm1: respawned" \
+    "a changed secondmate harness should still recover, but without replaying an old unrestricted approval"
+  assert_grep "harness=claude" "$w/home/state/sm1.meta" \
+    "respawn should re-resolve the current secondmate harness"
+  assert_grep "permissions=bounded" "$w/home/state/sm1.meta" \
+    "a mismatched approved harness must drop back to the bounded profile"
+  assert_no_grep "approved_harness=" "$w/home/state/sm1.meta" \
+    "a bounded respawn on the new harness must not retain the old unrestricted approval binding"
+  pass "sweep: a changed secondmate harness drops an old unrestricted approval"
 }
 
 test_sweep_skipped_under_detect_only() {
@@ -413,6 +456,8 @@ test_sweep_never_acts_on_inconclusive_reading
 test_sweep_never_acts_on_unverified_harness_dead_reading
 test_sweep_converges_no_retouch_once_alive
 test_sweep_replays_recorded_unrestricted_permissions
+test_sweep_legacy_unrestricted_meta_falls_back_fail_closed
+test_sweep_drops_unrestricted_when_current_harness_changes
 test_sweep_skipped_under_detect_only
 test_sweep_noop_with_no_secondmate_meta
 

--- a/tests/fm-secondmate-liveness.test.sh
+++ b/tests/fm-secondmate-liveness.test.sh
@@ -243,7 +243,7 @@ new_world() {
 # worktree; a non-git home just makes the unrelated fast-forward sweep log a
 # harmless "not a git repo" skip.
 add_sm_home() {
-  local w=$1 id=$2 window=$3 harness=${4:-claude}
+  local w=$1 id=$2 window=$3 harness=${4:-claude} permissions=${5:-}
   local home="$w/$id"
   mkdir -p "$home/bin" "$home/data" "$home/state" "$home/config" "$home/projects"
   printf '%s\n' "$id" > "$home/.fm-secondmate-home"
@@ -253,6 +253,7 @@ add_sm_home() {
     printf 'window=%s\n' "$window"
     printf 'kind=secondmate\n'
     printf 'harness=%s\n' "$harness"
+    [ -z "$permissions" ] || printf 'permissions=%s\n' "$permissions"
     printf 'home=%s\n' "$home"
   } > "$w/home/state/$id.meta"
 }
@@ -350,6 +351,23 @@ test_sweep_converges_no_retouch_once_alive() {
   pass "sweep: idempotent by construction - a live secondmate is never re-touched on a later run"
 }
 
+test_sweep_replays_recorded_unrestricted_permissions() {
+  local w fb tmuxfb log out
+  w=$(new_world sweep-unrestricted-replay)
+  printf 'pi\n' > "$w/home/config/secondmate-harness"
+  add_sm_home "$w" sm1 firstmate:fm-sm1 pi unrestricted
+  fb=$(make_toolchain "$w"); tmuxfb=$(make_liveness_tmux "$w")
+  log="$w/calls.log"; : > "$log"
+
+  out=$(run_bootstrap "$tmuxfb:$fb" "$w/home" zsh "$log")
+
+  assert_contains "$out" "SECONDMATE_LIVENESS: secondmate sm1: respawned" \
+    "a recorded unrestricted secondmate should replay that approval during bootstrap recovery"
+  assert_contains "$(cat "$log")" "new-window" \
+    "replaying unrestricted permissions should relaunch the dead secondmate"
+  pass "sweep: bootstrap replays recorded unrestricted secondmate permissions"
+}
+
 test_sweep_skipped_under_detect_only() {
   local w fb tmuxfb log out
   w=$(new_world sweep-detect-only)
@@ -394,6 +412,7 @@ test_sweep_leaves_alive_secondmate_untouched
 test_sweep_never_acts_on_inconclusive_reading
 test_sweep_never_acts_on_unverified_harness_dead_reading
 test_sweep_converges_no_retouch_once_alive
+test_sweep_replays_recorded_unrestricted_permissions
 test_sweep_skipped_under_detect_only
 test_sweep_noop_with_no_secondmate_meta
 

--- a/tests/fm-send-secondmate-marker-herdr-e2e.test.sh
+++ b/tests/fm-send-secondmate-marker-herdr-e2e.test.sh
@@ -128,7 +128,7 @@ PY
 
 "$LAB_HELPER" provision "$SESSION"
 PATH="$FAKEBIN:$ORIGINAL_PATH" FM_GATE_REFUSE_BYPASS=1 FM_HOME="$SENDER_HOME" HERDR_SESSION="$SESSION" \
-  "$ROOT/bin/fm-spawn.sh" "$ID" "$SECOND_HOME" --secondmate --harness pi --backend herdr >/dev/null
+  "$ROOT/bin/fm-spawn.sh" "$ID" "$SECOND_HOME" --secondmate --harness pi --backend herdr --unrestricted >/dev/null
 
 META="$SENDER_HOME/state/$ID.meta"
 [ -f "$META" ] || fail "real secondmate spawn did not write exact-id metadata"

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -117,6 +117,8 @@ test_no_profile_uses_bounded_claude_launch() {
   expect_code 0 "$status" "claude spawn without profile flags should succeed"
   assert_contains "$out" "spawned $id harness=claude" "spawn did not report claude"
   assert_meta_profile "$HOME_DIR/state/$id.meta" claude default default
+  assert_no_grep "approved_harness=" "$HOME_DIR/state/$id.meta" \
+    "bounded claude spawn should not record an unrestricted approval binding"
 
   launch=$(cat "$LAUNCH_LOG")
   expected="CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --permission-mode acceptEdits \"\$(cat '$HOME_DIR/data/$id/brief.md')\""
@@ -375,6 +377,8 @@ test_unrestricted_profile_preserves_bypass_launches() {
   status=$?
   expect_code 0 "$status" "explicit unrestricted Claude spawn should succeed"
   assert_meta_profile "$HOME_DIR/state/$id.meta" claude default default unrestricted
+  assert_grep "approved_harness=claude" "$HOME_DIR/state/$id.meta" \
+    "explicit unrestricted spawn must bind its approval to the launched harness"
   launch=$(cat "$LAUNCH_LOG")
   assert_contains "$launch" "claude --dangerously-skip-permissions" \
     "explicit unrestricted profile did not preserve Claude's bypass launch"

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -353,7 +353,16 @@ test_unverified_bounded_harnesses_fail_closed() {
   expect_code 1 "$status" "opencode should fail closed without an unrestricted approval"
   assert_contains "$out" "no verified bounded launch profile" "opencode refusal did not explain the bounded-profile gate"
   assert_absent "$HOME_DIR/state/$id.meta" "bounded-profile refusal should happen before meta is written"
-  pass "OpenCode and Grok class adapters fail closed without --unrestricted"
+
+  id=profile-pi-bounded-z7e
+  rec=$(make_spawn_case profile-pi-bounded pi "$id")
+  read_case_record "$rec"
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR")
+  status=$?
+  expect_code 1 "$status" "pi should fail closed without an unrestricted approval"
+  assert_contains "$out" "no verified bounded launch profile" "pi refusal did not explain the bounded-profile gate"
+  assert_absent "$HOME_DIR/state/$id.meta" "bounded Pi refusal should happen before meta is written"
+  pass "OpenCode, Pi, and Grok adapters fail closed without --unrestricted"
 }
 
 test_unrestricted_profile_preserves_bypass_launches() {
@@ -378,10 +387,10 @@ test_pi_omits_invalid_max_effort() {
   rec=$(make_spawn_case profile-pi pi "$id")
   read_case_record "$rec"
 
-  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --model sonnet --effort max)
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --model sonnet --effort max --unrestricted)
   status=$?
   expect_code 0 "$status" "pi spawn with max effort should not pass an invalid flag"
-  assert_meta_profile "$HOME_DIR/state/$id.meta" pi sonnet max
+  assert_meta_profile "$HOME_DIR/state/$id.meta" pi sonnet max unrestricted
   launch=$(cat "$LAUNCH_LOG")
   assert_contains "$launch" "pi --model 'sonnet' -e" "pi launch did not thread model"
   assert_not_contains "$launch" "--thinking" "pi launch must omit --thinking max because the CLI rejects it"

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -99,13 +99,14 @@ EOF
 }
 
 assert_meta_profile() {
-  local meta=$1 harness=$2 model=$3 effort=$4
+  local meta=$1 harness=$2 model=$3 effort=$4 permissions=${5:-bounded}
   assert_grep "harness=$harness" "$meta" "meta missing harness=$harness"
   assert_grep "model=$model" "$meta" "meta missing model=$model"
   assert_grep "effort=$effort" "$meta" "meta missing effort=$effort"
+  assert_grep "permissions=$permissions" "$meta" "meta missing permissions=$permissions"
 }
 
-test_no_profile_keeps_claude_launch_unchanged() {
+test_no_profile_uses_bounded_claude_launch() {
   local rec id out status expected launch
   id=profile-off-z1
   rec=$(make_spawn_case profile-off claude "$id")
@@ -118,9 +119,9 @@ test_no_profile_keeps_claude_launch_unchanged() {
   assert_meta_profile "$HOME_DIR/state/$id.meta" claude default default
 
   launch=$(cat "$LAUNCH_LOG")
-  expected="CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions \"\$(cat '$HOME_DIR/data/$id/brief.md')\""
-  [ "$launch" = "$expected" ] || fail "no-profile claude launch changed"$'\n'"expected: $expected"$'\n'"actual:   $launch"
-  pass "no --model/--effort records defaults and keeps the claude launch byte-identical"
+  expected="CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --permission-mode acceptEdits \"\$(cat '$HOME_DIR/data/$id/brief.md')\""
+  [ "$launch" = "$expected" ] || fail "bounded claude launch mismatch"$'\n'"expected: $expected"$'\n'"actual:   $launch"
+  pass "no --model/--effort records defaults and uses bounded Claude permissions"
 }
 
 test_active_dispatch_profile_requires_explicit_harness_for_ship() {
@@ -169,7 +170,7 @@ test_active_dispatch_profile_allows_explicit_harness() {
   assert_contains "$out" "spawned $id harness=codex" "spawn did not report explicit codex harness"
   assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5 high
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "codex --model 'gpt-5' -c 'model_reasoning_effort=\"high\"' --dangerously-bypass-approvals-and-sandbox" \
+  assert_contains "$launch" "codex --model 'gpt-5' -c 'model_reasoning_effort=\"high\"' --sandbox workspace-write --ask-for-approval on-request" \
     "explicit harness launch did not thread model and effort"
   pass "active crew-dispatch profile allows an explicit resolved harness"
 }
@@ -202,7 +203,7 @@ test_active_dispatch_profile_allows_raw_launch_command() {
   status=$?
   expect_code 0 "$status" "raw launch command should satisfy active dispatch-profile requirement"
   assert_contains "$out" "spawned $id harness=custom-agent" "spawn did not report raw command harness"
-  assert_meta_profile "$HOME_DIR/state/$id.meta" custom-agent default default
+  assert_meta_profile "$HOME_DIR/state/$id.meta" custom-agent default default custom
   launch=$(cat "$LAUNCH_LOG")
   [ "$launch" = "custom-agent --flag" ] || fail "raw launch command changed"$'\n'"actual: $launch"
   pass "active crew-dispatch profile allows the raw launch-command escape hatch"
@@ -219,7 +220,7 @@ test_claude_threads_model_and_effort() {
   expect_code 0 "$status" "claude spawn with profile flags should succeed"
   assert_meta_profile "$HOME_DIR/state/$id.meta" claude sonnet high
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "claude --dangerously-skip-permissions --model 'sonnet' --effort 'high'" \
+  assert_contains "$launch" "claude --permission-mode acceptEdits --model 'sonnet' --effort 'high'" \
     "claude launch did not thread model and effort flags"
   pass "claude receives --model and --effort profile flags"
 }
@@ -235,8 +236,10 @@ test_codex_threads_model_and_effort() {
   expect_code 0 "$status" "codex spawn with profile flags should succeed"
   assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5 high
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "codex --model 'gpt-5' -c 'model_reasoning_effort=\"high\"' --dangerously-bypass-approvals-and-sandbox" \
+  assert_contains "$launch" "codex --model 'gpt-5' -c 'model_reasoning_effort=\"high\"' --sandbox workspace-write --ask-for-approval on-request" \
     "codex launch did not thread model and reasoning effort config"
+  assert_contains "$launch" 'approvals_reviewer=\"auto_review\"' \
+    "bounded codex launch did not enable fail-closed automatic escalation review"
   pass "codex receives --model and model_reasoning_effort profile flags"
 }
 
@@ -251,7 +254,7 @@ test_codex_omits_invalid_max_effort() {
   expect_code 0 "$status" "codex spawn with unsupported max effort should omit the effort flag"
   assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5 max
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "codex --model 'gpt-5' --dangerously-bypass-approvals-and-sandbox" \
+  assert_contains "$launch" "codex --model 'gpt-5' --sandbox workspace-write --ask-for-approval on-request" \
     "codex launch did not preserve the model flag when max effort was omitted"
   assert_not_contains "$launch" "model_reasoning_effort" "codex launch must omit unsupported max reasoning effort"
   pass "codex omits unsupported max effort instead of passing a bad config value"
@@ -263,10 +266,10 @@ test_grok_threads_model_and_reasoning_effort() {
   rec=$(make_spawn_case profile-grok grok "$id")
   read_case_record "$rec"
 
-  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --model grok-4 --effort high)
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --model grok-4 --effort high --unrestricted)
   status=$?
   expect_code 0 "$status" "grok spawn with profile flags should succeed"
-  assert_meta_profile "$HOME_DIR/state/$id.meta" grok grok-4 high
+  assert_meta_profile "$HOME_DIR/state/$id.meta" grok grok-4 high unrestricted
   launch=$(cat "$LAUNCH_LOG")
   assert_contains "$launch" "grok --always-approve --model 'grok-4' --reasoning-effort 'high'" \
     "grok launch did not thread model and reasoning-effort flags"
@@ -280,10 +283,10 @@ test_grok_omits_invalid_max_reasoning_effort() {
   rec=$(make_spawn_case profile-grok-max grok "$id")
   read_case_record "$rec"
 
-  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --model grok-4 --effort max)
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --model grok-4 --effort max --unrestricted)
   status=$?
   expect_code 0 "$status" "grok spawn with unsupported max reasoning effort should omit the effort flag"
-  assert_meta_profile "$HOME_DIR/state/$id.meta" grok grok-4 max
+  assert_meta_profile "$HOME_DIR/state/$id.meta" grok grok-4 max unrestricted
   launch=$(cat "$LAUNCH_LOG")
   assert_contains "$launch" "grok --always-approve --model 'grok-4' \"\$(cat " \
     "grok launch did not preserve the model flag when max effort was omitted"
@@ -299,10 +302,10 @@ test_grok_omits_invalid_xhigh_reasoning_effort() {
   read_case_record "$rec"
 
   # grok 0.2.99 rejects xhigh (accepted set is only low|medium|high).
-  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --model grok-4 --effort xhigh)
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --model grok-4 --effort xhigh --unrestricted)
   status=$?
   expect_code 0 "$status" "grok spawn with unsupported xhigh reasoning effort should omit the effort flag"
-  assert_meta_profile "$HOME_DIR/state/$id.meta" grok grok-4 xhigh
+  assert_meta_profile "$HOME_DIR/state/$id.meta" grok grok-4 xhigh unrestricted
   launch=$(cat "$LAUNCH_LOG")
   assert_contains "$launch" "grok --always-approve --model 'grok-4' \"\$(cat " \
     "grok launch did not preserve the model flag when xhigh effort was omitted"
@@ -317,10 +320,10 @@ test_opencode_threads_model_and_ignores_effort_axis() {
   rec=$(make_spawn_case profile-opencode opencode "$id")
   read_case_record "$rec"
 
-  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --model anthropic/claude-sonnet-4-5 --effort high)
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --model anthropic/claude-sonnet-4-5 --effort high --unrestricted)
   status=$?
   expect_code 0 "$status" "opencode spawn with model and ignored effort should succeed"
-  assert_meta_profile "$HOME_DIR/state/$id.meta" opencode anthropic/claude-sonnet-4-5 high
+  assert_meta_profile "$HOME_DIR/state/$id.meta" opencode anthropic/claude-sonnet-4-5 high unrestricted
   launch=$(cat "$LAUNCH_LOG")
   assert_contains "$launch" "opencode --model 'anthropic/claude-sonnet-4-5' --prompt" \
     "opencode launch did not thread model"
@@ -328,6 +331,45 @@ test_opencode_threads_model_and_ignores_effort_axis() {
   assert_not_contains "$launch" "--variant" "opencode launch must not pass run-only --variant"
   assert_not_contains "$launch" "--thinking" "opencode launch must not pass pi thinking flag"
   pass "opencode receives --model and omits the unsupported effort axis"
+}
+
+test_unverified_bounded_harnesses_fail_closed() {
+  local rec id out status
+  id=profile-grok-bounded-z7b
+  rec=$(make_spawn_case profile-grok-bounded grok "$id")
+  read_case_record "$rec"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR")
+  status=$?
+  expect_code 1 "$status" "grok should fail closed without an unrestricted approval"
+  assert_contains "$out" "no verified bounded launch profile" "grok refusal did not explain the bounded-profile gate"
+  assert_absent "$HOME_DIR/state/$id.meta" "bounded-profile refusal should happen before meta is written"
+
+  id=profile-opencode-bounded-z7d
+  rec=$(make_spawn_case profile-opencode-bounded opencode "$id")
+  read_case_record "$rec"
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR")
+  status=$?
+  expect_code 1 "$status" "opencode should fail closed without an unrestricted approval"
+  assert_contains "$out" "no verified bounded launch profile" "opencode refusal did not explain the bounded-profile gate"
+  assert_absent "$HOME_DIR/state/$id.meta" "bounded-profile refusal should happen before meta is written"
+  pass "OpenCode and Grok class adapters fail closed without --unrestricted"
+}
+
+test_unrestricted_profile_preserves_bypass_launches() {
+  local rec id out status launch
+  id=profile-claude-unrestricted-z7c
+  rec=$(make_spawn_case profile-claude-unrestricted claude "$id")
+  read_case_record "$rec"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --unrestricted)
+  status=$?
+  expect_code 0 "$status" "explicit unrestricted Claude spawn should succeed"
+  assert_meta_profile "$HOME_DIR/state/$id.meta" claude default default unrestricted
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "claude --dangerously-skip-permissions" \
+    "explicit unrestricted profile did not preserve Claude's bypass launch"
+  pass "--unrestricted is explicit, functional, and recorded in task metadata"
 }
 
 test_pi_omits_invalid_max_effort() {
@@ -383,7 +425,7 @@ test_active_dispatch_profile_does_not_block_secondmate_launch() {
   pass "active crew-dispatch profile does not block secondmate launches"
 }
 
-test_no_profile_keeps_claude_launch_unchanged
+test_no_profile_uses_bounded_claude_launch
 test_active_dispatch_profile_requires_explicit_harness_for_ship
 test_active_dispatch_profile_requires_explicit_harness_for_scout
 test_active_dispatch_profile_allows_explicit_harness
@@ -396,6 +438,8 @@ test_grok_threads_model_and_reasoning_effort
 test_grok_omits_invalid_max_reasoning_effort
 test_grok_omits_invalid_xhigh_reasoning_effort
 test_opencode_threads_model_and_ignores_effort_axis
+test_unverified_bounded_harnesses_fail_closed
+test_unrestricted_profile_preserves_bypass_launches
 test_pi_omits_invalid_max_effort
 test_batch_forwards_shared_profile_flags
 test_active_dispatch_profile_does_not_block_secondmate_launch


### PR DESCRIPTION
## Intent

Install the four Firstmate support CLIs and make verified crew launches bounded by default, with explicit unrestricted overrides and Fleet-visible permission metadata.

## What Changed
- Defaulted verified crew launches to bounded permissions, added explicit `--unrestricted` opt-ins for unrestricted runs, and classified raw launch commands as `custom` unless they are explicitly marked unrestricted.
- Recorded each task's permission class in metadata and surfaced it across Fleet snapshot/view and compact bearings output, including `unknown` for legacy metadata and parent-sourced secondmate permissions.
- Tightened secondmate bootstrap recovery so an unrestricted respawn is replayed only when the recorded approval still matches the currently resolved secondmate harness.

## Risk Assessment

✅ Low: The remaining delta is a small, focused bearings fix that now sources secondmate permission state from the authoritative parent task metadata, and I did not find a substantiated regression in the current HEAD.

## Testing

The baseline full test command had already succeeded before this run; I then reran the targeted spawn, secondmate-liveness, Fleet snapshot/view, bearings, and bootstrap suites and captured reviewer-visible CLI evidence in hermetic fixtures. The evidence shows `fm-bootstrap.sh install` driving `no-mistakes`, `gh-axi`, `chrome-devtools-axi`, and `lavish-axi`, `fm-spawn.sh` defaulting Claude to bounded mode, failing Grok closed without approval, honoring `--unrestricted` when explicitly requested, and Fleet/bearings surfacing `bounded`, `unrestricted`, and legacy `unknown` permission metadata. This is a CLI-only change, so text transcripts were the appropriate visible artifact, and the worktree was clean afterward.

<details>
<summary>Evidence: support-cli-install-transcript</summary>

```text
$ PATH=<fakebin> bin/fm-bootstrap.sh install no-mistakes gh-axi chrome-devtools-axi lavish-axi
installing no-mistakes: curl -fsSL https://raw.githubusercontent.com/kunchenguid/no-mistakes/main/docs/install.sh | sh
installing gh-axi: npm install -g gh-axi && gh-axi setup hooks
installing chrome-devtools-axi: npm install -g chrome-devtools-axi && chrome-devtools-axi setup hooks
installing lavish-axi: npm install -g lavish-axi && lavish-axi setup hooks

$ cat invocations.log
curl -fsSL https://raw.githubusercontent.com/kunchenguid/no-mistakes/main/docs/install.sh
no-mistakes installer script ran
npm install -g gh-axi
gh-axi setup hooks
npm install -g chrome-devtools-axi
chrome-devtools-axi setup hooks
npm install -g lavish-axi
lavish-axi setup hooks
```
</details>
<details>
<summary>Evidence: crew-permissions-and-fleet-transcript</summary>

```text
$ PATH=<fakebin> bin/fm-spawn.sh claude-bounded <project>
warn: no registry at /tmp/no-mistakes-evidence/01KXH6XFC6ZWEJY5EDXG115ECT/crew-permissions-demo/home/data/projects.md; defaulting project to no-mistakes off
spawned claude-bounded harness=claude kind=ship permissions=bounded mode=no-mistakes yolo=off window=firstmate:fm-claude-bounded worktree=/tmp/no-mistakes-evidence/01KXH6XFC6ZWEJY5EDXG115ECT/crew-permissions-demo/wt
$ cat launch.log
CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --permission-mode acceptEdits "$(cat '/tmp/no-mistakes-evidence/01KXH6XFC6ZWEJY5EDXG115ECT/crew-permissions-demo/home/data/claude-bounded/brief.md')"
$ cat home/state/claude-bounded.meta
window=firstmate:fm-claude-bounded
worktree=/tmp/no-mistakes-evidence/01KXH6XFC6ZWEJY5EDXG115ECT/crew-permissions-demo/wt
project=/tmp/no-mistakes-evidence/01KXH6XFC6ZWEJY5EDXG115ECT/crew-permissions-demo/project
harness=claude
kind=ship
permissions=bounded
mode=no-mistakes
yolo=off
tasktmp=/tmp/fm-claude-bounded
model=default
effort=default

$ PATH=<fakebin> bin/fm-spawn.sh grok-bounded <project> --harness grok
error: harness 'grok' has no verified bounded launch profile; pass --unrestricted only with the captain's explicit per-task approval
exit=1

$ PATH=<fakebin> bin/fm-spawn.sh grok-unrestricted <project> --harness grok --unrestricted
warn: no registry at /tmp/no-mistakes-evidence/01KXH6XFC6ZWEJY5EDXG115ECT/crew-permissions-demo/home/data/projects.md; defaulting project to no-mistakes off
spawned grok-unrestricted harness=grok kind=ship permissions=unrestricted mode=no-mistakes yolo=off window=firstmate:fm-grok-unrestricted worktree=/tmp/no-mistakes-evidence/01KXH6XFC6ZWEJY5EDXG115ECT/crew-permissions-demo/wt
$ cat launch.log
grok --always-approve "$(cat '/tmp/no-mistakes-evidence/01KXH6XFC6ZWEJY5EDXG115ECT/crew-permissions-demo/home/data/grok-unrestricted/brief.md')"
$ cat home/state/grok-unrestricted.meta
window=firstmate:fm-grok-unrestricted
worktree=/tmp/no-mistakes-evidence/01KXH6XFC6ZWEJY5EDXG115ECT/crew-permissions-demo/wt
project=/tmp/no-mistakes-evidence/01KXH6XFC6ZWEJY5EDXG115ECT/crew-permissions-demo/project
harness=grok
kind=ship
permissions=unrestricted
approved_harness=grok
mode=no-mistakes
yolo=off
tasktmp=/tmp/fm-grok-unrestricted
model=default
effort=default

$ PATH=<fakebin> bin/fm-fleet-view.sh
# Fleet View

Schema: fm-fleet-snapshot.v1
Home: /tmp/no-mistakes-evidence/01KXH6XFC6ZWEJY5EDXG115ECT/crew-permissions-demo/home

## In Flight
| ID | Current | Permissions | Kind | Repo/Project | Backend | Endpoint | Artifact | Path | Watch / return channel |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| claude-bounded | unknown / none | bounded | ship | /tmp/no-mistakes-evidence/01KXH6XFC6ZWEJY5EDXG115ECT/crew-permissions-demo/project | tmux | present | - | /tmp/no-mistakes-evidence/01KXH6XFC6ZWEJY5EDXG115ECT/crew-permissions-demo/wt | bin/fm-peek.sh fm-claude-bounded |
| grok-unrestricted | unknown / none | unrestricted | ship | /tmp/no-mistakes-evidence/01KXH6XFC6ZWEJY5EDXG115ECT/crew-permissions-demo/project | tmux | present | - | /tmp/no-mistakes-evidence/01KXH6XFC6ZWEJY5EDXG115ECT/crew-permissions-demo/wt | bin/fm-peek.sh fm-grok-unrestricted |
| legacy-task | working / status-log | unknown | ship | demo | tmux | present | - | /tmp/no-mistakes-evidence/01KXH6XFC6ZWEJY5EDXG115ECT/crew-permissions-demo/wt | bin/fm-peek.sh fm-legacy-task |

## Queued
No queued backlog records found.

## Done
No done backlog records found.

## Secondmates
For kind=secondmate, bearings selects validated structured state from that registered home; parent events and bounded terminal evidence are fallback-only supplements and never current-state authority.

$ PATH=<fakebin> bin/fm-bearings-snapshot.sh
schema: fm-bearings.v1
home: crew-permissions-demo/home
generated: "2026-07-14T21:58:49Z"
prs: "not_requested (run: /bearings include PRs)"
in_flight[3]{id,kind,permissions,state,doing}:
  claude-bounded,ship,bounded,unknown,no current-state source available
  grok-unrestricted,ship,unrestricted,unknown,no current-state source available
  legacy-task,ship,unknown,working,still on older metadata
secondmates: []
decisions_open: []
landed: []
gates: []
reports: []
recorded_prs: []
omitted[7]{surface,reveal}:
  backlog item bodies,"--fields bodies"
  task paths,"--fields paths"
  watch/steer actions,"--fields actions"
  healthy endpoint detail,"--fields endpoints"
  full scout-report inventory,"--all-reports"
  superseded queued items,"--all-queued"
  live PR discovery + checks,"--include-prs"
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (3) ✅</summary>

- 🚨 `bin/fm-spawn.sh:407` - Previously approved unrestricted secondmates on `pi`, `grok`, or `opencode` can no longer auto-respawn. This new fail-closed branch rejects a plain `fm-spawn.sh &lt;id&gt; --secondmate`, but `bin/fm-bootstrap.sh:300` still uses that exact recovery path and never replays `permissions=unrestricted` from `state/&lt;id&gt;.meta`, so a dead secondmate is killed and then left down until someone manually respawns it with `--unrestricted`.
- ⚠️ `bin/fm-fleet-snapshot.sh:481` - The intent requires &#34;Fleet-visible permission metadata&#34;, but this change only adds `permissions` to the raw snapshot JSON here; the rendered Fleet surfaces (`bin/fm-fleet-view.sh` and the compact bearings projection) still omit bounded/unrestricted/custom status. If the requirement was meant to make the permission state visible in normal Fleet views, the change is still incomplete.

🔧 Fix: Replay unrestricted secondmate respawn approvals
1 error still open:
- 🚨 `bin/fm-bootstrap.sh:302` - The intent says to &#34;make verified crew launches bounded by default, with explicit unrestricted overrides&#34;, but this hunk replays `--unrestricted` solely from stale meta: `permissions=$(fm_meta_get &#34;$meta&#34; permissions)` and `[ &#34;$permissions&#34; != unrestricted ] || respawn_args+=(--unrestricted)`. `fm-spawn.sh` re-resolves `config/secondmate-harness` on every respawn, so if a captain has since changed a secondmate from `pi/grok/opencode` to `claude` or `codex`, the next bootstrap recovery will relaunch the new harness unrestricted without a fresh explicit override.

🔧 Fix: Bind unrestricted respawns to approved harnesses
1 warning still open:
- ⚠️ `bin/fm-bearings-snapshot.sh:336` - The compact bearings projection drops the real `kind==&#34;secondmate&#34;` task rows here, then repopulates `permissions` from child endpoint/activity summaries (see the derived fields at lines 324 and 345). That means a secondmate launched `permissions=unrestricted` can still appear as `bounded` or `unknown` whenever its children are bounded or legacy, so bearings is not actually surfacing the task&#39;s recorded permission metadata. Join the parent secondmate task&#39;s `.permissions` by id instead of deriving a child summary.

🔧 Fix: Source bearings permissions from parent secondmates
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- <code>Pre-run baseline already passed: `command -v tmux &gt;/dev/null || { echo &#34;tmux is required for e2e tests&#34; &gt;&amp;2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo &#34;== $t ==&#34;; bash &#34;$t&#34; || rc=1; done; exit &#34;$rc&#34;`</code>
- `bash tests/fm-spawn-dispatch-profile.test.sh`
- `bash tests/fm-secondmate-liveness.test.sh`
- `bash tests/fm-fleet-snapshot-view.test.sh`
- `bash tests/fm-bearings-snapshot.test.sh`
- `bash tests/fm-bootstrap.test.sh`
- <code>Hermetic install demo: `PATH=&lt;fakebin&gt; bin/fm-bootstrap.sh install no-mistakes gh-axi chrome-devtools-axi lavish-axi`</code>
- <code>Hermetic launch/Fleet demo: `bin/fm-spawn.sh claude-bounded &lt;project&gt;` , `bin/fm-spawn.sh grok-bounded &lt;project&gt; --harness grok`, `bin/fm-spawn.sh grok-unrestricted &lt;project&gt; --harness grok --unrestricted`, `bin/fm-fleet-view.sh`, and `bin/fm-bearings-snapshot.sh`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
