### PR TITLE
feat(harness): add cursor-agent crew oneshot harness

### DIFF
--- a/.agents/skills/firstmate-orca/SKILL.md
+++ b/.agents/skills/firstmate-orca/SKILL.md
@@ -13,7 +13,7 @@ It does not replace `AGENTS.md`, `docs/orca-backend.md`, or `harness-adapters`.
 
 Orca is a runtime backend, not an agent harness.
 The runtime backend owns the task endpoint and, for Orca, the task worktree.
-The harness is the agent process launched inside that endpoint, such as `claude`, `codex`, `opencode`, `pi`, or `grok`.
+The harness is the agent process launched inside that endpoint; `docs/configuration.md` owns supported harness scope.
 Load `harness-adapters` for harness-specific launch, interrupt, resume, trust-dialog, and skill-invocation facts.
 
 Implementation details, metadata fields, teardown guarantees, limitations, and smoke evidence live in `docs/orca-backend.md`.

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -319,17 +319,6 @@ Grok's primary watcher protocol is Claude-shaped background-notify around `bin/f
 
 ## cursor-agent (CREW ONESHOT ONLY, verified 2026-07-20)
 
-Partial crew adapter for Cursor's `cursor-agent` CLI.
-Launch template (in `bin/fm-spawn.sh`): `cursor-agent -p --force --trust --workspace "$(pwd)" "$(cat <brief>)"`.
-Canonical harness name is `cursor-agent`; do not use bare `cursor` (that names the IDE).
-
-| Fact | Value |
-|---|---|
-| Scope | Crew oneshot ship/scout only. Not a verified primary. |
-| Busy / done | Process exit of the `-p` oneshot. No pane busy-signature, turn-end hook, or watcher protocol. |
-| Env marker | `CURSOR_AGENT=1` (also match process basename/args `*cursor-agent*`; never bare `cursor`). |
-| Autonomy | `--force` and `--trust` skip interactive approval gates for the oneshot. |
-| Interactive | Unverified. Herdr `agent start … -- cursor-agent` returned `agent_status=unknown` and flaky name lookup; do not claim interactive verified. |
-
-Do not arm primary turn-end or watch hooks for this adapter.
-See `docs/cursor-agent-crew.md` for the scope contract.
+`docs/cursor-agent-crew.md` owns the scope contract for this partial adapter.
+`bin/fm-spawn.sh` owns the launch template, and `bin/fm-harness.sh` owns detection.
+There is no primary turn-end or watch hook, secondmate launch, interactive recovery procedure, busy signature, exit command, interrupt, resume, or skill-invocation form to use.

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harness-adapters
-description: Agent-only reference for firstmate harness operations. Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter. Contains verified facts for claude, codex, opencode, pi, and grok.
+description: Agent-only reference for firstmate harness operations. Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter. Contains verified facts for claude, codex, opencode, pi, and grok, plus a partial crew-oneshot adapter for cursor-agent.
 user-invocable: false
 metadata:
   internal: true
@@ -316,3 +316,20 @@ The adapter therefore runs the shared predicate and, when it returns 2, forces o
 It does not pass `--permission-mode`, so the passive hook cannot escalate the primary session's tool permissions.
 Project-local Grok hooks require folder trust, verified with launch-time `--trust`; if the primary firstmate checkout is not trusted for Grok hooks, this primary guard fails open and `fm-guard.sh` remains the next-command alarm.
 Grok's primary watcher protocol is Claude-shaped background-notify around `bin/fm-watch-arm.sh`; the passive Stop hook is only a backstop for blind turn ends.
+
+## cursor-agent (CREW ONESHOT ONLY, verified 2026-07-20)
+
+Partial crew adapter for Cursor's `cursor-agent` CLI.
+Launch template (in `bin/fm-spawn.sh`): `cursor-agent -p --force --trust --workspace "$(pwd)" "$(cat <brief>)"`.
+Canonical harness name is `cursor-agent`; do not use bare `cursor` (that names the IDE).
+
+| Fact | Value |
+|---|---|
+| Scope | Crew oneshot ship/scout only. Not a verified primary. |
+| Busy / done | Process exit of the `-p` oneshot. No pane busy-signature, turn-end hook, or watcher protocol. |
+| Env marker | `CURSOR_AGENT=1` (also match process basename/args `*cursor-agent*`; never bare `cursor`). |
+| Autonomy | `--force` and `--trust` skip interactive approval gates for the oneshot. |
+| Interactive | Unverified. Herdr `agent start … -- cursor-agent` returned `agent_status=unknown` and flaky name lookup; do not claim interactive verified. |
+
+Do not arm primary turn-end or watch hooks for this adapter.
+See `docs/cursor-agent-crew.md` for the scope contract.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -481,3 +481,12 @@ Keep this file for knowledge useful to almost every future agent session in this
 Do not repeat what the codebase already shows; point to the authoritative file, skill, command, or doc.
 Prefer rewriting or pruning existing entries over appending new ones.
 When updating this file, preserve every safety boundary and keep the always-loaded contract concise.
+
+
+<claude-mem-context>
+# Memory Context
+
+# [01KY5KRAJXZJFFJ33T1W3B0NP2] recent context, 2026-07-22 9:19pm GMT+2
+
+No previous sessions found.
+</claude-mem-context>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,7 +154,8 @@ A silent bootstrap section needs no action; for any printed actionable diagnosti
 ## 4. Harness and runtime dispatch
 
 Load `harness-adapters` before every spawn or recovery and before trust handling, skill invocation, interrupt, exit, resume, or adapter verification.
