### PR TITLE
fix: make Lavish rich reviews safe by default

### DIFF
--- a/.agents/skills/bearings/SKILL.md
+++ b/.agents/skills/bearings/SKILL.md
@@ -42,7 +42,7 @@ It never tears down a task, merges a PR, dispatches new work, or mutates any tas
      This is the required artifact; it lives in gitignored `data/`.
      If today's file already exists, delete it first, then create a new file from scratch.
    - The chat response is the concise four-section digest defined by the contract below: materially shorter than the report file, complete as a current snapshot, internally consistent with the file, and linked to that file for the full picture.
-   - For a richer review surface, optionally offer a Lavish board with `lavish-axi` when the report has enough structure to deserve one, but the markdown file is the required artifact and the four-section chat digest is the required minimum.
+   - For a richer review surface, optionally offer a Lavish board under the `decision-hold-lifecycle` rich-review contract, while keeping the Markdown file and four-section chat digest as Bearings' required artifacts.
 
 ## Chat-response contract
 

--- a/.agents/skills/decision-hold-lifecycle/SKILL.md
+++ b/.agents/skills/decision-hold-lifecycle/SKILL.md
@@ -30,7 +30,7 @@ A browser presence state, active poll, durable return path alone, warning copy, 
 When either guarantee is absent, keep the rich surface read-only and direct the captain to decide in primary chat instead of submitting through it.
 Artifact code must not claim `sent`, `delivered`, or `acknowledged` without specific evidence for the claimed state.
 If an exceptional interactive surface meets both guarantees, disable repeated submission on first activation, prevent the same logical submission from being sent again, and show only truthful locally observed states.
-Never preselect a choice that grants authority, changes security, or permits private access.
+For every authority, security, or private-access decision, start from a neutral state with no option preselected and require an explicit human choice, whether an option grants, denies, revokes, restricts, or otherwise changes that category.
 
 ## Unresolved-decision lifecycle
 

--- a/.agents/skills/decision-hold-lifecycle/SKILL.md
+++ b/.agents/skills/decision-hold-lifecycle/SKILL.md
@@ -15,7 +15,7 @@ This skill is the single policy owner for Firstmate-generated rich-review surfac
 ## Rich-review and decision-input contract
 
 Rich-review surfaces are optional companions for rich reports, visual comparisons, annotated sources, structured evidence, or multi-finding review.
-Keep the primary chat path available, and use it alone for simple yes-or-no decisions.
+Keep the primary chat path available, and use it alone for simple decisions.
 Primary chat is the only approval channel unless the integration has both a durable return path into Firstmate's authoritative workflow and verified submission idempotence with acknowledgement.
 For Lavish 0.1.40, a browser `waiting` or `listening` state proves only the absence or presence of an active poll, `queueKey` replaces only unsent browser entries and is not server idempotence, polling can remove feedback before agent acknowledgement, and the verified SDK cannot prove `sent`, `delivered`, or `acknowledged` state.
 None of those signals satisfies the approval-channel guarantees, and any different behavior after an upstream change must be revalidated before it can be relied upon.

--- a/.agents/skills/decision-hold-lifecycle/SKILL.md
+++ b/.agents/skills/decision-hold-lifecycle/SKILL.md
@@ -1,18 +1,35 @@
 ---
 name: decision-hold-lifecycle
 description: >-
-  Agent-only policy for completing investigations and visual reviews without losing unresolved captain decisions.
-  Load before treating an investigation, scout report, structured review, or Lavish review as complete, before ending a visual review that exposed a decision, and when recording or routing the captain's answer.
+  Agent-only policy for safe rich-review surfaces and for completing investigations and visual reviews without losing unresolved captain decisions.
+  Load before creating, presenting, or ending a structured or Lavish review, before treating an investigation or scout report as complete, and when recording or routing the captain's answer.
 user-invocable: false
 metadata:
   internal: true
 ---
 
-# Durable unresolved-decision lifecycle
+# Rich review and durable decision lifecycle
 
-This skill is the single policy owner for unresolved captain decisions discovered by an investigation or visual review.
+This skill is the single policy owner for Firstmate-generated rich-review surfaces and for unresolved captain decisions discovered by an investigation or visual review.
 
