### PR TITLE
fix(spawn): require same-repo worktree selection

### DIFF
--- a/bin/backends/cmux.sh
+++ b/bin/backends/cmux.sh
@@ -398,9 +398,9 @@ fm_backend_cmux_parse_target() {  # <target>
 # (fm_backend_zellij_pane_exists) rather than the design sketch's original
 # read-screen-based suggestion.
 fm_backend_cmux_surface_exists() {  # <workspace_id> <surface_id>
-  local wsid=$1 sfid=$2
-  fm_backend_cmux_cli list-panes --workspace "$wsid" --json --id-format uuids 2>/dev/null \
-    | jq -e --arg s "$sfid" '[.panes[]? | select(.surface_ids // [] | index($s))] | length > 0' >/dev/null 2>&1
+  local wsid=$1 sfid=$2 out
+  out=$(fm_backend_cmux_cli list-panes --workspace "$wsid" --json --id-format uuids 2>/dev/null) || return 1
+  printf '%s' "$out" | jq -e --arg s "$sfid" '[.panes[]? | select(.surface_ids // [] | index($s))] | length > 0' >/dev/null 2>&1
 }
 
 # fm_backend_cmux_target_ready: parse the target and verify it is live via

--- a/bin/backends/cmux.sh
+++ b/bin/backends/cmux.sh
@@ -504,8 +504,8 @@ fm_backend_cmux_send_key() {  # <target> <key> [expected-label]
 # fm_backend_cmux_send_text_line: send one line of TEXT then submit. cmux has
 # no single-call atomic "run and submit" primitive (like herdr's `pane run`),
 # so this composes send (literal) + send-key enter, exactly like zellij's
-# equivalent - used for the fixed spawn-time commands (treehouse get, the
-# GOTMPDIR export).
+# equivalent - used for the fixed spawn-time commands (the leased-worktree
+# `cd`, the GOTMPDIR export).
 fm_backend_cmux_send_text_line() {  # <target> <text> [expected-label]
   fm_backend_cmux_send_literal "$1" "$2" "${3:-}" || return 1
   fm_backend_cmux_send_key "$1" Enter "${3:-}"

--- a/bin/backends/cmux.sh
+++ b/bin/backends/cmux.sh
@@ -336,9 +336,9 @@ fm_backend_cmux_workspace_id_for_label() {  # <label>
 }
 
 fm_backend_cmux_surface_id_for_workspace() {  # <workspace_id>
-  local wsid=$1
-  fm_backend_cmux_cli list-panes --workspace "$wsid" --json --id-format uuids 2>/dev/null \
-    | jq -r '.panes[0] // {} | .selected_surface_id // (.surface_ids[0] // empty)' 2>/dev/null
+  local wsid=$1 out
+  out=$(fm_backend_cmux_cli list-panes --workspace "$wsid" --json --id-format uuids 2>/dev/null) || return 1
+  printf '%s' "$out" | jq -r '.panes[0] // {} | .selected_surface_id // (.surface_ids[0] // empty)' 2>/dev/null
 }
 
 # fm_backend_cmux_create_task: create the task's workspace (one surface),

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -585,8 +585,8 @@ fm_backend_herdr_current_path() {  # <target>
 
 # fm_backend_herdr_send_text_line: send one line of TEXT then submit,
 # ATOMICALLY - mirrors tmux's `send-keys -t T text Enter`. Used for the fixed
-# spawn-time commands (treehouse get, the GOTMPDIR export). `pane run` types
-# the command and submits it in one call (verified).
+# spawn-time commands (the leased-worktree `cd`, the GOTMPDIR export).
+# `pane run` types the command and submits it in one call (verified).
 fm_backend_herdr_send_text_line() {  # <target> <text>
   fm_backend_herdr_target_ready "$1" || return 1
   fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" pane run "$FM_BACKEND_HERDR_PANE" "$2" >/dev/null 2>&1

--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -8,10 +8,10 @@
 # default (tmux, `backend=` absent) path stays byte-identical. Sourced only
 # through bin/fm-backend.sh's fm_backend_source, never directly.
 #
-# Worktree acquisition (running `treehouse get` inside the pane, and polling
-# its cwd) is unchanged by this extraction: P1 scopes only the session
-# provider, not the worktree provider, so fm-spawn.sh still drives that part
-# inline with these same send/current-path primitives.
+# Worktree acquisition is still owned by fm-spawn.sh: P1 scopes only the
+# session provider, not the worktree provider, so fm-spawn.sh drives the
+# Treehouse lease, cwd move, and cwd poll inline with these same
+# send/current-path primitives.
 #
 # The verified composer/busy-detection and verify-and-retry-submit primitives
 # already live in bin/fm-tmux-lib.sh, shared with the away-mode daemon
@@ -103,8 +103,8 @@ fm_backend_tmux_current_path() {  # <target>
 
 # fm_backend_tmux_send_text_line: send one line of TEXT then Enter, with no
 # composer verification - used for the fixed spawn-time commands
-# (`treehouse get`, the GOTMPDIR export) that already ran this exact sequence
-# inline in fm-spawn.sh. Mirrors `tmux send-keys -t "$T" "<text>" Enter`.
+# (the leased-worktree `cd`, the GOTMPDIR export) that already ran this exact
+# sequence inline in fm-spawn.sh. Mirrors `tmux send-keys -t "$T" "<text>" Enter`.
 fm_backend_tmux_send_text_line() {  # <target> <text>
   tmux send-keys -t "$1" "$2" Enter
 }

--- a/bin/backends/zellij.sh
+++ b/bin/backends/zellij.sh
@@ -462,10 +462,10 @@ fm_backend_zellij_send_key() {  # <target> <key> [expected-label]
 
 # fm_backend_zellij_send_text_line: send one line of TEXT then submit,
 # ATOMICALLY - mirrors tmux's `send-keys -t T text Enter` / herdr's `pane
-# run`. Used for the fixed spawn-time commands (treehouse get, the GOTMPDIR
-# export). Zellij has no single-call atomic "run and submit" action, so this
-# composes paste (literal) + send-keys Enter, exactly like send_literal +
-# send_key are composed elsewhere - the two-step form is the ONLY form for
+# run`. Used for the fixed spawn-time commands (the leased-worktree `cd`, the
+# GOTMPDIR export). Zellij has no single-call atomic "run and submit" action,
+# so this composes paste (literal) + send-keys Enter, exactly like send_literal
+# + send_key are composed elsewhere - the two-step form is the ONLY form for
 # this adapter, unlike tmux/herdr which have a genuinely atomic primitive.
 fm_backend_zellij_send_text_line() {  # <target> <text> [expected-label]
   fm_backend_zellij_send_literal "$1" "$2" "${3:-}" || return 1

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -664,6 +664,25 @@ real_path_or_raw() {  # <path>
   fi
 }
 
+git_common_dir_real() {  # <path>
+  local path=$1 common common_abs
+  common=$(git -C "$path" rev-parse --git-common-dir 2>/dev/null) || return 1
+  case "$common" in
+    /*) common_abs=$common ;;
+    *) common_abs="$path/$common" ;;
+  esac
+  cd "$common_abs" 2>/dev/null && pwd -P
+}
+
+if [ "$KIND" != secondmate ]; then
+  PROJ_GIT_COMMON_REAL=$(git_common_dir_real "$PROJ_ABS") || {
+    echo "error: project path is not a git repository: $PROJ_ABS" >&2
+    exit 1
+  }
+else
+  PROJ_GIT_COMMON_REAL=
+fi
+
 # Session-provider container-ensure + task creation. tmux stays exactly as P1
 # left it (same session-name / new-window sequence, see bin/backends/tmux.sh);
 # a herdr spawn goes through the version-gated, workspace-per-HOME,
@@ -673,7 +692,7 @@ real_path_or_raw() {  # <path>
 # that every downstream operation (send/capture/kill) already treats as opaque
 # per-backend routing (fm_backend_resolve_selector).
 validate_spawn_worktree() {  # <source> <inspect-target>
-  local source=$1 inspect_target=$2 wt_real proj_real wt_top wt_top_real
+  local source=$1 inspect_target=$2 wt_real proj_real wt_top wt_top_real wt_common_real
   wt_real=
   if ! wt_real=$(cd "$WT" 2>/dev/null && pwd -P); then
     wt_real=
@@ -684,10 +703,22 @@ validate_spawn_worktree() {  # <source> <inspect-target>
   if ! wt_top_real=$(cd "$wt_top" 2>/dev/null && pwd -P); then
     wt_top_real=
   fi
-  if [ -z "$wt_real" ] || [ -z "$wt_top_real" ] || [ "$wt_real" != "$wt_top_real" ] || [ "$wt_real" = "$proj_real" ]; then
-    echo "error: $source did not yield an isolated worktree (resolved '$WT'; worktree root '${wt_top:-none}'; primary '$PROJ_ABS'); refusing to launch to avoid tangling the primary checkout. Inspect target $inspect_target" >&2
+  wt_common_real=$(git_common_dir_real "$WT" 2>/dev/null || true)
+  if [ -z "$wt_real" ] || [ -z "$wt_top_real" ] || [ "$wt_real" != "$wt_top_real" ] || [ "$wt_real" = "$proj_real" ] || [ "$wt_common_real" != "$PROJ_GIT_COMMON_REAL" ]; then
+    echo "error: $source did not yield an isolated worktree for the requested repository (resolved '$WT'; worktree root '${wt_top:-none}'; primary '$PROJ_ABS'); refusing to launch to avoid tangling the primary checkout. Inspect target $inspect_target" >&2
     exit 1
   fi
+}
+
+spawn_candidate_is_requested_worktree() {  # <path>
+  local candidate=$1 candidate_real wt_top wt_top_real wt_common_real
+  candidate_real=$(real_path_or_raw "$candidate")
+  [ "$candidate_real" != "$PROJ_ABS_REAL" ] || return 1
+  wt_top=$(git -C "$candidate" rev-parse --show-toplevel 2>/dev/null) || return 1
+  wt_top_real=$(cd "$wt_top" 2>/dev/null && pwd -P) || return 1
+  [ "$candidate_real" = "$wt_top_real" ] || return 1
+  wt_common_real=$(git_common_dir_real "$candidate") || return 1
+  [ "$wt_common_real" = "$PROJ_GIT_COMMON_REAL" ] || return 1
 }
 
 W="fm-$ID"
@@ -845,7 +876,7 @@ if [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   # PROJ_ABS on the very first poll, before the pane has actually moved.
   for _ in $(seq 1 60); do
     p=$(spawn_current_path "$WT_TARGET" || true)
-    if [ -n "$p" ] && [ "$(real_path_or_raw "$p")" != "$PROJ_ABS_REAL" ]; then
+    if [ -n "$p" ] && spawn_candidate_is_requested_worktree "$p"; then
       WT="$p"
       break
     fi

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -192,6 +192,8 @@ fi
 ORCA_ABORT_CLEANUP=0
 ORCA_WORKTREE_ID=
 ORCA_TERMINAL=
+TREEHOUSE_ABORT_CLEANUP=0
+TREEHOUSE_LEASED_WT=
 
 parse_orca_worktree_result() {
   local raw=$1 rest
@@ -210,38 +212,43 @@ parse_orca_worktree_result() {
   fi
 }
 
-orca_spawn_abort_cleanup() {
+spawn_abort_cleanup() {
   local status=$?
-  [ "$ORCA_ABORT_CLEANUP" = 1 ] || return "$status"
-  ORCA_ABORT_CLEANUP=0
-  if [ -n "${ORCA_TERMINAL:-}" ]; then
-    fm_backend_kill orca "$ORCA_TERMINAL" 2>/dev/null || true
-  fi
-  if [ -n "${ORCA_WORKTREE_ID:-}" ]; then
-    if ! fm_backend_remove_worktree orca "$ORCA_WORKTREE_ID" 2>/dev/null; then
-      mkdir -p "$STATE" 2>/dev/null || true
-      if [ -d "$STATE" ]; then
-        {
-          echo "window=$W"
-          echo "worktree=${WT:-}"
-          echo "project=$PROJ_ABS"
-          echo "harness=$HARNESS"
-          echo "kind=$KIND"
-          echo "mode=${MODE:-no-mistakes}"
-          echo "yolo=${YOLO:-off}"
-          echo "tasktmp=${TASK_TMP:-}"
-          echo "model=${MODEL:-default}"
-          echo "effort=${EFFORT:-default}"
-          echo "backend=orca"
-          echo "orca_worktree_id=$ORCA_WORKTREE_ID"
-          [ -z "${ORCA_TERMINAL:-}" ] || echo "terminal=$ORCA_TERMINAL"
-        } > "$STATE/$ID.meta" 2>/dev/null || true
+  if [ "$ORCA_ABORT_CLEANUP" = 1 ]; then
+    ORCA_ABORT_CLEANUP=0
+    if [ -n "${ORCA_TERMINAL:-}" ]; then
+      fm_backend_kill orca "$ORCA_TERMINAL" 2>/dev/null || true
+    fi
+    if [ -n "${ORCA_WORKTREE_ID:-}" ]; then
+      if ! fm_backend_remove_worktree orca "$ORCA_WORKTREE_ID" 2>/dev/null; then
+        mkdir -p "$STATE" 2>/dev/null || true
+        if [ -d "$STATE" ]; then
+          {
+            echo "window=$W"
+            echo "worktree=${WT:-}"
+            echo "project=$PROJ_ABS"
+            echo "harness=$HARNESS"
+            echo "kind=$KIND"
+            echo "mode=${MODE:-no-mistakes}"
+            echo "yolo=${YOLO:-off}"
+            echo "tasktmp=${TASK_TMP:-}"
+            echo "model=${MODEL:-default}"
+            echo "effort=${EFFORT:-default}"
+            echo "backend=orca"
+            echo "orca_worktree_id=$ORCA_WORKTREE_ID"
+            [ -z "${ORCA_TERMINAL:-}" ] || echo "terminal=$ORCA_TERMINAL"
+          } > "$STATE/$ID.meta" 2>/dev/null || true
+        fi
       fi
     fi
   fi
+  if [ "$TREEHOUSE_ABORT_CLEANUP" = 1 ] && [ -n "${TREEHOUSE_LEASED_WT:-}" ]; then
+    TREEHOUSE_ABORT_CLEANUP=0
+    ( cd "$PROJ_ABS" && treehouse return --force "$TREEHOUSE_LEASED_WT" >/dev/null 2>&1 ) || true
+  fi
   return "$status"
 }
-trap orca_spawn_abort_cleanup EXIT
+trap spawn_abort_cleanup EXIT
 
 # Batch dispatch (see header): when the first positional is an `id=repo` pair, treat every
 # positional as one and spawn each by re-execing this script in single-task mode. We use
@@ -721,6 +728,14 @@ spawn_candidate_is_requested_worktree() {  # <path>
   [ "$wt_common_real" = "$PROJ_GIT_COMMON_REAL" ] || return 1
 }
 
+spawn_candidate_is_leased_worktree() {  # <path>
+  local candidate=$1 candidate_real wt_real
+  candidate_real=$(real_path_or_raw "$candidate")
+  wt_real=$(real_path_or_raw "$WT")
+  [ "$candidate_real" = "$wt_real" ] || return 1
+  spawn_candidate_is_requested_worktree "$candidate"
+}
+
 W="fm-$ID"
 case "$BACKEND" in
   tmux)
@@ -864,9 +879,18 @@ spawn_send_key() {  # <target> <key>
   esac
 }
 if [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
-  spawn_send_text_line "$WT_TARGET" 'treehouse get'
+  WT_ENTERED=
+  WT=$(cd "$PROJ_ABS" && treehouse get --lease --lease-holder "$ID") || {
+    echo "error: treehouse get --lease failed for $ID" >&2
+    exit 1
+  }
+  [ -n "$WT" ] || { echo "error: treehouse get --lease did not report a worktree for $ID" >&2; exit 1; }
+  TREEHOUSE_LEASED_WT=$WT
+  TREEHOUSE_ABORT_CLEANUP=1
+  validate_spawn_worktree "treehouse get --lease" "$T"
+  spawn_send_text_line "$WT_TARGET" "cd $(shell_quote "$WT")"
 
-  # Wait for the treehouse subshell: the pane's cwd moves from the project to the worktree.
+  # Wait for the pane's cwd to move from the project to this exact leased worktree.
   # Target the stable window id, not the name: if the name is ever lost (e.g. an
   # automatic-rename slips through), display-message -t <bad-name> falls back to the
   # active client's window, which would misread firstmate's OWN pane path as the
@@ -876,18 +900,19 @@ if [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   # PROJ_ABS on the very first poll, before the pane has actually moved.
   for _ in $(seq 1 60); do
     p=$(spawn_current_path "$WT_TARGET" || true)
-    if [ -n "$p" ] && spawn_candidate_is_requested_worktree "$p"; then
+    if [ -n "$p" ] && spawn_candidate_is_leased_worktree "$p"; then
       WT="$p"
+      WT_ENTERED=1
       break
     fi
     sleep 1
   done
-  if [ -z "$WT" ]; then
-    echo "error: treehouse get did not enter a worktree within 60s; inspect window $T" >&2
+  if [ -z "$WT_ENTERED" ]; then
+    echo "error: pane did not enter the leased treehouse worktree within 60s; inspect window $T" >&2
     exit 1
   fi
 
-  validate_spawn_worktree "treehouse get" "$T"
+  validate_spawn_worktree "treehouse get --lease" "$T"
 fi
 
 # Per-task temp root: /tmp/fm-<id>/ with Go's build temp nested at gotmp/. Go won't
@@ -1059,6 +1084,7 @@ META_WINDOW=$T
   fi
 } > "$STATE/$ID.meta"
 [ "$BACKEND" = orca ] && ORCA_ABORT_CLEANUP=0
+[ "$TREEHOUSE_ABORT_CLEANUP" = 1 ] && TREEHOUSE_ABORT_CLEANUP=0
 
 sq_brief=$(shell_quote "$BRIEF")
 sq_turnend=$(shell_quote "$TURNEND")

--- a/tests/fm-backend-cmux.test.sh
+++ b/tests/fm-backend-cmux.test.sh
@@ -55,10 +55,10 @@ fi
 next=$(( $(cat "$COUNT_FILE" 2>/dev/null || echo 0) + 1 ))
 n=$next
 echo "$n" > "$COUNT_FILE"
+[ -f "$RESP/$n.out" ] && cat "$RESP/$n.out"
 if [ -f "$RESP/$n.exit" ]; then
   exit "$(cat "$RESP/$n.exit")"
 fi
-[ -f "$RESP/$n.out" ] && cat "$RESP/$n.out"
 exit 0
 SH
   chmod +x "$fb/cmux"
@@ -539,6 +539,22 @@ test_target_ready_rejects_label_mismatch() {
   assert_not_contains "$(cat "$dir/log")" $'\x1f''list-panes' \
     "target_ready should not call list-panes after a label mismatch"
   pass "fm_backend_cmux_target_ready: rejects a workspace id reused under a different title"
+}
+
+test_target_ready_fails_when_label_recovery_list_panes_fails_with_json() {
+  local dir fb status title
+  dir="$TMP_ROOT/ready-label-recovery-list-panes-fail"; mkdir -p "$dir/responses"
+  title=$(cmux_expected_scoped_title fm-label)
+  cmux_workspace_list_response "$dir" 1 "cccccccc-2222-2222-2222-222222222222" "$title"
+  cmux_workspace_list_response "$dir" 2 "cccccccc-2222-2222-2222-222222222222" "$title"
+  cmux_panes_response "$dir" 3 "dddddddd-3333-3333-3333-333333333333"
+  printf '1\n' > "$dir/responses/3.exit"
+  fb=$(make_cmux_fakebin "$dir")
+  PATH="$fb:$PATH" FM_CMUX_LOG="$dir/log" FM_CMUX_RESPONSES="$dir/responses" \
+    bash -c '. "$0/bin/backends/cmux.sh"; fm_backend_cmux_target_ready "aaaaaaaa-0000-0000-0000-000000000000:bbbbbbbb-1111-1111-1111-111111111111" fm-label' "$ROOT"
+  status=$?
+  [ "$status" -ne 0 ] || fail "target_ready should fail closed when label recovery list-panes exits nonzero even with parseable JSON"
+  pass "fm_backend_cmux_target_ready: fails closed when label recovery list-panes exits nonzero with JSON"
 }
 
 test_capture_trims_locally() {
@@ -1036,6 +1052,7 @@ test_create_task_creates_and_parses_ids
 test_target_ready_fails_when_target_absent
 test_target_ready_checks_expected_label
 test_target_ready_rejects_label_mismatch
+test_target_ready_fails_when_label_recovery_list_panes_fails_with_json
 test_capture_trims_locally
 test_capture_fails_when_read_screen_fails_empty
 test_capture_fails_when_target_not_ready

--- a/tests/fm-backend.test.sh
+++ b/tests/fm-backend.test.sh
@@ -754,7 +754,28 @@ esac
 exit 0
 SH
   chmod +x "$fb/tmux"
-  fm_fake_exit0 "$fb" treehouse
+  cat > "$fb/treehouse" <<SH
+#!/usr/bin/env bash
+set -u
+if [ "\${1:-}" = get ]; then
+  shift
+  lease=0
+  while [ "\$#" -gt 0 ]; do
+    case "\$1" in
+      --lease) lease=1 ;;
+      --lease-holder) shift ;;
+      --lease-holder=*) ;;
+    esac
+    shift || true
+  done
+  if [ "\$lease" -eq 1 ]; then
+    printf '%s\n' "$wt"
+    exit 0
+  fi
+fi
+exit 0
+SH
+  chmod +x "$fb/treehouse"
   printf '%s\n' "$fb"
 }
 
@@ -824,7 +845,28 @@ esac
 exit 0
 SH
   chmod +x "$fb/tmux"
-  fm_fake_exit0 "$fb" treehouse
+  cat > "$fb/treehouse" <<SH
+#!/usr/bin/env bash
+set -u
+if [ "\${1:-}" = get ]; then
+  shift
+  lease=0
+  while [ "\$#" -gt 0 ]; do
+    case "\$1" in
+      --lease) lease=1 ;;
+      --lease-holder) shift ;;
+      --lease-holder=*) ;;
+    esac
+    shift || true
+  done
+  if [ "\$lease" -eq 1 ]; then
+    printf '%s\n' "$wt"
+    exit 0
+  fi
+fi
+exit 0
+SH
+  chmod +x "$fb/treehouse"
   printf '%s\n' "$fb"
 }
 

--- a/tests/fm-gate-refuse.test.sh
+++ b/tests/fm-gate-refuse.test.sh
@@ -152,7 +152,28 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse
+  cat > "$fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+set -u
+if [ "${1:-}" = get ]; then
+  shift
+  lease=0
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --lease) lease=1 ;;
+      --lease-holder) shift ;;
+      --lease-holder=*) ;;
+    esac
+    shift || true
+  done
+  if [ "$lease" -eq 1 ]; then
+    printf '%s\n' "${FM_FAKE_PANE_PATH:?}"
+    exit 0
+  fi
+fi
+exit 0
+SH
+  chmod +x "$fakebin/treehouse"
   printf '%s\n' "$fakebin"
 }
 

--- a/tests/fm-grok-harness.test.sh
+++ b/tests/fm-grok-harness.test.sh
@@ -26,7 +26,29 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse gh-axi gh
+  cat > "$fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+set -u
+if [ "${1:-}" = get ]; then
+  shift
+  lease=0
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --lease) lease=1 ;;
+      --lease-holder) shift ;;
+      --lease-holder=*) ;;
+    esac
+    shift || true
+  done
+  if [ "$lease" -eq 1 ]; then
+    printf '%s\n' "${FM_FAKE_PANE_PATH:?}"
+    exit 0
+  fi
+fi
+exit 0
+SH
+  chmod +x "$fakebin/treehouse"
+  fm_fake_exit0 "$fakebin" gh-axi gh
   printf '%s\n' "$fakebin"
 }
 

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -410,8 +410,8 @@ meta_field() { grep "^$2=" "$1" 2>/dev/null | tail -1 | cut -d= -f2-; }
 # `send-keys -l <cmd>` launch command into FM_FAKE_LAUNCH_LOG, mirroring the
 # capture technique in fm-spawn-dispatch-profile.test.sh so the constructed
 # launch command (not just meta) can be asserted on. Also answers the
-# `#{pane_current_path}` probe from FM_FAKE_PANE_PATH so this same stub works
-# for a crew/scout (non-secondmate) spawn's treehouse-worktree wait loop.
+# `#{pane_current_path}` probe from FM_FAKE_PANE_PATH and fakes leased
+# treehouse output so this same stub works for crew/scout spawn's worktree loop.
 make_launch_capturing_tmux() {
   local dir=$1 fakebin="$1/fakebin"
   mkdir -p "$fakebin"
@@ -441,6 +441,28 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
+  cat > "$fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+set -u
+if [ "${1:-}" = get ]; then
+  shift
+  lease=0
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --lease) lease=1 ;;
+      --lease-holder) shift ;;
+      --lease-holder=*) ;;
+    esac
+    shift || true
+  done
+  if [ "$lease" -eq 1 ]; then
+    printf '%s\n' "${FM_FAKE_PANE_PATH:?}"
+    exit 0
+  fi
+fi
+exit 0
+SH
+  chmod +x "$fakebin/treehouse"
   printf '%s\n' "$fakebin"
 }
 

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -66,7 +66,31 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse
+  cat > "$fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+set -u
+if [ "${1:-}" = get ]; then
+  shift
+  lease=0
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --lease) lease=1 ;;
+      --lease-holder) shift ;;
+      --lease-holder=*) ;;
+    esac
+    shift || true
+  done
+  if [ "$lease" -eq 1 ]; then
+    if [ -n "${FM_FAKE_TREEHOUSE_LEASE_HOOK:-}" ]; then
+      sh -c "$FM_FAKE_TREEHOUSE_LEASE_HOOK"
+    fi
+    printf '%s\n' "${FM_FAKE_TREEHOUSE_LEASE_PATH:?}"
+    exit 0
+  fi
+fi
+exit 0
+SH
+  chmod +x "$fakebin/treehouse"
   printf '%s\n' "$fakebin"
 }
 
@@ -112,6 +136,7 @@ run_spawn() {
     FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
     FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
     FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" TMUX="fake,1,0" \
+    FM_FAKE_TREEHOUSE_LEASE_PATH="$wt" \
     FM_FAKE_LAUNCH_LOG="$launchlog" GROK_HOME="$home/grok-home" PATH="$fakebin:$PATH" \
     "$SPAWN" "$@" 2>&1
 }
@@ -248,6 +273,7 @@ test_spawn_ignores_unrelated_git_root_before_project_worktree() {
     FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
     FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$WT_DIR" TMUX="fake,1,0" \
     FM_FAKE_PANE_PATH_SEQUENCE="$sequence" FM_FAKE_PANE_PATH_LOG="$target_log" \
+    FM_FAKE_TREEHOUSE_LEASE_PATH="$WT_DIR" \
     FM_FAKE_LAUNCH_LOG="$LAUNCH_LOG" GROK_HOME="$HOME_DIR/grok-home" PATH="$FAKEBIN_DIR:$PATH" \
     "$SPAWN" "$id" "$PROJ_DIR" 2>&1)
   status=$?
@@ -259,6 +285,36 @@ test_spawn_ignores_unrelated_git_root_before_project_worktree() {
   assert_no_grep "worktree=$unrelated" "$meta" "meta must never persist an unrelated git root as the task worktree"
   assert_grep 'target=%42' "$target_log" "worktree polling did not use the stable tmux window id"
   pass "spawn poll skips unrelated git roots and records the requested project's isolated worktree"
+}
+
+test_spawn_ignores_other_linked_worktree_before_acquired_worktree() {
+  local rec id other sequence target_log out status meta
+  id=profile-worktree-same-repo-race-z18
+  rec=$(make_spawn_case profile-worktree-same-repo-race codex "$id")
+  read_case_record "$rec"
+  other="$CASE_DIR/other-linked-worktree"
+  sequence="$CASE_DIR/pane-path-sequence"
+  target_log="$CASE_DIR/pane-path-targets.log"
+  git -C "$PROJ_DIR" worktree add --quiet -b other-linked "$other"
+  printf '%s\n' "$PROJ_DIR" "$other" "$WT_DIR" > "$sequence"
+
+  out=$(FM_ROOT_OVERRIDE='' FM_HOME="$HOME_DIR" \
+    FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
+    FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
+    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$WT_DIR" TMUX="fake,1,0" \
+    FM_FAKE_PANE_PATH_SEQUENCE="$sequence" FM_FAKE_PANE_PATH_LOG="$target_log" \
+    FM_FAKE_TREEHOUSE_LEASE_PATH="$WT_DIR" \
+    FM_FAKE_LAUNCH_LOG="$LAUNCH_LOG" GROK_HOME="$HOME_DIR/grok-home" PATH="$FAKEBIN_DIR:$PATH" \
+    "$SPAWN" "$id" "$PROJ_DIR" 2>&1)
+  status=$?
+  expect_code 0 "$status" "spawn with transient same-repo linked worktree should keep polling for this acquisition's worktree"$'\n'"$out"
+
+  meta="$HOME_DIR/state/$id.meta"
+  assert_contains "$out" "worktree=$WT_DIR" "spawn summary chose another task's linked worktree instead of this acquisition's worktree"
+  assert_grep "worktree=$WT_DIR" "$meta" "meta chose another task's linked worktree instead of this acquisition's worktree"
+  assert_no_grep "worktree=$other" "$meta" "meta must never persist another same-repo linked worktree as the task worktree"
+  assert_grep 'target=%42' "$target_log" "worktree polling did not use the stable tmux window id"
+  pass "spawn poll skips other same-repo linked worktrees and records this acquisition's worktree"
 }
 
 test_claude_threads_model_and_effort() {
@@ -444,6 +500,7 @@ test_active_dispatch_profile_allows_explicit_harness
 test_active_dispatch_profile_allows_positional_harness
 test_active_dispatch_profile_allows_raw_launch_command
 test_spawn_ignores_unrelated_git_root_before_project_worktree
+test_spawn_ignores_other_linked_worktree_before_acquired_worktree
 test_claude_threads_model_and_effort
 test_codex_threads_model_and_effort
 test_codex_omits_invalid_max_effort

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -20,12 +20,36 @@ make_spawn_fakebin() {
 #!/usr/bin/env bash
 set -u
 case "$*" in
-  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+  *"#{pane_current_path}"*)
+    target=
+    prev=
+    for a in "$@"; do
+      if [ "$prev" = "-t" ]; then
+        target=$a
+      fi
+      prev=$a
+    done
+    [ -z "${FM_FAKE_PANE_PATH_LOG:-}" ] || printf 'target=%s\n' "$target" >> "$FM_FAKE_PANE_PATH_LOG"
+    if [ -n "${FM_FAKE_PANE_PATH_SEQUENCE:-}" ] && [ -f "$FM_FAKE_PANE_PATH_SEQUENCE" ]; then
+      first=
+      IFS= read -r first < "$FM_FAKE_PANE_PATH_SEQUENCE" || true
+      if [ -n "$first" ]; then
+        tmp="$FM_FAKE_PANE_PATH_SEQUENCE.tmp"
+        sed '1d' "$FM_FAKE_PANE_PATH_SEQUENCE" > "$tmp"
+        mv "$tmp" "$FM_FAKE_PANE_PATH_SEQUENCE"
+        printf '%s\n' "$first"
+        exit 0
+      fi
+    fi
+    printf '%s\n' "${FM_FAKE_PANE_PATH:-}"
+    exit 0
+    ;;
 esac
 case "${1:-}" in
   display-message) printf 'firstmate\n'; exit 0 ;;
   list-windows) exit 0 ;;
-  has-session|new-session|new-window|kill-window) exit 0 ;;
+  new-window) printf '%%42\n'; exit 0 ;;
+  has-session|new-session|kill-window) exit 0 ;;
   send-keys)
     if [ -n "${FM_FAKE_LAUNCH_LOG:-}" ]; then
       prev=
@@ -206,6 +230,35 @@ test_active_dispatch_profile_allows_raw_launch_command() {
   launch=$(cat "$LAUNCH_LOG")
   [ "$launch" = "custom-agent --flag" ] || fail "raw launch command changed"$'\n'"actual: $launch"
   pass "active crew-dispatch profile allows the raw launch-command escape hatch"
+}
+
+test_spawn_ignores_unrelated_git_root_before_project_worktree() {
+  local rec id unrelated sequence target_log out status meta
+  id=profile-worktree-race-z17
+  rec=$(make_spawn_case profile-worktree-race codex "$id")
+  read_case_record "$rec"
+  unrelated="$CASE_DIR/unrelated-git-root"
+  sequence="$CASE_DIR/pane-path-sequence"
+  target_log="$CASE_DIR/pane-path-targets.log"
+  fm_git_init_commit "$unrelated"
+  printf '%s\n' "$PROJ_DIR" "$unrelated" "$WT_DIR" > "$sequence"
+
+  out=$(FM_ROOT_OVERRIDE='' FM_HOME="$HOME_DIR" \
+    FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
+    FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
+    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$WT_DIR" TMUX="fake,1,0" \
+    FM_FAKE_PANE_PATH_SEQUENCE="$sequence" FM_FAKE_PANE_PATH_LOG="$target_log" \
+    FM_FAKE_LAUNCH_LOG="$LAUNCH_LOG" GROK_HOME="$HOME_DIR/grok-home" PATH="$FAKEBIN_DIR:$PATH" \
+    "$SPAWN" "$id" "$PROJ_DIR" 2>&1)
+  status=$?
+  expect_code 0 "$status" "spawn with transient unrelated git cwd should keep polling for the requested repo worktree"$'\n'"$out"
+
+  meta="$HOME_DIR/state/$id.meta"
+  assert_contains "$out" "worktree=$WT_DIR" "spawn summary chose the transient unrelated repository instead of the project worktree"
+  assert_grep "worktree=$WT_DIR" "$meta" "meta chose the transient unrelated repository instead of the project worktree"
+  assert_no_grep "worktree=$unrelated" "$meta" "meta must never persist an unrelated git root as the task worktree"
+  assert_grep 'target=%42' "$target_log" "worktree polling did not use the stable tmux window id"
+  pass "spawn poll skips unrelated git roots and records the requested project's isolated worktree"
 }
 
 test_claude_threads_model_and_effort() {
@@ -390,6 +443,7 @@ test_active_dispatch_profile_requires_explicit_harness_for_scout
 test_active_dispatch_profile_allows_explicit_harness
 test_active_dispatch_profile_allows_positional_harness
 test_active_dispatch_profile_allows_raw_launch_command
+test_spawn_ignores_unrelated_git_root_before_project_worktree
 test_claude_threads_model_and_effort
 test_codex_threads_model_and_effort
 test_codex_omits_invalid_max_effort

--- a/tests/fm-tangle-guard.test.sh
+++ b/tests/fm-tangle-guard.test.sh
@@ -169,7 +169,28 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse
+  cat > "$fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+set -u
+if [ "${1:-}" = get ]; then
+  shift
+  lease=0
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --lease) lease=1 ;;
+      --lease-holder) shift ;;
+      --lease-holder=*) ;;
+    esac
+    shift || true
+  done
+  if [ "$lease" -eq 1 ]; then
+    printf '%s\n' "${FM_FAKE_PANE_PATH:?}"
+    exit 0
+  fi
+fi
+exit 0
+SH
+  chmod +x "$fakebin/treehouse"
   printf '%s\n' "$fakebin"
 }
 
@@ -225,7 +246,7 @@ test_spawn_isolation_abort() {
 #     collides under base-index 1;
 #   - the window id is captured (-P -F #{window_id}) and automatic-rename/allow-rename
 #     are disabled so the fm-<id> name survives treehouse cd'ing into the worktree;
-#   - the treehouse-get send-keys and the worktree wait loop target that stable
+#   - the leased-worktree cd and the worktree wait loop target that stable
 #     window id, never the (possibly-renamed) name - a lost name would let
 #     display-message fall back to the active client's window and misread firstmate's
 #     OWN pane as the worktree, tangling a hook into the primary checkout.
@@ -248,7 +269,28 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse
+  cat > "$fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+set -u
+if [ "${1:-}" = get ]; then
+  shift
+  lease=0
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --lease) lease=1 ;;
+      --lease-holder) shift ;;
+      --lease-holder=*) ;;
+    esac
+    shift || true
+  done
+  if [ "$lease" -eq 1 ]; then
+    printf '%s\n' "${FM_FAKE_PANE_PATH:?}"
+    exit 0
+  fi
+fi
+exit 0
+SH
+  chmod +x "$fakebin/treehouse"
   printf '%s\n' "$fakebin"
 }
 
@@ -292,9 +334,9 @@ test_spawn_tmux_window_construction() {
   assert_grep "set-window-option -t @spawnwid allow-rename off" "$rec" \
     "must disable allow-rename on the spawned window"
 
-  # Bug 2 fix (b): treehouse-get and the worktree wait loop target the stable id.
-  assert_grep "send-keys -t @spawnwid treehouse get Enter" "$rec" \
-    "treehouse get must be sent to the stable window id"
+  # Bug 2 fix (b): leased-worktree cd and the worktree wait loop target the stable id.
+  assert_grep "send-keys -t @spawnwid cd " "$rec" \
+    "leased worktree cd must be sent to the stable window id"
   assert_grep "display-message -p -t @spawnwid #{pane_current_path}" "$rec" \
     "the worktree wait loop must query the stable window id, not the name"
 


### PR DESCRIPTION
## Summary

This fixes a spawn-safety race where `bin/fm-spawn.sh` could persist a transient unrelated Git repository as `worktree=` during `treehouse get` startup.
The end-user-aligned regression drives the observed current-path sequence: the primary project root, then an unrelated Git root such as a shell startup repo, then the real isolated worktree for the same requested project.
The poll now ignores transient or unrelated Git roots and accepts only an isolated worktree whose Git common directory matches the requested primary repository.
That same-repository check is a deterministic Git invariant, not a Treehouse path-name convention.

## Safety

If no matching same-repository isolated worktree appears, spawn still fails closed at the bounded timeout before durable metadata is written.
Symlink normalization and stable tmux window-id targeting are preserved and covered by the fake-tmux regression.
The cmux recovery helper now also fails closed when `list-panes` exits nonzero even if it emits parseable JSON, so target recovery cannot mask a failed cmux structural read.

## Verification

Exact current head: `2a42a6a244ba1f7242bc10a2019495e62dea595a`.
Prior Opus rereview of head `7449faa7c7805a1570cae7e09bac97c1822e0257` found that three deterministic test fakes still emitted no leased worktree path for `treehouse get --lease`:

- `tests/fm-gate-refuse.test.sh`
- `tests/fm-grok-harness.test.sh`
- `tests/fm-tangle-guard.test.sh`

Commit `2a42a6a244ba1f7242bc10a2019495e62dea595a` corrects those stale lease fakes.
The mandated Behavior workflow command also surfaced one additional stale lease fake in `tests/fm-secondmate-harness.test.sh`, and this commit corrects that fake too.
It also refreshes the tangle recording assertion from the old in-pane `treehouse get` command to the current stable-window `cd <leased worktree>` command that production now sends after acquiring the lease outside the pane.

Focused correction proof passed:

- Red first: `tests/fm-gate-refuse.test.sh`, `tests/fm-grok-harness.test.sh`, and `tests/fm-tangle-guard.test.sh` reproduced the Opus-reported failures before edits.
- Green targeted rerun: `tests/fm-gate-refuse.test.sh`, `tests/fm-grok-harness.test.sh`, and `tests/fm-tangle-guard.test.sh`.
- Additional stale-fake proof: `tests/fm-secondmate-harness.test.sh`.
- `shellcheck -x tests/fm-gate-refuse.test.sh tests/fm-grok-harness.test.sh tests/fm-tangle-guard.test.sh tests/fm-secondmate-harness.test.sh`.
- `git diff --check`.
- Exact Behavior workflow test command: `set -eu; for test_script in tests/*.test.sh; do "$test_script"; done`.