### PR TITLE
feat(spawn): add structurally restricted Pi-native DeepSeek analysis lane

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -231,6 +231,27 @@ The model arms through `fm_watch_arm_pi`, never a foreground bash arm; the watch
 `bin/fm-session-start.sh` reports when the live Pi session has not loaded both the turn-end guard and watcher extensions, and points at plain `pi` after project trust as the fix, with `-e` as a trust-free fallback.
 When a secondmate is launched on Pi, `fm-spawn.sh --secondmate` launches Pi with both `-e .pi/extensions/fm-primary-turnend-guard.ts` and `-e .pi/extensions/fm-primary-pi-watch.ts`, both already present in the secondmate home's git worktree.
 
+### Restricted direct-DeepSeek analysis lane
+
+`bin/fm-spawn.sh`'s `pi_restricted_model()` lists Pi's direct DeepSeek models (`deepseek/deepseek-v4-pro`) that get a structurally locked-down launch instead of the ordinary crewmate template.
+Ordinary pi/Sol crewmates and secondmates are unaffected; this branch only fires for a ship/scout (never secondmate) spawn whose `--model` matches the allowlist.
+
+The restricted launch disables every ambient/private capability structurally, not just by convention:
+
+- `--no-builtin-tools --tools public_fetch,write_report,append_status,complete_scout` removes every built-in tool, then allowlists only the four custom tools `bin/fm-pi-restricted-tools.ts` registers.
+- `--no-context-files --no-skills --no-prompt-templates --no-extensions` disable AGENTS.md/CLAUDE.md, skill, prompt-template, and extension DISCOVERY. Two extensions still load explicitly via `-e`: the ordinary turn-end hook (`state/<id>.pi-ext.ts`) and the static tracked `bin/fm-pi-restricted-tools.ts`.
+- `--no-session` runs ephemeral, so no prior session context can leak in.
+
+`bin/fm-pi-restricted-tools.ts` is deliberately static and tracked, not generated per spawn: nothing model- or task-controlled is ever interpolated into its source, closing off a whole class of injection risk.
+Its only per-spawn input is the `FM_RESTRICTED_TASK_CONFIG` env var, a small JSON object of non-secret paths (report path, status path, task id) that `fm-spawn.sh` exports into the pane before launch, the same way it exports `GOTMPDIR`.
+The extension never reads any other environment variable and never shells out, so provider credentials in Pi's own auth store are never touched.
+
+Its four tools: `public_fetch` (HTTPS-only, DNS/IP-validated on every request and redirect hop, rejects private/loopback/link-local/metadata targets, bounded bytes/time/content-type, no ambient auth/cookies/proxy), `write_report` (overwrites only the fixed report path), `append_status` (appends one bounded, newline-free line to the fixed status path, allowed states only), and `complete_scout` (the decision-hold completion gate: a declared `unresolvedDecision: true` appends `needs-decision:` and returns `terminate: true`, ending the run immediately rather than letting the model self-resolve a captain-only decision).
+
+The model-facing brief for this lane should carry only the public research question, never private absolute paths or lifecycle mechanics - the extension alone owns where output and status land.
+
+Adding a second restricted model (for example a flash variant) needs an explicit documented task class that justifies it, not just availability; add it to `pi_restricted_model()`'s case list once justified.
+
 ## grok (VERIFIED 2026-06-29, grok 0.2.73; slash-submit re-verified 2026-07-03 on 0.2.82; reasoning-effort ceiling re-verified 2026-07-13 on 0.2.99; exit paths re-verified 2026-07-19 on grok 0.2.103)
 
 Grok Build TUI (`grok`), a Claude-Code-compatible CLI from xAI.

