### PR TITLE
feat(watch): follow GitLab merge requests to merge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,7 +86,7 @@ state/               volatile runtime signals; gitignored
   <id>.status        appended by crewmates: "<state>: <note>" wake-event lines, not current-state truth
   <id>.turn-ended    touched by turn-end hooks
   <id>.grok-turnend-token   firstmate-owned grok hook registry token for the task; removed by teardown
-  <id>.meta          written by fm-spawn: window=, worktree=, project=, harness=, model=, effort=, kind=, mode=, yolo=, tasktmp=; kind=secondmate also records home= and projects=; a non-default runtime backend records further backend-specific fields (docs/configuration.md "Runtime backend"; bin/fm-backend.sh, section 8); fm-pr-check, including through fm-pr-merge, records one canonical pr= and GitHub's pr_head= when available; fm-x-link appends x_request=, x_request_ts=, x_followups=, and optional x_platform=/x_reply_max_chars= for an X-mode-originated task (section 14)
+  <id>.meta          written by fm-spawn: window=, worktree=, project=, harness=, model=, effort=, kind=, mode=, yolo=, tasktmp=; kind=secondmate also records home= and projects=; a non-default runtime backend records further backend-specific fields (docs/configuration.md "Runtime backend"; bin/fm-backend.sh, section 8); fm-pr-check, including through fm-pr-merge, records one canonical pr= and the forge's pr_head= when available (GitHub pull requests and GitLab merge requests; docs/gitlab-merge-watch.md); fm-x-link appends x_request=, x_request_ts=, x_followups=, and optional x_platform=/x_reply_max_chars= for an X-mode-originated task (section 14)
   <id>.herdr-presentation  quarantinable attempt journal for Herdr's optional visual projection; never task or endpoint authority; see docs/herdr-backend.md "Optional disposable single-task presentation spaces"
   <id>.check.sh      authenticated slow poll; the watcher dispatches validated PR data and the byte-identified X shim through trusted repository scripts, runs registered custom checks from hash-validated private snapshots, and rejects every other state check without execution
   <id>.check-trust   private content binding created by fm-check-register.sh for an intentional custom check
@@ -287,7 +287,7 @@ The worker reports the PR when CI first becomes green rather than waiting for me
 ### PR ready, landing, and teardown
 
 For PR-based ship tasks, the ready signal depends on mode: `no-mistakes` reports `done: PR <url> checks green` after CI is green, while `direct-PR` reports `done: PR <url>` after opening the PR.
-Run `bin/fm-pr-check.sh <id> <PR url>` - it records `pr=` and GitHub's `pr_head=` when available in the task's meta and arms the watcher's merge poll.
+Run `bin/fm-pr-check.sh <id> <PR url>` - it records `pr=` and the forge's `pr_head=` when available in the task's meta and arms the watcher's merge poll.
 Tell the captain the PR's full URL, always the complete `https://...` link rather than a bare `#number`, a concise outcome summary, and the no-mistakes risk level when applicable.
 A captain instruction to merge is explicit authority; `yolo` is the only standing routine authority.
 For any custom `state/<id>.check.sh` you write yourself, keep it an ordinary single-link mode-`0700` file, print one line only when firstmate should wake, print nothing otherwise, finish before `FM_CHECK_TIMEOUT`, then bind its current bytes with `bin/fm-check-register.sh <id>` before the watcher may execute it.

--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ Firstmate's skills live in two separate places with different audiences:
 - [docs/orca-backend.md](docs/orca-backend.md) - setup guide for the experimental Orca backend, plus its lifecycle notes and known gaps.
 - [docs/cmux-backend.md](docs/cmux-backend.md) - setup guide for the experimental cmux backend, plus its verification notes and known gaps.
 - [docs/codex-app-backend.md](docs/codex-app-backend.md) - Codex App backend boundary, evidence, and rollout contract.
+- [docs/gitlab-merge-watch.md](docs/gitlab-merge-watch.md) - how the merge watch follows a GitLab merge request on any instance, and the evidence behind it.
 - [docs/turnend-guard.md](docs/turnend-guard.md) - the primary session's structural "no turn ends blind" backstop: verified per-harness hook mechanisms, scoping, loop safety, and fail-open tradeoffs.
 - [docs/supervision-protocols/](docs/supervision-protocols/) - rendered primary-harness watcher protocols for Claude, Codex, OpenCode, Pi, Grok, and unknown harness fallback.
 - [docs/scripts.md](docs/scripts.md) - the `bin/` toolbelt reference.

--- a/bin/fm-pr-check-migrate.sh
+++ b/bin/fm-pr-check-migrate.sh
@@ -488,20 +488,23 @@ quarantine_tree_repair_and_validate() {
   quarantine_dir_valid
 }
 
+MIGRATION_PROVIDER=
 MIGRATION_URL=
-MIGRATION_OWNER=
-MIGRATION_REPO=
+MIGRATION_HOST=
+MIGRATION_PATH=
 MIGRATION_NUMBER=
 metadata_pr_is_canonical() {
   local meta=$1
+  MIGRATION_PROVIDER=
   MIGRATION_URL=
-  MIGRATION_OWNER=
-  MIGRATION_REPO=
+  MIGRATION_HOST=
+  MIGRATION_PATH=
   MIGRATION_NUMBER=
   fm_pr_metadata_identity_parse "$meta" || return 1
+  MIGRATION_PROVIDER=$FM_PR_META_PROVIDER
   MIGRATION_URL=$FM_PR_META_URL
-  MIGRATION_OWNER=$FM_PR_META_OWNER
-  MIGRATION_REPO=$FM_PR_META_REPO
+  MIGRATION_HOST=$FM_PR_META_HOST
+  MIGRATION_PATH=$FM_PR_META_PATH
   MIGRATION_NUMBER=$FM_PR_META_NUMBER
 }
 
