### PR TITLE
fix(spawn): refuse missing harness binaries before launch

### DIFF
--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -319,17 +319,26 @@ fm_backend_required_tools() {  # <backend>
   esac
 }
 
+# fm_backend_resolve_executable: resolve <tool> with the same backend-specific
+# lookup used by bootstrap dependency detection.
+# Most tools use PATH, while adapters with a supported non-PATH location own
+# that fallback themselves.
+fm_backend_resolve_executable() {  # <backend> <tool>
+  local backend=$1 tool=$2
+  case "$backend:$tool" in
+    cmux:cmux)
+      fm_backend_source cmux >/dev/null 2>&1 || return 1
+      fm_backend_cmux_bin
+      ;;
+    *) command -v "$tool" ;;
+  esac
+}
+
 fm_backend_required_tool_available() {  # <backend> <tool>
   local backend=$1 tool=$2 required
   required=$(fm_backend_required_tools "$backend") || return 1
   fm_backend_list_contains "$required" "$tool" || return 1
-  case "$backend:$tool" in
-    cmux:cmux)
-      fm_backend_source cmux >/dev/null 2>&1 || return 1
-      fm_backend_cmux_bin >/dev/null 2>&1
-      ;;
-    *) command -v "$tool" >/dev/null 2>&1 ;;
-  esac
+  fm_backend_resolve_executable "$backend" "$tool" >/dev/null 2>&1
 }
 
 # fm_meta_get: the LAST value of `key=` in <meta-file>, or empty (never

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -37,6 +37,15 @@
 #   overrides it for this spawn (either kind). A non-flag string containing
 #   whitespace is treated as a RAW launch command - the escape hatch for verifying
 #   new adapters.
+#   Before creating any task endpoint, every verified adapter resolves the first
+#   executable in its launch template through the backend's shared executable
+#   resolver and requires its cheap --version probe to succeed. The probe runs
+#   with stdin closed and is bounded by a portable timeout (default 10 seconds,
+#   override with FM_SPAWN_PROBE_TIMEOUT_SECS=<positive integer seconds>); a
+#   probe that times out refuses the spawn loudly, naming the binary and knob.
+#   Raw launch commands are exempt because arbitrary shell syntax can depend on
+#   pane-only aliases, functions, or setup that cannot be resolved safely without
+#   executing the unverified command; the escape hatch therefore stays explicit.
 #   config/secondmate-harness may also carry an optional model and effort as extra
 #   whitespace-separated tokens ("<harness> [<model>] [<effort>]"). For a
 #   --secondmate spawn, those tokens apply only when this spawn also resolves its
@@ -352,13 +361,99 @@ launch_template() {
   esac
 }
 
