### PR TITLE
fix(afk): detect GUI-hosted primary and refuse instead of guessing a pane

### DIFF
--- a/.agents/skills/afk/SKILL.md
+++ b/.agents/skills/afk/SKILL.md
@@ -76,6 +76,13 @@ what**. "Away" never means "approves more." A PR ready for merge, a
 needs-decision finding, or anything destructive still waits for the captain's
 explicit word - the daemon just batches the notification.
 
+## Unsupported: GUI-hosted (Claude Desktop) primary
+
+The daemon injects escalations by `tmux send-keys`/herdr into the captain's pane, so it needs firstmate to actually run in a tmux or herdr pane.
+A firstmate running inside Claude Desktop's local-agent-mode is not a pane: `bin/fm-afk-launch.sh` (both `start` and `start-native`) and `bin/fm-supervise-daemon.sh` detect this via `fm_supervisor_gui_hosted` in `bin/fm-supervisor-target-lib.sh` (no `$TMUX_PANE`/herdr markers, plus Claude Desktop's `__CFBundleIdentifier`) and refuse to start rather than guess a pane that could resolve to an unrelated stale session and silently misdirect escalations (`data/learnings.md`).
+On refusal, do not retry with a different backend: stay on the normal always-on watcher, which already delivers wakes through Claude Code background-task completion instead of pane injection.
+An explicit `FM_SUPERVISOR_TARGET`/`FM_SUPERVISOR_BACKEND` still overrides the detection for a captain or test harness that knows the real pane.
+
 ## Sentinel marker contract
 
 The daemon prefixes every injection with `FM_INJECT_MARK` (U+2063 INVISIBLE SEPARATOR), which has no normal keyboard keystroke and survives terminal transport as UTF-8 text.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -353,6 +353,7 @@ The skill owns the daemon procedure; these safety facts remain inline:
 - Any other unmarked message means the captain returned; load `/afk`, run the return owner, and do not process that message as ordinary work until its durable catch-up gate clears.
 - Away mode never expands approval authority for merges, ask-user findings, destructive actions, irreversible actions, or security-sensitive choices.
 - Bias ambiguous input toward exit because a present captain takes precedence.
+- The daemon needs a real tmux/herdr pane to inject into; a GUI-hosted (Claude Desktop) primary has none, and launch refuses loudly rather than guessing one (`/afk` skill, "Unsupported: GUI-hosted (Claude Desktop) primary").
 
 ### Stuck-worker trigger
 

