### PR TITLE
fix(supervision): make stale watcher advisory

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -26,7 +26,7 @@ Inheritance also copies the literal `config/crew-dispatch.json` file, so secondm
 
 Each adapter splits into mechanics and knowledge.
 The per-task mechanics, including launch command, autonomy flag, and crewmate turn-end hook, live in `bin/fm-spawn.sh`.
-The primary-session "no turn ends blind" guard contract and harness hook installation paths live in `docs/turnend-guard.md`.
+The primary-session non-blocking supervision diagnostic and harness hook installation paths live in `docs/turnend-guard.md`.
 The primary-session watcher wake protocols are rendered from `docs/supervision-protocols/` by `bin/fm-supervision-instructions.sh`.
 The supervision knowledge lives here: busy signature, exit command, interrupt, dialogs, resume behavior, skill invocation, and quirks.
 
@@ -48,11 +48,11 @@ When verifying a new adapter, record its env marker and command name in `bin/fm-
 For stuck recovery, the target window's harness is recorded as `harness=` in `state/<id>.meta`.
 Use that value for interrupt, exit, resume, and skill-invocation facts.
 
-## Primary turn-end guard
+## Primary turn-end diagnostic
 
-Every verified primary harness has an empirically validated hook path for the "no turn ends blind" guard.
-`claude` and `codex` block directly through Stop hooks that preserve exit status 2 and stderr from `bin/fm-turnend-guard.sh`.
-`opencode`, `pi`, and `grok` expose passive lifecycle callbacks for this purpose, so their tracked primary adapters force one bounded follow-up or resume when the shared predicate blocks.
+Every verified primary harness has an empirically validated hook path for the turn-end supervision diagnostic.
+`bin/fm-turnend-guard.sh` reports stale or missing supervision and exits 0, so no harness blocks Stop or forces a supervision-only follow-up.
+The live watcher contract remains mandatory during active work, while session-start and pull-based diagnostics own later recovery.
 The exact hook files, commands, validation transcripts, scoping rules, and fail-open tradeoffs are owned by `docs/turnend-guard.md`.
 When changing any primary turn-end hook, validate the real harness behavior in a scratch project or throwaway home before trusting it, then update that doc and the relevant concise fact below.
 
@@ -145,10 +145,11 @@ Its broader dark-TRUECOLOR placeholder handling and dark-theme tradeoff are docu
 That styled capture is internal to the boolean detector only.
 `fm-peek` and every other human or LLM-facing capture path stays plain `tmux capture-pane` with no escape codes.
 
-**Primary-session guard fact (verified 2026-07-04, Claude Code 2.1.201; preserved 2026-07-08, Claude Code 2.1.204).**
+**Primary-session diagnostic fact (blocking transport verified 2026-07-04 and 2026-07-08; exit-0 policy current from 2026-07-19).**
 This is separate from the per-task crewmate turn-end hook above (that one just `touch`es a marker file in a task's own `.claude/settings.local.json`).
-The firstmate PRIMARY's own `.claude/settings.json` registers `bin/fm-turnend-guard.sh` as a Stop hook, and exiting with status 2 plus stderr reliably forces the model to continue.
-Claude Code's stdin payload to a Stop hook carries a `stop_hook_active` boolean that is `true` exactly when the current stop attempt is itself a forced continuation from an earlier block this turn; a hook can and should use that as its own loop-guard (always allow the stop when it is already `true`) rather than tracking state itself.
+The firstmate PRIMARY's own `.claude/settings.json` registers `bin/fm-turnend-guard.sh` as a Stop hook.
+The shared script now emits an advisory with status 0, so stale supervision never forces Claude to continue.
+Claude Code's `stop_hook_active` field remains a legacy duplicate-advisory guard.
 A project-level `.claude/settings.json` only takes effect when Claude Code's project root is that exact directory - it does not walk up from a subdirectory looking for one, so firstmate launches the primary from the repo root.
 After those settings are loaded, hook command resolution is still cwd-sensitive because Claude Code runs commands through `/bin/sh` against the session's current cwd; keep the tracked command anchored through `"$CLAUDE_PROJECT_DIR"/bin/fm-turnend-guard.sh` and see `docs/turnend-guard.md` for the verified Stop-hook details.
 Claude Code's primary watcher protocol is the lowest-friction path: run `bin/fm-watch-arm.sh` as its own Claude Code background task and treat background-task completion as the wake.
@@ -175,9 +176,9 @@ The decision persists for the repo, so later worktrees of the same project skip 
 Resume after exit with `codex resume <session-id>`.
 The session id is printed on quit.
 
-**Primary-session guard fact (verified 2026-07-08, codex-cli 0.142.1).**
+**Primary-session diagnostic fact (blocking transport verified 2026-07-08; exit-0 policy current from 2026-07-19).**
 The firstmate PRIMARY's own `.codex/hooks.json` registers a Stop hook that pipes Codex's Stop payload to `bin/fm-turnend-guard.sh`.
-Codex Stop hooks block on exit 2 and expose `stop_hook_active` for the same one-block loop safety Claude uses.
+The shared script returns status 0 after a stale-supervision advisory, so the Codex Stop hook never blocks completion.
 Codex's Stop payload includes `cwd`, but the tracked primary hook does not use it to choose the guard executable.
 Verified on 2026-07-08: Codex runs the Stop hook command with process PWD set to the hook-loaded project root, and no `CODEX_PROJECT_DIR`, `CODEX_WORKSPACE_ROOT`, or `CODEX_CWD` root variable is set.
 The tracked hook anchors to `pwd -P`, verifies that root is firstmate-shaped and hook-bearing, and then invokes `bin/fm-turnend-guard.sh` with the original payload.
@@ -197,9 +198,10 @@ Opencode can auto-upgrade itself in the background and the running TUI can exit 
 If a pane shows the exit banner, relaunch with `--continue` to resume the session.
 `--prompt` does not auto-submit alongside `--continue`, so send the next instruction via `fm-send` once the TUI is up.
 
-**Primary-session guard fact (verified 2026-07-08, OpenCode 1.17.6).**
+**Primary-session diagnostic fact (passive callback verified 2026-07-08; exit-0 policy current from 2026-07-19).**
 The firstmate PRIMARY's own `.opencode/plugins/fm-primary-turnend-guard.js` listens for `session.idle`.
-Throwing from `session.idle` does not block `opencode run`, so the primary adapter treats the event as passive and uses `client.session.promptAsync` to force one follow-up turn when `bin/fm-turnend-guard.sh` returns 2.
+Throwing from `session.idle` does not block `opencode run`.
+The shared diagnostic now returns 0, so the adapter does not force a supervision-only follow-up.
 The companion `.opencode/plugins/fm-primary-watch-arm.js` owns normal TUI watcher wake supervision and coordinates with the guard plugin before the guard tries a blind-turn follow-up.
 The follow-up was verified in the interactive TUI; `opencode run` can exit before displaying a queued follow-up, so the adapter is fail-open in headless mode.
 
@@ -223,8 +225,9 @@ The decision persists per path in `~/.pi/agent/trust.json`, so later spawns in t
 The extension must listen for pi's `turn_end` event, not `agent_end`, so the watcher wakes after each completed turn instead of only when the whole agent run exits.
 Pi sets `PI_CODING_AGENT=true` for its children; this is its harness-detection env marker.
 
-**Primary-session guard fact (verified 2026-07-09, Pi 0.80.5).**
-The firstmate PRIMARY's own `.pi/extensions/fm-primary-turnend-guard.ts` listens for logical-run `agent_settled`, not per-tool-loop `turn_end`, and uses `pi.sendUserMessage(..., { deliverAs: "followUp" })` to force one guarded follow-up when `bin/fm-turnend-guard.sh` returns 2.
+**Primary-session diagnostic fact (follow-up transport verified 2026-07-09; exit-0 policy current from 2026-07-19).**
+The firstmate PRIMARY's own `.pi/extensions/fm-primary-turnend-guard.ts` listens for logical-run `agent_settled`, not per-tool-loop `turn_end`.
+The shared diagnostic now returns 0, so the extension does not force a supervision-only follow-up.
 Without `deliverAs: "followUp"`, Pi rejects the send while the agent is still processing.
 Pi's primary watcher protocol also requires the tracked `.pi/extensions/fm-primary-pi-watch.ts` extension, same trust-once discovery as the turn-end guard.
 The model arms through `fm_watch_arm_pi`, never a foreground bash arm; the watcher tool result and clean-exit fallback are owned by `docs/supervision-protocols/pi.md`.
@@ -280,10 +283,10 @@ This keeps the hook outside the worktree, needs no trust grant, and writes only 
 `fm-teardown` removes the worktree pointer before returning a pooled worktree.
 Secondmate spawns skip the pointer (idle panes are healthy, no stale-pane detection for them).
 
-**Primary-session guard fact (verified 2026-07-08, Grok 0.2.91).**
+**Primary-session diagnostic fact (resume transport verified 2026-07-08; exit-0 policy current from 2026-07-19).**
 The firstmate PRIMARY's own `.grok/hooks/fm-primary-turnend-guard.json` invokes `bin/fm-turnend-guard-grok.sh`.
 Grok Stop hooks are passive for this purpose: exit 2 does not make the model continue.
-The adapter therefore runs the shared predicate and, when it returns 2, forces one same-session follow-up with `grok --resume <sessionId> -p <guard-reason>` while setting `GROK_TURNEND_GUARD_ACTIVE=1` so the nested Stop hook does not recurse.
+The adapter runs the shared diagnostic, which now returns 0 and never forces a supervision-only resume.
 It does not pass `--permission-mode`, so the passive hook cannot escalate the primary session's tool permissions.
 Project-local Grok hooks require folder trust, verified with launch-time `--trust`; if the primary firstmate checkout is not trusted for Grok hooks, this primary guard fails open and `fm-guard.sh` remains the next-command alarm.
-Grok's primary watcher protocol is Claude-shaped background-notify around `bin/fm-watch-arm.sh`; the passive Stop hook is only a backstop for blind turn ends.
+Grok's primary watcher protocol is Claude-shaped background-notify around `bin/fm-watch-arm.sh`; the passive Stop hook is advisory only.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -315,7 +315,8 @@ Whenever work is under way, keep exactly one live supervision cycle using the em
 X mode may require that same live cycle with no fleet work.
 Do not substitute another harness's wait shape, use shell `&`, or create a second cycle when a healthy one already exists.
 After every actionable wake, resume the emitted protocol as the final action before ending the turn.
-No turn ends blind while work is under way, including turns described as holding or waiting.
+Do not intentionally end a turn without the emitted supervision cycle while work is under way, including turns described as holding or waiting.
+Missing or stale supervision at the turn-end hook is advisory and must never block task completion or force a follow-up turn.
 
 At the start of every wake-handling turn, drain the durable wake queue before peeking, reading beyond the reason line, steering, or starting work.
 Session start is the only exception because its one-shot digest already drained while locked or deliberately left the queue untouched in lock-refused read-only mode.
@@ -340,7 +341,7 @@ A forced repair must use the home-scoped owner path emitted by supervision instr
 Guard warnings do not replace the contract.
 Queued wakes must be drained before other action, stale liveness must be repaired through the emitted protocol, and the worktree-tangle warning must be resolved without touching unlanded work.
 The spawn assertion and generated ship brief must both enforce that project work starts in an isolated disposable worktree, never the primary checkout.
-Harness-aware turn-end guards are structural backstops, not permission to omit the live cycle.
+Harness-aware turn-end guards are advisory diagnostics, not permission to omit the live cycle.
 
 ### Away-mode stub
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Launching a supported harness inside it instantiates your first mate - and makes
 - **Two task shapes** - ship tasks deliver a change; scout tasks investigate, plan, reproduce, or audit and leave a report.
 - **Explicit project modes** - each project ships via `no-mistakes`, `direct-PR`, or `local-only`, with an optional `+yolo` autonomy flag.
 - **Optional secondmates** - opt in to persistent second mates that run from isolated firstmate homes with their own `FM_HOME`, state, projects, and session lock, supervising project clones or a project-less firstmate-repo domain, kept on the primary firstmate version by guarded local fast-forwards and checked for live agent processes at session start.
-- **Event-driven, zero-token supervision** - a bash watcher sleeps on the fleet and wakes the first mate only when something needs you; verified primary harnesses also get a turn-end backstop that blocks or follows up on a blind stop when work is under way and supervision is not live.
+- **Event-driven, zero-token supervision** - a bash watcher sleeps on the fleet and wakes the first mate only when something needs you; verified primary harnesses also get a non-blocking turn-end diagnostic when work is under way and supervision is not live.
 - **Optional X mode** - opt in with one local `.env` token so firstmate can answer your public `@myfirstmate` mentions, act on normal reversible mention requests through the same lifecycle as chat requests, acknowledge spawned work, and post up to three public-safe completion follow-ups within seven days for genuine milestones and the final outcome without changing non-X behavior; dry-run preview records would-be replies and dismissals locally before go-live.
 - **Guarded by construction** - the first mate is read-only over your projects outside guarded clone refreshes, safe branch pruning, and approved `local-only` fast-forward merges; crewmates make every project change behind the configured merge authority.
 - **Restart-proof** - all state lives on disk and in the active session backend (tmux by hard default, herdr or cmux when selected or auto-detected, zellij/orca when explicitly selected); kill the session anytime and the next one reconciles, including confirmed-dead secondmate agents, and carries on.
@@ -191,7 +191,7 @@ Firstmate's skills live in two separate places with different audiences:
 - [docs/orca-backend.md](docs/orca-backend.md) - setup guide for the experimental Orca backend, plus its lifecycle notes and known gaps.
 - [docs/cmux-backend.md](docs/cmux-backend.md) - setup guide for the experimental cmux backend, plus its verification notes and known gaps.
 - [docs/codex-app-backend.md](docs/codex-app-backend.md) - Codex App backend boundary, evidence, and rollout contract.
-- [docs/turnend-guard.md](docs/turnend-guard.md) - the primary session's structural "no turn ends blind" backstop: verified per-harness hook mechanisms, scoping, loop safety, and fail-open tradeoffs.
+- [docs/turnend-guard.md](docs/turnend-guard.md) - the primary session's non-blocking supervision diagnostic: verified per-harness hook mechanisms, scoping, and recovery guidance.
 - [docs/supervision-protocols/](docs/supervision-protocols/) - rendered primary-harness watcher protocols for Claude, Codex, OpenCode, Pi, Grok, and unknown harness fallback.
 - [docs/scripts.md](docs/scripts.md) - the `bin/` toolbelt reference.
 - [`AGENTS.md`](AGENTS.md) - the distro's always-loaded operating contract and routing index for conditional procedures.

--- a/bin/fm-turnend-guard-grok.sh
+++ b/bin/fm-turnend-guard-grok.sh
@@ -1,12 +1,11 @@
 #!/usr/bin/env bash
 # Grok Stop-hook adapter for the firstmate PRIMARY turn-end guard.
 #
-# Grok Stop hooks are passive: exit 2 does not block or feed stderr back to the
-# model. This adapter still uses the shared primary-scoped predicate in
-# fm-turnend-guard.sh. When that predicate says the primary would end blind, the
-# adapter forces one same-session follow-up by running `grok --resume <session>`
-# with a guard instruction. GROK_TURNEND_GUARD_ACTIVE is the loop guard: the
-# nested turn's own Stop hook exits without spawning another nested turn.
+# Grok Stop hooks are passive. This adapter uses the shared primary-scoped
+# diagnostic in fm-turnend-guard.sh, whose current contract always permits
+# completion after an advisory. The legacy exit-2 resume path remains only for
+# compatibility with older recorded sessions; current code does not activate it.
+# GROK_TURNEND_GUARD_ACTIVE prevents recursion if that legacy path is replayed.
 set -u
 
 PAYLOAD=$(cat 2>/dev/null || true)

--- a/bin/fm-turnend-guard.sh
+++ b/bin/fm-turnend-guard.sh
@@ -10,9 +10,8 @@
 # fleet-touching command itself, can sit blind for hours.
 # This script is push-based: verified harness turn-end hooks invoke it every time
 # the primary is about to end a turn.
-# Claude and codex can block directly by preserving exit status 2 and stderr.
-# OpenCode, pi, and grok adapters use the same predicate and force one bounded
-# follow-up because their turn-end events are passive.
+# Missing supervision is advisory at this boundary: the hook reports the exact
+# recovery action but always permits the turn to end.
 # See docs/turnend-guard.md for the per-harness mechanics, validation evidence,
 # and fail-open tradeoffs.
 #
@@ -26,15 +25,8 @@
 # primary checkout - the main home or a genuinely marked secondmate home - and
 # stay a silent, fast no-op inside child task worktrees.
 #
-# Loop-guard: never block twice in the same turn. Claude Code and codex Stop
-# payloads carry stop_hook_active=true when the CURRENT stop attempt was itself
-# already forced by an earlier block this turn; on that signal we always allow
-# the stop, whether or not watcher supervision actually got resumed. Passive
-# harness adapters provide their own one-follow-up guard before calling this
-# script.
-# That bounds this to at most one forced continuation per turn - never a wedged,
-# un-endable session - while still nagging again on a later turn if the problem
-# persists.
+# Legacy loop-guard payloads remain silent so an already-forced continuation is
+# never shown a duplicate advisory.
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -94,9 +86,9 @@ REASON=$("$SCRIPT_DIR/fm-supervision-instructions.sh" --afk "$afk" --x-mode "$x_
 rule='━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'
 {
   printf '●%s\n' "$rule"
-  printf '●  TURN WOULD END BLIND - SUPERVISION IS OFF\n'
+  printf '●  SUPERVISION ADVISORY - MONITORING IS OFF\n'
   printf '●  %s task(s) in flight, but no live watcher holds this home lock (last beat: %s).\n' "$FM_SUP_IN_FLIGHT" "$FM_SUP_BEACON_DESC"
   printf '●  %s\n' "$REASON"
   printf '●%s\n' "$rule"
 } >&2
-exit 2
+exit 0

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -53,8 +53,8 @@ Its `--restart` mode signals only the watcher recorded in the current home's `st
 A pull-based guard (`bin/fm-guard.sh`) warns through supervision tool output if the primary checkout is tangled, or if tasks are in flight and that watcher stops running or queued wakes are waiting to be drained.
 The drain script calls that guard after emptying the queue, which avoids repeating the queued-wakes warning for records it just consumed while still warning on stale watcher liveness.
 It leads with a prominent bordered tangle banner, while `bin/fm-guard.sh` owns the stale-watcher banner/reminder policy so repeated guarded commands stay noisy without reprinting the full watcher-down banner in the same episode.
