### PR TITLE
feat(herdr): add human-readable worker presentation

### DIFF
--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -5,7 +5,7 @@
 # decisions D1-D6) and the empirical verification recorded in
 # data/fm-backend-design-d7/herdr-verification-p2.md (real herdr v0.7.1,
 # protocol 14, macOS aarch64), refined by docs/herdr-backend.md's
-# "workspace-per-home" pass (AGENTS.md task herdr-sm-spaces-k4). Herdr is a
+# project-workspace and human worker presentation contract. Herdr is a
 # session provider ONLY (D3): the worktree provider stays treehouse, exactly
 # like tmux. Sourced only through bin/fm-backend.sh's fm_backend_source in
 # normal operation; the unit tests source it directly, so the FM_HOME fallback
@@ -13,12 +13,11 @@
 #
 # Container shape (D4, decided empirically - see herdr-verification-p2.md
 # "Task container shape", refined by docs/herdr-backend.md "Task container
-# shape"): ONE herdr workspace PER FIRSTMATE HOME (the primary, and each
-# secondmate, gets its own), ONE herdr TAB per task inside its home's
-# workspace. Workspace-per-task was tried and rejected (bad human-watching
-# ergonomics); workspace-per-HOME keeps that same rejection while giving every
-# home its own space, labeled distinctly, in the shared spaces sidebar. Target
-# resolution and the human-watch story stay parallel to the tmux adapter.
+# shape"): new project workers use one Herdr workspace per physical home and
+# physical project, with one tab per task.
+# Compact hidden metadata tokens own workspace/task identity while mutable
+# labels carry human project, role, outcome, and authoritative state.
+# Legacy home workspaces remain readable until their tasks finish.
 #
 # Target string shape: "<herdr-session>:<pane-id>", e.g. "default:w1:p2" (the
 # pane id itself contains a colon; the session is always the FIRST field, the
@@ -29,10 +28,8 @@
 # function has no herdr-specific logic; it just returns meta's window=
 # verbatim).
 #
-# Recovery/orphan discovery (ids may not deterministically match live state
-# after a server restart in a differently-configured session; see the
-# verification doc) uses LABEL matching (fm-<id> tab labels), never trusts a
-# stored pane id blindly: fm_backend_herdr_list_live.
+# Recovery/orphan discovery reads hidden fm_task_id tokens for new rows and
+# retains the visible fm-<id> fallback for legacy rows.
 #
 # Requires: herdr (CLI + socket), jq (JSON parsing). Bootstrap detects these
 # through fm_backend_required_tools only when herdr is the resolved backend;
@@ -43,9 +40,9 @@
 # global before sourcing fm-backend.sh (which sources this file), so this
 # never overrides a real invocation. It exists only so this file's own unit
 # tests, which source it directly without that preamble, resolve to a sane
-# default (the firstmate repo root - never a secondmate home, so
-# fm_backend_herdr_workspace_label falls through to "firstmate" exactly like
-# pre-P3 behavior when a test does not care about home-specific labeling).
+# default (the firstmate repo root - never a secondmate home, so legacy label
+# resolution falls through to "firstmate" when a test does not supply project
+# presentation inputs).
 FM_BACKEND_HERDR_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-${FM_ROOT:-$FM_BACKEND_HERDR_ROOT}}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
@@ -73,6 +70,17 @@ FM_BACKEND_HERDR_MIN_PROTOCOL=14
 # (14): the adapter's spawn/capture/send primitives work on 14, only the push
 # subscriber needs 16.
 FM_BACKEND_HERDR_MIN_EVENTS_PROTOCOL=16
+# The managed presentation surfaces - `workspace report-metadata`, `pane
+# report-metadata --token`, hidden `.tokens` in workspace/pane list output,
+# and `workspace`/`tab rename` - are verified at protocol 16 (herdr 0.7.4).
+# Below this floor the token/label projection fails closed like the events
+# gate above: a non-secondmate spawn keeps the prior label-based flow
+# (fm-<id> tab in the legacy per-home workspace, no identity tokens), and
+# bin/fm-visible-status.sh exits without touching any tab or workspace so
+# legacy fm-<id> recovery labels survive. Distinct from
+# FM_BACKEND_HERDR_MIN_PROTOCOL (14), which still governs the adapter's core
+# spawn/capture/send primitives.
+FM_BACKEND_HERDR_MIN_PRESENTATION_PROTOCOL=16
 # Per-pane escalation dedupe marker prefix, under the state dir. One marker per
 # window (keyed like the watcher's own .stale-<key>): set when a ->blocked edge
 # is enqueued, cleared on any working edge, so exactly one wake fires per
@@ -84,8 +92,9 @@ FM_BACKEND_HERDR_ESCALATED_PREFIX=".herdr-escalated-"
 # The primary firstmate home never carries this marker.
 FM_BACKEND_HERDR_SECONDMATE_MARKER=".fm-secondmate-home"
 
-# fm_backend_herdr_workspace_label: the per-firstmate-HOME herdr workspace
-# label (docs/herdr-backend.md "Task container shape"). The PRIMARY home (no
+# fm_backend_herdr_workspace_label: the supplied human project label for a new
+# managed project workspace, or the legacy per-home label when no project
+# presentation input is supplied. The PRIMARY home (no
 # secondmate marker) resolves to the constant "firstmate", byte-identical to
 # every pre-existing task's recorded label - no forced migration. A SECONDMATE
 # home resolves to "2ndmate-<secondmate-id>", so its tasks land in their own
@@ -99,6 +108,10 @@ FM_BACKEND_HERDR_SECONDMATE_MARKER=".fm-secondmate-home"
 # names the primary at that point) - see fm-spawn.sh's herdr case arm.
 fm_backend_herdr_workspace_label() {
   local marker="$FM_HOME/$FM_BACKEND_HERDR_SECONDMATE_MARKER" id
+  if [ -n "${FM_HERDR_PROJECT_LABEL:-}" ]; then
+    printf '%s' "$FM_HERDR_PROJECT_LABEL"
+    return 0
+  fi
   if [ -f "$marker" ]; then
     id=$(tr -d '[:space:]' < "$marker" 2>/dev/null)
     if [ -n "$id" ]; then
@@ -159,6 +172,26 @@ fm_backend_herdr_version_check() {
   return 0
 }
 
+# fm_backend_herdr_presentation_capable: the capability gate for the managed
+# human-presentation flow (identity tokens, WORKER titles, rename-based
+# refresh). Quiet on purpose - callers fall back to the legacy label flow
+# rather than refusing, so this never writes to stderr the way
+# fm_backend_herdr_version_check does. FM_BACKEND_HERDR_PRESENTATION_FORCE
+# overrides the whole verdict for tests (1 = capable, 0 = incapable),
+# mirroring FM_BACKEND_HERDR_EVENTS_FORCE.
+fm_backend_herdr_presentation_capable() {
+  local protocol
+  case "${FM_BACKEND_HERDR_PRESENTATION_FORCE:-}" in
+    1) return 0 ;;
+    0) return 1 ;;
+  esac
+  command -v herdr >/dev/null 2>&1 || return 1
+  command -v jq >/dev/null 2>&1 || return 1
+  protocol=$(herdr status --json 2>/dev/null | jq -r '.client.protocol // empty' 2>/dev/null)
+  case "$protocol" in ''|*[!0-9]*) return 1 ;; esac
+  [ "$protocol" -ge "$FM_BACKEND_HERDR_MIN_PRESENTATION_PROTOCOL" ]
+}
+
 # fm_backend_herdr_session: resolve which named herdr session this normal
 # spawn/op uses. HERDR_SESSION mirrors tmux's $TMUX ambient-selection for
 # adapter workspace/tab/pane operations: an operator (or firstmate's own
@@ -188,22 +221,43 @@ fm_backend_herdr_server_ensure() {  # <session>
   return 1
 }
 
-# fm_backend_herdr_workspace_find: this HOME's own workspace id inside
-# <session> (fm_backend_herdr_workspace_label), or empty (never creates).
-# Read-only, safe for recovery/list paths. Label-collision semantics
-# (docs/herdr-backend.md "Label collisions"): herdr enforces no label
-# uniqueness at all, so this adopts the FIRST matching workspace `jq` returns
-# (list order, normally creation order/oldest) rather than disambiguating -
-# identical in spirit to the pre-existing tab duplicate-label check below.
+# Resolve a path to its physical identity token without requiring it to be a
+# project root.
+fm_backend_herdr_physical_path() {  # <path>
+  local path=$1
+  if [ -d "$path" ]; then
+    (CDPATH='' cd -- "$path" && pwd -P)
+  else
+    printf '%s' "$path"
+  fi
+}
+
+# Herdr metadata tokens are intentionally compact.
+# Hash the full physical path rather than storing a value Herdr may truncate.
+fm_backend_herdr_identity_token() {  # <physical-path>
+  local physical
+  physical=$(fm_backend_herdr_physical_path "$1")
+  printf 'path-v1:%s' "$(printf '%s' "$physical" | git -C "$FM_BACKEND_HERDR_ROOT" hash-object --stdin)"
+}
+
+# fm_backend_herdr_workspace_find: find this home's managed project workspace,
+# or the legacy per-home workspace when no project key was supplied.
+# Managed workspaces are adopted only by immutable physical owner/project
+# tokens.
+# Their mutable human label is never an identity selector.
 fm_backend_herdr_workspace_find() {  # <session>
-  local session=$1 label list
+  local session=$1 label list owner project
   label=$(fm_backend_herdr_workspace_label)
   list=$(fm_backend_herdr_cli "$session" workspace list 2>/dev/null) || return 0
+  if [ -n "${FM_HERDR_PROJECT_KEY:-}" ]; then
+    owner=$(fm_backend_herdr_identity_token "$FM_HOME")
+    project=$(fm_backend_herdr_identity_token "$FM_HERDR_PROJECT_KEY")
+    printf '%s' "$list" | jq -r --arg owner "$owner" --arg project "$project" \
+      '.result.workspaces[]? | select(.tokens.fm_owner == $owner and .tokens.fm_project == $project) | .workspace_id' 2>/dev/null | head -1
+    return 0
+  fi
   # NOTE: the jq variable is $want, NOT $label - `label` is a jq reserved
-  # keyword (label/break), so declaring a jq variable named "label" is a
-  # compile error that `2>/dev/null` would silently swallow, making this find
-  # ALWAYS return empty and every spawn mint a fresh "firstmate" workspace
-  # (the workspace leak).
+  # keyword (label/break).
   printf '%s' "$list" | jq -r --arg want "$label" \
     '.result.workspaces[]? | select(.label == $want) | .workspace_id' 2>/dev/null | head -1
 }
@@ -304,7 +358,7 @@ fm_backend_herdr_workspace_prune_seeded_default_tab() {  # <session> <workspace_
 # attach to). --no-focus is passed unconditionally anyway, for defense in
 # depth and because it is a no-op in the already-safe case.
 fm_backend_herdr_workspace_ensure() {  # <session> <cwd>
-  local session=$1 cwd=$2 wsid out label
+  local session=$1 cwd=$2 wsid out label owner project
   FM_BACKEND_HERDR_WS_ID=""
   FM_BACKEND_HERDR_WS_SEEDED_TAB_ID=""
   wsid=$(fm_backend_herdr_workspace_find "$session")
@@ -318,6 +372,17 @@ fm_backend_herdr_workspace_ensure() {  # <session> <cwd>
   wsid=$(printf '%s' "$out" | jq -r '.result.workspace.workspace_id // empty' 2>/dev/null)
   [ -n "$wsid" ] || return 1
   FM_BACKEND_HERDR_WS_ID=$wsid
+  if [ -n "${FM_HERDR_PROJECT_KEY:-}" ]; then
+    owner=$(fm_backend_herdr_identity_token "$FM_HOME")
+    project=$(fm_backend_herdr_identity_token "$FM_HERDR_PROJECT_KEY")
+    fm_backend_herdr_cli "$session" workspace report-metadata "$wsid" \
+      --source firstmate-project-identity-v1 \
+      --token "fm_owner=$owner" \
+      --token "fm_project=$project" >/dev/null 2>&1 || {
+        echo "error: could not bind Herdr workspace $wsid to its Firstmate home and project" >&2
+        return 1
+      }
+  fi
   # Herdr seeds a new workspace with one auto-created default tab firstmate
   # never uses. It is NOT pruned here: at this instant it is the workspace's
   # ONLY tab, and closing a workspace's last tab deletes the workspace itself
@@ -493,25 +558,36 @@ fm_backend_herdr_agent_alive() {  # <target>
 # the safety argument). An ADOPTED workspace's caller always passes an empty
 # 4th arg, so this function never even queries for a prune candidate in that
 # case. Echoes "<tab_id> <pane_id>" on success.
-fm_backend_herdr_create_task() {  # <container> <label> <cwd> <seeded_default_tab_id>
-  local container=$1 label=$2 cwd=$3 seeded_tab_id=${4:-} session wsid list dup_tabs dup dup_pane dup_tab_ids out tab_id pane_id remaining_dup_tabs
+fm_backend_herdr_create_task() {  # <container> <label> <cwd> <seeded_default_tab_id> [task_id]
+  local container=$1 label=$2 cwd=$3 seeded_tab_id=${4:-} task_id=${5:-}
+  local session wsid list panes dup_tabs dup dup_pane dup_tab_ids out tab_id pane_id legacy_label
   session=${container%%:*}
   wsid=${container#*:}
   list=$(fm_backend_herdr_cli "$session" tab list --workspace "$wsid" 2>/dev/null) || return 1
-  dup_tabs=$(printf '%s' "$list" | jq -r --arg want "$label" 'if (.result.tabs | type) == "array" then .result.tabs[] | select(.label == $want) | .tab_id else error("missing result.tabs") end' 2>/dev/null) || {
-    echo "error: could not parse herdr tab list output for workspace $wsid (session $session)" >&2
-    return 1
-  }
   dup_tab_ids=""
+  if [ -n "$task_id" ]; then
+    panes=$(fm_backend_herdr_cli "$session" pane list --workspace "$wsid" 2>/dev/null) || return 1
+    dup_tabs=$(printf '%s' "$panes" | jq -r --arg task "$task_id" \
+      '.result.panes[]? | select(.tokens.fm_task_id == $task) | .tab_id' 2>/dev/null)
+    legacy_label="fm-$task_id"
+    dup_tabs="${dup_tabs}${dup_tabs:+$'\n'}$(printf '%s' "$list" | jq -r --arg want "$legacy_label" '.result.tabs[]? | select(.label == $want) | .tab_id' 2>/dev/null)"
+  else
+    dup_tabs=$(printf '%s' "$list" | jq -r --arg want "$label" \
+      'if (.result.tabs | type) == "array" then .result.tabs[] | select(.label == $want) | .tab_id else error("missing result.tabs") end' 2>/dev/null) || {
+      echo "error: could not parse herdr tab list output for workspace $wsid (session $session)" >&2
+      return 1
+    }
+  fi
   if [ -n "$dup_tabs" ]; then
     while IFS= read -r dup; do
       [ -n "$dup" ] || continue
+      case "$dup_tab_ids" in *$'\n'"$dup"$'\n'*) continue ;; esac
       dup_pane=$(fm_backend_herdr_pane_for_tab "$session" "$wsid" "$dup")
       if [ -z "$dup_pane" ] || ! fm_backend_herdr_tab_is_husk "$session" "$dup_pane"; then
-        echo "error: herdr tab '$label' already exists in workspace $wsid (session $session)" >&2
+        echo "error: Herdr task '${task_id:-$label}' already exists in workspace $wsid (session $session)" >&2
         return 1
       fi
-      dup_tab_ids="${dup_tab_ids}${dup}"$'\n'
+      dup_tab_ids="${dup_tab_ids}"$'\n'"${dup}"$'\n'
     done <<EOF
 $dup_tabs
 EOF
@@ -523,6 +599,12 @@ EOF
     echo "error: could not parse tab/pane id from herdr tab create output" >&2
     return 1
   fi
+  if [ -n "$task_id" ]; then
+    fm_backend_herdr_cli "$session" pane report-metadata "$pane_id" \
+      --source firstmate-task-identity-v1 \
+      --token "fm_task_id=$task_id" >/dev/null 2>&1 \
+      || echo "warning: could not project hidden task identity onto Herdr pane $pane_id; recorded backend ids remain authoritative" >&2
+  fi
   [ -z "$seeded_tab_id" ] || fm_backend_herdr_workspace_prune_seeded_default_tab "$session" "$wsid" "$seeded_tab_id"
   if [ -n "$dup_tab_ids" ]; then
     while IFS= read -r dup; do
@@ -532,20 +614,21 @@ EOF
 $dup_tab_ids
 EOF
     list=$(fm_backend_herdr_cli "$session" tab list --workspace "$wsid" 2>/dev/null) || {
-      echo "error: could not verify herdr husk removal for tab '$label' in workspace $wsid (session $session)" >&2
+      echo "error: could not verify herdr husk removal for '${task_id:-$label}' in workspace $wsid (session $session)" >&2
       return 1
     }
-    if ! printf '%s' "$list" | jq -e '(.result.tabs | type) == "array"' >/dev/null 2>&1; then
-      echo "error: could not parse herdr tab list output for workspace $wsid (session $session)" >&2
-      return 1
+    if [ -n "$task_id" ]; then
+      panes=$(fm_backend_herdr_cli "$session" pane list --workspace "$wsid" 2>/dev/null) || return 1
+      dup=$(printf '%s' "$panes" | jq -r --arg task "$task_id" --arg replacement "$pane_id" \
+        '.result.panes[]? | select(.tokens.fm_task_id == $task and .pane_id != $replacement) | .pane_id' 2>/dev/null)
+      [ -z "$dup" ] || { echo "error: failed to remove preexisting herdr task '$task_id' in workspace $wsid" >&2; return 1; }
+      dup=$(printf '%s' "$list" | jq -r --arg want "$legacy_label" --arg replacement "$tab_id" \
+        '.result.tabs[]? | select(.label == $want and .tab_id != $replacement) | .tab_id' 2>/dev/null)
+    else
+      dup=$(printf '%s' "$list" | jq -r --arg want "$label" --arg replacement "$tab_id" \
+        '.result.tabs[]? | select(.label == $want and .tab_id != $replacement) | .tab_id' 2>/dev/null)
     fi
-    remaining_dup_tabs=$(printf '%s' "$list" | jq -r --arg want "$label" --arg replacement "$tab_id" \
-      '.result.tabs[]? | select(.label == $want and .tab_id != $replacement) | .tab_id' 2>/dev/null)
-    remaining_dup_tabs=${remaining_dup_tabs//$'\n'/ }
-    if [ -n "$remaining_dup_tabs" ]; then
-      echo "error: failed to remove preexisting herdr tab(s) $remaining_dup_tabs for label '$label' in workspace $wsid (session $session)" >&2
-      return 1
-    fi
+    [ -z "$dup" ] || { echo "error: failed to remove preexisting herdr tab(s) for '${task_id:-$label}' in workspace $wsid" >&2; return 1; }
   fi
   printf '%s %s' "$tab_id" "$pane_id"
 }
@@ -1169,28 +1252,33 @@ EOF
   return 1
 }
 
-# fm_backend_herdr_list_live: recovery/orphan discovery. Lists every tab whose
-# label looks like a firstmate task window (fm-<id>) in <session>'s, THIS
-# HOME'S OWN workspace (fm_backend_herdr_workspace_label - never another
-# home's), by LABEL - never by trusting a stored pane id, since ids are not
-# guaranteed stable across every server lifecycle (see herdr-verification-p2.md
-# "ID stability"). A caller running as a given home (e.g. a secondmate
-# recovering its own in-flight work) naturally scopes to that home's own
-# workspace because FM_HOME already names it - no glue needed, unlike the
-# primary-spawns-a-secondmate path in fm-spawn.sh. Read-only: a session/
-# workspace that does not exist yet simply lists nothing. One
-# "<session>:<pane_id>\t<label>" line per live task tab.
+# fm_backend_herdr_list_live: recovery/orphan discovery.
+# New rows recover through hidden fm_task_id pane tokens inside workspaces whose
+# fm_owner token matches this physical home.
+# Legacy per-home workspaces and fm-<id> tab labels remain readable until their
+# tasks finish.
+# Another home's tokened workspace is never claimed by label.
 fm_backend_herdr_list_live() {  # <session>
-  local session=$1 wsid tabs tab_id label pane_id
-  wsid=$(fm_backend_herdr_workspace_find "$session") || return 0
-  [ -n "$wsid" ] || return 0
-  tabs=$(fm_backend_herdr_cli "$session" tab list --workspace "$wsid" 2>/dev/null) || return 0
-  while IFS=$'\t' read -r tab_id label; do
-    [ -n "$tab_id" ] || continue
-    pane_id=$(fm_backend_herdr_pane_for_tab "$session" "$wsid" "$tab_id") || continue
-    [ -n "$pane_id" ] || continue
-    printf '%s:%s\t%s\n' "$session" "$pane_id" "$label"
-  done < <(printf '%s' "$tabs" | jq -r '.result.tabs[]? | select(.label | startswith("fm-")) | "\(.tab_id)\t\(.label)"' 2>/dev/null)
+  local session=$1 workspaces owner legacy_label wsid tabs panes pane_id tab_id task_id label
+  owner=$(fm_backend_herdr_identity_token "$FM_HOME")
+  legacy_label=$(FM_HERDR_PROJECT_KEY='' FM_HERDR_PROJECT_LABEL='' fm_backend_herdr_workspace_label)
+  workspaces=$(fm_backend_herdr_cli "$session" workspace list 2>/dev/null) || return 0
+  while IFS= read -r wsid; do
+    [ -n "$wsid" ] || continue
+    tabs=$(fm_backend_herdr_cli "$session" tab list --workspace "$wsid" 2>/dev/null) || continue
+    panes=$(fm_backend_herdr_cli "$session" pane list --workspace "$wsid" 2>/dev/null) || continue
+    while IFS=$'\t' read -r pane_id tab_id task_id; do
+      [ -n "$pane_id" ] || continue
+      if [ -n "$task_id" ]; then
+        printf '%s:%s\tfm-%s\n' "$session" "$pane_id" "$task_id"
+        continue
+      fi
+      label=$(printf '%s' "$tabs" | jq -r --arg tab "$tab_id" \
+        '.result.tabs[]? | select(.tab_id == $tab) | .label // ""' 2>/dev/null | head -1)
+      case "$label" in fm-*) printf '%s:%s\t%s\n' "$session" "$pane_id" "$label" ;; esac
+    done < <(printf '%s' "$panes" | jq -r '.result.panes[]? | "\(.pane_id)\t\(.tab_id // "")\t\(.tokens.fm_task_id // "")"' 2>/dev/null)
+  done < <(printf '%s' "$workspaces" | jq -r --arg owner "$owner" --arg legacy "$legacy_label" \
+    '.result.workspaces[]? | select(.tokens.fm_owner == $owner or (((.tokens.fm_owner // "") == "") and .label == $legacy)) | .workspace_id' 2>/dev/null)
 }
 
 # --- native event push: pane.agent_status_changed subscriber -----------------

--- a/bin/fm-project-display-name.sh
+++ b/bin/fm-project-display-name.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Resolve a project slug to the human display name used on captain-facing UI.
+#
+# Usage: fm-project-display-name.sh <project-slug>
+#
+# This script is the single owner of project display-name resolution.
+# Explicit entries preserve brand casing, acronyms, and names that cannot be
+# inferred from a repository basename.
+# Unknown slugs use a documented synthesized fallback: split on dash,
+# underscore, and dot boundaries, then capitalize each word.
+# The fallback is presentation only and is never claimed to be an authoritative
+# human title.
+set -eu
+
+slug=${1:?usage: fm-project-display-name.sh <project-slug>}
+
+case "$slug" in
+  your-magical-journey) printf '%s\n' 'Your Magical Journey' ;;
+  artevo) printf '%s\n' 'Artevo' ;;
+  api-platform) printf '%s\n' 'API Platform' ;;
+  starship|firstmate) printf '%s\n' 'Starship' ;;
+  *)
+    printf '%s\n' "$slug" | awk '
+      BEGIN { FS="[-_.]+"; OFS=" " }
+      {
+        for (i = 1; i <= NF; i++) {
+          if ($i == "") continue
+          $i = toupper(substr($i, 1, 1)) substr($i, 2)
+        }
+        print
+      }
+    '
+    ;;
+esac

