### PR TITLE
fix(supervision): distinguish ordinary wakes from recovery

### DIFF
--- a/.opencode/plugins/fm-primary-turnend-guard.js
+++ b/.opencode/plugins/fm-primary-turnend-guard.js
@@ -82,7 +82,7 @@ export const FmPrimaryTurnendGuard = async ({ client, directory, worktree }) => 
                 type: "text",
                 text:
                   "TURN WOULD END BLIND - supervision is off. " +
-                  "Resume supervision according to the session-start operating block before ending the turn.\n\n" +
+                  "The watcher cycle is missing, failed, or unhealthy. Follow the harness recovery instruction below before ending the turn.\n\n" +
                   result.stderr,
               },
             ],

--- a/.pi/extensions/fm-primary-turnend-guard.ts
+++ b/.pi/extensions/fm-primary-turnend-guard.ts
@@ -142,7 +142,7 @@ export default function (pi: ExtensionAPI) {
     try {
       await pi.sendUserMessage(
         "TURN WOULD END BLIND - supervision is off. " +
-          "Resume supervision according to the session-start operating block before ending the turn.\n\n" +
+          "The watcher cycle is missing, failed, or unhealthy. Follow the harness recovery instruction below before ending the turn.\n\n" +
           result.stderr,
         { deliverAs: "followUp" },
       );

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -315,7 +315,7 @@ Fleet supervision is an always-loaded operational contract; `docs/architecture.m
 Whenever work is under way, keep exactly one live supervision cycle using the emitted protocol for this primary harness.
 X mode may require that same live cycle with no fleet work.
 Do not substitute another harness's wait shape, use shell `&`, or create a second cycle when a healthy one already exists.
-After every actionable wake, resume the emitted protocol as the final action before ending the turn.
+For every actionable wake, follow the ordinary-wake continuation in the emitted protocol; use its repair action only when the live cycle is missing or failed.
 No turn ends blind while work is under way, including turns described as holding or waiting.
 
 At the start of every wake-handling turn, drain the durable wake queue before peeking, reading beyond the reason line, steering, or starting work.

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -579,7 +579,7 @@ x_mode_setup() {
   x_mode_supervision_repair() {
     local out
     out=$("$SCRIPT_DIR/fm-supervision-instructions.sh" --repair-line 2>/dev/null) \
-      || out='resume supervision according to the session-start operating block.'
+      || out='repair missing watcher supervision according to the session-start operating block.'
     printf '%s\n' "$out"
   }
 

--- a/bin/fm-guard.sh
+++ b/bin/fm-guard.sh
@@ -182,7 +182,7 @@ if [ "$watcher_fresh" = false ]; then
       --afk "$afk" \
       --x-mode "$x_mode" \
       --queue-pending "$queue_arg" \
-      --repair-line 2>/dev/null || printf '%s\n' 'Resume supervision according to the session-start operating block.')
+      --repair-line 2>/dev/null || printf '%s\n' 'Repair missing watcher supervision according to the session-start operating block.')
     rule='━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'
     {
       printf '●%s\n' "$rule"

--- a/bin/fm-supervision-instructions.sh
+++ b/bin/fm-supervision-instructions.sh
@@ -134,22 +134,45 @@ repair_line() {
 
   case "$HARNESS" in
     claude)
-      printf '%s%s\n' "$prefix" 'resume supervision with bin/fm-watch-arm.sh as its own Claude Code background task, never shell &.'
+      printf '%s%s\n' "$prefix" 'repair missing watcher supervision with bin/fm-watch-arm.sh as its own Claude Code background task, never shell &.'
       ;;
     codex)
-      printf '%s%s%s%s\n' "$prefix" 'resume supervision with a foreground checkpoint: bin/fm-watch-checkpoint.sh --seconds ' "$checkpoint_seconds" '.'
+      printf '%s%s%s%s\n' "$prefix" 'repair missing watcher supervision with a foreground checkpoint: bin/fm-watch-checkpoint.sh --seconds ' "$checkpoint_seconds" '.'
       ;;
     pi)
-      printf '%s%s%s%s%s%s\n' "$prefix" 'resume supervision with the Pi tool fm_watch_arm_pi or restart Pi with -e ' "$pi_turnend_ext" ' -e ' "$pi_ext" ' if the extension is not loaded.'
+      printf '%s%s%s%s%s%s\n' "$prefix" 'repair a missing or failed watcher cycle with the Pi tool fm_watch_arm_pi, or restart Pi with -e ' "$pi_turnend_ext" ' -e ' "$pi_ext" ' if the extensions are not loaded.'
       ;;
     opencode)
-      printf '%s%s\n' "$prefix" 'resume supervision by letting the OpenCode TUI plugin arm after idle; use bin/fm-watch-arm.sh only as a manual recovery probe if the plugin reports failure.'
+      printf '%s%s\n' "$prefix" 'repair missing watcher supervision by letting the OpenCode TUI plugin arm after idle; use bin/fm-watch-arm.sh only as a manual recovery probe if the plugin reports failure.'
       ;;
     grok)
-      printf '%s%s\n' "$prefix" 'resume supervision with bin/fm-watch-arm.sh as its own Grok tracked background task, never shell &.'
+      printf '%s%s\n' "$prefix" 'repair missing watcher supervision with bin/fm-watch-arm.sh as its own Grok tracked background task, never shell &.'
       ;;
     *)
-      printf '%s%s\n' "$prefix" 'resume supervision according to the session-start block for this harness; do not use shell &.'
+      printf '%s%s\n' "$prefix" 'repair missing watcher supervision according to the session-start block for this harness; do not use shell &.'
+      ;;
+  esac
+}
+
+ordinary_wake_line() {
+  case "$HARNESS" in
+    claude)
+      printf '%s\n' '- Ordinary wake: re-arm exactly one bin/fm-watch-arm.sh Claude Code background task as directed below.'
+      ;;
+    codex)
+      printf '%s\n' '- Ordinary wake: take the next foreground bin/fm-watch-checkpoint.sh checkpoint as directed below.'
+      ;;
+    pi)
+      printf '%s\n' '- Ordinary wake: the Pi extension already owns watcher continuity; do not arm another cycle.'
+      ;;
+    opencode)
+      printf '%s\n' '- Ordinary wake: the OpenCode TUI plugin already owns watcher continuity; do not arm manually.'
+      ;;
+    grok)
+      printf '%s\n' '- Ordinary wake: re-arm exactly one bin/fm-watch-arm.sh Grok tracked background task as directed below.'
+      ;;
+    *)
+      printf '%s\n' '- Ordinary wake: follow the continuation in the harness protocol below; do not use shell &.'
       ;;
   esac
 }
@@ -179,7 +202,7 @@ if [ "$X_MODE" -eq 1 ]; then
 else
   printf '%s\n' '- X mode: inactive; use the default watcher cadence.'
 fi
-printf '%s\n' '- After every handled wake, resume this emitted harness protocol instead of following a hardcoded background-arm recipe.'
+ordinary_wake_line
 printf '\n'
 render_snippet
 printf '\n'

--- a/bin/fm-turnend-guard-grok.sh
+++ b/bin/fm-turnend-guard-grok.sh
@@ -34,13 +34,13 @@ RC=$?
 [ "$RC" -eq 2 ] || exit 0
 
 REASON=$(cat "$ERR" 2>/dev/null || true)
-[ -n "$REASON" ] || REASON='tasks in flight, no live watcher - resume supervision according to the session-start operating block before ending the turn'
+[ -n "$REASON" ] || REASON='tasks in flight, no live watcher - repair missing watcher supervision according to the session-start operating block before ending the turn'
 
 GROK_TURNEND_GUARD_ACTIVE=1 \
   GROK_HOME="${GROK_HOME:-$HOME/.grok}" \
   grok --resume "$SESSION_ID" \
     --cwd "$ROOT" \
     --output-format plain \
-    -p "TURN WOULD END BLIND - supervision is off. Resume supervision according to the session-start operating block before ending the turn.
+    -p "TURN WOULD END BLIND - supervision is off. Repair missing watcher supervision according to the session-start operating block before ending the turn.
 
 $REASON" >/dev/null 2>&1 || true

--- a/bin/fm-turnend-guard.sh
+++ b/bin/fm-turnend-guard.sh
@@ -90,7 +90,7 @@ afk=0
 x_mode=0
 [ -f "$CONFIG/x-mode.env" ] && x_mode=1
 REASON=$("$SCRIPT_DIR/fm-supervision-instructions.sh" --afk "$afk" --x-mode "$x_mode" --repair-line 2>/dev/null \
-  || printf '%s\n' 'tasks in flight, no live watcher - resume supervision according to the session-start operating block before ending the turn')
+  || printf '%s\n' 'tasks in flight, no live watcher - repair missing watcher supervision according to the session-start operating block before ending the turn')
 rule='━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'
 {
   printf '●%s\n' "$rule"

--- a/docs/supervision-protocols/claude.md
+++ b/docs/supervision-protocols/claude.md
@@ -3,18 +3,18 @@ Mode: Claude background-notify supervision.
 When this session owns supervision and away mode is not active:
 1. Drain first with `bin/fm-wake-drain.sh`.
 2. Source `__FM_X_MODE_ENV__` first when X mode is active.
-3. Run `bin/fm-watch-arm.sh` as its own Claude Code background task.
+3. First cycle: run `bin/fm-watch-arm.sh` as its own Claude Code background task.
 4. Never bundle the arm command with other commands.
 5. Never use shell `&` for watcher supervision.
    A shell `&`, a truncating pipe, or bundling is denied automatically by the PreToolUse seatbelt (`bin/fm-arm-pretool-check.sh`) registered in `.claude/settings.json`.
 6. Treat `watcher: started ...` and `watcher: attached ...` as proof that one live cycle exists.
    On attach, the background task follows verified identity-matched successors instead of exiting when the first cycle ends.
-7. Treat any `watcher: FAILED ...` result as an alarm and repair it before ending the turn.
-8. When the background task completes with `signal:`, `stale:`, `check:`, or `heartbeat`, drain queued wakes, then start exactly one fresh background task before running other fleet commands to handle the wake.
+7. Failure or missing cycle only: treat any `watcher: FAILED ...` result as an alarm and repair it before ending the turn.
+8. Ordinary wake: when the background task completes with `signal:`, `stale:`, `check:`, or `heartbeat`, drain queued wakes, then start exactly one fresh background task before running other fleet commands to handle the wake.
    Do not invent a wake from an attach-status line alone; drain and act only on real wake records or a real watcher reason line.
 9. The continuity PreToolUse gate allows wake drain and watcher arm recovery, and refuses only other `bin/fm-*.sh` fleet commands while tasks are in flight and no identity-matched live watcher holds the home lock.
 10. The existing turn-end guard remains unchanged as the final backstop and is not replaced by this command gate.
-11. If a forced restart is genuinely needed, run `bin/fm-watch-arm.sh --restart` through the same Claude background task mechanism.
+11. Recovery only: if a forced restart is genuinely needed, run `bin/fm-watch-arm.sh --restart` through the same Claude background task mechanism.
 12. Do not send idle progress while the watcher is parked.
 
 Claude Code's background task completion is the wake mechanism.

--- a/docs/supervision-protocols/codex.md
+++ b/docs/supervision-protocols/codex.md
@@ -3,12 +3,13 @@ Mode: Codex foreground checkpoint.
 When this session owns supervision and away mode is not active:
 1. Drain first with `bin/fm-wake-drain.sh`.
 2. Source `__FM_X_MODE_ENV__` first when X mode is active.
-3. Run one foreground watcher checkpoint with `bin/fm-watch-checkpoint.sh --seconds "${FM_CODEX_WATCH_CHECKPOINT:-180}"`.
-4. If the command prints `signal:`, `stale:`, `check:`, or `heartbeat`, drain queued wakes, handle that wake, then start the next checkpoint.
+3. First cycle: run one foreground watcher checkpoint with `bin/fm-watch-checkpoint.sh --seconds "${FM_CODEX_WATCH_CHECKPOINT:-180}"`.
+4. Ordinary wake: if the command prints `signal:`, `stale:`, `check:`, or `heartbeat`, drain queued wakes, handle that wake, then start the next checkpoint.
 5. If the command prints `checkpoint:` or exits 124 with no wake, drain queued wakes anyway, process any queued user message now visible to Codex, then start the next checkpoint.
 6. Never use shell `&` or Codex background tasks for firstmate watcher supervision.
 7. Do not run `bin/fm-watch-arm.sh` as Codex's normal supervision command.
    If it is ever shelled anyway, a backgrounded, piped, or bundled anti-pattern is denied automatically by the PreToolUse seatbelt (`bin/fm-arm-pretool-check.sh`) registered in `.codex/hooks.json`.
+8. Failure or missing cycle only: drain queued wakes, inspect the failure, then start a fresh foreground checkpoint.
 
 Codex cannot reason while a foreground tool call is running.
 The bounded checkpoint returns control regularly so user messages and queued wakes can be handled without relying on background-task wake semantics.

--- a/docs/supervision-protocols/grok.md
+++ b/docs/supervision-protocols/grok.md
@@ -3,7 +3,7 @@ Mode: Grok background-notify supervision.
 When this session owns supervision and away mode is not active:
 1. Drain first with `bin/fm-wake-drain.sh`.
 2. Source `__FM_X_MODE_ENV__` first when X mode is active.
-3. Arm with Grok's tracked background tool, as its own call:
+3. First cycle: arm with Grok's tracked background tool, as its own call:
 
    `run_terminal_command` with `background: true` on:
    `[ -f __FM_X_MODE_ENV_SH__ ] && . __FM_X_MODE_ENV_SH__; exec bin/fm-watch-arm.sh`
@@ -11,7 +11,7 @@ When this session owns supervision and away mode is not active:
 4. Trust only the arm's one-line status.
 5. `watcher: started ...` or `watcher: attached ...` means a live cycle exists.
    On attach, the background task follows verified identity-matched successors instead of exiting when the first cycle ends.
-6. `watcher: FAILED ...` means supervision is down; fix and re-arm.
+6. Failure or missing cycle only: `watcher: FAILED ...` means supervision is down; fix and re-arm.
 7. After a successful start or attach status, end the turn.
    The background arm remains the live wait until it returns an actionable wake or failure.
 8. Waiting is silent.
@@ -24,7 +24,7 @@ When you see a background-task-completed system reminder for the arm:
 1. Run `bin/fm-wake-drain.sh` first.
 2. Optionally fetch arm output with `get_command_or_subagent_output(<task_id>)` for the reason line.
 3. Handle `signal`, `stale`, `check`, or `heartbeat` using the harness-neutral contract in `AGENTS.md`.
-4. Re-arm the next cycle with the same background `bin/fm-watch-arm.sh` call if work remains in flight or X mode still needs polling.
+4. Ordinary wake: re-arm the next cycle with the same background `bin/fm-watch-arm.sh` call if work remains in flight or X mode still needs polling.
 5. Do not invent a wake from an attach-status line alone.
    Drain the queue and act only on real wake records or a real watcher reason line.
    Re-arm attaches to an existing healthy cycle when one is already present and follows its verified successor chain.

--- a/docs/supervision-protocols/opencode.md
+++ b/docs/supervision-protocols/opencode.md
@@ -2,12 +2,12 @@ Mode: OpenCode TUI plugin background wake.
 
 When this session owns supervision and away mode is not active:
 1. Drain first with `bin/fm-wake-drain.sh`.
-2. Let `.opencode/plugins/fm-primary-watch-arm.js` arm supervision after the OpenCode session goes idle.
+2. First cycle: let `.opencode/plugins/fm-primary-watch-arm.js` arm supervision after the OpenCode session goes idle.
 3. The plugin listens for `session.idle`, spawns `bin/fm-watch-arm.sh --restart` without awaiting it in the idle handler, and owns every later successor launch.
 4. After an actionable child close, the plugin rechecks session-lock ownership and verifies one singleton successor before it calls `client.session.promptAsync`; its bounded fallback is defined in `docs/watcher-continuity.md`.
-5. Do not ask the model to re-arm after an ordinary wake because continuity is plugin-owned.
+5. Ordinary wake: do not ask the model to re-arm because continuity is plugin-owned.
 6. An unexpected child close enters bounded exponential retry, and an exhausted retry or lost session lock is surfaced as a watcher failure instead of disappearing.
-7. If the plugin reports a watcher failure, drain queued wakes, inspect the failure text, and use `bin/fm-watch-arm.sh` manually only as a short recovery probe.
+7. Failure or missing cycle only: if the plugin reports a watcher failure, drain queued wakes, inspect the failure text, and use `bin/fm-watch-arm.sh` manually only as a short recovery probe.
 8. Never use shell `&` for watcher supervision.
    The arm mechanism above is plugin-owned, not a model tool call, but a manual recovery probe that backgrounds, pipes, or bundles the arm is denied automatically by the PreToolUse seatbelt (`.opencode/plugins/fm-primary-pretool-check.js`, `bin/fm-arm-pretool-check.sh`).
 9. Do not rely on this plugin in headless `opencode run`; firstmate primary supervision targets persistent OpenCode TUI sessions.

--- a/docs/supervision-protocols/pi.md
+++ b/docs/supervision-protocols/pi.md
@@ -3,15 +3,15 @@ Mode: Pi extension background wake.
 When this session owns supervision and away mode is not active:
 1. Drain first with `bin/fm-wake-drain.sh`.
 2. Confirm the Pi primary auto-loaded both project extensions (plain `pi`, after approving project trust once per clone); if not, restart with `-e __FM_PI_TURNEND_EXT__ -e __FM_PI_EXT__` as a trust-free fallback.
-3. Arm the first cycle with the `fm_watch_arm_pi` tool.
+3. First cycle: arm with the `fm_watch_arm_pi` tool.
    Use `/fm-watch-arm-pi` only as a human-entered fallback.
    Never run `bin/fm-watch-arm.sh` through Pi's bash tool because that foreground arm can wedge the agent and bypasses extension-owned cleanup.
 4. If the extension says no live session holds the lock, run `bin/fm-session-start.sh` to reclaim the session lock, then call `fm_watch_arm_pi` again.
 5. The extension starts `bin/fm-watch-arm.sh --restart`, keeps the child attached to the live Pi process, and owns every later successor launch.
 6. After an actionable child close, the extension rechecks session-lock ownership and verifies one successor before it delivers the follow-up wake; its bounded fallback is defined in `docs/watcher-continuity.md`.
-7. Do not call `fm_watch_arm_pi` again after an ordinary wake because continuity is extension-owned rather than model-memory-owned.
+7. Ordinary wake: do not call `fm_watch_arm_pi` again because continuity is extension-owned rather than model-memory-owned.
 8. An unexpected child close enters bounded exponential retry, and an exhausted retry or lost session lock is surfaced as a watcher failure instead of disappearing.
-9. If the extension reports a watcher failure, drain queued wakes, inspect the failure text, and restart Pi with both extensions loaded if needed.
+9. Failure or missing cycle only: if the extension reports a watcher failure, drain queued wakes, inspect the failure text, call `fm_watch_arm_pi`, and restart Pi with both extensions loaded if needed.
 10. Never use shell `&` for watcher supervision.
    The arm mechanism above is extension-owned, not a model tool call, but a manual recovery probe that backgrounds, pipes, or bundles the arm is denied automatically by the PreToolUse seatbelt (`bin/fm-arm-pretool-check.sh`, wired into the turn-end guard extension at `__FM_PI_TURNEND_EXT__`).
 

--- a/docs/supervision-protocols/unknown.md
+++ b/docs/supervision-protocols/unknown.md
@@ -2,9 +2,11 @@ Mode: Unknown harness fallback.
 
 This primary harness does not have a verified watcher wake adapter.
 Follow the generic supervision contract in `AGENTS.md`.
-Drain queued wakes first, then choose a supervision wait that the harness can actually wake from.
+First cycle: drain queued wakes, then choose a supervision wait that the harness can actually wake from.
+Ordinary wake: drain and handle the wake, then repeat that verified wait while supervision is still required.
 Use `bin/fm-watch-arm.sh` only when the harness has a tracked background mechanism that survives the tool call and notifies the model on process exit.
 Use a bounded foreground wait over `bin/fm-watch.sh` when that wake mechanism is not verified.
 Never use shell `&` for watcher supervision.
+Failure or missing cycle only: inspect the failure and restore the same verified wait shape.
 
 Record new verification evidence before promoting an unknown harness to a named snippet.

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -14,7 +14,7 @@ The primary can otherwise end a turn after handling wakes without resuming super
 On 2026-07-04, that exact gap left a parked no-mistakes gate unwatched for about nine hours.
 
 `bin/fm-turnend-guard.sh` closes the gap by checking the primary's own turn-end path.
-When tasks are in flight and there is no live identity-matched watcher with a fresh beacon, a harness hook must either block the turn end or force a bounded follow-up turn that tells the primary to resume the session-start supervision protocol for its harness.
+When tasks are in flight and there is no live identity-matched watcher with a fresh beacon, a harness hook must either block the turn end or force a bounded follow-up turn that tells the primary to repair the missing or failed watcher cycle using the recovery instruction in its emitted session-start protocol.
 
 ## Shared Predicate
 

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -95,6 +95,7 @@ The next no-tool prompt produced exactly one `TURN WOULD END BLIND` follow-up, a
 The three earlier tool turns produced no guard follow-up because no work was in flight.
 Command used to fire the watcher: `printf 'done: pi e2e watcher fire\n' > "$FM_HOME/state/pi-e2e.status"`.
 Observed output after the wake: Pi ran `bin/fm-wake-drain.sh`, read the terminal status, called `fm_watch_arm_pi`, and rendered `watcher: started Pi extension arm child 2`.
+This 2026-07-09 observation predates extension-owned successor continuity; [`watcher-continuity.md`](watcher-continuity.md) owns the current ordinary-wake contract.
 The complete pane contained one guard message and zero foreground `bin/fm-watch-arm.sh` bash calls.
 `/quit` printed `PI_EXIT=0`, and the second arm process plus its watcher child were both gone afterward.
 
@@ -125,7 +126,7 @@ Only unmarked child worktrees fall through to the linked-worktree exemption, and
 
 "No turn ends blind" for a secondmate is delivered by the same two mechanisms the main primary relies on.
 Mechanism B, the turn-end backstop, is this guard; its secondmate-home behavior is covered by hermetic tests in `tests/fm-turnend-guard.test.sh` (`test_hook_blocks_in_secondmate_own_home`, `test_hook_blocks_in_treehouse_leased_secondmate_home`, `test_hook_silent_in_idle_secondmate_home`, `test_hook_secondmate_loop_guard_allows_retry`, `test_hook_secondmate_reinvoke_recovery_loop`, `test_hook_silent_in_secondmate_child_worktree`, and `test_hook_exempts_linked_worktree_with_stray_marker`).
-Mechanism A, the autonomous wake, is a harness property: when a background watcher task exits, the harness re-invokes the model, which drains the wake, advances children, and re-arms a fresh watcher.
+Mechanism A, the autonomous wake, is a harness property; the emitted supervision protocol owns whether the model or an extension/plugin continues the watcher cycle after delivering that wake.
 Mechanism A cannot be a hermetic CI assertion because it requires a live model session, so it is recorded here as a dated first-hand measurement while `test_hook_secondmate_reinvoke_recovery_loop` covers the guard's deterministic half of the same recovery loop.
 
 Autonomous-re-invoke measurement, run first-hand on Claude Code 2.1.207 (Darwin 25.5.0) on 2026-07-12.

--- a/tests/fm-supervision-instructions.test.sh
+++ b/tests/fm-supervision-instructions.test.sh
@@ -67,6 +67,32 @@ test_repair_lines() {
   pass "renderer repair-line mode is harness-aware and honors conditional state"
 }
 
+test_ordinary_wake_lines_are_distinct_from_repair() {
+  local claude_ordinary opencode_ordinary out pi_ordinary
+
+  out=$("$RENDER" --harness pi)
+  pi_ordinary=$(printf '%s\n' "$out" | grep -F -- '- Ordinary wake:')
+  assert_contains "$pi_ordinary" "Pi extension already owns watcher continuity" "pi ordinary-wake line does not leave continuity to the extension"
+  assert_not_contains "$pi_ordinary" "fm_watch_arm_pi" "pi ordinary-wake line incorrectly calls the recovery tool"
+
+  out=$("$RENDER" --harness pi --repair-line)
+  assert_contains "$out" "fm_watch_arm_pi" "pi recovery line lost the extension-owned repair tool"
+
+  out=$("$RENDER" --harness claude)
+  claude_ordinary=$(printf '%s\n' "$out" | grep -F -- '- Ordinary wake:')
+  assert_contains "$claude_ordinary" "re-arm" "claude ordinary-wake line does not tell the model to re-arm"
+  assert_contains "$claude_ordinary" "bin/fm-watch-arm.sh" "claude ordinary-wake line lost the background arm command"
+
+  out=$("$RENDER" --harness opencode)
+  opencode_ordinary=$(printf '%s\n' "$out" | grep -F -- '- Ordinary wake:')
+  assert_contains "$opencode_ordinary" "plugin already owns watcher continuity" "opencode ordinary-wake line does not leave continuity to the plugin"
+  assert_not_contains "$opencode_ordinary" "bin/fm-watch-arm.sh" "opencode ordinary-wake line incorrectly calls the recovery probe"
+
+  out=$("$RENDER" --harness opencode --repair-line)
+  assert_contains "$out" "manual recovery probe" "opencode recovery line lost its manual probe"
+  pass "renderer distinguishes ordinary wake continuation from failure recovery"
+}
+
 test_grok_is_background_notify() {
   local out
   out=$("$RENDER" --harness grok)
@@ -111,6 +137,7 @@ test_selected_harness_block_only
 test_unknown_fallback
 test_conditional_stanzas
 test_repair_lines
+test_ordinary_wake_lines_are_distinct_from_repair
 test_grok_is_background_notify
 test_grok_command_sources_effective_config
 test_pi_snippet_uses_effective_extension_path

--- a/tests/fm-turnend-guard.test.sh
+++ b/tests/fm-turnend-guard.test.sh
@@ -19,7 +19,7 @@ set -u
 TMP_ROOT=$(fm_test_tmproot fm-turnend-guard)
 fm_git_identity fmtest fmtest@example.invalid
 
-REQUIRED_REASON='resume supervision with bin/fm-watch-arm.sh as its own Claude Code background task'
+REQUIRED_REASON='repair missing watcher supervision with bin/fm-watch-arm.sh as its own Claude Code background task'
 
 # --- PREDICATE: bin/fm-supervision-lib.sh -----------------------------------
 

--- a/tests/fm-turnend-guard.test.sh
+++ b/tests/fm-turnend-guard.test.sh
@@ -695,6 +695,9 @@ test_opencode_plugin_forces_followup() {
   assert_contains "$content" 'promptAsync' "OpenCode plugin must force a follow-up turn"
   assert_contains "$content" 'skipNextIdle' "OpenCode plugin must carry a loop guard"
   assert_contains "$content" 'worktree' "OpenCode plugin must anchor the guard from the git worktree path"
+  assert_contains "$content" 'watcher cycle is missing, failed, or unhealthy' "OpenCode plugin must identify a blind turn as watcher recovery"
+  assert_contains "$content" 'harness recovery instruction below' "OpenCode plugin must delegate recovery action to the shared guard line"
+  assert_not_contains "$content" 'Resume supervision according to the session-start operating block' "OpenCode plugin must not route a blind turn through ordinary continuity"
   pass ".opencode primary plugin: session.idle forces one follow-up through the shared guard"
 }
 
@@ -737,6 +740,14 @@ if (!promptBody.includes("guard-fired")) {
   console.error(`missing prompt body: ${promptBody}`);
   process.exit(1);
 }
+if (!promptBody.includes("watcher cycle is missing, failed, or unhealthy")) {
+  console.error(`missing recovery-only preamble: ${promptBody}`);
+  process.exit(1);
+}
+if (promptBody.includes("Resume supervision according to the session-start operating block")) {
+  console.error(`ordinary continuity leaked into guard follow-up: ${promptBody}`);
+  process.exit(1);
+}
 EOF
 )
   status=$?
@@ -756,7 +767,9 @@ test_pi_extension_forces_followup() {
   assert_contains "$content" 'deliverAs: "followUp"' "pi extension must queue the follow-up safely"
   assert_contains "$content" 'guardFollowupActive' "pi extension must carry a logical-run loop guard"
   assert_not_contains "$content" 'skipNextTurnEnd' "pi extension kept the internal-turn loop guard"
-  assert_contains "$content" 'session-start operating block' "pi extension must use harness-neutral repair wording"
+  assert_contains "$content" 'watcher cycle is missing, failed, or unhealthy' "pi extension must identify a blind turn as watcher recovery"
+  assert_contains "$content" 'harness recovery instruction below' "pi extension must delegate recovery action to the shared guard line"
+  assert_not_contains "$content" 'Resume supervision according to the session-start operating block' "pi extension must not route a blind turn through ordinary continuity"
   assert_contains "$content" '.pi-turnend-extension-loaded' "pi extension must write its loaded marker for session-start diagnostics"
   assert_contains "$content" 'lockOwnership' "pi extension loaded marker must respect the session lock"
   assert_contains "$content" 'const command = String((event.input as { command?: unknown })?.command ?? "")' "pi extension changed bash command extraction for the PreToolUse contract"
@@ -799,6 +812,8 @@ const pi = {
   async sendUserMessage(message, options) {
     prompts += 1;
     if (!message.includes("TURN WOULD END BLIND")) throw new Error(`unexpected prompt: ${message}`);
+    if (!message.includes("watcher cycle is missing, failed, or unhealthy")) throw new Error(`guard prompt omitted recovery-only state: ${message}`);
+    if (message.includes("Resume supervision according to the session-start operating block")) throw new Error(`guard prompt used ordinary continuity: ${message}`);
     if (options?.deliverAs !== "followUp") throw new Error("guard prompt was not a follow-up");
     await handlers.get("agent_settled")?.({ type: "agent_settled" }, {});
   },

--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -112,7 +112,7 @@ test_guard_warnings() {
   # four copy-coupled tests:
   #   (1) watcher DOWN + queued wakes: a prominent no-watcher banner leads (alarm
   #       title, in-flight count, beacon age, fix command), the queued-wakes
-  #       warning follows it, and the guidance is re-arm-after-drain (never the
+  #       warning follows it, and the guidance is repair-after-drain (never the
   #       old conflicting "restart NOW first").
   #   (2) a fresh watcher and an empty queue: total silence.
   local dir state err first banner_line queue_line
@@ -137,9 +137,9 @@ test_guard_warnings() {
   grep -F 'last beat: never' "$err" >/dev/null || fail "guard banner missing the beacon age"
   grep -F 'guarded operation WILL still run' "$err" >/dev/null || fail "guard banner missing generic continuation wording"
   ! grep -F 'requested message WILL still be sent' "$err" >/dev/null || fail "shared guard used send-specific continuation wording"
-  grep -F 'resume supervision' "$err" >/dev/null || fail "guard banner missing the harness-aware fix command"
+  grep -F 'repair missing watcher supervision' "$err" >/dev/null || fail "guard banner missing the harness-aware fix command"
   grep -F 'queued wakes pending - drain them' "$err" >/dev/null || fail "guard did not warn about pending queue"
-  grep -F 'After draining queued wakes, resume supervision' "$err" >/dev/null || fail "guard did not order supervision repair after drain"
+  grep -F 'After draining queued wakes, repair missing watcher supervision' "$err" >/dev/null || fail "guard did not order supervision repair after drain"
   ! grep -F 'Restart it NOW, before anything else' "$err" >/dev/null || fail "guard still gave conflicting restart-first instruction"
   ! grep -F 'as the harness-tracked background task' "$err" >/dev/null || fail "guard still printed the old universal background-task repair text"
   banner_line=$(grep -n 'WATCHER DOWN' "$err" | head -1 | cut -d: -f1)
@@ -165,7 +165,7 @@ test_guard_warnings() {
   # total silence" stays a pure assertion about watcher state.
   FM_ROOT_OVERRIDE="$dir" FM_STATE_OVERRIDE="$state" FM_GUARD_GRACE=300 "$ROOT/bin/fm-guard.sh" 2> "$err" >/dev/null || fail "guard failed"
   [ ! -s "$err" ] || fail "guard warned with a fresh watcher and no queued wakes: $(cat "$err")"
-  pass "guard banner leads when down with pending wakes (re-arm-after-drain) and stays silent when fresh"
+  pass "guard banner leads when down with pending wakes (repair-after-drain) and stays silent when fresh"
 }
 
 test_lock_single_winner_under_concurrency() {


### PR DESCRIPTION
## Intent

Fix the Firstmate supervision-instruction conflict that caused a Pi primary to call fm_watch_arm_pi after ordinary wakes. Keep AGENTS.md harness-agnostic and leave the emitted session-start block as the sole owner of harness-specific verbs. Explicitly distinguish first-cycle arming, ordinary-wake continuation, and failure-only recovery for every supported harness: Pi and OpenCode must leave ordinary continuity to their extension or plugin, Claude and Grok must re-arm their tracked background task, and Codex must take its next foreground checkpoint. Keep Pi recovery able to call fm_watch_arm_pi when the cycle is missing or failed, preserve OpenCode recovery semantics, update turn-end guard output to recovery-only language, add colocated renderer regression coverage for Pi and at least one model-owned harness, and do not change watcher algorithms, adapters, or extension continuity implementation. Deliver a green PR but do not merge it because landing timing must be coordinated with the main Firstmate.

## What Changed

- Separate first-cycle arming, ordinary-wake continuation, and failure recovery in emitted supervision instructions for every supported harness.
- Keep Pi and OpenCode ordinary continuity extension/plugin-owned, while Claude and Grok re-arm tracked background tasks and Codex starts its next foreground checkpoint.
- Make watcher and turn-end guard follow-ups recovery-only, and update protocol documentation and regression coverage for the distinct paths.

## Risk Assessment

✅ Low: The repaired passive guard follow-ups now state recovery-only conditions and delegate harness-specific actions to the shared renderer, while ordinary continuity paths remain unchanged.

## Testing

The supplied full-suite baseline was green; focused renderer, guard, and watcher-lock regressions also passed. Manual CLI evidence confirms Pi and OpenCode leave ordinary continuity to their extension/plugin while retaining recovery paths, Claude and Grok re-arm tracked tasks, Codex continues with a foreground checkpoint, and the turn-end guard presents recovery-only wording when it prevents a blind turn end.

<details>
<summary>Evidence: Rendered session-start and recovery behavior across all supported harnesses, plus an actual unhealthy Claude turn-end guard invocation.</summary>

```text
Firstmate supervision instruction rendering - end-to-end validation transcript
Each session-start block is rendered by bin/fm-supervision-instructions.sh.

[claude session start]
SUPERVISION OPERATING INSTRUCTIONS - primary harness: claude
- Ordinary wake: re-arm exactly one bin/fm-watch-arm.sh Claude Code background task as directed below.
3. First cycle: run `bin/fm-watch-arm.sh` as its own Claude Code background task.
7. Failure or missing cycle only: treat any `watcher: FAILED ...` result as an alarm and repair it before ending the turn.
8. Ordinary wake: when the background task completes with `signal:`, `stale:`, `check:`, or `heartbeat`, drain queued wakes, then start exactly one fresh background task before running other fleet commands to handle the wake.
[claude recovery-only guard instruction]
repair missing watcher supervision with bin/fm-watch-arm.sh as its own Claude Code background task, never shell &.

[codex session start]
SUPERVISION OPERATING INSTRUCTIONS - primary harness: codex
- Ordinary wake: take the next foreground bin/fm-watch-checkpoint.sh checkpoint as directed below.
3. First cycle: run one foreground watcher checkpoint with `bin/fm-watch-checkpoint.sh --seconds "${FM_CODEX_WATCH_CHECKPOINT:-180}"`.
4. Ordinary wake: if the command prints `signal:`, `stale:`, `check:`, or `heartbeat`, drain queued wakes, handle that wake, then start the next checkpoint.
8. Failure or missing cycle only: drain queued wakes, inspect the failure, then start a fresh foreground checkpoint.
[codex recovery-only guard instruction]
repair missing watcher supervision with a foreground checkpoint: bin/fm-watch-checkpoint.sh --seconds 180.

[pi session start]
SUPERVISION OPERATING INSTRUCTIONS - primary harness: pi
- Ordinary wake: the Pi extension already owns watcher continuity; do not arm another cycle.
3. First cycle: arm with the `fm_watch_arm_pi` tool.
7. Ordinary wake: do not call `fm_watch_arm_pi` again because continuity is extension-owned rather than model-memory-owned.
9. Failure or missing cycle only: if the extension reports a watcher failure, drain queued wakes, inspect the failure text, call `fm_watch_arm_pi`, and restart Pi with both extensions loaded if needed.
[pi recovery-only guard instruction]
repair a missing or failed watcher cycle with the Pi tool fm_watch_arm_pi, or restart Pi with -e /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KXY99KXAF8ZETYGW2YG3RTS9/.pi/extensions/fm-primary-turnend-guard.ts -e /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KXY99KXAF8ZETYGW2YG3RTS9/.pi/extensions/fm-primary-pi-watch.ts if the extensions are not loaded.

[opencode session start]
SUPERVISION OPERATING INSTRUCTIONS - primary harness: opencode
- Ordinary wake: the OpenCode TUI plugin already owns watcher continuity; do not arm manually.
2. First cycle: let `.opencode/plugins/fm-primary-watch-arm.js` arm supervision after the OpenCode session goes idle.
5. Ordinary wake: do not ask the model to re-arm because continuity is plugin-owned.
7. Failure or missing cycle only: if the plugin reports a watcher failure, drain queued wakes, inspect the failure text, and use `bin/fm-watch-arm.sh` manually only as a short recovery probe.
[opencode recovery-only guard instruction]
repair missing watcher supervision by letting the OpenCode TUI plugin arm after idle; use bin/fm-watch-arm.sh only as a manual recovery probe if the plugin reports failure.

[grok session start]
SUPERVISION OPERATING INSTRUCTIONS - primary harness: grok
- Ordinary wake: re-arm exactly one bin/fm-watch-arm.sh Grok tracked background task as directed below.
3. First cycle: arm with Grok's tracked background tool, as its own call:
6. Failure or missing cycle only: `watcher: FAILED ...` means supervision is down; fix and re-arm.
4. Ordinary wake: re-arm the next cycle with the same background `bin/fm-watch-arm.sh` call if work remains in flight or X mode still needs polling.
[grok recovery-only guard instruction]
repair missing watcher supervision with bin/fm-watch-arm.sh as its own Grok tracked background task, never shell &.

[actual Claude turn-end guard with an in-flight task and no watcher]
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
●  TURN WOULD END BLIND - SUPERVISION IS OFF
●  1 task(s) in flight, but no live watcher holds this home lock (last beat: never).
●  repair missing watcher supervision with bin/fm-watch-arm.sh as its own Claude Code background task, never shell &.
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
guard exit status: 2 (2 means it prevented a blind turn end)
```
</details>
- Outcome: 🔧 1 issue found → auto-fixed ✅ across 2 runs (52m50s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- 🚨 `.pi/extensions/fm-primary-turnend-guard.ts:145` - Required criterion: “update turn-end guard output to recovery-only language.” The Pi passive guard still prepends “Resume supervision according to the session-start operating block” to its forced follow-up, so an unhealthy Pi cycle receives the old non-recovery-only instruction before the shared repair reason.
- 🚨 `.opencode/plugins/fm-primary-turnend-guard.js:85` - Required criterion: “update turn-end guard output to recovery-only language.” The OpenCode passive guard still emits “Resume supervision according to the session-start operating block” in its forced follow-up. This path remains reachable when the coordinator does not handle the idle event.

🔧 Fix: Make passive guard follow-ups recovery-only
✅ Re-checked - no issues remain.

</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed ✅</summary>

- 🚨 tests failed with exit code 1
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`

🔧 Fix: Verify OpenCode watcher test stability
✅ Re-checked - no issues remain.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- <code>Baseline full suite previously completed successfully: `command -v tmux &gt;/dev/null || { echo &#34;tmux is required for e2e tests&#34; &gt;&amp;2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo &#34;== $t ==&#34;; bash &#34;$t&#34; || rc=1; done; exit &#34;$rc&#34;`</code>
- `bash tests/fm-supervision-instructions.test.sh`
- `bash tests/fm-turnend-guard.test.sh`
- `bash tests/fm-watcher-lock.test.sh`
- <code>Manual evidence: rendered `bin/fm-supervision-instructions.sh --harness &lt;claude|codex|pi|opencode|grok&gt;` and `--repair-line`; invoked a fixture-backed `bin/fm-turnend-guard.sh` with an in-flight task and no watcher.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
