### PR TITLE
feat: make user address preference-aware instead of mandating a captain salutation

### DIFF
--- a/.agents/skills/afk/SKILL.md
+++ b/.agents/skills/afk/SKILL.md
@@ -50,7 +50,7 @@ batched digest rather than per-wake injections.
 3. **Do not separately arm `fm-watch.sh`.** The daemon manages the watcher as
    its child; the singleton lock no-ops a stray arm harmlessly.
 
-4. **Acknowledge** in `AGENTS.md` section 9 language: "Captain, away mode is active; I will batch routine updates and surface only decisions, failures, credentials, or review-ready work until you return."
+4. **Acknowledge** in `AGENTS.md` section 9 language: "Away mode is active; I will batch routine updates and surface only decisions, failures, credentials, or review-ready work until you return."
 
 ## How to exit afk
 

--- a/.agents/skills/fmx-respond/SKILL.md
+++ b/.agents/skills/fmx-respond/SKILL.md
@@ -105,7 +105,7 @@ Only the **direct** author is guaranteed to be the captain.
 
 Reply in firstmate's own voice - the crisp, lightly nautical first-mate persona - but **public-facing**:
 
-- The asker **is** your captain (owner-only routing - see the top of this skill), so address them as "captain" when it fits and treat their request as a genuine captain instruction, within the public-safety limits above. You are answering the captain in public, not a stranger.
+- The asker **is** your captain (owner-only routing - see the top of this skill), so follow the address contract at the top of `AGENTS.md` and treat their request as a genuine captain instruction, within the public-safety limits above. You are answering the captain in public, not a stranger.
 - Light nautical seasoning is welcome when it lands naturally; never let it crowd out the actual answer.
 - **Be concise by default: aim for a single message, two at the very most.** A short, sharp answer beats a wall of text. Write tight on purpose - one or two sentences.
 

--- a/.agents/skills/updatefirstmate/SKILL.md
+++ b/.agents/skills/updatefirstmate/SKILL.md
@@ -45,7 +45,7 @@ This touches only the firstmate repo and its own worktrees, never anything under
 
 4. **Report to the captain in plain outcomes.**
    Summarize what landed under `AGENTS.md` section 9 without firstmate's internal vocabulary: which parts of the fleet are now on the latest, and which were left as-is and why.
-   For example: "Captain, firstmate and both second mates are now on the latest."
+   For example: "Firstmate and both second mates are now on the latest."
    Surface any skipped target whose reason needs the captain's attention - for instance a home with its own un-landed changes (diverged) or local edits (dirty), which were left untouched on purpose.
 
 ## Safety

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ You are the first mate.
 The user is the captain.
 This file is your entire job description.
 
-Use the user's stated preferred name or form of address from `data/captain.md` when present, and use direct address only when it is useful.
+Use the user's stated preferred name or form of address from `data/captain.md` or inherited `data/captain-shared.md` when present, and use direct address only when it is useful.
 When no preference exists, default to neutral direct prose with no required salutation or repeated form of address.
 Use light nautical seasoning only when it fits: the occasional "aye", "on deck", "shipshape", "under way", or "ahoy" may land naturally.
 Keep that seasoning optional, never let it override a stated address preference, and never let it obscure technical content; never use it in commits, briefs, PRs, or anything crewmates or other tools read; drop the playful flavor entirely when delivering bad news or relaying serious findings.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,11 +4,10 @@ You are the first mate.
 The user is the captain.
 This file is your entire job description.
 
-Address the user as "captain" at least once in every response.
-This is mandatory respectful address, not performance: it applies even when delivering bad news or relaying serious findings, such as "Captain, the build broke - ...".
-Do not force it into every sentence, but never send a response with zero direct address.
+Use the user's stated preferred name or form of address from `data/captain.md` when present, and use direct address only when it is useful.
+When no preference exists, default to neutral direct prose with no required salutation or repeated form of address.
 Use light nautical seasoning only when it fits: the occasional "aye", "on deck", "shipshape", "under way", or "ahoy" may land naturally.
-Keep that seasoning optional and never let it obscure technical content; never use it in commits, briefs, PRs, or anything crewmates or other tools read; drop the playful flavor entirely when delivering bad news or relaying serious findings.
+Keep that seasoning optional, never let it override a stated address preference, and never let it obscure technical content; never use it in commits, briefs, PRs, or anything crewmates or other tools read; drop the playful flavor entirely when delivering bad news or relaying serious findings.
 For captain-facing escalation style and outcome phrasing, see section 9.
 
 ## 1. Identity and prime directives

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ For Pi, approve the project trust prompt once per clone on first launch so both 
 # fm-fix-login-k3 and fm-dark-mode-p7.
 # Minutes later:
 
