### PR TITLE
feat(skills): install beautify-github-readme

### DIFF
--- a/.agents/skills/beautify-github-readme/SKILL.md
+++ b/.agents/skills/beautify-github-readme/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: beautify-github-readme
+description: Redesign GitHub README homepages or create standalone GitHub-safe SVG and animated GIF assets around a repository's real theme. Use when a user asks to beautify, redesign, rebrand, visually upgrade, simplify, or audit a GitHub README; create only a hero, section headers, diagrams, badges, motion graphics, showcase modules, or other README assets; or turn a repository homepage into a cohesive visual story. If the request does not clearly distinguish whole-README work from asset-only work, ask which scope the user wants before editing anything.
+---
+
+# Beautify GitHub README
+
+Turn a repository homepage or a requested SVG asset into a concise, theme-specific visual story. Treat SVG as the visual layer and Markdown as the content layer.
+
+## Workflow
+
+### 1. Confirm the mode before editing
+
+Use exactly one execution mode:
+
+- **README mode** — improve the whole README: information order, copy hierarchy, proof, Markdown, and visual system.
+- **Asset-only mode** — create only the requested static SVG or visual asset set. Static SVG is the default. Only after the user explicitly opts into meaningful motion, optionally deliver a GitHub-safe GIF while keeping the SVG as the editable fallback. Do not rewrite, reorder, or embed anything in the README unless the user explicitly adds that scope.
+
+If the mode is not explicit, ask one compact question before making changes:
+
+> Would you like me to improve the whole README or only create visual assets? If asset-only, tell me whether you need a hero, section headers, workflow, badge, motion graphic, or a coordinated set.
+
+When a hero, badge, workflow, or diagram has meaningful motion and the user has not specified static or animated output, ask one compact follow-up:
+
+> Should this stay as a static SVG, or would you like a GitHub-safe GIF animation with the SVG kept as the editable fallback?
+
+GIF is opt-in and never the default. If the user declines, does not answer, or has no meaningful motion case, continue with static SVG only. Do not ask when motion would be purely decorative or the user already chose the output. Read-only inspection is allowed before the answer when it helps understand the repository. Do not interpret “use this Skill,” a repository path, or “beautify it” as permission to modify the whole README. Once the user chooses asset-only mode, expanding into README edits requires new authorization.
+
+If the user explicitly asks only for an audit, audit without editing and do not force the two-mode question.
+
+### 2. Inspect before designing
+
+- Read the existing README, repository tree, package metadata, screenshots, examples, design tokens, logo, and real outputs.
+- In asset-only mode, inspect only the context needed to design the requested assets. Reading the README for context does not authorize changing it.
+- For a GitHub URL, inspect the current remote page and default branch before proposing changes.
+- Identify the audience, the problem solved, the clearest proof, the shortest path to first use, and any claims that lack evidence.
+- Preserve unrelated user changes. Start read-only; do not commit, push, rename, or publish without explicit authorization.
+
+### 3. Extract the project story
+
+Write these before drawing:
+
+```text
+Audience:
+One-sentence value:
+Primary proof:
+First successful action:
+Visual theme:
+```
+
+Do not invent adoption, benchmarks, compatibility, testimonials, or features. Prefer a real screenshot, output, diagram, or generated artifact over decorative stock imagery.
+
+### 4. Define a theme-specific visual system
+
+Read [references/visual-direction.md](references/visual-direction.md). Freeze a compact art-direction spec:
+
+```text
+Palette: background / foreground / primary / accent / muted
+Typography: system font stack / scale / weight contrast
+Shape: radius / stroke / grid / spacing
+Motif: one recurring project-specific visual cue
+Composition: calm / editorial / technical / playful / cinematic
+```
+
+Derive the motif from the project. A terminal tool may use prompts and cursor marks; an icon system may use keylines and cutouts; a research project may use coordinates and evidence labels. Never apply the same yellow-grid template to every repository.
+
+Before designing the hero, read [references/project-native-hero.md](references/project-native-hero.md). Build the title from project content rather than treating it as a banner placed above the proof. Choose the typography, composition, and right-side material from the repository itself.
+
+### 5. Execute only the selected mode
+
+#### README mode
+
+Decide how deeply the README needs to change:
+
+- **Full redesign** — restructure the story and build a new visual system.
+- **Visual refresh** — preserve the information architecture while replacing weak or inconsistent presentation.
+
+Use the smallest change inside README mode that can produce a meaningful improvement. Rebuild the reading order only when the selected scope requires it. A strong default is:
+
+1. Hero: name + plain-language value.
+2. Proof: screenshots, outputs, or a showcase wall.
+3. What it is: one short explanation.
+4. Why it is different: mechanism, not slogans.
+5. How it works: a short process or architecture.
+6. How to use: install + first command.
+7. Limits, compatibility, license, or contribution details when relevant.
+
+Put the example before the long explanation. Remove repeated promises and internal implementation detail that does not help adoption.
+
+#### Asset-only mode
+
+- Confirm the requested asset type, whether the user wants one asset or a coordinated set, and whether a meaningful motion candidate should stay static or become a GIF. Derive exact copy and style from the repository when they are unambiguous; ask only for missing decisions that would materially change the result.
+- Create the assets under `assets/readme/` or another user-approved path and provide rendered previews.
+- Default to pure, maintainable SVG for title systems, section headers, diagrams, badges, and deterministic decorative modules.
+- For approved animation, keep the SVG source, read [references/motion-production.md](references/motion-production.md), and derive a GitHub-safe GIF with the bundled `scripts/render_motion_gif.py` workflow. Do not generate the GIF unless the user opted in.
+- Keep one shared visual grammar across a set, but give every asset a specific communication job.
+- Do not change README text, reading order, embeds, or links. Offer an embed snippet separately when useful; only insert it after explicit approval.
+
+### 6. Build the visual layer
+
+Read [references/github-readme-canvas.md](references/github-readme-canvas.md) and [references/svg-production.md](references/svg-production.md) before creating assets.
+
+- Use SVG for the hero, section banners, diagrams, and deterministic design modules.
+- Use PNG/WebP for screenshots, generated art, photo material, and complex compositing. Use GIF only for approved motion that must play directly on GitHub.
+- Keep body copy, commands, tables, links, and details in Markdown.
+- Prefer a `1200`-wide SVG `viewBox`, `width="100%"` embeds, system fonts, semantic alt text, and rounded containers.
+- Use one reusable component grammar, but vary the art direction by repository theme.
+- When a showcase contains several artifacts, arrange them with controlled scale, overlap, rotation, and whitespace; keep reading order obvious.
+- Let the hero absorb a real project diagram, screenshot, code fragment, output, specimen, or artifact when it makes the first screen more useful. Do not separate the title and proof by habit.
+- When the user explicitly wants attribution in a repository they own, design a compact project-native `README MADE WITH` SVG instead of leaving a plain promotional sentence. Keep it near the footer and link it to this Skill. Never add this credit to a third-party repository without the maintainer's explicit request.
+- In README mode, when proof would become unreadable inside the hero, use a concise SVG title followed immediately by a larger proof board. When a few artifacts remain legible and define the product, integrate title and proof into one composed raster hero. Let proof legibility decide, not a fixed template. In asset-only mode, keep the requested SVG source and propose any raster or animated derivative as a separate, optional deliverable.
+
+Do not rasterize the whole README. Do not use scripts, `foreignObject`, remote fonts, essential animation, or CSS that GitHub strips. GitHub does not play animation embedded inside SVG; use a GIF plus static SVG fallback instead. Avoid decorative borders and heavy shadows unless the theme genuinely calls for them.
+
+### 7. Preview and verify
+
+- Render a local GitHub-width preview or inspect the README on a local Markdown renderer.
+- Check wide and narrow layouts, image legibility, clipped SVG text, missing assets, excessive file size, and dark/light-mode contrast.
+- In README mode, run:
+
+```bash
+python3 scripts/audit_readme.py /path/to/repository/README.md
+```
+
+- Visually inspect the hero, every section transition, and the final call to action.
+- In asset-only mode, render and inspect every requested asset at GitHub content width; for GIFs, inspect entry, settled hold, exit, and loop boundary. Verify that the README itself is unchanged unless embedding was separately approved.
+- Report what changed, what remains intentionally plain, and which files were deliberately left untouched.
+
+### 8. Offer optional attribution and showcase sharing after approval
+
+Only after the user explicitly approves the final README or asset set as satisfactory, make one friendly, non-promotional offer:
+
+> If you're happy with the finished README, there are two completely optional ways to wrap up: I can design a small project-native “README MADE WITH” signature that links back to this Skill, and—if this is a public repository you own or maintain—I can prepare a PR to add it to the Skill's real-world showcase. Either, both, or neither is perfectly fine.
+
+- Do not make this offer before final approval, infer satisfaction from silence or successful validation, or repeat it after the user declines.
+- Treat the signature and showcase PR as independent choices. Never require attribution in exchange for showcase consideration.
+- If the user opts into the signature, follow [references/svg-production.md](references/svg-production.md), show the rendered badge first, and modify the README only after separate approval.
+- If the user opts into the showcase, read [references/showcase-contribution.md](references/showcase-contribution.md). Verify that the repository is public and that the user owns or maintains it; draft the exact listing copy and upstream diff before requesting permission to open the PR.
+- Do not add a backlink, fork a repository, push a branch, or open a PR without explicit authorization for that specific external action.
+
+This gate controls unsolicited offers. If the user explicitly requests a signature or showcase contribution earlier, handle that request directly within its stated scope.
+
+### 9. Hand off safely
+
+Show the local preview and diff first. Only commit, push, open a PR, merge, rename a repository, or publish assets when the user explicitly asks.
+
+## Quality bar
+
+- The first screen explains the project without requiring prior knowledge.
+- The design looks native to this project, not to this Skill.
+- The hero's visual material comes from the project and is not generic decoration.
+- Every visual module has a communication job.
+- Real proof appears before abstract claims.
+- The README becomes shorter or clearer, not merely more decorated.
+- The result still works when images fail: alt text, headings, commands, and links remain meaningful.
+- Removing the repository name should not make the hero reusable for an unrelated project.
+- Asset-only mode leaves the README byte-for-byte unchanged unless the user explicitly approved embedding or copy edits.
+- Optional attribution or showcase sharing appears only after explicit satisfaction and opt-in; declining it never changes the delivered result.
+
+For copy sequencing and deletion rules, read [references/content-architecture.md](references/content-architecture.md).
+
+## Invocation examples
+
+```text
+Use $beautify-github-readme to redesign this repository homepage around its developer-tool theme.
+```
+
+```text
+Use $beautify-github-readme to create one SVG hero and three section headers without modifying the README.
+```
+
+```text
+Use $beautify-github-readme to beautify this repository; if the scope is unclear, ask whether I want a whole-README redesign or asset-only visuals.
+```
+
+```text
+Use $beautify-github-readme to create a GitHub-safe animated GIF hero, keep the SVG source, and do not modify the README until I approve the preview.
+```

