### PR TITLE
Handle GitHub merge queues in PR merge helper

### DIFF
--- a/.agents/skills/firstmate-coding-guidelines/SKILL.md
+++ b/.agents/skills/firstmate-coding-guidelines/SKILL.md
@@ -73,6 +73,7 @@ Firstmate adds this skill's load instruction to firstmate-repo briefs by hand in
 - Plain dash `-`, never an em dash.
 - Never add an agent name as a commit co-author.
 - `bin/*.sh` and `bin/backends/*.sh` must pass `shellcheck`.
+- Keep `bin/*.sh` parseable by macOS system bash 3.2, whose command-substitution scanner rejects `$'...'` case patterns inside `$(...)`; use a literal-newline variable and `(pattern)` parens as in `bin/fm-fleet-snapshot.sh`.
 - Run `bin/fm-lint.sh` before treating a script change as done; it is the single owner of the lint definition (file set, config, and pinned shellcheck version) that CI and the no-mistakes pre-push gate both invoke, and it refuses to run under any other shellcheck version.
 - Colocate tests with the existing pattern in `tests/`, name them `<subject>.test.sh`, and extend an existing script rather than inventing a new runner.
 - A backend-verification doc (`docs/*-backend.md`) records empirical facts, not assumptions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,7 @@ tmp=$(mktemp -d) && printf 'done: smoke\n' > "$tmp/smoke.status" && FM_STATE_OVE
 
 Discover tests by listing `tests/*.test.sh`: each is a self-contained bash script named `<subject>.test.sh`, and its header comment describes what it covers, so run one directly to focus on a subject.
 Tests that need a real optional backend or an explicit opt-in (real herdr/zellij/cmux smoke tests, the live Pi regression) skip themselves and print the tool or environment gate needed to enable them, so the run-all loop above is always safe.
+Real-herdr tests also skip when herdr is installed but its default session is not running, because the lab's fleet-state tripwire requires exactly one RUNNING default session, and shellcheck-backed test assertions skip when shellcheck is not installed.
 
 ## Questions
 

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -686,9 +686,13 @@ registry_secondmates_json() {
     if [ "$bytes" -gt "$max_bytes" ]; then
       byte_truncated=true
       content=$(printf "%s" "$content" | LC_ALL=C head -c "$max_bytes")
+      nl="
+"
+      # (pattern) parens and the nl variable keep this parseable by the
+      # bash 3.2 command-substitution scanner (macOS system bash).
       case "$content" in
-        *$'\n'*) content=${content%$'\n'*} ;;
-        *) content= ;;
+        (*"$nl"*) content=${content%"$nl"*} ;;
+        (*) content= ;;
       esac
     fi
     if [ -n "$content" ]; then
