### PR TITLE
Fix cancelled-run precedence over a later declared pause

### DIFF
--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -286,6 +286,7 @@ signal_reason_is_actionable() {  # <file> ...
 # One fm-crew-state.sh read serves BOTH absorb reasons at once. Reading the state
 # authoritatively (not the status log) is what keeps run-step precedence: a crew
 # that appended paused: but then STARTED a run reports working, never paused.
+# The complementary cancelled-then-paused exception lives in fm-crew-state.sh.
 # NOT a pure read: fm-crew-state.sh may make a bounded no-mistakes call, so callers
 # run it only on no-verb signal and first-sighting stale paths, never every wake.
 # FM_CREW_STATE_BIN lets tests stub the verdict.

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -28,6 +28,10 @@
 #      checks" from "checks green, waiting on merge" (see nm_ci_checks_state) -
 #      a ci-step log-tail check overrides working -> done once checks read
 #      green, so a green PR is never silently read as still-validating.
+#      Second exception: a TERMINAL cancelled run whose status-log tip is a
+#      later declared pause (paused:) reports paused from the status log, so a
+#      captain mid-run delivery redirect does not leave supervision stuck on
+#      cancelled/failed. Active runs and other terminal outcomes are unchanged.
 #   3. Reconcile the status log: if its last line says needs-decision/blocked but
 #      the run-step shows the run moved on, the log is deterministically stale and
 #      is flagged superseded. A genuinely parked run plus a needs-decision log
@@ -432,6 +436,11 @@ if [ "$HAVE_RUN" = 1 ]; then
   CI_STEP_STATUS=""
   CI_LOG_STATE=""
   RUN_STATUS=""
+  # Set when the matching run reached a terminal cancelled state (outcome,
+  # status word, or coarse runs-list word). Distinct from RUN_STATE=failed so
+  # a later paused: tip can supersede cancelled without also overriding a real
+  # outcome:failed or outcome:passed terminal run.
+  RUN_TERMINAL_CANCELLED=0
   if [ "$RUN_SOURCE" = coarse ]; then
     # No step/gate detail is available from the plain runs list - only ever
     # true/working, done, or failed. A crew genuinely parked at a gate still
@@ -444,7 +453,7 @@ if [ "$HAVE_RUN" = 1 ]; then
       running)   RUN_STATE=working; RUN_DETAIL="validating (background run)" ;;
       completed) RUN_STATE="done";  RUN_DETAIL="run completed" ;;
       failed)    RUN_STATE=failed;  RUN_DETAIL="run failed" ;;
-      cancelled) RUN_STATE=failed;  RUN_DETAIL="run cancelled" ;;
+      cancelled) RUN_STATE=failed;  RUN_DETAIL="run cancelled"; RUN_TERMINAL_CANCELLED=1 ;;
       *)         RUN_STATE=unknown; RUN_DETAIL="runs list status: $COARSE_STATUS" ;;
     esac
   else
@@ -461,7 +470,7 @@ if [ "$HAVE_RUN" = 1 ]; then
         passed)        RUN_STATE="done"; RUN_DETAIL="run passed: PR merged/closed" ;;
         checks-passed) RUN_STATE="done"; RUN_DETAIL="checks green: PR ready for review" ;;
         failed)        RUN_STATE=failed; RUN_DETAIL="run failed" ;;
-        cancelled)     RUN_STATE=failed; RUN_DETAIL="run cancelled" ;;
+        cancelled)     RUN_STATE=failed; RUN_DETAIL="run cancelled"; RUN_TERMINAL_CANCELLED=1 ;;
         *)             RUN_STATE=unknown; RUN_DETAIL="outcome: $outcome" ;;
       esac
     elif [ -n "$awaiting" ] || [ "$status" = awaiting_approval ] || [ "$status" = fix_review ] || [ -n "$gate_status" ] || [ "$has_gate" = 1 ]; then
@@ -485,7 +494,7 @@ if [ "$HAVE_RUN" = 1 ]; then
         running|fixing) RUN_STATE=working; RUN_DETAIL="validating ($status)" ;;
         completed)      RUN_STATE="done"; RUN_DETAIL="run completed" ;;
         failed)         RUN_STATE=failed;  RUN_DETAIL="run failed" ;;
