### PR TITLE
feat(skills): add captain-invocable /retire-doc skill

### DIFF
--- a/.agents/skills/retire-doc/SKILL.md
+++ b/.agents/skills/retire-doc/SKILL.md
@@ -12,10 +12,10 @@ Retire a document from this home's `data/` corpus safely.
 The `data/` corpus is captain-private and gitignored, so it has no version history to fall back on: every retirement is unversioned and potentially unrecoverable unless this skill's backup step runs first.
 The goal is a corpus that no longer carries the retired material, with a durable backup, an intact index, and no silent loss of anything the corpus still relies on.
 
-## 0. Local override first
+## 0. Local SOP first
 
-If this home keeps its own document-lifecycle SOP in `data/` (for example a `data/doc-map.md`, a librarian charter, or a stated retirement procedure), read it and follow it over the defaults below wherever the two differ.
-This skill is the fallback procedure for homes that have not written their own; a home's own SOP always wins.
+If this home keeps its own document-lifecycle SOP in `data/` (for example a `data/doc-map.md`, a librarian charter, or a stated retirement procedure), read it first and let it refine or strengthen the procedure below.
+A local SOP must never waive or weaken this skill's required scoped backup, valid recorded SHA-256, captain sign-off gate, former-path consolidation pointer, atomic index update, or final retirement report.
 
 ## 1. Back up before any destructive step
 

--- a/.agents/skills/retire-doc/SKILL.md
+++ b/.agents/skills/retire-doc/SKILL.md
@@ -29,8 +29,17 @@ Example:
 ```
 mkdir -p data/backups
 ts="$(date +%Y%m%d-%H%M%S)"
-tar czf "data/backups/retire-<slug>-${ts}.tar.gz" <affected-path> [<affected-path> ...]
-sha256sum "data/backups/retire-<slug>-${ts}.tar.gz"
+backup="data/backups/retire-<slug>-${ts}.tar.gz"
+tar czf "$backup" <affected-path> [<affected-path> ...]
+if command -v shasum >/dev/null 2>&1; then
+  hash="$(shasum -a 256 "$backup" | awk '{print $1}')"
+elif command -v sha256sum >/dev/null 2>&1; then
+  hash="$(sha256sum "$backup" | awk '{print $1}')"
+else
+  printf '%s\n' 'No SHA-256 command is available; stop before retiring anything.' >&2
+  exit 1
+fi
+printf '%s  %s\n' "$hash" "$backup"
 ```
 
 Carry the tarball path and its hash forward; the final report cites them.
@@ -64,7 +73,7 @@ If you are a crewmate rather than firstmate itself, surface this as a decision f
 
 When the retirement is really a consolidation - the same information living in two places - merge it into the one authoritative home and replace the other copy with a pointer to that home.
 Never leave two full copies: the moment only one is edited, they drift.
-Choose the authoritative home deliberately (the more discoverable, more maintained, or index-referenced location), fold in anything unique from the copy being retired, then reduce the retired copy to a one-line pointer or remove it with a tombstone per step 2.
+Choose the authoritative home deliberately (the more discoverable, more maintained, or index-referenced location), fold in anything unique from the copy being retired, then reduce the retired document at its former path to a one-line pointer to that authoritative home.
 
 ## 5. Update the index in the same action
 

--- a/.agents/skills/retire-doc/SKILL.md
+++ b/.agents/skills/retire-doc/SKILL.md
@@ -30,15 +30,36 @@ Example:
 mkdir -p data/backups
 ts="$(date +%Y%m%d-%H%M%S)"
 backup="data/backups/retire-<slug>-${ts}.tar.gz"
-tar czf "$backup" <affected-path> [<affected-path> ...]
+if ! tar czf "$backup" <affected-path> [<affected-path> ...]; then
+  rm -f "$backup"
+  printf '%s\n' 'The scoped backup failed; stop before retiring anything.' >&2
+  exit 1
+fi
 if command -v shasum >/dev/null 2>&1; then
