### PR TITLE
docs: relabel built-in defaults as the firstmate repo

### DIFF
--- a/.agents/skills/secondmate-provisioning/SKILL.md
+++ b/.agents/skills/secondmate-provisioning/SKILL.md
@@ -91,7 +91,7 @@ Before replacing divergent secondmate bytes, the helper hash-compares source and
 Never copy any secondmate `data/captain-shared.md` back into the primary.
 Keep each home's `data/captain.md` domain-local.
 After first propagation to an existing home, trim that home's local `data/captain.md` by hand to domain-specific content plus pointers to `data/captain-shared.md`; do not automate or silently delete private content.
-Keep every `data/learnings.md` fully local by captain decision; route fleet-general machinery facts into tracked documentation through the normal Firstmate template path rather than inventing shared learnings propagation.
+Keep every `data/learnings.md` fully local by captain decision; route fleet-general machinery facts into tracked documentation through the normal firstmate repo path rather than inventing shared learnings propagation.
 No reread nudge is needed at spawn or respawn because the agent reads `AGENTS.md` fresh on launch; only the bootstrap sweep's running-home instruction-surface advance needs one.
 Bootstrap reports successful sends as `BOOTSTRAP_INFO:` and only emits `NUDGE_SECONDMATES:` when that send fails and needs retry.
 For already-live secondmates, use `bin/fm-config-push.sh` to push a mid-session inherited local-material change without running the tracked-file fast-forward or nudging the agents.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,7 +120,7 @@ Tracked native session-open adapters only nudge this command; `docs/sessionstart
 
 Read the complete digest once and trust it as this turn's startup and recovery input.
 Do not separately re-read the context, backlog, metadata, or bulk status inputs it just printed unless a source was reported absent or corrupt, older history is specifically needed, or a targeted workflow must inspect before writing.
-An `ABSENT` captain, shared-captain, secondmate, or learnings file means template defaults, no shared captain preferences, no registered secondmates, or no captured learnings; rebuild an absent or stale project registry from the clones before dispatch.
+An `ABSENT` captain, shared-captain, secondmate, or learnings file means the firstmate repo's built-in defaults, no shared captain preferences, no registered secondmates, or no captured learnings; rebuild an absent or stale project registry from the clones before dispatch.
 
 If the session lock is refused, tell the captain another active session is managing the fleet and remain read-only.
 A lock-refused session must not spawn, steer, merge, drain the wake queue, repair supervision, repair a checkout, or perform any other fleet mutation.
@@ -133,7 +133,7 @@ A lock-refused session must not spawn, steer, merge, drain the wake queue, repai
 3. **Wake queue** - when locked, drains the durable wake queue and prints the records prominently as this turn's first work queue, exactly as `bin/fm-wake-drain.sh` did before; a lapsed watcher chain still surfaces here via the same guard alarm.
    When the lock could not be acquired, the queue is left untouched because another session owns it, and the guard's tangle/watcher-liveness alarms still print in read-only advisory mode without drain, supervision repair, or checkout repair commands.
 4. **Context digest** - the full contents of `data/projects.md`, `data/secondmates.md`, `data/captain.md`, `data/captain-shared.md`, and `data/learnings.md`, each clearly delimited.
-   A file that does not exist prints an explicit `ABSENT` marker, never confused with an empty-but-present file: absence is meaningful (`captain.md` absent means use this template's defaults, `projects.md` absent means rebuild it from the clones under `projects/`, etc.).
+   A file that does not exist prints an explicit `ABSENT` marker, never confused with an empty-but-present file: absence is meaningful (`captain.md` absent means use the firstmate repo's built-in defaults, `projects.md` absent means rebuild it from the clones under `projects/`, etc.).
 5. **Fleet-state digest** - the compact backlog listing owned by `bin/fm-session-start.sh`; every `state/<id>.meta`; a bounded tail of each task's `state/<id>.status` (labeled as wake-EVENT history, not current state, with the full log path printed for a deeper read); the `state/.afk` flag; and one cheap alive/dead read of each task's recorded backend endpoint.
    That liveness line is a fast presence check only, not a full state read - when you need a crew's actual current state (a run-step, not just "is the pane there"), read it with `bin/fm-crew-state.sh <id>` as before; the digest deliberately skips that deeper, slower read for every task so it stays fast and bounded.
 6. **Supervision operating instructions and next step** - after the wake queue and before context, the digest emits exactly one operating block for the detected primary harness.

--- a/bin/fm-session-start.sh
+++ b/bin/fm-session-start.sh
@@ -114,10 +114,10 @@ subsection() { printf '\n%s\n%s\n' "$1" "$SUBRULE"; }
 
 # print_file_or_absent <path> <label>: full contents under a labeled
 # subsection, or an explicit ABSENT marker. Absence is semantically
-# meaningful for every one of these files (captain.md absent = template
-# defaults, projects.md absent = rebuild from clones, etc. - AGENTS.md
-# section 3) and must never be confused with an empty-but-present file, so
-# the two cases print differently.
+# meaningful for every one of these files (captain.md absent = firstmate
+# repo built-in defaults, projects.md absent = rebuild from clones, etc. -
+# AGENTS.md section 3) and must never be confused with an empty-but-present
+# file, so the two cases print differently.
 print_file_or_absent() {
   local path=$1 label=$2
   subsection "$label"


### PR DESCRIPTION
## Intent

The captain objects to calling this repo/domain a "template" as an identity label for built-in defaults; that is inaccurate. Relabel tracked uses of "template" that stand in for THIS repo's built-in defaults to "the firstmate repo" phrasing, while KEEPING design-tenet statements that firstmate IS a reusable OSS template (AGENTS.md "This repo is a shared template..." and CONTRIBUTING.md "This repo is a template for running a firstmate orchestrator agent."). Also keep all unrelated command/file "template" uses: launch_template / launch template (spawn, architecture, configuration, harness-adapters) and PR-poll TEMPLATE hashes/vars. Do not touch gitignored data/. Named spots: AGENTS.md "means template defaults" and "use this template's defaults"; bin/fm-session-start.sh "captain.md absent = template defaults"; plus any other same-sense domain label found by grep (e.g. secondmate-provisioning "Firstmate template path"). Wording only - no behavior change. Tight reviewable diff; one sentence per line in Markdown; plain dash; bin/fm-lint.sh green.

## What Changed
- Relabeled built-in default wording in `AGENTS.md` and `bin/fm-session-start.sh` from template-based identity language to firstmate repo phrasing.
- Updated the secondmate provisioning skill to refer to the firstmate repo path instead of a Firstmate template path.
- Preserved unrelated template terminology for reusable project guidance and command/file concepts.

## Risk Assessment

✅ Low: Captain, risk is low because this is a tight wording-only change that preserves the required template identity statements and unrelated launch/PR-poll template uses while updating the named same-sense defaults references.

## Testing

The pre-run full shell test baseline had already passed; I reran the session-start and instruction-owner suites, then captured a focused CLI transcript proving the relabel intent on the real tracked files plus isolated session-start behavior. All exercised tests passed, and the worktree was left clean; only `bin/fm-lint.sh` evidence is missing because this test prompt forbade linters.

<details>
<summary>Evidence: Domain relabel evidence transcript</summary>

```text
Evidence generated: 2026-07-18T02:18:47Z
Worktree: /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KXSETK42BKTB4MTPTTPCN8SG
HEAD: 142829ba2bea061406c7a1b123baedee0cf5fea0