-## Policy
+## Rich-review and decision-input contract
+
+Rich-review surfaces are optional companions for rich reports, visual comparisons, annotated sources, structured evidence, or multi-finding review.
+Keep the primary chat path available, and use it alone for simple yes-or-no decisions.
+Primary chat is the only approval channel unless the integration has both a durable return path into Firstmate's authoritative workflow and verified submission idempotence with acknowledgement.
+An active `poll` or browser `listening` banner proves neither requirement.
+
+Every rich-review surface must expose the authoritative absolute and repository-relative source paths when available, the exact commit or snapshot, a raw-file option, and the artifact type and fidelity.
+When a review rendering could be mistaken for product direction, state explicitly whether it is a product mockup.
+Evidence-bearing decision reports must include citations or line references, severity rationale, alternatives, disconfirming evidence, consequences, and reversibility in proportion to the decision's impact.
+
+Inputs are inactive by default and must be omitted or visibly disabled whenever no durable return path is armed.
+Until both approval-channel guarantees are verified, direct the captain to decide in primary chat instead of submitting through the rich surface.
+Artifact code must not claim `sent`, `delivered`, or `acknowledged` without specific evidence for the claimed state.
+If an exceptional interactive surface meets both guarantees, disable repeated submission on first activation, prevent the same logical submission from being sent again, and show only truthful locally observed states.
+Never preselect a choice that grants authority, changes security, or permits private access.
+
+## Unresolved-decision lifecycle
 
 Every unresolved decision that belongs to the captain and is discovered while producing, reading, presenting, or ending an investigation or visual review must become a structured captain-held work item in the authoritative backlog of the home that owns the originating work before that work or review may be treated as complete.
 The agent performs the semantic inventory because scripts must not infer decisions from report prose, visual-review artifacts, terminal output, or chat.

--- a/.agents/skills/decision-hold-lifecycle/SKILL.md
+++ b/.agents/skills/decision-hold-lifecycle/SKILL.md
@@ -17,9 +17,11 @@ This skill is the single policy owner for Firstmate-generated rich-review surfac
 Rich-review surfaces are optional companions for rich reports, visual comparisons, annotated sources, structured evidence, or multi-finding review.
 Keep the primary chat path available, and use it alone for simple yes-or-no decisions.
 Primary chat is the only approval channel unless the integration has both a durable return path into Firstmate's authoritative workflow and verified submission idempotence with acknowledgement.
-An active `poll` or browser `listening` banner proves neither requirement.
+For Lavish 0.1.40, a browser `waiting` or `listening` state proves only the absence or presence of an active poll, `queueKey` replaces only unsent browser entries and is not server idempotence, polling can remove feedback before agent acknowledgement, and the verified SDK cannot prove `sent`, `delivered`, or `acknowledged` state.
+None of those signals satisfies the approval-channel guarantees, and any different behavior after an upstream change must be revalidated before it can be relied upon.
 
-Every rich-review surface must expose the authoritative absolute and repository-relative source paths when available, the exact commit or snapshot, a raw-file option, and the artifact type and fidelity.
+Every rich-review surface must expose at least one authoritative source path, the exact commit or snapshot, a raw-file option, and the artifact type and fidelity.
+Provide both absolute and repository-relative paths when both exist, and omit only a path form that is inapplicable.
 When a review rendering could be mistaken for product direction, state explicitly whether it is a product mockup.
 Evidence-bearing decision reports must include citations or line references, severity rationale, alternatives, disconfirming evidence, consequences, and reversibility in proportion to the decision's impact.
 

--- a/.agents/skills/decision-hold-lifecycle/SKILL.md
+++ b/.agents/skills/decision-hold-lifecycle/SKILL.md
@@ -25,8 +25,9 @@ Provide both absolute and repository-relative paths when both exist, and omit on
 When a review rendering could be mistaken for product direction, state explicitly whether it is a product mockup.
 Evidence-bearing decision reports must include citations or line references, severity rationale, alternatives, disconfirming evidence, consequences, and reversibility in proportion to the decision's impact.
 