-        cancelled)      RUN_STATE=failed;  RUN_DETAIL="run cancelled" ;;
+        cancelled)      RUN_STATE=failed;  RUN_DETAIL="run cancelled"; RUN_TERMINAL_CANCELLED=1 ;;
         "")             RUN_STATE=working; RUN_DETAIL="run active" ;;
         *)              RUN_STATE=working; RUN_DETAIL="run active ($status)" ;;
       esac
@@ -522,6 +531,20 @@ if [ "$HAVE_RUN" = 1 ]; then
     if [ "$CI_LOG_STATE" != not-ready ]; then
       emit "done" status-log "$(status_line_note "$LOG_LINE")${SEP}run still monitoring PR"
     fi
+  fi
+
+  # Terminal cancelled + later declared pause (paused: tip on the append-only
+  # status log): prefer the pause so a captain mid-run delivery redirect does
+  # not leave supervision treating a deliberately-idle worker as failed.
+  # "Later" proxy: axi status (and the coarse runs list) do not expose a terminal
+  # transition timestamp the helper already reads, so the ordering signal is the
+  # status-log tip itself - last non-empty line is paused: while the matching
+  # run is TERMINAL cancelled. An ACTIVE run never reaches this branch (RUN_STATE
+  # is working/parked, not cancelled), so a pause written before or during an
+  # active run is still outranked by the run-step. Other terminal outcomes
+  # (passed/failed) keep run-step precedence.
+  if [ "$RUN_TERMINAL_CANCELLED" = 1 ] && [ -n "$LOG_LINE" ] && status_is_paused "$LOG_LINE"; then
+    emit paused status-log "$(status_line_note "$LOG_LINE")${SEP}run cancelled, later pause declared"
   fi
 
   # Reconcile the status log. A needs-decision/blocked log line that the run-step

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,6 +25,7 @@ Crew status files are append-only wake-event logs, not current-state fields.
 `bin/fm-crew-state.sh <id>` is the cheap current-state read for an actionable heartbeat review: it attributes the matching no-mistakes run, active or terminal, to the crew's own branch and keeps that run-step authoritative even if the pane has closed.
 During no-mistakes' `ci` monitor phase, it also reads the ci step log tail because `axi status` reports both "still waiting on checks" and "checks green, waiting on merge" as `ci,running`.
 The most recent recognized ci log marker wins, so checks-green monitoring reports done while a later re-arm, failed-check, or issue marker returns the crew to working.
+One terminal exception: a cancelled run whose status-log tip is a later declared `paused:` reports paused from the status log, so a mid-run delivery redirect does not leave supervision stuck on cancelled/failed; active runs and other terminal outcomes keep run-step precedence.
 Only when no matching run exists does it fall back to the pane busy-signature and then a status-log event whose verb maps to a recognized run-state; a dead pane without a run reports unknown instead of trusting a stale log.
 Decision-only events such as `resolved` never become current state or leak their prose into the current-state detail.
 In that status-log fallback, a declared external wait reports the distinct `paused` state with its reason.

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -13,6 +13,10 @@
 #   (b) needs-decision/blocked log + resumed run = SUPERSEDED     -> run-step
 #   (c) genuine parked run + needs-decision log = NOT superseded  -> run-step
 #   (d) terminal run-step (passed/failed) is authoritative        -> run-step
+#   (d') terminal cancelled + LATER paused: status -> paused (not cancelled);
+#        cancelled alone still failed; active run still outranks pause;
+#        other terminal outcomes keep run-step precedence. Regression for the
+#        2026-07-16 captain-redirect stale-wake loop.
 #   (e) cross-branch attribution: this branch's own run found via list lookup
 #   (f) no run + busy pane                                        -> pane
 #   (g) no run + idle pane falls to the status-log verb           -> status-log
@@ -277,6 +281,19 @@ run:
   pr: ""
   findings: none
 outcome: failed
+EOF
+}
+
+run_cancelled() {  # <branch>
+  cat <<EOF
+run:
+  id: "01RUN"
+  branch: $1
+  status: completed
+  head: "abc1234"
+  pr: ""
+  findings: none
+outcome: cancelled
 EOF
 }
 
