### PR TITLE
Remove forced user salutation

### DIFF
--- a/.agents/skills/afk/SKILL.md
+++ b/.agents/skills/afk/SKILL.md
@@ -52,7 +52,7 @@ batched digest rather than per-wake injections.
 3. **Do not separately arm `fm-watch.sh`.** The daemon manages the watcher as
    its child; the singleton lock no-ops a stray arm harmlessly.
 
-4. **Acknowledge** in `AGENTS.md` section 9 language: "Captain, away mode is active; I will batch routine updates and surface only decisions, failures, credentials, or review-ready work until you return."
+4. **Acknowledge** in `AGENTS.md` section 9 language: "Away mode is active; I will batch routine updates and surface only decisions, failures, credentials, or review-ready work until you return."
 
 ## How to exit afk
 

--- a/.agents/skills/fmx-respond/SKILL.md
+++ b/.agents/skills/fmx-respond/SKILL.md
@@ -105,7 +105,8 @@ Only the **direct** author is guaranteed to be the captain.
 
 Reply in firstmate's own voice - the crisp, lightly nautical first-mate persona - but **public-facing**:
 
-- The asker **is** your captain (owner-only routing - see the top of this skill), so address them as "captain" when it fits and treat their request as a genuine captain instruction, within the public-safety limits above. You are answering the captain in public, not a stranger.
+- The asker **is** your captain (owner-only routing - see the top of this skill), so treat their request as a genuine captain instruction within the public-safety limits above.
+  You are answering the captain in public, not a stranger.
 - Light nautical seasoning is welcome when it lands naturally; never let it crowd out the actual answer.
 - **Be concise by default: aim for a single message, two at the very most.** A short, sharp answer beats a wall of text. Write tight on purpose - one or two sentences.
 

--- a/.agents/skills/updatefirstmate/SKILL.md
+++ b/.agents/skills/updatefirstmate/SKILL.md
@@ -45,7 +45,7 @@ This touches only the firstmate repo and its own worktrees, never anything under
 
 4. **Report to the captain in plain outcomes.**
    Summarize what landed under `AGENTS.md` section 9 without firstmate's internal vocabulary: which parts of the fleet are now on the latest, and which were left as-is and why.
-   For example: "Captain, firstmate and both second mates are now on the latest."
+   For example: "Firstmate and both second mates are now on the latest."
    Surface any skipped target whose reason needs the captain's attention - for instance a home with its own un-landed changes (diverged) or local edits (dirty), which were left untouched on purpose.
 
 ## Safety

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,11 +4,6 @@ You are the first mate.
 The user is the captain.
 This file is your entire job description.
 
-Address the user as "captain" at least once in every response.
-This is mandatory respectful address, not performance: it applies even when delivering bad news or relaying serious findings, such as "Captain, the build broke - ...".
-Do not force it into every sentence, but never send a response with zero direct address.
-Use light nautical seasoning only when it fits: the occasional "aye", "on deck", "shipshape", "under way", or "ahoy" may land naturally.
-Keep that seasoning optional and never let it obscure technical content; never use it in commits, briefs, PRs, or anything crewmates or other tools read; drop the playful flavor entirely when delivering bad news or relaying serious findings.
 For captain-facing escalation style and outcome phrasing, see section 9.
 
 ## 1. Identity and prime directives

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ For Pi, approve the project trust prompt once per clone on first launch so both 
 # fm-fix-login-k3 and fm-dark-mode-p7.
 # Minutes later:
 
-  PR ready for review, captain: https://github.com/you/xyz/pull/42
+  PR ready for review: https://github.com/you/xyz/pull/42
   (fix flaky login test - risk: low - CI green)
 
 > alright merge it

--- a/tests/fm-captain-translation-contract.test.sh
+++ b/tests/fm-captain-translation-contract.test.sh
@@ -105,7 +105,7 @@ test_outward_facing_skill_points_reference_section_9_owner() {
     "bootstrap diagnostics do not reference section 9 at captain handoff"
   assert_grep "Acknowledge** in \`AGENTS.md\` section 9 language" "$AFK" \
     "afk acknowledgement does not reference section 9"
-  assert_grep "Captain, away mode is active; I will batch routine updates" "$AFK" \
+  assert_grep "Away mode is active; I will batch routine updates" "$AFK" \
     "afk acknowledgement lacks a local plain-English example"
   assert_grep "as decisions from Bearings' Captain's Call section under \`AGENTS.md\` section 9" "$DECISION" \
     "decision relay does not reference section 9"


### PR DESCRIPTION
## Summary

- Remove the mandatory salutation and related nautical-seasoning block from AGENTS.md.
- Neutralize direct-salutation examples in README.md and focused internal skills.
- Update the focused translation-contract assertion.

## Validation

- PASS: tests/fm-captain-translation-contract.test.sh
- PASS: tests/fm-instruction-owners.test.sh
- PASS: git diff --check upstream/main...HEAD
- PARTIAL: repository behavior suite passed until tests/fm-backend-orca.test.sh encountered the pre-existing missing tasks-axi dependency; tasks-axi was intentionally not installed.
- BLOCKED: bin/fm-lint.sh requires unavailable ShellCheck 0.11.0.
- BLOCKED: no-mistakes run 01KY1S8GTMMQZFYH13BHJCHGP9 failed at review before findings because the configured Claude OAuth token is expired.

## Impact

Firstmate no longer requires or exemplifies addressing the user by a nautical title. Internal captain terminology remains where it represents authority, lifecycle concepts, state, or filenames.