### PR TITLE
fix: deliver afk escalations when Herdr is idle

### DIFF
--- a/bin/fm-composer-lib.sh
+++ b/bin/fm-composer-lib.sh
@@ -159,6 +159,29 @@ fm_composer_strip_ghost() {
   '
 }
 
+# fm_composer_trim: trim ordinary whitespace plus the U+00A0 no-break-space
+# that Claude renders after an otherwise-empty prompt glyph. POSIX [:space:]
+# does not include U+00A0, so it must be handled explicitly without treating a
+# no-break space inside real typed text as disposable.
+fm_composer_trim() {  # <content>
+  local content=$1 nbsp=$'\302\240'
+  while :; do
+    case "$content" in
+      "$nbsp"*) content=${content#"$nbsp"} ;;
+      [[:space:]]*) content="${content#"${content%%[![:space:]]*}"}" ;;
+      *) break ;;
+    esac
+  done
+  while :; do
+    case "$content" in
+      *"$nbsp") content=${content%"$nbsp"} ;;
+      *[[:space:]]) content="${content%"${content##*[![:space:]]}"}" ;;
+      *) break ;;
+    esac
+  done
+  printf '%s' "$content"
+}
+
 # fm_composer_classify_content: the single shared composer-content verdict.
 #   <bordered> 1 when <content> came from a genuine agent-composer container (a
 #              bordered composer box, or a structurally-identified bare AGENT
