### PR TITLE
feat: verified Cursor harness + tmux/bootstrap Cursor liveness

### DIFF
--- a/.agents/skills/feature-cycle-throughput/SKILL.md
+++ b/.agents/skills/feature-cycle-throughput/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: feature-cycle-throughput
+description: >-
+  Agent-only playbook for finishing non-trivial ship work as fast as quality allows.
+  Use before intake or dispatch of authz, money, multi-iteration UI, or multi-decision product ships;
+  when stacking captain decisions onto a cursor (or other follow-up-queue) worker;
+  when the only next step is captain staging, sign-off, or merge;
+  and when scoping dual-tool UI verification to surfaces this tip actually changed.
+user-invocable: false
+metadata:
+  internal: true
+---
+
+# feature-cycle-throughput
+
+This skill is the single owner of Firstmate's feature-cycle throughput procedure.
+Captain priority: large features must complete as fast as quality allows so business experiments are not blocked.
+Hard delivery invariants still win - never merge without word, never violate project-specific unlock-on-spend or live-Stripe gates, and never discard unlanded work.
+
+Evidence: 2026-07-17 Inspect.Properties org-members + credits campaign (org-members PR #28, credits PR #29).
+Wall clock was dominated by serial product iterations, mid-flight A/B decisions, Cursor follow-up pile-ups, staging tip-deploy latency, and parked agents waiting on captain review - not by the first coding pass.
+
+## When to load
+
+Load before writing the brief or spawning for any non-trivial ship that touches authz, money, multi-iteration UI, or multi-decision product work.
+Load again when applying a batch of captain locks to a follow-up-queue harness, when parking a tip that only awaits captain sign-off, or when deciding whether a tip needs a fresh dual-tool UI pass.
+Skip for trivial one-shot fixes, docs-only, scout-only, or pure test-mock work unless the captain expands scope mid-flight.
+
+## Intake decision matrix
+
+Before the first ship spawn, lock the matrix below in the brief (or ask the captain once).
+Do not discover A/B product options inside review.
+
+Copy and fill:
+
+```text
+Feature-cycle intake matrix
+- Goal / experiment unlocked:
+- Authz (who can see / edit / spend / admin):
+- Editability (which fields mutable; who; when):
+- Money edge cases (packs, grants, refunds, legacy vs new, unlock-on-spend):
+- In scope this tip:
+- Explicitly out of scope:
+- PR slice plan (behavior-first vs craft follow-on):
+- Captain feedback loop (screenshots / local / one tip-deploy per round):
+- Hard streams already under way (avoid a second money/authz stream unless accepted):
+- Dual-tool surfaces this tip will change (chrome-devtools-axi + Playwright):
+```
+
+Ask the captain once when any cell is ambiguous.
+Prefer the path that unblocks the next captain experiment sooner without violating hard delivery invariants.
+
+## PR slicing (behavior vs craft)
+
+Prefer a behavior and authz PR green first.
+Ship visual craft as a follow-on PR, or as a clearly scoped second tip, when pixel polish matters.
+Do not reopen authz review on every layout tweak.
+If craft and behavior are inseparable for a safe ship, say so in the brief and keep the craft delta minimal.
+
+## UI feedback and tip-deploy batching
+
+Prefer one staging tip-deploy per captain feedback round.
+Use screenshots or local browser checks for pure layout when that is enough.
+Do not tip-redeploy after every micro-tweak unless the captain asked for a live redeploy.
+Batch accepted layout notes into one deploy, then wait for the next round.
+
+## Force-apply captain locks (follow-up queue)
+
+When the captain returns several decisions at once, force-apply them as one locked list.
+Never leave the same decisions stacked as unread follow-ups on a cursor (or any harness with a follow-up queue).
+
+Procedure:
+
+1. Interrupt the running turn (`Ctrl-C` on cursor; use the harness interrupt from `harness-adapters` for other adapters).
+2. If a follow-up panel is still open, dismiss it with `Esc` so the composer is clear.
+3. Send one `fm-send` message that lists every locked decision and the exact action for each.
+4. Confirm the worker is acting on that single locked list, not draining stale follow-ups.
+
+Cross-ref: `.agents/skills/harness-adapters/SKILL.md` cursor "Follow-up queue thrash" quirk for the adapter-local keystrokes.
+This skill owns the when-and-why; harness-adapters owns the keystroke facts.
+
+## Park when waiting on the captain
+
+If the only next step is captain staging review, sign-off, or merge approval:
+
+1. Record the tip SHA, PR or checklist URL, and what the captain must verify.
+2. Keep the branch and durable task records.
+3. Exit the worker or leave it truly idle without re-steering.
+4. Do not deep-inspect false wedge or stale signals from a deliberately parked pane.
+5. Resume only when the captain returns a decision or new work lands on that tip.
+
+An idle parked tip is healthy supervision, not a stuck worker.
+
+## Dual-tool scope
+
+Keep chrome-devtools-axi plus Playwright for user-visible UI or authz surfaces that this tip actually changed.
+Docs-only, test-mock-only, or pure review-fix commits do not need a fresh dual-tool pass.
+Vitest alone is not the ship bar for UI surfaces unless the captain explicitly waives live or browser verification for that task.
+Explore or repro with chrome-devtools-axi, then lock the finding in Playwright.
+
+## One hard stream
+
+Avoid running two high-risk money or authz PRs that both need frequent captain decisions at once.
+Serialize those streams unless the captain explicitly accepts the supervision tax.
+Independent low-risk tips may still run in parallel.
+
+## Token-efficiency notes
+
+Pay tokens where they buy wall-clock reduction: intake matrix, one locked decision send, one tip-deploy per feedback round.
+Do not pay tokens for: re-asking settled matrix cells, draining stacked follow-ups one by one, redeploying for every micro-tweak, or re-steering a parked tip that only awaits captain sign-off.
+Prefer short status outcomes over narrating internal supervision mechanics.
+When tradeoffs appear, prefer the path that unblocks the next captain experiment sooner without violating hard delivery invariants.

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -287,3 +287,38 @@ The adapter therefore runs the shared predicate and, when it returns 2, forces o
 It does not pass `--permission-mode`, so the passive hook cannot escalate the primary session's tool permissions.
 Project-local Grok hooks require folder trust, verified with launch-time `--trust`; if the primary firstmate checkout is not trusted for Grok hooks, this primary guard fails open and `fm-guard.sh` remains the next-command alarm.
 Grok's primary watcher protocol is Claude-shaped background-notify around `bin/fm-watch-arm.sh`; the passive Stop hook is only a backstop for blind turn ends.
+
+## cursor (VERIFIED 2026-07-05, cursor-agent 2026.07.01-41b2de7)
+
+Cursor Agent (`cursor-agent`), Cursor's Claude-Code-compatible CLI.
+Binary at `~/.local/bin/cursor-agent`; `~/.local/bin` must be on PATH for the spawn shell to find it.
+Launch with a positional prompt: `cursor-agent --force "$(cat <brief>)"`.
+
+| Fact | Value |
+|---|---|
+| Busy-pane signature | `ctrl+c to stop` (ASCII, in the footer while a turn runs, shown with a braille spinner + `N tokens`). Idle composer shows `→ Add a follow-up`. The ASCII `ctrl+c to stop` is the busy regex. |
+| Exit command | double `Ctrl-C`. On exit it prints `To resume this session: agent --resume=<id>`. A single `Ctrl-C` only interrupts the current turn. |
+| Interrupt | single `Ctrl-C` (stops the current turn; the footer's `ctrl+c to stop` clears back to `→ Add a follow-up`). |
+| Skill invocation | `/<skill>`, e.g. `/no-mistakes`. Opens the `/` slash-autocomplete popup (built-in commands like `/model`, `/plan` plus discovered skills such as `/no-mistakes`), so the same too-fast-Enter popup hazard as claude/grok applies; the shared submit retry handles it (see below). |
+| Autonomy | `--force` (alias `--yolo`, footer shows `Run Everything`); runs every tool without the per-command allowlist approval dialog. The targeted equivalent of claude's `--dangerously-skip-permissions`. |
+| Env marker | `CURSOR_AGENT=1` (also sets `CURSOR_INVOKED_AS=cursor-agent` and `CURSOR_CONVERSATION_ID`). IMPORTANT: cursor ALSO sets `CLAUDECODE=1` and `AI_AGENT=claude-code_*` (it is Claude-Code-compatible under the hood), so `bin/fm-harness.sh` checks `CURSOR_AGENT` BEFORE the claude marker; a claude-first check would misdetect a cursor session as claude. |
+| Resume | `cursor-agent --resume=<id>` (id printed on exit) or `--continue`. |
+| Model / effort | `--model <id>`; effort rides the model string as a bracket parameter, e.g. `--model 'claude-opus-4-8[effort=high]'`. `fm-spawn` folds a valid effort into that bracket; a model without bracket support ignores the parameter. |
+
+Trust dialog on first interactive launch per workspace: "Do you trust the contents of this directory?" with `[a] Trust this workspace` / `[q] Quit` (the selector defaults to Trust).
+Accept with Enter.
+The `--trust` flag exists but works only in `--print`/headless mode, so it cannot be used to pre-clear the interactive dialog; peek the pane after spawn and accept with `bin/fm-send.sh <window> --key Enter`.
+
+Submit hazard and its handling (verified 2026-07-05): a `/`-command or any steer sent via `fm-send` on the tmux backend submits cleanly.
+`fm_tmux_submit_core`'s cursor-row-read retry (`bin/fm-tmux-lib.sh`) recognizes the composer's post-submit empty state and does not false-retry; a plain steer landed and was processed on the first landed Enter, so no bespoke settle is needed.
+Cursor's idle `→ Add a follow-up` footer sits below the composer, not on the cursor row, so an idle cursor pane reads as an empty composer without a `FM_COMPOSER_IDLE_RE` override.
+
+Turn-end hook: none is wired.
+cursor-agent is Claude-Code-compatible but its interactive Stop/turn-end hook surface is unverified, so firstmate does not assume one and relies on the busy signature (provably-working check) plus stale-pane detection instead.
+
+## Follow-up queue thrash (cursor and similar)
+
+When captain decisions stack as unread follow-ups while a turn is running, do not leave them piled.
+Force-apply: single Ctrl-C to interrupt, Esc to dismiss the follow-up panel if it is open, then one locked `fm-send` list of decisions.
+Full procedure: `feature-cycle-throughput`.
+

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harness-adapters
-description: Agent-only reference for firstmate harness operations. Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter. Contains verified facts for claude, codex, opencode, pi, and grok.
+description: Agent-only reference for firstmate harness operations. Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter. Contains verified facts for claude, codex, opencode, pi, grok, and cursor.
 user-invocable: false
 metadata:
   internal: true
@@ -313,8 +313,13 @@ Submit hazard and its handling (verified 2026-07-05): a `/`-command or any steer
 `fm_tmux_submit_core`'s cursor-row-read retry (`bin/fm-tmux-lib.sh`) recognizes the composer's post-submit empty state and does not false-retry; a plain steer landed and was processed on the first landed Enter, so no bespoke settle is needed.
 Cursor's idle `→ Add a follow-up` footer sits below the composer, not on the cursor row, so an idle cursor pane reads as an empty composer without a `FM_COMPOSER_IDLE_RE` override.
 
-Turn-end hook: none is wired.
-cursor-agent is Claude-Code-compatible but its interactive Stop/turn-end hook surface is unverified, so firstmate does not assume one and relies on the busy signature (provably-working check) plus stale-pane detection instead.
+Crewmate turn-end hook: none is wired for per-task Cursor panes.
+cursor-agent's interactive Stop/turn-end surface for crewmates remains unverified, so firstmate relies on the busy signature (provably-working check) plus stale-pane detection for crew supervision.
+
+**Primary-session guard fact (wired 2026-07-17).**
+Tracked `.cursor/hooks.json` registers `stop` -> `bin/fm-cursor-stop.sh` (shared `fm-turnend-guard.sh`, exit 2 blocks once with `loop_limit: 1`) and `beforeShellExecution` -> `bin/fm-cursor-before-shell.sh` (arm + cd seatbelts).
+Primary watcher protocol is Claude-shaped background-notify: arm `bin/fm-watch-arm.sh` as its own Cursor Shell background task (`block_until_ms: 0`), never shell `&`.
+Rendered from `docs/supervision-protocols/cursor.md` by `bin/fm-supervision-instructions.sh`.
 
 ## Follow-up queue thrash (cursor and similar)
 

--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,0 +1,16 @@
+{
+  "version": 1,
+  "hooks": {
+    "beforeShellExecution": [
+      {
+        "command": "./bin/fm-cursor-before-shell.sh"
+      }
+    ],
+    "stop": [
+      {
+        "command": "./bin/fm-cursor-stop.sh",
+        "loop_limit": 1
+      }
+    ]
+  }
+}

--- a/.opencode/plugins/fm-primary-turnend-guard.js
+++ b/.opencode/plugins/fm-primary-turnend-guard.js
@@ -19,6 +19,7 @@ function runProcess(command, args, input = "") {
     child.stderr.on("data", (chunk) => {
       stderr += chunk.toString();
     });
+    child.stdin.on("error", () => {});
     child.on("error", () => resolve({ code: 0, stdout: "", stderr: "" }));
     child.on("close", (code) => resolve({ code: code ?? 0, stdout, stderr }));
     child.stdin.end(input);

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,7 +151,8 @@ A silent bootstrap section needs no action; for any printed actionable diagnosti
 ## 4. Harness and runtime dispatch
 
 Load `harness-adapters` before every spawn or recovery and before trust handling, skill invocation, interrupt, exit, resume, or adapter verification.
-The verified harnesses are `claude`, `codex`, `opencode`, `pi`, and `grok`; never dispatch on an unverified adapter.
+For non-trivial ship work (authz, money, multi-iteration UI, or multi-decision product), load `feature-cycle-throughput` and run its intake matrix before writing the brief or spawning.
+The verified harnesses are `claude`, `codex`, `opencode`, `pi`, `grok`, and `cursor`; never dispatch on an unverified adapter.
 If configured harness data names an unverified adapter, report it and fall back only to a verified adapter rather than launching it.
 
 `docs/configuration.md` owns dispatch-profile and runtime-backend schemas, `bin/fm-dispatch-select.sh` owns selector mechanics, `bin/fm-harness.sh` owns static resolution, and `bin/fm-spawn.sh` owns launch flags and fail-closed validation.
@@ -313,6 +314,7 @@ Scratch commits and debug edits never ride along, and a reproduced bug becomes t
 Fleet supervision is an always-loaded operational contract; `docs/architecture.md`, `docs/turnend-guard.md`, the emitted session-start block, and script help own mechanisms and harness-specific recipes.
 
 Whenever work is under way, keep exactly one live supervision cycle using the emitted protocol for this primary harness.
+When the only next step is captain staging, sign-off, or merge, load `feature-cycle-throughput` and park per that skill (do not keep a live idle agent waking supervision).
 X mode may require that same live cycle with no fleet work.
 Do not substitute another harness's wait shape, use shell `&`, or create a second cycle when a healthy one already exists.
 For every actionable wake, follow the ordinary-wake continuation in the emitted protocol; use its repair action only when the live cycle is missing or failed.
@@ -452,6 +454,7 @@ These skills are not captain-invocable; load them only at their precise triggers
 - `bootstrap-diagnostics` - load whenever the session-start digest's bootstrap section prints an actionable diagnostic line (`MISSING:`, `MISSING_MANUAL:`, `BACKEND_INVALID:`, `NEEDS_GH_AUTH`, `TANGLE:`, `CREW_DISPATCH: invalid`, `FLEET_SYNC:`, `PR_CHECK_MIGRATION:`, `SECONDMATE_SYNC:`, `SECONDMATE_LIVENESS:`, `NUDGE_SECONDMATES:`, or `FMX:`); silence and `BOOTSTRAP_INFO:` need no load.
 - `diagnostic-reasoning` - load before scoping a reported bug and before acting on a diagnostic report.
 - `harness-adapters` - load before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter.
+- `feature-cycle-throughput` - load before intake or dispatch of non-trivial ships (authz, money, multi-iteration UI, multi-decision product); when force-applying captain locks on a follow-up-queue harness; when parking a tip that only awaits captain sign-off; and when scoping dual-tool UI verification.
 - `firstmate-orca` - load before switching to Orca, spawning or supervising Orca-backed work, smoke-testing Orca backend behavior, debugging Orca task state, or reconciling Orca-backed task metadata.
 - `project-management` - load before adding, creating, removing, or initializing a project.
 - `stuck-crewmate-recovery` - load when the session-start digest reports an ordinary direct report's endpoint dead or its metadata has no window, or after a stale wake, looping pane, repeated confusion, an answered-by-brief question, an unresponsive crewmate, or a failed steer.

--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -143,8 +143,11 @@ fm_backend_tmux_current_command() {  # <target>
 # AGENTS.md's session-start guarantee closes). See docs/tmux-backend.md
 # "Agent liveness probe" for the empirical basis. Prints one of:
 #   alive   - the foreground command is one of the verified harness binaries
-#             (claude, codex, opencode, grok - each confirmed to run as its
-#             own process name, never wrapped by a generic interpreter).
+#             (claude, codex, opencode, grok, cursor-agent - each confirmed to
+#             run as its own process name, never wrapped by a generic
+#             interpreter). cursor-agent may also appear as MainThread or as
+#             argv0 `agent` (the ~/.local/bin/agent symlink); those shapes are
+#             confirmed via pane process args before counting as alive.
 #   dead    - the foreground command is a bare shell: nothing is running in
 #             the pane, so a prior agent process has exited.
 #   unknown - anything else, INCLUDING a bare "node"/"python" interpreter
@@ -154,13 +157,42 @@ fm_backend_tmux_current_command() {  # <target>
 #             pane. Callers must never treat unknown as a confirmed-dead
 #             signal (bin/fm-bootstrap.sh's secondmate-liveness sweep gates a
 #             respawn on `dead` only).
+fm_backend_tmux_pane_has_cursor_agent() {  # <target>
+  local target=$1 pid child
+  pid=$(tmux display-message -p -t "$target" '#{pane_pid}' 2>/dev/null) || return 1
+  [ -n "$pid" ] || return 1
+  # pane_pid is usually the login shell; cursor-agent is typically a descendant.
+  if ps -o args= -p "$pid" 2>/dev/null | grep -Eq 'cursor-agent|/cursor-agent|share/cursor-agent'; then
+    return 0
+  fi
+  while IFS= read -r child; do
+    [ -n "$child" ] || continue
+    if ps -o args= -p "$child" 2>/dev/null | grep -Eq 'cursor-agent|/cursor-agent|share/cursor-agent'; then
+      return 0
+    fi
+    if ps --ppid "$child" -o args= 2>/dev/null | grep -Eq 'cursor-agent|/cursor-agent|share/cursor-agent'; then
+      return 0
+    fi
+  done <<EOF
+$(ps --ppid "$pid" -o pid= 2>/dev/null)
+EOF
+  return 1
+}
+
 fm_backend_tmux_agent_alive() {  # <target>
   local target=$1 comm
   comm=$(fm_backend_tmux_current_command "$target") || { printf 'unknown'; return 0; }
   comm=${comm#-}
   case "$comm" in
     '') printf 'unknown' ;;
-    *claude*|*codex*|*opencode*|*grok*) printf 'alive' ;;
+    *claude*|*codex*|*opencode*|*grok*|*cursor-agent*) printf 'alive' ;;
+    MainThread|agent)
+      if fm_backend_tmux_pane_has_cursor_agent "$target"; then
+        printf 'alive'
+      else
+        printf 'unknown'
+      fi
+      ;;
     zsh|bash|sh|dash|ash|ksh|mksh|tcsh|csh|fish) printf 'dead' ;;
     *) printf 'unknown' ;;
   esac

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -400,7 +400,7 @@ secondmate_liveness_sweep() {
     [ -n "$target" ] || target="$window"
     verdict=$(fm_backend_agent_alive "$backend" "$target" 2>/dev/null) || verdict="unknown"
     case "$harness" in
-      claude|codex|opencode|pi|grok) ;;
+      claude|codex|opencode|pi|grok|cursor) ;;
       *) [ "$verdict" = dead ] && verdict=unknown ;;
     esac
     case "$verdict" in
