### PR TITLE
fix(spawn): acquire the task worktree with treehouse get --lease instead of an in-window treehouse get

### DIFF
--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -17,8 +17,11 @@
 #   then tmux.
 #   Spawn-capable backends are the reference tmux adapter and experimental
 #   herdr, zellij, orca, and cmux. Orca owns both the task worktree and
-#   terminal, so ship/scout Orca spawns do not run treehouse get; cmux is a
-#   session provider only, exactly like herdr/zellij, so it does. An
+#   terminal, so ship/scout Orca spawns do not lease a treehouse worktree;
+#   cmux is a session provider only, exactly like herdr/zellij, so it does.
+#   Every non-Orca ship/scout spawn acquires its worktree with
+#   `treehouse get --lease` from THIS process and then moves the task window
+#   into it; the lease is released by fm-teardown.sh's `treehouse return`. An
 #   auto-detected herdr or cmux spawn prints a loud stderr notice;
 #   auto-detected tmux stays silent; zellij and orca are never auto-detected.
 #   codex-app is not a known backend yet; docs/codex-app-backend.md owns that
@@ -84,7 +87,7 @@ set -eu
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 usage() {
-  sed -n '2,78p' "$0" | sed 's/^# \{0,1\}//'
+  sed -n '2,84p' "$0" | sed 's/^# \{0,1\}//'
 }
 
 case "${1:-}" in
@@ -833,30 +836,65 @@ spawn_send_key() {  # <target> <key>
   esac
 }
 if [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
-  spawn_send_text_line "$WT_TARGET" 'treehouse get'
+  # Acquire the worktree from THIS process, not by typing `treehouse get` into
+  # the task window and inferring success from the window's cwd.
+  #
+  # Why this changed (2026-07-19, task spawn-worktree-failure): bare
+  # `treehouse get` runs its worktree setup inside the new window, and that
+  # setup can reach the network. With an https `origin` and no credential
+  # path inside that window, git stops at an interactive
+  # `Username for 'https://github.com':` prompt and never returns, so the old
+  # 60s cwd poll always expired. The observed symptom was a timeout; the
+  # actual cause was a window blocked on a password prompt, with the worktree
+  # still half-acquired. Reproduced live: the abandoned window sat at that
+  # prompt with its cwd never leaving the project.
+  #
+  # `--lease` is treehouse's purpose-built scripted path: it prints only the
+  # worktree path on stdout, durably reserves it (prune-safe, never handed to
+  # a later get until returned), and needs no subshell and no terminal. Run
+  # here, it inherits firstmate's own working credential environment instead
+  # of the task window's. The lease is released by exactly the same
+  # `treehouse return --force` that bin/fm-teardown.sh already runs, so
+  # teardown needs no change and a leased slot cannot leak past teardown.
+  if ! WT=$( ( cd "$PROJ_ABS" && treehouse get --lease --lease-holder "$W" ) 2>/dev/null ); then
+    WT=
+  fi
+  WT=$(printf '%s\n' "$WT" | sed -n '1p' | tr -d '\r')
+  if [ -z "$WT" ] || [ ! -d "$WT" ]; then
+    echo "error: treehouse get --lease did not yield a worktree for $W (run it by hand in $PROJ_ABS to see why)" >&2
+    exit 1
+  fi
 
-  # Wait for the treehouse subshell: the pane's cwd moves from the project to the worktree.
+  # Validate BEFORE the window is moved: an unusable lease must never become a
+  # window sitting in the primary checkout running an agent.
+  validate_spawn_worktree "treehouse get --lease" "$T"
+
+  # Move the task window into the leased worktree. This is a plain `cd` with no
+  # network and no subshell, so unlike the old acquisition step it cannot block
+  # on a prompt.
+  spawn_send_text_line "$WT_TARGET" "cd $(printf '%q' "$WT")"
+
+  # Confirm the window actually landed there before launching the agent.
   # Target the stable window id, not the name: if the name is ever lost (e.g. an
   # automatic-rename slips through), display-message -t <bad-name> falls back to the
   # active client's window, which would misread firstmate's OWN pane path as the
   # worktree and tangle a hook into the primary checkout. The window id never lies.
-  # Compare against PROJ_ABS_REAL (physical), not PROJ_ABS: a symlinked project
-  # prefix would otherwise make the pane's OS-level cwd read differ from
-  # PROJ_ABS on the very first poll, before the pane has actually moved.
-  for _ in $(seq 1 60); do
+  # Compare physical paths: a symlinked prefix would otherwise make the window's
+  # OS-level cwd read differ from the leased path even once it has arrived.
+  WT_REAL=$(real_path_or_raw "$WT")
+  WINDOW_IN_WORKTREE=
+  for _ in $(seq 1 30); do
     p=$(spawn_current_path "$WT_TARGET" || true)
-    if [ -n "$p" ] && [ "$(real_path_or_raw "$p")" != "$PROJ_ABS_REAL" ]; then
-      WT="$p"
+    if [ -n "$p" ] && [ "$(real_path_or_raw "$p")" = "$WT_REAL" ]; then
+      WINDOW_IN_WORKTREE=1
       break
     fi
     sleep 1
   done
-  if [ -z "$WT" ]; then
-    echo "error: treehouse get did not enter a worktree within 60s; inspect window $T" >&2
+  if [ -z "$WINDOW_IN_WORKTREE" ]; then
+    echo "error: task window did not enter the leased worktree $WT within 30s; inspect window $T" >&2
     exit 1
   fi
-
-  validate_spawn_worktree "treehouse get" "$T"
 fi
 
 # Per-task temp root: /tmp/fm-<id>/ with Go's build temp nested at gotmp/. Go won't

--- a/tests/fm-backend.test.sh
+++ b/tests/fm-backend.test.sh
@@ -754,7 +754,15 @@ esac
 exit 0
 SH
   chmod +x "$fb/tmux"
-  fm_fake_exit0 "$fb" treehouse
+  cat > "$fb/treehouse" <<SH
+#!/usr/bin/env bash
+set -u
+case "\$*" in
+  "get --lease --lease-holder"*) printf '%s\\n' "$wt"; exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fb/treehouse"
   printf '%s\n' "$fb"
 }
 
