### PR TITLE
fix: fetch current PR head for review diffs

### DIFF
--- a/bin/fm-review-diff.sh
+++ b/bin/fm-review-diff.sh
@@ -4,10 +4,12 @@
 # Pooled project clones do not keep their local default branch current, so this
 # helper compares remote-backed projects against origin/<default> after fetching
 # the default branch, and local-only projects against the local default branch.
-# When state/<id>.meta records pr= for an open PR, the compare side is the PR
-# head (recorded pr_head= when reachable, else refs/pull/<n>/head) so review
-# stays current after no-mistakes fix rounds push to the PR; if the PR head
-# cannot be resolved, the script falls back to the local branch with a warning.
+# When state/<id>.meta records pr= (URL or number) for an open PR, the compare
+# side is ALWAYS a freshly fetched refs/pull/<n>/head by default so review stays
+# current after no-mistakes fix rounds push to the PR. A recorded pr_head= is
+# only a fallback when fetch fails (stale recorded SHAs must never win over a
+# reachable remote PR head). If neither PR head can be resolved, fall back to
+# the local branch with a warning. Without pr=, compare the local branch.
 # Usage: fm-review-diff.sh <task-id> [--stat]
 #   --stat prints only the stat summary; default prints stat summary plus full diff.
 set -eu
@@ -89,19 +91,35 @@ pr_number_from_target() {
   printf '%s' "$n"
 }
 
