### PR TITLE
fix(send): treat opencode busy-queued composer state as submitted

### DIFF
--- a/bin/fm-tmux-lib.sh
+++ b/bin/fm-tmux-lib.sh
@@ -150,8 +150,18 @@ fm_tmux_submit_enter_core() {  # <target> <retries> <enter-sleep>
     state=$(fm_tmux_composer_state "$target")
     [ "$state" = pending ] || { printf '%s' "$state"; return 0; }
     i=$((i + 1))
-    [ "$i" -lt "$retries" ] || { printf 'pending'; return 0; }
+    [ "$i" -lt "$retries" ] || break
   done
+  # Retries exhausted, composer still shows pending.
+  # If the pane is busy (agent mid-turn), the harness accepted the Enter
+  # and queued the message for processing when the current turn ends.
+  # Treat it as submitted so the caller does not re-send.
+  # On an idle pane, keep reporting pending - a genuine swallow.
+  if fm_pane_is_busy "$target"; then
+    printf 'empty'
+  else
+    printf 'pending'
+  fi
 }
 
 fm_tmux_submit_core() {  # <target> <text> <retries> <enter-sleep> <settle>

--- a/tests/fm-tmux-submit-busy.test.sh
+++ b/tests/fm-tmux-submit-busy.test.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# tests/fm-tmux-submit-busy.test.sh - regression: busy pane + pending composer
+# after Enter retries must return "empty" (message queued), not "pending".
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+# shellcheck source=bin/fm-tmux-lib.sh
+. "$ROOT/bin/fm-tmux-lib.sh"
+
+TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/fm-tmux-submit-busy.XXXXXX")
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+# Override fm_pane_is_busy for testing: FM_FAKE_PANE_BUSY=1 means busy.
+fm_pane_is_busy() {
+  [ "${FM_FAKE_PANE_BUSY:-0}" = 1 ]
+}
+
+make_submit_mock() {
+  local dir=$1 fakebin="$1/fakebin"
+  mkdir -p "$fakebin"
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+COMPOSER="${FM_FAKE_COMPOSER:?}"
+case "${1:-}" in
+  display-message)
+    for a in "$@"; do
+      case "$a" in *cursor_y*) printf '0\n'; exit 0 ;; esac
+    done
+    exit 0 ;;
+  capture-pane) cat "$COMPOSER" 2>/dev/null; exit 0 ;;
+  send-keys)
+    shift; is_enter=0
+    while [ "$#" -gt 0 ]; do
+      case "$1" in -t) shift ;; -l) ;; Enter) is_enter=1 ;; esac; shift
+    done
+    if [ "$is_enter" = 1 ]; then
+      if [ -n "${FM_FAKE_SWALLOW:-}" ] && [ -f "$FM_FAKE_SWALLOW" ]; then
+        [ "${FM_FAKE_PERSIST_SWALLOW:-0}" = 1 ] || rm -f "$FM_FAKE_SWALLOW"
+      else
+        printf '│ > │\n' > "$COMPOSER"
+      fi
+    fi
+    exit 0 ;;
+  list-windows) exit 0 ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/tmux"
+  printf '%s\n' "$fakebin"
+}
+
+test_busy_pane_pending_returns_empty() {
+  local dir fakebin composer sent vfile
+  dir="$TMP_ROOT/busy-accepted"
+  fakebin=$(make_submit_mock "$dir")
+  composer="$dir/composer"
+  sent="$dir/sent.log"
+  vfile="$dir/verdict"
+  printf '│ > fix findings 1 and 3 │\n' > "$composer"
+  : > "$sent"
+  touch "$dir/.swallow"
+  # Pre-check: composer state should be pending (via function, not $()).
+  PATH="$fakebin:$PATH" FM_FAKE_COMPOSER="$composer" fm_tmux_composer_state "win" > "$vfile" 2>/dev/null
+  [ "$(cat "$vfile")" = pending ] || fail "pre-check: composer state expected pending, got '$(cat "$vfile")'"
+  # Now test the submit - write verdict to file to avoid nested $().
+  PATH="$fakebin:$PATH" FM_FAKE_COMPOSER="$composer" FM_FAKE_SENT="$sent" \
+    FM_FAKE_SWALLOW="$dir/.swallow" FM_FAKE_PERSIST_SWALLOW=1 FM_FAKE_PANE_BUSY=1 \
+    fm_tmux_submit_enter_core "win" 3 0.05 > "$vfile" 2>/dev/null || [ $? -eq 0 ]
+  [ "$(cat "$vfile")" = empty ] || fail "busy-pane pending should return empty, got '$(cat "$vfile")'"
+  [ "$(grep -c 'fix findings' "$sent" 2>/dev/null || true)" -eq 0 ] \
+    || fail "busy-pane should not retype text"
+  pass "fm_tmux_submit_enter_core: busy pane + pending composer returns empty (message queued)"
+}
+
+test_idle_pane_pending_returns_pending() {
+  local dir fakebin composer sent vfile
+  dir="$TMP_ROOT/idle-swallow"
+  fakebin=$(make_submit_mock "$dir")
+  composer="$dir/composer"
+  sent="$dir/sent.log"
+  vfile="$dir/verdict"
+  printf '│ > fix findings 1 and 3 │\n' > "$composer"
+  : > "$sent"
+  touch "$dir/.swallow"
+  PATH="$fakebin:$PATH" FM_FAKE_COMPOSER="$composer" FM_FAKE_SENT="$sent" \
+    FM_FAKE_SWALLOW="$dir/.swallow" FM_FAKE_PERSIST_SWALLOW=1 FM_FAKE_PANE_BUSY=0 \
+    fm_tmux_submit_enter_core "win" 3 0.05 > "$vfile" 2>/dev/null
+  [ "$(cat "$vfile")" = pending ] || fail "idle-pane pending should return pending, got '$(cat "$vfile")'"
+  pass "fm_tmux_submit_enter_core: idle pane + pending composer stays pending (genuine swallow preserved)"
+}
+
+test_busy_pane_composer_clears_first_try() {
+  local dir fakebin composer sent vfile
+  dir="$TMP_ROOT/busy-clear"
+  fakebin=$(make_submit_mock "$dir")
+  composer="$dir/composer"
+  sent="$dir/sent.log"
+  vfile="$dir/verdict"
+  printf '│ > fix findings 1 and 3 │\n' > "$composer"
+  : > "$sent"
+  PATH="$fakebin:$PATH" FM_FAKE_COMPOSER="$composer" FM_FAKE_SENT="$sent" FM_FAKE_PANE_BUSY=1 \
+    fm_tmux_submit_enter_core "win" 3 0.05 > "$vfile" 2>/dev/null
+  [ "$(cat "$vfile")" = empty ] || fail "busy-pane with cleared composer should return empty, got '$(cat "$vfile")'"
+  pass "fm_tmux_submit_enter_core: busy pane clears composer on first Enter - returns empty"
+}
+
+test_idle_pane_composer_clears_first_try() {
+  local dir fakebin composer sent vfile
+  dir="$TMP_ROOT/idle-clear"
+  fakebin=$(make_submit_mock "$dir")
+  composer="$dir/composer"
+  sent="$dir/sent.log"
+  vfile="$dir/verdict"
+  printf '│ > fix findings 1 and 3 │\n' > "$composer"
+  : > "$sent"
+  PATH="$fakebin:$PATH" FM_FAKE_COMPOSER="$composer" FM_FAKE_SENT="$sent" FM_FAKE_PANE_BUSY=0 \
+    fm_tmux_submit_enter_core "win" 3 0.05 > "$vfile" 2>/dev/null
+  [ "$(cat "$vfile")" = empty ] || fail "idle-pane with cleared composer should return empty, got '$(cat "$vfile")'"
+  pass "fm_tmux_submit_enter_core: idle pane clears composer on first Enter - returns empty as before"
+}
+
+test_busy_pane_pending_returns_empty
+test_idle_pane_pending_returns_pending
+test_busy_pane_composer_clears_first_try
+test_idle_pane_composer_clears_first_try


### PR DESCRIPTION
When fm-send sends a message to a BUSY opencode crewmate on the tmux backend, opencode accepts the Enter and queues the message for the next turn, but leaves the typed text visible in the composer row.  The submit-verification loop sees a pending composer, exhausts retries, and reports a false "Enter swallowed" failure while the message is actually delivered.

Fix: after Enter retries are exhausted and the composer still shows pending, check fm_pane_is_busy.  If the pane is busy (agent mid-turn, footer shows "esc interrupt"), the harness queued the message, so return "empty" (accepted).  On an idle pane, keep returning "pending" (genuine swallow detection preserved).

Regression tests cover four scenarios:
- busy pane + pending composer -> empty (message queued)
- idle pane + pending composer -> pending (genuine swallow)
- busy pane + composer clears on first Enter -> empty
- idle pane + composer clears on first Enter -> empty (existing path)