### PR TITLE
feat: alert captains when decisions need attention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ config/backend
 config/x-mode.env
 config/cmux-socket-password
 config/wedge-alarm
+config/decision-alert

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,7 @@ config/backlog-backend  backlog backend override; LOCAL, gitignored; absent or "
 config/backend  runtime session-provider backend override for new tasks; LOCAL, gitignored; absent = falls through to runtime auto-detection (the runtime firstmate itself is executing inside), then tmux; tmux is the verified reference backend (docs/tmux-backend.md), while herdr, zellij, orca, and cmux are experimental spawn backends (docs/herdr-backend.md, docs/zellij-backend.md, docs/orca-backend.md, docs/cmux-backend.md) - herdr and cmux can also be selected by runtime auto-detection, zellij and orca never are (always explicit), and codex-app is not accepted; see docs/codex-app-backend.md; not inherited into secondmate homes
 config/cmux-socket-password  optional cmux control-socket password; LOCAL, gitignored; read fresh on every cmux CLI call and passed through without ever overriding an operator's own ambient CMUX_SOCKET_PASSWORD when absent (docs/cmux-backend.md "Setup")
 config/wedge-alarm  optional away-mode wedge-alarm active-alert directives; LOCAL, gitignored; absent means auto (macOS Notification Center when available); see docs/wedge-alarm.md
+config/decision-alert  optional captain decision-alert directives; LOCAL, gitignored; absent means auto (audible macOS Notification Center alert when available); see docs/decision-alert.md
 config/x-mode.env    generated X-mode watcher cadence; LOCAL, gitignored; source before arming watcher when present
 data/                personal fleet records; LOCAL, gitignored as a whole
   backlog.md         task queue, dependencies, history
@@ -104,6 +105,7 @@ state/               volatile runtime signals; gitignored
   .hash-* .count-* .stale-* .stale-since-* .paused-* .wedge-escalations-* .seen-* .hb-surfaced-* .last-* .heartbeat-streak   watcher internals; never touch
   .watch-triage.log  watcher's absorbed-wake debug log (size-capped); never relied on, safe to delete
   .last-watcher-beat watcher liveness beacon, touched every poll (including while absorbing benign wakes); guard scripts read it
+  .decision-alerted-* privacy-safe decision-alert deduplication markers; never touch
   .subsuper-* .supervise-daemon.*   sub-supervisor internals; never touch
 .no-mistakes/        local validation state and evidence; gitignored
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -397,6 +397,7 @@ Reach the captain immediately for:
 - Anything destructive, irreversible, or security-sensitive.
 - A needed credential or login.
 
+Immediately before sending an approval or user-specific decision prompt, invoke `bin/fm-decision-alert.sh` with the stable privacy-safe identity required by its help; worker status and decision-hold paths alert automatically.
 Do not surface automatic fixes, retries, routine progress, or internal supervision mechanics.
 Batch non-urgent updates into the next natural reply.
 Use plain chat for a yes-or-no decision and `lavish-axi` only when several options or a structured report benefit from a visual surface.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Launching a supported harness inside it instantiates your first mate - and makes
 ## Features
 
 - **One liaison** - you talk only to the first mate; it dispatches, supervises, escalates only real decisions, and reports plain outcomes.
+- **Decision alerts** - Firstmate posts a generic audible and visible macOS notification when it needs your approval or a user-specific decision, with local opt-out and custom channels for other platforms.
 - **A visible crew** - every crewmate works in its own tmux window, experimental herdr/zellij tab, cmux workspace, or Orca terminal you can watch or type into; the first mate reconciles.
 - **Disposable worktrees** - each task runs in a clean [treehouse](https://github.com/kunchenguid/treehouse) git worktree, or an Orca-managed worktree when `backend=orca`, so parallel work on one repo never collides.
 - **Two task shapes** - ship tasks deliver a change; scout tasks investigate, plan, reproduce, or audit and leave a report.
@@ -184,6 +185,7 @@ Firstmate's skills live in two separate places with different audiences:
 
 - [docs/architecture.md](docs/architecture.md) - how the crew, supervision, worktrees, secondmates, and project modes work.
 - [docs/configuration.md](docs/configuration.md) - environment variables, `FM_HOME`, runtime backend selection, optional X mode, the files you set, and harness support.
+- [docs/decision-alert.md](docs/decision-alert.md) - configure privacy-safe alerts for approvals and captain-owned decisions, including custom channels and opt-out.
 - [docs/wedge-alarm.md](docs/wedge-alarm.md) - configure the active alert for an away-mode escalation delivery that gets stuck.
 - [docs/tmux-backend.md](docs/tmux-backend.md) - setup guide for the tmux reference backend: prerequisites, attaching, and watching crew windows.
 - [docs/herdr-backend.md](docs/herdr-backend.md) - setup guide for the experimental herdr backend, plus its verification notes and known gaps.

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -739,7 +739,7 @@ FM_BACKEND_HERDR_IDLE_RE=${FM_BACKEND_HERDR_IDLE_RE:-'^Type a message\.\.\.$'}
 # Known bare (unbordered) prompt glyphs a composer row may start with: ❯
 # (claude) and › (codex) only. Generic shell-style glyphs > $ % # are still
 # recognized after a bordered composer row has already been structurally found.
-FM_BACKEND_HERDR_BARE_PROMPT_RE=${FM_BACKEND_HERDR_BARE_PROMPT_RE:-'^[❯›]'}
+FM_BACKEND_HERDR_BARE_PROMPT_RE=${FM_BACKEND_HERDR_BARE_PROMPT_RE:-'^(❯|›)'}
 # Pi allows a multi-line composer between its horizontal separators. Bound the
 # structural candidate so two unrelated transcript rules with an arbitrarily
 # large region between them can never be promoted into a composer.
@@ -903,7 +903,7 @@ EOF
   fi
   # Delegate the empty/pending/unknown decision to the shared owner. The bare
   # shape only ever starts with an AGENT glyph (FM_BACKEND_HERDR_BARE_PROMPT_RE
-  # is '^[❯›]'), so a bare shell prompt never reaches here - it stays 'unknown'
+  # is '^(❯|›)'), so a bare shell prompt never reaches here - it stays 'unknown'
   # via the no-composer-row path above, exactly as before.
   fm_composer_classify_content "$bordered" "$stripped" "$FM_BACKEND_HERDR_IDLE_RE"
 }

--- a/bin/fm-decision-alert.sh
+++ b/bin/fm-decision-alert.sh
@@ -34,6 +34,8 @@
 # Sourcing this script defaults that seam to discard so library-mode tests can
 # never post a real notification or play a real sound.
 # FM_DECISION_ALERT_TIMEOUT_SECS bounds each channel and defaults to 10 seconds.
+# FM_DECISION_ALERT_TOTAL_TIMEOUT_SECS bounds the complete invocation and
+# defaults to 10 seconds.
 #
 # Deduplication uses state/.decision-alerted-<sha256(identity)>.
 # Marker creation is atomic and occurs before notifier execution, so concurrent
@@ -49,9 +51,11 @@ FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
 DECISION_ALERT_TIMEOUT_SECS_DEFAULT=10
+DECISION_ALERT_TOTAL_TIMEOUT_SECS_DEFAULT=10
 DECISION_ALERT_TITLE='Firstmate needs your decision'
 DECISION_ALERT_BODY='Return to Firstmate to review the decision.'
 DECISION_ALERT_SOUND='Basso'
+DECISION_ALERT_DEADLINE=
 
 # shellcheck source=bin/fm-classify-lib.sh
 . "$SCRIPT_DIR/fm-classify-lib.sh"
@@ -126,6 +130,19 @@ decision_alert_run_bounded() {  # <timeout> <channel> <command> [args...]
   return "$rc"
 }
 
+decision_alert_begin_budget() {
+  local total
+  total=${FM_DECISION_ALERT_TOTAL_TIMEOUT_SECS:-$DECISION_ALERT_TOTAL_TIMEOUT_SECS_DEFAULT}
+  case "$total" in ''|*[!0-9]*|0) total=$DECISION_ALERT_TOTAL_TIMEOUT_SECS_DEFAULT ;; esac
+  DECISION_ALERT_DEADLINE=$((SECONDS + total))
+}
+
+decision_alert_remaining_budget() {
+  local remaining=$((DECISION_ALERT_DEADLINE - SECONDS))
+  [ "$remaining" -gt 0 ] || return 1
+  printf '%s\n' "$remaining"
+}
+
 decision_alert_claim() {  # <origin-id> <decision-key>
   local digest marker
   mkdir -p "$STATE" || return 1
@@ -135,7 +152,7 @@ decision_alert_claim() {  # <origin-id> <decision-key>
 }
 
 decision_alert_notify() {  # <origin-id> <decision-key>
-  local origin=$1 key=$2 ch resolved_ch command_body rc timeout override
+  local origin=$1 key=$2 ch resolved_ch command_body rc timeout channel_timeout override remaining
   local -a configured=() channels=()
   decision_alert_validate_slug origin-id "$origin" || return 2
   decision_alert_validate_slug decision-key "$key" || return 2
@@ -154,20 +171,25 @@ decision_alert_notify() {  # <origin-id> <decision-key>
     esac
   done
   [ "${#channels[@]}" -gt 0 ] || return 0
+  [ -n "$DECISION_ALERT_DEADLINE" ] || decision_alert_begin_budget
+  remaining=$(decision_alert_remaining_budget) || return 0
   decision_alert_claim "$origin" "$key" || return 0
   timeout=${FM_DECISION_ALERT_TIMEOUT_SECS:-$DECISION_ALERT_TIMEOUT_SECS_DEFAULT}
   case "$timeout" in ''|*[!0-9]*|0) timeout=$DECISION_ALERT_TIMEOUT_SECS_DEFAULT ;; esac
   override=${FM_DECISION_ALERT_EXEC:-}
   for ch in "${channels[@]}"; do
+    remaining=$(decision_alert_remaining_budget) || break
+    channel_timeout=$timeout
+    [ "$channel_timeout" -le "$remaining" ] || channel_timeout=$remaining
     resolved_ch=$ch
     command_body=
     if [ "${ch#command:}" != "$ch" ]; then
-      resolved_ch=command
+      resolved_ch='command'
       command_body=${ch#command:}
-      fm_notify_emit decision_alert_run_bounded "$override" "$timeout" command \
+      fm_notify_emit decision_alert_run_bounded "$override" "$channel_timeout" command \
         "$DECISION_ALERT_TITLE" "$DECISION_ALERT_BODY" "$DECISION_ALERT_SOUND" "$command_body"
     else
-      fm_notify_emit decision_alert_run_bounded "$override" "$timeout" "$ch" \
+      fm_notify_emit decision_alert_run_bounded "$override" "$channel_timeout" "$ch" \
         "$DECISION_ALERT_TITLE" "$DECISION_ALERT_BODY" "$DECISION_ALERT_SOUND"
     fi
     rc=$?
@@ -205,14 +227,17 @@ decision_alert_main() {
   case "$command" in
     decision|prompt)
       [ "$#" -eq 3 ] || { usage >&2; return 2; }
+      decision_alert_begin_budget
       decision_alert_notify "$2" "$3"
       ;;
     status)
       [ "$#" -eq 2 ] || { usage >&2; return 2; }
+      decision_alert_begin_budget
       decision_alert_status "$2"
       ;;
     scan-state)
       [ "$#" -eq 1 ] || { usage >&2; return 2; }
+      decision_alert_begin_budget
       decision_alert_scan_state
       ;;
     -h|--help) usage ;;

--- a/bin/fm-decision-alert.sh
+++ b/bin/fm-decision-alert.sh
@@ -255,9 +255,11 @@ decision_alert_dispatch() {
       fi
       job_index=$((job_index + 1))
     done
-    for pid in "${pids[@]}"; do
-      wait "$pid" || true
-    done
+    if [ "${#pids[@]}" -gt 0 ]; then
+      for pid in "${pids[@]}"; do
+        wait "$pid" || true
+      done
+    fi
   done
   return 0
 }

--- a/bin/fm-decision-alert.sh
+++ b/bin/fm-decision-alert.sh
@@ -36,7 +36,8 @@
 # FM_DECISION_ALERT_TIMEOUT_SECS bounds each channel and defaults to 10 seconds.
 # FM_DECISION_ALERT_TOTAL_TIMEOUT_SECS bounds the complete invocation and
 # defaults to 10 seconds.
-# Enabled attempts run concurrently within the shared invocation deadline.
+# Up to eight notifier workers run concurrently within the shared invocation
+# deadline.
 #
 # Deduplication uses state/.decision-alerted-<sha256(identity)>.
 # Marker creation is atomic and occurs before notifier execution, so concurrent
@@ -53,10 +54,14 @@ STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
 DECISION_ALERT_TIMEOUT_SECS_DEFAULT=10
 DECISION_ALERT_TOTAL_TIMEOUT_SECS_DEFAULT=10
+DECISION_ALERT_MAX_WORKERS=8
 DECISION_ALERT_TITLE='Firstmate needs your decision'
 DECISION_ALERT_BODY='Return to Firstmate to review the decision.'
 DECISION_ALERT_SOUND='Basso'
 DECISION_ALERT_DEADLINE=
+DECISION_ALERT_ORIGINS=()
+DECISION_ALERT_KEYS=()
+DECISION_ALERT_CHANNELS=()
 
 # shellcheck source=bin/fm-classify-lib.sh
 . "$SCRIPT_DIR/fm-classify-lib.sh"
@@ -152,13 +157,6 @@ decision_alert_claim() {  # <origin-id> <decision-key>
   ( set -C; : > "$marker" ) 2>/dev/null
 }
 
-decision_alert_wait_for_pids() {
-  local pid
-  for pid in "$@"; do
-    wait "$pid" || true
-  done
-}
-
 decision_alert_emit_channel() {  # <channel> <override> <timeout>
   local ch=$1 override=$2 timeout=$3 resolved_ch=$1 command_body='' rc
   if [ "${ch#command:}" != "$ch" ]; then
@@ -175,46 +173,97 @@ decision_alert_emit_channel() {  # <channel> <override> <timeout>
   return 0
 }
 
-decision_alert_notify() {  # <origin-id> <decision-key>
-  local origin=$1 key=$2 ch timeout channel_timeout override remaining
-  local -a configured=() channels=() pids=()
-  decision_alert_validate_slug origin-id "$origin" || return 2
-  decision_alert_validate_slug decision-key "$key" || return 2
+decision_alert_prepare_channels() {
+  local ch limit_logged=
+  local -a configured=()
+  DECISION_ALERT_CHANNELS=()
   while IFS= read -r ch; do
     [ -n "$ch" ] && configured+=("$ch")
   done < <(decision_alert_configured_channels)
   for ch in "${configured[@]}"; do
-    [ "$ch" = off ] && return 0
+    [ "$ch" = off ] && return 1
   done
   for ch in "${configured[@]}"; do
     case "$ch" in auto|default) ch=$(decision_alert_platform_default) ;; esac
     case "$ch" in
       '') ;;
-      osascript|herdr|command:*) channels+=("$ch") ;;
+      osascript|herdr|command:*)
+        if [ "${#DECISION_ALERT_CHANNELS[@]}" -lt "$DECISION_ALERT_MAX_WORKERS" ]; then
+          DECISION_ALERT_CHANNELS+=("$ch")
+        elif [ -z "$limit_logged" ]; then
+          decision_alert_log "channel limit is $DECISION_ALERT_MAX_WORKERS; remaining directives ignored"
+          limit_logged=1
+        fi
+        ;;
       *) decision_alert_log 'unrecognized channel directive ignored (redacted)' ;;
     esac
   done
-  [ "${#channels[@]}" -gt 0 ] || return 0
+  [ "${#DECISION_ALERT_CHANNELS[@]}" -gt 0 ]
+}
+
+decision_alert_add_identity() {  # <origin-id> <decision-key>
+  local origin=$1 key=$2
+  decision_alert_validate_slug origin-id "$origin" || return 2
+  decision_alert_validate_slug decision-key "$key" || return 2
+  DECISION_ALERT_ORIGINS+=("$origin")
+  DECISION_ALERT_KEYS+=("$key")
+}
+
+decision_alert_dispatch() {
+  local timeout override remaining identity_count channel_count batch_capacity total_jobs
+  local job_index remaining_jobs remaining_batches batch_timeout batch_end
+  local identity_index channel_index claim_state_value pid
+  local -a claim_states=() pids=()
+  [ "${#DECISION_ALERT_ORIGINS[@]}" -gt 0 ] || return 0
+  decision_alert_prepare_channels || return 0
   [ -n "$DECISION_ALERT_DEADLINE" ] || decision_alert_begin_budget
-  remaining=$(decision_alert_remaining_budget) || return 0
-  decision_alert_claim "$origin" "$key" || return 0
   timeout=${FM_DECISION_ALERT_TIMEOUT_SECS:-$DECISION_ALERT_TIMEOUT_SECS_DEFAULT}
   case "$timeout" in ''|*[!0-9]*|0) timeout=$DECISION_ALERT_TIMEOUT_SECS_DEFAULT ;; esac
   override=${FM_DECISION_ALERT_EXEC:-}