+launch_binary_from_command() {  # <launch-command>
+  local launch_command=$1 word
+  local -a words
+  read -r -a words <<< "$launch_command"
+  for word in "${words[@]}"; do
+    case "$word" in
+      [A-Za-z_]*=*) continue ;;
+      *) printf '%s\n' "$word"; return 0 ;;
+    esac
+  done
+  return 1
+}
+
+launch_binary_install_hint() {  # <binary>
+  case "$1" in
+    claude) printf '%s' 'npm install -g @anthropic-ai/claude-code' ;;
+    codex) printf '%s' 'npm install -g @openai/codex' ;;
+    opencode) printf '%s' 'npm install -g opencode-ai' ;;
+    pi) printf '%s' 'npm install -g @mariozechner/pi-coding-agent' ;;
+    grok) printf '%s' 'curl -fsSL https://x.ai/cli/install.sh | bash' ;;
+    agent) printf '%s' 'curl https://cursor.com/install -fsS | bash' ;;
+    *) return 1 ;;
+  esac
+}
+
+run_version_probe() {  # <resolved-binary> <timeout-secs>
+  local resolved=$1 timeout_secs=$2 pid waited=0 limit
+  set -m
+  "$resolved" --version </dev/null >/dev/null 2>&1 &
+  pid=$!
+  set +m
+  limit=$((timeout_secs * 10))
+  while kill -0 "$pid" 2>/dev/null; do
+    if [ "$waited" -ge "$limit" ]; then
+      kill -- -"$pid" 2>/dev/null
+      local grace=0
+      while kill -0 "$pid" 2>/dev/null && [ "$grace" -lt 20 ]; do
+        sleep 0.1
+        grace=$((grace + 1))
+      done
+      kill -9 -- -"$pid" 2>/dev/null
+      wait "$pid" 2>/dev/null
+      return 124
+    fi
+    sleep 0.1
+    waited=$((waited + 1))
+  done
+  wait "$pid"
+}
+
+preflight_verified_launch_binary() {  # <backend> <harness> <launch-command>
+  local backend=$1 harness=$2 launch_command=$3 binary resolved hint probe_rc
+  local timeout_secs=${FM_SPAWN_PROBE_TIMEOUT_SECS:-10}
+  case "$timeout_secs" in
+    ''|0|*[!0-9]*)
+      echo "error: FM_SPAWN_PROBE_TIMEOUT_SECS must be a positive integer number of seconds (got '${FM_SPAWN_PROBE_TIMEOUT_SECS:-}'); refusing before creating a task endpoint" >&2
+      return 1
+      ;;
+  esac
+  binary=$(launch_binary_from_command "$launch_command") || {
+    echo "error: harness '$harness' launch template has no executable; refusing before creating a task endpoint" >&2
+    return 1
+  }
+  hint=$(launch_binary_install_hint "$binary") || {
+    echo "error: harness '$harness' launch binary '$binary' has no install hint; refusing before creating a task endpoint" >&2
+    return 1
+  }
+  if ! resolved=$(fm_backend_resolve_executable "$backend" "$binary" 2>/dev/null); then
+    echo "error: harness '$harness' launch binary '$binary' was not found (install: $hint); refusing before creating a task endpoint" >&2
+    return 1
+  fi
+  run_version_probe "$resolved" "$timeout_secs"
+  probe_rc=$?
+  if [ "$probe_rc" -eq 124 ]; then
+    echo "error: harness '$harness' launch binary '$binary' --version probe timed out after ${timeout_secs}s (raise with FM_SPAWN_PROBE_TIMEOUT_SECS); refusing before creating a task endpoint" >&2
+    return 1
+  fi
+  if [ "$probe_rc" -ne 0 ]; then
+    echo "error: harness '$harness' launch binary '$binary' failed its --version probe (reinstall: $hint); refusing before creating a task endpoint" >&2
+    return 1
+  fi
+}
+
+RAW_LAUNCH=0
 case "$ARG3" in
   *' '*)  # raw launch command (unverified-adapter escape hatch)
     LAUNCH=$ARG3
-    HARNESS=""
-    for word in $LAUNCH; do
-      case "$word" in [A-Za-z_]*=*) continue ;; *) HARNESS=$(basename "$word"); break ;; esac
-    done
+    RAW_LAUNCH=1
+    RAW_BINARY=$(launch_binary_from_command "$LAUNCH") || {
+      echo "error: raw launch command has no executable" >&2
+      exit 1
+    }
+    HARNESS=$(basename "$RAW_BINARY")
     ;;
   '')
     # No explicit harness: resolve from config. A secondmate AGENT launches on the
@@ -387,6 +482,9 @@ case "$ARG3" in
     LAUNCH=$(launch_template "$HARNESS" "$KIND") || { echo "error: unknown harness '$HARNESS'; pass a raw launch command to use an unverified adapter" >&2; exit 1; }
     ;;
 esac
+if [ "$RAW_LAUNCH" -eq 0 ]; then
+  preflight_verified_launch_binary "$BACKEND" "$HARNESS" "$LAUNCH" || exit 1
+fi
 
 # config/secondmate-harness may carry optional model/effort tokens alongside the
 # harness ("<harness> [<model>] [<effort>]"). They apply only when this is a

--- a/tests/fm-backend.test.sh
+++ b/tests/fm-backend.test.sh
@@ -754,7 +754,7 @@ esac
 exit 0
 SH
   chmod +x "$fb/tmux"
-  fm_fake_exit0 "$fb" treehouse
+  fm_fake_exit0 "$fb" treehouse claude
   printf '%s\n' "$fb"
 }
 
@@ -824,7 +824,7 @@ esac
 exit 0
 SH
   chmod +x "$fb/tmux"
-  fm_fake_exit0 "$fb" treehouse
+  fm_fake_exit0 "$fb" treehouse claude
   printf '%s\n' "$fb"
 }
 