-On every verified primary harness, tracked hook integration gives the primary session a push-based backstop: when work is in flight and no identity-matched watcher lock with a fresh beacon is live, direct Stop hooks block and passive turn-end hooks force one bounded follow-up.
-The guard covers the main primary and genuinely marked secondmate homes, exempts child crewmate/scout worktrees, is loop-safe per harness, and is documented in [turnend-guard.md](turnend-guard.md).
+On every verified primary harness, tracked hook integration gives the primary session a push-based diagnostic: when work is in flight and no identity-matched watcher lock with a fresh beacon is live, the hook reports the recovery action and permits the turn to end.
+The diagnostic covers the main primary and genuinely marked secondmate homes, exempts child crewmate/scout worktrees, remains compatible with legacy loop-guard payloads, and is documented in [turnend-guard.md](turnend-guard.md).
 
 A presence-gated sub-supervisor (`bin/fm-supervise-daemon.sh`) extends this for walk-away supervision: the `/afk` skill starts it through the tracked foreground helper `bin/fm-afk-start.sh`, after which the watcher reverts to daemon-managed one-shot mode and the daemon self-handles routine wakes in bash.
 The watcher and daemon share `bin/fm-classify-lib.sh` for captain-relevant status verbs, declared-external-wait vocabulary, and status-scan primitives.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -22,7 +22,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-ensure-agents-md.sh` | Ensure a project's real `AGENTS.md`, its `CLAUDE.md` symlink, and the canonical self-governance section |
 | `fm-guard.sh`            | Warn on primary-checkout tangles, pending queued wakes, and stale watcher liveness   |
 | `fm-primary-scope-lib.sh` | Shared marker-or-plain-checkout primary-home predicate for tracked hooks             |
-| `fm-turnend-guard.sh`    | Shared primary turn-end guard predicate so no turn ends blind (docs/turnend-guard.md) |
+| `fm-turnend-guard.sh`    | Shared non-blocking primary turn-end supervision diagnostic (docs/turnend-guard.md) |
 | `fm-turnend-guard-grok.sh` | Grok Stop-hook adapter for the primary turn-end guard                              |
 | `fm-arm-pretool-check.sh` | Stable PreToolUse transport for the watcher-arm command policy (docs/arm-pretool-check.md) |
 | `fm-arm-command-policy.mjs` | Semantic owner of the watcher-arm PreToolUse policy (docs/arm-pretool-check.md)   |

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -1,20 +1,22 @@
-# Primary turn-end supervision guard
+# Primary turn-end supervision diagnostic
 
-This is the authoritative contract for the "no turn ends blind" primary guard referenced from AGENTS.md section 8.
+This is the authoritative contract for the non-blocking primary supervision diagnostic referenced from AGENTS.md section 8.
 The turn-end supervision predicate lives in `bin/fm-turnend-guard.sh`.
 Its primary-checkout scope lives in `bin/fm-primary-scope-lib.sh`, shared with the native session-start nudge documented in `docs/sessionstart-nudge.md`.
 Harness-specific tracked hook files only adapt each verified harness's real turn-end mechanism to that shared predicate.
 Two related but separate PreToolUse seatbelts deny a bad command shape before it runs rather than detecting a blind turn end afterward: the watcher-arm seatbelt (`bin/fm-arm-pretool-check.sh`, `docs/arm-pretool-check.md`) and the cd-guard (`bin/fm-cd-pretool-check.sh`, `docs/cd-guard.md`).
 Each seatbelt's own document defines its scope; they do not share the turn-end guard's marker-aware primary detection.
 
-## Gap Closed
+## Purpose
 
 `bin/fm-guard.sh` is pull-based: it warns whenever some other supervision script happens to run, and prints nothing otherwise.
 The primary can otherwise end a turn after handling wakes without resuming supervision, then sit blind until another fleet command happens to run.
 On 2026-07-04, that exact gap left a parked no-mistakes gate unwatched for about nine hours.
 
-`bin/fm-turnend-guard.sh` closes the gap by checking the primary's own turn-end path.
-When tasks are in flight and there is no live identity-matched watcher with a fresh beacon, a harness hook must either block the turn end or force a bounded follow-up turn that tells the primary to resume the session-start supervision protocol for its harness.
+`bin/fm-turnend-guard.sh` detects the gap on the primary's own turn-end path.
+When tasks are in flight and there is no live identity-matched watcher with a fresh beacon, the hook prints the recovery action and exits 0.
+It never blocks completion and never forces a follow-up turn solely because supervision is stale or missing.
+The session-start digest, wake queue, and pull-based `bin/fm-guard.sh` remain the recovery mechanisms on the next active turn.
 
 ## Shared Predicate
 
@@ -29,8 +31,8 @@ For an in-scope primary checkout, it counts in-flight work from `state/*.meta`.
 If no task is in flight, it exits silently.
 If work is in flight, it requires `fm_watcher_healthy <state-dir> <watch-path> [grace-seconds] [home]` from `bin/fm-wake-lib.sh`.
 That is the same identity-matched live lock and fresh beacon check used by `bin/fm-watch-arm.sh`.
-A stale beacon blocks even if a watcher pid is still live.
-A fresh leftover beacon blocks if the watcher lock is missing, dead, or identity-mismatched.
+A stale beacon produces an advisory even if a watcher pid is still live.
+A fresh leftover beacon produces an advisory if the watcher lock is missing, dead, or identity-mismatched.
 
 `FM_STATE_OVERRIDE` wins over `FM_HOME/state`, and `FM_HOME` wins over repo-root `state/`.
 `FM_GUARD_GRACE` controls the beacon freshness window and defaults to 300 seconds.
@@ -42,25 +44,20 @@ All verified primary harnesses have a tracked integration:
 
 - `claude`: `.claude/settings.json` registers a `Stop` hook command anchored through `"$CLAUDE_PROJECT_DIR"/bin/fm-turnend-guard.sh`.
 - `codex`: `.codex/hooks.json` registers a `Stop` hook that reads the hook payload once, anchors the executable to the hook command process working directory, verifies that root is firstmate-shaped and hook-bearing, and pipes the original payload to that checkout's `bin/fm-turnend-guard.sh`.
-- `opencode`: `.opencode/plugins/fm-primary-turnend-guard.js` listens for `session.idle`, lets the watcher-arm coordinator handle normal idle supervision first, runs the shared guard only when that coordinator does not act, and uses `client.session.promptAsync` to force one follow-up prompt when the guard returns 2.
-- `pi`: `.pi/extensions/fm-primary-turnend-guard.ts` listens for `agent_settled`, marks the extension version loaded for session-start checks, runs the shared guard once per logical agent run, and uses `pi.sendUserMessage(..., { deliverAs: "followUp" })` to force one follow-up prompt when the guard returns 2.
+- `opencode`: `.opencode/plugins/fm-primary-turnend-guard.js` listens for `session.idle`, lets the watcher-arm coordinator handle normal idle supervision first, and runs the shared diagnostic only when that coordinator does not act.
+- `pi`: `.pi/extensions/fm-primary-turnend-guard.ts` listens for `agent_settled`, marks the extension version loaded for session-start checks, and runs the shared diagnostic once per logical agent run.
 - `grok`: `.grok/hooks/fm-primary-turnend-guard.json` registers a `Stop` hook that invokes `bin/fm-turnend-guard-grok.sh`.
-  The adapter runs the shared guard and, when it returns 2, invokes `grok --resume <sessionId> -p <guard-reason>` with `GROK_TURNEND_GUARD_ACTIVE=1`.
+  The adapter runs the shared diagnostic and allows the turn to end after an advisory result.
   It does not pass `--permission-mode`, so the passive Stop hook cannot grant stronger tool permissions than Grok's resumed-session default.
 
-Claude and Codex support a direct blocking Stop hook.
-For those harnesses, exit status 2 plus stderr from `bin/fm-turnend-guard.sh` blocks the stop and feeds the reason back into the model.
-Both payloads include `stop_hook_active`; when it is true, the shared guard exits 0 so the harness can end after one forced continuation.
-
-OpenCode, Pi, and Grok expose passive lifecycle callbacks for this purpose.
-Their adapters fail open at the hook boundary to avoid corrupting a user session, but they force one follow-up turn when the shared predicate blocks.
-Each adapter carries its own in-process or environment loop guard so the forced follow-up does not recursively schedule another follow-up.
-Pi keeps that latch active across every internal tool turn and clears it only when the generated guard follow-up reaches `agent_settled`, or immediately when follow-up delivery fails.
-If a passive adapter cannot call its SDK method, cannot find `grok`, or cannot recover the Grok session id, it fails open and relies on the pull-based `fm-guard.sh` warning at the next fleet command.
-That warning uses `bin/fm-supervision-instructions.sh --repair-line`, so it points back to the active harness protocol instead of hardcoding one background-arm command.
+Claude and Codex preserve stderr from the shared diagnostic but receive exit status 0, so a stale watcher cannot block Stop.
+OpenCode, Pi, and Grok receive the same exit status and do not schedule a supervision-only follow-up.
+Legacy loop-guard fields and adapter code remain compatible with old recorded sessions, but the current shared diagnostic never emits the blocking status that activated them.
+The pull-based `fm-guard.sh` warning remains available at the next fleet command and uses `bin/fm-supervision-instructions.sh --repair-line` to point back to the active harness protocol.
 
 ## Empirical Validation
 
+The dated measurements below describe the former blocking behavior and are retained as historical harness evidence; the current exit-0 contract is owned by the behavior suite.
 All harnesses were validated on 2026-07-08 in scratch repos or throwaway homes, not against the captain's live primary fleet state.
 
 Claude Code 2.1.204 preserved the existing behavior.
@@ -123,10 +120,10 @@ That was a scoping choice inherited from the guard's primary-only origin, not a 
 A genuinely marked secondmate home is now force-included as a guarded primary regardless of whether it is a treehouse-leased linked worktree or a git-cloned plain checkout.
 Only unmarked child worktrees fall through to the linked-worktree exemption, and marker validation prevents an empty, malformed, or symlink marker from spoofing inclusion.
 
-"No turn ends blind" for a secondmate is delivered by the same two mechanisms the main primary relies on.
-Mechanism B, the turn-end backstop, is this guard; its secondmate-home behavior is covered by hermetic tests in `tests/fm-turnend-guard.test.sh` (`test_hook_blocks_in_secondmate_own_home`, `test_hook_blocks_in_treehouse_leased_secondmate_home`, `test_hook_silent_in_idle_secondmate_home`, `test_hook_secondmate_loop_guard_allows_retry`, `test_hook_secondmate_reinvoke_recovery_loop`, `test_hook_silent_in_secondmate_child_worktree`, and `test_hook_exempts_linked_worktree_with_stray_marker`).
+Secondmate supervision uses the same two mechanisms as the main primary.
+Mechanism B, the turn-end diagnostic, is this script; its secondmate-home behavior is covered by hermetic tests in `tests/fm-turnend-guard.test.sh`.
 Mechanism A, the autonomous wake, is a harness property: when a background watcher task exits, the harness re-invokes the model, which drains the wake, advances children, and re-arms a fresh watcher.
-Mechanism A cannot be a hermetic CI assertion because it requires a live model session, so it is recorded here as a dated first-hand measurement while `test_hook_secondmate_reinvoke_recovery_loop` covers the guard's deterministic half of the same recovery loop.
+Mechanism A cannot be a hermetic CI assertion because it requires a live model session, so it is recorded here as a dated first-hand measurement while the behavior suite covers the diagnostic half of the same recovery loop.
 
 Autonomous-re-invoke measurement, run first-hand on Claude Code 2.1.207 (Darwin 25.5.0) on 2026-07-12.
 Procedure: launch a detached `run_in_background` Bash task that models a one-shot watcher - it records a launch epoch, runs `sleep 25`, then records a completion epoch just before exit, writing only to the session scratchpad - then end the turn with no further tool calls and no pending question, a genuinely idle session with no human input.
@@ -147,6 +144,6 @@ No Herdr command was issued and no fleet state was touched; the experiment wrote
 
 ## Tests
 
-`tests/fm-turnend-guard.test.sh` covers the shared predicate, primary scoping (including a secondmate's own home being guarded like the main primary while its child worktrees stay exempt), `FM_HOME` and `FM_STATE_OVERRIDE` precedence, Pi logical-run latch behavior for no-tool and multi-tool runs, fail-open behavior without `jq`, tracked hook registration for all five harnesses, and the Grok adapter's forced-resume loop guard and permission-mode regression.
+`tests/fm-turnend-guard.test.sh` covers the shared predicate, non-blocking advisory behavior, primary scoping, `FM_HOME` and `FM_STATE_OVERRIDE` precedence, fail-open behavior without `jq`, and tracked hook registration for all five harnesses.
 The default behavior suite does not invoke live language-model harnesses.
 `FM_PI_LIVE_E2E=1 tests/fm-pi-primary-live-e2e.test.sh` opts into the isolated interactive Pi regression recorded above.

--- a/tests/fm-turnend-guard.test.sh
+++ b/tests/fm-turnend-guard.test.sh
@@ -5,8 +5,8 @@
 #   PREDICATE  - bin/fm-supervision-lib.sh, the shared beacon/status computation
 #                used by fm-guard.sh and by the hook's banner details.
 #   HOOK       - bin/fm-turnend-guard.sh, the shared primary hook predicate that
-#                scopes in-flight work to the PRIMARY checkout only and requires
-#                a live, identity-matched watcher lock plus a fresh beacon.
+#                scopes in-flight work to the PRIMARY checkout and reports a
+#                missing live, identity-matched watcher without blocking Stop.
 # All hermetic over temp dirs; no real agent session is invoked.
 set -u
 
@@ -205,18 +205,18 @@ test_hook_silent_when_no_work_in_flight() {
   pass "fm-turnend-guard: silent no-op with nothing in flight"
 }
 
-test_hook_blocks_when_fresh_beacon_has_no_live_lock() {
+test_hook_warns_when_fresh_beacon_has_no_live_lock() {
   local dir out status
   dir=$(make_primary_dir "$TMP_ROOT/hook-fresh-no-lock")
   : > "$dir/state/task1.meta"
   touch "$dir/state/.last-watcher-beat"
   out=$(run_hook "$dir" false); status=$?
-  expect_code 2 "$status" "hook must block when a fresh beacon has no live watcher lock"
-  assert_contains "$out" "$REQUIRED_REASON" "block reason must contain the exact required instruction"
-  pass "fm-turnend-guard: blocks when a fresh beacon has no live watcher lock"
+  expect_code 0 "$status" "hook must allow Stop when a fresh beacon has no live watcher lock"
+  assert_contains "$out" "$REQUIRED_REASON" "advisory must contain the exact recovery instruction"
+  pass "fm-turnend-guard: warns without blocking when a fresh beacon has no live watcher lock"
 }
 
-test_hook_blocks_when_dead_lock_has_fresh_beacon() {
+test_hook_warns_when_dead_lock_has_fresh_beacon() {
   local dir dead out status
   dir=$(make_primary_dir "$TMP_ROOT/hook-dead-lock-fresh")
   dead=$(nonexistent_pid)
@@ -224,9 +224,9 @@ test_hook_blocks_when_dead_lock_has_fresh_beacon() {
   record_watcher_lock "$dir" "$dead" "dead watcher identity"
   touch "$dir/state/.last-watcher-beat"
   out=$(run_hook "$dir" false); status=$?
-  expect_code 2 "$status" "hook must block when the watcher lock pid is dead despite a fresh beacon"
-  assert_contains "$out" "$REQUIRED_REASON" "block reason must contain the exact required instruction"
-  pass "fm-turnend-guard: blocks on a dead watcher lock even when the beacon is fresh"
+  expect_code 0 "$status" "hook must allow Stop when the watcher lock pid is dead despite a fresh beacon"
+  assert_contains "$out" "$REQUIRED_REASON" "advisory must contain the exact recovery instruction"
+  pass "fm-turnend-guard: warns without blocking on a dead watcher lock even when the beacon is fresh"
 }
 
 test_hook_silent_with_live_lock_and_fresh_beacon() {
@@ -250,7 +250,7 @@ test_hook_silent_with_live_lock_and_fresh_beacon() {
   pass "fm-turnend-guard: silent no-op with a live watcher lock and fresh beacon"
 }
 
-test_hook_blocks_with_live_lock_and_stale_beacon() {
+test_hook_warns_with_live_lock_and_stale_beacon() {
   local dir pid identity out status
   dir=$(make_primary_dir "$TMP_ROOT/hook-live-lock-stale")
   : > "$dir/state/task1.meta"
@@ -266,32 +266,32 @@ test_hook_blocks_with_live_lock_and_stale_beacon() {
   out=$(run_hook "$dir" false); status=$?
   kill "$pid" 2>/dev/null || true
   wait "$pid" 2>/dev/null || true
-  expect_code 2 "$status" "hook must block when a live watcher lock has an ancient beacon"
-  assert_contains "$out" "$REQUIRED_REASON" "block reason must contain the exact required instruction"
-  pass "fm-turnend-guard: blocks on a live watcher lock with an ancient beacon"
+  expect_code 0 "$status" "hook must allow Stop when a live watcher lock has an ancient beacon"
+  assert_contains "$out" "$REQUIRED_REASON" "advisory must contain the exact recovery instruction"
+  pass "fm-turnend-guard: warns without blocking on a live watcher lock with an ancient beacon"
 }
 
-test_hook_blocks_when_unhealthy_in_primary() {
+test_hook_warns_when_unhealthy_in_primary() {
   local dir out status
   dir=$(make_primary_dir "$TMP_ROOT/hook-block")
   : > "$dir/state/task1.meta"
   out=$(run_hook "$dir" false); status=$?
-  expect_code 2 "$status" "hook must block (exit 2) when in-flight work has no live watcher"
-  assert_contains "$out" "$REQUIRED_REASON" "block reason must contain the exact required instruction"
-  assert_contains "$out" "TURN WOULD END BLIND" "block banner must read as an alarm"
-  pass "fm-turnend-guard: blocks with the exact required reason in the primary when unhealthy"
+  expect_code 0 "$status" "hook must allow Stop when in-flight work has no live watcher"
+  assert_contains "$out" "$REQUIRED_REASON" "advisory must contain the exact recovery instruction"
+  assert_contains "$out" "SUPERVISION ADVISORY" "advisory banner must identify itself"
+  pass "fm-turnend-guard: warns with the exact recovery instruction in the primary when unhealthy"
 }
 
-test_hook_blocks_from_fm_home_state() {
+test_hook_warns_from_fm_home_state() {
   local dir home out status
   dir=$(make_primary_dir "$TMP_ROOT/hook-fm-home")
   home="$TMP_ROOT/hook-fm-home-op"
   mkdir -p "$home/state"
   : > "$home/state/task1.meta"
   out=$(printf '{"stop_hook_active":false}' | CLAUDECODE=1 FM_HOME="$home" bash "$dir/bin/fm-turnend-guard.sh" 2>&1); status=$?
-  expect_code 2 "$status" "hook must inspect the active FM_HOME state dir"
-  assert_contains "$out" "$REQUIRED_REASON" "block reason must contain the exact required instruction"
-  pass "fm-turnend-guard: blocks from active FM_HOME state, not only repo-root state"
+  expect_code 0 "$status" "hook must allow Stop after inspecting the active FM_HOME state dir"
+  assert_contains "$out" "$REQUIRED_REASON" "advisory must contain the exact recovery instruction"
+  pass "fm-turnend-guard: warns from active FM_HOME state, not only repo-root state"
 }
 
 test_hook_x_mode_reason_sources_cadence() {
@@ -302,8 +302,8 @@ test_hook_x_mode_reason_sources_cadence() {
   : > "$dir/config/x-mode.env"
   : > "$dir/state/task1.meta"
   out=$(run_hook "$dir" false); status=$?
-  expect_code 2 "$status" "hook must block when in-flight X-mode work has no live watcher"
-  assert_contains "$out" "source '$home/config/x-mode.env' first" "block reason must source the effective X-mode cadence"
+  expect_code 0 "$status" "hook must allow Stop when in-flight X-mode work has no live watcher"
+  assert_contains "$out" "source '$home/config/x-mode.env' first" "advisory must source the effective X-mode cadence"
   pass "fm-turnend-guard: X-mode repair reason sources the cadence config"
 }
 
@@ -327,8 +327,8 @@ test_hook_uses_state_override() {
   mkdir -p "$home/state" "$state"
   : > "$state/task1.meta"
   out=$(printf '{"stop_hook_active":false}' | CLAUDECODE=1 FM_HOME="$home" FM_STATE_OVERRIDE="$state" bash "$dir/bin/fm-turnend-guard.sh" 2>&1); status=$?
-  expect_code 2 "$status" "hook must let FM_STATE_OVERRIDE win over FM_HOME/state"
-  assert_contains "$out" "$REQUIRED_REASON" "block reason must contain the exact required instruction"
+  expect_code 0 "$status" "hook must allow Stop after letting FM_STATE_OVERRIDE win over FM_HOME/state"
+  assert_contains "$out" "$REQUIRED_REASON" "advisory must contain the exact recovery instruction"
   pass "fm-turnend-guard: uses FM_STATE_OVERRIDE ahead of FM_HOME/state"
 }
 
@@ -347,15 +347,15 @@ test_hook_loop_guard_allows_retry() {
 # .fm-secondmate-home marker used to early-exit here, so an overnight secondmate
 # could end a turn with an unsupervised child and sit blind. Removing that marker
 # check makes the guard fire, mirroring the cd-guard.
-test_hook_blocks_in_secondmate_own_home() {
+test_hook_warns_in_secondmate_own_home() {
   local dir out status
   dir=$(make_secondmate_dir "$TMP_ROOT/hook-secondmate")
   : > "$dir/state/task1.meta"
   out=$(run_hook "$dir" false); status=$?
-  expect_code 2 "$status" "hook must guard a secondmate's own home like the main primary when unhealthy"
-  assert_contains "$out" "$REQUIRED_REASON" "block reason must contain the exact required instruction"
-  assert_contains "$out" "TURN WOULD END BLIND" "block banner must read as an alarm"
-  pass "fm-turnend-guard: blocks a blind turn end in a secondmate's own home (.fm-secondmate-home no longer excludes it)"
+  expect_code 0 "$status" "hook must allow Stop in a secondmate's own home when unhealthy"
+  assert_contains "$out" "$REQUIRED_REASON" "advisory must contain the exact recovery instruction"
+  assert_contains "$out" "SUPERVISION ADVISORY" "advisory banner must identify itself"
+  pass "fm-turnend-guard: warns without blocking in a secondmate's own home"
 }
 
 # Idle-by-default: an empty-queue secondmate has no in-flight meta, so the guard
@@ -385,8 +385,8 @@ test_hook_secondmate_loop_guard_allows_retry() {
 # The guard's half of the deferred-death recovery loop in a secondmate home,
 # proven deterministically without a live model or any daemon: silent while the
 # watcher is live (the secondmate ends its turn and relies on the background
-# re-invoke), then blocks to force the re-arm once the watcher has exited and a
-# second child event lands. The live half - that Claude Code autonomously
+# re-invoke), then warns once the watcher has exited and a second child event
+# lands. The live half - that Claude Code autonomously
 # re-invokes the model when the background watcher exits (Mechanism A) - is a
 # harness property recorded empirically in docs/turnend-guard.md; it needs a live
 # session and cannot be a hermetic CI assertion.
@@ -412,16 +412,16 @@ test_hook_secondmate_reinvoke_recovery_loop() {
   }
   # The watcher exits on the wake (its normal lifecycle) and a SECOND child event
   # lands. On the re-invoked recovery turn the secondmate must re-arm; if it did
-  # not, the guard blocks that turn's end and forces the re-arm (Stop #2).
+  # not, the guard warns on that turn's end without forcing the re-arm (Stop #2).
   kill "$pid" 2>/dev/null || true
   wait "$pid" 2>/dev/null || true
   rm -rf "$dir/state/.watch.lock"
   : > "$dir/state/child2.meta"
   touch "$dir/state/.last-watcher-beat"
   out=$(run_hook "$dir" false); status=$?
-  expect_code 2 "$status" "secondmate recovery turn must not end blind after the watcher exits (Stop #2)"
-  assert_contains "$out" "$REQUIRED_REASON" "block reason must contain the exact required instruction"
-  pass "fm-turnend-guard: secondmate deferred-death recovery - silent while watched, forces re-arm once the watcher exits"
+  expect_code 0 "$status" "secondmate recovery turn must remain endable after the watcher exits (Stop #2)"
+  assert_contains "$out" "$REQUIRED_REASON" "advisory must contain the exact recovery instruction"
+  pass "fm-turnend-guard: secondmate deferred-death recovery - silent while watched, advisory once the watcher exits"
 }
 
 # The marker force-include must guard only the secondmate's OWN home, never its
@@ -445,7 +445,7 @@ test_hook_silent_in_secondmate_child_worktree() {
 # remove-only form wrongly exempted. With the marker force-include, its own
 # primary session is GUARDED. The test asserts the fixture really is a linked
 # worktree so it can never silently regress back into a plain-checkout shape.
-test_hook_blocks_in_treehouse_leased_secondmate_home() {
+test_hook_warns_in_treehouse_leased_secondmate_home() {
   local base dir gd gcd out status
   base="$TMP_ROOT/hook-sm-leased-base"
   dir="$TMP_ROOT/hook-sm-leased-home"
@@ -455,10 +455,10 @@ test_hook_blocks_in_treehouse_leased_secondmate_home() {
   [ "$gd" != "$gcd" ] || fail "leased-home fixture must be a linked worktree (git-dir != git-common-dir), got equal: $gd"
   : > "$dir/state/task1.meta"
   out=$(run_hook "$dir" false); status=$?
-  expect_code 2 "$status" "hook must GUARD a treehouse-leased (linked) secondmate home via its marker when unhealthy"
-  assert_contains "$out" "$REQUIRED_REASON" "block reason must contain the exact required instruction"
-  assert_contains "$out" "TURN WOULD END BLIND" "block banner must read as an alarm"
-  pass "fm-turnend-guard: blocks a blind turn end in a treehouse-leased LINKED secondmate home (marker force-include)"
+  expect_code 0 "$status" "hook must allow Stop in a treehouse-leased secondmate home when unhealthy"
+  assert_contains "$out" "$REQUIRED_REASON" "advisory must contain the exact recovery instruction"
+  assert_contains "$out" "SUPERVISION ADVISORY" "advisory banner must identify itself"
+  pass "fm-turnend-guard: warns without blocking in a treehouse-leased linked secondmate home"
 }
 
 # Anti-spoof: a linked worktree with an INVALID (empty) marker must NOT be
@@ -544,7 +544,7 @@ test_hook_runs_fast() {
   pass "fm-turnend-guard: runs well under the generous timing margin (${elapsed_s}s)"
 }
 
-test_grok_adapter_forces_one_resume_when_unhealthy() {
+test_grok_adapter_does_not_resume_for_advisory() {
   local dir fakebin log out status
   dir=$(make_primary_dir "$TMP_ROOT/grok-adapter-block")
   : > "$dir/state/task1.meta"
@@ -564,15 +564,10 @@ test_grok_adapter_forces_one_resume_when_unhealthy() {
 EOF
   chmod +x "$fakebin/grok"
   out=$(printf '{"sessionId":"session-test","hookEventName":"stop"}' | PATH="$fakebin:$PATH" GROK_WORKSPACE_ROOT="$dir" bash "$dir/bin/fm-turnend-guard-grok.sh" 2>&1); status=$?
-  expect_code 0 "$status" "grok adapter must fail open after queuing a forced resume"
+  expect_code 0 "$status" "grok adapter must allow Stop after a supervision advisory"
   [ -z "$out" ] || fail "grok adapter printed output: $out"
-  assert_contains "$(cat "$log")" 'active=1' "grok adapter must mark its forced resume as loop-guarded"
-  assert_contains "$(cat "$log")" '<--resume>' "grok adapter must resume the current session"
-  assert_contains "$(cat "$log")" '<session-test>' "grok adapter must pass the hook session id"
-  assert_not_contains "$(cat "$log")" '<--permission-mode>' "grok adapter must not add a stronger permission mode"
-  assert_not_contains "$(cat "$log")" '<bypassPermissions>' "grok adapter must not bypass permissions on forced resume"
-  assert_contains "$(cat "$log")" 'TURN WOULD END BLIND' "grok adapter must carry the guard reason into the forced resume"
-  pass "fm-turnend-guard-grok: forces one same-session resume when the shared predicate blocks"
+  [ ! -e "$log" ] || fail "grok adapter resumed the session for an advisory: $(cat "$log")"
+  pass "fm-turnend-guard-grok: supervision advisory does not force a resumed turn"
 }
 
 test_grok_adapter_loop_guard_skips_resume() {
@@ -892,29 +887,29 @@ test_predicate_unhealthy_stale_beacon
 test_predicate_healthy_fresh_beacon
 test_predicate_queue_pending_flag
 test_hook_silent_when_no_work_in_flight
-test_hook_blocks_when_fresh_beacon_has_no_live_lock
-test_hook_blocks_when_dead_lock_has_fresh_beacon
+test_hook_warns_when_fresh_beacon_has_no_live_lock
+test_hook_warns_when_dead_lock_has_fresh_beacon
 test_hook_silent_with_live_lock_and_fresh_beacon
-test_hook_blocks_with_live_lock_and_stale_beacon
-test_hook_blocks_when_unhealthy_in_primary
-test_hook_blocks_from_fm_home_state
+test_hook_warns_with_live_lock_and_stale_beacon
+test_hook_warns_when_unhealthy_in_primary
+test_hook_warns_from_fm_home_state
 test_hook_x_mode_reason_sources_cadence
 test_hook_ignores_repo_state_when_fm_home_set
 test_hook_uses_state_override
 test_hook_loop_guard_allows_retry
-test_hook_blocks_in_secondmate_own_home
+test_hook_warns_in_secondmate_own_home
 test_hook_silent_in_idle_secondmate_home
 test_hook_secondmate_loop_guard_allows_retry
 test_hook_secondmate_reinvoke_recovery_loop
 test_hook_silent_in_secondmate_child_worktree
-test_hook_blocks_in_treehouse_leased_secondmate_home
+test_hook_warns_in_treehouse_leased_secondmate_home
 test_hook_exempts_linked_worktree_with_stray_marker
 test_hook_exempts_linked_worktree_with_non_ascii_marker
 test_hook_silent_in_crewmate_worktree
 test_hook_silent_without_jq
 test_hook_silent_without_stdin
 test_hook_runs_fast
-test_grok_adapter_forces_one_resume_when_unhealthy
+test_grok_adapter_does_not_resume_for_advisory
 test_grok_adapter_loop_guard_skips_resume
 test_settings_hook_uses_claude_project_dir
 test_codex_hook_invokes_shared_guard


### PR DESCRIPTION
## Outcome

Stale or missing First Mate supervision no longer blocks Stop or forces a supervision-only follow-up. The hook still reports the exact recovery action and preserves active supervision behavior.

## Changes

- return exit 0 for stale/missing supervision advisories
- update primary and secondmate behavior tests
- keep legacy adapter loop compatibility
- update the operating contract and user documentation

## Verification

- bash tests/fm-turnend-guard.test.sh
- bash bin/fm-lint.sh
- global engineering architecture guard