### PR TITLE
fix(watch): canonicalize watcher-lock paths against case-insensitive-fs aliases

### DIFF
--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -50,14 +50,49 @@ fm_path_age() {
   echo $(( $(date +%s) - m ))
 }
 
+# fm_canonical_path <path>
+# Resolves <path> to its physical form (no symlinks, on-disk casing) via `cd` +
+# `pwd -P` - bash 3.2 safe, no GNU realpath dependency. On a case-insensitive
+# filesystem (macOS default), two differently-cased strings for the same
+# directory canonicalize to one identical string, so callers that compare
+# resolved paths instead of raw strings never false-negative on a casing or
+# symlink alias of the same location (e.g. a harness that cd'd via a
+# lower-cased path alias). Works for both directories and regular files: a
+# file's containing directory is resolved and its basename is reattached
+# unchanged, since a differently-cased leaf *filename* (as opposed to a
+# directory component in the chain) is not something this codebase's
+# fixed-literal script paths ever vary. Falls back to the original string
+# unresolved (and a non-zero return) when <path> is empty or its directory
+# cannot be entered (e.g. it does not exist), so a miss degrades to the prior
+# literal-string comparison rather than silently matching everything.
+fm_canonical_path() {
+  local path=$1 dir base resolved
+  [ -n "$path" ] || { printf '%s\n' "$path"; return 1; }
+  if [ -d "$path" ]; then
+    resolved=$(cd "$path" 2>/dev/null && pwd -P) || { printf '%s\n' "$path"; return 1; }
+    printf '%s\n' "$resolved"
+    return 0
+  fi
+  dir=$(dirname "$path")
+  base=$(basename "$path")
+  resolved=$(cd "$dir" 2>/dev/null && pwd -P) || { printf '%s\n' "$path"; return 1; }
+  printf '%s/%s\n' "$resolved" "$base"
+}
+
 fm_watcher_lock_matches_pid() {
   local state=$1 watch_path=$2 pid=$3 home=${4:-$FM_HOME} lockdir lock_home lock_path lock_identity current_identity
   lockdir="$state/.watch.lock"
   lock_home=$(cat "$lockdir/fm-home" 2>/dev/null || true)
   lock_path=$(cat "$lockdir/watcher-path" 2>/dev/null || true)
   lock_identity=$(cat "$lockdir/pid-identity" 2>/dev/null || true)
-  [ "$lock_home" = "$home" ] || return 1
-  [ "$lock_path" = "$watch_path" ] || return 1
+  [ -n "$lock_home" ] && [ -n "$lock_path" ] || return 1
+  # Compare canonical (physical, case-normalized) forms so a case-insensitive-
+  # filesystem alias of the recorded home/watcher path - or of the caller's own
+  # $home/$watch_path - still matches. Both sides are re-canonicalized here
+  # (not trusted from the writer) so this stays correct even against a lock
+  # written before this fix shipped.
+  [ "$(fm_canonical_path "$lock_home")" = "$(fm_canonical_path "$home")" ] || return 1
+  [ "$(fm_canonical_path "$lock_path")" = "$(fm_canonical_path "$watch_path")" ] || return 1
   [ -n "$lock_identity" ] || return 1
   current_identity=$(fm_pid_identity "$pid") || return 1
   [ "$current_identity" = "$lock_identity" ]

--- a/bin/fm-watch-arm.sh
+++ b/bin/fm-watch-arm.sh
@@ -68,8 +68,12 @@ clear_stale_recorded_watcher_lock() {
   lock_home=$(cat "$WATCH_LOCK/fm-home" 2>/dev/null || true)
   lock_path=$(cat "$WATCH_LOCK/watcher-path" 2>/dev/null || true)
   lock_identity=$(cat "$WATCH_LOCK/pid-identity" 2>/dev/null || true)
-  [ "$lock_home" = "$FM_HOME" ] || return 0
-  [ "$lock_path" = "$WATCH" ] || return 0
+  [ -n "$lock_home" ] && [ -n "$lock_path" ] || return 0
+  # Canonical comparison (see fm_watcher_lock_matches_pid): a case-insensitive-
+  # filesystem alias of this home or of $WATCH must still be recognized as this
+  # home's own recorded lock, not treated as a foreign one left alone.
+  [ "$(fm_canonical_path "$lock_home")" = "$(fm_canonical_path "$FM_HOME")" ] || return 0
+  [ "$(fm_canonical_path "$lock_path")" = "$(fm_canonical_path "$WATCH")" ] || return 0
   [ -n "$lock_identity" ] || return 0
   fm_lock_remove_path "$WATCH_LOCK" || true
 }

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -605,8 +605,12 @@ trap 'fm_lock_release "$WATCH_LOCK"' EXIT
 # ${BASHPID:-$$} from this same main shell). Read directly, never via a command
 # substitution, so it matches the stored holder pid for the self-eviction check.
 WATCHER_PID=${BASHPID:-$$}
-printf '%s\n' "$FM_HOME" > "$WATCH_LOCK/fm-home" || true
-printf '%s\n' "$WATCH_PATH" > "$WATCH_LOCK/watcher-path" || true
+# Record canonical (physical, case-normalized) forms so a reader on a
+# case-insensitive filesystem never has to reconcile a casing alias against
+# what this watcher actually saw; fm_watcher_lock_matches_pid re-canonicalizes
+# on read too, so a lock from an older, un-canonicalized writer still matches.
+printf '%s\n' "$(fm_canonical_path "$FM_HOME")" > "$WATCH_LOCK/fm-home" || true
+printf '%s\n' "$(fm_canonical_path "$WATCH_PATH")" > "$WATCH_LOCK/watcher-path" || true
 fm_pid_identity "$WATCHER_PID" > "$WATCH_LOCK/pid-identity" 2>/dev/null || true
 
 [ -e "$STATE/.last-heartbeat" ] || touch "$STATE/.last-heartbeat"

--- a/tests/fm-turnend-guard.test.sh
+++ b/tests/fm-turnend-guard.test.sh
@@ -19,6 +19,11 @@ set -u
 TMP_ROOT=$(fm_test_tmproot fm-turnend-guard)
 fm_git_identity fmtest fmtest@example.invalid
 
+# Node 24 warns when these test-only dynamic imports load tracked ESM plugins
+# from a clean checkout with no tracked .opencode/package.json. The warning is
+# unrelated to plugin output, which the assertions intentionally require empty.
+export NODE_NO_WARNINGS=1
+
 REQUIRED_REASON='resume supervision with bin/fm-watch-arm.sh as its own Claude Code background task'
 
 # --- PREDICATE: bin/fm-supervision-lib.sh -----------------------------------

--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -703,6 +703,138 @@ test_pid_identity_is_locale_invariant() {
   pass "fm_pid_identity is locale-invariant across LC_ALL/LC_TIME"
 }
 
+# make_path_alias <real-dir> <alias-name>: create a differently-named path to
+# the SAME physical directory as <real-dir>, so `cd + pwd -P` canonicalizes both
+# to one string. A symlink reproduces this deterministically on every OS and
+# filesystem (unlike relying on the host's case-folding behavior, which is only
+# sometimes present on macOS and never on a case-sensitive Linux CI runner), and
+# it exercises the identical fm_canonical_path codepath the real case-insensitive-
+# filesystem bug hits: `pwd -P` resolves a symlink alias exactly the way it
+# resolves a same-directory casing alias. Echoes the alias path.
+make_path_alias() {
+  local real=$1 name=$2 alias
+  alias="$(dirname "$real")/$name"
+  ln -s "$real" "$alias" || fail "could not create path alias for $real"
+  printf '%s\n' "$alias"
+}
+
+test_watcher_lock_matches_pid_tolerates_case_alias() {
+  # macOS's default filesystem is case-insensitive: the same directory is
+  # reachable via differently-cased path strings. fm-watch.sh and fm-watch-arm.sh
+  # each derive FM_HOME/WATCH via `cd + pwd`, which preserves whatever casing the
+  # caller's cwd had, so a lock written under one casing must still match a
+  # caller resolving the other casing. Modeled portably here with a symlink
+  # alias (see make_path_alias) so this asserts deterministically on any
+  # filesystem instead of skipping wherever case-folding isn't observed.
+  # Exercises the library comparator directly (both the fm-home and
+  # watcher-path fields) without spinning up a real watcher process.
+  local dir alias state lockdir pid identity out
+  dir=$(make_case CaseLibHome)
+  alias=$(make_path_alias "$dir" CaseLibHome-alias)
+  state="$dir/state"
+  lockdir="$state/.watch.lock"
+  mkdir -p "$lockdir"
+  pid=$$
+  identity=$(FM_STATE_OVERRIDE="$state" bash -c '. "$1"; fm_pid_identity "$2"' _ "$LIB" "$pid") || fail "could not identify test pid"
+  # The lock was written by a watcher that resolved home/watcher-path under the
+  # ORIGINAL path.
+  printf '%s\n' "$dir" > "$lockdir/fm-home"
+  printf '%s\n' "$WATCH" > "$lockdir/watcher-path"
+  printf '%s\n' "$identity" > "$lockdir/pid-identity"
+  # A caller resolves FM_HOME via the alias (the harness-set-differently-cased-
+  # cwd scenario) and asks whether the recorded lock is this home's own.
+  out=$(FM_STATE_OVERRIDE="$state" bash -c '
+    . "$1"
+    if fm_watcher_lock_matches_pid "$2" "$3" "$4" "$5"; then echo match; else echo nomatch; fi
+  ' _ "$LIB" "$state" "$WATCH" "$pid" "$alias")
+  [ "$out" = match ] || fail "fm_watcher_lock_matches_pid rejected a path-aliased fm-home (case bug not fixed)"
+  pass "fm_watcher_lock_matches_pid tolerates a path-aliased fm-home"
+}
+
+test_arm_attaches_healthy_watcher_case_aliased_home() {
+  # Reproduces the reported bug directly through fm-watch-arm.sh: a genuinely
+  # live, fresh watcher is seeded under FM_HOME's original path, then arm is
+  # invoked with FM_HOME set to an alias of that SAME physical directory (see
+  # make_path_alias - portable stand-in for a case-insensitive-filesystem
+  # casing alias). Pre-fix this string-mismatches, so healthy_watcher() returns
+  # false, arm reports FAILED, and it forks a duplicate child that loses the
+  # singleton race. Post-fix arm must attach to the existing watcher instead.
+  local dir alias state fakebin out armout wpid armpid i
+  dir=$(make_case CaseAliasHome)
+  alias=$(make_path_alias "$dir" CaseAliasHome-alias)
+  state="$dir/state"
+  fakebin="$dir/fakebin"
+  out="$dir/watch.out"
+  armout="$dir/arm.out"
+  PATH="$fakebin:$PATH" FM_HOME="$dir" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  wpid=$!
+  i=0
+  while [ "$i" -lt 60 ]; do
+    [ "$(cat "$state/.watch.lock/pid" 2>/dev/null || true)" = "$wpid" ] && [ -e "$state/.last-watcher-beat" ] && break
+    sleep 0.1
+    i=$((i + 1))
+  done
+  [ "$(cat "$state/.watch.lock/pid" 2>/dev/null || true)" = "$wpid" ] || fail "seed watcher (case-aliased home) did not take the lock"
+  PATH="$fakebin:$PATH" FM_HOME="$alias" FM_ARM_ATTACH_POLL=0.1 FM_ARM_CONFIRM_TIMEOUT=3 "$WATCH_ARM" > "$armout" &
+  armpid=$!
+  i=0
+  while [ "$i" -lt 80 ]; do
+    grep -qF "watcher: attached pid=$wpid" "$armout" 2>/dev/null && break
+    grep -qF 'watcher: FAILED' "$armout" 2>/dev/null && break
+    sleep 0.1
+    i=$((i + 1))
+  done
+  grep -qF "watcher: attached pid=$wpid" "$armout" || fail "case-aliased arm did not attach to the healthy watcher (case bug not fixed): $(cat "$armout")"
+  ! grep -qF 'watcher: FAILED' "$armout" || fail "case-aliased arm falsely reported FAILED for a healthy watcher"
+  ! grep -qF 'watcher: started' "$armout" || fail "case-aliased arm forked a duplicate child instead of attaching"
+  [ "$(cat "$state/.watch.lock/pid" 2>/dev/null || true)" = "$wpid" ] || fail "case-aliased arm disturbed the healthy watcher's lock"
+  is_live_non_zombie "$armpid" || fail "case-aliased arm exited while the seed watcher was still healthy"
+  kill "$wpid" 2>/dev/null || true
+  wait "$wpid" 2>/dev/null || true
+  wait_for_exit "$armpid" 80
+  pass "arm attaches to a healthy watcher despite a case-aliased FM_HOME (reports healthy, not FAILED)"
+}
+
+test_arm_restart_case_aliased_home_restarts_watcher() {
+  # Same alias setup, exercising --restart: pre-fix, watch_lock_matches_pid
+  # cannot match the case-aliased fm-home, so restart silently no-ops instead of
+  # stopping and relaunching this home's own watcher. Post-fix it must recognize
+  # the seed watcher as its own, stop it, and confirm a fresh one.
+  local dir alias state fakebin out armout wpid armpid i lock_pid
+  dir=$(make_case CaseAliasRestart)
+  alias=$(make_path_alias "$dir" CaseAliasRestart-alias)
+  state="$dir/state"
+  fakebin="$dir/fakebin"
+  out="$dir/watch.out"
+  armout="$dir/restart.out"
+  PATH="$fakebin:$PATH" FM_HOME="$dir" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  wpid=$!
+  i=0
+  while [ "$i" -lt 60 ]; do
+    [ "$(cat "$state/.watch.lock/pid" 2>/dev/null || true)" = "$wpid" ] && [ -e "$state/.last-watcher-beat" ] && break
+    sleep 0.1
+    i=$((i + 1))
+  done
+  [ "$(cat "$state/.watch.lock/pid" 2>/dev/null || true)" = "$wpid" ] || fail "seed watcher (case-aliased restart) did not take the lock"
+  PATH="$fakebin:$PATH" FM_HOME="$alias" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH_ARM" --restart > "$armout" &
+  armpid=$!
+  i=0
+  while [ "$i" -lt 80 ]; do
+    grep -qF 'watcher: started pid=' "$armout" 2>/dev/null && break
+    sleep 0.1
+    i=$((i + 1))
+  done
+  grep -qF 'watcher: started pid=' "$armout" || fail "case-aliased restart did not report a fresh started watcher (silent no-op, case bug not fixed): $(cat "$armout")"
+  lock_pid=$(cat "$state/.watch.lock/pid" 2>/dev/null || true)
+  { [ -n "$lock_pid" ] && [ "$lock_pid" != "$wpid" ] && kill -0 "$lock_pid" 2>/dev/null; } \
+    || fail "case-aliased restart did not replace the seed watcher pid with a live one (got '$lock_pid')"
+  is_live_non_zombie "$wpid" && fail "case-aliased restart did not stop the original seed watcher"
+  kill "$armpid" "$lock_pid" "$wpid" 2>/dev/null || true
+  wait "$armpid" 2>/dev/null || true
+  wait "$wpid" 2>/dev/null || true
+  pass "case-aliased --restart recognizes and restarts this home's own live watcher"
+}
+
 test_singleton_start
 test_pid_identity_is_locale_invariant
 test_stale_watch_lock_reclaimed
@@ -725,3 +857,6 @@ test_arm_hup_cleans_child_and_temp_output
 test_arm_propagates_immediate_wake_before_confirmation
 test_arm_waits_for_peer_beacon_after_child_stands_down
 test_arm_fails_loud_when_no_fresh_watcher_confirmable
+test_watcher_lock_matches_pid_tolerates_case_alias
+test_arm_attaches_healthy_watcher_case_aliased_home
+test_arm_restart_case_aliased_home_restarts_watcher


### PR DESCRIPTION
## Summary

Fixes a path-casing false negative in the watcher arm's healthy-watcher verification, observed live on 2026-07-15.

`bin/fm-watch-arm.sh` (via the shared `fm_watcher_lock_matches_pid` in `bin/fm-wake-lib.sh`) verified a healthy watcher by comparing the lock's recorded `fm-home`/`watcher-path` fields against its own resolved `$FM_HOME`/`$WATCH` with exact string equality. `SCRIPT_DIR`/`FM_HOME` are derived via `cd + pwd`, which preserves the caller's casing rather than resolving to a canonical form. On macOS's case-insensitive filesystem, the same directory is reachable via differently-cased paths (e.g. a harness that `cd`'d via a lowercased alias), so:

- `healthy_watcher()` returned false for a genuinely live, fresh watcher — the arm reported `watcher: FAILED - no live watcher with a fresh beacon` and forked a duplicate child that always lost the singleton race.
- `--restart` could not match the lock's pid via `watch_lock_matches_pid`, so it silently no-op'd instead of restarting this home's own watcher.

## Changes

- `bin/fm-wake-lib.sh` — new `fm_canonical_path` helper (`cd` + `pwd -P`, bash 3.2 safe, no GNU `realpath` dependency); `fm_watcher_lock_matches_pid` now compares canonicalized forms of both `fm-home` and `watcher-path` on both sides, so a case-insensitive-filesystem alias (or a stray symlink) of either path matches.
- `bin/fm-watch-arm.sh` — `clear_stale_recorded_watcher_lock` uses the same canonical comparison for both fields, so a case-aliased recorded lock is still recognized as this home's own.
- `bin/fm-watch.sh` — the watcher's lock writer now records canonical `fm-home`/`watcher-path` at lock time too, so writer and reader converge on one form. The reader still re-canonicalizes independently, so a lock written by an older, un-fixed watcher still matches.
- `tests/fm-watcher-lock.test.sh` — three new tests: a direct unit test of the fixed comparator tolerating a path alias, an end-to-end test that arm mode attaches to (rather than falsely fails) a healthy watcher despite a path-aliased `FM_HOME`, and an end-to-end test that `--restart` actually restarts (rather than silently no-ops on) this home's own watcher under the same alias condition. These use a symlink-based alias rather than relying on the host's case-folding behavior, since that's deterministic on every OS/filesystem (a literal case-fold alias never occurs on a case-sensitive Linux CI runner, and proved unreliable even in this PR's own validation sandbox) — it exercises the identical `fm_canonical_path` codepath the real bug hits. Verified all three fail against the pre-fix code and pass against the fix.

