### PR TITLE
feat(bootstrap): add FIRSTMATE_UPDATE self-update heads-up diagnostic

### DIFF
--- a/.agents/skills/bootstrap-diagnostics/SKILL.md
+++ b/.agents/skills/bootstrap-diagnostics/SKILL.md
@@ -2,7 +2,7 @@
 name: bootstrap-diagnostics
 description: >-
   Agent-only handling playbook for session-start bootstrap diagnostics.
-  Use whenever the session-start digest's bootstrap section prints an actionable diagnostic line - MISSING, MISSING_MANUAL, BACKEND_INVALID, NEEDS_GH_AUTH, TANGLE, CREW_DISPATCH invalid, FLEET_SYNC, PR_CHECK_MIGRATION, SECONDMATE_SYNC, SECONDMATE_LIVENESS, NUDGE_SECONDMATES, or FMX - or when a standalone bin/fm-bootstrap.sh run prints one of those lines.
+  Use whenever the session-start digest's bootstrap section prints an actionable diagnostic line - MISSING, MISSING_MANUAL, BACKEND_INVALID, NEEDS_GH_AUTH, TANGLE, CREW_DISPATCH invalid, FLEET_SYNC, PR_CHECK_MIGRATION, SECONDMATE_SYNC, SECONDMATE_LIVENESS, NUDGE_SECONDMATES, FIRSTMATE_UPDATE, or FMX - or when a standalone bin/fm-bootstrap.sh run prints one of those lines.
   A silent bootstrap section, or a BOOTSTRAP_INFO fact, means no skill load.
 user-invocable: false
 metadata:
@@ -27,6 +27,8 @@ When any diagnostic needs captain attention, report the plain consequence and re
 - `TANGLE: <remediation>` - the primary checkout is stranded on a feature branch instead of its default branch; `AGENTS.md` section 8 explains why this guard exists and what it protects.
   The work is safe on that branch ref; restore the primary to its default branch with the printed `git -C <root> checkout <default>`, then re-validate that branch in a proper worktree.
   This is the only sanctioned firstmate-initiated git write to the primary, and it is a non-destructive branch switch that strands nothing.
+- `FIRSTMATE_UPDATE: firstmate checkout is <N> commit(s) behind origin/<default> (update: /updatefirstmate)` - a firstmate update is available: this checkout is behind its origin default branch by the stated number of commits.
+  Mention to the captain that a firstmate update is available and offer to run `/updatefirstmate`; do not run it unprompted, and do not block dispatch or other session-start work on the answer.
 - `CREW_DISPATCH: invalid config/crew-dispatch.json - <reason>` - the optional dispatch profile file exists but failed low-cost bootstrap validation; continue with the normal fallback chain, resolve and pass the chosen fallback harness explicitly while the file remains present, fix the malformed schema, unverified harness name, unknown selector, or invalid harness/effort pair when convenient, and do not select a bad profile.
 - `FLEET_SYNC: <repo>: skipped: <reason>` - a benign one-off skip (offline, no origin, local-only); bootstrap continued, investigate only if it blocks work.
   A skip can also report the bounded fleet-refresh timeout (`FM_FLEET_SYNC_BOOTSTRAP_TIMEOUT`, or a fleet-size-aware default with a 20 second floor); a timeout never blocks startup.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -448,7 +448,7 @@ It performs guarded fast-forward updates of firstmate and registered secondmate 
 
 These skills are not captain-invocable; load them only at their precise triggers.
 
