### PR TITLE
fix(bin): install worktree dependencies in ship briefs before tooling

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -33,7 +33,7 @@
 #   direct-PR    implement -> push + open PR via gh-axi (no pipeline) -> captain merge
 #   local-only   implement on branch, stop and report "ready in branch" (no push/PR);
 #                captain approves, firstmate merges to local main
-# Ship briefs begin with a worktree-isolation assertion before the branch step.
+# Ship briefs begin with a worktree-isolation assertion before the branch step, then require dependency installation before tooling or tests so fresh worktrees have usable language servers and test environments.
 # Scout tasks ignore mode - their deliverable is a report, not a merge.
 # Every scaffold's status protocol distinguishes the configured
 # declared-external-wait verb (FM_CLASSIFY_PAUSED_VERB, default "paused") from
@@ -302,8 +302,7 @@ EOF
 )
     ;;
   *)  # no-mistakes (default)
-    SETUP2="
-2. Run \`no-mistakes doctor\`; if it reports the repo is not initialized here, run \`no-mistakes init\`."
+    SETUP2="3. Run \`no-mistakes doctor\`; if it reports the repo is not initialized here, run \`no-mistakes init\`."
     RULE1='1. Never push to the default branch. Never merge a PR.'
     DOD=$(cat <<EOF
 # Definition of done
@@ -341,7 +340,9 @@ You are in a disposable git worktree of $REPO, at a detached HEAD on a clean def
 The path check is authoritative: \`git rev-parse --git-dir\` and \`git rev-parse --git-common-dir\` can help inspect the repo, but they do not prove you are outside the primary checkout.
 If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append \`blocked: launched in primary checkout, not an isolated worktree\` to the status file and stop.
 
-1. First action: create your branch: \`git checkout -b fm/$ID\`$SETUP2
+1. First action: create your branch: \`git checkout -b fm/$ID\`
+2. Install this worktree's dependencies before any tooling or tests: it was freshly cut and has no .venv/node_modules, so language servers and test runs are degraded until you do. Detect the stack and run the project's setup - Python (pyproject.toml/requirements*.txt): create a .venv and install (prefer \`uv sync\`, else \`pip install -r requirements*.txt\` plus any requirements-dev.txt); Node/TypeScript (package.json): \`npm ci\` (or the project's package manager). Prefer any setup command the README/AGENTS.md documents. Skip only if there's no dependency manifest.
+$SETUP2
 
 # Rules
 $RULE1

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -302,7 +302,8 @@ EOF
 )
     ;;
   *)  # no-mistakes (default)
-    SETUP2="3. Run \`no-mistakes doctor\`; if it reports the repo is not initialized here, run \`no-mistakes init\`."
+    SETUP2="
+3. Run \`no-mistakes doctor\`; if it reports the repo is not initialized here, run \`no-mistakes init\`."
     RULE1='1. Never push to the default branch. Never merge a PR.'
     DOD=$(cat <<EOF
 # Definition of done
@@ -341,8 +342,7 @@ The path check is authoritative: \`git rev-parse --git-dir\` and \`git rev-parse
 If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append \`blocked: launched in primary checkout, not an isolated worktree\` to the status file and stop.
 
 1. First action: create your branch: \`git checkout -b fm/$ID\`
-2. Install this worktree's dependencies before any tooling or tests: it was freshly cut and has no .venv/node_modules, so language servers and test runs are degraded until you do. Detect the stack and run the project's setup - Python (pyproject.toml/requirements*.txt): create a .venv and install (prefer \`uv sync\`, else \`pip install -r requirements*.txt\` plus any requirements-dev.txt); Node/TypeScript (package.json): \`npm ci\` (or the project's package manager). Prefer any setup command the README/AGENTS.md documents. Skip only if there's no dependency manifest.
-$SETUP2
+2. Install this worktree's dependencies before any tooling or tests: it was freshly cut and has no .venv/node_modules, so language servers and test runs are degraded until you do. Detect the stack and run the project's setup - Python (pyproject.toml/requirements*.txt): create a .venv and install (prefer \`uv sync\`, else \`pip install -r requirements*.txt\` plus any requirements-dev.txt); Node/TypeScript (package.json): \`npm ci\` (or the project's package manager). Prefer any setup command the README/AGENTS.md documents. Skip only if there's no dependency manifest.$SETUP2
 
 # Rules
 $RULE1

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -109,6 +109,7 @@ Only a named non-default branch checked out in `FM_ROOT` is a worktree tangle.
 `fm-guard.sh` prints the repair command on the next mutable fleet action, while `bin/fm-session-start.sh` reports the same condition through bootstrap as a `TANGLE:` line at session start.
 If another live session holds the fleet lock, both surfaces keep the alarm but switch to read-only wording with no repair command.
 Ship briefs also tell the crewmate to verify `pwd -P` and `git rev-parse --show-toplevel` before creating `fm/<id>`, then stop with a blocked status if it landed in the primary checkout.
+Because a freshly cut worktree has no gitignored environments such as `.venv` or `node_modules`, every ship brief then requires installing the project's dependencies right after branch creation, before any tooling or tests, so language servers and test runs work from the start.
 
 ## No-mistakes gate authority boundary
 

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -71,8 +71,8 @@ test_ship_modes_generate_clean_briefs() {
   pass "fm-brief.sh: no-mistakes/direct-PR/local-only briefs generate cleanly"
 }
 
-test_ship_dependency_setup_renders_by_mode_only() {
-  local home id proj brief scout dependency_step
+test_ship_dependency_setup_renders_all_modes() {
+  local home id proj brief dependency_step
   home="$TMP_ROOT/dependency-setup-home"
   write_registry "$home"
   IFS= read -r dependency_step <<'EOF'
@@ -93,11 +93,7 @@ EOF
   assert_grep '3. Run `no-mistakes doctor`' "$brief" \
     "no-mistakes brief did not renumber its doctor step to 3"
 
-  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-deps-scout no-registry-proj --scout >/dev/null 2>&1
-  scout="$home/data/brief-deps-scout/brief.md"
-  assert_no_grep "$dependency_step" "$scout" \
-    "scout brief incorrectly received the ship-only dependency-install step"
-  pass "fm-brief.sh: dependency setup renders for every ship mode and not scouts"
+  pass "fm-brief.sh: dependency setup renders for every ship mode"
 }
 
 test_faster_paths_use_configured_authority_without_stacked_review() {
@@ -371,7 +367,7 @@ test_scout_and_secondmate_scaffold() {
 test_script_parses
 test_help_includes_entire_header
 test_ship_modes_generate_clean_briefs
-test_ship_dependency_setup_renders_by_mode_only
+test_ship_dependency_setup_renders_all_modes
 test_faster_paths_use_configured_authority_without_stacked_review
 test_no_mistakes_dod_wording
 test_ship_project_memory_wording

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -71,6 +71,35 @@ test_ship_modes_generate_clean_briefs() {
   pass "fm-brief.sh: no-mistakes/direct-PR/local-only briefs generate cleanly"
 }
 
+test_ship_dependency_setup_renders_by_mode_only() {
+  local home id proj brief scout dependency_step
+  home="$TMP_ROOT/dependency-setup-home"
+  write_registry "$home"
+  IFS= read -r dependency_step <<'EOF'
+2. Install this worktree's dependencies before any tooling or tests: it was freshly cut and has no .venv/node_modules, so language servers and test runs are degraded until you do. Detect the stack and run the project's setup - Python (pyproject.toml/requirements*.txt): create a .venv and install (prefer `uv sync`, else `pip install -r requirements*.txt` plus any requirements-dev.txt); Node/TypeScript (package.json): `npm ci` (or the project's package manager). Prefer any setup command the README/AGENTS.md documents. Skip only if there's no dependency manifest.
+EOF
+
+  for id_proj in "brief-deps-nomistakes:no-registry-proj" "brief-deps-direct:direct-proj" "brief-deps-local:local-proj"; do
+    id=${id_proj%%:*}
+    proj=${id_proj##*:}
+    FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" "$proj" >/dev/null 2>&1
+    brief="$home/data/$id/brief.md"
+    assert_grep "$dependency_step" "$brief" \
+      "$id: ship brief missing the shared dependency-install step"
+  done
+
+  brief="$home/data/brief-deps-nomistakes/brief.md"
+  # shellcheck disable=SC2016 # Literal backticks must remain unexpanded.
+  assert_grep '3. Run `no-mistakes doctor`' "$brief" \
+    "no-mistakes brief did not renumber its doctor step to 3"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-deps-scout no-registry-proj --scout >/dev/null 2>&1
+  scout="$home/data/brief-deps-scout/brief.md"
+  assert_no_grep "$dependency_step" "$scout" \
+    "scout brief incorrectly received the ship-only dependency-install step"
+  pass "fm-brief.sh: dependency setup renders for every ship mode and not scouts"
+}
+
 test_faster_paths_use_configured_authority_without_stacked_review() {
   local home id brief
   home="$TMP_ROOT/configured-authority-home"
@@ -334,7 +363,7 @@ test_scout_and_secondmate_scaffold() {
     || fail "fm-brief.sh secondmate scaffold exited non-zero"
   brief="$BRIEF_HOME/data/brief-sm-q6/brief.md"
   assert_present "$brief" "secondmate charter was not scaffolded"
-  assert_grep "persistent second mate" "$brief" \
+  assert_grep "persistent second mate managed by the main firstmate" "$brief" \
     "secondmate charter must declare its role"
   pass "fm-brief: scout and secondmate code paths still scaffold well-formed briefs"
 }
@@ -342,6 +371,7 @@ test_scout_and_secondmate_scaffold() {
 test_script_parses
 test_help_includes_entire_header
 test_ship_modes_generate_clean_briefs
+test_ship_dependency_setup_renders_by_mode_only
 test_faster_paths_use_configured_authority_without_stacked_review
 test_no_mistakes_dod_wording
 test_ship_project_memory_wording


### PR DESCRIPTION
## Intent

Ensure every rendered ship brief created by fm-brief.sh tells crewmates, immediately after branch creation and before tooling or tests, to install dependencies in the freshly cut worktree because gitignored .venv and node_modules environments are absent. The dependency bootstrap instruction must be unconditional shared SHIP heredoc text across no-mistakes, direct-PR, and local-only modes; the no-mistakes doctor instruction must become step 3; and the script header must document this setup behavior. Extend the existing colocated fm-brief behavior test to assert the full rendered dependency step in all three ship modes and the step-3 no-mistakes doctor line. Do not assert anything about scout briefs either way because scout dependency bootstrap is intentionally out of scope, not prohibited. Keep the change based on main, shellcheck-clean through bin/fm-lint.sh, and do not modify generated files.

## What Changed

- `bin/fm-brief.sh` now renders an unconditional dependency-install step in every ship brief (no-mistakes, direct-PR, and local-only), placed right after branch creation and before tooling, so crewmates restore gitignored environments like `.venv` and `node_modules` in a freshly cut worktree; the no-mistakes doctor instruction moves to step 3, and the script header documents the new setup behavior.
- Fixed the rendering so direct-PR and local-only briefs no longer emit a stray blank line before `# Rules` when no doctor step is present, and extended `tests/fm-brief.test.sh` to assert the full dependency step across all three ship modes plus the step-3 doctor line (scout briefs are intentionally left unasserted).
- Documented the ship-brief dependency-install step in `docs/architecture.md`.