@@ -655,7 +655,7 @@ crew_dispatch_validate() {
     return 0
   fi
   err=$(jq -r '
-    def verified($h): ["claude","codex","opencode","pi","grok"] | index($h);
+    def verified($h): ["claude","codex","opencode","pi","grok","cursor"] | index($h);
     def effort_ok($h; $e):
       if $e == null then true
       elif ($e | type) != "string" then false

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -428,6 +428,7 @@ install_cmd() {
     cmux) echo "brew install --cask cmux  # or see https://cmux.com" ;;
     treehouse) echo "curl -fsSL https://kunchenguid.github.io/treehouse/install.sh | sh" ;;
     no-mistakes) echo "curl -fsSL https://raw.githubusercontent.com/kunchenguid/no-mistakes/main/docs/install.sh | sh" ;;
+    cursor-agent) echo "curl https://cursor.com/install -fsS | bash  # installs cursor-agent" ;;
     gh-axi|chrome-devtools-axi|lavish-axi) echo "npm install -g $1 && $1 setup hooks" ;;
     tasks-axi|quota-axi) echo "npm install -g $1" ;;
     *) return 1 ;;
@@ -793,6 +794,17 @@ crew=
 [ -f "$CONFIG/crew-harness" ] && crew=$(tr -d '[:space:]' < "$CONFIG/crew-harness" || true)
 if [ "${FM_BOOTSTRAP_VERBOSE_FACTS:-0}" = 1 ] && [ -n "$crew" ] && [ "$crew" != "default" ]; then
   echo "BOOTSTRAP_INFO: crew harness override active: $crew"