-- `bootstrap-diagnostics` - load whenever the session-start digest's bootstrap section prints an actionable diagnostic line (`MISSING:`, `MISSING_MANUAL:`, `BACKEND_INVALID:`, `NEEDS_GH_AUTH`, `TANGLE:`, `CREW_DISPATCH: invalid`, `FLEET_SYNC:`, `PR_CHECK_MIGRATION:`, `SECONDMATE_SYNC:`, `SECONDMATE_LIVENESS:`, `NUDGE_SECONDMATES:`, or `FMX:`); silence and `BOOTSTRAP_INFO:` need no load.
+- `bootstrap-diagnostics` - load whenever the session-start digest's bootstrap section prints an actionable diagnostic line (`MISSING:`, `MISSING_MANUAL:`, `BACKEND_INVALID:`, `NEEDS_GH_AUTH`, `TANGLE:`, `CREW_DISPATCH: invalid`, `FLEET_SYNC:`, `PR_CHECK_MIGRATION:`, `SECONDMATE_SYNC:`, `SECONDMATE_LIVENESS:`, `NUDGE_SECONDMATES:`, `FIRSTMATE_UPDATE:`, or `FMX:`); silence and `BOOTSTRAP_INFO:` need no load.
 - `diagnostic-reasoning` - load before scoping a reported bug and before acting on a diagnostic report.
 - `harness-adapters` - load before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter.
 - `firstmate-orca` - load before switching to Orca, spawning or supervising Orca-backed work, smoke-testing Orca backend behavior, debugging Orca task state, or reconciling Orca-backed task metadata.

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -16,6 +16,7 @@
 #                 "NUDGE_SECONDMATES: secondmate <id>: send failed: <reason>",
 #                 "BOOTSTRAP_INFO: nudged fm-<id> with '<message>'",
 #                 "SECONDMATE_LIVENESS: secondmate <id>: skipped: <reason>|respawn failed: <reason>",
+#                 "FIRSTMATE_UPDATE: firstmate checkout is <N> commit(s) behind origin/<default> (update: /updatefirstmate)",
 #                 "FMX: X mode on ..." or "FMX: X mode off ...".
 #          When a RUNNING secondmate worktree is fast-forwarded to firstmate's
 #          own current default-branch commit (a purely LOCAL fast-forward, never
@@ -54,6 +55,15 @@
 #          tasks-axi default backend is silent. quota-axi is required because
 #          crew-dispatch quota-balanced may call it; fm-dispatch-select.sh still
 #          degrades at runtime when quota data is unavailable.
+#          FIRSTMATE_UPDATE is a best-effort self-update heads-up scoped to
+#          firstmate's OWN repo (FM_ROOT) only, never anything under projects/:
+#          a cheap fetch of the default branch plus a rev-list count, silent
+#          when up to date and silent (comparing against the last-fetched
+#          origin ref) when the fetch fails, e.g. offline - it never fails
+#          bootstrap, mirroring fleet_sync's posture. Detect-only sessions skip
+#          the fetch (no remote-tracking ref writes) but still report from
+#          already-fetched refs. Set FM_SELF_UPDATE_CHECK=0 to skip the check
+#          entirely (tests/lib.sh pins this so suites stay hermetic).
 #          X mode is OPTIONAL and inert unless FM_HOME/.env has a non-empty
 #          FMX_PAIRING_TOKEN. When opted in, bootstrap requires curl+jq, writes
 #          the relay poll shim and 30s cadence config, and prints an FMX line.
@@ -642,6 +652,28 @@ EOF
   echo "FMX: X mode on - relay poll armed via state/x-watch.check.sh; 30s watcher cadence in config/x-mode.env"
 }
 
