### PR TITLE
fix(bin): balance bearings landed baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,8 +89,8 @@ jobs:
           bearings_output=$(/bin/bash tests/fm-bearings-snapshot.test.sh)
           printf '%s\n' "$bearings_output"
           bearings_count=$(printf '%s\n' "$bearings_output" | grep -c '^ok - ')
-          [ "$bearings_count" -eq 30 ] || {
-            echo "::error::expected 30 Bearings tests, got $bearings_count"
+          [ "$bearings_count" -eq 36 ] || {
+            echo "::error::expected 36 Bearings tests, got $bearings_count"
             exit 1
           }
 

--- a/bin/fm-bearings-snapshot.sh
+++ b/bin/fm-bearings-snapshot.sh
@@ -27,6 +27,10 @@
 # recorded in ITS OWN backlog, never the main one - are visible. It stays bounded by
 # a per-home cap and an overall cap, with omitted[] disclosure of both and of any
 # secondmate home whose backlog was unreadable; no GitHub/network call is involved.
+# The default landed baseline is balanced across homes: each home keeps its internal
+# newest-first ordering, homes iterate in deterministic id order, sparse homes do not
+# waste capacity, and --all-landed switches back to the complete global newest-first
+# order.
 #
 # Flags:
 #   (default)        compact projection, TOON, local-only
@@ -98,7 +102,9 @@ Default fields: schema, home, generated, prs, in_flight{id,kind,state,doing},
   unhealthy_endpoints{...} (only when non-empty), omitted{surface,reveal}.
 landed merges this home's Done with registered secondmate homes' Done, bounded by
   a per-home cap (FM_BEARINGS_LANDED_PER_HOME) and an overall cap (FM_BEARINGS_LANDED),
-  with omitted[] disclosure; --all-landed reveals the full set.
+  with omitted[] disclosure. Default selection is balanced across deterministic home
+  order while preserving each home's internal newest-first order; sparse homes do
+  not waste capacity. --all-landed reveals the full global newest-first set.
 For every registered secondmate, validated structured state from its own home is
   authoritative. Parent events and bounded terminal reads are labeled fallback or
   contradiction evidence and never become current work.

--- a/bin/fm-bearings-snapshot.sh
+++ b/bin/fm-bearings-snapshot.sh
@@ -290,6 +290,12 @@ MODEL=$(printf '%s' "$SNAP" | jq \
   --argjson candidate_prs "$CANDIDATE_PRS" '
   def trunc($n): if . == null then null else
     (tostring | gsub("\\s+"; " ") | if (length > $n) then (.[:$n] + "…") else . end) end;
+  def round_robin_landed($n):
+    . as $groups
+    | [range(0; (($groups | map(length) | max) // 0)) as $i
+       | $groups[]
+       | select(length > $i)
+       | .[$i]][:$n];
   ($fields | split(",") | map(gsub("^\\s+|\\s+$"; "")) | map(select(. != ""))) as $fl
   | (($fl | index("bodies")) != null) as $f_bodies
   | (($fl | index("paths")) != null) as $f_paths
@@ -301,10 +307,11 @@ MODEL=$(printf '%s' "$SNAP" | jq \
   | ($main_done + $mate_done) as $all_landed_rows
   | ([ $all_landed_rows | group_by(.home_id)[]
        | sort_by([(.completion.date // ""), .id]) | reverse
-       | (if $all_landed == 1 then . else .[:$landed_per_home_n] end) ] | add // []) as $per_home_capped
+       | (if $all_landed == 1 then . else .[:$landed_per_home_n] end) ]) as $per_home_groups
+  | ($per_home_groups | add // []) as $per_home_capped
   | ([ $all_landed_rows | group_by(.home_id)[] | select(length > $landed_per_home_n) ] | length) as $home_cap_dropped
   | ($per_home_capped | sort_by([(.completion.date // ""), .id]) | reverse) as $landed_sorted
-  | (if $all_landed == 1 then $landed_sorted else $landed_sorted[:$landed_n] end) as $done
+  | (if $all_landed == 1 then $landed_sorted else ($per_home_groups | round_robin_landed($landed_n)) end) as $done
   | ($done | map(.id)) as $done_ids
   | ([.tasks[] | select(.kind != "secondmate") | .id]) as $live_ids
   | ($live_ids + $done_ids) as $rel_ids

--- a/tests/fm-bearings-snapshot.test.sh
+++ b/tests/fm-bearings-snapshot.test.sh
@@ -399,6 +399,19 @@ append_secondmate_registry() {  # <parent> <id> <home>
     "$2" "$3" >> "$1/data/secondmates.md"
 }
 
+append_landed_row() {  # <secondmate-home> <id> <title> <date>
+  printf -- '- [x] %s - %s (repo: firstmate) (kind: ship) (merged %s)\n' \
+    "$2" "$3" "$4" >> "$1/data/backlog.md"
+}
+
+make_landed_secondmate() {  # <parent> <id>
+  local parent=$1 id=$2 mate
+  mate="$TMP_ROOT/$(basename "$parent")-$id-home"
+  make_valid_secondmate_home "$id" "$mate"
+  append_secondmate_registry "$parent" "$id" "$mate"
+  printf '%s\n' "$mate"
+}
+
 write_parent_secondmate_event() {  # <parent> <id> <home> <note>
   fm_write_secondmate_meta "$1/state/$2.meta" "$3" "firstmate:fm-$2" sample
   printf 'working [key=%s]: %s\n' "$2" "$4" > "$1/state/$2.status"
@@ -1107,6 +1120,166 @@ test_landed_includes_secondmate_home_merges() {
   pass "landed includes secondmate-managed merges alongside main-home merges"
 }
 
+test_landed_default_balances_dominant_and_sparse_homes() {
+  local home dominant sparse_a sparse_b sparse_c fakebin json i actual expected
+  home=$(make_home landed-balanced-default)
+  : > "$home/data/secondmates.md"
+  printf '## Done\n' > "$home/data/backlog.md"
+  dominant=$(make_landed_secondmate "$home" dominant)
+  sparse_a=$(make_landed_secondmate "$home" sparse-a)
+  sparse_b=$(make_landed_secondmate "$home" sparse-b)
+  sparse_c=$(make_landed_secondmate "$home" sparse-c)
+  i=1
+  while [ "$i" -le 12 ]; do
+    append_landed_row "$dominant" "$(printf 'dominant-landed-%02d' "$i")" \
+      "$(printf 'Dominant landed %02d' "$i")" "$(printf '2026-07-%02d' "$((31 - i))")"
+    i=$((i + 1))
+  done
+  i=1
+  while [ "$i" -le 2 ]; do
+    append_landed_row "$sparse_a" "$(printf 'sparse-a-landed-%02d' "$i")" \
+      "$(printf 'Sparse A landed %02d' "$i")" "$(printf '2026-07-%02d' "$((12 - i))")"
+    append_landed_row "$sparse_b" "$(printf 'sparse-b-landed-%02d' "$i")" \
+      "$(printf 'Sparse B landed %02d' "$i")" "$(printf '2026-07-%02d' "$((10 - i))")"
+    append_landed_row "$sparse_c" "$(printf 'sparse-c-landed-%02d' "$i")" \
+      "$(printf 'Sparse C landed %02d' "$i")" "$(printf '2026-07-%02d' "$((8 - i))")"
+    i=$((i + 1))
+  done
+  fakebin=$(make_fakebin "$home")
+  json=$(run "$home" "$fakebin" --json)
+  actual=$(printf '%s' "$json" | jq -r '.landed[] | "\(.owner)/\(.id)"')
+  expected='dominant/dominant-landed-01
+sparse-a/sparse-a-landed-01
+sparse-b/sparse-b-landed-01
+sparse-c/sparse-c-landed-01
+dominant/dominant-landed-02
+sparse-a/sparse-a-landed-02'
+  [ "$actual" = "$expected" ] || fail "default landed selection was not balanced across homes: $actual"
+  printf '%s' "$json" | jq -e '
+    (.landed | length) == 6
+      and ([.landed[].owner] | unique | length) == 4
+      and ([.omitted[].surface] | any(test("landed showing 6 of 12")))
+  ' >/dev/null || fail "balanced landed default did not preserve cap disclosure: $json"
+  pass "default landed selection balances one dominant home with sparse homes"
+}
+
+test_landed_default_refills_capacity_after_sparse_homes_exhaust() {
+  local home dominant sparse fakebin json actual expected i
+  home=$(make_home landed-sparse-refill)
+  : > "$home/data/secondmates.md"
+  printf '## Done\n' > "$home/data/backlog.md"
+  dominant=$(make_landed_secondmate "$home" dominant)
+  sparse=$(make_landed_secondmate "$home" sparse)
+  i=1
+  while [ "$i" -le 5 ]; do
+    append_landed_row "$dominant" "$(printf 'dominant-landed-%02d' "$i")" \
+      "$(printf 'Dominant landed %02d' "$i")" "$(printf '2026-07-%02d' "$((20 - i))")"
+    i=$((i + 1))
+  done
+  append_landed_row "$sparse" sparse-landed-01 "Sparse landed 01" 2026-07-01
+  fakebin=$(make_fakebin "$home")
+  json=$(run "$home" "$fakebin" --json)
+  actual=$(printf '%s' "$json" | jq -r '.landed[] | "\(.owner)/\(.id)"')
+  expected='dominant/dominant-landed-01
+sparse/sparse-landed-01
+dominant/dominant-landed-02
+dominant/dominant-landed-03
+dominant/dominant-landed-04
+dominant/dominant-landed-05'
+  [ "$actual" = "$expected" ] || fail "sparse homes wasted landed capacity: $actual"
+  pass "landed selection refills capacity after sparse homes exhaust"
+}
+
+test_landed_default_uses_deterministic_home_order_when_homes_exceed_cap() {
+  local home mate fakebin json actual expected i id
+  home=$(make_home landed-home-order)
+  : > "$home/data/secondmates.md"
+  printf '## Done\n' > "$home/data/backlog.md"
+  i=1
+  while [ "$i" -le 8 ]; do
+    id=$(printf 'home-%02d' "$i")
+    mate=$(make_landed_secondmate "$home" "$id")
+    append_landed_row "$mate" "$id-landed-01" "$id landed 01" 2026-07-10
+    i=$((i + 1))
+  done
+  fakebin=$(make_fakebin "$home")
+  json=$(run "$home" "$fakebin" --json)
+  actual=$(printf '%s' "$json" | jq -r '.landed[] | "\(.owner)/\(.id)"')
+  expected='home-01/home-01-landed-01
+home-02/home-02-landed-01
+home-03/home-03-landed-01
+home-04/home-04-landed-01
+home-05/home-05-landed-01
+home-06/home-06-landed-01'
+  [ "$actual" = "$expected" ] || fail "landed home-order tie was not deterministic: $actual"
+  printf '%s' "$json" | jq -e '
+    ([.omitted[].surface] | any(test("landed showing 6 of 8")))
+  ' >/dev/null || fail "more-homes-than-cap omission was not disclosed: $json"
+  pass "landed selection uses deterministic home order when homes exceed the cap"
+}
+
+test_landed_default_preserves_internal_order_for_ties() {
+  local home tie_a tie_b fakebin json actual expected
+  home=$(make_home landed-ties)
+  : > "$home/data/secondmates.md"
+  printf '## Done\n' > "$home/data/backlog.md"
+  tie_a=$(make_landed_secondmate "$home" tie-a)
+  tie_b=$(make_landed_secondmate "$home" tie-b)
+  append_landed_row "$tie_b" tie-b-a "Tie B A" 2026-07-10
+  append_landed_row "$tie_b" tie-b-z "Tie B Z" 2026-07-10
+  append_landed_row "$tie_a" tie-a-a "Tie A A" 2026-07-10
+  append_landed_row "$tie_a" tie-a-z "Tie A Z" 2026-07-10
+  fakebin=$(make_fakebin "$home")
+  json=$(run "$home" "$fakebin" --json)
+  actual=$(printf '%s' "$json" | jq -r '.landed[] | "\(.owner)/\(.id)"')
+  expected='tie-a/tie-a-z
+tie-b/tie-b-z
+tie-a/tie-a-a
+tie-b/tie-b-a'
+  [ "$actual" = "$expected" ] || fail "landed tie ordering changed: $actual"
+  pass "landed selection preserves deterministic home and internal tie ordering"
+}
+
+test_landed_default_handles_no_landed_items() {
+  local home fakebin json
+  home=$(make_home landed-empty)
+  : > "$home/data/secondmates.md"
+  printf '## Done\n' > "$home/data/backlog.md"
+  fakebin=$(make_fakebin "$home")
+  json=$(run "$home" "$fakebin" --json)
+  printf '%s' "$json" | jq -e '
+    (.landed | length) == 0
+      and ([.omitted[].surface] | any(test("landed")) | not)
+  ' >/dev/null || fail "empty landed set was not handled cleanly: $json"
+  pass "landed selection handles no landed items"
+}
+
+test_all_landed_keeps_complete_global_order() {
+  local home alpha beta fakebin json actual expected
+  home=$(make_home landed-all-order)
+  : > "$home/data/secondmates.md"
+  printf '## Done\n' > "$home/data/backlog.md"
+  alpha=$(make_landed_secondmate "$home" alpha)
+  beta=$(make_landed_secondmate "$home" beta)
+  append_landed_row "$alpha" alpha-old "Alpha old" 2026-07-01
+  append_landed_row "$alpha" alpha-new "Alpha new" 2026-07-09
+  append_landed_row "$beta" beta-new "Beta new" 2026-07-10
+  append_landed_row "$beta" beta-mid "Beta mid" 2026-07-05
+  fakebin=$(make_fakebin "$home")
+  json=$(FM_BEARINGS_LANDED=1 run "$home" "$fakebin" --json --all-landed)
+  actual=$(printf '%s' "$json" | jq -r '.landed[] | "\(.owner)/\(.id)"')
+  expected='beta/beta-new
+alpha/alpha-new
+beta/beta-mid
+alpha/alpha-old'
+  [ "$actual" = "$expected" ] || fail "--all-landed global order changed: $actual"
+  printf '%s' "$json" | jq -e '
+    (.landed | length) == 4
+      and ([.omitted[].surface] | any(test("landed|snapshot layer")) | not)
+  ' >/dev/null || fail "--all-landed no longer revealed the complete landed set: $json"
+  pass "--all-landed keeps the complete global landed output"
+}
+
 # The roll-up stays bounded: a per-home cap and an overall cap, both disclosed in
 # omitted[], with --all-landed as the counted expansion knob. This also covers the
 # previously-silent main-home landed truncation.
@@ -1239,6 +1412,12 @@ test_current_landed_baseline_is_repeatable_and_prior_report_independent
 test_default_is_bounded_and_local_only
 test_toon_json_parity
 test_landed_includes_secondmate_home_merges
+test_landed_default_balances_dominant_and_sparse_homes
+test_landed_default_refills_capacity_after_sparse_homes_exhaust
+test_landed_default_uses_deterministic_home_order_when_homes_exceed_cap
+test_landed_default_preserves_internal_order_for_ties
+test_landed_default_handles_no_landed_items
+test_all_landed_keeps_complete_global_order
 test_landed_bounded_and_disclosed
 test_live_blocker_is_not_charted_queue_work
 test_captains_call_anti_leak


### PR DESCRIPTION
## Intent

Implement a balanced default Recently Landed baseline for Bearings as one small Firstmate PR. The original end-user failure was that the default bounded snapshot selected 6 of 18 landed items and all six came from one secondmate home because per-home caps interacted with global recency ordering. Preserve Bearings authority, Captain's Call classification, privacy boundaries, deterministic home ordering, each home's internal landed ordering, the global bound, sparse-home capacity refill, and complete --all-landed behavior. Validate focused regressions for one dominant home plus sparse homes, fewer homes than the cap, more homes than the cap, deterministic ties, no landed items, and unchanged --all-landed output under stock macOS Bash 3.2. Let no-mistakes v1.38.1 perform guarded branch sync onto current main without manual reset, cherry-pick, merge, or hand-copying commits.

## What Changed

- Balance the default Bearings landed baseline across deterministic home order, preserving each home's newest-first landed ordering while still honoring per-home and global caps.
- Preserve `--all-landed` as the complete global newest-first landed view, with omission disclosures only on bounded default output.
- Add focused `fm-bearings-snapshot` regressions for dominant plus sparse homes, sparse capacity refill, home-count caps, deterministic ties, empty landed sets, and unchanged `--all-landed` output.

## Risk Assessment

✅ Low: The change is narrowly scoped to the Bearings landed projection, keeps the complete --all-landed path on the existing global ordering, and adds focused regression coverage for the stated balancing edge cases.

## Testing

The configured all-test baseline had already passed; I then ran the focused Bearings regression suite under stock macOS `/bin/bash` 3.2, generated end-user TOON and JSON evidence from a real `fm-bearings-snapshot.sh` invocation over a dominant-plus-sparse secondmate fixture, verified complete `--all-landed` expansion, and confirmed no working-tree artifacts were left behind.

<details>
<summary>Evidence: Balanced Bearings Evidence Summary</summary>

<code>default landed order:&#10;- dominant/dominant-landed-01&#10;- sparse-a/sparse-a-landed-01&#10;- sparse-b/sparse-b-landed-01&#10;- sparse-c/sparse-c-landed-01&#10;- dominant/dominant-landed-02&#10;- sparse-a/sparse-a-landed-02&#10;&#10;default omitted landed disclosures:&#10;- landed showing 6 of 12 (incl. 4 secondmate home(s)) -&gt; --all-landed&#10;- landed per-home capped at 6 for 1 home(s) -&gt; --all-landed&#10;&#10;--all-landed count and first/last:&#10;count=18&#10;first=dominant/dominant-landed-01&#10;last=sparse-c/sparse-c-landed-02</code>

```text
default landed order:
- dominant/dominant-landed-01
- sparse-a/sparse-a-landed-01
- sparse-b/sparse-b-landed-01
- sparse-c/sparse-c-landed-01
- dominant/dominant-landed-02
- sparse-a/sparse-a-landed-02

default omitted landed disclosures:
- landed showing 6 of 12 (incl. 4 secondmate home(s)) -> --all-landed
- landed per-home capped at 6 for 1 home(s) -> --all-landed

--all-landed count and first/last:
count=18
first=dominant/dominant-landed-01
last=sparse-c/sparse-c-landed-02
```
</details>
<details>
<summary>Evidence: End-user default Bearings TOON output</summary>

```text
schema: fm-bearings.v1
home: 01KXNMQAJT2EWCT5HH82Q3971Q/bearings-balanced-home
generated: "2026-07-16T12:00:00Z"
prs: "not_requested (run: /bearings include PRs)"
in_flight: []
secondmates[4]{id,state,doing,provenance,freshness,age_seconds,contradiction,reason}:
  dominant,no_active_work,No active child work,structured-home,fresh,0,false,"-"
  sparse-a,no_active_work,No active child work,structured-home,fresh,0,false,"-"
  sparse-b,no_active_work,No active child work,structured-home,fresh,0,false,"-"
  sparse-c,no_active_work,No active child work,structured-home,fresh,0,false,"-"
decisions_open: []
landed[6]{id,what,artifact,owner}:
  dominant-landed-01,Dominant landed 01,"-",dominant
  sparse-a-landed-01,Sparse A landed 01,"-",sparse-a
  sparse-b-landed-01,Sparse B landed 01,"-",sparse-b
  sparse-c-landed-01,Sparse C landed 01,"-",sparse-c
  dominant-landed-02,Dominant landed 02,"-",dominant
  sparse-a-landed-02,Sparse A landed 02,"-",sparse-a
gates: []
reports: []
recorded_prs: []
omitted[10]{surface,reveal}:
  backlog item bodies,"--fields bodies"
  task paths,"--fields paths"
  watch/steer actions,"--fields actions"
  healthy endpoint detail,"--fields endpoints"
  full scout-report inventory,"--all-reports"
  superseded queued items,"--all-queued"
  landed showing 6 of 12 (incl. 4 secondmate home(s)),"--all-landed"
  landed per-home capped at 6 for 1 home(s),"--all-landed"
  secondmate home Done capped at the snapshot layer for 1 home(s),"--all-landed"
  live PR discovery + checks,"--include-prs"
```
</details>
<details>
<summary>Evidence: Default Bearings JSON output</summary>

```text
{
  "schema": "fm-bearings.v1",
  "home": "01KXNMQAJT2EWCT5HH82Q3971Q/bearings-balanced-home",
  "generated": "2026-07-16T12:00:00Z",
  "prs": "not_requested (run: /bearings include PRs)",
  "in_flight": [],
  "secondmates": [
    {
      "id": "dominant",
      "state": "no_active_work",
      "doing": "No active child work",
      "provenance": "structured-home",
      "freshness": "fresh",
      "age_seconds": 0,
      "contradiction": false,
      "reason": "-"
    },
    {
      "id": "sparse-a",
      "state": "no_active_work",
      "doing": "No active child work",
      "provenance": "structured-home",
      "freshness": "fresh",
      "age_seconds": 0,
      "contradiction": false,
      "reason": "-"
    },
    {
      "id": "sparse-b",
      "state": "no_active_work",
      "doing": "No active child work",
      "provenance": "structured-home",
      "freshness": "fresh",
      "age_seconds": 0,
      "contradiction": false,
      "reason": "-"
    },
    {
      "id": "sparse-c",
      "state": "no_active_work",
      "doing": "No active child work",
      "provenance": "structured-home",
      "freshness": "fresh",
      "age_seconds": 0,
      "contradiction": false,
      "reason": "-"
    }
  ],
  "decisions_open": [],
  "landed": [
    {
      "id": "dominant-landed-01",
      "what": "Dominant landed 01",
      "artifact": "-",
      "owner": "dominant"
    },
    {
      "id": "sparse-a-landed-01",
      "what": "Sparse A landed 01",
      "artifact": "-",
      "owner": "sparse-a"
    },
    {
      "id": "sparse-b-landed-01",
      "what": "Sparse B landed 01",
      "artifact": "-",
      "owner": "sparse-b"
    },
    {
      "id": "sparse-c-landed-01",
      "what": "Sparse C landed 01",
      "artifact": "-",
      "owner": "sparse-c"
    },
    {
      "id": "dominant-landed-02",
      "what": "Dominant landed 02",
      "artifact": "-",
      "owner": "dominant"
    },
    {
      "id": "sparse-a-landed-02",
      "what": "Sparse A landed 02",
      "artifact": "-",
      "owner": "sparse-a"
    }
  ],
  "gates": [],
  "reports": [],
  "recorded_prs": [],
  "omitted": [
    {
      "surface": "backlog item bodies",
      "reveal": "--fields bodies"
    },
    {
      "surface": "task paths",
      "reveal": "--fields paths"
    },
    {
      "surface": "watch/steer actions",
      "reveal": "--fields actions"
    },
    {
      "surface": "healthy endpoint detail",
      "reveal": "--fields endpoints"
    },
    {
      "surface": "full scout-report inventory",
      "reveal": "--all-reports"
    },
    {
      "surface": "superseded queued items",
      "reveal": "--all-queued"
    },
    {
      "surface": "landed showing 6 of 12 (incl. 4 secondmate home(s))",
      "reveal": "--all-landed"
    },
    {
      "surface": "landed per-home capped at 6 for 1 home(s)",
      "reveal": "--all-landed"
    },
    {
      "surface": "secondmate home Done capped at the snapshot layer for 1 home(s)",
      "reveal": "--all-landed"
    },
    {
      "surface": "live PR discovery + checks",
      "reveal": "--include-prs"
    }
  ]
}
```
</details>
<details>
<summary>Evidence: Complete --all-landed Bearings JSON output</summary>

```text
{
  "schema": "fm-bearings.v1",
  "home": "01KXNMQAJT2EWCT5HH82Q3971Q/bearings-balanced-home",
  "generated": "2026-07-16T12:00:00Z",
  "prs": "not_requested (run: /bearings include PRs)",
  "in_flight": [],
  "secondmates": [
    {
      "id": "dominant",
      "state": "no_active_work",
      "doing": "No active child work",
      "provenance": "structured-home",
      "freshness": "fresh",
      "age_seconds": 0,
      "contradiction": false,
      "reason": "-"
    },
    {
      "id": "sparse-a",
      "state": "no_active_work",
      "doing": "No active child work",
      "provenance": "structured-home",
      "freshness": "fresh",
      "age_seconds": 0,
      "contradiction": false,
      "reason": "-"
    },
    {
      "id": "sparse-b",
      "state": "no_active_work",
      "doing": "No active child work",
      "provenance": "structured-home",
      "freshness": "fresh",
      "age_seconds": 0,
      "contradiction": false,
      "reason": "-"
    },
    {
      "id": "sparse-c",
      "state": "no_active_work",
      "doing": "No active child work",
      "provenance": "structured-home",
      "freshness": "fresh",
      "age_seconds": 0,
      "contradiction": false,
      "reason": "-"
    }
  ],
  "decisions_open": [],
  "landed": [
    {
      "id": "dominant-landed-01",
      "what": "Dominant landed 01",
      "artifact": "-",
      "owner": "dominant"
    },
    {
      "id": "dominant-landed-02",
      "what": "Dominant landed 02",
      "artifact": "-",
      "owner": "dominant"
    },
    {
      "id": "dominant-landed-03",
      "what": "Dominant landed 03",
      "artifact": "-",
      "owner": "dominant"
    },
    {
      "id": "dominant-landed-04",
      "what": "Dominant landed 04",
      "artifact": "-",
      "owner": "dominant"
    },
    {
      "id": "dominant-landed-05",
      "what": "Dominant landed 05",
      "artifact": "-",
      "owner": "dominant"
    },
    {
      "id": "dominant-landed-06",
      "what": "Dominant landed 06",
      "artifact": "-",
      "owner": "dominant"
    },
    {
      "id": "dominant-landed-07",
      "what": "Dominant landed 07",
      "artifact": "-",
      "owner": "dominant"
    },
    {
      "id": "dominant-landed-08",
      "what": "Dominant landed 08",
      "artifact": "-",
      "owner": "dominant"
    },
    {
      "id": "dominant-landed-09",
      "what": "Dominant landed 09",
      "artifact": "-",
      "owner": "dominant"
    },
    {
      "id": "dominant-landed-10",
      "what": "Dominant landed 10",
      "artifact": "-",
      "owner": "dominant"
    },
    {
      "id": "dominant-landed-11",
      "what": "Dominant landed 11",
      "artifact": "-",
      "owner": "dominant"
    },
    {
      "id": "dominant-landed-12",
      "what": "Dominant landed 12",
      "artifact": "-",
      "owner": "dominant"
    },
    {
      "id": "sparse-a-landed-01",
      "what": "Sparse A landed 01",
      "artifact": "-",
      "owner": "sparse-a"
    },
    {
      "id": "sparse-a-landed-02",
      "what": "Sparse A landed 02",
      "artifact": "-",
      "owner": "sparse-a"
    },
    {
      "id": "sparse-b-landed-01",
      "what": "Sparse B landed 01",
      "artifact": "-",
      "owner": "sparse-b"
    },
    {
      "id": "sparse-b-landed-02",
      "what": "Sparse B landed 02",
      "artifact": "-",
      "owner": "sparse-b"
    },
    {
      "id": "sparse-c-landed-01",
      "what": "Sparse C landed 01",
      "artifact": "-",
      "owner": "sparse-c"
    },
    {
      "id": "sparse-c-landed-02",
      "what": "Sparse C landed 02",
      "artifact": "-",
      "owner": "sparse-c"
    }
  ],
  "gates": [],
  "reports": [],
  "recorded_prs": [],
  "omitted": [
    {
      "surface": "backlog item bodies",
      "reveal": "--fields bodies"
    },
    {
      "surface": "task paths",
      "reveal": "--fields paths"
    },
    {
      "surface": "watch/steer actions",
      "reveal": "--fields actions"
    },
    {
      "surface": "healthy endpoint detail",
      "reveal": "--fields endpoints"
    },
    {
      "surface": "full scout-report inventory",
      "reveal": "--all-reports"
    },
    {
      "surface": "superseded queued items",
      "reveal": "--all-queued"
    },
    {
      "surface": "live PR discovery + checks",
      "reveal": "--include-prs"
    }
  ]
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- <code>Baseline already completed successfully before this validation: `command -v tmux &gt;/dev/null || { echo &#34;tmux is required for e2e tests&#34; &gt;&amp;2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo &#34;== $t ==&#34;; bash &#34;$t&#34; || rc=1; done; exit &#34;$rc&#34;`</code>
- `/bin/bash tests/fm-bearings-snapshot.test.sh`
- <code>Constructed an evidence-only Firstmate home under `/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KXNMQAJT2EWCT5HH82Q3971Q`, with one dominant secondmate home and three sparse homes, then ran `FM_HOME=... FM_STATE_OVERRIDE=... FM_BEARINGS_NOW=2026-07-16T12:00:00Z /bin/bash bin/fm-bearings-snapshot.sh` and captured TOON output.</code>
- <code>Ran the same evidence fixture with `--json` and `--json --all-landed`, then checked the default landed owner/id order, counted landed omission disclosures, confirmed `--all-landed` returned 18 rows, and confirmed it had zero landed/snapshot-layer omission disclosures.</code>
- `git status --short`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