@@ -774,7 +777,7 @@ record_ambiguous_failure() {
 }
 
 canonical_repair_from_pending() {
-  local id=$1 meta data registration url owner repo number check
+  local id=$1 meta data registration provider url host path number check
   meta="$STATE/$id.meta"
   data="$STATE/$id.pr-poll"
   registration="$STATE/$id.pr-poll-registration"
@@ -782,15 +785,16 @@ canonical_repair_from_pending() {
   [ ! -e "$check" ] && [ ! -L "$check" ] || return 1
   quarantined_artifact_exists "$id" check || return 1
   metadata_pr_is_canonical "$meta" || return 1
+  provider=$MIGRATION_PROVIDER
   url=$MIGRATION_URL
-  owner=$MIGRATION_OWNER
-  repo=$MIGRATION_REPO
+  host=$MIGRATION_HOST
+  path=$MIGRATION_PATH
   number=$MIGRATION_NUMBER
   quarantine_artifact "$data" "$id" data || return 1
   quarantine_artifact "$registration" "$id" registration || return 1
   [ ! -e "$data" ] && [ ! -L "$data" ] || return 1
   [ ! -e "$registration" ] && [ ! -L "$registration" ] || return 1
-  fm_pr_poll_prepare "$STATE" "$id" "$url" "$owner" "$repo" "$number" "$TEMPLATE" || return 1
+  fm_pr_poll_prepare "$STATE" "$id" "$provider" "$url" "$host" "$path" "$number" "$TEMPLATE" || return 1
   fm_pr_poll_publish_prepared || return 1
   canonical_terminal_success "$id"
 }
@@ -1028,9 +1032,10 @@ if migration_needed; then
       data="$STATE/$id.pr-poll"
       registration="$STATE/$id.pr-poll-registration"
       if metadata_pr_is_canonical "$meta"; then
+        provider=$MIGRATION_PROVIDER
         url=$MIGRATION_URL
-        owner=$MIGRATION_OWNER
-        repo=$MIGRATION_REPO
+        host=$MIGRATION_HOST
+        path=$MIGRATION_PATH
         number=$MIGRATION_NUMBER
         message="task $id: migration outcome tracking started before legacy poll handling"
         if ! ensure_diagnostic_obligation "$prefix" pending-canonical "$message" \
@@ -1042,7 +1047,7 @@ if migration_needed; then
         if quarantine_artifact "$check" "$prefix" check \
           && quarantine_artifact "$data" "$prefix" data \
           && quarantine_artifact "$registration" "$prefix" registration \
-          && fm_pr_poll_prepare "$STATE" "$id" "$url" "$owner" "$repo" "$number" "$TEMPLATE" \
+          && fm_pr_poll_prepare "$STATE" "$id" "$provider" "$url" "$host" "$path" "$number" "$TEMPLATE" \
           && fm_pr_poll_publish_prepared \
           && complete_canonical_outcome "$id"; then
           :

--- a/bin/fm-pr-check.sh
+++ b/bin/fm-pr-check.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
-# Record a PR-ready task: store one validated canonical pr=<url> and GitHub's
+# Record a PR-ready task: store one validated canonical pr=<url> and the forge's
 # exact pr_head=<sha> when available, then atomically arm a static merge poll.
 # The watcher check source is byte-for-byte bin/fm-pr-poll.sh; task and PR data
 # live only in a private sidecar and are never interpolated into shell source.
+# A GitHub pull request URL and a GitLab merge request URL are both accepted,
+# including a merge request on a self-hosted GitLab instance.
 # Usage: fm-pr-check.sh <task-id> <pr-url>
 set -eu
 
@@ -25,8 +27,9 @@ if ! fm_pr_task_id_valid "$ID" || ! fm_pr_url_parse "$RAW_URL"; then
   exit 2
 fi
 URL=$FM_PR_URL
-OWNER=$FM_PR_OWNER
-REPO=$FM_PR_REPO
+PROVIDER=$FM_PR_PROVIDER
+HOST=$FM_PR_HOST
+PROJECT_PATH=$FM_PR_PATH
 NUMBER=$FM_PR_NUMBER
 
 # Task-derived paths are constructed only after the canonical ID validation.
@@ -36,15 +39,31 @@ if [ ! -f "$META" ] || [ -L "$META" ] || [ "$(fm_pr_file_link_count "$META")" !=
   exit 1
 fi
 
+# Refuse to arm a GitLab watch with no glab on PATH. The poll is silent on
+# every error by design, so a missing CLI would be indistinguishable from a
+# merge request that is never merged. Arming is the one point where that can be
+# reported, so the absent tool stops the watch here instead of watching nothing.
+if [ "$PROVIDER" = gitlab ] && ! command -v glab >/dev/null 2>&1; then
+  echo "error: watching a GitLab merge request requires glab on PATH" >&2
+  exit 1
+fi
+
 # Neutralize any pre-fix poll before recording or arming this task. The
 # migration never executes legacy artifacts and holds watcher exclusion while
 # it quarantines or rebuilds them.
 "$SCRIPT_DIR/fm-pr-check-migrate.sh" --checks-safe || exit 1
 "$FM_ROOT/bin/fm-guard.sh" || true
 
+# pr_head is recorded only when the forge's CLI can supply it. gh exposes the
+# head commit as a selectable field; plain glab exposes it only inside its JSON
+# output, which would need a JSON processor firstmate does not require, so a
+# GitLab task records no pr_head. Both consumers already treat it as optional:
+# bin/fm-teardown.sh reads the head from the forge at teardown rather than from
+# metadata and falls back to its provider-agnostic content check, and
+# bin/fm-review-diff.sh resolves the head from the remote when none is recorded.
 WT=$(grep '^worktree=' "$META" | tail -1 | cut -d= -f2- || true)
 PR_HEAD=
-if [ -n "$WT" ] && [ -d "$WT" ] && command -v gh >/dev/null 2>&1; then
+if [ "$PROVIDER" = github ] && [ -n "$WT" ] && [ -d "$WT" ] && command -v gh >/dev/null 2>&1; then
   if REMOTE_HEAD=$(cd "$WT" && gh pr view "$URL" --json headRefOid -q .headRefOid 2>/dev/null) \
     && fm_pr_head_valid "$REMOTE_HEAD"; then
     PR_HEAD=$REMOTE_HEAD
@@ -58,7 +77,7 @@ pr_check_cleanup() {
 }
 trap pr_check_cleanup EXIT
 trap 'exit 1' HUP INT TERM
-fm_pr_poll_prepare "$STATE" "$ID" "$URL" "$OWNER" "$REPO" "$NUMBER" "$SCRIPT_DIR/fm-pr-poll.sh" \
+fm_pr_poll_prepare "$STATE" "$ID" "$PROVIDER" "$URL" "$HOST" "$PROJECT_PATH" "$NUMBER" "$SCRIPT_DIR/fm-pr-poll.sh" \
   || { echo "error: could not prepare PR poll" >&2; exit 1; }
 
 META_DEVICE=$(fm_pr_file_device "$META") || exit 1
@@ -76,15 +95,17 @@ printf 'pr=%s\n' "$URL" >> "$META_TMP" || exit 1
 chmod 0600 "$META_TMP" || exit 1
 fm_pr_private_file_valid "$META_TMP" 600 "$STATE_DEVICE" || exit 1
 fm_pr_metadata_identity_parse "$META_TMP" || exit 1
-[ "$FM_PR_META_URL" = "$URL" ] && [ "$FM_PR_META_OWNER" = "$OWNER" ] \
-  && [ "$FM_PR_META_REPO" = "$REPO" ] && [ "$FM_PR_META_NUMBER" = "$NUMBER" ] || exit 1
+[ "$FM_PR_META_PROVIDER" = "$PROVIDER" ] && [ "$FM_PR_META_URL" = "$URL" ] \
+  && [ "$FM_PR_META_HOST" = "$HOST" ] && [ "$FM_PR_META_PATH" = "$PROJECT_PATH" ] \
+  && [ "$FM_PR_META_NUMBER" = "$NUMBER" ] || exit 1
 fm_pr_regular_destination_on_device_or_absent "$META" "$STATE_DEVICE" || exit 1
 mv -f -- "$META_TMP" "$META" || exit 1
 META_TMP=
 fm_pr_private_file_valid "$META" 600 "$STATE_DEVICE" || exit 1
 fm_pr_metadata_identity_parse "$META" || exit 1
-[ "$FM_PR_META_URL" = "$URL" ] && [ "$FM_PR_META_OWNER" = "$OWNER" ] \
-  && [ "$FM_PR_META_REPO" = "$REPO" ] && [ "$FM_PR_META_NUMBER" = "$NUMBER" ] || exit 1
+[ "$FM_PR_META_PROVIDER" = "$PROVIDER" ] && [ "$FM_PR_META_URL" = "$URL" ] \
+  && [ "$FM_PR_META_HOST" = "$HOST" ] && [ "$FM_PR_META_PATH" = "$PROJECT_PATH" ] \
+  && [ "$FM_PR_META_NUMBER" = "$NUMBER" ] || exit 1
 
 fm_pr_poll_publish_prepared || {
   echo "error: could not publish PR poll" >&2

--- a/bin/fm-pr-lib.sh
+++ b/bin/fm-pr-lib.sh
@@ -80,11 +80,16 @@ fm_task_id_creation_valid() {
 # GitLab serves self-hosted instances, so the host is part of the identity
 # rather than a constant. It is accepted only as a lowercase DNS name with no
 # userinfo, port, or trailing dot, which keeps one canonical spelling per MR.
+# github.com is refused here even though its shape is otherwise valid: it is
+# GitHub's own host and never a GitLab instance, so a URL like
+# https://github.com/o/r/-/merge_requests/1 (a typo'd or spoofed GitHub URL)
+# would otherwise be armed as a GitLab watch that can never succeed.
 fm_pr_gitlab_host_valid() {
   local host=${1-} label
   local LC_ALL=C
   local -a labels
   [ "${#host}" -ge 1 ] && [ "${#host}" -le 253 ] || return 1
+  [ "$host" != github.com ] || return 1
   case "$host" in
     .*|*.|*..*|*[!a-z0-9.-]*) return 1 ;;
   esac

--- a/bin/fm-pr-lib.sh
+++ b/bin/fm-pr-lib.sh
@@ -1,24 +1,39 @@
 #!/usr/bin/env bash
-# Shared validation and atomic artifact helpers for GitHub PR merge polling.
-# Callers must validate task IDs and raw PR URLs before constructing task paths
-# or performing any side effect.
+# Shared validation and atomic artifact helpers for merge polling on the
+# supported forges. Callers must validate task IDs and raw PR/MR URLs before
+# constructing task paths or performing any side effect.
+#
+# The stored identity is provider-tagged: provider, url, host, path, number.
+# "path" is the full project path, which is owner/repository on GitHub and an
+# arbitrarily nested group/subgroup/project namespace on GitLab. A GitLab
+# project can sit at any depth, so no owner/repository pair can address one and
+# the sidecar carries the whole path instead. GitLab also runs on self-hosted
+# instances, so the host is part of that identity rather than a constant. Every
+# consumer re-derives the identity from the stored URL and refuses any record
+# whose parts do not reconstruct that exact URL.
 
+FM_PR_PROVIDER=
 FM_PR_URL=
+FM_PR_HOST=
+FM_PR_PATH=
 FM_PR_OWNER=
 FM_PR_REPO=
 FM_PR_NUMBER=
+FM_PR_DATA_PROVIDER=
 FM_PR_DATA_URL=
-FM_PR_DATA_OWNER=
-FM_PR_DATA_REPO=
+FM_PR_DATA_HOST=
+FM_PR_DATA_PATH=
 FM_PR_DATA_NUMBER=
+FM_PR_META_PROVIDER=
 FM_PR_META_URL=
-FM_PR_META_OWNER=
-FM_PR_META_REPO=
+FM_PR_META_HOST=
+FM_PR_META_PATH=
 FM_PR_META_NUMBER=
 FM_PR_REG_ID=
+FM_PR_REG_PROVIDER=
 FM_PR_REG_URL=
-FM_PR_REG_OWNER=
-FM_PR_REG_REPO=
+FM_PR_REG_HOST=
+FM_PR_REG_PATH=
 FM_PR_REG_NUMBER=
 FM_PR_REG_DATA_HASH=
 FM_PR_REG_TEMPLATE_HASH=
@@ -31,9 +46,10 @@ FM_PR_POLL_DATA_DEST=
 FM_PR_POLL_CHECK_DEST=
 FM_PR_POLL_REG_DEST=
 FM_PR_POLL_EXPECT_ID=
+FM_PR_POLL_EXPECT_PROVIDER=
 FM_PR_POLL_EXPECT_URL=
-FM_PR_POLL_EXPECT_OWNER=
-FM_PR_POLL_EXPECT_REPO=
+FM_PR_POLL_EXPECT_HOST=
+FM_PR_POLL_EXPECT_PATH=
 FM_PR_POLL_EXPECT_NUMBER=
 FM_PR_POLL_EXPECT_DATA_HASH=
 FM_PR_POLL_EXPECT_TEMPLATE_HASH=
@@ -61,20 +77,96 @@ fm_task_id_creation_valid() {
   [ "${#id}" -le 64 ]
 }
 
-fm_pr_url_parse() {
-  local raw=${1-} pattern
+# GitLab serves self-hosted instances, so the host is part of the identity
+# rather than a constant. It is accepted only as a lowercase DNS name with no
+# userinfo, port, or trailing dot, which keeps one canonical spelling per MR.
+fm_pr_gitlab_host_valid() {
+  local host=${1-} label
   local LC_ALL=C
+  local -a labels
+  [ "${#host}" -ge 1 ] && [ "${#host}" -le 253 ] || return 1
+  case "$host" in
+    .*|*.|*..*|*[!a-z0-9.-]*) return 1 ;;
+  esac
+  IFS=. read -ra labels <<< "$host"
+  for label in "${labels[@]}"; do
+    [ "${#label}" -ge 1 ] && [ "${#label}" -le 63 ] || return 1
+    case "$label" in
+      -*|*-) return 1 ;;
+    esac
+  done
+}
+
+# A GitLab project path is group[/subgroup...]/project, so at least two
+# segments and no fixed depth. GitLab reserves "-" as its route separator and
+# forbids a leading hyphen, ".git", and ".atom", so none of those can name a
+# real namespace and each is refused here.
+fm_pr_gitlab_path_valid() {
+  local path=${1-} segment
+  local LC_ALL=C
+  local -a segments
+  [ "${#path}" -ge 3 ] && [ "${#path}" -le 1024 ] || return 1
+  case "$path" in
+    /*|*/|*//*) return 1 ;;
+  esac
+  IFS=/ read -ra segments <<< "$path"
+  [ "${#segments[@]}" -ge 2 ] && [ "${#segments[@]}" -le 20 ] || return 1
+  for segment in "${segments[@]}"; do
+    [ "${#segment}" -ge 1 ] && [ "${#segment}" -le 255 ] || return 1
+    case "$segment" in
+      .|..|-*|*.git|*.atom|*[!A-Za-z0-9._-]*) return 1 ;;
+    esac
+  done
+}
+
+# Parse a canonical PR or MR URL into the provider-tagged identity. Validation
+# is strict and per provider: the GitHub username and repository rules are
+# unchanged, and GitLab gets its own host and namespace rules rather than a
+# loosened GitHub rule.
+#
+# FM_PR_OWNER and FM_PR_REPO are additionally set for github because
+# bin/fm-pr-merge.sh addresses GitHub by owner/repository. A gitlab URL leaves
+# them empty; teaching the merge path about GitLab is a separate change, and
+# until then it refuses a GitLab URL rather than merging anything.
+fm_pr_url_parse() {
+  local raw=${1-} pattern host path
+  local LC_ALL=C
+  FM_PR_PROVIDER=
   FM_PR_URL=
+  FM_PR_HOST=
+  FM_PR_PATH=
   FM_PR_OWNER=
   FM_PR_REPO=
   FM_PR_NUMBER=
   pattern='^https://github\.com/([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9-]{0,37}[A-Za-z0-9])/([A-Za-z0-9._-]{1,100})/pull/([1-9][0-9]*)$'
+  if [[ "$raw" =~ $pattern ]]; then
+    [[ "${BASH_REMATCH[1]}" != *--* ]] || return 1
+    [ "${BASH_REMATCH[2]}" != . ] && [ "${BASH_REMATCH[2]}" != .. ] || return 1
+    FM_PR_PROVIDER=github
+    FM_PR_URL=$raw
+    FM_PR_HOST=github.com
+    FM_PR_PATH="${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
+    # Consumed by bin/fm-pr-merge.sh, which addresses GitHub by owner/repository.
+    # shellcheck disable=SC2034
+    FM_PR_OWNER=${BASH_REMATCH[1]}
+    # shellcheck disable=SC2034
+    FM_PR_REPO=${BASH_REMATCH[2]}
+    FM_PR_NUMBER=${BASH_REMATCH[3]}
+    return 0
+  fi
+  # The path class contains "/" and "-", so this match is greedy to the last
+  # "/-/merge_requests/". Any earlier separator therefore lands inside the
+  # captured path, where the reserved "-" segment is refused.
+  pattern='^https://([a-z0-9.-]{1,253})/([A-Za-z0-9._/-]{3,1024})/-/merge_requests/([1-9][0-9]*)$'
   [[ "$raw" =~ $pattern ]] || return 1
-  [[ "${BASH_REMATCH[1]}" != *--* ]] || return 1
-  [ "${BASH_REMATCH[2]}" != . ] && [ "${BASH_REMATCH[2]}" != .. ] || return 1
+  host=${BASH_REMATCH[1]}
+  path=${BASH_REMATCH[2]}
+  fm_pr_gitlab_host_valid "$host" || return 1
+  fm_pr_gitlab_path_valid "$path" || return 1
+  FM_PR_PROVIDER=gitlab
   FM_PR_URL=$raw
-  FM_PR_OWNER=${BASH_REMATCH[1]}
-  FM_PR_REPO=${BASH_REMATCH[2]}
+  FM_PR_HOST=$host
+  FM_PR_PATH=$path
   FM_PR_NUMBER=${BASH_REMATCH[3]}
 }
 
@@ -158,9 +250,10 @@ fm_pr_regular_destination_on_device_or_absent() {
 
 fm_pr_metadata_identity_parse() {
   local file=$1 line value pr_count=0 seen_pr=0 post_pr_invalid=0
+  FM_PR_META_PROVIDER=
   FM_PR_META_URL=
-  FM_PR_META_OWNER=
-  FM_PR_META_REPO=
+  FM_PR_META_HOST=
+  FM_PR_META_PATH=
   FM_PR_META_NUMBER=
   [ -f "$file" ] && [ ! -L "$file" ] || return 1
   [ "$(fm_pr_file_link_count "$file")" = 1 ] || return 1
@@ -171,9 +264,10 @@ fm_pr_metadata_identity_parse() {
         [ "$pr_count" -eq 1 ] || continue
         value=${line#pr=}
         if fm_pr_url_parse "$value"; then
+          FM_PR_META_PROVIDER=$FM_PR_PROVIDER
           FM_PR_META_URL=$FM_PR_URL
-          FM_PR_META_OWNER=$FM_PR_OWNER
-          FM_PR_META_REPO=$FM_PR_REPO
+          FM_PR_META_HOST=$FM_PR_HOST
+          FM_PR_META_PATH=$FM_PR_PATH
           FM_PR_META_NUMBER=$FM_PR_NUMBER
         fi
         seen_pr=1
@@ -196,17 +290,23 @@ fm_pr_metadata_identity_parse() {
   [ -n "$FM_PR_META_URL" ]
 }
 
+# Sidecar layout: provider, url, host, path, number, one per line. A sidecar
+# written before the provider tag existed has a URL on its first line and one
+# line fewer, so it fails both the field count and the provider comparison and
+# is refused rather than misread as a provider-tagged record.
 fm_pr_poll_data_parse() {
-  local file=$1 url owner repo number
+  local file=$1 provider url host path number
+  FM_PR_DATA_PROVIDER=
   FM_PR_DATA_URL=
-  FM_PR_DATA_OWNER=
-  FM_PR_DATA_REPO=
+  FM_PR_DATA_HOST=
+  FM_PR_DATA_PATH=
   FM_PR_DATA_NUMBER=
   [ -f "$file" ] && [ ! -L "$file" ] || return 1
   exec 8< "$file" || return 1
+  IFS= read -r provider <&8 || { exec 8<&-; return 1; }
   IFS= read -r url <&8 || { exec 8<&-; return 1; }
-  IFS= read -r owner <&8 || { exec 8<&-; return 1; }
-  IFS= read -r repo <&8 || { exec 8<&-; return 1; }
+  IFS= read -r host <&8 || { exec 8<&-; return 1; }
+  IFS= read -r path <&8 || { exec 8<&-; return 1; }
   IFS= read -r number <&8 || { exec 8<&-; return 1; }
   if IFS= read -r _extra <&8; then
     exec 8<&-
@@ -214,21 +314,30 @@ fm_pr_poll_data_parse() {
   fi
   exec 8<&-
   fm_pr_url_parse "$url" || return 1
-  [ "$owner" = "$FM_PR_OWNER" ] || return 1
-  [ "$repo" = "$FM_PR_REPO" ] || return 1
+  [ "$provider" = "$FM_PR_PROVIDER" ] || return 1
+  [ "$host" = "$FM_PR_HOST" ] || return 1
+  [ "$path" = "$FM_PR_PATH" ] || return 1
   [ "$number" = "$FM_PR_NUMBER" ] || return 1
+  FM_PR_DATA_PROVIDER=$FM_PR_PROVIDER
   FM_PR_DATA_URL=$FM_PR_URL
-  FM_PR_DATA_OWNER=$FM_PR_OWNER
-  FM_PR_DATA_REPO=$FM_PR_REPO
+  FM_PR_DATA_HOST=$FM_PR_HOST
+  FM_PR_DATA_PATH=$FM_PR_PATH
   FM_PR_DATA_NUMBER=$FM_PR_NUMBER
 }
 
+# Registration layout: version tag, task id, then the same provider-tagged
+# identity as the sidecar, then the two hashes and the two file identities.
+# The version tag moved to v2 with the provider tag, so a registration written
+# by the previous release is recognised as old and refused. The non-executing
+# migration in bin/fm-pr-check-migrate.sh then rebuilds that poll from the
+# task's recorded pull request URL.
 fm_pr_poll_registration_parse() {
-  local file=$1 version id url owner repo number data_hash template_hash data_identity check_identity
+  local file=$1 version id provider url host path number data_hash template_hash data_identity check_identity
   FM_PR_REG_ID=
+  FM_PR_REG_PROVIDER=
   FM_PR_REG_URL=
-  FM_PR_REG_OWNER=
-  FM_PR_REG_REPO=
+  FM_PR_REG_HOST=
+  FM_PR_REG_PATH=
   FM_PR_REG_NUMBER=
   FM_PR_REG_DATA_HASH=
   FM_PR_REG_TEMPLATE_HASH=
@@ -238,9 +347,10 @@ fm_pr_poll_registration_parse() {
   exec 7< "$file" || return 1
   IFS= read -r version <&7 || { exec 7<&-; return 1; }
   IFS= read -r id <&7 || { exec 7<&-; return 1; }
+  IFS= read -r provider <&7 || { exec 7<&-; return 1; }
   IFS= read -r url <&7 || { exec 7<&-; return 1; }
-  IFS= read -r owner <&7 || { exec 7<&-; return 1; }
-  IFS= read -r repo <&7 || { exec 7<&-; return 1; }
+  IFS= read -r host <&7 || { exec 7<&-; return 1; }
+  IFS= read -r path <&7 || { exec 7<&-; return 1; }
   IFS= read -r number <&7 || { exec 7<&-; return 1; }
   IFS= read -r data_hash <&7 || { exec 7<&-; return 1; }
   IFS= read -r template_hash <&7 || { exec 7<&-; return 1; }
@@ -251,20 +361,22 @@ fm_pr_poll_registration_parse() {
     return 1
   fi
   exec 7<&-
-  [ "$version" = fm-pr-poll-registration-v1 ] || return 1
+  [ "$version" = fm-pr-poll-registration-v2 ] || return 1
   fm_pr_task_id_valid "$id" || return 1
   fm_pr_url_parse "$url" || return 1
-  [ "$owner" = "$FM_PR_OWNER" ] || return 1
-  [ "$repo" = "$FM_PR_REPO" ] || return 1
+  [ "$provider" = "$FM_PR_PROVIDER" ] || return 1
+  [ "$host" = "$FM_PR_HOST" ] || return 1
+  [ "$path" = "$FM_PR_PATH" ] || return 1
   [ "$number" = "$FM_PR_NUMBER" ] || return 1
   [[ "$data_hash" =~ ^[0-9a-f]{64}$ ]] || return 1
   [[ "$template_hash" =~ ^[0-9a-f]{64}$ ]] || return 1
   [[ "$data_identity" =~ ^[0-9]+:[0-9]+$ ]] || return 1
   [[ "$check_identity" =~ ^[0-9]+:[0-9]+$ ]] || return 1
   FM_PR_REG_ID=$id
+  FM_PR_REG_PROVIDER=$FM_PR_PROVIDER
   FM_PR_REG_URL=$FM_PR_URL
-  FM_PR_REG_OWNER=$FM_PR_OWNER
-  FM_PR_REG_REPO=$FM_PR_REPO
+  FM_PR_REG_HOST=$FM_PR_HOST
+  FM_PR_REG_PATH=$FM_PR_PATH
   FM_PR_REG_NUMBER=$FM_PR_NUMBER
   FM_PR_REG_DATA_HASH=$data_hash
   FM_PR_REG_TEMPLATE_HASH=$template_hash
@@ -301,11 +413,12 @@ fm_pr_poll_revoke_final() {
 }
 
 fm_pr_poll_prepare() {
-  local state=$1 id=$2 url=$3 owner=$4 repo=$5 number=$6 template=$7
+  local state=$1 id=$2 provider=$3 url=$4 host=$5 path=$6 number=$7 template=$8
   fm_pr_task_id_valid "$id" || return 1
   fm_pr_url_parse "$url" || return 1
-  [ "$owner" = "$FM_PR_OWNER" ] || return 1
-  [ "$repo" = "$FM_PR_REPO" ] || return 1
+  [ "$provider" = "$FM_PR_PROVIDER" ] || return 1
+  [ "$host" = "$FM_PR_HOST" ] || return 1
+  [ "$path" = "$FM_PR_PATH" ] || return 1
   [ "$number" = "$FM_PR_NUMBER" ] || return 1
   [ -f "$template" ] || return 1
 
@@ -317,9 +430,10 @@ fm_pr_poll_prepare() {
   FM_PR_POLL_CHECK_DEST="$state/$id.check.sh"
   FM_PR_POLL_REG_DEST="$state/$id.pr-poll-registration"
   FM_PR_POLL_EXPECT_ID=$id
+  FM_PR_POLL_EXPECT_PROVIDER=$provider
   FM_PR_POLL_EXPECT_URL=$url
-  FM_PR_POLL_EXPECT_OWNER=$owner
-  FM_PR_POLL_EXPECT_REPO=$repo
+  FM_PR_POLL_EXPECT_HOST=$host
+  FM_PR_POLL_EXPECT_PATH=$path
   FM_PR_POLL_EXPECT_NUMBER=$number
   FM_PR_POLL_TEMPLATE=$template
   FM_PR_POLL_STATE_DEVICE=$(fm_pr_file_device "$state") || return 1
@@ -334,13 +448,14 @@ fm_pr_poll_prepare() {
     return 1
   }
 
-  if ! printf '%s\n%s\n%s\n%s\n' "$url" "$owner" "$repo" "$number" > "$FM_PR_POLL_DATA_TMP" \
+  if ! printf '%s\n%s\n%s\n%s\n%s\n' "$provider" "$url" "$host" "$path" "$number" > "$FM_PR_POLL_DATA_TMP" \
     || ! chmod 0600 "$FM_PR_POLL_DATA_TMP" \
     || ! fm_pr_private_file_valid "$FM_PR_POLL_DATA_TMP" 600 "$FM_PR_POLL_STATE_DEVICE" \
     || ! fm_pr_poll_data_parse "$FM_PR_POLL_DATA_TMP" \
+    || [ "$FM_PR_DATA_PROVIDER" != "$provider" ] \
     || [ "$FM_PR_DATA_URL" != "$url" ] \
-    || [ "$FM_PR_DATA_OWNER" != "$owner" ] \
-    || [ "$FM_PR_DATA_REPO" != "$repo" ] \
+    || [ "$FM_PR_DATA_HOST" != "$host" ] \
+    || [ "$FM_PR_DATA_PATH" != "$path" ] \
     || [ "$FM_PR_DATA_NUMBER" != "$number" ] \
     || ! cp "$template" "$FM_PR_POLL_CHECK_TMP" \
     || ! chmod 0600 "$FM_PR_POLL_CHECK_TMP" \
@@ -353,8 +468,8 @@ fm_pr_poll_prepare() {
   FM_PR_POLL_EXPECT_TEMPLATE_HASH=$(fm_pr_sha256 "$FM_PR_POLL_CHECK_TMP") || { fm_pr_poll_cleanup; return 1; }
   FM_PR_POLL_EXPECT_DATA_IDENTITY=$(fm_pr_file_identity "$FM_PR_POLL_DATA_TMP") || { fm_pr_poll_cleanup; return 1; }
   FM_PR_POLL_EXPECT_CHECK_IDENTITY=$(fm_pr_file_identity "$FM_PR_POLL_CHECK_TMP") || { fm_pr_poll_cleanup; return 1; }
-  if ! printf '%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n' \
-      fm-pr-poll-registration-v1 "$id" "$url" "$owner" "$repo" "$number" \
+  if ! printf '%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n' \
+      fm-pr-poll-registration-v2 "$id" "$provider" "$url" "$host" "$path" "$number" \
       "$FM_PR_POLL_EXPECT_DATA_HASH" "$FM_PR_POLL_EXPECT_TEMPLATE_HASH" \
       "$FM_PR_POLL_EXPECT_DATA_IDENTITY" "$FM_PR_POLL_EXPECT_CHECK_IDENTITY" \
       > "$FM_PR_POLL_REG_TMP" \
@@ -385,9 +500,10 @@ fm_pr_poll_publish_prepared() {
     || [ "$(fm_pr_file_identity "$FM_PR_POLL_DATA_DEST")" != "$FM_PR_POLL_EXPECT_DATA_IDENTITY" ] \
     || [ "$(fm_pr_sha256 "$FM_PR_POLL_DATA_DEST")" != "$FM_PR_POLL_EXPECT_DATA_HASH" ] \
     || ! fm_pr_poll_data_parse "$FM_PR_POLL_DATA_DEST" \
+    || [ "$FM_PR_DATA_PROVIDER" != "$FM_PR_POLL_EXPECT_PROVIDER" ] \
     || [ "$FM_PR_DATA_URL" != "$FM_PR_POLL_EXPECT_URL" ] \
-    || [ "$FM_PR_DATA_OWNER" != "$FM_PR_POLL_EXPECT_OWNER" ] \
-    || [ "$FM_PR_DATA_REPO" != "$FM_PR_POLL_EXPECT_REPO" ] \
+    || [ "$FM_PR_DATA_HOST" != "$FM_PR_POLL_EXPECT_HOST" ] \
+    || [ "$FM_PR_DATA_PATH" != "$FM_PR_POLL_EXPECT_PATH" ] \
     || [ "$FM_PR_DATA_NUMBER" != "$FM_PR_POLL_EXPECT_NUMBER" ]; then
     fm_pr_poll_revoke_final || true
     return 1
@@ -401,9 +517,10 @@ fm_pr_poll_publish_prepared() {
   if ! fm_pr_private_file_valid "$FM_PR_POLL_REG_DEST" 600 "$FM_PR_POLL_STATE_DEVICE" \
     || ! fm_pr_poll_registration_parse "$FM_PR_POLL_REG_DEST" \
     || [ "$FM_PR_REG_ID" != "$FM_PR_POLL_EXPECT_ID" ] \
+    || [ "$FM_PR_REG_PROVIDER" != "$FM_PR_POLL_EXPECT_PROVIDER" ] \
     || [ "$FM_PR_REG_URL" != "$FM_PR_POLL_EXPECT_URL" ] \
-    || [ "$FM_PR_REG_OWNER" != "$FM_PR_POLL_EXPECT_OWNER" ] \
-    || [ "$FM_PR_REG_REPO" != "$FM_PR_POLL_EXPECT_REPO" ] \
+    || [ "$FM_PR_REG_HOST" != "$FM_PR_POLL_EXPECT_HOST" ] \
+    || [ "$FM_PR_REG_PATH" != "$FM_PR_POLL_EXPECT_PATH" ] \
     || [ "$FM_PR_REG_NUMBER" != "$FM_PR_POLL_EXPECT_NUMBER" ] \
     || [ "$FM_PR_REG_DATA_HASH" != "$FM_PR_POLL_EXPECT_DATA_HASH" ] \
     || [ "$FM_PR_REG_TEMPLATE_HASH" != "$FM_PR_POLL_EXPECT_TEMPLATE_HASH" ] \
@@ -447,17 +564,19 @@ fm_pr_poll_artifacts_valid() {
   check_identity=$(fm_pr_file_identity "$check") || return 1
   fm_pr_poll_registration_parse "$registration" || return 1
   [ "$FM_PR_REG_ID" = "$id" ] || return 1
+  [ "$FM_PR_REG_PROVIDER" = "$FM_PR_DATA_PROVIDER" ] || return 1
   [ "$FM_PR_REG_URL" = "$FM_PR_DATA_URL" ] || return 1
-  [ "$FM_PR_REG_OWNER" = "$FM_PR_DATA_OWNER" ] || return 1
-  [ "$FM_PR_REG_REPO" = "$FM_PR_DATA_REPO" ] || return 1
+  [ "$FM_PR_REG_HOST" = "$FM_PR_DATA_HOST" ] || return 1
+  [ "$FM_PR_REG_PATH" = "$FM_PR_DATA_PATH" ] || return 1
   [ "$FM_PR_REG_NUMBER" = "$FM_PR_DATA_NUMBER" ] || return 1
   [ "$FM_PR_REG_DATA_HASH" = "$data_hash" ] || return 1
   [ "$FM_PR_REG_TEMPLATE_HASH" = "$template_hash" ] || return 1
   [ "$FM_PR_REG_DATA_IDENTITY" = "$data_identity" ] || return 1
   [ "$FM_PR_REG_CHECK_IDENTITY" = "$check_identity" ] || return 1
   fm_pr_metadata_identity_parse "$meta" || return 1
+  [ "$FM_PR_META_PROVIDER" = "$FM_PR_DATA_PROVIDER" ] || return 1
   [ "$FM_PR_META_URL" = "$FM_PR_DATA_URL" ] || return 1
-  [ "$FM_PR_META_OWNER" = "$FM_PR_DATA_OWNER" ] || return 1
-  [ "$FM_PR_META_REPO" = "$FM_PR_DATA_REPO" ] || return 1
+  [ "$FM_PR_META_HOST" = "$FM_PR_DATA_HOST" ] || return 1
+  [ "$FM_PR_META_PATH" = "$FM_PR_DATA_PATH" ] || return 1
   [ "$FM_PR_META_NUMBER" = "$FM_PR_DATA_NUMBER" ]
 }

--- a/bin/fm-pr-merge.sh
+++ b/bin/fm-pr-merge.sh
@@ -24,7 +24,11 @@ if [ "$#" -lt 2 ]; then
 fi
 ID=$1
 RAW_URL=$2
-if ! fm_pr_task_id_valid "$ID" || ! fm_pr_url_parse "$RAW_URL"; then
+# bin/fm-pr-lib.sh parses GitLab merge request URLs so the watcher can follow
+# them, but this path still addresses only GitHub by owner/repository. The
+# provider check holds that refusal exactly as it was until merge parity lands.
+if ! fm_pr_task_id_valid "$ID" || ! fm_pr_url_parse "$RAW_URL" \
+  || [ "$FM_PR_PROVIDER" != github ]; then
   echo "error: invalid PR merge request" >&2
   exit 2
 fi

--- a/bin/fm-pr-poll.sh
+++ b/bin/fm-pr-poll.sh
@@ -67,6 +67,7 @@ case "$provider" in
     ;;
   gitlab)
     [ "${#host}" -ge 1 ] && [ "${#host}" -le 253 ] || exit 0
+    [ "$host" != github.com ] || exit 0
     case "$host" in
       .*|*.|*..*|*[!a-z0-9.-]*) exit 0 ;;
     esac

--- a/bin/fm-pr-poll.sh
+++ b/bin/fm-pr-poll.sh
@@ -1,15 +1,21 @@
 #!/usr/bin/env bash
-# Static watcher program for a validated PR poll sidecar.
-# It emits exactly one merged line for MERGED and stays silent otherwise.
+# Static watcher program for a validated PR/MR poll sidecar.
+# It emits exactly one merged line for a merged PR or MR and stays silent
+# otherwise, including on every error, so a failed lookup can never be read as
+# a merge. The provider-tagged identity is data in the sidecar and is never
+# interpolated into this source: these bytes are identical for every task.
+# Each provider is read through its own standard CLI, gh for GitHub and glab
+# for GitLab, so an upstream checkout needs no extra tooling to follow either.
 set -u
 LC_ALL=C
 export LC_ALL
 
-if [ "$#" -eq 5 ] && [ "$1" = --validated ]; then
-  url=$2
-  owner=$3
-  repo=$4
-  number=$5
+if [ "$#" -eq 6 ] && [ "$1" = --validated ]; then
+  provider=$2
+  url=$3
+  host=$4
+  path=$5
+  number=$6
 elif [ "$#" -eq 0 ]; then
   case "$0" in
     *.check.sh) data=${0%.check.sh}.pr-poll ;;
@@ -18,9 +24,10 @@ elif [ "$#" -eq 0 ]; then
 
   [ -f "$data" ] && [ ! -L "$data" ] || exit 0
   { exec 3< "$data"; } 2>/dev/null || exit 0
+  IFS= read -r provider <&3 || exit 0
   IFS= read -r url <&3 || exit 0
-  IFS= read -r owner <&3 || exit 0
-  IFS= read -r repo <&3 || exit 0
+  IFS= read -r host <&3 || exit 0
+  IFS= read -r path <&3 || exit 0
   IFS= read -r number <&3 || exit 0
   if IFS= read -r _extra <&3; then
     exit 0
@@ -30,14 +37,6 @@ else
   exit 0
 fi
 
-[ "${#owner}" -ge 1 ] && [ "${#owner}" -le 39 ] || exit 0
-case "$owner" in
-  *[!A-Za-z0-9-]*|-*|*-|*--*) exit 0 ;;
-esac
-[ "${#repo}" -ge 1 ] && [ "${#repo}" -le 100 ] || exit 0
-case "$repo" in
-  .|..|*[!A-Za-z0-9._-]*) exit 0 ;;
-esac
 case "$number" in
   [1-9]*) ;;
   *) exit 0 ;;
@@ -45,8 +44,66 @@ esac
 case "$number" in
   *[!0-9]*) exit 0 ;;
 esac
-[ "$url" = "https://github.com/$owner/$repo/pull/$number" ] || exit 0
 
-state=$(gh pr view "$url" --json state -q .state 2>/dev/null) || exit 0
-[ "$state" = MERGED ] && printf '%s\n' merged
+# Every component is revalidated here rather than trusted from the sidecar, and
+# the stored URL must then be exactly reconstructible from those components, so
+# a doctored sidecar cannot redirect this poll at another host or project.
+case "$provider" in
+  github)
+    [ "$host" = github.com ] || exit 0
+    owner=${path%%/*}
+    repo=${path#*/}
+    [ "${#owner}" -ge 1 ] && [ "${#owner}" -le 39 ] || exit 0
+    case "$owner" in
+      *[!A-Za-z0-9-]*|-*|*-|*--*) exit 0 ;;
+    esac
+    [ "${#repo}" -ge 1 ] && [ "${#repo}" -le 100 ] || exit 0
+    case "$repo" in
+      .|..|*[!A-Za-z0-9._-]*) exit 0 ;;
+    esac
+    [ "$url" = "https://github.com/$owner/$repo/pull/$number" ] || exit 0
+    state=$(gh pr view "$url" --json state -q .state 2>/dev/null) || exit 0
+    [ "$state" = MERGED ] && printf '%s\n' merged
+    ;;
+  gitlab)
+    [ "${#host}" -ge 1 ] && [ "${#host}" -le 253 ] || exit 0
+    case "$host" in
+      .*|*.|*..*|*[!a-z0-9.-]*) exit 0 ;;
+    esac
+    [ "${#path}" -ge 3 ] && [ "${#path}" -le 1024 ] || exit 0
+    case "$path" in
+      /*|*/|*//*) exit 0 ;;
+    esac
+    # A GitLab project sits under at least one group at no fixed depth, and
+    # GitLab reserves the "-" segment as its route separator.
+    rest=$path
+    segments=0
+    while [ -n "$rest" ]; do
+      case "$rest" in
+        */*) segment=${rest%%/*}; rest=${rest#*/} ;;
+        *) segment=$rest; rest= ;;
+      esac
+      segments=$((segments + 1))
+      [ "$segments" -le 20 ] || exit 0
+      [ "${#segment}" -ge 1 ] && [ "${#segment}" -le 255 ] || exit 0
+      case "$segment" in
+        .|..|-*|*.git|*.atom|*[!A-Za-z0-9._-]*) exit 0 ;;
+      esac
+    done
+    [ "$segments" -ge 2 ] || exit 0
+    [ "$url" = "https://$host/$path/-/merge_requests/$number" ] || exit 0
+    # glab resolves the instance from the project URL passed to -R, so the host
+    # comes from the validated record rather than glab's configured default.
+    # It cannot take a merge request URL the way gh does: that form shells out
+    # to git for the current repository, and the watcher runs in no repository.
+    # The state is read from glab's own field output rather than its JSON,
+    # because plain glab has no field selector and firstmate does not require a
+    # JSON processor; only an exact "merged" wakes, so a changed format or an
+    # unreadable merge request stays silent instead of reporting a merge.
+    raw=$(glab mr view "$number" -R "https://$host/$path" 2>/dev/null) || exit 0
+    state=$(printf '%s\n' "$raw" | sed -n 's/^state:[[:space:]]*//p' | head -1) || exit 0
+    [ "$state" = merged ] && printf '%s\n' merged
+    ;;
+  *) exit 0 ;;
+esac
 exit 0

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -777,11 +777,13 @@ while :; do
       else
         id=$(basename "$c" .check.sh)
         if fm_pr_poll_artifacts_valid "$STATE" "$id" "$SCRIPT_DIR/fm-pr-poll.sh"; then
