### PR TITLE
fix(brief): eliminate heredoc-in-command-substitution bash 3.2 bug at the root

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,25 @@ jobs:
             exit 1
           }
 
+          /bin/bash -n bin/fm-brief.sh
+          /bin/bash -n bin/fm-spawn.sh
+
+          brief_output=$(/bin/bash tests/fm-brief.test.sh)
+          printf '%s\n' "$brief_output"
+          brief_count=$(printf '%s\n' "$brief_output" | grep -c '^ok - ')
+          [ "$brief_count" -eq 11 ] || {
+            echo "::error::expected 11 fm-brief.sh tests, got $brief_count"
+            exit 1
+          }
+
+          spawn_batch_output=$(/bin/bash tests/fm-spawn-batch.test.sh)
+          printf '%s\n' "$spawn_batch_output"
+          spawn_batch_count=$(printf '%s\n' "$spawn_batch_output" | grep -c '^ok - ')
+          [ "$spawn_batch_count" -eq 3 ] || {
+            echo "::error::expected 3 fm-spawn.sh batch tests, got $spawn_batch_count"
+            exit 1
+          }
+
   invariants:
     name: Repo invariants
     runs-on: ubuntu-latest

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -211,13 +211,20 @@ HERDR_SECTION=$(printf '%s\n' \
 'Never bypass the helper, even for a read-only lifecycle probe or cleanup after failure.' \
 'The captain fleet uses the running `default` session.')
 else
-HERDR_SECTION=$(cat <<'EOF'
+# Bash 3.2's lexer loses track of quote state when a heredoc sits directly
+# inside a $(...) capture, so an apostrophe anywhere in the body breaks
+# parsing of the rest of the script. Defining the heredoc inside a function
+# and capturing the function's stdout instead keeps the heredoc lexically
+# outside any $(...).
+herdr_lab_not_enabled_text() {
+cat <<'EOF'
 # Herdr lifecycle declaration - NOT ENABLED
 **HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
 If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
 Do not add Herdr lifecycle commands to this unguarded brief by hand.
 EOF
-)
+}
+HERDR_SECTION=$(herdr_lab_not_enabled_text)
 fi
 
 if [ "$KIND" = scout ]; then
@@ -277,19 +284,27 @@ case "$MODE" in
   direct-PR)
     SETUP2=""
     RULE1='1. Never push to the default branch (push only your `fm/'"$ID"'` branch). Never merge a PR.'
