### PR TITLE
fix: align active-work wording with under way

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ This file is your entire job description.
 Address the user as "captain" at least once in every response.
 This is mandatory respectful address, not performance: it applies even when delivering bad news or relaying serious findings, such as "Captain, the build broke - ...".
 Do not force it into every sentence, but never send a response with zero direct address.
-Use light nautical seasoning only when it fits: the occasional "aye", "on deck", or "shipshape" may land naturally.
+Use light nautical seasoning only when it fits: the occasional "aye", "on deck", "shipshape", "under way", or "ahoy" may land naturally.
 Keep that seasoning optional and never let it obscure technical content; never use it in commits, briefs, PRs, or anything crewmates or other tools read; drop the playful flavor entirely when delivering bad news or relaying serious findings.
 For captain-facing escalation style and outcome phrasing, see section 9.
 
@@ -188,7 +188,7 @@ Its scope field drives routing and its project list is non-exclusive provisionin
 Keep `local-only` work in the main home.
 
 A secondmate is idle by default and acts only on work routed by the main firstmate.
-It reconciles its own in-flight work after restart, then waits silently; an empty queue never authorizes a survey, audit, or self-directed improvement sweep.
+It reconciles its own work under way after restart, then waits silently; an empty queue never authorizes a survey, audit, or self-directed improvement sweep.
 Do not reconstruct or supervise a secondmate's child tree from the main home.
 
 Route durable knowledge to its most specific owner:
@@ -212,7 +212,7 @@ The delivery lifecycle is an always-loaded operational contract; referenced scri
 ### Intake and authority
 
 Resolve the project independently for every request.
-An explicit project wins, a clear follow-up inherits its referent, and otherwise match the request against the registry, in-flight work, and project code or README.
+An explicit project wins, a clear follow-up inherits its referent, and otherwise match the request against the registry, work under way, and project code or README.
 Proceed on one confident match while naming the project in plain language; ask one concise question when multiple or no projects plausibly match.
 
 Route by the nature of the work against each registered secondmate scope, not by a non-exclusive clone list.
@@ -229,7 +229,7 @@ A diagnostic request, report, recommendation, or implementation-ready finding is
 Implementation requires a separate request or other clear implementation scope.
 Load `diagnostic-reasoning` before scoping a reported bug and before acting on a diagnostic report.
 
-Classify work as dispatchable when it does not overlap in-flight work, or queued and blocked when it touches the same project subsystem or depends on unlanded work.
+Classify work as dispatchable when it does not overlap work under way, or queued and blocked when it touches the same project subsystem or depends on unlanded work.
 Dispatch independent work immediately with no concurrency cap, serialize coarse overlaps, and record blockers durably.
 Write the task-specific brief under section 11 before spawning.
 
@@ -237,7 +237,7 @@ Write the task-specific brief under section 11 before spawning.
 
 Spawn only through `bin/fm-spawn.sh` after the profile and backend checks in section 4.
 The spawn must resolve a genuine isolated task worktree distinct from the primary checkout; a failed isolation assertion stops the task.
-After spawning, confirm the worker is processing the brief, handle any trust dialog through `harness-adapters`, and record ship or scout work as in flight.
+After spawning, confirm the worker is processing the brief, handle any trust dialog through `harness-adapters`, and record ship or scout work as under way.
 A persistent secondmate is recorded in the secondmate registry and runtime state, never as a backlog work item.
 
 Steer a worker with short single-line messages through fail-closed `fm-send`; put long instructions in a file.
@@ -294,7 +294,7 @@ Never force teardown without explicit discard authority.
 After successful teardown, record completion, retain only the configured recent Done history, and re-evaluate queued work whose blockers and time gates have cleared.
 
 A secondmate is persistent and an empty queue is healthy.
-Retire one only on an explicit captain or main-firstmate decision, after loading `secondmate-provisioning`; its home must contain no in-flight work, and forced discard still requires explicit captain authority.
+Retire one only on an explicit captain or main-firstmate decision, after loading `secondmate-provisioning`; its home must contain no work under way, and forced discard still requires explicit captain authority.
 
 ### Scout outcome and promotion
 