+fetch_pull_head() {
+  local n=$1 resolved
+  git -C "$WT" remote get-url origin >/dev/null 2>&1 || return 1
+  # Fetch into a private ref so a later base-branch fetch cannot clobber the
+  # compare tip via FETCH_HEAD, and so we never review a stale local object.
+  git -C "$WT" fetch --quiet origin \
+    "+refs/pull/$n/head:refs/fm-review/pull/$n/head" >/dev/null 2>&1 || return 1
+  resolved=$(git -C "$WT" rev-parse --verify "refs/fm-review/pull/$n/head^{commit}" 2>/dev/null) || return 1
+  [ -n "$resolved" ] || return 1
+  printf '%s' "$resolved"
+}
+
 resolve_pr_head() {
   local pr_url=$1 recorded_head=$2 n resolved
+  n=$(pr_number_from_target "$pr_url") || true
+  if [ -n "$n" ]; then
+    if resolved=$(fetch_pull_head "$n"); then
+      printf '%s' "$resolved"
+      return 0
+    fi
+  fi
+  # Offline / unreachable remote: recorded pr_head is better than the local
+  # branch, but never preferred over a successful pull-head fetch above.
   if [ -n "$recorded_head" ] \
     && git -C "$WT" cat-file -e "$recorded_head^{commit}" 2>/dev/null; then
     printf '%s' "$recorded_head"
     return 0
   fi
-  n=$(pr_number_from_target "$pr_url") || return 1
-  git -C "$WT" remote get-url origin >/dev/null 2>&1 || return 1
-  git -C "$WT" fetch --quiet origin "refs/pull/$n/head" >/dev/null 2>&1 || return 1
-  resolved=$(git -C "$WT" rev-parse --verify 'FETCH_HEAD^{commit}' 2>/dev/null) || return 1
-  [ -n "$resolved" ] || return 1
-  printf '%s' "$resolved"
+  return 1
 }
 
 PR_URL=$(grep '^pr=' "$META" | tail -1 | cut -d= -f2- || true)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -171,7 +171,7 @@ The `data/secondmates.md` line contract is owned by the [`secondmate-provisionin
 
 `data/projects.md` records each project's delivery mode and optional `+yolo` autonomy flag.
 `no-mistakes` projects run the full validation pipeline, `direct-PR` projects open PRs without that pipeline, and `local-only` projects stay local until firstmate performs an approved fast-forward merge.
-When a selected delivery path calls for a diff, `bin/fm-review-diff.sh` refreshes the authoritative base and, when task meta records `pr=`, compares against the reachable recorded `pr_head=` or a freshly fetched `refs/pull/<n>/head` before falling back to the local branch with a warning.
+When a selected delivery path calls for a diff, `bin/fm-review-diff.sh` refreshes the authoritative base and, when task meta records `pr=`, always fetches and compares against `refs/pull/<n>/head` by default (recorded `pr_head=` is only an offline fallback) before falling back to the local branch with a warning.
 For target project repos shipped through their own no-mistakes pipeline, commits under `.no-mistakes/evidence/` are the pipeline's PR-viewable validation evidence and are expected to stay in the crew branch until the evidence-hosting design changes.
 The firstmate repo itself is the exception: its `.no-mistakes/` directory is local state, stays gitignored, and is rejected by CI if tracked.
 PR-based task merges go through `bin/fm-pr-merge.sh`, which records `pr=` and any available `pr_head=` through `bin/fm-pr-check.sh` before calling `gh-axi pr merge`.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -43,7 +43,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-config-push.sh`      | Push declared inherited local material to live secondmate homes mid-session          |
 | `fm-project-mode.sh`     | Resolve a project's delivery mode and `+yolo` flag from `data/projects.md`           |
 | `fm-merge-local.sh`      | Fast-forward a `local-only` project's local default branch after approval            |
-| `fm-review-diff.sh`      | Review a crewmate branch or recorded PR head against the authoritative base          |
+| `fm-review-diff.sh`      | Review a crewmate branch or freshly fetched PR head against the authoritative base   |
 | `fm-marker-lib.sh`       | Shared from-firstmate request marker, detector, and idempotent transformation         |
 | `fm-gate-refuse-lib.sh`  | Shared no-mistakes gate-context refusal for fleet lifecycle entrypoints               |
 | `fm-watch-arm.sh`        | Verified home-scoped watcher arm wrapper with loud cycle endings and bounded lifecycle ledger |

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -43,7 +43,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-config-push.sh`      | Push declared inherited local material to live secondmate homes mid-session          |
 | `fm-project-mode.sh`     | Resolve a project's delivery mode and `+yolo` flag from `data/projects.md`           |
 | `fm-merge-local.sh`      | Fast-forward a `local-only` project's local default branch after approval            |
-| `fm-review-diff.sh`      | Review a crewmate branch or freshly fetched PR head against the authoritative base   |
+| `fm-review-diff.sh`      | Review a crewmate branch or resolved PR head against the authoritative base          |
 | `fm-marker-lib.sh`       | Shared from-firstmate request marker, detector, and idempotent transformation         |
 | `fm-gate-refuse-lib.sh`  | Shared no-mistakes gate-context refusal for fleet lifecycle entrypoints               |
 | `fm-watch-arm.sh`        | Verified home-scoped watcher arm wrapper with loud cycle endings and bounded lifecycle ledger |

--- a/tests/fm-review-diff.test.sh
+++ b/tests/fm-review-diff.test.sh
@@ -1,13 +1,16 @@
 #!/usr/bin/env bash
 # Tests for bin/fm-review-diff.sh: when a task has an open PR recorded in meta,
-# the review diff must compare the authoritative base against the PR head, not a
-# stale local branch left behind after no-mistakes fix rounds push to the PR.
+# the review diff must compare the authoritative base against a freshly fetched
+# PR head, not a stale local branch or a stale recorded pr_head= left behind
+# after no-mistakes fix rounds push to the PR.
 #
 # Matrix:
-#   (a) pr= + reachable pr_head= -> diff uses PR head, not the lagging local branch
+#   (a) pr= + reachable pr_head=, no remote pull ref -> offline fallback to recorded SHA
 #   (b) pr= without pr_head= -> fetch refs/pull/<n>/head and diff that
 #   (c) pr= absent -> unchanged worktree-branch diff
 #   (d) pr= present but PR head unreachable -> fallback to local branch + warning
+#   (e) pr= + STALE recorded pr_head= + newer remote pull head -> must use fetched head
+#       (this is the class that bit reviewers holding merges over "missing" fixes)
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -76,6 +79,7 @@ test_pr_meta_uses_pr_head_not_stale_local() {
   local case_dir out
   case_dir=$(make_case pr-head-sha)
   stale_and_pr_commits "$case_dir"
+  # No remote pull ref: fetch fails, recorded pr_head is the offline fallback.
   write_task_meta "$case_dir" \
     "pr=https://github.com/example/repo/pull/9" \
     "pr_head=$PR_SHA"
@@ -85,8 +89,32 @@ test_pr_meta_uses_pr_head_not_stale_local() {
   assert_contains "$out" '+pr-fixed' "pr-head-sha: diff should show the PR head content"
   assert_not_contains "$out" 'stale-local' "pr-head-sha: diff must not use the stale local branch"
   assert_not_contains "$(cat "$case_dir/stderr")" 'warning: PR head unavailable' \
-    "pr-head-sha: should not warn when pr_head is reachable"
-  pass "fm-review-diff uses recorded pr_head instead of the lagging local branch"
+    "pr-head-sha: should not warn when recorded pr_head is reachable offline"
+  pass "fm-review-diff falls back to recorded pr_head when pull head cannot be fetched"
+}
+
+test_stale_recorded_pr_head_loses_to_fetched_pull_head() {
+  local case_dir out stale_sha
+  case_dir=$(make_case stale-recorded)
+  stale_and_pr_commits "$case_dir"
+  stale_sha=$(git -C "$case_dir/wt" rev-parse fm/task-x1)
+  # Remote PR head is newer (pipeline fix); meta still points at the older local tip.
+  git -C "$case_dir/wt" push -q origin "pr-head-tmp:refs/pull/9/head"
+  write_task_meta "$case_dir" \
+    "pr=https://github.com/example/repo/pull/9" \
+    "pr_head=$stale_sha"
+
+  out=$(run_review_diff "$case_dir" task-x1 2> "$case_dir/stderr")
+
+  assert_contains "$out" '+pr-fixed' \
+    "stale-recorded: diff must show the fetched PR head, not the recorded stale SHA"
+  assert_not_contains "$out" 'stale-local' \
+    "stale-recorded: diff must not use the stale local/recorded content"
+  assert_not_contains "$(cat "$case_dir/stderr")" 'warning: PR head unavailable' \
+    "stale-recorded: fetch of refs/pull/<n>/head should succeed"
+  # Pre-fix behavior preferred reachable recorded pr_head= and would show stale-local.
+  [ "$stale_sha" != "$PR_SHA" ] || fail "stale-recorded: fixture did not diverge recorded vs PR head"
+  pass "fm-review-diff prefers freshly fetched PR head over a stale recorded pr_head="
 }
 
 test_pr_meta_fetches_pull_head_without_recorded_sha() {
@@ -143,5 +171,6 @@ test_unreachable_pr_head_falls_back_with_warning() {
 
 test_pr_meta_uses_pr_head_not_stale_local
 test_pr_meta_fetches_pull_head_without_recorded_sha
+test_stale_recorded_pr_head_loses_to_fetched_pull_head
 test_no_pr_meta_uses_local_branch
 test_unreachable_pr_head_falls_back_with_warning

--- a/tests/fm-sessionstart-nudge.test.sh
+++ b/tests/fm-sessionstart-nudge.test.sh
@@ -5,6 +5,8 @@ set -u
 # shellcheck source=tests/lib.sh
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
+unset NO_MISTAKES_GATE
+
 TMP_ROOT=$(fm_test_tmproot fm-sessionstart-nudge)
 NUDGE="$ROOT/bin/fm-sessionstart-nudge.sh"
 NUDGE_LINE="Run \`bin/fm-session-start.sh\` now, exactly once, before executing any other instructions."


### PR DESCRIPTION
## Intent

Machinery-over-memory fix for Firstmate review diffs: make bin/fm-review-diff.sh FETCH the actual PR head (refs/pull/<n>/head) by DEFAULT whenever task meta records pr=, so reviews always compare the true remote PR tip and never a stale local checkout or a stale recorded pr_head=.

This class of bug has bitten reviewers multiple times (holding a merge over a "missing" fix that had already landed on the PR because the review looked at lagging local objects after no-mistakes fix rounds pushed).

Deliberate design choices:
- Always attempt git fetch of refs/pull/<n>/head first when a PR URL or number is in meta; do not prefer a reachable recorded pr_head= even if present (recorded SHAs go stale when pr-check does not refresh them).
- Store the fetched tip under refs/fm-review/pull/<n>/head so a later base-branch fetch cannot clobber the compare tip via FETCH_HEAD.
- Offline/unreachable fallback order: recorded pr_head= if the object exists, else local branch with a warning. Without pr=, keep local-branch compare unchanged.
- Add a regression test that sets local+recorded SHA to old content, remote pull head to newer content, and asserts the review shows the fetched tip (must fail under pre-fix prefer-recorded behavior).
- Docs (architecture.md, scripts.md) updated to match the new precedence.

## What Changed

- Fetch PR heads into a dedicated `refs/fm-review/pull/<n>/head` ref before generating review diffs, ensuring the remote tip takes precedence over recorded metadata.
- Retain recorded `pr_head` and local-branch fallbacks when the PR head cannot be fetched, while preserving local-branch comparisons for tasks without a PR.
- Add stale-recorded-head coverage, isolate session-start nudge tests from gate state, and update review-diff documentation.

## Risk Assessment

✅ Low: The change is tightly scoped and implements the required fresh PR-head fetch with the specified isolated ref and fallback order; surrounding call paths and updated regression coverage are consistent.

## Testing

The prior baseline was successful; focused regression coverage, a direct end-to-end CLI review transcript, and the complete test suite all passed (`FULL_SUITE_EXIT=0`).

<details>
<summary>Evidence: End-to-end PR-head review transcript</summary>

```text
Scenario: PR metadata still records a reachable stale SHA while the remote pull head has the newer fix.
recorded pr_head: 3cfb7793d7915f2653a3cce92be15bc56792936c
remote PR head:  9830ce48278639e89897ede2dcf216d13c45a449

$ fm-review-diff.sh task-x1
diff base: origin/main
 feature.txt | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

diff --git a/feature.txt b/feature.txt
index df967b9..da34a17 100644
--- a/feature.txt
+++ b/feature.txt
@@ -1 +1 @@
-base
+pr-fixed

$ git rev-parse refs/fm-review/pull/42/head
9830ce48278639e89897ede2dcf216d13c45a449

Assertions: reviewer output contains +pr-fixed, omits stale-local, and private fetched ref equals remote PR head.
PASS: private fetched ref matches the remote PR tip.
PASS: review surfaced only the newer PR-tip content.
```
</details>
- Outcome: 🔧 1 issue found → auto-fixed ✅ across 2 runs (1h51m30s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed ✅</summary>

- 🚨 tests failed with exit code 1
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`

🔧 Fix: Isolate session-start nudge tests from gate state
✅ Re-checked - no issues remain.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- `Baseline configured suite reported successful before this run.`
- `bash tests/fm-review-diff.test.sh`
- <code>Isolated `bin/fm-review-diff.sh task-x1` scenario with stale `pr_head=` and newer remote `refs/pull/42/head`</code>
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; echo "FULL_SUITE_EXIT=$rc"; exit "$rc"`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