+fi
+# When this home (or its crew override) runs cursor, cursor-agent must be on PATH.
+# Absent binary is a hard MISSING for cursor homes; other harnesses stay silent.
+own_harness=
+own_harness=$("$SCRIPT_DIR/fm-harness.sh" 2>/dev/null || true)
+effective_crew=$crew
+[ -n "$effective_crew" ] && [ "$effective_crew" != "default" ] || effective_crew=$own_harness
+if [ "$effective_crew" = "cursor" ] || [ "$own_harness" = "cursor" ]; then
+  if ! command -v cursor-agent >/dev/null 2>&1; then
+    missing_tool_diagnostic cursor-agent
+  fi
 fi
 crew_dispatch_validate
 if [ "${FM_BOOTSTRAP_VERBOSE_FACTS:-0}" = 1 ] \

--- a/bin/fm-cursor-before-shell.sh
+++ b/bin/fm-cursor-before-shell.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Cursor beforeShellExecution adapter for firstmate primary seatbelts.
+#
+# Cursor Hooks pass a JSON payload with .command (and related fields) on stdin
+# and expect a permission decision object on stdout. This wrapper extracts the
+# command, runs the shared arm + cd pretool checks with --claude (empty stdout
+# on deny so we control the Cursor response shape), and maps exit 2 into
+# Cursor's {permission:"deny", user_message, agent_message} object.
+#
+# Fail open on empty/malformed transport or missing jq - never wedge the shell.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ARM="$SCRIPT_DIR/fm-arm-pretool-check.sh"
+CD="$SCRIPT_DIR/fm-cd-pretool-check.sh"
+
+PAYLOAD=$(cat 2>/dev/null || true)
+[ -n "$PAYLOAD" ] || { printf '%s\n' '{"permission":"allow"}'; exit 0; }
+command -v jq >/dev/null 2>&1 || { printf '%s\n' '{"permission":"allow"}'; exit 0; }
+
+CMD=$(printf '%s' "$PAYLOAD" | jq -r '(.command // .tool_input.command // .toolInput.command // empty)' 2>/dev/null) || {
+  printf '%s\n' '{"permission":"allow"}'
+  exit 0
+}
+[ -n "$CMD" ] || { printf '%s\n' '{"permission":"allow"}'; exit 0; }
+
+deny_with() {
+  local reason=$1
+  jq -nc --arg reason "$reason" \
+    '{permission:"deny", user_message:$reason, agent_message:$reason}'
+  exit 0
+}
+
+arm_err=
+arm_rc=0
+arm_err=$("$ARM" --command "$CMD" --claude 2>&1 >/dev/null) || arm_rc=$?
+if [ "$arm_rc" -eq 2 ]; then
+  reason=$(printf '%s' "$arm_err" | jq -r '.reason // .message // empty' 2>/dev/null)
+  [ -n "$reason" ] || reason=$(printf '%s' "$arm_err" | tr '\n' ' ' | sed 's/[[:space:]]\+/ /g; s/^[[:space:]]*//; s/[[:space:]]*$//')
+  [ -n "$reason" ] || reason='Watcher arm must use a tracked Cursor Shell background task, not shell &.'
+  deny_with "$reason"
+fi
+
+cd_err=
+cd_rc=0
+cd_err=$("$CD" --command "$CMD" --claude 2>&1 >/dev/null) || cd_rc=$?
+if [ "$cd_rc" -eq 2 ]; then
+  reason=$(printf '%s' "$cd_err" | jq -r '.reason // .message // empty' 2>/dev/null)
+  [ -n "$reason" ] || reason=$(printf '%s' "$cd_err" | tr '\n' ' ' | sed 's/[[:space:]]\+/ /g; s/^[[:space:]]*//; s/[[:space:]]*$//')
+  [ -n "$reason" ] || reason='Do not cd the primary shell into a project clone or worktree.'
+  deny_with "$reason"
+fi
+
+printf '%s\n' '{"permission":"allow"}'
+exit 0

--- a/bin/fm-cursor-stop.sh
+++ b/bin/fm-cursor-stop.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Cursor stop-hook adapter for bin/fm-turnend-guard.sh.
+#
+# Cursor Hooks invoke this on agent stop. Exit 2 blocks the stop (Claude-shaped
+# direct block). When Cursor already re-entered stop because of a prior block
+# (loop_count / stop_hook_active), we allow the stop so the session cannot wedge.
+#
+# Fail open on empty stdin, missing jq, or guard allow - never wedge the primary.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GUARD="$SCRIPT_DIR/fm-turnend-guard.sh"
+
+PAYLOAD=$(cat 2>/dev/null || true)
+[ -n "$PAYLOAD" ] || exit 0
+command -v jq >/dev/null 2>&1 || exit 0
+
+# Normalize Cursor / Claude-shaped loop-guard fields into stop_hook_active.
+NORMALIZED=$(printf '%s' "$PAYLOAD" | jq -c '
+  . as $in
+  | (if (.stop_hook_active == true) then true
+     elif ((.loop_count // 0) | tonumber) > 0 then true
+     else false end) as $active
+  | ($in + {stop_hook_active: $active})
+' 2>/dev/null) || exit 0
+
+err=
+rc=0
+err=$(printf '%s' "$NORMALIZED" | "$GUARD" 2>&1 >/dev/null) || rc=$?
+[ "$rc" -eq 2 ] || exit 0
+
+# Prefer a followup nudge when Cursor accepts followup_message on stop; still
+# exit 2 so harnesses that only honor exit status also block once.
+reason=$(printf '%s' "$err" | tr '\n' ' ' | sed 's/[[:space:]]\+/ /g; s/^[[:space:]]*//; s/[[:space:]]*$//')
+[ -n "$reason" ] || reason='Tasks are in flight without a live watcher. Resume supervision with bin/fm-watch-arm.sh as its own Cursor Shell background task (block_until_ms: 0), then continue.'
+
+jq -nc --arg msg "$reason" '{followup_message: $msg}' 2>/dev/null || true
+exit 2

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Detect the agent harness this process tree runs on.
-# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|grok|unknown
+# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|grok|cursor|unknown
 #        fm-harness.sh crew             print the effective CREWMATE harness
 #                                        (config/crew-harness; "default" resolves to own)
 #        fm-harness.sh secondmate       print the harness the PRIMARY uses to launch
@@ -29,6 +29,10 @@ CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
 
 detect_own() {
   # Layer 1: environment markers for verified harnesses.
+  # cursor-agent ALSO sets CLAUDECODE=1 (it is Claude-Code-compatible under the
+  # hood), so CURSOR_AGENT must be checked BEFORE CLAUDECODE or a cursor session
+  # misdetects as claude (verified, cursor-agent 2026.07.01).
+  [ "${CURSOR_AGENT:-}" = "1" ] && { echo cursor; return; }
   [ "${CLAUDECODE:-}" = "1" ] && { echo claude; return; }
   [ "${PI_CODING_AGENT:-}" = "true" ] && { echo pi; return; }
   # grok sets GROK_AGENT=1 for its child/tool processes (verified, grok 0.2.73).
@@ -40,6 +44,7 @@ detect_own() {
   for _ in 1 2 3 4 5 6 7 8; do
     comm=$(ps -o comm= -p "$pid" 2>/dev/null) || break
     case "$(basename "$comm")" in
+      *cursor-agent*) echo cursor; return ;;
       *claude*) echo claude; return ;;
       *codex*) echo codex; return ;;
       *opencode*) echo opencode; return ;;
@@ -49,6 +54,7 @@ detect_own() {
         # Bare interpreter: match the harness name in its script path.
         args=$(ps -o args= -p "$pid" 2>/dev/null)
         case "$args" in
+          *cursor-agent*) echo cursor; return ;;
           *claude*) echo claude; return ;;
           *codex*) echo codex; return ;;
           *opencode*) echo opencode; return ;;

