### PR TITLE
docs: document Chromium toolchain and shared-lib requirement

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -229,7 +229,7 @@ Secondmate homes inherit this file from the primary, so a secondmate's own crewm
 On session start the first mate detects what its required toolchain is missing or too old and lists each problem with either an exact install command or manual instructions.
 It installs automatically supported tools only after you say go; manual-only tools remain for you to install from the printed instructions.
 Required tools come in two parts: a universal toolchain every home needs regardless of backend, and a per-backend delta that follows the runtime backend actually resolved for this home.
-The universal toolchain is node, git, gh with GitHub auth via `gh auth login`, no-mistakes v1.31.2 or newer, gh-axi, chrome-devtools-axi, lavish-axi, compatible tasks-axi per "Backlog backend" above, and quota-axi.
+The universal toolchain is node, git, gh with GitHub auth via `gh auth login`, no-mistakes v1.31.2 or newer, gh-axi, chrome-devtools-axi with a real Chromium binary and its OS-level shared-library dependencies for a working headless launch, lavish-axi, compatible tasks-axi per "Backlog backend" above, and quota-axi.
 This section is the single owner of that universal toolchain list; backend guides' prerequisites point here and add only their backend-specific tools.
 In that list, no-mistakes runs the validation pipeline, gh-axi, chrome-devtools-axi, and lavish-axi cover GitHub, browser, and rich-review operations, and tasks-axi plus quota-axi back backlog mutations and quota-balanced dispatch.
 The per-backend delta is required only for the backend resolved from `FM_BACKEND`, then `config/backend`, then runtime auto-detection, then default `tmux`, so a home is never told to install a tool an inactive backend or feature would need.
@@ -243,6 +243,9 @@ When X mode is opted in, bootstrap also requires `curl` and `jq` before arming t
 `tasks-axi` and `quota-axi` are required bootstrap tools in every profile, the same class as `lavish-axi`.
 An absent or incompatible `tasks-axi` reports `MISSING: tasks-axi (install: npm install -g tasks-axi)`; when `config/backlog-backend` is not `manual` and compatible `tasks-axi` is on `PATH`, bootstrap stays silent and firstmate uses its verbs for routine backlog mutations, otherwise it hand-edits `data/backlog.md` until installation is approved and completed.
 An absent `quota-axi` reports `MISSING: quota-axi (install: npm install -g quota-axi)`; `bin/fm-dispatch-select.sh` still degrades to the first profile at runtime when quota data is unavailable.
+A real Chromium binary is a required bootstrap tool in every profile, the same class as `lavish-axi`, needed alongside `chrome-devtools-axi` for a working headless launch.
+The binary alone is not enough: on Debian/Ubuntu-family hosts a cached Playwright Chromium binary such as `~/.cache/ms-playwright/chromium-<version>/chrome-linux64/chrome` can still be missing OS-level shared libraries like `libnspr4` that are not installed by default.
+An absent or non-functional Chromium reports `MISSING: chromium (install: npx --yes playwright install-deps chromium)`, the same install-only-after-consent flow as every other automatically supported tool above.
 Bootstrap also reports a `TANGLE:` line when `FM_ROOT` is on a named non-default branch; follow the printed checkout remediation rather than treating it as an installable tool problem.
 In a read-only session that did not get the fleet lock, the same line is advisory and omits the checkout command.
 The locked session-start bootstrap step also runs a best-effort project clone refresh through `fm-fleet-sync.sh`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -229,7 +229,7 @@ Secondmate homes inherit this file from the primary, so a secondmate's own crewm
 On session start the first mate detects what its required toolchain is missing or too old and lists each problem with either an exact install command or manual instructions.
 It installs automatically supported tools only after you say go; manual-only tools remain for you to install from the printed instructions.
 Required tools come in two parts: a universal toolchain every home needs regardless of backend, and a per-backend delta that follows the runtime backend actually resolved for this home.