@@ -182,6 +205,8 @@ fm_composer_idle_matches() {
 fm_composer_classify_content() {  # <bordered> <content> [idle_re] [idle_case] [plain_content]
   local bordered=$1 content=$2 idle_re=${3:-} idle_case=${4:-sensitive} plain_content
   plain_content=${5:-$content}
+  content=$(fm_composer_trim "$content")
+  plain_content=$(fm_composer_trim "$plain_content")
   if [ "$bordered" != 1 ] && [ -z "$content" ] && [ -n "$plain_content" ]; then
     case "$plain_content" in
       '❯'|'›') printf 'empty'; return 0 ;;
@@ -210,8 +235,7 @@ fm_composer_classify_content() {  # <bordered> <content> [idle_re] [idle_case] [
     '❯ '*|'› '*|'> '*|'$ '*|'% '*|'# '*) content=${content#??} ;;
     '❯'*|'›'*|'>'*|'$'*|'%'*|'#'*) content=${content#?} ;;
   esac
-  content="${content#"${content%%[![:space:]]*}"}"
-  content="${content%"${content##*[![:space:]]}"}"
+  content=$(fm_composer_trim "$content")
   [ -n "$content" ] || { printf 'empty'; return 0; }
   # Known idle placeholder (matched again after the leading glyph was stripped,
   # e.g. "❯ Type a message...").

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -540,18 +540,19 @@ mark_escalated_seen() {  # <kind> <arg> <state>
 # caller/test that passes only <target> is unaffected. Dispatch goes through
 # bin/fm-backend.sh's generic per-backend primitives (fm_backend_busy_state,
 # fm_backend_capture, fm_backend_composer_state) rather than hand-rolling a
-# case statement here, mirroring the same fallback pattern
-# stale_window_is_busy already uses for per-task panes: try the backend's
-# native busy-state first, and fall back to the shared regex-over-capture
-# reader whenever it does not report "busy" (tmux has no native busy-state
-# primitive, so it always takes this fallback path - byte-identical to the
-# pre-existing fm_pane_is_busy, since fm_backend_capture's tmux arm runs the
-# exact same `tmux capture-pane -p -t <target> -S -40`).
+# case statement here. A native `busy` or `idle` verdict is conclusive for the
+# supervisor guard: Herdr's native agent state describes the live footer,
+# whereas a scrollback capture can retain historical busy strings that the
+# supervisor itself printed. Only `unknown` falls back to the shared
+# regex-over-capture reader. Tmux has no native busy-state primitive, so it
+# always takes that fallback path, byte-identical to the pre-existing
+# fm_pane_is_busy.
 pane_is_busy() {  # <target> [backend]
   local target=$1 backend=${2:-tmux} bs tail40
   bs=$(fm_backend_busy_state "$backend" "$target" 2>/dev/null)
   case "$bs" in
     busy) return 0 ;;
+    idle) return 1 ;;
   esac
   tail40=$(fm_backend_capture "$backend" "$target" 40 2>/dev/null) || return 1
   printf '%s' "$tail40" | grep -v '^[[:space:]]*$' | tail -6 \

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -517,8 +517,9 @@ Other runtime backends, including zellij, orca, and cmux, are not yet supported 
 
 **Injection dispatch.** `inject_msg`'s pane-exists probe, busy-guard (`pane_is_busy`), composer-guard (a direct `fm_backend_composer_state` read; see the composer-safety note below), and verified submit all take an optional `<backend>` argument (defaulting to `tmux` when omitted, so every pre-existing caller/test is unaffected) and route through the generic dispatchers instead of calling `tmux` directly.
 For `backend=tmux` every dispatch resolves to the exact same underlying call as before (`fm_backend_capture`'s tmux arm runs the identical `tmux capture-pane -p -t <target> -S -40`; `fm_backend_tmux_send_text_submit` re-exports `fm_tmux_submit_core` verbatim), so tmux behavior is unchanged byte-for-byte.
-For `backend=herdr`, busy detection tries the native `agent.get`-backed `fm_backend_herdr_busy_state` first, trusts only `busy` outright, and corroborates every non-`busy` verdict with the shared regex-over-capture reader before treating the supervisor pane as not busy.
-This mirrors the per-task stale-pane busy check `bin/fm-supervise-daemon.sh`'s `stale_window_is_busy` already used; composer/pending detection and the verified submit route through `fm_backend_herdr_composer_state`/`fm_backend_herdr_send_text_submit`.
+For `backend=herdr`, the supervisor injection guard treats native `agent.get` `busy` and `idle` verdicts as conclusive, because agent state describes the live pane while a scrollback capture can retain busy strings quoted by the supervisor itself.
+Only an `unknown` native verdict falls back to the shared regex-over-capture reader.
+This is intentionally narrower than the per-task stale-pane check `bin/fm-supervise-daemon.sh`'s `stale_window_is_busy`, which keeps its existing corroboration policy; composer/pending detection and verified submit route through `fm_backend_herdr_composer_state`/`fm_backend_herdr_send_text_submit`.
 The wedge alarm's supervisor-client status-line flash (`tmux display-message ...`) is tmux-only cosmetic UI with no herdr equivalent, so it is skipped for non-tmux backends.
 A max-defer wedge also attempts the configured backend-independent active alert described in [`wedge-alarm.md`](wedge-alarm.md), while the ERROR log line and durable `state/.subsuper-inject-wedged` marker remain backend-independent.
 
@@ -784,6 +785,35 @@ The luminance rule assumes a dark terminal theme (the fleet reality); the SGR-2 
 
 **Resolved: backend-independent wedge alarm.** The max-defer wedge alarm (`inject_wedge_alarm`, `bin/fm-supervise-daemon.sh`) formerly alarmed into the void because its only active signal was a tmux client status-line flash, skipped for herdr, leaving only the passive `state/.subsuper-inject-wedged` marker.
 It now also attempts a configurable active alert independent of the supervisor backend; [`wedge-alarm.md`](wedge-alarm.md) owns its channels and verification evidence.
+
+## Incident (2026-07-15): historical busy text wedged Herdr away-mode delivery
+
+During extended away-mode stretches, the primary home's read-only `state/.supervise-daemon.log` recorded repeated `inject deferred: supervisor pane busy (agent mid-turn)` lines and max-defer alarms, including `away-mode escalation undelivered 31726s` on 2026-07-14.
+The same log later recorded a 301s wedge on 2026-07-15 while the buffer and wake queue remained preserved.
+
+**Root cause.** `pane_is_busy` asked Herdr's native `agent.get` state first, but treated native `idle` as non-conclusive and then searched a 40-line scrollback tail for the busy regex.
+The supervisor regularly prints peeked crew output and diagnostic log text, so a historical `esc to interrupt` in that scrollback made an idle primary permanently appear mid-turn.
+The independent tmux submission failure had the same delivery symptom: Claude renders an empty composer as `❯` followed by U+00A0 NO-BREAK SPACE, while POSIX `[:space:]` does not trim U+00A0, so a cleared composer was misread as pending after Enter.
+
+**Fix.** The Herdr supervisor guard now trusts a legible native `idle` verdict just as it already trusts `busy`, and uses the scrollback regex only for `unknown` native state.
+The required confirmed-empty composer guard remains after that decision, so native idle never authorizes injection over real draft text or a dead-shell prompt.
+`bin/fm-composer-lib.sh` now owns U+00A0-aware edge trimming, which every composer classifier reaches through `fm_composer_classify_content` without discarding U+00A0 inside real text.
+
+**Verification (2026-07-15, herdr 0.7.3, GNU bash 5.2.21 on Linux).**
+No Herdr session, workspace, or pane lifecycle command ran for this verification.
+
+```text
+$ herdr --version
+herdr 0.7.3
+
+$ bash tests/fm-composer-lib.test.sh && bash tests/fm-daemon.test.sh
+ok - fm_composer_classify_content: Claude's U+00A0 prompt spacer is empty without discarding real text
+ok - fm_tmux_composer_state: bordered, bare agent, and Claude U+00A0 prompt rows read empty
+ok - pane_is_busy: Herdr native idle ignores historical busy signatures in scrollback
+ok - Herdr native idle delivers the buffered digest at max-defer despite historical busy text
+```
+
+The last deterministic simulation sets an escalation age above `FM_MAX_DEFER_SECS=60`, supplies native `idle`, a confirmed-empty composer, and historical `esc to interrupt` scrollback text, then confirms the digest submits and clears the buffer without a wedge marker.
 
 ## Native `pane.agent_status_changed` push escalation (immediate blocked wake)
 

--- a/tests/fm-composer-lib.test.sh
+++ b/tests/fm-composer-lib.test.sh
@@ -82,6 +82,15 @@ test_agent_glyphs_are_empty_bordered_and_bare() {
   pass "fm_composer_classify_content: agent prompt glyphs (❯ claude, › codex) read empty bordered or bare"
 }
 
+test_claude_nbsp_prompt_spacer_is_empty() {
+  local out
+  out=$(classify 0 $'❯\302\240')
+  [ "$out" = empty ] || fail "a Claude prompt followed by U+00A0 must read empty, got '$out'"
+  out=$(classify 0 $'❯\302\240real text')
+  [ "$out" = pending ] || fail "a Claude prompt with real text after U+00A0 must stay pending, got '$out'"
+  pass "fm_composer_classify_content: Claude's U+00A0 prompt spacer is empty without discarding real text"
+}
+
 # --- Empty content and idle placeholder -------------------------------------
 
 test_empty_content_is_empty() {
@@ -130,6 +139,7 @@ test_stripped_unbordered_content_uses_plain_content
 test_bare_shell_prompt_with_command_is_not_empty
 test_bordered_shell_glyph_is_empty
 test_agent_glyphs_are_empty_bordered_and_bare
+test_claude_nbsp_prompt_spacer_is_empty
 test_empty_content_is_empty
 test_idle_placeholder_is_empty
 test_idle_placeholder_case_mode_is_explicit

--- a/tests/fm-daemon.test.sh
+++ b/tests/fm-daemon.test.sh
@@ -846,7 +846,11 @@ test_tmux_composer_state_bordered_and_agent_rows_are_empty() {
   out=$(PATH="$fakebin:$PATH" FM_FAKE_TMUX_CAPTURE="$capture" FM_FAKE_TMUX_CURSOR_Y=0 \
     fm_tmux_composer_state "fakepane")
   [ "$out" = empty ] || fail "a bare codex '›' composer should read empty, got '$out'"
-  pass "fm_tmux_composer_state: a bordered composer box and bare agent glyphs (❯/›) still read empty"
+  printf '❯\302\240\n' > "$capture"
+  out=$(PATH="$fakebin:$PATH" FM_FAKE_TMUX_CAPTURE="$capture" FM_FAKE_TMUX_CURSOR_Y=0 \
+    fm_tmux_composer_state "fakepane")
+  [ "$out" = empty ] || fail "a Claude '❯' plus U+00A0 composer should read empty, got '$out'"
+  pass "fm_tmux_composer_state: bordered, bare agent, and Claude U+00A0 prompt rows read empty"
 }
 
 test_tmux_composer_state_requires_matching_box_borders() {
@@ -1524,13 +1528,15 @@ test_pane_is_busy_herdr_falls_back_to_capture_regex() {
   pass "pane_is_busy: herdr falls back to the shared regex-over-capture reader when native busy_state is unknown"
 }
 
-test_pane_is_busy_herdr_idle_falls_back_to_capture_regex() {
+test_pane_is_busy_herdr_idle_ignores_scrollback_busy_text() {
   (
     fm_backend_busy_state() { printf 'idle'; }
-    fm_backend_capture() { [ "$1" = herdr ] && [ "$2" = "default:w1:p2" ] || fail "unexpected capture args: $1 $2"; printf 'esc to interrupt\n'; }
-    pane_is_busy "default:w1:p2" herdr || fail "pane_is_busy should fall back to the regex-over-capture reader when busy_state is idle"
-  ) || fail "herdr idle capture-fallback pane_is_busy subshell failed"
-  pass "pane_is_busy: herdr corroborates native idle with the shared regex-over-capture reader"
+    fm_backend_capture() { printf 'quoted crew pane: esc to interrupt\n'; }
+    if pane_is_busy "default:w1:p2" herdr; then
+      fail "pane_is_busy must trust Herdr native idle over historical busy text"
+    fi
+  ) || fail "herdr native-idle pane_is_busy subshell failed"
+  pass "pane_is_busy: Herdr native idle ignores historical busy signatures in scrollback"
 }
 
 test_pane_is_busy_defaults_to_tmux_when_backend_omitted() {
@@ -1628,6 +1634,29 @@ test_inject_msg_herdr_submits_through_backend_dispatch() {
       || fail "inject_msg should succeed when send_text_submit confirms empty"
   ) || fail "herdr successful-submit inject_msg subshell failed"
   pass "inject_msg: dispatches busy-guard/composer-guard/submit through the herdr backend and succeeds on a confirmed empty composer"
+}
+
+test_herdr_idle_scrollback_delivers_at_max_defer() {
+  local dir state sent
+  dir=$(make_supercase herdr-idle-max-defer)
+  state="$dir/state"; sent="$dir/sent.log"; : > "$sent"
+  escalate_add "$state" "done: PR https://example.test/pr/400"
+  echo $(( $(date +%s) - 61 )) > "$state/.subsuper-escalations.since"
+  afk_enter "$state"
+  (
+    fm_backend_target_exists() { return 0; }
+    fm_backend_busy_state() { printf 'idle'; }
+    fm_backend_capture() { printf 'quoted crew pane: esc to interrupt\n'; }
+    fm_backend_composer_state() { printf 'empty'; }
+    fm_backend_send_text_submit() { printf '%s\n' "$3" > "$sent"; printf 'empty'; }
+    FM_SUPERVISOR_BACKEND=herdr FM_SUPERVISOR_TARGET="default:w1:p2" \
+      FM_ESCALATE_BATCH_SECS=99999 FM_MAX_DEFER_SECS=60 housekeeping "$state"
+  ) || fail "native-idle Herdr max-defer delivery did not complete"
+  [ ! -s "$state/.subsuper-escalations" ] || fail "native-idle Herdr delivery left the escalation buffered past max-defer"
+  [ ! -e "$state/.subsuper-inject-wedged" ] || fail "native-idle Herdr delivery raised a wedge marker"
+  grep -F "Supervisor escalate (1 event(s))" "$sent" >/dev/null \
+    || fail "native-idle Herdr max-defer delivery did not submit the digest"
+  pass "Herdr native idle delivers the buffered digest at max-defer despite historical busy text"
 }
 
 # Safety-critical (task fm-composer-shellglyph-safety): the away-mode injector
@@ -1740,11 +1769,12 @@ test_discover_supervisor_backend_precedence
 test_discover_supervisor_target_herdr
 test_pane_is_busy_herdr_native_busy_state
 test_pane_is_busy_herdr_falls_back_to_capture_regex
-test_pane_is_busy_herdr_idle_falls_back_to_capture_regex
+test_pane_is_busy_herdr_idle_ignores_scrollback_busy_text
 test_pane_is_busy_defaults_to_tmux_when_backend_omitted
 test_pane_input_pending_herdr_dispatch
 test_inject_msg_herdr_busy_guard_defers
 test_inject_msg_herdr_composer_guard_defers
 test_inject_msg_herdr_pane_gone_defers
 test_inject_msg_herdr_submits_through_backend_dispatch
+test_herdr_idle_scrollback_delivers_at_max_defer
 test_inject_msg_defers_on_dead_shell_unknown


### PR DESCRIPTION
## Diagnosis

The primary read-only daemon log recorded repeated `inject deferred: supervisor pane busy (agent mid-turn)` events and a 31,726-second max-defer wedge.

`pane_is_busy` asked Herdr for native state but then re-scanned scrollback when it reported `idle`; historical quoted `esc to interrupt` output therefore made an idle supervisor appear busy indefinitely.

A related tmux submit-verification bug treated Claude’s `❯` plus U+00A0 empty composer as pending because POSIX `[:space:]` does not trim U+00A0.

## Fix

- Treat a legible Herdr native `busy` or `idle` status as conclusive for the supervisor injection guard, while retaining regex fallback for `unknown`.
- Keep the confirmed-empty composer guard and type-once, Enter-only submit model unchanged.
- Add shared U+00A0-aware edge trimming without discarding U+00A0 inside typed text.
- Record the 2026-07-15 incident and verification in `docs/herdr-backend.md`.

## Tests and verification

- `bash tests/fm-composer-lib.test.sh`
- `bash tests/fm-daemon.test.sh`
- `PATH="$PWD/.tmp-bin:$PATH" bin/fm-lint.sh` with the repository-pinned ShellCheck 0.11.0 installer.
- Regression coverage includes native-idle scrollback containing `esc to interrupt`, a max-defer delivery simulation, and the Claude U+00A0 composer state.

No Herdr session, workspace, or pane lifecycle command was used.