### PR TITLE
fix: clarify captain-facing translation contract

### DIFF
--- a/.agents/skills/afk/SKILL.md
+++ b/.agents/skills/afk/SKILL.md
@@ -50,8 +50,7 @@ batched digest rather than per-wake injections.
 3. **Do not separately arm `fm-watch.sh`.** The daemon manages the watcher as
    its child; the singleton lock no-ops a stray arm harmlessly.
 
-4. **Acknowledge** to the captain that away-mode is active.
-   The daemon will self-handle routine wakes, escalate captain-relevant events and bounded declared-external-wait rechecks, and let the captain exit by sending any real message.
+4. **Acknowledge** in `AGENTS.md` section 9 language: "Captain, away mode is active; I will batch routine updates and surface only decisions, failures, credentials, or review-ready work until you return."
 
 ## How to exit afk
 

--- a/.agents/skills/bearings/SKILL.md
+++ b/.agents/skills/bearings/SKILL.md
@@ -32,7 +32,7 @@ It never tears down a task, merges a PR, dispatches new work, or mutates any tas
    Never read an earlier `data/status-report-*.md` to decide what to omit, include, describe as changed, or call current.
    The report uses the same four complete sections as the chat (see the chat-response contract below), in the same order, each always present, and adds the detail the chat omits:
    - **Title** - `# Bearings - <day> <YYYY-MM-DD>` (use "Morning status" only when the captain specifically asks for a morning brief), followed by two or three sentences framing where things stand.
-   - **Captain's Call** - every open decision relayed verbatim with its options, plus each PR ready to merge and each needed credential or login, every PR with the full `https://...` URL, never a bare `#number`.
+   - **Captain's Call** - every open decision summarized with its options from the structured decision record, plus each PR ready to merge and each needed credential or login, every PR with the full `https://...` URL, never a bare `#number`.
    - **Recently Landed** - the bounded current recent-completions baseline from structured state across the main fleet and every registered secondmate home, rendered in full on every run.
    - **Underway** - each live direct report making progress, with its current state, and the plans / main pickup pointers worth reopening (`data/<id>/report.md` files, `.lavish/*.html` boards).
    - **Charted Next** - queued or gated next work, with each item's blocker or date reason.
@@ -66,7 +66,7 @@ Rules that keep the contract unambiguous:
 - The four buckets are mutually exclusive, so every item is forced into exactly one: needs-your-action is Captain's Call, done is Recently Landed, self-progressing is Underway, not-yet-started is Charted Next.
 - The strict boundary keeps action-free items OUT of Captain's Call: a working or validating task, a queued item blocked on another task or a date, landed work, a completed scout's report pointer, a declared `paused:` external wait, and a bare recorded PR with no merge-ready signal each belong to one of the other three sections, never Captain's Call.
 - A secondmate appears Underway only for `active_child_work`; `externally_held` belongs in Charted Next, and `unknown` belongs there as an unavailable-state gate unless its reason requires the captain's action.
-- The chat carries one scannable line per item, each PR as the full `https://...` URL; the verbatim decisions, plans, full gate reasons, and evidence live only in the report file, which the chat links to, so the chat stays materially shorter than that file.
+- The chat follows `AGENTS.md` section 9 and carries one scannable line per item, each PR as the full `https://...` URL; detailed decisions, plans, full gate reasons, and evidence live only in the report file, which the chat links to, so the chat stays materially shorter than that file.
 
 ## Tone and content rules
 

--- a/.agents/skills/bootstrap-diagnostics/SKILL.md
+++ b/.agents/skills/bootstrap-diagnostics/SKILL.md
@@ -14,6 +14,7 @@ metadata:
 Handle each printed line as below, before dispatching work that depends on it.
 The line formats themselves are owned by `bin/fm-bootstrap.sh`'s header; this playbook owns the response.
 The inline rules in `AGENTS.md` section 3 still bind: detect, then consent, then install - never install anything the captain has not approved in this session - and no work is dispatched until the tools it needs are present and GitHub auth is good.
+When any diagnostic needs captain attention, report the plain consequence and requested action using `AGENTS.md` section 9's captain-facing translation contract; do not name the diagnostic label unless the captain needs to paste it into a command or issue.
 
 - `MISSING: <tool> (install: <command>)` - list the missing tools to the captain with a one-line purpose each plus the printed install commands, wait for consent (one approval may cover the list), then run `bin/fm-bootstrap.sh install <approved tools...>`.
   For `treehouse`, this also covers an installed version whose `treehouse get` lacks `--lease`; treat it as an upgrade request.