--- a/bin/fm-session-start.sh
+++ b/bin/fm-session-start.sh
@@ -318,6 +318,10 @@ if [ "$PRIMARY_HARNESS" = pi ]; then
     printf 'PI_WATCH_EXTENSION: not loaded - approve Pi project trust once per clone, then restart plain pi so %s and %s auto-load for turn-end guard and background wake coverage; use -e %s -e %s only if project hooks are not trusted\n' "$PI_TURNEND_EXT" "$PI_EXT" "$PI_TURNEND_EXT" "$PI_EXT"
   fi
 fi
+# Recovery is a bounded presentation refresh point only for the session owner.
+# A lock-refused read-only session must not mutate Herdr presentation.
+# Projection is best-effort and never affects durable task control.
+[ "$READ_ONLY" -eq 1 ] || "$SCRIPT_DIR/fm-visible-status.sh" --all >/dev/null 2>&1 || true
 "$SCRIPT_DIR/fm-supervision-instructions.sh" \
   --harness "$PRIMARY_HARNESS" \
   --read-only "$READ_ONLY" \

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Spawn a direct report: a crewmate in a treehouse or Orca worktree, or a
 # secondmate in its isolated firstmate home.
-# Usage: fm-spawn.sh <task-id> <project-dir> [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] [--scout]
+# Usage: fm-spawn.sh <task-id> <project-dir> [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] [--outcome <text>] [--scout]
 #        fm-spawn.sh <task-id> [<firstmate-home>] [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] --secondmate
 #   --harness <name> is the explicit per-spawn harness/profile adapter. The old
 #   positional harness arg still works for back-compat.
@@ -50,6 +50,9 @@
 #   material, so the secondmate's OWN crewmates inherit primary config and the
 #   secondmate receives the primary's read-only shared captain-preference file
 #   (fm-config-inherit-lib.sh).
+#   --outcome records an explicit concise human task outcome for supported
+#   presentation surfaces; otherwise fm-task-outcome.sh resolves the structured
+#   backlog title and then its documented safe fallback.
 #   --scout records kind=scout in the task's meta (report deliverable, scratch worktree;
 #   see AGENTS.md task lifecycle); --secondmate records kind=secondmate and launches in a
 #   provisioned firstmate home; the default is kind=ship.
@@ -60,7 +63,7 @@
 # Batch dispatch: pass one or more `id=repo` pairs instead of a single <id> <project>, e.g.
 #     fm-spawn.sh fix-a-k3=projects/foo add-b-q7=projects/bar [--scout]
 #   Each pair re-execs this script in single-task mode, so the single path stays the only
-#   source of truth; shared --scout/--harness/--model/--effort/--backend applies to every pair.
+#   source of truth; shared --scout/--harness/--model/--effort/--backend/--outcome applies to every pair.
 #   If config/crew-dispatch.json exists, shared --harness is required for crewmate
 #   and scout batches. The loop lives here, in bash, so callers never hand-write a
 #   multi-task shell loop (the tool shell is zsh, which does not word-split unquoted
@@ -119,10 +122,12 @@ HARNESS_ARG=
 MODEL=
 EFFORT=
 BACKEND_ARG=
+OUTCOME=
 HARNESS_SET=0
 MODEL_SET=0
 EFFORT_SET=0
 BACKEND_SET=0
+OUTCOME_SET=0
 POS=()
 want_value=
 for a in "$@"; do
@@ -135,6 +140,7 @@ for a in "$@"; do
       model) MODEL=$a; MODEL_SET=1 ;;
       effort) EFFORT=$a; EFFORT_SET=1 ;;
       backend) BACKEND_ARG=$a; BACKEND_SET=1 ;;
+      outcome) OUTCOME=$a; OUTCOME_SET=1 ;;
       *) echo "error: internal parser state for --$want_value" >&2; exit 1 ;;
     esac
     want_value=
@@ -151,6 +157,8 @@ for a in "$@"; do
     --effort=*) EFFORT=${a#--effort=}; EFFORT_SET=1 ;;
     --backend) want_value=backend ;;
     --backend=*) BACKEND_ARG=${a#--backend=}; BACKEND_SET=1 ;;
+    --outcome) want_value=outcome ;;
+    --outcome=*) OUTCOME=${a#--outcome=}; OUTCOME_SET=1 ;;
     *) POS+=("$a") ;;
   esac
 done
@@ -159,6 +167,7 @@ done
 [ "$MODEL_SET" -eq 0 ] || [ -n "$MODEL" ] || { echo "error: --model requires a non-empty value" >&2; exit 1; }
 [ "$EFFORT_SET" -eq 0 ] || [ -n "$EFFORT" ] || { echo "error: --effort requires a non-empty value" >&2; exit 1; }
 [ "$BACKEND_SET" -eq 0 ] || [ -n "$BACKEND_ARG" ] || { echo "error: --backend requires a non-empty value" >&2; exit 1; }
+[ "$OUTCOME_SET" -eq 0 ] || [ -n "$OUTCOME" ] || { echo "error: --outcome requires a non-empty value" >&2; exit 1; }
 case "$EFFORT" in
   ''|low|medium|high|xhigh|max) ;;
   *) echo "error: --effort must be one of low, medium, high, xhigh, max" >&2; exit 1 ;;
@@ -262,6 +271,7 @@ if [ "${#POS[@]}" -gt 0 ] && [ "${POS[0]}" != "$idpart" ] && case "$idpart" in *
   [ -z "$MODEL" ] || shared_args+=(--model "$MODEL")
   [ -z "$EFFORT" ] || shared_args+=(--effort "$EFFORT")
   [ -z "$BACKEND_ARG" ] || shared_args+=(--backend "$BACKEND_ARG")
+  [ -z "$OUTCOME" ] || shared_args+=(--outcome "$OUTCOME")
   for pair in "${POS[@]}"; do
     case "$pair" in
       *=*) : ;;
