### PR TITLE
feat(skills): add issue-workflow skill and fm-brief --plan

### DIFF
--- a/.agents/skills/issue-workflow/SKILL.md
+++ b/.agents/skills/issue-workflow/SKILL.md
@@ -76,7 +76,7 @@ The crewmate follows the project's selected delivery path to a single PR; there 
 
 Deviation threshold, carried verbatim into every plan artifact:
 
-- **Minor mechanical deviations** (wording, ordering, naming): adapt, and list EVERY one in the PR body under "Deviations from approved plan".
+- **Minor mechanical deviations** (wording, ordering, naming): adapt, and disclose EVERY one where the delivery path surfaces it - the PR body under "Deviations from approved plan" for a PR-producing mode, or the final ready-branch done summary for local-only.
 - **Material deviations** (a different approach, files added or dropped, changed success criteria): STOP, append `needs-decision: plan deviation - {summary}` to the status file, and wait for re-approval.
 
 PR hygiene:

--- a/.agents/skills/issue-workflow/SKILL.md
+++ b/.agents/skills/issue-workflow/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: issue-workflow
+description: >-
+  Agent-only procedure for the standing issue workflow: pick, grill, scope in a review surface, get approval, then dispatch one crewmate per issue.
+  Use when the captain asks to work on an issue in a named repo, asks for the best issue to work on in a named repo, or names a specific issue to take on in a repo.
+user-invocable: false
+metadata:
+  internal: true
+---
+
+# issue-workflow
+
+The captain's standing way of turning an open issue into shipped work: pick with a quick confirm, grill out the ambiguity, scope one ticket per review artifact, get explicit approval, then dispatch a single crewmate per issue and hand off to normal supervision.
+This skill owns the ordering and the per-step contract only.
+It points at existing machinery for every mechanic - `bin/fm-brief.sh` for briefs, `bin/fm-spawn.sh` for launch, the backlog verbs for tracking, and AGENTS.md section 8 for supervision - and never restates lifecycle mechanics.
+
+## (a) Trigger and repo resolution
+
+The trigger is the captain asking to work on an issue, and it always names the repo ("what's the best issue to work on in e-foil?", "let's do #47 in e-foil").
+Resolve the project from that name exactly as AGENTS.md section 7 intake requires; route in-scope work to the fitting secondmate rather than the main home.
+
+List the repo's open issues with `gh-axi issue list` and rank them:
+
+1. Unblocked before blocked (nothing depends on unlanded or unstarted work).
+2. Dependency-critical next (other issues wait on it).
+3. Then best value for effort.
+
+If the captain named the exact issue, skip the pick and confirm and go straight to the grill.
+Otherwise reply in chat with your pick, one or two runner-ups, and one line of why for each, in outcome language - the issue and what shipping it gets the captain, never internal mechanics.
+Wait for the captain to confirm or redirect before scoping anything.
+
+## (b) Grill protocol
+
+Grill only to resolve ambiguity that would change the plan; skip it entirely when the ticket is already unambiguous.
+This protocol is self-contained - do not depend on any external grill skill.
+
+- Ask one question at a time, using the harness's question tool, each with two to four concrete options.
+- Explore before you ask: anything the codebase, the issue thread, or the project docs can answer, you answer yourself instead of spending a question on it.
+- Every question must be one whose answer changes the scope, the approach, or the success criteria; skip preference-neutral detail.
+- Stop as soon as every plan-changing ambiguity is resolved, not after a fixed number of questions.
+
+## (c) Scope contract
+
+Scope the approved issue in a review surface with `lavish-axi` (load the `lavish` skill for its mechanics).
+One ticket per artifact, at full depth - never fold multiple issues into one plan.
+
+Each plan artifact must contain, at minimum:
+
+- **Why this issue** - the outcome shipping it delivers.
+- **Files table** - each file marked CREATE or MODIFY with its role.
+- **What's in each file** - the concrete change per file.
+- **Key code** - the load-bearing snippets the implementer will write.
+- **Success criteria** - mapped one-to-one to the ticket's acceptance criteria.
+- **Risks and gotchas** - what could go wrong and the mitigation.
+- **Deviation threshold** - the exact statement from section (e) so the implementer inherits it.
+- **Approval control** - the surface the captain uses to approve.
+
+Run planning on the dispatch profile that matches planning and scout work, per AGENTS.md section 4 and the dispatch profiles.
+
+## (d) Approval and dispatch
+
+No implementation crewmate runs before the captain approves the plan in the review surface.
+Once approved:
+
+1. Write the approved plan to `data/<id>/plan.md` under the active home.
+2. Scaffold the brief with `bin/fm-brief.sh <id> <repo> --plan data/<id>/plan.md`, then replace `{TASK}` with the task description, acceptance criteria, and context per AGENTS.md section 11.
+   The `--plan` block already carries the binding-plan declaration and the deviation threshold, so do not restate them in the task text.
+   If the task touches firstmate's own shared tracked material, add the `firstmate-coding-guidelines` load instruction by hand as section 11 requires.
+3. Spawn exactly one crewmate for the issue through `bin/fm-spawn.sh` on the execution dispatch profile, after the profile and backend checks in AGENTS.md section 4.
+4. Record the work item on the backlog and hand off to normal supervision under AGENTS.md section 8.
+
+## (e) Ship rules
+
+The crewmate follows the project's selected delivery path to a single PR; there is one PR per issue, opened only after the issue is done.
+
+Deviation threshold, carried verbatim into every plan artifact:
+
+- **Minor mechanical deviations** (wording, ordering, naming): adapt, and list EVERY one in the PR body under "Deviations from approved plan".
+- **Material deviations** (a different approach, files added or dropped, changed success criteria): STOP, append `needs-decision: plan deviation - {summary}` to the status file, and wait for re-approval.
+
+PR hygiene:
+
+- Body structure: What, Why, Changes, Verification.
+- `Closes #N` for the issue so it auto-closes on merge.
+- At least one label from the repo's existing taxonomy (`gh-axi label list`); do not invent labels.
+- No AI attribution anywhere in the PR body or commits, and no co-author trailer.
+- No references to the internal validation pipeline or its step names in the PR or commits.
+
+The captain merges; the `yolo` carve-outs in AGENTS.md section 7 are unchanged, and destructive, irreversible, or security-sensitive choices still escalate.
+Teardown and backlog update follow the normal lifecycle in AGENTS.md section 7.

