### PR TITLE
fix(bin): prevent Codex visual workspace leaks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,9 +142,8 @@ A lock-refused session must not spawn, steer, merge, drain the wake queue, repai
 Bootstrap detects first, asks for consent, and installs only after the captain approves in the current session.
 Do not dispatch until the required tools are present and GitHub authentication is good.
 Use `gh-axi` for GitHub, `chrome-devtools-axi` for browser work, and `lavish-axi` for structured decisions or reports; consult current help rather than memorizing flags.
-Use `bin/fm-visual-guard.sh` for every Codex-owned GUI, browser, app-launcher, and screenshot action so windows land on the hidden `CODEX-HEADLESS` workspace 99 instead of a visible workspace.
-Prefer `bin/fm-visual-guard.sh browser <url>`, `bin/fm-visual-guard.sh exec -- <command ...>`, `bin/fm-visual-guard.sh screenshot <path>`, `bin/fm-visual-guard.sh clients`, and `bin/fm-visual-guard.sh doctor` over plain launchers, legacy dotfiles browser wrappers, or manual Hyprland dispatches.
-The guard also passes hidden-workspace environment to legacy wrappers and Chrome DevTools launches, then checks for dedicated Codex visual clients on visible workspaces and moves those identified clients back to workspace 99.
+Use `bin/fm-visual-guard.sh` for every Codex-owned GUI, browser, app-launcher, and screenshot action.
+Read its header and `--help` for the authoritative commands and hidden-placement/remediation mechanics.
 A silent bootstrap section needs no action; for any printed actionable diagnostic line, load `bootstrap-diagnostics` and follow its owner procedure.
 `BOOTSTRAP_INFO:` lines are completed no-action facts and do not require loading a skill.
 `secondmate-provisioning` owns startup secondmate sync, liveness, and inherited local-material convergence.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,6 +142,9 @@ A lock-refused session must not spawn, steer, merge, drain the wake queue, repai
 Bootstrap detects first, asks for consent, and installs only after the captain approves in the current session.
 Do not dispatch until the required tools are present and GitHub authentication is good.
 Use `gh-axi` for GitHub, `chrome-devtools-axi` for browser work, and `lavish-axi` for structured decisions or reports; consult current help rather than memorizing flags.
+Use `bin/fm-visual-guard.sh` for every Codex-owned GUI, browser, app-launcher, and screenshot action so windows land on the hidden `CODEX-HEADLESS` workspace 99 instead of a visible workspace.
+Prefer `bin/fm-visual-guard.sh browser <url>`, `bin/fm-visual-guard.sh exec -- <command ...>`, `bin/fm-visual-guard.sh screenshot <path>`, `bin/fm-visual-guard.sh clients`, and `bin/fm-visual-guard.sh doctor` over plain launchers, legacy dotfiles browser wrappers, or manual Hyprland dispatches.
+The guard also passes hidden-workspace environment to legacy wrappers and Chrome DevTools launches, then checks for dedicated Codex visual clients on visible workspaces and moves those identified clients back to workspace 99.
 A silent bootstrap section needs no action; for any printed actionable diagnostic line, load `bootstrap-diagnostics` and follow its owner procedure.
 `BOOTSTRAP_INFO:` lines are completed no-action facts and do not require loading a skill.
 `secondmate-provisioning` owns startup secondmate sync, liveness, and inherited local-material convergence.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,7 +142,7 @@ A lock-refused session must not spawn, steer, merge, drain the wake queue, repai
 Bootstrap detects first, asks for consent, and installs only after the captain approves in the current session.
 Do not dispatch until the required tools are present and GitHub authentication is good.
 Use `gh-axi` for GitHub, `chrome-devtools-axi` for browser work, and `lavish-axi` for structured decisions or reports; consult current help rather than memorizing flags.
-Use `bin/fm-visual-guard.sh` for every Codex-owned GUI, browser, app-launcher, and screenshot action.
+On Hyprland hosts where `hyprctl` is available and `CODEX-HEADLESS` is the visual target, use `bin/fm-visual-guard.sh` for every Codex-owned GUI, browser, app-launcher, and screenshot action.
 Read its header and `--help` for the authoritative commands and hidden-placement/remediation mechanics.
 A silent bootstrap section needs no action; for any printed actionable diagnostic line, load `bootstrap-diagnostics` and follow its owner procedure.
 `BOOTSTRAP_INFO:` lines are completed no-action facts and do not require loading a skill.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -240,7 +240,8 @@ The report is the only thing that survives, so anything worth keeping must be in
 1. Never push to any remote and never open a PR.
 2. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
 3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
-4. Use \`$FM_ROOT/bin/fm-visual-guard.sh\` for every GUI, browser, app-launcher, and screenshot action.
+4. This visual-guard requirement applies on Hyprland hosts where \`hyprctl\` is available and \`CODEX-HEADLESS\` is the visual target.
+   Use \`$FM_ROOT/bin/fm-visual-guard.sh\` for every GUI, browser, app-launcher, and screenshot action.
    Read its header and \`--help\` for the authoritative commands and hidden-placement/remediation mechanics; do not use plain launchers, normal Chrome, legacy Codex visual wrappers, or manual Hyprland dispatches.
 5. Report status by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`
@@ -349,7 +350,8 @@ If the top-level path is the primary checkout or not the worktree you were launc
 $RULE1
 2. Stay inside this worktree; modify nothing outside it.
 3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
-4. Use \`$FM_ROOT/bin/fm-visual-guard.sh\` for every GUI, browser, app-launcher, and screenshot action.
+4. This visual-guard requirement applies on Hyprland hosts where \`hyprctl\` is available and \`CODEX-HEADLESS\` is the visual target.
+   Use \`$FM_ROOT/bin/fm-visual-guard.sh\` for every GUI, browser, app-launcher, and screenshot action.
    Read its header and \`--help\` for the authoritative commands and hidden-placement/remediation mechanics; do not use plain launchers, normal Chrome, legacy Codex visual wrappers, or manual Hyprland dispatches.
 5. Report status by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -240,7 +240,9 @@ The report is the only thing that survives, so anything worth keeping must be in
 1. Never push to any remote and never open a PR.
 2. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
 3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
-4. Report status by appending one line:
+4. Use \`$FM_ROOT/bin/fm-visual-guard.sh\` for every GUI, browser, app-launcher, and screenshot action.
+   Prefer \`browser <url>\`, \`exec -- <command ...>\`, \`screenshot <path>\`, \`clients\`, and \`doctor\` over plain launchers, normal Chrome, legacy Codex visual wrappers, or manual Hyprland dispatches.
+5. Report status by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`
    States: working, needs-decision, blocked, $PAUSED_VERB, done, failed.
    Each append wakes firstmate, so report sparingly: only phase changes a supervisor
@@ -250,11 +252,11 @@ The report is the only thing that survives, so anything worth keeping must be in
    known external wait you expect to clear on its own (an upstream release, a rate-limit reset):
    firstmate then leaves your idle pane alone and rechecks it on a long cadence instead of
    treating it as a possible wedge. Use \`blocked:\` when you are stuck and need help.
-5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
-6. If a decision belongs to a human (product choices, destructive actions),
+6. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
+7. If a decision belongs to a human (product choices, destructive actions),
    append \`needs-decision: {summary of options}\` and stop. Firstmate will reply with the decision.
    When firstmate replies or a blocker clears and you resume, append \`resolved: {how it was decided or unblocked}\` (add the same \`[key=<slug>]\` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
-7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
+8. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
 
@@ -347,7 +349,9 @@ If the top-level path is the primary checkout or not the worktree you were launc
 $RULE1
 2. Stay inside this worktree; modify nothing outside it.
 3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
-4. Report status by appending one line:
+4. Use \`$FM_ROOT/bin/fm-visual-guard.sh\` for every GUI, browser, app-launcher, and screenshot action.
+   Prefer \`browser <url>\`, \`exec -- <command ...>\`, \`screenshot <path>\`, \`clients\`, and \`doctor\` over plain launchers, normal Chrome, legacy Codex visual wrappers, or manual Hyprland dispatches.
+5. Report status by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`
    States: working, needs-decision, blocked, $PAUSED_VERB, done, failed.
    Each append wakes firstmate, so report sparingly: only phase changes a supervisor
@@ -358,11 +362,11 @@ $RULE1
    known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
    a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
    cadence instead of treating it as a possible wedge. Use \`blocked:\` when you are stuck and need help.
-5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
-6. If a decision belongs to a human (product choices, destructive actions, ask-user findings),
+6. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
+7. If a decision belongs to a human (product choices, destructive actions, ask-user findings),
    append \`needs-decision: {summary of options}\` and stop. Firstmate will reply with the decision.
    When firstmate replies or a blocker clears and you resume, append \`resolved: {how it was decided or unblocked}\` (add the same \`[key=<slug>]\` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
-7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
+8. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -241,7 +241,7 @@ The report is the only thing that survives, so anything worth keeping must be in
 2. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
 3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
 4. Use \`$FM_ROOT/bin/fm-visual-guard.sh\` for every GUI, browser, app-launcher, and screenshot action.
-   Prefer \`browser <url>\`, \`exec -- <command ...>\`, \`screenshot <path>\`, \`clients\`, and \`doctor\` over plain launchers, normal Chrome, legacy Codex visual wrappers, or manual Hyprland dispatches.
+   Read its header and \`--help\` for the authoritative commands and hidden-placement/remediation mechanics; do not use plain launchers, normal Chrome, legacy Codex visual wrappers, or manual Hyprland dispatches.
 5. Report status by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`
    States: working, needs-decision, blocked, $PAUSED_VERB, done, failed.
@@ -350,7 +350,7 @@ $RULE1
 2. Stay inside this worktree; modify nothing outside it.
 3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
 4. Use \`$FM_ROOT/bin/fm-visual-guard.sh\` for every GUI, browser, app-launcher, and screenshot action.
-   Prefer \`browser <url>\`, \`exec -- <command ...>\`, \`screenshot <path>\`, \`clients\`, and \`doctor\` over plain launchers, normal Chrome, legacy Codex visual wrappers, or manual Hyprland dispatches.
+   Read its header and \`--help\` for the authoritative commands and hidden-placement/remediation mechanics; do not use plain launchers, normal Chrome, legacy Codex visual wrappers, or manual Hyprland dispatches.
 5. Report status by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`
    States: working, needs-decision, blocked, $PAUSED_VERB, done, failed.

--- a/bin/fm-visual-guard.sh
+++ b/bin/fm-visual-guard.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # Deterministic Codex GUI guard for Firstmate.
 #
-# Use this instead of plain GUI launchers, raw browser commands, or ad hoc
-# Hyprland dispatches when Codex/crewmates need a visual surface.
+# On Hyprland hosts where hyprctl is available and CODEX-HEADLESS is the visual
+# target, use this instead of plain GUI launchers, raw browser commands, or ad
+# hoc Hyprland dispatches when Codex/crewmates need a visual surface.
 # It dispatches windows to workspace 99 on the hidden CODEX-HEADLESS output and
 # keeps CODEX_GUI_GUARD=1 in the launched process environment so local wrappers
 # can recognize Firstmate-owned GUI work.
@@ -44,6 +45,9 @@ Usage:
   $(basename "$0") screenshot <path>
   $(basename "$0") clients
   $(basename "$0") doctor
+
+Scope:
+  Hyprland/CODEX-HEADLESS visual workflows where hyprctl is available
 
 Environment:
   FM_VISUAL_OUTPUT       output name, default CODEX-HEADLESS

