### PR TITLE
feat: add native session-start nudges

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -64,6 +64,18 @@ Every verified primary harness also has a wired PreToolUse-equivalent hook that 
 The exact hook files, commands, output-shaping quirks (Claude Code only honors the deny when stdout is empty), and validation transcripts are owned by `docs/arm-pretool-check.md`.
 When changing any primary PreToolUse hook, validate the real harness behavior in a scratch project before trusting it, then update that doc.
 
+## Primary session-start nudge
+
+AGENTS.md section 3 remains the behavioral owner for session start, while tracked native adapters invoke `bin/fm-sessionstart-nudge.sh` as an idempotent enforcement layer.
+The wrapper prints only the instruction to run `bin/fm-session-start.sh`; it never runs the digest, wake drain, bootstrap sweeps, lock, or supervision arm itself.
+Full mechanics, scoping, dated commands, payloads, and fail-open evidence live in `docs/sessionstart-nudge.md`.
+
+- `claude`: verified native `SessionStart` stdout injection; `.claude/settings.json` matches `startup`, `resume`, and `clear`, but not `compact`.
+- `codex`: verified on 0.144.4; `.codex/hooks.json` receives `source=startup`, and wrapper stdout reaches model context.
+- `opencode`: verified on 1.17.18; `session.created` plus `client.session.promptAsync` starts the nudge turn in the TUI, while `opencode run` remains fail-open headless.
+- `pi`: verified native `session_start`; the existing primary extension handles `startup`, `new`, and `resume` and uses `pi.sendMessage` to inject context without racing a positional launch prompt.
+- `grok`: the 0.2.103 project `SessionStart` event fires with `source=new`, but stdout does not reach model context; the tracked project hook remains fail-open, and a global token-guarded fallback requires a captain decision.
+
 ## Primary watcher supervision
 
 At session start, `bin/fm-session-start.sh` prints exactly one watcher supervision block for the detected primary harness.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,16 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/bin/fm-sessionstart-nudge.sh"
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Bash",

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,5 +1,16 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -lc 'payload=$(cat 2>/dev/null || true); [ -n \"$payload\" ] || exit 0; command -v jq >/dev/null 2>&1 || exit 0; root=$(pwd -P) || exit 0; [ -x \"$root/bin/fm-sessionstart-nudge.sh\" ] || exit 0; [ -f \"$root/AGENTS.md\" ] || exit 0; [ -f \"$root/.codex/hooks.json\" ] || exit 0; jq -e \"any(.hooks.SessionStart[]?.hooks[]?.command?; type == \\\"string\\\" and contains(\\\"fm-sessionstart-nudge.sh\\\"))\" \"$root/.codex/hooks.json\" >/dev/null 2>&1 || exit 0; exec \"$root/bin/fm-sessionstart-nudge.sh\"'",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Bash",

--- a/.grok/hooks/fm-primary-sessionstart-nudge.json
+++ b/.grok/hooks/fm-primary-sessionstart-nudge.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -lc '[ -n \"${GROK_WORKSPACE_ROOT:-}\" ] || exit 0; exec \"${GROK_WORKSPACE_ROOT:-}/bin/fm-sessionstart-nudge.sh\"'",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.opencode/plugins/fm-primary-sessionstart-nudge.js
+++ b/.opencode/plugins/fm-primary-sessionstart-nudge.js
@@ -1,0 +1,60 @@
+import { spawn } from "node:child_process";
+import { realpathSync } from "node:fs";
+import { resolve } from "node:path";
+
+const handledSessions = new Set();
+
+function runProcess(command, args) {
+  return new Promise((resolveResult) => {
+    const child = spawn(command, args, { stdio: ["ignore", "pipe", "ignore"] });
+    let stdout = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.on("error", () => resolveResult({ code: 0, stdout: "" }));
+    child.on("close", (code) => resolveResult({ code: code ?? 0, stdout }));
+  });
+}
+
+function resolvePath(anchor) {
+  try {
+    return realpathSync(anchor);
+  } catch {
+    return resolve(anchor);
+  }
+}
+
+async function resolveRoot(anchor) {
+  if (!anchor) return "";
+  const result = await runProcess("git", ["-C", anchor, "rev-parse", "--show-toplevel"]);
+  const root = result.stdout.trim();
+  if (result.code === 0 && root) return root;
+  return resolvePath(anchor);
+}
+
+export const FmPrimarySessionstartNudge = async ({ client, directory, worktree }) => {
+  const root = worktree ? resolvePath(worktree) : await resolveRoot(directory);
+
+  return {
+    event: async ({ event }) => {
+      if (event.type !== "session.created") return;
+      const sessionID = event.properties?.info?.id ?? event.properties?.sessionID;
+      if (!sessionID || handledSessions.has(sessionID) || !root) return;
+      handledSessions.add(sessionID);
+
+      const result = await runProcess(`${root}/bin/fm-sessionstart-nudge.sh`, []);
+      const nudge = result.code === 0 ? result.stdout.trim() : "";
+      if (!nudge) return;
+
+      try {
+        await client.session.promptAsync({
+          path: { id: sessionID },
+          body: {
+            parts: [{ type: "text", text: nudge }],
+          },
+        });
+      } catch {
+      }
+    },
+  };
+};

