### PR TITLE
test(ci): split shell behavior lanes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,49 @@ jobs:
       # re-spell the shellcheck command here; keep CI and the pre-push gate on it.
       - run: bin/fm-lint.sh
 
-  tests:
-    name: Behavior tests
+  behavior-unit:
+    name: Behavior tests - unit lane
     runs-on: ubuntu-latest
-    # The suite should finish in ~2-3 minutes; this generous cap fails loudly on a
-    # hung watcher or tmux test instead of riding GitHub's 360-minute default.
+    # Hermetic parser, policy, static, and fake-adapter coverage.
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Install pinned ShellCheck
+        run: |
+          set -eu
+          bin/fm-install-shellcheck.sh "$RUNNER_TEMP/bin"
+          echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+      - run: bin/fm-test-lane.sh unit
+
+  behavior-integration:
+    name: Behavior tests - integration lane
+    runs-on: ubuntu-latest
+    # Full script behavior over temp files, git fixtures, fake tools, and local
+    # child processes. The lane is isolated from the real-backend e2e lane.
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Install pinned ShellCheck
+        run: |
+          set -eu
+          bin/fm-install-shellcheck.sh "$RUNNER_TEMP/bin"
+          echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+      - name: Install tasks-axi for backlog-handoff delegation
+        run: |
+          set -eu
+          npm install -g tasks-axi
+          tasks-axi --version
+      - run: bin/fm-test-lane.sh integration
+
+  behavior-e2e:
+    name: Behavior tests - e2e lane
+    runs-on: ubuntu-latest
+    # Real tmux, optional real backend, live-harness, and operator-visible daemon
+    # paths. Optional backend and harness probes remain self-gated by each test.
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
@@ -52,11 +90,7 @@ jobs:
           set -eu
           npm install -g tasks-axi
           tasks-axi --version
