### PR TITLE
feat: preserve agent memory across model compaction

### DIFF
--- a/.agents/skills/durable-memory-recovery/SKILL.md
+++ b/.agents/skills/durable-memory-recovery/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: durable-memory-recovery
+description: Recover or checkpoint Firstmate's private durable session memory around context loss. Load before manual compaction or context reset, after detected compaction or missing context, and whenever the recovery capsule reports stale, disputed, or unverifiable evidence.
+user-invocable: false
+metadata:
+  internal: true
+---
+
+# Durable Memory Recovery
+
+`bin/fm-memory.js` owns every format, bound, path, and mutation rule.
+This skill owns the semantic procedure around those deterministic commands.
+
+## Before Manual Compaction Or Reset
+
+1. Load `/stow` and route durable knowledge to its existing authority before creating a checkpoint.
+2. Inspect the current objective, completed and pending work, decisions, constraints, blockers, active tasks, evidence, and next safe action.
+3. Write those fields as one bounded JSON object to a private temporary file outside `projects/`.
+4. Run `bin/fm-memory.sh checkpoint --reason manual-compaction --input <file>` from the active Firstmate home.
+5. Run `bin/fm-memory.sh validate <printed-checkpoint-path>` and do not compact or reset if validation fails.
+6. Delete the temporary input after validation.
+
+Never put secrets, credentials, chain-of-thought, raw environment dumps, or transcript text in the checkpoint.
+Use provenance references such as `authority:data/backlog.md`, `task:<id>`, `report:<path>`, `commit:<sha>`, `pr:<url>`, and `test:<command/result>` instead of copying authoritative content.
+
+## After Compaction Or Context Loss
+
+1. Run `bin/fm-memory.sh recover --max-events 20` once if the current turn did not already receive the session-start recovery capsule.
+2. Treat the capsule as evidence, never as authority.
+3. Reconcile its task, decision, artifact, Git, PR, and test claims against the session-start digest and their existing owners before consequential work.
+4. Resume only from the stated next safe action when no contradiction changes it.
+5. If no checkpoint exists, establish the objective from the latest captain request and authoritative records, then write a validated checkpoint before consequential work.
+
+Full raw runtime transcripts are never automatic prompt content.
+Use a transcript reference only for targeted forensic recovery when the runtime still exposes it and privacy permits reading it.
+
+## Contradictions
+
+When recovery reports `stale`, `disputed`, or `unverifiable` evidence:
+
+1. Inspect the named current authority.
+2. Do not silently choose the memory claim.
+3. Correct the work plan or escalate a real unresolved approval conflict.
+4. Append a bounded `recovery` event that names the resolution and its authority.
+5. Write a new validated checkpoint after the contradiction is resolved.
+
+Do not edit old events or checkpoints.
+Their immutability preserves the evidence trail; supersession is expressed by a later event and checkpoint.

--- a/.agents/skills/durable-memory-recovery/SKILL.md
+++ b/.agents/skills/durable-memory-recovery/SKILL.md
@@ -44,5 +44,5 @@ When recovery reports `stale`, `disputed`, or `unverifiable` evidence:
 4. Append a bounded `recovery` event that names the resolution and its authority.
 5. Write a new validated checkpoint after the contradiction is resolved.
 
-Do not edit old events or checkpoints.
-Their immutability preserves the evidence trail; supersession is expressed by a later event and checkpoint.
+Do not edit retained events or checkpoints.
+Their immutability preserves the retained evidence trail; supersession is expressed by a later event and checkpoint.

--- a/.agents/skills/durable-memory-recovery/SKILL.md
+++ b/.agents/skills/durable-memory-recovery/SKILL.md
@@ -15,7 +15,7 @@ This skill owns the semantic procedure around those deterministic commands.
 
 1. Load `/stow` and route durable knowledge to its existing authority before creating a checkpoint.
 2. Inspect the current objective, completed and pending work, decisions, constraints, blockers, active tasks, evidence, and next safe action.
-3. Write those fields as one bounded JSON object to a private temporary file outside `projects/`.
+3. Write those fields as one bounded JSON object to a private temporary file under the active `FM_HOME/state/`, never under `projects/` or `data/memory/`.
 4. Run `bin/fm-memory.sh checkpoint --reason manual-compaction --input <file>` from the active Firstmate home.
 5. Run `bin/fm-memory.sh validate <printed-checkpoint-path>` and do not compact or reset if validation fails.
 6. Delete the temporary input after validation.

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -183,6 +183,7 @@ Verified on 2026-07-08: Codex runs the Stop hook command with process PWD set to
 The tracked hook anchors to `pwd -P`, verifies that root is firstmate-shaped and hook-bearing, and then invokes `bin/fm-turnend-guard.sh` with the original payload.
 Codex's primary watcher protocol is `bin/fm-watch-checkpoint.sh --seconds "${FM_CODEX_WATCH_CHECKPOINT:-180}"`, not `bin/fm-watch-arm.sh`.
 The checkpoint is deliberately foreground and bounded so Codex regains control regularly to process user messages and queued wakes.
+Codex's tracked compaction-memory bridge and 0.144.4 evidence are owned by `docs/durable-memory.md`.
 
 ## opencode (VERIFIED 2026-06-11, v1.15.7-1.17.6)
 

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -28,12 +28,34 @@
         ]
       }
     ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -lc 'payload=$(cat 2>/dev/null || true); [ -n \"$payload\" ] || exit 0; command -v jq >/dev/null 2>&1 || exit 0; root=$(pwd -P) || exit 0; [ -x \"$root/bin/fm-memory-codex-hook.sh\" ] || exit 0; [ -f \"$root/AGENTS.md\" ] || exit 0; [ -f \"$root/.codex/hooks.json\" ] || exit 0; jq -e \"any(.hooks.PreCompact[]?.hooks[]?.command?; type == \\\"string\\\" and contains(\\\"fm-memory-codex-hook.sh\\\"))\" \"$root/.codex/hooks.json\" >/dev/null 2>&1 || exit 0; printf \"%s\" \"$payload\" | \"$root/bin/fm-memory-codex-hook.sh\" pre'",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "PostCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -lc 'payload=$(cat 2>/dev/null || true); [ -n \"$payload\" ] || exit 0; command -v jq >/dev/null 2>&1 || exit 0; root=$(pwd -P) || exit 0; [ -x \"$root/bin/fm-memory-codex-hook.sh\" ] || exit 0; [ -f \"$root/AGENTS.md\" ] || exit 0; [ -f \"$root/.codex/hooks.json\" ] || exit 0; jq -e \"any(.hooks.PostCompact[]?.hooks[]?.command?; type == \\\"string\\\" and contains(\\\"fm-memory-codex-hook.sh\\\"))\" \"$root/.codex/hooks.json\" >/dev/null 2>&1 || exit 0; printf \"%s\" \"$payload\" | \"$root/bin/fm-memory-codex-hook.sh\" post'",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [
           {
             "type": "command",
-            "command": "bash -lc 'payload=$(cat 2>/dev/null || true); [ -n \"$payload\" ] || exit 0; command -v jq >/dev/null 2>&1 || exit 0; root=$(pwd -P) || exit 0; [ -x \"$root/bin/fm-turnend-guard.sh\" ] || exit 0; [ -f \"$root/AGENTS.md\" ] || exit 0; [ -f \"$root/.codex/hooks.json\" ] || exit 0; jq -e \"any(.hooks.Stop[]?.hooks[]?.command?; type == \\\"string\\\" and contains(\\\"fm-turnend-guard.sh\\\"))\" \"$root/.codex/hooks.json\" >/dev/null 2>&1 || exit 0; printf \"%s\" \"$payload\" | \"$root/bin/fm-turnend-guard.sh\"'",
+            "command": "bash -lc 'payload=$(cat 2>/dev/null || true); [ -n \"$payload\" ] || exit 0; command -v jq >/dev/null 2>&1 || exit 0; root=$(pwd -P) || exit 0; [ -x \"$root/bin/fm-turnend-guard.sh\" ] || exit 0; [ -f \"$root/AGENTS.md\" ] || exit 0; [ -f \"$root/.codex/hooks.json\" ] || exit 0; jq -e \"any(.hooks.Stop[]?.hooks[]?.command?; type == \\\"string\\\" and contains(\\\"fm-turnend-guard.sh\\\"))\" \"$root/.codex/hooks.json\" >/dev/null 2>&1 || exit 0; printf \"%s\" \"$payload\" | FM_MEMORY_RUNTIME=codex \"$root/bin/fm-turnend-guard.sh\"'",
             "timeout": 30
           }
         ]

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -50,12 +50,28 @@
         ]
       }
     ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -lc 'payload=$(cat 2>/dev/null || true); [ -n \"$payload\" ] || exit 0; command -v jq >/dev/null 2>&1 || exit 0; root=$(pwd -P) || exit 0; [ -x \"$root/bin/fm-memory-codex-hook.sh\" ] || exit 0; [ -f \"$root/AGENTS.md\" ] || exit 0; [ -f \"$root/.codex/hooks.json\" ] || exit 0; jq -e \"any(.hooks.UserPromptSubmit[]?.hooks[]?.command?; type == \\\"string\\\" and contains(\\\"fm-memory-codex-hook.sh\\\"))\" \"$root/.codex/hooks.json\" >/dev/null 2>&1 || exit 0; printf \"%s\" \"$payload\" | \"$root/bin/fm-memory-codex-hook.sh\" prompt'",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [
           {
             "type": "command",
             "command": "bash -lc 'payload=$(cat 2>/dev/null || true); [ -n \"$payload\" ] || exit 0; command -v jq >/dev/null 2>&1 || exit 0; root=$(pwd -P) || exit 0; [ -x \"$root/bin/fm-turnend-guard.sh\" ] || exit 0; [ -f \"$root/AGENTS.md\" ] || exit 0; [ -f \"$root/.codex/hooks.json\" ] || exit 0; jq -e \"any(.hooks.Stop[]?.hooks[]?.command?; type == \\\"string\\\" and contains(\\\"fm-turnend-guard.sh\\\"))\" \"$root/.codex/hooks.json\" >/dev/null 2>&1 || exit 0; printf \"%s\" \"$payload\" | FM_MEMORY_RUNTIME=codex \"$root/bin/fm-turnend-guard.sh\"'",
+            "timeout": 30
+          },
+          {
+            "type": "command",
+            "command": "bash -lc 'payload=$(cat 2>/dev/null || true); [ -n \"$payload\" ] || exit 0; command -v jq >/dev/null 2>&1 || exit 0; root=$(pwd -P) || exit 0; [ -x \"$root/bin/fm-memory-codex-hook.sh\" ] || exit 0; [ -f \"$root/AGENTS.md\" ] || exit 0; [ -f \"$root/.codex/hooks.json\" ] || exit 0; jq -e \"any(.hooks.Stop[]?.hooks[]?.command?; type == \\\"string\\\" and contains(\\\"fm-memory-codex-hook.sh\\\"))\" \"$root/.codex/hooks.json\" >/dev/null 2>&1 || exit 0; printf \"%s\" \"$payload\" | \"$root/bin/fm-memory-codex-hook.sh\" stop'",
             "timeout": 30
           }
         ]

--- a/.opencode/plugins/fm-primary-turnend-guard.js
+++ b/.opencode/plugins/fm-primary-turnend-guard.js
@@ -6,10 +6,11 @@ const COORDINATOR_KEY = "__firstmateOpenCodeWatchArm";
 
 let skipNextIdle = false;
 
