### PR TITLE
fix(supervision): honor declared pause on live terminal-run crews

### DIFF
--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -539,6 +539,24 @@ if [ "$HAVE_RUN" = 1 ]; then
       ;;
   esac
 
+  # A crew whose run has FINISHED (done/failed) but which has since declared an
+  # external-wait pause (paused:) or a captain-held transfer is genuinely paused
+  # NOW, not terminal: the finished run is usually the PRECONDITION of the pause
+  # ("checks green, now waiting for the maintainer to merge"). Honor that current
+  # declared intent so the supervisor reads a distinct pause (and its reason) and
+  # absorbs the idle pane, instead of a terminal state that classifies as a
+  # wedge-suspect idle. NEVER when a captain decision is still open in the durable
+  # keyed fold (a real gate is never silenced by a pause; status_open_decisions),
+  # and only for done/failed - working/parked (active run, open gate) keep their
+  # run-step precedence untouched above.
+  case "$RUN_STATE" in
+    done|failed)
+      if status_is_paused_or_captain_held "$LOG_LINE" && [ -z "$(status_open_decisions "$LOG")" ]; then
+        emit paused status-log "$(status_line_note "$LOG_LINE")"
+      fi
+      ;;
+  esac
+
   emit "$RUN_STATE" run-step "$RUN_DETAIL"
 fi
 

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -354,8 +354,13 @@ clear_pause_tracking() {  # <window>
 }
 
 # Reconcile a declared pause or captain-held status with authoritative crew state.
