### PR TITLE
fix: make fm-brief compatible with Bash 3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,7 @@ jobs:
           /bin/bash --version | head -1
           command -v jq >/dev/null || { echo "::error::jq is required"; exit 1; }
           /bin/bash -n bin/fm-fleet-snapshot.sh
+          /bin/bash tests/fm-brief.test.sh
 
           snapshot_output=$(/bin/bash tests/fm-fleet-snapshot-view.test.sh)
           printf '%s\n' "$snapshot_output"

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -269,6 +269,7 @@ fi
 
 # Ship task: shape Setup / Rule 1 / Definition of done by the project's delivery mode.
 # yolo does not affect the brief (it governs firstmate's approval behaviour), so discard it.
+# Keep Definition-of-done text out of heredoc command substitutions because Bash 3.2 scans their body for quote state.
 read -r MODE _ <<EOF
 $("$FM_ROOT/bin/fm-project-mode.sh" "$REPO")
 EOF
@@ -277,50 +278,44 @@ case "$MODE" in
   direct-PR)
     SETUP2=""
     RULE1='1. Never push to the default branch (push only your `fm/'"$ID"'` branch). Never merge a PR.'
-    DOD=$(cat <<EOF
-# Definition of done
-This project ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
-The task is complete only when committed on your branch.
-When it is implemented and committed, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\` to the status file and stop.
-Do NOT run /no-mistakes. The captain reviews and merges the PR; firstmate relays it.
-EOF
-)
+    DOD=$(printf '%s\n' \
+      "# Definition of done" \
+      "This project ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline." \
+      "The task is complete only when committed on your branch." \
+      "When it is implemented and committed, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\` to the status file and stop." \
+      "Do NOT run /no-mistakes. The captain reviews and merges the PR; firstmate relays it.")
     ;;
   local-only)
     SETUP2=""
     RULE1="1. Never push to any remote and never open a PR. Work only on your \`fm/$ID\` branch; firstmate handles the merge into local \`main\`."
-    DOD=$(cat <<EOF
-# Definition of done
-This project ships **local-only**: no remote, no PR, no pipeline.
-The task is complete only when committed on your branch \`fm/$ID\`. Do NOT push, do NOT open a PR, do NOT merge.
-Keep your branch a clean fast-forward onto the current default branch - if \`main\` has advanced, rebase onto it so the eventual merge stays a fast-forward.
-When it is implemented and committed, append \`done: ready in branch fm/$ID\` to the status file and stop.
-Firstmate then reviews your branch diff, the captain approves, and firstmate merges it into local \`main\`.
-EOF
-)
+    DOD=$(printf '%s\n' \
+      "# Definition of done" \
+      "This project ships **local-only**: no remote, no PR, no pipeline." \
+      "The task is complete only when committed on your branch \`fm/$ID\`. Do NOT push, do NOT open a PR, do NOT merge." \
+      "Keep your branch a clean fast-forward onto the current default branch - if \`main\` has advanced, rebase onto it so the eventual merge stays a fast-forward." \
+      "When it is implemented and committed, append \`done: ready in branch fm/$ID\` to the status file and stop." \
+      "Firstmate then reviews your branch diff, the captain approves, and firstmate merges it into local \`main\`.")
     ;;
   *)  # no-mistakes (default)
     SETUP2="
 2. Run \`no-mistakes doctor\`; if it reports the repo is not initialized here, run \`no-mistakes init\`."
     RULE1='1. Never push to the default branch. Never merge a PR.'
-    DOD=$(cat <<EOF
-# Definition of done
-The task is complete only when committed on your branch.
-When you believe it is complete, append \`done: {summary}\` to the status file and stop.
-Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
-
-You drive no-mistakes by responding to its gates, not by implementing fixes.
-Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.
-Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.
-
-Two firstmate-specific rules layer on top of that guidance:
-- ask-user findings are not yours to answer: escalate to firstmate (rule 6) and stop.
-  When the decision comes back, feed it to the gate with \`no-mistakes axi respond\` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
-- Avoid \`--yes\`: the captain, not you, owns the ask-user decisions it would silently auto-resolve.
-
-After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished.
-EOF
-)
+    DOD=$(printf '%s\n' \
+      "# Definition of done" \
+      "The task is complete only when committed on your branch." \
+      "When you believe it is complete, append \`done: {summary}\` to the status file and stop." \
+      "Firstmate will then instruct you to run /no-mistakes to validate and ship a PR." \
+      "" \
+      "You drive no-mistakes by responding to its gates, not by implementing fixes." \
+      "Follow the no-mistakes guidance for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary." \
+      "Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix." \
+      "" \
+      "Two firstmate-specific rules layer on top of that guidance:" \
+      "- ask-user findings are not yours to answer: escalate to firstmate (rule 6) and stop." \
+      "  When the decision comes back, feed it to the gate with \`no-mistakes axi respond\` and let the pipeline apply it - do not route the question to \"the user\" or implement the fix yourself." \
+      "- Avoid \`--yes\`: the captain, not you, owns the ask-user decisions it would silently auto-resolve." \
+      "" \
+      "After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished.")
     ;;
 esac
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -307,7 +307,7 @@ case "$MODE" in
       "Firstmate will then instruct you to run /no-mistakes to validate and ship a PR." \
       "" \
       "You drive no-mistakes by responding to its gates, not by implementing fixes." \
-      "Follow the no-mistakes guidance for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary." \
+      "Follow no-mistakes' own guidance for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary." \
       "Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix." \
       "" \
       "Two firstmate-specific rules layer on top of that guidance:" \

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -2,13 +2,9 @@
 # Behavior tests for bin/fm-brief.sh.
 #
 # Regression coverage for the heredoc-in-command-substitution parse bug (issue
-# #166): each ship-mode branch builds its Definition-of-done text with
-# `VAR=$(cat <<EOF ... EOF)`. Bash's lexer tracks quote state through the
-# heredoc body while it scans for the matching `)` of the command
-# substitution, so a single unescaped apostrophe anywhere in that body breaks
-# parsing of the *entire rest of the script* - `bash -n` fails, not just the
-# generated brief. A plain `cat > file <<EOF ... EOF` (not wrapped in `$(...)`)
-# is unaffected, so the secondmate charter block does not need this guard.
+# #166): Bash's lexer tracks quote state through a heredoc body while it scans
+# for the matching `)` of the command substitution, so an apostrophe anywhere
+# in that body can break parsing of the entire rest of the script.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -16,12 +12,10 @@ set -u
 
 TMP_ROOT=$(fm_test_tmproot fm-brief)
 
-# The script itself must always parse. This is the direct regression test for
-# issue #166: a stray apostrophe in any of the three DOD heredoc bodies
-# (no-mistakes/direct-PR/local-only) breaks `bash -n` on the whole file.
+# The script itself must always parse under the system Bash 3.2.
 test_script_parses() {
-  bash -n "$ROOT/bin/fm-brief.sh" 2>&1 || fail "bin/fm-brief.sh fails bash -n (heredoc/quote regression)"
-  pass "fm-brief.sh: bash -n succeeds"
+  /bin/bash -n "$ROOT/bin/fm-brief.sh" 2>&1 || fail "bin/fm-brief.sh fails Bash 3.2 syntax check"
+  pass "fm-brief.sh: Bash 3.2 syntax check succeeds"
 }
 
 test_help_includes_entire_header() {
@@ -55,32 +49,67 @@ test_ship_modes_generate_clean_briefs() {
   for id_proj in "brief-nomistakes-a1:no-registry-proj" "brief-directpr-a2:direct-proj" "brief-localonly-a3:local-proj"; do
     id=${id_proj%%:*}
     proj=${id_proj##*:}
-    FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" "$proj" >/dev/null 2>&1; status=$?
+    FM_HOME="$home" /bin/bash "$ROOT/bin/fm-brief.sh" "$id" "$proj" >/dev/null 2>&1; status=$?
     expect_code 0 "$status" "fm-brief.sh $id $proj should exit 0"
     brief="$home/data/$id/brief.md"
     assert_present "$brief" "$id: brief was not scaffolded"
     assert_grep "# Definition of done" "$brief" "$id: brief missing Definition of done section"
     assert_grep "{TASK}" "$brief" "$id: brief missing the {TASK} placeholder"
     assert_no_grep "EOF" "$brief" "$id: brief leaked a heredoc EOF marker (unterminated heredoc)"
+    case "$proj" in
+      no-registry-proj)
+        assert_grep "Follow the no-mistakes guidance for the mechanics" "$brief" \
+          "$id: no-mistakes contract was not rendered literally"
+        ;;
+      direct-proj)
+        assert_grep "This project ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline." "$brief" \
+          "$id: direct-PR contract was not rendered literally"
+        ;;
+      local-proj)
+        assert_grep "This project ships **local-only**: no remote, no PR, no pipeline." "$brief" \
+          "$id: local-only contract was not rendered literally"
+        ;;
+    esac
   done
   pass "fm-brief.sh: no-mistakes/direct-PR/local-only briefs generate cleanly"
 }
 
-# Pin the specific line the bug lived on: the no-mistakes DOD's no-mistakes
-# reference must render as plain prose with no dangling apostrophe artifact.
-test_no_mistakes_dod_wording() {
+# Execute the real ship path under Bash 3.2 and assert that the full no-mistakes
+# contract, including its apostrophe, survives into the generated brief.
+test_no_mistakes_dod_contract() {
   local home id brief
   home="$TMP_ROOT/wording-home"
   mkdir -p "$home/data"
   id="brief-wording-b1"
-  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj >/dev/null 2>&1
+  FM_HOME="$home" /bin/bash "$ROOT/bin/fm-brief.sh" "$id" some-proj >/dev/null 2>&1
   brief="$home/data/$id/brief.md"
   assert_present "$brief" "brief was not scaffolded"
-  assert_grep "no-mistakes itself provides for the mechanics" "$brief" \
+  assert_grep "Follow the no-mistakes guidance for the mechanics" "$brief" \
     "no-mistakes DOD lost its guidance-reference sentence"
-  assert_no_grep "no-mistakes' own guidance" "$brief" \
-    "no-mistakes DOD regressed to the apostrophe form that breaks bash -n"
-  pass "fm-brief.sh: no-mistakes DOD wording avoids the apostrophe regression"
+  assert_grep 'When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.' "$brief" \
+    "no-mistakes DOD lost its ask-user response contract"
+  assert_grep 'After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.' "$brief" \
+    "no-mistakes DOD lost its CI-ready completion contract"
+  pass "fm-brief.sh: Bash 3.2 preserves the complete no-mistakes DOD contract"
+}
+
+# Scout generation uses a separate direct heredoc and must remain unaffected by
+# the ship-mode Definition-of-done construction.
+test_scout_generation_remains_unaffected() {
+  local home id brief
+  home="$TMP_ROOT/scout-home"
+  mkdir -p "$home/data"
+  id="brief-scout-e2"
+  FM_HOME="$home" /bin/bash "$ROOT/bin/fm-brief.sh" "$id" some-proj --scout >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_present "$brief" "scout brief was not scaffolded"
+  assert_grep "This is a SCOUT task: the deliverable is a written report, not a PR." "$brief" \
+    "scout brief lost its report-only contract"
+  assert_grep "Write your findings to \`$home/data/$id/report.md\`" "$brief" \
+    "scout brief lost its report path contract"
+  assert_no_grep "Follow the no-mistakes guidance for the mechanics" "$brief" \
+    "scout brief unexpectedly received the ship no-mistakes contract"
+  pass "fm-brief.sh: scout generation remains unaffected"
 }
 
 test_ship_project_memory_wording() {
@@ -269,7 +298,8 @@ test_pause_verb_override_renders_all_brief_scaffolds() {
 test_script_parses
 test_help_includes_entire_header
 test_ship_modes_generate_clean_briefs
-test_no_mistakes_dod_wording
+test_no_mistakes_dod_contract
+test_scout_generation_remains_unaffected
 test_ship_project_memory_wording
 test_herdr_lab_contract_is_explicit_and_complete
 test_herdr_lab_contract_quotes_foreign_firstmate_path

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -58,7 +58,7 @@ test_ship_modes_generate_clean_briefs() {
     assert_no_grep "EOF" "$brief" "$id: brief leaked a heredoc EOF marker (unterminated heredoc)"
     case "$proj" in
       no-registry-proj)
-        assert_grep "Follow the no-mistakes guidance for the mechanics" "$brief" \
+        assert_grep "Follow no-mistakes' own guidance for the mechanics" "$brief" \
           "$id: no-mistakes contract was not rendered literally"
         ;;
       direct-proj)
@@ -84,7 +84,7 @@ test_no_mistakes_dod_contract() {
   FM_HOME="$home" /bin/bash "$ROOT/bin/fm-brief.sh" "$id" some-proj >/dev/null 2>&1
   brief="$home/data/$id/brief.md"
   assert_present "$brief" "brief was not scaffolded"
-  assert_grep "Follow the no-mistakes guidance for the mechanics" "$brief" \
+  assert_grep "Follow no-mistakes' own guidance for the mechanics" "$brief" \
     "no-mistakes DOD lost its guidance-reference sentence"
   assert_grep 'When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.' "$brief" \
     "no-mistakes DOD lost its ask-user response contract"
@@ -107,7 +107,7 @@ test_scout_generation_remains_unaffected() {
     "scout brief lost its report-only contract"
   assert_grep "Write your findings to \`$home/data/$id/report.md\`" "$brief" \
     "scout brief lost its report path contract"
-  assert_no_grep "Follow the no-mistakes guidance for the mechanics" "$brief" \
+  assert_no_grep "Follow no-mistakes' own guidance for the mechanics" "$brief" \
     "scout brief unexpectedly received the ship no-mistakes contract"
   pass "fm-brief.sh: scout generation remains unaffected"
 }


### PR DESCRIPTION
## Intent

The transcript does not include the developer's underlying change request or stated implementation goal; it only provides repository operating instructions and later assistant status updates.

## What Changed

- Rebuild ship-mode definition-of-done text with `printf` so apostrophes no longer break `fm-brief` parsing under Bash 3.2.
- Expand regression coverage across all delivery modes and verify scout brief generation remains unaffected.
- Run the `fm-brief` behavior suite in the stock macOS Bash CI job.

## Risk Assessment

✅ Low: The change is narrowly scoped, preserves generated brief behavior, removes the Bash 3.2-sensitive construction, and adds targeted stock-macOS-Bash regression coverage without introducing material risks.

## Testing

Completed 1 recorded test check.

- Outcome: ⚠️ 1 error across 1 run (12m31s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Test** - 1 error</summary>

- 🚨 tests failed with exit code 1
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
