### PR TITLE
feat: add durable Telegram topic board

### DIFF
--- a/.agents/skills/topic-board/SKILL.md
+++ b/.agents/skills/topic-board/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: topic-board
+description: >-
+  Agent-only procedure for handling durable Telegram topic-board messages and linked worker returns.
+user-invocable: false
+metadata:
+  internal: true
+---
+
+# Telegram topic board
+
+Load this skill on a `check: topic-board: topic-message ...` wake and before acting on a worker return that names a `topic-item`.
+The durable item and its local topic map are authoritative for origin and routing.
+
+## Intake
+
+1. Drain the normal firstmate wake queue before inspecting the topic inbox, as required by the supervision contract.
+2. Run `bin/fm-topic-inbox.sh list` and inspect every listed item with `bin/fm-topic-inbox.sh show <update-id>`.
+3. Claim an item before starting work with `bin/fm-topic-inbox.sh claim <update-id> <owner>`.
+4. Use `main` as the owner for work handled directly, or use the routed secondmate or task id for delegated work.
+5. Include the exact marker `topic-item <update-id>` in routed instructions and require that marker in every milestone or terminal return.
+
+The listener retains claimed items in the inbox until a successful answer is recorded.
+Never delete or bulk-clear inbox files.
+
+## Routing
+
+Read each item's `route` field.
+For `lmoon-mate` or `koru-mate`, load `secondmate-provisioning`, route the request to that secondmate, and include the `topic-item` marker.
+For `main`, handle the request under the normal firstmate project and task lifecycle.
+For an unknown route, stop safely and treat it as `main` only after reporting that the local map needs correction.
+
+An optional acknowledgement may be sent without closing the item by using a stable follow-up key such as `acknowledgement`.
+The worker's actual outcome must still be returned into the originating topic.
+
+## Reply
+
+Write captain-facing response text to a private temporary file, then use the tracked sender so shell interpolation cannot alter the message.
+
+```bash
+bin/fm-topic-reply.sh <update-id> --text-file <private-response-file>
+```
+
+A successful initial reply archives the item as answered.
+For later milestones or completion updates, use a stable idempotency key against the archived item.
+
+```bash
+bin/fm-topic-reply.sh <update-id> --follow-up completion --text-file <private-response-file>
+```
+
+If the sender reports that delivery is unknown, inspect the originating Telegram topic before choosing either `--confirm-sent` or `--retry-unknown`.
+Never retry an ambiguous send automatically because Telegram has no idempotency key for `sendMessage`.
+
+## Safety
+
+This feature owns only the separate topic-board bot configured under `data/fm-telegram-topics/`.
+Never point it at the direct-message firstmate bot or touch that bot's plugin poller.
+Telegram permits only one `getUpdates` consumer per token, so sharing the direct-message token would let the topic listener steal the captain's lifeline messages.