-The verified harnesses are `claude`, `codex`, `opencode`, `pi`, and `grok`; never dispatch on an unverified adapter.
+The verified primary harnesses are `claude`, `codex`, `opencode`, `pi`, and `grok`; `cursor-agent` is only the partial crew-oneshot exception documented in `docs/cursor-agent-crew.md`.
+Never dispatch on any other unverified adapter.
 If configured harness data names an unverified adapter, report it and fall back only to a verified adapter rather than launching it.
 
 `docs/configuration.md` owns dispatch-profile and runtime-backend schemas, `bin/fm-dispatch-select.sh` owns selector mechanics, `bin/fm-harness.sh` owns static resolution, and `bin/fm-spawn.sh` owns launch flags and fail-closed validation.
@@ -486,7 +487,7 @@ When updating this file, preserve every safety boundary and keep the always-load
 <claude-mem-context>
 # Memory Context
 
-# [01KY5KRAJXZJFFJ33T1W3B0NP2] recent context, 2026-07-22 9:19pm GMT+2
+# [01KY5KRAJXZJFFJ33T1W3B0NP2] recent context, 2026-07-22 9:36pm GMT+2
 
 No previous sessions found.
 </claude-mem-context>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -487,7 +487,7 @@ When updating this file, preserve every safety boundary and keep the always-load
 <claude-mem-context>
 # Memory Context
 
-# [01KY5KRAJXZJFFJ33T1W3B0NP2] recent context, 2026-07-22 9:36pm GMT+2
+# [01KY5KRAJXZJFFJ33T1W3B0NP2] recent context, 2026-07-22 10:11pm GMT+2
 
 No previous sessions found.
 </claude-mem-context>

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ firstmate is not a model, not a harness, not a skill, not an MCP server, and not
 firstmate is an agent distro for running a crew of agents.
 An agent distro is a portable directory of instructions, skills, tooling, policies, and state conventions that turns a general-purpose agent into a specialized one.
 There is no app to install: the cloned repo is the distro - `AGENTS.md`, bundled firstmate skills, and helper scripts that any terminal coding agent can follow.
-Launching a supported harness inside it instantiates your first mate - and makes you the captain.
+Launching a supported primary harness inside it instantiates your first mate - and makes you the captain.
 
 ## Features
 
@@ -58,7 +58,7 @@ Full detail on every feature lives in [docs/architecture.md](docs/architecture.m
 
 ### Requirements
 
-- A verified agent harness: Claude Code, Grok, Pi, Codex, or OpenCode.
+- A verified primary agent harness: Claude Code, Grok, Pi, Codex, or OpenCode.
 - Git and the GitHub CLI, authenticated through `gh auth login`.
 - tmux, for the reference session backend.
 

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -31,7 +31,7 @@ FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
 
 detect_own() {
-  # Layer 1: environment markers for verified harnesses.
+  # Layer 1: verified environment markers.
   [ "${CLAUDECODE:-}" = "1" ] && { echo claude; return; }
   [ "${PI_CODING_AGENT:-}" = "true" ] && { echo pi; return; }
   # grok sets GROK_AGENT=1 for its child/tool processes (verified, grok 0.2.73).

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Detect the agent harness this process tree runs on.
-# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|grok|unknown
+# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|grok|cursor-agent|unknown
 #        fm-harness.sh crew             print the effective CREWMATE harness
 #                                        (config/crew-harness; "default" resolves to own)
 #        fm-harness.sh secondmate       print the harness the PRIMARY uses to launch
@@ -20,6 +20,9 @@
 # name and is never parsed for a model.
 # Detection layers: verified environment markers first, then process ancestry.
 # Record each newly verified env marker here.
+# cursor-agent is a crew oneshot adapter only (see docs/cursor-agent-crew.md); it is
+# detected so config/crew-harness=default can resolve to it, but it is not a verified
+# primary harness (no turn-end/watch hooks).
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -35,6 +38,9 @@ detect_own() {
   # It does NOT set CLAUDECODE despite being Claude-Code-compatible, so this marker
   # is unambiguous when firstmate runs natively on grok.
   [ "${GROK_AGENT:-}" = "1" ] && { echo grok; return; }
+  # cursor-agent sets CURSOR_AGENT=1 for its child/tool processes (verified 2026-07-20).
+  # Match only this marker; do not treat the bare Cursor IDE as an agent harness.
+  [ "${CURSOR_AGENT:-}" = "1" ] && { echo cursor-agent; return; }
   # Layer 2: walk the parent chain and match the command name.
   local pid=$$ comm args
   for _ in 1 2 3 4 5 6 7 8; do
@@ -44,6 +50,7 @@ detect_own() {
       *codex*) echo codex; return ;;
       *opencode*) echo opencode; return ;;
       *grok*) echo grok; return ;;
+      *cursor-agent*) echo cursor-agent; return ;;
       pi) echo pi; return ;;
       node*|python*)
         # Bare interpreter: match the harness name in its script path.
@@ -53,6 +60,7 @@ detect_own() {
           *codex*) echo codex; return ;;
           *opencode*) echo opencode; return ;;
           *grok*) echo grok; return ;;
+          *cursor-agent*) echo cursor-agent; return ;;
           *" pi "*|*/pi) echo pi; return ;;
         esac ;;
     esac

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -58,7 +58,8 @@
 #   secondmate-vs-crewmate split is DURABLE across every respawn (recovery,
 #   /updatefirstmate, restart). A bare adapter name
 #   (claude|codex|opencode|pi|grok|cursor-agent) overrides it for this spawn