--- a/tests/fm-gate-refuse.test.sh
+++ b/tests/fm-gate-refuse.test.sh
@@ -152,7 +152,7 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse
+  fm_fake_exit0 "$fakebin" treehouse codex
   printf '%s\n' "$fakebin"
 }
 

--- a/tests/fm-grok-harness.test.sh
+++ b/tests/fm-grok-harness.test.sh
@@ -26,7 +26,7 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse gh-axi gh
+  fm_fake_exit0 "$fakebin" treehouse grok gh-axi gh
   printf '%s\n' "$fakebin"
 }
 

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -245,6 +245,7 @@ make_noop_tmux() {
 exit 0
 SH
   chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" claude codex opencode pi grok agent
   printf '%s\n' "$fakebin"
 }
 
@@ -441,6 +442,7 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" claude codex opencode pi grok agent
   printf '%s\n' "$fakebin"
 }
 

--- a/tests/fm-secondmate-sync.test.sh
+++ b/tests/fm-secondmate-sync.test.sh
@@ -710,6 +710,7 @@ test_spawn_fast_forwards_before_launch() {
 exit 0
 SH
   chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" codex
 
   PATH="$fakebin:$BASE_PATH" TMUX='' \
     FM_ROOT_OVERRIDE="$w/main" FM_HOME="$w/home" \
@@ -744,6 +745,7 @@ test_spawn_warns_when_sync_skipped_before_launch() {
 exit 0
 SH
   chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" codex
 
   PATH="$fakebin:$BASE_PATH" TMUX='' \
     FM_ROOT_OVERRIDE="$w/main" FM_HOME="$w/home" \

--- a/tests/fm-shared-captain-inheritance.test.sh
+++ b/tests/fm-shared-captain-inheritance.test.sh
@@ -213,6 +213,7 @@ make_fake_spawn_toolchain() {
 exit 0
 SH
   chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" codex
   printf '%s\n' "$fakebin"
 }
 

--- a/tests/fm-spawn-batch.test.sh
+++ b/tests/fm-spawn-batch.test.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 # Behavior tests for fm-spawn.sh batch dispatch (`id=repo` pairs).
 #
-# These exercise argument routing only: each spawn attempt fails fast at the
-# missing-brief check, which is reached before any tmux/treehouse side effect, so
-# the tests create no windows or worktrees. FM_SPAWN_NO_GUARD=1 keeps them off the
-# live watcher guard / state. Parser and path-scoping cases are table-driven; the
-# only behavior asserted on its own is "a multi-pair batch does not stop after the
-# first failure".
+# These exercise argument routing only: each spawn attempt passes the launch
+# preflight with a fake codex binary, then fails before any tmux/treehouse side
+# effect, so the tests create no windows or worktrees.
+# FM_SPAWN_NO_GUARD=1 keeps them off the live watcher guard and state.
+# Parser and path-scoping cases are table-driven.
+# The only behavior asserted on its own is that a multi-pair batch does not stop
+# after the first failure.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -14,6 +15,8 @@ set -u
 
 SPAWN="$ROOT/bin/fm-spawn.sh"
 TMP_ROOT=$(fm_test_tmproot fm-spawn-batch)
+FAKEBIN=$(fm_fakebin "$TMP_ROOT/tools")
+fm_fake_exit0 "$FAKEBIN" codex
 export FM_BACKEND=tmux
 
 # Clear ambient firstmate overrides so the behavior test owns its environment.
@@ -25,7 +28,8 @@ run_spawn() {
     FM_PROJECTS_OVERRIDE='' \
     FM_CONFIG_OVERRIDE='' \
     FM_SPAWN_NO_GUARD=1 \
-    "$SPAWN" "$@" 2>&1
+    PATH="$FAKEBIN:$PATH" \
+    "$SPAWN" "$@" --harness codex 2>&1
 }
 
 # Every pair in a batch is dispatched even though the first one fails; the loop
@@ -81,12 +85,12 @@ test_projects_path_scoping() {
     if [ "$use_override" = yes ]; then
       out=$(FM_ROOT_OVERRIDE='' FM_STATE_OVERRIDE='' FM_DATA_OVERRIDE='' FM_CONFIG_OVERRIDE='' \
         FM_HOME="$home" FM_PROJECTS_OVERRIDE="$projects" FM_SPAWN_NO_GUARD=1 \
-        "$SPAWN" "$id" projects/alpha codex 2>&1)
+        PATH="$FAKEBIN:$PATH" "$SPAWN" "$id" projects/alpha codex 2>&1)
     else
       mkdir -p "$home/projects/alpha"
       out=$(FM_ROOT_OVERRIDE='' FM_STATE_OVERRIDE='' FM_DATA_OVERRIDE='' FM_PROJECTS_OVERRIDE='' FM_CONFIG_OVERRIDE='' \
         FM_HOME="$home" FM_SPAWN_NO_GUARD=1 \
-        "$SPAWN" "$id" projects/alpha codex 2>&1)
+        PATH="$FAKEBIN:$PATH" "$SPAWN" "$id" projects/alpha codex 2>&1)
     fi
     status=$?
     [ "$status" -ne 0 ] || fail "$label: spawn with missing brief should fail"

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -42,7 +42,7 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse
+  fm_fake_exit0 "$fakebin" treehouse claude codex opencode pi grok agent
   printf '%s\n' "$fakebin"
 }
 

