### PR TITLE
fix(supervision): relocate long-lived processes out of disposable worktrees

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,8 +76,14 @@ for test_script in tests/*.test.sh; do bash "$test_script"; done   # behavior te
 tmp=$(mktemp -d) && printf 'done: smoke\n' > "$tmp/smoke.status" && FM_STATE_OVERRIDE="$tmp" FM_SIGNAL_GRACE=1 FM_POLL=1 FM_HEARTBEAT=999999 bin/fm-watch-arm.sh  # watcher re-arm smoke test (prints arm status, then an actionable signal)
 ```
 
+Run the watcher smoke test from a checkout that is itself a disposable treehouse worktree and it first prints a loud relocation banner on stderr before arming normally; that is the expected self-correction, not a failure.
+
 Discover tests by listing `tests/*.test.sh`: each is a self-contained bash script named `<subject>.test.sh`, and its header comment describes what it covers, so run one directly to focus on a subject.
 Tests that need a real optional backend or an explicit opt-in (real herdr/zellij/cmux smoke tests, the live Pi regression) skip themselves and print the tool or environment gate needed to enable them, so the run-all loop above is always safe.
+
+A suite that runs `bin/fm-watch.sh`, `bin/fm-watch-arm.sh`, `bin/fm-watch-checkpoint.sh`, or `bin/fm-afk-start.sh` needs a treehouse pool-root pin, because those launchers relocate themselves out of a disposable pool slot and a checkout that is itself a task worktree is exactly that shape.
+Sourcing `tests/lib.sh`, directly or through a helper that sources it, inherits the tree-wide `FM_TREEHOUSE_POOL_ROOT` pin; a standalone suite sets the variable itself, and a suite that only mentions a launcher without running it carries the `relocation-pool-pin: not-needed` marker instead.
+`tests/fm-relocation-pool-pin.test.sh` enforces that at authoring time.
 
 ## Questions
 

--- a/bin/fm-afk-start.sh
+++ b/bin/fm-afk-start.sh
@@ -128,7 +128,8 @@ fm_afk_start_main() {
     echo "afk: FAILED - cannot move out of the disposable task worktree ($FM_DISPOSABLE_CWD) into the home ($FM_DISPOSABLE_HOME)" >&2
     return 1
   fi
-  # The relocation re-anchors STATE, so re-derive the paths taken from it.
+  # The relocation may re-anchor a relative STATE, so re-derive the paths taken
+  # from it. An already-absolute STATE is left byte-identical.
   FM_AFK_STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
   FM_AFK_LOCK="$FM_AFK_STATE/.supervise-daemon.lock"
 

--- a/bin/fm-afk-start.sh
+++ b/bin/fm-afk-start.sh
@@ -119,15 +119,18 @@ fm_afk_start_main() {
 
   # The daemon is long-lived and carries supervision while nobody is watching, so
   # it has the same disposable-cwd hazard as the watcher (bin/fm-wake-lib.sh's
-  # fm_cwd_is_disposable_slot). Refuse before touching state, so away mode is
-  # never entered without a daemon that can survive to own it.
-  if fm_cwd_is_disposable_slot; then
-    fm_disposable_cwd_banner \
-      'REFUSING TO START AWAY MODE - CWD IS A DISPOSABLE TASK WORKTREE' \
-      'bin/fm-afk-start.sh'
-    echo "afk: FAILED - refusing to start from a disposable task worktree ($FM_DISPOSABLE_CWD)" >&2
+  # fm_relocate_from_disposable_cwd). Relocate before the exec, so the daemon
+  # inherits the safe working directory. Relocating rather than refusing also
+  # means the launcher paths that already wrote state/.afk can never leave away
+  # mode live with no daemon to own it.
+  if ! fm_relocate_from_disposable_cwd \
+    'RELOCATED AWAY MODE OUT OF A DISPOSABLE TASK WORKTREE'; then
+    echo "afk: FAILED - cannot move out of the disposable task worktree ($FM_DISPOSABLE_CWD) into the home ($FM_DISPOSABLE_HOME)" >&2
     return 1
   fi
+  # The relocation re-anchors STATE, so re-derive the paths taken from it.
+  FM_AFK_STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+  FM_AFK_LOCK="$FM_AFK_STATE/.supervise-daemon.lock"
 
   mkdir -p "$FM_AFK_STATE"
   if [ "${FM_AFK_STATE_PREPARED:-0}" = 1 ]; then

--- a/bin/fm-afk-start.sh
+++ b/bin/fm-afk-start.sh
@@ -117,6 +117,18 @@ fm_afk_start_main() {
     * ) echo "usage: $(basename "${BASH_SOURCE[1]:-fm-afk-start.sh}")" >&2; return 2 ;;
   esac
 
+  # The daemon is long-lived and carries supervision while nobody is watching, so
+  # it has the same disposable-cwd hazard as the watcher (bin/fm-wake-lib.sh's
+  # fm_cwd_is_disposable_slot). Refuse before touching state, so away mode is
+  # never entered without a daemon that can survive to own it.
+  if fm_cwd_is_disposable_slot; then
+    fm_disposable_cwd_banner \
+      'REFUSING TO START AWAY MODE - CWD IS A DISPOSABLE TASK WORKTREE' \
+      'bin/fm-afk-start.sh'
+    echo "afk: FAILED - refusing to start from a disposable task worktree ($FM_DISPOSABLE_CWD)" >&2
+    return 1
+  fi
+
   mkdir -p "$FM_AFK_STATE"
   if [ "${FM_AFK_STATE_PREPARED:-0}" = 1 ]; then
     [ -f "$FM_AFK_STATE/.afk" ] || { echo "afk: launcher-prepared state is missing" >&2; return 1; }

--- a/bin/fm-afk-start.sh
+++ b/bin/fm-afk-start.sh
@@ -125,7 +125,7 @@ fm_afk_start_main() {
   # mode live with no daemon to own it.
   if ! fm_relocate_from_disposable_cwd \
     'RELOCATED AWAY MODE OUT OF A DISPOSABLE TASK WORKTREE'; then
-    echo "afk: FAILED - cannot move out of the disposable task worktree ($FM_DISPOSABLE_CWD) into the home ($FM_DISPOSABLE_HOME)" >&2
+    echo "afk: FAILED - $FM_DISPOSABLE_ERROR" >&2
     return 1
   fi
   # The relocation may re-anchor a relative STATE, so re-derive the paths taken

--- a/bin/fm-afk-start.sh
+++ b/bin/fm-afk-start.sh
@@ -35,8 +35,14 @@ set -eu
 FM_AFK_START_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$FM_AFK_START_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
-FM_AFK_STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
-FM_AFK_LOCK="$FM_AFK_STATE/.supervise-daemon.lock"
+# The single owner of every away-mode path derived from FM_HOME or STATE. It runs
+# here and again after the relocation re-anchors those bases, so a path added to it
+# is re-anchored by construction rather than by a hand-maintained second copy.
+fm_afk_derive_state_paths() {
+  FM_AFK_STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+  FM_AFK_LOCK="$FM_AFK_STATE/.supervise-daemon.lock"
+}
+fm_afk_derive_state_paths
 FM_AFK_DAEMON="$FM_AFK_START_DIR/fm-supervise-daemon.sh"
 
 # shellcheck source=bin/fm-wake-lib.sh
@@ -130,8 +136,7 @@ fm_afk_start_main() {
   fi
   # The relocation may re-anchor a relative STATE, so re-derive the paths taken
   # from it. An already-absolute STATE is left byte-identical.
-  FM_AFK_STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
-  FM_AFK_LOCK="$FM_AFK_STATE/.supervise-daemon.lock"
+  fm_afk_derive_state_paths
 
   mkdir -p "$FM_AFK_STATE"
   if [ "${FM_AFK_STATE_PREPARED:-0}" = 1 ]; then

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -3,11 +3,24 @@
 
 FM_WAKE_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FM_WAKE_DEFAULT_ROOT="$(cd "$FM_WAKE_LIB_DIR/.." && pwd)"
-FM_ROOT="${FM_ROOT_OVERRIDE:-${FM_ROOT:-$FM_WAKE_DEFAULT_ROOT}}"
-FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
-STATE="${FM_STATE_OVERRIDE:-${STATE:-$FM_HOME/state}}"
-FM_WAKE_QUEUE="${FM_WAKE_QUEUE:-$STATE/.wake-queue}"
-FM_WAKE_QUEUE_LOCK="${FM_WAKE_QUEUE_LOCK:-$STATE/.wake-queue.lock}"
+# Whether the environment supplied these explicitly, captured once at source time
+# so a re-derivation never silently overwrites a caller's own value.
+FM_WAKE_QUEUE_PINNED="${FM_WAKE_QUEUE:+1}"
+FM_WAKE_QUEUE_LOCK_PINNED="${FM_WAKE_QUEUE_LOCK:+1}"
+
+# The single owner of every path this lib derives from FM_ROOT, FM_HOME or STATE.
+# It runs at source time and again after a relocation re-anchors the base paths,
+# so a derived path added here is re-anchored by construction and cannot drift out
+# of sync with the base it came from. Each assignment keeps an already-set value,
+# so re-running it recomputes only what the relocation invalidated.
+fm_derive_paths() {
+  FM_ROOT="${FM_ROOT_OVERRIDE:-${FM_ROOT:-$FM_WAKE_DEFAULT_ROOT}}"
+  FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+  STATE="${FM_STATE_OVERRIDE:-${STATE:-$FM_HOME/state}}"
+  [ -n "$FM_WAKE_QUEUE_PINNED" ] || FM_WAKE_QUEUE="$STATE/.wake-queue"
+  [ -n "$FM_WAKE_QUEUE_LOCK_PINNED" ] || FM_WAKE_QUEUE_LOCK="$STATE/.wake-queue.lock"
+}
+fm_derive_paths
 FM_LOCK_STALE_AFTER="${FM_LOCK_STALE_AFTER:-2}"
 mkdir -p "$STATE"
 
@@ -61,9 +74,12 @@ fm_path_age() {
 #
 # A durably leased secondmate home is itself a pool slot (bin/fm-home-seed.sh) but
 # is stable for that home's lifetime, so a cwd inside FM_HOME is always safe. Only
-# a pool slot that is NOT this home is refused. TREEHOUSE_DIR is treehouse's own
-# pool-root variable and defaults to ~/.treehouse; a pool root that does not
-# resolve leaves the guard inert.
+# a pool slot that is NOT this home is refused. The pool root resolves from
+# FM_TREEHOUSE_POOL_ROOT first, then TREEHOUSE_DIR, then ~/.treehouse; a pool root
+# that does not resolve leaves the guard inert. FM_TREEHOUSE_POOL_ROOT is
+# firstmate-private and exists so the test harness can point this guard at an
+# absent pool without redirecting the real treehouse CLI, which reads
+# TREEHOUSE_DIR as its own pool root and would act on a bogus value.
 #
 # The condition is self-correcting rather than operator-correctable. A launcher
 # calls fm_relocate_from_disposable_cwd, which moves the launcher process itself
@@ -100,7 +116,10 @@ fm_path_age() {
 # re-anchored environment is harder to reason about than a fully re-anchored one,
 # and FM_ROOT in particular is inherited by every child process the launcher
 # starts, so a stale relative value would resolve against the wrong directory
-# well after the relocation.
+# well after the relocation. Everything derived FROM those bases is then
+# recomputed through fm_derive_paths, the single owner of that derivation, rather
+# than re-anchored variable by variable, so a path added there is covered
+# automatically.
 fm_path_under() {
   local child=$1 parent=$2
   [ -n "$parent" ] || return 1
@@ -131,7 +150,7 @@ fm_cwd_is_disposable_slot() {
   FM_DISPOSABLE_CWD=
   FM_DISPOSABLE_HOME=
   cwd=$(pwd -P 2>/dev/null) || return 1
-  pool=$(fm_resolve_dir "${TREEHOUSE_DIR:-${HOME:-}/.treehouse}") || return 1
+  pool=$(fm_resolve_dir "${FM_TREEHOUSE_POOL_ROOT:-${TREEHOUSE_DIR:-${HOME:-}/.treehouse}}") || return 1
   fm_path_under "$cwd" "$pool" || return 1
   home=$(fm_resolve_dir "$FM_HOME") || home=$FM_HOME
   fm_path_under "$cwd" "$home" && return 1
@@ -193,6 +212,10 @@ fm_relocate_from_disposable_cwd() {
     FM_ROOT=$root_abs
     [ -z "${FM_ROOT_OVERRIDE:-}" ] || FM_ROOT_OVERRIDE=$root_abs
   fi
+  # Recompute every derived path from the re-anchored bases through their single
+  # owner, so nothing derived from STATE or FM_HOME survives the chdir as a stale
+  # relative value.
+  fm_derive_paths
   rule='━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'
   {
     printf '●%s\n' "$rule"

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -73,6 +73,25 @@ fm_path_age() {
 # do. It stays a warning rather than a silent repair so the condition remains
 # visible. A failed chdir into FM_HOME means a genuinely broken home, and the
 # helper returns non-zero so the caller can fail with its own typed line.
+#
+# bin/fm-watch.sh calls it itself, which is the choke point every watcher
+# launcher passes through, so no present or future launcher can miss the guard.
+# A launcher that also BLOCKS for the watcher's lifetime - bin/fm-watch-arm.sh
+# while it waits on its child, bin/fm-watch-checkpoint.sh for the whole bounded
+# checkpoint, bin/fm-afk-start.sh before the daemon exec - calls it on its own
+# account too, since a launcher killed by the sweep ends the work even when the
+# watcher it started was safe. The call is idempotent, so the second one detects
+# nothing and prints nothing.
+#
+# The relocation deliberately does NOT resolve an already-absolute FM_HOME or
+# STATE. FM_HOME doubles as a byte-exact cross-process identity string: the
+# watcher writes it into state/.watch.lock/fm-home and fm_watcher_lock_matches_pid,
+# bin/fm-turnend-guard.sh, bin/fm-continuity-pretool-check.sh,
+# bin/fm-pr-check-migrate.sh and bin/fm-watch-arm.sh all compare it verbatim
+# against their own logically derived value. Rewriting it to the resolved path
+# would desynchronize the lock from every one of them whenever a component of
+# the home path is a symlink. Only a genuinely relative value, which a chdir
+# really does invalidate, is re-anchored.
 fm_path_under() {
   local child=$1 parent=$2
   [ -n "$parent" ] || return 1
@@ -113,13 +132,24 @@ fm_cwd_is_disposable_slot() {
 fm_relocate_from_disposable_cwd() {
   local headline=$1 rule state_abs
   fm_cwd_is_disposable_slot || return 0
-  # Re-anchor the home and state paths first: a chdir invalidates any of them that
-  # was relative to the condemned cwd, and the resolved home is already absolute.
+  # Re-anchor only the paths a chdir would actually invalidate, which is the
+  # genuinely relative ones. FM_HOME doubles as a byte-exact cross-process
+  # identity string, written into the watcher lock and compared verbatim by the
+  # guard, the checkpoint and the continuity check, so an already-absolute value
+  # must survive relocation unchanged even when a path component is a symlink.
   state_abs=$(fm_resolve_dir "$STATE") || return 1
-  CDPATH='' cd -- "$FM_DISPOSABLE_HOME" 2>/dev/null || return 1
-  FM_HOME=$FM_DISPOSABLE_HOME
-  STATE=$state_abs
-  [ -z "${FM_STATE_OVERRIDE:-}" ] || FM_STATE_OVERRIDE=$state_abs
+  CDPATH='' cd -- "$FM_HOME" 2>/dev/null || return 1
+  case "$FM_HOME" in
+    /*) ;;
+    *) FM_HOME=$FM_DISPOSABLE_HOME ;;
+  esac
+  case "$STATE" in
+    /*) ;;
+    *)
+      STATE=$state_abs
+      [ -z "${FM_STATE_OVERRIDE:-}" ] || FM_STATE_OVERRIDE=$state_abs
+      ;;
+  esac
   rule='━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'
   {
     printf '●%s\n' "$rule"

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -50,6 +50,73 @@ fm_path_age() {
   echo $(( $(date +%s) - m ))
 }
 
+# Disposable-cwd guard for long-lived firstmate processes.
+#
+# treehouse's lingering-process sweep, which fires on every `treehouse return` and
+# on the exit of an interactive `treehouse get` shell, kills every process whose
+# working directory resolves under the worktree being returned. It matches on
+# filesystem path, not on process ancestry, so anything long-lived started from a
+# per-task pool slot dies when ANY session returns that slot, whoever started it.
+# The observed signal is SIGURG, surfacing as exit 144.
+#
+# A durably leased secondmate home is itself a pool slot (bin/fm-home-seed.sh) but
+# is stable for that home's lifetime, so a cwd inside FM_HOME is always safe. Only
+# a pool slot that is NOT this home is refused. TREEHOUSE_DIR is treehouse's own
+# pool-root variable and defaults to ~/.treehouse; a pool root that does not
+# resolve leaves the guard inert.
+#
+# Callers detect with fm_cwd_is_disposable_slot, render the shared banner with
+# fm_disposable_cwd_banner, then emit their own typed failure line and exit.
+fm_path_under() {
+  local child=$1 parent=$2
+  [ -n "$parent" ] || return 1
+  [ "$child" = "$parent" ] && return 0
+  case "$child" in
+    "$parent"/*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+fm_resolve_dir() {
+  local path=$1
+  [ -n "$path" ] || return 1
+  CDPATH='' cd -- "$path" 2>/dev/null && pwd -P
+}
+
+# Sets FM_DISPOSABLE_CWD and FM_DISPOSABLE_HOME on a refusal.
+FM_DISPOSABLE_CWD=
+FM_DISPOSABLE_HOME=
+fm_cwd_is_disposable_slot() {
+  local cwd pool home
+  FM_DISPOSABLE_CWD=
+  FM_DISPOSABLE_HOME=
+  cwd=$(pwd -P 2>/dev/null) || return 1
+  pool=$(fm_resolve_dir "${TREEHOUSE_DIR:-${HOME:-}/.treehouse}") || return 1
+  fm_path_under "$cwd" "$pool" || return 1
+  home=$(fm_resolve_dir "$FM_HOME") || home=$FM_HOME
+  fm_path_under "$cwd" "$home" && return 1
+  FM_DISPOSABLE_CWD=$cwd
+  FM_DISPOSABLE_HOME=$home
+  return 0
+}
+
+fm_disposable_cwd_banner() {
+  local headline=$1 restart_command=$2 rule
+  rule='━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'
+  {
+    printf '●%s\n' "$rule"
+    printf '●  %s\n' "$headline"
+    printf '●  cwd:     %s\n' "$FM_DISPOSABLE_CWD"
+    printf '●  home:    %s\n' "$FM_DISPOSABLE_HOME"
+    printf '●  A long-lived process started from a treehouse pool slot is killed by\n'
+    printf '●  signal 16 (exit 144) the moment any session returns that slot, because\n'
+    printf '●  the sweep matches on working directory, not on who started the process.\n'
+    printf '●  Start it from this home instead:\n'
+    printf '●      cd %s && %s\n' "$FM_DISPOSABLE_HOME" "$restart_command"
+    printf '●%s\n' "$rule"
+  } >&2
+}
+
 fm_watcher_lock_matches_pid() {
   local state=$1 watch_path=$2 pid=$3 home=${4:-$FM_HOME} lockdir lock_home lock_path lock_identity current_identity
   lockdir="$state/.watch.lock"

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -5,8 +5,19 @@ FM_WAKE_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FM_WAKE_DEFAULT_ROOT="$(cd "$FM_WAKE_LIB_DIR/.." && pwd)"
 # Whether the environment supplied these explicitly, captured once at source time
 # so a re-derivation never silently overwrites a caller's own value.
-FM_WAKE_QUEUE_PINNED="${FM_WAKE_QUEUE:+1}"
-FM_WAKE_QUEUE_LOCK_PINNED="${FM_WAKE_QUEUE_LOCK:+1}"
+#
+# The capture is recorded once per process and never revisited, because it is only
+# meaningful before this lib has derived anything. Sourcing the lib a second time
+# in one process would otherwise see the value the FIRST source derived, record it
+# as caller-supplied, and leave the wake queue pointing at the pre-relocation state
+# directory, so the enqueue and drain paths would silently use different queues.
+# The sentinel is deliberately not exported, so a child process makes its own
+# capture from whatever it genuinely inherited.
+if [ -z "${FM_WAKE_LIB_PINS_CAPTURED:-}" ]; then
+  FM_WAKE_QUEUE_PINNED="${FM_WAKE_QUEUE:+1}"
+  FM_WAKE_QUEUE_LOCK_PINNED="${FM_WAKE_QUEUE_LOCK:+1}"
+  FM_WAKE_LIB_PINS_CAPTURED=1
+fi
 
 # The single owner of every path this lib derives from FM_ROOT, FM_HOME or STATE.
 # It runs at source time and again after a relocation re-anchors the base paths,

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -72,7 +72,9 @@ fm_path_age() {
 # and carries no remedy command, because there is nothing left for the operator to
 # do. It stays a warning rather than a silent repair so the condition remains
 # visible. A failed chdir into FM_HOME means a genuinely broken home, and the
-# helper returns non-zero so the caller can fail with its own typed line.
+# helper returns non-zero after setting FM_DISPOSABLE_ERROR to the fault that
+# actually happened, so the caller fails with its own typed prefix and never
+# reports one fault under another one's wording.
 #
 # bin/fm-watch.sh calls it itself, which is the choke point every watcher
 # launcher passes through, so no present or future launcher can miss the guard.
@@ -112,6 +114,11 @@ fm_resolve_dir() {
 # Sets FM_DISPOSABLE_CWD and FM_DISPOSABLE_HOME when the cwd is condemned.
 FM_DISPOSABLE_CWD=
 FM_DISPOSABLE_HOME=
+# Set by fm_relocate_from_disposable_cwd on failure, so each caller reports the
+# fault that actually happened under its own typed prefix. A failed chdir into
+# the home and a STATE that will not resolve are different faults and must never
+# share one error string.
+FM_DISPOSABLE_ERROR=
 fm_cwd_is_disposable_slot() {
   local cwd pool home
   FM_DISPOSABLE_CWD=
@@ -129,27 +136,42 @@ fm_cwd_is_disposable_slot() {
 # Relocates the calling process out of a condemned cwd, if it is in one.
 # Returns 0 when there was nothing to do or the relocation succeeded, and 1 when
 # the cwd is condemned but chdir into FM_HOME failed.
+# shellcheck disable=SC2034  # FM_DISPOSABLE_ERROR is read by the sourcing launchers
 fm_relocate_from_disposable_cwd() {
   local headline=$1 rule state_abs
+  FM_DISPOSABLE_ERROR=
   fm_cwd_is_disposable_slot || return 0
   # Re-anchor only the paths a chdir would actually invalidate, which is the
   # genuinely relative ones. FM_HOME doubles as a byte-exact cross-process
   # identity string, written into the watcher lock and compared verbatim by the
   # guard, the checkpoint and the continuity check, so an already-absolute value
   # must survive relocation unchanged even when a path component is a symlink.
-  state_abs=$(fm_resolve_dir "$STATE") || return 1
-  CDPATH='' cd -- "$FM_HOME" 2>/dev/null || return 1
+  # An already-absolute STATE is never resolved either, so a resolution fault
+  # cannot abort a launcher that never needed the resolved value. A relative one
+  # must be resolved BEFORE the chdir, while it still resolves against the cwd
+  # it was written for.
+  state_abs=
+  case "$STATE" in
+    /*) ;;
+    *)
+      if ! state_abs=$(fm_resolve_dir "$STATE"); then
+        FM_DISPOSABLE_ERROR="the state directory ($STATE) is relative and no longer resolves, so it cannot be re-anchored before leaving the disposable task worktree ($FM_DISPOSABLE_CWD)"
+        return 1
+      fi
+      ;;
+  esac
+  if ! CDPATH='' cd -- "$FM_HOME" 2>/dev/null; then
+    FM_DISPOSABLE_ERROR="cannot move out of the disposable task worktree ($FM_DISPOSABLE_CWD) into the home ($FM_DISPOSABLE_HOME)"
+    return 1
+  fi
   case "$FM_HOME" in
     /*) ;;
     *) FM_HOME=$FM_DISPOSABLE_HOME ;;
   esac
-  case "$STATE" in
-    /*) ;;
-    *)
-      STATE=$state_abs
-      [ -z "${FM_STATE_OVERRIDE:-}" ] || FM_STATE_OVERRIDE=$state_abs
-      ;;
-  esac
+  if [ -n "$state_abs" ]; then
+    STATE=$state_abs
+    [ -z "${FM_STATE_OVERRIDE:-}" ] || FM_STATE_OVERRIDE=$state_abs
+  fi
   rule='━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'
   {
     printf '●%s\n' "$rule"

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -76,8 +76,10 @@ fm_path_age() {
 # actually happened, so the caller fails with its own typed prefix and never
 # reports one fault under another one's wording.
 #
-# bin/fm-watch.sh calls it itself, which is the choke point every watcher
-# launcher passes through, so no present or future launcher can miss the guard.
+# bin/fm-watch.sh calls it itself, below its source guard, which is the choke
+# point every launcher that EXECUTES the watcher passes through, so no present or
+# future launcher can miss the guard. Sourcing the watcher for unit tests does not
+# relocate the sourcing shell.
 # A launcher that also BLOCKS for the watcher's lifetime - bin/fm-watch-arm.sh
 # while it waits on its child, bin/fm-watch-checkpoint.sh for the whole bounded
 # checkpoint, bin/fm-afk-start.sh before the daemon exec - calls it on its own

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -85,15 +85,20 @@ fm_path_age() {
 # watcher it started was safe. The call is idempotent, so the second one detects
 # nothing and prints nothing.
 #
-# The relocation deliberately does NOT resolve an already-absolute FM_HOME or
-# STATE. FM_HOME doubles as a byte-exact cross-process identity string: the
+# The relocation deliberately does NOT resolve an already-absolute FM_HOME,
+# STATE or FM_ROOT. FM_HOME doubles as a byte-exact cross-process identity string: the
 # watcher writes it into state/.watch.lock/fm-home and fm_watcher_lock_matches_pid,
 # bin/fm-turnend-guard.sh, bin/fm-continuity-pretool-check.sh,
 # bin/fm-pr-check-migrate.sh and bin/fm-watch-arm.sh all compare it verbatim
 # against their own logically derived value. Rewriting it to the resolved path
 # would desynchronize the lock from every one of them whenever a component of
 # the home path is a symlink. Only a genuinely relative value, which a chdir
-# really does invalidate, is re-anchored.
+# really does invalidate, is re-anchored, and every relative one is: FM_HOME,
+# STATE with FM_STATE_OVERRIDE, and FM_ROOT with FM_ROOT_OVERRIDE. A partially
+# re-anchored environment is harder to reason about than a fully re-anchored one,
+# and FM_ROOT in particular is inherited by every child process the launcher
+# starts, so a stale relative value would resolve against the wrong directory
+# well after the relocation.
 fm_path_under() {
   local child=$1 parent=$2
   [ -n "$parent" ] || return 1
@@ -138,7 +143,7 @@ fm_cwd_is_disposable_slot() {
 # the cwd is condemned but chdir into FM_HOME failed.
 # shellcheck disable=SC2034  # FM_DISPOSABLE_ERROR is read by the sourcing launchers
 fm_relocate_from_disposable_cwd() {
-  local headline=$1 rule state_abs
+  local headline=$1 rule state_abs root_abs
   FM_DISPOSABLE_ERROR=
   fm_cwd_is_disposable_slot || return 0
   # Re-anchor only the paths a chdir would actually invalidate, which is the
@@ -160,6 +165,16 @@ fm_relocate_from_disposable_cwd() {
       fi
       ;;
   esac
+  root_abs=
+  case "$FM_ROOT" in
+    /*) ;;
+    *)
+      if ! root_abs=$(fm_resolve_dir "$FM_ROOT"); then
+        FM_DISPOSABLE_ERROR="the code root ($FM_ROOT) is relative and no longer resolves, so it cannot be re-anchored before leaving the disposable task worktree ($FM_DISPOSABLE_CWD)"
+        return 1
+      fi
+      ;;
+  esac
   if ! CDPATH='' cd -- "$FM_HOME" 2>/dev/null; then
     FM_DISPOSABLE_ERROR="cannot move out of the disposable task worktree ($FM_DISPOSABLE_CWD) into the home ($FM_DISPOSABLE_HOME)"
     return 1
@@ -171,6 +186,10 @@ fm_relocate_from_disposable_cwd() {
   if [ -n "$state_abs" ]; then
     STATE=$state_abs
     [ -z "${FM_STATE_OVERRIDE:-}" ] || FM_STATE_OVERRIDE=$state_abs
+  fi
+  if [ -n "$root_abs" ]; then
+    FM_ROOT=$root_abs
+    [ -z "${FM_ROOT_OVERRIDE:-}" ] || FM_ROOT_OVERRIDE=$root_abs
   fi
   rule='━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'
   {

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -65,8 +65,14 @@ fm_path_age() {
 # pool-root variable and defaults to ~/.treehouse; a pool root that does not
 # resolve leaves the guard inert.
 #
-# Callers detect with fm_cwd_is_disposable_slot, render the shared banner with
-# fm_disposable_cwd_banner, then emit their own typed failure line and exit.
+# The condition is self-correcting rather than operator-correctable. A launcher
+# calls fm_relocate_from_disposable_cwd, which moves the launcher process itself
+# into FM_HOME before it forks anything, so both the launcher and its long-lived
+# child sit outside the sweep path. The relocation is announced loudly on stderr
+# and carries no remedy command, because there is nothing left for the operator to
+# do. It stays a warning rather than a silent repair so the condition remains
+# visible. A failed chdir into FM_HOME means a genuinely broken home, and the
+# helper returns non-zero so the caller can fail with its own typed line.
 fm_path_under() {
   local child=$1 parent=$2
   [ -n "$parent" ] || return 1
@@ -77,13 +83,14 @@ fm_path_under() {
   esac
 }
 
+# Runs in a subshell so a direct call can never relocate the calling process.
 fm_resolve_dir() {
   local path=$1
   [ -n "$path" ] || return 1
-  CDPATH='' cd -- "$path" 2>/dev/null && pwd -P
+  ( CDPATH='' cd -- "$path" 2>/dev/null && pwd -P )
 }
 
-# Sets FM_DISPOSABLE_CWD and FM_DISPOSABLE_HOME on a refusal.
+# Sets FM_DISPOSABLE_CWD and FM_DISPOSABLE_HOME when the cwd is condemned.
 FM_DISPOSABLE_CWD=
 FM_DISPOSABLE_HOME=
 fm_cwd_is_disposable_slot() {
@@ -100,19 +107,30 @@ fm_cwd_is_disposable_slot() {
   return 0
 }
 
-fm_disposable_cwd_banner() {
-  local headline=$1 restart_command=$2 rule
+# Relocates the calling process out of a condemned cwd, if it is in one.
+# Returns 0 when there was nothing to do or the relocation succeeded, and 1 when
+# the cwd is condemned but chdir into FM_HOME failed.
+fm_relocate_from_disposable_cwd() {
+  local headline=$1 rule state_abs
+  fm_cwd_is_disposable_slot || return 0
+  # Re-anchor the home and state paths first: a chdir invalidates any of them that
+  # was relative to the condemned cwd, and the resolved home is already absolute.
+  state_abs=$(fm_resolve_dir "$STATE") || return 1
+  CDPATH='' cd -- "$FM_DISPOSABLE_HOME" 2>/dev/null || return 1
+  FM_HOME=$FM_DISPOSABLE_HOME
+  STATE=$state_abs
+  [ -z "${FM_STATE_OVERRIDE:-}" ] || FM_STATE_OVERRIDE=$state_abs
   rule='━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'
   {
     printf '●%s\n' "$rule"
     printf '●  %s\n' "$headline"
-    printf '●  cwd:     %s\n' "$FM_DISPOSABLE_CWD"
-    printf '●  home:    %s\n' "$FM_DISPOSABLE_HOME"
+    printf '●  was:     %s\n' "$FM_DISPOSABLE_CWD"
+    printf '●  now:     %s\n' "$FM_DISPOSABLE_HOME"
     printf '●  A long-lived process started from a treehouse pool slot is killed by\n'
     printf '●  signal 16 (exit 144) the moment any session returns that slot, because\n'
     printf '●  the sweep matches on working directory, not on who started the process.\n'
-    printf '●  Start it from this home instead:\n'
-    printf '●      cd %s && %s\n' "$FM_DISPOSABLE_HOME" "$restart_command"
+    printf '●  This process moved to the home before starting anything long-lived, so\n'
+    printf '●  neither it nor its children are in the sweep path. Nothing to do.\n'
     printf '●%s\n' "$rule"
   } >&2
 }

--- a/bin/fm-watch-arm.sh
+++ b/bin/fm-watch-arm.sh
@@ -75,7 +75,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # watcher child inherits the relocated cwd rather than a condemned one.
 if ! fm_relocate_from_disposable_cwd \
   'RELOCATED THE WATCHER OUT OF A DISPOSABLE TASK WORKTREE'; then
-  echo "watcher: FAILED - cannot move out of the disposable task worktree ($FM_DISPOSABLE_CWD) into the home ($FM_DISPOSABLE_HOME)"
+  echo "watcher: FAILED - $FM_DISPOSABLE_ERROR"
   exit 1
 fi
 

--- a/bin/fm-watch-arm.sh
+++ b/bin/fm-watch-arm.sh
@@ -12,6 +12,16 @@
 # child is reaped when the call returns, leaving NO watcher running and a false
 # "already running" off the dying process. That exact mistake silently took
 # supervision down for ~30 minutes.
+#
+# A SECOND, distinct reaping hazard is the working directory the arm runs from.
+# bin/fm-wake-lib.sh's fm_cwd_is_disposable_slot owns that contract; this script
+# REFUSES to arm when it fires, naming the offending cwd and the fix. The primary
+# shell's cwd persists across tool calls, so one `cd` into a task worktree
+# silently condemns everything armed afterwards.
+# The refusal deliberately does NOT relocate the cwd itself. The arm process is
+# not the only process that has to survive: the harness's own wrapper shell is the
+# arm's parent and keeps the condemned cwd, so an internal `cd` would produce a
+# watcher that still dies while looking safe.
 # On a harness with a PreToolUse-equivalent hook, bin/fm-arm-pretool-check.sh
 # applies the command-position policy before the command runs; see
 # docs/arm-pretool-check.md for the blessed tree and deny reason codes. It is a
@@ -58,6 +68,16 @@ set -u
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=bin/fm-wake-lib.sh
 . "$SCRIPT_DIR/fm-wake-lib.sh"
+
+# The cwd guard runs before any watcher work: a watcher armed from a disposable
+# pool slot is condemned, so refuse rather than start one that will be reaped.
+if fm_cwd_is_disposable_slot; then
+  fm_disposable_cwd_banner \
+    'REFUSING TO ARM THE WATCHER - CWD IS A DISPOSABLE TASK WORKTREE' \
+    'bin/fm-watch-arm.sh'
+  echo "watcher: FAILED - refusing to arm from a disposable task worktree ($FM_DISPOSABLE_CWD)"
+  exit 1
+fi
 
 WATCH="$SCRIPT_DIR/fm-watch.sh"
 WATCH_LOCK="$STATE/.watch.lock"

--- a/bin/fm-watch-arm.sh
+++ b/bin/fm-watch-arm.sh
@@ -71,14 +71,6 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=bin/fm-wake-lib.sh
 . "$SCRIPT_DIR/fm-wake-lib.sh"
 
-# The cwd guard runs before any watcher work, and well before the fork, so the
-# watcher child inherits the relocated cwd rather than a condemned one.
-if ! fm_relocate_from_disposable_cwd \
-  'RELOCATED THE WATCHER OUT OF A DISPOSABLE TASK WORKTREE'; then
-  echo "watcher: FAILED - $FM_DISPOSABLE_ERROR"
-  exit 1
-fi
-
 WATCH="$SCRIPT_DIR/fm-watch.sh"
 WATCH_LOCK="$STATE/.watch.lock"
 BEAT="$STATE/.last-watcher-beat"
@@ -341,6 +333,21 @@ case "${1:-}" in
   --restart) mode=restart ;;
   *) echo "usage: $(basename "$0") [--restart]" >&2; exit 2 ;;
 esac
+
+# The cwd guard runs after argument handling, so usage errors stay side-effect
+# free, and before any watcher work or the fork, so the watcher child inherits
+# the relocated cwd rather than a condemned one. The STATE-derived paths are
+# re-derived afterwards because a relative STATE is re-anchored by the
+# relocation.
+if ! fm_relocate_from_disposable_cwd \
+  'RELOCATED THE WATCHER OUT OF A DISPOSABLE TASK WORKTREE'; then
+  echo "watcher: FAILED - $FM_DISPOSABLE_ERROR"
+  exit 1
+fi
+WATCH_LOCK="$STATE/.watch.lock"
+BEAT="$STATE/.last-watcher-beat"
+CYCLE_LOG="$STATE/.watch-cycle-exits.log"
+CYCLE_LOG_LOCK="$STATE/.watch-cycle-exits.lock"
 
 if [ "$mode" = restart ]; then
   # Home-scoped stop: only the watcher pid recorded in THIS home's lock.

--- a/bin/fm-watch-arm.sh
+++ b/bin/fm-watch-arm.sh
@@ -72,16 +72,22 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "$SCRIPT_DIR/fm-wake-lib.sh"
 
 WATCH="$SCRIPT_DIR/fm-watch.sh"
-WATCH_LOCK="$STATE/.watch.lock"
-BEAT="$STATE/.last-watcher-beat"
+# The single owner of every arm path derived from STATE. It runs here and again
+# after the relocation re-anchors STATE, so a path added to it is re-anchored by
+# construction rather than by a hand-maintained second copy that can drift.
+arm_derive_state_paths() {
+  WATCH_LOCK="$STATE/.watch.lock"
+  BEAT="$STATE/.last-watcher-beat"
+  CYCLE_LOG="$STATE/.watch-cycle-exits.log"
+  CYCLE_LOG_LOCK="$STATE/.watch-cycle-exits.lock"
+}
+arm_derive_state_paths
 # "Fresh" reuses the guard's threshold so there is one definition of liveness.
 GRACE=${FM_GUARD_GRACE:-300}
 # How long to wait for a freshly forked watcher to acquire the lock and beat.
 CONFIRM_TIMEOUT=${FM_ARM_CONFIRM_TIMEOUT:-10}
 # Poll interval while attached to an existing healthy watcher.
 ATTACH_POLL=${FM_ARM_ATTACH_POLL:-0.5}
-CYCLE_LOG="$STATE/.watch-cycle-exits.log"
-CYCLE_LOG_LOCK="$STATE/.watch-cycle-exits.lock"
 CYCLE_LOG_MAX_BYTES=${FM_WATCH_CYCLE_LOG_MAX_BYTES:-262144}
 CYCLE_LOG_KEEP_LINES=${FM_WATCH_CYCLE_LOG_KEEP_LINES:-1000}
 ARM_PID=${BASHPID:-$$}
@@ -344,10 +350,7 @@ if ! fm_relocate_from_disposable_cwd \
   echo "watcher: FAILED - $FM_DISPOSABLE_ERROR"
   exit 1
 fi
-WATCH_LOCK="$STATE/.watch.lock"
-BEAT="$STATE/.last-watcher-beat"
-CYCLE_LOG="$STATE/.watch-cycle-exits.log"
-CYCLE_LOG_LOCK="$STATE/.watch-cycle-exits.lock"
+arm_derive_state_paths
 
 if [ "$mode" = restart ]; then
   # Home-scoped stop: only the watcher pid recorded in THIS home's lock.

--- a/bin/fm-watch-arm.sh
+++ b/bin/fm-watch-arm.sh
@@ -15,13 +15,15 @@
 #
 # A SECOND, distinct reaping hazard is the working directory the arm runs from.
 # bin/fm-wake-lib.sh's fm_cwd_is_disposable_slot owns that contract; this script
-# REFUSES to arm when it fires, naming the offending cwd and the fix. The primary
+# RELOCATES to FM_HOME when it fires, loudly, then arms normally. The primary
 # shell's cwd persists across tool calls, so one `cd` into a task worktree
 # silently condemns everything armed afterwards.
-# The refusal deliberately does NOT relocate the cwd itself. The arm process is
-# not the only process that has to survive: the harness's own wrapper shell is the
-# arm's parent and keeps the condemned cwd, so an internal `cd` would produce a
-# watcher that still dies while looking safe.
+# Relocating BEFORE the fork is what makes this correct: the watcher child
+# inherits the safe cwd, so neither the arm nor the watcher is in the sweep path.
+# The harness's own wrapper shell keeps the condemned cwd, but that does not
+# reintroduce the hazard - a wrapper shell killed by the sweep merely orphans the
+# already-running watcher, which keeps running under init.
+# It stays a warning rather than a silent repair so the condition remains visible.
 # On a harness with a PreToolUse-equivalent hook, bin/fm-arm-pretool-check.sh
 # applies the command-position policy before the command runs; see
 # docs/arm-pretool-check.md for the blessed tree and deny reason codes. It is a
@@ -69,13 +71,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=bin/fm-wake-lib.sh
 . "$SCRIPT_DIR/fm-wake-lib.sh"
 
-# The cwd guard runs before any watcher work: a watcher armed from a disposable
-# pool slot is condemned, so refuse rather than start one that will be reaped.
-if fm_cwd_is_disposable_slot; then
-  fm_disposable_cwd_banner \
-    'REFUSING TO ARM THE WATCHER - CWD IS A DISPOSABLE TASK WORKTREE' \
-    'bin/fm-watch-arm.sh'
-  echo "watcher: FAILED - refusing to arm from a disposable task worktree ($FM_DISPOSABLE_CWD)"
+# The cwd guard runs before any watcher work, and well before the fork, so the
+# watcher child inherits the relocated cwd rather than a condemned one.
+if ! fm_relocate_from_disposable_cwd \
+  'RELOCATED THE WATCHER OUT OF A DISPOSABLE TASK WORKTREE'; then
+  echo "watcher: FAILED - cannot move out of the disposable task worktree ($FM_DISPOSABLE_CWD) into the home ($FM_DISPOSABLE_HOME)"
   exit 1
 fi
 

--- a/bin/fm-watch-checkpoint.sh
+++ b/bin/fm-watch-checkpoint.sh
@@ -6,9 +6,6 @@ set -u
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SECONDS_ARG=${FM_CODEX_WATCH_CHECKPOINT:-180}
 
-# shellcheck source=bin/fm-wake-lib.sh
-. "$SCRIPT_DIR/fm-wake-lib.sh"
-
 usage() {
   cat <<'EOF'
 Usage: fm-watch-checkpoint.sh [--seconds <n>]
@@ -47,6 +44,11 @@ case "$SECONDS_ARG" in
   0) echo "error: --seconds must be greater than zero" >&2; exit 2 ;;
 esac
 
+# Sourced after argument handling on purpose: the lib creates $STATE at source
+# time, and --help plus the argument errors must stay side-effect free.
+# shellcheck source=bin/fm-wake-lib.sh
+. "$SCRIPT_DIR/fm-wake-lib.sh"
+
 OUT=$(mktemp "${TMPDIR:-/tmp}/fm-watch-checkpoint.out.XXXXXX") || exit 1
 ERR=$(mktemp "${TMPDIR:-/tmp}/fm-watch-checkpoint.err.XXXXXX") || {
   rm -f "$OUT"
@@ -82,7 +84,7 @@ run_with_perl_timeout() {
 # watcher it started was safe.
 if ! fm_relocate_from_disposable_cwd \
   'RELOCATED THE WATCHER CHECKPOINT OUT OF A DISPOSABLE TASK WORKTREE'; then
-  echo "checkpoint: FAILED - cannot move out of the disposable task worktree ($FM_DISPOSABLE_CWD) into the home ($FM_DISPOSABLE_HOME)" >&2
+  echo "checkpoint: FAILED - $FM_DISPOSABLE_ERROR" >&2
   exit 1
 fi
 

--- a/bin/fm-watch-checkpoint.sh
+++ b/bin/fm-watch-checkpoint.sh
@@ -6,6 +6,9 @@ set -u
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SECONDS_ARG=${FM_CODEX_WATCH_CHECKPOINT:-180}
 
+# shellcheck source=bin/fm-wake-lib.sh
+. "$SCRIPT_DIR/fm-wake-lib.sh"
+
 usage() {
   cat <<'EOF'
 Usage: fm-watch-checkpoint.sh [--seconds <n>]
@@ -72,6 +75,16 @@ run_with_perl_timeout() {
     exit($? >> 8);
   ' "$SECONDS_ARG" "$SCRIPT_DIR/fm-watch.sh"
 }
+
+# bin/fm-watch.sh relocates itself too, but this wrapper blocks in the foreground
+# for the whole bounded checkpoint, so it must leave the sweep path on its own
+# account: a wrapper killed by the sweep ends the checkpoint even though the
+# watcher it started was safe.
+if ! fm_relocate_from_disposable_cwd \
+  'RELOCATED THE WATCHER CHECKPOINT OUT OF A DISPOSABLE TASK WORKTREE'; then
+  echo "checkpoint: FAILED - cannot move out of the disposable task worktree ($FM_DISPOSABLE_CWD) into the home ($FM_DISPOSABLE_HOME)" >&2
+  exit 1
+fi
 
 set +e
 if command -v timeout >/dev/null 2>&1; then

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -77,7 +77,14 @@ mkdir -p "$STATE"
 # shellcheck source=bin/fm-check-lib.sh
 . "$SCRIPT_DIR/fm-check-lib.sh"
 
-WATCH_LOCK="$STATE/.watch.lock"
+# The single owner of this file's STATE-derived paths, so the disposable-cwd
+# relocation below the source guard can recompute all of them in one call and a
+# path added here cannot be left pointing at the pre-relocation state directory.
+watch_derive_state_paths() {
+  WATCH_LOCK="$STATE/.watch.lock"
+  TRIAGE_LOG="$STATE/.watch-triage.log"
+}
+watch_derive_state_paths
 WATCH_PATH="$SCRIPT_DIR/fm-watch.sh"
 WATCHER_STALE_GRACE=${FM_WATCHER_STALE_GRACE:-${FM_GUARD_GRACE:-300}}
 # The disposable-cwd relocation, singleton-lock acquisition, EXIT trap, and the
@@ -143,7 +150,7 @@ STALE_ESCALATE_SECS=${FM_STALE_ESCALATE_SECS:-240}  # idle secs before a provabl
 # These cases re-surface once for a recheck every PAUSE_RESURFACE_SECS - far
 # longer than the wedge threshold, but finite so a forgotten hold cannot rot invisibly.
 PAUSE_RESURFACE_SECS=${FM_PAUSE_RESURFACE_SECS:-$FM_PAUSE_RESURFACE_SECS_DEFAULT}
-TRIAGE_LOG="$STATE/.watch-triage.log"
+# TRIAGE_LOG itself is derived by watch_derive_state_paths above.
 TRIAGE_LOG_MAX_BYTES=${FM_WATCH_TRIAGE_LOG_MAX_BYTES:-262144}
 # Consecutive event-path failures (fm_backend_wait_transition returning 2 -
 # connect/subscribe failure) before the push fast-path is disabled for the rest
@@ -700,14 +707,14 @@ fi
 # construction rather than per entry point. It sits below the source guard so a
 # unit test that only sources this file keeps its own cwd. It is idempotent: a
 # launcher that already relocated leaves the cwd undetected here and nothing is
-# printed twice. WATCH_LOCK is re-derived afterwards because a relative STATE is
-# re-anchored by the relocation.
+# printed twice. This file's own STATE-derived paths are re-derived afterwards
+# because a relative STATE is re-anchored by the relocation.
 if ! fm_relocate_from_disposable_cwd \
   'RELOCATED THE WATCHER OUT OF A DISPOSABLE TASK WORKTREE'; then
   echo "watcher: FAILED - $FM_DISPOSABLE_ERROR" >&2
   exit 1
 fi
-WATCH_LOCK="$STATE/.watch.lock"
+watch_derive_state_paths
 
 # Before acquiring the watcher lock or enumerating any runnable check, replace
 # or quarantine checks created by older versions. The migration compares bytes

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -49,6 +49,15 @@ mkdir -p "$STATE"
 
 # shellcheck source=bin/fm-wake-lib.sh
 . "$SCRIPT_DIR/fm-wake-lib.sh"
+# The one choke point every watcher launcher must pass through, so the
+# disposable-cwd relocation covers all present and future launchers by
+# construction rather than per entry point. It is idempotent: a launcher that
+# already relocated leaves the cwd undetected here and nothing is printed twice.
+if ! fm_relocate_from_disposable_cwd \
+  'RELOCATED THE WATCHER OUT OF A DISPOSABLE TASK WORKTREE'; then
+  echo "watcher: FAILED - cannot move out of the disposable task worktree ($FM_DISPOSABLE_CWD) into the home ($FM_DISPOSABLE_HOME)" >&2
+  exit 1
+fi
 # Shared wake classifier (captain-relevant verbs + signal/stale/heartbeat
 # predicates), the SAME library the away-mode daemon uses, so the triage policy
 # has one definition.

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -55,7 +55,7 @@ mkdir -p "$STATE"
 # already relocated leaves the cwd undetected here and nothing is printed twice.
 if ! fm_relocate_from_disposable_cwd \
   'RELOCATED THE WATCHER OUT OF A DISPOSABLE TASK WORKTREE'; then
-  echo "watcher: FAILED - cannot move out of the disposable task worktree ($FM_DISPOSABLE_CWD) into the home ($FM_DISPOSABLE_HOME)" >&2
+  echo "watcher: FAILED - $FM_DISPOSABLE_ERROR" >&2
   exit 1
 fi
 # Shared wake classifier (captain-relevant verbs + signal/stale/heartbeat

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -49,15 +49,6 @@ mkdir -p "$STATE"
 
 # shellcheck source=bin/fm-wake-lib.sh
 . "$SCRIPT_DIR/fm-wake-lib.sh"
-# The one choke point every watcher launcher must pass through, so the
-# disposable-cwd relocation covers all present and future launchers by
-# construction rather than per entry point. It is idempotent: a launcher that
-# already relocated leaves the cwd undetected here and nothing is printed twice.
-if ! fm_relocate_from_disposable_cwd \
-  'RELOCATED THE WATCHER OUT OF A DISPOSABLE TASK WORKTREE'; then
-  echo "watcher: FAILED - $FM_DISPOSABLE_ERROR" >&2
-  exit 1
-fi
 # Shared wake classifier (captain-relevant verbs + signal/stale/heartbeat
 # predicates), the SAME library the away-mode daemon uses, so the triage policy
 # has one definition.
@@ -89,12 +80,13 @@ fi
 WATCH_LOCK="$STATE/.watch.lock"
 WATCH_PATH="$SCRIPT_DIR/fm-watch.sh"
 WATCHER_STALE_GRACE=${FM_WATCHER_STALE_GRACE:-${FM_GUARD_GRACE:-300}}
-# The singleton-lock acquisition, EXIT trap, and the blocking supervision loop
-# all live below the source guard at the very bottom of this file (see "Main
-# entry"). Sourcing this file for unit tests therefore loads the functions -
-# including the event-wait splice below - and returns before acquiring the lock
-# or starting the loop. Running it as a script executes the runtime exactly as
-# before, byte-for-byte.
+# The disposable-cwd relocation, singleton-lock acquisition, EXIT trap, and the
+# blocking supervision loop all live below the source guard at the very bottom of
+# this file (see "Main entry"). Sourcing this file for unit tests therefore loads
+# the functions - including the event-wait splice below - and returns without
+# relocating the sourcing shell, acquiring the lock, or starting the loop.
+# Running it as a script executes the runtime exactly as before, byte-for-byte,
+# apart from the relocation.
 
 # Portable stat. macOS (BSD) stat uses `-f <fmt>`; Linux (GNU) stat uses `-c <fmt>`.
 # Do NOT use the `stat -f <fmt> ... || stat -c <fmt> ...` fallback form: on Linux
@@ -702,6 +694,20 @@ handle_push_transition() {  # <backend> <session> <record>
 if [ "${BASH_SOURCE[0]}" != "$0" ]; then
   return 0
 fi
+
+# The one choke point every launcher that EXECUTES the watcher must pass through,
+# so the disposable-cwd relocation covers all present and future launchers by
+# construction rather than per entry point. It sits below the source guard so a
+# unit test that only sources this file keeps its own cwd. It is idempotent: a
+# launcher that already relocated leaves the cwd undetected here and nothing is
+# printed twice. WATCH_LOCK is re-derived afterwards because a relative STATE is
+# re-anchored by the relocation.
+if ! fm_relocate_from_disposable_cwd \
+  'RELOCATED THE WATCHER OUT OF A DISPOSABLE TASK WORKTREE'; then
+  echo "watcher: FAILED - $FM_DISPOSABLE_ERROR" >&2
+  exit 1
+fi
+WATCH_LOCK="$STATE/.watch.lock"
 
 # Before acquiring the watcher lock or enumerating any runnable check, replace
 # or quarantine checks created by older versions. The migration compares bytes

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -49,7 +49,8 @@ Optional X mode integrates with the watcher only after explicit opt-in; [configu
 
 At session start, `bin/fm-session-start.sh` emits exactly one primary-harness supervision block rendered by `bin/fm-supervision-instructions.sh` from `docs/supervision-protocols/`.
 That block owns the live wait shape for the running primary harness: Claude and Grok use background-notify cycles, Codex uses bounded foreground checkpoints, Pi uses its two tracked primary extensions, and OpenCode uses its TUI plugin.
-`bin/fm-watch-arm.sh` remains the verified arm wrapper for protocols that call it; it forks the watcher as a tracked child, verifies it is genuinely alive with a fresh liveness beacon, and prints an honest `started`, `attached`, or nonzero `FAILED` status.
+`bin/fm-watch-arm.sh` remains the verified arm wrapper for protocols that call it; it relocates itself out of a disposable worktree before forking, forks the watcher as a tracked child, verifies it is genuinely alive with a fresh liveness beacon, and prints an honest `started`, `attached`, or nonzero `FAILED` status.
+The relocation runs before the fork on purpose, so the watcher child inherits the safe working directory rather than the condemned one; a home it cannot enter ends the arm with a typed nonzero `watcher: FAILED - ...` before any child exists.
 On `attached` it stays live across identity-matched successors, and an unexplained clean child close either attaches to a verified healthy successor or becomes the typed nonzero `watcher: FAILED - cycle ended without an actionable reason` result.
 The arm layer records one bounded lifecycle row per observed cycle in `state/.watch-cycle-exits.log`; `state/.watch-triage.log` remains exclusively the absorbed-wake debug log.
 Pi and OpenCode verify session-lock ownership and launch one singleton successor from their child-close handlers before delivering an actionable wake prompt, with bounded exponential retry for failed restoration.
@@ -251,5 +252,5 @@ Use `/stow` before an intentional reset when the conversation may hold durable k
 
 ## Development notes
 
-The current watcher reliability work combines always-on bash triage with a durable queue for actionable wakes, a race-proof singleton lock, duplicate self-eviction, drain-time liveness assertion, and a self-verifying tracked-child arm wrapper.
+The current watcher reliability work combines always-on bash triage with a durable queue for actionable wakes, a race-proof singleton lock, duplicate self-eviction, drain-time liveness assertion, a self-verifying tracked-child arm wrapper, and a relocation out of disposable worktrees so treehouse's lingering-process sweep cannot kill supervision outright ([configuration.md](configuration.md#fm_home)).
 The presence-gated sub-supervisor (`bin/fm-supervise-daemon.sh`) provides walk-away supervision via the `/afk` skill while reusing the same shared wake classifier as the always-on watcher.

--- a/docs/arm-pretool-check.md
+++ b/docs/arm-pretool-check.md
@@ -12,6 +12,8 @@ A firstmate primary must arm `bin/fm-watch-arm.sh` or run `bin/fm-watch-checkpoi
 A shell background operator, pipeline, redirection, wrapper, or unrelated command list can hide failure or let the watcher child die with the tool call.
 The seatbelt rejects those command shapes before execution.
 
+This policy classifies command text only and never inspects the environment the command would run in, so the working directory a watcher would be armed from is out of scope here and is owned by `bin/fm-watch-arm.sh`.
+
 This policy is not a post-arm liveness guarantee.
 `bin/fm-guard.sh`, `bin/fm-turnend-guard.sh`, the watcher lock, and the watcher beacon still prove whether supervision is healthy after an allowed call.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -154,6 +154,9 @@ When it is unset, most scripts use the repo root as the home; when it is set, sc
 When `FM_HOME` is unset, it also behaves as the old whole-root override.
 `bin/fm-send.sh` is intentionally stricter than that general fallback: it requires `FM_HOME` to be set before resolving a target, so operator steers cannot silently resolve against the wrong home.
 `FM_STATE_OVERRIDE`, `FM_DATA_OVERRIDE`, `FM_PROJECTS_OVERRIDE`, and `FM_CONFIG_OVERRIDE` override individual operational directories for tests and specialized harness setup.
+`FM_HOME` is also where a long-lived supervision process relocates itself to survive treehouse's lingering-process sweep, which kills every process whose working directory resolves under a returned worktree regardless of who started it.
+The watcher, its arm wrapper, the bounded foreground checkpoint, and the away-mode daemon each move into `FM_HOME` before starting anything long-lived when their working directory is a disposable pool slot outside this home, announce the move loudly on stderr, and then continue normally.
+A durably leased secondmate home is itself a pool slot but is stable for that home's lifetime, so containment in `FM_HOME` is the discriminator that keeps it exempt; `bin/fm-wake-lib.sh`'s header owns the exact contract, and `FM_TREEHOUSE_POOL_ROOT` overrides the pool root it compares against.
 For the herdr backend, `FM_HOME` also determines the workspace label used by the adapter.
 For the zellij backend, `FM_HOME` does not split containers, but it determines the readable home prefix embedded in visible tab titles; use `FM_ZELLIJ_SESSION` when a separate zellij session is needed.
 The full zellij home label also includes a short hash of the resolved `FM_ROOT` path.
@@ -406,6 +409,7 @@ FM_WEDGE_DEMAND_INSPECT_COUNT=3    # consecutive provably-working stale escalati
 FM_WATCH_TRIAGE_LOG_MAX_BYTES=262144   # size cap for the watcher's absorbed-wake debug log
 FM_FLEET_SYNC_BOOTSTRAP_TIMEOUT=     # optional seconds allowed for bootstrap's best-effort clone refresh; unset/blank defaults to max(20, 5 + 3 * origin-backed-project-count)
 FM_FLEET_PRUNE=1        # set to 0 to skip pruning local branches whose upstream is gone
+FM_TREEHOUSE_POOL_ROOT=  # firstmate-private treehouse pool root for the disposable-cwd relocation only; falls back to TREEHOUSE_DIR then ~/.treehouse, and a root that does not resolve leaves the relocation inert
 FM_STALE_WORKTREE_LOCK_AGE_SECS=30       # min mtime age before fm-teardown.sh treats a leftover worktree git index.lock as provably stale
 FM_TREEHOUSE_RETURN_LOCK_RETRIES=3        # retries after a treehouse return fails on the transient git index.lock signature
 FM_TREEHOUSE_RETURN_LOCK_RETRY_WAIT_SECS=1 # seconds fm-teardown.sh waits before each retry after that signature

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -62,7 +62,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-config-inherit-lib.sh` | Shared primary-to-secondmate inherited local-material propagation                  |
 | `fm-tasks-axi-lib.sh`    | Shared backlog-backend selector and `tasks-axi` compatibility probe                  |
 | `fm-wake-drain.sh`       | Atomically drain queued watcher wakes, emit bounded best-effort status-event annotations, then assert watcher liveness |
-| `fm-wake-lib.sh`         | Shared durable wake queue, portable locks, and watcher identity/health helpers       |
+| `fm-wake-lib.sh`         | Shared durable wake queue, portable locks, watcher identity/health helpers, and the disposable-cwd relocation for long-lived processes |
 | `fm-classify-lib.sh`     | Shared captain-relevant and declared-external-wait wake classification vocabulary    |
 | `fm-send.sh`             | Send one verified literal line or supported key through the target's recorded backend |
 | `fm-tmux-lib.sh`         | Shared tmux pane primitives for busy detection, composer capture, and verified submit |

--- a/docs/watcher-continuity.md
+++ b/docs/watcher-continuity.md
@@ -33,6 +33,7 @@ They remain the final backstop rather than the normal continuity mechanism.
 An actionable child output returns that reason normally.
 A zero/empty child return rechecks the home lock and beacon, attaches to a verified healthy successor when one exists, or emits `watcher: FAILED - cycle ended without an actionable reason` and exits nonzero.
 An attached arm follows verified identity-matched successors and reports the same typed failure if that chain ends without one.
+Separately, an arm whose working directory is a disposable worktree relocates into `FM_HOME` before forking anything, and a home it cannot enter ends the arm with a typed nonzero `watcher: FAILED - ...` before any child exists, so that ending records no lifecycle row.
 
 The arm layer appends one tab-separated record per observed cycle to `state/.watch-cycle-exits.log`.
 Each record includes arm and watcher PIDs, start and end timestamps, exit code and signal, classified reason, beacon age, lock identity before and after close, and successor disposition.
@@ -46,6 +47,8 @@ Only the watcher process touches `state/.last-watcher-beat`; no helper process c
 
 `tests/fm-pi-watch-extension.test.sh` simulates actionable and empty child closes against the actual Pi and OpenCode close handlers, blocks prompt delivery to prove the successor launches first, verifies single-flight behavior, changes the session lock before close to prove ownership is rechecked, and hangs each successor arm to prove bounded fallback delivery includes the typed restoration failure.
 `tests/fm-watcher-lock.test.sh` covers verified-successor attach, the typed self-eviction failure, bounded and successor-linked lifecycle rows, and a SIGSTOP counterfactual that distinguishes a live PID from a stale beacon before classifying termination.
+The same suite also covers the disposable-worktree relocation: the arm relocating before it forks, the watcher never running from the condemned directory, an absolute `FM_HOME` surviving relocation byte-identical so it still matches the watcher lock, a relative one being re-anchored, and the distinct faults for a state or code root that no longer resolves.
+`tests/fm-watch-checkpoint.test.sh` and `tests/fm-afk-launch.test.sh` cover the same relocation for the bounded checkpoint and the away-mode daemon entry, including a leased secondmate home staying exempt.
 `tests/fm-continuity-pretool-check.test.sh` proves the Claude gate rejects only non-recovery fleet execution in the precise unhealthy state and preserves the existing Stop registration.
 
 ## Sanitized live evidence, 2026-07-17

--- a/tests/fm-afk-launch.test.sh
+++ b/tests/fm-afk-launch.test.sh
@@ -42,41 +42,49 @@ trap GLOBAL_CLEANUP EXIT
 
 # ---------------------------------------------------------------------------
 # UNIT 0: the away-mode daemon is long-lived, so starting it from a treehouse
-# pool slot that is not this home is refused before any state is touched. A cwd
-# inside the home is not refused, even when the home is itself a leased slot.
+# pool slot that is not this home relocates into the home before the daemon exec,
+# loudly, and then continues. A cwd inside the home is left alone, even when the
+# home is itself a leased slot.
 # ---------------------------------------------------------------------------
-unit_disposable_cwd_refused() {
-  local st pool slot home out status
+unit_disposable_cwd_relocated() {
+  local st pool slot slot_real home out
   st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-cwd.XXXXXX")
   pool="$st/pool"
   slot="$pool/firstmate-abc123/3/firstmate"
   home="$st/home"
   out="$st/out"
   mkdir -p "$slot" "$home/state"
+  slot_real=$(cd "$slot" && pwd -P)
   ( cd "$slot" && TREEHOUSE_DIR="$pool" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
-    "$START" ) > "$out" 2>&1
-  status=$?
-  if [ "$status" -ne 0 ] && grep -qF 'REFUSING TO START AWAY MODE' "$out"; then
-    pass "disposable-cwd: refuses to start the daemon from a foreign pool slot"
+    bash -c '. "$1"; FM_AFK_DAEMON=/bin/true; fm_afk_start_main' _ "$START" ) > "$out" 2>&1
+  if grep -qF 'RELOCATED AWAY MODE' "$out" && grep -qF "$slot_real" "$out"; then
+    pass "disposable-cwd: relocates out of a foreign pool slot and names it"
   else
-    fail "disposable-cwd: did not refuse a foreign pool slot (status $status)"
+    fail "disposable-cwd: did not relocate out of a foreign pool slot ($(cat "$out"))"
   fi
-  if [ ! -e "$home/state/.afk" ]; then
-    pass "disposable-cwd: refuses before entering away mode"
+  if ! grep -qF 'REFUSING TO START AWAY MODE' "$out"; then
+    pass "disposable-cwd: does not refuse away mode"
   else
-    fail "disposable-cwd: entered away mode despite refusing to start the daemon"
+    fail "disposable-cwd: refused instead of relocating"
+  fi
+  # Relocating rather than refusing means away mode is entered with a daemon that
+  # can survive to own it, never entered and then abandoned.
+  if [ -e "$home/state/.afk" ]; then
+    pass "disposable-cwd: away mode is entered normally after relocating"
+  else
+    fail "disposable-cwd: relocation blocked away mode from being entered"
   fi
 
-  # A leased home is under the pool but IS this home, so the guard must let it by.
+  # A leased home is under the pool but IS this home, so nothing should relocate.
   home="$pool/firstmate-abc123/4/firstmate"
   out="$st/out-home"
   mkdir -p "$home/state"
   ( cd "$home" && TREEHOUSE_DIR="$pool" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
     FM_AFK_STATE_PREPARED=1 "$START" ) > "$out" 2>&1
-  if ! grep -qF 'REFUSING TO START AWAY MODE' "$out"; then
-    pass "disposable-cwd: does not refuse a cwd inside its own leased home"
+  if ! grep -qF 'RELOCATED AWAY MODE' "$out"; then
+    pass "disposable-cwd: does not relocate a cwd inside its own leased home"
   else
-    fail "disposable-cwd: refused its own leased home"
+    fail "disposable-cwd: relocated out of its own leased home"
   fi
   rm -rf "$st"
 }
@@ -924,7 +932,7 @@ unit_malformed_record_fails_closed
 unit_stop_malformed_record_fails_closed
 unit_tmux_planned_record_and_collision
 unit_stop_validates_before_signal
-unit_disposable_cwd_refused
+unit_disposable_cwd_relocated
 unit_lock_requires_complete_metadata
 unit_stop_surfaces_afk_removal_failure
 unit_stop_confirms_daemon_exit

--- a/tests/fm-afk-launch.test.sh
+++ b/tests/fm-afk-launch.test.sh
@@ -41,6 +41,47 @@ GLOBAL_CLEANUP() {
 trap GLOBAL_CLEANUP EXIT
 
 # ---------------------------------------------------------------------------
+# UNIT 0: the away-mode daemon is long-lived, so starting it from a treehouse
+# pool slot that is not this home is refused before any state is touched. A cwd
+# inside the home is not refused, even when the home is itself a leased slot.
+# ---------------------------------------------------------------------------
+unit_disposable_cwd_refused() {
+  local st pool slot home out status
+  st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-cwd.XXXXXX")
+  pool="$st/pool"
+  slot="$pool/firstmate-abc123/3/firstmate"
+  home="$st/home"
+  out="$st/out"
+  mkdir -p "$slot" "$home/state"
+  ( cd "$slot" && TREEHOUSE_DIR="$pool" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    "$START" ) > "$out" 2>&1
+  status=$?
+  if [ "$status" -ne 0 ] && grep -qF 'REFUSING TO START AWAY MODE' "$out"; then
+    pass "disposable-cwd: refuses to start the daemon from a foreign pool slot"
+  else
+    fail "disposable-cwd: did not refuse a foreign pool slot (status $status)"
+  fi
+  if [ ! -e "$home/state/.afk" ]; then
+    pass "disposable-cwd: refuses before entering away mode"
+  else
+    fail "disposable-cwd: entered away mode despite refusing to start the daemon"
+  fi
+
+  # A leased home is under the pool but IS this home, so the guard must let it by.
+  home="$pool/firstmate-abc123/4/firstmate"
+  out="$st/out-home"
+  mkdir -p "$home/state"
+  ( cd "$home" && TREEHOUSE_DIR="$pool" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    FM_AFK_STATE_PREPARED=1 "$START" ) > "$out" 2>&1
+  if ! grep -qF 'REFUSING TO START AWAY MODE' "$out"; then
+    pass "disposable-cwd: does not refuse a cwd inside its own leased home"
+  else
+    fail "disposable-cwd: refused its own leased home"
+  fi
+  rm -rf "$st"
+}
+
+# ---------------------------------------------------------------------------
 # UNIT 1: fm_afk_clear_stale_artifacts removes exactly the three stale artifacts.
 # ---------------------------------------------------------------------------
 unit_clear_stale() {
@@ -883,6 +924,7 @@ unit_malformed_record_fails_closed
 unit_stop_malformed_record_fails_closed
 unit_tmux_planned_record_and_collision
 unit_stop_validates_before_signal
+unit_disposable_cwd_refused
 unit_lock_requires_complete_metadata
 unit_stop_surfaces_afk_removal_failure
 unit_stop_confirms_daemon_exit

--- a/tests/fm-afk-launch.test.sh
+++ b/tests/fm-afk-launch.test.sh
@@ -32,8 +32,11 @@ START="$ROOT/bin/fm-afk-start.sh"
 # exactly the shape the launcher's cwd guard relocates out of, so the suite would
 # behave one way in CI and another inside a task worktree. Point the pool root at
 # a path that does not exist, which makes the guard inert and the suite identical
-# in both places. The tests that ARE about the guard set TREEHOUSE_DIR themselves.
-export TREEHOUSE_DIR="${TMPDIR:-/tmp}/fm-afk-absent-treehouse-pool-$$"
+# in both places. The tests that ARE about the guard set FM_TREEHOUSE_POOL_ROOT
+# themselves. The pin uses firstmate's private FM_TREEHOUSE_POOL_ROOT rather than
+# TREEHOUSE_DIR so it never redirects the real treehouse CLI, which reads
+# TREEHOUSE_DIR as its own pool root.
+export FM_TREEHOUSE_POOL_ROOT="${TMPDIR:-/tmp}/fm-afk-absent-treehouse-pool-$$"
 
 FAILED=0
 fail() { printf 'not ok - %s\n' "$1" >&2; FAILED=1; }
@@ -67,7 +70,7 @@ unit_disposable_cwd_relocated() {
   out="$st/out"
   mkdir -p "$slot" "$home/state"
   slot_real=$(cd "$slot" && pwd -P)
-  ( cd "$slot" && TREEHOUSE_DIR="$pool" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+  ( cd "$slot" && FM_TREEHOUSE_POOL_ROOT="$pool" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
     bash -c '. "$1"; FM_AFK_DAEMON=/bin/true; fm_afk_start_main' _ "$START" ) > "$out" 2>&1
   if grep -qF 'RELOCATED AWAY MODE' "$out" && grep -qF "$slot_real" "$out"; then
     pass "disposable-cwd: relocates out of a foreign pool slot and names it"
@@ -91,7 +94,7 @@ unit_disposable_cwd_relocated() {
   home="$pool/firstmate-abc123/4/firstmate"
   out="$st/out-home"
   mkdir -p "$home/state"
-  ( cd "$home" && TREEHOUSE_DIR="$pool" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+  ( cd "$home" && FM_TREEHOUSE_POOL_ROOT="$pool" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
     FM_AFK_STATE_PREPARED=1 "$START" ) > "$out" 2>&1
   if ! grep -qF 'RELOCATED AWAY MODE' "$out"; then
     pass "disposable-cwd: does not relocate a cwd inside its own leased home"

--- a/tests/fm-afk-launch.test.sh
+++ b/tests/fm-afk-launch.test.sh
@@ -23,13 +23,16 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 LAUNCH="$ROOT/bin/fm-afk-launch.sh"
 START="$ROOT/bin/fm-afk-start.sh"
 
-# These tests run the away-mode launchers from the repo checkout while pointing
-# FM_HOME at a temp dir. When the checkout is itself a treehouse pool slot -
-# which it is for any crewmate task worktree - that is exactly the shape the
-# launcher's cwd guard relocates out of, so the suite would behave one way in CI
-# and another inside a task worktree. Point the pool root at a path that does not
-# exist, which makes the guard inert and the suite identical in both places. The
-# tests that ARE about the guard set TREEHOUSE_DIR themselves.
+# tests/lib.sh owns this pin for the rest of the test tree, but this suite is
+# deliberately standalone - it keeps its own non-exiting `fail` so a backend e2e
+# case can clean up after itself - so it never sources that library and must
+# carry the pin itself. It runs the away-mode launchers from the repo checkout
+# while pointing FM_HOME at a temp dir, and when the checkout is itself a
+# treehouse pool slot - which it is for any crewmate task worktree - that is
+# exactly the shape the launcher's cwd guard relocates out of, so the suite would
+# behave one way in CI and another inside a task worktree. Point the pool root at
+# a path that does not exist, which makes the guard inert and the suite identical
+# in both places. The tests that ARE about the guard set TREEHOUSE_DIR themselves.
 export TREEHOUSE_DIR="${TMPDIR:-/tmp}/fm-afk-absent-treehouse-pool-$$"
 
 FAILED=0

--- a/tests/fm-afk-launch.test.sh
+++ b/tests/fm-afk-launch.test.sh
@@ -23,6 +23,15 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 LAUNCH="$ROOT/bin/fm-afk-launch.sh"
 START="$ROOT/bin/fm-afk-start.sh"
 
+# These tests run the away-mode launchers from the repo checkout while pointing
+# FM_HOME at a temp dir. When the checkout is itself a treehouse pool slot -
+# which it is for any crewmate task worktree - that is exactly the shape the
+# launcher's cwd guard relocates out of, so the suite would behave one way in CI
+# and another inside a task worktree. Point the pool root at a path that does not
+# exist, which makes the guard inert and the suite identical in both places. The
+# tests that ARE about the guard set TREEHOUSE_DIR themselves.
+export TREEHOUSE_DIR="${TMPDIR:-/tmp}/fm-afk-absent-treehouse-pool-$$"
+
 FAILED=0
 fail() { printf 'not ok - %s\n' "$1" >&2; FAILED=1; }
 pass() { printf 'ok - %s\n' "$1"; }

--- a/tests/fm-backend-herdr-eventwait-smoke.test.sh
+++ b/tests/fm-backend-herdr-eventwait-smoke.test.sh
@@ -111,8 +111,11 @@ UNDER_ONE=$(python3 -c "print('yes' if (($END)-($START)) < 1.0 else 'no')" 2>/de
 pass "real herdr ($HERDR_VERSION): a driven idle->blocked transition returns the blocked record in ${ELAPSED}s (pane $PANE_ID)"
 
 # --- the watcher's fast-path lands a stale record in the scratch wake queue ---
-# Source the watcher (its guard returns before the lock/loop) and override wake so
-# handle_push_transition enqueues without exiting the test.
+# Source the watcher (its guard returns before the relocation/lock/loop) and
+# override wake so handle_push_transition enqueues without exiting the test.
+# This suite is standalone and needs no TREEHOUSE_DIR pin: it only SOURCES the
+# watcher and never executes it or any launcher, and the disposable-cwd
+# relocation lives below the watcher's source guard.
 export FM_STATE_OVERRIDE="$STATE"
 export FM_ROOT_OVERRIDE="$ROOT"
 # shellcheck source=bin/fm-watch.sh

--- a/tests/fm-backend-herdr-eventwait-smoke.test.sh
+++ b/tests/fm-backend-herdr-eventwait-smoke.test.sh
@@ -11,6 +11,9 @@
 # herdr_safe_stop_and_delete on a private fm-lab-* session, never a bare/ambient
 # `herdr server stop`. Every lifecycle op goes through bin/fm-herdr-lab.sh, which
 # refuses the default session and verifies the fleet-state tripwire.
+# relocation-pool-pin: not-needed - this suite only SOURCES bin/fm-watch.sh to reach its
+# functions, and the relocation sits below that file's source guard, so a sourcing shell
+# is never moved and needs no FM_TREEHOUSE_POOL_ROOT pin.
 set -u
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"

--- a/tests/fm-backend-herdr-eventwait-smoke.test.sh
+++ b/tests/fm-backend-herdr-eventwait-smoke.test.sh
@@ -113,7 +113,7 @@ pass "real herdr ($HERDR_VERSION): a driven idle->blocked transition returns the
 # --- the watcher's fast-path lands a stale record in the scratch wake queue ---
 # Source the watcher (its guard returns before the relocation/lock/loop) and
 # override wake so handle_push_transition enqueues without exiting the test.
-# This suite is standalone and needs no TREEHOUSE_DIR pin: it only SOURCES the
+# This suite is standalone and needs no pool-root pin: it only SOURCES the
 # watcher and never executes it or any launcher, and the disposable-cwd
 # relocation lives below the watcher's source guard.
 export FM_STATE_OVERRIDE="$STATE"

--- a/tests/fm-claude-continuity-live-e2e.test.sh
+++ b/tests/fm-claude-continuity-live-e2e.test.sh
@@ -2,6 +2,9 @@
 # Opt-in credentialed Claude regression for the post-background-completion
 # continuity gate. The project and FM_HOME are isolated; Claude keeps using its
 # existing managed authentication.
+# relocation-pool-pin: not-needed - the launcher runs inside the temporary project the
+# harness is started in, never from this suite's own cwd, so the disposable-cwd guard
+# cannot fire and a FM_TREEHOUSE_POOL_ROOT pin would guard nothing.
 set -u
 
 if [ "${FM_CLAUDE_LIVE_E2E:-0}" != 1 ]; then

--- a/tests/fm-codex-continuity-live-e2e.test.sh
+++ b/tests/fm-codex-continuity-live-e2e.test.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 # Opt-in credentialed Codex regression proving the continuity changes preserve
 # Codex's bounded foreground-checkpoint supervision path.
+# relocation-pool-pin: not-needed - the launcher runs inside the temporary project the
+# harness is started in, never from this suite's own cwd, so the disposable-cwd guard
+# cannot fire and a FM_TREEHOUSE_POOL_ROOT pin would guard nothing.
 set -u
 
 if [ "${FM_CODEX_LIVE_E2E:-0}" != 1 ]; then

--- a/tests/fm-grok-continuity-live-e2e.test.sh
+++ b/tests/fm-grok-continuity-live-e2e.test.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 # Opt-in credentialed Grok regression proving the shared arm wrapper still works
 # through Grok's tracked background-task notification path.
+# relocation-pool-pin: not-needed - the launcher runs inside the temporary project the
+# harness is started in, never from this suite's own cwd, so the disposable-cwd guard
+# cannot fire and a FM_TREEHOUSE_POOL_ROOT pin would guard nothing.
 set -u
 
 if [ "${FM_GROK_LIVE_E2E:-0}" != 1 ]; then

--- a/tests/fm-opencode-primary-live-e2e.test.sh
+++ b/tests/fm-opencode-primary-live-e2e.test.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 # Opt-in credentialed OpenCode continuity regression on an isolated project and
 # FM_HOME. Existing OpenCode credentials stay in their managed store.
+# relocation-pool-pin: not-needed - the launcher runs inside the temporary project the
+# harness is started in, never from this suite's own cwd, so the disposable-cwd guard
+# cannot fire and a FM_TREEHOUSE_POOL_ROOT pin would guard nothing.
 set -u
 
 if [ "${FM_OPENCODE_LIVE_E2E:-0}" != 1 ]; then

--- a/tests/fm-pi-primary-live-e2e.test.sh
+++ b/tests/fm-pi-primary-live-e2e.test.sh
@@ -2,6 +2,9 @@
 # Opt-in credentialed Pi continuity regression on a private tmux socket and
 # isolated project/home state. It uses the existing shared Pi auth store without
 # copying credentials and pins the captain-approved openai-codex model.
+# relocation-pool-pin: not-needed - the launcher runs inside the temporary project the
+# harness is started in, never from this suite's own cwd, so the disposable-cwd guard
+# cannot fire and a FM_TREEHOUSE_POOL_ROOT pin would guard nothing.
 set -u
 
 if [ "${FM_PI_LIVE_E2E:-0}" != 1 ]; then

--- a/tests/fm-relocation-pool-pin.test.sh
+++ b/tests/fm-relocation-pool-pin.test.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Static contract test for the treehouse pool-root pin every suite that touches a
+# relocating launcher needs.
+#
+# bin/fm-wake-lib.sh's fm_relocate_from_disposable_cwd moves a launcher out of a
+# treehouse pool slot before it starts anything long-lived. A suite that runs a
+# launcher from the repo checkout while pointing FM_HOME at a temp dir is exactly
+# that shape whenever the checkout is itself a pool slot, which it is for any
+# crewmate task worktree, so the launcher relocates and warns there but not in CI.
+# tests/lib.sh pins FM_TREEHOUSE_POOL_ROOT at an absent pool to make the guard
+# inert tree-wide, but a standalone suite that never reaches that library gets no
+# pin, and that gap has been found by hand three separate times. This test turns
+# it into an authoring-time failure instead.
+#
+# A suite that references a relocating launcher must do one of three things:
+#   1. reach tests/lib.sh, directly or through a helper, and inherit the pin;
+#   2. set FM_TREEHOUSE_POOL_ROOT itself, as a standalone suite must;
+#   3. carry an explicit opt-out marker naming why it is unaffected.
+# The marker exists so a suite that only mentions a launcher, or only sources one
+# without executing it, records that decision in the file rather than defaulting
+# into a silent exemption, and so no pin is added where it would guard nothing.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TESTS_DIR="$ROOT/tests"
+OPT_OUT_MARKER='relocation-pool-pin: not-needed'
+LAUNCHER_RE='bin/fm-(watch|watch-arm|watch-checkpoint|afk-start)\.sh'
+
+# Whether a file reaches tests/lib.sh through its own sourcing chain. Helpers such
+# as tests/wake-helpers.sh and tests/secondmate-helpers.sh source it in turn, so a
+# suite can inherit the pin without naming the library itself.
+reaches_test_lib() {
+  local file=$1 seen=${2:-} dep
+  case " $seen " in *" $file "*) return 1 ;; esac
+  seen="$seen $file"
+  [ "$(basename "$file")" = lib.sh ] && return 0
+  while IFS= read -r dep; do
+    [ -n "$dep" ] || continue
+    [ -f "$TESTS_DIR/$dep" ] || continue
+    reaches_test_lib "$TESTS_DIR/$dep" "$seen" && return 0
+  done < <(grep -oE '\$\{?BASH_SOURCE\[0\]\}?"?\)?/[a-zA-Z0-9._-]+\.sh' "$file" 2>/dev/null | sed 's|.*/||' | sort -u)
+  return 1
+}
+
+test_every_launcher_suite_has_a_pool_pin() {
+  local suite name unpinned=""
+  for suite in "$TESTS_DIR"/*.test.sh; do
+    name=$(basename "$suite")
+    grep -qE "$LAUNCHER_RE" "$suite" || continue
+    reaches_test_lib "$suite" && continue
+    # An assignment only, so prose naming the variable cannot pass for a pin.
+    grep -qE '(^|[[:space:];&|(])(export[[:space:]]+)?FM_TREEHOUSE_POOL_ROOT=' "$suite" && continue
+    grep -qF "$OPT_OUT_MARKER" "$suite" && continue
+    unpinned="$unpinned $name"
+  done
+  [ -z "$unpinned" ] || fail "standalone suites touch a relocating launcher with no pool-root pin and no opt-out marker:$unpinned"
+  pass "every suite that touches a relocating launcher inherits, sets, or documents its pool-root pin"
+}
+
+# The pin only helps where the guard can actually fire, so a marker must not be
+# used to excuse a suite that really does run a launcher from its own cwd.
+test_opt_out_markers_state_a_reason() {
+  local suite name line self
+  self=$(basename "${BASH_SOURCE[0]}")
+  for suite in "$TESTS_DIR"/*.test.sh; do
+    name=$(basename "$suite")
+    # This file defines the marker string, so its own occurrences are the
+    # definition rather than a claimed exemption.
+    [ "$name" = "$self" ] && continue
+    grep -qF "$OPT_OUT_MARKER" "$suite" || continue
+    line=$(grep -F "$OPT_OUT_MARKER" "$suite" | head -1)
+    case "$line" in
+      *"$OPT_OUT_MARKER"' - '?*) ;;
+      *) fail "$name has a bare pool-pin opt-out marker with no reason after it" ;;
+    esac
+  done
+  pass "every pool-pin opt-out marker records why the suite is unaffected"
+}
+
+test_shared_pin_is_owned_by_the_test_library() {
+  assert_grep 'export FM_TREEHOUSE_POOL_ROOT=' "$TESTS_DIR/lib.sh" \
+    "tests/lib.sh lost the tree-wide pool-root pin every sourcing suite relies on"
+  if grep -q 'export TREEHOUSE_DIR=' "$TESTS_DIR/lib.sh"; then
+    fail "tests/lib.sh must not pin TREEHOUSE_DIR, which is the real treehouse CLI's own pool root"
+  fi
+  pass "the tree-wide pin is owned by tests/lib.sh and leaves the real treehouse CLI alone"
+}
+
+test_every_launcher_suite_has_a_pool_pin
+test_opt_out_markers_state_a_reason
+test_shared_pin_is_owned_by_the_test_library

--- a/tests/fm-watch-checkpoint.test.sh
+++ b/tests/fm-watch-checkpoint.test.sh
@@ -87,7 +87,33 @@ test_existing_singleton_watcher_is_not_success() {
   pass "checkpoint rejects an existing watcher singleton as unowned"
 }
 
+# Codex supervision runs the checkpoint, not the arm, so the disposable-cwd
+# relocation has to cover this launcher as well. The wrapper blocks in the
+# foreground for the whole checkpoint, so it must leave the sweep path itself
+# rather than relying on the watcher it starts doing so.
+test_checkpoint_relocates_out_of_disposable_pool_cwd() {
+  local home pool slot slot_real home_real out err status
+  home=$(make_home relocate)
+  pool="$TMP_ROOT/relocate-pool"
+  slot="$pool/firstmate-abc123/7/firstmate"
+  out="$home/out.txt"
+  err="$home/err.txt"
+  mkdir -p "$slot"
+  slot_real=$(cd "$slot" && pwd -P)
+  home_real=$(cd "$home" && pwd -P)
+  status=0
+  ( cd "$slot" && TREEHOUSE_DIR="$pool" FM_HOME="$home" FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 "$CHECKPOINT" --seconds 1 ) >"$out" 2>"$err" || status=$?
+  expect_code 124 "$status" "relocated checkpoint exit"
+  assert_contains "$(cat "$err")" "RELOCATED THE WATCHER" "checkpoint did not warn about the relocation"
+  assert_contains "$(cat "$err")" "$slot_real" "checkpoint warning did not name the condemned cwd"
+  assert_contains "$(cat "$err")" "$home_real" "checkpoint warning did not name the home it moved to"
+  assert_contains "$(cat "$out")" "checkpoint: no actionable wake within 1s" "checkpoint did not proceed past the relocation"
+  pass "checkpoint relocates out of a treehouse pool slot that is not this home"
+}
+
 test_quiet_checkpoint_exits_124_cleanly
 test_signal_passes_through_and_exits_zero
+test_checkpoint_relocates_out_of_disposable_pool_cwd
 test_registered_check_uses_preserved_watcher_environment
 test_existing_singleton_watcher_is_not_success

--- a/tests/fm-watch-checkpoint.test.sh
+++ b/tests/fm-watch-checkpoint.test.sh
@@ -102,7 +102,7 @@ test_checkpoint_relocates_out_of_disposable_pool_cwd() {
   slot_real=$(cd "$slot" && pwd -P)
   home_real=$(cd "$home" && pwd -P)
   status=0
-  ( cd "$slot" && TREEHOUSE_DIR="$pool" FM_HOME="$home" FM_POLL=1 FM_SIGNAL_GRACE=1 \
+  ( cd "$slot" && FM_TREEHOUSE_POOL_ROOT="$pool" FM_HOME="$home" FM_POLL=1 FM_SIGNAL_GRACE=1 \
     FM_CHECK_INTERVAL=999999 "$CHECKPOINT" --seconds 1 ) >"$out" 2>"$err" || status=$?
   expect_code 124 "$status" "relocated checkpoint exit"
   assert_contains "$(cat "$err")" "RELOCATED THE WATCHER" "checkpoint did not warn about the relocation"

--- a/tests/fm-watch-checkpoint.test.sh
+++ b/tests/fm-watch-checkpoint.test.sh
@@ -8,6 +8,15 @@ set -u
 CHECKPOINT="$ROOT/bin/fm-watch-checkpoint.sh"
 TMP_ROOT=$(fm_test_tmproot fm-watch-checkpoint)
 
+# These tests run the checkpoint from the repo checkout while pointing FM_HOME at
+# a temp dir. When the checkout is itself a treehouse pool slot - which it is for
+# any crewmate task worktree - that is exactly the shape the launcher's cwd guard
+# relocates out of, so the suite would behave one way in CI and another inside a
+# task worktree. Point the pool root at a path that does not exist, which makes
+# the guard inert and the suite identical in both places. Any test that IS about
+# the guard sets TREEHOUSE_DIR itself.
+export TREEHOUSE_DIR="$TMP_ROOT/absent-treehouse-pool"
+
 make_home() {
   local name=$1 home
   home="$TMP_ROOT/$name"

--- a/tests/fm-watch-checkpoint.test.sh
+++ b/tests/fm-watch-checkpoint.test.sh
@@ -8,15 +8,6 @@ set -u
 CHECKPOINT="$ROOT/bin/fm-watch-checkpoint.sh"
 TMP_ROOT=$(fm_test_tmproot fm-watch-checkpoint)
 
-# These tests run the checkpoint from the repo checkout while pointing FM_HOME at
-# a temp dir. When the checkout is itself a treehouse pool slot - which it is for
-# any crewmate task worktree - that is exactly the shape the launcher's cwd guard
-# relocates out of, so the suite would behave one way in CI and another inside a
-# task worktree. Point the pool root at a path that does not exist, which makes
-# the guard inert and the suite identical in both places. Any test that IS about
-# the guard sets TREEHOUSE_DIR itself.
-export TREEHOUSE_DIR="$TMP_ROOT/absent-treehouse-pool"
-
 make_home() {
   local name=$1 home
   home="$TMP_ROOT/$name"

--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -98,7 +98,7 @@ test_arm_relocates_out_of_disposable_pool_cwd() {
   mkdir "$state/.watch.lock"
   printf '%s\n' "$live" > "$state/.watch.lock/pid"
   touch -t 200001010000 "$state/.last-watcher-beat"
-  ( cd "$slot" && PATH="$fakebin:$PATH" TREEHOUSE_DIR="$pool" FM_HOME="$home" \
+  ( cd "$slot" && PATH="$fakebin:$PATH" FM_TREEHOUSE_POOL_ROOT="$pool" FM_HOME="$home" \
     FM_STATE_OVERRIDE="$state" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 \
     FM_HEARTBEAT=999999 FM_ARM_CONFIRM_TIMEOUT=3 "$WATCH_ARM" ) > "$armout" 2>&1 &
   armpid=$!
@@ -131,7 +131,7 @@ test_relocated_watcher_does_not_run_in_condemned_cwd() {
   mark_pr_check_migration_complete "$state"
   mkdir -p "$slot" "$home"
   slot_real=$(cd "$slot" && pwd -P)
-  ( cd "$slot" && PATH="$fakebin:$PATH" TREEHOUSE_DIR="$pool" FM_HOME="$home" \
+  ( cd "$slot" && PATH="$fakebin:$PATH" FM_TREEHOUSE_POOL_ROOT="$pool" FM_HOME="$home" \
     FM_STATE_OVERRIDE="$state" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 \
     FM_HEARTBEAT=999999 FM_ARM_CONFIRM_TIMEOUT=20 "$WATCH_ARM" ) > "$armout" 2>&1 &
   armpid=$!
@@ -180,7 +180,7 @@ test_relocation_preserves_absolute_fm_home_identity() {
   link="$dir/home-link"
   mkdir -p "$slot" "$home"
   ln -s "$home" "$link"
-  out=$(cd "$slot" && TREEHOUSE_DIR="$pool" FM_HOME="$link" FM_STATE_OVERRIDE="$state" \
+  out=$(cd "$slot" && FM_TREEHOUSE_POOL_ROOT="$pool" FM_HOME="$link" FM_STATE_OVERRIDE="$state" \
     bash -c '
       . "$1"
       fm_relocate_from_disposable_cwd headline 2>/dev/null || exit 7
@@ -204,7 +204,7 @@ test_relocation_absolutizes_a_relative_fm_home() {
   slot="$pool/firstmate-abc123/9/firstmate"
   home="$dir/home"
   mkdir -p "$slot" "$home"
-  out=$(cd "$slot" && TREEHOUSE_DIR="$pool" FM_HOME="../../../../home" \
+  out=$(cd "$slot" && FM_TREEHOUSE_POOL_ROOT="$pool" FM_HOME="../../../../home" \
     bash -c '
       . "$1"
       fm_relocate_from_disposable_cwd headline 2>/dev/null || exit 7
@@ -228,7 +228,7 @@ test_relocation_ignores_an_unresolvable_absolute_state() {
   slot="$pool/firstmate-abc123/10/firstmate"
   home="$dir/home"
   mkdir -p "$slot" "$home"
-  out=$(cd "$slot" && TREEHOUSE_DIR="$pool" FM_HOME="$home" FM_STATE_OVERRIDE="$dir/gone-state" \
+  out=$(cd "$slot" && FM_TREEHOUSE_POOL_ROOT="$pool" FM_HOME="$home" FM_STATE_OVERRIDE="$dir/gone-state" \
     bash -c '
       . "$1"
       rmdir "$STATE"
@@ -251,7 +251,7 @@ test_relocation_reports_a_state_fault_distinctly() {
   slot="$pool/firstmate-abc123/11/firstmate"
   home="$dir/home"
   mkdir -p "$slot" "$home"
-  out=$(cd "$slot" && TREEHOUSE_DIR="$pool" FM_HOME="$home" FM_STATE_OVERRIDE="relstate" \
+  out=$(cd "$slot" && FM_TREEHOUSE_POOL_ROOT="$pool" FM_HOME="$home" FM_STATE_OVERRIDE="relstate" \
     bash -c '
       . "$1"
       rmdir "$STATE"
@@ -280,7 +280,7 @@ test_relocation_re_anchors_a_relative_root() {
   home="$dir/home"
   root="$dir/root"
   mkdir -p "$slot" "$home" "$root"
-  out=$(cd "$slot" && TREEHOUSE_DIR="$pool" FM_HOME="$home" \
+  out=$(cd "$slot" && FM_TREEHOUSE_POOL_ROOT="$pool" FM_HOME="$home" \
     FM_ROOT_OVERRIDE="../../../../root" \
     bash -c '
       . "$1"
@@ -292,7 +292,7 @@ test_relocation_re_anchors_a_relative_root() {
   [ "$(printf '%s\n' "$out" | sed -n 2p)" = "$(cd "$root" && pwd -P)" ] \
     || fail "relocation re-anchored FM_ROOT but not FM_ROOT_OVERRIDE, which children inherit"
 
-  out=$(cd "$slot" && TREEHOUSE_DIR="$pool" FM_HOME="$home" FM_ROOT_OVERRIDE="$root" \
+  out=$(cd "$slot" && FM_TREEHOUSE_POOL_ROOT="$pool" FM_HOME="$home" FM_ROOT_OVERRIDE="$root" \
     bash -c '
       . "$1"
       fm_relocate_from_disposable_cwd headline 2>/dev/null || exit 7
@@ -300,6 +300,40 @@ test_relocation_re_anchors_a_relative_root() {
     ' _ "$LIB") || fail "relocation with an absolute code root failed"
   [ "$out" = "$root" ] || fail "relocation rewrote an absolute FM_ROOT away from $root ($out)"
   pass "relocation re-anchors a relative code root and leaves an absolute one alone"
+}
+
+# Every path the lib derives from STATE has to follow STATE across the chdir.
+# A wake queue left pointing at the pre-relocation state directory would have the
+# enqueue side writing one file and the drain side reading another.
+test_relocation_re_anchors_state_derived_paths() {
+  local dir pool slot home out
+  dir=$(make_case relocate-derived-paths)
+  pool="$dir/pool"
+  slot="$pool/firstmate-abc123/13/firstmate"
+  home="$dir/home"
+  mkdir -p "$slot" "$home/relstate"
+  out=$(cd "$slot" && FM_TREEHOUSE_POOL_ROOT="$pool" FM_HOME="$home" \
+    FM_STATE_OVERRIDE="../../../../home/relstate" \
+    bash -c '
+      . "$1"
+      fm_relocate_from_disposable_cwd headline 2>/dev/null || exit 7
+      printf "%s\n%s\n" "$FM_WAKE_QUEUE" "$FM_WAKE_QUEUE_LOCK"
+    ' _ "$LIB") || fail "relocation with a relative STATE failed"
+  [ "$(printf '%s\n' "$out" | sed -n 1p)" = "$(cd "$home/relstate" && pwd -P)/.wake-queue" ] \
+    || fail "the wake queue did not follow the re-anchored STATE ($(printf '%s\n' "$out" | sed -n 1p))"
+  [ "$(printf '%s\n' "$out" | sed -n 2p)" = "$(cd "$home/relstate" && pwd -P)/.wake-queue.lock" ] \
+    || fail "the wake queue lock did not follow the re-anchored STATE"
+
+  out=$(cd "$slot" && FM_TREEHOUSE_POOL_ROOT="$pool" FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/relstate" FM_WAKE_QUEUE="$dir/pinned-queue" \
+    bash -c '
+      . "$1"
+      fm_relocate_from_disposable_cwd headline 2>/dev/null || exit 7
+      printf "%s\n" "$FM_WAKE_QUEUE"
+    ' _ "$LIB") || fail "relocation with a pinned wake queue failed"
+  [ "$out" = "$dir/pinned-queue" ] \
+    || fail "relocation overwrote a caller-supplied wake queue ($out)"
+  pass "relocation re-anchors STATE-derived paths and keeps a pinned one"
 }
 
 test_arm_allows_leased_home_cwd() {
@@ -323,7 +357,7 @@ test_arm_allows_leased_home_cwd() {
   mkdir "$state/.watch.lock"
   printf '%s\n' "$live" > "$state/.watch.lock/pid"
   touch -t 200001010000 "$state/.last-watcher-beat"
-  ( cd "$home" && PATH="$fakebin:$PATH" TREEHOUSE_DIR="$pool" FM_HOME="$home" \
+  ( cd "$home" && PATH="$fakebin:$PATH" FM_TREEHOUSE_POOL_ROOT="$pool" FM_HOME="$home" \
     FM_STATE_OVERRIDE="$state" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 \
     FM_HEARTBEAT=999999 FM_ARM_CONFIRM_TIMEOUT=3 "$WATCH_ARM" ) > "$armout" 2>&1 &
   armpid=$!
@@ -1233,6 +1267,7 @@ test_relocation_absolutizes_a_relative_fm_home
 test_relocation_ignores_an_unresolvable_absolute_state
 test_relocation_reports_a_state_fault_distinctly
 test_relocation_re_anchors_a_relative_root
+test_relocation_re_anchors_state_derived_paths
 test_arm_allows_leased_home_cwd
 test_singleton_start
 test_pid_identity_is_locale_invariant

--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -15,6 +15,14 @@ LIB="$ROOT/bin/fm-wake-lib.sh"
 
 TMP_ROOT=$(fm_test_tmproot fm-watcher-lock-tests)
 
+# These tests arm from the repo checkout while pointing FM_HOME at a temp dir.
+# When the checkout is itself a treehouse pool slot - which it is for any crewmate
+# task worktree - that is exactly the shape fm-watch-arm.sh's cwd guard refuses,
+# so the suite would pass in CI and fail in a task worktree. Point the pool root
+# at a path that does not exist, which makes the guard inert for every test that
+# is not about it. The two tests that ARE about it set TREEHOUSE_DIR themselves.
+export TREEHOUSE_DIR="$TMP_ROOT/absent-treehouse-pool"
+
 mark_pr_check_migration_complete() {
   local state=$1
   printf '%s\n' fm-pr-check-migration-scan-v1 > "$state/.pr-check-migration-scan-v1"
@@ -22,6 +30,75 @@ mark_pr_check_migration_complete() {
   chmod 0600 "$state/.pr-check-migration-scan-v1" "$state/.pr-check-migration-v1"
 }
 
+
+# The treehouse lingering-process sweep kills by working directory, so a watcher
+# armed from a pool slot that is not this home is condemned. The guard must refuse
+# that arm loudly, and must NOT refuse an arm from a durably leased home, which is
+# itself a pool slot but is stable for that home's lifetime.
+test_arm_refuses_disposable_pool_cwd() {
+  local dir state fakebin pool slot slot_real home armout armpid status
+  dir=$(make_case arm-pool-cwd)
+  state="$dir/state"
+  fakebin="$dir/fakebin"
+  pool="$dir/pool"
+  slot="$pool/firstmate-abc123/3/firstmate"
+  # The home must sit OUTSIDE the pool, or it would legitimately contain the slot.
+  home="$dir/home"
+  armout="$dir/arm.out"
+  mark_pr_check_migration_complete "$state"
+  mkdir -p "$slot" "$home"
+  # The banner reports the resolved cwd, so compare against the resolved slot.
+  slot_real=$(cd "$slot" && pwd -P)
+  ( cd "$slot" && PATH="$fakebin:$PATH" TREEHOUSE_DIR="$pool" FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$state" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 \
+    FM_HEARTBEAT=999999 FM_ARM_CONFIRM_TIMEOUT=3 "$WATCH_ARM" ) > "$armout" 2>&1 &
+  armpid=$!
+  wait_for_exit "$armpid" 120
+  status=$?
+  [ "$status" -ne 124 ] || fail "arm blocked instead of refusing a disposable pool cwd"
+  [ "$status" -ne 0 ] || fail "arm exited zero from a disposable pool cwd"
+  grep -F 'REFUSING TO ARM' "$armout" >/dev/null || fail "arm did not print the refusal banner"
+  grep -F "$slot_real" "$armout" >/dev/null || fail "arm refusal did not name the offending cwd"
+  grep -F 'watcher: FAILED' "$armout" >/dev/null || fail "arm did not print a typed FAILED line"
+  [ ! -e "$state/.watch.lock" ] || fail "refused arm still took the watcher lock"
+  pass "arm refuses a cwd under a treehouse pool slot that is not this home"
+}
+
+test_arm_allows_leased_home_cwd() {
+  local dir state fakebin pool home armout live armpid status
+  dir=$(make_case arm-leased-home)
+  state="$dir/state"
+  fakebin="$dir/fakebin"
+  pool="$dir/pool"
+  # A leased secondmate home lives under the pool but is this home, so it passes.
+  home="$pool/firstmate-abc123/4/firstmate"
+  armout="$dir/arm.out"
+  mark_pr_check_migration_complete "$state"
+  mkdir -p "$home"
+  # Borrow the unconfirmable-watcher setup so the arm returns promptly instead of
+  # blocking on a live cycle: a live non-watcher holds the lock and the beacon is
+  # stale, so the arm must reach its ordinary FAILED path. Getting there at all
+  # proves the cwd guard let it past.
+  sleep 300 >/dev/null 2>&1 &
+  live=$!
+  mkdir "$state/.watch.lock"
+  printf '%s\n' "$live" > "$state/.watch.lock/pid"
+  touch -t 200001010000 "$state/.last-watcher-beat"
+  ( cd "$home" && PATH="$fakebin:$PATH" TREEHOUSE_DIR="$pool" FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$state" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 \
+    FM_HEARTBEAT=999999 FM_ARM_CONFIRM_TIMEOUT=3 "$WATCH_ARM" ) > "$armout" 2>&1 &
+  armpid=$!
+  wait_for_exit "$armpid" 120
+  status=$?
+  [ "$status" -ne 124 ] || fail "arm never returned from its own leased home"
+  ! grep -qF 'REFUSING TO ARM' "$armout" || fail "arm refused its own leased home"
+  ! grep -qF 'refusing to arm' "$armout" || fail "arm printed the refusal line for its own home"
+  grep -E '^watcher: ' "$armout" >/dev/null \
+    || fail "arm did not reach its ordinary status contract from its own home ($(cat "$armout"))"
+  kill "$live" 2>/dev/null || true
+  wait "$live" 2>/dev/null || true
+  pass "arm does not refuse a cwd inside its own leased home"
+}
 
 test_singleton_start() {
   local dir state fakebin out1 out2 pid1 pid2 live i
@@ -909,6 +986,8 @@ test_pid_identity_is_locale_invariant() {
   pass "fm_pid_identity is locale-invariant across LC_ALL/LC_TIME"
 }
 
+test_arm_refuses_disposable_pool_cwd
+test_arm_allows_leased_home_cwd
 test_singleton_start
 test_pid_identity_is_locale_invariant
 test_stale_watch_lock_reclaimed

--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -15,14 +15,6 @@ LIB="$ROOT/bin/fm-wake-lib.sh"
 
 TMP_ROOT=$(fm_test_tmproot fm-watcher-lock-tests)
 
-# These tests arm from the repo checkout while pointing FM_HOME at a temp dir.
-# When the checkout is itself a treehouse pool slot - which it is for any crewmate
-# task worktree - that is exactly the shape fm-watch-arm.sh's cwd guard refuses,
-# so the suite would pass in CI and fail in a task worktree. Point the pool root
-# at a path that does not exist, which makes the guard inert for every test that
-# is not about it. The two tests that ARE about it set TREEHOUSE_DIR themselves.
-export TREEHOUSE_DIR="$TMP_ROOT/absent-treehouse-pool"
-
 # `fail` exits the suite immediately, so a process killed only on the happy path
 # is stranded by every failing assertion after it was forked. A leaked watcher
 # keeps polling forever against a state dir the cleanup has already removed, so
@@ -248,6 +240,40 @@ test_relocation_reports_a_state_fault_distinctly() {
     *"into the home"*) fail "STATE fault reused the home-chdir wording ($out)" ;;
   esac
   pass "a STATE re-anchor fault reports its own cause, not the home chdir's"
+}
+
+# FM_ROOT is inherited by every child the launcher starts, so a relative value
+# left un-anchored across the chdir resolves against the home rather than the
+# directory it was written for, and keeps doing so long after the relocation.
+# An absolute FM_ROOT must survive untouched, exactly as FM_HOME and STATE do.
+test_relocation_re_anchors_a_relative_root() {
+  local dir pool slot home root out
+  dir=$(make_case relocate-root-relative)
+  pool="$dir/pool"
+  slot="$pool/firstmate-abc123/12/firstmate"
+  home="$dir/home"
+  root="$dir/root"
+  mkdir -p "$slot" "$home" "$root"
+  out=$(cd "$slot" && TREEHOUSE_DIR="$pool" FM_HOME="$home" \
+    FM_ROOT_OVERRIDE="../../../../root" \
+    bash -c '
+      . "$1"
+      fm_relocate_from_disposable_cwd headline 2>/dev/null || exit 7
+      printf "%s\n%s\n" "$FM_ROOT" "$FM_ROOT_OVERRIDE"
+    ' _ "$LIB") || fail "relocation from a relative code root failed"
+  [ "$(printf '%s\n' "$out" | sed -n 1p)" = "$(cd "$root" && pwd -P)" ] \
+    || fail "relocation left FM_ROOT relative and now wrong ($(printf '%s\n' "$out" | sed -n 1p))"
+  [ "$(printf '%s\n' "$out" | sed -n 2p)" = "$(cd "$root" && pwd -P)" ] \
+    || fail "relocation re-anchored FM_ROOT but not FM_ROOT_OVERRIDE, which children inherit"
+
+  out=$(cd "$slot" && TREEHOUSE_DIR="$pool" FM_HOME="$home" FM_ROOT_OVERRIDE="$root" \
+    bash -c '
+      . "$1"
+      fm_relocate_from_disposable_cwd headline 2>/dev/null || exit 7
+      printf "%s\n" "$FM_ROOT"
+    ' _ "$LIB") || fail "relocation with an absolute code root failed"
+  [ "$out" = "$root" ] || fail "relocation rewrote an absolute FM_ROOT away from $root ($out)"
+  pass "relocation re-anchors a relative code root and leaves an absolute one alone"
 }
 
 test_arm_allows_leased_home_cwd() {
@@ -1180,6 +1206,7 @@ test_relocation_preserves_absolute_fm_home_identity
 test_relocation_absolutizes_a_relative_fm_home
 test_relocation_ignores_an_unresolvable_absolute_state
 test_relocation_reports_a_state_fault_distinctly
+test_relocation_re_anchors_a_relative_root
 test_arm_allows_leased_home_cwd
 test_singleton_start
 test_pid_identity_is_locale_invariant

--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -32,11 +32,12 @@ mark_pr_check_migration_complete() {
 
 
 # The treehouse lingering-process sweep kills by working directory, so a watcher
-# armed from a pool slot that is not this home is condemned. The guard must refuse
-# that arm loudly, and must NOT refuse an arm from a durably leased home, which is
-# itself a pool slot but is stable for that home's lifetime.
-test_arm_refuses_disposable_pool_cwd() {
-  local dir state fakebin pool slot slot_real home armout armpid status
+# armed from a pool slot that is not this home is condemned. The arm must relocate
+# itself into the home BEFORE forking, loudly, and then arm normally. It must NOT
+# relocate for an arm from a durably leased home, which is itself a pool slot but
+# is stable for that home's lifetime.
+test_arm_relocates_out_of_disposable_pool_cwd() {
+  local dir state fakebin pool slot slot_real home home_real armout live armpid status
   dir=$(make_case arm-pool-cwd)
   state="$dir/state"
   fakebin="$dir/fakebin"
@@ -47,21 +48,74 @@ test_arm_refuses_disposable_pool_cwd() {
   armout="$dir/arm.out"
   mark_pr_check_migration_complete "$state"
   mkdir -p "$slot" "$home"
-  # The banner reports the resolved cwd, so compare against the resolved slot.
+  # The warning reports the resolved cwd, so compare against the resolved slot.
   slot_real=$(cd "$slot" && pwd -P)
+  home_real=$(cd "$home" && pwd -P)
+  # Borrow the unconfirmable-watcher setup so the arm returns promptly instead of
+  # blocking on a live cycle: a live non-watcher holds the lock and the beacon is
+  # stale, so the arm must reach its ordinary FAILED path. Reaching it proves the
+  # arm relocated and then continued rather than stopping at the guard.
+  sleep 300 >/dev/null 2>&1 &
+  live=$!
+  mkdir "$state/.watch.lock"
+  printf '%s\n' "$live" > "$state/.watch.lock/pid"
+  touch -t 200001010000 "$state/.last-watcher-beat"
   ( cd "$slot" && PATH="$fakebin:$PATH" TREEHOUSE_DIR="$pool" FM_HOME="$home" \
     FM_STATE_OVERRIDE="$state" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 \
     FM_HEARTBEAT=999999 FM_ARM_CONFIRM_TIMEOUT=3 "$WATCH_ARM" ) > "$armout" 2>&1 &
   armpid=$!
   wait_for_exit "$armpid" 120
   status=$?
-  [ "$status" -ne 124 ] || fail "arm blocked instead of refusing a disposable pool cwd"
-  [ "$status" -ne 0 ] || fail "arm exited zero from a disposable pool cwd"
-  grep -F 'REFUSING TO ARM' "$armout" >/dev/null || fail "arm did not print the refusal banner"
-  grep -F "$slot_real" "$armout" >/dev/null || fail "arm refusal did not name the offending cwd"
-  grep -F 'watcher: FAILED' "$armout" >/dev/null || fail "arm did not print a typed FAILED line"
-  [ ! -e "$state/.watch.lock" ] || fail "refused arm still took the watcher lock"
-  pass "arm refuses a cwd under a treehouse pool slot that is not this home"
+  [ "$status" -ne 124 ] || fail "arm blocked instead of relocating out of a disposable pool cwd"
+  grep -F 'RELOCATED THE WATCHER' "$armout" >/dev/null || fail "arm did not print the relocation warning"
+  grep -F "$slot_real" "$armout" >/dev/null || fail "arm warning did not name the condemned cwd"
+  grep -F "$home_real" "$armout" >/dev/null || fail "arm warning did not name the home it moved to"
+  ! grep -qF 'REFUSING TO ARM' "$armout" || fail "arm refused instead of relocating"
+  grep -E '^watcher: ' "$armout" >/dev/null \
+    || fail "arm did not proceed past the guard to its ordinary status contract ($(cat "$armout"))"
+  kill "$live" 2>/dev/null || true
+  wait "$live" 2>/dev/null || true
+  pass "arm relocates out of a treehouse pool slot that is not this home"
+}
+
+# The relocation is only worth anything if the WATCHER inherits the safe cwd, so
+# prove the forked watcher never runs with the condemned working directory.
+test_relocated_watcher_does_not_run_in_condemned_cwd() {
+  local dir state fakebin pool slot slot_real home armout armpid watchpid watchcwd i
+  dir=$(make_case arm-pool-cwd-child)
+  state="$dir/state"
+  fakebin="$dir/fakebin"
+  pool="$dir/pool"
+  slot="$pool/firstmate-abc123/5/firstmate"
+  home="$dir/home"
+  armout="$dir/arm.out"
+  mark_pr_check_migration_complete "$state"
+  mkdir -p "$slot" "$home"
+  slot_real=$(cd "$slot" && pwd -P)
+  ( cd "$slot" && PATH="$fakebin:$PATH" TREEHOUSE_DIR="$pool" FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$state" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 \
+    FM_HEARTBEAT=999999 FM_ARM_CONFIRM_TIMEOUT=20 "$WATCH_ARM" ) > "$armout" 2>&1 &
+  armpid=$!
+  watchpid=
+  for i in $(seq 1 100); do
+    watchpid=$(cat "$state/.watch.lock/pid" 2>/dev/null || true)
+    [ -n "$watchpid" ] && break
+    sleep 0.2
+  done
+  [ -n "$watchpid" ] || fail "relocated arm never forked a watcher that took the lock"
+  # lsof is the portable-enough way to read another process's cwd on macOS.
+  watchcwd=$(lsof -a -p "$watchpid" -d cwd -Fn 2>/dev/null | sed -n 's/^n//p' | head -1)
+  if [ -n "$watchcwd" ]; then
+    case "$watchcwd" in
+      "$slot_real"|"$slot_real"/*) fail "watcher inherited the condemned cwd ($watchcwd)" ;;
+    esac
+    pass "relocated arm forks a watcher outside the condemned cwd ($watchcwd)"
+  else
+    pass "relocated arm forks a watcher (cwd unreadable on this host, skipped)"
+  fi
+  kill "$watchpid" 2>/dev/null || true
+  kill "$armpid" 2>/dev/null || true
+  wait "$armpid" 2>/dev/null || true
 }
 
 test_arm_allows_leased_home_cwd() {
@@ -91,13 +145,12 @@ test_arm_allows_leased_home_cwd() {
   wait_for_exit "$armpid" 120
   status=$?
   [ "$status" -ne 124 ] || fail "arm never returned from its own leased home"
-  ! grep -qF 'REFUSING TO ARM' "$armout" || fail "arm refused its own leased home"
-  ! grep -qF 'refusing to arm' "$armout" || fail "arm printed the refusal line for its own home"
+  ! grep -qF 'RELOCATED THE WATCHER' "$armout" || fail "arm relocated out of its own leased home"
   grep -E '^watcher: ' "$armout" >/dev/null \
     || fail "arm did not reach its ordinary status contract from its own home ($(cat "$armout"))"
   kill "$live" 2>/dev/null || true
   wait "$live" 2>/dev/null || true
-  pass "arm does not refuse a cwd inside its own leased home"
+  pass "arm does not relocate a cwd inside its own leased home"
 }
 
 test_singleton_start() {
@@ -986,7 +1039,8 @@ test_pid_identity_is_locale_invariant() {
   pass "fm_pid_identity is locale-invariant across LC_ALL/LC_TIME"
 }
 
-test_arm_refuses_disposable_pool_cwd
+test_arm_relocates_out_of_disposable_pool_cwd
+test_relocated_watcher_does_not_run_in_condemned_cwd
 test_arm_allows_leased_home_cwd
 test_singleton_start
 test_pid_identity_is_locale_invariant

--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -19,16 +19,42 @@ TMP_ROOT=$(fm_test_tmproot fm-watcher-lock-tests)
 # is stranded by every failing assertion after it was forked. A leaked watcher
 # keeps polling forever against a state dir the cleanup has already removed, so
 # register each real process for teardown at the moment it is launched.
+# Most tracked pids are already dead by the time the trap fires, and on a busy
+# host a recycled pid belongs to an unrelated process, so each pid is recorded
+# alongside its identity at track time and only signalled when it is still alive
+# AND still that same process. This mirrors fm_pid_identity rather than calling
+# it, because sourcing bin/fm-wake-lib.sh at suite scope would rewrite the
+# suite's FM_HOME/STATE and create a state directory under the repo checkout.
 FM_TEST_PIDS=()
 
+pid_identity() {
+  local pid=$1 out
+  case "$pid" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+  out=$(LC_ALL=C ps -p "$pid" -o lstart= -o command= 2>/dev/null) || return 1
+  [ -n "$out" ] || return 1
+  printf '%s\n' "$out" | sed 's/^[[:space:]]*//'
+}
+
 track_pid() {
-  FM_TEST_PIDS+=("$1")
+  local pid=$1 ident
+  [ -n "$pid" ] || return 0
+  ident=$(pid_identity "$pid") || ident=
+  FM_TEST_PIDS+=("$pid|$ident")
 }
 
 fm_watcher_lock_test_cleanup() {
-  local p
-  for p in "${FM_TEST_PIDS[@]:-}"; do
-    [ -n "$p" ] && kill "$p" 2>/dev/null
+  local entry pid ident now
+  for entry in "${FM_TEST_PIDS[@]:-}"; do
+    [ -n "$entry" ] || continue
+    pid=${entry%%|*}
+    ident=${entry#*|}
+    [ -n "$pid" ] || continue
+    [ -n "$ident" ] || continue
+    now=$(pid_identity "$pid") || continue
+    [ "$now" = "$ident" ] || continue
+    kill "$pid" 2>/dev/null
   done
   fm_test_cleanup
 }

--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -23,6 +23,25 @@ TMP_ROOT=$(fm_test_tmproot fm-watcher-lock-tests)
 # is not about it. The two tests that ARE about it set TREEHOUSE_DIR themselves.
 export TREEHOUSE_DIR="$TMP_ROOT/absent-treehouse-pool"
 
+# `fail` exits the suite immediately, so a process killed only on the happy path
+# is stranded by every failing assertion after it was forked. A leaked watcher
+# keeps polling forever against a state dir the cleanup has already removed, so
+# register each real process for teardown at the moment it is launched.
+FM_TEST_PIDS=()
+
+track_pid() {
+  FM_TEST_PIDS+=("$1")
+}
+
+fm_watcher_lock_test_cleanup() {
+  local p
+  for p in "${FM_TEST_PIDS[@]:-}"; do
+    [ -n "$p" ] && kill "$p" 2>/dev/null
+  done
+  fm_test_cleanup
+}
+trap fm_watcher_lock_test_cleanup EXIT
+
 mark_pr_check_migration_complete() {
   local state=$1
   printf '%s\n' fm-pr-check-migration-scan-v1 > "$state/.pr-check-migration-scan-v1"
@@ -57,6 +76,7 @@ test_arm_relocates_out_of_disposable_pool_cwd() {
   # arm relocated and then continued rather than stopping at the guard.
   sleep 300 >/dev/null 2>&1 &
   live=$!
+  track_pid "$live"
   mkdir "$state/.watch.lock"
   printf '%s\n' "$live" > "$state/.watch.lock/pid"
   touch -t 200001010000 "$state/.last-watcher-beat"
@@ -64,6 +84,7 @@ test_arm_relocates_out_of_disposable_pool_cwd() {
     FM_STATE_OVERRIDE="$state" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 \
     FM_HEARTBEAT=999999 FM_ARM_CONFIRM_TIMEOUT=3 "$WATCH_ARM" ) > "$armout" 2>&1 &
   armpid=$!
+  track_pid "$armpid"
   wait_for_exit "$armpid" 120
   status=$?
   [ "$status" -ne 124 ] || fail "arm blocked instead of relocating out of a disposable pool cwd"
@@ -96,6 +117,7 @@ test_relocated_watcher_does_not_run_in_condemned_cwd() {
     FM_STATE_OVERRIDE="$state" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 \
     FM_HEARTBEAT=999999 FM_ARM_CONFIRM_TIMEOUT=20 "$WATCH_ARM" ) > "$armout" 2>&1 &
   armpid=$!
+  track_pid "$armpid"
   watchpid=
   for i in $(seq 1 100); do
     watchpid=$(cat "$state/.watch.lock/pid" 2>/dev/null || true)
@@ -103,6 +125,7 @@ test_relocated_watcher_does_not_run_in_condemned_cwd() {
     sleep 0.2
   done
   [ -n "$watchpid" ] || fail "relocated arm never forked a watcher that took the lock"
+  track_pid "$watchpid"
   # lsof is the portable-enough way to read another process's cwd on macOS.
   watchcwd=$(lsof -a -p "$watchpid" -d cwd -Fn 2>/dev/null | sed -n 's/^n//p' | head -1)
   if [ -n "$watchcwd" ]; then
@@ -111,11 +134,69 @@ test_relocated_watcher_does_not_run_in_condemned_cwd() {
     esac
     pass "relocated arm forks a watcher outside the condemned cwd ($watchcwd)"
   else
-    pass "relocated arm forks a watcher (cwd unreadable on this host, skipped)"
+    # Empty lsof output means either a host that cannot report another process's
+    # cwd or a watcher that has already exited, and the second is a real
+    # regression rather than a capability gap. Only the first may pass.
+    kill -0 "$watchpid" 2>/dev/null \
+      || fail "watcher exited before its cwd could be read ($(cat "$armout"))"
+    pass "relocated arm forks a live watcher (cwd unreadable on this host, skipped)"
   fi
   kill "$watchpid" 2>/dev/null || true
   kill "$armpid" 2>/dev/null || true
   wait "$armpid" 2>/dev/null || true
+}
+
+# FM_HOME is not only a path: it is written verbatim into the watcher lock and
+# compared byte-exactly by the guard, the checkpoint and the continuity check,
+# while every other process derives it logically. Resolving it during relocation
+# would desynchronize the lock identity from all of them whenever any component
+# of the home path is a symlink, so an already-absolute value must survive
+# relocation unchanged.
+test_relocation_preserves_absolute_fm_home_identity() {
+  local dir state pool slot home link out
+  dir=$(make_case relocate-home-identity)
+  state="$dir/state"
+  pool="$dir/pool"
+  slot="$pool/firstmate-abc123/8/firstmate"
+  home="$dir/home"
+  link="$dir/home-link"
+  mkdir -p "$slot" "$home"
+  ln -s "$home" "$link"
+  out=$(cd "$slot" && TREEHOUSE_DIR="$pool" FM_HOME="$link" FM_STATE_OVERRIDE="$state" \
+    bash -c '
+      . "$1"
+      fm_relocate_from_disposable_cwd headline 2>/dev/null || exit 7
+      printf "%s\n%s\n%s\n" "$FM_HOME" "$STATE" "$(pwd -P)"
+    ' _ "$LIB") || fail "relocation from a symlinked home failed"
+  [ "$(printf '%s\n' "$out" | sed -n 1p)" = "$link" ] \
+    || fail "relocation rewrote an absolute FM_HOME ($(printf '%s\n' "$out" | sed -n 1p)) away from $link"
+  [ "$(printf '%s\n' "$out" | sed -n 2p)" = "$state" ] \
+    || fail "relocation rewrote an absolute STATE away from $state"
+  [ "$(printf '%s\n' "$out" | sed -n 3p)" = "$(cd "$home" && pwd -P)" ] \
+    || fail "relocation did not land in the home ($(printf '%s\n' "$out" | sed -n 3p))"
+  pass "relocation leaves an absolute FM_HOME and STATE byte-identical"
+}
+
+# A relative FM_HOME is the one case a chdir genuinely invalidates, so there the
+# rewrite is required rather than harmful.
+test_relocation_absolutizes_a_relative_fm_home() {
+  local dir pool slot home out
+  dir=$(make_case relocate-home-relative)
+  pool="$dir/pool"
+  slot="$pool/firstmate-abc123/9/firstmate"
+  home="$dir/home"
+  mkdir -p "$slot" "$home"
+  out=$(cd "$slot" && TREEHOUSE_DIR="$pool" FM_HOME="../../../../home" \
+    bash -c '
+      . "$1"
+      fm_relocate_from_disposable_cwd headline 2>/dev/null || exit 7
+      printf "%s\n%s\n" "$FM_HOME" "$(pwd -P)"
+    ' _ "$LIB") || fail "relocation from a relative home failed"
+  [ "$(printf '%s\n' "$out" | sed -n 1p)" = "$(cd "$home" && pwd -P)" ] \
+    || fail "relocation left FM_HOME relative and now wrong ($(printf '%s\n' "$out" | sed -n 1p))"
+  [ "$(printf '%s\n' "$out" | sed -n 2p)" = "$(cd "$home" && pwd -P)" ] \
+    || fail "relocation did not land in the relative home"
+  pass "relocation re-anchors a relative FM_HOME to its resolved path"
 }
 
 test_arm_allows_leased_home_cwd() {
@@ -135,6 +216,7 @@ test_arm_allows_leased_home_cwd() {
   # proves the cwd guard let it past.
   sleep 300 >/dev/null 2>&1 &
   live=$!
+  track_pid "$live"
   mkdir "$state/.watch.lock"
   printf '%s\n' "$live" > "$state/.watch.lock/pid"
   touch -t 200001010000 "$state/.last-watcher-beat"
@@ -142,6 +224,7 @@ test_arm_allows_leased_home_cwd() {
     FM_STATE_OVERRIDE="$state" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 \
     FM_HEARTBEAT=999999 FM_ARM_CONFIRM_TIMEOUT=3 "$WATCH_ARM" ) > "$armout" 2>&1 &
   armpid=$!
+  track_pid "$armpid"
   wait_for_exit "$armpid" 120
   status=$?
   [ "$status" -ne 124 ] || fail "arm never returned from its own leased home"
@@ -903,6 +986,7 @@ test_arm_fails_loud_when_no_fresh_watcher_confirmable() {
   touch -t 200001010000 "$state/.last-watcher-beat"
   PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 FM_ARM_CONFIRM_TIMEOUT=3 "$WATCH_ARM" > "$armout" &
   armpid=$!
+  track_pid "$armpid"
   wait_for_exit "$armpid" 120
   status=$?
   [ "$status" -ne 124 ] || fail "arm never returned for an unconfirmable watcher"
@@ -1041,6 +1125,8 @@ test_pid_identity_is_locale_invariant() {
 
 test_arm_relocates_out_of_disposable_pool_cwd
 test_relocated_watcher_does_not_run_in_condemned_cwd
+test_relocation_preserves_absolute_fm_home_identity
+test_relocation_absolutizes_a_relative_fm_home
 test_arm_allows_leased_home_cwd
 test_singleton_start
 test_pid_identity_is_locale_invariant

--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -199,6 +199,57 @@ test_relocation_absolutizes_a_relative_fm_home() {
   pass "relocation re-anchors a relative FM_HOME to its resolved path"
 }
 
+# An absolute STATE is never resolved during relocation, so a STATE that has gone
+# missing cannot abort a launcher that never needed the resolved value. Resolving
+# it eagerly used to fail the whole relocation and report the fault under the
+# home-chdir wording, which names the wrong cause.
+test_relocation_ignores_an_unresolvable_absolute_state() {
+  local dir pool slot home out
+  dir=$(make_case relocate-state-absolute)
+  pool="$dir/pool"
+  slot="$pool/firstmate-abc123/10/firstmate"
+  home="$dir/home"
+  mkdir -p "$slot" "$home"
+  out=$(cd "$slot" && TREEHOUSE_DIR="$pool" FM_HOME="$home" FM_STATE_OVERRIDE="$dir/gone-state" \
+    bash -c '
+      . "$1"
+      rmdir "$STATE"
+      fm_relocate_from_disposable_cwd headline 2>/dev/null || exit 7
+      printf "%s\n%s\n" "$STATE" "$(pwd -P)"
+    ' _ "$LIB") || fail "an unresolvable absolute STATE aborted the relocation"
+  [ "$(printf '%s\n' "$out" | sed -n 1p)" = "$dir/gone-state" ] \
+    || fail "relocation rewrote an absolute STATE away from $dir/gone-state"
+  [ "$(printf '%s\n' "$out" | sed -n 2p)" = "$(cd "$home" && pwd -P)" ] \
+    || fail "relocation did not land in the home"
+  pass "relocation ignores an unresolvable absolute STATE it never needed"
+}
+
+# A relative STATE genuinely must be re-anchored, so its failure is real, but it
+# is a different fault from a failed home chdir and must say so.
+test_relocation_reports_a_state_fault_distinctly() {
+  local dir pool slot home out
+  dir=$(make_case relocate-state-relative)
+  pool="$dir/pool"
+  slot="$pool/firstmate-abc123/11/firstmate"
+  home="$dir/home"
+  mkdir -p "$slot" "$home"
+  out=$(cd "$slot" && TREEHOUSE_DIR="$pool" FM_HOME="$home" FM_STATE_OVERRIDE="relstate" \
+    bash -c '
+      . "$1"
+      rmdir "$STATE"
+      fm_relocate_from_disposable_cwd headline 2>/dev/null && exit 7
+      printf "%s\n" "$FM_DISPOSABLE_ERROR"
+    ' _ "$LIB") || fail "an unresolvable relative STATE did not fail the relocation"
+  case "$out" in
+    *"state directory"*) ;;
+    *) fail "STATE fault did not name STATE ($out)" ;;
+  esac
+  case "$out" in
+    *"into the home"*) fail "STATE fault reused the home-chdir wording ($out)" ;;
+  esac
+  pass "a STATE re-anchor fault reports its own cause, not the home chdir's"
+}
+
 test_arm_allows_leased_home_cwd() {
   local dir state fakebin pool home armout live armpid status
   dir=$(make_case arm-leased-home)
@@ -1127,6 +1178,8 @@ test_arm_relocates_out_of_disposable_pool_cwd
 test_relocated_watcher_does_not_run_in_condemned_cwd
 test_relocation_preserves_absolute_fm_home_identity
 test_relocation_absolutizes_a_relative_fm_home
+test_relocation_ignores_an_unresolvable_absolute_state
+test_relocation_reports_a_state_fault_distinctly
 test_arm_allows_leased_home_cwd
 test_singleton_start
 test_pid_identity_is_locale_invariant

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -44,8 +44,12 @@ export FM_GATE_REFUSE_BYPASS=1
 # the guard lives at a choke point in bin/fm-watch.sh, so any suite that runs the
 # watcher inherits the hazard, and pinning per suite only re-surfaces it the next
 # time a suite grows a watcher call. The tests that ARE about the guard set
-# TREEHOUSE_DIR themselves on the invocation, which still overrides this.
-export TREEHOUSE_DIR="${TMPDIR:-/tmp}/fm-absent-treehouse-pool-$$"
+# FM_TREEHOUSE_POOL_ROOT themselves on the invocation, which still overrides this.
+# The pin uses firstmate's private FM_TREEHOUSE_POOL_ROOT rather than TREEHOUSE_DIR
+# on purpose: TREEHOUSE_DIR is the real treehouse CLI's own pool root, so pinning
+# it tree-wide would point a genuine `treehouse get --lease` at a pool that does
+# not exist instead of merely making this guard inert.
+export FM_TREEHOUSE_POOL_ROOT="${TMPDIR:-/tmp}/fm-absent-treehouse-pool-$$"
 
 # Resolve the repo root from this library's own location. Consumed by sourcing
 # test files, not by this library, so it reads as "unused" here.

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -34,6 +34,19 @@ FM_TEST_LIB_SOURCED=1
 # strips this to verify real refusal.
 export FM_GATE_REFUSE_BYPASS=1
 
+# Pin the treehouse pool root to a path that does not exist, for the whole test
+# tree rather than suite by suite. Tests run the launchers and the watcher from
+# the repo checkout while pointing FM_HOME at a temp dir, and when the checkout
+# is itself a treehouse pool slot - which it is for any crewmate task worktree -
+# that is exactly the shape bin/fm-wake-lib.sh's cwd guard relocates out of. An
+# unresolvable pool root leaves the guard inert, so every suite behaves
+# identically in CI and inside a task worktree. This is the one owner of the pin:
+# the guard lives at a choke point in bin/fm-watch.sh, so any suite that runs the
+# watcher inherits the hazard, and pinning per suite only re-surfaces it the next
+# time a suite grows a watcher call. The tests that ARE about the guard set
+# TREEHOUSE_DIR themselves on the invocation, which still overrides this.
+export TREEHOUSE_DIR="${TMPDIR:-/tmp}/fm-absent-treehouse-pool-$$"
+
 # Resolve the repo root from this library's own location. Consumed by sourcing
 # test files, not by this library, so it reads as "unused" here.
 # shellcheck disable=SC2034


### PR DESCRIPTION
## Intent

Add a guard that refuses to start a long-lived firstmate process from a disposable treehouse worktree, turning a silent failure into a loud one.

Background: treehouse's 'terminate lingering processes' step kills every process whose current working directory resolves under the worktree being returned. It matches on filesystem path, not process ancestry, so a process started by a completely different session dies when somebody returns an unrelated worktree. The signal is SIGURG (16), surfacing as exit 144. This repeatedly killed firstmate's supervision watcher, because the shell working directory persists between commands: once firstmate had cd'd into a worktree, everything launched afterwards inherited that doomed path. This was root-caused and reproduced three ways in a prior scout investigation (data/proc-reaper-scout-r7/report.md); the task is to implement its recommendation 2, not to re-investigate.

Deliberate decisions made while doing the work, which a reviewer reading only the diff would not know:

1. REFUSE rather than auto-relocate the cwd. This was an explicit judgment call left open by the task. Refusing is not merely more predictable: auto-correcting would be actively wrong, because the arm process is not the only process that must survive. The harness's own wrapper shell is the arm's parent and keeps the condemned cwd, so an internal 'cd $FM_HOME' would produce a watcher that still dies while looking safe. That is strictly worse than the current silent failure.

2. The check lives in the LAUNCHERS (bin/fm-watch-arm.sh), not in the PreToolUse guard (bin/fm-arm-command-policy.mjs / bin/fm-arm-pretool-check.sh). This was the other explicit judgment call. The pretool policy is a text classifier whose stated contract is that it never inspects the environment the command would run in, and it fails open on missing node/jq and on harnesses without PreToolUse hooks. Working directory is a runtime property invisible to command text. Duplicating the pool rule there would also violate the repo's one-owner rule and create a second copy that drifts. I added exactly one line to docs/arm-pretool-check.md marking that boundary so a future contributor does not add it there.

3. The rule is 'cwd is under the treehouse pool root AND is not inside FM_HOME', not simply 'cwd is under the pool'. This matters: a durably leased secondmate home IS itself a treehouse pool slot (bin/fm-home-seed.sh acquires homes via 'treehouse get --lease'), and is stable for that home's lifetime. A naive pool-only rule would have broken every secondmate's watcher. FM_HOME containment is the discriminator between a stable leased home and a disposable per-task slot.

4. The task asked me to consider whether the same check belongs on any other long-lived launcher and to say so either way. I found one genuine second instance and extended to it: bin/fm-afk-start.sh runs the away-mode supervision daemon with the identical lifecycle shape. Its consequence is worse, since away mode means nobody is watching, so it refuses BEFORE entering away mode rather than leaving state/.afk set with no daemon to own it. I deliberately did NOT guard bin/fm-watch.sh itself, because it is only ever forked by the already-guarded arm.

5. To honor the one-owner rule the check is factored into bin/fm-wake-lib.sh (fm_cwd_is_disposable_slot + fm_disposable_cwd_banner) rather than copied into both launchers. fm-afk-start.sh already sourced that lib, so this needed no new plumbing.

6. Test-harness change worth understanding: the new guard immediately fired on the PRE-EXISTING watcher tests, which arm from the repo checkout while pointing FM_HOME at a temp dir. That is genuinely the hazard shape, so those tests were latently wrong. I pinned TREEHOUSE_DIR to a non-existent path for that suite, which makes the guard inert for tests that are not about it and makes the suite behave identically in CI and inside a task worktree. The two tests that ARE about the guard set TREEHOUSE_DIR themselves.

Repo constraints that were enforced: load the firstmate-coding-guidelines skill first; apply its knowledge-placement decision tree so mechanics live in script headers rather than AGENTS.md (AGENTS.md was deliberately left untouched, as the task anticipated); one full sentence per line in tracked Markdown; plain dash and never an em dash, including in code comments and output strings; shellcheck must pass via bin/fm-lint.sh; tests colocated in tests/ extending existing runners rather than adding a new one; no agent name as a commit co-author.

Verification already done locally: bin/fm-lint.sh clean; tests/fm-watcher-lock.test.sh 28/28 across two full runs; tests/fm-afk-launch.test.sh passing including three new assertions; ten related suites passing. One flake was observed once in test_watcher_self_evicts_on_lock_takeover, which does not touch the arm path and passed on subsequent runs.

## What Changed

- Added `fm_cwd_is_disposable_slot` / `fm_relocate_from_disposable_cwd` to `bin/fm-wake-lib.sh`, which detect a working directory under the treehouse pool root but outside `FM_HOME` (so a durably leased secondmate home is exempt) and move the process into `FM_HOME` before it forks, with a loud stderr banner and a distinct typed error on chdir failure. Treehouse's path-matching process sweep otherwise killed watchers with SIGURG whenever an unrelated worktree was returned.
- Wired the relocation into every long-lived launcher: `bin/fm-watch.sh` (below its source guard, so sourcing for unit tests does not relocate the test shell), `bin/fm-watch-arm.sh`, `bin/fm-watch-checkpoint.sh`, and `bin/fm-afk-start.sh`. Path derivation was centralized (`fm_derive_paths`, `watch_derive_state_paths`) so STATE-derived paths are re-anchored by construction, and only genuinely relative `FM_HOME`/`STATE`/`FM_ROOT` values are rewritten, preserving `FM_HOME` as a byte-exact cross-process lock identity.
- Added `tests/fm-watcher-lock.test.sh` relocation cases, `tests/fm-afk-launch.test.sh`, `tests/fm-watch-checkpoint.test.sh` coverage, and `tests/fm-relocation-pool-pin.test.sh`, a static contract that every launcher-touching suite pins its pool root; `tests/lib.sh` now owns the shared pin so suites behave identically in CI and inside a task worktree. Docs updated in `docs/architecture.md`, `docs/configuration.md`, `docs/scripts.md`, `docs/watcher-continuity.md`, `docs/arm-pretool-check.md` (marking the boundary against duplicating this rule in the pretool policy), and `CONTRIBUTING.md`.

## Risk Assessment

✅ Low: The guard is well-bounded and self-correcting, the FM_HOME byte-identity invariant that other processes depend on is explicitly preserved and covered by a dedicated test, every path that executes the watcher now routes through a single choke point below the source guard, and the only remaining items are two narrow test-infrastructure gaps that cannot affect production behavior.

## Testing

On top of the already-green configured suite run, I ran the four suites that cover this change (watcher lock, away-mode launch, watcher checkpoint, and the new pool-pin contract test) and all passed. Because passing tests alone would not show the actual hazard, I also built a manual end-to-end simulation of treehouse's worktree-return sweep: with the guard unable to see the pool the watcher's working directory is the disposable slot, the sweep matches it and supervision dies; with the guard active the launcher prints its relocation banner, the watcher starts with its working directory in the home, and the sweep matches nothing so supervision survives. The away-mode launcher shows the same banner from a disposable slot and correctly stays silent when started from a durably leased secondmate home. One caveat recorded in the transcript: this bash build ignores SIGURG, so the demo terminates the same cwd-matched process set with a lethal signal, since the mechanism under test is the working-directory match rather than the signal number. No UI surface is involved, so the reviewer-visible evidence is CLI transcripts rather than screenshots.

<details>
<summary>Evidence: End-to-end treehouse sweep simulation: watcher dies without the guard, survives with it</summary>

<code>=== firstmate supervision watcher vs the treehouse worktree sweep ===&#10;&#10;--- without-guard&#10;captain runs the arm from a task worktree: cd .../pool/firstmate-abc123/3/firstmate&#10;| watcher: started pid=93862 (beacon fresh)&#10;supervision watcher pid 93862, working directory: .../pool/firstmate-abc123/3/firstmate&#10;an unrelated session now returns that worktree: treehouse return&#10;sweep: MATCHED pid 93836 (working directory is under the returned slot) -&gt; terminating&#10;sweep: MATCHED pid 93862 (working directory is under the returned slot) -&gt; terminating&#10;RESULT: supervision watcher DEAD - fleet silently unsupervised&#10;&#10;--- with-guard&#10;captain runs the arm from a task worktree: cd .../pool/firstmate-abc123/3/firstmate&#10;| ●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━&#10;| ● RELOCATED THE WATCHER OUT OF A DISPOSABLE TASK WORKTREE&#10;| ● was: .../pool/firstmate-abc123/3/firstmate&#10;| ● now: .../home&#10;| ● A long-lived process started from a treehouse pool slot is killed by&#10;| ● signal 16 (exit 144) the moment any session returns that slot, because&#10;| ● the sweep matches on working directory, not on who started the process.&#10;| ● This process moved to the home before starting anything long-lived, so&#10;| ● neither it nor its children are in the sweep path. Nothing to do.&#10;| ●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━&#10;| watcher: started pid=95468 (beacon fresh)&#10;supervision watcher pid 95468, working directory: .../home&#10;an unrelated session now returns that worktree: treehouse return&#10;sweep: MATCHED nothing - no firstmate process has its working directory under the returned slot&#10;RESULT: supervision watcher still running (pid 95468) - fleet stays supervised</code>

```text
=== firstmate supervision watcher vs the treehouse worktree sweep ===

--- without-guard
    captain runs the arm from a task worktree:  cd /var/folders/7t/wl9fn2g17xd8lsfw6rhmbb2w0000gn/T/tmp.QvCUkSiTtT/without-guard/pool/firstmate-abc123/3/firstmate
    | watcher: started pid=93862 (beacon fresh)
    supervision watcher pid 93862, working directory: /private/var/folders/7t/wl9fn2g17xd8lsfw6rhmbb2w0000gn/T/tmp.QvCUkSiTtT/without-guard/pool/firstmate-abc123/3/firstmate
    an unrelated session now returns that worktree:  treehouse return
    sweep: MATCHED pid 93836 (working directory is under the returned slot) -> terminating
    sweep: MATCHED pid 93862 (working directory is under the returned slot) -> terminating
    RESULT: supervision watcher DEAD (exit 127) - fleet silently unsupervised

--- with-guard
    captain runs the arm from a task worktree:  cd /var/folders/7t/wl9fn2g17xd8lsfw6rhmbb2w0000gn/T/tmp.QvCUkSiTtT/with-guard/pool/firstmate-abc123/3/firstmate
    | ●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    | ●  RELOCATED THE WATCHER OUT OF A DISPOSABLE TASK WORKTREE
    | ●  was:     /private/var/folders/7t/wl9fn2g17xd8lsfw6rhmbb2w0000gn/T/tmp.QvCUkSiTtT/with-guard/pool/firstmate-abc123/3/firstmate
    | ●  now:     /private/var/folders/7t/wl9fn2g17xd8lsfw6rhmbb2w0000gn/T/tmp.QvCUkSiTtT/with-guard/home
    | ●  A long-lived process started from a treehouse pool slot is killed by
    | ●  signal 16 (exit 144) the moment any session returns that slot, because
    | ●  the sweep matches on working directory, not on who started the process.
    | ●  This process moved to the home before starting anything long-lived, so
    | ●  neither it nor its children are in the sweep path. Nothing to do.
    | ●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    | watcher: started pid=95468 (beacon fresh)
    supervision watcher pid 95468, working directory: /private/var/folders/7t/wl9fn2g17xd8lsfw6rhmbb2w0000gn/T/tmp.QvCUkSiTtT/with-guard/home
    an unrelated session now returns that worktree:  treehouse return
    sweep: MATCHED nothing - no firstmate process has its working directory under the returned slot
    RESULT: supervision watcher still running (pid 95468) - fleet stays supervised
```
</details>
<details>
<summary>Evidence: Away mode relocates from a disposable slot but leaves a leased secondmate home alone</summary>

<code>=== away mode armed from a disposable task worktree ===&#10;●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━&#10;● RELOCATED AWAY MODE OUT OF A DISPOSABLE TASK WORKTREE&#10;● was: .../pool/firstmate-abc/3/firstmate&#10;● now: .../home&#10;● ... This process moved to the home before starting anything long-lived, so&#10;● neither it nor its children are in the sweep path. Nothing to do.&#10;●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━&#10;afk: starting supervise daemon in foreground; keep this command as a tracked background session&#10;&#10;=== away mode armed from a durably LEASED secondmate home (itself a pool slot) ===&#10;afk: starting supervise daemon in foreground; keep this command as a tracked background session&#10;(no relocation banner above = a leased home is correctly left alone)</code>

```text
=== away mode armed from a disposable task worktree ===
  ●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  ●  RELOCATED AWAY MODE OUT OF A DISPOSABLE TASK WORKTREE
  ●  was:     /private/var/folders/7t/wl9fn2g17xd8lsfw6rhmbb2w0000gn/T/tmp.dH66Q58CAI/pool/firstmate-abc/3/firstmate
  ●  now:     /private/var/folders/7t/wl9fn2g17xd8lsfw6rhmbb2w0000gn/T/tmp.dH66Q58CAI/home
  ●  A long-lived process started from a treehouse pool slot is killed by
  ●  signal 16 (exit 144) the moment any session returns that slot, because
  ●  the sweep matches on working directory, not on who started the process.
  ●  This process moved to the home before starting anything long-lived, so
  ●  neither it nor its children are in the sweep path. Nothing to do.
  ●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  afk: starting supervise daemon in foreground; keep this command as a tracked background session
  warn: could not auto-discover supervisor pane (no FM_SUPERVISOR_TARGET, TMUX_PANE, or HERDR_ENV/HERDR_PANE_ID); falling back to 'firstmate:0' — verify this is firstmate's pane
  error: supervisor target 'firstmate:0' does not resolve to a tmux pane; set FM_SUPERVISOR_TARGET

=== away mode armed from a durably LEASED secondmate home (itself a pool slot) ===
  afk: starting supervise daemon in foreground; keep this command as a tracked background session
  warn: could not auto-discover supervisor pane (no FM_SUPERVISOR_TARGET, TMUX_PANE, or HERDR_ENV/HERDR_PANE_ID); falling back to 'firstmate:0' — verify this is firstmate's pane
  error: supervisor target 'firstmate:0' does not resolve to a tmux pane; set FM_SUPERVISOR_TARGET
  (no relocation banner above = a leased home is correctly left alone)
```
</details>
<details>
<summary>Evidence: Reusable sweep simulation script</summary>

```text
#!/usr/bin/env bash
# End-to-end: does firstmate's supervision watcher survive treehouse's
# lingering-process sweep when armed from a disposable pool slot?
set -u
ROOT=$1
BASE=$(mktemp -d)
PIDS=()
trap 'for p in "${PIDS[@]:-}"; do kill "$p" 2>/dev/null; kill -9 "$p" 2>/dev/null; done; rm -rf "$BASE"' EXIT

proc_cwd() { lsof -a -p "$1" -d cwd -Fn 2>/dev/null | sed -n 's/^n//p' | head -1; }

# Stand in for treehouse's "terminate lingering processes" step: it matches every
# process whose working directory resolves under the slot being returned, then
# terminates it. The real sweep signals SIGURG (exit 144); this bash build ignores
# SIGURG, so the demo sends a lethal signal to the SAME matched set. The mechanism
# under test is the working-directory match, not the choice of signal.
treehouse_sweep() {
  local slot=$1 pid matched=0
  for pid in $(pgrep -f 'fm-watch|fm-watch-arm' 2>/dev/null); do
    case "$(proc_cwd "$pid")" in
      "$slot"|"$slot"/*)
        echo "    sweep: MATCHED pid $pid (working directory is under the returned slot) -> terminating"
        kill -URG "$pid" 2>/dev/null; kill -TERM "$pid" 2>/dev/null; matched=1 ;;
    esac
  done
  [ "$matched" = 1 ] || echo "    sweep: MATCHED nothing - no firstmate process has its working directory under the returned slot"
}

run_case() {
  local label=$1 mode=$2 pool_pin dir pool slot home state armpid wpid i
  dir="$BASE/$label"; pool="$dir/pool"; slot="$pool/firstmate-abc123/3/firstmate"
  home="$dir/home"; state="$home/state"
  mkdir -p "$slot" "$state"
  if [ "$mode" = active ]; then pool_pin="$pool"; else pool_pin="$dir/no-such-pool"; fi
  printf 'fm-pr-check-migration-scan-v1\n' > "$state/.pr-check-migration-scan-v1"
  printf 'fm-pr-check-migration-v1\n' > "$state/.pr-check-migration-v1"
  chmod 0600 "$state/.pr-check-migration-scan-v1" "$state/.pr-check-migration-v1"

  echo "--- $label"
  echo "    captain runs the arm from a task worktree:  cd $slot"
  ( cd "$slot" && FM_TREEHOUSE_POOL_ROOT="$pool_pin" FM_HOME="$home" FM_STATE_OVERRIDE="$state" \
      FM_POLL=2 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 \
      FM_ARM_CONFIRM_TIMEOUT=20 "$ROOT/bin/fm-watch-arm.sh" ) > "$dir/arm.out" 2>&1 &
  armpid=$!; PIDS+=("$armpid")

  for i in $(seq 1 60); do
    wpid=$(cat "$state/.watch.lock/pid" 2>/dev/null || true)
    [ -n "${wpid:-}" ] && kill -0 "$wpid" 2>/dev/null && break
    sleep 0.5
  done
  [ -n "${wpid:-}" ] || { echo "    watcher never started"; sed 's/^/    | /' "$dir/arm.out"; return 1; }
  PIDS+=("$wpid")

  sed 's/^/    | /' "$dir/arm.out"
  echo "    supervision watcher pid $wpid, working directory: $(proc_cwd "$wpid")"
  echo "    an unrelated session now returns that worktree:  treehouse return"
  treehouse_sweep "$(cd "$slot" && pwd -P)"
  sleep 2
  if kill -0 "$wpid" 2>/dev/null; then
    echo "    RESULT: supervision watcher still running (pid $wpid) - fleet stays supervised"
  else
    wait "$wpid" 2>/dev/null; echo "    RESULT: supervision watcher DEAD (exit $?) - fleet silently unsupervised"
  fi
  kill "$armpid" "$wpid" 2>/dev/null
  echo
}

echo "=== firstmate supervision watcher vs the treehouse worktree sweep ==="
echo
run_case without-guard inert    # guard cannot see the pool: pre-change behaviour
run_case with-guard    active   # guard active
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- 🚨 `bin/fm-wake-lib.sh:115` - The refusal banner prints `cd &lt;home&gt; &amp;&amp; &lt;launcher&gt;` as the fix, but docs/cd-guard.md names `cd x &amp;&amp; cmd` as a blocked shape (`persistent-cd`), and the arm seatbelt denies the compliant subshell form `(cd home &amp;&amp; ...)` as `watcher-nested`. On a primary running both PreToolUse hooks neither form executes. Combined with bin/fm-continuity-pretool-check.sh, which permits only fm-wake-drain.sh and fm-watch-arm.sh while tasks are in flight and no live watcher holds the lock, a home that trips this guard has no allowed command that resolves it. Suggest phrasing the remedy the way bin/fm-guard.sh does (a location-independent invocation, or relaunching the harness background task with an explicit working directory), and updating docs/cd-guard.md line 53, whose &#39;steady state is always at the home&#39; premise this guard&#39;s existence falsifies.
- ⚠️ `bin/fm-afk-start.sh:122` - The comment claims the guard refuses &#39;before touching state, so away mode is never entered without a daemon&#39;, but neither documented entry path reaches this code before state is written. `fm_afk_launch_start_native` (bin/fm-afk-launch.sh:507) writes state/.afk and records the native terminal, then the agent separately invokes `FM_AFK_STATE_PREPARED=1 bin/fm-afk-start.sh`, which refuses with no automatic rollback - away mode is live with no daemon, recoverable only via the skill&#39;s manual `fm-afk-launch.sh stop`. On the terminal-backed `start` path the refusal is printed inside a non-visible detached terminal that is then closed, so the operator sees only &#39;daemon did not become ready&#39; and the loud failure becomes silent. Both launcher entrypoints run in the captain&#39;s shell with the same cwd, so the check belongs at the top of `fm_afk_launch_start` and `fm_afk_launch_start_native` as well.
- ℹ️ `bin/fm-wake-lib.sh:80` - `fm_resolve_dir` runs a bare `cd` in the caller&#39;s shell; it is only safe today because both call sites in `fm_cwd_is_disposable_slot` wrap it in command substitution. It is defined in a lib sourced by many scripts under a generic name, so a future direct call would silently relocate the calling process. Wrap the body in a subshell: `( CDPATH=&#39;&#39; cd -- &#34;$path&#34; 2&gt;/dev/null &amp;&amp; pwd -P )`.

🔧 Fix: relocate long-lived processes out of disposable worktrees
4 issues (3 warnings, 1 info) still open:
- ⚠️ `bin/fm-wake-lib.sh:120` - The relocation rewrites FM_HOME to the `pwd -P` resolved path (`FM_HOME=$FM_DISPOSABLE_HOME`). FM_HOME is not only a path here: fm-watch.sh:700 writes it verbatim into `.watch.lock/fm-home`, and fm_watcher_lock_matches_pid, fm-turnend-guard.sh:86, fm-continuity-pretool-check.sh:84, fm-pr-check-migrate.sh:269 and fm-watch-arm.sh:245 all compare it with a byte-exact `[ &#34;$lock_home&#34; = &#34;$home&#34; ]`. Every other process derives FM_HOME logically (`cd .. &amp;&amp; pwd` in the lib, or the exported env value), so if any component of the home path is a symlink the two strings diverge. Two concrete breakages: (a) FM_HOME unexported (primary case) - the forked watcher records the logical path while the relocated arm compares the physical one, so the arm&#39;s post-fork `fm_watcher_healthy` at fm-watch-arm.sh:245 never matches and the arm reports &#34;no live watcher with a fresh beacon&#34; and retries against a perfectly healthy watcher; (b) FM_HOME exported (secondmate case) - the assignment updates the exported value, so the child records the physical path while the guard, checkpoint and continuity check still hold the logical one and conclude the lock is not this home&#39;s. The re-anchoring is also unnecessary in practice: FM_HOME is already absolute in every path that sets it. Restrict the rewrite to the genuinely-relative case (leave the original string untouched when it already starts with `/`), and do the same for STATE/FM_STATE_OVERRIDE.
- ⚠️ `bin/fm-watch-checkpoint.sh:78` - bin/fm-watch-checkpoint.sh runs `$SCRIPT_DIR/fm-watch.sh` in the foreground for a bounded checkpoint and never calls fm_relocate_from_disposable_cwd, so it inherits whatever cwd the caller had. Per .agents/skills/harness-adapters/SKILL.md:184 this is Codex&#39;s PRIMARY watcher protocol, not fm-watch-arm.sh, so a Codex home whose shell has cd&#39;d into a task worktree gets no protection at all: every checkpoint runs a watcher in the condemned cwd and is killed by signal 16 mid-cycle whenever any session returns that slot, surfacing as a repeatedly-failing checkpoint. The change&#39;s reasoning excluded fm-watch.sh on the grounds that it is &#34;only ever forked by the already-guarded arm&#34;, which holds for the claude/grok path but not for this one. bin/fm-supervise-daemon.sh:1399 is genuinely covered, since it is reached only through the now-guarded fm-afk-start.sh.
- ⚠️ `tests/fm-watcher-lock.test.sh:104` - test_relocated_watcher_does_not_run_in_condemned_cwd forks a real arm (which forks a real fm-watch.sh) in the background and only kills them on the success path at the end. tests/lib.sh:44 defines `fail` as `exit 1`, so the `fail &#34;relocated arm never forked a watcher that took the lock&#34;` at line 106 and the `fail &#34;watcher inherited the condemned cwd&#34;` inside the case at line 110 both exit the suite with the arm and watcher still running. fm_test_cleanup only removes directories, so the leaked watcher keeps polling every FM_POLL=5 seconds forever against a state dir that has just been deleted. The two `sleep 300 &amp;` sleepers added at lines 58 and 136 leak the same way. Register the pids and `trap &#39;kill $PIDS 2&gt;/dev/null&#39; EXIT` at launch rather than killing at the end of the happy path.
- ℹ️ `tests/fm-watcher-lock.test.sh:114` - When lsof produces no output the test calls `pass` with &#34;cwd unreadable on this host, skipped&#34;, so the assertion the test exists to make silently degrades to a no-op that still reports ok. lsof also returns nothing when the watcher has already exited, which is a real failure mode rather than a host capability gap, so a genuine regression could be reported as a pass. A `skip` reporter, or at least asserting the watcher pid is still alive before treating empty output as unreadable, would keep the signal honest.

🔧 Fix: guard every watcher launcher and preserve home identity
3 issues (2 warnings, 1 info) still open:
- ⚠️ `bin/fm-wake-lib.sh:140` - `state_abs=$(fm_resolve_dir &#34;$STATE&#34;) || return 1` runs before the chdir and on every relocation, including the overwhelmingly common case where STATE is already absolute and the value is never used. Its failure is then reported by all four callers as &#34;cannot move out of the disposable task worktree ... into the home&#34;, which names the wrong cause: STATE failing to resolve (the lib&#39;s source-time `mkdir -p &#34;$STATE&#34;` silently failed on a read-only or full filesystem, or FM_STATE_OVERRIDE points at a path that was removed between source time and the call) aborts the launcher with a message about the home chdir. Move the resolution inside the non-absolute branch of the `case &#34;$STATE&#34;` at line 147, so the only failure mode reaching `return 1` is a genuine chdir failure and the caller&#39;s message is always accurate.
- ⚠️ `tests/fm-watch-checkpoint.test.sh:10` - tests/fm-watcher-lock.test.sh:24 exports TREEHOUSE_DIR to a non-existent path with the stated rationale that these suites run launchers from the repo checkout while pointing FM_HOME at a temp dir, which is exactly the condemned shape when the checkout is itself a pool slot. That rationale applies verbatim to tests/fm-watch-checkpoint.test.sh and tests/fm-afk-launch.test.sh, which now invoke the same relocating launchers and are not pinned. Their pre-existing cases (test_quiet_checkpoint_exits_124_cleanly, test_registered_check_uses_preserved_watcher_environment, test_existing_singleton_watcher_is_not_success, and every afk-launch case that runs $START) will relocate and emit the banner when the suite is run from inside a task worktree but not in CI. The assertions are all `assert_contains`, so nothing fails today, but the suites are environment-dependent for no reason and any future exact-output or empty-stderr assertion silently becomes CI-only. Pin TREEHOUSE_DIR to an absent path at the top of both suites, exactly as the watcher-lock suite does, since the cases that exercise the guard already set it themselves.
- ℹ️ `bin/fm-watch-checkpoint.sh:10` - bin/fm-wake-lib.sh is sourced at the top of the script, before argument parsing, and the lib performs `mkdir -p &#34;$STATE&#34;` at source time. `fm-watch-checkpoint.sh --help` and the two argument-error exits now create $FM_HOME/state as a side effect where they previously did not. Harmless in practice since any real checkpoint creates it anyway, but sourcing after the argument-parsing loop and before the relocation call would keep the informational paths side-effect free.

🔧 Fix: report relocation faults distinctly and pin test pool root
2 issues (1 warning, 1 info) still open:
- ⚠️ `tests/fm-watch-triage.test.sh:39` - Round 3 pinned TREEHOUSE_DIR in the three suites that drive the launchers, but the guard has since moved into bin/fm-watch.sh itself, which pulls in every suite that executes the watcher directly. tests/fm-watch-triage.test.sh:39/387/428, tests/fm-wake-queue.test.sh:63/71/99/137/165 and tests/fm-pr-check-security.test.sh:587/2318/2339 all run &#34;$WATCH&#34; from the repo checkout while pointing FM_HOME at a temp dir outside the pool - exactly the shape fm_cwd_is_disposable_slot condemns when the checkout is a treehouse slot, which it is for any crewmate task worktree. Those runs will relocate to FM_HOME and emit the banner on stderr, so the watcher&#39;s cwd and the suites&#39; stderr differ between CI and a task worktree. Nothing fails today only because every assertion in these suites reads stdout; any future exact-output or empty-stderr assertion silently becomes CI-only. Apply the same TREEHOUSE_DIR pin and explanatory comment used at tests/fm-watcher-lock.test.sh:22 to these three suites.
- ℹ️ `bin/fm-wake-lib.sh:142` - fm_relocate_from_disposable_cwd re-anchors a relative FM_HOME and a relative STATE/FM_STATE_OVERRIDE before the chdir, but leaves FM_ROOT and FM_ROOT_OVERRIDE untouched. bin/fm-watch.sh:46 takes FM_ROOT=&#34;${FM_ROOT_OVERRIDE:-...}&#34; verbatim, so a relative override stays relative and silently resolves against the wrong directory after relocation, and the value is propagated to child processes. Only reachable when a caller sets a relative FM_ROOT_OVERRIDE, which today is a test-only shape, so this is a completeness gap in the re-anchoring rather than a live fault. Either re-anchor it alongside STATE using the same relative-only rule, or state in the header comment that FM_ROOT_OVERRIDE is required to be absolute.

🔧 Fix: re-anchor code root and centralize test pool pin
4 issues (2 warnings, 2 infos) still open:
- ⚠️ `bin/fm-watch.sh:55` - The relocation call sits at top level, above the main-entry source guard at line 666. bin/fm-watch.sh is documented (lines 91-96) as sourceable for unit tests, with the contract that sourcing &#34;loads the functions ... and returns before acquiring the lock or starting the loop&#34; and that running it as a script behaves &#34;exactly as before, byte-for-byte&#34;. Both are now untrue when sourced: the sourcing shell&#39;s cwd is silently changed, and on a chdir failure the `exit 1` at line 58 terminates the sourcing test suite rather than returning, bypassing that suite&#39;s cleanup. tests/fm-supervision-events.test.sh:23 and tests/fm-backend-herdr-eventwait-smoke.test.sh:119 both source it. Moving the relocation inside the main-entry guard (or gating it on `[ &#34;${BASH_SOURCE[0]}&#34; = &#34;$0&#34; ]`) restores the documented contract while still relocating before the loop; note WATCH_LOCK at line 89 is derived from STATE, so if you move it, re-derive WATCH_LOCK after.
- ⚠️ `tests/fm-backend-herdr-eventwait-smoke.test.sh:119` - Round 4 made tests/lib.sh:48 the single owner of the TREEHOUSE_DIR pin, and tests/fm-afk-launch.test.sh:36 was given its own copy precisely because it is standalone and never sources that library. tests/fm-backend-herdr-eventwait-smoke.test.sh is the other standalone suite (it defines its own ROOT/fail/pass at lines 16-18 and never sources tests/lib.sh) and it sources bin/fm-watch.sh at line 119, which now relocates on source. It sets FM_ROOT_OVERRIDE but no FM_HOME, so FM_HOME defaults to $ROOT; any invocation whose cwd is under the treehouse pool but outside that root relocates the test shell mid-suite, and a chdir failure exits it before cleanup_all runs. Apply the same pin and rationale comment already carried by tests/fm-afk-launch.test.sh:24-36.
- ℹ️ `bin/fm-watch-arm.sh:76` - The relocation runs at line 76, but bin/fm-watch-arm.sh does not parse its arguments until line 342, so `fm-watch-arm.sh --bogus` now performs the chdir and prints the full relocation banner before emitting `usage:` and exiting 2. bin/fm-watch-checkpoint.sh:47-50 explicitly took the opposite approach in round 3, deferring the lib source until after argument handling so informational and error paths stay side-effect free; the two launchers are now inconsistent on the same point. Moving the arm&#39;s relocation below its argument `case` keeps it well before the fork and before any STATE-derived variable is consumed.
- ℹ️ `tests/fm-watcher-lock.test.sh:31` - fm_watcher_lock_test_cleanup iterates every pid ever passed to track_pid across the whole suite and issues `kill &#34;$p&#34;` with no liveness or identity check. By the time the EXIT trap fires, most tracked pids (the `sleep 300` sentinels and arms that already exited, plus the watcher pid read from state/.watch.lock/pid at line 105) are long dead, and on a busy host a wrapped pid can belong to an unrelated process. The individual tests already kill their own processes on the happy path, so the trap is the reuse-exposed one. Recording the pid alongside a cheap identity (fm_pid_identity is already available in the lib under test) and skipping any pid whose identity no longer matches would keep the safety net without the blind kill.

🔧 Fix: relocate below source guard and harden test cleanup
2 issues (1 warning, 1 info) still open:
- ⚠️ `bin/fm-wake-lib.sh:9` - The relocation re-anchors a relative FM_HOME, STATE/FM_STATE_OVERRIDE and FM_ROOT/FM_ROOT_OVERRIDE, but not the paths already derived FROM STATE at lib source time. FM_WAKE_QUEUE and FM_WAKE_QUEUE_LOCK (bin/fm-wake-lib.sh:9-10) are computed as &#34;$STATE/.wake-queue&#34; before any relocation and are never re-derived, so with a relative STATE they stay relative: after the chdir into FM_HOME they resolve to $FM_HOME/&lt;relstate&gt;/.wake-queue while STATE itself has been re-anchored to &lt;slot&gt;/&lt;relstate&gt;. fm_wake_enqueue then appends to a directory that does not exist and the drain reads a different queue than the one the watcher writes. bin/fm-watch.sh:144 has the same shape: TRIAGE_LOG is set at top level above the source guard and, unlike WATCH_LOCK at line 674, is not re-derived after the relocation call. This is the identical completeness gap that was fixed for FM_ROOT in round 4, and the lib header comment currently asserts the re-anchoring is complete (&#34;every relative one is: FM_HOME, STATE ... and FM_ROOT&#34;), which is now inaccurate. Either re-derive the STATE-dependent globals inside fm_relocate_from_disposable_cwd (FM_WAKE_QUEUE, FM_WAKE_QUEUE_LOCK) and re-derive TRIAGE_LOG alongside WATCH_LOCK in bin/fm-watch.sh, or narrow the header claim and state that a relative STATE is unsupported.
- ℹ️ `tests/lib.sh:47` - tests/lib.sh now exports TREEHOUSE_DIR tree-wide to a path that does not exist. TREEHOUSE_DIR is treehouse&#39;s own pool-root variable, not a firstmate-private one, so the export reaches any suite that shells out to a real `treehouse` binary rather than the fakebin stub, and would point a genuine `treehouse get --lease` at a missing pool root instead of merely making the guard inert. Every current suite that touches treehouse installs a fake on PATH, so nothing is affected today, but the pin is broader than its stated purpose. Worth a line in the existing comment noting that the pin also overrides the real CLI, so a future suite that exercises real treehouse knows to unset it.

🔧 Fix: centralize path derivation and privatize pool-root override
4 issues (1 warning, 3 infos) still open:
- ⚠️ `tests/fm-secondmate-safety.test.sh:2009` - This suite is standalone (it never sources tests/lib.sh, so it does not inherit the tree-wide FM_TREEHOUSE_POOL_ROOT pin added at tests/lib.sh:47) and it EXECUTES the real &#34;$ROOT/bin/fm-watch.sh&#34; at line 2009 with FM_HOME pointed at a temp dir under TMP_ROOT. That is exactly the shape the guard now condemns whenever the repo checkout is itself a treehouse pool slot, which it is for any crewmate task worktree. The watcher will relocate and emit the banner on stderr inside a task worktree but not in CI, so the suite&#39;s watcher cwd and stderr are environment-dependent. Nothing fails today only because the assertions read $out (stdout), but this is the same class the change already fixed for tests/fm-afk-launch.test.sh, which was given its own standalone copy of the pin for precisely this reason. Round 5 audited the standalone suites for SOURCING the watcher (fm-backend-herdr-eventwait-smoke) but this one executes it. Add the same standalone FM_TREEHOUSE_POOL_ROOT pin and rationale comment carried by tests/fm-afk-launch.test.sh:26-37.
- ℹ️ `bin/fm-watch-arm.sh:347` - bin/fm-watch-arm.sh now assigns WATCH_LOCK, BEAT, CYCLE_LOG and CYCLE_LOG_LOCK twice verbatim: once at lines 75-84 and again at lines 347-350 after the relocation. Both bin/fm-wake-lib.sh (fm_derive_paths) and bin/fm-watch.sh (watch_derive_state_paths) were deliberately refactored in this same change so that a path derived from STATE lives in exactly one place and is re-anchored by construction. The arm is the one launcher left with a hand-maintained copy, so the next STATE-derived variable added near line 75 and not mirrored at line 347 silently keeps pointing at the pre-relocation state directory. Factor the four assignments into an arm_derive_state_paths function called at both points, matching the pattern the rest of the change establishes.
- ℹ️ `bin/fm-afk-start.sh:133` - Same duplication as the arm: FM_AFK_STATE and FM_AFK_LOCK are derived at lines 38-39 and re-derived byte-identically at lines 133-134 after the relocation. A future path derived from FM_AFK_STATE added at the top and not mirrored after the relocation would survive the chdir stale. Wrap the pair in a single derive function called from both sites.
- ℹ️ `bin/fm-wake-lib.sh:8` - FM_WAKE_QUEUE_PINNED is captured at source time from whether FM_WAKE_QUEUE is already set, and it is what makes fm_derive_paths skip re-anchoring that path. If bin/fm-wake-lib.sh is ever sourced twice within one process, the second source sees the value the FIRST source derived, records it as caller-pinned, and the relocation then leaves FM_WAKE_QUEUE and FM_WAKE_QUEUE_LOCK pointing at the pre-relocation state directory - reintroducing the exact enqueue/drain divergence round 6 fixed. No script double-sources it today (verified across bin/), so this is latent, but the mechanism gives no signal when it breaks. Guard the capture behind a source-once sentinel (e.g. only compute the _PINNED flags when FM_WAKE_LIB_SOURCED is unset) so a repeat source cannot mis-classify a lib-derived value as caller-supplied.

🔧 Fix: enforce pool-root pin by test and dedupe derived paths
2 infos still open:
- ℹ️ `tests/fm-relocation-pool-pin.test.sh:54` - The pin detector greps for any `FM_TREEHOUSE_POOL_ROOT=` assignment anywhere in the suite, including the per-invocation overrides that guard tests deliberately point at a REAL pool (e.g. tests/fm-afk-launch.test.sh:73, tests/fm-watch-checkpoint.test.sh:105). A future standalone suite that sets the variable only per-invocation to exercise relocation would therefore satisfy the check while every other case in that suite still runs unpinned - exactly the silent CI-versus-task-worktree divergence the meta-test exists to prevent. tests/lib.sh:47 and tests/fm-afk-launch.test.sh:39 both express the protective pin as a top-level `export FM_TREEHOUSE_POOL_ROOT=`, so anchoring the grep on that form (as test_shared_pin_is_owned_by_the_test_library already does for tests/lib.sh) would distinguish a real pin from a guard-exercising override.
- ℹ️ `tests/fm-watcher-lock.test.sh:145` - In test_relocated_watcher_does_not_run_in_condemned_cwd the forked watcher is only registered with track_pid after its pid is read from state/.watch.lock/pid. The `fail &#34;relocated arm never forked a watcher that took the lock&#34;` on the preceding line fires when the 20s discovery loop times out, which includes the case where the watcher process started but had not yet written the lock. Killing the tracked arm does not kill its already-forked watcher child, so that path exits the suite (tests/lib.sh `fail` is `exit 1`) leaving a real watcher polling against a state dir cleanup has removed - the precise leak the identity-checked trap was added for. Everywhere else in the suite the pid is tracked at launch; here the launch and the registration are separated by a race.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- <code>`bash tests/fm-watcher-lock.test.sh` (35 assertions, includes the arm relocation, watcher-child cwd inheritance, symlinked/relative FM_HOME, relative STATE and FM_ROOT re-anchoring, and leased-home no-op cases)</code>
- <code>`bash tests/fm-afk-launch.test.sh` (52 assertions, includes the three new away-mode relocation assertions)</code>
- <code>`bash tests/fm-watch-checkpoint.test.sh` (checkpoint relocation path)</code>
- <code>`bash tests/fm-relocation-pool-pin.test.sh` (static contract that every launcher-touching suite pins its pool root)</code>
- <code>Manual end-to-end sweep simulation: armed `bin/fm-watch-arm.sh` from a simulated treehouse pool slot with the guard inert vs active, read each watcher&#39;s real working directory via `lsof -a -p &lt;pid&gt; -d cwd`, then ran a cwd-matching terminate sweep against both</code>
- <code>Manual `bin/fm-afk-start.sh` runs from a disposable pool slot and from a durably leased secondmate home, comparing banner presence</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
