### PR TITLE
feat(spawn): crew-scoped permissions.deny for autonomous claude crews

### DIFF
--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -324,7 +324,20 @@ launch_template() {
     # does NOT suppress the interactive ghost text (verified empirically), so the env
     # var is the correct control. The dim-aware composer reader in fm-tmux-lib.sh is
     # the defense-in-depth backstop for any pane this flag cannot reach.
-    claude) printf '%s' 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions __MODELFLAG____EFFORTFLAG__"$(cat __BRIEF__)"' ;;
+    claude)
+      # A crew (ship/scout) also carries a crew-scoped permissions.deny set through
+      # an fm-spawn-generated --settings file (crew_deny_settings_file; the
+      # __CREWSETTINGS__ placeholder). Claude enforces permissions.deny even under
+      # --dangerously-skip-permissions, so the deny set is a real, if partial,
+      # per-launch control on the autonomous crew (docs/crew-deny-hardening.md). A
+      # secondmate is a firstmate instance, not an autonomous crew, so it launches
+      # WITHOUT the deny set - only the crew branch gets the placeholder.
+      if [ "$kind" = secondmate ]; then
+        printf '%s' 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions __MODELFLAG____EFFORTFLAG__"$(cat __BRIEF__)"'
+      else
+        printf '%s' 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions __CREWSETTINGS____MODELFLAG____EFFORTFLAG__"$(cat __BRIEF__)"'
+      fi
+      ;;
     codex)
       if [ "$kind" = secondmate ]; then
         printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox "$(cat __BRIEF__)"'