-The universal toolchain is node, git, gh with GitHub auth via `gh auth login`, no-mistakes v1.31.2 or newer, gh-axi, chrome-devtools-axi with a real Chromium binary and its OS-level shared-library dependencies for a working headless launch, lavish-axi, compatible tasks-axi per "Backlog backend" above, and quota-axi.
+The universal toolchain is node, git, gh with GitHub auth via `gh auth login`, no-mistakes v1.31.2 or newer, gh-axi, chrome-devtools-axi, lavish-axi, compatible tasks-axi per "Backlog backend" above, and quota-axi.
 This section is the single owner of that universal toolchain list; backend guides' prerequisites point here and add only their backend-specific tools.
 In that list, no-mistakes runs the validation pipeline, gh-axi, chrome-devtools-axi, and lavish-axi cover GitHub, browser, and rich-review operations, and tasks-axi plus quota-axi back backlog mutations and quota-balanced dispatch.
 The per-backend delta is required only for the backend resolved from `FM_BACKEND`, then `config/backend`, then runtime auto-detection, then default `tmux`, so a home is never told to install a tool an inactive backend or feature would need.
@@ -243,9 +243,9 @@ When X mode is opted in, bootstrap also requires `curl` and `jq` before arming t
 `tasks-axi` and `quota-axi` are required bootstrap tools in every profile, the same class as `lavish-axi`.
 An absent or incompatible `tasks-axi` reports `MISSING: tasks-axi (install: npm install -g tasks-axi)`; when `config/backlog-backend` is not `manual` and compatible `tasks-axi` is on `PATH`, bootstrap stays silent and firstmate uses its verbs for routine backlog mutations, otherwise it hand-edits `data/backlog.md` until installation is approved and completed.
 An absent `quota-axi` reports `MISSING: quota-axi (install: npm install -g quota-axi)`; `bin/fm-dispatch-select.sh` still degrades to the first profile at runtime when quota data is unavailable.
-A real Chromium binary is a required bootstrap tool in every profile, the same class as `lavish-axi`, needed alongside `chrome-devtools-axi` for a working headless launch.
+`chrome-devtools-axi`'s headless launches also need a real Chromium binary and its OS-level shared-library dependencies, but bootstrap does not yet detect or report this the way it does for `tasks-axi` and `quota-axi` above; no `MISSING: chromium` line exists today.
 The binary alone is not enough: on Debian/Ubuntu-family hosts a cached Playwright Chromium binary such as `~/.cache/ms-playwright/chromium-<version>/chrome-linux64/chrome` can still be missing OS-level shared libraries like `libnspr4` that are not installed by default.
-An absent or non-functional Chromium reports `MISSING: chromium (install: npx --yes playwright install-deps chromium)`, the same install-only-after-consent flow as every other automatically supported tool above.
+Until bootstrap gains that detection, install it yourself before session start with `npx --yes playwright install-deps chromium`.
 Bootstrap also reports a `TANGLE:` line when `FM_ROOT` is on a named non-default branch; follow the printed checkout remediation rather than treating it as an installable tool problem.
 In a read-only session that did not get the fleet lock, the same line is advisory and omits the checkout command.
 The locked session-start bootstrap step also runs a best-effort project clone refresh through `fm-fleet-sync.sh`.


### PR DESCRIPTION
## Intent

Add Chromium + its OS-level shared-library dependencies as a required toolchain item in docs/configuration.md, matching the doc's existing manual-install framing

## What Changed

- Added a note in `docs/configuration.md` that `chrome-devtools-axi`'s headless launches require a real Chromium binary plus its OS-level shared-library dependencies (e.g. `libnspr4` on Debian/Ubuntu), and that bootstrap does not currently detect or report this like it does for `tasks-axi`/`quota-axi`.
- Documented the manual remediation step (`npx --yes playwright install-deps chromium`) to install those dependencies before session start.
- Follow-up wording fix clarifies that no `MISSING: chromium` bootstrap line exists today, avoiding any implication that bootstrap auto-detects the Chromium toolchain.

## Risk Assessment

✅ Low: Documentation-only change confined to docs/configuration.md; verified against bin/fm-bootstrap.sh that the claims made (bootstrap's COMMON_TOOLS list has no chromium detection) are accurate, and the change fulfills the stated intent using the doc's existing manual-install framing with no code or behavior changes.

## Testing

Completed 1 recorded test check.

- Outcome: ⏭️ skipped across 1 run (16m28s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⏭️ **Test** - skipped</summary>

- 🚨 tests failed with exit code 1
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⏭️ **Lint** - skipped</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
