### PR TITLE
fix(send): wait for agent idle before text steers

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -105,6 +105,26 @@ This preserves launch success instead of passing a known-bad value.
 Send the validation skill using the target harness's skill invocation form.
 Natural language is acceptable if uncertain.
 
+### Pi / long-shell steer trap (verified operationally 2026-07-17)
+
+Pi only processes queued steers after a running shell exits. Crews that run
+`no-mistakes axi respond ... 2>&1 | tail -20` with a multi-hour tool timeout
+freeze the agent for tens of minutes: firstmate `fm-send` used to report
+success while text sat as `Steering: …`, and even after busy-wait landed in
+`fm-send`, the crew still cannot act until the shell ends.
+
+Rules for crews (also generated into ship briefs by `bin/fm-brief.sh`):
+- Do not pipe `axi run` / `axi respond` through `tail`/`head`.
+- Do not use multi-hour blocking timeouts as the only progress channel.
+- After each respond, poll `no-mistakes axi status`; if the step already
+  completed, continue from current status rather than re-running respond.
+- Firstmate text steers wait for agent idle via `fm_send_wait_until_idle`
+  (`bin/fm-send-wait-lib.sh`); `--key` Escape/C-c still interrupts immediately.
+
+Claude Code and Grok Code stream tool output differently and are less prone to
+this exact freeze; the brief rules still apply so crews stay responsive on every
+harness.
+
 - claude: `/<skill>`, for example `/no-mistakes`.
 - codex: `$<skill>`, for example `$no-mistakes`; `/<skill>` is claude-only and codex rejects it as "Unrecognized command".
 - opencode: no separate verified skill invocation beyond normal slash-command behavior; use natural language if the exact skill command is uncertain.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -320,6 +320,12 @@ Two firstmate-specific rules layer on top of that guidance:
   When the decision comes back, feed it to the gate with \`no-mistakes axi respond\` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
 - Avoid \`--yes\`: the captain, not you, owns the ask-user decisions it would silently auto-resolve.
 
+Hard rules for running axi (especially on Pi / Herdr — this is a known productivity killer):
+- NEVER pipe \`no-mistakes axi run\` or \`no-mistakes axi respond\` through \`tail\`, \`head\`, or similar. You must see the full TOON return.
+- NEVER wrap axi in a multi-hour shell timeout (e.g. 2400s) as a single blocking tool call that freezes your turn. If a step is long, call axi, read the return, then poll \`no-mistakes axi status\` until the next gate or outcome.
+- After every axi respond, immediately run \`no-mistakes axi status\`. If the pipeline has already moved past that step (or the run completed), do NOT re-run the same respond — continue from current status.
+- While axi is in flight, do not start unrelated long shells. Standing instructions belong in the brief before /no-mistakes starts; firstmate steers wait for idle (fm-send busy-wait) and cannot cut into a blocked shell.
+
 After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished.
 EOF
 )

--- a/bin/fm-send-wait-lib.sh
+++ b/bin/fm-send-wait-lib.sh
@@ -27,8 +27,12 @@ fm_send_wait_until_idle() {  # <backend> <target>
       busy)
         if [ "$waited" -eq 0 ]; then
           echo "fm-send: $target is busy; waiting up to ${wait_s}s for idle before delivering text (set FM_SEND_BUSY_WAIT_SECS=0 to skip)" >&2
-        elif [ $((waited % 30)) -eq 0 ]; then
-          echo "fm-send: still waiting on busy $target (${waited}s/${wait_s}s)" >&2
+        else
+          # Emit progress every ~30s of wall time, independent of poll interval
+          # (poll_s may not divide 30; e.g. poll_s=7 never hits waited%30==0).
+          if [ $((waited % 30)) -lt "$poll_s" ]; then
+            echo "fm-send: still waiting on busy $target (${waited}s/${wait_s}s)" >&2
+          fi
         fi
         sleep "$poll_s"
         waited=$((waited + poll_s))

--- a/bin/fm-send-wait-lib.sh
+++ b/bin/fm-send-wait-lib.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# fm-send-wait-lib.sh - the busy-agent wait helper for bin/fm-send.sh.
+#
+# Extracted so the shipped fm_send_wait_until_idle can be sourced and exercised
+# directly by tests (tests/fm-send-busy-wait.test.sh) instead of a drifting copy.
+# fm-send.sh sources this after fm-backend.sh (which provides
+# fm_backend_busy_state) and before the send dispatch.
+#
+# Wait until the target agent is not busy so text is not merely queued behind a
+# long shell. Backends that report unknown (tmux) skip the wait. The --key path
+# never waits so Escape/C-c can interrupt a busy agent. The final
+# budget-exhaustion branch fails loudly (returns 1) so the caller learns the
+# steer did not land instead of delivering into a queue. RESOLUTION_TRIED, set by
+# fm-send.sh's target resolver, is referenced in that error for diagnosis.
+fm_send_wait_until_idle() {  # <backend> <target>
+  local backend=$1 target=$2 wait_s poll_s waited state
+  wait_s=${FM_SEND_BUSY_WAIT_SECS:-3600}
+  poll_s=${FM_SEND_BUSY_POLL_SECS:-5}
+  case "$wait_s" in ''|*[!0-9]*) wait_s=3600 ;; esac
+  case "$poll_s" in ''|*[!0-9]*) poll_s=5 ;; esac
+  [ "$wait_s" -gt 0 ] || return 0
+  [ "$poll_s" -gt 0 ] || poll_s=5
+  waited=0
+  while [ "$waited" -le "$wait_s" ]; do
+    state=$(fm_backend_busy_state "$backend" "$target" 2>/dev/null || printf 'unknown')
+    case "$state" in
+      busy)
+        if [ "$waited" -eq 0 ]; then
+          echo "fm-send: $target is busy; waiting up to ${wait_s}s for idle before delivering text (set FM_SEND_BUSY_WAIT_SECS=0 to skip)" >&2
+        elif [ $((waited % 30)) -eq 0 ]; then
+          echo "fm-send: still waiting on busy $target (${waited}s/${wait_s}s)" >&2
+        fi
+        sleep "$poll_s"
+        waited=$((waited + poll_s))
+        ;;
+      *)
+        if [ "$waited" -gt 0 ]; then
+          echo "fm-send: $target idle after ${waited}s; delivering text" >&2
+        fi
+        return 0
+        ;;
+    esac
+  done
+  echo "error: $target still busy after ${wait_s}s; text not sent (tried ${RESOLUTION_TRIED:-}). Interrupt the agent or raise FM_SEND_BUSY_WAIT_SECS." >&2
+  return 1
+}

--- a/bin/fm-send.sh
+++ b/bin/fm-send.sh
@@ -33,6 +33,16 @@
 # footer appears, so an immediate peek would otherwise see the stale idle pane.
 # The pause is fm-send-only; the shared submit core (used by the away-mode daemon,
 # which only needs "submitted") does not pay it, and the --key path is unaffected.
+#
+# Busy-agent wait (text path only, not --key): when the target backend reports
+# busy/working (e.g. herdr agent_status=working while a long shell like
+# no-mistakes axi respond is running), Pi-like TUIs only QUEUE steering and do
+# not process it until the shell ends. Delivering into that queue looks like a
+# successful send but the instruction is not acted on for minutes. Before typing
+# text, fm-send waits until the agent is not busy, then submits. Tune with
+# FM_SEND_BUSY_WAIT_SECS (default 3600, 0 disables). Poll interval
+# FM_SEND_BUSY_POLL_SECS (default 5). Progress lines go to stderr. --key is never
+# waited: Escape/C-c are how you interrupt a busy agent.
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -203,12 +213,51 @@ fi
 # send implementation. A failed backend send is still surfaced below as a hard
 # error with the attempted resolution attached.
 
+# Wait until the target agent is not busy so text is not merely queued behind a
+# long shell. Backends that report unknown (tmux) skip the wait. --key path
+# never waits so Escape/C-c can interrupt.
+fm_send_wait_until_idle() {  # <backend> <target>
+  local backend=$1 target=$2 wait_s poll_s waited state
+  wait_s=${FM_SEND_BUSY_WAIT_SECS:-3600}
+  poll_s=${FM_SEND_BUSY_POLL_SECS:-5}
+  case "$wait_s" in ''|*[!0-9]*) wait_s=3600 ;; esac
+  case "$poll_s" in ''|*[!0-9]*) poll_s=5 ;; esac
+  [ "$wait_s" -gt 0 ] || return 0
+  [ "$poll_s" -gt 0 ] || poll_s=5
+  waited=0
+  while [ "$waited" -le "$wait_s" ]; do
+    state=$(fm_backend_busy_state "$backend" "$target" 2>/dev/null || printf 'unknown')
+    case "$state" in
+      busy)
+        if [ "$waited" -eq 0 ]; then
+          echo "fm-send: $target is busy; waiting up to ${wait_s}s for idle before delivering text (set FM_SEND_BUSY_WAIT_SECS=0 to skip)" >&2
+        elif [ $((waited % 30)) -eq 0 ]; then
+          echo "fm-send: still waiting on busy $target (${waited}s/${wait_s}s)" >&2
+        fi
+        sleep "$poll_s"
+        waited=$((waited + poll_s))
+        ;;
+      *)
+        if [ "$waited" -gt 0 ]; then
+          echo "fm-send: $target idle after ${waited}s; delivering text" >&2
+        fi
+        return 0
+        ;;
+    esac
+  done
+  echo "error: $target still busy after ${wait_s}s; text not sent (tried $RESOLUTION_TRIED). Interrupt the agent or raise FM_SEND_BUSY_WAIT_SECS." >&2
+  return 1
+}
+
 if [ "${1:-}" = "--key" ]; then
   if ! fm_backend_send_key "$TARGET_BACKEND" "$T" "$2" "$EXPECTED_LABEL"; then
     echo "error: key '$2' not sent to $T ($TARGET_BACKEND send failed; tried $RESOLUTION_TRIED)" >&2
     exit 1
   fi
 else
+  if ! fm_send_wait_until_idle "$TARGET_BACKEND" "$T"; then
+    exit 1
+  fi
   MESSAGE=$*
   if [ "$MARK_FROM_FIRSTMATE" = 1 ]; then
     fm_message_mark_from_firstmate "$MESSAGE" MESSAGE

--- a/bin/fm-send.sh
+++ b/bin/fm-send.sh
@@ -73,6 +73,8 @@ fi
 . "$SCRIPT_DIR/fm-backend.sh"
 # shellcheck source=bin/fm-marker-lib.sh
 . "$SCRIPT_DIR/fm-marker-lib.sh"
+# shellcheck source=bin/fm-send-wait-lib.sh
+. "$SCRIPT_DIR/fm-send-wait-lib.sh"
 
 FM_GUARD_CONTINUE_LINE='This is a supervision warning only; the requested message WILL still be sent.' "$SCRIPT_DIR/fm-guard.sh" || true
 
@@ -215,39 +217,8 @@ fi
 
 # Wait until the target agent is not busy so text is not merely queued behind a
 # long shell. Backends that report unknown (tmux) skip the wait. --key path
-# never waits so Escape/C-c can interrupt.
-fm_send_wait_until_idle() {  # <backend> <target>
-  local backend=$1 target=$2 wait_s poll_s waited state
-  wait_s=${FM_SEND_BUSY_WAIT_SECS:-3600}
-  poll_s=${FM_SEND_BUSY_POLL_SECS:-5}
-  case "$wait_s" in ''|*[!0-9]*) wait_s=3600 ;; esac
-  case "$poll_s" in ''|*[!0-9]*) poll_s=5 ;; esac
-  [ "$wait_s" -gt 0 ] || return 0
-  [ "$poll_s" -gt 0 ] || poll_s=5
-  waited=0
-  while [ "$waited" -le "$wait_s" ]; do
-    state=$(fm_backend_busy_state "$backend" "$target" 2>/dev/null || printf 'unknown')
-    case "$state" in
-      busy)
-        if [ "$waited" -eq 0 ]; then
-          echo "fm-send: $target is busy; waiting up to ${wait_s}s for idle before delivering text (set FM_SEND_BUSY_WAIT_SECS=0 to skip)" >&2
-        elif [ $((waited % 30)) -eq 0 ]; then
-          echo "fm-send: still waiting on busy $target (${waited}s/${wait_s}s)" >&2
-        fi
-        sleep "$poll_s"
-        waited=$((waited + poll_s))
-        ;;
-      *)
-        if [ "$waited" -gt 0 ]; then
-          echo "fm-send: $target idle after ${waited}s; delivering text" >&2
-        fi
-        return 0
-        ;;
-    esac
-  done
-  echo "error: $target still busy after ${wait_s}s; text not sent (tried $RESOLUTION_TRIED). Interrupt the agent or raise FM_SEND_BUSY_WAIT_SECS." >&2
-  return 1
-}
+# never waits so Escape/C-c can interrupt. fm_send_wait_until_idle lives in
+# bin/fm-send-wait-lib.sh (sourced above) so the shipped helper is testable.
 
 if [ "${1:-}" = "--key" ]; then
   if ! fm_backend_send_key "$TARGET_BACKEND" "$T" "$2" "$EXPECTED_LABEL"; then

--- a/tests/fm-send-busy-wait.test.sh
+++ b/tests/fm-send-busy-wait.test.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# fm-send busy-agent wait: do not type text while the target reports busy, so
+# steers are not merely queued behind a long shell (Pi "Steering:" trap).
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SEND="$ROOT/bin/fm-send.sh"
+TMP_ROOT=$(fm_test_tmproot fm-send-busy-wait)
+STATE="$TMP_ROOT/state"
+mkdir -p "$STATE"
+
+# Hermetic herdr busy_state stub via PATH-wrapped backend is heavy; instead
+# unit-test the wait helper by extracting behavior with a fake busy_state.
+# We source only the wait loop pattern through a tiny harness script.
+
+cat >"$TMP_ROOT/wait-harness.sh" <<'H'
+#!/usr/bin/env bash
+set -eu
+# Simulate fm_backend_busy_state: first N polls busy, then idle.
+COUNT_FILE=${COUNT_FILE:?}
+N_BUSY=${N_BUSY:-2}
+fm_backend_busy_state() {
+  local n
+  n=$(cat "$COUNT_FILE")
+  n=$((n + 1))
+  printf '%s' "$n" >"$COUNT_FILE"
+  if [ "$n" -le "$N_BUSY" ]; then
+    printf 'busy'
+  else
+    printf 'idle'
+  fi
+}
+fm_send_wait_until_idle() {
+  local backend=$1 target=$2 wait_s poll_s waited state
+  wait_s=${FM_SEND_BUSY_WAIT_SECS:-3600}
+  poll_s=${FM_SEND_BUSY_POLL_SECS:-5}
+  case "$wait_s" in ''|*[!0-9]*) wait_s=3600 ;; esac
+  case "$poll_s" in ''|*[!0-9]*) poll_s=5 ;; esac
+  [ "$wait_s" -gt 0 ] || return 0
+  [ "$poll_s" -gt 0 ] || poll_s=5
+  waited=0
+  while [ "$waited" -le "$wait_s" ]; do
+    state=$(fm_backend_busy_state "$backend" "$target" 2>/dev/null || printf 'unknown')
+    case "$state" in
+      busy)
+        sleep "$poll_s"
+        waited=$((waited + poll_s))
+        ;;
+      *)
+        printf 'waited=%s\n' "$waited"
+        return 0
+        ;;
+    esac
+  done
+  return 1
+}
+printf '0' >"$COUNT_FILE"
+fm_send_wait_until_idle herdr pane
+H
+chmod +x "$TMP_ROOT/wait-harness.sh"
+
+# 2 busy polls * 1s poll = waited 2
+export COUNT_FILE="$TMP_ROOT/count"
+export N_BUSY=2
+export FM_SEND_BUSY_WAIT_SECS=30
+export FM_SEND_BUSY_POLL_SECS=1
+out=$(bash "$TMP_ROOT/wait-harness.sh")
+echo "$out" | grep -q 'waited=2' || fail "expected waited=2 after 2 busy polls, got: $out"
+pass "busy-wait polls until idle"
+
+# Disabled wait returns immediately even if busy forever (no waited= line)
+export FM_SEND_BUSY_WAIT_SECS=0
+export N_BUSY=100
+printf '0' >"$COUNT_FILE"
+if ! out=$(bash "$TMP_ROOT/wait-harness.sh"); then
+	fail "disabled wait should return 0, got failure: $out"
+fi
+# When wait is disabled the harness returns before any poll; count file stays 0
+[ "$(cat "$COUNT_FILE")" = 0 ] || fail "disabled wait must not poll busy_state, count=$(cat "$COUNT_FILE")"
+pass "busy-wait disabled with FM_SEND_BUSY_WAIT_SECS=0"
+
+# Confirm fm-send.sh still contains the wait call on the text path
+grep -q 'fm_send_wait_until_idle' "$SEND" || fail "fm-send.sh missing busy-wait call"
+pass "fm-send.sh wires busy-wait on text path"

--- a/tests/fm-send-busy-wait.test.sh
+++ b/tests/fm-send-busy-wait.test.sh
@@ -8,79 +8,74 @@ set -u
 
 SEND="$ROOT/bin/fm-send.sh"
 TMP_ROOT=$(fm_test_tmproot fm-send-busy-wait)
-STATE="$TMP_ROOT/state"
-mkdir -p "$STATE"
+mkdir -p "$TMP_ROOT"
 
-# Hermetic herdr busy_state stub via PATH-wrapped backend is heavy; instead
-# unit-test the wait helper by extracting behavior with a fake busy_state.
-# We source only the wait loop pattern through a tiny harness script.
-
-cat >"$TMP_ROOT/wait-harness.sh" <<'H'
+# Exercise the SHIPPED fm_send_wait_until_idle (bin/fm-send-wait-lib.sh), not a
+# copy: source the real helper and drive it with a stubbed fm_backend_busy_state.
+# A harness subshell runs the real function so a failing (return 1) budget path
+# does not abort this test under set -e.
+cat >"$TMP_ROOT/wait-harness.sh" <<H
 #!/usr/bin/env bash
-set -eu
+set -u
 # Simulate fm_backend_busy_state: first N polls busy, then idle.
-COUNT_FILE=${COUNT_FILE:?}
-N_BUSY=${N_BUSY:-2}
+COUNT_FILE=\${COUNT_FILE:?}
+N_BUSY=\${N_BUSY:-2}
+RESOLUTION_TRIED="meta=stub; backend=herdr"
 fm_backend_busy_state() {
   local n
-  n=$(cat "$COUNT_FILE")
-  n=$((n + 1))
-  printf '%s' "$n" >"$COUNT_FILE"
-  if [ "$n" -le "$N_BUSY" ]; then
+  n=\$(cat "\$COUNT_FILE")
+  n=\$((n + 1))
+  printf '%s' "\$n" >"\$COUNT_FILE"
+  if [ "\$n" -le "\$N_BUSY" ]; then
     printf 'busy'
   else
     printf 'idle'
   fi
 }
-fm_send_wait_until_idle() {
-  local backend=$1 target=$2 wait_s poll_s waited state
-  wait_s=${FM_SEND_BUSY_WAIT_SECS:-3600}
-  poll_s=${FM_SEND_BUSY_POLL_SECS:-5}
-  case "$wait_s" in ''|*[!0-9]*) wait_s=3600 ;; esac
-  case "$poll_s" in ''|*[!0-9]*) poll_s=5 ;; esac
-  [ "$wait_s" -gt 0 ] || return 0
-  [ "$poll_s" -gt 0 ] || poll_s=5
-  waited=0
-  while [ "$waited" -le "$wait_s" ]; do
-    state=$(fm_backend_busy_state "$backend" "$target" 2>/dev/null || printf 'unknown')
-    case "$state" in
-      busy)
-        sleep "$poll_s"
-        waited=$((waited + poll_s))
-        ;;
-      *)
-        printf 'waited=%s\n' "$waited"
-        return 0
-        ;;
-    esac
-  done
-  return 1
-}
-printf '0' >"$COUNT_FILE"
-fm_send_wait_until_idle herdr pane
+. "$ROOT/bin/fm-send-wait-lib.sh"
+if fm_send_wait_until_idle herdr pane; then
+  printf 'rc=0\n'
+else
+  printf 'rc=1\n'
+fi
 H
 chmod +x "$TMP_ROOT/wait-harness.sh"
 
-# 2 busy polls * 1s poll = waited 2
+# Busy for 2 polls of 1s, then idle: succeeds and delivers.
 export COUNT_FILE="$TMP_ROOT/count"
 export N_BUSY=2
 export FM_SEND_BUSY_WAIT_SECS=30
 export FM_SEND_BUSY_POLL_SECS=1
-out=$(bash "$TMP_ROOT/wait-harness.sh")
-echo "$out" | grep -q 'waited=2' || fail "expected waited=2 after 2 busy polls, got: $out"
-pass "busy-wait polls until idle"
+printf '0' >"$COUNT_FILE"
+out=$(bash "$TMP_ROOT/wait-harness.sh" 2>"$TMP_ROOT/err")
+assert_contains "$out" 'rc=0' "expected success after 2 busy polls, got: $out / $(cat "$TMP_ROOT/err")"
+assert_grep 'idle after' "$TMP_ROOT/err" "expected idle-after progress line on stderr"
+[ "$(cat "$COUNT_FILE")" = 3 ] || fail "expected 3 busy_state polls (2 busy + 1 idle), got $(cat "$COUNT_FILE")"
+pass "busy-wait polls until idle then delivers"
 
-# Disabled wait returns immediately even if busy forever (no waited= line)
+# Fail loudly after the wait budget: agent stays busy forever, wait budget is
+# short, the shipped helper must return non-zero and print the error. This is the
+# path the intent requires ("fail loudly after wait budget") and the one a copied
+# loop previously never exercised.
+export N_BUSY=100
+export FM_SEND_BUSY_WAIT_SECS=2
+export FM_SEND_BUSY_POLL_SECS=1
+printf '0' >"$COUNT_FILE"
+out=$(bash "$TMP_ROOT/wait-harness.sh" 2>"$TMP_ROOT/err")
+assert_contains "$out" 'rc=1' "expected failure when agent never idles within budget, got: $out"
+assert_grep 'still busy after 2s' "$TMP_ROOT/err" "expected loud budget-exhaustion error on stderr"
+assert_grep 'backend=herdr' "$TMP_ROOT/err" "expected RESOLUTION_TRIED echoed in budget-exhaustion error"
+pass "busy-wait fails loudly after wait budget"
+
+# Disabled wait returns immediately even if busy forever, without polling.
 export FM_SEND_BUSY_WAIT_SECS=0
 export N_BUSY=100
 printf '0' >"$COUNT_FILE"
-if ! out=$(bash "$TMP_ROOT/wait-harness.sh"); then
-	fail "disabled wait should return 0, got failure: $out"
-fi
-# When wait is disabled the harness returns before any poll; count file stays 0
+out=$(bash "$TMP_ROOT/wait-harness.sh" 2>"$TMP_ROOT/err")
+assert_contains "$out" 'rc=0' "disabled wait should return 0, got: $out"
 [ "$(cat "$COUNT_FILE")" = 0 ] || fail "disabled wait must not poll busy_state, count=$(cat "$COUNT_FILE")"
 pass "busy-wait disabled with FM_SEND_BUSY_WAIT_SECS=0"
 
-# Confirm fm-send.sh still contains the wait call on the text path
-grep -q 'fm_send_wait_until_idle' "$SEND" || fail "fm-send.sh missing busy-wait call"
+# Confirm fm-send.sh still wires the wait on the text path (and only there).
+grep -q 'fm_send_wait_until_idle "\$TARGET_BACKEND" "\$T"' "$SEND" || fail "fm-send.sh missing busy-wait call on text path"
 pass "fm-send.sh wires busy-wait on text path"


### PR DESCRIPTION
## Summary

Fixes https://github.com/kunchenguid/firstmate/issues/677

Pi only **queues** steering while a long shell runs (e.g. `no-mistakes axi respond`). `fm-send` previously reported success as soon as text hit the composer, so captain decisions and course corrections sat unprocessed in the Pi `Steering:` UI for many minutes.

### Change

- On the **text** path, wait until `fm_backend_busy_state` is not `busy` before typing.
- Default wait budget 3600s, poll every 5s (env: `FM_SEND_BUSY_WAIT_SECS`, `FM_SEND_BUSY_POLL_SECS`).
- Fail loudly if still busy after the budget (no false success).
- `--key` path unchanged so Escape / C-c can still interrupt immediately.
- Hermetic test: `tests/fm-send-busy-wait.test.sh`

### How we fixed it

1. Confirmed live: worker mid-`axi respond`, steers visible as `Steering: …` but not acted on.
2. Root cause: Pi defers processing until shell ends; `fm-send` did not wait for idle.
3. Wait-for-idle on text steers; keep interrupt keys immediate.

## Test plan

- [x] `bash -n bin/fm-send.sh`
- [x] `tests/fm-send-busy-wait.test.sh`
- [x] `tests/fm-send-settle.test.sh`
- [ ] Manual: steer a herdr/pi crew mid-long-shell; observe wait logs then delivery after idle

## Notes

- Opened from fork `korallis/firstmate` (no push permission on upstream).
- Please **do not merge** from this account — no merge permissions; for upstream maintainer review only.