-  hash="$(shasum -a 256 "$backup" | awk '{print $1}')"
+  if ! hash_output="$(shasum -a 256 "$backup")"; then
+    printf '%s\n' 'SHA-256 hashing failed; stop before retiring anything.' >&2
+    exit 1
+  fi
 elif command -v sha256sum >/dev/null 2>&1; then
-  hash="$(sha256sum "$backup" | awk '{print $1}')"
+  if ! hash_output="$(sha256sum "$backup")"; then
+    printf '%s\n' 'SHA-256 hashing failed; stop before retiring anything.' >&2
+    exit 1
+  fi
 else
   printf '%s\n' 'No SHA-256 command is available; stop before retiring anything.' >&2
   exit 1
 fi
+hash="${hash_output%%[[:space:]]*}"
+if [ "${#hash}" -ne 64 ]; then
+  printf '%s\n' 'The SHA-256 digest is invalid; stop before retiring anything.' >&2
+  exit 1
+fi
+case "$hash" in
+  *[!0123456789abcdefABCDEF]*)
+    printf '%s\n' 'The SHA-256 digest is invalid; stop before retiring anything.' >&2
+    exit 1
+    ;;
+esac
 printf '%s  %s\n' "$hash" "$backup"
 ```
 

--- a/.agents/skills/retire-doc/SKILL.md
+++ b/.agents/skills/retire-doc/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: retire-doc
+description: Guided, safe procedure for retiring a document from a firstmate home's data/ corpus - archive it, correct a stale claim, or delete it - with a backup taken first and a captain sign-off gate for anything that changes what the corpus asserts. Use when the captain invokes /retire-doc (e.g. "/retire-doc", "retire that doc", "archive the old runbook").
+user-invocable: true
+metadata:
+  internal: true
+---
+
+# retire-doc
+
+Retire a document from this home's `data/` corpus safely.
+The `data/` corpus is captain-private and gitignored, so it has no version history to fall back on: every retirement is unversioned and potentially unrecoverable unless this skill's backup step runs first.
+The goal is a corpus that no longer carries the retired material, with a durable backup, an intact index, and no silent loss of anything the corpus still relies on.
+
+## 0. Local override first
+
+If this home keeps its own document-lifecycle SOP in `data/` (for example a `data/doc-map.md`, a librarian charter, or a stated retirement procedure), read it and follow it over the defaults below wherever the two differ.
+This skill is the fallback procedure for homes that have not written their own; a home's own SOP always wins.
+
+## 1. Back up before any destructive step
+
+Before moving, rewriting, or deleting anything, snapshot the affected files so an unversioned corpus stays recoverable.
+- Write a dated tarball of every affected path under `data/backups/`, creating that directory if it does not exist.
+- Record the tarball's hash so the backup is verifiable later.
+- Keep the tarball scoped to the files this retirement touches, not the whole corpus, so the backup is small and its provenance is clear.
+
+Example:
+
+```
+mkdir -p data/backups
+ts="$(date +%Y%m%d-%H%M%S)"
+tar czf "data/backups/retire-<slug>-${ts}.tar.gz" <affected-path> [<affected-path> ...]
+sha256sum "data/backups/retire-<slug>-${ts}.tar.gz"
+```
+
+Carry the tarball path and its hash forward; the final report cites them.
+
+## 2. Classify the retirement
+
+Decide which of three kinds this is, because each has a different safe procedure and a different sign-off requirement.
+
+- **archive** - the document is superseded or no longer active, but retains provenance value.
+  Move it to a dated archive location under `data/` (for example `data/archive/<YYYY-MM-DD>/`) and leave a one-line tombstone pointer where it used to live, or record the move as an index note, so anything looking for the old path finds where it went.
+- **rewrite-claim** - the document stays in place, but a stale or misleading claim inside it must be corrected or clearly bannered as no longer true.
+  The document is not removed; only the specific assertion changes.
+- **delete** - the material has no provenance value (a scratch note, a true duplicate with nothing unique, a mistaken file) and can be removed outright.
+  Delete is the narrowest kind; when in doubt, archive instead.
+
+## 3. Provenance gate - present, then wait for the captain
+
+Any retirement that changes what the corpus *asserts* requires the captain's explicit sign-off before you act.
+That includes deleting evidence, retiring or correcting a claim, and removing a document that other documents cite.
+Routine archival of a plainly superseded duplicate - where the same material lives authoritatively elsewhere and nothing unique is lost - does not need sign-off.
+
+When the gate applies, present to the captain, then stop and wait for their word:
+- the item being retired (path and what it is),
+- the classification from step 2,
+- the consequence - what the corpus will no longer assert, and who or what cites it.
+
+Do not act on a gated retirement until the captain answers.
+If you are a crewmate rather than firstmate itself, surface this as a decision for the captain rather than deciding it yourself.
+
+## 4. Consolidation - keep a single source of truth
+
+When the retirement is really a consolidation - the same information living in two places - merge it into the one authoritative home and replace the other copy with a pointer to that home.
+Never leave two full copies: the moment only one is edited, they drift.
+Choose the authoritative home deliberately (the more discoverable, more maintained, or index-referenced location), fold in anything unique from the copy being retired, then reduce the retired copy to a one-line pointer or remove it with a tombstone per step 2.
+
+## 5. Update the index in the same action
+
+If this home keeps a master document index in `data/` (many do - for example a `data/doc-map.md` or similar registry), update it in the same action that retires the document, so the index never points at a retired path.
+Fix the entry to the new archive path, the pointer, or remove it, matching what step 2 did to the file.
+An index left pointing at a moved or deleted document is exactly the silent breakage this step prevents.
+
+## 6. Report
+
+Summarize the outcome in plain language:
+- what moved, was rewritten, or was deleted, with `old -> new` paths for anything relocated,
+- the classification applied,
+- the backup tarball path and its hash,
+- the index entry updated, if any,
+- for a gated retirement, a note that the captain signed off.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,6 +202,7 @@ Firstmate never writes a project's `AGENTS.md` directly.
 A crewmate creates or updates it lazily through the project's selected delivery path, using `bin/fm-ensure-agents-md.sh` and preferring pointers to authoritative sources over copied detail.
 Keep fleet delivery posture and captain-private strategy out of project memory.
 When the captain invokes `/stow`, load the `stow` skill for the complete knowledge-routing and unfinished-work sweep.
+When the captain invokes `/retire-doc`, load the `retire-doc` skill for the guarded procedure to archive, correct, or delete a document from this home's `data/` corpus.
 
 ## 7. Task lifecycle
 

--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Claude and grok use the slash form shown here; codex uses the same names with `$
 | `/bearings`        | Generate a standalone current-status report from bounded local fleet and registered-secondmate state, with live PR enrichment only when requested, written to a dated file in `data/` and surfaced concisely in chat; read-mostly, mutates no task state |
 | `/updatefirstmate` | Self-update the running firstmate and its secondmates to the latest from origin with fast-forward-only pulls, then re-read instructions and nudge secondmates |
 | `/stow`            | Sweep the session for uncaptured durable knowledge, route each finding to its disk home per AGENTS.md, file undone next steps to the backlog, and report what is now safe to reset |