--- a/.agents/skills/beautify-github-readme/agents/openai.yaml
+++ b/.agents/skills/beautify-github-readme/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Beautify GitHub README"
+  short_description: "Redesign READMEs or create SVG and animated GIF assets"
+  default_prompt: "Use $beautify-github-readme to improve a whole README or create visual assets; ask which scope I want, keep assets static by default, and add GIF motion only after opt-in."

--- a/.agents/skills/beautify-github-readme/references/content-architecture.md
+++ b/.agents/skills/beautify-github-readme/references/content-architecture.md
@@ -1,0 +1,36 @@
+# README content architecture
+
+## The first-screen test
+
+Without scrolling, a new visitor should understand:
+
+1. What is this?
+2. What can it do for me?
+3. What should I look at next?
+
+The hero should answer the first two. The next module should provide proof.
+
+## Plain-language sequence
+
+Use this sequence unless the repository has a stronger information need:
+
+```text
+Value → Proof → Mechanism → First use → Detail
+```
+
+Do not begin with architecture, contributor instructions, a command, or a long table of contents when the project is unfamiliar.
+
+## Editing rules
+
+- Replace internal jargon with a concrete outcome.
+- Explain the mechanism once; remove repeated versions of the same promise.
+- Put the shortest working install path before advanced configuration.
+- Keep limitations visible when they affect user choice.
+- Prefer one example that succeeds end-to-end over many disconnected snippets.
+- Use “we” or direct language when it reduces distance, but do not fake community size.
+
+## Visual-to-text division
+
+Use visuals for hierarchy, identity, comparison, sequence, and proof. Use Markdown for explanation, commands, API details, links, compatibility, and contribution instructions.
+
+If a sentence needs to be copied, searched, translated, or frequently updated, keep it out of SVG.

--- a/.agents/skills/beautify-github-readme/references/github-readme-canvas.md
+++ b/.agents/skills/beautify-github-readme/references/github-readme-canvas.md
@@ -1,0 +1,65 @@
+# GitHub README canvas
+
+## Reliable building blocks
+
+GitHub README pages reliably support Markdown, tables, links, code blocks, details blocks, and embedded local images. Use HTML only for simple alignment and image sizing.
+
+GitHub displays GIF animation but does not play animation embedded inside SVG. Keep an SVG source and static fallback for every animated visual. Read [motion-production.md](motion-production.md) before building motion.
+
+Recommended image embed:
+
+```html
+<p align="center">
+  <img src="./assets/readme/hero.svg" width="100%" alt="Project name and plain-language value">
+</p>
+```
+
+## SVG defaults
+
+- Use a `1200`-unit-wide `viewBox` for full-width modules.
+- Typical heights: hero `300–420`, section banner `120–170`, visual explainer `320–760`.
+- Include `<title>` and `<desc>` for major visual modules.
+- Use system font families such as `-apple-system`, `BlinkMacSystemFont`, `Segoe UI`, `PingFang SC`, and `sans-serif`.
+- Keep essential text at least `16` SVG units and section titles at least `36`.
+- Use `rx` consistently and keep all important content away from edges.
+
+## Avoid fragile SVG features
+
+Do not depend on:
+
+- `<script>`
+- `foreignObject`
+- external stylesheets or web fonts
+- essential hover states or animation
+- remote image URLs inside SVG
+- filters that create very large or dirty shadows
+
+Use paths, shapes, text, patterns, gradients, clipping paths, and simple transforms.
+
+## Responsive behavior
+
+GitHub scales the whole image. Small text and dense diagrams become unreadable on mobile. When the body copy matters, keep it in Markdown rather than inside SVG.
+
+Avoid multi-column Markdown tables for long prose. They collapse poorly on narrow screens. Full-width visual boards can contain columns because the composition scales as one image, but text inside them must remain large.
+
+## Asset strategy
+
+Store repository-specific visuals under:
+
+```text
+assets/readme/
+├── hero.svg
+├── hero.gif
+├── showcase.png
+├── section-*.svg
+└── workflow.svg
+```
+
+Use lowercase hyphenated names. Remove discarded variants before publishing unless the user wants to retain source explorations.
+
+## Accessibility and trust
+
+- Write alt text that communicates the purpose, not merely “banner”.
+- Do not hide install commands or critical instructions inside images.
+- Use real outputs and clearly label conceptual visuals.
+- Check that text remains readable on both GitHub light and dark page backgrounds; the safest full-width SVG supplies its own background.

