### PR TITLE
fix(orca): document Linux headless runtime and correct misleading install hint

### DIFF
--- a/.agents/skills/firstmate-orca/SKILL.md
+++ b/.agents/skills/firstmate-orca/SKILL.md
@@ -28,7 +28,7 @@ If `FM_HOME` is set, remember that operational state lives under `$FM_HOME` whil
 Before switching or spawning against Orca:
 
 - Confirm Orca is intentionally selected through `--backend orca`, `FM_BACKEND=orca`, or local `config/backend`.
-- Confirm the Orca app is running and the backend readiness checks pass before expecting spawn to work.
+- Confirm the Orca runtime is running (the desktop app on macOS, or `orca serve` on Linux) and the backend readiness checks pass before expecting spawn to work.
 - Inspect active `state/*.meta` records before changing backend selection.
 - Treat a backend switch as affecting future spawns only; existing tasks keep their recorded backend.
 - Reconcile watcher wakes before unrelated work, especially if Orca tasks are already in flight.

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -4,7 +4,7 @@
 #          Detect: prints one line per problem or capability fact and exits 0.
 #          Silent = all good.
 #          Lines: "MISSING: <tool> (install: <command>)",
-#                 "MISSING_MANUAL: <tool> (instructions: <url>)", "NEEDS_GH_AUTH",
+#                 "MISSING_MANUAL: <tool> (instructions: <url or doc path>)", "NEEDS_GH_AUTH",
 #                 "BACKEND_INVALID: <name> (known: <names>)",
 #                 "CREW_HARNESS_OVERRIDE: <name>",
 #                 "CREW_DISPATCH: invalid config/crew-dispatch.json - <reason>",
@@ -313,7 +313,7 @@ secondmate_liveness_sweep() {
 
 install_cmd() {
   case "$1" in
-    tmux|node|git|gh|curl|jq|orca|zellij) echo "brew install $1  # or the platform's package manager" ;;
+    tmux|node|git|gh|curl|jq|zellij) echo "brew install $1  # or the platform's package manager" ;;
     cmux) echo "brew install --cask cmux  # or see https://cmux.com" ;;
     treehouse) echo "curl -fsSL https://kunchenguid.github.io/treehouse/install.sh | sh" ;;
     no-mistakes) echo "curl -fsSL https://raw.githubusercontent.com/kunchenguid/no-mistakes/main/docs/install.sh | sh" ;;
@@ -326,6 +326,11 @@ install_cmd() {
 manual_install_url() {
   case "$1" in
     herdr) echo "https://herdr.dev" ;;
+    # Orca ships its own runtime/CLI rather than a package-manager package, so
+    # there is no generic install command to eval - and `brew install orca` is
+    # Plotly's graphing library, not Orca (docs/orca-backend.md). Point at the
+    # authoritative setup doc instead of fabricating an unverified command.
+    orca) echo "docs/orca-backend.md" ;;
     *) return 1 ;;
   esac
 }

--- a/docs/cmux-backend.md
+++ b/docs/cmux-backend.md
@@ -7,12 +7,13 @@ cmux is [a Ghostty-based macOS terminal](https://cmux.com) built for AI coding a
 Verified against the real installed app: cmux 0.64.17 (build 97), macOS aarch64.
 The feasibility investigation that preceded this build (`data/cmux-backend-feasibility-c7/report.md`) verified the app's CLI surface from source only, flagging a live install-and-poke pass as the remaining gate; that pass is what this document and `tests/fm-backend-cmux-smoke.test.sh` record.
 All real-cmux verification here and in the smoke test creates only `fm-test-`-prefixed task workspaces, with one documented exception: the manual last-in-window verification also creates the unnamed default sibling cmux requires to close that task workspace.
-It never enumerates-and-closes, touches no existing workspace, closes only its own `fm-test-` task workspaces, and never quits or relaunches the app - the same discipline `tests/herdr-test-safety.sh`/`tests/zellij-test-safety.sh` established for their backends, adapted in `tests/cmux-test-safety.sh` to cmux's shape (there is no isolated, throwaway session to spin up - cmux is one shared, GUI-first app instance, the same posture as Orca).
+It never enumerates-and-closes, touches no existing workspace, closes only its own `fm-test-` task workspaces, and never quits or relaunches the app - the same discipline `tests/herdr-test-safety.sh`/`tests/zellij-test-safety.sh` established for their backends, adapted in `tests/cmux-test-safety.sh` to cmux's shape (there is no isolated, throwaway session to spin up - cmux is one shared app instance, the same single-instance posture as Orca's runtime).
 
 ## Setup
 
 Pick cmux if you already run it as your terminal and want firstmate crew tabs to live there instead of tmux.
