### PR TITLE
docs(harness): correct Grok exit guidance

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -231,7 +231,7 @@ The model arms through `fm_watch_arm_pi`, never a foreground bash arm; the watch
 `bin/fm-session-start.sh` reports when the live Pi session has not loaded both the turn-end guard and watcher extensions, and points at plain `pi` after project trust as the fix, with `-e` as a trust-free fallback.
 When a secondmate is launched on Pi, `fm-spawn.sh --secondmate` launches Pi with both `-e .pi/extensions/fm-primary-turnend-guard.ts` and `-e .pi/extensions/fm-primary-pi-watch.ts`, both already present in the secondmate home's git worktree.
 
-## grok (VERIFIED 2026-06-29, grok 0.2.73; slash-submit re-verified 2026-07-03 on 0.2.82; reasoning-effort ceiling re-verified 2026-07-13 on 0.2.99)
+## grok (VERIFIED 2026-06-29, grok 0.2.73; slash-submit re-verified 2026-07-03 on 0.2.82; reasoning-effort ceiling re-verified 2026-07-13 on 0.2.99; exit re-verified 2026-07-19 on grok 0.2.103)
 
 Grok Build TUI (`grok`), a Claude-Code-compatible CLI from xAI.
 Launch with a positional prompt: `grok --always-approve "$(cat <brief>)"`.
