### PR TITLE
docs(readme): redesign via beautify-github-readme skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,64 +1,54 @@
-<h1 align="center">firstmate</h1>
 <p align="center">
-  <a
-    href="https://img.shields.io/badge/platform-macOS%20%7C%20Linux-blue?style=flat-square"
-    ><img
-      alt="Platform"
-      src="https://img.shields.io/badge/platform-macOS%20%7C%20Linux-blue?style=flat-square"
-  /></a>
-  <a href="https://x.com/kunchenguid"
-    ><img
-      alt="X"
-      src="https://img.shields.io/badge/X-@kunchenguid-black?style=flat-square"
-  /></a>
-  <a href="https://discord.gg/Wsy2NpnZDu"
-    ><img
-      alt="Discord"
-      src="https://img.shields.io/discord/1439901831038763092?style=flat-square&label=discord"
-  /></a>
+  <img src="./assets/readme/hero.svg" width="100%" alt="firstmate — talk to one agent, ship with a crew. A portable runtime and supervision contract for fleets of coding agents.">
 </p>
 
-<h3 align="center">Talk to one agent. Ship with a crew.</h3>
-
 <p align="center">
-  <img alt="firstmate - talk to one agent, ship with a crew" src="assets/banner.png" width="100%" />
+  <a href="https://img.shields.io/badge/platform-macOS%20%7C%20Linux-blue?style=flat-square"><img alt="Platform" src="https://img.shields.io/badge/platform-macOS%20%7C%20Linux-blue?style=flat-square"></a>
+  <a href="https://x.com/kunchenguid"><img alt="X" src="https://img.shields.io/badge/X-@kunchenguid-black?style=flat-square"></a>
+  <a href="https://discord.gg/Wsy2NpnZDu"><img alt="Discord" src="https://img.shields.io/discord/1439901831038763092?style=flat-square&label=discord"></a>
 </p>
 
 ## What it is
 
-You can run one coding agent easily.
-But the moment you want three project tasks done in parallel - fixes, investigations, plans, audits - you become a tab-juggler: babysitting sessions, copy-pasting context between repos, forgetting which terminal had the failing test.
+You can run one coding agent easily. The moment you want three project tasks done in parallel — fixes, investigations, plans, audits — you become a tab-juggler: babysitting sessions, copy-pasting context between repos, forgetting which terminal had the failing test.
 
-firstmate flips the model.
-You talk to a single agent - the first mate - and it runs the crew for you: spawning autonomous agents in a visible session backend, giving each a clean git worktree, supervising them to completion, and handing you finished PRs, approved local merges, or standalone investigation reports.
-For larger fleets, you can opt in to persistent secondmates: domain supervisors that are still ordinary direct reports, but run from their own isolated firstmate homes.
+firstmate flips the model. You talk to a single agent — the first mate — and it runs the crew for you: spawning autonomous agents in a visible session backend, giving each a clean git worktree, supervising them to completion, and handing you finished PRs, approved local merges, or standalone investigation reports. For larger fleets, you can opt in to persistent **secondmates** — domain supervisors that are still ordinary direct reports, but run from their own isolated firstmate homes.
 
 firstmate is not a model, not a harness, not a skill, not an MCP server, and not a CLI.
-firstmate is an agent distro for running a crew of agents.
+firstmate is an **agent distro** for running a crew of agents.
 An agent distro is a portable directory of instructions, skills, tooling, policies, and state conventions that turns a general-purpose agent into a specialized one.
-There is no app to install: the cloned repo is the distro - `AGENTS.md`, bundled firstmate skills, and helper scripts that any terminal coding agent can follow.
-Launching a supported harness inside it instantiates your first mate - and makes you the captain.
+There is no app to install: the cloned repo *is* the distro — `AGENTS.md`, bundled firstmate skills, and helper scripts that any terminal coding agent can follow.
+Launching a supported harness inside it instantiates your first mate — and makes you the captain.
 
-## Features
+## What's in the box
 
