### PR TITLE
docs(secondmate-provisioning): clarify concise registry ownership

### DIFF
--- a/.agents/skills/secondmate-provisioning/SKILL.md
+++ b/.agents/skills/secondmate-provisioning/SKILL.md
@@ -17,12 +17,15 @@ Keep the always-inline routing rules in `AGENTS.md` authoritative: route by natu
 
 ## Routing table
 
-`data/secondmates.md` has one line per persistent domain supervisor:
+`data/secondmates.md` has one parser-compatible line per persistent domain supervisor:
 
 ```markdown
-- <id> - <charter summary> (home: <absolute-home-path>; scope: <natural-language responsibility>; projects: <project-a>, <project-b>; added <date>)
+- <id> - <one-sentence charter summary> (home: <absolute-home-path>; scope: <natural-language responsibility>; projects: <project-a>, <project-b>; added <date>)
 ```
 
+Each registry entry stays concise and single-line: the summary is one sentence naming the durable charter, `scope:` is the natural-language intake responsibility, `projects:` is the non-exclusive clone list, and any extra prose is limited to genuinely domain-specific hard rules that change routing or safety for that secondmate.
+The `home:` path points to the seeded home containing `data/charter.md`; no extra registry pointer field is needed.
+The home-seeded `data/charter.md` is the sole owner of boilerplate idle-by-default behavior, the normal delegation lifecycle, and standard escalation contracts, so point to that charter rather than restating those contracts in the registry entry.
 The `scope:` field is used during intake.
 The `projects:` field is a non-exclusive clone list, not ownership.
 
@@ -41,9 +44,9 @@ Pass `--no-projects` instead of a project list to scaffold a project-less charte
 `--no-projects` is mutually exclusive with a project list, and omitting both still fails loudly, so an accidental omission is never mistaken for a deliberate project-less seed.
 Re-seeding a populated home as project-less is refused non-destructively when the home contains project clones or `data/projects.md` entries.
 Retire or clean that home first, and re-scaffold a stale project-bearing charter with `--no-projects` before seeding.
-Keep the charter focused on the persistent responsibility, available project clones, escalation back to the main firstmate status file, and the requests-from-main-firstmate contract.
-The scaffold's definition of done encodes the idle-by-default contract: on startup the secondmate reconciles only its own in-flight work and then waits for routed tasks, never self-initiating a survey or audit.
-Preserve that wording when filling the charter, including the marker rule that marked supervisor requests return through status or a doc pointer while unmarked captain messages stay conversational.
+Keep custom charter text focused on the persistent responsibility, available project clones, and genuinely domain-specific hard rules.
+The scaffolded charter, later copied to `data/charter.md`, owns the standard lifecycle and escalation wording.
+Preserve the generated charter sections unless the domain genuinely needs a hard rule.
 
 Provision the persistent home and registry entry after the charter is filled:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -161,7 +161,7 @@ An explicit per-spawn harness or raw launch command does not inherit model or ef
 `config/crew-dispatch.json` is inherited too; secondmates use the same natural-language dispatch profiles when spawning their own crewmates.
 `config/backlog-backend` is inherited too; absent or `tasks-axi` selects the default tasks-axi backlog backend, while `manual` forces routine backlog updates to hand-editing across the fleet without disabling validated handoff delegation.
 
