### PR TITLE
test: isolate Herdr autodetect smoke sessions

### DIFF
--- a/bin/fm-herdr-lab.sh
+++ b/bin/fm-herdr-lab.sh
@@ -167,7 +167,7 @@ fm_herdr_lab_cancel_provision() { # <pid>
 }
 
 fm_herdr_lab_provision() { # <session>
-  local name=$1 sessions tripwire running attempt server_pid
+  local name=$1 sessions tripwire running attempt server_pid max_attempts timeout_seconds
   fm_herdr_lab_validate_name "$name" || return 1
   command -v herdr >/dev/null 2>&1 || { fm_herdr_lab_error "herdr is required"; return 1; }
   command -v jq >/dev/null 2>&1 || { fm_herdr_lab_error "jq is required"; return 1; }
@@ -196,7 +196,9 @@ fm_herdr_lab_provision() { # <session>
   fm_herdr_lab_raw "$name" server >/dev/null 2>&1 &
   server_pid=$!
   attempt=0
-  while [ "$attempt" -lt 50 ]; do
+  max_attempts=300
+  timeout_seconds=60
+  while [ "$attempt" -lt "$max_attempts" ]; do
     running=$(fm_herdr_lab_cli "$name" status --json 2>/dev/null | jq -r '.server.running // false' 2>/dev/null) || running=false
     if [ "$running" = true ]; then
       fm_herdr_lab_refuse_if_default "$name" || {
@@ -209,7 +211,7 @@ fm_herdr_lab_provision() { # <session>
     attempt=$((attempt + 1))
   done
   fm_herdr_lab_cancel_provision "$server_pid"
-  fm_herdr_lab_error "lab session '$name' did not report running within 10 seconds"
+  fm_herdr_lab_error "lab session '$name' did not report running within $timeout_seconds seconds"
   return 1
 }
 
@@ -287,6 +289,9 @@ fm_herdr_lab_teardown() { # <session>
 fm_herdr_lab_name() { # <label>
   local label=${1:-lab}
   label=$(printf '%s' "$label" | tr -cd 'a-zA-Z0-9_-' | sed 's/^[^a-zA-Z0-9]*//; s/-*$//')
+  [ -n "$label" ] || label=lab
+  label=${label:0:16}
+  label=${label%-}
   [ -n "$label" ] || label=lab
   printf 'fm-lab-%s-%s-%s\n' "$label" "$$" "$RANDOM"
 }

--- a/bin/fm-herdr-lab.sh
+++ b/bin/fm-herdr-lab.sh
@@ -11,6 +11,8 @@
 #   fm-herdr-lab.sh teardown <session>
 #
 # Session names must begin with "fm-lab-" and can never be "default".
+# The name command sanitizes the label, caps it at 16 characters, and appends
+# process/random suffixes to keep generated socket paths short.
 # Every Herdr call made here carries a trailing --session <session>.
 # The run command rejects caller-supplied --session flags, any leading option
 # before the subcommand, all session lifecycle operations, and every server

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -5,7 +5,7 @@ It is the herdr equivalent of the tmux facts recorded in the `harness-adapters` 
 
 Herdr is [an agent-native terminal multiplexer](https://herdr.dev) with a socket API, CLI wrappers, and native per-pane agent-state detection.
 Originally verified against herdr 0.7.1, protocol 14, on macOS aarch64; the latest dated evidence below uses herdr 0.7.3, protocol 16.
-Current real-herdr verification uses isolated `HERDR_SESSION` names plus the guarded teardown helper in `tests/herdr-test-safety.sh`.
+Current real-herdr verification uses isolated named sessions plus the guarded `bin/fm-herdr-lab.sh` lifecycle helper, either directly or through the compatibility wrappers in `tests/herdr-test-safety.sh`.
 A 2026-07-02 cleanup bug proved that `HERDR_SESSION` alone is not a safe way to target destructive session cleanup; see "Session targeting: the `--session` flag, not `HERDR_SESSION` alone" below.
 All real-herdr verification in this document uses isolated sessions and guarded cleanup; the captain's default herdr session and live tmux fleet were never intended targets.
 

--- a/tests/fm-backend-autodetect-smoke.test.sh
+++ b/tests/fm-backend-autodetect-smoke.test.sh
@@ -8,9 +8,9 @@
 # directly), this suite drives the REAL bin/fm-spawn.sh and bin/fm-teardown.sh
 # end to end, because auto-detection is a fm-spawn-TIME decision, not an
 # adapter primitive - it has to be proven where fm_backend_name is actually
-# called. Mirrors fm-backend-herdr-smoke.test.sh's isolated-session convention:
-# a private, throwaway HERDR_SESSION, a scratch FM_HOME, and a scratch
-# local-only project, never the captain's real herdr usage or fleet state.
+# called. The real spawn runs in a helper-provisioned, per-run named Herdr lab
+# session, with a scratch FM_HOME and scratch local-only project. Concurrent
+# copies therefore never share the default session or a workspace namespace.
 #
 # The complementary "tmux nested inside herdr resolves to tmux, silently" case
 # is covered as a fast, deterministic fake-tmux fm-spawn.sh test in
@@ -20,16 +20,15 @@
 # manufacture; the selection LOGIC for that case is already exercised for real
 # by fm_backend_detect's own unit coverage plus that fake-tmux fm-spawn test.
 #
-# Safety (2026-07-02 incident, see tests/herdr-test-safety.sh): cleanup uses
-# ONLY herdr_safe_stop_and_delete, never a bare/inline-prefixed `herdr server
-# stop` - that command killed the captain's live default herdr server twice in
-# production because HERDR_SESSION-based targeting (env var OR inline prefix)
-# is not reliably honored once another herdr server is already running.
+# Safety (2026-07-02 incident): every test-owned Herdr operation goes through
+# bin/fm-herdr-lab.sh, which appends the named session flag and verifies the
+# default fleet session is unchanged after teardown. Never replace the helper
+# with an ambient HERDR_SESSION-only command.
 set -u
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-fail() { printf 'not ok - %s\n' "$1" >&2; cleanup_all; exit 1; }
+fail() { printf 'not ok - %s\n' "$1" >&2; exit 1; }
 pass() { printf 'ok - %s\n' "$1"; }
 assert_contains_local() {  # <haystack> <needle> <msg>
   case "$1" in
@@ -42,9 +41,6 @@ command -v herdr >/dev/null 2>&1 || { echo "skip: herdr not found"; exit 0; }
 command -v jq >/dev/null 2>&1 || { echo "skip: jq not found (required by the herdr adapter)"; exit 0; }
 command -v treehouse >/dev/null 2>&1 || { echo "skip: treehouse not found (required by fm-spawn.sh)"; exit 0; }
 
-# shellcheck source=tests/herdr-test-safety.sh
-. "$ROOT/tests/herdr-test-safety.sh"
-
 # TMP_ROOT is physically resolved (mktemp -d "$(pwd -P)"-relative) to keep this
 # real-herdr smoke fixture free of unrelated OS symlink noise.
 # The old fm-spawn bug that originally motivated this fixture shape was fixed in
@@ -53,17 +49,29 @@ command -v treehouse >/dev/null 2>&1 || { echo "skip: treehouse not found (requi
 # The dedicated regression is
 # tests/fm-backend.test.sh:test_spawn_symlinked_project_prefix_avoids_false_refusal.
 TMP_ROOT=$(mktemp -d "$(cd "${TMPDIR:-/tmp}" && pwd -P)/fm-backend-autodetect-smoke.XXXXXX")
-SESSION="fm-lab-autodetect-smoke-$$"
-export HERDR_SESSION="$SESSION"
+HERDR_LAB_HELPER="$ROOT/bin/fm-herdr-lab.sh"
+HERDR_LAB_SESSION=$("$HERDR_LAB_HELPER" name fm-autodetect-smoke-concurrency-h3) || {
+  rm -rf "$TMP_ROOT"
+  fail "could not generate an isolated Herdr lab session name"
+}
+export HERDR_SESSION="$HERDR_LAB_SESSION"
 ID="autodetectsmoke1"
 WT=
 cleanup_all() {
+  local cleanup_status=0
   [ -n "$WT" ] && command -v treehouse >/dev/null 2>&1 && treehouse return --force "$WT" >/dev/null 2>&1
-  herdr_safe_stop_and_delete "$SESSION"
+  "$HERDR_LAB_HELPER" teardown "$HERDR_LAB_SESSION" || cleanup_status=$?
   rm -rf "$TMP_ROOT"
+  return "$cleanup_status"
 }
-trap cleanup_all EXIT
-fm_herdr_lab_prepare "$SESSION" || fail "could not prepare isolated Herdr lab session"
+on_exit() {
+  local status=$?
+  cleanup_all || status=$?
+  trap - EXIT
+  exit "$status"
+}
+trap on_exit EXIT
+"$HERDR_LAB_HELPER" provision "$HERDR_LAB_SESSION" || fail "could not provision isolated Herdr lab session"
 
 # --- scratch world: FM_HOME with NO backend config, one throwaway project ---
 
@@ -100,9 +108,14 @@ META="$STATE/$ID.meta"
 [ -f "$META" ] || fail "fm-spawn.sh did not write a meta file for $ID"
 assert_contains_local "$(cat "$META")" "backend=herdr" \
   "auto-detected spawn did not record backend=herdr in meta"
-assert_contains_local "$(cat "$META")" "herdr_session=$SESSION" \
+assert_contains_local "$(cat "$META")" "herdr_session=$HERDR_LAB_SESSION" \
   "auto-detected spawn did not record the isolated herdr_session in meta"
-pass "real herdr: auto-detected spawn records backend=herdr and herdr_session/workspace/tab/pane fields in meta"
+
+WORKSPACE=$(grep '^herdr_workspace_id=' "$META" | cut -d= -f2-)
+[ -n "$WORKSPACE" ] || fail "auto-detected spawn meta is missing herdr_workspace_id"
+
+TAB=$(grep '^herdr_tab_id=' "$META" | cut -d= -f2-)
+[ -n "$TAB" ] || fail "auto-detected spawn meta is missing herdr_tab_id"
 
 WT=$(grep '^worktree=' "$META" | cut -d= -f2-)
 if [ -z "$WT" ] || [ ! -d "$WT" ]; then
@@ -111,14 +124,14 @@ fi
 
 PANE=$(grep '^herdr_pane_id=' "$META" | cut -d= -f2-)
 [ -n "$PANE" ] || fail "auto-detected spawn meta is missing herdr_pane_id"
+pass "real herdr: auto-detected spawn records backend=herdr and herdr_session/workspace/tab/pane fields in meta"
 
 # --- confirm the trivial launch command actually ran in the herdr pane ------
 
-# shellcheck source=bin/fm-backend.sh
-. "$ROOT/bin/fm-backend.sh"
-fm_backend_source herdr || fail "fm_backend_source herdr failed"
 sleep 1
-CAPTURED=$(fm_backend_herdr_capture "$SESSION:$PANE" 30) || fail "capture failed on the auto-detected herdr pane"
+CAPTURED=$("$HERDR_LAB_HELPER" run "$HERDR_LAB_SESSION" pane read "$PANE" --source recent --lines 200) || \
+  fail "capture failed on the auto-detected herdr pane"
+CAPTURED=$(printf '%s\n' "$CAPTURED" | tail -n 30)
 case "$CAPTURED" in
   *autodetect-smoke-ok*) : ;;
   *) fail "the raw launch command did not run in the auto-detected herdr pane"$'\n'"$CAPTURED" ;;
@@ -134,11 +147,15 @@ FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$STATE" FM_DATA_OVERRIDE="$DATA" \
 status=$?
 [ "$status" -eq 0 ] || fail "fm-teardown.sh failed for the auto-detected herdr task"$'\n'"$(cat "$TEARDOWN_OUT")"
 [ -f "$META" ] && fail "fm-teardown.sh did not remove $META"
-if herdr pane get "$PANE" --session "$SESSION" >/dev/null 2>&1; then
+if "$HERDR_LAB_HELPER" run "$HERDR_LAB_SESSION" pane get "$PANE" >/dev/null 2>&1; then
   fail "fm-teardown.sh did not close the auto-detected herdr pane"
 fi
 WT=
 pass "real herdr: teardown completes the auto-detected spawn/teardown cycle (meta cleared, pane closed)"
 
-cleanup_all
+if ! cleanup_all; then
+  trap - EXIT
+  fail "isolated Herdr lab teardown failed or the default fleet session changed"
+fi
 trap - EXIT
+pass "real herdr: isolated lab session removed and default fleet session unchanged"

--- a/tests/fm-backend-autodetect-smoke.test.sh
+++ b/tests/fm-backend-autodetect-smoke.test.sh
@@ -41,6 +41,8 @@ command -v herdr >/dev/null 2>&1 || { echo "skip: herdr not found"; exit 0; }
 command -v jq >/dev/null 2>&1 || { echo "skip: jq not found (required by the herdr adapter)"; exit 0; }
 command -v treehouse >/dev/null 2>&1 || { echo "skip: treehouse not found (required by fm-spawn.sh)"; exit 0; }
 
+export FM_GATE_REFUSE_BYPASS=1
+
 # TMP_ROOT is physically resolved (mktemp -d "$(pwd -P)"-relative) to keep this
 # real-herdr smoke fixture free of unrelated OS symlink noise.
 # The old fm-spawn bug that originally motivated this fixture shape was fixed in

--- a/tests/fm-herdr-lab.test.sh
+++ b/tests/fm-herdr-lab.test.sh
@@ -87,13 +87,16 @@ run_with_fake() {
 }
 
 test_refuses_unsafe_names() {
-  local status=0
+  local status=0 generated
   fm_herdr_lab_validate_name default >/dev/null 2>&1 || status=$?
   expect_code 1 "$status" "literal default must be refused"
   status=0
   fm_herdr_lab_validate_name arbitrary-session >/dev/null 2>&1 || status=$?
   expect_code 1 "$status" "non-lab prefix must be refused"
   fm_herdr_lab_validate_name fm-lab-safe-123 || fail "valid lab session name was refused"
+  generated=$(fm_herdr_lab_name fm-autodetect-smoke-concurrency-h3)
+  fm_herdr_lab_validate_name "$generated" || fail "generated lab session name was refused"
+  [ "${#generated}" -le 40 ] || fail "generated lab session name is too long for Herdr socket paths: $generated"
   pass "fm-herdr-lab: names fail closed and require the lab prefix"
 }
 


### PR DESCRIPTION
## Intent

Make tests/fm-backend-autodetect-smoke.test.sh robust to concurrent crew load by running the genuine real-Herdr auto-detection spawn and teardown cycle in an isolated per-run named non-default Herdr lab session through bin/fm-herdr-lab.sh, without serializing concurrent suites. Preserve the existing coverage: fm-spawn must auto-select Herdr solely from HERDR_ENV=1 with no explicit backend, record backend=herdr and all Herdr session, workspace, tab, and pane metadata, execute the launch command in the real Herdr pane, and complete teardown. Every test-orchestrated Herdr command must use the lab helper with explicit named-session routing, every exit path must clean up, and helper teardown must verify the captain fleet's default session is unchanged. Keep the change scoped to test isolation, shellcheck-clean, and bin/fm-lint.sh green.

## What Changed
- Isolated the real Herdr autodetect smoke test in a helper-provisioned, per-run named non-default lab session, with all test-owned Herdr reads and pane checks routed through `bin/fm-herdr-lab.sh`.
- Preserved the end-to-end coverage that `HERDR_ENV=1` alone selects Herdr, records backend/session/workspace/tab/pane metadata, runs the launch command in the real pane, and completes teardown.
- Hardened Herdr lab provisioning with shorter generated session names, a longer startup wait, default-session teardown verification, and refreshed docs/tests for the lab helper path.

## Risk Assessment

✅ Low: The updated change is confined to one real-Herdr smoke test, restores the gate-refusal bypass, and routes test-owned Herdr operations through the existing lab helper while preserving the required spawn, metadata, pane execution, and teardown coverage.

## Testing

The configured full-suite baseline had already passed; I then exercised the changed helper and the real Herdr autodetect spawn/teardown path under 4 concurrent copies, confirming HERDR_ENV-only autodetection, Herdr metadata, real pane command execution, teardown, default-session invariance, and no leftover lab sessions. I did not run linters or static analysis because this testing prompt explicitly forbids them.

<details>
<summary>Evidence: fm-herdr-lab helper regression</summary>

```text
ok - fm-herdr-lab: names fail closed and require the lab prefix
ok - fm-herdr-lab: provisioning, scoped calls, guarded teardown, and fleet tripwire are deterministic
ok - fm-herdr-lab: missing tripwire refuses teardown before any Herdr call
ok - fm-herdr-lab: changed default fleet state is a hard failure
ok - fm-herdr-lab: an owned stopped lab can re-provision safely
ok - fm-herdr-lab: failed deletion retains ownership until absence is confirmed
ok - fm-herdr-lab: timed-out provisioning cancels the launch before teardown
```
</details>
<details>
<summary>Evidence: 4-way concurrent real Herdr autodetect smoke transcript</summary>

```text
default-session-before=[{"name":"default","default":true,"running":true,"socket_path":"/Users/kunchen/.config/herdr/herdr.sock"}]
concurrent-copy-1=pass
[copy 1] ok - real herdr: fm-spawn.sh auto-detects herdr from HERDR_ENV=1 (no explicit config) and prints the loud notice
[copy 1] ok - real herdr: auto-detected spawn records backend=herdr and herdr_session/workspace/tab/pane fields in meta
[copy 1] ok - real herdr: the auto-detected spawn's launch command actually ran in the herdr pane
[copy 1] ok - real herdr: teardown completes the auto-detected spawn/teardown cycle (meta cleared, pane closed)
[copy 1] ok - real herdr: isolated lab session removed and default fleet session unchanged
concurrent-copy-2=pass
[copy 2] ok - real herdr: fm-spawn.sh auto-detects herdr from HERDR_ENV=1 (no explicit config) and prints the loud notice
[copy 2] ok - real herdr: auto-detected spawn records backend=herdr and herdr_session/workspace/tab/pane fields in meta
[copy 2] ok - real herdr: the auto-detected spawn's launch command actually ran in the herdr pane
[copy 2] ok - real herdr: teardown completes the auto-detected spawn/teardown cycle (meta cleared, pane closed)
[copy 2] ok - real herdr: isolated lab session removed and default fleet session unchanged
concurrent-copy-3=pass
[copy 3] ok - real herdr: fm-spawn.sh auto-detects herdr from HERDR_ENV=1 (no explicit config) and prints the loud notice
[copy 3] ok - real herdr: auto-detected spawn records backend=herdr and herdr_session/workspace/tab/pane fields in meta
[copy 3] ok - real herdr: the auto-detected spawn's launch command actually ran in the herdr pane
[copy 3] ok - real herdr: teardown completes the auto-detected spawn/teardown cycle (meta cleared, pane closed)
[copy 3] ok - real herdr: isolated lab session removed and default fleet session unchanged
concurrent-copy-4=pass
[copy 4] ok - real herdr: fm-spawn.sh auto-detects herdr from HERDR_ENV=1 (no explicit config) and prints the loud notice
[copy 4] ok - real herdr: auto-detected spawn records backend=herdr and herdr_session/workspace/tab/pane fields in meta
[copy 4] ok - real herdr: the auto-detected spawn's launch command actually ran in the herdr pane
[copy 4] ok - real herdr: teardown completes the auto-detected spawn/teardown cycle (meta cleared, pane closed)
[copy 4] ok - real herdr: isolated lab session removed and default fleet session unchanged
default-session-after=[{"name":"default","default":true,"running":true,"socket_path":"/Users/kunchen/.config/herdr/herdr.sock"}]
default-session-unchanged
```
</details>
<details>
<summary>Evidence: concurrent autodetect copy 1</summary>

```text
ok - real herdr: fm-spawn.sh auto-detects herdr from HERDR_ENV=1 (no explicit config) and prints the loud notice
ok - real herdr: auto-detected spawn records backend=herdr and herdr_session/workspace/tab/pane fields in meta
ok - real herdr: the auto-detected spawn's launch command actually ran in the herdr pane
ok - real herdr: teardown completes the auto-detected spawn/teardown cycle (meta cleared, pane closed)
ok - real herdr: isolated lab session removed and default fleet session unchanged
```
</details>
<details>
<summary>Evidence: concurrent autodetect copy 2</summary>

```text
ok - real herdr: fm-spawn.sh auto-detects herdr from HERDR_ENV=1 (no explicit config) and prints the loud notice
ok - real herdr: auto-detected spawn records backend=herdr and herdr_session/workspace/tab/pane fields in meta
ok - real herdr: the auto-detected spawn's launch command actually ran in the herdr pane
ok - real herdr: teardown completes the auto-detected spawn/teardown cycle (meta cleared, pane closed)
ok - real herdr: isolated lab session removed and default fleet session unchanged
```
</details>
<details>
<summary>Evidence: concurrent autodetect copy 3</summary>

```text
ok - real herdr: fm-spawn.sh auto-detects herdr from HERDR_ENV=1 (no explicit config) and prints the loud notice
ok - real herdr: auto-detected spawn records backend=herdr and herdr_session/workspace/tab/pane fields in meta
ok - real herdr: the auto-detected spawn's launch command actually ran in the herdr pane
ok - real herdr: teardown completes the auto-detected spawn/teardown cycle (meta cleared, pane closed)
ok - real herdr: isolated lab session removed and default fleet session unchanged
```
</details>
<details>
<summary>Evidence: concurrent autodetect copy 4</summary>

```text
ok - real herdr: fm-spawn.sh auto-detects herdr from HERDR_ENV=1 (no explicit config) and prints the loud notice
ok - real herdr: auto-detected spawn records backend=herdr and herdr_session/workspace/tab/pane fields in meta
ok - real herdr: the auto-detected spawn's launch command actually ran in the herdr pane
ok - real herdr: teardown completes the auto-detected spawn/teardown cycle (meta cleared, pane closed)
ok - real herdr: isolated lab session removed and default fleet session unchanged
```
</details>
<details>
<summary>Evidence: default Herdr session before concurrent smoke</summary>

`[{"name":"default","default":true,"running":true,"socket_path":"/Users/kunchen/.config/herdr/herdr.sock"}]`

```text
[{"name":"default","default":true,"running":true,"socket_path":"/Users/kunchen/.config/herdr/herdr.sock"}]
```
</details>
<details>
<summary>Evidence: default Herdr session after concurrent smoke</summary>

`[{"name":"default","default":true,"running":true,"socket_path":"/Users/kunchen/.config/herdr/herdr.sock"}]`

```text
[{"name":"default","default":true,"running":true,"socket_path":"/Users/kunchen/.config/herdr/herdr.sock"}]
```
</details>
- Outcome: 🔧 1 issue found → auto-fixed ✅ across 2 runs (51m22s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `tests/fm-backend-autodetect-smoke.test.sh:92` - Removing the `tests/herdr-test-safety.sh` source also removed its `FM_GATE_REFUSE_BYPASS=1` export, but this test still invokes `bin/fm-spawn.sh` and later `bin/fm-teardown.sh`; both call `fm_refuse_if_gate_agent` and exit from a no-mistakes gate worktree or when `NO_MISTAKES_GATE` is set. In the gate environment this fails before the required real Herdr autodetect spawn/teardown cycle, so add the bypass back before these lifecycle calls or pass it explicitly in their env.

🔧 Fix: Restored autodetect smoke gate bypass
✅ Re-checked - no issues remain.

</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed ✅</summary>

- 🚨 tests failed with exit code 1
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`

🔧 Fix: Harden Herdr lab provisioning
✅ Re-checked - no issues remain.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- <code>Baseline already completed before this round: `command -v tmux &gt;/dev/null || { echo &#34;tmux is required for e2e tests&#34; &gt;&amp;2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo &#34;== $t ==&#34;; bash &#34;$t&#34; || rc=1; done; exit &#34;$rc&#34;`.</code>
- <code>Verified prerequisites with `command -v herdr; command -v jq; command -v treehouse; command -v tmux; tmux -V`.</code>
- <code>`bash tests/fm-herdr-lab.test.sh | tee /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KXPWH10BARDP2RJ5HSDXNWAV/fm-herdr-lab-test.log`.</code>
- <code>Ran 4 concurrent copies of `bash tests/fm-backend-autodetect-smoke.test.sh`, captured per-copy logs, and compared `herdr session list --json --session default` snapshots before and after in `/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KXPWH10BARDP2RJ5HSDXNWAV/concurrent-autodetect-smoke.log`.</code>
- <code>Final cleanup checks: `git status --short` was clean, and `herdr session list --json --session default | jq -c &#39;[.sessions[]? | select(.name | startswith(&#34;fm-lab-fm-autodetect&#34;) or startswith(&#34;fm-lab-autodetect&#34;) or startswith(&#34;fm-lab-behavior&#34;) or startswith(&#34;fm-lab-tripwire&#34;) or startswith(&#34;fm-lab-reprovision&#34;) or startswith(&#34;fm-lab-delete-fail&#34;) or startswith(&#34;fm-lab-timeout&#34;)) | {name, running, default}]&#39;` returned `[]`.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