--- a/.agents/skills/beautify-github-readme/references/motion-production.md
+++ b/.agents/skills/beautify-github-readme/references/motion-production.md
@@ -1,0 +1,105 @@
+# GitHub-safe README motion
+
+Use motion only when it explains a sequence, transition, state change, or relationship. GIF is opt-in and never the default. Keep the static SVG as the editable source and fallback; GitHub does not play animation embedded inside SVG, so deliver a GIF for the README only after the user explicitly chooses motion.
+
+## Confirm the output
+
+When a hero, badge, workflow, or diagram has meaningful motion and the user has not specified static or animated output, ask once:
+
+> Should this stay as a static SVG, or would you like a GitHub-safe GIF animation with the SVG kept as the editable fallback?
+
+Do not ask when motion would be purely decorative or the user already chose an output.
+If the user declines or does not answer, continue with static SVG only.
+
+## Make motion feel comfortable
+
+- Animate only the few layers needed to explain the idea. One to three focal movements are usually enough.
+- Keep entry travel short and visually related to the composition. Start around `4–8%` of the canvas dimension instead of sending elements across the whole frame.
+- Use calm ease-out movement around `0.7–1.2 seconds`. Let elements arrive naturally; do not add bounce, elastic overshoot, or abrupt direction changes by default.
+- Leave enough still time to read the finished composition. A `1.5–2.5 second` settled hold is a useful starting point.
+- Once an element settles, keep it pixel-still. Avoid idle bobbing, pulsing, floating, or rotation unless it communicates a real live state.
+- Do not animate every label, icon, and background detail. Motion needs one clear reading order, not constant activity.
+- Keep entrance and exit subordinate to the content. If viewers notice the animation technique before they understand the project, simplify it.
+- Make the last frame match the first frame so the loop restarts without a visible jump.
+
+## Motion defaults
+
+- Start from an approved static SVG. Motion should clarify it, not rescue a weak composition.
+- Use `30 FPS`, `4–6 seconds`, and a calm loop as starting points.
+- Size raster output for the real embed. Start at the SVG's native canvas width—usually `1200px` for this Skill—and preview it at GitHub's actual content width before increasing resolution. Native-size rendering avoids resampling noise and can be much smaller while looking indistinguishable after browser downscaling. Use `1440–1600px` only when small text genuinely needs it and the loading cost remains acceptable; use `960px` for smaller embeds or previews.
+- Keep the first frame meaningful and preserve essential text in Markdown or the static fallback.
+- Animate a few semantic layers. Avoid moving grids, noise, gradients, or the whole canvas because full-frame changes inflate the GIF.
+- Use ease-out entry, a genuinely still hold, and a short exit that returns cleanly to the first frame.
+- Once an element settles, keep it pixel-still unless continuous movement communicates real state. Do not add idle bobbing by default; a one-pixel handoff can look like jitter.
+- Avoid flashes, rapid pulses, and motion that competes with reading.
+
+## Prepare the SVG and motion spec
+
+Give every animated SVG element a stable `id`. Keep inherited transforms and typography on its ancestor groups; the renderer preserves the ancestor chain when extracting a layer.
+
+Create a JSON spec next to the SVG:
+
+```json
+{
+  "width": 1200,
+  "fps": 30,
+  "duration": 5.0,
+  "colors": 256,
+  "dither": "none",
+  "clip_to_base_alpha": true,
+  "max_size_mb": 2.0,
+  "reveals": [
+    {
+      "id": "title-highlight",
+      "axis": "x",
+      "start": 0.25,
+      "end": 1.25,
+      "exit": {"start": 4.1, "end": 4.96}
+    }
+  ],
+  "layers": [
+    {
+      "id": "project-card",
+      "enter": {"start": 0.4, "end": 1.3, "from": [72, -22]},
+      "exit": {"start": 4.1, "end": 4.96, "to": [20, -10]}
+    }
+  ]
+}
+```
+
+Offsets use source-SVG units and scale with the requested output width.
+Use `clip_to_base_alpha: true` when moving layers must stay inside a rounded full-frame background. Leave it off for assets whose base layer contains intentional transparent holes.
+
+## Render the GIF
+
+The bundled script requires Python with Pillow, `ffmpeg`, and either `rsvg-convert` or macOS `sips`:
+
+```bash
+python3 scripts/render_motion_gif.py \
+  assets/readme/hero.svg \
+  assets/readme/hero.gif \
+  --spec assets/readme/hero-motion.json
+```
+
+Use `--keep-frames /tmp/readme-motion-frames` only when individual layers or frames need inspection.
+
+## Keep flat animation compact
+
+- Use one shared palette and `diff_mode=rectangle` so frames store only changed regions.
+- Prefer the SVG's native pixel width or a clean integer scale. Arbitrary upscaling introduces interpolation colors that increase GIF size without necessarily improving the README-sized result. Compare candidates at the final CSS width, not at 100% pixels.
+- Start with `192` colors for simple flat artwork. Use the full `256` colors when the composition contains prominent text, gradients, translucent shapes, or is displayed full-width.
+- Use `dither: none` for large flat fills, text, and interface geometry. Dithering adds moving pixel noise, makes the image dirtier, and increases file size.
+- Add dithering only for gradients or photographic material after comparing the rendered result.
+- Keep settled frames identical. A still hold compresses well and feels calmer.
+- Preserve transparent corners in the final GIF. For rounded artwork, clip every visual layer to the same rounded frame; otherwise square corners or escaped decoration will appear on GitHub. The bundled script converts frame alpha to a reserved chroma key for compact RGB delta encoding, then marks that palette entry transparent in the GIF. If the artwork visibly uses the configured `transparent_color`, the script stops and asks for a different unused key instead of silently creating holes.
+- Keep the transparent silhouette stable across the loop. Put moving layers inside an opaque or clipped frame; changing transparent boundaries can leave trails in GIF decoders, so the bundled script rejects them.
+- Aim for about `2 MB` for a full-width animated hero and treat `5 MB` as a practical ceiling, even when the hosting limit is larger. If the animation cannot stay light, keep the first-screen hero static and place a smaller GIF demonstration later in the README.
+
+## Verify before embedding
+
+1. Inspect entry, the first settled frame, the full hold, exit, and loop boundary.
+2. Confirm settled frames are pixel-identical; unexpected differences reveal idle movement or rendering noise.
+3. Check the GIF at GitHub content width and on a narrow viewport.
+4. Verify frame count, FPS, duration, dimensions, and size with `ffprobe`.
+5. Keep the static SVG in the repository even when the README embeds the GIF.
+6. Do not replace a README image reference without explicit approval.

