### PR TITLE
fix(bin): parse handoff homes after registry parentheticals

### DIFF
--- a/bin/fm-backlog-handoff.sh
+++ b/bin/fm-backlog-handoff.sh
@@ -63,7 +63,11 @@ secondmate_home() {
   [ -f "$REG" ] || { echo "error: no secondmate registry at $REG" >&2; return 1; }
   line=$(grep -E "^- $id( |$)" "$REG" | tail -1 || true)
   [ -n "$line" ] || { echo "error: secondmate $id is not registered in $REG" >&2; return 1; }
-  printf '%s\n' "$line" | sed -n 's/^[^(]*(home: \([^;)]*\);.*/\1/p'
+  # Match the (home: ...) field itself; do not require zero parentheses before it.
+  # Summary/scope prose often contains parentheticals (e.g. "(id is legacy)"), and
+  # ^[^(]* would leave those entries looking like "has no home". Greedy prefix so the
+  # last (home: ...) on the line wins. Empty when the field is absent.
+  printf '%s\n' "$line" | sed -n 's/.*(home:[[:space:]]*\([^;)]*\);.*/\1/p' | sed 's/[[:space:]]*$//'
 }
 
 path_is_ancestor_of() {

--- a/tests/fm-backlog-handoff.test.sh
+++ b/tests/fm-backlog-handoff.test.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # tests/fm-backlog-handoff.test.sh - full item-block handoff (header + indented body).
 #
-# The happy single-line path and safety refusals live in the secondmate lifecycle
-# and safety suites. This file owns the multi-line body contract: the full block
-# moves byte-exact, nothing orphans in the source, and re-running is a no-op.
+# The happy single-line path and broad safety refusals live in the secondmate
+# lifecycle and safety suites. This file owns focused delegated-handoff
+# regressions: the multi-line body contract and registry home parsing edge cases.
 set -u
 
 # shellcheck source=tests/secondmate-helpers.sh disable=SC1091

--- a/tests/fm-backlog-handoff.test.sh
+++ b/tests/fm-backlog-handoff.test.sh
@@ -472,6 +472,71 @@ EOF
   pass "multi-paragraph body with internal blank lines moves whole and is idempotent"
 }
 
+# Registry lines may carry parentheticals in the summary before the structured
+# (home: ...) field (e.g. "(id is legacy)"). The home extractor must still find
+# the field; the old ^[^(]* regex treated those entries as home-less.
+test_registry_home_with_pre_home_parentheses() {
+  local home="$TMP_ROOT/reg-parens-main"
+  local sub="$TMP_ROOT/reg-parens-sub"
+  local id=oss-triage-t4
+  setup_homes "$home" "$sub" "$id"
+  local sub_abs
+  sub_abs=$(cd "$sub" && pwd -P)
+  # Prose parentheses before (home: ...), matching live registry shape.
+  printf -- '- %s - issue triage (id is legacy) (home: %s; scope: issue triage; projects: alpha; added 2026-07-09)\n' \
+    "$id" "$sub_abs" > "$home/data/secondmates.md"
+
+  cat > "$home/data/backlog.md" <<'EOF'
+## Queued
+- [ ] paren-item - should hand off (repo: alpha)
+  body line
+
+## Done
+EOF
+
+  FM_HOME="$home" "$ROOT/bin/fm-backlog-handoff.sh" "$id" paren-item >/dev/null \
+    || fail "handoff failed for registry entry with parentheses before (home: ...)"
+
+  assert_grep 'paren-item' "$sub/data/backlog.md" \
+    "item did not arrive when registry summary had pre-home parentheses"
+  assert_no_grep 'paren-item' "$home/data/backlog.md" \
+    "item still in source after handoff with pre-home parentheses"
+
+  pass "registry home parses when summary has parentheses before (home: ...)"
+}
+
+# An entry that genuinely lacks (home: ...) must still fail cleanly (empty parse
+# surfaces as "has no home"), not succeed or mis-parse prose.
+test_registry_home_missing_field_fails_cleanly() {
+  local home="$TMP_ROOT/reg-nohome-main"
+  local sub="$TMP_ROOT/reg-nohome-sub"
+  local id=no-home-mate
+  mkdir -p "$home/data" "$home/state"
+  seed_secondmate_home_marker "$sub" "$id"
+  # Registered, but no structured (home: ...) field at all.
+  printf -- '- %s - charter only (scope prose mentions home: /tmp/ignored-path)\n' \
+    "$id" > "$home/data/secondmates.md"
+
+  cat > "$home/data/backlog.md" <<'EOF'
+## Queued
+- [ ] orphan-item - never moves (repo: alpha)
+
+## Done
+EOF
+
+  local out rc=0
+  out=$(FM_HOME="$home" "$ROOT/bin/fm-backlog-handoff.sh" "$id" orphan-item 2>&1) || rc=$?
+  [ "$rc" -ne 0 ] || fail "handoff succeeded for registry entry with no (home: ...) field"
+  assert_contains "$out" "has no home" \
+    "missing (home: ...) field did not report the clean 'has no home' error"
+  assert_grep 'orphan-item' "$home/data/backlog.md" \
+    "source backlog was mutated despite missing home"
+  [ ! -f "$sub/data/backlog.md" ] || ! grep -q 'orphan-item' "$sub/data/backlog.md" 2>/dev/null \
+    || fail "item appeared in secondmate backlog despite missing home"
+
+  pass "registry entry without (home: ...) fails cleanly with has no home"
+}
+
 test_body_moves_when_followed_by_another_item
 test_body_moves_when_followed_by_section_heading
 test_multi_paragraph_body_with_internal_blanks_moves_whole