-#   (either kind). cursor-agent is crew oneshot only (docs/cursor-agent-crew.md).
+#   when that adapter supports the requested kind. cursor-agent is crew oneshot
+#   only (docs/cursor-agent-crew.md).
 #   A non-flag string containing whitespace is treated as a RAW launch command -
 #   the escape hatch for verifying new adapters.
 #   config/secondmate-harness may also carry an optional model and effort as extra

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -449,7 +449,10 @@ launch_template() {
     # Not a verified primary (no turn-end/watch hooks). Interactive Herdr launch
     # is unverified - do not use this template for multiturn panes. See
     # docs/cursor-agent-crew.md. Canonical name is cursor-agent (not bare cursor).
-    cursor-agent) printf '%s' 'cursor-agent -p --force --trust --workspace "$(pwd)" "$(cat __BRIEF__)"' ;;
+    cursor-agent)
+      [ "$kind" != secondmate ] || return 1
+      printf '%s' 'cursor-agent -p --force --trust --workspace "$(pwd)" "$(cat __BRIEF__)"'
+      ;;
     *) return 1 ;;
   esac
 }

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -56,10 +56,11 @@
 #   profile consultation. A --secondmate spawn is exempt and resolves the SECONDMATE
 #   harness (config/secondmate-harness -> config/crew-harness -> own), so the
 #   secondmate-vs-crewmate split is DURABLE across every respawn (recovery,
-#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|grok)
-#   overrides it for this spawn (either kind). A non-flag string containing
-#   whitespace is treated as a RAW launch command - the escape hatch for verifying
-#   new adapters.
+#   /updatefirstmate, restart). A bare adapter name
+#   (claude|codex|opencode|pi|grok|cursor-agent) overrides it for this spawn
+#   (either kind). cursor-agent is crew oneshot only (docs/cursor-agent-crew.md).
+#   A non-flag string containing whitespace is treated as a RAW launch command -
+#   the escape hatch for verifying new adapters.
 #   config/secondmate-harness may also carry an optional model and effort as extra
 #   whitespace-separated tokens ("<harness> [<model>] [<effort>]"). For a
 #   --secondmate spawn, those tokens apply only when this spawn also resolves its
@@ -443,6 +444,12 @@ launch_template() {
     # launch command - it is a Stop-event hook installed below (global hook +
     # per-task pointer), so the template is identical for ship/scout/secondmate.
     grok) printf '%s' 'grok --always-approve __MODELFLAG____EFFORTFLAG__"$(cat __BRIEF__)"' ;;
+    # cursor-agent: crew oneshot only (verified 2026-07-20). -p prints and exits;
+    # --force/--trust skip interactive approval gates; --workspace pins the cwd.
+    # Not a verified primary (no turn-end/watch hooks). Interactive Herdr launch
+    # is unverified - do not use this template for multiturn panes. See
+    # docs/cursor-agent-crew.md. Canonical name is cursor-agent (not bare cursor).
+    cursor-agent) printf '%s' 'cursor-agent -p --force --trust --workspace "$(pwd)" "$(cat __BRIEF__)"' ;;
     *) return 1 ;;
   esac
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -55,7 +55,7 @@ On `attached` it stays live across identity-matched successors, and an unexplain
 The arm layer records one bounded lifecycle row per observed cycle in `state/.watch-cycle-exits.log`; `state/.watch-triage.log` remains exclusively the absorbed-wake debug log.
 Pi and OpenCode verify session-lock ownership and launch one singleton successor from their child-close handlers before delivering an actionable wake prompt, with bounded exponential retry for failed restoration.
 Claude keeps its tracked background-task protocol and adds a narrow PreToolUse continuity gate that allows drain, arm recovery, and fail-closed teardown while refusing only other fleet commands when tasks are in flight and no identity-matched live watcher holds the home lock.
-The existing turn-end guard is unchanged and remains the final backstop for all five harness protocols.
+The existing turn-end guard is unchanged and remains the final backstop for all five primary-harness protocols.
 Its `--restart` mode signals only the watcher recorded in the current home's `state/.watch.lock`, so restarting one home cannot kill sibling secondmate watchers.
 A pull-based guard (`bin/fm-guard.sh`) warns through supervision tool output if the primary checkout is tangled, or if tasks are in flight and that watcher stops running or queued wakes are waiting to be drained.
 The drain script calls that guard after emptying the queue, which avoids repeating the queued-wakes warning for records it just consumed while still warning on stale watcher liveness.

--- a/docs/cmux-backend.md
+++ b/docs/cmux-backend.md
@@ -18,7 +18,7 @@ Prerequisites:
 
 - The cmux app itself, installed from [cmux.com](https://cmux.com) or `brew install --cask cmux`, version 0.64.17 or newer.
 - `jq`, required to parse cmux's JSON output: `brew install jq` (or your platform's package manager).
