### PR TITLE
feat: recognize Cursor agent for session lock and harness detect

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -44,7 +44,7 @@ If the captain asks for a new harness, propose verifying it first: spawn a trivi
 On `unknown`, ask the captain instead of guessing.
 A captain override always beats detection.
 When verifying a new adapter, record its env marker and command name in `bin/fm-harness.sh`.
-`cursor` may be detected for session identity and lock ancestry (`docs/cursor-harness.md`); it is not a verified launch template - spawn with raw `agent` / `agent --yolo` until full adapter verification lands.
+`cursor` may be detected for session identity and lock ancestry, and has a provisional `fm-spawn` launch template (`agent --yolo --trust` plus brief feed; `docs/cursor-harness.md`). It is not a fully verified adapter - busy signature, turn-end guard, and supervision protocol remain open before promoting it alongside claude/codex/opencode/pi/grok.
 
 For stuck recovery, the target window's harness is recorded as `harness=` in `state/<id>.meta`.
 Use that value for interrupt, exit, resume, and skill-invocation facts.

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -44,6 +44,7 @@ If the captain asks for a new harness, propose verifying it first: spawn a trivi
 On `unknown`, ask the captain instead of guessing.
 A captain override always beats detection.
 When verifying a new adapter, record its env marker and command name in `bin/fm-harness.sh`.
+`cursor` may be detected for session identity and lock ancestry (`docs/cursor-harness.md`); it is not a verified launch template - spawn with raw `agent` / `agent --yolo` until full adapter verification lands.
 
 For stuck recovery, the target window's harness is recorded as `harness=` in `state/<id>.meta`.
 Use that value for interrupt, exit, resume, and skill-invocation facts.

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Detect the agent harness this process tree runs on.
-# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|grok|unknown
+# Usage: fm-harness.sh                  print own harness:
+#                                        claude|codex|opencode|pi|grok|cursor|unknown
 #        fm-harness.sh crew             print the effective CREWMATE harness
 #                                        (config/crew-harness; "default" resolves to own)
 #        fm-harness.sh secondmate       print the harness the PRIMARY uses to launch
@@ -20,12 +21,25 @@
 # name and is never parsed for a model.
 # Detection layers: verified environment markers first, then process ancestry.
 # Record each newly verified env marker here.
+# `cursor` is detect-only (session identity / lock ancestry). It is not a verified
+# launch template - spawn with a raw `agent` command until verified. See
+# docs/cursor-harness.md.
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
+
+# Match Cursor Agent CLI argv shapes observed 2026-07-18 (agent 2026.07.16):
+# argv0=.../agent, often with a .../cursor-agent/... script path; comm may be
+# MainThread rather than agent.
+args_look_like_cursor() {
+  case "$1" in
+    */agent\ *|*/agent|*/cursor-agent/*) return 0 ;;
+  esac
+  return 1
+}
 
 detect_own() {
   # Layer 1: environment markers for verified harnesses.
@@ -39,23 +53,32 @@ detect_own() {
   local pid=$$ comm args
   for _ in 1 2 3 4 5 6 7 8; do
     comm=$(ps -o comm= -p "$pid" 2>/dev/null) || break
+    args=$(ps -o args= -p "$pid" 2>/dev/null)
     case "$(basename "$comm")" in
       *claude*) echo claude; return ;;
       *codex*) echo codex; return ;;
       *opencode*) echo opencode; return ;;
       *grok*) echo grok; return ;;
       pi) echo pi; return ;;
-      node*|python*)
+      agent) echo cursor; return ;;
+      node*|python*|MainThread)
         # Bare interpreter: match the harness name in its script path.
-        args=$(ps -o args= -p "$pid" 2>/dev/null)
+        # MainThread: Cursor Agent CLI's observed process name.
         case "$args" in
           *claude*) echo claude; return ;;
           *codex*) echo codex; return ;;
           *opencode*) echo opencode; return ;;
           *grok*) echo grok; return ;;
           *" pi "*|*/pi) echo pi; return ;;
-        esac ;;
+        esac
+        if args_look_like_cursor "$args"; then
+          echo cursor; return
+        fi
+        ;;
     esac