-      - run: |
-          set -eu
-          for test_script in tests/*.test.sh; do
-            "$test_script"
-          done
+      - run: bin/fm-test-lane.sh e2e
 
   macos-stock-bash:
     name: Stock macOS Bash snapshot compatibility

--- a/.no-mistakes.yaml
+++ b/.no-mistakes.yaml
@@ -19,13 +19,14 @@ disable_project_settings: true
 # them. commands.lint delegates to bin/fm-lint.sh, the single owner of the lint
 # definition that .github/workflows/ci.yml also invokes, so local can never
 # diverge from CI again (parity asserted by tests/fm-lint.test.sh).
-# The test command mirrors the Linux behavior job in .github/workflows/ci.yml:
-# iterate every tests/*.test.sh, run each, and fail the step if any one exits
-# non-zero (an agent-driven test step has crashed the daemon). The e2e tests need
-# tmux on PATH, which the firstmate environment provides.
+# The test command mirrors the Linux behavior jobs in .github/workflows/ci.yml:
+# run every shell behavior lane through bin/fm-test-lane.sh, whose manifest
+# validation fails before execution when a tests/*.test.sh file is missing,
+# duplicate, stale, or unknown. The e2e lane needs tmux on PATH, which the
+# firstmate environment provides.
 commands:
   lint: 'bin/fm-lint.sh'
-  test: 'command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"'
+  test: 'command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; bin/fm-test-lane.sh unit && bin/fm-test-lane.sh integration && bin/fm-test-lane.sh e2e'
 
 # Keep test evidence out of this repo; it stays in a temp dir instead.
 test:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,14 +70,17 @@ Check and test the toolbelt before pushing:
 ```sh
 for script in bin/*.sh bin/backends/*.sh; do bash -n "$script"; done   # syntax-check the toolbelt
 bin/fm-lint.sh   # lint the toolbelt and behavior tests; the single owner CI and the no-mistakes gate both run
-for test_script in tests/*.test.sh; do bash "$test_script"; done   # behavior tests, matching CI and no-mistakes commands.test
+bin/fm-test-lane.sh unit   # hermetic shell behavior tests, matching CI and no-mistakes commands.test
+bin/fm-test-lane.sh integration   # script behavior over temp state, fake tools, and local child processes
+bin/fm-test-lane.sh e2e   # real tmux, optional backend, live-harness, and daemon path coverage
 [ "$(readlink CLAUDE.md)" = "AGENTS.md" ]
 [ "$(readlink .claude/skills)" = "../.agents/skills" ]
 tmp=$(mktemp -d) && printf 'done: smoke\n' > "$tmp/smoke.status" && FM_STATE_OVERRIDE="$tmp" FM_SIGNAL_GRACE=1 FM_POLL=1 FM_HEARTBEAT=999999 bin/fm-watch-arm.sh  # watcher re-arm smoke test (prints arm status, then an actionable signal)
 ```
 
 Discover tests by listing `tests/*.test.sh`: each is a self-contained bash script named `<subject>.test.sh`, and its header comment describes what it covers, so run one directly to focus on a subject.
-Tests that need a real optional backend or an explicit opt-in (real herdr/zellij/cmux smoke tests, the live Pi regression) skip themselves and print the tool or environment gate needed to enable them, so the run-all loop above is always safe.
+Shell behavior lane ownership lives in `tests/shell-lanes.tsv`; `bin/fm-test-lane.sh` refuses missing, duplicate, stale, or unknown classifications before running any script.
+Tests that need a real optional backend or an explicit opt-in (real herdr/zellij/cmux smoke tests, live harness continuity probes, the live Pi regression) skip themselves and print the tool or environment gate needed to enable them, so the e2e lane remains safe for ordinary local validation.
 
 ## Questions
 

--- a/bin/backends/cmux.sh
+++ b/bin/backends/cmux.sh
@@ -398,8 +398,9 @@ fm_backend_cmux_parse_target() {  # <target>
 # (fm_backend_zellij_pane_exists) rather than the design sketch's original
 # read-screen-based suggestion.
 fm_backend_cmux_surface_exists() {  # <workspace_id> <surface_id>
-  local wsid=$1 sfid=$2
-  fm_backend_cmux_cli list-panes --workspace "$wsid" --json --id-format uuids 2>/dev/null \
+  local wsid=$1 sfid=$2 raw
+  raw=$(fm_backend_cmux_cli list-panes --workspace "$wsid" --json --id-format uuids 2>/dev/null) || return 1
+  printf '%s' "$raw" \
     | jq -e --arg s "$sfid" '[.panes[]? | select(.surface_ids // [] | index($s))] | length > 0' >/dev/null 2>&1
 }
 

--- a/bin/fm-test-lane.sh
+++ b/bin/fm-test-lane.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Run one shell behavior-test lane.
+#
+# Usage:
+#   fm-test-lane.sh <unit|integration|e2e>
+#
+# tests/shell-lanes.tsv is the single owner of shell-test lane classification.
+# This runner validates that every tracked tests/*.test.sh file appears exactly
+# once before it runs any script.
+# Output deliberately includes lane/script start and finish markers with elapsed
+# seconds so CI and local timeout logs name the active script.
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TEST_DIR=${FM_TEST_LANE_TEST_DIR:-"$ROOT/tests"}
+MANIFEST=${FM_TEST_LANE_MANIFEST:-"$ROOT/tests/shell-lanes.tsv"}
+
+usage() {
+  echo "usage: fm-test-lane.sh <unit|integration|e2e>" >&2
+}
+
+die() {
+  echo "error: $1" >&2
+  exit 2
+}
+
+lane=${1:-}
+[ "$#" -eq 1 ] || { usage; exit 2; }
+case "$lane" in
+  unit|integration|e2e) ;;
+  *) usage; exit 2 ;;
+esac
+
+[ -d "$TEST_DIR" ] || die "test directory not found: $TEST_DIR"
+[ -f "$MANIFEST" ] || die "lane manifest not found: $MANIFEST"
+
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-lane.XXXXXX") || exit 2
+cleanup() { rm -rf "$tmp"; }
+trap cleanup EXIT
+
+actual="$tmp/actual"
+manifest_scripts="$tmp/manifest-scripts"
+entries="$tmp/entries"
+selected="$tmp/selected"
+: > "$manifest_scripts"
+: > "$entries"
+: > "$selected"
+
+find "$TEST_DIR" -maxdepth 1 -type f -name '*.test.sh' -exec basename {} \; | sort > "$actual"
+
+tab=$(printf '\t')
+line_no=0
+while IFS= read -r line || [ -n "$line" ]; do
+  line_no=$((line_no + 1))
+  case "$line" in
+    ''|'#'*) continue ;;
+  esac
+
+  case "$line" in
+    *"$tab"*) ;;
+    *) die "malformed lane manifest line $line_no" ;;
+  esac
+  entry_lane=${line%%"$tab"*}
+  rest=${line#*"$tab"}
+  case "$rest" in
+    *"$tab"*) script=${rest%%"$tab"*} ;;
+    *) script=$rest ;;
+  esac
+  [ -n "$entry_lane" ] && [ -n "$script" ] \
+    || die "malformed lane manifest line $line_no"
+  case "$entry_lane" in
+    unit|integration|e2e) ;;
+    *) die "unknown lane '$entry_lane' in manifest line $line_no" ;;
+  esac
+  case "$script" in
+    */*) die "manifest line $line_no must use a test basename, got '$script'" ;;
+    *.test.sh) ;;
+    *) die "manifest line $line_no is not a shell behavior test: $script" ;;
+  esac
+  printf '%s\n' "$script" >> "$manifest_scripts"
+  printf '%s\t%s\n' "$entry_lane" "$script" >> "$entries"
+  [ "$entry_lane" = "$lane" ] && printf '%s\n' "$script" >> "$selected"
+done < "$MANIFEST"
+
+duplicates=$(sort "$manifest_scripts" | uniq -d)
+if [ -n "$duplicates" ]; then
+  while IFS= read -r script; do
+    [ -n "$script" ] && echo "error: duplicate lane classification: $script" >&2
+  done <<EOF
+$duplicates
+EOF
+  exit 2
+fi
+
+while IFS= read -r script || [ -n "$script" ]; do
+  [ -n "$script" ] || continue
+  if ! grep -Fx -- "$script" "$manifest_scripts" >/dev/null; then
+    echo "error: missing lane classification: $script" >&2
+    exit 2
+  fi
+done < "$actual"
+
+while IFS= read -r script || [ -n "$script" ]; do
+  [ -n "$script" ] || continue
+  if ! grep -Fx -- "$script" "$actual" >/dev/null; then
+    echo "error: stale lane classification: $script" >&2
+    exit 2
+  fi
+done < "$manifest_scripts"
+
+count=$(grep -c . "$selected" || true)
+[ "$count" -gt 0 ] || die "lane '$lane' has no tests"
+
+lane_start=$(date +%s)
+printf 'lane-start lane=%s script-count=%s started=%s\n' "$lane" "$count" "$(date -u +%FT%TZ)"
+
+while IFS= read -r script || [ -n "$script" ]; do
+  [ -n "$script" ] || continue
+  display="tests/$script"
+  script_start=$(date +%s)
+  printf 'script-start lane=%s script=%s started=%s\n' "$lane" "$display" "$(date -u +%FT%TZ)"
+  "$TEST_DIR/$script"
+  status=$?
+  script_end=$(date +%s)
+  printf 'script-end lane=%s script=%s status=%s elapsed=%ss\n' \
+    "$lane" "$display" "$status" "$((script_end - script_start))"
+  if [ "$status" -ne 0 ]; then
+    lane_end=$(date +%s)
+    printf 'lane-end lane=%s status=%s failed=%s elapsed=%ss\n' \
+      "$lane" "$status" "$display" "$((lane_end - lane_start))"
+    exit "$status"
+  fi
+done < "$selected"
+
+lane_end=$(date +%s)
+printf 'lane-end lane=%s status=0 elapsed=%ss\n' "$lane" "$((lane_end - lane_start))"

