### PR TITLE
Windows (Git Bash/MSYS) support for spawn, supervision, adapters, and the test suite

### DIFF
--- a/.opencode/plugins/fm-primary-turnend-guard.js
+++ b/.opencode/plugins/fm-primary-turnend-guard.js
@@ -43,7 +43,14 @@ function resolvePath(anchor) {
 
 function runGuard(root) {
   if (!root) return Promise.resolve({ code: 0, stderr: "" });
-  return runProcess(`${root}/bin/fm-turnend-guard.sh`, [], '{"stop_hook_active":false}');
+  const script = `${root}/bin/fm-turnend-guard.sh`;
+  // Windows node cannot exec a shebang script directly; spawn would emit
+  // 'error' (swallowed as a pass) instead of running the guard. Route it
+  // through bash (Git Bash on PATH) there.
+  if (process.platform === "win32") {
+    return runProcess("bash", [script], '{"stop_hook_active":false}');
+  }
+  return runProcess(script, [], '{"stop_hook_active":false}');
 }
 
 async function letWatchArmRun(sessionID, client) {

--- a/.pi/extensions/fm-primary-pi-watch.ts
+++ b/.pi/extensions/fm-primary-pi-watch.ts
@@ -23,6 +23,7 @@ const state = process.env.FM_STATE_OVERRIDE || `${fmHome}/state`;
 const config = process.env.FM_CONFIG_OVERRIDE || `${fmHome}/config`;
 const armScript = `${fmRoot}/bin/fm-watch-arm.sh`;
 const marker = `${state}/.pi-watch-extension-loaded`;
+const armMsysPidFile = `${state}/.pi-watch-arm-msys-pid`;
 const extensionVersion = `sha256:${createHash("sha256").update(readFileSync(extensionFile)).digest("hex")}`;
 
 let child: any = null;
@@ -87,7 +88,28 @@ function failureLine(stdout: string, stderr: string, code: number | null): strin
 
 export default function (pi: ExtensionAPI) {
   function stopArm(): void {
-    if (child) child.kill("SIGTERM");
+    if (child) {
+      // Native node's child.kill() is TerminateProcess on Windows - the bash
+      // arm child would die without running its TERM trap (no cleanup, no lock
+      // release), and node's Windows pid cannot be mapped back to the child
+      // after MSYS exec swaps the underlying Windows process. The launch
+      // command records the child's own MSYS pid ($$ survives exec) in
+      // armMsysPidFile; deliver a real MSYS TERM to that pid via Git Bash
+      // kill. spawnSync because this also runs inside the process-exit
+      // fallback, which must stay synchronous.
+      let signalled = false;
+      if (process.platform === "win32") {
+        try {
+          const msysPid = readFileSync(armMsysPidFile, "utf8").trim();
+          if (/^[0-9]+$/.test(msysPid)) {
+            signalled = spawnSync("bash", ["-c", `kill -TERM ${msysPid}`]).status === 0;
+          }
+        } catch {
+          // fall through to child.kill below
+        }
+      }
+      if (!signalled) child.kill("SIGTERM");
+    }
     child = null;
   }
 
@@ -114,8 +136,11 @@ export default function (pi: ExtensionAPI) {
       FM_ROOT_OVERRIDE: fmRoot,
       FM_CONFIG_OVERRIDE: config,
       FM_WATCH_ARM_SCRIPT: armScript,
+      // Read back by stopArm on Windows; the bash child records its own MSYS
+      // pid there ($$ survives MSYS exec, node's Windows pid does not).
+      ...(process.platform === "win32" ? { FM_ARM_MSYS_PID_FILE: armMsysPidFile } : {}),
     };
-    child = spawn("bash", ["-lc", "config_dir=\"${FM_CONFIG_OVERRIDE:-$FM_HOME/config}\"; [ -f \"$config_dir/x-mode.env\" ] && . \"$config_dir/x-mode.env\"; exec \"$FM_WATCH_ARM_SCRIPT\" --restart"], {
+    child = spawn("bash", ["-lc", "[ -n \"${FM_ARM_MSYS_PID_FILE:-}\" ] && printf '%s\\n' \"$$\" > \"$FM_ARM_MSYS_PID_FILE\"; config_dir=\"${FM_CONFIG_OVERRIDE:-$FM_HOME/config}\"; [ -f \"$config_dir/x-mode.env\" ] && . \"$config_dir/x-mode.env\"; exec \"$FM_WATCH_ARM_SCRIPT\" --restart"], {
       cwd: fmRoot,
       env,
       stdio: ["ignore", "pipe", "pipe"],

--- a/.pi/extensions/fm-primary-turnend-guard.ts
+++ b/.pi/extensions/fm-primary-turnend-guard.ts
@@ -55,11 +55,19 @@ function markLoaded(): void {
   writeFileSync(marker, `${extensionVersion}\n${process.pid}\n`);
 }
 
+// Windows node cannot exec a shebang script directly; spawn would emit
+// 'error' (swallowed as a pass) instead of running the guard. Route the
+// script through bash (Git Bash on PATH) there.
+function spawnScript(script: string, args: string[], stdio: ("pipe" | "ignore")[]) {
+  if (process.platform === "win32") {
+    return spawn("bash", [script, ...args], { stdio });
+  }
+  return spawn(script, args, { stdio });
+}
+
 function runGuard(): Promise<{ code: number; stderr: string }> {
   return new Promise((resolveResult) => {
-    const child = spawn(`${root}/bin/fm-turnend-guard.sh`, {
-      stdio: ["pipe", "ignore", "pipe"],
-    });
+    const child = spawnScript(`${root}/bin/fm-turnend-guard.sh`, [], ["pipe", "ignore", "pipe"]);
     let stderr = "";
     child.stderr.on("data", (chunk) => {
       stderr += chunk.toString();
@@ -79,9 +87,7 @@ function runGuard(): Promise<{ code: number; stderr: string }> {
 // script owns its own decision and is inert outside the real primary checkout.
 function runChecker(script: string, command: string): Promise<{ code: number; stderr: string }> {
   return new Promise((resolveResult) => {
-    const child = spawn(`${root}/bin/${script}`, ["--command", command], {
-      stdio: ["ignore", "ignore", "pipe"],
-    });
+    const child = spawnScript(`${root}/bin/${script}`, ["--command", command], ["ignore", "ignore", "pipe"]);
     let stderr = "";
     child.stderr.on("data", (chunk) => {
       stderr += chunk.toString();

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -569,18 +569,44 @@ fm_backend_herdr_target_ready() {  # <target>
 # any error. Mirrors tmux's pane_current_path poll used for worktree-path
 # discovery after `treehouse get`.
 #
-# Verified pitfall: `pane get`'s `.result.pane.cwd` is the pane's cwd AT
+# Verified pitfall (Unix): `pane get`'s `.result.pane.cwd` is the pane's cwd AT
 # CREATION TIME - the top-level shell's cwd - and does NOT update when that
-# shell `cd`s or enters a subshell (as `treehouse get` does). Reading it here
+# shell `cd`s or enters a subshell (as `treehouse get` does). Reading it there
 # would make fm-spawn.sh's worktree-discovery poll never see the pane "leave"
 # the project directory, since `cwd` stays frozen at the original path forever.
 # `.result.pane.foreground_cwd` tracks the ACTUALLY RUNNING foreground
 # process's cwd instead, which is what changes when `treehouse get` enters its
 # worktree subshell - confirmed live against a real treehouse acquisition.
+#
+# Windows (Git Bash/MSYS): herdr does NOT populate `foreground_cwd` at all - the
+# field is absent from `pane get`, so foreground_cwd-only returns empty forever
+# and the poll times out. But on Windows `.cwd` DOES update live, via the
+# PowerShell shell integration's OSC 7 cwd report, so it tracks the treehouse
+# subshell's cwd there (the exact opposite of Unix). The `// .cwd` fallback below
+# recovers the worktree path on Windows while leaving Unix untouched, since
+# foreground_cwd is non-empty on Unix and short-circuits the fallback. This
+# depends on treehouse's subshell being PowerShell (which emits OSC 7), not the
+# default cmd.exe (which does not); fm-spawn.sh sets COMSPEC to arrange that.
+#
+# Windows also reports a Windows-format path (`C:\...`), while fm-spawn.sh's
+# PROJ_ABS is an MSYS path (`/c/...`); left as-is, the worktree-discovery
+# comparison `$p != $PROJ_ABS` is ALWAYS true (different strings for the same
+# dir), so the poll breaks on its first read with the project dir itself as a
+# bogus worktree. Normalize the reported path to the MSYS form with `cygpath -u`
+# on Windows so the comparison, and the downstream cd/git on the result, all see
+# one consistent format. cygpath leaves an already-POSIX path unchanged, and the
+# branch is skipped entirely off Windows, so Unix is untouched.
+# Verified 2026-07-11; see docs/herdr-backend.md.
 fm_backend_herdr_current_path() {  # <target>
   fm_backend_herdr_target_ready "$1" || return 0
-  fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" pane get "$FM_BACKEND_HERDR_PANE" 2>/dev/null \
-    | jq -r '.result.pane.foreground_cwd // empty' 2>/dev/null
+  local p
+  p=$(fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" pane get "$FM_BACKEND_HERDR_PANE" 2>/dev/null \
+    | jq -r '.result.pane.foreground_cwd // .result.pane.cwd // empty' 2>/dev/null)
+  [ -n "$p" ] || return 0
+  case "$(uname -s)" in
+    MINGW*|MSYS*) command -v cygpath >/dev/null 2>&1 && p=$(cygpath -u "$p" 2>/dev/null || printf '%s' "$p") ;;
+  esac
+  printf '%s\n' "$p"
 }
 
 # fm_backend_herdr_send_text_line: send one line of TEXT then submit,

--- a/bin/fm-arm-command-policy.mjs
+++ b/bin/fm-arm-command-policy.mjs
@@ -601,10 +601,27 @@ const PROTECTED_SCRIPTS = [
   { relative: "bin/fm-watch.sh", kind: "watch" },
 ];
 
+// Commands and roots arrive in POSIX form (the callers are bash, Git Bash
+// included), but path.normalize flips separators to backslashes on Windows
+// node, which would silently un-match every protected pattern below. Compare
+// in forward-slash form everywhere. On Windows the same absolute path also
+// arrives in two spellings: MSYS converts --root/--home arguments to C:/...
+// while paths inside the command string keep the Git Bash /c/... form - fold
+// both into an uppercase-drive C:/... shape so they compare equal.
+function posixNormalize(value) {
+  let v = path.normalize(value).replaceAll("\\", "/");
+  if (process.platform === "win32") {
+    const msysDrive = /^\/([A-Za-z])(\/|$)/.exec(v);
+    if (msysDrive) v = `${msysDrive[1].toUpperCase()}:/${v.slice(msysDrive[2] ? 3 : 2)}`;
+    if (/^[a-z]:\//.test(v)) v = v[0].toUpperCase() + v.slice(1);
+  }
+  return v;
+}
+
 function protectedIdentity(value, root) {
-  const normalized = path.normalize(value);
+  const normalized = posixNormalize(value);
   for (const { relative, kind } of PROTECTED_SCRIPTS) {
-    if (normalized === relative || normalized === path.join(root, relative) || normalized.endsWith(`/${relative}`)) return kind;
+    if (normalized === relative || normalized === posixNormalize(path.join(root, relative)) || normalized.endsWith(`/${relative}`)) return kind;
   }
   return "";
 }
@@ -857,7 +874,7 @@ function analyzeProgram(command, context, depth = 0) {
 function xModePathAllowed(value, home) {
   if (value === "config/x-mode.env" || value === "./config/x-mode.env") return true;
   if (!path.isAbsolute(value)) return false;
-  return path.normalize(value) === path.join(path.normalize(home), "config/x-mode.env");
+  return posixNormalize(value) === posixNormalize(path.join(home, "config/x-mode.env"));
 }
 
 function ordinaryWordsOnly(tokens) {
@@ -900,7 +917,7 @@ function blessedProgram(analysis, context) {
 }
 
 function decision(command, root, home) {
-  const context = { root: path.normalize(root), home: path.normalize(home), protectedVariables: new Set(), watcherPatterns: new Set(), watcherPids: new Set() };
+  const context = { root: posixNormalize(root), home: posixNormalize(home), protectedVariables: new Set(), watcherPatterns: new Set(), watcherPids: new Set() };
   const analysis = analyzeProgram(command, context);
   if (analysis.broadKill) return deny("broad-watcher-kill");
   if (analysis.error && analysis.protectedFound) return deny("unclassifiable-protected-command");

--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -17,6 +17,46 @@ mkdir -p "$STATE"
 # Known harness command names; extend when a new adapter is verified.
 HARNESS_RE='claude|codex|opencode|grok|^pi$'
 
+# Windows (Git Bash/MSYS): the native parent chain is invisible to MSYS ps
+# (the shell's PPID reads as 1), so walk it via PowerShell CIM instead.
+# Lock-file pids are then Windows pids; holder_alive falls back the same way.
+harness_pid_win() {
+  local pid=$$ ppid top wpid out
+  command -v powershell.exe >/dev/null 2>&1 || return 1
+  # Climb the MSYS side first: nested shells hit dead fork intermediates in
+  # the native chain, but the TOP MSYS ancestor's native parent is the live
+  # harness process.
+  top=$pid
+  while :; do
+    ppid=$(cat "/proc/$pid/ppid" 2>/dev/null) || break
+    [ -n "$ppid" ] && [ "$ppid" -gt 1 ] || break
+    pid=$ppid; top=$pid
+  done
+  wpid=$(cat "/proc/$top/winpid" 2>/dev/null) || return 1
+  out=$(FM_WPID="$wpid" FM_HARNESS_RE="$HARNESS_RE" powershell.exe -NoProfile -Command '
+    $id = [int]$env:FM_WPID
+    for ($i = 0; $i -lt 12 -and $id -gt 4; $i++) {
+      $p = Get-CimInstance Win32_Process -Filter "ProcessId=$id" -ErrorAction SilentlyContinue
+      if (-not $p) { exit 1 }
+      $n = $p.Name -replace "\.exe$",""
+      if ($n -match $env:FM_HARNESS_RE) { Write-Output $p.ProcessId; exit 0 }
+      if ($n -match "^(node|python[0-9.]*)$" -and $p.CommandLine -match $env:FM_HARNESS_RE) { Write-Output $p.ProcessId; exit 0 }
+      $id = $p.ParentProcessId
+    }
+    exit 1' 2>/dev/null | tr -d '\r ')
+  [ -n "$out" ] || return 1
+  echo "$out"
+}
+
+holder_alive_win() {  # true if $1 is a live WINDOWS pid that looks like a harness
+  local out
+  command -v powershell.exe >/dev/null 2>&1 || return 1
+  out=$(FM_WPID="$1" powershell.exe -NoProfile -Command '
+    $p = Get-CimInstance Win32_Process -Filter "ProcessId=$([int]$env:FM_WPID)" -ErrorAction SilentlyContinue
+    if ($p) { Write-Output (($p.Name -replace "\.exe$","") + " " + $p.CommandLine) }' 2>/dev/null | tr -d '\r')
+  [ -n "$out" ] && printf '%s' "$out" | grep -qE "$HARNESS_RE"
+}
+
 harness_pid() {
   local pid=$$ comm args
   for _ in 1 2 3 4 5 6 7 8; do
@@ -37,9 +77,10 @@ harness_pid() {
 
 holder_alive() {  # true if $1 is a live process that looks like a harness
   local pid=$1 comm
-  kill -0 "$pid" 2>/dev/null || return 1
-  comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
-  printf '%s' "$(basename "$comm") $(ps -o args= -p "$pid" 2>/dev/null)" | grep -qE "$HARNESS_RE"
+  if kill -0 "$pid" 2>/dev/null && comm=$(ps -o comm= -p "$pid" 2>/dev/null); then
+    printf '%s' "$(basename "$comm") $(ps -o args= -p "$pid" 2>/dev/null)" | grep -qE "$HARNESS_RE" && return 0
+  fi
+  holder_alive_win "$pid"
 }
 
 if [ "${1:-}" = "status" ]; then
@@ -49,7 +90,7 @@ if [ "${1:-}" = "status" ]; then
   exit 0
 fi
 
-me=$(harness_pid) || { echo "error: cannot locate harness process in ancestry" >&2; exit 1; }
+me=$(harness_pid) || me=$(harness_pid_win) || { echo "error: cannot locate harness process in ancestry" >&2; exit 1; }
 if [ -f "$LOCK" ]; then
   old=$(cat "$LOCK")
   if [ "$old" != "$me" ] && holder_alive "$old"; then

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -835,7 +835,24 @@ spawn_send_key() {  # <target> <key>
   esac
 }
 if [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
-  spawn_send_text_line "$WT_TARGET" 'treehouse get'
+  # treehouse opens a subshell in the worktree; we detect entry by the pane's cwd
+  # moving off the project dir. On Windows + herdr that detection needs help:
+  # treehouse's default subshell is cmd.exe, whose cwd herdr cannot track (no
+  # foreground_cwd on Windows, and cmd.exe emits no OSC 7 to update the pane cwd),
+  # so the poll below never sees the move and times out. Point COMSPEC at
+  # PowerShell so treehouse opens a PowerShell subshell instead, whose cd into the
+  # worktree updates the pane cwd via OSC 7 (see fm_backend_herdr_current_path).
+  # The prefix is PowerShell syntax, valid because the herdr spawn pane runs
+  # PowerShell on Windows; scoped to Windows + herdr so no other path is affected.
+  # Verified 2026-07-11; see docs/herdr-backend.md.
+  TH_GET='treehouse get'
+  case "$(uname -s)" in
+    MINGW*|MSYS*)
+      # shellcheck disable=SC2016  # single quotes are deliberate: $env:COMSPEC expands in the PowerShell pane, not here
+      [ "$BACKEND" = herdr ] && TH_GET='$env:COMSPEC="C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe"; treehouse get'
+      ;;
+  esac
+  spawn_send_text_line "$WT_TARGET" "$TH_GET"
 
   # Wait for the treehouse subshell: the pane's cwd moves from the project to the worktree.
   # Target the stable window id, not the name: if the name is ever lost (e.g. an

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1069,10 +1069,42 @@ fi
 # Export GOTMPDIR into the crewmate's pane shell so the agent and every child
 # process (go build, go test, ...) inherit it. Sent before the launch command so
 # the env is set when the agent starts; the brief sleep lets the export land.
-spawn_send_text_line "$T" "export GOTMPDIR=$TASK_TMP/gotmp"
-sleep 0.3
-spawn_send_literal "$T" "$LAUNCH"
-sleep 0.3
-spawn_send_key "$T" Enter
+#
+# Windows + herdr: the pane (and treehouse's PowerShell subshell) run PowerShell,
+# but GOTMPDIR export and the launch command are POSIX/bash (`export`, `VAR=val
+# cmd`, `"$(cat /c/...)"`), which PowerShell cannot run. Write the launch to a
+# script and invoke it through Git Bash via PowerShell's call operator:
+# `& '<bash.exe>' -l '<script>'`. A login shell (-l) gives the full MSYS PATH
+# (cat, claude, ...); the script cds into the worktree and exports GOTMPDIR
+# itself. Using a script file avoids any nested PowerShell/bash quoting - the
+# only PowerShell-quoted tokens are the bash.exe path and the script path, both
+# free of single quotes. The script lives under TASK_TMP, which teardown removes.
+launch_wrapped=0
+case "$(uname -s)" in
+  MINGW*|MSYS*)
+    if [ "$BACKEND" = herdr ]; then
+      LAUNCH_SH="$TASK_TMP/launch.sh"
+      {
+        printf 'cd %s\n' "$(shell_quote "$WT")"
+        printf 'export GOTMPDIR=%s\n' "$(shell_quote "$TASK_TMP/gotmp")"
+        printf '%s\n' "$LAUNCH"
+      } > "$LAUNCH_SH"
+      bash_win=$(cygpath -w "$(command -v bash)" 2>/dev/null || printf 'bash')
+      ps_bash=${bash_win//\'/\'\'}
+      ps_launch_sh=${LAUNCH_SH//\'/\'\'}
+      spawn_send_literal "$T" "& '$ps_bash' -l '$ps_launch_sh'"
+      sleep 0.3
+      spawn_send_key "$T" Enter
+      launch_wrapped=1
+    fi
+    ;;
+esac
+if [ "$launch_wrapped" = 0 ]; then
+  spawn_send_text_line "$T" "export GOTMPDIR=$TASK_TMP/gotmp"
+  sleep 0.3
+  spawn_send_literal "$T" "$LAUNCH"
+  sleep 0.3
+  spawn_send_key "$T" Enter
+fi
 
 echo "spawned $ID harness=$HARNESS kind=$KIND mode=$MODE yolo=$YOLO window=$META_WINDOW worktree=$WT"

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -11,6 +11,19 @@ FM_WAKE_QUEUE_LOCK="${FM_WAKE_QUEUE_LOCK:-$STATE/.wake-queue.lock}"
 FM_LOCK_STALE_AFTER="${FM_LOCK_STALE_AFTER:-2}"
 mkdir -p "$STATE"
 
+# Git Bash/MSYS: ln -s COPIES by default, which breaks the symlink lock
+# protocol below (the copy fails readlink verification but keeps the lock
+# path occupied, deadlocking every contender). Force emulated symlinks for
+# the child ln/readlink calls; sys-file mode needs no Windows privileges.
+case "$(uname -s)" in
+  MINGW*|MSYS*)
+    case "${MSYS:-}" in
+      *winsymlinks*) ;;
+      '') export MSYS="winsymlinks:sys" ;;
+      *) export MSYS="$MSYS winsymlinks:sys" ;;
+    esac ;;
+esac
+
 fm_current_pid() {
   printf '%s\n' "${BASHPID:-$$}"
 }

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -41,10 +41,23 @@ fm_pid_identity() {
   case "$pid" in
     ''|*[!0-9]*) return 1 ;;
   esac
-  # Pin LC_ALL=C so lstart's date format is locale-invariant: the identity is
-  # written under one locale but re-read under the machine's ambient locale, which
-  # would otherwise mismatch on a non-C locale (e.g. ko_KR) and reject a live watcher.
-  out=$(LC_ALL=C ps -p "$pid" -o lstart= -o command= 2>/dev/null) || return 1
+  case "$(uname -s)" in
+    MINGW*|MSYS*)
+      # MSYS ps (BusyBox-style) rejects -o, so the Unix `lstart+command` query
+      # returns nothing and the identity would be empty - which makes the watcher
+      # lock unverifiable and the turn-end guard block forever. Parse the default
+      # `ps -p` columns instead: WINPID ($4) + STIME ($7) + COMMAND ($8..) is a
+      # stable per-instance signature that changes on pid reuse, the same
+      # guarantee lstart+command gives on Unix.
+      out=$(ps -p "$pid" 2>/dev/null | awk 'NR==2{cmd=""; for(i=8;i<=NF;i++) cmd=cmd (i>8?" ":"") $i; print $4, $7, cmd}')
+      ;;
+    *)
+      # Pin LC_ALL=C so lstart's date format is locale-invariant: the identity is
+      # written under one locale but re-read under the machine's ambient locale, which
+      # would otherwise mismatch on a non-C locale (e.g. ko_KR) and reject a live watcher.
+      out=$(LC_ALL=C ps -p "$pid" -o lstart= -o command= 2>/dev/null) || return 1
+      ;;
+  esac
   [ -n "$out" ] || return 1
   printf '%s\n' "$out" | sed 's/^[[:space:]]*//'
 }

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -908,6 +908,24 @@ The worktree-discovery poll compares `$p != $PROJ_ABS`; two different strings fo
 `fm-spawn.sh` prefixes `treehouse get` with a PowerShell `COMSPEC` set, scoped to `uname -s` MINGW/MSYS and `BACKEND=herdr`, so treehouse's subshell is herdr-trackable.
 Unit coverage: `tests/fm-backend-herdr.test.sh` `test_current_path_falls_back_to_cwd_on_windows` (foreground_cwd absent -> `.cwd`) alongside the existing `test_current_path_reads_cwd` (foreground_cwd present still wins).
 
+## Verified (2026-07-11, Windows): agent launch runs through Git Bash, not PowerShell
+
+Once worktree discovery was fixed (above), the spawn reached the launch step and failed differently: the herdr pane (and treehouse's PowerShell subshell) run **PowerShell**, but `fm-spawn.sh`'s launch is POSIX/bash - `export GOTMPDIR=...`, the `CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude ...` env-prefix form, and `"$(cat '/c/.../brief.md')"`.
+PowerShell rejected all of it (`CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false : n'est pas reconnu`; `Get-Content ...\c\Users\...` from the `/c/...` path), so the agent never started.
+Crewmate launch had therefore never worked end to end on this Windows home.
+
+**Fix.**
+On MINGW/MSYS + herdr, `fm-spawn.sh` writes the launch (a `cd` into the worktree, the `GOTMPDIR` export, then the normal `$LAUNCH`) to `TASK_TMP/launch.sh` and runs it through Git Bash via PowerShell's call operator: `& '<bash.exe>' -l '<launch.sh>'`.
+`-l` (login shell) is required so the agent inherits the full MSYS PATH (`cat`, `claude`, ...); `bash` is not on the pane's PowerShell PATH, so the absolute `cygpath -w` path to `bash.exe` is used.
+A script file is used rather than an inline `bash -lc '...'` specifically to avoid nested PowerShell/bash quoting: the launch contains single-quoted paths (`"$(cat '/c/.../brief.md')"`), and PowerShell single-quote doubling of that inline was verified to corrupt the command (`unexpected EOF while looking for matching ')'`); the only PowerShell-quoted tokens with the script approach are the bash and script paths, neither of which contains a quote.
+`TASK_TMP` is removed by teardown, so the script needs no separate cleanup.
+
+Verified end to end: `& 'C:\Program Files\Git\usr\bin\bash.exe' -l '/tmp/fm-<id>/launch.sh'` from the PowerShell pane launched Claude Code (`[Fable 5] | scrapmax`, bypass-permissions on) in the worktree, with `cat`/`claude` resolved and `GOTMPDIR` set.
+
+**Follow-up rough edges (Windows, not yet fixed - operational workarounds only):**
+- **First launch in a fresh pool worktree shows Claude's folder-trust dialog, which consumes the initial brief prompt.** Accepting the dialog leaves an empty composer instead of a running brief; the brief must be re-sent. Subsequent spawns in the same (now-trusted) pool worktree do not show it. Candidate fix: pre-trust the treehouse pool root, or have supervision re-send the brief when the post-dialog composer is empty.
+- **`fm-send.sh` stages text into the herdr pane composer but the submit Enter does not land**, so a steer sits unsent until a manual `herdr pane send-keys <pane> enter`. Likely the same composer-submit plumbing the tmux path handles via cursor-row retry; the herdr Windows path needs the equivalent.
+
 ## Known gaps and follow-up notes
 
 - **RESOLVED: worktree-discovery isolation guard's symlinked-project-prefix false refusal.** Originally discovered while building the runtime-backend-auto-detection real smoke test (`tests/fm-backend-autodetect-smoke.test.sh`), which needed a scratch project.

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -868,6 +868,46 @@ On entry the launcher drops the prior session's artifacts when the daemon is not
 This never drops a genuinely-pending escalation: the durable record is `state/.wake-queue` plus each crew's `state/<id>.status`, and any still-true condition is re-escalated by the daemon's heartbeat catch-all scan.
 Covered by the unit cases in `tests/fm-afk-launch.test.sh` (clear-on-fresh-entry vs refresh, and the stop ordering asserting the daemon saw `state/.afk` present at SIGTERM).
 
+## Verified (2026-07-11, Windows): worktree-discovery needs a PowerShell subshell + a `.cwd` fallback
+
+On Windows (Git Bash/MSYS, herdr client 0.7.1), every crewmate spawn failed with `error: treehouse get did not enter a worktree within 60s`.
+Two Windows-specific facts, both verified live against a real treehouse acquisition, combine to break the worktree-discovery poll, and both fixes are needed together.
+
+**Fact 1: herdr does not populate `foreground_cwd` on Windows.**
+`herdr pane get <pane>` returns no `foreground_cwd` field at all (not stale - absent), so `fm_backend_herdr_current_path`'s `foreground_cwd`-only read returned empty forever and the poll timed out.
+Exact evidence, a pane sitting inside a treehouse subshell:
+
+```
+$ herdr pane get w1:pH | jq '{cwd, foreground_cwd, keys: keys}'
+cwd: C:\Users\maxim\dev\projects\firstmate\projects\scrapmax
+foreground_cwd: None
+keys: ['agent_status','cwd','focused','pane_id','revision','tab_id','terminal_id','workspace_id']
+```
+
+**Fact 2: on Windows, `.cwd` DOES update live (the opposite of Unix), but only for a PowerShell subshell.**
+Unlike Unix (where `.cwd` is frozen at pane creation - see "Verified CLI facts"), on Windows `.cwd` tracks the live cwd via PowerShell's OSC 7 report.
+But `treehouse get`'s default subshell is `cmd.exe` (via `COMSPEC`), which emits no OSC 7, so `.cwd` stays frozen under it.
+Pointing `COMSPEC` at PowerShell makes treehouse open a PowerShell subshell whose `cd` into the worktree updates `.cwd`.
+Verified end to end in a throwaway pane:
+
+```
+$ herdr pane run <pane> 'Set-Location <project>'                 # PowerShell, herdr-tracked
+$ herdr pane get <pane> | jq -r .result.pane.cwd                  # -> <project>   (.cwd IS live on Windows)
+$ herdr pane run <pane> '$env:COMSPEC="...powershell.exe"; treehouse get'
+$ herdr pane get <pane> | jq -r .result.pane.cwd                  # -> C:\Users\maxim\.treehouse\...\scrapmax  (subshell tracked)
+# pane buffer shows a "Windows PowerShell" banner + `PS ...worktree>` prompt, NOT the cmd.exe banner; `exit` still returns the worktree.
+```
+
+**Fact 3: herdr reports a Windows-format path, but `PROJ_ABS` is an MSYS path.**
+`.cwd` (and `foreground_cwd` where present) come back as `C:\Users\maxim\...`, while `fm-spawn.sh`'s `PROJ_ABS` is the MSYS `cd && pwd` form `/c/Users/maxim/...`.
+The worktree-discovery poll compares `$p != $PROJ_ABS`; two different strings for the identical directory make that ALWAYS true, so with Facts 1-2 fixed the poll broke on its FIRST read - before treehouse had entered - handing `validate_spawn_worktree` the project dir itself, which it then correctly refused as "not isolated" (`resolved '...\projects\scrapmax'` == primary).
+`cygpath -u 'C:\Users\maxim\.treehouse\...\scrapmax'` -> `/c/Users/maxim/.treehouse/.../scrapmax`; `cygpath -u '/tmp/x'` -> `/tmp/x` (POSIX passthrough, so the fix is inert off Windows and in the POSIX-path unit tests).
+
+**Fix.**
+`fm_backend_herdr_current_path` now reads `.result.pane.foreground_cwd // .result.pane.cwd // empty`, then on Windows only normalizes the result with `cygpath -u`: Unix keeps using `foreground_cwd` (non-empty, short-circuits the fallback; the cygpath branch is skipped entirely), Windows falls through to the live `.cwd` and reports it in MSYS form so the comparison and the downstream `cd`/`git` on the result all agree.
+`fm-spawn.sh` prefixes `treehouse get` with a PowerShell `COMSPEC` set, scoped to `uname -s` MINGW/MSYS and `BACKEND=herdr`, so treehouse's subshell is herdr-trackable.
+Unit coverage: `tests/fm-backend-herdr.test.sh` `test_current_path_falls_back_to_cwd_on_windows` (foreground_cwd absent -> `.cwd`) alongside the existing `test_current_path_reads_cwd` (foreground_cwd present still wins).
+
 ## Known gaps and follow-up notes
 
 - **RESOLVED: worktree-discovery isolation guard's symlinked-project-prefix false refusal.** Originally discovered while building the runtime-backend-auto-detection real smoke test (`tests/fm-backend-autodetect-smoke.test.sh`), which needed a scratch project.

--- a/tests/fm-arm-pretool-check.test.sh
+++ b/tests/fm-arm-pretool-check.test.sh
@@ -377,7 +377,7 @@ test_failopen_missing_jq() {
   local tool
   for tool in bash grep sed tr; do
     real=$(command -v "$tool")
-    ln -sf "$real" "$fakebin/$tool"
+    fm_fakebin_tool "$fakebin" "$tool" "$real"
   done
   PATH="$fakebin" bash -c "printf '%s' '{\"tool_input\":{\"command\":\"bin/fm-watch-arm.sh &\"}}' | '$CHECK'" >/dev/null 2>&1
   rc=$?
@@ -392,7 +392,7 @@ test_failopen_missing_node() {
   mkdir -p "$fakebin"
   for tool in bash dirname; do
     real=$(command -v "$tool")
-    ln -sf "$real" "$fakebin/$tool"
+    fm_fakebin_tool "$fakebin" "$tool" "$real"
   done
   PATH="$fakebin" "$CHECK" --command 'bin/fm-watch-arm.sh &' >/dev/null 2>&1
   rc=$?

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -767,6 +767,21 @@ test_current_path_reads_cwd() {
   pass "fm_backend_herdr_current_path: reads pane foreground_cwd (the live running process), not the frozen creation-time cwd"
 }
 
+test_current_path_falls_back_to_cwd_on_windows() {
+  local dir log resp fb out
+  dir="$TMP_ROOT/cwd-win"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  # Windows (Git Bash/MSYS): herdr does NOT populate foreground_cwd - the field is
+  # absent from pane get. There, .cwd DOES track the live cwd via PowerShell's
+  # OSC 7 report, so current_path must fall back to .cwd to recover the treehouse
+  # worktree path. Verified 2026-07-11; see docs/herdr-backend.md.
+  printf '{"result":{"pane":{"cwd":"/tmp/win-worktree"}}}\n' > "$resp/1.out"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_current_path default:w1:p2' "$ROOT" )
+  [ "$out" = "/tmp/win-worktree" ] || fail "current_path should fall back to .cwd when foreground_cwd is absent (Windows), got '$out'"
+  pass "fm_backend_herdr_current_path: falls back to .cwd when foreground_cwd is absent (Windows)"
+}
+
 # --- busy_state (semantic agent state) ---------------------------------------
 
 test_busy_state_working_maps_to_busy() {
@@ -2080,6 +2095,7 @@ test_capture_preserves_pane_read_failure
 test_send_key_normalizes_and_targets_pane
 test_kill_is_best_effort
 test_current_path_reads_cwd
+test_current_path_falls_back_to_cwd_on_windows
 test_busy_state_working_maps_to_busy
 test_busy_state_done_and_blocked_map_to_idle
 test_busy_state_unknown_on_no_agent

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -20,6 +20,17 @@ set -u
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 BASE_PATH=${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin}
+# The suite needs a REAL git under BASE_PATH: tool detection checks for it
+# (COMMON_TOOLS) and the fleet-sync fakes delegate repo-state queries through
+# `command git`. On Git-for-Windows git lives in /mingw64/bin, outside the
+# hermetic Unix base, so append the ambient git's own directory there.
+case "$(uname -s)" in
+  MINGW*|MSYS*)
+    if command -v git >/dev/null 2>&1; then
+      BASE_PATH="$BASE_PATH:$(dirname "$(command -v git)")"
+    fi
+    ;;
+esac
 TMP_ROOT=$(fm_test_tmproot fm-bootstrap-tests)
 export FM_BACKEND_CMUX_BUNDLE_BIN="$TMP_ROOT/no-bundled-cmux"
 
@@ -114,7 +125,13 @@ add_real_jq() {
   real_jq=$(command -v jq 2>/dev/null) || fail "jq is required for dispatch profile validation tests"
   cat > "$fakebin/jq" <<SH
 #!/usr/bin/env bash
-exec '$real_jq' "\$@"
+# Native Windows jq builds open stdout in text mode and emit CRLF (even 1.8.x),
+# which poisons exact-string assertions against bootstrap output. Strip the CRs
+# here on MSYS; everywhere else stay a plain exec shim.
+case "\$(uname -s)" in
+  MINGW*|MSYS*) '$real_jq' "\$@" | tr -d '\r'; exit "\${PIPESTATUS[0]}" ;;
+  *) exec '$real_jq' "\$@" ;;
+esac
 SH
   chmod +x "$fakebin/jq"
 }

--- a/tests/fm-cd-pretool-check.test.sh
+++ b/tests/fm-cd-pretool-check.test.sh
@@ -304,7 +304,7 @@ test_fail_open_missing_node() {
   fakebin=$(fm_fakebin "$TMP_ROOT/nonode")
   for tool in bash sh git dirname cat printf sed tr jq; do
     tool_path=$(command -v "$tool") || continue
-    ln -s "$tool_path" "$fakebin/$tool"
+    fm_fakebin_tool "$fakebin" "$tool" "$tool_path"
   done
   # node deliberately absent from this PATH.
   out=$(PATH="$fakebin" "$CHECK" --command 'cd projects/foo' 2>&1); rc=$?
@@ -318,7 +318,7 @@ test_fail_open_missing_jq_on_stdin() {
   fakebin=$(fm_fakebin "$TMP_ROOT/nojq")
   for tool in bash sh git dirname cat printf sed tr node; do
     tool_path=$(command -v "$tool") || continue
-    ln -s "$tool_path" "$fakebin/$tool"
+    fm_fakebin_tool "$fakebin" "$tool" "$tool_path"
   done
   # jq deliberately absent: the stdin transport cannot extract the command.
   out=$(printf '{"tool_input":{"command":"cd projects/foo"}}' | PATH="$fakebin" "$CHECK" 2>&1); rc=$?
@@ -337,7 +337,7 @@ test_prefilter_skips_node_without_cd_substring() {
   marker="$TMP_ROOT/prefilter-node-called"
   for tool in bash sh git dirname cat printf sed tr jq; do
     tool_path=$(command -v "$tool") || continue
-    ln -s "$tool_path" "$fakebin/$tool"
+    fm_fakebin_tool "$fakebin" "$tool" "$tool_path"
   done
   cat > "$fakebin/node" <<EOF
 #!/usr/bin/env bash

--- a/tests/fm-turnend-guard.test.sh
+++ b/tests/fm-turnend-guard.test.sh
@@ -513,7 +513,7 @@ test_hook_silent_without_jq() {
   fakebin=$(fm_fakebin "$TMP_ROOT/hook-nojq-fake")
   for tool in bash sh git cat printf date uname stat mkdir dirname; do
     tool_path=$(command -v "$tool") || fail "test host must provide $tool"
-    ln -s "$tool_path" "$fakebin/$tool"
+    fm_fakebin_tool "$fakebin" "$tool" "$tool_path"
   done
   out=$(printf '{"stop_hook_active":false}' | PATH="$fakebin" bash "$dir/bin/fm-turnend-guard.sh" 2>&1)
   status=$?

--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -427,7 +427,11 @@ test_watch_restart_reports_healthy_peer_without_attaching() {
   state="$dir/state"
   fakebin="$dir/fakebin"
   out="$dir/restart.out"
-  node -e 'process.on("SIGTERM", () => {}); setTimeout(() => {}, 300000)' &
+  # A TERM-resistant peer must be an MSYS-native process on Windows: MSYS kill
+  # emulates TERM to non-MSYS binaries (like node) as TerminateProcess, which no
+  # in-process handler can ignore, so a node peer dies and the restart steals the
+  # lock. bash's trap ignores TERM identically on every platform.
+  bash -c 'trap "" TERM; sleep 300' &
   peer=$!
   identity=$(FM_STATE_OVERRIDE="$state" bash -c '. "$1"; fm_pid_identity "$2"' _ "$LIB" "$peer") || fail "could not identify peer pid"
   mkdir "$state/.watch.lock"

--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -155,12 +155,14 @@ test_guard_warnings() {
 }
 
 test_lock_single_winner_under_concurrency() {
-  local dir state lockdir marker i pids pid wins
+  local dir state lockdir marker donedir i pids pid wins
   dir=$(make_case lock-concurrency)
   state="$dir/state"
   lockdir="$state/.contend.lock"
   marker="$dir/wins"
+  donedir="$dir/done"
   : > "$marker"
+  mkdir -p "$donedir"
   pids=
   i=1
   while [ "$i" -le 40 ]; do
@@ -168,11 +170,20 @@ test_lock_single_winner_under_concurrency() {
       . "$1"
       if fm_lock_try_acquire "$2"; then
         printf "%s\n" "$$" >> "$3"
-        # Stay alive so the held lock names a live pid for the whole window;
-        # otherwise a late contender could legitimately reclaim a dead-pid lock.
-        sleep 1
+        # Hold the lock until every loser has finished its attempt, so the
+        # held lock names a live pid for the WHOLE contention window. A fixed
+        # hold (sleep 1) breaks on slow-spawn machines: a straggler contender
+        # that first runs after the winner exited finds a dead-pid lock past
+        # the stale window and reclaims it - legitimate under the protocol,
+        # but miscounted here as a second winner.
+        i=0
+        while [ "$(ls "$4"/done.* 2>/dev/null | wc -l)" -lt 39 ] && [ "$i" -lt 1200 ]; do
+          sleep 0.05
+          i=$((i + 1))
+        done
       fi
-    ' _ "$LIB" "$lockdir" "$marker" &
+      : > "$4/done.$$"
+    ' _ "$LIB" "$lockdir" "$marker" "$donedir" &
     pids="$pids $!"
     i=$((i + 1))
   done
@@ -471,7 +482,10 @@ test_watcher_self_evicts_on_lock_takeover() {
   # Simulate a second watcher taking over the singleton lock. $$ (the test
   # runner) is a live pid that is not the watcher.
   printf '%s\n' "$$" > "$state/.watch.lock/pid"
-  wait_for_exit "$pid" 60 || fail "watcher did not self-evict after lock takeover"
+  # Generous limit: eviction takes a few watcher poll cycles and each cycle
+  # spawns processes, which slows to hundreds of ms per spawn on a loaded
+  # MSYS machine; the wait returns as soon as the watcher dies.
+  wait_for_exit "$pid" 300 || fail "watcher did not self-evict after lock takeover"
   lock_pid=$(cat "$state/.watch.lock/pid" 2>/dev/null || true)
   [ "$lock_pid" = "$$" ] || fail "self-evicting watcher clobbered the new holder's lock (got '$lock_pid')"
   pass "watcher self-evicts when the lock pid no longer names it"

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -88,6 +88,23 @@ fm_fakebin() {
   printf '%s\n' "$fakebin"
 }
 
+# fm_fakebin_tool <fakebin> <tool> <resolved-path> exposes a real host tool
+# inside a fakebin. Wrapper scripts, not symlinks: on MSYS ln -s copies the
+# exe away from its DLLs (a copied bash.exe cannot load msys-2.0.dll when
+# PATH is only the fakebin), and bash resolves builtins like printf to a bare
+# name that no link can target. The wrapper execs the real path, so DLL
+# lookup stays in the tool's own directory; a builtin-resolved bare name runs
+# as the wrapper's /bin/sh builtin instead of recursing through PATH.
+fm_fakebin_tool() {
+  local fakebin=$1 tool=$2 tool_path=$3
+  if [ "$tool_path" = "$tool" ]; then
+    printf '#!/bin/sh\n%s "$@"\n' "$tool" > "$fakebin/$tool"
+  else
+    printf '#!/bin/sh\nexec "%s" "$@"\n' "$tool_path" > "$fakebin/$tool"
+  fi
+  chmod +x "$fakebin/$tool"
+}
+
 fm_fake_exit0() {
   local fakebin=$1 tool
   shift


### PR DESCRIPTION
## Summary

This PR makes firstmate fully functional on Windows 11 under Git Bash (MSYS) with the herdr backend.
It is the stack we have been running in production locally since 2026-07-11; a crewmate was spawned, supervised, and shipped a merged PR end to end with these patches, and the targeted test suites now pass on Windows.

The commits fall into three groups.

### Runtime enablement (spawn and supervision path)

- **Session and wake-queue locks on Git Bash**: lock helpers gain an MSYS arm (PowerShell CIM pid walk, `MSYS=winsymlinks:sys`).
- **Worktree discovery for crewmate spawns**: herdr has no `foreground_cwd` on Windows, so pane cwd falls back to `.cwd` + `cygpath -u`; treehouse subshell detection points `COMSPEC` at PowerShell so the pane cwd updates via OSC 7.
- **Agent launch through Git Bash**: herdr panes run PowerShell on Windows, so the launch command is routed through `bash -l <launch.sh>`.
- **`fm_pid_identity` on MSYS**: BusyBox-style `ps` rejects `-o`, so the identity is parsed from the default `ps -p` columns (WINPID + STIME + COMMAND), preserving the pid-reuse guarantee the Unix `lstart+command` query gives. The Unix branch keeps the upstream `LC_ALL=C` pin.

### Node-side adapters

- **OpenCode plugin and Pi extension spawned `bin/*.sh` directly**: Windows node cannot exec a shebang script, and the spawn `error` event was swallowed as a pass, so the turn-end guard silently never ran. Scripts are now routed through bash on `win32`.
- **`fm-arm-command-policy.mjs` path matching**: `path.normalize`/`path.join` flip to backslashes on Windows node and never match the POSIX patterns, and MSYS hands `--root`/`--home` as `C:/...` while paths inside the command string stay `/c/...` - on Windows the deny policy was effectively inert. A `posixNormalize` helper folds every spelling into one forward-slash, uppercase-drive form.
- **TERM delivery to the Pi watch arm child**: native node's `child.kill()` is `TerminateProcess` on Windows, so the bash arm child died without running its TERM trap, and node's Windows pid cannot be mapped back after MSYS `exec` swaps the underlying Windows process. The launch command records the child's own MSYS pid (`$$` survives exec) in `state/.pi-watch-arm-msys-pid`, and `stopArm` delivers a real MSYS TERM via Git Bash `kill`, falling back to `child.kill` when unavailable.

### Test harness

- **TERM-resistant test peers must be MSYS processes**: MSYS `kill -TERM` to a non-MSYS binary (node) is emulated as `TerminateProcess`, which no in-process handler can ignore, so the watcher-lock healthy-peer scenario used a node peer that died and had its lock stolen. A `bash -c 'trap "" TERM; sleep 300'` peer ignores TERM identically on every platform.
- **`fm_fakebin_tool` replaces `ln -s` fakebins**: on MSYS `ln -s` copies the exe away from its DLLs (a copied `bash.exe` cannot load `msys-2.0.dll` from a bare-PATH fakebin), and bash resolves builtins like `printf` to a bare name no link can target. A `/bin/sh` wrapper execs the real path instead. Applied across the turnend-guard, cd-pretool, and arm-pretool suites.
- **Bootstrap suite**: the hermetic `BASE_PATH` (`/usr/bin:/bin`) has no git on Git-for-Windows (git lives in `/mingw64/bin`), which broke both the new `COMMON_TOOLS` git check and the fleet-sync fakes that delegate repo-state queries through `command git`; the ambient git's directory is appended on MSYS. The `add_real_jq` shim also strips the CRLF that native Windows jq builds emit, which poisoned exact-string assertions.

## Environment notes (not part of the diff)

Two host-level requirements surfaced while getting the suites green; they may be worth documenting in the Windows section of the docs:

- Native Windows jq builds (winget, even 1.8.x) open stdout in text mode and emit CRLF, which corrupts every bash `$(jq -r ...)` capture in the herdr adapter. We run an LF-stripping wrapper ahead of it on PATH.
- An empty locale (`LANG` unset) breaks multibyte glyph classification in `fm-composer-lib` (the composer `❯` row reads `pending` instead of `empty`); `LANG=C.UTF-8` fixes it.

## Test plan

On Windows 11 + Git Bash, with the environment notes above applied, all of the following pass (most failed or could not run before this stack):

`fm-bootstrap`, `fm-watcher-lock`, `fm-wake-queue`, `fm-turnend-guard`, `fm-spawn-batch`, `fm-spawn-dispatch-profile`, `fm-backend-herdr`, `fm-composer-lib`, `fm-arm-pretool-check`, `fm-cd-pretool-check`, `fm-pi-watch-extension`, `fm-pi-primary-types`, `fm-lint`.

No behavior change on macOS/Linux: every Windows arm is gated on `uname` `MINGW*|MSYS*` or `process.platform === "win32"`, and the shared-code changes (`posixNormalize`, wrapper fakebins, bash test peers) are platform-neutral.