## Risk Assessment

✅ Low: A small, well-bounded change to one generated-brief template plus a colocated fixed-string test whose expectation byte-matches the emitted line in all three ship modes, with the prior round's blank-line fix applied exactly as directed and all remaining round-1 concerns explicitly ignored by the user.

## Testing

Ran the extended colocated fm-brief behavior test (all 15 cases pass; full suite passed as baseline), then generated real briefs end-to-end in all three ship modes plus a scout brief and captured them as artifacts: every ship brief renders the unconditional dependency-install step 2 immediately after branch creation, the no-mistakes doctor step is step 3 with no stray blank line in the other modes, --help documents the behavior, and scout briefs are untouched. No screenshot evidence applies because the end-user surface is the generated markdown brief itself, captured verbatim.

<details>
<summary>Evidence: Generated no-mistakes ship brief (dependency step 2, doctor step 3)</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of no-registry-proj, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/evid-nomistakes`
2. Install this worktree's dependencies before any tooling or tests: it was freshly cut and has no .venv/node_modules, so language servers and test runs are degraded until you do. Detect the stack and run the project's setup - Python (pyproject.toml/requirements*.txt): create a .venv and install (prefer `uv sync`, else `pip install -r requirements*.txt` plus any requirements-dev.txt); Node/TypeScript (package.json): `npm ci` (or the project's package manager). Prefer any setup command the README/AGENTS.md documents. Skip only if there's no dependency manifest.
3. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/fm-brief-evidence.qE7uoP/state/evid-nomistakes.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs to a human (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.
   When firstmate replies or a blocker clears and you resume, append `resolved: {how it was decided or unblocked}` (add the same `[key=<slug>]` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/Users/eugene/.no-mistakes/worktrees/815d1e47484d/01KXT21VZP6918FB4ET34J92PA/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/Users/eugene/.no-mistakes/worktrees/815d1e47484d/01KXT21VZP6918FB4ET34J92PA/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are not yours to answer: escalate to firstmate (rule 6) and stop.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: the captain, not you, owns the ask-user decisions it would silently auto-resolve.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
```
</details>
<details>
<summary>Evidence: Generated direct-PR ship brief (dependency step 2)</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of direct-proj, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/evid-directpr`
2. Install this worktree's dependencies before any tooling or tests: it was freshly cut and has no .venv/node_modules, so language servers and test runs are degraded until you do. Detect the stack and run the project's setup - Python (pyproject.toml/requirements*.txt): create a .venv and install (prefer `uv sync`, else `pip install -r requirements*.txt` plus any requirements-dev.txt); Node/TypeScript (package.json): `npm ci` (or the project's package manager). Prefer any setup command the README/AGENTS.md documents. Skip only if there's no dependency manifest.

# Rules
1. Never push to the default branch (push only your `fm/evid-directpr` branch). Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/fm-brief-evidence.qE7uoP/state/evid-directpr.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs to a human (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.
   When firstmate replies or a blocker clears and you resume, append `resolved: {how it was decided or unblocked}` (add the same `[key=<slug>]` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/Users/eugene/.no-mistakes/worktrees/815d1e47484d/01KXT21VZP6918FB4ET34J92PA/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/Users/eugene/.no-mistakes/worktrees/815d1e47484d/01KXT21VZP6918FB4ET34J92PA/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
This project ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
The task is complete only when committed on your branch.
When it is implemented and committed, push your branch and open a PR with `gh-axi`, then append `done: PR {url}` to the status file and stop.
Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
```
</details>
<details>
<summary>Evidence: Generated local-only ship brief (dependency step 2)</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of local-proj, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/evid-localonly`
2. Install this worktree's dependencies before any tooling or tests: it was freshly cut and has no .venv/node_modules, so language servers and test runs are degraded until you do. Detect the stack and run the project's setup - Python (pyproject.toml/requirements*.txt): create a .venv and install (prefer `uv sync`, else `pip install -r requirements*.txt` plus any requirements-dev.txt); Node/TypeScript (package.json): `npm ci` (or the project's package manager). Prefer any setup command the README/AGENTS.md documents. Skip only if there's no dependency manifest.

# Rules
1. Never push to any remote and never open a PR. Work only on your `fm/evid-localonly` branch; firstmate handles the merge into local `main`.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/fm-brief-evidence.qE7uoP/state/evid-localonly.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs to a human (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.
   When firstmate replies or a blocker clears and you resume, append `resolved: {how it was decided or unblocked}` (add the same `[key=<slug>]` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/Users/eugene/.no-mistakes/worktrees/815d1e47484d/01KXT21VZP6918FB4ET34J92PA/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/Users/eugene/.no-mistakes/worktrees/815d1e47484d/01KXT21VZP6918FB4ET34J92PA/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
This project ships **local-only**: no remote, no PR, no pipeline.
The task is complete only when committed on your branch `fm/evid-localonly`. Do NOT push, do NOT open a PR, do NOT merge.
Keep your branch a clean fast-forward onto the current default branch - if `main` has advanced, rebase onto it so the eventual merge stays a fast-forward.
When it is implemented and committed, append `done: ready in branch fm/evid-localonly` to the status file and stop.
The configured merge authority approves the ready branch, then firstmate merges it into local `main` through the guarded fast-forward path.
```
</details>
<details>
<summary>Evidence: Generated scout brief (no dependency step, as intended)</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of no-registry-proj, at a detached HEAD on a clean default branch.
This is a SCOUT task: the deliverable is a written report, not a PR.
The worktree is your laboratory - install, run, edit, and make scratch commits freely; all of it is discarded at teardown.
The report is the only thing that survives, so anything worth keeping must be in it.