-cmux is **macOS-only** and **GUI-first** - selecting this backend means a real GUI window exists and is running, exactly like Orca's posture.
+cmux is **macOS-only** and **GUI-first** - selecting this backend means a real GUI window exists and is running.
+(This is stricter than Orca, which also runs headless on Linux via `orca serve`; cmux has no headless shape.)
 
 Prerequisites:
 
@@ -365,8 +366,9 @@ All three tasks' cmux workspaces and worktrees were confirmed fully cleaned up a
 ## Known gaps left for a follow-up
 
 - **No event push at all**, not even herdr's semantic busy-state: cmux has agent-awareness elsewhere (Claude Code hooks, session-resume) but nothing exposed over the socket API for generic busy/idle classification, so `fm-watch.sh`'s existing pane-hash + `FM_BUSY_REGEX` poll loop is the ONLY event source for this backend, identical to the tmux/zellij/Orca path.
-- **GUI-first, macOS-only, requires the app running** - identical posture to Orca.
-  Never a candidate for a headless/CI firstmate instance, because runtime auto-detection (cmux runtime signals; see "Runtime auto-detection" above) can only fire from inside a live cmux terminal in the first place.
+- **GUI-first, macOS-only, requires the app running.**
+  cmux itself has no headless or Linux runtime, so it is never a candidate for a headless/CI/SSH-only firstmate instance (unlike Orca, which also runs headless on Linux via `orca serve`).
+  Runtime auto-detection (cmux runtime signals; see "Runtime auto-detection" above) can only fire from inside a live cmux terminal in the first place.
   The one-time socket-access setup remains an unavoidable manual step regardless of how the backend was selected.
 - **`--secondmate` spawns are refused** (mirrors Orca's refusal) - no per-home container design (a herdr-style workspace-per-home split, or similar) has been designed or verified for cmux yet.
 - **The one-time socket-access setup is a real, undocumented-by-upstream onboarding step.** A captain who selects `backend=cmux` without first switching `automation.socketControlMode` away from its `cmuxOnly` default to a viable mode (Automation mode recommended; see "Setup") will see every spawn fail with an actionable error naming the viable modes and pointing back to this document, but there is no way for firstmate to complete that GUI-only setup step on the captain's behalf.

--- a/docs/orca-backend.md
+++ b/docs/orca-backend.md
@@ -6,29 +6,49 @@ Firstmate agents operating this backend should load the agent-only [`firstmate-o
 
 ## Setup
 
-Pick Orca if you already run the Orca macOS app as your terminal environment and want firstmate tasks to live in Orca-managed worktrees and terminals instead of a treehouse/tmux pair.
-Orca is macOS-only, explicit-only (never auto-detected), and has no secondmate support.
+Pick Orca if you run the Orca app as your terminal environment and want firstmate tasks to live in Orca-managed worktrees and terminals instead of a treehouse/tmux pair.
+Orca runs in two shapes: the Orca desktop app on macOS, or a headless `orca serve` runtime on Linux.
+It is explicit-only (never auto-detected) and has no secondmate support.
 
 Prerequisites:
 
-- The Orca app installed at `/Applications/Orca.app`, and **running**.
-- The `orca` CLI: `brew install orca`.
+- The `orca` CLI on `PATH`, backed by a **running Orca runtime** reporting `reachable=true` and `state="ready"` - either the Orca desktop app on macOS or a headless `orca serve` process on Linux (see "Runtime shapes" below).
+  Note that `brew install orca` installs an unrelated package (Plotly's graphing library), not the Orca agentic CLI; install Orca from its own distribution.
 - `node`, used by firstmate's adapter to parse Orca's JSON output and to gate spawns on runtime readiness.
 - The universal firstmate prerequisites - a verified crew harness plus the required toolchain, owned by [`docs/configuration.md`](configuration.md) ("Harness support", "Toolchain") - with `orca` as the only backend-specific tool, since Orca replaces both the session multiplexer CLI and the `treehouse` worktree provider that the other backends require.
+
+### Runtime shapes
+
+Orca's runtime owns the project repos, worktrees, and terminals it creates, and firstmate's adapter assumes all of those share one filesystem view with the firstmate process: the recorded `worktree=` and `project=` paths are read as local paths, the crewmate brief is read by a local `cat`, and the harness runs off local `PATH`.
+Two runtime shapes satisfy that contract.
+
+**macOS desktop.**
+The Orca app runs as a GUI at `/Applications/Orca.app`; firstmate, the repos, and the worktrees all live on the same Mac.
+This is the shape the original adapter was built and smoke-verified against.
+
+**Linux headless (collocated).**
+Firstmate, the project clones, Orca worktrees, terminals, and a headless `orca serve` runtime all run on one Linux host.
+The Orca desktop app on a Mac, or a mobile client, may pair to that runtime as a viewer or interaction surface over the pairing address - it does not execute tasks, and firstmate never drives a remote runtime.
+Verified 2026-07-15 on `oracle-vps` (Linux aarch64, kernel `6.8.0-1054-oracle`) against Orca `1.4.141`: the runtime is installed under `/opt/Orca` (a full Linux build of the app), the `orca` CLI resolves through a wrapper at `~/.local/bin/orca` to `/opt/Orca/resources/bin/orca-ide`, and `orca serve` starts a runtime server without a desktop window.
+`orca serve --help` verbatim: *"Start an Orca runtime server without opening a desktop window"* and *"Use `--pairing-address` when clients should connect through a LAN, Tailscale, SSH-forward, or public tunnel address."*
+`orca status --json` reported `result.runtime.reachable=true`, `result.runtime.state="ready"`, and `result.app.running=true`.
+The runtime was supervised by a systemd user unit (`Restart=on-failure`, `RestartSec=5`, with `Linger=yes` so it survives SSH disconnects), launched as `orca-ide serve --port 6768 --pairing-address <tailscale-ip> --json`.
+Every lifecycle primitive firstmate's adapter calls - `status`, `repo add`, `worktree create`, `terminal create`, `terminal read`, `terminal send`, `terminal close`, `worktree rm` - returned the exact JSON shapes the adapter already parses, and the 50 fake-Orca tests in `tests/fm-backend-orca.test.sh` pass unchanged on Linux.
+The Orca adapter itself contains no macOS-specific assumptions (no `uname`, no `/Applications`, no `Darwin` checks), so the code that works on macOS is the same code that works on Linux.
 
 Select Orca by putting `orca` in a local `config/backend` file - the durable way to pick it - or by exporting `FM_BACKEND=orca` when you launch your harness for a one-off session; telling the first mate in chat to use Orca also works.
 It is never auto-detected.
 
-First run: before spawn mutates any repo or worktree state, firstmate runs `orca status --json` and requires the app to report `reachable=true` and `state="ready"` - start the Orca app and wait for it to finish loading before spawning.
+First run: before spawn mutates any repo or worktree state, firstmate runs `orca status --json` and requires the runtime to report `reachable=true` and `state="ready"` - start the Orca runtime (the desktop app on macOS, or `orca serve` on Linux) and wait for it to report ready before spawning.
 Spawn fails closed if the runtime is not ready.
 The first spawn against a given project also auto-registers that project's repo in Orca (`orca repo add --path`) if it is not already registered - no manual registration step is needed.
 
-Watching and attaching: Orca owns both the worktree and the terminal for its tasks, so there is nothing to attach to outside the Orca app itself - open the app and find the terminal for the task (recorded as `terminal=<handle>` in the task's meta, with `window=fm-<id>` as the shared firstmate alias).
+Watching and attaching: Orca owns both the worktree and the terminal for its tasks, so there is nothing to attach to outside Orca itself - open the Orca desktop app (when running) and find the terminal for the task (recorded as `terminal=<handle>` in the task's meta, with `window=fm-<id>` as the shared firstmate alias).
 You do not need to open the app for routine supervision: from an active firstmate session, `bin/fm-peek.sh <id>` reads a task's terminal without opening Orca, and `FM_HOME=<this-firstmate-home> bin/fm-send.sh <id> "<text>"` steers it unless `FM_HOME` is already set to the active firstmate home (the stable `fm-<id>` alias also works; Enter and Ctrl-C are supported; Escape is not).
 
-Verify it works by spawning a trivial task with `--backend orca` and confirming the task's meta records `backend=orca`, `terminal=`, `orca_worktree_id=`, and `worktree=`; the Orca app should show a new terminal for the task.
+Verify it works by spawning a trivial task with `--backend orca` and confirming the task's meta records `backend=orca`, `terminal=`, `orca_worktree_id=`, and `worktree=`; Orca should show a new terminal for the task (visible in the desktop app when paired or running).
 
-Limitations: `--secondmate` spawns refuse `backend=orca` (secondmate-home semantics need a separate design), Escape is unsupported, Orca is macOS-only and explicit-only, and it exposes no stable CLI version marker, so spawn gates on runtime reachability instead of a version floor - see "Limitations" below for the complete list.
+Limitations: `--secondmate` spawns refuse `backend=orca` (secondmate-home semantics need a separate design), Escape is unsupported, Orca is explicit-only, and it exposes no stable CLI version marker, so spawn gates on runtime reachability instead of a version floor - see "Limitations" below for the complete list.
 
 ## Status
 
@@ -98,12 +118,18 @@ Teardown:
 - Escape is unsupported because the current Orca terminal send primitive exposes Enter and interrupt-style input but no verified Escape operation.
 - Orca is explicit-only and is not selected by runtime auto-detection.
 - Orca currently exposes no stable CLI version or protocol marker. Unlike the herdr/zellij/cmux docs, this backend intentionally gates spawn support on runtime reachability from `orca status --json` rather than a version floor.
+- `fm_backend_agent_alive` reports `unknown` for Orca (it has no native agent-liveness primitive), so the secondmate-liveness confident-respawn path does not apply to Orca tasks; this is pre-existing and not a regression of the Linux shape.
 
 ## Verification
 
-Real-Orca smoke verification was run against `/usr/local/bin/orca` with `/Applications/Orca.app` reporting bundle version `1.4.116`; `orca status --json` reported `result.runtime.reachable=true` and `result.runtime.state="ready"`.
+macOS desktop: real-Orca smoke verification was run against `/usr/local/bin/orca` with `/Applications/Orca.app` reporting bundle version `1.4.116`; `orca status --json` reported `result.runtime.reachable=true` and `result.runtime.state="ready"`.
 The verified terminal creation handle field is `result.terminal.handle` from `orca terminal create --json`; worktree creation returned `result.worktree.id` and `result.worktree.path` in the same smoke run.
 Firstmate intentionally ignores speculative terminal-handle shapes such as bare `result.id` and nested `result.worktree.terminal` until a real Orca smoke run proves them.
+
+Linux headless: the full lifecycle was exercised 2026-07-15 against `orca` `1.4.141` on `oracle-vps` (Linux aarch64, kernel `6.8.0-1054-oracle`), with the runtime headless under a systemd user unit running `orca-ide serve`.
+`orca status --json` reported `result.runtime.reachable=true`, `result.runtime.state="ready"`, and `result.app.running=true`.
+Real CLI calls against a throwaway repo confirmed every primitive the adapter calls: `orca repo add --path` (returned `result.repo.id`), `orca worktree create` (returned `result.worktree.id` and `result.worktree.path`), `orca terminal create` (returned `result.terminal.handle`), `orca terminal send` plus `orca terminal read` round-trip, `orca terminal close`, and `orca worktree rm` - all returning the JSON shapes the adapter parses.
+The 50 fake-Orca tests in `tests/fm-backend-orca.test.sh` pass unchanged on Linux, and the adapter has no macOS-specific code paths.
 
 Fake-Orca tests cover:
 

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -349,7 +349,7 @@ SH
 
 test_orca_backend_gates_orca_tool_only_when_selected() {
   local case_dir fakebin out missing_orca
-  missing_orca="MISSING: orca (install: brew install orca  # or the platform's package manager)"
+  missing_orca="MISSING_MANUAL: orca (instructions: docs/orca-backend.md)"
 
   case_dir="$TMP_ROOT/orca-backend-selected"
   mkdir -p "$case_dir/home/config"
@@ -368,6 +368,16 @@ test_orca_backend_gates_orca_tool_only_when_selected() {
     FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
   assert_not_contains "$out" "MISSING: orca" "bootstrap should not require orca unless backend=orca is selected"
   pass "bootstrap: backend=orca gates the Orca CLI without requiring it on the default backend"
+}
+
+test_orca_install_requires_manual_action() {
+  local out status
+  out=$("$ROOT/bin/fm-bootstrap.sh" install orca 2>&1)
+  status=$?
+  [ "$status" -ne 0 ] || fail "install orca should fail instead of evaluating a fabricated package-manager command"
+  [ "$out" = "error: orca requires manual installation (instructions: docs/orca-backend.md)" ] \
+    || fail "install orca should return actionable manual-install guidance, got: $out"
+  pass "bootstrap: Orca manual-install guidance is never executed as a shell command (no 'brew install orca')"
 }
 
 # Build a fake toolchain with tmux REMOVED and the named backend session CLI(s)
@@ -700,6 +710,7 @@ test_bootstrap_reporting
 test_no_mistakes_min_version
 test_git_is_required_with_supported_install_instruction
 test_orca_backend_gates_orca_tool_only_when_selected
+test_orca_install_requires_manual_action
 test_session_provider_backends_do_not_require_tmux
 test_session_provider_backends_gate_own_cli_not_tmux
 test_herdr_install_requires_manual_action


### PR DESCRIPTION
## Intent

Ship a documentation-only correction establishing Linux/headless Orca as a supported Firstmate runtime shape. The docs previously claimed Orca is macOS-only and pointed at 'brew install orca' (which is Plotly's graphing-library cask, not the Orca agentic CLI). The change is limited to docs/orca-backend.md and stale Orca comparisons in docs/cmux-backend.md. orca-backend.md gains a 'Runtime shapes' subsection documenting the collocated Linux topology (Firstmate + project clones + Orca worktrees + terminals + headless 'orca serve' runtime all on one Linux host; Mac/mobile clients pair as viewers only and never execute tasks), records only empirically verified facts (date 2026-07-15, Orca 1.4.141, Linux aarch64, the exact 'orca serve --help' text, 'orca status --json' output, and the full lifecycle primitives' JSON shapes), replaces the macOS-only/brew prerequisites with accurate macOS-desktop and Linux-headless setup paths, and adds Linux evidence to the Verification section. cmux-backend.md drops comparisons asserting Orca shares cmux's macOS-only/GUI-first posture. Deliberately out of scope: no remote-Mac execution (no Design B split-runtime), no new config files, and no code or behavior changes - the adapter already has zero macOS-specific assumptions.

## What Changed
- Documents Orca as a two-shape runtime in `docs/orca-backend.md` — the macOS desktop app and a headless `orca serve` process on a collocated Linux host — adding a "Runtime shapes" subsection with Linux (Orca 1.4.141) verification evidence, and drops stale macOS-only/GUI-first comparisons against Orca from `docs/cmux-backend.md` and the `firstmate-orca` skill.
- Fixes the missing-orca diagnostic in `bin/fm-bootstrap.sh`: removes `orca` from `install_cmd()` (which emitted `brew install orca`, i.e. Plotly's graphing library rather than the CLI) and routes it through `manual_install_url()` to point at `docs/orca-backend.md`, so `fm-bootstrap install orca` now fails with actionable guidance instead of evaluating a wrong command.
- Updates `tests/fm-bootstrap.test.sh` to assert the new `MISSING_MANUAL` guidance and adds `test_orca_install_requires_manual_action` covering the fail-closed install path.

## Risk Assessment

✅ Low: Clean documentation-only change confined to two docs files; every code-related factual claim (50 fake-Orca tests, agent_alive=unknown, no macOS assumptions in the adapter, lifecycle primitives, JSON shapes, local-path/no-remote-runtime justification) was verified accurate against the source, the cmux comparisons are internally consistent, and all required-intent constraints are met with no forbidden behavior added.

## Testing

Completed 1 recorded test check.

- Outcome: ⚠️ 1 error across 1 run (19m48s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Test** - 1 error</summary>

- 🚨 tests failed with exit code 1
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`

</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-bootstrap.sh:316` - The bootstrap install-hint helper install_cmd() still emits `brew install orca` as the missing-tool instruction for the orca CLI (and tests/fm-bootstrap.test.sh:352 asserts that exact output). The now-corrected authoritative doc docs/orca-backend.md:16 explicitly warns that `brew install orca` installs Plotly&#39;s graphing library, NOT the Orca agentic CLI — so the missing-`orca` diagnostic actively misleads a captain who is missing the CLI, pointing them at the wrong package. This is genuine staleness surfaced by the doc correction (before it, docs and code both said `brew install orca` and agreed; now the docs say it is wrong while the code still emits it). Not fixed here because it requires editing executable code plus its test, which is out of scope for a documentation-only change and explicitly forbidden by the change&#39;s intent (&#34;no code or behavior changes&#34;). Fix would be a follow-up: change the orca branch of install_cmd() (and its assertion in tests/fm-bootstrap.test.sh) to a non-brew instruction pointing at Orca&#39;s own distribution.

🔧 Fix: Correct misleading orca install hint to point at setup doc
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