## Diff Under Test
diff --git a/.agents/skills/secondmate-provisioning/SKILL.md b/.agents/skills/secondmate-provisioning/SKILL.md
index bb614ff..81393e8 100644
--- a/.agents/skills/secondmate-provisioning/SKILL.md
+++ b/.agents/skills/secondmate-provisioning/SKILL.md
@@ -92,5 +92,5 @@ Never copy any secondmate `data/captain-shared.md` back into the primary.
 Keep each home's `data/captain.md` domain-local.
 After first propagation to an existing home, trim that home's local `data/captain.md` by hand to domain-specific content plus pointers to `data/captain-shared.md`; do not automate or silently delete private content.
-Keep every `data/learnings.md` fully local by captain decision; route fleet-general machinery facts into tracked documentation through the normal Firstmate template path rather than inventing shared learnings propagation.
+Keep every `data/learnings.md` fully local by captain decision; route fleet-general machinery facts into tracked documentation through the normal firstmate repo path rather than inventing shared learnings propagation.
 No reread nudge is needed at spawn or respawn because the agent reads `AGENTS.md` fresh on launch; only the bootstrap sweep's running-home instruction-surface advance needs one.
 Bootstrap reports successful sends as `BOOTSTRAP_INFO:` and only emits `NUDGE_SECONDMATES:` when that send fails and needs retry.