# Rules
1. Never push to any remote and never open a PR.
2. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/fm-brief-evidence.qE7uoP/state/evid-scout.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on and the needs-decision/blocked/paused/done/failed states. No step-by-step
   FYI progress lines; firstmate reads your pane for that.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset):
   firstmate then leaves your idle pane alone and rechecks it on a long cadence instead of
   treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs to a human (product choices, destructive actions),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.
   When firstmate replies or a blocker clears and you resume, append `resolved: {how it was decided or unblocked}` (add the same `[key=<slug>]` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Definition of done
Write your findings to `/tmp/fm-brief-evidence.qE7uoP/data/evid-scout/report.md`.
The report must stand alone: what you did, what you found, the evidence (commands run, output, file:line references), and what you recommend.
Before reporting done, read and follow `/Users/eugene/.no-mistakes/worktrees/815d1e47484d/01KXT21VZP6918FB4ET34J92PA/.agents/skills/decision-hold-lifecycle/SKILL.md` and pass its shared completion gate for the report and any visual review.
When the report is complete, append `done: {one-line conclusion}` to the status file and stop.
If your findings reveal work that should ship (e.g. you reproduced a bug and the fix is clear), say so in the report; firstmate may promote this task in place, and you would then receive mode-specific ship instructions as a follow-up message.
```
</details>
<details>
<summary>Evidence: Rendered setup-section excerpts across all modes</summary>

<code>## brief-no-mistakes&#10;1. First action: create your branch: `git checkout -b fm/evid-nomistakes`&#10;2. Install this worktree&#39;s dependencies before any tooling or tests: it was freshly cut and has no .venv/node_modules, so language servers and test runs are degraded until you do. Detect the stack and run the project&#39;s setup - Python (pyproject.toml/requirements*.txt): create a .venv and install (prefer `uv sync`, else `pip install -r requirements*.txt` plus any requirements-dev.txt); Node/TypeScript (package.json): `npm ci` (or the project&#39;s package manager). Prefer any setup command the README/AGENTS.md documents. Skip only if there&#39;s no dependency manifest.&#10;3. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.&#10;(direct-PR and local-only render the identical step 2 with no doctor step and no stray blank line; scout briefs carry no dependency step)</code>

```text
# Rendered setup sections of freshly generated ship briefs (bin/fm-brief.sh @ f0233d3)

## brief-no-mistakes
1. First action: create your branch: `git checkout -b fm/evid-nomistakes`
2. Install this worktree's dependencies before any tooling or tests: it was freshly cut and has no .venv/node_modules, so language servers and test runs are degraded until you do. Detect the stack and run the project's setup - Python (pyproject.toml/requirements*.txt): create a .venv and install (prefer `uv sync`, else `pip install -r requirements*.txt` plus any requirements-dev.txt); Node/TypeScript (package.json): `npm ci` (or the project's package manager). Prefer any setup command the README/AGENTS.md documents. Skip only if there's no dependency manifest.
3. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.


## brief-direct-pr
1. First action: create your branch: `git checkout -b fm/evid-directpr`
2. Install this worktree's dependencies before any tooling or tests: it was freshly cut and has no .venv/node_modules, so language servers and test runs are degraded until you do. Detect the stack and run the project's setup - Python (pyproject.toml/requirements*.txt): create a .venv and install (prefer `uv sync`, else `pip install -r requirements*.txt` plus any requirements-dev.txt); Node/TypeScript (package.json): `npm ci` (or the project's package manager). Prefer any setup command the README/AGENTS.md documents. Skip only if there's no dependency manifest.

# Rules

## brief-local-only
1. First action: create your branch: `git checkout -b fm/evid-localonly`
2. Install this worktree's dependencies before any tooling or tests: it was freshly cut and has no .venv/node_modules, so language servers and test runs are degraded until you do. Detect the stack and run the project's setup - Python (pyproject.toml/requirements*.txt): create a .venv and install (prefer `uv sync`, else `pip install -r requirements*.txt` plus any requirements-dev.txt); Node/TypeScript (package.json): `npm ci` (or the project's package manager). Prefer any setup command the README/AGENTS.md documents. Skip only if there's no dependency manifest.

# Rules

## brief-scout (no dependency step; scout is out of scope)
dependency-install step absent, as expected for scouts
```
</details>
<details>
<summary>Evidence: fm-brief test transcript (15/15 ok)</summary>

```text
ok - fm-brief.sh: bash -n succeeds
ok - fm-brief.sh: --help renders the complete header
ok - fm-brief.sh: no-mistakes/direct-PR/local-only briefs generate cleanly
ok - fm-brief.sh: dependency setup renders for every ship mode
ok - fm-brief.sh: faster paths use configured authority without stacked review
ok - fm-brief.sh: no-mistakes DOD wording avoids the apostrophe regression
ok - fm-brief.sh: ship project-memory wording carries the AGENTS.md authoring bar
ok - fm-brief.sh: --herdr-lab emits the complete hard safety contract
ok - fm-brief.sh: --herdr-lab uses its quoted Firstmate-owned helper path
ok - fm-brief.sh: ship and scout scaffolds make omitted Herdr intent fail-visible
ok - fm-brief.sh: Herdr lab contract covers scouts and rejects secondmate misuse
ok - fm-brief.sh: --no-projects scaffolds a project-less charter and guards misuse
ok - fm-brief.sh: custom pause verb renders in every scaffold
ok - fm-brief.sh: investigation and visual-review completions load the shared decision policy
ok - fm-brief: scout and secondmate code paths still scaffold well-formed briefs
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 4 issues found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-brief.sh:344` - The generated dependency step tells crewmates to run `pip install -r requirements*.txt`. When a project has more than one matching file (e.g. requirements.txt and requirements-dev.txt), the shell expands the glob to `pip install -r requirements.txt requirements-dev.txt`; pip reads only the first as a requirements file and treats the second as a package name, so the install fails. The instruction already says &#34;plus any requirements-dev.txt&#34; separately, so the glob is both wrong and redundant - use `pip install -r requirements.txt` instead.
- ℹ️ `bin/fm-brief.sh:345` - `$SETUP2` is empty for direct-PR and local-only modes, so those briefs now render two consecutive blank lines between the new step 2 and the `# Rules` heading (the bare `$SETUP2` line plus the intentional separator). Previously `$SETUP2` was appended to the end of the branch-creation line, so an empty value produced no stray line. Cosmetic in the rendered brief only; can be tidied by keeping the doctor line appended to step 2&#39;s line or by trimming trailing blanks.
- ℹ️ `bin/fm-brief.sh:344` - The dependency bootstrap is only in the ship heredoc; scout briefs (the branch exiting at line 269) get no equivalent instruction, even though scouts are the default classification for bug reproduction and diagnosis - work that needs a usable test environment in an equally fresh worktree. Understood to be an intentional scope boundary for this change, but the reproduction case makes it a real gap worth an explicit follow-up decision.
- ℹ️ `tests/fm-brief.test.sh:362` - The secondmate charter assertion was changed from &#34;persistent domain supervisor&#34; to &#34;persistent second mate managed by the main firstmate&#34;. The old string does not appear anywhere in bin/fm-brief.sh at the base commit either, so this test was already failing on main and the change is a repair of pre-existing breakage rather than a consequence of this feature. Noting it so the unrelated scope is visible in review; the fix itself matches bin/fm-brief.sh:132 exactly.

🔧 Fix: drop stray blank line in direct-PR and local-only briefs
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- <code>Baseline: full `tests/*.test.sh` suite via the configured test command (ran successfully before this validation)</code>
- <code>`bash tests/fm-brief.test.sh` — all 15 cases pass, including the new `dependency setup renders for every ship mode` case and the step-3 doctor assertion</code>
- <code>Manual e2e: generated real briefs with `FM_HOME=&lt;fixture&gt; bin/fm-brief.sh &lt;id&gt; &lt;proj&gt;` for no-mistakes, direct-PR, and local-only projects plus a `--scout` brief, then inspected the rendered setup sections</code>
- <code>Byte-level check (`sed -n l`) that direct-PR/local-only briefs render step 2 followed by exactly one blank line before `# Rules` (no stray blank line)</code>
- <code>`bin/fm-brief.sh --help | grep &#39;dependency installation&#39;` — header documents the new setup behavior</code>
- <code>`git merge-base --is-ancestor bc1a21b HEAD` — branch is based on the main tip</code>
- `Confirmed scout brief contains no dependency-install step (intentionally out of scope)`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
