### PR TITLE
fix(readiness): ignore Vercel Preview deployments when reporting PR readiness

### DIFF
--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -33,8 +33,10 @@
 #      passed/checks-passed -> done, failed/cancelled -> failed. EXCEPT: while
 #      the active step is ci, `axi status` alone cannot tell "still waiting on
 #      checks" from "checks green, waiting on merge" (see nm_ci_checks_state) -
-#      a ci-step log-tail check overrides working -> done once checks read
-#      green, so a green PR is never silently read as still-validating.
+#      a ci-step log-tail check or bin/fm-pr-ready.sh's exact-head GitHub read
+#      overrides working -> done once checks read ready, so a PR whose only
+#      non-success context is a classified Vercel Preview deployment is not
+#      silently read as still-validating.
 #   3. Reconcile the status log: if its last line says needs-decision/blocked but
 #      the run-step shows the run moved on, the log is deterministically stale and
 #      is flagged superseded. A genuinely parked run plus a needs-decision log
@@ -62,6 +64,8 @@ STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 . "$SCRIPT_DIR/fm-backend.sh"
 # shellcheck source=bin/fm-classify-lib.sh
 . "$SCRIPT_DIR/fm-classify-lib.sh"
+# shellcheck source=bin/fm-pr-lib.sh
+. "$SCRIPT_DIR/fm-pr-lib.sh"
 
 ID=${1:-}
 [ -n "$ID" ] || { echo "usage: fm-crew-state.sh <id>" >&2; exit 2; }
@@ -294,7 +298,7 @@ log_reports_ci_ready() {
 
 nm_ci_step_status() {
   local row rest
-  row=$(printf '%s\n' "$RUN_OUT" | grep -E '^[[:space:]]*ci,[[:space:]]*"?(running|fixing)"?[[:space:]]*,' | head -1)
+  row=$(printf '%s\n' "$RUN_OUT" | grep -E '^[[:space:]]*ci,[[:space:]]*"?[A-Za-z_-]+"?[[:space:]]*,' | head -1)
   [ -n "$row" ] || return 0
   row=$(trim "$row")
   rest=${row#*,}
@@ -346,6 +350,25 @@ nm_ci_checks_state() {
     *"no CI checks reported yet"*|*"checks failed"*|*"issues detected"*|*"CI checks running"*|*"base branch advanced"*"re-arming CI monitor timeout"*) printf 'not-ready' ;;
     *) printf 'unknown' ;;
   esac
+}
+
+# no-mistakes intentionally remains unmodified and may keep monitoring a
+# non-success Vercel status.  fm-pr-ready.sh is the single owner of the narrow
+# Preview-deployment exception and every ordinary GitHub readiness rule.  Bind
+# that read to both this run's recorded head prefix and the worktree's exact
+# current head before allowing it to override the coarse ci/log state.
+nm_github_pr_ready() {
+  local pr_url run_head expected_head
+  pr_url=$(strip_quotes "$(nm_field pr)")
+  run_head=$(strip_quotes "$(nm_field head)")
+  [ -n "$pr_url" ] && [[ "$run_head" =~ ^[0-9a-f]{7,64}$ ]] || return 1
+  expected_head=$(git -C "$WT" rev-parse HEAD 2>/dev/null) || return 1
+  fm_pr_head_valid "$expected_head" || return 1
+  case "$expected_head" in
+    "$run_head"*) ;;
+    *) return 1 ;;
+  esac
+  "$SCRIPT_DIR/fm-pr-ready.sh" "$pr_url" "$expected_head" >/dev/null 2>&1
 }
 # Coarse fallback for cross-branch attribution. `no-mistakes axi status` (bare)
 # reports the active-or-most-recent run for the CURRENT branch when one
@@ -550,12 +573,28 @@ if [ "$HAVE_RUN" = 1 ]; then
             if [ "$CI_LOG_STATE" = green ]; then
               RUN_STATE="done"
               RUN_DETAIL="checks green: PR ready for review (still monitoring for merge/close)"