@@ -824,7 +832,15 @@ esac
 exit 0
 SH
   chmod +x "$fb/tmux"
-  fm_fake_exit0 "$fb" treehouse
+  cat > "$fb/treehouse" <<SH
+#!/usr/bin/env bash
+set -u
+case "\$*" in
+  "get --lease --lease-holder"*) printf '%s\\n' "$wt"; exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fb/treehouse"
   printf '%s\n' "$fb"
 }
 

--- a/tests/fm-gate-refuse.test.sh
+++ b/tests/fm-gate-refuse.test.sh
@@ -152,7 +152,15 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse
+  cat > "$fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  "get --lease --lease-holder"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/treehouse"
   printf '%s\n' "$fakebin"
 }
 

--- a/tests/fm-grok-harness.test.sh
+++ b/tests/fm-grok-harness.test.sh
@@ -26,7 +26,16 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse gh-axi gh
+  cat > "$fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  "get --lease --lease-holder"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/treehouse"
+  fm_fake_exit0 "$fakebin" gh-axi gh
   printf '%s\n' "$fakebin"
 }
 

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -441,6 +441,15 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
+  cat > "$fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  "get --lease --lease-holder"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/treehouse"
   printf '%s\n' "$fakebin"
 }
 

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -42,7 +42,15 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse
+  cat > "$fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  "get --lease --lease-holder"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/treehouse"
   printf '%s\n' "$fakebin"
 }
 

