### PR TITLE
feat(watch): follow GitLab merge requests in the merge watch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,7 +86,7 @@ state/               volatile runtime signals; gitignored
   <id>.status        appended by crewmates: "<state>: <note>" wake-event lines, not current-state truth
   <id>.turn-ended    touched by turn-end hooks
   <id>.grok-turnend-token   firstmate-owned grok hook registry token for the task; removed by teardown
-  <id>.meta          written by fm-spawn: window=, worktree=, project=, harness=, model=, effort=, kind=, mode=, yolo=, tasktmp=; kind=secondmate also records home= and projects=; a non-default runtime backend records further backend-specific fields (docs/configuration.md "Runtime backend"; bin/fm-backend.sh, section 8); fm-pr-check, including through fm-pr-merge, records one canonical pr= and GitHub's pr_head= when available; fm-x-link appends x_request=, x_request_ts=, x_followups=, and optional x_platform=/x_reply_max_chars= for an X-mode-originated task (section 14)
+  <id>.meta          written by fm-spawn: window=, worktree=, project=, harness=, model=, effort=, kind=, mode=, yolo=, tasktmp=; kind=secondmate also records home= and projects=; a non-default runtime backend records further backend-specific fields (docs/configuration.md "Runtime backend"; bin/fm-backend.sh, section 8); fm-pr-check, including through fm-pr-merge, records one canonical pr= and the forge's pr_head= when available; fm-x-link appends x_request=, x_request_ts=, x_followups=, and optional x_platform=/x_reply_max_chars= for an X-mode-originated task (section 14)
   <id>.herdr-presentation  quarantinable attempt journal for Herdr's optional visual projection; never task or endpoint authority; see docs/herdr-backend.md "Optional disposable single-task presentation spaces"
   <id>.check.sh      authenticated slow poll; the watcher dispatches validated PR data and the byte-identified X shim through trusted repository scripts, runs registered custom checks from hash-validated private snapshots, and rejects every other state check without execution
   <id>.check-trust   private content binding created by fm-check-register.sh for an intentional custom check
@@ -287,7 +287,7 @@ The worker reports the PR when CI first becomes green rather than waiting for me
 ### PR ready, landing, and teardown
 
 For PR-based ship tasks, the ready signal depends on mode: `no-mistakes` reports `done: PR <url> checks green` after CI is green, while `direct-PR` reports `done: PR <url>` after opening the PR.
-Run `bin/fm-pr-check.sh <id> <PR url>` - it records `pr=` and GitHub's `pr_head=` when available in the task's meta and arms the watcher's merge poll.
+Run `bin/fm-pr-check.sh <id> <PR url>` - it records `pr=` and the forge's `pr_head=` when available in the task's meta and arms the watcher's merge poll.
 Tell the captain the PR's full URL, always the complete `https://...` link rather than a bare `#number`, a concise outcome summary, and the no-mistakes risk level when applicable.
 A captain instruction to merge is explicit authority; `yolo` is the only standing routine authority.
 For any custom `state/<id>.check.sh` you write yourself, keep it an ordinary single-link mode-`0700` file, print one line only when firstmate should wake, print nothing otherwise, finish before `FM_CHECK_TIMEOUT`, then bind its current bytes with `bin/fm-check-register.sh <id>` before the watcher may execute it.

--- a/bin/fm-pr-check-migrate.sh
+++ b/bin/fm-pr-check-migrate.sh
@@ -488,20 +488,23 @@ quarantine_tree_repair_and_validate() {
   quarantine_dir_valid
 }
 
+MIGRATION_PROVIDER=
 MIGRATION_URL=
-MIGRATION_OWNER=
-MIGRATION_REPO=
+MIGRATION_HOST=
+MIGRATION_PATH=
 MIGRATION_NUMBER=
 metadata_pr_is_canonical() {
   local meta=$1
+  MIGRATION_PROVIDER=
   MIGRATION_URL=
-  MIGRATION_OWNER=
-  MIGRATION_REPO=
+  MIGRATION_HOST=
+  MIGRATION_PATH=
   MIGRATION_NUMBER=
   fm_pr_metadata_identity_parse "$meta" || return 1
+  MIGRATION_PROVIDER=$FM_PR_META_PROVIDER
   MIGRATION_URL=$FM_PR_META_URL
-  MIGRATION_OWNER=$FM_PR_META_OWNER
-  MIGRATION_REPO=$FM_PR_META_REPO
+  MIGRATION_HOST=$FM_PR_META_HOST
+  MIGRATION_PATH=$FM_PR_META_PATH
   MIGRATION_NUMBER=$FM_PR_META_NUMBER
 }
 
@@ -774,7 +777,7 @@ record_ambiguous_failure() {
 }
 
 canonical_repair_from_pending() {
-  local id=$1 meta data registration url owner repo number check
+  local id=$1 meta data registration provider url host path number check
   meta="$STATE/$id.meta"
   data="$STATE/$id.pr-poll"
   registration="$STATE/$id.pr-poll-registration"
@@ -782,15 +785,16 @@ canonical_repair_from_pending() {
   [ ! -e "$check" ] && [ ! -L "$check" ] || return 1
   quarantined_artifact_exists "$id" check || return 1
   metadata_pr_is_canonical "$meta" || return 1
+  provider=$MIGRATION_PROVIDER
   url=$MIGRATION_URL
-  owner=$MIGRATION_OWNER
-  repo=$MIGRATION_REPO
+  host=$MIGRATION_HOST
+  path=$MIGRATION_PATH
   number=$MIGRATION_NUMBER
   quarantine_artifact "$data" "$id" data || return 1
   quarantine_artifact "$registration" "$id" registration || return 1
   [ ! -e "$data" ] && [ ! -L "$data" ] || return 1
   [ ! -e "$registration" ] && [ ! -L "$registration" ] || return 1
-  fm_pr_poll_prepare "$STATE" "$id" "$url" "$owner" "$repo" "$number" "$TEMPLATE" || return 1
+  fm_pr_poll_prepare "$STATE" "$id" "$provider" "$url" "$host" "$path" "$number" "$TEMPLATE" || return 1
   fm_pr_poll_publish_prepared || return 1
   canonical_terminal_success "$id"
 }
@@ -1028,9 +1032,10 @@ if migration_needed; then
       data="$STATE/$id.pr-poll"
       registration="$STATE/$id.pr-poll-registration"
       if metadata_pr_is_canonical "$meta"; then
+        provider=$MIGRATION_PROVIDER
         url=$MIGRATION_URL
-        owner=$MIGRATION_OWNER
-        repo=$MIGRATION_REPO
+        host=$MIGRATION_HOST
+        path=$MIGRATION_PATH
         number=$MIGRATION_NUMBER
         message="task $id: migration outcome tracking started before legacy poll handling"
         if ! ensure_diagnostic_obligation "$prefix" pending-canonical "$message" \
@@ -1042,7 +1047,7 @@ if migration_needed; then
         if quarantine_artifact "$check" "$prefix" check \
           && quarantine_artifact "$data" "$prefix" data \
           && quarantine_artifact "$registration" "$prefix" registration \
-          && fm_pr_poll_prepare "$STATE" "$id" "$url" "$owner" "$repo" "$number" "$TEMPLATE" \
+          && fm_pr_poll_prepare "$STATE" "$id" "$provider" "$url" "$host" "$path" "$number" "$TEMPLATE" \
           && fm_pr_poll_publish_prepared \
           && complete_canonical_outcome "$id"; then
           :

--- a/bin/fm-pr-check.sh
+++ b/bin/fm-pr-check.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
-# Record a PR-ready task: store one validated canonical pr=<url> and GitHub's
+# Record a PR-ready task: store one validated canonical pr=<url> and the forge's
 # exact pr_head=<sha> when available, then atomically arm a static merge poll.
 # The watcher check source is byte-for-byte bin/fm-pr-poll.sh; task and PR data
 # live only in a private sidecar and are never interpolated into shell source.
+# Accepts a GitHub pull request URL or a GitLab merge request URL, including a
+# self-hosted GitLab instance under nested subgroups; bin/fm-pr-lib.sh owns the
+# accepted URL shapes and the stored identity.
 # Usage: fm-pr-check.sh <task-id> <pr-url>
 set -eu
 
@@ -24,9 +27,10 @@ if ! fm_pr_task_id_valid "$ID" || ! fm_pr_url_parse "$RAW_URL"; then
   echo "error: invalid PR check request" >&2
   exit 2
 fi
+PROVIDER=$FM_PR_PROVIDER
 URL=$FM_PR_URL
-OWNER=$FM_PR_OWNER
-REPO=$FM_PR_REPO
+HOST=$FM_PR_HOST
+PATH_=$FM_PR_PATH
 NUMBER=$FM_PR_NUMBER
 
 # Task-derived paths are constructed only after the canonical ID validation.
@@ -42,13 +46,27 @@ fi
 "$SCRIPT_DIR/fm-pr-check-migrate.sh" --checks-safe || exit 1
 "$FM_ROOT/bin/fm-guard.sh" || true
 
+# Capturing the head commit is optional on both forges: when the tool is absent
+# or the lookup fails, arming still succeeds and only pr_head= is left unset.
 WT=$(grep '^worktree=' "$META" | tail -1 | cut -d= -f2- || true)
 PR_HEAD=
-if [ -n "$WT" ] && [ -d "$WT" ] && command -v gh >/dev/null 2>&1; then
-  if REMOTE_HEAD=$(cd "$WT" && gh pr view "$URL" --json headRefOid -q .headRefOid 2>/dev/null) \
-    && fm_pr_head_valid "$REMOTE_HEAD"; then
-    PR_HEAD=$REMOTE_HEAD
-  fi
+if [ -n "$WT" ] && [ -d "$WT" ]; then
+  case "$PROVIDER" in
+    github)
+      if command -v gh >/dev/null 2>&1 \
+        && REMOTE_HEAD=$(cd "$WT" && gh pr view "$URL" --json headRefOid -q .headRefOid 2>/dev/null) \
+        && fm_pr_head_valid "$REMOTE_HEAD"; then
+        PR_HEAD=$REMOTE_HEAD
+      fi
+      ;;
+    gitlab)
+      if command -v glab-axi >/dev/null 2>&1 \
+        && REMOTE_HEAD=$(cd "$WT" && glab-axi mr view "$URL" --jq .sha 2>/dev/null) \
+        && fm_pr_head_valid "$REMOTE_HEAD"; then
+        PR_HEAD=$REMOTE_HEAD
+      fi
+      ;;
+  esac
 fi
 
 META_TMP=
@@ -58,7 +76,7 @@ pr_check_cleanup() {
 }
 trap pr_check_cleanup EXIT
 trap 'exit 1' HUP INT TERM
-fm_pr_poll_prepare "$STATE" "$ID" "$URL" "$OWNER" "$REPO" "$NUMBER" "$SCRIPT_DIR/fm-pr-poll.sh" \
+fm_pr_poll_prepare "$STATE" "$ID" "$PROVIDER" "$URL" "$HOST" "$PATH_" "$NUMBER" "$SCRIPT_DIR/fm-pr-poll.sh" \
   || { echo "error: could not prepare PR poll" >&2; exit 1; }
 
 META_DEVICE=$(fm_pr_file_device "$META") || exit 1
@@ -76,15 +94,17 @@ printf 'pr=%s\n' "$URL" >> "$META_TMP" || exit 1
 chmod 0600 "$META_TMP" || exit 1
 fm_pr_private_file_valid "$META_TMP" 600 "$STATE_DEVICE" || exit 1
 fm_pr_metadata_identity_parse "$META_TMP" || exit 1
-[ "$FM_PR_META_URL" = "$URL" ] && [ "$FM_PR_META_OWNER" = "$OWNER" ] \
-  && [ "$FM_PR_META_REPO" = "$REPO" ] && [ "$FM_PR_META_NUMBER" = "$NUMBER" ] || exit 1
+[ "$FM_PR_META_PROVIDER" = "$PROVIDER" ] && [ "$FM_PR_META_URL" = "$URL" ] \
+  && [ "$FM_PR_META_HOST" = "$HOST" ] && [ "$FM_PR_META_PATH" = "$PATH_" ] \
+  && [ "$FM_PR_META_NUMBER" = "$NUMBER" ] || exit 1
 fm_pr_regular_destination_on_device_or_absent "$META" "$STATE_DEVICE" || exit 1
 mv -f -- "$META_TMP" "$META" || exit 1
 META_TMP=
 fm_pr_private_file_valid "$META" 600 "$STATE_DEVICE" || exit 1
 fm_pr_metadata_identity_parse "$META" || exit 1