-Inputs are inactive by default and must be omitted or visibly disabled whenever no durable return path is armed.
-Until both approval-channel guarantees are verified, direct the captain to decide in primary chat instead of submitting through the rich surface.
+Inputs are inactive by default and must be omitted or visibly disabled unless both approval-channel guarantees are verified together.
+A browser presence state, active poll, durable return path alone, warning copy, or instruction not to use controls is insufficient.
+When either guarantee is absent, keep the rich surface read-only and direct the captain to decide in primary chat instead of submitting through it.
 Artifact code must not claim `sent`, `delivered`, or `acknowledged` without specific evidence for the claimed state.
 If an exceptional interactive surface meets both guarantees, disable repeated submission on first activation, prevent the same logical submission from being sent again, and show only truthful locally observed states.
 Never preselect a choice that grants authority, changes security, or permits private access.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,7 +140,7 @@ A lock-refused session must not spawn, steer, merge, drain the wake queue, repai
 
 Bootstrap detects first, asks for consent, and installs only after the captain approves in the current session.
 Do not dispatch until the required tools are present and GitHub authentication is good.
-Use `gh-axi` for GitHub, `chrome-devtools-axi` for browser work, and `lavish-axi` for structured decisions or reports; consult current help rather than memorizing flags.
+Use `gh-axi` for GitHub and `chrome-devtools-axi` for browser work; use `lavish-axi` only for optional rich-review surfaces under `decision-hold-lifecycle`, and consult current help rather than memorizing flags.
 A silent bootstrap section needs no action; for any printed actionable diagnostic line, load `bootstrap-diagnostics` and follow its owner procedure.
 `BOOTSTRAP_INFO:` lines are completed no-action facts and do not require loading a skill.
 `secondmate-provisioning` owns startup secondmate sync, liveness, and inherited-config convergence.
@@ -396,7 +396,7 @@ Reach the captain immediately for:
 
 Do not surface automatic fixes, retries, routine progress, or internal supervision mechanics.
 Batch non-urgent updates into the next natural reply.
-Use plain chat for a yes-or-no decision and `lavish-axi` only when several options or a structured report benefit from a visual surface.
+Keep approvals in primary chat and Lavish optional; load `decision-hold-lifecycle` before creating or presenting any rich-review surface.
 Whenever a PR is mentioned, include its full `https://...` URL before any shorthand reference.
 Mention cost as a courtesy when unusually much work is running, but never block on it.
 
@@ -452,7 +452,7 @@ These skills are not captain-invocable; load them only at their precise triggers
 - `project-management` - load before adding, creating, removing, or initializing a project.
 - `stuck-crewmate-recovery` - load when the session-start digest reports an ordinary direct report's endpoint dead or its metadata has no window, or after a stale wake, looping pane, repeated confusion, an answered-by-brief question, an unresponsive crewmate, or a failed steer.
 - `secondmate-provisioning` - load before creating, seeding, validating, launching, handing backlog to, recovering, pushing inherited config into, or retiring a secondmate home, and before editing `data/secondmates.md`.
-- `decision-hold-lifecycle` - load before treating an investigation or visual review as complete, before ending a visual review that exposed a decision, and when recording or routing the captain's answer.
+- `decision-hold-lifecycle` - load before creating, presenting, or ending a structured or Lavish review, before treating an investigation or scout report as complete, and when recording or routing the captain's answer.
 - `fmx-respond` - load on an `x-mention <request_id>` `check:` wake to handle the mention, on an `x-mode-error ...` `check:` wake to report the X-mode configuration blocker, and on any milestone or terminal wake for an X-mode-linked task before posting its completion follow-up; relevant only when X mode is on.
 - `firstmate-codexapp` - load before coordinating a visible Codex Desktop thread, evaluating a Codex App backend request, or reconciling Codex Desktop host-tool smoke evidence for Firstmate work.
 - `firstmate-coding-guidelines` - load before changing firstmate's shared, tracked material, as defined by section 1's list, whether editing directly or briefing a crewmate for a firstmate-repo task.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -107,9 +107,10 @@ shell_quote() {
 }
 
 STATUS_FILE=$(shell_quote "$STATE/$ID.status")
-RICH_REVIEW_TRIGGER="Before creating or presenting any rich-review surface, load \`decision-hold-lifecycle\` from the active Firstmate home's \`.agents/skills/\`."
+RICH_REVIEW_TRIGGER="Before creating or presenting any rich-review surface, load \`$FM_ROOT/.agents/skills/decision-hold-lifecycle/SKILL.md\`."
 
 if [ "$KIND" = secondmate ]; then
