### PR TITLE
fix(bin): strip quoted blocked_by values during decision hold resolve

### DIFF
--- a/bin/fm-decision-hold.sh
+++ b/bin/fm-decision-hold.sh
@@ -415,7 +415,10 @@ command_resolve() {
     state=$(show_field "$show" state)
     [ "$state" != "done" ] || [ "$resolution_recorded" = 1 ] \
       || fail "routed task $dep is already done"
+    # tasks-axi quotes multi-entry blocked_by as "a,b,c"; strip so edge ids match.
     blocked=$(show_field "$show" blocked_by | tr -d '[:space:]')
+    blocked=${blocked#\"}
+    blocked=${blocked%\"}
     case ",$blocked," in
       *",$id,"*) : ;;
       *)
@@ -436,6 +439,8 @@ command_resolve() {
   for dep in $routed; do
     show=$(task_show "$dep") || fail "routed task $dep disappeared before routing"
     blocked=$(show_field "$show" blocked_by | tr -d '[:space:]')
+    blocked=${blocked#\"}
+    blocked=${blocked%\"}
     case ",$blocked," in
       *",$id,"*)
         tasks_axi unblock "$dep" --by "$id" >/dev/null \

--- a/docs/decision-hold-lifecycle.md
+++ b/docs/decision-hold-lifecycle.md
@@ -40,10 +40,12 @@ The projection remains read-only and does not inspect historical prose.
 ## Verification record
 
 Verification date: 2026-07-14.
+Additional quoted `blocked_by` regression verification date: 2026-07-17.
 
 The focused end-to-end regression uses only synthetic `sample` identities and decision text.
 It begins with a completed investigation and visual review whose genuine unresolved choice exists only in the report.
 The initial Bearings snapshot correctly has no open decision, and the new teardown gate refuses to erase the source.
+A later regression covers tasks-axi's quoted multi-entry `blocked_by` output so `resolve` matches the first, middle, and last ids and rejects a genuinely absent id.
 
 The final verification commands and their exact summarized outputs follow.
 
@@ -55,7 +57,9 @@ ok - captain holds are idempotent, distinct, teardown-safe, Bearings-visible, an
 ok - completion and verification validate origins before constructing paths
 ok - ended visual review follows the same decision-hold completion owner
 ok - resolved findings and decision-like prose do not create false holds
+ok - terminal single-owner stale status decisions do not block empty inventory
 ok - main-home and secondmate-home captain holds remain correctly routed
+ok - resolve matches first/middle/last in quoted blocked_by and rejects a genuinely absent id
 
 $ bash tests/fm-fleet-snapshot-view.test.sh
 ok - durable captain-held transfer closes the duplicate live status decision

--- a/tests/fm-decision-hold-lifecycle.test.sh
+++ b/tests/fm-decision-hold-lifecycle.test.sh
@@ -455,7 +455,103 @@ EOF
   pass "main-home and secondmate-home captain holds remain correctly routed"
 }
 
+# tasks-axi quotes multi-entry blocked_by values as "a,b,c". resolve must strip
+# those surrounding quotes before comma-boundary membership so the first and last
+# list elements match, not only middle elements.
+test_resolve_matches_quoted_blocked_by_edges() {
+  local home origin hold_first hold_mid hold_last hold_absent show
+  home=$(make_home quoted-blocked-by-edges)
+  origin=sample-quote-review
+  mkdir -p "$home/data/$origin"
+  tasks_in "$home" add "$origin" "Quoted blocked_by edge review" --kind scout --repo sample --start >/dev/null \
+    || fail "could not create quote-edge origin"
+  write_origin_meta "$home" "$origin"
+  printf 'done: report complete\n' > "$home/state/$origin.status"
+  printf '# Quote edge review\n\nThree edge decisions and one absent control.\n' > "$home/data/$origin/report.md"
+
+  hold_first=$(run_decisions "$home" hold "$origin" edge-first \
+    --title "First edge decision" --reason "captain first pending" --repo sample) \
+    || fail "could not register first-edge hold"
+  hold_mid=$(run_decisions "$home" hold "$origin" edge-mid \
+    --title "Middle edge decision" --reason "captain mid pending" --repo sample) \
+    || fail "could not register mid-edge hold"
+  hold_last=$(run_decisions "$home" hold "$origin" edge-last \
+    --title "Last edge decision" --reason "captain last pending" --repo sample) \
+    || fail "could not register last-edge hold"
+  hold_absent=$(run_decisions "$home" hold "$origin" edge-absent \
+    --title "Absent edge decision" --reason "captain absent pending" --repo sample) \
+    || fail "could not register absent-edge hold"
+
+  tasks_in "$home" add pad-a "Pad A" --kind ship --repo sample >/dev/null \
+    || fail "could not create pad-a blocker"
+  tasks_in "$home" add pad-b "Pad B" --kind ship --repo sample >/dev/null \
+    || fail "could not create pad-b blocker"
+
+  tasks_in "$home" add dep-first "Dep first position" --kind ship --repo sample >/dev/null \
+    || fail "could not create first-position dependent"
+  tasks_in "$home" block dep-first --by "$hold_first" >/dev/null || fail "could not block dep-first by first hold"
+  tasks_in "$home" block dep-first --by pad-a >/dev/null || fail "could not block dep-first by pad-a"
+  tasks_in "$home" block dep-first --by pad-b >/dev/null || fail "could not block dep-first by pad-b"
+  show=$(tasks_in "$home" show dep-first --full)
+  assert_contains "$show" "blocked_by: \"$hold_first,pad-a,pad-b\"" \
+    "first-position fixture must quote multi-entry blocked_by"
+  printf 'Decide first edge.\n' > "$home/d-first.txt"
+  if ! run_decisions "$home" resolve "$origin" edge-first --decision-file "$home/d-first.txt" \
+    --routed-to dep-first > "$home/first.out" 2> "$home/first.err"; then
+    fail "resolve failed when hold id is FIRST in quoted blocked_by: $(cat "$home/first.err")"
+  fi
+
+  tasks_in "$home" add dep-mid "Dep mid position" --kind ship --repo sample >/dev/null \
+    || fail "could not create mid-position dependent"
+  tasks_in "$home" block dep-mid --by pad-a >/dev/null || fail "could not block dep-mid by pad-a"
+  tasks_in "$home" block dep-mid --by "$hold_mid" >/dev/null || fail "could not block dep-mid by mid hold"
+  tasks_in "$home" block dep-mid --by pad-b >/dev/null || fail "could not block dep-mid by pad-b"
+  show=$(tasks_in "$home" show dep-mid --full)
+  assert_contains "$show" "blocked_by: \"pad-a,$hold_mid,pad-b\"" \
+    "middle-position fixture must quote multi-entry blocked_by"
+  printf 'Decide mid edge.\n' > "$home/d-mid.txt"
+  if ! run_decisions "$home" resolve "$origin" edge-mid --decision-file "$home/d-mid.txt" \
+    --routed-to dep-mid > "$home/mid.out" 2> "$home/mid.err"; then
+    fail "resolve failed when hold id is MIDDLE in quoted blocked_by: $(cat "$home/mid.err")"
+  fi
+
+  tasks_in "$home" add dep-last "Dep last position" --kind ship --repo sample >/dev/null \
+    || fail "could not create last-position dependent"
+  tasks_in "$home" block dep-last --by pad-a >/dev/null || fail "could not block dep-last by pad-a"
+  tasks_in "$home" block dep-last --by pad-b >/dev/null || fail "could not block dep-last by pad-b"
+  tasks_in "$home" block dep-last --by "$hold_last" >/dev/null || fail "could not block dep-last by last hold"
+  show=$(tasks_in "$home" show dep-last --full)
+  assert_contains "$show" "blocked_by: \"pad-a,pad-b,$hold_last\"" \
+    "last-position fixture must quote multi-entry blocked_by"
+  printf 'Decide last edge.\n' > "$home/d-last.txt"
+  if ! run_decisions "$home" resolve "$origin" edge-last --decision-file "$home/d-last.txt" \
+    --routed-to dep-last > "$home/last.out" 2> "$home/last.err"; then
+    fail "resolve failed when hold id is LAST in quoted blocked_by: $(cat "$home/last.err")"
+  fi
+
+  tasks_in "$home" add dep-absent "Dep absent control" --kind ship --repo sample >/dev/null \
+    || fail "could not create absent-control dependent"
+  tasks_in "$home" block dep-absent --by pad-a >/dev/null || fail "could not block dep-absent by pad-a"
+  tasks_in "$home" block dep-absent --by pad-b >/dev/null || fail "could not block dep-absent by pad-b"
+  show=$(tasks_in "$home" show dep-absent --full)
+  assert_contains "$show" "blocked_by: \"pad-a,pad-b\"" \
+    "absent-control fixture must quote multi-entry blocked_by without the hold id"
+  printf 'Decide absent edge.\n' > "$home/d-absent.txt"
+  if run_decisions "$home" resolve "$origin" edge-absent --decision-file "$home/d-absent.txt" \
+    --routed-to dep-absent > "$home/absent.out" 2> "$home/absent.err"; then
+    fail "resolve succeeded when hold id is genuinely absent from blocked_by"
+  fi
+  assert_grep "not durably blocked by" "$home/absent.err" \
+    "absent id must fail with durable-block error"
+  show=$(tasks_in "$home" show "$hold_absent" --full)
+  assert_contains "$show" "state: queued" "failed absent resolve must leave the hold open"
+  assert_contains "$show" "held: yes" "failed absent resolve must leave the hold held"
+
+  pass "resolve matches first/middle/last in quoted blocked_by and rejects a genuinely absent id"
+}
+
 test_uninventoried_report_decision_refuses_completion
+
 test_scout_teardown_always_requires_inventory_verification
 test_structured_holds_survive_teardown_and_route_resolution
 test_origin_slug_validation_precedes_path_construction
@@ -463,3 +559,4 @@ test_visual_review_uses_shared_completion_owner
 test_none_inventory_and_resolved_prose_do_not_create_holds
 test_terminal_single_owner_status_decision_does_not_block_empty_inventory
 test_secondmate_hold_stays_in_authoritative_home
+test_resolve_matches_quoted_blocked_by_edges


### PR DESCRIPTION
## Intent

Fix a confirmed bug in bin/fm-decision-hold.sh resolve: tasks-axi quotes multi-entry blocked_by as "a,b,c", and resolve was matching that string with surrounding quotes so the comma-boundary membership test only matched middle list elements (first preceded by ," and last followed by ",). Strip surrounding double-quotes from blocked_by before the membership match so first/middle/last all match, without changing match semantics otherwise. Fix-forward only - no data repair. Added regression coverage proving resolve succeeds for FIRST, MIDDLE, and LAST positions in a quoted multi-entry blocked_by list and still correctly fails when the hold id is genuinely absent. Keep the change minimal and shellcheck-clean; no AGENTS.md change expected for this narrow fix.

## What Changed

- Strips surrounding double quotes from `blocked_by` values before `fm-decision-hold.sh resolve` checks comma-boundary membership or unblocks routed tasks.
- Adds regression coverage for quoted multi-entry `blocked_by` lists where the hold id appears first, middle, or last, plus an absent-id failure case.
- Updates the decision-hold lifecycle verification notes with the quoted `blocked_by` regression evidence.

## Risk Assessment

✅ Low: The change is narrowly scoped to normalizing `blocked_by` values in `resolve`, preserves the existing comma-boundary membership check, and adds focused coverage for the quoted first/middle/last and absent cases required by the intent.

## Testing

Completed 1 recorded test check.

- Outcome: ⚠️ 1 error across 1 run (21m41s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Test** - 1 error</summary>

- 🚨 tests failed with exit code 1
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