-[ "$FM_PR_META_URL" = "$URL" ] && [ "$FM_PR_META_OWNER" = "$OWNER" ] \
-  && [ "$FM_PR_META_REPO" = "$REPO" ] && [ "$FM_PR_META_NUMBER" = "$NUMBER" ] || exit 1
+[ "$FM_PR_META_PROVIDER" = "$PROVIDER" ] && [ "$FM_PR_META_URL" = "$URL" ] \
+  && [ "$FM_PR_META_HOST" = "$HOST" ] && [ "$FM_PR_META_PATH" = "$PATH_" ] \
+  && [ "$FM_PR_META_NUMBER" = "$NUMBER" ] || exit 1
 
 fm_pr_poll_publish_prepared || {
   echo "error: could not publish PR poll" >&2

--- a/bin/fm-pr-lib.sh
+++ b/bin/fm-pr-lib.sh
@@ -1,24 +1,38 @@
 #!/usr/bin/env bash
-# Shared validation and atomic artifact helpers for GitHub PR merge polling.
-# Callers must validate task IDs and raw PR URLs before constructing task paths
-# or performing any side effect.
+# Shared validation and atomic artifact helpers for merge polling on the
+# supported forges. Callers must validate task IDs and raw PR/MR URLs before
+# constructing task paths or performing any side effect.
+#
+# The stored identity is provider-tagged: provider, url, host, path, number.
+# "path" is the full project path, which is owner/repository on GitHub and an
+# arbitrarily nested group/subgroup/project namespace on GitLab. A GitLab
+# project can sit at any depth, so no owner/repository pair can address one and
+# the sidecar carries the whole path instead. Every consumer re-derives that
+# identity from the stored URL and refuses any record whose parts do not
+# reconstruct that exact URL.
 
+FM_PR_PROVIDER=
 FM_PR_URL=
+FM_PR_HOST=
+FM_PR_PATH=
 FM_PR_OWNER=
 FM_PR_REPO=
 FM_PR_NUMBER=
+FM_PR_DATA_PROVIDER=
 FM_PR_DATA_URL=
-FM_PR_DATA_OWNER=
-FM_PR_DATA_REPO=
+FM_PR_DATA_HOST=
+FM_PR_DATA_PATH=
 FM_PR_DATA_NUMBER=
+FM_PR_META_PROVIDER=
 FM_PR_META_URL=
-FM_PR_META_OWNER=
-FM_PR_META_REPO=
+FM_PR_META_HOST=
+FM_PR_META_PATH=
 FM_PR_META_NUMBER=
 FM_PR_REG_ID=
+FM_PR_REG_PROVIDER=
 FM_PR_REG_URL=
-FM_PR_REG_OWNER=
-FM_PR_REG_REPO=
+FM_PR_REG_HOST=
+FM_PR_REG_PATH=
 FM_PR_REG_NUMBER=
 FM_PR_REG_DATA_HASH=
 FM_PR_REG_TEMPLATE_HASH=
@@ -31,9 +45,10 @@ FM_PR_POLL_DATA_DEST=
 FM_PR_POLL_CHECK_DEST=
 FM_PR_POLL_REG_DEST=
 FM_PR_POLL_EXPECT_ID=
+FM_PR_POLL_EXPECT_PROVIDER=
 FM_PR_POLL_EXPECT_URL=
-FM_PR_POLL_EXPECT_OWNER=
-FM_PR_POLL_EXPECT_REPO=
+FM_PR_POLL_EXPECT_HOST=
+FM_PR_POLL_EXPECT_PATH=
 FM_PR_POLL_EXPECT_NUMBER=
 FM_PR_POLL_EXPECT_DATA_HASH=
 FM_PR_POLL_EXPECT_TEMPLATE_HASH=
@@ -61,20 +76,96 @@ fm_task_id_creation_valid() {
   [ "${#id}" -le 64 ]
 }
 
-fm_pr_url_parse() {
-  local raw=${1-} pattern
+# GitLab serves self-hosted instances, so the host is part of the identity
+# rather than a constant. It is accepted only as a lowercase DNS name with no
+# userinfo, port, or trailing dot, which keeps one canonical spelling per MR.
+fm_pr_gitlab_host_valid() {
+  local host=${1-} label
   local LC_ALL=C
+  local -a labels
+  [ "${#host}" -ge 1 ] && [ "${#host}" -le 253 ] || return 1
+  case "$host" in
+    .*|*.|*..*|*[!a-z0-9.-]*) return 1 ;;
+  esac
+  IFS=. read -ra labels <<< "$host"
+  for label in "${labels[@]}"; do
+    [ "${#label}" -ge 1 ] && [ "${#label}" -le 63 ] || return 1
+    case "$label" in
+      -*|*-) return 1 ;;
+    esac
+  done
+}
+
+# A GitLab project path is group[/subgroup...]/project, so at least two
+# segments and no fixed depth. GitLab reserves "-" as its route separator and
+# forbids a leading hyphen, ".git", and ".atom", so none of those can name a
+# real namespace and each is refused here.
+fm_pr_gitlab_path_valid() {
+  local path=${1-} segment
+  local LC_ALL=C
+  local -a segments
+  [ "${#path}" -ge 3 ] && [ "${#path}" -le 1024 ] || return 1
+  case "$path" in
+    /*|*/|*//*) return 1 ;;
+  esac
+  IFS=/ read -ra segments <<< "$path"
+  [ "${#segments[@]}" -ge 2 ] && [ "${#segments[@]}" -le 20 ] || return 1
+  for segment in "${segments[@]}"; do
+    [ "${#segment}" -ge 1 ] && [ "${#segment}" -le 255 ] || return 1
+    case "$segment" in
+      .|..|-*|*.git|*.atom|*[!A-Za-z0-9._-]*) return 1 ;;
+    esac
+  done
+}
+
+# Parse a canonical PR or MR URL into the provider-tagged identity. Validation
+# is strict and per provider: the GitHub username and repository rules are
+# unchanged, and GitLab gets its own host and namespace rules rather than a
+# loosened GitHub rule.
+#
+# FM_PR_OWNER and FM_PR_REPO are additionally set for github because
+# bin/fm-pr-merge.sh addresses GitHub by owner/repository. A gitlab URL leaves
+# them empty; teaching the merge path about GitLab is a separate change, and
+# until then it refuses a GitLab URL at gh-axi rather than merging anything.
+fm_pr_url_parse() {
+  local raw=${1-} pattern host path
+  local LC_ALL=C
+  FM_PR_PROVIDER=
   FM_PR_URL=
+  FM_PR_HOST=
+  FM_PR_PATH=
   FM_PR_OWNER=
   FM_PR_REPO=
   FM_PR_NUMBER=
   pattern='^https://github\.com/([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9-]{0,37}[A-Za-z0-9])/([A-Za-z0-9._-]{1,100})/pull/([1-9][0-9]*)$'
+  if [[ "$raw" =~ $pattern ]]; then
+    [[ "${BASH_REMATCH[1]}" != *--* ]] || return 1
+    [ "${BASH_REMATCH[2]}" != . ] && [ "${BASH_REMATCH[2]}" != .. ] || return 1
+    FM_PR_PROVIDER=github
+    FM_PR_URL=$raw
+    FM_PR_HOST=github.com
+    FM_PR_PATH="${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
+    # Consumed by bin/fm-pr-merge.sh, which addresses GitHub by owner/repository.
+    # shellcheck disable=SC2034
+    FM_PR_OWNER=${BASH_REMATCH[1]}
+    # shellcheck disable=SC2034
+    FM_PR_REPO=${BASH_REMATCH[2]}
+    FM_PR_NUMBER=${BASH_REMATCH[3]}
+    return 0
+  fi
+  # The path class contains "/" and "-", so this match is greedy to the last
+  # "/-/merge_requests/". Any earlier separator therefore lands inside the
+  # captured path, where the reserved "-" segment is refused.
+  pattern='^https://([a-z0-9.-]{1,253})/([A-Za-z0-9._/-]{3,1024})/-/merge_requests/([1-9][0-9]*)$'
   [[ "$raw" =~ $pattern ]] || return 1
-  [[ "${BASH_REMATCH[1]}" != *--* ]] || return 1
-  [ "${BASH_REMATCH[2]}" != . ] && [ "${BASH_REMATCH[2]}" != .. ] || return 1
+  host=${BASH_REMATCH[1]}
+  path=${BASH_REMATCH[2]}
+  fm_pr_gitlab_host_valid "$host" || return 1
+  fm_pr_gitlab_path_valid "$path" || return 1
+  FM_PR_PROVIDER=gitlab
   FM_PR_URL=$raw
-  FM_PR_OWNER=${BASH_REMATCH[1]}
-  FM_PR_REPO=${BASH_REMATCH[2]}
+  FM_PR_HOST=$host
+  FM_PR_PATH=$path
   FM_PR_NUMBER=${BASH_REMATCH[3]}
 }
 