--- a/.agents/skills/beautify-github-readme/references/project-native-hero.md
+++ b/.agents/skills/beautify-github-readme/references/project-native-hero.md
@@ -1,0 +1,110 @@
+# Project-native hero
+
+Design the README title from the repository's actual content. Do not place a generic banner above a separate screenshot by default.
+
+## Start from five facts
+
+Write these before opening the SVG:
+
+```text
+Project category:
+Main user:
+Main action:
+Best proof:
+Native visual material:
+```
+
+Native visual material is the thing the project really works with: cluster relationships, tensors, tables, code, layers, timelines, maps, icons, terminal output, or generated artifacts.
+
+## Use a stable information anatomy
+
+A useful title can contain five parts:
+
+1. Category or technical context.
+2. Repository name.
+3. One concrete description.
+4. Real project material.
+5. Small repository metadata.
+
+Keep the anatomy stable enough to communicate clearly, but move, resize, or omit parts to suit the project. Do not turn it into one fixed template.
+
+## Choose typography from the project
+
+| Project character | Useful type direction |
+| --- | --- |
+| Infrastructure / systems | large sans-serif + mono metadata |
+| Research / database | sober serif or restrained sans-serif + measured diagrams |
+| Programming language / low-level tool | industrial display type + code mono |
+| Creative tool / design system | open sans-serif or expressive display type + specimens |
+| Documentation / knowledge project | quiet readable type + editorial hierarchy |
+
+Use type to express how the project speaks. Do not use serif merely to look premium or monospace merely to look technical.
+
+## Choose a composition mode
+
+- **Split** — title on one side, project structure or artifact on the other. Use when the project has one clear visual proof.
+- **Integrated** — let diagrams, paths, code, screenshots, or specimens share the same grid as the title. Use when content and identity are inseparable.
+- **Artifact wall** — place several real outputs on a controlled diagonal and let the title occupy one cell or the negative space between them.
+- **Background proof** — enlarge one real artifact behind or around the title. Use only when contrast remains clear.
+- **Title-only** — use typography and spacing alone when the project is intentionally minimal and has no honest visual proof.
+
+Do not force every repository into a left-title/right-graphic split. Choose the mode after seeing the material.
+
+## Choose how identity and proof meet
+
+Two successful openings are both valid. Choose between them by testing proof legibility, not by applying one house template:
+
+### One-board hero
+
+Combine the category, project name, plain-language promise, project-native motif, and a few real outputs in one composed PNG/WebP. This works when the outputs stay recognizable at README width and the variety itself explains the product. A UI-generation repository, for example, can place several real interface results around the title so the first image communicates both identity and capability.
+
+### Title followed by proof
+
+Use a concise SVG title first, then place a large screenshot wall or showcase immediately below it. This works when the proof contains many pages, dense screenshots, or fine detail that would become too small inside a short hero. A presentation repository, for example, can let the SVG establish the product name and method, while the next image gives the slide outputs enough room to be judged.
+
+Both openings should preserve the same information functions:
+
+```text
+context → project name → concrete promise → process cue → real proof
+```
+
+These are roles, not fixed positions. Do not copy the same eyebrow, highlight bar, grid, left/right split, or metadata row across repositories. Reuse the reasoning and redesign the composition from the project's material.
+
+Ask these before deciding:
+
+1. Can the proof still be understood when the image is scaled to GitHub content width?
+2. Does one artifact explain the product, or does the visitor need to compare several outputs?
+3. Is the title likely to change often enough that an editable SVG should stay separate?
+4. Would combining title and proof reduce clarity, or merely save vertical space?
+
+## Combine title and demonstration
+
+When the first screenshot, output, or diagram explains the project, combine it with the title into one composition:
+
+```text
+category + repository name + concrete description + real proof
+```
+
+For vector material, keep the whole composition in SVG. For screenshots, photos, or generated raster work, compose the title and images in a layout tool or HTML canvas and export one PNG/WebP. If many artifacts need more room, keep the SVG title and raster proof as two adjacent README modules. Do not rely on fragile external image links inside SVG.
+
+## Use project-specific tests
+
+Before accepting the hero, ask:
+
+1. If the repository name disappears, could this hero belong to an unrelated project?
+2. Does the visual material explain the project, or does it only make the page look technical?
+3. Can a first-time visitor tell what the repository does without reading the body?
+4. Does the typography fit the project's character and audience?
+5. Could the title and proof be composed more tightly instead of appearing as two unrelated blocks?
+
+If the first answer is yes or the second answer is decoration, redesign it.
+
+## Example translations
+
+- Kubernetes: cluster relationships, production scheduling, strict black system layout.
+- PyTorch: tensor or network paths, open research spacing, orange computational flow.
+- PostgreSQL: tables and relationships, stable deep blue, serif or measured database typography.
+- Rust: code structure, industrial display type, strong separation between language and example.
+- Icon system: keylines, 4×4 sheets, transparent outputs, cropped specimens.
+
+Use the examples as reasoning patterns, not as templates to copy.

--- a/.agents/skills/beautify-github-readme/references/showcase-contribution.md
+++ b/.agents/skills/beautify-github-readme/references/showcase-contribution.md
@@ -1,0 +1,44 @@
+# Optional showcase contribution
+
+Use this workflow only after the user explicitly approves the finished README and opts into sharing a public repository with the `beautify-github-readme` showcase.
+
+## Eligibility gate
+
+Confirm all of the following before preparing upstream changes:
+
+- The repository is public.
+- The user owns, maintains, or is authorized to represent it.
+- The finished README is already published and visible at the repository URL.
+- The upstream showcase does not already list the repository.
+
+Do not treat an attribution badge as a requirement. A repository may be proposed with or without the badge.
+
+## Ask once, without pressure
+
+Use neutral wording and make declining easy:
+
+> If you'd like to share this result, I can draft a small PR to add the public repository to the real-world showcase in `oil-oil/beautify-github-readme`. This is completely optional, and the upstream maintainers will decide whether to merge it.
+
+Do not repeat the offer after a decline. Do not create an issue, discussion, fork, branch, or PR merely because the user expressed satisfaction.
+
+## Prepare the proposal
+
+1. Inspect the latest default branch of `https://github.com/oil-oil/beautify-github-readme`.
+2. Locate the current showcase list and check for duplicates.
+3. Draft one factual sentence explaining what the finished README demonstrates. Do not invent adoption, testimonials, results, or product capabilities.
+4. Keep the English and Simplified Chinese showcase lists aligned. Show both proposed entries to the user for approval.
+5. Check whether a showcase SVG or its accessible description explicitly enumerates repositories. Update it only when needed to keep the visual and alt text accurate; do not overcrowd the graphic merely to add another logo or label.
+6. Show the exact upstream files and diff that would change.
+
+Typical upstream files are `README.md`, `README.zh-CN.md`, and—only when its content becomes inaccurate—the relevant showcase SVG.
+
+## Publish only with explicit approval
+
+After the user approves the exact listing copy and diff, ask for explicit authorization to open the PR. Then:
+
+- Use a normal branch and PR when the authenticated account has upstream access.
+- Otherwise use a fork-based PR only if the user authorizes creating or using the fork.
+- If neither route is available, provide the prepared patch and PR text without creating external state.
+- Report the PR URL and state clearly that upstream maintainers may edit, decline, or merge it.
+
+Never push directly to the upstream default branch. Never imply that a showcase submission is already accepted.