-# Only a confidently dead ordinary crew may recover paused classification after
-# fm-crew-state has fallen back to stopped or unknown.
+# A declared pause is honored (absorb) when the authoritative state itself confirms
+# it (crew_absorb_class == paused), regardless of agent aliveness - fm-crew-state
+# only reports paused once no captain decision is open, so a live idle paused crew
+# absorbs rather than storming. As an additional route, a confidently DEAD ordinary
+# crew recovers paused classification even after fm-crew-state has fallen back to
+# stopped or unknown. Only a `none` verdict on a LIVE agent (the authoritative state
+# does not confirm the pause, so a real gate may be masked) surfaces.
 pause_state_class() {  # <window> <task>
   local win=$1 task=$2 key last recheck_file class agent_alive
   key=${win//:/_}
@@ -369,14 +374,13 @@ pause_state_class() {  # <window> <task>
     return
   fi
   if [ -e "$STATE/.paused-$key" ] && [ "$(age_of "$recheck_file")" -lt "$STALE_ESCALATE_SECS" ]; then
-    if [ "$(window_kind "$win")" != secondmate ]; then
-      agent_alive=$(fm_backend_agent_alive "$(window_backend "$win")" "$win" 2>/dev/null) || agent_alive=unknown
-      if [ "$agent_alive" != dead ]; then
-        rm -f "$recheck_file"
-        printf 'none'
-        return
-      fi
-    fi
+    # This key was authoritatively classified paused within the last
+    # STALE_ESCALATE_SECS, so trust that verdict without the costly re-read - and
+    # regardless of agent aliveness, since a legitimately idle-but-alive paused crew
+    # must absorb, not surface. The verdict is re-verified against authoritative
+    # state once the recheck marker ages past STALE_ESCALATE_SECS (below), and a
+    # transition off the pause changes the last status line, which the callers
+    # reclassify.
     printf 'paused'
     return
   fi
@@ -384,6 +388,17 @@ pause_state_class() {  # <window> <task>
   if [ "$class" = working ]; then
     rm -f "$recheck_file"
     printf 'working'
+    return
+  fi
+  # The authoritative state itself confirms the declared pause (fm-crew-state honors
+  # the crew's current paused:/captain-held intent, having verified no captain
+  # decision is open). Honor it BEFORE the agent-alive gate so a live idle paused
+  # crew absorbs instead of surfacing. Only a `none` verdict (authoritative state
+  # does NOT confirm the pause, so a live gate may be masked) falls through to the
+  # alive-agent wedge path, which keeps the dead-agent none->paused recovery.
+  if [ "$class" = paused ]; then
+    date +%s > "$recheck_file"
+    printf 'paused'
     return
   fi
   if [ "$(window_kind "$win")" != secondmate ]; then

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -280,6 +280,19 @@ outcome: failed
 EOF
 }
 
+run_checks_passed() {  # <branch>
+  cat <<EOF
+run:
+  id: "01RUN"
+  branch: $1
+  status: completed
+  head: "abc1234"
+  pr: "https://github.com/o/r/pull/1"
+  findings: none
+outcome: checks-passed
+EOF
+}
+
 run_ci_monitoring() {  # <branch>
   cat <<EOF
 run:
@@ -671,6 +684,87 @@ test_terminal_failed() {
   assert_contains "$out" "state: failed" "failed run -> failed"
   assert_contains "$out" "source: run-step" "failed -> run-step source"
   pass "terminal failed run is authoritative"
+}
+
+# (d') A TERMINAL run (checks-passed/failed) that the crew has SINCE declared a
+# pause upon must read as paused, not terminal: the finished run is the
+# precondition of the pause (checks green, now awaiting the external maintainer).
+# This is the fm-crew-state half of the parked-crew stale-misclassification fix -
+# without it crew_absorb_class reads `none` and the watcher storms the idle pane.
+test_terminal_checks_passed_honors_declared_pause() {
+  reset_fakes
+  local d; d=$(new_case terminal-paused-checks)
+  make_repo_on_branch "$d/wt" fm/feat-paused-checks
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-paused-checks.meta" "window=fm:fm-feat-paused-checks" "worktree=$d/wt" "kind=ship"
+  printf 'paused: awaiting the external maintainer to merge the PR\n' > "$d/state/feat-paused-checks.status"
+  FM_FAKE_AXI_STATUS="$(run_checks_passed fm/feat-paused-checks)"
+  local out; out=$(run_crew_state "$d" feat-paused-checks)
+  assert_contains "$out" "state: paused" "terminal checks-passed + paused: -> paused"
+  assert_contains "$out" "source: status-log" "terminal-but-paused reads from the status log"
+  assert_contains "$out" "awaiting the external maintainer" "the pause reason is carried in the detail"
+  assert_not_contains "$out" "state: done" "a declared pause is not masked by the finished run"
+  pass "a terminal checks-passed run declared paused reads paused, not done"
+}
+
+test_terminal_failed_honors_declared_pause() {
+  reset_fakes
+  local d; d=$(new_case terminal-paused-failed)
+  make_repo_on_branch "$d/wt" fm/feat-paused-failed
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-paused-failed.meta" "window=fm:fm-feat-paused-failed" "worktree=$d/wt" "kind=ship"
+  printf 'paused: waiting on a rate-limit reset before retrying\n' > "$d/state/feat-paused-failed.status"
+  FM_FAKE_AXI_STATUS="$(run_failed fm/feat-paused-failed)"
+  local out; out=$(run_crew_state "$d" feat-paused-failed)
+  assert_contains "$out" "state: paused" "terminal failed + paused: -> paused"
+  assert_contains "$out" "source: status-log" "terminal-but-paused reads from the status log"
+  assert_contains "$out" "rate-limit reset" "the pause reason is carried in the detail"
+  assert_not_contains "$out" "state: failed" "a declared pause is not masked by the failed run"
+  pass "a terminal failed run declared paused reads paused, not failed"
+}
+
+# An OPEN captain decision in the durable keyed fold WINS over a later paused:
+# line: a real gate is never silenced by a pause, so the terminal run-step state
+# stands and the decision keeps surfacing.
+test_terminal_open_decision_beats_declared_pause() {
+  reset_fakes
+  local d; d=$(new_case terminal-open-decision)
+  make_repo_on_branch "$d/wt" fm/feat-open-decision
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-open-decision.meta" "window=fm:fm-feat-open-decision" "worktree=$d/wt" "kind=ship"
+  # An open captain decision, then a later paused: line that must NOT silence it.
+  printf 'needs-decision [key=q1]: pick storage backend\npaused: awaiting the maintainer\n' \
+    > "$d/state/feat-open-decision.status"
+  FM_FAKE_AXI_STATUS="$(run_checks_passed fm/feat-open-decision)"
+  local out; out=$(run_crew_state "$d" feat-open-decision)
+  assert_contains "$out" "state: done" "an open captain decision keeps the terminal run-step state"
+  assert_contains "$out" "source: run-step" "open-decision case stays run-step sourced"
+  assert_not_contains "$out" "state: paused" "a later paused: must not mask an open captain decision"
+
+  # The failed variant behaves the same: the open decision still wins.
+  FM_FAKE_AXI_STATUS="$(run_failed fm/feat-open-decision)"
+  out=$(run_crew_state "$d" feat-open-decision)
+  assert_contains "$out" "state: failed" "an open captain decision keeps a failed run-step state"
+  assert_not_contains "$out" "state: paused" "a later paused: must not mask an open decision on a failed run"
+  pass "an open captain decision beats a later declared pause on a terminal run"
+}
+
+# Invariant 1 (active-run precedence): a crew that appended paused: then STARTED a
+# run still reads working - the active run overrides the stale pause. The
+# terminal-run pause honoring above must NOT bleed into a working/parked run.
+test_active_run_overrides_stale_pause() {
+  reset_fakes
+  local d; d=$(new_case active-over-pause)
+  make_repo_on_branch "$d/wt" fm/feat-active-pause
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-active-pause.meta" "window=fm:fm-feat-active-pause" "worktree=$d/wt" "kind=ship"
+  printf 'paused: awaiting the maintainer\n' > "$d/state/feat-active-pause.status"
+  FM_FAKE_AXI_STATUS="$(run_running fm/feat-active-pause)"
+  local out; out=$(run_crew_state "$d" feat-active-pause)
+  assert_contains "$out" "state: working" "an active run overrides a stale paused: line"
+  assert_contains "$out" "source: run-step" "active-run precedence stays run-step sourced"
+  assert_not_contains "$out" "state: paused" "a stale pause must not mask an active run"
+  pass "an active run overrides a stale declared pause (invariant 1)"
 }
 
 # (e) cross-branch attribution: `axi status` returns ANOTHER branch's run (the
@@ -1155,6 +1249,10 @@ test_top_level_fixing_ci_running_after_green_stays_working
 test_top_level_fixing_done_log_stays_working
 test_terminal_passed
 test_terminal_failed
+test_terminal_checks_passed_honors_declared_pause
+test_terminal_failed_honors_declared_pause
+test_terminal_open_decision_beats_declared_pause
+test_active_run_overrides_stale_pause
 test_cross_branch_attribution_via_runs_list
 test_cross_branch_attribution_picks_most_recent_row
 test_coarse_run_does_not_probe_other_branch_ci_log_for_ready_status

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -624,9 +624,12 @@ test_nonterminal_stale_paused_absorbed_then_resurfaced() {
 # fm-crew-state then authoritatively reports stopped rather than paused, but the
 # confirmed-dead agent plus the declared wait or captain-held transfer must retain
 # bounded pause handling.
-# A still-live agent at an external-decision gate is the disconfirming case: it
-# must surface once, while the unchanged hash must not append the same wake on
-# every watcher re-arm.
+# A still-live agent whose AUTHORITATIVE state is an open decision gate is the
+# disconfirming case: fm-crew-state honors the open captain decision over a later
+# paused: line (crew_absorb_class reports `none`, not `paused`), so a live pane at a
+# real gate must surface once, while the unchanged hash must not append the same
+# wake on every watcher re-arm. (A live crew whose authoritative state DOES confirm
+# the pause is absorbed - covered by the parked-crew stale-misclassification tests.)
 test_exited_declared_pause_is_bounded_but_live_gate_surfaces() {
   local dir state fakebin out capture_file statusf window key pane_hash sig pid back round wakes bare
   dir=$(make_case exited-declared-pause); state="$dir/state"; fakebin="$dir/fakebin"
@@ -699,7 +702,7 @@ test_exited_declared_pause_is_bounded_but_live_gate_surfaces() {
   # First sight must surface promptly so a live external-decision gate is not
   # hidden behind the pause cadence.
   PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
-    FM_FAKE_TMUX_CURRENT_COMMAND=grok FM_FAKE_CREW_STATE='state: paused · source: status-log · waiting at an active external-decision gate' \
+    FM_FAKE_TMUX_CURRENT_COMMAND=grok FM_FAKE_CREW_STATE='state: parked · source: run-step · parked at review (ask-user: captain decision)' \
     FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_PAUSE_RESURFACE_SECS=999 FM_POLL=1 FM_SIGNAL_GRACE=1 \
     FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" >> "$out" &
   pid=$!
@@ -711,7 +714,7 @@ test_exited_declared_pause_is_bounded_but_live_gate_surfaces() {
   # a second possible-wedge wake.
   printf '%s\n' $(( $(date +%s) - 500 )) > "$state/.stale-since-$key"
   PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
-    FM_FAKE_TMUX_CURRENT_COMMAND=grok FM_FAKE_CREW_STATE='state: paused · source: status-log · waiting at an active external-decision gate' \
+    FM_FAKE_TMUX_CURRENT_COMMAND=grok FM_FAKE_CREW_STATE='state: parked · source: run-step · parked at review (ask-user: captain decision)' \
     FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_STALE_ESCALATE_SECS=240 FM_PAUSE_RESURFACE_SECS=999 FM_POLL=1 FM_SIGNAL_GRACE=1 \
     FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" >> "$out" &
   pid=$!
@@ -1236,6 +1239,146 @@ test_afk_paused_changed_pane_hands_off_plain_stale() {
   pass "AFK changed paused panes hand off plain stale identities for daemon-owned pause triage"
 }
 
+# --- parked-crew stale-misclassification regression (the pP/pM storm) ----------
+# A crew whose finished run it has since declared a pause upon reads authoritatively
+# `state: paused` (fm-crew-state Fix 1). pause_state_class must then honor that pause
+# on a LIVE ordinary crew - absorb it - not refuse it because the agent is alive. The
+# old code returned `none` for any alive pane, so the crew surfaced and the watcher
+# exited on every distinct stale hash (a ticking idle pane storms the continuity
+# guard fleet-wide). A confidently DEAD agent still absorbs on the same authoritative
+# verdict.
+test_declared_pause_absorbed_regardless_of_aliveness() {
+  local dir state fakebin out capture_file statusf window key sig pid cmd
+  for cmd in grok zsh; do
+    dir=$(make_case "declared-pause-alive-$cmd"); state="$dir/state"; fakebin="$dir/fakebin"
+    out="$dir/watch.out"; capture_file="$dir/pane.txt"; statusf="$state/held.status"
+    window="test:fm-held"
+    printf 'idle awaiting external\n' > "$capture_file"
+    printf 'window=%s\nkind=ship\nharness=grok\nbackend=tmux\n' "$window" > "$state/held.meta"
+    printf 'paused: checks green, awaiting the external maintainer to merge\n' > "$statusf"
+    sig=$(seen_sig "$statusf"); printf '%s' "$sig" > "$state/.seen-held_status"
+    key=$(printf '%s' "$window" | tr ':/.' '___')
+    printf '%s' "$(hash_text "idle awaiting external")" > "$state/.hash-$key"
+    printf '1\n' > "$state/.count-$key"
+    # The authoritative state confirms the declared pause (the finished run is the
+    # pause's precondition). cmd=grok is a live agent; cmd=zsh is a bare (dead) shell.
+    PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
+      FM_FAKE_TMUX_CURRENT_COMMAND="$cmd" \
+      FM_FAKE_CREW_STATE='state: paused · source: status-log · checks green, awaiting the external maintainer to merge' \
+      FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_PAUSE_RESURFACE_SECS=999 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+      FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+    pid=$!
+    if ! wait_live "$pid" 30; then
+      reap "$pid"; fail "watcher exited for an authoritatively-paused $cmd crew (should absorb): $(cat "$out")"
+    fi
+    [ ! -s "$out" ] || { reap "$pid"; fail "authoritatively-paused $cmd crew printed a wake reason during absorb: $(cat "$out")"; }
+    [ ! -s "$state/.wake-queue" ] || { reap "$pid"; fail "authoritatively-paused $cmd crew enqueued a wake during absorb"; }
+    [ -e "$state/.paused-$key" ] || { reap "$pid"; fail "authoritatively-paused $cmd crew did not record the bounded pause cadence"; }
+    [ ! -e "$state/.stale-since-$key" ] || { reap "$pid"; fail "an absorbed pause must not start the wedge timer ($cmd)"; }
+    reap "$pid"
+  done
+  pass "a declared pause confirmed by authoritative state is absorbed whether the agent is alive or dead"
+}
+
+# The direct pP/pM reproduction: a LIVE idle crew authoritatively paused whose pane
+# TICKS (a clock/spinner/token counter yields a new hash each poll) must be absorbed
+# on every distinct stale hash and keep the watcher live, then re-surface exactly once
+# past PAUSE_RESURFACE_SECS. Before the fix each new hash surfaced and exited the
+# watcher, tripping the continuity guard every poll.
+test_live_paused_ticking_pane_absorbed_then_resurfaced() {
+  local dir state fakebin out capture_file statusf window key sig pid i back
+  dir=$(make_case live-paused-ticking); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"; capture_file="$dir/pane.txt"; statusf="$state/paused.status"
+  window="test:fm-live-paused"
+  printf 'idle awaiting external tick 0\n' > "$capture_file"
+  printf 'window=%s\nkind=ship\nharness=grok\nbackend=tmux\n' "$window" > "$state/paused.meta"
+  printf 'paused: checks green, awaiting the external maintainer to merge\n' > "$statusf"
+  sig=$(seen_sig "$statusf"); printf '%s' "$sig" > "$state/.seen-paused_status"
+  key=$(printf '%s' "$window" | tr ':/.' '___')
+  printf '%s' "$(hash_text "idle awaiting external tick 0")" > "$state/.hash-$key"
+  printf '1\n' > "$state/.count-$key"
+  export FM_FAKE_CREW_STATE='state: paused · source: status-log · checks green, awaiting the external maintainer to merge'
+
+  # Phase A: a live agent, fresh pause, high re-surface threshold. Tick the idle pane
+  # so each poll sees a new stale hash; the watcher must absorb every one and stay live.
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
+    FM_FAKE_TMUX_CURRENT_COMMAND=grok \
+    FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_PAUSE_RESURFACE_SECS=999 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  i=1
+  while [ "$i" -le 3 ]; do
+    sleep 1.2
+    printf 'idle awaiting external tick %d\n' "$i" > "$capture_file"
+    i=$((i + 1))
+  done
+  sleep 1.2
+  if ! kill -0 "$pid" 2>/dev/null; then
+    wait "$pid" 2>/dev/null || true
+    fail "watcher exited on a ticking idle paused pane (the pP/pM storm): $(cat "$out")"
+  fi
+  [ ! -s "$out" ] || { reap "$pid"; fail "ticking paused pane printed a wake reason instead of absorbing: $(cat "$out")"; }
+  [ ! -s "$state/.wake-queue" ] || { reap "$pid"; fail "ticking paused pane enqueued a wake instead of absorbing"; }
+  [ -e "$state/.paused-$key" ] || { reap "$pid"; fail "ticking paused pane did not record the bounded pause cadence"; }
+  [ -e "$state/.last-watcher-beat" ] || { reap "$pid"; fail "watcher beacon missing while absorbing the ticking pane"; }
+  [ "$(( $(date +%s) - $(file_mtime "$state/.last-watcher-beat") ))" -lt 10 ] \
+    || { reap "$pid"; fail "watcher beacon went stale while absorbing the ticking paused pane"; }
+  reap "$pid"
+
+  # Phase B: age the pause past the (now normal) threshold; re-prime .seen-* and give
+  # it a fresh hash. It must re-surface exactly once as a paused recheck, never a wedge.
+  back=$(( $(date +%s) - 500 ))
+  if [ "$(uname)" = Darwin ]; then touch -mt "$(date -r "$back" '+%Y%m%d%H%M.%S')" "$statusf"
+  else touch -m -d "@$back" "$statusf"; fi
+  sig=$(seen_sig "$statusf"); printf '%s' "$sig" > "$state/.seen-paused_status"
+  : > "$out"
+  printf 'idle awaiting external tick final\n' > "$capture_file"
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
+    FM_FAKE_TMUX_CURRENT_COMMAND=grok \
+    FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_PAUSE_RESURFACE_SECS=240 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  wait_for_exit "$pid" 40 || fail "watcher did not re-surface a live declared pause past the threshold"
+  grep -F "awaiting external" "$out" >/dev/null || fail "live pause re-surface was not labeled an awaiting-external recheck"
+  grep -F "possible wedge" "$out" >/dev/null && fail "a live declared pause was mislabeled a possible wedge"
+  [ -e "$state/.paused-resurfaced-$key" ] || fail "the live pause re-surface throttle marker was not recorded"
+  unset FM_FAKE_CREW_STATE
+  pass "a live idle authoritatively-paused pane is absorbed across ticking polls, then re-surfaced once past the threshold"
+}
+
+# Invariant 2 (genuine wedges still surface): a LIVE crew with NO current declared
+# pause - a bare working: line and an authoritative `none` verdict - still surfaces
+# immediately. The pause fix must not over-absorb a real wedge.
+test_live_wedge_without_declared_pause_still_surfaces() {
+  local dir state fakebin out drain_out capture_file window key pane_hash sig pid
+  dir=$(make_case live-wedge-no-pause); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"; drain_out="$dir/drain.out"; capture_file="$dir/pane.txt"
+  window="test:fm-live-wedge"
+  printf 'idle prompt, quiet\n' > "$capture_file"
+  printf 'window=%s\nkind=ship\nharness=grok\nbackend=tmux\n' "$window" > "$state/wedge.meta"
+  printf 'working: implementing the parser\n' > "$state/wedge.status"
+  sig=$(seen_sig "$state/wedge.status"); printf '%s' "$sig" > "$state/.seen-wedge_status"
+  key=$(printf '%s' "$window" | tr ':/.' '___')
+  pane_hash=$(hash_text "idle prompt, quiet")
+  printf '%s' "$pane_hash" > "$state/.hash-$key"
+  printf '1\n' > "$state/.count-$key"
+  # No declared pause (last line is working:), and no running pipeline: authoritative
+  # `none`. A live pane must still surface at once - the crew may be wedged.
+  export FM_FAKE_CREW_STATE='state: unknown · source: none · no current-state source available'
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
+    FM_FAKE_TMUX_CURRENT_COMMAND=grok \
+    FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_STALE_ESCALATE_SECS=999 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  wait_for_exit "$pid" 40 || fail "watcher did not surface a live wedge with no declared pause"
+  grep -Fx "stale: $window" "$out" >/dev/null || fail "watcher did not print the immediate stale wake for a genuine wedge"
+  [ ! -e "$state/.paused-$key" ] || { reap "$pid"; fail "a genuine wedge was wrongly recorded as a bounded pause"; }
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$drain_out" 2>/dev/null || fail "drain after the genuine-wedge stale failed"
+  grep "$(printf '\tstale\t')" "$drain_out" | grep -F "$window" >/dev/null || fail "genuine-wedge stale was not queued"
+  unset FM_FAKE_CREW_STATE
+  pass "a live crew with no declared pause still surfaces as a genuine wedge (invariant 2 preserved)"
+}
+
 test_signal_reason_is_actionable_classifier
 test_stale_is_terminal_classifier
 test_scan_captain_relevant_statuses_classifier
@@ -1270,3 +1413,6 @@ test_heartbeat_backstop_surfaces_unsurfaced_status
 test_beacon_stays_fresh_while_absorbing
 test_afk_present_reverts_watcher_to_one_shot
 test_afk_paused_changed_pane_hands_off_plain_stale
+test_declared_pause_absorbed_regardless_of_aliveness
+test_live_paused_ticking_pane_absorbed_then_resurfaced
+test_live_wedge_without_declared_pause_still_surfaces


### PR DESCRIPTION
## Summary

Fixes a supervision correctness bug: a crew that declared a `paused:` external wait but whose no-mistakes run is terminal (`checks-passed`/`passed`/`completed` -> `done`, `failed`/`cancelled` -> `failed`) was misclassified as `absorb-class none` instead of `paused`. `fm-watch` then surfaced-and-exited on every distinct stale hash. A live idle pane with any ticking element (clock/spinner/token counter) yields a new hash each poll, so the watcher exited every poll, tripping the watcher-continuity guard and denying teardown, decision holds, and session-start across the fleet (the live pP/pM storm).

## The fix

Two coordinated edits; the third dispatch arm already exists in the codebase.

1. **`bin/fm-crew-state.sh`** — in the run-step authoritative path, a terminal `RUN_STATE` (`done`/`failed`) no longer masks the crew's current declared pause. When the last status line is a `paused:`/`captain-held` declaration **and** no captain decision is open in the durable keyed fold (`status_open_decisions`), it emits `state: paused` instead of the terminal state. The finished run is usually the *precondition* of the pause ("checks green, now awaiting the external maintainer"). `working`/`parked` run states are left untouched, preserving active-run precedence and open-gate surfacing.

2. **`bin/fm-watch.sh` `pause_state_class`** — honors a `paused` absorb-class **before** the agent-alive gate, in both the within-recheck-window and past-window branches, so a legitimately idle-but-alive paused crew absorbs instead of surfacing. A `none` verdict on a live agent still falls through to the wedge path, and the dead-agent `none`->`paused` recovery is kept.

3. **Stale dispatch (no change needed)** — the `paused) handle_paused_stale` arms already exist on all three dispatch sites (new-hash, same-hash, changed-hash), landed by earlier work. Edits 1 and 2 make `pause_state_class` return `paused`, so those existing arms fire. No duplicate case arm was added.

### Invariants preserved (and covered by new regressions)

- **Active-run precedence** — a crew that paused then started a run still reads `working`.
- **Open captain decisions still surface** — an open `needs-decision:`/`blocked:` in the durable keyed fold wins over a later `paused:`.
- **Genuine wedges still surface** — a live crew with no current declared pause still surfaces stale.
- **No invisible rot** — an honored pause still re-surfaces once per `PAUSE_RESURFACE_SECS` (1h, unchanged).

## Files changed

- `bin/fm-crew-state.sh` — terminal run no longer masks a current declared pause.
- `bin/fm-watch.sh` — `pause_state_class` honors a declared pause on a live crew.
- `tests/fm-crew-state.test.sh` — regressions: terminal+paused -> paused, open-decision-wins -> done/failed, active-run overrides stale pause.
- `tests/fm-watch-triage.test.sh` — regressions: alive/dead authoritative-paused absorb, the ticking-pane absorb-then-resurface reproduction, a genuine wedge still surfacing; the pre-existing live-decision-gate case is updated to the new contract (a live gate surfaces because its authoritative state is the open gate, not paused).

## Compatibility

The changed classification is read by both the watcher (`bin/fm-watch.sh`) and the away-mode daemon (`bin/fm-supervise-daemon.sh`) via `bin/fm-classify-lib.sh`. The daemon uses `status_is_paused` directly (untouched) and never calls `fm-crew-state` or `pause_state_class`, so it is unaffected — verified by running the daemon suite. The change is backend-agnostic (status/run-step classification, not a specific tmux/herdr probe).

## Validation

This change used the **direct-PR path** rather than the no-mistakes pipeline because no-mistakes v1.37.0 refused to *launch* its gate agent: it reported `gate agent "claude" does not neutralize the target repository's project agent-instruction files (AGENTS.md/CLAUDE.md); refusing to launch it in the target checkout`, and failed before step 0. This is self-contradictory — `no-mistakes doctor` reports `gate validation: claude is runnable`, and this repo's `.no-mistakes.yaml` already sets `disable_project_settings: true` (honored from the trusted default-branch copy). The likely cause is a version gap (v1.37.0 installed, v1.40.0 available) in how the claude neutralization knob is verified against this repo's `AGENTS.md` plus its `CLAUDE.md` symlink. The refusal is unrelated to this change (which touches only `bin/` and `tests/`).

Local verification, all green:

- `bin/fm-lint.sh` clean over the whole canonical set (`bin/*.sh bin/backends/*.sh tests/*.sh`), pinned ShellCheck 0.11.0.
- `tests/fm-crew-state.test.sh` — all pass, including the 4 new pause cases.
- `tests/fm-watch-triage.test.sh` — all 37 pass, including the 3 new pause cases.
- `tests/fm-daemon.test.sh` — all 95 pass (away-mode daemon compatibility).

CI runs the same lint and behavior suites, so the pushed branch is validated by CI on this PR.