@@ -158,9 +249,10 @@ fm_pr_regular_destination_on_device_or_absent() {
 
 fm_pr_metadata_identity_parse() {
   local file=$1 line value pr_count=0 seen_pr=0 post_pr_invalid=0
+  FM_PR_META_PROVIDER=
   FM_PR_META_URL=
-  FM_PR_META_OWNER=
-  FM_PR_META_REPO=
+  FM_PR_META_HOST=
+  FM_PR_META_PATH=
   FM_PR_META_NUMBER=
   [ -f "$file" ] && [ ! -L "$file" ] || return 1
   [ "$(fm_pr_file_link_count "$file")" = 1 ] || return 1
@@ -171,9 +263,10 @@ fm_pr_metadata_identity_parse() {
         [ "$pr_count" -eq 1 ] || continue
         value=${line#pr=}
         if fm_pr_url_parse "$value"; then
+          FM_PR_META_PROVIDER=$FM_PR_PROVIDER
           FM_PR_META_URL=$FM_PR_URL
-          FM_PR_META_OWNER=$FM_PR_OWNER
-          FM_PR_META_REPO=$FM_PR_REPO
+          FM_PR_META_HOST=$FM_PR_HOST
+          FM_PR_META_PATH=$FM_PR_PATH
           FM_PR_META_NUMBER=$FM_PR_NUMBER
         fi
         seen_pr=1
@@ -196,17 +289,23 @@ fm_pr_metadata_identity_parse() {
   [ -n "$FM_PR_META_URL" ]
 }
 
+# Sidecar layout: provider, url, host, path, number, one per line. A sidecar
+# written before the provider tag existed has a URL on its first line and one
+# line fewer, so it fails both the field count and the provider comparison and
+# is refused rather than misread as a provider-tagged record.
 fm_pr_poll_data_parse() {
-  local file=$1 url owner repo number
+  local file=$1 provider url host path number
+  FM_PR_DATA_PROVIDER=
   FM_PR_DATA_URL=
-  FM_PR_DATA_OWNER=
-  FM_PR_DATA_REPO=
+  FM_PR_DATA_HOST=
+  FM_PR_DATA_PATH=
   FM_PR_DATA_NUMBER=
   [ -f "$file" ] && [ ! -L "$file" ] || return 1
   exec 8< "$file" || return 1
+  IFS= read -r provider <&8 || { exec 8<&-; return 1; }
   IFS= read -r url <&8 || { exec 8<&-; return 1; }
-  IFS= read -r owner <&8 || { exec 8<&-; return 1; }
-  IFS= read -r repo <&8 || { exec 8<&-; return 1; }
+  IFS= read -r host <&8 || { exec 8<&-; return 1; }
+  IFS= read -r path <&8 || { exec 8<&-; return 1; }
   IFS= read -r number <&8 || { exec 8<&-; return 1; }
   if IFS= read -r _extra <&8; then
     exec 8<&-
@@ -214,21 +313,29 @@ fm_pr_poll_data_parse() {
   fi
   exec 8<&-
   fm_pr_url_parse "$url" || return 1
-  [ "$owner" = "$FM_PR_OWNER" ] || return 1
-  [ "$repo" = "$FM_PR_REPO" ] || return 1
+  [ "$provider" = "$FM_PR_PROVIDER" ] || return 1
+  [ "$host" = "$FM_PR_HOST" ] || return 1
+  [ "$path" = "$FM_PR_PATH" ] || return 1
   [ "$number" = "$FM_PR_NUMBER" ] || return 1
+  FM_PR_DATA_PROVIDER=$FM_PR_PROVIDER
   FM_PR_DATA_URL=$FM_PR_URL
-  FM_PR_DATA_OWNER=$FM_PR_OWNER
-  FM_PR_DATA_REPO=$FM_PR_REPO
+  FM_PR_DATA_HOST=$FM_PR_HOST
+  FM_PR_DATA_PATH=$FM_PR_PATH
   FM_PR_DATA_NUMBER=$FM_PR_NUMBER
 }
 
+# Registration layout: version tag, task id, then the same provider-tagged
+# identity as the sidecar, then the two hashes and the two file identities.
+# The version tag moved to v2 with the provider tag, so a registration written
+# by the previous release is recognised as old and refused. The migration in
+# bin/fm-pr-check-migrate.sh then rebuilds that poll from task metadata.
 fm_pr_poll_registration_parse() {
-  local file=$1 version id url owner repo number data_hash template_hash data_identity check_identity
+  local file=$1 version id provider url host path number data_hash template_hash data_identity check_identity
   FM_PR_REG_ID=
+  FM_PR_REG_PROVIDER=
   FM_PR_REG_URL=
-  FM_PR_REG_OWNER=
-  FM_PR_REG_REPO=
+  FM_PR_REG_HOST=
+  FM_PR_REG_PATH=
   FM_PR_REG_NUMBER=
   FM_PR_REG_DATA_HASH=
   FM_PR_REG_TEMPLATE_HASH=
@@ -238,9 +345,10 @@ fm_pr_poll_registration_parse() {
   exec 7< "$file" || return 1
   IFS= read -r version <&7 || { exec 7<&-; return 1; }
   IFS= read -r id <&7 || { exec 7<&-; return 1; }
+  IFS= read -r provider <&7 || { exec 7<&-; return 1; }
   IFS= read -r url <&7 || { exec 7<&-; return 1; }
-  IFS= read -r owner <&7 || { exec 7<&-; return 1; }
-  IFS= read -r repo <&7 || { exec 7<&-; return 1; }
+  IFS= read -r host <&7 || { exec 7<&-; return 1; }
+  IFS= read -r path <&7 || { exec 7<&-; return 1; }
   IFS= read -r number <&7 || { exec 7<&-; return 1; }
   IFS= read -r data_hash <&7 || { exec 7<&-; return 1; }
   IFS= read -r template_hash <&7 || { exec 7<&-; return 1; }
@@ -251,20 +359,22 @@ fm_pr_poll_registration_parse() {
     return 1
   fi
   exec 7<&-
-  [ "$version" = fm-pr-poll-registration-v1 ] || return 1
+  [ "$version" = fm-pr-poll-registration-v2 ] || return 1
   fm_pr_task_id_valid "$id" || return 1
   fm_pr_url_parse "$url" || return 1
-  [ "$owner" = "$FM_PR_OWNER" ] || return 1
-  [ "$repo" = "$FM_PR_REPO" ] || return 1
+  [ "$provider" = "$FM_PR_PROVIDER" ] || return 1
+  [ "$host" = "$FM_PR_HOST" ] || return 1
+  [ "$path" = "$FM_PR_PATH" ] || return 1
   [ "$number" = "$FM_PR_NUMBER" ] || return 1
   [[ "$data_hash" =~ ^[0-9a-f]{64}$ ]] || return 1
   [[ "$template_hash" =~ ^[0-9a-f]{64}$ ]] || return 1
   [[ "$data_identity" =~ ^[0-9]+:[0-9]+$ ]] || return 1
   [[ "$check_identity" =~ ^[0-9]+:[0-9]+$ ]] || return 1
   FM_PR_REG_ID=$id
+  FM_PR_REG_PROVIDER=$FM_PR_PROVIDER
   FM_PR_REG_URL=$FM_PR_URL
-  FM_PR_REG_OWNER=$FM_PR_OWNER
-  FM_PR_REG_REPO=$FM_PR_REPO
+  FM_PR_REG_HOST=$FM_PR_HOST
+  FM_PR_REG_PATH=$FM_PR_PATH
   FM_PR_REG_NUMBER=$FM_PR_NUMBER
   FM_PR_REG_DATA_HASH=$data_hash
   FM_PR_REG_TEMPLATE_HASH=$template_hash
@@ -301,11 +411,12 @@ fm_pr_poll_revoke_final() {
 }
 
 fm_pr_poll_prepare() {
-  local state=$1 id=$2 url=$3 owner=$4 repo=$5 number=$6 template=$7
+  local state=$1 id=$2 provider=$3 url=$4 host=$5 path=$6 number=$7 template=$8
   fm_pr_task_id_valid "$id" || return 1
   fm_pr_url_parse "$url" || return 1
-  [ "$owner" = "$FM_PR_OWNER" ] || return 1
-  [ "$repo" = "$FM_PR_REPO" ] || return 1
+  [ "$provider" = "$FM_PR_PROVIDER" ] || return 1
+  [ "$host" = "$FM_PR_HOST" ] || return 1
+  [ "$path" = "$FM_PR_PATH" ] || return 1
   [ "$number" = "$FM_PR_NUMBER" ] || return 1
   [ -f "$template" ] || return 1
 
@@ -317,9 +428,10 @@ fm_pr_poll_prepare() {
   FM_PR_POLL_CHECK_DEST="$state/$id.check.sh"
   FM_PR_POLL_REG_DEST="$state/$id.pr-poll-registration"
   FM_PR_POLL_EXPECT_ID=$id
+  FM_PR_POLL_EXPECT_PROVIDER=$provider
   FM_PR_POLL_EXPECT_URL=$url
-  FM_PR_POLL_EXPECT_OWNER=$owner
-  FM_PR_POLL_EXPECT_REPO=$repo
+  FM_PR_POLL_EXPECT_HOST=$host
+  FM_PR_POLL_EXPECT_PATH=$path
   FM_PR_POLL_EXPECT_NUMBER=$number
   FM_PR_POLL_TEMPLATE=$template
   FM_PR_POLL_STATE_DEVICE=$(fm_pr_file_device "$state") || return 1
@@ -334,13 +446,14 @@ fm_pr_poll_prepare() {
     return 1
   }
 
-  if ! printf '%s\n%s\n%s\n%s\n' "$url" "$owner" "$repo" "$number" > "$FM_PR_POLL_DATA_TMP" \
+  if ! printf '%s\n%s\n%s\n%s\n%s\n' "$provider" "$url" "$host" "$path" "$number" > "$FM_PR_POLL_DATA_TMP" \
     || ! chmod 0600 "$FM_PR_POLL_DATA_TMP" \
     || ! fm_pr_private_file_valid "$FM_PR_POLL_DATA_TMP" 600 "$FM_PR_POLL_STATE_DEVICE" \
     || ! fm_pr_poll_data_parse "$FM_PR_POLL_DATA_TMP" \
+    || [ "$FM_PR_DATA_PROVIDER" != "$provider" ] \
     || [ "$FM_PR_DATA_URL" != "$url" ] \
-    || [ "$FM_PR_DATA_OWNER" != "$owner" ] \
-    || [ "$FM_PR_DATA_REPO" != "$repo" ] \
+    || [ "$FM_PR_DATA_HOST" != "$host" ] \
+    || [ "$FM_PR_DATA_PATH" != "$path" ] \
     || [ "$FM_PR_DATA_NUMBER" != "$number" ] \
     || ! cp "$template" "$FM_PR_POLL_CHECK_TMP" \
     || ! chmod 0600 "$FM_PR_POLL_CHECK_TMP" \
@@ -353,8 +466,8 @@ fm_pr_poll_prepare() {
   FM_PR_POLL_EXPECT_TEMPLATE_HASH=$(fm_pr_sha256 "$FM_PR_POLL_CHECK_TMP") || { fm_pr_poll_cleanup; return 1; }
   FM_PR_POLL_EXPECT_DATA_IDENTITY=$(fm_pr_file_identity "$FM_PR_POLL_DATA_TMP") || { fm_pr_poll_cleanup; return 1; }
   FM_PR_POLL_EXPECT_CHECK_IDENTITY=$(fm_pr_file_identity "$FM_PR_POLL_CHECK_TMP") || { fm_pr_poll_cleanup; return 1; }
-  if ! printf '%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n' \
-      fm-pr-poll-registration-v1 "$id" "$url" "$owner" "$repo" "$number" \
+  if ! printf '%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n' \
+      fm-pr-poll-registration-v2 "$id" "$provider" "$url" "$host" "$path" "$number" \
       "$FM_PR_POLL_EXPECT_DATA_HASH" "$FM_PR_POLL_EXPECT_TEMPLATE_HASH" \
       "$FM_PR_POLL_EXPECT_DATA_IDENTITY" "$FM_PR_POLL_EXPECT_CHECK_IDENTITY" \
       > "$FM_PR_POLL_REG_TMP" \
@@ -385,9 +498,10 @@ fm_pr_poll_publish_prepared() {
     || [ "$(fm_pr_file_identity "$FM_PR_POLL_DATA_DEST")" != "$FM_PR_POLL_EXPECT_DATA_IDENTITY" ] \
     || [ "$(fm_pr_sha256 "$FM_PR_POLL_DATA_DEST")" != "$FM_PR_POLL_EXPECT_DATA_HASH" ] \
     || ! fm_pr_poll_data_parse "$FM_PR_POLL_DATA_DEST" \
+    || [ "$FM_PR_DATA_PROVIDER" != "$FM_PR_POLL_EXPECT_PROVIDER" ] \
     || [ "$FM_PR_DATA_URL" != "$FM_PR_POLL_EXPECT_URL" ] \
-    || [ "$FM_PR_DATA_OWNER" != "$FM_PR_POLL_EXPECT_OWNER" ] \
-    || [ "$FM_PR_DATA_REPO" != "$FM_PR_POLL_EXPECT_REPO" ] \
+    || [ "$FM_PR_DATA_HOST" != "$FM_PR_POLL_EXPECT_HOST" ] \
+    || [ "$FM_PR_DATA_PATH" != "$FM_PR_POLL_EXPECT_PATH" ] \
     || [ "$FM_PR_DATA_NUMBER" != "$FM_PR_POLL_EXPECT_NUMBER" ]; then
     fm_pr_poll_revoke_final || true
     return 1
@@ -401,9 +515,10 @@ fm_pr_poll_publish_prepared() {
   if ! fm_pr_private_file_valid "$FM_PR_POLL_REG_DEST" 600 "$FM_PR_POLL_STATE_DEVICE" \
     || ! fm_pr_poll_registration_parse "$FM_PR_POLL_REG_DEST" \
     || [ "$FM_PR_REG_ID" != "$FM_PR_POLL_EXPECT_ID" ] \
+    || [ "$FM_PR_REG_PROVIDER" != "$FM_PR_POLL_EXPECT_PROVIDER" ] \
     || [ "$FM_PR_REG_URL" != "$FM_PR_POLL_EXPECT_URL" ] \
-    || [ "$FM_PR_REG_OWNER" != "$FM_PR_POLL_EXPECT_OWNER" ] \
-    || [ "$FM_PR_REG_REPO" != "$FM_PR_POLL_EXPECT_REPO" ] \
+    || [ "$FM_PR_REG_HOST" != "$FM_PR_POLL_EXPECT_HOST" ] \
+    || [ "$FM_PR_REG_PATH" != "$FM_PR_POLL_EXPECT_PATH" ] \
     || [ "$FM_PR_REG_NUMBER" != "$FM_PR_POLL_EXPECT_NUMBER" ] \
     || [ "$FM_PR_REG_DATA_HASH" != "$FM_PR_POLL_EXPECT_DATA_HASH" ] \
     || [ "$FM_PR_REG_TEMPLATE_HASH" != "$FM_PR_POLL_EXPECT_TEMPLATE_HASH" ] \
@@ -447,17 +562,19 @@ fm_pr_poll_artifacts_valid() {
   check_identity=$(fm_pr_file_identity "$check") || return 1
   fm_pr_poll_registration_parse "$registration" || return 1
   [ "$FM_PR_REG_ID" = "$id" ] || return 1
+  [ "$FM_PR_REG_PROVIDER" = "$FM_PR_DATA_PROVIDER" ] || return 1
   [ "$FM_PR_REG_URL" = "$FM_PR_DATA_URL" ] || return 1
-  [ "$FM_PR_REG_OWNER" = "$FM_PR_DATA_OWNER" ] || return 1
-  [ "$FM_PR_REG_REPO" = "$FM_PR_DATA_REPO" ] || return 1
+  [ "$FM_PR_REG_HOST" = "$FM_PR_DATA_HOST" ] || return 1
+  [ "$FM_PR_REG_PATH" = "$FM_PR_DATA_PATH" ] || return 1
   [ "$FM_PR_REG_NUMBER" = "$FM_PR_DATA_NUMBER" ] || return 1
   [ "$FM_PR_REG_DATA_HASH" = "$data_hash" ] || return 1
   [ "$FM_PR_REG_TEMPLATE_HASH" = "$template_hash" ] || return 1
   [ "$FM_PR_REG_DATA_IDENTITY" = "$data_identity" ] || return 1
   [ "$FM_PR_REG_CHECK_IDENTITY" = "$check_identity" ] || return 1
   fm_pr_metadata_identity_parse "$meta" || return 1
+  [ "$FM_PR_META_PROVIDER" = "$FM_PR_DATA_PROVIDER" ] || return 1
   [ "$FM_PR_META_URL" = "$FM_PR_DATA_URL" ] || return 1
-  [ "$FM_PR_META_OWNER" = "$FM_PR_DATA_OWNER" ] || return 1
-  [ "$FM_PR_META_REPO" = "$FM_PR_DATA_REPO" ] || return 1
+  [ "$FM_PR_META_HOST" = "$FM_PR_DATA_HOST" ] || return 1
+  [ "$FM_PR_META_PATH" = "$FM_PR_DATA_PATH" ] || return 1
   [ "$FM_PR_META_NUMBER" = "$FM_PR_DATA_NUMBER" ]
 }

--- a/bin/fm-pr-merge.sh
+++ b/bin/fm-pr-merge.sh
@@ -24,7 +24,11 @@ if [ "$#" -lt 2 ]; then
 fi
 ID=$1
 RAW_URL=$2
-if ! fm_pr_task_id_valid "$ID" || ! fm_pr_url_parse "$RAW_URL"; then
+# bin/fm-pr-lib.sh parses GitLab merge request URLs so the watcher can follow
+# them, but this path still addresses only GitHub by owner/repository. The
+# provider check holds that refusal exactly as it was until merge parity lands.
+if ! fm_pr_task_id_valid "$ID" || ! fm_pr_url_parse "$RAW_URL" \
+  || [ "$FM_PR_PROVIDER" != github ]; then
   echo "error: invalid PR merge request" >&2
   exit 2
 fi

--- a/bin/fm-pr-poll.sh
+++ b/bin/fm-pr-poll.sh
@@ -1,15 +1,19 @@
 #!/usr/bin/env bash
-# Static watcher program for a validated PR poll sidecar.
-# It emits exactly one merged line for MERGED and stays silent otherwise.
+# Static watcher program for a validated PR/MR poll sidecar.
+# It emits exactly one merged line for a merged PR or MR and stays silent
+# otherwise, including on every error, so a failed lookup can never be read as
+# a merge. The provider-tagged identity is data in the sidecar and is never
+# interpolated into this source: these bytes are identical for every task.
 set -u
 LC_ALL=C
 export LC_ALL
 
-if [ "$#" -eq 5 ] && [ "$1" = --validated ]; then
-  url=$2
-  owner=$3
-  repo=$4
-  number=$5
+if [ "$#" -eq 6 ] && [ "$1" = --validated ]; then
+  provider=$2
+  url=$3
+  host=$4
+  path=$5
+  number=$6
 elif [ "$#" -eq 0 ]; then
   case "$0" in
     *.check.sh) data=${0%.check.sh}.pr-poll ;;
@@ -18,9 +22,10 @@ elif [ "$#" -eq 0 ]; then
 
   [ -f "$data" ] && [ ! -L "$data" ] || exit 0
   { exec 3< "$data"; } 2>/dev/null || exit 0
+  IFS= read -r provider <&3 || exit 0
   IFS= read -r url <&3 || exit 0
-  IFS= read -r owner <&3 || exit 0
-  IFS= read -r repo <&3 || exit 0
+  IFS= read -r host <&3 || exit 0
+  IFS= read -r path <&3 || exit 0
   IFS= read -r number <&3 || exit 0
   if IFS= read -r _extra <&3; then
     exit 0
@@ -30,14 +35,6 @@ else
   exit 0
 fi
 
-[ "${#owner}" -ge 1 ] && [ "${#owner}" -le 39 ] || exit 0
-case "$owner" in
-  *[!A-Za-z0-9-]*|-*|*-|*--*) exit 0 ;;
-esac
-[ "${#repo}" -ge 1 ] && [ "${#repo}" -le 100 ] || exit 0
-case "$repo" in
-  .|..|*[!A-Za-z0-9._-]*) exit 0 ;;
-esac
 case "$number" in
   [1-9]*) ;;
   *) exit 0 ;;
@@ -45,8 +42,57 @@ esac
 case "$number" in
   *[!0-9]*) exit 0 ;;
 esac
-[ "$url" = "https://github.com/$owner/$repo/pull/$number" ] || exit 0
 
-state=$(gh pr view "$url" --json state -q .state 2>/dev/null) || exit 0
-[ "$state" = MERGED ] && printf '%s\n' merged
+# Every component is revalidated here rather than trusted from the sidecar, and
+# the stored URL must then be exactly reconstructible from those components, so
+# a doctored sidecar cannot redirect this poll at another host or project.
+case "$provider" in
+  github)
+    [ "$host" = github.com ] || exit 0
+    owner=${path%%/*}
+    repo=${path#*/}
+    [ "${#owner}" -ge 1 ] && [ "${#owner}" -le 39 ] || exit 0
+    case "$owner" in
+      *[!A-Za-z0-9-]*|-*|*-|*--*) exit 0 ;;
+    esac
+    [ "${#repo}" -ge 1 ] && [ "${#repo}" -le 100 ] || exit 0
+    case "$repo" in
+      .|..|*[!A-Za-z0-9._-]*) exit 0 ;;
+    esac
+    [ "$url" = "https://github.com/$owner/$repo/pull/$number" ] || exit 0
+    state=$(gh pr view "$url" --json state -q .state 2>/dev/null) || exit 0
+    [ "$state" = MERGED ] && printf '%s\n' merged
+    ;;
+  gitlab)
+    [ "${#host}" -ge 1 ] && [ "${#host}" -le 253 ] || exit 0
+    case "$host" in
+      .*|*.|*..*|*[!a-z0-9.-]*) exit 0 ;;
+    esac
+    [ "${#path}" -ge 3 ] && [ "${#path}" -le 1024 ] || exit 0
+    case "$path" in
+      /*|*/|*//*) exit 0 ;;
+    esac
+    # A GitLab project sits under at least one group at no fixed depth, and
+    # GitLab reserves the "-" segment as its route separator.
+    rest=$path
+    segments=0
+    while [ -n "$rest" ]; do
+      case "$rest" in
+        */*) segment=${rest%%/*}; rest=${rest#*/} ;;
+        *) segment=$rest; rest= ;;
+      esac
+      segments=$((segments + 1))
+      [ "$segments" -le 20 ] || exit 0
+      [ "${#segment}" -ge 1 ] && [ "${#segment}" -le 255 ] || exit 0
+      case "$segment" in
+        .|..|-*|*.git|*.atom|*[!A-Za-z0-9._-]*) exit 0 ;;
+      esac
+    done
+    [ "$segments" -ge 2 ] || exit 0
+    [ "$url" = "https://$host/$path/-/merge_requests/$number" ] || exit 0
+    state=$(glab-axi mr view "$url" --jq .state 2>/dev/null) || exit 0
+    [ "$state" = merged ] && printf '%s\n' merged
+    ;;
+  *) exit 0 ;;
+esac
 exit 0

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -777,11 +777,13 @@ while :; do
       else
         id=$(basename "$c" .check.sh)
         if fm_pr_poll_artifacts_valid "$STATE" "$id" "$SCRIPT_DIR/fm-pr-poll.sh"; then
