### PR TITLE
feat: add public-writing policy to remote task scaffolds

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -326,6 +326,21 @@ EOF
     ;;
 esac
 
+PUBLIC_REGISTER=""
+case "$MODE" in
+  no-mistakes|direct-PR)
+    PUBLIC_REGISTER=$(cat <<'EOF'
+# Public register
+Everything leaving the worktree for the remote - PR titles, PR bodies, PR comments, commit messages, and committed file text - must be written for the open web in a neutral third-party voice.
+Never use the words `captain`, `crewmate`, `firstmate`, `scout`, `brief`, `worktree`, or other fleet or supervisor vocabulary in that text.
+Attribute direction to "the site owner" or "user feedback".
+Never name or describe internal scanning, suppression, validation, or supervision tooling in public text.
+Never include local machine paths.
+EOF
+)
+    ;;
+esac
+
 cat > "$BRIEF" <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
 
@@ -333,6 +348,8 @@ You are a crewmate: an autonomous worker agent managed by firstmate. Work on you
 {TASK}
 
 $HERDR_SECTION
+
+$PUBLIC_REGISTER
 
 # Setup
 You are in a disposable git worktree of $REPO, at a detached HEAD on a clean default branch.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -34,6 +34,9 @@
 #   local-only   implement on branch, stop and report "ready in branch" (no push/PR);
 #                captain approves, firstmate merges to local main
 # Ship briefs begin with a worktree-isolation assertion before the branch step.
+# Remote-backed ship briefs (no-mistakes and direct-PR) also carry a Public register
+# section requiring a neutral open-web voice for all remote-facing text; local-only,
+# scout, and secondmate scaffolds omit it.
 # Scout tasks ignore mode - their deliverable is a report, not a merge.
 # Every scaffold's status protocol distinguishes the configured
 # declared-external-wait verb (FM_CLASSIFY_PAUSED_VERB, default "paused") from

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -71,6 +71,47 @@ test_ship_modes_generate_clean_briefs() {
   pass "fm-brief.sh: no-mistakes/direct-PR/local-only briefs generate cleanly"
 }
 
+test_public_register_only_for_remote_backed_ship_briefs() {
+  local home id brief mode
+  home="$TMP_ROOT/public-register-home"
+  write_registry "$home"
+
+  for mode in "no-mistakes:no-registry-proj" "direct-PR:direct-proj"; do
+    id="brief-public-${mode%%:*}"
+    FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" "${mode##*:}" >/dev/null 2>&1
+    brief="$home/data/$id/brief.md"
+    assert_grep "# Public register" "$brief" \
+      "${mode%%:*} ship brief omitted the public register"
+    assert_grep "Everything leaving the worktree for the remote" "$brief" \
+      "${mode%%:*} public register omitted its remote-output scope"
+    assert_grep "written for the open web in a neutral third-party voice" "$brief" \
+      "${mode%%:*} public register omitted its audience and voice"
+    assert_grep 'Never use the words `captain`, `crewmate`, `firstmate`, `scout`, `brief`, `worktree`' "$brief" \
+      "${mode%%:*} public register omitted forbidden fleet vocabulary"
+    assert_grep 'Attribute direction to "the site owner" or "user feedback"' "$brief" \
+      "${mode%%:*} public register omitted neutral attribution"
+    assert_grep "internal scanning, suppression, validation, or supervision tooling" "$brief" \
+      "${mode%%:*} public register omitted internal-tooling privacy"
+    assert_grep "Never include local machine paths" "$brief" \
+      "${mode%%:*} public register omitted local-path privacy"
+  done
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-public-local local-proj >/dev/null 2>&1
+  assert_no_grep "# Public register" "$home/data/brief-public-local/brief.md" \
+    "local-only ship brief unexpectedly included the public register"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-public-scout direct-proj --scout >/dev/null 2>&1
+  assert_no_grep "# Public register" "$home/data/brief-public-scout/brief.md" \
+    "scout brief unexpectedly included the public register"
+
+  FM_HOME="$home" FM_SECONDMATE_CHARTER=ops \
+    "$ROOT/bin/fm-brief.sh" brief-public-secondmate --secondmate direct-proj >/dev/null 2>&1
+  assert_no_grep "# Public register" "$home/data/brief-public-secondmate/brief.md" \
+    "secondmate charter unexpectedly included the public register"
+
+  pass "fm-brief.sh: public register appears only in remote-backed ship briefs"
+}
+
 test_faster_paths_use_configured_authority_without_stacked_review() {
   local home id brief
   home="$TMP_ROOT/configured-authority-home"
@@ -342,6 +383,7 @@ test_scout_and_secondmate_scaffold() {
 test_script_parses
 test_help_includes_entire_header
 test_ship_modes_generate_clean_briefs
+test_public_register_only_for_remote_backed_ship_briefs
 test_faster_paths_use_configured_authority_without_stacked_review
 test_no_mistakes_dod_wording
 test_ship_project_memory_wording

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -86,6 +86,7 @@ test_public_register_only_for_remote_backed_ship_briefs() {
       "${mode%%:*} public register omitted its remote-output scope"
     assert_grep "written for the open web in a neutral third-party voice" "$brief" \
       "${mode%%:*} public register omitted its audience and voice"
+    # shellcheck disable=SC2016  # Single quotes preserve the literal backticks in generated scaffold text.
     assert_grep 'Never use the words `captain`, `crewmate`, `firstmate`, `scout`, `brief`, `worktree`' "$brief" \
       "${mode%%:*} public register omitted forbidden fleet vocabulary"
     assert_grep 'Attribute direction to "the site owner" or "user feedback"' "$brief" \


### PR DESCRIPTION
## Summary

Remote-backed task scaffolds now include a public-writing policy that keeps outward-facing text neutral, reviewer-oriented, and free of private operational context.
Local-only and investigation scaffolds remain unchanged.

## Review notes

- Applies to both supported remote delivery modes.
- Keeps the policy text in the scaffold generator as the single source.
- Covers each inclusion and exclusion path with regression tests.

## Validation

- Script syntax and repository lint passed.
- New inclusion and exclusion coverage passed.
- The full test sweep completed with one known unrelated assertion mismatch in existing role-label wording.