--- a/bin/fm-test-lane.sh
+++ b/bin/fm-test-lane.sh
@@ -119,7 +119,7 @@ while IFS= read -r script || [ -n "$script" ]; do
   display="tests/$script"
   script_start=$(date +%s)
   printf 'script-start lane=%s script=%s started=%s\n' "$lane" "$display" "$(date -u +%FT%TZ)"
-  "$TEST_DIR/$script"
+  "$TEST_DIR/$script" </dev/null
   status=$?
   script_end=$(date +%s)
   printf 'script-end lane=%s script=%s status=%s elapsed=%ss\n' \

--- a/docs/arm-pretool-check.md
+++ b/docs/arm-pretool-check.md
@@ -250,5 +250,7 @@ bash -n bin/fm-arm-pretool-check.sh
 shellcheck bin/fm-arm-pretool-check.sh tests/fm-arm-pretool-check.test.sh
 node --check bin/fm-arm-command-policy.mjs
 tests/fm-arm-pretool-check.test.sh
-for test_script in tests/*.test.sh; do bash "$test_script"; done
+bin/fm-test-lane.sh unit
+bin/fm-test-lane.sh integration
+bin/fm-test-lane.sh e2e
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -104,9 +104,10 @@ See [`wedge-alarm.md`](wedge-alarm.md) for the channel reference and macOS verif
 
 ## Gate defaults (.no-mistakes.yaml)
 
-The tracked `.no-mistakes.yaml` keeps test evidence outside the repo and defines `commands.test` so no-mistakes runs firstmate's bash behavior suite directly.
+The tracked `.no-mistakes.yaml` keeps test evidence outside the repo and defines `commands.test` so no-mistakes runs firstmate's bash behavior lanes directly.
 That evidence policy is specific to the firstmate repo: target projects may legitimately commit `.no-mistakes/evidence/` from their own no-mistakes pipeline, but firstmate keeps `.no-mistakes/` local and CI rejects tracked entries under that path.
-That command requires `tmux` on `PATH`, prints `tmux -V`, runs every `tests/*.test.sh` with `bash`, and fails if any script exits non-zero.
+That command requires `tmux` on `PATH`, prints `tmux -V`, then runs `bin/fm-test-lane.sh unit`, `bin/fm-test-lane.sh integration`, and `bin/fm-test-lane.sh e2e`.
+The lane manifest lives in `tests/shell-lanes.tsv`, and the runner refuses missing, duplicate, stale, or unknown shell-test classifications before running a lane.
 It intentionally mirrors the behavior-test baseline in [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) instead of delegating the test step to an agent.
 
 ## Captain Preferences (data/captain.md / data/captain-shared.md)

--- a/docs/decision-hold-lifecycle.md
+++ b/docs/decision-hold-lifecycle.md
@@ -81,6 +81,12 @@ fm-lint.sh: ShellCheck 0.11.0 (pinned 0.11.0)
 $ git diff --check
 (no output)
 
-$ for test_script in tests/*.test.sh; do bash "$test_script"; done
-ALL 71 TEST SCRIPTS PASSED
+$ bin/fm-test-lane.sh unit
+...
+
+$ bin/fm-test-lane.sh integration
+...
+
+$ bin/fm-test-lane.sh e2e
+...
 ```

--- a/tests/fm-afk-inject-e2e.test.sh
+++ b/tests/fm-afk-inject-e2e.test.sh
@@ -94,7 +94,7 @@ trap cleanup EXIT INT TERM
 
 _buf=
 redraw() {
-  printf '\r\033[K%s' "$_buf"
+  printf '\r%s\033[K' "$_buf"
 }
 submit_line() {
   local _line=$_buf _c _hex
@@ -249,6 +249,23 @@ wait_for_pane_input_pending() {
   return 1
 }
 
+wait_for_stable_pending_text() {  # <text>
+  local text=$1 i=0 stable=0 state cap
+  while [ "$i" -lt 60 ]; do
+    state=$(PATH="$TMUX_SHIM_DIR:$PATH" fm_backend_composer_state tmux "$SUPERVISOR_PANE")
+    cap=$("$REAL_TMUX" -L "$SOCKET" capture-pane -p -t "$SUPERVISOR_PANE" 2>/dev/null || true)
+    if [ "$state" = pending ] && printf '%s' "$cap" | grep -F "$text" >/dev/null; then
+      stable=$((stable + 1))
+      [ "$stable" -ge 5 ] && return 0
+    else
+      stable=0
+    fi
+    sleep 0.05
+    i=$((i + 1))
+  done
+  return 1
+}
+
 selfcheck_pane_input_pending
 
 # --- Scenario A: human-partial-input ----------------------------------------
@@ -261,8 +278,8 @@ test_scenario_a() {
   # Type partial text into the supervisor pane with NO Enter. This simulates the
   # captain returning and starting to type before afk has been cleared.
   "$REAL_TMUX" -L "$SOCKET" send-keys -t "$SUPERVISOR_PANE" -l "human draft text"
-  wait_for_pane_input_pending \
-    || fail "Scenario A: human draft text did not become detectable as pending input"
+  wait_for_stable_pending_text "human draft text" \
+    || fail "Scenario A: human draft text did not become stable pending input before escalation"
 
   # Write a captain-relevant status to trigger a real escalation through the
   # real watcher child.

--- a/tests/fm-backend-tmux-smoke.test.sh
+++ b/tests/fm-backend-tmux-smoke.test.sh
@@ -24,6 +24,20 @@ cleanup_all() {
   [ -n "${SHIM_DIR:-}" ] && rm -rf "$SHIM_DIR"
 }
 
+wait_for_capture_contains() {  # <target> <lines> <needle>
+  local target=$1 lines=$2 needle=$3 i=0 out
+  while [ "$i" -lt 50 ]; do
+    out=$(fm_backend_tmux_capture "$target" "$lines") || return 1
+    case "$out" in
+      *"$needle"*) return 0 ;;
+    esac
+    sleep 0.1
+    i=$((i + 1))
+  done
+  printf '%s' "$out"
+  return 1
+}
+
 # A `tmux` shim on PATH that transparently redirects every call to the private
 # socket, so bin/backends/tmux.sh's bare `tmux ...` invocations never touch the
 # host's real sessions.
@@ -99,7 +113,9 @@ pass "real tmux: fm_backend_tmux_send_literal + fm_backend_tmux_send_key Enter s
 # far enough to still see the earliest line - the same -S -N bounding fm-peek.sh
 # and fm-watch.sh rely on for a bounded, cheap pane read.
 fm_backend_tmux_send_text_line "$TARGET" "for i in \$(seq 1 80); do echo tag-line-\$i; done"
-sleep 0.6
+if ! wait_for_capture_contains "$TARGET" 20 "tag-line-80"; then
+  fail "recent numbered output did not appear before capture assertions"$'\n'"$(fm_backend_tmux_capture "$TARGET" 20 2>/dev/null || true)"
+fi
 small=$(fm_backend_tmux_capture "$TARGET" 3) || fail "fm_backend_tmux_capture (small window) failed"
 case "$small" in
   *tag-line-1$'\n'*) fail "a 3-line capture should not still see the very first numbered line"$'\n'"$small" ;;

--- a/tests/fm-lint.test.sh
+++ b/tests/fm-lint.test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Parity guard for firstmate's shell-lint definition.
 #
-# bin/fm-lint.sh must be the single owner that BOTH CI
+# bin/fm-lint.sh must be the single owner that CI
 # (.github/workflows/ci.yml) and the pre-push gate (.no-mistakes.yaml
 # commands.lint) invoke, so the local lint can never diverge from CI again.
 # Regression origin: with no commands.lint configured, the local no-mistakes
@@ -73,7 +73,7 @@ test_ci_installs_and_logs_the_pinned_version() {
   # CI must derive the version from the one owner (never hardcode a divergent
   # number) and log the resolved version as parity evidence.
   assert_grep "VERSION=\"\$(\"\$ROOT/bin/fm-lint.sh\" --required-version)\"" "$INSTALLER" "installer must read the version fm-lint.sh pins"
-  [ "$(grep -Fc "bin/fm-install-shellcheck.sh \"\$RUNNER_TEMP/bin\"" "$CI")" -eq 2 ] || fail "both CI jobs must use the shared ShellCheck installer"
+  [ "$(grep -Fc "bin/fm-install-shellcheck.sh \"\$RUNNER_TEMP/bin\"" "$CI")" -eq 4 ] || fail "CI lint plus all three behavior lane jobs must use the shared ShellCheck installer"
   assert_grep "ACTUAL_SHA256=\$(sha256sum" "$INSTALLER" "installer must calculate the ShellCheck archive checksum"
   assert_grep "[ \"\$ACTUAL_SHA256\" = \"\$SHA256\" ]" "$INSTALLER" "installer must verify the ShellCheck archive checksum"
   assert_grep "\"\$DESTINATION/shellcheck\" --version" "$INSTALLER" "installer must log the resolved ShellCheck version as evidence"

--- a/tests/fm-spawn-batch.test.sh
+++ b/tests/fm-spawn-batch.test.sh
@@ -14,6 +14,8 @@ set -u
 
 SPAWN="$ROOT/bin/fm-spawn.sh"
 TMP_ROOT=$(fm_test_tmproot fm-spawn-batch)
+EMPTY_CONFIG="$TMP_ROOT/empty-config"
+mkdir -p "$EMPTY_CONFIG"
 export FM_BACKEND=tmux
 
 # Clear ambient firstmate overrides so the behavior test owns its environment.
@@ -23,7 +25,7 @@ run_spawn() {
     FM_STATE_OVERRIDE='' \
     FM_DATA_OVERRIDE='' \
     FM_PROJECTS_OVERRIDE='' \
-    FM_CONFIG_OVERRIDE='' \
+    FM_CONFIG_OVERRIDE="$EMPTY_CONFIG" \
     FM_SPAWN_NO_GUARD=1 \
     "$SPAWN" "$@" 2>&1
 }
@@ -79,12 +81,12 @@ test_projects_path_scoping() {
     projects="$TMP_ROOT/$id projects"
     mkdir -p "$home/data" "$projects/alpha"
     if [ "$use_override" = yes ]; then
-      out=$(FM_ROOT_OVERRIDE='' FM_STATE_OVERRIDE='' FM_DATA_OVERRIDE='' FM_CONFIG_OVERRIDE='' \
+      out=$(FM_ROOT_OVERRIDE='' FM_STATE_OVERRIDE='' FM_DATA_OVERRIDE='' FM_CONFIG_OVERRIDE="$EMPTY_CONFIG" \
         FM_HOME="$home" FM_PROJECTS_OVERRIDE="$projects" FM_SPAWN_NO_GUARD=1 \
         "$SPAWN" "$id" projects/alpha codex 2>&1)
     else
       mkdir -p "$home/projects/alpha"
-      out=$(FM_ROOT_OVERRIDE='' FM_STATE_OVERRIDE='' FM_DATA_OVERRIDE='' FM_PROJECTS_OVERRIDE='' FM_CONFIG_OVERRIDE='' \
+      out=$(FM_ROOT_OVERRIDE='' FM_STATE_OVERRIDE='' FM_DATA_OVERRIDE='' FM_PROJECTS_OVERRIDE='' FM_CONFIG_OVERRIDE="$EMPTY_CONFIG" \
         FM_HOME="$home" FM_SPAWN_NO_GUARD=1 \
         "$SPAWN" "$id" projects/alpha codex 2>&1)
     fi

--- a/tests/fm-test-lane.test.sh
+++ b/tests/fm-test-lane.test.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# Contract tests for the public shell behavior lane runner.
+#
+# The public seam is bin/fm-test-lane.sh <unit|integration|e2e>.
+# The runner owns manifest validation, deterministic selection, timing markers,
+# and exit propagation before CI or local operators depend on it.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+RUNNER="$ROOT/bin/fm-test-lane.sh"
+TMP_ROOT=$(fm_test_tmproot fm-test-lane)
+
+make_fixture() {  # <name>
+  local dir=$1
+  mkdir -p "$dir/tests" "$dir/bin"
+}
+
+write_script() {  # <dir> <script> <body>
+  local dir=$1 script=$2 body=$3
+  cat > "$dir/tests/$script" <<SH
+#!/usr/bin/env bash
+set -u
+$body
+SH
+  chmod +x "$dir/tests/$script"
+}
+
+run_lane() {  # <dir> <lane> [manifest]
+  local dir=$1 lane=$2 manifest
+  manifest=${3:-$dir/manifest.tsv}
+  FM_TEST_LANE_TEST_DIR="$dir/tests" \
+    FM_TEST_LANE_MANIFEST="$manifest" \
+    "$RUNNER" "$lane" > "$dir/stdout" 2> "$dir/stderr"
+}
+
+test_requires_known_lane() {
+  local dir rc
+  dir="$TMP_ROOT/known-lane"; make_fixture "$dir"
+  write_script "$dir" alpha.test.sh 'exit 0'
+  printf 'unit\talpha.test.sh\tfixture\n' > "$dir/manifest.tsv"
+
+  run_lane "$dir" nope
+  rc=$?
+
+  expect_code 2 "$rc" "unknown lane must exit 2"
+  assert_contains "$(cat "$dir/stderr")" "usage: fm-test-lane.sh <unit|integration|e2e>" \
+    "unknown lane must print usage"
+  pass "fm-test-lane: rejects unknown lanes before running tests"
+}
+
+test_manifest_must_cover_each_script_once() {
+  local dir rc
+  dir="$TMP_ROOT/manifest-coverage"; make_fixture "$dir"
+  write_script "$dir" alpha.test.sh 'exit 0'
+  write_script "$dir" beta.test.sh 'exit 0'
+
+  printf 'unit\talpha.test.sh\tfixture\n' > "$dir/manifest.tsv"
+  run_lane "$dir" unit
+  rc=$?
+  expect_code 2 "$rc" "missing manifest entry must exit 2"
+  assert_contains "$(cat "$dir/stderr")" "missing lane classification: beta.test.sh" \
+    "missing script must be named"
+
+  printf 'unit\talpha.test.sh\tfixture\nintegration\talpha.test.sh\tdup\nunit\tbeta.test.sh\tfixture\n' > "$dir/manifest.tsv"
+  run_lane "$dir" unit
+  rc=$?
+  expect_code 2 "$rc" "duplicate manifest entry must exit 2"
+  assert_contains "$(cat "$dir/stderr")" "duplicate lane classification: alpha.test.sh" \
+    "duplicate script must be named"
+
+  printf 'unit\talpha.test.sh\tfixture\nunit\tbeta.test.sh\tfixture\nunit\tghost.test.sh\tstale\n' > "$dir/manifest.tsv"
+  run_lane "$dir" unit
+  rc=$?
+  expect_code 2 "$rc" "stale manifest entry must exit 2"
+  assert_contains "$(cat "$dir/stderr")" "stale lane classification: ghost.test.sh" \
+    "stale script must be named"
+
+  pass "fm-test-lane: validates manifest completeness, uniqueness, and freshness"
+}
+
+test_runs_selected_lane_in_manifest_order_with_timing_markers() {
+  local dir rc out order
+  dir="$TMP_ROOT/ordered"; make_fixture "$dir"
+  write_script "$dir" alpha.test.sh "printf 'alpha\n' >> '$dir/order.log'"
+  write_script "$dir" beta.test.sh "printf 'beta\n' >> '$dir/order.log'"
+  write_script "$dir" gamma.test.sh "printf 'gamma\n' >> '$dir/order.log'"
+  {
+    printf 'unit\tbeta.test.sh\tfixture\n'
+    printf 'integration\tgamma.test.sh\tfixture\n'
+    printf 'unit\talpha.test.sh\tfixture\n'
+  } > "$dir/manifest.tsv"
+
+  run_lane "$dir" unit
+  rc=$?
+  expect_code 0 "$rc" "unit lane should pass"
+  out=$(cat "$dir/stdout")
+  order=$(cat "$dir/order.log")
+  [ "$order" = $'beta\nalpha' ] || fail "unit lane did not run in manifest order: $order"
+  assert_contains "$out" "lane-start lane=unit" "lane start marker missing"
+  assert_contains "$out" "script-start lane=unit script=tests/beta.test.sh" "first script start marker missing"
+  assert_contains "$out" "script-end lane=unit script=tests/beta.test.sh status=0 elapsed=" "script end timing missing"
+  assert_contains "$out" "lane-end lane=unit status=0 elapsed=" "lane end timing missing"
+  assert_not_contains "$out" "gamma.test.sh" "integration script leaked into unit lane"
+  pass "fm-test-lane: runs selected scripts in manifest order with timing markers"
+}
+
+test_propagates_nonzero_with_failure_identity() {
+  local dir rc out
+  dir="$TMP_ROOT/nonzero"; make_fixture "$dir"
+  write_script "$dir" alpha.test.sh 'exit 0'
+  write_script "$dir" beta.test.sh 'exit 7'
+  printf 'unit\talpha.test.sh\tfixture\nunit\tbeta.test.sh\tfixture\n' > "$dir/manifest.tsv"
+
+  run_lane "$dir" unit
+  rc=$?
+
+  expect_code 7 "$rc" "runner must return the failing script status"
+  out=$(cat "$dir/stdout")
+  assert_contains "$out" "script-end lane=unit script=tests/beta.test.sh status=7 elapsed=" \
+    "failing script marker missing"
+  assert_contains "$out" "lane-end lane=unit status=7 failed=tests/beta.test.sh elapsed=" \
+    "lane failure identity missing"
+  pass "fm-test-lane: propagates nonzero status with failure identity"
+}
+
+test_requires_known_lane
+test_manifest_must_cover_each_script_once
+test_runs_selected_lane_in_manifest_order_with_timing_markers
+test_propagates_nonzero_with_failure_identity

--- a/tests/fm-test-lane.test.sh
+++ b/tests/fm-test-lane.test.sh
@@ -106,6 +106,25 @@ test_runs_selected_lane_in_manifest_order_with_timing_markers() {
   pass "fm-test-lane: runs selected scripts in manifest order with timing markers"
 }
 
+test_stdin_reading_script_cannot_consume_next_manifest_entry() {
+  local dir rc out
+  dir="$TMP_ROOT/stdin-isolation"; make_fixture "$dir"
+  write_script "$dir" alpha.test.sh "IFS= read -r _stolen || true; printf 'alpha\n' >> '$dir/order.log'"
+  write_script "$dir" beta.test.sh "printf 'beta\n' >> '$dir/order.log'"
+  printf 'unit\talpha.test.sh\tfixture\nunit\tbeta.test.sh\tfixture\n' > "$dir/manifest.tsv"
+
+  run_lane "$dir" unit
+  rc=$?
+
+  expect_code 0 "$rc" "unit lane should pass"
+  out=$(cat "$dir/stdout")
+  assert_contains "$(cat "$dir/order.log" 2>/dev/null || true)" $'alpha\nbeta' \
+    "stdin-reading first script must not consume the second manifest entry"
+  assert_contains "$out" "script-start lane=unit script=tests/beta.test.sh" \
+    "second script start marker missing after stdin-reading first script"
+  pass "fm-test-lane: redirects script stdin so one test cannot skip the next manifest entry"
+}
+
 test_propagates_nonzero_with_failure_identity() {
   local dir rc out
   dir="$TMP_ROOT/nonzero"; make_fixture "$dir"
@@ -128,4 +147,5 @@ test_propagates_nonzero_with_failure_identity() {
 test_requires_known_lane
 test_manifest_must_cover_each_script_once
 test_runs_selected_lane_in_manifest_order_with_timing_markers
+test_stdin_reading_script_cannot_consume_next_manifest_entry
 test_propagates_nonzero_with_failure_identity

--- a/tests/shell-lanes.tsv
+++ b/tests/shell-lanes.tsv
@@ -1,0 +1,91 @@
+# Shell behavior-test lane owner.
+# Format: lane<TAB>script<TAB>classification reason.
+# Lanes are resource boundaries.
+# unit is hermetic parser, policy, static, or fake-adapter coverage.
+# integration drives Firstmate scripts over temp files, git fixtures, fake tools, or local child processes.
+# e2e uses real session backends, live harnesses, or full operator-visible daemon paths.
+# Mixed files belong to the highest-resource lane they exercise.
+e2e	fm-afk-inject-e2e.test.sh	real isolated tmux socket injection path
+e2e	fm-afk-inject-herdr-e2e.test.sh	optional real Herdr injection path
+e2e	fm-afk-launch.test.sh	mixed unit plus real detached tmux or Herdr topology checks
+e2e	fm-afk-pi-herdr-return-e2e.test.sh	opt-in real Pi and Herdr away-return path
+integration	fm-afk-return.test.sh	return catch-up script behavior over temp state
+unit	fm-arm-pretool-check.test.sh	harness transport policy matrix without live harnesses
+e2e	fm-backend-autodetect-smoke.test.sh	real Herdr spawn-time autodetect smoke
+e2e	fm-backend-cmux-smoke.test.sh	optional real cmux smoke
+unit	fm-backend-cmux.test.sh	fake cmux adapter primitive coverage
+e2e	fm-backend-herdr-eventwait-smoke.test.sh	real Herdr event-wait smoke
+e2e	fm-backend-herdr-prune-safety-e2e.test.sh	real Herdr prune safety path
+e2e	fm-backend-herdr-respawn-idem-e2e.test.sh	real Herdr restart idempotency path
+e2e	fm-backend-herdr-smoke.test.sh	real Herdr adapter smoke
+e2e	fm-backend-herdr-workspace-per-home-e2e.test.sh	real Herdr spawn and teardown path
+unit	fm-backend-herdr.test.sh	fake Herdr adapter primitive coverage
+unit	fm-backend-orca.test.sh	fake Orca adapter primitive coverage
+e2e	fm-backend-tmux-smoke.test.sh	real isolated tmux adapter smoke
+e2e	fm-backend-zellij-smoke.test.sh	optional real Zellij smoke
+unit	fm-backend-zellij.test.sh	fake Zellij adapter primitive coverage
+integration	fm-backend.test.sh	backend dispatch scripts over fake tmux and git fixtures
+integration	fm-backlog-handoff.test.sh	backlog handoff over temp tasks and homes
+integration	fm-bearings-snapshot.test.sh	Bearings projection over temp fleet state
+integration	fm-bootstrap.test.sh	bootstrap script behavior over temp fleet state
+integration	fm-brief.test.sh	brief generation script behavior
+unit	fm-captain-translation-contract.test.sh	static captain-facing wording contract
+unit	fm-cd-pretool-check.test.sh	cd guard transport and policy matrix
+e2e	fm-claude-continuity-live-e2e.test.sh	opt-in live Claude continuity probe
+e2e	fm-codex-continuity-live-e2e.test.sh	opt-in live Codex continuity probe
+integration	fm-composer-ghost.test.sh	composer state behavior over fake captures
+unit	fm-composer-lib.test.sh	pure composer classifier coverage
+unit	fm-continuity-pretool-check.test.sh	continuity guard transport and policy matrix
+integration	fm-crew-state.test.sh	crew-state helper behavior over temp repos and fake no-mistakes
+integration	fm-daemon.test.sh	away daemon behavior over temp state and fake notifiers
+integration	fm-decision-hold-lifecycle.test.sh	decision lifecycle scripts over temp backlog state
+unit	fm-dispatch-select.test.sh	dispatch-profile selection logic
+integration	fm-ensure-agents-md.test.sh	project AGENTS.md helper behavior over temp repos
+integration	fm-fleet-snapshot-view.test.sh	fleet snapshot rendering over temp state
+integration	fm-fleet-sync.test.sh	fleet sync behavior over temp repos
+integration	fm-gate-refuse.test.sh	gate refusal scripts over temp gate topology
+integration	fm-gotmp.test.sh	temp-home cleanup behavior over stub scripts
+e2e	fm-grok-continuity-live-e2e.test.sh	opt-in live Grok continuity probe
+unit	fm-grok-harness.test.sh	Grok hook and harness contract checks
+integration	fm-guard-stale-banner.test.sh	guard warning behavior over temp state
+integration	fm-herdr-lab.test.sh	Herdr lab helper behavior with fake CLI
+unit	fm-instruction-owners.test.sh	static instruction ownership contract
+unit	fm-lint.test.sh	lint owner parity contract
+unit	fm-no-mistakes-ownership.test.sh	static no-mistakes ownership contract
+e2e	fm-opencode-primary-live-e2e.test.sh	opt-in live OpenCode primary probe
+e2e	fm-pi-primary-live-e2e.test.sh	opt-in live Pi primary probe
+unit	fm-pi-primary-types.test.sh	Pi extension type and static contract checks
+unit	fm-pi-watch-extension.test.sh	Pi watcher extension static contract
+integration	fm-pr-check-security.test.sh	PR-check security behavior over temp state and child processes
+integration	fm-pr-merge.test.sh	PR merge helper behavior with fake gh-axi
+integration	fm-review-diff.test.sh	review diff helper behavior over temp repos and fake gh-axi
+integration	fm-secondmate-harness.test.sh	secondmate harness resolution and spawn behavior with fake tmux
+integration	fm-secondmate-lifecycle-e2e.test.sh	secondmate lifecycle over fake tmux and treehouse
+integration	fm-secondmate-liveness.test.sh	secondmate liveness sweep over fake backends
+integration	fm-secondmate-safety.test.sh	secondmate safety over fake tmux and temp homes
+integration	fm-secondmate-sync.test.sh	secondmate sync over temp git worktrees
+integration	fm-send-popup-settle.test.sh	send settle behavior over fake tmux captures
+e2e	fm-send-secondmate-marker-herdr-e2e.test.sh	opt-in real Pi and Herdr marker path
+integration	fm-send-secondmate-marker.test.sh	secondmate marker send behavior with fake tmux
+integration	fm-send-settle.test.sh	send settle behavior with fake sleep
+integration	fm-send-strict.test.sh	strict send resolution over fake backends
+integration	fm-session-start.test.sh	session-start composition over temp state and fake tools
+integration	fm-sessionstart-nudge.test.sh	session-start nudge registration over temp repos
+integration	fm-shared-captain-inheritance.test.sh	shared captain inheritance over temp homes
+integration	fm-spawn-batch.test.sh	spawn argument routing without live launch
+integration	fm-spawn-dispatch-profile.test.sh	spawn command construction with fake tmux
+unit	fm-stow-contract.test.sh	static stow skill contract
+integration	fm-supervision-events.test.sh	watcher event handling over temp state and fake sleeps
+unit	fm-supervision-instructions.test.sh	supervision instruction rendering
+integration	fm-tangle-guard.test.sh	tangle guard behavior over temp repos and fake tools
+integration	fm-teardown.test.sh	teardown safety over temp repos and fake gh-axi
+unit	fm-test-lane.test.sh	public lane runner contract
+unit	fm-transition-lib.test.sh	pure transition record and policy coverage
+unit	fm-turnend-guard.test.sh	turn-end guard predicates over temp state
+integration	fm-update.test.sh	self-update behavior over temp repos
+e2e	fm-wake-daemon-lifecycle-e2e.test.sh	watcher and daemon lifecycle over a full operator-visible path
+integration	fm-wake-queue.test.sh	wake queue behavior over temp state and child processes
+integration	fm-watch-checkpoint.test.sh	foreground checkpoint helper behavior over temp state
+integration	fm-watch-triage.test.sh	watcher triage subprocess behavior over temp state
+integration	fm-watcher-lock.test.sh	watcher lock and process invariants over local child processes
+integration	fm-x-mode.test.sh	X-mode client and activation behavior with fake curl


### PR DESCRIPTION
## Summary

This splits Firstmate shell behavior validation into explicit `unit`, `integration`, and `e2e` lanes with one manifest owner, `tests/shell-lanes.tsv`.
The lane runner validates missing, duplicate, stale, and unknown classifications before execution, then emits lane and per-script start/end markers with elapsed time and failure identity.

The diagnosis reports found PR #711 was not the cause of the timeout. The structural issue was the single serial behavior command growing until local macOS execution exceeded the 15-minute job cap, while hosted Ubuntu history still passed near the limit. GitHub Actions currently reports no CI checks configured for this PR, so exact-head local proof is the gate.

## Changes

- Add `bin/fm-test-lane.sh <unit|integration|e2e>` and contract tests for validation, ordering, markers, and exit propagation.
- Add `tests/shell-lanes.tsv` as the single shell-test classification owner.
- Split the GitHub behavior job into `behavior-unit`, `behavior-integration`, and `behavior-e2e` jobs with lane-specific commands and bounded timeouts.
- Update contributor, no-mistakes, and reference docs away from the monolithic `for test_script in tests/*.test.sh` command.
- Preserve cmux `list-panes` failures before `jq` parsing so absent targets report `send-failed` instead of being masked as `unknown`.
- Isolate `fm-spawn-batch.test.sh` from local `config/crew-dispatch.json` so the fixture owns its config environment.
- Stabilize two real-tmux e2e readiness races found during local proof: AFK injection waits for stable pending input before firing the escalation, and the tmux smoke waits for actual numbered output before capture-bound assertions.
- BLOCK-1 review correction: run each selected shell test with stdin redirected from `/dev/null`, so a test script cannot consume later manifest entries from the runner loop.

## Local Proof

Commands ran in the isolated worktree `/Users/aaronstevens/.treehouse/firstmate-7bab20/2/firstmate` at corrected head `2200abd624f01d102581eec59c35c60f273ffb7c`. Logs are preserved in `/tmp/firstmate-pr740-block1-proof.YabF3R`.

- Focused contract: `bash -n bin/fm-test-lane.sh tests/fm-test-lane.test.sh && shellcheck -x bin/fm-test-lane.sh tests/fm-test-lane.test.sh && tests/fm-test-lane.test.sh` - passed. The regression proves a first selected test that reads stdin cannot consume or skip the second manifest entry.
- `bin/fm-lint.sh` - passed with ShellCheck 0.11.0.
- `bin/fm-test-lane.sh unit` - passed, 21 scripts in 169s.
- `bin/fm-test-lane.sh integration` - passed, 43 scripts in 1103s.
- `bin/fm-test-lane.sh e2e` - passed, 20 scripts in 76s.
- `git diff --check` - passed.
- Final local branch state after push: clean on `fm/firstmate-pr711-timeout-head-diagnosis-u8` at `2200abd624f01d102581eec59c35c60f273ffb7c`.

## Diagnosis Evidence

- Prior local CI diagnosis: `data/firstmate-pr711-local-ci-r7/report.md`.
- Exact-head timeout diagnosis: `data/firstmate-pr711-timeout-head-diagnosis-u8/report.md`.
- Companion history scout: `data/firstmate-pr711-timeout-history-scout-v9/report.md`.

## Publication Note

`git push -u origin fm/firstmate-pr711-timeout-head-diagnosis-u8` was previously attempted and failed with GitHub 403 for `astev89` against `kunchenguid/firstmate`. The corrected branch was pushed explicitly to the configured `fork` remote and this PR targets `kunchenguid/firstmate:main` from that fork branch.