+          provider=$FM_PR_DATA_PROVIDER
           url=$FM_PR_DATA_URL
-          owner=$FM_PR_DATA_OWNER
-          repo=$FM_PR_DATA_REPO
+          host=$FM_PR_DATA_HOST
+          path=$FM_PR_DATA_PATH
           number=$FM_PR_DATA_NUMBER
-          run_check_capture "$SCRIPT_DIR/fm-pr-poll.sh" --validated "$url" "$owner" "$repo" "$number" || exit 1
+          run_check_capture "$SCRIPT_DIR/fm-pr-poll.sh" --validated \
+            "$provider" "$url" "$host" "$path" "$number" || exit 1
           out=$FM_CHECK_RESULT
         elif fm_custom_check_snapshot_prepare "$STATE" "$id"; then
           custom_snapshot=$FM_CUSTOM_CHECK_SNAPSHOT

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -182,7 +182,7 @@ When a selected delivery path calls for a diff, `bin/fm-review-diff.sh` refreshe
 For target project repos shipped through their own no-mistakes pipeline, commits under `.no-mistakes/evidence/` are the pipeline's PR-viewable validation evidence and are expected to stay in the crew branch until the evidence-hosting design changes.
 The firstmate repo itself is the exception: its `.no-mistakes/` directory is local state, stays gitignored, and is rejected by CI if tracked.
 PR-based task merges go through `bin/fm-pr-merge.sh`, which records `pr=` and any available `pr_head=` through `bin/fm-pr-check.sh` before calling `gh-axi pr merge`.