diff --git a/AGENTS.md b/AGENTS.md
index b47d686..cdf7b16 100644
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,5 +121,5 @@ Tracked native session-open adapters only nudge this command; `docs/sessionstart
 Read the complete digest once and trust it as this turn's startup and recovery input.
 Do not separately re-read the context, backlog, metadata, or bulk status inputs it just printed unless a source was reported absent or corrupt, older history is specifically needed, or a targeted workflow must inspect before writing.
-An `ABSENT` captain, shared-captain, secondmate, or learnings file means template defaults, no shared captain preferences, no registered secondmates, or no captured learnings; rebuild an absent or stale project registry from the clones before dispatch.
+An `ABSENT` captain, shared-captain, secondmate, or learnings file means the firstmate repo's built-in defaults, no shared captain preferences, no registered secondmates, or no captured learnings; rebuild an absent or stale project registry from the clones before dispatch.
 
 If the session lock is refused, tell the captain another active session is managing the fleet and remain read-only.
@@ -134,5 +134,5 @@ A lock-refused session must not spawn, steer, merge, drain the wake queue, repai
    When the lock could not be acquired, the queue is left untouched because another session owns it, and the guard's tangle/watcher-liveness alarms still print in read-only advisory mode without drain, supervision repair, or checkout repair commands.
 4. **Context digest** - the full contents of `data/projects.md`, `data/secondmates.md`, `data/captain.md`, `data/captain-shared.md`, and `data/learnings.md`, each clearly delimited.
-   A file that does not exist prints an explicit `ABSENT` marker, never confused with an empty-but-present file: absence is meaningful (`captain.md` absent means use this template's defaults, `projects.md` absent means rebuild it from the clones under `projects/`, etc.).
+   A file that does not exist prints an explicit `ABSENT` marker, never confused with an empty-but-present file: absence is meaningful (`captain.md` absent means use the firstmate repo's built-in defaults, `projects.md` absent means rebuild it from the clones under `projects/`, etc.).
 5. **Fleet-state digest** - the compact backlog listing owned by `bin/fm-session-start.sh`; every `state/<id>.meta`; a bounded tail of each task's `state/<id>.status` (labeled as wake-EVENT history, not current state, with the full log path printed for a deeper read); the `state/.afk` flag; and one cheap alive/dead read of each task's recorded backend endpoint.
    That liveness line is a fast presence check only, not a full state read - when you need a crew's actual current state (a run-step, not just "is the pane there"), read it with `bin/fm-crew-state.sh <id>` as before; the digest deliberately skips that deeper, slower read for every task so it stays fast and bounded.
diff --git a/bin/fm-session-start.sh b/bin/fm-session-start.sh
index c266dfc..cdeb03f 100755
--- a/bin/fm-session-start.sh
+++ b/bin/fm-session-start.sh
@@ -115,8 +115,8 @@ subsection() { printf '\n%s\n%s\n' "$1" "$SUBRULE"; }
 # print_file_or_absent <path> <label>: full contents under a labeled
 # subsection, or an explicit ABSENT marker. Absence is semantically
-# meaningful for every one of these files (captain.md absent = template
-# defaults, projects.md absent = rebuild from clones, etc. - AGENTS.md
-# section 3) and must never be confused with an empty-but-present file, so
-# the two cases print differently.
+# meaningful for every one of these files (captain.md absent = firstmate
+# repo built-in defaults, projects.md absent = rebuild from clones, etc. -
+# AGENTS.md section 3) and must never be confused with an empty-but-present
+# file, so the two cases print differently.
 print_file_or_absent() {
   local path=$1 label=$2

## Required firstmate repo wording now present
.agents/skills/secondmate-provisioning/SKILL.md:94:Keep every `data/learnings.md` fully local by captain decision; route fleet-general machinery facts into tracked documentation through the normal firstmate repo path rather than inventing shared learnings propagation.
bin/fm-session-start.sh:117:# meaningful for every one of these files (captain.md absent = firstmate
AGENTS.md:123:An `ABSENT` captain, shared-captain, secondmate, or learnings file means the firstmate repo's built-in defaults, no shared captain preferences, no registered secondmates, or no captured learnings; rebuild an absent or stale project registry from the clones before dispatch.
AGENTS.md:136:   A file that does not exist prints an explicit `ABSENT` marker, never confused with an empty-but-present file: absence is meaningful (`captain.md` absent means use the firstmate repo's built-in defaults, `projects.md` absent means rebuild it from the clones under `projects/`, etc.).

## Protected OSS-template statements still present
AGENTS.md:42:This repo is a shared template, while `.env`, `data/`, `state/`, `config/`, `projects/`, and `.no-mistakes/` are captain-private and gitignored.
CONTRIBUTING.md:35:- This repo is a template for running a firstmate orchestrator agent.

## Forbidden domain-label phrases absent
No matches for forbidden domain-label phrases outside gitignored data/.

## Unrelated template uses still present
bin/fm-pr-check-migrate.sh:15:TEMPLATE="$SCRIPT_DIR/fm-pr-poll.sh"
bin/fm-pr-check-migrate.sh:88:    fm_pr_poll_artifacts_valid "$STATE" "$id" "$TEMPLATE" || return 1
bin/fm-pr-check-migrate.sh:378:    if ! fm_pr_poll_artifacts_valid "$STATE" "$id" "$TEMPLATE"; then
bin/fm-pr-check-migrate.sh:395:    fm_pr_poll_artifacts_valid "$STATE" "$id" "$TEMPLATE" || return 1
bin/fm-pr-check-migrate.sh:716:  fm_pr_poll_artifacts_valid "$STATE" "$id" "$TEMPLATE" \
bin/fm-pr-check-migrate.sh:793:  fm_pr_poll_prepare "$STATE" "$id" "$url" "$owner" "$repo" "$number" "$TEMPLATE" || return 1
bin/fm-pr-check-migrate.sh:1023:    fm_pr_poll_artifacts_valid "$STATE" "$id" "$TEMPLATE" && continue
bin/fm-pr-check-migrate.sh:1045:          && fm_pr_poll_prepare "$STATE" "$id" "$url" "$owner" "$repo" "$number" "$TEMPLATE" \
.agents/skills/harness-adapters/SKILL.md:216:Multiple positional args become separate queued messages; `fm-spawn`'s template already does this correctly.
bin/fm-spawn.sh:68:#   Launch templates live in launch_template() below; placeholders replaced before launch:
bin/fm-spawn.sh:314:launch_template() {
bin/fm-spawn.sh:370:    # The launch_template lookup below is the unverified-adapter guard for both
bin/fm-spawn.sh:383:    LAUNCH=$(launch_template "$HARNESS" "$KIND") || { echo "error: no launch template for harness '$HARNESS' (from $harness_src or detection); pass a raw launch command to use an unverified adapter" >&2; exit 1; }
bin/fm-spawn.sh:387:    LAUNCH=$(launch_template "$HARNESS" "$KIND") || { echo "error: unknown harness '$HARNESS'; pass a raw launch command to use an unverified adapter" >&2; exit 1; }
bin/fm-pr-lib.sh:24:FM_PR_REG_TEMPLATE_HASH=
bin/fm-pr-lib.sh:39:FM_PR_POLL_EXPECT_TEMPLATE_HASH=
bin/fm-pr-lib.sh:42:FM_PR_POLL_TEMPLATE=
bin/fm-pr-lib.sh:227:  local file=$1 version id url owner repo number data_hash template_hash data_identity check_identity
bin/fm-pr-lib.sh:234:  FM_PR_REG_TEMPLATE_HASH=
bin/fm-pr-lib.sh:246:  IFS= read -r template_hash <&7 || { exec 7<&-; return 1; }
bin/fm-pr-lib.sh:261:  [[ "$template_hash" =~ ^[0-9a-f]{64}$ ]] || return 1
bin/fm-pr-lib.sh:270:  FM_PR_REG_TEMPLATE_HASH=$template_hash
bin/fm-pr-lib.sh:324:  FM_PR_POLL_TEMPLATE=$template
bin/fm-pr-lib.sh:353:  FM_PR_POLL_EXPECT_TEMPLATE_HASH=$(fm_pr_sha256 "$FM_PR_POLL_CHECK_TMP") || { fm_pr_poll_cleanup; return 1; }
bin/fm-pr-lib.sh:358:      "$FM_PR_POLL_EXPECT_DATA_HASH" "$FM_PR_POLL_EXPECT_TEMPLATE_HASH" \
bin/fm-pr-lib.sh:366:    || [ "$FM_PR_REG_TEMPLATE_HASH" != "$FM_PR_POLL_EXPECT_TEMPLATE_HASH" ]; then
bin/fm-pr-lib.sh:409:    || [ "$FM_PR_REG_TEMPLATE_HASH" != "$FM_PR_POLL_EXPECT_TEMPLATE_HASH" ] \
bin/fm-pr-lib.sh:422:  if ! fm_pr_poll_artifacts_valid "${FM_PR_POLL_CHECK_DEST%/*}" "$FM_PR_POLL_EXPECT_ID" "$FM_PR_POLL_TEMPLATE"; then
bin/fm-pr-lib.sh:429:  local state=$1 id=$2 template=$3 state_device check data registration meta data_hash template_hash data_identity check_identity
bin/fm-pr-lib.sh:445:  template_hash=$(fm_pr_sha256 "$check") || return 1
bin/fm-pr-lib.sh:455:  [ "$FM_PR_REG_TEMPLATE_HASH" = "$template_hash" ] || return 1

## Isolated session-start digest excerpt
SESSION START - /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KXSETK42BKTB4MTPTTPCN8SG/session-home
LOCK
lock acquired: harness pid 82438
CONTEXT
data/projects.md
ABSENT
data/secondmates.md
ABSENT
data/captain.md
ABSENT
data/captain-shared.md (shared, main-authoritative, read-only in secondmate homes)
ABSENT
data/learnings.md
ABSENT
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (25m14s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ Author intent asks for `bin/fm-lint.sh` to be green, but this testing prompt explicitly prohibited running linters or static analysis, so I did not run `bin/fm-lint.sh`. Lint evidence remains uncollected in this test step unless that rule is overridden or a later lint step runs it.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- <code>Baseline already ran successfully before this step: `command -v tmux &gt;/dev/null || { echo &#34;tmux is required for e2e tests&#34; &gt;&amp;2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo &#34;== $t ==&#34;; bash &#34;$t&#34; || rc=1; done; exit &#34;$rc&#34;`</code>
- `bash tests/fm-session-start.test.sh`
- `bash tests/fm-instruction-owners.test.sh`
- <code>Generated reviewer evidence with `git diff`, `rg` checks for required/protected/forbidden template wording, and an isolated `FM_HOME=... bin/fm-session-start.sh` digest excerpt into `/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KXSETK42BKTB4MTPTTPCN8SG/fm-domain-relabel-evidence.txt`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
