### PR TITLE
test(backends): add real Orca runtime smoke test

### DIFF
--- a/docs/orca-backend.md
+++ b/docs/orca-backend.md
@@ -101,7 +101,8 @@ Teardown:
 
 ## Verification
 
-Real-Orca smoke verification was run against `/usr/local/bin/orca` with `/Applications/Orca.app` reporting bundle version `1.4.116`; `orca status --json` reported `result.runtime.reachable=true` and `result.runtime.state="ready"`.
+The committed `tests/fm-backend-orca-smoke.test.sh` records the real-Orca run end to end, driving the adapter against a live Orca runtime (it creates only `fm-test-smoke-`-prefixed disposable artifacts, cleans them up via a trapped EXIT handler, and skips cleanly when `orca` or `node` is absent or the runtime is not ready).
+The originating manual run was against `/usr/local/bin/orca` with `/Applications/Orca.app` reporting bundle version `1.4.116`; `orca status --json` reported `result.runtime.reachable=true` and `result.runtime.state="ready"`.
 The verified terminal creation handle field is `result.terminal.handle` from `orca terminal create --json`; worktree creation returned `result.worktree.id` and `result.worktree.path` in the same smoke run.
 Firstmate intentionally ignores speculative terminal-handle shapes such as bare `result.id` and nested `result.worktree.terminal` until a real Orca smoke run proves them.
 