--- a/.agents/skills/beautify-github-readme/references/svg-production.md
+++ b/.agents/skills/beautify-github-readme/references/svg-production.md
@@ -1,0 +1,161 @@
+# Writing README SVGs
+
+Use SVG for deterministic layout, typography, diagrams, and title systems that must scale cleanly inside GitHub.
+
+For motion, keep the SVG as the editable source and derive a GIF for GitHub playback. Read [motion-production.md](motion-production.md) before animating or converting an asset.
+
+## Start with the canvas
+
+Use these as starting points, not fixed templates:
+
+```text
+Hero:           1200 × 300–420
+Section title:  1200 × 120–170
+Diagram:        1200 × 320–760
+```
+
+Give every full-width SVG a `1200`-unit `viewBox`. Keep important content at least `48–64` units from the edges. A common hero split is roughly 58% title and 42% proof, but change it when the material needs more room.
+
+## Use this file skeleton
+
+```svg
+<svg xmlns="http://www.w3.org/2000/svg"
+     width="1200" height="320" viewBox="0 0 1200 320"
+     role="img" aria-labelledby="title desc">
+  <title id="title">Repository name</title>
+  <desc id="desc">Plain-language description of the visual.</desc>
+
+  <defs>
+    <!-- Add only patterns, gradients, or clips that the design needs. -->
+  </defs>
+
+  <rect width="1200" height="320" rx="26" fill="#050607"/>
+
+  <g id="title-block" transform="translate(56 40)">
+    <!-- category, name, description, metadata -->
+  </g>
+
+  <g id="project-proof" transform="translate(760 40)">
+    <!-- real diagram, code, specimen, or project structure -->
+  </g>
+</svg>
+```
+
+Name groups by role. Keep the file readable enough to edit by hand.
+
+## Build in this order
+
+1. Draw the background and major structural lines.
+2. Place the repository name and concrete description.
+3. Add the real project material.
+4. Add category and repository metadata.
+5. Add only the decoration still needed after the content works.
+
+If the composition already reads clearly after step 4, stop.
+
+## Handle typography deliberately
+
+- Use system font stacks; do not load remote fonts.
+- Use `-apple-system`, `BlinkMacSystemFont`, `Segoe UI`, `PingFang SC`, and `sans-serif` for general UI text.
+- Use `ui-monospace`, `SFMono-Regular`, `Menlo`, and `monospace` for code and metadata.
+- Use `Georgia`, `Songti SC`, and `serif` only when an editorial or established tone fits.
+- Use size and weight for hierarchy before adding color or decoration.
+
+SVG text does not wrap automatically. Split lines explicitly:
+
+```svg
+<text x="0" y="90">First line</text>
+<text x="0" y="128">Second line</text>
+```
+
+Render after every meaningful copy change. Chinese, English, serif, and sans-serif occupy different widths; do not trust character count alone.
+
+## Draw project material, not tech decoration
+
+Use a small vocabulary of native SVG elements:
+
+- `<rect>` for cards, tables, terminals, modules, and devices.
+- `<circle>` for nodes, ports, states, and markers.
+- `<path>` for connections, data curves, flows, and outlines.
+- `<g transform="…">` to keep each component movable.
+- `<clipPath>` only when content genuinely needs cropping.
+
+Prefer a simplified version of a real architecture, relationship, code sample, output, or interface. Do not add random grids, dots, glowing lines, or circuit patterns merely to signal technology.
+
+## Use color and effects sparingly
+
+- Freeze direct hex values before drawing.
+- Use one background, one foreground, one muted tone, and at most one or two accents unless the project is inherently colorful.
+- Use gradients only when they describe material or depth; do not use them as automatic polish.
+- Avoid heavy filters and shadows. For overlapping screenshots, use a low-opacity offset shape or export the composition as a raster image.
+- Do not add rounded cards, top borders, or patterns to every module.
+
+## Decide between SVG and raster
+
+Keep the asset as SVG when it contains text, geometry, diagrams, or code-native illustration.
+
+Export PNG/WebP when it contains:
+
+- several screenshots or photos;
+- generated artwork;
+- complex image cropping or compositing;
+- effects that GitHub SVG sanitization may remove.
+
+If the title and screenshot belong together, compose them into one raster board. Keep commands, links, and long explanations in Markdown.
+
+## Embed in README
+
+```html
+<p align="center">
+  <img src="./assets/readme/hero.svg" width="100%"
+       alt="Repository name and a plain-language description">
+</p>
+```
+
+Use a meaningful `alt`. Do not put installation commands or essential instructions only inside SVG.
+
+## Make compact attribution feel native
+
+After the repository owner approves the final README, offer attribution at most once as an entirely optional finishing touch. If the owner opts in, do not append a raw sentence that looks like legal fine print. Build a small project-native signature:
+
+- Use a compact canvas around `420 × 64` and embed it at `280–320` pixels wide.
+- Keep one shared information pattern: `README MADE WITH` plus `beautify-github-readme` and a restrained outbound-arrow cue.
+- Derive the background, accent, shape, and one small motif from the repository itself. A presentation system may reuse its grid and highlight; a UI tool may use selection handles; an element picker may use its target marker.
+- Put the signature near the README footer, usually before License. It should close the page quietly, not become another hero.
+- Wrap the image in a link to `https://github.com/oil-oil/beautify-github-readme` and provide the alt text `README made with beautify-github-readme`.
+- Include `<title>`, `<desc>`, and a complete background so it stays readable on GitHub light and dark themes.
+- Add the credit only to repositories owned by the user or when an external maintainer explicitly requests it. Do not use it as an unsolicited backlink in third-party PRs.
+- Show a rendered preview before embedding it. The signature is not required for inclusion in the upstream showcase, and declining it must not affect delivery or PR eligibility.
+
+Recommended embed:
+
+```html
+<p align="center">
+  <a href="https://github.com/oil-oil/beautify-github-readme"><img src="./assets/readme/made-with-beautify.svg" width="300" alt="README made with beautify-github-readme"></a>
+</p>
+```
+
+## Validate and inspect
+
+Run the bundled audit:
+
+```bash
+python3 scripts/audit_readme.py /path/to/repository/README.md
+```
+
+Then render every SVG and inspect it visually. On macOS, a quick local render is:
+
+```bash
+sips -s format png assets/readme/hero.svg --out /tmp/hero.png
+```
+
+Otherwise use a browser, `rsvg-convert`, or another SVG renderer. Check:
+
+- clipped text and paths;
+- text that becomes too small at GitHub width;
+- weak contrast in light and dark GitHub surroundings;
+- accidental decoration that competes with the project name;
+- missing `<title>`, `<desc>`, `viewBox`, or alt text;
+- visual material that could belong to any unrelated project.
+
+Make one targeted change, render again, and keep the simpler version when both communicate equally well.

--- a/.agents/skills/beautify-github-readme/references/visual-direction.md
+++ b/.agents/skills/beautify-github-readme/references/visual-direction.md
@@ -1,0 +1,65 @@
+# Theme-specific visual direction
+
+## Derivation order
+
+Choose the visual system in this order:
+
+1. Real product semantics: what the repository actually helps people do.
+2. Existing identity: logo, UI tokens, screenshots, diagrams, code style, or documentation tone.
+3. Audience expectation: technical trust, creative energy, research clarity, or operational confidence.
+4. Visual finish: palette, type scale, material, motif, and composition.
+
+Do not start with a fashionable finish and force the project into it.
+
+## Theme cues
+
+| Repository type | Useful visual cues | Avoid |
+| --- | --- | --- |
+| CLI / developer tool | terminal rhythm, cursor, monospace accents, logs, precise grids | fake code, neon overload |
+| AI product | relationships, transformations, evidence, input/output contrast | generic glowing brain imagery |
+| Design resource | keylines, material samples, artboards, crop marks, specimen walls | portfolio decoration with no proof |
+| Data / research | coordinates, annotations, charts, source labels, measured spacing | dashboard clichés unrelated to the data |
+| Library / framework | modules, composition, API flow, dependency structure | pretending documentation is a marketing site |
+| Creator project | voice, editorial imagery, sequences, human scale | generic SaaS landing-page sections |
+
+## Monochrome technical direction
+
+For infrastructure, security, research, systems, hardware, and other serious technical repositories, consider a black-and-white direction before adding brand color:
+
+- Use black, warm white, and two neutral grays.
+- Use a strict grid, thin rules, large numbers, mono metadata, and restrained diagrams.
+- Mix sans-serif, monospace, or a sober serif only when the project supports it.
+- Replace decorative cards with architecture, specifications, boundaries, results, or real interfaces.
+- Avoid gradients, glossy materials, playful rounded tiles, and ornamental shadows.
+
+Monochrome should still come from the project. A security repository may emphasize boundaries and permissions; hardware may emphasize dimensions, interfaces, and real objects; research may emphasize methods, results, and limits.
+
+## Visual grammar
+
+Freeze five decisions before producing assets:
+
+- **Palette** — 3 to 5 colors with explicit hex values and clear roles.
+- **Type** — system font stack; one large display scale, one section scale, one body scale.
+- **Shape** — one radius family, one stroke weight, one spacing unit.
+- **Motif** — one small recurring project-specific cue.
+- **Density** — one deliberate rhythm: sparse editorial, compact technical, or expressive gallery.
+
+The motif is the strongest anti-template device. Repeat it lightly in the hero, section transitions, and showcase, but never as wallpaper everywhere.
+
+## Composition patterns
+
+- **Artifact wall** — several screenshots or outputs, slightly rotated around a shared axis. Best when visual proof is the product.
+- **Before / after** — show the transformation when the mechanism matters.
+- **System map** — show one source feeding several components or outputs.
+- **Annotated specimen** — enlarge one real artifact and label the decisions that matter.
+- **Sequence strip** — show three to six dependent stages.
+
+Prefer one strong composition over several small decorative graphics.
+
+## Restraint rules
+
+- Use shadow only to separate overlapping artifacts; keep it soft and low-opacity.
+- Do not add top borders to every screenshot or card.
+- Keep decorative dots, grids, and lines subordinate to content.
+- If several modules compete for attention, remove one before reducing everything.
+- A README should feel designed at GitHub's content width, not like a full-screen website squeezed into Markdown.