--- a/bin/fm-afk-launch.sh
+++ b/bin/fm-afk-launch.sh
@@ -441,6 +441,14 @@ fm_afk_launch_start() {
     fm_afk_launch_log "return catch-up is still pending; run bin/fm-afk-return.sh check before re-entering away mode"
     return 1
   fi
+  # Refuse loudly instead of guessing a pane when firstmate looks GUI-hosted
+  # (Claude Desktop): there is no tmux/herdr pane to inject escalations into
+  # (data/learnings.md "afk daemon does NOT work when firstmate is GUI-hosted").
+  if [ -z "${FM_SUPERVISOR_TARGET:-}" ] && [ -z "${FM_SUPERVISOR_BACKEND:-}" ] \
+      && fm_supervisor_gui_hosted; then
+    fm_afk_launch_log "refusing to start the away-mode daemon: firstmate looks GUI-hosted (Claude Desktop), which has no tmux/herdr pane to inject escalations into; keep the always-on watcher running instead of /afk"
+    return 1
+  fi
   # Capture the captain pane FIRST, before creating anything.
   captain_target=$(discover_supervisor_target) || {
     fm_afk_launch_log "could not resolve the captain supervisor pane (set FM_SUPERVISOR_TARGET)"; return 1; }
@@ -509,6 +517,15 @@ fm_afk_launch_start_native() {
   mkdir -p "$FM_AFK_LAUNCH_STATE" || return 1
   if [ -e "$FM_AFK_LAUNCH_STATE/.afk-return-catchup" ]; then
     fm_afk_launch_log "return catch-up is still pending; run bin/fm-afk-return.sh check before re-entering away mode"
+    return 1
+  fi
+  # This path hands off to a harness-native background job that inherits this
+  # process's own env and auto-discovers the captain pane from it (see file
+  # header); refuse here too so a GUI-hosted primary fails loudly instead of
+  # spending that native job on a daemon that would guess a pane.
+  if [ -z "${FM_SUPERVISOR_TARGET:-}" ] && [ -z "${FM_SUPERVISOR_BACKEND:-}" ] \
+      && fm_supervisor_gui_hosted; then
+    fm_afk_launch_log "refusing to start the away-mode daemon: firstmate looks GUI-hosted (Claude Desktop), which has no tmux/herdr pane to inject escalations into; keep the always-on watcher running instead of /afk"
     return 1
   fi
   if daemon_lock_held_by_live_daemon; then

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -1275,6 +1275,19 @@ fm_super_main() {
   echo "$$" > "$PIDFILE"
   fm_pid_identity "${BASHPID:-$$}" > "$LOCK/pid-identity" 2>/dev/null || true
 
+  # --- refuse loudly on a GUI-hosted primary instead of guessing a pane -----
+  # An explicit FM_SUPERVISOR_TARGET/FM_SUPERVISOR_BACKEND still wins (a
+  # captain or test harness that names a real pane knows better than this
+  # heuristic); only the auto-discover path is guarded.
+  if [ -z "${FM_SUPERVISOR_TARGET:-}" ] && [ -z "${FM_SUPERVISOR_BACKEND:-}" ] \
+      && fm_supervisor_gui_hosted; then
+    echo "error: firstmate looks GUI-hosted (Claude Desktop) - there is no tmux/herdr pane to inject escalations into, and guessing one risks silently misdirecting them; keep the always-on watcher running instead of the away-mode daemon (data/learnings.md), or set FM_SUPERVISOR_TARGET/FM_SUPERVISOR_BACKEND to override" >&2
+    log "startup failed: GUI-hosted primary detected, refusing to auto-discover a supervisor pane"
+    fm_lock_release "$LOCK" 2>/dev/null || true
+    rm -f "$PIDFILE" 2>/dev/null || true
+    exit 1
+  fi
+
   # --- auto-discover the supervisor BACKEND (tmux vs herdr) first -----------
   # Priority: FM_SUPERVISOR_BACKEND override > $TMUX_PANE (tmux) > $HERDR_ENV=1
   # (herdr) > tmux fallback. Resolved before the target below, since target

--- a/bin/fm-supervisor-target-lib.sh
+++ b/bin/fm-supervisor-target-lib.sh
@@ -52,6 +52,25 @@ discover_supervisor_target() {
   return 1
 }
 
+# fm_supervisor_gui_hosted: true when firstmate itself looks like a Claude
+# Desktop local-agent-mode session rather than a tmux/herdr pane. Such a
+# session has no pane for the daemon to inject into: discover_supervisor_target
+# would fall through to FM_SUPERVISOR_TARGET_DEFAULT ("firstmate:0"), which is
+# only a guess and can accidentally resolve against an unrelated tmux session
+# of the same name, silently misdirecting escalations instead of refusing
+# (data/learnings.md "afk daemon does NOT work when firstmate is GUI-hosted").
+# Verified empirically 2026-07-16, mirroring the cmux bundle-id check
+# (docs/cmux-backend.md "Detection"): a Claude Desktop-launched `claude`
+# process carries no $TMUX_PANE and no herdr markers, but does carry
+# __CFBundleIdentifier=com.anthropic.claudefordesktop (macOS sets this on
+# every process an app bundle launches). An explicit FM_SUPERVISOR_TARGET or
+# FM_SUPERVISOR_BACKEND override, or a real tmux/herdr pane, always wins.
+fm_supervisor_gui_hosted() {
+  [ -n "${TMUX_PANE:-}" ] && return 1
+  [ "${HERDR_ENV:-}" = "1" ] && [ -n "${HERDR_PANE_ID:-}" ] && return 1
+  [ "${__CFBundleIdentifier:-}" = "com.anthropic.claudefordesktop" ]
+}
+
 # discover_supervisor_backend: resolve the supervisor pane's BACKEND, independent
 # of the target string so an explicit FM_SUPERVISOR_TARGET override still knows
 # which primitives (tmux vs herdr) to dispatch through. Priority mirrors

--- a/tests/fm-afk-launch.test.sh
+++ b/tests/fm-afk-launch.test.sh
@@ -462,6 +462,40 @@ unit_native_entry_preserves_prepared_state() {
   rm -rf "$st"
 }
 
+unit_gui_hosted_refuses_start() {
+  local st out status
+  st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-gui-start.XXXXXX")
+  mkdir -p "$st/state"
+  out=$(TMUX_PANE='' HERDR_ENV='' HERDR_PANE_ID='' __CFBundleIdentifier=com.anthropic.claudefordesktop \
+    FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" FM_SUPERVISOR_TARGET='' FM_SUPERVISOR_BACKEND='' \
+    "$LAUNCH" start 2>&1)
+  status=$?
+  if [ "$status" -ne 0 ] && [ ! -e "$st/state/.afk" ] && [ ! -e "$st/state/.afk-daemon-terminal" ]; then
+    pass "start: refuses on a detected GUI-hosted primary, no state or terminal created"
+  else
+    fail "start: should refuse without creating state/a terminal on GUI-hosted detection (status=$status out=$out)"
+  fi
+  printf '%s' "$out" | grep -qi "GUI-hosted" || fail "start: refusal should name GUI-hosted primary: $out"
+  rm -rf "$st"
+}
+
+unit_gui_hosted_refuses_start_native() {
+  local st out status
+  st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-gui-native.XXXXXX")
+  mkdir -p "$st/state"
+  out=$(TMUX_PANE='' HERDR_ENV='' HERDR_PANE_ID='' __CFBundleIdentifier=com.anthropic.claudefordesktop \
+    FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" FM_SUPERVISOR_TARGET='' FM_SUPERVISOR_BACKEND='' \
+    "$LAUNCH" start-native 2>&1)
+  status=$?
+  if [ "$status" -ne 0 ] && [ ! -e "$st/state/.afk" ]; then
+    pass "start-native: refuses on a detected GUI-hosted primary, no lifecycle state created"
+  else
+    fail "start-native: should refuse without creating state on GUI-hosted detection (status=$status out=$out)"
+  fi
+  printf '%s' "$out" | grep -qi "GUI-hosted" || fail "start-native: refusal should name GUI-hosted primary: $out"
+  rm -rf "$st"
+}
+
 unit_close_failure_preserves_record() {
   local st
   st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-close-fail.XXXXXX")
@@ -877,6 +911,8 @@ unit_readiness_failure_preserves_unconfirmed_record
 unit_tmux_absence_distinguishes_probe_failure
 unit_native_lifecycle
 unit_native_entry_preserves_prepared_state
+unit_gui_hosted_refuses_start
+unit_gui_hosted_refuses_start_native
 unit_close_failure_preserves_record
 unit_record_publication_atomic
 unit_malformed_record_fails_closed

--- a/tests/fm-daemon.test.sh
+++ b/tests/fm-daemon.test.sh
@@ -1506,6 +1506,48 @@ test_discover_supervisor_target_herdr() {
   pass "discover_supervisor_target: override > TMUX_PANE > herdr '<session>:<pane-id>' composition > firstmate:0 fallback"
 }
 
+test_fm_supervisor_gui_hosted() {
+  if TMUX_PANE='' HERDR_ENV='' HERDR_PANE_ID='' __CFBundleIdentifier=com.anthropic.claudefordesktop fm_supervisor_gui_hosted; then
+    :
+  else
+    fail "no TMUX_PANE/HERDR + Claude Desktop bundle id should detect GUI hosting"
+  fi
+
+  if TMUX_PANE='%9' HERDR_ENV='' HERDR_PANE_ID='' __CFBundleIdentifier=com.anthropic.claudefordesktop fm_supervisor_gui_hosted; then
+    fail "TMUX_PANE set should win over the Claude Desktop bundle id"
+  fi
+
+  if TMUX_PANE='' HERDR_ENV=1 HERDR_PANE_ID=w1:p1 __CFBundleIdentifier=com.anthropic.claudefordesktop fm_supervisor_gui_hosted; then
+    fail "a herdr pane should win over the Claude Desktop bundle id"
+  fi
+
+  if TMUX_PANE='' HERDR_ENV='' HERDR_PANE_ID='' __CFBundleIdentifier='' fm_supervisor_gui_hosted; then
+    fail "no pane and no Claude Desktop bundle id should not detect GUI hosting (e.g. a bare non-tmux shell)"
+  fi
+
+  if TMUX_PANE='' HERDR_ENV='' HERDR_PANE_ID='' __CFBundleIdentifier=com.github.wez.wezterm fm_supervisor_gui_hosted; then
+    fail "an unrelated terminal-app bundle id should not detect GUI hosting"
+  fi
+
+  pass "fm_supervisor_gui_hosted: no tmux/herdr pane + Claude Desktop bundle id, and only that combination"
+}
+
+test_daemon_refuses_gui_hosted_primary() {
+  local dir state out status
+  dir=$(make_supercase daemon-refuses-gui-hosted)
+  state="$dir/state"
+  mkdir -p "$state"
+
+  out=$(TMUX_PANE='' HERDR_ENV='' HERDR_PANE_ID='' __CFBundleIdentifier=com.anthropic.claudefordesktop \
+    FM_STATE_OVERRIDE="$state" FM_SUPERVISOR_TARGET='' FM_SUPERVISOR_BACKEND='' "$DAEMON" 2>&1)
+  status=$?
+
+  [ "$status" -ne 0 ] || fail "daemon should refuse to start on a detected GUI-hosted primary"
+  printf '%s' "$out" | grep -qi "GUI-hosted" || fail "refusal should name GUI-hosted primary: $out"
+
+  pass "fm-supervise-daemon.sh: refuses to auto-discover a supervisor pane on a detected GUI-hosted primary"
+}
+
 test_pane_is_busy_herdr_native_busy_state() {
   (
     fm_backend_busy_state() { [ "$1" = herdr ] && [ "$2" = "default:w1:p2" ] || fail "unexpected busy_state args: $1 $2"; printf 'busy'; }
@@ -1738,6 +1780,8 @@ test_fm_send_exits_nonzero_on_confirmed_swallow
 test_fm_send_exits_nonzero_on_initial_send_failure
 test_discover_supervisor_backend_precedence
 test_discover_supervisor_target_herdr
+test_fm_supervisor_gui_hosted
+test_daemon_refuses_gui_hosted_primary
 test_pane_is_busy_herdr_native_busy_state
 test_pane_is_busy_herdr_falls_back_to_capture_regex
 test_pane_is_busy_herdr_idle_falls_back_to_capture_regex


### PR DESCRIPTION
## Summary
- The away-mode daemon injects escalations into a tmux/herdr pane; a Claude Desktop local-agent-mode primary has no such pane, and the prior fallback (guessing `firstmate:0`) could coincidentally resolve against an unrelated stale session and silently misdirect escalations instead of failing loudly.
- Add `fm_supervisor_gui_hosted` (`bin/fm-supervisor-target-lib.sh`): detects no tmux/herdr pane markers plus Claude Desktop's `__CFBundleIdentifier`, verified empirically against a live Claude Desktop-launched process.
- Wire a loud refusal into both `bin/fm-afk-launch.sh` entry points (`start`, `start-native`) and `bin/fm-supervise-daemon.sh`'s own auto-discovery, so the daemon never silently guesses a pane on a GUI-hosted primary. An explicit `FM_SUPERVISOR_TARGET`/`FM_SUPERVISOR_BACKEND` still overrides detection.
- Document the limitation in the `afk` skill and `AGENTS.md`.

## Test plan
- [x] `bin/fm-lint.sh` (shellcheck) - clean
- [x] `tests/fm-daemon.test.sh` - all pass, including new `fm_supervisor_gui_hosted` and daemon-startup-refusal cases
- [x] `tests/fm-afk-launch.test.sh` - all pass, including new `start`/`start-native` refusal cases
- Note: the no-mistakes pipeline is currently down fleet-wide (macOS TCC blocking the launchd daemon), so this was validated by running the relevant test files and lint directly rather than through `/no-mistakes`.