### PR TITLE
fix(bin): make fm-lock.sh harness detection and liveness work on Windows

### DIFF
--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -17,7 +17,70 @@ mkdir -p "$STATE"
 # Known harness command names; extend when a new adapter is verified.
 HARNESS_RE='claude|codex|opencode|grok|^pi$'
 
+# Windows (Git Bash / MSYS / Cygwin): the bundled MSYS ps has no -o support and
+# only sees MSYS processes, while the harness runs as a NATIVE Windows process
+# (e.g. claude.exe) that the MSYS ancestry never reaches - its view bottoms out
+# at ppid 1. So on these platforms the walk starts from this shell's native
+# Windows pid (/proc/$$/winpid) and follows ParentProcessId through one CIM
+# query loop. The pid written to the lock is then a native Windows pid, and
+# liveness must be answered by CIM too: MSYS kill -0 operates on MSYS pids and
+# would misjudge a native one.
+case "$(uname -s)" in MINGW*|MSYS*|CYGWIN*) FM_LOCK_WINDOWS=1 ;; *) FM_LOCK_WINDOWS=0 ;; esac
+
+win_harness_pid() {
+  local pid=$$ ppid winpid exe out
+  # Climb the MSYS side first via /proc: MSYS emulates fork/exec with transient
+  # stub processes, so a nested shell's NATIVE parent pid may already be dead,
+  # while /proc/<pid>/ppid tracks the logical parent correctly. Only the
+  # topmost MSYS process (ppid 1) has a trustworthy native ancestry - its
+  # parents are real long-lived processes (launcher, harness), not exec stubs.
+  for _ in 1 2 3 4 5 6 7 8; do
+    exe=$(cat "/proc/$pid/exename" 2>/dev/null) || break
+    if printf '%s' "$(basename "$exe")" | grep -qE "$HARNESS_RE"; then
+      cat "/proc/$pid/winpid" 2>/dev/null
+      return
+    fi
+    ppid=$(cat "/proc/$pid/ppid" 2>/dev/null) || break
+    case "$ppid" in ''|*[!0-9]*) break ;; esac
+    [ "$ppid" -gt 1 ] || break
+    pid=$ppid
+  done
+  winpid=$(cat "/proc/$pid/winpid" 2>/dev/null) || return 1
+  # One powershell invocation for the native walk; pid and regex ride in as env
+  # vars so no bash-side escaping can corrupt the script. [int] casts make a
+  # garbage pid a hard error (empty output) rather than a WQL injection.
+  # shellcheck disable=SC2016  # Single quotes are deliberate: $... belongs to the PowerShell snippet.
+  out=$(FM_LOCK_PID="$winpid" FM_LOCK_RE="$HARNESS_RE" powershell.exe -NoProfile -NonInteractive -Command '
+    $p = [int]$env:FM_LOCK_PID
+    for ($i = 0; $i -lt 12; $i++) {
+      $proc = Get-CimInstance Win32_Process -Filter "ProcessId=$p" -ErrorAction SilentlyContinue
+      if (-not $proc) { exit 1 }
+      $name = $proc.Name -replace "\.exe$", ""
+      if ($name -cmatch $env:FM_LOCK_RE) { Write-Output $proc.ProcessId; exit 0 }
+      if ($name -match "^(node|python[0-9.]*)$" -and "$($proc.CommandLine)" -cmatch $env:FM_LOCK_RE) { Write-Output $proc.ProcessId; exit 0 }
+      $p = [int]$proc.ParentProcessId
+      if ($p -le 1) { exit 1 }
+    }
+    exit 1' 2>/dev/null) || return 1
+  out=${out//[$'\r\n ']/}
+  [ -n "$out" ] || return 1
+  echo "$out"
+}
+
+win_holder_alive() {
+  local out
+  # shellcheck disable=SC2016  # Single quotes are deliberate: $... belongs to the PowerShell snippet.
+  out=$(FM_LOCK_PID="$1" FM_LOCK_RE="$HARNESS_RE" powershell.exe -NoProfile -NonInteractive -Command '
+    $proc = Get-CimInstance Win32_Process -Filter "ProcessId=$([int]$env:FM_LOCK_PID)" -ErrorAction SilentlyContinue
+    if (-not $proc) { exit 1 }
+    $name = $proc.Name -replace "\.exe$", ""
+    if ("$name $($proc.CommandLine)" -cmatch $env:FM_LOCK_RE) { Write-Output live }' 2>/dev/null)
+  out=${out//[$'\r\n ']/}
+  [ "$out" = live ]
+}
+
 harness_pid() {
+  if [ "$FM_LOCK_WINDOWS" = 1 ]; then win_harness_pid; return; fi
   local pid=$$ comm args
   for _ in 1 2 3 4 5 6 7 8; do
     comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
@@ -37,6 +100,7 @@ harness_pid() {
 
 holder_alive() {  # true if $1 is a live process that looks like a harness
   local pid=$1 comm
+  if [ "$FM_LOCK_WINDOWS" = 1 ]; then win_holder_alive "$pid"; return; fi
   kill -0 "$pid" 2>/dev/null || return 1
   comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
   printf '%s' "$(basename "$comm") $(ps -o args= -p "$pid" 2>/dev/null)" | grep -qE "$HARNESS_RE"


### PR DESCRIPTION
## Problem

On Windows (Git Bash / MSYS / Cygwin), `fm-lock.sh` could never find the harness process:

- The bundled MSYS `ps` only sees MSYS processes, while the harness (e.g. `claude.exe`) runs as a native Windows process, so the ancestry walk bottomed out at ppid 1 before reaching it.
- Liveness checks used `kill -0`, which operates on MSYS pids and misjudges native Windows pids.

## Fix

On MINGW/MSYS/CYGWIN:

- Climb the MSYS side first via `/proc/<pid>/ppid` (MSYS emulates fork with transient stubs, so native parent pids of nested shells may already be dead, while /proc tracks the logical parent correctly), then switch to the native side via `/proc/<pid>/winpid`.
- Continue the ancestry walk with a single `powershell.exe` CIM query loop following `ParentProcessId`. The pid and harness regex ride in as env vars so no bash-side escaping can corrupt the script, and `[int]` casts make a garbage pid a hard error rather than a WQL injection.
- Answer liveness through CIM as well, since the pid stored in the lock is now a native Windows pid.

Non-Windows platforms keep the existing `ps`-based walk unchanged.

## Testing

Verified end-to-end on Windows 11 (Git Bash under Claude Code):

- `fm-lock.sh` acquires the lock with the real native pid of `claude.exe` (confirmed via CIM that the detected pid is the harness, not an MSYS stub).
- `fm-lock.sh status` reports the holder as live; re-acquiring as the same holder succeeds.
- Stale-lock takeover: with a dead pid planted in an isolated `FM_STATE_OVERRIDE` dir, status reports it stale and acquire takes over.
- `bash -n` passes on all scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)