+            elif nm_github_pr_ready; then
+              CI_LOG_STATE=green
+              RUN_STATE="done"
+              RUN_DETAIL="checks ready: Vercel Preview deployments do not block review"
             fi
             ;;
           fixing)
             CI_LOG_STATE=not-ready
             ;;
         esac
+      fi
+    fi
+
+    # A failed no-mistakes outcome is overridden only when its own ci row
+    # failed and an exact-head GitHub read proves every ordinary context ready.
+    # Failures from review, test, lint, push, or an unclassified deployment keep
+    # their existing terminal result.
+    if [ "$RUN_STATE" = failed ]; then
+      CI_STEP_STATUS=$(nm_ci_step_status)
+      if [ "$CI_STEP_STATUS" = failed ] && nm_github_pr_ready; then
+        RUN_STATE="done"
+        RUN_DETAIL="checks ready: failed Vercel Preview deployment does not block review"
       fi
     fi
   fi

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -298,7 +298,7 @@ log_reports_ci_ready() {
 
 nm_ci_step_status() {
   local row rest
-  row=$(printf '%s\n' "$RUN_OUT" | grep -E '^[[:space:]]*ci,[[:space:]]*"?[A-Za-z_-]+"?[[:space:]]*,' | head -1)
+  row=$(printf '%s\n' "$RUN_OUT" | grep -E '^[[:space:]]*ci,[[:space:]]*"?(running|fixing|failed)"?[[:space:]]*,' | head -1)
   [ -n "$row" ] || return 0
   row=$(trim "$row")
   rest=${row#*,}

--- a/bin/fm-pr-ready.sh
+++ b/bin/fm-pr-ready.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Determine whether an open GitHub PR's current head is ready for review.
+#
+# This script owns Firstmate's reusable GitHub readiness classification.
+# It reads the PR's current head, combined commit statuses, latest check runs,
+# and exact-head deployments without caching any result.
+# The caller supplies the expected full head SHA; a changed PR head makes the
+# result not ready before status evidence is read, so stale readiness cannot be
+# reused.
+#
+# Every status and check must have a passing GitHub state, with one narrow
+# exception: a non-success commit status whose context is exactly `Vercel` is
+# excluded only when the exact head has at least one Vercel-authored deployment
+# and every Vercel-authored deployment for that head has environment `Preview`
+# and production_environment=false.
+# The deployment API fields, exact SHA, and Vercel deployment creator are the
+# classification boundary; the ambiguous status display name alone is never
+# enough.
+# A production, mixed-environment, missing, or otherwise unclassified Vercel
+# deployment remains blocking, as does every pending or failed ordinary check.
+# Zero reported checks is not ready here because no-mistakes owns its settling
+# period for repositories that genuinely have no CI.
+#
+# Readiness is not merge authority.
+# This script only prints `ready` and exits 0; it never records approval, arms a
+# merge poll, or invokes a merge command.
+#
+# Usage: fm-pr-ready.sh <canonical-pr-url> <expected-full-head-sha>
+# Exit 0 means ready, 1 means not ready or authoritative data was unavailable,
+# and 2 means invalid arguments.
+set -u
+LC_ALL=C
+export LC_ALL
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=bin/fm-pr-lib.sh
+. "$SCRIPT_DIR/fm-pr-lib.sh"
+
+if [ "$#" -ne 2 ] || ! fm_pr_url_parse "$1" || ! fm_pr_head_valid "$2"; then
+  echo "usage: fm-pr-ready.sh <canonical-pr-url> <expected-full-head-sha>" >&2
+  exit 2
+fi
+URL=$FM_PR_URL
+OWNER=$FM_PR_OWNER
+REPO=$FM_PR_REPO
+EXPECTED_HEAD=$2
+TAB=$(printf '\t')
+
+command -v gh >/dev/null 2>&1 || exit 1
+
+PR_ROW=$(gh pr view "$URL" --json state,headRefOid --jq '[.state,.headRefOid] | @tsv' 2>/dev/null) || exit 1
+IFS="$TAB" read -r PR_STATE PR_HEAD PR_EXTRA <<EOF
+$PR_ROW
+EOF
+[ -z "${PR_EXTRA:-}" ] || exit 1
+[ "$PR_STATE" = OPEN ] || exit 1
+fm_pr_head_valid "$PR_HEAD" || exit 1
+[ "$PR_HEAD" = "$EXPECTED_HEAD" ] || exit 1
+
+STATUS_ROWS=$(gh api --paginate "/repos/$OWNER/$REPO/commits/$PR_HEAD/status?per_page=100" \
+  --jq '.statuses[] | [.context,.state] | @tsv' 2>/dev/null) || exit 1
+CHECK_ROWS=$(gh api --paginate "/repos/$OWNER/$REPO/commits/$PR_HEAD/check-runs?per_page=100&filter=latest" \
+  --jq '.check_runs[] | [.name,.status,(.conclusion // "")] | @tsv' 2>/dev/null) || exit 1
+
+STATUS_COUNT=0
+CHECK_COUNT=0
+VERCEL_BLOCKING=0
+OTHER_BLOCKING=0
+while IFS="$TAB" read -r CONTEXT STATUS EXTRA; do
+  [ -n "$CONTEXT" ] || continue
+  STATUS_COUNT=$((STATUS_COUNT + 1))
+  [ -z "${EXTRA:-}" ] || { OTHER_BLOCKING=1; continue; }
+  case "$STATUS" in
+    success) ;;
+    pending|failure|error)
+      if [ "$CONTEXT" = Vercel ]; then
+        VERCEL_BLOCKING=1
+      else
+        OTHER_BLOCKING=1
+      fi
+      ;;
+    *) OTHER_BLOCKING=1 ;;
+  esac
+done <<EOF
+$STATUS_ROWS
+EOF
+
+while IFS="$TAB" read -r NAME CHECK_STATUS CONCLUSION EXTRA; do
+  [ -n "$NAME" ] || continue
+  CHECK_COUNT=$((CHECK_COUNT + 1))
+  [ -z "${EXTRA:-}" ] || { OTHER_BLOCKING=1; continue; }
+  if [ "$CHECK_STATUS" != completed ]; then
+    OTHER_BLOCKING=1
+    continue
+  fi
+  case "$CONCLUSION" in
+    success|neutral|skipped) ;;
+    *) OTHER_BLOCKING=1 ;;
+  esac
+done <<EOF
+$CHECK_ROWS
+EOF
+
+[ "$((STATUS_COUNT + CHECK_COUNT))" -gt 0 ] || exit 1
+[ "$OTHER_BLOCKING" -eq 0 ] || exit 1
+
+if [ "$VERCEL_BLOCKING" -eq 1 ]; then
+  DEPLOYMENT_ROWS=$(gh api --paginate "/repos/$OWNER/$REPO/deployments?sha=$PR_HEAD&per_page=100" \
+    --jq '.[] | [.sha,.environment,(.production_environment | tostring),(.creator.login // "")] | @tsv' \
+    2>/dev/null) || exit 1
+  VERCEL_DEPLOYMENTS=0
+  VERCEL_PREVIEW_ONLY=1
+  while IFS="$TAB" read -r DEPLOY_SHA ENVIRONMENT PRODUCTION CREATOR EXTRA; do
+    [ -n "$DEPLOY_SHA" ] || continue
+    [ -z "${EXTRA:-}" ] || { VERCEL_PREVIEW_ONLY=0; continue; }
+    [ "$DEPLOY_SHA" = "$PR_HEAD" ] || { VERCEL_PREVIEW_ONLY=0; continue; }
+    [ "$CREATOR" = 'vercel[bot]' ] || continue
+    VERCEL_DEPLOYMENTS=$((VERCEL_DEPLOYMENTS + 1))
+    if [ "$ENVIRONMENT" != Preview ] || [ "$PRODUCTION" != false ]; then
+      VERCEL_PREVIEW_ONLY=0
+    fi
+  done <<EOF
+$DEPLOYMENT_ROWS
+EOF
+  [ "$VERCEL_DEPLOYMENTS" -gt 0 ] || exit 1
+  [ "$VERCEL_PREVIEW_ONLY" -eq 1 ] || exit 1
+fi
+
+printf 'ready\n'
+exit 0

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,6 +28,7 @@ Crew status files are append-only wake-event logs, not current-state fields.
 The script header owns the exact run-head ancestry rules.
 During no-mistakes' `ci` monitor phase, it also reads the ci step log tail because `axi status` reports both "still waiting on checks" and "checks green, waiting on merge" as `ci,running`.
 The most recent recognized ci log marker wins, so checks-green monitoring reports done while a later re-arm, failed-check, or issue marker returns the crew to working.