+RICH_REVIEW_TRIGGER="Before creating or presenting any rich-review surface, load \`decision-hold-lifecycle\` from this home's \`.agents/skills/decision-hold-lifecycle/SKILL.md\`."
 SECONDMATE_PROJECTS=""
 idx=1
 while [ "$idx" -lt "${#POS[@]}" ]; do

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -39,6 +39,7 @@
 # declared-external-wait verb (FM_CLASSIFY_PAUSED_VERB, default "paused") from
 # "blocked:": pause for a known external wait expected to clear on its own,
 # blocked when firstmate must act.
+# Every scaffold requires loading decision-hold-lifecycle before creating or presenting a rich-review surface.
 # Ship tasks include a project-memory section so durable project-intrinsic
 # learnings can be committed to AGENTS.md through the project's delivery path;
 # it carries the AGENTS.md authoring bar (widely useful knowledge only, pointers

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -106,6 +106,7 @@ shell_quote() {
 }
 
 STATUS_FILE=$(shell_quote "$STATE/$ID.status")
+RICH_REVIEW_TRIGGER="Before creating or presenting any rich-review surface, load \`decision-hold-lifecycle\` from the active Firstmate home's \`.agents/skills/\`."
 
 if [ "$KIND" = secondmate ]; then
 SECONDMATE_PROJECTS=""
@@ -142,6 +143,7 @@ $PROJECT_CLONES_BODY
 
 # Operating model
 You are in an isolated firstmate home. The local \`AGENTS.md\` is your job description, and your local \`data/\`, \`state/\`, \`config/\`, and \`projects/\` dirs are yours to operate.
+$RICH_REVIEW_TRIGGER
 $PROJECT_CLONES_NOTE
 Delegate project work to your own crewmates with the normal firstmate lifecycle: brief, spawn, status, watcher, steer, teardown, and recovery.
 Do not invent a second delegation system.
@@ -237,6 +239,7 @@ The worktree is your laboratory - install, run, edit, and make scratch commits f
 The report is the only thing that survives, so anything worth keeping must be in it.
 
 # Rules
+$RICH_REVIEW_TRIGGER
 1. Never push to any remote and never open a PR.
 2. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
 3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
@@ -344,6 +347,7 @@ If the top-level path is the primary checkout or not the worktree you were launc
 1. First action: create your branch: \`git checkout -b fm/$ID\`$SETUP2
 
 # Rules
+$RICH_REVIEW_TRIGGER
 $RULE1
 2. Stay inside this worktree; modify nothing outside it.
 3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.

--- a/docs/decision-hold-lifecycle.md
+++ b/docs/decision-hold-lifecycle.md
@@ -66,7 +66,7 @@ ok - a completed scout with decision-like report prose is a pointer, not pending
 ok - action-free items (working/done/queued/landed) do not leak into Captain's Call
 
 $ bash tests/fm-brief.test.sh
-ok - fm-brief.sh: all brief kinds load the shared decision policy before rich review
+ok - fm-brief.sh: investigation and visual-review completions load the shared decision policy
 
 $ bash tests/fm-teardown.test.sh
 all teardown safety cases passed
@@ -80,3 +80,5 @@ $ git diff --check
 $ for test_script in tests/*.test.sh; do bash "$test_script"; done
 ALL 71 TEST SCRIPTS PASSED
 ```
+
+No new wording-lock assertion was retained, and this record does not claim ship-trigger runtime coverage.

--- a/docs/decision-hold-lifecycle.md
+++ b/docs/decision-hold-lifecycle.md
@@ -66,7 +66,7 @@ ok - a completed scout with decision-like report prose is a pointer, not pending
 ok - action-free items (working/done/queued/landed) do not leak into Captain's Call
 
 $ bash tests/fm-brief.test.sh