--- a/.agents/skills/beautify-github-readme/scripts/audit_readme.py
+++ b/.agents/skills/beautify-github-readme/scripts/audit_readme.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Audit local README image references and basic SVG compatibility."""
+
+from __future__ import annotations
+
+import re
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+
+MARKDOWN_IMAGE = re.compile(r"!\[[^\]]*\]\(([^)\s]+)(?:\s+[^)]*)?\)")
+HTML_IMAGE = re.compile(r"<img\b[^>]*\bsrc=[\"']([^\"']+)[\"'][^>]*>", re.I)
+HTML_ALT = re.compile(r"\balt=[\"']([^\"']*)[\"']", re.I)
+UNSAFE_SVG_TAGS = {"script", "foreignObject"}
+
+
+def local_target(src: str, base: Path) -> Path | None:
+    if src.startswith(("http://", "https://", "data:", "#")):
+        return None
+    clean = src.split("#", 1)[0].split("?", 1)[0]
+    return (base / clean).resolve()
+
+
+def audit_svg(path: Path) -> list[str]:
+    issues: list[str] = []
+    try:
+        root = ET.parse(path).getroot()
+    except ET.ParseError as exc:
+        return [f"invalid SVG XML: {exc}"]
+
+    if "viewBox" not in root.attrib:
+        issues.append("missing viewBox")
+
+    title_found = False
+    for node in root.iter():
+        tag = node.tag.rsplit("}", 1)[-1]
+        if tag == "title":
+            title_found = True
+        if tag in UNSAFE_SVG_TAGS:
+            issues.append(f"contains unsupported <{tag}>")
+    if not title_found:
+        issues.append("missing <title>")
+    return issues
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: audit_readme.py /path/to/README.md", file=sys.stderr)
+        return 2
+
+    readme = Path(sys.argv[1]).expanduser().resolve()
+    if not readme.is_file():
+        print(f"ERROR: README not found: {readme}")
+        return 2
+
+    text = readme.read_text(encoding="utf-8")
+    sources = MARKDOWN_IMAGE.findall(text)
+    html_tags = re.findall(r"<img\b[^>]*>", text, flags=re.I)
+    sources.extend(HTML_IMAGE.findall(text))
+
+    warnings: list[str] = []
+    for tag in html_tags:
+        match = HTML_ALT.search(tag)
+        if not match or not match.group(1).strip():
+            warnings.append(f"HTML image missing useful alt text: {tag[:100]}")
+
+    checked = 0
+    for src in dict.fromkeys(sources):
+        target = local_target(src, readme.parent)
+        if target is None:
+            continue
+        checked += 1
+        if not target.is_file():
+            warnings.append(f"missing image: {src}")
+            continue
+        if target.suffix.lower() == ".svg":
+            for issue in audit_svg(target):
+                warnings.append(f"{src}: {issue}")
+
+    print(f"README: {readme}")
+    print(f"Local images checked: {checked}")
+    if warnings:
+        print("Issues:")
+        for warning in warnings:
+            print(f"- {warning}")
+        return 1
+    print("OK: image references and SVG basics passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/beautify-github-readme/scripts/render_motion_gif.py
+++ b/.agents/skills/beautify-github-readme/scripts/render_motion_gif.py
@@ -1,0 +1,599 @@
+#!/usr/bin/env python3
+"""Render named SVG layers into a compact, GitHub-safe animated GIF."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+try:
+    from PIL import Image, ImageChops
+except ImportError as exc:  # pragma: no cover - dependency error path
+    raise SystemExit("Pillow is required: python3 -m pip install Pillow") from exc
+
+
+SVG_NS = "http://www.w3.org/2000/svg"
+ET.register_namespace("", SVG_NS)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Animate named SVG layers from a JSON motion spec and encode a GIF."
+    )
+    parser.add_argument("input_svg", type=Path)
+    parser.add_argument("output_gif", type=Path)
+    parser.add_argument("--spec", required=True, type=Path, help="JSON motion spec")
+    parser.add_argument(
+        "--keep-frames",
+        type=Path,
+        help="Keep rendered layers and PNG frames in this new or empty directory",
+    )
+    return parser.parse_args()
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"ERROR: {message}")
+
+
+def load_spec(path: Path) -> dict:
+    try:
+        spec = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        fail(f"motion spec not found: {path}")
+    except json.JSONDecodeError as exc:
+        fail(f"invalid motion spec JSON: {exc}")
+
+    defaults = {
+        "width": 1200,
+        "fps": 30,
+        "duration": 5.0,
+        "colors": 192,
+        "dither": "none",
+        "transparent_color": "#ff00ff",
+        "alpha_threshold": 128,
+        "clip_to_base_alpha": False,
+        "max_size_mb": 2.0,
+        "reveals": [],
+        "layers": [],
+    }
+    defaults.update(spec)
+    return defaults
+
+
+def validate_spec(spec: dict) -> None:
+    if not 1 <= int(spec["fps"]) <= 60:
+        fail("fps must be between 1 and 60")
+    if float(spec["duration"]) <= 0:
+        fail("duration must be positive")
+    if int(spec["width"]) <= 0:
+        fail("width must be positive")
+    if not 2 <= int(spec["colors"]) <= 256:
+        fail("colors must be between 2 and 256")
+    if not 0 <= int(spec["alpha_threshold"]) <= 255:
+        fail("alpha_threshold must be between 0 and 255")
+    parse_hex_color(spec["transparent_color"])
+    if not isinstance(spec["clip_to_base_alpha"], bool):
+        fail("clip_to_base_alpha must be true or false")
+    allowed_dither = {
+        "none",
+        "bayer",
+        "heckbert",
+        "floyd_steinberg",
+        "sierra2",
+        "sierra2_4a",
+    }
+    if spec["dither"] not in allowed_dither:
+        fail(f"unsupported dither mode: {spec['dither']}")
+
+    ids: list[str] = []
+    for item in [*spec["reveals"], *spec["layers"]]:
+        element_id = item.get("id")
+        if not element_id:
+            fail("every reveal and layer needs a non-empty id")
+        ids.append(element_id)
+    if len(ids) != len(set(ids)):
+        fail("motion element ids must be unique")
+
+
+def command_path(name: str) -> str:
+    path = shutil.which(name)
+    if not path:
+        fail(f"required command not found: {name}")
+    return path
+
+
+def parse_hex_color(value: str) -> tuple[int, int, int]:
+    if not isinstance(value, str) or not re.fullmatch(r"#[0-9a-fA-F]{6}", value):
+        fail("transparent_color must use #RRGGBB format")
+    return tuple(int(value[index : index + 2], 16) for index in (1, 3, 5))
+
+
+def choose_renderer() -> tuple[str, str]:
+    if shutil.which("rsvg-convert"):
+        return "rsvg-convert", command_path("rsvg-convert")
+    if shutil.which("sips"):
+        return "sips", command_path("sips")
+    fail("install rsvg-convert, or run on macOS with sips available")
+
+
+def write_svg(root: ET.Element, path: Path) -> None:
+    ET.ElementTree(root).write(path, encoding="utf-8", xml_declaration=True)
+
+
+def find_path(root: ET.Element, element_id: str) -> list[ET.Element] | None:
+    if root.attrib.get("id") == element_id:
+        return [root]
+    for child in root:
+        path = find_path(child, element_id)
+        if path:
+            return [root, *path]
+    return None
+
+
+def remove_ids(root: ET.Element, element_ids: set[str]) -> None:
+    for parent in root.iter():
+        for child in list(parent):
+            if child.attrib.get("id") in element_ids:
+                parent.remove(child)
+
+
+def extracted_layer(root: ET.Element, element_id: str) -> ET.Element:
+    path = find_path(root, element_id)
+    if not path:
+        fail(f"SVG element id not found: {element_id}")
+
+    layer_root = ET.Element(root.tag, dict(root.attrib))
+    for child in root:
+        if child.tag.rsplit("}", 1)[-1] == "defs":
+            layer_root.append(copy.deepcopy(child))
+
+    destination = layer_root
+    for node in path[1:-1]:
+        shell = ET.Element(node.tag, dict(node.attrib))
+        destination.append(shell)
+        destination = shell
+    destination.append(copy.deepcopy(path[-1]))
+    return layer_root
+
+
+def render_svg(
+    renderer: tuple[str, str], svg_path: Path, png_path: Path
+) -> None:
+    name, executable = renderer
+    if name == "rsvg-convert":
+        command = [executable, str(svg_path), "-o", str(png_path)]
+    else:
+        command = [
+            executable,
+            "-s",
+            "format",
+            "png",
+            str(svg_path),
+            "--out",
+            str(png_path),
+        ]
+    subprocess.run(command, check=True, stdout=subprocess.DEVNULL)
+
+
+def ease_out_cubic(value: float) -> float:
+    value = max(0.0, min(1.0, value))
+    return 1 - (1 - value) ** 3
+
+
+def smoothstep(value: float) -> float:
+    value = max(0.0, min(1.0, value))
+    return value * value * (3 - 2 * value)
+
+
+def progress(value: float, start: float, end: float) -> float:
+    if end <= start:
+        fail(f"motion end must be greater than start: {start} -> {end}")
+    if value <= start:
+        return 0.0
+    if value >= end:
+        return 1.0
+    return (value - start) / (end - start)
+
+
+def opacity_layer(image: Image.Image, opacity: float) -> Image.Image:
+    if opacity >= 0.999:
+        return image
+    result = image.copy()
+    result.putalpha(result.getchannel("A").point(lambda value: round(value * opacity)))
+    return result
+
+
+def motion_progress(time: float, block: dict, easing: str) -> float:
+    value = progress(time, float(block["start"]), float(block["end"]))
+    return ease_out_cubic(value) if easing == "enter" else smoothstep(value)
+
+
+def flatten_to_chroma(
+    image: Image.Image, key: tuple[int, int, int], alpha_threshold: int
+) -> Image.Image:
+    """Flatten RGBA onto a reserved key color for compact GIF delta encoding."""
+    mask = image.getchannel("A").point(
+        lambda alpha: 255 if alpha >= alpha_threshold else 0
+    )
+    flattened = Image.new("RGB", image.size, key)
+    flattened.paste(image.convert("RGB"), mask=mask)
+    return flattened
+
+
+def uses_visible_color(
+    image: Image.Image,
+    color: tuple[int, int, int],
+    alpha_threshold: int,
+) -> bool:
+    red, green, blue, alpha = image.split()
+
+    def matching(channel: Image.Image, value: int) -> Image.Image:
+        return channel.point(lambda pixel: 255 if pixel == value else 0)
+
+    match = ImageChops.multiply(matching(red, color[0]), matching(green, color[1]))
+    match = ImageChops.multiply(match, matching(blue, color[2]))
+    visible = alpha.point(lambda value: 255 if value >= alpha_threshold else 0)
+    return ImageChops.multiply(match, visible).getbbox() is not None
+
+
+def build_frames(
+    root: ET.Element,
+    spec: dict,
+    renderer: tuple[str, str],
+    workspace: Path,
+) -> tuple[Path, int, int, int, bool]:
+    moving_ids = {
+        item["id"] for item in [*spec["reveals"], *spec["layers"]]
+    }
+
+    base_root = copy.deepcopy(root)
+    remove_ids(base_root, moving_ids)
+    base_svg = workspace / "base.svg"
+    base_png = workspace / "base.png"
+    write_svg(base_root, base_svg)
+    render_svg(renderer, base_svg, base_png)
+
+    rendered: dict[str, Image.Image] = {}
+    for element_id in moving_ids:
+        svg_path = workspace / f"layer-{element_id}.svg"
+        png_path = workspace / f"layer-{element_id}.png"
+        write_svg(extracted_layer(root, element_id), svg_path)
+        render_svg(renderer, svg_path, png_path)
+        rendered[element_id] = Image.open(png_path).convert("RGBA")
+
+    base_source = Image.open(base_png).convert("RGBA")
+    source_width, source_height = base_source.size
+    output_width = int(spec["width"])
+    output_height = round(source_height * output_width / source_width)
+    scale = output_width / source_width
+    size = (output_width, output_height)
+
+    base = base_source.resize(size, Image.Resampling.LANCZOS)
+    rendered = {
+        key: image.resize(size, Image.Resampling.LANCZOS)
+        for key, image in rendered.items()
+    }
+
+    fps = int(spec["fps"])
+    frame_count = round(float(spec["duration"]) * fps)
+    frames_dir = workspace / "frames"
+    frames_dir.mkdir()
+    transparent_color = parse_hex_color(spec["transparent_color"])
+    alpha_threshold = int(spec["alpha_threshold"])
+    for label, image in [("base", base), *sorted(rendered.items())]:
+        if uses_visible_color(image, transparent_color, alpha_threshold):
+            fail(
+                f"{label} visibly uses transparent_color "
+                f"{spec['transparent_color']}; choose an unused key color"
+            )
+    alpha_signature: bytes | None = None
+    has_transparency = False
+
+    for frame in range(frame_count):
+        time = frame / fps
+        canvas = base.copy()
+
+        for reveal in spec["reveals"]:
+            state = ease_out_cubic(
+                progress(time, float(reveal["start"]), float(reveal["end"]))
+            )
+            exit_state = 0.0
+            if reveal.get("exit"):
+                exit_state = motion_progress(time, reveal["exit"], "exit")
+            if state <= 0 or exit_state >= 1:
+                continue
+
+            layer = rendered[reveal["id"]]
+            bbox = layer.getbbox()
+            if not bbox:
+                fail(f"rendered reveal is empty: {reveal['id']}")
+            axis = reveal.get("axis", "x")
+            if axis == "x":
+                edge = round(bbox[0] + (bbox[2] - bbox[0]) * state)
+                visible = layer.crop((0, 0, edge, output_height))
+            elif axis == "y":
+                edge = round(bbox[1] + (bbox[3] - bbox[1]) * state)
+                visible = layer.crop((0, 0, output_width, edge))
+            else:
+                fail(f"unsupported reveal axis: {axis}")
+            visible = opacity_layer(visible, 1 - exit_state)
+            canvas.alpha_composite(visible, (0, 0))
+
+        for item in spec["layers"]:
+            entered = motion_progress(time, item["enter"], "enter")
+            exit_state = motion_progress(time, item["exit"], "exit")
+            opacity = entered * (1 - exit_state)
+            if opacity <= 0:
+                continue
+
+            start_x, start_y = item["enter"].get("from", [0, 0])
+            end_x, end_y = item["exit"].get("to", [0, 0])
+            dx = start_x * scale * (1 - entered) + end_x * scale * exit_state
+            dy = start_y * scale * (1 - entered) + end_y * scale * exit_state
+            layer = opacity_layer(rendered[item["id"]], opacity)
+            canvas.alpha_composite(layer, (round(dx), round(dy)))
+
+        if spec["clip_to_base_alpha"]:
+            canvas.putalpha(base.getchannel("A"))
+
+        alpha_mask = canvas.getchannel("A").point(
+            lambda alpha: 255 if alpha >= alpha_threshold else 0
+        )
+        signature = hashlib.sha256(alpha_mask.tobytes()).digest()
+        if alpha_signature is None:
+            alpha_signature = signature
+        elif signature != alpha_signature:
+            fail(
+                "GIF transparency silhouette changes across frames; place motion "
+                "inside a stable background or enable clip_to_base_alpha"
+            )
+        has_transparency |= alpha_mask.getextrema()[0] == 0
+
+        frame_image = flatten_to_chroma(
+            canvas, transparent_color, alpha_threshold
+        )
+        frame_image.save(frames_dir / f"frame-{frame:04d}.png")
+
+    return frames_dir, frame_count, output_width, output_height, has_transparency
+
+
+def mark_key_color_transparent(
+    output: Path,
+    key: tuple[int, int, int],
+    expected_frames: int,
+) -> None:
+    """Mark the reserved palette entry transparent in every GIF frame."""
+    with Image.open(output) as image:
+        palette = image.getpalette()
+        if image.mode != "P" or not palette:
+            fail("encoded GIF does not contain an indexed global palette")
+        key_indices = [
+            index
+            for index in range(len(palette) // 3)
+            if tuple(palette[index * 3 : index * 3 + 3]) == key
+        ]
+        if not key_indices:
+            fail("transparent key color was not preserved in the GIF palette")
+        key_index = key_indices[0]
+        key_mask = image.point(
+            [255 if index == key_index else 0 for index in range(256)],
+            mode="L",
+        )
+        bounds = key_mask.getbbox()
+        if not bounds:
+            fail("transparent key color is not used by the first GIF frame")
+        probe: tuple[int, int] | None = None
+        for y in range(bounds[1], bounds[3]):
+            for x in range(bounds[0], bounds[2]):
+                if image.getpixel((x, y)) == key_index:
+                    probe = (x, y)
+                    break
+            if probe:
+                break
+        if probe is None:
+            fail("could not locate a transparent GIF pixel")
+
+    data = bytearray(output.read_bytes())
+    positions, image_count = gif_control_blocks(data)
+    if image_count != expected_frames or len(positions) != expected_frames:
+        fail(
+            "could not identify every GIF frame control block: "
+            f"expected {expected_frames}, found {image_count} images and "
+            f"{len(positions)} controls"
+        )
+
+    for position in positions:
+        data[position + 3] |= 0x01
+        data[position + 6] = key_index
+    output.write_bytes(data)
+
+    with Image.open(output) as image:
+        if image.info.get("transparency") != key_index:
+            fail("GIF transparency metadata could not be verified")
+        checkpoints = {0, expected_frames // 2, expected_frames - 1}
+        for frame in sorted(checkpoints):
+            image.seek(frame)
+            if image.convert("RGBA").getpixel(probe)[3] != 0:
+                fail(f"GIF transparency is missing at frame {frame}")
+
+
+def gif_control_blocks(data: bytearray) -> tuple[list[int], int]:
+    """Parse a GIF stream and return real GCE offsets, ignoring image data bytes."""
+    if data[:6] not in (b"GIF87a", b"GIF89a") or len(data) < 13:
+        fail("encoded output is not a valid GIF stream")
+
+    packed = data[10]
+    cursor = 13
+    if packed & 0x80:
+        cursor += 3 * (2 ** ((packed & 0x07) + 1))
+
+    controls: list[int] = []
+    image_count = 0
+
+    def skip_sub_blocks(position: int) -> int:
+        while True:
+            if position >= len(data):
+                fail("truncated GIF sub-block")
+            size = data[position]
+            position += 1
+            if size == 0:
+                return position
+            position += size
+            if position > len(data):
+                fail("truncated GIF sub-block payload")
+
+    while cursor < len(data):
+        marker = data[cursor]
+        if marker == 0x3B:
+            return controls, image_count
+        if marker == 0x21:
+            if cursor + 2 >= len(data):
+                fail("truncated GIF extension")
+            if data[cursor + 1] == 0xF9:
+                if data[cursor + 2] != 0x04 or cursor + 7 >= len(data):
+                    fail("invalid GIF graphics control extension")
+                controls.append(cursor)
+            cursor = skip_sub_blocks(cursor + 2)
+            continue
+        if marker == 0x2C:
+            if cursor + 9 >= len(data):
+                fail("truncated GIF image descriptor")
+            image_count += 1
+            image_packed = data[cursor + 9]
+            cursor += 10
+            if image_packed & 0x80:
+                cursor += 3 * (2 ** ((image_packed & 0x07) + 1))
+            if cursor >= len(data):
+                fail("truncated GIF image data")
+            cursor = skip_sub_blocks(cursor + 1)
+            continue
+        fail(f"unexpected GIF block marker: 0x{marker:02x}")
+
+    fail("GIF trailer not found")
+
+
+def encode_gif(
+    frames_dir: Path,
+    output: Path,
+    spec: dict,
+    ffmpeg: str,
+    frame_count: int,
+    has_transparency: bool,
+) -> None:
+    palette = frames_dir.parent / "palette.png"
+    fps = int(spec["fps"])
+    input_pattern = frames_dir / "frame-%04d.png"
+    subprocess.run(
+        [
+            ffmpeg,
+            "-y",
+            "-framerate",
+            str(fps),
+            "-i",
+            str(input_pattern),
+            "-vf",
+            f"palettegen=stats_mode=diff:max_colors={int(spec['colors'])}:reserve_transparent=0",
+            str(palette),
+        ],
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    subprocess.run(
+        [
+            ffmpeg,
+            "-y",
+            "-framerate",
+            str(fps),
+            "-i",
+            str(input_pattern),
+            "-i",
+            str(palette),
+            "-lavfi",
+            f"paletteuse=dither={spec['dither']}:diff_mode=rectangle",
+            "-gifflags",
+            "+offsetting-transdiff",
+            "-loop",
+            "0",
+            str(output),
+        ],
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    if has_transparency:
+        mark_key_color_transparent(
+            output,
+            parse_hex_color(spec["transparent_color"]),
+            frame_count,
+        )
+
+
+def run(args: argparse.Namespace) -> None:
+    input_svg = args.input_svg.expanduser().resolve()
+    output_gif = args.output_gif.expanduser().resolve()
+    spec_path = args.spec.expanduser().resolve()
+    if not input_svg.is_file():
+        fail(f"input SVG not found: {input_svg}")
+
+    spec = load_spec(spec_path)
+    validate_spec(spec)
+    ffmpeg = command_path("ffmpeg")
+    renderer = choose_renderer()
+
+    try:
+        root = ET.parse(input_svg).getroot()
+    except ET.ParseError as exc:
+        fail(f"invalid SVG XML: {exc}")
+
+    if args.keep_frames:
+        workspace = args.keep_frames.expanduser().resolve()
+        if workspace.exists() and any(workspace.iterdir()):
+            fail(f"keep-frames directory must be empty: {workspace}")
+        workspace.mkdir(parents=True, exist_ok=True)
+        temporary = None
+    else:
+        temporary = tempfile.TemporaryDirectory(prefix="readme-motion-")
+        workspace = Path(temporary.name)
+
+    try:
+        frames_dir, frame_count, width, height, has_transparency = build_frames(
+            root, spec, renderer, workspace
+        )
+        output_gif.parent.mkdir(parents=True, exist_ok=True)
+        encode_gif(
+            frames_dir,
+            output_gif,
+            spec,
+            ffmpeg,
+            frame_count,
+            has_transparency,
+        )
+    finally:
+        if temporary:
+            temporary.cleanup()
+
+    size_mb = output_gif.stat().st_size / (1024 * 1024)
+    print(f"GIF: {output_gif}")
+    print(
+        f"Output: {width}x{height}, {frame_count} frames, "
+        f"{spec['fps']} FPS, {float(spec['duration']):.2f}s, {size_mb:.2f} MB"
+    )
+    if size_mb > float(spec["max_size_mb"]):
+        print(
+            f"WARNING: exceeds preferred {spec['max_size_mb']} MB budget",
+            file=sys.stderr,
+        )
+
+
+if __name__ == "__main__":
+    run(parse_args())


### PR DESCRIPTION
## What

Adds `beautify-github-readme` to firstmate's tracked `.agents/skills/` so it's available to firstmate and any crewmate.

## Source

Upstream: https://github.com/oil-oil/beautify-github-readme (shallow-cloned at install time, HEAD verified). The skill is a README beautification agent skill with two modes (whole-README and asset-only) and explicit no-publish-without-approval semantics.

## Files

- `SKILL.md` — instruction surface (frontmatter `name: beautify-github-readme`)
- `references/` — visual-direction, svg-production, motion-production, content-architecture, etc.
- `scripts/audit_readme.py` — read-only README audit
- `scripts/render_motion_gif.py` — optional animated GIF for approved motion
- `agents/` — sub-agent definitions, if any

## Verification

- SKILL.md frontmatter parses (`name`, `description` present)
- `scripts/*.py` are Python; no external network calls; no writes outside the working directory
- `make test` passes (sanity check on firstmate infrastructure)
- `.claude/skills` symlink resolves correctly (the skill is visible to claude-code via the symlink to `.agents/skills/`)

## Captain's verification path

Once merged, `bin/fm-session-start.sh` will list the new skill in the available-skills block. The captain can confirm by:
- `ls /home/sanjay/firstmate/.agents/skills/beautify-github-readme/SKILL.md`
- `ls /home/sanjay/firstmate/.claude/skills/beautify-github-readme/SKILL.md` (resolves via the symlink)
- A future task that needs README beautification can reference this skill directly.