Lock semantics, singleton behavior, and beacon freshness rules are unchanged — only path comparison/normalization.

### Audit of sibling guards

Checked the other places that compare recorded watcher/session state by path for the same exact-string-comparison class:

- `bin/fm-session-start.sh`'s lock step delegates to `bin/fm-lock.sh`, which is PID-only (no path comparison) — not affected.
- `bin/fm-turnend-guard.sh` already calls the shared `fm_watcher_healthy`/`fm_watcher_lock_matches_pid` — it inherits this fix for free with no direct edit needed.
- `bin/fm-guard.sh` delegates to `bin/fm-supervision-lib.sh`, which only checks beacon mtime freshness, no path comparison — not affected.

## Test plan

- [x] `bin/fm-lint.sh` (pinned ShellCheck) clean
- [x] `tests/fm-watcher-lock.test.sh` full suite passes, including the three new tests
- [x] Confirmed the three new tests fail against the pre-fix code (via `git stash`) and pass against the fix
- [x] `tests/fm-daemon.test.sh`, `tests/fm-secondmate-sync.test.sh`, `tests/fm-turnend-guard.test.sh` unaffected
- [x] no-mistakes pipeline: review, test, document, and lint steps all passed (one test-step fix round applied `NODE_NO_WARNINGS=1` to `tests/fm-turnend-guard.test.sh` to suppress a pre-existing, unrelated Node.js `ExperimentalWarning` quirk — the same known flake noted in #594's test plan)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
