### PR TITLE
feat: PR-screenshots as an isolated, upstream-compatible skill + script

### DIFF
--- a/.agents/skills/pr-screenshots/SKILL.md
+++ b/.agents/skills/pr-screenshots/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: pr-screenshots
+description: Agent-only playbook for embedding UI screenshots in a ship PR via GitHub release assets. Use before dispatching a UI ship task on a PR-producing project, to add the screenshot-capture step to the brief by hand, and after that PR opens, to embed the crewmate's data/<id>/screenshots.md into the PR body. Relevant only for UI ship work.
+user-invocable: false
+metadata:
+  internal: true
+---
+
+# pr-screenshots
+
+Firstmate's standard for UI ship work is that the PR demonstrates the change with screenshots, so a reviewer sees the result without checking out the branch.
+This skill owns when and how firstmate applies that standard.
+`bin/fm-pr-screenshots.sh` (its header comment and `--help`) owns the mechanics, and `docs/pr-screenshots.md` owns the mechanism narrative and the empirical inline-rendering record.
+
+The feature is deliberately isolated so it never collides with an upstream change: the helper, this skill, `docs/pr-screenshots.md`, and the colocated `tests/fm-pr-screenshots.test.sh` are the whole feature.
+Nothing about it lives inline in upstream-owned core files beyond this skill's one-line trigger in `AGENTS.md` section 13.
+
+## When it applies
+
+A ship task whose change is visible in the UI, on a `direct-PR` or `no-mistakes` project: both produce a PR to embed images into.
+`local-only` projects have no PR, so this skill never applies to them, and non-UI work never applies either.
+
+## At dispatch: add the capture step to the brief by hand
+
+`bin/fm-brief.sh` deliberately does not inject this step, so add it yourself when you dispatch a UI ship task on a PR-producing mode.
+After scaffolding the brief, append a `# UI screenshots` section to `data/<id>/brief.md` before spawning, using the same absolute firstmate-home paths that brief already uses for its status file.
+
+Shared wording for both PR modes, with `<firstmate-home>` and `<id>` filled in:
+
+```
+# UI screenshots
+If this task changes the UI, capture the key states of your change with the project's own browser tooling (Playwright or chrome-devtools-axi) and save the images under <firstmate-home>/data/<id>/screenshots/ (a sanctioned path outside your worktree, like the status file).
+Then run <firstmate-home>/bin/fm-pr-screenshots.sh --namespace fm/<id> <firstmate-home>/data/<id>/screenshots/* from your worktree and <delivery line>.
+This applies only to UI changes; skip it entirely for non-UI work.
+```
+
+Fill `<delivery line>` from the project mode:
+
+- `direct-PR`: `include its printed markdown in your gh-axi pr create --body-file so the images render in the PR body`.
+- `no-mistakes`: `save its printed markdown to <firstmate-home>/data/<id>/screenshots.md; firstmate embeds that block into the pull request after the pipeline opens it`.
+
+Keep it proportionate: the section is conditional on the change touching the UI, so a task that turns out to be non-UI simply skips it.
+
+## After the PR opens: embed (no-mistakes only)
+
+For a `no-mistakes` UI PR the crewmate leaves the markdown at `data/<id>/screenshots.md` and never touches the PR body, because a PR-body edit is a project write that firstmate owns.
+Once the PR is open, embed it yourself as part of normal PR handling:
+
+```
+bin/fm-pr-screenshots.sh embed <full GitHub PR URL> data/<id>/screenshots.md
+```
+
+The block carries a `<!-- fm-pr-screenshots -->` marker, so `embed` is idempotent and a re-run is a safe no-op.
+If `data/<id>/screenshots.md` is absent, the change had no UI to capture, so skip the embed.
+A `direct-PR` crewmate has already folded the markdown into its own PR body, so firstmate never runs `embed` for that mode.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -767,6 +767,7 @@ These skills are not captain-invocable; they are conditional operating reference
 - `fmx-respond` - load on an `x-mention <request_id>` `check:` wake to handle the mention, on an `x-mode-error ...` `check:` wake to report the X-mode configuration blocker, and on any milestone or terminal wake for an X-mode-linked task before posting its completion follow-up; relevant only when X mode is on.
 - `firstmate-codexapp` - load before coordinating a visible Codex Desktop thread, evaluating a Codex App backend request, or reconciling Codex Desktop host-tool smoke evidence for Firstmate work.
 - `firstmate-coding-guidelines` - load before changing firstmate's shared, tracked material, as defined by section 1's list, whether editing directly or briefing a crewmate for a firstmate-repo task.
+- `pr-screenshots` - load before dispatching a UI ship task on a PR-producing project, to add the screenshot-capture step to the brief, and after that PR opens, to embed the crewmate's `data/<id>/screenshots.md` into the PR body.
 
 ## 14. X mode
 