+firstmate_update_check() {
+  # Best-effort heads-up when this firstmate checkout (FM_ROOT, never anything
+  # under projects/) is behind its origin default branch, so the captain can be
+  # offered /updatefirstmate without having to remember to ask. Silent when up
+  # to date, when FM_ROOT has no repo/origin/default branch, and when the fetch
+  # fails (offline): a failed fetch just compares against the last-fetched
+  # origin ref. Detect-only sessions skip the fetch but still report from
+  # already-fetched refs.
+  local default behind
+  [ "${FM_SELF_UPDATE_CHECK:-1}" != 0 ] || return 0
+  git -C "$FM_ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 0
+  git -C "$FM_ROOT" remote get-url origin >/dev/null 2>&1 || return 0
+  default=$(fm_default_branch "$FM_ROOT") || return 0
+  if [ "${FM_BOOTSTRAP_DETECT_ONLY:-0}" != 1 ]; then
+    GIT_TERMINAL_PROMPT=0 git -C "$FM_ROOT" fetch --quiet origin "$default" >/dev/null 2>&1 || true
+  fi
+  behind=$(git -C "$FM_ROOT" rev-list --count "HEAD..origin/$default" 2>/dev/null) || return 0
+  case "$behind" in ''|*[!0-9]*) return 0 ;; esac
+  [ "$behind" -gt 0 ] || return 0
+  echo "FIRSTMATE_UPDATE: firstmate checkout is $behind commit(s) behind origin/$default (update: /updatefirstmate)"
+}
+
 crew_dispatch_validate() {
   local file err
   file="$CONFIG/crew-dispatch.json"
@@ -789,6 +821,7 @@ if [ -n "$tangle_branch" ]; then
     echo "TANGLE: primary checkout on feature branch '$tangle_branch' (expected '$tangle_default'); the work is safe on that ref - restore the primary with: git -C $FM_ROOT checkout $tangle_default, then re-validate the branch in a proper worktree"
   fi
 fi
+firstmate_update_check
 crew=
 [ -f "$CONFIG/crew-harness" ] && crew=$(tr -d '[:space:]' < "$CONFIG/crew-harness" || true)
 if [ "${FM_BOOTSTRAP_VERBOSE_FACTS:-0}" = 1 ] && [ -n "$crew" ] && [ "$crew" != "default" ]; then

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -57,10 +57,12 @@
 #          degrades at runtime when quota data is unavailable.
 #          FIRSTMATE_UPDATE is a best-effort self-update heads-up scoped to
 #          firstmate's OWN repo (FM_ROOT) only, never anything under projects/:
-#          a cheap fetch of the default branch plus a rev-list count, silent
-#          when up to date and silent (comparing against the last-fetched
-#          origin ref) when the fetch fails, e.g. offline - it never fails
-#          bootstrap, mirroring fleet_sync's posture. Detect-only sessions skip
+#          a cheap time-bounded fetch of the default branch (killed after
+#          FM_SELF_UPDATE_FETCH_TIMEOUT seconds, default 10) plus a rev-list
+#          count, silent when up to date and silent (comparing against the
+#          last-fetched origin ref) when the fetch fails or times out, e.g.
+#          offline - it never fails or blocks bootstrap, mirroring
+#          fleet_sync's posture. Detect-only sessions skip
 #          the fetch (no remote-tracking ref writes) but still report from
 #          already-fetched refs. Set FM_SELF_UPDATE_CHECK=0 to skip the check
 #          entirely (tests/lib.sh pins this so suites stay hermetic).
@@ -652,21 +654,54 @@ EOF
   echo "FMX: X mode on - relay poll armed via state/x-watch.check.sh; 30s watcher cadence in config/x-mode.env"
 }
 