--- a/.agents/skills/issue-workflow/SKILL.md
+++ b/.agents/skills/issue-workflow/SKILL.md
@@ -64,6 +64,7 @@ Once approved:
 
 1. Write the approved plan to `data/<id>/plan.md` under the active home.
 2. Scaffold the brief with `bin/fm-brief.sh <id> <repo> --plan data/<id>/plan.md`, then replace `{TASK}` with the task description, acceptance criteria, and context per AGENTS.md section 11.
+   fm-brief resolves a relative `--plan` path against the current working directory, so the `data/<id>/plan.md` form above is correct only when invoked from the active firstmate home; from any other directory, pass the plan's absolute path.
    The `--plan` block already carries the binding-plan declaration and the deviation threshold, so do not restate them in the task text.
    If the task touches firstmate's own shared tracked material, add the `firstmate-coding-guidelines` load instruction by hand as section 11 requires.
 3. Spawn exactly one crewmate for the issue through `bin/fm-spawn.sh` on the execution dispatch profile, after the profile and backend checks in AGENTS.md section 4.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,6 +225,7 @@ Classify the deliverable:
 A diagnostic request, report, recommendation, or implementation-ready finding is evidence, not authorization to change code.
 Implementation requires a separate request or other clear implementation scope.
 Load `diagnostic-reasoning` before scoping a reported bug and before acting on a diagnostic report.
+When the captain asks to work on an issue in a named repo, or for the best issue to work on there, load `issue-workflow`; the skill owns picking, grilling, scoping for approval, and single-crewmate dispatch.
 
 Classify work as dispatchable when it does not overlap in-flight work, or queued and blocked when it touches the same project subsystem or depends on unlanded work.
 Dispatch independent work immediately with no concurrency cap, serialize coarse overlaps, and record blockers durably.