--- a/bin/fm-pr-screenshots.sh
+++ b/bin/fm-pr-screenshots.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+# Turn captured UI screenshots into PR-embeddable markdown by uploading them as
+# GitHub *release assets* and printing image markdown that renders inline in a
+# pull request or issue body. It serves both delivery paths: a direct-PR
+# crewmate folds the printed markdown into its own `gh-axi pr create
+# --body-file`, while for a no-mistakes PR the crewmate produces the markdown
+# during its turn and firstmate appends it to the opened PR body with `embed`.
+#
+# Why release assets (empirical record and versions in docs/pr-screenshots.md):
+# GitHub renders ![](https://github.com/<o>/<r>/releases/download/<tag>/<file>)
+# as a direct inline <img>, and browsers decode and paint the bytes even though
+# GitHub serves the asset as application/octet-stream with an attachment
+# disposition. Assets live in GitHub release storage, NOT the git object store,
+# so nothing bloats the code branches or main history, no new repo or external
+# host is needed, and the upload works with a normal `repo`-scoped token (no
+# browser session, unlike GitHub's web user-attachments upload).
+#
+# Modes:
+#   fm-pr-screenshots.sh [options] <image>...
+#       Upload each image as a release asset under a dedicated prerelease and
+#       print PR-embeddable markdown to stdout.
+#       --repo <owner/repo>  target repo (default: parsed from the cwd git
+#                            `origin` remote)
+#       --tag <tag>          release holding the assets (default: fm-pr-assets)
+#       --namespace <ns>     asset-filename prefix keeping assets unique across
+#                            tasks (default: sanitized current git branch, e.g.
+#                            fm/<id> -> fm-<id>)
+#       --title <text>       markdown section heading (default: Screenshots)
+#       --no-heading         emit only the image lines, no heading
+#       --dry-run            skip all network; print the exact markdown built
+#                            from deterministic release-download URLs
+#
+#   fm-pr-screenshots.sh embed [--dry-run] <pr-url> <markdown-file>
+#       Append <markdown-file> to the PR's current body (fetch body, concatenate,
+#       `gh-axi pr edit --body-file`). Idempotent: skips if the marker is already
+#       in the body. --dry-run prints the composed body instead of editing.
+#
+# The download URL is fully deterministic from (owner, repo, tag, asset-name),
+# so --dry-run prints byte-identical markdown to a live run without uploading.
+# Uploads and PR-body edits are project writes, so a crewmate (never firstmate)
+# runs the upload mode; firstmate runs only `embed`, a PR-body edit that is part
+# of its normal PR handling.
+set -eu
+
+MARKER='<!-- fm-pr-screenshots -->'
+
+usage() {
+  # Lines 2-42 are the header comment block; line 43 begins the code (set -eu).
+  sed -n '2,42p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+# Collapse anything outside the GitHub-safe asset-name set to a single dash.
+sanitize() {
+  printf '%s' "$1" | LC_ALL=C sed 's/[^A-Za-z0-9._-]/-/g'
+}
+
+# Parse owner/repo from the cwd git `origin` remote, ssh or https form.
+derive_repo() {
+  local url
+  url=$(git remote get-url origin 2>/dev/null) || return 1
+  url=${url%.git}
+  case "$url" in
+    git@github.com:*)          printf '%s\n' "${url#git@github.com:}" ;;
+    ssh://git@github.com/*)    printf '%s\n' "${url#ssh://git@github.com/}" ;;
+    https://github.com/*)      printf '%s\n' "${url#https://github.com/}" ;;
+    *) return 1 ;;
+  esac
+}
+
+parse_pr_url() {
+  local url=$1
+  if [[ "$url" =~ ^https://github\.com/([A-Za-z0-9][A-Za-z0-9-]{0,38})/([A-Za-z0-9._-]+)/pull/([0-9]+)/?$ ]] \
+     && [[ "${BASH_REMATCH[1]}" != *- ]]; then
+    PR_OWNER="${BASH_REMATCH[1]}"
+    PR_REPO="${BASH_REMATCH[2]}"
+    PR_NUMBER="${BASH_REMATCH[3]}"
+    return 0
+  fi
+  echo "error: PR URL must match https://github.com/<owner>/<repo>/pull/<number> (got: $url)" >&2
+  return 1
+}
+
+embed_mode() {
+  local dry=0
+  if [ "${1:-}" = --dry-run ]; then dry=1; shift; fi
+  local pr_url=${1:-} md_file=${2:-}
+  if [ -z "$pr_url" ] || [ -z "$md_file" ]; then
+    echo "usage: fm-pr-screenshots.sh embed [--dry-run] <pr-url> <markdown-file>" >&2
+    exit 2
+  fi
+  [ -f "$md_file" ] || { echo "error: markdown file not found: $md_file" >&2; exit 1; }
+  parse_pr_url "$pr_url" || exit 1
+
+  # Distinguish a genuinely empty body (read succeeds, empty string) from a
+  # failed read (network or rate limit). Swallowing the failure would let an
+  # empty `current` overwrite the whole PR description with just the block.
+  local current
+  if ! current=$(gh pr view "$PR_NUMBER" --repo "$PR_OWNER/$PR_REPO" --json body -q .body 2>/dev/null); then
+    echo "error: could not read the current body of $PR_OWNER/$PR_REPO#$PR_NUMBER (network or rate limit?); refusing to overwrite the PR body" >&2
+    exit 1
+  fi
+  if printf '%s' "$current" | grep -qF "$MARKER"; then
+    echo "already embedded (marker present in PR body); nothing to do" >&2
+    return 0
+  fi
+
+  local body_file
+  body_file=$(mktemp)
+  # Preserve the existing body, then a blank separator, then the screenshots block.
+  { printf '%s' "$current"; printf '\n\n'; cat "$md_file"; } > "$body_file"
+  if [ "$dry" -eq 1 ]; then
+    cat "$body_file"
+    rm -f "$body_file"
+    return 0
+  fi
+  gh-axi pr edit "$PR_NUMBER" --repo "$PR_OWNER/$PR_REPO" --body-file "$body_file"
+  rm -f "$body_file"
+}
+
+upload_mode() {
+  local repo="" tag="fm-pr-assets" namespace="" title="Screenshots" heading=1 dry=0
+  local images=()
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --repo)        repo=${2:?--repo needs a value}; shift 2 ;;
+      --repo=*)      repo=${1#*=}; shift ;;
+      --tag)         tag=${2:?--tag needs a value}; shift 2 ;;
+      --tag=*)       tag=${1#*=}; shift ;;
+      --namespace)   namespace=${2:?--namespace needs a value}; shift 2 ;;
+      --namespace=*) namespace=${1#*=}; shift ;;
+      --title)       title=${2:?--title needs a value}; shift 2 ;;
+      --title=*)     title=${1#*=}; shift ;;
+      --no-heading)  heading=0; shift ;;
+      --dry-run)     dry=1; shift ;;
+      -h|--help)     usage; exit 0 ;;
+      --)            shift; while [ $# -gt 0 ]; do images+=("$1"); shift; done ;;
+      -*)            echo "error: unknown option: $1" >&2; exit 2 ;;
+      *)             images+=("$1"); shift ;;
+    esac
+  done
+  [ ${#images[@]} -gt 0 ] || { echo "error: no image files given" >&2; usage >&2; exit 2; }
+
+  if [ -z "$repo" ]; then
+    repo=$(derive_repo) || { echo "error: --repo not given and could not derive owner/repo from the cwd git origin remote" >&2; exit 1; }
+  fi
+  [[ "$repo" =~ ^[A-Za-z0-9][A-Za-z0-9-]*/[A-Za-z0-9._-]+$ ]] || { echo "error: --repo must be owner/repo (got: $repo)" >&2; exit 1; }
+
+  if [ -z "$namespace" ]; then
+    local branch
+    branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+    if [ -n "$branch" ] && [ "$branch" != HEAD ]; then namespace=$branch; fi
+  fi
+  [ -n "$namespace" ] || { echo "error: --namespace not given and no current git branch to derive it from" >&2; exit 1; }
+  local ns
+  ns=$(sanitize "$namespace")
+
+  local img
+  for img in "${images[@]}"; do
+    [ -f "$img" ] || { echo "error: image not found: $img" >&2; exit 1; }
+  done
+
+  # Stage each image under its final asset name so the upload controls the
+  # asset name (and thus the URL); gh release upload names an asset after the
+  # uploaded file's basename, not a #label. Refuse duplicate asset names.
+  local staging
+  staging=$(mktemp -d)
+  # shellcheck disable=SC2064
+  trap "rm -rf '$staging'" EXIT
+  local staged=() lines=() seen=" "
+  for img in "${images[@]}"; do
+    local base asset alt url
+    base=$(basename "$img")
+    asset="${ns}-$(sanitize "$base")"
+    case "$seen" in
+      *" $asset "*) echo "error: two images map to the same asset name '$asset'; rename so basenames are unique" >&2; exit 1 ;;
+    esac
+    seen="$seen$asset "
+    alt="${base%.*}"
+    url="https://github.com/$repo/releases/download/$tag/$asset"
+    cp "$img" "$staging/$asset"
+    staged+=("$staging/$asset")
+    lines+=("![${alt}](${url})")
+  done
+
+  if [ "$dry" -eq 0 ]; then
+    if ! gh release view "$tag" --repo "$repo" >/dev/null 2>&1; then
+      # Prerelease so it never claims the repo's "Latest release" slot. Tolerate
+      # a concurrent creator: the upload below still lands on the now-existing release.
+      gh release create "$tag" --repo "$repo" --prerelease \
+        --title "Firstmate PR screenshots" \
+        --notes "Automated asset store for screenshots embedded in pull requests by firstmate. Not a software release." \
+        >/dev/null 2>&1 || true
+    fi
+    gh release upload "$tag" --repo "$repo" --clobber "${staged[@]}" >/dev/null
+  fi
+
+  if [ "$heading" -eq 1 ]; then
+    printf '## %s\n\n' "$title"
+  fi
+  printf '%s\n' "$MARKER"
+  local line
+  for line in "${lines[@]}"; do
+    printf '%s\n' "$line"
+  done
+}
+
+case "${1:-}" in
+  embed)      shift; embed_mode "$@" ;;
+  -h|--help)  usage; exit 0 ;;
+  *)          upload_mode "$@" ;;
+esac