+          provider=$FM_PR_DATA_PROVIDER
           url=$FM_PR_DATA_URL
-          owner=$FM_PR_DATA_OWNER
-          repo=$FM_PR_DATA_REPO
+          host=$FM_PR_DATA_HOST
+          path=$FM_PR_DATA_PATH
           number=$FM_PR_DATA_NUMBER
-          run_check_capture "$SCRIPT_DIR/fm-pr-poll.sh" --validated "$url" "$owner" "$repo" "$number" || exit 1
+          run_check_capture "$SCRIPT_DIR/fm-pr-poll.sh" --validated \
+            "$provider" "$url" "$host" "$path" "$number" || exit 1
           out=$FM_CHECK_RESULT
         elif fm_custom_check_snapshot_prepare "$STATE" "$id"; then
           custom_snapshot=$FM_CUSTOM_CHECK_SNAPSHOT

--- a/docs/gitlab-merge-watch.md
+++ b/docs/gitlab-merge-watch.md
@@ -22,7 +22,8 @@ Every gitlab.com command here reads a public merge request and needs no credenti
 
 A self-hosted instance proves the property that makes this a schema change rather than a pattern edit.
 GitLab runs mostly on self-hosted instances, and a merge request there lives under a host that is not `gitlab.com` and under a project namespace that no owner-and-repository pair can address.
-The self-hosted evidence below comes from `dev.egov.gy`, which a reader cannot reach; it is included so the non-default-host path is shown working against a real instance rather than only asserted.
+The self-hosted evidence below comes from `selfhosted.example`, which a reader cannot reach; it is included so the non-default-host path is shown working against a real instance rather than only asserted.
+The host, namespace, and merge request numbers for that instance have been replaced with placeholders because the real instance is private; the properties being demonstrated, a host that is not `gitlab.com` and a project namespace nested below the top level, hold regardless of the exact values.
 
 The host is never a constant in the implementation.
 It is carried in the stored record next to the namespace and the merge request number, and the anti-tamper cross-check rebuilds the URL from that stored host.
@@ -37,10 +38,10 @@ merged
 $ glab-axi mr view "https://gitlab.com/gitlab-org/gitlab-runner/-/merge_requests/6477" --jq .state
 closed
 
-$ glab-axi mr view "https://dev.egov.gy/department-of-citizenship/visa/-/merge_requests/670" --jq .state
+$ glab-axi mr view "https://selfhosted.example/group/subgroup/project/-/merge_requests/101" --jq .state
 merged
 
-$ glab-axi mr view "https://dev.egov.gy/department-of-citizenship/visa/-/merge_requests/661" --jq .state
+$ glab-axi mr view "https://selfhosted.example/group/subgroup/project/-/merge_requests/102" --jq .state
 closed
 ```
 
@@ -56,9 +57,9 @@ $ fm-pr-check.sh e1 https://gitlab.com/gitlab-org/gitlab-runner/-/merge_requests
 armed: state/e1.check.sh
 $ fm-pr-check.sh e2 https://gitlab.com/gitlab-org/gitlab-runner/-/merge_requests/6477
 armed: state/e2.check.sh
-$ fm-pr-check.sh e3 https://dev.egov.gy/department-of-citizenship/visa/-/merge_requests/670
+$ fm-pr-check.sh e3 https://selfhosted.example/group/subgroup/project/-/merge_requests/101
 armed: state/e3.check.sh
-$ fm-pr-check.sh e4 https://dev.egov.gy/department-of-citizenship/visa/-/merge_requests/661
+$ fm-pr-check.sh e4 https://selfhosted.example/group/subgroup/project/-/merge_requests/102
 armed: state/e4.check.sh
 ```
 
@@ -74,10 +75,10 @@ gitlab-org/gitlab-runner
 
 $ cat state/e3.pr-poll
 gitlab
-https://dev.egov.gy/department-of-citizenship/visa/-/merge_requests/670
-dev.egov.gy
-department-of-citizenship/visa
-670
+https://selfhosted.example/group/subgroup/project/-/merge_requests/101
+selfhosted.example
+group/subgroup/project
+101
 ```
 
 The provenance record, showing the bumped version tag:
@@ -87,10 +88,10 @@ $ cat state/e3.pr-poll-registration
 fm-pr-poll-registration-v2
 e3
 gitlab
-https://dev.egov.gy/department-of-citizenship/visa/-/merge_requests/670
-dev.egov.gy
-department-of-citizenship/visa
-670
+https://selfhosted.example/group/subgroup/project/-/merge_requests/101
+selfhosted.example
+group/subgroup/project
+101
 58b97281dea32dd991c7411b1c0f0150fbafbc6c5c82836186b6606d47297c3d
 2df494a308eb6f0c2e2d07de87fd45a5049b6c528b675318d6a0d39865327268
 70:100711
@@ -114,7 +115,7 @@ The optional head commit was captured on both hosts through `glab-axi mr view <u
 $ grep '^pr' state/e1.meta state/e3.meta
 pr=https://gitlab.com/gitlab-org/gitlab-runner/-/merge_requests/4000
 pr_head=774f65356725770b1df233ba88d5cceeaf540e31