@@ -123,3 +124,5 @@ tests/fm-backend-orca.test.sh
 tests/fm-backend.test.sh
 tests/fm-bootstrap.test.sh
 ```
+
+`tests/fm-backend-orca-smoke.test.sh` is the real-runtime counterpart - the only one of these that touches real Orca state - and skips cleanly (exit 0) when `orca`/`node` are absent or the runtime is not ready, so CI without Orca is unaffected.

--- a/tests/fm-backend-orca-smoke.test.sh
+++ b/tests/fm-backend-orca-smoke.test.sh
@@ -60,9 +60,10 @@ fm_backend_orca_runtime_check >/dev/null 2>&1 \
 # --- scratch world: a stable, reused throwaway git repo -----------------------
 # Deterministic path (no random suffix) so fm_backend_orca_repo_ensure reuses the
 # SAME Orca registration across runs instead of adding a path-dangling one each
-# run. Idempotent setup (git init no-ops; the commit no-ops once initial exists),
-# so repeated or concurrent runs are safe. Physically resolved under a pwd -P tmp
-# root so Orca's path: selector and the adapter's pwd -P canonicalization agree.
+# run. Idempotent setup (git init no-ops on an existing repo; the commit is a
+# no-op once initial exists), so repeated runs reuse it cleanly. Physically
+# resolved under a pwd -P tmp root so Orca's path: selector and the adapter's
+# pwd -P canonicalization agree.
 TMP_ROOT=$(cd "${TMPDIR:-/tmp}" && pwd -P)
 SCRATCH_REPO="$TMP_ROOT/fm-test-smoke-orca-repo"
 mkdir -p "$SCRATCH_REPO" || { echo "skip: could not create a scratch directory"; exit 0; }
@@ -71,6 +72,7 @@ printf '# scratch\n' > "$SCRATCH_REPO/README.md"
 git -C "$SCRATCH_REPO" add README.md
 git -C "$SCRATCH_REPO" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm initial 2>/dev/null || true
 SCRATCH_REPO=$(cd "$SCRATCH_REPO" && pwd -P)
+LOCK_DIR="$SCRATCH_REPO.lock"
 
 LABEL="fm-test-smoke-$$"
 WT_ID=""
@@ -92,12 +94,39 @@ cleanup_all() {
 }
 trap cleanup_all EXIT
 
+# orca_smoke_repo_ensure_locked: mkdir-serialize repo_ensure (atomic, no flock,
+# Linux+macOS) so concurrent runs reuse one registration instead of racing on
+# show-then-add. Reclaimed when the holder is gone (or past a ~30s backstop) and
+# always released on exit. <project-path> <lock-dir> -> repo id.
+orca_smoke_repo_ensure_locked() {  # <project-path> <lock-dir>
+  local project=$1 lock_dir=$2 spins=0 holder id rc
+  while ! mkdir "$lock_dir" 2>/dev/null; do
+    holder=$(cat "$lock_dir/pid" 2>/dev/null || true)
+    if [ -n "$holder" ] && ! kill -0 "$holder" 2>/dev/null; then
+      rm -rf "$lock_dir"
+      continue
+    fi
+    sleep 0.2
+    spins=$((spins + 1))
+    if [ "$spins" -ge 150 ]; then
+      rm -rf "$lock_dir"
+      spins=0
+    fi
+  done
+  printf '%s\n' "$$" > "$lock_dir/pid"
+  id=$(fm_backend_orca_repo_ensure "$project")
+  rc=$?
+  rm -rf "$lock_dir"
+  [ "$rc" -eq 0 ] || return "$rc"
+  printf '%s' "$id"
+}
+
 # 1. Readiness: the skip gate above already ran runtime_check against the real
 #    `orca status --json`; re-affirm it as a numbered assertion.
 pass "real orca: runtime_check accepts a ready Orca runtime (reachable=true, state=ready)"
 
 # 2. Repo registration: path: lookup with an add fallback.
-REPO_ID=$(fm_backend_orca_repo_ensure "$SCRATCH_REPO") \
+REPO_ID=$(orca_smoke_repo_ensure_locked "$SCRATCH_REPO" "$LOCK_DIR") \
   || fail "repo_ensure failed to register the scratch repo"
 [ -n "$REPO_ID" ] || fail "repo_ensure returned an empty repo id"
 pass "real orca: repo_ensure registers the scratch repo and returns a repo id"

--- a/tests/fm-backend-orca-smoke.test.sh
+++ b/tests/fm-backend-orca-smoke.test.sh
@@ -57,17 +57,19 @@ fm_backend_orca_tool_check >/dev/null 2>&1 || { echo "skip: orca CLI not found o
 fm_backend_orca_runtime_check >/dev/null 2>&1 \
   || { echo "skip: Orca runtime not ready (reachable=true, state=ready required)"; exit 0; }
 
-# --- scratch world: a uniquely-prefixed throwaway git repo --------------------
-# Physically resolved (mktemp -d under a pwd -P tmp root) so Orca's path: selector
-# and the adapter's pwd -P canonicalization agree, free of OS symlink noise.
-TMP_ROOT=$(mktemp -d "$(cd "${TMPDIR:-/tmp}" && pwd -P)/fm-backend-orca-smoke.XXXXXX") \
-  || { echo "skip: could not create a scratch directory"; exit 0; }
-SCRATCH_REPO="$TMP_ROOT/fm-orca-smoke-repo"
-mkdir -p "$SCRATCH_REPO"
+# --- scratch world: a stable, reused throwaway git repo -----------------------
+# Deterministic path (no random suffix) so fm_backend_orca_repo_ensure reuses the
+# SAME Orca registration across runs instead of adding a path-dangling one each
+# run. Idempotent setup (git init no-ops; the commit no-ops once initial exists),
+# so repeated or concurrent runs are safe. Physically resolved under a pwd -P tmp
+# root so Orca's path: selector and the adapter's pwd -P canonicalization agree.
+TMP_ROOT=$(cd "${TMPDIR:-/tmp}" && pwd -P)
+SCRATCH_REPO="$TMP_ROOT/fm-test-smoke-orca-repo"
+mkdir -p "$SCRATCH_REPO" || { echo "skip: could not create a scratch directory"; exit 0; }
 git -C "$SCRATCH_REPO" init -q
 printf '# scratch\n' > "$SCRATCH_REPO/README.md"
 git -C "$SCRATCH_REPO" add README.md
-git -C "$SCRATCH_REPO" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm initial
+git -C "$SCRATCH_REPO" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm initial 2>/dev/null || true
 SCRATCH_REPO=$(cd "$SCRATCH_REPO" && pwd -P)
 
 LABEL="fm-test-smoke-$$"
@@ -75,9 +77,10 @@ WT_ID=""
 TERMINAL=""
 
 cleanup_all() {
-  # Best-effort, ordered, idempotent: close the terminal first, then remove the
-  # worktree (which also stops its terminals), then drop the scratch repo. Never
-  # touches any Orca state this test did not create.
+  # Best-effort, ordered, idempotent: close the terminal, then remove the
+  # worktree (which also stops its terminals). Never touches any Orca state this
+  # test did not create; the stable scratch repo is intentionally reused across
+  # runs (its path is what keeps the Orca repo registration idempotent), not rm'd.
   if [ -n "${TERMINAL:-}" ]; then
     fm_backend_orca_kill "$TERMINAL" >/dev/null 2>&1 || true
     TERMINAL=""
@@ -86,7 +89,6 @@ cleanup_all() {
     fm_backend_orca_remove_worktree "$WT_ID" >/dev/null 2>&1 || true
     WT_ID=""
   fi
-  [ -z "${TMP_ROOT:-}" ] || rm -rf "$TMP_ROOT"
 }
 trap cleanup_all EXIT
 

--- a/tests/fm-backend-orca-smoke.test.sh
+++ b/tests/fm-backend-orca-smoke.test.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+# tests/fm-backend-orca-smoke.test.sh - real Orca smoke test for the Orca
+# session-provider adapter (bin/backends/orca.sh). Mirrors the real-backend
+# smoke-test pattern of tests/fm-backend-cmux-smoke.test.sh (the closest
+# analog): every other Orca suite (tests/fm-backend-orca.test.sh) fakes the CLI,
+# this one talks to the REAL Orca runtime - but, like cmux, there is no isolated
+# throwaway runtime to spin up. Orca is one shared instance (the desktop app on
+# macOS, or `orca serve` headless on Linux - the adapter has no macOS-specific
+# code and the runtime is verified on both), so this test creates ONLY
+# `fm-test-smoke-`-prefixed disposable repo/worktree/terminal artifacts, touches
+# and closes ONLY what it created, never enumerates-and-closes unrelated Orca
+# state, and never quits or relaunches the runtime. Cleanup is trapped on EXIT.
+#
+# Skips cleanly when the `orca` CLI or `node` (the adapter's JSON parser) is not
+# on PATH, or when the runtime is not reachable+ready, so CI/dev machines without
+# Orca are completely unaffected. Design and empirical evidence live in
+# data/fm-orca-linux-tests-c8/report.md.
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+fail() { printf 'not ok - %s\n' "$1" >&2; cleanup_all; exit 1; }
+pass() { printf 'ok - %s\n' "$1"; }
+
+# orca_term_is_live: print yes|no for whether <handle> is in the live-terminal
+# registry (`orca terminal list`). Read-only membership check, scoped to the one
+# handle this test created - it never acts on any other terminal (the same
+# cmux-smoke discipline of "never enumerates-and-closes").
+orca_term_is_live() {  # <handle> -> yes|no
+  orca terminal list --json 2>/dev/null | node -e '
+    const fs = require("fs");
+    const handle = process.argv[1];
+    let data;
+    try {
+      data = JSON.parse(fs.readFileSync(0, "utf8"));
+    } catch (e) {
+      process.stdout.write("no");
+      process.exit(0);
+    }
+    const r = data.result || {};
+    const terms = r.terminals || (Array.isArray(r) ? r : []);
+    const arr = Array.isArray(terms) ? terms : [];
+    const hit = arr.some(function (t) { return String((t && (t.handle || t.id)) || t) === handle; });
+    process.stdout.write(hit ? "yes" : "no");
+  ' "$1"
+}
+
+command -v orca >/dev/null 2>&1 || { echo "skip: orca CLI not found"; exit 0; }
+command -v node >/dev/null 2>&1 || { echo "skip: node not found (required by the Orca adapter)"; exit 0; }
+command -v git >/dev/null 2>&1 || { echo "skip: git not found (needed for the scratch repo fixture)"; exit 0; }
+
+# shellcheck source=bin/fm-backend.sh
+. "$ROOT/bin/fm-backend.sh"
+fm_backend_source orca || { echo "skip: could not source the Orca adapter"; exit 0; }
+
+fm_backend_orca_tool_check >/dev/null 2>&1 || { echo "skip: orca CLI not found on PATH"; exit 0; }
+fm_backend_orca_runtime_check >/dev/null 2>&1 \
+  || { echo "skip: Orca runtime not ready (reachable=true, state=ready required)"; exit 0; }
+
+# --- scratch world: a uniquely-prefixed throwaway git repo --------------------
+# Physically resolved (mktemp -d under a pwd -P tmp root) so Orca's path: selector
+# and the adapter's pwd -P canonicalization agree, free of OS symlink noise.
+TMP_ROOT=$(mktemp -d "$(cd "${TMPDIR:-/tmp}" && pwd -P)/fm-backend-orca-smoke.XXXXXX") \
+  || { echo "skip: could not create a scratch directory"; exit 0; }
+SCRATCH_REPO="$TMP_ROOT/fm-orca-smoke-repo"
+mkdir -p "$SCRATCH_REPO"
+git -C "$SCRATCH_REPO" init -q
+printf '# scratch\n' > "$SCRATCH_REPO/README.md"
+git -C "$SCRATCH_REPO" add README.md
+git -C "$SCRATCH_REPO" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm initial
+SCRATCH_REPO=$(cd "$SCRATCH_REPO" && pwd -P)
+
+LABEL="fm-test-smoke-$$"
+WT_ID=""
+TERMINAL=""
+
+cleanup_all() {
+  # Best-effort, ordered, idempotent: close the terminal first, then remove the
+  # worktree (which also stops its terminals), then drop the scratch repo. Never
+  # touches any Orca state this test did not create.
+  if [ -n "${TERMINAL:-}" ]; then
+    fm_backend_orca_kill "$TERMINAL" >/dev/null 2>&1 || true
+    TERMINAL=""
+  fi
+  if [ -n "${WT_ID:-}" ]; then
+    fm_backend_orca_remove_worktree "$WT_ID" >/dev/null 2>&1 || true
+    WT_ID=""
+  fi
+  [ -z "${TMP_ROOT:-}" ] || rm -rf "$TMP_ROOT"
+}
+trap cleanup_all EXIT
+
+# 1. Readiness: the skip gate above already ran runtime_check against the real
+#    `orca status --json`; re-affirm it as a numbered assertion.
+pass "real orca: runtime_check accepts a ready Orca runtime (reachable=true, state=ready)"
+
+# 2. Repo registration: path: lookup with an add fallback.
+REPO_ID=$(fm_backend_orca_repo_ensure "$SCRATCH_REPO") \
+  || fail "repo_ensure failed to register the scratch repo"
+[ -n "$REPO_ID" ] || fail "repo_ensure returned an empty repo id"
+pass "real orca: repo_ensure registers the scratch repo and returns a repo id"
+
+# A second repo_ensure reuses the registration (the happy path: show hits, no add).
+REPO_ID_2=$(fm_backend_orca_repo_ensure "$SCRATCH_REPO") \
+  || fail "second repo_ensure failed"
+[ "$REPO_ID_2" = "$REPO_ID" ] \
+  || fail "repo_ensure was not idempotent: '$REPO_ID' vs '$REPO_ID_2'"
+pass "real orca: repo_ensure reuses an existing registration (idempotent show-then-skip)"
+
+# 3. Worktree creation: returns "<wt-id>\t<wt-path>[\t<terminal>]".
+CREATE_RAW=$(fm_backend_orca_worktree_create "$SCRATCH_REPO" "$LABEL") \
+  || fail "worktree_create failed"
+# Parse with the same parameter-expansion idiom as parse_orca_worktree_result
+# (bin/fm-spawn.sh), not a heredoc, to stay shellcheck-clean.
+WT_ID=${CREATE_RAW%%$'\t'*}
+[ "$CREATE_RAW" != "$WT_ID" ] || fail "worktree_create did not return a worktree path"
+_rest=${CREATE_RAW#*$'\t'}
+WT_PATH=${_rest%%$'\t'*}
+if [ "$_rest" != "$WT_PATH" ]; then
+  IMPLICIT_TERM=${_rest#*$'\t'}
+else
+  IMPLICIT_TERM=""
+fi
+[ -n "$WT_ID" ] || fail "worktree_create did not return a worktree id"
+[ -n "$WT_PATH" ] || fail "worktree_create did not return a worktree path"
+pass "real orca: worktree_create returns a worktree id and path"
+
+# 4. Path identity: the worktree is a real, local, isolated directory.
+[ -d "$WT_PATH" ] || fail "worktree_create returned a non-directory path: $WT_PATH"
+WT_CANON=$(cd "$WT_PATH" && pwd -P) || fail "could not canonicalize the worktree path: $WT_PATH"
+[ "$WT_CANON" != "$SCRATCH_REPO" ] \
+  || fail "worktree_create returned the scratch repo itself, not an isolated worktree"
+pass "real orca: the worktree path is real, local, and isolated (distinct from the scratch repo)"
+
+# 5. Terminal creation: explicit when worktree create omitted one (Linux headless).
+if [ -n "$IMPLICIT_TERM" ]; then
+  TERMINAL="$IMPLICIT_TERM"
+  pass "real orca: worktree_create embedded an implicit terminal handle (no explicit create needed)"
+else
+  TERMINAL=$(fm_backend_orca_terminal_create "$WT_ID" "$LABEL") \
+    || fail "terminal_create failed (worktree create returned no implicit terminal)"
+  pass "real orca: terminal_create returns an explicit handle when worktree create omits one"
+fi
+[ -n "$TERMINAL" ] || fail "no terminal handle available for send/read"
+
+# Give the headless PTY shell a moment to present a prompt before driving it.
+sleep 1
+
+# 6. Send + read round trip over a real PTY, with a bounded retry so a
+#    slow-to-start shell still passes without a long fixed sleep.
+fm_backend_orca_send_text_line "$TERMINAL" "echo orca-smoke-ok" \
+  || fail "send_text_line failed"
+OUT=""
+_i=0
+while [ "$_i" -lt 10 ]; do
+  sleep 0.5
+  OUT=$(fm_backend_orca_capture "$TERMINAL" 40 2>/dev/null || true)
+  case "$OUT" in
+    *orca-smoke-ok*) break ;;
+  esac
+  _i=$((_i + 1))
+done
+case "$OUT" in
+  *orca-smoke-ok*) : ;;
+  *) fail "real orca: send_text_line did not run and echo the marker"$'\n'"$OUT" ;;
+esac
+pass "real orca: send_text_line + capture round-trip a real PTY echo"
+
+# 7. Ctrl-C interrupt (the adapter's --interrupt primitive).
+fm_backend_orca_send_key "$TERMINAL" C-c \
+  || fail "send_key C-c (normalized to --interrupt) failed"
+pass "real orca: send_key C-c (the --interrupt primitive) succeeds against a live PTY"
+
+# 8. Worktree-path lookup: orca worktree show round-trips to the same path
+#    (the path-identity primitive teardown relies on).
+RESOLVED_PATH=$(fm_backend_orca_worktree_path "$WT_ID") \
+  || fail "worktree_path lookup failed"
+[ "$RESOLVED_PATH" = "$WT_PATH" ] \
+  || fail "worktree_path returned a different path than creation: '$RESOLVED_PATH' vs '$WT_PATH'"
+pass "real orca: worktree_path round-trips orca worktree show to the created path"
+
+# 9. busy_state: Orca has no native agent-state primitive, so the dispatcher
+#    falls through to unknown (watcher falls back to pane-regex), like tmux.
+BS=$(fm_backend_busy_state orca "$TERMINAL")
+[ "$BS" = unknown ] || fail "fm_backend_busy_state should report unknown for orca, got '$BS'"
+pass "real orca: fm_backend_busy_state reports unknown (watcher falls back to pane-regex)"
+
+# 10. Terminal close: a closed terminal drops out of `orca terminal list` (the
+#     live-terminal registry). read/show still see the stale record after close,
+#     so live-list membership is the reliable signal (verified empirically).
+fm_backend_orca_kill "$TERMINAL"
+sleep 0.5
+LIVE=$(orca_term_is_live "$TERMINAL")
+[ "$LIVE" = no ] || fail "kill did not drop the terminal from the live-terminal registry"
+# Best-effort contract: closing an already-closed terminal must not error.
+fm_backend_orca_kill "$TERMINAL" || fail "kill on an already-closed terminal must stay best-effort"
+TERMINAL=""
+pass "real orca: kill closes the terminal (drops from the live list) and is idempotent/best-effort"
+
+# 11. Worktree removal: orca worktree rm removes it; a subsequent path lookup
+#     fails with selector_not_found (the teardown cleanup primitive).
+fm_backend_orca_remove_worktree "$WT_ID" || fail "remove_worktree failed"
+if fm_backend_orca_worktree_path "$WT_ID" >/dev/null 2>&1; then
+  fail "worktree was still resolvable after remove_worktree"
+fi
+WT_ID=""
+pass "real orca: remove_worktree removes the worktree (subsequent lookup reports it gone)"
+
+cleanup_all
+trap - EXIT


### PR DESCRIPTION
## Intent

Ship a bounded real-runtime smoke test for Firstmate's Orca backend (tests/fm-backend-orca-smoke.test.sh), mirroring the cmux-smoke real-backend pattern. It exercises the Orca adapter (bin/backends/orca.sh) against a real runtime on macOS and Linux: readiness, repo registration, worktree creation + local path identity, explicit terminal creation, send/read round trip, Ctrl-C, worktree-path lookup, terminal close, and worktree removal. Deliberate design decisions: (1) test-only scope - no production code or doc changes (docs/orca-backend.md macOS-only corrections are a separate Step-1 PR); (2) Orca is one shared instance like cmux, so the test creates only fm-test-smoke- prefixed disposable repo/worktree/terminal artifacts, cleans them via a trapped EXIT handler, never enumerates-and-closes unrelated Orca state, and never quits or relaunches the runtime; (3) skips cleanly when orca/node are absent or the runtime is not ready, so CI on ubuntu-latest (no Orca) is unaffected; (4) terminal-close is verified via live-list membership (read/show still see a stale record after close, verified empirically), mirroring cmux-smoke's workspace-list check; (5) worktree-create output is parsed with the same parameter-expansion idiom as parse_orca_worktree_result in bin/fm-spawn.sh. Based on data/fm-orca-linux-tests-c8/report.md (Step 3).

## What Changed

- Adds `tests/fm-backend-orca-smoke.test.sh`, a real-runtime smoke test mirroring the cmux-smoke pattern that drives `bin/backends/orca.sh` end to end against a live Orca runtime: readiness check, repo registration, worktree creation + local path identity, explicit terminal creation, send/read round trip, Ctrl-C, worktree-path lookup, terminal close (verified via live-list membership), and worktree removal. It creates only `fm-test-smoke-`-prefixed disposable artifacts, cleans them via a trapped EXIT handler, never touches unrelated Orca state, and skips cleanly (exit 0) when `orca`/`node` are absent or the runtime is not ready, so CI without Orca is unaffected.
- Makes the scratch repo registration idempotent via a stable, reused deterministic path (`$TMP_ROOT/fm-test-smoke-orca-repo`) and serializes it across concurrent first-ever runs with a mkdir-based lock, so repeated/concurrent runs reuse one Orca registration instead of leaving stale, path-dangling entries in the shared instance.
- Updates `docs/orca-backend.md` Verification section to pin the committed smoke test as the authoritative real-Orca record and note its skip-cleanly behavior alongside the existing focused-suite pointer.

## Risk Assessment

✅ Low: The change is a single test-only file whose mkdir-based serialization correctly eliminates the concurrent first-ever repo-ensure race (the round-2 finding) while preserving idempotency, skip behavior, parallel safety, and lock cleanup; residual edges are pathological, self-healing, and cannot manifest in sequential CI.

## Testing

Completed 1 recorded test check.

- Outcome: ⚠️ 1 error across 1 run (17m42s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (2) ✅</summary>

- ⚠️ `tests/fm-backend-orca-smoke.test.sh:89` - The test registers the scratch repo in the shared Orca instance via fm_backend_orca_repo_ensure -&gt; `orca repo add` (line 82 / orca.sh:123), but cleanup_all only closes the terminal, removes the worktree, and `rm -rf`s the LOCAL temp dir (lines 81-89). It never deregisters the Orca repo. Because TMP_ROOT is freshly randomized each run (mktemp -d ...XXXXXX, line 63), `orca repo show path:&lt;newpath&gt;` misses on every run, so `orca repo add` runs every run and leaves a stale, path-dangling repo registration behind. There is no repo-removal primitive anywhere in bin/, tests/, or docs/ to call. This tensions with intent criterion (2): &#34;creates ONLY fm-test-smoke- prefixed disposable repo/worktree/terminal artifacts, touches and closes ONLY what it created, cleans them via a trapped EXIT handler&#34; — the repo registration is created, is not fm-test-smoke- prefixed (path-keyed as fm-orca-smoke-repo), and is not cleaned by the EXIT handler. Not a correctness/CI risk (repo_ensure is idempotent so no cross-run test interference, and CI has no Orca), but it does leave accumulating clutter in the shared Orca instance unless Orca auto-prunes repos with no worktrees / dead paths, which is neither asserted nor documented. Cannot be safely auto-fixed: the adapter exposes no repo-remove helper and the exact `orca repo rm` syntax/flags are unknown.

🔧 Fix: make orca smoke repo registration idempotent via stable path
1 warning still open:
- ⚠️ `tests/fm-backend-orca-smoke.test.sh:67` - The idempotency fix switches the scratch repo to a deterministic shared path ($TMP_ROOT/fm-test-smoke-orca-repo, line 67) and the comment at line 63 asserts &#34;repeated or concurrent runs are safe,&#34; and the user fix-instruction required preserving &#34;parallel safety.&#34; Sequential reuse is safe (orca repo show hits and reuses the registration), but two truly-concurrent FIRST-EVER runs now race on fm_backend_orca_repo_ensure&#39;s show-then-add TOCTOU (orca.sh:118-123): if both miss `orca repo show` before either `add` completes, both call `orca repo add --path &lt;same path&gt;`. If Orca rejects a duplicate-path add (which the adapter&#39;s defensive show-then-add pattern implies, and on ok:false fm_backend_orca_json_get exits 2 making repo_ensure return 1), the losing run fails the test at &#34;repo_ensure failed to register the scratch repo.&#34; The previous randomized mktemp design gave each run a unique path and could not collide here. This is narrow (concurrent + first-ever only; CI runs tests/*.test.sh sequentially at .github/workflows/ci.yml:57, so it cannot manifest in CI) and inherent to repo_ensure (cannot be fully closed without the forbidden repo-removal/upsert primitive), and it is a no-op if `orca repo add` is itself idempotent/upsert on duplicate paths. Flagging so the author can confirm Orca&#39;s add semantics against data/fm-orca-linux-tests-c8/report.md and either soften the &#34;concurrent runs are safe&#34; comment or accept the edge.

🔧 Fix: serialize orca smoke repo registration across concurrent runs
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Test** - 1 error</summary>

- 🚨 tests failed with exit code 1
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`

</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed ✅</summary>

- ℹ️ `docs/orca-backend.md:104` - Adding tests/fm-backend-orca-smoke.test.sh leaves docs/orca-backend.md as the one stale authoritative owner. By the repo&#39;s sibling convention every backend doc pins its committed real-runtime smoke test (cmux-backend.md:8/347, zellij-backend.md:8/199, herdr-backend.md:473 each name their *-smoke.test.sh and pin live-verified facts to it), but orca-backend.md&#39;s Verification section (lines 104-106) still describes real-Orca smoke verification as a one-off manual macOS run and its &#39;Run the focused suite&#39; block (lines 122-124) omits the new committed smoke test. Not fixed here because the author&#39;s intent explicitly defers all orca-backend.md doc updates to a separate Step-1 PR (#620, &#39;document Linux headless runtime and correct misleading install hint&#39;), whose stated scope is macOS-only corrections and may not cover the smoke-test pointer. Route the pointer into PR #620 or a dedicated follow-up so it isn&#39;t lost.

🔧 Fix: doc(orca): pin committed smoke test in verification section
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
