### PR TITLE
fix: probe tasks-axi live compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Install tasks-axi for backlog-handoff delegation
         run: |
           set -eu
-          npm install -g tasks-axi
+          npm install -g tasks-axi@0.2.3
           tasks-axi --version
       - run: |
           set -eu

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -415,6 +415,7 @@ Update the backlog on every dispatch, completion, and decision for a work item.
 Re-evaluate queued work after every teardown and heartbeat, dispatching items only when dependencies and time gates have cleared.
 
 `.tasks.toml`, `docs/configuration.md`, and current `tasks-axi --help` own the backlog schema, compatibility, retention, and routine command syntax.
+`docs/configuration.md` "Backlog backend" owns the compatibility contract proved by the shared live probe.
 Use compatible `tasks-axi` when the configured backend selects it and the documented manual path otherwise; keep only the configured recent Done entries.
 `secondmate-provisioning` and `bin/fm-backlog-handoff.sh` own cross-home handoff safety.
 

--- a/bin/fm-backlog-handoff.sh
+++ b/bin/fm-backlog-handoff.sh
@@ -36,8 +36,8 @@
 # Item bodies must use at least two leading spaces. The helper refuses a selected
 # item with a single-space or tab-indented continuation rather than risk leaving
 # it orphaned, because tasks-axi treats only two-or-more-space lines as body.
-# The move needs compatible `tasks-axi` on PATH, including atomic multi-ID `mv`
-# (introduced in 0.2.2). Bootstrap requires it fleet-wide, so this works
+# The move needs compatible `tasks-axi` on PATH, including atomic multi-ID `mv`.
+# Bootstrap requires the shared live compatibility probe fleet-wide, so this works
 # everywhere; the `config/backlog-backend=manual` knob only governs firstmate's
 # own hand-editing of its own backlog, not this validated helper. Idempotent:
 # re-running converges. Atomic: on any move failure nothing moves.
@@ -300,7 +300,7 @@ if [ "$FAILED" -ne 0 ]; then
 fi
 
 if ! fm_tasks_axi_compatible; then
-  echo "error: tasks-axi with atomic multi-ID mv support (0.2.2+) is required to move backlog items" >&2
+  echo "error: compatible tasks-axi with atomic multi-ID mv support is required to move backlog items" >&2
   exit 1
 fi
 

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -48,10 +48,11 @@
 #          no-mistakes is also MISSING when its installed version is older than
 #          1.31.2.
 #          tasks-axi and quota-axi are required bootstrap tools (same class as
-#          lavish-axi). tasks-axi is also version and feature gated (0.1.1+
-#          with update --archive-body and mv [<id>...]); an installed but
-#          incompatible build reports MISSING like no-mistakes. A compatible
-#          tasks-axi default backend is silent. quota-axi is required because
+#          lavish-axi). tasks-axi runs one shared live compatibility probe for
+#          recoverable body updates and atomic multi-ID handoffs; an installed
+#          but incompatible build reports MISSING like no-mistakes. A compatible
+#          tasks-axi default backend is silent unless verbose facts are enabled.
+#          quota-axi is required because
 #          crew-dispatch quota-balanced may call it; fm-dispatch-select.sh still
 #          degrades at runtime when quota data is unavailable.
 #          X mode is OPTIONAL and inert unless FM_HOME/.env has a non-empty
@@ -429,7 +430,8 @@ install_cmd() {
     treehouse) echo "curl -fsSL https://kunchenguid.github.io/treehouse/install.sh | sh" ;;
     no-mistakes) echo "curl -fsSL https://raw.githubusercontent.com/kunchenguid/no-mistakes/main/docs/install.sh | sh" ;;
     gh-axi|chrome-devtools-axi|lavish-axi) echo "npm install -g $1 && $1 setup hooks" ;;
-    tasks-axi|quota-axi) echo "npm install -g $1" ;;
+    tasks-axi) echo "npm install -g tasks-axi@0.2.3" ;;
+    quota-axi) echo "npm install -g quota-axi" ;;
     *) return 1 ;;
   esac
 }

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -48,9 +48,9 @@
 #          no-mistakes is also MISSING when its installed version is older than
 #          1.31.2.
 #          tasks-axi and quota-axi are required bootstrap tools (same class as
-#          lavish-axi). tasks-axi runs one shared live compatibility probe for
-#          recoverable body updates and atomic multi-ID handoffs; an installed
-#          but incompatible build reports MISSING like no-mistakes. A compatible
+#          lavish-axi). tasks-axi runs the shared live compatibility probe owned
+#          by docs/configuration.md "Backlog backend"; an installed but
+#          incompatible build reports MISSING like no-mistakes. A compatible
 #          tasks-axi default backend is silent unless verbose facts are enabled.
 #          quota-axi is required because
 #          crew-dispatch quota-balanced may call it; fm-dispatch-select.sh still

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -765,6 +765,7 @@ done
 for t in $COMMON_TOOLS; do
   command -v "$t" >/dev/null || missing_tool_diagnostic "$t"
 done
+tasks_axi_compatible=0
 # The treehouse lease-support upgrade check is only relevant when the resolved
 # backend actually requires treehouse (every backend except orca, which owns its
 # own worktrees); an orca home must not be told to upgrade a provider it never uses.
@@ -775,8 +776,12 @@ fi
 if command -v no-mistakes >/dev/null 2>&1 && ! no_mistakes_compatible; then
   echo "MISSING: no-mistakes (install: $(install_cmd no-mistakes))"
 fi
-if command -v tasks-axi >/dev/null 2>&1 && ! fm_tasks_axi_compatible; then
-  echo "MISSING: tasks-axi (install: $(install_cmd tasks-axi))"
+if command -v tasks-axi >/dev/null 2>&1; then
+  if fm_tasks_axi_compatible; then
+    tasks_axi_compatible=1
+  else
+    echo "MISSING: tasks-axi (install: $(install_cmd tasks-axi))"
+  fi
 fi
 gh auth status >/dev/null 2>&1 || echo "NEEDS_GH_AUTH"
 # Worktree-tangle check: the firstmate primary checkout (FM_ROOT) must sit on its