+| `/retire-doc`      | Retire a document from a home's `data/` corpus through a guided safe procedure: back up the affected files first, classify the retirement, gate anything that changes what the corpus asserts on captain sign-off, consolidate to a single source of truth, and update the `data/` index in the same action |
 
 Agent-only reference skills live under `.agents/skills/` and are loaded by firstmate at the trigger points named in [`AGENTS.md`](AGENTS.md).
 

--- a/tests/fm-retire-doc-contract.test.sh
+++ b/tests/fm-retire-doc-contract.test.sh
@@ -26,6 +26,10 @@ test_retire_doc_skill_encodes_safety_procedure() {
   # shellcheck disable=SC2016 # Literal backticks/paths must remain unexpanded.
   assert_grep 'data/backups/' "$skill" "retire-doc skill does not require a dated backup tarball"
   assert_grep 'hash' "$skill" "retire-doc skill does not record the backup hash"
+  assert_grep 'command -v shasum' "$skill" "retire-doc skill does not prefer the portable SHA-256 command"
+  assert_grep 'command -v sha256sum' "$skill" "retire-doc skill does not fall back to sha256sum"
+  assert_grep 'No SHA-256 command is available; stop before retiring anything.' "$skill" \
+    "retire-doc skill does not fail closed when no SHA-256 command is available"
   for kind in archive rewrite-claim delete; do
     assert_grep "**$kind**" "$skill" "retire-doc skill is missing the $kind classification"
   done
@@ -33,6 +37,8 @@ test_retire_doc_skill_encodes_safety_procedure() {
   assert_grep 'wait for the captain' "$skill" "retire-doc skill does not stop and wait at the provenance gate"
   assert_grep 'single source of truth' "$skill" "retire-doc skill does not enforce single-source consolidation"
   assert_grep 'Never leave two full copies' "$skill" "retire-doc skill does not forbid duplicate full copies"
+  assert_grep 'at its former path to a one-line pointer to that authoritative home' "$skill" \
+    "retire-doc skill does not preserve a pointer at every consolidated document's former path"
   assert_grep 'never points at a retired path' "$skill" "retire-doc skill does not require the index update"
   assert_grep 'own document-lifecycle SOP' "$skill" "retire-doc skill does not defer to a local SOP"
   pass "retire-doc skill encodes backup, classification, gate, consolidation, index, and local-override steps"

--- a/tests/fm-retire-doc-contract.test.sh
+++ b/tests/fm-retire-doc-contract.test.sh
@@ -27,7 +27,7 @@ test_retire_doc_skill_encodes_safety_procedure() {
   assert_grep 'data/backups/' "$skill" "retire-doc skill does not require a dated backup tarball"
   assert_grep 'hash' "$skill" "retire-doc skill does not record the backup hash"
   for kind in archive rewrite-claim delete; do
-    assert_grep "$kind" "$skill" "retire-doc skill is missing the $kind classification"
+    assert_grep "**$kind**" "$skill" "retire-doc skill is missing the $kind classification"
   done
   assert_grep 'sign-off' "$skill" "retire-doc skill does not require captain sign-off"
   assert_grep 'wait for the captain' "$skill" "retire-doc skill does not stop and wait at the provenance gate"

--- a/tests/fm-retire-doc-contract.test.sh
+++ b/tests/fm-retire-doc-contract.test.sh
@@ -26,10 +26,19 @@ test_retire_doc_skill_encodes_safety_procedure() {
   # shellcheck disable=SC2016 # Literal backticks/paths must remain unexpanded.
   assert_grep 'data/backups/' "$skill" "retire-doc skill does not require a dated backup tarball"
   assert_grep 'hash' "$skill" "retire-doc skill does not record the backup hash"
+  assert_grep 'if ! tar czf "$backup"' "$skill" "retire-doc skill does not stop when the scoped backup fails"
   assert_grep 'command -v shasum' "$skill" "retire-doc skill does not prefer the portable SHA-256 command"
   assert_grep 'command -v sha256sum' "$skill" "retire-doc skill does not fall back to sha256sum"
+  assert_grep 'if ! hash_output="$(shasum -a 256 "$backup")"' "$skill" \
+    "retire-doc skill does not stop when shasum fails"
+  assert_grep 'if ! hash_output="$(sha256sum "$backup")"' "$skill" \
+    "retire-doc skill does not stop when sha256sum fails"
   assert_grep 'No SHA-256 command is available; stop before retiring anything.' "$skill" \
     "retire-doc skill does not fail closed when no SHA-256 command is available"
+  assert_grep 'if [ "${#hash}" -ne 64 ]' "$skill" \
+    "retire-doc skill does not require a 64-character SHA-256 digest"
+  assert_grep '*[!0123456789abcdefABCDEF]*)' "$skill" \
+    "retire-doc skill does not require a hexadecimal SHA-256 digest"
   for kind in archive rewrite-claim delete; do
     assert_grep "**$kind**" "$skill" "retire-doc skill is missing the $kind classification"
   done

--- a/tests/fm-retire-doc-contract.test.sh
+++ b/tests/fm-retire-doc-contract.test.sh
@@ -50,6 +50,10 @@ test_retire_doc_skill_encodes_safety_procedure() {
     "retire-doc skill does not preserve a pointer at every consolidated document's former path"
   assert_grep 'never points at a retired path' "$skill" "retire-doc skill does not require the index update"
   assert_grep 'own document-lifecycle SOP' "$skill" "retire-doc skill does not defer to a local SOP"
+  assert_grep 'A local SOP must never waive or weaken' "$skill" \
+    "retire-doc skill lets a local SOP weaken its core safeguards"
+  assert_grep 'former-path consolidation pointer, atomic index update, or final retirement report' "$skill" \
+    "retire-doc skill does not preserve every core safeguard under a local SOP"
   pass "retire-doc skill encodes backup, classification, gate, consolidation, index, and local-override steps"
 }
 

--- a/tests/fm-retire-doc-contract.test.sh
+++ b/tests/fm-retire-doc-contract.test.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Static contract tests for the /retire-doc skill and its AGENTS.md trigger.
+set -u
+
+# shellcheck source=tests/lib.sh disable=SC1091
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+test_retire_doc_skill_metadata_and_trigger() {
+  local skill="$ROOT/.agents/skills/retire-doc/SKILL.md"
+  local agents="$ROOT/AGENTS.md"
+
+  assert_present "$skill" "retire-doc skill is missing"
+  assert_grep 'name: retire-doc' "$skill" "retire-doc skill metadata has the wrong name"
+  assert_grep 'user-invocable: true' "$skill" "retire-doc skill must be user-invocable"
+  assert_grep '  internal: true' "$skill" "retire-doc skill must be internal"
+
+  # shellcheck disable=SC2016 # Literal backticks must remain unexpanded.
+  assert_grep 'When the captain invokes `/retire-doc`, load the `retire-doc` skill' "$agents" \
+    "AGENTS.md lost the retire-doc trigger"
+  pass "retire-doc skill has internal metadata and one AGENTS.md trigger"
+}
+
+test_retire_doc_skill_encodes_safety_procedure() {
+  local skill="$ROOT/.agents/skills/retire-doc/SKILL.md"
+
+  # shellcheck disable=SC2016 # Literal backticks/paths must remain unexpanded.
+  assert_grep 'data/backups/' "$skill" "retire-doc skill does not require a dated backup tarball"
+  assert_grep 'hash' "$skill" "retire-doc skill does not record the backup hash"
+  for kind in archive rewrite-claim delete; do
+    assert_grep "$kind" "$skill" "retire-doc skill is missing the $kind classification"
+  done
+  assert_grep 'sign-off' "$skill" "retire-doc skill does not require captain sign-off"
+  assert_grep 'wait for the captain' "$skill" "retire-doc skill does not stop and wait at the provenance gate"
+  assert_grep 'single source of truth' "$skill" "retire-doc skill does not enforce single-source consolidation"
+  assert_grep 'Never leave two full copies' "$skill" "retire-doc skill does not forbid duplicate full copies"
+  assert_grep 'never points at a retired path' "$skill" "retire-doc skill does not require the index update"
+  assert_grep 'own document-lifecycle SOP' "$skill" "retire-doc skill does not defer to a local SOP"
+  pass "retire-doc skill encodes backup, classification, gate, consolidation, index, and local-override steps"
+}
+
+test_agents_does_not_duplicate_retire_doc_procedure() {
+  local agents="$ROOT/AGENTS.md"
+
+  assert_no_grep 'data/backups/' "$agents" \
+    "AGENTS.md duplicates the retire-doc backup mechanics from the skill owner"
+  assert_no_grep 'rewrite-claim' "$agents" \
+    "AGENTS.md duplicates the retire-doc classification from the skill owner"
+  pass "AGENTS.md keeps the retire-doc trigger inline and leaves the procedure to the skill owner"
+}
+
+test_retire_doc_skill_metadata_and_trigger
+test_retire_doc_skill_encodes_safety_procedure
+test_agents_does_not_duplicate_retire_doc_procedure


### PR DESCRIPTION
## Intent

The developer wanted to add a captain-invocable /retire-doc skill to the firstmate repo, placed at .agents/skills/retire-doc/ and modeled on the existing /stow skill's file layout, frontmatter, and tone, while following the firstmate-coding-guidelines (knowledge-placement tree, one-owner rule, trigger hygiene, one-sentence-per-line, plain dashes, shellcheck, no agent co-author). The skill had to encode a generic, safe seven-step procedure for retiring a document from a firstmate home's data/ corpus: back up affected files first as a dated tarball with a recorded hash, classify the retirement (archive, rewrite-claim, or delete), gate any corpus-asserting change behind explicit captain sign-off, consolidate duplicated information into a single authoritative source with a pointer, update the master document index, defer to a home's local doc-lifecycle SOP, and report old-to-new paths plus the backup hash. They required a matching one-line load trigger in AGENTS.md section 6 phrased like the /stow line, with no procedure detail duplicated there. The definition of done was driving the gated no-mistakes pipeline to a PR with green checks without merging, since the captain owns the merge. During the run the developer approved Option A (adding a /retire-doc row to the README built-in skills table plus a minor test-guard tightening), and later instructed resuming from the preserved branch without resetting or discarding commits, starting a fresh no-mistakes run from the current committed HEAD with the configured Codex fixer and stopping before merge.

## What Changed

- Added `.agents/skills/retire-doc/SKILL.md`, a captain-invocable skill encoding a guarded procedure for retiring a document from a home's gitignored `data/` corpus: take a scoped dated backup tarball with a validated 64-char hex SHA-256 (failing closed if the tar, the hash command, or the digest is invalid), classify the retirement as archive/rewrite-claim/delete, gate any corpus-asserting change on explicit captain sign-off, consolidate duplicates to a single source of truth with a former-path pointer, update the `data/` master index atomically, and emit an old→new report; it defers to a home's local doc-lifecycle SOP but only allows that SOP to strengthen the core safeguards.
- Wired the trigger into the fleet: a one-line load line in AGENTS.md section 6 and a `/retire-doc` row in the README built-in skills table, with no procedure detail duplicated outside the skill owner.
- Added `tests/fm-retire-doc-contract.test.sh` asserting the skill's metadata and single AGENTS.md trigger, the fail-closed backup/hash-validation and classification/gate/consolidation/index/SOP-override mechanics, and that AGENTS.md does not restate the backup or classification detail.

## Risk Assessment

✅ Low: Purely additive change — a new documentation skill, a static contract test, and two one-line index updates modeled faithfully on the existing /stow skill; the embedded backup snippet fails closed at every step and no existing behavior is touched.

## Testing

Completed 1 recorded test check.

- Outcome: ⚠️ 1 error across 1 run (13m32s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Test** - 1 error</summary>

- 🚨 tests failed with exit code 1
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 1)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