--- a/bin/fm-pi-restricted-tools.ts
+++ b/bin/fm-pi-restricted-tools.ts
@@ -1,0 +1,335 @@
+// Firstmate restricted DeepSeek-lane tool extension.
+//
+// Loaded via `-e` for a restricted Pi launch (bin/fm-spawn.sh, pi_restricted_model()).
+// This file is static and tracked: nothing here is generated or interpolated per
+// spawn. Per-task parameters (report path, status path, task id) arrive only
+// through the FM_RESTRICTED_TASK_CONFIG environment variable, which
+// fm-spawn.sh sets to a small JSON object of non-secret paths before launch.
+//
+// Threat model: the launching Pi process has --no-builtin-tools, --tools
+// <this file's tool names>, --no-context-files, --no-skills,
+// --no-prompt-templates, --no-extensions, and --no-session. This extension is
+// the ONLY code path the model can reach. It must never expose the shell, the
+// filesystem beyond the two fixed output paths, MCP, local config/auth, or any
+// environment value beyond the three non-secret config fields it reads itself.
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Type } from "typebox";
+import { StringEnum } from "@earendil-works/pi-ai";
+import { appendFile, writeFile } from "node:fs/promises";
+import { lookup } from "node:dns/promises";
+import * as https from "node:https";
+import { isIPv4, isIPv6 } from "node:net";
+
+interface RestrictedTaskConfig {
+  reportPath: string;
+  statusPath: string;
+  taskId: string;
+}
+
+const ALLOWED_STATUS_STATES = ["working", "needs-decision", "blocked", "paused", "done", "failed"] as const;
+const MAX_STATUS_MESSAGE_CHARS = 500;
+const MAX_REPORT_CHARS = 200_000;
+const MAX_FETCH_BYTES = 1_000_000;
+const MAX_REDIRECTS = 5;
+const PER_REQUEST_TIMEOUT_MS = 15_000;
+const TOTAL_FETCH_TIMEOUT_MS = 30_000;
+const ALLOWED_CONTENT_TYPE_PREFIXES = ["text/", "application/json", "application/xml", "application/xhtml+xml"];
+
+function loadConfig(): RestrictedTaskConfig {
+  const raw = process.env.FM_RESTRICTED_TASK_CONFIG;
+  if (!raw) {
+    throw new Error("restricted task config is not set; refusing to run without a trusted destination");
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error("restricted task config is not valid JSON");
+  }
+  const cfg = parsed as Partial<RestrictedTaskConfig>;
+  if (
+    typeof cfg.reportPath !== "string" ||
+    typeof cfg.statusPath !== "string" ||
+    typeof cfg.taskId !== "string"
+  ) {
+    throw new Error("restricted task config is missing required fields");
+  }
+  return cfg as RestrictedTaskConfig;
+}
+
+function rejectNewline(label: string, value: string): void {
+  if (/[\r\n]/.test(value)) {
+    throw new Error(`${label} must not contain a newline`);
+  }
+}
+
+async function appendStatusLine(config: RestrictedTaskConfig, state: string, message: string): Promise<void> {
+  rejectNewline("status message", message);
+  if (message.length > MAX_STATUS_MESSAGE_CHARS) {
+    throw new Error(`status message exceeds ${MAX_STATUS_MESSAGE_CHARS} characters`);
+  }
+  await appendFile(config.statusPath, `${state}: ${message}\n`, "utf8");
+}
+
+// --- public_fetch: HTTPS-only, per-hop DNS/IP validated, no ambient auth ---
+
+function ipv4ToUint(parts: number[]): number {
+  return ((parts[0] << 24) | (parts[1] << 16) | (parts[2] << 8) | parts[3]) >>> 0;
+}
+
+function isForbiddenIPv4(address: string): boolean {
+  const parts = address.split(".").map((p) => Number(p));
+  if (parts.length !== 4 || parts.some((p) => !Number.isInteger(p) || p < 0 || p > 255)) {
+    return true;
+  }
+  const value = ipv4ToUint(parts);
+  const inRange = (base: string, bits: number): boolean => {
+    const baseParts = base.split(".").map((p) => Number(p));
+    const baseValue = ipv4ToUint(baseParts);
+    const mask = bits === 0 ? 0 : (0xffffffff << (32 - bits)) >>> 0;
+    return (value & mask) === (baseValue & mask);
+  };
+  return (
+    inRange("0.0.0.0", 8) || // "this network"
+    inRange("10.0.0.0", 8) || // RFC1918
+    inRange("100.64.0.0", 10) || // CGNAT
+    inRange("127.0.0.0", 8) || // loopback
+    inRange("169.254.0.0", 16) || // link-local incl. cloud metadata
+    inRange("172.16.0.0", 12) || // RFC1918
+    inRange("192.168.0.0", 16) || // RFC1918
+    inRange("192.0.0.0", 24) || // IETF protocol assignments
+    inRange("192.0.2.0", 24) || // documentation (TEST-NET-1)
+    inRange("198.18.0.0", 15) || // benchmarking
+    inRange("198.51.100.0", 24) || // documentation (TEST-NET-2)
+    inRange("203.0.113.0", 24) || // documentation (TEST-NET-3)
+    inRange("224.0.0.0", 4) || // multicast
+    inRange("240.0.0.0", 4) || // reserved
+    value === 0xffffffff // broadcast
+  );
+}
+
+function isForbiddenIPv6(address: string): boolean {
+  const normalized = address.toLowerCase();
+  if (normalized === "::1" || normalized === "::") {
+    return true;
+  }
+  // IPv4-mapped/compatible IPv6 (::ffff:a.b.c.d, ::a.b.c.d): re-check the embedded IPv4.
+  const mapped = normalized.match(/^::(?:ffff:)?(\d+\.\d+\.\d+\.\d+)$/);
+  if (mapped) {
+    return isForbiddenIPv4(mapped[1]);
+  }
+  if (normalized.startsWith("fe80:") || normalized.startsWith("fe8") || normalized.startsWith("fe9") || normalized.startsWith("fea") || normalized.startsWith("feb")) {
+    return true; // link-local fe80::/10
+  }
+  if (normalized.startsWith("fc") || normalized.startsWith("fd")) {
+    return true; // unique local fc00::/7
+  }
+  if (normalized.startsWith("ff")) {
+    return true; // multicast ff00::/8
+  }
+  return false;
+}
+
+function isForbiddenAddress(address: string): boolean {
+  if (isIPv4(address)) return isForbiddenIPv4(address);
+  if (isIPv6(address)) return isForbiddenIPv6(address);
+  return true; // unrecognized form: refuse rather than guess
+}
+
+async function resolveSafeAddress(hostname: string): Promise<string> {
+  if (hostname.toLowerCase() === "localhost") {
+    throw new Error("refusing to fetch localhost");
+  }
+  let addresses: Array<{ address: string }>;
+  try {
+    addresses = await lookup(hostname, { all: true, verbatim: true });
+  } catch {
+    throw new Error(`could not resolve host: ${hostname}`);
+  }
+  if (addresses.length === 0) {
+    throw new Error(`could not resolve host: ${hostname}`);
+  }
+  for (const { address } of addresses) {
+    if (isForbiddenAddress(address)) {
+      throw new Error("refusing to fetch a private, loopback, link-local, or metadata address");
+    }
+  }
+  return addresses[0].address;
+}
+
+interface FetchHop {
+  status: number;
+  headers: Record<string, string | string[] | undefined>;
+  body: Buffer;
+}
+
+function requestOnce(url: URL, ip: string, deadline: number): Promise<FetchHop> {
+  return new Promise((resolve, reject) => {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) {
+      reject(new Error("fetch deadline exceeded"));
+      return;
+    }
+    const req = https.request(
+      {
+        hostname: ip,
+        servername: url.hostname,
+        port: url.port ? Number(url.port) : 443,
+        path: `${url.pathname}${url.search}`,
+        method: "GET",
+        headers: { Host: url.hostname, "User-Agent": "firstmate-restricted-scout/1.0" },
+        timeout: Math.min(PER_REQUEST_TIMEOUT_MS, remaining),
+        rejectUnauthorized: true,
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        let total = 0;
+        res.on("data", (chunk: Buffer) => {
+          total += chunk.length;
+          if (total > MAX_FETCH_BYTES) {
+            req.destroy();
+            reject(new Error(`response exceeds ${MAX_FETCH_BYTES} bytes`));
+            return;
+          }
+          chunks.push(chunk);
+        });
+        res.on("end", () => {
+          resolve({ status: res.statusCode ?? 0, headers: res.headers, body: Buffer.concat(chunks) });
+        });
+        res.on("error", reject);
+      },
+    );
+    req.on("timeout", () => {
+      req.destroy();
+      reject(new Error("fetch timed out"));
+    });
+    req.on("error", () => reject(new Error("fetch failed")));
+    req.end();
+  });
+}
+
+async function safeFetch(rawUrl: string): Promise<{ status: number; contentType: string; body: string }> {
+  let current: URL;
+  try {
+    current = new URL(rawUrl);
+  } catch {
+    throw new Error("invalid URL");
+  }
+  const deadline = Date.now() + TOTAL_FETCH_TIMEOUT_MS;
+  for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+    if (current.protocol !== "https:") {
+      throw new Error("only https URLs are allowed");
+    }
+    const ip = await resolveSafeAddress(current.hostname);
+    const result = await requestOnce(current, ip, deadline);
+    if (result.status >= 300 && result.status < 400) {
+      const location = result.headers.location;
+      if (!location || Array.isArray(location)) {
+        throw new Error("redirect without a usable location");
+      }
+      if (hop === MAX_REDIRECTS) {
+        throw new Error("too many redirects");
+      }
+      current = new URL(location, current);
+      continue;
+    }
+    const contentType = Array.isArray(result.headers["content-type"])
+      ? result.headers["content-type"][0]
+      : result.headers["content-type"] ?? "";
+    if (!ALLOWED_CONTENT_TYPE_PREFIXES.some((prefix) => contentType.startsWith(prefix))) {
+      throw new Error(`unsupported content type: ${contentType || "(none)"}`);
+    }
+    return { status: result.status, contentType, body: result.body.toString("utf8") };
+  }
+  throw new Error("too many redirects");
+}
+
+export default function (pi: ExtensionAPI) {
+  const config = loadConfig();
+
+  pi.registerTool({
+    name: "public_fetch",
+    label: "Public Fetch",
+    description: "Fetch a public HTTPS URL. Rejects private, loopback, link-local, and metadata addresses on every request and redirect hop.",
+    promptSnippet: "Fetch a public HTTPS URL for research",
+    promptGuidelines: ["Use public_fetch only for public, non-sensitive HTTPS URLs needed to answer the task."],
+    parameters: Type.Object({ url: Type.String() }),
+    async execute(_toolCallId, params) {
+      const result = await safeFetch(params.url);
+      return {
+        content: [{ type: "text", text: result.body }],
+        details: { status: result.status, contentType: result.contentType },
+      };
+    },
+  });
+
+  pi.registerTool({
+    name: "write_report",
+    label: "Write Report",
+    description: "Overwrite the task's report with the given content.",
+    promptSnippet: "Write the final task report",
+    promptGuidelines: ["Use write_report once, with the complete report content, before calling complete_scout."],
+    parameters: Type.Object({ content: Type.String() }),
+    async execute(_toolCallId, params) {
+      if (params.content.length > MAX_REPORT_CHARS) {
+        throw new Error(`report exceeds ${MAX_REPORT_CHARS} characters`);
+      }
+      await writeFile(config.reportPath, params.content, "utf8");
+      return { content: [{ type: "text", text: "Report written." }], details: {} };
+    },
+  });
+
+  pi.registerTool({
+    name: "append_status",
+    label: "Append Status",
+    description: "Append one supervisor-actionable status line.",
+    promptSnippet: "Report task progress to the supervisor",
+    promptGuidelines: [
+      "Use append_status with state working to report progress, blocked or paused for a bounded wait, and failed if the task cannot be completed.",
+    ],
+    parameters: Type.Object({
+      state: StringEnum(ALLOWED_STATUS_STATES),
+      message: Type.String(),
+    }),
+    async execute(_toolCallId, params) {
+      await appendStatusLine(config, params.state, params.message);
+      return { content: [{ type: "text", text: "Status recorded." }], details: {} };
+    },
+  });
+
+  pi.registerTool({
+    name: "complete_scout",
+    label: "Complete Scout",
+    description:
+      "Declare whether the task surfaced an unresolved decision that needs the captain's input. This is the required last step before finishing.",
+    promptSnippet: "Declare completion or an unresolved decision",
+    promptGuidelines: [
+      "Call complete_scout exactly once when the task is finished, after write_report for a normal completion.",
+      "Set unresolvedDecision to true and stop immediately if the task surfaced a choice only the captain can make; do not resolve it yourself.",
+    ],
+    parameters: Type.Object({
+      unresolvedDecision: Type.Boolean(),
+      summary: Type.String(),
+    }),
+    async execute(_toolCallId, params) {
+      if (params.unresolvedDecision) {
+        await appendStatusLine(config, "needs-decision", params.summary);
+        return {
+          content: [{ type: "text", text: "Recorded needs-decision. Stopping for firstmate." }],
+          details: {},
+          terminate: true,
+        };
+      }
+      rejectNewline("summary", params.summary);
+      return {
+        content: [
+          {
+            type: "text",
+            text: "No unresolved decision confirmed. Call write_report, then append_status with state done, to finish.",
+          },
+        ],
+        details: {},
+      };
+    },
+  });
+}