-- The universal firstmate prerequisites - a verified crew harness plus the required toolchain, owned by [`docs/configuration.md`](configuration.md) ("Harness support", "Toolchain"); treehouse still provides the worktree, cmux only provides the session.
+- The universal firstmate prerequisites - supported harness scope plus the required toolchain, owned by [`docs/configuration.md`](configuration.md) ("Harness support", "Toolchain"); treehouse still provides the worktree, cmux only provides the session.
 - The cmux CLI binary is not guaranteed to be on `PATH` after a plain app install (see "CLI is not on PATH by default" below) - the adapter falls back to the well-known bundle path automatically, so this is not a blocker, just something to be aware of if you want to run `cmux` yourself from a shell.
 
 **One-time socket access setup (required, not optional):** cmux's control socket defaults to `automation.socketControlMode: "cmuxOnly"`, which rejects any CLI process not spawned inside cmux itself - firstmate always drives cmux from an external shell, so this must be changed before `backend=cmux` can work at all.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -165,10 +165,11 @@ The full cmux home label also includes a short hash of the resolved `FM_ROOT` pa
 
 ## Harness support
 
-claude, codex, opencode, pi, and grok are all empirically verified; new harnesses get verified through a supervised trial task before joining the set.
+`claude`, `codex`, `opencode`, `pi`, and `grok` are the empirically verified primary harnesses; new primary harnesses get verified through a supervised trial task before joining that set.
+`cursor-agent` is a separate partial crew-oneshot adapter; [`docs/cursor-agent-crew.md`](cursor-agent-crew.md) owns its supported scope and exclusions.
 The verified adapter knowledge - busy signatures, interrupt and exit commands, skill-invocation syntax, and per-harness quirks - lives in [`.agents/skills/harness-adapters/SKILL.md`](../.agents/skills/harness-adapters/SKILL.md).
 Launch mechanics, including the verified command templates, live in [`bin/fm-spawn.sh`](../bin/fm-spawn.sh).
-Primary-session turn-end guard integrations for verified harnesses are tracked as repo-level hook files and documented in [`docs/turnend-guard.md`](turnend-guard.md).
+Primary-session turn-end guard integrations for verified primary harnesses are tracked as repo-level hook files and documented in [`docs/turnend-guard.md`](turnend-guard.md).
 Primary-session watcher wake protocols are rendered at session start by [`bin/fm-supervision-instructions.sh`](../bin/fm-supervision-instructions.sh) from [`docs/supervision-protocols/`](supervision-protocols/).
 Claude and Grok use background-notify cycles, Codex uses bounded foreground checkpoints, Pi uses its two tracked primary extensions, and OpenCode uses its TUI plugin.
 `config/crew-harness` is a local, gitignored file containing one adapter name for crewmate and scout launches.
@@ -217,6 +218,7 @@ This section is the single owner of the canonical schema and its per-field seman
 Per rule, `when` and `use` are required.
 Both `use` and the optional top-level `default` accept either one profile object or a non-empty array of profile objects.
 The single-object form stays fully backward-compatible, and every profile needs `harness`.