@@ -478,6 +491,53 @@ effort_flag_for_harness() {
     # flag but no verified effort flag. Its `opencode run --variant` flag belongs
     # to a different, non-interactive launch mode, so fm-spawn does not pass it.
   esac
+}
+
+# Crew-scoped hardening deny set, baked into a --settings JSON for autonomous
+# claude crews. Claude enforces permissions.deny in EVERY permission mode,
+# including bypassPermissions (= --dangerously-skip-permissions), while allow
+# rules become moot in bypass - so this deny set really constrains a crew's Bash
+# egress, force-push, catastrophic deletes, and secret-path Read-tool access
+# (docs/crew-deny-hardening.md records the empirical proof, claude version, and
+# commands). It is a defense-in-depth speed bump, NOT a hard boundary: native
+# Bash-argument matching is fragile (a crew can still read a secret with cat or
+# node -e, or POST over HTTP with python3, and trailing-flag / path-expansion
+# forms slip prefix patterns), so the hard boundary - an OS sandbox and a
+# deny-first PreToolUse hook - stays separate, captain-gated follow-up work.
+# The file lives in the task's own temp root (outside every worktree, never
+# committed to a project) and fm-teardown removes it with that root. Only the
+# claude ship/scout launch template carries __CREWSETTINGS__; a secondmate (a
+# firstmate instance, not a crew), every other harness, and the raw-launch escape
+# hatch omit it, so none of them generate this file. This heredoc is the versioned
+# source of truth for the deny set; --settings MERGES it on top of the worktree's
+# turn-end settings.local.json rather than replacing it.
+crew_deny_settings_file() {  # <task-tmp> ; writes JSON, echoes "--settings '<path>' "
+  local task_tmp=$1 path
+  path="$task_tmp/crew-deny.settings.json"
+  cat > "$path" <<'JSON'
+{
+  "permissions": {
+    "deny": [
+      "Bash(curl:*)",
+      "Bash(wget:*)",
+      "Bash(gh auth token:*)",
+      "Bash(git push --force:*)",
+      "Bash(git push -f:*)",
+      "Bash(git push --force-with-lease:*)",
+      "Bash(rm -rf /:*)",
+      "Bash(rm -rf ~:*)",
+      "Bash(rm -rf $HOME:*)",
+      "Read(~/.ssh/**)",
+      "Read(~/.aws/**)",
+      "Read(~/.kube/**)",
+      "Read(~/.npmrc)",
+      "Read(~/.claude/.credentials.json)",
+      "Read(~/.docker/config.json)"
+    ]
+  }
+}
+JSON
+  printf -- "--settings %s " "$(shell_quote "$path")"
 }
 
 json_escape() {
@@ -1036,6 +1096,16 @@ sq_piturnend=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-turnend-guard.ts
 sq_piwatch=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-pi-watch.ts")
 MODELFLAG=$(model_flag_for_harness "$HARNESS" "$MODEL")
 EFFORTFLAG=$(effort_flag_for_harness "$HARNESS" "$EFFORT")
+# Crew-scoped deny set: only the claude ship/scout template carries the
+# __CREWSETTINGS__ placeholder, so its presence is the single control point.
+# Generate the deny-settings file (into the task temp root) only when it is there;
+# a secondmate, another harness, or a raw launch command has no placeholder, so
+# CREWSETTINGS stays empty and no file is written.
+CREWSETTINGS=
+case "$LAUNCH" in
+  *__CREWSETTINGS__*) CREWSETTINGS=$(crew_deny_settings_file "$TASK_TMP") ;;
+esac
+LAUNCH=${LAUNCH//__CREWSETTINGS__/$CREWSETTINGS}
 LAUNCH=${LAUNCH//__MODELFLAG__/$MODELFLAG}
 LAUNCH=${LAUNCH//__EFFORTFLAG__/$EFFORTFLAG}
 LAUNCH=${LAUNCH//__BRIEF__/$sq_brief}

--- a/docs/crew-deny-hardening.md
+++ b/docs/crew-deny-hardening.md
@@ -1,0 +1,77 @@
+# Crew-scoped deny set (defense-in-depth hardening)
+
+This records what `bin/fm-spawn.sh` injects into every autonomous **claude crew** launch, why it lives there, exactly what it does and does not protect, and the empirical proof that it works.
+It is the verification record for the change; the deny set's versioned source of truth is the heredoc in `crew_deny_settings_file()` in `bin/fm-spawn.sh`, not this doc.
+
+Context and threat model: `data/sec-automode-scout-q3/report.md` (quick win 1 plus the npmrc-hygiene portion of quick win 3) and the captain decision `data/sec-automode-scout-q3/decision-sec-deny-rules.md`.
+
+## What it is
+
+Every claude crew (a ship or scout task) launches with a `--settings <file>` flag pointing at a `permissions.deny` JSON that `fm-spawn` generates per task.
+Claude enforces `permissions.deny` in **every** permission mode, including `bypassPermissions` (which is what `--dangerously-skip-permissions` selects), while `allow` rules become moot under bypass.
+That asymmetry is the whole reason this works: the crew stays fully autonomous, but the deny set still constrains it.
+
+The deny set blocks:
+
+- Network egress by the two ubiquitous CLI clients: `Bash(curl:*)`, `Bash(wget:*)`.
+- Token exfiltration in one command: `Bash(gh auth token:*)`.
+- Remote history rewrites: `Bash(git push --force:*)`, `Bash(git push -f:*)`, `Bash(git push --force-with-lease:*)` - a plain `git push` to a task branch is deliberately NOT denied.
+- Catastrophic-delete circuit breakers: `Bash(rm -rf /:*)`, `Bash(rm -rf ~:*)`, `Bash(rm -rf $HOME:*)`.
+- Secret-path reads through the **Read tool**: `Read(~/.ssh/**)`, `Read(~/.aws/**)`, `Read(~/.kube/**)`, `Read(~/.npmrc)`, `Read(~/.claude/.credentials.json)`, `Read(~/.docker/config.json)`.
+
+## Why it lives in fm-spawn (and nowhere else)
+
+Crews run in worktrees of the **project** repo, so the firstmate repo's own `.claude/settings.json` never reaches them.
+Editing the captain's global `~/.claude/settings.json` is off-limits - that would constrain the captain's own sessions, not just crews.
+The one crew-scoped, per-launch injection point is the claude launch template in `fm-spawn.sh`, the same place `CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false` is already injected as a crew-only control.
+
+The generated file lives in the task's own temp root (`/tmp/fm-<id>/crew-deny.settings.json`), outside every worktree, never committed to a project, and `fm-teardown` removes it with that root.
+`--settings` **merges** on top of the worktree's turn-end `settings.local.json` rather than replacing it, so the crew's Stop hook (the watcher's turn-end signal) is unaffected (verified below).
+
+Only the claude **crew** template carries the `__CREWSETTINGS__` placeholder.
+A secondmate is a firstmate instance, not an autonomous crew, so it launches without the deny set; every other harness and the raw-launch escape hatch omit it too, and none of them generate the file.
+
+## Mechanism choice: `--settings` file over `--disallowedTools`
+
+`--disallowedTools` and a `--settings` `permissions.deny` block are functionally equivalent and both enforced under bypass.
+The deny set has 15 entries; inlining them as `--disallowedTools` flags would bloat the single-line launch command into something unreadable in pane captures and logs.
+A `--settings` file keeps the launch line to one readable flag whose target path names the control, and keeps the versioned deny-set definition in one heredoc in the tracked script.
+
+## This is a speed bump, not a hard boundary
+
+Native Bash-argument matching is fragile and this is explicitly defense-in-depth staging, not containment:
+
+- A crew can still read a secret with `cat`, `node -e`, `head`, etc. (only the **Read tool** is denied for those paths, not arbitrary Bash reads), and can still exfiltrate over HTTP with `python3 -c` or `node -e` instead of `curl`/`wget`.
+- Prefix patterns miss trailing-flag and path-expansion forms: `git push origin main --force` (force flag last) and an already-expanded absolute home path slip the `--force:*` / `~` / `$HOME` patterns.
+- Flag-order variants such as `rm -fr /` are not the same string as `rm -rf /`.
+
+The hard boundary - an OS sandbox (macOS Seatbelt) and a deny-first PreToolUse hook that inspects the fully expanded command - is separate, captain-gated follow-up work (report sections 6.2 item 5 and 6.3; decision keys `sec-sandbox-crews`, `sec-custom-deny-hook`).
+
+## Harness scope
+
+Crews are always claude today (codex is banned by captain decision; `config/crew-dispatch.json`), so only the claude template is hardened.
+The codex, opencode, pi, and grok templates are left unchanged; each would need its own mechanism if it were ever used for crews, because `permissions.deny` / `--settings` are claude-specific.
+
+## Empirical verification
+
+Date: 2026-07-17. Claude Code version: `2.1.212`. Backend: reproduced the exact launched command shape (`claude --dangerously-skip-permissions --settings <file> ...`) with the real per-task file `fm-spawn` generates.
+
+Per the captain's hard verification limit, the destructive and exfiltration rules (rm, force-push, `gh auth token`, secret-path reads) were verified by **inspecting the generated deny config only** - never by executing the denied command, because a deny that silently failed to load would have let the command run. Only one harmless `curl https://example.com` GET was used as proof the deny mechanism fires at all, plus positive controls.
+
+1. **Deny fires under bypass.** With `--dangerously-skip-permissions` and the deny `--settings` file, asking the agent to run `curl -sS https://example.com` returned:
+   `BLOCKED: "Permission to use Bash with command curl ... has been denied."`
+   The command never executed.
+
+2. **Legitimate workflow still runs.** In the same launch shape, `git --version` -> `git version 2.54.0` and `yarn --version` -> `1.22.22` both **executed**.
+
+3. **No turn-end regression.** With a worktree `.claude/settings.local.json` Stop hook (exactly what `fm-spawn` writes) plus the deny `--settings` file, the Stop hook still fired (its marker file was touched), confirming `--settings` merges rather than replaces and the watcher's turn-end signal is intact.
+
+4. **Deny set complete and non-over-blocking (by inspection).** The generated file is valid JSON with all 15 required rules, and contains none of the patterns that would break a legitimate crew workflow (no bare `Bash(git push:*)`, no `kubectl`/`gh api`/`yarn`/`npm`/`helm`/`treehouse`/`tasks-axi` deny). `tests/fm-spawn-crew-deny.test.sh` pins both the required and the forbidden sets.
+
+The `Read(~/.npmrc)` deny is Read-tool-only, so `yarn`/`npm install` in a crew worktree still read the feed credentials at the OS level; `kubectl get/list`, `gh api` POST, treehouse worktree ops, and `tasks-axi` are all unaffected.
+
+## Maintaining this file
+
+Keep this doc as the verification record and rationale for the crew deny set.
+When the deny set in `bin/fm-spawn.sh` changes, update the rule list and re-run the verification above, refreshing the date, version, and captured output.
+Do not restate the deny entries as a second source of truth - the heredoc in `crew_deny_settings_file()` owns them; this doc summarizes and justifies them.

--- a/tests/fm-spawn-crew-deny.test.sh
+++ b/tests/fm-spawn-crew-deny.test.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+# Behavior tests for fm-spawn.sh's crew-scoped permissions.deny injection.
+#
+# A claude CREW (ship/scout) launch must carry a --settings file holding the
+# crew-scoped deny set; a secondmate (a firstmate instance, not a crew) and every
+# other harness must NOT. These tests drive fm-spawn through launch construction
+# with a fake tmux pane and a real isolated git worktree (same rig as
+# fm-spawn-dispatch-profile.test.sh): the fake tmux captures the literal launch
+# command sent with `tmux send-keys -l`, and the generated deny JSON is inspected
+# directly. This is deliberately a pure config-inspection test - it never executes
+# any denied command (the captain's hard verification limit), so a deny that
+# silently failed to load could not run the command here anyway.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SPAWN="$ROOT/bin/fm-spawn.sh"
+TMP_ROOT=$(fm_test_tmproot fm-spawn-crew-deny)
+
+# Every Bash(...) / Read(...) rule the deny set must contain. Egress, token
+# exfiltration, force-push, catastrophic-delete circuit breakers, and secret-path
+# Read-tool blocks (report data/sec-automode-scout-q3, quick win 1 + npmrc hygiene).
+# shellcheck disable=SC2016  # $HOME is a literal deny-pattern token, not a shell expansion
+REQUIRED_DENY=(
+  'Bash(curl:*)'
+  'Bash(wget:*)'
+  'Bash(gh auth token:*)'
+  'Bash(git push --force:*)'
+  'Bash(git push -f:*)'
+  'Bash(git push --force-with-lease:*)'
+  'Bash(rm -rf /:*)'
+  'Bash(rm -rf ~:*)'
+  'Bash(rm -rf $HOME:*)'
+  'Read(~/.ssh/**)'
+  'Read(~/.aws/**)'
+  'Read(~/.kube/**)'
+  'Read(~/.npmrc)'
+  'Read(~/.claude/.credentials.json)'
+  'Read(~/.docker/config.json)'
+)
+
+# Patterns that MUST NOT appear, or the deny set would break a legitimate crew
+# workflow: plain git push to a task branch, gh api POST, kubectl reads, and the
+# package managers reading their own feeds at the OS level.
+FORBIDDEN_DENY=(
+  'Bash(git push:*)'
+  'Bash(gh api'
+  'Bash(kubectl'
+  'Bash(yarn'
+  'Bash(npm'
+  'Bash(helm'
+  'Bash(treehouse'
+  'Bash(tasks-axi'
+)
+
+make_spawn_fakebin() {
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+esac
+case "${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+  list-windows) exit 0 ;;
+  has-session|new-session|new-window|kill-window) exit 0 ;;
+  send-keys)
+    if [ -n "${FM_FAKE_LAUNCH_LOG:-}" ]; then
+      prev=
+      for a in "$@"; do
+        if [ "$prev" = "-l" ]; then
+          printf '%s\n' "$a" >> "$FM_FAKE_LAUNCH_LOG"
+        fi
+        prev=$a
+      done
+    fi
+    exit 0
+    ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" treehouse
+  printf '%s\n' "$fakebin"
+}
+
+make_spawn_case() {
+  local name=$1 harness=$2 case_dir home proj wt fakebin launchlog id
+  shift 2
+  case_dir="$TMP_ROOT/$name"
+  home="$case_dir/home"
+  proj="$case_dir/project"
+  wt="$case_dir/wt"
+  launchlog="$case_dir/launch.log"
+  fakebin=$(make_spawn_fakebin "$case_dir/fake")
+  mkdir -p "$home/data" "$home/projects" "$home/state" "$home/config"
+  printf '%s\n' "$harness" > "$home/config/crew-harness"
+  fm_git_worktree "$proj" "$wt" "wt-$name"
+  touch "$home/state/.last-watcher-beat"
+  for id in "$@"; do
+    mkdir -p "$home/data/$id"
+    printf 'brief for %s\n' "$id" > "$home/data/$id/brief.md"
+  done
+  printf '%s\n' "$case_dir|$home|$proj|$wt|$fakebin|$launchlog"
+}
+
+make_seeded_secondmate_home() {
+  local home=$1 id=$2
+  mkdir -p "$home/bin" "$home/data"
+  printf '# Firstmate\n' > "$home/AGENTS.md"
+  printf '%s\n' "$id" > "$home/.fm-secondmate-home"
+  printf 'charter for %s\n' "$id" > "$home/data/charter.md"
+}
+
+run_spawn() {
+  local home=$1 wt=$2 fakebin=$3 launchlog=$4
+  shift 4
+  : > "$launchlog"
+  FM_ROOT_OVERRIDE='' FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
+    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" TMUX="fake,1,0" \
+    FM_FAKE_LAUNCH_LOG="$launchlog" PATH="$fakebin:$PATH" \
+    "$SPAWN" "$@" 2>&1
+}
+
+read_case_record() {
+  IFS='|' read -r CASE_DIR HOME_DIR PROJ_DIR WT_DIR FAKEBIN_DIR LAUNCH_LOG <<EOF
+$1
+EOF
+}
+
+assert_valid_json() {
+  local path=$1 msg=$2
+  node -e 'JSON.parse(require("fs").readFileSync(process.argv[1],"utf8"))' "$path" \
+    >/dev/null 2>&1 || fail "$msg (invalid JSON at $path)"
+}
+
+assert_deny_set_complete() {
+  local path=$1 rule
+  assert_valid_json "$path" "deny settings file is not valid JSON"
+  for rule in "${REQUIRED_DENY[@]}"; do
+    assert_grep "$rule" "$path" "deny set missing required rule: $rule"
+  done
+  for rule in "${FORBIDDEN_DENY[@]}"; do
+    assert_no_grep "$rule" "$path" "deny set over-blocks a legitimate workflow: $rule"
+  done
+}
+
+test_claude_ship_gets_deny_settings() {
+  local rec id out status launch deny
+  id=crew-deny-ship-z1
+  rec=$(make_spawn_case crew-deny-ship claude "$id")
+  read_case_record "$rec"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR")
+  status=$?
+  expect_code 0 "$status" "claude ship spawn should succeed"
+  assert_contains "$out" "spawned $id harness=claude kind=ship" "spawn did not report a claude ship crew"
+
+  launch=$(cat "$LAUNCH_LOG")
+  deny="/tmp/fm-$id/crew-deny.settings.json"
+  assert_contains "$launch" "claude --dangerously-skip-permissions --settings '$deny'" \
+    "claude ship launch did not carry the crew deny --settings flag"
+  assert_present "$deny" "claude ship spawn did not generate the deny settings file"
+  assert_deny_set_complete "$deny"
+  pass "claude ship crew launch carries a complete, non-over-blocking deny --settings file"
+}
+
+test_claude_scout_gets_deny_settings() {
+  local rec id out status launch deny
+  id=crew-deny-scout-z2
+  rec=$(make_spawn_case crew-deny-scout claude "$id")
+  read_case_record "$rec"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --scout)
+  status=$?
+  expect_code 0 "$status" "claude scout spawn should succeed"
+  assert_contains "$out" "spawned $id harness=claude kind=scout" "spawn did not report a claude scout crew"
+
+  launch=$(cat "$LAUNCH_LOG")
+  deny="/tmp/fm-$id/crew-deny.settings.json"
+  assert_contains "$launch" "--settings '$deny'" "claude scout launch did not carry the crew deny --settings flag"
+  assert_present "$deny" "claude scout spawn did not generate the deny settings file"
+  assert_deny_set_complete "$deny"
+  pass "claude scout crew launch carries the deny --settings file"
+}
+
+test_claude_secondmate_omits_deny_settings() {
+  local rec id sm out status launch deny
+  id=crew-deny-secondmate-z3
+  rec=$(make_spawn_case crew-deny-secondmate claude "$id")
+  read_case_record "$rec"
+  sm="$CASE_DIR/secondmate-home"
+  make_seeded_secondmate_home "$sm" "$id"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$sm" --secondmate)
+  status=$?
+  expect_code 0 "$status" "claude secondmate spawn should succeed"
+  assert_contains "$out" "spawned $id harness=claude kind=secondmate" "spawn did not report a claude secondmate"
+
+  launch=$(cat "$LAUNCH_LOG")
+  deny="/tmp/fm-$id/crew-deny.settings.json"
+  assert_not_contains "$launch" "--settings" "secondmate (a firstmate instance, not a crew) must not carry the crew deny --settings flag"
+  assert_absent "$deny" "secondmate spawn must not generate the crew deny settings file"
+  pass "a claude secondmate launches WITHOUT the crew deny set"
+}
+
+test_non_claude_harness_omits_deny_settings() {
+  local rec id out status launch deny
+  id=crew-deny-codex-z4
+  rec=$(make_spawn_case crew-deny-codex codex "$id")
+  read_case_record "$rec"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR")
+  status=$?
+  expect_code 0 "$status" "codex ship spawn should succeed"
+  assert_contains "$out" "spawned $id harness=codex" "spawn did not report a codex crew"
+
+  launch=$(cat "$LAUNCH_LOG")
+  deny="/tmp/fm-$id/crew-deny.settings.json"
+  assert_not_contains "$launch" "--settings" "a non-claude harness must not carry the claude-only crew deny --settings flag"
+  assert_absent "$deny" "a non-claude harness must not generate the claude deny settings file"
+  pass "a non-claude crew harness launches WITHOUT the claude-only deny set"
+}
+
+test_claude_ship_gets_deny_settings
+test_claude_scout_gets_deny_settings
+test_claude_secondmate_omits_deny_settings
+test_non_claude_harness_omits_deny_settings
+
+echo "# all fm-spawn-crew-deny tests passed"

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -118,9 +118,11 @@ test_no_profile_keeps_claude_launch_unchanged() {
   assert_meta_profile "$HOME_DIR/state/$id.meta" claude default default
 
   launch=$(cat "$LAUNCH_LOG")
-  expected="CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions \"\$(cat '$HOME_DIR/data/$id/brief.md')\""
+  # A claude crew (ship) now carries the crew-scoped deny set via a --settings file
+  # in the task temp root; the rest of the launch stays byte-identical.
+  expected="CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions --settings '/tmp/fm-$id/crew-deny.settings.json' \"\$(cat '$HOME_DIR/data/$id/brief.md')\""
   [ "$launch" = "$expected" ] || fail "no-profile claude launch changed"$'\n'"expected: $expected"$'\n'"actual:   $launch"
-  pass "no --model/--effort records defaults and keeps the claude launch byte-identical"
+  pass "no --model/--effort keeps the claude crew launch byte-identical apart from the deny --settings flag"
 }
 
 test_active_dispatch_profile_requires_explicit_harness_for_ship() {
@@ -219,8 +221,9 @@ test_claude_threads_model_and_effort() {
   expect_code 0 "$status" "claude spawn with profile flags should succeed"
   assert_meta_profile "$HOME_DIR/state/$id.meta" claude sonnet high
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "claude --dangerously-skip-permissions --model 'sonnet' --effort 'high'" \
-    "claude launch did not thread model and effort flags"
+  # The crew deny --settings flag sits between --dangerously-skip-permissions and --model.
+  assert_contains "$launch" "claude --dangerously-skip-permissions --settings '/tmp/fm-$id/crew-deny.settings.json' --model 'sonnet' --effort 'high'" \
+    "claude launch did not thread model and effort flags after the deny --settings flag"
   pass "claude receives --model and --effort profile flags"
 }
 


### PR DESCRIPTION
## What

Injects a **crew-scoped `permissions.deny` set** into the claude crew launch in `bin/fm-spawn.sh`, so autonomous crews are constrained even though they run with `--dangerously-skip-permissions`. Claude enforces `permissions.deny` in every permission mode, including `bypassPermissions`, so the deny set really applies while the crew stays fully autonomous.

`fm-spawn` generates a `permissions.deny` JSON per task into the task's own temp root (`/tmp/fm-<id>/crew-deny.settings.json`) and passes it with `--settings`. The file lives outside every worktree, is never committed to a project, and `fm-teardown` removes it with that root.

### Deny set

- Egress: `Bash(curl:*)`, `Bash(wget:*)`
- Token exfiltration: `Bash(gh auth token:*)`
- Force-push (history rewrite): `Bash(git push --force:*)`, `Bash(git push -f:*)`, `Bash(git push --force-with-lease:*)` — a plain `git push` to a task branch stays allowed
- Catastrophic-delete circuit breakers: `Bash(rm -rf /:*)`, `Bash(rm -rf ~:*)`, `Bash(rm -rf $HOME:*)`
- Secret-path reads via the **Read tool**: `Read(~/.ssh/**)`, `Read(~/.aws/**)`, `Read(~/.kube/**)`, `Read(~/.npmrc)`, `Read(~/.claude/.credentials.json)`, `Read(~/.docker/config.json)`

## Why here

Crews run in worktrees of the **project** repo, so the firstmate repo's own `.claude/settings.json` never reaches them, and the captain's global `~/.claude/settings.json` must not be edited (that would constrain the captain's own sessions). The claude launch template in `fm-spawn.sh` is the only per-launch, crew-scoped injection point — the same place `CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false` is already injected.

## Scope: crew-only, claude-only

- Only the claude **ship/scout** template carries the deny set. A secondmate (a firstmate instance, not an autonomous crew), every other harness, and the raw-launch escape hatch omit it and generate no file.
- Crews are always claude today (codex is banned), so only the claude template is hardened. The codex/opencode/pi/grok templates are unchanged; each would need its own mechanism if ever used for crews, since `permissions.deny` / `--settings` are claude-specific.

## Mechanism choice

Chose an `fm-spawn`-generated `--settings` file over `--disallowedTools` flags: 15 deny rules inline would make the single-line launch command unreadable in pane captures and logs. `--settings` keeps the launch to one readable flag and the deny set versioned in one heredoc. Crucially, `--settings` **merges** on top of the worktree's turn-end `settings.local.json` rather than replacing it, so the crew's Stop hook (the watcher's turn-end signal) is unaffected.

## Does not break

By design the deny set does not touch: plain `git push` to task branches, `gh api` POST, `kubectl get/list` reads, `yarn`/`npm install` in a crew worktree (the `Read(~/.npmrc)` deny is Read-tool-only — yarn reads the feed credentials itself at the OS level), treehouse worktree ops, and `tasks-axi`. A guard test pins the forbidden patterns so future edits cannot silently over-block these.

## Honest scope note — this is a speed bump, not a hard boundary

Native Bash-argument matching is fragile. A crew can still read a secret with `cat`/`head`/`node -e` (only the **Read tool** is denied for those paths, not arbitrary Bash), can still POST over HTTP with `python3 -c`/`node -e` instead of `curl`/`wget`, and trailing-flag / path-expansion / flag-order forms slip the prefix patterns (`git push origin main --force`, an already-expanded home path, `rm -fr /`). This is **defense-in-depth staging**, not containment. The hard boundary — an OS sandbox (macOS Seatbelt) and a deny-first PreToolUse hook that inspects the fully expanded command — is separate, captain-gated follow-up work (security assessment sections 6.2 item 5 and 6.3).

## Verification

`docs/crew-deny-hardening.md` records the rationale and the empirical evidence (claude 2.1.212). Destructive/exfil rules were verified by **config inspection only**, never by executing the denied command (a deny that silently failed to load would otherwise run the command); only one harmless `curl https://example.com` GET was used to prove the mechanism fires.

- `curl` is **BLOCKED** under `--dangerously-skip-permissions` (deny fires in bypass mode).
- Positive controls `git --version` (2.54.0) and `yarn --version` (1.22.22) still **execute**.
- The worktree Stop hook still fires with the deny `--settings` present — **no turn-end regression**; `--settings` merges rather than replaces.
- The generated file is valid JSON with all 15 required rules and none of the forbidden over-blocking patterns.

`tests/fm-spawn-crew-deny.test.sh` (new) pins the required and forbidden deny sets and the crew-vs-secondmate/other-harness scoping. `tests/fm-spawn-dispatch-profile.test.sh` byte-exact assertions updated for the new `--settings` flag. `bin/fm-lint.sh` (shellcheck 0.11.0) is clean.