--- a/bin/fm-pi-restricted-tools.ts
+++ b/bin/fm-pi-restricted-tools.ts
@@ -108,15 +108,64 @@ function isForbiddenIPv4(address: string): boolean {
   );
 }
 
+// Expands a textual IPv6 address (with optional "::" compression and a trailing
+// dotted-quad group) into its eight 16-bit groups, or null if unparseable.
+function expandIPv6Groups(address: string): number[] | null {
+  const addr = address.split("%")[0];
+  const halves = addr.split("::");
+  if (halves.length > 2) return null;
+  const parseSide = (side: string): number[] | null => {
+    if (side === "") return [];
+    const segs = side.split(":");
+    const groups: number[] = [];
+    for (let i = 0; i < segs.length; i++) {
+      const seg = segs[i];
+      if (seg.includes(".")) {
+        if (i !== segs.length - 1) return null;
+        const bytes = seg.split(".").map(Number);
+        if (bytes.length !== 4 || bytes.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) return null;
+        groups.push((bytes[0] << 8) | bytes[1], (bytes[2] << 8) | bytes[3]);
+      } else {
+        if (!/^[0-9a-f]{1,4}$/.test(seg)) return null;
+        groups.push(parseInt(seg, 16));
+      }
+    }
+    return groups;
+  };
+  if (halves.length === 1) {
+    const groups = parseSide(halves[0]);
+    return groups && groups.length === 8 ? groups : null;
+  }
+  const head = parseSide(halves[0]);
+  const tail = parseSide(halves[1]);
+  if (head === null || tail === null) return null;
+  const missing = 8 - head.length - tail.length;
+  if (missing < 0) return null;
+  return [...head, ...new Array(missing).fill(0), ...tail];
+}
+
+// Embedded-IPv4 prefixes to unwrap before re-checking the low 32 bits: IPv4-mapped
+// (::ffff:0:0/96), IPv4-compatible (deprecated ::/96), and the NAT64 well-known
+// prefix (64:ff9b::/96, RFC 6052) all carry a real IPv4 address in their low 32 bits.
+const EMBEDDED_IPV4_PREFIXES: number[][] = [
+  [0, 0, 0, 0, 0, 0xffff],
+  [0, 0, 0, 0, 0, 0],
+  [0x64, 0xff9b, 0, 0, 0, 0],
+];
+
 function isForbiddenIPv6(address: string): boolean {
   const normalized = address.toLowerCase();
   if (normalized === "::1" || normalized === "::") {
     return true;
   }
-  // IPv4-mapped/compatible IPv6 (::ffff:a.b.c.d, ::a.b.c.d): re-check the embedded IPv4.
-  const mapped = normalized.match(/^::(?:ffff:)?(\d+\.\d+\.\d+\.\d+)$/);
-  if (mapped) {
-    return isForbiddenIPv4(mapped[1]);
+  const groups = expandIPv6Groups(normalized);
+  if (groups) {
+    const prefix = groups.slice(0, 6);
+    const embedsIPv4 = EMBEDDED_IPV4_PREFIXES.some((p) => p.every((g, i) => prefix[i] === g));
+    if (embedsIPv4) {
+      const ipv4 = `${groups[6] >> 8}.${groups[6] & 0xff}.${groups[7] >> 8}.${groups[7] & 0xff}`;
+      return isForbiddenIPv4(ipv4);
+    }
   }
   if (normalized.startsWith("fe80:") || normalized.startsWith("fe8") || normalized.startsWith("fe9") || normalized.startsWith("fea") || normalized.startsWith("feb")) {
     return true; // link-local fe80::/10

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -73,6 +73,16 @@
 #                  written by this script; outside the worktree to avoid pi's trust gate)
 #     __PITURNEND__ absolute path to .pi/extensions/fm-primary-turnend-guard.ts in a pi secondmate home
 #     __PIWATCH__   absolute path to .pi/extensions/fm-primary-pi-watch.ts in a pi secondmate home
+#     __PIRESTRICTED__ absolute path to bin/fm-pi-restricted-tools.ts (static, tracked;
+#                  the restricted DeepSeek lane's only tool extension, see pi_restricted_model())
+# A ship/scout spawn whose --model is a restricted DeepSeek analysis model
+# (pi_restricted_model() below) launches pi with every built-in/default tool
+# disabled, extension/context/skill/prompt-template discovery disabled, no
+# session persistence, and only the four tools bin/fm-pi-restricted-tools.ts
+# registers. FM_RESTRICTED_TASK_CONFIG (a small JSON object of non-secret
+# paths: report path, status path, task id) is exported into
+# the pane before launch so that extension knows its trusted output
+# destinations without any path being model-controlled.
 # Per-harness turn-end hooks are installed automatically; some live outside the worktree.
 # grok uses a firstmate-owned global hook under ${GROK_HOME:-$HOME/.grok}/hooks
 # plus a gitignored .fm-grok-turnend worktree pointer and a state token.
@@ -84,7 +94,7 @@ set -eu
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 usage() {
-  sed -n '2,78p' "$0" | sed 's/^# \{0,1\}//'
+  sed -n '2,91p' "$0" | sed 's/^# \{0,1\}//'
 }
 
 case "${1:-}" in
@@ -309,10 +319,20 @@ else
 fi
 [ -z "$HARNESS_ARG" ] || ARG3=$HARNESS_ARG
 
+# Direct Pi DeepSeek analysis models that get the restricted tool lane (see
+# __PIRESTRICTED__ above). Deliberately narrow: only a model actually verified
+# with the restricted flag combination is listed here, never guessed.
+pi_restricted_model() {
+  case "$1" in
+    deepseek/deepseek-v4-pro) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 # The verified launch command per adapter. The knowledge half of each adapter
 # (busy signature, exit command, dialogs, quirks) lives in the harness-adapters skill.
 launch_template() {
-  local harness=$1 kind=${2:-ship}
+  local harness=$1 kind=${2:-ship} model=${3:-}
   # shellcheck disable=SC2016  # single quotes are deliberate: $(cat ...) expands in the crewmate pane, not here
   case "$harness" in
     # CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false disables claude's interactive
@@ -336,6 +356,8 @@ launch_template() {
     pi)
       if [ "$kind" = secondmate ]; then
         printf '%s' 'pi __MODELFLAG____EFFORTFLAG__-e __PITURNEND__ -e __PIWATCH__ "$(cat __BRIEF__)"'
+      elif pi_restricted_model "$model"; then
+        printf '%s' 'pi __MODELFLAG____EFFORTFLAG__--no-builtin-tools --tools public_fetch,write_report,append_status,complete_scout --no-context-files --no-skills --no-prompt-templates --no-extensions --no-session -e __PIEXT__ -e __PIRESTRICTED__ "$(cat __BRIEF__)"'
       else
         printf '%s' 'pi __MODELFLAG____EFFORTFLAG__-e __PIEXT__ "$(cat __BRIEF__)"'
       fi
@@ -380,11 +402,11 @@ case "$ARG3" in
       HARNESS=$("$FM_ROOT/bin/fm-harness.sh" crew)
       harness_src='config/crew-harness'
     fi
-    LAUNCH=$(launch_template "$HARNESS" "$KIND") || { echo "error: no launch template for harness '$HARNESS' (from $harness_src or detection); pass a raw launch command to use an unverified adapter" >&2; exit 1; }
+    LAUNCH=$(launch_template "$HARNESS" "$KIND" "$MODEL") || { echo "error: no launch template for harness '$HARNESS' (from $harness_src or detection); pass a raw launch command to use an unverified adapter" >&2; exit 1; }
     ;;
   *)
     HARNESS=$ARG3
-    LAUNCH=$(launch_template "$HARNESS" "$KIND") || { echo "error: unknown harness '$HARNESS'; pass a raw launch command to use an unverified adapter" >&2; exit 1; }
+    LAUNCH=$(launch_template "$HARNESS" "$KIND" "$MODEL") || { echo "error: unknown harness '$HARNESS'; pass a raw launch command to use an unverified adapter" >&2; exit 1; }
     ;;
 esac
 
@@ -1034,6 +1056,7 @@ sq_turnend=$(shell_quote "$TURNEND")
 sq_piext=$(shell_quote "$STATE/$ID.pi-ext.ts")
 sq_piturnend=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-turnend-guard.ts")
 sq_piwatch=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-pi-watch.ts")
+sq_pirestricted=$(shell_quote "$FM_ROOT/bin/fm-pi-restricted-tools.ts")
 MODELFLAG=$(model_flag_for_harness "$HARNESS" "$MODEL")
 EFFORTFLAG=$(effort_flag_for_harness "$HARNESS" "$EFFORT")
 LAUNCH=${LAUNCH//__MODELFLAG__/$MODELFLAG}
@@ -1043,6 +1066,7 @@ LAUNCH=${LAUNCH//__TURNEND__/$sq_turnend}
 LAUNCH=${LAUNCH//__PIEXT__/$sq_piext}
 LAUNCH=${LAUNCH//__PITURNEND__/$sq_piturnend}
 LAUNCH=${LAUNCH//__PIWATCH__/$sq_piwatch}
+LAUNCH=${LAUNCH//__PIRESTRICTED__/$sq_pirestricted}
 if [ "$KIND" = secondmate ]; then
   sq_home=$(shell_quote "$PROJ_ABS")
   LAUNCH="FM_ROOT_OVERRIDE= FM_STATE_OVERRIDE= FM_DATA_OVERRIDE= FM_PROJECTS_OVERRIDE= FM_CONFIG_OVERRIDE= FM_HOME=$sq_home $LAUNCH"
@@ -1052,6 +1076,18 @@ fi
 # the env is set when the agent starts; the brief sleep lets the export land.
 spawn_send_text_line "$T" "export GOTMPDIR=$TASK_TMP/gotmp"
 sleep 0.3
+# Restricted DeepSeek lane: give bin/fm-pi-restricted-tools.ts its trusted
+# output destinations through an env var rather than any model-controlled
+# input. Non-secret paths only (report path, status path, task id); never read
+# into this from the wider environment.
+if [ "$KIND" != secondmate ] && [ "$HARNESS" = pi ] && pi_restricted_model "$MODEL"; then
+  restricted_config=$(printf '{"reportPath":"%s","statusPath":"%s","taskId":"%s"}' \
+    "$(json_escape "$DATA/$ID/report.md")" \
+    "$(json_escape "$STATE/$ID.status")" \
+    "$(json_escape "$ID")")
+  spawn_send_text_line "$T" "export FM_RESTRICTED_TASK_CONFIG=$(shell_quote "$restricted_config")"
+  sleep 0.3
+fi
 spawn_send_literal "$T" "$LAUNCH"
 sleep 0.3
 spawn_send_key "$T" Enter

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -329,6 +329,15 @@ pi_restricted_model() {
   esac
 }
 
+# Single source of truth for "does this spawn use the restricted DeepSeek lane"
+# (harness=pi, not a secondmate, model verified via pi_restricted_model). Used
+# both to pick the launch_template branch and to decide whether to export
+# FM_RESTRICTED_TASK_CONFIG, so the two decisions cannot drift apart.
+uses_restricted_pi_lane() {
+  local harness=$1 kind=$2 model=$3
+  [ "$harness" = pi ] && [ "$kind" != secondmate ] && pi_restricted_model "$model"
+}
+
 # The verified launch command per adapter. The knowledge half of each adapter
 # (busy signature, exit command, dialogs, quirks) lives in the harness-adapters skill.
 launch_template() {
@@ -356,7 +365,7 @@ launch_template() {
     pi)
       if [ "$kind" = secondmate ]; then
         printf '%s' 'pi __MODELFLAG____EFFORTFLAG__-e __PITURNEND__ -e __PIWATCH__ "$(cat __BRIEF__)"'
-      elif pi_restricted_model "$model"; then
+      elif uses_restricted_pi_lane "$harness" "$kind" "$model"; then
         printf '%s' 'pi __MODELFLAG____EFFORTFLAG__--no-builtin-tools --tools public_fetch,write_report,append_status,complete_scout --no-context-files --no-skills --no-prompt-templates --no-extensions --no-session -e __PIEXT__ -e __PIRESTRICTED__ "$(cat __BRIEF__)"'
       else
         printf '%s' 'pi __MODELFLAG____EFFORTFLAG__-e __PIEXT__ "$(cat __BRIEF__)"'
@@ -1080,7 +1089,7 @@ sleep 0.3
 # output destinations through an env var rather than any model-controlled
 # input. Non-secret paths only (report path, status path, task id); never read
 # into this from the wider environment.
-if [ "$KIND" != secondmate ] && [ "$HARNESS" = pi ] && pi_restricted_model "$MODEL"; then
+if uses_restricted_pi_lane "$HARNESS" "$KIND" "$MODEL"; then
   restricted_config=$(printf '{"reportPath":"%s","statusPath":"%s","taskId":"%s"}' \
     "$(json_escape "$DATA/$ID/report.md")" \
     "$(json_escape "$STATE/$ID.status")" \

--- a/tests/fm-pi-restricted-tools.test.sh
+++ b/tests/fm-pi-restricted-tools.test.sh
@@ -152,6 +152,8 @@ const targets = [
   "https://[fe80::1]/x",                          // link-local IPv6
   "https://[fc00::1]/x",                          // unique-local IPv6
   "https://[::ffff:127.0.0.1]/x",                 // IPv4-mapped IPv6 loopback
+  "https://[64:ff9b::a9fe:a9fe]/x",               // NAT64-mapped cloud metadata (hex form)
+  "https://[64:ff9b::169.254.169.254]/x",         // NAT64-mapped cloud metadata (dotted form)
 ];
 for (const url of targets) {
   try {

--- a/tests/fm-pi-restricted-tools.test.sh
+++ b/tests/fm-pi-restricted-tools.test.sh
@@ -1,0 +1,448 @@
+#!/usr/bin/env bash
+# Adversarial and credential-canary tests for bin/fm-pi-restricted-tools.ts,
+# the restricted DeepSeek lane's only tool extension (see bin/fm-spawn.sh's
+# pi_restricted_model() and the harness-adapters skill).
+#
+# These import the real tracked extension file directly with Node
+# (`node --input-type=module`), the same pattern tests/fm-pi-watch-extension.test.sh
+# uses: a minimal stub `pi` object captures registerTool() calls, then each
+# tool's execute() is invoked directly and asserted on. No real pi process or
+# LLM call is needed to prove the extension's own validation logic.
+#
+# Every rejection case here fails before any network connection is attempted
+# (bad scheme, localhost, or a forbidden IP address are all caught before the
+# request is ever made), so this file needs no network access and is safe to
+# run in CI. A successful public fetch and redirect-following were verified
+# manually against a real HTTPS endpoint; see the harness-adapters skill.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+EXT="$ROOT/bin/fm-pi-restricted-tools.ts"
+TMP_ROOT=$(fm_test_tmproot fm-pi-restricted-tools)
+# Node warns about loading a tracked extension with no local package.json;
+# unrelated to the assertions below, which only care about tool behavior.
+export NODE_NO_WARNINGS=1
+
+install_stub_node_modules() {
+  local dir=$1
+  mkdir -p "$dir/node_modules/typebox" "$dir/node_modules/@earendil-works/pi-ai"
+  cat > "$dir/node_modules/typebox/package.json" <<'JSON'
+{"name":"typebox","type":"module","exports":"./index.js"}
+JSON
+  cat > "$dir/node_modules/typebox/index.js" <<'JS'
+export const Type = {
+  Object(properties) { return { type: "object", properties }; },
+  String() { return { type: "string" }; },
+  Boolean() { return { type: "boolean" }; },
+};
+JS
+  cat > "$dir/node_modules/@earendil-works/pi-ai/package.json" <<'JSON'
+{"name":"@earendil-works/pi-ai","type":"module","exports":"./index.js"}
+JSON
+  cat > "$dir/node_modules/@earendil-works/pi-ai/index.js" <<'JS'
+export function StringEnum(values) { return { type: "string", enum: values }; }
+JS
+}
+
+# Copies the real tracked extension next to a stub node_modules (module
+# resolution for typebox/pi-ai walks up from the imported file's own
+# location), and a fixture config pointing at this case's own report/status
+# paths, then echoes "<case_dir>|<plugin_path>|<report_path>|<status_path>".
+make_case() {
+  local name=$1 case_dir plugin report status
+  case_dir="$TMP_ROOT/$name"
+  mkdir -p "$case_dir"
+  install_stub_node_modules "$case_dir"
+  plugin="$case_dir/ext.ts"
+  cp "$EXT" "$plugin"
+  report="$case_dir/report.md"
+  status="$case_dir/status.log"
+  printf '%s\n' "$case_dir|$plugin|$report|$status"
+}
+
+read_case() {
+  # shellcheck disable=SC2034  # CASE_DIR is part of the destructured record shape, unused here
+  IFS='|' read -r CASE_DIR PLUGIN REPORT STATUS <<EOF
+$1
+EOF
+}
+
+restricted_config() {
+  printf '{"reportPath":"%s","statusPath":"%s","taskId":"canary-task"}' "$REPORT" "$STATUS"
+}
+
+run_node() {  # <script-heredoc-on-stdin> [extra env "NAME=value" ...]
+  local rec=$1
+  shift
+  read_case "$rec"
+  env "$@" FM_RESTRICTED_TASK_CONFIG="$(restricted_config)" PLUGIN="$PLUGIN" \
+    node --input-type=module
+}
+
+test_extension_registers_exactly_four_tools() {
+  local rec out status
+  rec=$(make_case four-tools)
+  out=$(run_node "$rec" <<'EOF'
+import { pathToFileURL } from "node:url";
+const tools = {};
+const pi = { registerTool(t) { tools[t.name] = t; } };
+const mod = await import(pathToFileURL(process.env.PLUGIN).href);
+mod.default(pi);
+const names = Object.keys(tools).sort();
+const expected = ["append_status", "complete_scout", "public_fetch", "write_report"];
+if (JSON.stringify(names) !== JSON.stringify(expected)) {
+  throw new Error(`expected exactly ${expected}, got ${names}`);
+}
+EOF
+)
+  status=$?
+  expect_code 0 "$status" "extension must register exactly the four scoped tools"
+  [ -z "$out" ] || fail "unexpected output: $out"
+  pass "restricted extension registers exactly public_fetch, write_report, append_status, complete_scout"
+}
+
+test_public_fetch_rejects_non_https_scheme() {
+  local rec out status
+  rec=$(make_case reject-scheme)
+  out=$(run_node "$rec" <<'EOF'
+import { pathToFileURL } from "node:url";
+const tools = {};
+const pi = { registerTool(t) { tools[t.name] = t; } };
+const mod = await import(pathToFileURL(process.env.PLUGIN).href);
+mod.default(pi);
+try {
+  await tools.public_fetch.execute("c", { url: "http://example.com" });
+  throw new Error("did not reject a plain http URL");
+} catch (e) {
+  if (!/https/i.test(e.message)) throw new Error(`wrong rejection reason: ${e.message}`);
+}
+try {
+  await tools.public_fetch.execute("c", { url: "file:///etc/passwd" });
+  throw new Error("did not reject a file:// URL");
+} catch (e) {
+  if (!/https/i.test(e.message)) throw new Error(`wrong rejection reason: ${e.message}`);
+}
+EOF
+)
+  status=$?
+  expect_code 0 "$status" "public_fetch must reject non-https schemes before any connection"
+  [ -z "$out" ] || fail "unexpected output: $out"
+  pass "public_fetch structurally rejects http:// and file:// targets"
+}
+
+test_public_fetch_rejects_localhost_and_forbidden_addresses() {
+  local rec out status
+  rec=$(make_case reject-addresses)
+  out=$(run_node "$rec" <<'EOF'
+import { pathToFileURL } from "node:url";
+const tools = {};
+const pi = { registerTool(t) { tools[t.name] = t; } };
+const mod = await import(pathToFileURL(process.env.PLUGIN).href);
+mod.default(pi);
+const targets = [
+  "https://localhost/x",
+  "https://127.0.0.1/x",
+  "https://169.254.169.254/latest/meta-data/",   // cloud metadata
+  "https://10.0.0.5/x",                           // RFC1918
+  "https://172.16.0.5/x",                         // RFC1918
+  "https://192.168.1.5/x",                        // RFC1918
+  "https://[::1]/x",                              // loopback IPv6
+  "https://[fe80::1]/x",                          // link-local IPv6
+  "https://[fc00::1]/x",                          // unique-local IPv6
+  "https://[::ffff:127.0.0.1]/x",                 // IPv4-mapped IPv6 loopback
+];
+for (const url of targets) {
+  try {
+    await tools.public_fetch.execute("c", { url });
+    throw new Error(`did not reject forbidden target: ${url}`);
+  } catch (e) {
+    if (/did not reject/.test(e.message)) throw e;
+  }
+}
+EOF
+)
+  status=$?
+  expect_code 0 "$status" "public_fetch must reject every private/loopback/link-local/metadata address, IPv4 and IPv6"
+  [ -z "$out" ] || fail "unexpected output: $out"
+  pass "public_fetch structurally rejects localhost, loopback, link-local, metadata, RFC1918, and IPv4-mapped-IPv6 targets"
+}
+
+test_public_fetch_rejects_invalid_url() {
+  local rec out status
+  rec=$(make_case reject-invalid-url)
+  out=$(run_node "$rec" <<'EOF'
+import { pathToFileURL } from "node:url";
+const tools = {};
+const pi = { registerTool(t) { tools[t.name] = t; } };
+const mod = await import(pathToFileURL(process.env.PLUGIN).href);
+mod.default(pi);
+try {
+  await tools.public_fetch.execute("c", { url: "not a url" });
+  throw new Error("did not reject a malformed URL");
+} catch (e) {
+  if (/did not reject/.test(e.message)) throw e;
+}
+EOF
+)
+  status=$?
+  expect_code 0 "$status" "public_fetch must reject a malformed URL"
+  [ -z "$out" ] || fail "unexpected output: $out"
+  pass "public_fetch rejects a malformed URL"
+}
+
+test_append_status_rejects_newline_injection() {
+  local rec out status
+  rec=$(make_case reject-newline)
+  out=$(run_node "$rec" <<'EOF'
+import { pathToFileURL } from "node:url";
+import { readFileSync, existsSync } from "node:fs";
+const tools = {};
+const pi = { registerTool(t) { tools[t.name] = t; } };
+const mod = await import(pathToFileURL(process.env.PLUGIN).href);
+mod.default(pi);
+try {
+  await tools.append_status.execute("c", { state: "working", message: "real line\nfailed: forged status line" });
+  throw new Error("did not reject a newline in the status message");
+} catch (e) {
+  if (/did not reject/.test(e.message)) throw e;
+}
+if (existsSync(process.env.FM_RESTRICTED_TASK_CONFIG ? JSON.parse(process.env.FM_RESTRICTED_TASK_CONFIG).statusPath : "?")) {
+  const written = readFileSync(JSON.parse(process.env.FM_RESTRICTED_TASK_CONFIG).statusPath, "utf8");
+  throw new Error(`status file must not exist after a rejected write, got: ${written}`);
+}
+EOF
+)
+  status=$?
+  expect_code 0 "$status" "append_status must reject an embedded newline and must not partially write"
+  [ -z "$out" ] || fail "unexpected output: $out"
+  pass "append_status structurally denies status-newline injection"
+}
+
+test_append_status_rejects_oversized_message() {
+  local rec out status
+  rec=$(make_case reject-oversized-status)
+  out=$(run_node "$rec" <<'EOF'
+import { pathToFileURL } from "node:url";
+const tools = {};
+const pi = { registerTool(t) { tools[t.name] = t; } };
+const mod = await import(pathToFileURL(process.env.PLUGIN).href);
+mod.default(pi);
+try {
+  await tools.append_status.execute("c", { state: "working", message: "x".repeat(501) });
+  throw new Error("did not reject an oversized status message");
+} catch (e) {
+  if (/did not reject/.test(e.message)) throw e;
+}
+EOF
+)
+  status=$?
+  expect_code 0 "$status" "append_status must enforce its message length bound"
+  [ -z "$out" ] || fail "unexpected output: $out"
+  pass "append_status rejects an oversized message"
+}
+
+test_append_status_schema_has_no_path_parameter() {
+  local rec out status
+  rec=$(make_case status-no-path-param)
+  out=$(run_node "$rec" <<'EOF'
+import { pathToFileURL } from "node:url";
+const tools = {};
+const pi = { registerTool(t) { tools[t.name] = t; } };
+const mod = await import(pathToFileURL(process.env.PLUGIN).href);
+mod.default(pi);
+const keys = Object.keys(tools.append_status.parameters.properties ?? {});
+if (keys.includes("path") || keys.includes("statusPath") || keys.includes("file")) {
+  throw new Error(`append_status schema exposes a path-like parameter: ${keys}`);
+}
+const enumValues = tools.append_status.parameters.properties.state.enum;
+const expected = ["working", "needs-decision", "blocked", "paused", "done", "failed"];
+if (JSON.stringify(enumValues) !== JSON.stringify(expected)) {
+  throw new Error(`unexpected allowed status states: ${JSON.stringify(enumValues)}`);
+}
+EOF
+)
+  status=$?
+  expect_code 0 "$status" "append_status must never accept a model-controlled destination"
+  [ -z "$out" ] || fail "unexpected output: $out"
+  pass "append_status's schema has no path parameter and a closed status-state enum"
+}
+
+test_write_report_rejects_oversized_content() {
+  local rec out status
+  rec=$(make_case reject-oversized-report)
+  out=$(run_node "$rec" <<'EOF'
+import { pathToFileURL } from "node:url";
+import { existsSync } from "node:fs";
+const tools = {};
+const pi = { registerTool(t) { tools[t.name] = t; } };
+const mod = await import(pathToFileURL(process.env.PLUGIN).href);
+mod.default(pi);
+try {
+  await tools.write_report.execute("c", { content: "x".repeat(200_001) });
+  throw new Error("did not reject an oversized report");
+} catch (e) {
+  if (/did not reject/.test(e.message)) throw e;
+}
+if (existsSync(JSON.parse(process.env.FM_RESTRICTED_TASK_CONFIG).reportPath)) {
+  throw new Error("report file must not exist after a rejected oversized write");
+}
+EOF
+)
+  status=$?
+  expect_code 0 "$status" "write_report must enforce its size bound and not partially write"
+  [ -z "$out" ] || fail "unexpected output: $out"
+  pass "write_report rejects oversized content without writing"
+}
+
+test_write_report_schema_has_no_path_parameter() {
+  local rec out status
+  rec=$(make_case report-no-path-param)
+  out=$(run_node "$rec" <<'EOF'
+import { pathToFileURL } from "node:url";
+const tools = {};
+const pi = { registerTool(t) { tools[t.name] = t; } };
+const mod = await import(pathToFileURL(process.env.PLUGIN).href);
+mod.default(pi);
+const keys = Object.keys(tools.write_report.parameters.properties ?? {});
+if (keys.length !== 1 || keys[0] !== "content") {
+  throw new Error(`write_report schema must accept only content, got: ${keys}`);
+}
+EOF
+)
+  status=$?
+  expect_code 0 "$status" "write_report must never accept a model-controlled path"
+  [ -z "$out" ] || fail "unexpected output: $out"
+  pass "write_report's schema accepts only report content, never a path"
+}
+
+test_complete_scout_true_terminates_without_shelling_out() {
+  local rec out status
+  rec=$(make_case complete-scout-true)
+  out=$(run_node "$rec" <<'EOF'
+import { pathToFileURL } from "node:url";
+import { readFileSync } from "node:fs";
+const tools = {};
+const pi = { registerTool(t) { tools[t.name] = t; } };
+const mod = await import(pathToFileURL(process.env.PLUGIN).href);
+mod.default(pi);
+const result = await tools.complete_scout.execute("c", { unresolvedDecision: true, summary: "captain must choose X or Y" });
+if (result.terminate !== true) throw new Error("declaring an unresolved decision must terminate the run");
+const statusPath = JSON.parse(process.env.FM_RESTRICTED_TASK_CONFIG).statusPath;
+const written = readFileSync(statusPath, "utf8");
+if (written !== "needs-decision: captain must choose X or Y\n") {
+  throw new Error(`unexpected status content: ${JSON.stringify(written)}`);
+}
+EOF
+)
+  status=$?
+  expect_code 0 "$status" "complete_scout(true) must record needs-decision and terminate, never self-resolve"
+  [ -z "$out" ] || fail "unexpected output: $out"
+  pass "complete_scout stops for firstmate on a discovered decision instead of self-resolving"
+}
+
+test_complete_scout_false_does_not_auto_write_status() {
+  local rec out status
+  rec=$(make_case complete-scout-false)
+  out=$(run_node "$rec" <<'EOF'
+import { pathToFileURL } from "node:url";
+import { existsSync } from "node:fs";
+const tools = {};
+const pi = { registerTool(t) { tools[t.name] = t; } };
+const mod = await import(pathToFileURL(process.env.PLUGIN).href);
+mod.default(pi);
+const result = await tools.complete_scout.execute("c", { unresolvedDecision: false, summary: "all good" });
+if (result.terminate) throw new Error("a clean completion must not terminate before write_report/append_status run");
+if (existsSync(JSON.parse(process.env.FM_RESTRICTED_TASK_CONFIG).statusPath)) {
+  throw new Error("complete_scout(false) must not write status itself");
+}
+EOF
+)
+  status=$?
+  expect_code 0 "$status" "complete_scout(false) must hand control back for write_report/append_status, not auto-finish"
+  [ -z "$out" ] || fail "unexpected output: $out"
+  pass "complete_scout(false) requires the model to still write the report and status itself"
+}
+
+test_missing_task_config_refuses_to_load() {
+  local rec out status
+  rec=$(make_case missing-config)
+  read_case "$rec"
+  out=$(env PLUGIN="$PLUGIN" node --input-type=module 2>&1 <<'EOF'
+import { pathToFileURL } from "node:url";
+try {
+  const mod = await import(pathToFileURL(process.env.PLUGIN).href);
+  mod.default({ registerTool() {} });
+  console.log("FAIL: loaded without FM_RESTRICTED_TASK_CONFIG");
+} catch (e) {
+  console.log(`refused: ${e.message}`);
+}
+EOF
+)
+  status=$?
+  expect_code 0 "$status" "node harness itself must not crash"
+  assert_contains "$out" "refused:" "extension must refuse to load without its trusted task config"
+  assert_not_contains "$out" "FAIL" "extension must not silently proceed without a trusted destination"
+  pass "the extension refuses to load at all when FM_RESTRICTED_TASK_CONFIG is absent"
+}
+
+test_credential_canary_no_leak_into_tool_metadata() {
+  local rec out status
+  rec=$(make_case credential-canary)
+  out=$(run_node "$rec" FM_SECRET_CANARY=sk-canary-0123456789abcdef <<'EOF'
+import { pathToFileURL } from "node:url";
+const tools = {};
+const pi = { registerTool(t) { tools[t.name] = t; } };
+const mod = await import(pathToFileURL(process.env.PLUGIN).href);
+mod.default(pi);
+const dump = JSON.stringify(Object.values(tools).map((t) => ({
+  name: t.name,
+  description: t.description,
+  promptSnippet: t.promptSnippet,
+  promptGuidelines: t.promptGuidelines,
+  parameters: t.parameters,
+})));
+const canary = process.env.FM_SECRET_CANARY;
+if (dump.includes(canary)) throw new Error("tool metadata leaked the credential canary");
+try {
+  await tools.public_fetch.execute("c", { url: "not a url " + canary });
+  throw new Error("expected rejection");
+} catch (e) {
+  if (e.message.includes(canary)) throw new Error(`error message leaked the credential canary: ${e.message}`);
+}
+EOF
+)
+  status=$?
+  expect_code 0 "$status" "no ambient credential value may reach tool metadata or error messages"
+  [ -z "$out" ] || fail "unexpected output: $out"
+  pass "no ambient environment credential leaks into tool schemas, descriptions, or error messages"
+}
+
+test_extension_source_never_shells_out_or_reads_wider_environment() {
+  local text env_refs
+  text=$(cat "$EXT")
+  assert_not_contains "$text" "pi.exec" "restricted extension must never shell out"
+  assert_not_contains "$text" "child_process" "restricted extension must never shell out"
+  assert_contains "$text" "process.env.FM_RESTRICTED_TASK_CONFIG" "restricted extension must read its trusted config the one documented way"
+  env_refs=$(grep -oE 'process\.env\.[A-Z_]+' "$EXT" | sort -u)
+  [ "$env_refs" = "process.env.FM_RESTRICTED_TASK_CONFIG" ] || fail "restricted extension reads more environment variables than the one documented FM_RESTRICTED_TASK_CONFIG: $env_refs"
+  pass "the restricted extension's source never shells out and reads only its one documented env var"
+}
+
+test_extension_registers_exactly_four_tools
+test_public_fetch_rejects_non_https_scheme
+test_public_fetch_rejects_localhost_and_forbidden_addresses
+test_public_fetch_rejects_invalid_url
+test_append_status_rejects_newline_injection
+test_append_status_rejects_oversized_message
+test_append_status_schema_has_no_path_parameter
+test_write_report_rejects_oversized_content
+test_write_report_schema_has_no_path_parameter
+test_complete_scout_true_terminates_without_shelling_out
+test_complete_scout_false_does_not_auto_write_status
+test_missing_task_config_refuses_to_load
+test_credential_canary_no_leak_into_tool_metadata
+test_extension_source_never_shells_out_or_reads_wider_environment
+
+echo "# all fm-pi-restricted-tools tests passed"

--- a/tests/fm-spawn-pi-restricted.test.sh
+++ b/tests/fm-spawn-pi-restricted.test.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+# Tests for the restricted direct-DeepSeek Pi launch lane (bin/fm-spawn.sh's
+# pi_restricted_model()) and its tracked tool extension
+# (bin/fm-pi-restricted-tools.ts).
+#
+# Launch-construction tests drive fm-spawn through meta writing with a fake
+# tmux pane and a real isolated git worktree, mirroring
+# tests/fm-spawn-dispatch-profile.test.sh. The fake tmux captures both the
+# literal launch command (`send-keys -l`) and the plain text-line sends
+# (`send-keys -t <target> <text> Enter`, used for the GOTMPDIR and
+# FM_RESTRICTED_TASK_CONFIG exports), so both the launch string and the
+# per-spawn config env var can be asserted on without starting any real harness.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SPAWN="$ROOT/bin/fm-spawn.sh"
+EXT="$ROOT/bin/fm-pi-restricted-tools.ts"
+TMP_ROOT=$(fm_test_tmproot fm-spawn-pi-restricted)
+RESTRICTED_MODEL="deepseek/deepseek-v4-pro"
+
+make_spawn_fakebin() {
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+esac
+case "${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+  list-windows) exit 0 ;;
+  has-session|new-session|new-window|kill-window) exit 0 ;;
+  send-keys)
+    if [ -n "${FM_FAKE_LAUNCH_LOG:-}" ]; then
+      prev=
+      for a in "$@"; do
+        if [ "$prev" = "-l" ]; then
+          printf '%s\n' "$a" >> "$FM_FAKE_LAUNCH_LOG"
+        fi
+        prev=$a
+      done
+    fi
+    if [ -n "${FM_FAKE_TEXTLINE_LOG:-}" ]; then
+      case "$*" in
+        *' -l '*) : ;;
+        *) printf '%s\n' "$4" >> "$FM_FAKE_TEXTLINE_LOG" ;;
+      esac
+    fi
+    exit 0
+    ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" treehouse
+  printf '%s\n' "$fakebin"
+}
+
+make_spawn_case() {
+  local name=$1 harness=$2 case_dir home proj wt fakebin launchlog textlog id
+  shift 2
+  case_dir="$TMP_ROOT/$name"
+  home="$case_dir/home"
+  proj="$case_dir/project"
+  wt="$case_dir/wt"
+  launchlog="$case_dir/launch.log"
+  textlog="$case_dir/textline.log"
+  fakebin=$(make_spawn_fakebin "$case_dir/fake")
+  mkdir -p "$home/data" "$home/projects" "$home/state" "$home/config"
+  printf '%s\n' "$harness" > "$home/config/crew-harness"
+  fm_git_worktree "$proj" "$wt" "wt-$name"
+  touch "$home/state/.last-watcher-beat"
+  for id in "$@"; do
+    mkdir -p "$home/data/$id"
+    printf 'brief for %s\n' "$id" > "$home/data/$id/brief.md"
+  done
+  printf '%s\n' "$case_dir|$home|$proj|$wt|$fakebin|$launchlog|$textlog"
+}
+
+run_spawn() {
+  local home=$1 wt=$2 fakebin=$3 launchlog=$4 textlog=$5
+  shift 5
+  : > "$launchlog"
+  : > "$textlog"
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
+    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" TMUX="fake,1,0" \
+    FM_FAKE_LAUNCH_LOG="$launchlog" FM_FAKE_TEXTLINE_LOG="$textlog" \
+    PATH="$fakebin:$PATH" \
+    "$SPAWN" "$@" 2>&1
+}
+
+read_case_record() {
+  IFS='|' read -r CASE_DIR HOME_DIR PROJ_DIR WT_DIR FAKEBIN_DIR LAUNCH_LOG TEXT_LOG <<EOF
+$1
+EOF
+}
+
+test_pi_restricted_model_gets_restricted_launch_and_config_env() {
+  local rec id out status launch textlines config_line
+  id=pi-restricted-ship-z1
+  rec=$(make_spawn_case restricted-ship pi "$id")
+  read_case_record "$rec"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$TEXT_LOG" "$id" "$PROJ_DIR" --model "$RESTRICTED_MODEL")
+  status=$?
+  expect_code 0 "$status" "restricted-model pi ship spawn should succeed"
+  assert_grep "model=$RESTRICTED_MODEL" "$HOME_DIR/state/$id.meta" "meta missing restricted model"
+
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "pi --model '$RESTRICTED_MODEL' --no-builtin-tools --tools public_fetch,write_report,append_status,complete_scout --no-context-files --no-skills --no-prompt-templates --no-extensions --no-session -e " \
+    "restricted pi launch is missing the structural lockdown flags"
+  assert_contains "$launch" "$HOME_DIR/state/$id.pi-ext.ts" "restricted pi launch dropped the trusted turn-end extension"
+  assert_contains "$launch" "$ROOT/bin/fm-pi-restricted-tools.ts" "restricted pi launch dropped the tracked restricted-tools extension"
+  assert_not_contains "$launch" "read_task_file" "restricted pi launch allowlists a tool that was never registered"
+
+  textlines=$(cat "$TEXT_LOG")
+  assert_contains "$textlines" "export GOTMPDIR=" "restricted pi spawn dropped the ordinary GOTMPDIR export"
+  config_line=$(printf '%s\n' "$textlines" | grep '^export FM_RESTRICTED_TASK_CONFIG=' || true)
+  [ -n "$config_line" ] || fail "restricted pi spawn did not export FM_RESTRICTED_TASK_CONFIG"
+  assert_contains "$config_line" "\"taskId\":\"$id\"" "restricted task config missing taskId"
+  assert_contains "$config_line" "\"reportPath\":\"$HOME_DIR/data/$id/report.md\"" "restricted task config missing reportPath"
+  assert_contains "$config_line" "\"statusPath\":\"$HOME_DIR/state/$id.status\"" "restricted task config missing statusPath"
+  pass "restricted DeepSeek model gets the structurally locked-down pi launch and its trusted config env"
+}
+
+test_pi_restricted_model_also_applies_to_scout() {
+  local rec id out status launch
+  id=pi-restricted-scout-z2
+  rec=$(make_spawn_case restricted-scout pi "$id")
+  read_case_record "$rec"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$TEXT_LOG" "$id" "$PROJ_DIR" --model "$RESTRICTED_MODEL" --scout)
+  status=$?
+  expect_code 0 "$status" "restricted-model pi scout spawn should succeed"
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "--no-builtin-tools" "scout kind did not get the restricted lane"
+  pass "restricted DeepSeek model also locks down a scout spawn, not only ship"
+}
+
+test_pi_non_restricted_model_keeps_ordinary_launch() {
+  local rec id out status launch textlines
+  id=pi-ordinary-z3
+  rec=$(make_spawn_case ordinary pi "$id")
+  read_case_record "$rec"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$TEXT_LOG" "$id" "$PROJ_DIR" --model openai-codex/gpt-5.6-sol)
+  status=$?
+  expect_code 0 "$status" "ordinary pi model spawn should succeed"
+  launch=$(cat "$LAUNCH_LOG")
+  expected="pi --model 'openai-codex/gpt-5.6-sol' -e '$HOME_DIR/state/$id.pi-ext.ts' \"\$(cat '$HOME_DIR/data/$id/brief.md')\""
+  [ "$launch" = "$expected" ] || fail "ordinary pi launch changed for a non-restricted model"$'\n'"expected: $expected"$'\n'"actual:   $launch"
+  textlines=$(cat "$TEXT_LOG")
+  assert_not_contains "$textlines" "FM_RESTRICTED_TASK_CONFIG" "ordinary pi spawn should not export the restricted task config"
+  pass "a non-restricted model keeps the ordinary unrestricted pi crewmate launch byte-identical"
+}
+
+test_pi_no_model_keeps_ordinary_launch() {
+  local rec id out status launch
+  id=pi-nomodel-z4
+  rec=$(make_spawn_case nomodel pi "$id")
+  read_case_record "$rec"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$TEXT_LOG" "$id" "$PROJ_DIR")
+  status=$?
+  expect_code 0 "$status" "pi spawn with no --model should succeed"
+  launch=$(cat "$LAUNCH_LOG")
+  assert_not_contains "$launch" "--no-builtin-tools" "a spawn with no model at all must never get the restricted lane"
+  pass "no --model at all keeps the ordinary pi crewmate launch"
+}
+
+test_pi_secondmate_ignores_restricted_model_name() {
+  local rec id out status launch sm
+  id=pi-restricted-secondmate-z5
+  rec=$(make_spawn_case restricted-secondmate pi "$id")
+  read_case_record "$rec"
+  sm="$CASE_DIR/secondmate-home"
+  mkdir -p "$sm/bin" "$sm/data"
+  printf '# Firstmate\n' > "$sm/AGENTS.md"
+  printf '%s\n' "$id" > "$sm/.fm-secondmate-home"
+  printf 'charter for %s\n' "$id" > "$sm/data/charter.md"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$TEXT_LOG" "$id" "$sm" --model "$RESTRICTED_MODEL" --secondmate)
+  status=$?
+  expect_code 0 "$status" "secondmate spawn naming the restricted model string should still succeed"
+  assert_contains "$out" "spawned $id harness=pi kind=secondmate" "secondmate spawn output did not confirm secondmate kind"
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "/.pi/extensions/fm-primary-turnend-guard.ts" "secondmate launch dropped its ordinary turn-end guard extension"
+  assert_contains "$launch" "/.pi/extensions/fm-primary-pi-watch.ts" "secondmate launch dropped its ordinary watch extension"
+  assert_not_contains "$launch" "--no-builtin-tools" "a secondmate must never get the restricted crewmate lane, even naming the same model string"
+  pass "kind=secondmate never enters the restricted lane, even when --model matches the restricted allowlist"
+}
+
+test_restricted_tools_extension_is_tracked_and_shell_free() {
+  local text
+  assert_present "$EXT" "tracked restricted-tools pi extension is missing"
+  text=$(cat "$EXT")
+  assert_contains "$text" 'name: "public_fetch"' "restricted extension missing public_fetch tool"
+  assert_contains "$text" 'name: "write_report"' "restricted extension missing write_report tool"
+  assert_contains "$text" 'name: "append_status"' "restricted extension missing append_status tool"
+  assert_contains "$text" 'name: "complete_scout"' "restricted extension missing complete_scout tool"
+  assert_contains "$text" "FM_RESTRICTED_TASK_CONFIG" "restricted extension does not read its trusted per-spawn config"
+  assert_contains "$text" "terminate: true" "restricted extension's decision gate does not terminate on an unresolved decision"
+  assert_not_contains "$text" "pi.exec" "restricted extension must never shell out"
+  assert_not_contains "$text" "child_process" "restricted extension must never shell out"
+  assert_not_contains "$text" "node:child_process" "restricted extension must never shell out"
+  pass "the restricted-tools pi extension is a static tracked file exposing exactly the four scoped tools with no shell-out"
+}
+
+test_pi_restricted_model_allowlist_is_narrow() {
+  local text
+  text=$(cat "$ROOT/bin/fm-spawn.sh")
+  assert_contains "$text" 'deepseek/deepseek-v4-pro) return 0 ;;' "pi_restricted_model lost the verified DeepSeek model"
+  assert_not_contains "$text" "deepseek/deepseek-v4-flash" "pi_restricted_model added the flash model without a documented task-class justification"
+  pass "pi_restricted_model stays narrow to the one verified DeepSeek model"
+}
+
+test_pi_restricted_model_gets_restricted_launch_and_config_env
+test_pi_restricted_model_also_applies_to_scout
+test_pi_non_restricted_model_keeps_ordinary_launch
+test_pi_no_model_keeps_ordinary_launch
+test_pi_secondmate_ignores_restricted_model_name
+test_restricted_tools_extension_is_tracked_and_shell_free
+test_pi_restricted_model_allowlist_is_narrow
+
+echo "# all fm-spawn-pi-restricted tests passed"


### PR DESCRIPTION
## What Changed
- Added `bin/fm-pi-restricted-tools.ts`, a restricted tool surface for the new lane, including an SSRF-safe `public_fetch` guard that blocks private, link-local, and IPv4-mapped/NAT64-embedded IPv6 addresses.
- Wired `bin/fm-spawn.sh` to route Pi-native DeepSeek analysis tasks through this restricted lane, exporting `FM_RESTRICTED_TASK_CONFIG` behind a single consolidated guard condition instead of a duplicated check.
- Documented the new harness adapter in `.agents/skills/harness-adapters/SKILL.md` and added test coverage in `tests/fm-pi-restricted-tools.test.sh` and `tests/fm-spawn-pi-restricted.test.sh`.

## Risk Assessment

✅ Low: This commit correctly fixes both prior findings: isForbiddenIPv6 now generically expands any IPv6 address and rechecks the embedded IPv4 for all three embedding prefixes (IPv4-mapped, IPv4-compatible, and NAT64 64:ff9b::/96), verified by hand-tracing the parser against the metadata-address test cases added, and the restricted-lane guard condition is now a single shared predicate (uses_restricted_pi_lane) used identically at both call sites, eliminating the drift risk; the fallback behavior for unparseable addresses is unchanged so the fix is strictly additive with no regression.

## Testing

Completed 1 recorded test check.

- Outcome: ⚠️ 1 error across 1 run (38m0s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Rebase** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `.agents/skills/harness-adapters/SKILL.md` - merge conflict rebasing onto origin/main

🔧 Fix applied.
✅ Re-checked - no issues remain.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-pi-restricted-tools.ts:111` - isForbiddenIPv6() unwraps IPv4-mapped forms (::ffff:a.b.c.d / ::a.b.c.d) and re-checks the embedded IPv4 address, but does not do the same for the NAT64 well-known prefix 64:ff9b::/96, which also embeds an IPv4 address in its low 32 bits. On a network with NAT64 enabled (common on IPv6-only/CGNAT setups), a hostname that resolves to e.g. 64:ff9b::a9fe:a9fe would resolve the embedded 169.254.169.254 (cloud metadata) address, pass isForbiddenAddress unblocked (unrecognized-as-mapped, and not otherwise excluded by the ULA/link-local/multicast prefix checks), and let public_fetch reach it. This is the same class of bypass the ::ffff: handling was explicitly added to prevent, just via a different embedding prefix.
- ℹ️ `bin/fm-spawn.sh:1083` - The condition selecting the restricted DeepSeek lane is expressed twice: implicitly inside launch_template()&#39;s pi case (kind != secondmate via the preceding if, harness=pi via the outer case, pi_restricted_model &#34;$model&#34;) at lines 357-360, and explicitly again at line 1083 to decide whether to export FM_RESTRICTED_TASK_CONFIG. If the two conditions ever drift (e.g. the template gets a new kind exemption without updating line 1083), the failure mode is fail-safe (the extension refuses to run without config) rather than a security hole, but it&#39;s still worth consolidating into one predicate to avoid future drift.

🔧 Fix: Fix NAT64 IPv6 SSRF gap and dedupe restricted-lane guard
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Test** - 1 error</summary>

- 🚨 tests failed with exit code 1
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
