### PR TITLE
docs: document Chromium binary and shared-lib deps for chrome-devtools-axi

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -248,7 +248,7 @@ Secondmate homes inherit this file from the primary, so a secondmate's own crewm
 On session start the first mate detects what its required toolchain is missing or too old and lists each problem with either an exact install command or manual instructions.
 It installs automatically supported tools only after you say go; manual-only tools remain for you to install from the printed instructions.
 Required tools come in two parts: a universal toolchain every home needs regardless of backend, and a per-backend delta that follows the runtime backend actually resolved for this home.
-The universal toolchain is node, git, gh with GitHub auth via `gh auth login`, no-mistakes v1.31.2 or newer, gh-axi, chrome-devtools-axi with a real Chromium binary and its OS-level shared-library dependencies for a working headless launch, lavish-axi, compatible tasks-axi per "Backlog backend" above, and quota-axi.
+The universal toolchain is node, git, gh with GitHub auth via `gh auth login`, no-mistakes v1.31.2 or newer, gh-axi, chrome-devtools-axi, lavish-axi, compatible tasks-axi per "Backlog backend" above, and quota-axi.
 This section is the single owner of that universal toolchain list; backend guides' prerequisites point here and add only their backend-specific tools.
 In that list, no-mistakes runs the validation pipeline, gh-axi, chrome-devtools-axi, and lavish-axi cover GitHub, browser, and rich-review operations, and tasks-axi plus quota-axi back backlog mutations and quota-aware array dispatch.
 The per-backend delta is required only for the backend resolved from `FM_BACKEND`, then `config/backend`, then runtime auto-detection, then default `tmux`, so a home is never told to install a tool an inactive backend or feature would need.
@@ -262,9 +262,9 @@ When X mode is opted in, bootstrap also requires `curl` and `jq` before arming t
 `tasks-axi` and `quota-axi` are required bootstrap tools in every profile, the same class as `lavish-axi`.
 An absent or incompatible `tasks-axi` reports `MISSING: tasks-axi (install: npm install -g tasks-axi)`; when `config/backlog-backend` is not `manual` and compatible `tasks-axi` is on `PATH`, bootstrap stays silent and firstmate uses its verbs for routine backlog mutations, otherwise it hand-edits `data/backlog.md` until installation is approved and completed.
 An absent `quota-axi` reports `MISSING: quota-axi (install: npm install -g quota-axi)`; firstmate cannot resolve a profile array until current quota output is available for every candidate.
-A real Chromium binary is a required bootstrap tool in every profile, the same class as `lavish-axi`, needed alongside `chrome-devtools-axi` for a working headless launch.
+`chrome-devtools-axi`'s headless launches also need a real Chromium binary and its OS-level shared-library dependencies, but bootstrap does not yet detect or report this the way it does for `tasks-axi` and `quota-axi` above; no `MISSING: chromium` line exists today.
 The binary alone is not enough: on Debian/Ubuntu-family hosts a cached Playwright Chromium binary such as `~/.cache/ms-playwright/chromium-<version>/chrome-linux64/chrome` can still be missing OS-level shared libraries like `libnspr4` that are not installed by default.
-An absent or non-functional Chromium reports `MISSING: chromium (install: npx --yes playwright install-deps chromium)`, the same install-only-after-consent flow as every other automatically supported tool above.
+Until bootstrap gains that detection, install it yourself before session start with `npx --yes playwright install-deps chromium`.
 Bootstrap also reports a `TANGLE:` line when `FM_ROOT` is on a named non-default branch; follow the printed checkout remediation rather than treating it as an installable tool problem.
 In a read-only session that did not get the fleet lock, the same line is advisory and omits the checkout command.
 The locked session-start bootstrap step also runs a best-effort project clone refresh through `fm-fleet-sync.sh`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -248,7 +248,7 @@ Secondmate homes inherit this file from the primary, so a secondmate's own crewm
 On session start the first mate detects what its required toolchain is missing or too old and lists each problem with either an exact install command or manual instructions.
 It installs automatically supported tools only after you say go; manual-only tools remain for you to install from the printed instructions.
 Required tools come in two parts: a universal toolchain every home needs regardless of backend, and a per-backend delta that follows the runtime backend actually resolved for this home.