@@ -798,7 +803,7 @@ if [ "${FM_BOOTSTRAP_VERBOSE_FACTS:-0}" = 1 ] && [ -n "$crew" ] && [ "$crew" != 
 fi
 crew_dispatch_validate
 if [ "${FM_BOOTSTRAP_VERBOSE_FACTS:-0}" = 1 ] \
-  && ! fm_backlog_backend_manual "$CONFIG" && fm_tasks_axi_compatible; then
+  && ! fm_backlog_backend_manual "$CONFIG" && [ "$tasks_axi_compatible" -eq 1 ]; then
   echo "BOOTSTRAP_INFO: tasks-axi available"
 fi
 if [ "${FM_BOOTSTRAP_DETECT_ONLY:-0}" != 1 ]; then

--- a/bin/fm-tasks-axi-lib.sh
+++ b/bin/fm-tasks-axi-lib.sh
@@ -13,10 +13,15 @@
 
 fm_tasks_axi_compatible() {
   local probe source destination replacement previous
+  local expected_source expected_destination rejected_source rejected_destination
   command -v tasks-axi >/dev/null 2>&1 || return 1
   probe=$(mktemp -d "${TMPDIR:-/tmp}/fm-tasks-axi-probe.XXXXXX") || return 1
   source="$probe/source.md"
   destination="$probe/destination.md"
+  expected_source="$probe/expected-source.md"
+  expected_destination="$probe/expected-destination.md"
+  rejected_source="$probe/rejected-source.md"
+  rejected_destination="$probe/rejected-destination.md"
   replacement='replacement probe body'
   previous='previous probe body'
 
@@ -36,18 +41,41 @@ fm_tasks_axi_compatible() {
     return 1
   fi
 
+  if ! printf '%s\n' \
+    '## Queued' \
+    '- [ ] fm-probe-a - first probe item (repo: firstmate)' \
+    "  $replacement" \
+    '- [ ] fm-probe-b - second probe item (repo: firstmate)' \
+    '  second probe body' > "$expected_source" ||
+    ! cmp -s "$source" "$expected_source" ||
+    ! cp "$source" "$rejected_source" ||
+    ! cp "$destination" "$rejected_destination"; then
+    rm -rf "$probe"
+    return 1
+  fi
+
   # A failed two-ID move must not leave the valid item half-moved.
   if tasks-axi mv fm-probe-a fm-probe-missing --file "$source" --to "$destination" >/dev/null 2>&1 ||
-    ! grep -Fq 'fm-probe-a' "$source" ||
-    grep -Fq 'fm-probe-a' "$destination"; then
+    ! cmp -s "$source" "$rejected_source" ||
+    ! cmp -s "$destination" "$rejected_destination"; then
+    rm -rf "$probe"
+    return 1
+  fi
+
+  if ! printf '%s\n' \
+    '## In flight' '' '## Queued' \
+    '- [ ] fm-probe-a - first probe item (repo: firstmate)' \
+    "  $replacement" \
+    '- [ ] fm-probe-b - second probe item (repo: firstmate)' \
+    '  second probe body' '' '## Done' > "$expected_destination" ||
+    ! printf '%s\n' '## Queued' > "$expected_source"; then
     rm -rf "$probe"
     return 1
   fi
 
   if ! tasks-axi mv fm-probe-a fm-probe-b --file "$source" --to "$destination" >/dev/null 2>&1 ||
-    grep -Eq 'fm-probe-a|fm-probe-b' "$source" ||
-    ! grep -Fq 'fm-probe-a' "$destination" ||
-    ! grep -Fq 'fm-probe-b' "$destination"; then
+    ! cmp -s "$source" "$expected_source" ||
+    ! cmp -s "$destination" "$expected_destination"; then
     rm -rf "$probe"
     return 1
   fi

--- a/bin/fm-tasks-axi-lib.sh
+++ b/bin/fm-tasks-axi-lib.sh
@@ -29,7 +29,7 @@ fm_tasks_axi_compatible() {
     '## Queued' \
     '- [ ] fm-probe-a - first probe item (repo: firstmate)' \
     "  $previous" \
-    '- [ ] fm-probe-b - second probe item (repo: firstmate)' \
+    '- [ ] fm-probe-b - second probe item (repo: firstmate) blocked-by: fm-probe-a - probe dependency' \
     '  second probe body' > "$source"
   printf '%s\n' '## In flight' '' '## Queued' '' '## Done' > "$destination"
 
@@ -45,7 +45,7 @@ fm_tasks_axi_compatible() {
     '## Queued' \
     '- [ ] fm-probe-a - first probe item (repo: firstmate)' \
     "  $replacement" \
-    '- [ ] fm-probe-b - second probe item (repo: firstmate)' \
+    '- [ ] fm-probe-b - second probe item (repo: firstmate) blocked-by: fm-probe-a - probe dependency' \
     '  second probe body' > "$expected_source" ||
     ! cmp -s "$source" "$expected_source" ||
     ! cp "$source" "$rejected_source" ||
@@ -66,7 +66,7 @@ fm_tasks_axi_compatible() {
     '## In flight' '' '## Queued' \
     '- [ ] fm-probe-a - first probe item (repo: firstmate)' \
     "  $replacement" \
-    '- [ ] fm-probe-b - second probe item (repo: firstmate)' \
+    '- [ ] fm-probe-b - second probe item (repo: firstmate) blocked-by: fm-probe-a - probe dependency' \
     '  second probe body' '' '## Done' > "$expected_destination" ||
     ! printf '%s\n' '## Queued' > "$expected_source"; then
     rm -rf "$probe"

--- a/bin/fm-tasks-axi-lib.sh
+++ b/bin/fm-tasks-axi-lib.sh
@@ -2,54 +2,57 @@
 # Shared tasks-axi backend selection and compatibility probe for bootstrap,
 # teardown, and secondmate backlog handoff.
 # Usage: . bin/fm-tasks-axi-lib.sh
-# Compatible means tasks-axi --version reports 0.1.1 or newer,
-# `tasks-axi update --help` exposes --archive-body for recoverable note rewrites,
-# and `tasks-axi mv --help` exposes [<id>...] for atomic multi-ID moves required
-# by secondmate handoffs (introduced in tasks-axi 0.2.2).
+# Compatibility is proved by one live, disposable-fixture probe: `update
+# --archive-body` must preserve the replaced body outside the backlog, and a
+# two-ID `mv` must reject an incomplete set without mutation before moving the
+# complete set together. Version and help output are advisory and never gates.
 # `config/backlog-backend=manual` opts out of tasks-axi for routine firstmate
 # backlog mutations, but validated secondmate handoffs always use `tasks-axi mv`.
 # Absent or any other value keeps the default tasks-axi backend path, falling
 # back to manual mutation when the tool is not compatible.
 
-fm_tasks_axi_version_parts() {
-  local output
-  command -v tasks-axi >/dev/null 2>&1 || return 1
-  output=$(tasks-axi --version 2>/dev/null) || return 1
-  printf '%s\n' "$output" |
-    sed -n 's/.*\([0-9][0-9]*\)\.\([0-9][0-9]*\)\.\([0-9][0-9]*\).*/\1 \2 \3/p' |
-    head -1
-}
-
 fm_tasks_axi_compatible() {
-  local parts major minor patch rest
-  parts=$(fm_tasks_axi_version_parts) || return 1
-  [ -n "$parts" ] || return 1
-  major=${parts%% *}
-  rest=${parts#* }
-  minor=${rest%% *}
-  patch=${rest##* }
+  local probe source destination replacement previous
+  command -v tasks-axi >/dev/null 2>&1 || return 1
+  probe=$(mktemp -d "${TMPDIR:-/tmp}/fm-tasks-axi-probe.XXXXXX") || return 1
+  source="$probe/source.md"
+  destination="$probe/destination.md"
+  replacement='replacement probe body'
+  previous='previous probe body'
 
-  if [ "$major" -gt 0 ] ||
-    { [ "$major" -eq 0 ] && [ "$minor" -gt 1 ]; } ||
-    { [ "$major" -eq 0 ] && [ "$minor" -eq 1 ] && [ "$patch" -ge 1 ]; }; then
-    fm_tasks_axi_update_has_archive_body && fm_tasks_axi_mv_has_multi_id
-    return $?
+  printf '%s\n' \
+    '## Queued' \
+    '- [ ] fm-probe-a - first probe item (repo: firstmate)' \
+    "  $previous" \
+    '- [ ] fm-probe-b - second probe item (repo: firstmate)' \
+    '  second probe body' > "$source"
+  printf '%s\n' '## In flight' '' '## Queued' '' '## Done' > "$destination"
+
+  if ! tasks-axi update fm-probe-a --file "$source" --body "$replacement" --archive-body >/dev/null 2>&1 ||
+    ! grep -Fqx "  $replacement" "$source" ||
+    grep -Fqx "  $previous" "$source" ||
+    ! grep -R -Fqx "  $previous" "$probe" 2>/dev/null; then
+    rm -rf "$probe"
+    return 1
   fi
-  return 1
-}
 
-fm_tasks_axi_update_has_archive_body() {
-  local output
-  command -v tasks-axi >/dev/null 2>&1 || return 1
-  output=$(tasks-axi update --help 2>&1) || return 1
-  printf '%s\n' "$output" | grep -F -- '--archive-body' >/dev/null
-}
+  # A failed two-ID move must not leave the valid item half-moved.
+  if tasks-axi mv fm-probe-a fm-probe-missing --file "$source" --to "$destination" >/dev/null 2>&1 ||
+    ! grep -Fq 'fm-probe-a' "$source" ||
+    grep -Fq 'fm-probe-a' "$destination"; then
+    rm -rf "$probe"
+    return 1
+  fi
 
-fm_tasks_axi_mv_has_multi_id() {
-  local output
-  command -v tasks-axi >/dev/null 2>&1 || return 1
-  output=$(tasks-axi mv --help 2>&1) || return 1
-  printf '%s\n' "$output" | grep -F -- '[<id>...]' >/dev/null
+  if ! tasks-axi mv fm-probe-a fm-probe-b --file "$source" --to "$destination" >/dev/null 2>&1 ||
+    grep -Eq 'fm-probe-a|fm-probe-b' "$source" ||
+    ! grep -Fq 'fm-probe-a' "$destination" ||
+    ! grep -Fq 'fm-probe-b' "$destination"; then
+    rm -rf "$probe"
+    return 1
+  fi
+
+  rm -rf "$probe"
 }
 
 fm_backlog_backend_value() {

--- a/bin/fm-tasks-axi-lib.sh
+++ b/bin/fm-tasks-axi-lib.sh
@@ -2,10 +2,9 @@
 # Shared tasks-axi backend selection and compatibility probe for bootstrap,
 # teardown, and secondmate backlog handoff.
 # Usage: . bin/fm-tasks-axi-lib.sh
-# Compatibility is proved by one live, disposable-fixture probe: `update
-# --archive-body` must preserve the replaced body outside the backlog, and a
-# two-ID `mv` must reject an incomplete set without mutation before moving the
-# complete set together. Version and help output are advisory and never gates.
+# Compatibility is proved by one live, disposable-fixture probe against the
+# contract owned by docs/configuration.md "Backlog backend". Version and help
+# output are advisory and never gates.
 # `config/backlog-backend=manual` opts out of tasks-axi for routine firstmate
 # backlog mutations, but validated secondmate handoffs always use `tasks-axi mv`.
 # Absent or any other value keeps the default tasks-axi backend path, falling

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,8 +31,10 @@ Secondmate handoffs are separate and unconditional: `fm-backlog-handoff.sh` keep
 It moves in-scope `## Queued` items only and refuses `## In flight` and historical `## Done` records, which stay with their home for pruning or archiving.
 Handoff item bodies must use at least two leading spaces, and the helper refuses a selected item with a single-space or tab-indented continuation rather than risk orphaning it.
 Because bootstrap requires `tasks-axi` on `PATH` on every profile, that delegation works fleet-wide, and the `config/backlog-backend=manual` knob governs firstmate's own hand-editing of its backlog, not this validated helper.
-Compatible means the shared bootstrap probe accepts `tasks-axi --version` as 0.1.1 or newer, `tasks-axi update --help` exposes `--archive-body`, and `tasks-axi mv --help` exposes `[<id>...]` for the atomic multi-ID move introduced in 0.2.2 and required by handoff delegation.
-That sentence is the single owner of the tasks-axi compatibility definition; every other document points here instead of restating the version gates.
+Compatible means the shared `fm_tasks_axi_compatible` live probe succeeds in an isolated fixture: `tasks-axi update --archive-body` replaces a body while preserving the old body recoverably, and a two-ID `tasks-axi mv` first rejects an incomplete set without mutation, then moves the complete set together.
+The probe does not trust `--version` or `--help`, so a CLI that advertises the flags but cannot execute the contract is incompatible.
+The first published release verified against that contract is `tasks-axi@0.2.3`; bootstrap's install and upgrade guidance pins that release with `npm install -g tasks-axi@0.2.3`.
+This paragraph is the single owner of the tasks-axi compatibility definition; every other document points here instead of restating it.
 Bootstrap requires compatible `tasks-axi` on every profile; see "Toolchain" below for missing-tool reporting and silent default-backend behavior.
 Set the local, gitignored `config/backlog-backend` file to `manual` to force manual backlog editing and suppress the verbose `BOOTSTRAP_INFO: tasks-axi available` fact, not missing-tool reporting.
 Absent or `tasks-axi` selects the default tasks-axi backend.
@@ -242,7 +244,7 @@ A herdr, zellij, or cmux home is therefore never told `tmux` is missing, and the
 When `config/crew-dispatch.json` exists, bootstrap also requires `jq` for dispatch profile validation.
 When X mode is opted in, bootstrap also requires `curl` and `jq` before arming the relay poll shim.
 `tasks-axi` and `quota-axi` are required bootstrap tools in every profile, the same class as `lavish-axi`.
-An absent or incompatible `tasks-axi` reports `MISSING: tasks-axi (install: npm install -g tasks-axi)`; when `config/backlog-backend` is not `manual` and compatible `tasks-axi` is on `PATH`, bootstrap stays silent and firstmate uses its verbs for routine backlog mutations, otherwise it hand-edits `data/backlog.md` until installation is approved and completed.
+An absent or incompatible `tasks-axi` reports `MISSING: tasks-axi (install: npm install -g tasks-axi@0.2.3)`; when `config/backlog-backend` is not `manual` and compatible `tasks-axi` is on `PATH`, bootstrap stays silent unless verbose facts are enabled and firstmate uses its verbs for routine backlog mutations, otherwise it hand-edits `data/backlog.md` until installation is approved and completed.
 An absent `quota-axi` reports `MISSING: quota-axi (install: npm install -g quota-axi)`; `bin/fm-dispatch-select.sh` still degrades to the first profile at runtime when quota data is unavailable.
 Bootstrap also reports a `TANGLE:` line when `FM_ROOT` is on a named non-default branch; follow the printed checkout remediation rather than treating it as an installable tool problem.
 In a read-only session that did not get the fleet lock, the same line is advisory and omits the checkout command.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,7 +31,7 @@ Secondmate handoffs are separate and unconditional: `fm-backlog-handoff.sh` keep
 It moves in-scope `## Queued` items only and refuses `## In flight` and historical `## Done` records, which stay with their home for pruning or archiving.
 Handoff item bodies must use at least two leading spaces, and the helper refuses a selected item with a single-space or tab-indented continuation rather than risk orphaning it.
 Because bootstrap requires `tasks-axi` on `PATH` on every profile, that delegation works fleet-wide, and the `config/backlog-backend=manual` knob governs firstmate's own hand-editing of its backlog, not this validated helper.
-Compatible means the shared `fm_tasks_axi_compatible` live probe succeeds in an isolated fixture: `tasks-axi update --archive-body` replaces a body while preserving the old body recoverably, and a two-ID `tasks-axi mv` first rejects an incomplete set without mutation, then moves the complete set together.
+Compatible means the shared `fm_tasks_axi_compatible` live probe succeeds in an isolated fixture: `tasks-axi update --archive-body` replaces a body while preserving the old body recoverably, and a two-ID `tasks-axi mv` first rejects an incomplete set without mutation, then moves the complete set together with both item bodies and the `blocked-by` dependency edge intact.
 The probe does not trust `--version` or `--help`, so a CLI that advertises the flags but cannot execute the contract is incompatible.
 The first published release verified against that contract is `tasks-axi@0.2.3`; bootstrap's install and upgrade guidance pins that release with `npm install -g tasks-axi@0.2.3`.
 This paragraph is the single owner of the tasks-axi compatibility definition; every other document points here instead of restating it.

--- a/tests/fm-backlog-handoff.test.sh
+++ b/tests/fm-backlog-handoff.test.sh
@@ -10,8 +10,9 @@ set -u
 . "$(dirname "${BASH_SOURCE[0]}")/secondmate-helpers.sh"
 
 # The move is delegated to `tasks-axi mv`, so this suite exercises the real
-# binary. Skip cleanly when it is absent (matching the backend smoke suites).
-command -v tasks-axi >/dev/null 2>&1 || { echo "skip: tasks-axi not found (required by the delegated handoff path)"; exit 0; }
+# binary. Skip cleanly unless the live shared compatibility probe accepts it.
+. "$ROOT/bin/fm-tasks-axi-lib.sh"
+fm_tasks_axi_compatible || { echo "skip: compatible tasks-axi not found (required by the delegated handoff path)"; exit 0; }
 
 TMP_ROOT=$(fm_test_tmproot fm-backlog-handoff)
 

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -86,11 +86,14 @@ SH
 add_tasks_axi() {
   local fakebin=$1 version=$2 archive_help=${3:-yes} multi_help=${4:-yes}
   local archive_live=${5:-yes} multi_live=${6:-yes} reject_atomic=${7:-yes}
-  local move_bodies=${8:-yes} transient_live=${9:-no} archive_line mv_usage
+  local move_bodies=${8:-yes} transient_live=${9:-no} preserve_dependency=${10:-yes}
+  local archive_line mv_usage destination_dependency
   archive_line=""
   [ "$archive_help" = yes ] && archive_line='  --archive-body'
   mv_usage='usage: tasks-axi mv <id> [<id>...] --to <path-or-dir>'
   [ "$multi_help" = yes ] || mv_usage='usage: tasks-axi mv <id> --to <path-or-dir>'
+  destination_dependency='- [ ] fm-probe-b - second probe item (repo: firstmate) blocked-by: fm-probe-a - probe dependency'
+  [ "$preserve_dependency" = yes ] || destination_dependency='- [ ] fm-probe-b - second probe item (repo: firstmate)'
   cat > "$fakebin/tasks-axi" <<SH
 #!/usr/bin/env bash
 if [ "\${1:-}" = --version ]; then
@@ -129,7 +132,7 @@ if [ "\${1:-}" = update ]; then
     '## Queued' \\
     '- [ ] fm-probe-a - first probe item (repo: firstmate)' \\
     '  replacement probe body' \\
-    '- [ ] fm-probe-b - second probe item (repo: firstmate)' \\
+    '- [ ] fm-probe-b - second probe item (repo: firstmate) blocked-by: fm-probe-a - probe dependency' \\
     '  second probe body' > "\$file"
   printf '%s\n' '## Archived probe' '- [ ] fm-probe-a - first probe item (repo: firstmate)' \\
     '  previous probe body' > "\$(dirname "\$file")/note-archive.md"
@@ -162,12 +165,12 @@ if [ "\${1:-}" = mv ]; then
       '## In flight' '' '## Queued' \\
       '- [ ] fm-probe-a - first probe item (repo: firstmate)' \\
       '  replacement probe body' \\
-      '- [ ] fm-probe-b - second probe item (repo: firstmate)' \\
+      '$destination_dependency' \\
       '  second probe body' '' '## Done' > "\$destination"
   else
     printf '%s\n' '## In flight' '' '## Queued' \
       '- [ ] fm-probe-a - first probe item (repo: firstmate)' \
-      '- [ ] fm-probe-b - second probe item (repo: firstmate)' \
+      '$destination_dependency' \
       '' '## Done' > "\$destination"
   fi
   exit 0
@@ -294,7 +297,7 @@ assert_timeout_report() {
 test_bootstrap_reporting() {
   local label lease tasks quota backend mode expect notcontains case_dir fakebin out n
   local version features archive_help multi_help archive_live multi_live
-  local reject_atomic move_bodies transient_live
+  local reject_atomic move_bodies transient_live preserve_dependency
   n=0
   while IFS='^' read -r label lease tasks quota backend mode expect notcontains; do
     [ -n "$label" ] || continue
@@ -319,6 +322,7 @@ test_bootstrap_reporting() {
       reject_atomic=yes
       move_bodies=yes
       transient_live=no
+      preserve_dependency=yes
       case ":$features:" in *:noarchive:*) archive_help=no; archive_live=no ;; esac
       case ":$features:" in *:nomulti:*) multi_help=no; multi_live=no ;; esac
       # This CLI advertises the newest version and both flags, but rejects the
@@ -327,8 +331,9 @@ test_bootstrap_reporting() {
       case ":$features:" in *:mutatereject:*) reject_atomic=no ;; esac
       case ":$features:" in *:dropbodies:*) move_bodies=no ;; esac
       case ":$features:" in *:transient:*) transient_live=yes ;; esac
+      case ":$features:" in *:dropdependency:*) preserve_dependency=no ;; esac
       add_tasks_axi "$fakebin" "$version" "$archive_help" "$multi_help" "$archive_live" "$multi_live" \
-        "$reject_atomic" "$move_bodies" "$transient_live"
+        "$reject_atomic" "$move_bodies" "$transient_live" "$preserve_dependency"
     fi
     if [ "$quota" = "0" ]; then
       rm -f "$fakebin/quota-axi"
@@ -359,6 +364,7 @@ incompatible old tasks-axi is required by default^1^0.1.2:noarchive:nomulti^1^-^
 tasks-axi with misleading version/help output is required by default^1^0.2.3:lies^1^-^exact^MISSING: tasks-axi (install: npm install -g tasks-axi@0.2.3)^
 tasks-axi rejected move mutation fails closed^1^0.2.3:mutatereject^1^-^exact^MISSING: tasks-axi (install: npm install -g tasks-axi@0.2.3)^
 tasks-axi dropped move bodies fail closed^1^0.2.3:dropbodies^1^-^exact^MISSING: tasks-axi (install: npm install -g tasks-axi@0.2.3)^
+tasks-axi dropped dependency edge fails closed^1^0.2.3:dropdependency^1^-^exact^MISSING: tasks-axi (install: npm install -g tasks-axi@0.2.3)^
 tasks-axi transient probe result stays cached^1^0.2.3:transient^1^-^exact^MISSING: tasks-axi (install: npm install -g tasks-axi@0.2.3)^
 missing quota-axi is required by default^1^0.1.1^0^manual^exact^MISSING: quota-axi (install: npm install -g quota-axi)^
 manual backlog backend still requires missing tasks-axi^1^-^1^manual^exact^MISSING: tasks-axi (install: npm install -g tasks-axi@0.2.3)^

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -7,9 +7,9 @@
 # 'MISSING: tasks-axi (install: ...)', 'MISSING: quota-axi (install: ...)', and
 # 'BOOTSTRAP_INFO: ...' lines, so those contracts are pinned verbatim. The cases
 # are table-driven over the inputs that vary: whether `treehouse get --help`
-# advertises --lease, which (if any) tasks-axi version is on PATH, whether
-# tasks-axi update advertises --archive-body, whether its mv help advertises
-# multi-ID moves, whether quota-axi is on PATH,
+# advertises --lease, whether tasks-axi can execute recoverable body updates and
+# atomic multi-ID moves (rather than merely claim them in version/help output),
+# whether quota-axi is on PATH,
 # whether the local backend config opts out of tasks-axi backlog mutations, and
 # which no-mistakes version is on PATH.
 # Dedicated fleet-sync cases pin the computed bootstrap timeout, explicit
@@ -84,11 +84,12 @@ SH
 }
 
 add_tasks_axi() {
-  local fakebin=$1 version=$2 archive_body=${3:-yes} multi_id=${4:-yes} archive_line mv_usage
+  local fakebin=$1 version=$2 archive_help=${3:-yes} multi_help=${4:-yes}
+  local archive_live=${5:-yes} multi_live=${6:-yes} archive_line mv_usage
   archive_line=""
-  [ "$archive_body" = yes ] && archive_line='  --archive-body'
+  [ "$archive_help" = yes ] && archive_line='  --archive-body'
   mv_usage='usage: tasks-axi mv <id> [<id>...] --to <path-or-dir>'
-  [ "$multi_id" = yes ] || mv_usage='usage: tasks-axi mv <id> --to <path-or-dir>'
+  [ "$multi_help" = yes ] || mv_usage='usage: tasks-axi mv <id> --to <path-or-dir>'
   cat > "$fakebin/tasks-axi" <<SH
 #!/usr/bin/env bash
 if [ "\${1:-}" = --version ]; then
@@ -105,7 +106,51 @@ if [ "\${1:-}" = mv ] && [ "\${2:-}" = --help ]; then
   printf '%s\n' '$mv_usage'
   exit 0
 fi
-exit 0
+if [ "\${1:-}" = update ]; then
+  [ '$archive_live' = yes ] || exit 64
+  file=
+  while [ "\$#" -gt 0 ]; do
+    case "\$1" in
+      --file) file=\$2; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+  [ -n "\$file" ] || exit 64
+  printf '%s\n' \\
+    '## Queued' \\
+    '- [ ] fm-probe-a - first probe item (repo: firstmate)' \\
+    '  replacement probe body' \\
+    '- [ ] fm-probe-b - second probe item (repo: firstmate)' \\
+    '  second probe body' > "\$file"
+  printf '%s\n' '## Archived probe' '- [ ] fm-probe-a - first probe item (repo: firstmate)' \\
+    '  previous probe body' > "\$(dirname "\$file")/note-archive.md"
+  exit 0
+fi
+if [ "\${1:-}" = mv ]; then
+  shift
+  ids=()
+  file=
+  destination=
+  while [ "\$#" -gt 0 ]; do
+    case "\$1" in
+      --file) file=\$2; shift 2 ;;
+      --to) destination=\$2; shift 2 ;;
+      *) ids+=("\$1"); shift ;;
+    esac
+  done
+  [ "\${#ids[@]}" -gt 1 ] && [ '$multi_live' != yes ] && exit 64
+  [ -n "\$file" ] && [ -n "\$destination" ] || exit 64
+  [ "\${ids[*]}" = 'fm-probe-a fm-probe-b' ] || exit 1
+  printf '%s\n' '## Queued' > "\$file"
+  printf '%s\n' \\
+    '## In flight' '' '## Queued' \\
+    '- [ ] fm-probe-a - first probe item (repo: firstmate)' \\
+    '  replacement probe body' \\
+    '- [ ] fm-probe-b - second probe item (repo: firstmate)' \\
+    '  second probe body' '' '## Done' > "\$destination"
+  exit 0
+fi
+exit 64
 SH
   chmod +x "$fakebin/tasks-axi"
 }
@@ -225,7 +270,8 @@ assert_timeout_report() {
 #   mode=exact -> output must equal <expect>
 #   mode=grep  -> output must contain <expect> (fixed string); <notcontains> must not appear
 test_bootstrap_reporting() {
-  local label lease tasks quota backend mode expect notcontains case_dir fakebin out n archive_body multi_id
+  local label lease tasks quota backend mode expect notcontains case_dir fakebin out n
+  local version features archive_help multi_help archive_live multi_live
   n=0
   while IFS='^' read -r label lease tasks quota backend mode expect notcontains; do
     [ -n "$label" ] || continue
@@ -240,21 +286,19 @@ test_bootstrap_reporting() {
     if [ "$tasks" = "-" ]; then
       rm -f "$fakebin/tasks-axi"
     else
-      archive_body=yes
-      multi_id=yes
-      case "$tasks" in
-        *:noarchive)
-          archive_body=no
-          tasks=${tasks%:noarchive}
-          ;;
-      esac
-      case "$tasks" in
-        *:nomulti)
-          multi_id=no
-          tasks=${tasks%:nomulti}
-          ;;
-      esac
-      add_tasks_axi "$fakebin" "$tasks" "$archive_body" "$multi_id"
+      version=${tasks%%:*}
+      features=
+      [ "$version" = "$tasks" ] || features=${tasks#*:}
+      archive_help=yes
+      multi_help=yes
+      archive_live=yes
+      multi_live=yes
+      case ":$features:" in *:noarchive:*) archive_help=no; archive_live=no ;; esac
+      case ":$features:" in *:nomulti:*) multi_help=no; multi_live=no ;; esac
+      # This CLI advertises the newest version and both flags, but rejects the
+      # real operations. The bootstrap must fail closed instead of trusting it.
+      case ":$features:" in *:lies:*) archive_live=no; multi_live=no ;; esac
+      add_tasks_axi "$fakebin" "$version" "$archive_help" "$multi_help" "$archive_live" "$multi_live"
     fi
     if [ "$quota" = "0" ]; then
       rm -f "$fakebin/quota-axi"
@@ -279,14 +323,13 @@ test_bootstrap_reporting() {
   done <<'ROWS'
 treehouse --lease support is accepted silently^1^0.1.1^1^manual^empty^^
 treehouse without --lease reports an upgrade, gh auth is fine^0^0.1.1^1^-^grep^MISSING: treehouse (install: curl -fsSL https://kunchenguid.github.io/treehouse/install.sh | sh)^NEEDS_GH_AUTH
-compatible tasks-axi is silent by default^1^0.1.1^1^-^empty^^
-missing tasks-axi is required by default^1^-^1^-^exact^MISSING: tasks-axi (install: npm install -g tasks-axi)^
-incompatible tasks-axi is required by default^1^0.1.0^1^-^exact^MISSING: tasks-axi (install: npm install -g tasks-axi)^
-tasks-axi without archive-body is required by default^1^0.1.2:noarchive^1^-^exact^MISSING: tasks-axi (install: npm install -g tasks-axi)^
-tasks-axi without multi-id mv is required by default^1^0.2.2:nomulti^1^-^exact^MISSING: tasks-axi (install: npm install -g tasks-axi)^
+compatible tasks-axi is silent by default^1^development build^1^-^empty^^
+missing tasks-axi is required by default^1^-^1^-^exact^MISSING: tasks-axi (install: npm install -g tasks-axi@0.2.3)^
+incompatible old tasks-axi is required by default^1^0.1.2:noarchive:nomulti^1^-^exact^MISSING: tasks-axi (install: npm install -g tasks-axi@0.2.3)^
+tasks-axi with misleading version/help output is required by default^1^0.2.3:lies^1^-^exact^MISSING: tasks-axi (install: npm install -g tasks-axi@0.2.3)^
 missing quota-axi is required by default^1^0.1.1^0^manual^exact^MISSING: quota-axi (install: npm install -g quota-axi)^
-manual backlog backend still requires missing tasks-axi^1^-^1^manual^exact^MISSING: tasks-axi (install: npm install -g tasks-axi)^
-manual backlog backend suppresses tasks-axi availability^1^0.1.1^1^manual^empty^^
+manual backlog backend still requires missing tasks-axi^1^-^1^manual^exact^MISSING: tasks-axi (install: npm install -g tasks-axi@0.2.3)^
+manual backlog backend suppresses tasks-axi availability^1^development build^1^manual^empty^^
 ROWS
   pass "bootstrap reports treehouse lease + tasks-axi/quota-axi bootstrap contracts"
 }

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -85,7 +85,8 @@ SH
 
 add_tasks_axi() {
   local fakebin=$1 version=$2 archive_help=${3:-yes} multi_help=${4:-yes}
-  local archive_live=${5:-yes} multi_live=${6:-yes} archive_line mv_usage
+  local archive_live=${5:-yes} multi_live=${6:-yes} reject_atomic=${7:-yes}
+  local move_bodies=${8:-yes} transient_live=${9:-no} archive_line mv_usage
   archive_line=""
   [ "$archive_help" = yes ] && archive_line='  --archive-body'
   mv_usage='usage: tasks-axi mv <id> [<id>...] --to <path-or-dir>'
@@ -108,6 +109,14 @@ if [ "\${1:-}" = mv ] && [ "\${2:-}" = --help ]; then
 fi
 if [ "\${1:-}" = update ]; then
   [ '$archive_live' = yes ] || exit 64
+  if [ '$transient_live' = yes ]; then
+    probe_attempt_file='$fakebin/tasks-axi-probe-attempts'
+    probe_attempt=0
+    [ ! -f "\$probe_attempt_file" ] || probe_attempt=\$(cat "\$probe_attempt_file")
+    probe_attempt=\$((probe_attempt + 1))
+    printf '%s\n' "\$probe_attempt" > "\$probe_attempt_file"
+    [ "\$probe_attempt" -gt 1 ] || exit 64
+  fi
   file=
   while [ "\$#" -gt 0 ]; do
     case "\$1" in
@@ -140,14 +149,27 @@ if [ "\${1:-}" = mv ]; then
   done
   [ "\${#ids[@]}" -gt 1 ] && [ '$multi_live' != yes ] && exit 64
   [ -n "\$file" ] && [ -n "\$destination" ] || exit 64
-  [ "\${ids[*]}" = 'fm-probe-a fm-probe-b' ] || exit 1
+  if [ "\${ids[*]}" != 'fm-probe-a fm-probe-b' ]; then
+    if [ '$reject_atomic' != yes ]; then
+      printf '%s\n' '  rejected move mutation' >> "\$file"
+      printf '%s\n' 'rejected move mutation' >> "\$destination"
+    fi
+    exit 1
+  fi
   printf '%s\n' '## Queued' > "\$file"
-  printf '%s\n' \\
-    '## In flight' '' '## Queued' \\
-    '- [ ] fm-probe-a - first probe item (repo: firstmate)' \\
-    '  replacement probe body' \\
-    '- [ ] fm-probe-b - second probe item (repo: firstmate)' \\
-    '  second probe body' '' '## Done' > "\$destination"
+  if [ '$move_bodies' = yes ]; then
+    printf '%s\n' \\
+      '## In flight' '' '## Queued' \\
+      '- [ ] fm-probe-a - first probe item (repo: firstmate)' \\
+      '  replacement probe body' \\
+      '- [ ] fm-probe-b - second probe item (repo: firstmate)' \\
+      '  second probe body' '' '## Done' > "\$destination"
+  else
+    printf '%s\n' '## In flight' '' '## Queued' \
+      '- [ ] fm-probe-a - first probe item (repo: firstmate)' \
+      '- [ ] fm-probe-b - second probe item (repo: firstmate)' \
+      '' '## Done' > "\$destination"
+  fi
   exit 0
 fi
 exit 64
@@ -272,6 +294,7 @@ assert_timeout_report() {
 test_bootstrap_reporting() {
   local label lease tasks quota backend mode expect notcontains case_dir fakebin out n
   local version features archive_help multi_help archive_live multi_live
+  local reject_atomic move_bodies transient_live
   n=0
   while IFS='^' read -r label lease tasks quota backend mode expect notcontains; do
     [ -n "$label" ] || continue
@@ -293,12 +316,19 @@ test_bootstrap_reporting() {
       multi_help=yes
       archive_live=yes
       multi_live=yes
+      reject_atomic=yes
+      move_bodies=yes
+      transient_live=no
       case ":$features:" in *:noarchive:*) archive_help=no; archive_live=no ;; esac
       case ":$features:" in *:nomulti:*) multi_help=no; multi_live=no ;; esac
       # This CLI advertises the newest version and both flags, but rejects the
       # real operations. The bootstrap must fail closed instead of trusting it.
       case ":$features:" in *:lies:*) archive_live=no; multi_live=no ;; esac
-      add_tasks_axi "$fakebin" "$version" "$archive_help" "$multi_help" "$archive_live" "$multi_live"
+      case ":$features:" in *:mutatereject:*) reject_atomic=no ;; esac
+      case ":$features:" in *:dropbodies:*) move_bodies=no ;; esac
+      case ":$features:" in *:transient:*) transient_live=yes ;; esac
+      add_tasks_axi "$fakebin" "$version" "$archive_help" "$multi_help" "$archive_live" "$multi_live" \
+        "$reject_atomic" "$move_bodies" "$transient_live"
     fi
     if [ "$quota" = "0" ]; then
       rm -f "$fakebin/quota-axi"
@@ -327,6 +357,9 @@ compatible tasks-axi is silent by default^1^development build^1^-^empty^^
 missing tasks-axi is required by default^1^-^1^-^exact^MISSING: tasks-axi (install: npm install -g tasks-axi@0.2.3)^
 incompatible old tasks-axi is required by default^1^0.1.2:noarchive:nomulti^1^-^exact^MISSING: tasks-axi (install: npm install -g tasks-axi@0.2.3)^
 tasks-axi with misleading version/help output is required by default^1^0.2.3:lies^1^-^exact^MISSING: tasks-axi (install: npm install -g tasks-axi@0.2.3)^
+tasks-axi rejected move mutation fails closed^1^0.2.3:mutatereject^1^-^exact^MISSING: tasks-axi (install: npm install -g tasks-axi@0.2.3)^
+tasks-axi dropped move bodies fail closed^1^0.2.3:dropbodies^1^-^exact^MISSING: tasks-axi (install: npm install -g tasks-axi@0.2.3)^
+tasks-axi transient probe result stays cached^1^0.2.3:transient^1^-^exact^MISSING: tasks-axi (install: npm install -g tasks-axi@0.2.3)^
 missing quota-axi is required by default^1^0.1.1^0^manual^exact^MISSING: quota-axi (install: npm install -g quota-axi)^
 manual backlog backend still requires missing tasks-axi^1^-^1^manual^exact^MISSING: tasks-axi (install: npm install -g tasks-axi@0.2.3)^
 manual backlog backend suppresses tasks-axi availability^1^development build^1^manual^empty^^

--- a/tests/fm-secondmate-lifecycle-e2e.test.sh
+++ b/tests/fm-secondmate-lifecycle-e2e.test.sh
@@ -26,6 +26,8 @@ set -u
 
 # shellcheck source=tests/secondmate-helpers.sh disable=SC1091
 . "$(dirname "${BASH_SOURCE[0]}")/secondmate-helpers.sh"
+# shellcheck source=bin/fm-tasks-axi-lib.sh disable=SC1091
+. "$ROOT/bin/fm-tasks-axi-lib.sh"
 
 TMP_ROOT=$(fm_test_tmproot fm-secondmate-lifecycle)
 export FM_BACKEND=tmux
@@ -151,10 +153,11 @@ phase_send() {
 }
 
 phase_handoff() {
-  # The move is delegated to `tasks-axi mv`; skip cleanly when it is absent (the
-  # downstream recovery and teardown phases do not depend on this phase).
-  if ! command -v tasks-axi >/dev/null 2>&1; then
-    echo "skip: tasks-axi not found (backlog handoff delegates to it)"
+  # The move is delegated to `tasks-axi mv`; skip cleanly when the shared live
+  # compatibility probe rejects the installed CLI. The downstream recovery and
+  # teardown phases do not depend on this phase.
+  if ! fm_tasks_axi_compatible; then
+    echo "skip: compatible tasks-axi not found (backlog handoff delegates to it)"
     return 0
   fi
   cat > "$HOME_DIR/data/backlog.md" <<'EOF'

--- a/tests/fm-secondmate-sync.test.sh
+++ b/tests/fm-secondmate-sync.test.sh
@@ -332,12 +332,51 @@ SH
   chmod +x "$fakebin/no-mistakes"
   cat > "$fakebin/tasks-axi" <<'SH'
 #!/usr/bin/env bash
-case "${1:-} ${2:-}" in
-  "--version ") printf '%s\n' '0.1.1' ;;
-  "update --help") printf '%s\n' 'usage: tasks-axi update <id> [flags]' '  --archive-body' ;;
-  "mv --help") printf '%s\n' 'usage: tasks-axi mv <id> [<id>...] --to <path-or-dir>' ;;
-esac
-exit 0
+if [ "${1:-}" = update ]; then
+  file=
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --file) file=$2; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+  [ -n "$file" ] || exit 64
+  printf '%s\n' \
+    '## Queued' \
+    '- [ ] fm-probe-a - first probe item (repo: firstmate)' \
+    '  replacement probe body' \
+    '- [ ] fm-probe-b - second probe item (repo: firstmate) blocked-by: fm-probe-a - probe dependency' \
+    '  second probe body' > "$file"
+  printf '%s\n' \
+    '## Archived probe' \
+    '- [ ] fm-probe-a - first probe item (repo: firstmate)' \
+    '  previous probe body' > "$(dirname "$file")/note-archive.md"
+  exit 0
+fi
+if [ "${1:-}" = mv ]; then
+  shift
+  ids=()
+  file=
+  destination=
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --file) file=$2; shift 2 ;;
+      --to) destination=$2; shift 2 ;;
+      *) ids+=("$1"); shift ;;
+    esac
+  done
+  [ -n "$file" ] && [ -n "$destination" ] || exit 64
+  [ "${ids[*]}" = 'fm-probe-a fm-probe-b' ] || exit 1
+  printf '%s\n' '## Queued' > "$file"
+  printf '%s\n' \
+    '## In flight' '' '## Queued' \
+    '- [ ] fm-probe-a - first probe item (repo: firstmate)' \
+    '  replacement probe body' \
+    '- [ ] fm-probe-b - second probe item (repo: firstmate) blocked-by: fm-probe-a - probe dependency' \
+    '  second probe body' '' '## Done' > "$destination"
+  exit 0
+fi
+exit 64
 SH
   chmod +x "$fakebin/tasks-axi"
   cat > "$fakebin/quota-axi" <<'SH'

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -132,21 +132,49 @@ add_compatible_tasks_axi() {
   local case_dir=$1
   cat > "$case_dir/fakebin/tasks-axi" <<'SH'
 #!/usr/bin/env bash
-if [ "${1:-}" = --version ]; then
-  printf '%s\n' '0.1.1'
+if [ "${1:-}" = update ]; then
+  file=
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --file) file=$2; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+  [ -n "$file" ] || exit 64
+  printf '%s\n' \
+    '## Queued' \
+    '- [ ] fm-probe-a - first probe item (repo: firstmate)' \
+    '  replacement probe body' \
+    '- [ ] fm-probe-b - second probe item (repo: firstmate)' \
+    '  second probe body' > "$file"
+  printf '%s\n' '## Archived probe' '- [ ] fm-probe-a - first probe item (repo: firstmate)' \
+    '  previous probe body' > "$(dirname "$file")/note-archive.md"
   exit 0
 fi