+Profiles accept only the verified primary harness set from [Harness support](#harness-support); the partial `cursor-agent` adapter is outside this schema until it graduates.
 Profile `model` and `effort` fields and rule `why` are optional.
 An omitted model or effort means the selected harness uses its own default for that axis.
 Every profile array is an implicit quota-aware choice and does not need a selector property.

--- a/docs/cursor-agent-crew.md
+++ b/docs/cursor-agent-crew.md
@@ -1,32 +1,29 @@
 # cursor-agent crew oneshot
 
-Status: partial crew adapter only.
-Verified oneshot launch on 2026-07-20.
-Not a verified primary harness.
+Status: this is a partial crew-oneshot adapter only.
+The oneshot launch was verified on 2026-07-20.
+It is not a verified primary harness.
 
 ## Scope
 
-Firstmate may dispatch a crewmate or scout on `cursor-agent` through the normal `fm-spawn` launch template:
-
-```text
-cursor-agent -p --force --trust --workspace "$(pwd)" "$(cat <brief>)"
-```
-
-That path is oneshot print mode (`-p`): the process runs the brief, prints the result, and exits.
-Busy and done are process lifetime, not a pane busy signature or turn-end hook.
+Firstmate may dispatch a crewmate or scout on `cursor-agent` through `fm-spawn`'s cursor-agent launch template.
+The exact launch flags live in [`bin/fm-spawn.sh`](../bin/fm-spawn.sh).
+That path is print-and-exit mode, not a verified interactive pane.
+It has no pane busy signature, turn-end hook, primary watcher protocol, resume path, or skill-invocation form.
 
 ## Out of scope
 
-- Primary firstmate session (no turn-end guard, no session-start nudge, no watcher protocol).
-- Interactive / multiturn panes (Herdr `agent start … -- cursor-agent` was tried; `agent_status` stayed unknown and name lookup flaked — do not claim interactive verified).
-- Bare harness name `cursor` (the IDE). Canonical name is `cursor-agent`.
-- `config/crew-dispatch.json` verified-harness allowlist (still the five full primaries until this adapter graduates).
+- A primary firstmate session is out of scope because there is no turn-end guard, session-start nudge, or watcher protocol.
+- Secondmate launches are out of scope.
+- Interactive or multiturn panes are out of scope.
+- The bare harness name `cursor` is out of scope because it names the IDE; the canonical name is `cursor-agent`.
+- `config/crew-dispatch.json` profiles are out of scope; [`docs/configuration.md`](configuration.md#crew-dispatch-profiles-configcrew-dispatchjson) owns that schema.
 
 ## Detection
 
-`bin/fm-harness.sh` recognizes `CURSOR_AGENT=1` and process names/args matching `*cursor-agent*`.
-Set `config/crew-harness` to `cursor-agent` to force crew resolution without depending on own-harness detection.
+`bin/fm-harness.sh` owns cursor-agent detection.
+Set `config/crew-harness` to `cursor-agent` or pass an explicit `--harness cursor-agent` to use this adapter for a crewmate or scout.
 
 ## Knowledge owner
 
-Operational facts for spawn and supervision live in `.agents/skills/harness-adapters/SKILL.md` under the `cursor-agent` section.
+Operational facts for spawn and supervision live in [`.agents/skills/harness-adapters/SKILL.md`](../.agents/skills/harness-adapters/SKILL.md).

--- a/docs/cursor-agent-crew.md
+++ b/docs/cursor-agent-crew.md
@@ -1,0 +1,32 @@
+# cursor-agent crew oneshot
+
+Status: partial crew adapter only.
+Verified oneshot launch on 2026-07-20.
+Not a verified primary harness.
+
+## Scope
+
+Firstmate may dispatch a crewmate or scout on `cursor-agent` through the normal `fm-spawn` launch template:
+
+```text
+cursor-agent -p --force --trust --workspace "$(pwd)" "$(cat <brief>)"
+```
+
+That path is oneshot print mode (`-p`): the process runs the brief, prints the result, and exits.
+Busy and done are process lifetime, not a pane busy signature or turn-end hook.
+
+## Out of scope
+
+- Primary firstmate session (no turn-end guard, no session-start nudge, no watcher protocol).
+- Interactive / multiturn panes (Herdr `agent start … -- cursor-agent` was tried; `agent_status` stayed unknown and name lookup flaked — do not claim interactive verified).
+- Bare harness name `cursor` (the IDE). Canonical name is `cursor-agent`.
+- `config/crew-dispatch.json` verified-harness allowlist (still the five full primaries until this adapter graduates).
+
+## Detection
+
+`bin/fm-harness.sh` recognizes `CURSOR_AGENT=1` and process names/args matching `*cursor-agent*`.
+Set `config/crew-harness` to `cursor-agent` to force crew resolution without depending on own-harness detection.
+
+## Knowledge owner
+
+Operational facts for spawn and supervision live in `.agents/skills/harness-adapters/SKILL.md` under the `cursor-agent` section.

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -20,7 +20,7 @@ Prerequisites:
 
 - `herdr` itself, protocol 14 or newer (0.7.1, 0.7.3, and 0.7.4 verified) - see [herdr.dev](https://herdr.dev) for install instructions.
 - `jq`, required to parse herdr's JSON output: `brew install jq` (or your platform's package manager).
-- The universal firstmate prerequisites - a verified crew harness plus the required toolchain, owned by [`docs/configuration.md`](configuration.md) ("Harness support", "Toolchain"); treehouse still provides the worktree, herdr only provides the session.
+- The universal firstmate prerequisites - supported harness scope plus the required toolchain, owned by [`docs/configuration.md`](configuration.md) ("Harness support", "Toolchain"); treehouse still provides the worktree, herdr only provides the session.
 
 ### CI pin and required real-Herdr lane
 

--- a/docs/orca-backend.md
+++ b/docs/orca-backend.md
@@ -1,7 +1,8 @@
 # Orca Backend
 
 Orca is an experimental runtime backend for firstmate.
-It is distinct from the crewmate harness: the harness is the agent process firstmate launches (`claude`, `codex`, `opencode`, `pi`, or `grok`), while Orca owns the task worktree and terminal endpoint underneath that process.
+It is distinct from the crewmate harness: the harness is the agent process firstmate launches, while Orca owns the task worktree and terminal endpoint underneath that process.
+[`docs/configuration.md`](configuration.md#harness-support) owns supported harness scope.
 Firstmate agents operating this backend should load the agent-only [`firstmate-orca`](../.agents/skills/firstmate-orca/SKILL.md) checklist before switching to Orca, spawning or supervising Orca-backed work, smoke-testing, debugging task state, or reconciling Orca metadata.
 
 ## Setup
@@ -13,7 +14,7 @@ Prerequisites:
 
 - The Orca app installed at `/Applications/Orca.app`, and **running**.
 - The `orca` CLI: `brew install orca`.
-- The universal firstmate prerequisites - a verified crew harness plus the required toolchain, owned by [`docs/configuration.md`](configuration.md) ("Harness support", "Toolchain") - with `orca` as the only backend-specific tool, since Orca replaces both the session multiplexer CLI and the `treehouse` worktree provider that the other backends require.
+- The universal firstmate prerequisites - supported harness scope plus the required toolchain, owned by [`docs/configuration.md`](configuration.md) ("Harness support", "Toolchain") - with `orca` as the only backend-specific tool, since Orca replaces both the session multiplexer CLI and the `treehouse` worktree provider that the other backends require.
 
 Select Orca by putting `orca` in a local `config/backend` file - the durable way to pick it - or by exporting `FM_BACKEND=orca` when you launch your harness for a one-off session; telling the first mate in chat to use Orca also works.
 It is never auto-detected.

--- a/docs/tmux-backend.md
+++ b/docs/tmux-backend.md
@@ -12,7 +12,7 @@ Pick tmux unless you have a specific reason to try an experimental backend (herd
 ## Prerequisites
 
 - tmux itself: `brew install tmux` (or your platform's package manager).
-- The universal firstmate prerequisites: a verified crew harness plus the required toolchain, detected at session start and installed only after you approve; [`docs/configuration.md`](configuration.md) owns both lists ("Harness support", "Toolchain").
+- The universal firstmate prerequisites: supported harness scope plus the required toolchain, detected at session start and installed only after you approve; [`docs/configuration.md`](configuration.md) owns both lists ("Harness support", "Toolchain").
 
 ## Selecting it
 

--- a/docs/zellij-backend.md
+++ b/docs/zellij-backend.md
@@ -15,7 +15,7 @@ Prerequisites:
 
 - `zellij` itself, version 0.44 or newer (installed 0.44.0 verified) - see [zellij.dev](https://zellij.dev) for install instructions.
 - `jq`, required to parse zellij's JSON output: `brew install jq` (or your platform's package manager).
-- The universal firstmate prerequisites - a verified crew harness plus the required toolchain, owned by [`docs/configuration.md`](configuration.md) ("Harness support", "Toolchain"); treehouse still provides the worktree, zellij only provides the session.
+- The universal firstmate prerequisites - supported harness scope plus the required toolchain, owned by [`docs/configuration.md`](configuration.md) ("Harness support", "Toolchain"); treehouse still provides the worktree, zellij only provides the session.
 
 Select zellij by putting `zellij` in a local `config/backend` file - the durable way to pick it - or by exporting `FM_BACKEND=zellij` when you launch your harness for a one-off session; telling the first mate in chat to use zellij also works.
 Unlike tmux and herdr, zellij is **never** auto-detected - it always requires an explicit choice.

--- a/tests/fm-cursor-agent-harness.test.sh
+++ b/tests/fm-cursor-agent-harness.test.sh
@@ -147,6 +147,7 @@ test_spawn_uses_cursor_agent_oneshot() {
   assert_grep 'kind=ship' "$home/state/$id.meta" \
     "spawn meta should record a crew ship task"
   launch=$(cat "$launchlog")
+  # shellcheck disable=SC2016
   assert_contains "$launch" 'cursor-agent -p --force --trust --workspace "$(pwd)"' \
     "spawn launch command missing cursor-agent oneshot flags"
   assert_contains "$launch" "\"\$(cat '$home/data/$id/brief.md')\"" \

--- a/tests/fm-cursor-agent-harness.test.sh
+++ b/tests/fm-cursor-agent-harness.test.sh
@@ -41,6 +41,14 @@ test_launch_template_cursor_agent() {
   pass "launch_template emits cursor-agent oneshot command"
 }
 
+test_launch_template_cursor_agent_rejects_secondmate() {
+  extract_launch_template
+  if launch_template cursor-agent secondmate >/dev/null 2>&1; then
+    fail "cursor-agent must not have a secondmate launch template"
+  fi
+  pass "launch_template refuses cursor-agent secondmate"
+}
+
 test_crew_harness_resolves_cursor_agent() {
   local cfg got
   cfg="$TMP_ROOT/config"
@@ -73,5 +81,6 @@ test_detect_own_cursor_agent_env() {
 
 test_usage_lists_cursor_agent
 test_launch_template_cursor_agent
+test_launch_template_cursor_agent_rejects_secondmate
 test_crew_harness_resolves_cursor_agent
 test_detect_own_cursor_agent_env

--- a/tests/fm-cursor-agent-harness.test.sh
+++ b/tests/fm-cursor-agent-harness.test.sh
@@ -7,6 +7,7 @@ set -u
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 TMP_ROOT=$(fm_test_tmproot fm-cursor-agent-harness)
+SPAWN="$ROOT/bin/fm-spawn.sh"
 
 # Extract launch_template() from fm-spawn.sh and evaluate the cursor-agent case
 # without running a full spawn (avoids backend/treehouse fixtures).
@@ -79,8 +80,83 @@ test_detect_own_cursor_agent_env() {
   pass "CURSOR_AGENT=1 detects as cursor-agent"
 }
 
+make_spawn_fakebin() {
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+esac
+case "${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+  list-windows) exit 0 ;;
+  has-session|new-session|new-window|set-window-option|kill-window) exit 0 ;;
+  send-keys)
+    if [ -n "${FM_FAKE_LAUNCH_LOG:-}" ]; then
+      prev=
+      for a in "$@"; do
+        if [ "$prev" = "-l" ]; then
+          printf '%s\n' "$a" >> "$FM_FAKE_LAUNCH_LOG"
+        fi
+        prev=$a
+      done
+    fi
+    exit 0
+    ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" treehouse
+  printf '%s\n' "$fakebin"
+}
+
+test_spawn_uses_cursor_agent_oneshot() {
+  local id case_dir home proj wt fakebin launchlog out status launch
+  id=cursor-spawn-z6
+  case_dir="$TMP_ROOT/spawn"
+  home="$case_dir/home"
+  proj="$case_dir/project"
+  wt="$case_dir/wt"
+  launchlog="$case_dir/launch.log"
+  fakebin=$(make_spawn_fakebin "$case_dir/fake")
+  mkdir -p "$home/data/$id" "$home/projects" "$home/state" "$home/config"
+  printf '%s\n' 'cursor-agent' > "$home/config/crew-harness"
+  printf 'cursor-agent brief\n' > "$home/data/$id/brief.md"
+  fm_git_worktree "$proj" "$wt" cursor-agent-wt
+  touch "$home/state/.last-watcher-beat"
+  : > "$launchlog"
+
+  out=$(
+    FM_ROOT_OVERRIDE='' FM_HOME="$home" \
+      FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+      FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
+      FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" TMUX="fake,1,0" \
+      FM_FAKE_LAUNCH_LOG="$launchlog" PATH="$fakebin:$PATH" \
+      "$SPAWN" "$id" "$proj" 2>&1
+  )
+  status=$?
+  rm -rf "/tmp/fm-$id"
+  expect_code 0 "$status" "cursor-agent crew spawn should succeed"
+  assert_contains "$out" "spawned $id harness=cursor-agent kind=ship" \
+    "spawn did not report cursor-agent ship launch"
+  assert_grep 'harness=cursor-agent' "$home/state/$id.meta" \
+    "spawn meta missing cursor-agent harness"
+  assert_grep 'kind=ship' "$home/state/$id.meta" \
+    "spawn meta should record a crew ship task"
+  launch=$(cat "$launchlog")
+  assert_contains "$launch" 'cursor-agent -p --force --trust --workspace "$(pwd)"' \
+    "spawn launch command missing cursor-agent oneshot flags"
+  assert_contains "$launch" "\"\$(cat '$home/data/$id/brief.md')\"" \
+    "spawn launch command missing quoted brief path"
+  pass "fm-spawn uses cursor-agent oneshot template and records cursor-agent metadata"
+}
+
 test_usage_lists_cursor_agent
 test_launch_template_cursor_agent
 test_launch_template_cursor_agent_rejects_secondmate
 test_crew_harness_resolves_cursor_agent
 test_detect_own_cursor_agent_env
+test_spawn_uses_cursor_agent_oneshot

--- a/tests/fm-cursor-agent-harness.test.sh
+++ b/tests/fm-cursor-agent-harness.test.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Behavior tests for the partial cursor-agent crew oneshot adapter:
+# launch template, harness usage listing, and crew-harness resolution.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-cursor-agent-harness)
+
+# Extract launch_template() from fm-spawn.sh and evaluate the cursor-agent case
+# without running a full spawn (avoids backend/treehouse fixtures).
+extract_launch_template() {
+  # shellcheck disable=SC1090
+  eval "$(sed -n '/^launch_template()/,/^}/p' "$ROOT/bin/fm-spawn.sh")"
+}
+
+test_usage_lists_cursor_agent() {
+  assert_grep 'cursor-agent' "$ROOT/bin/fm-harness.sh" \
+    "fm-harness.sh should list cursor-agent in usage/comments"
+  pass "fm-harness.sh lists cursor-agent"
+}
+
+test_launch_template_cursor_agent() {
+  local got
+  extract_launch_template
+  got=$(launch_template cursor-agent) || fail "launch_template cursor-agent returned non-zero"
+  assert_contains "$got" 'cursor-agent -p --force --trust' \
+    "launch template missing oneshot flags"
+  assert_contains "$got" '--workspace "$(pwd)"' \
+    "launch template missing --workspace"
+  assert_contains "$got" '"$(cat __BRIEF__)"' \
+    "launch template missing brief cat"
+  if launch_template cursor >/dev/null 2>&1; then
+    fail "bare 'cursor' must not have a launch template (canonical name is cursor-agent)"
+  fi
+  pass "launch_template emits cursor-agent oneshot command"
+}
+
+test_crew_harness_resolves_cursor_agent() {
+  local cfg got
+  cfg="$TMP_ROOT/config"
+  mkdir -p "$cfg"
+  printf '%s\n' 'cursor-agent' > "$cfg/crew-harness"
+  # Force own unknown: clear every Layer-1 marker detect_own checks, including
+  # CURSOR_AGENT which this Builder session itself may set.
+  got=$(
+    env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT -u CURSOR_AGENT \
+      FM_CONFIG_OVERRIDE="$cfg" \
+      "$ROOT/bin/fm-harness.sh" crew
+  )
+  [ "$got" = "cursor-agent" ] || fail "crew resolved '$got', expected cursor-agent"
+  pass "config/crew-harness=cursor-agent resolves crew to cursor-agent"
+}
+
+test_detect_own_cursor_agent_env() {
+  local got cfg
+  cfg="$TMP_ROOT/empty-config"
+  mkdir -p "$cfg"
+  got=$(
+    env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
+      CURSOR_AGENT=1 \
+      FM_CONFIG_OVERRIDE="$cfg" \
+      "$ROOT/bin/fm-harness.sh"
+  )
+  [ "$got" = "cursor-agent" ] || fail "detect_own with CURSOR_AGENT=1 returned '$got'"
+  pass "CURSOR_AGENT=1 detects as cursor-agent"
+}
+
+test_usage_lists_cursor_agent
+test_launch_template_cursor_agent
+test_crew_harness_resolves_cursor_agent
+test_detect_own_cursor_agent_env

--- a/tests/fm-cursor-agent-harness.test.sh
+++ b/tests/fm-cursor-agent-harness.test.sh
@@ -27,8 +27,12 @@ test_launch_template_cursor_agent() {
   got=$(launch_template cursor-agent) || fail "launch_template cursor-agent returned non-zero"
   assert_contains "$got" 'cursor-agent -p --force --trust' \
     "launch template missing oneshot flags"
+  # Intentional literals: template must contain the characters $(pwd) / $(cat …),
+  # not their expansions. shellcheck SC2016 would otherwise false-positive.
+  # shellcheck disable=SC2016
   assert_contains "$got" '--workspace "$(pwd)"' \
     "launch template missing --workspace"
+  # shellcheck disable=SC2016
   assert_contains "$got" '"$(cat __BRIEF__)"' \
     "launch template missing brief cat"
   if launch_template cursor >/dev/null 2>&1; then


### PR DESCRIPTION
## What Changed
- Added a cursor-agent crew oneshot harness template and spawn handling for `config/crew-harness=cursor-agent`, while rejecting cursor-agent for secondmate launches.
- Added focused coverage for cursor-agent harness dispatch, metadata, template literals, and secondmate rejection behavior.
- Documented the cursor-agent crew-only scope across harness adapter guidance, configuration/backend docs, README, and the new cursor-agent crew doc.

## Risk Assessment

🚨 High: Captain, the source change still includes a generated AGENTS.md context block and the new adapter has a supervision gap around process-lifetime busy detection.

## Testing

<code>I inspected the cursor-agent adapter intent, added and ran a targeted spawn-path test, and captured an end-user-style CLI transcript showing `fm-spawn.sh` resolving `cursor-agent`, sending the documented `cursor-agent -p --force --trust --workspace &#34;$(pwd)&#34; &#34;$(cat &lt;brief&gt;)&#34;` command, and persisting `harness=cursor-agent`/`kind=ship` metadata. The first manual transcript attempt hit the expected no-mistakes gate-agent guard in this validation environment, then the same check passed with the repository&#39;s test-suite bypass.</code>

<details>
<summary>Evidence: cursor-agent spawn transcript</summary>

```text
Command: bin/fm-spawn.sh cursor-agent-e2e-z7 <project>
Exit: 0

CLI output:
warn: no registry at /var/folders/0t/r5khnk6x4l547bjdr4q0dxvm0000gn/T/no-mistakes-evidence/01KY5KRAJXZJFFJ33T1W3B0NP2/cursor-agent-spawn.jMvO7I/home/data/projects.md; defaulting project to no-mistakes off
spawned cursor-agent-e2e-z7 harness=cursor-agent kind=ship mode=no-mistakes yolo=off window=firstmate:fm-cursor-agent-e2e-z7 worktree=/var/folders/0t/r5khnk6x4l547bjdr4q0dxvm0000gn/T/no-mistakes-evidence/01KY5KRAJXZJFFJ33T1W3B0NP2/cursor-agent-spawn.jMvO7I/wt

Captured pane launch command:
cursor-agent -p --force --trust --workspace "$(pwd)" "$(cat '/var/folders/0t/r5khnk6x4l547bjdr4q0dxvm0000gn/T/no-mistakes-evidence/01KY5KRAJXZJFFJ33T1W3B0NP2/cursor-agent-spawn.jMvO7I/home/data/cursor-agent-e2e-z7/brief.md')"

Persisted state/cursor-agent-e2e-z7.meta:
window=firstmate:fm-cursor-agent-e2e-z7
worktree=/var/folders/0t/r5khnk6x4l547bjdr4q0dxvm0000gn/T/no-mistakes-evidence/01KY5KRAJXZJFFJ33T1W3B0NP2/cursor-agent-spawn.jMvO7I/wt
project=/var/folders/0t/r5khnk6x4l547bjdr4q0dxvm0000gn/T/no-mistakes-evidence/01KY5KRAJXZJFFJ33T1W3B0NP2/cursor-agent-spawn.jMvO7I/project
harness=cursor-agent
kind=ship
mode=no-mistakes
yolo=off
model=default
effort=default
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 issues (1 error, 1 warning)</summary>

- 🚨 `bin/fm-spawn.sh:452` - The cursor-agent template is available for every spawn kind, so `config/crew-harness=cursor-agent` also flows through the existing secondmate fallback when `config/secondmate-harness` is absent. That lets `fm-spawn.sh --secondmate` start `cursor-agent -p`, which prints and exits instead of creating the persistent secondmate agent the rest of the lifecycle expects. Reject `cursor-agent` for `kind=secondmate` or keep the secondmate resolver from falling back to this crew-only adapter.

🔧 Fix: Reject cursor-agent secondmate launches
2 issues (1 error, 1 warning) still open:
- 🚨 `AGENTS.md:486` - The committed `&lt;claude-mem-context&gt;` block is generated, worktree-specific session context (`No previous sessions found`) appended to the always-loaded project instructions. That makes stale local runtime state part of every future agent session and contradicts this file&#39;s own concise/shared contract; remove this generated block from tracked `AGENTS.md`.
- ⚠️ `bin/fm-spawn.sh:452` - The new cursor-agent template is documented as supervised by process lifetime, but the watcher only treats a task as busy via backend busy state or the existing pane busy regex. Since cursor-agent has no busy signature and no process-liveness integration here, a silent long-running `cursor-agent -p` can be surfaced as stopped or wedged after two unchanged pane polls while it is still running; add a cursor-agent process-liveness busy path before enabling this adapter broadly.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected the committed delta with `git diff --stat 51404137e8c4729670233cc31ff43eeae527b77c..437e04c1823cb7766e978a29cec1c47c5c39bfc8`, `git diff --name-only 51404137e8c4729670233cc31ff43eeae527b77c..437e04c1823cb7766e978a29cec1c47c5c39bfc8`, and targeted file reads.</code>
- <code>Ran `tests/fm-cursor-agent-harness.test.sh`.</code>
- <code>Produced reviewer evidence by running a fake-tmux `bin/fm-spawn.sh cursor-agent-e2e-z7 &lt;project&gt;` flow with `config/crew-harness=cursor-agent`, then recording CLI output, captured pane launch command, and persisted `state/&lt;id&gt;.meta` fields to the evidence transcript.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ linter found issues (exit code 127)

🔧 Fix: Silence cursor-agent literal lint warning
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