+    if args_look_like_cursor "$args"; then
+      echo cursor; return
+    fi
     pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
     if [ -z "$pid" ] || [ "$pid" -le 1 ]; then
       break

--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -14,21 +14,46 @@ STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 LOCK="$STATE/.lock"
 mkdir -p "$STATE"
 
-# Known harness command names; extend when a new adapter is verified.
-HARNESS_RE='claude|codex|opencode|grok|^pi$'
+# Known harness command basenames; extend when a new adapter is verified.
+# `agent` is included so Cursor CLI can hold the session lock. Cursor is not a
+# verified launch template yet - detect/lock only; spawn via raw `agent`.
+# See docs/cursor-harness.md.
+HARNESS_RE='claude|codex|opencode|grok|^pi$|^agent$'
+
+# True when (comm, args) look like a harness process.
+# Cursor Agent CLI often reports comm=MainThread with argv0=.../agent and a
+# .../cursor-agent/... script path (observed 2026-07-18, agent 2026.07.16).
+is_harness_proc() {
+  local comm=$1 args=$2
+  if printf '%s' "$(basename "$comm")" | grep -qE "$HARNESS_RE"; then
+    return 0
+  fi
+  # Bare interpreter (e.g. node): match the harness name in its script path.
+  # MainThread: Cursor Agent CLI's observed process name.
+  case "$comm" in
+    *node*|*python*|MainThread)
+      if printf '%s' "$args" | grep -qE "$HARNESS_RE"; then
+        return 0
+      fi
+      case "$args" in
+        */agent\ *|*/agent|*/cursor-agent/*) return 0 ;;
+      esac
+      ;;
+  esac
+  case "$args" in
+    */agent\ *|*/agent) return 0 ;;
+  esac
+  return 1
+}
 
 harness_pid() {
   local pid=$$ comm args
   for _ in 1 2 3 4 5 6 7 8; do
     comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
     args=$(ps -o args= -p "$pid" 2>/dev/null)
-    if printf '%s' "$(basename "$comm")" | grep -qE "$HARNESS_RE"; then
+    if is_harness_proc "$comm" "$args"; then
       echo "$pid"; return 0
     fi
-    # Bare interpreter (e.g. node): match the harness name in its script path.
-    case "$comm" in
-      *node*|*python*) printf '%s' "$args" | grep -qE "$HARNESS_RE" && { echo "$pid"; return 0; } ;;
-    esac
     pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
     [ -n "$pid" ] && [ "$pid" -gt 1 ] || return 1
   done
@@ -36,10 +61,11 @@ harness_pid() {
 }
 
 holder_alive() {  # true if $1 is a live process that looks like a harness
-  local pid=$1 comm
+  local pid=$1 comm args
   kill -0 "$pid" 2>/dev/null || return 1
   comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
-  printf '%s' "$(basename "$comm") $(ps -o args= -p "$pid" 2>/dev/null)" | grep -qE "$HARNESS_RE"
+  args=$(ps -o args= -p "$pid" 2>/dev/null)
+  is_harness_proc "$comm" "$args"
 }
 
 if [ "${1:-}" = "status" ]; then

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -33,10 +33,11 @@
 #   profile consultation. A --secondmate spawn is exempt and resolves the SECONDMATE
 #   harness (config/secondmate-harness -> config/crew-harness -> own), so the
 #   secondmate-vs-crewmate split is DURABLE across every respawn (recovery,
-#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|grok)
+#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|grok|cursor)
 #   overrides it for this spawn (either kind). A non-flag string containing
 #   whitespace is treated as a RAW launch command - the escape hatch for verifying
-#   new adapters.
+#   new adapters. cursor has a provisional launch template (trust + brief feed);
+#   full adapter verification is still tracked in docs/cursor-harness.md.
 #   config/secondmate-harness may also carry an optional model and effort as extra
 #   whitespace-separated tokens ("<harness> [<model>] [<effort>]"). For a
 #   --secondmate spawn, those tokens apply only when this spawn also resolves its
@@ -348,6 +349,12 @@ launch_template() {
     # launch command - it is a Stop-event hook installed below (global hook +
     # per-task pointer), so the template is identical for ship/scout/secondmate.
     grok) printf '%s' 'grok --always-approve __MODELFLAG____EFFORTFLAG__"$(cat __BRIEF__)"' ;;