--- a/.opencode/plugins/fm-primary-watch-arm.js
+++ b/.opencode/plugins/fm-primary-watch-arm.js
@@ -95,6 +95,9 @@ async function isPrimaryRoot(root, home) {
 function shouldArm(paths) {
   if (existsSync(`${paths.state}/.afk`)) return false;
   if (existsSync(`${paths.config}/x-mode.env`)) return true;
+  const topicData = process.env.FM_TOPIC_DATA_DIR || `${paths.home}/data/fm-telegram-topics`;
+  if (process.env.FM_TOPIC_CONFIG && existsSync(process.env.FM_TOPIC_CONFIG)) return true;
+  if (existsSync(`${topicData}/config.env`) || existsSync(`${topicData}/test-bot-token.txt`)) return true;
   try {
     return readdirSync(paths.state).some((name) => name.endsWith(".meta"));
   } catch {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -312,6 +312,7 @@ Fleet supervision is an always-loaded operational contract; `docs/architecture.m
 
 Whenever work is under way, keep exactly one live supervision cycle using the emitted protocol for this primary harness.
 X mode may require that same live cycle with no fleet work.
+A configured Telegram topic board requires that same live cycle with no fleet work.
 Do not substitute another harness's wait shape, use shell `&`, or create a second cycle when a healthy one already exists.
 After every actionable wake, resume the emitted protocol as the final action before ending the turn.
 No turn ends blind while work is under way, including turns described as holding or waiting.
@@ -330,6 +331,7 @@ Handle actionable wakes as follows:
 
 When any wake reports a merged PR for a project cloned in this home, refresh that clone through the guarded fleet-sync path.
 When X-linked work reaches a milestone or terminal state, load `fmx-respond`; before terminal teardown, always post the final completion follow-up so the link clears even if earlier follow-ups were spent.
+On a `topic-board` check wake or a return that names a `topic-item`, load `topic-board` before routing or replying.
 
 A secondmate's idle endpoint is healthy, and parent supervision relies on its routed status rather than treating a quiet pane as stale.
 Waiting on a healthy supervision cycle is silent; empty polls, elapsed time, and no-change updates are not captain-facing progress.
@@ -456,6 +458,7 @@ These skills are not captain-invocable; load them only at their precise triggers
 - `secondmate-provisioning` - load before creating, seeding, validating, launching, handing backlog to, recovering, pushing inherited local material into, or retiring a secondmate home, and before editing `data/secondmates.md`.
 - `decision-hold-lifecycle` - load before treating an investigation or visual review as complete, before ending a visual review that exposed a decision, and when recording or routing the captain's answer.
 - `fmx-respond` - load on an `x-mention <request_id>` `check:` wake to handle the mention, on an `x-mode-error ...` `check:` wake to report the X-mode configuration blocker, and on any milestone or terminal wake for an X-mode-linked task before posting its completion follow-up; relevant only when X mode is on.
+- `topic-board` - load on a `topic-board` `check:` wake and before handling a worker return that names a `topic-item`.
 - `firstmate-codexapp` - load before coordinating a visible Codex Desktop thread, evaluating a Codex App backend request, or reconciling Codex Desktop host-tool smoke evidence for Firstmate work.
 - `firstmate-coding-guidelines` - load before changing firstmate's shared, tracked material, as defined by section 1's list, whether editing directly or briefing a crewmate for a firstmate-repo task.
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Launching a supported harness inside it instantiates your first mate - and makes
 - **Optional secondmates** - opt in to persistent domain supervisors that run from isolated firstmate homes with their own `FM_HOME`, state, projects, and session lock, supervising project clones or a project-less firstmate-repo domain, kept on the primary firstmate version by guarded local fast-forwards and checked for live agent processes at session start.
 - **Event-driven, zero-token supervision** - a bash watcher sleeps on the fleet and wakes the first mate only when something needs you; verified primary harnesses also get a turn-end backstop that blocks or follows up on a blind stop when work is under way and supervision is not live.
 - **Optional X mode** - opt in with one local `.env` token so firstmate can answer your public `@myfirstmate` mentions, act on normal reversible mention requests through the same lifecycle as chat requests, acknowledge spawned work, and post up to three public-safe completion follow-ups within seven days for genuine milestones and the final outcome without changing non-X behavior; dry-run preview records would-be replies and dismissals locally before go-live.
+- **Optional Telegram topic board** - run a dedicated forum bot as a persistent long-poll service so project messages are retained, routed by topic, and answered back into their originating thread without sharing or risking the direct-message bot token.
 - **Guarded by construction** - the first mate is read-only over your projects outside guarded clone refreshes, safe branch pruning, and approved `local-only` fast-forward merges; crewmates make every project change behind the configured merge authority.
 - **Restart-proof** - all state lives on disk and in the active session backend (tmux by hard default, herdr or cmux when selected or auto-detected, zellij/orca when explicitly selected); kill the session anytime and the next one reconciles, including confirmed-dead secondmate agents, and carries on.
 
@@ -183,8 +184,9 @@ Firstmate's skills live in two separate places with different audiences:
 ## Documentation
 
 - [docs/architecture.md](docs/architecture.md) - how the crew, supervision, worktrees, secondmates, and project modes work.
-- [docs/configuration.md](docs/configuration.md) - environment variables, `FM_HOME`, runtime backend selection, optional X mode, the files you set, and harness support.
-- [docs/wedge-alarm.md](docs/wedge-alarm.md) - configure the active alert for an away-mode escalation delivery that gets stuck.
+- [docs/configuration.md](docs/configuration.md) - environment variables, `FM_HOME`, runtime backend selection, optional X mode, the optional Telegram topic board, the files you set, and harness support.
+- [docs/topic-board.md](docs/topic-board.md) - real-time Telegram topics, durable inbox and replies, project routing, service setup, and direct-message lifeline safety.
+- [docs/wedge-alarm.md](docs/wedge-alarm.md) - configure the active alert for a wedged away-mode escalation delivery.
 - [docs/tmux-backend.md](docs/tmux-backend.md) - setup guide for the tmux reference backend: prerequisites, attaching, and watching crew windows.
 - [docs/herdr-backend.md](docs/herdr-backend.md) - setup guide for the experimental herdr backend, plus its verification notes and known gaps.
 - [docs/zellij-backend.md](docs/zellij-backend.md) - setup guide for the experimental zellij backend, plus its verification notes and known gaps.

--- a/bin/fm-guard.sh
+++ b/bin/fm-guard.sh
@@ -5,8 +5,8 @@
 # First, always warn if the firstmate primary checkout (FM_ROOT) is on a named
 # non-default branch, because that means firstmate-on-itself work landed in the
 # primary instead of an isolated worktree.
-# Then, if any task is in flight (a state/<id>.meta exists) and the watcher's
-# liveness beacon (state/.last-watcher-beat, touched every poll cycle) is
+# Then, if any task is in flight or the Telegram topic board is enabled and the
+# watcher's liveness beacon (state/.last-watcher-beat, touched every poll cycle) is
 # missing or older than FM_GUARD_GRACE seconds, prints a loud, clearly delimited
 # banner so the agent cannot skim past it in the tool output of whatever it was
 # doing - the one channel every harness has. The full banner is emitted once per
@@ -140,18 +140,17 @@ if [ -n "$tangle_branch" ]; then
   } >&2
 fi
 
-# Compute in-flight count and watcher-beacon freshness via the shared
-# grace-based predicate (bin/fm-supervision-lib.sh). Only act with tasks in
-# flight; count them so the banner can say how much is riding on an absent
-# watcher.
-fm_supervision_status "$STATE" "$GRACE"
+# Compute supervision demand and watcher-beacon freshness via the shared
+# grace-based predicate (bin/fm-supervision-lib.sh).
+fm_supervision_status "$STATE" "$GRACE" "$FM_HOME"
 in_flight=$FM_SUP_IN_FLIGHT
+topic_board=$FM_SUP_TOPIC_BOARD
 watcher_fresh=$FM_SUP_WATCHER_FRESH
 beacon_desc=$FM_SUP_BEACON_DESC
-if [ "$in_flight" -eq 0 ]; then
-  # Leave the unhealthy state (no work riding on the watcher): clear so a later
-  # in-flight + stale combination is a fresh episode even if the beacon is still
-  # absent with the same key string.
+if [ "$FM_SUP_REQUIRED" = false ]; then
+  # Leave the unhealthy state: clear so a later supervision-required plus stale
+  # combination is a fresh episode even if the beacon is still absent with the
+  # same key string.
   [ "$READ_ONLY" -eq 1 ] || fm_guard_clear_stale_banner
   exit 0
 fi
@@ -177,17 +176,26 @@ if [ "$watcher_fresh" = false ]; then
     "$queue_pending" && queue_arg=1
     x_mode=0
     [ -f "$CONFIG/x-mode.env" ] && x_mode=1
+    topic_arg=0
+    [ "$topic_board" = true ] && topic_arg=1
     fix=$("$SCRIPT_DIR/fm-supervision-instructions.sh" \
       --read-only "$READ_ONLY" \
       --afk "$afk" \
       --x-mode "$x_mode" \
+      --topic-board "$topic_arg" \
       --queue-pending "$queue_arg" \
       --repair-line 2>/dev/null || printf '%s\n' 'Resume supervision according to the session-start operating block.')
     rule='━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'
     {
       printf '●%s\n' "$rule"
       printf '●  WATCHER DOWN - SUPERVISION IS OFF\n'
-      printf '●  %s task(s) in flight, but no watcher has a fresh beacon (last beat: %s, grace %ss).\n' "$in_flight" "$beacon_desc" "$GRACE"
+      if [ "$topic_board" = true ] && [ "$in_flight" -gt 0 ]; then
+        printf '●  %s task(s) and the Telegram topic board need supervision, but no watcher has a fresh beacon (last beat: %s, grace %ss).\n' "$in_flight" "$beacon_desc" "$GRACE"
+      elif [ "$topic_board" = true ]; then
+        printf '●  The Telegram topic board needs supervision, but no watcher has a fresh beacon (last beat: %s, grace %ss).\n' "$beacon_desc" "$GRACE"
+      else
+        printf '●  %s task(s) in flight, but no watcher has a fresh beacon (last beat: %s, grace %ss).\n' "$in_flight" "$beacon_desc" "$GRACE"
+      fi
       if [ "$READ_ONLY" -eq 1 ]; then
         printf '●  This read-only session should report the lapse, not repair it.\n'
       else

--- a/bin/fm-session-start.sh
+++ b/bin/fm-session-start.sh
@@ -304,6 +304,13 @@ AFK_PRESENT=0
 [ -e "$STATE/.afk" ] && AFK_PRESENT=1
 X_MODE_PRESENT=0
 [ -f "$CONFIG/x-mode.env" ] && X_MODE_PRESENT=1
+TOPIC_BOARD_PRESENT=0
+TOPIC_DATA_PRESENT="${FM_TOPIC_DATA_DIR:-$DATA/fm-telegram-topics}"
+if { [ -n "${FM_TOPIC_CONFIG:-}" ] && [ -f "$FM_TOPIC_CONFIG" ]; } \
+  || [ -f "$TOPIC_DATA_PRESENT/config.env" ] \
+  || [ -f "$TOPIC_DATA_PRESENT/test-bot-token.txt" ]; then
+  TOPIC_BOARD_PRESENT=1
+fi
 
 if [ "$PRIMARY_HARNESS" = pi ]; then
   PI_EXT="$FM_ROOT/.pi/extensions/fm-primary-pi-watch.ts"
@@ -322,7 +329,8 @@ fi
   --harness "$PRIMARY_HARNESS" \
   --read-only "$READ_ONLY" \
   --afk "$AFK_PRESENT" \
-  --x-mode "$X_MODE_PRESENT"
+  --x-mode "$X_MODE_PRESENT" \
+  --topic-board "$TOPIC_BOARD_PRESENT"
 
 # --- 4. context digest -----------------------------------------------------
 section "CONTEXT"
@@ -402,10 +410,10 @@ load /afk and ensure the daemon is running, because the daemon owns watcher
 supervision.
 
 EOF
-elif [ -f "$CONFIG/x-mode.env" ]; then
+elif [ -f "$CONFIG/x-mode.env" ] || [ "$TOPIC_BOARD_PRESENT" -eq 1 ]; then
   cat <<EOF
 Follow the supervision operating instructions block above for harness '$PRIMARY_HARNESS'.
-X mode is active, so the emitted block's cadence instruction applies.
+Any active X-mode cadence and topic-board supervision instructions in that block apply.
 This script never starts supervision itself.
 
 EOF

--- a/bin/fm-supervision-instructions.sh
+++ b/bin/fm-supervision-instructions.sh
@@ -14,12 +14,13 @@ HARNESS=
 READ_ONLY=0
 AFK=0
 X_MODE=0
+TOPIC_BOARD=0
 REPAIR_LINE=0
 QUEUE_PENDING=0
 
 usage() {
   cat <<'EOF'
-Usage: fm-supervision-instructions.sh [--harness <name>] [--read-only 0|1] [--afk 0|1] [--x-mode 0|1] [--repair-line] [--queue-pending 0|1]
+Usage: fm-supervision-instructions.sh [--harness <name>] [--read-only 0|1] [--afk 0|1] [--x-mode 0|1] [--topic-board 0|1] [--repair-line] [--queue-pending 0|1]
 
 Print the current primary harness's supervision operating instructions.
 With --repair-line, print one concise repair instruction for guard and hook messages.
@@ -53,6 +54,11 @@ while [ "$#" -gt 0 ]; do
     --x-mode)
       [ "$#" -gt 1 ] || { echo "error: --x-mode requires 0 or 1" >&2; exit 2; }
       X_MODE=$(bool_value "$2")
+      shift 2
+      ;;
+    --topic-board)
+      [ "$#" -gt 1 ] || { echo "error: --topic-board requires 0 or 1" >&2; exit 2; }
+      TOPIC_BOARD=$(bool_value "$2")
       shift 2
       ;;
     --queue-pending)
@@ -90,6 +96,7 @@ checkpoint_seconds=${FM_CODEX_WATCH_CHECKPOINT:-180}
 pi_ext="$FM_ROOT/.pi/extensions/fm-primary-pi-watch.ts"
 pi_turnend_ext="$FM_ROOT/.pi/extensions/fm-primary-turnend-guard.ts"
 x_mode_env="$CONFIG/x-mode.env"
+topic_data="${FM_TOPIC_DATA_DIR:-$FM_HOME/data/fm-telegram-topics}"
 
 shell_quote() {
   printf "'"
@@ -101,6 +108,9 @@ x_mode_env_sh=$(shell_quote "$x_mode_env")
 
 if [ "$X_MODE" -eq 0 ] && [ -f "$x_mode_env" ]; then
   X_MODE=1
+fi
+if [ "$TOPIC_BOARD" -eq 0 ] && { { [ -n "${FM_TOPIC_CONFIG:-}" ] && [ -f "$FM_TOPIC_CONFIG" ]; } || [ -f "$topic_data/config.env" ] || [ -f "$topic_data/test-bot-token.txt" ]; }; then
+  TOPIC_BOARD=1
 fi
 
 render_snippet() {
@@ -178,6 +188,11 @@ if [ "$X_MODE" -eq 1 ]; then
   printf '%s%s%s\n' '- X mode: active; source ' "$x_mode_env" ' before launching any watcher process so the 30s cadence is inherited.'
 else
   printf '%s\n' '- X mode: inactive; use the default watcher cadence.'
+fi
+if [ "$TOPIC_BOARD" -eq 1 ]; then
+  printf '%s\n' '- Telegram topic board: active; keep one live supervision cycle even when no project work is in flight.'
+else
+  printf '%s\n' '- Telegram topic board: inactive.'
 fi
 printf '%s\n' '- After every handled wake, resume this emitted harness protocol instead of following a hardcoded background-arm recipe.'
 printf '\n'

--- a/bin/fm-supervision-lib.sh
+++ b/bin/fm-supervision-lib.sh
@@ -2,12 +2,14 @@
 # Shared "supervision missing" predicate.
 # Usage: . bin/fm-supervision-lib.sh
 #
-# True exactly when a firstmate home has in-flight work (a state/<id>.meta
-# exists) but no watcher has a fresh liveness beacon (state/.last-watcher-beat,
-# touched every poll cycle, within the grace window). bin/fm-guard.sh uses this
-# grace-based warning predicate directly; bin/fm-turnend-guard.sh uses the status
-# fields here for its banner but performs its end-of-turn block decision with the
-# live watcher lock check in bin/fm-wake-lib.sh.
+# True exactly when a firstmate home needs live supervision because it has
+# in-flight work or an enabled Telegram topic board, but no watcher has a fresh
+# liveness beacon (state/.last-watcher-beat, touched every poll cycle, within the
+# grace window).
+# bin/fm-guard.sh uses this grace-based warning predicate directly.
+# bin/fm-turnend-guard.sh uses the status fields here for its banner but performs
+# its end-of-turn block decision with the live watcher lock check in
+# bin/fm-wake-lib.sh.
 
 # Portable mtime; Linux stat lacks -f, macOS stat lacks -c.
 fm_sup_stat_mtime() {
@@ -18,17 +20,22 @@ fm_sup_stat_mtime() {
   fi
 }
 
-# fm_supervision_status <state-dir> [grace-seconds]
+# fm_supervision_status <state-dir> [grace-seconds] [home-dir]
 # Populates, for the state dir at $1:
 #   FM_SUP_IN_FLIGHT      count of state/*.meta (in-flight tasks)
+#   FM_SUP_TOPIC_BOARD    true/false - a local topic-board credential file exists
+#   FM_SUP_REQUIRED       true/false - work or the topic board needs a live watcher
 #   FM_SUP_WATCHER_FRESH  true/false - a watcher beacon within the grace window
 #   FM_SUP_BEACON_DESC    human-readable beacon age, for banners ("never" if absent)
 #   FM_SUP_QUEUE_PENDING  true/false - state/.wake-queue has unread records
 # grace-seconds defaults to $FM_GUARD_GRACE, then 300, matching fm-guard.sh.
 # Always returns 0; callers read the vars, or use fm_supervision_unhealthy below.
 fm_supervision_status() {
-  local state=$1 grace=${2:-${FM_GUARD_GRACE:-300}} meta beat m age
+  local state=$1 grace=${2:-${FM_GUARD_GRACE:-300}} home=${3:-${FM_HOME:-}} meta beat m age data config
+  [ -n "$home" ] || home=$(dirname "$state")
   FM_SUP_IN_FLIGHT=0
+  FM_SUP_TOPIC_BOARD=false
+  FM_SUP_REQUIRED=false
   FM_SUP_WATCHER_FRESH=false
   FM_SUP_BEACON_DESC=never
   FM_SUP_QUEUE_PENDING=false
@@ -37,6 +44,21 @@ fm_supervision_status() {
     [ -e "$meta" ] || continue
     FM_SUP_IN_FLIGHT=$((FM_SUP_IN_FLIGHT + 1))
   done
+
+  data=${FM_TOPIC_DATA_DIR:-$home/data/fm-telegram-topics}
+  if [ -n "${FM_TOPIC_CONFIG:-}" ]; then
+    config=$FM_TOPIC_CONFIG
+  elif [ -f "$data/config.env" ]; then
+    config="$data/config.env"
+  else
+    config="$data/test-bot-token.txt"
+  fi
+  if [ -f "$config" ] && [ ! -L "$config" ]; then
+    FM_SUP_TOPIC_BOARD=true
+  fi
+  if [ "$FM_SUP_IN_FLIGHT" -gt 0 ] || [ "$FM_SUP_TOPIC_BOARD" = true ]; then
+    FM_SUP_REQUIRED=true
+  fi
 
   beat="$state/.last-watcher-beat"
   if [ -e "$beat" ]; then
@@ -57,9 +79,10 @@ fm_supervision_status() {
 }
 
 # fm_supervision_unhealthy <state-dir> [grace-seconds]
-# Exit 0 (true) exactly in the dangerous state: in-flight work exists and no
-# watcher has a fresh beacon. Exit 1 (false) otherwise, including zero in-flight.
+# Exit 0 (true) exactly in the dangerous state: supervision is required and no
+# watcher has a fresh beacon.
+# Exit 1 (false) otherwise.
 fm_supervision_unhealthy() {
   fm_supervision_status "$@"
-  [ "$FM_SUP_IN_FLIGHT" -gt 0 ] && [ "$FM_SUP_WATCHER_FRESH" = false ]
+  [ "$FM_SUP_REQUIRED" = true ] && [ "$FM_SUP_WATCHER_FRESH" = false ]
 }

--- a/bin/fm-topic-inbox.sh
+++ b/bin/fm-topic-inbox.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Inspect and claim durable Telegram topic-board inbox items without deleting them.
+#
+# Usage:
+#   fm-topic-inbox.sh list
+#   fm-topic-inbox.sh show <update-id>
+#   fm-topic-inbox.sh claim <update-id> <owner>
+#   fm-topic-inbox.sh release <update-id>
+#   fm-topic-inbox.sh count
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=bin/fm-topic-lib.sh
+. "$SCRIPT_DIR/fm-topic-lib.sh"
+
+usage() {
+  sed -n '2,10p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+fm_topic_prepare_storage
+
+command=${1:-list}
+case "$command" in
+  list)
+    [ "$#" -eq 1 ] || { usage >&2; exit 2; }
+    for item in "$FM_TOPIC_INBOX"/update-*.json; do
+      [ -f "$item" ] && [ ! -L "$item" ] || continue
+      jq -r '[
+        (.update_id | tostring),
+        .status,
+        .topic,
+        .project,
+        .route,
+        (.claimed_by // "-"),
+        (.text | gsub("[\\t\\r\\n]"; " "))
+      ] | @tsv' "$item"
+    done | sort -n -k1,1
+    ;;
+  show)
+    [ "$#" -eq 2 ] || { usage >&2; exit 2; }
+    item=$(fm_topic_any_item "$2") || { echo "error: topic item not found: $2" >&2; exit 1; }
+    cat "$item"
+    ;;
+  claim)
+    [ "$#" -eq 3 ] || { usage >&2; exit 2; }
+    owner=$3
+    case "$owner" in ''|*[!A-Za-z0-9._-]*) echo 'error: owner must use letters, digits, dot, underscore, or dash' >&2; exit 2 ;; esac
+    item=$(fm_topic_pending_item "$2") || { echo "error: unanswered topic item not found: $2" >&2; exit 1; }
+    status=$(jq -r '.status' "$item")
+    claimed_by=$(jq -r '.claimed_by // ""' "$item")
+    if [ "$status" = claimed ] && [ "$claimed_by" = "$owner" ]; then
+      printf 'ok: update %s already claimed by %s\n' "$(jq -r '.update_id' "$item")" "$owner"
+      exit 0
+    fi
+    [ "$status" = pending ] || {
+      printf 'error: update %s is already claimed by %s\n' "$(jq -r '.update_id' "$item")" "${claimed_by:-unknown}" >&2
+      exit 1
+    }
+    jq --arg owner "$owner" --arg claimed_at "$(fm_topic_now)" \
+      '.status = "claimed" | .claimed_by = $owner | .claimed_at = $claimed_at' "$item" \
+      | fm_topic_atomic_from_stdin "$item"
+    printf 'ok: update %s claimed by %s\n' "$(jq -r '.update_id' "$item")" "$owner"
+    ;;
+  release)
+    [ "$#" -eq 2 ] || { usage >&2; exit 2; }
+    item=$(fm_topic_pending_item "$2") || { echo "error: unanswered topic item not found: $2" >&2; exit 1; }
+    jq 'del(.claimed_by, .claimed_at) | .status = "pending"' "$item" | fm_topic_atomic_from_stdin "$item"
+    printf 'ok: update %s released\n' "$(jq -r '.update_id' "$item")"
+    ;;
+  count)
+    [ "$#" -eq 1 ] || { usage >&2; exit 2; }
+    fm_topic_unanswered_count
+    ;;
+  -h|--help|help)
+    usage
+    ;;
+  *)
+    echo "error: unknown command: $command" >&2
+    usage >&2
+    exit 2
+    ;;
+esac

--- a/bin/fm-topic-lib.sh
+++ b/bin/fm-topic-lib.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+# Shared paths, validation, atomic persistence, and item lookup for the Telegram topic board.
+
+FM_TOPIC_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_TOPIC_DEFAULT_ROOT="$(cd "$FM_TOPIC_LIB_DIR/.." && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-${FM_ROOT:-$FM_TOPIC_DEFAULT_ROOT}}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-${STATE:-$FM_HOME/state}}"
+FM_TOPIC_DATA_DIR="${FM_TOPIC_DATA_DIR:-$FM_HOME/data/fm-telegram-topics}"
+FM_TOPIC_MAP="${FM_TOPIC_MAP:-$FM_TOPIC_DATA_DIR/topic-map.json}"
+FM_TOPIC_INBOX="$FM_TOPIC_DATA_DIR/inbox"
+FM_TOPIC_ANSWERED="$FM_TOPIC_DATA_DIR/answered"
+FM_TOPIC_OUTBOX="$FM_TOPIC_DATA_DIR/outbox"
+FM_TOPIC_LOCKS="$FM_TOPIC_DATA_DIR/locks"
+FM_TOPIC_OFFSET_FILE="${FM_TOPIC_OFFSET_FILE:-$FM_TOPIC_DATA_DIR/.poll-offset}"
+# shellcheck disable=SC2034 # Shared with fm-topic-listener.sh after sourcing.
+FM_TOPIC_LAST_WAKE="$FM_TOPIC_DATA_DIR/.last-wake"
+
+fm_topic_log() {
+  printf '%s fm-topic: %s\n' "$(date -Is)" "$*" >&2
+}
+
+fm_topic_prepare_storage() {
+  local directory
+  umask 077
+  mkdir -p "$FM_TOPIC_DATA_DIR" "$FM_TOPIC_INBOX" "$FM_TOPIC_ANSWERED" "$FM_TOPIC_OUTBOX" "$FM_TOPIC_LOCKS" "$STATE"
+  for directory in "$FM_TOPIC_DATA_DIR" "$FM_TOPIC_INBOX" "$FM_TOPIC_ANSWERED" "$FM_TOPIC_OUTBOX" "$FM_TOPIC_LOCKS" "$STATE"; do
+    [ -d "$directory" ] && [ ! -L "$directory" ] || {
+      printf 'error: topic-board storage path is not a real directory: %s\n' "$directory" >&2
+      return 1
+    }
+  done
+  chmod 700 "$FM_TOPIC_DATA_DIR" "$FM_TOPIC_INBOX" "$FM_TOPIC_ANSWERED" "$FM_TOPIC_OUTBOX" "$FM_TOPIC_LOCKS" 2>/dev/null || true
+}
+
+fm_topic_file_mode() {
+  if [ "$(uname)" = Darwin ]; then
+    stat -f %Lp "$1" 2>/dev/null
+  else
+    stat -c %a "$1" 2>/dev/null
+  fi
+}
+
+fm_topic_require_private_file() {
+  local file=$1 mode perm
+  [ -f "$file" ] && [ ! -L "$file" ] || {
+    printf 'error: required private file is missing, not regular, or a symlink: %s\n' "$file" >&2
+    return 1
+  }
+  mode=$(fm_topic_file_mode "$file") || {
+    printf 'error: cannot inspect private file permissions: %s\n' "$file" >&2
+    return 1
+  }
+  case "$mode" in
+    ''|*[!0-7]*)
+      printf 'error: invalid permission mode for private file %s: %s\n' "$file" "$mode" >&2
+      return 1
+      ;;
+  esac
+  perm=$((8#$mode))
+  if [ $((perm & 077)) -ne 0 ]; then
+    printf 'error: private file must not be readable or writable by group/other: %s (mode %s)\n' "$file" "$mode" >&2
+    return 1
+  fi
+}
+
+fm_topic_select_config() {
+  if [ -n "${FM_TOPIC_CONFIG:-}" ]; then
+    printf '%s\n' "$FM_TOPIC_CONFIG"
+  elif [ -f "$FM_TOPIC_DATA_DIR/config.env" ]; then
+    printf '%s\n' "$FM_TOPIC_DATA_DIR/config.env"
+  else
+    printf '%s\n' "$FM_TOPIC_DATA_DIR/test-bot-token.txt"
+  fi
+}
+
+fm_topic_load_credentials() {
+  local config line key value token='' captain=''
+  config=$(fm_topic_select_config)
+  fm_topic_require_private_file "$config" || return 1
+
+  while IFS= read -r line || [ -n "$line" ]; do
+    line=${line%$'\r'}
+    case "$line" in
+      ''|'#'*) continue ;;
+      *=*) ;;
+      *)
+        printf 'error: malformed topic-board credential line in %s\n' "$config" >&2
+        return 1
+        ;;
+    esac
+    key=${line%%=*}
+    value=${line#*=}
+    case "$key" in
+      FM_TOPIC_BOT_TOKEN|TEST_BOT_TOKEN) token=$value ;;
+      FM_TOPIC_CAPTAIN_ID|CAPTAIN_CHAT_ID) captain=$value ;;
+      *)
+        printf 'error: unsupported key in topic-board credential file: %s\n' "$key" >&2
+        return 1
+        ;;
+    esac
+  done < "$config"
+
+  [[ "$token" =~ ^[0-9]+:[A-Za-z0-9_-]+$ ]] || {
+    printf 'error: topic-board bot token is missing or malformed in %s\n' "$config" >&2
+    return 1
+  }
+  [[ "$captain" =~ ^[0-9]+$ ]] || {
+    printf 'error: captain Telegram user id is missing or malformed in %s\n' "$config" >&2
+    return 1
+  }
+
+  FM_TOPIC_BOT_TOKEN=$token
+  FM_TOPIC_CAPTAIN_ID=$captain
+  FM_TOPIC_CONFIG_EFFECTIVE=$config
+  export FM_TOPIC_BOT_TOKEN FM_TOPIC_CAPTAIN_ID FM_TOPIC_CONFIG_EFFECTIVE
+}
+
+fm_topic_assert_lifeline_separate() {
+  local lifeline_file=${FM_TOPIC_LIFELINE_CONFIG:-$HOME/.claude/channels/telegram/.env} line key value lifeline_token=${TELEGRAM_BOT_TOKEN:-}
+  if [ -z "$lifeline_token" ] && [ -f "$lifeline_file" ] && [ ! -L "$lifeline_file" ]; then
+    while IFS= read -r line || [ -n "$line" ]; do
+      line=${line%$'\r'}
+      case "$line" in
+        TELEGRAM_BOT_TOKEN=*)
+          key=${line%%=*}
+          value=${line#*=}
+          case "$value" in
+            \"*\") value=${value#\"}; value=${value%\"} ;;
+            \'*\') value=${value#\'}; value=${value%\'} ;;
+          esac
+          [ "$key" = TELEGRAM_BOT_TOKEN ] && lifeline_token=$value
+          ;;
+      esac
+    done < "$lifeline_file"
+  fi
+  if [ -n "$lifeline_token" ] && [ "$lifeline_token" = "$FM_TOPIC_BOT_TOKEN" ]; then
+    printf 'error: topic-board credentials match the direct-message bot; refusing to risk the captain lifeline\n' >&2
+    return 1
+  fi
+}
+
+fm_topic_validate_map() {
+  [ -f "$FM_TOPIC_MAP" ] && [ ! -L "$FM_TOPIC_MAP" ] || {
+    printf 'error: topic map is missing, not regular, or a symlink: %s\n' "$FM_TOPIC_MAP" >&2
+    return 1
+  }
+  jq -e '
+    (.chat_id | type == "string" or type == "number")
+    and (.topics | type == "object")
+    and all(.topics[];
+      (.name | type == "string" and length > 0)
+      and (.project | type == "string" and length > 0)
+      and (.route | type == "string" and length > 0)
+    )
+  ' "$FM_TOPIC_MAP" >/dev/null 2>&1 || {
+    printf 'error: topic map has an invalid schema: %s\n' "$FM_TOPIC_MAP" >&2
+    return 1
+  }
+}
+
+fm_topic_check_config() {
+  command -v jq >/dev/null 2>&1 || { echo 'error: jq is required' >&2; return 1; }
+  command -v "${FM_TOPIC_CURL_BIN:-curl}" >/dev/null 2>&1 || { echo 'error: curl is required' >&2; return 1; }
+  fm_topic_load_credentials || return 1
+  fm_topic_assert_lifeline_separate || return 1
+  fm_topic_validate_map || return 1
+}
+
+fm_topic_sync_path() {
+  if sync -f "$1" 2>/dev/null; then
+    return 0
+  fi
+  sync
+}
+
+fm_topic_atomic_from_stdin() {
+  local destination=$1 directory base tmp
+  if [ -e "$destination" ] && { [ ! -f "$destination" ] || [ -L "$destination" ]; }; then
+    printf 'error: atomic destination is not a regular non-symlink file: %s\n' "$destination" >&2
+    return 1
+  fi
+  directory=$(dirname "$destination")
+  base=$(basename "$destination")
+  mkdir -p "$directory" || return 1
+  tmp=$(mktemp "$directory/.${base}.tmp.XXXXXX") || return 1
+  chmod 600 "$tmp" 2>/dev/null || true
+  if ! cat > "$tmp"; then
+    rm -f "$tmp"
+    return 1
+  fi
+  if ! fm_topic_sync_path "$tmp"; then
+    rm -f "$tmp"
+    return 1
+  fi
+  if ! mv -f "$tmp" "$destination"; then
+    rm -f "$tmp"
+    return 1
+  fi
+  fm_topic_sync_path "$directory"
+}
+
+fm_topic_atomic_text() {
+  local destination=$1 value=$2
+  printf '%s\n' "$value" | fm_topic_atomic_from_stdin "$destination"
+}
+
+fm_topic_item_filename() {
+  local update_id=$1
+  case "$update_id" in
+    update-*.json) update_id=${update_id#update-}; update_id=${update_id%.json} ;;
+    update-*) update_id=${update_id#update-} ;;
+  esac
+  case "$update_id" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+  printf 'update-%s.json\n' "$update_id"
+}
+
+fm_topic_pending_item() {
+  local name
+  name=$(fm_topic_item_filename "$1") || return 1
+  [ -f "$FM_TOPIC_INBOX/$name" ] && [ ! -L "$FM_TOPIC_INBOX/$name" ] || return 1
+  printf '%s\n' "$FM_TOPIC_INBOX/$name"
+}
+
+fm_topic_any_item() {
+  local name
+  name=$(fm_topic_item_filename "$1") || return 1
+  if [ -f "$FM_TOPIC_INBOX/$name" ] && [ ! -L "$FM_TOPIC_INBOX/$name" ]; then
+    printf '%s\n' "$FM_TOPIC_INBOX/$name"
+    return 0
+  fi
+  if [ -f "$FM_TOPIC_ANSWERED/$name" ] && [ ! -L "$FM_TOPIC_ANSWERED/$name" ]; then
+    printf '%s\n' "$FM_TOPIC_ANSWERED/$name"
+    return 0
+  fi
+  return 1
+}
+
+fm_topic_unanswered_count() {
+  find "$FM_TOPIC_INBOX" -maxdepth 1 -type f -name 'update-*.json' -print 2>/dev/null | wc -l | tr -d '[:space:]'
+}
+
+fm_topic_now() {
+  date -u '+%Y-%m-%dT%H:%M:%SZ'
+}
+
+fm_topic_hash() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum | awk '{print $1}'
+  else
+    shasum -a 256 | awk '{print $1}'
+  fi
+}

--- a/bin/fm-topic-listener.sh
+++ b/bin/fm-topic-listener.sh
@@ -1,0 +1,294 @@
+#!/usr/bin/env bash
+# Long-poll Telegram with the dedicated topic-board bot and durably queue captain messages before advancing the offset.
+#
+# Usage:
+#   fm-topic-listener.sh
+#   fm-topic-listener.sh --once
+#   fm-topic-listener.sh --check-config
+#
+# The default credential file is data/fm-telegram-topics/config.env, with the
+# prototype's test-bot-token.txt accepted as a migration fallback.
+# The listener never reads or uses the direct-message firstmate bot token.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=bin/fm-topic-lib.sh
+. "$SCRIPT_DIR/fm-topic-lib.sh"
+# shellcheck source=bin/fm-wake-lib.sh
+. "$SCRIPT_DIR/fm-wake-lib.sh"
+
+MODE=loop
+case "${1:-}" in
+  '') ;;
+  --once) MODE=once ;;
+  --check-config) MODE=check ;;
+  -h|--help)
+    sed -n '2,11p' "$0" | sed 's/^# \{0,1\}//'
+    exit 0
+    ;;
+  *) echo "error: unknown argument: $1" >&2; exit 2 ;;
+esac
+
+fm_topic_check_config || exit 1
+[ "$MODE" = check ] && {
+  printf 'ok: topic board config valid (credentials=%s map=%s)\n' "$FM_TOPIC_CONFIG_EFFECTIVE" "$FM_TOPIC_MAP"
+  exit 0
+}
+
+fm_topic_prepare_storage || exit 1
+LISTENER_LOCK="$FM_TOPIC_LOCKS/listener.lock"
+if ! fm_lock_try_acquire "$LISTENER_LOCK"; then
+  printf 'error: another topic-board listener already owns %s (pid %s)\n' "$LISTENER_LOCK" "${FM_LOCK_HELD_PID:-unknown}" >&2
+  exit 75
+fi
+
+listener_cleanup() {
+  fm_lock_release "$LISTENER_LOCK"
+}
+trap listener_cleanup EXIT
+trap 'exit 0' HUP INT TERM
+
+CURL_BIN=${FM_TOPIC_CURL_BIN:-curl}
+POLL_TIMEOUT=${FM_TOPIC_POLL_TIMEOUT:-25}
+REMIND_SECONDS=${FM_TOPIC_REMIND_SECONDS:-300}
+WATCHER_GRACE=${FM_TOPIC_WATCHER_GRACE:-300}
+WATCH_PATH="$FM_ROOT/bin/fm-watch.sh"
+API="https://api.telegram.org/bot${FM_TOPIC_BOT_TOKEN}"
+
+case "$POLL_TIMEOUT" in ''|*[!0-9]*) echo 'error: FM_TOPIC_POLL_TIMEOUT must be a non-negative integer' >&2; exit 2 ;; esac
+case "$REMIND_SECONDS" in ''|*[!0-9]*|0) echo 'error: FM_TOPIC_REMIND_SECONDS must be a positive integer' >&2; exit 2 ;; esac
+
+read_offset() {
+  local offset
+  if [ ! -e "$FM_TOPIC_OFFSET_FILE" ]; then
+    printf '0\n'
+    return 0
+  fi
+  offset=$(cat "$FM_TOPIC_OFFSET_FILE" 2>/dev/null) || return 1
+  case "$offset" in
+    ''|*[!0-9]*)
+      printf 'error: durable Telegram offset is malformed: %s\n' "$FM_TOPIC_OFFSET_FILE" >&2
+      return 1
+      ;;
+  esac
+  printf '%s\n' "$offset"
+}
+
+topic_wake_is_queued() {
+  [ -s "$FM_WAKE_QUEUE" ] || return 1
+  awk -F '\t' '$3 == "check" && $4 == "topic-board" { found=1 } END { exit(found ? 0 : 1) }' "$FM_WAKE_QUEUE"
+}
+
+last_wake_age() {
+  local last now
+  last=$(cat "$FM_TOPIC_LAST_WAKE" 2>/dev/null || true)
+  case "$last" in ''|*[!0-9]*) printf '999999\n'; return ;; esac
+  now=$(date +%s)
+  printf '%s\n' "$((now - last))"
+}
+
+notify_firstmate() {
+  local pending=$1 force_append=$2 reason pid
+  reason="check: topic-board: topic-message ${pending} unanswered"
+  if [ "$force_append" -eq 1 ] || ! topic_wake_is_queued; then
+    fm_wake_append check topic-board "$reason" || return 1
+  fi
+
+  if fm_watcher_healthy "$STATE" "$WATCH_PATH" "$WATCHER_GRACE" "$FM_HOME"; then
+    pid=$FM_WATCHER_HEALTHY_PID
+    if kill -USR1 "$pid" 2>/dev/null; then
+      fm_topic_atomic_text "$FM_TOPIC_LAST_WAKE" "$(date +%s)" || return 1
+      fm_topic_log "queued ${pending} unanswered item(s) and signaled watcher pid ${pid}"
+      return 0
+    fi
+  fi
+  fm_topic_log "queued ${pending} unanswered item(s); no identity-verified watcher is ready yet"
+  return 1
+}
+
+surface_unanswered_if_due() {
+  local force_append=${1:-0} pending age
+  pending=$(fm_topic_unanswered_count)
+  [ "$pending" -gt 0 ] || return 0
+  if [ "$force_append" -eq 1 ]; then
+    notify_firstmate "$pending" 1 || true
+    return 0
+  fi
+  age=$(last_wake_age)
+  if [ "$age" -ge "$REMIND_SECONDS" ]; then
+    notify_firstmate "$pending" 0 || true
+  fi
+}
+
+item_already_persisted() {
+  local update_id=$1 name path
+  name=$(fm_topic_item_filename "$update_id") || return 1
+  for path in "$FM_TOPIC_INBOX/$name" "$FM_TOPIC_ANSWERED/$name"; do
+    if [ -L "$path" ] || { [ -e "$path" ] && [ ! -f "$path" ]; }; then
+      fm_topic_log "refusing unsafe existing item path ${path}"
+      return 2
+    fi
+    [ -f "$path" ] && return 0
+  done
+  return 1
+}
+
+message_content_type() {
+  jq -r '
+    if has("text") then "text"
+    elif has("photo") then "photo"
+    elif has("document") then "document"
+    elif has("video") then "video"
+    elif has("voice") then "voice"
+    elif has("audio") then "audio"
+    elif has("sticker") then "sticker"
+    elif has("location") then "location"
+    elif has("contact") then "contact"
+    else "other"
+    end
+  '
+}
+
+persist_captain_message() {
+  local update_id=$1 message=$2 chat_id sender_id thread_id message_id topic_record topic project route text content_type destination existing_rc
+  chat_id=$(printf '%s' "$message" | jq -r '.chat.id | tostring') || return 1
+  sender_id=$(printf '%s' "$message" | jq -r '.from.id | tostring') || return 1
+  [ "$sender_id" = "$FM_TOPIC_CAPTAIN_ID" ] || {
+    fm_topic_log "ignored update ${update_id} from non-captain sender ${sender_id}"
+    return 2
+  }
+  [ "$chat_id" = "$(jq -r '.chat_id | tostring' "$FM_TOPIC_MAP")" ] || {
+    fm_topic_log "ignored captain update ${update_id} from unconfigured chat ${chat_id}"
+    return 2
+  }
+
+  thread_id=$(printf '%s' "$message" | jq -r '.message_thread_id // "null"') || return 1
+  case "$thread_id" in null|*[!0-9]*) [ "$thread_id" = null ] || return 1 ;; esac
+  topic_record=$(jq -c --arg thread "$thread_id" '.topics[$thread] // empty' "$FM_TOPIC_MAP") || return 1
+  if [ -n "$topic_record" ]; then
+    topic=$(printf '%s' "$topic_record" | jq -r '.name')
+    project=$(printf '%s' "$topic_record" | jq -r '.project')
+    route=$(printf '%s' "$topic_record" | jq -r '.route')
+  else
+    topic="Unmapped topic ${thread_id}"
+    project=Unmapped
+    route=main
+    fm_topic_log "captain update ${update_id} uses an unmapped thread ${thread_id}; retained for main routing"
+  fi
+
+  item_already_persisted "$update_id"
+  existing_rc=$?
+  case "$existing_rc" in
+    0) return 3 ;;
+    1) ;;
+    *) return 1 ;;
+  esac
+  message_id=$(printf '%s' "$message" | jq -r '.message_id') || return 1
+  text=$(printf '%s' "$message" | jq -r '.text // .caption // ""') || return 1
+  content_type=$(printf '%s' "$message" | message_content_type) || return 1
+  destination="$FM_TOPIC_INBOX/$(fm_topic_item_filename "$update_id")"
+
+  jq -n \
+    --argjson version 1 \
+    --argjson update_id "$update_id" \
+    --argjson message_id "$message_id" \
+    --arg chat_id "$chat_id" \
+    --arg thread_id "$thread_id" \
+    --arg topic "$topic" \
+    --arg project "$project" \
+    --arg route "$route" \
+    --arg from_id "$sender_id" \
+    --arg content_type "$content_type" \
+    --arg text "$text" \
+    --arg received_at "$(fm_topic_now)" \
+    --argjson telegram_message "$message" \
+    '{
+      version: $version,
+      update_id: $update_id,
+      message_id: $message_id,
+      chat_id: $chat_id,
+      thread_id: (if $thread_id == "null" then null else ($thread_id | tonumber) end),
+      topic: $topic,
+      project: $project,
+      route: $route,
+      from_id: $from_id,
+      content_type: $content_type,
+      text: $text,
+      received_at: $received_at,
+      status: "pending",
+      telegram_message: $telegram_message
+    }' | fm_topic_atomic_from_stdin "$destination"
+}
+
+poll_once() {
+  local offset response rc max_update=-1 update update_id message persist_rc new=0
+  offset=$(read_offset) || return 1
+  response=$(
+    "$CURL_BIN" --silent --show-error --connect-timeout 10 --max-time "$((POLL_TIMEOUT + 15))" \
+      --get "$API/getUpdates" \
+      --data-urlencode "timeout=${POLL_TIMEOUT}" \
+      --data-urlencode "offset=${offset}" \
+      --data-urlencode 'limit=100' \
+      --data-urlencode 'allowed_updates=["message"]'
+  )
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fm_topic_log "getUpdates transport failure (curl exit ${rc}); offset remains ${offset}"
+    return 1
+  fi
+  if [ "$(printf '%s' "$response" | jq -r '.ok // false' 2>/dev/null)" != true ]; then
+    fm_topic_log "getUpdates API failure: $(printf '%s' "$response" | jq -r '.description // "invalid JSON response"' 2>/dev/null)"
+    return 1
+  fi
+
+  while IFS= read -r update; do
+    [ -n "$update" ] || continue
+    update_id=$(printf '%s' "$update" | jq -r '.update_id') || return 1
+    case "$update_id" in ''|*[!0-9]*) fm_topic_log 'getUpdates returned a malformed update_id'; return 1 ;; esac
+    [ "$update_id" -gt "$max_update" ] && max_update=$update_id
+    message=$(printf '%s' "$update" | jq -c '.message // empty') || return 1
+    if [ -z "$message" ]; then
+      fm_topic_log "ignored non-message update ${update_id}"
+      continue
+    fi
+    persist_captain_message "$update_id" "$message"
+    persist_rc=$?
+    case "$persist_rc" in
+      0) new=$((new + 1)) ;;
+      2|3) ;;
+      *) fm_topic_log "failed to persist update ${update_id}; offset remains ${offset}"; return 1 ;;
+    esac
+  done < <(printf '%s' "$response" | jq -c '.result[]?')
+
+  if [ "$max_update" -ge 0 ]; then
+    fm_topic_atomic_text "$FM_TOPIC_OFFSET_FILE" "$((max_update + 1))" || {
+      fm_topic_log "failed to persist offset after update ${max_update}"
+      return 1
+    }
+  fi
+
+  if [ "$new" -gt 0 ]; then
+    surface_unanswered_if_due 1
+  else
+    surface_unanswered_if_due 0
+  fi
+  return 0
+}
+
+surface_unanswered_if_due 0
+
+if [ "$MODE" = once ]; then
+  poll_once
+  exit $?
+fi
+
+backoff=1
+while :; do
+  if poll_once; then
+    backoff=1
+  else
+    sleep "$backoff"
+    backoff=$((backoff * 2))
+    [ "$backoff" -gt 30 ] && backoff=30
+  fi
+done

--- a/bin/fm-topic-reply.sh
+++ b/bin/fm-topic-reply.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+# Send an idempotently keyed reply into an item's originating Telegram topic and archive the item after its initial answer.
+#
+# Usage:
+#   fm-topic-reply.sh <update-id> [--text-file <path>]
+#   fm-topic-reply.sh <update-id> --follow-up <key> [--text-file <path>]
+#   fm-topic-reply.sh <update-id> [--follow-up <key>] --confirm-sent
+#   fm-topic-reply.sh <update-id> [--follow-up <key>] --retry-unknown [--text-file <path>]
+#
+# Text comes from --text-file or stdin.
+# A crash after Telegram may have accepted a send leaves an ambiguous intent that
+# will not be retried until --confirm-sent or --retry-unknown is chosen explicitly.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=bin/fm-topic-lib.sh
+. "$SCRIPT_DIR/fm-topic-lib.sh"
+# shellcheck source=bin/fm-wake-lib.sh
+. "$SCRIPT_DIR/fm-wake-lib.sh"
+
+usage() {
+  sed -n '2,13p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+[ "$#" -ge 1 ] || { usage >&2; exit 2; }
+item_id=$1
+shift
+reply_key=initial
+text_file=
+confirm_sent=0
+retry_unknown=0
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --text-file)
+      [ "$#" -gt 1 ] || { echo 'error: --text-file requires a path' >&2; exit 2; }
+      text_file=$2
+      shift 2
+      ;;
+    --follow-up)
+      [ "$#" -gt 1 ] || { echo 'error: --follow-up requires a stable key' >&2; exit 2; }
+      reply_key=$2
+      shift 2
+      ;;
+    --confirm-sent) confirm_sent=1; shift ;;
+    --retry-unknown) retry_unknown=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "error: unknown argument: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+case "$reply_key" in ''|*[!A-Za-z0-9._-]*) echo 'error: reply key must use letters, digits, dot, underscore, or dash' >&2; exit 2 ;; esac
+[ "$confirm_sent" -eq 0 ] || [ "$retry_unknown" -eq 0 ] || { echo 'error: choose only one of --confirm-sent or --retry-unknown' >&2; exit 2; }
+
+fm_topic_check_config
+fm_topic_prepare_storage
+item=$(fm_topic_any_item "$item_id") || { echo "error: topic item not found: $item_id" >&2; exit 1; }
+update_id=$(jq -r '.update_id' "$item")
+intent="$FM_TOPIC_OUTBOX/update-${update_id}-${reply_key}.json"
+if [ -L "$intent" ] || { [ -e "$intent" ] && [ ! -f "$intent" ]; }; then
+  printf 'error: reply intent path is not a regular non-symlink file: %s\n' "$intent" >&2
+  exit 1
+fi
+reply_lock="$FM_TOPIC_LOCKS/reply-${update_id}-${reply_key}.lock"
+if ! fm_lock_try_acquire "$reply_lock"; then
+  printf 'error: reply %s for update %s is already in progress\n' "$reply_key" "$update_id" >&2
+  exit 75
+fi
+cleanup_reply_lock() {
+  fm_lock_release "$reply_lock"
+}
+trap cleanup_reply_lock EXIT
+
+finalize_initial_answer() {
+  local pending answered
+  [ "$reply_key" = initial ] || return 0
+  pending=$(fm_topic_pending_item "$update_id" 2>/dev/null || true)
+  [ -n "$pending" ] || return 0
+  answered="$FM_TOPIC_ANSWERED/$(fm_topic_item_filename "$update_id")"
+  if [ -L "$answered" ] || { [ -e "$answered" ] && [ ! -f "$answered" ]; }; then
+    printf 'error: answered-item path is not a regular non-symlink file: %s\n' "$answered" >&2
+    return 1
+  fi
+  jq --arg answered_at "$(fm_topic_now)" --arg intent_file "$(basename "$intent")" \
+    '.status = "answered" | .answered_at = $answered_at | .initial_reply_intent = $intent_file' "$pending" \
+    | fm_topic_atomic_from_stdin "$pending"
+  mv -f "$pending" "$answered"
+  fm_topic_sync_path "$FM_TOPIC_ANSWERED"
+}
+
+mark_intent() {
+  local status=$1 note=${2:-}
+  jq --arg status "$status" --arg changed_at "$(fm_topic_now)" --arg note "$note" '
+    .status = $status
+    | .changed_at = $changed_at
+    | if $note == "" then del(.note) else .note = $note end
+  ' "$intent" | fm_topic_atomic_from_stdin "$intent"
+}
+
+if [ "$confirm_sent" -eq 1 ]; then
+  [ -f "$intent" ] || { echo 'error: no reply intent exists to confirm' >&2; exit 1; }
+  intent_status=$(jq -r '.status' "$intent")
+  case "$intent_status" in
+    sending|delivery_unknown) ;;
+    sent)
+      finalize_initial_answer
+      printf 'ok: reply %s for update %s was already recorded as sent\n' "$reply_key" "$update_id"
+      exit 0
+      ;;
+    *) printf 'error: reply intent status %s is not ambiguous and cannot be manually confirmed\n' "$intent_status" >&2; exit 1 ;;
+  esac
+  jq --arg sent_at "$(fm_topic_now)" '
+    .status = "sent"
+    | .sent_at = $sent_at
+    | .confirmed_manually = true
+    | .changed_at = $sent_at
+  ' "$intent" | fm_topic_atomic_from_stdin "$intent"
+  finalize_initial_answer
+  printf 'ok: reply %s for update %s marked sent after manual confirmation\n' "$reply_key" "$update_id"
+  exit 0
+fi
+
+if [ -n "$text_file" ]; then
+  [ -f "$text_file" ] && [ ! -L "$text_file" ] || { echo "error: text file is missing, not regular, or a symlink: $text_file" >&2; exit 1; }
+  text=$(cat "$text_file")
+else
+  text=$(cat)
+fi
+[ -n "$text" ] || { echo 'error: reply text is empty' >&2; exit 1; }
+text_hash=$(printf '%s' "$text" | fm_topic_hash)
+
+if [ -f "$intent" ]; then
+  recorded_hash=$(jq -r '.text_sha256' "$intent")
+  [ "$recorded_hash" = "$text_hash" ] || {
+    printf 'error: reply key %s already belongs to different text for update %s\n' "$reply_key" "$update_id" >&2
+    exit 1
+  }
+  intent_status=$(jq -r '.status' "$intent")
+  case "$intent_status" in
+    sent)
+      finalize_initial_answer
+      printf 'ok: reply %s for update %s was already sent; no duplicate was sent\n' "$reply_key" "$update_id"
+      exit 0
+      ;;
+    sending|delivery_unknown)
+      [ "$retry_unknown" -eq 1 ] || {
+        printf 'error: reply %s for update %s may already have reached Telegram; inspect the topic, then use --confirm-sent or --retry-unknown\n' "$reply_key" "$update_id" >&2
+        exit 1
+      }
+      mark_intent prepared 'explicit retry after ambiguous delivery'
+      ;;
+    prepared|failed) ;;
+    *) printf 'error: unknown reply intent status: %s\n' "$intent_status" >&2; exit 1 ;;
+  esac
+else
+  jq -n \
+    --argjson version 1 \
+    --argjson update_id "$update_id" \
+    --arg reply_key "$reply_key" \
+    --arg text "$text" \
+    --arg text_sha256 "$text_hash" \
+    --arg prepared_at "$(fm_topic_now)" \
+    '{
+      version: $version,
+      update_id: $update_id,
+      reply_key: $reply_key,
+      text: $text,
+      text_sha256: $text_sha256,
+      prepared_at: $prepared_at,
+      changed_at: $prepared_at,
+      status: "prepared"
+    }' | fm_topic_atomic_from_stdin "$intent"
+fi
+
+mark_intent sending
+chat_id=$(jq -r '.chat_id' "$item")
+thread_id=$(jq -r '.thread_id // "null"' "$item")
+CURL_BIN=${FM_TOPIC_CURL_BIN:-curl}
+API="https://api.telegram.org/bot${FM_TOPIC_BOT_TOKEN}"
+curl_args=(
+  --silent
+  --show-error
+  --connect-timeout 10
+  --max-time 35
+  "$API/sendMessage"
+  --data-urlencode "chat_id=${chat_id}"
+  --data-urlencode "text=${text}"
+)
+[ "$thread_id" = null ] || curl_args+=(--data-urlencode "message_thread_id=${thread_id}")
+
+set +e
+response=$("$CURL_BIN" "${curl_args[@]}")
+curl_rc=$?
+set -e
+if [ "$curl_rc" -ne 0 ]; then
+  mark_intent delivery_unknown "curl exit ${curl_rc}"
+  printf 'error: Telegram delivery result is unknown for update %s; automatic retry is disabled\n' "$update_id" >&2
+  exit 1
+fi
+if ! printf '%s' "$response" | jq -e 'type == "object" and has("ok")' >/dev/null 2>&1; then
+  mark_intent delivery_unknown 'Telegram returned an unreadable response'
+  printf 'error: Telegram delivery result is unknown for update %s; automatic retry is disabled\n' "$update_id" >&2
+  exit 1
+fi
+if [ "$(printf '%s' "$response" | jq -r '.ok')" != true ]; then
+  description=$(printf '%s' "$response" | jq -r '.description // "Telegram rejected the request"')
+  mark_intent failed "$description"
+  printf 'error: Telegram did not accept reply for update %s: %s\n' "$update_id" "$description" >&2
+  exit 1
+fi
+
+telegram_message_id=$(printf '%s' "$response" | jq -r '.result.message_id')
+telegram_thread_id=$(printf '%s' "$response" | jq -r '.result.message_thread_id // "null"')
+jq --arg sent_at "$(fm_topic_now)" \
+  --arg message_id "$telegram_message_id" \
+  --arg thread_id "$telegram_thread_id" '
+  .status = "sent"
+  | .sent_at = $sent_at
+  | .changed_at = $sent_at
+  | .telegram_message_id = ($message_id | tonumber)
+  | .telegram_thread_id = (if $thread_id == "null" then null else ($thread_id | tonumber) end)
+  | del(.note)
+' "$intent" | fm_topic_atomic_from_stdin "$intent"
+finalize_initial_answer
+printf 'ok: reply %s for update %s sent into topic thread %s\n' "$reply_key" "$update_id" "$thread_id"

--- a/bin/fm-topic-service.sh
+++ b/bin/fm-topic-service.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Install and manage the persistent systemd user service for the Telegram topic-board listener.
+#
+# Usage:
+#   fm-topic-service.sh install
+#   fm-topic-service.sh status
+#   fm-topic-service.sh restart
+#   fm-topic-service.sh uninstall
+#   fm-topic-service.sh print-unit
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+FM_ROOT_EFFECTIVE="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd -P)}"
+FM_HOME_EFFECTIVE="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT_EFFECTIVE}}"
+SYSTEMD_DIR=${FM_TOPIC_SYSTEMD_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user}
+SYSTEMCTL=${FM_TOPIC_SYSTEMCTL:-systemctl}
+SERVICE_NAME=${FM_TOPIC_SERVICE_NAME:-firstmate-topic-board.service}
+UNIT_FILE="$SYSTEMD_DIR/$SERVICE_NAME"
+LEGACY_CHECK="$FM_HOME_EFFECTIVE/state/topic-watch.check.sh"
+
+usage() {
+  sed -n '2,9p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+unit_escape() {
+  printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e 's/%/%%/g'
+}
+
+render_unit() {
+  local root home listener
+  root=$(unit_escape "$FM_ROOT_EFFECTIVE")
+  home=$(unit_escape "$FM_HOME_EFFECTIVE")
+  listener=$(unit_escape "$FM_ROOT_EFFECTIVE/bin/fm-topic-listener.sh")
+  cat <<EOF
+[Unit]
+Description=Firstmate real-time Telegram topic board
+Wants=network-online.target
+After=network-online.target
+StartLimitIntervalSec=0
+
+[Service]
+Type=simple
+Environment="HOME=$(unit_escape "$HOME")"
+Environment="PATH=/usr/local/bin:/usr/bin:/bin"
+Environment="FM_HOME=$home"
+Environment="FM_ROOT_OVERRIDE=$root"
+EOF
+  if [ -n "${FM_TOPIC_DATA_DIR:-}" ]; then
+    printf 'Environment="FM_TOPIC_DATA_DIR=%s"\n' "$(unit_escape "$FM_TOPIC_DATA_DIR")"
+  fi
+  if [ -n "${FM_TOPIC_CONFIG:-}" ]; then
+    printf 'Environment="FM_TOPIC_CONFIG=%s"\n' "$(unit_escape "$FM_TOPIC_CONFIG")"
+  fi
+  if [ -n "${FM_TOPIC_MAP:-}" ]; then
+    printf 'Environment="FM_TOPIC_MAP=%s"\n' "$(unit_escape "$FM_TOPIC_MAP")"
+  fi
+  if [ -n "${FM_TOPIC_LIFELINE_CONFIG:-}" ]; then
+    printf 'Environment="FM_TOPIC_LIFELINE_CONFIG=%s"\n' "$(unit_escape "$FM_TOPIC_LIFELINE_CONFIG")"
+  fi
+  cat <<EOF
+ExecStart="$listener"
+Restart=always
+RestartSec=3
+KillSignal=SIGTERM
+TimeoutStopSec=10
+UMask=0077
+NoNewPrivileges=true
+PrivateTmp=true
+
+[Install]
+WantedBy=default.target
+EOF
+}
+
+command=${1:-status}
+case "$command" in
+  install)
+    [ "$#" -eq 1 ] || { usage >&2; exit 2; }
+    [ ! -e "$LEGACY_CHECK" ] || {
+      printf 'error: legacy watcher poll still exists at %s\n' "$LEGACY_CHECK" >&2
+      printf 'Disable that prototype poller before installation so two getUpdates consumers cannot race on the topic-bot token.\n' >&2
+      exit 1
+    }
+    FM_HOME="$FM_HOME_EFFECTIVE" FM_ROOT_OVERRIDE="$FM_ROOT_EFFECTIVE" "$FM_ROOT_EFFECTIVE/bin/fm-topic-listener.sh" --check-config >/dev/null
+    mkdir -p "$SYSTEMD_DIR"
+    render_unit | {
+      umask 077
+      tmp=$(mktemp "$SYSTEMD_DIR/.${SERVICE_NAME}.tmp.XXXXXX")
+      cat > "$tmp"
+      chmod 600 "$tmp"
+      mv -f "$tmp" "$UNIT_FILE"
+    }
+    "$SYSTEMCTL" --user daemon-reload
+    "$SYSTEMCTL" --user enable --now "$SERVICE_NAME"
+    printf 'ok: installed and started %s\n' "$SERVICE_NAME"
+    ;;
+  status)
+    [ "$#" -eq 1 ] || { usage >&2; exit 2; }
+    "$SYSTEMCTL" --user status "$SERVICE_NAME" --no-pager
+    ;;
+  restart)
+    [ "$#" -eq 1 ] || { usage >&2; exit 2; }
+    "$SYSTEMCTL" --user restart "$SERVICE_NAME"
+    "$SYSTEMCTL" --user status "$SERVICE_NAME" --no-pager
+    ;;
+  uninstall)
+    [ "$#" -eq 1 ] || { usage >&2; exit 2; }
+    "$SYSTEMCTL" --user disable --now "$SERVICE_NAME" 2>/dev/null || true
+    rm -f "$UNIT_FILE"
+    "$SYSTEMCTL" --user daemon-reload
+    printf 'ok: removed %s; topic data and credentials were preserved\n' "$SERVICE_NAME"
+    ;;
+  print-unit)
+    [ "$#" -eq 1 ] || { usage >&2; exit 2; }
+    render_unit
+    ;;
+  -h|--help|help)
+    usage
+    ;;
+  *)
+    echo "error: unknown command: $command" >&2
+    usage >&2
+    exit 2
+    ;;
+esac

--- a/bin/fm-turnend-guard.sh
+++ b/bin/fm-turnend-guard.sh
@@ -112,21 +112,29 @@ fi
 # shellcheck source=bin/fm-wake-lib.sh
 . "$SCRIPT_DIR/fm-wake-lib.sh"
 
-fm_supervision_status "$STATE" "$GRACE"
-[ "$FM_SUP_IN_FLIGHT" -gt 0 ] || exit 0
+fm_supervision_status "$STATE" "$GRACE" "$FM_HOME"
+[ "$FM_SUP_REQUIRED" = true ] || exit 0
 fm_watcher_healthy "$STATE" "$WATCH" "$GRACE" "$FM_HOME" && exit 0
 
 afk=0
 [ -e "$STATE/.afk" ] && afk=1
 x_mode=0
 [ -f "$CONFIG/x-mode.env" ] && x_mode=1
-REASON=$("$SCRIPT_DIR/fm-supervision-instructions.sh" --afk "$afk" --x-mode "$x_mode" --repair-line 2>/dev/null \
-  || printf '%s\n' 'tasks in flight, no live watcher - resume supervision according to the session-start operating block before ending the turn')
+topic_board=0
+[ "$FM_SUP_TOPIC_BOARD" = true ] && topic_board=1
+REASON=$("$SCRIPT_DIR/fm-supervision-instructions.sh" --afk "$afk" --x-mode "$x_mode" --topic-board "$topic_board" --repair-line 2>/dev/null \
+  || printf '%s\n' 'supervision is required, but no live watcher exists - resume supervision according to the session-start operating block before ending the turn')
 rule='━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'
 {
   printf '●%s\n' "$rule"
   printf '●  TURN WOULD END BLIND - SUPERVISION IS OFF\n'
-  printf '●  %s task(s) in flight, but no live watcher holds this home lock (last beat: %s).\n' "$FM_SUP_IN_FLIGHT" "$FM_SUP_BEACON_DESC"
+  if [ "$FM_SUP_TOPIC_BOARD" = true ] && [ "$FM_SUP_IN_FLIGHT" -gt 0 ]; then
+    printf '●  %s task(s) and the Telegram topic board need supervision, but no live watcher holds this home lock (last beat: %s).\n' "$FM_SUP_IN_FLIGHT" "$FM_SUP_BEACON_DESC"
+  elif [ "$FM_SUP_TOPIC_BOARD" = true ]; then
+    printf '●  The Telegram topic board needs supervision, but no live watcher holds this home lock (last beat: %s).\n' "$FM_SUP_BEACON_DESC"
+  else
+    printf '●  %s task(s) in flight, but no live watcher holds this home lock (last beat: %s).\n' "$FM_SUP_IN_FLIGHT" "$FM_SUP_BEACON_DESC"
+  fi
   printf '●  %s\n' "$REASON"
   printf '●%s\n' "$rule"
 } >&2

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -34,6 +34,9 @@
 #   check: <script>: <out> authenticated check output, always actionable
 #   check: rejected unauthenticated state checks: <paths>
 #                          unsafe state checks were refused without execution
+#   check: topic-board: external event queued
+#                          the durable topic listener appended its own check
+#                          record, then used the home-scoped USR1 fast path
 #   heartbeat              fleet-scan backstop found an unsurfaced captain-relevant
 #                          status, unless afk is active
 # For normal supervision, resume the session-start primary-harness protocol
@@ -154,6 +157,38 @@ EVENT_CAP_FAIL_MAX=${FM_EVENT_CAP_FAIL_MAX:-3}
 _event_cap_key=""
 _event_cap_ok=0
 _event_cap_fails=0
+FM_ACTIVE_WAIT_PID=
+FM_ACTIVE_WAIT_PGID=
+FM_ACTIVE_WAIT_OUTPUT=
+
+fm_active_wait_stop() {
+  local pid=${FM_ACTIVE_WAIT_PID:-} pgid=${FM_ACTIVE_WAIT_PGID:-}
+  [ -z "$pgid" ] || kill -TERM -- "-$pgid" 2>/dev/null || true
+  if [ -n "$pid" ]; then
+    kill -TERM "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+  fi
+  FM_ACTIVE_WAIT_PID=
+  FM_ACTIVE_WAIT_PGID=
+  if [ -n "${FM_ACTIVE_WAIT_OUTPUT:-}" ]; then
+    rm -f "$FM_ACTIVE_WAIT_OUTPUT" 2>/dev/null || true
+  fi
+  FM_ACTIVE_WAIT_OUTPUT=
+}
+
+# A trapped USR1 interrupts Bash's builtin wait immediately, unlike a direct
+# foreground sleep whose signal trap may be deferred until the whole poll
+# budget elapses.
+fm_interruptible_sleep() {
+  set -m
+  sleep "$1" &
+  FM_ACTIVE_WAIT_PID=$!
+  FM_ACTIVE_WAIT_PGID=$FM_ACTIVE_WAIT_PID
+  set +m
+  wait "$FM_ACTIVE_WAIT_PID" 2>/dev/null || true
+  FM_ACTIVE_WAIT_PID=
+  FM_ACTIVE_WAIT_PGID=
+}
 
 # afk_present: 0 while the away-mode flag exists. When set, the daemon wraps this
 # watcher and owns triage, so the watcher must behave one-shot (enqueue + exit on
@@ -580,7 +615,7 @@ event_wait_or_sleep() {
   done < <(recorded_windows)
 
   if [ "${#windows[@]}" -eq 0 ]; then
-    sleep "$POLL"
+    fm_interruptible_sleep "$POLL"
     return
   fi
 
@@ -596,12 +631,23 @@ event_wait_or_sleep() {
     _event_cap_fails=0
   fi
   if [ "$_event_cap_ok" != 1 ]; then
-    sleep "$POLL"
+    fm_interruptible_sleep "$POLL"
     return
   fi
 
-  rec=$(FM_BACKEND_EVENTS_CAPABILITY_CONFIRMED=1 fm_backend_wait_transition "$first_backend" "$first_session" "$POLL" "$STATE" "${windows[@]}")
+  FM_ACTIVE_WAIT_OUTPUT=$(mktemp "$STATE/.fm-event-wait-output.XXXXXX") || exit 1
+  set -m
+  FM_BACKEND_EVENTS_CAPABILITY_CONFIRMED=1 fm_backend_wait_transition "$first_backend" "$first_session" "$POLL" "$STATE" "${windows[@]}" > "$FM_ACTIVE_WAIT_OUTPUT" &
+  FM_ACTIVE_WAIT_PID=$!
+  FM_ACTIVE_WAIT_PGID=$FM_ACTIVE_WAIT_PID
+  set +m
+  wait "$FM_ACTIVE_WAIT_PID" 2>/dev/null
   rc=$?
+  FM_ACTIVE_WAIT_PID=
+  FM_ACTIVE_WAIT_PGID=
+  rec=$(cat "$FM_ACTIVE_WAIT_OUTPUT" 2>/dev/null || true)
+  rm -f "$FM_ACTIVE_WAIT_OUTPUT" 2>/dev/null || true
+  FM_ACTIVE_WAIT_OUTPUT=
   case "$rc" in
     0)
       _event_cap_fails=0
@@ -613,7 +659,7 @@ event_wait_or_sleep() {
       # pure polling for the rest of this watcher process.
       _event_cap_fails=$((_event_cap_fails + 1))
       [ "$_event_cap_fails" -ge "$EVENT_CAP_FAIL_MAX" ] && _event_cap_ok=0
-      sleep "$POLL"
+      fm_interruptible_sleep "$POLL"
       ;;
     *)
       # 1: a clean full-budget wait with no actionable edge - the reader already
@@ -686,6 +732,7 @@ if ! fm_lock_try_acquire "$WATCH_LOCK"; then
   exit 0
 fi
 watcher_cleanup() {
+  fm_active_wait_stop || return 1
   fm_active_check_stop || return 1
   fm_check_output_cleanup
   fm_custom_check_snapshot_cleanup
@@ -693,6 +740,13 @@ watcher_cleanup() {
 }
 trap watcher_cleanup EXIT
 trap 'exit 1' HUP INT TERM
+# The durable topic listener may append its own wake record, verify this exact
+# home-scoped watcher identity through fm-wake-lib.sh, then send USR1 to shorten
+# notification latency without running an unauthenticated check or waiting for
+# the normal poll cadence.
+# The queue append must happen first because this trap only returns the active
+# supervision mechanism to firstmate; the durable queue remains the authority.
+trap 'wake "check: topic-board: external event queued"' USR1
 # This watcher's own pid, as recorded in the lock by fm_lock_claim (which writes
 # ${BASHPID:-$$} from this same main shell). Read directly, never via a command
 # substitution, so it matches the stored holder pid for the self-eviction check.

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -174,6 +174,11 @@ fm_active_wait_stop() {
     [ -z "$pgid" ] || kill -KILL -- "-$pgid" 2>/dev/null || true
     [ -z "$pid" ] || kill -KILL "$pid" 2>/dev/null || true
     [ -z "$pid" ] || wait "$pid" 2>/dev/null || true
+    i=0
+    while [ -n "$pgid" ] && kill -0 -- "-$pgid" 2>/dev/null && [ "$i" -lt 100 ]; do
+      sleep 0.01
+      i=$((i + 1))
+    done
     if [ -n "$pgid" ] && kill -0 -- "-$pgid" 2>/dev/null; then
       rc=1
     fi

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -162,11 +162,21 @@ FM_ACTIVE_WAIT_PGID=
 FM_ACTIVE_WAIT_OUTPUT=
 
 fm_active_wait_stop() {
-  local pid=${FM_ACTIVE_WAIT_PID:-} pgid=${FM_ACTIVE_WAIT_PGID:-}
-  [ -z "$pgid" ] || kill -TERM -- "-$pgid" 2>/dev/null || true
-  if [ -n "$pid" ]; then
-    kill -TERM "$pid" 2>/dev/null || true
-    wait "$pid" 2>/dev/null || true
+  local pid=${FM_ACTIVE_WAIT_PID:-} pgid=${FM_ACTIVE_WAIT_PGID:-} i rc=0
+  if [ -n "$pid" ] || [ -n "$pgid" ]; then
+    [ -z "$pgid" ] || kill -TERM -- "-$pgid" 2>/dev/null || true
+    [ -z "$pid" ] || kill -TERM "$pid" 2>/dev/null || true
+    i=0
+    while [ -n "$pgid" ] && kill -0 -- "-$pgid" 2>/dev/null && [ "$i" -lt 20 ]; do
+      sleep 0.01
+      i=$((i + 1))
+    done
+    [ -z "$pgid" ] || kill -KILL -- "-$pgid" 2>/dev/null || true
+    [ -z "$pid" ] || kill -KILL "$pid" 2>/dev/null || true
+    [ -z "$pid" ] || wait "$pid" 2>/dev/null || true
+    if [ -n "$pgid" ] && kill -0 -- "-$pgid" 2>/dev/null; then
+      rc=1
+    fi
   fi
   FM_ACTIVE_WAIT_PID=
   FM_ACTIVE_WAIT_PGID=
@@ -174,6 +184,7 @@ fm_active_wait_stop() {
     rm -f "$FM_ACTIVE_WAIT_OUTPUT" 2>/dev/null || true
   fi
   FM_ACTIVE_WAIT_OUTPUT=
+  return $rc
 }
 
 # A trapped USR1 interrupts Bash's builtin wait immediately, unlike a direct

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,7 +9,7 @@ firstmate's always-loaded operating contract and routing index for conditional p
 ## Event-driven supervision
 
 A zero-token bash watcher (`bin/fm-watch.sh`) sleeps on the fleet, classifies detected wakes in bash, and wakes the first mate only when something is actionable.
-Actionable wakes include captain-relevant status signals, no-verb signals whose crew is not provably working, authenticated check output such as PR merge polling or an X-mode mention, stale panes whose crew is not provably working whether their status log looks terminal or non-terminal, provably-working stale panes that persist past `FM_STALE_ESCALATE_SECS`, declared external waits that remain paused past `FM_PAUSE_RESURFACE_SECS`, and heartbeat backstop hits.
+Actionable wakes include captain-relevant status signals, no-verb signals whose crew is not provably working, authenticated check output such as PR merge polling or an X-mode mention, durable external events such as a Telegram topic message, stale panes whose crew is not provably working whether their status log looks terminal or non-terminal, provably-working stale panes that persist past `FM_STALE_ESCALATE_SECS`, declared external waits that remain paused past `FM_PAUSE_RESURFACE_SECS`, and heartbeat backstop hits.
 Repeated provably-working stale escalations on the same unchanged pane add an escalation count to the wake reason and, at `FM_WEDGE_DEMAND_INSPECT_COUNT`, a `demand-deep-inspection` marker.
 Those actionable wakes are written to a durable local queue (`state/.wake-queue`) before detector state advances, so a missed process exit can be recovered by draining the queue.
 No-verb wakes, such as `working:` notes and bare turn-ended signals, are benign only when `bin/fm-crew-state.sh` reports positive evidence that the crew is still working: an actively running no-mistakes step for that crew's branch or a backend busy signature.
@@ -44,16 +44,17 @@ A bounded direct-report terminal tail can help diagnose a mismatch by showing th
 The snapshot strips control sequences, retains only capture metadata and literal event-corroboration flags, and never lets terminal evidence override a valid structured classification.
 The default path remains local-only; live GitHub enrichment exists only behind the bearings `--include-prs` opt-in.
 Optional X mode integrates with the watcher only after explicit opt-in; [configuration.md](configuration.md#x-mode-env) owns its generated-artifact and dispatch mechanics.
+The optional Telegram topic board uses a persistent long-poll service that queues an event and signals only the identity-verified watcher for its home; [topic-board.md](topic-board.md) owns its durability, service, routing, and lifeline-safety contract.
 
 At session start, `bin/fm-session-start.sh` emits exactly one primary-harness supervision block rendered by `bin/fm-supervision-instructions.sh` from `docs/supervision-protocols/`.
 That block owns the live wait shape for the running primary harness: Claude and Grok use background-notify cycles, Codex uses bounded foreground checkpoints, Pi uses its two tracked primary extensions, and OpenCode uses its TUI plugin.
 `bin/fm-watch-arm.sh` remains the verified arm wrapper for protocols that call it; it forks the watcher as a tracked child, verifies it is genuinely alive with a fresh liveness beacon, and prints exactly one honest status line (`started` / `attached` / restart-only `healthy` / `FAILED`, the last exiting non-zero).
 On `attached` it stays live until that existing cycle ends so background-notify harnesses do not get an empty false wake from a healthy no-op exit.
 Its `--restart` mode signals only the watcher recorded in the current home's `state/.watch.lock`, so restarting one home cannot kill sibling secondmate watchers.
-A pull-based guard (`bin/fm-guard.sh`) warns through supervision tool output if the primary checkout is tangled, or if tasks are in flight and that watcher stops running or queued wakes are waiting to be drained.
+A pull-based guard (`bin/fm-guard.sh`) warns through supervision tool output if the primary checkout is tangled, or if supervision is required by tasks or the topic board and that watcher stops running or queued wakes are waiting to be drained.
 The drain script calls that guard after emptying the queue, which avoids repeating the queued-wakes warning for records it just consumed while still warning on stale watcher liveness.
 It leads with a prominent bordered tangle banner, while `bin/fm-guard.sh` owns the stale-watcher banner/reminder policy so repeated guarded commands stay noisy without reprinting the full watcher-down banner in the same episode.
-On every verified primary harness, tracked hook integration gives the primary session a push-based backstop: when work is in flight and no identity-matched watcher lock with a fresh beacon is live, direct Stop hooks block and passive turn-end hooks force one bounded follow-up.
+On every verified primary harness, tracked hook integration gives the primary session a push-based backstop: when work or the topic board requires supervision and no identity-matched watcher lock with a fresh beacon is live, direct Stop hooks block and passive turn-end hooks force one bounded follow-up.
 The guard covers the main primary and genuinely marked secondmate homes, exempts child crewmate/scout worktrees, is loop-safe per harness, and is documented in [turnend-guard.md](turnend-guard.md).
 
 A presence-gated sub-supervisor (`bin/fm-supervise-daemon.sh`) extends this for walk-away supervision: the `/afk` skill starts it through the tracked foreground helper `bin/fm-afk-start.sh`, after which the watcher reverts to daemon-managed one-shot mode and the daemon self-handles routine wakes in bash.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -333,6 +333,14 @@ In dry-run, `fm-x-dismiss.sh` records `{request_id, endpoint:"dismiss"}` to the 
 The live answer and follow-up bodies intentionally stay the same shape, including optional `image`; the relay distinguishes them by endpoint, and dismiss stays `{request_id}`.
 These paths need `jq` to build the JSON payload, but they run before token and network checks, so they need neither `FMX_PAIRING_TOKEN` nor `curl`.
 
+## Telegram topic board (data/fm-telegram-topics)
+
+The optional Telegram topic board is enabled when the effective home contains private credentials at `data/fm-telegram-topics/config.env` or the legacy prototype path `data/fm-telegram-topics/test-bot-token.txt`.
+Its durable offset, inbox, answered archive, keyed reply intents, and singleton locks remain under that same gitignored data directory.
+The local `topic-map.json` binds one Telegram group and its thread ids to project names and firstmate routes.
+The tracked [topic-board guide](topic-board.md) owns activation, the systemd service, the lifeline-safety boundary, migration from the prototype check, and the operator runbook.
+The producing scripts' headers and help own exact item and reply-state mechanics.
+
 ## Environment variables
 
 Runtime tuning via environment variables (defaults shown):
@@ -367,6 +375,14 @@ FM_HEARTBEAT=600        # base seconds between heartbeat scans; no-change heartb
 FM_HEARTBEAT_MAX=7200   # heartbeat backoff cap
 FM_CHECK_INTERVAL=300   # seconds between slow checks (authenticated merge polls, custom checks, or X-mode dispatch)
 FM_CHECK_TIMEOUT=30     # seconds allowed per slow check script
+FM_TOPIC_DATA_DIR=      # optional topic-board data directory; defaults to $FM_HOME/data/fm-telegram-topics
+FM_TOPIC_CONFIG=        # optional private topic-board credential file; defaults to config.env, then the legacy test-bot-token.txt
+FM_TOPIC_MAP=           # optional topic map; defaults to $FM_TOPIC_DATA_DIR/topic-map.json
+FM_TOPIC_LIFELINE_CONFIG=   # optional direct-message plugin credential path used only for token-separation validation
+FM_TOPIC_POLL_TIMEOUT=25   # seconds per Telegram getUpdates long poll
+FM_TOPIC_REMIND_SECONDS=300   # seconds before an unanswered topic item is surfaced again
+FM_TOPIC_WATCHER_GRACE=300   # seconds within which the home-scoped watcher beacon must be fresh before the listener signals it
+FM_TOPIC_CURL_BIN=curl  # test seam for Telegram HTTP calls
 FM_CODEX_WATCH_CHECKPOINT=180   # seconds per foreground watcher checkpoint in Codex primary supervision
 FM_CREW_STATE_NM_TIMEOUT=10   # seconds allowed per no-mistakes query inside fm-crew-state.sh
 FM_CREW_STATE_RUNS_LIMIT=200  # recent no-mistakes runs rows scanned when cross-branch attribution falls back from axi status

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -52,7 +52,7 @@ The shared no-mistakes gate refusal used by `fm-spawn.sh`, `fm-send.sh`, and `fm
 | `fm-supervise-daemon.sh` | Presence-gated away-mode sub-supervisor: self-handle routine wakes, escalate batched digests, alert on failed delivery |
 | `fm-crew-state.sh`       | Print one deterministic current-state line for a crew                                |
 | `fm-tangle-lib.sh`       | Shared default-branch resolution and primary-checkout tangle classification          |
-| `fm-supervision-lib.sh`  | Shared in-flight-work-without-fresh-watcher-beacon predicate                         |
+| `fm-supervision-lib.sh`  | Shared supervision-required-without-fresh-watcher-beacon predicate (in-flight work or an enabled topic board) |
 | `fm-ff-lib.sh`           | Shared guarded fast-forward helper for origin pulls and local secondmate syncs       |
 | `fm-lock-lib.sh`         | Shared "is this git lock provably abandoned?" proof used by teardown and fleet-sync   |
 | `fm-config-inherit-lib.sh` | Shared primary-to-secondmate inherited local-material propagation                  |
@@ -80,3 +80,8 @@ The shared no-mistakes gate refusal used by `fm-spawn.sh`, `fm-send.sh`, and `fm
 | `fm-x-dismiss.sh`        | Dismiss a skipped X-mode mention at the relay without replying                       |
 | `fm-x-link.sh`           | Link a spawned task to its originating X-mode mention in task meta                   |
 | `fm-x-followup.sh`       | Detect, post, and cap completion follow-ups for an X-mode-linked task                |
+| `fm-topic-lib.sh`        | Shared paths, validation, atomic persistence, and item lookup for the Telegram topic board |
+| `fm-topic-listener.sh`   | Long-poll Telegram with the dedicated topic-board bot and durably queue captain messages before advancing the offset |
+| `fm-topic-inbox.sh`      | Inspect and claim durable Telegram topic-board inbox items without deleting them     |
+| `fm-topic-reply.sh`      | Send an idempotently keyed reply into an item's originating Telegram topic and archive it after its initial answer |
+| `fm-topic-service.sh`    | Install and manage the persistent systemd user service for the Telegram topic-board listener |

--- a/docs/supervision-protocols/grok.md
+++ b/docs/supervision-protocols/grok.md
@@ -24,7 +24,7 @@ When you see a background-task-completed system reminder for the arm:
 1. Run `bin/fm-wake-drain.sh` first.
 2. Optionally fetch arm output with `get_command_or_subagent_output(<task_id>)` for the reason line.
 3. Handle `signal`, `stale`, `check`, or `heartbeat` using the harness-neutral contract in `AGENTS.md`.
-4. Re-arm the next cycle with the same background `bin/fm-watch-arm.sh` call if work remains in flight or X mode still needs polling.
+4. Re-arm the next cycle with the same background `bin/fm-watch-arm.sh` call if work remains in flight, X mode still needs polling, or the Telegram topic board is active.
 5. Do not invent a wake from an attach-status line alone.
    Drain the queue and act only on real wake records or a real watcher reason line.
    Re-arm attaches to an existing cycle when one is already healthy, so the background task stays live until that cycle ends.

--- a/docs/topic-board.md
+++ b/docs/topic-board.md
@@ -1,0 +1,119 @@
+# Telegram topic board
+
+The topic board gives the captain a real-time Telegram forum channel with one project stream per topic.
+It uses the dedicated `@secondmate_kingbot` bot in the `DevBois II` forum group.
+It never uses the `@firstmate_kingbot` token or changes that bot's direct-message plugin poller.
+
+## Architecture
+
+`bin/fm-topic-listener.sh` runs continuously as a systemd user service and uses Telegram `getUpdates` long polling with a default 25 second timeout.
+Each accepted update is written atomically to a deterministic `update-<id>.json` inbox file before the durable Telegram offset advances.
+If the listener stops after writing the item but before advancing the offset, Telegram redelivers the update and the deterministic filename makes that replay idempotent.
+If the listener stops after advancing the offset but before notifying firstmate, the retained inbox item is found again and notification is retried.
+
+The listener appends a `topic-board` record to firstmate's durable wake queue before sending `USR1` to the identity-verified watcher for the same `FM_HOME`.
+The signal returns the active harness supervision cycle immediately, while the queued record remains the authority for recovery after a crash or restart.
+No state check or 300 second check sweep participates in the delivery path.
+The listener repeats unanswered notifications on a bounded default 300 second cadence so a crash after a queue drain cannot strand an inbox item.
+
+`bin/fm-topic-inbox.sh` lists, shows, claims, and releases individual items.
+Claiming records ownership but leaves the item in the inbox until a successful initial answer.
+`bin/fm-topic-reply.sh` sends through Telegram `sendMessage` with the item's recorded `message_thread_id`, so the response lands in the originating topic.
+A successful initial answer moves only that item into `answered/` and never bulk-deletes the inbox.
+
+Telegram does not provide an idempotency key for `sendMessage`.
+The reply helper therefore records a durable send intent before calling Telegram and refuses automatic retry after an ambiguous transport result.
+An operator must inspect the topic and choose `--confirm-sent` or `--retry-unknown`, which avoids silently creating duplicate answers after a crash.
+
+## Lifeline safety
+
+Telegram permits only one `getUpdates` consumer per bot token.
+Pointing this service at `@firstmate_kingbot` would compete with the direct-message plugin and could steal the captain's private messages.
+The separate `@secondmate_kingbot` token gives the project board its own single consumer and keeps the direct-message lifeline isolated.
+Configuration validation compares against the direct-message plugin token when it is locally available and refuses if the two tokens match.
+The group bot must have privacy mode disabled through BotFather so normal topic messages are visible to it.
+
+## Local data
+
+All runtime data is gitignored under `$FM_HOME/data/fm-telegram-topics/`.
+
+```text
+config.env                 private bot token and captain user id, mode 0600
+test-bot-token.txt         accepted legacy prototype credential filename
+topic-map.json             chat, topic, project, and route map
+.poll-offset               next Telegram update id to request
+.last-wake                 last successfully signaled notification epoch
+inbox/update-<id>.json     unanswered or claimed messages
+answered/update-<id>.json  answered messages retained for follow-ups
+outbox/*.json              durable keyed reply intents and delivery results
+locks/                     listener and per-reply singleton locks
+```
+
+The credential file accepts the following exact unquoted keys.
+
+```dotenv
+FM_TOPIC_BOT_TOKEN=<dedicated-topic-bot-token>
+FM_TOPIC_CAPTAIN_ID=<captain-telegram-user-id>
+```
+
+The legacy prototype keys `TEST_BOT_TOKEN` and `CAPTAIN_CHAT_ID` remain accepted so the existing private token file can be used without copying its secret.
+The listener refuses a credential file that is a symlink or exposes any group or other permission bits.
+
+The current project map is represented locally with this schema.
+
+```json
+{
+  "chat_id": "-1004497246253",
+  "group": "DevBois II",
+  "bot": "@secondmate_kingbot",
+  "topics": {
+    "3": {"name": "LMoonDev", "project": "L'Moon", "route": "lmoon-mate"},
+    "2": {"name": "KoruDev", "project": "Koru", "route": "koru-mate"},
+    "4": {"name": "VisDev", "project": "Vintage in Style", "route": "main"},
+    "5": {"name": "DevOps", "project": "General DevOps", "route": "main"},
+    "9": {"name": "MiscDev", "project": "Misc", "route": "main"}
+  }
+}
+```
+
+Messages in an unknown thread are retained with route `main` and an explicit unmapped-topic label.
+They are never silently discarded because the map is stale.
+
+## Installation and migration
+
+Run installation only from the landed main firstmate copy so the service does not point at a disposable branch.
+The installer validates the private credentials and map before writing or starting the unit.
+
+```bash
+bin/fm-topic-listener.sh --check-config
+bin/fm-topic-service.sh install
+```
+
+The installer refuses while the prototype `state/topic-watch.check.sh` still exists because starting the service first would create two `getUpdates` consumers for the topic bot.
+Disable or archive that legacy check, wait for any one-second prototype poll to finish, then run the installer.
+Do not remove `.poll-offset` or any inbox file during migration.
+
+The generated `firstmate-topic-board.service` is enabled under the user's `default.target`, restarts automatically, and uses the machine's existing user linger configuration to survive logout and reboot.
+It deliberately has no `After=default.target` ordering edge, which avoids the user-service ordering cycle previously seen on this host.
+
+```bash
+bin/fm-topic-service.sh status
+journalctl --user -u firstmate-topic-board.service -f
+bin/fm-topic-service.sh restart
+```
+
+Uninstalling the unit preserves credentials, offsets, inbox items, answered items, and reply intents.
+
+```bash
+bin/fm-topic-service.sh uninstall
+```
+
+## Firstmate handling
+
+The agent-only `topic-board` skill owns intake, route selection, claiming, reply, and ambiguous-delivery recovery.
+L'Moon and Koru items route to `lmoon-mate` and `koru-mate` respectively.
+VIS, DevOps, Misc, and unmapped topics remain with main firstmate.
+Worker instructions and returns carry `topic-item <update-id>` so the final outcome can be sent back to the correct originating topic.
+
+An enabled topic board requires one live harness supervision cycle even when no project task is running.
+Session-start instructions, the turn-end guard, the normal liveness guard, and the OpenCode idle-arm plugin all treat the local topic credential file as supervision demand.

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -13,7 +13,7 @@ The primary can otherwise end a turn after handling wakes without resuming super
 On 2026-07-04, that exact gap left a parked no-mistakes gate unwatched for about nine hours.
 
 `bin/fm-turnend-guard.sh` closes the gap by checking the primary's own turn-end path.
-When tasks are in flight and there is no live identity-matched watcher with a fresh beacon, a harness hook must either block the turn end or force a bounded follow-up turn that tells the primary to resume the session-start supervision protocol for its harness.
+When tasks are in flight or the Telegram topic board is active and there is no live identity-matched watcher with a fresh beacon, a harness hook must either block the turn end or force a bounded follow-up turn that tells the primary to resume the session-start supervision protocol for its harness.
 
 ## Shared Predicate
 
@@ -24,9 +24,9 @@ An unmarked checkout, or one with an invalid marker, falls through to the git-di
 That check keeps crewmate and scout worktrees inert because firstmate provisions them as linked git worktrees, where `git rev-parse --git-dir` differs from `git rev-parse --git-common-dir`.
 It also requires `AGENTS.md`, `bin/`, and the effective state directory to exist.
 
-For an in-scope primary checkout, it counts in-flight work from `state/*.meta`.
-If no task is in flight, it exits silently.
-If work is in flight, it requires `fm_watcher_healthy <state-dir> <watch-path> [grace-seconds] [home]` from `bin/fm-wake-lib.sh`.
+For an in-scope primary checkout, it counts in-flight work from `state/*.meta` and detects topic-board activation from the effective home's private credential file.
+If no task is in flight and the topic board is inactive, it exits silently.
+If supervision is required, it requires `fm_watcher_healthy <state-dir> <watch-path> [grace-seconds] [home]` from `bin/fm-wake-lib.sh`.
 That is the same identity-matched live lock and fresh beacon check used by `bin/fm-watch-arm.sh`.
 A stale beacon blocks even if a watcher pid is still live.
 A fresh leftover beacon blocks if the watcher lock is missing, dead, or identity-mismatched.

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -349,7 +349,7 @@ SH
 }
 
 test_orca_backend_gates_orca_tool_only_when_selected() {
-  local case_dir fakebin out missing_orca
+  local case_dir fakebin bash_env out missing_orca
   missing_orca="MISSING: orca (install: brew install orca  # or the platform's package manager)"
 
   case_dir="$TMP_ROOT/orca-backend-selected"
@@ -357,7 +357,19 @@ test_orca_backend_gates_orca_tool_only_when_selected() {
   printf '%s\n' manual > "$case_dir/home/config/backlog-backend"
   printf '%s\n' orca > "$case_dir/home/config/backend"
   fakebin=$(make_fake_toolchain "$case_dir")
-  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+  bash_env="$case_dir/no-orca.bash"
+  cat > "$bash_env" <<'SH'
+command() {
+  if [ "${1:-}" = -v ] && [ "${2:-}" = orca ]; then
+    return 1
+  fi
+  builtin command "$@"
+}
+orca() {
+  return 127
+}
+SH
+  out=$(PATH="$fakebin:$BASE_PATH" BASH_ENV="$bash_env" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
     FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
   [ "$out" = "$missing_orca" ] || fail "backend=orca should require only the Orca-specific missing tool, got: $out"
 

--- a/tests/fm-cd-pretool-check.test.sh
+++ b/tests/fm-cd-pretool-check.test.sh
@@ -435,6 +435,7 @@ test_pi_wiring() {
 }
 
 test_scripts_are_shellcheck_clean() {
+  command -v shellcheck >/dev/null 2>&1 || { pass "shellcheck not installed, skipping"; return; }
   shellcheck "$ROOT/bin/fm-cd-pretool-check.sh" >/dev/null 2>&1 \
     || fail "bin/fm-cd-pretool-check.sh is not shellcheck-clean"
   pass "bin/fm-cd-pretool-check.sh is shellcheck-clean"

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -394,19 +394,29 @@ EOF
 # --- output ordering ----------------------------------------------------------
 
 test_output_ordering_diagnostics_lead() {
-  local rec root home fakebin out lock_line boot_line wake_line context_line fleet_line next_line
+  local rec root home fakebin out lock_line boot_line wake_line context_line fleet_line next_line mask
   rec=$(new_world ordering)
   IFS='|' read -r root home fakebin <<EOF
 $rec
 EOF
   make_fake_toolchain "$fakebin"
   make_fake_ps_claude "$fakebin"
-  # Force a MISSING diagnostic line so the bootstrap section is non-trivial.
+  # Force a MISSING diagnostic line so the bootstrap section is non-trivial,
+  # even when the host also has node in the baseline /usr/bin path.
   rm -f "$fakebin/node"
+  mask="$home/mask-node.bash"
+  cat > "$mask" <<'SH'
+command() {
+  if [ "${1:-}" = -v ] && [ "${2:-}" = node ]; then
+    return 1
+  fi
+  builtin command "$@"
+}
+SH
 
   printf 'window=fm-sess:w1\nkind=ship\n' > "$home/state/task-a.meta"
 
-  out=$(run_session_start "$home" "$root" "$fakebin:$BASE_PATH")
+  out=$(BASH_ENV="$mask" run_session_start "$home" "$root" "$fakebin:$BASE_PATH")
 
   lock_line=$(printf '%s\n' "$out" | grep -n '^LOCK$' | head -1 | cut -d: -f1)
   boot_line=$(printf '%s\n' "$out" | grep -n '^BOOTSTRAP$' | head -1 | cut -d: -f1)
@@ -578,7 +588,7 @@ EOF
 # --- composition: real scripts run, not reimplemented ------------------------
 
 test_composition_invokes_real_scripts() {
-  local rec root home fakebin out
+  local rec root home fakebin out mask
   rec=$(new_world composition)
   IFS='|' read -r root home fakebin <<EOF
 $rec
@@ -586,10 +596,19 @@ EOF
   make_fake_toolchain "$fakebin"
   make_fake_ps_claude "$fakebin"
   rm -f "$fakebin/node"
+  mask="$home/mask-node.bash"
+  cat > "$mask" <<'SH'
+command() {
+  if [ "${1:-}" = -v ] && [ "${2:-}" = node ]; then
+    return 1
+  fi
+  builtin command "$@"
+}
+SH
 
   append_wake "$home/state" signal task-z "needs-decision: pick a library"
 
-  out=$(run_session_start "$home" "$root" "$fakebin:$BASE_PATH")
+  out=$(BASH_ENV="$mask" run_session_start "$home" "$root" "$fakebin:$BASE_PATH")
 
   # fm-lock.sh's own exact success text.
   assert_contains "$out" "lock acquired: harness pid" "fm-lock.sh's real output did not appear (composition, not reimplementation)"
@@ -747,6 +766,25 @@ EOF
   assert_contains "$out" "Follow the supervision operating instructions block above" "next step did not point back to the emitted supervision block"
 
   pass "session start emits X-mode cadence guidance in the harness supervision block"
+}
+
+test_next_step_keeps_topic_board_supervision_live() {
+  local rec root home fakebin out
+  rec=$(new_world next-step-topic-board)
+  IFS='|' read -r root home fakebin <<EOF
+$rec
+EOF
+  make_fake_toolchain "$fakebin"
+  make_fake_ps_claude "$fakebin"
+  mkdir -p "$home/data/fm-telegram-topics"
+  : > "$home/data/fm-telegram-topics/config.env"
+
+  out=$(run_session_start "$home" "$root" "$fakebin:$BASE_PATH")
+
+  assert_contains "$out" "Telegram topic board: active" "session supervision block omitted active topic-board demand"
+  assert_contains "$out" "keep one live supervision cycle even when no project work is in flight" "topic-board-only session was allowed to end blind"
+  assert_contains "$out" "topic-board supervision instructions" "next step did not point back to topic-board supervision"
+  pass "session start keeps supervision live for a topic-board-only home"
 }
 
 test_next_step_afk_delegates_to_daemon() {
@@ -915,6 +953,7 @@ test_backlog_compact_manual_backend_skips_indented_bodies
 test_backlog_compact_tasks_axi_unavailable_uses_manual_fallback
 test_fleet_digest_empty_fleet
 test_next_step_sources_x_mode_cadence
+test_next_step_keeps_topic_board_supervision_live
 test_next_step_afk_delegates_to_daemon
 test_supervision_block_exactly_one_and_pi_diagnostic
 test_pi_diagnostic_rejects_stale_loaded_marker

--- a/tests/fm-supervision-instructions.test.sh
+++ b/tests/fm-supervision-instructions.test.sh
@@ -32,14 +32,15 @@ test_conditional_stanzas() {
   home="$TMP_ROOT/conditional-home"
   config="$TMP_ROOT/conditional-config"
   mkdir -p "$home/state" "$home/config" "$config"
-  out=$(FM_HOME="$home" FM_CONFIG_OVERRIDE="$config" "$RENDER" --harness codex --read-only 1 --afk 1 --x-mode 1)
+  out=$(FM_HOME="$home" FM_CONFIG_OVERRIDE="$config" "$RENDER" --harness codex --read-only 1 --afk 1 --x-mode 1 --topic-board 1)
   assert_contains "$out" "- Lock: read-only" "read-only stanza missing"
   assert_contains "$out" "- Away mode: active" "afk stanza missing"
   assert_contains "$out" "- X mode: active" "x-mode stanza missing"
+  assert_contains "$out" "- Telegram topic board: active" "topic-board stanza missing"
   assert_contains "$out" "$config/x-mode.env" "x-mode stanza did not render the effective config path"
   assert_contains "$out" 'Mode: Codex foreground checkpoint.' "codex snippet missing"
   assert_not_contains "$out" "Source \`config/x-mode.env\`" "snippet kept the repo-relative x-mode config path"
-  pass "renderer includes read-only, afk, and effective x-mode current-state stanzas"
+  pass "renderer includes read-only, afk, X-mode, and topic-board current-state stanzas"
 }
 
 test_repair_lines() {

--- a/tests/fm-topic-board.test.sh
+++ b/tests/fm-topic-board.test.sh
@@ -1,0 +1,329 @@
+#!/usr/bin/env bash
+# End-to-end behavior tests for durable Telegram topic intake, wake delivery, replies, and service installation.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+LISTENER="$ROOT/bin/fm-topic-listener.sh"
+INBOX="$ROOT/bin/fm-topic-inbox.sh"
+REPLY="$ROOT/bin/fm-topic-reply.sh"
+SERVICE="$ROOT/bin/fm-topic-service.sh"
+TMP_ROOT=$(fm_test_tmproot fm-topic-board)
+
+make_home() {
+  local home="$TMP_ROOT/$1" data
+  data="$home/data/fm-telegram-topics"
+  mkdir -p "$home/state" "$home/config" "$data"
+  cat > "$data/config.env" <<'EOF'
+FM_TOPIC_BOT_TOKEN=123456:test_topic_token
+FM_TOPIC_CAPTAIN_ID=953048088
+EOF
+  chmod 600 "$data/config.env"
+  cat > "$data/topic-map.json" <<'EOF'
+{
+  "chat_id": "-1004497246253",
+  "group": "DevBois II",
+  "bot": "@secondmate_kingbot",
+  "topics": {
+    "3": {"name": "LMoonDev", "project": "L'Moon", "route": "lmoon-mate"},
+    "2": {"name": "KoruDev", "project": "Koru", "route": "koru-mate"},
+    "4": {"name": "VisDev", "project": "Vintage in Style", "route": "main"}
+  }
+}
+EOF
+  printf '%s\n' "$home"
+}
+
+make_fake_curl() {
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/curl" <<'SH'
+#!/usr/bin/env bash
+for arg in "$@"; do
+  printf '%s\n' "$arg" >> "${FM_FAKE_CURL_LOG:?}"
+done
+printf '%s\n' END >> "$FM_FAKE_CURL_LOG"
+case " $* " in
+  *getUpdates*) cat "${FM_FAKE_GET_UPDATES:?}" ;;
+  *sendMessage*)
+    rc=${FM_FAKE_SEND_RC:-0}
+    [ "$rc" -eq 0 ] || exit "$rc"
+    cat "${FM_FAKE_SEND_RESPONSE:?}"
+    ;;
+  *) echo 'unexpected fake curl request' >&2; exit 2 ;;
+esac
+SH
+  chmod +x "$fakebin/curl"
+  printf '%s\n' "$fakebin"
+}
+
+write_updates() {
+  local file=$1
+  shift
+  jq -n --args '$ARGS.positional | map(fromjson) | {ok:true, result:.}' "$@" > "$file"
+}
+
+listener_once() {
+  local home=$1 fakebin=$2 response=$3 log=$4
+  PATH="$fakebin:$PATH" \
+    FM_HOME="$home" \
+    FM_ROOT_OVERRIDE="$ROOT" \
+    FM_TOPIC_POLL_TIMEOUT=0 \
+    FM_TOPIC_REMIND_SECONDS=300 \
+    FM_FAKE_GET_UPDATES="$response" \
+    FM_FAKE_CURL_LOG="$log" \
+    FM_FAKE_SEND_RESPONSE="$response" \
+    "$LISTENER" --once
+}
+
+test_listener_is_lossless_and_topic_aware() {
+  local home fakebin response log data count out status lifeline
+  home=$(make_home listener-lossless)
+  fakebin=$(make_fake_curl "$home")
+  response="$home/updates.json"
+  log="$home/curl.log"
+  : > "$log"
+  write_updates "$response" \
+    '{"update_id":10,"message":{"message_id":101,"message_thread_id":3,"from":{"id":953048088},"chat":{"id":-1004497246253},"text":"Build the booking fix"}}' \
+    '{"update_id":11,"message":{"message_id":102,"message_thread_id":3,"from":{"id":42},"chat":{"id":-1004497246253},"text":"not captain"}}' \
+    '{"update_id":12,"message":{"message_id":103,"message_thread_id":99,"from":{"id":953048088},"chat":{"id":-1004497246253},"caption":"diagram","photo":[{"file_id":"p1"}]}}'
+
+  listener_once "$home" "$fakebin" "$response" "$log" >/dev/null 2>&1 || fail "listener rejected valid updates"
+  data="$home/data/fm-telegram-topics"
+  [ "$(cat "$data/.poll-offset")" = 13 ] || fail "listener did not advance offset past every inspected update"
+  assert_present "$data/inbox/update-10.json" "mapped captain item was not retained"
+  assert_absent "$data/inbox/update-11.json" "non-captain item reached the private inbox"
+  assert_present "$data/inbox/update-12.json" "unmapped captain item was silently dropped"
+  [ "$(jq -r '.route' "$data/inbox/update-10.json")" = lmoon-mate ] || fail "mapped topic did not retain its secondmate route"
+  [ "$(jq -r '.topic' "$data/inbox/update-10.json")" = LMoonDev ] || fail "mapped topic name was not retained"
+  [ "$(jq -r '.route' "$data/inbox/update-12.json")" = main ] || fail "unmapped topic did not fall back to main"
+  [ "$(jq -r '.content_type' "$data/inbox/update-12.json")" = photo ] || fail "non-text captain message metadata was not retained"
+  count=$(find "$data/inbox" -type f -name 'update-*.json' | wc -l | tr -d '[:space:]')
+  [ "$count" -eq 2 ] || fail "listener persisted an unexpected inbox count: $count"
+  assert_grep "$(printf '\tcheck\ttopic-board\t')" "$home/state/.wake-queue" "listener did not queue a durable topic wake"
+
+  printf '10\n' > "$data/.poll-offset"
+  listener_once "$home" "$fakebin" "$response" "$log" >/dev/null 2>&1 || fail "listener failed while replaying an unconfirmed batch"
+  count=$(find "$data/inbox" -type f -name 'update-*.json' | wc -l | tr -d '[:space:]')
+  [ "$count" -eq 2 ] || fail "replayed Telegram updates created duplicate inbox items"
+  out=$(FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" "$INBOX" list)
+  assert_contains "$out" $'10\tpending\tLMoonDev\tL\x27Moon\tlmoon-mate' "inbox list omitted topic and route context"
+
+  lifeline="$home/direct-message.env"
+  printf 'TELEGRAM_BOT_TOKEN=123456:test_topic_token\n' > "$lifeline"
+  chmod 600 "$lifeline"
+  set +e
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" FM_TOPIC_LIFELINE_CONFIG="$lifeline" "$LISTENER" --check-config 2>&1)
+  status=$?
+  set -e
+  [ "$status" -ne 0 ] || fail "listener accepted the direct-message bot token for topic polling"
+  assert_contains "$out" 'refusing to risk the captain lifeline' "same-token refusal did not explain the safety boundary"
+  pass "listener persists before offset, survives replay exactly once, and retains mapped or unmapped captain content"
+}
+
+test_boundary_offset_and_failed_persistence() {
+  local home fakebin response log data
+  home=$(make_home offset-boundary)
+  fakebin=$(make_fake_curl "$home")
+  response="$home/updates.json"
+  log="$home/curl.log"
+  : > "$log"
+  data="$home/data/fm-telegram-topics"
+  printf '20\n' > "$data/.poll-offset"
+  write_updates "$response" \
+    '{"update_id":20,"message":{"message_id":201,"message_thread_id":2,"from":{"id":953048088},"chat":{"id":-1004497246253},"text":"boundary"}}'
+  listener_once "$home" "$fakebin" "$response" "$log" >/dev/null 2>&1 || fail "listener failed at the exact offset boundary"
+  [ "$(cat "$data/.poll-offset")" = 21 ] || fail "boundary update did not advance the offset"
+
+  printf '30\n' > "$data/.poll-offset"
+  mkdir "$data/inbox/update-30.json"
+  write_updates "$response" \
+    '{"update_id":30,"message":{"message_id":301,"message_thread_id":2,"from":{"id":953048088},"chat":{"id":-1004497246253},"text":"must persist"}}'
+  if listener_once "$home" "$fakebin" "$response" "$log" >/dev/null 2>&1; then
+    fail "listener advanced despite an unwritable item destination"
+  fi
+  [ "$(cat "$data/.poll-offset")" = 30 ] || fail "failed item persistence advanced the durable offset"
+
+  rmdir "$data/inbox/update-30.json"
+  cat > "$fakebin/sync" <<'SH'
+#!/usr/bin/env bash
+exit 1
+SH
+  chmod +x "$fakebin/sync"
+  printf '31\n' > "$data/.poll-offset"
+  write_updates "$response" \
+    '{"update_id":31,"message":{"message_id":302,"message_thread_id":2,"from":{"id":953048088},"chat":{"id":-1004497246253},"text":"must flush"}}'
+  if listener_once "$home" "$fakebin" "$response" "$log" >/dev/null 2>&1; then
+    fail "listener accepted an inbox write whose filesystem flush failed"
+  fi
+  [ "$(cat "$data/.poll-offset")" = 31 ] || fail "failed inbox flush advanced the durable offset"
+  assert_absent "$data/inbox/update-31.json" "failed inbox flush published an item as durable"
+  pass "offset boundary advances and persistence or flush failure leaves the update recoverable"
+}
+
+wait_for_file() {
+  local file=$1 i=0
+  while [ "$i" -lt 100 ]; do
+    [ -e "$file" ] && return 0
+    sleep 0.05
+    i=$((i + 1))
+  done
+  return 1
+}
+
+test_fast_wake_signals_only_verified_home_watcher() {
+  local home fakebin response log watch_out watcher
+  home=$(make_home fast-wake)
+  fakebin=$(make_fake_curl "$home")
+  response="$home/updates.json"
+  log="$home/curl.log"
+  watch_out="$home/watch.out"
+  : > "$log"
+  write_updates "$response" \
+    '{"update_id":40,"message":{"message_id":401,"message_thread_id":3,"from":{"id":953048088},"chat":{"id":-1004497246253},"text":"wake now"}}'
+
+  FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" FM_POLL=60 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$ROOT/bin/fm-watch.sh" > "$watch_out" 2>&1 &
+  watcher=$!
+  if ! wait_for_file "$home/state/.watch.lock/pid" || ! wait_for_file "$home/state/.last-watcher-beat"; then
+    kill "$watcher" 2>/dev/null || true
+    wait "$watcher" 2>/dev/null || true
+    fail "test watcher did not become healthy"
+  fi
+  listener_once "$home" "$fakebin" "$response" "$log" >/dev/null 2>&1 || {
+    kill "$watcher" 2>/dev/null || true
+    wait "$watcher" 2>/dev/null || true
+    fail "listener failed while signaling the watcher"
+  }
+  wait "$watcher" || fail "watcher did not exit cleanly through the USR1 fast path"
+  assert_grep 'check: topic-board: external event queued' "$watch_out" "watcher did not report the queued topic event"
+  assert_grep "$(printf '\tcheck\ttopic-board\t')" "$home/state/.wake-queue" "fast wake lost its durable queue record"
+  pass "listener queues first, then returns the identity-verified home watcher immediately"
+}
+
+test_claim_reply_idempotency_and_ambiguous_delivery() {
+  local home fakebin response send_response log data out status send_count
+  home=$(make_home replies)
+  fakebin=$(make_fake_curl "$home")
+  response="$home/updates.json"
+  send_response="$home/send.json"
+  log="$home/curl.log"
+  : > "$log"
+  printf '%s\n' '{"ok":true,"result":{"message_id":900,"message_thread_id":3,"chat":{"title":"DevBois II"}}}' > "$send_response"
+  write_updates "$response" \
+    '{"update_id":50,"message":{"message_id":501,"message_thread_id":3,"from":{"id":953048088},"chat":{"id":-1004497246253},"text":"ship it"}}'
+  listener_once "$home" "$fakebin" "$response" "$log" >/dev/null 2>&1 || fail "could not seed reply item"
+  data="$home/data/fm-telegram-topics"
+
+  FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" "$INBOX" claim 50 lmoon-mate >/dev/null || fail "claim failed"
+  [ "$(jq -r '.status' "$data/inbox/update-50.json")" = claimed ] || fail "claim status was not persisted"
+  out=$(printf 'Started and routed.' | PATH="$fakebin:$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" FM_FAKE_CURL_LOG="$log" FM_FAKE_SEND_RESPONSE="$send_response" "$REPLY" 50)
+  assert_contains "$out" 'sent into topic thread 3' "reply did not report the originating thread"
+  assert_absent "$data/inbox/update-50.json" "answered item remained in the active inbox"
+  assert_present "$data/answered/update-50.json" "answered item was deleted instead of archived"
+  [ "$(jq -r '.status' "$data/outbox/update-50-initial.json")" = sent ] || fail "reply intent was not recorded as sent"
+
+  printf 'Started and routed.' | PATH="$fakebin:$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" FM_FAKE_CURL_LOG="$log" FM_FAKE_SEND_RESPONSE="$send_response" "$REPLY" 50 >/dev/null || fail "idempotent reply replay failed"
+  send_count=$(grep -c 'sendMessage' "$log")
+  [ "$send_count" -eq 1 ] || fail "same keyed reply was sent more than once"
+
+  printf 'Finished successfully.' | PATH="$fakebin:$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" FM_FAKE_CURL_LOG="$log" FM_FAKE_SEND_RESPONSE="$send_response" "$REPLY" 50 --follow-up completion >/dev/null || fail "follow-up to archived item failed"
+  assert_grep 'message_thread_id=3' "$log" "reply did not carry the originating message_thread_id"
+  send_count=$(grep -c 'sendMessage' "$log")
+  [ "$send_count" -eq 2 ] || fail "stable follow-up key did not create exactly one additional send"
+
+  write_updates "$response" \
+    '{"update_id":51,"message":{"message_id":502,"message_thread_id":3,"from":{"id":953048088},"chat":{"id":-1004497246253},"text":"ambiguous"}}'
+  printf '51\n' > "$data/.poll-offset"
+  listener_once "$home" "$fakebin" "$response" "$log" >/dev/null 2>&1 || fail "could not seed ambiguous reply item"
+  set +e
+  printf 'Maybe delivered.' | PATH="$fakebin:$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" FM_FAKE_CURL_LOG="$log" FM_FAKE_SEND_RESPONSE="$send_response" FM_FAKE_SEND_RC=28 "$REPLY" 51 >/dev/null 2>&1
+  status=$?
+  set -e
+  [ "$status" -ne 0 ] || fail "transport failure was reported as a successful reply"
+  [ "$(jq -r '.status' "$data/outbox/update-51-initial.json")" = delivery_unknown ] || fail "ambiguous send was not durably marked"
+  set +e
+  printf 'Maybe delivered.' | PATH="$fakebin:$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" FM_FAKE_CURL_LOG="$log" FM_FAKE_SEND_RESPONSE="$send_response" "$REPLY" 51 >/dev/null 2>&1
+  status=$?
+  set -e
+  [ "$status" -ne 0 ] || fail "ambiguous reply retried automatically"
+  PATH="$fakebin:$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" FM_FAKE_CURL_LOG="$log" FM_FAKE_SEND_RESPONSE="$send_response" "$REPLY" 51 --confirm-sent >/dev/null || fail "manual sent confirmation failed"
+  assert_present "$data/answered/update-51.json" "confirmed ambiguous item was not archived"
+  pass "claims persist, keyed replies do not duplicate, and ambiguous delivery requires an explicit decision"
+}
+
+test_service_and_supervision_integration() {
+  local home fakebin systemctl_log systemd_dir unit out status plugin repo arm_log
+  home=$(make_home service)
+  fakebin=$(fm_fakebin "$home/systemctl")
+  systemctl_log="$home/systemctl.log"
+  systemd_dir="$home/systemd"
+  cat > "$fakebin/systemctl" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${FM_FAKE_SYSTEMCTL_LOG:?}"
+exit 0
+SH
+  chmod +x "$fakebin/systemctl"
+
+  unit=$(FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" "$SERVICE" print-unit)
+  assert_contains "$unit" 'Restart=always' "service unit does not restart persistently"
+  assert_contains "$unit" "ExecStart=\"$ROOT/bin/fm-topic-listener.sh\"" "service unit does not run the tracked listener"
+  assert_not_contains "$unit" 'test_topic_token' "service unit leaked the bot token"
+  assert_not_contains "$unit" 'After=default.target' "service unit recreated the known default-target ordering cycle"
+
+  : > "$home/state/topic-watch.check.sh"
+  set +e
+  out=$(FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" FM_TOPIC_SYSTEMD_DIR="$systemd_dir" FM_TOPIC_SYSTEMCTL="$fakebin/systemctl" FM_FAKE_SYSTEMCTL_LOG="$systemctl_log" "$SERVICE" install 2>&1)
+  status=$?
+  set -e
+  [ "$status" -ne 0 ] || fail "service installer accepted the competing prototype poller"
+  assert_contains "$out" 'two getUpdates consumers' "prototype conflict refusal did not explain the token race"
+  rm -f "$home/state/topic-watch.check.sh"
+  FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" FM_TOPIC_SYSTEMD_DIR="$systemd_dir" FM_TOPIC_SYSTEMCTL="$fakebin/systemctl" FM_FAKE_SYSTEMCTL_LOG="$systemctl_log" "$SERVICE" install >/dev/null || fail "service installation failed"
+  assert_present "$systemd_dir/firstmate-topic-board.service" "service installer did not persist the unit"
+  assert_grep 'enable --now firstmate-topic-board.service' "$systemctl_log" "service installer did not enable the durable unit"
+
+  # shellcheck source=bin/fm-supervision-lib.sh
+  . "$ROOT/bin/fm-supervision-lib.sh"
+  if ! FM_HOME="$home" fm_supervision_unhealthy "$home/state" 300 "$home"; then
+    fail "topic credentials did not require supervision with an empty fleet"
+  fi
+  [ "$FM_SUP_TOPIC_BOARD" = true ] || fail "supervision status did not expose active topic-board demand"
+  out=$(FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" "$ROOT/bin/fm-supervision-instructions.sh" --harness codex --topic-board 1)
+  assert_contains "$out" 'Telegram topic board: active' "session supervision block omitted topic-board demand"
+
+  plugin="$ROOT/.opencode/plugins/fm-primary-watch-arm.js"
+  repo="$home/opencode-root"
+  arm_log="$home/opencode-arm.log"
+  mkdir -p "$repo/bin"
+  git init -q "$repo"
+  : > "$repo/AGENTS.md"
+  cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
+#!/usr/bin/env bash
+printf 'armed\n' >> "${FM_ARM_LOG:?}"
+printf 'watcher: healthy pid=1 (beacon 0s)\n'
+SH
+  chmod +x "$repo/bin/fm-watch-arm.sh"
+  out=$(PLUGIN="$plugin" WORKTREE="$repo" FM_HOME="$home" FM_ARM_LOG="$arm_log" node 2>&1 <<'EOF'
+import { existsSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+const mod = await import(pathToFileURL(process.env.PLUGIN).href);
+const client = { session: { promptAsync: async () => {} } };
+const hooks = await mod.FmPrimaryWatchArm({client, directory: process.env.WORKTREE, worktree: process.env.WORKTREE});
+writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
+await hooks.event({event: {type: "session.idle", properties: {sessionID: "topic-test"}}});
+for (let i = 0; i < 50 && !existsSync(process.env.FM_ARM_LOG); i += 1) await new Promise((resolve) => setTimeout(resolve, 20));
+if (!existsSync(process.env.FM_ARM_LOG)) process.exit(1);
+EOF
+  )
+  status=$?
+  expect_code 0 "$status" "OpenCode did not arm for topic-board-only supervision"
+  [ -z "$out" ] || fail "OpenCode topic-board arm test printed output: $out"
+  pass "systemd persistence refuses poller races and every primary supervision path stays active for the topic board"
+}
+
+test_listener_is_lossless_and_topic_aware
+test_boundary_offset_and_failed_persistence
+test_fast_wake_signals_only_verified_home_watcher
+test_claim_reply_idempotency_and_ambiguous_delivery
+test_service_and_supervision_integration

--- a/tests/fm-turnend-guard.test.sh
+++ b/tests/fm-turnend-guard.test.sh
@@ -77,6 +77,18 @@ test_predicate_queue_pending_flag() {
   pass "fm_supervision_status: FM_SUP_QUEUE_PENDING tracks state/.wake-queue"
 }
 
+test_predicate_topic_board_requires_supervision() {
+  local home="$TMP_ROOT/pred-topic-board" state
+  state="$home/state"
+  mkdir -p "$state" "$home/data/fm-telegram-topics"
+  : > "$home/data/fm-telegram-topics/config.env"
+  fm_supervision_unhealthy "$state" 300 "$home" || fail "predicate did not require a watcher for an active topic board"
+  [ "$FM_SUP_IN_FLIGHT" -eq 0 ] || fail "topic-board predicate invented an in-flight task"
+  [ "$FM_SUP_TOPIC_BOARD" = true ] || fail "topic-board predicate did not expose active topic supervision"
+  [ "$FM_SUP_REQUIRED" = true ] || fail "topic-board predicate did not mark supervision required"
+  pass "fm_supervision_unhealthy: topic board requires supervision with no task in flight"
+}
+
 # --- HOOK: bin/fm-turnend-guard.sh ------------------------------------------
 #
 # Each scenario gets its own directory carrying a copy of the two guard scripts
@@ -202,6 +214,18 @@ test_hook_silent_when_no_work_in_flight() {
   expect_code 0 "$status" "hook must exit 0 with no in-flight work"
   [ -z "$out" ] || fail "hook produced output with no in-flight work: $out"
   pass "fm-turnend-guard: silent no-op with nothing in flight"
+}
+
+test_hook_blocks_for_topic_board_without_inflight_work() {
+  local dir out status
+  dir=$(make_primary_dir "$TMP_ROOT/hook-topic-board")
+  mkdir -p "$dir/data/fm-telegram-topics"
+  : > "$dir/data/fm-telegram-topics/config.env"
+  out=$(run_hook "$dir" false); status=$?
+  expect_code 2 "$status" "hook must block when the topic board is active without a watcher"
+  assert_contains "$out" "Telegram topic board needs supervision" "topic-board-only block did not name the active supervision demand"
+  assert_contains "$out" "$REQUIRED_REASON" "topic-board-only block omitted the harness repair instruction"
+  pass "fm-turnend-guard: active topic board cannot end blind with an empty fleet"
 }
 
 test_hook_blocks_when_fresh_beacon_has_no_live_lock() {
@@ -890,7 +914,9 @@ test_predicate_unhealthy_no_beacon
 test_predicate_unhealthy_stale_beacon
 test_predicate_healthy_fresh_beacon
 test_predicate_queue_pending_flag
+test_predicate_topic_board_requires_supervision
 test_hook_silent_when_no_work_in_flight
+test_hook_blocks_for_topic_board_without_inflight_work
 test_hook_blocks_when_fresh_beacon_has_no_live_lock
 test_hook_blocks_when_dead_lock_has_fresh_beacon
 test_hook_silent_with_live_lock_and_fresh_beacon

--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -474,12 +474,16 @@ test_watcher_self_evicts_on_lock_takeover() {
   PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_POLL=0.2 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
   pid=$!
   i=0
-  while [ "$i" -lt 50 ]; do
-    [ "$(cat "$state/.watch.lock/pid" 2>/dev/null || true)" = "$pid" ] && break
+  while [ "$i" -lt 100 ]; do
+    if [ "$(cat "$state/.watch.lock/pid" 2>/dev/null || true)" = "$pid" ] \
+      && [ -e "$state/.last-watcher-beat" ]; then
+      break
+    fi
     sleep 0.1
     i=$((i + 1))
   done
   [ "$(cat "$state/.watch.lock/pid" 2>/dev/null || true)" = "$pid" ] || fail "watcher did not record its own pid in the lock"
+  [ -e "$state/.last-watcher-beat" ] || fail "watcher did not finish startup before the takeover test"
   # Simulate a second watcher taking over the singleton lock. $$ (the test
   # runner) is a live pid that is not the watcher.
   printf '%s\n' "$$" > "$state/.watch.lock/pid"


### PR DESCRIPTION
## Intent

Build a reliable, real-time, topic-aware Telegram project-board channel for firstmate that replaces the flaky local prototype. Use the separate @secondmate_kingbot group bot and never touch or compete with the live @firstmate_kingbot direct-message poller. Persist each captain update durably before advancing the Telegram offset, retain each inbox item until its specific answer succeeds, prevent blanket-delete races and duplicate replies, route L'Moon and Koru topics to their registered secondmates while main firstmate handles VIS, DevOps, Misc, and unmapped topics, and reply into the originating Telegram topic. Use a persistent long-poll service and a prompt, durable, home-scoped supervision wake path rather than the 300-second watcher sweep or X-mode cadence hack. Survive firstmate restarts, keep all secrets in gitignored local files, provide tracked shellcheck-clean scripts, colocated tests, one-sentence-per-line documentation, and a clear separate-bot lifeline-safety explanation. Keep behavior tests hermetic when ShellCheck is absent because the pinned lint gate owns enforcement, and make the watcher takeover regression wait for genuine watcher readiness so loaded full-suite runs do not start the eviction timeout during process startup. This is firstmate repository infrastructure and must produce a captain-reviewed PR with green CI, but must not be self-merged.

## What Changed

- Added a persistent long-poll Telegram topic-board service (`fm-topic-service.sh`, `fm-topic-listener.sh`, `fm-topic-lib.sh`, `fm-topic-inbox.sh`, `fm-topic-reply.sh`) that durably persists each captain update before advancing the Telegram offset, retains inbox items until their reply succeeds, and routes L'Moon/Koru topics to their registered secondmates while firstmate handles VIS, DevOps, Misc, and unmapped topics via the separate `@secondmate_kingbot` bot.
- Reworked the watcher's wake path (`bin/fm-watch.sh`, `bin/fm-guard.sh`, `bin/fm-session-start.sh`, `bin/fm-supervision-lib.sh`, `bin/fm-supervision-instructions.sh`, `bin/fm-turnend-guard.sh`) to use a prompt, home-scoped USR1 signal instead of the 300-second sweep/X-mode cadence hack, including SIGTERM/SIGKILL escalation in `fm_active_wait_stop`'s cleanup path.
- Added docs (`docs/topic-board.md`, `docs/architecture.md`, `docs/configuration.md`, `docs/turnend-guard.md`, `.agents/skills/topic-board/SKILL.md`) and tests (`tests/fm-topic-board.test.sh`, updates to `tests/fm-session-start.test.sh`, `tests/fm-turnend-guard.test.sh`, `tests/fm-watcher-lock.test.sh`, `tests/fm-bootstrap.test.sh`), and made the behavior suite tolerate a missing ShellCheck and wait for genuine watcher readiness before takeover.

## Risk Assessment

✅ Low: The only change in this round is the fix for the previously-reported missing SIGKILL escalation; the fix closes the indefinite-hang risk but leaves a narrower, lower-probability inconsistency (a missing confirmation-retry loop present in the analogous sibling function) that is partially self-healing via existing dead-pid lock recovery, so it is safe to merge with a small follow-up.

## Testing

All topic-board and watcher-lock tests passed, and a manual CLI walkthrough confirmed routing, lifeline-safety refusal, archive-not-delete, and duplicate-reply prevention end to end.

<details>
<summary>Evidence: fm-topic-board.test.sh transcript</summary>

```text
ok - listener persists before offset, survives replay exactly once, and retains mapped or unmapped captain content
ok - offset boundary advances and persistence or flush failure leaves the update recoverable
ok - listener queues first, then returns the identity-verified home watcher immediately
ok - claims persist, keyed replies do not duplicate, and ambiguous delivery requires an explicit decision
ok - systemd persistence refuses poller races and every primary supervision path stays active for the topic board
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 warning</summary>

- ⚠️ `bin/fm-watch.sh:164` - fm_active_wait_stop (bin/fm-watch.sh:164-177), added so USR1 can interrupt the watcher&#39;s blocking event wait promptly, only sends SIGTERM to the background wait job/group and then does an unbounded `wait &#34;$pid&#34;` with no SIGKILL escalation. The sibling function fm_active_check_stop (bin/fm-watch.sh:480-503), which stops the analogous active-check background job, explicitly escalates to SIGKILL after a bounded poll because a background subprocess is not guaranteed to die on TERM alone. fm_active_wait_stop runs from the EXIT trap (watcher_cleanup), which fires when the new `trap &#39;wake ...&#39; USR1` handler calls exit - exactly the fast path this PR adds for the topic-board listener&#39;s `kill -USR1`. If the backgrounded fm_backend_wait_transition (or the raw-socket reader subprocess it itself forks, see fm_backend_herdr_wait_transition in bin/backends/herdr.sh) does not exit promptly on SIGTERM, `wait &#34;$pid&#34;` blocks indefinitely, hanging the watcher&#39;s exit and defeating the prompt-wake path the feature is built around, and potentially leaving the watcher lock held so no successor watcher can take over. No test exercises this stop path.

🔧 Fix: Add SIGKILL escalation to fm_active_wait_stop&#39;s cleanup path
1 warning still open:
- ⚠️ `bin/fm-watch.sh:177` - The fix (bin/fm-watch.sh:164-187) added the SIGTERM-&gt;wait-&gt;SIGKILL escalation that was missing before, but it omits the confirmation retry loop that the sibling fm_active_check_stop (bin/fm-watch.sh:491-513, unchanged) uses between the SIGKILL and the final liveness check: fm_active_check_stop polls `kill -0 -- &#34;-$pgid&#34;` for up to 100*0.01s=~1s after the KILL+wait before declaring failure, while the new fm_active_wait_stop checks `kill -0 -- &#34;-$pgid&#34;` at line 177 exactly once, immediately after `wait &#34;$pid&#34;` (which only reaps the direct child - the backgrounded fm_backend_wait_transition subshell - not any grandchild it forked, e.g. the raw-socket reader in fm_backend_herdr_wait_transition, which also received the group SIGKILL but may take a moment to actually become unschedulable/reaped). This can cause a spurious rc=1 even when the kill fully succeeds a moment later. Because watcher_cleanup (bin/fm-watch.sh:746) does `fm_active_wait_stop || return 1`, a spurious failure skips every remaining cleanup step in the same trap invocation: fm_active_check_stop (line 747, so a genuinely active custom-check subprocess would be left unterminated instead of stopped), fm_check_output_cleanup, fm_custom_check_snapshot_cleanup, and fm_lock_release &#34;$WATCH_LOCK&#34; (line 750). The watch-lock omission is largely masked by the existing dead-pid lock-stealing path in fm_lock_try_acquire, but the skipped fm_active_check_stop call is not similarly self-healing. Mirroring the sibling&#39;s confirmation loop (or reusing fm_active_check_stop&#39;s escalation logic directly) would close this gap.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- `bash tests/fm-topic-board.test.sh`
- `bash tests/fm-watcher-lock.test.sh`
- `manual CLI walkthrough of listener/inbox/reply scripts`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

🔧 Fix: No lint issues found; fm-lint.sh passes clean with ShellCheck 0.11.0
1 warning still open:
- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
