### PR TITLE
fix: treat away-mode daemon as healthy in turn-end guard

### DIFF
--- a/bin/fm-turnend-guard.sh
+++ b/bin/fm-turnend-guard.sh
@@ -112,9 +112,29 @@ fi
 # shellcheck source=bin/fm-wake-lib.sh
 . "$SCRIPT_DIR/fm-wake-lib.sh"
 
+# fm_afk_supervision_healthy: while state/.afk is present the away-mode
+# sub-supervisor daemon owns the watcher and runs it one-shot per poll, so no
+# foreground watcher holds the home watch-lock and fm_watcher_healthy correctly
+# fails. A live daemon plus a fresh beacon is still proof of supervision: the
+# daemon-liveness contract is reused (not restated) from bin/fm-afk-start.sh,
+# and beacon freshness was already computed by fm_supervision_status above into
+# FM_SUP_WATCHER_FRESH. fm-afk-start.sh enables errexit at source time; restore
+# the guard's set -u only. See docs/turnend-guard.md "Away-mode health".
+fm_afk_supervision_healthy() {
+  [ -e "$STATE/.afk" ] || return 1
+  # shellcheck source=bin/fm-afk-start.sh
+  . "$SCRIPT_DIR/fm-afk-start.sh" 2>/dev/null || return 1
+  set +e
+  FM_AFK_LOCK="$STATE/.supervise-daemon.lock" \
+    daemon_lock_held_by_live_daemon || return 1
+  [ "$FM_SUP_WATCHER_FRESH" = true ] || return 1
+  return 0
+}
+
 fm_supervision_status "$STATE" "$GRACE"
 [ "$FM_SUP_IN_FLIGHT" -gt 0 ] || exit 0
 fm_watcher_healthy "$STATE" "$WATCH" "$GRACE" "$FM_HOME" && exit 0
+fm_afk_supervision_healthy && exit 0
 
 afk=0
 [ -e "$STATE/.afk" ] && afk=1

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -35,6 +35,16 @@ A fresh leftover beacon blocks if the watcher lock is missing, dead, or identity
 `FM_GUARD_GRACE` controls the beacon freshness window and defaults to 300 seconds.
 If `jq` is missing or hook stdin is empty, the guard fails open and exits 0 because it cannot safely read loop-guard fields.
 
+### Away-mode health
+
+While `state/.afk` is present the away-mode sub-supervisor daemon (`bin/fm-supervise-daemon.sh`) owns the watcher and runs it one-shot per poll, so no long-lived foreground watcher holds the home watch-lock.
+The identity-matched lock check above therefore fails even though supervision is genuinely healthy: the daemon's child watcher still touches `state/.last-watcher-beat` every poll.
+The guard treats away-mode supervision as healthy exactly when both hold: the daemon lock at `state/.supervise-daemon.lock` is held by a live process (the same liveness predicate `bin/fm-afk-start.sh` exposes as `daemon_lock_held_by_live_daemon`, reused rather than restated) AND the beacon is fresh within the grace window.
+Either failing - a dead daemon or a stale beacon - still trips the guard, because a genuinely dark away-mode primary is exactly the gap it exists to catch; only a live daemon plus a fresh beacon suppresses it.
+The fired banner's repair line then points at the afk daemon rather than the normal watcher arm, since away mode must not start a competing foreground watcher.
+Away mode off behaves unchanged: the lock-plus-beacon check above is the sole health predicate.
+The same code path guards a secondmate's own primary session, so an away-mode secondmate home is covered identically.
+
 ## Harness Integrations
 
 All verified primary harnesses have a tracked integration:
@@ -146,6 +156,6 @@ No Herdr command was issued and no fleet state was touched; the experiment wrote
 
 ## Tests
 