--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -14,21 +14,38 @@ STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 LOCK="$STATE/.lock"
 mkdir -p "$STATE"
 
-# Known harness command names; extend when a new adapter is verified.
-HARNESS_RE='claude|codex|opencode|grok|^pi$'
+# Match harness processes the same way fm-harness.sh walks ancestry: comm basename
+# first, then argv. cursor-agent often runs as comm=MainThread with cursor-agent in
+# args, so comm-only regex matching is not enough.
+fm_lock_process_is_harness() {
+  local pid=$1 comm args
+  comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
+  args=$(ps -o args= -p "$pid" 2>/dev/null)
+  case "$(basename "$comm")" in
+    *cursor-agent*) return 0 ;;
+    *claude*) return 0 ;;
+    *codex*) return 0 ;;
+    *opencode*) return 0 ;;
+    *grok*) return 0 ;;
+    pi) return 0 ;;
+  esac
+  case "$args" in
+    *cursor-agent*) return 0 ;;
+    *claude*) return 0 ;;
+    *codex*) return 0 ;;
+    *opencode*) return 0 ;;
+    *grok*) return 0 ;;
+    *" pi "*|*/pi) return 0 ;;
+  esac
+  return 1
+}
 
 harness_pid() {
-  local pid=$$ comm args
-  for _ in 1 2 3 4 5 6 7 8; do
-    comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
-    args=$(ps -o args= -p "$pid" 2>/dev/null)
-    if printf '%s' "$(basename "$comm")" | grep -qE "$HARNESS_RE"; then
+  local pid=$$
+  for _ in 1 2 3 4 5 6 7 8 9 10 11 12; do
+    if fm_lock_process_is_harness "$pid"; then
       echo "$pid"; return 0
     fi
-    # Bare interpreter (e.g. node): match the harness name in its script path.
-    case "$comm" in
-      *node*|*python*) printf '%s' "$args" | grep -qE "$HARNESS_RE" && { echo "$pid"; return 0; } ;;
-    esac
     pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
     [ -n "$pid" ] && [ "$pid" -gt 1 ] || return 1
   done
@@ -36,10 +53,9 @@ harness_pid() {
 }
 
 holder_alive() {  # true if $1 is a live process that looks like a harness
-  local pid=$1 comm
+  local pid=$1
   kill -0 "$pid" 2>/dev/null || return 1
-  comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
-  printf '%s' "$(basename "$comm") $(ps -o args= -p "$pid" 2>/dev/null)" | grep -qE "$HARNESS_RE"
+  fm_lock_process_is_harness "$pid"
 }
 
 if [ "${1:-}" = "status" ]; then

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -33,7 +33,7 @@
 #   profile consultation. A --secondmate spawn is exempt and resolves the SECONDMATE
 #   harness (config/secondmate-harness -> config/crew-harness -> own), so the
 #   secondmate-vs-crewmate split is DURABLE across every respawn (recovery,
-#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|grok)
+#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|grok|cursor)
 #   overrides it for this spawn (either kind). A non-flag string containing
 #   whitespace is treated as a RAW launch command - the escape hatch for verifying
 #   new adapters.
@@ -287,7 +287,7 @@ FIRSTMATE_HOME=
 
 if [ "$KIND" = secondmate ]; then
   case "${POS[1]:-}" in
-    ''|claude|codex|opencode|pi|grok)
+    ''|claude|codex|opencode|pi|grok|cursor)
       ARG3=${POS[1]:-}
       ;;
     *' '*)
@@ -348,6 +348,9 @@ launch_template() {
     # launch command - it is a Stop-event hook installed below (global hook +
     # per-task pointer), so the template is identical for ship/scout/secondmate.
     grok) printf '%s' 'grok --always-approve __MODELFLAG____EFFORTFLAG__"$(cat __BRIEF__)"' ;;
+    # cursor (Cursor Agent CLI): positional prompt; --force auto-approves tools.
+    # No standalone effort flag - model_flag_for_harness folds effort into the model bracket.
+    cursor) printf '%s' 'cursor-agent --force __MODELFLAG__"$(cat __BRIEF__)"' ;;
     *) return 1 ;;
   esac
 }
@@ -432,10 +435,21 @@ shell_quote() {
 }
 
 model_flag_for_harness() {
-  local harness=$1 model=$2
-  [ -n "$model" ] && [ "$model" != default ] || return 0
+  local harness=$1 model=$2 effort=${3:-}
   case "$harness" in
+    cursor)
+      # cursor has no standalone effort flag; a valid effort rides the model
+      # string as a bracket parameter. When model is default/empty there is
+      # nothing to attach effort to, so omit the flag.
+      [ -n "$model" ] && [ "$model" != default ] || return 0
+      local m=$model
+      case "$effort" in
+        low|medium|high|xhigh|max) m="${model}[effort=${effort}]" ;;
+      esac
+      printf -- '--model %s ' "$(shell_quote "$m")"
+      ;;
     claude|codex|opencode|pi|grok)
+      [ -n "$model" ] && [ "$model" != default ] || return 0
       printf -- '--model %s ' "$(shell_quote "$model")"
       ;;
   esac
@@ -918,6 +932,10 @@ EOF
     codex*)
       # codex: turn-end rides the launch command via -c notify=[...] and __TURNEND__.
       ;;
+    cursor*)
+      # cursor: no turn-end hook is wired. cursor-agent Stop/turn-end surface is
+      # unverified; rely on busy-pane signature + stale-pane detection.
+      ;;
     grok*)
       # grok fires a Stop hook at every turn boundary (verified, grok 0.2.73), the
       # clean equivalent of codex's notify= and pi's turn_end. But grok only loads
@@ -1034,7 +1052,7 @@ sq_turnend=$(shell_quote "$TURNEND")
 sq_piext=$(shell_quote "$STATE/$ID.pi-ext.ts")
 sq_piturnend=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-turnend-guard.ts")
 sq_piwatch=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-pi-watch.ts")
-MODELFLAG=$(model_flag_for_harness "$HARNESS" "$MODEL")
+MODELFLAG=$(model_flag_for_harness "$HARNESS" "$MODEL" "$EFFORT")
 EFFORTFLAG=$(effort_flag_for_harness "$HARNESS" "$EFFORT")
 LAUNCH=${LAUNCH//__MODELFLAG__/$MODELFLAG}
 LAUNCH=${LAUNCH//__EFFORTFLAG__/$EFFORTFLAG}

--- a/bin/fm-supervision-instructions.sh
+++ b/bin/fm-supervision-instructions.sh
@@ -81,7 +81,7 @@ if [ -z "$HARNESS" ]; then
 fi
 
 case "$HARNESS" in
-  claude|codex|opencode|pi|grok) SNIPPET="$DOC_DIR/$HARNESS.md" ;;
+  claude|codex|opencode|pi|grok|cursor) SNIPPET="$DOC_DIR/$HARNESS.md" ;;
   *) HARNESS=unknown; SNIPPET="$DOC_DIR/unknown.md" ;;
 esac
 [ -f "$SNIPPET" ] || SNIPPET="$DOC_DIR/unknown.md"
@@ -135,6 +135,9 @@ repair_line() {
   case "$HARNESS" in
     claude)
       printf '%s%s\n' "$prefix" 'repair missing watcher supervision with bin/fm-watch-arm.sh as its own Claude Code background task, never shell &.'
+      ;;
+    cursor)
+      printf '%s%s\n' "$prefix" 'resume supervision with bin/fm-watch-arm.sh as its own Cursor Shell background task (block_until_ms: 0), never shell &.'
       ;;
     codex)
       printf '%s%s%s%s\n' "$prefix" 'repair missing watcher supervision with a foreground checkpoint: bin/fm-watch-checkpoint.sh --seconds ' "$checkpoint_seconds" '.'

--- a/bin/fm-tmux-lib.sh
+++ b/bin/fm-tmux-lib.sh
@@ -48,8 +48,24 @@
 
 # Busy footers per harness (mirror fm-watch.sh). claude/codex: "esc to
 # interrupt"; opencode: "esc interrupt"; pi: "Working..."; grok: "Ctrl+c:cancel"
-# (grok's mid-turn cancel hint, shown iff a turn is running - verified grok 0.2.73).
-FM_TMUX_BUSY_REGEX_DEFAULT='esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel'
+# (grok's mid-turn cancel hint, shown iff a turn is running - verified grok 0.2.73);
+# cursor: "ctrl+c to stop" (cursor-agent's mid-turn footer hint, shown iff a turn
+# is running, alongside a braille spinner + token count - verified cursor-agent
+# 2026.07.01; grep is case-insensitive so this also matches any Ctrl+C casing).
+FM_TMUX_BUSY_REGEX_DEFAULT='esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel|ctrl\+c to stop'
+
+# fm_tmux_session_target: unambiguous tmux -t target for a session-only flag.
+# Purely numeric session names (e.g. Cursor's default "0") are parsed as window
+# indices unless disambiguated; a trailing colon forces session interpretation
+# so `new-window -t 0` does not fail with "index 0 in use" when window 0 exists.
+fm_tmux_session_target() {  # <session-name>
+  local ses=$1
+  case "$ses" in
+    *:*) printf '%s\n' "$ses" ;;
+    [0-9]*) printf '%s:\n' "$ses" ;;
+    *) printf '%s\n' "$ses" ;;
+  esac
+}
 
 # fm_tmux_strip_ghost: thin adapter over the shared, fleet-wide ghost extractor
 # fm_composer_strip_ghost (bin/fm-composer-lib.sh). It drops de-emphasised