--- a/tests/fm-spawn-launch-preflight.test.sh
+++ b/tests/fm-spawn-launch-preflight.test.sh
@@ -1,0 +1,274 @@
+#!/usr/bin/env bash
+# Behavior tests for fm-spawn.sh launch-binary preflight.
+#
+# These tests use a fake tmux endpoint and real isolated git worktrees.
+# The missing-binary case asserts refusal before tmux is touched or task meta is written.
+# The healthy cases assert all five verified launch templates still reach the normal spawn path.
+# Raw launch commands remain exempt because arbitrary shell syntax cannot be resolved reliably without executing it.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SPAWN="$ROOT/bin/fm-spawn.sh"
+TMP_ROOT=$(fm_test_tmproot fm-spawn-launch-preflight)
+
+make_spawn_case() {
+  local name=$1 harness=$2 launch_binary=${3:-}
+  CASE_DIR="$TMP_ROOT/$name"
+  HOME_DIR="$CASE_DIR/home"
+  PROJ_DIR="$CASE_DIR/project"
+  WT_DIR="$CASE_DIR/wt"
+  ENDPOINT_LOG="$CASE_DIR/endpoint.log"
+  LAUNCH_LOG="$CASE_DIR/launch.log"
+  PROBE_LOG="$CASE_DIR/probe.log"
+  ID="preflight-$name"
+  FAKEBIN_DIR=$(fm_fakebin "$CASE_DIR")
+
+  mkdir -p "$HOME_DIR/data/$ID" "$HOME_DIR/projects" "$HOME_DIR/state" "$HOME_DIR/config"
+  printf '%s\n' "$harness" > "$HOME_DIR/config/crew-harness"
+  printf 'brief for %s\n' "$ID" > "$HOME_DIR/data/$ID/brief.md"
+  fm_git_worktree "$PROJ_DIR" "$WT_DIR" "wt-$name"
+  touch "$HOME_DIR/state/.last-watcher-beat"
+  : > "$ENDPOINT_LOG"
+  : > "$LAUNCH_LOG"
+
+  cat > "$FAKEBIN_DIR/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+printf '%s\n' "$*" >> "${FM_FAKE_ENDPOINT_LOG:?}"
+case "$*" in
+  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+esac
+case "${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+  new-window) printf '@42\n'; exit 0 ;;
+  list-windows|has-session|new-session|set-window-option|kill-window) exit 0 ;;
+  send-keys)
+    prev=
+    for arg in "$@"; do
+      if [ "$prev" = "-l" ]; then
+        printf '%s\n' "$arg" >> "${FM_FAKE_LAUNCH_LOG:?}"
+      fi
+      prev=$arg
+    done
+    exit 0
+    ;;
+esac
+exit 0
+SH
+  chmod +x "$FAKEBIN_DIR/tmux"
+  fm_fake_exit0 "$FAKEBIN_DIR" treehouse
+
+  if [ -n "$launch_binary" ]; then
+    cat > "$FAKEBIN_DIR/$launch_binary" <<'SH'
+#!/usr/bin/env bash
+set -u
+printf '%s %s\n' "$(basename "$0")" "$*" >> "${FM_FAKE_PROBE_LOG:?}"
+[ "$#" -eq 1 ] && [ "$1" = "--version" ]
+SH
+    chmod +x "$FAKEBIN_DIR/$launch_binary"
+  fi
+}
+
+run_spawn() {
+  FM_ROOT_OVERRIDE='' FM_HOME="$HOME_DIR" \
+    FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
+    FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
+    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$WT_DIR" TMUX="fake,1,0" \
+    FM_FAKE_ENDPOINT_LOG="$ENDPOINT_LOG" FM_FAKE_LAUNCH_LOG="$LAUNCH_LOG" \
+    FM_FAKE_PROBE_LOG="$PROBE_LOG" GROK_HOME="$HOME_DIR/grok-home" \
+    PATH="$FAKEBIN_DIR:/usr/bin:/bin" "$SPAWN" "$@" 2>&1
+}
+
+cleanup_task_tmp() {
+  rm -rf "/tmp/fm-$1"
+}
+
+test_missing_verified_binary_refuses_before_endpoint_creation() {
+  local out status
+  make_spawn_case missing-opencode opencode
+
+  out=$(run_spawn "$ID" "$PROJ_DIR")
+  status=$?
+
+  expect_code 1 "$status" "missing verified launch binary should fail"
+  assert_contains "$out" \
+    "error: harness 'opencode' launch binary 'opencode' was not found (install: npm install -g opencode-ai); refusing before creating a task endpoint" \
+    "missing-binary refusal did not name the binary and exact install hint"
+  [ ! -s "$ENDPOINT_LOG" ] || fail "missing-binary refusal touched tmux before failing"
+  assert_absent "$HOME_DIR/state/$ID.meta" "missing-binary refusal wrote task meta"
+  assert_absent "$PROBE_LOG" "missing binary unexpectedly ran a version probe"
+  pass "missing verified binary is refused before endpoint creation or meta"
+}
+
+test_present_verified_binaries_spawn_as_before() {
+  local harness launch_binary out status
+  while IFS='|' read -r harness launch_binary; do
+    make_spawn_case "present-$harness" "$harness" "$launch_binary"
+
+    out=$(run_spawn "$ID" "$PROJ_DIR")
+    status=$?
+
+    expect_code 0 "$status" "present $harness launch binary should spawn"
+    assert_contains "$out" "spawned $ID harness=$harness" "$harness spawn did not reach the healthy path"
+    assert_grep "$launch_binary --version" "$PROBE_LOG" "$harness did not run the expected cheap version probe"
+    assert_grep "new-window" "$ENDPOINT_LOG" "$harness did not create the normal tmux endpoint"
+    assert_present "$HOME_DIR/state/$ID.meta" "$harness healthy spawn did not write task meta"
+    cleanup_task_tmp "$ID"
+  done <<'EOF'
+claude|claude
+codex|codex
+opencode|opencode
+pi|pi
+grok|grok
+EOF
+  pass "all five verified adapters preflight and spawn normally when their binaries are present"
+}
+
+test_raw_launch_command_remains_exempt() {
+  local out status launch
+  make_spawn_case raw-exempt claude
+
+  out=$(run_spawn "$ID" "$PROJ_DIR" "custom-agent --flag")
+  status=$?
+
+  expect_code 0 "$status" "raw launch command should remain exempt from verified-adapter preflight"
+  assert_contains "$out" "spawned $ID harness=custom-agent" "raw launch command did not spawn"
+  assert_absent "$PROBE_LOG" "raw launch command unexpectedly ran a first-word probe"
+  launch=$(cat "$LAUNCH_LOG")
+  [ "$launch" = "custom-agent --flag" ] || fail "raw launch command changed"$'\n'"actual: $launch"
+  cleanup_task_tmp "$ID"
+  pass "raw launch command stays exempt from preflight and is sent unchanged"
+}
+
+test_hanging_version_probe_times_out_before_endpoint_creation() {
+  local out status
+  make_spawn_case hang-probe opencode
+  cat > "$FAKEBIN_DIR/opencode" <<'SH'
+#!/usr/bin/env bash
+set -u
+printf '%s %s\n' "$(basename "$0")" "$*" >> "${FM_FAKE_PROBE_LOG:?}"
+sleep 60
+SH
+  chmod +x "$FAKEBIN_DIR/opencode"
+
+  out=$(FM_SPAWN_PROBE_TIMEOUT_SECS=1 run_spawn "$ID" "$PROJ_DIR")
+  status=$?
+
+  expect_code 1 "$status" "hanging version probe should fail"
+  assert_contains "$out" \
+    "error: harness 'opencode' launch binary 'opencode' --version probe timed out after 1s (raise with FM_SPAWN_PROBE_TIMEOUT_SECS); refusing before creating a task endpoint" \
+    "timeout refusal did not name the binary and override knob"
+  [ ! -s "$ENDPOINT_LOG" ] || fail "timed-out probe touched tmux before failing"
+  assert_absent "$HOME_DIR/state/$ID.meta" "timed-out probe wrote task meta"
+  pass "hanging version probe times out and refuses before endpoint creation or meta"
+}
+
+test_sigterm_ignoring_probe_is_killed_after_grace() {
+  local out status
+  make_spawn_case hang-sigterm opencode
+  cat > "$FAKEBIN_DIR/opencode" <<'SH'
+#!/usr/bin/env bash
+set -u
+printf '%s %s\n' "$(basename "$0")" "$*" >> "${FM_FAKE_PROBE_LOG:?}"
+trap '' TERM
+while :; do sleep 1; done
+SH
+  chmod +x "$FAKEBIN_DIR/opencode"
+
+  out=$(FM_SPAWN_PROBE_TIMEOUT_SECS=1 run_spawn "$ID" "$PROJ_DIR")
+  status=$?
+
+  expect_code 1 "$status" "SIGTERM-ignoring probe should still fail via SIGKILL escalation"
+  assert_contains "$out" \
+    "error: harness 'opencode' launch binary 'opencode' --version probe timed out after 1s (raise with FM_SPAWN_PROBE_TIMEOUT_SECS); refusing before creating a task endpoint" \
+    "SIGTERM-ignoring probe did not produce the timeout refusal"
+  [ ! -s "$ENDPOINT_LOG" ] || fail "SIGTERM-ignoring probe touched tmux before failing"
+  assert_absent "$HOME_DIR/state/$ID.meta" "SIGTERM-ignoring probe wrote task meta"
+  pass "SIGTERM-ignoring probe is force-killed after a bounded grace period"
+}
+
+test_timed_out_probe_leaves_no_wrapper_descendants() {
+  local out status child_pid tries
+  make_spawn_case hang-descendant opencode
+  local child_pid_file="$CASE_DIR/hang-descendant-child.pid"
+  cat > "$FAKEBIN_DIR/opencode" <<SH
+#!/usr/bin/env bash
+set -u
+printf '%s %s\n' "\$(basename "\$0")" "\$*" >> "\${FM_FAKE_PROBE_LOG:?}"
+bash -c 'trap "" TERM; echo \$\$ > "$child_pid_file"; while :; do sleep 1; done' &
+wait
+SH
+  chmod +x "$FAKEBIN_DIR/opencode"
+
+  out=$(FM_SPAWN_PROBE_TIMEOUT_SECS=1 run_spawn "$ID" "$PROJ_DIR")
+  status=$?
+
+  expect_code 1 "$status" "wrapper probe with hanging descendant should time out"
+  assert_contains "$out" \
+    "error: harness 'opencode' launch binary 'opencode' --version probe timed out after 1s (raise with FM_SPAWN_PROBE_TIMEOUT_SECS); refusing before creating a task endpoint" \
+    "wrapper probe did not produce the timeout refusal"
+  [ -s "$child_pid_file" ] || fail "wrapper never recorded its descendant pid"
+  child_pid=$(cat "$child_pid_file")
+  tries=0
+  while kill -0 "$child_pid" 2>/dev/null && [ "$tries" -lt 20 ]; do
+    sleep 0.1
+    tries=$((tries + 1))
+  done
+  if kill -0 "$child_pid" 2>/dev/null; then
+    kill -9 "$child_pid" 2>/dev/null
+    fail "TERM-resistant descendant (pid $child_pid) survived the timed-out probe"
+  fi
+  [ ! -s "$ENDPOINT_LOG" ] || fail "wrapper probe touched tmux before failing"
+  assert_absent "$HOME_DIR/state/$ID.meta" "wrapper probe wrote task meta"
+  pass "timed-out probe kills TERM-resistant wrapper descendants via its process group"
+}
+
+test_probe_closes_stdin() {
+  local out status
+  make_spawn_case stdin-probe opencode
+  cat > "$FAKEBIN_DIR/opencode" <<'SH'
+#!/usr/bin/env bash
+set -u
+printf '%s %s\n' "$(basename "$0")" "$*" >> "${FM_FAKE_PROBE_LOG:?}"
+cat >/dev/null
+exit 0
+SH
+  chmod +x "$FAKEBIN_DIR/opencode"
+
+  out=$(FM_SPAWN_PROBE_TIMEOUT_SECS=2 run_spawn "$ID" "$PROJ_DIR" < /dev/zero)
+  status=$?
+
+  expect_code 0 "$status" "stdin-reading probe should finish immediately because stdin is closed"
+  assert_contains "$out" "spawned $ID harness=opencode" "stdin-closed probe did not reach the healthy spawn path"
+  cleanup_task_tmp "$ID"
+  pass "version probe runs with stdin closed"
+}
+
+test_invalid_probe_timeout_knob_refuses() {
+  local out status
+  make_spawn_case bad-knob opencode opencode
+
+  out=$(FM_SPAWN_PROBE_TIMEOUT_SECS=soon run_spawn "$ID" "$PROJ_DIR")
+  status=$?
+
+  expect_code 1 "$status" "invalid FM_SPAWN_PROBE_TIMEOUT_SECS should fail"
+  assert_contains "$out" \
+    "error: FM_SPAWN_PROBE_TIMEOUT_SECS must be a positive integer number of seconds (got 'soon'); refusing before creating a task endpoint" \
+    "invalid knob refusal did not name the knob and value"
+  [ ! -s "$ENDPOINT_LOG" ] || fail "invalid knob touched tmux before failing"
+  assert_absent "$HOME_DIR/state/$ID.meta" "invalid knob wrote task meta"
+  pass "invalid probe timeout knob is refused before endpoint creation"
+}
+
+test_missing_verified_binary_refuses_before_endpoint_creation
+test_present_verified_binaries_spawn_as_before
+test_raw_launch_command_remains_exempt
+test_hanging_version_probe_times_out_before_endpoint_creation
+test_sigterm_ignoring_probe_is_killed_after_grace
+test_timed_out_probe_leaves_no_wrapper_descendants
+test_probe_closes_stdin
+test_invalid_probe_timeout_knob_refuses
+
+echo "# all fm-spawn launch-preflight tests passed"