@@ -310,11 +310,11 @@ Scratch commits and debug edits never ride along, and a reproduced bug becomes t
 
 Fleet supervision is an always-loaded operational contract; `docs/architecture.md`, `docs/turnend-guard.md`, the emitted session-start block, and script help own mechanisms and harness-specific recipes.
 
-Whenever work is in flight, keep exactly one live supervision cycle using the emitted protocol for this primary harness.
+Whenever work is under way, keep exactly one live supervision cycle using the emitted protocol for this primary harness.
 X mode may require that same live cycle with no fleet work.
 Do not substitute another harness's wait shape, use shell `&`, or create a second cycle when a healthy one already exists.
 After every actionable wake, resume the emitted protocol as the final action before ending the turn.
-No turn ends blind while work is in flight, including turns described as holding or waiting.
+No turn ends blind while work is under way, including turns described as holding or waiting.
 
 At the start of every wake-handling turn, drain the durable wake queue before peeking, reading beyond the reason line, steering, or starting work.
 Session start is the only exception because its one-shot digest already drained while locked or deliberately left the queue untouched in lock-refused read-only mode.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Launching a supported harness inside it instantiates your first mate - and makes
 - **Two task shapes** - ship tasks deliver a change; scout tasks investigate, plan, reproduce, or audit and leave a report.
 - **Explicit project modes** - each project ships via `no-mistakes`, `direct-PR`, or `local-only`, with an optional `+yolo` autonomy flag.
 - **Optional secondmates** - opt in to persistent domain supervisors that run from isolated firstmate homes with their own `FM_HOME`, state, projects, and session lock, supervising project clones or a project-less firstmate-repo domain, kept on the primary firstmate version by guarded local fast-forwards and checked for live agent processes at session start.
-- **Event-driven, zero-token supervision** - a bash watcher sleeps on the fleet and wakes the first mate only when something needs you; verified primary harnesses also get a turn-end backstop that blocks or follows up on a blind stop when work is in flight and supervision is not live.
+- **Event-driven, zero-token supervision** - a bash watcher sleeps on the fleet and wakes the first mate only when something needs you; verified primary harnesses also get a turn-end backstop that blocks or follows up on a blind stop when work is under way and supervision is not live.
 - **Optional X mode** - opt in with one local `.env` token so firstmate can answer your public `@myfirstmate` mentions, act on normal reversible mention requests through the same lifecycle as chat requests, acknowledge spawned work, and post up to three public-safe completion follow-ups within seven days for genuine milestones and the final outcome without changing non-X behavior; dry-run preview records would-be replies and dismissals locally before go-live.
 - **Guarded by construction** - the first mate is read-only over your projects outside guarded clone refreshes, safe branch pruning, and approved `local-only` fast-forward merges; crewmates make every project change behind the configured merge authority.
 - **Restart-proof** - all state lives on disk and in the active session backend (tmux by hard default, herdr or cmux when selected or auto-detected, zellij/orca when explicitly selected); kill the session anytime and the next one reconciles, including confirmed-dead secondmate agents, and carries on.