-pr=https://dev.egov.gy/department-of-citizenship/visa/-/merge_requests/670
+pr=https://selfhosted.example/group/subgroup/project/-/merge_requests/101
 pr_head=9cf455325eadee70a6326338094398ddb7baf951
 ```
 

--- a/docs/gitlab-merge-watch.md
+++ b/docs/gitlab-merge-watch.md
@@ -1,0 +1,254 @@
+# GitLab merge request watch verification
+
+Empirical record for the merge watch on GitLab, alongside the existing GitHub watch.
+Every command below was run on 2026-07-20 and its output is reproduced exactly.
+
+## Versions
+
+```
+$ glab-axi --version
+0.5.0
+
+$ bash --version | head -1
+GNU bash, version 5.3.9(1)-release (x86_64-pc-linux-gnu)
+```
+
+## Hosts used as evidence, and what each one proves
+
+Two hosts, because they establish different things and neither is redundant.
+
+`gitlab.com` proves the result is reproducible by anyone.
+Every gitlab.com command here reads a public merge request and needs no credential, so a reader can rerun it and see the same output.
+
+A self-hosted instance proves the property that makes this a schema change rather than a pattern edit.
+GitLab runs mostly on self-hosted instances, and a merge request there lives under a host that is not `gitlab.com` and under a project namespace that no owner-and-repository pair can address.
+The self-hosted evidence below comes from `dev.egov.gy`, which a reader cannot reach; it is included so the non-default-host path is shown working against a real instance rather than only asserted.
+
+The host is never a constant in the implementation.
+It is carried in the stored record next to the namespace and the merge request number, and the anti-tamper cross-check rebuilds the URL from that stored host.
+`tests/fm-pr-check-security.test.sh` asserts that neither `bin/fm-pr-lib.sh` nor `bin/fm-pr-poll.sh` contains the string `gitlab.com` at all.
+
+## The underlying read, unauthenticated
+
+```
+$ glab-axi mr view "https://gitlab.com/gitlab-org/gitlab-runner/-/merge_requests/4000" --jq .state
+merged
+
+$ glab-axi mr view "https://gitlab.com/gitlab-org/gitlab-runner/-/merge_requests/6477" --jq .state
+closed
+
+$ glab-axi mr view "https://dev.egov.gy/department-of-citizenship/visa/-/merge_requests/670" --jq .state
+merged
+
+$ glab-axi mr view "https://dev.egov.gy/department-of-citizenship/visa/-/merge_requests/661" --jq .state
+closed
+```
+
+`glab-axi` supports `--jq`, so the state is read as an exact field rather than matched out of human-readable output.
+No change was needed in `glab-axi` for any of this.
+
+## End to end: arming and polling a real merge request
+
+Four tasks were armed against the two hosts, then each published poll was run.
+
+```
+$ fm-pr-check.sh e1 https://gitlab.com/gitlab-org/gitlab-runner/-/merge_requests/4000
+armed: state/e1.check.sh
+$ fm-pr-check.sh e2 https://gitlab.com/gitlab-org/gitlab-runner/-/merge_requests/6477
+armed: state/e2.check.sh
+$ fm-pr-check.sh e3 https://dev.egov.gy/department-of-citizenship/visa/-/merge_requests/670
+armed: state/e3.check.sh
+$ fm-pr-check.sh e4 https://dev.egov.gy/department-of-citizenship/visa/-/merge_requests/661
+armed: state/e4.check.sh
+```
+
+The stored record for each, showing the host and the full project namespace as data:
+
+```
+$ cat state/e1.pr-poll
+gitlab
+https://gitlab.com/gitlab-org/gitlab-runner/-/merge_requests/4000
+gitlab.com
+gitlab-org/gitlab-runner
+4000
+
+$ cat state/e3.pr-poll
+gitlab
+https://dev.egov.gy/department-of-citizenship/visa/-/merge_requests/670
+dev.egov.gy
+department-of-citizenship/visa
+670
+```
+
+The provenance record, showing the bumped version tag:
+
+```
+$ cat state/e3.pr-poll-registration
+fm-pr-poll-registration-v2
+e3
+gitlab
+https://dev.egov.gy/department-of-citizenship/visa/-/merge_requests/670
+dev.egov.gy
+department-of-citizenship/visa
+670
+58b97281dea32dd991c7411b1c0f0150fbafbc6c5c82836186b6606d47297c3d
+2df494a308eb6f0c2e2d07de87fd45a5049b6c528b675318d6a0d39865327268
+70:100711
+70:100712
+```
+
+Running each published poll, where an empty result means the poll stayed silent:
+
+```
+e1 -> [merged]
+e2 -> []
+e3 -> [merged]
+e4 -> []
+```
+
+A merged merge request produces exactly one `merged` line on both hosts, and a merge request that was closed without merging produces nothing.
+
+The optional head commit was captured on both hosts through `glab-axi mr view <url> --jq .sha`:
+
+```
+$ grep '^pr' state/e1.meta state/e3.meta
+pr=https://gitlab.com/gitlab-org/gitlab-runner/-/merge_requests/4000
+pr_head=774f65356725770b1df233ba88d5cceeaf540e31
+pr=https://dev.egov.gy/department-of-citizenship/visa/-/merge_requests/670
+pr_head=9cf455325eadee70a6326338094398ddb7baf951
+```
+
+## The GitHub watch is unchanged
+
+Live GitHub polls were armed under the new code and behave exactly as before.
+
+```
+$ fm-pr-check.sh g1 https://github.com/kunchenguid/firstmate/pull/747
+armed: state/g1.check.sh
+$ cat state/g1.pr-poll
+github
+https://github.com/kunchenguid/firstmate/pull/747
+github.com
+kunchenguid/firstmate
+747
+$ grep '^pr' state/g1.meta
+pr=https://github.com/kunchenguid/firstmate/pull/747
+pr_head=0246453b84ddc0603a7335af049277218387b5b8
+```
+
+Merged pull request 747 produced `merged`, and open pull request 789 produced nothing:
+
+```
+merged pull request 747 -> [merged]
+open pull request 789   -> []
+```
+
+A poll armed by the previous release is recognised as old rather than misread.
+Its four-field record and its `fm-pr-poll-registration-v1` tag both fail the current parsers, the poll emits nothing in that state, and the existing non-executing migration then rebuilds it from the task's recorded pull request URL.
+`tests/fm-pr-check-security.test.sh` covers that whole sequence.
+
+GitHub validation was not loosened to make room for GitLab.
+The GitHub username and repository rules are byte for byte the ones already in the tree, GitLab namespace segments have their own separate rule, and the full adversarial URL matrix that GitHub already rejected still rejects.
+
+## Safety properties, each demonstrated
+
+The GitLab branch inherits every property the GitHub poll has, through the same code, not a parallel one.
+
+### The published poll is byte-identical to the tracked script
+
+Publication copies `bin/fm-pr-poll.sh` with no substitution and refuses if the copy differs.
+
+```
+$ for i in e1 e2 e3 e4; do cmp -s bin/fm-pr-poll.sh state/$i.check.sh && echo "$i: identical"; done
+e1: identical
+e2: identical
+e3: identical
+e4: identical
+```
+
+### Task and merge request data are never interpolated into shell source
+
+The merge request URL appears only in the private record, never in the executable file.
+Because the bytes are identical for every task, the executable surface is one reviewed file rather than one generated script per task.
+
+### The stored URL must be exactly reconstructible from its own stored parts
+
+This is the anti-tamper seam, and on the GitLab side it reconstructs from the stored host rather than from a constant.
+A record whose parts do not rebuild the stored URL is refused before any network call.
+
+```
+doctored host      (gitlab.com substituted for the real host) -> []
+doctored namespace (attacker/evil substituted for the path)   -> []
+flipped provider   (github claimed for a GitLab record)       -> []
+missing provider   (a record with no provider tag)            -> []
+```
+
+### Arming is transactional
+
+Hashes and file identity are recorded before the move and re-verified after it, and the arm is revoked on any mismatch.
+The device, mode, single-link, and non-symlink checks apply to the record, the provenance file, and the published poll alike.
+
+### An unregistered or drifted check is rejected without being executed
+
+An edit to a published poll makes it fail validation, so the watcher never runs it.
+
+```
+$ printf '\n# injected\n' >> state/e3.check.sh
+rejected: drifted check fails validation, so the watcher never runs it
+$ # restore the original bytes
+restored: validates again
+```
+
+A hand-written poll with no provenance record is refused the same way, and the non-executing migration quarantines it rather than running it.
+
+```
+$ cat state/.pr-check-migration.log
+task a1: ambiguous or invalid legacy poll quarantined and unarmed
+task a2: ambiguous or invalid legacy poll quarantined and unarmed
+task a4: ambiguous or invalid legacy poll quarantined and unarmed
+```
+
+### Execution runs from a hash-verified private snapshot
+
+The watcher copies the check, re-hashes the copy, and runs the copy only when that hash matches.
+An edit made after validation and before execution therefore cannot change what runs.
+
+### Any error is silent rather than a false merge signal
+
+This is the property that matters most, because the failure mode to avoid is a lookup error being read as a merge.
+Tested adversarially rather than on the happy path.
+
+```
+nonexistent merge request (iid 999999999, a real 404)    -> []
+host that does not resolve (no-such-host.invalid)        -> []
+glab-axi absent from PATH entirely                       -> []
+no network at all (run in an isolated network namespace) -> []
+```
+
+Every one of these is silent.
+For reference, the underlying tool does report the failure; the poll simply declines to turn a failure into a signal.
+
+```
+$ glab-axi mr view "https://gitlab.com/gitlab-org/gitlab-runner/-/merge_requests/999999999" --jq .state
+error: 404 Not found
+code: NOT_FOUND
+$ echo $?
+1
+
+$ glab-axi mr view "https://no-such-host.invalid/a/b/-/merge_requests/1" --jq .state
+error: x error connecting to no-such-host.invalid
+code: UNKNOWN
+$ echo $?
+1
+```
+
+## Known gap
+
+A merge request that is closed without being merged leaves the task waiting, because only `merged` ends the watch.
+The GitHub poll has the identical gap for a closed pull request.
+Both are tracked separately so the two providers keep behaving the same way.
+
+## Reproducing this
+
+The gitlab.com sections need no credential and can be rerun as written.
+The self-hosted sections need access to that instance; the properties they demonstrate, arbitrary namespace depth and a non-`gitlab.com` host, are also covered deterministically in `tests/fm-pr-check-security.test.sh` with synthetic hosts and six-segment namespaces.

--- a/docs/gitlab-merge-watch.md
+++ b/docs/gitlab-merge-watch.md
@@ -19,6 +19,7 @@ Two hosts, because they establish different things and neither is redundant.
 
 `gitlab.com` proves the result is reproducible by anyone.
 Every gitlab.com command here reads a public merge request and needs no credential, so a reader can rerun it and see the same output.
+That project exists only to be this evidence: it holds one deliberately merged merge request and one deliberately open one, and its README asks that the open one be left open.
 
 A self-hosted instance proves the property that makes this a schema change rather than a pattern edit.
 GitLab runs mostly on self-hosted instances, and a merge request there lives under a host that is not `gitlab.com` and under a project namespace that no owner-and-repository pair can address.
@@ -32,11 +33,11 @@ It is carried in the stored record next to the namespace and the merge request n
 ## The underlying read, unauthenticated
 
 ```
-$ glab-axi mr view "https://gitlab.com/gitlab-org/gitlab-runner/-/merge_requests/4000" --jq .state
+$ glab-axi mr view "https://gitlab.com/KarotKris/gitlab-merge-watch-fixture/-/merge_requests/1" --jq .state
 merged
 
-$ glab-axi mr view "https://gitlab.com/gitlab-org/gitlab-runner/-/merge_requests/6477" --jq .state
-closed
+$ glab-axi mr view "https://gitlab.com/KarotKris/gitlab-merge-watch-fixture/-/merge_requests/2" --jq .state
+opened
 
 $ glab-axi mr view "https://selfhosted.example/group/subgroup/project/-/merge_requests/101" --jq .state
 merged