-The helper requires a full `https://github.com/<owner>/<repo>/pull/<n>` URL, invokes `gh-axi pr merge <n> --repo <owner>/<repo>`, defaults to `--squash`, preserves explicit merge-method flags, and rejects malformed URLs or repo override flags before recording merge state.
+The helper requires a full `https://github.com/<owner>/<repo>/pull/<n>` URL, invokes `gh-axi pr merge <n> --repo <owner>/<repo>`, defaults to `--squash`, preserves explicit merge-method flags, and rejects malformed URLs or repo override flags before recording merge state; a well-formed GitLab merge request URL (see [docs/gitlab-merge-watch.md](gitlab-merge-watch.md)) is refused too, explicitly, rather than sent to the wrong forge.
 Teardown is fail-closed for ship worktrees: dirty worktrees refuse, and committed work must be landed before the worktree is returned.
 [`bin/fm-teardown.sh`](../bin/fm-teardown.sh)'s header owns the landed-work proofs, PR-discovery fallback, and stale-lock recovery procedure.
 

--- a/docs/gitlab-merge-watch.md
+++ b/docs/gitlab-merge-watch.md
@@ -1,0 +1,200 @@
+# GitLab merge request watch verification
+
+Empirical record for the merge watch on GitLab, alongside the existing GitHub watch.
+Every command below was run on 2026-07-21 and its output is reproduced exactly.
+
+## Versions
+
+```
+$ glab --version
+Current glab version: 1.53.0
+
+$ bash --version | head -1
+GNU bash, version 5.3.9(1)-release (x86_64-pc-linux-gnu)
+```
+
+## The evidence project
+
+All live evidence here reads <https://gitlab.com/KarotKris/gitlab-merge-watch-fixture>, a public project that exists only to be this evidence.
+It holds one deliberately merged merge request and one deliberately open one, so both outcomes can be shown against real data.
+Every command against it reads a public merge request and needs no credential, so a reader can rerun each one and see the same output.
+Its README asks that the open merge request be left open.
+
+A non-default host appears below only as the placeholder `gitlab.example`, which resolves nowhere.
+That is deliberate: the host-agnostic property is a property of the stored record and the poll's URL reconstruction, so it is demonstrated by inspecting those rather than by reaching any private instance.
+
+## Why the host is data rather than a constant
+
+GitLab runs mostly on self-hosted instances, so a merge request can live under any host.
+A GitLab project also sits under at least one group at no fixed depth, so no owner-and-repository pair can address one the way it can on GitHub.
+The stored record therefore carries `provider`, `url`, `host`, `path`, and `number`, and every consumer rebuilds the URL from those parts and refuses any record that does not reconstruct the stored URL exactly.
+`tests/fm-pr-check-security.test.sh` asserts that neither `bin/fm-pr-lib.sh` nor `bin/fm-pr-poll.sh` contains the string `gitlab.com` at all.
+
+## How plain glab is invoked, and why
+
+Two things about plain `glab` were established by running it, because assuming either one would have failed silently into a permanent "not merged".
+
+First, plain `glab` has no field selector.
+`gh` reads one field with `--json state -q .state`; `glab mr view` offers only `-F, --output string  Format output as: text, json`.
+Its JSON would need a JSON processor, and `jq` is not one of firstmate's common tools, so the state is read from glab's own field output instead.
+Only an exact `merged` wakes firstmate, so a changed output format produces no wake rather than a false merge.
+
+Second, `glab` cannot take a merge request URL the way `gh pr view` can.
+That form shells out to git for the current repository, and the watcher runs in no repository:
+
+```
+$ cd /tmp && glab mr view https://gitlab.com/KarotKris/gitlab-merge-watch-fixture/-/merge_requests/1
+fatal: not a git repository (or any parent up to mount point /)
+Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
+git: exit status 128
+```
+
+Passing the project URL to `-R` with the merge request number works from anywhere, and resolves the instance from that URL rather than from glab's configured default:
+
+```
+$ cd /tmp && glab mr view 1 -R https://gitlab.com/KarotKris/gitlab-merge-watch-fixture
+title:	Add the merged example file
+state:	merged
+author:	KarotKris
+labels:	
+assignees:	
+reviewers:	
+comments:	0
+number:	1
+url:	https://gitlab.com/KarotKris/gitlab-merge-watch-fixture/-/merge_requests/1
+--
+This merge request is the merged half of the fixture. It is merged on purpose, so that reading its state returns merged.
+
+$ cd /tmp && glab mr view 2 -R https://gitlab.com/KarotKris/gitlab-merge-watch-fixture | sed -n 's/^state:[[:space:]]*//p'
+open
+```
+
+## End to end: arming and polling a real merge request
+
+Three tasks were armed, two against the fixture and one against the placeholder host:
+
+```
+$ fm-pr-check.sh e1 https://gitlab.com/KarotKris/gitlab-merge-watch-fixture/-/merge_requests/1
+armed: state/e1.check.sh
+$ fm-pr-check.sh e2 https://gitlab.com/KarotKris/gitlab-merge-watch-fixture/-/merge_requests/2
+armed: state/e2.check.sh
+$ fm-pr-check.sh e3 https://gitlab.example/group/subgroup/project/-/merge_requests/7
+armed: state/e3.check.sh
+```
+
+The stored record for each, showing the host and the full project namespace as data:
+
+```
+$ cat state/e1.pr-poll
+gitlab
+https://gitlab.com/KarotKris/gitlab-merge-watch-fixture/-/merge_requests/1
+gitlab.com
+KarotKris/gitlab-merge-watch-fixture
+1
+
+$ cat state/e3.pr-poll
+gitlab
+https://gitlab.example/group/subgroup/project/-/merge_requests/7
+gitlab.example
+group/subgroup/project
+7
+```
+
+The provenance record for the non-default host, showing the bumped version tag:
+
+```
+$ cat state/e3.pr-poll-registration
+fm-pr-poll-registration-v2
+e3
+gitlab
+https://gitlab.example/group/subgroup/project/-/merge_requests/7
+gitlab.example
+group/subgroup/project
+7
+514b7e04f0cca3e2c913c9fd504c54dfe54c8a51a7f5ebc57279bbd4db5d4a60
+1817b0f95db7148246434a4afa0b2c8e7b81fd8f74ef7d473bbd62023e47c439
+70:957243
+70:957244
+```
+
+Running each published poll the way the watcher does, where an empty result means the poll stayed silent and produced no wake:
+
+```
+$ fm-pr-poll.sh --validated $(tr '\n' ' ' < state/e1.pr-poll)
+merged
+$ fm-pr-poll.sh --validated $(tr '\n' ' ' < state/e2.pr-poll)
+$ fm-pr-poll.sh --validated $(tr '\n' ' ' < state/e3.pr-poll)
+```
+
+The merged fixture merge request produces exactly one `merged` line.
+The open one produces nothing, and the unreachable placeholder host produces nothing rather than a false merge.
+
+The same bytes work in the watcher's sidecar-driven mode, where the published check locates its own record:
+
+```
+$ state/e1x.check.sh
+merged
+```
+
+## A missing CLI produces no wake, never a false merge
+
+The poll is silent on every error by design, so a missing `glab` would otherwise be indistinguishable from a merge request that is never merged.
+With `glab` removed from `PATH`, the poll stays silent even for the merge request that is genuinely merged:
+
+```
+$ PATH="$noglab" fm-pr-poll.sh --validated $(tr '\n' ' ' < state/e1.pr-poll)
+$ PATH="$noglab" fm-pr-poll.sh --validated $(tr '\n' ' ' < state/e3.pr-poll)
+```
+
+Arming is the one point where that can be reported, so it refuses there instead of arming a watch that can never fire:
+
+```
+$ PATH="$noglab" fm-pr-check.sh e5 https://gitlab.com/KarotKris/gitlab-merge-watch-fixture/-/merge_requests/1
+error: watching a GitLab merge request requires glab on PATH
+$ echo $?
+1
+```
+
+A GitHub task is unaffected by a missing `glab`:
+
+```
+$ PATH="$noglab" fm-pr-check.sh e6 https://github.com/kunchenguid/firstmate/pull/750
+armed: state/e6.check.sh
+```
+
+## Upgrade path from an existing armed watch
+
+The stored record gained the provider tag, so its version moved to `fm-pr-poll-registration-v2` and a record written by the previous release no longer parses.
+The existing non-executing migration handles that: it never runs the old artifact, and rebuilds the poll from the task's recorded pull request URL.
+Starting from a poll armed exactly as the previous release wrote it:
+
+```
+$ head -1 state/t1.pr-poll-registration
+fm-pr-poll-registration-v1
+$ fm-pr-check-migrate.sh --checks-safe
+PR_CHECK_MIGRATION: canonical polls rebuilt and armed; resume supervision for this home
+$ head -2 state/t1.pr-poll-registration
+fm-pr-poll-registration-v2
+t1
+$ cat state/.pr-check-migration.log
+task t1: migration outcome tracking started before legacy poll handling
+task t1: canonical legacy poll rebuilt and armed
+```
+
+The rebuilt poll works, verified against a pull request that is genuinely merged:
+
+```
+$ fm-pr-poll.sh --validated $(tr '\n' ' ' < state/t1.pr-poll)
+merged
+```
+
+No armed watch is lost by upgrading.
+
+## What this change does not cover
+
+`bin/fm-pr-merge.sh` still addresses GitHub only, by owner and repository.
+It refuses a GitLab merge request URL rather than sending it to the wrong forge, so merging a merge request stays a deliberate manual step until merge parity lands separately.
+
+A GitLab task records no `pr_head=`.
+`gh` exposes the head commit as a selectable field, while plain `glab` exposes it only inside its JSON output, which would need a JSON processor firstmate does not require.
+Both consumers already treat it as optional: `bin/fm-teardown.sh` reads the head from the forge at teardown rather than from metadata and falls back to its provider-agnostic content check, and `bin/fm-review-diff.sh` resolves the head from the remote when none is recorded.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -70,7 +70,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-check-register.sh`   | Bind an intentional custom watcher check to its current bytes                       |
 | `fm-check-lib.sh`        | Validate custom-check registrations and prepare private execution snapshots          |
 | `fm-pr-lib.sh`           | Own canonical task and PR validation plus private atomic PR-poll and provenance publication |
-| `fm-pr-poll.sh`          | Provide the byte-static watcher program for validated PR-poll sidecars              |
+| `fm-pr-poll.sh`          | Provide the byte-static watcher program for validated PR/MR-poll sidecars           |
 | `fm-pr-check-migrate.sh` | Quarantine older task polls without execution and rebuild only canonical polls       |
 | `fm-pr-check.sh`         | Record validated `pr=` and `pr_head=` values, then atomically arm a static merge poll |
 | `fm-pr-merge.sh`         | Record PR metadata, then merge a task's canonical full GitHub URL                    |

--- a/tests/fm-pr-check-security.test.sh
+++ b/tests/fm-pr-check-security.test.sh
@@ -78,9 +78,19 @@ SH
 printf '%s\n' "$*" >> "$FM_TEST_GH_AXI_LOG"
 exit "${FM_TEST_GH_AXI_RC:-0}"
 SH
-  chmod +x "$fakebin/gh" "$fakebin/gh-axi"
+  # Plain glab, reproducing the real CLI's contract: its field output on stdout
+  # and exit 0 on success, and a non-zero exit with no stdout on any failure.
+  cat > "$fakebin/glab" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$FM_TEST_GLAB_LOG"
+[ "${FM_TEST_GLAB_FAIL:-0}" = 0 ] || exit 1
+[ "${FM_TEST_GLAB_SLEEP:-0}" = 0 ] || sleep "$FM_TEST_GLAB_SLEEP"
+printf 'title:\tfixture merge request\nstate:\t%s\nauthor:\tsomeone\n' "${FM_TEST_GLAB_STATE:-opened}"
+SH
+  chmod +x "$fakebin/gh" "$fakebin/gh-axi" "$fakebin/glab"
   : > "$dir/gh.log"
   : > "$dir/gh-axi.log"
+  : > "$dir/glab.log"
   : > "$dir/guard.log"
   printf '%s\n' "$dir"
 }
@@ -117,13 +127,14 @@ write_v1_x_shim() {
 }
 
 write_manual_poll_pair() {
-  local state=$1 url=${2:-https://github.com/o/r/pull/10} owner repo number
+  local state=$1 url=${2:-https://github.com/o/r/pull/10} provider host path number
   fm_pr_url_parse "$url" || fail "manual poll fixture URL was invalid"
-  owner=$FM_PR_OWNER
-  repo=$FM_PR_REPO
+  provider=$FM_PR_PROVIDER
+  host=$FM_PR_HOST
+  path=$FM_PR_PATH
   number=$FM_PR_NUMBER
   cp "$POLL" "$state/task-a.check.sh"
-  printf '%s\n%s\n%s\n%s\n' "$url" "$owner" "$repo" "$number" > "$state/task-a.pr-poll"
+  printf '%s\n%s\n%s\n%s\n%s\n' "$provider" "$url" "$host" "$path" "$number" > "$state/task-a.pr-poll"
   chmod 0600 "$state/task-a.check.sh" "$state/task-a.pr-poll"
 }
 
@@ -225,7 +236,8 @@ run_check_entry() {
   shift
   FM_ROOT_OVERRIDE="$dir/root" FM_HOME="$dir/home" \
     FM_TEST_GUARD_LOG="$dir/guard.log" FM_TEST_GH_LOG="$dir/gh.log" \
-    FM_TEST_GH_AXI_LOG="$dir/gh-axi.log" PATH="$dir/fakebin:$BASE_PATH" \
+    FM_TEST_GH_AXI_LOG="$dir/gh-axi.log" FM_TEST_GLAB_LOG="$dir/glab.log" \
+    PATH="$dir/fakebin:$BASE_PATH" \
     "$PR_CHECK" "$@"
 }
 
@@ -234,12 +246,30 @@ run_merge_entry() {
   shift
   FM_ROOT_OVERRIDE="$dir/root" FM_HOME="$dir/home" \
     FM_TEST_GUARD_LOG="$dir/guard.log" FM_TEST_GH_LOG="$dir/gh.log" \
-    FM_TEST_GH_AXI_LOG="$dir/gh-axi.log" PATH="$dir/fakebin:$BASE_PATH" \
+    FM_TEST_GH_AXI_LOG="$dir/gh-axi.log" FM_TEST_GLAB_LOG="$dir/glab.log" \
+    PATH="$dir/fakebin:$BASE_PATH" \
     "$PR_MERGE" "$@"
 }
 
 # shellcheck disable=SC2016 # Literal rejected URL bytes are parser test data.
 INVALID_URLS=(
+  'https://gitlab.com/single/-/merge_requests/1'
+  'https://gitlab.com/g/p/-/merge_requests/0'
+  'https://gitlab.com/g/p/-/merge_requests/01'
+  'https://GitLab.com/g/p/-/merge_requests/1'
+  'https://gitlab.com:443/g/p/-/merge_requests/1'
+  'https://user@gitlab.com/g/p/-/merge_requests/1'
+  'https://gitlab.com/g/p/-/merge_requests/1/'
+  'https://gitlab.com/-/p/-/merge_requests/1'
+  'https://gitlab.com/g/p.git/-/merge_requests/1'
+  'https://gitlab.com/g/p.atom/-/merge_requests/1'
+  'https://gitlab.com/g/p/-/merge_requests/1?x=1'
+  'https://gitlab.com/g/p/-/merge_requests/1#note'
+  'https://gitlab.com/g/p/-/issues/1'
+  'https://gitlab.com//p/-/merge_requests/1'
+  'https://.gitlab.com/g/p/-/merge_requests/1'
+  'https://gitlab.com./g/p/-/merge_requests/1'
+  'http://gitlab.com/g/p/-/merge_requests/1'
   'https://github.com/o/r/pull/1/'
   ' https://github.com/o/r/pull/1'
   'https://github.com/o/r/pull/1 '
@@ -360,6 +390,26 @@ https://github.com/a/b/pull/1|a|b|1
 https://github.com/my-org/repo/pull/42|my-org|repo|42
 https://github.com/Owner/repo-name_with.parts/pull/123456|Owner|repo-name_with.parts|123456
 EOF
+  while IFS='|' read -r url host path number; do
+    [ -n "$url" ] || continue
+    fm_pr_url_parse "$url" || fail "parser rejected a canonical merge request URL"
+    [ "$FM_PR_PROVIDER" = gitlab ] || fail "parser did not tag a merge request URL as gitlab"
+    [ "$FM_PR_URL" = "$url" ] || fail "parser changed a canonical merge request URL"
+    [ "$FM_PR_HOST" = "$host" ] || fail "parser returned wrong GitLab host"
+    [ "$FM_PR_PATH" = "$path" ] || fail "parser returned wrong GitLab project path"
+    [ "$FM_PR_NUMBER" = "$number" ] || fail "parser returned wrong merge request number"
+    [ -z "$FM_PR_OWNER" ] && [ -z "$FM_PR_REPO" ] \
+      || fail "parser set GitHub owner/repository for a merge request URL"
+  done <<'EOF'
+https://gitlab.com/group/project/-/merge_requests/1|gitlab.com|group/project|1
+https://gitlab.com/group/sub/deep/project/-/merge_requests/42|gitlab.com|group/sub/deep/project|42
+https://gitlab.example.co.uk/g/p/-/merge_requests/7|gitlab.example.co.uk|g/p|7
+https://code.internal/team/tools/ci-runner/-/merge_requests/123456|code.internal|team/tools/ci-runner|123456
+EOF
+  fm_pr_url_parse https://github.com/a/b/pull/1 || fail "parser rejected canonical URL"
+  [ "$FM_PR_PROVIDER" = github ] || fail "parser did not tag a pull request URL as github"
+  [ "$FM_PR_HOST" = github.com ] || fail "parser returned wrong GitHub host"
+  [ "$FM_PR_PATH" = a/b ] || fail "parser returned wrong GitHub project path"
   for row in "${INVALID_URLS[@]}"; do
     ! fm_pr_url_parse "$row" || fail "parser accepted a rejected raw-byte URL class"
   done
@@ -485,7 +535,7 @@ test_valid_recording_and_merge_derivation() {
   fm_pr_poll_artifacts_valid "$dir/home/state" task-a "$POLL" \
     || fail "published poll provenance or metadata binding was invalid"
   sidecar=$(cat "$dir/home/state/task-a.pr-poll")
-  [ "$sidecar" = $'https://github.com/my-org/repo_name.with-dots/pull/37\nmy-org\nrepo_name.with-dots\n37' ] \
+  [ "$sidecar" = $'github\nhttps://github.com/my-org/repo_name.with-dots/pull/37\ngithub.com\nmy-org/repo_name.with-dots\n37' ] \
     || fail "published sidecar bytes were not exact"
 
   FM_TEST_GH_HEAD=$expected run_check_entry "$dir" task-a https://github.com/my-org/repo_name.with-dots/pull/37 \
@@ -592,7 +642,7 @@ test_rejected_metacharacter_bytes_are_inert() {
   dir=$(make_case rejected-metacharacters)
   write_task_meta "$dir"
   write_poll_meta "$dir/home/state" safe-check https://github.com/o/r/pull/99
-  fm_pr_poll_prepare "$dir/home/state" safe-check https://github.com/o/r/pull/99 o r 99 "$POLL" \
+  fm_pr_poll_prepare "$dir/home/state" safe-check github https://github.com/o/r/pull/99 github.com o/r 99 "$POLL" \
     || fail "could not prepare bounded watcher poll"
   fm_pr_poll_publish_prepared || fail "could not publish bounded watcher poll"
   families=(
@@ -635,14 +685,15 @@ test_rejected_metacharacter_bytes_are_inert() {
 make_poll_fixture() {
   local dir=$1
   cp "$POLL" "$dir/home/state/task-a.check.sh"
-  printf '%s\n%s\n%s\n%s\n' \
-    https://github.com/o/r/pull/1 o r 1 > "$dir/home/state/task-a.pr-poll"
+  printf '%s\n%s\n%s\n%s\n%s\n' \
+    github https://github.com/o/r/pull/1 github.com o/r 1 > "$dir/home/state/task-a.pr-poll"
   chmod 0600 "$dir/home/state/task-a.check.sh" "$dir/home/state/task-a.pr-poll"
 }
 
 run_poll() {
   local dir=$1
-  FM_TEST_GH_LOG="$dir/gh.log" PATH="$dir/fakebin:$BASE_PATH" \
+  FM_TEST_GH_LOG="$dir/gh.log" FM_TEST_GLAB_LOG="$dir/glab.log" \
+    PATH="$dir/fakebin:$BASE_PATH" \
     bash "$dir/home/state/task-a.check.sh"
 }
 
@@ -669,10 +720,10 @@ test_static_poll_contract() {
   out=$(run_poll "$dir")
   [ -z "$out" ] || fail "static poll emitted with missing sidecar"
   mv "$dir/home/state/task-a.pr-poll.missing" "$dir/home/state/task-a.pr-poll"
-  printf '%s\n%s\n%s\n%s\n%s\n' https://github.com/o/r/pull/1 o r 1 extra > "$dir/home/state/task-a.pr-poll"
+  printf '%s\n%s\n%s\n%s\n%s\n%s\n' github https://github.com/o/r/pull/1 github.com o/r 1 extra > "$dir/home/state/task-a.pr-poll"
   out=$(FM_TEST_GH_STATE=MERGED run_poll "$dir")
   [ -z "$out" ] || fail "static poll emitted with multiline sidecar"
-  printf '%s\n%s\n%s\n%s\n' https://github.com/o/r/pull/1x o r 1x > "$dir/home/state/task-a.pr-poll"
+  printf '%s\n%s\n%s\n%s\n%s\n' github https://github.com/o/r/pull/1x github.com o/r 1x > "$dir/home/state/task-a.pr-poll"
   out=$(FM_TEST_GH_STATE=MERGED run_poll "$dir")
   [ -z "$out" ] || fail "static poll emitted with malformed numeric data"
 
@@ -687,7 +738,7 @@ test_static_poll_contract() {
   [ -z "$out" ] || fail "timed-out static poll emitted output"
 
   write_poll_meta "$dir/home/state" task-a https://github.com/o/r/pull/1
-  fm_pr_poll_prepare "$dir/home/state" task-a https://github.com/o/r/pull/1 o r 1 "$POLL" \
+  fm_pr_poll_prepare "$dir/home/state" task-a github https://github.com/o/r/pull/1 github.com o/r 1 "$POLL" \
     || fail "could not prepare authenticated watcher poll"
   fm_pr_poll_publish_prepared || fail "could not publish authenticated watcher poll"
   rm -f "$dir/home/state/.last-check"
@@ -849,7 +900,7 @@ test_private_artifact_paths_refuse_symlinks_and_directories() {
     for kind in regular dangling directory; do
       dir=$(make_case "poll-path-${artifact//./-}-$kind")
       state="$dir/home/state"
-      fm_pr_poll_prepare "$state" task-a https://github.com/o/r/pull/1 o r 1 "$POLL" \
+      fm_pr_poll_prepare "$state" task-a github https://github.com/o/r/pull/1 github.com o/r 1 "$POLL" \
         || fail "could not stage poll symlink refusal fixture"
       destination="$state/$artifact"
       make_private_symlink "$dir" "$destination" "$kind"
@@ -864,7 +915,7 @@ test_private_artifact_paths_refuse_symlinks_and_directories() {
 
     dir=$(make_case "poll-path-${artifact//./-}-direct-directory")
     state="$dir/home/state"
-    fm_pr_poll_prepare "$state" task-a https://github.com/o/r/pull/1 o r 1 "$POLL" \
+    fm_pr_poll_prepare "$state" task-a github https://github.com/o/r/pull/1 github.com o/r 1 "$POLL" \
       || fail "could not stage poll directory refusal fixture"
     destination="$state/$artifact"
     mkdir "$destination"
@@ -975,11 +1026,11 @@ test_postrename_poll_validation_revokes_and_retries() {
       dir=$(make_case "poll-final-$artifact-$action")
       state="$dir/home/state"
       write_poll_meta "$state" task-a https://github.com/o/r/pull/1
-      fm_pr_poll_prepare "$state" task-a https://github.com/o/r/pull/1 o r 1 "$POLL" \
+      fm_pr_poll_prepare "$state" task-a github https://github.com/o/r/pull/1 github.com o/r 1 "$POLL" \
         || fail "could not prepare prior poll"
       fm_pr_poll_publish_prepared || fail "could not publish prior poll"
       write_poll_meta "$state" task-a https://github.com/o/r/pull/2
-      fm_pr_poll_prepare "$state" task-a https://github.com/o/r/pull/2 o r 2 "$POLL" \
+      fm_pr_poll_prepare "$state" task-a github https://github.com/o/r/pull/2 github.com o/r 2 "$POLL" \
         || fail "could not stage replacement poll"
       case "$artifact" in
         data) destination="$state/task-a.pr-poll" ;;
@@ -1002,7 +1053,7 @@ test_postrename_poll_validation_revokes_and_retries() {
       [ "$(cat "$link_target")" = 'external sentinel' ] || fail "poll type fault changed an external target"
       [ "$(file_mode "$link_target")" = 644 ] || fail "poll type fault changed an external target mode"
 
-      fm_pr_poll_prepare "$state" task-a https://github.com/o/r/pull/2 o r 2 "$POLL" \
+      fm_pr_poll_prepare "$state" task-a github https://github.com/o/r/pull/2 github.com o/r 2 "$POLL" \
         || fail "could not prepare poll retry"
       PATH="$BASE_PATH" fm_pr_poll_publish_prepared || fail "poll retry did not recover after final validation fault"
       fm_pr_poll_artifacts_valid "$state" task-a "$POLL" || fail "poll retry did not publish a valid pair"
@@ -1419,7 +1470,7 @@ test_replacement_provenance_negative_matrix() {
         donor="$dir/donor"
         mkdir -p "$donor"
         write_poll_meta "$donor" task-a https://github.com/o/r/pull/10
-        fm_pr_poll_prepare "$donor" task-a https://github.com/o/r/pull/10 o r 10 "$POLL" \
+        fm_pr_poll_prepare "$donor" task-a github https://github.com/o/r/pull/10 github.com o/r 10 "$POLL" \
           || fail "could not prepare donor registration fixture"
         fm_pr_poll_publish_prepared || fail "could not publish donor registration fixture"
         cp "$donor/task-a.check.sh" "$state/task-a.check.sh"
@@ -1428,13 +1479,13 @@ test_replacement_provenance_negative_matrix() {
         chmod 0600 "$state/task-a.check.sh" "$state/task-a.pr-poll" "$state/task-a.pr-poll-registration"
         ;;
       metadata-mismatch)
-        fm_pr_poll_prepare "$state" task-a https://github.com/o/r/pull/10 o r 10 "$POLL" \
+        fm_pr_poll_prepare "$state" task-a github https://github.com/o/r/pull/10 github.com o/r 10 "$POLL" \
           || fail "could not prepare metadata-mismatch fixture"
         fm_pr_poll_publish_prepared || fail "could not publish metadata-mismatch fixture"
         write_poll_meta "$state" task-a https://github.com/o/r/pull/11
         ;;
       task-mismatch)
-        fm_pr_poll_prepare "$state" task-a https://github.com/o/r/pull/10 o r 10 "$POLL" \
+        fm_pr_poll_prepare "$state" task-a github https://github.com/o/r/pull/10 github.com o/r 10 "$POLL" \
           || fail "could not prepare task-mismatch fixture"
         fm_pr_poll_publish_prepared || fail "could not publish task-mismatch fixture"
         { head -n 1 "$state/task-a.pr-poll-registration"; printf '%s\n' task-b; tail -n +3 "$state/task-a.pr-poll-registration"; } \
@@ -1444,8 +1495,8 @@ test_replacement_provenance_negative_matrix() {
         ;;
       forged-registration)
         write_manual_poll_pair "$state"
-        printf '%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n' \
-          fm-pr-poll-registration-v1 task-a https://github.com/o/r/pull/10 o r 10 \
+        printf '%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n' \
+          fm-pr-poll-registration-v2 task-a github https://github.com/o/r/pull/10 github.com o/r 10 \
           "$zeros" "$zeros" 1:1 1:2 > "$state/task-a.pr-poll-registration"
         chmod 0600 "$state/task-a.pr-poll-registration"
         ;;
@@ -2255,7 +2306,7 @@ test_bootstrap_isolates_incomplete_poll_migration() {
   printf 'legacy bytes\n' > "$state/task-a.check.sh"
   mkdir "$state/task-a.pr-poll"
   write_poll_meta "$state" z-healthy https://github.com/o/r/pull/13
-  fm_pr_poll_prepare "$state" z-healthy https://github.com/o/r/pull/13 o r 13 "$POLL" \
+  fm_pr_poll_prepare "$state" z-healthy github https://github.com/o/r/pull/13 github.com o/r 13 "$POLL" \
     || fail "could not prepare healthy poll for migration isolation"
   fm_pr_poll_publish_prepared || fail "could not publish healthy poll for migration isolation"
   fm_write_meta "$state/secondmate-a.meta" \
@@ -2678,7 +2729,118 @@ SH
   pass "teardown removes safe poll artifacts and refuses quarantine-directory symlinks without traversal"
 }
 
+# The GitLab watch must follow a merge request exactly as the GitHub watch
+# follows a pull request, on any instance, and must never turn an unreadable
+# merge request into a merge. Its evidence against the public fixture project
+# https://gitlab.com/KarotKris/gitlab-merge-watch-fixture is in
+# docs/gitlab-merge-watch.md; this exercises the same paths hermetically.
+test_gitlab_merge_watch() {
+  local dir state out rc url value noglab entry bindir name
+  dir=$(make_case gitlab-merge-watch)
+  state="$dir/home/state"
+  url=https://gitlab.example/group/subgroup/project/-/merge_requests/7
+
+  write_poll_meta "$state" task-a "$url"
+  fm_pr_poll_prepare "$state" task-a gitlab "$url" gitlab.example group/subgroup/project 7 "$POLL" \
+    || fail "could not prepare a GitLab poll"
+  fm_pr_poll_publish_prepared || fail "could not publish a GitLab poll"
+  fm_pr_poll_artifacts_valid "$state" task-a "$POLL" \
+    || fail "published GitLab poll provenance or metadata binding was invalid"
+  [ "$(cat "$state/task-a.pr-poll")" = "gitlab
+$url
+gitlab.example
+group/subgroup/project
+7" ] || fail "published GitLab sidecar bytes were not exact"
+
+  # Only an exact merged state wakes firstmate. Every other reading, including
+  # an unreadable merge request and a changed output format, stays silent.
+  for value in opened closed locked '' not-a-state MERGED merged-but-not; do
+    out=$(FM_TEST_GLAB_STATE="$value" run_poll "$dir")
+    [ -z "$out" ] || fail "GitLab poll emitted for a non-merged state"
+  done
+  out=$(FM_TEST_GLAB_STATE=merged run_poll "$dir")
+  [ "$out" = merged ] || fail "GitLab poll did not emit exactly one merged line"
+  out=$(FM_TEST_GLAB_FAIL=1 run_poll "$dir")
+  [ -z "$out" ] || fail "GitLab poll emitted after a glab failure"
+
+  # glab is addressed by project URL and merge request number, never by the
+  # merge request URL, which the real CLI resolves through the current git
+  # repository the watcher does not have.
+  grep -qF -- "mr view 7 -R https://gitlab.example/group/subgroup/project" "$dir/glab.log" \
+    || fail "GitLab poll did not address glab by project URL and merge request number"
+  ! grep -qF -- "$url" "$dir/glab.log" \
+    || fail "GitLab poll passed a merge request URL to glab"
+
+  # An absent CLI must produce no wake rather than a false merge. The whole
+  # search path is mirrored without glab, because a real glab anywhere on
+  # PATH would make this prove nothing.
+  noglab="$dir/noglab"
+  mkdir -p "$noglab"
+  while IFS= read -r bindir; do
+    [ -d "$bindir" ] || continue
+    for entry in "$bindir"/*; do
+      [ -e "$entry" ] || continue
+      name=$(basename "$entry")
+      [ "$name" = glab ] && continue
+      [ -e "$noglab/$name" ] || ln -s "$entry" "$noglab/$name" 2>/dev/null
+    done
+  done <<EOF
+$dir/fakebin
+$(printf '%s\n' "$BASE_PATH" | tr ':' '\n')
+EOF
+  ! PATH="$noglab" command -v glab >/dev/null 2>&1 \
+    || fail "the glab-free search path still resolved glab"
+  out=$(FM_TEST_GLAB_STATE=merged FM_TEST_GH_LOG="$dir/gh.log" FM_TEST_GLAB_LOG="$dir/glab.log" \
+    PATH="$noglab" \
+    bash "$state/task-a.check.sh")
+  [ -z "$out" ] || fail "GitLab poll emitted with glab absent from PATH"
+
+  # A doctored sidecar cannot redirect the poll: the stored parts must rebuild
+  # the stored URL exactly.
+  printf '%s\n%s\n%s\n%s\n%s\n' gitlab "$url" elsewhere.example group/subgroup/project 7 \
+    > "$state/task-a.pr-poll"
+  out=$(FM_TEST_GLAB_STATE=merged run_poll "$dir")
+  [ -z "$out" ] || fail "GitLab poll emitted for a sidecar whose host was swapped"
+  printf '%s\n%s\n%s\n%s\n%s\n' gitlab "$url" gitlab.example group/subgroup/other 7 \
+    > "$state/task-a.pr-poll"
+  out=$(FM_TEST_GLAB_STATE=merged run_poll "$dir")
+  [ -z "$out" ] || fail "GitLab poll emitted for a sidecar whose project was swapped"
+
+  # Arming is where a missing CLI can still be reported, so it refuses there.
+  write_task_meta "$dir" task-b
+  set +e
+  out=$(FM_ROOT_OVERRIDE="$dir/root" FM_HOME="$dir/home" \
+    FM_TEST_GUARD_LOG="$dir/guard.log" PATH="$noglab" \
+    "$PR_CHECK" task-b "$url" 2>&1)
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "arming a GitLab watch succeeded with glab absent"
+  case "$out" in
+    *"requires glab on PATH"*) ;;
+    *) fail "arming a GitLab watch with glab absent did not report the missing CLI" ;;
+  esac
+  [ ! -e "$state/task-b.check.sh" ] || fail "refused GitLab arming left a poll armed"
+
+  # The merge path still addresses GitHub only, so it refuses rather than
+  # sending a merge request to the wrong forge.
+  write_task_meta "$dir" task-c
+  set +e
+  run_merge_entry "$dir" task-c "$url" >/dev/null 2>&1
+  rc=$?
+  set -e
+  [ "$rc" -eq 2 ] || fail "merge wrapper did not refuse a GitLab merge request URL"
+  [ ! -s "$dir/gh-axi.log" ] || fail "merge wrapper reached the GitHub CLI for a GitLab URL"
+
+  # The instance is data, never a constant, so self-hosted instances work.
+  ! grep -qF gitlab.com "$ROOT/bin/fm-pr-lib.sh" \
+    || fail "the shared PR library hardcodes a GitLab host"
+  ! grep -qF gitlab.com "$ROOT/bin/fm-pr-poll.sh" \
+    || fail "the static poll hardcodes a GitLab host"
+  pass "GitLab merge requests are followed on any instance and never wake falsely"
+}
+
 test_parser_matrix
+test_gitlab_merge_watch
 test_invalid_entrypoints_have_zero_side_effects
 test_valid_recording_and_merge_derivation
 test_rejected_metacharacter_bytes_are_inert


### PR DESCRIPTION
## Intent

Add GitLab merge-request support to firstmate's merge watch, so a task whose deliverable is a GitLab merge request is followed to merge exactly the way a GitHub pull request already is.

Key deliberate decisions a reviewer should not mistake for oversights:

1. Plain 'glab', never the 'glab-axi' agent wrapper. A prior attempt at this used glab-axi and was abandoned for it: upstream users do not have that wrapper installed, so the watch would never fire on their machines and would fail silently rather than erroring. The existing GitHub path in these same files calls plain 'gh', so the GitLab path matches it.

2. No 'jq' dependency anywhere. Plain glab has no field selector (gh has --json/-q; glab offers only -F text|json), so reading its JSON would need a JSON processor. jq is NOT one of firstmate's common bootstrap tools (COMMON_TOOLS in bin/fm-bootstrap.sh is node/git/gh/no-mistakes/gh-axi/chrome-devtools-axi/lavish-axi/tasks-axi/quota-axi); it is required only for opt-in X mode and dispatch profiles. Merge watch is core, so making it depend on an optional-tier tool would be a regression - and a missing-or-broken jq produces empty output, which is indistinguishable from 'not merged'. The state is therefore read from glab's own field output with sed, taking the first '^state:' line. Only an exact 'merged' wakes firstmate, so a changed output format or an unreadable merge request stays silent rather than reporting a false merge.

3. glab is addressed by project URL (-R) plus merge request number, not by the merge request URL. This was verified by running it, not assumed: 'glab mr view <url>' shells out to git for the current repository and fails with 'not a git repository', and the watcher runs in no repository.

4. GitLab tasks record no pr_head=. gh exposes the head commit as a selectable field; plain glab exposes it only inside JSON. Both consumers already treat pr_head as optional - bin/fm-teardown.sh asks the forge for the head at teardown rather than reading metadata and falls back to its provider-agnostic content check, and bin/fm-review-diff.sh resolves the head from the remote when none is recorded.

5. bin/fm-pr-merge.sh deliberately stays GitHub-only and now refuses a GitLab URL explicitly rather than sending a merge request to the wrong forge. Merge parity is out of scope for this change; the scope is the watch.

6. The stored poll identity is generalized from owner/repository to provider/url/host/path/number. GitLab runs mostly on self-hosted instances and its projects nest under groups at no fixed depth, so no owner+repository pair can address one and the host cannot be a constant. Every consumer rebuilds the URL from the stored parts and refuses any record that does not reconstruct it exactly, so a doctored sidecar cannot redirect the poll at another host or project. The registration version moves to v2; the existing non-executing migration rebuilds an already-armed watch from its recorded URL, verified so no user loses a watch by upgrading.

7. Safety properties of the existing watch are preserved: the byte-static poll, its reconstruct-and-compare check, the data-only sidecar, and silence on every error. An absent glab produces no wake rather than a false merge, and arming refuses loudly with 'requires glab on PATH' because arming is the one point where a missing CLI can still be reported.

Evidence in docs/gitlab-merge-watch.md was taken only against the captain's own public fixture project https://gitlab.com/KarotKris/gitlab-merge-watch-fixture, which holds one merged and one open merge request. No self-hosted instance is referenced anywhere; the non-default-host case uses the reserved placeholder domain gitlab.example.

Testing: tests/fm-pr-check-security.test.sh passes 29/29 including a new test_gitlab_merge_watch covering merged/non-merged states, absent glab, sidecar tampering, arming refusal, merge-path refusal, and an assertion that neither bin/fm-pr-lib.sh nor bin/fm-pr-poll.sh hardcodes 'gitlab.com'. fm-pr-merge, fm-teardown, fm-watch-triage, fm-instruction-owners, fm-captain-translation-contract, fm-watcher-lock all pass; bin/fm-lint.sh is clean.

Two test failures on this machine are pre-existing and NOT part of this change: tests/fm-dispatch-select.test.sh 'missing quota-axi should not fail dispatch' (verified to reproduce identically on a clean origin/main clone at 339427d) and a timing-flaky watcher-lock assertion. Both are filed as separate work; please do not attribute or fix them here.

## What Changed

- Extended `bin/fm-pr-lib.sh`, `bin/fm-pr-check.sh`, and `bin/fm-pr-poll.sh` to recognize GitLab merge request URLs alongside GitHub PR URLs, arming and polling a GitLab watch through plain `glab mr view -R <url> <number>` and parsing merged state from its field output with `sed` (no `jq` dependency). The GitLab host is validated to reject `github.com`, and arming refuses loudly when `glab` is not on `PATH`.
- Generalized the stored poll identity from a GitHub-specific owner/repository pair to a provider/url/host/path/number record (registration v2), with every consumer reconstructing and comparing the URL against the recorded parts before acting, and added a non-executing `bin/fm-pr-check-migrate.sh` migration that rebuilds already-armed v1 watches under the new schema.
- Kept `bin/fm-pr-merge.sh` GitHub-only, now explicitly refusing GitLab URLs instead of attempting to merge against the wrong forge.
- Added `docs/gitlab-merge-watch.md` documenting the GitLab watch behavior and updated `docs/architecture.md`, `docs/scripts.md`, `README.md`, and `AGENTS.md` accordingly.
- Expanded `tests/fm-pr-check-security.test.sh` with `test_gitlab_merge_watch` covering merged/non-merged states, absent `glab`, sidecar tampering, arming refusal, and merge-path refusal, plus an assertion that neither `fm-pr-lib.sh` nor `fm-pr-poll.sh` hardcodes `gitlab.com`.

## Risk Assessment

✅ Low: This is a minimal, surgical two-line fix (plus comment) that precisely closes the previously-identified github.com/GitLab-URL host-ambiguity gap in both the library validator and the static poll script's duplicate inline check, verified live to reject the bad case while leaving all legitimate GitHub and GitLab URL parsing unchanged.

## Testing

Completed 1 recorded test check.

- Outcome: ⚠️ 1 error across 1 run (19m26s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-pr-lib.sh:160` - fm_pr_url_parse&#39;s GitLab pattern (`^https://([a-z0-9.-]{1,253})/([A-Za-z0-9._/-]{3,1024})/-/merge_requests/([1-9][0-9]*)$`) does not exclude host `github.com`. A URL such as `https://github.com/org/repo/-/merge_requests/1` (e.g. a typo&#39;d GitHub PR URL) is accepted and classified provider=gitlab, host=github.com. Verified live: `fm_pr_url_parse` returns success with `provider=gitlab host=github.com path=org/repo number=1`. fm-pr-check.sh would then arm a watch that calls `glab mr view 1 -R https://github.com/org/repo`, which can never succeed against github.com, so the watch is permanently and silently non-functional (fails safe re: no false merge, but never detects the real merge either, defeating the feature&#39;s purpose for that task). Not covered by the INVALID_URLS test matrix or docs. Fix is a small, mechanical validation tightening (e.g. reject host == github.com in the GitLab branch/fm_pr_gitlab_host_valid) and doesn&#39;t touch any documented or tested behavior.

🔧 Fix: Reject github.com host in GitLab MR URL/sidecar validation
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Test** - 1 error</summary>

- 🚨 tests failed with exit code 1
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