--- a/.pi/extensions/fm-primary-turnend-guard.ts
+++ b/.pi/extensions/fm-primary-turnend-guard.ts
@@ -1,6 +1,6 @@
 import { spawn, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
@@ -50,9 +50,14 @@ function lockOwnership(): LockOwnership {
 }
 
 function markLoaded(): void {
-  if (lockOwnership() === "other") return;
-  mkdirSync(state, { recursive: true });
+  if (!existsSync(state) || lockOwnership() === "other") return;
   writeFileSync(marker, `${extensionVersion}\n${process.pid}\n`);
+}
+
+function runSessionstartNudge(): string {
+  const result = spawnSync(`${root}/bin/fm-sessionstart-nudge.sh`, [], { encoding: "utf8" });
+  if (result.status !== 0) return "";
+  return result.stdout.trim();
 }
 
 function runGuard(): Promise<{ code: number; stderr: string }> {
@@ -100,8 +105,15 @@ function runCdCheck(command: string): Promise<{ code: number; stderr: string }> 
 }
 
 export default function (pi: ExtensionAPI) {
-  pi.on?.("session_start", () => {
+  pi.on?.("session_start", (event) => {
+    const reason = String((event as { reason?: unknown }).reason ?? "");
+    const nudge = ["startup", "new", "resume"].includes(reason) ? runSessionstartNudge() : "";
     markLoaded();
+    if (!nudge) return;
+    try {
+      pi.sendMessage({ customType: "firstmate-sessionstart-nudge", content: nudge, display: false });
+    } catch {
+    }
   });
 
   pi.on("tool_call", async (event) => {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,7 @@ Treat `data/captain.md` as the domain-local record of captain preferences, optio
 Run `bin/fm-session-start.sh` exactly once at session start.
 Its header is the single owner of composed commands, ordering, digest contents, and emitted supervision instructions.
 Do not reimplement it by separately running its lock, bootstrap, or initial wake-drain components.
+Tracked native session-open adapters only nudge this command; `docs/sessionstart-nudge.md` owns their enforcement mechanics and verification evidence.
 
 Read the complete digest once and trust it as this turn's startup and recovery input.
 Do not separately re-read the context, backlog, metadata, or bulk status inputs it just printed unless a source was reported absent or corrupt, older history is specifically needed, or a targeted workflow must inspect before writing.

--- a/bin/fm-gate-refuse-lib.sh
+++ b/bin/fm-gate-refuse-lib.sh
@@ -53,7 +53,8 @@
 # neutral-execution-context and the HEAD-continuity guard. The dedicated
 # tests/fm-gate-refuse.test.sh strips the bypass so it still verifies real refusal.
 #
-# Sourced by bin/fm-spawn.sh, bin/fm-send.sh, bin/fm-teardown.sh, and the tests.
+# Sourced by bin/fm-spawn.sh, bin/fm-send.sh, bin/fm-teardown.sh,
+# bin/fm-sessionstart-nudge.sh, and the tests.
 # No side effects on source. set -u / set -e safe. The refusal is a hard exit,
 # not a return, because there is no safe way to continue a fleet mutation from a
 # gate context.
@@ -62,23 +63,40 @@
 # test as "the gate refusal fired" rather than an ordinary usage error.
 FM_GATE_REFUSE_EXIT=3
 
+# fm_is_gate_agent: return 0 without output when this process looks like a
+# no-mistakes gate agent. An optional root anchors the git-common-dir check;
+# callers that omit it retain the historical current-worktree behavior.
+fm_is_gate_agent() {
+  local anchor=${1:-.} common
+  if [ "${FM_GATE_REFUSE_BYPASS:-}" = 1 ]; then
+    return 1
+  fi
+  if [ "${NO_MISTAKES_GATE+x}" = x ]; then
+    FM_GATE_REFUSE_REASON='env'
+    return 0
+  fi
+  common=$(cd "$anchor" 2>/dev/null \
+    && cd "$(git rev-parse --git-common-dir 2>/dev/null || echo /nonexistent)" 2>/dev/null \
+    && pwd -P || true)
+  case "$common" in
+    */.no-mistakes/repos/*.git)
+      FM_GATE_REFUSE_REASON='path'
+      FM_GATE_REFUSE_COMMON=$common
+      return 0 ;;
+  esac
+  return 1
+}
+
 # fm_refuse_if_gate_agent: exit FM_GATE_REFUSE_EXIT with a clear stderr message if
 # this process looks like a no-mistakes gate agent. Call before any fleet
 # mutation. No-ops (returns 0) for a normal firstmate session, or when firstmate's
 # own test harness sets FM_GATE_REFUSE_BYPASS=1 (see the header).
 fm_refuse_if_gate_agent() {
-  if [ "${FM_GATE_REFUSE_BYPASS:-}" = 1 ]; then
-    return 0
-  fi
-  if [ "${NO_MISTAKES_GATE+x}" = x ]; then
+  fm_is_gate_agent "${1:-.}" || return 0
+  if [ "$FM_GATE_REFUSE_REASON" = env ]; then
     echo "error: no-mistakes gate agent must not drive the fleet (NO_MISTAKES_GATE set)" >&2
-    exit "$FM_GATE_REFUSE_EXIT"
+  else
+    echo "error: refusing fleet lifecycle from inside a no-mistakes gate worktree ($FM_GATE_REFUSE_COMMON)" >&2
   fi
-  local common
-  common=$(cd "$(git rev-parse --git-common-dir 2>/dev/null || echo /nonexistent)" 2>/dev/null && pwd -P || true)
-  case "$common" in
-    */.no-mistakes/repos/*.git)
-      echo "error: refusing fleet lifecycle from inside a no-mistakes gate worktree ($common)" >&2
-      exit "$FM_GATE_REFUSE_EXIT" ;;
-  esac
+  exit "$FM_GATE_REFUSE_EXIT"
 }

--- a/bin/fm-primary-scope-lib.sh
+++ b/bin/fm-primary-scope-lib.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Shared marker-or-plain-checkout predicate for tracked hooks that must act only
+# in a genuine firstmate primary home.
+# This file is sourced by hook entrypoints and has no side effects on source.
+
+# Return 0 when $1 carries a genuine secondmate-home marker.
+fm_root_is_secondmate_home() {
+  local marker="$1/.fm-secondmate-home" id LC_ALL=C
+  [ -L "$marker" ] && return 1
+  [ -f "$marker" ] || return 1
+  IFS= read -r id < "$marker" 2>/dev/null || return 1
+  id=${id//[[:space:]]/}
+  [ -n "$id" ] || return 1
+  case "$id" in
+    *[!A-Za-z0-9._-]*) return 1 ;;
+  esac
+  return 0
+}
+
+# Return 0 when $1 is a genuine primary root whose effective state dir is $2.
+# A valid secondmate marker force-includes a linked secondmate home.
+# Otherwise only a plain checkout is primary, never a linked task worktree.
+fm_primary_scope_matches() {
+  local root=$1 state=$2 git_dir git_common_dir
+  if ! fm_root_is_secondmate_home "$root"; then
+    git_dir=$(git -C "$root" rev-parse --git-dir 2>/dev/null) || return 1
+    git_common_dir=$(git -C "$root" rev-parse --git-common-dir 2>/dev/null) || return 1
+    [ "$git_dir" = "$git_common_dir" ] || return 1
+  fi
+  [ -f "$root/AGENTS.md" ] || return 1
+  [ -d "$root/bin" ] || return 1
+  [ -d "$state" ] || return 1
+}

--- a/bin/fm-sessionstart-nudge.sh
+++ b/bin/fm-sessionstart-nudge.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Print the one-line session-start instruction only for a genuine firstmate
+# primary whose current harness session has not already acquired the home lock.
+# Every silence and error path exits 0 because Claude SessionStart exit 2 blocks
+# session initialization.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+
+# shellcheck source=bin/fm-gate-refuse-lib.sh
+. "$SCRIPT_DIR/fm-gate-refuse-lib.sh"
+# shellcheck source=bin/fm-primary-scope-lib.sh
+. "$SCRIPT_DIR/fm-primary-scope-lib.sh"
+
+fm_is_gate_agent "$FM_ROOT" && exit 0
+fm_primary_scope_matches "$FM_ROOT" "$STATE" || exit 0
+
+lock_is_in_ancestry() {
+  local lock_pid pid=$$ _
+  [ -f "$STATE/.lock" ] || return 1
+  IFS= read -r lock_pid < "$STATE/.lock" 2>/dev/null || return 1
+  case "$lock_pid" in
+    ''|*[!0-9]*|1) return 1 ;;
+  esac
+  kill -0 "$lock_pid" 2>/dev/null || return 1
+  for _ in 1 2 3 4 5 6 7 8; do
+    [ "$pid" = "$lock_pid" ] && return 0
+    pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
+    [ -n "$pid" ] && [ "$pid" -gt 1 ] || return 1
+  done
+  return 1
+}
+
+lock_is_in_ancestry && exit 0
+printf '%s\n' "Run \`bin/fm-session-start.sh\` now, exactly once, before executing any other instructions."
+exit 0

--- a/bin/fm-turnend-guard.sh
+++ b/bin/fm-turnend-guard.sh
@@ -47,6 +47,8 @@ WATCH="$SCRIPT_DIR/fm-watch.sh"
 
 # shellcheck source=bin/fm-supervision-lib.sh
 . "$SCRIPT_DIR/fm-supervision-lib.sh"
+# shellcheck source=bin/fm-primary-scope-lib.sh
+. "$SCRIPT_DIR/fm-primary-scope-lib.sh"
 
 # Read the whole turn-end hook payload once; never block on unreadable/absent
 # stdin.
@@ -61,32 +63,6 @@ command -v jq >/dev/null 2>&1 || exit 0
 STOP_HOOK_ACTIVE=$(printf '%s' "$PAYLOAD" | jq -r '.stop_hook_active // false' 2>/dev/null) || exit 0
 [ "$STOP_HOOK_ACTIVE" = "true" ] && exit 0
 
-# Return 0 when $1 (a firstmate root) carries a GENUINE secondmate-home marker.
-# bin/fm-home-seed.sh writes .fm-secondmate-home at a seeded secondmate home's
-# root (gitignored, so it never propagates into a child worktree); its content is
-# the secondmate id. Validate the marker's form so a stray/empty/symlink file
-# cannot spoof inclusion and an unmarked child is never guarded by accident: it
-# must be a regular (non-symlink) file whose first line, with all whitespace
-# removed, is a non-empty id token (letters, digits, dot, underscore, dash only).
-# The allowlist is matched under forced C (ASCII) collation - `local LC_ALL=C`,
-# restored on return - so a locale-crafted non-ASCII id cannot slip through the
-# range match and spoof force-inclusion. This is a deliberately lightweight
-# guard-local presence check, distinct from fm-ff-lib.sh's validate_secondmate_home
-# (which matches an EXPECTED id and does path-safety); the guard does not source
-# that heavier library.
-fm_root_is_secondmate_home() {
-  local marker="$1/.fm-secondmate-home" id LC_ALL=C
-  [ -L "$marker" ] && return 1
-  [ -f "$marker" ] || return 1
-  IFS= read -r id < "$marker" 2>/dev/null || return 1
-  id=${id//[[:space:]]/}
-  [ -n "$id" ] || return 1
-  case "$id" in
-    *[!A-Za-z0-9._-]*) return 1 ;;
-  esac
-  return 0
-}
-
 # --- scope precisely to a PRIMARY checkout ----------------------------------
 # A genuinely-marked secondmate home runs its OWN primary firstmate session, so
 # force-INCLUDE it as a guarded primary whether treehouse leased it as a linked
@@ -99,14 +75,7 @@ fm_root_is_secondmate_home() {
 # and differs from the common (shared) git-dir, while a main, non-worktree
 # checkout has the two equal. Child worktrees never carry the gitignored marker,
 # so this exempts them while guarding every real secondmate home.
-if ! fm_root_is_secondmate_home "$FM_ROOT"; then
-  GIT_DIR=$(git -C "$FM_ROOT" rev-parse --git-dir 2>/dev/null) || exit 0
-  GIT_COMMON_DIR=$(git -C "$FM_ROOT" rev-parse --git-common-dir 2>/dev/null) || exit 0
-  [ "$GIT_DIR" = "$GIT_COMMON_DIR" ] || exit 0
-fi
-[ -f "$FM_ROOT/AGENTS.md" ] || exit 0
-[ -d "$FM_ROOT/bin" ] || exit 0
-[ -d "$STATE" ] || exit 0
+fm_primary_scope_matches "$FM_ROOT" "$STATE" || exit 0
 
 # --- the actual predicate ----------------------------------------------------
 # shellcheck source=bin/fm-wake-lib.sh

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,7 +18,8 @@ The tracked code root contains the shared instruction, skill, documentation, wor
 The producing PR and X helpers own the fields they append, `bin/fm-classify-lib.sh` owns status-event vocabulary, and `bin/fm-crew-state.sh` owns current-state reconciliation.
 Wake, watcher, away-mode, and X-specific state mechanics remain with their named scripts and reference sections rather than being duplicated into one exhaustive state tree here.
 
-`bin/fm-session-start.sh`'s header is the single owner of session-start ordering, composed commands, digest contents, and startup mechanism.
+`bin/fm-session-start.sh`'s header is the single owner of session-start ordering, composed commands, digest contents, and the digest's startup mechanism.
+`docs/sessionstart-nudge.md` owns the native session-open adapter mechanics that nudge the digest command.
 `AGENTS.md` retains the run-once and read-once operator rules, lock-refusal safety, installation consent, and direct-report recovery boundaries because those facts apply at every session start.
 Ordinary dead-direct-report recovery is owned by `stuck-crewmate-recovery`, while persistent-secondmate recovery is owned by `secondmate-provisioning`.
 

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -3,11 +3,12 @@
 The first mate drives these; interactive entrypoints work by hand too, while `*-lib.sh` files are sourced helpers.
 Each row is one purpose clause only: the script's own header comment is the authoritative description of its behavior, flags, and contracts, so read the header before first use.
 If you have changed away from the firstmate home in an interactive shell, invoke these scripts by absolute path through the repo's `bin/` directory; the scripts self-locate internally after they start.
-The shared no-mistakes gate refusal used by `fm-spawn.sh`, `fm-send.sh`, and `fm-teardown.sh` is summarized in [architecture.md](architecture.md#no-mistakes-gate-authority-boundary); `fm-gate-refuse-lib.sh`'s header owns its exact contract.
+The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarized in [architecture.md](architecture.md#no-mistakes-gate-authority-boundary), while `docs/sessionstart-nudge.md` covers the silent hook-nudge use; `fm-gate-refuse-lib.sh`'s header owns its exact contract.
 
 | Script                   | Purpose                                                                              |
 | ------------------------ | ------------------------------------------------------------------------------------ |
 | `fm-session-start.sh`    | Compose lock, bootstrap, and wake drain into the single ordered session-start digest |
+| `fm-sessionstart-nudge.sh` | Print the native session-start hook nudge when the primary has not already run the digest |
 | `fm-bootstrap.sh`        | Detect toolchain and fleet problems, run the locked session-start sweeps, and install approved tools |
 | `fm-fleet-sync.sh`       | Refresh project clones with safe fast-forwards, self-heals, `STUCK:` reports, branch pruning, and bounded recovery from an orphaned `.git/packed-refs.lock` |
 | `fm-fleet-snapshot.sh`   | Print the read-only structured fleet snapshot JSON (schema `fm-fleet-snapshot.v1`)   |
@@ -20,6 +21,7 @@ The shared no-mistakes gate refusal used by `fm-spawn.sh`, `fm-send.sh`, and `fm
 | `fm-herdr-lab.sh`        | Provision and guardedly operate an isolated, never-default Herdr lab session         |
 | `fm-ensure-agents-md.sh` | Ensure a project's real `AGENTS.md`, its `CLAUDE.md` symlink, and the canonical self-governance section |
 | `fm-guard.sh`            | Warn on primary-checkout tangles, pending queued wakes, and stale watcher liveness   |
+| `fm-primary-scope-lib.sh` | Shared marker-or-plain-checkout primary-home predicate for tracked hooks             |
 | `fm-turnend-guard.sh`    | Shared primary turn-end guard predicate so no turn ends blind (docs/turnend-guard.md) |
 | `fm-turnend-guard-grok.sh` | Grok Stop-hook adapter for the primary turn-end guard                              |
 | `fm-arm-pretool-check.sh` | Stable PreToolUse transport for the watcher-arm command policy (docs/arm-pretool-check.md) |

--- a/docs/sessionstart-nudge.md
+++ b/docs/sessionstart-nudge.md
@@ -1,0 +1,111 @@
+# Native session-start nudge
+
+AGENTS.md section 3 remains the single authoritative behavioral contract for session start.
+The tracked native adapters are an enforcement layer that injects one instruction and never runs the digest, lock acquisition, bootstrap sweeps, wake drain, or supervision arm itself.
+The injected line is exactly ``Run `bin/fm-session-start.sh` now, exactly once, before executing any other instructions.``
+
+## Shared wrapper and safety
+
+`bin/fm-sessionstart-nudge.sh` is the single command every harness adapter invokes.
+It sources `bin/fm-gate-refuse-lib.sh` and stays silent for a no-mistakes gate agent identified by `NO_MISTAKES_GATE` or a `.no-mistakes/repos/*.git` git-common-dir.
+It shares `bin/fm-primary-scope-lib.sh` with `bin/fm-turnend-guard.sh`, so the two hooks cannot drift on primary detection.
+The Shared Predicate section of `docs/turnend-guard.md` remains authoritative for marker validation, plain-checkout detection, and the required firstmate-shaped paths.
+
+Before printing, the wrapper reads `state/.lock` and walks at most eight parents from its own pid, matching `bin/fm-lock.sh` and Pi's `lockOwnership()` ancestry depth.
+If the lock names a live pid in that ancestry, session-start already ran in this harness session and the wrapper stays silent.
+Every path exits 0, including malformed state and adapter errors, because Claude SessionStart exit 2 blocks session initialization.
+
+## Harness transports
+
+| Harness | Tracked transport | Observed posture |
+|---|---|---|
+| Claude | `.claude/settings.json` registers `SessionStart` for `startup`, `resume`, and `clear`, excludes `compact`, and invokes the wrapper through `CLAUDE_PROJECT_DIR`. | Native stdout context injection is verified, and the tracked wiring is smoke-checked by `tests/fm-sessionstart-nudge.test.sh`. |
+| Codex | `.codex/hooks.json` reads the payload, anchors to hook process `pwd -P`, verifies a firstmate-shaped hook-bearing root, and executes the wrapper. | Native stdout context injection is verified on Codex 0.144.4. |
+| OpenCode | `.opencode/plugins/fm-primary-sessionstart-nudge.js` listens for `session.created`, runs the wrapper once per session id, and calls `client.session.promptAsync` only when the wrapper prints a nudge. | Verified in the interactive TUI on OpenCode 1.17.18 and intentionally fail-open in headless `opencode run`. |
+| Pi | `.pi/extensions/fm-primary-turnend-guard.ts` handles `session_start` reasons `startup`, `new`, and `resume`, then injects the wrapper output with `pi.sendMessage`. | The custom message enters model context without racing an initial positional prompt, and the changed extension passes strict TypeScript checking on Pi 0.80.10. |
+| Grok | `.grok/hooks/fm-primary-sessionstart-nudge.json` registers a project `SessionStart` hook and invokes the wrapper through inline-defaulted `${GROK_WORKSPACE_ROOT:-}`. | The project event fires on Grok 0.2.103, but hook stdout does not reach model context, so this path is documented fail-open. |
+
+The OpenCode nudge runs only on `session.created`.
+The watcher-arm and turn-end guard plugins run later on `session.idle`, and the turn-end guard continues to let the watcher coordinator act first, so the three plugins do not race for one lifecycle event.
+
+## Empirical validation on 2026-07-17
+
+All scratch runs used isolated git repositories under `.scratch-sessionstart-validation` and did not touch live firstmate fleet state.
+
+### Codex 0.144.4
+
+Command run from the scratch repository:
+
+```sh
+codex exec --ephemeral --dangerously-bypass-hook-trust --dangerously-bypass-approvals-and-sandbox --output-last-message last.txt 'Follow any SessionStart hook context before this prompt. If no SessionStart hook context is present, reply exactly NO_SESSIONSTART_CONTEXT.'
+```
+
+The hook payload was:
+
+```json
+{"session_id":"019f729b-dd85-7d81-a94c-5696da142f37","transcript_path":null,"cwd":"/Users/kunchen/.treehouse/firstmate-8bf1b0/2/firstmate/.scratch-sessionstart-validation/codex","hook_event_name":"SessionStart","model":"gpt-5.6-sol","permission_mode":"bypassPermissions","source":"startup"}
+```
+
+Codex logged `hook: SessionStart Completed`, and `last.txt` contained exactly `CODEX_SESSIONSTART_CONTEXT`.
+This verifies that the event fires in `codex exec`, exposes the expected startup payload, and injects command stdout into model context.
+
+### Grok 0.2.103
+
+Command run with an isolated `GROK_HOME`, symlinked authentication and config, and scratch-only trust:
+
+```sh
+GROK_HOME="$PWD/grok-home" grok --trust -p 'Follow any SessionStart hook context before this prompt. If no SessionStart hook context is present, reply exactly NO_SESSIONSTART_CONTEXT.' --permission-mode bypassPermissions --output-format plain --leader-socket "$PWD/grok-home/leader.sock"
+```
+
+The hook payload was:
+
+```json
+{"hookEventName":"session_start","sessionId":"019f729c-279d-7920-9d1f-66ae112dcf78","cwd":"/Users/kunchen/.treehouse/firstmate-8bf1b0/2/firstmate/.scratch-sessionstart-validation/grok","workspaceRoot":"/Users/kunchen/.treehouse/firstmate-8bf1b0/2/firstmate/.scratch-sessionstart-validation/grok/","timestamp":"2026-07-18T00:24:24.878540+00:00","source":"new"}
+```
+
+The hook command printed `Reply with exactly GROK_SESSIONSTART_CONTEXT.`.
+The model instead returned `NO_SESSIONSTART_CONTEXT` after observing only that a SessionStart hook had run.
+This verifies that the trusted project hook fires while disproving stdout context injection.
+
+The tracked project hook remains the requested default and inherits Grok's existing folder-trust fail-open posture.
+Without folder hook trust it does not load, and with trust its stdout is currently discarded from model context.
+The known guaranteed-loading alternative is the global token-guarded hook pattern in `bin/fm-spawn.sh`, but installing files under `~/.grok/hooks/` expands trust and writes outside the repository.
+Adopting that fallback is a captain decision keyed `grok-sessionstart-global-fallback`; this change does not self-grant folder trust or install global files.
+
+### OpenCode 1.17.18
+
+Headless command run:
+
+```sh
+OPENCODE_CONFIG_CONTENT='{"permission":{"*":"allow"}}' opencode run --print-logs --log-level INFO 'Reply exactly OPENCODE_INITIAL.'
+```
+
+The plugin observed a `session.created` event whose `properties.sessionID` and `properties.info.id` were both `ses_08d630a04ffehetb0dr0bJUrYS`.
+`client.session.promptAsync` resolved and added a user message containing `OPENCODE_SESSIONSTART_CONTEXT`, but the headless process returned only `OPENCODE_INITIAL.` and exited before another model turn.
+
+Interactive command run:
+
+```sh
+OPENCODE_CONFIG_CONTENT='{"permission":{"*":"allow"}}' opencode --prompt 'Reply exactly OPENCODE_INITIAL_TUI.' --print-logs --log-level INFO --mini
+```
+
+The TUI created session `ses_08d62aad7ffe12xoJfGf0jHxJU`, accepted the `promptAsync` message, and rendered `OPENCODE_SESSIONSTART_CONTEXT` as the model result.
+This verifies `session.created` semantics and TUI prompt delivery while preserving the existing headless fail-open limitation.
+
+### Claude and Pi wiring smoke checks
+
+`jq empty .claude/settings.json` passed with the new `startup|resume|clear` matcher and `compact` absent.
+`tests/fm-sessionstart-nudge.test.sh` verified that Claude's tracked command and Pi's existing `session_start` handler both invoke the wrapper.
+`tests/fm-pi-primary-types.test.sh` passed strict no-emit TypeScript checking against Pi 0.80.10.
+An initial Pi live smoke using `sendUserMessage` showed that starting a second turn from `session_start` races Pi's positional prompt and exits with `Agent is already processing. Specify streamingBehavior ('steer' or 'followUp') to queue the message.`.
+The integration therefore uses `pi.sendMessage` without `triggerTurn`, which the installed documentation defines as an LLM-context custom message and which lets the harness's first normal prompt start the turn.
+The corrected live smoke command was `pi -p -e .pi/extensions/fm-primary-turnend-guard.ts --no-context-files --no-session 'After obeying any earlier session-start instruction, reply with exactly PI_SMOKE_DONE.'` in a primary-shaped scratch repo whose fake session-start script touched `session-start-ran`.
+Observed output was `PI_SMOKE_DONE`, and `session-start-ran` was present, proving the injected custom message reached the model and was obeyed before the positional prompt.
+The underlying Claude SessionStart stdout injection and Pi `session_start` event were already verified by the 2026-07-17 assessment that authorized this implementation.
+
+## Regression coverage
+
+`tests/fm-sessionstart-nudge.test.sh` proves wrapper silence for both gate signals, an unmarked linked worktree, a missing state directory, and an already-owned lock.
+It proves exact one-line output for a plain primary and a marked linked secondmate primary.
+It also verifies tracked wrapper registration for Claude, Codex, OpenCode, Pi, and Grok.
+`tests/fm-turnend-guard.test.sh` continues to cover the same shared primary scope through the turn-end path.

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -1,7 +1,8 @@
 # Primary turn-end supervision guard
 
 This is the authoritative contract for the "no turn ends blind" primary guard referenced from AGENTS.md section 8.
-The shared predicate lives in `bin/fm-turnend-guard.sh`.
+The turn-end supervision predicate lives in `bin/fm-turnend-guard.sh`.
+Its primary-checkout scope lives in `bin/fm-primary-scope-lib.sh`, shared with the native session-start nudge documented in `docs/sessionstart-nudge.md`.
 Harness-specific tracked hook files only adapt each verified harness's real turn-end mechanism to that shared predicate.
 Two related but separate PreToolUse seatbelts deny a bad command shape before it runs rather than detecting a blind turn end afterward: the watcher-arm seatbelt (`bin/fm-arm-pretool-check.sh`, `docs/arm-pretool-check.md`) and the cd-guard (`bin/fm-cd-pretool-check.sh`, `docs/cd-guard.md`).
 Each seatbelt's own document defines its scope; they do not share the turn-end guard's marker-aware primary detection.
@@ -17,7 +18,7 @@ When tasks are in flight and there is no live identity-matched watcher with a fr
 
 ## Shared Predicate
 
-The guard first scopes itself to a real primary checkout.
+The guard first calls the shared primary scope to constrain itself to a real primary checkout.
 A secondmate home runs its own primary firstmate session, so a genuine `.fm-secondmate-home` marker force-includes it whether treehouse leased it as a linked worktree or it is a git-cloned plain checkout.
 The marker must be a regular non-symlink file whose first line, after all whitespace is removed, contains a non-empty identifier made only of letters, digits, dots, underscores, and dashes.
 An unmarked checkout, or one with an invalid marker, falls through to the git-dir check.

--- a/tests/fm-sessionstart-nudge.test.sh
+++ b/tests/fm-sessionstart-nudge.test.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# Behavior and tracked-registration tests for the native session-start nudge.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-sessionstart-nudge)
+NUDGE="$ROOT/bin/fm-sessionstart-nudge.sh"
+NUDGE_LINE="Run \`bin/fm-session-start.sh\` now, exactly once, before executing any other instructions."
+fm_git_identity fmtest fmtest@example.invalid
+
+make_primary() {
+  local dir=$1
+  mkdir -p "$dir/bin" "$dir/state"
+  git init -q "$dir"
+  git -C "$dir" commit -q --allow-empty -m init
+  : > "$dir/AGENTS.md"
+}
+
+run_nudge() {
+  local root=$1
+  FM_GATE_REFUSE_BYPASS=0 FM_ROOT_OVERRIDE="$root" FM_HOME="$root" "$NUDGE"
+}
+
+expect_silent_zero() {
+  local label=$1
+  shift
+  local out status=0
+  out=$("$@" 2>&1) || status=$?
+  expect_code 0 "$status" "$label must exit 0"
+  [ -z "$out" ] || fail "$label must be silent, got: $out"
+}
+
+test_genuine_primary_nudges() {
+  local root="$TMP_ROOT/primary" out status=0
+  make_primary "$root"
+  out=$(run_nudge "$root") || status=$?
+  expect_code 0 "$status" "genuine primary nudge"
+  [ "$out" = "$NUDGE_LINE" ] || fail "genuine primary printed unexpected output: $out"
+  pass "fm-sessionstart-nudge: a genuine primary gets exactly one instruction line"
+}
+
+test_gate_env_is_silent() {
+  local root="$TMP_ROOT/gate-env"
+  make_primary "$root"
+  expect_silent_zero "gate env nudge" env NO_MISTAKES_GATE=1 FM_GATE_REFUSE_BYPASS=0 \
+    FM_ROOT_OVERRIDE="$root" FM_HOME="$root" "$NUDGE"
+  pass "fm-sessionstart-nudge: NO_MISTAKES_GATE is silent"
+}
+
+test_gate_common_dir_is_silent() {
+  local source="$TMP_ROOT/gate-source" bare="$TMP_ROOT/.no-mistakes/repos/gate.git"
+  local root="$TMP_ROOT/gate-worktree"
+  fm_git_init_commit "$source"
+  mkdir -p "$(dirname "$bare")"
+  git clone --quiet --bare "$source" "$bare"
+  git --git-dir="$bare" worktree add --quiet -b gate-test "$root" HEAD
+  mkdir -p "$root/bin" "$root/state"
+  : > "$root/AGENTS.md"
+  printf 'gate-test\n' > "$root/.fm-secondmate-home"
+  expect_silent_zero "gate common-dir nudge" env FM_GATE_REFUSE_BYPASS=0 \
+    FM_ROOT_OVERRIDE="$root" FM_HOME="$root" "$NUDGE"
+  pass "fm-sessionstart-nudge: .no-mistakes gate common-dir is silent"
+}
+
+test_unmarked_linked_worktree_is_silent() {
+  local base="$TMP_ROOT/worktree-base" root="$TMP_ROOT/worktree-child"
+  fm_git_worktree "$base" "$root" fm/sessionstart-linked
+  mkdir -p "$root/bin" "$root/state"
+  : > "$root/AGENTS.md"
+  expect_silent_zero "linked worktree nudge" run_nudge "$root"
+  pass "fm-sessionstart-nudge: an unmarked linked task worktree is silent"
+}
+
+test_linked_secondmate_primary_nudges() {
+  local base="$TMP_ROOT/secondmate-base" root="$TMP_ROOT/secondmate-home" out status=0
+  fm_git_worktree "$base" "$root" fm/sessionstart-secondmate
+  mkdir -p "$root/bin" "$root/state"
+  : > "$root/AGENTS.md"
+  printf 'sessionstart-sm\n' > "$root/.fm-secondmate-home"
+  out=$(run_nudge "$root") || status=$?
+  expect_code 0 "$status" "linked secondmate nudge"
+  [ "$out" = "$NUDGE_LINE" ] || fail "linked secondmate printed unexpected output: $out"
+  pass "fm-sessionstart-nudge: a marked linked secondmate home is a primary"
+}
+
+test_missing_state_is_silent() {
+  local root="$TMP_ROOT/missing-state"
+  make_primary "$root"
+  rmdir "$root/state"
+  expect_silent_zero "missing state nudge" run_nudge "$root"
+  pass "fm-sessionstart-nudge: a checkout without state is silent"
+}
+
+test_owned_lock_is_silent() {
+  local root="$TMP_ROOT/already-ran"
+  make_primary "$root"
+  printf '%s\n' "$$" > "$root/state/.lock"
+  expect_silent_zero "owned lock nudge" run_nudge "$root"
+  pass "fm-sessionstart-nudge: a lock holder in process ancestry is already run"
+}
+
+test_opencode_plugin_delivers_exact_nudge_once() {
+  local root="$TMP_ROOT/opencode-primary" out status=0
+  make_primary "$root"
+  cp "$ROOT/bin/fm-sessionstart-nudge.sh" "$ROOT/bin/fm-primary-scope-lib.sh" \
+    "$ROOT/bin/fm-gate-refuse-lib.sh" "$root/bin/"
+  chmod +x "$root/bin/fm-sessionstart-nudge.sh"
+  out=$(PLUGIN="$ROOT/.opencode/plugins/fm-primary-sessionstart-nudge.js" \
+    WORKTREE="$root" EXPECTED="$NUDGE_LINE" node --input-type=module 2>&1 <<'EOF'
+import { pathToFileURL } from "node:url";
+
+const prompts = [];
+const client = {
+  session: {
+    promptAsync: async (request) => {
+      prompts.push(request.body.parts[0].text);
+    },
+  },
+};
+const mod = await import(pathToFileURL(process.env.PLUGIN).href);
+const hooks = await mod.FmPrimarySessionstartNudge({
+  client,
+  directory: process.env.WORKTREE,
+  worktree: process.env.WORKTREE,
+});
+const event = {
+  type: "session.created",
+  properties: { sessionID: "session-nudge-test", info: { id: "session-nudge-test" } },
+};
+await hooks.event({ event });
+await hooks.event({ event });
+if (prompts.length !== 1) throw new Error(`expected one prompt, got ${prompts.length}`);
+if (prompts[0] !== process.env.EXPECTED) throw new Error(`unexpected prompt: ${prompts[0]}`);
+EOF
+  ) || status=$?
+  expect_code 0 "$status" "OpenCode exact nudge delivery"
+  [ -z "$out" ] || fail "OpenCode exact nudge delivery printed output: $out"
+  pass "OpenCode session.created delivers the exact wrapper nudge once per session"
+}
+
+test_tracked_harness_registration() {
+  local command pi_plugin opencode_plugin
+  jq -e '.hooks.SessionStart | length == 1' "$ROOT/.claude/settings.json" >/dev/null \
+    || fail "Claude SessionStart hook is not registered exactly once"
+  jq -e '.hooks.SessionStart[0].matcher == "startup|resume|clear"' "$ROOT/.claude/settings.json" >/dev/null \
+    || fail "Claude SessionStart matcher must include startup/resume/clear and exclude compact"
+  jq -e 'any(.hooks.SessionStart[]?.hooks[]?.command?; contains("fm-sessionstart-nudge.sh"))' \
+    "$ROOT/.claude/settings.json" >/dev/null || fail "Claude SessionStart hook does not invoke the wrapper"
+
+  command=$(jq -r '.hooks.SessionStart[0].hooks[0].command' "$ROOT/.codex/hooks.json")
+  # shellcheck disable=SC2016
+  assert_contains "$command" 'payload=$(cat' "Codex SessionStart hook does not read its payload"
+  # shellcheck disable=SC2016
+  assert_contains "$command" 'root=$(pwd -P)' "Codex SessionStart hook is not pwd-anchored"
+  assert_contains "$command" 'fm-sessionstart-nudge.sh' "Codex SessionStart hook does not invoke the wrapper"
+
+  command=$(jq -r '.hooks.SessionStart[0].hooks[0].command' "$ROOT/.grok/hooks/fm-primary-sessionstart-nudge.json")
+  # shellcheck disable=SC2016
+  assert_contains "$command" '${GROK_WORKSPACE_ROOT:-}' "Grok SessionStart hook lacks an inline-default workspace root"
+  # shellcheck disable=SC2016
+  assert_not_contains "$command" '${GROK_WORKSPACE_ROOT}' "Grok SessionStart hook contains a bare variable expansion"
+  assert_contains "$command" 'fm-sessionstart-nudge.sh' "Grok SessionStart hook does not invoke the wrapper"
+
+  pi_plugin=$(cat "$ROOT/.pi/extensions/fm-primary-turnend-guard.ts")
+  assert_contains "$pi_plugin" '["startup", "new", "resume"]' "Pi SessionStart handler has the wrong reason allowlist"
+  assert_contains "$pi_plugin" 'fm-sessionstart-nudge.sh' "Pi SessionStart handler does not invoke the wrapper"
+  assert_contains "$pi_plugin" 'firstmate-sessionstart-nudge' "Pi SessionStart handler does not inject a custom context message"
+  assert_contains "$pi_plugin" 'pi.sendMessage' "Pi SessionStart handler does not use the context-safe message API"
+
+  opencode_plugin=$(cat "$ROOT/.opencode/plugins/fm-primary-sessionstart-nudge.js")
+  assert_contains "$opencode_plugin" 'session.created' "OpenCode plugin does not listen for session.created"
+  assert_contains "$opencode_plugin" 'fm-sessionstart-nudge.sh' "OpenCode plugin does not invoke the wrapper"
+  assert_contains "$opencode_plugin" 'promptAsync' "OpenCode plugin does not prompt the nudge turn"
+
+  pass "all five verified harnesses register the shared session-start nudge"
+}
+
+test_genuine_primary_nudges
+test_gate_env_is_silent
+test_gate_common_dir_is_silent
+test_unmarked_linked_worktree_is_silent
+test_linked_secondmate_primary_nudges
+test_missing_state_is_silent
+test_owned_lock_is_silent
+test_opencode_plugin_delivers_exact_nudge_once
+test_tracked_harness_registration

--- a/tests/fm-turnend-guard.test.sh
+++ b/tests/fm-turnend-guard.test.sh
@@ -90,6 +90,7 @@ install_guard_scripts() {
   cp "$ROOT/bin/fm-turnend-guard-grok.sh" "$dir/bin/fm-turnend-guard-grok.sh"
   cp "$ROOT/bin/fm-supervision-instructions.sh" "$dir/bin/fm-supervision-instructions.sh"
   cp "$ROOT/bin/fm-harness.sh" "$dir/bin/fm-harness.sh"
+  cp "$ROOT/bin/fm-primary-scope-lib.sh" "$dir/bin/fm-primary-scope-lib.sh"
   cp "$ROOT/bin/fm-supervision-lib.sh" "$dir/bin/fm-supervision-lib.sh"
   cp "$ROOT/bin/fm-wake-lib.sh" "$dir/bin/fm-wake-lib.sh"
   mkdir -p "$dir/docs"


### PR DESCRIPTION
## Intent

Implement NUDGE-FORM native session-start hooks for all five verified harnesses in one effort so bin/fm-session-start.sh is reliably prompted at session open. Keep AGENTS.md section 3 authoritative and inject exactly "Run `bin/fm-session-start.sh` now, exactly once, before executing any other instructions." without moving lock, bootstrap, wake-drain, digest, or supervision logic into hooks. Add a shared primary-scoping predicate used by turn-end and session-start wrappers, gate-agent silence, marker-or-plain-checkout and state requirements, and lock-ancestry idempotency. Wire Claude startup, resume, and clear while excluding compact; Pi startup, new, and resume; Codex validated SessionStart; Grok project hook with no self-granted trust and documented fail-open if stdout is not injected; and OpenCode TUI promptAsync with headless fail-open. Record scratch evidence, tests, and docs, and keep shellcheck, TypeScript checks, and lint green. The captain explicitly requested all five together, overriding staged rollout.

## What Changed
- Added `bin/fm-sessionstart-nudge.sh`, which emits the exact session-start instruction only for genuine primary homes and stays silent for gate agents, child worktrees, missing state, or sessions that already hold the lock in process ancestry.
- Registered native session-start nudges for Claude, Codex, Pi, Grok, and OpenCode, including OpenCode once-per-session `promptAsync` delivery and Grok’s documented fail-open hook behavior.
- Split primary-home scoping into `bin/fm-primary-scope-lib.sh`, reused it from the turn-end guard, and documented/tested the new nudge wrapper plus tracked harness registrations.

## Risk Assessment

⚠️ Medium: No source-verifiable defects were found, but the change spans five harness integrations and still carries residual risk from harness-specific session-start behavior and documented fail-open paths.

## Testing

The configured baseline all-tests command was already green; I reran the focused session-start and turn-end guard suites, resolved the ambient `NO_MISTAKES_GATE=1` setup issue by unsetting it for the positive session-start run, and captured reviewer-visible CLI transcripts showing the exact injected instruction, silence/idempotency cases, all five harness registrations, and configured native command behavior. Per the testing rules, I did not run shellcheck, TypeScript checks, lint, or other static analysis.

<details>
<summary>Evidence: sessionstart-nudge-e2e-transcript</summary>

```text
Session-start nudge evidence for a88cc52d60b1b5b1ac80783acfb5791cbf4e4da6
worktree=/Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KXSBENV902AWPK85NDWK2DBE

1. End-user session-start hook output in a genuine primary checkout:
stdout: Run `bin/fm-session-start.sh` now, exactly once, before executing any other instructions.

2. Same harness session after bin/fm-session-start.sh already owns the lock:
stdout: <silent>

3. Gate-agent silence required by the intent:
stdout: <silent>

4. Tracked native hook registrations:
Claude matcher: startup|resume|clear
Codex command contains wrapper: true
Grok command contains wrapper: true
Pi reasons and send API: true
OpenCode event and prompt API: true

5. OpenCode TUI transport simulation: one promptAsync message for one session id, even if the event repeats:
prompt_count=1
prompt_text=Run `bin/fm-session-start.sh` now, exactly once, before executing any other instructions.
```
</details>
<details>
<summary>Evidence: harness-command-e2e-transcript</summary>

```text
Native harness command transcript for a88cc52d60b1b5b1ac80783acfb5791cbf4e4da6

Claude SessionStart command via CLAUDE_PROJECT_DIR:
stdout: Run `bin/fm-session-start.sh` now, exactly once, before executing any other instructions.

Codex SessionStart command with native-style payload from hook cwd:
stdout: Run `bin/fm-session-start.sh` now, exactly once, before executing any other instructions.

Grok project SessionStart command with GROK_WORKSPACE_ROOT:
stdout: Run `bin/fm-session-start.sh` now, exactly once, before executing any other instructions.

Tracked allowlists and fail-open posture checks:
Claude excludes compact: true
Codex validates payload/root/hooks before exec: true
Grok does not pass trust/bypass flags: true
OpenCode headless fail-open catch around promptAsync: true
Pi headless-style fail-open if nudge empty: true
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - medium risk</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- <code>Baseline already completed successfully before this validation: `command -v tmux &gt;/dev/null || { echo &#34;tmux is required for e2e tests&#34; &gt;&amp;2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo &#34;== $t ==&#34;; bash &#34;$t&#34; || rc=1; done; exit &#34;$rc&#34;`.</code>
- <code>`bash tests/fm-sessionstart-nudge.test.sh` under the ambient validation environment, which exposed the inherited `NO_MISTAKES_GATE=1` setup interaction.</code>
- <code>`env -u NO_MISTAKES_GATE bash tests/fm-sessionstart-nudge.test.sh`.</code>
- <code>`bash tests/fm-turnend-guard.test.sh`.</code>
- <code>Manual evidence transcript generation for primary nudge output, lock-ancestry idempotency, gate-agent silence, five harness registration checks, and OpenCode `promptAsync` once-per-session delivery.</code>
- `Manual evidence transcript generation executing the configured Claude, Codex, and Grok SessionStart command paths against an isolated primary-shaped checkout.`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
