### PR TITLE
feat: add update-tools skill and fm-tool-versions inventory

### DIFF
--- a/.agents/skills/update-tools/SKILL.md
+++ b/.agents/skills/update-tools/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: update-tools
+description: >-
+  Check and drive updates for the live firstmate home, Nix agentic tools, and
+  harness CLIs. Use when the captain invokes /update-tools (e.g. "/update-tools",
+  "update tools", "update harnesses", "check for tool updates", "update no-mistakes
+  and claude", "are our agent tools current"). Inventory is bin/fm-tool-versions.sh;
+  firstmate home updates reuse /updatefirstmate; agentic pins and nixpkgs harness
+  bumps ship through a dotfiles project change, then activate after green merge.
+user-invocable: true
+metadata:
+  internal: true
+---
+
+# update-tools
+
+Captain-invocable skill for **fleet tooling awareness and updates**.
+
+This is broader than `/updatefirstmate`.
+
+| Concern | Owner |
+| --- | --- |
+| Live firstmate home + secondmates (tracked `AGENTS.md` / `bin/` / skills) | `/updatefirstmate` and `bin/fm-update.sh` only - do not invent a second firstmate updater |
+| Agentic Nix pins (no-mistakes, treehouse, `*-axi`, lavish-axi, firstmate flake pin) | Dotfiles `scripts/agentic-tools-check-updates.sh` / `agentic-tools-bump.sh` |
+| Harness CLIs (claude-code, codex, grok-build, opencode, pi-coding-agent) | Dotfiles **nixpkgs** pin (`nixos-unstable`), not `agentic-tools-bump` today |
+
+`bin/fm-tool-versions.sh` is the read-only inventory owner (installed, locked nixpkgs package versions, agentic pin status, fail-soft upstream tips, exit codes).
+Its header and `--help` own flags, tool sources, and classification (`current` / `behind` / `ahead` / `unknown` / `error`).
+
+## When to load
+
+Load when the captain says `/update-tools`, "update tools", "update harnesses", "check for tool updates", "update no-mistakes and claude", or similar language about keeping agent CLIs current.
+
+## Procedure (firstmate, not a crewmate)
+
+### 1. Check
+
+Run from the firstmate code root (absolute path; no persistent primary `cd`):
+
+```sh
+bin/fm-tool-versions.sh
+```
+
+Optional flags: `--installed-only`, `--no-network`, `--skip-agentic`, `--skip-nix`, `--dotfiles PATH` (defaults to `$FM_HOME/projects/dotfiles`).
+
+Present a captain-facing table of installed vs locked pin vs upstream, using `AGENTS.md` section 9 translation.
+Do not dump internal exit-code jargon; say what is behind, what is current, and what could not be checked.
+
+### 2. Firstmate home
+
+If the live firstmate (or a secondmate home) is behind origin on its tracked instruction surface, run the existing **`/updatefirstmate`** path only:
+
+- `bin/fm-update.sh`
+- re-read `AGENTS.md` when the updater says to
+- nudge updated secondmates
+
+Do not restate that skill's procedure body here; load and follow `/updatefirstmate`.
+
+### 3. Dotfiles bumps when agentic pins or harnesses are behind
+
+Firstmate does **not** hand-edit `projects/dotfiles` (project-write boundary).
+
+When agentic pins or harnesses (via nixpkgs) are behind, prefer dispatching a **dotfiles** ship task (that project is no-mistakes + yolo when so registered) whose brief requires the worker to:
+
+1. Bump selected agentic tools with `scripts/agentic-tools-bump.sh <tools...>` (pin semantics stay in that script; do not reimplement).
+2. Advance the **nixpkgs** input toward current `nixos-unstable` and re-evaluate harness package versions (`claude-code`, `codex`, `grok-build`, `opencode`, `pi-coding-agent`) until they match or exceed known upstream tips where nixpkgs has caught up.
+3. If nixpkgs still lags upstream after a fresh pin, document the lag in the PR and list options: wait for nixpkgs, maintain an overlay, or temporary non-nix install.
+   Escalate to the captain when policy is unclear; do not silently leave the fleet on a permanent non-nix path.
+4. Run repo tests, no-mistakes, and open a PR.
+
+### 4. Activate after green merge
+
+After the captain (or yolo authority) lands the dotfiles PR and the local clone is refreshed via the guarded fleet-sync path:
+
+1. From the primary `projects/dotfiles` checkout, with absolute paths and no persistent primary `cd`:
+   - `scripts/rebuild.sh --locked --agentic-tools`
+   - `setup-agentic-tools`
+2. Re-run `bin/fm-tool-versions.sh`.
+3. If `setup-agentic-tools` resets the firstmate pin (known hazard), run `/updatefirstmate` again so the live home is not left on a stale checkout.
+
+### 5. Safety
+
+- Never force-discard unlanded work.
+- Never kill or restart the shared no-mistakes daemon with `--force` while foreign runs are active without explicit captain OK.
+- Never mutate pins or packages from this skill's check step; inventory is read-only.
+- Report what stayed behind and why (nixpkgs lag, probe offline, dirty home skipped by fast-forward update, and so on).
+
+## Cross-links
+
+- **Firstmate-only tracked-code refresh:** `/updatefirstmate` (`bin/fm-update.sh`).
+- **Full fleet tooling check and drive:** this skill (`/update-tools`, `bin/fm-tool-versions.sh`).
+- **Agentic pin mechanics:** captain's dotfiles `scripts/agentic-tools-*.sh` and `scripts/lib/agentic-tools-lib.sh`.
+- **Harness package ownership:** nixpkgs attrs listed in the dotfiles home profile; inventory header in `bin/fm-tool-versions.sh`.

--- a/.no-mistakes.yaml
+++ b/.no-mistakes.yaml
@@ -25,7 +25,7 @@ disable_project_settings: true
 # tmux on PATH, which the firstmate environment provides.
 commands:
   lint: 'bin/fm-lint.sh'
-  test: 'command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"'
+  test: 'export PATH="${HOME}/.nix-profile/bin:/nix/var/nix/profiles/default/bin:${PATH}"; command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"'
 
 # Keep test evidence out of this repo; it stays in a temp dir instead.
 test:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -446,6 +446,8 @@ Firstmate's shared instruction surface reaches running homes only after it lands
 Only `AGENTS.md`, `bin/`, and `.agents/skills/` are loaded by a running firstmate; public `skills/` is an installer-facing surface.
 When the captain invokes `/updatefirstmate` or asks to update firstmate, load the `/updatefirstmate` skill.
 It performs guarded fast-forward updates of firstmate and registered secondmate homes, refreshes instructions, and never touches anything under `projects/`.
+When the captain invokes `/update-tools` or asks to update tools, harnesses, or agentic CLIs, load the `/update-tools` skill.
+That skill checks versions with `bin/fm-tool-versions.sh`, reuses `/updatefirstmate` for the live home, and drives agentic and nixpkgs harness bumps through a dotfiles ship rather than hand-editing `projects/`.
 
 ## 13. Agent-only reference skills
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,9 @@ See the [no-mistakes quick start](https://kunchenguid.github.io/no-mistakes/star
   `bin/fm-lint.sh` must pass: it is the single owner of the lint definition (the shellcheck file set, config, and pinned shellcheck version), and both CI and the no-mistakes pre-push gate run it, so local and CI can never diverge.
   It pins one exact shellcheck version and refuses to run under any other; print it with `bin/fm-lint.sh --required-version` and install that build locally.
 - Changes to harness adapters (detection in `bin/fm-harness.sh`, launch and hook mechanics in `bin/fm-spawn.sh`, busy signatures in `bin/fm-watch.sh` and `bin/fm-tmux-lib.sh`, cleanup in `bin/fm-teardown.sh`, and facts in `.agents/skills/harness-adapters/SKILL.md`) must be verified empirically against the real harness, never written from documentation alone.
+- Fleet tooling version inventory is owned by `bin/fm-tool-versions.sh` and the captain-invocable `/update-tools` skill.
+  Harness CLIs (claude-code, codex, grok-build, opencode, pi-coding-agent) are **nixpkgs-owned** in the captain's dotfiles flake; the agentic pin list (no-mistakes, treehouse, `*-axi`, lavish-axi, firstmate flake pin) is separate and advanced with that repo's `scripts/agentic-tools-bump.sh`.
+  Do not teach `agentic-tools-bump` as the path for harness CLI upgrades.
 - Changes to runtime session backends (`bin/fm-backend.sh`, `bin/backends/`, and the scripts that dispatch through them) need empirical adapter notes in the relevant backend guide: `docs/tmux-backend.md`, `docs/herdr-backend.md`, `docs/zellij-backend.md`, `docs/orca-backend.md`, `docs/cmux-backend.md`, or `docs/codex-app-backend.md` for blocked Codex App transport work.
 - In Markdown, put each full sentence on its own line.
 - `README.md` stays a concise overview plus pointers: it never carries a wall of inline detail.

--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Claude and grok use the slash form shown here; codex uses the same names with `$
 | `/afk`             | Enter away-mode supervision: the sub-supervisor self-handles routine notifications in bash, escalates captain-relevant events and bounded declared-external-wait rechecks as batched digests, and actively alerts if delivery gets stuck while you step away |
 | `/bearings`        | Generate a standalone current-status report from bounded local fleet and registered-secondmate state, with live PR enrichment only when requested, written to a dated file in `data/` and surfaced concisely in chat; read-mostly, mutates no task state |
 | `/updatefirstmate` | Self-update the running firstmate and its secondmates to the latest from origin with fast-forward-only pulls, then re-read instructions and nudge secondmates |
+| `/update-tools`    | Check installed vs upstream tool versions (`bin/fm-tool-versions.sh`), update the live firstmate home via `/updatefirstmate`, and drive agentic pin plus nixpkgs harness bumps through a dotfiles ship |
 | `/stow`            | Sweep the session for uncaptured durable knowledge, route each finding to its disk home per AGENTS.md, file undone next steps to the backlog, and report what is now safe to reset |
 
 Agent-only reference skills live under `.agents/skills/` and are loaded by firstmate at the trigger points named in [`AGENTS.md`](AGENTS.md).

--- a/bin/fm-lint.sh
+++ b/bin/fm-lint.sh
@@ -61,6 +61,21 @@ for nix_bin in "${HOME:-}/.nix-profile/bin" /nix/var/nix/profiles/default/bin; d
 done
 export PATH
 
+# Still missing (e.g. no Nix profile): bootstrap the pinned, checksum-verified
+# build into the user cache and prepend it to PATH. Reuse fm-install-shellcheck.sh
+# so the download/checksum logic stays in one place; its --version line goes to
+# stderr to keep lint stdout clean.
+if ! command -v shellcheck >/dev/null 2>&1; then
+  cache_bin="${XDG_CACHE_HOME:-$HOME/.cache}/firstmate/bin"
+  if ! mkdir -p "$cache_bin" || ! "$ROOT/bin/fm-install-shellcheck.sh" "$cache_bin" >&2; then
+    printf 'fm-lint.sh: failed to install ShellCheck %s for CI parity.\n' \
+      "$REQUIRED_SHELLCHECK" >&2
+    exit 127
+  fi
+  PATH="$cache_bin:$PATH"
+  export PATH
+fi
+
 # Enforce the pin so local and CI resolve the identical rule set.
 if ! command -v shellcheck >/dev/null 2>&1; then
   printf 'fm-lint.sh: ShellCheck not found; install ShellCheck %s for CI parity.\n' \

--- a/bin/fm-lint.sh
+++ b/bin/fm-lint.sh
@@ -67,10 +67,12 @@ export PATH
 # stderr to keep lint stdout clean.
 if ! command -v shellcheck >/dev/null 2>&1; then
   cache_bin="${XDG_CACHE_HOME:-$HOME/.cache}/firstmate/bin"
-  if ! mkdir -p "$cache_bin" || ! "$ROOT/bin/fm-install-shellcheck.sh" "$cache_bin" >&2; then
-    printf 'fm-lint.sh: failed to install ShellCheck %s for CI parity.\n' \
-      "$REQUIRED_SHELLCHECK" >&2
-    exit 127
+  if [ ! -x "$cache_bin/shellcheck" ]; then
+    if ! mkdir -p "$cache_bin" || ! "$ROOT/bin/fm-install-shellcheck.sh" "$cache_bin" >&2; then
+      printf 'fm-lint.sh: failed to install ShellCheck %s for CI parity.\n' \
+        "$REQUIRED_SHELLCHECK" >&2
+      exit 127
+    fi
   fi
   PATH="$cache_bin:$PATH"
   export PATH

--- a/bin/fm-lint.sh
+++ b/bin/fm-lint.sh
@@ -51,6 +51,16 @@ if [ "${1:-}" = "--required-version" ]; then
   exit 0
 fi
 
+# Make the Nix-provided ShellCheck discoverable when the caller's PATH is bare
+# (e.g. the gate runs with PATH=/usr/bin:/bin). Only prepend the two standard
+# Nix profile bin dirs, when present; no broader PATH rewrite.
+for nix_bin in "${HOME:-}/.nix-profile/bin" /nix/var/nix/profiles/default/bin; do
+  if [ -n "$nix_bin" ] && [ -d "$nix_bin" ]; then
+    PATH="$nix_bin:$PATH"
+  fi
+done
+export PATH
+
 # Enforce the pin so local and CI resolve the identical rule set.
 if ! command -v shellcheck >/dev/null 2>&1; then
   printf 'fm-lint.sh: ShellCheck not found; install ShellCheck %s for CI parity.\n' \

--- a/bin/fm-lint.sh
+++ b/bin/fm-lint.sh
@@ -61,21 +61,48 @@ for nix_bin in "${HOME:-}/.nix-profile/bin" /nix/var/nix/profiles/default/bin; d
 done
 export PATH
 
-# Still missing (e.g. no Nix profile): bootstrap the pinned, checksum-verified
-# build into the user cache and prepend it to PATH. Reuse fm-install-shellcheck.sh
-# so the download/checksum logic stays in one place; its --version line goes to
-# stderr to keep lint stdout clean.
+host_os=$(uname -s 2>/dev/null || printf 'unknown')
+host_arch=$(uname -m 2>/dev/null || printf 'unknown')
+can_bootstrap=0
+if [ "$host_os" = Linux ] && [ "$host_arch" = x86_64 ]; then
+  can_bootstrap=1
+fi
+
+cache_bin="${XDG_CACHE_HOME:-$HOME/.cache}/firstmate/bin"
+cache_shellcheck="$cache_bin/shellcheck"
+cache_selected=0
+
+install_cached_shellcheck() {
+  if ! mkdir -p "$cache_bin" || ! "$ROOT/bin/fm-install-shellcheck.sh" "$cache_bin" >&2; then
+    printf 'fm-lint.sh: failed to install ShellCheck %s for CI parity.\n' \
+      "$REQUIRED_SHELLCHECK" >&2
+    return 1
+  fi
+}
+
+shellcheck_version() {
+  local version_output
+  version_output=$(shellcheck --version 2>/dev/null) || return 1
+  printf '%s\n' "$version_output" | awk '/^version:/ {print $2; exit}'
+}
+
 if ! command -v shellcheck >/dev/null 2>&1; then
-  cache_bin="${XDG_CACHE_HOME:-$HOME/.cache}/firstmate/bin"
-  if [ ! -x "$cache_bin/shellcheck" ]; then
-    if ! mkdir -p "$cache_bin" || ! "$ROOT/bin/fm-install-shellcheck.sh" "$cache_bin" >&2; then
-      printf 'fm-lint.sh: failed to install ShellCheck %s for CI parity.\n' \
-        "$REQUIRED_SHELLCHECK" >&2
+  if [ -x "$cache_shellcheck" ]; then
+    PATH="$cache_bin:$PATH"
+    export PATH
+    cache_selected=1
+  elif [ "$can_bootstrap" -eq 1 ]; then
+    if ! install_cached_shellcheck; then
       exit 127
     fi
+    PATH="$cache_bin:$PATH"
+    export PATH
+    cache_selected=1
+  else
+    printf 'fm-lint.sh: ShellCheck is missing on %s/%s; automatic bootstrap supports Linux x86_64 only. Install ShellCheck %s for CI parity.\n' \
+      "$host_os" "$host_arch" "$REQUIRED_SHELLCHECK" >&2
+    exit 127
   fi
-  PATH="$cache_bin:$PATH"
-  export PATH
 fi
 
 # Enforce the pin so local and CI resolve the identical rule set.
@@ -85,12 +112,47 @@ if ! command -v shellcheck >/dev/null 2>&1; then
   exit 127
 fi
 unset SHELLCHECK_OPTS
-resolved=$(shellcheck --version | awk '/^version:/ {print $2; exit}')
+resolved=""
+if ! resolved=$(shellcheck_version); then
+  resolved=""
+fi
+if [ -z "$resolved" ] && [ "$cache_selected" -eq 1 ]; then
+  if [ "$can_bootstrap" -eq 1 ]; then
+    if ! install_cached_shellcheck; then
+      exit 127
+    fi
+    if ! resolved=$(shellcheck_version); then
+      resolved=""
+    fi
+  else
+    printf 'fm-lint.sh: cached ShellCheck could not run on %s/%s; automatic bootstrap supports Linux x86_64 only. Install ShellCheck %s for CI parity.\n' \
+      "$host_os" "$host_arch" "$REQUIRED_SHELLCHECK" >&2
+    exit 127
+  fi
+fi
 # Log the resolved version to stderr so both CI and local runs record it.
 printf 'fm-lint.sh: ShellCheck %s (pinned %s)\n' "$resolved" "$REQUIRED_SHELLCHECK" >&2
 if [ "$resolved" != "$REQUIRED_SHELLCHECK" ]; then
-  printf 'fm-lint.sh: ShellCheck %s required for CI parity, found %s. Install %s.\n' \
-    "$REQUIRED_SHELLCHECK" "$resolved" "$REQUIRED_SHELLCHECK" >&2
+  if [ "$cache_selected" -eq 1 ] && [ "$can_bootstrap" -eq 1 ]; then
+    if ! install_cached_shellcheck; then
+      exit 127
+    fi
+    if ! resolved=$(shellcheck_version); then
+      resolved=""
+    fi
+    if [ "$resolved" = "$REQUIRED_SHELLCHECK" ]; then
+      printf 'fm-lint.sh: ShellCheck %s (pinned %s)\n' "$resolved" "$REQUIRED_SHELLCHECK" >&2
+    fi
+  fi
+fi
+if [ "$resolved" != "$REQUIRED_SHELLCHECK" ]; then
+  if [ "$cache_selected" -eq 1 ] && [ "$can_bootstrap" -eq 0 ]; then
+    printf 'fm-lint.sh: cached ShellCheck %s is not pinned to %s on %s/%s; automatic bootstrap supports Linux x86_64 only. Install ShellCheck %s for CI parity.\n' \
+      "$resolved" "$REQUIRED_SHELLCHECK" "$host_os" "$host_arch" "$REQUIRED_SHELLCHECK" >&2
+  else
+    printf 'fm-lint.sh: ShellCheck %s required for CI parity, found %s. Install %s.\n' \
+      "$REQUIRED_SHELLCHECK" "$resolved" "$REQUIRED_SHELLCHECK" >&2
+  fi
   exit 1
 fi
 

--- a/bin/fm-tool-versions.sh
+++ b/bin/fm-tool-versions.sh
@@ -1,0 +1,572 @@
+#!/usr/bin/env bash
+# Read-only inventory of fleet tooling versions: installed binaries, locked
+# nixpkgs harness package versions from the captain's dotfiles flake, agentic
+# pin status (via the dotfiles check script), and fail-soft upstream tips.
+#
+# Ownership
+#   This script owns the inventory contract and exit codes below. It never
+#   mutates the system, flake.lock, pins, or installed packages.
+#   Agentic pin semantics stay in the dotfiles project
+#   (scripts/agentic-tools-check-updates.sh and its lib). Call that script; do
+#   not reimplement pin styles, lock parsing, or remote tip rules for agentic
+#   tools.
+#   Harness CLIs (claude-code, codex, grok-build, opencode, pi-coding-agent)
+#   come from the nixpkgs pin in the same flake, not from agentic-tools-bump.
+#
+# Tools in scope
+#   Harness (installed + locked nixpkgs + upstream tip):
+#     claude   -> package claude-code; upstream npm @anthropic-ai/claude-code
+#     codex    -> package codex; upstream GitHub openai/codex stable release
+#     grok     -> package grok-build; upstream only via nixpkgs when no public
+#                 stable channel is known (documented as unknown when tip missing)
+#     opencode -> package opencode; upstream GitHub anomalyco/opencode stable
+#     pi       -> package pi-coding-agent; upstream GitHub badlogic/pi-mono stable
+#   Agentic (delegated when the check script is present):
+#     firstmate, no-mistakes, treehouse, gh-axi, chrome-devtools-axi,
+#     tasks-axi, quota-axi, lavish-axi
+#   Also prints installed no-mistakes version on the harness table for quick
+#   comparison with the agentic pin section.
+#
+# Dotfiles resolution (first match wins)
+#   1. --dotfiles PATH
+#   2. FM_DOTFILES env
+#   3. $FM_HOME/projects/dotfiles when FM_HOME is set
+#   4. <this-script>/../projects/dotfiles when that path exists (rare)
+#
+# Classification (STATUS column)
+#   current  installed (or pin) matches upstream tip
+#   behind   installed (or pin) is older than upstream tip
+#   ahead    installed is newer than the known tip
+#   unknown  tip or pin not available without a hard failure
+#   error    probe or parse failed (offline, missing tool, bad output)
+#
+# Exit codes (agentic-tools-check spirit)
+#   0  all compared rows current or soft-unknown; no hard errors
+#   1  one or more rows behind
+#   2  usage error
+#   3  partial offline / hard probe failure for one or more rows
+#      (takes precedence over 1 when any error row exists)
+#
+# Usage: fm-tool-versions.sh [options]
+#   -h, --help              show this help
+#   --dotfiles PATH         path to the dotfiles project (flake.nix root)
+#   --installed-only        skip locked nixpkgs eval, agentic check, and network
+#   --no-network            skip upstream harness probes (locked + installed only)
+#   --skip-agentic          do not invoke agentic-tools-check-updates.sh
+#   --skip-nix              do not evaluate locked nixpkgs package versions
+#   --include-prerelease    prefer latest GitHub release including pre-releases
+#   --json                  reserved; not implemented (exit 2 if passed)
+#
+# Environment
+#   FM_HOME, FM_DOTFILES, FM_ROOT_OVERRIDE - path resolution
+#   FM_TOOL_VERSIONS_NIX, FM_TOOL_VERSIONS_NPM, FM_TOOL_VERSIONS_GH - override
+#     the nix / npm / gh binaries used for probes (tests inject fakes here)
+#   NIX_CONFIG - when unset, this script sets experimental-features for nix-command flakes
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+
+NIX_BIN="${FM_TOOL_VERSIONS_NIX:-nix}"
+NPM_BIN="${FM_TOOL_VERSIONS_NPM:-npm}"
+GH_BIN="${FM_TOOL_VERSIONS_GH:-gh}"
+
+DOTFILES_ARG=""
+INSTALLED_ONLY=0
+NO_NETWORK=0
+SKIP_AGENTIC=0
+SKIP_NIX=0
+INCLUDE_PRERELEASE=0
+
+usage() {
+  sed -n '2,70p' "$0" | sed 's/^# \?//'
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    --dotfiles)
+      if [ "$#" -lt 2 ]; then
+        printf 'fm-tool-versions: --dotfiles requires a path\n' >&2
+        exit 2
+      fi
+      DOTFILES_ARG="$2"
+      shift 2
+      continue
+      ;;
+    --installed-only)
+      INSTALLED_ONLY=1
+      NO_NETWORK=1
+      SKIP_AGENTIC=1
+      SKIP_NIX=1
+      ;;
+    --no-network)
+      NO_NETWORK=1
+      ;;
+    --skip-agentic)
+      SKIP_AGENTIC=1
+      ;;
+    --skip-nix)
+      SKIP_NIX=1
+      ;;
+    --include-prerelease)
+      INCLUDE_PRERELEASE=1
+      ;;
+    --json)
+      printf 'fm-tool-versions: --json is not implemented\n' >&2
+      exit 2
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      printf 'fm-tool-versions: unknown option: %s\n' "$1" >&2
+      usage >&2
+      exit 2
+      ;;
+    *)
+      printf 'fm-tool-versions: unexpected argument: %s\n' "$1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+if [ "$#" -gt 0 ]; then
+  printf 'fm-tool-versions: unexpected argument: %s\n' "$1" >&2
+  usage >&2
+  exit 2
+fi
+
+# --- helpers ----------------------------------------------------------------
+
+resolve_dotfiles() {
+  local candidate
+  if [ -n "$DOTFILES_ARG" ]; then
+    candidate="$DOTFILES_ARG"
+  elif [ -n "${FM_DOTFILES:-}" ]; then
+    candidate="$FM_DOTFILES"
+  elif [ -n "${FM_HOME:-}" ] && [ -d "$FM_HOME/projects/dotfiles" ]; then
+    candidate="$FM_HOME/projects/dotfiles"
+  elif [ -d "$FM_ROOT/projects/dotfiles" ]; then
+    candidate="$FM_ROOT/projects/dotfiles"
+  else
+    return 1
+  fi
+  if [ -f "$candidate/flake.nix" ]; then
+    printf '%s\n' "$(cd "$candidate" && pwd -P)"
+    return 0
+  fi
+  return 1
+}
+
+# Strip common noise into a bare version-ish token (digits/dots, optional pre).
+normalize_version() {
+  local raw=$1
+  raw=$(printf '%s' "$raw" | tr -d '\r')
+  # Prefer the first semver-looking token in the string.
+  if printf '%s' "$raw" | grep -Eo '[0-9]+(\.[0-9]+)+([.-][A-Za-z0-9.]+)?' >/dev/null 2>&1; then
+    printf '%s' "$raw" | grep -Eo '[0-9]+(\.[0-9]+)+([.-][A-Za-z0-9.]+)?' | head -1
+    return 0
+  fi
+  printf '%s' "$raw" | sed -E 's/^[^0-9]*//; s/[[:space:]].*$//; s/^v//; s/^rust-v//'
+}
+
+# Compare two version tokens. Echo -1 / 0 / 1 (a<b / equal / a>b).
+# Pre-release suffixes (alpha, beta, rc, pre) sort before a bare release of the
+# same numeric prefix when only one side has them.
+version_cmp() {
+  local a b
+  a=$(normalize_version "$1")
+  b=$(normalize_version "$2")
+  if [ -z "$a" ] || [ -z "$b" ]; then
+    printf '0\n'
+    return 1
+  fi
+  if [ "$a" = "$b" ]; then
+    printf '0\n'
+    return 0
+  fi
+  # Split numeric core and optional suffix at first non-digit/dot boundary.
+  local a_core a_suf b_core b_suf
+  a_core=$(printf '%s' "$a" | sed -E 's/([0-9]+(\.[0-9]+)*)(.*)/\1/')
+  a_suf=$(printf '%s' "$a" | sed -E 's/([0-9]+(\.[0-9]+)*)(.*)/\3/' | sed 's/^[.-]//')
+  b_core=$(printf '%s' "$b" | sed -E 's/([0-9]+(\.[0-9]+)*)(.*)/\1/')
+  b_suf=$(printf '%s' "$b" | sed -E 's/([0-9]+(\.[0-9]+)*)(.*)/\3/' | sed 's/^[.-]//')
+
+  local IFS='.'
+  # shellcheck disable=SC2086
+  set -- $a_core
+  local a1=${1:-0} a2=${2:-0} a3=${3:-0} a4=${4:-0}
+  # shellcheck disable=SC2086
+  set -- $b_core
+  local b1=${1:-0} b2=${2:-0} b3=${3:-0} b4=${4:-0}
+
+  for pair in "$a1:$b1" "$a2:$b2" "$a3:$b3" "$a4:$b4"; do
+    local left=${pair%%:*} right=${pair##*:}
+    left=${left//[^0-9]/}
+    right=${right//[^0-9]/}
+    left=${left:-0}
+    right=${right:-0}
+    if [ "$left" -lt "$right" ]; then
+      printf -- '-1\n'
+      return 0
+    fi
+    if [ "$left" -gt "$right" ]; then
+      printf '1\n'
+      return 0
+    fi
+  done
+
+  if [ -z "$a_suf" ] && [ -n "$b_suf" ]; then
+    printf '1\n'
+    return 0
+  fi
+  if [ -n "$a_suf" ] && [ -z "$b_suf" ]; then
+    printf -- '-1\n'
+    return 0
+  fi
+  if [ "$a_suf" '<' "$b_suf" ]; then
+    printf -- '-1\n'
+    return 0
+  fi
+  if [ "$a_suf" '>' "$b_suf" ]; then
+    printf '1\n'
+    return 0
+  fi
+  printf '0\n'
+}
+
+classify_pair() {
+  # Args: installed_or_pin tip
+  # Empty tip with empty err -> unknown; empty tip with err flag via third arg error
+  local have=$1 tip=$2 mode=${3:-}
+  if [ "$mode" = error ]; then
+    printf 'error\n'
+    return 0
+  fi
+  if [ -z "$have" ]; then
+    printf 'error\n'
+    return 0
+  fi
+  if [ -z "$tip" ]; then
+    printf 'unknown\n'
+    return 0
+  fi
+  local cmp
+  if ! cmp=$(version_cmp "$have" "$tip"); then
+    printf 'unknown\n'
+    return 0
+  fi
+  case "$cmp" in
+    0) printf 'current\n' ;;
+    -1) printf 'behind\n' ;;
+    1) printf 'ahead\n' ;;
+    *) printf 'unknown\n' ;;
+  esac
+}
+
+# Capture first line of a command's stdout; empty on failure.
+cmd_first_line() {
+  local out
+  if ! out=$("$@" 2>/dev/null); then
+    return 1
+  fi
+  printf '%s\n' "$out" | head -1 | tr -d '\r'
+}
+
+installed_version() {
+  local tool=$1
+  local out raw
+  case "$tool" in
+    claude)
+      raw=$(cmd_first_line claude --version) || return 1
+      normalize_version "$raw"
+      ;;
+    codex)
+      raw=$(cmd_first_line codex --version) || return 1
+      normalize_version "$raw"
+      ;;
+    grok)
+      raw=$(cmd_first_line grok --version) || return 1
+      normalize_version "$raw"
+      ;;
+    opencode)
+      raw=$(cmd_first_line opencode --version) || return 1
+      normalize_version "$raw"
+      ;;
+    pi)
+      raw=$(cmd_first_line pi --version) || return 1
+      normalize_version "$raw"
+      ;;
+    no-mistakes)
+      raw=$(cmd_first_line no-mistakes --version) || return 1
+      normalize_version "$raw"
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+nixpkgs_locked_rev() {
+  local root=$1
+  local lock=$root/flake.lock
+  [ -f "$lock" ] || return 1
+  # Prefer python for robust JSON; fall back to sed/grep for minimal envs.
+  if command -v python3 >/dev/null 2>&1; then
+    python3 -c '
+import json, sys
+lock = json.load(open(sys.argv[1]))
+node = lock.get("nodes", {}).get("nixpkgs", {})
+rev = node.get("locked", {}).get("rev")
+if not rev:
+    sys.exit(1)
+print(rev)
+' "$lock"
+    return 0
+  fi
+  # Fallback: crude extraction of the nixpkgs locked rev near its node.
+  grep -A20 '"nixpkgs"' "$lock" | grep -m1 '"rev"' | sed -E 's/.*"rev": *"([^"]+)".*/\1/'
+}
+
+locked_pkg_version() {
+  local rev=$1 pkg=$2
+  local out
+  if [ -z "${NIX_CONFIG:-}" ]; then
+    export NIX_CONFIG="experimental-features = nix-command flakes"
+  fi
+  if ! out=$("$NIX_BIN" eval --raw "github:NixOS/nixpkgs/${rev}#${pkg}.version" 2>/dev/null); then
+    return 1
+  fi
+  normalize_version "$out"
+}
+
+# Stable (non-prerelease) GitHub release tag -> bare version.
+gh_stable_release_version() {
+  local repo=$1
+  local jq_filter tag
+  if [ "$INCLUDE_PRERELEASE" -eq 1 ]; then
+    jq_filter='.[0].tag_name // empty'
+  else
+    jq_filter='[.[] | select(.prerelease==false and .draft==false) | .tag_name][0] // empty'
+  fi
+  if ! tag=$("$GH_BIN" api "repos/${repo}/releases" --jq "$jq_filter" 2>/dev/null); then
+    return 1
+  fi
+  [ -n "$tag" ] || return 1
+  # openai/codex tags look like rust-v0.144.6
+  tag=$(printf '%s' "$tag" | sed -E 's/^rust-//')
+  normalize_version "$tag"
+}
+
+upstream_harness_tip() {
+  local tool=$1
+  case "$tool" in
+    claude)
+      local v
+      v=$("$NPM_BIN" view @anthropic-ai/claude-code version 2>/dev/null) || return 1
+      normalize_version "$v"
+      ;;
+    codex)
+      gh_stable_release_version openai/codex
+      ;;
+    opencode)
+      # nixpkgs meta.homepage points at anomalyco/opencode
+      gh_stable_release_version anomalyco/opencode
+      ;;
+    pi)
+      gh_stable_release_version badlogic/pi-mono
+      ;;
+    grok)
+      # Public xai-org/grok-build has no GitHub Releases API surface today.
+      # Upstream tip is unknown unless a future channel is documented; callers
+      # treat empty as unknown rather than error when this returns 1 with empty.
+      return 1
+      ;;
+    no-mistakes)
+      # Prefer agentic section; optional npm/git tip not used here.
+      return 1
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+# --- main -------------------------------------------------------------------
+
+BEHIND=0
+ERRORS=0
+DOTFILES=""
+NIXPKGS_REV=""
+
+if [ "$INSTALLED_ONLY" -eq 0 ]; then
+  if DOTFILES=$(resolve_dotfiles); then
+    :
+  else
+    DOTFILES=""
+  fi
+fi
+
+if [ -n "$DOTFILES" ] && [ "$SKIP_NIX" -eq 0 ]; then
+  NIXPKGS_REV=$(nixpkgs_locked_rev "$DOTFILES" 2>/dev/null || true)
+fi
+
+printf 'Fleet tool versions (read-only; never mutates)\n'
+if [ -n "$DOTFILES" ]; then
+  printf 'dotfiles: %s\n' "$DOTFILES"
+  if [ -n "$NIXPKGS_REV" ]; then
+    printf 'nixpkgs lock: %s\n' "$NIXPKGS_REV"
+  elif [ "$SKIP_NIX" -eq 0 ]; then
+    printf 'nixpkgs lock: (unreadable)\n'
+  fi
+else
+  printf 'dotfiles: (not resolved; locked nixpkgs and agentic pin sections skipped or limited)\n'
+fi
+printf '\n'
+
+# --- harness table ----------------------------------------------------------
+
+printf '## Harness CLIs (nixpkgs-owned in dotfiles; not agentic-tools-bump)\n'
+printf '%-12s %-14s %-14s %-14s %s\n' 'TOOL' 'INSTALLED' 'LOCKED' 'UPSTREAM' 'STATUS'
+printf '%-12s %-14s %-14s %-14s %s\n' '----' '---------' '------' '--------' '------'
+
+# shell name : nixpkgs attr : show in table
+HARNESS_ROWS=(
+  'claude:claude-code'
+  'codex:codex'
+  'grok:grok-build'
+  'opencode:opencode'
+  'pi:pi-coding-agent'
+  'no-mistakes:'
+)
+
+for row in "${HARNESS_ROWS[@]}"; do
+  tool=${row%%:*}
+  pkg=${row#*:}
+
+  installed='-'
+  locked='-'
+  upstream='-'
+  status='unknown'
+  tip_failed=0
+  lock_failed=0
+  install_missing=0
+
+  if inst=$(installed_version "$tool" 2>/dev/null); then
+    installed=$inst
+  else
+    installed='(missing)'
+    install_missing=1
+  fi
+
+  if [ -n "$pkg" ] && [ -n "$NIXPKGS_REV" ] && [ "$SKIP_NIX" -eq 0 ]; then
+    if lkv=$(locked_pkg_version "$NIXPKGS_REV" "$pkg" 2>/dev/null); then
+      locked=$lkv
+    else
+      locked='(error)'
+      lock_failed=1
+    fi
+  elif [ -n "$pkg" ] && [ "$SKIP_NIX" -eq 0 ] && [ -z "$NIXPKGS_REV" ]; then
+    locked='(no lock)'
+  fi
+
+  if [ "$NO_NETWORK" -eq 0 ]; then
+    if tip=$(upstream_harness_tip "$tool" 2>/dev/null); then
+      upstream=$tip
+    else
+      # grok has no public stable channel today; no-mistakes is agentic-owned.
+      if [ "$tool" = grok ] || [ "$tool" = no-mistakes ]; then
+        upstream='(unknown)'
+      else
+        upstream='(unreachable)'
+        tip_failed=1
+      fi
+    fi
+  else
+    upstream='(skipped)'
+  fi
+
+  # Status prioritizes: missing install / unreachable tip -> error; else
+  # compare installed vs a real upstream tip; else soft unknown.
+  if [ "$install_missing" -eq 1 ]; then
+    status=error
+  elif [ "$tip_failed" -eq 1 ]; then
+    status=error
+  elif [ "$upstream" != '(unknown)' ] && [ "$upstream" != '(skipped)' ] && [ "$upstream" != '-' ] && [ "$upstream" != '(unreachable)' ]; then
+    status=$(classify_pair "$installed" "$upstream")
+  elif [ "$lock_failed" -eq 1 ]; then
+    # No tip to compare; a hard lock eval failure still surfaces as error.
+    status=error
+  else
+    status=unknown
+  fi
+
+  case "$status" in
+    behind) BEHIND=$((BEHIND + 1)) ;;
+    error) ERRORS=$((ERRORS + 1)) ;;
+  esac
+
+  printf '%-12s %-14s %-14s %-14s %s\n' "$tool" "$installed" "$locked" "$upstream" "$status"
+done
+
+printf '\n'
+printf 'Note: harnesses advance when the dotfiles flake nixpkgs (nixos-unstable)\n'
+printf 'pin is updated and Home Manager is rebuilt. agentic-tools-bump.sh does not\n'
+printf 'bump claude/codex/grok/opencode/pi.\n'
+printf '\n'
+
+# --- agentic section --------------------------------------------------------
+
+if [ "$SKIP_AGENTIC" -eq 0 ] && [ -n "$DOTFILES" ]; then
+  agentic_check="$DOTFILES/scripts/agentic-tools-check-updates.sh"
+  printf '## Agentic pins (dotfiles agentic-tools-check-updates.sh)\n'
+  if [ -x "$agentic_check" ] || [ -f "$agentic_check" ]; then
+    set +e
+    agentic_out=$(bash "$agentic_check" 2>&1)
+    agentic_ec=$?
+    set -e
+    printf '%s\n' "$agentic_out"
+    case "$agentic_ec" in
+      0) : ;;
+      1) BEHIND=$((BEHIND + 1)) ;;
+      2)
+        ERRORS=$((ERRORS + 1))
+        printf '(agentic check usage error)\n' >&2
+        ;;
+      3) ERRORS=$((ERRORS + 1)) ;;
+      *)
+        ERRORS=$((ERRORS + 1))
+        printf '(agentic check exited %s)\n' "$agentic_ec" >&2
+        ;;
+    esac
+  else
+    printf 'agentic check script missing at %s\n' "$agentic_check"
+    ERRORS=$((ERRORS + 1))
+  fi
+  printf '\n'
+elif [ "$SKIP_AGENTIC" -eq 0 ]; then
+  printf '## Agentic pins\n'
+  printf '(skipped: dotfiles path not resolved)\n\n'
+fi
+
+# --- summary ----------------------------------------------------------------
+
+printf 'Summary: behind=%s errors=%s\n' "$BEHIND" "$ERRORS"
+if [ "$ERRORS" -gt 0 ]; then
+  printf 'Check incomplete: one or more probes failed (offline, missing tool, or parse error).\n' >&2
+  exit 3
+fi
+if [ "$BEHIND" -gt 0 ]; then
+  printf 'One or more tools are behind upstream or their agentic pin is behind.\n'
+  exit 1
+fi
+printf 'All compared tools are current (or soft-unknown without a hard failure).\n'
+exit 0

--- a/bin/fm-tool-versions.sh
+++ b/bin/fm-tool-versions.sh
@@ -80,7 +80,7 @@ SKIP_NIX=0
 INCLUDE_PRERELEASE=0
 
 usage() {
-  sed -n '2,70p' "$0" | sed 's/^# \?//'
+  sed -n '2,64p' "$0" | sed 's/^# \?//'
 }
 
 while [ "$#" -gt 0 ]; do

--- a/bin/fm-tool-versions.sh
+++ b/bin/fm-tool-versions.sh
@@ -168,14 +168,20 @@ resolve_dotfiles() {
 
 # Strip common noise into a bare version-ish token (digits/dots, optional pre).
 normalize_version() {
-  local raw=$1
+  local raw=$1 normalized
   raw=$(printf '%s' "$raw" | tr -d '\r')
   # Prefer the first semver-looking token in the string.
-  if printf '%s' "$raw" | grep -Eo '[0-9]+(\.[0-9]+)+([.-][A-Za-z0-9.]+)?' >/dev/null 2>&1; then
-    printf '%s' "$raw" | grep -Eo '[0-9]+(\.[0-9]+)+([.-][A-Za-z0-9.]+)?' | head -1
+  if normalized=$(printf '%s' "$raw" | grep -Eo '[0-9]+(\.[0-9]+)+([.-][A-Za-z0-9]+([.-][A-Za-z0-9]+)*)?' | head -1) \
+    && [ -n "$normalized" ]; then
+    printf '%s\n' "$normalized"
     return 0
   fi
-  printf '%s' "$raw" | sed -E 's/^[^0-9]*//; s/[[:space:]].*$//; s/^v//; s/^rust-v//'
+  normalized=$(printf '%s' "$raw" | sed -E 's/^[^0-9]*//; s/[[:space:]].*$//; s/^v//; s/^rust-v//')
+  if printf '%s' "$normalized" | grep -Eq '^[0-9]+(\.[0-9]+)+([.-][A-Za-z0-9]+([.-][A-Za-z0-9]+)*)?$'; then
+    printf '%s\n' "$normalized"
+    return 0
+  fi
+  return 1
 }
 
 # Compare two version tokens. Echo -1 / 0 / 1 (a<b / equal / a>b).
@@ -321,7 +327,7 @@ nixpkgs_locked_rev() {
   [ -f "$lock" ] || return 1
   # Prefer python for robust JSON; fall back to sed/grep for minimal envs.
   if command -v python3 >/dev/null 2>&1; then
-    python3 -c '
+    if python3 -c '
 import json, sys
 lock = json.load(open(sys.argv[1]))
 node = lock.get("nodes", {}).get("nixpkgs", {})
@@ -329,11 +335,16 @@ rev = node.get("locked", {}).get("rev")
 if not rev:
     sys.exit(1)
 print(rev)
-' "$lock"
-    return 0
+' "$lock"; then
+      return 0
+    fi
+    return 1
   fi
   # Fallback: crude extraction of the nixpkgs locked rev near its node.
-  grep -A20 '"nixpkgs"' "$lock" | grep -m1 '"rev"' | sed -E 's/.*"rev": *"([^"]+)".*/\1/'
+  local rev
+  rev=$(grep -A20 '"nixpkgs"' "$lock" | grep -m1 '"rev"' | sed -E 's/.*"rev": *"([^"]+)".*/\1/') || return 1
+  [ -n "$rev" ] || return 1
+  printf '%s\n' "$rev"
 }
 
 locked_pkg_version() {
@@ -406,6 +417,7 @@ BEHIND=0
 ERRORS=0
 DOTFILES=""
 NIXPKGS_REV=""
+NIXPKGS_LOCK_FAILED=0
 
 if [ "$INSTALLED_ONLY" -eq 0 ]; then
   if DOTFILES=$(resolve_dotfiles); then
@@ -416,7 +428,9 @@ if [ "$INSTALLED_ONLY" -eq 0 ]; then
 fi
 
 if [ -n "$DOTFILES" ] && [ "$SKIP_NIX" -eq 0 ]; then
-  NIXPKGS_REV=$(nixpkgs_locked_rev "$DOTFILES" 2>/dev/null || true)
+  if ! NIXPKGS_REV=$(nixpkgs_locked_rev "$DOTFILES" 2>/dev/null); then
+    NIXPKGS_LOCK_FAILED=1
+  fi
 fi
 
 printf 'Fleet tool versions (read-only; never mutates)\n'
@@ -474,8 +488,13 @@ for row in "${HARNESS_ROWS[@]}"; do
       locked='(error)'
       lock_failed=1
     fi
-  elif [ -n "$pkg" ] && [ "$SKIP_NIX" -eq 0 ] && [ -z "$NIXPKGS_REV" ]; then
-    locked='(no lock)'
+  elif [ -n "$pkg" ] && [ "$SKIP_NIX" -eq 0 ]; then
+    if [ "$NIXPKGS_LOCK_FAILED" -eq 1 ]; then
+      locked='(error)'
+      lock_failed=1
+    else
+      locked='(no lock)'
+    fi
   fi
 
   if [ "$NO_NETWORK" -eq 0 ]; then
@@ -494,17 +513,15 @@ for row in "${HARNESS_ROWS[@]}"; do
     upstream='(skipped)'
   fi
 
-  # Status prioritizes: missing install / unreachable tip -> error; else
-  # compare installed vs a real upstream tip; else soft unknown.
+  # Status prioritizes missing installs, probe failures, and unreadable locks.
   if [ "$install_missing" -eq 1 ]; then
     status=error
   elif [ "$tip_failed" -eq 1 ]; then
     status=error
+  elif [ "$lock_failed" -eq 1 ]; then
+    status=error
   elif [ "$upstream" != '(unknown)' ] && [ "$upstream" != '(skipped)' ] && [ "$upstream" != '-' ] && [ "$upstream" != '(unreachable)' ]; then
     status=$(classify_pair "$installed" "$upstream")
-  elif [ "$lock_failed" -eq 1 ]; then
-    # No tip to compare; a hard lock eval failure still surfaces as error.
-    status=error
   else
     status=unknown
   fi

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -15,6 +15,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-fleet-view.sh`       | Render the fleet snapshot as a human Markdown view                                   |
 | `fm-bearings-snapshot.sh` | Project the fleet snapshot to the compact TOON bearings view; local-only unless `--include-prs` |
 | `fm-update.sh`           | Fast-forward-only self-update of firstmate and secondmate homes from origin          |
+| `fm-tool-versions.sh`    | Read-only inventory of installed, locked nixpkgs, and agentic-pin tool versions against upstream tips for `/update-tools` |
 | `fm-backlog-handoff.sh`  | Validate and delegate queued backlog-item moves into a secondmate home               |
 | `fm-decision-hold.sh`    | Create, verify, complete, and resolve durable captain-held decisions                 |
 | `fm-brief.sh`            | Scaffold ship, scout, secondmate-charter, and Herdr-lab briefs                       |

--- a/tests/fm-lint.test.sh
+++ b/tests/fm-lint.test.sh
@@ -103,6 +103,106 @@ SH
   pass "fm-lint.sh refuses to lint under a non-pinned ShellCheck version"
 }
 
+test_reuses_cached_shellcheck_on_supported_version() {
+  local tmp fakebin cache out rc marker
+  tmp=$(fm_test_tmproot fm-lint-cache)
+  fakebin=$(fm_fakebin "$tmp")
+  cache="$tmp/cache/firstmate/bin"
+  marker="$tmp/curl"
+  mkdir -p "$cache"
+  cat > "$fakebin/uname" <<'SH'
+#!/usr/bin/env bash
+if [ "${1:-}" = "-s" ]; then
+  printf 'Darwin\n'
+else
+  printf 'arm64\n'
+fi
+SH
+  cat > "$fakebin/curl" <<'SH'
+#!/usr/bin/env bash
+: > "$CURL_MARKER"
+exit 1
+SH
+  cat > "$cache/shellcheck" <<'SH'
+#!/usr/bin/env bash
+if [ "${1:-}" = "--version" ]; then
+  printf 'ShellCheck - shell script analysis tool\nversion: 0.11.0\n'
+  exit 0
+fi
+exit 0
+SH
+  chmod +x "$fakebin/uname" "$fakebin/curl" "$cache/shellcheck"
+  rc=0
+  out=$(PATH="$fakebin:/bin" HOME="$tmp/home" XDG_CACHE_HOME="$tmp/cache" CURL_MARKER="$marker" \
+    "$LINT" "$LINT" 2>&1) || rc=$?
+  [ "$rc" -eq 0 ] || fail "fm-lint.sh did not reuse the pinned cache binary"$'\n'"$out"
+  [ ! -e "$marker" ] || fail "fm-lint.sh attempted a download for a valid cache binary"
+  pass "fm-lint.sh reuses a valid cached ShellCheck"
+}
+
+test_unsupported_platform_does_not_bootstrap() {
+  local tmp fakebin out rc marker
+  tmp=$(fm_test_tmproot fm-lint-platform)
+  fakebin=$(fm_fakebin "$tmp")
+  marker="$tmp/curl"
+  cat > "$fakebin/uname" <<'SH'
+#!/usr/bin/env bash
+if [ "${1:-}" = "-s" ]; then
+  printf 'Darwin\n'
+else
+  printf 'x86_64\n'
+fi
+SH
+  cat > "$fakebin/curl" <<'SH'
+#!/usr/bin/env bash
+: > "$CURL_MARKER"
+exit 1
+SH
+  chmod +x "$fakebin/uname" "$fakebin/curl"
+  rc=0
+  out=$(PATH="$fakebin:/bin" HOME="$tmp/home" XDG_CACHE_HOME="$tmp/cache" CURL_MARKER="$marker" \
+    "$LINT" "$LINT" 2>&1) || rc=$?
+  [ "$rc" -eq 127 ] || fail "fm-lint.sh did not reject unsupported bootstrap platform"$'\n'"$out"
+  assert_contains "$out" "automatic bootstrap supports Linux x86_64 only" \
+    "unsupported platform message"
+  [ ! -e "$marker" ] || fail "fm-lint.sh attempted a download on an unsupported platform"
+  [ ! -e "$tmp/cache/firstmate/bin/shellcheck" ] || \
+    fail "fm-lint.sh cached a ShellCheck binary on an unsupported platform"
+  pass "fm-lint.sh does not bootstrap ShellCheck off Linux x86_64"
+}
+
+test_cached_wrong_version_fails_clearly_off_platform() {
+  local tmp fakebin cache out rc
+  tmp=$(fm_test_tmproot fm-lint-cache-mismatch)
+  fakebin=$(fm_fakebin "$tmp")
+  cache="$tmp/cache/firstmate/bin"
+  mkdir -p "$cache"
+  cat > "$fakebin/uname" <<'SH'
+#!/usr/bin/env bash
+if [ "${1:-}" = "-s" ]; then
+  printf 'Darwin\n'
+else
+  printf 'x86_64\n'
+fi
+SH
+  cat > "$cache/shellcheck" <<'SH'
+#!/usr/bin/env bash
+if [ "${1:-}" = "--version" ]; then
+  printf 'ShellCheck - shell script analysis tool\nversion: 0.9.9\n'
+  exit 0
+fi
+exit 0
+SH
+  chmod +x "$fakebin/uname" "$cache/shellcheck"
+  rc=0
+  out=$(PATH="$fakebin:/bin" HOME="$tmp/home" XDG_CACHE_HOME="$tmp/cache" \
+    "$LINT" "$LINT" 2>&1) || rc=$?
+  [ "$rc" -eq 1 ] || fail "fm-lint.sh accepted an unpinned cached ShellCheck"$'\n'"$out"
+  assert_contains "$out" "cached ShellCheck 0.9.9 is not pinned" \
+    "cached mismatch message"
+  pass "fm-lint.sh reports an unpinned cached ShellCheck clearly"
+}
+
 test_catches_a_real_lint_defect() {
   if ! pinned_ready; then
     pass "SKIP (ShellCheck $REQUIRED not resolved): lint-defect regression check"
@@ -187,6 +287,9 @@ test_nomistakes_invokes_the_owner
 test_pins_an_explicit_version
 test_ci_installs_and_logs_the_pinned_version
 test_rejects_wrong_shellcheck_version
+test_reuses_cached_shellcheck_on_supported_version
+test_unsupported_platform_does_not_bootstrap
+test_cached_wrong_version_fails_clearly_off_platform
 test_catches_a_real_lint_defect
 test_ignores_ambient_shellcheck_opts
 test_clean_fixture_passes

--- a/tests/fm-tool-versions.test.sh
+++ b/tests/fm-tool-versions.test.sh
@@ -320,6 +320,105 @@ SH
   pass "matching installed and upstream exits 0"
 }
 
+test_unreadable_lock_is_error() {
+  local w fakebin npm gh nix map_gh map_nix out ec df
+  w="$TMP_ROOT/unreadable-lock"
+  mkdir -p "$w"
+  fakebin=$(fm_fakebin "$w")
+  setup_fake_harness "$fakebin" 2.1.216 0.144.6 0.2.93 1.18.4 0.80.10 1.40.1
+  df="$w/dotfiles"
+  make_dotfiles "$df"
+  printf '{broken\n' > "$df/flake.lock"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$df/scripts/agentic-tools-check-updates.sh"
+  chmod +x "$df/scripts/agentic-tools-check-updates.sh"
+  npm="$w/npm"; gh="$w/gh"; nix="$w/nix"
+  map_gh="$w/gh.map"; map_nix="$w/nix.map"
+  printf 'openai/codex=0.144.6\nanomalyco/opencode=1.18.4\nbadlogic/pi-mono=0.80.10\n' > "$map_gh"
+  printf '%s\n' \
+    'claude-code=2.1.216' \
+    'codex=0.144.6' \
+    'opencode=1.18.4' \
+    'pi-coding-agent=0.80.10' \
+    'grok-build=0.2.93' > "$map_nix"
+  write_npm_stub "$npm" 2.1.216
+  write_gh_stub "$gh" "$map_gh"
+  write_nix_stub "$nix" "$map_nix"
+  set +e
+  out=$(run_tool "$fakebin" "$npm" "$gh" "$nix" "$df" 2>&1)
+  ec=$?
+  set -e
+  expect_code 3 "$ec" "unreadable lock exits 3"
+  assert_contains "$out" "nixpkgs lock: (unreadable)" "unreadable lock marker"
+  assert_contains "$out" "claude       2.1.216        (error)" "unreadable lock row error"
+  assert_contains "$out" "Summary: behind=0 errors=5" "unreadable lock counts errors"
+  pass "unreadable nixpkgs lock is a hard inventory error"
+}
+
+test_locked_probe_error_is_error() {
+  local w fakebin npm gh nix map_gh map_nix out ec df
+  w="$TMP_ROOT/locked-probe-error"
+  mkdir -p "$w"
+  fakebin=$(fm_fakebin "$w")
+  setup_fake_harness "$fakebin" 2.1.216 0.144.6 0.2.93 1.18.4 0.80.10 1.40.1
+  df="$w/dotfiles"
+  make_dotfiles "$df"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$df/scripts/agentic-tools-check-updates.sh"
+  chmod +x "$df/scripts/agentic-tools-check-updates.sh"
+  npm="$w/npm"; gh="$w/gh"; nix="$w/nix"
+  map_gh="$w/gh.map"; map_nix="$w/nix.map"
+  printf 'openai/codex=0.144.6\nanomalyco/opencode=1.18.4\nbadlogic/pi-mono=0.80.10\n' > "$map_gh"
+  printf '%s\n' \
+    'claude-code=2.1.216' \
+    'codex=0.144.6' \
+    'opencode=1.18.4' \
+    'pi-coding-agent=0.80.10' \
+    'grok-build=0.2.93' > "$map_nix"
+  write_npm_stub "$npm" 2.1.216
+  write_gh_stub "$gh" "$map_gh"
+  write_nix_stub "$nix" "$map_nix" fail
+  set +e
+  out=$(run_tool "$fakebin" "$npm" "$gh" "$nix" "$df" 2>&1)
+  ec=$?
+  set -e
+  expect_code 3 "$ec" "locked probe failure exits 3"
+  assert_contains "$out" "claude       2.1.216        (error)" "locked probe row error"
+  assert_contains "$out" "Summary: behind=0 errors=5" "locked probe errors are counted"
+  pass "locked nixpkgs probe failures cannot appear current"
+}
+
+test_empty_upstream_parse_is_error() {
+  local w fakebin npm gh nix map_gh map_nix out ec df
+  w="$TMP_ROOT/empty-upstream"
+  mkdir -p "$w"
+  fakebin=$(fm_fakebin "$w")
+  setup_fake_harness "$fakebin" 2.1.216 0.144.6 0.2.93 1.18.4 0.80.10 1.40.1
+  df="$w/dotfiles"
+  make_dotfiles "$df"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$df/scripts/agentic-tools-check-updates.sh"
+  chmod +x "$df/scripts/agentic-tools-check-updates.sh"
+  npm="$w/npm"; gh="$w/gh"; nix="$w/nix"
+  map_gh="$w/gh.map"; map_nix="$w/nix.map"
+  printf 'openai/codex=0.144.6\nanomalyco/opencode=1.18.4\nbadlogic/pi-mono=0.80.10\n' > "$map_gh"
+  printf '%s\n' \
+    'claude-code=2.1.216' \
+    'codex=0.144.6' \
+    'opencode=1.18.4' \
+    'pi-coding-agent=0.80.10' \
+    'grok-build=0.2.93' > "$map_nix"
+  write_npm_stub "$npm" ""
+  write_gh_stub "$gh" "$map_gh"
+  write_nix_stub "$nix" "$map_nix"
+  set +e
+  out=$(run_tool "$fakebin" "$npm" "$gh" "$nix" "$df" 2>&1)
+  ec=$?
+  set -e
+  expect_code 3 "$ec" "empty upstream parse exits 3"
+  assert_contains "$out" "claude       2.1.216        2.1.216        (unreachable)" \
+    "empty upstream parse is not accepted"
+  assert_contains "$out" "Summary: behind=0 errors=1" "empty upstream parse counts an error"
+  pass "empty upstream versions are hard parse errors"
+}
+
 test_upstream_error_exit_3() {
   local w fakebin npm gh nix map_gh map_nix out ec df
   w="$TMP_ROOT/offline"
@@ -510,6 +609,9 @@ test_help_and_usage
 test_installed_only_exit_0_soft_unknown
 test_behind_exit_1
 test_current_exit_0
+test_unreadable_lock_is_error
+test_locked_probe_error_is_error
+test_empty_upstream_parse_is_error
 test_upstream_error_exit_3
 test_agentic_behind_counts
 test_agentic_error_takes_precedence

--- a/tests/fm-tool-versions.test.sh
+++ b/tests/fm-tool-versions.test.sh
@@ -1,0 +1,520 @@
+#!/usr/bin/env bash
+# Tests for bin/fm-tool-versions.sh: read-only fleet tool inventory, version
+# classification, and exit codes with network/nix/agentic probes mocked via PATH
+# and FM_TOOL_VERSIONS_* overrides.
+#
+# Guarantees under test:
+#   - --help exits 0; unknown options exit 2
+#   - never mutates the system (no writes under a fixture root)
+#   - installed-only mode reports installed versions without network
+#   - classification: current / behind / ahead / unknown / error
+#   - exit 0 when all current or soft-unknown
+#   - exit 1 when any harness row is behind
+#   - exit 3 when a required upstream probe fails (partial offline)
+#   - agentic section invokes the dotfiles check script when present
+#   - locked nixpkgs versions come from flake.lock rev + nix eval (mocked)
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TOOL="$ROOT/bin/fm-tool-versions.sh"
+TMP_ROOT=$(fm_test_tmproot fm-tool-versions)
+
+assert_present "$TOOL" "bin/fm-tool-versions.sh is missing"
+[ -x "$TOOL" ] || fail "bin/fm-tool-versions.sh must be executable"
+
+# --- fixtures ---------------------------------------------------------------
+
+# Write a minimal fake harness CLI that prints a fixed --version line.
+fake_tool_version() {
+  local fakebin=$1 name=$2 version_line=$3
+  cat > "$fakebin/$name" <<SH
+#!/usr/bin/env bash
+if [ "\${1:-}" = "--version" ] || [ "\${1:-}" = "-V" ]; then
+  printf '%s\n' '$version_line'
+  exit 0
+fi
+printf 'fake %s: unexpected args\n' '$name' >&2
+exit 1
+SH
+  chmod +x "$fakebin/$name"
+}
+
+# npm stub: only supports "view @anthropic-ai/claude-code version"
+write_npm_stub() {
+  local path=$1 claude_ver=$2 mode=${3:-ok}
+  cat > "$path" <<SH
+#!/usr/bin/env bash
+if [ "\$1" = "view" ] && [ "\$2" = "@anthropic-ai/claude-code" ] && [ "\$3" = "version" ]; then
+  if [ "$mode" = fail ]; then
+    exit 1
+  fi
+  printf '%s\n' '$claude_ver'
+  exit 0
+fi
+printf 'npm stub: unexpected: %s\n' "\$*" >&2
+exit 1
+SH
+  chmod +x "$path"
+}
+
+# gh stub: supports api repos/<owner>/<repo>/releases --jq ...
+# VERSION map is encoded as lines owner/repo=version in a companion file.
+write_gh_stub() {
+  local path=$1 mapfile=$2 mode=${3:-ok}
+  cat > "$path" <<SH
+#!/usr/bin/env bash
+if [ "\$1" != "api" ]; then
+  printf 'gh stub: only api supported\n' >&2
+  exit 1
+fi
+repo=\$2
+# strip leading path noise; expect repos/owner/repo/releases
+repo=\${repo#repos/}
+repo=\${repo%/releases}
+if [ "$mode" = fail ]; then
+  exit 1
+fi
+ver=\$(grep -F "\$repo=" "$mapfile" | head -1 | cut -d= -f2-)
+if [ -z "\$ver" ]; then
+  # empty release list -> empty jq result
+  exit 0
+fi
+# Emit a tag that normalize_version can parse (codex uses rust-v prefix upstream).
+case "\$repo" in
+  openai/codex) printf 'rust-v%s\n' "\$ver" ;;
+  *) printf 'v%s\n' "\$ver" ;;
+esac
+exit 0
+SH
+  chmod +x "$path"
+}
+
+# nix stub: github:NixOS/nixpkgs/<rev>#<pkg>.version
+write_nix_stub() {
+  local path=$1 mapfile=$2 mode=${3:-ok}
+  cat > "$path" <<SH
+#!/usr/bin/env bash
+if [ "$mode" = fail ]; then
+  exit 1
+fi
+# Find the github:NixOS/nixpkgs/...#pkg.version arg
+arg=""
+for a in "\$@"; do
+  case "\$a" in
+    github:NixOS/nixpkgs/*#*.version) arg=\$a ;;
+  esac
+done
+if [ -z "\$arg" ]; then
+  printf 'nix stub: no eval target\n' >&2
+  exit 1
+fi
+pkg=\${arg##*#}
+pkg=\${pkg%.version}
+ver=\$(grep -F "\$pkg=" "$mapfile" | head -1 | cut -d= -f2-)
+if [ -z "\$ver" ]; then
+  exit 1
+fi
+printf '%s\n' "\$ver"
+exit 0
+SH
+  chmod +x "$path"
+}
+
+# Minimal dotfiles fixture with flake.lock nixpkgs rev and optional agentic check.
+make_dotfiles() {
+  local dir=$1 rev=${2:-abc123def456}
+  mkdir -p "$dir/scripts"
+  cat > "$dir/flake.nix" <<'NIX'
+{
+  description = "fixture";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  outputs = { ... }: { };
+}
+NIX
+  cat > "$dir/flake.lock" <<LOCK
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1,
+        "narHash": "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "$rev",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}
+LOCK
+}
+
+# Common PATH of fake harness binaries at fixed "installed" versions.
+setup_fake_harness() {
+  local fakebin=$1
+  # Optional overrides: claude_ver codex_ver ...
+  local claude_ver=${2:-2.1.214}
+  local codex_ver=${3:-0.144.4}
+  local grok_ver=${4:-0.2.93}
+  local opencode_ver=${5:-1.18.3}
+  local pi_ver=${6:-0.80.10}
+  local nm_ver=${7:-1.40.1}
+  fake_tool_version "$fakebin" claude "$claude_ver (Claude Code)"
+  fake_tool_version "$fakebin" codex "codex-cli $codex_ver"
+  fake_tool_version "$fakebin" grok "grok $grok_ver (deadbeef) [stable]"
+  fake_tool_version "$fakebin" opencode "$opencode_ver"
+  fake_tool_version "$fakebin" pi "$pi_ver"
+  fake_tool_version "$fakebin" no-mistakes "no-mistakes version $nm_ver (abc) 2026-01-01T00:00:00Z"
+}
+
+run_tool() {
+  # Usage: run_tool <fakebin> <npm> <gh> <nix> <dotfiles> -- script args...
+  local fakebin=$1 npm=$2 gh=$3 nix=$4 dotfiles=$5
+  shift 5
+  env -u FM_DOTFILES \
+    PATH="$fakebin:$PATH" \
+    FM_HOME="$TMP_ROOT/home-empty" \
+    FM_TOOL_VERSIONS_NPM="$npm" \
+    FM_TOOL_VERSIONS_GH="$gh" \
+    FM_TOOL_VERSIONS_NIX="$nix" \
+    "$TOOL" --dotfiles "$dotfiles" "$@"
+}
+
+# --- tests ------------------------------------------------------------------
+
+test_help_and_usage() {
+  local out ec
+  out=$("$TOOL" --help 2>&1) || true
+  assert_contains "$out" "Read-only inventory" "help should print ownership header"
+  assert_contains "$out" "Exit codes" "help should document exit codes"
+  set +e
+  out=$("$TOOL" --not-a-flag 2>&1)
+  ec=$?
+  set -e
+  expect_code 2 "$ec" "unknown option"
+  set +e
+  out=$("$TOOL" --json 2>&1)
+  ec=$?
+  set -e
+  expect_code 2 "$ec" "unimplemented --json"
+  pass "help exits 0; bad usage exits 2"
+}
+
+test_installed_only_exit_0_soft_unknown() {
+  local w fakebin out ec
+  w="$TMP_ROOT/installed-only"
+  mkdir -p "$w"
+  fakebin=$(fm_fakebin "$w")
+  setup_fake_harness "$fakebin"
+  set +e
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$w/nohome" "$TOOL" --installed-only 2>&1)
+  ec=$?
+  set -e
+  expect_code 0 "$ec" "installed-only with soft unknown tips"
+  assert_contains "$out" "claude" "lists claude"
+  assert_contains "$out" "2.1.214" "prints installed claude version"
+  assert_contains "$out" "0.144.4" "prints installed codex version"
+  assert_contains "$out" "(skipped)" "upstream skipped without network"
+  assert_contains "$out" "unknown" "status soft-unknown without tip"
+  pass "installed-only reports versions and exits 0"
+}
+
+test_behind_exit_1() {
+  local w fakebin npm gh nix map_gh map_nix out ec df
+  w="$TMP_ROOT/behind"
+  mkdir -p "$w"
+  fakebin=$(fm_fakebin "$w")
+  setup_fake_harness "$fakebin" 2.1.214 0.144.4 0.2.93 1.18.3 0.80.10 1.40.1
+  df="$w/dotfiles"
+  make_dotfiles "$df" deadbeef01
+  # agentic check: all current so harness behind drives exit 1 alone
+  cat > "$df/scripts/agentic-tools-check-updates.sh" <<'SH'
+#!/usr/bin/env bash
+printf 'All checked agentic pins are current.\n'
+exit 0
+SH
+  chmod +x "$df/scripts/agentic-tools-check-updates.sh"
+
+  npm="$w/npm"
+  gh="$w/gh"
+  nix="$w/nix"
+  map_gh="$w/gh.map"
+  map_nix="$w/nix.map"
+  # Upstream newer than installed for claude/codex/opencode
+  printf 'openai/codex=0.144.6\nanomalyco/opencode=1.18.4\nbadlogic/pi-mono=0.80.10\n' > "$map_gh"
+  printf '%s\n' \
+    'claude-code=2.1.214' \
+    'codex=0.144.4' \
+    'opencode=1.18.3' \
+    'pi-coding-agent=0.80.10' \
+    'grok-build=0.2.93' > "$map_nix"
+  write_npm_stub "$npm" 2.1.216
+  write_gh_stub "$gh" "$map_gh"
+  write_nix_stub "$nix" "$map_nix"
+
+  set +e
+  out=$(run_tool "$fakebin" "$npm" "$gh" "$nix" "$df" 2>&1)
+  ec=$?
+  set -e
+  expect_code 1 "$ec" "behind tools must exit 1"
+  assert_contains "$out" "behind" "status behind present"
+  assert_contains "$out" "2.1.216" "upstream claude tip"
+  assert_contains "$out" "0.144.6" "upstream codex tip"
+  assert_contains "$out" "1.18.4" "upstream opencode tip"
+  # Ensure we did not claim all current
+  assert_not_contains "$out" "All compared tools are current" "must not claim all current when behind"
+  pass "behind harness rows exit 1 and show tips"
+}
+
+test_current_exit_0() {
+  local w fakebin npm gh nix map_gh map_nix out ec df
+  w="$TMP_ROOT/current"
+  mkdir -p "$w"
+  fakebin=$(fm_fakebin "$w")
+  setup_fake_harness "$fakebin" 2.1.216 0.144.6 0.2.93 1.18.4 0.80.10 1.40.1
+  df="$w/dotfiles"
+  make_dotfiles "$df"
+  cat > "$df/scripts/agentic-tools-check-updates.sh" <<'SH'
+#!/usr/bin/env bash
+printf 'All checked agentic pins are current.\n'
+exit 0
+SH
+  chmod +x "$df/scripts/agentic-tools-check-updates.sh"
+  npm="$w/npm"; gh="$w/gh"; nix="$w/nix"
+  map_gh="$w/gh.map"; map_nix="$w/nix.map"
+  printf 'openai/codex=0.144.6\nanomalyco/opencode=1.18.4\nbadlogic/pi-mono=0.80.10\n' > "$map_gh"
+  printf '%s\n' \
+    'claude-code=2.1.216' \
+    'codex=0.144.6' \
+    'opencode=1.18.4' \
+    'pi-coding-agent=0.80.10' \
+    'grok-build=0.2.93' > "$map_nix"
+  write_npm_stub "$npm" 2.1.216
+  write_gh_stub "$gh" "$map_gh"
+  write_nix_stub "$nix" "$map_nix"
+  set +e
+  out=$(run_tool "$fakebin" "$npm" "$gh" "$nix" "$df" 2>&1)
+  ec=$?
+  set -e
+  expect_code 0 "$ec" "all current exits 0"
+  assert_contains "$out" "current" "status current present"
+  assert_not_contains "$out" $'\tbehind' "no tab-behind"
+  # STATUS column word behind should not appear as a status when all current;
+  # summary may still say behind=0
+  assert_contains "$out" "behind=0" "summary behind=0"
+  pass "matching installed and upstream exits 0"
+}
+
+test_upstream_error_exit_3() {
+  local w fakebin npm gh nix map_gh map_nix out ec df
+  w="$TMP_ROOT/offline"
+  mkdir -p "$w"
+  fakebin=$(fm_fakebin "$w")
+  setup_fake_harness "$fakebin"
+  df="$w/dotfiles"
+  make_dotfiles "$df"
+  cat > "$df/scripts/agentic-tools-check-updates.sh" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  chmod +x "$df/scripts/agentic-tools-check-updates.sh"
+  npm="$w/npm"; gh="$w/gh"; nix="$w/nix"
+  map_gh="$w/gh.map"; map_nix="$w/nix.map"
+  printf 'openai/codex=0.144.6\n' > "$map_gh"
+  printf '%s\n' \
+    'claude-code=2.1.214' \
+    'codex=0.144.4' \
+    'opencode=1.18.3' \
+    'pi-coding-agent=0.80.10' \
+    'grok-build=0.2.93' > "$map_nix"
+  write_npm_stub "$npm" 2.1.216 fail
+  write_gh_stub "$gh" "$map_gh" fail
+  write_nix_stub "$nix" "$map_nix"
+  set +e
+  out=$(run_tool "$fakebin" "$npm" "$gh" "$nix" "$df" 2>&1)
+  ec=$?
+  set -e
+  expect_code 3 "$ec" "unreachable upstream probes exit 3"
+  assert_contains "$out" "error" "error status for failed probes"
+  assert_contains "$out" "(unreachable)" "unreachable marker"
+  pass "partial offline upstream probes exit 3"
+}
+
+test_agentic_behind_counts() {
+  local w fakebin npm gh nix map_gh map_nix out ec df
+  w="$TMP_ROOT/agentic-behind"
+  mkdir -p "$w"
+  fakebin=$(fm_fakebin "$w")
+  # Installed matches upstream so only agentic drives exit 1
+  setup_fake_harness "$fakebin" 2.1.216 0.144.6 0.2.93 1.18.4 0.80.10 1.40.1
+  df="$w/dotfiles"
+  make_dotfiles "$df"
+  cat > "$df/scripts/agentic-tools-check-updates.sh" <<'SH'
+#!/usr/bin/env bash
+printf 'no-mistakes  v1.40.1  v1.40.2  update-available\n'
+printf '1 tool(s) behind upstream.\n'
+exit 1
+SH
+  chmod +x "$df/scripts/agentic-tools-check-updates.sh"
+  npm="$w/npm"; gh="$w/gh"; nix="$w/nix"
+  map_gh="$w/gh.map"; map_nix="$w/nix.map"
+  printf 'openai/codex=0.144.6\nanomalyco/opencode=1.18.4\nbadlogic/pi-mono=0.80.10\n' > "$map_gh"
+  printf '%s\n' \
+    'claude-code=2.1.216' \
+    'codex=0.144.6' \
+    'opencode=1.18.4' \
+    'pi-coding-agent=0.80.10' \
+    'grok-build=0.2.93' > "$map_nix"
+  write_npm_stub "$npm" 2.1.216
+  write_gh_stub "$gh" "$map_gh"
+  write_nix_stub "$nix" "$map_nix"
+  set +e
+  out=$(run_tool "$fakebin" "$npm" "$gh" "$nix" "$df" 2>&1)
+  ec=$?
+  set -e
+  expect_code 1 "$ec" "agentic behind exits 1"
+  assert_contains "$out" "Agentic pins" "agentic section header"
+  assert_contains "$out" "update-available" "relays agentic output"
+  pass "agentic check behind folds into exit 1"
+}
+
+test_agentic_error_takes_precedence() {
+  local w fakebin npm gh nix map_gh map_nix out ec df
+  w="$TMP_ROOT/agentic-err"
+  mkdir -p "$w"
+  fakebin=$(fm_fakebin "$w")
+  setup_fake_harness "$fakebin" 2.1.214 0.144.4 0.2.93 1.18.3 0.80.10 1.40.1
+  df="$w/dotfiles"
+  make_dotfiles "$df"
+  cat > "$df/scripts/agentic-tools-check-updates.sh" <<'SH'
+#!/usr/bin/env bash
+printf 'firstmate  (unreachable)  error\n'
+exit 3
+SH
+  chmod +x "$df/scripts/agentic-tools-check-updates.sh"
+  npm="$w/npm"; gh="$w/gh"; nix="$w/nix"
+  map_gh="$w/gh.map"; map_nix="$w/nix.map"
+  # Also behind so we can prove 3 wins over 1
+  printf 'openai/codex=0.144.6\nanomalyco/opencode=1.18.4\nbadlogic/pi-mono=0.80.10\n' > "$map_gh"
+  printf '%s\n' \
+    'claude-code=2.1.214' \
+    'codex=0.144.4' \
+    'opencode=1.18.3' \
+    'pi-coding-agent=0.80.10' \
+    'grok-build=0.2.93' > "$map_nix"
+  write_npm_stub "$npm" 2.1.216
+  write_gh_stub "$gh" "$map_gh"
+  write_nix_stub "$nix" "$map_nix"
+  set +e
+  out=$(run_tool "$fakebin" "$npm" "$gh" "$nix" "$df" 2>&1)
+  ec=$?
+  set -e
+  expect_code 3 "$ec" "agentic error exit 3 beats harness behind"
+  pass "exit 3 takes precedence over behind"
+}
+
+test_ahead_status() {
+  local w fakebin npm gh nix map_gh map_nix out ec df
+  w="$TMP_ROOT/ahead"
+  mkdir -p "$w"
+  fakebin=$(fm_fakebin "$w")
+  setup_fake_harness "$fakebin" 2.1.300 0.144.6 0.2.93 1.18.4 0.80.10 1.40.1
+  df="$w/dotfiles"
+  make_dotfiles "$df"
+  cat > "$df/scripts/agentic-tools-check-updates.sh" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  chmod +x "$df/scripts/agentic-tools-check-updates.sh"
+  npm="$w/npm"; gh="$w/gh"; nix="$w/nix"
+  map_gh="$w/gh.map"; map_nix="$w/nix.map"
+  printf 'openai/codex=0.144.6\nanomalyco/opencode=1.18.4\nbadlogic/pi-mono=0.80.10\n' > "$map_gh"
+  printf '%s\n' \
+    'claude-code=2.1.216' \
+    'codex=0.144.6' \
+    'opencode=1.18.4' \
+    'pi-coding-agent=0.80.10' \
+    'grok-build=0.2.93' > "$map_nix"
+  write_npm_stub "$npm" 2.1.216
+  write_gh_stub "$gh" "$map_gh"
+  write_nix_stub "$nix" "$map_nix"
+  set +e
+  out=$(run_tool "$fakebin" "$npm" "$gh" "$nix" "$df" 2>&1)
+  ec=$?
+  set -e
+  expect_code 0 "$ec" "ahead is not behind"
+  assert_contains "$out" "ahead" "status ahead for newer installed claude"
+  pass "installed newer than tip classifies ahead"
+}
+
+test_no_mutation() {
+  local w fakebin df stamp
+  w="$TMP_ROOT/nomut"
+  mkdir -p "$w"
+  fakebin=$(fm_fakebin "$w")
+  setup_fake_harness "$fakebin"
+  df="$w/dotfiles"
+  make_dotfiles "$df"
+  cat > "$df/scripts/agentic-tools-check-updates.sh" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  chmod +x "$df/scripts/agentic-tools-check-updates.sh"
+  stamp=$(find "$df" -type f -print0 | sort -z | xargs -0 sha256sum)
+  PATH="$fakebin:$PATH" FM_HOME="$w" \
+    FM_TOOL_VERSIONS_NPM=/bin/false \
+    FM_TOOL_VERSIONS_GH=/bin/false \
+    FM_TOOL_VERSIONS_NIX=/bin/false \
+    "$TOOL" --dotfiles "$df" --no-network --skip-nix >/dev/null 2>&1 || true
+  [ "$(find "$df" -type f -print0 | sort -z | xargs -0 sha256sum)" = "$stamp" ] \
+    || fail "dotfiles fixture files mutated"
+  pass "read-only: fixture files unchanged"
+}
+
+test_skill_and_agents_trigger() {
+  local skill="$ROOT/.agents/skills/update-tools/SKILL.md"
+  assert_present "$skill" "update-tools skill missing"
+  assert_grep "name: update-tools" "$skill" "skill name"
+  assert_grep "user-invocable: true" "$skill" "skill must be captain-invocable"
+  assert_grep "  internal: true" "$skill" "skill must be internal"
+  assert_grep "/update-tools" "$skill" "slash form"
+  assert_grep "bin/fm-tool-versions.sh" "$skill" "inventory script pointer"
+  assert_grep "updatefirstmate" "$skill" "cross-link firstmate updater"
+  assert_grep "agentic-tools-bump" "$skill" "agentic bump pointer"
+  assert_grep "nixpkgs" "$skill" "nixpkgs harness ownership"
+  assert_grep "When the captain invokes \`/update-tools\`" "$ROOT/AGENTS.md" \
+    "AGENTS.md must load update-tools on captain language"
+  assert_grep '/update-tools' "$ROOT/README.md" "README skills table lists update-tools"
+  assert_grep 'nixpkgs-owned' "$ROOT/CONTRIBUTING.md" "CONTRIBUTING notes harness ownership"
+  pass "skill metadata, AGENTS trigger, README, CONTRIBUTING wired"
+}
+
+# --- run --------------------------------------------------------------------
+
+test_help_and_usage
+test_installed_only_exit_0_soft_unknown
+test_behind_exit_1
+test_current_exit_0
+test_upstream_error_exit_3
+test_agentic_behind_counts
+test_agentic_error_takes_precedence
+test_ahead_status
+test_no_mutation
+test_skill_and_agents_trigger
+
+printf 'All fm-tool-versions tests passed.\n'


### PR DESCRIPTION
## Intent

Add a captain-invocable firstmate skill (`/update-tools`) for fleet tooling awareness and updates: live firstmate home via existing `/updatefirstmate`, Nix agentic tools via dotfiles `agentic-tools-check-updates.sh` / `agentic-tools-bump.sh`, and harness CLIs (claude-code, codex, grok-build, opencode, pi-coding-agent) from the nixpkgs pin (not agentic-tools-bump). Deliver read-only `bin/fm-tool-versions.sh` inventory, skill procedure, AGENTS/README/CONTRIBUTING wiring, and tests.

## What Changed

- Add `bin/fm-tool-versions.sh`: installed versions, locked nixpkgs harness package versions, agentic pin check via the existing dotfiles script, fail-soft upstream tips, classification and exit codes; never mutates.
- Add `.agents/skills/update-tools/SKILL.md` (captain-invocable `/update-tools`) with check → firstmate home → dotfiles ship → activate procedure; cross-links `/updatefirstmate`.
- Wire AGENTS.md §12 load trigger, README skills table, CONTRIBUTING note that harnesses are nixpkgs-owned and agentic pins are separate.
- Harden inventory error handling (lock parse, locked probe, empty version parse) and `fm-lint.sh` ShellCheck bootstrap (nix profile PATH, cache reuse, linux x86_64 only auto-install).
- Document `fm-tool-versions.sh` in `docs/scripts.md`; prefix bare-PATH gate `commands.test` with nix-profile bins for tmux.

## Risk Assessment

Low: additive skill and read-only inventory; lint bootstrap is bounded to known paths and a pinned installer; no project-write or merge authority changes.

## Testing

- `tests/fm-tool-versions.test.sh` (mocked network/nix/gh/npm): exit codes, classification, no-mutation, skill wiring.
- Extended coverage for lock/probe/empty-version error classification and fm-lint cache bootstrap.
- Local full-suite remains gated on tmux; CI Linux job runs the configured suite.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ Hardened lock parsing, version validation, and portable ShellCheck caching (auto-fixed earlier findings).

</details>

<details>
<summary>⚠️ **Test** - skipped in bare-PATH gate</summary>

Local gate PATH is bare (`/usr/bin:/bin`) so `tmux` is missing despite the feature-branch `commands.test` PATH prefix (trusted default-branch command). Feature branch includes nix-profile PATH prefix for when that config lands on main. CI runs the full suite with tmux available.

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ Pushed to fork `socalkol1/firstmate` branch `fm/fleet-update-tools-skill-w2`.

</details>