--- a/tests/fm-spawn-lease.test.sh
+++ b/tests/fm-spawn-lease.test.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# Behavior tests for fm-spawn.sh's treehouse worktree acquisition.
+#
+# fm-spawn.sh acquires the task worktree by running `treehouse get --lease
+# --lease-holder <holder>` from ITS OWN process, then validates the result
+# before moving the task window into it with a plain `cd`. The old behavior -
+# typing bare `treehouse get` into the just-created window and polling its cwd -
+# could block forever on a network credential prompt inside that window
+# (2026-07-19, task spawn-worktree-failure). These tests pin the replacement
+# contract with a recording fake tmux and a recording fake treehouse, so no real
+# pool, network, or terminal is needed.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SPAWN="$ROOT/bin/fm-spawn.sh"
+TMP_ROOT=$(fm_test_tmproot fm-spawn-lease)
+
+# make_lease_fakebin <dir> <treehouse-reply-mode> <reply-path> -> echoes fakebin dir
+#   reply-mode:
+#     path    - `treehouse get --lease ...` prints <reply-path> to stdout (success case)
+#     empty   - prints nothing (empty lease)
+#     silent  - like empty, but also used for the "never consulted" assertions
+#   Every invocation of treehouse and every `tmux send-keys` are appended to
+#   TREEHOUSE_LOG / TMUX_SEND_LOG (env vars) for assertion.
+make_lease_fakebin() {
+  local dir=$1 mode=$2 reply=$3 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+esac
+case "${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+  list-windows) exit 0 ;;
+  has-session|new-session|new-window|kill-window) exit 0 ;;
+  send-keys)
+    if [ -n "${FM_SEND_LOG:-}" ]; then
+      prev=
+      for a in "$@"; do
+        if [ "$prev" = "-l" ] || [ "$prev" = "-t" ]; then
+          :
+        fi
+        prev=$a
+      done
+      printf '%s\n' "$*" >> "$FM_SEND_LOG"
+    fi
+    exit 0
+    ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+  case "$mode" in
+    path)
+      cat > "$fakebin/treehouse" <<SH
+#!/usr/bin/env bash
+set -u
+[ -n "\${FM_TREEHOUSE_LOG:-}" ] && printf '%s\n' "\$*" >> "\$FM_TREEHOUSE_LOG"
+case "\$*" in
+  "get --lease --lease-holder"*) printf '%s\n' "$reply"; exit 0 ;;
+esac
+exit 0
+SH
+      ;;
+    empty)
+      cat > "$fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+set -u
+[ -n "${FM_TREEHOUSE_LOG:-}" ] && printf '%s\n' "$*" >> "$FM_TREEHOUSE_LOG"
+case "$*" in
+  "get --lease --lease-holder"*) printf ''; exit 0 ;;
+esac
+exit 0
+SH
+      ;;
+  esac
+  chmod +x "$fakebin/treehouse"
+  printf '%s\n' "$fakebin"
+}
+
+run_spawn() {  # <home> <proj> <pane> <fakebin> <id>
+  local home=$1 proj=$2 pane=$3 fakebin=$4 id=$5
+  mkdir -p "$home/data/$id"
+  printf 'brief\n' > "$home/data/$id/brief.md"
+  : > "$home/send.log"
+  : > "$home/treehouse.log"
+  FM_ROOT_OVERRIDE='' FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
+    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$pane" TMUX="fake,1,0" \
+    FM_SEND_LOG="$home/send.log" FM_TREEHOUSE_LOG="$home/treehouse.log" \
+    PATH="$fakebin:$PATH" \
+    "$SPAWN" "$id" "$proj" codex 2>&1
+}
+
+test_lease_acquired_from_own_process_not_typed_into_window() {
+  local home proj wt fakebin id out status
+  home="$TMP_ROOT/ok-home"; proj="$TMP_ROOT/ok-proj"; wt="$TMP_ROOT/ok-wt"
+  id=lease-ok-a1
+  mkdir -p "$home/data" "$home/state" "$home/config"
+  fm_git_worktree "$proj" "$wt" "fm/$id"
+  fakebin=$(make_lease_fakebin "$TMP_ROOT/ok-fake" path "$wt")
+
+  out=$(run_spawn "$home" "$proj" "$wt" "$fakebin" "$id")
+  status=$?
+  expect_code 0 "$status" "spawn with a valid lease should succeed"$'\n'"$out"
+  assert_contains "$out" "spawned $id" "spawn did not report success"
+
+  assert_grep "get --lease --lease-holder fm-$id" "$home/treehouse.log" \
+    "fm-spawn did not run treehouse get --lease --lease-holder fm-<id> from its own process"
+  assert_no_grep 'treehouse get' "$home/send.log" \
+    "fm-spawn must never type 'treehouse get' into the task window"
+  assert_grep "cd $wt" "$home/send.log" \
+    "fm-spawn must cd the window into the leased worktree"
+  pass "fm-spawn acquires the worktree via treehouse get --lease from its own process, never by typing into the window"
+}
+
+test_lease_empty_path_fails_without_launching() {
+  local home proj wt fakebin id out status
+  home="$TMP_ROOT/empty-home"; proj="$TMP_ROOT/empty-proj"; wt="$TMP_ROOT/empty-wt"
+  id=lease-empty-b2
+  mkdir -p "$home/data" "$home/state" "$home/config"
+  fm_git_worktree "$proj" "$wt" "fm/$id"
+  fakebin=$(make_lease_fakebin "$TMP_ROOT/empty-fake" empty "")
+
+  out=$(run_spawn "$home" "$proj" "$wt" "$fakebin" "$id")
+  status=$?
+  expect_code 1 "$status" "an empty lease path must fail the spawn"
+  assert_contains "$out" "did not yield a worktree" "empty-lease failure did not name the cause"
+  assert_absent "$home/state/$id.meta" "an empty-lease spawn must never record meta"
+  assert_no_grep 'codex' "$home/send.log" \
+    "an empty-lease spawn must never send the agent launch command into the window"
+  pass "an empty lease path fails loudly and never launches an agent"
+}
+
+test_lease_nondirectory_path_fails_without_launching() {
+  local home proj wt fakebin id out status not_a_dir
+  home="$TMP_ROOT/notdir-home"; proj="$TMP_ROOT/notdir-proj"; wt="$TMP_ROOT/notdir-wt"
+  id=lease-notdir-c3
+  mkdir -p "$home/data" "$home/state" "$home/config"
+  fm_git_worktree "$proj" "$wt" "fm/$id"
+  not_a_dir="$TMP_ROOT/notdir-wt-plain-file"
+  printf 'not a worktree\n' > "$not_a_dir"
+  fakebin=$(make_lease_fakebin "$TMP_ROOT/notdir-fake" path "$not_a_dir")
+
+  out=$(run_spawn "$home" "$proj" "$wt" "$fakebin" "$id")
+  status=$?
+  expect_code 1 "$status" "a lease path that is not a directory must fail the spawn"
+  assert_contains "$out" "did not yield a worktree" "non-directory lease failure did not name the cause"
+  assert_absent "$home/state/$id.meta" "a non-directory-lease spawn must never record meta"
+  assert_no_grep 'codex' "$home/send.log" \
+    "a non-directory-lease spawn must never send the agent launch command into the window"
+  pass "a lease that resolves to a non-directory fails loudly and never launches an agent"
+}
+
+test_lease_validated_before_window_moved() {
+  local home proj wt fakebin id out status unisolated
+  home="$TMP_ROOT/unisolated-home"; proj="$TMP_ROOT/unisolated-proj"; wt="$TMP_ROOT/unisolated-wt-unused"
+  id=lease-unisolated-d4
+  mkdir -p "$home/data" "$home/state" "$home/config"
+  fm_git_worktree "$proj" "$wt" "fm/$id"
+  # A directory that exists but is not an isolated git worktree at all (plain dir).
+  unisolated="$TMP_ROOT/unisolated-plain-dir"
+  mkdir -p "$unisolated"
+  fakebin=$(make_lease_fakebin "$TMP_ROOT/unisolated-fake" path "$unisolated")
+
+  out=$(run_spawn "$home" "$proj" "$unisolated" "$fakebin" "$id")
+  status=$?
+  expect_code 1 "$status" "a lease that is not an isolated worktree must fail the spawn"
+  assert_contains "$out" "did not yield an isolated worktree" \
+    "unisolated-lease failure did not trip validate_spawn_worktree"
+  assert_no_grep "cd $unisolated" "$home/send.log" \
+    "the task window must never be moved into an unvalidated lease"
+  assert_no_grep 'codex' "$home/send.log" \
+    "an unisolated-lease spawn must never send the agent launch command into the window"
+  assert_absent "$home/state/$id.meta" "an unisolated-lease spawn must never record meta"
+  pass "the leased worktree is validated before the window is moved into it"
+}
+
+test_lease_acquired_from_own_process_not_typed_into_window
+test_lease_empty_path_fails_without_launching
+test_lease_nondirectory_path_fails_without_launching
+test_lease_validated_before_window_moved
+
+echo "# all fm-spawn-lease tests passed"