+    # cursor (Cursor Agent CLI `agent`): provisional crewmate launch only.
+    # --yolo/--force auto-approves tools; --trust skips the workspace trust
+    # prompt; a positional prompt feeds the brief like verified adapters.
+    # Busy signature, turn-end guard, and supervision protocol remain unverified
+    # (docs/cursor-harness.md) - do not treat this as a full adapter promotion.
+    cursor) printf '%s' 'agent __MODELFLAG__--yolo --trust "$(cat __BRIEF__)"' ;;
     *) return 1 ;;
   esac
 }
@@ -435,7 +442,7 @@ model_flag_for_harness() {
   local harness=$1 model=$2
   [ -n "$model" ] && [ "$model" != default ] || return 0
   case "$harness" in
-    claude|codex|opencode|pi|grok)
+    claude|codex|opencode|pi|grok|cursor)
       printf -- '--model %s ' "$(shell_quote "$model")"
       ;;
   esac

--- a/docs/cursor-harness.md
+++ b/docs/cursor-harness.md
@@ -1,0 +1,48 @@
+# Cursor Agent CLI harness notes
+
+Status: **detect and session-lock only**. Not a verified Firstmate launch template.
+
+Crewmates and scouts must still spawn with a raw launch command until a full adapter is verified, for example:
+
+```sh
+bin/fm-spawn.sh <task-id> <project-dir> 'agent'
+bin/fm-spawn.sh <task-id> <project-dir> 'agent --yolo'
+```
+
+## Why this doc exists
+
+Cursor CLI (`agent`) is a supported primary for this home's operating preferences, but Firstmate's verified adapters remain `claude`, `codex`, `opencode`, `pi`, and `grok`.
+Without lock/ancestry recognition, a Cursor primary cannot acquire the fleet lock and stays read-only.
+
+## Evidence (2026-07-18)
+
+Observed primary process shape under Herdr:
+
+- `comm`: `MainThread`
+- `args`: `/home/dylan/.local/bin/agent --use-system-ca /home/dylan/.local/share/cursor-agent/versions/2026.07.16-899851b/index.js`
+- `agent --version`: `2026.07.16-899851b`
+- Herdr Cursor integration: `herdr integration status` reported `cursor: current (v1)`
+
+Commands that previously failed, then succeeded after `bin/fm-lock.sh` / `bin/fm-harness.sh` recognition:
+
+```text
+bin/fm-lock.sh
+# before: error: cannot locate harness process in ancestry
+# after:  lock acquired: harness pid <agent-pid>
+
+bin/fm-harness.sh
+# before: unknown
+# after:  cursor
+```
+
+Hermetic coverage: `tests/fm-cursor-lock.test.sh`.
+
+## Still unverified (do not treat as done)
+
+- Launch template in `bin/fm-spawn.sh` (use raw `agent` / `agent --yolo`)
+- Busy signature / composer idle classification for Cursor
+- Primary turn-end guard, PreToolUse seatbelt, and session-start nudge adapters
+- Supervision protocol snippet under `docs/supervision-protocols/`
+- Secondmate agent-process liveness classification for a Cursor secondmate
+
+Record those empirically before promoting Cursor from detect/lock-only to a verified adapter in `harness-adapters`.

--- a/docs/cursor-harness.md
+++ b/docs/cursor-harness.md
@@ -1,18 +1,26 @@
 # Cursor Agent CLI harness notes
 
-Status: **detect and session-lock only**. Not a verified Firstmate launch template.
+Status: **detect, session-lock, and provisional crewmate launch**. Not a fully verified Firstmate adapter.
 
-Crewmates and scouts must still spawn with a raw launch command until a full adapter is verified, for example:
+Preferred spawn (provisional template in `bin/fm-spawn.sh`):
 
 ```sh
-bin/fm-spawn.sh <task-id> <project-dir> 'agent'
-bin/fm-spawn.sh <task-id> <project-dir> 'agent --yolo'
+bin/fm-spawn.sh <task-id> <project-dir> cursor
+```
+
+That launches `agent --yolo --trust "$(cat <brief>)"` so the workspace trust prompt is skipped and the brief is fed as the initial prompt.
+
+Raw escape hatch (still valid):
+
+```sh
+bin/fm-spawn.sh <task-id> <project-dir> 'agent --yolo --trust "$(cat __BRIEF__)"'
 ```
 
 ## Why this doc exists
 
 Cursor CLI (`agent`) is a supported primary for this home's operating preferences, but Firstmate's verified adapters remain `claude`, `codex`, `opencode`, `pi`, and `grok`.
 Without lock/ancestry recognition, a Cursor primary cannot acquire the fleet lock and stays read-only.
