### PR TITLE
docs(frontend): add planned visual frontend contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ firstmate is an agent distro for running a crew of agents.
 An agent distro is a portable directory of instructions, skills, tooling, policies, and state conventions that turns a general-purpose agent into a specialized one.
 There is no app to install: the cloned repo is the distro - `AGENTS.md`, bundled firstmate skills, and helper scripts that any terminal coding agent can follow.
 Launching a supported harness inside it instantiates your first mate - and makes you the captain.
+The current visible product is terminal-native.
+A dedicated captain-facing visual frontend is planned in [`docs/visual-frontend.md`](docs/visual-frontend.md), but is not shipped yet.
 
 ## Features
 
@@ -155,6 +157,7 @@ Optional secondmates extend this to persistent second mates, dispatch profiles l
 `codex-app` is not a runtime backend yet; [docs/codex-app-backend.md](docs/codex-app-backend.md) owns the Codex App boundary.
 
 Full architecture - the supervision engine, worktree isolation, secondmates, dispatch profiles, project modes, optional X mode, fleet sync, and self-update - is in [docs/architecture.md](docs/architecture.md).
+The planned visual observer/control surface is defined separately in [docs/visual-frontend.md](docs/visual-frontend.md).
 
 ## Built-in skills
 
@@ -191,6 +194,7 @@ Firstmate's skills live in two separate places with different audiences:
 - [docs/orca-backend.md](docs/orca-backend.md) - setup guide for the experimental Orca backend, plus its lifecycle notes and known gaps.
 - [docs/cmux-backend.md](docs/cmux-backend.md) - setup guide for the experimental cmux backend, plus its verification notes and known gaps.
 - [docs/codex-app-backend.md](docs/codex-app-backend.md) - Codex App backend boundary, evidence, and rollout contract.
+- [docs/visual-frontend.md](docs/visual-frontend.md) - planned captain-facing visual frontend contract and rollout.
 - [docs/turnend-guard.md](docs/turnend-guard.md) - the primary session's structural "no turn ends blind" backstop: verified per-harness hook mechanisms, scoping, loop safety, and fail-open tradeoffs.
 - [docs/supervision-protocols/](docs/supervision-protocols/) - rendered primary-harness watcher protocols for Claude, Codex, OpenCode, Pi, Grok, and unknown harness fallback.
 - [docs/scripts.md](docs/scripts.md) - the `bin/` toolbelt reference.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -96,6 +96,7 @@ Orca is experimental and selected only explicitly: Orca owns both worktree and t
 cmux is experimental, GUI-first, macOS-only, and can be selected explicitly or by runtime auto-detection from its primary `CMUX_WORKSPACE_ID` marker plus documented fallback signals: treehouse remains its worktree provider (cmux is a session provider only, like herdr/zellij), and its full verification - the socket access setup requirement with Automation mode recommended, the read-screen-fails-on-a-fresh-surface finding, the close-surface-refuses-on-the-last-surface finding, the source-verified runtime marker and fallback behavior, and known gaps - is recorded in `docs/cmux-backend.md`.
 cmux's container shape is one workspace per task with one surface, no per-home container split; workspace titles are scoped by the active home label plus a short hash of the resolved `FM_ROOT` path, and `--secondmate` spawns are refused, mirroring Orca.
 Codex App support is recorded in `docs/codex-app-backend.md`; it is not selectable as a runtime backend.
+A captain-facing visual frontend is a separate planned layer above these backends, not another backend itself; its contract lives in `docs/visual-frontend.md`.
 
 ## Worktrees, not branches in your checkout
 