@@ -446,6 +447,7 @@ These skills are not captain-invocable; load them only at their precise triggers
 
 - `bootstrap-diagnostics` - load whenever the session-start digest's bootstrap section prints any diagnostic or capability line (`MISSING:`, `MISSING_MANUAL:`, `BACKEND_INVALID:`, `NEEDS_GH_AUTH`, `TANGLE:`, `CREW_HARNESS_OVERRIDE:`, `CREW_DISPATCH:`, `FLEET_SYNC:`, `PR_CHECK_MIGRATION:`, `SECONDMATE_SYNC:`, `SECONDMATE_LIVENESS:`, `TASKS_AXI:`, `NUDGE_SECONDMATES:`, or `FMX:`); silence needs no load.
 - `diagnostic-reasoning` - load before scoping a reported bug and before acting on a diagnostic report.
+- `issue-workflow` - load when the captain asks to work on an issue in a named repo, asks for the best issue to work on there, or names a specific issue to take on; owns pick, grill, scope-for-approval, and single-crewmate dispatch.
 - `harness-adapters` - load before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter.
 - `firstmate-orca` - load before switching to Orca, spawning or supervising Orca-backed work, smoke-testing Orca backend behavior, debugging Orca task state, or reconciling Orca-backed task metadata.
 - `project-management` - load before adding, creating, removing, or initializing a project.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -6,10 +6,15 @@
 # description, acceptance criteria, and context, and may adjust other sections
 # when the task genuinely deviates (e.g. working an existing external PR instead
 # of shipping a new one).
-# Usage: fm-brief.sh <task-id> <repo-name> [--scout] [--herdr-lab]
+# Usage: fm-brief.sh <task-id> <repo-name> [--scout] [--herdr-lab] [--plan <path>]
 #        fm-brief.sh <task-id> --secondmate {<project>...|--no-projects}
 #   --scout writes the scout contract instead: the deliverable is a report at
 #   data/<task-id>/report.md (no branch, no push, no PR) and the worktree is scratch.
+#   --plan <path> marks a SHIP brief as executing a binding approved plan: it adds an
+#   "# Approved plan" block after the Task section naming the plan path and stating the
+#   deviation threshold (minor = adapt and list every deviation in the PR body; material =
+#   stop and append a needs-decision line). The path must exist. Ship briefs only.
+#   Without --plan the scaffold output is byte-identical to before.
 #   --secondmate writes a persistent secondmate charter. The project list
 #   is cloned into the secondmate home, while the natural-language scope
 #   tells the main firstmate when to route work there; routine churn stays in its own home;
@@ -73,17 +78,32 @@ STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 KIND=ship
 HERDR_LAB=0
 NO_PROJECTS=0
+PLAN_PATH=""
 POS=()
-for a in "$@"; do
-  case "$a" in
+while [ "$#" -gt 0 ]; do
+  case "$1" in
     --scout) KIND=scout ;;
     --secondmate) KIND=secondmate ;;
     --herdr-lab) HERDR_LAB=1 ;;
     --no-projects) NO_PROJECTS=1 ;;
-    *) POS+=("$a") ;;
+    --plan)
+      shift
+      [ "$#" -gt 0 ] || { echo "error: --plan requires a path argument" >&2; exit 1; }
+      PLAN_PATH="$1"
+      ;;
+    *) POS+=("$1") ;;
   esac
+  shift
 done
 ID=${POS[0]}
+
+if [ -n "$PLAN_PATH" ]; then
+  if [ "$KIND" != ship ]; then
+    echo "error: --plan applies only to ship briefs" >&2
+    exit 1
+  fi
+  [ -f "$PLAN_PATH" ] || { echo "error: --plan file not found: $PLAN_PATH" >&2; exit 1; }
+fi
 
 if [ "$KIND" = secondmate ] && [ "$HERDR_LAB" -eq 1 ]; then
   echo "error: --herdr-lab applies only to crewmate ship or scout briefs" >&2
@@ -326,11 +346,30 @@ EOF
     ;;
 esac
 