--- a/tests/fm-tangle-guard.test.sh
+++ b/tests/fm-tangle-guard.test.sh
@@ -169,7 +169,15 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse
+  cat > "$fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  "get --lease --lease-holder"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/treehouse"
   printf '%s\n' "$fakebin"
 }
 
@@ -248,7 +256,15 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse
+  cat > "$fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  "get --lease --lease-holder"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/treehouse"
   printf '%s\n' "$fakebin"
 }
 
@@ -292,11 +308,11 @@ test_spawn_tmux_window_construction() {
   assert_grep "set-window-option -t @spawnwid allow-rename off" "$rec" \
     "must disable allow-rename on the spawned window"
 
-  # Bug 2 fix (b): treehouse-get and the worktree wait loop target the stable id.
-  assert_grep "send-keys -t @spawnwid treehouse get Enter" "$rec" \
-    "treehouse get must be sent to the stable window id"
+  # Bug 2 fix (b): the leased-worktree cd and the confirmation poll target the stable id.
+  assert_grep "send-keys -t @spawnwid cd $wt Enter" "$rec" \
+    "the leased worktree cd must be sent to the stable window id"
   assert_grep "display-message -p -t @spawnwid #{pane_current_path}" "$rec" \
-    "the worktree wait loop must query the stable window id, not the name"
+    "the worktree confirmation poll must query the stable window id, not the name"
 
   pass "fm-spawn: appends windows by session-colon, pins the name, and targets the window id"
 }