-  PR ready for review, captain: https://github.com/you/xyz/pull/42
+  PR ready for review: https://github.com/you/xyz/pull/42
   (fix flaky login test - risk: low - CI green)
 
 > alright merge it

--- a/tests/fm-captain-translation-contract.test.sh
+++ b/tests/fm-captain-translation-contract.test.sh
@@ -141,6 +141,10 @@ test_outward_facing_skill_points_reference_section_9_owner() {
     "X reply safety does not state that it supplements section 9"
   assert_grep "under \`AGENTS.md\` section 9 without firstmate's internal vocabulary" "$UPDATE" \
     "Firstmate update reporting does not reference section 9"
+  assert_grep "Firstmate and both second mates are now on the latest" "$UPDATE" \
+    "update reporting lacks a local neutral plain-English example"
+  assert_no_grep "Captain, firstmate and both second mates" "$UPDATE" \
+    "update reporting example overrides the address preference"
   pass "outward-facing skill handoffs point to the section 9 owner"
 }
 

--- a/tests/fm-captain-translation-contract.test.sh
+++ b/tests/fm-captain-translation-contract.test.sh
@@ -25,7 +25,7 @@ section_9() {
 }
 
 test_chat_address_respects_private_preference() {
-  assert_grep 'Use the user'"'"'s stated preferred name or form of address from `data/captain.md` when present, and use direct address only when it is useful.' "$AGENTS" \
+  assert_grep "Use the user's stated preferred name or form of address from \`data/captain.md\` when present, and use direct address only when it is useful." "$AGENTS" \
     "AGENTS.md does not apply the private address preference"
   assert_grep 'When no preference exists, default to neutral direct prose with no required salutation or repeated form of address.' "$AGENTS" \
     "AGENTS.md does not provide a neutral no-preference default"

--- a/tests/fm-captain-translation-contract.test.sh
+++ b/tests/fm-captain-translation-contract.test.sh
@@ -25,7 +25,7 @@ section_9() {
 }
 
 test_chat_address_respects_private_preference() {
-  assert_grep "Use the user's stated preferred name or form of address from \`data/captain.md\` when present, and use direct address only when it is useful." "$AGENTS" \
+  assert_grep "Use the user's stated preferred name or form of address from \`data/captain.md\` or inherited \`data/captain-shared.md\` when present, and use direct address only when it is useful." "$AGENTS" \
     "AGENTS.md does not apply the private address preference"
   assert_grep 'When no preference exists, default to neutral direct prose with no required salutation or repeated form of address.' "$AGENTS" \
     "AGENTS.md does not provide a neutral no-preference default"

--- a/tests/fm-captain-translation-contract.test.sh
+++ b/tests/fm-captain-translation-contract.test.sh
@@ -24,6 +24,22 @@ section_9() {
   ' "$AGENTS"
 }
 
+test_chat_address_respects_private_preference() {
+  assert_grep 'Use the user'"'"'s stated preferred name or form of address from `data/captain.md` when present, and use direct address only when it is useful.' "$AGENTS" \
+    "AGENTS.md does not apply the private address preference"
+  assert_grep 'When no preference exists, default to neutral direct prose with no required salutation or repeated form of address.' "$AGENTS" \
+    "AGENTS.md does not provide a neutral no-preference default"
+  assert_grep 'never let it override a stated address preference' "$AGENTS" \
+    "nautical language can override the stated address preference"
+  assert_no_grep 'Address the user as "captain"' "$AGENTS" \
+    "AGENTS.md reintroduced a mandatory captain salutation"
+  assert_no_grep 'never send a response with zero direct address' "$AGENTS" \
+    "AGENTS.md reintroduced mandatory direct address"
+  assert_grep 'The user is the captain.' "$AGENTS" \
+    "the internal captain role vocabulary was removed"
+  pass "chat address follows private preference without removing internal captain vocabulary"
+}
+
 test_section_9_owns_positive_translation_contract() {
   local contract
   contract=$(section_9)
@@ -105,8 +121,10 @@ test_outward_facing_skill_points_reference_section_9_owner() {
     "bootstrap diagnostics do not reference section 9 at captain handoff"
   assert_grep "Acknowledge** in \`AGENTS.md\` section 9 language" "$AFK" \
     "afk acknowledgement does not reference section 9"
-  assert_grep "Captain, away mode is active; I will batch routine updates" "$AFK" \
-    "afk acknowledgement lacks a local plain-English example"
+  assert_grep "Away mode is active; I will batch routine updates" "$AFK" \
+    "afk acknowledgement lacks a local neutral plain-English example"
+  assert_no_grep "Captain, away mode is active" "$AFK" \
+    "afk acknowledgement overrides the address preference"
   assert_grep "as decisions from Bearings' Captain's Call section under \`AGENTS.md\` section 9" "$DECISION" \
     "decision relay does not reference section 9"
   assert_grep "using \`AGENTS.md\` section 9; do not mention metadata, harness, window, or worktree" "$RECOVERY" \
@@ -138,6 +156,7 @@ test_section_9_owner_is_not_duplicated_into_skills() {
   pass "skills cross-reference section 9 instead of duplicating the mapping list"
 }
 
+test_chat_address_respects_private_preference
 test_section_9_owns_positive_translation_contract
 test_scout_remains_allowed_house_vocabulary
 test_compressed_safety_labels_have_plain_renderings

--- a/tests/fm-cd-pretool-check.test.sh
+++ b/tests/fm-cd-pretool-check.test.sh
@@ -435,6 +435,7 @@ test_pi_wiring() {
 }
 
 test_scripts_are_shellcheck_clean() {
+  command -v shellcheck >/dev/null 2>&1 || { pass "shellcheck not installed, skipping"; return; }
   shellcheck "$ROOT/bin/fm-cd-pretool-check.sh" >/dev/null 2>&1 \
     || fail "bin/fm-cd-pretool-check.sh is not shellcheck-clean"
   pass "bin/fm-cd-pretool-check.sh is shellcheck-clean"

--- a/tests/fm-sessionstart-nudge.test.sh
+++ b/tests/fm-sessionstart-nudge.test.sh
@@ -5,6 +5,8 @@ set -u
 # shellcheck source=tests/lib.sh
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
+# A surrounding no-mistakes gate exports NO_MISTAKES_GATE=1, which makes the
+# nudge silent; clear it so only test_gate_env_is_silent exercises that path.
 unset NO_MISTAKES_GATE
 
 TMP_ROOT=$(fm_test_tmproot fm-sessionstart-nudge)


### PR DESCRIPTION
## Intent

The developer wanted to remove Firstmate's mandatory rule requiring every response to address the user as "captain," replacing it with a preference-aware address contract: use the preferred name from data/captain.md when present (Oz, addressed only when useful), fall back to neutral prose with no required salutation, and keep nautical language strictly optional. They required preserving "captain" as the internal role name for authority and lifecycle concepts, not hardcoding "Oz" into shared tracked templates, updating any duplicate or contradictory salutation mandates in docs/tests/skills, and adding regression coverage that rejects a mandatory salutation while allowing the role vocabulary. They constrained the change to be minimal (one sentence per Markdown line, plain dashes, no unrelated cleanup) and to follow the firstmate coding guidelines skill. After committing, they directed the agent to ship the change through the no-mistakes validation pipeline without --yes, resolving gates along the way: authorizing a fix to a contradictory canned "Captain" message in the updatefirstmate skill, clearing a ShellCheck 0.11.0 lint blocker, and redirecting the push to a fork at s3-oz/firstmate after a 403 on the upstream repo.

## What Changed

- Replaced the mandatory "address the user as captain" rule in AGENTS.md with a preference-aware contract: use the preferred name recorded in `data/captain.md` (or the shared `data/captain-shared.md`) when present, otherwise fall back to neutral prose with no required salutation; nautical language stays optional and "captain" remains the internal role name for authority/lifecycle concepts.
- Updated stale salutation wording that contradicted the new contract in the README quickstart example and the `afk`, `fmx-respond`, and `updatefirstmate` skills, pointing address guidance at the AGENTS.md contract instead.
- Added regression coverage in `tests/fm-captain-translation-contract.test.sh` that rejects reintroduction of a mandatory captain salutation while allowing role vocabulary, and hardened related tests (sanitizing an inherited `NO_MISTAKES_GATE` in the sessionstart-nudge test, skipping the shellcheck assertion when shellcheck is absent). The full test suite passed through the no-mistakes pipeline, including a negative check that re-adding the old mandate fails the contract test.

## Risk Assessment

✅ Low: The round's only change is a one-sentence documentation contract edit plus its matching test assertion, applied exactly as the user instructed with no runtime code touched.

## Testing

Ran the full test suite baseline plus the four changed test files (all pass), proved the new regression test rejects a reintroduced mandatory "captain" salutation via a temporary negative mutation, and demonstrated the preference-aware contract end-to-end by running the real fm-session-start.sh with a data/captain.md preference and capturing it in the agent-facing context digest. No visual evidence applies — this is a CLI/prompt-contract change with no rendered UI surface; CLI transcripts are the end-user surface.

<details>
<summary>Evidence: New AGENTS.md address contract (agent-facing preamble)</summary>

<code>Use the user&#39;s stated preferred name or form of address from `data/captain.md` or inherited `data/captain-shared.md` when present, and use direct address only when it is useful.&#10;When no preference exists, default to neutral direct prose with no required salutation or repeated form of address.&#10;Use light nautical seasoning only when it fits: the occasional &#34;aye&#34;, &#34;on deck&#34;, &#34;shipshape&#34;, &#34;under way&#34;, or &#34;ahoy&#34; may land naturally.&#10;Keep that seasoning optional, never let it override a stated address preference, and never let it obscure technical content...</code>

```text
# Firstmate

You are the first mate.
The user is the captain.
This file is your entire job description.

Use the user's stated preferred name or form of address from `data/captain.md` or inherited `data/captain-shared.md` when present, and use direct address only when it is useful.
When no preference exists, default to neutral direct prose with no required salutation or repeated form of address.
Use light nautical seasoning only when it fits: the occasional "aye", "on deck", "shipshape", "under way", or "ahoy" may land naturally.
Keep that seasoning optional, never let it override a stated address preference, and never let it obscure technical content; never use it in commits, briefs, PRs, or anything crewmates or other tools read; drop the playful flavor entirely when delivering bad news or relaying serious findings.
For captain-facing escalation style and outcome phrasing, see section 9.
```
</details>
<details>
<summary>Evidence: End-to-end: fm-session-start.sh injects the captain.md address preference into the agent&#39;s context digest</summary>

<code>data/captain.md&#10;--------------------------------------------------------------------------------&#10;Preferred name: Oz.&#10;Address me as Oz only when direct address is actually useful; no salutation required.&#10;&#10;data/captain-shared.md (shared, main-authoritative, read-only in secondmate homes)&#10;--------------------------------------------------------------------------------&#10;ABSENT</code>

```text
data/captain.md
--------------------------------------------------------------------------------
Preferred name: Oz.
Address me as Oz only when direct address is actually useful; no salutation required.

data/captain-shared.md (shared, main-authoritative, read-only in secondmate homes)
--------------------------------------------------------------------------------
ABSENT
```
</details>
<details>
<summary>Evidence: Regression test rejects a reintroduced mandatory salutation (negative mutation)</summary>

<code>== Reintroducing old mandatory salutation lines into AGENTS.md ==&#10;== Running tests/fm-captain-translation-contract.test.sh ==&#10;not ok - AGENTS.md reintroduced a mandatory captain salutation&#10;exit=1</code>

```text
== Reintroducing old mandatory salutation lines into AGENTS.md ==
== Running tests/fm-captain-translation-contract.test.sh ==
not ok - AGENTS.md reintroduced a mandatory captain salutation
exit=1
```
</details>
<details>
<summary>Evidence: Targeted test transcript (4 changed test files, all passing)</summary>

```text
== tests/fm-captain-translation-contract.test.sh ==
ok - chat address follows private preference without removing internal captain vocabulary
ok - section 9 owns the positive captain-facing translation contract
ok - scout remains allowed in private captain chat
ok - compressed safety labels require concrete plain renderings
ok - section 9 maps high-risk internal vocabulary families
ok - captain chat rejects verbatim internal evidence while private reports stay precise
ok - outward-facing skill handoffs point to the section 9 owner
ok - skills cross-reference section 9 instead of duplicating the mapping list
exit=0
== tests/fm-brief.test.sh ==
ok - fm-brief.sh: bash -n succeeds
ok - fm-brief.sh: --help renders the complete header
ok - fm-brief.sh: no-mistakes/direct-PR/local-only briefs generate cleanly
ok - fm-brief.sh: faster paths use configured authority without stacked review
ok - fm-brief.sh: no-mistakes DOD wording avoids the apostrophe regression
ok - fm-brief.sh: ship project-memory wording carries the AGENTS.md authoring bar
ok - fm-brief.sh: --herdr-lab emits the complete hard safety contract
ok - fm-brief.sh: --herdr-lab uses its quoted Firstmate-owned helper path
ok - fm-brief.sh: ship and scout scaffolds make omitted Herdr intent fail-visible
ok - fm-brief.sh: Herdr lab contract covers scouts and rejects secondmate misuse
ok - fm-brief.sh: --no-projects scaffolds a project-less charter and guards misuse
ok - fm-brief.sh: custom pause verb renders in every scaffold
ok - fm-brief.sh: investigation and visual-review completions load the shared decision policy
ok - fm-brief: scout and secondmate code paths still scaffold well-formed briefs
exit=0
== tests/fm-cd-pretool-check.test.sh ==
ok - cd-guard acceptance matrix: 63 cases x 5 harness entry forms, block/allow all correct
ok - cd-guard: fires in a secondmate home (its own primary session is a primary)
ok - cd-guard: inert in a crewmate/scout task worktree (linked git worktree)
ok - cd-guard: inert in a non-firstmate repo (no AGENTS.md)
ok - cd-guard: inert when not inside a git repo
ok - cd-guard: reproduces the cwd leak and denies the exact command that causes it
ok - cd-guard: fails open on empty stdin
ok - cd-guard: fails open on unparseable stdin JSON
ok - cd-guard: fails open (never blocks) when node is missing
ok - cd-guard: fails open on the stdin path when jq is missing
ok - cd-guard: prefilter fast-allows (skips node) when no cd/pushd/popd substring is present
ok - cd-guard: fm-cd-command-policy.mjs CLI honors the deny/allow output contract
ok - .claude/settings.json: PreToolUse invokes the cd-guard alongside the arm guard
ok - .codex/hooks.json: PreToolUse invokes the cd-guard alongside the arm guard
ok - .grok primary cd hook: PreToolUse invokes the cd-guard
ok - .opencode cd plugin: tool.execute.before invokes the cd-guard and blocks by throwing
ok - .pi primary extension: tool_call runs the cd-guard alongside the watcher-arm check
ok - bin/fm-cd-pretool-check.sh is shellcheck-clean
exit=0
== tests/fm-sessionstart-nudge.test.sh ==
ok - fm-sessionstart-nudge: a genuine primary gets exactly one instruction line
ok - fm-sessionstart-nudge: NO_MISTAKES_GATE is silent
ok - fm-sessionstart-nudge: .no-mistakes gate common-dir is silent
ok - fm-sessionstart-nudge: an unmarked linked task worktree is silent
ok - fm-sessionstart-nudge: a marked linked secondmate home is a primary
ok - fm-sessionstart-nudge: a checkout without state is silent
ok - fm-sessionstart-nudge: a lock holder in process ancestry is already run
ok - OpenCode session.created delivers the exact wrapper nudge once per session
ok - all five verified harnesses register the shared session-start nudge
exit=0
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed ✅</summary>

- ℹ️ `AGENTS.md:7` - The new address contract in AGENTS.md names only `data/captain.md` as the preference source, but AGENTS.md:111 also establishes `data/captain-shared.md` as the main-authoritative shared captain-preference file inherited by secondmates. A preferred name recorded only in captain-shared.md would fall outside the letter of the new rule. Likely acceptable because captain.md is documented as canonical and carries pointers to the shared file, but worth confirming the omission is intentional.
- ℹ️ `tests/fm-captain-translation-contract.test.sh:28` - test_chat_address_respects_private_preference asserts entire AGENTS.md sentences verbatim, so any future rewording of the address contract will break the test even when the semantics are preserved. This matches the file&#39;s existing assertion style and is deliberate regression coverage, so no change is needed.
- ℹ️ `tests/fm-cd-pretool-check.test.sh:438` - The shellcheck-absent guard reports the test as passing when shellcheck is not installed, which silently skips lint verification on machines without it. This mirrors the identical pre-existing pattern in tests/fm-arm-pretool-check.test.sh:531, so it is consistent repo style rather than a new weakening.

🔧 Fix: accept captain-shared.md as address-preference source
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- <code>Full suite baseline `for t in tests/*.test.sh; do bash $t; done` (ran successfully before this session)</code>
- <code>`bash tests/fm-captain-translation-contract.test.sh` including the new test_chat_address_respects_private_preference (all ok)</code>
- <code>`bash tests/fm-brief.test.sh`, `bash tests/fm-cd-pretool-check.test.sh`, `bash tests/fm-sessionstart-nudge.test.sh` (all ok)</code>
- <code>Negative regression check: temporarily appended the old &#39;Address the user as &#34;captain&#34;&#39; mandate to AGENTS.md and re-ran the contract test — it failed with `not ok - AGENTS.md reintroduced a mandatory captain salutation`, then restored AGENTS.md (clean git status)</code>
- <code>Repo-wide grep for surviving mandatory-salutation language (`Address the user as`, `Captain,`, `zero direct address`) — only internal role-vocabulary mentions remain</code>
- <code>End-to-end: ran real `bin/fm-session-start.sh` in a sandbox FM_HOME with data/captain.md stating a preferred name (Oz, no salutation) and captured the context digest showing the preference injected verbatim</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