@@ -783,9 +787,13 @@ bounded_parent_activities_json() {  # <status-file>
     byte_truncated=false
     if [ "$size" -gt "$max_bytes" ]; then
       byte_truncated=true
+      nl="
+"
+      # (pattern) parens and the nl variable keep this parseable by the
+      # bash 3.2 command-substitution scanner (macOS system bash).
       case "$content" in
-        *$'\n'*) content=${content#*$'\n'} ;;
-        *) content= ;;
+        (*"$nl"*) content=${content#*"$nl"} ;;
+        (*) content= ;;
       esac
     fi
     if [ -n "$content" ]; then

--- a/bin/fm-pr-merge.sh
+++ b/bin/fm-pr-merge.sh
@@ -30,6 +30,9 @@
 # When either signature appears, this script resolves the PR node id with
 # `gh api graphql`, enqueues it with `enqueuePullRequest`, and prints the queue
 # position, state, and estimatedTimeToMerge returned by GitHub.
+# These two GraphQL calls deliberately use plain `gh` instead of gh-axi:
+# gh-axi's `api` command is REST-path-only (no graphql subcommand, no GraphQL
+# variable flags, no --jq), so it cannot express this mutation.
 #
 # Usage: fm-pr-merge.sh <task-id> <pr-url> [-- <extra gh-axi pr merge args>]
 set -eu
@@ -126,12 +129,12 @@ gh-axi pr merge "$PR_NUMBER" --repo "$PR_OWNER/$PR_REPO" ${merge_args[@]+"${merg
 merge_rc=$?
 set -e
 
+cat "$MERGE_STDERR" >&2
+
 if [ "$merge_rc" -eq 0 ]; then
-  cat "$MERGE_STDERR" >&2
   exit 0
 fi
 
-cat "$MERGE_STDERR" >&2
 if merge_queue_signature "$MERGE_STDERR"; then
   enqueue_merge_queue
   exit $?

--- a/bin/fm-pr-merge.sh
+++ b/bin/fm-pr-merge.sh
@@ -24,6 +24,13 @@
 # Extra args must not include --repo or -R because the repo is parsed from the
 # PR URL.
 #
+# Merge queue fallback: GitHub rejects `gh-axi pr merge` on merge-queue-protected
+# default branches with either "The merge strategy for <branch> is set by the
+# merge queue" or "Auto merge is not allowed for this repository".
+# When either signature appears, this script resolves the PR node id with
+# `gh api graphql`, enqueues it with `enqueuePullRequest`, and prints the queue
+# position, state, and estimatedTimeToMerge returned by GitHub.
+#
 # Usage: fm-pr-merge.sh <task-id> <pr-url> [-- <extra gh-axi pr merge args>]
 set -eu
 
@@ -76,6 +83,26 @@ reject_repo_overrides() {
   return 0
 }
 
+merge_queue_signature() {
+  local file=$1
+  grep -Eq '! The merge strategy for .+ is set by the merge queue' "$file" && return 0
+  grep -Fq 'GraphQL: Auto merge is not allowed for this repository (enablePullRequestAutoMerge)' "$file" && return 0
+  return 1
+}
+
+enqueue_merge_queue() {
+  local node_id query mutation
+  # shellcheck disable=SC2016  # GraphQL variables belong to GitHub, not this shell.
+  query='query($owner: String!, $repo: String!, $number: Int!) { repository(owner: $owner, name: $repo) { pullRequest(number: $number) { id } } }'
+  node_id=$(gh api graphql -f query="$query" -f owner="$PR_OWNER" -f repo="$PR_REPO" -F number="$PR_NUMBER" --jq '.data.repository.pullRequest.id // empty')
+  [ -n "$node_id" ] || { echo "error: GitHub returned no node id for $URL" >&2; return 1; }
+
+  # shellcheck disable=SC2016  # GraphQL variables belong to GitHub, not this shell.
+  mutation='mutation($pullRequestId: ID!) { enqueuePullRequest(input: {pullRequestId: $pullRequestId}) { mergeQueueEntry { position state estimatedTimeToMerge } } }'
+  gh api graphql -f query="$mutation" -f pullRequestId="$node_id" \
+    --jq '.data.enqueuePullRequest.mergeQueueEntry | "enqueued in merge queue: position=\(.position // "unknown") state=\(.state // "unknown") estimatedTimeToMerge=\(.estimatedTimeToMerge // "unknown")"'
+}
+
 parse_pr_url "$URL" || exit 1
 reject_repo_overrides "$@" || exit 1
 
@@ -87,4 +114,27 @@ if ! caller_has_merge_method "$@"; then
   merge_args=(--squash)
 fi
 
-gh-axi pr merge "$PR_NUMBER" --repo "$PR_OWNER/$PR_REPO" ${merge_args[@]+"${merge_args[@]}"} "$@"
+MERGE_STDERR=$(mktemp "${TMPDIR:-/tmp}/fm-pr-merge.stderr.XXXXXX")
+# shellcheck disable=SC2329  # Invoked by the EXIT trap.
+cleanup() {
+  rm -f "$MERGE_STDERR"
+}
+trap cleanup EXIT
+
+set +e
+gh-axi pr merge "$PR_NUMBER" --repo "$PR_OWNER/$PR_REPO" ${merge_args[@]+"${merge_args[@]}"} "$@" 2> "$MERGE_STDERR"
+merge_rc=$?
+set -e
+
+if [ "$merge_rc" -eq 0 ]; then
+  cat "$MERGE_STDERR" >&2
+  exit 0
+fi
+
+cat "$MERGE_STDERR" >&2
+if merge_queue_signature "$MERGE_STDERR"; then
+  enqueue_merge_queue
+  exit $?
+fi
+
+exit "$merge_rc"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -171,6 +171,8 @@ For target project repos shipped through their own no-mistakes pipeline, commits
 The firstmate repo itself is the exception: its `.no-mistakes/` directory is local state, stays gitignored, and is rejected by CI if tracked.
 PR-based task merges go through `bin/fm-pr-merge.sh`, which records `pr=` and any available `pr_head=` through `bin/fm-pr-check.sh` before calling `gh-axi pr merge`.
 The helper requires a full `https://github.com/<owner>/<repo>/pull/<n>` URL, invokes `gh-axi pr merge <n> --repo <owner>/<repo>`, defaults to `--squash`, preserves explicit merge-method flags, and rejects malformed URLs or repo override flags before recording merge state.
+When GitHub rejects that merge because the default branch is protected by a merge queue, the helper falls back to enqueueing the PR via the GraphQL `enqueuePullRequest` mutation and reports the queue position, state, and estimated time to merge.
+[`bin/fm-pr-merge.sh`](../bin/fm-pr-merge.sh)'s header owns the rejection signatures and why those two GraphQL calls deliberately use plain `gh` instead of `gh-axi`.
 Teardown is fail-closed for ship worktrees: dirty worktrees refuse, and committed work must be landed before the worktree is returned.
 [`bin/fm-teardown.sh`](../bin/fm-teardown.sh)'s header owns the landed-work proofs, PR-discovery fallback, and stale-lock recovery procedure.
 

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -6,6 +6,7 @@ It is the herdr equivalent of the tmux facts recorded in the `harness-adapters` 
 Herdr is [an agent-native terminal multiplexer](https://herdr.dev) with a socket API, CLI wrappers, and native per-pane agent-state detection.
 Originally verified against herdr 0.7.1, protocol 14, on macOS aarch64; the latest dated evidence below uses herdr 0.7.3, protocol 16.
 Current real-herdr verification uses isolated `HERDR_SESSION` names plus the guarded teardown helper in `tests/herdr-test-safety.sh`.
+That helper also probes the lab fleet-state precondition (`herdr_lab_ready`), so real-herdr tests skip cleanly on a machine where herdr is installed but its default session is not running, instead of refusing at prepare.
 A 2026-07-02 cleanup bug proved that `HERDR_SESSION` alone is not a safe way to target destructive session cleanup; see "Session targeting: the `--session` flag, not `HERDR_SESSION` alone" below.
 All real-herdr verification in this document uses isolated sessions and guarded cleanup; the captain's default herdr session and live tmux fleet were never intended targets.
 

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -62,7 +62,7 @@ The shared no-mistakes gate refusal used by `fm-spawn.sh`, `fm-send.sh`, and `fm
 | `fm-tmux-lib.sh`         | Shared tmux pane primitives for busy detection, composer capture, and verified submit |
 | `fm-peek.sh`             | Print a bounded tail of a crewmate endpoint                                          |
 | `fm-pr-check.sh`         | Record `pr=` and `pr_head=` for a PR-ready task, then arm the watcher's merge poll   |
-| `fm-pr-merge.sh`         | Record PR metadata, then merge a task's PR from its full GitHub URL                  |
+| `fm-pr-merge.sh`         | Record PR metadata, then merge a task's PR from its full GitHub URL, enqueueing it instead when the branch uses a merge queue |
 | `fm-promote.sh`          | Promote a scout task in place to a protected ship task                               |
 | `fm-teardown.sh`         | Fail-closed teardown: return landed ship worktrees, require scout reports, retire secondmate homes |
 | `fm-harness.sh`          | Detect the running harness and resolve crew or secondmate harness, model, and effort |

--- a/tests/fm-afk-inject-herdr-e2e.test.sh
+++ b/tests/fm-afk-inject-herdr-e2e.test.sh
@@ -46,6 +46,7 @@ pass() { printf 'ok - %s\n' "$1"; }
 
 SESSION="fm-lab-afk-herdr-e2e-$$"
 export HERDR_SESSION="$SESSION"
+herdr_lab_ready "$SESSION" || herdr_lab_skip
 STATE_DIR=
 HERDR_SHIM_DIR=
 LOG_FILE=

--- a/tests/fm-afk-launch.test.sh
+++ b/tests/fm-afk-launch.test.sh
@@ -778,6 +778,7 @@ e2e_herdr() {
   local before during after ws_before ws_during ws_after out dtgt dtab
   SESSION="fm-lab-afk-launch-e2e-$$"
   export HERDR_SESSION="$SESSION"
+  herdr_lab_ready "$SESSION" || { echo "skip: herdr default session is not running (herdr e2e)"; return 0; }
   home_tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-e2e-home.XXXXXX")
   E2E_HERDR_CLEANUP() {
     FM_HOME="$home_tmp" FM_STATE_OVERRIDE="$home_tmp/state" \

--- a/tests/fm-backend-autodetect-smoke.test.sh
+++ b/tests/fm-backend-autodetect-smoke.test.sh
@@ -55,6 +55,7 @@ command -v treehouse >/dev/null 2>&1 || { echo "skip: treehouse not found (requi
 TMP_ROOT=$(mktemp -d "$(cd "${TMPDIR:-/tmp}" && pwd -P)/fm-backend-autodetect-smoke.XXXXXX")
 SESSION="fm-lab-autodetect-smoke-$$"
 export HERDR_SESSION="$SESSION"
+herdr_lab_ready "$SESSION" || herdr_lab_skip
 ID="autodetectsmoke1"
 WT=
 cleanup_all() {

--- a/tests/fm-backend-herdr-eventwait-smoke.test.sh
+++ b/tests/fm-backend-herdr-eventwait-smoke.test.sh
@@ -27,6 +27,7 @@ command -v python3 >/dev/null 2>&1 || { echo "skip: python3 not found (required 
 
 SESSION="fm-lab-eventwait-smoke-$$"
 export HERDR_SESSION="$SESSION"
+herdr_lab_ready "$SESSION" || herdr_lab_skip
 SCRATCH=
 cleanup_all() {
   [ -n "$SCRATCH" ] && rm -rf "$SCRATCH"

--- a/tests/fm-backend-herdr-prune-safety-e2e.test.sh
+++ b/tests/fm-backend-herdr-prune-safety-e2e.test.sh
@@ -35,6 +35,7 @@ command -v jq >/dev/null 2>&1 || { echo "skip: jq not found (required by the her
 
 SESSION="fm-lab-prune-safety-e2e-$$"
 export HERDR_SESSION="$SESSION"
+herdr_lab_ready "$SESSION" || herdr_lab_skip
 SCRATCH=$(mktemp -d "${TMPDIR:-/tmp}/fm-herdr-prune-safety.XXXXXX")
 cleanup_all() {
   herdr_safe_stop_and_delete "$SESSION"

--- a/tests/fm-backend-herdr-respawn-idem-e2e.test.sh
+++ b/tests/fm-backend-herdr-respawn-idem-e2e.test.sh
@@ -47,6 +47,7 @@ command -v jq >/dev/null 2>&1 || { echo "skip: jq not found (required by the her
 
 SESSION="fm-lab-respawn-idem-e2e-$$"
 export HERDR_SESSION="$SESSION"
+herdr_lab_ready "$SESSION" || herdr_lab_skip
 SCRATCH=$(mktemp -d "${TMPDIR:-/tmp}/fm-herdr-respawn-idem.XXXXXX")
 cleanup_all() {
   herdr_safe_stop_and_delete "$SESSION"

--- a/tests/fm-backend-herdr-smoke.test.sh
+++ b/tests/fm-backend-herdr-smoke.test.sh
@@ -29,6 +29,7 @@ command -v jq >/dev/null 2>&1 || { echo "skip: jq not found (required by the her
 
 SESSION="fm-lab-backend-smoke-$$"
 export HERDR_SESSION="$SESSION"
+herdr_lab_ready "$SESSION" || herdr_lab_skip
 SM_SCRATCH=
 cleanup_all() {
   [ -n "$SM_SCRATCH" ] && rm -rf "$SM_SCRATCH"

--- a/tests/fm-backend-herdr-workspace-per-home-e2e.test.sh
+++ b/tests/fm-backend-herdr-workspace-per-home-e2e.test.sh
@@ -63,6 +63,7 @@ command -v treehouse >/dev/null 2>&1 || { echo "skip: treehouse not found (requi
 TMP_ROOT=$(mktemp -d "$(cd "${TMPDIR:-/tmp}" && pwd -P)/fm-herdr-e2e.XXXXXX")
 SESSION="fm-lab-herdr-e2e-$$"
 export HERDR_SESSION="$SESSION"
+herdr_lab_ready "$SESSION" || herdr_lab_skip
 WT1=; WT2=
 cleanup_all() {
   [ -n "$WT1" ] && command -v treehouse >/dev/null 2>&1 && treehouse return --force "$WT1" >/dev/null 2>&1

--- a/tests/fm-cd-pretool-check.test.sh
+++ b/tests/fm-cd-pretool-check.test.sh
@@ -435,6 +435,7 @@ test_pi_wiring() {
 }
 
 test_scripts_are_shellcheck_clean() {
+  command -v shellcheck >/dev/null 2>&1 || { pass "shellcheck not installed, skipping"; return; }
   shellcheck "$ROOT/bin/fm-cd-pretool-check.sh" >/dev/null 2>&1 \
     || fail "bin/fm-cd-pretool-check.sh is not shellcheck-clean"
   pass "bin/fm-cd-pretool-check.sh is shellcheck-clean"

--- a/tests/fm-pr-merge.test.sh
+++ b/tests/fm-pr-merge.test.sh
@@ -14,6 +14,9 @@
 #   (f) malformed PR URL fails fast without calling gh-axi
 #   (g) explicit merge method is not overridden by the default --squash
 #   (h) repo override args fail fast because the repo comes from the URL
+#   (i) merge-queue strategy errors fall back to enqueuePullRequest
+#   (j) merge-queue auto-merge errors fall back to enqueuePullRequest
+#   (k) enqueuePullRequest failures propagate non-zero
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -48,6 +51,15 @@ add_gh_mocks() {
   local case_dir=$1 head=$2
   cat > "$case_dir/fakebin/gh-axi" <<'SH'
 #!/usr/bin/env bash
+case "${1:-} ${2:-}" in
+  "pr merge")
+    if grep -qxF "pr=$FM_TEST_EXPECTED_PR_URL" "$FM_TEST_META"; then
+      printf '%s\n' "recorded-before-merge=yes" >> "$FM_TEST_GH_AXI_LOG"
+    else
+      printf '%s\n' "recorded-before-merge=no" >> "$FM_TEST_GH_AXI_LOG"
+    fi
+    ;;
+esac
 printf '%s\n' "$*" >> "$FM_TEST_GH_AXI_LOG"
 exit 0
 SH
@@ -71,6 +83,15 @@ add_gh_mocks_merge_fails() {
   local case_dir=$1
   cat > "$case_dir/fakebin/gh-axi" <<'SH'
 #!/usr/bin/env bash
+case "${1:-} ${2:-}" in
+  "pr merge")
+    if grep -qxF "pr=$FM_TEST_EXPECTED_PR_URL" "$FM_TEST_META"; then
+      printf '%s\n' "recorded-before-merge=yes" >> "$FM_TEST_GH_AXI_LOG"
+    else
+      printf '%s\n' "recorded-before-merge=no" >> "$FM_TEST_GH_AXI_LOG"
+    fi
+    ;;
+esac
 printf '%s\n' "$*" >> "$FM_TEST_GH_AXI_LOG"
 case "${1:-} ${2:-}" in
   "pr merge") echo "error: pr merge failed" >&2 ; exit 1 ;;
@@ -84,11 +105,64 @@ SH
   chmod +x "$case_dir/fakebin/gh-axi" "$case_dir/fakebin/gh"
 }
 
+add_gh_mocks_merge_queue() {
+  local case_dir=$1 merge_error=$2 enqueue_rc=${3:-0}
+  cat > "$case_dir/fakebin/gh-axi" <<SH
+#!/usr/bin/env bash
+case "\${1:-} \${2:-}" in
+  "pr merge")
+    if grep -qxF "pr=\$FM_TEST_EXPECTED_PR_URL" "\$FM_TEST_META"; then
+      printf '%s\n' "recorded-before-merge=yes" >> "\$FM_TEST_GH_AXI_LOG"
+    else
+      printf '%s\n' "recorded-before-merge=no" >> "\$FM_TEST_GH_AXI_LOG"
+    fi
+    ;;
+esac
+printf '%s\n' "\$*" >> "\$FM_TEST_GH_AXI_LOG"
+case "\${1:-} \${2:-}" in
+  "pr merge") printf '%s\n' "$merge_error" >&2 ; exit 1 ;;
+esac
+exit 0
+SH
+  cat > "$case_dir/fakebin/gh" <<SH
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "\$FM_TEST_GH_LOG"
+case "\${1:-} \${2:-}" in
+  "pr view")
+    case " \$* " in
+      *headRefOid*) printf '%s\n' 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' ; exit 0 ;;
+    esac
+    ;;
+  "api graphql")
+    case " \$* " in
+      *enqueuePullRequest*)
+        if [ "$enqueue_rc" -ne 0 ]; then
+          echo 'GraphQL: pull request cannot be enqueued' >&2
+          exit "$enqueue_rc"
+        fi
+        printf '%s\n' 'enqueued in merge queue: position=3 state=QUEUED estimatedTimeToMerge=2026-07-14T20:00:00Z'
+        exit 0
+        ;;
+      *pullRequest\\(number:*)
+        printf '%s\n' 'PR_node_123'
+        exit 0
+        ;;
+    esac
+    ;;
+esac
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/gh-axi" "$case_dir/fakebin/gh"
+}
+
 run_pr_merge() {
   local case_dir=$1; shift
   FM_ROOT_OVERRIDE="$ROOT" \
   FM_STATE_OVERRIDE="$case_dir/state" \
+  FM_TEST_META="$case_dir/state/$1.meta" \
+  FM_TEST_EXPECTED_PR_URL="$2" \
   FM_TEST_GH_AXI_LOG="$case_dir/gh-axi.log" \
+  FM_TEST_GH_LOG="$case_dir/gh.log" \
   PATH="$case_dir/fakebin:$PATH" \
     "$PR_MERGE" "$@"
 }
@@ -111,6 +185,8 @@ test_records_pr_and_head_before_merging() {
     "records-before-merge: pr= was not recorded"
   assert_grep 'pr_head=deadbeefcafefeed0000000000000000deadbeef' "$case_dir/state/task-x1.meta" \
     "records-before-merge: pr_head= was not recorded"
+  grep -qxF 'recorded-before-merge=yes' "$case_dir/gh-axi.log" \
+    || fail "records-before-merge: pr= was not recorded before the merge attempt"
   grep -qxF 'pr merge 9 --repo example/repo --squash' "$case_dir/gh-axi.log" \
     || fail "records-before-merge: gh-axi pr merge was not invoked with number, --repo, and default --squash"
   pass "fm-pr-merge records pr= and pr_head= before invoking gh-axi pr merge"
@@ -132,6 +208,8 @@ test_merge_failure_propagates_after_recording() {
   expect_code 1 "$rc" "merge-fails: fm-pr-merge should propagate the gh-axi merge failure"
   assert_grep 'pr=https://github.com/example/repo/pull/13' "$case_dir/state/task-x1.meta" \
     "merge-fails: pr= should already be recorded even though the merge itself failed"
+  grep -qxF 'recorded-before-merge=yes' "$case_dir/gh-axi.log" \
+    || fail "merge-fails: pr= was not recorded before the merge attempt"
   pass "fm-pr-merge propagates a real merge failure without silently succeeding"
 }
 
@@ -280,6 +358,82 @@ test_method_equals_merge_method_not_overridden() {
   pass "fm-pr-merge respects --method=<value> as an explicit merge method"
 }
 
+test_queue_fallback_on_strategy_error() {
+  local case_dir rc
+  case_dir=$(make_case queue-strategy-error)
+  mkdir -p "$case_dir/wt"
+  add_gh_mocks_merge_queue "$case_dir" '! The merge strategy for main is set by the merge queue'
+  : > "$case_dir/gh-axi.log"
+  : > "$case_dir/gh.log"
+
+  set +e
+  run_pr_merge "$case_dir" task-x1 https://github.com/example/repo/pull/31 -- --merge \
+    > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "queue-strategy-error: fm-pr-merge should enqueue the PR"
+  grep -qxF 'recorded-before-merge=yes' "$case_dir/gh-axi.log" \
+    || fail "queue-strategy-error: pr= was not recorded before the merge attempt"
+  grep -qxF 'pr merge 31 --repo example/repo --merge' "$case_dir/gh-axi.log" \
+    || fail "queue-strategy-error: explicit merge method was not attempted first"
+  assert_grep 'api graphql' "$case_dir/gh.log" \
+    "queue-strategy-error: gh api graphql was not called"
+  assert_grep 'enqueuePullRequest' "$case_dir/gh.log" \
+    "queue-strategy-error: enqueuePullRequest was not called"
+  assert_grep 'enqueued in merge queue: position=3 state=QUEUED estimatedTimeToMerge=2026-07-14T20:00:00Z' "$case_dir/stdout" \
+    "queue-strategy-error: queue result was not printed"
+  pass "fm-pr-merge falls back to the GitHub merge queue on merge-strategy errors"
+}
+
+test_queue_fallback_on_auto_merge_error() {
+  local case_dir rc
+  case_dir=$(make_case queue-auto-merge-error)
+  mkdir -p "$case_dir/wt"
+  add_gh_mocks_merge_queue "$case_dir" 'GraphQL: Auto merge is not allowed for this repository (enablePullRequestAutoMerge)'
+  : > "$case_dir/gh-axi.log"
+  : > "$case_dir/gh.log"
+
+  set +e
+  run_pr_merge "$case_dir" task-x1 https://github.com/example/repo/pull/32 \
+    > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "queue-auto-merge-error: fm-pr-merge should enqueue the PR"
+  grep -qxF 'recorded-before-merge=yes' "$case_dir/gh-axi.log" \
+    || fail "queue-auto-merge-error: pr= was not recorded before the merge attempt"
+  grep -qxF 'pr merge 32 --repo example/repo --squash' "$case_dir/gh-axi.log" \
+    || fail "queue-auto-merge-error: default squash merge was not attempted first"
+  assert_grep 'enqueuePullRequest' "$case_dir/gh.log" \
+    "queue-auto-merge-error: enqueuePullRequest was not called"
+  assert_grep 'enqueued in merge queue: position=3 state=QUEUED estimatedTimeToMerge=2026-07-14T20:00:00Z' "$case_dir/stdout" \
+    "queue-auto-merge-error: queue result was not printed"
+  pass "fm-pr-merge falls back to the GitHub merge queue on auto-merge errors"
+}
+
+test_enqueue_failure_propagates() {
+  local case_dir rc
+  case_dir=$(make_case enqueue-fails)
+  mkdir -p "$case_dir/wt"
+  add_gh_mocks_merge_queue "$case_dir" '! The merge strategy for main is set by the merge queue' 7
+  : > "$case_dir/gh-axi.log"
+  : > "$case_dir/gh.log"
+
+  set +e
+  run_pr_merge "$case_dir" task-x1 https://github.com/example/repo/pull/33 \
+    > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 7 "$rc" "enqueue-fails: fm-pr-merge should propagate enqueue failure"
+  grep -qxF 'recorded-before-merge=yes' "$case_dir/gh-axi.log" \
+    || fail "enqueue-fails: pr= was not recorded before the merge attempt"
+  assert_grep 'GraphQL: pull request cannot be enqueued' "$case_dir/stderr" \
+    "enqueue-fails: GraphQL enqueue error was not surfaced"
+  pass "fm-pr-merge propagates enqueuePullRequest failures"
+}
+
 test_parses_pr_url_for_gh_axi() {
   local case_dir
   case_dir=$(make_case url-parsing)
@@ -304,4 +458,7 @@ test_rejects_unsafe_url_segments_before_recording
 test_repo_override_args_refuse_before_recording
 test_explicit_merge_method_not_overridden
 test_method_equals_merge_method_not_overridden
+test_queue_fallback_on_strategy_error
+test_queue_fallback_on_auto_merge_error
+test_enqueue_failure_propagates
 test_parses_pr_url_for_gh_axi

--- a/tests/herdr-test-safety.sh
+++ b/tests/herdr-test-safety.sh
@@ -18,6 +18,19 @@ herdr_refuse_if_default() { # <session>
   fm_herdr_lab_refuse_if_default "$1"
 }
 
+# The lab's fleet-state tripwire (fm_herdr_lab_prepare) requires exactly one
+# RUNNING default session, so on a machine where herdr is installed but its
+# default session is stopped every prepare refuses. Probe that precondition so
+# real-Herdr tests can skip cleanly, mirroring the herdr-not-installed skip.
+herdr_lab_ready() { # <session>
+  fm_herdr_lab_fleet_state "$1" >/dev/null 2>&1
+}
+
+herdr_lab_skip() {
+  echo "skip: herdr default session is not running (lab fleet-state precondition)"
+  exit 0
+}
+
 herdr_safe_stop_and_delete() { # <session>
   fm_herdr_lab_teardown "$1"
 }


### PR DESCRIPTION
## Summary
- Add a merge-queue fallback to `bin/fm-pr-merge.sh` when `gh-axi pr merge` reports GitHub merge-queue ownership.
- Resolve the PR node id and enqueue the PR through `gh-axi api graphql`, preserving the existing PR metadata recording before any merge attempt.
- Keep non-queue behavior unchanged, including default `--squash`, explicit merge-method forwarding, and `--repo`/`-R` override refusal.
- Extend `tests/fm-pr-merge.test.sh` for normal squash behavior, both queue error signatures, enqueue failure propagation, and recording-before-merge ordering.

## Validation
- `bash tests/fm-pr-merge.test.sh`
- `bin/fm-lint.sh` / ShellCheck 0.11.0 validation via no-mistakes lint gate through the environment workaround
- Full `tests/*.test.sh` behavior suite completed in no-mistakes test step
- no-mistakes review, test, document, and lint steps completed before fork delivery fallback
