### PR TITLE
feat(quota): combined fleet-quota headroom view (quota-axi + multi-Claude)

### DIFF
--- a/.agents/skills/fleet-quota/SKILL.md
+++ b/.agents/skills/fleet-quota/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: fleet-quota
+description: >-
+  Show combined subscription headroom across every agent provider before dispatching work, so harness and model are chosen against real remaining quota.
+  Merges quota-axi (authoritative for Codex, and Grok when signed in) with the /opt/claude multi-seat balancer (the five Anthropic seats with 5h and 7d usage, rate-limit flags, and the balancer's own pick), and prints one summary plus an evidence-backed dispatch recommendation.
+  Load when the captain asks about quota, headroom, or remaining capacity; before a spawn when capacity is uncertain; or when Claude, GPT/Codex, or Grok routing is being discussed.
+  Read-only: it never mutates the active account or selects a seat.
+user-invocable: true
+metadata:
+  internal: true
+---
+
+# fleet-quota
+
+One place to see remaining subscription headroom across the whole fleet before dispatching a worker.
+Run the tool, read its summary, and let its recommendation inform the harness and model choice for the next spawn.
+
+## When to load
+
+- The captain asks about quota, headroom, remaining capacity, or "which account/harness has room".
+- Before a spawn when capacity is uncertain and picking the wrong provider would rate-limit.
+- When Claude vs GPT/Codex vs Grok routing is being discussed for a task.
+
+## Run it
+
+```
+bin/fm-quota.sh            # human-readable combined summary + recommendation
+bin/fm-quota.sh --json     # combined machine-readable object for scripts
+bin/fm-quota.sh --provider codex,grok   # restrict the quota-axi half
+```
+
+`bin/fm-quota.sh --help` is the authoritative owner of flags, environment overrides, the JSON shape, and the recommendation logic.
+
+## What it reports
+
+- Per-provider remaining headroom from `quota-axi` (Codex is authoritative; Grok/Cursor/Copilot show when signed in).
+- The five Anthropic seats from the `/opt/claude` balancer: per-seat 5h usage, plan-wide 7d usage, rate-limit flags, and the balancer's current pick.
+- One evidence-backed dispatch recommendation (claude-opus / pi-codex / pi-grok, or the DeepSeek `ds` fallback when nothing subscription-backed has room), scored by remaining headroom.
+
+## Portability and boundaries
+
+- Fail-soft: a host without `/opt/claude` still gets quota-axi-only output; a host without `quota-axi` still gets the balancer's Claude seats; both absent still produces a valid answer.
+- No secrets: output carries usage percentages, status strings, and seat labels only, never credentials or tokens.
+- Advice, not routing: this tool does not change accounts or dispatch anything.
+  `bin/fm-dispatch-select.sh` owns the deterministic `quota-balanced` strategy; feeding multi-Claude into that selector is a separate follow-up, not part of this skill.
+
+## Why not extend quota-axi for multi-Claude
+
+quota-axi's Claude provider is single-OAuth by design (it reads one `~/.claude/.credentials.json`, with no config-dir override), and quota-axi ships as a compiled `dist/` build from the external `kunchenguid/quota-axi` repo, so an in-repo patch would be overwritten on update.
+The `/opt/claude` balancer already tracks all five seats natively from a local usage database without hammering the Claude quota endpoint (which rate-limits after a single probe).
+So the multi-Claude view comes from the balancer, and this skill combines the two sources rather than forking quota-axi.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,6 +159,7 @@ When dispatch profiles exist, consult them at every crewmate or scout intake and
 Routing precedence is an explicit per-task captain override, then the best-fit configured rule, then the configured default, then the static crewmate harness.
 The generic effort fallback and its precedence are owned by `harness-adapters`: explicit captain and standing configured effort win; otherwise use low for well-understood explicit work, xhigh for ambiguous investigation or design, intermediate levels proportionally, and never max without explicit captain preference.
 Do not add model-specific versions of that policy.
+When capacity is uncertain before a spawn, or the captain asks about quota, headroom, or Claude/GPT/Grok routing, load `fleet-quota` for a combined quota-axi and multi-Claude headroom view with an evidence-backed dispatch recommendation.
 
 `secondmate-provisioning` owns secondmate harness pins and inherited local material, while `harness-adapters` owns the harness consequences.
 Dispatch only on a backend that `fm-spawn` validates as spawn-capable.

--- a/bin/fm-quota.sh
+++ b/bin/fm-quota.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# Combined fleet quota view: subscription headroom across all agent providers.
+# Merges two sources that each see a different slice of the fleet:
+#   1. quota-axi --json    - authoritative for Codex (and Grok/Cursor/Copilot
+#      when signed in). Its Claude reading is single-OAuth and under-reads the
+#      multi-seat Anthropic fleet, so it is dropped from the view whenever the
+#      multi-Claude balancer below is reachable.
+#   2. /opt/claude balancer - the five-seat Anthropic view (per-seat 5h usage,
+#      plan-wide 7d usage, rate-limit flags, and the load-balancer's own pick),
+#      read via `bun run /opt/claude/src/cli.ts balance --json`. Read-only: this
+#      never mutates the active account or selects a seat.
+#
+# Usage:
+#   fm-quota.sh [--json] [--provider <claude,codex,cursor,copilot,grok>]
+#   --json               emit the combined machine-readable object (see below)
+#   --provider <list>    restrict quota-axi to these providers (passthrough)
+#   --help
+#
+# Portable and fail-soft: a host without quota-axi, without /opt/claude, or
+# without bun still gets whatever source is present. The tool never blocks and
+# never prints credentials or tokens - only usage percentages, status strings,
+# and seat labels (arcs/jr/nyu/ra/yfz), which are not secrets.
+#
+# Recommendation is evidence-first and continuous: each candidate is scored by
+# its remaining headroom fraction (higher is better), rate-limited/unavailable
+# candidates are hard-excluded, and the max wins. When Claude is fully rate-
+# limited and no metered-free provider has headroom, it recommends the DeepSeek
+# (ds) throwaway fallback. It advises; it does not route - fm-dispatch-select.sh
+# owns the deterministic quota-balanced strategy and is untouched by this tool.
+#
+# JSON shape:
+#   {generatedAt, claude:{available,pick,weeklyPct,allRateLimited,seats:[...]}|null,
+#    providers:[{provider,label,status,minRemainingPct}], recommendation:{pick,remainingPct,reason,alternatives}}
+set -u
+
+QUOTA_CMD=${FM_QUOTA_AXI:-quota-axi}
+CLAUDE_CLI=${FM_QUOTA_CLAUDE_CLI:-/opt/claude/src/cli.ts}
+BUN=${FM_QUOTA_BUN:-bun}
+TIMEOUT_SECS=${FM_QUOTA_TIMEOUT:-40}
+
+json_mode=0
+provider_arg=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --json) json_mode=1 ;;
+    --provider)
+      [ "$#" -gt 1 ] || { echo "error: --provider requires a value" >&2; exit 2; }
+      provider_arg=$2; shift ;;
+    --provider=*) provider_arg=${1#--provider=} ;;
+    -h|--help) sed -n '2,32p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "error: unknown argument: $1" >&2; exit 2 ;;
+  esac
+  shift
+done
+
+run_timeout() { if command -v timeout >/dev/null 2>&1; then timeout "$TIMEOUT_SECS" "$@"; else "$@"; fi; }
+
+# --- Source 1: quota-axi (multi-vendor) --------------------------------------
+quota_json='{"providers":[]}'
+if command -v "$QUOTA_CMD" >/dev/null 2>&1; then
+  qargs=(--json)
+  [ -n "$provider_arg" ] && qargs+=(--provider "$provider_arg")
+  raw=$(run_timeout "$QUOTA_CMD" "${qargs[@]}" 2>/dev/null || true)
+  if [ -n "$raw" ] && printf '%s' "$raw" | jq -e . >/dev/null 2>&1; then
+    quota_json=$raw
+  fi
+fi
+
+# --- Source 2: /opt/claude multi-seat balancer -------------------------------
+claude_json=null
+if [ -r "$CLAUDE_CLI" ] && command -v "$BUN" >/dev/null 2>&1; then
+  raw=$(run_timeout "$BUN" run "$CLAUDE_CLI" balance --json 2>/dev/null || true)
+  if [ -n "$raw" ] && printf '%s' "$raw" | jq -e . >/dev/null 2>&1; then
+    claude_json=$raw
+  fi
+fi
+
+generated_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+# --- Combine + recommend (one jq program) ------------------------------------
+combined=$(jq -n \
+  --argjson q "$quota_json" \
+  --argjson c "$claude_json" \
+  --arg now "$generated_at" '
+  # remaining fraction for a quota-axi provider = min percentRemaining over its
+  # usable windows, /100; null when no windows (signed out / rate limited).
+  def min_remaining($p):
+    ([ $p.windows[]? | .percentRemaining // empty ] | if length > 0 then (min / 100) else null end);
+
+  # Claude block from the balancer (null when balancer unreachable).
+  ($c) as $cb
+  | (if $cb == null then null else {
+      available: ($cb.allRateLimited | not),
+      pick: $cb.account,
+      weeklyPct: $cb.weeklyPct,
+      allRateLimited: $cb.allRateLimited,
+      seats: [ $cb.scores[] | {
+        account,
+        fivehrUsedPct: ((.rollingPct * 100) | round),
+        rateLimited,
+        paceStatus,
+        activeSessions,
+        isPick: (.account == $cb.account)
+      } ]
+    } end) as $claude
+
+  # Provider table from quota-axi. Drop claude when the balancer supersedes it.
+  | [ $q.providers[]?
+      | select(.provider != "claude" or $claude == null)
+      | { provider, label, status: .state.status,
+          minRemainingPct: (min_remaining(.) | if . == null then null else (. * 100 | round) end) } ] as $providers
+
+  # Candidates for the recommendation, each with a remaining fraction.
+  | ([ if $claude != null and $claude.available then
+         { label: ("claude-opus (seat " + $claude.pick + ")"),
+           # binding = min(plan-wide 7d headroom, best available seat 5h headroom)
+           remaining: ([ (1 - $claude.weeklyPct),
+                         ([ $claude.seats[] | select(.rateLimited | not) | (1 - (.fivehrUsedPct/100)) ] | max // 0) ] | min) }
+       else empty end ]
+     + [ $q.providers[]?
+         | select(.provider == "codex" and .state.status == "fresh")
+         | { label: "pi-codex", remaining: (min_remaining(.) // 0) } ]
+     + [ $q.providers[]?
+         | select(.provider == "grok" and .state.status == "fresh")
+         | { label: "pi-grok", remaining: (min_remaining(.) // 0) } ]
+    ) as $cands
+
+  | ($cands | map(select(.remaining > 0)) | sort_by(-.remaining)) as $ranked
+  | (if ($ranked | length) == 0 then
+       { pick: "deepseek (ds) fallback",
+         remainingPct: null,
+         reason: "no subscription provider has usable headroom (Claude fully rate-limited and no metered-free provider free); route disposable fan-out to ds.",
+         alternatives: [] }
+     else
+       ($ranked[0]) as $best
+       | { pick: $best.label,
+           remainingPct: ($best.remaining * 100 | round),
+           reason: ("highest remaining headroom: " + ([ $ranked[] | (.label + " " + ((.remaining*100)|round|tostring) + "%") ] | join(", ")) + "."),
+           alternatives: [ $ranked[1:][] | { pick: .label, remainingPct: (.remaining*100|round) } ] }
+     end) as $rec
+
+  | { generatedAt: $now, claude: $claude, providers: $providers, recommendation: $rec }
+')
+
+if [ "$json_mode" -eq 1 ]; then
+  printf '%s\n' "$combined"
+  exit 0
+fi
+
+# --- Human-readable render ----------------------------------------------------
+printf '%s\n' "$combined" | jq -r '
+  def bar($usedPct): ([[($usedPct // 0) / 10 | floor, 0] | max, 10] | min) as $n
+    | (("#" * $n) + ("." * (10 - $n)));
+  def pad($s; $w): $s + (" " * ([$w - ($s | length), 0] | max));
+  "FLEET QUOTA  (" + .generatedAt + ")",
+  "",
+  "Providers (quota-axi):",
+  ( if (.providers | length) == 0 then "  (quota-axi unavailable)"
+    else (.providers[]
+      | "  " + (.label // .provider | .[0:16]) + "\t"
+        + (if .minRemainingPct == null then ("-- " + .status) else ((.minRemainingPct|tostring) + "% free") end))
+    end ),
+  "",
+  ( if .claude == null then "Claude (multi-seat): balancer unreachable (/opt/claude absent); quota-axi single-OAuth reading above is the only Claude signal."
+    else
+      ( "Claude seats (/opt/claude balancer)  plan 7d used " + ((.claude.weeklyPct*100)|round|tostring) + "%"
+        + (if .claude.allRateLimited then "  [ALL RATE-LIMITED]" else "" end) ),
+      ( .claude.seats[]
+        | "  " + (if .isPick then "* " else "  " end) + pad(.account; 5)
+          + "  5h [" + bar(.fivehrUsedPct) + "] " + (.fivehrUsedPct|tostring) + "% used"
+          + (if .rateLimited then "  RATE-LIMITED" else "" end)
+          + (if .activeSessions > 0 then ("  (" + (.activeSessions|tostring) + " active)") else "" end) ),
+      "  (* = balancers current pick)"
+    end ),
+  "",
+  "-> Recommended dispatch: " + .recommendation.pick
+    + (if .recommendation.remainingPct != null then ("  (" + (.recommendation.remainingPct|tostring) + "% headroom)") else "" end),
+  "   " + .recommendation.reason
+'

--- a/tests/fm-quota.test.sh
+++ b/tests/fm-quota.test.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# tests/fm-quota.test.sh - bin/fm-quota.sh combine + recommendation logic.
+#
+# Deterministic and offline: the two live sources are replaced with fixtures via
+# the script's env overrides. FM_QUOTA_AXI points at a fake quota-axi that cats a
+# fixture on --json; FM_QUOTA_BUN points at a fake `bun` that cats a balancer
+# fixture regardless of args; FM_QUOTA_CLAUDE_CLI points at a readable stub so the
+# balancer branch is taken. This exercises the non-trivial logic - source merge,
+# candidate scoring, hard-exclusion of rate-limited/unavailable providers, and the
+# DeepSeek fallback - without touching the network or any real account.
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+QUOTA="$ROOT/bin/fm-quota.sh"
+
+FAILED=0
+fail() { printf 'not ok - %s\n' "$1" >&2; FAILED=1; }
+pass() { printf 'ok - %s\n' "$1"; }
+
+TMP=$(mktemp -d "${TMPDIR:-/tmp}/fm-quota-test.XXXXXX")
+trap 'rm -rf "$TMP"' EXIT
+
+# Fake quota-axi: prints $FMQ_QUOTA_FIXTURE on any invocation.
+FAKE_QUOTA="$TMP/quota-axi"
+cat > "$FAKE_QUOTA" <<'FAKE'
+#!/usr/bin/env bash
+cat "$FMQ_QUOTA_FIXTURE"
+FAKE
+chmod +x "$FAKE_QUOTA"
+
+# Fake bun: ignores `run <cli> balance --json`, prints $FMQ_CLAUDE_FIXTURE.
+FAKE_BUN="$TMP/bun"
+cat > "$FAKE_BUN" <<'FAKE'
+#!/usr/bin/env bash
+cat "$FMQ_CLAUDE_FIXTURE"
+FAKE
+chmod +x "$FAKE_BUN"
+
+STUB_CLI="$TMP/cli.ts"  # just needs to be readable
+echo "// stub" > "$STUB_CLI"
+
+# quota-axi fixtures
+cat > "$TMP/codex-high.json" <<'JSON'
+{"providers":[{"provider":"codex","label":"Codex","source":"cli-rpc","windows":[{"percentRemaining":80}],"state":{"status":"fresh"}}]}
+JSON
+cat > "$TMP/codex-low.json" <<'JSON'
+{"providers":[{"provider":"codex","label":"Codex","source":"cli-rpc","windows":[{"percentRemaining":30}],"state":{"status":"fresh"}}]}
+JSON
+cat > "$TMP/codex-signedout.json" <<'JSON'
+{"providers":[{"provider":"codex","label":"Codex","source":"unavailable","windows":[],"state":{"status":"auth_required"}}]}
+JSON
+
+# balancer fixtures
+cat > "$TMP/claude-mid.json" <<'JSON'
+{"account":"arcs","scores":[{"account":"arcs","rollingPct":0.5,"paceStatus":"on-pace","activeSessions":0,"rateLimited":false}],"weeklyPct":0.4,"allRateLimited":false}
+JSON
+cat > "$TMP/claude-fresh.json" <<'JSON'
+{"account":"arcs","scores":[{"account":"arcs","rollingPct":0.1,"paceStatus":"on-pace","activeSessions":0,"rateLimited":false}],"weeklyPct":0.1,"allRateLimited":false}
+JSON
+cat > "$TMP/claude-ratelimited.json" <<'JSON'
+{"account":"arcs","scores":[{"account":"arcs","rollingPct":0.9,"paceStatus":"over-pace","activeSessions":0,"rateLimited":true}],"weeklyPct":0.9,"allRateLimited":true}
+JSON
+
+run() { # $1=quota fixture $2=claude fixture -> combined JSON on stdout
+  FM_QUOTA_AXI="$FAKE_QUOTA" FM_QUOTA_BUN="$FAKE_BUN" FM_QUOTA_CLAUDE_CLI="$STUB_CLI" \
+    FMQ_QUOTA_FIXTURE="$1" FMQ_CLAUDE_FIXTURE="$2" \
+    "$QUOTA" --json 2>/dev/null
+}
+
+# Case 1: codex (80%) beats claude (min(0.6,0.5)=50%) -> pi-codex.
+pick=$(run "$TMP/codex-high.json" "$TMP/claude-mid.json" | jq -r '.recommendation.pick')
+[ "$pick" = "pi-codex" ] || fail "codex-high: expected pi-codex, got '$pick'"
+[ "$pick" = "pi-codex" ] && pass "codex with more headroom wins"
+
+# Case 2: claude fresh (90%) beats codex (30%) -> claude-opus.
+pick=$(run "$TMP/codex-low.json" "$TMP/claude-fresh.json" | jq -r '.recommendation.pick')
+case "$pick" in
+  claude-opus*) pass "claude with more headroom wins" ;;
+  *) fail "claude-fresh: expected claude-opus*, got '$pick'" ;;
+esac
+
+# Case 3: claude all rate-limited + codex signed out -> deepseek fallback.
+out=$(run "$TMP/codex-signedout.json" "$TMP/claude-ratelimited.json")
+pick=$(printf '%s' "$out" | jq -r '.recommendation.pick')
+[ "$pick" = "deepseek (ds) fallback" ] || fail "all-exhausted: expected deepseek fallback, got '$pick'"
+[ "$pick" = "deepseek (ds) fallback" ] && pass "deepseek fallback when nothing has headroom"
+
+# Case 4: rate-limited seat is excluded from claude candidacy (no claude in alts).
+alt=$(printf '%s' "$out" | jq -r '[.recommendation.alternatives[].pick] | join(",")')
+case "$alt" in
+  *claude*) fail "rate-limited claude leaked into alternatives: '$alt'" ;;
+  *) pass "rate-limited claude excluded from candidates" ;;
+esac
+
+# Case 5: output is always valid JSON with the documented top-level keys.
+if run "$TMP/codex-high.json" "$TMP/claude-mid.json" \
+    | jq -e 'has("generatedAt") and has("claude") and has("providers") and has("recommendation")' >/dev/null; then
+  pass "combined JSON has documented top-level keys"
+else
+  fail "combined JSON missing documented keys"
+fi
+
+# Case 6: both sources absent -> still valid JSON, deepseek fallback, no crash.
+both=$(FM_QUOTA_AXI=/nonexistent FM_QUOTA_CLAUDE_CLI=/nonexistent "$QUOTA" --json 2>/dev/null)
+if printf '%s' "$both" | jq -e '.recommendation.pick == "deepseek (ds) fallback" and .claude == null' >/dev/null; then
+  pass "both sources absent degrades to valid deepseek fallback"
+else
+  fail "both absent did not degrade cleanly: '$both'"
+fi
+
+exit $FAILED


### PR DESCRIPTION
## What and why

Give firstmate one place to see remaining subscription headroom across every agent provider before dispatching workers, so harness and model are chosen against real quota instead of guessing.

The two quota sources each see a different slice of the fleet, so this combines them:

- `quota-axi --json` — authoritative for Codex (and Grok when signed in). Its Claude reading is single-OAuth and under-reads the multi-seat Anthropic fleet.
- The `/opt/claude` balancer's `balance --json` — the five Anthropic seats (per-seat 5h usage, plan-wide 7d usage, rate-limit flags, and the balancer's own pick).

## What ships

- **`bin/fm-quota.sh`** — the combining tool and mechanics owner (header + `--help`). Human summary by default, `--json` for scripts, `--provider <list>` to restrict the quota-axi half. Emits per-provider remaining headroom, the Claude per-seat table, and one evidence-backed dispatch recommendation.
- **`.agents/skills/fleet-quota/SKILL.md`** — user-invocable firstmate skill (`metadata.internal: true`), with its load trigger declared.
- **`AGENTS.md` §4** — one-line trigger: consult `fleet-quota` when capacity is uncertain before a spawn, or when the captain asks about quota/headroom or Claude/GPT/Grok routing.
- **`tests/fm-quota.test.sh`** — offline, fixture-driven tests for the combine + recommendation logic (auto-discovered by the CI/`no-mistakes` test runner).

## Design decisions

1. **Part A (extend quota-axi itself for multi-Claude) — investigated and rejected as not feasible in-repo, documented rather than implemented.** quota-axi's Claude provider is single-OAuth by design (reads one `~/.claude/.credentials.json`, only env hook is `CLAUDE_CODE_USER_AGENT`, no config-dir override), and quota-axi installs as compiled `dist/` from the external `kunchenguid/quota-axi` repo, so an in-repo patch is overwritten on `quota-axi update`. Even a multi-credential variant would hammer the Claude quota endpoint per seat and rate-limit (observed live: a single probe returns `rate_limited`). The `/opt/claude` balancer already tracks all five seats natively from a local usage DB. So the skill combines the two sources rather than forking quota-axi.
2. **Read-only.** The tool never mutates the active account or selects a seat. Dispatch stays with `bin/fm-dispatch-select.sh`, whose deterministic `quota-balanced` strategy is deliberately left untouched — this tool advises, it does not route.
3. **Portable / fail-soft.** A host without `/opt/claude`, without `quota-axi`, or without `bun` still gets whatever source is present and a valid answer; when nothing subscription-backed has headroom it recommends the DeepSeek (`ds`) fallback.
4. **No secrets in output.** Only usage percentages, status strings, and seat labels (arcs/jr/nyu/ra/yfz) — never credentials or tokens.
5. **Continuous recommendation, no threshold cliffs.** Candidates are scored by remaining-headroom fraction (higher wins); only rate-limited/unavailable candidates are hard-excluded.

Shared tracked material was changed per `firstmate-coding-guidelines` (mechanics in the script header + `--help`, thin SKILL.md, one-line AGENTS.md trigger, colocated test).

## Local validation evidence

This PR was validated locally because the no-mistakes daemon on this host was holding stale config (its configured gate agent could not neutralize the firstmate `AGENTS.md`) and could not be restarted while other pipelines were running. All local gates are green:

```
$ ./bin/fm-lint.sh bin/fm-quota.sh tests/fm-quota.test.sh
fm-lint.sh: ShellCheck 0.11.0 (pinned 0.11.0)
rc=0

$ ./tests/fm-quota.test.sh
ok - codex with more headroom wins
ok - claude with more headroom wins
ok - deepseek fallback when nothing has headroom
ok - rate-limited claude excluded from candidates
ok - combined JSON has documented top-level keys
ok - both sources absent degrades to valid deepseek fallback
rc=0
```

`bin/fm-lint.sh` (the single owner of the lint definition invoked by both CI and the no-mistakes pre-push gate) is clean over the full tracked set as well. CI (`.github/workflows/ci.yml`) will re-run the same lint and behavior suite on this branch.

Live combined run on this host (Codex + all five Claude seats, no tokens leaked):

```
Providers (quota-axi):  Codex 68% free  |  Grok/Cursor/Copilot signed out
Claude seats: * arcs 24% used | yfz 47% | ra 76% | jr 46% | nyu 25% RATE-LIMITED
-> Recommended dispatch: pi-codex (68% headroom)  [claude-opus seat arcs 56%]
```