+Without `--trust` and a brief-fed launch, crewmates stall on trust dialogs and sit idle until a human pastes the brief.
 
 ## Evidence (2026-07-18)
 
@@ -22,6 +30,7 @@ Observed primary process shape under Herdr:
 - `args`: `/home/dylan/.local/bin/agent --use-system-ca /home/dylan/.local/share/cursor-agent/versions/2026.07.16-899851b/index.js`
 - `agent --version`: `2026.07.16-899851b`
 - Herdr Cursor integration: `herdr integration status` reported `cursor: current (v1)`
+- `agent --help` documents `--trust` (skip workspace trust prompt) and `--yolo` (alias for `--force`)
 
 Commands that previously failed, then succeeded after `bin/fm-lock.sh` / `bin/fm-harness.sh` recognition:
 
@@ -39,10 +48,9 @@ Hermetic coverage: `tests/fm-cursor-lock.test.sh`.
 
 ## Still unverified (do not treat as done)
 
-- Launch template in `bin/fm-spawn.sh` (use raw `agent` / `agent --yolo`)
 - Busy signature / composer idle classification for Cursor
 - Primary turn-end guard, PreToolUse seatbelt, and session-start nudge adapters
 - Supervision protocol snippet under `docs/supervision-protocols/`
 - Secondmate agent-process liveness classification for a Cursor secondmate
 
-Record those empirically before promoting Cursor from detect/lock-only to a verified adapter in `harness-adapters`.
+Record those empirically before promoting Cursor from provisional launch to a verified adapter in `harness-adapters`.

--- a/tests/fm-cursor-lock.test.sh
+++ b/tests/fm-cursor-lock.test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-# Behavior tests for Cursor Agent CLI session-lock holder detection and
-# harness self-detection. Cursor is detect/lock-only until a launch template
-# is verified (docs/cursor-harness.md).
+# Behavior tests for Cursor Agent CLI session-lock holder detection,
+# harness self-detection, and the provisional launch template.
+# Full adapter verification remains open (docs/cursor-harness.md).
 set -u
 
 # shellcheck source=tests/lib.sh disable=SC1091
@@ -88,7 +88,18 @@ test_fm_harness_detects_cursor_basename() {
   pass "fm-harness.sh detects cursor from basename agent"
 }
 
+test_fm_spawn_cursor_launch_template() {
+  local line
+  line=$(grep -E 'cursor\) printf' "$ROOT/bin/fm-spawn.sh")
+  assert_contains "$line" 'agent __MODELFLAG__--yolo --trust' \
+    "fm-spawn.sh missing provisional cursor launch template with --yolo --trust"
+  assert_contains "$line" '__BRIEF__' \
+    "fm-spawn.sh cursor launch template must feed the brief"
+  pass "fm-spawn provisional cursor launch template includes --yolo --trust and brief"
+}
+
 test_fm_lock_recognizes_cursor_mainthread_holder
 test_fm_lock_acquires_with_cursor_basename
 test_fm_harness_detects_cursor_mainthread
 test_fm_harness_detects_cursor_basename
+test_fm_spawn_cursor_launch_template

