### PR TITLE
fix(orca): actionable stale_bootstrap readiness diagnostic with edge-state tests

### DIFF
--- a/bin/backends/orca.sh
+++ b/bin/backends/orca.sh
@@ -43,6 +43,14 @@ const runtime = r.runtime || {};
 const reachable = runtime.reachable ?? r.runtimeReachable;
 const state = runtime.state || r.runtimeState || "";
 if (reachable === true && state === "ready") process.exit(0);
+// stale_bootstrap: Orca reports the local server process is not alive, but its
+// bootstrap metadata file is still on disk. Surface a cross-platform recovery
+// hint (desktop app or a supervised `orca serve` service) instead of the generic
+// readiness line; fail-closed is unchanged - no auto-restart, no backend swap.
+if (state === "stale_bootstrap") {
+  console.error("error: Orca runtime is not running (state=stale_bootstrap): the local Orca process is not alive, but its bootstrap metadata remains. Start the Orca desktop app, or start your supervised orca serve service, then retry.");
+  process.exit(1);
+}
 console.error(`error: backend=orca requires a ready Orca runtime (reachable=${String(reachable)}, state=${state || "unknown"})`);
 process.exit(1);
 '

--- a/docs/orca-backend.md
+++ b/docs/orca-backend.md
@@ -109,7 +109,7 @@ Fake-Orca tests cover:
 
 - helper parsing for repo registration, worktree creation, verified implicit-terminal reuse, terminal creation, terminal sends, and worktree removal;
 - rejection of undocumented terminal-handle result shapes;
-- runtime readiness gating through `orca status --json`;
+- runtime readiness gating through `orca status --json`, including fail-closed handling of a reachable-but-non-ready state, an `ok:false` status, malformed status JSON, a failed status command, and an actionable cross-platform recovery message for the `stale_bootstrap` state (start the Orca desktop app or a supervised `orca serve` service);
 - `fm-spawn.sh --backend orca` metadata creation and harness launch;
 - `fm-peek.sh`, `fm-send.sh`, and `fm-crew-state.sh` routing through recorded Orca metadata;
 - slash-command popup placeholder handling that requires a second Enter before `fm-send.sh` reports submission;

--- a/tests/fm-backend-orca.test.sh
+++ b/tests/fm-backend-orca.test.sh
@@ -133,6 +133,72 @@ test_runtime_check_refuses_unready_orca_status() {
   pass "fm_backend_orca_runtime_check: fails closed when runtime is not ready"
 }
 