--- a/docs/pr-screenshots.md
+++ b/docs/pr-screenshots.md
@@ -1,0 +1,84 @@
+# PR screenshots for UI work
+
+Firstmate's standard for UI ship work is that the PR demonstrates the change with screenshots, so a reviewer sees the result without checking out the branch.
+`bin/fm-pr-screenshots.sh` is the helper that makes this possible; its header comment and `--help` are the authoritative mechanics.
+The `pr-screenshots` agent-only skill owns when firstmate applies this and the exact dispatch and embed steps.
+This doc is the mechanism narrative and the empirical record behind the mechanism choice.
+
+## The mechanism: GitHub release assets
+
+The hard part is getting a durable image URL that GitHub markdown renders inline via `![](url)`.
+`gh-axi` has no attachment/upload verb, and GitHub's web drag-and-drop upload (`github.com/user-attachments/assets/...`) needs a browser session cookie plus CSRF token, not a `repo`-scoped token, so a CLI cannot drive it.
+
+The helper uploads each screenshot as a GitHub **release asset** on a dedicated `fm-pr-assets` prerelease in the target repo, and references the stable URL `https://github.com/<owner>/<repo>/releases/download/<tag>/<file>`.
+Release assets live in GitHub's release storage, not the git object store, so they add zero bloat to code branches or `main` history, need no new repo or external host, and upload with the ordinary `repo` token scope.
+The URL is fully deterministic from `(owner, repo, tag, asset-name)`, which is why `--dry-run` prints byte-identical markdown to a live run without uploading.
+
+Assets in the single shared `fm-pr-assets` release are namespaced by a per-task prefix (the sanitized `fm/<id>` branch by default) so parallel tasks never collide; `gh release upload --clobber` makes a re-run overwrite its own assets.
+The release is a prerelease so it never claims the repo's "Latest release" slot.
+The assets must persist for as long as the PR references them, exactly like any other image-hosting choice.
+
+## Where screenshots live and how each path embeds them
+
+A crewmate doing UI work captures the key states of its change with the project's own browser tooling (Playwright or chrome-devtools-axi) and leaves the images under `data/<id>/screenshots/` in the firstmate home, never committed into the product repo's branch.
+The upload and any PR-body edit are project writes, so the crewmate (never firstmate) runs the upload, while firstmate only ever runs `embed`, a PR-body edit that is part of its normal PR handling.
+That split drives the two delivery paths, whose exact dispatch and embed steps the `pr-screenshots` skill owns:
+
+- direct-PR: the crewmate folds the helper's markdown into its own `gh-axi pr create --body-file`.
+- no-mistakes: the crewmate saves the markdown to `data/<id>/screenshots.md`, and firstmate embeds that block into the PR body after the pipeline opens it.
+
+The emitted block carries a `<!-- fm-pr-screenshots -->` marker so `embed` is idempotent and never double-appends.
+
+## Empirical verification
+
+Verified 2026-07-07 with gh 2.81.0, gh-axi 0.1.24, Google Chrome 148.0.7778.215, shellcheck 0.10.0, against a throwaway public repo `MabezDev/fm-screenshot-render-probe`.
+
+### A release-asset URL serves the bytes, but with surprising headers
+
+`curl -sIL https://github.com/<owner>/<repo>/releases/download/v-probe/probe.png`:
+
+```
+HTTP/2 302
+location: https://release-assets.githubusercontent.com/.../...?...  (short-lived, signed)
+HTTP/2 200
+content-type: application/octet-stream
+content-disposition: attachment; filename=probe.png
+content-length: 139
+```
+
+The stable `github.com/.../releases/download/...` URL 302-redirects to a short-lived signed URL that serves the bytes as `application/octet-stream` with an `attachment` disposition, not `image/png`.
+The stable top URL itself does not expire; it re-issues a fresh signed redirect on each request.
+
+### GitHub renders the URL as a direct inline image
+
+`![screenshot](<release-download-url>)` in an issue body, read back via `Accept: application/vnd.github.full+json`, produced `body_html`:
+
+```html
+<p dir="auto"><a target="_blank" rel="noopener noreferrer" href="https://github.com/.../releases/download/v-probe/probe.png"><img src="https://github.com/.../releases/download/v-probe/probe.png" alt="screenshot" style="max-width: 100%;"></a></p>
+```
+
+The same markdown in a real pull request body renders identically (issues and PRs share the same GitHub-flavored-markdown renderer):
+
+```html
+<p dir="auto"><a ... href=".../releases/download/fm-pr-assets/fm-helper-e2e-login.png"><img src=".../releases/download/fm-pr-assets/fm-helper-e2e-login.png" alt="login" style="max-width: 100%;"></a></p>
+```
+
+The URL becomes a direct `<img src>` (not camo-proxied, not stripped to a plain link), because it is a github.com URL that GitHub trusts.
+
+### A browser decodes the octet-stream bytes and paints the image
+
+The `application/octet-stream` content-type and `attachment` disposition do not stop an `<img>` element from decoding the bytes.
+Rendering `<img src="<release-download-url>" width="120" height="40">` on a white page in headless `google-chrome-stable --headless=new --screenshot` and analyzing the pixels showed the full 120x40 image region painted with the image's color (4800 of 4800 pixels), zero broken/white pixels.
+Screenshotting the actual public issue page confirmed the image is visible inline to an anonymous viewer.
+
+### Private repos need a logged-in reviewer session
+
+The `releases/download/<tag>/<file>` URL that the inline `<img>` points at authorizes off the viewer's github.com browser session, not a token.
+On a private repo it returns 404 to both unauthenticated and token-authenticated (PAT) requests, so command-line or CI tooling cannot fetch the image; the asset itself is still retrievable with auth through the release-assets API.
+A human reviewer viewing the PR while logged in does load it: the image renders inline, captain-verified in-browser on a private repo on 2026-07-08.
+So the standard works for human reviewers on private (the firstmate default) and public repos alike; only unauthenticated or token-only tooling cannot fetch the rendered image.
+
+### Conclusion
+
+Release-asset URLs render inline in PR and issue bodies reliably for a logged-in reviewer (captain-verified on both public and private repos), with no git bloat, no new repo, and token-only upload auth.
+This is why the helper uses release assets rather than an orphan assets branch (git object-store bloat), the web user-attachments upload (browser-session auth, fragile), or a separate assets repo (new hosting).

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -64,6 +64,7 @@ The shared no-mistakes gate refusal used by `fm-spawn.sh`, `fm-send.sh`, and `fm
 | `fm-peek.sh`             | Print a bounded tail of a crewmate endpoint                                          |
 | `fm-pr-check.sh`         | Record `pr=` and `pr_head=` for a PR-ready task, then arm the watcher's merge poll   |
 | `fm-pr-merge.sh`         | Record PR metadata, then merge a task's PR from its full GitHub URL                  |
+| `fm-pr-screenshots.sh`   | Upload UI screenshots as GitHub release assets and print PR-embeddable markdown, or `embed` it into an existing PR body; `--dry-run` prints the deterministic markdown offline (docs/pr-screenshots.md) |
 | `fm-promote.sh`          | Promote a scout task in place to a protected ship task                               |
 | `fm-teardown.sh`         | Fail-closed teardown: return landed ship worktrees, require scout reports, retire secondmate homes |
 | `fm-harness.sh`          | Detect the running harness and resolve crew or secondmate harness, model, and effort |

--- a/tests/fm-pr-screenshots.test.sh
+++ b/tests/fm-pr-screenshots.test.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# Tests for bin/fm-pr-screenshots.sh: the helper that uploads UI screenshots as
+# GitHub release assets and prints PR-embeddable markdown, plus the `embed` mode
+# that appends that markdown to an existing PR body for the no-mistakes path.
+#
+# Matrix:
+#   (a) --dry-run makes zero network calls and prints deterministic URLs
+#   (b) upload creates the release when missing, then uploads with --clobber and
+#       namespaced asset filenames, and prints matching markdown
+#   (c) upload reuses an existing release (no create call)
+#   (d) --repo is derived from the cwd git origin remote when omitted
+#   (e) --namespace is derived from the current git branch when omitted
+#   (f) --no-heading drops the heading but keeps the idempotency marker
+#   (g) two images with the same basename fail (asset-name collision)
+#   (h) a missing image file fails
+#   (i) embed appends the block to the PR body via gh-axi pr edit --body-file
+#   (j) embed is idempotent when the marker is already in the body (no edit call)
+#   (k) embed --dry-run prints the composed body and makes no edit call
+#   (m) embed aborts on a failed body read instead of overwriting the body
+#   (l) an unknown option fails with a usage error
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+fm_git_identity fmtest fmtest@example.invalid
+
+SCRIPT="$ROOT/bin/fm-pr-screenshots.sh"
+TMP_ROOT=$(fm_test_tmproot fm-pr-screenshots-tests)
+
+# Build a sandbox with a fakebin whose gh/gh-axi mocks log every invocation.
+# `release-exists` toggles the gh release view exit code; `pr-body.txt` feeds
+# the gh pr view body read; the gh-axi mock captures any --body-file it is given.
+make_case() {
+  local dir="$TMP_ROOT/$1" fakebin
+  fakebin="$dir/fakebin"
+  mkdir -p "$fakebin"
+  cat > "$fakebin/gh" <<'SH'
+#!/usr/bin/env bash
+printf 'gh %s\n' "$*" >> "$FM_TEST_LOG"
+case "${1:-} ${2:-}" in
+  "release view") [ -f "$FM_TEST_CASE/release-exists" ] && exit 0 || exit 1 ;;
+  "pr view")
+    [ -f "$FM_TEST_CASE/pr-read-fails" ] && exit 1
+    cat "$FM_TEST_CASE/pr-body.txt" 2>/dev/null || true; exit 0 ;;
+esac
+exit 0
+SH
+  cat > "$fakebin/gh-axi" <<'SH'
+#!/usr/bin/env bash
+printf 'gh-axi %s\n' "$*" >> "$FM_TEST_LOG"
+prev=
+for a in "$@"; do
+  [ "$prev" = "--body-file" ] && cp "$a" "$FM_TEST_CASE/edited-body.txt"
+  prev=$a
+done
+exit 0
+SH
+  chmod +x "$fakebin/gh" "$fakebin/gh-axi"
+  printf '%s\n' "$dir"
+}
+
+# run_case <case-dir> [cwd] -- <helper args...>: run the helper with the mocks on
+# PATH, capturing stdout into RUN_OUT and the exit code into RUN_CODE.
+run_case() {
+  local dir=$1 cwd=$2; shift 2
+  [ "$1" = "--" ] && shift
+  export FM_TEST_LOG="$dir/calls.log" FM_TEST_CASE="$dir"
+  : > "$FM_TEST_LOG"
+  RUN_OUT=$(cd "$cwd" && PATH="$dir/fakebin:$PATH" "$SCRIPT" "$@" 2>"$dir/err.txt")
+  RUN_CODE=$?
+}
+
+# --- (a) dry-run: zero network, deterministic URLs --------------------------
+dir=$(make_case dryrun)
+printf 'x' > "$dir/login.png"
+printf 'x' > "$dir/home screen.png"
+run_case "$dir" "$dir" -- --dry-run --repo acme/widget --namespace fm/login-x1 \
+  "$dir/login.png" "$dir/home screen.png"
+expect_code 0 "$RUN_CODE" "dry-run exits 0"
+assert_contains "$RUN_OUT" "## Screenshots" "dry-run emits heading"
+assert_contains "$RUN_OUT" "<!-- fm-pr-screenshots -->" "dry-run emits marker"
+assert_contains "$RUN_OUT" \
+  "![login](https://github.com/acme/widget/releases/download/fm-pr-assets/fm-login-x1-login.png)" \
+  "dry-run emits deterministic login URL"
+assert_contains "$RUN_OUT" \
+  "![home screen](https://github.com/acme/widget/releases/download/fm-pr-assets/fm-login-x1-home-screen.png)" \
+  "dry-run sanitizes spaces in the asset name but keeps the alt text"
+[ ! -s "$dir/calls.log" ] || fail "dry-run must make no gh/gh-axi calls"$'\n'"$(cat "$dir/calls.log")"
+pass "dry-run: no network, deterministic sanitized URLs"
+
+# --- (b) upload creates release when missing, uploads namespaced + clobber ---
+dir=$(make_case upload_create)
+printf 'x' > "$dir/login.png"
+run_case "$dir" "$dir" -- --repo acme/widget --namespace fm/login-x1 "$dir/login.png"
+expect_code 0 "$RUN_CODE" "upload exits 0"
+assert_grep "release view fm-pr-assets --repo acme/widget" "$dir/calls.log" "checks for the release"
+assert_grep "release create fm-pr-assets" "$dir/calls.log" "creates the release when missing"
+assert_grep "--prerelease" "$dir/calls.log" "creates a prerelease"
+assert_grep "release upload fm-pr-assets --repo acme/widget --clobber" "$dir/calls.log" "uploads with --clobber"
+assert_grep "fm-login-x1-login.png" "$dir/calls.log" "uploads under the namespaced asset name"
+assert_contains "$RUN_OUT" \
+  "https://github.com/acme/widget/releases/download/fm-pr-assets/fm-login-x1-login.png" \
+  "prints the matching URL"
+pass "upload: creates release then uploads namespaced asset with --clobber"
+
+# --- (c) upload reuses an existing release ----------------------------------
+dir=$(make_case upload_reuse)
+touch "$dir/release-exists"
+printf 'x' > "$dir/a.png"
+run_case "$dir" "$dir" -- --repo acme/widget --namespace fm/x2 "$dir/a.png"
+expect_code 0 "$RUN_CODE" "upload (reuse) exits 0"
+assert_no_grep "release create" "$dir/calls.log" "does not create a release that already exists"
+assert_grep "release upload fm-pr-assets" "$dir/calls.log" "still uploads to the existing release"
+pass "upload: reuses an existing release without recreating it"
+
+# --- (d) repo derived from the cwd git origin remote ------------------------
+dir=$(make_case derive_repo)
+repo="$dir/repo"
+fm_git_init_commit "$repo"
+git -C "$repo" remote add origin git@github.com:derived/proj.git
+printf 'x' > "$repo/shot.png"
+run_case "$dir" "$repo" -- --dry-run --namespace fm/z1 "$repo/shot.png"
+expect_code 0 "$RUN_CODE" "derive-repo exits 0"
+assert_contains "$RUN_OUT" \
+  "https://github.com/derived/proj/releases/download/fm-pr-assets/fm-z1-shot.png" \
+  "derives owner/repo from the ssh origin remote"
+pass "repo derivation: owner/repo parsed from the git origin remote"
+
+# --- (e) namespace derived from the current git branch ----------------------
+dir=$(make_case derive_ns)
+repo="$dir/repo"
+fm_git_init_commit "$repo"
+git -C "$repo" checkout -q -b fm/feature-9
+printf 'x' > "$repo/shot.png"
+run_case "$dir" "$repo" -- --dry-run --repo acme/widget "$repo/shot.png"
+expect_code 0 "$RUN_CODE" "derive-namespace exits 0"
+assert_contains "$RUN_OUT" \
+  "releases/download/fm-pr-assets/fm-feature-9-shot.png" \
+  "derives the asset namespace from the fm/<id> branch"
+pass "namespace derivation: prefix taken from the current git branch"
+
+# --- (f) --no-heading drops the heading, keeps the marker -------------------
+dir=$(make_case no_heading)
+printf 'x' > "$dir/a.png"
+run_case "$dir" "$dir" -- --dry-run --no-heading --repo acme/widget --namespace fm/x "$dir/a.png"
+expect_code 0 "$RUN_CODE" "--no-heading exits 0"
+assert_not_contains "$RUN_OUT" "## Screenshots" "--no-heading drops the heading"
+assert_contains "$RUN_OUT" "<!-- fm-pr-screenshots -->" "--no-heading keeps the idempotency marker"
+pass "--no-heading: heading omitted, marker kept"
+
+# --- (g) duplicate asset names fail -----------------------------------------
+dir=$(make_case dup_names)
+mkdir -p "$dir/one" "$dir/two"
+printf 'x' > "$dir/one/shot.png"
+printf 'x' > "$dir/two/shot.png"
+run_case "$dir" "$dir" -- --dry-run --repo acme/widget --namespace fm/x "$dir/one/shot.png" "$dir/two/shot.png"
+expect_code 1 "$RUN_CODE" "duplicate asset names fail"
+assert_grep "same asset name" "$dir/err.txt" "explains the collision"
+pass "duplicate basenames: rejected as an asset-name collision"
+
+# --- (h) a missing image file fails -----------------------------------------
+dir=$(make_case missing_img)
+run_case "$dir" "$dir" -- --dry-run --repo acme/widget --namespace fm/x "$dir/nope.png"
+expect_code 1 "$RUN_CODE" "missing image fails"
+assert_grep "image not found" "$dir/err.txt" "reports the missing image"
+pass "missing image: rejected before any upload"
+
+# --- (i) embed appends the block to the PR body -----------------------------
+dir=$(make_case embed_append)
+printf 'Existing body.\n' > "$dir/pr-body.txt"
+printf '## Screenshots\n\n<!-- fm-pr-screenshots -->\n![a](https://example/a.png)\n' > "$dir/block.md"
+run_case "$dir" "$dir" -- embed https://github.com/acme/widget/pull/7 "$dir/block.md"
+expect_code 0 "$RUN_CODE" "embed exits 0"
+assert_grep "pr edit 7 --repo acme/widget --body-file" "$dir/calls.log" "edits the PR via gh-axi"
+assert_present "$dir/edited-body.txt" "embed writes a body file"
+new_body=$(cat "$dir/edited-body.txt")
+assert_contains "$new_body" "Existing body." "embed preserves the existing body"
+assert_contains "$new_body" "![a](https://example/a.png)" "embed appends the screenshots block"
+pass "embed: appends the block to the existing PR body"
+
+# --- (j) embed is idempotent when the marker is present ---------------------
+dir=$(make_case embed_idempotent)
+printf 'Body with block.\n\n<!-- fm-pr-screenshots -->\n![a](https://example/a.png)\n' > "$dir/pr-body.txt"
+printf '<!-- fm-pr-screenshots -->\n![a](https://example/a.png)\n' > "$dir/block.md"
+run_case "$dir" "$dir" -- embed https://github.com/acme/widget/pull/7 "$dir/block.md"
+expect_code 0 "$RUN_CODE" "idempotent embed exits 0"
+assert_no_grep "pr edit" "$dir/calls.log" "does not re-edit a body that already has the block"
+assert_grep "already embedded" "$dir/err.txt" "reports the no-op"
+pass "embed: idempotent when the marker is already in the body"
+
+# --- (k) embed --dry-run prints the composed body, no edit ------------------
+dir=$(make_case embed_dryrun)
+printf 'Existing body.\n' > "$dir/pr-body.txt"
+printf '<!-- fm-pr-screenshots -->\n![a](https://example/a.png)\n' > "$dir/block.md"
+run_case "$dir" "$dir" -- embed --dry-run https://github.com/acme/widget/pull/7 "$dir/block.md"
+expect_code 0 "$RUN_CODE" "embed --dry-run exits 0"
+assert_contains "$RUN_OUT" "Existing body." "dry-run prints the existing body"
+assert_contains "$RUN_OUT" "![a](https://example/a.png)" "dry-run prints the appended block"
+assert_no_grep "pr edit" "$dir/calls.log" "dry-run makes no edit call"
+pass "embed --dry-run: composes the body without editing"
+
+# --- (m) embed aborts on a failed body read, never overwriting the body -----
+dir=$(make_case embed_read_fail)
+touch "$dir/pr-read-fails"
+printf '<!-- fm-pr-screenshots -->\n![a](https://example/a.png)\n' > "$dir/block.md"
+run_case "$dir" "$dir" -- embed https://github.com/acme/widget/pull/7 "$dir/block.md"
+expect_code 1 "$RUN_CODE" "embed aborts when the PR body read fails"
+assert_no_grep "pr edit" "$dir/calls.log" "must not edit the PR body after a failed read"
+assert_grep "refusing to overwrite" "$dir/err.txt" "explains why it aborted"
+pass "embed: aborts on a failed body read instead of clobbering the description"
+
+# --- (l) unknown option fails -----------------------------------------------
+dir=$(make_case bad_opt)
+printf 'x' > "$dir/a.png"
+run_case "$dir" "$dir" -- --bogus --repo acme/widget --namespace fm/x "$dir/a.png"
+expect_code 2 "$RUN_CODE" "unknown option exits 2"
+assert_grep "unknown option" "$dir/err.txt" "reports the unknown option"
+pass "unknown option: rejected with a usage error"
+
+printf '\nall fm-pr-screenshots tests passed\n'


### PR DESCRIPTION
Rebuilds firstmate's PR-screenshots feature (embed UI screenshots in a PR body via GitHub release assets) as an **isolated, additive skill + script**, so it never conflicts with an upstream update.

## What
- `bin/fm-pr-screenshots.sh` — the uploader (restored verbatim; mechanics in its header + `--help`).
- `.agents/skills/pr-screenshots/SKILL.md` — the operating knowledge (when/how firstmate captures + embeds screenshots), moved out of core prose.
- `docs/pr-screenshots.md` — reference doc (skill-based delivery).
- `tests/fm-pr-screenshots.test.sh` — colocated tests (13/13 pass, shellcheck-clean).
- Only upstream-owned edits: one `AGENTS.md` section-13 trigger line + one `docs/scripts.md` catalog row. `bin/fm-brief.sh` untouched (the skill instructs hand-injection at dispatch).

## Why
The prior implementation baked integration into core files and diverged from upstream. Packaging it as an additive skill keeps the feature fully compatible with future firstmate updates.

Validated through the full pipeline: review, test (one pre-existing environment-only failure unrelated to this change, accepted), document, and lint all green.