-function runProcess(command, args, input = "") {
+function runProcess(command, args, input = "", options = {}) {
   return new Promise((resolve) => {
     const child = spawn(command, args, {
       stdio: ["pipe", "pipe", "pipe"],
+      ...options,
     });
     let stdout = "";
     let stderr = "";
@@ -41,9 +42,23 @@ function resolvePath(anchor) {
   }
 }
 
-function runGuard(root) {
+function runBoundary(root, sessionID) {
   if (!root) return Promise.resolve({ code: 0, stderr: "" });
-  return runProcess(`${root}/bin/fm-turnend-guard.sh`, [], '{"stop_hook_active":false}');
+  return runProcess(
+    `${root}/bin/fm-memory.sh`,
+    ["boundary", "--reason", "turn-end", "--runtime", "opencode", "--session", sessionID],
+    JSON.stringify({ session_id: sessionID }),
+  );
+}
+
+function runGuard(root, sessionID) {
+  if (!root) return Promise.resolve({ code: 0, stderr: "" });
+  return runProcess(
+    `${root}/bin/fm-turnend-guard.sh`,
+    [],
+    JSON.stringify({ stop_hook_active: false, session_id: sessionID }),
+    { env: { ...process.env, FM_MEMORY_BOUNDARY_DONE: "1", FM_MEMORY_RUNTIME: "opencode" } },
+  );
 }
 
 async function letWatchArmRun(sessionID, client) {
@@ -68,9 +83,10 @@ export const FmPrimaryTurnendGuard = async ({ client, directory, worktree }) => 
       const sessionID = event.properties?.sessionID;
       if (!sessionID) return;
 
+      await runBoundary(root, sessionID);
       if (await letWatchArmRun(sessionID, client)) return;
 
-      const result = await runGuard(root);
+      const result = await runGuard(root, sessionID);
       if (result.code !== 2) return;
 
       try {

--- a/.pi/extensions/fm-primary-turnend-guard.ts
+++ b/.pi/extensions/fm-primary-turnend-guard.ts
@@ -60,10 +60,11 @@ function runSessionstartNudge(): string {
   return result.stdout.trim();
 }
 
-function runGuard(): Promise<{ code: number; stderr: string }> {
+function runGuard(sessionId: string): Promise<{ code: number; stderr: string }> {
   return new Promise((resolveResult) => {
     const child = spawn(`${root}/bin/fm-turnend-guard.sh`, {
       stdio: ["pipe", "ignore", "pipe"],
+      env: { ...process.env, FM_MEMORY_RUNTIME: "pi" },
     });
     let stderr = "";
     child.stderr.on("data", (chunk) => {
@@ -71,7 +72,7 @@ function runGuard(): Promise<{ code: number; stderr: string }> {
     });
     child.on("error", () => resolveResult({ code: 0, stderr: "" }));
     child.on("close", (code) => resolveResult({ code: code ?? 0, stderr }));
-    child.stdin.end('{"stop_hook_active":false}');
+    child.stdin.end(JSON.stringify({ stop_hook_active: false, session_id: sessionId }));
   });
 }
 
@@ -129,13 +130,14 @@ export default function (pi: ExtensionAPI) {
     return { block: true, reason: result.stderr.trim() || "denied by the watcher-arm PreToolUse seatbelt" };
   });
 
-  pi.on("agent_settled", async () => {
+  pi.on("agent_settled", async (_event, ctx) => {
     if (guardFollowupActive) {
       guardFollowupActive = false;
       return;
     }
 
-    const result = await runGuard();
+    const sessionId = String(ctx?.sessionManager?.getSessionId?.() ?? "unknown");
+    const result = await runGuard(sessionId);
     if (result.code !== 2) return;
 
     guardFollowupActive = true;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,7 @@ data/                personal fleet records; LOCAL, gitignored as a whole
   captain.md         this home's domain-local captain preferences and working style; LOCAL, gitignored, canonical even if harness memory mirrors it, and updated with inspect-then-update
   captain-shared.md  main-authoritative shared captain preferences propagated read-only to secondmate homes; LOCAL, gitignored, owned by secondmate-provisioning
   learnings.md       fleet-local operational facts and gotchas; LOCAL, gitignored; dated, evidence-backed, curated, and updated with inspect-then-update - rewrite and prune rather than append forever, the same contract as captain.md; created lazily, absent until this home has a learning to store
+  memory/            private immutable session evidence and checkpoints owned by bin/fm-memory.js; never an authority over curated files, backlog, decisions, Git, PRs, tests, or live state
   projects.md        thin fleet navigation registry; firstmate-private, parsed by fm-project-mode.sh (section 6)
   secondmates.md      secondmate routing table; firstmate-private, maintained by fm-home-seed.sh (section 6)
   <id>/brief.md      per-task crewmate brief, or per-secondmate charter brief when kind=secondmate
@@ -120,6 +121,7 @@ Do not reimplement it by separately running its lock, bootstrap, or initial wake
 Tracked native session-open adapters only nudge this command; `docs/sessionstart-nudge.md` owns their enforcement mechanics and verification evidence.
 
 Read the complete digest once and trust it as this turn's startup and recovery input.
+Its bounded durable-recovery capsule is evidence to reconcile with the same digest, not a replacement authority or a reason to re-read the sources it just printed.
 Do not separately re-read the context, backlog, metadata, or bulk status inputs it just printed unless a source was reported absent or corrupt, older history is specifically needed, or a targeted workflow must inspect before writing.
 An `ABSENT` captain, shared-captain, secondmate, or learnings file means the firstmate repo's built-in defaults, no shared captain preferences, no registered secondmates, or no captured learnings; rebuild an absent or stale project registry from the clones before dispatch.
 
@@ -133,11 +135,12 @@ A lock-refused session must not spawn, steer, merge, drain the wake queue, repai
    The secondmate liveness sweep deterministically guarantees every registered secondmate is actually running: it probes each live secondmate's endpoint for a real agent process (not just pane presence), respawns only on a confident dead reading, and reports only skipped or failed guarantees as `SECONDMATE_LIVENESS:` lines (`bin/fm-bootstrap.sh`; `bin/fm-backend.sh`'s `fm_backend_agent_alive`).
 3. **Wake queue** - when locked, drains the durable wake queue and prints the raw records prominently as this turn's first work queue; a bounded, clearly labeled historical status-event annotation may follow a valid `signal` record but never replaces it or current-state reconciliation, and a lapsed watcher chain still surfaces here via the same guard alarm.
    When the lock could not be acquired, the queue is left untouched because another session owns it, and the guard's tangle/watcher-liveness alarms still print in read-only advisory mode without drain, supervision repair, or checkout repair commands.
-4. **Context digest** - the full contents of `data/projects.md`, `data/secondmates.md`, `data/captain.md`, `data/captain-shared.md`, and `data/learnings.md`, each clearly delimited.
+4. **Durable recovery** - prints one bounded validated recovery capsule; a lock-refused session reads only, while the lock holder records the session-start boundary through `bin/fm-memory.js`.
+5. **Context digest** - the full contents of `data/projects.md`, `data/secondmates.md`, `data/captain.md`, `data/captain-shared.md`, and `data/learnings.md`, each clearly delimited.
    A file that does not exist prints an explicit `ABSENT` marker, never confused with an empty-but-present file: absence is meaningful (`captain.md` absent means use the firstmate repo's built-in defaults, `projects.md` absent means rebuild it from the clones under `projects/`, etc.).
-5. **Fleet-state digest** - the compact backlog listing owned by `bin/fm-session-start.sh`; every `state/<id>.meta`; a bounded tail of each task's `state/<id>.status` (labeled as wake-EVENT history, not current state, with the full log path printed for a deeper read); the `state/.afk` flag; and one cheap alive/dead read of each task's recorded backend endpoint.
+6. **Fleet-state digest** - the compact backlog listing owned by `bin/fm-session-start.sh`; every `state/<id>.meta`; a bounded tail of each task's `state/<id>.status` (labeled as wake-EVENT history, not current state, with the full log path printed for a deeper read); the `state/.afk` flag; and one cheap alive/dead read of each task's recorded backend endpoint.
    That liveness line is a fast presence check only, not a full state read - when you need a crew's actual current state (a run-step, not just "is the pane there"), read it with `bin/fm-crew-state.sh <id>` as before; the digest deliberately skips that deeper, slower read for every task so it stays fast and bounded.
-6. **Supervision operating instructions and next step** - after the wake queue and before context, the digest emits exactly one operating block for the detected primary harness.
+7. **Supervision operating instructions and next step** - after durable recovery and before context, the digest emits exactly one operating block for the detected primary harness.
    The closing reminder points back to that emitted block and preserves only the lock, afk, X-mode, and read-once reminders.
    The script itself never starts supervision; the emitted harness protocol owns the exact wait or wake mechanism.
 
@@ -206,6 +209,8 @@ Firstmate never writes a project's `AGENTS.md` directly.
 A crewmate creates or updates it lazily through the project's selected delivery path, using `bin/fm-ensure-agents-md.sh` and preferring pointers to authoritative sources over copied detail.
 Keep fleet delivery posture and captain-private strategy out of project memory.
 When the captain invokes `/stow`, load the `stow` skill for the complete knowledge-routing and unfinished-work sweep.
+Load `durable-memory-recovery` before manual compaction or reset, after detected context loss, and whenever recovery reports a contradiction; runtime summaries never override current authority.
+Record meaningful objectives, captain decisions or approvals, blockers, task transitions, and artifact, PR, or test outcomes through `bin/fm-memory.sh` as they occur; never record transcript dumps, secrets, or private reasoning.
 
 ## 7. Task lifecycle
 
@@ -460,6 +465,7 @@ These skills are not captain-invocable; load them only at their precise triggers
 - `fmx-respond` - load on an `x-mention <request_id>` `check:` wake to handle the mention, on an `x-mode-error ...` `check:` wake to report the X-mode configuration blocker, and on any milestone or terminal wake for an X-mode-linked task before posting its completion follow-up; relevant only when X mode is on.
 - `firstmate-codexapp` - load before coordinating a visible Codex Desktop thread, evaluating a Codex App backend request, or reconciling Codex Desktop host-tool smoke evidence for Firstmate work.
 - `firstmate-coding-guidelines` - load before changing firstmate's shared, tracked material, as defined by section 1's list, whether editing directly or briefing a crewmate for a firstmate-repo task.
+- `durable-memory-recovery` - load before manual compaction or context reset, after detected compaction or missing context, and whenever the recovery capsule reports stale, disputed, or unverifiable evidence.
 
 ## 14. X mode
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Launching a supported harness inside it instantiates your first mate - and makes
 - **Event-driven, zero-token supervision** - a bash watcher sleeps on the fleet and wakes the first mate only when something needs you; verified primary harnesses also get a turn-end backstop that blocks or follows up on a blind stop when work is under way and supervision is not live.
 - **Optional X mode** - opt in with one local `.env` token so firstmate can answer your public `@myfirstmate` mentions, act on normal reversible mention requests through the same lifecycle as chat requests, acknowledge spawned work, and post up to three public-safe completion follow-ups within seven days for genuine milestones and the final outcome without changing non-X behavior; dry-run preview records would-be replies and dismissals locally before go-live.
 - **Guarded by construction** - the first mate is read-only over your projects except for the guarded paths authorized by [hard rule 1](AGENTS.md#1-identity-and-prime-directives), with fleet sync's safe branch pruning remaining part of the fleet-sync exception; crewmates make every project change behind the configured merge authority.
-- **Restart-proof** - all state lives on disk and in the active session backend (tmux by hard default, herdr or cmux when selected or auto-detected, zellij/orca when explicitly selected); kill the session anytime and the next one reconciles, including confirmed-dead secondmate agents, and carries on.
+- **Restart- and compaction-resilient** - authoritative state stays on disk and in the active session backend, while bounded private checkpoints preserve recovery evidence outside model context; the next session or compacted turn reconciles current authority and carries on.
 
 Full detail on every feature lives in [docs/architecture.md](docs/architecture.md).
 
@@ -191,6 +191,7 @@ Firstmate's skills live in two separate places with different audiences:
 - [docs/orca-backend.md](docs/orca-backend.md) - setup guide for the experimental Orca backend, plus its lifecycle notes and known gaps.
 - [docs/cmux-backend.md](docs/cmux-backend.md) - setup guide for the experimental cmux backend, plus its verification notes and known gaps.
 - [docs/codex-app-backend.md](docs/codex-app-backend.md) - Codex App backend boundary, evidence, and rollout contract.
+- [docs/durable-memory.md](docs/durable-memory.md) - private bounded recovery evidence, compaction integration, runtime support, and limitations.
 - [docs/turnend-guard.md](docs/turnend-guard.md) - the primary session's structural "no turn ends blind" backstop: verified per-harness hook mechanisms, scoping, loop safety, and fail-open tradeoffs.
 - [docs/supervision-protocols/](docs/supervision-protocols/) - rendered primary-harness watcher protocols for Claude, Codex, OpenCode, Pi, Grok, and unknown harness fallback.
 - [docs/scripts.md](docs/scripts.md) - the `bin/` toolbelt reference.

--- a/bin/fm-memory-codex-hook.sh
+++ b/bin/fm-memory-codex-hook.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MODE=${1:-}
+PAYLOAD=$(cat 2>/dev/null || true)
+[ -n "$PAYLOAD" ] || exit 0
+
+case "$MODE" in
+  pre)
+    printf '%s' "$PAYLOAD" | "$SCRIPT_DIR/fm-memory.sh" boundary --reason pre-compact --runtime codex >/dev/null 2>&1 || true
+    ;;
+  post)
+    CAPSULE=$("$SCRIPT_DIR/fm-memory.sh" recover --max-events 20 2>/dev/null) || exit 0
+    printf '%s' "$CAPSULE" | node -e '
+let value = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => { value += chunk; });
+process.stdin.on("end", () => process.stdout.write(`${JSON.stringify({ continue: true, systemMessage: value })}\n`));
+'
+    ;;
+  *)
+    exit 0
+    ;;
+esac

--- a/bin/fm-memory-codex-hook.sh
+++ b/bin/fm-memory-codex-hook.sh
@@ -11,12 +11,35 @@ case "$MODE" in
     printf '%s' "$PAYLOAD" | "$SCRIPT_DIR/fm-memory.sh" boundary --reason pre-compact --runtime codex >/dev/null 2>&1 || true
     ;;
   post)
-    CAPSULE=$("$SCRIPT_DIR/fm-memory.sh" recover --max-events 20 2>/dev/null) || exit 0
+    printf '%s' "$PAYLOAD" | "$SCRIPT_DIR/fm-memory.sh" codex-stage-recovery >/dev/null 2>&1 || true
+    ;;
+  stop)
+    STOP_HOOK_ACTIVE=$(printf '%s' "$PAYLOAD" | node -e '
+let value = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => { value += chunk; });
+process.stdin.on("end", () => {
+  try { process.stdout.write(JSON.parse(value).stop_hook_active ? "true" : "false"); } catch { process.stdout.write("invalid"); }
+});
+')
+    if [ "$STOP_HOOK_ACTIVE" = "true" ]; then
+      printf '%s' "$PAYLOAD" | "$SCRIPT_DIR/fm-memory.sh" codex-claim-recovery --event Stop >/dev/null 2>&1 || true
+      exit 0
+    fi
+    [ "$STOP_HOOK_ACTIVE" = "false" ] || exit 0
+    CAPSULE=$(printf '%s' "$PAYLOAD" | "$SCRIPT_DIR/fm-memory.sh" codex-claim-recovery --event Stop --retain 2>/dev/null) || exit 0
+    [ -n "$CAPSULE" ] || exit 0
+    printf '%s\n' "$CAPSULE" >&2
+    exit 2
+    ;;
+  prompt)
+    CAPSULE=$(printf '%s' "$PAYLOAD" | "$SCRIPT_DIR/fm-memory.sh" codex-claim-recovery --event UserPromptSubmit 2>/dev/null) || exit 0
+    [ -n "$CAPSULE" ] || exit 0
     printf '%s' "$CAPSULE" | node -e '
 let value = "";
 process.stdin.setEncoding("utf8");
 process.stdin.on("data", (chunk) => { value += chunk; });
-process.stdin.on("end", () => process.stdout.write(`${JSON.stringify({ continue: true, systemMessage: value })}\n`));
+process.stdin.on("end", () => process.stdout.write(`${JSON.stringify({ hookSpecificOutput: { hookEventName: "UserPromptSubmit", additionalContext: value } })}\n`));
 '
     ;;
   *)

--- a/bin/fm-memory.js
+++ b/bin/fm-memory.js
@@ -25,10 +25,11 @@
  * overwritten. The sidecar hashes the exact Markdown bytes.
  *
  * Bounds: 8192-byte event payload, 65536-byte checkpoint input, 5000 events,
- * 1000 checkpoints, 20 search results by default (max 100), 12000-byte recovery
- * capsule. Restricted events and checkpoints are excluded from search unless
- * explicitly requested; curated files retain file-level access. Capacity
- * exhaustion refuses rather than deleting evidence.
+ * 1000 retained checkpoints, 20 search results by default (max 100), 12000-byte
+ * recovery capsule. Restricted events and checkpoints are excluded from search
+ * unless explicitly requested; curated files retain file-level access. Event
+ * capacity exhaustion refuses, while checkpoint publication retains the newest
+ * validated 1000 records and removes older checkpoint/hash pairs.
  *
  * Usage:
  *   fm-memory.sh event --type TYPE [scope flags] [--payload-file FILE|-]
@@ -36,6 +37,8 @@
  *   fm-memory.sh boundary --reason REASON [--runtime NAME]
  *   fm-memory.sh validate [checkpoint-file]
  *   fm-memory.sh recover [--max-events N]
+ *   fm-memory.sh codex-stage-recovery
+ *   fm-memory.sh codex-claim-recovery --event Stop|UserPromptSubmit
  *   fm-memory.sh search [--query TEXT] [--kind events|checkpoints|curated]
  *                       [--project P] [--task T] [--type T] [--status S] [--since ISO]
  *                       [--limit N] [--include-sensitive]
@@ -55,6 +58,7 @@ import { fileURLToPath } from "node:url";
 
 const SCHEMA_EVENT = "fm.memory.event.v1";
 const SCHEMA_CHECKPOINT = "fm.memory.checkpoint.v1";
+const SCHEMA_CODEX_RECOVERY = "fm.memory.codex-recovery.v1";
 const MAX_EVENT_PAYLOAD = 8192;
 const MAX_CHECKPOINT_INPUT = 65536;
 const MAX_EVENTS = 5000;
@@ -77,7 +81,7 @@ function argsOf(argv) {
     const arg = argv[i];
     if (!arg.startsWith("--")) { out._.push(arg); continue; }
     const key = arg.slice(2);
-    if (["include-sensitive", "read-only"].includes(key)) { out[key] = true; continue; }
+    if (["include-sensitive", "read-only", "retain"].includes(key)) { out[key] = true; continue; }
     if (i + 1 >= argv.length) fail(`missing value for ${arg}`);
     out[key] = argv[++i];
   }
@@ -237,6 +241,24 @@ function atomicCreate(layout, file, bytes) {
     try { fs.fsyncSync(dfd); } finally { fs.closeSync(dfd); }
   } catch { /* Directory fsync is unavailable on some filesystems. */ }
   return created;
+}
+
+function atomicReplace(layout, file, bytes) {
+  ensurePrivateDirectory(layout, path.dirname(file));
+  const tmp = path.join(path.dirname(file), `.${path.basename(file)}.${process.pid}.${crypto.randomBytes(4).toString("hex")}.tmp`);
+  const fd = fs.openSync(tmp, "wx", 0o600);
+  try {
+    fs.writeFileSync(fd, bytes);
+    fs.fsyncSync(fd);
+  } finally { fs.closeSync(fd); }
+  try { fs.renameSync(tmp, file); } catch (error) {
+    try { fs.unlinkSync(tmp); } catch { }
+    throw error;
+  }
+  try {
+    const dfd = fs.openSync(path.dirname(file), "r");
+    try { fs.fsyncSync(dfd); } finally { fs.closeSync(dfd); }
+  } catch { }
 }
 
 function processAlive(pid) {
@@ -486,8 +508,6 @@ function checkpointCommand(opts, supplied) {
     try { input = JSON.parse(raw); } catch { fail("checkpoint input must be valid JSON"); }
   }
   const result = withWriteLock(layout, () => {
-    const files = listFiles(path.join(layout.memory, "checkpoints"), ".md");
-    if (files.length >= MAX_CHECKPOINTS) fail(`checkpoint capacity ${MAX_CHECKPOINTS} reached; archive this home's memory before writing more`);
     if (allEvents(layout).length >= MAX_EVENTS) fail(`event capacity ${MAX_EVENTS} reached; archive this home's memory before writing more`);
     const cp = normalizeCheckpoint(input, opts, layout);
     const markdown = checkpointMarkdown(cp);
@@ -498,11 +518,32 @@ function checkpointCommand(opts, supplied) {
     const checked = parseCheckpoint(file, layout);
     if (!checked.valid) fail(`checkpoint read-back validation failed: ${checked.reason}`);
     writeEvent(layout, opts, { type: "checkpoint", runtime: cp.runtime, session: cp.session, project: cp.project, payload: { checkpoint_id: cp.checkpoint_id, reason: cp.reason, event_high_water: cp.event_high_water }, sources: [`checkpoint:${cp.checkpoint_id}`], idempotency: cp.checkpoint_id, quiet: true });
+    retainRecentCheckpoints(layout, file);
     return { cp, file };
   });
   const { cp, file } = result;
   process.stdout.write(`${file}\n`);
   return cp;
+}
+
+function retainRecentCheckpoints(layout, protectedFile) {
+  const dir = path.join(layout.memory, "checkpoints");
+  const files = listFiles(dir, ".md");
+  const removable = files.filter((file) => path.resolve(file) !== path.resolve(protectedFile));
+  while (removable.length > MAX_CHECKPOINTS - 1) {
+    const file = removable.shift();
+    if (!file) break;
+    try { fs.unlinkSync(file); } catch (error) {
+      if (error?.code !== "ENOENT") throw error;
+    }
+    try { fs.unlinkSync(`${file}.sha256`); } catch (error) {
+      if (error?.code !== "ENOENT") throw error;
+    }
+  }
+  try {
+    const dfd = fs.openSync(dir, "r");
+    try { fs.fsyncSync(dfd); } finally { fs.closeSync(dfd); }
+  } catch { }
 }
 
 function lockOwned(layout) {
@@ -607,12 +648,15 @@ function reconcile(cp, layout) {
 
 function recoverCommand(opts) {
   const layout = resolvedLayout();
+  process.stdout.write(recoveryCapsule(layout, opts));
+}
+
+function recoveryCapsule(layout, opts) {
   const latest = latestCheckpoint(layout);
   const maxEvents = Math.max(0, Math.min(Number(opts["max-events"] || 20), 100));
   if (!latest.valid) {
     const note = latest.invalid.length ? `; ${latest.invalid.length} invalid checkpoint(s) ignored` : "";
-    process.stdout.write(`RECOVERY CAPSULE\ncheckpoint: none${note}\nobjective: use the session-start digest and authoritative records\nnext safe action: establish an objective and write a validated checkpoint before consequential work\n`);
-    return;
+    return `RECOVERY CAPSULE\ncheckpoint: none${note}\nobjective: use the session-start digest and authoritative records\nnext safe action: establish an objective and write a validated checkpoint before consequential work\n`;
   }
   const cp = latest.checkpoint;
   const events = allEvents(layout);
@@ -644,7 +688,61 @@ function recoverCommand(opts) {
     while (end > 0 && (bytes[end] & 0xc0) === 0x80) end -= 1;
     output = `${bytes.subarray(0, end).toString("utf8")}${suffix}`;
   }
-  process.stdout.write(output);
+  return output;
+}
+
+function codexHookPayload(raw, expectedEvent) {
+  let payload;
+  try { payload = JSON.parse(raw); } catch { fail("Codex hook payload must be valid JSON"); }
+  if (payload.hook_event_name !== expectedEvent) fail(`expected ${expectedEvent} hook payload`);
+  return {
+    session: safeName(payload.session_id, "Codex session"),
+    turn: safeName(payload.turn_id, "Codex turn"),
+    trigger: payload.trigger ? safeName(payload.trigger, "Codex compaction trigger") : "unknown",
+  };
+}
+
+function codexRecoveryFile(layout, session) {
+  return path.join(layout.memory, "pending", "codex", `${session}.json`);
+}
+
+function codexStageRecoveryCommand() {
+  const layout = resolvedLayout();
+  if (!lockOwned(layout)) fail("Codex recovery staging requires the active home session lock");
+  const payload = codexHookPayload(readStdinBounded(16384), "PostCompact");
+  withWriteLock(layout, () => {
+    const record = {
+      schema: SCHEMA_CODEX_RECOVERY,
+      session: payload.session,
+      turn: payload.turn,
+      trigger: payload.trigger,
+      staged_at: now(),
+      capsule: recoveryCapsule(layout, { "max-events": 20 }),
+    };
+    atomicReplace(layout, codexRecoveryFile(layout, payload.session), `${stableJson(record)}\n`);
+  });
+}
+
+function codexClaimRecoveryCommand(opts) {
+  const layout = resolvedLayout();
+  if (!lockOwned(layout)) return;
+  const event = opts.event;
+  if (!new Set(["Stop", "UserPromptSubmit"]).has(event)) fail("--event must be Stop or UserPromptSubmit");
+  const payload = codexHookPayload(readStdinBounded(16384), event);
+  const capsule = withWriteLock(layout, () => {
+    const file = codexRecoveryFile(layout, payload.session);
+    let stat;
+    try { stat = fs.lstatSync(file); } catch (error) {
+      if (error?.code === "ENOENT") return "";
+      throw error;
+    }
+    if (!stat.isFile() || stat.isSymbolicLink() || stat.size > 32768) fail("pending Codex recovery is not a bounded regular file");
+    const record = JSON.parse(fs.readFileSync(file, "utf8"));
+    if (record.schema !== SCHEMA_CODEX_RECOVERY || record.session !== payload.session || typeof record.capsule !== "string" || Buffer.byteLength(record.capsule) > MAX_CAPSULE) fail("pending Codex recovery record is invalid");
+    if (!opts.retain) fs.unlinkSync(file);
+    return record.capsule;
+  });
+  if (capsule) process.stdout.write(capsule);
 }
 
 function searchCommand(opts) {
@@ -718,7 +816,7 @@ function transcriptRefCommand(opts) {
 }
 
 function help() {
-  process.stdout.write("Usage: fm-memory.sh event|checkpoint|boundary|validate|recover|search|transcript-ref [options]\nSee bin/fm-memory.js header and docs/durable-memory.md for the canonical contracts.\n");
+  process.stdout.write("Usage: fm-memory.sh event|checkpoint|boundary|validate|recover|search|transcript-ref|codex-stage-recovery|codex-claim-recovery [options]\nSee bin/fm-memory.js header and docs/durable-memory.md for the canonical contracts.\n");
 }
 
 const [command, ...rest] = process.argv.slice(2);
@@ -734,6 +832,8 @@ try {
     if (!result.valid) fail(`checkpoint invalid: ${result.reason || "none found"}`, 1);
     process.stdout.write(`${result.checkpoint.checkpoint_id}\n`);
   } else if (command === "recover") recoverCommand(opts);
+  else if (command === "codex-stage-recovery") codexStageRecoveryCommand();
+  else if (command === "codex-claim-recovery") codexClaimRecoveryCommand(opts);
   else if (command === "search") searchCommand(opts);
   else if (command === "transcript-ref") transcriptRefCommand(opts);
   else if (command === "--help" || command === "help" || !command) help();

--- a/bin/fm-memory.js
+++ b/bin/fm-memory.js
@@ -1,0 +1,604 @@
+#!/usr/bin/env node
+/*
+ * fm-memory.js - canonical private durable session-memory owner.
+ *
+ * Canonical files live under $FM_DATA_OVERRIDE/memory or
+ * $FM_HOME/data/memory. Events are immutable, one-file append records under
+ * events/<writer>/; this per-writer layout avoids a shared append race.
+ * Checkpoints are immutable Markdown plus a SHA-256 sidecar under checkpoints/.
+ * Canonical files never depend on the optional search projection.
+ *
+ * Event schema fm.memory.event.v1:
+ *   schema, event_id, sequence, created_at, writer, runtime, session, task,
+ *   project, type, payload, sources[], sensitivity, previous_high_water.
+ * sequence is the sortable <UTC milliseconds>-<event id prefix>. Retries with
+ * the same --idempotency-key resolve to the same event_id and never append a
+ * duplicate. Payload JSON is limited to 8192 bytes; source references to 32.
+ *
+ * Checkpoint schema fm.memory.checkpoint.v1 is the JSON object inside the
+ * generated Markdown fence. It carries checkpoint_id, created_at, reason,
+ * runtime/session/project scope, event_high_water, objective, completed,
+ * pending, decisions, constraints, blockers, active_tasks, evidence,
+ * next_safe_action, provenance, and sensitivity. Input is JSON from --input
+ * or stdin. Unknown fields are rejected. Files are temp-written, fsynced,
+ * atomically renamed, read back, schema/high-water validated, and never
+ * overwritten. The sidecar hashes the exact Markdown bytes.
+ *
+ * Bounds: 8192-byte event payload, 65536-byte checkpoint input, 5000 events,
+ * 1000 checkpoints, 20 search results by default (max 100), 12000-byte recovery
+ * capsule. Restricted records are excluded from search unless explicitly
+ * requested. Capacity exhaustion refuses rather than deleting evidence.
+ *
+ * Usage:
+ *   fm-memory.sh event --type TYPE [scope flags] [--payload-file FILE|-]
+ *   fm-memory.sh checkpoint --reason REASON [--input FILE|-]
+ *   fm-memory.sh boundary --reason turn-end|manual-compaction [--runtime NAME]
+ *   fm-memory.sh validate [checkpoint-file]
+ *   fm-memory.sh recover [--max-events N]
+ *   fm-memory.sh search [--query TEXT] [--kind events|checkpoints|curated]
+ *                       [--project P] [--task T] [--type T] [--status S] [--since ISO]
+ *                       [--limit N] [--include-sensitive]
+ *   fm-memory.sh transcript-ref --runtime NAME --session ID [--path FILE]
+ *
+ * This implementation was inspired by Nous Research Hermes Agent's durable
+ * session lineage, bounded retrieval, pre-compression memory callback, atomic
+ * curated-memory writes, and source-first search policy. It is an independent
+ * Node/shell implementation for Firstmate, not format-compatible copied code.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import crypto from "node:crypto";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const SCHEMA_EVENT = "fm.memory.event.v1";
+const SCHEMA_CHECKPOINT = "fm.memory.checkpoint.v1";
+const MAX_EVENT_PAYLOAD = 8192;
+const MAX_CHECKPOINT_INPUT = 65536;
+const MAX_EVENTS = 5000;
+const MAX_CHECKPOINTS = 1000;
+const MAX_CAPSULE = 12000;
+const TYPES = new Set(["objective", "decision", "approval", "blocker", "task-transition", "artifact", "pr", "test", "checkpoint", "recovery", "session-lineage"]);
+const SENSITIVITY = new Set(["internal", "private", "restricted"]);
+const CHECKPOINT_KEYS = new Set(["runtime", "session", "project", "objective", "completed", "pending", "decisions", "constraints", "blockers", "active_tasks", "evidence", "next_safe_action", "provenance", "sensitivity", "event_high_water"]);
+const SECRET_RE = /(-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----|["']?\b(?:api[_-]?key|access[_-]?token|refresh[_-]?token|client[_-]?secret|password)\b["']?\s*[:=]\s*["']?[^\s"']{6,}|\b(?:bearer|basic)\s+[A-Za-z0-9+/_=-]{12,}|\b(?:gh[opusr]_|sk-[A-Za-z0-9])\S{8,})/i;
+const COT_RE = /\b(chain[- ]of[- ]thought|hidden reasoning|private reasoning|scratchpad reasoning)\b/i;
+
+function fail(message, code = 2) {
+  process.stderr.write(`fm-memory: ${message}\n`);
+  process.exit(code);
+}
+
+function argsOf(argv) {
+  const out = { _: [] };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (!arg.startsWith("--")) { out._.push(arg); continue; }
+    const key = arg.slice(2);
+    if (["include-sensitive", "read-only"].includes(key)) { out[key] = true; continue; }
+    if (i + 1 >= argv.length) fail(`missing value for ${arg}`);
+    out[key] = argv[++i];
+  }
+  return out;
+}
+
+function resolvedLayout() {
+  const root = process.env.FM_ROOT_OVERRIDE || path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+  const home = process.env.FM_HOME || process.env.FM_ROOT_OVERRIDE || root;
+  const data = process.env.FM_DATA_OVERRIDE || path.join(home, "data");
+  const state = process.env.FM_STATE_OVERRIDE || path.join(home, "state");
+  return { root: path.resolve(root), home: path.resolve(home), data: path.resolve(data), state: path.resolve(state), memory: path.resolve(data, "memory") };
+}
+
+function inside(child, parent) {
+  const rel = path.relative(parent, child);
+  return rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel));
+}
+
+function safeName(value, label, fallback = "none") {
+  const text = String(value || fallback);
+  if (!/^[A-Za-z0-9._-]{1,128}$/.test(text)) fail(`unsafe ${label}: ${text}`);
+  return text;
+}
+
+function mkdirPrivate(dir) {
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  fs.chmodSync(dir, 0o700);
+}
+
+function sha(value) { return crypto.createHash("sha256").update(value).digest("hex"); }
+function hashFile(file, maxBytes = 100 * 1024 * 1024) {
+  const stat = fs.statSync(file);
+  if (stat.size > maxBytes) fail(`evidence file exceeds ${maxBytes} bytes`);
+  const hash = crypto.createHash("sha256");
+  const fd = fs.openSync(file, "r");
+  const buffer = Buffer.alloc(64 * 1024);
+  let offset = 0;
+  try {
+    while (offset < stat.size) {
+      const read = fs.readSync(fd, buffer, 0, Math.min(buffer.length, stat.size - offset), offset);
+      if (!read) break;
+      hash.update(buffer.subarray(0, read));
+      offset += read;
+    }
+  } finally { fs.closeSync(fd); }
+  return hash.digest("hex");
+}
+function canonical(value) {
+  if (Array.isArray(value)) return value.map(canonical);
+  if (value && typeof value === "object") return Object.fromEntries(Object.keys(value).sort().map((key) => [key, canonical(value[key])]));
+  return value;
+}
+function stableJson(value) { return JSON.stringify(canonical(value)); }
+function now() { return new Date().toISOString(); }
+function compactTime(iso) { return iso.replace(/[-:.TZ]/g, "").slice(0, 17); }
+
+function readBounded(file, limit) {
+  if (file === "-") {
+    return readStdinBounded(limit);
+  }
+  const target = path.resolve(file);
+  const stat = fs.lstatSync(target);
+  if (!stat.isFile() || stat.isSymbolicLink()) fail("input must be a regular non-symlink file");
+  if (stat.size > limit) fail(`input exceeds ${limit} bytes`);
+  return fs.readFileSync(target, "utf8");
+}
+
+function readStdinBounded(limit) {
+  const chunks = [];
+  const buffer = Buffer.alloc(Math.min(64 * 1024, limit + 1));
+  let total = 0;
+  while (total <= limit) {
+    const read = fs.readSync(0, buffer, 0, Math.min(buffer.length, limit + 1 - total), null);
+    if (!read) break;
+    chunks.push(Buffer.from(buffer.subarray(0, read)));
+    total += read;
+  }
+  if (total > limit) fail(`stdin exceeds ${limit} bytes`);
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+function rejectSecrets(value) {
+  const text = typeof value === "string" ? value : stableJson(value);
+  if (SECRET_RE.test(text)) fail("content resembles a secret or credential");
+  if (COT_RE.test(text)) fail("chain-of-thought or private reasoning is not valid memory evidence");
+}
+
+function atomicCreate(file, bytes) {
+  mkdirPrivate(path.dirname(file));
+  const tmp = path.join(path.dirname(file), `.${path.basename(file)}.${process.pid}.${crypto.randomBytes(4).toString("hex")}.tmp`);
+  const fd = fs.openSync(tmp, "wx", 0o600);
+  try {
+    fs.writeFileSync(fd, bytes);
+    fs.fsyncSync(fd);
+  } finally { fs.closeSync(fd); }
+  let created = true;
+  try { fs.linkSync(tmp, file); } catch (error) {
+    if (error.code !== "EEXIST") throw error;
+    created = false;
+  } finally { fs.unlinkSync(tmp); }
+  try {
+    const dfd = fs.openSync(path.dirname(file), "r");
+    try { fs.fsyncSync(dfd); } finally { fs.closeSync(dfd); }
+  } catch { /* Directory fsync is unavailable on some filesystems. */ }
+  return created;
+}
+
+function listFiles(dir, suffix) {
+  if (!fs.existsSync(dir)) return [];
+  const out = [];
+  for (const ent of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, ent.name);
+    if (ent.isDirectory()) out.push(...listFiles(full, suffix));
+    else if (ent.isFile() && ent.name.endsWith(suffix)) out.push(full);
+  }
+  return out.sort();
+}
+
+function readEvent(file) {
+  try {
+    const stat = fs.lstatSync(file);
+    if (!stat.isFile() || stat.isSymbolicLink() || stat.size > 32768) return null;
+    const event = JSON.parse(fs.readFileSync(file, "utf8"));
+    if (event.schema !== SCHEMA_EVENT || !event.event_id || !event.sequence || !event.created_at) return null;
+    return event;
+  } catch { return null; }
+}
+
+function allEvents(layout) {
+  return listFiles(path.join(layout.memory, "events"), ".json").map(readEvent).filter(Boolean).sort((a, b) => `${a.sequence}|${a.event_id}`.localeCompare(`${b.sequence}|${b.event_id}`));
+}
+
+function highWater(events) {
+  const last = events.at(-1);
+  return last ? `${last.sequence}|${last.event_id}` : "none";
+}
+
+function parsePayload(opts) {
+  if (!opts["payload-file"]) return {};
+  const raw = readBounded(opts["payload-file"], MAX_EVENT_PAYLOAD);
+  try { return JSON.parse(raw || "{}"); } catch { return { summary: raw.trim() }; }
+}
+
+function eventCommand(opts, forced = {}) {
+  const layout = resolvedLayout();
+  const type = forced.type || opts.type;
+  if (!TYPES.has(type)) fail(`unsupported event type: ${type || "(missing)"}`);
+  const writer = safeName(forced.writer || opts.writer || `${opts.runtime || "unknown"}-${opts.session || process.pid}`, "writer");
+  const runtime = safeName(forced.runtime || opts.runtime || "unknown", "runtime");
+  const session = safeName(forced.session || opts.session || "unknown", "session");
+  const task = safeName(forced.task || opts.task || "none", "task");
+  const project = safeName(forced.project || opts.project || "none", "project");
+  const sensitivity = forced.sensitivity || opts.sensitivity || "private";
+  if (!SENSITIVITY.has(sensitivity)) fail(`unsupported sensitivity: ${sensitivity}`);
+  const payload = forced.payload ?? parsePayload(opts);
+  const sources = forced.sources || (opts.source ? String(opts.source).split(",").map((v) => v.trim()).filter(Boolean) : []);
+  if (sources.length > 32 || sources.some((v) => typeof v !== "string" || v.length > 512)) fail("source references exceed bounds");
+  const payloadBytes = Buffer.byteLength(stableJson(payload));
+  if (payloadBytes > MAX_EVENT_PAYLOAD) fail(`event payload exceeds ${MAX_EVENT_PAYLOAD} bytes`);
+  rejectSecrets(payload);
+  rejectSecrets(sources);
+  const events = allEvents(layout);
+  if (events.length >= MAX_EVENTS) fail(`event capacity ${MAX_EVENTS} reached; archive this home's memory before writing more`);
+  const idempotency = opts["idempotency-key"] || forced.idempotency || stableJson({ type, writer, runtime, session, task, project, payload, sources });
+  if (String(idempotency).length > 512) fail("idempotency key exceeds 512 characters");
+  const eventId = `ev_${sha(`${SCHEMA_EVENT}\0${writer}\0${idempotency}`).slice(0, 24)}`;
+  const existing = events.find((item) => item.event_id === eventId);
+  if (existing) {
+    const retryShape = { runtime, session, task, project, type, payload, sources, sensitivity };
+    const existingShape = Object.fromEntries(Object.keys(retryShape).map((key) => [key, existing[key]]));
+    if (stableJson(retryShape) !== stableJson(existingShape)) fail("idempotency key already belongs to a different event");
+    if (!forced.quiet) process.stdout.write(`${existing.event_id}\n`);
+    return existing;
+  }
+  const createdAt = forced.createdAt || now();
+  const record = {
+    schema: SCHEMA_EVENT,
+    event_id: eventId,
+    sequence: `${compactTime(createdAt)}-${eventId.slice(3, 11)}`,
+    created_at: createdAt,
+    writer, runtime, session, task, project, type, payload, sources,
+    sensitivity,
+    previous_high_water: highWater(events),
+  };
+  const file = path.join(layout.memory, "events", writer, `${eventId}.json`);
+  const created = atomicCreate(file, `${stableJson(record)}\n`);
+  if (!created) {
+    const winner = readEvent(file);
+    const retryShape = { runtime, session, task, project, type, payload, sources, sensitivity };
+    const winnerShape = winner && Object.fromEntries(Object.keys(retryShape).map((key) => [key, winner[key]]));
+    if (!winner || stableJson(retryShape) !== stableJson(winnerShape)) fail("concurrent idempotency key conflict");
+    if (!forced.quiet) process.stdout.write(`${winner.event_id}\n`);
+    return winner;
+  }
+  if (!forced.quiet) process.stdout.write(`${eventId}\n`);
+  return record;
+}
+
+function currentGitEvidence(layout) {
+  try {
+    const head = execFileSync("git", ["-C", layout.root, "rev-parse", "HEAD"], { encoding: "utf8", timeout: 2000 }).trim();
+    const dirty = execFileSync("git", ["-C", layout.root, "status", "--porcelain"], { encoding: "utf8", timeout: 2000 }).trim() !== "";
+    return { kind: "git", ref: layout.root, expected: { head, dirty } };
+  } catch { return { kind: "git", ref: layout.root, expected: { unavailable: true } }; }
+}
+
+function activeTaskRefs(layout) {
+  if (!fs.existsSync(layout.state)) return [];
+  return fs.readdirSync(layout.state).filter((name) => name.endsWith(".meta")).sort().slice(0, 100).map((name) => name.slice(0, -5));
+}
+
+function validateEvidence(evidence, layout) {
+  for (const item of evidence) {
+    if (!item || typeof item !== "object" || Array.isArray(item) || typeof item.kind !== "string" || typeof item.ref !== "string") fail("checkpoint evidence entries require kind and ref strings");
+    if (item.kind === "task") {
+      const task = safeName(item.ref, "task evidence");
+      if (!fs.existsSync(path.join(layout.state, `${task}.meta`))) fail(`task evidence is not currently verifiable: ${task}`);
+    } else if (item.kind === "git") {
+      if (path.resolve(item.ref) !== layout.root || typeof item.expected?.head !== "string") fail("git evidence must reference the active root and expected HEAD");
+      let head;
+      try { head = execFileSync("git", ["-C", layout.root, "rev-parse", "HEAD"], { encoding: "utf8", timeout: 2000 }).trim(); } catch { fail("git evidence is not currently verifiable"); }
+      if (head !== item.expected.head) fail("git evidence expected HEAD does not match current authority");
+    } else if (item.kind === "file") {
+      const target = path.resolve(item.ref);
+      if (!inside(target, layout.data) && !inside(target, layout.state)) fail("file evidence must remain under the active home's data or state directory");
+      const stat = fs.lstatSync(target);
+      if (!stat.isFile() || stat.isSymbolicLink() || typeof item.expected?.sha256 !== "string" || hashFile(target) !== item.expected.sha256) fail("file evidence hash is not currently verifiable");
+    } else if (!["artifact", "commit", "pr", "test", "report"].includes(item.kind) || item.validation !== "external") {
+      fail(`unsupported or unvalidated evidence kind: ${item.kind}`);
+    }
+  }
+}
+
+function normalizeCheckpoint(input, opts, layout) {
+  for (const key of Object.keys(input)) if (!CHECKPOINT_KEYS.has(key)) fail(`unknown checkpoint field: ${key}`);
+  const strings = ["objective", "next_safe_action"];
+  for (const key of strings) if (typeof input[key] !== "string" || !input[key].trim()) fail(`checkpoint ${key} is required`);
+  const arrays = ["completed", "pending", "decisions", "constraints", "blockers", "active_tasks", "evidence", "provenance"];
+  for (const key of arrays) {
+    if (input[key] === undefined) input[key] = [];
+    if (!Array.isArray(input[key]) || input[key].length > 100) fail(`checkpoint ${key} must be an array of at most 100 items`);
+  }
+  validateEvidence(input.evidence, layout);
+  rejectSecrets(input);
+  const events = allEvents(layout);
+  const eventHighWater = input.event_high_water || highWater(events);
+  if (eventHighWater !== "none" && !events.some((event) => `${event.sequence}|${event.event_id}` === eventHighWater)) fail("checkpoint event_high_water does not reference a valid event");
+  const createdAt = now();
+  const scope = {
+    runtime: safeName(input.runtime || opts.runtime || "unknown", "runtime"),
+    session: safeName(input.session || opts.session || "unknown", "session"),
+    project: safeName(input.project || opts.project || "none", "project"),
+  };
+  const reason = safeName(opts.reason || "manual", "reason");
+  const body = { schema: SCHEMA_CHECKPOINT, created_at: createdAt, reason, ...scope, event_high_water: eventHighWater, ...input };
+  delete body.checkpoint_id;
+  body.checkpoint_id = `cp_${sha(stableJson(body)).slice(0, 24)}`;
+  return body;
+}
+
+function checkpointMarkdown(cp) {
+  return `---\nschema: ${SCHEMA_CHECKPOINT}\ncheckpoint_id: ${cp.checkpoint_id}\ncreated_at: ${cp.created_at}\nreason: ${cp.reason}\nruntime: ${cp.runtime}\nsession: ${cp.session}\nproject: ${cp.project}\nsensitivity: ${cp.sensitivity || "private"}\n---\n\n# Firstmate Recovery Checkpoint\n\nThis immutable record references authoritative owners; it does not override them.\n\n\`\`\`json\n${stableJson(cp)}\n\`\`\`\n`;
+}
+
+function parseCheckpoint(file, layout = resolvedLayout()) {
+  try {
+    const target = path.resolve(file);
+    if (!inside(target, path.join(layout.memory, "checkpoints"))) return { valid: false, reason: "outside checkpoint directory" };
+    const stat = fs.lstatSync(target);
+    if (!stat.isFile() || stat.isSymbolicLink() || stat.size > 131072) return { valid: false, reason: "unsafe checkpoint file" };
+    const markdown = fs.readFileSync(target, "utf8");
+    const sidecar = `${target}.sha256`;
+    if (!fs.existsSync(sidecar) || fs.readFileSync(sidecar, "utf8").trim() !== sha(markdown)) return { valid: false, reason: "hash mismatch" };
+    const match = markdown.match(/```json\n([^\n]+)\n```/);
+    if (!match) return { valid: false, reason: "missing canonical JSON fence" };
+    const cp = JSON.parse(match[1]);
+    if (cp.schema !== SCHEMA_CHECKPOINT || !cp.checkpoint_id || !cp.objective || !cp.next_safe_action) return { valid: false, reason: "schema invalid" };
+    const claimedId = cp.checkpoint_id;
+    const unhashed = { ...cp };
+    delete unhashed.checkpoint_id;
+    if (`cp_${sha(stableJson(unhashed)).slice(0, 24)}` !== claimedId) return { valid: false, reason: "checkpoint id mismatch" };
+    const events = allEvents(layout);
+    if (cp.event_high_water !== "none" && !events.some((event) => `${event.sequence}|${event.event_id}` === cp.event_high_water)) return { valid: false, reason: "event high-water missing" };
+    return { valid: true, checkpoint: cp, file: target };
+  } catch (error) { return { valid: false, reason: error.message }; }
+}
+
+function checkpointCommand(opts, supplied) {
+  const layout = resolvedLayout();
+  if (!lockOwned(layout)) fail("checkpoint write requires the active home session lock");
+  const files = listFiles(path.join(layout.memory, "checkpoints"), ".md");
+  if (files.length >= MAX_CHECKPOINTS) fail(`checkpoint capacity ${MAX_CHECKPOINTS} reached; archive this home's memory before writing more`);
+  let input = supplied;
+  if (!input) {
+    const raw = readBounded(opts.input || "-", MAX_CHECKPOINT_INPUT);
+    try { input = JSON.parse(raw); } catch { fail("checkpoint input must be valid JSON"); }
+  }
+  const cp = normalizeCheckpoint(input, opts, layout);
+  const markdown = checkpointMarkdown(cp);
+  const dir = path.join(layout.memory, "checkpoints");
+  const file = path.join(dir, `${compactTime(cp.created_at)}-${cp.checkpoint_id}.md`);
+  atomicCreate(file, markdown);
+  atomicCreate(`${file}.sha256`, `${sha(markdown)}\n`);
+  const checked = parseCheckpoint(file, layout);
+  if (!checked.valid) fail(`checkpoint read-back validation failed: ${checked.reason}`);
+  eventCommand(opts, { type: "checkpoint", runtime: cp.runtime, session: cp.session, project: cp.project, payload: { checkpoint_id: cp.checkpoint_id, reason: cp.reason, event_high_water: cp.event_high_water }, sources: [`checkpoint:${cp.checkpoint_id}`], idempotency: cp.checkpoint_id, quiet: true });
+  process.stdout.write(`${file}\n`);
+  return cp;
+}
+
+function lockOwned(layout) {
+  const lock = path.join(layout.state, ".lock");
+  try {
+    const holder = fs.readFileSync(lock, "utf8").trim();
+    if (!/^\d+$/.test(holder) || holder === "1") return false;
+    let pid = process.pid;
+    for (let i = 0; i < 10; i += 1) {
+      if (String(pid) === holder) return true;
+      const out = execFileSync("ps", ["-o", "ppid=", "-p", String(pid)], { encoding: "utf8", timeout: 1000 }).trim();
+      if (!/^\d+$/.test(out) || out === "1") break;
+      pid = Number(out);
+    }
+    return false;
+  } catch { return false; }
+}
+
+function runtimeFromEnv(opts) {
+  if (opts.runtime) return opts.runtime;
+  if (process.env.CLAUDECODE) return "claude";
+  if (process.env.PI_CODING_AGENT) return "pi";
+  if (process.env.GROK_AGENT || process.env.GROK_HOOK_EVENT) return "grok";
+  return "unknown";
+}
+
+function payloadSession(raw) {
+  try {
+    const value = JSON.parse(raw || "{}");
+    return value.session_id || value.sessionId || value.thread_id || value.threadId || "unknown";
+  } catch { return "unknown"; }
+}
+
+function latestCheckpoint(layout) {
+  const files = listFiles(path.join(layout.memory, "checkpoints"), ".md").reverse();
+  const invalid = [];
+  for (const file of files) {
+    const result = parseCheckpoint(file, layout);
+    if (result.valid) return { ...result, invalid };
+    invalid.push({ file, reason: result.reason });
+  }
+  return { valid: false, invalid };
+}
+
+function boundaryCommand(opts) {
+  const layout = resolvedLayout();
+  if (opts["read-only"] || !lockOwned(layout)) { process.stdout.write("skipped: session lock not owned\n"); return; }
+  const raw = readStdinBounded(16384);
+  const runtime = safeName(runtimeFromEnv(opts), "runtime");
+  const session = safeName(opts.session || payloadSession(raw), "session");
+  const reason = opts.reason || "turn-end";
+  const lineage = eventCommand(opts, { type: "session-lineage", runtime, session, payload: { reason, evidence: "opaque runtime session identifier; transcript content not copied" }, sources: [`runtime:${runtime}`], idempotency: `${reason}:${runtime}:${session}:${opts["idempotency-key"] || compactTime(now()).slice(0, 12)}`, quiet: true });
+  const previous = latestCheckpoint(layout);
+  const prior = previous.valid ? previous.checkpoint : {};
+  const active = activeTaskRefs(layout);
+  const input = {
+    runtime, session, project: opts.project || prior.project || "none",
+    objective: prior.objective || "Recover the active Firstmate session from durable authority after a context boundary.",
+    completed: prior.completed || [], pending: prior.pending || [], decisions: prior.decisions || [], constraints: prior.constraints || [], blockers: prior.blockers || [],
+    active_tasks: active,
+    evidence: [...(prior.evidence || []).filter((item) => !["git", "task", "file"].includes(item?.kind)), currentGitEvidence(layout), ...active.map((task) => ({ kind: "task", ref: task, expected: { meta_present: true } }))].slice(-100),
+    next_safe_action: prior.next_safe_action || "Read the bounded recovery capsule, then reconcile it with the session-start digest before consequential work.",
+    provenance: [...(prior.provenance || []), `event:${lineage.event_id}`, "authority:data/backlog.md", "authority:state/*.meta", "authority:git"].slice(-100),
+    sensitivity: "private",
+  };
+  checkpointCommand({ ...opts, reason, runtime, session }, input);
+}
+
+function reconcile(cp, layout) {
+  const findings = [];
+  for (const evidence of cp.evidence || []) {
+    if (!evidence || typeof evidence !== "object") continue;
+    if (evidence.kind === "task") {
+      const ref = safeName(evidence.ref, "task evidence");
+      if (!fs.existsSync(path.join(layout.state, `${ref}.meta`))) findings.push(`stale: task ${ref} no longer has authoritative metadata`);
+    } else if (evidence.kind === "git" && path.resolve(evidence.ref) === layout.root && evidence.expected?.head) {
+      try {
+        const head = execFileSync("git", ["-C", layout.root, "rev-parse", "HEAD"], { encoding: "utf8", timeout: 2000 }).trim();
+        if (head !== evidence.expected.head) findings.push(`disputed: Git HEAD changed from ${evidence.expected.head.slice(0, 12)} to ${head.slice(0, 12)}`);
+        const dirty = execFileSync("git", ["-C", layout.root, "status", "--porcelain"], { encoding: "utf8", timeout: 2000 }).trim() !== "";
+        if (typeof evidence.expected.dirty === "boolean" && dirty !== evidence.expected.dirty) findings.push(`disputed: Git dirty state changed from ${evidence.expected.dirty} to ${dirty}`);
+      } catch { findings.push("unverifiable: Git evidence could not be read"); }
+    } else if (evidence.kind === "file") {
+      try {
+        if (hashFile(path.resolve(evidence.ref)) !== evidence.expected?.sha256) findings.push(`disputed: file evidence changed at ${evidence.ref}`);
+      } catch { findings.push(`unverifiable: file evidence could not be read at ${evidence.ref}`); }
+    }
+  }
+  return findings;
+}
+
+function recoverCommand(opts) {
+  const layout = resolvedLayout();
+  const latest = latestCheckpoint(layout);
+  const maxEvents = Math.max(0, Math.min(Number(opts["max-events"] || 20), 100));
+  if (!latest.valid) {
+    const note = latest.invalid.length ? `; ${latest.invalid.length} invalid checkpoint(s) ignored` : "";
+    process.stdout.write(`RECOVERY CAPSULE\ncheckpoint: none${note}\nobjective: use the session-start digest and authoritative records\nnext safe action: establish an objective and write a validated checkpoint before consequential work\n`);
+    return;
+  }
+  const cp = latest.checkpoint;
+  const events = allEvents(layout);
+  const later = events.filter((event) => cp.event_high_water === "none" || `${event.sequence}|${event.event_id}` > cp.event_high_water).slice(-maxEvents);
+  const findings = reconcile(cp, layout);
+  const lines = [
+    "RECOVERY CAPSULE (bounded; memory is evidence, current authority wins)",
+    `checkpoint: ${cp.checkpoint_id}`,
+    `event high-water: ${cp.event_high_water}`,
+    `objective: ${cp.objective}`,
+    `next safe action: ${cp.next_safe_action}`,
+    `unresolved decisions: ${(cp.decisions || []).length ? stableJson(cp.decisions) : "none recorded"}`,
+    `blockers: ${(cp.blockers || []).length ? stableJson(cp.blockers) : "none recorded"}`,
+    `active task references: ${(cp.active_tasks || []).join(", ") || "none"}`,
+    `artifacts/evidence: ${(cp.evidence || []).length ? stableJson(cp.evidence).slice(0, 3000) : "none recorded"}`,
+    `later events (${later.length}): ${later.length ? later.map((e) => `${e.event_id}:${e.type}`).join(", ") : "none"}`,
+    `contradictions: ${findings.length ? findings.join("; ") : "none found by bounded checks; reconcile with digest below"}`,
+    `invalid newer checkpoints ignored: ${latest.invalid.length}`,
+  ];
+  let output = `${lines.join("\n")}\n`;
+  if (Buffer.byteLength(output) > MAX_CAPSULE) output = `${output.slice(0, MAX_CAPSULE - 80)}\n[recovery capsule truncated at ${MAX_CAPSULE} bytes]\n`;
+  process.stdout.write(output);
+}
+
+function searchCommand(opts) {
+  const layout = resolvedLayout();
+  const limit = Math.max(1, Math.min(Number(opts.limit || 20), 100));
+  const query = String(opts.query || "").toLowerCase();
+  const since = opts.since ? Date.parse(opts.since) : 0;
+  if (opts.since && Number.isNaN(since)) fail("--since must be an ISO date");
+  const results = [];
+  const allow = (value) => opts["include-sensitive"] || value !== "restricted";
+  if (!opts.kind || opts.kind === "events") {
+    for (const event of allEvents(layout).reverse()) {
+      if (!allow(event.sensitivity) || (opts.project && event.project !== opts.project) || (opts.task && event.task !== opts.task) || (opts.type && event.type !== opts.type) || (opts.status && event.payload?.status !== opts.status) || (since && Date.parse(event.created_at) < since)) continue;
+      const text = stableJson(event);
+      if (query && !text.toLowerCase().includes(query)) continue;
+      results.push({ kind: "event", id: event.event_id, time: event.created_at, provenance: event.sources, snippet: text.slice(0, 600) });
+    }
+  }
+  if (!opts.kind || opts.kind === "checkpoints") {
+    for (const file of listFiles(path.join(layout.memory, "checkpoints"), ".md").reverse()) {
+      const parsed = parseCheckpoint(file, layout);
+      if (!parsed.valid || !allow(parsed.checkpoint.sensitivity) || (opts.project && parsed.checkpoint.project !== opts.project) || (since && Date.parse(parsed.checkpoint.created_at) < since)) continue;
+      const text = stableJson(parsed.checkpoint);
+      if (query && !text.toLowerCase().includes(query)) continue;
+      results.push({ kind: "checkpoint", id: parsed.checkpoint.checkpoint_id, time: parsed.checkpoint.created_at, provenance: parsed.checkpoint.provenance, snippet: text.slice(0, 600) });
+    }
+  }
+  if (!opts.kind || opts.kind === "curated") {
+    for (const name of ["captain.md", "captain-shared.md", "learnings.md", "backlog.md"]) {
+      const file = path.join(layout.data, name);
+      if (!fs.existsSync(file)) continue;
+      const stat = fs.lstatSync(file);
+      if (!stat.isFile() || stat.isSymbolicLink()) continue;
+      const text = fs.readFileSync(file, "utf8").slice(0, 262144);
+      const lower = text.toLowerCase();
+      const at = query ? lower.indexOf(query) : 0;
+      if (query && at < 0) continue;
+      results.push({ kind: "curated", id: name, time: stat.mtime.toISOString(), provenance: [`authority:data/${name}`], snippet: text.slice(Math.max(0, at - 120), Math.max(0, at - 120) + 600) });
+    }
+  }
+  process.stdout.write(`${stableJson({ schema: "fm.memory.search.v1", count: Math.min(results.length, limit), truncated: results.length > limit, results: results.slice(0, limit) })}\n`);
+}
+
+function transcriptRefCommand(opts) {
+  const runtime = safeName(opts.runtime, "runtime");
+  const session = safeName(opts.session, "session");
+  const layout = resolvedLayout();
+  const payload = { reference: session, content_copied: false };
+  const sources = [`runtime:${runtime}`];
+  if (opts.path) {
+    const target = path.resolve(opts.path);
+    if (inside(target, path.join(layout.home, "projects"))) fail("transcript evidence must not read under projects/");
+    const runtimeRoots = {
+      codex: [path.join(process.env.HOME || "", ".codex")],
+      claude: [path.join(process.env.HOME || "", ".claude")],
+      opencode: [path.join(process.env.HOME || "", ".local", "share", "opencode")],
+      pi: [path.join(process.env.HOME || "", ".pi")],
+      grok: [process.env.GROK_HOME || path.join(process.env.HOME || "", ".grok")],
+    };
+    const allowed = [layout.home, ...(runtimeRoots[runtime] || [])].filter(Boolean).map((root) => path.resolve(root));
+    if (!allowed.some((root) => inside(target, root))) fail("transcript path is outside the active home and the selected runtime's known private store");
+    const stat = fs.lstatSync(target);
+    if (!stat.isFile() || stat.isSymbolicLink()) fail("transcript path must be a regular non-symlink file");
+    payload.path = target;
+    payload.bytes = stat.size;
+    payload.sha256 = hashFile(target);
+    sources.push(`file:${target}`);
+  }
+  eventCommand(opts, { type: "session-lineage", runtime, session, payload, sources, idempotency: `${runtime}:${session}:${payload.sha256 || "opaque"}` });
+}
+
+function help() {
+  process.stdout.write("Usage: fm-memory.sh event|checkpoint|boundary|validate|recover|search|transcript-ref [options]\nSee bin/fm-memory.js header and docs/durable-memory.md for the canonical contracts.\n");
+}
+
+const [command, ...rest] = process.argv.slice(2);
+const opts = argsOf(rest);
+try {
+  if (command === "event") eventCommand(opts);
+  else if (command === "checkpoint") checkpointCommand(opts);
+  else if (command === "boundary") boundaryCommand(opts);
+  else if (command === "validate") {
+    const layout = resolvedLayout();
+    const target = opts._[0];
+    const result = target ? parseCheckpoint(target, layout) : latestCheckpoint(layout);
+    if (!result.valid) fail(`checkpoint invalid: ${result.reason || "none found"}`, 1);
+    process.stdout.write(`${result.checkpoint.checkpoint_id}\n`);
+  } else if (command === "recover") recoverCommand(opts);
+  else if (command === "search") searchCommand(opts);
+  else if (command === "transcript-ref") transcriptRefCommand(opts);
+  else if (command === "--help" || command === "help" || !command) help();
+  else fail(`unknown command: ${command}`);
+} catch (error) {
+  fail(error?.message || String(error), 1);
+}

--- a/bin/fm-memory.js
+++ b/bin/fm-memory.js
@@ -21,18 +21,19 @@
  * pending, decisions, constraints, blockers, active_tasks, evidence,
  * next_safe_action, provenance, and sensitivity. Input is JSON from --input
  * or stdin. Unknown fields are rejected. Files are temp-written, fsynced,
- * atomically renamed, read back, schema/high-water validated, and never
+ * published by hard link, read back, schema/high-water validated, and never
  * overwritten. The sidecar hashes the exact Markdown bytes.
  *
  * Bounds: 8192-byte event payload, 65536-byte checkpoint input, 5000 events,
  * 1000 checkpoints, 20 search results by default (max 100), 12000-byte recovery
- * capsule. Restricted records are excluded from search unless explicitly
- * requested. Capacity exhaustion refuses rather than deleting evidence.
+ * capsule. Restricted events and checkpoints are excluded from search unless
+ * explicitly requested; curated files retain file-level access. Capacity
+ * exhaustion refuses rather than deleting evidence.
  *
  * Usage:
  *   fm-memory.sh event --type TYPE [scope flags] [--payload-file FILE|-]
  *   fm-memory.sh checkpoint --reason REASON [--input FILE|-]
- *   fm-memory.sh boundary --reason turn-end|manual-compaction [--runtime NAME]
+ *   fm-memory.sh boundary --reason REASON [--runtime NAME]
  *   fm-memory.sh validate [checkpoint-file]
  *   fm-memory.sh recover [--max-events N]
  *   fm-memory.sh search [--query TEXT] [--kind events|checkpoints|curated]

--- a/bin/fm-memory.js
+++ b/bin/fm-memory.js
@@ -102,11 +102,28 @@ function safeName(value, label, fallback = "none") {
   return text;
 }
 
+function ensurePrivateDataRoot(layout) {
+  let stat;
+  try {
+    stat = fs.lstatSync(layout.data);
+  } catch (error) {
+    if (error?.code !== "ENOENT") throw error;
+    const parent = path.dirname(layout.data);
+    const parentStat = fs.lstatSync(parent);
+    if (!parentStat.isDirectory() || parentStat.isSymbolicLink()) fail("active data root parent must be a real directory");
+    try { fs.mkdirSync(layout.data, { mode: 0o700 }); } catch (mkdirError) {
+      if (mkdirError?.code !== "EEXIST") throw mkdirError;
+    }
+    stat = fs.lstatSync(layout.data);
+  }
+  if (!stat.isDirectory() || stat.isSymbolicLink()) fail("active data root must be a real directory");
+  fs.chmodSync(layout.data, 0o700);
+}
+
 function ensurePrivateDirectory(layout, dir) {
   const target = path.resolve(dir);
   if (!inside(target, layout.memory)) fail("memory directory escapes the active data root");
-  const dataStat = fs.lstatSync(layout.data);
-  if (!dataStat.isDirectory() || dataStat.isSymbolicLink()) fail("active data root must be a real directory");
+  ensurePrivateDataRoot(layout);
   let current = layout.data;
   const parts = path.relative(layout.data, target).split(path.sep).filter(Boolean);
   for (const part of parts) {

--- a/bin/fm-memory.js
+++ b/bin/fm-memory.js
@@ -102,9 +102,45 @@ function safeName(value, label, fallback = "none") {
   return text;
 }
 
-function mkdirPrivate(dir) {
-  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
-  fs.chmodSync(dir, 0o700);
+function ensurePrivateDirectory(layout, dir) {
+  const target = path.resolve(dir);
+  if (!inside(target, layout.memory)) fail("memory directory escapes the active data root");
+  const dataStat = fs.lstatSync(layout.data);
+  if (!dataStat.isDirectory() || dataStat.isSymbolicLink()) fail("active data root must be a real directory");
+  let current = layout.data;
+  const parts = path.relative(layout.data, target).split(path.sep).filter(Boolean);
+  for (const part of parts) {
+    current = path.join(current, part);
+    try {
+      const stat = fs.lstatSync(current);
+      if (!stat.isDirectory() || stat.isSymbolicLink()) fail(`memory parent is not a real directory: ${current}`);
+    } catch (error) {
+      if (error?.code !== "ENOENT") throw error;
+      try { fs.mkdirSync(current, { mode: 0o700 }); } catch (mkdirError) {
+        if (mkdirError?.code !== "EEXIST") throw mkdirError;
+      }
+      const stat = fs.lstatSync(current);
+      if (!stat.isDirectory() || stat.isSymbolicLink()) fail(`memory parent is not a real directory: ${current}`);
+    }
+    fs.chmodSync(current, 0o700);
+  }
+}
+
+function safeMemoryDirectory(layout, dir) {
+  const target = path.resolve(dir);
+  if (!inside(target, layout.memory)) return false;
+  try {
+    const dataStat = fs.lstatSync(layout.data);
+    if (!dataStat.isDirectory() || dataStat.isSymbolicLink()) return false;
+    let current = layout.data;
+    const parts = path.relative(layout.data, target).split(path.sep).filter(Boolean);
+    for (const part of parts) {
+      current = path.join(current, part);
+      const stat = fs.lstatSync(current);
+      if (!stat.isDirectory() || stat.isSymbolicLink()) return false;
+    }
+    return true;
+  } catch { return false; }
 }
 
 function sha(value) { return crypto.createHash("sha256").update(value).digest("hex"); }
@@ -165,8 +201,8 @@ function rejectSecrets(value) {
   if (COT_RE.test(text)) fail("chain-of-thought or private reasoning is not valid memory evidence");
 }
 
-function atomicCreate(file, bytes) {
-  mkdirPrivate(path.dirname(file));
+function atomicCreate(layout, file, bytes) {
+  ensurePrivateDirectory(layout, path.dirname(file));
   const tmp = path.join(path.dirname(file), `.${path.basename(file)}.${process.pid}.${crypto.randomBytes(4).toString("hex")}.tmp`);
   const fd = fs.openSync(tmp, "wx", 0o600);
   try {
@@ -183,6 +219,56 @@ function atomicCreate(file, bytes) {
     try { fs.fsyncSync(dfd); } finally { fs.closeSync(dfd); }
   } catch { /* Directory fsync is unavailable on some filesystems. */ }
   return created;
+}
+
+function processAlive(pid) {
+  try { process.kill(pid, 0); return true; } catch (error) { return error?.code === "EPERM"; }
+}
+
+function pause(milliseconds) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
+}
+
+function withWriteLock(layout, action) {
+  ensurePrivateDirectory(layout, layout.memory);
+  const lock = path.join(layout.memory, ".write-lock");
+  const token = `${process.pid}:${crypto.randomBytes(12).toString("hex")}`;
+  const deadline = Date.now() + 10000;
+  while (true) {
+    try {
+      const fd = fs.openSync(lock, "wx", 0o600);
+      try { fs.writeFileSync(fd, `${token}\n`); fs.fsyncSync(fd); } finally { fs.closeSync(fd); }
+      break;
+    } catch (error) {
+      if (error?.code !== "EEXIST") throw error;
+      let stat;
+      let current;
+      try {
+        stat = fs.lstatSync(lock);
+        current = fs.readFileSync(lock, "utf8").trim();
+      } catch (readError) {
+        if (readError?.code === "ENOENT") continue;
+        throw readError;
+      }
+      if (!stat.isFile() || stat.isSymbolicLink()) fail("memory write lock is not a regular file");
+      const holder = Number(current.split(":", 1)[0]);
+      if (Number.isSafeInteger(holder) && holder > 1 && !processAlive(holder)) {
+        try {
+          if (fs.readFileSync(lock, "utf8").trim() === current) fs.unlinkSync(lock);
+        } catch (staleError) {
+          if (staleError?.code !== "ENOENT") throw staleError;
+        }
+        continue;
+      }
+      if (Date.now() >= deadline) fail("timed out waiting for the memory write lock");
+      pause(10);
+    }
+  }
+  try { return action(); } finally {
+    try {
+      if (fs.readFileSync(lock, "utf8").trim() === token) fs.unlinkSync(lock);
+    } catch { }
+  }
 }
 
 function listFiles(dir, suffix) {
@@ -207,6 +293,7 @@ function readEvent(file) {
 }
 
 function allEvents(layout) {
+  if (!safeMemoryDirectory(layout, path.join(layout.memory, "events"))) return [];
   return listFiles(path.join(layout.memory, "events"), ".json").map(readEvent).filter(Boolean).sort((a, b) => `${a.sequence}|${a.event_id}`.localeCompare(`${b.sequence}|${b.event_id}`));
 }
 
@@ -221,13 +308,12 @@ function parsePayload(opts) {
   try { return JSON.parse(raw || "{}"); } catch { return { summary: raw.trim() }; }
 }
 
-function eventCommand(opts, forced = {}) {
-  const layout = resolvedLayout();
+function writeEvent(layout, opts, forced = {}) {
   const type = forced.type || opts.type;
   if (!TYPES.has(type)) fail(`unsupported event type: ${type || "(missing)"}`);
-  const writer = safeName(forced.writer || opts.writer || `${opts.runtime || "unknown"}-${opts.session || process.pid}`, "writer");
   const runtime = safeName(forced.runtime || opts.runtime || "unknown", "runtime");
   const session = safeName(forced.session || opts.session || "unknown", "session");
+  const writer = safeName(forced.writer || opts.writer || `${runtime}-${session === "unknown" ? process.pid : session}`, "writer");
   const task = safeName(forced.task || opts.task || "none", "task");
   const project = safeName(forced.project || opts.project || "none", "project");
   const sensitivity = forced.sensitivity || opts.sensitivity || "private";
@@ -263,7 +349,7 @@ function eventCommand(opts, forced = {}) {
     previous_high_water: highWater(events),
   };
   const file = path.join(layout.memory, "events", writer, `${eventId}.json`);
-  const created = atomicCreate(file, `${stableJson(record)}\n`);
+  const created = atomicCreate(layout, file, `${stableJson(record)}\n`);
   if (!created) {
     const winner = readEvent(file);
     const retryShape = { runtime, session, task, project, type, payload, sources, sensitivity };
@@ -274,6 +360,12 @@ function eventCommand(opts, forced = {}) {
   }
   if (!forced.quiet) process.stdout.write(`${eventId}\n`);
   return record;
+}
+
+function eventCommand(opts, forced = {}) {
+  const layout = resolvedLayout();
+  if (!lockOwned(layout)) fail("event write requires the active home session lock");
+  return withWriteLock(layout, () => writeEvent(layout, opts, forced));
 }
 
 function currentGitEvidence(layout) {
@@ -346,11 +438,13 @@ function parseCheckpoint(file, layout = resolvedLayout()) {
   try {
     const target = path.resolve(file);
     if (!inside(target, path.join(layout.memory, "checkpoints"))) return { valid: false, reason: "outside checkpoint directory" };
+    if (!safeMemoryDirectory(layout, path.dirname(target))) return { valid: false, reason: "unsafe checkpoint parent" };
     const stat = fs.lstatSync(target);
     if (!stat.isFile() || stat.isSymbolicLink() || stat.size > 131072) return { valid: false, reason: "unsafe checkpoint file" };
     const markdown = fs.readFileSync(target, "utf8");
     const sidecar = `${target}.sha256`;
-    if (!fs.existsSync(sidecar) || fs.readFileSync(sidecar, "utf8").trim() !== sha(markdown)) return { valid: false, reason: "hash mismatch" };
+    const sidecarStat = fs.lstatSync(sidecar);
+    if (!sidecarStat.isFile() || sidecarStat.isSymbolicLink() || sidecarStat.size > 256 || fs.readFileSync(sidecar, "utf8").trim() !== sha(markdown)) return { valid: false, reason: "hash mismatch" };
     const match = markdown.match(/```json\n([^\n]+)\n```/);
     if (!match) return { valid: false, reason: "missing canonical JSON fence" };
     const cp = JSON.parse(match[1]);
@@ -368,22 +462,27 @@ function parseCheckpoint(file, layout = resolvedLayout()) {
 function checkpointCommand(opts, supplied) {
   const layout = resolvedLayout();
   if (!lockOwned(layout)) fail("checkpoint write requires the active home session lock");
-  const files = listFiles(path.join(layout.memory, "checkpoints"), ".md");
-  if (files.length >= MAX_CHECKPOINTS) fail(`checkpoint capacity ${MAX_CHECKPOINTS} reached; archive this home's memory before writing more`);
   let input = supplied;
   if (!input) {
     const raw = readBounded(opts.input || "-", MAX_CHECKPOINT_INPUT);
     try { input = JSON.parse(raw); } catch { fail("checkpoint input must be valid JSON"); }
   }
-  const cp = normalizeCheckpoint(input, opts, layout);
-  const markdown = checkpointMarkdown(cp);
-  const dir = path.join(layout.memory, "checkpoints");
-  const file = path.join(dir, `${compactTime(cp.created_at)}-${cp.checkpoint_id}.md`);
-  atomicCreate(file, markdown);
-  atomicCreate(`${file}.sha256`, `${sha(markdown)}\n`);
-  const checked = parseCheckpoint(file, layout);
-  if (!checked.valid) fail(`checkpoint read-back validation failed: ${checked.reason}`);
-  eventCommand(opts, { type: "checkpoint", runtime: cp.runtime, session: cp.session, project: cp.project, payload: { checkpoint_id: cp.checkpoint_id, reason: cp.reason, event_high_water: cp.event_high_water }, sources: [`checkpoint:${cp.checkpoint_id}`], idempotency: cp.checkpoint_id, quiet: true });
+  const result = withWriteLock(layout, () => {
+    const files = listFiles(path.join(layout.memory, "checkpoints"), ".md");
+    if (files.length >= MAX_CHECKPOINTS) fail(`checkpoint capacity ${MAX_CHECKPOINTS} reached; archive this home's memory before writing more`);
+    if (allEvents(layout).length >= MAX_EVENTS) fail(`event capacity ${MAX_EVENTS} reached; archive this home's memory before writing more`);
+    const cp = normalizeCheckpoint(input, opts, layout);
+    const markdown = checkpointMarkdown(cp);
+    const dir = path.join(layout.memory, "checkpoints");
+    const file = path.join(dir, `${compactTime(cp.created_at)}-${cp.checkpoint_id}.md`);
+    atomicCreate(layout, file, markdown);
+    atomicCreate(layout, `${file}.sha256`, `${sha(markdown)}\n`);
+    const checked = parseCheckpoint(file, layout);
+    if (!checked.valid) fail(`checkpoint read-back validation failed: ${checked.reason}`);
+    writeEvent(layout, opts, { type: "checkpoint", runtime: cp.runtime, session: cp.session, project: cp.project, payload: { checkpoint_id: cp.checkpoint_id, reason: cp.reason, event_high_water: cp.event_high_water }, sources: [`checkpoint:${cp.checkpoint_id}`], idempotency: cp.checkpoint_id, quiet: true });
+    return { cp, file };
+  });
+  const { cp, file } = result;
   process.stdout.write(`${file}\n`);
   return cp;
 }
@@ -406,6 +505,7 @@ function lockOwned(layout) {
 
 function runtimeFromEnv(opts) {
   if (opts.runtime) return opts.runtime;
+  if (process.env.FM_MEMORY_RUNTIME) return process.env.FM_MEMORY_RUNTIME;
   if (process.env.CLAUDECODE) return "claude";
   if (process.env.PI_CODING_AGENT) return "pi";
   if (process.env.GROK_AGENT || process.env.GROK_HOOK_EVENT) return "grok";
@@ -419,7 +519,15 @@ function payloadSession(raw) {
   } catch { return "unknown"; }
 }
 
+function payloadTurn(raw) {
+  try {
+    const value = JSON.parse(raw || "{}");
+    return value.turn_id || value.turnId || "";
+  } catch { return ""; }
+}
+
 function latestCheckpoint(layout) {
+  if (!safeMemoryDirectory(layout, path.join(layout.memory, "checkpoints"))) return { valid: false, invalid: [] };
   const files = listFiles(path.join(layout.memory, "checkpoints"), ".md").reverse();
   const invalid = [];
   for (const file of files) {
@@ -437,7 +545,8 @@ function boundaryCommand(opts) {
   const runtime = safeName(runtimeFromEnv(opts), "runtime");
   const session = safeName(opts.session || payloadSession(raw), "session");
   const reason = opts.reason || "turn-end";
-  const lineage = eventCommand(opts, { type: "session-lineage", runtime, session, payload: { reason, evidence: "opaque runtime session identifier; transcript content not copied" }, sources: [`runtime:${runtime}`], idempotency: `${reason}:${runtime}:${session}:${opts["idempotency-key"] || compactTime(now()).slice(0, 12)}`, quiet: true });
+  const turn = payloadTurn(raw);
+  const lineage = eventCommand(opts, { type: "session-lineage", runtime, session, payload: { reason, evidence: "opaque runtime session identifier; transcript content not copied" }, sources: [`runtime:${runtime}`], idempotency: `${reason}:${runtime}:${session}:${opts["idempotency-key"] || turn || compactTime(now()).slice(0, 12)}`, quiet: true });
   const previous = latestCheckpoint(layout);
   const prior = previous.valid ? previous.checkpoint : {};
   const active = activeTaskRefs(layout);
@@ -450,6 +559,7 @@ function boundaryCommand(opts) {
     next_safe_action: prior.next_safe_action || "Read the bounded recovery capsule, then reconcile it with the session-start digest before consequential work.",
     provenance: [...(prior.provenance || []), `event:${lineage.event_id}`, "authority:data/backlog.md", "authority:state/*.meta", "authority:git"].slice(-100),
     sensitivity: "private",
+    event_high_water: prior.event_high_water || "none",
   };
   checkpointCommand({ ...opts, reason, runtime, session }, input);
 }
@@ -488,7 +598,10 @@ function recoverCommand(opts) {
   }
   const cp = latest.checkpoint;
   const events = allEvents(layout);
-  const later = events.filter((event) => cp.event_high_water === "none" || `${event.sequence}|${event.event_id}` > cp.event_high_water).slice(-maxEvents);
+  const laterAll = events.filter((event) => cp.event_high_water === "none" || `${event.sequence}|${event.event_id}` > cp.event_high_water);
+  const meaningful = laterAll.filter((event) => !["checkpoint", "session-lineage"].includes(event.type));
+  const selected = meaningful.length ? meaningful : laterAll;
+  const later = selected.slice(-maxEvents);
   const findings = reconcile(cp, layout);
   const lines = [
     "RECOVERY CAPSULE (bounded; memory is evidence, current authority wins)",
@@ -500,12 +613,19 @@ function recoverCommand(opts) {
     `blockers: ${(cp.blockers || []).length ? stableJson(cp.blockers) : "none recorded"}`,
     `active task references: ${(cp.active_tasks || []).join(", ") || "none"}`,
     `artifacts/evidence: ${(cp.evidence || []).length ? stableJson(cp.evidence).slice(0, 3000) : "none recorded"}`,
-    `later events (${later.length}): ${later.length ? later.map((e) => `${e.event_id}:${e.type}`).join(", ") : "none"}`,
+    `later event evidence (shown ${later.length} of ${selected.length}): ${later.length ? later.map((e) => `${e.event_id}:${e.type}:${stableJson(e.payload).slice(0, 400)}`).join(", ") : "none"}`,
     `contradictions: ${findings.length ? findings.join("; ") : "none found by bounded checks; reconcile with digest below"}`,
     `invalid newer checkpoints ignored: ${latest.invalid.length}`,
   ];
   let output = `${lines.join("\n")}\n`;
-  if (Buffer.byteLength(output) > MAX_CAPSULE) output = `${output.slice(0, MAX_CAPSULE - 80)}\n[recovery capsule truncated at ${MAX_CAPSULE} bytes]\n`;
+  if (Buffer.byteLength(output) > MAX_CAPSULE) {
+    const suffix = `\n[recovery capsule truncated at ${MAX_CAPSULE} bytes]\n`;
+    const budget = MAX_CAPSULE - Buffer.byteLength(suffix);
+    const bytes = Buffer.from(output);
+    let end = budget;
+    while (end > 0 && (bytes[end] & 0xc0) === 0x80) end -= 1;
+    output = `${bytes.subarray(0, end).toString("utf8")}${suffix}`;
+  }
   process.stdout.write(output);
 }
 
@@ -526,7 +646,8 @@ function searchCommand(opts) {
     }
   }
   if (!opts.kind || opts.kind === "checkpoints") {
-    for (const file of listFiles(path.join(layout.memory, "checkpoints"), ".md").reverse()) {
+    const checkpointFiles = safeMemoryDirectory(layout, path.join(layout.memory, "checkpoints")) ? listFiles(path.join(layout.memory, "checkpoints"), ".md").reverse() : [];
+    for (const file of checkpointFiles) {
       const parsed = parseCheckpoint(file, layout);
       if (!parsed.valid || !allow(parsed.checkpoint.sensitivity) || (opts.project && parsed.checkpoint.project !== opts.project) || (since && Date.parse(parsed.checkpoint.created_at) < since)) continue;
       const text = stableJson(parsed.checkpoint);

--- a/bin/fm-memory.sh
+++ b/bin/fm-memory.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Thin launcher for the durable session-memory owner.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec node "$SCRIPT_DIR/fm-memory.js" "$@"

--- a/bin/fm-session-start.sh
+++ b/bin/fm-session-start.sh
@@ -33,14 +33,16 @@
 #                       when this session actually holds the lock.
 #   3. wake-drain     - mutates the durable wake queue, so it also only runs
 #                       when locked.
-#   4. context digest - data/projects.md, data/secondmates.md, data/captain.md,
+#   4. recovery       - bounded validated memory capsule; read-only in both
+#                       lock modes, followed by a checkpoint only when locked.
+#   5. context digest - data/projects.md, data/secondmates.md, data/captain.md,
 #                       data/captain-shared.md, data/learnings.md: read-only,
 #                       always safe, always runs.
-#   5. fleet digest   - a compact data/backlog.md identity/metadata listing,
+#   6. fleet digest   - a compact data/backlog.md identity/metadata listing,
 #                       every state/*.meta, a bounded state/*.status tail,
 #                       state/.afk, and a cheap per-task endpoint-liveness read:
 #                       read-only, always runs.
-#   6. closing reminder - prints the context-specific watcher next step; this
+#   7. closing reminder - prints the context-specific watcher next step; this
 #                       script points back to the emitted harness supervision
 #                       block and deliberately never arms the watcher itself.
 #
@@ -299,7 +301,21 @@ else
   fi
 fi
 
-# --- 4. supervision operating instructions ----------------------------------
+# --- 4. durable recovery -----------------------------------------------------
+section "DURABLE RECOVERY"
+MEMORY_OUT=$("$SCRIPT_DIR/fm-memory.sh" recover --max-events 20 2>&1)
+MEMORY_RC=$?
+if [ "$MEMORY_RC" -eq 0 ] && [ -n "$MEMORY_OUT" ]; then
+  printf '%s\n' "$MEMORY_OUT"
+else
+  printf 'DURABLE_MEMORY: recovery unavailable - %s\n' "${MEMORY_OUT:-memory owner returned no capsule}"
+fi
+if [ "$READ_ONLY" -eq 0 ] && [ "$MEMORY_RC" -eq 0 ] && [ -n "$MEMORY_OUT" ]; then
+  printf '{}\n' | "$SCRIPT_DIR/fm-memory.sh" boundary --reason session-start --runtime "$PRIMARY_HARNESS" >/dev/null 2>&1 || \
+    printf 'DURABLE_MEMORY: could not record the validated session-start boundary.\n'
+fi
+
+# --- 5. supervision operating instructions ----------------------------------
 AFK_PRESENT=0
 [ -e "$STATE/.afk" ] && AFK_PRESENT=1
 X_MODE_PRESENT=0
@@ -324,7 +340,7 @@ fi
   --afk "$AFK_PRESENT" \
   --x-mode "$X_MODE_PRESENT"
 
-# --- 4. context digest -----------------------------------------------------
+# --- 6. context digest -----------------------------------------------------
 section "CONTEXT"
 print_file_or_absent "$DATA/projects.md" "data/projects.md"
 print_file_or_absent "$DATA/secondmates.md" "data/secondmates.md"
@@ -332,7 +348,7 @@ print_file_or_absent "$DATA/captain.md" "data/captain.md"
 print_file_or_absent "$DATA/captain-shared.md" "data/captain-shared.md (shared, main-authoritative, read-only in secondmate homes)"
 print_file_or_absent "$DATA/learnings.md" "data/learnings.md"
 
-# --- 5. fleet-state digest ---------------------------------------------
+# --- 7. fleet-state digest ---------------------------------------------
 section "FLEET STATE"
 print_backlog_compact "$DATA/backlog.md" "data/backlog.md"
 
@@ -386,7 +402,7 @@ else
   printf 'absent\n'
 fi
 
-# --- 6. closing reminder -----------------------------------------------
+# --- 8. closing reminder -----------------------------------------------
 section "NEXT STEP"
 if [ "$READ_ONLY" -eq 1 ]; then
   cat <<'EOF'
@@ -421,6 +437,9 @@ The digest above is complete for this session start. Do NOT re-read
 data/projects.md, data/secondmates.md, data/captain.md,
 data/captain-shared.md, data/learnings.md,
 or state/*.meta now - they were just printed in full.
+The durable recovery capsule was also printed once. Do not reload it unless
+this digest reported invalid memory or a later contradiction requires the
+durable-memory recovery procedure.
 Do NOT bulk-read data/backlog.md now either: the compact identity/metadata
 listing was just printed with a pointer for targeted full-body follow-up.
 Do NOT bulk-read state/*.status now either: their bounded tails were just

--- a/bin/fm-turnend-guard-grok.sh
+++ b/bin/fm-turnend-guard-grok.sh
@@ -29,7 +29,7 @@ SESSION_ID=$(printf '%s' "$PAYLOAD" | jq -r '.sessionId // empty' 2>/dev/null) |
 ERR=$(mktemp "${TMPDIR:-/tmp}/fm-turnend-grok.XXXXXX") || exit 0
 trap 'rm -f "$ERR"' EXIT
 
-printf '%s' "$PAYLOAD" | "$ROOT/bin/fm-turnend-guard.sh" 2>"$ERR"
+printf '%s' "$PAYLOAD" | FM_MEMORY_RUNTIME=grok "$ROOT/bin/fm-turnend-guard.sh" 2>"$ERR"
 RC=$?
 [ "$RC" -eq 2 ] || exit 0
 

--- a/bin/fm-turnend-guard.sh
+++ b/bin/fm-turnend-guard.sh
@@ -81,7 +81,9 @@ fm_primary_scope_matches "$FM_ROOT" "$STATE" || exit 0
 # portable fallback for runtimes without a verified pre-compaction callback.
 # The memory owner independently requires this session to own the home lock;
 # hook failures never make an otherwise healthy turn un-endable.
-printf '%s' "$PAYLOAD" | "$SCRIPT_DIR/fm-memory.sh" boundary --reason turn-end >/dev/null 2>&1 || true
+if [ "${FM_MEMORY_BOUNDARY_DONE:-0}" != 1 ]; then
+  printf '%s' "$PAYLOAD" | "$SCRIPT_DIR/fm-memory.sh" boundary --reason turn-end >/dev/null 2>&1 || true
+fi
 
 # --- the actual predicate ----------------------------------------------------
 # shellcheck source=bin/fm-wake-lib.sh

--- a/bin/fm-turnend-guard.sh
+++ b/bin/fm-turnend-guard.sh
@@ -77,6 +77,12 @@ STOP_HOOK_ACTIVE=$(printf '%s' "$PAYLOAD" | jq -r '.stop_hook_active // false' 2
 # so this exempts them while guarding every real secondmate home.
 fm_primary_scope_matches "$FM_ROOT" "$STATE" || exit 0
 
+# Persist a bounded checkpoint before the supervision predicate. This is the
+# portable fallback for runtimes without a verified pre-compaction callback.
+# The memory owner independently requires this session to own the home lock;
+# hook failures never make an otherwise healthy turn un-endable.
+printf '%s' "$PAYLOAD" | "$SCRIPT_DIR/fm-memory.sh" boundary --reason turn-end >/dev/null 2>&1 || true
+
 # --- the actual predicate ----------------------------------------------------
 # shellcheck source=bin/fm-wake-lib.sh
 . "$SCRIPT_DIR/fm-wake-lib.sh"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -225,6 +225,10 @@ Memory writes use inspect-then-update: read the current destination first, then 
 Task-scoped notes use `tasks-axi show <id> --full` followed by `tasks-axi update <id> --body-file <path>`, adding `--archive-body` when the prior body should remain recoverable.
 Generalizable firstmate knowledge goes to shared tracked docs through the normal PR pipeline; the firstmate-internal `/stow` deliberately never stores findings in either skill directory.
 
+Immutable session evidence is a separate recovery layer, not another knowledge authority.
+[`bin/fm-memory.js`](../bin/fm-memory.js) owns bounded append-only events, validated checkpoints, recovery, and local search under the active home's private `data/memory/`; [`durable-memory.md`](durable-memory.md) records the full architecture, runtime support matrix, and threat model.
+The shared turn-end guard records portable boundary checkpoints because no reliable pre-compaction callback exists across all supported runtimes, and session start prints one bounded capsule before the existing authoritative digest.
+
 ## Local clones stay fresh
 
 The locked session-start bootstrap step, PR-based teardown, and merged-PR wake handling refresh remote-backed project clones when the clone is safe to move.
@@ -247,7 +251,7 @@ The mechanics are owned by the `/updatefirstmate` skill and firstmate's operatin
 Fleet state lives in each task's session-provider backend (tmux by hard default, herdr or cmux when selected or auto-detected, zellij/orca when explicitly selected), no-mistakes run records, status event logs, local markdown under `data/` including `data/captain.md`, `data/captain-shared.md`, and `data/learnings.md`, and persistent secondmate homes.
 For herdr, respawning after a server-restored layout closes and replaces confirmed no-agent or dead task-tab husks instead of requiring manual tab cleanup.
 At session start, confirmed-dead secondmate agent endpoints are closed and relaunched through the same secondmate spawn path, while ambiguous liveness reads are left untouched to avoid duplicate supervisors.
-Use `/stow` before an intentional reset when the conversation may hold durable knowledge that has not yet been written to disk; after that, the next firstmate session can reconcile and carry on.
+Use `/stow` plus the `durable-memory-recovery` procedure before an intentional reset or manual compaction; after that, the next firstmate session can validate the checkpoint, reconcile it against current authority, and carry on.
 
 ## Development notes
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -227,7 +227,7 @@ Generalizable firstmate knowledge goes to shared tracked docs through the normal
 
 Immutable session evidence is a separate recovery layer, not another knowledge authority.
 [`bin/fm-memory.js`](../bin/fm-memory.js) owns bounded append-only events, validated checkpoints, recovery, and local search under the active home's private `data/memory/`; [`durable-memory.md`](durable-memory.md) records the full architecture, runtime support matrix, and threat model.
-The portable turn-boundary fallback covers all supported runtimes, Codex adds tracked `PreCompact` and `PostCompact` hooks, and session start prints one bounded capsule before the existing authoritative digest.
+The portable turn-boundary fallback covers all supported runtimes, Codex adds tracked compaction staging plus model-visible Stop/prompt recovery, and session start prints one bounded capsule before the existing authoritative digest.
 
 ## Local clones stay fresh
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -246,7 +246,7 @@ The update is fast-forward only: dirty, diverged, offline, and off-default targe
 The origin-based updater and the local secondmate sync share the same guarded fast-forward helper; only the origin mode fetches.
 The mechanics are owned by the `/updatefirstmate` skill and firstmate's operating manual in [`AGENTS.md`](../AGENTS.md) (self-update).
 
-## Restart-proof
+## Restart and compaction resilience
 
 Fleet state lives in each task's session-provider backend (tmux by hard default, herdr or cmux when selected or auto-detected, zellij/orca when explicitly selected), no-mistakes run records, status event logs, local markdown under `data/` including `data/captain.md`, `data/captain-shared.md`, and `data/learnings.md`, and persistent secondmate homes.
 For herdr, respawning after a server-restored layout closes and replaces confirmed no-agent or dead task-tab husks instead of requiring manual tab cleanup.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -227,7 +227,7 @@ Generalizable firstmate knowledge goes to shared tracked docs through the normal
 
 Immutable session evidence is a separate recovery layer, not another knowledge authority.
 [`bin/fm-memory.js`](../bin/fm-memory.js) owns bounded append-only events, validated checkpoints, recovery, and local search under the active home's private `data/memory/`; [`durable-memory.md`](durable-memory.md) records the full architecture, runtime support matrix, and threat model.
-The shared turn-end guard records portable boundary checkpoints because no reliable pre-compaction callback exists across all supported runtimes, and session start prints one bounded capsule before the existing authoritative digest.
+The portable turn-boundary fallback covers all supported runtimes, Codex adds tracked `PreCompact` and `PostCompact` hooks, and session start prints one bounded capsule before the existing authoritative digest.
 
 ## Local clones stay fresh
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,6 +11,7 @@ The shared orchestrator behavior lives in [`AGENTS.md`](../AGENTS.md) - edit it 
 This section is the single owner of the top-level operational-home layout; producer script headers and their help own exact child-file fields and mutation contracts.
 The tracked code root contains the shared instruction, skill, documentation, workflow, and `bin/` surfaces, while each effective `FM_HOME` contains private operational directories.
 `data/` holds durable private fleet records such as the project and secondmate registries, captain preferences, optional shared captain preferences, learnings, backlog, briefs, and scout reports.
+Private immutable session events and checkpoints live under `data/memory/`; [`bin/fm-memory.js`](../bin/fm-memory.js) owns its child formats and [`durable-memory.md`](durable-memory.md) records the architecture and runtime evidence.
 `state/` holds volatile runtime records such as task metadata, append-only status events, endpoint signals, watcher and wake-queue coordination, away-mode state, and generated X-mode artifacts.
 `config/` holds local gitignored operating choices, and `projects/` holds the local project clones that Firstmate reads but changes only through the guarded exceptions in `AGENTS.md`.
 
@@ -19,6 +20,7 @@ The producing PR and X helpers own the fields they append, `bin/fm-classify-lib.
 Wake, watcher, away-mode, and X-specific state mechanics remain with their named scripts and reference sections rather than being duplicated into one exhaustive state tree here.
 
 `bin/fm-session-start.sh`'s header is the single owner of session-start ordering, composed commands, digest contents, and the digest's startup mechanism.
+Its durable-recovery section composes the read-only recovery owner and records a boundary only for the session that acquired the active home lock.
 `docs/sessionstart-nudge.md` owns the native session-open adapter mechanics that nudge the digest command.
 `AGENTS.md` retains the run-once and read-once operator rules, lock-refusal safety, installation consent, and direct-report recovery boundaries because those facts apply at every session start.
 Ordinary dead-direct-report recovery is owned by `stuck-crewmate-recovery`, while persistent-secondmate recovery is owned by `secondmate-provisioning`.

--- a/docs/durable-memory.md
+++ b/docs/durable-memory.md
@@ -96,8 +96,8 @@ PreCompact
 model_auto_compact_token_limit
 ```
 
-Pi was also absent from this task environment.
-The latest repository-recorded live evidence remains Pi 0.80.5 and Grok 0.2.93 in `docs/turnend-guard.md`; those records are not represented as a new live re-verification.
+Pi and Grok were absent from this task environment.
+The latest repository-recorded turn-end evidence remains Pi 0.80.5 and Grok 0.2.93 in `docs/turnend-guard.md`; the newer session-start-only evidence in `docs/sessionstart-nudge.md` is not represented as turn-end re-verification.
 The Codex hook inventory was checked against the installed binary, the tracked `.codex/hooks.json`, and strict parsing of `model_auto_compact_token_limit`.
 No persistent compaction setting was added or changed, so Codex retains its model-selected automatic compaction threshold.
 ShellCheck 0.11.0 and tmux were absent before validation, and the focused local round did not install or substitute either tool.
@@ -116,7 +116,7 @@ Targeted transcript reading remains a privacy-sensitive forensic action.
 
 `fm-memory.sh search` performs bounded local substring search over events, validated checkpoints, and the existing curated Markdown owners.
 It supports project, task, type, status, time, kind, and result-limit filters and returns provenance with every result.
-Restricted records are excluded unless `--include-sensitive` is explicit.
+Schema-backed events and checkpoints marked `restricted` are excluded unless `--include-sensitive` is explicit; curated Markdown retains its existing file-level access model.
 The implementation uses only the universally required Node runtime and canonical files.
 No SQLite projection, embeddings, graph database, cloud service, or new daemon is required.
 

--- a/docs/durable-memory.md
+++ b/docs/durable-memory.md
@@ -20,7 +20,8 @@ Checkpoint publication uses the same primitive, then reads back and validates th
 
 Events record only objectives, decisions and approvals, blockers, task transitions, artifact, PR, and test outcomes, checkpoints, recovery outcomes, and session lineage.
 The owner rejects secret-like text, explicit chain-of-thought material, unsafe names, symlink inputs, oversized inputs, unsupported event types, and missing high-water references.
-Capacity exhaustion refuses rather than deleting canonical evidence.
+Event capacity exhaustion refuses rather than deleting canonical evidence.
+Checkpoint publication keeps the newest 1000 validated checkpoint/hash pairs and removes older pairs only after the replacement checkpoint and its event have been published and read back successfully.
 
 ## Authority
 
@@ -46,6 +47,11 @@ OpenCode records that boundary before its watcher coordinator can return from no
 The memory owner verifies that the hook process descends from the active home's lock holder, records only opaque runtime lineage from the bounded hook payload, and writes a validated checkpoint.
 Hook memory failure remains non-blocking so a storage problem cannot wedge a model session; session start surfaces recovery failure explicitly.
 
+Codex `PostCompact` output has no model-context field in 0.144.4, and its common `systemMessage` field is only a UI or event-stream warning.
+The tracked `PostCompact` hook therefore stages the bounded capsule privately and returns no output, leaving automatic compaction enabled.
+At the end of that compacted turn, the tracked blocking `Stop` hook reads the staged capsule and uses its continuation prompt, which Codex records as model input for one bounded follow-up.
+The follow-up Stop callback acknowledges the staged record; if the process ends first, the next `UserPromptSubmit` claims it through `hookSpecificOutput.additionalContext`.
+
 `fm-session-start.sh` prints the latest bounded recovery capsule after its wake queue and before the existing supervision, context, and fleet sections.
 When the session owns the lock, it then records a session-start boundary.
 When lock acquisition is refused, it performs no memory mutation.
@@ -61,7 +67,7 @@ Codex additionally uses its verified first-class compaction callbacks, and no ot
 | Runtime | Session lineage and boundary surface | Pre-compaction support | Firstmate behavior |
 | --- | --- | --- | --- |
 | Claude | Tracked `SessionStart` and blocking `Stop` hooks. | Claude supports a `compact` session-start reason, but the tracked matcher deliberately covers `startup|resume|clear`; no pre-discard callback was verified. | Turn-boundary checkpoint plus next-session recovery. |
-| Codex | Tracked `SessionStart`, blocking `Stop`, `PreCompact`, and `PostCompact` hooks; compaction payloads provide opaque session and turn identifiers plus `manual|auto` trigger. | Verified in Codex CLI 0.144.4. | `PreCompact` writes a validated checkpoint without stopping automatic compaction, and `PostCompact` emits the bounded recovery capsule through `systemMessage`. |
+| Codex | Tracked `SessionStart`, blocking `Stop`, `PreCompact`, `PostCompact`, and `UserPromptSubmit` hooks; compaction payloads provide opaque session and turn identifiers plus `manual|auto` trigger. | Verified in Codex CLI 0.144.4. | `PreCompact` writes a validated checkpoint without stopping automatic compaction, `PostCompact` privately stages recovery, `Stop` injects it through one model continuation, and the next prompt is the unclaimed-record fallback. |
 | OpenCode | `session.created` and passive `session.idle` project plugin events. | No verified pre-compaction callback. | Passive logical-turn checkpoint and session-start recovery; headless follow-up limitations remain unchanged. |
 | Pi | `session_start` and `agent_settled` tracked extension events. | No verified pre-compaction callback. | Logical-run checkpoint and session-start recovery. |
 | Grok | Project `SessionStart` and passive `Stop` hooks with an opaque session ID. | No verified pre-compaction callback. | Passive turn-boundary checkpoint and session-start recovery; project trust remains required. |
@@ -101,6 +107,15 @@ The latest repository-recorded turn-end evidence remains Pi 0.80.5 and Grok 0.2.
 The Codex hook inventory was checked against the installed binary, the tracked `.codex/hooks.json`, and strict parsing of `model_auto_compact_token_limit`.
 No persistent compaction setting was added or changed, so Codex retains its model-selected automatic compaction threshold.
 ShellCheck 0.11.0 and tmux were absent before validation, and the focused local round did not install or substitute either tool.
+
+The credentialed automatic-compaction experiment is opt-in because it spends live Codex model turns and uses ambient authentication.
+It preserves automatic compaction, sets `model_auto_compact_token_limit=8000` only for the isolated commands, records Codex's resolved token limit and automatic trigger in turn-level trace evidence, requires a `pre-compact` checkpoint and lineage event, requires the PostCompact staged record to be acknowledged, and requires the private objective marker to appear in a subsequent model response.
+Its full JSONL and stderr evidence remains under the testing evidence directory named by the script.
+
+```text
+$ FM_CODEX_LIVE_COMPACTION=1 bash tests/fm-memory-codex-live.test.sh
+ok - durable memory: Codex 0.144.4 auto compaction fires both hooks and reaches the model
+```
 
 ## Transcript Evidence
 

--- a/docs/durable-memory.md
+++ b/docs/durable-memory.md
@@ -1,0 +1,131 @@
+# Durable Session Memory
+
+Firstmate preserves bounded recovery evidence outside model context so a runtime-generated compaction summary is never the sole copy of decisions, constraints, work state, or the next safe action.
+`bin/fm-memory.js` is the one owner of formats, paths, bounds, validation, atomic writes, and command behavior.
+The `durable-memory-recovery` skill owns the conditional semantic procedure.
+
+## Architecture
+
+Canonical private records live under the active home's `data/memory/` directory.
+`FM_DATA_OVERRIDE` retains its normal test precedence, and no command implicitly searches another `FM_HOME`.
+
+- `events/<writer>/*.json` contains immutable `fm.memory.event.v1` records.
+- `checkpoints/*.md` contains immutable `fm.memory.checkpoint.v1` Markdown with canonical JSON and a sibling SHA-256 file.
+- Runtime transcript content remains in the runtime's own store; Firstmate records an opaque lineage reference and an optional file hash, size, and path only when deliberately supplied.
+
+One immutable event file per writer and event is the serialization strategy.
+It avoids a shared JSONL append race while retaining append-only semantics, deterministic event IDs, sortable sequences, retry idempotency, and previous-high-water linkage.
+That verified publication primitive permits narrowly scoped event writers to append without the session lock; checkpoint creation still requires ancestry ownership of the active home's lock.
+Atomic create uses a same-directory temporary file, file `fsync`, hard-link publication without overwrite, and best-effort directory `fsync`.
+Checkpoint publication uses the same primitive, then reads back and validates the hash, schema, and referenced event high-water.
+
+Events record only objectives, decisions and approvals, blockers, task transitions, artifact, PR, and test outcomes, checkpoints, recovery outcomes, and session lineage.
+The owner rejects secret-like text, explicit chain-of-thought material, unsafe names, symlink inputs, oversized inputs, unsupported event types, and missing high-water references.
+Capacity exhaustion refuses rather than deleting canonical evidence.
+
+## Authority
+
+Memory references existing owners and never overrides them.
+
+- `data/captain.md` remains home-local captain preference authority.
+- `data/captain-shared.md` remains primary-owned shared preference authority.
+- `data/learnings.md` remains curated fleet-local knowledge authority.
+- Backlog and decision records remain work and approval authority.
+- Scout reports remain investigation evidence.
+- Project `AGENTS.md` remains project-intrinsic contributor knowledge authority.
+- Git, PRs, tests, and live process state remain current operational evidence.
+
+Recovery validates the newest intact checkpoint, replays only bounded later events, and performs cheap reconciliation of recorded task-presence and local Git evidence.
+It labels conflicts `stale`, `disputed`, or `unverifiable` and points the agent at the session-start digest for the remaining authoritative reconciliation.
+The capsule is capped at 12000 bytes and is printed once by `fm-session-start.sh` without replacing or causing a second read of the existing context and fleet digest.
+A lock-refused session may read recovery evidence but may not append an event or checkpoint.
+
+## Lifecycle
+
+Every supported primary runtime already reaches `bin/fm-turnend-guard.sh` at a logical turn boundary.
+That shared owner now invokes `fm-memory.sh boundary` before its supervision predicate.
+The memory owner verifies that the hook process descends from the active home's lock holder, records only opaque runtime lineage from the bounded hook payload, and writes a validated checkpoint.
+Hook memory failure remains non-blocking so a storage problem cannot wedge a model session; session start surfaces recovery failure explicitly.
+
+`fm-session-start.sh` prints the latest bounded recovery capsule after its wake queue and before the existing supervision, context, and fleet sections.
+When the session owns the lock, it then records a session-start boundary.
+When lock acquisition is refused, it performs no memory mutation.
+
+Before intentional compaction or reset, load `durable-memory-recovery` and `/stow`, then supply a semantic checkpoint through the safe JSON file or stdin contract.
+After detected context loss, load the same skill and reconcile before consequential work.
+
+## Runtime Support Matrix
+
+The portable guarantee is continuous external evidence plus logical turn and session-start checkpoints.
+No runtime is claimed to provide a pre-compaction callback without direct evidence.
+
+| Runtime | Session lineage and boundary surface | Pre-compaction support | Firstmate behavior |
+| --- | --- | --- | --- |
+| Claude | Tracked `SessionStart` and blocking `Stop` hooks. | Claude supports a `compact` session-start reason, but the tracked matcher deliberately covers `startup|resume|clear`; no pre-discard callback was verified. | Turn-boundary checkpoint plus next-session recovery. |
+| Codex | Tracked `SessionStart` and blocking `Stop` hooks; hook payload provides an opaque session identifier and process-root signal. | No trustworthy pre-compaction hook was found in Codex CLI 0.144.4. | Turn-boundary checkpoint, opaque session lineage, and mandatory bounded recovery on the next turn or session. |
+| OpenCode | `session.created` and passive `session.idle` project plugin events. | No verified pre-compaction callback. | Passive logical-turn checkpoint and session-start recovery; headless follow-up limitations remain unchanged. |
+| Pi | `session_start` and `agent_settled` tracked extension events. | No verified pre-compaction callback. | Logical-run checkpoint and session-start recovery. |
+| Grok | Project `SessionStart` and passive `Stop` hooks with an opaque session ID. | No verified pre-compaction callback. | Passive turn-boundary checkpoint and session-start recovery; project trust remains required. |
+
+Verification was reviewed on 2026-07-20.
+Installed commands and exact outputs were:
+
+```text
+$ codex --version
+codex-cli 0.144.4
+$ claude --version
+2.1.209 (Claude Code)
+$ opencode --version
+1.18.3
+$ grok --version
+Error: grok not found in PATH
+```
+
+Pi was also absent from this task environment.
+The latest repository-recorded live evidence remains Pi 0.80.5 and Grok 0.2.93 in `docs/turnend-guard.md`; those records are not represented as a new live re-verification.
+The Codex hook inventory was checked with `codex --help` and the tracked `.codex/hooks.json` against the installed version.
+
+## Transcript Evidence
+
+Runtime session stores are opaque evidence archives, not a shared transcript schema and not automatic prompt content.
+`transcript-ref` records the runtime, opaque session identifier, and optionally the SHA-256, size, and absolute path of one deliberately supplied regular file no larger than 100 MiB.
+It rejects project-clone paths, symlinks, and paths outside the active home or the selected runtime's known private store.
+It never crawls provider caches, copies raw messages, or indexes transcript text.
+
+This preserves recoverability without assuming stable vendor-private JSON formats or ingesting secrets blindly.
+Targeted transcript reading remains a privacy-sensitive forensic action.
+
+## Search
+
+`fm-memory.sh search` performs bounded local substring search over events, validated checkpoints, and the existing curated Markdown owners.
+It supports project, task, type, status, time, kind, and result-limit filters and returns provenance with every result.
+Restricted records are excluded unless `--include-sensitive` is explicit.
+The implementation uses only the universally required Node runtime and canonical files.
+No SQLite projection, embeddings, graph database, cloud service, or new daemon is required.
+
+## Curated Markdown Portability
+
+Existing curated files do not require a rewrite.
+When richer provenance is useful, a normal Markdown section or entry may use YAML frontmatter fields such as `id`, `scope`, `status`, `confidence`, `provenance`, `reviewed`, `sensitivity`, and `supersedes`.
+Stable IDs and normal relative Markdown links are preferred where they improve Open Knowledge Format v0.1 portability.
+Obsidian may open the same private Markdown as a human interface, but wikilinks, plugins, Sync, and conflict behavior are not machine contracts.
+
+## Hermes Inspiration And License
+
+The design was informed by Nous Research's Hermes Agent at commit `31c08a9aad6e83ded5d0e55dc7d41b94a99f08a1`.
+Reviewed sources were `agent/context_compressor.py`, `agent/conversation_compression.py`, `hermes_state.py`, `tools/session_search_tool.py`, `tools/memory_tool.py`, and `LICENSE`.
+Hermes is MIT licensed, copyright 2025 Nous Research.
+
+Firstmate adapts the ideas of durable session lineage, bounded source-first retrieval, immutable evidence before lossy compression, atomic memory writes, and reconciliation after session rotation.
+It does not copy substantial Hermes source, does not use Hermes' SQLite transcript schema, does not normalize runtime transcripts, and does not claim byte-for-byte or API compatibility.
+Because no substantial source was copied, a separate bundled license copy is not required; this reference records the inspiration and upstream license accurately.
+
+## Threat Model And Limitations
+
+The design protects against automatic compaction loss, abrupt process exit after an earlier boundary, concurrent writers, duplicate hook retries, truncated or malformed records, accidental checkpoint modification, path traversal, and stale operational claims.
+Hashes detect accidental changes; they are not signatures and do not defend against a malicious process with write access to the same home.
+Secret-pattern checks reduce accidental credential capture but cannot prove arbitrary prose contains no sensitive information.
+The checkpoint is only as complete as the meaningful events and semantic checkpoint input supplied before loss.
+A crash before the first durable event cannot be reconstructed.
+Runtime providers may delete their own transcript archives independently.
+Current authority can change after checkpoint creation, which is why recovery must reconcile rather than trust memory silently.

--- a/docs/durable-memory.md
+++ b/docs/durable-memory.md
@@ -13,9 +13,8 @@ Canonical private records live under the active home's `data/memory/` directory.
 - `checkpoints/*.md` contains immutable `fm.memory.checkpoint.v1` Markdown with canonical JSON and a sibling SHA-256 file.
 - Runtime transcript content remains in the runtime's own store; Firstmate records an opaque lineage reference and an optional file hash, size, and path only when deliberately supplied.
 
-One immutable event file per writer and event is the serialization strategy.
-It avoids a shared JSONL append race while retaining append-only semantics, deterministic event IDs, sortable sequences, retry idempotency, and previous-high-water linkage.
-That verified publication primitive permits narrowly scoped event writers to append without the session lock; checkpoint creation still requires ancestry ownership of the active home's lock.
+One immutable file per event avoids a shared JSONL append race while retaining append-only semantics, deterministic event IDs, sortable sequences, retry idempotency, and previous-high-water linkage.
+Every mutation requires ancestry ownership of the active home's session lock and is serialized through one private home-local write lock, so capacity checks and publication form one bounded operation.
 Atomic create uses a same-directory temporary file, file `fsync`, hard-link publication without overwrite, and best-effort directory `fsync`.
 Checkpoint publication uses the same primitive, then reads back and validates the hash, schema, and referenced event high-water.
 
@@ -42,8 +41,8 @@ A lock-refused session may read recovery evidence but may not append an event or
 
 ## Lifecycle
 
-Every supported primary runtime already reaches `bin/fm-turnend-guard.sh` at a logical turn boundary.
-That shared owner now invokes `fm-memory.sh boundary` before its supervision predicate.
+Every supported primary runtime reaches a logical turn boundary that invokes `fm-memory.sh boundary` before its supervision predicate.
+OpenCode records that boundary before its watcher coordinator can return from normal `session.idle` handling, while the other adapters reach it through `bin/fm-turnend-guard.sh`.
 The memory owner verifies that the hook process descends from the active home's lock holder, records only opaque runtime lineage from the bounded hook payload, and writes a validated checkpoint.
 Hook memory failure remains non-blocking so a storage problem cannot wedge a model session; session start surfaces recovery failure explicitly.
 
@@ -57,12 +56,12 @@ After detected context loss, load the same skill and reconcile before consequent
 ## Runtime Support Matrix
 
 The portable guarantee is continuous external evidence plus logical turn and session-start checkpoints.
-No runtime is claimed to provide a pre-compaction callback without direct evidence.
+Codex additionally uses its verified first-class compaction callbacks, and no other runtime is claimed to provide a pre-compaction callback without direct evidence.
 
 | Runtime | Session lineage and boundary surface | Pre-compaction support | Firstmate behavior |
 | --- | --- | --- | --- |
 | Claude | Tracked `SessionStart` and blocking `Stop` hooks. | Claude supports a `compact` session-start reason, but the tracked matcher deliberately covers `startup|resume|clear`; no pre-discard callback was verified. | Turn-boundary checkpoint plus next-session recovery. |
-| Codex | Tracked `SessionStart` and blocking `Stop` hooks; hook payload provides an opaque session identifier and process-root signal. | No trustworthy pre-compaction hook was found in Codex CLI 0.144.4. | Turn-boundary checkpoint, opaque session lineage, and mandatory bounded recovery on the next turn or session. |
+| Codex | Tracked `SessionStart`, blocking `Stop`, `PreCompact`, and `PostCompact` hooks; compaction payloads provide opaque session and turn identifiers plus `manual|auto` trigger. | Verified in Codex CLI 0.144.4. | `PreCompact` writes a validated checkpoint without stopping automatic compaction, and `PostCompact` emits the bounded recovery capsule through `systemMessage`. |
 | OpenCode | `session.created` and passive `session.idle` project plugin events. | No verified pre-compaction callback. | Passive logical-turn checkpoint and session-start recovery; headless follow-up limitations remain unchanged. |
 | Pi | `session_start` and `agent_settled` tracked extension events. | No verified pre-compaction callback. | Logical-run checkpoint and session-start recovery. |
 | Grok | Project `SessionStart` and passive `Stop` hooks with an opaque session ID. | No verified pre-compaction callback. | Passive turn-boundary checkpoint and session-start recovery; project trust remains required. |
@@ -79,11 +78,29 @@ $ opencode --version
 1.18.3
 $ grok --version
 Error: grok not found in PATH
+$ command -v shellcheck
+(no output)
+$ shellcheck --version
+zsh: command not found: shellcheck
+$ command -v tmux
+(no output)
+$ tmux -V
+zsh: command not found: tmux
+$ codex --strict-config -c model_auto_compact_token_limit=123456 --version
+codex-cli 0.144.4
+$ CODEX_JS=$(realpath "$(command -v codex)")
+$ CODEX_BIN=$(find -L "$(dirname "$CODEX_JS")/../node_modules/@openai/codex-darwin-arm64/vendor" -type f -name codex -perm -111)
+$ strings "$CODEX_BIN" | rg -x 'PreCompact|PostCompact|model_auto_compact_token_limit' | sort -u
+PostCompact
+PreCompact
+model_auto_compact_token_limit
 ```
 
 Pi was also absent from this task environment.
 The latest repository-recorded live evidence remains Pi 0.80.5 and Grok 0.2.93 in `docs/turnend-guard.md`; those records are not represented as a new live re-verification.
-The Codex hook inventory was checked with `codex --help` and the tracked `.codex/hooks.json` against the installed version.
+The Codex hook inventory was checked against the installed binary, the tracked `.codex/hooks.json`, and strict parsing of `model_auto_compact_token_limit`.
+No persistent compaction setting was added or changed, so Codex retains its model-selected automatic compaction threshold.
+ShellCheck 0.11.0 and tmux were absent before validation, and the focused local round did not install or substitute either tool.
 
 ## Transcript Evidence
 
@@ -122,7 +139,7 @@ Because no substantial source was copied, a separate bundled license copy is not
 
 ## Threat Model And Limitations
 
-The design protects against automatic compaction loss, abrupt process exit after an earlier boundary, concurrent writers, duplicate hook retries, truncated or malformed records, accidental checkpoint modification, path traversal, and stale operational claims.
+The design protects against automatic compaction loss, abrupt process exit after an earlier boundary, concurrent writers at capacity, duplicate hook retries, truncated or malformed records, accidental checkpoint modification, symlinked storage parents, path traversal, and stale operational claims.
 Hashes detect accidental changes; they are not signatures and do not defend against a malicious process with write access to the same home.
 Secret-pattern checks reduce accidental credential capture but cannot prove arbitrary prose contains no sensitive information.
 The checkpoint is only as complete as the meaningful events and semantic checkpoint input supplied before loss.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -7,7 +7,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 
 | Script                   | Purpose                                                                              |
 | ------------------------ | ------------------------------------------------------------------------------------ |
-| `fm-session-start.sh`    | Compose lock, bootstrap, and wake drain into the single ordered session-start digest |
+| `fm-session-start.sh`    | Print the single ordered session-start and durable-recovery digest                   |
 | `fm-memory.sh`           | Launch the private durable event, checkpoint, recovery, transcript-reference, and search owner (`docs/durable-memory.md`) |
 | `fm-sessionstart-nudge.sh` | Print the native session-start hook nudge when the primary has not already run the digest |
 | `fm-bootstrap.sh`        | Detect toolchain and fleet problems, run the locked session-start sweeps, and install approved tools |

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -8,6 +8,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | Script                   | Purpose                                                                              |
 | ------------------------ | ------------------------------------------------------------------------------------ |
 | `fm-session-start.sh`    | Compose lock, bootstrap, and wake drain into the single ordered session-start digest |
+| `fm-memory.sh`           | Launch the private durable event, checkpoint, recovery, transcript-reference, and search owner (`docs/durable-memory.md`) |
 | `fm-sessionstart-nudge.sh` | Print the native session-start hook nudge when the primary has not already run the digest |
 | `fm-bootstrap.sh`        | Detect toolchain and fleet problems, run the locked session-start sweeps, and install approved tools |
 | `fm-fleet-sync.sh`       | Refresh project clones with safe fast-forwards, self-heals, `STUCK:` reports, branch pruning, and bounded recovery from an orphaned `.git/packed-refs.lock` |

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -43,7 +43,7 @@ All verified primary harnesses have a tracked integration:
 
 - `claude`: `.claude/settings.json` registers a `Stop` hook command anchored through `"$CLAUDE_PROJECT_DIR"/bin/fm-turnend-guard.sh`.
 - `codex`: `.codex/hooks.json` registers a `Stop` hook that reads the hook payload once, anchors the executable to the hook command process working directory, verifies that root is firstmate-shaped and hook-bearing, and pipes the original payload to that checkout's `bin/fm-turnend-guard.sh`.
-- `opencode`: `.opencode/plugins/fm-primary-turnend-guard.js` listens for `session.idle`, lets the watcher-arm coordinator handle normal idle supervision first, runs the shared guard only when that coordinator does not act, and uses `client.session.promptAsync` to force one follow-up prompt when the guard returns 2.
+- `opencode`: `.opencode/plugins/fm-primary-turnend-guard.js` listens for `session.idle`, records the durable-memory boundary with the opaque session identifier, lets the watcher-arm coordinator handle normal idle supervision, runs the shared guard only when that coordinator does not act, and uses `client.session.promptAsync` to force one follow-up prompt when the guard returns 2.
 - `pi`: `.pi/extensions/fm-primary-turnend-guard.ts` listens for `agent_settled`, marks the extension version loaded for session-start checks, runs the shared guard once per logical agent run, and uses `pi.sendUserMessage(..., { deliverAs: "followUp" })` to force one follow-up prompt when the guard returns 2.
 - `grok`: `.grok/hooks/fm-primary-turnend-guard.json` registers a `Stop` hook that invokes `bin/fm-turnend-guard-grok.sh`.
   The adapter runs the shared guard and, when it returns 2, invokes `grok --resume <sessionId> -p <guard-reason>` with `GROK_TURNEND_GUARD_ACTIVE=1`.
@@ -57,7 +57,7 @@ OpenCode, Pi, and Grok expose passive lifecycle callbacks for this purpose.
 Their adapters fail open at the hook boundary to avoid corrupting a user session, but they force one follow-up turn when the shared predicate blocks.
 Each adapter carries its own in-process or environment loop guard so the forced follow-up does not recursively schedule another follow-up.
 Pi keeps that latch active across every internal tool turn and clears it only when the generated guard follow-up reaches `agent_settled`, or immediately when follow-up delivery fails.
-All five integrations therefore reach the same portable durable-memory boundary without a second hook registration or lifecycle cycle; [`durable-memory.md`](durable-memory.md) owns the compaction support matrix and fallback rationale.
+All five integrations therefore reach the same portable durable-memory boundary; [`durable-memory.md`](durable-memory.md) owns Codex's additional compaction hooks, the support matrix, and the fallback rationale.
 If a passive adapter cannot call its SDK method, cannot find `grok`, or cannot recover the Grok session id, it fails open and relies on the pull-based `fm-guard.sh` warning at the next fleet command.
 That warning uses `bin/fm-supervision-instructions.sh --repair-line`, so it points back to the active harness protocol instead of hardcoding one background-arm command.
 

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -2,6 +2,7 @@
 
 This is the authoritative contract for the "no turn ends blind" primary guard referenced from AGENTS.md section 8.
 The turn-end supervision predicate lives in `bin/fm-turnend-guard.sh`.
+Before that predicate, the same shared turn boundary asks `bin/fm-memory.sh` for a lock-verified private checkpoint; memory failure stays non-blocking and does not change supervision outcomes.
 Its primary-checkout scope lives in `bin/fm-primary-scope-lib.sh`, shared with the native session-start nudge documented in `docs/sessionstart-nudge.md`.
 Harness-specific tracked hook files only adapt each verified harness's real turn-end mechanism to that shared predicate.
 Two related but separate PreToolUse seatbelts deny a bad command shape before it runs rather than detecting a blind turn end afterward: the watcher-arm seatbelt (`bin/fm-arm-pretool-check.sh`, `docs/arm-pretool-check.md`) and the cd-guard (`bin/fm-cd-pretool-check.sh`, `docs/cd-guard.md`).
@@ -56,6 +57,7 @@ OpenCode, Pi, and Grok expose passive lifecycle callbacks for this purpose.
 Their adapters fail open at the hook boundary to avoid corrupting a user session, but they force one follow-up turn when the shared predicate blocks.
 Each adapter carries its own in-process or environment loop guard so the forced follow-up does not recursively schedule another follow-up.
 Pi keeps that latch active across every internal tool turn and clears it only when the generated guard follow-up reaches `agent_settled`, or immediately when follow-up delivery fails.
+All five integrations therefore reach the same portable durable-memory boundary without a second hook registration or lifecycle cycle; [`durable-memory.md`](durable-memory.md) owns the compaction support matrix and fallback rationale.
 If a passive adapter cannot call its SDK method, cannot find `grok`, or cannot recover the Grok session id, it fails open and relies on the pull-based `fm-guard.sh` warning at the next fleet command.
 That warning uses `bin/fm-supervision-instructions.sh --repair-line`, so it points back to the active harness protocol instead of hardcoding one background-arm command.
 

--- a/tests/fm-memory-codex-live.test.sh
+++ b/tests/fm-memory-codex-live.test.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Opt-in credentialed Codex 0.144.4 automatic-compaction experiment.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+if [ "${FM_CODEX_LIVE_COMPACTION:-0}" != 1 ]; then
+  pass "durable memory: live Codex automatic-compaction experiment skipped (opt in with FM_CODEX_LIVE_COMPACTION=1)"
+  exit 0
+fi
+
+command -v codex >/dev/null 2>&1 || fail "Codex CLI is required for the live compaction experiment"
+[ "$(codex --version)" = "codex-cli 0.144.4" ] || fail "live compaction experiment requires codex-cli 0.144.4"
+
+EVIDENCE_ROOT=${FM_CODEX_COMPACTION_EVIDENCE_ROOT:-/var/folders/fd/lyw7_hdx0j39x560w1s0lngw0000gn/T/no-mistakes-evidence/fm-memory-codex-auto-compact}
+RUN_DIR="$EVIDENCE_ROOT/2026-07-20-$$"
+HOME_DIR="$RUN_DIR/home"
+PROBE_ROOT="$RUN_DIR/probe-repo"
+PROMPT_FILE="$RUN_DIR/prompt.txt"
+SEED_EVENTS_FILE="$RUN_DIR/codex-seed-events.jsonl"
+EVENTS_FILE="$RUN_DIR/codex-events.jsonl"
+STDERR_FILE="$RUN_DIR/codex-stderr.txt"
+MARKER="FM_AUTO_COMPACT_RECOVERY_20260720"
+PRECOMPACT_CHECKPOINT=""
+PRECOMPACT_EVENT=""
+THREAD_ID=""
+CODEX_HOOK_CONFIG=()
+
+mkdir -p "$HOME_DIR/data" "$HOME_DIR/state" "$HOME_DIR/config" "$PROBE_ROOT/bin" "$PROBE_ROOT/.codex"
+cp "$ROOT/bin/fm-memory.js" "$ROOT/bin/fm-memory.sh" "$ROOT/bin/fm-memory-codex-hook.sh" "$PROBE_ROOT/bin/"
+chmod +x "$PROBE_ROOT/bin/fm-memory.js" "$PROBE_ROOT/bin/fm-memory.sh" "$PROBE_ROOT/bin/fm-memory-codex-hook.sh"
+jq '{hooks:{PreCompact:.hooks.PreCompact,PostCompact:.hooks.PostCompact,UserPromptSubmit:.hooks.UserPromptSubmit,Stop:[{hooks:[.hooks.Stop[0].hooks[] | select(.command | contains("fm-memory-codex-hook.sh"))]}]}}' "$ROOT/.codex/hooks.json" > "$PROBE_ROOT/.codex/hooks.json"
+printf '%s\n' 'This repository is an isolated read-only compaction experiment. Follow the user prompt exactly and do not inspect files or run session startup.' > "$PROBE_ROOT/AGENTS.md"
+git -C "$PROBE_ROOT" init -q -b main
+git -C "$PROBE_ROOT" add AGENTS.md .codex/hooks.json bin
+git -C "$PROBE_ROOT" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm fixture
+CODEX_HOOK_CONFIG=(
+  -c "hooks.PreCompact=[{hooks=[{type=\"command\",command=\"$PROBE_ROOT/bin/fm-memory-codex-hook.sh pre\",timeout=30}]}]"
+  -c "hooks.PostCompact=[{hooks=[{type=\"command\",command=\"$PROBE_ROOT/bin/fm-memory-codex-hook.sh post\",timeout=30}]}]"
+  -c "hooks.UserPromptSubmit=[{hooks=[{type=\"command\",command=\"$PROBE_ROOT/bin/fm-memory-codex-hook.sh prompt\",timeout=30}]}]"
+  -c "hooks.Stop=[{hooks=[{type=\"command\",command=\"$PROBE_ROOT/bin/fm-memory-codex-hook.sh stop\",timeout=30}]}]"
+)
+printf '%s\n' "$$" > "$HOME_DIR/state/.lock"
+jq -cn --arg marker "$MARKER" '{objective:$marker,completed:[],pending:["verify automatic compaction recovery"],decisions:[],constraints:["automatic compaction remains enabled"],blockers:[],active_tasks:[],evidence:[],next_safe_action:"Return the objective marker exactly",provenance:["test:codex-0.144.4-auto-compaction"],sensitivity:"private"}' |
+  FM_HOME="$HOME_DIR" FM_ROOT_OVERRIDE="$PROBE_ROOT" "$PROBE_ROOT/bin/fm-memory.sh" checkpoint --reason live-auto-compact --runtime codex --session live-probe --input - >/dev/null
+
+{
+  printf '%s\n' 'This is a read-only automatic-compaction experiment.'
+  printf '%s\n' 'Use the shell tool once to run `printf COMPACTION_TOOL_OK`, then finish the task.'
+  printf '%s\n' 'After the shell tool completes, reply SEED_COMPLETE.'
+  awk 'BEGIN { for (i = 0; i < 3000; i += 1) print "bounded automatic compaction probe context" }'
+} > "$PROMPT_FILE"
+
+RUST_LOG=codex_core::session::turn=trace FM_HOME="$HOME_DIR" FM_ROOT_OVERRIDE="$PROBE_ROOT" codex exec --json --sandbox read-only --dangerously-bypass-hook-trust \
+  --disable token_budget --strict-config -c model_auto_compact_token_limit=8000 "${CODEX_HOOK_CONFIG[@]}" -C "$PROBE_ROOT" - < "$PROMPT_FILE" > "$SEED_EVENTS_FILE" 2> "$STDERR_FILE" || fail "credentialed Codex history-seeding turn failed; inspect $STDERR_FILE"
+THREAD_ID=$(jq -r 'select(.type == "thread.started") | .thread_id' "$SEED_EVENTS_FILE" | head -n 1)
+[ -n "$THREAD_ID" ] || fail "Codex history-seeding turn did not report a thread id"
+RUST_LOG=codex_core::session::turn=trace FM_HOME="$HOME_DIR" FM_ROOT_OVERRIDE="$PROBE_ROOT" codex exec --json --sandbox read-only --dangerously-bypass-hook-trust \
+  --disable token_budget --strict-config -c model_auto_compact_token_limit=8000 "${CODEX_HOOK_CONFIG[@]}" -C "$PROBE_ROOT" resume "$THREAD_ID" \
+  'Use the shell tool once to run `printf RESUME_TOOL_OK`. If a RECOVERY CAPSULE then arrives through a hook continuation, reply with its objective value exactly and nothing else. If no capsule arrives, reply NO_RECOVERY_CAPSULE.' > "$EVENTS_FILE" 2>> "$STDERR_FILE" || fail "credentialed Codex automatic-compaction resume failed; inspect $STDERR_FILE"
+
+jq -e --arg marker "$MARKER" 'select(.type == "item.completed" and .item.type == "agent_message" and ((.item.text // "") | contains($marker)))' "$EVENTS_FILE" >/dev/null || fail "bounded recovery did not reach a subsequent Codex model turn; inspect $EVENTS_FILE"
+PRECOMPACT_CHECKPOINT=$(find "$HOME_DIR/data/memory/checkpoints" -type f -name '*.md' -exec rg -l '"reason":"pre-compact"' {} + | head -n 1)
+[ -n "$PRECOMPACT_CHECKPOINT" ] || fail "PreCompact did not publish a durable checkpoint"
+PRECOMPACT_EVENT=$(find "$HOME_DIR/data/memory/events" -type f -name '*.json' -exec jq -r 'select(.type == "session-lineage" and .payload.reason == "pre-compact") | .event_id' {} + | head -n 1)
+[ -n "$PRECOMPACT_EVENT" ] || fail "PreCompact did not publish its lineage event"
+[ ! -e "$HOME_DIR/data/memory/pending/codex/$THREAD_ID.json" ] || fail "PostCompact recovery was not acknowledged after its model continuation"
+
+pass "durable memory: Codex 0.144.4 auto compaction fires both hooks and reaches the model"

--- a/tests/fm-memory.test.sh
+++ b/tests/fm-memory.test.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# Behavior tests for the canonical private durable-memory owner.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+MEMORY="$ROOT/bin/fm-memory.sh"
+TMP_ROOT=$(fm_test_tmproot fm-memory)
+fm_git_identity fmtest fmtest@example.invalid
+
+new_home() {
+  local name=$1 home
+  home="$TMP_ROOT/$name"
+  mkdir -p "$home/data" "$home/state" "$home/config"
+  printf '%s\n' "$$" > "$home/state/.lock"
+  printf '%s\n' "$home"
+}
+
+run_memory() {
+  local home=$1
+  shift
+  FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" "$MEMORY" "$@"
+}
+
+checkpoint_json() {
+  local objective=${1:-"Recover durable work"}
+  jq -cn --arg objective "$objective" '{objective:$objective,completed:[],pending:["verify"],decisions:["captain approved bounded local files"],constraints:["memory never overrides authority"],blockers:[],active_tasks:[],evidence:[],next_safe_action:"Run bounded recovery",provenance:["authority:data/backlog.md"],sensitivity:"private"}'
+}
+
+test_concurrent_idempotent_events_and_malformed_recovery() {
+  local home count unique i out
+  home=$(new_home concurrent)
+  for i in $(seq 1 40); do
+    run_memory "$home" event --type task-transition --runtime codex --session session-a --writer writer-a \
+      --task task-a --project firstmate --idempotency-key "event-$i" --payload-file - >/dev/null <<EOF &
+{"summary":"transition $i"}
+EOF
+  done
+  wait
+  count=$(find "$home/data/memory/events" -type f -name '*.json' | wc -l | tr -d ' ')
+  [ "$count" -eq 40 ] || fail "concurrent writes produced $count events, expected 40"
+
+  run_memory "$home" event --type task-transition --runtime codex --session session-a --writer writer-a \
+    --task task-a --project firstmate --idempotency-key event-1 --payload-file - <<<'{"summary":"transition 1"}' >/dev/null
+  unique=$(find "$home/data/memory/events" -type f -name '*.json' | wc -l | tr -d ' ')
+  [ "$unique" -eq 40 ] || fail "idempotent retry created a duplicate event"
+
+  printf '{"truncated":' > "$home/data/memory/events/writer-a/truncated.json"
+  out=$(checkpoint_json | run_memory "$home" checkpoint --reason test --runtime codex --session session-a --input -)
+  [ -f "$out" ] || fail "checkpoint was not written after malformed event recovery"
+  out=$(run_memory "$home" recover)
+  assert_contains "$out" "checkpoint:" "recovery failed after a truncated event record"
+  pass "durable memory: concurrent appends, retry idempotency, and malformed event recovery"
+}
+
+test_checkpoint_atomic_validation_and_immutable_history() {
+  local home first second status
+  home=$(new_home checkpoints)
+  first=$(checkpoint_json first | run_memory "$home" checkpoint --reason manual --runtime claude --session one --input -)
+  second=$(checkpoint_json second | run_memory "$home" checkpoint --reason turn-end --runtime claude --session one --input -)
+  [ "$first" != "$second" ] || fail "immutable checkpoint history reused one path"
+  [ -f "$first.sha256" ] && [ -f "$second.sha256" ] || fail "checkpoint hash sidecars missing"
+  run_memory "$home" validate "$first" >/dev/null || fail "fresh checkpoint did not validate"
+  printf '\nmodified\n' >> "$first"
+  status=0
+  run_memory "$home" validate "$first" >/dev/null 2>&1 || status=$?
+  expect_code 1 "$status" "modified checkpoint must fail validation"
+  run_memory "$home" validate "$second" >/dev/null || fail "newer immutable checkpoint was damaged by older tamper"
+  pass "durable memory: atomic validation and immutable checkpoint history"
+}
+
+test_high_water_replay_has_no_duplicate_or_loss() {
+  local home cp out later_count
+  home=$(new_home replay)
+  run_memory "$home" event --type objective --runtime codex --session replay --writer replay --idempotency-key before --payload-file - <<<'{"summary":"before"}' >/dev/null
+  cp=$(checkpoint_json replay | run_memory "$home" checkpoint --reason test --runtime codex --session replay --input -)
+  [ -f "$cp" ] || fail "replay checkpoint missing"
+  run_memory "$home" event --type test --runtime codex --session replay --writer replay --idempotency-key after --payload-file - <<<'{"summary":"after passed"}' >/dev/null
+  out=$(run_memory "$home" recover --max-events 20)
+  assert_contains "$out" "later events (2):" "recovery did not replay the checkpoint event plus later test event"
+  later_count=$(printf '%s\n' "$out" | grep '^later events' | grep -o 'ev_[a-f0-9]*' | sort -u | wc -l | tr -d ' ')
+  [ "$later_count" -eq 2 ] || fail "recovery replay duplicated or lost later events: $out"
+  pass "durable memory: high-water replay has no duplicate or lost events"
+}
+
+test_recovery_marks_changed_git_and_task_evidence() {
+  local home repo old input out
+  home=$(new_home reconcile)
+  repo="$TMP_ROOT/reconcile-repo"
+  git init -q -b main "$repo"
+  : > "$repo/file"
+  git -C "$repo" add file
+  git -C "$repo" commit -q -m first
+  old=$(git -C "$repo" rev-parse HEAD)
+  : > "$home/state/gone-task.meta"
+  input=$(jq -cn --arg root "$repo" --arg head "$old" '{objective:"Reconcile changed authority",completed:[],pending:[],decisions:[],constraints:[],blockers:[],active_tasks:["gone-task"],evidence:[{kind:"git",ref:$root,expected:{head:$head,dirty:false}},{kind:"task",ref:"gone-task",expected:{meta_present:true}}],next_safe_action:"Inspect contradictions",provenance:["authority:git","authority:state/gone-task.meta"],sensitivity:"private"}')
+  printf '%s\n' "$input" | FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" "$MEMORY" checkpoint --reason test --runtime codex --session reconcile --input - >/dev/null
+  rm "$home/state/gone-task.meta"
+  printf 'changed\n' >> "$repo/file"
+  git -C "$repo" add file
+  git -C "$repo" commit -q -m second
+  out=$(FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" "$MEMORY" recover)
+  assert_contains "$out" "disputed: Git HEAD changed" "changed Git evidence was not disputed"
+  assert_contains "$out" "stale: task gone-task" "missing task evidence was not marked stale"
+  printf '{"session_id":"reconcile"}\n' | FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" "$MEMORY" boundary --reason turn-end --runtime codex >/dev/null
+  FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" "$MEMORY" validate >/dev/null || fail "a new boundary could not supersede stale local evidence"
+  pass "durable memory: changed Git and task evidence becomes disputed or stale"
+}
+
+test_lock_refusal_and_home_isolation() {
+  local one two out status
+  one=$(new_home home-one)
+  two=$(new_home home-two)
+  printf '1\n' > "$one/state/.lock"
+  out=$(printf '{}' | run_memory "$one" boundary --reason turn-end --runtime codex)
+  assert_contains "$out" "skipped: session lock not owned" "foreign lock did not suppress mutation"
+  status=0
+  checkpoint_json refused | run_memory "$one" checkpoint --reason manual --runtime codex --session refused --input - >/dev/null 2>&1 || status=$?
+  [ "$status" -ne 0 ] || fail "lock-refused direct checkpoint mutated memory"
+  [ ! -e "$one/data/memory" ] || fail "lock-refused boundary mutated memory"
+
+  run_memory "$two" event --type objective --runtime codex --session two --writer two --idempotency-key isolated --payload-file - <<<'{"summary":"home two only"}' >/dev/null
+  out=$(run_memory "$one" search --query "home two only")
+  assert_contains "$out" '"count":0' "one home searched another home's memory"
+  out=$(run_memory "$two" search --query "home two only")
+  assert_contains "$out" '"count":1' "own-home search did not find its event"
+  pass "durable memory: lock refusal is read-only and homes stay isolated"
+}
+
+test_search_bounds_sensitivity_and_provenance() {
+  local home out
+  home=$(new_home search)
+  run_memory "$home" event --type decision --runtime opencode --session s --writer w --sensitivity private --source authority:data/backlog.md --idempotency-key visible --payload-file - <<<'{"summary":"visible needle"}' >/dev/null
+  run_memory "$home" event --type decision --runtime opencode --session s --writer w --sensitivity restricted --source authority:data/captain.md --idempotency-key restricted --payload-file - <<<'{"summary":"restricted needle"}' >/dev/null
+  out=$(run_memory "$home" search --query needle --kind events --limit 1)
+  assert_contains "$out" '"count":1' "bounded search did not respect limit"
+  assert_contains "$out" '"truncated":false' "restricted result should be filtered before limit accounting"
+  assert_contains "$out" 'authority:data/backlog.md' "search omitted provenance"
+  assert_not_contains "$out" 'restricted needle' "default search exposed restricted evidence"
+  out=$(run_memory "$home" search --query "restricted needle" --include-sensitive)
+  assert_contains "$out" '"count":1' "explicit sensitive search did not find restricted evidence"
+  pass "durable memory: bounded search filters sensitivity and returns provenance"
+}
+
+test_secret_path_and_transcript_guards() {
+  local home status payload symlink projects
+  home=$(new_home guards)
+  status=0
+  run_memory "$home" event --type objective --runtime codex --session s --writer w --payload-file - <<<'{"password":"supersecret123"}' >/dev/null 2>&1 || status=$?
+  [ "$status" -ne 0 ] || fail "secret-like payload was accepted"
+
+  payload="$home/payload.json"
+  printf '{"summary":"safe"}\n' > "$payload"
+  symlink="$home/payload-link.json"
+  ln -s "$payload" "$symlink"
+  status=0
+  run_memory "$home" event --type objective --runtime codex --session s --writer w --payload-file "$symlink" >/dev/null 2>&1 || status=$?
+  [ "$status" -ne 0 ] || fail "symlink payload input was accepted"
+
+  projects="$home/projects/demo"
+  mkdir -p "$projects"
+  printf 'opaque transcript\n' > "$projects/session.jsonl"
+  status=0
+  run_memory "$home" transcript-ref --runtime codex --session s --path "$projects/session.jsonl" >/dev/null 2>&1 || status=$?
+  [ "$status" -ne 0 ] || fail "transcript-ref read under projects/"
+  pass "durable memory: secret, symlink, and project-path guards"
+}
+
+test_all_runtime_turn_fallbacks_share_boundary_owner() {
+  local runtime home count
+  for runtime in claude codex opencode pi grok; do
+    home=$(new_home "runtime-$runtime")
+    printf '%s\n' "$$" > "$home/state/.lock"
+    printf '{"session_id":"%s-session"}\n' "$runtime" | run_memory "$home" boundary --reason turn-end --runtime "$runtime" >/dev/null
+    count=$(find "$home/data/memory/checkpoints" -type f -name '*.md' | wc -l | tr -d ' ')
+    [ "$count" -eq 1 ] || fail "$runtime fallback did not create one turn checkpoint"
+    run_memory "$home" validate >/dev/null || fail "$runtime checkpoint did not validate: $runtime"
+  done
+  pass "durable memory: all five supported runtimes use the verified turn-boundary fallback"
+}
+
+test_recovery_capsule_is_bounded() {
+  local home objective input out bytes
+  home=$(new_home capsule-bound)
+  objective=$(printf '%020000d' 0 | tr '0' x)
+  input=$(jq -cn --arg objective "$objective" '{objective:$objective,completed:[],pending:[],decisions:[],constraints:[],blockers:[],active_tasks:[],evidence:[],next_safe_action:"bounded",provenance:[],sensitivity:"private"}')
+  printf '%s\n' "$input" | run_memory "$home" checkpoint --reason test --runtime codex --session bounded --input - >/dev/null
+  out=$(run_memory "$home" recover)
+  bytes=$(printf '%s' "$out" | wc -c | tr -d ' ')
+  [ "$bytes" -le 12000 ] || fail "recovery capsule exceeded 12000 bytes: $bytes"
+  assert_contains "$out" "recovery capsule truncated" "oversized recovery content did not report truncation"
+  pass "durable memory: recovery capsule output stays bounded"
+}
+
+test_concurrent_idempotent_events_and_malformed_recovery
+test_checkpoint_atomic_validation_and_immutable_history
+test_high_water_replay_has_no_duplicate_or_loss
+test_recovery_marks_changed_git_and_task_evidence
+test_lock_refusal_and_home_isolation
+test_search_bounds_sensitivity_and_provenance
+test_secret_path_and_transcript_guards
+test_all_runtime_turn_fallbacks_share_boundary_owner
+test_recovery_capsule_is_bounded

--- a/tests/fm-memory.test.sh
+++ b/tests/fm-memory.test.sh
@@ -28,6 +28,21 @@ checkpoint_json() {
   jq -cn --arg objective "$objective" '{objective:$objective,completed:[],pending:["verify"],decisions:["captain approved bounded local files"],constraints:["memory never overrides authority"],blockers:[],active_tasks:[],evidence:[],next_safe_action:"Run bounded recovery",provenance:["authority:data/backlog.md"],sensitivity:"private"}'
 }
 
+test_fresh_home_initializes_private_data_root() {
+  local home mode count
+  home="$TMP_ROOT/fresh-home"
+  mkdir -p "$home/state" "$home/config"
+  printf '%s\n' "$$" > "$home/state/.lock"
+  printf '{"session_id":"fresh-session","turn_id":"turn-one"}\n' |
+    run_memory "$home" boundary --reason pre-compact --runtime codex >/dev/null
+  [ -d "$home/data" ] && [ ! -L "$home/data" ] || fail "fresh home did not create a real data root"
+  mode=$(stat -f '%Lp' "$home/data" 2>/dev/null || stat -c '%a' "$home/data")
+  [ "$mode" = "700" ] || fail "fresh home data root mode was $mode, expected 700"
+  count=$(find "$home/data/memory/checkpoints" -type f -name '*.md' | wc -l | tr -d ' ')
+  [ "$count" -eq 1 ] || fail "fresh home did not create one pre-compaction checkpoint"
+  pass "durable memory: fresh home securely initializes its private data root"
+}
+
 test_concurrent_idempotent_events_and_malformed_recovery() {
   local home count unique i out
   home=$(new_home concurrent)
@@ -266,6 +281,7 @@ test_recovery_capsule_is_bounded() {
   pass "durable memory: recovery capsule output stays bounded"
 }
 
+test_fresh_home_initializes_private_data_root
 test_concurrent_idempotent_events_and_malformed_recovery
 test_checkpoint_atomic_validation_and_immutable_history
 test_high_water_replay_has_no_duplicate_or_loss

--- a/tests/fm-memory.test.sh
+++ b/tests/fm-memory.test.sh
@@ -237,8 +237,32 @@ EOF
   pass "durable memory: concurrent event capacity remains strict"
 }
 
+test_checkpoint_retention_keeps_automatic_writes_live() {
+  local home first renamed count latest
+  home=$(new_home checkpoint-retention)
+  first=$(checkpoint_json oldest | run_memory "$home" checkpoint --reason turn-end --runtime codex --session retention --input -)
+  renamed="$home/data/memory/checkpoints/0000-oldest.md"
+  mv "$first" "$renamed"
+  mv "$first.sha256" "$renamed.sha256"
+  CHECKPOINT_DIR="$home/data/memory/checkpoints" node <<'EOF'
+import fs from "node:fs";
+for (let i = 1; i < 1000; i += 1) {
+  const name = `1000-seed-${String(i).padStart(4, "0")}.md`;
+  fs.writeFileSync(`${process.env.CHECKPOINT_DIR}/${name}`, "invalid retained seed\n");
+  fs.writeFileSync(`${process.env.CHECKPOINT_DIR}/${name}.sha256`, "invalid\n");
+}
+EOF
+  checkpoint_json newest | run_memory "$home" checkpoint --reason turn-end --runtime codex --session retention --input - >/dev/null
+  count=$(find "$home/data/memory/checkpoints" -type f -name '*.md' | wc -l | tr -d ' ')
+  [ "$count" -eq 1000 ] || fail "checkpoint retention kept $count records instead of 1000"
+  [ ! -e "$renamed" ] && [ ! -e "$renamed.sha256" ] || fail "checkpoint retention did not remove the oldest checkpoint pair"
+  latest=$(run_memory "$home" validate)
+  [ -n "$latest" ] || fail "checkpoint retention did not leave a valid newest checkpoint"
+  pass "durable memory: rolling checkpoint retention keeps automatic writes live"
+}
+
 test_codex_compaction_hook_bridge() {
-  local home pre_count post bytes
+  local home pre_count post stop_out stop_status prompt bytes
   home=$(new_home codex-compact)
   printf '{"session_id":"codex-hook-session","turn_id":"compact-turn","hook_event_name":"PreCompact","trigger":"auto"}\n' |
     FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" "$ROOT/bin/fm-memory-codex-hook.sh" pre
@@ -246,13 +270,31 @@ test_codex_compaction_hook_bridge() {
   [ "$pre_count" -eq 1 ] || fail "Codex PreCompact bridge did not create one checkpoint"
   post=$(printf '{"session_id":"codex-hook-session","turn_id":"compact-turn","hook_event_name":"PostCompact","trigger":"auto"}\n' |
     FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" "$ROOT/bin/fm-memory-codex-hook.sh" post)
-  assert_contains "$post" '"continue":true' "Codex PostCompact bridge did not preserve compaction"
-  assert_contains "$post" 'RECOVERY CAPSULE' "Codex PostCompact bridge did not return bounded recovery"
-  bytes=$(printf '%s' "$post" | jq -r '.systemMessage' | wc -c | tr -d ' ')
+  [ -z "$post" ] || fail "Codex PostCompact bridge emitted an ineffective direct hook message"
+  [ -f "$home/data/memory/pending/codex/codex-hook-session.json" ] || fail "Codex PostCompact bridge did not stage recovery"
+  stop_status=0
+  stop_out=$(printf '{"session_id":"codex-hook-session","turn_id":"compact-turn","hook_event_name":"Stop","stop_hook_active":false}\n' |
+    FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" "$ROOT/bin/fm-memory-codex-hook.sh" stop 2>&1) || stop_status=$?
+  expect_code 2 "$stop_status" "Codex Stop bridge must request one model continuation"
+  assert_contains "$stop_out" 'RECOVERY CAPSULE' "Codex Stop bridge did not deliver model-visible recovery"
+  [ -e "$home/data/memory/pending/codex/codex-hook-session.json" ] || fail "Codex Stop bridge removed recovery before its continuation completed"
+  bytes=$(printf '%s' "$stop_out" | wc -c | tr -d ' ')
   [ "$bytes" -le 12000 ] || fail "Codex PostCompact recovery exceeded 12000 bytes: $bytes"
+  printf '{"session_id":"codex-hook-session","turn_id":"compact-turn","hook_event_name":"Stop","stop_hook_active":true}\n' |
+    FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" "$ROOT/bin/fm-memory-codex-hook.sh" stop
+  [ ! -e "$home/data/memory/pending/codex/codex-hook-session.json" ] || fail "Codex Stop bridge did not acknowledge completed recovery"
+
+  printf '{"session_id":"codex-hook-session","turn_id":"compact-turn-two","hook_event_name":"PostCompact","trigger":"auto"}\n' |
+    FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" "$ROOT/bin/fm-memory-codex-hook.sh" post
+  prompt=$(printf '{"session_id":"codex-hook-session","turn_id":"next-turn","hook_event_name":"UserPromptSubmit","prompt":"continue"}\n' |
+    FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" "$ROOT/bin/fm-memory-codex-hook.sh" prompt)
+  assert_contains "$prompt" '"hookEventName":"UserPromptSubmit"' "Codex prompt fallback did not use the model-visible hook contract"
+  assert_contains "$prompt" 'RECOVERY CAPSULE' "Codex prompt fallback did not deliver staged recovery"
   jq -e '.hooks.PreCompact[0].hooks[0].command | contains("fm-memory-codex-hook.sh")' "$ROOT/.codex/hooks.json" >/dev/null || fail "Codex PreCompact hook is not tracked"
   jq -e '.hooks.PostCompact[0].hooks[0].command | contains("fm-memory-codex-hook.sh")' "$ROOT/.codex/hooks.json" >/dev/null || fail "Codex PostCompact hook is not tracked"
-  pass "durable memory: Codex automatic compaction bridge checkpoints and recovers"
+  jq -e '.hooks.UserPromptSubmit[0].hooks[0].command | contains("fm-memory-codex-hook.sh")' "$ROOT/.codex/hooks.json" >/dev/null || fail "Codex UserPromptSubmit recovery fallback is not tracked"
+  jq -e '.hooks.Stop[0].hooks[1].command | contains("fm-memory-codex-hook.sh")' "$ROOT/.codex/hooks.json" >/dev/null || fail "Codex Stop recovery continuation is not tracked"
+  pass "durable memory: Codex compaction stages model-visible bounded recovery"
 }
 
 test_all_runtime_turn_fallbacks_share_boundary_owner() {
@@ -291,6 +333,7 @@ test_search_bounds_sensitivity_and_provenance
 test_secret_path_and_transcript_guards
 test_boundary_preserves_uncaptured_semantic_events
 test_concurrent_capacity_is_strict
+test_checkpoint_retention_keeps_automatic_writes_live
 test_codex_compaction_hook_bridge
 test_all_runtime_turn_fallbacks_share_boundary_owner
 test_recovery_capsule_is_bounded

--- a/tests/fm-memory.test.sh
+++ b/tests/fm-memory.test.sh
@@ -78,9 +78,10 @@ test_high_water_replay_has_no_duplicate_or_loss() {
   [ -f "$cp" ] || fail "replay checkpoint missing"
   run_memory "$home" event --type test --runtime codex --session replay --writer replay --idempotency-key after --payload-file - <<<'{"summary":"after passed"}' >/dev/null
   out=$(run_memory "$home" recover --max-events 20)
-  assert_contains "$out" "later events (2):" "recovery did not replay the checkpoint event plus later test event"
-  later_count=$(printf '%s\n' "$out" | grep '^later events' | grep -o 'ev_[a-f0-9]*' | sort -u | wc -l | tr -d ' ')
-  [ "$later_count" -eq 2 ] || fail "recovery replay duplicated or lost later events: $out"
+  assert_contains "$out" "later event evidence (shown 1 of 1):" "recovery did not replay the later semantic event"
+  later_count=$(printf '%s\n' "$out" | grep '^later event evidence' | grep -o 'ev_[a-f0-9]*' | sort -u | wc -l | tr -d ' ')
+  [ "$later_count" -eq 1 ] || fail "recovery replay duplicated or lost later semantic events: $out"
+  assert_contains "$out" "after passed" "recovery replay omitted the later event payload"
   pass "durable memory: high-water replay has no duplicate or lost events"
 }
 
@@ -118,6 +119,12 @@ test_lock_refusal_and_home_isolation() {
   status=0
   checkpoint_json refused | run_memory "$one" checkpoint --reason manual --runtime codex --session refused --input - >/dev/null 2>&1 || status=$?
   [ "$status" -ne 0 ] || fail "lock-refused direct checkpoint mutated memory"
+  status=0
+  run_memory "$one" event --type objective --runtime codex --session refused --payload-file - <<<'{"summary":"refused"}' >/dev/null 2>&1 || status=$?
+  [ "$status" -ne 0 ] || fail "lock-refused direct event mutated memory"
+  status=0
+  run_memory "$one" transcript-ref --runtime codex --session refused >/dev/null 2>&1 || status=$?
+  [ "$status" -ne 0 ] || fail "lock-refused transcript reference mutated memory"
   [ ! -e "$one/data/memory" ] || fail "lock-refused boundary mutated memory"
 
   run_memory "$two" event --type objective --runtime codex --session two --writer two --idempotency-key isolated --payload-file - <<<'{"summary":"home two only"}' >/dev/null
@@ -164,7 +171,73 @@ test_secret_path_and_transcript_guards() {
   status=0
   run_memory "$home" transcript-ref --runtime codex --session s --path "$projects/session.jsonl" >/dev/null 2>&1 || status=$?
   [ "$status" -ne 0 ] || fail "transcript-ref read under projects/"
+
+  rm -rf "$home/data/memory"
+  mkdir -p "$home/escape"
+  ln -s "$home/escape" "$home/data/memory"
+  status=0
+  run_memory "$home" event --type objective --runtime codex --session s --writer w --payload-file - <<<'{"summary":"escape"}' >/dev/null 2>&1 || status=$?
+  [ "$status" -ne 0 ] || fail "symlinked memory parent accepted a write"
+  [ -z "$(find "$home/escape" -mindepth 1 -print -quit)" ] || fail "symlinked memory parent escaped the active data root"
   pass "durable memory: secret, symlink, and project-path guards"
+}
+
+test_boundary_preserves_uncaptured_semantic_events() {
+  local home out lineage_count
+  home=$(new_home boundary-events)
+  printf '{"session_id":"codex-session","turn_id":"turn-one"}\n' | run_memory "$home" boundary --reason turn-end --runtime codex >/dev/null
+  run_memory "$home" event --type decision --runtime codex --session codex-session --idempotency-key captain-choice --payload-file - <<<'{"summary":"keep the approved route"}' >/dev/null
+  printf '{"session_id":"codex-session","turn_id":"turn-two"}\n' | run_memory "$home" boundary --reason pre-compact --runtime codex >/dev/null
+  out=$(run_memory "$home" recover --max-events 20)
+  assert_contains "$out" "keep the approved route" "automatic boundary swallowed an uncaptured semantic event"
+  printf '{"session_id":"codex-session","turn_id":"turn-two"}\n' | run_memory "$home" boundary --reason pre-compact --runtime codex >/dev/null
+  lineage_count=$(find "$home/data/memory/events" -type f -name '*.json' -exec jq -r 'select(.type == "session-lineage" and .payload.reason == "pre-compact") | .event_id' {} + | sort -u | wc -l | tr -d ' ')
+  [ "$lineage_count" -eq 1 ] || fail "identical boundary retry created $lineage_count lineage events"
+  pass "durable memory: automatic boundaries preserve events and retry identity"
+}
+
+test_concurrent_capacity_is_strict() {
+  local home dir first second count first_status second_status
+  home=$(new_home capacity)
+  dir="$home/data/memory/events/seed"
+  mkdir -p "$dir"
+  EVENT_DIR="$dir" node <<'EOF'
+import fs from "node:fs";
+for (let i = 0; i < 4999; i += 1) {
+  const id = `seed-${String(i).padStart(4, "0")}`;
+  fs.writeFileSync(`${process.env.EVENT_DIR}/${id}.json`, JSON.stringify({ schema: "fm.memory.event.v1", event_id: id, sequence: id, created_at: "2026-01-01T00:00:00.000Z" }));
+}
+EOF
+  run_memory "$home" event --type test --runtime codex --session capacity --writer one --idempotency-key one --payload-file - <<<'{"summary":"one"}' >/dev/null 2>&1 &
+  first=$!
+  run_memory "$home" event --type test --runtime codex --session capacity --writer two --idempotency-key two --payload-file - <<<'{"summary":"two"}' >/dev/null 2>&1 &
+  second=$!
+  first_status=0
+  second_status=0
+  wait "$first" || first_status=$?
+  wait "$second" || second_status=$?
+  count=$(find "$home/data/memory/events" -type f -name '*.json' | wc -l | tr -d ' ')
+  [ "$count" -eq 5000 ] || fail "concurrent capacity writers produced $count events"
+  [ "$first_status" -ne 0 ] || [ "$second_status" -ne 0 ] || fail "both concurrent capacity writers succeeded"
+  pass "durable memory: concurrent event capacity remains strict"
+}
+
+test_codex_compaction_hook_bridge() {
+  local home pre_count post bytes
+  home=$(new_home codex-compact)
+  printf '{"session_id":"codex-hook-session","turn_id":"compact-turn","hook_event_name":"PreCompact","trigger":"auto"}\n' |
+    FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" "$ROOT/bin/fm-memory-codex-hook.sh" pre
+  pre_count=$(find "$home/data/memory/checkpoints" -type f -name '*.md' | wc -l | tr -d ' ')
+  [ "$pre_count" -eq 1 ] || fail "Codex PreCompact bridge did not create one checkpoint"
+  post=$(printf '{"session_id":"codex-hook-session","turn_id":"compact-turn","hook_event_name":"PostCompact","trigger":"auto"}\n' |
+    FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" "$ROOT/bin/fm-memory-codex-hook.sh" post)
+  assert_contains "$post" '"continue":true' "Codex PostCompact bridge did not preserve compaction"
+  assert_contains "$post" 'RECOVERY CAPSULE' "Codex PostCompact bridge did not return bounded recovery"
+  bytes=$(printf '%s' "$post" | jq -r '.systemMessage' | wc -c | tr -d ' ')
+  [ "$bytes" -le 12000 ] || fail "Codex PostCompact recovery exceeded 12000 bytes: $bytes"
+  jq -e '.hooks.PreCompact[0].hooks[0].command | contains("fm-memory-codex-hook.sh")' "$ROOT/.codex/hooks.json" >/dev/null || fail "Codex PreCompact hook is not tracked"
+  jq -e '.hooks.PostCompact[0].hooks[0].command | contains("fm-memory-codex-hook.sh")' "$ROOT/.codex/hooks.json" >/dev/null || fail "Codex PostCompact hook is not tracked"
+  pass "durable memory: Codex automatic compaction bridge checkpoints and recovers"
 }
 
 test_all_runtime_turn_fallbacks_share_boundary_owner() {
@@ -183,7 +256,7 @@ test_all_runtime_turn_fallbacks_share_boundary_owner() {
 test_recovery_capsule_is_bounded() {
   local home objective input out bytes
   home=$(new_home capsule-bound)
-  objective=$(printf '%020000d' 0 | tr '0' x)
+  objective=$(printf '%06000d' 0 | sed 's/0/🧭/g')
   input=$(jq -cn --arg objective "$objective" '{objective:$objective,completed:[],pending:[],decisions:[],constraints:[],blockers:[],active_tasks:[],evidence:[],next_safe_action:"bounded",provenance:[],sensitivity:"private"}')
   printf '%s\n' "$input" | run_memory "$home" checkpoint --reason test --runtime codex --session bounded --input - >/dev/null
   out=$(run_memory "$home" recover)
@@ -200,5 +273,8 @@ test_recovery_marks_changed_git_and_task_evidence
 test_lock_refusal_and_home_isolation
 test_search_bounds_sensitivity_and_provenance
 test_secret_path_and_transcript_guards
+test_boundary_preserves_uncaptured_semantic_events
+test_concurrent_capacity_is_strict
+test_codex_compaction_hook_bridge
 test_all_runtime_turn_fallbacks_share_boundary_owner
 test_recovery_capsule_is_bounded

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -54,6 +54,7 @@ new_world() {
 make_fake_toolchain() {
   local fakebin=$1
   fm_fake_exit0 "$fakebin" tmux node gh-axi chrome-devtools-axi lavish-axi
+  ln -sf "$(command -v node)" "$fakebin/node"
   cat > "$fakebin/gh" <<'SH'
 #!/usr/bin/env bash
 exit 0
@@ -306,6 +307,8 @@ EOF
 
   out=$(run_session_start "$home" "$root" "$fakebin:$BASE_PATH")
 
+  assert_contains "$out" "DURABLE RECOVERY" "session start omitted the bounded durable recovery section"
+  assert_contains "$out" "RECOVERY CAPSULE" "session start omitted the recovery capsule"
   assert_contains "$out" "data/projects.md" "digest did not label the projects.md section"
   assert_contains "$out" "- demo [no-mistakes] - a demo project (added 2026-07-01)" "digest did not print projects.md content"
 
@@ -383,6 +386,7 @@ EOF
   # untouched (fm-ff-lib would have tried to fast-forward it otherwise).
   assert_not_contains "$out" "SECONDMATE_SYNC" "mutating secondmate sweep ran during a lock refusal"
   assert_not_contains "$out" "NUDGE_SECONDMATES" "mutating secondmate sweep ran during a lock refusal"
+  [ ! -e "$home/data/memory" ] || fail "lock-refused session start mutated durable memory"
 
   # The rest of the digest (read-only-safe) still completed.
   assert_contains "$out" "FLEET STATE" "fleet-state digest section missing on the read-only path"
@@ -394,7 +398,7 @@ EOF
 # --- output ordering ----------------------------------------------------------
 
 test_output_ordering_diagnostics_lead() {
-  local rec root home fakebin out lock_line boot_line wake_line context_line fleet_line next_line
+  local rec root home fakebin out lock_line boot_line wake_line recovery_line context_line fleet_line next_line
   rec=$(new_world ordering)
   IFS='|' read -r root home fakebin <<EOF
 $rec
@@ -411,17 +415,19 @@ EOF
   lock_line=$(printf '%s\n' "$out" | grep -n '^LOCK$' | head -1 | cut -d: -f1)
   boot_line=$(printf '%s\n' "$out" | grep -n '^BOOTSTRAP$' | head -1 | cut -d: -f1)
   wake_line=$(printf '%s\n' "$out" | grep -n '^WAKE QUEUE$' | head -1 | cut -d: -f1)
+  recovery_line=$(printf '%s\n' "$out" | grep -n '^DURABLE RECOVERY$' | head -1 | cut -d: -f1)
   context_line=$(printf '%s\n' "$out" | grep -n '^CONTEXT$' | head -1 | cut -d: -f1)
   fleet_line=$(printf '%s\n' "$out" | grep -n '^FLEET STATE$' | head -1 | cut -d: -f1)
   next_line=$(printf '%s\n' "$out" | grep -n '^NEXT STEP$' | head -1 | cut -d: -f1)
 
-  if [ -z "$lock_line" ] || [ -z "$boot_line" ] || [ -z "$wake_line" ] || [ -z "$context_line" ] || [ -z "$fleet_line" ] || [ -z "$next_line" ]; then
+  if [ -z "$lock_line" ] || [ -z "$boot_line" ] || [ -z "$wake_line" ] || [ -z "$recovery_line" ] || [ -z "$context_line" ] || [ -z "$fleet_line" ] || [ -z "$next_line" ]; then
     fail "one or more section headers missing from digest: $out"
   fi
 
   [ "$lock_line" -lt "$boot_line" ] || fail "LOCK did not precede BOOTSTRAP"
   [ "$boot_line" -lt "$wake_line" ] || fail "BOOTSTRAP did not precede WAKE QUEUE"
-  [ "$wake_line" -lt "$context_line" ] || fail "WAKE QUEUE did not precede CONTEXT"
+  [ "$wake_line" -lt "$recovery_line" ] || fail "WAKE QUEUE did not precede DURABLE RECOVERY"
+  [ "$recovery_line" -lt "$context_line" ] || fail "DURABLE RECOVERY did not precede CONTEXT"
   [ "$context_line" -lt "$fleet_line" ] || fail "CONTEXT did not precede FLEET STATE"
   [ "$fleet_line" -lt "$next_line" ] || fail "FLEET STATE did not precede NEXT STEP"
 

--- a/tests/fm-turnend-guard.test.sh
+++ b/tests/fm-turnend-guard.test.sh
@@ -793,6 +793,8 @@ test_codex_compaction_hooks_are_tracked() {
   settings="$ROOT/.codex/hooks.json"
   jq -e '.hooks.PreCompact[0].hooks[0].command | contains("fm-memory-codex-hook.sh")' "$settings" >/dev/null || fail "Codex PreCompact memory hook is missing"
   jq -e '.hooks.PostCompact[0].hooks[0].command | contains("fm-memory-codex-hook.sh")' "$settings" >/dev/null || fail "Codex PostCompact recovery hook is missing"
+  jq -e '.hooks.UserPromptSubmit[0].hooks[0].command | contains("fm-memory-codex-hook.sh")' "$settings" >/dev/null || fail "Codex prompt recovery fallback is missing"
+  jq -e '.hooks.Stop[0].hooks[1].command | contains("fm-memory-codex-hook.sh")' "$settings" >/dev/null || fail "Codex model-visible recovery continuation is missing"
   jq -e '.hooks.Stop[0].hooks[0].command | contains("FM_MEMORY_RUNTIME=codex")' "$settings" >/dev/null || fail "Codex Stop hook does not preserve runtime identity"
   pass ".codex primary hooks: compaction bridge and runtime identity are tracked"
 }

--- a/tests/fm-turnend-guard.test.sh
+++ b/tests/fm-turnend-guard.test.sh
@@ -779,6 +779,14 @@ test_pi_extension_forces_followup() {
   pass ".pi primary extension: agent_settled forces one follow-up through the shared guard"
 }
 
+test_shared_guard_invokes_durable_memory_boundary() {
+  local content
+  content=$(cat "$ROOT/bin/fm-turnend-guard.sh")
+  assert_contains "$content" 'fm-memory.sh" boundary --reason turn-end' "shared turn boundary does not invoke the durable-memory owner"
+  assert_contains "$content" '>/dev/null 2>&1 || true' "memory failure could block an otherwise healthy turn"
+  pass "fm-turnend-guard: all harness adapters share one non-blocking durable-memory boundary"
+}
+
 test_pi_extension_injects_once_per_logical_agent_run() {
   local repo home ext log out status
   repo="$TMP_ROOT/pi-logical-run-root"
@@ -937,6 +945,7 @@ test_codex_hook_uses_process_pwd_when_payload_cwd_is_outside_root
 test_codex_hook_ignores_nested_git_root_guard
 test_opencode_plugin_forces_followup
 test_opencode_plugin_anchors_guard_to_worktree
+test_shared_guard_invokes_durable_memory_boundary
 test_pi_extension_forces_followup
 test_pi_extension_injects_once_per_logical_agent_run
 test_pi_extension_retries_after_followup_delivery_failure

--- a/tests/fm-turnend-guard.test.sh
+++ b/tests/fm-turnend-guard.test.sh
@@ -762,6 +762,7 @@ test_pi_extension_forces_followup() {
   [ -f "$ext" ] || fail "tracked pi primary extension is missing"
   content=$(cat "$ext")
   assert_contains "$content" 'agent_settled' "pi extension must run after one logical agent run settles"
+  assert_contains "$content" 'getSessionId' "pi extension must preserve the active opaque session identity"
   assert_contains "$content" 'fm-turnend-guard.sh' "pi extension must invoke the shared guard"
   assert_contains "$content" 'sendUserMessage' "pi extension must force a follow-up turn"
   assert_contains "$content" 'deliverAs: "followUp"' "pi extension must queue the follow-up safely"
@@ -785,6 +786,15 @@ test_shared_guard_invokes_durable_memory_boundary() {
   assert_contains "$content" 'fm-memory.sh" boundary --reason turn-end' "shared turn boundary does not invoke the durable-memory owner"
   assert_contains "$content" '>/dev/null 2>&1 || true' "memory failure could block an otherwise healthy turn"
   pass "fm-turnend-guard: all harness adapters share one non-blocking durable-memory boundary"
+}
+
+test_codex_compaction_hooks_are_tracked() {
+  local settings
+  settings="$ROOT/.codex/hooks.json"
+  jq -e '.hooks.PreCompact[0].hooks[0].command | contains("fm-memory-codex-hook.sh")' "$settings" >/dev/null || fail "Codex PreCompact memory hook is missing"
+  jq -e '.hooks.PostCompact[0].hooks[0].command | contains("fm-memory-codex-hook.sh")' "$settings" >/dev/null || fail "Codex PostCompact recovery hook is missing"
+  jq -e '.hooks.Stop[0].hooks[0].command | contains("FM_MEMORY_RUNTIME=codex")' "$settings" >/dev/null || fail "Codex Stop hook does not preserve runtime identity"
+  pass ".codex primary hooks: compaction bridge and runtime identity are tracked"
 }
 
 test_pi_extension_injects_once_per_logical_agent_run() {
@@ -915,6 +925,7 @@ test_predicate_unhealthy_stale_beacon
 test_predicate_healthy_fresh_beacon
 test_predicate_queue_pending_flag
 test_hook_silent_when_no_work_in_flight
+test_codex_compaction_hooks_are_tracked
 test_hook_blocks_when_fresh_beacon_has_no_live_lock
 test_hook_blocks_when_dead_lock_has_fresh_beacon
 test_hook_silent_with_live_lock_and_fresh_beacon


### PR DESCRIPTION
## Intent

Adapt the proven durable-memory mechanisms from Nous Research's MIT-licensed Hermes Agent into Firstmate so automatic model compaction, especially Codex's aggressive compaction, cannot make important prior work unrecoverable. Prioritize the installed Codex CLI 0.144.4 official PreCompact and PostCompact hooks plus model_auto_compact_token_limit: automatic pre-compaction checkpoints and post-compaction bounded context recovery must work and be empirically tested without disabling compaction. Preserve existing authorities and lock-refused read-only behavior; keep memory private and bounded; complete the broader supported-runtime integration after the Codex bridge. Preserve missing local ShellCheck 0.11.0 and tmux as explicit environmental evidence when they cannot be supplied safely. Never merge the PR.

## What Changed

- Add a private, bounded durable-memory store with immutable events, validated checkpoints, retention, recovery, search, and transcript references.
- Integrate checkpointing and recovery with session starts and supported runtime turn boundaries, including model-visible Codex recovery across automatic compaction.
- Add the durable-memory recovery skill, architecture documentation, and focused coverage for locking, retention, bounded capsules, runtime adapters, and live Codex compaction.

## Risk Assessment

✅ Low: No task has been requested yet.

## Testing

Completed 1 recorded test check.

- Outcome: ⏭️ skipped across 1 run (21ms)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- 🚨 `bin/fm-memory-codex-hook.sh:19` - Intent requires “post-compaction bounded context recovery must work,” but this returns the capsule only as `systemMessage`. Codex documents that field as a UI/event-stream warning, and the 0.144.4 runtime discards PostCompact output except `should_stop`, so the capsule never becomes model context. Route recovery through a supported model-visible surface. See the [hook contract](https://learn.chatgpt.com/codex/hooks) and [0.144.4 runtime](https://github.com/openai/codex/blob/rust-v0.144.4/codex-rs/core/src/hook_runtime.rs).
- 🚨 `tests/fm-memory.test.sh:243` - Intent requires automatic compaction recovery to “be empirically tested without disabling compaction,” but this test directly invokes the shell adapter with synthetic payloads; it never runs Codex, triggers `model_auto_compact_token_limit`, observes automatic compaction, or verifies recovered model context. Add a real Codex auto-compaction experiment before accepting the required criterion.
- ⚠️ `bin/fm-memory.js:490` - Every logical turn and session start creates a checkpoint, but writes permanently stop at 1,000 checkpoints and the repository provides no archive/rotation command despite the error instructing users to archive. Because hook callers suppress this failure, a long-lived home eventually loses all new automatic checkpoints; define bounded retention or an operational archive path and surface exhaustion.

🔧 Fix: Captain, restore model-visible compaction recovery and checkpoint retention
1 info still open:
- ℹ️ What would you like me to work on?

</details>

<details>
<summary>⏭️ **Test** - skipped</summary>

- 🚨 tests failed with exit code 1
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⏭️ **Lint** - skipped</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