@@ -240,7 +240,7 @@ For Grok's supported reasoning-effort values and omission behavior, see the [lau
 | Fact | Value |
 |---|---|
 | Busy-pane signature | `Ctrl+c:cancel` (the mid-turn cancel hint in grok's keybind bar, shown iff a turn is running; the spinner line is a braille glyph + `<status>… N.Ns` + `[stop]`, e.g. `⠹ Thinking… 1.1s … [stop]`). Idle keybind bar shows only `Shift+Tab:mode │ Ctrl+.:shortcuts`. The ASCII `Ctrl+c:cancel` is the busy regex (avoids locale fragility of matching braille). |
-| Exit command | `Ctrl+Q` double-press within 1000ms (it is a confirmed destructive action). Prints `Resume this session with: grok --resume <session-id>`. `Ctrl+D` is the quit key in VS Code family terminals. NOT `/exit` and NOT `Ctrl+C`. |
+| Exit command | `/exit` typed into the composer exits the TUI cleanly; `Ctrl+Q` double-press within 1000ms remains a fallback and prints `Resume this session with: grok --resume <session-id>`; `Ctrl+D` is the quit key in VS Code family terminals; `Ctrl+C` is the interrupt, not the exit. |
 | Interrupt | single `Ctrl+C` (cancels the current turn; the footer shows `Ctrl+c:cancel` mid-turn). `Esc` only moves focus to the scrollback, it does NOT interrupt. |
 | Skill invocation | `/<skill>` (e.g. `/no-mistakes`), same as claude. Opens a slash-autocomplete popup, so a too-fast Enter selects the popup entry instead of sending. For an argument-taking command that first Enter does not submit at all - it expands the selection into an argument-hint placeholder in the composer (e.g. `/compact` -> `/compact compaction instructions`, live-verified), leaving real text still sitting there unsubmitted; a genuine second Enter is required. `fm-send`'s retried Enter lands it on BOTH backends, but only because each backend's own submit-verification correctly recognizes that placeholder-filled text as still-pending - see the incident below. |
 | Autonomy | `--always-approve` (footer shows `· always-approve`); auto-approves every tool execution, verified to run fully unattended. `--permission-mode bypassPermissions` is the stronger equivalent. |

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -231,7 +231,7 @@ The model arms through `fm_watch_arm_pi`, never a foreground bash arm; the watch
 `bin/fm-session-start.sh` reports when the live Pi session has not loaded both the turn-end guard and watcher extensions, and points at plain `pi` after project trust as the fix, with `-e` as a trust-free fallback.
 When a secondmate is launched on Pi, `fm-spawn.sh --secondmate` launches Pi with both `-e .pi/extensions/fm-primary-turnend-guard.ts` and `-e .pi/extensions/fm-primary-pi-watch.ts`, both already present in the secondmate home's git worktree.
 
-## grok (VERIFIED 2026-06-29, grok 0.2.73; slash-submit re-verified 2026-07-03 on 0.2.82; reasoning-effort ceiling re-verified 2026-07-13 on 0.2.99; exit re-verified 2026-07-19 on grok 0.2.103)
+## grok (VERIFIED 2026-06-29, grok 0.2.73; slash-submit re-verified 2026-07-03 on 0.2.82; reasoning-effort ceiling re-verified 2026-07-13 on 0.2.99; exit paths re-verified 2026-07-19 on grok 0.2.103)
 
 Grok Build TUI (`grok`), a Claude-Code-compatible CLI from xAI.
 Launch with a positional prompt: `grok --always-approve "$(cat <brief>)"`.
@@ -240,7 +240,7 @@ For Grok's supported reasoning-effort values and omission behavior, see the [lau
 | Fact | Value |
 |---|---|
 | Busy-pane signature | `Ctrl+c:cancel` (the mid-turn cancel hint in grok's keybind bar, shown iff a turn is running; the spinner line is a braille glyph + `<status>… N.Ns` + `[stop]`, e.g. `⠹ Thinking… 1.1s … [stop]`). Idle keybind bar shows only `Shift+Tab:mode │ Ctrl+.:shortcuts`. The ASCII `Ctrl+c:cancel` is the busy regex (avoids locale fragility of matching braille). |
-| Exit command | `/exit` typed into the composer exits the TUI cleanly; `Ctrl+Q` double-press within 1000ms remains a fallback and prints `Resume this session with: grok --resume <session-id>`; `Ctrl+D` is the quit key in VS Code family terminals; `Ctrl+C` is the interrupt, not the exit. |
+| Exit command | `/exit` typed into the composer exits the TUI cleanly and prints `Resume this session with: grok --resume <session-id>`; `Ctrl+Q` double-press within 1000ms remains a fallback; `Ctrl+D` is the quit key in VS Code family terminals; `Ctrl+C` is the interrupt, not the exit. |
 | Interrupt | single `Ctrl+C` (cancels the current turn; the footer shows `Ctrl+c:cancel` mid-turn). `Esc` only moves focus to the scrollback, it does NOT interrupt. |
 | Skill invocation | `/<skill>` (e.g. `/no-mistakes`), same as claude. Opens a slash-autocomplete popup, so a too-fast Enter selects the popup entry instead of sending. For an argument-taking command that first Enter does not submit at all - it expands the selection into an argument-hint placeholder in the composer (e.g. `/compact` -> `/compact compaction instructions`, live-verified), leaving real text still sitting there unsubmitted; a genuine second Enter is required. `fm-send`'s retried Enter lands it on BOTH backends, but only because each backend's own submit-verification correctly recognizes that placeholder-filled text as still-pending - see the incident below. |
 | Autonomy | `--always-approve` (footer shows `· always-approve`); auto-approves every tool execution, verified to run fully unattended. `--permission-mode bypassPermissions` is the stronger equivalent. |


### PR DESCRIPTION
## Intent

Correct the stale empirically verified Grok exit-command fact in the shared harness-adapters skill. Re-verify the installed Grok version once in an isolated scratch tmux lab, confirm that /exit typed into the composer cleanly terminates the TUI process, and separately confirm that double Ctrl+Q remains a working fallback. Update only that Grok exit fact and its dated version-evidence stamp, preserve that Ctrl+D is the quit key in VS Code family terminals and Ctrl+C is interrupt rather than exit, use plain dashes and one sentence per line, and keep the change tiny and focused.

## What Changed

- Update Grok harness guidance to identify composer-entered `/exit` as the clean TUI exit path that prints the session resume command.
- Retain double `Ctrl+Q` as a fallback, clarify `Ctrl+D` and `Ctrl+C` behavior, and refresh the exit-path evidence stamp for Grok 0.2.103.

## Risk Assessment

✅ Low: The tiny, single-file documentation change satisfies the specified Grok exit-fact constraints without affecting executable behavior or dependent code.

## Testing

The supplied full-suite baseline had already passed; focused live tmux checks verified both Grok exit paths on 0.2.103, the evidence transcript captures the user-visible resume output and clean exits, and the worktree remained clean.

<details>
<summary>Evidence: Live Grok exit-path verification transcript</summary>

```text
Grok exit verification - target c349c37a1bd8a971e65d0911387fa91c62162942

Installed binary: grok 0.2.103 (89c3d36fb6f1) [stable]

Slash-command path
Action: selected New worktree in an isolated tmux lab, typed /exit, waited 1 second for autocomplete, then pressed Enter.
Resume this session with:
  grok --resume 019f7c4d-dd88-7f92-9cfc-1241cb3cda95
[tmux-wrapper] grok_exit_status=0
tmux pane: dead=1 command=grok status=0

Ctrl+Q fallback path
Action: selected New worktree in a second isolated tmux lab, then pressed Ctrl+Q twice 200ms apart.
Resume this session with:
  grok --resume 019f7c4e-c316-7493-8c67-85e18b2f6e0f
[tmux-wrapper] grok_exit_status=0
tmux pane: dead=1 command=grok status=0

Documentation acceptance check
Changed file: .agents/skills/harness-adapters/SKILL.md
Fact: | Exit command | `/exit` typed into the composer exits the TUI cleanly and prints `Resume this session with: grok --resume <session-id>`; `Ctrl+Q` double-press within 1000ms remains a fallback; `Ctrl+D` is the quit key in VS Code family terminals; `Ctrl+C` is the interrupt, not the exit. |
Result: required exit-path wording, Ctrl+D/Ctrl+C preservation, one sentence, no em dash, and whitespace validation passed.
```
</details>
- Outcome: 🔧 1 issue found → auto-fixed ✅ across 2 runs (59m57s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `.agents/skills/harness-adapters/SKILL.md:243` - The exit fact says double Ctrl+Q &#34;prints `Resume this session with...`&#34;, but live Grok 0.2.103 showed that text only for `/exit`. Ctrl+Q showed its confirmation, then exited with code 0 and no resume text. Move the resume-output claim to `/exit` or remove it from Ctrl+Q.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- <code>Baseline supplied as passed: `command -v tmux &gt;/dev/null || { echo &#34;tmux is required for e2e tests&#34; &gt;&amp;2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo &#34;== $t ==&#34;; bash &#34;$t&#34; || rc=1; done; exit &#34;$rc&#34;`</code>
- <code>`grok --version` - verified installed `grok 0.2.103 (89c3d36fb6f1) [stable]`</code>
- `bash tests/fm-grok-harness.test.sh`
- <code>Manual isolated tmux lab: launched `grok --always-approve`, typed `/exit` into the composer, pressed Enter, and captured the rendered TUI plus exit code</code>
- `Manual isolated tmux lab: launched a fresh Grok TUI, sent Ctrl+Q twice 250ms apart, captured its confirmation plus exit code`
- <code>`git diff --check b2bf95fa9e1eac5ff23eb0ea7f6c5241bfdf82eb..dbc35a1121dfa46d0627967dd172bee2bd6444ad` and worktree-status check</code>

🔧 Fix: Correct Grok exit resume attribution
✅ Re-checked - no issues remain.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- <code>Provided baseline, already successful: `command -v tmux &gt;/dev/null || { echo &#34;tmux is required for e2e tests&#34; &gt;&amp;2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo &#34;== $t ==&#34;; bash &#34;$t&#34; || rc=1; done; exit &#34;$rc&#34;`</code>
- `git diff --check b2bf95fa9e1eac5ff23eb0ea7f6c5241bfdf82eb c349c37a1bd8a971e65d0911387fa91c62162942`
- <code>Live isolated tmux lab with Grok 0.2.103: selected New worktree, typed `/exit`, waited one second for autocomplete, and pressed Enter. The retained pane showed the resume command and exit status 0.</code>
- `Live isolated tmux lab with Grok 0.2.103: selected New worktree and pressed Ctrl+Q twice 200ms apart. The first press displayed the confirmation and the process exited with status 0.`
- <code>Focused documentation acceptance check for the changed fact: required `/exit`, Ctrl+Q fallback, Ctrl+D, Ctrl+C, one-sentence, plain-dash, changed-file scope, and whitespace constraints.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
