### PR TITLE
chore(gitignore): ignore .claude/settings.local.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ data/
 __pycache__/
 *.pyc
 .env
+.claude/settings.local.json
 config/crew-harness
 config/crew-dispatch.json
 config/secondmate-harness


### PR DESCRIPTION
Claude Code writes per-user permission overrides (e.g. personal Bash allow rules) to `.claude/settings.local.json` in the home it runs from.
That file is personal local configuration, same as `.env` and the `config/` entries already listed, and should never land in the shared template.
Today it shows up as untracked noise in every firstmate home whose captain grants a local permission, and risks being swept into a shared-material commit.

One line added to `.gitignore`, grouped with the other local-only entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qx79bqjHiAa5aZzmNB4uCu