@@ -666,10 +676,12 @@ real_path_or_raw() {  # <path>
 
 # Session-provider container-ensure + task creation. tmux stays exactly as P1
 # left it (same session-name / new-window sequence, see bin/backends/tmux.sh);
-# a herdr spawn goes through the version-gated, workspace-per-HOME,
-# tab-per-task sequence in bin/backends/herdr.sh instead (D4/D5 as refined by
-# docs/herdr-backend.md's "workspace-per-home" pass, AGENTS.md task
-# herdr-sm-spaces-k4). Both branches converge on the same $T ("target") string
+# a Herdr worker spawn goes through the version-gated project-workspace,
+# tab-per-task sequence in bin/backends/herdr.sh.
+# Workspace identity uses physical home/project metadata tokens while mutable
+# labels carry human presentation.
+# Secondmate primary panes retain the legacy home workspace shape.
+# Both branches converge on the same $T ("target") string
 # that every downstream operation (send/capture/kill) already treats as opaque
 # per-backend routing (fm_backend_resolve_selector).
 validate_spawn_worktree() {  # <source> <inspect-target>
@@ -717,10 +729,30 @@ case "$BACKEND" in
     # after each prefixed simple-command call) so the secondmate's tab lands
     # in the secondmate's own workspace, not the primary's "firstmate" one.
     HERDR_LABEL_HOME=$FM_HOME
+    HERDR_PROJECT_KEY=
+    HERDR_PROJECT_NAME=
+    HERDR_PRESENTATION=0
+    if fm_backend_herdr_presentation_capable; then
+      HERDR_PRESENTATION=1
+    fi
+    TASK_OUTCOME=$(FM_HOME="$FM_HOME" FM_DATA_OVERRIDE="$DATA" \
+      "$FM_ROOT/bin/fm-task-outcome.sh" "$ID" "$OUTCOME")
+    HERDR_TAB_TITLE="WORKER · $TASK_OUTCOME · 🟡 WAITING"
     if [ "$KIND" = secondmate ]; then
       HERDR_LABEL_HOME=$PROJ_ABS
+      HERDR_CONTAINER_RAW=$(FM_HOME="$HERDR_LABEL_HOME" fm_backend_herdr_container_ensure "$PROJ_ABS") || exit 1
+      HERDR_TAB_TITLE=$W
+    elif [ "$HERDR_PRESENTATION" -eq 1 ]; then
+      HERDR_PROJECT_KEY=$PROJ_ABS_REAL
+      HERDR_PROJECT_NAME=$("$FM_ROOT/bin/fm-project-display-name.sh" "$(basename "$PROJ_ABS_REAL")")
+      HERDR_CONTAINER_RAW=$(FM_HOME="$HERDR_LABEL_HOME" \
+        FM_HERDR_PROJECT_KEY="$HERDR_PROJECT_KEY" \
+        FM_HERDR_PROJECT_LABEL="$HERDR_PROJECT_NAME" \
+        fm_backend_herdr_container_ensure "$PROJ_ABS") || exit 1
+    else
+      HERDR_TAB_TITLE=$W
+      HERDR_CONTAINER_RAW=$(FM_HOME="$HERDR_LABEL_HOME" fm_backend_herdr_container_ensure "$PROJ_ABS") || exit 1
     fi
-    HERDR_CONTAINER_RAW=$(FM_HOME="$HERDR_LABEL_HOME" fm_backend_herdr_container_ensure "$PROJ_ABS") || exit 1
     # fm_backend_herdr_container_ensure echoes "<session>:<workspace_id>\t<seeded_default_tab_id>"
     # (the second field empty when this call ADOPTED a pre-existing workspace
     # rather than creating a fresh one). Split on the guaranteed single tab
@@ -731,7 +763,9 @@ case "$BACKEND" in
     HERDR_SEEDED_DEFAULT_TAB_ID=${HERDR_CONTAINER_RAW#*$'\t'}
     HERDR_SES=${CONTAINER%%:*}
     HERDR_WORKSPACE_ID=${CONTAINER#*:}
-    HERDR_TASK_IDS=$(FM_HOME="$HERDR_LABEL_HOME" fm_backend_herdr_create_task "$CONTAINER" "$W" "$PROJ_ABS" "$HERDR_SEEDED_DEFAULT_TAB_ID") || exit 1
+    HERDR_TOKEN_TASK_ID=$ID
+    [ "$HERDR_PRESENTATION" -eq 1 ] || HERDR_TOKEN_TASK_ID=
+    HERDR_TASK_IDS=$(FM_HOME="$HERDR_LABEL_HOME" fm_backend_herdr_create_task "$CONTAINER" "$HERDR_TAB_TITLE" "$PROJ_ABS" "$HERDR_SEEDED_DEFAULT_TAB_ID" "$HERDR_TOKEN_TASK_ID") || exit 1
     read -r HERDR_TAB_ID HERDR_PANE_ID <<EOF
 $HERDR_TASK_IDS
 EOF
@@ -1008,6 +1042,12 @@ META_WINDOW=$T
     echo "herdr_workspace_id=$HERDR_WORKSPACE_ID"
     echo "herdr_tab_id=$HERDR_TAB_ID"
     echo "herdr_pane_id=$HERDR_PANE_ID"
+    if [ "$KIND" != secondmate ] && [ "$HERDR_PRESENTATION" -eq 1 ]; then
+      echo "herdr_workspace_managed=1"
+      echo "herdr_project_key=$HERDR_PROJECT_KEY"
+      echo "herdr_project_name=$HERDR_PROJECT_NAME"
+      echo "outcome=$TASK_OUTCOME"
+    fi
   fi
   if [ "$BACKEND" = zellij ]; then
     echo "zellij_session=$ZELLIJ_SES"
@@ -1028,6 +1068,9 @@ META_WINDOW=$T
   fi
 } > "$STATE/$ID.meta"
 [ "$BACKEND" = orca ] && ORCA_ABORT_CLEANUP=0
+if [ "$BACKEND" = herdr ] && [ "${HERDR_PRESENTATION:-0}" -eq 1 ]; then
+  "$FM_ROOT/bin/fm-visible-status.sh" "$ID" >/dev/null 2>&1 || true
+fi
 
 sq_brief=$(shell_quote "$BRIEF")
 sq_turnend=$(shell_quote "$TURNEND")

--- a/bin/fm-task-outcome.sh
+++ b/bin/fm-task-outcome.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Resolve the concise human outcome used for a managed worker.
+#
+# Usage: fm-task-outcome.sh <task-id> [explicit-outcome]
+#
+# Precedence is an explicit spawn/meta outcome, then the structured title of the
+# matching tasks-axi backlog row, then a safe humanized task-id fallback.
+set -eu
+
+SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)
+FM_ROOT=${FM_ROOT_OVERRIDE:-$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd -P)}
+FM_HOME=${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}
+DATA=${FM_DATA_OVERRIDE:-$FM_HOME/data}
+id=${1:?usage: fm-task-outcome.sh <task-id> [explicit-outcome]}
+outcome=${2:-}
+
+one_line() {
+  printf '%s' "$1" | tr '\r\n\t' '   ' | tr -s ' ' | sed 's/^ *//; s/ *$//'
+}
+
+if [ -z "$outcome" ] && [ -f "$DATA/backlog.md" ]; then
+  outcome=$(awk -v id="$id" '
+    {
+      prefix = "- [ ] " id " - "
+      done_prefix = "- [x] " id " - "
+      done_prefix_upper = "- [X] " id " - "
+      if (index($0, prefix) == 1 || index($0, done_prefix) == 1 || index($0, done_prefix_upper) == 1) {
+        line = $0
+        sub(/^- \[[ xX]\] [^ ]+ - /, "", line)
+        sub(/[[:space:]]+\(repo:[[:space:]].*$/, "", line)
+        print line
+        exit
+      }
+    }
+  ' "$DATA/backlog.md")
+fi
+[ -n "$outcome" ] || outcome=$(printf '%s' "$id" | tr '._-' '   ')
+one_line "$outcome"
+printf '\n'

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1123,6 +1123,9 @@ elif [ -d "$WT" ] && [ "$KIND" != secondmate ]; then
 fi
 
 if [ "$BACKEND" != orca ]; then
+  # Clear only presentation metadata before closing the stable recorded target.
+  # A cosmetic failure never weakens endpoint cleanup.
+  "$FM_ROOT/bin/fm-visible-status.sh" --clear "$ID" >/dev/null 2>&1 || true
   fm_backend_kill "$BACKEND" "$T" "$(meta_value "$META" zellij_tab_id)" "fm-$ID" 2>/dev/null || true
 fi
 if [ "$KIND" = secondmate ]; then
@@ -1137,6 +1140,7 @@ fm_backend_clear_transition "$BACKEND" "$STATE" "$T" || true
 [ -n "$TASK_TMP" ] && rm -rf "$TASK_TMP"
 remove_pr_poll_artifacts "$STATE" "$ID" || exit 1
 rm -f "$STATE/$ID.status" "$STATE/$ID.turn-ended" "$STATE/$ID.meta" "$STATE/$ID.pi-ext.ts" "$STATE/$ID.grok-turnend-token"
+"$FM_ROOT/bin/fm-visible-status.sh" --all >/dev/null 2>&1 || true
 if [ "$KIND" != scout ] && [ "$KIND" != secondmate ] && [ "$MODE" != local-only ]; then
   "$FM_ROOT/bin/fm-fleet-sync.sh" "$PROJ" || true
 fi

--- a/bin/fm-visible-status.sh
+++ b/bin/fm-visible-status.sh
@@ -1,0 +1,289 @@
+#!/usr/bin/env bash
+# Project authoritative Firstmate task details onto Herdr presentation metadata.
+#
+# Usage:
+#   fm-visible-status.sh --all
+#   fm-visible-status.sh <task-id>
+#   fm-visible-status.sh --clear <task-id>
+#
+# New managed tabs read:
+#   WORKER · <human outcome> · <authoritative state>
+# Pane detail reads:
+#   <runtime/model> · <actual branch or detached>
+# Project workspaces retain their human project name and add prioritized task
+# counts.
+#
+# This is presentation only.
+# Every operational action continues to use recorded Herdr ids.
+# Herdr API failures are therefore best-effort and never make task control fail.
+# State comes only from fm-crew-state.sh.
+# A kind=secondmate task keeps its legacy fm-<id> tab and is never restyled.
+# On a Herdr build below the verified presentation protocol this script exits
+# without touching any tab or workspace, so legacy fm-<id> labels survive.
+# This script never projects FIRSTMATE or LAB roles; it only refreshes
+# worker-facing presentation on recorded non-secondmate task panes.
+set -u
+
+SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)
+FM_ROOT=${FM_ROOT_OVERRIDE:-$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd -P)}
+FM_HOME=${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}
+STATE=${FM_STATE_OVERRIDE:-$FM_HOME/state}
+SOURCE=firstmate-worker-visible-v1
+
+# fm_backend_herdr_presentation_capable owns the capability verdict shared
+# with fm-spawn.sh's herdr arm.
+# shellcheck source=bin/backends/herdr.sh
+. "$SCRIPT_DIR/backends/herdr.sh"
+
+usage() {
+  sed -n '2,/^set -u$/s/^# \{0,1\}//p' "$0"
+}
+
+meta_value() {  # <meta> <key>
+  sed -n "s/^$2=//p" "$1" 2>/dev/null | tail -1
+}
+
+one_line() {  # <text>
+  printf '%s' "$1" | tr '\r\n\t' '   ' | tr -s ' ' | sed 's/^ *//; s/ *$//'
+}
+
+project_slug() {  # <meta>
+  local project
+  project=$(meta_value "$1" project)
+  basename "$project"
+}
+
+project_name() {  # <meta>
+  local explicit slug
+  explicit=$(meta_value "$1" herdr_project_name)
+  if [ -n "$explicit" ]; then
+    one_line "$explicit"
+    return 0
+  fi
+  slug=$(project_slug "$1")
+  "$SCRIPT_DIR/fm-project-display-name.sh" "$slug"
+}
+
+project_key() {  # <meta>
+  local explicit project
+  explicit=$(meta_value "$1" herdr_project_key)
+  [ -n "$explicit" ] && { printf '%s' "$explicit"; return 0; }
+  project=$(meta_value "$1" project)
+  if [ -d "$project" ]; then
+    (CDPATH='' cd -- "$project" && pwd -P)
+  else
+    printf '%s' "$project"
+  fi
+}
+
+human_outcome() {  # <id> <meta>
+  "$SCRIPT_DIR/fm-task-outcome.sh" "$1" "$(meta_value "$2" outcome)"
+}
+
+canonical_state() {  # <id>
+  local id=$1 line
+  if [ -n "${FM_VISIBLE_STATE_FILE:-}" ] && [ -f "$FM_VISIBLE_STATE_FILE" ]; then
+    line=$(sed -n "s/^$id=//p" "$FM_VISIBLE_STATE_FILE" | tail -1)
+    [ -z "$line" ] || { printf '%s' "${line#state: }" | cut -d' ' -f1; return 0; }
+  fi
+  line=$(FM_CREW_STATE_NM_TIMEOUT=${FM_VISIBLE_NM_TIMEOUT:-2} \
+    "$SCRIPT_DIR/fm-crew-state.sh" "$id" 2>/dev/null || true)
+  line=${line#state: }
+  printf '%s' "${line%% · *}"
+}
+
+visible_state() {  # <canonical-state>
+  case "$1" in
+    parked) printf 'NEEDS LARS' ;;
+    failed) printf 'FAILED' ;;
+    blocked) printf 'BLOCKED' ;;
+    working) printf 'WORKING' ;;
+    paused) printf 'WAITING' ;;
+    done) printf 'READY' ;;
+    *) printf 'WAITING' ;;
+  esac
+}
+
+state_icon() {  # <visible-state>
+  case "$1" in
+    'NEEDS LARS') printf '🟣' ;;
+    FAILED) printf '🔴' ;;
+    BLOCKED) printf '🟠' ;;
+    WORKING) printf '🔵' ;;
+    WAITING) printf '🟡' ;;
+    READY) printf '🟢' ;;
+  esac
+}
+
+state_rank() {  # <visible-state>
+  case "$1" in
+    'NEEDS LARS') printf 1 ;;
+    FAILED) printf 2 ;;
+    BLOCKED) printf 3 ;;
+    WORKING) printf 4 ;;
+    WAITING) printf 5 ;;
+    READY) printf 6 ;;
+    *) printf 7 ;;
+  esac
+}
+
+runtime_text() {  # <meta>
+  local harness model
+  harness=$(meta_value "$1" harness)
+  model=$(meta_value "$1" model)
+  [ -n "$harness" ] || harness=unknown
+  if [ -n "$model" ] && [ "$model" != default ]; then
+    printf '%s/%s' "$harness" "$model"
+  else
+    printf '%s' "$harness"
+  fi
+}
+
+actual_branch() {  # <worktree>
+  local branch
+  branch=$(git -C "$1" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
+  [ -n "$branch" ] && printf '%s' "$branch" || printf 'detached'
+}
+
+herdr_call() {  # <session> <args...>
+  local session=$1
+  shift
+  HERDR_SESSION="$session" herdr "$@" --session "$session"
+}
+
+project_stats() {  # <project-key>
+  local key=$1 meta id state rank
+  local needs=0 failed=0 blocked=0 working=0 waiting=0 ready=0 best=99
+  for meta in "$STATE"/*.meta; do
+    [ -f "$meta" ] || continue
+    [ "$(meta_value "$meta" backend)" = herdr ] || continue
+    [ "$(meta_value "$meta" herdr_workspace_managed)" = 1 ] || continue
+    [ "$(project_key "$meta")" = "$key" ] || continue
+    id=$(basename "$meta" .meta)
+    state=$(visible_state "$(canonical_state "$id")")
+    rank=$(state_rank "$state")
+    [ "$rank" -ge "$best" ] || best=$rank
+    case "$state" in
+      'NEEDS LARS') needs=$((needs + 1)) ;;
+      FAILED) failed=$((failed + 1)) ;;
+      BLOCKED) blocked=$((blocked + 1)) ;;
+      WORKING) working=$((working + 1)) ;;
+      WAITING) waiting=$((waiting + 1)) ;;
+      READY) ready=$((ready + 1)) ;;
+    esac
+  done
+  printf '%s %s %s %s %s %s' "$needs" "$failed" "$blocked" "$working" "$waiting" "$ready"
+}
+
+aggregate_text() {  # <stats>
+  local needs failed blocked working waiting ready part icon count label text=
+  read -r needs failed blocked working waiting ready <<EOF
+$1
+EOF
+  for part in \
+    "🟣:$needs:NEEDS LARS" \
+    "🔴:$failed:FAILED" \
+    "🟠:$blocked:BLOCKED" \
+    "🔵:$working:WORKING" \
+    "🟡:$waiting:WAITING" \
+    "🟢:$ready:READY"; do
+    IFS=: read -r icon count label <<EOF
+$part
+EOF
+    [ "$count" -gt 0 ] || continue
+    text="${text}${text:+ · }$icon $count $label"
+  done
+  printf '%s' "${text:-no tasks}"
+}
+
+update_project() {  # <meta>
+  local meta=$1 session workspace key name stats aggregate
+  [ "$(meta_value "$meta" herdr_workspace_managed)" = 1 ] || return 0
+  session=$(meta_value "$meta" herdr_session)
+  workspace=$(meta_value "$meta" herdr_workspace_id)
+  key=$(project_key "$meta")
+  name=$(project_name "$meta")
+  [ -n "$session" ] && [ -n "$workspace" ] && [ -n "$key" ] && [ -n "$name" ] || return 0
+  stats=$(project_stats "$key")
+  aggregate=$(aggregate_text "$stats")
+  herdr_call "$session" workspace rename "$workspace" "$name · $aggregate" >/dev/null 2>&1 || true
+}
+
+update_task() {  # <task-id>
+  local id=$1 meta session tab pane state icon title detail outcome runtime branch
+  meta="$STATE/$id.meta"
+  [ -f "$meta" ] || return 0
+  [ "$(meta_value "$meta" backend)" = herdr ] || return 0
+  [ "$(meta_value "$meta" kind)" != secondmate ] || return 0
+  session=$(meta_value "$meta" herdr_session)
+  tab=$(meta_value "$meta" herdr_tab_id)
+  pane=$(meta_value "$meta" herdr_pane_id)
+  [ -n "$session" ] && [ -n "$tab" ] && [ -n "$pane" ] || return 0
+  state=$(visible_state "$(canonical_state "$id")")
+  icon=$(state_icon "$state")
+  outcome=$(human_outcome "$id" "$meta")
+  runtime=$(runtime_text "$meta")
+  branch=$(actual_branch "$(meta_value "$meta" worktree)")
+  title="WORKER · $outcome · $icon $state"
+  detail="$runtime · $branch"
+  herdr_call "$session" tab rename "$tab" "$title" >/dev/null 2>&1 || true
+  herdr_call "$session" pane report-metadata "$pane" \
+    --source "$SOURCE" \
+    --title "$title" \
+    --display-agent "$detail" \
+    --state-label "working=$icon $state" \
+    --state-label "blocked=$icon $state" \
+    --state-label "idle=$icon $state" \
+    --state-label "done=$icon $state" \
+    --token "fm_task_id=$id" \
+    --token "fm_runtime=$runtime" \
+    --token "fm_branch=$branch" \
+    --token "fm_state=$state" >/dev/null 2>&1 || true
+  update_project "$meta"
+}
+
+clear_task() {  # <task-id>
+  local id=$1 meta session tab pane
+  meta="$STATE/$id.meta"
+  [ -f "$meta" ] || return 0
+  [ "$(meta_value "$meta" backend)" = herdr ] || return 0
+  session=$(meta_value "$meta" herdr_session)
+  tab=$(meta_value "$meta" herdr_tab_id)
+  pane=$(meta_value "$meta" herdr_pane_id)
+  if [ -n "$session" ] && [ -n "$pane" ]; then
+    herdr_call "$session" pane report-metadata "$pane" \
+      --source "$SOURCE" \
+      --clear-title \
+      --clear-display-agent \
+      --clear-state-labels \
+      --clear-token fm_task_id \
+      --clear-token fm_runtime \
+      --clear-token fm_branch \
+      --clear-token fm_state >/dev/null 2>&1 || true
+  fi
+  [ -z "$session" ] || [ -z "$tab" ] \
+    || herdr_call "$session" tab rename "$tab" "fm-$id" >/dev/null 2>&1 \
+    || true
+}
+
+case "${1:-}" in
+  -h|--help|'') usage ;;
+  --all)
+    fm_backend_herdr_presentation_capable || exit 0
+    for meta in "$STATE"/*.meta; do
+      [ -f "$meta" ] || continue
+      update_task "$(basename "$meta" .meta)"
+    done
+    ;;
+  --clear)
+    [ "$#" -eq 2 ] || { usage >&2; exit 2; }
+    fm_backend_herdr_presentation_capable || exit 0
+    clear_task "$2"
+    ;;
+  --*) usage >&2; exit 2 ;;
+  *)
+    [ "$#" -eq 1 ] || { usage >&2; exit 2; }
+    fm_backend_herdr_presentation_capable || exit 0
+    update_task "$1"
+    ;;
+esac

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -675,6 +675,7 @@ handle_push_transition() {  # <backend> <session> <record>
   [ -n "$pane_id" ] || { sleep 1; return; }
   window="$session:$pane_id"
   task=$(window_to_task "$window" "$STATE")
+  "$SCRIPT_DIR/fm-visible-status.sh" "$task" >/dev/null 2>&1 || true
   if status_is_paused "$(last_status_line "$STATE/$task.status")"; then
     triage_log "absorbed push $to (declared pause, awaiting external): $window"
     fm_backend_commit_transition "$backend" "$STATE" "$session" "$record" || exit 1
@@ -819,6 +820,9 @@ while :; do
   if [ -n "$pending" ]; then
     sleep "$SIGNAL_GRACE"
     pending=$(printf '%s\n%s' "$pending" "$(scan_signals)")
+    # Status writes and turn-end markers are bounded authoritative-state
+    # refresh points for captain-facing Herdr presentation.
+    "$SCRIPT_DIR/fm-visible-status.sh" --all >/dev/null 2>&1 || true
     files=""
     while IFS=$(printf '\t') read -r sf sig f; do
       [ -n "$sf" ] || continue

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -58,7 +58,9 @@ A zellij spawn additionally version-gates against the installed `zellij` binary'
 A cmux spawn additionally version-gates against the installed `cmux` binary's version, requires `jq`, and requires the control socket to be reachable and accessible (see [`docs/cmux-backend.md`](cmux-backend.md) "Setup" for the one-time socket-access configuration this needs; Automation mode is the recommended socket control mode, with Password mode supported via `config/cmux-socket-password`), refusing loudly and non-retryably on a `cmuxOnly`/unauthenticated socket.
 A backend spawn refusal from a missing dependency, version gate, or unauthenticated socket is terminal for that selected backend; firstmate surfaces it as a blocker instead of silently retrying another backend.
 Task meta records `backend=` only for a non-default backend; an absent `backend=` means `tmux`, preserving existing default-path meta files.
-A herdr task additionally records `herdr_session=`, `herdr_workspace_id=`, `herdr_tab_id=`, and `herdr_pane_id=`.
+A Herdr task additionally records `herdr_session=`, `herdr_workspace_id=`, `herdr_tab_id=`, and `herdr_pane_id=`.
+A managed Herdr project worker also records `herdr_workspace_managed=1`, physical `herdr_project_key=`, human `herdr_project_name=`, and `outcome=` presentation inputs.
+A spawn on a Herdr build below the verified presentation protocol falls back to the prior label-based flow and records none of those managed presentation fields.
 A zellij task additionally records `zellij_session=`, `zellij_tab_id=`, and `zellij_pane_id=`.
 An Orca task additionally records `orca_worktree_id=` and `terminal=`, with `window=fm-<id>` kept as the shared firstmate alias.
 A cmux task additionally records `cmux_workspace_id=` and `cmux_surface_id=`.
@@ -69,8 +71,10 @@ A metadata-routed selector returns the recorded backend target (`terminal=` for 
 Only metadata-routed task selectors carry secondmate-marker and Codex-harness context; explicit endpoint escape hatches do not.
 These five sentences are the single owner of the task-selector vocabulary; backend guides and other documents point here instead of restating the resolution order.
 `fm-teardown.sh <id>` takes a task id directly and uses the same recorded backend target fields after loading `state/<id>.meta`.
-Herdr workspaces are derived from `FM_HOME`: the primary home uses `firstmate`, and a secondmate home marked by `.fm-secondmate-home` uses `2ndmate-<secondmate-id>`.
-Spawn, list-live, and recovery paths read that label from the active home, so a secondmate's own crewmates stay inside that secondmate home's herdr space.
+New managed Herdr workers use one workspace per physical `FM_HOME` and physical project pair.
+Hidden `fm_owner` and `fm_project` metadata tokens own workspace identity, while the workspace label is mutable human presentation and is never an adoption selector.
+Hidden pane token `fm_task_id` owns recovery identity after a task tab becomes `WORKER · <outcome> · <authoritative state>`.
+Legacy `firstmate` and `2ndmate-<id>` workspaces plus `fm-<id>` tabs remain readable without migration.
 For normal herdr operations, `HERDR_SESSION` selects the named session, but destructive test cleanup must not rely on `HERDR_SESSION` alone.
 Use the explicit guarded cleanup path described in [`docs/herdr-backend.md`](herdr-backend.md) instead of `herdr server stop`.
 For normal zellij operations, `FM_ZELLIJ_SESSION` selects the named session and defaults to `firstmate`.

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -29,14 +29,62 @@ For `--secondmate` launches, secondmate home sync and inherited local-material p
 
 No first-run provisioning is needed beyond having `herdr` and `jq` on `PATH`; firstmate creates the workspace and tab it needs on first spawn.
 
-Watching and attaching: each firstmate home gets its own herdr workspace (the primary uses `firstmate`; each secondmate uses `2ndmate-<secondmate-id>`), with one tab per task inside it, named `fm-<id>`.
-Attach to the selected `HERDR_SESSION` and switch to the workspace for the home you want to watch to see every one of that home's tasks as tabs in one tab bar.
+Watching and attaching: new managed workers are grouped into one Herdr workspace per physical Firstmate home and physical project.
+The workspace shows the human project name plus prioritized aggregate state, and each task tab reads `WORKER · <human outcome> · <authoritative state>`.
+The grouped Agents detail row shows the recorded runtime/model and the branch read from the task's isolated copy, or `detached` for a detached scout.
 You do not need to attach for routine supervision: from an active firstmate session, `bin/fm-peek.sh fm-<id>` reads a task's pane without attaching, and `FM_HOME=<this-firstmate-home> bin/fm-send.sh fm-<id> "<text>"` steers it unless `FM_HOME` is already set to the active firstmate home.
 
-Verify it works by spawning a trivial task with `--backend herdr` and confirming the task's meta records `backend=herdr` plus `herdr_session=`, `herdr_workspace_id=`, `herdr_tab_id=`, and `herdr_pane_id=`; the workspace for your home should show the new `fm-<id>` tab.
+Verify it works by spawning a trivial task with `--backend herdr` and confirming the task's meta records the stable Herdr ids plus `herdr_workspace_managed=1`, `herdr_project_key=`, `herdr_project_name=`, and `outcome=`.
+The visible workspace and tab are presentation only; task control continues to use the recorded backend ids.
 
 Limitations: herdr is experimental and still carries the open gaps documented below.
 Resolved backend evidence, including the 2026-07-06 symlinked-project-prefix isolation fix, is kept in the same follow-up log for auditability.
+
+### Human worker presentation verification - 2026-07-19
+
+Verified with Herdr 0.7.4, protocol 16, and Pi 0.80.10 in a generated non-`default` session.
+Every operation used the hardened `bin/fm-herdr-lab.sh` helper, and guarded teardown confirmed the default-session fleet tripwire was unchanged.
+The reproducible command is `FM_HERDR_WORKER_PRESENTATION_E2E=1 HERDR_LAB_HELPER=bin/fm-herdr-lab.sh tests/fm-herdr-worker-presentation-e2e.test.sh`.
+The real `workspace list`, `tab list`, `pane list`, `agent list`, and `api snapshot` outputs reported these grouped Agents inputs:
+
+```text
+workspace_label=Your Magical Journey · 🔵 1 WORKING
+tab_label=WORKER · Validate GPS triggers across all seven Amsterdam stops · 🔵 WORKING
+display_agent=pi/gpt-5.6 · detached
+native_agent=pi
+fm_task_id=journey-gps-seven-stop-v8
+```
+
+This verifies an actual registered Pi agent rather than only fake API logs.
+Herdr's default grouped row configuration consumes workspace and tab on its first row and agent presentation on its second row, so these are the captain-visible values on that surface.
+
+The exact validation commands and results for this implementation were:
+
+```text
+bin/fm-lint.sh
+PASS - ShellCheck 0.11.0, no findings
+
+tests/fm-project-presentation.test.sh && tests/fm-visible-status.test.sh && tests/fm-spawn-herdr-presentation.test.sh
+PASS
+
+tests/fm-backend-herdr.test.sh
+PASS
+
+tests/fm-spawn-batch.test.sh && tests/fm-session-start.test.sh
+PASS
+
+tests/fm-teardown.test.sh && tests/fm-crew-state.test.sh
+PASS
+
+HERDR_LAB_HELPER=bin/fm-herdr-lab.sh tests/fm-backend-herdr-workspace-per-home-e2e.test.sh
+PASS
+
+FM_HERDR_WORKER_PRESENTATION_E2E=1 HERDR_LAB_HELPER=bin/fm-herdr-lab.sh tests/fm-herdr-worker-presentation-e2e.test.sh
+PASS
+
+set -o pipefail; for test_file in tests/*.test.sh; do printf '\\n===== %s =====\\n' "$test_file"; "$test_file"; done 2>&1 | tee /tmp/firstmate-herdr-naming-full-suite.log
+PASS - 84/84 test scripts completed, 0 not-ok results, 6 documented opt-in skips
+```
 
 ## Status: experimental
 
@@ -51,6 +99,7 @@ Auto-detecting tmux stays silent, since that reproduces today's unconfigured def
 Only when none of that resolves anything does firstmate fall back to the hard default, tmux.
 Absent `backend=` in a task's meta always means `tmux`; a herdr task carries an explicit `backend=herdr` line, while other experimental adapters carry their own backend values.
 A herdr spawn refuses loudly if `herdr` or `jq` is missing, or if the installed herdr's protocol is older than the verified minimum (`fm_backend_herdr_version_check`).
+The managed human-presentation flow is additionally capability-gated (`fm_backend_herdr_presentation_capable`, protocol 16); below that it falls back to the prior label-based spawn flow instead of refusing - see "Presentation capability gate" below.
 
 ## Worktree provider stays treehouse
 
@@ -58,39 +107,35 @@ Herdr is a session provider only.
 Treehouse remains the worktree provider, exactly as it is for tmux.
 Herdr's own `worktree.*` operations (branch-based, pooling/lease-free) are never used by this adapter.
 
-## Task container shape: tab-per-task in one workspace PER FIRSTMATE HOME
+## Task container shape: one workspace per physical home and project
 
-Firstmate creates one herdr workspace PER FIRSTMATE HOME - the primary gets `firstmate`, each secondmate gets its own `2ndmate-<secondmate-id>` - and one TAB per task inside that home's own workspace.
-This is the same "one container, one endpoint per task" shape tmux uses (one session, one window per task), refined one level: the container is now scoped per home, not shared machine-wide.
+New managed ship and scout tasks use one Herdr workspace per `(physical FM_HOME, physical project)` and one tab per task.
+The adapter binds a newly created workspace once with hidden `fm_owner` and `fm_project` tokens.
+Each token is a versioned Git object hash of the complete physical path, keeping the immutable identity below Herdr's metadata value limit without storing a truncatable raw path.
+Workspace lookup exact-matches both tokens and never identifies or adopts managed work by its visible label.
+The human project label is mutable presentation and may include prioritized aggregate state without weakening ownership.
 
-This refines, but does not reverse, P2's original decision (AGENTS.md task herdr-sm-spaces-k4).
-P2 established workspace-per-TASK vs. tab-per-task-in-one-shared-workspace and picked tab-per-task on the human-watching axis (below); that axis is untouched here and workspace-per-task stays rejected.
-What changed is the container's OWNER: P2 assumed a single firstmate instance per herdr session, so one shared `firstmate` workspace was enough.
-With secondmates now spawning their own herdr tasks, jamming every home's tabs into that one shared workspace made a captain's tab bar an unlabeled mix of primary and secondmate work with no visual way to tell them apart.
-Workspace-per-HOME fixes that while keeping tab-per-task's original human-watching win intact **within** each home: attaching to a home's own workspace (`herdr`, then switching to its space) still shows every one of *that home's* tasks as a tab in one tab bar, switchable with `ctrl+b <n>`; the ADDITIONAL win is that a captain juggling several homes on one herdr session now sees them as clearly labeled, separate spaces in herdr's spaces sidebar instead of one undifferentiated pile.
+The project display name comes from `bin/fm-project-display-name.sh`, the single resolver owner.
+It has explicit brand and acronym casing overrides and labels its generic title-cased result as a synthesized fallback rather than claiming a repository basename is authoritative human naming.
+`your-magical-journey` resolves to `Your Magical Journey`, and `artevo` resolves to `Artevo`.
 
-### Label derivation (stable, derived from the home itself)
+A task's visible tab title is separate from its durable identity.
+New panes carry hidden `fm_task_id`, while the recorded workspace, tab, and pane ids remain the operational targets.
+The tab reads `WORKER · <human outcome> · <authoritative state>`.
+`bin/fm-task-outcome.sh` owns outcome precedence: explicit `fm-spawn.sh --outcome`, structured backlog title, then a safe humanized task-id fallback.
+`bin/fm-visible-status.sh` reads runtime/model from task metadata, branch or detached state from the recorded isolated copy, and lifecycle state from `bin/fm-crew-state.sh`.
+It never derives lifecycle state from the append-only status tail or Herdr's native activity alone.
 
-`fm_backend_herdr_workspace_label` (`bin/backends/herdr.sh`) resolves the label from `$FM_HOME`, read fresh on every call rather than cached or threaded through env plumbing:
+### Legacy home labels
 
-- The PRIMARY home (no `.fm-secondmate-home` marker at its root) resolves to the constant `firstmate` - byte-identical to every pre-P3 task's recorded label.
-- A SECONDMATE home (carrying `.fm-secondmate-home`, written by `bin/fm-home-seed.sh` at seed time and containing exactly that secondmate's id) resolves to `2ndmate-<secondmate-id>`, e.g. `2ndmate-sshhip-h7`.
+The former workspace labels remain the compatibility vocabulary: `firstmate` for a primary home and `2ndmate-<id>` for a marked secondmate home.
+A secondmate primary pane still uses that home workspace because it has no physical project of its own.
+Its tab keeps the legacy `fm-<id>` title too: `bin/fm-visible-status.sh` skips every `kind=secondmate` task, so the WORKER convention never applies to a secondmate primary.
+New project workers spawned from either a primary or secondmate home use the token-owned project workspace contract instead.
 
-Because the label is derived from the home's own durable identity - the marker file lives at the home's root, not in an environment variable passed down a call chain - it is automatically stable across every respawn, recovery, and firstmate restart for the life of that home, with no extra bookkeeping required.
-Two different secondmate homes always get two different, non-colliding labels because their marker ids are unique (verified: `tests/fm-backend-herdr.test.sh`'s `test_workspace_label_different_secondmates_get_different_labels`).
-
-Every workspace-scoped adapter path reads this SAME resolution: find/ensure (`fm_backend_herdr_workspace_find`/`_ensure`), tab create and its duplicate-label check (`fm_backend_herdr_create_task`), list-live recovery (`fm_backend_herdr_list_live`), and pane-for-tab (`fm_backend_herdr_pane_for_tab`, via the workspace id these resolve).
-So a secondmate's own recovery/duplicate-check calls are automatically scoped to its own space and never see (or collide with) the primary's or a sibling secondmate's tabs.
-
-### The one wrinkle: a `--secondmate` spawn is launched BY the primary
-
-For every other spawn kind, `$FM_HOME` at spawn time already names the right home: the primary spawning its own crewmate/scout, or a secondmate spawning a crewmate/scout FROM ITS OWN `fm-spawn.sh` process (its own `$FM_HOME` already IS that secondmate's home).
-The one exception is `bin/fm-spawn.sh <id> <secondmate-home> --secondmate`: this command runs IN THE PRIMARY's own process, so the primary's OWN `$FM_HOME` is what the label-resolution helpers would see by default, even though the tab being created belongs to the SECONDMATE.
-`fm-spawn.sh`'s herdr case arm handles this with a narrow, targeted shadow: it computes `HERDR_LABEL_HOME` (the secondmate's own home, `PROJ_ABS`, for `KIND = secondmate`; the process's own `$FM_HOME` otherwise) and passes it as a bash temporary-assignment prefix - `FM_HOME="$HERDR_LABEL_HOME" fm_backend_herdr_container_ensure ...` and `FM_HOME="$HERDR_LABEL_HOME" fm_backend_herdr_create_task ...` - which scopes the override to exactly those two calls and is automatically restored afterward (verified: bash's temporary-assignment-before-a-simple-command form applies for the duration of a shell FUNCTION call too, not only external commands).
-Nothing else in `fm-spawn.sh` reads `$FM_HOME` again after this point, so no explicit restore is needed.
-
-Every other backend-scoped call site needs no such glue: it already runs inside a process whose own `$FM_HOME` correctly names the home doing the work.
-This includes the previously-unexercised path of a crewmate spawned FROM a secondmate's own `fm-spawn.sh` - proven end to end in `tests/fm-backend-herdr-workspace-per-home-e2e.test.sh`, not merely by code inspection (see "End-to-end verification" below).
+Recovery scans token-owned workspaces whose `fm_owner` equals the active physical home and reads hidden `fm_task_id` from each pane.
+It also scans that home's un-tokened legacy workspace for visible `fm-<id>` tabs.
+It never claims a tokened workspace owned by another home, even when the visible project label collides.
 
 ### Focus behavior: never steals the captain's attention
 
@@ -104,27 +149,39 @@ Both `fm_backend_herdr_workspace_ensure`'s workspace create and `fm_backend_herd
 This is defense in depth rather than a behavior change in the already-safe steady state: it guards workspace and tab creation after the session already has a focused workspace, but it cannot prevent herdr's unavoidable first-workspace focus in a brand-new empty session.
 Once a workspace exists, spawning - primary or secondmate, workspace or tab - should not switch whatever space the captain is actively watching.
 
-### Label collisions: adopt-don't-duplicate, unchanged in spirit
+### Label collisions do not identify managed work
 
-Herdr enforces NO label uniqueness at all for either workspaces or tabs (re-verified for workspaces specifically in this pass: creating a second workspace with an already-used label succeeds and produces two workspaces sharing that label).
-`fm_backend_herdr_workspace_find` therefore adopts the FIRST matching workspace `jq` returns for a home's own label - in practice list order, normally creation order / the oldest - rather than attempting to disambiguate; this mirrors the pre-existing tab duplicate-label check in `fm_backend_herdr_create_task` (which still refuses an exact duplicate TAB label within the adopted workspace).
-Practical consequence: if a user manually creates their own herdr workspace that happens to share a firstmate home's label (`firstmate`, or `2ndmate-<some-id>`), firstmate's next spawn silently ADOPTS that pre-existing workspace as if it were its own, rather than creating a second one or refusing.
-This is a pre-existing characteristic of the adapter's find-before-create pattern, not a new risk introduced by the per-home refinement; avoid naming a personal herdr workspace `firstmate` or `2ndmate-<secondmate-id>` if you want to keep it separate from firstmate's own space.
+Herdr enforces no workspace or tab label uniqueness.
+Managed workspace adoption therefore ignores labels and exact-matches hidden physical owner/project tokens.
+Managed task duplication and recovery read hidden `fm_task_id`; visible `fm-<id>` matching remains only as the legacy fallback.
+Two projects or homes may safely share the same human display name without being adopted as each other.
 
 ### No forced migration
 
-Existing live tasks are unaffected by this change: a task's meta already records its own `window=`/`herdr_pane_id=` target, which every backend-scoped operation (send/capture/kill/busy-state) resolves directly and never re-derives from a workspace label.
-So a task spawned before this pass keeps working exactly as before, from whatever workspace it already lives in (the old shared `firstmate` workspace, or a pre-rename `firstmate-<secondmate-id>` workspace if that is where its home's tasks previously landed).
-New workspace lookup does not adopt old secondmate labels: for new spawns, recovery, and list-live, the adapter exact-matches the current label derived from `FM_HOME` (`2ndmate-<secondmate-id>`).
-If an older live workspace is still labeled `firstmate-<secondmate-id>`, rename it with `herdr workspace rename <workspace_id> 2ndmate-<secondmate-id>` before expecting new tasks or recovery/list-live to use that workspace.
+Existing live tasks keep their recorded pane targets and remain operational in legacy `firstmate` or `2ndmate-*` workspaces.
+A bounded presentation refresh may rename a legacy task's recorded tab and update that recorded pane's metadata, but it never renames the shared legacy workspace to one task's project and never moves panes implicitly.
+If cleanup cannot close a refreshed legacy pane, `fm-visible-status.sh --clear` restores `fm-<id>` before returning so the legacy recovery fallback remains available.
+Other backends keep their existing selector and title contracts.
 
-Tab-per-task (within each home's own workspace) still wins on the human-watching axis for the reason P2 originally found: attaching once shows every one of that home's tasks as a tab in one tab bar, switchable with `ctrl+b <n>`, matching how a captain already watches a tmux-backed fleet.
-Workspace-per-task - tried against the real binary in P2 and again considered here - would still only show one task's workspace at a time by default, requiring a separate top-level "space" switch to see the rest of even a single home's fleet; that tradeoff is unchanged by the per-home refinement and workspace-per-task remains rejected.
+### Presentation capability gate
 
-## Workspace lifecycle: one persistent per-home workspace, reused
+The managed presentation surfaces - `workspace report-metadata`, `pane report-metadata --token`, hidden `.tokens` in workspace/pane list output, and `workspace`/`tab rename` - are verified at protocol 16 (herdr 0.7.4).
+`FM_BACKEND_HERDR_MIN_PROTOCOL` stays 14: the adapter's core spawn/capture/send primitives still work there, so the presentation dependency is capability-gated instead of raising the floor, mirroring the protocol-16 events gate.
+Below `FM_BACKEND_HERDR_MIN_PRESENTATION_PROTOCOL` (16), `fm_backend_herdr_presentation_capable` fails closed: a non-secondmate spawn uses the prior label-based flow (an `fm-<id>` tab in the legacy per-home workspace, no identity tokens, and no `herdr_workspace_managed=1` meta), and `bin/fm-visible-status.sh` exits without touching any tab or workspace, so legacy `fm-<id>` recovery labels survive.
+`FM_BACKEND_HERDR_PRESENTATION_FORCE` (1 = capable, 0 = incapable) overrides the probe for tests, exactly like `FM_BACKEND_HERDR_EVENTS_FORCE`.
 
-Each home's own workspace (`firstmate` for the primary, `2ndmate-<secondmate-id>` for a secondmate - see "Label derivation" above) is created once per session and reused by every subsequent spawn from that home: `fm_backend_herdr_workspace_ensure` calls `fm_backend_herdr_workspace_find` first and creates a workspace only when none labelled for that home exists yet.
-Teardown (`fm_backend_herdr_kill`) closes only the task's pane/tab, never the workspace.
+### Bounded presentation refresh and primary boundary
+
+`bin/fm-visible-status.sh` refreshes after spawn metadata is written, during session recovery, on status or native blocked transitions, and before cleanup.
+Every Herdr presentation call is best-effort because recorded ids, landed-work checks, and endpoint cleanup remain authoritative.
+The helper updates only recorded, non-secondmate task panes and never emits `FIRSTMATE` or `LAB`.
+An ordinary worker merely carrying `HERDR_ENV=1` can therefore never acquire captain-facing primary presentation through this path.
+
+## Workspace lifecycle: one persistent workspace per project pair
+
+A token-owned project workspace is reused by subsequent tasks from the same physical home and physical project.
+Teardown closes only the task's recorded pane/tab, never a workspace by label.
+Closing the final tab may let Herdr remove the now-empty workspace as its normal side effect.
 
 Reserved-keyword guard: never name a `jq --arg`/`--argjson` after a `jq` keyword (`label`, `and`, `or`, `not`, `if`, `then`, `else`, `end`, `reduce`, `foreach`, `import`, `def`, `as`, `__loc__`).
 jq <= 1.6 rejects a keyword-named `$`-variable as a compile error, and this adapter pipes `jq`'s stderr to `/dev/null`, so on jq <= 1.6 the error silently becomes an empty result rather than a visible failure.
@@ -137,7 +194,7 @@ Use a distinct name such as `$want` instead; `tests/fm-backend-herdr.test.sh` gr
 
 **The prune target is identified structurally (created-vs-adopted), never by label pattern.**
 `fm_backend_herdr_workspace_ensure` captures the seeded default tab's `tab_id` straight from its OWN `workspace create` response (`.result.tab.tab_id`, verified empirically to be present on the same response as `.result.workspace.workspace_id` - no follow-up `tab list` call is needed) ONLY when that call itself just created the workspace.
-`fm_backend_herdr_container_ensure` threads that id through to its caller as a second field: it echoes `"<session>:<workspace_id>\t<seeded_default_tab_id>"`, the second field empty whenever the workspace was ADOPTED (`fm_backend_herdr_workspace_find` matched a pre-existing workspace by label) rather than created fresh.
+`fm_backend_herdr_container_ensure` threads that id through to its caller as a second field: it echoes `"<session>:<workspace_id>\t<seeded_default_tab_id>"`, the second field empty whenever the workspace was adopted through its managed identity tokens or legacy label rather than created fresh.
 `fm_backend_herdr_create_task` accepts that value as an explicit 4th argument and is the ONLY place allowed to act on it; it never re-derives "prunable" from a tab's label or the workspace's tab count.
 An adopted workspace's caller always passes an empty 4th argument, so create_task never even looks for a prune candidate in that case - it is structurally impossible for an adopted workspace's tabs to be pruned, regardless of how they are labeled.
 
@@ -154,9 +211,9 @@ Log evidence: `~/.config/herdr/herdr-server.log` showed `cli:tab:create` (the ne
 
 The fix is structural, not another heuristic, and is unit- and E2E-tested: see `tests/fm-backend-herdr.test.sh`'s `test_adopted_workspace_never_prunes_default_tab` and `test_label_collision_startup_workspace_leaves_live_tab_alone`, and `tests/fm-backend-herdr-prune-safety-e2e.test.sh`'s isolated real-herdr reproduction of the exact incident shape.
 
-Because closing a workspace's last tab deletes it, a home's workspace does not outlive a fully idle fleet (zero live tasks for that home) - the next spawn's `workspace_find` simply finds nothing and recreates it. Reuse holds across concurrent and sequential tasks; it is not a guarantee that the workspace itself survives the whole session unconditionally.
-
-A workspace whose label this adapter did not derive (see "Label derivation" above) is never adopted, reused, or torn down by firstmate - `fm_backend_herdr_workspace_find` and `fm_backend_herdr_list_live` only ever match a home's own derived label.
+Because closing a workspace's last tab deletes it, a project workspace does not outlive a fully idle project fleet.
+The next spawn recreates it with the same physical owner/project identity tokens.
+Managed workspace lookup never adopts, reuses, or tears down a workspace by its visible label.
 
 ## Target string and meta fields
 
@@ -169,9 +226,13 @@ For a bare unknown non-`fm-` name, Herdr retains the legacy tmux live-window fal
 Herdr tasks additionally record:
 
 - `herdr_session=` - the named herdr session this task's server lives in.
-- `herdr_workspace_id=` - the id of the workspace belonging to the home that spawned this task (the primary's `firstmate` workspace, or a secondmate's own `2ndmate-<id>` workspace; for reference - not needed for day-to-day operations, which re-derive it from the target string).
-- `herdr_tab_id=` - the task's tab id.
-- `herdr_pane_id=` - the task's pane id, the fast-path operational target.
+- `herdr_workspace_id=` - the stable workspace id recorded at spawn.
+- `herdr_tab_id=` - the stable task tab id.
+- `herdr_pane_id=` - the stable task pane id and fast-path operational target.
+- `herdr_workspace_managed=1` - marks a new token-owned project workspace.
+- `herdr_project_key=` - the physical project identity used with the physical home token.
+- `herdr_project_name=` - the resolved human display name.
+- `outcome=` - the resolved concise human outcome.
 
 ## Verified CLI facts
 
@@ -179,7 +240,7 @@ Herdr tasks additionally record:
 |---|---|---|
 | Version/protocol gate | `herdr status --json` -> `.client.protocol` | Session-independent; `.server.*` fields ARE session-dependent. |
 | Headless server start | `HERDR_SESSION=<name> herdr server --session <name>` (backgrounded) | A bare socket call does NOT auto-start the server; the adapter always starts-then-polls before any workspace/tab/pane call. This fact is for start only, not cleanup, and the explicit `--session` flag is intentional because `HERDR_SESSION` alone is not safe session targeting. |
-| Duplicate task check | `herdr tab list --workspace <id>`, match by `.label` | Herdr does NOT enforce tab-label uniqueness itself; two tabs can share a label. The adapter's own duplicate check is required. |
+| Duplicate task check | `herdr pane list --workspace <id>`, match hidden `.tokens.fm_task_id`; visible `fm-<id>` tab fallback for legacy rows | Herdr does not enforce label uniqueness, so mutable human titles are never task identity. |
 | Send literal (unsubmitted) | `herdr pane send-text <pane> <text>` | Does NOT auto-submit, contrary to the original design addendum's guess. Verified directly: a unique marker sent this way sits unexecuted in the composer until a separate Enter. Behaves exactly like tmux's `send-keys -l`. |
 | Send + submit atomically | `herdr pane run <pane> <command>` | Runs and submits a command in one call; used for the two fixed spawn-time commands (`treehouse get`, the `GOTMPDIR` export) exactly where tmux used one `send-keys ... Enter` call. |
 | Send key | `herdr pane send-keys <pane> <key>` | Verified names: `enter`, `escape` (alias `esc`), `ctrl+c` (aliases `C-c`, `c-c`). `ctrl+c` verified to interrupt a running foreground process immediately. |
@@ -189,7 +250,7 @@ Herdr tasks additionally record:
 | Busy state | `herdr agent get <pane>` -> `.result.agent.agent_status` | Verified live against an interactive `claude` session: reports `working` while generating, `done` once idle. Mapped: `working` -> busy; `idle`/`done` -> idle; `blocked` -> idle (surfaced like a stale pane, not suppressed as busy - a blocked agent is stuck waiting on the human, not grinding); anything else -> unknown (the cue for the shared tail-regex fallback). |
 | Kill | `herdr pane close <pane>` | Closing a tab's only (root) pane also closes the tab - no separate tab-close call needed for this adapter's one-pane-per-tab shape. Best-effort: closing an already-closed pane exits non-zero, matching tmux's `kill-window \|\| true` contract. Teardown itself only ever closes the task's own pane/tab, never the workspace - but closing a workspace's LAST tab (verified real-herdr behavior) deletes the workspace as a side effect, so a home's own workspace persists only while at least one task tab remains; see "Workspace lifecycle" above. |
 | Default-tab prune (create_task, first task in a fresh workspace only) | `herdr workspace create`'s own response (`.result.tab.tab_id`) identifies the seeded tab; `herdr tab list` + `herdr agent get <pane>` re-verify it; `herdr pane close <pane>` closes exactly that tab id | `herdr workspace create` seeds the new workspace with one auto-created default tab (label `1`, id captured straight from the create response) firstmate never uses. `fm_backend_herdr_create_task` closes EXACTLY that captured tab id right after creating the first real task tab in a freshly created workspace - never right after `workspace create` itself (see Kill row), and never re-derived from a tab's label or the workspace's tab count at create_task time (see "Default-tab prune" above for the created-vs-adopted safety gate and the 2026-07-02 incident it fixes). Best-effort; an ADOPTED workspace (not freshly created by this same call) is never a prune candidate at all. |
-| Recovery / list-live | `herdr tab list --workspace <id>`, filter labels starting with `fm-` | Label-based, never trusts a stored id blindly - see "ID stability" below. `<id>` is always THIS home's own workspace (`fm_backend_herdr_workspace_find`), so recovery never sees a sibling home's tabs. |
+| Recovery / list-live | Workspace `fm_owner` token plus pane `fm_task_id`; legacy home label plus visible `fm-<id>` fallback | New recovery refuses another physical home's project workspace even when labels collide, while legacy rows remain readable. |
 | Workspace create / tab create (focus) | `herdr workspace create --no-focus`, `herdr tab create --no-focus` | Verified: neither focuses by default once a workspace already exists in the session, matching pre-P3 (flagless) behavior; `--no-focus` is passed anyway for defense in depth, since the very first workspace ever created in a brand-new session focuses regardless of the flag. `--focus` was separately verified to reliably focus, confirming the flag has real effect. |
 | Session targeting for DESTRUCTIVE calls | `herdr session stop <name> --session <name> --json`, then `herdr session delete <name> --session <name> --json`; never `herdr server stop` | Owned by `bin/fm-herdr-lab.sh` (which `tests/herdr-test-safety.sh` sources), re-querying `herdr session list --json` before every destructive call. See "Session targeting" below - `HERDR_SESSION` alone is not reliably honored once another herdr server is already running on the machine. |
 
@@ -440,20 +501,21 @@ Herdr persists this metadata to disk per named session, independent of the live 
 What does NOT survive is the underlying shell/agent process inside each pane (a fresh shell starts in its place) and each pane's live `agent_status` (resets to unknown).
 
 P2 verified this in the single-workspace shape only.
-Re-verified here in the MULTI-workspace shape (P3, workspace-per-home): with two coexisting workspaces (a `firstmate` and a `2ndmate-<secondmate-id>`, each with its own tab/pane) in one isolated session, a `session stop` + fresh server restart preserved BOTH workspaces' ids and labels, and BOTH tasks' pane ids, exactly - automated in `tests/fm-backend-herdr-smoke.test.sh`'s restart-stability section.
+Re-verified in the multi-workspace shape: a `session stop` plus fresh server restart preserved every workspace id, label, tab id, and pane id.
 
-Practical consequence: a stored `herdr_pane_id=` remains a valid, fast-path operational target across an ordinary server restart within the same named session, regardless of how many other homes' workspaces coexist in that session.
-The adapter still implements label-based recovery (`fm_backend_herdr_list_live`), both for a differently-configured or freshly-created session where old ids would not exist at all, and as the more defensive default in general.
+Practical consequence: a stored `herdr_pane_id=` remains a valid fast-path operational target across an ordinary server restart within the same named session.
+Bulk recovery reads hidden workspace owner and task identity tokens for new rows, with the legacy home-label and `fm-<id>` fallback retained for old rows.
 
 ## Respawn idempotency: a restored task tab is a husk, not a duplicate
 
-A restart's other consequence (the previous section's "what does NOT survive") used to make every fleet respawn after it a manual chore: a restored `fm-<id>` tab comes back alive but with a fresh shell process and no registered agent (`agent_status` reset to unknown, `agent get` reporting `agent_not_found`) - or, if the pane's own process failed to restart at all, structurally gone (`pane get` reporting `pane_not_found`).
-Before this fix, `fm_backend_herdr_create_task`'s duplicate-label guard treated either shape identically to a genuinely live duplicate and refused unconditionally, so recovering a fleet after a real herdr server restart (or, worse, a full reboot) meant closing every husk pane by hand before firstmate could spawn into it again - this reproduced in production on 2026-07-03.
+A restart's other consequence used to make every fleet respawn a manual chore: a restored task tab comes back with a fresh shell process and no registered agent, or its pane is structurally gone.
+Before the husk fix, task duplication treated either shape identically to a genuinely live duplicate and refused unconditionally.
 
 The guard is now husk-aware.
-`fm_backend_herdr_pane_agent_state` classifies an existing same-labeled tab's pane as one of `dead` (`pane get` -> `pane_not_found`), `no-agent` (the pane exists but `agent get` -> `agent_not_found` - the restored-plain-shell shape, and also what a future `resume_agents_on_restore = false` herdr config would produce unconditionally), `live` (a real registered `agent_status`, including idle/blocked - never just "working"), or `unknown` (anything unparseable or unexpected).
+`fm_backend_herdr_pane_agent_state` classifies an existing same-identity pane as one of `dead` (`pane get` -> `pane_not_found`), `no-agent` (the pane exists but `agent get` -> `agent_not_found`), `live` (a real registered `agent_status`), or `unknown` (anything unparseable or unexpected).
+New tasks match hidden `fm_task_id`, while legacy rows match visible `fm-<id>`.
 Only `dead` and `no-agent` are treated as a husk; `live` and `unknown` both refuse exactly as before, fail-safe toward refusal whenever the state cannot be classified with confidence.
-A confirmed husk is closed and replaced instead of refused: `fm_backend_herdr_create_task` always creates the REPLACEMENT tab first, closes the preexisting husk tab by id only after that succeeds, and verifies no same-labeled tab except the replacement remains before returning success.
+A confirmed husk is closed and replaced instead of refused: `fm_backend_herdr_create_task` always creates the replacement first, closes the preexisting husk tab by id only after that succeeds, and verifies no duplicate hidden identity or legacy label remains before returning success.
 It never closes the husk first, because closing a workspace's last remaining tab deletes the whole workspace on real herdr (see "Workspace lifecycle" above) and a session-restore husk can legitimately be that workspace's only tab.
 This is the identical create-before-close safety argument `fm_backend_herdr_workspace_prune_seeded_default_tab` already established for the seeded default tab.
 
@@ -489,19 +551,19 @@ Two real, non-obvious bugs were caught and fixed by this pass alone, both alread
 
 The isolated herdr session, the treehouse pool worktree, and the scratch `FM_HOME` were all stopped/deleted/removed after this run, using the guarded teardown described in "Session targeting" above; the captain's default herdr session and the live tmux fleet were never touched at any point.
 
-## End-to-end verification: workspace-per-home (P3)
+## End-to-end verification: project workspaces across primary and secondmate homes
 
-`tests/fm-backend-herdr-workspace-per-home-e2e.test.sh` drives `bin/fm-spawn.sh` and `bin/fm-teardown.sh` for real, in a scratch `TMP_ROOT` holding two scratch firstmate homes (a primary-shaped one with no marker, and a secondmate-shaped one carrying `.fm-secondmate-home`) and two scratch local-only projects, on one isolated `HERDR_SESSION` (never the captain's default), with the same `herdr_safe_stop_and_delete` guarded cleanup.
-This exercises the fm-spawn.sh-level behavior the adapter-primitive smoke test cannot reach: the label-resolution home-shadowing for a `--secondmate` spawn, and - the one path that had never run before this test - a crewmate spawned FROM a secondmate's own `fm-spawn.sh` process.
+`tests/fm-backend-herdr-workspace-per-home-e2e.test.sh` drives real spawn and cleanup against two scratch homes and two scratch projects in a guarded non-default lab session.
+The updated assertions cover the compatibility boundary:
 
-1. A primary-shaped home spawns an ordinary crewmate (`cm1`) on the herdr backend: its tab lands in a workspace herdr itself labels `firstmate`.
-2. The PRIMARY spawns a `--secondmate` task (`e2esm1`, home = the secondmate-shaped scratch home): its tab lands in a DIFFERENT workspace than `cm1`'s, labeled `2ndmate-e2esm1` by herdr - proving the `fm-spawn.sh` FM_HOME-shadow glue for this one launched-by-the-primary case.
-3. A crewmate (`cm2`) is spawned by running `bin/fm-spawn.sh` again, this time with `FM_HOME` set to the SECONDMATE's own home (simulating the secondmate running its own spawn, exactly as it would live) - no special-casing needed. Its tab lands in the SAME workspace as `e2esm1`'s (`2ndmate-e2esm1`), never the primary's - confirming per-home resolution "falls out" naturally for this path, as the design predicted, now proven rather than merely inspected.
-4. `fm_backend_herdr_list_live`, called with `FM_HOME` set to each home in turn, sees only that home's own tab(s): the primary's list shows only `cm1`; the secondmate's list shows both `e2esm1` and `cm2`, and neither list leaks into the other.
-5. `bin/fm-teardown.sh cm1` closes only `cm1`'s pane - the secondmate's own pane and `cm2`'s pane, both confirmed still open via `herdr pane get`, survive untouched. `bin/fm-teardown.sh cm2` (run with the secondmate's own `FM_HOME`) then closes only `cm2`'s pane, leaving the secondmate's own pane (same workspace) open.
+1. A primary-home worker lands in its human project workspace with compact physical owner/project identity tokens.
+2. A secondmate primary pane retains its legacy `2ndmate-<id>` home workspace.
+3. A project worker spawned from that secondmate home lands in a distinct token-owned human project workspace, never the secondmate primary workspace or the primary home's project workspace.
+4. Recovery from each home combines that home's token-owned project workspaces with its readable legacy home workspace and excludes the other home.
+5. Cleanup targets recorded pane ids and leaves every unrelated project and secondmate pane alive.
 
-All ten assertions passed on the real binary on the first run.
-As with every other real-herdr test in this document, the default session's own workspace state (label, tab count) was confirmed byte-identical immediately before and immediately after the run.
+Every explicit inspection and lifecycle action in the test routes through `bin/fm-herdr-lab.sh`.
+Guarded teardown confirms the default-session fleet tripwire is unchanged.
 
 ## Away-mode daemon: herdr supervisor-pane support
 

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -42,6 +42,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `backends/cmux.sh`       | Experimental cmux session-provider adapter                                           |
 | `fm-config-push.sh`      | Push declared inherited local material to live secondmate homes mid-session          |
 | `fm-project-mode.sh`     | Resolve a project's delivery mode and `+yolo` flag from `data/projects.md`           |
+| `fm-project-display-name.sh` | Resolve a project slug to its human display name with explicit brand overrides and a synthesized fallback |
 | `fm-merge-local.sh`      | Fast-forward a `local-only` project's local default branch after approval            |
 | `fm-review-diff.sh`      | Review a crewmate branch or resolved PR head against the authoritative base          |
 | `fm-marker-lib.sh`       | Shared from-firstmate request marker, detector, and idempotent transformation         |
@@ -55,6 +56,8 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-supervisor-target-lib.sh` | Resolve the shared supervisor target and backend for the daemon and launcher       |
 | `fm-supervise-daemon.sh` | Presence-gated away-mode sub-supervisor: self-handle routine wakes, escalate batched digests, alert on failed delivery |
 | `fm-crew-state.sh`       | Print one deterministic current-state line for a crew                                |
+| `fm-task-outcome.sh`     | Resolve a worker outcome from an explicit value, structured backlog title, or safe fallback |
+| `fm-visible-status.sh`   | Project authoritative worker details onto Herdr presentation metadata                |
 | `fm-tangle-lib.sh`       | Shared default-branch resolution and primary-checkout tangle classification          |
 | `fm-supervision-lib.sh`  | Shared in-flight-work-without-fresh-watcher-beacon predicate                         |
 | `fm-ff-lib.sh`           | Shared guarded fast-forward helper for origin pulls and local secondmate syncs       |

--- a/tests/fm-backend-herdr-workspace-per-home-e2e.test.sh
+++ b/tests/fm-backend-herdr-workspace-per-home-e2e.test.sh
@@ -1,33 +1,13 @@
 #!/usr/bin/env bash
-# tests/fm-backend-herdr-workspace-per-home-e2e.test.sh - mandatory ISOLATED
-# end-to-end real-herdr test for the P3 "workspace-per-home" pass (AGENTS.md
-# task herdr-sm-spaces-k4). Drives the REAL bin/fm-spawn.sh and
-# bin/fm-teardown.sh (not just adapter primitives), because the requirement
-# under test - a --secondmate spawn's tab landing in the secondmate's OWN
-# herdr workspace, and a crewmate spawned FROM a secondmate home landing there
-# too - only exists at fm-spawn.sh's own home-shadowing logic (the herdr case
-# arm) and at fm_backend_herdr_workspace_label's FM_HOME read; neither is
-# exercised by the adapter-primitive smoke test.
-#
-# Mirrors tests/fm-backend-autodetect-smoke.test.sh's isolated-session
-# convention: a private throwaway HERDR_SESSION (never the captain's
-# default), scratch FM_HOME(s), and scratch local-only projects.
-#
-# Safety (2026-07-02 incident, see tests/herdr-test-safety.sh): cleanup uses
-# ONLY herdr_safe_stop_and_delete, never a bare/inline-prefixed `herdr server
-# stop`.
-#
-# Covers, at minimum (per the task brief):
-#   - a primary-shaped home (no .fm-secondmate-home marker) spawning a
-#     crewmate into the "firstmate" workspace
-#   - a secondmate-shaped home (with .fm-secondmate-home) getting its own
-#     labeled workspace when the PRIMARY spawns it (fm-spawn.sh's FM_HOME
-#     shadow for --secondmate)
-#   - a crewmate spawned FROM that secondmate-shaped home (the secondmate
-#     running its OWN fm-spawn.sh) landing in the secondmate's own workspace -
-#     this exact path has never run before this test
-#   - teardown closing the right tab (and no other)
-#   - list-live recovery seeing only its own home's tabs, for both homes
+# Mandatory isolated real-Herdr end-to-end coverage for project workspaces
+# across primary and secondmate homes.
+# It drives real spawn and cleanup, verifies compact physical ownership tokens,
+# preserves the secondmate primary's legacy home workspace, and proves a
+# secondmate-owned project worker lands in a distinct human project workspace.
+# Recovery combines only the active home's managed and legacy rows, and cleanup
+# closes only recorded pane ids.
+# The generated non-default session is provisioned, inspected, and removed only
+# through bin/fm-herdr-lab.sh.
 set -u
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -62,16 +42,21 @@ command -v treehouse >/dev/null 2>&1 || { echo "skip: treehouse not found (requi
 # poll.
 TMP_ROOT=$(mktemp -d "$(cd "${TMPDIR:-/tmp}" && pwd -P)/fm-herdr-e2e.XXXXXX")
 SESSION="fm-lab-herdr-e2e-$$"
+HERDR_LAB_HELPER=${HERDR_LAB_HELPER:-$ROOT/bin/fm-herdr-lab.sh}
 export HERDR_SESSION="$SESSION"
-WT1=; WT2=
+WT1=; WT2=; SESSION_READY=0
 cleanup_all() {
   [ -n "$WT1" ] && command -v treehouse >/dev/null 2>&1 && treehouse return --force "$WT1" >/dev/null 2>&1
   [ -n "$WT2" ] && command -v treehouse >/dev/null 2>&1 && treehouse return --force "$WT2" >/dev/null 2>&1
-  herdr_safe_stop_and_delete "$SESSION"
+  if [ "$SESSION_READY" -eq 1 ]; then
+    "$HERDR_LAB_HELPER" teardown "$SESSION" >/dev/null 2>&1 || true
+    SESSION_READY=0
+  fi
   rm -rf "$TMP_ROOT"
 }
 trap cleanup_all EXIT
-fm_herdr_lab_prepare "$SESSION" || fail "could not prepare isolated Herdr lab session"
+"$HERDR_LAB_HELPER" provision "$SESSION" || fail "could not provision isolated Herdr lab session"
+SESSION_READY=1
 
 # shellcheck source=bin/fm-backend.sh
 . "$ROOT/bin/fm-backend.sh"
@@ -123,11 +108,20 @@ sleep 1
 CM1_CAPTURE=$(fm_backend_herdr_capture "$SESSION:$CM1_PANE" 30) || fail "capture failed on cm1's pane"
 assert_contains_local "$CM1_CAPTURE" "primary-crew-ok" "cm1's raw launch command did not run in its herdr pane"
 
-CM1_WSID=$(herdr pane get "$CM1_PANE" --session "$SESSION" 2>/dev/null | jq -r '.result.pane.workspace_id // empty')
+CM1_WSID=$("$HERDR_LAB_HELPER" run "$SESSION" pane get "$CM1_PANE" 2>/dev/null | jq -r '.result.pane.workspace_id // empty')
 [ -n "$CM1_WSID" ] || fail "could not read cm1's pane workspace_id"
-CM1_WS_LABEL=$(herdr workspace list --session "$SESSION" 2>&1 | jq -r --arg id "$CM1_WSID" '.result.workspaces[]? | select(.workspace_id == $id) | .label')
-[ "$CM1_WS_LABEL" = "firstmate" ] || fail "a primary-shaped home's crewmate should land in the 'firstmate' workspace, got '$CM1_WS_LABEL'"
-pass "real herdr E2E: the primary-shaped home's crewmate landed in the 'firstmate' workspace"
+CM1_WORKSPACES=$("$HERDR_LAB_HELPER" run "$SESSION" workspace list 2>&1)
+CM1_WS_LABEL=$(printf '%s' "$CM1_WORKSPACES" | jq -r --arg id "$CM1_WSID" '.result.workspaces[]? | select(.workspace_id == $id) | .label')
+assert_contains_local "$CM1_WS_LABEL" "Scratch Project 1" "a primary-shaped home's crewmate should land in its human project workspace"
+CM1_WS_OWNER=$(printf '%s' "$CM1_WORKSPACES" | jq -r --arg id "$CM1_WSID" '.result.workspaces[]? | select(.workspace_id == $id) | .tokens.fm_owner')
+CM1_WS_PROJECT=$(printf '%s' "$CM1_WORKSPACES" | jq -r --arg id "$CM1_WSID" '.result.workspaces[]? | select(.workspace_id == $id) | .tokens.fm_project')
+CM1_OWNER_PATH=$(cd "$PRIMARY_HOME" && pwd -P)
+CM1_PROJECT_PATH=$(cd "$PROJ1" && pwd -P)
+CM1_OWNER_TOKEN="path-v1:$(printf '%s' "$CM1_OWNER_PATH" | git -C "$ROOT" hash-object --stdin)"
+CM1_PROJECT_TOKEN="path-v1:$(printf '%s' "$CM1_PROJECT_PATH" | git -C "$ROOT" hash-object --stdin)"
+[ "$CM1_WS_OWNER" = "$CM1_OWNER_TOKEN" ] || fail "cm1 workspace owner token mismatch: got '$CM1_WS_OWNER'"
+[ "$CM1_WS_PROJECT" = "$CM1_PROJECT_TOKEN" ] || fail "cm1 workspace project token mismatch: got '$CM1_WS_PROJECT'"
+pass "real herdr E2E: the primary-shaped home's crewmate landed in its token-owned human project workspace"
 
 # --- 2. the PRIMARY spawns a secondmate: its tab lands in the SECONDMATE's own space ---
 # (fm-spawn.sh's herdr case arm shadows FM_HOME to the secondmate's home for
@@ -149,12 +143,19 @@ SM_PANE=$(grep '^herdr_pane_id=' "$SM_META" | cut -d= -f2-)
 [ -n "$SM_PANE" ] || fail "e2esm1 meta missing herdr_pane_id"
 pass "real herdr E2E: the primary spawns a --secondmate task on the herdr backend"
 
-SM_WSID=$(herdr pane get "$SM_PANE" --session "$SESSION" 2>/dev/null | jq -r '.result.pane.workspace_id // empty')
+SM_WSID=$("$HERDR_LAB_HELPER" run "$SESSION" pane get "$SM_PANE" 2>/dev/null | jq -r '.result.pane.workspace_id // empty')
 [ -n "$SM_WSID" ] || fail "could not read e2esm1's pane workspace_id"
 [ "$SM_WSID" != "$CM1_WSID" ] || fail "the secondmate's tab must NOT land in the primary's workspace, but it shares $CM1_WSID"
-SM_WS_LABEL=$(herdr workspace list --session "$SESSION" 2>&1 | jq -r --arg id "$SM_WSID" '.result.workspaces[]? | select(.workspace_id == $id) | .label')
+SM_WS_LABEL=$("$HERDR_LAB_HELPER" run "$SESSION" workspace list 2>&1 | jq -r --arg id "$SM_WSID" '.result.workspaces[]? | select(.workspace_id == $id) | .label')
 [ "$SM_WS_LABEL" = "2ndmate-e2esm1" ] || fail "a --secondmate spawn should land in '2ndmate-<id>', got '$SM_WS_LABEL'"
-pass "real herdr E2E: a --secondmate spawn by the PRIMARY lands in the SECONDMATE's own labeled workspace, distinct from the primary's"
+SM_TAB=$("$HERDR_LAB_HELPER" run "$SESSION" pane list --workspace "$SM_WSID" 2>/dev/null \
+  | jq -r --arg pane "$SM_PANE" '.result.panes[]? | select(.pane_id == $pane) | .tab_id' | head -1)
+[ -n "$SM_TAB" ] || fail "could not resolve e2esm1's tab id"
+SM_TAB_LABEL=$("$HERDR_LAB_HELPER" run "$SESSION" tab list --workspace "$SM_WSID" 2>/dev/null \
+  | jq -r --arg id "$SM_TAB" '.result.tabs[]? | select(.tab_id == $id) | .label')
+[ "$SM_TAB_LABEL" = "fm-e2esm1" ] \
+  || fail "the secondmate primary tab must keep its legacy fm-<id> title after the spawn-time presentation refresh, got '$SM_TAB_LABEL'"
+pass "real herdr E2E: a --secondmate spawn by the PRIMARY lands in the SECONDMATE's own labeled workspace with its legacy fm-<id> tab, distinct from the primary's"
 
 # --- 3. a crewmate spawned FROM the secondmate-shaped home lands in the SAME
 # secondmate workspace (this exact path has never run before this test) -----
@@ -178,10 +179,12 @@ sleep 1
 CM2_CAPTURE=$(fm_backend_herdr_capture "$SESSION:$CM2_PANE" 30) || fail "capture failed on cm2's pane"
 assert_contains_local "$CM2_CAPTURE" "sm-crew-ok" "cm2's raw launch command did not run in its herdr pane"
 
-CM2_WSID=$(herdr pane get "$CM2_PANE" --session "$SESSION" 2>/dev/null | jq -r '.result.pane.workspace_id // empty')
-[ "$CM2_WSID" = "$SM_WSID" ] || fail "a crewmate spawned FROM the secondmate home should land in the SAME workspace as the secondmate's own task ($SM_WSID), got '$CM2_WSID'"
-[ "$CM2_WSID" != "$CM1_WSID" ] || fail "a crewmate spawned FROM the secondmate home must NOT land in the primary's workspace"
-pass "real herdr E2E: a crewmate spawned FROM the secondmate-shaped home lands in the secondmate's OWN workspace - falls out of per-home resolution, no glue needed"
+CM2_WSID=$("$HERDR_LAB_HELPER" run "$SESSION" pane get "$CM2_PANE" 2>/dev/null | jq -r '.result.pane.workspace_id // empty')
+[ "$CM2_WSID" != "$SM_WSID" ] || fail "a secondmate-owned project worker must not share the secondmate primary's legacy home workspace"
+[ "$CM2_WSID" != "$CM1_WSID" ] || fail "a crewmate spawned FROM the secondmate home must NOT land in the primary's project workspace"
+CM2_WS_LABEL=$("$HERDR_LAB_HELPER" run "$SESSION" workspace list 2>&1 | jq -r --arg id "$CM2_WSID" '.result.workspaces[]? | select(.workspace_id == $id) | .label')
+assert_contains_local "$CM2_WS_LABEL" "Scratch Project 2" "secondmate-owned worker did not receive its human project workspace"
+pass "real herdr E2E: a worker spawned from a secondmate home lands in that home's token-owned project workspace"
 
 # --- 4. list-live recovery: each home sees only its own tabs ---------------
 
@@ -195,7 +198,7 @@ SM_LIVE=$(FM_HOME="$SM_HOME" fm_backend_herdr_list_live "$SESSION")
 assert_contains_local "$SM_LIVE" "fm-e2esm1" "the secondmate home's list_live did not see its own task"
 assert_contains_local "$SM_LIVE" "fm-cm2" "the secondmate home's list_live did not see the crewmate spawned from it"
 assert_not_contains_local "$SM_LIVE" "fm-cm1" "the secondmate home's list_live must not see the primary's task"
-pass "real herdr E2E: list_live from the secondmate's own context sees only tasks in the secondmate's own workspace (both its own tab and its crewmate's)"
+pass "real herdr E2E: list_live from the secondmate context combines its legacy primary and token-owned project workspaces"
 
 # --- 5. teardown closes the RIGHT tab, and no other ------------------------
 
@@ -206,13 +209,13 @@ FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$PRIMARY_HOME/state" FM_DATA_OVERRID
 rc=$?
 [ "$rc" -eq 0 ] || fail "fm-teardown.sh failed for the primary-shaped crewmate cm1"$'\n'"$(cat "$TD1_OUT")"
 [ -f "$CM1_META" ] && fail "fm-teardown.sh did not remove cm1's meta"
-if herdr pane get "$CM1_PANE" --session "$SESSION" >/dev/null 2>&1; then
+if "$HERDR_LAB_HELPER" run "$SESSION" pane get "$CM1_PANE" >/dev/null 2>&1; then
   fail "fm-teardown.sh did not close cm1's pane"
 fi
-if ! herdr pane get "$SM_PANE" --session "$SESSION" >/dev/null 2>&1; then
+if ! "$HERDR_LAB_HELPER" run "$SESSION" pane get "$SM_PANE" >/dev/null 2>&1; then
   fail "tearing down cm1 must not have closed the secondmate's OWN pane (wrong tab closed)"
 fi
-if ! herdr pane get "$CM2_PANE" --session "$SESSION" >/dev/null 2>&1; then
+if ! "$HERDR_LAB_HELPER" run "$SESSION" pane get "$CM2_PANE" >/dev/null 2>&1; then
   fail "tearing down cm1 must not have closed cm2's pane (wrong tab closed)"
 fi
 WT1=
@@ -225,10 +228,10 @@ FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$SM_HOME/state" FM_DATA_OVERRIDE="$S
 rc=$?
 [ "$rc" -eq 0 ] || fail "fm-teardown.sh failed for the secondmate-owned crewmate cm2"$'\n'"$(cat "$TD2_OUT")"
 [ -f "$CM2_META" ] && fail "fm-teardown.sh did not remove cm2's meta"
-if herdr pane get "$CM2_PANE" --session "$SESSION" >/dev/null 2>&1; then
+if "$HERDR_LAB_HELPER" run "$SESSION" pane get "$CM2_PANE" >/dev/null 2>&1; then
   fail "fm-teardown.sh did not close cm2's pane"
 fi
-if ! herdr pane get "$SM_PANE" --session "$SESSION" >/dev/null 2>&1; then
+if ! "$HERDR_LAB_HELPER" run "$SESSION" pane get "$SM_PANE" >/dev/null 2>&1; then
   fail "tearing down cm2 must not have closed the secondmate's OWN pane (wrong tab closed)"
 fi
 WT2=

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -96,10 +96,12 @@ save() { local tmp="$STATE.tmp.$$"; cat > "$tmp" && mv "$tmp" "$STATE"; }
 cmd=${1:-}; sub=${2:-}
 ws=""; label=""
 args=("$@")
+tokens=()
 for ((i=0; i<${#args[@]}; i++)); do
   case "${args[$i]}" in
     --workspace) ws=${args[$((i+1))]:-} ;;
     --label) label=${args[$((i+1))]:-} ;;
+    --token) tokens+=("${args[$((i+1))]:-}") ;;
   esac
 done
 
@@ -114,8 +116,8 @@ case "$cmd $sub" in
     n=$(jq_state -r '.next'); wsid="w$n"; dn=$((n + 1))
     jq_state --arg wsid "$wsid" --arg wlabel "$label" \
       --arg tabid "$wsid:t$dn" --arg paneid "$wsid:p$dn" \
-      '.workspaces += [{workspace_id:$wsid, label:$wlabel}]
-       | .tabs += [{tab_id:$tabid, label:"1", workspace_id:$wsid, pane_id:$paneid}]
+      '.workspaces += [{workspace_id:$wsid, label:$wlabel, tokens:{}}]
+       | .tabs += [{tab_id:$tabid, label:"1", workspace_id:$wsid, pane_id:$paneid, tokens:{}}]
        | .next = (.next + 2)' | save
     printf '{"result":{"workspace":{"workspace_id":"%s","label":"%s"},"tab":{"tab_id":"%s"},"root_pane":{"pane_id":"%s"}}}\n' \
       "$wsid" "$label" "$wsid:t$dn" "$wsid:p$dn"
@@ -126,12 +128,38 @@ case "$cmd $sub" in
   "tab create")
     n=$(jq_state -r '.next'); tabid="$ws:t$n"; paneid="$ws:p$n"
     jq_state --arg w "$ws" --arg wlabel "$label" --arg tabid "$tabid" --arg paneid "$paneid" \
-      '.tabs += [{tab_id:$tabid, label:$wlabel, workspace_id:$w, pane_id:$paneid}]
+      '.tabs += [{tab_id:$tabid, label:$wlabel, workspace_id:$w, pane_id:$paneid, tokens:{}}]
        | .next = (.next + 1)' | save
     printf '{"result":{"tab":{"tab_id":"%s"},"root_pane":{"pane_id":"%s"}}}\n' "$tabid" "$paneid"
     ;;
   "pane list")
-    jq_state --arg w "$ws" '{result:{panes:[.tabs[]|select(.workspace_id==$w)|{pane_id:.pane_id, tab_id:.tab_id}]}}'
+    jq_state --arg w "$ws" '{result:{panes:[.tabs[]|select(.workspace_id==$w)|{pane_id:.pane_id, tab_id:.tab_id, tokens:(.tokens // {})}]}}'
+    ;;
+  "workspace report-metadata")
+    target=${3:-}
+    for token in "${tokens[@]}"; do
+      key=${token%%=*}; value=${token#*=}
+      jq_state --arg id "$target" --arg key "$key" --arg value "$value" \
+        '.workspaces |= map(if .workspace_id == $id then (.tokens[$key] = $value) else . end)' | save
+    done
+    ;;
+  "pane report-metadata")
+    target=${3:-}
+    for token in "${tokens[@]}"; do
+      key=${token%%=*}; value=${token#*=}
+      jq_state --arg id "$target" --arg key "$key" --arg value "$value" \
+        '.tabs |= map(if .pane_id == $id then (.tokens[$key] = $value) else . end)' | save
+    done
+    ;;
+  "workspace rename")
+    target=${3:-}; new_label=${4:-}
+    jq_state --arg id "$target" --arg label "$new_label" \
+      '.workspaces |= map(if .workspace_id == $id then .label = $label else . end)' | save
+    ;;
+  "tab rename")
+    target=${3:-}; new_label=${4:-}
+    jq_state --arg id "$target" --arg label "$new_label" \
+      '.tabs |= map(if .tab_id == $id then .label = $label else . end)' | save
     ;;
   "pane close")
     pane=${3:-}
@@ -2037,6 +2065,84 @@ test_wait_transition_clean_timeout_returns_1() {
   pass "fm_backend_herdr_wait_transition: stock macOS Bash clean timeout closes fd 9 and returns 1"
 }
 
+herdr_test_path_token() {  # <path>
+  local physical
+  physical=$(cd "$1" && pwd -P)
+  printf 'path-v1:%s' "$(printf '%s' "$physical" | git -C "$ROOT" hash-object --stdin)"
+}
+
+test_managed_workspace_identity_uses_hidden_physical_tokens() {
+  local dir fb home_a home_b project state out
+  dir="$TMP_ROOT/managed-workspace-identity"; mkdir -p "$dir"
+  fb=$(make_herdr_statefake "$dir")
+  state="$dir/state.json"
+  home_a="$dir/home-a"; home_b="$dir/home-b"; project="$dir/project"
+  mkdir -p "$home_a" "$home_b" "$project"
+  jq --arg a "$(herdr_test_path_token "$home_a")" \
+    --arg b "$(herdr_test_path_token "$home_b")" \
+    --arg p "$(herdr_test_path_token "$project")" \
+    '.workspaces = [
+      {workspace_id:"ours",label:"Your Magical Journey",tokens:{fm_owner:$a,fm_project:$p}},
+      {workspace_id:"theirs",label:"Your Magical Journey",tokens:{fm_owner:$b,fm_project:$p}}
+    ]' "$state" > "$state.tmp" && mv "$state.tmp" "$state"
+  out=$(PATH="$fb:$PATH" FM_HERDR_LOG="$dir/log" FM_FAKE_HERDR_STATE="$state" \
+    FM_HOME="$home_a" FM_HERDR_PROJECT_KEY="$(cd "$project" && pwd -P)" \
+    FM_HERDR_PROJECT_LABEL='Your Magical Journey' \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_workspace_find lab' "$ROOT")
+  [ "$out" = ours ] || fail "managed workspace lookup adopted by label or another home's token: '$out'"
+  pass 'managed Herdr workspace lookup uses hidden physical home/project tokens, never its human label'
+}
+
+test_managed_task_identity_allows_shared_titles_and_recovers_hidden_ids() {
+  local dir fb state home project first second live
+  dir="$TMP_ROOT/managed-task-identity"; mkdir -p "$dir"
+  fb=$(make_herdr_statefake "$dir")
+  state="$dir/state.json"; home="$dir/home"; project="$dir/project"
+  mkdir -p "$home" "$project"; : > "$dir/log"
+  jq --arg owner "$(herdr_test_path_token "$home")" \
+    --arg project "$(herdr_test_path_token "$project")" \
+    '.workspaces=[{workspace_id:"w1",label:"Your Magical Journey",tokens:{fm_owner:$owner,fm_project:$project}}]' \
+    "$state" > "$state.tmp" && mv "$state.tmp" "$state"
+  first=$(PATH="$fb:$PATH" FM_HERDR_LOG="$dir/log" FM_FAKE_HERDR_STATE="$state" FM_HOME="$home" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_create_task lab:w1 "WORKER · Same outcome · 🟡 WAITING" /tmp "" task-one' "$ROOT")
+  second=$(PATH="$fb:$PATH" FM_HERDR_LOG="$dir/log" FM_FAKE_HERDR_STATE="$state" FM_HOME="$home" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_create_task lab:w1 "WORKER · Same outcome · 🟡 WAITING" /tmp "" task-two' "$ROOT")
+  [ -n "$first" ] && [ -n "$second" ] && [ "$first" != "$second" ] \
+    || fail 'managed tasks with the same human title did not retain distinct stable ids'
+  live=$(PATH="$fb:$PATH" FM_HERDR_LOG="$dir/log" FM_FAKE_HERDR_STATE="$state" FM_HOME="$home" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_list_live lab' "$ROOT")
+  assert_contains "$live" $'fm-task-one' 'list_live did not recover first hidden task id'
+  assert_contains "$live" $'fm-task-two' 'list_live did not recover second hidden task id'
+  pass 'managed Herdr tasks use hidden ids, allow duplicate human outcomes, and recover both rows'
+}
+
+test_list_live_hidden_legacy_and_other_home_boundary() {
+  local dir fb state home other project live
+  dir="$TMP_ROOT/list-live-mixed"; mkdir -p "$dir"
+  fb=$(make_herdr_statefake "$dir")
+  state="$dir/state.json"; home="$dir/home"; other="$dir/other"; project="$dir/project"
+  mkdir -p "$home" "$other" "$project"; : > "$dir/log"
+  jq --arg owner "$(herdr_test_path_token "$home")" \
+    --arg other "$(herdr_test_path_token "$other")" \
+    --arg project "$(herdr_test_path_token "$project")" '
+    .workspaces=[
+      {workspace_id:"managed",label:"Shared Human Name",tokens:{fm_owner:$owner,fm_project:$project}},
+      {workspace_id:"foreign",label:"Shared Human Name",tokens:{fm_owner:$other,fm_project:$project}},
+      {workspace_id:"legacy",label:"firstmate",tokens:{}}
+    ] |
+    .tabs=[
+      {tab_id:"managed:t1",pane_id:"managed:p1",workspace_id:"managed",label:"WORKER · New · WORKING",tokens:{fm_task_id:"new-task"}},
+      {tab_id:"foreign:t1",pane_id:"foreign:p1",workspace_id:"foreign",label:"WORKER · Foreign · WORKING",tokens:{fm_task_id:"foreign-task"}},
+      {tab_id:"legacy:t1",pane_id:"legacy:p1",workspace_id:"legacy",label:"fm-legacy-task",tokens:{}}
+    ]' "$state" > "$state.tmp" && mv "$state.tmp" "$state"
+  live=$(PATH="$fb:$PATH" FM_HERDR_LOG="$dir/log" FM_FAKE_HERDR_STATE="$state" FM_HOME="$home" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_list_live lab' "$ROOT")
+  assert_contains "$live" 'fm-new-task' 'new hidden task token was not recovered'
+  assert_contains "$live" 'fm-legacy-task' 'legacy visible fm-id fallback was not recovered'
+  assert_not_contains "$live" 'foreign-task' "another home's token-owned workspace was claimed"
+  pass 'list_live supports hidden and legacy recovery while refusing another home workspace'
+}
+
 # shellcheck source=bin/fm-backend.sh
 . "$ROOT/bin/fm-backend.sh"
 
@@ -2072,6 +2178,9 @@ test_create_task_creates_and_parses_ids
 test_create_task_creates_with_no_focus_flag
 test_workspace_find_matches_only_this_homes_own_label
 test_list_live_scoped_to_this_homes_workspace_only
+test_managed_workspace_identity_uses_hidden_physical_tokens
+test_managed_task_identity_allows_shared_titles_and_recovers_hidden_ids
+test_list_live_hidden_legacy_and_other_home_boundary
 test_parse_target
 test_normalize_key
 test_capture_calls_pane_read

--- a/tests/fm-herdr-worker-presentation-e2e.test.sh
+++ b/tests/fm-herdr-worker-presentation-e2e.test.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Opt-in real Herdr verification for the grouped Agents worker presentation.
+# Every Herdr operation, including lifecycle cleanup, goes through the guarded
+# helper and a generated non-default lab session.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+[ "${FM_HERDR_WORKER_PRESENTATION_E2E:-0}" = 1 ] || {
+  echo 'skip: set FM_HERDR_WORKER_PRESENTATION_E2E=1 for real Herdr worker presentation verification'
+  exit 0
+}
+command -v herdr >/dev/null 2>&1 || { echo 'skip: herdr not found'; exit 0; }
+command -v jq >/dev/null 2>&1 || { echo 'skip: jq not found'; exit 0; }
+command -v pi >/dev/null 2>&1 || { echo 'skip: pi not found'; exit 0; }
+
+HERDR_LAB_HELPER=${HERDR_LAB_HELPER:-$ROOT/bin/fm-herdr-lab.sh}
+HERDR_LAB_SESSION=$("$HERDR_LAB_HELPER" name worker-presentation)
+TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/fm-herdr-worker-presentation-e2e.XXXXXX")
+
+cleanup() {
+  "$HERDR_LAB_HELPER" teardown "$HERDR_LAB_SESSION" >/dev/null 2>&1 || true
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+"$HERDR_LAB_HELPER" provision "$HERDR_LAB_SESSION" \
+  || fail 'could not provision guarded non-default Herdr lab'
+
+WS_OUT=$("$HERDR_LAB_HELPER" run "$HERDR_LAB_SESSION" workspace create \
+  --cwd "$ROOT" --label 'Your Magical Journey · 🔵 1 WORKING' --no-focus) \
+  || fail 'could not create project workspace in lab'
+WS=$(printf '%s' "$WS_OUT" | jq -r '.result.workspace.workspace_id // empty')
+SEED=$(printf '%s' "$WS_OUT" | jq -r '.result.root_pane.pane_id // empty')
+[ -n "$WS" ] && [ -n "$SEED" ] || fail 'workspace creation did not return stable ids'
+
+OWNER_TOKEN="path-v1:$(printf '%s' "$ROOT" | git -C "$ROOT" hash-object --stdin)"
+PROJECT_TOKEN=$OWNER_TOKEN
+"$HERDR_LAB_HELPER" run "$HERDR_LAB_SESSION" workspace report-metadata "$WS" \
+  --source firstmate-project-identity-v1 \
+  --token "fm_owner=$OWNER_TOKEN" \
+  --token "fm_project=$PROJECT_TOKEN" >/dev/null \
+  || fail 'could not bind project identity tokens'
+
+AGENT_OUT=$("$HERDR_LAB_HELPER" run "$HERDR_LAB_SESSION" agent start \
+  'WORKER · Validate GPS triggers across all seven Amsterdam stops · 🔵 WORKING' \
+  --workspace "$WS" --cwd "$ROOT" --no-focus \
+  --env 'FM_PRESENTATION_LAB=1' \
+  -- pi) || fail 'could not start isolated Pi presentation probe'
+TAB=$(printf '%s' "$AGENT_OUT" | jq -r '.result.agent.tab_id // empty')
+PANE=$(printf '%s' "$AGENT_OUT" | jq -r '.result.agent.pane_id // empty')
+[ -n "$TAB" ] && [ -n "$PANE" ] || fail 'agent start did not return stable tab/pane ids'
+
+"$HERDR_LAB_HELPER" run "$HERDR_LAB_SESSION" tab rename "$TAB" \
+  'WORKER · Validate GPS triggers across all seven Amsterdam stops · 🔵 WORKING' >/dev/null \
+  || fail 'could not set worker tab title'
+"$HERDR_LAB_HELPER" run "$HERDR_LAB_SESSION" pane report-metadata "$PANE" \
+  --source firstmate-worker-visible-v1 \
+  --title 'WORKER · Validate GPS triggers across all seven Amsterdam stops · 🔵 WORKING' \
+  --display-agent 'pi/gpt-5.6 · detached' \
+  --state-label 'working=🔵 WORKING' \
+  --state-label 'blocked=🔵 WORKING' \
+  --state-label 'idle=🔵 WORKING' \
+  --state-label 'done=🔵 WORKING' \
+  --token 'fm_task_id=journey-gps-seven-stop-v8' \
+  --token 'fm_runtime=pi/gpt-5.6' \
+  --token 'fm_branch=detached' \
+  --token 'fm_state=WORKING' >/dev/null \
+  || fail 'could not project worker presentation metadata'
+"$HERDR_LAB_HELPER" run "$HERDR_LAB_SESSION" pane close "$SEED" >/dev/null \
+  || fail 'could not close the unused seeded pane'
+sleep 1
+
+"$HERDR_LAB_HELPER" run "$HERDR_LAB_SESSION" workspace list > "$TMP_ROOT/workspaces.json" \
+  || fail 'could not inspect real workspace presentation'
+"$HERDR_LAB_HELPER" run "$HERDR_LAB_SESSION" tab list --workspace "$WS" > "$TMP_ROOT/tabs.json" \
+  || fail 'could not inspect real tab presentation'
+"$HERDR_LAB_HELPER" run "$HERDR_LAB_SESSION" pane list --workspace "$WS" > "$TMP_ROOT/panes.json" \
+  || fail 'could not inspect real pane presentation'
+"$HERDR_LAB_HELPER" run "$HERDR_LAB_SESSION" agent list > "$TMP_ROOT/agents.json" \
+  || fail 'could not inspect real grouped Agents inventory'
+"$HERDR_LAB_HELPER" run "$HERDR_LAB_SESSION" api snapshot > "$TMP_ROOT/snapshot.json" \
+  || fail 'could not inspect real session snapshot'
+
+workspace_label=$(jq -r --arg id "$WS" '.result.workspaces[]|select(.workspace_id==$id)|.label' "$TMP_ROOT/workspaces.json")
+tab_label=$(jq -r --arg id "$TAB" '.result.tabs[]|select(.tab_id==$id)|.label' "$TMP_ROOT/tabs.json")
+display_agent=$(jq -r --arg id "$PANE" '.result.panes[]|select(.pane_id==$id)|.display_agent' "$TMP_ROOT/panes.json")
+task_id=$(jq -r --arg id "$PANE" '.result.panes[]|select(.pane_id==$id)|.tokens.fm_task_id' "$TMP_ROOT/panes.json")
+native_agent=$(jq -r --arg id "$PANE" '.result.agents[]|select(.pane_id==$id)|.agent' "$TMP_ROOT/agents.json")
+
+[ "$workspace_label" = 'Your Magical Journey · 🔵 1 WORKING' ] \
+  || fail "real grouped workspace row mismatch: $workspace_label"
+[ "$tab_label" = 'WORKER · Validate GPS triggers across all seven Amsterdam stops · 🔵 WORKING' ] \
+  || fail "real grouped task row mismatch: $tab_label"
+[ "$display_agent" = 'pi/gpt-5.6 · detached' ] \
+  || fail "real grouped detail row mismatch: $display_agent"
+[ "$task_id" = journey-gps-seven-stop-v8 ] \
+  || fail "real hidden task identity mismatch: $task_id"
+[ "$native_agent" = pi ] \
+  || fail "real Agents inventory did not register Pi: $native_agent"
+
+"$HERDR_LAB_HELPER" teardown "$HERDR_LAB_SESSION" \
+  || fail 'guarded lab teardown or default-session tripwire failed'
+trap - EXIT
+pass 'real Herdr grouped Agents presentation shows human project, WORKER outcome/state, Pi detail, and hidden task identity'

--- a/tests/fm-project-presentation.test.sh
+++ b/tests/fm-project-presentation.test.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Focused tests for the single project-name and task-outcome resolver owners.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-project-presentation)
+HOME_FIX="$TMP_ROOT/home"
+mkdir -p "$HOME_FIX/data"
+
+assert_eq() {
+  [ "$1" = "$2" ] || fail "$3: expected '$2', got '$1'"
+}
+
+test_project_names() {
+  assert_eq "$("$ROOT/bin/fm-project-display-name.sh" your-magical-journey)" 'Your Magical Journey' \
+    'Journey human display name'
+  assert_eq "$("$ROOT/bin/fm-project-display-name.sh" artevo)" 'Artevo' \
+    'Artevo brand casing'
+  assert_eq "$("$ROOT/bin/fm-project-display-name.sh" api-platform)" 'API Platform' \
+    'acronym override'
+  assert_eq "$("$ROOT/bin/fm-project-display-name.sh" ordinary-project)" 'Ordinary Project' \
+    'documented synthesized fallback'
+  pass 'project display names preserve brand/acronym overrides and synthesize only the fallback'
+}
+
+test_outcomes() {
+  cat > "$HOME_FIX/data/backlog.md" <<'EOF'
+# Backlog
+## In flight
+- [ ] journey-gps-seven-stop-v8 - Validate GPS triggers across all seven Amsterdam stops (repo: your-magical-journey) (kind: scout)
+- [ ] journey-launch-date-plan-r3 - Rebaseline the Your Magical Journey launch plan with a date (repo: your-magical-journey) (kind: scout)
+EOF
+  assert_eq "$(FM_HOME="$HOME_FIX" "$ROOT/bin/fm-task-outcome.sh" journey-gps-seven-stop-v8)" \
+    'Validate GPS triggers across all seven Amsterdam stops' 'first structured backlog title'
+  assert_eq "$(FM_HOME="$HOME_FIX" "$ROOT/bin/fm-task-outcome.sh" journey-launch-date-plan-r3)" \
+    'Rebaseline the Your Magical Journey launch plan with a date' 'second structured backlog title'
+  assert_eq "$(FM_HOME="$HOME_FIX" "$ROOT/bin/fm-task-outcome.sh" any-id 'Explicit human outcome')" \
+    'Explicit human outcome' 'explicit outcome precedence'
+  assert_eq "$(FM_HOME="$HOME_FIX" "$ROOT/bin/fm-task-outcome.sh" no-structured-title)" \
+    'no structured title' 'safe task-id fallback'
+  pass 'task outcomes prefer explicit text, parse real-shaped backlog titles, and fall back safely'
+}
+
+test_project_names
+test_outcomes

--- a/tests/fm-spawn-herdr-presentation.test.sh
+++ b/tests/fm-spawn-herdr-presentation.test.sh
@@ -1,0 +1,257 @@
+#!/usr/bin/env bash
+# End-to-end fake-Herdr-CLI coverage for single and batch fm-spawn presentation.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+command -v jq >/dev/null 2>&1 || { echo 'skip: jq not found'; exit 0; }
+
+TMP_ROOT=$(fm_test_tmproot fm-spawn-herdr-presentation)
+HOME_FIX="$TMP_ROOT/home"
+FAKEBIN=$(fm_fakebin "$TMP_ROOT")
+HERDR_STATE="$TMP_ROOT/herdr-state.json"
+HERDR_LOG="$TMP_ROOT/herdr.log"
+WT_ROOT="$TMP_ROOT/worktrees"
+mkdir -p "$HOME_FIX/state" "$HOME_FIX/data" "$HOME_FIX/config" "$WT_ROOT"
+printf '{"next":1,"workspaces":[],"tabs":[]}\n' > "$HERDR_STATE"
+: > "$HERDR_LOG"
+
+cat > "$FAKEBIN/treehouse" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+
+cat > "$FAKEBIN/herdr" <<'SH'
+#!/usr/bin/env bash
+set -u
+state=${FM_FAKE_HERDR_STATE:?}
+log=${FM_FAKE_HERDR_LOG:?}
+{
+  for arg in "$@"; do printf '<%s>' "$arg"; done
+  printf '\n'
+} >> "$log"
+
+save() { local tmp="$state.tmp.$$"; cat > "$tmp" && mv "$tmp" "$state"; }
+query() { jq "$@" "$state"; }
+args=("$@")
+cmd=${1:-}; sub=${2:-}; workspace= label= cwd=
+tokens=(); clears=()
+for ((i=0; i<${#args[@]}; i++)); do
+  case "${args[$i]}" in
+    --workspace) workspace=${args[$((i+1))]:-} ;;
+    --label) label=${args[$((i+1))]:-} ;;
+    --cwd) cwd=${args[$((i+1))]:-} ;;
+    --token) tokens+=("${args[$((i+1))]:-}") ;;
+    --clear-token) clears+=("${args[$((i+1))]:-}") ;;
+  esac
+done
+
+protocol=${FM_FAKE_HERDR_PROTOCOL:-16}
+require_presentation() {
+  [ "$protocol" -ge 16 ] && return 0
+  printf '{"error":{"code":"unknown_method"}}\n' >&2
+  exit 1
+}
+
+case "$cmd $sub" in
+  'status --json')
+    printf '{"client":{"version":"0.7.4","protocol":%s},"server":{"running":true}}\n' "$protocol"
+    ;;
+  'workspace list') query '{result:{workspaces:.workspaces}}' ;;
+  'workspace create')
+    n=$(query -r .next); ws="w$n"; tab="$ws:t1"; pane="$ws:p1"
+    query --arg ws "$ws" --arg label "$label" --arg tab "$tab" --arg pane "$pane" --arg cwd "$cwd" '
+      .next += 1 |
+      .workspaces += [{workspace_id:$ws,label:$label,tokens:{}}] |
+      .tabs += [{workspace_id:$ws,tab_id:$tab,pane_id:$pane,label:"1",cwd:$cwd,tokens:{}}]' | save
+    jq -n --arg ws "$ws" --arg tab "$tab" --arg pane "$pane" \
+      '{result:{workspace:{workspace_id:$ws},tab:{tab_id:$tab},root_pane:{pane_id:$pane}}}'
+    ;;
+  'workspace report-metadata')
+    require_presentation
+    target=${3:-}
+    for token in "${tokens[@]}"; do
+      key=${token%%=*}; value=${token#*=}
+      query --arg id "$target" --arg key "$key" --arg value "$value" \
+        '.workspaces |= map(if .workspace_id == $id then (.tokens[$key]=$value) else . end)' | save
+    done
+    ;;
+  'workspace rename')
+    require_presentation
+    target=${3:-}; value=${4:-}
+    query --arg id "$target" --arg value "$value" \
+      '.workspaces |= map(if .workspace_id == $id then .label=$value else . end)' | save
+    ;;
+  'tab list') query --arg ws "$workspace" '{result:{tabs:[.tabs[]|select(.workspace_id==$ws)]}}' ;;
+  'tab create')
+    n=$(query -r .next); tab="$workspace:t$n"; pane="$workspace:p$n"
+    query --arg ws "$workspace" --arg tab "$tab" --arg pane "$pane" --arg label "$label" --arg cwd "$cwd" '
+      .next += 1 |
+      .tabs += [{workspace_id:$ws,tab_id:$tab,pane_id:$pane,label:$label,cwd:$cwd,tokens:{}}]' | save
+    jq -n --arg tab "$tab" --arg pane "$pane" '{result:{tab:{tab_id:$tab},root_pane:{pane_id:$pane}}}'
+    ;;
+  'tab rename')
+    require_presentation
+    target=${3:-}; value=${4:-}
+    query --arg id "$target" --arg value "$value" \
+      '.tabs |= map(if .tab_id == $id then .label=$value else . end)' | save
+    ;;
+  'tab close')
+    target=${3:-}
+    query --arg id "$target" '.tabs |= map(select(.tab_id != $id))' | save
+    ;;
+  'pane list')
+    query --arg ws "$workspace" '{result:{panes:[.tabs[]|select(.workspace_id==$ws)|{workspace_id,tab_id,pane_id,tokens}]}}'
+    ;;
+  'pane report-metadata')
+    require_presentation
+    target=${3:-}
+    for token in "${tokens[@]}"; do
+      key=${token%%=*}; value=${token#*=}
+      query --arg id "$target" --arg key "$key" --arg value "$value" \
+        '.tabs |= map(if .pane_id == $id then (.tokens[$key]=$value) else . end)' | save
+    done
+    for key in ${clears[@]+"${clears[@]}"}; do
+      query --arg id "$target" --arg key "$key" \
+        '.tabs |= map(if .pane_id == $id then .tokens |= del(.[$key]) else . end)' | save
+    done
+    ;;
+  'pane get')
+    target=${3:-}
+    query --arg id "$target" '{result:{pane:(.tabs[]|select(.pane_id==$id)|{pane_id,workspace_id,tab_id,foreground_cwd:.cwd,cwd:.cwd})}}'
+    ;;
+  'pane run')
+    target=${3:-}; command=${4:-}
+    if [ "$command" = 'treehouse get' ]; then
+      project=$(query -r --arg id "$target" '.tabs[]|select(.pane_id==$id)|.cwd')
+      safe=${target//[:\/]/_}; wt="$FM_FAKE_WT_ROOT/$safe"
+      git -C "$project" worktree add -q --detach "$wt" HEAD
+      query --arg id "$target" --arg wt "$wt" \
+        '.tabs |= map(if .pane_id == $id then .cwd=$wt else . end)' | save
+    fi
+    ;;
+  'pane close')
+    target=${3:-}
+    query --arg id "$target" '.tabs |= map(select(.pane_id != $id))' | save
+    ;;
+  'pane read'|'pane send-text'|'pane send-keys') : ;;
+  'agent get') printf '{"result":{"agent":{"agent":"pi","agent_status":"idle"}}\n' ;;
+  *) : ;;
+esac
+SH
+chmod +x "$FAKEBIN/herdr" "$FAKEBIN/treehouse"
+
+make_project() {  # <slug>
+  local dir="$TMP_ROOT/$1"
+  fm_git_init_commit "$dir"
+  printf '%s' "$dir"
+}
+
+JOURNEY=$(make_project your-magical-journey)
+ARTEVO=$(make_project artevo)
+for id in journey-single journey-batch-one journey-batch-two artevo-single; do
+  mkdir -p "$HOME_FIX/data/$id"
+  printf 'fake spawn instructions for %s\n' "$id" > "$HOME_FIX/data/$id/brief.md"
+done
+cat > "$HOME_FIX/data/projects.md" <<'EOF'
+- your-magical-journey [local-only] - Journey
+- artevo [local-only] - Artevo
+EOF
+cat > "$HOME_FIX/data/backlog.md" <<'EOF'
+- [ ] journey-single - Validate GPS triggers across all seven Amsterdam stops (repo: your-magical-journey)
+- [ ] journey-batch-one - Rebaseline the Your Magical Journey launch plan with a date (repo: your-magical-journey)
+- [ ] journey-batch-two - Audit the Journey release checklist (repo: your-magical-journey)
+- [ ] artevo-single - Align Artevo launch surfaces (repo: artevo)
+EOF
+cat > "$TMP_ROOT/states" <<'EOF'
+journey-single=working
+journey-batch-one=parked
+journey-batch-two=working
+artevo-single=blocked
+EOF
+
+run_spawn() {
+  PATH="$FAKEBIN:$PATH" \
+    FM_HOME="$HOME_FIX" \
+    FM_ROOT_OVERRIDE="$ROOT" \
+    FM_SPAWN_NO_GUARD=1 \
+    FM_FAKE_HERDR_STATE="$HERDR_STATE" \
+    FM_FAKE_HERDR_LOG="$HERDR_LOG" \
+    FM_FAKE_WT_ROOT="$WT_ROOT" \
+    FM_VISIBLE_STATE_FILE="$TMP_ROOT/states" \
+    HERDR_SESSION=fm-lab-fake-presentation \
+    "$ROOT/bin/fm-spawn.sh" "$@"
+}
+
+run_spawn journey-single "$JOURNEY" --harness pi --backend herdr >/dev/null \
+  || fail 'single Journey Herdr spawn failed'
+run_spawn \
+  "journey-batch-one=$JOURNEY" \
+  "journey-batch-two=$JOURNEY" \
+  --scout --harness codex --backend herdr >/dev/null \
+  || fail 'batch Journey Herdr spawn failed'
+run_spawn artevo-single "$ARTEVO" --harness codex --backend herdr --outcome 'Align Artevo launch surfaces' >/dev/null \
+  || fail 'concurrent Artevo Herdr spawn failed'
+
+journey_path=$(cd "$JOURNEY" && pwd -P)
+artevo_path=$(cd "$ARTEVO" && pwd -P)
+home_path=$(cd "$HOME_FIX" && pwd -P)
+journey_key="path-v1:$(printf '%s' "$journey_path" | git -C "$ROOT" hash-object --stdin)"
+artevo_key="path-v1:$(printf '%s' "$artevo_path" | git -C "$ROOT" hash-object --stdin)"
+home_key="path-v1:$(printf '%s' "$home_path" | git -C "$ROOT" hash-object --stdin)"
+workspace_count=$(jq '.workspaces|length' "$HERDR_STATE")
+[ "$workspace_count" -eq 2 ] || fail "expected one workspace per project, got $workspace_count"
+journey_ws=$(jq -r --arg owner "$home_key" --arg project "$journey_key" \
+  '.workspaces[]|select(.tokens.fm_owner==$owner and .tokens.fm_project==$project)|.workspace_id' "$HERDR_STATE")
+artevo_ws=$(jq -r --arg owner "$home_key" --arg project "$artevo_key" \
+  '.workspaces[]|select(.tokens.fm_owner==$owner and .tokens.fm_project==$project)|.workspace_id' "$HERDR_STATE")
+[ -n "$journey_ws" ] && [ -n "$artevo_ws" ] && [ "$journey_ws" != "$artevo_ws" ] \
+  || fail 'concurrent project workspaces did not get distinct hidden identities'
+[ "$(jq --arg ws "$journey_ws" '[.tabs[]|select(.workspace_id==$ws)]|length' "$HERDR_STATE")" -eq 3 ] \
+  || fail 'single and batch Journey spawns did not converge on one project workspace'
+assert_contains "$(jq -r --arg ws "$journey_ws" '.workspaces[]|select(.workspace_id==$ws)|.label' "$HERDR_STATE")" \
+  'Your Magical Journey' 'Journey workspace lost its human project name'
+assert_contains "$(jq -r --arg ws "$artevo_ws" '.workspaces[]|select(.workspace_id==$ws)|.label' "$HERDR_STATE")" \
+  'Artevo' 'Artevo workspace lost its human project name'
+
+labels=$(jq -r '.tabs[].label' "$HERDR_STATE")
+assert_contains "$labels" 'WORKER · Validate GPS triggers across all seven Amsterdam stops · 🔵 WORKING' \
+  'single spawn did not render backlog outcome and authoritative state'
+assert_contains "$labels" 'WORKER · Rebaseline the Your Magical Journey launch plan with a date · 🟣 NEEDS LARS' \
+  'first batch scout did not render its distinct outcome'
+assert_contains "$labels" 'WORKER · Audit the Journey release checklist · 🔵 WORKING' \
+  'second batch scout did not render its distinct outcome'
+assert_contains "$labels" 'WORKER · Align Artevo launch surfaces · 🟠 BLOCKED' \
+  'concurrent project explicit outcome did not render'
+for id in journey-single journey-batch-one journey-batch-two artevo-single; do
+  [ "$(jq -r --arg id "$id" '.tabs[]|select(.tokens.fm_task_id==$id)|.tokens.fm_task_id' "$HERDR_STATE")" = "$id" ] \
+    || fail "spawned pane missing hidden fm_task_id=$id"
+done
+assert_contains "$(cat "$HOME_FIX/state/journey-single.meta")" 'harness=pi' 'Pi runtime was not preserved'
+assert_contains "$(cat "$HOME_FIX/state/journey-batch-one.meta")" 'harness=codex' 'Codex runtime was not preserved'
+assert_contains "$(cat "$HOME_FIX/state/journey-single.meta")" 'kind=ship' 'ship kind was not preserved'
+assert_contains "$(cat "$HOME_FIX/state/journey-batch-one.meta")" 'kind=scout' 'scout kind was not preserved'
+pass 'fm-spawn fake Herdr E2E: single, batch, projects, axes, human labels, outcomes, states, and hidden ids converge'
+
+mkdir -p "$HOME_FIX/data/journey-protocol14"
+printf 'fake spawn instructions for journey-protocol14\n' > "$HOME_FIX/data/journey-protocol14/brief.md"
+cat >> "$HOME_FIX/data/backlog.md" <<'EOF'
+- [ ] journey-protocol14 - Keep spawning on an old Herdr build (repo: your-magical-journey)
+EOF
+: > "$HERDR_LOG"
+FM_FAKE_HERDR_PROTOCOL=14 run_spawn journey-protocol14 "$JOURNEY" --harness pi --backend herdr >/dev/null \
+  || fail 'a protocol-14 Herdr build no longer spawns through the label fallback'
+legacy_ws=$(jq -r '.workspaces[]|select(.label=="firstmate")|.workspace_id' "$HERDR_STATE")
+[ -n "$legacy_ws" ] || fail 'protocol-14 fallback did not use the legacy per-home workspace label'
+[ "$(jq -r --arg ws "$legacy_ws" '.tabs[]|select(.workspace_id==$ws)|.label' "$HERDR_STATE")" = 'fm-journey-protocol14' ] \
+  || fail 'protocol-14 fallback tab did not keep the legacy fm-<id> label'
+[ "$(jq -r --arg ws "$legacy_ws" '.workspaces[]|select(.workspace_id==$ws)|.tokens|length' "$HERDR_STATE")" -eq 0 ] \
+  || fail 'protocol-14 fallback attempted hidden workspace identity tokens'
+legacy_log=$(cat "$HERDR_LOG")
+assert_not_contains "$legacy_log" 'report-metadata' 'protocol-14 fallback still called report-metadata'
+assert_not_contains "$legacy_log" 'rename' 'protocol-14 fallback still renamed a tab or workspace'
+legacy_meta=$(cat "$HOME_FIX/state/journey-protocol14.meta")
+assert_contains "$legacy_meta" 'backend=herdr' 'protocol-14 fallback did not record its backend'
+assert_not_contains "$legacy_meta" 'herdr_workspace_managed' 'protocol-14 fallback claimed a managed workspace'
+pass 'fm-spawn fake Herdr E2E: a protocol-14 build spawns through the prior label-based flow untouched by presentation'

--- a/tests/fm-visible-status.test.sh
+++ b/tests/fm-visible-status.test.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# Focused behavior coverage for authoritative Herdr worker presentation.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-visible-status)
+HOME_FIX="$TMP_ROOT/home"
+FAKEBIN=$(fm_fakebin "$TMP_ROOT")
+LOG="$TMP_ROOT/herdr.log"
+STATES="$TMP_ROOT/states"
+mkdir -p "$HOME_FIX/state" "$HOME_FIX/data" "$TMP_ROOT/worktrees"
+
+cat > "$FAKEBIN/herdr" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$FM_VISIBLE_HERDR_LOG"
+exit 0
+SH
+cat > "$FAKEBIN/pi" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+chmod +x "$FAKEBIN/herdr" "$FAKEBIN/pi"
+
+make_worktree() {  # <name> <branch-or-detached>
+  local wt="$TMP_ROOT/worktrees/$1"
+  fm_git_init_commit "$wt"
+  if [ "$2" = detached ]; then
+    git -C "$wt" checkout -q --detach
+  else
+    git -C "$wt" checkout -qb "$2"
+  fi
+  printf '%s' "$wt"
+}
+
+write_task() {  # <id> <project-key> <project-name> <ws> <tab> <pane> <wt> <kind> <harness> <model> [managed]
+  fm_write_meta "$HOME_FIX/state/$1.meta" \
+    "window=fm-lab-visible:$6" \
+    "worktree=$7" \
+    "project=$2" \
+    "harness=$9" \
+    "model=${10}" \
+    "kind=$8" \
+    "backend=herdr" \
+    "herdr_session=fm-lab-visible" \
+    "herdr_workspace_id=$4" \
+    "herdr_tab_id=$5" \
+    "herdr_pane_id=$6" \
+    "herdr_workspace_managed=${11:-1}" \
+    "herdr_project_name=$3" \
+    "herdr_project_key=$2"
+}
+
+JOURNEY_SHIP=$(make_worktree journey-ship fm/journey-release-q7)
+JOURNEY_SCOUT=$(make_worktree journey-scout detached)
+ARTEVO_BLOCK=$(make_worktree artevo-block fm/artevo-block-p2)
+ARTEVO_FAIL=$(make_worktree artevo-fail fm/artevo-fail-z9)
+ARTEVO_PAUSE=$(make_worktree artevo-pause fm/artevo-pause-r2)
+ARTEVO_READY=$(make_worktree artevo-ready fm/artevo-ready-r8)
+LEGACY_WT=$(make_worktree legacy fm/legacy-k1)
+write_task journey-ship /projects/your-magical-journey 'Your Magical Journey' w1 t1 w1:p1 "$JOURNEY_SHIP" ship pi default
+write_task journey-scout /projects/your-magical-journey 'Your Magical Journey' w1 t2 w1:p2 "$JOURNEY_SCOUT" scout codex gpt-5.6
+write_task artevo-block /projects/artevo Artevo w2 t3 w2:p1 "$ARTEVO_BLOCK" ship pi default
+write_task artevo-fail /projects/artevo Artevo w2 t4 w2:p2 "$ARTEVO_FAIL" ship codex gpt-5.6
+write_task artevo-pause /projects/artevo Artevo w2 t5 w2:p3 "$ARTEVO_PAUSE" scout pi default
+write_task artevo-ready /projects/artevo Artevo w2 t6 w2:p4 "$ARTEVO_READY" ship codex gpt-5.6
+write_task legacy-task /projects/legacy 'Legacy Project' oldw oldt oldw:p1 "$LEGACY_WT" ship pi default 0
+fm_write_meta "$HOME_FIX/state/secondmate-task.meta" \
+  "window=fm-lab-visible:sm:p1" \
+  "worktree=$HOME_FIX" \
+  "project=$HOME_FIX" \
+  "harness=pi" \
+  "kind=secondmate" \
+  "backend=herdr" \
+  "herdr_session=fm-lab-visible" \
+  "herdr_workspace_id=smw" \
+  "herdr_tab_id=smt" \
+  "herdr_pane_id=sm:p1" \
+  "home=$HOME_FIX"
+
+cat > "$HOME_FIX/data/backlog.md" <<'EOF'
+- [ ] journey-ship - Ship the Journey release (repo: your-magical-journey)
+- [ ] journey-scout - Validate the Journey route (repo: your-magical-journey)
+- [ ] artevo-block - Unblock Artevo deploy (repo: artevo)
+- [ ] artevo-fail - Repair Artevo failure (repo: artevo)
+- [ ] artevo-pause - Wait for Artevo upstream (repo: artevo)
+- [ ] artevo-ready - Prepare Artevo release (repo: artevo)
+- [ ] legacy-task - Refresh legacy task safely (repo: legacy)
+EOF
+cat > "$STATES" <<'EOF'
+journey-ship=working
+journey-scout=parked
+artevo-block=blocked
+artevo-fail=failed
+artevo-pause=paused
+artevo-ready=done
+legacy-task=working
+EOF
+
+run_all() {
+  : > "$LOG"
+  PATH="$FAKEBIN:$PATH" \
+    FM_HOME="$HOME_FIX" \
+    FM_VISIBLE_STATE_FILE="$STATES" \
+    FM_VISIBLE_HERDR_LOG="$LOG" \
+    FM_BACKEND_HERDR_PRESENTATION_FORCE=1 \
+    HERDR_ENV=1 \
+    HERDR_SESSION=fm-lab-visible \
+    HERDR_PANE_ID=ordinary-worker:p9 \
+    "$ROOT/bin/fm-visible-status.sh" --all
+}
+
+test_tasks_projects_axes_and_states() {
+  local out
+  run_all
+  out=$(cat "$LOG")
+  assert_contains "$out" 'tab rename t1 WORKER · Ship the Journey release · 🔵 WORKING' \
+    'Pi ship did not receive the worker contract'
+  assert_contains "$out" 'tab rename t2 WORKER · Validate the Journey route · 🟣 NEEDS LARS' \
+    'Codex scout did not receive the same worker contract'
+  assert_contains "$out" '--display-agent pi · fm/journey-release-q7' \
+    'Pi runtime or named branch was not projected'
+  assert_contains "$out" '--display-agent codex/gpt-5.6 · detached' \
+    'Codex model or detached scout state was not projected'
+  assert_contains "$out" 'workspace rename w1 Your Magical Journey · 🟣 1 NEEDS LARS · 🔵 1 WORKING' \
+    'Journey tasks did not aggregate in one human project workspace'
+  assert_contains "$out" 'workspace rename w2 Artevo · 🔴 1 FAILED · 🟠 1 BLOCKED · 🟡 1 WAITING · 🟢 1 READY' \
+    'authoritative states were not prioritized for the concurrent Artevo project'
+  assert_contains "$out" '--token fm_task_id=journey-ship' \
+    'hidden durable task identity was not preserved'
+  assert_not_contains "$out" 'tab rename t1 fm-journey-ship' \
+    'durable task id leaked into a new human-facing tab'
+  pass 'visible status: concurrent projects, ship/scout, Pi/Codex, outcomes, runtime/model, branches, and authoritative states'
+}
+
+test_legacy_refresh_and_primary_boundary() {
+  local out
+  run_all
+  out=$(cat "$LOG")
+  assert_contains "$out" 'tab rename oldt WORKER · Refresh legacy task safely · 🔵 WORKING' \
+    'legacy task was not safely refreshed by recorded tab id'
+  assert_not_contains "$out" 'workspace rename oldw' \
+    'legacy mixed workspace was renamed to one task project'
+  assert_not_contains "$out" 'FIRSTMATE' \
+    'ordinary worker environment acquired the primary role'
+  assert_not_contains "$out" 'ordinary-worker:p9' \
+    'worker environment pane was mistaken for the primary pane'
+  pass 'visible status: legacy mixed workspace stays in place and worker environments never project FIRSTMATE'
+}
+
+test_secondmate_keeps_legacy_presentation() {
+  local out
+  run_all
+  out=$(cat "$LOG")
+  assert_not_contains "$out" 'tab rename smt' \
+    'a secondmate tab was renamed to the WORKER convention'
+  assert_not_contains "$out" 'sm:p1' \
+    'a secondmate pane received worker presentation metadata'
+  pass 'visible status: kind=secondmate keeps its legacy fm-<id> tab untouched'
+}
+
+test_incapable_build_projects_nothing() {
+  : > "$LOG"
+  PATH="$FAKEBIN:$PATH" \
+    FM_HOME="$HOME_FIX" \
+    FM_VISIBLE_STATE_FILE="$STATES" \
+    FM_VISIBLE_HERDR_LOG="$LOG" \
+    FM_BACKEND_HERDR_PRESENTATION_FORCE=0 \
+    HERDR_SESSION=fm-lab-visible \
+    "$ROOT/bin/fm-visible-status.sh" --all
+  [ -s "$LOG" ] && fail 'a below-capability Herdr build still received presentation calls'
+  pass 'visible status: below the presentation capability no tab or workspace is touched'
+}
+
+test_cleanup_keeps_stable_target_fallback() {
+  : > "$LOG"
+  PATH="$FAKEBIN:$PATH" FM_HOME="$HOME_FIX" FM_VISIBLE_HERDR_LOG="$LOG" \
+    FM_BACKEND_HERDR_PRESENTATION_FORCE=1 \
+    "$ROOT/bin/fm-visible-status.sh" --clear journey-ship
+  assert_contains "$(cat "$LOG")" '--clear-title --clear-display-agent --clear-state-labels' \
+    'cleanup did not clear presentation metadata'
+  assert_contains "$(cat "$LOG")" 'tab rename t1 fm-journey-ship' \
+    'cleanup did not restore the legacy readable fallback before endpoint close'
+  [ -f "$HOME_FIX/state/journey-ship.meta" ] || fail 'presentation cleanup changed durable task metadata'
+  pass 'visible status: cleanup clears cosmetics while preserving stable metadata and a legacy title fallback'
+}
+
+test_tasks_projects_axes_and_states
+test_legacy_refresh_and_primary_boundary
+test_secondmate_keeps_legacy_presentation
+test_incapable_build_projects_nothing
+test_cleanup_keeps_stable_target_fallback


### PR DESCRIPTION
## Summary

Managed Herdr ship/scout tasks now get human-readable workspace and tab presentation while durable backend ids remain the control plane.

- One workspace per `(physical FM_HOME, physical project)` with hidden ownership tokens; visible labels are mutable presentation only
- Tab titles carry task outcome / state without replacing recorded ids
- Capability-gated on Herdr protocol 16 via `fm_backend_herdr_presentation_capable`; older builds keep the prior label-based spawn flow instead of refusing
- `kind=secondmate` tasks keep legacy `fm-<id>` tabs and are never restyled
- Worker presentation never emits `FIRSTMATE` or `LAB` roles

New helpers: `bin/fm-project-display-name.sh`, `bin/fm-visible-status.sh`, `bin/fm-task-outcome.sh`.

## Test plan

- [x] `bin/fm-lint.sh`
- [x] `tests/fm-project-presentation.test.sh`
- [x] `tests/fm-visible-status.test.sh`
- [x] `tests/fm-spawn-herdr-presentation.test.sh`
- [x] `tests/fm-backend-herdr.test.sh`