@@ -481,5 +546,7 @@ test_untouched_eof_line_preserves_terminator
 test_body_handoff_is_idempotent
 test_noncanonical_indented_continuations_refuse_without_changes
 test_indented_heading_is_not_section_boundary
+test_registry_home_with_pre_home_parentheses
+test_registry_home_missing_field_fails_cleanly
 
 echo "ALL TESTS PASSED"


### PR DESCRIPTION
## Intent

Fix bin/fm-backlog-handoff.sh's secondmate registry home parser so it still extracts (home: ...) when the summary/charter prose contains parentheses before that field. Root cause: sed used ^[^(]*(home: ...), which requires zero parentheses before (home:) and caused most live registry entries (e.g. those with '(id is legacy)') to look like 'has no home'. Fix: greedy match of the last (home: ...) field (aligned with fm-ff-lib.sh), still empty/failing cleanly when the field is absent. Add tests under tests/fm-backlog-handoff.test.sh for prose-with-parens and no-home cases. Keep the diff focused to this script; no scope/projects sibling extractors exist here.

## What Changed

- Updated `bin/fm-backlog-handoff.sh` to extract the last structured `(home: ...)` field even when earlier registry prose contains parentheses.
- Preserved the clean missing-home failure path when a secondmate registry entry has no structured `(home: ...)` field.
- Expanded `tests/fm-backlog-handoff.test.sh` with regression coverage for pre-home parentheticals and missing home fields.

## Risk Assessment

✅ Low: The change is tightly scoped to the handoff home-field parser, matches the existing fm-ff-lib extraction pattern, and adds focused coverage for both the parenthetical-prose case and the missing-field failure path.

## Testing

The configured full shell-test baseline had already passed; I reran the focused handoff suite successfully and captured an end-to-end CLI transcript showing the parser moves the item with parenthesized prose, fails cleanly when the structured home field is absent, and uses the final `(home: ...)` field.

<details>
<summary>Evidence: fm-backlog-handoff home parser E2E transcript</summary>