--- a/.agents/skills/decision-hold-lifecycle/SKILL.md
+++ b/.agents/skills/decision-hold-lifecycle/SKILL.md
@@ -31,7 +31,7 @@ Bearings reads the resulting structured state and must never compensate by scrap
 2. Inventory only genuine unresolved choices that require the captain.
 3. For each choice, choose a stable key and use the script's `hold` command with a concise title, reason, and repository.
 4. Run the script's `complete` command with the full unresolved-key inventory for that review pass.
-5. Relay the choices to the captain from the structured holds surfaced by Bearings.
+5. Relay the choices to the captain as decisions from Bearings' Captain's Call section under `AGENTS.md` section 9; do not use the word hold in captain chat.
 6. After the captain decides, record dependent work with normal tasks-axi commands and block it by the hold identity.
 7. Put the captain's exact durable decision in a file and use the script's `resolve` command with every routed task.
 8. Confirm Bearings no longer shows the closed hold and that routed work remains in structured backlog state.

--- a/.agents/skills/firstmate-codexapp/SKILL.md
+++ b/.agents/skills/firstmate-codexapp/SKILL.md
@@ -91,6 +91,7 @@ For Firstmate reconciliation, prefer concrete evidence:
 
 Avoid repeating long transcripts into Firstmate docs or PR bodies.
 Summarize only the host-tool calls, the status-file result, and the archive result.
+When reporting a Desktop-thread result to the captain, translate status prefixes and return-channel evidence through `AGENTS.md` section 9.
 
 ## Archive
 

--- a/.agents/skills/fmx-respond/SKILL.md
+++ b/.agents/skills/fmx-respond/SKILL.md
@@ -75,6 +75,7 @@ Normal reversible work - filing backlog, a scout investigation, gated code chang
 
 The answer is posted publicly through the relay under a **shared** bot identity.
 This is a strict version of the section 9 "talk in outcomes" rule, with a wider blast radius - assume anyone can read it.
+It supplements `AGENTS.md` section 9; apply both, and this public-channel rule wins wherever it is stricter.
 The asker being your own captain (owner-only routing) does **not** relax this: a public reply is public no matter who prompted it, so an owner's request never licenses leaking private state into a public reply.
 
 Never include, in any form:

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -31,7 +31,7 @@ The primary-session watcher wake protocols are rendered from `docs/supervision-p
 The supervision knowledge lives here: busy signature, exit command, interrupt, dialogs, resume behavior, skill invocation, and quirks.
 
 Never dispatch a crewmate or secondmate on an unverified adapter.
-If `config/crew-harness` or `config/secondmate-harness` names an unverified adapter, tell the captain and fall back to firstmate's own harness until that adapter is verified.
+If `config/crew-harness` or `config/secondmate-harness` names an unverified adapter, tell the captain under `AGENTS.md` section 9 that the requested worker runtime is not verified yet, name the practical fallback, and ask whether to verify it before future use.
 If the captain asks for a new harness, propose verifying it first: spawn a trivial supervised task using `fm-spawn`'s raw-launch-command escape hatch, confirm every fact empirically, then record the mechanics in `fm-spawn`, the busy signature in `fm-watch.sh` and `fm-tmux-lib.sh` defaults, any needed `FM_COMPOSER_IDLE_RE` empty-composer override plus any novel bare agent prompt glyph in `bin/fm-composer-lib.sh`'s shared composer classifier (the one fleet-wide owner of the empty/dead-shell/pending decision, so a new harness's own idle composer is not misread as a dead shell), the tmux agent-process liveness classification in `bin/backends/tmux.sh` when the harness can launch a secondmate, and the verified knowledge here.
 
 ## Detection

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -31,7 +31,8 @@ The primary-session watcher wake protocols are rendered from `docs/supervision-p
 The supervision knowledge lives here: busy signature, exit command, interrupt, dialogs, resume behavior, skill invocation, and quirks.
 
 Never dispatch a crewmate or secondmate on an unverified adapter.