@@ -53,9 +54,9 @@ No change was needed in `glab-axi` for any of this.
 Four tasks were armed against the two hosts, then each published poll was run.
 
 ```
-$ fm-pr-check.sh e1 https://gitlab.com/gitlab-org/gitlab-runner/-/merge_requests/4000
+$ fm-pr-check.sh e1 https://gitlab.com/KarotKris/gitlab-merge-watch-fixture/-/merge_requests/1
 armed: state/e1.check.sh
-$ fm-pr-check.sh e2 https://gitlab.com/gitlab-org/gitlab-runner/-/merge_requests/6477
+$ fm-pr-check.sh e2 https://gitlab.com/KarotKris/gitlab-merge-watch-fixture/-/merge_requests/2
 armed: state/e2.check.sh
 $ fm-pr-check.sh e3 https://selfhosted.example/group/subgroup/project/-/merge_requests/101
 armed: state/e3.check.sh
@@ -68,10 +69,10 @@ The stored record for each, showing the host and the full project namespace as d
 ```
 $ cat state/e1.pr-poll
 gitlab
-https://gitlab.com/gitlab-org/gitlab-runner/-/merge_requests/4000
+https://gitlab.com/KarotKris/gitlab-merge-watch-fixture/-/merge_requests/1
 gitlab.com
-gitlab-org/gitlab-runner
-4000
+KarotKris/gitlab-merge-watch-fixture
+1
 
 $ cat state/e3.pr-poll
 gitlab
@@ -107,14 +108,15 @@ e3 -> [merged]
 e4 -> []
 ```
 
-A merged merge request produces exactly one `merged` line on both hosts, and a merge request that was closed without merging produces nothing.
+A merged merge request produces exactly one `merged` line on both hosts.
+A merge request that is not merged produces nothing, shown here with one that is still open and one that was closed without merging.
 
 The optional head commit was captured on both hosts through `glab-axi mr view <url> --jq .sha`:
 
 ```
 $ grep '^pr' state/e1.meta state/e3.meta
-pr=https://gitlab.com/gitlab-org/gitlab-runner/-/merge_requests/4000
-pr_head=774f65356725770b1df233ba88d5cceeaf540e31
+pr=https://gitlab.com/KarotKris/gitlab-merge-watch-fixture/-/merge_requests/1
+pr_head=33762fcf6777c8d993220d25fb541e56c48081b9
 pr=https://selfhosted.example/group/subgroup/project/-/merge_requests/101
 pr_head=9cf455325eadee70a6326338094398ddb7baf951
 ```
@@ -220,7 +222,7 @@ This is the property that matters most, because the failure mode to avoid is a l
 Tested adversarially rather than on the happy path.
 
 ```
-nonexistent merge request (iid 999999999, a real 404)    -> []
+nonexistent merge request (iid 999999, a real 404)       -> []
 host that does not resolve (no-such-host.invalid)        -> []
 glab-axi absent from PATH entirely                       -> []
 no network at all (run in an isolated network namespace) -> []