+firstmate_update_fetch_timeout() {
+  case "${FM_SELF_UPDATE_FETCH_TIMEOUT:-}" in
+    ''|*[!0-9]*) echo 10 ;;
+    *) echo "$FM_SELF_UPDATE_FETCH_TIMEOUT" ;;
+  esac
+}
+
+firstmate_update_fetch() {
+  # Time-bounded origin fetch for the self-update check, mirroring fleet_sync's
+  # background+kill posture: a fetch that stalls (captive portal, half-open
+  # network, SSH waiting on a tty prompt) is killed at the timeout so it can
+  # never block session start; the check then falls back to already-fetched refs.
+  local default=$1 pid timeout start elapsed monitor_was_on
+  timeout=$(firstmate_update_fetch_timeout)
+  monitor_was_on=0
+  case $- in *m*) monitor_was_on=1 ;; esac
+  set -m 2>/dev/null || true
+  GIT_TERMINAL_PROMPT=0 git -C "$FM_ROOT" fetch --quiet origin "$default" >/dev/null 2>&1 &
+  pid=$!
+
+  start=$SECONDS
+  while jobs -r -p | grep -qx "$pid"; do
+    elapsed=$((SECONDS - start))
+    if [ "$elapsed" -ge "$timeout" ]; then
+      kill -TERM "-$pid" 2>/dev/null || kill "$pid" 2>/dev/null || true
+      break
+    fi
+    sleep 1
+  done
+  wait "$pid" 2>/dev/null || true
+  [ "$monitor_was_on" -eq 1 ] || set +m 2>/dev/null || true
+}
+
 firstmate_update_check() {
   # Best-effort heads-up when this firstmate checkout (FM_ROOT, never anything
   # under projects/) is behind its origin default branch, so the captain can be
   # offered /updatefirstmate without having to remember to ask. Silent when up
   # to date, when FM_ROOT has no repo/origin/default branch, and when the fetch
-  # fails (offline): a failed fetch just compares against the last-fetched
-  # origin ref. Detect-only sessions skip the fetch but still report from
-  # already-fetched refs.
+  # fails (offline): a failed or timed-out fetch just compares against the
+  # last-fetched origin ref. Detect-only sessions skip the fetch but still
+  # report from already-fetched refs.
   local default behind
   [ "${FM_SELF_UPDATE_CHECK:-1}" != 0 ] || return 0
   git -C "$FM_ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 0
   git -C "$FM_ROOT" remote get-url origin >/dev/null 2>&1 || return 0
   default=$(fm_default_branch "$FM_ROOT") || return 0
   if [ "${FM_BOOTSTRAP_DETECT_ONLY:-0}" != 1 ]; then
-    GIT_TERMINAL_PROMPT=0 git -C "$FM_ROOT" fetch --quiet origin "$default" >/dev/null 2>&1 || true
+    firstmate_update_fetch "$default"
   fi
   behind=$(git -C "$FM_ROOT" rev-list --count "HEAD..origin/$default" 2>/dev/null) || return 0
   case "$behind" in ''|*[!0-9]*) return 0 ;; esac

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -258,6 +258,7 @@ It emits `SECONDMATE_SYNC:` only when a home was skipped for an actionable sync 
 When a running home advances and its loaded instruction surface (`AGENTS.md`, `bin/`, or `.agents/skills/`) changed, bootstrap sends the re-read nudge itself through the stable `fm-<id>` selector and reports the exact completed send as `BOOTSTRAP_INFO:`.
 If that send fails, bootstrap keeps an idempotent retry marker and emits `NUDGE_SECONDMATES:` with the failure reason.
 The same bootstrap run emits `SECONDMATE_LIVENESS:` only when a live secondmate endpoint is skipped or respawn fails; already-live and successfully respawned endpoints are handled silently.
+Bootstrap also runs a best-effort self-update heads-up scoped to firstmate's own `FM_ROOT` checkout only, never `projects/`: a time-bounded `origin` fetch of the default branch (`FM_SELF_UPDATE_FETCH_TIMEOUT`, default 10s) followed by a commit-count comparison, emitting `FIRSTMATE_UPDATE:` only when the checkout is behind; it stays silent when up to date, offline, or the fetch times out (falling back to already-fetched refs), and `FM_SELF_UPDATE_CHECK=0` skips it entirely.
 For a mid-session inherited local-material edit where tracked-file sync and reread nudges are not needed, run `bin/fm-config-push.sh`.
 It uses the same live secondmate discovery and propagation helper as bootstrap, prints each live home's `crew-dispatch.json`, `crew-harness`, `backlog-backend`, and `data/captain-shared.md` result as `pushed`, `unchanged`, `skipped`, or `error`, and exits non-zero only for real propagation errors.
 That live discovery starts from `state/*.meta` records with `kind=secondmate`; `data/secondmates.md` only backfills `home=` for older or incomplete meta records.