@@ -163,7 +163,7 @@ Claude and grok use the slash form shown here; codex uses the same names with `$
 
 | Skill              | What it does                                                                                                                                  |
 | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| `/afk`             | Enter away-mode supervision: the sub-supervisor self-handles routine wakes in bash, escalates captain-relevant events and bounded declared-external-wait rechecks as batched digests, and actively alerts if delivery wedges while you step away |
+| `/afk`             | Enter away-mode supervision: the sub-supervisor self-handles routine notifications in bash, escalates captain-relevant events and bounded declared-external-wait rechecks as batched digests, and actively alerts if delivery gets stuck while you step away |
 | `/bearings`        | Generate a standalone current-status report from bounded local fleet and registered-secondmate state, with live PR enrichment only when requested, written to a dated file in `data/` and surfaced concisely in chat; read-mostly, mutates no task state |
 | `/updatefirstmate` | Self-update the running firstmate and its secondmates to the latest from origin with fast-forward-only pulls, then re-read instructions and nudge secondmates |
 | `/stow`            | Sweep the session for uncaptured durable knowledge, route each finding to its disk home per AGENTS.md, file undone next steps to the backlog, and report what is now safe to reset |
@@ -184,7 +184,7 @@ Firstmate's skills live in two separate places with different audiences:
 
 - [docs/architecture.md](docs/architecture.md) - how the crew, supervision, worktrees, secondmates, and project modes work.
 - [docs/configuration.md](docs/configuration.md) - environment variables, `FM_HOME`, runtime backend selection, optional X mode, the files you set, and harness support.
-- [docs/wedge-alarm.md](docs/wedge-alarm.md) - configure the active alert for a wedged away-mode escalation delivery.
+- [docs/wedge-alarm.md](docs/wedge-alarm.md) - configure the active alert for an away-mode escalation delivery that gets stuck.
 - [docs/tmux-backend.md](docs/tmux-backend.md) - setup guide for the tmux reference backend: prerequisites, attaching, and watching crew windows.
 - [docs/herdr-backend.md](docs/herdr-backend.md) - setup guide for the experimental herdr backend, plus its verification notes and known gaps.
 - [docs/zellij-backend.md](docs/zellij-backend.md) - setup guide for the experimental zellij backend, plus its verification notes and known gaps.

--- a/bin/fm-fleet-view.sh
+++ b/bin/fm-fleet-view.sh
@@ -64,7 +64,7 @@ printf '%s\n' "$SNAPSHOT" | jq -r '
   "Schema: \(.schema)",
   "Home: \(.fm_home)",
   "",
-  "## In Flight",
+  "## Under Way",
   (if (.tasks | length) == 0 then
     "No live task metadata found."
    else

--- a/bin/fm-session-start.sh
+++ b/bin/fm-session-start.sh
@@ -336,7 +336,7 @@ print_file_or_absent "$DATA/learnings.md" "data/learnings.md"
 section "FLEET STATE"
 print_backlog_compact "$DATA/backlog.md" "data/backlog.md"
 
-subsection "In-flight tasks (state/*.meta)"
+subsection "Work under way (state/*.meta)"
 META_FOUND=0
 for meta in "$STATE"/*.meta; do
   [ -f "$meta" ] || continue


### PR DESCRIPTION
## Intent

Implement exactly Option B of the nautical-lexicon audit in firstmate's shared tracked material. Replace prose uses of in-flight or in flight that describe active work with the consistent term under way in AGENTS.md and README.md, using work under way attributively. Extend only the existing AGENTS.md sanctioned seasoning list with under way and ahoy, preserving it as the single curated flavor-lexicon owner. Replace the two captain-facing README jargon leaks so wakes becomes notifications and wedges or wedged becomes plain English such as gets stuck or a stuck delivery. After re-verifying that they are display-only and unparsed, align the bin/fm-fleet-view.sh and bin/fm-session-start.sh display headings with under way. Keep the diff tight and near 1:1, preserve one sentence per Markdown line and plain dashes, and keep both scripts shellcheck-clean. Do not rename the machine-parsed tasks-axi backlog heading ## In flight, any identifier such as FM_SUP_IN_FLIGHT, script name, machine-parsed string, state or metadata vocabulary, or section 9 translation-table left-column term. Option C is explicitly rejected. Validate with shellcheck and bin/fm-lint.sh, do not merge, and stop at a green PR.

## What Changed
- Replaces prose references to active work as in-flight/in flight with under way or work under way while preserving protected parsed vocabulary.
- Extends the AGENTS.md optional seasoning list with under way and ahoy as the curated flavor-lexicon owner.
- Updates captain-facing README wording and display-only fleet/session headings to use notifications, gets stuck, and Under Way language.

## Risk Assessment

✅ Low: Captain, the diff is narrow, source-only, and conforms to the stated Option B lexical constraints without touching protected parsed vocabulary.

## Testing

The configured baseline was already reported green before this step; on the target commit I reran the prior failing Zellij smoke test, the two relevant script suites, and the full configured `tests/*.test.sh` loop successfully, then captured CLI evidence showing `fm-fleet-view` renders `## Under Way` while the JSON contract remains `in_flight`, and `fm-session-start` preserves the parsed `## In flight` backlog heading while rendering `Work under way (state/*.meta)`.

<details>
<summary>Evidence: fm-fleet-view human output and JSON contract evidence</summary>

```text
### fm-fleet-view human output
# Fleet View

Schema: fm-fleet-snapshot.v1
Home: /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KXQ5ZC7595A8PNGS3MTWR0C7/fm-home

## Under Way
| ID | Current | Kind | Repo/Project | Backend | Endpoint | Artifact | Path | Watch / return channel |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| active-task | working / status-log | ship | sample | tmux | present | - | /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KXQ5ZC7595A8PNGS3MTWR0C7/fm-home/projects/sample | bin/fm-peek.sh fm-active-task |

## Queued
| ID | Title | Repo | Kind | Blocked By | Artifact |
| --- | --- | --- | --- | --- | --- |
| queued-task | Queued Task | sample | scout | - | - |

## Done
No done backlog records found.

## Secondmates
For kind=secondmate, bearings selects validated structured state from that registered home; parent events and bounded terminal evidence are fallback-only supplements and never current-state authority.

### fm-fleet-view underlying machine JSON summary
{
  "backlog_states": [
    "in_flight",
    "queued"
  ],
  "task_ids": [
    "active-task"
  ]
}
```
</details>
<details>
<summary>Evidence: fm-session-start backlog and state heading evidence</summary>

```text
### fm-session-start selected user-visible lines (manual backlog backend)
data/backlog.md
compact backlog listing (manual backend; max 20 item(s); indented task bodies omitted)
## In flight
Full task bodies remain available on demand: tasks-axi show <id> --full when compatible tasks-axi is available, or data/backlog.md.
Work under way (state/*.meta)
--- active-task ---
endpoint: alive (backend=tmux window=firstmate:fm-active-task)
working: validating display wording
Do NOT bulk-read data/backlog.md now either: the compact identity/metadata
```
</details>
- Outcome: 🔧 1 issue found → auto-fixed ✅ across 2 runs (1h30m41s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed ✅</summary>

- 🚨 tests failed with exit code 1
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`

🔧 Fix: Verify transient Zellij smoke flake
✅ Re-checked - no issues remain.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- <code>Inspected the target diff with `git diff --color=never 85643eec1f8cbe2136895c7dbe4277899f057348..51ef870906361a2d2e9c064ccf09539901b1b7a0 -- AGENTS.md README.md bin/fm-fleet-view.sh bin/fm-session-start.sh`.</code>
- <code>Checked changed and protected vocabulary with `rg -n &#34;in[- ]flight|In[- ]flight|In flight|wakes|wedges|wedged|under way|ahoy|FM_SUP_IN_FLIGHT|## In flight&#34; AGENTS.md README.md bin/fm-fleet-view.sh bin/fm-session-start.sh` and repo-wide `rg -n &#34;In flight|in flight|in-flight|FM_SUP_IN_FLIGHT|under way&#34; .`.</code>
- <code>Ran `bash tests/fm-backend-zellij-smoke.test.sh`.</code>
- <code>Generated reviewer-visible evidence by running `bin/fm-fleet-view.sh` and `bin/fm-fleet-view.sh --json` against an evidence FM_HOME fixture.</code>
- <code>Generated reviewer-visible evidence by running `bin/fm-session-start.sh` against a manual-backend evidence FM_HOME fixture.</code>
- <code>Ran `bash tests/fm-fleet-snapshot-view.test.sh`.</code>
- <code>Ran `bash tests/fm-session-start.test.sh`.</code>
- <code>Ran the full configured test loop: `command -v tmux &gt;/dev/null || { echo &#34;tmux is required for e2e tests&#34; &gt;&amp;2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo &#34;== $t ==&#34;; bash &#34;$t&#34; || rc=1; done; exit &#34;$rc&#34;`.</code>
- <code>Checked cleanup with `git status --short` and a transient-artifact `find` scan in the worktree.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