--- a/bin/fm-turnend-guard.sh
+++ b/bin/fm-turnend-guard.sh
@@ -10,7 +10,7 @@
 # fleet-touching command itself, can sit blind for hours.
 # This script is push-based: verified harness turn-end hooks invoke it every time
 # the primary is about to end a turn.
-# Claude and codex can block directly by preserving exit status 2 and stderr.
+# Claude, codex, and cursor can block directly by preserving exit status 2 and stderr.
 # OpenCode, pi, and grok adapters use the same predicate and force one bounded
 # follow-up because their turn-end events are passive.
 # See docs/turnend-guard.md for the per-harness mechanics, validation evidence,

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -114,8 +114,11 @@ SIGNAL_GRACE=${FM_SIGNAL_GRACE:-30}   # seconds to linger after a signal so trai
 # claude/codex: "esc to interrupt"; opencode: "esc interrupt"; pi: "Working...";
 # grok: "Ctrl+c:cancel" (the mid-turn cancel hint in grok's keybind bar, shown iff a
 # turn is running; absent when idle - verified grok 0.2.73, ASCII to avoid the
-# locale fragility of matching grok's braille spinner glyph directly).
-BUSY_REGEX=${FM_BUSY_REGEX:-'esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel'}
+# locale fragility of matching grok's braille spinner glyph directly); cursor:
+# "ctrl+c to stop" (cursor-agent's mid-turn footer hint alongside a braille
+# spinner + token count, shown iff a turn is running - verified cursor-agent
+# 2026.07.01).
+BUSY_REGEX=${FM_BUSY_REGEX:-'esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel|ctrl\+c to stop'}
 # Always-on wake triage: most wakes during a long crew validation are benign (a
 # working: note or turn-end while a pipeline runs, a no-change heartbeat). Rather
 # than wake firstmate's LLM for each, this watcher classifies every wake in bash

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -133,7 +133,7 @@ The session-start bootstrap step surfaces either the active rule block or a conc
 When the file exists, `fm-spawn.sh` refuses crewmate and scout launches without an explicit harness, so `config/crew-harness` is only automatic when no dispatch profile file is active.
 Secondmate launches are exempt because they resolve the secondmate harness and any optional secondmate model or effort tokens instead.
 Unsupported effort values are still recorded in task meta when passed to `fm-spawn.sh`, but the launch template omits any effort flag that the selected harness does not accept.
-That keeps spawn launch compatible across claude, codex, grok, pi, and opencode while preserving the requested profile for later audit.
+That keeps spawn launch compatible across claude, codex, grok, pi, opencode, and cursor while preserving the requested profile for later audit.
 
 ## Optional secondmates
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -162,7 +162,7 @@ The full cmux home label also includes a short hash of the resolved `FM_ROOT` pa
 
 ## Harness support
 
-claude, codex, opencode, pi, and grok are all empirically verified; new harnesses get verified through a supervised trial task before joining the set.
+claude, codex, opencode, pi, grok, and cursor are all empirically verified; new harnesses get verified through a supervised trial task before joining the set.
 The verified adapter knowledge - busy signatures, interrupt and exit commands, skill-invocation syntax, and per-harness quirks - lives in [`.agents/skills/harness-adapters/SKILL.md`](../.agents/skills/harness-adapters/SKILL.md).
 Launch mechanics, including the verified command templates, live in [`bin/fm-spawn.sh`](../bin/fm-spawn.sh).
 Primary-session turn-end guard integrations for verified harnesses are tracked as repo-level hook files and documented in [`docs/turnend-guard.md`](turnend-guard.md).

--- a/docs/supervision-protocols/cursor.md
+++ b/docs/supervision-protocols/cursor.md
@@ -1,0 +1,10 @@
+Mode: Cursor background-notify supervision.
+Keep exactly one live watcher cycle while any task is in flight.
+Arm with `bin/fm-watch-arm.sh` as its own Cursor Shell background task (`block_until_ms: 0`), never shell `&` and never bundled with unrelated commands.
+Do not use Codex-style foreground checkpoints (`bin/fm-watch-checkpoint.sh`) on Cursor.
+When X mode is active, source `__FM_X_MODE_ENV__` in that same Shell background task before arming so the watcher inherits the 30s cadence.
+On every wake (`signal`/`stale`/`check`/`heartbeat`): drain with `bin/fm-wake-drain.sh`, handle the drained records, then re-arm with another standalone Cursor Shell background task.
+`watcher: started` and `watcher: healthy` both mean a live cycle already exists - do not start another.
+`watcher: FAILED` means no live cycle - drain any queued wakes, then arm one now.
+Never end a turn while tasks are in flight without a live cycle.
+Tracked Cursor Hooks (`.cursor/hooks.json`) backstop shell `cd` into worktrees, blind shell `&` arms, and turn-end without a live watcher; they do not replace this protocol.

--- a/docs/tmux-backend.md
+++ b/docs/tmux-backend.md
@@ -99,7 +99,7 @@ Verified the same session: a persisting parent process running a child command (
 
 The classifier (`fm_backend_tmux_agent_alive`) maps the observed name to `alive`, `dead`, or `unknown`:
 
-- `alive` - the name contains `claude`, `codex`, `opencode`, or `grok`. All four were confirmed to run as their own literal process name (`ps -ef`, 2026-07-07): `claude` and `codex` and `opencode` are each a native compiled binary (`file` reports Mach-O), so their `comm` is their own binary name with no interpreter wrapper to hide behind.
+- `alive` - the name contains `claude`, `codex`, `opencode`, `grok`, or `cursor-agent`. Those were confirmed to run as their own literal process name. `cursor-agent` may also appear as `MainThread` or argv0 `agent` (the `~/.local/bin/agent` symlink); those shapes are confirmed via pane process args (`fm_backend_tmux_pane_has_cursor_agent`) before counting as alive.
 - `dead` - the name is a bare shell (`zsh`, `bash`, `sh`, `dash`, `ash`, `ksh`, `mksh`, `tcsh`, `csh`, `fish`).
 - `unknown` - anything else, including an unreadable pane.
 

--- a/docs/tmux-backend.md
+++ b/docs/tmux-backend.md
@@ -115,3 +115,4 @@ Resolving this would need either a `pi`-specific env marker inspectable from out
 
 None specific to tmux for the reference path itself - it is the fully verified reference backend, while Orca and cmux are the backends without secondmate support.
 The agent-liveness probe above has one known gap (`pi`'s generic `node` process name, see above).
+If your harness runs inside a tmux session whose name is purely numeric (Cursor's default session is often `0`), firstmate disambiguates session targets when creating crew windows so `new-window` is not parsed as a window index; without that, tmux reports `create window failed: index 0 in use` once a window at index 0 already exists.

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -47,8 +47,9 @@ All verified primary harnesses have a tracked integration:
 - `grok`: `.grok/hooks/fm-primary-turnend-guard.json` registers a `Stop` hook that invokes `bin/fm-turnend-guard-grok.sh`.
   The adapter runs the shared guard and, when it returns 2, invokes `grok --resume <sessionId> -p <guard-reason>` with `GROK_TURNEND_GUARD_ACTIVE=1`.
   It does not pass `--permission-mode`, so the passive Stop hook cannot grant stronger tool permissions than Grok's resumed-session default.
+- `cursor`: `.cursor/hooks.json` registers `stop` -> `bin/fm-cursor-stop.sh` (wraps `bin/fm-turnend-guard.sh`; exit 2 blocks once via `loop_limit: 1`) and `beforeShellExecution` -> `bin/fm-cursor-before-shell.sh` (shared arm + cd seatbelts mapped to Cursor permission JSON).
 
-Claude and Codex support a direct blocking Stop hook.
+Claude, Codex, and Cursor support a direct blocking Stop hook.
 For those harnesses, exit status 2 plus stderr from `bin/fm-turnend-guard.sh` blocks the stop and feeds the reason back into the model.
 Both payloads include `stop_hook_active`; when it is true, the shared guard exits 0 so the harness can end after one forced continuation.
 

--- a/tests/fm-backend-tmux-smoke.test.sh
+++ b/tests/fm-backend-tmux-smoke.test.sh
@@ -99,7 +99,12 @@ pass "real tmux: fm_backend_tmux_send_literal + fm_backend_tmux_send_key Enter s
 # far enough to still see the earliest line - the same -S -N bounding fm-peek.sh
 # and fm-watch.sh rely on for a bounded, cheap pane read.
 fm_backend_tmux_send_text_line "$TARGET" "for i in \$(seq 1 80); do echo tag-line-\$i; done"
-sleep 0.6
+for _ in $(seq 1 30); do
+  if fm_backend_tmux_capture "$TARGET" 100 | grep -q 'tag-line-80'; then
+    break
+  fi
+  sleep 0.1
+done
 small=$(fm_backend_tmux_capture "$TARGET" 3) || fail "fm_backend_tmux_capture (small window) failed"
 case "$small" in
   *tag-line-1$'\n'*) fail "a 3-line capture should not still see the very first numbered line"$'\n'"$small" ;;
@@ -136,6 +141,32 @@ fi
 # Best-effort contract: killing an already-gone window must not error.
 fm_backend_tmux_kill "$TARGET" || fail "fm_backend_tmux_kill on an already-dead target must stay best-effort (never fail)"
 pass "real tmux: fm_backend_tmux_kill removes the window and is idempotent/best-effort"
+
+# --- numeric session name (Cursor default "0") --------------------------------
+# When base-index is 1 and a window already occupies index 0, `new-window -t 0`
+# is parsed as window index 0 (in use) instead of session "0". fm_tmux_session_target
+# must disambiguate with a trailing colon.
+
+tmux set-option -g base-index 1
+tmux set-option -g renumber-windows on
+NUM_SESSION="0"
+NUM_WINDOW="fm-smoke-num"
+tmux new-session -d -s "$NUM_SESSION" -x 200 -y 50 \
+  || fail "real tmux: new-session for numeric session name failed"
+tmux new-window -d -t '0:0' -n decoy-at-zero -c "$HOME" \
+  || fail "real tmux: could not seed decoy window at index 0"
+if tmux new-window -d -t 0 -n should-fail -c "$HOME" 2>/dev/null; then
+  fail "raw tmux new-window -t 0 should fail when window index 0 is already in use"
+fi
+fm_backend_tmux_create_task "$NUM_SESSION" "$NUM_WINDOW" "$HOME" \
+  || fail "fm_backend_tmux_create_task failed for numeric session with window 0 occupied"
+if ! tmux list-windows -t "$NUM_SESSION" -F '#{window_name}' | grep -qx "$NUM_WINDOW"; then
+  fail "numeric-session create_task did not add window $NUM_WINDOW"
+fi
+fm_backend_tmux_kill "$NUM_SESSION:$NUM_WINDOW"
+tmux kill-window -t "$NUM_SESSION:decoy-at-zero" 2>/dev/null || true
+tmux kill-session -t "$NUM_SESSION" 2>/dev/null || true
+pass "real tmux: fm_backend_tmux_create_task disambiguates numeric session names"
 
 cleanup_all
 trap - EXIT

--- a/tests/fm-backend.test.sh
+++ b/tests/fm-backend.test.sh
@@ -1064,6 +1064,49 @@ test_spawn_autodetect_nesting_resolves_tmux_silently() {
   pass "fm-spawn.sh: auto-detect resolves nested tmux-in-herdr to tmux and stays silent end to end"
 }
 
+test_tmux_session_target_disambiguates_numeric_names() {
+  local out
+  out=$(bash -c '. "$0/bin/fm-tmux-lib.sh"; fm_tmux_session_target firstmate' "$ROOT")
+  [ "$out" = firstmate ] || fail "fm_tmux_session_target should leave non-numeric names unchanged, got '$out'"
+  out=$(bash -c '. "$0/bin/fm-tmux-lib.sh"; fm_tmux_session_target 0' "$ROOT")
+  [ "$out" = '0:' ] || fail "fm_tmux_session_target should suffix numeric session names with colon, got '$out'"
+  out=$(bash -c '. "$0/bin/fm-tmux-lib.sh"; fm_tmux_session_target "0:"' "$ROOT")
+  [ "$out" = '0:' ] || fail "fm_tmux_session_target should not double-suffix, got '$out'"
+  pass "fm_tmux_session_target: numeric session names get trailing colon"
+}
+
+test_tmux_create_task_logs_disambiguated_session() {
+  local fb log
+  fb=$(mktemp -d "${TMPDIR:-/tmp}/fm-tmux-numses.XXXXXX")/fakebin
+  mkdir -p "$fb"
+  log="$TMP_ROOT/tmux-numses.log"
+  : > "$log"
+  cat > "$fb/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+{ printf 'tmux'; for a in "$@"; do printf '\x1f%s' "$a"; done; printf '\n'; } >> "${FM_TMUX_LOG:?}"
+case "${1:-}" in
+  list-windows) exit 0 ;;
+  new-window)
+    for a in "$@"; do
+      [ "$a" = '0:' ] || continue
+      exit 0
+    done
+    echo "error: new-window missing disambiguated session target 0:" >&2
+    exit 1
+    ;;
+esac
+exit 0
+SH
+  chmod +x "$fb/tmux"
+  PATH="$fb:$PATH" FM_TMUX_LOG="$log" bash -c \
+    '. "$0/bin/fm-backend.sh"; fm_backend_source tmux; fm_backend_tmux_create_task 0 fm-numtest /tmp' "$ROOT" \
+    || fail "fm_backend_tmux_create_task should succeed with numeric session name"
+  assert_contains "$(cat "$log")" $'\x1f''new-window'$'\x1f''-d'$'\x1f''-t'$'\x1f''0:' \
+    "new-window should target session 0: not bare 0"
+  pass "fm_backend_tmux_create_task: new-window uses disambiguated numeric session target"
+}
+
 test_backend_name_precedence
 test_backend_detect_precedence
 test_backend_detect_cmux_fallback_bundle_id