@@ -671,6 +688,122 @@ test_terminal_failed() {
   assert_contains "$out" "state: failed" "failed run -> failed"
   assert_contains "$out" "source: run-step" "failed -> run-step source"
   pass "terminal failed run is authoritative"
+}
+
+# (d') terminal cancelled run + a LATER paused: status line must reconcile to
+# paused (declared external wait), not cancelled/failed. Incident 2026-07-16:
+# captain redirected delivery mid-run, the no-mistakes run cancelled, the
+# worker declared paused:, and supervision looped stale wakes against the
+# deliberately-idle pane because run-step cancelled outranked the pause.
+test_terminal_cancelled_later_paused_reports_paused() {
+  reset_fakes
+  local d; d=$(new_case cancelled-then-paused)
+  make_repo_on_branch "$d/wt" fm/feat-cancel-pause
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-cancel-pause.meta" \
+    "window=fm:fm-feat-cancel-pause" "worktree=$d/wt" "kind=ship"
+  # Prior working: then the post-cancel declared pause (append-only tip).
+  printf 'working: validating via no-mistakes\npaused: captain redirected delivery; holding for new path\n' \
+    > "$d/state/feat-cancel-pause.status"
+  FM_FAKE_AXI_STATUS="$(run_cancelled fm/feat-cancel-pause)"
+  FM_FAKE_BUSY=0
+  local out; out=$(run_crew_state "$d" feat-cancel-pause)
+  assert_contains "$out" "state: paused" "cancelled run + later paused: -> paused"
+  assert_contains "$out" "source: status-log" "later pause is status-log sourced"
+  assert_contains "$out" "captain redirected delivery" "pause reason is carried"
+  assert_not_contains "$out" "state: failed" "must not stick on cancelled/failed"
+  pass "terminal cancelled run + later paused: reconciles to paused"
+}
+
+# Cancelled with no later pause still reports failed from the run-step.
+test_terminal_cancelled_without_pause_reports_failed() {
+  reset_fakes
+  local d; d=$(new_case cancelled-alone)
+  make_repo_on_branch "$d/wt" fm/feat-cancel-alone
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-cancel-alone.meta" \
+    "window=fm:fm-feat-cancel-alone" "worktree=$d/wt" "kind=ship"
+  printf 'working: validating via no-mistakes\n' > "$d/state/feat-cancel-alone.status"
+  FM_FAKE_AXI_STATUS="$(run_cancelled fm/feat-cancel-alone)"
+  local out; out=$(run_crew_state "$d" feat-cancel-alone)
+  assert_contains "$out" "state: failed" "cancelled without later pause -> failed"
+  assert_contains "$out" "source: run-step" "cancelled alone stays run-step"
+  assert_contains "$out" "run cancelled" "cancelled detail is preserved"
+  pass "terminal cancelled run without a later pause still reports failed"
+}
+
+# Active run still outranks a paused: status line (precedence otherwise unchanged).
+test_active_run_outranks_paused_status() {
+  reset_fakes
+  local d; d=$(new_case active-outranks-pause)
+  make_repo_on_branch "$d/wt" fm/feat-active-pause
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-active-pause.meta" \
+    "window=fm:fm-feat-active-pause" "worktree=$d/wt" "kind=ship"
+  printf 'paused: holding for vendor window\n' > "$d/state/feat-active-pause.status"
+  FM_FAKE_AXI_STATUS="$(run_running fm/feat-active-pause)"
+  local out; out=$(run_crew_state "$d" feat-active-pause)
+  assert_contains "$out" "state: working" "active run outranks paused: status"
+  assert_contains "$out" "source: run-step" "active run stays run-step sourced"
+  assert_not_contains "$out" "state: paused" "active run must not yield to pause"
+  pass "active run still outranks a paused: status line"
+}
+
+# Other terminal outcomes (passed/failed) keep run-step precedence over pause.
+test_terminal_failed_outranks_paused_status() {
+  reset_fakes
+  local d; d=$(new_case failed-outranks-pause)
+  make_repo_on_branch "$d/wt" fm/feat-fail-pause
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-fail-pause.meta" \
+    "window=fm:fm-feat-fail-pause" "worktree=$d/wt" "kind=ship"
+  printf 'paused: holding after a real failure?\n' > "$d/state/feat-fail-pause.status"
+  FM_FAKE_AXI_STATUS="$(run_failed fm/feat-fail-pause)"
+  local out; out=$(run_crew_state "$d" feat-fail-pause)
+  assert_contains "$out" "state: failed" "failed run still outranks paused:"
+  assert_contains "$out" "source: run-step" "failed stays run-step sourced"
+  assert_not_contains "$out" "state: paused" "failed must not yield to pause"
+  pass "terminal failed run still outranks a paused: status line"
+}
+
+test_terminal_passed_outranks_paused_status() {
+  reset_fakes
+  local d; d=$(new_case passed-outranks-pause)
+  make_repo_on_branch "$d/wt" fm/feat-pass-pause
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-pass-pause.meta" \
+    "window=fm:fm-feat-pass-pause" "worktree=$d/wt" "kind=ship"
+  printf 'paused: should not mask a passed run\n' > "$d/state/feat-pass-pause.status"
+  FM_FAKE_AXI_STATUS="$(run_passed fm/feat-pass-pause)"
+  local out; out=$(run_crew_state "$d" feat-pass-pause)
+  assert_contains "$out" "state: done" "passed run still outranks paused:"
+  assert_contains "$out" "source: run-step" "passed stays run-step sourced"
+  assert_not_contains "$out" "state: paused" "passed must not yield to pause"
+  pass "terminal passed run still outranks a paused: status line"
+}
+
+# Coarse runs-list cancelled + later paused: follows the same exception.
+test_coarse_cancelled_later_paused_reports_paused() {
+  reset_fakes
+  local d; d=$(new_case coarse-cancel-pause)
+  make_repo_on_branch "$d/wt" fm/feat-coarse-cp
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-coarse-cp.meta" \
+    "window=fm:fm-feat-coarse-cp" "worktree=$d/wt" "kind=ship"
+  printf 'working: validating\npaused: redirected mid-run; holding\n' \
+    > "$d/state/feat-coarse-cp.status"
+  FM_FAKE_AXI_STATUS="$(run_running fm/other-crew)"
+  FM_FAKE_RUNS_LIST="$(cat <<'EOF'
+  running    fm/other-crew aaaaaaa  2026-07-16 12:10
+  cancelled  fm/feat-coarse-cp bbbbbbb  2026-07-16 12:05
+EOF
+)"
+  FM_FAKE_BUSY=0
+  local out; out=$(run_crew_state "$d" feat-coarse-cp)
+  assert_contains "$out" "state: paused" "coarse cancelled + later paused: -> paused"
+  assert_contains "$out" "source: status-log" "coarse later pause is status-log sourced"
+  assert_not_contains "$out" "state: failed" "coarse cancelled must not stick over pause"
+  pass "coarse cancelled run + later paused: reconciles to paused"
 }
 
 # (e) cross-branch attribution: `axi status` returns ANOTHER branch's run (the