-if [ "${1:-}" = update ] && [ "${2:-}" = --help ]; then
-  printf '%s\n' 'usage: tasks-axi update <id> [flags]'
-  printf '%s\n' '  --body-file <path>'
-  printf '%s\n' '  --archive-body'
+if [ "${1:-}" = mv ]; then
+  shift
+  ids=()
+  file=
+  destination=
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --file) file=$2; shift 2 ;;
+      --to) destination=$2; shift 2 ;;
+      *) ids+=("$1"); shift ;;
+    esac
+  done
+  [ -n "$file" ] && [ -n "$destination" ] || exit 64
+  [ "${ids[*]}" = 'fm-probe-a fm-probe-b' ] || exit 1
+  printf '%s\n' '## Queued' > "$file"
+  printf '%s\n' \
+    '## In flight' '' '## Queued' \
+    '- [ ] fm-probe-a - first probe item (repo: firstmate)' \
+    '  replacement probe body' \
+    '- [ ] fm-probe-b - second probe item (repo: firstmate)' \
+    '  second probe body' '' '## Done' > "$destination"
   exit 0
 fi
-if [ "${1:-}" = mv ] && [ "${2:-}" = --help ]; then
-  printf '%s\n' 'usage: tasks-axi mv <id> [<id>...] --to <path-or-dir>'
-  exit 0
-fi
-exit 0
+exit 64
 SH
   chmod +x "$case_dir/fakebin/tasks-axi"
 }

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -145,7 +145,7 @@ if [ "${1:-}" = update ]; then
     '## Queued' \
     '- [ ] fm-probe-a - first probe item (repo: firstmate)' \
     '  replacement probe body' \