-`tests/fm-turnend-guard.test.sh` covers the shared predicate, primary scoping (including a secondmate's own home being guarded like the main primary while its child worktrees stay exempt), `FM_HOME` and `FM_STATE_OVERRIDE` precedence, Pi logical-run latch behavior for no-tool and multi-tool runs, fail-open behavior without `jq`, tracked hook registration for all five harnesses, and the Grok adapter's forced-resume loop guard and permission-mode regression.
+`tests/fm-turnend-guard.test.sh` covers the shared predicate, primary scoping (including a secondmate's own home being guarded like the main primary while its child worktrees stay exempt), `FM_HOME` and `FM_STATE_OVERRIDE` precedence, away-mode health (silent with a live daemon and fresh beacon; still firing for a dead daemon or a stale beacon), Pi logical-run latch behavior for no-tool and multi-tool runs, fail-open behavior without `jq`, tracked hook registration for all five harnesses, and the Grok adapter's forced-resume loop guard and permission-mode regression.
 The default behavior suite does not invoke live language-model harnesses.
 `FM_PI_LIVE_E2E=1 tests/fm-pi-primary-live-e2e.test.sh` opts into the isolated interactive Pi regression recorded above.

--- a/tests/fm-turnend-guard.test.sh
+++ b/tests/fm-turnend-guard.test.sh
@@ -20,6 +20,10 @@ TMP_ROOT=$(fm_test_tmproot fm-turnend-guard)
 fm_git_identity fmtest fmtest@example.invalid
 
 REQUIRED_REASON='resume supervision with bin/fm-watch-arm.sh as its own Claude Code background task'
+# When the guard fires WHILE away mode is on, the repair line correctly points at
+# the afk daemon rather than the normal watcher arm (the normal path would be
+# wrong: away mode must not start a competing foreground watcher).
+AFK_REASON='Away mode owns watcher supervision; load /afk and ensure the daemon is running instead of starting normal supervision directly.'
 
 # --- PREDICATE: bin/fm-supervision-lib.sh -----------------------------------
 
@@ -92,6 +96,9 @@ install_guard_scripts() {
   cp "$ROOT/bin/fm-harness.sh" "$dir/bin/fm-harness.sh"
   cp "$ROOT/bin/fm-supervision-lib.sh" "$dir/bin/fm-supervision-lib.sh"
   cp "$ROOT/bin/fm-wake-lib.sh" "$dir/bin/fm-wake-lib.sh"
+  # fm-afk-start.sh owns the away-mode daemon-liveness contract reused by the
+  # guard's away-mode health path (sourced by fm-turnend-guard.sh when .afk).
+  cp "$ROOT/bin/fm-afk-start.sh" "$dir/bin/fm-afk-start.sh"
   mkdir -p "$dir/docs"
   cp -R "$ROOT/docs/supervision-protocols" "$dir/docs/supervision-protocols"
   chmod +x "$dir/bin/fm-turnend-guard.sh" "$dir/bin/fm-turnend-guard-grok.sh" "$dir/bin/fm-supervision-instructions.sh" "$dir/bin/fm-harness.sh"
@@ -268,6 +275,85 @@ test_hook_blocks_with_live_lock_and_stale_beacon() {
   expect_code 2 "$status" "hook must block when a live watcher lock has an ancient beacon"
   assert_contains "$out" "$REQUIRED_REASON" "block reason must contain the exact required instruction"
   pass "fm-turnend-guard: blocks on a live watcher lock with an ancient beacon"
+}
+
+# --- HOOK: away-mode (sub-supervisor daemon) health -------------------------
+#
+# While state/.afk is present the away-mode daemon owns the watcher and runs it
+# one-shot per poll, so no foreground watcher holds the home watch-lock and the
+# lock-based fm_watcher_healthy check fails even though supervision is healthy.
+# The guard must treat a LIVE daemon plus a FRESH beacon as healthy (silent),
+# while still firing for a dead daemon or a stale beacon - a genuinely dark
+# away-mode primary is exactly the gap the guard exists to catch. Together with
+# test_hook_blocks_when_unhealthy_in_primary (afk off, no watcher -> fire) and
+# test_hook_silent_with_live_lock_and_fresh_beacon (afk off, live watcher ->
+# silent), these cover all four away-mode-aware health cases.
+
+record_daemon_lock() {
+  local dir=$1 pid=$2 identity=$3
+  mkdir -p "$dir/state/.supervise-daemon.lock"
+  printf '%s\n' "$pid" > "$dir/state/.supervise-daemon.lock/pid"
+  printf '%s\n' "$identity" > "$dir/state/.supervise-daemon.lock/pid-identity"
+}
+
+test_hook_afk_silent_with_live_daemon_and_fresh_beacon() {
+  local dir pid identity out status
+  dir=$(make_primary_dir "$TMP_ROOT/hook-afk-live")
+  : > "$dir/state/task1.meta"
+  : > "$dir/state/.afk"
+  sleep 60 &
+  pid=$!
+  identity=$(watcher_identity "$dir" "$pid") || {
+    kill "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+    fail "could not identify live daemon holder"
+  }
+  record_daemon_lock "$dir" "$pid" "$identity"
+  touch "$dir/state/.last-watcher-beat"
+  out=$(run_hook "$dir" false); status=$?
+  kill "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+  expect_code 0 "$status" "hook must be silent in away mode when the daemon is live and the beacon is fresh"
+  [ -z "$out" ] || fail "hook produced output despite a live away-mode daemon and fresh beacon: $out"
+  pass "fm-turnend-guard: silent in away mode with a live daemon and a fresh beacon"
+}
+
+test_hook_afk_blocks_with_dead_daemon() {
+  local dir dead out status
+  dir=$(make_primary_dir "$TMP_ROOT/hook-afk-dead-daemon")
+  : > "$dir/state/task1.meta"
+  : > "$dir/state/.afk"
+  dead=$(nonexistent_pid)
+  record_daemon_lock "$dir" "$dead" "dead daemon identity"
+  touch "$dir/state/.last-watcher-beat"
+  out=$(run_hook "$dir" false); status=$?
+  expect_code 2 "$status" "hook must fire in away mode when the daemon lock pid is dead despite a fresh beacon"
+  assert_contains "$out" "$AFK_REASON" "afk-mode block reason must point at the afk daemon, not the normal watcher arm"
+  assert_contains "$out" "TURN WOULD END BLIND" "block banner must read as an alarm"
+  pass "fm-turnend-guard: fires in away mode when the daemon is dead (fresh beacon alone is not enough)"
+}
+
+test_hook_afk_blocks_with_stale_beacon() {
+  local dir pid identity out status
+  dir=$(make_primary_dir "$TMP_ROOT/hook-afk-stale-beacon")
+  : > "$dir/state/task1.meta"
+  : > "$dir/state/.afk"
+  sleep 60 &
+  pid=$!
+  identity=$(watcher_identity "$dir" "$pid") || {
+    kill "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+    fail "could not identify live daemon holder"
+  }
+  record_daemon_lock "$dir" "$pid" "$identity"
+  touch -t 202001010000 "$dir/state/.last-watcher-beat"
+  out=$(run_hook "$dir" false); status=$?
+  kill "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+  expect_code 2 "$status" "hook must fire in away mode when the beacon is stale despite a live daemon"
+  assert_contains "$out" "$AFK_REASON" "afk-mode block reason must point at the afk daemon, not the normal watcher arm"
+  assert_contains "$out" "TURN WOULD END BLIND" "block banner must read as an alarm"
+  pass "fm-turnend-guard: fires in away mode when the beacon is stale (live daemon alone is not enough)"
 }
 
 test_hook_blocks_when_unhealthy_in_primary() {
@@ -562,7 +648,7 @@ test_grok_adapter_forces_one_resume_when_unhealthy() {
 } >> "$log"
 EOF
   chmod +x "$fakebin/grok"
-  out=$(printf '{"sessionId":"session-test","hookEventName":"stop"}' | PATH="$fakebin:$PATH" GROK_WORKSPACE_ROOT="$dir" bash "$dir/bin/fm-turnend-guard-grok.sh" 2>&1); status=$?
+  out=$(printf '{"sessionId":"session-test","hookEventName":"stop"}' | PATH="$fakebin:$PATH" GROK_WORKSPACE_ROOT="$dir" FM_HOME="$dir" bash "$dir/bin/fm-turnend-guard-grok.sh" 2>&1); status=$?
   expect_code 0 "$status" "grok adapter must fail open after queuing a forced resume"
   [ -z "$out" ] || fail "grok adapter printed output: $out"
   assert_contains "$(cat "$log")" 'active=1' "grok adapter must mark its forced resume as loop-guarded"
@@ -585,7 +671,7 @@ test_grok_adapter_loop_guard_skips_resume() {
 printf 'called\n' >> "$log"
 EOF
   chmod +x "$fakebin/grok"
-  out=$(printf '{"sessionId":"session-test","hookEventName":"stop"}' | PATH="$fakebin:$PATH" GROK_WORKSPACE_ROOT="$dir" GROK_TURNEND_GUARD_ACTIVE=1 bash "$dir/bin/fm-turnend-guard-grok.sh" 2>&1); status=$?
+  out=$(printf '{"sessionId":"session-test","hookEventName":"stop"}' | PATH="$fakebin:$PATH" GROK_WORKSPACE_ROOT="$dir" FM_HOME="$dir" GROK_TURNEND_GUARD_ACTIVE=1 bash "$dir/bin/fm-turnend-guard-grok.sh" 2>&1); status=$?
   expect_code 0 "$status" "grok adapter must allow its own forced resume turn to end"
   [ -z "$out" ] || fail "grok adapter printed output while loop-guarded: $out"
   [ ! -e "$log" ] || fail "grok adapter spawned another resume while loop-guarded: $(cat "$log")"
@@ -894,6 +980,9 @@ test_hook_blocks_when_fresh_beacon_has_no_live_lock
 test_hook_blocks_when_dead_lock_has_fresh_beacon
 test_hook_silent_with_live_lock_and_fresh_beacon
 test_hook_blocks_with_live_lock_and_stale_beacon
+test_hook_afk_silent_with_live_daemon_and_fresh_beacon
+test_hook_afk_blocks_with_dead_daemon
+test_hook_afk_blocks_with_stale_beacon
 test_hook_blocks_when_unhealthy_in_primary
 test_hook_blocks_from_fm_home_state
 test_hook_x_mode_reason_sources_cadence


### PR DESCRIPTION
## Intent

Fix a recurring FALSE POSITIVE in the primary turn-end guard (bin/fm-turnend-guard.sh) that fires 'TURN WOULD END BLIND - SUPERVISION IS OFF' on nearly every turn while away mode is active and supervision is actually healthy. Root cause: the guard's fm_watcher_healthy check requires a lock-holding foreground watcher (state/.watch.lock), but in away mode the sub-supervisor daemon (bin/fm-supervise-daemon.sh) owns the watcher and runs it one-shot per poll, so no persistent lock is held even though the daemon is live and the beacon (state/.last-watcher-beat) is fresh. Fix: add fm_afk_supervision_healthy - while state/.afk is present, treat supervision as healthy when the away-mode daemon is genuinely live AND the beacon is fresh within the grace window. The daemon-liveness contract is REUSED (not restated) from bin/fm-afk-start.sh's daemon_lock_held_by_live_daemon, exactly as bin/fm-afk-launch.sh already does. Deliberate must-preserve constraints: away mode OFF is completely unchanged (the lock+beacon check stays the sole predicate); a dead daemon OR a stale beacon must STILL fire the guard because a genuinely-dark away-mode primary is exactly the gap it exists to catch; the secondmate-primary guard path shares the same predicate so it is covered identically. Also made the two grok adapter tests hermetic against ambient FM_HOME env leakage that this change exposed (the tests did not set FM_HOME, so a captain's exported FM_HOME leaked in and made the guard read the real fleet state).

## What Changed

ffddeb4 fix: treat away-mode daemon as healthy in turn-end guard

## Risk Assessment

✅ Low: A small, surgical 20-line predicate addition that reuses an existing liveness contract, conservatively requires BOTH a live daemon AND a fresh beacon to suppress the guard (so a dead daemon, stale beacon, or away-off still fires exactly as before), and is covered by hermetic tests for all four away-mode-aware health cases.

## Testing

Completed 1 recorded test check.

- Outcome: ⚠️ 1 error across 1 run (18m50s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Rebase** - 1 warning</summary>

- ⚠️ `.agents/skills/bearings/SKILL.md` - branch carries 1 commit(s) that exist on your local main branch but were never pushed to origin/main; rebasing would bundle this unrelated work (11 file(s)) into the PR:
- 8934c17 fix: derive bearings from authoritative secondmate state (#555)

Push main to origin, or rebase your branch onto origin/main, before gating.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Test** - 1 error</summary>

- 🚨 tests failed with exit code 1
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `AGENTS.md:617` - The change&#39;s away-mode branch means the guard no longer blocks whenever there is no live identity-matched watcher lock with a fresh beacon: a live afk daemon plus a fresh beacon now keeps it silent. Two high-level summaries still state that lock+beacon condition as the sole block predicate: AGENTS.md:617 (&#39;blocks ... when tasks are in flight without a live identity-matched watcher lock and fresh beacon&#39;) and the parallel docs/architecture.md:56 (&#39;when work is in flight and no identity-matched watcher lock with a fresh beacon is live, direct Stop hooks block&#39;). Both already defer the exact predicate to docs/turnend-guard.md (which the change updated) and both preserve the core invariant (&#39;stays silent when supervision is healthy&#39;), so this is a judgment call rather than a clear-cut fix: the cleanest correction would be to NOT restate the now-two-pronged predicate in these summaries, but that either loses the load-bearing &#39;watcher lock and fresh beacon&#39; concreteness or expands the always-loaded AGENTS.md against repo policy and open issue #560. No edits made; flagged for your call on whether to soften the literal predicate in one or both summaries.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