@@ -402,6 +403,8 @@ FM_PAUSE_RESURFACE_SECS=3600       # seconds before an idle declared external wa
 FM_WEDGE_DEMAND_INSPECT_COUNT=3    # consecutive provably-working stale escalations on the same unchanged pane before demand-deep-inspection is added
 FM_WATCH_TRIAGE_LOG_MAX_BYTES=262144   # size cap for the watcher's absorbed-wake debug log
 FM_FLEET_SYNC_BOOTSTRAP_TIMEOUT=     # optional seconds allowed for bootstrap's best-effort clone refresh; unset/blank defaults to max(20, 5 + 3 * origin-backed-project-count)
+FM_SELF_UPDATE_CHECK=1  # set to 0 to skip bootstrap's FIRSTMATE_UPDATE self-update heads-up entirely (tests/lib.sh pins this so suites stay hermetic)
+FM_SELF_UPDATE_FETCH_TIMEOUT=10  # seconds allowed for bootstrap's best-effort origin fetch of FM_ROOT's own default branch before it is killed and the check falls back to already-fetched refs
 FM_FLEET_PRUNE=1        # set to 0 to skip pruning local branches whose upstream is gone
 FM_STALE_WORKTREE_LOCK_AGE_SECS=30       # min mtime age before fm-teardown.sh treats a leftover worktree git index.lock as provably stale
 FM_TREEHOUSE_RETURN_LOCK_RETRIES=3        # retries after a treehouse return fails on the transient git index.lock signature

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -15,6 +15,10 @@
 # Dedicated fleet-sync cases pin the computed bootstrap timeout, explicit
 # override, blank-env defaulting, partial-output relay, and pre-launch timeout
 # scan.
+# Self-update-check cases pin the FIRSTMATE_UPDATE line against local file://
+# origins: silent when up to date, behind-by-N reporting, a silently tolerated
+# failed fetch, the FM_SELF_UPDATE_CHECK=0 opt-out, and detect-only's
+# no-fetch stale-ref reporting.
 set -u
 
 # shellcheck source=tests/lib.sh disable=SC1091
@@ -746,6 +750,112 @@ test_crew_dispatch_active_rules_are_verbose_bootstrap_info() {
   pass "bootstrap surfaces active crew-dispatch rules only as verbose BOOTSTRAP_INFO"
 }
 