-    '- [ ] fm-probe-b - second probe item (repo: firstmate)' \
+    '- [ ] fm-probe-b - second probe item (repo: firstmate) blocked-by: fm-probe-a - probe dependency' \
     '  second probe body' > "$file"
   printf '%s\n' '## Archived probe' '- [ ] fm-probe-a - first probe item (repo: firstmate)' \
     '  previous probe body' > "$(dirname "$file")/note-archive.md"
@@ -170,7 +170,7 @@ if [ "${1:-}" = mv ]; then
     '## In flight' '' '## Queued' \
     '- [ ] fm-probe-a - first probe item (repo: firstmate)' \
     '  replacement probe body' \
-    '- [ ] fm-probe-b - second probe item (repo: firstmate)' \
+    '- [ ] fm-probe-b - second probe item (repo: firstmate) blocked-by: fm-probe-a - probe dependency' \
     '  second probe body' '' '## Done' > "$destination"
   exit 0
 fi


### PR DESCRIPTION
## Summary

- Proves `tasks-axi update --archive-body` and connected multi-ID `mv` behavior with a canonical live fixture, including complete bodies and the `blocked-by` edge.
- Caches one compatibility verdict per bootstrap run so diagnostics cannot disagree.
- Pins the first verified release (`tasks-axi@0.2.3`) and documents the contract.

## Validation

- Local no-mistakes pipeline passed at `0cf69834`; push, PR, and CI steps were intentionally skipped during that run.
- Focused bootstrap, teardown, handoff, and lint evidence passed.
- The full suite had two unrelated AFK digest-classification failures. The captain accepted that exception; it is tracked separately as `afk-digest-classification-r8`. No AFK changes are included here.