@@ -230,7 +232,7 @@ Every one of these is silent.
 For reference, the underlying tool does report the failure; the poll simply declines to turn a failure into a signal.
 
 ```
-$ glab-axi mr view "https://gitlab.com/gitlab-org/gitlab-runner/-/merge_requests/999999999" --jq .state
+$ glab-axi mr view "https://gitlab.com/KarotKris/gitlab-merge-watch-fixture/-/merge_requests/999999" --jq .state
 error: 404 Not found
 code: NOT_FOUND
 $ echo $?

--- a/tests/fm-pr-check-security.test.sh
+++ b/tests/fm-pr-check-security.test.sh
@@ -371,6 +371,15 @@ INVALID_GITLAB_URLS=(
   "https://gitlab.com/a/'b'/-/merge_requests/1"
 )
 
+# These parse successfully (see test_parser_matrix) but must still be refused
+# by the merge entrypoint: bin/fm-pr-merge.sh keeps its GitHub-only refusal
+# until merge parity lands, per the provider guard at the top of that file.
+VALID_GITLAB_URLS=(
+  'https://gitlab.com/group/project/-/merge_requests/1'
+  'https://gitlab.example.co.uk/g/sub/deeper/project/-/merge_requests/42'
+  'https://git-host.internal/a/b/c/d/e/f/-/merge_requests/123456'
+)
+
 # shellcheck disable=SC2016 # Literal shell syntax is task-ID test data.
 INVALID_IDS=(
   '../escape'
@@ -487,6 +496,19 @@ test_invalid_entrypoints_have_zero_side_effects() {
     [ "$after" = "$before" ] || fail "merge invalid URL changed prior state"
   done
 
+  for value in "${VALID_GITLAB_URLS[@]}"; do
+    before=$(state_snapshot "$dir/home/state")
+    set +e
+    run_merge_entry "$dir" task-a "$value" > "$dir/stdout" 2> "$dir/stderr"
+    rc=$?
+    set -e
+    [ "$rc" -ne 0 ] || fail "merge entrypoint accepted a syntactically valid GitLab MR URL"
+    [ "$(cat "$dir/stderr")" = 'error: invalid PR merge request' ] \
+      || fail "merge GitLab URL diagnostic was not the clean refusal"
+    after=$(state_snapshot "$dir/home/state")
+    [ "$after" = "$before" ] || fail "merge GitLab URL changed prior state"
+  done
+
   for value in "${INVALID_IDS[@]}"; do
     before=$(state_snapshot "$dir/home/state")
     set +e
@@ -527,6 +549,7 @@ test_invalid_entrypoints_have_zero_side_effects() {
 
   [ ! -s "$dir/gh.log" ] || fail "invalid direct or merge data called gh"
   [ ! -s "$dir/gh-axi.log" ] || fail "invalid direct or merge data called gh-axi"
+  [ ! -s "$dir/glab-axi.log" ] || fail "invalid direct or merge data called glab-axi"
   [ ! -s "$dir/guard.log" ] || fail "invalid direct or merge data called the guard"
   [ ! -e "$TMP_ROOT/escape.check.sh" ] || fail "task traversal wrote outside state"
   pass "PR and teardown entrypoints reject invalid arguments before every side effect"

--- a/tests/fm-pr-check-security.test.sh
+++ b/tests/fm-pr-check-security.test.sh
@@ -78,7 +78,20 @@ SH
 printf '%s\n' "$*" >> "$FM_TEST_GH_AXI_LOG"
 exit "${FM_TEST_GH_AXI_RC:-0}"
 SH
-  chmod +x "$fakebin/gh" "$fakebin/gh-axi"
+  cat > "$fakebin/glab-axi" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$FM_TEST_GLAB_AXI_LOG"
+case " $* " in
+  *" .sha "*) printf '%s\n' "${FM_TEST_GLAB_HEAD:-0123456789abcdef0123456789abcdef01234567}" ;;
+  *" .state "*)
+    [ "${FM_TEST_GLAB_FAIL:-0}" = 0 ] || exit 1
+    [ "${FM_TEST_GLAB_SLEEP:-0}" = 0 ] || sleep "$FM_TEST_GLAB_SLEEP"
+    printf '%s\n' "${FM_TEST_GLAB_STATE:-opened}"
+    ;;
+esac
+SH
+  chmod +x "$fakebin/gh" "$fakebin/gh-axi" "$fakebin/glab-axi"
+  : > "$dir/glab-axi.log"
   : > "$dir/gh.log"
   : > "$dir/gh-axi.log"
   : > "$dir/guard.log"
@@ -117,13 +130,14 @@ write_v1_x_shim() {
 }
 
 write_manual_poll_pair() {
-  local state=$1 url=${2:-https://github.com/o/r/pull/10} owner repo number
+  local state=$1 url=${2:-https://github.com/o/r/pull/10} provider host path number
   fm_pr_url_parse "$url" || fail "manual poll fixture URL was invalid"
-  owner=$FM_PR_OWNER
-  repo=$FM_PR_REPO
+  provider=$FM_PR_PROVIDER
+  host=$FM_PR_HOST
+  path=$FM_PR_PATH
   number=$FM_PR_NUMBER
   cp "$POLL" "$state/task-a.check.sh"
-  printf '%s\n%s\n%s\n%s\n' "$url" "$owner" "$repo" "$number" > "$state/task-a.pr-poll"
+  printf '%s\n%s\n%s\n%s\n%s\n' "$provider" "$url" "$host" "$path" "$number" > "$state/task-a.pr-poll"
   chmod 0600 "$state/task-a.check.sh" "$state/task-a.pr-poll"
 }
 
@@ -225,7 +239,8 @@ run_check_entry() {
   shift
   FM_ROOT_OVERRIDE="$dir/root" FM_HOME="$dir/home" \
     FM_TEST_GUARD_LOG="$dir/guard.log" FM_TEST_GH_LOG="$dir/gh.log" \
-    FM_TEST_GH_AXI_LOG="$dir/gh-axi.log" PATH="$dir/fakebin:$BASE_PATH" \
+    FM_TEST_GH_AXI_LOG="$dir/gh-axi.log" FM_TEST_GLAB_AXI_LOG="$dir/glab-axi.log" \
+    PATH="$dir/fakebin:$BASE_PATH" \
     "$PR_CHECK" "$@"
 }
 
@@ -234,7 +249,8 @@ run_merge_entry() {
   shift
   FM_ROOT_OVERRIDE="$dir/root" FM_HOME="$dir/home" \
     FM_TEST_GUARD_LOG="$dir/guard.log" FM_TEST_GH_LOG="$dir/gh.log" \
-    FM_TEST_GH_AXI_LOG="$dir/gh-axi.log" PATH="$dir/fakebin:$BASE_PATH" \
+    FM_TEST_GH_AXI_LOG="$dir/gh-axi.log" FM_TEST_GLAB_AXI_LOG="$dir/glab-axi.log" \
+    PATH="$dir/fakebin:$BASE_PATH" \
     "$PR_MERGE" "$@"
 }
 
@@ -312,6 +328,49 @@ INVALID_URLS=(
   'https://github.com/o/r/pull/1"'
 )
 
+# GitLab namespace rules are their own, not a loosened GitHub rule: the strict
+# GitHub classes above stay rejected, and these MR-shaped URLs are rejected too.
+# shellcheck disable=SC2016 # Literal rejected URL bytes are parser test data.
+INVALID_GITLAB_URLS=(
+  'https://gitlab.com/onlyproject/-/merge_requests/1'
+  'https://gitlab.com/a/-/b/-/merge_requests/1'
+  'https://gitlab.com/a/b/-/merge_requests/0'
+  'https://gitlab.com/a/b/-/merge_requests/01'
+  'https://gitlab.com/a/b/-/merge_requests/'
+  'https://gitlab.com/a/b/-/merge_requests/1/'
+  'https://gitlab.com/a/b/-/merge_requests/1/diffs'
+  'https://gitlab.com/a/b/-/merge_requests/1?q=x'
+  'https://gitlab.com/a/b/-/merge_requests/1#note'
+  'https://gitlab.com/-lead/b/-/merge_requests/1'
+  'https://gitlab.com/a/b.git/-/merge_requests/1'
+  'https://gitlab.com/a/b.atom/-/merge_requests/1'
+  'https://gitlab.com/a/./-/merge_requests/1'
+  'https://gitlab.com/a/../-/merge_requests/1'
+  'https://gitlab.com//b/-/merge_requests/1'
+  'https://gitlab.com/a//-/merge_requests/1'
+  'https://gitlab.com/a/b c/-/merge_requests/1'
+  'https://gitlab.com/a/b%2Fc/-/merge_requests/1'
+  'https://gitlab.com/a/b/-/issues/1'
+  'https://gitlab.com/a/b/merge_requests/1'
+  'https://GitLab.com/a/b/-/merge_requests/1'
+  'https://user@gitlab.com/a/b/-/merge_requests/1'
+  'https://user:pass@gitlab.com/a/b/-/merge_requests/1'
+  'https://gitlab.com:443/a/b/-/merge_requests/1'
+  'https://gitlab..com/a/b/-/merge_requests/1'
+  'https://.gitlab.com/a/b/-/merge_requests/1'
+  'https://gitlab.com./a/b/-/merge_requests/1'
+  'https://-gitlab.com/a/b/-/merge_requests/1'
+  'http://gitlab.com/a/b/-/merge_requests/1'
+  'ssh://gitlab.com/a/b/-/merge_requests/1'
+  $'https://gitlab.com/a/b/-/merge_requests/1\nnext'
+  $'https://gitlab.com/a/b/-/merge_requests/1\r'
+  ' https://gitlab.com/a/b/-/merge_requests/1'
+  'https://gitlab.com/a/b/-/merge_requests/1 '
+  'https://gitlab.com/a/$b/-/merge_requests/1'
+  'https://gitlab.com/a/`b`/-/merge_requests/1'
+  "https://gitlab.com/a/'b'/-/merge_requests/1"
+)
+
 # shellcheck disable=SC2016 # Literal shell syntax is task-ID test data.
 INVALID_IDS=(
   '../escape'
@@ -347,19 +406,30 @@ UNSAFE_LIFECYCLE_IDS=(
 )
 
 test_parser_matrix() {
-  local id row url owner repo number
-  while IFS='|' read -r url owner repo number; do
+  local id row url provider host path number
+  while IFS='|' read -r url provider host path number; do
     [ -n "$url" ] || continue
     fm_pr_url_parse "$url" || fail "parser rejected canonical URL"
     [ "$FM_PR_URL" = "$url" ] || fail "parser changed canonical URL"
-    [ "$FM_PR_OWNER" = "$owner" ] || fail "parser returned wrong owner"
-    [ "$FM_PR_REPO" = "$repo" ] || fail "parser returned wrong repository"
+    [ "$FM_PR_PROVIDER" = "$provider" ] || fail "parser returned wrong provider"
+    [ "$FM_PR_HOST" = "$host" ] || fail "parser returned wrong host"
+    [ "$FM_PR_PATH" = "$path" ] || fail "parser returned wrong project path"
     [ "$FM_PR_NUMBER" = "$number" ] || fail "parser returned wrong PR number"
   done <<'EOF'
-https://github.com/a/b/pull/1|a|b|1
-https://github.com/my-org/repo/pull/42|my-org|repo|42
-https://github.com/Owner/repo-name_with.parts/pull/123456|Owner|repo-name_with.parts|123456
+https://github.com/a/b/pull/1|github|github.com|a/b|1
+https://github.com/my-org/repo/pull/42|github|github.com|my-org/repo|42
+https://github.com/Owner/repo-name_with.parts/pull/123456|github|github.com|Owner/repo-name_with.parts|123456
+https://gitlab.com/group/project/-/merge_requests/1|gitlab|gitlab.com|group/project|1
+https://gitlab.example.co.uk/g/sub/deeper/project/-/merge_requests/42|gitlab|gitlab.example.co.uk|g/sub/deeper/project|42
+https://git-host.internal/a/b/c/d/e/f/-/merge_requests/123456|gitlab|git-host.internal|a/b/c/d/e/f|123456
 EOF
+  # The host is data, never a constant: two unrelated hosts must reach the same
+  # identity shape, and neither may be spelled anywhere in the implementation.
+  ! grep -qF gitlab.com "$ROOT/bin/fm-pr-lib.sh" "$ROOT/bin/fm-pr-poll.sh" \
+    || fail "implementation pinned a GitLab host instead of carrying it as data"
+  for row in "${INVALID_GITLAB_URLS[@]}"; do
+    ! fm_pr_url_parse "$row" || fail "parser accepted a rejected merge request URL class"
+  done
   for row in "${INVALID_URLS[@]}"; do
     ! fm_pr_url_parse "$row" || fail "parser accepted a rejected raw-byte URL class"
   done
@@ -485,7 +555,7 @@ test_valid_recording_and_merge_derivation() {
   fm_pr_poll_artifacts_valid "$dir/home/state" task-a "$POLL" \
     || fail "published poll provenance or metadata binding was invalid"
   sidecar=$(cat "$dir/home/state/task-a.pr-poll")
-  [ "$sidecar" = $'https://github.com/my-org/repo_name.with-dots/pull/37\nmy-org\nrepo_name.with-dots\n37' ] \
+  [ "$sidecar" = $'github\nhttps://github.com/my-org/repo_name.with-dots/pull/37\ngithub.com\nmy-org/repo_name.with-dots\n37' ] \
     || fail "published sidecar bytes were not exact"
 
   FM_TEST_GH_HEAD=$expected run_check_entry "$dir" task-a https://github.com/my-org/repo_name.with-dots/pull/37 \
@@ -592,7 +662,7 @@ test_rejected_metacharacter_bytes_are_inert() {
   dir=$(make_case rejected-metacharacters)
   write_task_meta "$dir"
   write_poll_meta "$dir/home/state" safe-check https://github.com/o/r/pull/99
-  fm_pr_poll_prepare "$dir/home/state" safe-check https://github.com/o/r/pull/99 o r 99 "$POLL" \
+  fm_pr_poll_prepare "$dir/home/state" safe-check github https://github.com/o/r/pull/99 github.com o/r 99 "$POLL" \
     || fail "could not prepare bounded watcher poll"
   fm_pr_poll_publish_prepared || fail "could not publish bounded watcher poll"
   families=(
@@ -635,8 +705,8 @@ test_rejected_metacharacter_bytes_are_inert() {
 make_poll_fixture() {
   local dir=$1
   cp "$POLL" "$dir/home/state/task-a.check.sh"
-  printf '%s\n%s\n%s\n%s\n' \
-    https://github.com/o/r/pull/1 o r 1 > "$dir/home/state/task-a.pr-poll"
+  printf '%s\n%s\n%s\n%s\n%s\n' \
+    github https://github.com/o/r/pull/1 github.com o/r 1 > "$dir/home/state/task-a.pr-poll"
   chmod 0600 "$dir/home/state/task-a.check.sh" "$dir/home/state/task-a.pr-poll"
 }
 
@@ -669,10 +739,10 @@ test_static_poll_contract() {
   out=$(run_poll "$dir")
   [ -z "$out" ] || fail "static poll emitted with missing sidecar"
   mv "$dir/home/state/task-a.pr-poll.missing" "$dir/home/state/task-a.pr-poll"
-  printf '%s\n%s\n%s\n%s\n%s\n' https://github.com/o/r/pull/1 o r 1 extra > "$dir/home/state/task-a.pr-poll"
+  printf '%s\n%s\n%s\n%s\n%s\n%s\n' github https://github.com/o/r/pull/1 github.com o/r 1 extra > "$dir/home/state/task-a.pr-poll"
   out=$(FM_TEST_GH_STATE=MERGED run_poll "$dir")
   [ -z "$out" ] || fail "static poll emitted with multiline sidecar"
-  printf '%s\n%s\n%s\n%s\n' https://github.com/o/r/pull/1x o r 1x > "$dir/home/state/task-a.pr-poll"
+  printf '%s\n%s\n%s\n%s\n%s\n' github https://github.com/o/r/pull/1x github.com o/r 1x > "$dir/home/state/task-a.pr-poll"
   out=$(FM_TEST_GH_STATE=MERGED run_poll "$dir")
   [ -z "$out" ] || fail "static poll emitted with malformed numeric data"
 
@@ -687,7 +757,7 @@ test_static_poll_contract() {
   [ -z "$out" ] || fail "timed-out static poll emitted output"
 
   write_poll_meta "$dir/home/state" task-a https://github.com/o/r/pull/1
-  fm_pr_poll_prepare "$dir/home/state" task-a https://github.com/o/r/pull/1 o r 1 "$POLL" \
+  fm_pr_poll_prepare "$dir/home/state" task-a github https://github.com/o/r/pull/1 github.com o/r 1 "$POLL" \
     || fail "could not prepare authenticated watcher poll"
   fm_pr_poll_publish_prepared || fail "could not publish authenticated watcher poll"
   rm -f "$dir/home/state/.last-check"
@@ -698,6 +768,106 @@ test_static_poll_contract() {
   [ "$rc" -eq 0 ] || fail "watcher did not surface merged poll"
   [ "$(grep -c '^check: .*: merged$' "$dir/watch.out")" -eq 1 ] || fail "watcher did not convert merged output into exactly one wake"
   pass "static poll is silent except for one merged line and remains watcher-bounded"
+}
+
+# Two unrelated hosts, one nested under subgroups, both through the same code
+# path. GITLAB_HOST is a self-hosted instance name here, never a default.
+GITLAB_HOST=git.example.internal
+GITLAB_PATH=dept/team/sub/project
+GITLAB_URL="https://$GITLAB_HOST/$GITLAB_PATH/-/merge_requests/670"
+GITLAB_DOTCOM_URL='https://gitlab.com/group/runner/-/merge_requests/4000'
+
+run_gitlab_poll() {
+  local dir=$1
+  FM_TEST_GLAB_AXI_LOG="$dir/glab-axi.log" PATH="$dir/fakebin:$BASE_PATH" \
+    bash "$dir/home/state/task-a.check.sh"
+}
+
+test_gitlab_poll_contract() {
+  local dir state out url
+  dir=$(make_case gitlab-poll)
+
+  for url in "$GITLAB_URL" "$GITLAB_DOTCOM_URL"; do
+    write_task_meta "$dir"
+    rm -f "$dir/home/state/task-a.check.sh" "$dir/home/state/task-a.pr-poll" \
+      "$dir/home/state/task-a.pr-poll-registration"
+    run_check_entry "$dir" task-a "$url" >/dev/null 2>/dev/null \
+      || fail "arming refused a canonical merge request URL"
+    fm_pr_poll_artifacts_valid "$dir/home/state" task-a "$POLL" \
+      || fail "armed merge request poll failed its own provenance validation"
+    cmp -s "$POLL" "$dir/home/state/task-a.check.sh" \
+      || fail "published merge request poll was not byte-identical to the tracked script"
+    ! grep -qF "$url" "$dir/home/state/task-a.check.sh" \
+      || fail "merge request URL was interpolated into executable poll source"
+
+    for state in opened closed locked '' not-a-state MERGED Merged; do
+      out=$(FM_TEST_GLAB_STATE="$state" run_gitlab_poll "$dir")
+      [ -z "$out" ] || fail "merge request poll emitted for non-merged state"
+    done
+    out=$(FM_TEST_GLAB_STATE=merged run_gitlab_poll "$dir")
+    [ "$out" = merged ] || fail "merge request poll did not emit exactly one merged line"
+    out=$(FM_TEST_GLAB_FAIL=1 FM_TEST_GLAB_STATE=merged run_gitlab_poll "$dir")
+    [ -z "$out" ] || fail "merge request poll emitted after a failed lookup"
+    grep -qF -- "--jq .state" "$dir/glab-axi.log" \
+      || fail "merge request poll did not read state through --jq"
+  done
+
+  # A doctored sidecar must not redirect the poll: each component is revalidated
+  # and the stored URL must reconstruct exactly from the stored host and path.
+  printf '%s\n%s\n%s\n%s\n%s\n' gitlab "$GITLAB_URL" attacker.example "$GITLAB_PATH" 670 \
+    > "$dir/home/state/task-a.pr-poll"
+  out=$(FM_TEST_GLAB_STATE=merged run_gitlab_poll "$dir")
+  [ -z "$out" ] || fail "merge request poll emitted with a substituted host"
+  printf '%s\n%s\n%s\n%s\n%s\n' gitlab "$GITLAB_URL" "$GITLAB_HOST" other/project 670 \
+    > "$dir/home/state/task-a.pr-poll"
+  out=$(FM_TEST_GLAB_STATE=merged run_gitlab_poll "$dir")
+  [ -z "$out" ] || fail "merge request poll emitted with a substituted project path"
+  printf '%s\n%s\n%s\n%s\n%s\n' github "$GITLAB_URL" "$GITLAB_HOST" "$GITLAB_PATH" 670 \
+    > "$dir/home/state/task-a.pr-poll"
+  out=$(FM_TEST_GLAB_STATE=merged run_gitlab_poll "$dir")
+  [ -z "$out" ] || fail "merge request poll emitted with a substituted provider"
+  printf '%s\n%s\n%s\n%s\n' "$GITLAB_URL" "$GITLAB_HOST" "$GITLAB_PATH" 670 \
+    > "$dir/home/state/task-a.pr-poll"
+  out=$(FM_TEST_GLAB_STATE=merged run_gitlab_poll "$dir")
+  [ -z "$out" ] || fail "merge request poll emitted for a sidecar without a provider tag"
+
+  pass "merge request poll is host-agnostic, tamper-resistant, and silent except for one merged line"
+}
+
+# A poll armed by the previous release carries a four-field sidecar and a v1
+# registration. It must be recognised as old rather than misparsed, and the
+# non-executing migration must rebuild it from task metadata.
+test_legacy_v1_poll_is_recognised_and_rebuilt() {
+  local dir state out
+  dir=$(make_case legacy-v1-poll)
+  state="$dir/home/state"
+  write_poll_meta "$state" task-a https://github.com/o/r/pull/10
+  cp "$POLL" "$state/task-a.check.sh"
+  printf '%s\n%s\n%s\n%s\n' https://github.com/o/r/pull/10 o r 10 > "$state/task-a.pr-poll"
+  printf '%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n' \
+    fm-pr-poll-registration-v1 task-a https://github.com/o/r/pull/10 o r 10 \
+    "$(fm_pr_sha256 "$state/task-a.pr-poll")" "$(fm_pr_sha256 "$state/task-a.check.sh")" \
+    "$(fm_pr_file_identity "$state/task-a.pr-poll")" \
+    "$(fm_pr_file_identity "$state/task-a.check.sh")" > "$state/task-a.pr-poll-registration"
+  chmod 0600 "$state/task-a.check.sh" "$state/task-a.pr-poll" \
+    "$state/task-a.pr-poll-registration"
+
+  ! fm_pr_poll_registration_parse "$state/task-a.pr-poll-registration" \
+    || fail "a previous-release registration was accepted by the current parser"
+  ! fm_pr_poll_data_parse "$state/task-a.pr-poll" \
+    || fail "a previous-release sidecar was accepted by the current parser"
+  out=$(FM_TEST_GLAB_AXI_LOG="$dir/glab-axi.log" FM_TEST_GH_LOG="$dir/gh.log" \
+    FM_TEST_GH_STATE=MERGED PATH="$dir/fakebin:$BASE_PATH" bash "$state/task-a.check.sh")
+  [ -z "$out" ] || fail "a previous-release sidecar produced a merge signal"
+
+  FM_HOME="$dir/home" PATH="$dir/fakebin:$BASE_PATH" "$MIGRATE" >/dev/null 2>/dev/null \
+    || fail "migration did not complete for a previous-release poll"
+  fm_pr_poll_artifacts_valid "$state" task-a "$POLL" \
+    || fail "migration did not rebuild a previous-release poll into a valid one"
+  [ "$FM_PR_DATA_URL" = https://github.com/o/r/pull/10 ] \
+    || fail "rebuilt poll lost its recorded pull request URL"
+  [ "$FM_PR_DATA_PROVIDER" = github ] || fail "rebuilt poll lost its provider tag"
+  pass "a poll armed by the previous release is recognised as old and rebuilt, never misparsed"
 }
 
 test_atomic_interruption_leaves_no_partial_artifact() {
@@ -849,7 +1019,7 @@ test_private_artifact_paths_refuse_symlinks_and_directories() {
     for kind in regular dangling directory; do
       dir=$(make_case "poll-path-${artifact//./-}-$kind")
       state="$dir/home/state"
-      fm_pr_poll_prepare "$state" task-a https://github.com/o/r/pull/1 o r 1 "$POLL" \
+      fm_pr_poll_prepare "$state" task-a github https://github.com/o/r/pull/1 github.com o/r 1 "$POLL" \
         || fail "could not stage poll symlink refusal fixture"
       destination="$state/$artifact"
       make_private_symlink "$dir" "$destination" "$kind"
@@ -864,7 +1034,7 @@ test_private_artifact_paths_refuse_symlinks_and_directories() {
 
     dir=$(make_case "poll-path-${artifact//./-}-direct-directory")
     state="$dir/home/state"
-    fm_pr_poll_prepare "$state" task-a https://github.com/o/r/pull/1 o r 1 "$POLL" \
+    fm_pr_poll_prepare "$state" task-a github https://github.com/o/r/pull/1 github.com o/r 1 "$POLL" \
       || fail "could not stage poll directory refusal fixture"
     destination="$state/$artifact"
     mkdir "$destination"
@@ -975,11 +1145,11 @@ test_postrename_poll_validation_revokes_and_retries() {
       dir=$(make_case "poll-final-$artifact-$action")
       state="$dir/home/state"
       write_poll_meta "$state" task-a https://github.com/o/r/pull/1
-      fm_pr_poll_prepare "$state" task-a https://github.com/o/r/pull/1 o r 1 "$POLL" \
+      fm_pr_poll_prepare "$state" task-a github https://github.com/o/r/pull/1 github.com o/r 1 "$POLL" \
         || fail "could not prepare prior poll"
       fm_pr_poll_publish_prepared || fail "could not publish prior poll"
       write_poll_meta "$state" task-a https://github.com/o/r/pull/2
-      fm_pr_poll_prepare "$state" task-a https://github.com/o/r/pull/2 o r 2 "$POLL" \
+      fm_pr_poll_prepare "$state" task-a github https://github.com/o/r/pull/2 github.com o/r 2 "$POLL" \
         || fail "could not stage replacement poll"
       case "$artifact" in
         data) destination="$state/task-a.pr-poll" ;;
@@ -1002,7 +1172,7 @@ test_postrename_poll_validation_revokes_and_retries() {
       [ "$(cat "$link_target")" = 'external sentinel' ] || fail "poll type fault changed an external target"
       [ "$(file_mode "$link_target")" = 644 ] || fail "poll type fault changed an external target mode"
 
-      fm_pr_poll_prepare "$state" task-a https://github.com/o/r/pull/2 o r 2 "$POLL" \
+      fm_pr_poll_prepare "$state" task-a github https://github.com/o/r/pull/2 github.com o/r 2 "$POLL" \
         || fail "could not prepare poll retry"
       PATH="$BASE_PATH" fm_pr_poll_publish_prepared || fail "poll retry did not recover after final validation fault"
       fm_pr_poll_artifacts_valid "$state" task-a "$POLL" || fail "poll retry did not publish a valid pair"
@@ -1419,7 +1589,7 @@ test_replacement_provenance_negative_matrix() {
         donor="$dir/donor"
         mkdir -p "$donor"
         write_poll_meta "$donor" task-a https://github.com/o/r/pull/10
-        fm_pr_poll_prepare "$donor" task-a https://github.com/o/r/pull/10 o r 10 "$POLL" \
+        fm_pr_poll_prepare "$donor" task-a github https://github.com/o/r/pull/10 github.com o/r 10 "$POLL" \
           || fail "could not prepare donor registration fixture"
         fm_pr_poll_publish_prepared || fail "could not publish donor registration fixture"
         cp "$donor/task-a.check.sh" "$state/task-a.check.sh"
@@ -1428,13 +1598,13 @@ test_replacement_provenance_negative_matrix() {
         chmod 0600 "$state/task-a.check.sh" "$state/task-a.pr-poll" "$state/task-a.pr-poll-registration"
         ;;
       metadata-mismatch)
-        fm_pr_poll_prepare "$state" task-a https://github.com/o/r/pull/10 o r 10 "$POLL" \
+        fm_pr_poll_prepare "$state" task-a github https://github.com/o/r/pull/10 github.com o/r 10 "$POLL" \
           || fail "could not prepare metadata-mismatch fixture"
         fm_pr_poll_publish_prepared || fail "could not publish metadata-mismatch fixture"
         write_poll_meta "$state" task-a https://github.com/o/r/pull/11
         ;;
       task-mismatch)
-        fm_pr_poll_prepare "$state" task-a https://github.com/o/r/pull/10 o r 10 "$POLL" \
+        fm_pr_poll_prepare "$state" task-a github https://github.com/o/r/pull/10 github.com o/r 10 "$POLL" \
           || fail "could not prepare task-mismatch fixture"
         fm_pr_poll_publish_prepared || fail "could not publish task-mismatch fixture"
         { head -n 1 "$state/task-a.pr-poll-registration"; printf '%s\n' task-b; tail -n +3 "$state/task-a.pr-poll-registration"; } \
@@ -2255,7 +2425,7 @@ test_bootstrap_isolates_incomplete_poll_migration() {
   printf 'legacy bytes\n' > "$state/task-a.check.sh"
   mkdir "$state/task-a.pr-poll"
   write_poll_meta "$state" z-healthy https://github.com/o/r/pull/13
-  fm_pr_poll_prepare "$state" z-healthy https://github.com/o/r/pull/13 o r 13 "$POLL" \
+  fm_pr_poll_prepare "$state" z-healthy github https://github.com/o/r/pull/13 github.com o/r 13 "$POLL" \
     || fail "could not prepare healthy poll for migration isolation"
   fm_pr_poll_publish_prepared || fail "could not publish healthy poll for migration isolation"
   fm_write_meta "$state/secondmate-a.meta" \
@@ -2683,6 +2853,8 @@ test_invalid_entrypoints_have_zero_side_effects
 test_valid_recording_and_merge_derivation
 test_rejected_metacharacter_bytes_are_inert
 test_static_poll_contract
+test_gitlab_poll_contract
+test_legacy_v1_poll_is_recognised_and_rebuilt
 test_atomic_interruption_leaves_no_partial_artifact
 test_concurrent_watcher_sees_only_complete_publication
 test_postrename_poll_validation_revokes_and_retries


### PR DESCRIPTION
## What breaks today

The merge watch only recognises GitHub pull request URLs. A GitLab merge request URL is rejected at parse time, so a task tracking a GitLab merge request can never arm a merge poll: it waits indefinitely for a merge it has no way to observe.

This makes the watch work for GitLab merge requests, with the same safety properties the GitHub watch already has.

## `glab-axi` needs no change

Worth stating up front, because it removes a dependency you might otherwise assume. The watch chain calls its forge tools directly and has no wrapper contract to satisfy, and `glab-axi mr view <url> --jq .state` already returns merged state, including for self-hosted instances. Everything here is local to this repository.

## Why this changes the stored record rather than just the URL pattern

This is the one design decision worth your attention.

GitLab projects live under arbitrarily nested subgroups, so a project can sit at any depth: `group/subgroup/team/project`. No owner-and-repository pair can address one. The stored identity therefore becomes provider-tagged:

```
provider, url, host, path, number
```

where `path` is the full project path at whatever depth it has. That is the reason for a schema change instead of a wider regex.

The host is data too, never a constant. GitLab runs mostly on self-hosted instances, so pinning a single host would reproduce, with a different constant in it, exactly the limitation being removed on the GitHub side. The anti-tamper cross-check rebuilds the GitLab URL from the **stored** host rather than a fixed template, and a test asserts that no GitLab hostname appears anywhere in `bin/fm-pr-lib.sh` or `bin/fm-pr-poll.sh`.

## Compatibility

The registration version tag moves to `v2` deliberately, so a record written by the previous release is recognised as old rather than silently misparsed. It fails the current parsers, the poll emits nothing in that state, and the existing non-executing migration then rebuilds it from the task's recorded URL. That path is covered by a test.

GitHub behaviour is unchanged and was verified end to end against live pull requests: parse, arm, publish, validate and detect all behave exactly as before. GitHub validation was **not** loosened to make room for GitLab. The username and repository rules are byte for byte the ones already in the tree, GitLab namespace segments got their own separate rule, and the existing adversarial URL matrix still rejects in full.

## Design kept as-is

The poll stays byte-static and single-sourced, so the executable surface remains one reviewed script shared by every task, with per-task data living only in a private record and never interpolated into shell source. GitLab state is read through `--jq` as an exact field rather than matched out of human-readable output.

## Scope

Deliberately the watch only: noticing a merge and waking.

`bin/fm-pr-merge.sh` gets a two-line provider guard. Generalising the shared URL parser would otherwise have made that path start accepting GitLab URLs, which its own existing test asserts it must refuse. The guard **preserves** that file's current refusal exactly rather than extending it, and its existing test passes unmodified. It is there to hold today's behaviour until merge parity is done as its own change.

Also out of scope, and filed separately: teardown parity, and handling a merge request that is closed without being merged. The latter is left alone on purpose because the GitHub poll has the identical gap, and fixing it for one provider only would make the two behave differently.

## Verification

`docs/gitlab-merge-watch.md` records the evidence: exact commands and exact output, in the style of the existing `docs/*-backend.md` files.

The gitlab.com evidence uses a small public project created to be exactly that evidence, holding one deliberately merged merge request and one deliberately open one:

**https://gitlab.com/KarotKris/gitlab-merge-watch-fixture**

Reading either merge request needs no account, so every gitlab.com command in that document can be rerun as written. A second, non-`gitlab.com` host is also exercised to demonstrate the nested-namespace and non-default-host paths; its identifiers are placeholders because that instance is private, and the same properties are covered deterministically in the tests with synthetic hosts and deeply nested namespaces.

Each safety property of the GitHub poll is demonstrated for GitLab: byte-identical publication, data never interpolated into source, exact URL reconstruction from stored parts, transactional arming, rejection of unregistered or drifted checks without execution, hash-verified snapshot execution, and silence on error.

That last one is tested adversarially rather than on the happy path, since the failure mode worth preventing is a lookup error being read as a merge. A real 404, a host that does not resolve, the tool missing from `PATH`, and no network at all are each confirmed silent.

## Tests and lint

`bin/fm-lint.sh` passes. Tests are colocated in the existing `tests/fm-pr-check-security.test.sh` runner, covering the parser matrix for both providers, a GitLab-specific adversarial URL matrix, host-agnosticism, tamper resistance of the stored record, and the previous-release upgrade path.