+An exact-head `bin/fm-pr-ready.sh` read can likewise report done when the only non-success context is a deployment-proven Vercel Preview status; that script owns the full readiness classification.
 Only when no matching run exists does it fall back to the pane busy-signature and then a status-log event whose verb maps to a recognized run-state; a dead pane without a run reports unknown instead of trusting a stale log.
 Decision-only events such as `resolved` never become current state or leak their prose into the current-state detail.
 In that status-log fallback, a declared external wait reports the distinct `paused` state with its reason.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -70,6 +70,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-check-register.sh`   | Bind an intentional custom watcher check to its current bytes                       |
 | `fm-check-lib.sh`        | Validate custom-check registrations and prepare private execution snapshots          |
 | `fm-pr-lib.sh`           | Own canonical task and PR validation plus private atomic PR-poll and provenance publication |
+| `fm-pr-ready.sh`         | Classify exact-head GitHub readiness, excluding only deployment-proven Vercel Preview statuses |
 | `fm-pr-poll.sh`          | Provide the byte-static watcher program for validated PR-poll sidecars              |
 | `fm-pr-check-migrate.sh` | Quarantine older task polls without execution and rebuild only canonical polls       |
 | `fm-pr-check.sh`         | Record validated `pr=` and `pr_head=` values, then atomically arm a static merge poll |

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -93,6 +93,25 @@ case "${1:-}" in
 esac
 exit 0
 SH
+  cat > "$fb/gh" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "${1:-} ${2:-}" in
+  "pr view")
+    [ -n "${FM_FAKE_GH_PR_HEAD:-}" ] || exit 1
+    printf 'OPEN\t%s\n' "$FM_FAKE_GH_PR_HEAD"
+    ;;
+  "api --paginate")
+    case "${3:-}" in
+      */status\?*) printf '%s\n' "${FM_FAKE_GH_STATUS_ROWS:-}" ;;
+      */check-runs\?*) printf '%s\n' "${FM_FAKE_GH_CHECK_ROWS:-}" ;;
+      */deployments\?*) printf '%s\n' "${FM_FAKE_GH_DEPLOYMENT_ROWS:-}" ;;
+      *) exit 1 ;;
+    esac
+    ;;
+  *) exit 1 ;;
+esac
+SH
   cat > "$fb/herdr" <<'SH'
 #!/usr/bin/env bash
 set -u
@@ -122,7 +141,7 @@ case "${1:-}" in
 esac
 exit 0
 SH
-  chmod +x "$fb/no-mistakes" "$fb/tmux" "$fb/herdr"
+  chmod +x "$fb/no-mistakes" "$fb/tmux" "$fb/gh" "$fb/herdr"
   printf '%s\n' "$fb"
 }
 
@@ -162,8 +181,13 @@ reset_fakes() {
   FM_FAKE_HERDR_MISSING=0
   FM_FAKE_HERDR_AGENT_STATUS=""
   FM_FAKE_CI_LOGS=""
+  FM_FAKE_GH_PR_HEAD=""
+  FM_FAKE_GH_STATUS_ROWS=""
+  FM_FAKE_GH_CHECK_ROWS=""
+  FM_FAKE_GH_DEPLOYMENT_ROWS=""
   export FM_FAKE_AXI_STATUS FM_FAKE_AXI_STATUS_RUN FM_FAKE_RUNS_LIST FM_FAKE_BUSY FM_FAKE_TMUX_MISSING
   export FM_FAKE_HERDR_BUSY FM_FAKE_HERDR_MISSING FM_FAKE_HERDR_AGENT_STATUS FM_FAKE_CI_LOGS
+  export FM_FAKE_GH_PR_HEAD FM_FAKE_GH_STATUS_ROWS FM_FAKE_GH_CHECK_ROWS FM_FAKE_GH_DEPLOYMENT_ROWS
 }
 
 # --- run-object fixtures (TOON, as `no-mistakes axi status` emits) -----------
@@ -331,6 +355,24 @@ run:
     review,completed,0,0
     push,completed,0,0
     ci,fixing,0,0
+EOF
+}
+
+run_ci_failed() {  # <branch>
+  cat <<EOF
+run:
+  id: "01RUN"
+  branch: $1
+  status: completed
+  head: "abc1234"
+  pr: "https://github.com/o/r/pull/2"
+  findings: none
+  steps[4]{step,status,findings,duration_ms}:
+    intent,completed,0,0
+    review,completed,0,0
+    push,completed,0,0
+    ci,failed,0,0
+outcome: failed
 EOF
 }
 
@@ -556,6 +598,51 @@ test_ci_monitoring_still_waiting_stays_working() {
   assert_contains "$out" "state: working" "ci step still red -> working"
   assert_not_contains "$out" "checks green" "no green marker present -> no checks-green detail"
   pass "ci-monitoring run with checks not yet green stays working"
+}
+
+# Firstmate independently recognizes the exact GitHub representation observed
+# on stacker-scan PR 657 even while no-mistakes' unmodified ci monitor still
+# reports the Vercel commit status as running or failed.
+test_ci_monitoring_only_vercel_preview_surfaces_done() {
+  reset_fakes
+  local d head short out
+  d=$(new_case ci-vercel-preview)
+  make_repo_on_branch "$d/wt" fm/feat-civercel
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-civercel.meta" "window=fm:fm-feat-civercel" "worktree=$d/wt" "kind=ship"
+  head=$(git -C "$d/wt" rev-parse HEAD)
+  short=$(printf '%s' "$head" | cut -c1-7)
+  FM_FAKE_AXI_STATUS=$(run_ci_monitoring fm/feat-civercel | sed "s/abc1234/$short/")
+  FM_FAKE_CI_LOGS="CI checks running, waiting for results..."
+  FM_FAKE_GH_PR_HEAD=$head
+  FM_FAKE_GH_STATUS_ROWS=$'Vercel\tpending'
+  FM_FAKE_GH_DEPLOYMENT_ROWS="$head"$'\tPreview\tfalse\tvercel[bot]'
+  out=$(run_crew_state "$d" feat-civercel)
+  assert_contains "$out" "state: done" "only Vercel Preview -> done"
+  assert_contains "$out" "source: run-step" "Vercel Preview readiness remains run-step sourced"
+  assert_contains "$out" "Vercel Preview deployments do not block" "detail explains the readiness exception"
+  pass "ci monitoring recognizes an exact-head Vercel Preview as non-blocking"
+}
+
+test_ci_failed_only_vercel_preview_surfaces_done() {
+  reset_fakes
+  local d head short out
+  d=$(new_case ci-vercel-preview-failed)
+  make_repo_on_branch "$d/wt" fm/feat-civercelfailed
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-civercelfailed.meta" "window=fm:fm-feat-civercelfailed" "worktree=$d/wt" "kind=ship"
+  head=$(git -C "$d/wt" rev-parse HEAD)
+  short=$(printf '%s' "$head" | cut -c1-7)
+  FM_FAKE_AXI_STATUS=$(run_ci_failed fm/feat-civercelfailed | sed "s/abc1234/$short/")
+  FM_FAKE_GH_PR_HEAD=$head
+  FM_FAKE_GH_STATUS_ROWS=$'Vercel\tfailure'
+  FM_FAKE_GH_DEPLOYMENT_ROWS="$head"$'\tPreview\tfalse\tvercel[bot]'
+  out=$(run_crew_state "$d" feat-civercelfailed)
+  assert_contains "$out" "state: done" "failed Vercel Preview alone -> done"
+  assert_contains "$out" "failed Vercel Preview deployment does not block" \
+    "failed-preview detail explains the narrow override"
+  assert_not_contains "$out" "state: failed" "failed Preview must not keep the PR failed"
+  pass "a ci failure caused only by Vercel Preview is non-blocking"
 }
 
 # A later merge-conflict auto-fix round after an earlier green reading must
@@ -1245,6 +1332,8 @@ test_ci_monitoring_no_checks_terminal_surfaces_done
 test_ci_monitoring_green_then_rearm_stays_working
 test_ci_monitoring_no_checks_yet_stays_working
 test_ci_monitoring_still_waiting_stays_working
+test_ci_monitoring_only_vercel_preview_surfaces_done
+test_ci_failed_only_vercel_preview_surfaces_done
 test_ci_monitoring_green_then_new_issue_stays_working
 test_ci_ready_done_log_relapse_stays_working
 test_ci_fixing_after_green_stays_working

--- a/tests/fm-pr-ready.test.sh
+++ b/tests/fm-pr-ready.test.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Focused readiness classification tests for bin/fm-pr-ready.sh.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+READY="$ROOT/bin/fm-pr-ready.sh"
+TMP_ROOT=$(fm_test_tmproot fm-pr-ready)
+HEAD_A=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+HEAD_B=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+URL=https://github.com/example/project/pull/42
+
+make_fake_gh() {
+  local dir=$1
+  mkdir -p "$dir/fakebin"
+  cat > "$dir/fakebin/gh" <<'SH'
+#!/usr/bin/env bash
+set -u
+printf '%s\n' "$*" >> "$FM_FAKE_GH_LOG"
+case "${1:-} ${2:-}" in
+  "pr view")
+    printf '%s\t%s\n' "${FM_FAKE_PR_STATE:-OPEN}" "${FM_FAKE_PR_HEAD:-}"
+    ;;
+  "api --paginate")
+    case "${3:-}" in
+      */status\?*) printf '%s\n' "${FM_FAKE_STATUS_ROWS:-}" ;;
+      */check-runs\?*) printf '%s\n' "${FM_FAKE_CHECK_ROWS:-}" ;;
+      */deployments\?*) printf '%s\n' "${FM_FAKE_DEPLOYMENT_ROWS:-}" ;;
+      *) exit 1 ;;
+    esac
+    ;;
+  *) exit 1 ;;
+esac
+SH
+  chmod +x "$dir/fakebin/gh"
+}
+
+reset_fake_data() {
+  FM_FAKE_PR_STATE=OPEN
+  FM_FAKE_PR_HEAD=$HEAD_A
+  FM_FAKE_STATUS_ROWS=
+  FM_FAKE_CHECK_ROWS=
+  FM_FAKE_DEPLOYMENT_ROWS=
+  export FM_FAKE_PR_STATE FM_FAKE_PR_HEAD FM_FAKE_STATUS_ROWS FM_FAKE_CHECK_ROWS FM_FAKE_DEPLOYMENT_ROWS
+}
+
+run_ready() {
+  local dir=$1 expected_head=$2
+  FM_FAKE_GH_LOG="$dir/gh.log" PATH="$dir/fakebin:$PATH" "$READY" "$URL" "$expected_head"
+}
+
+expect_ready() {
+  local name=$1 expected_head=${2:-$HEAD_A} dir out rc
+  dir="$TMP_ROOT/$name"
+  make_fake_gh "$dir"
+  : > "$dir/gh.log"
+  set +e
+  out=$(run_ready "$dir" "$expected_head" 2> "$dir/stderr")
+  rc=$?
+  set -e
+  expect_code 0 "$rc" "$name should be ready"
+  [ "$out" = ready ] || fail "$name did not print the stable ready result"
+  LAST_CASE_DIR=$dir
+}
+
+expect_not_ready() {
+  local name=$1 expected_head=${2:-$HEAD_A} dir out rc
+  dir="$TMP_ROOT/$name"
+  make_fake_gh "$dir"
+  : > "$dir/gh.log"
+  set +e
+  out=$(run_ready "$dir" "$expected_head" 2> "$dir/stderr")
+  rc=$?
+  set -e
+  expect_code 1 "$rc" "$name should remain not ready"
+  [ -z "$out" ] || fail "$name printed a ready result"
+  LAST_CASE_DIR=$dir
+}
+
+# The representation observed on stacker-scan PR 657: a commit status named
+# Vercel plus an exact-head deployment whose authoritative environment is
+# Preview. Pending and failed Preview deployments are both non-blocking.
+test_only_vercel_preview_pending() {
+  reset_fake_data
+  FM_FAKE_STATUS_ROWS=$'Vercel\tpending'
+  FM_FAKE_DEPLOYMENT_ROWS="$HEAD_A"$'\tPreview\tfalse\tvercel[bot]'
+  expect_ready preview-pending
+  pass "only a pending Vercel Preview deployment is ready"
+}
+
+test_only_vercel_preview_failed() {
+  reset_fake_data
+  FM_FAKE_STATUS_ROWS=$'Vercel\tfailure'
+  FM_FAKE_DEPLOYMENT_ROWS="$HEAD_A"$'\tPreview\tfalse\tvercel[bot]'
+  expect_ready preview-failed
+  pass "only a failed Vercel Preview deployment is ready"
+}
+
+test_preview_plus_pending_ordinary_check() {
+  reset_fake_data
+  FM_FAKE_STATUS_ROWS=$'Vercel\tpending'
+  FM_FAKE_CHECK_ROWS=$'unit tests\tin_progress\t'
+  FM_FAKE_DEPLOYMENT_ROWS="$HEAD_A"$'\tPreview\tfalse\tvercel[bot]'
+  expect_not_ready preview-plus-tests
+  pass "a pending ordinary check still blocks beside Vercel Preview"
+}
+
+test_production_deployment_pending() {
+  reset_fake_data
+  FM_FAKE_STATUS_ROWS=$'Vercel\tpending'
+  FM_FAKE_DEPLOYMENT_ROWS="$HEAD_A"$'\tProduction\ttrue\tvercel[bot]'
+  expect_not_ready production-pending
+  pass "a pending production Vercel deployment remains blocking"
+}
+
+test_unclassified_vercel_status() {
+  reset_fake_data
+  FM_FAKE_STATUS_ROWS=$'Vercel\tpending'
+  FM_FAKE_DEPLOYMENT_ROWS=
+  expect_not_ready unclassified-vercel
+  pass "a Vercel display status without deployment evidence remains blocking"
+}
+
+test_failed_ordinary_status() {
+  reset_fake_data
+  FM_FAKE_STATUS_ROWS=$'security scan\tfailure'
+  expect_not_ready failed-security
+  pass "a failed ordinary status remains blocking"
+}
+
+test_head_change_rejects_stale_evidence() {
+  reset_fake_data
+  FM_FAKE_PR_HEAD=$HEAD_B
+  FM_FAKE_STATUS_ROWS=$'Vercel\tpending'
+  FM_FAKE_DEPLOYMENT_ROWS="$HEAD_A"$'\tPreview\tfalse\tvercel[bot]'
+  expect_not_ready changed-head "$HEAD_A"
+  assert_no_grep '/commits/' "$LAST_CASE_DIR/gh.log" \
+    "changed head should refuse before reading stale status evidence"
+  assert_no_grep '/deployments' "$LAST_CASE_DIR/gh.log" \
+    "changed head should refuse before reading stale deployment evidence"
+  pass "a changed PR head cannot reuse stale readiness evidence"
+}
+
+test_only_vercel_preview_pending
+test_only_vercel_preview_failed
+test_preview_plus_pending_ordinary_check
+test_production_deployment_pending
+test_unclassified_vercel_status
+test_failed_ordinary_status
+test_head_change_rejects_stale_evidence


### PR DESCRIPTION
## Intent

The developer wanted Firstmate's reusable PR-readiness logic changed so that Vercel Preview deployments are non-blocking: a pending or failed GitHub status that the deployment API identifies as environment Preview (as seen on stacker-scan PR 657, where a lone Vercel context kept the PR stuck "waiting on CI") must not prevent Firstmate from reporting a PR ready. They required all other checks to keep their safety semantics — pending/failed tests, lint, security, production deployments, and unclassified Vercel statuses must still block — and the classification had to use an authoritative boundary (GitHub's actual status/check and deployment-environment data), not fuzzy display-string matching, while handling head-SHA changes without reusing stale readiness evidence. Constraints included not disabling Vercel or mutating repo/Vercel settings, not touching no-mistakes itself, keeping merge authority separate (readiness never implies permission to merge), putting the logic in one owner with only a minimal AGENTS.md pointer, and following the firstmate coding guidelines. They also required focused regression tests covering preview-only pending/failed, preview plus a pending ordinary check, production pending, unclassified status, and head-SHA change cases, plus running fm-lint.sh for shell changes, then committing on branch fm/ignore-vercel-preview-q7 and shipping a PR through the no-mistakes pipeline without merging.

## What Changed

- Added `bin/fm-pr-ready.sh`, which classifies a PR's blocking checks using GitHub's status/check-runs and deployments APIs and treats a pending or failed status as non-blocking only when the deployment API identifies it as a Vercel Preview environment; production deployments, ordinary checks, and unclassified Vercel statuses still block.
- Wired the new readiness check into `bin/fm-crew-state.sh` so CI polling consults it when the ci log is not green, restricting the ci row match to `running|fixing|failed` statuses to preserve existing behavior for other states (per pipeline review feedback, auto-fixed in commit 0a41375).
- Added regression tests (`tests/fm-pr-ready.test.sh`, extended `tests/fm-crew-state.test.sh`) covering preview-only pending/failed, preview plus pending ordinary check, production pending, unclassified status, and head-SHA change cases, plus one-line doc pointers in `docs/architecture.md` and `docs/scripts.md`.

Note: the pipeline's Test step reported a failure (exit code 1) and Lint reported a warning (exit 127) on this branch.

## Risk Assessment

✅ Low: The only change this round is the exact one-line regex restriction requested from round 1, which restores prior behavior for non-failed ci rows while enabling the intended failed-CI Vercel Preview override; the branch remains fail-closed and well-tested.

## Testing

Completed 1 recorded test check.

- Outcome: ⚠️ 1 error across 1 run (20m33s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-crew-state.sh:301` - nm_ci_step_status&#39;s regex was broadened from matching only running/fixing ci rows to any status word. The function is also used by nm_effective_ci_step_status, which previously returned &#39;running&#39; (when RUN_STATUS=ci) for ci rows in other states like &#39;pending&#39;; now the raw row status is returned instead, so the log-tail green check (line 570 case &#39;running&#39;) and the CI_STEP_STATUS=running branch at line 609 can silently stop firing for those states. Restrict the regex to &#39;(running|fixing|failed)&#39; to preserve prior behavior while still serving the new failed-path read.
- ℹ️ `bin/fm-crew-state.sh:360` - nm_github_pr_ready adds up to 4 GitHub API calls (pr view, status, check-runs, deployments) to every crew-state poll whenever the ci log is not green, and again on every poll of a failed run with a failed ci row. This is a hot polling path; if crew-state is invoked frequently this adds network latency and rate-limit consumption. Acceptable tradeoff for authoritative classification, but worth noting.
- ℹ️ `bin/fm-pr-ready.sh:78` - The Vercel exception keys on the exact commit-status context string &#39;Vercel&#39;. Multi-project Vercel setups emit contexts like &#39;Vercel – &lt;project&gt;&#39;, which will remain blocking even with valid Preview deployment evidence. This is the conservative/fail-safe direction and matches the observed PR 657 representation, but limits the exception&#39;s reach.

🔧 Fix: restrict ci row match to running/fixing/failed statuses
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Test** - 1 error</summary>

- 🚨 tests failed with exit code 1
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