--- a/tests/fm-tangle-guard.test.sh
+++ b/tests/fm-tangle-guard.test.sh
@@ -169,7 +169,7 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse
+  fm_fake_exit0 "$fakebin" treehouse codex
   printf '%s\n' "$fakebin"
 }
 
@@ -248,7 +248,7 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse
+  fm_fake_exit0 "$fakebin" treehouse codex
   printf '%s\n' "$fakebin"
 }
 

--- a/tests/secondmate-helpers.sh
+++ b/tests/secondmate-helpers.sh
@@ -92,6 +92,7 @@ exit 0
 SH
   chmod +x "$fakebin/tmux"
   chmod +x "$fakebin/treehouse"
+  fm_fake_exit0 "$fakebin" codex
   : > "$dir/tmux.log"
   printf '%s\n' "$fakebin"
 }


### PR DESCRIPTION
## Summary

When a verified harness CLI was missing from `PATH`, spawn still created the task endpoint and left a dead worker shell. This refuses missing (or probe-failing) launch binaries before any endpoint or task metadata is created.

Behavior:

- Resolve the first executable word of each verified adapter's launch template
- Require a cheap `--version` probe to succeed before creating the task endpoint
- Probes run with stdin closed and a portable timeout (default 10s, override with `FM_SPAWN_PROBE_TIMEOUT_SECS`)
- Timed-out probes escalate to SIGKILL of the probe process group so wrapper descendants cannot linger
- Raw launch-command escape hatches remain exempt, because arbitrary shell syntax cannot be resolved safely without executing it

## Test plan

- [x] `bin/fm-lint.sh`
- [x] `tests/fm-spawn-launch-preflight.test.sh`
- [x] `tests/fm-spawn-batch.test.sh`
- [x] `tests/fm-backend.test.sh`
- [x] `tests/fm-gate-refuse.test.sh`
