### PR TITLE
feat: add revisioned Bridge protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,15 @@ grok --trust
 pi
 ```
 
+**Codex**
+
+```sh
+FM_HARNESS_OWNER_PID=$$ exec codex
+```
+
+Codex can execute tools outside the interactive process's ancestry.
+The explicit owner PID lets firstmate keep the fleet lock tied to the live Codex session; `exec` preserves that PID until Codex exits.
+
 For Grok, `--trust` is needed once per clone so project hooks and the turn-end guard load; `/hooks-trust` inside Grok works too.
 For Pi, approve the project trust prompt once per clone on first launch so both tracked `.pi/extensions/*.ts` files auto-load.
 

--- a/README.md
+++ b/README.md
@@ -104,11 +104,11 @@ pi
 **Codex**
 
 ```sh
-FM_HARNESS_OWNER_PID=$$ exec codex
+bin/fm-primary-codex.sh
 ```
 
 Codex can execute tools outside the interactive process's ancestry.
-The explicit owner PID lets firstmate keep the fleet lock tied to the live Codex session; `exec` preserves that PID until Codex exits.
+The launcher gives that session a private fleet-lock identity and releases its lock when Codex exits.
 
 For Grok, `--trust` is needed once per clone so project hooks and the turn-end guard load; `/hooks-trust` inside Grok works too.
 For Pi, approve the project trust prompt once per clone on first launch so both tracked `.pi/extensions/*.ts` files auto-load.

--- a/bin/fm-bridge-lib.sh
+++ b/bin/fm-bridge-lib.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Shared helpers for the fm-bridge.v1 machine contract.
+
+fm_bridge_fail() { # <code> <message>
+  jq -n --arg code "$1" --arg message "$2" \
+    '{accepted:false,error:{code:$code,message:$message}}'
+}
+
+fm_bridge_digest() {
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 | awk '{print $1}'
+  else
+    sha256sum | awk '{print $1}'
+  fi
+}
+
+fm_bridge_task_revision() { # <task-json>
+  printf '%s' "$1" | jq -cS . | fm_bridge_digest
+}
+
+fm_bridge_state() { # <snapshot state>
+  case "$1" in
+    parked|needs-decision|awaiting-captain) printf 'awaitingCaptain' ;;
+    blocked|failed) printf 'blocked' ;;
+    validating|reviewing|ci|checks-running) printf 'verifying' ;;
+    pr-ready|ready) printf 'prReady' ;;
+    working|running|fixing) printf 'working' ;;
+    paused|idle) printf 'paused' ;;
+    approved|signed-off) printf 'approved' ;;
+    done|merged|completed) printf 'completed' ;;
+    *) printf 'unknown' ;;
+  esac
+}
+
+fm_bridge_capabilities() { # <state> <pr-url>
+  local state=$1
+  jq -n --arg state "$state" '
+    ["feedback","defer"]
+    + (if ($state == "awaitingCaptain" or $state == "prReady") then ["sign-off"] else [] end)
+  '
+}
+
+fm_bridge_evidence() { # <task-json> <revision>
+  local task=$1 revision=$2 report pr
+  report=$(printf '%s' "$task" | jq -r '.paths.report.path // empty')
+  pr=$(printf '%s' "$task" | jq -r '.pr.url // empty')
+  jq -n --arg report "$report" --arg pr "$pr" --arg revision "$revision" '
+    [
+      if $report != "" then {
+        id:"report",kind:"Report",status:"present",summary:"Shipmate report is available",
+        source:"FirstMate",taskRevision:$revision,reference:$report
+      } else empty end,
+      if $pr != "" then {
+        id:"pull-request",kind:"Pull request",status:"present",summary:"Pull request is available",
+        source:"GitHub",taskRevision:$revision,reference:$pr
+      } else empty end
+    ]
+  '
+}
+
+fm_bridge_snapshot() {
+  local raw captured snapshot_revision
+  raw=$("$SCRIPT_DIR/fm-fleet-snapshot.sh" --json) || return
+  captured=$(printf '%s' "$raw" | jq -r '.generated')
+  snapshot_revision=$(printf '%s' "$raw" | jq -cS '{tasks,backlog,scout_reports,secondmate_current}' | fm_bridge_digest)
+  printf '%s' "$raw" | jq -c \
+    --arg protocol "fm-bridge.v1" \
+    --arg snapshot_revision "$snapshot_revision" --arg captured "$captured" '
+    {
+      protocolVersion:$protocol,
+      snapshotRevision:$snapshot_revision,
+      capturedAt:.generated,
+      freshness:"fresh",
+      tasks:[.tasks[] | {
+        id:.id,
+        title:(.backlog.title // .id),
+        project:(.project // "unknown"),
+        shipmate:(.harness // "shipmate"),
+        rawState:(.current_state.state // "unknown"),
+        updatedAt:$captured,
+        attentionReason:(.current_state.detail // null),
+        summary:(.backlog.body_excerpt // null),
+        pr:(.pr.url // ""),
+        source:.
+      }]
+    }'
+}
+
+fm_bridge_project_snapshot() {
+  local base tasks='[]' task source revision state evidence evidence_revision capabilities projected
+  base=$(fm_bridge_snapshot) || return
+  while IFS= read -r task; do
+    source=$(printf '%s' "$task" | jq -c '.source | {
+      id,
+      current_state:{
+        state:.current_state.state,
+        source:.current_state.source,
+        detail:.current_state.detail
+      },
+      pr,
+      backlog,
+      hints,
+      report:.paths.report
+    }')
+    revision=$(fm_bridge_task_revision "$source")
+    state=$(fm_bridge_state "$(printf '%s' "$task" | jq -r '.rawState')")
+    evidence=$(fm_bridge_evidence "$(printf '%s' "$task" | jq -c '.source')" "$revision" | jq -c .)
+    evidence_revision=$(printf '%s' "$evidence" | jq -cS . | fm_bridge_digest)
+    capabilities=$(fm_bridge_capabilities "$state" "$(printf '%s' "$task" | jq -r '.pr')" | jq -c .)
+    projected=$(printf '%s' "$task" | jq -c \
+      --arg revision "$revision" --arg state "$state" \
+      --arg evidence_revision "$evidence_revision" \
+      --argjson evidence "$evidence" --argjson capabilities "$capabilities" '
+      del(.rawState,.pr,.source) + {
+        state:$state,
+        taskRevision:$revision,
+        capabilities:$capabilities,
+        evidenceRevision:$evidence_revision,
+        evidence:$evidence
+      }')
+    tasks=$(jq -c --argjson tasks "$tasks" --argjson task "$projected" '$tasks + [$task]' <<< '{}')
+  done < <(printf '%s' "$base" | jq -c '.tasks[]')
+  printf '%s' "$base" | jq -c --argjson tasks "$tasks" '.tasks=$tasks'
+}

--- a/bin/fm-bridge.sh
+++ b/bin/fm-bridge.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# fm-bridge.sh - versioned machine boundary for Captain's Log and local clients.
+#
+# Reads one JSON request from stdin.
+# Supported operations:
+#   {"protocolVersion":"fm-bridge.v1","operation":"snapshot"}
+#   {"protocolVersion":"fm-bridge.v1","operation":"command","command":{...}}
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+
+# shellcheck source=bin/fm-bridge-lib.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/fm-bridge-lib.sh"
+
+command -v jq >/dev/null 2>&1 || {
+  echo "fm-bridge: jq not found" >&2
+  exit 1
+}
+
+request=$(head -c 65537)
+[ "${#request}" -le 65536 ] || {
+  fm_bridge_fail request_too_large "Bridge requests are limited to 64 KiB"
+  exit 2
+}
+printf '%s' "$request" | jq -e . >/dev/null 2>&1 || {
+  fm_bridge_fail malformed_request "Request must be valid JSON"
+  exit 2
+}
+version=$(printf '%s' "$request" | jq -r '.protocolVersion // empty')
+[ "$version" = "fm-bridge.v1" ] || {
+  fm_bridge_fail unsupported_version "Only fm-bridge.v1 is supported"
+  exit 2
+}
+operation=$(printf '%s' "$request" | jq -r '.operation // empty')
+case "$operation" in
+  snapshot)
+    fm_bridge_project_snapshot
+    ;;
+  command)
+    command_json=$(printf '%s' "$request" | jq -c '.command // empty')
+    command_id=$(printf '%s' "$command_json" | jq -r '.commandId // empty')
+    action=$(printf '%s' "$command_json" | jq -r '.action // empty')
+    task_id=$(printf '%s' "$command_json" | jq -r '.taskId // empty')
+    expected=$(printf '%s' "$command_json" | jq -r '.expectedRevision // empty')
+    [ -n "$command_id" ] && [ -n "$task_id" ] && [ -n "$expected" ] || {
+      fm_bridge_fail malformed_command "commandId, taskId, and expectedRevision are required"
+      exit 2
+    }
+    case "$command_id" in
+      *[!A-Za-z0-9._-]*|'') fm_bridge_fail malformed_command "commandId contains unsafe characters"; exit 2 ;;
+    esac
+    [ "${#command_id}" -le 128 ] || {
+      fm_bridge_fail malformed_command "commandId is too long"
+      exit 2
+    }
+    case "$action" in sign-off|defer|feedback|merge) ;; *)
+      fm_bridge_fail illegal_action "Unsupported Bridge action"
+      exit 2
+    esac
+    journal="$STATE/bridge-command-journal"
+    mkdir -p "$journal"
+    lock="$journal/$command_id.lock"
+    mkdir "$lock" 2>/dev/null || {
+      fm_bridge_fail command_busy "This command is already being processed"
+      exit 2
+    }
+    trap 'rmdir "$lock" 2>/dev/null || true' EXIT
+    digest=$(printf '%s' "$command_json" | jq -cS . | fm_bridge_digest)
+    record="$journal/$command_id.json"
+    if [ -f "$record" ]; then
+      prior_digest=$(jq -r '.requestDigest' "$record")
+      [ "$prior_digest" = "$digest" ] || {
+        fm_bridge_fail command_id_conflict "commandId was already used for a different request"
+        exit 2
+      }
+      jq -c '.outcome + {replayed:true}' "$record"
+      exit 0
+    fi
+    snapshot=$(fm_bridge_project_snapshot) || exit 1
+    task=$(printf '%s' "$snapshot" | jq -c --arg id "$task_id" '.tasks[] | select(.id==$id)')
+    [ -n "$task" ] || {
+      fm_bridge_fail task_not_found "Task is not present in the current fleet"
+      exit 2
+    }
+    current=$(printf '%s' "$task" | jq -r '.taskRevision')
+    [ "$current" = "$expected" ] || {
+      jq -n --arg current "$current" \
+        '{accepted:false,error:{code:"stale_revision",message:"Task revision changed",currentRevision:$current}}'
+      exit 2
+    }
+    capability=$(printf '%s' "$task" | jq -e --arg action "$action" '.capabilities | index($action) != null')
+    [ "$capability" = true ] || {
+      fm_bridge_fail capability_absent "Action is not legal for the current task state"
+      exit 2
+    }
+    if [ "$action" = merge ]; then
+      fm_bridge_fail merge_requires_guarded_mode "Merge is unavailable until a guarded project mode is configured"
+      exit 2
+    fi
+    if [ "$action" = sign-off ]; then
+      reviewed_evidence=$(printf '%s' "$command_json" | jq -r '.evidenceRevision // empty')
+      current_evidence=$(printf '%s' "$task" | jq -r '.evidenceRevision')
+      [ "$reviewed_evidence" = "$current_evidence" ] || {
+        fm_bridge_fail stale_evidence "Evidence changed before sign-off"
+        exit 2
+      }
+    fi
+    case "$action" in
+      feedback)
+        feedback=$(printf '%s' "$command_json" | jq -r '.feedback // empty')
+        [ -n "$feedback" ] || {
+          fm_bridge_fail malformed_command "Feedback text is required"
+          exit 2
+        }
+        FM_HOME="$FM_HOME" "$SCRIPT_DIR/fm-send.sh" "$task_id" "$feedback" >/dev/null || {
+          fm_bridge_fail endpoint_unavailable "Feedback could not be delivered to the shipmate"
+          exit 2
+        }
+        ;;
+      sign-off|defer)
+        review_dir="$FM_HOME/data/$task_id"
+        mkdir -p "$review_dir"
+        review_record="$review_dir/bridge-review.json"
+        review_tmp="$review_record.$$"
+        jq -n --arg action "$action" --arg revision "$current" \
+          --arg evidenceRevision "$(printf '%s' "$task" | jq -r '.evidenceRevision')" \
+          --arg at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+          '{action:$action,taskRevision:$revision,evidenceRevision:$evidenceRevision,recordedAt:$at}' \
+          > "$review_tmp"
+        mv "$review_tmp" "$review_record"
+        ;;
+    esac
+    outcome=$(jq -n --arg action "$action" --arg task_id "$task_id" \
+      '{accepted:true,message:("FirstMate accepted " + $action + " for " + $task_id)}')
+    tmp="$record.$$"
+    jq -n --arg requestDigest "$digest" --argjson outcome "$outcome" \
+      '{requestDigest:$requestDigest,outcome:$outcome}' > "$tmp"
+    mv "$tmp" "$record"
+    printf '%s' "$outcome"
+    ;;
+  *)
+    fm_bridge_fail unsupported_operation "Operation must be snapshot or command"
+    exit 2
+    ;;
+esac

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -30,6 +30,7 @@ CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
 detect_own() {
   # Layer 1: environment markers for verified harnesses.
   [ "${CLAUDECODE:-}" = "1" ] && { echo claude; return; }
+  [ "${CODEX_SHELL:-}" = "1" ] && { echo codex; return; }
   [ "${PI_CODING_AGENT:-}" = "true" ] && { echo pi; return; }
   # grok sets GROK_AGENT=1 for its child/tool processes (verified, grok 0.2.73).
   # It does NOT set CLAUDECODE despite being Claude-Code-compatible, so this marker
@@ -39,7 +40,7 @@ detect_own() {
   local pid=$$ comm args
   for _ in 1 2 3 4 5 6 7 8; do
     comm=$(ps -o comm= -p "$pid" 2>/dev/null) || break
-    case "$(basename "$comm")" in
+    case "$(basename -- "$comm")" in
       *claude*) echo claude; return ;;
       *codex*) echo codex; return ;;
       *opencode*) echo opencode; return ;;

--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -3,8 +3,13 @@
 # Writes the harness (agent) process PID found by walking the shell's ancestry,
 # which lives as long as the firstmate session - unlike the transient subshell
 # PID of any one tool call, which is dead moments after it is written.
-# Usage: fm-lock.sh           acquire; exit 1 if another live session holds it
+# Usage: fm-lock.sh           acquire; exit 2 if another live session holds it,
+#                            or exit 1 for another acquisition failure
 #        fm-lock.sh status    print holder and liveness; always exits 0
+# FM_HARNESS_OWNER_PID may name an explicit long-lived harness process when
+# the harness runs tools outside its process ancestry. The process must be
+# alive and its command must still identify a verified harness. For Codex,
+# launch with `FM_HARNESS_OWNER_PID=$$ exec codex` so exec preserves the PID.
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -17,12 +22,42 @@ mkdir -p "$STATE"
 # Known harness command names; extend when a new adapter is verified.
 HARNESS_RE='claude|codex|opencode|grok|^pi$'
 
+process_is_harness() {
+  local pid=$1 expected=${2:-$HARNESS_RE} comm args
+  comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
+  if printf '%s' "$(basename -- "$comm")" | grep -qE "$expected"; then
+    return 0
+  fi
+  case "$comm" in
+    *node*|*python*)
+      args=$(ps -o args= -p "$pid" 2>/dev/null)
+      printf '%s' "$args" | grep -qE "$expected"
+      ;;
+    *) return 1 ;;
+  esac
+}
+
 harness_pid() {
   local pid=$$ comm args
+  if [ -n "${FM_HARNESS_OWNER_PID:-}" ]; then
+    if [ "${CODEX_SHELL:-}" != 1 ]; then
+      echo "error: FM_HARNESS_OWNER_PID requires a verified Codex session marker" >&2
+      return 1
+    fi
+    case "$FM_HARNESS_OWNER_PID" in
+      *[!0-9]*|'') echo "error: FM_HARNESS_OWNER_PID must be a process id" >&2; return 1 ;;
+    esac
+    if [ "$FM_HARNESS_OWNER_PID" -le 1 ] || ! process_is_harness "$FM_HARNESS_OWNER_PID" codex; then
+      echo "error: FM_HARNESS_OWNER_PID is not a live Codex harness process" >&2
+      return 1
+    fi
+    echo "$FM_HARNESS_OWNER_PID"
+    return 0
+  fi
   for _ in 1 2 3 4 5 6 7 8; do
     comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
     args=$(ps -o args= -p "$pid" 2>/dev/null)
-    if printf '%s' "$(basename "$comm")" | grep -qE "$HARNESS_RE"; then
+    if printf '%s' "$(basename -- "$comm")" | grep -qE "$HARNESS_RE"; then
       echo "$pid"; return 0
     fi
     # Bare interpreter (e.g. node): match the harness name in its script path.
@@ -35,26 +70,23 @@ harness_pid() {
   return 1
 }
 
-holder_alive() {  # true if $1 is a live process that looks like a harness
-  local pid=$1 comm
-  kill -0 "$pid" 2>/dev/null || return 1
-  comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
-  printf '%s' "$(basename "$comm") $(ps -o args= -p "$pid" 2>/dev/null)" | grep -qE "$HARNESS_RE"
-}
-
 if [ "${1:-}" = "status" ]; then
   if [ ! -f "$LOCK" ]; then echo "lock: free"; exit 0; fi
   old=$(cat "$LOCK")
-  if holder_alive "$old"; then echo "lock: held by live harness pid $old"; else echo "lock: stale (pid $old dead or not a harness)"; fi
+  if process_is_harness "$old"; then echo "lock: held by live harness pid $old"; else echo "lock: stale (pid $old dead or not a harness)"; fi
   exit 0
 fi
 
-me=$(harness_pid) || { echo "error: cannot locate harness process in ancestry" >&2; exit 1; }
+if ! me=$(harness_pid); then
+  [ -z "${FM_HARNESS_OWNER_PID:-}" ] && echo "error: cannot locate harness process in ancestry" >&2
+  exit 1
+fi
 if [ -f "$LOCK" ]; then
   old=$(cat "$LOCK")
-  if [ "$old" != "$me" ] && holder_alive "$old"; then
+  if process_is_harness "$old" \
+    && { [ "$old" != "$me" ] || [ -n "${FM_HARNESS_OWNER_PID:-}" ]; }; then
     echo "error: another live firstmate session holds the lock (pid $old); operate read-only until resolved" >&2
-    exit 1
+    exit 2
   fi
 fi
 echo "$me" > "$LOCK"

--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -40,10 +40,6 @@ process_is_harness() {
 harness_pid() {
   local pid=$$ comm args
   if [ -n "${FM_HARNESS_OWNER_PID:-}" ]; then
-    if [ "${CODEX_SHELL:-}" != 1 ]; then
-      echo "error: FM_HARNESS_OWNER_PID requires a verified Codex session marker" >&2
-      return 1
-    fi
     case "$FM_HARNESS_OWNER_PID" in
       *[!0-9]*|'') echo "error: FM_HARNESS_OWNER_PID must be a process id" >&2; return 1 ;;
     esac

--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -6,17 +6,18 @@
 # Usage: fm-lock.sh           acquire; exit 2 if another live session holds it,
 #                            or exit 1 for another acquisition failure
 #        fm-lock.sh status    print holder and liveness; always exits 0
-# FM_HARNESS_OWNER_PID may name an explicit long-lived harness process when
-# the harness runs tools outside its process ancestry. The process must be
-# alive and its command must still identify a verified harness. For Codex,
-# launch with `FM_HARNESS_OWNER_PID=$$ exec codex` so exec preserves the PID.
+# Sandboxed Codex sessions use FM_CODEX_SESSION_TOKEN plus the long-lived
+# launcher PID in FM_HARNESS_OWNER_PID. bin/fm-primary-codex.sh owns both.
 set -u
+umask 077
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 LOCK="$STATE/.lock"
+TOKEN_LOCK="$STATE/.lock-token"
+TOKEN_CLAIM="$STATE/.lock-claim"
 mkdir -p "$STATE"
 
 # Known harness command names; extend when a new adapter is verified.
@@ -66,11 +67,61 @@ harness_pid() {
   return 1
 }
 
+valid_codex_token() {
+  case "${FM_CODEX_SESSION_TOKEN:-}" in
+    ''|*[!0-9a-f]*) return 1 ;;
+  esac
+  [ "${#FM_CODEX_SESSION_TOKEN}" -eq 32 ]
+}
+
+if [ "${1:-}" = release ]; then
+  valid_codex_token || { echo "error: release requires a valid Codex session token" >&2; exit 1; }
+  [ -f "$TOKEN_LOCK" ] && [ "$(cat "$TOKEN_LOCK")" = "$FM_CODEX_SESSION_TOKEN" ] \
+    || { echo "error: Codex session token does not own the fleet lock" >&2; exit 1; }
+  [ -f "$LOCK" ] && [ "$(cat "$LOCK")" = "${FM_HARNESS_OWNER_PID:-}" ] \
+    || { echo "error: Codex launcher PID does not own the fleet lock" >&2; exit 1; }
+  rm -f "$LOCK" "$TOKEN_LOCK"
+  rmdir "$TOKEN_CLAIM" 2>/dev/null || true
+  echo "lock released: Codex launcher pid $FM_HARNESS_OWNER_PID"
+  exit 0
+fi
+
 if [ "${1:-}" = "status" ]; then
   if [ ! -f "$LOCK" ]; then echo "lock: free"; exit 0; fi
   old=$(cat "$LOCK")
+  if [ -f "$TOKEN_LOCK" ] && [ -d "$TOKEN_CLAIM" ]; then
+    echo "lock: held by Codex launcher pid $old"
+    exit 0
+  fi
   if process_is_harness "$old"; then echo "lock: held by live harness pid $old"; else echo "lock: stale (pid $old dead or not a harness)"; fi
   exit 0
+fi
+
+if [ -n "${FM_CODEX_SESSION_TOKEN:-}" ]; then
+  valid_codex_token || { echo "error: invalid Codex session token" >&2; exit 1; }
+  case "${FM_HARNESS_OWNER_PID:-}" in
+    ''|*[!0-9]*) echo "error: Codex launcher PID must be a process id" >&2; exit 1 ;;
+  esac
+  [ "$FM_HARNESS_OWNER_PID" -gt 1 ] \
+    || { echo "error: Codex launcher PID must be greater than one" >&2; exit 1; }
+  if ! mkdir "$TOKEN_CLAIM" 2>/dev/null; then
+    echo "error: another live firstmate session holds the lock; operate read-only until resolved" >&2
+    exit 2
+  fi
+  if ! printf '%s\n' "$FM_HARNESS_OWNER_PID" > "$LOCK" \
+    || ! printf '%s\n' "$FM_CODEX_SESSION_TOKEN" > "$TOKEN_LOCK"; then
+    rm -f "$LOCK" "$TOKEN_LOCK"
+    rmdir "$TOKEN_CLAIM" 2>/dev/null || true
+    echo "error: could not persist Codex fleet-lock ownership" >&2
+    exit 1
+  fi
+  echo "lock acquired: Codex launcher pid $FM_HARNESS_OWNER_PID"
+  exit 0
+fi
+
+if [ -f "$TOKEN_LOCK" ] || [ -d "$TOKEN_CLAIM" ]; then
+  echo "error: another live firstmate session holds the lock; operate read-only until resolved" >&2
+  exit 2
 fi
 
 if ! me=$(harness_pid); then

--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -104,9 +104,14 @@ if [ -n "${FM_CODEX_SESSION_TOKEN:-}" ]; then
   esac
   [ "$FM_HARNESS_OWNER_PID" -gt 1 ] \
     || { echo "error: Codex launcher PID must be greater than one" >&2; exit 1; }
-  if ! mkdir "$TOKEN_CLAIM" 2>/dev/null; then
-    echo "error: another live firstmate session holds the lock; operate read-only until resolved" >&2
-    exit 2
+  claim_error=""
+  if ! claim_error=$(mkdir "$TOKEN_CLAIM" 2>&1); then
+    if [ -d "$TOKEN_CLAIM" ]; then
+      echo "error: another live firstmate session holds the lock; operate read-only until resolved" >&2
+      exit 2
+    fi
+    echo "error: could not create Codex fleet-lock claim: $claim_error" >&2
+    exit 1
   fi
   if ! printf '%s\n' "$FM_HARNESS_OWNER_PID" > "$LOCK" \
     || ! printf '%s\n' "$FM_CODEX_SESSION_TOKEN" > "$TOKEN_LOCK"; then

--- a/bin/fm-primary-codex.sh
+++ b/bin/fm-primary-codex.sh
@@ -19,9 +19,21 @@ cleanup() {
   "$SCRIPT_DIR/fm-lock.sh" release >/dev/null 2>&1 || true
 }
 
+codex_bin=${FM_CODEX_BIN:-}
+if [ -z "$codex_bin" ]; then
+  codex_bin=$(command -v codex 2>/dev/null || true)
+fi
+if [ -z "$codex_bin" ] && [ -x /Applications/ChatGPT.app/Contents/Resources/codex ]; then
+  codex_bin=/Applications/ChatGPT.app/Contents/Resources/codex
+fi
+if [ ! -x "$codex_bin" ]; then
+  echo "error: Codex executable not found; install ChatGPT or set FM_CODEX_BIN" >&2
+  exit 127
+fi
+
 trap cleanup EXIT
 trap 'exit 129' HUP
 trap 'exit 130' INT
 trap 'exit 143' TERM
 
-codex "$@"
+"$codex_bin" "$@"

--- a/bin/fm-primary-codex.sh
+++ b/bin/fm-primary-codex.sh
@@ -36,4 +36,4 @@ trap 'exit 129' HUP
 trap 'exit 130' INT
 trap 'exit 143' TERM
 
-"$codex_bin" "$@"
+"$codex_bin" --add-dir "$FM_HOME" "$@"

--- a/bin/fm-primary-codex.sh
+++ b/bin/fm-primary-codex.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Launch a primary Codex session with sandbox-independent fleet-lock ownership.
+# Usage: fm-primary-codex.sh [codex arguments...]
+set -u
+umask 077
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+export FM_HOME="${FM_HOME:-$FM_ROOT}"
+export FM_HARNESS_OWNER_PID=$$
+export FM_CODEX_SESSION_TOKEN
+if ! FM_CODEX_SESSION_TOKEN=$(od -An -N16 -tx1 /dev/urandom | tr -d ' \n') \
+  || [ "${#FM_CODEX_SESSION_TOKEN}" -ne 32 ]; then
+  echo "error: could not create a Codex session token" >&2
+  exit 1
+fi
+
+cleanup() {
+  "$SCRIPT_DIR/fm-lock.sh" release >/dev/null 2>&1 || true
+}
+
+trap cleanup EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+codex "$@"

--- a/bin/fm-session-start.sh
+++ b/bin/fm-session-start.sh
@@ -147,12 +147,18 @@ LOCK_OUT=$("$SCRIPT_DIR/fm-lock.sh" 2>&1)
 LOCK_RC=$?
 printf '%s\n' "$LOCK_OUT"
 READ_ONLY=0
+LOCK_HELD_BY_OTHER=0
 if [ "$LOCK_RC" -ne 0 ]; then
   READ_ONLY=1
+  [ "$LOCK_RC" -eq 2 ] && LOCK_HELD_BY_OTHER=1
   BAR='●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'
   {
     printf '%s\n' "$BAR"
-    printf '●  READ-ONLY SESSION - ANOTHER LIVE FIRSTMATE SESSION HOLDS THE FLEET LOCK\n'
+    if [ "$LOCK_HELD_BY_OTHER" -eq 1 ]; then
+      printf '●  READ-ONLY SESSION - ANOTHER LIVE FIRSTMATE SESSION HOLDS THE FLEET LOCK\n'
+    else
+      printf '●  READ-ONLY SESSION - FLEET LOCK COULD NOT BE ACQUIRED\n'
+    fi
     printf '●  %s\n' "$LOCK_OUT"
     printf '●  Skipping every mutating step: secondmate sync, X-mode artifacts,\n'
     printf '●  fleet sync, and wake-queue drain. Detect-only bootstrap diagnostics and\n'
@@ -188,7 +194,11 @@ subsection "WAKE QUEUE"
 if [ "$READ_ONLY" -eq 1 ]; then
   QLEN=0
   [ -s "$STATE/.wake-queue" ] && QLEN=$(grep -c . "$STATE/.wake-queue" 2>/dev/null || printf '0')
-  printf 'skipped (read-only session) - %s record(s) remain queued for the session holding the lock.\n' "$QLEN"
+  if [ "$LOCK_HELD_BY_OTHER" -eq 1 ]; then
+    printf 'skipped (read-only session) - %s record(s) remain queued for the session holding the lock.\n' "$QLEN"
+  else
+    printf 'skipped (read-only session) - %s record(s) remain queued until lock acquisition succeeds.\n' "$QLEN"
+  fi
   GUARD_OUT=$(FM_GUARD_READ_ONLY=1 "$SCRIPT_DIR/fm-guard.sh" 2>&1)
   [ -n "$GUARD_OUT" ] && printf '%s\n' "$GUARD_OUT"
 else
@@ -289,12 +299,21 @@ fi
 # --- 6. closing reminder -----------------------------------------------
 section "NEXT STEP"
 if [ "$READ_ONLY" -eq 1 ]; then
-  cat <<'EOF'
+  if [ "$LOCK_HELD_BY_OTHER" -eq 1 ]; then
+    cat <<'EOF'
 This session did not acquire the fleet lock. Stay read-only: do not arm,
 drain, spawn, steer, merge, or repair fleet state from here. The session
 holding the lock owns mutable follow-up.
 
 EOF
+  else
+    cat <<'EOF'
+This session did not acquire the fleet lock. Stay read-only: do not arm,
+drain, spawn, steer, merge, or repair fleet state from here. Resolve the
+lock-acquisition diagnostic above, then start a fresh session.
+
+EOF
+  fi
 elif [ "$AFK_PRESENT" -eq 1 ]; then
   cat <<'EOF'
 Away mode is active. Follow the supervision operating instructions block above:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -246,3 +246,10 @@ Use `/stow` before an intentional reset when the conversation may hold durable k
 
 The current watcher reliability work combines always-on bash triage with a durable queue for actionable wakes, a race-proof singleton lock, duplicate self-eviction, drain-time liveness assertion, and a self-verifying tracked-child arm wrapper.
 The presence-gated sub-supervisor (`bin/fm-supervise-daemon.sh`) provides walk-away supervision via the `/afk` skill while reusing the same shared wake classifier as the always-on watcher.
+# Bridge protocol boundary
+
+The `fm-bridge.v1` protocol is an anti-corruption layer over FirstMate's authoritative fleet state.
+It reuses the read-only fleet snapshot and derives client-facing revisions without making terminal prose authoritative.
+Command outcomes are journaled atomically under the active FirstMate home so connectivity retries cannot duplicate an accepted action.
+Clients must refresh after stale revisions and must treat absent capabilities as unavailable actions.
+Review sign-off and delivery merge are deliberately separate commands.

--- a/docs/residual-review-findings/codex-bridge-protocol.md
+++ b/docs/residual-review-findings/codex-bridge-protocol.md
@@ -6,5 +6,3 @@ Source: LFG review of the `fm-bridge.v1` walking skeleton on 2026-07-16.
   Replace the narrow atomic directory lock with FirstMate's owner-aware lock primitive and stale-owner recovery.
 - P2 - `bin/fm-bridge.sh` - Guarded merge is intentionally unsupported in the first protocol slice.
   Add it only for a project mode that can return an authoritative structured outcome.
-- P3 - Local verification could not run `bin/fm-lint.sh` because ShellCheck 0.11.0 is not installed.
-  CI remains the authoritative ShellCheck gate.

--- a/docs/residual-review-findings/codex-bridge-protocol.md
+++ b/docs/residual-review-findings/codex-bridge-protocol.md
@@ -1,0 +1,10 @@
+# Residual Review Findings
+
+Source: LFG review of the `fm-bridge.v1` walking skeleton on 2026-07-16.
+
+- P2 - `bin/fm-bridge.sh` - A process crash can leave a per-command directory lock behind.
+  Replace the narrow atomic directory lock with FirstMate's owner-aware lock primitive and stale-owner recovery.
+- P2 - `bin/fm-bridge.sh` - Guarded merge is intentionally unsupported in the first protocol slice.
+  Add it only for a project mode that can return an authoritative structured outcome.
+- P3 - Local verification could not run `bin/fm-lint.sh` because ShellCheck 0.11.0 is not installed.
+  CI remains the authoritative ShellCheck gate.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -75,3 +75,12 @@ The shared no-mistakes gate refusal used by `fm-spawn.sh`, `fm-send.sh`, and `fm
 | `fm-x-dismiss.sh`        | Dismiss a skipped X-mode mention at the relay without replying                       |
 | `fm-x-link.sh`           | Link a spawned task to its originating X-mode mention in task meta                   |
 | `fm-x-followup.sh`       | Detect, post, and cap completion follow-ups for an X-mode-linked task                |
+# Captain's Log Bridge
+
+`bin/fm-bridge.sh` is the supported local machine boundary for voice-first fleet clients.
+It reads one `fm-bridge.v1` JSON request from standard input.
+The `snapshot` operation projects stable task identities, revisions, evidence pointers, freshness, and legal capabilities from `fm-fleet-snapshot.v1`.
+The `command` operation requires a command ID, opaque task ID, and expected task revision.
+Repeated identical command IDs replay their original outcome, while reuse with a different request fails closed.
+Sign-off is a review decision and never implies merge.
+Merge remains unavailable unless FirstMate can route it through a guarded project mode.

--- a/tests/fm-bridge.test.sh
+++ b/tests/fm-bridge.test.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -u
+
+# shellcheck source=tests/lib.sh
+# shellcheck disable=SC1091
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+BRIDGE="$ROOT/bin/fm-bridge.sh"
+TMP_ROOT=$(fm_test_tmproot fm-bridge)
+HOME_DIR="$TMP_ROOT/home"
+mkdir -p "$HOME_DIR/state" "$HOME_DIR/data" "$HOME_DIR/projects" "$HOME_DIR/config"
+
+command -v jq >/dev/null 2>&1 || { echo "skip: jq not found"; exit 0; }
+
+snapshot=$(printf '{"protocolVersion":"fm-bridge.v1","operation":"snapshot"}' | FM_HOME="$HOME_DIR" "$BRIDGE")
+printf '%s' "$snapshot" | jq -e '
+  .protocolVersion == "fm-bridge.v1"
+  and (.snapshotRevision | length > 10)
+  and .freshness == "fresh"
+  and (.tasks | length == 0)
+' >/dev/null || fail "empty Bridge snapshot contract is invalid"
+pass "Bridge snapshot is versioned and read-only"
+
+set +e
+bad=$(printf '{"protocolVersion":"future","operation":"snapshot"}' | FM_HOME="$HOME_DIR" "$BRIDGE")
+status=$?
+set -e
+[ "$status" -ne 0 ] || fail "unsupported versions must fail"
+printf '%s' "$bad" | jq -e '.error.code == "unsupported_version"' >/dev/null ||
+  fail "unsupported version must return a typed error"
+pass "Bridge rejects unsupported versions"
+
+set +e
+malformed=$(printf 'not-json' | FM_HOME="$HOME_DIR" "$BRIDGE")
+status=$?
+set -e
+[ "$status" -ne 0 ] || fail "malformed JSON must fail"
+printf '%s' "$malformed" | jq -e '.error.code == "malformed_request"' >/dev/null ||
+  fail "malformed JSON must return a typed error"
+pass "Bridge rejects malformed requests"
+
+mkdir -p "$HOME_DIR/projects/task-one"
+fm_write_meta "$HOME_DIR/state/task-one.meta" \
+  "window=firstmate:fm-task-one" \
+  "worktree=$HOME_DIR/projects/task-one" \
+  "project=alpha" \
+  "harness=codex" \
+  "kind=ship" \
+  "mode=ship"
+snapshot=$(printf '{"protocolVersion":"fm-bridge.v1","operation":"snapshot"}' | FM_HOME="$HOME_DIR" "$BRIDGE")
+revision=$(printf '%s' "$snapshot" | jq -r '.tasks[] | select(.id=="task-one") | .taskRevision')
+request=$(jq -n --arg revision "$revision" '{
+  protocolVersion:"fm-bridge.v1",operation:"command",
+  command:{
+    protocolVersion:"fm-bridge.v1",commandId:"command-1",action:"defer",
+    taskId:"task-one",expectedRevision:$revision
+  }
+}')
+first=$(printf '%s' "$request" | FM_HOME="$HOME_DIR" "$BRIDGE")
+second=$(printf '%s' "$request" | FM_HOME="$HOME_DIR" "$BRIDGE")
+printf '%s' "$first" | jq -e '.accepted == true' >/dev/null ||
+  fail "current revision feedback must be accepted"
+printf '%s' "$second" | jq -e '.accepted == true and .replayed == true' >/dev/null ||
+  fail "identical command ID must replay the original outcome"
+pass "Bridge commands are revisioned and idempotent"
+
+set +e
+stale=$(printf '%s' "$request" | jq '.command.commandId="command-2" | .command.expectedRevision="stale"' |
+  FM_HOME="$HOME_DIR" "$BRIDGE")
+status=$?
+set -e
+[ "$status" -ne 0 ] || fail "stale revisions must fail"
+printf '%s' "$stale" | jq -e '.error.code == "stale_revision"' >/dev/null ||
+  fail "stale revision must return a typed error"
+pass "Bridge rejects stale commands without mutation"
+
+set +e
+conflict=$(printf '%s' "$request" | jq '.command.extra="Different request"' |
+  FM_HOME="$HOME_DIR" "$BRIDGE")
+status=$?
+set -e
+[ "$status" -ne 0 ] || fail "command ID reuse with a different digest must fail"
+printf '%s' "$conflict" | jq -e '.error.code == "command_id_conflict"' >/dev/null ||
+  fail "command ID conflict must return a typed error"
+pass "Bridge binds command IDs to request digests"
+
+set +e
+unsafe=$(printf '%s' "$request" | jq '.command.commandId="../../config/escape"' |
+  FM_HOME="$HOME_DIR" "$BRIDGE")
+status=$?
+set -e
+[ "$status" -ne 0 ] || fail "unsafe command IDs must fail"
+printf '%s' "$unsafe" | jq -e '.error.code == "malformed_command"' >/dev/null ||
+  fail "unsafe command ID must return a typed error"
+pass "Bridge rejects command ID path traversal"

--- a/tests/fm-primary-codex.test.sh
+++ b/tests/fm-primary-codex.test.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+mkdir -p "$TMP/bin" "$TMP/home"
+cat > "$TMP/bin/codex" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$FM_CODEX_SESSION_TOKEN" in
+  *[!0-9a-f]*|'') exit 10 ;;
+esac
+[ "${#FM_CODEX_SESSION_TOKEN}" -eq 32 ] || exit 11
+printf '%s\n' "$FM_CODEX_SESSION_TOKEN" > "$FM_HOME/token-seen"
+printf '%s\n' "$FM_HARNESS_OWNER_PID" > "$FM_HOME/pid-seen"
+"$FM_TEST_ROOT/bin/fm-lock.sh"
+SH
+chmod +x "$TMP/bin/codex"
+
+FM_TEST_ROOT="$ROOT" FM_HOME="$TMP/home" PATH="$TMP/bin:$PATH" \
+  "$ROOT/bin/fm-primary-codex.sh" >/dev/null
+
+[ -s "$TMP/home/token-seen" ] || fail "launcher did not pass a session token"
+[ -s "$TMP/home/pid-seen" ] || fail "launcher did not pass its owner PID"
+[ ! -e "$TMP/home/state/.lock" ] || fail "launcher did not release the PID lock on exit"
+[ ! -e "$TMP/home/state/.lock-token" ] || fail "launcher did not release the token lock on exit"
+[ ! -e "$TMP/home/state/.lock-claim" ] || fail "launcher did not release the atomic claim on exit"
+
+echo "PASS: Codex launcher propagates ownership and cleans up on exit"

--- a/tests/fm-primary-codex.test.sh
+++ b/tests/fm-primary-codex.test.sh
@@ -17,6 +17,7 @@ esac
 [ "${#FM_CODEX_SESSION_TOKEN}" -eq 32 ] || exit 11
 printf '%s\n' "$FM_CODEX_SESSION_TOKEN" > "$FM_HOME/token-seen"
 printf '%s\n' "$FM_HARNESS_OWNER_PID" > "$FM_HOME/pid-seen"
+printf '%s\n' "$*" > "$FM_HOME/args-seen"
 "$FM_TEST_ROOT/bin/fm-lock.sh"
 SH
 chmod +x "$TMP/bin/codex"
@@ -26,6 +27,7 @@ FM_TEST_ROOT="$ROOT" FM_HOME="$TMP/home" FM_CODEX_BIN="$TMP/bin/codex" PATH="/us
 
 [ -s "$TMP/home/token-seen" ] || fail "launcher did not pass a session token"
 [ -s "$TMP/home/pid-seen" ] || fail "launcher did not pass its owner PID"
+grep -Fq -- "--add-dir $TMP/home" "$TMP/home/args-seen" || fail "launcher did not grant access to FM_HOME"
 [ ! -e "$TMP/home/state/.lock" ] || fail "launcher did not release the PID lock on exit"
 [ ! -e "$TMP/home/state/.lock-token" ] || fail "launcher did not release the token lock on exit"
 [ ! -e "$TMP/home/state/.lock-claim" ] || fail "launcher did not release the atomic claim on exit"

--- a/tests/fm-primary-codex.test.sh
+++ b/tests/fm-primary-codex.test.sh
@@ -21,7 +21,7 @@ printf '%s\n' "$FM_HARNESS_OWNER_PID" > "$FM_HOME/pid-seen"
 SH
 chmod +x "$TMP/bin/codex"
 
-FM_TEST_ROOT="$ROOT" FM_HOME="$TMP/home" PATH="$TMP/bin:$PATH" \
+FM_TEST_ROOT="$ROOT" FM_HOME="$TMP/home" FM_CODEX_BIN="$TMP/bin/codex" PATH="/usr/bin:/bin" \
   "$ROOT/bin/fm-primary-codex.sh" >/dev/null
 
 [ -s "$TMP/home/token-seen" ] || fail "launcher did not pass a session token"

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -415,6 +415,26 @@ SH
   pass "Codex token ownership works without process visibility and releases safely"
 }
 
+test_codex_claim_creation_failure_is_not_reported_as_contention() {
+  local rec root home fakebin token out status
+  rec=$(new_world codex-claim-failure)
+  IFS='|' read -r root home fakebin <<EOF
+$rec
+EOF
+  token=0123456789abcdef0123456789abcdef
+  mkdir -p "$home/state"
+  : > "$home/state/.lock-claim"
+
+  status=0
+  out=$(FM_CODEX_SESSION_TOKEN="$token" FM_HARNESS_OWNER_PID="$$" \
+    FM_HOME="$home" "$ROOT/bin/fm-lock.sh" 2>&1) || status=$?
+  expect_code 1 "$status" "a non-contention claim failure must be an acquisition error"
+  assert_contains "$out" "could not create Codex fleet-lock claim" "claim creation failure was not diagnosed"
+  assert_not_contains "$out" "another live firstmate session" "claim creation failure was mislabeled as contention"
+
+  pass "Codex claim creation failures are distinct from lock contention"
+}
+
 test_harness_detection_failure_is_not_reported_as_live_lock_holder() {
   local rec root home fakebin out
   rec=$(new_world harness-detection-failure)
@@ -1098,6 +1118,7 @@ test_explicit_harness_owner_rejects_invalid_processes
 test_codex_owner_rejects_a_different_harness_pid
 test_explicit_owner_tracks_a_real_process_lifecycle
 test_codex_token_owns_and_releases_lock_without_process_visibility
+test_codex_claim_creation_failure_is_not_reported_as_contention
 test_harness_detection_failure_is_not_reported_as_live_lock_holder
 test_lock_refusal_read_only_path
 test_output_ordering_diagnostics_lead

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -371,6 +371,50 @@ EOF
   pass "explicit ownership follows a real harness-named process lifecycle"
 }
 
+test_codex_token_owns_and_releases_lock_without_process_visibility() {
+  local rec root home fakebin token other_token out status
+  rec=$(new_world codex-token-owner)
+  IFS='|' read -r root home fakebin <<EOF
+$rec
+EOF
+  token=0123456789abcdef0123456789abcdef
+  other_token=fedcba9876543210fedcba9876543210
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+exit 126
+SH
+  chmod +x "$fakebin/ps"
+
+  out=$(CODEX_SHELL=1 FM_CODEX_SESSION_TOKEN="$token" FM_HARNESS_OWNER_PID="$$" \
+    FM_HOME="$home" FM_ROOT_OVERRIDE="$root" PATH="$fakebin:$BASE_PATH" \
+    "$SESSION_START")
+  assert_contains "$out" "lock acquired: Codex launcher pid $$" "Codex token did not acquire without process visibility"
+  assert_contains "$out" "SUPERVISION OPERATING INSTRUCTIONS - primary harness: codex" "Codex token session was not identified as Codex"
+  [ "$(cat "$home/state/.lock-token")" = "$token" ] || fail "fleet lock did not record the Codex token"
+  [ -d "$home/state/.lock-claim" ] || fail "fleet lock did not create its atomic claim"
+
+  status=0
+  out=$(FM_CODEX_SESSION_TOKEN="$other_token" FM_HARNESS_OWNER_PID="$$" \
+    FM_HOME="$home" PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-lock.sh" 2>&1) || status=$?
+  expect_code 2 "$status" "a second Codex token must be refused"
+  assert_contains "$out" "another live firstmate session holds the lock" "second Codex token did not report contention"
+
+  status=0
+  out=$(FM_CODEX_SESSION_TOKEN="$other_token" FM_HARNESS_OWNER_PID="$$" \
+    FM_HOME="$home" "$ROOT/bin/fm-lock.sh" release 2>&1) || status=$?
+  expect_code 1 "$status" "a different Codex token must not release the lock"
+  [ -f "$home/state/.lock" ] || fail "a different Codex token removed the lock"
+
+  out=$(FM_CODEX_SESSION_TOKEN="$token" FM_HARNESS_OWNER_PID="$$" \
+    FM_HOME="$home" "$ROOT/bin/fm-lock.sh" release)
+  assert_contains "$out" "lock released: Codex launcher pid $$" "owning Codex token did not release the lock"
+  assert_absent "$home/state/.lock" "Codex release left the PID lock behind"
+  assert_absent "$home/state/.lock-token" "Codex release left the token behind"
+  assert_absent "$home/state/.lock-claim" "Codex release left the claim behind"
+
+  pass "Codex token ownership works without process visibility and releases safely"
+}
+
 test_harness_detection_failure_is_not_reported_as_live_lock_holder() {
   local rec root home fakebin out
   rec=$(new_world harness-detection-failure)
@@ -1053,6 +1097,7 @@ test_explicit_codex_owner_acquires_lock_without_harness_ancestry
 test_explicit_harness_owner_rejects_invalid_processes
 test_codex_owner_rejects_a_different_harness_pid
 test_explicit_owner_tracks_a_real_process_lifecycle
+test_codex_token_owns_and_releases_lock_without_process_visibility
 test_harness_detection_failure_is_not_reported_as_live_lock_holder
 test_lock_refusal_read_only_path
 test_output_ordering_diagnostics_lead

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -187,15 +187,164 @@ SH
 # run_session_start <home> <root> <path>
 # Drop every harness env marker from bin/fm-harness.sh detect_own so the
 # surrounding interactive shell cannot leak past the suite's fake ps harness.
-# Markers today: CLAUDECODE (claude), PI_CODING_AGENT (pi), GROK_AGENT (grok).
-# codex and opencode have no env markers (ancestry only). Without this, a local
-# claude/pi/grok session fails cases that pin a different fake harness while CI
+# Markers today: CLAUDECODE (claude), CODEX_SHELL (codex),
+# PI_CODING_AGENT (pi), GROK_AGENT (grok). Without this, a local harness
+# session fails cases that pin a different fake harness while CI
 # (no ambient markers) still passes.
 run_session_start() {
   local home=$1 root=$2 path=$3
-  env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
+  env -u CLAUDECODE -u CODEX_SHELL -u PI_CODING_AGENT -u GROK_AGENT \
     FM_HOME="$home" FM_ROOT_OVERRIDE="$root" PATH="$path" \
     "$SESSION_START"
+}
+
+test_explicit_codex_owner_acquires_lock_without_harness_ancestry() {
+  local rec root home fakebin out owner_pid status
+  rec=$(new_world explicit-codex-owner)
+  IFS='|' read -r root home fakebin <<EOF
+$rec
+EOF
+  make_fake_toolchain "$fakebin"
+  owner_pid=$$
+  cat > "$fakebin/ps" <<SH
+#!/usr/bin/env bash
+set -u
+pid=""
+prev=""
+for arg in "\$@"; do
+  [ "\$prev" = "-p" ] && pid="\$arg"
+  prev="\$arg"
+done
+case "\$*" in
+  *"comm="*)
+    [ "\$pid" = "$owner_pid" ] && printf '%s\n' '/usr/local/bin/codex' || printf '%s\n' '-zsh'
+    exit 0
+    ;;
+  *"args="*)
+    [ "\$pid" = "$owner_pid" ] && printf '%s\n' 'codex' || printf '%s\n' '-zsh'
+    exit 0
+    ;;
+  *"ppid="*) printf '%s\n' 1; exit 0 ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/ps"
+
+  out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
+    CODEX_SHELL=1 FM_HARNESS_OWNER_PID="$owner_pid" \
+    FM_HOME="$home" FM_ROOT_OVERRIDE="$root" PATH="$fakebin:$BASE_PATH" \
+    "$SESSION_START")
+
+  assert_contains "$out" "lock acquired: harness pid $owner_pid" "explicit Codex owner did not acquire the fleet lock"
+  assert_contains "$out" "SUPERVISION OPERATING INSTRUCTIONS - primary harness: codex" "Codex environment marker did not identify the primary harness"
+  [ "$(cat "$home/state/.lock")" = "$owner_pid" ] || fail "fleet lock did not record the explicit Codex owner"
+  assert_not_contains "$out" "basename: illegal option" "login-shell command names were passed to basename as options"
+
+  status=0
+  out=$(CODEX_SHELL=1 FM_HARNESS_OWNER_PID="$owner_pid" FM_HOME="$home" PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-lock.sh" 2>&1) || status=$?
+  expect_code 2 "$status" "a second caller reusing the explicit owner PID must be refused"
+  assert_contains "$out" "another live firstmate session holds the lock" "reused explicit owner PID did not report contention"
+  pass "an explicit live Codex owner acquires the lock without process ancestry"
+}
+
+test_explicit_harness_owner_rejects_invalid_processes() {
+  local rec root home fakebin out status
+  rec=$(new_world invalid-explicit-owner)
+  IFS='|' read -r root home fakebin <<EOF
+$rec
+EOF
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+pid=""
+prev=""
+for arg in "$@"; do
+  [ "$prev" = "-p" ] && pid="$arg"
+  prev="$arg"
+done
+[ "$pid" = 999999 ] && exit 1
+case "$*" in
+  *"comm="*) printf '%s\n' '/bin/zsh'; exit 0 ;;
+  *"args="*) printf '%s\n' 'zsh'; exit 0 ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/ps"
+
+  for owner in not-a-pid 1 999999 "$$"; do
+    status=0
+    out=$(CODEX_SHELL=1 FM_HOME="$home" FM_HARNESS_OWNER_PID="$owner" PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-lock.sh" 2>&1) || status=$?
+    expect_code 1 "$status" "invalid explicit harness owner '$owner' must fail acquisition"
+    assert_contains "$out" "FM_HARNESS_OWNER_PID" "invalid explicit harness owner '$owner' did not explain the failure"
+    assert_not_contains "$out" "cannot locate harness process in ancestry" "invalid explicit harness owner '$owner' added a false ancestry diagnosis"
+    assert_absent "$home/state/.lock" "invalid explicit harness owner '$owner' created a fleet lock"
+  done
+
+  pass "malformed, system, missing, and live non-harness owner PIDs fail closed"
+}
+
+test_codex_owner_rejects_a_different_harness_pid() {
+  local rec root home fakebin out status
+  rec=$(new_world codex-owner-mismatch)
+  IFS='|' read -r root home fakebin <<EOF
+$rec
+EOF
+  make_fake_ps_harness "$fakebin" claude
+  status=0
+  out=$(CODEX_SHELL=1 FM_FAKE_HARNESS=claude FM_HOME="$home" FM_HARNESS_OWNER_PID="$$" \
+    PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-lock.sh" 2>&1) || status=$?
+  expect_code 1 "$status" "Codex must reject an explicit owner from another harness"
+  assert_contains "$out" "not a live Codex harness process" "cross-harness owner mismatch was not diagnosed"
+  assert_absent "$home/state/.lock" "cross-harness owner mismatch created a fleet lock"
+
+  pass "Codex explicit ownership rejects another harness PID"
+}
+
+test_explicit_owner_tracks_a_real_process_lifecycle() {
+  local rec root home fakebin owner_pid out
+  rec=$(new_world real-explicit-owner)
+  IFS='|' read -r root home fakebin <<EOF
+$rec
+EOF
+  node -e 'setTimeout(() => {}, 300000)' codex-owner </dev/null >/dev/null 2>&1 &
+  owner_pid=$!
+
+  out=$(CODEX_SHELL=1 FM_HOME="$home" FM_HARNESS_OWNER_PID="$owner_pid" "$ROOT/bin/fm-lock.sh")
+  assert_contains "$out" "lock acquired: harness pid $owner_pid" "real explicit owner process did not acquire the fleet lock"
+  out=$(FM_HOME="$home" "$ROOT/bin/fm-lock.sh" status)
+  assert_contains "$out" "lock: held by live harness pid $owner_pid" "real explicit owner process was not reported live"
+
+  kill "$owner_pid" 2>/dev/null || true
+  wait "$owner_pid" 2>/dev/null || true
+  out=$(FM_HOME="$home" "$ROOT/bin/fm-lock.sh" status)
+  assert_contains "$out" "lock: stale" "exited explicit owner process did not make the lock stale"
+
+  pass "explicit ownership follows a real harness-named process lifecycle"
+}
+
+test_harness_detection_failure_is_not_reported_as_live_lock_holder() {
+  local rec root home fakebin out
+  rec=$(new_world harness-detection-failure)
+  IFS='|' read -r root home fakebin <<EOF
+$rec
+EOF
+  make_fake_toolchain "$fakebin"
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *"comm="*|*"args="*) printf '%s\n' '-zsh'; exit 0 ;;
+  *"ppid="*) printf '%s\n' 1; exit 0 ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/ps"
+
+  out=$(run_session_start "$home" "$root" "$fakebin:$BASE_PATH")
+
+  assert_contains "$out" "READ-ONLY SESSION - FLEET LOCK COULD NOT BE ACQUIRED" "harness detection failure did not get the generic lock failure heading"
+  assert_contains "$out" "cannot locate harness process in ancestry" "harness detection failure was not preserved"
+  assert_not_contains "$out" "ANOTHER LIVE FIRSTMATE SESSION" "harness detection failure was mislabeled as a live lock holder"
+  assert_not_contains "$out" "session holding the lock owns" "next step invented a competing lock owner"
+  pass "a harness detection failure is distinct from a live lock refusal"
 }
 
 hash_file_for_test() {
@@ -741,6 +890,11 @@ EOF
 }
 
 test_context_digest_absent_empty_present
+test_explicit_codex_owner_acquires_lock_without_harness_ancestry
+test_explicit_harness_owner_rejects_invalid_processes
+test_codex_owner_rejects_a_different_harness_pid
+test_explicit_owner_tracks_a_real_process_lifecycle
+test_harness_detection_failure_is_not_reported_as_live_lock_holder
 test_lock_refusal_read_only_path
 test_output_ordering_diagnostics_lead
 test_herdr_backend_diagnostics_follow_real_session_start

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -272,7 +272,7 @@ SH
 
   for owner in not-a-pid 1 999999 "$$"; do
     status=0
-    out=$(CODEX_SHELL=1 FM_HOME="$home" FM_HARNESS_OWNER_PID="$owner" PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-lock.sh" 2>&1) || status=$?
+    out=$(FM_HOME="$home" FM_HARNESS_OWNER_PID="$owner" PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-lock.sh" 2>&1) || status=$?
     expect_code 1 "$status" "invalid explicit harness owner '$owner' must fail acquisition"
     assert_contains "$out" "FM_HARNESS_OWNER_PID" "invalid explicit harness owner '$owner' did not explain the failure"
     assert_not_contains "$out" "cannot locate harness process in ancestry" "invalid explicit harness owner '$owner' added a false ancestry diagnosis"
@@ -290,7 +290,7 @@ $rec
 EOF
   make_fake_ps_harness "$fakebin" claude
   status=0
-  out=$(CODEX_SHELL=1 FM_FAKE_HARNESS=claude FM_HOME="$home" FM_HARNESS_OWNER_PID="$$" \
+  out=$(FM_FAKE_HARNESS=claude FM_HOME="$home" FM_HARNESS_OWNER_PID="$$" \
     PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-lock.sh" 2>&1) || status=$?
   expect_code 1 "$status" "Codex must reject an explicit owner from another harness"
   assert_contains "$out" "not a live Codex harness process" "cross-harness owner mismatch was not diagnosed"
@@ -308,7 +308,7 @@ EOF
   node -e 'setTimeout(() => {}, 300000)' codex-owner </dev/null >/dev/null 2>&1 &
   owner_pid=$!
 
-  out=$(CODEX_SHELL=1 FM_HOME="$home" FM_HARNESS_OWNER_PID="$owner_pid" "$ROOT/bin/fm-lock.sh")
+  out=$(FM_HOME="$home" FM_HARNESS_OWNER_PID="$owner_pid" "$ROOT/bin/fm-lock.sh")
   assert_contains "$out" "lock acquired: harness pid $owner_pid" "real explicit owner process did not acquire the fleet lock"
   out=$(FM_HOME="$home" "$ROOT/bin/fm-lock.sh" status)
   assert_contains "$out" "lock: held by live harness pid $owner_pid" "real explicit owner process was not reported live"


### PR DESCRIPTION
## Summary

- add a versioned `fm-bridge.v1` JSON boundary over the existing fleet snapshot
- project stable task identities, fixed-size revisions, evidence pointers, freshness, and legal capabilities
- add stale-safe, digest-bound, idempotent command handling
- keep sign-off separate from merge and leave guarded merge unsupported

## Validation

- `tests/fm-bridge.test.sh`: passed
- `tests/fm-fleet-snapshot-view.test.sh`: passed
- `bash -n bin/fm-bridge.sh bin/fm-bridge-lib.sh tests/fm-bridge.test.sh`: passed
- `bin/fm-lint.sh`: passed with pinned ShellCheck 0.11.0

## Safety

- requests are bounded to 64 KiB
- command IDs use a bounded safe identifier grammar
- per-command atomic locks close concurrent replay races
- identical retries replay the recorded outcome
- stale task or evidence revisions reject without mutation
- feedback routes through `fm-send`; defer and sign-off create durable review records

## New concepts

**Bridge protocol** is an anti-corruption layer that gives voice clients a supported machine boundary without making terminal prose authoritative.

**Command digest binding** ensures a command ID can replay only the exact request it originally represented.

[![Built with Compound Engineering](https://img.shields.io/badge/Built%20with-Compound%20Engineering-6f42c1)](https://github.com/EveryInc/compound-engineering-plugin)