-    DOD=$(cat <<EOF
+# Bash 3.2's lexer loses track of quote state when a heredoc sits directly
+# inside a $(...) capture, so an apostrophe anywhere in the body breaks
+# parsing of the rest of the script. Defining the heredoc inside a function
+# and capturing the function's stdout instead keeps the heredoc lexically
+# outside any $(...).
+dod_direct_pr_text() {
+cat <<EOF
 # Definition of done
 This project ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
 The task is complete only when committed on your branch.
 When it is implemented and committed, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\` to the status file and stop.
 Do NOT run /no-mistakes. The captain reviews and merges the PR; firstmate relays it.
 EOF
-)
+}
+    DOD=$(dod_direct_pr_text)
     ;;
   local-only)
     SETUP2=""
     RULE1="1. Never push to any remote and never open a PR. Work only on your \`fm/$ID\` branch; firstmate handles the merge into local \`main\`."
-    DOD=$(cat <<EOF
+dod_local_only_text() {
+cat <<EOF
 # Definition of done
 This project ships **local-only**: no remote, no PR, no pipeline.
 The task is complete only when committed on your branch \`fm/$ID\`. Do NOT push, do NOT open a PR, do NOT merge.
@@ -297,13 +312,15 @@ Keep your branch a clean fast-forward onto the current default branch - if \`mai
 When it is implemented and committed, append \`done: ready in branch fm/$ID\` to the status file and stop.
 Firstmate then reviews your branch diff, the captain approves, and firstmate merges it into local \`main\`.
 EOF
-)
+}
+    DOD=$(dod_local_only_text)
     ;;
   *)  # no-mistakes (default)
     SETUP2="
 2. Run \`no-mistakes doctor\`; if it reports the repo is not initialized here, run \`no-mistakes init\`."
     RULE1='1. Never push to the default branch. Never merge a PR.'
-    DOD=$(cat <<EOF
+dod_no_mistakes_text() {
+cat <<EOF
 # Definition of done
 The task is complete only when committed on your branch.
 When you believe it is complete, append \`done: {summary}\` to the status file and stop.
@@ -320,7 +337,8 @@ Two firstmate-specific rules layer on top of that guidance:
 
 After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished.
 EOF
-)
+}
+    DOD=$(dod_no_mistakes_text)
     ;;
 esac
 


### PR DESCRIPTION
## Summary

- `bin/fm-brief.sh` had four `VAR=$(cat <<EOF ... EOF)` heredoc-in-command-substitution sites. Bash 3.2's lexer loses quote-tracking through a heredoc body nested inside `$(...)`, so a single unescaped apostrophe anywhere in that text breaks parsing of the *entire rest of the script* (`bash -n` fails). PR #173 previously worked around this by rewording the one sentence that happened to trip it, leaving the fragile pattern in place at all four sites. This PR fixes the root cause: each heredoc is now defined inside a small local function whose stdout is captured instead (`DOD=$(dod_text)`), keeping the heredoc lexically outside any `$(...)` and making it structurally immune to the bug regardless of body content.
- `bin/fm-spawn.sh`'s batch-dispatch `shared_args[@]` expansion was already fixed by the same prior PR (#173) with the portable `${shared_args[@]+"${shared_args[@]}"}` idiom. No code change needed there; verified clean under stock macOS Bash 3.2.57.
- Extended the existing `macos-stock-bash` CI job (added in #578) to cover both scripts going forward: `bash -n` on each, plus running `tests/fm-brief.test.sh` and `tests/fm-spawn-batch.test.sh` under real stock Bash 3.2.57, so this class of regression is caught on the actual target shell instead of only the Linux runners' modern bash.

## Test plan

- [x] `bash -n bin/fm-brief.sh` and `bash -n bin/fm-spawn.sh` under `/bin/bash` 3.2.57 (this machine's stock bash) and under a modern bash
- [x] `tests/fm-brief.test.sh` (11/11) and `tests/fm-spawn-batch.test.sh` (3/3) pass under both bash versions
- [x] Reproduced the original bug in isolation (`$(cat <<EOF ... apostrophe ... EOF)` fails to parse under 3.2 with both quoted and unquoted heredoc delimiters) and confirmed the post-fix script still parses even with an apostrophe re-injected into the DOD text
- [x] Diffed generated scaffolds (ship in all three delivery modes, scout, `--herdr-lab`, secondmate) between the pre-fix and post-fix script under bash 3.2.57 - byte-identical after normalizing incidental scratch-path differences
- [x] `bin/fm-lint.sh` (pinned ShellCheck 0.11.0) - clean
- [x] Simulated the added `macos-stock-bash` CI job steps locally in a sanitized stock-Bash environment - all pass

**No-mistakes gate note:** review/document/lint all completed cleanly through the local no-mistakes gate. The test step's single lump finding covered 4 pre-existing failures in `tests/fm-backlog-handoff.test.sh`, `tests/fm-pi-watch-extension.test.sh`, `tests/fm-secondmate-lifecycle-e2e.test.sh`, and `tests/fm-turnend-guard.test.sh` - none touch the files changed in this PR. Two were resolved by upgrading this sandbox's stale global `tasks-axi` (0.1.2 -> 0.2.3, matching what CI installs fresh); the remaining two are a Node v23.7.0 `ExperimentalWarning` runtime artifact in this sandbox, unrelated to firstmate code, so that gate step was skipped with documented reasoning rather than editing test files. The gate's automated `push` step then failed with a GitHub permissions error (the local git identity lacks write access to `kunchenguid/firstmate`), so this PR was opened manually via a fork per captain direction instead of through the gate's own push/PR steps.