@@ -1155,6 +1288,12 @@ test_top_level_fixing_ci_running_after_green_stays_working
 test_top_level_fixing_done_log_stays_working
 test_terminal_passed
 test_terminal_failed
+test_terminal_cancelled_later_paused_reports_paused
+test_terminal_cancelled_without_pause_reports_failed
+test_active_run_outranks_paused_status
+test_terminal_failed_outranks_paused_status
+test_terminal_passed_outranks_paused_status
+test_coarse_cancelled_later_paused_reports_paused
 test_cross_branch_attribution_via_runs_list
 test_cross_branch_attribution_picks_most_recent_row
 test_coarse_run_does_not_probe_other_branch_ci_log_for_ready_status


### PR DESCRIPTION
## Summary
- Fix crew-state reconciler precedence so a terminal cancelled no-mistakes run followed by a later declared `paused:` status line reports `paused` (status-log) instead of sticky cancelled/failed.
- Active runs and other terminal outcomes (passed/failed) keep run-step precedence; cancelled without a later pause still reports failed.
- Add regression tests covering cancelled+later pause, cancelled alone, active/failed/passed vs pause, and coarse runs-list cancelled+pause.

## Why
Captain mid-run delivery redirect cancelled validation; the worker declared `paused:`; supervision still treated the run as failed and looped stale wakes against a deliberately idle worker (2026-07-16 incident).

## Test plan
- [x] `tests/fm-crew-state.test.sh` reproduces then passes the cancelled+later-pause case and adjacent precedence cases
- [x] `bin/fm-lint.sh` (ShellCheck 0.11.0)
- [x] Broader suite exercised; unrelated pre-existing OpenCode session-lock flake observed on this host