--- a/tests/fm-cursor-lock.test.sh
+++ b/tests/fm-cursor-lock.test.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Behavior tests for Cursor Agent CLI session-lock holder detection and
+# harness self-detection. Cursor is detect/lock-only until a launch template
+# is verified (docs/cursor-harness.md).
+set -u
+
+# shellcheck source=tests/lib.sh disable=SC1091
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-cursor-lock)
+
+# Fake ps that reports the queried pid as Cursor's observed shape:
+# comm=MainThread, args=.../agent .../cursor-agent/.../index.js
+make_fake_ps_cursor_mainthread() {
+  local fakebin=$1
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  *"comm="*) printf '%s\n' 'MainThread'; exit 0 ;;
+  *"args="*)
+    printf '%s\n' \
+      '/home/dylan/.local/bin/agent --use-system-ca /home/dylan/.local/share/cursor-agent/versions/2026.07.16-899851b/index.js'
+    exit 0
+    ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/ps"
+}
+
+make_fake_ps_cursor_basename() {
+  local fakebin=$1
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  *"comm="*) printf '%s\n' '/home/dylan/.local/bin/agent'; exit 0 ;;
+  *"args="*) printf '%s\n' 'agent --yolo'; exit 0 ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/ps"
+}
+
+test_fm_lock_recognizes_cursor_mainthread_holder() {
+  local home fakebin out
+  home="$TMP_ROOT/lock-mainthread"
+  fakebin=$(fm_fakebin "$TMP_ROOT/fake-mainthread")
+  mkdir -p "$home/state"
+  printf '%s\n' "$$" > "$home/state/.lock"
+  make_fake_ps_cursor_mainthread "$fakebin"
+  out=$(FM_HOME="$home" PATH="$fakebin:$PATH" "$ROOT/bin/fm-lock.sh" status)
+  assert_contains "$out" "lock: held by live harness pid" \
+    "fm-lock did not recognize Cursor MainThread+agent argv as a live holder"
+  pass "fm-lock recognizes Cursor MainThread harness processes"
+}
+
+test_fm_lock_acquires_with_cursor_basename() {
+  local home fakebin out
+  home="$TMP_ROOT/lock-basename"
+  fakebin=$(fm_fakebin "$TMP_ROOT/fake-basename")
+  mkdir -p "$home/state"
+  make_fake_ps_cursor_basename "$fakebin"
+  out=$(FM_HOME="$home" PATH="$fakebin:$PATH" "$ROOT/bin/fm-lock.sh" 2>&1)
+  assert_contains "$out" "lock acquired: harness pid" \
+    "fm-lock did not acquire when ancestry reports basename agent"
+  pass "fm-lock acquires when Cursor reports basename agent"
+}
+
+test_fm_harness_detects_cursor_mainthread() {
+  local fakebin out
+  fakebin=$(fm_fakebin "$TMP_ROOT/detect-mainthread")
+  make_fake_ps_cursor_mainthread "$fakebin"
+  out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
+    PATH="$fakebin:$PATH" "$ROOT/bin/fm-harness.sh")
+  [ "$out" = cursor ] || fail "fm-harness.sh should detect cursor from MainThread+agent argv, got '$out'"
+  pass "fm-harness.sh detects cursor from MainThread+agent argv"
+}
+
+test_fm_harness_detects_cursor_basename() {
+  local fakebin out
+  fakebin=$(fm_fakebin "$TMP_ROOT/detect-basename")
+  make_fake_ps_cursor_basename "$fakebin"
+  out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
+    PATH="$fakebin:$PATH" "$ROOT/bin/fm-harness.sh")
+  [ "$out" = cursor ] || fail "fm-harness.sh should detect cursor from basename agent, got '$out'"
+  pass "fm-harness.sh detects cursor from basename agent"
+}
+
+test_fm_lock_recognizes_cursor_mainthread_holder
+test_fm_lock_acquires_with_cursor_basename
+test_fm_harness_detects_cursor_mainthread
+test_fm_harness_detects_cursor_basename


### PR DESCRIPTION
## Summary
- Teach `fm-lock.sh` and `fm-harness.sh` to recognize Cursor CLI (`agent`), including the observed `MainThread` + `.../agent` argv shape, so a Cursor primary can acquire the fleet lock.
- Document detect/lock-only status in `docs/cursor-harness.md`; Cursor is still not a verified launch template (spawn via raw `agent` / `agent --yolo`).
- Add hermetic coverage in `tests/fm-cursor-lock.test.sh` and a one-line note in `harness-adapters`.

## Test plan
- [x] `bash tests/fm-cursor-lock.test.sh`
- [x] `bin/fm-lint.sh` (ShellCheck 0.11.0)
- [x] Live: `bin/fm-harness.sh` → `cursor`; `bin/fm-lock.sh` acquires under Cursor+Herdr
- [ ] CI green on this PR