-The universal toolchain is node, git, gh with GitHub auth via `gh auth login`, no-mistakes v1.31.2 or newer, gh-axi, chrome-devtools-axi, lavish-axi, compatible tasks-axi per "Backlog backend" above, and quota-axi.
+The universal toolchain is node, git, gh with GitHub auth via `gh auth login`, no-mistakes v1.31.2 or newer, gh-axi, chrome-devtools-axi with a real Chromium binary and its OS-level shared-library dependencies for a working headless launch, lavish-axi, compatible tasks-axi per "Backlog backend" above, and quota-axi.
 This section is the single owner of that universal toolchain list; backend guides' prerequisites point here and add only their backend-specific tools.
 In that list, no-mistakes runs the validation pipeline, gh-axi, chrome-devtools-axi, and lavish-axi cover GitHub, browser, and rich-review operations, and tasks-axi plus quota-axi back backlog mutations and quota-aware array dispatch.
 The per-backend delta is required only for the backend resolved from `FM_BACKEND`, then `config/backend`, then runtime auto-detection, then default `tmux`, so a home is never told to install a tool an inactive backend or feature would need.
@@ -262,6 +262,9 @@ When X mode is opted in, bootstrap also requires `curl` and `jq` before arming t
 `tasks-axi` and `quota-axi` are required bootstrap tools in every profile, the same class as `lavish-axi`.
 An absent or incompatible `tasks-axi` reports `MISSING: tasks-axi (install: npm install -g tasks-axi)`; when `config/backlog-backend` is not `manual` and compatible `tasks-axi` is on `PATH`, bootstrap stays silent and firstmate uses its verbs for routine backlog mutations, otherwise it hand-edits `data/backlog.md` until installation is approved and completed.
 An absent `quota-axi` reports `MISSING: quota-axi (install: npm install -g quota-axi)`; firstmate cannot resolve a profile array until current quota output is available for every candidate.
+A real Chromium binary is a required bootstrap tool in every profile, the same class as `lavish-axi`, needed alongside `chrome-devtools-axi` for a working headless launch.
+The binary alone is not enough: on Debian/Ubuntu-family hosts a cached Playwright Chromium binary such as `~/.cache/ms-playwright/chromium-<version>/chrome-linux64/chrome` can still be missing OS-level shared libraries like `libnspr4` that are not installed by default.
+An absent or non-functional Chromium reports `MISSING: chromium (install: npx --yes playwright install-deps chromium)`, the same install-only-after-consent flow as every other automatically supported tool above.
 Bootstrap also reports a `TANGLE:` line when `FM_ROOT` is on a named non-default branch; follow the printed checkout remediation rather than treating it as an installable tool problem.
 In a read-only session that did not get the fleet lock, the same line is advisory and omits the checkout command.
 The locked session-start bootstrap step also runs a best-effort project clone refresh through `fm-fleet-sync.sh`.


### PR DESCRIPTION
## Intent

Document a real Chromium binary and its OS-level shared-library dependency set as a required bootstrap toolchain item in docs/configuration.md's Toolchain section, alongside chrome-devtools-axi, since the devtools tool is useless without a working headless-capable Chromium binary.

## What Changed
- Added a note in the Toolchain section clarifying that `chrome-devtools-axi`'s headless launches require a real Chromium binary plus its OS-level shared-library dependencies (e.g. `libnspr4`), separate from the `chrome-devtools-axi` package itself.
- Clarified that bootstrap does not currently detect or report a missing Chromium binary/shared-libs (no `MISSING: chromium` line exists), unlike its detection of `tasks-axi` and `quota-axi`.
- Documented the manual remediation step (`npx --yes playwright install-deps chromium`) to install the dependency before session start until bootstrap detection is added.

## Risk Assessment

✅ Low: Docs-only change with no code/behavior impact; the only concern is a wording-framing tension against the stated intent, not a functional or safety risk.

## Testing

- ⏭️ **Test** - skipped

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 warning</summary>

- ⚠️ `docs/configuration.md:247` - The intent requires documenting the Chromium binary + shared-lib deps as a &#34;required bootstrap toolchain item ... alongside chrome-devtools-axi.&#34; Commit 1 (70aae58) did this literally, adding it to the universal-toolchain list line and calling it &#34;a required bootstrap tool in every profile, the same class as `lavish-axi`.&#34; Commit 2 (98d44d3) reverted the universal-toolchain line (233) back to plain `chrome-devtools-axi` and rewrote the detail paragraph (247-249) to explicitly say bootstrap does NOT detect/report Chromium (&#34;no `MISSING: chromium` line exists today&#34;) and that it must be installed manually before session start. This is a legitimate accuracy fix — a repo-wide grep confirms no bootstrap code detects Chromium, so the original claim of an auto-detected `MISSING: chromium` line was false — but it also walks back the &#39;required toolchain item&#39; framing the intent asked for, and removes Chromium from the doc&#39;s own declared single source of truth for the universal toolchain (line 233).

</details>

<details>
<summary>⏭️ **Test** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⏭️ **Lint** - skipped</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