-If `config/crew-harness` or `config/secondmate-harness` names an unverified adapter, tell the captain under `AGENTS.md` section 9 that the requested worker runtime is not verified yet, name the practical fallback, and ask whether to verify it before future use.
+If `config/crew-harness` or `config/secondmate-harness` names an unverified adapter, tell the captain under `AGENTS.md` section 9 that the requested worker runtime is not verified yet, use firstmate's own verified runtime for current work, and ask only whether to verify the requested runtime before future use.
+Do not pause current work for that future-verification choice, and never launch an unverified adapter.
 If the captain asks for a new harness, propose verifying it first: spawn a trivial supervised task using `fm-spawn`'s raw-launch-command escape hatch, confirm every fact empirically, then record the mechanics in `fm-spawn`, the busy signature in `fm-watch.sh` and `fm-tmux-lib.sh` defaults, any needed `FM_COMPOSER_IDLE_RE` empty-composer override plus any novel bare agent prompt glyph in `bin/fm-composer-lib.sh`'s shared composer classifier (the one fleet-wide owner of the empty/dead-shell/pending decision, so a new harness's own idle composer is not misread as a dead shell), the tmux agent-process liveness classification in `bin/backends/tmux.sh` when the harness can launch a secondmate, and the verified knowledge here.
 
 ## Detection

--- a/.agents/skills/stuck-crewmate-recovery/SKILL.md
+++ b/.agents/skills/stuck-crewmate-recovery/SKILL.md
@@ -46,4 +46,4 @@ Escalate in order:
    Genuine wedging means looping, unresponsive, repeating the same obstacle, or truly dead.
    A low context reading is not wedging; modern harnesses auto-compact and keep going.
    The worktree and commits persist, so relaunch is cheap.
-5. If a second relaunch fails too, write `failed` to the backlog and tell the captain with evidence.
+5. If a second relaunch fails too, write `failed` to the backlog and tell the captain the plain failure, preserved work, and consequence using `AGENTS.md` section 9; do not mention metadata, harness, window, or worktree unless the path itself is needed for action.

--- a/.agents/skills/updatefirstmate/SKILL.md
+++ b/.agents/skills/updatefirstmate/SKILL.md
@@ -44,7 +44,7 @@ This touches only the firstmate repo and its own worktrees, never anything under
    A secondmate that was skipped, already current, or has no live metadata is not on the list and needs no nudge.
 
 4. **Report to the captain in plain outcomes.**
-   Summarize what landed without firstmate's internal vocabulary: which parts of the fleet are now on the latest, and which were left as-is and why.
+   Summarize what landed under `AGENTS.md` section 9 without firstmate's internal vocabulary: which parts of the fleet are now on the latest, and which were left as-is and why.
    For example: "Captain, firstmate and both domain supervisors are now on the latest."
    Surface any skipped target whose reason needs the captain's attention - for instance a home with its own un-landed changes (diverged) or local edits (dirty), which were left untouched on purpose.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -358,9 +358,27 @@ Load `stuck-crewmate-recovery` after a stale wake, looping or confused pane, ans
 ## 9. Escalation and captain etiquette
 
 **Talk in outcomes, not mechanics.**
-Describe what is being investigated, built, ready, blocked, failed, or awaiting a decision in plain language at the captain's altitude.
-Do not expose internal terms such as startup machinery, locks, watchers, polling, crewmates, task ids, briefs, worktrees, status or metadata files, teardown, promotion, harness names, context budgets, delivery-mode names, or autonomy flags.
-Translate those details into the project's outcome and consequence.
+Every captain-facing message must translate internal state into the project outcome, consequence, and next decision.
+Use the captain's nouns: the investigation, the scout, the fix, the PR, the review, the decision, the blocker, the credential, the local copy, the worker, or the project.
+Do not expose internal terms such as startup machinery, locks, watchers, polling, crewmates, task ids, briefs, worktrees, checkouts, status or metadata files, teardown, promotion, harness names, runtime backend names, context budgets, delivery-mode names, autonomy flags, wake types, status prefixes, decision holds, pipeline step names, validation-state labels, or compressed safety labels such as fail-closed, fails closed, fail-open, fails open, fail loudly, or close variants.
+Scout is accepted Firstmate nautical house vocabulary and does not need translation when it naturally names that work.
+When evidence uses an internal label, rewrite it before sending:
+
+- worktree, checkout, primary checkout, or local-main -> local copy, isolated copy, or local branch, only if the location matters.
+- teardown -> cleanup.
+- wake, watcher, heartbeat, stale, signal, or check -> notification, monitoring, waiting too long, or stopped responding.
+- hold, gate, ask-user, needs-decision, blocked, or paused -> the concrete decision, wait, approval, blocker, or external delay.
+- done, failed, fix-review, checks-passed, cancelled, validation step, or pipeline state -> the concrete result, review finding, passing checks, failed check, or stopped validation.
+- brief -> instructions.
+- crewmate or secondmate -> worker or domain supervisor, only when naming the helper matters.
+- harness, backend, runtime, or adapter -> worker runtime or tool, only when the tool choice itself blocks work.
+- status file, metadata, state, task id, or raw path -> durable record, local record, or omit it unless the captain needs the file path to act.
+- fail-closed, fails closed, fail loudly, or refuses loudly -> stops safely when something goes wrong, refuses rather than proceeding, or reports the concrete missing requirement.
+- fail-open, fails open, passive fail-open, or degraded-open -> steps aside and lets work continue when the check cannot complete, or continues without that optional protection.
+
+Never relay worker reports, status lines, tool output, validation-state labels, or decision records verbatim into captain chat.
+Read them as evidence, then send the plain-English outcome and consequence.
+Private evidence reports may retain exact identifiers, paths, status lines, validation labels, and internal terms when they are useful, but the captain-facing chat summary that points to the report still follows this translation rule.
 
 Every escalation must stand alone and remain concise.
 Lead directly with concrete evidence, then the consequence, options when applicable, and a recommendation.

--- a/tests/fm-captain-translation-contract.test.sh
+++ b/tests/fm-captain-translation-contract.test.sh
@@ -111,6 +111,10 @@ test_outward_facing_skill_points_reference_section_9_owner() {
     "stuck-worker failure does not reference section 9"
   assert_grep "under \`AGENTS.md\` section 9 that the requested worker runtime is not verified yet" "$HARNESS" \
     "runtime fallback does not reference section 9"
+  assert_grep "use firstmate's own verified runtime for current work" "$HARNESS" \
+    "runtime fallback does not require the current-work fallback"
+  assert_grep "Do not pause current work for that future-verification choice, and never launch an unverified adapter." "$HARNESS" \
+    "runtime fallback permits waiting on future verification or launching an unverified adapter"
   assert_grep "translate status prefixes and return-channel evidence through \`AGENTS.md\` section 9" "$CODEXAPP" \
     "Codex Desktop result reporting does not reference section 9"
   assert_grep "It supplements \`AGENTS.md\` section 9; apply both, and this public-channel rule wins wherever it is stricter." "$FMX" \

--- a/tests/fm-captain-translation-contract.test.sh
+++ b/tests/fm-captain-translation-contract.test.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# Static regression tests for the captain-facing plain-English translation
+# contract owned by AGENTS.md section 9.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+AGENTS="$ROOT/AGENTS.md"
+BOOTSTRAP="$ROOT/.agents/skills/bootstrap-diagnostics/SKILL.md"
+AFK="$ROOT/.agents/skills/afk/SKILL.md"
+DECISION="$ROOT/.agents/skills/decision-hold-lifecycle/SKILL.md"
+RECOVERY="$ROOT/.agents/skills/stuck-crewmate-recovery/SKILL.md"
+HARNESS="$ROOT/.agents/skills/harness-adapters/SKILL.md"
+CODEXAPP="$ROOT/.agents/skills/firstmate-codexapp/SKILL.md"
+FMX="$ROOT/.agents/skills/fmx-respond/SKILL.md"
+UPDATE="$ROOT/.agents/skills/updatefirstmate/SKILL.md"
+
+section_9() {
+  awk '
+    /^## 9\. Escalation and captain etiquette$/ { found = 1 }
+    found && /^## 10\. / { exit }
+    found { print }
+  ' "$AGENTS"
+}
+
+test_section_9_owns_positive_translation_contract() {
+  local contract
+  contract=$(section_9)
+  assert_contains "$contract" "Every captain-facing message must translate internal state into the project outcome, consequence, and next decision." \
+    "section 9 does not own the positive captain-facing translation contract"
+  assert_contains "$contract" "Use the captain's nouns:" \
+    "section 9 does not require captain-owned nouns"
+  assert_contains "$contract" "When evidence uses an internal label, rewrite it before sending:" \
+    "section 9 does not own the rewrite mapping list"
+  pass "section 9 owns the positive captain-facing translation contract"
+}
+
+test_scout_remains_allowed_house_vocabulary() {
+  local contract
+  contract=$(section_9)
+  assert_contains "$contract" "Scout is accepted Firstmate nautical house vocabulary and does not need translation" \
+    "section 9 does not preserve scout as allowed Firstmate vocabulary"
+  assert_not_contains "$contract" "scout -> investigation" \
+    "section 9 must not map scout to investigation"
+  assert_not_contains "$contract" "scout, ship" \
+    "section 9 must not add scout to the internal-vocabulary ban"
+  pass "scout remains allowed in private captain chat"
+}
+
+test_compressed_safety_labels_have_plain_renderings() {
+  local contract
+  contract=$(section_9)
+  for phrase in \
+    "fail-closed" \
+    "fails closed" \
+    "fail-open" \
+    "fails open" \
+    "fail loudly"; do
+    assert_contains "$contract" "$phrase" "section 9 does not cover compressed safety label '$phrase'"
+  done
+  assert_contains "$contract" "stops safely when something goes wrong" \
+    "fail-closed behavior lacks a concrete plain rendering"
+  assert_contains "$contract" "refuses rather than proceeding" \
+    "fail-closed behavior lacks refusal wording"
+  assert_contains "$contract" "steps aside and lets work continue when the check cannot complete" \
+    "fail-open behavior lacks a concrete plain rendering"
+  pass "compressed safety labels require concrete plain renderings"
+}
+
+test_mapping_list_covers_high_risk_internal_families() {
+  local contract
+  contract=$(section_9)
+  for phrase in \
+    "worktree, checkout, primary checkout, or local-main -> local copy" \
+    "teardown -> cleanup" \
+    "wake, watcher, heartbeat, stale, signal, or check -> notification" \
+    "hold, gate, ask-user, needs-decision, blocked, or paused -> the concrete decision" \
+    "done, failed, fix-review, checks-passed, cancelled, validation step, or pipeline state -> the concrete result" \
+    "brief -> instructions" \
+    "crewmate or secondmate -> worker or domain supervisor" \
+    "harness, backend, runtime, or adapter -> worker runtime or tool" \
+    "status file, metadata, state, task id, or raw path -> durable record"; do
+    assert_contains "$contract" "$phrase" "section 9 mapping list is missing '$phrase'"
+  done
+  pass "section 9 maps high-risk internal vocabulary families"
+}
+
+test_verbatim_internal_evidence_is_rejected_from_chat() {
+  local contract
+  contract=$(section_9)
+  assert_contains "$contract" "Never relay worker reports, status lines, tool output, validation-state labels, or decision records verbatim into captain chat." \
+    "section 9 does not reject verbatim internal evidence in captain chat"
+  assert_contains "$contract" "Private evidence reports may retain exact identifiers, paths, status lines, validation labels, and internal terms" \
+    "section 9 does not preserve private evidence precision"
+  assert_contains "$contract" "the captain-facing chat summary that points to the report still follows this translation rule" \
+    "section 9 does not keep chat summaries plain English"
+  pass "captain chat rejects verbatim internal evidence while private reports stay precise"
+}
+
+test_outward_facing_skill_points_reference_section_9_owner() {
+  assert_grep "using \`AGENTS.md\` section 9's captain-facing translation contract" "$BOOTSTRAP" \
+    "bootstrap diagnostics do not reference section 9 at captain handoff"
+  assert_grep "Acknowledge** in \`AGENTS.md\` section 9 language" "$AFK" \
+    "afk acknowledgement does not reference section 9"
+  assert_grep "Captain, away mode is active; I will batch routine updates" "$AFK" \
+    "afk acknowledgement lacks a local plain-English example"
+  assert_grep "as decisions from Bearings' Captain's Call section under \`AGENTS.md\` section 9" "$DECISION" \
+    "decision relay does not reference section 9"
+  assert_grep "using \`AGENTS.md\` section 9; do not mention metadata, harness, window, or worktree" "$RECOVERY" \
+    "stuck-worker failure does not reference section 9"
+  assert_grep "under \`AGENTS.md\` section 9 that the requested worker runtime is not verified yet" "$HARNESS" \
+    "runtime fallback does not reference section 9"
+  assert_grep "translate status prefixes and return-channel evidence through \`AGENTS.md\` section 9" "$CODEXAPP" \
+    "Codex Desktop result reporting does not reference section 9"
+  assert_grep "It supplements \`AGENTS.md\` section 9; apply both, and this public-channel rule wins wherever it is stricter." "$FMX" \
+    "X reply safety does not state that it supplements section 9"
+  assert_grep "under \`AGENTS.md\` section 9 without firstmate's internal vocabulary" "$UPDATE" \
+    "Firstmate update reporting does not reference section 9"
+  pass "outward-facing skill handoffs point to the section 9 owner"
+}
+
+test_section_9_owner_is_not_duplicated_into_skills() {
+  local duplicate_count file
+  duplicate_count=0
+  for file in "$BOOTSTRAP" "$AFK" "$DECISION" "$RECOVERY" "$HARNESS" "$CODEXAPP" "$UPDATE"; do
+    if grep -Fq "When evidence uses an internal label, rewrite it before sending:" "$file"; then
+      duplicate_count=$((duplicate_count + 1))
+    fi
+  done
+  [ "$duplicate_count" -eq 0 ] || fail "skills duplicated section 9's mapping owner"
+  pass "skills cross-reference section 9 instead of duplicating the mapping list"
+}
+
+test_section_9_owns_positive_translation_contract
+test_scout_remains_allowed_house_vocabulary
+test_compressed_safety_labels_have_plain_renderings
+test_mapping_list_covers_high_risk_internal_families
+test_verbatim_internal_evidence_is_rejected_from_chat
+test_outward_facing_skill_points_reference_section_9_owner
+test_section_9_owner_is_not_duplicated_into_skills


### PR DESCRIPTION
## Intent

Implement the captain-approved amended plain-English translation contract as one small Firstmate PR. Make AGENTS.md section 9 the single authoritative positive translation contract for every captain-facing message, requiring project outcome, consequence, and next decision in the captain's nouns rather than internal mechanics. Preserve the internal-vocabulary prohibition while adding positive mappings, explicitly reject verbatim relay of worker reports, status lines, tool output, validation labels, or decision records into captain chat, and allow private evidence reports to retain exact identifiers and internal terms. Keep scout as accepted Firstmate nautical house vocabulary and do not ban or map it to investigation. Add concrete plain renderings for fail-closed, fails closed, fail-open, fails open, fail loudly, and related compressed safety idioms, so fail-closed becomes stops safely or refuses rather than proceeding and fail-open becomes steps aside and lets work continue when a check cannot complete. Add only narrow section 9 cross-references or local examples at outward-facing handoff points in bootstrap diagnostics, AFK acknowledgement, decision relay, stuck-worker failure, runtime fallback, Codex Desktop results, X replies, and Firstmate update reporting, with X mode's stricter public-channel list supplementing section 9. Do not create a new translation skill, duplicate the full mapping list across skills, remove precise internal vocabulary from agent-only procedures, or change runtime behavior. Include focused static regression coverage proving section 9 owns the positive contract, scout remains permitted, compressed safety idioms have concrete plain renderings, outward-facing skill points reference the owner, and verbatim internal status or validation labels are rejected from captain-facing examples. Let no-mistakes v1.38.1 perform its guarded branch sync onto current main; report any branch-sync refusal, wrong head, lost commit, dirty state, credential failure, or unexpected diff as blocked with exact evidence.

## What Changed
- Updated `AGENTS.md` section 9 as the authoritative captain-facing plain-language translation contract, adding positive mappings for outcomes, consequences, next decisions, and compressed safety idioms while preserving private evidence terminology.
- Added narrow section 9 references and local plain-language examples across outward-facing skill handoff points, including AFK, Bearings, bootstrap diagnostics, decision relay, runtime fallback, Codex Desktop, X replies, stuck-worker recovery, and update reporting.
- Added focused static regression coverage for ownership of the translation contract, permitted Firstmate vocabulary, safety-idiom renderings, outward-facing cross-references, and rejection of verbatim internal labels in captain-facing examples.

## Risk Assessment

✅ Low: The final change is a bounded documentation and static-regression update, and the previously identified runtime fallback behavior is now explicitly preserved.

## Testing

The preconfigured full shell test suite was already green; I then ran the focused translation-contract regression test, verified the target HEAD, base ancestry, no-mistakes v1.38.1, expected changed-file set, and clean worktree, and captured reviewer-visible markdown evidence showing the actual section 9 contract and outward-facing references.

<details>
<summary>Evidence: captain-translation-contract-evidence</summary>

`Reviewer-readable evidence containing the rendered section 9 contract, outward-facing handoff references, repository state, no-mistakes version, and focused test transcript.`

```text
# Captain translation contract evidence

## Repository state

- HEAD: ff3e5c366c89d4cafe03e45bb44af51ba26fff91
- Base: c1155611c840765f44d9863b4eacfc06a2dda139
- Base ancestry: base-is-ancestor
- no-mistakes: no-mistakes version v1.38.1 (071f455) 2026-07-16T08:04:21Z

## Changed files from base

`` `
M	.agents/skills/afk/SKILL.md
M	.agents/skills/bootstrap-diagnostics/SKILL.md
M	.agents/skills/decision-hold-lifecycle/SKILL.md
M	.agents/skills/firstmate-codexapp/SKILL.md
M	.agents/skills/fmx-respond/SKILL.md
M	.agents/skills/harness-adapters/SKILL.md
M	.agents/skills/stuck-crewmate-recovery/SKILL.md
M	.agents/skills/updatefirstmate/SKILL.md
M	AGENTS.md
A	tests/fm-captain-translation-contract.test.sh
`` `

## AGENTS.md section 9 rendered contract

`` `markdown
## 9. Escalation and captain etiquette

**Talk in outcomes, not mechanics.**
Every captain-facing message must translate internal state into the project outcome, consequence, and next decision.
Use the captain's nouns: the investigation, the scout, the fix, the PR, the review, the decision, the blocker, the credential, the local copy, the worker, or the project.
Do not expose internal terms such as startup machinery, locks, watchers, polling, crewmates, task ids, briefs, worktrees, checkouts, status or metadata files, teardown, promotion, harness names, runtime backend names, context budgets, delivery-mode names, autonomy flags, wake types, status prefixes, decision holds, pipeline step names, validation-state labels, or compressed safety labels such as fail-closed, fails closed, fail-open, fails open, fail loudly, or close variants.
Scout is accepted Firstmate nautical house vocabulary and does not need translation when it naturally names that work.
When evidence uses an internal label, rewrite it before sending:

- worktree, checkout, primary checkout, or local-main -> local copy, isolated copy, or local branch, only if the location matters.
- teardown -> cleanup.
- wake, watcher, heartbeat, stale, signal, or check -> notification, monitoring, waiting too long, or stopped responding.
- hold, gate, ask-user, needs-decision, blocked, or paused -> the concrete decision, wait, approval, blocker, or external delay.
- done, failed, fix-review, checks-passed, cancelled, validation step, or pipeline state -> the concrete result, review finding, passing checks, failed check, or stopped validation.
- brief -> instructions.
- crewmate or secondmate -> worker or domain supervisor, only when naming the helper matters.
- harness, backend, runtime, or adapter -> worker runtime or tool, only when the tool choice itself blocks work.
- status file, metadata, state, task id, or raw path -> durable record, local record, or omit it unless the captain needs the file path to act.
- fail-closed, fails closed, fail loudly, or refuses loudly -> stops safely when something goes wrong, refuses rather than proceeding, or reports the concrete missing requirement.
- fail-open, fails open, passive fail-open, or degraded-open -> steps aside and lets work continue when the check cannot complete, or continues without that optional protection.

Never relay worker reports, status lines, tool output, validation-state labels, or decision records verbatim into captain chat.
Read them as evidence, then send the plain-English outcome and consequence.
Private evidence reports may retain exact identifiers, paths, status lines, validation labels, and internal terms when they are useful, but the captain-facing chat summary that points to the report still follows this translation rule.

Every escalation must stand alone and remain concise.
Lead directly with concrete evidence, then the consequence, options when applicable, and a recommendation.
Use the same evidence-first form for objections or clarifying challenges rather than unsupported deference.

Reach the captain immediately for:

- Work ready for their review, with the full PR URL.
- Finished investigation findings, relayed as findings rather than only a completion notice.
- Gate findings that require their decision under the configured authority.
- A real blocker or failure after the relevant playbook is exhausted.
- Anything destructive, irreversible, or security-sensitive.
- A needed credential or login.

Do not surface automatic fixes, retries, routine progress, or internal supervision mechanics.
Batch non-urgent updates into the next natural reply.
Use plain chat for a yes-or-no decision and `lavish-axi` only when several options or a structured report benefit from a visual surface.
Whenever a PR is mentioned, include its full `https://...` URL before any shorthand reference.
Mention cost as a courtesy when unusually much work is running, but never block on it.

`` `

## Outward-facing section 9 handoff references

`` `

== .agents/skills/bootstrap-diagnostics/SKILL.md ==
17:When any diagnostic needs captain attention, report the plain consequence and requested action using `AGENTS.md` section 9's captain-facing translation contract; do not name the diagnostic label unless the captain needs to paste it into a command or issue.

== .agents/skills/afk/SKILL.md ==
53:4. **Acknowledge** in `AGENTS.md` section 9 language: "Captain, away mode is active; I will batch routine updates and surface only decisions, failures, credentials, or review-ready work until you return."

== .agents/skills/decision-hold-lifecycle/SKILL.md ==
34:5. Relay the choices to the captain as decisions from Bearings' Captain's Call section under `AGENTS.md` section 9; do not use the word hold in captain chat.

== .agents/skills/stuck-crewmate-recovery/SKILL.md ==
49:5. If a second relaunch fails too, write `failed` to the backlog and tell the captain the plain failure, preserved work, and consequence using `AGENTS.md` section 9; do not mention metadata, harness, window, or worktree unless the path itself is needed for action.

== .agents/skills/harness-adapters/SKILL.md ==
34:If `config/crew-harness` or `config/secondmate-harness` names an unverified adapter, tell the captain under `AGENTS.md` section 9 that the requested worker runtime is not verified yet, use firstmate's own verified runtime for current work, and ask only whether to verify the requested runtime before future use.
35:Do not pause current work for that future-verification choice, and never launch an unverified adapter.

== .agents/skills/firstmate-codexapp/SKILL.md ==
94:When reporting a Desktop-thread result to the captain, translate status prefixes and return-channel evidence through `AGENTS.md` section 9.

== .agents/skills/fmx-respond/SKILL.md ==
77:This is a strict version of the section 9 "talk in outcomes" rule, with a wider blast radius - assume anyone can read it.
78:It supplements `AGENTS.md` section 9; apply both, and this public-channel rule wins wherever it is stricter.

== .agents/skills/updatefirstmate/SKILL.md ==
47:   Summarize what landed under `AGENTS.md` section 9 without firstmate's internal vocabulary: which parts of the fleet are now on the latest, and which were left as-is and why.
`` `

## Focused regression test transcript

`` `
ok - section 9 owns the positive captain-facing translation contract
ok - scout remains allowed in private captain chat
ok - compressed safety labels require concrete plain renderings
ok - section 9 maps high-risk internal vocabulary families
ok - captain chat rejects verbatim internal evidence while private reports stay precise
ok - outward-facing skill handoffs point to the section 9 owner
ok - skills cross-reference section 9 instead of duplicating the mapping list
`` `
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `.agents/skills/harness-adapters/SKILL.md:34` - Intent says to &#34;add only narrow section 9 cross-references ... at ... runtime fallback&#34; and &#34;do not ... change runtime behavior,&#34; but this hunk removed the imperative to actually fall back to Firstmate&#39;s own harness. Previous text said `tell the captain and fall back to firstmate&#39;s own harness until that adapter is verified`; the new text only says to name the practical fallback and ask about future verification, so an agent may now pause or only report the fallback instead of using it.

🔧 Fix: Restore runtime fallback mandate
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- <code>Baseline already ran successfully before this validation: `command -v tmux &gt;/dev/null || { echo &#34;tmux is required for e2e tests&#34; &gt;&amp;2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo &#34;== $t ==&#34;; bash &#34;$t&#34; || rc=1; done; exit &#34;$rc&#34;`</code>
- `bash tests/fm-captain-translation-contract.test.sh`
- <code>`git rev-parse HEAD` confirmed `ff3e5c366c89d4cafe03e45bb44af51ba26fff91`</code>
- `git merge-base --is-ancestor c1155611c840765f44d9863b4eacfc06a2dda139 HEAD`
- `git diff --name-status c1155611c840765f44d9863b4eacfc06a2dda139..HEAD`
- <code>`no-mistakes --version` confirmed `v1.38.1`</code>
- <code>Created `/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KXNRYZC7MMMEKTJZ5QSNR5V9/captain-translation-contract-evidence.md` from `AGENTS.md`, changed skill references, repository-state checks, and the focused regression test transcript</code>
- `git status --short`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