### PR DESCRIPTION
## The bug

`fm-spawn.sh` acquires a task worktree by typing `treehouse get` into the newly created task
window, then polling that window's working directory for up to 60 seconds and inferring success
when the directory changes.

Bare `treehouse get` runs its worktree setup *inside that window*, and that setup can reach the
network. With an `https` `origin` and no credential path available inside the window, git stops at
an interactive prompt:

```
Username for 'https://github.com':
```

It never returns. The poll then expires and spawn fails with:

```
error: treehouse get did not enter a worktree within 60s
```

The reported symptom is a timeout, but the actual cause is a window blocked on a password prompt,
with the worktree already half-acquired.

**Reproduced live on 2026-07-19** against a private repo with an `https` origin: the abandoned
window sat at exactly that prompt, and its working directory never left the project. While this was
happening, firstmate could not spawn **any** direct report at all — the fleet was fully blocked.

## The fix

Acquire the worktree from fm-spawn's own process using treehouse's purpose-built non-interactive
path, then move the window into it:

1. `treehouse get --lease --lease-holder "$W"` — run from fm-spawn itself, so it inherits the
   operator's working credential environment rather than the task window's. It prints only the
   worktree path on stdout, needs no terminal, and cannot block on a prompt.
2. `validate_spawn_worktree` runs **before** the window is moved, so an unusable lease can never
   become a window running an agent inside the primary checkout.
3. A plain `cd` into the leased worktree — no network, no subshell.
4. A bounded 30s confirmation that the window actually landed there before the agent launches.

`--lease` is treehouse's documented scripted acquisition path (treehouse v2.0.0): it durably
reserves the worktree so no later `get` or `prune` takes it, and it is released by `treehouse
return`.

## Why this needs no teardown change

`bin/fm-teardown.sh` already returns the task worktree with `treehouse return --force`
(`teardown_treehouse_return "$WT" "$PROJ" "worktree"`), and treehouse documents `return` as
releasing any lease. This was verified rather than assumed, and confirmed end to end in production:
after a task using the new path was torn down, the pool showed the slot back to `available`.

Leases are also not a new concept here — `fm-teardown.sh` already describes releasing a
secondmate home's durable lease. This extends an existing pattern rather than introducing a
foreign one.

## Tradeoff, stated plainly

Leases are durable by design. A task abandoned **without** teardown leaves its worktree leased, and
`treehouse prune` will not reclaim it, where a non-leased idle worktree would be.

The lease holder is labelled `fm-<task-id>` precisely so an orphan is traceable back to the task
that leaked it.

This is a deliberate trade: spawning working reliably is worth more than automatic reclamation of
abandoned slots, and abandonment already implies a teardown that did not run.

## Verification

- New `tests/fm-spawn-lease.test.sh` (4 tests): acquisition goes through `--lease` and not through
  an in-window `treehouse get`; an empty or non-directory lease fails loudly instead of launching an
  agent; the worktree is validated before the window is moved.
- 6 existing test files' fake `treehouse` stubs updated to emit `--lease` paths.
- `bin/fm-lint.sh` clean (ShellCheck 0.11.0, pinned).
- `bash -n bin/fm-spawn.sh` clean.
- Full suite run across 84 test files; the only failures are 2 pre-existing ones, confirmed
  failing identically on a clean tree.
- Live: a spawn that previously timed out now succeeds, the pool reports the worktree
  `leased ... (held by fm-<task-id>)`, and the window's working directory is the leased worktree.

## Note

The header comment block grew, which shifted the fixed line range `usage()` reads to print help.
That range is updated in the same commit so `--help` output stays correct.