-The `data/secondmates.md` line schema and the secondmate environment variables are documented in [configuration.md](configuration.md).
+The `data/secondmates.md` line contract is owned by the [`secondmate-provisioning` skill](../.agents/skills/secondmate-provisioning/SKILL.md#routing-table), and the secondmate environment variables are documented in [configuration.md](configuration.md).
 
 ## Project modes are explicit
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -121,7 +121,8 @@ The file is created lazily on first learning and follows the same dated, evidenc
 ## Secondmate routes (data/secondmates.md)
 
 Persistent secondmate routes live locally in `data/secondmates.md`.
-Each line records the secondmate id, charter summary, absolute home path, natural-language scope, project clone list, and added date; `fm-home-seed.sh validate` refuses duplicate ids, duplicate homes, and nested or overlapping homes.
+The concise single-line route contract is owned by the [`secondmate-provisioning` skill](../.agents/skills/secondmate-provisioning/SKILL.md#routing-table), including the parser-compatible fields, one-sentence summary requirement, `home:` pointer to the seeded charter, and limit on extra registry prose.
+`fm-home-seed.sh validate` refuses duplicate ids, duplicate homes, and nested or overlapping homes.
 The main first mate routes by reading those scopes with judgment; the project list is provisioning data, not exclusive ownership.
 Use `fm-home-seed.sh <id> - {<project>...|--no-projects}` to lease a fresh firstmate worktree for the secondmate home.
 Use the deliberate `--no-projects` signal only for a firstmate-repo domain that needs no separate project clones.
@@ -134,6 +135,7 @@ Secondmate routes cover `no-mistakes` and `direct-PR` projects; `local-only` pro
 For `no-mistakes` projects, seeding initializes only projects newly cloned into a secondmate home and refuses to mutate a preexisting clone that is not already initialized.
 After creating a secondmate, move existing main-backlog queued items that you have judged in-scope with `fm-backlog-handoff.sh <secondmate-id> <item-key>...`; it is idempotent and refuses In flight, Done, or non-secondmate homes.
 Set `FM_SECONDMATE_CHARTER` to seed from inline charter text when no filled charter brief exists; set `FM_SECONDMATE_SCOPE` when the routing scope should differ from the charter text.
+The seeded home's `data/charter.md` owns the standard secondmate lifecycle and escalation contract; the route file points to it through the existing `home:` field instead of adding another pointer.
 Each seed writes an `.fm-secondmate-home` identity marker at the home root.
 The tracked root `.gitignore` ignores that marker, so validation can read it without making a freshly seeded home appear dirty to porcelain-based safety checks.
 This does not relax protection for any other untracked file.

--- a/tests/fm-instruction-owners.test.sh
+++ b/tests/fm-instruction-owners.test.sh
@@ -12,6 +12,7 @@ PROJECT="$ROOT/.agents/skills/project-management/SKILL.md"
 HARNESS="$ROOT/.agents/skills/harness-adapters/SKILL.md"
 CODING="$ROOT/.agents/skills/firstmate-coding-guidelines/SKILL.md"
 RECOVERY="$ROOT/.agents/skills/stuck-crewmate-recovery/SKILL.md"
+SECONDMATE="$ROOT/.agents/skills/secondmate-provisioning/SKILL.md"
 CONFIG="$ROOT/docs/configuration.md"
 AGENTS="$ROOT/AGENTS.md"
 BRIEF="$ROOT/bin/fm-brief.sh"
@@ -111,6 +112,37 @@ test_shared_authoring_requirements_are_owned() {
   pass "firstmate-coding-guidelines owns compatibility review and deterministic enforcement"
 }
 
+test_secondmate_registry_contract_stays_concise() {
+  local section schema_line
+  section=$(awk '
+    /^## Routing table$/ { found = 1 }
+    found && /^## Charter and seed$/ { exit }
+    found { print }
+  ' "$SECONDMATE")
+  schema_line="- <id> - <one-sentence charter summary> (home: <absolute-home-path>; scope: <natural-language responsibility>; projects: <project-a>, <project-b>; added <date>)"
+  assert_contains "$section" "$schema_line" \
+    "secondmate routing table lost the parser-compatible single-line schema"
+  assert_contains "$section" "Each registry entry stays concise and single-line" \
+    "secondmate routing table no longer requires concise single-line entries"
+  assert_contains "$section" "genuinely domain-specific hard rules" \
+    "secondmate routing table no longer limits extra prose to domain-specific hard rules"
+  assert_contains "$section" "The home-seeded \`data/charter.md\` is the sole owner of boilerplate idle-by-default behavior, the normal delegation lifecycle, and standard escalation contracts" \
+    "secondmate routing table lost the explicit charter ownership pointer"
+  assert_contains "$section" "no extra registry pointer field is needed" \
+    "secondmate routing table no longer explains why the existing home field is the charter pointer"
+  for phrase in \
+    "go idle and wait silently" \
+    "Act only on tasks" \
+    "never spawn a survey" \
+    "run normal firstmate bootstrap" \
+    "marked supervisor requests return through status"; do
+    if printf '%s\n' "$section" | grep -F "$phrase" >/dev/null; then
+      fail "secondmate routing table restated charter boilerplate: $phrase"
+    fi
+  done
+  pass "secondmate registry guidance keeps concise routes and points to the charter"
+}
+
 test_state_startup_and_ordinary_recovery_placement() {
   assert_grep "single owner of the top-level operational-home layout" "$CONFIG" \
     "configuration docs do not own the operational state layout"
@@ -185,6 +217,7 @@ test_diagnostic_owner_covers_causal_procedure
 test_project_management_owner_covers_guarded_operations
 test_generic_effort_fallback_respects_precedence
 test_shared_authoring_requirements_are_owned
+test_secondmate_registry_contract_stays_concise
 test_state_startup_and_ordinary_recovery_placement
 test_compressed_agents_owner_map
 test_compressed_agents_retains_authority_and_supervision_safety

--- a/tests/fm-instruction-owners.test.sh
+++ b/tests/fm-instruction-owners.test.sh
@@ -113,31 +113,40 @@ test_shared_authoring_requirements_are_owned() {
 }
 
 test_secondmate_registry_contract_stays_concise() {
-  local section schema_line
-  section=$(awk '
+  local guidance routing_section schema_line
+  routing_section=$(awk '
     /^## Routing table$/ { found = 1 }
     found && /^## Charter and seed$/ { exit }
     found { print }
   ' "$SECONDMATE")
+  guidance=$(awk '
+    /^## Routing table$/ { found = 1 }
+    found && /^## Backlog handoff$/ { exit }
+    found { print }
+  ' "$SECONDMATE")
   schema_line="- <id> - <one-sentence charter summary> (home: <absolute-home-path>; scope: <natural-language responsibility>; projects: <project-a>, <project-b>; added <date>)"
-  assert_contains "$section" "$schema_line" \
+  assert_contains "$routing_section" "$schema_line" \
     "secondmate routing table lost the parser-compatible single-line schema"
-  assert_contains "$section" "Each registry entry stays concise and single-line" \
+  assert_contains "$routing_section" "Each registry entry stays concise and single-line" \
     "secondmate routing table no longer requires concise single-line entries"
-  assert_contains "$section" "genuinely domain-specific hard rules" \
+  assert_contains "$routing_section" "genuinely domain-specific hard rules" \
     "secondmate routing table no longer limits extra prose to domain-specific hard rules"
-  assert_contains "$section" "The home-seeded \`data/charter.md\` is the sole owner of boilerplate idle-by-default behavior, the normal delegation lifecycle, and standard escalation contracts" \
+  assert_contains "$routing_section" "The home-seeded \`data/charter.md\` is the sole owner of boilerplate idle-by-default behavior, the normal delegation lifecycle, and standard escalation contracts" \
     "secondmate routing table lost the explicit charter ownership pointer"
-  assert_contains "$section" "no extra registry pointer field is needed" \
+  assert_contains "$routing_section" "no extra registry pointer field is needed" \
     "secondmate routing table no longer explains why the existing home field is the charter pointer"
   for phrase in \
     "go idle and wait silently" \
     "Act only on tasks" \
     "never spawn a survey" \
     "run normal firstmate bootstrap" \
-    "marked supervisor requests return through status"; do
-    if printf '%s\n' "$section" | grep -F "$phrase" >/dev/null; then
-      fail "secondmate routing table restated charter boilerplate: $phrase"
+    "escalation back to the main firstmate status file" \
+    "requests-from-main-firstmate contract" \
+    "waits for routed tasks, never self-initiating a survey or audit" \
+    "marked supervisor requests return through status" \
+    "unmarked captain messages stay conversational"; do
+    if printf '%s\n' "$guidance" | grep -F "$phrase" >/dev/null; then
+      fail "secondmate provisioning guidance restated charter boilerplate: $phrase"
     fi
   done
   pass "secondmate registry guidance keeps concise routes and points to the charter"


### PR DESCRIPTION
## Intent

Implement the captain-ordered concise secondmate routing-table contract as one small Firstmate PR after the overlapping bootstrap and nudge PR lands. Preserve the parser-compatible single-line identity, home, project-list, scope, and added-date registry fields. Keep each data/secondmates.md entry to a one-sentence charter summary, explicit natural-language scope, and only genuinely domain-specific hard rules. Make the seeded home's data/charter.md the sole owner of boilerplate idle-by-default behavior, normal delegation lifecycle, and standard escalation contracts, with the registry pointing through the existing home field rather than adding a new pointer field. Do not rewrite captain-private data/secondmates.md, do not duplicate boilerplate into another tracked owner, and do not expand AGENTS.md unless its trigger became incorrect. Add focused regression coverage so future guidance cannot regress to multiline summaries or repeated boilerplate and so the charter pointer remains explicit. Let no-mistakes v1.39.0 own custody recovery and synchronization onto current main; do not reset, cherry-pick, merge, or hand-copy commits.

## What Changed
- Tightened the secondmate registry guidance so `data/secondmates.md` entries stay parser-compatible and concise, with one-sentence charter summaries, explicit natural-language scope, and domain-specific hard rules only.
- Clarified that seeded home `data/charter.md` owns standard idle, delegation lifecycle, and escalation boilerplate, with docs pointing through the existing `home` field instead of adding another pointer.
- Added focused instruction-owner regression coverage to catch multiline registry summaries, repeated boilerplate, and missing charter pointer guidance.

## Risk Assessment

✅ Low: The updated change is well-bounded to guidance plus static regression coverage, preserves the parser-compatible registry fields and explicit charter pointer, and addresses the prior coverage gap without introducing new source-verifiable risks.

## Testing

The pre-run full baseline was already green; I then reran the focused instruction-owner, brief, and secondmate lifecycle tests, plus a manual end-to-end secondmate scaffold/seed/validate flow that produced reviewer-visible evidence of the concise registry contract. All checks passed.

<details>
<summary>Evidence: Secondmate registry contract E2E evidence</summary>

```text
Manual end-to-end secondmate seed evidence
Active home: /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T//fm-secondmate-contract-e2e.1SIVZA/main-home
Requested secondmate home: /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T//fm-secondmate-contract-e2e.1SIVZA/onboarding-home
scaffolded: /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T//fm-secondmate-contract-e2e.1SIVZA/main-home/data/onboarding/brief.md (secondmate charter)
home=/private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/fm-secondmate-contract-e2e.1SIVZA/onboarding-home

Registry entry written to main data/secondmates.md:
- onboarding - Customer onboarding guidance. (home: /private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/fm-secondmate-contract-e2e.1SIVZA/onboarding-home; scope: customer onboarding routing and escalations; projects: alpha; added 2026-07-16)

Registry line count for onboarding id:
1

Registry line intentionally omits standard charter boilerplate phrases:
no boilerplate phrases found in registry line

Seeded charter owner exists at home/data/charter.md and contains lifecycle boilerplate:
Act only on tasks the main firstmate routes to you.
When you have no assigned or in-flight work after that reconciliation, go idle and wait silently for the main firstmate to route you a task.

Parser-compatible field check:
identity/home/scope/projects/added fields present on one line
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `tests/fm-instruction-owners.test.sh:117` - Intent requires: &#34;Add focused regression coverage so future guidance cannot regress to multiline summaries or repeated boilerplate.&#34; The added test only extracts the `## Routing table` section and checks boilerplate phrases there, but the boilerplate this PR removed was in `## Charter and seed`, so reintroducing it in that section would still pass. Expand the regression check to cover the section where the removed boilerplate lived, or otherwise scan the relevant guidance owner for repeated boilerplate.

🔧 Fix: Expand secondmate registry boilerplate coverage
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- <code>Baseline already passed before this run: `command -v tmux &gt;/dev/null || { echo &#34;tmux is required for e2e tests&#34; &gt;&amp;2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo &#34;== $t ==&#34;; bash &#34;$t&#34; || rc=1; done; exit &#34;$rc&#34;`</code>
- `bash tests/fm-instruction-owners.test.sh`
- `bash tests/fm-brief.test.sh`
- `bash tests/fm-secondmate-lifecycle-e2e.test.sh`
- <code>Manual evidence flow: scaffolded `onboarding` with `bin/fm-brief.sh --secondmate alpha`, seeded it with `bin/fm-home-seed.sh onboarding &lt;home&gt; alpha`, ran `bin/fm-home-seed.sh validate`, and recorded the resulting registry and charter evidence.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