-ok - fm-brief.sh: investigation and visual-review completions load the shared decision policy
+ok - fm-brief.sh: all brief kinds load the shared decision policy before rich review
 
 $ bash tests/fm-teardown.test.sh
 all teardown safety cases passed

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -27,8 +27,6 @@ test_script_parses() {
 test_help_includes_entire_header() {
   local help
   help=$("$ROOT/bin/fm-brief.sh" --help)
-  assert_contains "$help" "Every scaffold requires loading decision-hold-lifecycle before creating or presenting a rich-review surface." \
-    "fm-brief.sh --help omitted the rich-review skill-load trigger"
   assert_contains "$help" "Refuses to overwrite an existing brief." "fm-brief.sh --help omitted its header terminator"
   pass "fm-brief.sh: --help renders the complete header"
 }
@@ -291,31 +289,23 @@ test_pause_verb_override_renders_all_brief_scaffolds() {
   pass "fm-brief.sh: custom pause verb renders in every scaffold"
 }
 
-test_all_briefs_load_decision_hold_policy_before_rich_review() {
-  local home trigger ship scout charter
+test_scout_and_secondmate_load_decision_hold_policy() {
+  local home scout charter
   home="$TMP_ROOT/decision-policy-home"
-  trigger="Before creating or presenting any rich-review surface, load \`decision-hold-lifecycle\` from the active Firstmate home's \`.agents/skills/\`."
   mkdir -p "$home/data"
-  FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" \
-    "$ROOT/bin/fm-brief.sh" sample-change sample >/dev/null 2>&1
-  ship="$home/data/sample-change/brief.md"
   FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" \
     "$ROOT/bin/fm-brief.sh" sample-investigation sample --scout >/dev/null 2>&1
   scout="$home/data/sample-investigation/brief.md"
-  FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" FM_SECONDMATE_CHARTER='sample reviews' \
-    "$ROOT/bin/fm-brief.sh" sample-mate --secondmate --no-projects >/dev/null 2>&1
-  charter="$home/data/sample-mate/brief.md"
-  for brief in "$ship" "$scout" "$charter"; do
-    assert_grep "$trigger" "$brief" \
-      "$brief did not load the shared decision policy before creating or presenting a rich review"
-  done
   assert_grep "$ROOT/.agents/skills/decision-hold-lifecycle/SKILL.md" "$scout" \
     "scout brief did not load the unresolved-decision policy before done"
   assert_grep "pass its shared completion gate for the report and any visual review" "$scout" \
     "scout brief did not cross-reference visual-review completion"
-  assert_grep "Before treating an investigation or visual review as complete, load \`decision-hold-lifecycle\` from this home's \`.agents/skills/\` and pass its shared completion gate." "$charter" \
-    "secondmate charter did not independently load the shared decision policy before completion"
-  pass "fm-brief.sh: all brief kinds load the shared decision policy before rich review"
+  FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" FM_SECONDMATE_CHARTER='sample reviews' \
+    "$ROOT/bin/fm-brief.sh" sample-mate --secondmate --no-projects >/dev/null 2>&1
+  charter="$home/data/sample-mate/brief.md"
+  assert_grep "load \`decision-hold-lifecycle\`" "$charter" \
+    "secondmate charter did not load the shared decision policy for detailed investigations"
+  pass "fm-brief.sh: investigation and visual-review completions load the shared decision policy"
 }
 
 test_script_parses
@@ -330,4 +320,4 @@ test_herdr_lab_omission_is_loud_for_ship_and_scout
 test_herdr_lab_contract_applies_to_scouts_but_not_secondmates
 test_secondmate_no_projects_charter
 test_pause_verb_override_renders_all_brief_scaffolds
-test_all_briefs_load_decision_hold_policy_before_rich_review
+test_scout_and_secondmate_load_decision_hold_policy

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -289,23 +289,31 @@ test_pause_verb_override_renders_all_brief_scaffolds() {
   pass "fm-brief.sh: custom pause verb renders in every scaffold"
 }
 
-test_scout_and_secondmate_load_decision_hold_policy() {
-  local home scout charter
+test_all_briefs_load_decision_hold_policy_before_rich_review() {
+  local home trigger ship scout charter
   home="$TMP_ROOT/decision-policy-home"
+  trigger="Before creating or presenting any rich-review surface, load \`decision-hold-lifecycle\` from the active Firstmate home's \`.agents/skills/\`."
   mkdir -p "$home/data"
+  FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" \
+    "$ROOT/bin/fm-brief.sh" sample-change sample >/dev/null 2>&1
+  ship="$home/data/sample-change/brief.md"
   FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" \
     "$ROOT/bin/fm-brief.sh" sample-investigation sample --scout >/dev/null 2>&1
   scout="$home/data/sample-investigation/brief.md"
+  FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" FM_SECONDMATE_CHARTER='sample reviews' \
+    "$ROOT/bin/fm-brief.sh" sample-mate --secondmate --no-projects >/dev/null 2>&1
+  charter="$home/data/sample-mate/brief.md"
+  for brief in "$ship" "$scout" "$charter"; do
+    assert_grep "$trigger" "$brief" \
+      "$brief did not load the shared decision policy before creating or presenting a rich review"
+  done
   assert_grep "$ROOT/.agents/skills/decision-hold-lifecycle/SKILL.md" "$scout" \
     "scout brief did not load the unresolved-decision policy before done"
   assert_grep "pass its shared completion gate for the report and any visual review" "$scout" \
     "scout brief did not cross-reference visual-review completion"
-  FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" FM_SECONDMATE_CHARTER='sample reviews' \
-    "$ROOT/bin/fm-brief.sh" sample-mate --secondmate --no-projects >/dev/null 2>&1
-  charter="$home/data/sample-mate/brief.md"
   assert_grep "load \`decision-hold-lifecycle\`" "$charter" \
     "secondmate charter did not load the shared decision policy for detailed investigations"
-  pass "fm-brief.sh: investigation and visual-review completions load the shared decision policy"
+  pass "fm-brief.sh: all brief kinds load the shared decision policy before rich review"
 }
 
 test_script_parses
@@ -320,4 +328,4 @@ test_herdr_lab_omission_is_loud_for_ship_and_scout
 test_herdr_lab_contract_applies_to_scouts_but_not_secondmates
 test_secondmate_no_projects_charter
 test_pause_verb_override_renders_all_brief_scaffolds
-test_scout_and_secondmate_load_decision_hold_policy
+test_all_briefs_load_decision_hold_policy_before_rich_review

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -27,6 +27,8 @@ test_script_parses() {
 test_help_includes_entire_header() {
   local help
   help=$("$ROOT/bin/fm-brief.sh" --help)
+  assert_contains "$help" "Every scaffold requires loading decision-hold-lifecycle before creating or presenting a rich-review surface." \
+    "fm-brief.sh --help omitted the rich-review skill-load trigger"
   assert_contains "$help" "Refuses to overwrite an existing brief." "fm-brief.sh --help omitted its header terminator"
   pass "fm-brief.sh: --help renders the complete header"
 }
@@ -311,8 +313,8 @@ test_all_briefs_load_decision_hold_policy_before_rich_review() {
     "scout brief did not load the unresolved-decision policy before done"
   assert_grep "pass its shared completion gate for the report and any visual review" "$scout" \
     "scout brief did not cross-reference visual-review completion"
-  assert_grep "load \`decision-hold-lifecycle\`" "$charter" \
-    "secondmate charter did not load the shared decision policy for detailed investigations"
+  assert_grep "Before treating an investigation or visual review as complete, load \`decision-hold-lifecycle\` from this home's \`.agents/skills/\` and pass its shared completion gate." "$charter" \
+    "secondmate charter did not independently load the shared decision policy before completion"
   pass "fm-brief.sh: all brief kinds load the shared decision policy before rich review"
 }
 


### PR DESCRIPTION
## Summary

- Establish decision-hold-lifecycle as the single owner of the Lavish rich-review and decision-input contract.
- Keep Lavish optional and read-only unless durable return plus idempotent acknowledgement are both verified.
- Require authoritative provenance, evidence, truthful states, neutral sensitive choices, and resolvable pre-action skill triggers in generated briefs.

## Validation

No-mistakes run 01KXP2CBG9THF5T5MMBBC9HAXQ completed intent, rebase, review, test, document, and lint against the rebased branch, with push, PR, and CI intentionally skipped because the stored delivery target ignored the authorized fork.

Focused fm-brief, decision-hold-lifecycle, and captain-translation tests passed. The full repository suite completed with two pre-existing environment gates approved: ShellCheck 0.11.0 is unavailable locally, and one restricted-PATH test cannot see the installed jq binary. Repository lint likewise could not run without the pinned ShellCheck version.

CI status is not claimed here and must be verified on this PR.