-  for ch in "${channels[@]}"; do
+  identity_count=${#DECISION_ALERT_ORIGINS[@]}
+  channel_count=${#DECISION_ALERT_CHANNELS[@]}
+  batch_capacity=$((DECISION_ALERT_MAX_WORKERS / channel_count * channel_count))
+  total_jobs=$((identity_count * channel_count))
+  job_index=0
+  while [ "$job_index" -lt "$total_jobs" ]; do
     remaining=$(decision_alert_remaining_budget) || break
-    channel_timeout=$timeout
-    [ "$channel_timeout" -le "$remaining" ] || channel_timeout=$remaining
-    decision_alert_emit_channel "$ch" "$override" "$channel_timeout" &
-    pids+=("$!")
+    remaining_jobs=$((total_jobs - job_index))
+    remaining_batches=$(((remaining_jobs + batch_capacity - 1) / batch_capacity))
+    batch_timeout=$((remaining / remaining_batches))
+    [ "$batch_timeout" -gt 0 ] || batch_timeout=1
+    [ "$batch_timeout" -le "$timeout" ] || batch_timeout=$timeout
+    batch_end=$((job_index + batch_capacity))
+    [ "$batch_end" -le "$total_jobs" ] || batch_end=$total_jobs
+    pids=()
+    while [ "$job_index" -lt "$batch_end" ]; do
+      identity_index=$((job_index / channel_count))
+      channel_index=$((job_index % channel_count))
+      claim_state_value=${claim_states[$identity_index]:-}
+      if [ -z "$claim_state_value" ]; then
+        if decision_alert_claim "${DECISION_ALERT_ORIGINS[$identity_index]}" \
+          "${DECISION_ALERT_KEYS[$identity_index]}"; then
+          claim_state_value=claimed
+        else
+          claim_state_value=skipped
+        fi
+        claim_states[identity_index]=$claim_state_value
+      fi
+      if [ "$claim_state_value" = claimed ]; then
+        decision_alert_emit_channel "${DECISION_ALERT_CHANNELS[$channel_index]}" \
+          "$override" "$batch_timeout" &
+        pids+=("$!")
+      fi
+      job_index=$((job_index + 1))
+    done
+    for pid in "${pids[@]}"; do
+      wait "$pid" || true
+    done
   done
-  decision_alert_wait_for_pids "${pids[@]}"
   return 0
 }
 
-decision_alert_status() {  # <status-file>
+decision_alert_collect_status() {  # <status-file>
   local status_file=$1 task open key verb _note
-  local -a pids=()
   [ -f "$status_file" ] || return 0
   task=$(basename "$status_file")
   task=${task%.status}
@@ -223,23 +272,35 @@ decision_alert_status() {  # <status-file>
   while IFS=$'\t' read -r key verb _note; do
     [ -n "$key" ] || continue
     [ "$verb" = needs-decision ] || continue
-    decision_alert_notify "$task" "$key" &
-    pids+=("$!")
+    decision_alert_add_identity "$task" "$key" || true
   done <<EOF
 $open
 EOF
-  decision_alert_wait_for_pids "${pids[@]}"
+}
+
+decision_alert_notify() {  # <origin-id> <decision-key>
+  DECISION_ALERT_ORIGINS=()
+  DECISION_ALERT_KEYS=()
+  decision_alert_add_identity "$1" "$2" || return $?
+  decision_alert_dispatch
+}
+
+decision_alert_status() {  # <status-file>
+  DECISION_ALERT_ORIGINS=()
+  DECISION_ALERT_KEYS=()
+  decision_alert_collect_status "$1" || return $?
+  decision_alert_dispatch
 }
 
 decision_alert_scan_state() {
   local status_file
-  local -a pids=()
+  DECISION_ALERT_ORIGINS=()
+  DECISION_ALERT_KEYS=()
   for status_file in "$STATE"/*.status; do
     [ -e "$status_file" ] || continue
-    decision_alert_status "$status_file" &
-    pids+=("$!")
+    decision_alert_collect_status "$status_file" || true
   done
-  decision_alert_wait_for_pids "${pids[@]}"
+  decision_alert_dispatch
 }
 
 decision_alert_main() {

--- a/bin/fm-decision-alert.sh
+++ b/bin/fm-decision-alert.sh
@@ -226,7 +226,10 @@ decision_alert_dispatch() {
   total_jobs=$((identity_count * channel_count))
   job_index=0
   while [ "$job_index" -lt "$total_jobs" ]; do
-    remaining=$(decision_alert_remaining_budget) || break
+    if ! remaining=$(decision_alert_remaining_budget); then
+      [ "$job_index" -eq 0 ] || break
+      remaining=1
+    fi
     remaining_jobs=$((total_jobs - job_index))
     remaining_batches=$(((remaining_jobs + batch_capacity - 1) / batch_capacity))
     batch_timeout=$((remaining / remaining_batches))

--- a/bin/fm-decision-alert.sh
+++ b/bin/fm-decision-alert.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+# fm-decision-alert.sh - best-effort audible alerts for captain decisions.
+#
+# This script alerts only for a genuine unresolved `needs-decision` event or an
+# explicit Firstmate prompt registered with a stable privacy-safe identity.
+# Routine work, progress, blocked/paused/done events, and resolved decisions do
+# not alert.
+#
+# Usage:
+#   fm-decision-alert.sh decision <origin-id> <decision-key>
+#   fm-decision-alert.sh prompt <origin-id> <decision-key>
+#   fm-decision-alert.sh status <status-file>
+#   fm-decision-alert.sh scan-state
+#   fm-decision-alert.sh --help
+#
+# `decision` and `prompt` are equivalent identity registrations.
+# Use `prompt` immediately before Firstmate asks the captain directly.
+# Use the same origin and key as a matching decision hold or status event so
+# repeated delivery converges on one alert attempt.
+# `status` folds the whole append-only status stream and alerts for each still
+# open needs-decision key, even when a later unrelated event follows it.
+# `scan-state` applies that fold to every status file in the effective home.
+#
+# Config: config/decision-alert, one directive per non-empty, non-comment line.
+# FM_DECISION_ALERT_CHANNEL overrides the file with a single directive.
+# Directives are off, auto/default, osascript, herdr, and command:<cmd>.
+# An absent config means auto, which resolves to an audible macOS Notification
+# Center alert and no built-in channel on other platforms.
+# `off` disables every channel without consuming the decision identity.
+#
+# FM_DECISION_ALERT_EXEC replaces every real notifier with a test command invoked
+# as `<command> <channel> <body>`.
+# The value `discard` performs no notifier execution.
+# Sourcing this script defaults that seam to discard so library-mode tests can
+# never post a real notification or play a real sound.
+# FM_DECISION_ALERT_TIMEOUT_SECS bounds each channel and defaults to 10 seconds.
+#
+# Deduplication uses state/.decision-alerted-<sha256(identity)>.
+# Marker creation is atomic and occurs before notifier execution, so concurrent
+# or repeated delivery attempts cannot double-alert.
+# The marker contains no decision text or identity.
+# Notifier failure is reported best-effort but always leaves the durable decision
+# and alert marker intact, never grants approval, and never makes a caller fail.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
+DECISION_ALERT_TIMEOUT_SECS_DEFAULT=10
+DECISION_ALERT_TITLE='Firstmate needs your decision'
+DECISION_ALERT_BODY='Return to Firstmate to review the decision.'
+DECISION_ALERT_SOUND='Basso'
+
+# shellcheck source=bin/fm-classify-lib.sh
+. "$SCRIPT_DIR/fm-classify-lib.sh"
+# shellcheck source=bin/fm-notify-lib.sh
+. "$SCRIPT_DIR/fm-notify-lib.sh"
+
+usage() {
+  awk '
+    NR == 1 { next }
+    /^#/ { sub(/^# ?/, ""); print; next }
+    { exit }
+  ' "$0"
+}
+
+decision_alert_log() {
+  printf 'fm-decision-alert: %s\n' "$*" >&2
+}
+
+decision_alert_validate_slug() {  # <label> <value>
+  local label=$1 value=$2
+  case "$value" in
+    ''|*[!A-Za-z0-9._-]*) decision_alert_log "$label must be a non-empty privacy-safe slug"; return 1 ;;
+  esac
+}
+
+decision_alert_hash() {  # <privacy-safe-identity>
+  if command -v shasum >/dev/null 2>&1; then
+    printf '%s' "$1" | shasum -a 256 | awk '{print $1}'
+  elif command -v sha256sum >/dev/null 2>&1; then
+    printf '%s' "$1" | sha256sum | awk '{print $1}'
+  else
+    printf '%s' "$1" | cksum | awk '{print "cksum-" $1 "-" $2}'
+  fi
+}
+
+decision_alert_configured_channels() {
+  local cfg line found=
+  if [ -n "${FM_DECISION_ALERT_CHANNEL:-}" ]; then
+    printf '%s\n' "$FM_DECISION_ALERT_CHANNEL"
+    return 0
+  fi
+  cfg="$CONFIG/decision-alert"
+  if [ -f "$cfg" ]; then
+    while IFS= read -r line || [ -n "$line" ]; do
+      line="${line#"${line%%[![:space:]]*}"}"
+      line="${line%"${line##*[![:space:]]}"}"
+      [ -n "$line" ] || continue
+      case "$line" in '#'*) continue ;; esac
+      printf '%s\n' "$line"
+      found=1
+    done < "$cfg"
+  fi
+  [ -n "$found" ] || printf 'auto\n'
+}
+
+decision_alert_platform_default() {
+  case "$(uname)" in
+    Darwin) command -v osascript >/dev/null 2>&1 && printf 'osascript' ;;
+    *) : ;;
+  esac
+}
+
+decision_alert_run_bounded() {  # <timeout> <channel> <command> [args...]
+  local timeout=$1 channel=$2 rc
+  shift 2
+  fm_notify_run_bounded "$timeout" "$channel" "$@"
+  rc=$?
+  case "$rc" in
+    124) decision_alert_log "$channel notifier timed out after ${FM_NOTIFY_LAST_ELAPSED}s" ;;
+    125) decision_alert_log "$channel notifier skipped because its watchdog could not start" ;;
+  esac
+  return "$rc"
+}
+
+decision_alert_claim() {  # <origin-id> <decision-key>
+  local digest marker
+  mkdir -p "$STATE" || return 1
+  digest=$(decision_alert_hash "$1:$2") || return 1
+  marker="$STATE/.decision-alerted-$digest"
+  ( set -C; : > "$marker" ) 2>/dev/null
+}
+
+decision_alert_notify() {  # <origin-id> <decision-key>
+  local origin=$1 key=$2 ch resolved_ch command_body rc timeout override
+  local -a configured=() channels=()
+  decision_alert_validate_slug origin-id "$origin" || return 2
+  decision_alert_validate_slug decision-key "$key" || return 2
+  while IFS= read -r ch; do
+    [ -n "$ch" ] && configured+=("$ch")
+  done < <(decision_alert_configured_channels)
+  for ch in "${configured[@]}"; do
+    [ "$ch" = off ] && return 0
+  done
+  for ch in "${configured[@]}"; do
+    case "$ch" in auto|default) ch=$(decision_alert_platform_default) ;; esac
+    case "$ch" in
+      '') ;;
+      osascript|herdr|command:*) channels+=("$ch") ;;
+      *) decision_alert_log 'unrecognized channel directive ignored (redacted)' ;;
+    esac
+  done
+  [ "${#channels[@]}" -gt 0 ] || return 0
+  decision_alert_claim "$origin" "$key" || return 0
+  timeout=${FM_DECISION_ALERT_TIMEOUT_SECS:-$DECISION_ALERT_TIMEOUT_SECS_DEFAULT}
+  case "$timeout" in ''|*[!0-9]*|0) timeout=$DECISION_ALERT_TIMEOUT_SECS_DEFAULT ;; esac
+  override=${FM_DECISION_ALERT_EXEC:-}
+  for ch in "${channels[@]}"; do
+    resolved_ch=$ch
+    command_body=
+    if [ "${ch#command:}" != "$ch" ]; then
+      resolved_ch=command
+      command_body=${ch#command:}
+      fm_notify_emit decision_alert_run_bounded "$override" "$timeout" command \
+        "$DECISION_ALERT_TITLE" "$DECISION_ALERT_BODY" "$DECISION_ALERT_SOUND" "$command_body"
+    else
+      fm_notify_emit decision_alert_run_bounded "$override" "$timeout" "$ch" \
+        "$DECISION_ALERT_TITLE" "$DECISION_ALERT_BODY" "$DECISION_ALERT_SOUND"
+    fi
+    rc=$?
+    [ "$rc" -eq 0 ] || decision_alert_log "$resolved_ch notifier failed with status $rc"
+  done
+  return 0
+}
+
+decision_alert_status() {  # <status-file>
+  local status_file=$1 task open key verb _note
+  [ -f "$status_file" ] || return 0
+  task=$(basename "$status_file")
+  task=${task%.status}
+  decision_alert_validate_slug task-id "$task" || return 2
+  open=$(status_open_decisions "$status_file")
+  while IFS=$'\t' read -r key verb _note; do
+    [ -n "$key" ] || continue
+    [ "$verb" = needs-decision ] || continue
+    decision_alert_notify "$task" "$key" || true
+  done <<EOF
+$open
+EOF
+}
+
+decision_alert_scan_state() {
+  local status_file
+  for status_file in "$STATE"/*.status; do
+    [ -e "$status_file" ] || continue
+    decision_alert_status "$status_file" || true
+  done
+}
+
+decision_alert_main() {
+  local command=${1:-}
+  case "$command" in
+    decision|prompt)
+      [ "$#" -eq 3 ] || { usage >&2; return 2; }
+      decision_alert_notify "$2" "$3"
+      ;;
+    status)
+      [ "$#" -eq 2 ] || { usage >&2; return 2; }
+      decision_alert_status "$2"
+      ;;
+    scan-state)
+      [ "$#" -eq 1 ] || { usage >&2; return 2; }
+      decision_alert_scan_state
+      ;;
+    -h|--help) usage ;;
+    *) usage >&2; return 2 ;;
+  esac
+}
+
+if [ "${BASH_SOURCE[0]}" != "$0" ]; then
+  : "${FM_DECISION_ALERT_EXEC:=discard}"
+  export FM_DECISION_ALERT_EXEC
+else
+  decision_alert_main "$@"
+fi

--- a/bin/fm-decision-alert.sh
+++ b/bin/fm-decision-alert.sh
@@ -34,12 +34,13 @@
 # Sourcing this script defaults that seam to discard so library-mode tests can
 # never post a real notification or play a real sound.
 # FM_DECISION_ALERT_TIMEOUT_SECS bounds each channel and defaults to 10 seconds.
-# FM_DECISION_ALERT_TOTAL_TIMEOUT_SECS bounds the complete invocation and
-# defaults to 10 seconds.
+# FM_DECISION_ALERT_TOTAL_TIMEOUT_SECS bounds notifier dispatch across the
+# complete invocation and defaults to 10 seconds.
 # Up to eight notifier workers run concurrently within the shared invocation
 # deadline.
 #
-# Deduplication uses state/.decision-alerted-<sha256(identity)>.
+# Deduplication uses state/.decision-alerted-<digest(identity)>; the digest is
+# SHA-256 when either supported utility is available, with a cksum fallback.
 # Marker creation is atomic and occurs before notifier execution, so concurrent
 # or repeated delivery attempts cannot double-alert.
 # The marker contains no decision text or identity.

--- a/bin/fm-decision-alert.sh
+++ b/bin/fm-decision-alert.sh
@@ -36,6 +36,7 @@
 # FM_DECISION_ALERT_TIMEOUT_SECS bounds each channel and defaults to 10 seconds.
 # FM_DECISION_ALERT_TOTAL_TIMEOUT_SECS bounds the complete invocation and
 # defaults to 10 seconds.
+# Enabled attempts run concurrently within the shared invocation deadline.
 #
 # Deduplication uses state/.decision-alerted-<sha256(identity)>.
 # Marker creation is atomic and occurs before notifier execution, so concurrent
@@ -151,9 +152,32 @@ decision_alert_claim() {  # <origin-id> <decision-key>
   ( set -C; : > "$marker" ) 2>/dev/null
 }
 
+decision_alert_wait_for_pids() {
+  local pid
+  for pid in "$@"; do
+    wait "$pid" || true
+  done
+}
+
+decision_alert_emit_channel() {  # <channel> <override> <timeout>
+  local ch=$1 override=$2 timeout=$3 resolved_ch=$1 command_body='' rc
+  if [ "${ch#command:}" != "$ch" ]; then
+    resolved_ch='command'
+    command_body=${ch#command:}
+    fm_notify_emit decision_alert_run_bounded "$override" "$timeout" command \
+      "$DECISION_ALERT_TITLE" "$DECISION_ALERT_BODY" "$DECISION_ALERT_SOUND" "$command_body"
+  else
+    fm_notify_emit decision_alert_run_bounded "$override" "$timeout" "$ch" \
+      "$DECISION_ALERT_TITLE" "$DECISION_ALERT_BODY" "$DECISION_ALERT_SOUND"
+  fi
+  rc=$?
+  [ "$rc" -eq 0 ] || decision_alert_log "$resolved_ch notifier failed with status $rc"
+  return 0
+}
+
 decision_alert_notify() {  # <origin-id> <decision-key>
-  local origin=$1 key=$2 ch resolved_ch command_body rc timeout channel_timeout override remaining
-  local -a configured=() channels=()
+  local origin=$1 key=$2 ch timeout channel_timeout override remaining
+  local -a configured=() channels=() pids=()
   decision_alert_validate_slug origin-id "$origin" || return 2
   decision_alert_validate_slug decision-key "$key" || return 2
   while IFS= read -r ch; do
@@ -181,25 +205,16 @@ decision_alert_notify() {  # <origin-id> <decision-key>
     remaining=$(decision_alert_remaining_budget) || break
     channel_timeout=$timeout
     [ "$channel_timeout" -le "$remaining" ] || channel_timeout=$remaining
-    resolved_ch=$ch
-    command_body=
-    if [ "${ch#command:}" != "$ch" ]; then
-      resolved_ch='command'
-      command_body=${ch#command:}
-      fm_notify_emit decision_alert_run_bounded "$override" "$channel_timeout" command \
-        "$DECISION_ALERT_TITLE" "$DECISION_ALERT_BODY" "$DECISION_ALERT_SOUND" "$command_body"
-    else
-      fm_notify_emit decision_alert_run_bounded "$override" "$channel_timeout" "$ch" \
-        "$DECISION_ALERT_TITLE" "$DECISION_ALERT_BODY" "$DECISION_ALERT_SOUND"
-    fi
-    rc=$?
-    [ "$rc" -eq 0 ] || decision_alert_log "$resolved_ch notifier failed with status $rc"
+    decision_alert_emit_channel "$ch" "$override" "$channel_timeout" &
+    pids+=("$!")
   done
+  decision_alert_wait_for_pids "${pids[@]}"
   return 0
 }
 
 decision_alert_status() {  # <status-file>
   local status_file=$1 task open key verb _note
+  local -a pids=()
   [ -f "$status_file" ] || return 0
   task=$(basename "$status_file")
   task=${task%.status}
@@ -208,18 +223,23 @@ decision_alert_status() {  # <status-file>
   while IFS=$'\t' read -r key verb _note; do
     [ -n "$key" ] || continue
     [ "$verb" = needs-decision ] || continue
-    decision_alert_notify "$task" "$key" || true
+    decision_alert_notify "$task" "$key" &
+    pids+=("$!")
   done <<EOF
 $open
 EOF
+  decision_alert_wait_for_pids "${pids[@]}"
 }
 
 decision_alert_scan_state() {
   local status_file
+  local -a pids=()
   for status_file in "$STATE"/*.status; do
     [ -e "$status_file" ] || continue
-    decision_alert_status "$status_file" || true
+    decision_alert_status "$status_file" &
+    pids+=("$!")
   done
+  decision_alert_wait_for_pids "${pids[@]}"
 }
 
 decision_alert_main() {

--- a/bin/fm-decision-hold.sh
+++ b/bin/fm-decision-hold.sh
@@ -15,6 +15,9 @@
 # is idempotent. A different decision key creates a different backlog identity.
 # All backlog mutations run in the active FM_HOME, which keeps main-home and
 # secondmate-home ownership aligned with the work that discovered the decision.
+# After `hold` is verified durable, the script makes one best-effort decision
+# alert attempt using the same origin/key identity as worker status alerts.
+# Alert failure never changes the hold result.
 #
 # Usage:
 #   fm-decision-hold.sh id <origin-id> <decision-key>
@@ -271,6 +274,7 @@ command_hold() {
   tasks_axi hold "$id" --reason "$reason" --kind captain >/dev/null \
     || fail "could not activate captain hold $id"
   verify_hold_active "$id"
+  "$SCRIPT_DIR/fm-decision-alert.sh" decision "$origin" "$key" >/dev/null 2>&1 || true
   printf '%s\n' "$id"
 }
 

--- a/bin/fm-home-seed.sh
+++ b/bin/fm-home-seed.sh
@@ -859,6 +859,38 @@ refuse_projectful_projectless_charter() {
   return 1
 }
 
+prepare_seed_charter() {
+  local id=$1 no_projects=$2
+  shift 2
+  if [ ! -f "$SEED_PARENT_BRIEF" ]; then
+    [ -n "${FM_SECONDMATE_CHARTER:-}" ] || {
+      echo "error: no filled secondmate charter brief at $SEED_PARENT_BRIEF; set FM_SECONDMATE_CHARTER or scaffold one and replace {TASK}" >&2
+      return 1
+    }
+    [ -d "$DATA/$id" ] || SEED_PARENT_BRIEF_DIR_CREATED=1
+    if [ "$no_projects" -eq 1 ]; then
+      "$FM_ROOT/bin/fm-brief.sh" "$id" --secondmate --no-projects
+    else
+      "$FM_ROOT/bin/fm-brief.sh" "$id" --secondmate "$@"
+    fi
+    SEED_PARENT_BRIEF_CREATED=1
+  fi
+  if grep -F '{TASK}' "$SEED_PARENT_BRIEF" >/dev/null 2>&1; then
+    echo "error: secondmate charter brief at $SEED_PARENT_BRIEF still contains {TASK}; fill it before seeding" >&2
+    return 1
+  fi
+  charter_summary=$(registry_summary_for_brief "$SEED_PARENT_BRIEF")
+  [ -n "$charter_summary" ] || {
+    echo "error: secondmate charter brief at $SEED_PARENT_BRIEF has an empty Charter section; fill it before seeding" >&2
+    return 1
+  }
+  charter_scope=$(registry_scope_for_brief "$SEED_PARENT_BRIEF")
+  [ -n "$charter_scope" ] || {
+    echo "error: secondmate charter brief at $SEED_PARENT_BRIEF has an empty Routing scope section; fill it before seeding" >&2
+    return 1
+  }
+}
+
 seed_home() {
   local id=$1 requested_home=$2 requested_abs home projects_csv project project_dst charter_summary charter_scope
   local no_projects=0 arg
@@ -921,6 +953,10 @@ seed_home() {
     requested_abs=$(abs_path_for_new "$requested_home")
     refuse_active_home_path "$requested_abs" || return 1
     validate_home_assignment "$id" "$requested_abs" || return 1
+    prepare_seed_charter "$id" "$no_projects" "$@" || return 1
+    if [ "$no_projects" -eq 1 ]; then
+      refuse_projectful_projectless_charter "$id" "$SEED_PARENT_BRIEF" || return 1
+    fi
     SEED_HOME="$requested_abs"
     [ -e "$requested_abs" ] || SEED_HOME_CREATED=1
     home=$(ensure_home "$id" "$requested_abs")
@@ -951,33 +987,9 @@ seed_home() {
   fi
   SEED_HOME_BACKED_UP=1
 
-  if [ ! -f "$SEED_PARENT_BRIEF" ]; then
-    [ -n "${FM_SECONDMATE_CHARTER:-}" ] || {
-      echo "error: no filled secondmate charter brief at $SEED_PARENT_BRIEF; set FM_SECONDMATE_CHARTER or scaffold one and replace {TASK}" >&2
-      return 1
-    }
-    [ -d "$DATA/$id" ] || SEED_PARENT_BRIEF_DIR_CREATED=1
-    if [ "$no_projects" -eq 1 ]; then
-      "$FM_ROOT/bin/fm-brief.sh" "$id" --secondmate --no-projects
-    else
-      "$FM_ROOT/bin/fm-brief.sh" "$id" --secondmate "$@"
-    fi
-    SEED_PARENT_BRIEF_CREATED=1
+  if [ "$requested_home" = "-" ]; then
+    prepare_seed_charter "$id" "$no_projects" "$@" || return 1
   fi
-  if grep -F '{TASK}' "$SEED_PARENT_BRIEF" >/dev/null 2>&1; then
-    echo "error: secondmate charter brief at $SEED_PARENT_BRIEF still contains {TASK}; fill it before seeding" >&2
-    return 1
-  fi
-  charter_summary=$(registry_summary_for_brief "$SEED_PARENT_BRIEF")
-  [ -n "$charter_summary" ] || {
-    echo "error: secondmate charter brief at $SEED_PARENT_BRIEF has an empty Charter section; fill it before seeding" >&2
-    return 1
-  }
-  charter_scope=$(registry_scope_for_brief "$SEED_PARENT_BRIEF")
-  [ -n "$charter_scope" ] || {
-    echo "error: secondmate charter brief at $SEED_PARENT_BRIEF has an empty Routing scope section; fill it before seeding" >&2
-    return 1
-  }
 
   for project in "$@"; do
     project_dst=$(validate_project_destination "$home" "$project") || return 1

--- a/bin/fm-home-seed.sh
+++ b/bin/fm-home-seed.sh
@@ -650,10 +650,27 @@ seed_return_treehouse_home() {
   }
 }
 
+seed_remove_tree_bounded() {
+  local target=$1 attempts=0 absent=0
+  while [ "$attempts" -lt 5 ]; do
+    rm -rf -- "$target" 2>/dev/null || true
+    sleep 0.1
+    if [ ! -e "$target" ] && [ ! -L "$target" ]; then
+      absent=$((absent + 1))
+      [ "$absent" -ge 2 ] && return 0
+    else
+      absent=0
+    fi
+    attempts=$((attempts + 1))
+  done
+  echo "warning: failed to remove rollback target $target after bounded retries" >&2
+  return 0
+}
+
 seed_remove_created_home() {
   local home=$1 abs_home
   abs_home=$(seed_rollback_target "$home" "created home") || return 0
-  rm -rf -- "$abs_home" 2>/dev/null || true
+  seed_remove_tree_bounded "$abs_home"
 }
 
 seed_project_rollback_target() {
@@ -675,7 +692,7 @@ seed_project_rollback_target() {
 seed_remove_created_project() {
   local project_path=$1 abs_project
   abs_project=$(seed_project_rollback_target "$project_path") || return 0
-  rm -rf -- "$abs_project" 2>/dev/null || true
+  seed_remove_tree_bounded "$abs_project"
 }
 
 seed_project_was_created() {

--- a/bin/fm-notify-lib.sh
+++ b/bin/fm-notify-lib.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Shared bounded notification execution seam.
+#
+# This library owns the safety-sensitive process execution used by active
+# Firstmate notifications.
+# Callers own channel selection, titles, bodies, logging, and durable records.
+# Notification text is always passed as argv and stdin data, never interpolated
+# into AppleScript or a configured command string.
+#
+# fm_notify_run_bounded <timeout-seconds> <channel> <command> [args...]
+# fm_notify_stop_active
+# fm_notify_emit <runner-function> <override> <timeout-seconds> <channel> \
+#   <title> <body> <sound> [command-channel-body]
+#
+# The runner function must accept the same arguments as fm_notify_run_bounded.
+# An override replaces every real channel and is invoked as:
+#   <override> <resolved-channel> <notification-body>
+# The special override value "discard" performs no execution.
+# A command channel runs through `sh -c` with the notification body in `$1` and
+# on stdin.
+
+FM_NOTIFY_ACTIVE_PID=${FM_NOTIFY_ACTIVE_PID:-}
+FM_NOTIFY_LAST_ELAPSED=${FM_NOTIFY_LAST_ELAPSED:-0}
+FM_NOTIFY_LAST_TIMEOUT=${FM_NOTIFY_LAST_TIMEOUT:-0}
+
+fm_notify_stop_active() {
+  local pid=${FM_NOTIFY_ACTIVE_PID:-}
+  [ -n "$pid" ] || return 0
+  FM_NOTIFY_ACTIVE_PID=
+  kill -TERM "-$pid" 2>/dev/null || kill -TERM "$pid" 2>/dev/null || true
+  sleep 0.2
+  kill -KILL "-$pid" 2>/dev/null || kill -KILL "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+}
+
+fm_notify_run_bounded() {  # <timeout-seconds> <channel> <command> [args...]
+  local timeout=$1 _channel=$2 monitor_was_on=0 pid start elapsed rc
+  shift 2
+  case "$timeout" in
+    ''|*[!0-9]*|0) return 125 ;;
+  esac
+  case $- in *m*) monitor_was_on=1 ;; esac
+  set -m 2>/dev/null || true
+  case $- in
+    *m*) ;;
+    *) return 125 ;;
+  esac
+  "$@" &
+  pid=$!
+  FM_NOTIFY_ACTIVE_PID=$pid
+  FM_NOTIFY_LAST_TIMEOUT=$timeout
+  start=$SECONDS
+  while kill -0 "-$pid" 2>/dev/null; do
+    elapsed=$((SECONDS - start))
+    if [ "$elapsed" -ge "$timeout" ]; then
+      FM_NOTIFY_LAST_ELAPSED=$elapsed
+      fm_notify_stop_active
+      [ "$monitor_was_on" -eq 1 ] || set +m 2>/dev/null || true
+      return 124
+    fi
+    sleep 0.1
+  done
+  if wait "$pid"; then rc=0; else rc=$?; fi
+  FM_NOTIFY_ACTIVE_PID=
+  FM_NOTIFY_LAST_ELAPSED=$((SECONDS - start))
+  [ "$monitor_was_on" -eq 1 ] || set +m 2>/dev/null || true
+  return "$rc"
+}
+
+fm_notify_emit() {  # <runner> <override> <timeout> <channel> <title> <body> <sound> [command]
+  local runner=$1 override=$2 timeout=$3 channel=$4 title=$5 body=$6 sound=$7 command_body=${8:-}
+  case "$override" in
+    discard) return 0 ;;
+    '') ;;
+    *) "$runner" "$timeout" "$channel" "$override" "$channel" "$body" >/dev/null 2>&1; return $? ;;
+  esac
+  case "$channel" in
+    osascript)
+      command -v osascript >/dev/null 2>&1 || return 127
+      "$runner" "$timeout" osascript osascript \
+        -e 'on run argv' \
+        -e 'display notification (item 2 of argv) with title (item 1 of argv) sound name (item 3 of argv)' \
+        -e 'end run' "$title" "$body" "$sound" >/dev/null 2>&1
+      ;;
+    herdr)
+      command -v herdr >/dev/null 2>&1 || return 127
+      "$runner" "$timeout" herdr herdr notification show "$title" \
+        --body "$body" --sound request >/dev/null 2>&1
+      ;;
+    command)
+      [ -n "$command_body" ] || return 64
+      "$runner" "$timeout" command sh -c "$command_body" fm-notify "$body" \
+        <<< "$body" >/dev/null 2>&1
+      ;;
+    *) return 64 ;;
+  esac
+}

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -686,7 +686,7 @@ validate_spawn_worktree() {  # <source> <inspect-target>
   fi
   if [ -z "$wt_real" ] || [ -z "$wt_top_real" ] || [ "$wt_real" != "$wt_top_real" ] || [ "$wt_real" = "$proj_real" ]; then
     echo "error: $source did not yield an isolated worktree (resolved '$WT'; worktree root '${wt_top:-none}'; primary '$PROJ_ABS'); refusing to launch to avoid tangling the primary checkout. Inspect target $inspect_target" >&2
-    exit 1
+    return 1
   fi
 }
 
@@ -784,7 +784,7 @@ EOF
       echo "error: orca did not return a worktree id/path for $W" >&2
       exit 1
     fi
-    validate_spawn_worktree "orca worktree create" "$W"
+    validate_spawn_worktree "orca worktree create" "$W" || exit 1
     if [ -z "$ORCA_TERMINAL" ]; then
       ORCA_TERMINAL=$(fm_backend_orca_terminal_create "$ORCA_WORKTREE_ID" "$W") || exit 1
     fi
@@ -843,20 +843,29 @@ if [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   # Compare against PROJ_ABS_REAL (physical), not PROJ_ABS: a symlinked project
   # prefix would otherwise make the pane's OS-level cwd read differ from
   # PROJ_ABS on the very first poll, before the pane has actually moved.
-  for _ in $(seq 1 60); do
+  # Treehouse can also expose an intermediate setup cwd before its worktree shell
+  # starts, so accept only a candidate that already passes the isolation guard.
+  LAST_WT_CANDIDATE=
+  for _ in $(seq 1 "${FM_SPAWN_WORKTREE_POLLS:-60}"); do
     p=$(spawn_current_path "$WT_TARGET" || true)
     if [ -n "$p" ] && [ "$(real_path_or_raw "$p")" != "$PROJ_ABS_REAL" ]; then
       WT="$p"
-      break
+      LAST_WT_CANDIDATE=$p
+      if validate_spawn_worktree "treehouse get" "$T" >/dev/null 2>&1; then
+        break
+      fi
+      WT=
     fi
     sleep 1
   done
   if [ -z "$WT" ]; then
+    if [ -n "$LAST_WT_CANDIDATE" ]; then
+      WT=$LAST_WT_CANDIDATE
+      validate_spawn_worktree "treehouse get" "$T" || exit 1
+    fi
     echo "error: treehouse get did not enter a worktree within 60s; inspect window $T" >&2
     exit 1
   fi
-
-  validate_spawn_worktree "treehouse get" "$T"
 fi
 
 # Per-task temp root: /tmp/fm-<id>/ with Go's build temp nested at gotmp/. Go won't

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -161,6 +161,12 @@ FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 # shellcheck source=bin/fm-classify-lib.sh
 . "$FM_DAEMON_DIR/fm-classify-lib.sh"
 
+# Shared bounded notifier execution and argv-safe channel dispatch.
+# Channel selection, wedge-specific logging, and the durable alarm marker remain
+# owned here, while bin/fm-notify-lib.sh owns process and interpolation safety.
+# shellcheck source=bin/fm-notify-lib.sh
+. "$FM_DAEMON_DIR/fm-notify-lib.sh"
+
 # Supervisor-pane discovery (FM_SUPERVISOR_TARGET_DEFAULT,
 # FM_SUPERVISOR_BACKEND_DEFAULT, discover_supervisor_target,
 # discover_supervisor_backend). Shared with the script-owned away launcher
@@ -676,147 +682,61 @@ wedge_alarm_platform_default() {
   esac
 }
 
-wedge_alarm_run_bounded() {
-  local channel=$1 timeout monitor_was_on=0 pid start elapsed rc
-  shift
-  timeout=${FM_WEDGE_ALARM_TIMEOUT_SECS:-$WEDGE_ALARM_TIMEOUT_SECS_DEFAULT}
+wedge_alarm_run_bounded() {  # <timeout> <channel> <command> [args...]
+  local timeout=$1 channel=$2 rc
+  shift 2
   case "$timeout" in
     ''|*[!0-9]*) timeout=$WEDGE_ALARM_TIMEOUT_SECS_DEFAULT ;;
     *) [ "$timeout" -gt 0 ] 2>/dev/null || timeout=$WEDGE_ALARM_TIMEOUT_SECS_DEFAULT ;;
   esac
-  case $- in *m*) monitor_was_on=1 ;; esac
-  set -m 2>/dev/null || true
-  case $- in
-    *m*) ;;
-    *) log "wedge alarm: ${channel} notifier skipped because its watchdog could not start"; return 125 ;;
+  fm_notify_run_bounded "$timeout" "$channel" "$@"
+  rc=$?
+  case "$rc" in
+    124) log "wedge alarm: ${channel} notifier timed out after ${FM_NOTIFY_LAST_ELAPSED}s (limit ${timeout}s)" ;;
+    125) log "wedge alarm: ${channel} notifier skipped because its watchdog could not start" ;;
   esac
-  "$@" &
-  pid=$!
-  WEDGE_ALARM_NOTIFIER_PID=$pid
-  start=$SECONDS
-  while kill -0 "-$pid" 2>/dev/null; do
-    elapsed=$((SECONDS - start))
-    if [ "$elapsed" -ge "$timeout" ]; then
-      wedge_alarm_stop_active_notifier
-      [ "$monitor_was_on" -eq 1 ] || set +m 2>/dev/null || true
-      log "wedge alarm: ${channel} notifier timed out after ${elapsed}s (limit ${timeout}s)"
-      return 124
-    fi
-    sleep 0.1
-  done
-  if wait "$pid"; then rc=0; else rc=$?; fi
-  WEDGE_ALARM_NOTIFIER_PID=
-  [ "$monitor_was_on" -eq 1 ] || set +m 2>/dev/null || true
   return "$rc"
 }
 
 wedge_alarm_stop_active_notifier() {
-  local pid=${WEDGE_ALARM_NOTIFIER_PID:-}
-  [ -n "$pid" ] || return 0
-  WEDGE_ALARM_NOTIFIER_PID=
-  kill -TERM "-$pid" 2>/dev/null || kill -TERM "$pid" 2>/dev/null || true
-  sleep 0.2
-  kill -KILL "-$pid" 2>/dev/null || kill -KILL "$pid" 2>/dev/null || true
-  wait "$pid" 2>/dev/null || true
-}
-
-# The single execution seam for every configured notifier channel.
-# FM_WEDGE_ALARM_EXEC, when set, REPLACES the real notifier: the resolved channel
-# name and summary are handed to that command instead of ever invoking osascript
-# or herdr or a captain-supplied command. This is the one injection point the test harness forces to a recorder
-# so no test can post a real desktop notification - the library-mode guard at the
-# foot of this file defaults it to "discard" whenever the daemon is SOURCED
-# rather than executed, which is the only way a test reaches these functions. The
-# special value "discard" fires nothing; unset means production (the executed
-# daemon), so the real channels fire.
-wedge_alarm_os_notifier_override() {  # <channel> <summary>
-  local channel=$1 summary=$2 rc exec_override=${FM_WEDGE_ALARM_EXEC:-}
-  case "$exec_override" in
-    '') return 2 ;;
-    discard) return 0 ;;
-    *)
-      wedge_alarm_run_bounded "$channel" "$exec_override" "$channel" "$summary" >/dev/null 2>&1
-      rc=$?
-      [ "$rc" -eq 0 ] && return 0
-      log "wedge alarm: notifier override exited $rc for channel '$channel'"
-      return 1 ;;
-  esac
-}
-
-# Post a macOS Notification Center banner. `display notification` is OS-level,
-# independent of any terminal pane or multiplexer status-line. The summary is
-# passed as an argv item (never interpolated into the AppleScript source) so its
-# text can never break the script. Best-effort: logs and returns 1 on failure.
-wedge_alarm_via_osascript() {  # <summary>
-  local summary=$1 rc
-  wedge_alarm_os_notifier_override osascript "$summary"
-  rc=$?
-  case "$rc" in
-    0) return 0 ;;
-    1) return 1 ;;
-  esac
-  command -v osascript >/dev/null 2>&1 || {
-    log "wedge alarm: osascript not found; cannot post a macOS notification"; return 1; }
-  wedge_alarm_run_bounded osascript osascript -e 'on run argv' \
-    -e 'display notification (item 1 of argv) with title "firstmate: away-mode escalations WEDGED" sound name "Basso"' \
-    -e 'end run' "$summary" >/dev/null 2>&1 && return 0
-  log "wedge alarm: osascript notification failed"
-  return 1
-}
-
-# Post a herdr UI notification - herdr's own surface, separate from the pane and
-# its status-line. Best-effort: logs and returns 1 on failure.
-wedge_alarm_via_herdr() {  # <summary>
-  local summary=$1 rc
-  wedge_alarm_os_notifier_override herdr "$summary"
-  rc=$?
-  case "$rc" in
-    0) return 0 ;;
-    1) return 1 ;;
-  esac
-  command -v herdr >/dev/null 2>&1 || {
-    log "wedge alarm: herdr not found; cannot post a herdr notification"; return 1; }
-  wedge_alarm_run_bounded herdr herdr notification show "firstmate: away-mode escalations WEDGED" \
-    --body "$summary" --sound request >/dev/null 2>&1 && return 0
-  log "wedge alarm: herdr notification failed"
-  return 1
-}
-
-# Run a captain-supplied command with the summary on $1 and on stdin, so an
-# alert can reach a phone/pager (ntfy, Slack, SMS) even when the captain is away
-# from the machine entirely. Best-effort: logs and returns 1 on failure.
-wedge_alarm_via_command() {  # <cmd> <summary>
-  local cmd=$1 summary=$2 rc
-  if [ "${WEDGE_ALARM_EMIT_ACTIVE:-}" != 1 ]; then
-    wedge_alarm_emit command "$summary" "$cmd"
-    return $?
+  if [ -n "${WEDGE_ALARM_NOTIFIER_PID:-}" ] && [ -z "${FM_NOTIFY_ACTIVE_PID:-}" ]; then
+    FM_NOTIFY_ACTIVE_PID=$WEDGE_ALARM_NOTIFIER_PID
   fi
-  [ -n "$cmd" ] || { log "wedge alarm: empty command: channel; nothing to run"; return 1; }
-  wedge_alarm_run_bounded command sh -c "$cmd" fm-wedge-alarm "$summary" \
-    <<< "$summary" >/dev/null 2>&1
-  rc=$?
-  [ "$rc" -eq 0 ] && return 0
-  log "wedge alarm: command channel exited $rc (command redacted)"
-  return 1
+  WEDGE_ALARM_NOTIFIER_PID=
+  fm_notify_stop_active
+}
+
+# Direct channel helpers delegate to wedge_alarm_emit so every path crosses the
+# shared bounded and argv-safe seam in bin/fm-notify-lib.sh.
+wedge_alarm_via_osascript() {  # <summary>
+  wedge_alarm_emit osascript "$1"
+}
+
+wedge_alarm_via_herdr() {  # <summary>
+  wedge_alarm_emit herdr "$1"
+}
+
+wedge_alarm_via_command() {  # <cmd> <summary>
+  wedge_alarm_emit command "$2" "$1"
 }
 
 wedge_alarm_emit() {  # <channel> <summary>
-  local channel=$1 summary=$2 cmd=${3:-} rc exec_override=${FM_WEDGE_ALARM_EXEC:-} WEDGE_ALARM_EMIT_ACTIVE=1
-  case "$exec_override" in
-    '') ;;
-    discard) return 0 ;;
-    *)
-      wedge_alarm_run_bounded "$channel" "$exec_override" "$channel" "$summary" >/dev/null 2>&1
-      rc=$?
-      [ "$rc" -eq 0 ] && return 0
-      log "wedge alarm: notifier override exited $rc for channel '$channel'"
-      return 1 ;;
-  esac
-  case "$channel" in
-    osascript) wedge_alarm_via_osascript "$summary" ;;
-    herdr) wedge_alarm_via_herdr "$summary" ;;
-    command) wedge_alarm_via_command "$cmd" "$summary" ;;
-  esac
+  local channel=$1 summary=$2 cmd=${3:-} rc timeout exec_override=${FM_WEDGE_ALARM_EXEC:-}
+  timeout=${FM_WEDGE_ALARM_TIMEOUT_SECS:-$WEDGE_ALARM_TIMEOUT_SECS_DEFAULT}
+  fm_notify_emit wedge_alarm_run_bounded "$exec_override" "$timeout" "$channel" \
+    'firstmate: away-mode escalations WEDGED' "$summary" Basso "$cmd"
+  rc=$?
+  [ "$rc" -eq 0 ] && return 0
+  if [ -n "$exec_override" ] && [ "$exec_override" != discard ]; then
+    log "wedge alarm: notifier override exited $rc for channel '$channel'"
+  else
+    case "$channel" in
+      command) log "wedge alarm: command channel exited $rc (command redacted)" ;;
+      osascript) log "wedge alarm: osascript notification failed" ;;
+      herdr) log "wedge alarm: herdr notification failed" ;;
+    esac
+  fi
+  return 1
 }
 
 # Fire every configured active-alert channel, best-effort. Always returns 0: a

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -517,11 +517,8 @@ alert_decisions_in_status() {  # <status-file>
 }
 
 alert_all_open_decisions() {
-  local f
-  for f in "$STATE"/*.status; do
-    [ -e "$f" ] || continue
-    alert_decisions_in_status "$f"
-  done
+  [ -x "$FM_DECISION_ALERT_BIN" ] || return 0
+  "$FM_DECISION_ALERT_BIN" scan-state >/dev/null 2>&1 || true
 }
 
 # Record a status file's captain-relevant last line as surfaced (no-op for a

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -77,6 +77,11 @@ mkdir -p "$STATE"
 # shellcheck source=bin/fm-check-lib.sh
 . "$SCRIPT_DIR/fm-check-lib.sh"
 
+# Worker-originated captain decisions alert at the same deterministic boundary
+# that durably enqueues their wake.
+# The executable is overridable for focused watcher tests.
+FM_DECISION_ALERT_BIN=${FM_DECISION_ALERT_BIN:-$SCRIPT_DIR/fm-decision-alert.sh}
+
 WATCH_LOCK="$STATE/.watch.lock"
 WATCH_PATH="$SCRIPT_DIR/fm-watch.sh"
 WATCHER_STALE_GRACE=${FM_WATCHER_STALE_GRACE:-${FM_GUARD_GRACE:-300}}
@@ -504,11 +509,27 @@ run_check_capture() {
 # from one that has not - the latter being a per-wake-path miss it must surface.
 _hb_surfaced_path() { printf '%s/.hb-surfaced-%s' "$STATE" "$(printf '%s' "$1" | tr ':/.' '___')"; }
 
+alert_decisions_in_status() {  # <status-file>
+  local f=$1
+  case "$f" in *.status) ;; *) return 0 ;; esac
+  [ -x "$FM_DECISION_ALERT_BIN" ] || return 0
+  "$FM_DECISION_ALERT_BIN" status "$f" >/dev/null 2>&1 || true
+}
+
+alert_all_open_decisions() {
+  local f
+  for f in "$STATE"/*.status; do
+    [ -e "$f" ] || continue
+    alert_decisions_in_status "$f"
+  done
+}
+
 # Record a status file's captain-relevant last line as surfaced (no-op for a
 # non-captain-relevant or empty status). Call AFTER the wake is enqueued, so the
 # enqueue-before-suppress ordering holds for this marker too.
 mark_surfaced() {  # <status-file>
   local f=$1 task last
+  alert_decisions_in_status "$f"
   task=$(basename "$f"); task="${task%.status}"
   last=$(last_status_line "$f")
   [ -n "$last" ] || return 0
@@ -523,6 +544,7 @@ mark_all_captain_relevant_surfaced() {
   local f task last
   while IFS=$(printf '\t') read -r f task last; do
     [ -n "$f" ] || continue
+    alert_decisions_in_status "$f"
     printf '%s' "$last" > "$(_hb_surfaced_path "$task")"
   done < <(scan_captain_relevant_statuses "$STATE")
 }
@@ -824,6 +846,11 @@ EOF
       while IFS=$(printf '\t') read -r sf sig f; do
         [ -n "$sf" ] || continue
         printf '%s' "$sig" > "$sf"
+        # The whole-stream decision fold can retain an earlier open decision
+        # behind a later routine status line.
+        # The status record is already durable even though this routine signal
+        # needs no wake, so alert it here and let identity dedup suppress retries.
+        alert_decisions_in_status "$f"
       done <<EOF
 $pending
 EOF
@@ -1004,6 +1031,7 @@ EOF
     if afk_present; then
       fm_wake_append heartbeat heartbeat heartbeat || exit 1
       touch "$STATE/.last-heartbeat"
+      alert_all_open_decisions
       wake "heartbeat"
     elif heartbeat_scan_finds_actionable; then
       # Backstop: a captain-relevant status the per-wake path absorbed by mistake.
@@ -1015,6 +1043,7 @@ EOF
       wake "heartbeat"
     else
       touch "$STATE/.last-heartbeat"
+      alert_all_open_decisions
       echo $(( $(cat "$STATE/.heartbeat-streak" 2>/dev/null || echo 0) + 1 )) > "$STATE/.heartbeat-streak"
       triage_log "absorbed heartbeat (no captain-relevant change)"
     fi

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -108,7 +108,7 @@ See [`wedge-alarm.md`](wedge-alarm.md) for the channel reference and macOS verif
 An absent file means `auto`, which posts an audible Notification Center alert on macOS and selects no built-in channel on other platforms.
 The directives are `off`, `auto` or `default`, `osascript`, `herdr`, and `command:<cmd>`.
 `FM_DECISION_ALERT_CHANNEL` overrides the file with one directive.
-Every notifier is bounded, uses a generic privacy-safe body, and is best-effort after the durable decision boundary.
+Every notifier channel and complete alert invocation are bounded, use a generic privacy-safe body, and are best-effort after the durable decision boundary.
 See [`decision-alert.md`](decision-alert.md) for trigger coverage, deduplication, supported-surface evidence, test safety, and the direct-prompt limitation.
 See [`examples/decision-alert`](examples/decision-alert) for a copyable config.
 
@@ -438,6 +438,7 @@ FM_WEDGE_ALARM_EXEC=              # notifier seam: route every channel (osascrip
 FM_DECISION_ALERT_CHANNEL=        # override config/decision-alert with one directive; off|auto|osascript|herdr|command:<cmd>; absent = auto (macOS -> audible Notification Center alert)
 FM_DECISION_ALERT_EXEC=           # test seam replacing every real decision notifier as `<cmd> <channel> <body>`; "discard" fires nothing; unset in production (docs/decision-alert.md)
 FM_DECISION_ALERT_TIMEOUT_SECS=   # per-channel decision notifier process-group timeout; default 10
+FM_DECISION_ALERT_TOTAL_TIMEOUT_SECS= # total timeout shared by all decisions and channels in one alert invocation; default 10
 FM_WEDGE_ALARM_TIMEOUT_SECS=10    # maximum seconds for each osascript, herdr, override, or command: notifier before its watchdog terminates it and continues to the next channel; invalid or zero values use 10
 FM_INJECT_FAIL_SLEEP=30            # seconds to back off when the supervisor pane is unavailable
 FM_INJECT_CONFIRM_RETRIES=3        # daemon Enter-retry attempts after typing a digest once

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -108,7 +108,7 @@ See [`wedge-alarm.md`](wedge-alarm.md) for the channel reference and macOS verif
 An absent file means `auto`, which posts an audible Notification Center alert on macOS and selects no built-in channel on other platforms.
 The directives are `off`, `auto` or `default`, `osascript`, `herdr`, and `command:<cmd>`.
 `FM_DECISION_ALERT_CHANNEL` overrides the file with one directive.
-Every notifier channel and complete alert invocation are bounded, use a generic privacy-safe body, and are best-effort after the durable decision boundary.
+Every notifier channel is bounded, all notifier dispatch in one invocation shares a total time budget, and delivery uses a generic privacy-safe body after the durable decision boundary.
 See [`decision-alert.md`](decision-alert.md) for trigger coverage, deduplication, supported-surface evidence, test safety, and the direct-prompt limitation.
 See [`examples/decision-alert`](examples/decision-alert) for a copyable config.
 
@@ -438,7 +438,7 @@ FM_WEDGE_ALARM_EXEC=              # notifier seam: route every channel (osascrip
 FM_DECISION_ALERT_CHANNEL=        # override config/decision-alert with one directive; off|auto|osascript|herdr|command:<cmd>; absent = auto (macOS -> audible Notification Center alert)
 FM_DECISION_ALERT_EXEC=           # test seam replacing every real decision notifier as `<cmd> <channel> <body>`; "discard" fires nothing; unset in production (docs/decision-alert.md)
 FM_DECISION_ALERT_TIMEOUT_SECS=   # per-channel decision notifier process-group timeout; default 10
-FM_DECISION_ALERT_TOTAL_TIMEOUT_SECS= # total timeout shared by all decisions and channels in one alert invocation; default 10
+FM_DECISION_ALERT_TOTAL_TIMEOUT_SECS= # notifier-dispatch timeout shared by all decisions and channels in one alert invocation; default 10
 FM_WEDGE_ALARM_TIMEOUT_SECS=10    # maximum seconds for each osascript, herdr, override, or command: notifier before its watchdog terminates it and continues to the next channel; invalid or zero values use 10
 FM_INJECT_FAIL_SLEEP=30            # seconds to back off when the supervisor pane is unavailable
 FM_INJECT_CONFIRM_RETRIES=3        # daemon Enter-retry attempts after typing a digest once

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -102,6 +102,16 @@ An absent file means `auto`, i.e. default-on on macOS: the alarm exists precisel
 A missing or failing channel logs and falls through to the next, never crashing the daemon.
 See [`wedge-alarm.md`](wedge-alarm.md) for the channel reference and macOS verification evidence, and [`examples/wedge-alarm`](examples/wedge-alarm) for a copyable config.
 
+## Captain decision alert channels (config/decision-alert)
+
+`config/decision-alert` is a local gitignored channel list for audible and visible alerts when Firstmate needs a captain-owned approval or user-specific decision.
+An absent file means `auto`, which posts an audible Notification Center alert on macOS and selects no built-in channel on other platforms.
+The directives are `off`, `auto` or `default`, `osascript`, `herdr`, and `command:<cmd>`.
+`FM_DECISION_ALERT_CHANNEL` overrides the file with one directive.
+Every notifier is bounded, uses a generic privacy-safe body, and is best-effort after the durable decision boundary.
+See [`decision-alert.md`](decision-alert.md) for trigger coverage, deduplication, supported-surface evidence, test safety, and the direct-prompt limitation.
+See [`examples/decision-alert`](examples/decision-alert) for a copyable config.
+
 ## Gate defaults (.no-mistakes.yaml)
 
 The tracked `.no-mistakes.yaml` keeps test evidence outside the repo and defines `commands.test` so no-mistakes runs firstmate's bash behavior suite directly.
@@ -425,6 +435,9 @@ FM_ESCALATE_BATCH_SECS=90          # buffer window for batched escalation digest
 FM_MAX_DEFER_SECS=300              # max buffered escalation age before retry plus wedge alarm; 0 disables
 FM_WEDGE_ALARM_CHANNEL=            # override config/wedge-alarm with one active-alert directive for the wedge alarm; off|auto|osascript|herdr|command:<cmd>; absent = auto (macOS -> an OS notification)
 FM_WEDGE_ALARM_EXEC=              # notifier seam: route every channel (osascript, herdr, command:) through this command as `<cmd> <channel> <summary>`; "discard" fires nothing; unset in production; the daemon defaults it to "discard" when sourced so no test posts a real notification (docs/wedge-alarm.md)
+FM_DECISION_ALERT_CHANNEL=        # override config/decision-alert with one directive; off|auto|osascript|herdr|command:<cmd>; absent = auto (macOS -> audible Notification Center alert)
+FM_DECISION_ALERT_EXEC=           # test seam replacing every real decision notifier as `<cmd> <channel> <body>`; "discard" fires nothing; unset in production (docs/decision-alert.md)
+FM_DECISION_ALERT_TIMEOUT_SECS=   # per-channel decision notifier process-group timeout; default 10
 FM_WEDGE_ALARM_TIMEOUT_SECS=10    # maximum seconds for each osascript, herdr, override, or command: notifier before its watchdog terminates it and continues to the next channel; invalid or zero values use 10
 FM_INJECT_FAIL_SLEEP=30            # seconds to back off when the supervisor pane is unavailable
 FM_INJECT_CONFIRM_RETRIES=3        # daemon Enter-retry attempts after typing a digest once

--- a/docs/decision-alert.md
+++ b/docs/decision-alert.md
@@ -45,6 +45,8 @@ Other platforms have no built-in `auto` channel and can opt into `herdr` or a `c
 See [`examples/decision-alert`](examples/decision-alert) for a copyable file.
 
 Every channel is bounded by `FM_DECISION_ALERT_TIMEOUT_SECS`, which defaults to 10 seconds.
+The complete command is bounded by `FM_DECISION_ALERT_TOTAL_TIMEOUT_SECS`, which also defaults to 10 seconds and is shared across every open decision and configured channel in that invocation.
+Heartbeat fleet scans use one `scan-state` invocation, so the total bound also covers every status file in the scan.
 All execution routes through `bin/fm-notify-lib.sh`, extracted from the existing wedge-alarm seam.
 AppleScript receives title, body, and sound as argv items rather than source interpolation.
 A configured command receives the generic body in `$1` and on stdin, never as shell source.

--- a/docs/decision-alert.md
+++ b/docs/decision-alert.md
@@ -93,13 +93,11 @@ ok - only open needs-decision events alert, and status/direct delivery deduplica
 ok - off, environment override, and multi-channel config behave deterministically
 ok - macOS uses an audible argv-safe notification and command data never becomes shell source
 ok - notifier failure never blocks the decision path and repeated delivery stays at most once
+ok - one total deadline bounds concurrent decisions, channels, and heartbeat status files
+ok - decision alert execution stays within eight concurrent workers
+ok - an integer deadline tick still starts the first bounded worker batch
+ok - Bash 3.2 empty retry batches preserve later decision alerts
 ok - the watcher invokes the automatic boundary and library-mode tests default to discard
-
-$ failures=0; count=0; for test_script in tests/*.test.sh; do count=$((count + 1)); output=$(bash "$test_script" 2>&1); rc=$?; if [ "$rc" -ne 0 ]; then failures=$((failures + 1)); fi; done; printf 'SUMMARY scripts=%s failures=%s\n' "$count" "$failures"; [ "$failures" -eq 0 ]
-SUMMARY scripts=79 failures=0
-
-$ nix-shell -p shellcheck --run 'bin/fm-lint.sh'
-fm-lint.sh: ShellCheck 0.11.0 (pinned 0.11.0)
 
 $ git diff --check
 (no output)

--- a/docs/decision-alert.md
+++ b/docs/decision-alert.md
@@ -47,7 +47,9 @@ See [`examples/decision-alert`](examples/decision-alert) for a copyable file.
 Every channel is bounded by `FM_DECISION_ALERT_TIMEOUT_SECS`, which defaults to 10 seconds.
 The complete command is bounded by `FM_DECISION_ALERT_TOTAL_TIMEOUT_SECS`, which also defaults to 10 seconds and is shared across every open decision and configured channel in that invocation.
 Heartbeat fleet scans use one `scan-state` invocation, so the total bound also covers every status file in the scan.
-All enabled channel attempts for every open decision run concurrently within that shared deadline, so a hung notifier cannot starve a healthy fallback or a later decision.
+The dispatcher collects open decisions before execution and runs at most eight notifier workers concurrently within the shared deadline.
+It schedules complete channel sets for each claimed identity together and divides remaining time across pending batches, so a hung notifier cannot starve a healthy fallback while process fan-out stays fixed.
+Configurations with more than eight valid channel directives use the first eight and log one redacted limit diagnostic.
 All execution routes through `bin/fm-notify-lib.sh`, extracted from the existing wedge-alarm seam.
 AppleScript receives title, body, and sound as argv items rather than source interpolation.
 A configured command receives the generic body in `$1` and on stdin, never as shell source.

--- a/docs/decision-alert.md
+++ b/docs/decision-alert.md
@@ -47,6 +47,7 @@ See [`examples/decision-alert`](examples/decision-alert) for a copyable file.
 Every channel is bounded by `FM_DECISION_ALERT_TIMEOUT_SECS`, which defaults to 10 seconds.
 The complete command is bounded by `FM_DECISION_ALERT_TOTAL_TIMEOUT_SECS`, which also defaults to 10 seconds and is shared across every open decision and configured channel in that invocation.
 Heartbeat fleet scans use one `scan-state` invocation, so the total bound also covers every status file in the scan.
+All enabled channel attempts for every open decision run concurrently within that shared deadline, so a hung notifier cannot starve a healthy fallback or a later decision.
 All execution routes through `bin/fm-notify-lib.sh`, extracted from the existing wedge-alarm seam.
 AppleScript receives title, body, and sound as argv items rather than source interpolation.
 A configured command receives the generic body in `$1` and on stdin, never as shell source.

--- a/docs/decision-alert.md
+++ b/docs/decision-alert.md
@@ -45,7 +45,7 @@ Other platforms have no built-in `auto` channel and can opt into `herdr` or a `c
 See [`examples/decision-alert`](examples/decision-alert) for a copyable file.
 
 Every channel is bounded by `FM_DECISION_ALERT_TIMEOUT_SECS`, which defaults to 10 seconds.
-The complete command is bounded by `FM_DECISION_ALERT_TOTAL_TIMEOUT_SECS`, which also defaults to 10 seconds and is shared across every open decision and configured channel in that invocation.
+Notifier dispatch is bounded by `FM_DECISION_ALERT_TOTAL_TIMEOUT_SECS`, which also defaults to 10 seconds and is shared across every open decision and configured channel in that invocation.
 Heartbeat fleet scans use one `scan-state` invocation, so the total bound also covers every status file in the scan.
 The dispatcher collects open decisions before execution and runs at most eight notifier workers concurrently within the shared deadline.
 It schedules complete channel sets for each claimed identity together and divides remaining time across pending batches, so a hung notifier cannot starve a healthy fallback while process fan-out stays fixed.

--- a/docs/decision-alert.md
+++ b/docs/decision-alert.md
@@ -1,0 +1,101 @@
+# Captain decision alert
+
+`bin/fm-decision-alert.sh` is the mechanism owner for audible and visible alerts when Firstmate needs a captain decision.
+Its header and `--help` output own exact commands, environment variables, identity grammar, and marker paths.
+This document records the integration boundaries, safety properties, supported-surface review, and verification evidence.
+
+## Trigger boundaries
+
+Worker-originated decisions alert automatically at the shared watcher surface boundary.
+After `bin/fm-watch.sh` durably enqueues an actionable status wake, it passes the status file to `fm-decision-alert.sh status` before recording that status as surfaced.
+The alert script folds the whole append-only stream through `status_open_decisions` from `bin/fm-classify-lib.sh` and selects only still-open `needs-decision` records.
+It does not alert for `working`, `blocked`, `paused`, `done`, `failed`, `captain-held`, or `resolved` events.
+The heartbeat backstop also scans open decisions after enqueue, so a missed per-signal path does not leave an unattempted alert.
+The same watcher path runs while away mode is active, before the daemon performs its separate escalation classification.
+
+Investigation and visual-review decisions alert automatically at the durable hold boundary.
+`bin/fm-decision-hold.sh hold` first creates or updates the captain hold and verifies it active, then makes a best-effort alert attempt with the same origin and decision key used by a matching worker status.
+A notifier failure therefore cannot prevent, weaken, or reverse the durable decision record.
+
+Direct Firstmate approval prompts use the explicit `prompt` helper immediately before the captain-facing question.
+`AGENTS.md` section 9 carries the always-loaded reminder, while the script help owns the invocation syntax.
+This is the one non-automatic path because the supported primary harnesses expose lifecycle hooks, not one common semantic boundary for an outgoing assistant message that asks for approval.
+Parsing rendered terminal output or model prose would be nondeterministic, would couple the alert to UI wording, and could expose decision text to notification channels.
+
+## Stable identity and deduplication
+
+Every alert uses a stable pair of privacy-safe slugs: the originating work identity and decision key.
+The script hashes that pair and atomically claims an empty `state/.decision-alerted-<digest>` marker before notifier execution.
+No decision summary, prompt text, project path, or other private content enters the marker name or body.
+Worker status, durable hold, heartbeat recovery, and direct prompt delivery deduplicate when they use the same pair.
+An `off` configuration does not consume the identity, so enabling alerts later can still notify for an open decision.
+Once an enabled channel set claims the identity, notifier failure remains at most once and does not create a retry loop.
+A genuinely new decision must use a new key, matching the existing decision-hold lifecycle rule.
+
+## Channels and macOS behavior
+
+Local gitignored `config/decision-alert` accepts one non-empty, non-comment channel directive per line.
+`FM_DECISION_ALERT_CHANNEL` replaces the file with one directive for an invocation.
+The supported directives are `off`, `auto` or `default`, `osascript`, `herdr`, and `command:<cmd>`.
+An `off` directive disables the whole alert regardless of its position.
+An absent file means `auto`.
+On macOS, `auto` resolves to an OS-level Notification Center banner titled `Firstmate needs your decision` with the `Basso` system sound.
+The notification body is deliberately generic, so a lock-screen banner or external channel never exposes the decision.
+Other platforms have no built-in `auto` channel and can opt into `herdr` or a `command:` channel.
+See [`examples/decision-alert`](examples/decision-alert) for a copyable file.
+
+Every channel is bounded by `FM_DECISION_ALERT_TIMEOUT_SECS`, which defaults to 10 seconds.
+All execution routes through `bin/fm-notify-lib.sh`, extracted from the existing wedge-alarm seam.
+AppleScript receives title, body, and sound as argv items rather than source interpolation.
+A configured command receives the generic body in `$1` and on stdin, never as shell source.
+The library terminates the notifier process group on timeout so a background descendant cannot outlive the bound.
+
+`FM_DECISION_ALERT_EXEC` replaces every real notifier with a test executable invoked with the resolved channel and generic body.
+The special value `discard` executes nothing.
+Sourcing `fm-decision-alert.sh` defaults the seam to `discard`, and `tests/lib.sh` exports `discard` for the complete behavior suite so tests that reach a real watcher or decision hold cannot post a notification or play a sound.
+
+## Supported primary harness review
+
+The supported primary harness review was performed on 2026-07-19 against the tracked integration files.
+
+- Claude uses the `Stop` hook in `.claude/settings.json`, whose payload supports stop-loop control but does not identify the semantic content of the assistant message.
+- Codex uses the `Stop` hook in `.codex/hooks.json`, with the same lifecycle-only boundary.
+- OpenCode uses `session.idle` in `.opencode/plugins/fm-primary-turnend-guard.js`, which reports session lifecycle after output rather than classifying the output.
+- Pi uses `agent_settled` in `.pi/extensions/fm-primary-turnend-guard.ts`, which likewise has no shared approval-prompt semantic.
+- Grok uses the passive `Stop` hook in `.grok/hooks/fm-primary-turnend-guard.json`, whose adapter receives session lifecycle data rather than a normalized outgoing-message decision event.
+
+No harness-specific alert hook was added because none can provide complete equivalent semantics across all five supported primaries.
+The automatic worker and hold boundaries are harness-independent, and the explicit direct-prompt helper is the smallest equivalent reminder available to every primary.
+
+## Supported runtime backend review
+
+The supported runtime backend review was performed on 2026-07-19 against `bin/fm-backend.sh`, `bin/backends/*.sh`, and the watcher integration.
+
+- tmux, zellij, Orca, and cmux use the watcher's backend-neutral pull loop to synthesize status signals, then converge on the same post-enqueue surface function.
+- Herdr adds a native `pane.agent_status_changed` fast path for `blocked`, but `blocked` is not sufficient evidence of a captain-owned decision and intentionally does not alert.
+- Herdr status-file writes still use the same watcher signal path as every other backend, so a real `needs-decision` event receives automatic coverage.
+- Away-mode injection supports only its separately verified supervisor backends, but decision alerting happens in the watcher before away-mode classification and therefore does not depend on the injection backend.
+
+No runtime backend adapter changed because the authoritative input is the shared durable status stream, not terminal rendering, native pane status, or composer behavior.
+
+## Verification record
+
+Verification date: 2026-07-19.
+
+```text
+$ bash tests/fm-decision-alert.test.sh
+ok - only open needs-decision events alert, and status/direct delivery deduplicates by origin and key
+ok - off, environment override, and multi-channel config behave deterministically
+ok - macOS uses an audible argv-safe notification and command data never becomes shell source
+ok - notifier failure never blocks the decision path and repeated delivery stays at most once
+ok - the watcher invokes the automatic boundary and library-mode tests default to discard
+
+$ failures=0; count=0; for test_script in tests/*.test.sh; do count=$((count + 1)); output=$(bash "$test_script" 2>&1); rc=$?; if [ "$rc" -ne 0 ]; then failures=$((failures + 1)); fi; done; printf 'SUMMARY scripts=%s failures=%s\n' "$count" "$failures"; [ "$failures" -eq 0 ]
+SUMMARY scripts=79 failures=0
+
+$ nix-shell -p shellcheck --run 'bin/fm-lint.sh'
+fm-lint.sh: ShellCheck 0.11.0 (pinned 0.11.0)
+
+$ git diff --check
+(no output)
+```

--- a/docs/decision-hold-lifecycle.md
+++ b/docs/decision-hold-lifecycle.md
@@ -12,6 +12,8 @@ It never reads report bodies, review artifacts, terminal output, or chat.
 The `hold` subcommand maps an originating work id and stable decision key to `<origin-id>-decision-<decision-key>`.
 It creates a kind `captain` backlog item when absent and invokes `tasks-axi hold <id> --reason <reason> --kind captain` on every retry.
 It rejects an identity collision, a changed title, and attempts to reopen an already resolved identity.
+After the hold is verified active, it makes a best-effort alert attempt through `bin/fm-decision-alert.sh` using the same origin and decision key as a matching worker status alert.
+Notifier failure never changes the durable hold result.
 
 The `complete` subcommand unions the reviewed keys into `decision_keys=` and appends `decisions_reviewed=1` while originating task metadata is live.
 A post-teardown visual review can complete against the surviving report and durable holds without recreating volatile task metadata.

--- a/docs/examples/decision-alert
+++ b/docs/examples/decision-alert
@@ -1,0 +1,12 @@
+# Firstmate captain decision alert channels.
+# Copy to <FM_HOME>/config/decision-alert and keep it local.
+
+# Default macOS Notification Center banner with a system sound.
+auto
+
+# Optional additional channels.
+# herdr
+# command:ntfy publish firstmate-decisions "$1"
+
+# Disable every active decision alert.
+# off

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -17,6 +17,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-update.sh`           | Fast-forward-only self-update of firstmate and secondmate homes from origin          |
 | `fm-backlog-handoff.sh`  | Validate and delegate queued backlog-item moves into a secondmate home               |
 | `fm-decision-hold.sh`    | Create, verify, complete, and resolve durable captain-held decisions                 |
+| `fm-decision-alert.sh`   | Post bounded, deduplicated alerts for captain-owned decisions and direct prompts     |
 | `fm-brief.sh`            | Scaffold ship, scout, secondmate-charter, and Herdr-lab briefs                       |
 | `fm-herdr-lab.sh`        | Provision and guardedly operate an isolated, never-default Herdr lab session         |
 | `fm-ensure-agents-md.sh` | Ensure a project's real `AGENTS.md`, its `CLAUDE.md` symlink, and the canonical self-governance section |
@@ -64,6 +65,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-wake-drain.sh`       | Atomically drain queued watcher wakes, then assert watcher liveness                  |
 | `fm-wake-lib.sh`         | Shared durable wake queue, portable locks, and watcher identity/health helpers       |
 | `fm-classify-lib.sh`     | Shared captain-relevant and declared-external-wait wake classification vocabulary    |
+| `fm-notify-lib.sh`       | Shared bounded and data-safe notification channel execution                          |
 | `fm-send.sh`             | Send one verified literal line or supported key through the target's recorded backend |
 | `fm-tmux-lib.sh`         | Shared tmux pane primitives for busy detection, composer capture, and verified submit |
 | `fm-peek.sh`             | Print a bounded tail of a crewmate endpoint                                          |

--- a/docs/wedge-alarm.md
+++ b/docs/wedge-alarm.md
@@ -37,7 +37,8 @@ See `docs/examples/wedge-alarm` for a copyable starting config.
 
 ## Test safety: no test posts a real notification
 
-Every notifier channel (`osascript`, `herdr`, and `command:`) routes through a single seam, `FM_WEDGE_ALARM_EXEC`: when it is set, the daemon hands the fixed channel category and summary to that command instead of the real notifier (`wedge_alarm_emit` in `bin/fm-supervise-daemon.sh`).
+Every notifier channel (`osascript`, `herdr`, and `command:`) routes through the shared bounded execution seam in `bin/fm-notify-lib.sh`.
+`FM_WEDGE_ALARM_EXEC` remains the wedge-specific test override: when it is set, the daemon hands the fixed channel category and summary to that command instead of the real notifier (`wedge_alarm_emit` in `bin/fm-supervise-daemon.sh`).
 This makes it structurally impossible for a test to post a real desktop notification, and impossible for a future test author to forget to stub:
 
 - The daemon is only ever sourced (not executed) by tests - production `bin/fm-afk-start.sh` execs it.

--- a/docs/wedge-alarm.md
+++ b/docs/wedge-alarm.md
@@ -84,5 +84,5 @@ The daemon redirects this stdout to `/dev/null` and treats a zero exit as succes
 
 ### command channel dispatch (summary on $1 and stdin)
 
-The `command:` channel runs `sh -c "<cmd>" fm-wedge-alarm "<summary>"` with the summary also piped on stdin.
+The `command:` channel runs `sh -c "<cmd>" fm-notify "<summary>"` with the summary also piped on stdin.
 `test_wedge_alarm_command_channel_receives_summary` deliberately unsets the seam for a safe file-writing command to verify this dispatch contract without a notification.

--- a/tests/fm-backend-autodetect-smoke.test.sh
+++ b/tests/fm-backend-autodetect-smoke.test.sh
@@ -85,7 +85,8 @@ PROJ="$TMP_ROOT/scratch-project"
 mkdir -p "$PROJ"
 git -C "$PROJ" init -q
 printf '# scratch\n' > "$PROJ/README.md"
-git -C "$PROJ" add README.md
+printf 'max_trees = 2\nroot = "%s"\n' "$TMP_ROOT/treehouse-pool" > "$PROJ/treehouse.toml"
+git -C "$PROJ" add README.md treehouse.toml
 git -C "$PROJ" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm initial
 
 # --- spawn with NO explicit backend config; HERDR_ENV=1 is the only marker --

--- a/tests/fm-backend-herdr-workspace-per-home-e2e.test.sh
+++ b/tests/fm-backend-herdr-workspace-per-home-e2e.test.sh
@@ -90,17 +90,18 @@ printf 'e2esm1\n' > "$SM_HOME/.fm-secondmate-home"
 printf 'trivial e2e secondmate charter: nothing to do.\n' > "$SM_HOME/data/charter.md"
 printf 'trivial e2e secondmate-owned crewmate brief: nothing to do.\n' > "$SM_HOME/data/cm2/brief.md"
 
-make_scratch_project() {  # <dir>
-  local dir=$1
+make_scratch_project() {  # <dir> <treehouse-root>
+  local dir=$1 treehouse_root=$2
   mkdir -p "$dir"
   git -C "$dir" init -q
   printf '# scratch\n' > "$dir/README.md"
-  git -C "$dir" add README.md
+  printf 'max_trees = 2\nroot = "%s"\n' "$treehouse_root" > "$dir/treehouse.toml"
+  git -C "$dir" add README.md treehouse.toml
   git -C "$dir" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm initial
 }
 
-PROJ1="$TMP_ROOT/scratch-project-1"; make_scratch_project "$PROJ1"
-PROJ2="$TMP_ROOT/scratch-project-2"; make_scratch_project "$PROJ2"
+PROJ1="$TMP_ROOT/scratch-project-1"; make_scratch_project "$PROJ1" "$TMP_ROOT/treehouse-pool-1"
+PROJ2="$TMP_ROOT/scratch-project-2"; make_scratch_project "$PROJ2" "$TMP_ROOT/treehouse-pool-2"
 
 # --- 1. primary-shaped home: a crewmate spawns into the "firstmate" space ---
 

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -817,7 +817,7 @@ test_composer_state_bare_prompt_is_empty() {
   dir="$TMP_ROOT/composer-bare"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   printf '  ╭────────────────────────╮\n  │ ❯                      │\n  ╰──────── Composer ─────╯\n\n  Shift+Tab:mode\n' > "$resp/1.out"
   fb=$(make_herdr_fakebin "$dir")
-  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+  out=$( LC_ALL=C PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
     bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_composer_state default:w1:p2' "$ROOT" )
   [ "$out" = empty ] || fail "a bare prompt glyph should read as empty, got '$out'"
   pass "fm_backend_herdr_composer_state: a bare '❯' composer row reads empty"
@@ -886,7 +886,7 @@ test_composer_state_unknown_when_no_composer_row_found() {
   done
   fb=$(make_herdr_fakebin "$dir")
   for glyph in '>' '$' '%' '#'; do
-    out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    out=$( LC_ALL=C PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
       bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_composer_state default:w1:p2' "$ROOT" )
     [ "$out" = unknown ] || fail "a bare shell prompt '$glyph' should read as unknown, got '$out'"
   done

--- a/tests/fm-backend.test.sh
+++ b/tests/fm-backend.test.sh
@@ -799,8 +799,8 @@ run_spawn_case() {  # <bin-root> <fakebin> <log> <state> <data> <config> <proj> 
 # first pane_current_path poll, then the real worktree path from the second poll
 # onward, so this test fails loudly if the PROJ_ABS/PROJ_ABS_REAL
 # canonicalization in bin/fm-spawn.sh ever regresses.
-make_spawn_symlink_fakebin() {  # <dir> <initial-project-path> <worktree-path> -> echoes fakebin dir
-  local dir=$1 initial_path=$2 wt=$3 fb="$1/fakebin" counter="$1/poll-count"
+make_spawn_symlink_fakebin() {  # <dir> <initial-project-path> <worktree-path> [transient-path] -> echoes fakebin dir
+  local dir=$1 initial_path=$2 wt=$3 transient_path=${4:-} fb="$1/fakebin" counter="$1/poll-count"
   mkdir -p "$fb"
   : > "$counter"
   cat > "$fb/tmux" <<SH
@@ -811,8 +811,11 @@ case "\${1:-}" in
   display-message)
     for a in "\$@"; do case "\$a" in *pane_current_path*)
       printf x >> "$counter"
-      if [ "\$(wc -c < "$counter")" -le 1 ]; then
+      poll_count=\$(wc -c < "$counter")
+      if [ "\$poll_count" -le 1 ]; then
         printf '%s\\n' "$initial_path"
+      elif [ -n "$transient_path" ] && [ "\$poll_count" -eq 2 ]; then
+        printf '%s\\n' "$transient_path"
       else
         printf '%s\\n' "$wt"
       fi
@@ -869,6 +872,32 @@ test_spawn_symlinked_project_prefix_avoids_false_refusal() {
   run_spawn_symlink_case physical physical
   run_spawn_symlink_case logical logical
   pass "fm-spawn.sh: a project reached through a symlinked prefix (e.g. macOS /tmp -> /private/tmp) does not trip the isolation guard's false refusal"
+}
+
+test_spawn_retries_transient_non_worktree_cwd() {
+  local proj wt transient id fb data state config log out rc
+  proj="$TMP_ROOT/transient-cwd-proj"
+  wt="$TMP_ROOT/transient-cwd-wt"
+  transient="$TMP_ROOT/transient-cwd-setup"
+  id="spawntransientcwd"
+  fm_git_worktree "$proj" "$wt" "fm/$id"
+  mkdir -p "$transient"
+  fb=$(make_spawn_symlink_fakebin "$TMP_ROOT/transient-cwd-fake" "$proj" "$wt" "$transient")
+  data="$TMP_ROOT/transient-cwd-data"
+  mkdir -p "$data/$id"
+  printf 'test brief content\n' > "$data/$id/brief.md"
+  state="$TMP_ROOT/transient-cwd-state"; config="$TMP_ROOT/transient-cwd-config"
+  mkdir -p "$state" "$config"
+  log="$TMP_ROOT/transient-cwd-spawn.log"
+
+  out=$(run_spawn_case "$ROOT" "$fb" "$log" "$state" "$data" "$config" "$proj" -- "$id" "$proj" claude 2>&1)
+  rc=$?
+  expect_code 0 "$rc" "fm-spawn.sh should retry past a transient non-worktree cwd"$'\n'"$out"
+  assert_contains "$out" "worktree=$wt" \
+    "fm-spawn.sh did not wait for the genuine isolated worktree after a transient setup cwd"
+
+  rm -rf "/tmp/fm-$id"
+  pass "fm-spawn.sh: transient Treehouse setup cwd is retried until an isolated worktree appears"
 }
 
 # --- old vs new: fm-teardown.sh ----------------------------------------------
@@ -1084,6 +1113,7 @@ test_backend_of_selector_matches_explicit_target_meta
 test_send_conformance_old_vs_new
 test_peek_conformance_old_vs_new
 test_spawn_symlinked_project_prefix_avoids_false_refusal
+test_spawn_retries_transient_non_worktree_cwd
 test_teardown_conformance_old_vs_new
 test_spawn_refuses_unknown_backend_flag
 test_spawn_refuses_codex_app_backend_flag

--- a/tests/fm-decision-alert.test.sh
+++ b/tests/fm-decision-alert.test.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+# Focused tests for captain decision alert filtering, deduplication, channel
+# configuration, safe execution, and best-effort failure behavior.
+set -u
+
+# shellcheck source=tests/lib.sh
+# shellcheck disable=SC1091
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+ALERT="$ROOT/bin/fm-decision-alert.sh"
+TMP_ROOT=$(fm_test_tmproot fm-decision-alert)
+
+make_recorder() {  # <dir>
+  local dir=$1 recorder="$1/recorder"
+  mkdir -p "$dir"
+  cat > "$recorder" <<'SH'
+#!/usr/bin/env bash
+printf '%s\t%s\n' "$1" "$2" >> "${FM_DECISION_ALERT_LOG:?}"
+if [ "${FM_DECISION_ALERT_FAIL:-0}" = 1 ]; then
+  exit 73
+fi
+SH
+  chmod +x "$recorder"
+  printf '%s\n' "$recorder"
+}
+
+run_alert() {  # <home> <recorder> <args...>
+  local home=$1 recorder=$2
+  shift 2
+  FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" FM_CONFIG_OVERRIDE="$home/config" \
+    FM_DECISION_ALERT_EXEC="$recorder" FM_DECISION_ALERT_LOG="$home/alert.log" \
+    FM_DECISION_ALERT_CHANNEL=osascript "$ALERT" "$@"
+}
+
+test_status_filtering_and_cross_boundary_dedup() {
+  local home recorder status
+  home="$TMP_ROOT/filter"; mkdir -p "$home/state" "$home/config"
+  recorder=$(make_recorder "$home")
+  status="$home/state/sample-review.status"
+  printf 'working: inspecting\nblocked [key=tool]: supervisor can resolve\npaused: vendor wait\ndone: draft ready\n' > "$status"
+  run_alert "$home" "$recorder" status "$status"
+  [ ! -s "$home/alert.log" ] || fail "routine, blocked, paused, or done events triggered a decision alert"
+
+  printf 'needs-decision [key=route]: choose a route\n' >> "$status"
+  run_alert "$home" "$recorder" status "$status"
+  run_alert "$home" "$recorder" status "$status"
+  run_alert "$home" "$recorder" prompt sample-review route
+  [ "$(wc -l < "$home/alert.log" | tr -d ' ')" -eq 1 ] \
+    || fail "the same status/direct decision identity alerted more than once"
+
+  printf 'resolved [key=route]: route selected\n' >> "$status"
+  run_alert "$home" "$recorder" status "$status"
+  [ "$(wc -l < "$home/alert.log" | tr -d ' ')" -eq 1 ] \
+    || fail "a resolved decision triggered another alert"
+  printf 'needs-decision [key=masked]: choose the masked option\nworking: unrelated follow-up\n' >> "$status"
+  run_alert "$home" "$recorder" status "$status"
+  [ "$(wc -l < "$home/alert.log" | tr -d ' ')" -eq 2 ] \
+    || fail "a later routine event masked an earlier still-open decision"
+  printf 'resolved [key=masked]: masked option selected\n' >> "$status"
+  run_alert "$home" "$recorder" status "$status"
+  [ "$(wc -l < "$home/alert.log" | tr -d ' ')" -eq 2 ] \
+    || fail "the resolved masked decision alerted again"
+  pass "only open needs-decision events alert, and status/direct delivery deduplicates by origin and key"
+}
+
+test_configuration_and_opt_out() {
+  local home recorder count
+  home="$TMP_ROOT/config"; mkdir -p "$home/state" "$home/config"
+  recorder=$(make_recorder "$home")
+  printf 'off\n' > "$home/config/decision-alert"
+  FM_HOME="$home" FM_DECISION_ALERT_EXEC="$recorder" FM_DECISION_ALERT_LOG="$home/alert.log" \
+    "$ALERT" decision sample off-choice
+  [ ! -s "$home/alert.log" ] || fail "config/decision-alert=off still emitted"
+  count=$(find "$home/state" -name '.decision-alerted-*' -type f 2>/dev/null | wc -l | tr -d ' ')
+  [ "$count" -eq 0 ] || fail "off consumed the decision identity and prevented a later opt-in"
+
+  FM_HOME="$home" FM_DECISION_ALERT_EXEC="$recorder" FM_DECISION_ALERT_LOG="$home/alert.log" \
+    FM_DECISION_ALERT_CHANNEL=herdr "$ALERT" decision sample off-choice
+  assert_grep $'herdr\tReturn to Firstmate to review the decision.' "$home/alert.log" \
+    "the environment channel override did not replace config/decision-alert=off"
+
+  : > "$home/alert.log"
+  printf '# two channels\n\nosascript\ncommand:printf ignored\n' > "$home/config/decision-alert"
+  FM_HOME="$home" FM_DECISION_ALERT_EXEC="$recorder" FM_DECISION_ALERT_LOG="$home/alert.log" \
+    "$ALERT" decision sample multi-channel
+  assert_grep 'osascript' "$home/alert.log" "the config file did not select osascript"
+  assert_grep 'command' "$home/alert.log" "the config file did not select command:"
+  pass "off, environment override, and multi-channel config behave deterministically"
+}
+
+test_macos_notification_argv_and_command_safety() {
+  local home fakebin args injected out_argv out_stdin body command secret
+  home="$TMP_ROOT/safety"; fakebin="$home/fakebin"
+  mkdir -p "$home/state" "$home/config" "$fakebin"
+  args="$home/osascript.args"
+  cat > "$fakebin/uname" <<'SH'
+#!/usr/bin/env bash
+printf 'Darwin\n'
+SH
+  cat > "$fakebin/osascript" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "${FM_OSASCRIPT_ARGS:?}"
+SH
+  chmod +x "$fakebin/uname" "$fakebin/osascript"
+  env -u FM_DECISION_ALERT_EXEC PATH="$fakebin:$PATH" FM_HOME="$home" \
+    FM_OSASCRIPT_ARGS="$args" "$ALERT" decision sample macos
+  assert_grep 'Firstmate needs your decision' "$args" "the macOS alert title was not passed as argv"
+  assert_grep 'Return to Firstmate to review the decision.' "$args" "the macOS alert body was not passed as argv"
+  assert_grep 'Basso' "$args" "the macOS alert did not request an audible system sound"
+  assert_grep 'item 2 of argv' "$args" "notification text was not kept out of AppleScript source"
+
+  injected="$home/injected"; out_argv="$home/argv"; out_stdin="$home/stdin"
+  # shellcheck disable=SC2016  # Literal shell syntax is the hostile data under test.
+  body='$(touch '"$injected"') "quoted"; newline-safe'
+  command="printf '%s' \"\$1\" > '$out_argv'; cat > '$out_stdin'"
+  # shellcheck source=bin/fm-notify-lib.sh
+  . "$ROOT/bin/fm-notify-lib.sh"
+  fm_notify_emit fm_notify_run_bounded '' 2 command title "$body" Basso "$command"
+  [ ! -e "$injected" ] || fail "notification body text executed as shell syntax"
+  [ "$(cat "$out_argv")" = "$body" ] || fail "command channel changed the body passed in \$1"
+  [ "$(cat "$out_stdin")" = "$body" ] || fail "command channel changed the body passed on stdin"
+  secret='https://alerts.example.invalid/hook?token=private-decision-token'
+  env -u FM_DECISION_ALERT_EXEC FM_HOME="$home" \
+    FM_DECISION_ALERT_CHANNEL="command:exit 73 # $secret" \
+    "$ALERT" decision sample command-redaction 2> "$home/command-error"
+  assert_grep 'command notifier failed with status 73' "$home/command-error" \
+    "command notifier failure did not retain a useful redacted diagnostic"
+  assert_no_grep "$secret" "$home/command-error" \
+    "command notifier failure leaked the configured command"
+  pass "macOS uses an audible argv-safe notification and command data never becomes shell source"
+}
+
+test_notifier_failure_is_nonblocking_and_at_most_once() {
+  local home recorder rc attempts markers
+  home="$TMP_ROOT/failure"; mkdir -p "$home/state" "$home/config"
+  recorder=$(make_recorder "$home")
+  set +e
+  FM_HOME="$home" FM_DECISION_ALERT_EXEC="$recorder" FM_DECISION_ALERT_LOG="$home/alert.log" \
+    FM_DECISION_ALERT_FAIL=1 FM_DECISION_ALERT_CHANNEL=osascript \
+    "$ALERT" decision sample failure-choice >/dev/null 2> "$home/error.log"
+  rc=$?
+  set -e
+  [ "$rc" -eq 0 ] || fail "notifier failure propagated to the durable decision caller"
+  attempts=$(wc -l < "$home/alert.log" | tr -d ' ')
+  markers=$(find "$home/state" -name '.decision-alerted-*' -type f | wc -l | tr -d ' ')
+  [ "$attempts" -eq 1 ] || fail "failing notifier was not attempted exactly once"
+  [ "$markers" -eq 1 ] || fail "failing notifier did not retain the dedup marker"
+
+  FM_HOME="$home" FM_DECISION_ALERT_EXEC="$recorder" FM_DECISION_ALERT_LOG="$home/alert.log" \
+    FM_DECISION_ALERT_CHANNEL=osascript "$ALERT" decision sample failure-choice
+  [ "$(wc -l < "$home/alert.log" | tr -d ' ')" -eq 1 ] \
+    || fail "a repeated delivery retried an already-claimed failed notifier"
+  pass "notifier failure never blocks the decision path and repeated delivery stays at most once"
+}
+
+test_test_seam_and_watcher_integration() {
+  local home stub out
+  home="$TMP_ROOT/watcher"; mkdir -p "$home/state" "$home/config"
+  stub="$home/alert-stub"
+  cat > "$stub" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${FM_ALERT_STUB_LOG:?}"
+SH
+  chmod +x "$stub"
+  printf 'needs-decision [key=shape]: choose a shape\n' > "$home/state/sample.status"
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    FM_CONFIG_OVERRIDE="$home/config" FM_DECISION_ALERT_BIN="$stub" \
+    FM_ALERT_STUB_LOG="$home/stub.log" bash -c '. "$1"; mark_surfaced "$2"' \
+      _ "$ROOT/bin/fm-watch.sh" "$home/state/sample.status"
+  assert_grep "status $home/state/sample.status" "$home/stub.log" \
+    "the watcher surface boundary did not invoke the decision alert"
+
+  # shellcheck disable=SC2016  # The clean child must expand its sourced seam value.
+  out=$(env -u FM_DECISION_ALERT_EXEC bash -c '. "$1"; printf "%s" "$FM_DECISION_ALERT_EXEC"' \
+    _ "$ALERT")
+  [ "$out" = discard ] || fail "library mode did not default the test seam to discard"
+  pass "the watcher invokes the automatic boundary and library-mode tests default to discard"
+}
+
+test_status_filtering_and_cross_boundary_dedup
+test_configuration_and_opt_out
+test_macos_notification_argv_and_command_safety
+test_notifier_failure_is_nonblocking_and_at_most_once
+test_test_seam_and_watcher_integration

--- a/tests/fm-decision-alert.test.sh
+++ b/tests/fm-decision-alert.test.sh
@@ -187,7 +187,7 @@ SH
 }
 
 test_concurrency_is_bounded() {
-  local home recorder task max_active
+  local home recorder task active max_active
   home="$TMP_ROOT/worker-pool"; mkdir -p "$home/state" "$home/config" "$home/active"
   recorder="$home/recorder"
   cat > "$recorder" <<'SH'
@@ -204,10 +204,14 @@ SH
       > "$home/state/$task.status"
   done
   printf 'osascript\nherdr\ncommand:true\n' > "$home/config/decision-alert"
+  : > "$home/counts"
   FM_HOME="$home" FM_DECISION_ALERT_EXEC="$recorder" FM_DECISION_ALERT_POOL_DIR="$home" \
-    FM_DECISION_ALERT_TIMEOUT_SECS=1 FM_DECISION_ALERT_TOTAL_TIMEOUT_SECS=1 \
+    FM_DECISION_ALERT_TIMEOUT_SECS=2 FM_DECISION_ALERT_TOTAL_TIMEOUT_SECS=2 \
     "$ALERT" scan-state >/dev/null 2> "$home/error.log"
-  max_active=$(sort -nr "$home/counts" | head -1 | tr -d ' ')
+  max_active=0
+  while IFS= read -r active; do
+    [ "$active" -le "$max_active" ] || max_active=$active
+  done < "$home/counts"
   [ "$max_active" -le 8 ] || fail "decision alert execution exceeded its worker limit"
   [ "$max_active" -gt 1 ] || fail "the worker pool did not preserve concurrent fallback delivery"
   pass "decision alert execution stays within eight concurrent workers"

--- a/tests/fm-decision-alert.test.sh
+++ b/tests/fm-decision-alert.test.sh
@@ -213,6 +213,23 @@ SH
   pass "decision alert execution stays within eight concurrent workers"
 }
 
+test_deadline_tick_still_runs_first_batch() {
+  local home
+  home="$TMP_ROOT/deadline-tick"; mkdir -p "$home/state" "$home/config"
+  printf 'osascript\n' > "$home/config/decision-alert"
+  FM_HOME="$home" FM_DECISION_ALERT_TICK_LOG="$home/tick.log" bash -c '
+    . "$1"
+    DECISION_ALERT_ORIGINS=(sample)
+    DECISION_ALERT_KEYS=(tick-boundary)
+    decision_alert_remaining_budget() { return 1; }
+    decision_alert_emit_channel() { printf "started\n" >> "$FM_DECISION_ALERT_TICK_LOG"; }
+    decision_alert_dispatch
+  ' _ "$ALERT"
+  [ "$(wc -l < "$home/tick.log" | tr -d ' ')" -eq 1 ] \
+    || fail "an integer deadline tick skipped the first worker batch"
+  pass "an integer deadline tick still starts the first bounded worker batch"
+}
+
 test_bash32_empty_retry_batch_continues() {
   local home recorder task markers
   home="$TMP_ROOT/bash32-retry"; mkdir -p "$home/state" "$home/config"
@@ -266,5 +283,6 @@ test_macos_notification_argv_and_command_safety
 test_notifier_failure_is_nonblocking_and_at_most_once
 test_total_runtime_is_bounded_across_decisions_and_channels
 test_concurrency_is_bounded
+test_deadline_tick_still_runs_first_batch
 test_bash32_empty_retry_batch_continues
 test_test_seam_and_watcher_integration

--- a/tests/fm-decision-alert.test.sh
+++ b/tests/fm-decision-alert.test.sh
@@ -186,6 +186,33 @@ SH
   pass "one total deadline bounds concurrent decisions, channels, and heartbeat status files"
 }
 
+test_concurrency_is_bounded() {
+  local home recorder task max_active
+  home="$TMP_ROOT/worker-pool"; mkdir -p "$home/state" "$home/config" "$home/active"
+  recorder="$home/recorder"
+  cat > "$recorder" <<'SH'
+#!/usr/bin/env bash
+slot="${FM_DECISION_ALERT_POOL_DIR:?}/active/$BASHPID"
+: > "$slot"
+trap 'rm -f "$slot"' EXIT
+find "${FM_DECISION_ALERT_POOL_DIR:?}/active" -type f | wc -l >> "${FM_DECISION_ALERT_POOL_DIR:?}/counts"
+sleep 5
+SH
+  chmod +x "$recorder"
+  for task in one two three; do
+    printf 'needs-decision [key=a]: choose\nneeds-decision [key=b]: choose\nneeds-decision [key=c]: choose\n' \
+      > "$home/state/$task.status"
+  done
+  printf 'osascript\nherdr\ncommand:true\n' > "$home/config/decision-alert"
+  FM_HOME="$home" FM_DECISION_ALERT_EXEC="$recorder" FM_DECISION_ALERT_POOL_DIR="$home" \
+    FM_DECISION_ALERT_TIMEOUT_SECS=1 FM_DECISION_ALERT_TOTAL_TIMEOUT_SECS=1 \
+    "$ALERT" scan-state >/dev/null 2> "$home/error.log"
+  max_active=$(sort -nr "$home/counts" | head -1 | tr -d ' ')
+  [ "$max_active" -le 8 ] || fail "decision alert execution exceeded its worker limit"
+  [ "$max_active" -gt 1 ] || fail "the worker pool did not preserve concurrent fallback delivery"
+  pass "decision alert execution stays within eight concurrent workers"
+}
+
 test_test_seam_and_watcher_integration() {
   local home stub out
   home="$TMP_ROOT/watcher"; mkdir -p "$home/state" "$home/config"
@@ -215,4 +242,5 @@ test_configuration_and_opt_out
 test_macos_notification_argv_and_command_safety
 test_notifier_failure_is_nonblocking_and_at_most_once
 test_total_runtime_is_bounded_across_decisions_and_channels
+test_concurrency_is_bounded
 test_test_seam_and_watcher_integration

--- a/tests/fm-decision-alert.test.sh
+++ b/tests/fm-decision-alert.test.sh
@@ -153,6 +153,35 @@ test_notifier_failure_is_nonblocking_and_at_most_once() {
   pass "notifier failure never blocks the decision path and repeated delivery stays at most once"
 }
 
+test_total_runtime_is_bounded_across_decisions_and_channels() {
+  local home start elapsed attempts markers
+  home="$TMP_ROOT/total-timeout"; mkdir -p "$home/state" "$home/config"
+  printf 'needs-decision [key=one]: choose\nneeds-decision [key=two]: choose\n' > "$home/state/sample.status"
+  printf 'command:sleep 5\ncommand:sleep 5\n' > "$home/config/decision-alert"
+  start=$SECONDS
+  env -u FM_DECISION_ALERT_EXEC FM_HOME="$home" FM_DECISION_ALERT_TIMEOUT_SECS=5 \
+    FM_DECISION_ALERT_TOTAL_TIMEOUT_SECS=1 "$ALERT" status "$home/state/sample.status" \
+    >/dev/null 2> "$home/error.log"
+  elapsed=$((SECONDS - start))
+  [ "$elapsed" -le 2 ] || fail "total alert runtime multiplied across decisions and channels"
+  markers=$(find "$home/state" -name '.decision-alerted-*' -type f | wc -l | tr -d ' ')
+  [ "$markers" -eq 1 ] || fail "the total deadline consumed an unattempted decision identity"
+
+  cat > "$home/scan-stub" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${FM_ALERT_STUB_LOG:?}"
+SH
+  chmod +x "$home/scan-stub"
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    FM_CONFIG_OVERRIDE="$home/config" FM_DECISION_ALERT_BIN="$home/scan-stub" \
+    FM_ALERT_STUB_LOG="$home/scan.log" bash -c '. "$1"; alert_all_open_decisions' \
+      _ "$ROOT/bin/fm-watch.sh"
+  attempts=$(wc -l < "$home/scan.log" | tr -d ' ')
+  [ "$attempts" -eq 1 ] || fail "the watcher split a fleet scan across multiple alert budgets"
+  assert_grep 'scan-state' "$home/scan.log" "the watcher did not use one bounded fleet scan"
+  pass "one total deadline bounds all decisions, channels, and heartbeat status files"
+}
+
 test_test_seam_and_watcher_integration() {
   local home stub out
   home="$TMP_ROOT/watcher"; mkdir -p "$home/state" "$home/config"
@@ -181,4 +210,5 @@ test_status_filtering_and_cross_boundary_dedup
 test_configuration_and_opt_out
 test_macos_notification_argv_and_command_safety
 test_notifier_failure_is_nonblocking_and_at_most_once
+test_total_runtime_is_bounded_across_decisions_and_channels
 test_test_seam_and_watcher_integration

--- a/tests/fm-decision-alert.test.sh
+++ b/tests/fm-decision-alert.test.sh
@@ -154,18 +154,22 @@ test_notifier_failure_is_nonblocking_and_at_most_once() {
 }
 
 test_total_runtime_is_bounded_across_decisions_and_channels() {
-  local home start elapsed attempts markers
+  local home start elapsed attempts markers fallbacks
   home="$TMP_ROOT/total-timeout"; mkdir -p "$home/state" "$home/config"
-  printf 'needs-decision [key=one]: choose\nneeds-decision [key=two]: choose\n' > "$home/state/sample.status"
-  printf 'command:sleep 5\ncommand:sleep 5\n' > "$home/config/decision-alert"
+  printf 'needs-decision [key=one]: choose\n' > "$home/state/one.status"
+  printf 'needs-decision [key=two]: choose\n' > "$home/state/two.status"
+  printf "command:sleep 5\ncommand:echo fallback >> '%s/fallback.log'\n" "$home" \
+    > "$home/config/decision-alert"
   start=$SECONDS
   env -u FM_DECISION_ALERT_EXEC FM_HOME="$home" FM_DECISION_ALERT_TIMEOUT_SECS=5 \
-    FM_DECISION_ALERT_TOTAL_TIMEOUT_SECS=1 "$ALERT" status "$home/state/sample.status" \
+    FM_DECISION_ALERT_TOTAL_TIMEOUT_SECS=1 "$ALERT" scan-state \
     >/dev/null 2> "$home/error.log"
   elapsed=$((SECONDS - start))
   [ "$elapsed" -le 2 ] || fail "total alert runtime multiplied across decisions and channels"
   markers=$(find "$home/state" -name '.decision-alerted-*' -type f | wc -l | tr -d ' ')
-  [ "$markers" -eq 1 ] || fail "the total deadline consumed an unattempted decision identity"
+  [ "$markers" -eq 2 ] || fail "the total deadline did not attempt every open decision identity"
+  fallbacks=$(wc -l < "$home/fallback.log" | tr -d ' ')
+  [ "$fallbacks" -eq 2 ] || fail "hung channels starved healthy fallback channels"
 
   cat > "$home/scan-stub" <<'SH'
 #!/usr/bin/env bash
@@ -179,7 +183,7 @@ SH
   attempts=$(wc -l < "$home/scan.log" | tr -d ' ')
   [ "$attempts" -eq 1 ] || fail "the watcher split a fleet scan across multiple alert budgets"
   assert_grep 'scan-state' "$home/scan.log" "the watcher did not use one bounded fleet scan"
-  pass "one total deadline bounds all decisions, channels, and heartbeat status files"
+  pass "one total deadline bounds concurrent decisions, channels, and heartbeat status files"
 }
 
 test_test_seam_and_watcher_integration() {

--- a/tests/fm-decision-alert.test.sh
+++ b/tests/fm-decision-alert.test.sh
@@ -213,6 +213,29 @@ SH
   pass "decision alert execution stays within eight concurrent workers"
 }
 
+test_bash32_empty_retry_batch_continues() {
+  local home recorder task markers
+  home="$TMP_ROOT/bash32-retry"; mkdir -p "$home/state" "$home/config"
+  recorder=$(make_recorder "$home")
+  printf 'osascript\n' > "$home/config/decision-alert"
+  for task in 01 02 03 04 05 06 07 08 09; do
+    printf 'needs-decision [key=choice]: choose\n' > "$home/state/$task.status"
+  done
+  for task in 01 02 03 04 05 06 07 08; do
+    FM_HOME="$home" FM_DECISION_ALERT_EXEC=discard FM_DECISION_ALERT_CHANNEL=osascript \
+      /bin/bash "$ALERT" decision "$task" choice >/dev/null 2>&1 \
+      || fail "could not seed an existing decision alert identity"
+  done
+  FM_HOME="$home" FM_DECISION_ALERT_EXEC="$recorder" FM_DECISION_ALERT_LOG="$home/alert.log" \
+    /bin/bash "$ALERT" scan-state >/dev/null 2> "$home/error.log" \
+    || fail "an empty retry batch aborted the Bash 3.2 alert scan"
+  [ "$(wc -l < "$home/alert.log" | tr -d ' ')" -eq 1 ] \
+    || fail "the unclaimed decision after an empty retry batch was not alerted"
+  markers=$(find "$home/state" -name '.decision-alerted-*' -type f | wc -l | tr -d ' ')
+  [ "$markers" -eq 9 ] || fail "the later decision identity was not claimed after an empty retry batch"
+  pass "Bash 3.2 empty retry batches preserve later decision alerts"
+}
+
 test_test_seam_and_watcher_integration() {
   local home stub out
   home="$TMP_ROOT/watcher"; mkdir -p "$home/state" "$home/config"
@@ -243,4 +266,5 @@ test_macos_notification_argv_and_command_safety
 test_notifier_failure_is_nonblocking_and_at_most_once
 test_total_runtime_is_bounded_across_decisions_and_channels
 test_concurrency_is_bounded
+test_bash32_empty_retry_batch_continues
 test_test_seam_and_watcher_integration

--- a/tests/fm-decision-hold-lifecycle.test.sh
+++ b/tests/fm-decision-hold-lifecycle.test.sh
@@ -119,7 +119,7 @@ write_origin_meta() {  # <home> <id> [kind]
 }
 
 test_structured_holds_survive_teardown_and_route_resolution() {
-  local home id route_hold access_hold before after json open show
+  local home id route_hold access_hold before after json open show alert_recorder
   home=$(make_home durable-lifecycle)
   id=sample-systems-review
   mkdir -p "$home/data/$id"
@@ -137,6 +137,12 @@ EOF
 Two choices remain unresolved: the route and the sample access level.
 A separate recommendation is already resolved and requires no captain action.
 EOF
+  alert_recorder="$home/fakebin/decision-alert-recorder"
+  cat > "$alert_recorder" <<'SH'
+#!/usr/bin/env bash
+printf '%s\t%s\n' "$1" "$2" >> "${FM_DECISION_ALERT_LOG:?}"
+SH
+  chmod +x "$alert_recorder"
 
   if run_decisions "$home" complete "$id" route access > "$home/early-complete.out" 2> "$home/early-complete.err"; then
     fail "completion succeeded before unresolved decisions had captain holds"
@@ -144,17 +150,20 @@ EOF
   assert_no_grep "decisions_reviewed=1" "$home/state/$id.meta" \
     "failed completion recorded a false completion attestation"
 
-  route_hold=$(run_decisions "$home" hold "$id" route \
+  route_hold=$(FM_DECISION_ALERT_EXEC="$alert_recorder" FM_DECISION_ALERT_LOG="$home/decision-alert.log" \
+    FM_DECISION_ALERT_CHANNEL=osascript run_decisions "$home" hold "$id" route \
     --title "Choose the sample route" --reason "captain route choice pending" --repo sample) \
     || fail "could not register route hold"
   [ "$route_hold" = "$id-decision-route" ] || fail "route hold identity was not deterministic: $route_hold"
-  run_decisions "$home" hold "$id" route \
+  FM_DECISION_ALERT_EXEC="$alert_recorder" FM_DECISION_ALERT_LOG="$home/decision-alert.log" \
+    FM_DECISION_ALERT_CHANNEL=osascript run_decisions "$home" hold "$id" route \
     --title "Choose the sample route" --reason "captain route choice pending" --repo sample >/dev/null \
     || fail "idempotent hold retry failed"
   if run_decisions "$home" complete "$id" route access > "$home/partial-complete.out" 2> "$home/partial-complete.err"; then
     fail "completion succeeded while one of two distinct decisions lacked a hold"
   fi
-  access_hold=$(run_decisions "$home" hold "$id" access \
+  access_hold=$(FM_DECISION_ALERT_EXEC="$alert_recorder" FM_DECISION_ALERT_LOG="$home/decision-alert.log" \
+    FM_DECISION_ALERT_CHANNEL=osascript run_decisions "$home" hold "$id" access \
     --title "Choose the sample access level" --reason "captain access choice pending" --repo sample) \
     || fail "could not register access hold"
   [ "$access_hold" = "$id-decision-access" ] || fail "access hold identity was not distinct: $access_hold"
@@ -162,6 +171,8 @@ EOF
     || fail "idempotent retry duplicated the route hold"
   [ "$(grep -cE "^- \[ \] $access_hold -" "$home/data/backlog.md")" = 1 ] \
     || fail "second decision did not retain one distinct backlog identity"
+  [ "$(wc -l < "$home/decision-alert.log" | tr -d ' ')" -eq 2 ] \
+    || fail "durable hold alerts did not deduplicate retries while preserving distinct decisions"
 
   run_decisions "$home" complete "$id" route access >/dev/null \
     || fail "shared investigation completion gate failed"

--- a/tests/fm-pi-watch-extension.test.sh
+++ b/tests/fm-pi-watch-extension.test.sh
@@ -640,7 +640,7 @@ SH
   chmod +x "$repo/bin/fm-watch-arm.sh"
   out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" FM_ARM_LOG="$log" FM_RELEASE_FILE="$release" node --input-type=module 2>&1 <<'EOF'
 import { spawn } from "node:child_process";
-import { readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
 let tool = null;
@@ -660,6 +660,10 @@ writeFileSync(lock, `${process.pid}\n`);
 const mod = await import(pathToFileURL(process.env.PLUGIN).href);
 mod.default(pi);
 await tool.execute("tool-call-lock-close", {}, undefined, undefined, {});
+for (let i = 0; i < 250 && !existsSync(process.env.FM_ARM_LOG); i += 1) {
+  await new Promise((resolve) => setTimeout(resolve, 10));
+}
+if (!existsSync(process.env.FM_ARM_LOG)) throw new Error("initial watcher arm did not start");
 const other = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" });
 try {
   writeFileSync(lock, `${other.pid}\n`);

--- a/tests/fm-pi-watch-extension.test.sh
+++ b/tests/fm-pi-watch-extension.test.sh
@@ -129,7 +129,7 @@ if (!notification.includes("started Pi extension arm child")) {
   console.error(notification);
   process.exit(1);
 }
-for (let i = 0; i < 250 && !prompt; i += 1) {
+for (let i = 0; i < 1000 && !prompt; i += 1) {
   await new Promise((resolve) => setTimeout(resolve, 20));
 }
 if (!prompt.includes("FIRSTMATE WATCHER WAKE")) {
@@ -252,7 +252,7 @@ writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
 const mod = await import(pathToFileURL(process.env.PLUGIN).href);
 mod.default(pi);
 await tool.execute("tool-call-continuity", {}, undefined, undefined, {});
-for (let i = 0; i < 250; i += 1) {
+for (let i = 0; i < 1000; i += 1) {
   const rows = existsSync(process.env.FM_ARM_LOG)
     ? readFileSync(process.env.FM_ARM_LOG, "utf8").trim().split("\n")
     : [];
@@ -551,7 +551,7 @@ writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
 const mod = await import(pathToFileURL(process.env.PLUGIN).href);
 mod.default(pi);
 await tool.execute("tool-call-empty", {}, undefined, undefined, {});
-for (let i = 0; i < 250; i += 1) {
+for (let i = 0; i < 1000; i += 1) {
   const rows = existsSync(process.env.FM_ARM_LOG)
     ? readFileSync(process.env.FM_ARM_LOG, "utf8").trim().split("\n")
     : [];
@@ -606,7 +606,7 @@ writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
 const mod = await import(pathToFileURL(process.env.PLUGIN).href);
 mod.default(pi);
 await tool.execute("tool-call-established-empty", {}, undefined, undefined, {});
-for (let i = 0; i < 250 && !prompt; i += 1) {
+for (let i = 0; i < 1000 && !prompt; i += 1) {
   await new Promise((resolve) => setTimeout(resolve, 10));
 }
 const rows = existsSync(process.env.FM_ARM_LOG)
@@ -660,7 +660,7 @@ writeFileSync(lock, `${process.pid}\n`);
 const mod = await import(pathToFileURL(process.env.PLUGIN).href);
 mod.default(pi);
 await tool.execute("tool-call-lock-close", {}, undefined, undefined, {});
-for (let i = 0; i < 250 && !existsSync(process.env.FM_ARM_LOG); i += 1) {
+for (let i = 0; i < 1000 && !existsSync(process.env.FM_ARM_LOG); i += 1) {
   await new Promise((resolve) => setTimeout(resolve, 10));
 }
 if (!existsSync(process.env.FM_ARM_LOG)) throw new Error("initial watcher arm did not start");
@@ -668,7 +668,7 @@ const other = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { s
 try {
   writeFileSync(lock, `${other.pid}\n`);
   writeFileSync(process.env.FM_RELEASE_FILE, "release\n");
-  for (let i = 0; i < 250 && !prompt.includes("no longer owns the lock"); i += 1) {
+  for (let i = 0; i < 1000 && !prompt.includes("no longer owns the lock"); i += 1) {
     await new Promise((resolve) => setTimeout(resolve, 10));
   }
   const rows = readFileSync(process.env.FM_ARM_LOG, "utf8").trim().split("\n");
@@ -754,7 +754,7 @@ const owned = await callArm();
 if (owned.details?.ok !== true || !owned.details.message.includes("started Pi extension arm child")) {
   throw new Error(`owned lock did not arm: ${JSON.stringify(owned.details)}`);
 }
-for (let i = 0; i < 250 && !existsSync(process.env.FM_ARM_LOG); i += 1) {
+for (let i = 0; i < 1000 && !existsSync(process.env.FM_ARM_LOG); i += 1) {
   await new Promise((resolve) => setTimeout(resolve, 20));
 }
 if (!existsSync(process.env.FM_ARM_LOG)) throw new Error("owned lock did not run the watcher arm");
@@ -838,7 +838,7 @@ writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
 const mod = await import(pathToFileURL(process.env.PLUGIN).href);
 mod.default(pi);
 await tool.execute("tool-call-exit", {}, undefined, undefined, {});
-for (let i = 0; i < 250 && !existsSync(process.env.FM_CHILD_PID_FILE); i += 1) {
+for (let i = 0; i < 1000 && !existsSync(process.env.FM_CHILD_PID_FILE); i += 1) {
   await new Promise((resolve) => setTimeout(resolve, 20));
 }
 if (!existsSync(process.env.FM_CHILD_PID_FILE)) throw new Error("arm child did not start");
@@ -929,7 +929,7 @@ const hooks = await mod.FmPrimaryWatchArm({
 });
 writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
 await hooks.event({ event: { type: "session.idle", properties: { sessionID: "session-test" } } });
-for (let i = 0; i < 250 && !existsSync(process.env.FM_ARM_LOG); i += 1) {
+for (let i = 0; i < 1000 && !existsSync(process.env.FM_ARM_LOG); i += 1) {
   await new Promise((resolve) => setTimeout(resolve, 20));
 }
 if (!existsSync(process.env.FM_ARM_LOG)) {
@@ -979,7 +979,7 @@ const hooks = await mod.FmPrimaryWatchArm({
 });
 writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
 await hooks.event({ event: { type: "session.idle", properties: { sessionID: "session-test" } } });
-for (let i = 0; i < 250 && !existsSync(process.env.FM_ARM_LOG); i += 1) {
+for (let i = 0; i < 1000 && !existsSync(process.env.FM_ARM_LOG); i += 1) {
   await new Promise((resolve) => setTimeout(resolve, 20));
 }
 if (!existsSync(process.env.FM_ARM_LOG)) {
@@ -1036,7 +1036,7 @@ if (existsSync(process.env.FM_ARM_LOG)) {
 }
 writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
 await hooks.event(event);
-for (let i = 0; i < 250 && !existsSync(process.env.FM_ARM_LOG); i += 1) {
+for (let i = 0; i < 1000 && !existsSync(process.env.FM_ARM_LOG); i += 1) {
   await new Promise((resolve) => setTimeout(resolve, 20));
 }
 if (!existsSync(process.env.FM_ARM_LOG)) {
@@ -1152,7 +1152,7 @@ const hooks = await mod.FmPrimaryWatchArm({
 const event = { event: { type: "session.idle", properties: { sessionID: "session-test" } } };
 writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
 await hooks.event(event);
-for (let i = 0; i < 250; i += 1) {
+for (let i = 0; i < 1000; i += 1) {
   const rows = existsSync(process.env.FM_ARM_LOG)
     ? readFileSync(process.env.FM_ARM_LOG, "utf8").trim().split("\n")
     : [];
@@ -1541,7 +1541,7 @@ const hooks = await mod.FmPrimaryWatchArm({
 });
 writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
 await hooks.event({ event: { type: "session.idle", properties: { sessionID: "session-test" } } });
-for (let i = 0; i < 250; i += 1) {
+for (let i = 0; i < 1000; i += 1) {
   const rows = existsSync(process.env.FM_ARM_LOG)
     ? readFileSync(process.env.FM_ARM_LOG, "utf8").trim().split("\n")
     : [];
@@ -1597,7 +1597,7 @@ const hooks = await mod.FmPrimaryWatchArm({
 });
 writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
 await hooks.event({ event: { type: "session.idle", properties: { sessionID: "session-test" } } });
-for (let i = 0; i < 250 && !prompt; i += 1) {
+for (let i = 0; i < 1000 && !prompt; i += 1) {
   await new Promise((resolve) => setTimeout(resolve, 10));
 }
 const rows = existsSync(process.env.FM_ARM_LOG)
@@ -1653,7 +1653,7 @@ const hooks = await mod.FmPrimaryWatchArm({
 const lock = `${process.env.FM_HOME}/state/.lock`;
 writeFileSync(lock, `${process.pid}\n`);
 const eventPromise = hooks.event({ event: { type: "session.idle", properties: { sessionID: "session-test" } } });
-for (let i = 0; i < 250 && !existsSync(process.env.FM_ARM_LOG); i += 1) {
+for (let i = 0; i < 1000 && !existsSync(process.env.FM_ARM_LOG); i += 1) {
   await new Promise((resolve) => setTimeout(resolve, 10));
 }
 const other = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" });
@@ -1661,7 +1661,7 @@ try {
   writeFileSync(lock, `${other.pid}\n`);
   writeFileSync(process.env.FM_RELEASE_FILE, "release\n");
   await eventPromise;
-  for (let i = 0; i < 250 && !prompt.includes("no longer owns the lock"); i += 1) {
+  for (let i = 0; i < 1000 && !prompt.includes("no longer owns the lock"); i += 1) {
     await new Promise((resolve) => setTimeout(resolve, 10));
   }
   const rows = readFileSync(process.env.FM_ARM_LOG, "utf8").trim().split("\n");
@@ -1728,7 +1728,7 @@ const guardHooks = await guardMod.FmPrimaryTurnendGuard({
 });
 writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
 await guardHooks.event({ event: { type: "session.idle", properties: { sessionID: "session-test" } } });
-for (let i = 0; i < 250 && !existsSync(process.env.FM_ARM_LOG); i += 1) {
+for (let i = 0; i < 1000 && !existsSync(process.env.FM_ARM_LOG); i += 1) {
   await new Promise((resolve) => setTimeout(resolve, 20));
 }
 if (!existsSync(process.env.FM_ARM_LOG)) {
@@ -1801,7 +1801,7 @@ const guardHooks = await guardMod.FmPrimaryTurnendGuard({
 });
 writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
 await guardHooks.event({ event: { type: "session.idle", properties: { sessionID: "session-test" } } });
-for (let i = 0; i < 250 && !existsSync(process.env.FM_GUARD_LOG); i += 1) {
+for (let i = 0; i < 1000 && !existsSync(process.env.FM_GUARD_LOG); i += 1) {
   await new Promise((resolve) => setTimeout(resolve, 20));
 }
 if (!existsSync(process.env.FM_ARM_LOG)) {

--- a/tests/fm-sessionstart-nudge.test.sh
+++ b/tests/fm-sessionstart-nudge.test.sh
@@ -22,7 +22,8 @@ make_primary() {
 
 run_nudge() {
   local root=$1
-  FM_GATE_REFUSE_BYPASS=0 FM_ROOT_OVERRIDE="$root" FM_HOME="$root" "$NUDGE"
+  env -u NO_MISTAKES_GATE FM_GATE_REFUSE_BYPASS=0 \
+    FM_ROOT_OVERRIDE="$root" FM_HOME="$root" "$NUDGE"
 }
 
 expect_silent_zero() {

--- a/tests/fm-tangle-guard.test.sh
+++ b/tests/fm-tangle-guard.test.sh
@@ -180,7 +180,7 @@ run_spawn() {
   FM_ROOT_OVERRIDE='' FM_HOME="$home" \
     FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
     FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
-    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$pane" TMUX="fake,1,0" \
+    FM_SPAWN_NO_GUARD=1 FM_SPAWN_WORKTREE_POLLS=1 FM_FAKE_PANE_PATH="$pane" TMUX="fake,1,0" \
     PATH="$fakebin:$PATH" \
     "$ROOT/bin/fm-spawn.sh" "$id" "$proj" codex 2>&1
 }

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -427,9 +427,10 @@ test_stale_terminal_status_overridden_by_active_run() {
     FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_STALE_ESCALATE_SECS=999 FM_POLL=1 FM_SIGNAL_GRACE=1 \
     FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
   pid=$!
-  if ! wait_live "$pid" 30; then
-    reap "$pid"; fail "watcher exited for a stale terminal-looking status the run-step overrides (should absorb): $(cat "$out")"
-  fi
+  wait_numeric_file "$state/.stale-since-$key" 100 \
+    || { reap "$pid"; fail "stale terminal-looking status did not start its absorbed-run timer: $(cat "$out")"; }
+  kill -0 "$pid" 2>/dev/null \
+    || { wait "$pid" 2>/dev/null || true; fail "watcher exited for a stale terminal-looking status the run-step overrides (should absorb): $(cat "$out")"; }
   [ ! -s "$out" ] || fail "the overridden stale terminal status printed a wake reason during absorb"
   [ ! -s "$state/.wake-queue" ] || fail "the overridden stale terminal status enqueued a wake during absorb"
   [ "$(cat "$state/.stale-$key" 2>/dev/null || true)" = "$pane_hash" ] || fail "stale suppressor not advanced on absorb"
@@ -480,9 +481,10 @@ test_nonterminal_stale_provably_working_absorbed_then_escalated() {
     FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_STALE_ESCALATE_SECS=999 FM_POLL=1 FM_SIGNAL_GRACE=1 \
     FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
   pid=$!
-  if ! wait_live "$pid" 30; then
-    reap "$pid"; fail "watcher exited for a fresh provably-working non-terminal stale (should absorb): $(cat "$out")"
-  fi
+  wait_numeric_file "$state/.stale-since-$key" 100 \
+    || { reap "$pid"; fail "provably-working non-terminal stale did not start its absorbed-run timer: $(cat "$out")"; }
+  kill -0 "$pid" 2>/dev/null \
+    || { wait "$pid" 2>/dev/null || true; fail "watcher exited for a fresh provably-working non-terminal stale (should absorb): $(cat "$out")"; }
   [ ! -s "$out" ] || fail "fresh provably-working stale printed a wake reason during absorb"
   [ ! -s "$state/.wake-queue" ] || fail "fresh provably-working stale enqueued a wake during absorb"
   [ "$(cat "$state/.stale-$key" 2>/dev/null || true)" = "$pane_hash" ] || fail "stale suppressor not advanced on absorb"
@@ -756,9 +758,10 @@ test_nonterminal_paused_rechecks_authoritative_state() {
     FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_STALE_ESCALATE_SECS=999 FM_POLL=1 FM_SIGNAL_GRACE=1 \
     FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
   pid=$!
-  if ! wait_live "$pid" 30; then
-    reap "$pid"; fail "an active run behind a declared pause surfaced instead of resuming wedge tracking: $(cat "$out")"
-  fi
+  wait_numeric_file "$state/.stale-since-$key" 100 \
+    || { reap "$pid"; fail "an active run behind a declared pause did not resume wedge tracking: $(cat "$out")"; }
+  kill -0 "$pid" 2>/dev/null \
+    || { wait "$pid" 2>/dev/null || true; fail "an active run behind a declared pause surfaced instead of resuming wedge tracking: $(cat "$out")"; }
   [ ! -e "$state/.paused-$key" ] || { reap "$pid"; fail "authoritative active run retained paused mode"; }
   [ -s "$state/.stale-since-$key" ] || { reap "$pid"; fail "authoritative active run did not resume wedge tracking"; }
   reap "$pid"

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -34,6 +34,12 @@ FM_TEST_LIB_SOURCED=1
 # strips this to verify real refusal.
 export FM_GATE_REFUSE_BYPASS=1
 
+# Every active notification path must cross an explicit test seam.
+# Default the decision alert to discard for the whole behavior suite so a test
+# that reaches a real hold or watcher can never post a desktop notification or
+# play a sound.
+export FM_DECISION_ALERT_EXEC=discard
+
 # Resolve the repo root from this library's own location. Consumed by sourcing
 # test files, not by this library, so it reads as "unused" here.
 # shellcheck disable=SC2034


### PR DESCRIPTION
## What Changed

- Add bounded, privacy-safe, deduplicated alerts for open captain decisions, durable decision holds, and explicit prompts, with macOS, Herdr, and custom command channels.
- Integrate decision scanning into watcher and heartbeat flows, and centralize safe notification execution for decision and wedge alerts.
- Harden secondmate home rollback and charter validation, transient Treehouse worktree discovery, and Herdr prompt matching.

## Risk Assessment

✅ Low: Captain, the change is well-bounded and no material source risks were substantiated in the full review pass.

## Testing

Completed 1 recorded test check.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