```text
fm-backlog-handoff.sh home-parser E2E evidence
worktree: /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KXS9J2YD5Q140K6R4R642KHG

=== Case 1: registry prose has parentheses before structured (home: ...) ===
$ cat parens-main/data/secondmates.md
- oss-triage-t4 - issue triage (id is legacy) (home: /private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KXS9J2YD5Q140K6R4R642KHG/fm-backlog-handoff-home-parser-e2e/parens-sub; scope: issue triage; projects: alpha; added 2026-07-09)
$ cat parens-main/data/backlog.md
## Queued
- [ ] paren-item - should hand off (repo: alpha)
  body line

## Done
$ FM_HOME=/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KXS9J2YD5Q140K6R4R642KHG/fm-backlog-handoff-home-parser-e2e/parens-main bin/fm-backlog-handoff.sh oss-triage-t4 paren-item
handed off 1 item(s) to oss-triage-t4: paren-item
  into /private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KXS9J2YD5Q140K6R4R642KHG/fm-backlog-handoff-home-parser-e2e/parens-sub/data/backlog.md
$ cat parens-main/data/backlog.md
## Queued
## Done
$ cat parens-sub/data/backlog.md
## In flight

## Queued
- [ ] paren-item - should hand off (repo: alpha)
  body line

## Done

=== Case 2: registered secondmate line has no structured (home: ...) field ===
$ cat nohome-main/data/secondmates.md
- no-home-mate - charter only (scope prose mentions home: /private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KXS9J2YD5Q140K6R4R642KHG/fm-backlog-handoff-home-parser-e2e/nohome-sub)
$ FM_HOME=/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KXS9J2YD5Q140K6R4R642KHG/fm-backlog-handoff-home-parser-e2e/nohome-main bin/fm-backlog-handoff.sh no-home-mate orphan-item
error: secondmate no-home-mate has no home in /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KXS9J2YD5Q140K6R4R642KHG/fm-backlog-handoff-home-parser-e2e/nohome-main/data/secondmates.md
exit code: 1
$ cat nohome-main/data/backlog.md
## Queued
- [ ] orphan-item - never moves (repo: alpha)

## Done
nohome-sub/data/backlog.md was not created

=== Case 3: when more than one (home: ...) appears, the last field wins ===
$ cat last-main/data/secondmates.md
- last-home-mate - charter prose mentions an old field (home: /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KXS9J2YD5Q140K6R4R642KHG/fm-backlog-handoff-home-parser-e2e/bogus-home-that-should-not-be-used; stale) (home: /private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KXS9J2YD5Q140K6R4R642KHG/fm-backlog-handoff-home-parser-e2e/last-sub; scope: current charter; projects: alpha; added 2026-07-09)
$ FM_HOME=/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KXS9J2YD5Q140K6R4R642KHG/fm-backlog-handoff-home-parser-e2e/last-main bin/fm-backlog-handoff.sh last-home-mate last-home-item
handed off 1 item(s) to last-home-mate: last-home-item
  into /private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KXS9J2YD5Q140K6R4R642KHG/fm-backlog-handoff-home-parser-e2e/last-sub/data/backlog.md
$ test ! -e /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KXS9J2YD5Q140K6R4R642KHG/fm-backlog-handoff-home-parser-e2e/bogus-home-that-should-not-be-used
bogus earlier home was not used
$ cat last-sub/data/backlog.md
## In flight

## Queued
- [ ] last-home-item - should use the final home field (repo: alpha)
  body line

## Done
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- <code>Baseline already completed before this validation: `command -v tmux &gt;/dev/null || { echo &#34;tmux is required for e2e tests&#34; &gt;&amp;2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo &#34;== $t ==&#34;; bash &#34;$t&#34; || rc=1; done; exit &#34;$rc&#34;`</code>
- `bash tests/fm-backlog-handoff.test.sh`
- <code>Created throwaway firstmate/secondmate homes under `/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KXS9J2YD5Q140K6R4R642KHG/fm-backlog-handoff-home-parser-e2e` and ran `FM_HOME=&lt;fixture&gt; bin/fm-backlog-handoff.sh ...` for registry prose with pre-home parentheses, missing structured `(home: ...)`, and multiple `(home: ...)` fields where the last field must win.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