+# --- firstmate self-update check ---------------------------------------------
+
+# make_self_update_world <case-dir>: a fully local world for the firstmate
+# self-update check - an upstream writer repo, a bare file:// origin cloned from
+# it, and a local clone (the FM_ROOT under test) that starts up to date on main.
+# Also seeds the standard silent home. Echoes "<upstream>|<local-clone>".
+make_self_update_world() {
+  local dir=$1 upstream bare local_clone
+  upstream="$dir/upstream"
+  bare="$dir/origin.git"
+  local_clone="$dir/local"
+  fm_git_identity
+  mkdir -p "$dir/home/config"
+  printf '%s\n' manual > "$dir/home/config/backlog-backend"
+  git init -q -b main "$upstream"
+  git -C "$upstream" commit -q --allow-empty -m base
+  git clone --quiet --bare "$upstream" "$bare"
+  git -C "$upstream" remote add origin "$bare"
+  git clone --quiet "file://$bare" "$local_clone"
+  printf '%s|%s\n' "$upstream" "$local_clone"
+}
+
+run_self_update_bootstrap() {  # <case-dir> <local-clone> [extra env...] -> stdout
+  local case_dir=$1 local_clone=$2 fakebin
+  shift 2
+  fakebin=$(make_fake_toolchain "$case_dir")
+  PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$local_clone" \
+    FM_FAKE_TREEHOUSE_LEASE_HELP=1 env "$@" "$ROOT/bin/fm-bootstrap.sh"
+}
+
+test_self_update_check_silent_when_current() {
+  local case_dir fixture local_clone out
+  case_dir="$TMP_ROOT/self-update-current"
+  fixture=$(make_self_update_world "$case_dir")
+  local_clone=${fixture#*|}
+  out=$(run_self_update_bootstrap "$case_dir" "$local_clone" FM_SELF_UPDATE_CHECK=1)
+  [ -z "$out" ] || fail "up-to-date checkout should stay silent, got: $out"
+  pass "bootstrap self-update check is silent when the checkout is up to date"
+}
+
+test_self_update_check_reports_behind_count() {
+  local case_dir fixture upstream local_clone out expect
+  case_dir="$TMP_ROOT/self-update-behind"
+  fixture=$(make_self_update_world "$case_dir")
+  upstream=${fixture%%|*}
+  local_clone=${fixture#*|}
+  git -C "$upstream" commit -q --allow-empty -m ahead-1
+  git -C "$upstream" commit -q --allow-empty -m ahead-2
+  git -C "$upstream" push -q origin main
+
+  # The check's own fetch must discover the new origin commits.
+  out=$(run_self_update_bootstrap "$case_dir" "$local_clone" FM_SELF_UPDATE_CHECK=1)
+  expect="FIRSTMATE_UPDATE: firstmate checkout is 2 commit(s) behind origin/main (update: /updatefirstmate)"
+  [ "$out" = "$expect" ] || fail "expected '$expect', got: $out"
+
+  # FM_SELF_UPDATE_CHECK=0 (the suite-wide hermeticity default from
+  # tests/lib.sh) must suppress the check even while genuinely behind.
+  out=$(run_self_update_bootstrap "$case_dir" "$local_clone")
+  [ -z "$out" ] || fail "FM_SELF_UPDATE_CHECK=0 should suppress the check, got: $out"
+  pass "bootstrap self-update check fetches, reports the behind count, and honors the opt-out"
+}
+
+test_self_update_check_failed_fetch_is_silent() {
+  local case_dir fixture upstream local_clone out status
+  case_dir="$TMP_ROOT/self-update-offline"
+  fixture=$(make_self_update_world "$case_dir")
+  upstream=${fixture%%|*}
+  local_clone=${fixture#*|}
+  git -C "$upstream" commit -q --allow-empty -m ahead-1
+  git -C "$upstream" push -q origin main
+  # Simulate offline: the origin URL is unreachable and no remote-tracking ref
+  # survives to compare against, so the check has nothing trustworthy to say.
+  git -C "$local_clone" remote set-url origin "file://$case_dir/gone.git"
+  git -C "$local_clone" symbolic-ref --delete refs/remotes/origin/HEAD 2>/dev/null || true
+  git -C "$local_clone" update-ref -d refs/remotes/origin/main
+
+  out=$(run_self_update_bootstrap "$case_dir" "$local_clone" FM_SELF_UPDATE_CHECK=1)
+  status=$?
+  [ "$status" -eq 0 ] || fail "a failed fetch must not fail bootstrap (exit $status)"
+  [ -z "$out" ] || fail "a failed fetch with no prior origin ref should stay silent, got: $out"
+  pass "bootstrap self-update check tolerates a failed fetch without failing bootstrap"
+}
+
+test_self_update_check_detect_only_skips_fetch() {
+  local case_dir fixture upstream local_clone out expect
+  case_dir="$TMP_ROOT/self-update-detect-only"
+  fixture=$(make_self_update_world "$case_dir")
+  upstream=${fixture%%|*}
+  local_clone=${fixture#*|}
+  git -C "$upstream" commit -q --allow-empty -m ahead-1
+  git -C "$upstream" commit -q --allow-empty -m ahead-2
+  git -C "$upstream" push -q origin main
+  git -C "$local_clone" fetch -q origin main
+  # A third origin commit lands after the last fetch; a detect-only session
+  # must report from the already-fetched ref (2 behind), proving it never
+  # fetched the newer state.
+  git -C "$upstream" commit -q --allow-empty -m ahead-3
+  git -C "$upstream" push -q origin main
+
+  out=$(run_self_update_bootstrap "$case_dir" "$local_clone" \
+    FM_SELF_UPDATE_CHECK=1 FM_BOOTSTRAP_DETECT_ONLY=1)
+  expect="FIRSTMATE_UPDATE: firstmate checkout is 2 commit(s) behind origin/main (update: /updatefirstmate)"
+  [ "$out" = "$expect" ] || fail "detect-only should report from already-fetched refs, got: $out"
+  pass "bootstrap self-update check never fetches in detect-only mode but still reports stale-ref drift"
+}
+
 test_crew_dispatch_validation() {
   local label body expect mode case_dir fakebin out n
   n=0
@@ -806,4 +916,8 @@ test_routine_bootstrap_confirmations_are_silent
 test_routine_bootstrap_contract_runs_under_system_bash
 test_bootstrap_info_is_no_load_and_actionable_lines_trigger
 test_crew_dispatch_active_rules_are_verbose_bootstrap_info
+test_self_update_check_silent_when_current
+test_self_update_check_reports_behind_count
+test_self_update_check_failed_fetch_is_silent
+test_self_update_check_detect_only_skips_fetch
 test_crew_dispatch_validation

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -17,8 +17,9 @@
 # scan.
 # Self-update-check cases pin the FIRSTMATE_UPDATE line against local file://
 # origins: silent when up to date, behind-by-N reporting, a silently tolerated
-# failed fetch, the FM_SELF_UPDATE_CHECK=0 opt-out, and detect-only's
-# no-fetch stale-ref reporting.
+# failed fetch, a hanging fetch killed at FM_SELF_UPDATE_FETCH_TIMEOUT, the
+# FM_SELF_UPDATE_CHECK=0 opt-out, and detect-only's no-fetch stale-ref
+# reporting.
 set -u
 
 # shellcheck source=tests/lib.sh disable=SC1091
@@ -833,6 +834,43 @@ test_self_update_check_failed_fetch_is_silent() {
   pass "bootstrap self-update check tolerates a failed fetch without failing bootstrap"
 }
 
+test_self_update_check_hanging_fetch_is_bounded() {
+  local case_dir fixture upstream local_clone fakebin real_git out expect start elapsed
+  case_dir="$TMP_ROOT/self-update-hang"
+  fixture=$(make_self_update_world "$case_dir")
+  upstream=${fixture%%|*}
+  local_clone=${fixture#*|}
+  git -C "$upstream" commit -q --allow-empty -m ahead-1
+  git -C "$upstream" push -q origin main
+  git -C "$local_clone" fetch -q origin main
+  # A second origin commit lands after the last fetch; the hanging fetch below
+  # must be killed before it completes, so the check reports the stale 1-behind
+  # count (proving the fetch never finished) instead of 2.
+  git -C "$upstream" commit -q --allow-empty -m ahead-2
+  git -C "$upstream" push -q origin main
+
+  fakebin=$(make_fake_toolchain "$case_dir")
+  real_git=$(command -v git)
+  cat > "$fakebin/git" <<SH
+#!/usr/bin/env bash
+for arg in "\$@"; do
+  if [ "\$arg" = fetch ]; then sleep 60; break; fi
+done
+exec "$real_git" "\$@"
+SH
+  chmod +x "$fakebin/git"
+
+  start=$SECONDS
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$local_clone" \
+    FM_FAKE_TREEHOUSE_LEASE_HELP=1 FM_SELF_UPDATE_CHECK=1 FM_SELF_UPDATE_FETCH_TIMEOUT=1 \
+    "$ROOT/bin/fm-bootstrap.sh")
+  elapsed=$((SECONDS - start))
+  expect="FIRSTMATE_UPDATE: firstmate checkout is 1 commit(s) behind origin/main (update: /updatefirstmate)"
+  [ "$out" = "$expect" ] || fail "hanging fetch should fall back to stale refs, got: $out"
+  [ "$elapsed" -lt 30 ] || fail "hanging fetch blocked bootstrap for ${elapsed}s"
+  pass "bootstrap self-update check kills a hanging fetch instead of blocking session start"
+}
+
 test_self_update_check_detect_only_skips_fetch() {
   local case_dir fixture upstream local_clone out expect
   case_dir="$TMP_ROOT/self-update-detect-only"
@@ -919,5 +957,6 @@ test_crew_dispatch_active_rules_are_verbose_bootstrap_info
 test_self_update_check_silent_when_current
 test_self_update_check_reports_behind_count
 test_self_update_check_failed_fetch_is_silent
+test_self_update_check_hanging_fetch_is_bounded
 test_self_update_check_detect_only_skips_fetch
 test_crew_dispatch_validation

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -174,6 +174,7 @@ run_bootstrap_timeout_case() {
     # shellcheck disable=SC2317,SC2329 # Exported and invoked by the bootstrap subprocess.
     sleep() {
       local inc=${1:-1}
+      # shellcheck disable=SC2030 # Intentionally local; unrelated to the outer SECONDS usage elsewhere in this file.
       SECONDS=$((SECONDS + inc))
       # Advance fake time quickly, but yield on every tick so the background
       # fleet-sync process can deterministically write its partial output before
@@ -860,10 +861,12 @@ exec "$real_git" "\$@"
 SH
   chmod +x "$fakebin/git"
 
+  # shellcheck disable=SC2031 # Unrelated to the subshell-local SECONDS override in run_bootstrap_timeout_case above.
   start=$SECONDS
   out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$local_clone" \
     FM_FAKE_TREEHOUSE_LEASE_HELP=1 FM_SELF_UPDATE_CHECK=1 FM_SELF_UPDATE_FETCH_TIMEOUT=1 \
     "$ROOT/bin/fm-bootstrap.sh")
+  # shellcheck disable=SC2031 # Unrelated to the subshell-local SECONDS override in run_bootstrap_timeout_case above.
   elapsed=$((SECONDS - start))
   expect="FIRSTMATE_UPDATE: firstmate checkout is 1 commit(s) behind origin/main (update: /updatefirstmate)"
   [ "$out" = "$expect" ] || fail "hanging fetch should fall back to stale refs, got: $out"

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -34,6 +34,14 @@ FM_TEST_LIB_SOURCED=1
 # strips this to verify real refusal.
 export FM_GATE_REFUSE_BYPASS=1
 
+# Keep every suite hermetic against fm-bootstrap.sh's firstmate self-update
+# check: several suites run bootstrap with FM_ROOT resolving to the real
+# checkout, and the check's best-effort `git fetch origin` would otherwise hit
+# the real network and print a FIRSTMATE_UPDATE line whenever the developer's
+# checkout happens to be behind. The check's own tests re-enable it explicitly
+# against local file:// fixtures.
+export FM_SELF_UPDATE_CHECK=0
+
 # Resolve the repo root from this library's own location. Consumed by sourcing
 # test files, not by this library, so it reads as "unused" here.
 # shellcheck disable=SC2034


### PR DESCRIPTION
## Summary
- Add a best-effort `FIRSTMATE_UPDATE` bootstrap diagnostic that checks whether this firstmate checkout is behind its origin default branch, scoped strictly to firstmate's own repo and never `projects/`.
- Silent when up to date; time-bounded and fails silently when offline or on a hung fetch, mirroring `fleet_sync`'s posture.
- Wires the new prefix into `AGENTS.md` section 13 and `.agents/skills/bootstrap-diagnostics/SKILL.md` so the agent offers `/updatefirstmate` to the captain without auto-running it.

## Test plan
- [x] `bin/fm-lint.sh` clean under pinned ShellCheck 0.11.0
- [x] `tests/fm-bootstrap.test.sh` covers up-to-date (silent), behind-by-N (reports), failed/offline fetch (silent, non-fatal), hanging fetch (bounded, falls back to stale refs), and detect-only (no fetch, reports from already-fetched refs)
- [x] Full `tests/*.test.sh` suite passes