-- **One liaison** - you talk only to the first mate; it dispatches, supervises, escalates only real decisions, and reports plain outcomes.
-- **A visible crew** - every crewmate works in its own tmux window, experimental herdr/zellij tab, cmux workspace, or Orca terminal you can watch or type into; the first mate reconciles.
-- **Disposable worktrees** - each task runs in a clean [treehouse](https://github.com/kunchenguid/treehouse) git worktree, or an Orca-managed worktree when `backend=orca`, so parallel work on one repo never collides.
-- **Two task shapes** - ship tasks deliver a change; scout tasks investigate, plan, reproduce, or audit and leave a report.
-- **Explicit project modes** - each project ships via `no-mistakes`, `direct-PR`, or `local-only`, with an optional `+yolo` autonomy flag.
-- **Optional secondmates** - opt in to persistent domain supervisors that run from isolated firstmate homes with their own `FM_HOME`, state, projects, and session lock, supervising project clones or a project-less firstmate-repo domain, kept on the primary firstmate version by guarded local fast-forwards and checked for live agent processes at session start.
-- **Event-driven, zero-token supervision** - a bash watcher sleeps on the fleet and wakes the first mate only when something needs you; verified primary harnesses also get a turn-end backstop that blocks or follows up on a blind stop when work is under way and supervision is not live.
-- **Optional X mode** - opt in with one local `.env` token so firstmate can answer your public `@myfirstmate` mentions, act on normal reversible mention requests through the same lifecycle as chat requests, acknowledge spawned work, and post up to three public-safe completion follow-ups within seven days for genuine milestones and the final outcome without changing non-X behavior; dry-run preview records would-be replies and dismissals locally before go-live.
-- **Guarded by construction** - the first mate is read-only over your projects outside guarded clone refreshes, safe branch pruning, and approved `local-only` fast-forward merges; crewmates make every project change behind the configured merge authority.
-- **Restart-proof** - all state lives on disk and in the active session backend (tmux by hard default, herdr or cmux when selected or auto-detected, zellij/orca when explicitly selected); kill the session anytime and the next one reconciles, including confirmed-dead secondmate agents, and carries on.
+<p align="center">
+  <img src="./assets/readme/in-the-box.svg" width="100%" alt="Three-column showcase: 74 bin scripts, 16 firstmate-loaded skills under .agents/skills, and 1 public installer-facing skill under skills/.">
+</p>
 
-Full detail on every feature lives in [docs/architecture.md](docs/architecture.md).
+## How it works
 
-## Quick Start
+<p align="center">
+  <img src="./assets/readme/lifecycle.svg" width="100%" alt="Request lifecycle: captain chat request routed through firstmate (brief, spawn, supervise, merge) into a ship outcome (PR or local merge) or a scout outcome (investigation report).">
+</p>
+
+```
+you (the captain) → firstmate reads projects/ + routes → spawns crewmate in active backend
+                                                                  │
+                                                                  ├─ ship → project mode → PR or local merge → teardown
+                                                                  │
+                                                                  └─ scout → report at data/<id>/report.md → decision inventory → relay findings → teardown
+```
+
+You chat with the first mate. It routes each request to a crewmate in its own session endpoint and git worktree, supervises the fleet with a zero-token event-driven watcher, and brings you finished PRs, approved local merges, or investigation reports. Optional secondmates extend this to persistent domain supervisors, dispatch profiles let you steer which harness handles which task, and an opt-in X mode lets the same fleet answer public mentions.
+
+Full architecture — the supervision engine, worktree isolation, secondmates, dispatch profiles, project modes, optional X mode, fleet sync, and self-update — lives in [docs/architecture.md](docs/architecture.md).
+
+## Quick start
 
 ### Requirements
 
-- A verified agent harness: Claude Code, Grok, Pi, Codex, or OpenCode.
+- A verified agent harness: **Claude Code**, **Grok**, **Pi**, **Codex**, or **OpenCode**.
 - Git and the GitHub CLI, authenticated through `gh auth login`.
 - tmux, for the reference session backend.
 
@@ -81,24 +71,10 @@ git clone https://github.com/kunchenguid/firstmate
 cd firstmate
 ```
 
-Then launch one of the co-primary harnesses; AGENTS.md takes over from there:
-
-**Claude Code**
+Then launch one of the co-primary harnesses; `AGENTS.md` takes over from there:
 
 ```sh
-claude
-```
-
-**Grok**
-
-```sh
-grok --trust
-```
-
-**Pi**
-
-```sh
-pi
+claude      # or:  grok --trust   |   pi   |   codex   |   opencode
 ```
 
 For Grok, `--trust` is needed once per clone so project hooks and the turn-end guard load; `/hooks-trust` inside Grok works too.
@@ -110,97 +86,74 @@ For Pi, approve the project trust prompt once per clone on first launch so both 
 > ahoy! look at my github project xyz, then fix the flaky login test and add dark mode
 
 # firstmate checks its toolchain (asking your consent before installing anything),
-# clones the project under projects/, and spawns two crewmates in the active backend
-# fm-fix-login-k3 and fm-dark-mode-p7.
-# Minutes later:
+# clones xyz under projects/, and spawns two crewmates in the active backend —
+# fm-fix-login-k3 and fm-dark-mode-p7. Minutes later:
 
   PR ready for review, captain: https://github.com/you/xyz/pull/42
-  (fix flaky login test - risk: low - CI green)
+  (fix flaky login test — risk: low — CI green)
 
 > alright merge it
 ```
 
-### More backends
+`bin/fm-session-start.sh` runs once at the start of every firstmate session: it acquires the session lock, runs detect-only tool and auth checks, drains the durable wake queue, prints a fleet-state digest, and arms the supervision protocol for the detected primary harness. The first message after that lands as ordinary work.
 
-Setup guides for tmux (the default) and every other supported backend (herdr, zellij, Orca, cmux) are linked in [Documentation](#documentation) below.
+## Features
 
-## How It Works
+- **One liaison** — you talk only to the first mate; it dispatches, supervises, escalates only real decisions, and reports plain outcomes.
+- **A visible crew** — every crewmate works in its own tmux window, experimental herdr/zellij tab, cmux workspace, or Orca terminal you can watch or type into; the first mate reconciles.
+- **Disposable worktrees** — each task runs in a clean [treehouse](https://github.com/kunchenguid/treehouse) git worktree, or an Orca-managed worktree when `backend=orca`, so parallel work on one repo never collides.
+- **Two task shapes** — **ship** tasks deliver a change; **scout** tasks investigate, plan, reproduce, or audit and leave a report.
+- **Explicit project modes** — each project ships via `no-mistakes`, `direct-PR`, or `local-only`, with an optional `+yolo` autonomy flag.
+- **Optional secondmates** — opt in to persistent domain supervisors that run from isolated firstmate homes with their own `FM_HOME`, state, projects, and session lock, kept on the primary firstmate version by guarded local fast-forwards.
+- **Event-driven, zero-token supervision** — a bash watcher sleeps on the fleet and wakes the first mate only when something needs you; verified primary harnesses also get a turn-end backstop that blocks or follows up on a blind stop when work is under way and supervision is not live.
+- **Optional X mode** — opt in with one local `.env` token so firstmate can answer your public `@myfirstmate` mentions, post up to three public-safe completion follow-ups within seven days for milestones and the final outcome, and record dry-run previews locally before go-live.
+- **Guarded by construction** — the first mate is read-only over your projects outside guarded clone refreshes, safe branch pruning, and approved `local-only` fast-forward merges; crewmates make every project change behind the configured merge authority.
+- **Restart-proof** — all state lives on disk and in the active session backend (tmux by hard default, herdr or cmux when selected or auto-detected, zellij/orca when explicitly selected); kill the session anytime and the next one reconciles and carries on.
 
-```
-            you (the captain)
-                  │  chat: requests, decisions, "merge it"
-                  ▼
- ┌─────────────────────────────────────┐
- │ firstmate            (this repo)    │
- │ reads projects/ + firstmate routes  │
- │ writes guarded backlog/briefs/state │
- └──┬──────────────┬───────────────┬───┘
-    │ backend sends / status files │
-    ▼              ▼               ▼
- ┌────────┐   ┌────────┐      ┌────────┐
- │fm-task1│   │fm-task2│  ... │fm-taskN│   tmux windows, herdr/zellij tabs, cmux workspaces, or Orca terminals
- │crewmate│   │crewmate│      │crewmate│   one autonomous agent each
- └───┬────┘   └───┬────┘      └───┬────┘
-     ▼            ▼               ▼
-  treehouse worktree, Orca worktree, or isolated secondmate home
-     │
-     ├─ ship: project mode ► PR/local merge ► teardown
-     │
-     └─ scout: report at data/<id>/report.md ► decision inventory ► relay findings ► teardown
-```
+Full detail on every feature lives in [docs/architecture.md](docs/architecture.md).
 
-You chat with the first mate.
-It routes each request to a crewmate in its own session endpoint and git worktree, supervises the fleet with a zero-token event-driven watcher, and brings you finished PRs, approved local merges, or investigation reports.
-Optional secondmates extend this to persistent domain supervisors, dispatch profiles let you steer which harness handles which task, and an opt-in X mode lets the same fleet answer public mentions.
-`codex-app` is not a runtime backend yet; [docs/codex-app-backend.md](docs/codex-app-backend.md) owns the Codex App boundary.
+## Backends
 
-Full architecture - the supervision engine, worktree isolation, secondmates, dispatch profiles, project modes, optional X mode, fleet sync, and self-update - is in [docs/architecture.md](docs/architecture.md).
+Setup guides for tmux (the reference) and every other supported backend live in [docs/](docs/):
+
+- [docs/tmux-backend.md](docs/tmux-backend.md) — tmux reference backend: prerequisites, attaching, watching crew windows.
+- [docs/herdr-backend.md](docs/herdr-backend.md) — experimental herdr backend, with verification notes and known gaps.
+- [docs/zellij-backend.md](docs/zellij-backend.md) — experimental zellij backend, with verification notes and known gaps.
+- [docs/orca-backend.md](docs/orca-backend.md) — experimental Orca backend, with lifecycle notes and known gaps.
+- [docs/cmux-backend.md](docs/cmux-backend.md) — experimental cmux backend, with verification notes and known gaps.
+- [docs/codex-app-backend.md](docs/codex-app-backend.md) — Codex App backend boundary, evidence, and rollout contract.
+
+`codex-app` is not a runtime backend yet; the doc above owns that boundary.
 
 ## Built-in skills
 
-Firstmate ships these user-invocable built-in skills.
-Claude and grok use the slash form shown here; codex uses the same names with `$`, such as `$afk`.
+firstmate ships these user-invocable built-in skills.
+Claude and Grok use the slash form shown here; Codex uses the same names with `$`, such as `$afk`.
 
-| Skill              | What it does                                                                                                                                  |
-| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| `/afk`             | Enter away-mode supervision: the sub-supervisor self-handles routine notifications in bash, escalates captain-relevant events and bounded declared-external-wait rechecks as batched digests, and actively alerts if delivery gets stuck while you step away |
-| `/bearings`        | Generate a standalone current-status report from bounded local fleet and registered-secondmate state, with live PR enrichment only when requested, written to a dated file in `data/` and surfaced concisely in chat; read-mostly, mutates no task state |
-| `/updatefirstmate` | Self-update the running firstmate and its secondmates to the latest from origin with fast-forward-only pulls, then re-read instructions and nudge secondmates |
-| `/stow`            | Sweep the session for uncaptured durable knowledge, route each finding to its disk home per AGENTS.md, file undone next steps to the backlog, and report what is now safe to reset |
+| Skill | What it does |
+| --- | --- |
+| `/afk` | Enter away-mode supervision: the sub-supervisor self-handles routine notifications, escalates captain-relevant events and bounded declared-external-wait rechecks as batched digests, and actively alerts if delivery gets stuck while you step away. |
+| `/bearings` | Generate a standalone current-status report from bounded local fleet and registered-secondmate state, written to a dated file in `data/` and surfaced concisely in chat. |
+| `/updatefirstmate` | Self-update the running firstmate and its secondmates to the latest from origin with fast-forward-only pulls, then re-read instructions and nudge secondmates. |
+| `/stow` | Sweep the session for uncaptured durable knowledge, route each finding to its disk home per `AGENTS.md`, file undone next steps to the backlog, and report what is now safe to reset. |
 
-Agent-only reference skills live under `.agents/skills/` and are loaded by firstmate at the trigger points named in [`AGENTS.md`](AGENTS.md).
-
-### Two-tier skill layout
-
-Firstmate's skills live in two separate places with different audiences:
-
-- `.agents/skills/` - agent-loaded skills (this section's table, plus firstmate's agent-only reference skills). Every one of these assumes a live firstmate home and is meaningless, or actively misleading, installed anywhere else, so each carries `metadata.internal: true` in its frontmatter. That flag hides them from installer discovery (tools like the [skills.sh](https://skills.sh) `npx skills add` installer) without affecting how firstmate itself loads them - frontmatter metadata is inert to the agent's own skill loader.
-- `skills/` - public, installer-facing skills meant to be installed standalone into any project, independent of firstmate.
-  Each one is a self-contained skill with no dependency on firstmate's paths, tools, or vocabulary.
-  Today that is `skills/stow`, a generic session-knowledge-sweep skill that routes findings by explicit instruction first, then existing local conventions, then a private `.stow-notes.md` fallback in the current directory, and closes with a resume pointer for the next session.
-  It intentionally shares no code with the firstmate-internal `.agents/skills/stow` it is named after, so the two can evolve independently.
+Agent-only reference skills (loaded by firstmate at trigger points) live under `.agents/skills/`. The public, installer-facing `skills/stow` lives under `skills/` for standalone install into any project — see [docs/configuration.md](docs/configuration.md#two-tier-skill-layout) for the split.
 
 ## Documentation
 
-- [docs/architecture.md](docs/architecture.md) - how the crew, supervision, worktrees, secondmates, and project modes work.
-- [docs/configuration.md](docs/configuration.md) - environment variables, `FM_HOME`, runtime backend selection, optional X mode, the files you set, and harness support.
-- [docs/wedge-alarm.md](docs/wedge-alarm.md) - configure the active alert for an away-mode escalation delivery that gets stuck.
-- [docs/tmux-backend.md](docs/tmux-backend.md) - setup guide for the tmux reference backend: prerequisites, attaching, and watching crew windows.
-- [docs/herdr-backend.md](docs/herdr-backend.md) - setup guide for the experimental herdr backend, plus its verification notes and known gaps.
-- [docs/zellij-backend.md](docs/zellij-backend.md) - setup guide for the experimental zellij backend, plus its verification notes and known gaps.
-- [docs/orca-backend.md](docs/orca-backend.md) - setup guide for the experimental Orca backend, plus its lifecycle notes and known gaps.
-- [docs/cmux-backend.md](docs/cmux-backend.md) - setup guide for the experimental cmux backend, plus its verification notes and known gaps.
-- [docs/codex-app-backend.md](docs/codex-app-backend.md) - Codex App backend boundary, evidence, and rollout contract.
-- [docs/turnend-guard.md](docs/turnend-guard.md) - the primary session's structural "no turn ends blind" backstop: verified per-harness hook mechanisms, scoping, loop safety, and fail-open tradeoffs.
-- [docs/supervision-protocols/](docs/supervision-protocols/) - rendered primary-harness watcher protocols for Claude, Codex, OpenCode, Pi, Grok, and unknown harness fallback.
-- [docs/scripts.md](docs/scripts.md) - the `bin/` toolbelt reference.
-- [`AGENTS.md`](AGENTS.md) - the distro's always-loaded operating contract and routing index for conditional procedures.
-- [CONTRIBUTING.md](CONTRIBUTING.md) - how to contribute, including the dev/test commands.
+- [docs/architecture.md](docs/architecture.md) — how the crew, supervision, worktrees, secondmates, and project modes work.
+- [docs/configuration.md](docs/configuration.md) — environment variables, `FM_HOME`, runtime backend selection, optional X mode, the files you set, and harness support.
+- [docs/wedge-alarm.md](docs/wedge-alarm.md) — configure the active alert for an away-mode escalation delivery that gets stuck.
+- [docs/scripts.md](docs/scripts.md) — the `bin/` toolbelt reference.
+- [docs/turnend-guard.md](docs/turnend-guard.md) — the primary session's structural "no turn ends blind" backstop.
+- [docs/supervision-protocols/](docs/supervision-protocols/) — rendered primary-harness watcher protocols for Claude, Codex, OpenCode, Pi, Grok, and unknown harness fallback.
+- [`AGENTS.md`](AGENTS.md) — the distro's always-loaded operating contract and routing index for conditional procedures.
+- [CONTRIBUTING.md](CONTRIBUTING.md) — how to contribute, including the dev/test commands.
 
 ## Contributing
 
-Contributions are welcome - see [CONTRIBUTING.md](CONTRIBUTING.md) for the workflow, repo conventions, and how to run the tests.
+Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) for the workflow, repo conventions, and how to run the tests.
 
 ## License
 
-MIT - see [LICENSE](LICENSE).
+MIT — see [LICENSE](LICENSE).

--- a/assets/readme/hero.svg
+++ b/assets/readme/hero.svg
@@ -1,0 +1,159 @@
+<svg xmlns="http://www.w3.org/2000/svg"
+     width="1200" height="360" viewBox="0 0 1200 360"
+     role="img" aria-labelledby="hero-title hero-desc">
+  <title id="hero-title">firstmate — an agent distro for supervising fleets of coding agents</title>
+  <desc id="hero-desc">Hero with the firstmate wordmark, the tagline "Talk to one agent. Ship with a crew.", and a compact fleet diagram: a captain routes through firstmate to crewmates producing PRs or investigation reports.</desc>
+
+  <defs>
+    <linearGradient id="heroBg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#0a1929"/>
+      <stop offset="1" stop-color="#0d2238"/>
+    </linearGradient>
+    <pattern id="heroDots" x="0" y="0" width="48" height="48" patternUnits="userSpaceOnUse">
+      <circle cx="24" cy="24" r="0.8" fill="#16314f"/>
+    </pattern>
+    <marker id="heroArrow" viewBox="0 0 10 10" refX="9" refY="5"
+            markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#c9a961"/>
+    </marker>
+  </defs>
+
+  <rect width="1200" height="360" rx="20" fill="url(#heroBg)"/>
+  <rect width="1200" height="360" rx="20" fill="url(#heroDots)" opacity="0.6"/>
+  <rect x="0.75" y="0.75" width="1198.5" height="358.5" rx="19.25"
+        fill="none" stroke="#1a3a5c" stroke-width="1.5"/>
+
+  <!-- compass-rose motif, top-right, very subtle -->
+  <g transform="translate(1124 56)" opacity="0.35">
+    <circle cx="0" cy="0" r="22" fill="none" stroke="#c9a961" stroke-width="0.8"/>
+    <circle cx="0" cy="0" r="14" fill="none" stroke="#c9a961" stroke-width="0.6"/>
+    <path d="M 0 -22 L 4 0 L 0 22 L -4 0 z" fill="#c9a961" opacity="0.5"/>
+    <path d="M -22 0 L 0 4 L 22 0 L 0 -4 z" fill="#c9a961" opacity="0.35"/>
+    <circle cx="0" cy="0" r="1.5" fill="#c9a961"/>
+  </g>
+
+  <!-- Left column: identity (x 48 .. 472) -->
+  <g transform="translate(48 56)">
+    <text x="0" y="14"
+          font-family="ui-monospace, SFMono-Regular, Menlo, monospace"
+          font-size="13" letter-spacing="3" fill="#5d6d7e">AGENT DISTRO</text>
+
+    <text x="0" y="108"
+          font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+          font-size="84" font-weight="700" fill="#f4e8d0"
+          letter-spacing="-2">firstmate</text>
+
+    <text x="0" y="156"
+          font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+          font-size="24" font-weight="500" fill="#c9a961">
+      Talk to one agent. Ship with a crew.
+    </text>
+
+    <text x="0" y="200"
+          font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+          font-size="16" fill="#a8b5c2">
+      A portable runtime, tooling, and supervision
+    </text>
+    <text x="0" y="222"
+          font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+          font-size="16" fill="#a8b5c2">
+      contract for fleets of coding agents.
+    </text>
+
+    <text x="0" y="262"
+          font-family="ui-monospace, SFMono-Regular, Menlo, monospace"
+          font-size="12" letter-spacing="2" fill="#5d6d7e">
+      CLAUDE · CODEX · GROK · PI · OPENCODE
+    </text>
+  </g>
+
+  <!-- Right column: fleet diagram (translate 580 50, spans 580..1140) -->
+  <g transform="translate(580 50)">
+    <!-- captain node (centered at x=250) -->
+    <g>
+      <rect x="160" y="0" width="180" height="38" rx="9"
+            fill="#0a1929" stroke="#c9a961" stroke-width="1.5"/>
+      <text x="250" y="16" text-anchor="middle"
+            font-family="ui-monospace, SFMono-Regular, Menlo, monospace"
+            font-size="11" letter-spacing="2" fill="#5d6d7e">CAPTAIN</text>
+      <text x="250" y="32" text-anchor="middle"
+            font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+            font-size="14" fill="#f4e8d0">you, in chat</text>
+    </g>
+    <line x1="250" y1="38" x2="250" y2="64"
+          stroke="#c9a961" stroke-width="1.5" marker-end="url(#heroArrow)"/>
+
+    <!-- firstmate node (centered at x=250, width 340) -->
+    <g>
+      <rect x="80" y="72" width="340" height="62" rx="10"
+            fill="#0a1929" stroke="#c9a961" stroke-width="1.5"/>
+      <text x="250" y="94" text-anchor="middle"
+            font-family="ui-monospace, SFMono-Regular, Menlo, monospace"
+            font-size="11" letter-spacing="2" fill="#5d6d7e">FIRSTMATE</text>
+      <text x="250" y="114" text-anchor="middle"
+            font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+            font-size="13" fill="#f4e8d0">reads projects/, dispatches crew,</text>
+      <text x="250" y="130" text-anchor="middle"
+            font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+            font-size="13" fill="#f4e8d0">watches the fleet</text>
+    </g>
+
+    <!-- branch arrows down to three crewmate lanes (centers at 130, 250, 370) -->
+    <line x1="130" y1="134" x2="130" y2="166"
+          stroke="#c9a961" stroke-width="1.5" marker-end="url(#heroArrow)"/>
+    <line x1="250" y1="134" x2="250" y2="166"
+          stroke="#c9a961" stroke-width="1.5" marker-end="url(#heroArrow)"/>
+    <line x1="370" y1="134" x2="370" y2="166"
+          stroke="#c9a961" stroke-width="1.5" marker-end="url(#heroArrow)"/>
+
+    <!-- crewmate lanes (each width 110, centers at 130/250/370) -->
+    <g>
+      <rect x="75" y="170" width="110" height="48" rx="8"
+            fill="none" stroke="#5d6d7e" stroke-width="1.2"/>
+      <text x="130" y="190" text-anchor="middle"
+            font-family="ui-monospace, SFMono-Regular, Menlo, monospace"
+            font-size="10" fill="#a8b5c2">fm-fix-login-k3</text>
+      <text x="130" y="208" text-anchor="middle"
+            font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+            font-size="11" fill="#f4e8d0">crewmate → ship</text>
+    </g>
+    <g>
+      <rect x="195" y="170" width="110" height="48" rx="8"
+            fill="none" stroke="#5d6d7e" stroke-width="1.2"/>
+      <text x="250" y="190" text-anchor="middle"
+            font-family="ui-monospace, SFMono-Regular, Menlo, monospace"
+            font-size="10" fill="#a8b5c2">fm-dark-mode-p7</text>
+      <text x="250" y="208" text-anchor="middle"
+            font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+            font-size="11" fill="#f4e8d0">crewmate → ship</text>
+    </g>
+    <g>
+      <rect x="315" y="170" width="110" height="48" rx="8"
+            fill="none" stroke="#5d6d7e" stroke-width="1.2"/>
+      <text x="370" y="190" text-anchor="middle"
+            font-family="ui-monospace, SFMono-Regular, Menlo, monospace"
+            font-size="10" fill="#a8b5c2">fm-perf-audit-r2</text>
+      <text x="370" y="208" text-anchor="middle"
+            font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+            font-size="11" fill="#f4e8d0">crewmate → scout</text>
+    </g>
+
+    <!-- outcome row -->
+    <line x1="130" y1="218" x2="130" y2="244"
+          stroke="#c9a961" stroke-width="1.2"/>
+    <line x1="250" y1="218" x2="250" y2="244"
+          stroke="#c9a961" stroke-width="1.2"/>
+    <line x1="370" y1="218" x2="370" y2="244"
+          stroke="#c9a961" stroke-width="1.2"/>
+
+    <text x="130" y="262" text-anchor="middle"
+          font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+          font-size="13" font-weight="600" fill="#c9a961">PR #42</text>
+    <text x="250" y="262" text-anchor="middle"
+          font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+          font-size="13" font-weight="600" fill="#c9a961">PR #43</text>
+    <text x="370" y="262" text-anchor="middle"
+          font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+          font-size="13" font-weight="600" fill="#c9a961">report.md</text>
+  </g>
+</svg>

--- a/assets/readme/in-the-box.svg
+++ b/assets/readme/in-the-box.svg
@@ -1,0 +1,80 @@
+<svg xmlns="http://www.w3.org/2000/svg"
+     width="1200" height="220" viewBox="0 0 1200 220"
+     role="img" aria-labelledby="box-title box-desc">
+  <title id="box-title">What ships in the firstmate distro</title>
+  <desc id="box-desc">Three-column showcase of the repo's actual contents: 74 bin scripts for supervision tooling, 16 firstmate-loaded skills (agent-internal), and 1 public installer-facing skill under skills/.</desc>
+
+  <defs>
+    <linearGradient id="boxBg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#0a1929"/>
+      <stop offset="1" stop-color="#0d2238"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="1200" height="220" rx="16" fill="url(#boxBg)"/>
+  <rect x="0.75" y="0.75" width="1198.5" height="218.5" rx="15.25"
+        fill="none" stroke="#1a3a5c" stroke-width="1.5"/>
+
+  <text x="56" y="36"
+        font-family="ui-monospace, SFMono-Regular, Menlo, monospace"
+        font-size="11" letter-spacing="3" fill="#5d6d7e">WHAT SHIPS IN THE BOX</text>
+
+  <!-- column 1: bin/ -->
+  <g transform="translate(56 70)">
+    <text x="0" y="62"
+          font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+          font-size="80" font-weight="700" fill="#c9a961"
+          letter-spacing="-2">74</text>
+    <text x="0" y="92"
+          font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+          font-size="17" font-weight="600" fill="#f4e8d0">bin/ scripts</text>
+    <text x="0" y="118"
+          font-family="ui-monospace, SFMono-Regular, Menlo, monospace"
+          font-size="11" fill="#5d6d7e">fm-session-start · fm-spawn · fm-send</text>
+    <text x="0" y="132"
+          font-family="ui-monospace, SFMono-Regular, Menlo, monospace"
+          font-size="11" fill="#5d6d7e">fm-pr-merge · fm-teardown · ...</text>
+  </g>
+
+  <!-- divider -->
+  <line x1="432" y1="64" x2="432" y2="196"
+        stroke="#1a3a5c" stroke-width="1"/>
+
+  <!-- column 2: skills/ -->
+  <g transform="translate(472 70)">
+    <text x="0" y="62"
+          font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+          font-size="80" font-weight="700" fill="#c9a961"
+          letter-spacing="-2">16</text>
+    <text x="0" y="92"
+          font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+          font-size="17" font-weight="600" fill="#f4e8d0">firstmate skills</text>
+    <text x="0" y="118"
+          font-family="ui-monospace, SFMono-Regular, Menlo, monospace"
+          font-size="11" fill="#5d6d7e">.agents/skills/*  ·  metadata.internal=true</text>
+    <text x="0" y="132"
+          font-family="ui-monospace, SFMono-Regular, Menlo, monospace"
+          font-size="11" fill="#5d6d7e">afk · bearings · updatefirstmate · stow · ...</text>
+  </g>
+
+  <!-- divider -->
+  <line x1="848" y1="64" x2="848" y2="196"
+        stroke="#1a3a5c" stroke-width="1"/>
+
+  <!-- column 3: public skill -->
+  <g transform="translate(888 70)">
+    <text x="0" y="62"
+          font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+          font-size="80" font-weight="700" fill="#c9a961"
+          letter-spacing="-2">1</text>
+    <text x="0" y="92"
+          font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+          font-size="17" font-weight="600" fill="#f4e8d0">public skill</text>
+    <text x="0" y="118"
+          font-family="ui-monospace, SFMono-Regular, Menlo, monospace"
+          font-size="11" fill="#5d6d7e">skills/stow — installable standalone,</text>
+    <text x="0" y="132"
+          font-family="ui-monospace, SFMono-Regular, Menlo, monospace"
+          font-size="11" fill="#5d6d7e">no firstmate dependency</text>
+  </g>
+</svg>

--- a/assets/readme/lifecycle.svg
+++ b/assets/readme/lifecycle.svg
@@ -1,0 +1,78 @@
+<svg xmlns="http://www.w3.org/2000/svg"
+     width="1200" height="130" viewBox="0 0 1200 130"
+     role="img" aria-labelledby="lc-title lc-desc">
+  <title id="lc-title">firstmate request lifecycle</title>
+  <desc id="lc-desc">Three-stage horizontal flow: a captain chat request is routed through firstmate (brief, spawn, supervise, merge) into either a ship outcome (PR or local merge) or a scout outcome (investigation report).</desc>
+
+  <defs>
+    <linearGradient id="lcBg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#0d2238"/>
+      <stop offset="1" stop-color="#0a1929"/>
+    </linearGradient>
+    <marker id="lcArrow" viewBox="0 0 10 10" refX="9" refY="5"
+            markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#c9a961"/>
+    </marker>
+  </defs>
+
+  <rect width="1200" height="130" rx="16" fill="url(#lcBg)"/>
+  <rect x="0.75" y="0.75" width="1198.5" height="128.5" rx="15.25"
+        fill="none" stroke="#1a3a5c" stroke-width="1.5"/>
+
+  <text x="56" y="32"
+        font-family="ui-monospace, SFMono-Regular, Menlo, monospace"
+        font-size="11" letter-spacing="3" fill="#5d6d7e">REQUEST LIFECYCLE</text>
+
+  <text x="1144" y="32" text-anchor="end"
+        font-family="ui-monospace, SFMono-Regular, Menlo, monospace"
+        font-size="10" fill="#5d6d7e">captain → firstmate → outcome</text>
+
+  <!-- Stage 1: captain -->
+  <g transform="translate(56 56)">
+    <rect x="0" y="0" width="200" height="44" rx="8"
+          fill="#0a1929" stroke="#c9a961" stroke-width="1.5"/>
+    <text x="100" y="18" text-anchor="middle"
+          font-family="ui-monospace, SFMono-Regular, Menlo, monospace"
+          font-size="10" letter-spacing="2" fill="#5d6d7e">CAPTAIN</text>
+    <text x="100" y="36" text-anchor="middle"
+          font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+          font-size="13" fill="#f4e8d0">"fix the flaky test"</text>
+  </g>
+
+  <line x1="260" y1="78" x2="296" y2="78"
+        stroke="#c9a961" stroke-width="1.5" marker-end="url(#lcArrow)"/>
+
+  <!-- Stage 2: firstmate (wider, the engine) -->
+  <g transform="translate(308 50)">
+    <rect x="0" y="0" width="448" height="56" rx="10"
+          fill="#0a1929" stroke="#c9a961" stroke-width="1.5"/>
+    <text x="224" y="20" text-anchor="middle"
+          font-family="ui-monospace, SFMono-Regular, Menlo, monospace"
+          font-size="10" letter-spacing="2" fill="#5d6d7e">FIRSTMATE</text>
+    <text x="224" y="42" text-anchor="middle"
+          font-family="ui-monospace, SFMono-Regular, Menlo, monospace"
+          font-size="12" fill="#f4e8d0">brief → spawn → supervise → merge</text>
+  </g>
+
+  <line x1="760" y1="78" x2="796" y2="78"
+        stroke="#c9a961" stroke-width="1.5" marker-end="url(#lcArrow)"/>
+
+  <!-- Stage 3: outcomes -->
+  <g transform="translate(808 56)">
+    <rect x="0" y="0" width="200" height="20" rx="6"
+          fill="#0a1929" stroke="#c9a961" stroke-width="1.2"/>
+    <text x="100" y="14" text-anchor="middle"
+          font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+          font-size="12" fill="#f4e8d0">ship → PR or local merge</text>
+
+    <rect x="0" y="26" width="200" height="20" rx="6"
+          fill="none" stroke="#5d6d7e" stroke-width="1.2"/>
+    <text x="100" y="40" text-anchor="middle"
+          font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+          font-size="12" fill="#f4e8d0">scout → data/&lt;id&gt;/report.md</text>
+  </g>
+
+  <text x="1144" y="116" text-anchor="end"
+        font-family="ui-monospace, SFMono-Regular, Menlo, monospace"
+        font-size="10" fill="#5d6d7e">PR / merge gated by configured authority · scout delivers a self-contained report</text>
+</svg>


### PR DESCRIPTION
## docs(readme): redesign whole README via beautify-github-readme skill

Redesigns the firstmate README in whole-README mode using the `beautify-github-readme` skill already installed under `.agents/skills/beautify-github-readme/`.

### Visual system (frozen before drawing)

| | |
| --- | --- |
| Audience | single technical operator (the captain) running multiple parallel coding tasks across many repos |
| One-sentence value | a portable runtime, tooling, and supervision contract for fleets of coding agents |
| Primary proof | 74 bin/ scripts, 16 firstmate-loaded skills, 1 public skill — all real and in this repo |
| First successful action | `git clone … && cd firstmate && claude` (or any verified harness) |
| Visual theme | nautical — captain / first mate / crew / ship / scout (already the project's brand) |

Palette: deep navy gradient `#0a1929 → #0d2238`, brass accent `#c9a961`, parchment foreground `#f4e8d0`, muted fog `#5d6d7e`. System sans + mono only — no remote fonts, no animation, no invented claims. Recurring cue is a single subtle compass-rose in the top-right of the hero at 35% opacity.

### What changed

- New SVG hero (`assets/readme/hero.svg`) replaces the raster `assets/banner.png` — ships its own dark background so it stays legible on GitHub light AND dark page chrome.
- New "How it works" section banner (`assets/readme/lifecycle.svg`) — three-stage horizontal flow (captain → firstmate → ship / scout).
- New "What's in the box" showcase (`assets/readme/in-the-box.svg`) — three-column numeric wall (74 / 16 / 1) verified against `bin/`, `.agents/skills/`, `skills/`.
- Restructured README into the skill's recommended sequence: hero → what it is → what's in the box → how it works → quick start → features → backends → built-in skills → documentation → contributing → license.
- Trimmed repeated promises; folded the `Recommended harnesses` mechanics paragraph into a single line and pointed at `docs/` for harness-specific detail; collapsed the duplicate "Two-tier skill layout" subsection into one line under the Built-in skills table with a deep link to `docs/configuration.md#two-tier-skill-layout`.

### What did not change

- `AGENTS.md`, `bin/`, `.agents/skills/`, `.github/workflows/`, `.tasks.toml`, `docs/` — scope guard held.
- The tagline wording ("Talk to one agent. Ship with a crew.") — the skill explicitly warns against changing project voice without need.
- `assets/banner.png` — left on disk, no longer referenced.

### Captain's verification path

- Rendered PNG previews live at `data/firstmate-readme-beautify-c1/preview/{hero,lifecycle,in-the-box}.png` (firstmate home).
- Captain-facing writeup with the full visual-system freeze + change rationale lives at `data/firstmate-readme-beautify-c1/preview.md`.
- `python3 .agents/skills/beautify-github-readme/scripts/audit_readme.py README.md` was run on the draft and reported OK (3 local image references, SVG basics passed).

### Diff summary

```
README.md                          | 205 ++++++++++++-------- (79 +, 126 -)
assets/readme/hero.svg             | new
assets/readme/lifecycle.svg        | new
assets/readme/in-the-box.svg       | new
```