--- a/docs/visual-frontend.md
+++ b/docs/visual-frontend.md
@@ -1,0 +1,215 @@
+# Visual frontend contract
+
+Status: planned, not implemented.
+
+This document defines the visual frontend for firstmate.
+It exists to answer one recurring confusion clearly: firstmate already has visible surfaces, but they are terminal-native session backends, not a dedicated web or desktop dashboard.
+The visual frontend defined here is a captain-facing observer and control surface layered on top of the existing firstmate runtime.
+It is not a new runtime backend, not a second orchestration system, and not a second truth source.
+
+## Why there is no visual frontend today
+
+Today, firstmate's visible operating surface is the backend itself: tmux windows, herdr tabs, zellij tabs, cmux workspaces, or Orca terminals.
+That is the current product.
+It is why the README says there is no app to install.
+
+Codex App is also not the missing visual frontend.
+`codex-app` is currently blocked as a shell-callable runtime backend, which is a different concern from rendering firstmate state in a visual surface.
+
+## Product goal
+
+The visual frontend should give the captain one place to:
+
+- see fleet state at a glance
+- inspect one task without reading raw state files
+- review captain-owned decisions and approvals
+- send bounded steering actions through existing firstmate commands
+- open the underlying terminal surface when deep work or trust requires it
+
+The frontend is successful when it reduces tab-juggling without weakening firstmate's existing safety boundaries.
+
+## Non-goals
+
+- It does not replace tmux, herdr, zellij, cmux, or Orca as task endpoints.
+- It does not become a new runtime backend.
+- It does not write directly into project repos.
+- It does not invent a second task state model beside firstmate's existing disk and script contracts.
+- It does not bypass `fm-spawn`, `fm-send`, `fm-crew-state`, `fm-peek`, `fm-pr-merge`, `fm-merge-local`, or teardown guards.
+- It does not require Codex App backend support to exist first.
+
+## Authority boundary
+
+The frontend is a view and control layer over existing firstmate contracts.
+
+Read authority:
+
+- `bin/fm-fleet-snapshot.sh --json` is the primary read model for fleet overview.
+- `bin/fm-crew-state.sh <id>` is the authority for a task's current state.
+- `bin/fm-peek.sh <id>` is the bounded transcript and terminal preview surface.
+- existing docs and task reports remain the authority for human-readable detail
+
+Write and action authority:
+
+- `bin/fm-send.sh`
+- `bin/fm-spawn.sh`
+- `bin/fm-wake-drain.sh`
+- `bin/fm-pr-merge.sh`
+- `bin/fm-merge-local.sh`
+- `bin/fm-teardown.sh`
+
+The frontend may shell these commands or call a thin local wrapper around them.
+It must never reimplement their state transitions in frontend code.
+
+## Required screens
+
+### 1. Fleet overview
+
+Purpose: one-screen captain summary.
+
+Must show:
+
+- active work
+- captain-owned decisions
+- blocked items
+- recent landed work
+- watcher and away-mode status
+- backend type per live task
+
+Primary source: `bin/fm-fleet-snapshot.sh --json`.
+
+### 2. Task detail
+
+Purpose: inspect one task end to end.
+
+Must show:
+
+- task identity and brief summary
+- current state from `bin/fm-crew-state.sh`
+- bounded recent status history
+- bounded peek output from `bin/fm-peek.sh`
+- linked PR or report when present
+- exact backend target metadata when relevant
+
+### 3. Captain queue
+
+Purpose: separate "needs my decision now" from ordinary ongoing work.
+
+Must show only captain-owned actions such as:
+
+- merge approval
+- local-only landing approval
+- ask-user findings
+- explicit decisions held through the decision-hold lifecycle
+
+This surface should be a projection of existing lifecycle data, not a new inbox format.
+
+### 4. Action rail
+
+Purpose: allow safe, narrow control without opening the shell first.
+
+Initial allowed actions:
+
+- send a message to a task
+- send `Enter`, `Escape`, or `Ctrl-C` where already supported
+- wake drain
+- open report or PR
+- open the underlying backend target
+
+Every action must show:
+
+- exact command being invoked
+- success or failure
+- any changed durable state the command reported
+
+### 5. Backend inspector
+
+Purpose: make the terminal-native surface legible rather than hidden.
+
+Must show:
+
+- which backend owns the task
+- target identity such as tmux window, herdr pane, zellij pane, Orca terminal, or cmux workspace/surface
+- whether the backend is directly inspectable from the frontend or must be opened externally
+
+## UX principles
+
+- Read-only first.
+- One screen should answer "what needs me now?" in under five seconds.
+- The frontend should expose the underlying truth path, not hide it.
+- Every destructive or approval-bearing action should keep firstmate's existing friction and wording.
+- When state is unknown, the UI should say unknown, not guess.
+- A task detail page should always offer a direct jump to the real terminal surface.
+
+## Recommended implementation shape
+
+The first implementation should be a local web app, not a runtime backend.
+
+Recommended stack:
+
+- React
+- TypeScript
+- Vite
+
+Reasoning:
+
+- Vite is enough for a local dashboard.
+- It keeps the surface optional and decoupled from firstmate's bash runtime.
+- It avoids turning the frontend into a server-heavy product before the control contract is proven.
+
+The frontend should consume JSON from a thin local adapter layer that shells the authoritative `bin/` commands and returns normalized results.
+That adapter is allowed to be small and boring.
+It is not allowed to become a second orchestration engine.
+
+## Rollout phases
+
+### Phase 1. Read-only dashboard
+
+Deliver:
+
+- Fleet overview
+- Task detail
+- Captain queue
+
+No mutating actions beyond open-in-terminal or open-PR/report links.
+
+### Phase 2. Safe steering
+
+Deliver:
+
+- send text
+- send supported keys
+- wake drain
+
+All actions route through existing scripts and echo exact results.
+
+### Phase 3. Approval actions
+
+Deliver:
+
+- merge PR through `bin/fm-pr-merge.sh`
+- land local-only work through `bin/fm-merge-local.sh`
+- teardown through `bin/fm-teardown.sh`
+
+Keep current approval authority unchanged.
+
+### Phase 4. Rich backend affordances
+
+Optional, backend-specific enhancements such as:
+
+- deep links into terminal apps
+- attached screenshot previews where capture is safe and explicit
+- backend health diagnostics
+
+These are optional because backend safety and focus behavior differ materially across tmux, herdr, Orca, cmux, and zellij.
+
+## Relationship to Codex App
+
+The visual frontend can exist before `codex-app` backend support.
+
+If Codex Desktop later exposes a supported shell-callable bridge, that work should plug into the same frontend contract in two distinct ways:
+
+- as one more backend that firstmate can supervise
+- as one possible host surface for the visual frontend
+
+Those are separate rollout decisions.
+Neither one should be smuggled in as the other.


### PR DESCRIPTION
## Summary

Adds `docs/visual-frontend.md`, a contract for a planned captain-facing visual frontend for firstmate.

The frontend is defined strictly as a view and control layer over existing firstmate contracts:
- It is not a new runtime backend, not a second orchestration system, and not a second truth source.
- Read authority stays on `fm-fleet-snapshot.sh`, `fm-crew-state.sh`, and `fm-peek.sh`; write/action authority stays on the existing `fm-*` scripts.
- Non-goals explicitly forbid writing into project repos, reimplementing state transitions, or requiring Codex App backend support to exist first.

Per the one-owner rule, the full contract lives only in `docs/visual-frontend.md`; `README.md` and `docs/architecture.md` gain one-line cross-references clarifying the current product is terminal-native and this layer is planned, not shipped.

## Verification

- `bin/fm-lint.sh` exits `0` (ShellCheck 0.11.0, pinned 0.11.0). No shell changes in this PR; docs only.
- Tracked Markdown follows repo style: one sentence per line, plain dashes, no em dashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)