@@ -1091,3 +1134,5 @@ test_spawn_refuses_unknown_fm_backend_env
 test_spawn_default_backend_writes_no_meta_field
 test_spawn_explicit_backend_flag_beats_autodetect_herdr_env
 test_spawn_autodetect_nesting_resolves_tmux_silently
+test_tmux_session_target_disambiguates_numeric_names
+test_tmux_create_task_logs_disambiguated_session

--- a/tests/fm-cursor-harness.test.sh
+++ b/tests/fm-cursor-harness.test.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SPAWN="$ROOT/bin/fm-spawn.sh"
+TMP_ROOT=$(fm_test_tmproot fm-cursor-harness)
+
+make_spawn_fakebin() {
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+esac
+case "${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+  list-windows) exit 0 ;;
+  has-session|new-session|new-window|send-keys|kill-window) exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" treehouse gh-axi gh
+  printf '%s\n' "$fakebin"
+}
+
+make_spawn_case() {
+  local name=$1 case_dir home proj wt fakebin id
+  case_dir="$TMP_ROOT/$name"
+  home="$case_dir/home"
+  proj="$case_dir/project"
+  wt="$case_dir/wt"
+  fakebin=$(make_spawn_fakebin "$case_dir/fake")
+  id="cursor-$name-x1"
+  mkdir -p "$home/data/$id" "$home/projects" "$home/state" "$home/config"
+  printf 'brief\n' > "$home/data/$id/brief.md"
+  fm_git_worktree "$proj" "$wt" "fm/$id"
+  touch "$home/state/.last-watcher-beat"
+  printf '%s\n' "$case_dir|$home|$proj|$wt|$fakebin|$id"
+}
+
+run_cursor_spawn() {
+  local home=$1 proj=$2 wt=$3 fakebin=$4 id=$5
+  FM_ROOT_OVERRIDE='' FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
+    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" TMUX="fake,1,0" \
+    PATH="$fakebin:$PATH" \
+    "$SPAWN" "$id" "$proj" cursor 2>&1
+}
+
+test_cursor_spawn_installs_no_turnend_hook_artifacts() {
+  local rec case_dir home proj wt fakebin id out status
+  rec=$(make_spawn_case hookless)
+  IFS='|' read -r case_dir home proj wt fakebin id <<EOF
+$rec
+EOF
+  out=$(run_cursor_spawn "$home" "$proj" "$wt" "$fakebin" "$id")
+  status=$?
+  expect_code 0 "$status" "cursor spawn should succeed"
+  assert_contains "$out" "spawned $id harness=cursor" "cursor spawn did not report success"
+
+  assert_absent "$wt/.claude/settings.local.json" "cursor spawn must not install the claude Stop-hook settings file"
+  assert_absent "$wt/.opencode/plugins/fm-turn-end.js" "cursor spawn must not install the opencode turn-end plugin"
+  assert_absent "$wt/.fm-grok-turnend" "cursor spawn must not install the grok turn-end pointer"
+  assert_absent "$home/state/$id.pi-ext.ts" "cursor spawn must not install the pi turn-end extension"
+  assert_absent "$home/state/$id.grok-turnend-token" "cursor spawn must not write a grok turn-end token"
+  pass "cursor spawn wires no turn-end hook artifacts (relies on busy-pane + stale-pane detection)"
+}
+
+test_cursor_spawn_launch_template() {
+  local rec case_dir home proj wt fakebin id out status meta
+  rec=$(make_spawn_case launch)
+  IFS='|' read -r case_dir home proj wt fakebin id <<EOF
+$rec
+EOF
+  out=$(run_cursor_spawn "$home" "$proj" "$wt" "$fakebin" "$id")
+  status=$?
+  expect_code 0 "$status" "cursor spawn should succeed"
+  meta="$home/state/$id.meta"
+  assert_grep "harness=cursor" "$meta" "cursor meta missing harness=cursor"
+  assert_grep "model=default" "$meta" "cursor meta should default model when unset"
+  assert_grep "effort=default" "$meta" "cursor meta should default effort when unset"
+  pass "cursor spawn resolves the launch template and records default profile in meta"
+}
+
+test_fm_harness_detects_cursor_before_claude_marker() {
+  local out
+  # cursor-agent ALSO sets CLAUDECODE=1 and AI_AGENT=claude-code_* (it is
+  # Claude-Code-compatible under the hood); CURSOR_AGENT must win or a cursor
+  # session misdetects as claude.
+  out=$(CURSOR_AGENT=1 CLAUDECODE=1 AI_AGENT=claude-code_1.0 "$ROOT/bin/fm-harness.sh")
+  [ "$out" = cursor ] || fail "fm-harness.sh detected '$out', expected cursor to win over the claude-compatible markers"
+  pass "fm-harness.sh checks CURSOR_AGENT before CLAUDECODE"
+}
+
+test_fm_harness_detects_cursor_via_process_ancestry() {
+  local fakebin out
+  fakebin=$(fm_fakebin "$TMP_ROOT/ancestry-fake")
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *"comm="*) printf '%s\n' '/usr/local/bin/cursor-agent'; exit 0 ;;
+  *"args="*) printf '%s\n' 'cursor-agent'; exit 0 ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/ps"
+  out=$(PATH="$fakebin:$PATH" env -u CURSOR_AGENT -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT "$ROOT/bin/fm-harness.sh")
+  [ "$out" = cursor ] || fail "fm-harness.sh process-ancestry detection returned '$out', expected cursor"
+  pass "fm-harness.sh recognizes cursor-agent via process ancestry"
+}
+
+test_fm_lock_recognizes_cursor_holder() {
+  local home fakebin out
+  home="$TMP_ROOT/lock-home"
+  fakebin=$(fm_fakebin "$TMP_ROOT/lock-fake")
+  mkdir -p "$home/state"
+  printf '%s\n' "$$" > "$home/state/.lock"
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *"comm="*) printf '%s\n' '/usr/local/bin/cursor-agent'; exit 0 ;;
+  *"args="*) printf '%s\n' 'cursor-agent'; exit 0 ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/ps"
+  out=$(FM_HOME="$home" PATH="$fakebin:$PATH" "$ROOT/bin/fm-lock.sh" status)
+  assert_contains "$out" "lock: held by live harness pid" "fm-lock did not recognize cursor-agent as a live holder"
+  pass "fm-lock recognizes cursor-agent harness processes"
+}
+
+test_fm_lock_recognizes_cursor_mainthread_holder() {
+  local home fakebin out
+  home="$TMP_ROOT/lock-mainthread-home"
+  fakebin=$(fm_fakebin "$TMP_ROOT/lock-mainthread-fake")
+  mkdir -p "$home/state"
+  printf '%s\n' "$$" > "$home/state/.lock"
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *"comm="*) printf '%s\n' 'MainThread'; exit 0 ;;
+  *"args="*) printf '%s\n' '/home/user/.local/bin/cursor-agent --use-system-ca'; exit 0 ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/ps"
+  out=$(FM_HOME="$home" PATH="$fakebin:$PATH" "$ROOT/bin/fm-lock.sh" status)
+  assert_contains "$out" "lock: held by live harness pid" "fm-lock did not recognize MainThread cursor-agent as a live holder"
+  pass "fm-lock recognizes cursor-agent when comm is MainThread"
+}
+
+test_cursor_spawn_installs_no_turnend_hook_artifacts
+test_cursor_spawn_launch_template
+test_fm_harness_detects_cursor_before_claude_marker
+test_fm_harness_detects_cursor_via_process_ancestry
+test_fm_lock_recognizes_cursor_holder
+test_fm_lock_recognizes_cursor_mainthread_holder
+
+echo "# all fm-cursor-harness tests passed"

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -61,8 +61,8 @@ test_harness_resolution() {
     mkdir -p "$cfg"
     [ "$crew" = "-" ] || printf '%s\n' "$crew" > "$cfg/crew-harness"
     [ "$sm" = "-" ] || printf '%s\n' "$sm" > "$cfg/secondmate-harness"
-    got_sm=$(CLAUDECODE=1 FM_CONFIG_OVERRIDE="$cfg" "$ROOT/bin/fm-harness.sh" secondmate)
-    got_crew=$(CLAUDECODE=1 FM_CONFIG_OVERRIDE="$cfg" "$ROOT/bin/fm-harness.sh" crew)
+    got_sm=$(env -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u AI_AGENT CLAUDECODE=1 FM_CONFIG_OVERRIDE="$cfg" "$ROOT/bin/fm-harness.sh" secondmate)
+    got_crew=$(env -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u AI_AGENT CLAUDECODE=1 FM_CONFIG_OVERRIDE="$cfg" "$ROOT/bin/fm-harness.sh" crew)
     [ "$got_sm" = "$exp_sm" ] || fail "$label: secondmate resolved '$got_sm', expected '$exp_sm'"
     [ "$got_crew" = "$exp_crew" ] || fail "$label: crew resolved '$got_crew', expected '$exp_crew'"
   done <<'ROWS'
@@ -96,9 +96,9 @@ test_secondmate_model_effort_tokens() {
     cfg="$case_dir/config"
     mkdir -p "$cfg"
     [ "$line" = ABSENT ] || printf '%b\n' "$line" > "$cfg/secondmate-harness"
-    got_h=$(CLAUDECODE=1 FM_CONFIG_OVERRIDE="$cfg" "$ROOT/bin/fm-harness.sh" secondmate)
-    got_m=$(CLAUDECODE=1 FM_CONFIG_OVERRIDE="$cfg" "$ROOT/bin/fm-harness.sh" secondmate-model)
-    got_e=$(CLAUDECODE=1 FM_CONFIG_OVERRIDE="$cfg" "$ROOT/bin/fm-harness.sh" secondmate-effort)
+    got_h=$(env -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u AI_AGENT CLAUDECODE=1 FM_CONFIG_OVERRIDE="$cfg" "$ROOT/bin/fm-harness.sh" secondmate)
+    got_m=$(env -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u AI_AGENT CLAUDECODE=1 FM_CONFIG_OVERRIDE="$cfg" "$ROOT/bin/fm-harness.sh" secondmate-model)
+    got_e=$(env -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u AI_AGENT CLAUDECODE=1 FM_CONFIG_OVERRIDE="$cfg" "$ROOT/bin/fm-harness.sh" secondmate-effort)
     [ "$got_h" = "$exp_harness" ] || fail "$label: harness resolved '$got_h', expected '$exp_harness'"
     [ "$got_m" = "$exp_model" ] || fail "$label: model resolved '$got_m', expected '$exp_model'"
     [ "$got_e" = "$exp_effort" ] || fail "$label: effort resolved '$got_e', expected '$exp_effort'"
@@ -273,7 +273,7 @@ spawn_secondmate() {
   local spawn_args=("$id" "$home")
   [ -n "$harness" ] && spawn_args+=("$harness")
   spawn_args+=(--secondmate)
-  PATH="$fakebin:$BASE_PATH" TMUX='' CLAUDECODE=1 \
+  env -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u AI_AGENT PATH="$fakebin:$BASE_PATH" TMUX='' CLAUDECODE=1 \
     FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$world/home" \
     FM_STATE_OVERRIDE="$world/home/state" FM_DATA_OVERRIDE="$world/home/data" \
     FM_PROJECTS_OVERRIDE="$world/home/projects" FM_CONFIG_OVERRIDE="$world/home/config" \
@@ -383,7 +383,7 @@ test_spawn_unverified_secondmate_harness_refused() {
   fakebin=$(make_noop_tmux "$w/tmux")
   err="$w/spawn.err"
   rc=0
-  PATH="$fakebin:$BASE_PATH" TMUX='' CLAUDECODE=1 \
+  env -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u AI_AGENT PATH="$fakebin:$BASE_PATH" TMUX='' CLAUDECODE=1 \
     FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$w/home" \
     FM_STATE_OVERRIDE="$w/home/state" FM_DATA_OVERRIDE="$w/home/data" \
     FM_PROJECTS_OVERRIDE="$w/home/projects" FM_CONFIG_OVERRIDE="$w/home/config" \
@@ -453,7 +453,7 @@ spawn_secondmate_capture() {
   mkdir -p "$world/home/state" "$world/home/data"
   fakebin=$(make_launch_capturing_tmux "$world/tmux-$id")
   : > "$launchlog"
-  PATH="$fakebin:$BASE_PATH" TMUX='' CLAUDECODE=1 \
+  env -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u AI_AGENT PATH="$fakebin:$BASE_PATH" TMUX='' CLAUDECODE=1 \
     FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$world/home" \
     FM_STATE_OVERRIDE="$world/home/state" FM_DATA_OVERRIDE="$world/home/data" \
     FM_PROJECTS_OVERRIDE="$world/home/projects" FM_CONFIG_OVERRIDE="$world/home/config" \
@@ -658,7 +658,7 @@ test_spawn_fallback_chain_and_crew_scout_unaffected() {
   mkdir -p "$home/data/$id" "$home/projects" "$home/state"
   printf 'brief\n' > "$home/data/$id/brief.md"
   : > "$launchlog"
-  PATH="$fakebin:$BASE_PATH" TMUX="fake,1,0" CLAUDECODE=1 \
+  env -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u AI_AGENT PATH="$fakebin:$BASE_PATH" TMUX="fake,1,0" CLAUDECODE=1 \
     FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" \
     FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
     FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -402,7 +402,7 @@ EOF
   make_fake_toolchain "$fakebin"
   make_fake_ps_claude "$fakebin"
   # Force a MISSING diagnostic line so the bootstrap section is non-trivial.
-  rm -f "$fakebin/node"
+  rm -f "$fakebin/chrome-devtools-axi"
 
   printf 'window=fm-sess:w1\nkind=ship\n' > "$home/state/task-a.meta"
 
@@ -425,7 +425,7 @@ EOF
   [ "$context_line" -lt "$fleet_line" ] || fail "CONTEXT did not precede FLEET STATE"
   [ "$fleet_line" -lt "$next_line" ] || fail "FLEET STATE did not precede NEXT STEP"
 
-  missing_line=$(printf '%s\n' "$out" | grep -n 'MISSING: node' | head -1 | cut -d: -f1)
+  missing_line=$(printf '%s\n' "$out" | grep -n 'MISSING: chrome-devtools-axi' | head -1 | cut -d: -f1)
   [ -n "$missing_line" ] || fail "MISSING diagnostic did not appear at all"
   [ "$missing_line" -lt "$fleet_line" ] || fail "actionable MISSING diagnostic was buried after the bulk fleet-state digest"
 
@@ -585,7 +585,7 @@ $rec
 EOF
   make_fake_toolchain "$fakebin"
   make_fake_ps_claude "$fakebin"
-  rm -f "$fakebin/node"
+  rm -f "$fakebin/chrome-devtools-axi"
 
   printf 'needs-decision: pick a library\n' > "$home/state/task-z.status"
   append_wake "$home/state" signal task-z.status "needs-decision: pick a library"
@@ -595,7 +595,7 @@ EOF
   # fm-lock.sh's own exact success text.
   assert_contains "$out" "lock acquired: harness pid" "fm-lock.sh's real output did not appear (composition, not reimplementation)"
   # fm-bootstrap.sh's own exact MISSING-tool line format.
-  assert_contains "$out" "MISSING: node (install:" "fm-bootstrap.sh's real detect line did not appear verbatim"
+  assert_contains "$out" "MISSING: chrome-devtools-axi (install:" "fm-bootstrap.sh's real detect line did not appear verbatim"
   # fm-wake-drain.sh's real drained record (raw tab-separated queue line).
   assert_contains "$out" "$(printf 'signal\ttask-z.status\tneeds-decision: pick a library')" "fm-wake-drain.sh's real drained record did not appear"
   assert_contains "$out" "wake annotation: latest wake-EVENT observed at drain, not current state: task-z.status: needs-decision: pick a library" "fm-session-start.sh did not preserve the drain's separate annotation line"

--- a/tests/fm-supervision-instructions.test.sh
+++ b/tests/fm-supervision-instructions.test.sh
@@ -133,6 +133,19 @@ test_pi_snippet_uses_effective_extension_path() {
   pass "pi supervision snippet renders the effective extension path"
 }
 
+test_cursor_is_background_notify() {
+  local out
+  out=$("$RENDER" --harness cursor)
+  assert_contains "$out" "Mode: Cursor background-notify supervision." "cursor snippet missing background-notify mode"
+  assert_contains "$out" "block_until_ms: 0" "cursor snippet missing Shell background instruction"
+  assert_contains "$out" "bin/fm-watch-arm.sh" "cursor snippet missing watcher arm"
+  assert_not_contains "$out" "bin/fm-watch-checkpoint.sh --seconds" "cursor snippet must not instruct Codex-style checkpoint arms"
+  assert_not_contains "$out" "__FM_X_MODE_ENV" "renderer leaked an x-mode path placeholder"
+  out=$("$RENDER" --harness cursor --repair-line)
+  assert_contains "$out" "Cursor Shell background task" "cursor repair line is not background-notify shaped"
+  pass "cursor supervision is Claude-shaped background notify with Cursor Hooks backstop"
+}
+
 test_selected_harness_block_only
 test_unknown_fallback
 test_conditional_stanzas
@@ -141,3 +154,4 @@ test_ordinary_wake_lines_are_distinct_from_repair
 test_grok_is_background_notify
 test_grok_command_sources_effective_config
 test_pi_snippet_uses_effective_extension_path
+test_cursor_is_background_notify

--- a/tests/fm-turnend-guard.test.sh
+++ b/tests/fm-turnend-guard.test.sh
@@ -169,7 +169,7 @@ make_secondmate_linked_home_dir() {
 run_hook() {
   local dir=$1 stop_active=$2 home
   home=$(cd "$dir" && pwd)
-  printf '{"stop_hook_active":%s}' "$stop_active" | CLAUDECODE=1 FM_HOME="$home" bash "$dir/bin/fm-turnend-guard.sh" 2>&1
+  printf '{"stop_hook_active":%s}' "$stop_active" | env -u CURSOR_AGENT CLAUDECODE=1 FM_HOME="$home" bash "$dir/bin/fm-turnend-guard.sh" 2>&1
 }
 
 nonexistent_pid() {
@@ -288,7 +288,7 @@ test_hook_blocks_from_fm_home_state() {
   home="$TMP_ROOT/hook-fm-home-op"
   mkdir -p "$home/state"
   : > "$home/state/task1.meta"
-  out=$(printf '{"stop_hook_active":false}' | CLAUDECODE=1 FM_HOME="$home" bash "$dir/bin/fm-turnend-guard.sh" 2>&1); status=$?
+  out=$(printf '{"stop_hook_active":false}' | env -u CURSOR_AGENT CLAUDECODE=1 FM_HOME="$home" bash "$dir/bin/fm-turnend-guard.sh" 2>&1); status=$?
   expect_code 2 "$status" "hook must inspect the active FM_HOME state dir"
   assert_contains "$out" "$REQUIRED_REASON" "block reason must contain the exact required instruction"
   pass "fm-turnend-guard: blocks from active FM_HOME state, not only repo-root state"
@@ -326,7 +326,7 @@ test_hook_uses_state_override() {
   state="$TMP_ROOT/hook-state-override-active"
   mkdir -p "$home/state" "$state"
   : > "$state/task1.meta"
-  out=$(printf '{"stop_hook_active":false}' | CLAUDECODE=1 FM_HOME="$home" FM_STATE_OVERRIDE="$state" bash "$dir/bin/fm-turnend-guard.sh" 2>&1); status=$?
+  out=$(printf '{"stop_hook_active":false}' | env -u CURSOR_AGENT CLAUDECODE=1 FM_HOME="$home" FM_STATE_OVERRIDE="$state" bash "$dir/bin/fm-turnend-guard.sh" 2>&1); status=$?
   expect_code 2 "$status" "hook must let FM_STATE_OVERRIDE win over FM_HOME/state"
   assert_contains "$out" "$REQUIRED_REASON" "block reason must contain the exact required instruction"
   pass "fm-turnend-guard: uses FM_STATE_OVERRIDE ahead of FM_HOME/state"
@@ -913,6 +913,37 @@ test_hook_silent_with_live_lock_and_fresh_beacon
 test_hook_blocks_with_live_lock_and_stale_beacon
 test_hook_blocks_when_unhealthy_in_primary
 test_hook_blocks_from_fm_home_state
+test_cursor_hooks_register_stop_and_shell() {
+  local hooks stop_cmd shell_cmd
+  hooks="$ROOT/.cursor/hooks.json"
+  [ -f "$hooks" ] || fail "tracked .cursor/hooks.json is missing"
+  [ -x "$ROOT/bin/fm-cursor-stop.sh" ] || fail "bin/fm-cursor-stop.sh must be executable"
+  [ -x "$ROOT/bin/fm-cursor-before-shell.sh" ] || fail "bin/fm-cursor-before-shell.sh must be executable"
+  stop_cmd=$(jq -r '.hooks.stop[0].command // empty' "$hooks")
+  shell_cmd=$(jq -r '.hooks.beforeShellExecution[0].command // empty' "$hooks")
+  [ -n "$stop_cmd" ] || fail "stop hook command is missing from .cursor/hooks.json"
+  [ -n "$shell_cmd" ] || fail "beforeShellExecution hook command is missing from .cursor/hooks.json"
+  assert_contains "$stop_cmd" 'fm-cursor-stop.sh' "cursor stop hook must invoke fm-cursor-stop.sh"
+  assert_contains "$shell_cmd" 'fm-cursor-before-shell.sh' "cursor shell hook must invoke fm-cursor-before-shell.sh"
+  loop=$(jq -r '.hooks.stop[0].loop_limit // empty' "$hooks")
+  [ "$loop" = "1" ] || fail "cursor stop hook must set loop_limit 1, got: $loop"
+  pass ".cursor/hooks.json: stop + beforeShellExecution wire primary guard and seatbelts"
+}
+
+test_cursor_stop_adapter_blocks_once() {
+  local dir out status
+  dir=$(make_primary_dir "$TMP_ROOT/cursor-stop-block")
+  : > "$dir/state/task1.meta"
+  # No live watcher -> guard should block
+  out=$(printf '{"stop_hook_active":false}\n' | CURSOR_AGENT=1 FM_HOME="$dir" FM_ROOT_OVERRIDE="$dir" "$ROOT/bin/fm-cursor-stop.sh" 2>&1) && status=0 || status=$?
+  [ "$status" -eq 2 ] || fail "expected exit 2 when watcher missing, got $status out=$out"
+  assert_contains "$out" 'followup_message' "cursor stop adapter should emit followup_message JSON on block"
+  # Loop guard: stop_hook_active true must allow
+  out=$(printf '{"stop_hook_active":true}\n' | CURSOR_AGENT=1 FM_HOME="$dir" FM_ROOT_OVERRIDE="$dir" "$ROOT/bin/fm-cursor-stop.sh" 2>&1) && status=0 || status=$?
+  [ "$status" -eq 0 ] || fail "expected exit 0 when stop_hook_active, got $status out=$out"
+  pass "fm-cursor-stop.sh: blocks once then allows loop-guarded retry"
+}
+
 test_hook_x_mode_reason_sources_cadence
 test_hook_ignores_repo_state_when_fm_home_set
 test_hook_uses_state_override
@@ -941,3 +972,5 @@ test_pi_extension_forces_followup
 test_pi_extension_injects_once_per_logical_agent_run
 test_pi_extension_retries_after_followup_delivery_failure
 test_grok_hook_invokes_adapter
+test_cursor_hooks_register_stop_and_shell
+test_cursor_stop_adapter_blocks_once


### PR DESCRIPTION
## Summary
- Wire Cursor (`cursor-agent`) as a verified primary/crew harness (spawn, detect, busy signature, supervision protocol, primary hooks).
- Fix tmux `fm_backend_tmux_agent_alive` to recognize `cursor-agent` and `MainThread`/`agent` argv shapes (previously only claude/codex/opencode/grok).
- Bootstrap MISSING when a cursor home lacks `cursor-agent` on PATH.

## Why
Work fleets on Cursor were running from a local feature branch because `main` had zero Cursor spawn support. tmux secondmate liveness also failed closed toward `unknown` for Cursor panes.

## Test plan
- [ ] `bin/fm-harness.sh` prints `cursor` under `CURSOR_AGENT=1`
- [ ] `bin/fm-spawn.sh ... --harness cursor` launches `cursor-agent --force`
- [ ] tmux pane running `cursor-agent` classifies as `alive` via `fm_backend_tmux_agent_alive`
- [ ] With `config/crew-harness=cursor` and no `cursor-agent` on PATH, bootstrap prints `MISSING: cursor-agent`
- [ ] Existing claude/codex/opencode/grok liveness unchanged


Made with [Cursor](https://cursor.com)