--- a/bin/fm-visual-guard.sh
+++ b/bin/fm-visual-guard.sh
@@ -270,10 +270,10 @@ cmdline_matches_visual_profile() {
 
 client_rows() {
   local clients monitors
-  clients=$(hyprland_json clients)
-  monitors=$(hyprland_json monitors)
+  clients=$(hyprland_json clients) || return 1
+  monitors=$(hyprland_json monitors) || return 1
   # shellcheck disable=SC2016
-  printf '%s\n' "$clients" | jq_call -r --argjson monitors "$monitors" '
+  jq_call -r --argjson monitors "$monitors" '
     .[] as $client
     | (($client.monitor // "") | tostring) as $monitor
     | (($monitors | map(select(((.id? // "") | tostring) == $monitor) | .name) | first) // $monitor) as $monitor_name
@@ -289,12 +289,13 @@ client_rows() {
       ]
     | @tsv
     | gsub("\t"; "\u001f")
-  '
+  ' <<< "$clients"
 }
 
 visual_client_rows() {
-  local address pid class initial title workspace_id workspace_name monitor cmdline
-  client_rows | while IFS="$RECORD_SEPARATOR" read -r address pid class initial title workspace_id workspace_name monitor; do
+  local rows address pid class initial title workspace_id workspace_name monitor cmdline
+  rows=$(client_rows) || return 1
+  while IFS="$RECORD_SEPARATOR" read -r address pid class initial title workspace_id workspace_name monitor; do
     [ -n "$address" ] || continue
     cmdline=$(client_cmdline "$pid")
     if class_matches_visual_identity "$class" "$initial" || cmdline_matches_visual_profile "$cmdline"; then
@@ -302,15 +303,16 @@ visual_client_rows() {
         "$address" "$RECORD_SEPARATOR" "$pid" "$RECORD_SEPARATOR" "${class:-$initial}" "$RECORD_SEPARATOR" \
         "$title" "$RECORD_SEPARATOR" "$workspace_id" "$RECORD_SEPARATOR" "$workspace_name" "$RECORD_SEPARATOR" "$monitor"
     fi
-  done
+  done <<< "$rows"
 }
 
 visual_client_addresses() {
-  local address pid class title workspace_id workspace_name monitor
-  visual_client_rows | while IFS="$RECORD_SEPARATOR" read -r address pid class title workspace_id workspace_name monitor; do
+  local rows address pid class title workspace_id workspace_name monitor
+  rows=$(visual_client_rows) || return 1
+  while IFS="$RECORD_SEPARATOR" read -r address pid class title workspace_id workspace_name monitor; do
     [ -n "$address" ] || continue
     printf '%s\n' "$address"
-  done
+  done <<< "$rows"
 }
 
 client_address_in_set() {
@@ -333,7 +335,7 @@ visual_client_status() {
   local preexisting=${1:-} misplaced=0 new_count=0 new_client_set=""
   local address pid class title workspace_id workspace_name monitor rows
   local -a new_addresses=()
-  rows=$(visual_client_rows)
+  rows=$(visual_client_rows) || return 1
   if [ -n "$rows" ]; then
     while IFS="$RECORD_SEPARATOR" read -r address pid class title workspace_id workspace_name monitor; do
       [ -n "$address" ] || continue
@@ -356,7 +358,7 @@ EOF
 
 remediate_misplaced_visual_clients() {
   local rows address pid class title workspace_id workspace_name monitor moved=0
-  rows=$(visual_client_rows)
+  rows=$(visual_client_rows) || return 1
   while IFS="$RECORD_SEPARATOR" read -r address pid class title workspace_id workspace_name monitor; do
     [ -n "$address" ] || continue
     visual_client_is_hidden "$workspace_id" "$workspace_name" "$monitor" && continue
@@ -375,8 +377,10 @@ verify_visual_placement() {
   local preexisting=${1:-} remaining=$VERIFY_ATTEMPTS status misplaced new_count client_set remediated
   local stable_polls=0 saw_new_client=0 settling_client_set=""
   while [ "$remaining" -gt 0 ]; do
-    remediated=$(remediate_misplaced_visual_clients)
-    status=$(visual_client_status "$preexisting")
+    remediated=$(remediate_misplaced_visual_clients) \
+      || die "failed to query Codex visual clients during placement remediation"
+    status=$(visual_client_status "$preexisting") \
+      || die "failed to query Codex visual clients during placement verification"
     IFS="$RECORD_SEPARATOR" read -r misplaced new_count client_set <<EOF
 $status
 EOF
@@ -397,7 +401,8 @@ EOF
     sleep "$VERIFY_SLEEP"
     remaining=$((remaining - 1))
   done
-  status=$(visual_client_status "$preexisting")
+  status=$(visual_client_status "$preexisting") \
+    || die "failed to query Codex visual clients during final placement verification"
   IFS="$RECORD_SEPARATOR" read -r misplaced new_count client_set <<EOF
 $status
 EOF
@@ -414,7 +419,7 @@ guard_exec() {
   [ "$#" -gt 0 ] || die "exec requires a command after --"
 
   ensure_visual_target 1
-  preexisting=$(visual_client_addresses)
+  preexisting=$(visual_client_addresses) || die "failed to query existing Codex visual clients"
   command_string=$(join_shell_words "$@")
   env_assignments=$(guard_env_assignments)
   dispatch_string="[workspace $VISUAL_WORKSPACE silent] env $env_assignments $command_string"
@@ -476,9 +481,10 @@ guard_screenshot() {
 }
 
 guard_clients() {
-  local rows address pid class initial title workspace_id workspace_name monitor cmdline
+  local rows filtered_rows address pid class initial title workspace_id workspace_name monitor cmdline
   require_hyprland
-  rows=$(client_rows | while IFS="$RECORD_SEPARATOR" read -r address pid class initial title workspace_id workspace_name monitor; do
+  rows=$(client_rows) || die "failed to query Codex visual clients"
+  filtered_rows=$(while IFS="$RECORD_SEPARATOR" read -r address pid class initial title workspace_id workspace_name monitor; do
     [ -n "$address" ] || continue
     cmdline=$(client_cmdline "$pid")
     if [ "$monitor" = "$VISUAL_OUTPUT" ] \
@@ -489,9 +495,9 @@ guard_clients() {
       printf '%s\t%s\t%s\t%s\t%s\n' \
         "$address" "${class:-$initial}" "$title" "${workspace_name:-$workspace_id}" "$monitor"
     fi
-  done)
-  if [ -n "$rows" ]; then
-    printf '%s\n' "$rows"
+  done <<< "$rows")
+  if [ -n "$filtered_rows" ]; then
+    printf '%s\n' "$filtered_rows"
   else
     printf '(none)\n'
   fi

--- a/bin/fm-visual-guard.sh
+++ b/bin/fm-visual-guard.sh
@@ -320,14 +320,16 @@ visual_client_is_hidden() {
 }
 
 visual_client_status() {
-  local preexisting=${1:-} misplaced=0 new_count=0
+  local preexisting=${1:-} misplaced=0 new_count=0 new_client_set=""
   local address pid class title workspace_id workspace_name monitor rows
+  local -a new_addresses=()
   rows=$(visual_client_rows)
   if [ -n "$rows" ]; then
     while IFS="$RECORD_SEPARATOR" read -r address pid class title workspace_id workspace_name monitor; do
       [ -n "$address" ] || continue
       if ! client_address_in_set "$address" "$preexisting"; then
         new_count=$((new_count + 1))
+        new_addresses+=("$address")
       fi
       if ! visual_client_is_hidden "$workspace_id" "$workspace_name" "$monitor"; then
         misplaced=$((misplaced + 1))
@@ -336,7 +338,10 @@ visual_client_status() {
 $rows
 EOF
   fi
-  printf '%s%s%s\n' "$misplaced" "$RECORD_SEPARATOR" "$new_count"
+  if [ "${#new_addresses[@]}" -gt 0 ]; then
+    new_client_set=$(printf '%s\n' "${new_addresses[@]}" | LC_ALL=C sort -u | tr '\n' ',')
+  fi
+  printf '%s%s%s%s%s\n' "$misplaced" "$RECORD_SEPARATOR" "$new_count" "$RECORD_SEPARATOR" "$new_client_set"
 }
 
 remediate_misplaced_visual_clients() {
@@ -357,17 +362,21 @@ EOF
 }
 
 verify_visual_placement() {
-  local preexisting=${1:-} remaining=$VERIFY_ATTEMPTS status misplaced new_count remediated stable_polls=0 saw_new_client=0
+  local preexisting=${1:-} remaining=$VERIFY_ATTEMPTS status misplaced new_count client_set remediated
+  local stable_polls=0 saw_new_client=0 settling_client_set=""
   while [ "$remaining" -gt 0 ]; do
     remediated=$(remediate_misplaced_visual_clients)
     status=$(visual_client_status "$preexisting")
-    IFS="$RECORD_SEPARATOR" read -r misplaced new_count <<EOF
+    IFS="$RECORD_SEPARATOR" read -r misplaced new_count client_set <<EOF
 $status
 EOF
     if [ "$new_count" -gt 0 ]; then
       saw_new_client=1
     fi
-    if [ "$new_count" -gt 0 ] && [ "$misplaced" -eq 0 ] && [ "$remediated" -eq 0 ]; then
+    if [ "$client_set" != "$settling_client_set" ]; then
+      settling_client_set=$client_set
+      stable_polls=0
+    elif [ "$new_count" -gt 0 ] && [ "$misplaced" -eq 0 ] && [ "$remediated" -eq 0 ]; then
       stable_polls=$((stable_polls + 1))
       if [ "$stable_polls" -ge "$VERIFY_SETTLE_POLLS" ]; then
         return 0
@@ -379,7 +388,7 @@ EOF
     remaining=$((remaining - 1))
   done
   status=$(visual_client_status "$preexisting")
-  IFS="$RECORD_SEPARATOR" read -r misplaced new_count <<EOF
+  IFS="$RECORD_SEPARATOR" read -r misplaced new_count client_set <<EOF
 $status
 EOF
   if [ "$new_count" -gt 0 ]; then

--- a/bin/fm-visual-guard.sh
+++ b/bin/fm-visual-guard.sh
@@ -357,13 +357,16 @@ EOF
 }
 
 verify_visual_placement() {
-  local preexisting=${1:-} remaining=$VERIFY_ATTEMPTS status misplaced new_count remediated stable_polls=0
+  local preexisting=${1:-} remaining=$VERIFY_ATTEMPTS status misplaced new_count remediated stable_polls=0 saw_new_client=0
   while [ "$remaining" -gt 0 ]; do
     remediated=$(remediate_misplaced_visual_clients)
     status=$(visual_client_status "$preexisting")
     IFS="$RECORD_SEPARATOR" read -r misplaced new_count <<EOF
 $status
 EOF
+    if [ "$new_count" -gt 0 ]; then
+      saw_new_client=1
+    fi
     if [ "$new_count" -gt 0 ] && [ "$misplaced" -eq 0 ] && [ "$remediated" -eq 0 ]; then
       stable_polls=$((stable_polls + 1))
       if [ "$stable_polls" -ge "$VERIFY_SETTLE_POLLS" ]; then
@@ -379,7 +382,11 @@ EOF
   IFS="$RECORD_SEPARATOR" read -r misplaced new_count <<EOF
 $status
 EOF
+  if [ "$new_count" -gt 0 ]; then
+    saw_new_client=1
+  fi
   [ "${misplaced:-0}" -eq 0 ] || die "Codex visual client remains outside workspace $VISUAL_WORKSPACE on $VISUAL_OUTPUT"
+  [ "$saw_new_client" -eq 0 ] || die "Codex visual client did not remain hidden for $VERIFY_SETTLE_POLLS consecutive polls before verification timed out"
 }
 
 guard_exec() {

--- a/bin/fm-visual-guard.sh
+++ b/bin/fm-visual-guard.sh
@@ -298,6 +298,41 @@ visible_visual_clients() {
   done
 }
 
+visual_client_rows() {
+  local address pid class initial title workspace_id workspace_name monitor cmdline
+  client_rows | while IFS=$'\t' read -r address pid class initial title workspace_id workspace_name monitor; do
+    [ -n "$address" ] || continue
+    cmdline=$(client_cmdline "$pid")
+    if class_matches_visual_identity "$class" "$initial" || cmdline_matches_visual_profile "$cmdline"; then
+      printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+        "$address" "$pid" "${class:-$initial}" "$title" "$workspace_id" "$workspace_name" "$monitor"
+    fi
+  done
+}
+
+visual_client_is_hidden() {
+  local workspace_id=$1 workspace_name=$2 monitor=$3
+  { [ "$workspace_id" = "$VISUAL_WORKSPACE" ] || [ "$workspace_name" = "$VISUAL_WORKSPACE" ]; } \
+    && [ "$monitor" = "$VISUAL_OUTPUT" ]
+}
+
+visual_client_status() {
+  local count=0 misplaced=0 address pid class title workspace_id workspace_name monitor rows
+  rows=$(visual_client_rows)
+  if [ -n "$rows" ]; then
+    while IFS=$'\t' read -r address pid class title workspace_id workspace_name monitor; do
+      [ -n "$address" ] || continue
+      count=$((count + 1))
+      if ! visual_client_is_hidden "$workspace_id" "$workspace_name" "$monitor"; then
+        misplaced=$((misplaced + 1))
+      fi
+    done <<EOF
+$rows
+EOF
+  fi
+  printf '%s\t%s\n' "$count" "$misplaced"
+}
+
 remediate_visible_visual_clients() {
   local leaked address class title workspace monitor pid moved=0
   leaked=$(visible_visual_clients)
@@ -313,19 +348,29 @@ remediate_visible_visual_clients() {
   done <<EOF
 $leaked
 EOF
-
-  [ "$moved" -eq 0 ] || return 0
 }
 
 verify_visual_placement() {
-  local leaked remaining=$VERIFY_ATTEMPTS
+  local leaked remaining=$VERIFY_ATTEMPTS status count misplaced
   while [ "$remaining" -gt 0 ]; do
     remediate_visible_visual_clients
+    status=$(visual_client_status)
+    IFS=$'\t' read -r count misplaced <<EOF
+$status
+EOF
+    if [ "$count" -gt 0 ] && [ "$misplaced" -eq 0 ]; then
+      return 0
+    fi
     sleep "$VERIFY_SLEEP"
     remaining=$((remaining - 1))
   done
   leaked=$(visible_visual_clients)
   [ -z "$leaked" ] || die "Codex visual client remains on a visible workspace after remediation: $leaked"
+  status=$(visual_client_status)
+  IFS=$'\t' read -r count misplaced <<EOF
+$status
+EOF
+  [ "${misplaced:-0}" -eq 0 ] || die "Codex visual client remains outside workspace $VISUAL_WORKSPACE on $VISUAL_OUTPUT"
 }
 
 guard_exec() {

--- a/bin/fm-visual-guard.sh
+++ b/bin/fm-visual-guard.sh
@@ -28,6 +28,8 @@ ALLOW_USER_WORKSPACE=${FM_VISUAL_ALLOW_USER_WORKSPACE:-0}
 LEGACY_VISUAL_CLASSES=${FM_VISUAL_LEGACY_CLASSES:-CodexVisual}
 VERIFY_ATTEMPTS=${FM_VISUAL_VERIFY_ATTEMPTS:-10}
 VERIFY_SLEEP=${FM_VISUAL_VERIFY_SLEEP:-0.2}
+VERIFY_SETTLE_POLLS=${FM_VISUAL_VERIFY_SETTLE_POLLS:-3}
+RECORD_SEPARATOR=$'\x1f'
 
 usage() {
   cat <<EOF
@@ -256,17 +258,6 @@ cmdline_matches_visual_profile() {
   return 1
 }
 
-workspace_is_visible_user_workspace() {
-  local id=${1:-} name=${2:-}
-  case "$id" in
-    [1-9]|1[01]) return 0 ;;
-  esac
-  case "$name" in
-    [1-9]|1[01]) return 0 ;;
-  esac
-  return 1
-}
-
 client_rows() {
   local clients monitors
   clients=$(hyprland_json clients)
@@ -287,36 +278,26 @@ client_rows() {
         $monitor_name
       ]
     | @tsv
+    | gsub("\t"; "\u001f")
   '
-}
-
-visible_visual_clients() {
-  local address pid class initial title workspace_id workspace_name monitor cmdline
-  client_rows | while IFS=$'\t' read -r address pid class initial title workspace_id workspace_name monitor; do
-    [ -n "$address" ] || continue
-    workspace_is_visible_user_workspace "$workspace_id" "$workspace_name" || continue
-    cmdline=$(client_cmdline "$pid")
-    if class_matches_visual_identity "$class" "$initial" || cmdline_matches_visual_profile "$cmdline"; then
-      printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$address" "${class:-$initial}" "$title" "$workspace_name" "$monitor" "$pid"
-    fi
-  done
 }
 
 visual_client_rows() {
   local address pid class initial title workspace_id workspace_name monitor cmdline
-  client_rows | while IFS=$'\t' read -r address pid class initial title workspace_id workspace_name monitor; do
+  client_rows | while IFS="$RECORD_SEPARATOR" read -r address pid class initial title workspace_id workspace_name monitor; do
     [ -n "$address" ] || continue
     cmdline=$(client_cmdline "$pid")
     if class_matches_visual_identity "$class" "$initial" || cmdline_matches_visual_profile "$cmdline"; then
-      printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
-        "$address" "$pid" "${class:-$initial}" "$title" "$workspace_id" "$workspace_name" "$monitor"
+      printf '%s%s%s%s%s%s%s%s%s%s%s%s%s\n' \
+        "$address" "$RECORD_SEPARATOR" "$pid" "$RECORD_SEPARATOR" "${class:-$initial}" "$RECORD_SEPARATOR" \
+        "$title" "$RECORD_SEPARATOR" "$workspace_id" "$RECORD_SEPARATOR" "$workspace_name" "$RECORD_SEPARATOR" "$monitor"
     fi
   done
 }
 
 visual_client_addresses() {
   local address pid class title workspace_id workspace_name monitor
-  visual_client_rows | while IFS=$'\t' read -r address pid class title workspace_id workspace_name monitor; do
+  visual_client_rows | while IFS="$RECORD_SEPARATOR" read -r address pid class title workspace_id workspace_name monitor; do
     [ -n "$address" ] || continue
     printf '%s\n' "$address"
   done
@@ -343,7 +324,7 @@ visual_client_status() {
   local address pid class title workspace_id workspace_name monitor rows
   rows=$(visual_client_rows)
   if [ -n "$rows" ]; then
-    while IFS=$'\t' read -r address pid class title workspace_id workspace_name monitor; do
+    while IFS="$RECORD_SEPARATOR" read -r address pid class title workspace_id workspace_name monitor; do
       [ -n "$address" ] || continue
       if ! client_address_in_set "$address" "$preexisting"; then
         new_count=$((new_count + 1))
@@ -355,44 +336,47 @@ visual_client_status() {
 $rows
 EOF
   fi
-  printf '%s\t%s\n' "$misplaced" "$new_count"
+  printf '%s%s%s\n' "$misplaced" "$RECORD_SEPARATOR" "$new_count"
 }
 
-remediate_visible_visual_clients() {
-  local leaked address class title workspace monitor pid moved=0
-  leaked=$(visible_visual_clients)
-  [ -n "$leaked" ] || return 0
-
-  while IFS=$'\t' read -r address class title workspace monitor pid; do
+remediate_misplaced_visual_clients() {
+  local rows address pid class title workspace_id workspace_name monitor moved=0
+  rows=$(visual_client_rows)
+  while IFS="$RECORD_SEPARATOR" read -r address pid class title workspace_id workspace_name monitor; do
     [ -n "$address" ] || continue
+    visual_client_is_hidden "$workspace_id" "$workspace_name" "$monitor" && continue
     if ! hyprctl_call dispatch movetoworkspacesilent "$VISUAL_WORKSPACE,address:$address" >/dev/null 2>&1; then
-      die "failed to move Codex visual client $address from workspace '$workspace' to '$VISUAL_WORKSPACE'"
+      die "failed to move Codex visual client $address from workspace '${workspace_name:-$workspace_id}' to '$VISUAL_WORKSPACE'"
     fi
     moved=$((moved + 1))
-    warn "moved Codex visual client $address pid=$pid class=$class from workspace '$workspace' on $monitor to '$VISUAL_WORKSPACE'"
+    warn "moved Codex visual client $address pid=$pid class=$class from workspace '${workspace_name:-$workspace_id}' on $monitor to '$VISUAL_WORKSPACE'"
   done <<EOF
-$leaked
+$rows
 EOF
+  printf '%s\n' "$moved"
 }
 
 verify_visual_placement() {
-  local preexisting=${1:-} leaked remaining=$VERIFY_ATTEMPTS status misplaced new_count
+  local preexisting=${1:-} remaining=$VERIFY_ATTEMPTS status misplaced new_count remediated stable_polls=0
   while [ "$remaining" -gt 0 ]; do
-    remediate_visible_visual_clients
+    remediated=$(remediate_misplaced_visual_clients)
     status=$(visual_client_status "$preexisting")
-    IFS=$'\t' read -r misplaced new_count <<EOF
+    IFS="$RECORD_SEPARATOR" read -r misplaced new_count <<EOF
 $status
 EOF
-    if [ "$new_count" -gt 0 ] && [ "$misplaced" -eq 0 ]; then
-      return 0
+    if [ "$new_count" -gt 0 ] && [ "$misplaced" -eq 0 ] && [ "$remediated" -eq 0 ]; then
+      stable_polls=$((stable_polls + 1))
+      if [ "$stable_polls" -ge "$VERIFY_SETTLE_POLLS" ]; then
+        return 0
+      fi
+    else
+      stable_polls=0
     fi
     sleep "$VERIFY_SLEEP"
     remaining=$((remaining - 1))
   done
-  leaked=$(visible_visual_clients)
-  [ -z "$leaked" ] || die "Codex visual client remains on a visible workspace after remediation: $leaked"
   status=$(visual_client_status "$preexisting")
-  IFS=$'\t' read -r misplaced new_count <<EOF
+  IFS="$RECORD_SEPARATOR" read -r misplaced new_count <<EOF
 $status
 EOF
   [ "${misplaced:-0}" -eq 0 ] || die "Codex visual client remains outside workspace $VISUAL_WORKSPACE on $VISUAL_OUTPUT"
@@ -468,7 +452,7 @@ guard_screenshot() {
 guard_clients() {
   local rows address pid class initial title workspace_id workspace_name monitor cmdline
   require_hyprland
-  rows=$(client_rows | while IFS=$'\t' read -r address pid class initial title workspace_id workspace_name monitor; do
+  rows=$(client_rows | while IFS="$RECORD_SEPARATOR" read -r address pid class initial title workspace_id workspace_name monitor; do
     [ -n "$address" ] || continue
     cmdline=$(client_cmdline "$pid")
     if [ "$monitor" = "$VISUAL_OUTPUT" ] \

--- a/bin/fm-visual-guard.sh
+++ b/bin/fm-visual-guard.sh
@@ -268,19 +268,23 @@ workspace_is_visible_user_workspace() {
 }
 
 client_rows() {
-  local clients
+  local clients monitors
   clients=$(hyprland_json clients)
-  printf '%s\n' "$clients" | jq_call -r '
-    .[]
+  monitors=$(hyprland_json monitors)
+  # shellcheck disable=SC2016
+  printf '%s\n' "$clients" | jq_call -r --argjson monitors "$monitors" '
+    .[] as $client
+    | (($client.monitor // "") | tostring) as $monitor
+    | (($monitors | map(select(((.id? // "") | tostring) == $monitor) | .name) | first) // $monitor) as $monitor_name
     | [
-        (.address // ""),
-        ((.pid? // "") | tostring),
-        (.class // ""),
-        (.initialClass // ""),
-        (.title // ""),
-        ((.workspace.id? // "") | tostring),
-        (.workspace.name // ""),
-        (.monitor // "")
+        ($client.address // ""),
+        (($client.pid? // "") | tostring),
+        ($client.class // ""),
+        ($client.initialClass // ""),
+        ($client.title // ""),
+        (($client.workspace.id? // "") | tostring),
+        ($client.workspace.name // ""),
+        $monitor_name
       ]
     | @tsv
   '
@@ -310,6 +314,24 @@ visual_client_rows() {
   done
 }
 
+visual_client_addresses() {
+  local address pid class title workspace_id workspace_name monitor
+  visual_client_rows | while IFS=$'\t' read -r address pid class title workspace_id workspace_name monitor; do
+    [ -n "$address" ] || continue
+    printf '%s\n' "$address"
+  done
+}
+
+client_address_in_set() {
+  local needle=$1 addresses=$2 address
+  while IFS= read -r address; do
+    [ "$address" = "$needle" ] && return 0
+  done <<EOF
+$addresses
+EOF
+  return 1
+}
+
 visual_client_is_hidden() {
   local workspace_id=$1 workspace_name=$2 monitor=$3
   { [ "$workspace_id" = "$VISUAL_WORKSPACE" ] || [ "$workspace_name" = "$VISUAL_WORKSPACE" ]; } \
@@ -317,12 +339,15 @@ visual_client_is_hidden() {
 }
 
 visual_client_status() {
-  local count=0 misplaced=0 address pid class title workspace_id workspace_name monitor rows
+  local preexisting=${1:-} misplaced=0 new_count=0
+  local address pid class title workspace_id workspace_name monitor rows
   rows=$(visual_client_rows)
   if [ -n "$rows" ]; then
     while IFS=$'\t' read -r address pid class title workspace_id workspace_name monitor; do
       [ -n "$address" ] || continue
-      count=$((count + 1))
+      if ! client_address_in_set "$address" "$preexisting"; then
+        new_count=$((new_count + 1))
+      fi
       if ! visual_client_is_hidden "$workspace_id" "$workspace_name" "$monitor"; then
         misplaced=$((misplaced + 1))
       fi
@@ -330,7 +355,7 @@ visual_client_status() {
 $rows
 EOF
   fi
-  printf '%s\t%s\n' "$count" "$misplaced"
+  printf '%s\t%s\n' "$misplaced" "$new_count"
 }
 
 remediate_visible_visual_clients() {
@@ -351,14 +376,14 @@ EOF
 }
 
 verify_visual_placement() {
-  local leaked remaining=$VERIFY_ATTEMPTS status count misplaced
+  local preexisting=${1:-} leaked remaining=$VERIFY_ATTEMPTS status misplaced new_count
   while [ "$remaining" -gt 0 ]; do
     remediate_visible_visual_clients
-    status=$(visual_client_status)
-    IFS=$'\t' read -r count misplaced <<EOF
+    status=$(visual_client_status "$preexisting")
+    IFS=$'\t' read -r misplaced new_count <<EOF
 $status
 EOF
-    if [ "$count" -gt 0 ] && [ "$misplaced" -eq 0 ]; then
+    if [ "$new_count" -gt 0 ] && [ "$misplaced" -eq 0 ]; then
       return 0
     fi
     sleep "$VERIFY_SLEEP"
@@ -366,26 +391,27 @@ EOF
   done
   leaked=$(visible_visual_clients)
   [ -z "$leaked" ] || die "Codex visual client remains on a visible workspace after remediation: $leaked"
-  status=$(visual_client_status)
-  IFS=$'\t' read -r count misplaced <<EOF
+  status=$(visual_client_status "$preexisting")
+  IFS=$'\t' read -r misplaced new_count <<EOF
 $status
 EOF
   [ "${misplaced:-0}" -eq 0 ] || die "Codex visual client remains outside workspace $VISUAL_WORKSPACE on $VISUAL_OUTPUT"
 }
 
 guard_exec() {
-  local command_string dispatch_string env_assignments
+  local command_string dispatch_string env_assignments preexisting
   [ "${1:-}" = "--" ] && shift
   [ "$#" -gt 0 ] || die "exec requires a command after --"
 
   ensure_visual_target 1
+  preexisting=$(visual_client_addresses)
   command_string=$(join_shell_words "$@")
   env_assignments=$(guard_env_assignments)
   dispatch_string="[workspace $VISUAL_WORKSPACE silent] env $env_assignments $command_string"
   if ! hyprctl_call dispatch exec "$dispatch_string" >/dev/null 2>&1; then
     die "Hyprland failed to dispatch command to workspace '$VISUAL_WORKSPACE'"
   fi
-  verify_visual_placement
+  verify_visual_placement "$preexisting"
   printf 'launched on workspace %s: %s\n' "$VISUAL_WORKSPACE" "$command_string"
 }
 

--- a/bin/fm-visual-guard.sh
+++ b/bin/fm-visual-guard.sh
@@ -3,9 +3,13 @@
 #
 # Use this instead of plain GUI launchers, raw browser commands, or ad hoc
 # Hyprland dispatches when Codex/crewmates need a visual surface.
-# It keeps windows on workspace 99 on the hidden CODEX-HEADLESS output and keeps
-# CODEX_GUI_GUARD=1 in the launched process environment so local wrappers can
-# recognize Firstmate-owned GUI work.
+# It dispatches windows to workspace 99 on the hidden CODEX-HEADLESS output and
+# keeps CODEX_GUI_GUARD=1 in the launched process environment so local wrappers
+# can recognize Firstmate-owned GUI work.
+# After dispatch, it identifies dedicated Firstmate and legacy Codex visual
+# clients by class or isolated Chrome profile, moves any misplaced matches to
+# the hidden target, and succeeds only after newly observed matches remain there
+# for the configured settling interval.
 #
 # Usage:
 #   fm-visual-guard.sh ensure
@@ -50,7 +54,13 @@ Environment:
   FM_VISUAL_GRIM         grim command/path, default grim
   FM_VISUAL_JQ           jq command/path, default jq
   FM_VISUAL_BROWSER_CMD  browser command/path, otherwise Chrome/Chromium on PATH
+  FM_VISUAL_BROWSER_PROFILE  browser profile path, otherwise firstmate state path
+  FM_VISUAL_DEVTOOLS_PROFILE Chrome DevTools profile path, otherwise firstmate state path
+  FM_VISUAL_ALLOW_USER_WORKSPACE  truthy to allow numeric workspace 1-11, default false
   FM_VISUAL_LEGACY_CLASSES  comma-separated older dedicated classes to corral, default CodexVisual
+  FM_VISUAL_VERIFY_ATTEMPTS maximum post-launch placement polls, default 10
+  FM_VISUAL_VERIFY_SLEEP   seconds between placement polls, default 0.2
+  FM_VISUAL_VERIFY_SETTLE_POLLS  unchanged hidden polls required for success, default 3
 EOF
 }
 

--- a/bin/fm-visual-guard.sh
+++ b/bin/fm-visual-guard.sh
@@ -1,0 +1,479 @@
+#!/usr/bin/env bash
+# Deterministic Codex GUI guard for Firstmate.
+#
+# Use this instead of plain GUI launchers, raw browser commands, or ad hoc
+# Hyprland dispatches when Codex/crewmates need a visual surface.
+# It keeps windows on workspace 99 on the hidden CODEX-HEADLESS output and keeps
+# CODEX_GUI_GUARD=1 in the launched process environment so local wrappers can
+# recognize Firstmate-owned GUI work.
+#
+# Usage:
+#   fm-visual-guard.sh ensure
+#   fm-visual-guard.sh exec -- <command ...>
+#   fm-visual-guard.sh browser <url>
+#   fm-visual-guard.sh screenshot <path>
+#   fm-visual-guard.sh clients
+#   fm-visual-guard.sh doctor
+set -eu
+
+VISUAL_OUTPUT=${FM_VISUAL_OUTPUT:-CODEX-HEADLESS}
+VISUAL_WORKSPACE=${FM_VISUAL_WORKSPACE:-99}
+VISUAL_GEOMETRY=${FM_VISUAL_GEOMETRY:-1440x1000@60,0x0,1}
+VISUAL_CLASS=${FM_VISUAL_CLASS:-FirstmateVisual}
+HYPRCTL=${FM_VISUAL_HYPRCTL:-hyprctl}
+GRIM=${FM_VISUAL_GRIM:-grim}
+JQ=${FM_VISUAL_JQ:-jq}
+BROWSER_CMD=${FM_VISUAL_BROWSER_CMD:-}
+ALLOW_USER_WORKSPACE=${FM_VISUAL_ALLOW_USER_WORKSPACE:-0}
+LEGACY_VISUAL_CLASSES=${FM_VISUAL_LEGACY_CLASSES:-CodexVisual}
+VERIFY_ATTEMPTS=${FM_VISUAL_VERIFY_ATTEMPTS:-10}
+VERIFY_SLEEP=${FM_VISUAL_VERIFY_SLEEP:-0.2}
+
+usage() {
+  cat <<EOF
+Usage:
+  $(basename "$0") ensure
+  $(basename "$0") exec -- <command ...>
+  $(basename "$0") browser <url>
+  $(basename "$0") screenshot <path>
+  $(basename "$0") clients
+  $(basename "$0") doctor
+
+Environment:
+  FM_VISUAL_OUTPUT       output name, default CODEX-HEADLESS
+  FM_VISUAL_WORKSPACE    workspace id/name, default 99
+  FM_VISUAL_GEOMETRY     Hyprland monitor geometry, default 1440x1000@60,0x0,1
+  FM_VISUAL_CLASS        browser class, default FirstmateVisual
+  FM_VISUAL_HYPRCTL      hyprctl command/path, default hyprctl
+  FM_VISUAL_GRIM         grim command/path, default grim
+  FM_VISUAL_JQ           jq command/path, default jq
+  FM_VISUAL_BROWSER_CMD  browser command/path, otherwise Chrome/Chromium on PATH
+  FM_VISUAL_LEGACY_CLASSES  comma-separated older dedicated classes to corral, default CodexVisual
+EOF
+}
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+is_truthy() {
+  case "$1" in
+    1|true|TRUE|yes|YES|on|ON) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+warn() {
+  printf 'warning: %s\n' "$*" >&2
+}
+
+require_cmd() {
+  local cmd=$1 label=$2
+  command -v "$cmd" >/dev/null 2>&1 || die "missing required command: $label"
+}
+
+have_cmd() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+hyprctl_call() {
+  "$HYPRCTL" "$@"
+}
+
+jq_call() {
+  "$JQ" "$@"
+}
+
+require_hyprland() {
+  require_cmd "$HYPRCTL" hyprctl
+  require_cmd "$JQ" jq
+}
+
+validate_visual_workspace() {
+  case "$VISUAL_WORKSPACE" in
+    ''|*[!0-9]*) return 0 ;;
+    *)
+      if [ "$VISUAL_WORKSPACE" -ge 1 ] && [ "$VISUAL_WORKSPACE" -le 11 ] && ! is_truthy "$ALLOW_USER_WORKSPACE"; then
+        die "refusing to use user workspace '$VISUAL_WORKSPACE'; set FM_VISUAL_WORKSPACE to a non-user workspace such as 99"
+      fi
+      ;;
+  esac
+}
+
+hyprland_json() {
+  local what=$1 output
+  if ! output=$(hyprctl_call "$what" -j 2>&1); then
+    die "hyprctl $what -j failed: $output"
+  fi
+  printf '%s\n' "$output"
+}
+
+monitor_exists() {
+  local monitors
+  monitors=$(hyprland_json monitors)
+  # shellcheck disable=SC2016 # jq receives $output via --arg, not shell expansion.
+  printf '%s\n' "$monitors" | jq_call -e --arg output "$VISUAL_OUTPUT" \
+    '.[] | select(.name == $output)' >/dev/null
+}
+
+ensure_visual_target() {
+  local quiet=${1:-0}
+  require_hyprland
+  validate_visual_workspace
+
+  if ! monitor_exists; then
+    if ! hyprctl_call output create headless "$VISUAL_OUTPUT" >/dev/null 2>&1; then
+      die "failed to create Hyprland headless output '$VISUAL_OUTPUT'"
+    fi
+  fi
+
+  if ! monitor_exists; then
+    die "Hyprland did not report headless output '$VISUAL_OUTPUT' after creation"
+  fi
+
+  if ! hyprctl_call keyword monitor "$VISUAL_OUTPUT,$VISUAL_GEOMETRY" >/dev/null 2>&1; then
+    die "failed to configure monitor '$VISUAL_OUTPUT' with '$VISUAL_GEOMETRY'"
+  fi
+
+  if ! hyprctl_call keyword workspace "$VISUAL_WORKSPACE, monitor:$VISUAL_OUTPUT" >/dev/null 2>&1; then
+    die "failed to bind workspace '$VISUAL_WORKSPACE' to '$VISUAL_OUTPUT'"
+  fi
+
+  if ! hyprctl_call dispatch moveworkspacetomonitor "$VISUAL_WORKSPACE" "$VISUAL_OUTPUT" >/dev/null 2>&1; then
+    die "failed to move workspace '$VISUAL_WORKSPACE' to '$VISUAL_OUTPUT'"
+  fi
+
+  if [ "$quiet" != 1 ]; then
+    printf 'ensured Codex visual target: output=%s workspace=%s\n' "$VISUAL_OUTPUT" "$VISUAL_WORKSPACE"
+  fi
+}
+
+workspace_rule_status() {
+  local rules
+  rules=$(hyprctl_call workspacerules -j 2>/dev/null || true)
+  [ -n "$rules" ] || return 1
+  # shellcheck disable=SC2016 # jq receives $output and $workspace via --arg.
+  printf '%s\n' "$rules" | jq_call -e \
+    --arg output "$VISUAL_OUTPUT" \
+    --arg workspace "$VISUAL_WORKSPACE" \
+    '
+      .[]
+      | select(
+          (.monitor? == $output)
+          and (
+            (.workspaceString? == $workspace)
+            or (((.workspace? // "") | tostring) == $workspace)
+          )
+        )
+    ' >/dev/null
+}
+
+shell_quote() {
+  printf "'"
+  printf '%s' "$1" | sed "s/'/'\\\\''/g"
+  printf "'"
+}
+
+join_shell_words() {
+  local word out=""
+  for word in "$@"; do
+    out="${out}${out:+ }$(shell_quote "$word")"
+  done
+  printf '%s\n' "$out"
+}
+
+visual_browser_profile() {
+  printf '%s\n' "${FM_VISUAL_BROWSER_PROFILE:-${XDG_STATE_HOME:-${HOME:-/tmp/.fm-visual}/.local/state}/firstmate-codex-visual-chrome}"
+}
+
+visual_devtools_profile() {
+  printf '%s\n' "${FM_VISUAL_DEVTOOLS_PROFILE:-${XDG_STATE_HOME:-${HOME:-/tmp/.fm-visual}/.local/state}/firstmate-codex-devtools-chrome}"
+}
+
+devtools_chrome_args() {
+  local args=${CHROME_DEVTOOLS_AXI_CHROME_ARGS:-}
+  case " $args " in
+    *" --class="*) ;;
+    *) args="${args}${args:+ }--class=$VISUAL_CLASS" ;;
+  esac
+  case " $args " in
+    *" --no-first-run "*) ;;
+    *) args="${args}${args:+ }--no-first-run" ;;
+  esac
+  case " $args " in
+    *" --no-default-browser-check "*) ;;
+    *) args="${args}${args:+ }--no-default-browser-check" ;;
+  esac
+  printf '%s\n' "$args"
+}
+
+guard_env_assignments() {
+  local browser_profile devtools_profile devtools_args
+  browser_profile=$(visual_browser_profile)
+  devtools_profile=$(visual_devtools_profile)
+  devtools_args=$(devtools_chrome_args)
+
+  printf 'CODEX_GUI_GUARD=1'
+  printf ' CODEX_VISUAL_WORKSPACE=%s' "$(shell_quote "$VISUAL_WORKSPACE")"
+  printf ' CODEX_VISUAL_OUTPUT=%s' "$(shell_quote "$VISUAL_OUTPUT")"
+  printf ' CODEX_VISUAL_GEOMETRY=%s' "$(shell_quote "$VISUAL_GEOMETRY")"
+  printf ' CODEX_VISUAL_CHROME_PROFILE=%s' "$(shell_quote "$browser_profile")"
+  printf ' CHROME_DEVTOOLS_AXI_USER_DATA_DIR=%s' "$(shell_quote "$devtools_profile")"
+  printf ' CHROME_DEVTOOLS_AXI_CHROME_ARGS=%s' "$(shell_quote "$devtools_args")"
+}
+
+class_matches_visual_identity() {
+  local class=${1:-} initial=${2:-} legacy
+  local -a legacy_classes
+  [ "$class" = "$VISUAL_CLASS" ] || [ "$initial" = "$VISUAL_CLASS" ] && return 0
+  IFS=',' read -r -a legacy_classes <<< "$LEGACY_VISUAL_CLASSES"
+  for legacy in "${legacy_classes[@]}"; do
+    [ -n "$legacy" ] || continue
+    [ "$class" = "$legacy" ] || [ "$initial" = "$legacy" ] && return 0
+  done
+  return 1
+}
+
+client_cmdline() {
+  local pid=${1:-}
+  case "$pid" in
+    ''|*[!0-9]*) return 0 ;;
+  esac
+  [ -r "/proc/$pid/cmdline" ] || return 0
+  tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null || true
+}
+
+cmdline_matches_visual_profile() {
+  local cmdline=$1 browser_profile devtools_profile
+  browser_profile=$(visual_browser_profile)
+  devtools_profile=$(visual_devtools_profile)
+  case "$cmdline" in
+    *"--user-data-dir=$browser_profile"*|*"--user-data-dir=$devtools_profile"*|*"--userDataDir=$devtools_profile"*)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+workspace_is_visible_user_workspace() {
+  local id=${1:-} name=${2:-}
+  case "$id" in
+    [1-9]|1[01]) return 0 ;;
+  esac
+  case "$name" in
+    [1-9]|1[01]) return 0 ;;
+  esac
+  return 1
+}
+
+client_rows() {
+  local clients
+  clients=$(hyprland_json clients)
+  printf '%s\n' "$clients" | jq_call -r '
+    .[]
+    | [
+        (.address // ""),
+        ((.pid? // "") | tostring),
+        (.class // ""),
+        (.initialClass // ""),
+        (.title // ""),
+        ((.workspace.id? // "") | tostring),
+        (.workspace.name // ""),
+        (.monitor // "")
+      ]
+    | @tsv
+  '
+}
+
+visible_visual_clients() {
+  local address pid class initial title workspace_id workspace_name monitor cmdline
+  client_rows | while IFS=$'\t' read -r address pid class initial title workspace_id workspace_name monitor; do
+    [ -n "$address" ] || continue
+    workspace_is_visible_user_workspace "$workspace_id" "$workspace_name" || continue
+    cmdline=$(client_cmdline "$pid")
+    if class_matches_visual_identity "$class" "$initial" || cmdline_matches_visual_profile "$cmdline"; then
+      printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$address" "${class:-$initial}" "$title" "$workspace_name" "$monitor" "$pid"
+    fi
+  done
+}
+
+remediate_visible_visual_clients() {
+  local leaked address class title workspace monitor pid moved=0
+  leaked=$(visible_visual_clients)
+  [ -n "$leaked" ] || return 0
+
+  while IFS=$'\t' read -r address class title workspace monitor pid; do
+    [ -n "$address" ] || continue
+    if ! hyprctl_call dispatch movetoworkspacesilent "$VISUAL_WORKSPACE,address:$address" >/dev/null 2>&1; then
+      die "failed to move Codex visual client $address from workspace '$workspace' to '$VISUAL_WORKSPACE'"
+    fi
+    moved=$((moved + 1))
+    warn "moved Codex visual client $address pid=$pid class=$class from workspace '$workspace' on $monitor to '$VISUAL_WORKSPACE'"
+  done <<EOF
+$leaked
+EOF
+
+  [ "$moved" -eq 0 ] || return 0
+}
+
+verify_visual_placement() {
+  local leaked remaining=$VERIFY_ATTEMPTS
+  while [ "$remaining" -gt 0 ]; do
+    remediate_visible_visual_clients
+    sleep "$VERIFY_SLEEP"
+    remaining=$((remaining - 1))
+  done
+  leaked=$(visible_visual_clients)
+  [ -z "$leaked" ] || die "Codex visual client remains on a visible workspace after remediation: $leaked"
+}
+
+guard_exec() {
+  local command_string dispatch_string env_assignments
+  [ "${1:-}" = "--" ] && shift
+  [ "$#" -gt 0 ] || die "exec requires a command after --"
+
+  ensure_visual_target 1
+  command_string=$(join_shell_words "$@")
+  env_assignments=$(guard_env_assignments)
+  dispatch_string="[workspace $VISUAL_WORKSPACE silent] env $env_assignments $command_string"
+  if ! hyprctl_call dispatch exec "$dispatch_string" >/dev/null 2>&1; then
+    die "Hyprland failed to dispatch command to workspace '$VISUAL_WORKSPACE'"
+  fi
+  verify_visual_placement
+  printf 'launched on workspace %s: %s\n' "$VISUAL_WORKSPACE" "$command_string"
+}
+
+find_browser_command() {
+  local candidate
+  if [ -n "$BROWSER_CMD" ]; then
+    if have_cmd "$BROWSER_CMD"; then
+      printf '%s\n' "$BROWSER_CMD"
+      return 0
+    fi
+    return 1
+  fi
+  for candidate in google-chrome-stable google-chrome chromium chromium-browser; do
+    if have_cmd "$candidate"; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+guard_browser() {
+  local url=${1:-} browser profile
+  [ -n "$url" ] || die "browser requires a URL"
+  browser=$(find_browser_command) || die "no Chrome/Chromium browser command found"
+
+  profile=$(visual_browser_profile)
+  guard_exec -- "$browser" \
+    "--class=$VISUAL_CLASS" \
+    "--user-data-dir=$profile" \
+    --no-first-run \
+    --no-default-browser-check \
+    --new-window \
+    "$url"
+}
+
+guard_screenshot() {
+  local path=${1:-} parent
+  [ -n "$path" ] || die "screenshot requires an output path"
+  ensure_visual_target 1
+  require_cmd "$GRIM" grim
+  case "$path" in
+    */*)
+      parent=${path%/*}
+      [ -d "$parent" ] || die "screenshot parent directory does not exist: $parent"
+      ;;
+  esac
+  if ! "$GRIM" -o "$VISUAL_OUTPUT" "$path"; then
+    die "grim failed to capture output '$VISUAL_OUTPUT'"
+  fi
+  printf 'screenshot captured from %s: %s\n' "$VISUAL_OUTPUT" "$path"
+}
+
+guard_clients() {
+  local rows address pid class initial title workspace_id workspace_name monitor cmdline
+  require_hyprland
+  rows=$(client_rows | while IFS=$'\t' read -r address pid class initial title workspace_id workspace_name monitor; do
+    [ -n "$address" ] || continue
+    cmdline=$(client_cmdline "$pid")
+    if [ "$monitor" = "$VISUAL_OUTPUT" ] \
+      || [ "$workspace_name" = "$VISUAL_WORKSPACE" ] \
+      || [ "$workspace_id" = "$VISUAL_WORKSPACE" ] \
+      || class_matches_visual_identity "$class" "$initial" \
+      || cmdline_matches_visual_profile "$cmdline"; then
+      printf '%s\t%s\t%s\t%s\t%s\n' \
+        "$address" "${class:-$initial}" "$title" "${workspace_name:-$workspace_id}" "$monitor"
+    fi
+  done)
+  if [ -n "$rows" ]; then
+    printf '%s\n' "$rows"
+  else
+    printf '(none)\n'
+  fi
+}
+
+guard_doctor() {
+  local failures=0 browser
+
+  if have_cmd "$HYPRCTL"; then
+    printf 'ok: hyprctl\n'
+  else
+    printf 'error: missing required command: hyprctl\n' >&2
+    failures=$((failures + 1))
+  fi
+
+  if have_cmd "$JQ"; then
+    printf 'ok: jq\n'
+  else
+    printf 'error: missing required command: jq\n' >&2
+    failures=$((failures + 1))
+  fi
+
+  if have_cmd "$GRIM"; then
+    printf 'ok: grim\n'
+  else
+    printf 'error: missing required command: grim\n' >&2
+    failures=$((failures + 1))
+  fi
+
+  if browser=$(find_browser_command); then
+    printf 'ok: browser=%s\n' "$browser"
+  else
+    warn "no Chrome/Chromium browser command found; browser subcommand will fail"
+  fi
+
+  [ "$failures" -eq 0 ] || return 1
+  ensure_visual_target 1
+  printf 'ok: visual target output=%s workspace=%s geometry=%s class=%s\n' \
+    "$VISUAL_OUTPUT" "$VISUAL_WORKSPACE" "$VISUAL_GEOMETRY" "$VISUAL_CLASS"
+  if workspace_rule_status; then
+    printf 'ok: workspace rule %s -> %s\n' "$VISUAL_WORKSPACE" "$VISUAL_OUTPUT"
+  else
+    warn "workspace rule for $VISUAL_WORKSPACE -> $VISUAL_OUTPUT not visible through hyprctl workspacerules"
+  fi
+  printf 'clients:\n'
+  guard_clients
+}
+
+main() {
+  local cmd=${1:-}
+  [ -n "$cmd" ] || { usage; exit 2; }
+  shift || true
+
+  case "$cmd" in
+    ensure) ensure_visual_target ;;
+    exec) guard_exec "$@" ;;
+    browser) guard_browser "$@" ;;
+    screenshot) guard_screenshot "$@" ;;
+    clients) guard_clients ;;
+    doctor) guard_doctor ;;
+    -h|--help|help) usage ;;
+    *) usage >&2; exit 2 ;;
+  esac
+}
+
+main "$@"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -240,7 +240,7 @@ Orca provides both the task worktree and terminal endpoint (see "Runtime backend
 A herdr, zellij, or cmux home is therefore never told `tmux` is missing, and the `treehouse` durable-lease upgrade check runs only for the backends that actually use treehouse.
 When `config/crew-dispatch.json` exists, bootstrap also requires `jq` for dispatch profile validation.
 When X mode is opted in, bootstrap also requires `curl` and `jq` before arming the relay poll shim.
-Codex-owned visual actions are checked at use time rather than by bootstrap: `bin/fm-visual-guard.sh doctor` requires `hyprctl`, `jq`, and `grim`, warns when Chrome or Chromium is unavailable, and its header and `--help` own the commands and environment overrides.
+On Hyprland hosts where `hyprctl` is available and `CODEX-HEADLESS` is the visual target, Codex-owned visual actions are checked at use time rather than by bootstrap: `bin/fm-visual-guard.sh doctor` requires `hyprctl`, `jq`, and `grim`, warns when Chrome or Chromium is unavailable, and its header and `--help` own the commands and environment overrides.
 `tasks-axi` and `quota-axi` are required bootstrap tools in every profile, the same class as `lavish-axi`.
 An absent or incompatible `tasks-axi` reports `MISSING: tasks-axi (install: npm install -g tasks-axi)`; when `config/backlog-backend` is not `manual` and compatible `tasks-axi` is on `PATH`, bootstrap stays silent and firstmate uses its verbs for routine backlog mutations, otherwise it hand-edits `data/backlog.md` until installation is approved and completed.
 An absent `quota-axi` reports `MISSING: quota-axi (install: npm install -g quota-axi)`; `bin/fm-dispatch-select.sh` still degrades to the first profile at runtime when quota data is unavailable.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -240,6 +240,7 @@ Orca provides both the task worktree and terminal endpoint (see "Runtime backend
 A herdr, zellij, or cmux home is therefore never told `tmux` is missing, and the `treehouse` durable-lease upgrade check runs only for the backends that actually use treehouse.
 When `config/crew-dispatch.json` exists, bootstrap also requires `jq` for dispatch profile validation.
 When X mode is opted in, bootstrap also requires `curl` and `jq` before arming the relay poll shim.
+Codex-owned visual actions are checked at use time rather than by bootstrap: `bin/fm-visual-guard.sh doctor` requires `hyprctl`, `jq`, and `grim`, warns when Chrome or Chromium is unavailable, and its header and `--help` own the commands and environment overrides.
 `tasks-axi` and `quota-axi` are required bootstrap tools in every profile, the same class as `lavish-axi`.
 An absent or incompatible `tasks-axi` reports `MISSING: tasks-axi (install: npm install -g tasks-axi)`; when `config/backlog-backend` is not `manual` and compatible `tasks-axi` is on `PATH`, bootstrap stays silent and firstmate uses its verbs for routine backlog mutations, otherwise it hand-edits `data/backlog.md` until installation is approved and completed.
 An absent `quota-axi` reports `MISSING: quota-axi (install: npm install -g quota-axi)`; `bin/fm-dispatch-select.sh` still degrades to the first profile at runtime when quota data is unavailable.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -17,7 +17,7 @@ The shared no-mistakes gate refusal used by `fm-spawn.sh`, `fm-send.sh`, and `fm
 | `fm-backlog-handoff.sh`  | Validate and delegate queued backlog-item moves into a secondmate home               |
 | `fm-decision-hold.sh`    | Create, verify, complete, and resolve durable captain-held decisions                 |
 | `fm-brief.sh`            | Scaffold ship, scout, secondmate-charter, and Herdr-lab briefs                       |
-| `fm-visual-guard.sh`     | Keep Codex-owned GUI and browser windows on workspace 99 on `CODEX-HEADLESS`, including self-checks that corral dedicated visual clients leaking onto visible workspaces |
+| `fm-visual-guard.sh`     | Guard Codex-owned GUI, browser, app-launcher, and screenshot actions; its header and `--help` own placement and remediation mechanics |
 | `fm-herdr-lab.sh`        | Provision and guardedly operate an isolated, never-default Herdr lab session         |
 | `fm-ensure-agents-md.sh` | Ensure a project's real `AGENTS.md`, its `CLAUDE.md` symlink, and the canonical self-governance section |
 | `fm-guard.sh`            | Warn on primary-checkout tangles, pending queued wakes, and stale watcher liveness   |

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -17,7 +17,7 @@ The shared no-mistakes gate refusal used by `fm-spawn.sh`, `fm-send.sh`, and `fm
 | `fm-backlog-handoff.sh`  | Validate and delegate queued backlog-item moves into a secondmate home               |
 | `fm-decision-hold.sh`    | Create, verify, complete, and resolve durable captain-held decisions                 |
 | `fm-brief.sh`            | Scaffold ship, scout, secondmate-charter, and Herdr-lab briefs                       |
-| `fm-visual-guard.sh`     | Guard Codex-owned GUI, browser, app-launcher, and screenshot actions; its header and `--help` own placement and remediation mechanics |
+| `fm-visual-guard.sh`     | Guard Codex-owned GUI, browser, app-launcher, and screenshot actions in Hyprland/CODEX-HEADLESS workflows where `hyprctl` is available; its header and `--help` own placement and remediation mechanics |
 | `fm-herdr-lab.sh`        | Provision and guardedly operate an isolated, never-default Herdr lab session         |
 | `fm-ensure-agents-md.sh` | Ensure a project's real `AGENTS.md`, its `CLAUDE.md` symlink, and the canonical self-governance section |
 | `fm-guard.sh`            | Warn on primary-checkout tangles, pending queued wakes, and stale watcher liveness   |

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -17,6 +17,7 @@ The shared no-mistakes gate refusal used by `fm-spawn.sh`, `fm-send.sh`, and `fm
 | `fm-backlog-handoff.sh`  | Validate and delegate queued backlog-item moves into a secondmate home               |
 | `fm-decision-hold.sh`    | Create, verify, complete, and resolve durable captain-held decisions                 |
 | `fm-brief.sh`            | Scaffold ship, scout, secondmate-charter, and Herdr-lab briefs                       |
+| `fm-visual-guard.sh`     | Keep Codex-owned GUI and browser windows on workspace 99 on `CODEX-HEADLESS`, including self-checks that corral dedicated visual clients leaking onto visible workspaces |
 | `fm-herdr-lab.sh`        | Provision and guardedly operate an isolated, never-default Herdr lab session         |
 | `fm-ensure-agents-md.sh` | Ensure a project's real `AGENTS.md`, its `CLAUDE.md` symlink, and the canonical self-governance section |
 | `fm-guard.sh`            | Warn on primary-checkout tangles, pending queued wakes, and stale watcher liveness   |

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -66,6 +66,27 @@ test_ship_modes_generate_clean_briefs() {
   pass "fm-brief.sh: no-mistakes/direct-PR/local-only briefs generate cleanly"
 }
 
+test_ship_and_scout_briefs_require_visual_guard() {
+  local home ship scout
+  home="$TMP_ROOT/visual-guard-home"
+  mkdir -p "$home/data"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" visual-ship sample-proj >/dev/null 2>&1
+  ship="$home/data/visual-ship/brief.md"
+  assert_grep 'Use `'"$ROOT"'/bin/fm-visual-guard.sh` for every GUI, browser, app-launcher, and screenshot action.' "$ship" \
+    "ship brief did not require the Firstmate visual guard"
+  assert_grep "legacy Codex visual wrappers" "$ship" \
+    "ship brief did not steer away from legacy visual wrappers"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" visual-scout sample-proj --scout >/dev/null 2>&1
+  scout="$home/data/visual-scout/brief.md"
+  assert_grep 'Use `'"$ROOT"'/bin/fm-visual-guard.sh` for every GUI, browser, app-launcher, and screenshot action.' "$scout" \
+    "scout brief did not require the Firstmate visual guard"
+  assert_grep "legacy Codex visual wrappers" "$scout" \
+    "scout brief did not steer away from legacy visual wrappers"
+  pass "fm-brief.sh: ship and scout briefs require the Firstmate visual guard"
+}
+
 test_faster_paths_use_configured_authority_without_stacked_review() {
   local home id brief
   home="$TMP_ROOT/configured-authority-home"
@@ -311,6 +332,7 @@ test_scout_and_secondmate_load_decision_hold_policy() {
 test_script_parses
 test_help_includes_entire_header
 test_ship_modes_generate_clean_briefs
+test_ship_and_scout_briefs_require_visual_guard
 test_faster_paths_use_configured_authority_without_stacked_review
 test_no_mistakes_dod_wording
 test_ship_project_memory_wording

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -77,7 +77,27 @@ fi
 exit 0
 SH
   chmod +x "$fakebin/no-mistakes"
+  fm_fake_exit0 "$fakebin" quota-axi
   printf '%s\n' manual > "${fakebin%/*}/home-placeholder" 2>/dev/null || true
+}
+
+base_path_without_tool() {
+  local tool=$1 dest=$2 old_ifs dir entry name
+  mkdir -p "$dest"
+  old_ifs=$IFS
+  IFS=:
+  for dir in $BASE_PATH; do
+    [ -d "$dir" ] || continue
+    for entry in "$dir"/*; do
+      [ -e "$entry" ] || continue
+      name=$(basename "$entry")
+      [ "$name" = "$tool" ] && continue
+      [ -e "$dest/$name" ] && continue
+      ln -s "$entry" "$dest/$name"
+    done
+  done
+  IFS=$old_ifs
+  printf '%s\n' "$dest"
 }
 
 make_fake_tasks_axi_compact() {
@@ -394,7 +414,7 @@ EOF
 # --- output ordering ----------------------------------------------------------
 
 test_output_ordering_diagnostics_lead() {
-  local rec root home fakebin out lock_line boot_line wake_line context_line fleet_line next_line
+  local rec root home fakebin no_node_path out lock_line boot_line wake_line context_line fleet_line next_line
   rec=$(new_world ordering)
   IFS='|' read -r root home fakebin <<EOF
 $rec
@@ -403,10 +423,11 @@ EOF
   make_fake_ps_claude "$fakebin"
   # Force a MISSING diagnostic line so the bootstrap section is non-trivial.
   rm -f "$fakebin/node"
+  no_node_path=$(base_path_without_tool node "$home/no-node-path")
 
   printf 'window=fm-sess:w1\nkind=ship\n' > "$home/state/task-a.meta"
 
-  out=$(run_session_start "$home" "$root" "$fakebin:$BASE_PATH")
+  out=$(run_session_start "$home" "$root" "$fakebin:$no_node_path")
 
   lock_line=$(printf '%s\n' "$out" | grep -n '^LOCK$' | head -1 | cut -d: -f1)
   boot_line=$(printf '%s\n' "$out" | grep -n '^BOOTSTRAP$' | head -1 | cut -d: -f1)
@@ -578,18 +599,20 @@ EOF
 # --- composition: real scripts run, not reimplemented ------------------------
 
 test_composition_invokes_real_scripts() {
-  local rec root home fakebin out
+  local rec root home fakebin no_node_path out
   rec=$(new_world composition)
   IFS='|' read -r root home fakebin <<EOF
 $rec
 EOF
   make_fake_toolchain "$fakebin"
   make_fake_ps_claude "$fakebin"
+  make_fake_tasks_axi_compact "$fakebin"
   rm -f "$fakebin/node"
+  no_node_path=$(base_path_without_tool node "$home/no-node-path")
 
   append_wake "$home/state" signal task-z "needs-decision: pick a library"
 
-  out=$(run_session_start "$home" "$root" "$fakebin:$BASE_PATH")
+  out=$(run_session_start "$home" "$root" "$fakebin:$no_node_path")
 
   # fm-lock.sh's own exact success text.
   assert_contains "$out" "lock acquired: harness pid" "fm-lock.sh's real output did not appear (composition, not reimplementation)"

--- a/tests/fm-visual-guard.test.sh
+++ b/tests/fm-visual-guard.test.sh
@@ -11,6 +11,7 @@ LOG="$TMP_ROOT/calls.log"
 MONITOR_STATE="$TMP_ROOT/monitor-created"
 LEAK_STATE="$TMP_ROOT/leak-client"
 CLIENT_COUNT_STATE="$TMP_ROOT/client-count"
+DISPATCH_STATE="$TMP_ROOT/dispatched"
 
 write_fake_tools() {
   cat > "$FAKEBIN/hyprctl" <<'SH'
@@ -24,7 +25,7 @@ printf '\n' >> "$FM_VISUAL_TEST_LOG"
 
 if [ "${1:-}" = "monitors" ] && [ "${2:-}" = "-j" ]; then
   if [ -e "$FM_VISUAL_TEST_MONITOR_STATE" ]; then
-    printf '[{"name":"CODEX-HEADLESS"}]\n'
+    printf '[{"id":9,"name":"CODEX-HEADLESS"}]\n'
   else
     printf '[{"name":"eDP-1"}]\n'
   fi
@@ -37,7 +38,54 @@ if [ "${1:-}" = "clients" ] && [ "${2:-}" = "-j" ]; then
   count=$((count + 1))
   printf '%s\n' "$count" > "$FM_VISUAL_TEST_CLIENT_COUNT_STATE"
 
-  if [ "${FM_VISUAL_TEST_CLIENT_MODE:-}" = "late-leak" ]; then
+  if [ "${FM_VISUAL_TEST_CLIENT_MODE:-}" = "new-hidden" ]; then
+    if [ -e "${FM_VISUAL_TEST_DISPATCH_STATE:-}" ]; then
+      cat <<'JSON'
+[
+  {"address":"0xabc","pid":12345,"class":"FirstmateVisual","initialClass":"FirstmateVisual","title":"Preview","workspace":{"id":99,"name":"99"},"monitor":"CODEX-HEADLESS"},
+  {"address":"0xdef","pid":12347,"class":"google-chrome","initialClass":"google-chrome","title":"User Chrome","workspace":{"id":1,"name":"1"},"monitor":"eDP-1"}
+]
+JSON
+    else
+      cat <<'JSON'
+[
+  {"address":"0xdef","pid":12347,"class":"google-chrome","initialClass":"google-chrome","title":"User Chrome","workspace":{"id":1,"name":"1"},"monitor":"eDP-1"}
+]
+JSON
+    fi
+  elif [ "${FM_VISUAL_TEST_CLIENT_MODE:-}" = "preexisting-hidden-late-leak" ]; then
+    if [ "$count" -lt 4 ]; then
+      cat <<'JSON'
+[
+  {"address":"0xabc","pid":12345,"class":"FirstmateVisual","initialClass":"FirstmateVisual","title":"Preview","workspace":{"id":99,"name":"99"},"monitor":"CODEX-HEADLESS"},
+  {"address":"0xdef","pid":12347,"class":"google-chrome","initialClass":"google-chrome","title":"User Chrome","workspace":{"id":1,"name":"1"},"monitor":"eDP-1"}
+]
+JSON
+    elif [ -e "${FM_VISUAL_TEST_LEAK_STATE:-}" ]; then
+      cat <<'JSON'
+[
+  {"address":"0xabc","pid":12345,"class":"FirstmateVisual","initialClass":"FirstmateVisual","title":"Preview","workspace":{"id":99,"name":"99"},"monitor":"CODEX-HEADLESS"},
+  {"address":"0xced","pid":12346,"class":"CodexVisual","initialClass":"CodexVisual","title":"Legacy","workspace":{"id":11,"name":"11"},"monitor":"eDP-1"},
+  {"address":"0xdef","pid":12347,"class":"google-chrome","initialClass":"google-chrome","title":"User Chrome","workspace":{"id":1,"name":"1"},"monitor":"eDP-1"}
+]
+JSON
+    else
+      cat <<'JSON'
+[
+  {"address":"0xabc","pid":12345,"class":"FirstmateVisual","initialClass":"FirstmateVisual","title":"Preview","workspace":{"id":99,"name":"99"},"monitor":"CODEX-HEADLESS"},
+  {"address":"0xced","pid":12346,"class":"CodexVisual","initialClass":"CodexVisual","title":"Legacy","workspace":{"id":99,"name":"99"},"monitor":"CODEX-HEADLESS"},
+  {"address":"0xdef","pid":12347,"class":"google-chrome","initialClass":"google-chrome","title":"User Chrome","workspace":{"id":1,"name":"1"},"monitor":"eDP-1"}
+]
+JSON
+    fi
+  elif [ "${FM_VISUAL_TEST_CLIENT_MODE:-}" = "numeric-hidden" ]; then
+    cat <<'JSON'
+[
+  {"address":"0xabc","pid":12345,"class":"FirstmateVisual","initialClass":"FirstmateVisual","title":"Preview","workspace":{"id":99,"name":"99"},"monitor":9},
+  {"address":"0xdef","pid":12347,"class":"google-chrome","initialClass":"google-chrome","title":"User Chrome","workspace":{"id":1,"name":"1"},"monitor":0}
+]
+JSON
+  elif [ "${FM_VISUAL_TEST_CLIENT_MODE:-}" = "late-leak" ]; then
     if [ "$count" -lt 3 ]; then
       cat <<'JSON'
 [
@@ -83,6 +131,11 @@ if [ "${1:-}" = "dispatch" ] && [ "${2:-}" = "movetoworkspacesilent" ]; then
   exit 0
 fi
 
+if [ "${1:-}" = "dispatch" ] && [ "${2:-}" = "exec" ]; then
+  : > "$FM_VISUAL_TEST_DISPATCH_STATE"
+  exit 0
+fi
+
 if [ "${1:-}" = "output" ] && [ "${2:-}" = "create" ]; then
   : > "$FM_VISUAL_TEST_MONITOR_STATE"
   exit 0
@@ -116,6 +169,7 @@ run_guard() {
     FM_VISUAL_TEST_MONITOR_STATE="$MONITOR_STATE" \
     FM_VISUAL_TEST_LEAK_STATE="$LEAK_STATE" \
     FM_VISUAL_TEST_CLIENT_COUNT_STATE="$CLIENT_COUNT_STATE" \
+    FM_VISUAL_TEST_DISPATCH_STATE="$DISPATCH_STATE" \
     FM_VISUAL_HYPRCTL=hyprctl \
     FM_VISUAL_GRIM=grim \
     FM_VISUAL_VERIFY_SLEEP=0 \
@@ -196,35 +250,51 @@ test_exec_corrals_legacy_codex_visual_leak() {
   pass "fm-visual-guard.sh: exec corrals legacy codex-visual-browser workspace leaks"
 }
 
-test_exec_exits_early_when_visual_clients_already_hidden() {
+test_exec_exits_early_when_new_visual_client_is_hidden() {
   local count
   write_fake_tools
-  rm -f "$LOG" "$MONITOR_STATE" "$LEAK_STATE" "$CLIENT_COUNT_STATE"
-  FM_VISUAL_VERIFY_ATTEMPTS=5 run_guard exec -- xdg-open "https://example.test" >/dev/null \
-    || fail "exec with already-hidden client failed"
+  rm -f "$LOG" "$MONITOR_STATE" "$LEAK_STATE" "$CLIENT_COUNT_STATE" "$DISPATCH_STATE"
+  FM_VISUAL_TEST_CLIENT_MODE=new-hidden FM_VISUAL_VERIFY_ATTEMPTS=8 \
+    run_guard exec -- xdg-open "https://example.test" >/dev/null \
+    || fail "exec with newly hidden client failed"
   count=$(cat "$CLIENT_COUNT_STATE")
-  [ "$count" -lt 5 ] || fail "verification exhausted attempts despite already-hidden client; clients calls=$count"
+  [ "$count" -lt 8 ] || fail "verification exhausted attempts despite newly hidden client; clients calls=$count"
   assert_no_grep $'hyprctl\tdispatch\tmovetoworkspacesilent' "$LOG" \
     "guard moved a client even though every Codex visual client was already hidden"
-  pass "fm-visual-guard.sh: exits verification early after matching clients are already hidden"
+  pass "fm-visual-guard.sh: exits verification early after a new matching client is hidden"
 }
 
-test_exec_waits_for_late_visual_client_before_exiting() {
+test_exec_ignores_preexisting_hidden_client_until_late_leak_appears() {
   local count output
   write_fake_tools
-  rm -f "$LOG" "$MONITOR_STATE" "$CLIENT_COUNT_STATE"
+  rm -f "$LOG" "$MONITOR_STATE" "$CLIENT_COUNT_STATE" "$DISPATCH_STATE"
   : > "$LEAK_STATE"
-  output=$(FM_VISUAL_TEST_CLIENT_MODE=late-leak FM_VISUAL_VERIFY_ATTEMPTS=6 run_guard exec -- xdg-open "https://example.test" 2>&1) \
+  output=$(FM_VISUAL_TEST_CLIENT_MODE=preexisting-hidden-late-leak FM_VISUAL_VERIFY_ATTEMPTS=6 run_guard exec -- xdg-open "https://example.test" 2>&1) \
     || fail "exec with late-appearing client failed"
   assert_absent "$LEAK_STATE" "late CodexVisual leak marker was not cleared"
   count=$(cat "$CLIENT_COUNT_STATE")
-  [ "$count" -ge 3 ] || fail "verification exited before the late Codex visual client appeared; clients calls=$count"
-  [ "$count" -lt 6 ] || fail "verification did not exit after remediating the late Codex visual client; clients calls=$count"
+  [ "$count" -ge 4 ] || fail "verification treated a pre-existing hidden client as newly launched; clients calls=$count"
+  [ "$count" -lt 12 ] || fail "verification did not exit after remediating the late Codex visual client; clients calls=$count"
   assert_grep $'hyprctl\tdispatch\tmovetoworkspacesilent\t99,address:0xced' "$LOG" \
     "guard did not move the late legacy CodexVisual client"
   assert_contains "$output" "moved Codex visual client 0xced" \
     "guard did not report remediation of the late visible client"
-  pass "fm-visual-guard.sh: keeps settling until a late visual client appears and is hidden"
+  pass "fm-visual-guard.sh: pre-existing hidden clients do not mask a late visual leak"
+}
+
+test_exec_accepts_numeric_monitor_id_for_headless_output() {
+  local output
+  write_fake_tools
+  rm -f "$LOG" "$MONITOR_STATE" "$CLIENT_COUNT_STATE" "$DISPATCH_STATE"
+  : > "$MONITOR_STATE"
+  output=$(FM_VISUAL_TEST_CLIENT_MODE=numeric-hidden FM_VISUAL_VERIFY_ATTEMPTS=1 \
+    run_guard exec -- xdg-open "https://example.test" 2>&1) \
+    || fail "exec rejected a hidden client reported with numeric monitor id"
+  assert_contains "$output" "launched on workspace 99" \
+    "guard did not accept numeric monitor id 9 for CODEX-HEADLESS"
+  assert_no_grep $'hyprctl\tdispatch\tmovetoworkspacesilent' "$LOG" \
+    "guard tried to move a client already hidden on numeric monitor id 9"
+  pass "fm-visual-guard.sh: numeric monitor ids resolve to CODEX-HEADLESS"
 }
 
 test_refuses_normal_user_workspace_by_default() {
@@ -277,8 +347,9 @@ test_screenshot_routes_to_headless_output
 test_clients_filters_codex_visual_clients
 test_browser_uses_independent_firstmate_visual_class
 test_exec_corrals_legacy_codex_visual_leak
-test_exec_exits_early_when_visual_clients_already_hidden
-test_exec_waits_for_late_visual_client_before_exiting
+test_exec_exits_early_when_new_visual_client_is_hidden
+test_exec_ignores_preexisting_hidden_client_until_late_leak_appears
+test_exec_accepts_numeric_monitor_id_for_headless_output
 test_refuses_normal_user_workspace_by_default
 test_doctor_fails_when_hyprctl_missing
 test_doctor_checks_screenshot_dependency

--- a/tests/fm-visual-guard.test.sh
+++ b/tests/fm-visual-guard.test.sh
@@ -106,6 +106,29 @@ JSON
 ]
 JSON
     fi
+  elif [ "${FM_VISUAL_TEST_CLIENT_MODE:-}" = "new-hidden-late-hidden-sibling" ]; then
+    if [ ! -e "${FM_VISUAL_TEST_DISPATCH_STATE:-}" ]; then
+      cat <<'JSON'
+[
+  {"address":"0xdef","pid":12347,"class":"google-chrome","initialClass":"google-chrome","title":"User Chrome","workspace":{"id":1,"name":"1"},"monitor":"eDP-1"}
+]
+JSON
+    elif [ "$count" -lt 6 ]; then
+      cat <<'JSON'
+[
+  {"address":"0xabc","pid":12345,"class":"FirstmateVisual","initialClass":"FirstmateVisual","title":"Preview","workspace":{"id":99,"name":"99"},"monitor":"CODEX-HEADLESS"},
+  {"address":"0xdef","pid":12347,"class":"google-chrome","initialClass":"google-chrome","title":"User Chrome","workspace":{"id":1,"name":"1"},"monitor":"eDP-1"}
+]
+JSON
+    else
+      cat <<'JSON'
+[
+  {"address":"0xabc","pid":12345,"class":"FirstmateVisual","initialClass":"FirstmateVisual","title":"Preview","workspace":{"id":99,"name":"99"},"monitor":"CODEX-HEADLESS"},
+  {"address":"0xced","pid":12346,"class":"CodexVisual","initialClass":"CodexVisual","title":"Sibling","workspace":{"id":99,"name":"99"},"monitor":"CODEX-HEADLESS"},
+  {"address":"0xdef","pid":12347,"class":"google-chrome","initialClass":"google-chrome","title":"User Chrome","workspace":{"id":1,"name":"1"},"monitor":"eDP-1"}
+]
+JSON
+    fi
   elif [ "${FM_VISUAL_TEST_CLIENT_MODE:-}" = "misplaced-non-user" ]; then
     if [ -e "${FM_VISUAL_TEST_LEAK_STATE:-}" ]; then
       cat <<'JSON'
@@ -343,7 +366,7 @@ test_exec_exits_early_when_new_visual_client_is_hidden() {
     run_guard exec -- xdg-open "https://example.test" >/dev/null \
     || fail "exec with newly hidden client failed"
   count=$(cat "$CLIENT_COUNT_STATE")
-  [ "$count" -lt 8 ] || fail "verification exhausted attempts despite newly hidden client; clients calls=$count"
+  [ "$count" -eq 9 ] || fail "verification did not require three unchanged hidden polls; clients calls=$count"
   assert_no_grep $'hyprctl\tdispatch\tmovetoworkspacesilent' "$LOG" \
     "guard moved a client even though every Codex visual client was already hidden"
   pass "fm-visual-guard.sh: exits verification early after a new matching client is hidden"
@@ -365,6 +388,20 @@ test_exec_settles_before_corralling_delayed_sibling() {
   assert_contains "$output" "moved Codex visual client 0xced" \
     "guard did not report remediation of the delayed sibling"
   pass "fm-visual-guard.sh: verification settles before accepting hidden clients"
+}
+
+test_exec_restarts_settling_for_late_hidden_sibling() {
+  local count
+  write_fake_tools
+  rm -f "$LOG" "$MONITOR_STATE" "$LEAK_STATE" "$CLIENT_COUNT_STATE" "$DISPATCH_STATE"
+  FM_VISUAL_TEST_CLIENT_MODE=new-hidden-late-hidden-sibling FM_VISUAL_VERIFY_ATTEMPTS=7 \
+    run_guard exec -- xdg-open "https://example.test" >/dev/null \
+    || fail "exec with late hidden sibling failed"
+  count=$(cat "$CLIENT_COUNT_STATE")
+  [ "$count" -eq 13 ] || fail "verification did not restart settling for the late hidden sibling; clients calls=$count"
+  assert_no_grep $'hyprctl\tdispatch\tmovetoworkspacesilent' "$LOG" \
+    "guard moved a sibling that first appeared already hidden"
+  pass "fm-visual-guard.sh: late hidden siblings restart placement settling"
 }
 
 test_exec_fails_when_client_appears_on_final_poll() {
@@ -421,7 +458,7 @@ test_exec_accepts_numeric_monitor_id_for_headless_output() {
   write_fake_tools
   rm -f "$LOG" "$MONITOR_STATE" "$CLIENT_COUNT_STATE" "$DISPATCH_STATE"
   : > "$MONITOR_STATE"
-  output=$(FM_VISUAL_TEST_CLIENT_MODE=numeric-hidden FM_VISUAL_VERIFY_ATTEMPTS=3 \
+  output=$(FM_VISUAL_TEST_CLIENT_MODE=numeric-hidden FM_VISUAL_VERIFY_ATTEMPTS=4 \
     run_guard exec -- xdg-open "https://example.test" 2>&1) \
     || fail "exec rejected a hidden client reported with numeric monitor id"
   assert_contains "$output" "launched on workspace 99" \
@@ -484,6 +521,7 @@ test_browser_uses_independent_firstmate_visual_class
 test_exec_corrals_legacy_codex_visual_leak
 test_exec_exits_early_when_new_visual_client_is_hidden
 test_exec_settles_before_corralling_delayed_sibling
+test_exec_restarts_settling_for_late_hidden_sibling
 test_exec_fails_when_client_appears_on_final_poll
 test_exec_corrals_matching_clients_from_any_misplaced_workspace
 test_exec_ignores_preexisting_hidden_client_until_late_leak_appears

--- a/tests/fm-visual-guard.test.sh
+++ b/tests/fm-visual-guard.test.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# Behavior tests for bin/fm-visual-guard.sh.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-visual-guard)
+FAKEBIN=$(fm_fakebin "$TMP_ROOT")
+LOG="$TMP_ROOT/calls.log"
+MONITOR_STATE="$TMP_ROOT/monitor-created"
+LEAK_STATE="$TMP_ROOT/leak-client"
+
+write_fake_tools() {
+  cat > "$FAKEBIN/hyprctl" <<'SH'
+#!/usr/bin/env bash
+set -u
+printf 'hyprctl' >> "$FM_VISUAL_TEST_LOG"
+for arg in "$@"; do
+  printf '\t%s' "$arg" >> "$FM_VISUAL_TEST_LOG"
+done
+printf '\n' >> "$FM_VISUAL_TEST_LOG"
+
+if [ "${1:-}" = "monitors" ] && [ "${2:-}" = "-j" ]; then
+  if [ -e "$FM_VISUAL_TEST_MONITOR_STATE" ]; then
+    printf '[{"name":"CODEX-HEADLESS"}]\n'
+  else
+    printf '[{"name":"eDP-1"}]\n'
+  fi
+  exit 0
+fi
+
+if [ "${1:-}" = "clients" ] && [ "${2:-}" = "-j" ]; then
+  if [ -e "${FM_VISUAL_TEST_LEAK_STATE:-}" ]; then
+    cat <<'JSON'
+[
+  {"address":"0xabc","pid":12345,"class":"FirstmateVisual","initialClass":"FirstmateVisual","title":"Preview","workspace":{"id":99,"name":"99"},"monitor":"CODEX-HEADLESS"},
+  {"address":"0xced","pid":12346,"class":"CodexVisual","initialClass":"CodexVisual","title":"Legacy","workspace":{"id":11,"name":"11"},"monitor":"eDP-1"},
+  {"address":"0xdef","pid":12347,"class":"google-chrome","initialClass":"google-chrome","title":"User Chrome","workspace":{"id":1,"name":"1"},"monitor":"eDP-1"}
+]
+JSON
+  else
+    cat <<'JSON'
+[
+  {"address":"0xabc","pid":12345,"class":"FirstmateVisual","initialClass":"FirstmateVisual","title":"Preview","workspace":{"id":99,"name":"99"},"monitor":"CODEX-HEADLESS"},
+  {"address":"0xdef","pid":12347,"class":"google-chrome","initialClass":"google-chrome","title":"User Chrome","workspace":{"id":1,"name":"1"},"monitor":"eDP-1"}
+]
+JSON
+  fi
+  exit 0
+fi
+
+if [ "${1:-}" = "dispatch" ] && [ "${2:-}" = "movetoworkspacesilent" ]; then
+  rm -f "${FM_VISUAL_TEST_LEAK_STATE:-}"
+  exit 0
+fi
+
+if [ "${1:-}" = "output" ] && [ "${2:-}" = "create" ]; then
+  : > "$FM_VISUAL_TEST_MONITOR_STATE"
+  exit 0
+fi
+
+exit 0
+SH
+  chmod +x "$FAKEBIN/hyprctl"
+
+  cat > "$FAKEBIN/grim" <<'SH'
+#!/usr/bin/env bash
+set -u
+printf 'grim' >> "$FM_VISUAL_TEST_LOG"
+for arg in "$@"; do
+  printf '\t%s' "$arg" >> "$FM_VISUAL_TEST_LOG"
+done
+printf '\n' >> "$FM_VISUAL_TEST_LOG"
+printf 'fake png\n' > "${@: -1}"
+SH
+  chmod +x "$FAKEBIN/grim"
+
+  cat > "$FAKEBIN/google-chrome-stable" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  chmod +x "$FAKEBIN/google-chrome-stable"
+}
+
+run_guard() {
+    FM_VISUAL_TEST_LOG="$LOG" \
+    FM_VISUAL_TEST_MONITOR_STATE="$MONITOR_STATE" \
+    FM_VISUAL_TEST_LEAK_STATE="$LEAK_STATE" \
+    FM_VISUAL_HYPRCTL=hyprctl \
+    FM_VISUAL_GRIM=grim \
+    FM_VISUAL_VERIFY_SLEEP=0 \
+    PATH="$FAKEBIN:$PATH" \
+    "$ROOT/bin/fm-visual-guard.sh" "$@"
+}
+
+test_exec_preserves_arguments_and_silent_workspace() {
+  local output code
+  write_fake_tools
+  rm -f "$LOG" "$MONITOR_STATE"
+  output=$(run_guard exec -- printf "two words" "quote's" "\$dollar" 2>&1)
+  code=$?
+  expect_code 0 "$code" "exec guard"
+  assert_grep $'hyprctl\toutput\tcreate\theadless\tCODEX-HEADLESS' "$LOG" \
+    "ensure did not create missing CODEX-HEADLESS output"
+  assert_grep $'hyprctl\tdispatch\texec\t[workspace 99 silent] env CODEX_GUI_GUARD=1' "$LOG" \
+    "exec did not mark the launch as Codex-guarded"
+  assert_grep "CODEX_VISUAL_WORKSPACE='99'" "$LOG" \
+    "exec did not pass the hidden workspace to legacy visual wrappers"
+  assert_grep "CHROME_DEVTOOLS_AXI_USER_DATA_DIR=" "$LOG" \
+    "exec did not force chrome-devtools-axi onto a dedicated profile"
+  assert_grep "'printf' 'two words'" "$LOG" \
+    "exec did not preserve spaced arguments in one shell command"
+  assert_grep "quote'\\''s" "$LOG" "exec did not preserve single quotes"
+  assert_grep "\$dollar" "$LOG" "exec did not preserve dollar-sign argument"
+  assert_contains "$output" "launched on workspace 99" "exec did not report target workspace"
+  pass "fm-visual-guard.sh: exec preserves arguments and uses silent workspace dispatch"
+}
+
+test_screenshot_routes_to_headless_output() {
+  local shot
+  write_fake_tools
+  rm -f "$LOG" "$MONITOR_STATE"
+  shot="$TMP_ROOT/shot.png"
+  run_guard screenshot "$shot" >/dev/null || fail "screenshot failed"
+  assert_present "$shot" "screenshot file was not written by grim"
+  assert_grep $'grim\t-o\tCODEX-HEADLESS\t'"$shot" "$LOG" \
+    "screenshot did not target CODEX-HEADLESS"
+  pass "fm-visual-guard.sh: screenshot targets CODEX-HEADLESS"
+}
+
+test_clients_filters_codex_visual_clients() {
+  local output
+  write_fake_tools
+  rm -f "$LOG" "$MONITOR_STATE"
+  : > "$MONITOR_STATE"
+  output=$(run_guard clients)
+  assert_contains "$output" $'0xabc\tFirstmateVisual\tPreview\t99\tCODEX-HEADLESS' \
+    "clients did not include FirstmateVisual client"
+  assert_not_contains "$output" "0xdef" "clients included non-Codex visible workspace client"
+  pass "fm-visual-guard.sh: clients reports only Codex visual clients"
+}
+
+test_browser_uses_independent_firstmate_visual_class() {
+  write_fake_tools
+  rm -f "$LOG" "$MONITOR_STATE"
+  run_guard browser "http://127.0.0.1:5173" >/dev/null || fail "browser failed"
+  assert_grep "'google-chrome-stable' '--class=FirstmateVisual'" "$LOG" \
+    "browser did not launch Chrome with FirstmateVisual class on workspace 99"
+  assert_grep "--user-data-dir=" "$LOG" "browser did not set an isolated user-data-dir"
+  pass "fm-visual-guard.sh: browser uses an independent FirstmateVisual Chrome launch"
+}
+
+test_exec_corrals_legacy_codex_visual_leak() {
+  local output
+  write_fake_tools
+  rm -f "$LOG" "$MONITOR_STATE"
+  : > "$LEAK_STATE"
+  output=$(run_guard exec -- xdg-open "https://example.test" 2>&1)
+  assert_absent "$LEAK_STATE" "legacy CodexVisual leak marker was not cleared"
+  assert_grep $'hyprctl\tdispatch\tmovetoworkspacesilent\t99,address:0xced' "$LOG" \
+    "guard did not move the legacy CodexVisual client off visible workspace 11"
+  assert_no_grep "99,address:0xdef" "$LOG" \
+    "guard tried to move the user's ordinary Chrome window"
+  assert_contains "$output" "moved Codex visual client 0xced" \
+    "guard did not report remediation of the legacy visible client"
+  pass "fm-visual-guard.sh: exec corrals legacy codex-visual-browser workspace leaks"
+}
+
+test_refuses_normal_user_workspace_by_default() {
+  local output code
+  write_fake_tools
+  rm -f "$LOG" "$MONITOR_STATE"
+  output=$(FM_VISUAL_TEST_LOG="$LOG" \
+    FM_VISUAL_TEST_MONITOR_STATE="$MONITOR_STATE" \
+    FM_VISUAL_HYPRCTL=hyprctl \
+    FM_VISUAL_GRIM=grim \
+    FM_VISUAL_WORKSPACE=11 \
+    PATH="$FAKEBIN:$PATH" \
+    "$ROOT/bin/fm-visual-guard.sh" ensure 2>&1)
+  code=$?
+  [ "$code" -ne 0 ] || fail "ensure unexpectedly accepted user workspace 11"
+  assert_contains "$output" "refusing to use user workspace '11'" \
+    "ensure did not explain the user-workspace refusal"
+  pass "fm-visual-guard.sh: refuses normal user workspace by default"
+}
+
+test_doctor_fails_when_hyprctl_missing() {
+  local output code
+  output=$(FM_VISUAL_HYPRCTL="$TMP_ROOT/no-hyprctl" "$ROOT/bin/fm-visual-guard.sh" doctor 2>&1)
+  code=$?
+  [ "$code" -ne 0 ] || fail "doctor unexpectedly passed without hyprctl"
+  assert_contains "$output" "missing required command: hyprctl" \
+    "doctor did not explain missing hyprctl"
+  pass "fm-visual-guard.sh: doctor fails clearly without hyprctl"
+}
+
+test_doctor_checks_screenshot_dependency() {
+  local output code
+  write_fake_tools
+  rm -f "$LOG" "$MONITOR_STATE"
+  output=$(FM_VISUAL_TEST_LOG="$LOG" \
+    FM_VISUAL_TEST_MONITOR_STATE="$MONITOR_STATE" \
+    FM_VISUAL_HYPRCTL=hyprctl \
+    FM_VISUAL_GRIM="$TMP_ROOT/no-grim" \
+    PATH="$FAKEBIN:$PATH" \
+    "$ROOT/bin/fm-visual-guard.sh" doctor 2>&1)
+  code=$?
+  [ "$code" -ne 0 ] || fail "doctor unexpectedly passed without grim"
+  assert_contains "$output" "missing required command: grim" \
+    "doctor did not explain missing grim"
+  pass "fm-visual-guard.sh: doctor fails clearly without grim"
+}
+
+test_exec_preserves_arguments_and_silent_workspace
+test_screenshot_routes_to_headless_output
+test_clients_filters_codex_visual_clients
+test_browser_uses_independent_firstmate_visual_class
+test_exec_corrals_legacy_codex_visual_leak
+test_refuses_normal_user_workspace_by_default
+test_doctor_fails_when_hyprctl_missing
+test_doctor_checks_screenshot_dependency

--- a/tests/fm-visual-guard.test.sh
+++ b/tests/fm-visual-guard.test.sh
@@ -10,6 +10,7 @@ FAKEBIN=$(fm_fakebin "$TMP_ROOT")
 LOG="$TMP_ROOT/calls.log"
 MONITOR_STATE="$TMP_ROOT/monitor-created"
 LEAK_STATE="$TMP_ROOT/leak-client"
+CLIENT_COUNT_STATE="$TMP_ROOT/client-count"
 
 write_fake_tools() {
   cat > "$FAKEBIN/hyprctl" <<'SH'
@@ -31,7 +32,34 @@ if [ "${1:-}" = "monitors" ] && [ "${2:-}" = "-j" ]; then
 fi
 
 if [ "${1:-}" = "clients" ] && [ "${2:-}" = "-j" ]; then
-  if [ -e "${FM_VISUAL_TEST_LEAK_STATE:-}" ]; then
+  count=0
+  [ -f "${FM_VISUAL_TEST_CLIENT_COUNT_STATE:-}" ] && count=$(cat "$FM_VISUAL_TEST_CLIENT_COUNT_STATE")
+  count=$((count + 1))
+  printf '%s\n' "$count" > "$FM_VISUAL_TEST_CLIENT_COUNT_STATE"
+
+  if [ "${FM_VISUAL_TEST_CLIENT_MODE:-}" = "late-leak" ]; then
+    if [ "$count" -lt 3 ]; then
+      cat <<'JSON'
+[
+  {"address":"0xdef","pid":12347,"class":"google-chrome","initialClass":"google-chrome","title":"User Chrome","workspace":{"id":1,"name":"1"},"monitor":"eDP-1"}
+]
+JSON
+    elif [ -e "${FM_VISUAL_TEST_LEAK_STATE:-}" ]; then
+      cat <<'JSON'
+[
+  {"address":"0xced","pid":12346,"class":"CodexVisual","initialClass":"CodexVisual","title":"Legacy","workspace":{"id":11,"name":"11"},"monitor":"eDP-1"},
+  {"address":"0xdef","pid":12347,"class":"google-chrome","initialClass":"google-chrome","title":"User Chrome","workspace":{"id":1,"name":"1"},"monitor":"eDP-1"}
+]
+JSON
+    else
+      cat <<'JSON'
+[
+  {"address":"0xced","pid":12346,"class":"CodexVisual","initialClass":"CodexVisual","title":"Legacy","workspace":{"id":99,"name":"99"},"monitor":"CODEX-HEADLESS"},
+  {"address":"0xdef","pid":12347,"class":"google-chrome","initialClass":"google-chrome","title":"User Chrome","workspace":{"id":1,"name":"1"},"monitor":"eDP-1"}
+]
+JSON
+    fi
+  elif [ -e "${FM_VISUAL_TEST_LEAK_STATE:-}" ]; then
     cat <<'JSON'
 [
   {"address":"0xabc","pid":12345,"class":"FirstmateVisual","initialClass":"FirstmateVisual","title":"Preview","workspace":{"id":99,"name":"99"},"monitor":"CODEX-HEADLESS"},
@@ -87,6 +115,7 @@ run_guard() {
     FM_VISUAL_TEST_LOG="$LOG" \
     FM_VISUAL_TEST_MONITOR_STATE="$MONITOR_STATE" \
     FM_VISUAL_TEST_LEAK_STATE="$LEAK_STATE" \
+    FM_VISUAL_TEST_CLIENT_COUNT_STATE="$CLIENT_COUNT_STATE" \
     FM_VISUAL_HYPRCTL=hyprctl \
     FM_VISUAL_GRIM=grim \
     FM_VISUAL_VERIFY_SLEEP=0 \
@@ -167,6 +196,37 @@ test_exec_corrals_legacy_codex_visual_leak() {
   pass "fm-visual-guard.sh: exec corrals legacy codex-visual-browser workspace leaks"
 }
 
+test_exec_exits_early_when_visual_clients_already_hidden() {
+  local count
+  write_fake_tools
+  rm -f "$LOG" "$MONITOR_STATE" "$LEAK_STATE" "$CLIENT_COUNT_STATE"
+  FM_VISUAL_VERIFY_ATTEMPTS=5 run_guard exec -- xdg-open "https://example.test" >/dev/null \
+    || fail "exec with already-hidden client failed"
+  count=$(cat "$CLIENT_COUNT_STATE")
+  [ "$count" -lt 5 ] || fail "verification exhausted attempts despite already-hidden client; clients calls=$count"
+  assert_no_grep $'hyprctl\tdispatch\tmovetoworkspacesilent' "$LOG" \
+    "guard moved a client even though every Codex visual client was already hidden"
+  pass "fm-visual-guard.sh: exits verification early after matching clients are already hidden"
+}
+
+test_exec_waits_for_late_visual_client_before_exiting() {
+  local count output
+  write_fake_tools
+  rm -f "$LOG" "$MONITOR_STATE" "$CLIENT_COUNT_STATE"
+  : > "$LEAK_STATE"
+  output=$(FM_VISUAL_TEST_CLIENT_MODE=late-leak FM_VISUAL_VERIFY_ATTEMPTS=6 run_guard exec -- xdg-open "https://example.test" 2>&1) \
+    || fail "exec with late-appearing client failed"
+  assert_absent "$LEAK_STATE" "late CodexVisual leak marker was not cleared"
+  count=$(cat "$CLIENT_COUNT_STATE")
+  [ "$count" -ge 3 ] || fail "verification exited before the late Codex visual client appeared; clients calls=$count"
+  [ "$count" -lt 6 ] || fail "verification did not exit after remediating the late Codex visual client; clients calls=$count"
+  assert_grep $'hyprctl\tdispatch\tmovetoworkspacesilent\t99,address:0xced' "$LOG" \
+    "guard did not move the late legacy CodexVisual client"
+  assert_contains "$output" "moved Codex visual client 0xced" \
+    "guard did not report remediation of the late visible client"
+  pass "fm-visual-guard.sh: keeps settling until a late visual client appears and is hidden"
+}
+
 test_refuses_normal_user_workspace_by_default() {
   local output code
   write_fake_tools
@@ -217,6 +277,8 @@ test_screenshot_routes_to_headless_output
 test_clients_filters_codex_visual_clients
 test_browser_uses_independent_firstmate_visual_class
 test_exec_corrals_legacy_codex_visual_leak
+test_exec_exits_early_when_visual_clients_already_hidden
+test_exec_waits_for_late_visual_client_before_exiting
 test_refuses_normal_user_workspace_by_default
 test_doctor_fails_when_hyprctl_missing
 test_doctor_checks_screenshot_dependency

--- a/tests/fm-visual-guard.test.sh
+++ b/tests/fm-visual-guard.test.sh
@@ -38,7 +38,14 @@ if [ "${1:-}" = "clients" ] && [ "${2:-}" = "-j" ]; then
   count=$((count + 1))
   printf '%s\n' "$count" > "$FM_VISUAL_TEST_CLIENT_COUNT_STATE"
 
-  if [ "${FM_VISUAL_TEST_CLIENT_MODE:-}" = "new-hidden" ]; then
+  if [ "${FM_VISUAL_TEST_CLIENT_MODE:-}" = "empty-fields" ]; then
+    cat <<'JSON'
+[
+  {"address":"0xempty","pid":null,"class":null,"initialClass":"FirstmateVisual","title":null,"workspace":{"id":99,"name":null},"monitor":9},
+  {"address":"0xdef","pid":12347,"class":"google-chrome","initialClass":"google-chrome","title":"User Chrome","workspace":{"id":1,"name":"1"},"monitor":0}
+]
+JSON
+  elif [ "${FM_VISUAL_TEST_CLIENT_MODE:-}" = "new-hidden" ]; then
     if [ -e "${FM_VISUAL_TEST_DISPATCH_STATE:-}" ]; then
       cat <<'JSON'
 [
@@ -49,6 +56,57 @@ JSON
     else
       cat <<'JSON'
 [
+  {"address":"0xdef","pid":12347,"class":"google-chrome","initialClass":"google-chrome","title":"User Chrome","workspace":{"id":1,"name":"1"},"monitor":"eDP-1"}
+]
+JSON
+    fi
+  elif [ "${FM_VISUAL_TEST_CLIENT_MODE:-}" = "new-hidden-delayed-sibling" ]; then
+    if [ ! -e "${FM_VISUAL_TEST_DISPATCH_STATE:-}" ]; then
+      cat <<'JSON'
+[
+  {"address":"0xdef","pid":12347,"class":"google-chrome","initialClass":"google-chrome","title":"User Chrome","workspace":{"id":1,"name":"1"},"monitor":"eDP-1"}
+]
+JSON
+    elif [ "$count" -lt 4 ]; then
+      cat <<'JSON'
+[
+  {"address":"0xabc","pid":12345,"class":"FirstmateVisual","initialClass":"FirstmateVisual","title":"Preview","workspace":{"id":99,"name":"99"},"monitor":"CODEX-HEADLESS"},
+  {"address":"0xdef","pid":12347,"class":"google-chrome","initialClass":"google-chrome","title":"User Chrome","workspace":{"id":1,"name":"1"},"monitor":"eDP-1"}
+]
+JSON
+    elif [ -e "${FM_VISUAL_TEST_LEAK_STATE:-}" ]; then
+      cat <<'JSON'
+[
+  {"address":"0xabc","pid":12345,"class":"FirstmateVisual","initialClass":"FirstmateVisual","title":"Preview","workspace":{"id":99,"name":"99"},"monitor":"CODEX-HEADLESS"},
+  {"address":"0xced","pid":12346,"class":"CodexVisual","initialClass":"CodexVisual","title":"Sibling","workspace":{"id":12,"name":"12"},"monitor":"eDP-1"},
+  {"address":"0xdef","pid":12347,"class":"google-chrome","initialClass":"google-chrome","title":"User Chrome","workspace":{"id":1,"name":"1"},"monitor":"eDP-1"}
+]
+JSON
+    else
+      cat <<'JSON'
+[
+  {"address":"0xabc","pid":12345,"class":"FirstmateVisual","initialClass":"FirstmateVisual","title":"Preview","workspace":{"id":99,"name":"99"},"monitor":"CODEX-HEADLESS"},
+  {"address":"0xced","pid":12346,"class":"CodexVisual","initialClass":"CodexVisual","title":"Sibling","workspace":{"id":99,"name":"99"},"monitor":"CODEX-HEADLESS"},
+  {"address":"0xdef","pid":12347,"class":"google-chrome","initialClass":"google-chrome","title":"User Chrome","workspace":{"id":1,"name":"1"},"monitor":"eDP-1"}
+]
+JSON
+    fi
+  elif [ "${FM_VISUAL_TEST_CLIENT_MODE:-}" = "misplaced-non-user" ]; then
+    if [ -e "${FM_VISUAL_TEST_LEAK_STATE:-}" ]; then
+      cat <<'JSON'
+[
+  {"address":"0x12","pid":12341,"class":"FirstmateVisual","initialClass":"FirstmateVisual","title":"Twelve","workspace":{"id":12,"name":"12"},"monitor":"eDP-1"},
+  {"address":"0x99","pid":12342,"class":"FirstmateVisual","initialClass":"FirstmateVisual","title":"Wrong output","workspace":{"id":99,"name":"99"},"monitor":"eDP-1"},
+  {"address":"0xspecial","pid":12343,"class":"CodexVisual","initialClass":"CodexVisual","title":"Named","workspace":{"id":-99,"name":"special:review"},"monitor":"eDP-1"},
+  {"address":"0xdef","pid":12347,"class":"google-chrome","initialClass":"google-chrome","title":"User Chrome","workspace":{"id":1,"name":"1"},"monitor":"eDP-1"}
+]
+JSON
+    else
+      cat <<'JSON'
+[
+  {"address":"0x12","pid":12341,"class":"FirstmateVisual","initialClass":"FirstmateVisual","title":"Twelve","workspace":{"id":99,"name":"99"},"monitor":"CODEX-HEADLESS"},
+  {"address":"0x99","pid":12342,"class":"FirstmateVisual","initialClass":"FirstmateVisual","title":"Wrong output","workspace":{"id":99,"name":"99"},"monitor":"CODEX-HEADLESS"},
+  {"address":"0xspecial","pid":12343,"class":"CodexVisual","initialClass":"CodexVisual","title":"Named","workspace":{"id":99,"name":"99"},"monitor":"CODEX-HEADLESS"},
   {"address":"0xdef","pid":12347,"class":"google-chrome","initialClass":"google-chrome","title":"User Chrome","workspace":{"id":1,"name":"1"},"monitor":"eDP-1"}
 ]
 JSON
@@ -224,6 +282,18 @@ test_clients_filters_codex_visual_clients() {
   pass "fm-visual-guard.sh: clients reports only Codex visual clients"
 }
 
+test_clients_preserves_empty_nullable_fields() {
+  local output
+  write_fake_tools
+  rm -f "$LOG" "$MONITOR_STATE" "$CLIENT_COUNT_STATE"
+  : > "$MONITOR_STATE"
+  output=$(FM_VISUAL_TEST_CLIENT_MODE=empty-fields run_guard clients)
+  assert_contains "$output" $'0xempty\tFirstmateVisual\t\t99\tCODEX-HEADLESS' \
+    "clients shifted nullable fields instead of preserving their columns"
+  assert_not_contains "$output" "0xdef" "clients included non-Codex visible workspace client"
+  pass "fm-visual-guard.sh: client records preserve empty nullable fields"
+}
+
 test_browser_uses_independent_firstmate_visual_class() {
   write_fake_tools
   rm -f "$LOG" "$MONITOR_STATE"
@@ -264,6 +334,42 @@ test_exec_exits_early_when_new_visual_client_is_hidden() {
   pass "fm-visual-guard.sh: exits verification early after a new matching client is hidden"
 }
 
+test_exec_settles_before_corralling_delayed_sibling() {
+  local count output
+  write_fake_tools
+  rm -f "$LOG" "$MONITOR_STATE" "$CLIENT_COUNT_STATE" "$DISPATCH_STATE"
+  : > "$LEAK_STATE"
+  output=$(FM_VISUAL_TEST_CLIENT_MODE=new-hidden-delayed-sibling FM_VISUAL_VERIFY_ATTEMPTS=8 \
+    run_guard exec -- xdg-open "https://example.test" 2>&1) \
+    || fail "exec with delayed sibling client failed"
+  assert_absent "$LEAK_STATE" "delayed sibling leak marker was not cleared"
+  count=$(cat "$CLIENT_COUNT_STATE")
+  [ "$count" -ge 4 ] || fail "verification exited before the delayed sibling appeared; clients calls=$count"
+  assert_grep $'hyprctl\tdispatch\tmovetoworkspacesilent\t99,address:0xced' "$LOG" \
+    "guard did not move the delayed sibling off workspace 12"
+  assert_contains "$output" "moved Codex visual client 0xced" \
+    "guard did not report remediation of the delayed sibling"
+  pass "fm-visual-guard.sh: verification settles before accepting hidden clients"
+}
+
+test_exec_corrals_matching_clients_from_any_misplaced_workspace() {
+  write_fake_tools
+  rm -f "$LOG" "$MONITOR_STATE" "$CLIENT_COUNT_STATE" "$DISPATCH_STATE"
+  : > "$LEAK_STATE"
+  FM_VISUAL_TEST_CLIENT_MODE=misplaced-non-user FM_VISUAL_VERIFY_ATTEMPTS=5 \
+    run_guard exec -- xdg-open "https://example.test" >/dev/null 2>&1 \
+    || fail "exec with non-user misplaced clients failed"
+  assert_grep $'hyprctl\tdispatch\tmovetoworkspacesilent\t99,address:0x12' "$LOG" \
+    "guard did not move matching client from workspace 12"
+  assert_grep $'hyprctl\tdispatch\tmovetoworkspacesilent\t99,address:0x99' "$LOG" \
+    "guard did not move matching workspace 99 client from the wrong output"
+  assert_grep $'hyprctl\tdispatch\tmovetoworkspacesilent\t99,address:0xspecial' "$LOG" \
+    "guard did not move matching client from a named workspace"
+  assert_no_grep "99,address:0xdef" "$LOG" \
+    "guard tried to move the user's ordinary Chrome window"
+  pass "fm-visual-guard.sh: corrals every matching misplaced client"
+}
+
 test_exec_ignores_preexisting_hidden_client_until_late_leak_appears() {
   local count output
   write_fake_tools
@@ -287,7 +393,7 @@ test_exec_accepts_numeric_monitor_id_for_headless_output() {
   write_fake_tools
   rm -f "$LOG" "$MONITOR_STATE" "$CLIENT_COUNT_STATE" "$DISPATCH_STATE"
   : > "$MONITOR_STATE"
-  output=$(FM_VISUAL_TEST_CLIENT_MODE=numeric-hidden FM_VISUAL_VERIFY_ATTEMPTS=1 \
+  output=$(FM_VISUAL_TEST_CLIENT_MODE=numeric-hidden FM_VISUAL_VERIFY_ATTEMPTS=3 \
     run_guard exec -- xdg-open "https://example.test" 2>&1) \
     || fail "exec rejected a hidden client reported with numeric monitor id"
   assert_contains "$output" "launched on workspace 99" \
@@ -345,9 +451,12 @@ test_doctor_checks_screenshot_dependency() {
 test_exec_preserves_arguments_and_silent_workspace
 test_screenshot_routes_to_headless_output
 test_clients_filters_codex_visual_clients
+test_clients_preserves_empty_nullable_fields
 test_browser_uses_independent_firstmate_visual_class
 test_exec_corrals_legacy_codex_visual_leak
 test_exec_exits_early_when_new_visual_client_is_hidden
+test_exec_settles_before_corralling_delayed_sibling
+test_exec_corrals_matching_clients_from_any_misplaced_workspace
 test_exec_ignores_preexisting_hidden_client_until_late_leak_appears
 test_exec_accepts_numeric_monitor_id_for_headless_output
 test_refuses_normal_user_workspace_by_default

--- a/tests/fm-visual-guard.test.sh
+++ b/tests/fm-visual-guard.test.sh
@@ -45,6 +45,21 @@ if [ "${1:-}" = "clients" ] && [ "${2:-}" = "-j" ]; then
   {"address":"0xdef","pid":12347,"class":"google-chrome","initialClass":"google-chrome","title":"User Chrome","workspace":{"id":1,"name":"1"},"monitor":0}
 ]
 JSON
+  elif [ "${FM_VISUAL_TEST_CLIENT_MODE:-}" = "new-hidden-on-final-poll" ]; then
+    if [ "$count" -lt 5 ]; then
+      cat <<'JSON'
+[
+  {"address":"0xdef","pid":12347,"class":"google-chrome","initialClass":"google-chrome","title":"User Chrome","workspace":{"id":1,"name":"1"},"monitor":"eDP-1"}
+]
+JSON
+    else
+      cat <<'JSON'
+[
+  {"address":"0xabc","pid":12345,"class":"FirstmateVisual","initialClass":"FirstmateVisual","title":"Preview","workspace":{"id":99,"name":"99"},"monitor":"CODEX-HEADLESS"},
+  {"address":"0xdef","pid":12347,"class":"google-chrome","initialClass":"google-chrome","title":"User Chrome","workspace":{"id":1,"name":"1"},"monitor":"eDP-1"}
+]
+JSON
+    fi
   elif [ "${FM_VISUAL_TEST_CLIENT_MODE:-}" = "new-hidden" ]; then
     if [ -e "${FM_VISUAL_TEST_DISPATCH_STATE:-}" ]; then
       cat <<'JSON'
@@ -352,6 +367,19 @@ test_exec_settles_before_corralling_delayed_sibling() {
   pass "fm-visual-guard.sh: verification settles before accepting hidden clients"
 }
 
+test_exec_fails_when_client_appears_on_final_poll() {
+  local output code
+  write_fake_tools
+  rm -f "$LOG" "$MONITOR_STATE" "$CLIENT_COUNT_STATE" "$DISPATCH_STATE"
+  output=$(FM_VISUAL_TEST_CLIENT_MODE=new-hidden-on-final-poll FM_VISUAL_VERIFY_ATTEMPTS=2 \
+    run_guard exec -- xdg-open "https://example.test" 2>&1)
+  code=$?
+  [ "$code" -ne 0 ] || fail "verification accepted a client first observed on the final poll"
+  assert_contains "$output" "did not remain hidden for 3 consecutive polls" \
+    "verification did not explain the incomplete settle interval"
+  pass "fm-visual-guard.sh: final-poll clients fail without a stable settle interval"
+}
+
 test_exec_corrals_matching_clients_from_any_misplaced_workspace() {
   write_fake_tools
   rm -f "$LOG" "$MONITOR_STATE" "$CLIENT_COUNT_STATE" "$DISPATCH_STATE"
@@ -456,6 +484,7 @@ test_browser_uses_independent_firstmate_visual_class
 test_exec_corrals_legacy_codex_visual_leak
 test_exec_exits_early_when_new_visual_client_is_hidden
 test_exec_settles_before_corralling_delayed_sibling
+test_exec_fails_when_client_appears_on_final_poll
 test_exec_corrals_matching_clients_from_any_misplaced_workspace
 test_exec_ignores_preexisting_hidden_client_until_late_leak_appears
 test_exec_accepts_numeric_monitor_id_for_headless_output

--- a/tests/fm-visual-guard.test.sh
+++ b/tests/fm-visual-guard.test.sh
@@ -12,6 +12,7 @@ MONITOR_STATE="$TMP_ROOT/monitor-created"
 LEAK_STATE="$TMP_ROOT/leak-client"
 CLIENT_COUNT_STATE="$TMP_ROOT/client-count"
 DISPATCH_STATE="$TMP_ROOT/dispatched"
+REAL_JQ=$(command -v jq)
 
 write_fake_tools() {
   cat > "$FAKEBIN/hyprctl" <<'SH'
@@ -37,6 +38,12 @@ if [ "${1:-}" = "clients" ] && [ "${2:-}" = "-j" ]; then
   [ -f "${FM_VISUAL_TEST_CLIENT_COUNT_STATE:-}" ] && count=$(cat "$FM_VISUAL_TEST_CLIENT_COUNT_STATE")
   count=$((count + 1))
   printf '%s\n' "$count" > "$FM_VISUAL_TEST_CLIENT_COUNT_STATE"
+
+  if [ "${FM_VISUAL_TEST_CLIENT_MODE:-}" = "query-failure" ] \
+    && [ -e "${FM_VISUAL_TEST_DISPATCH_STATE:-}" ]; then
+    printf 'client query failed\n' >&2
+    exit 1
+  fi
 
   if [ "${FM_VISUAL_TEST_CLIENT_MODE:-}" = "empty-fields" ]; then
     cat <<'JSON'
@@ -241,6 +248,18 @@ exit 0
 SH
   chmod +x "$FAKEBIN/hyprctl"
 
+  cat > "$FAKEBIN/jq" <<'SH'
+#!/usr/bin/env bash
+set -u
+if [ "${FM_VISUAL_TEST_JQ_FAIL_AFTER_DISPATCH:-0}" = 1 ] \
+  && [ -e "${FM_VISUAL_TEST_DISPATCH_STATE:-}" ]; then
+  printf 'jq parse failed\n' >&2
+  exit 1
+fi
+exec "$FM_VISUAL_TEST_REAL_JQ" "$@"
+SH
+  chmod +x "$FAKEBIN/jq"
+
   cat > "$FAKEBIN/grim" <<'SH'
 #!/usr/bin/env bash
 set -u
@@ -266,6 +285,7 @@ run_guard() {
     FM_VISUAL_TEST_LEAK_STATE="$LEAK_STATE" \
     FM_VISUAL_TEST_CLIENT_COUNT_STATE="$CLIENT_COUNT_STATE" \
     FM_VISUAL_TEST_DISPATCH_STATE="$DISPATCH_STATE" \
+    FM_VISUAL_TEST_REAL_JQ="$REAL_JQ" \
     FM_VISUAL_HYPRCTL=hyprctl \
     FM_VISUAL_GRIM=grim \
     FM_VISUAL_VERIFY_SLEEP=0 \
@@ -468,6 +488,36 @@ test_exec_accepts_numeric_monitor_id_for_headless_output() {
   pass "fm-visual-guard.sh: numeric monitor ids resolve to CODEX-HEADLESS"
 }
 
+test_exec_fails_closed_when_client_query_fails() {
+  local output code
+  write_fake_tools
+  rm -f "$LOG" "$MONITOR_STATE" "$CLIENT_COUNT_STATE" "$DISPATCH_STATE"
+  output=$(FM_VISUAL_TEST_CLIENT_MODE=query-failure \
+    run_guard exec -- xdg-open "https://example.test" 2>&1)
+  code=$?
+  [ "$code" -ne 0 ] || fail "verification succeeded after the client query failed"
+  assert_contains "$output" "hyprctl clients -j failed" \
+    "verification did not propagate the failed client query"
+  assert_not_contains "$output" "launched on workspace 99" \
+    "verification reported launch success after the client query failed"
+  pass "fm-visual-guard.sh: client query failures fail placement verification closed"
+}
+
+test_exec_fails_closed_when_jq_fails() {
+  local output code
+  write_fake_tools
+  rm -f "$LOG" "$MONITOR_STATE" "$CLIENT_COUNT_STATE" "$DISPATCH_STATE"
+  output=$(FM_VISUAL_TEST_JQ_FAIL_AFTER_DISPATCH=1 \
+    run_guard exec -- xdg-open "https://example.test" 2>&1)
+  code=$?
+  [ "$code" -ne 0 ] || fail "verification succeeded after jq failed"
+  assert_contains "$output" "jq parse failed" \
+    "verification did not propagate the jq failure"
+  assert_not_contains "$output" "launched on workspace 99" \
+    "verification reported launch success after jq failed"
+  pass "fm-visual-guard.sh: jq failures fail placement verification closed"
+}
+
 test_refuses_normal_user_workspace_by_default() {
   local output code
   write_fake_tools
@@ -526,6 +576,8 @@ test_exec_fails_when_client_appears_on_final_poll
 test_exec_corrals_matching_clients_from_any_misplaced_workspace
 test_exec_ignores_preexisting_hidden_client_until_late_leak_appears
 test_exec_accepts_numeric_monitor_id_for_headless_output
+test_exec_fails_closed_when_client_query_fails
+test_exec_fails_closed_when_jq_fails
 test_refuses_normal_user_workspace_by_default
 test_doctor_fails_when_hyprctl_missing
 test_doctor_checks_screenshot_dependency


### PR DESCRIPTION
## Intent

Fix Codex-owned browser leakage from Firstmate visual workflows. The branch adds bin/fm-visual-guard.sh, routes generated briefs/docs to use it, preserves user browser behavior, and hardens guarded launches with dedicated FirstmateVisual identity, legacy CodexVisual/codex-visual-browser coverage, Hyprland client remediation to hidden workspace 99 on CODEX-HEADLESS, post-dispatch client tracking, stable hidden settling before success, numeric monitor resolution, robust client-field parsing, and focused tests for the exact leak and settle regressions. It also includes the narrow session-start missing-node fixture isolation. The required report remains private at /home/avi/dev/tools/firstmate/data/codex-browser-workspace-leak-k8/report.md; no tracked report artifact should be added. The PR diff must stay scoped to the browser-isolation task files.

## What Changed

- Add a Hyprland-specific visual guard that launches isolated Firstmate browser sessions, remediates dedicated visual clients to workspace 99 on `CODEX-HEADLESS`, and fails closed unless placement remains stable.
- Route generated ship/scout briefs and operator documentation through the guard while documenting its platform scope, prerequisites, and commands.
- Add focused coverage for visual placement, remediation, settling, client parsing, and brief guidance, plus isolate missing-node session-start fixtures from the host `PATH`.

## Risk Assessment

✅ Low: Captain, the prior fail-open defect is fixed across all client-query paths, the regression coverage is deterministic, and the complete diff remains scoped to the required browser-isolation files with no tracked report artifact.

## Testing

The supplied full baseline and focused regression suites passed; a real guarded Chrome launch appeared as `FirstmateVisual` on workspace 99 / `CODEX-HEADLESS` while visible workspaces 1–3 remained unchanged. The locked host caused `grim` to capture black or the compositor lock surface rather than browser content, so no misleading screenshot is presented; the rendered HTML and exact live placement transcript are retained as evidence.

<details>
<summary>Evidence: Live visual-guard transcript</summary>

```text
Firstmate visual guard end-to-end validation

Command:
  bin/fm-visual-guard.sh doctor

Observed:
  ok: hyprctl
  ok: jq
  ok: grim
  ok: browser=google-chrome-stable
  ok: visual target output=CODEX-HEADLESS workspace=99 geometry=1440x1000@60,0x0,1 class=FirstmateVisual
  ok: workspace rule 99 -> CODEX-HEADLESS
  clients: (none)

Command:
  FM_VISUAL_VERIFY_ATTEMPTS=30 FM_VISUAL_VERIFY_SLEEP=0.2 bin/fm-visual-guard.sh browser file:///tmp/no-mistakes-evidence/01KXQ62Y2EQC3TPM62860V9HZ4/visual-guard-proof.html

Observed:
  launched on workspace 99: 'google-chrome-stable' '--class=FirstmateVisual' '--user-data-dir=/home/avi/.local/state/firstmate-codex-visual-chrome' '--no-first-run' '--no-default-browser-check' '--new-window' 'file:///tmp/no-mistakes-evidence/01KXQ62Y2EQC3TPM62860V9HZ4/visual-guard-proof.html'

Command:
  bin/fm-visual-guard.sh clients

Observed:
  0x5594496dd640  FirstmateVisual  Firstmate Visual Guard End-to-End Proof - Google Chrome  99  CODEX-HEADLESS

Hyprland client readback:
  address=0x5594496dd640
  mapped=true
  hidden=false
  class=FirstmateVisual
  initialClass=FirstmateVisual
  title=Firstmate Visual Guard End-to-End Proof - Google Chrome
  workspace.id=99
  workspace.name=99
  monitor.id=3
  monitor.name=CODEX-HEADLESS

Visible-workspace snapshot before launch:
  eDP-1      active workspace 1
  DVI-I-1    active workspace 2
  DVI-I-2    active workspace 3
  CODEX-HEADLESS active workspace 99

Visible-workspace snapshot after launch:
  eDP-1      active workspace 1
  DVI-I-1    active workspace 2
  DVI-I-2    active workspace 3
  CODEX-HEADLESS active workspace 99

Screenshot attempt:
  bin/fm-visual-guard.sh screenshot /tmp/no-mistakes-evidence/01KXQ62Y2EQC3TPM62860V9HZ4/firstmate-visual-guard-hidden.png

Observed:
  grim succeeded and produced a 1440x1000 PNG, but CODEX-HEADLESS had DPMS off because the host session was locked, so the image was all black. Turning on DPMS for only CODEX-HEADLESS made the compositor lock surface visible rather than the guarded Chrome content. No screenshot is presented as application evidence because the lock surface prevents a truthful browser rendering capture.
```
</details>
<details>
<summary>Evidence: Rendered browser proof page</summary>

```text
<!doctype html>
<html lang="en">
<head>
  <meta charset="utf-8">
  <meta name="viewport" content="width=device-width, initial-scale=1">
  <title>Firstmate Visual Guard End-to-End Proof</title>
  <style>
    :root { color-scheme: dark; font-family: ui-sans-serif, system-ui, sans-serif; }
    body { margin: 0; min-height: 100vh; display: grid; place-items: center; background: #07111f; color: #eaf2ff; }
    main { width: min(920px, calc(100vw - 96px)); padding: 56px; border: 1px solid #2f4b70; border-radius: 28px; background: linear-gradient(145deg, #101f35, #0a1627); box-shadow: 0 28px 90px #0008; }
    .eyebrow { color: #7dd3fc; font-weight: 700; letter-spacing: .13em; text-transform: uppercase; }
    h1 { margin: 16px 0 12px; font-size: clamp(38px, 6vw, 72px); line-height: .98; }
    p { font-size: 23px; line-height: 1.5; color: #c6d7ee; }
    .status { display: inline-flex; align-items: center; gap: 12px; margin-top: 24px; padding: 14px 20px; border-radius: 999px; background: #082f2b; color: #99f6e4; font-weight: 750; }
    .dot { width: 12px; height: 12px; border-radius: 50%; background: #2dd4bf; box-shadow: 0 0 24px #2dd4bf; }
    code { color: #fde68a; }
  </style>
</head>
<body>
  <main>
    <div class="eyebrow">Rendered end-to-end evidence</div>
    <h1>Firstmate visual guard</h1>
    <p>This real Chrome window was launched by <code>bin/fm-visual-guard.sh browser</code> and captured from the hidden <code>CODEX-HEADLESS</code> output.</p>
    <div class="status"><span class="dot"></span>Hidden workspace 99 · FirstmateVisual</div>
  </main>
</body>
</html>
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `bin/fm-visual-guard.sh:297` - Captain, `client_rows` is the producer in a pipeline whose final `while` loop determines the status, while the script enables no `pipefail`. A failed `hyprctl clients -j`, monitor query, or `jq` parse therefore becomes an empty client set; verification can subsequently report success without proving placement, potentially leaving a visible leak. Capture and validate `client_rows` before iterating, or otherwise propagate producer failures.

🔧 Fix: Fail closed on visual client query errors
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- <code>Supplied successful baseline: `command -v tmux &gt;/dev/null || { echo &#34;tmux is required for e2e tests&#34; &gt;&amp;2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo &#34;== $t ==&#34;; bash &#34;$t&#34; || rc=1; done; exit &#34;$rc&#34;`</code>
- `bash tests/fm-visual-guard.test.sh`
- `bash tests/fm-brief.test.sh`
- `bash tests/fm-session-start.test.sh`
- <code>Scope verification: `git diff --name-status 85643eec1f8cbe2136895c7dbe4277899f057348..7dc44534398c7cab0416c57c71daf372e2ee3c87` and tracked-report check</code>
- `bin/fm-visual-guard.sh doctor`
- `FM_VISUAL_VERIFY_ATTEMPTS=30 FM_VISUAL_VERIFY_SLEEP=0.2 bin/fm-visual-guard.sh browser file:///tmp/no-mistakes-evidence/01KXQ62Y2EQC3TPM62860V9HZ4/visual-guard-proof.html`
- <code>`bin/fm-visual-guard.sh clients` plus before/after `hyprctl` monitor, workspace, and client readbacks</code>
- <code>`bin/fm-visual-guard.sh screenshot /tmp/no-mistakes-evidence/01KXQ62Y2EQC3TPM62860V9HZ4/firstmate-visual-guard-hidden.png` and visual inspection</code>
- `Exact-address browser cleanup and verification that visible workspaces and DPMS state were restored`

</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `AGENTS.md:145` - The unconditional visual-guard rule conflicts with Firstmate&#39;s documented macOS support: the guard requires Hyprland/hyprctl. Resolving this requires either a non-Hyprland fallback/platform gate or intentionally narrowing platform support.

🔧 Fix: Scope visual guard docs to Hyprland workflows
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