+# When executing a captain-approved plan, inject a binding-plan block after the Task
+# section. PLAN_SECTION stays empty otherwise so the scaffold is byte-identical to before.
+# Its leading blank lines are baked in here (command substitution strips trailing ones),
+# so `{TASK}${PLAN_SECTION}` renders with the correct spacing in both cases.
+if [ -n "$PLAN_PATH" ]; then
+PLAN_SECTION=$(cat <<EOF
+
+
+# Approved plan
+The approved implementation plan for this task is at \`$PLAN_PATH\`.
+Read it first, before writing any code. It is binding.
+- Minor mechanical deviations (wording, ordering, naming): adapt, and list EVERY one in the PR body under "Deviations from approved plan".
+- Material deviations (a different approach, files added or dropped, changed success criteria): STOP - append \`needs-decision: plan deviation - {summary}\` to the status file and wait.
+EOF
+)
+else
+PLAN_SECTION=""
+fi
+
 cat > "$BRIEF" <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
 
 # Task
-{TASK}
+{TASK}${PLAN_SECTION}
 
 $HERDR_SECTION
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -12,10 +12,10 @@
 #   data/<task-id>/report.md (no branch, no push, no PR) and the worktree is scratch.
 #   --plan <path> marks a SHIP brief as executing a binding approved plan: it adds an
 #   "# Approved plan" block after the Task section naming the plan path and stating the
-#   deviation threshold (minor = adapt and list every deviation in the PR body; material =
-#   stop and append a needs-decision line). The path must exist. Ship briefs only, and
-#   only for the PR-producing delivery modes (no-mistakes or direct-PR): local-only
-#   briefs produce no PR body to disclose deviations in, so --plan is rejected there.
+#   deviation threshold (minor = adapt and disclose every deviation; material = stop and
+#   append a needs-decision line). The disclosure destination is mode-aware: the PR body
+#   for PR-producing modes (no-mistakes, direct-PR), or the final ready-branch done
+#   summary for local-only, which opens no PR. The path must exist. Ship briefs only.
 #   Without --plan the scaffold output is byte-identical to before.
 #   --secondmate writes a persistent secondmate charter. The project list
 #   is cloned into the secondmate home, while the natural-language scope
@@ -299,9 +299,13 @@ read -r MODE _ <<EOF
 $("$FM_ROOT/bin/fm-project-mode.sh" "$REPO")
 EOF
 
-if [ -n "$PLAN_PATH" ] && [ "$MODE" = local-only ]; then
-  echo "error: --plan applies only to PR-producing ship briefs (no-mistakes or direct-PR), not local-only" >&2
-  exit 1
+# The binding-plan block asks the crewmate to disclose minor deviations somewhere
+# the delivery path actually surfaces. PR-producing modes have a PR body; local-only
+# has no PR, so its deviations belong in the final ready-branch done summary instead.
+if [ "$MODE" = local-only ]; then
+  DEVIATION_DISCLOSURE='note EVERY one in your final ready-branch done summary under "Deviations from approved plan"'
+else
+  DEVIATION_DISCLOSURE='list EVERY one in the PR body under "Deviations from approved plan"'
 fi
 
 case "$MODE" in
@@ -366,7 +370,7 @@ PLAN_SECTION=$(cat <<EOF
 # Approved plan
 The approved implementation plan for this task is at \`$PLAN_PATH\`.
 Read it first, before writing any code. It is binding.
-- Minor mechanical deviations (wording, ordering, naming): adapt, and list EVERY one in the PR body under "Deviations from approved plan".
+- Minor mechanical deviations (wording, ordering, naming): adapt, and $DEVIATION_DISCLOSURE.
 - Material deviations (a different approach, files added or dropped, changed success criteria): STOP - append \`needs-decision: plan deviation - {summary}\` to the status file and wait.
 EOF
 )

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -13,7 +13,9 @@
 #   --plan <path> marks a SHIP brief as executing a binding approved plan: it adds an
 #   "# Approved plan" block after the Task section naming the plan path and stating the
 #   deviation threshold (minor = adapt and list every deviation in the PR body; material =
-#   stop and append a needs-decision line). The path must exist. Ship briefs only.
+#   stop and append a needs-decision line). The path must exist. Ship briefs only, and
+#   only for the PR-producing delivery modes (no-mistakes or direct-PR): local-only
+#   briefs produce no PR body to disclose deviations in, so --plan is rejected there.
 #   Without --plan the scaffold output is byte-identical to before.
 #   --secondmate writes a persistent secondmate charter. The project list
 #   is cloned into the secondmate home, while the natural-language scope
@@ -296,6 +298,11 @@ fi
 read -r MODE _ <<EOF
 $("$FM_ROOT/bin/fm-project-mode.sh" "$REPO")
 EOF
+
+if [ -n "$PLAN_PATH" ] && [ "$MODE" = local-only ]; then
+  echo "error: --plan applies only to PR-producing ship briefs (no-mistakes or direct-PR), not local-only" >&2
+  exit 1
+fi
 
 case "$MODE" in
   direct-PR)

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -103,6 +103,7 @@ if [ -n "$PLAN_PATH" ]; then
     exit 1
   fi
   [ -f "$PLAN_PATH" ] || { echo "error: --plan file not found: $PLAN_PATH" >&2; exit 1; }
+  PLAN_PATH="$(cd "$(dirname "$PLAN_PATH")" && pwd)/$(basename "$PLAN_PATH")"
 fi
 
 if [ "$KIND" = secondmate ] && [ "$HERDR_LAB" -eq 1 ]; then

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -89,6 +89,7 @@ while [ "$#" -gt 0 ]; do
     --plan)
       shift
       [ "$#" -gt 0 ] || { echo "error: --plan requires a path argument" >&2; exit 1; }
+      [ -n "$1" ] || { echo "error: --plan requires a non-empty path" >&2; exit 1; }
       PLAN_PATH="$1"
       ;;
     *) POS+=("$1") ;;

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -314,6 +314,14 @@ test_plan_flag_injects_binding_block() {
   block=$(awk '/^# Task$/{f=1} f{print} /^# Herdr/{exit}' "$brief")
   assert_contains "$block" "{TASK}"$'\n'$'\n'"# Approved plan" \
     "--plan block was not placed immediately after the Task section"
+  # A relative plan path is embedded absolute: the crewmate runs in an isolated
+  # task worktree, so a home-relative path would be unresolvable from its cwd.
+  id="brief-plan-e6"
+  (cd "$home" && FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --plan data/plan.md >/dev/null 2>&1)
+  brief="$home/data/$id/brief.md"
+  assert_present "$brief" "relative-path plan brief was not scaffolded"
+  assert_grep "The approved implementation plan for this task is at \`$plan\`." "$brief" \
+    "--plan did not absolutize a relative plan path"
   pass "fm-brief.sh: --plan injects the binding-plan block naming the path"
 }
 

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -354,6 +354,27 @@ test_plan_flag_missing_file_fails_clearly() {
   pass "fm-brief.sh: --plan validates its path and ship-only scope"
 }
 
+# local-only ship briefs forbid pushing and opening a PR, so the plan block's
+# "list every deviation in the PR body" disclosure rule has no destination there.
+test_plan_flag_rejects_local_only_mode() {
+  local home out status
+  home="$TMP_ROOT/plan-localonly-home"
+  write_registry "$home"
+  printf '# plan\nbody\n' > "$home/data/plan.md"
+  out=$(FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-plan-e7 local-proj --plan "$home/data/plan.md" 2>&1); status=$?
+  expect_code 1 "$status" "--plan on a local-only brief must fail"
+  assert_contains "$out" "--plan applies only to PR-producing ship briefs (no-mistakes or direct-PR), not local-only" \
+    "--plan local-only rejection error was not clear"
+  assert_absent "$home/data/brief-plan-e7/brief.md" "local-only --plan run still wrote a brief"
+
+  # The PR-producing modes still accept --plan.
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-plan-e8 direct-proj --plan "$home/data/plan.md" >/dev/null 2>&1; status=$?
+  expect_code 0 "$status" "--plan on a direct-PR brief should exit 0"
+  assert_grep "# Approved plan" "$home/data/brief-plan-e8/brief.md" \
+    "direct-PR --plan brief lost the approved-plan block"
+  pass "fm-brief.sh: --plan is rejected for local-only delivery mode"
+}
+
 test_plan_flag_absent_is_byte_identical() {
   local home id brief block expected
   home="$TMP_ROOT/plan-absent-home"
@@ -405,5 +426,6 @@ test_secondmate_no_projects_charter
 test_pause_verb_override_renders_all_brief_scaffolds
 test_plan_flag_injects_binding_block
 test_plan_flag_missing_file_fails_clearly
+test_plan_flag_rejects_local_only_mode
 test_plan_flag_absent_is_byte_identical
 test_scout_and_secondmate_load_decision_hold_policy

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -339,6 +339,13 @@ test_plan_flag_missing_file_fails_clearly() {
   expect_code 1 "$status" "--plan with no path argument must fail"
   assert_contains "$out" "--plan requires a path argument" "--plan no-argument error was not clear"
 
+  # An empty --plan value (e.g. an unset shell variable) fails closed rather than
+  # silently skipping the binding-plan block.
+  out=$(FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-plan-e3b some-proj --plan "" 2>&1); status=$?
+  expect_code 1 "$status" "--plan with an empty path must fail"
+  assert_contains "$out" "--plan requires a non-empty path" "--plan empty-path error was not clear"
+  assert_absent "$home/data/brief-plan-e3b/brief.md" "empty --plan run still wrote a brief"
+
   # --plan applies only to ship briefs, never scout or secondmate.
   printf 'x\n' > "$home/data/plan.md"
   out=$(FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-plan-e4 some-proj --scout --plan "$home/data/plan.md" 2>&1); status=$?

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -354,25 +354,32 @@ test_plan_flag_missing_file_fails_clearly() {
   pass "fm-brief.sh: --plan validates its path and ship-only scope"
 }
 
-# local-only ship briefs forbid pushing and opening a PR, so the plan block's
-# "list every deviation in the PR body" disclosure rule has no destination there.
-test_plan_flag_rejects_local_only_mode() {
-  local home out status
-  home="$TMP_ROOT/plan-localonly-home"
+# --plan works in every ship mode; the deviation-disclosure destination is
+# mode-aware because local-only opens no PR body to disclose deviations in.
+test_plan_flag_disclosure_is_mode_aware() {
+  local home brief status
+  home="$TMP_ROOT/plan-modeaware-home"
   write_registry "$home"
   printf '# plan\nbody\n' > "$home/data/plan.md"
-  out=$(FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-plan-e7 local-proj --plan "$home/data/plan.md" 2>&1); status=$?
-  expect_code 1 "$status" "--plan on a local-only brief must fail"
-  assert_contains "$out" "--plan applies only to PR-producing ship briefs (no-mistakes or direct-PR), not local-only" \
-    "--plan local-only rejection error was not clear"
-  assert_absent "$home/data/brief-plan-e7/brief.md" "local-only --plan run still wrote a brief"
 
-  # The PR-producing modes still accept --plan.
-  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-plan-e8 direct-proj --plan "$home/data/plan.md" >/dev/null 2>&1; status=$?
+  # PR-producing modes disclose in the PR body.
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-plan-e7 direct-proj --plan "$home/data/plan.md" >/dev/null 2>&1; status=$?
   expect_code 0 "$status" "--plan on a direct-PR brief should exit 0"
-  assert_grep "# Approved plan" "$home/data/brief-plan-e8/brief.md" \
-    "direct-PR --plan brief lost the approved-plan block"
-  pass "fm-brief.sh: --plan is rejected for local-only delivery mode"
+  brief="$home/data/brief-plan-e7/brief.md"
+  assert_grep "# Approved plan" "$brief" "direct-PR --plan brief lost the approved-plan block"
+  assert_grep 'list EVERY one in the PR body under "Deviations from approved plan"' "$brief" \
+    "direct-PR --plan brief lost the PR-body disclosure destination"
+
+  # local-only accepts --plan and routes disclosure to the done summary, not a PR.
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-plan-e8 local-proj --plan "$home/data/plan.md" >/dev/null 2>&1; status=$?
+  expect_code 0 "$status" "--plan on a local-only brief should exit 0"
+  brief="$home/data/brief-plan-e8/brief.md"
+  assert_grep "# Approved plan" "$brief" "local-only --plan brief lost the approved-plan block"
+  assert_grep 'note EVERY one in your final ready-branch done summary under "Deviations from approved plan"' "$brief" \
+    "local-only --plan brief did not route disclosure to the done summary"
+  assert_no_grep "list EVERY one in the PR body" "$brief" \
+    "local-only --plan brief still referenced a PR body that does not exist for local-only"
+  pass "fm-brief.sh: --plan disclosure destination is mode-aware"
 }
 
 test_plan_flag_absent_is_byte_identical() {
@@ -426,6 +433,6 @@ test_secondmate_no_projects_charter
 test_pause_verb_override_renders_all_brief_scaffolds
 test_plan_flag_injects_binding_block
 test_plan_flag_missing_file_fails_clearly
-test_plan_flag_rejects_local_only_mode
+test_plan_flag_disclosure_is_mode_aware
 test_plan_flag_absent_is_byte_identical
 test_scout_and_secondmate_load_decision_hold_policy

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -289,6 +289,74 @@ test_pause_verb_override_renders_all_brief_scaffolds() {
   pass "fm-brief.sh: custom pause verb renders in every scaffold"
 }
 
+test_plan_flag_injects_binding_block() {
+  local home id brief plan
+  home="$TMP_ROOT/plan-flag-home"
+  mkdir -p "$home/data"
+  plan="$home/data/plan.md"
+  printf '# plan\nbody\n' > "$plan"
+  id="brief-plan-e1"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --plan "$plan" >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_present "$brief" "plan brief was not scaffolded"
+  assert_grep "# Approved plan" "$brief" \
+    "--plan did not inject the approved-plan block"
+  assert_grep "The approved implementation plan for this task is at \`$plan\`." "$brief" \
+    "--plan block did not name the plan path"
+  assert_grep "Read it first, before writing any code. It is binding." "$brief" \
+    "--plan block did not declare the plan binding"
+  assert_grep 'list EVERY one in the PR body under "Deviations from approved plan"' "$brief" \
+    "--plan block lost the minor-deviation disclosure rule"
+  assert_grep 'append `needs-decision: plan deviation - {summary}`' "$brief" \
+    "--plan block lost the material-deviation stop rule"
+  # The block sits between the Task section and the Herdr declaration.
+  local block
+  block=$(awk '/^# Task$/{f=1} f{print} /^# Herdr/{exit}' "$brief")
+  assert_contains "$block" "{TASK}"$'\n'$'\n'"# Approved plan" \
+    "--plan block was not placed immediately after the Task section"
+  pass "fm-brief.sh: --plan injects the binding-plan block naming the path"
+}
+
+test_plan_flag_missing_file_fails_clearly() {
+  local home out status
+  home="$TMP_ROOT/plan-missing-home"
+  mkdir -p "$home/data"
+  out=$(FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-plan-e2 some-proj --plan "$home/data/nope.md" 2>&1); status=$?
+  expect_code 1 "$status" "--plan with a missing file must fail"
+  assert_contains "$out" "--plan file not found" "--plan missing-file error was not clear"
+  assert_absent "$home/data/brief-plan-e2/brief.md" "failed --plan run still wrote a brief"
+
+  # A bare --plan with no path argument also fails loudly.
+  out=$(FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-plan-e3 some-proj --plan 2>&1); status=$?
+  expect_code 1 "$status" "--plan with no path argument must fail"
+  assert_contains "$out" "--plan requires a path argument" "--plan no-argument error was not clear"
+
+  # --plan applies only to ship briefs, never scout or secondmate.
+  printf 'x\n' > "$home/data/plan.md"
+  out=$(FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-plan-e4 some-proj --scout --plan "$home/data/plan.md" 2>&1); status=$?
+  expect_code 1 "$status" "--plan on a scout brief must fail"
+  assert_contains "$out" "--plan applies only to ship briefs" "--plan scout-rejection error was not clear"
+  pass "fm-brief.sh: --plan validates its path and ship-only scope"
+}
+
+test_plan_flag_absent_is_byte_identical() {
+  local home id brief block expected
+  home="$TMP_ROOT/plan-absent-home"
+  mkdir -p "$home/data"
+  id="brief-plan-e5"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_present "$brief" "no-flag brief was not scaffolded"
+  assert_no_grep "# Approved plan" "$brief" \
+    "no-flag brief leaked the approved-plan block"
+  # Without --plan the Task section is followed by exactly one blank line and then
+  # the Herdr declaration - no stray blank line from the injection point.
+  block=$(awk '/^# Task$/{f=1} f{print} /^# Herdr/{exit}' "$brief")
+  expected=$(printf '# Task\n{TASK}\n\n# Herdr lifecycle declaration - NOT ENABLED')
+  [ "$block" = "$expected" ] || fail "no-flag Task section is not byte-identical to legacy output"
+  pass "fm-brief.sh: without --plan the scaffold output is unchanged"
+}
+
 test_scout_and_secondmate_load_decision_hold_policy() {
   local home scout charter
   home="$TMP_ROOT/decision-policy-home"
@@ -320,4 +388,7 @@ test_herdr_lab_omission_is_loud_for_ship_and_scout
 test_herdr_lab_contract_applies_to_scouts_but_not_secondmates
 test_secondmate_no_projects_charter
 test_pause_verb_override_renders_all_brief_scaffolds
+test_plan_flag_injects_binding_block
+test_plan_flag_missing_file_fails_clearly
+test_plan_flag_absent_is_byte_identical
 test_scout_and_secondmate_load_decision_hold_policy


### PR DESCRIPTION
## What

Adds the `issue-workflow` skill and a `--plan` flag to `bin/fm-brief.sh`, codifying the standing "work an issue" workflow into the shared template.

## Why

The workflow of pick → grill → scope-for-approval → dispatch one crewmate per issue was operator knowledge that lived only in habit. This makes it a first-class, self-contained skill any firstmate can load, and gives `fm-brief.sh` a way to bind a dispatched crewmate to a captain-approved plan.

## Changes

- **`.agents/skills/issue-workflow/SKILL.md`** (new): agent-only skill (`metadata.internal: true`, `user-invocable: false`) owning the workflow's ordering and per-step contract — trigger & repo resolution + issue ranking, an embedded self-contained grill protocol, the lavish scope contract (one ticket per artifact, mandatory sections), approval → dispatch (write `data/<id>/plan.md`, scaffold with `fm-brief --plan`, spawn one crewmate on the execution profile), and ship rules (deviation threshold, PR hygiene, captain merges). It points at existing machinery (`fm-brief`, `fm-spawn`, backlog verbs, section 8 supervision) rather than restating lifecycle mechanics, per the repo's one-owner rule, and stays generic (no model- or captain-specific config).
- **`AGENTS.md`**: two pointer lines only — a section 7 intake trigger and a section 13 agent-only skill row. No other sections changed. (`CLAUDE.md` is a symlink to `AGENTS.md`, so it is not edited separately.)
- **`bin/fm-brief.sh`**: new `--plan <path>` flag. When set on a ship brief, it injects an `# Approved plan` block after the Task section declaring the plan binding and stating the deviation threshold. The disclosure destination is mode-aware: the PR body for PR-producing modes (no-mistakes, direct-PR), or the final ready-branch done summary for local-only (which opens no PR). The path is validated (non-empty, exists, ship-only) and absolutized so a crewmate reading it from an isolated worktree resolves it. Without the flag, scaffold output is byte-identical to before.
- **`tests/fm-brief.test.sh`**: coverage for block injection, path/scope/empty validation, mode-aware disclosure, and byte-identical no-flag output.

## Verification

- `tests/fm-brief.test.sh`: 17/17 pass.
- Related suites green locally: `fm-instruction-owners`, `fm-captain-translation-contract`, `fm-update`.
- No-flag scaffold output confirmed byte-identical by diffing against the pre-change script.
- Validated through the local gate (review, document steps clean). The full e2e suite and shellcheck lint are left to CI here, since this environment lacks `jq`, `herdr`, and ShellCheck; the failures observed locally were confined to those tool-absent tests and never to changed code.

## Deviations from approved plan

All minor (the plan reserves wording, ordering, and test naming as adaptable):

1. **Extra fail-closed guards on `--plan`.** The plan specified only ship-mode behavior. The undefined cases are rejected loudly, matching the script's existing `--herdr-lab`/`--no-projects` guards: `--plan` on scout/secondmate briefs, a bare `--plan` with no path, and an empty-string path.
2. **Mode-aware deviation-disclosure destination.** Rather than always "the PR body," the injected block routes disclosures to the PR body for PR-producing modes or the ready-branch done summary for local-only, which has no PR. (A review pass surfaced that a local-only brief has no PR body; resolved by this mode-aware wording.)
3. **`--plan` path absolutization.** The caller-supplied path is absolutized after the existence check so a crewmate in an isolated worktree resolves it, matching how the brief already embeds the status-file and report paths.
4. **Three new test functions** were added rather than folded into the existing scaffold test.
5. **Arg parsing** was converted from a `for` loop to a `while` loop so `--plan` can consume its value argument.

No AI attribution is included in any commit or this description.