+test_runtime_check_refuses_reachable_non_ready_state() {
+  local out status
+  orca_case runtime-reachable-degraded
+  printf '{"ok":true,"result":{"runtime":{"reachable":true,"state":"degraded"}}}\n' > "$RESP/1.out"
+  out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" FM_ORCA_STATUS_RESPONSE=sequence \
+    bash -c '. "$0/bin/backends/orca.sh"; fm_backend_orca_runtime_check' "$ROOT" 2>&1 )
+  status=$?
+  [ "$status" -ne 0 ] || fail "runtime_check should fail when a reachable runtime is not in the ready state"
+  assert_contains "$out" "requires a ready Orca runtime" "runtime_check should explain the readiness requirement for a reachable-but-degraded runtime"
+  assert_contains "$out" "state=degraded" "runtime_check should name the non-ready state"
+  pass "fm_backend_orca_runtime_check: fails closed when a reachable runtime is not ready"
+}
+
+test_runtime_check_refuses_orca_ok_false_status() {
+  local out status
+  orca_case runtime-ok-false
+  printf '{"ok":false,"error":{"message":"runtime overloaded"}}\n' > "$RESP/1.out"
+  out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" FM_ORCA_STATUS_RESPONSE=sequence \
+    bash -c '. "$0/bin/backends/orca.sh"; fm_backend_orca_runtime_check' "$ROOT" 2>&1 )
+  status=$?
+  [ "$status" -ne 0 ] || fail "runtime_check should fail when Orca status reports ok:false"
+  assert_contains "$out" "Orca runtime is not ready" "runtime_check should name the readiness failure from an ok:false status"
+  assert_contains "$out" "runtime overloaded" "runtime_check should surface the Orca status error message"
+  pass "fm_backend_orca_runtime_check: fails closed and surfaces ok:false status errors"
+}
+
+test_runtime_check_refuses_malformed_status_json() {
+  local out status
+  orca_case runtime-malformed-json
+  printf 'this is not json {{{\n' > "$RESP/1.out"
+  out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" FM_ORCA_STATUS_RESPONSE=sequence \
+    bash -c '. "$0/bin/backends/orca.sh"; fm_backend_orca_runtime_check' "$ROOT" 2>&1 )
+  status=$?
+  [ "$status" -ne 0 ] || fail "runtime_check should fail when orca status emits malformed JSON"
+  assert_contains "$out" "invalid Orca status JSON" "runtime_check should report the JSON parse failure"
+  pass "fm_backend_orca_runtime_check: fails closed on malformed status JSON without crashing"
+}
+
+test_runtime_check_refuses_status_command_failure() {
+  local out status
+  orca_case runtime-cmd-failure
+  printf '1\n' > "$RESP/1.exit"
+  out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" FM_ORCA_STATUS_RESPONSE=sequence \
+    bash -c '. "$0/bin/backends/orca.sh"; fm_backend_orca_runtime_check' "$ROOT" 2>&1 )
+  status=$?
+  [ "$status" -ne 0 ] || fail "runtime_check should fail when 'orca status --json' exits non-zero"
+  assert_contains "$out" "'orca status --json' failed" "runtime_check should name the failed status command"
+  pass "fm_backend_orca_runtime_check: fails closed when the status command itself fails"
+}
+
+test_runtime_check_refuses_stale_bootstrap() {
+  local out status
+  orca_case runtime-stale-bootstrap
+  printf '{"ok":true,"result":{"runtime":{"reachable":false,"state":"stale_bootstrap"}}}\n' > "$RESP/1.out"
+  out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" FM_ORCA_STATUS_RESPONSE=sequence \
+    bash -c '. "$0/bin/backends/orca.sh"; fm_backend_orca_runtime_check' "$ROOT" 2>&1 )
+  status=$?
+  [ "$status" -ne 0 ] || fail "runtime_check should fail closed when Orca reports stale_bootstrap"
+  assert_contains "$out" "stale_bootstrap" "runtime_check should name the stale_bootstrap state"
+  assert_contains "$out" "not alive" "runtime_check should explain the local runtime is not alive"
+  assert_contains "$out" "desktop app" "runtime_check should point operators at the Orca desktop app"
+  assert_contains "$out" "orca serve" "runtime_check should point operators at a supervised orca serve service"
+  assert_not_contains "$out" "requires a ready Orca runtime" "stale_bootstrap should use the actionable message, not the generic readiness line"
+  pass "fm_backend_orca_runtime_check: emits an actionable cross-platform message for stale_bootstrap"
+}
+
 test_send_text_submit_verifies_empty_composer_after_enter() {
   local out
   orca_case send-submit
@@ -1277,6 +1343,11 @@ test_capture_falls_back_to_text_fields
 test_capture_fails_on_orca_error_json
 test_runtime_check_accepts_ready_orca_status
 test_runtime_check_refuses_unready_orca_status
+test_runtime_check_refuses_reachable_non_ready_state
+test_runtime_check_refuses_orca_ok_false_status
+test_runtime_check_refuses_malformed_status_json
+test_runtime_check_refuses_status_command_failure
+test_runtime_check_refuses_stale_bootstrap
 test_send_text_submit_verifies_empty_composer_after_enter
 test_send_text_submit_keeps_current_tail_when_limited
 test_send_text_submit_retries_when_composer_stays_pending


### PR DESCRIPTION
## Intent

Ship actionable Orca runtime-readiness diagnostics for the stale_bootstrap state plus deterministic readiness edge-state test coverage. When Orca status reports state=stale_bootstrap (the local server process dead but bootstrap metadata still on disk), the runtime gate must emit a cross-platform actionable message explaining the runtime is not alive and pointing operators to start the Orca desktop app or their supervised orca serve service, instead of the generic readiness line. The fail-closed requirement (reachable=true AND state=ready) is preserved: no auto-restart, no silent backend swap, and no host-specific systemd unit name encoded as a universal default. Add deterministic fake-Orca tests covering reachable-but-non-ready state, ok:false status, malformed status JSON, status command failure, and the stale_bootstrap actionable message. Production changes limited to bin/backends/orca.sh; test additions to tests/fm-backend-orca.test.sh. Branched from origin/main so the upstream PR contains only this change.

## What Changed

- The Orca runtime readiness gate in `bin/backends/orca.sh` now emits a cross-platform, actionable recovery message when `orca status --json` reports `state=stale_bootstrap` (start the Orca desktop app, or start a supervised `orca serve` service, then retry) instead of the generic readiness line; the fail-closed gate (`reachable=true` AND `state=ready`) is unchanged — no auto-restart and no backend swap.
- Added five deterministic fake-Orca runtime-readiness tests to `tests/fm-backend-orca.test.sh` covering a reachable-but-non-ready state, an `ok:false` status, malformed status JSON, a failed status command, and the actionable `stale_bootstrap` message.
- Updated `docs/orca-backend.md` to document the expanded runtime-readiness test coverage.

## Risk Assessment

✅ Low: Small, well-bounded additive branch in an error-message path that preserves the existing exit code 1; the only caller checks the exit code (not message text), and five new deterministic tests cover the intended behavior and edge states.

## Testing

Completed 1 recorded test check.

- Outcome: ⚠️ 1 error across 1 run (17m3s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Test** - 1 error</summary>

- 🚨 tests failed with exit code 1
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
