### PR TITLE
feat(bin): add remote host registry and guarded SSH worktree helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ config/backend
 config/x-mode.env
 config/cmux-socket-password
 config/wedge-alarm
+config/remote-hosts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,7 @@ config/backend  runtime session-provider backend override for new tasks; LOCAL, 
 config/herdr-presentation-spaces  optional presence flag for Herdr's default-off disposable single-task visual projection; LOCAL, gitignored; not inherited into secondmate homes; see docs/herdr-backend.md "Optional disposable single-task presentation spaces"
 config/cmux-socket-password  optional cmux control-socket password; LOCAL, gitignored; read fresh on every cmux CLI call and passed through without ever overriding an operator's own ambient CMUX_SOCKET_PASSWORD when absent (docs/cmux-backend.md "Setup")
 config/wedge-alarm  optional away-mode wedge-alarm active-alert directives; LOCAL, gitignored; absent means auto (macOS Notification Center when available); see docs/wedge-alarm.md
+config/remote-hosts  optional registry of SSH hosts approved for remote-run task checkouts; LOCAL, gitignored; read only by bin/fm-remote-ssh.sh (docs/configuration.md "Remote host registry")
 config/x-mode.env    generated X-mode watcher cadence; LOCAL, gitignored; source before arming watcher when present
 data/                personal fleet records; LOCAL, gitignored as a whole
   backlog.md         task queue, dependencies, history

--- a/bin/fm-remote-ssh.sh
+++ b/bin/fm-remote-ssh.sh
@@ -1,0 +1,629 @@
+#!/usr/bin/env bash
+# fm-remote-ssh.sh - the single owner of remote-run shell mechanics for
+# phase-4 SSH-pane tasks: host-registry resolution, safe SSH quoting, a
+# bounded remote preflight, and git-worktree create/inspect/remove primitives
+# against a registered remote host's project checkout.
+#
+# Run with --help for the command reference, the config/remote-hosts registry
+# schema, the wire protocol, and the exit codes; that output is the exact
+# contract and is not restated elsewhere.
+#
+# Safety rules (fixed, not configurable):
+#   - Structured arguments only. Every caller-supplied value is validated
+#     against a strict allowlist charset BEFORE any ssh process is spawned,
+#     and is embedded into the remote script exclusively via printf %q, so no
+#     free text ever becomes a shell fragment.
+#   - Remote task paths are never accepted from the caller. Each primitive
+#     recomputes the one permitted worktree path from the registered task
+#     root, the remote project's basename, and the validated task id.
+#   - Never `rm -rf`. A task path is only ever removed through
+#     `git worktree remove` WITHOUT --force, after re-proving that the path
+#     is the exact registered worktree, physically below the registered task
+#     root, distinct from the project checkout, and clean.
+#   - The remote branch fm/<task-id> is deliberately NOT deleted here:
+#     branch deletion requires the handoff-reachability proof owned by the
+#     later remote-aware teardown path.
+#   - Unknown remote responses are refusals. Anything that is not exactly one
+#     well-formed fm-remote-v1 protocol line with the expected verb and an
+#     allowlisted field set refuses; absence of evidence never passes.
+#   - Remote stdout is read through a fixed byte bound; an over-long response
+#     is truncated and therefore refused as unparseable.
+#
+# No fm-spawn/fm-watch/fm-teardown path routes here yet; this is the
+# foundations layer of the phase-4 remote-run series
+# (data/phase4-sshpane-design-s1/report.md, PR 1).
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
+REGISTRY="$CONFIG/remote-hosts"
+
+# shellcheck source=bin/fm-pr-lib.sh
+. "$SCRIPT_DIR/fm-pr-lib.sh"
+
+MAX_REMOTE_OUTPUT=65536
+
+usage() {
+  cat <<'EOF'
+Usage: fm-remote-ssh.sh <command> [args]
+
+Commands (structured arguments only; free-form values are refused):
+  resolve <host-id>
+      Validate the whole registry and print the host's entry as key=value
+      lines: host=, alias=, class=, login_shell=, task_root=, handoff=.
+  preflight <host-id> <remote-project>
+      Bounded remote preflight. Verifies the remote user is non-root, git is
+      installed, <remote-project> is the top level of a git repository, and
+      the registered task root is a directory or absent. Prints host=,
+      class=, uid=, project= (remote-resolved physical path), taskroot=.
+  worktree-create <host-id> <remote-project> <task-id> <base-ref>
+      Create the task worktree <task-root>/worktrees/<basename-of-project>/
+      <task-id> on branch fm/<task-id> at <base-ref>, then re-read and verify
+      registration, top level, containment, branch, and head before
+      reporting. Prints path=, branch=, head=, base_oid=.
+  worktree-inspect <host-id> <remote-project> <task-id>
+      Report structural facts about the task worktree. Prints state=absent,
+      or state=worktree with path=, branch=, head=, clean= (a boolean only,
+      never filenames). A path that exists but is not the exact registered,
+      contained task worktree on branch fm/<task-id> is a refusal.
+  worktree-remove <host-id> <remote-project> <task-id>
+      Remove the task worktree via `git worktree remove` (never --force,
+      never rm -rf) after re-proving registration, containment, branch
+      identity, and cleanliness. Refuses dirty, unregistered, out-of-root,
+      or absent paths. The fm/<task-id> branch is left in place. Prints
+      path=, branch=.
+  --help
+      Print this reference.
+
+Registry (config/remote-hosts; local, gitignored; this block is the schema):
+  One host per non-empty, non-comment line, whitespace-separated:
+    <host-id> alias=<ssh-alias> class=<client|non-client> \
+      login-shell=<yes|no> task-root=<absolute-path> \
+      handoff=<git-remote>[,<git-remote>...]
+  host-id      [a-z0-9-], no leading dash, max 64 chars, unique per file.
+  alias        the ssh_config alias to connect through; [A-Za-z0-9._-], no
+               leading dash. Connection settings (keys, host names, ports)
+               belong in ssh_config, never here.
+  class        client or non-client; recorded and reported so callers can
+               gate policy, never interpreted by this helper.
+  login-shell  yes runs remote commands via `bash -lc`, no via `bash -c`.
+  task-root    the ONLY remote directory tree task worktrees may live under;
+               absolute, [A-Za-z0-9._/-], no dot components, no trailing or
+               doubled slash.
+  handoff      comma-separated git remote names approved for handoff pushes;
+               schema-only in this PR, consumed by later delivery wiring.
+  All five fields are required exactly once; unknown keys, duplicates, and
+  malformed lines anywhere in the file refuse the whole registry.
+
+Wire protocol (remote -> local): every remote script emits exactly one line
+  fm-remote-v1 <verb> <key>=<value>...     on success, or
+  fm-remote-v1 refuse reason=<code>        on a remote-side refusal.
+Values are limited to [A-Za-z0-9._/-]; anything else, a missing line, a
+duplicate line, an unexpected verb, or an unknown field is a local refusal.
+
+Environment:
+  FM_REMOTE_SSH_CONNECT_TIMEOUT  ssh ConnectTimeout seconds (default 10).
+  FM_CONFIG_OVERRIDE             alternate config directory (testing).
+
+Exit codes: 0 success; 1 registry, transport, protocol, or remote refusal;
+2 usage or invalid argument.
+EOF
+}
+
+err() { printf 'fm-remote-ssh.sh: error: %s\n' "$1" >&2; }
+refuse() { err "$1"; exit 1; }
+usage_error() { err "$1"; echo "run: fm-remote-ssh.sh --help" >&2; exit 2; }
+
+# --- local argument validation (all fail closed, LC_ALL=C charsets) ---------
+
+valid_host_id() {
+  local id=${1-}
+  local LC_ALL=C
+  [ "${#id}" -le 64 ] || return 1
+  case "$id" in ''|-*|*[!a-z0-9-]*) return 1 ;; esac
+}
+
+valid_alias() {
+  local a=${1-}
+  local LC_ALL=C
+  [ "${#a}" -le 128 ] || return 1
+  case "$a" in ''|-*|*[!A-Za-z0-9._-]*) return 1 ;; esac
+}
+
+valid_remote_name() {
+  local r=${1-}
+  local LC_ALL=C
+  [ "${#r}" -le 128 ] || return 1
+  case "$r" in ''|-*|*[!A-Za-z0-9._-]*) return 1 ;; esac
+}
+
+valid_abs_path() {
+  local p=${1-}
+  local LC_ALL=C
+  [ "${#p}" -le 512 ] || return 1
+  case "$p" in ''|[!/]*|*//*|*/) return 1 ;; esac
+  case "$p" in *[!A-Za-z0-9._/-]*) return 1 ;; esac
+  case "$p" in */..|*/../*|*/.|*/./*) return 1 ;; esac
+}
+
+valid_base_ref() {
+  local r=${1-}
+  local LC_ALL=C
+  [ "${#r}" -le 256 ] || return 1
+  case "$r" in ''|-*|/*|*[!A-Za-z0-9./_-]*) return 1 ;; esac
+  case "$r" in *..*|*//*|*/|*.lock) return 1 ;; esac
+}
+
+valid_oid() {
+  local o=${1-}
+  local LC_ALL=C
+  case "$o" in ''|*[!0-9a-f]*) return 1 ;; esac
+  [ "${#o}" -eq 40 ] || [ "${#o}" -eq 64 ]
+}
+
+# --- registry --------------------------------------------------------------
+
+HOST_ID=
+HOST_ALIAS=
+HOST_CLASS=
+HOST_LOGIN_SHELL=
+HOST_TASK_ROOT=
+HOST_HANDOFF=
+
+# parse_registry <host-id>: validate the ENTIRE registry file (any malformed
+# line anywhere refuses, so a typo in a security field can never be silently
+# skipped), then load the requested host into HOST_*.
+parse_registry() {
+  local want=$1 line lineno=0 seen=' ' found=no
+  local id halias hclass hlogin hroot hhandoff tok key val r i
+  local -a toks remotes
+  [ -e "$REGISTRY" ] || refuse "no remote host registry (config/remote-hosts)"
+  { [ -f "$REGISTRY" ] && [ ! -L "$REGISTRY" ]; } \
+    || refuse "remote host registry is not a regular file"
+  while IFS= read -r line || [ -n "$line" ]; do
+    lineno=$((lineno + 1))
+    toks=()
+    read -r -a toks <<<"$line" || true
+    [ "${#toks[@]}" -gt 0 ] || continue
+    case "${toks[0]}" in '#'*) continue ;; esac
+    id=${toks[0]}
+    valid_host_id "$id" \
+      || refuse "config/remote-hosts line $lineno: invalid host id"
+    case "$seen" in
+      *" $id "*) refuse "config/remote-hosts line $lineno: duplicate host id '$id'" ;;
+    esac
+    seen="$seen$id "
+    halias=''
+    hclass=''
+    hlogin=''
+    hroot=''
+    hhandoff=''
+    for ((i = 1; i < ${#toks[@]}; i++)); do
+      tok=${toks[$i]}
+      key=${tok%%=*}
+      val=${tok#*=}
+      [ "$key" != "$tok" ] && [ -n "$key" ] \
+        || refuse "config/remote-hosts line $lineno: not a key=value field: '$tok'"
+      case "$key" in
+        alias)
+          [ -z "$halias" ] || refuse "config/remote-hosts line $lineno: duplicate alias="
+          valid_alias "$val" || refuse "config/remote-hosts line $lineno: invalid alias value"
+          halias=$val ;;
+        class)
+          [ -z "$hclass" ] || refuse "config/remote-hosts line $lineno: duplicate class="
+          case "$val" in client|non-client) : ;; *)
+            refuse "config/remote-hosts line $lineno: class must be client or non-client" ;;
+          esac
+          hclass=$val ;;
+        login-shell)
+          [ -z "$hlogin" ] || refuse "config/remote-hosts line $lineno: duplicate login-shell="
+          case "$val" in yes|no) : ;; *)
+            refuse "config/remote-hosts line $lineno: login-shell must be yes or no" ;;
+          esac
+          hlogin=$val ;;
+        task-root)
+          [ -z "$hroot" ] || refuse "config/remote-hosts line $lineno: duplicate task-root="
+          valid_abs_path "$val" \
+            || refuse "config/remote-hosts line $lineno: task-root must be a clean absolute path"
+          hroot=$val ;;
+        handoff)
+          [ -z "$hhandoff" ] || refuse "config/remote-hosts line $lineno: duplicate handoff="
+          case "$val" in ''|,*|*,|*,,*)
+            refuse "config/remote-hosts line $lineno: invalid handoff list" ;;
+          esac
+          remotes=()
+          IFS=, read -r -a remotes <<<"$val" || true
+          [ "${#remotes[@]}" -ge 1 ] \
+            || refuse "config/remote-hosts line $lineno: invalid handoff list"
+          for r in "${remotes[@]}"; do
+            valid_remote_name "$r" \
+              || refuse "config/remote-hosts line $lineno: invalid handoff remote name"
+          done
+          hhandoff=$val ;;
+        *)
+          refuse "config/remote-hosts line $lineno: unknown key '$key'" ;;
+      esac
+    done
+    { [ -n "$halias" ] && [ -n "$hclass" ] && [ -n "$hlogin" ] \
+      && [ -n "$hroot" ] && [ -n "$hhandoff" ]; } \
+      || refuse "config/remote-hosts line $lineno: missing required field (need alias, class, login-shell, task-root, handoff)"
+    if [ "$id" = "$want" ]; then
+      HOST_ID=$id
+      HOST_ALIAS=$halias
+      HOST_CLASS=$hclass
+      HOST_LOGIN_SHELL=$hlogin
+      HOST_TASK_ROOT=$hroot
+      HOST_HANDOFF=$hhandoff
+      found=yes
+    fi
+  done <"$REGISTRY"
+  [ "$found" = yes ] || refuse "unknown remote host: '$want' (not in config/remote-hosts)"
+}
+
+# --- transport -------------------------------------------------------------
+
+REMOTE_OUT=
+
+# remote_run <script>: run <script> on HOST_ALIAS through bash -lc/-c per
+# HOST_LOGIN_SHELL, with BatchMode (never an interactive prompt), a bounded
+# connect timeout, keepalive bounds, and a fixed stdout byte cap. The script
+# text is embedded via printf %q so it crosses ssh as one argument.
+remote_run() {
+  local script=$1 flags rc
+  if [ "$HOST_LOGIN_SHELL" = yes ]; then flags='-lc'; else flags='-c'; fi
+  REMOTE_OUT=$(
+    ssh -o BatchMode=yes \
+      -o ConnectTimeout="${FM_REMOTE_SSH_CONNECT_TIMEOUT:-10}" \
+      -o ServerAliveInterval=15 -o ServerAliveCountMax=4 \
+      -- "$HOST_ALIAS" "bash $flags $(printf '%q' "$script")" \
+      | head -c "$MAX_REMOTE_OUTPUT"
+    exit "${PIPESTATUS[0]}"
+  )
+  rc=$?
+  [ "$rc" -eq 0 ] \
+    || refuse "remote host '$HOST_ID' unreachable or remote command failed (ssh exit $rc)"
+}
+
+# build_prelude <name> <value>...: emit one shell assignment per pair, with
+# the value rendered by printf %q. This is the ONLY way caller data enters a
+# remote script.
+build_prelude() {
+  while [ "$#" -ge 2 ]; do
+    printf '%s=%q\n' "$1" "$2"
+    shift 2
+  done
+}
+
+# --- wire-protocol parsing (unknown responses are refusals) ----------------
+
+RESP_TOKENS=()
+
+# parse_response <expected-verb> "<allowed keys>": require exactly one
+# well-formed fm-remote-v1 line in REMOTE_OUT, translate a remote refuse into
+# a local refusal, and load validated key=value tokens into RESP_TOKENS.
+parse_response() {
+  local verb=$1 allowed=" $2 " line proto='' tok key val keys_seen=' ' i
+  local -a toks
+  while IFS= read -r line; do
+    case "$line" in
+      'fm-remote-v1 '*)
+        [ -z "$proto" ] || refuse "unexpected remote response (multiple protocol lines)"
+        proto=$line ;;
+    esac
+  done <<<"$REMOTE_OUT"
+  [ -n "$proto" ] || refuse "unexpected remote response (no protocol line)"
+  toks=()
+  read -r -a toks <<<"$proto" || true
+  [ "${#toks[@]}" -ge 2 ] || refuse "unexpected remote response"
+  if [ "${toks[1]}" = refuse ]; then
+    [ "${#toks[@]}" -eq 3 ] || refuse "unexpected remote response"
+    case "${toks[2]}" in
+      reason=*)
+        val=${toks[2]#reason=}
+        case "$val" in ''|*[!a-z0-9-]*) refuse "unexpected remote response" ;; esac
+        refuse "remote refused: $val" ;;
+      *) refuse "unexpected remote response" ;;
+    esac
+  fi
+  [ "${toks[1]}" = "$verb" ] || refuse "unexpected remote response (verb mismatch)"
+  RESP_TOKENS=()
+  for ((i = 2; i < ${#toks[@]}; i++)); do
+    tok=${toks[$i]}
+    key=${tok%%=*}
+    val=${tok#*=}
+    [ "$key" != "$tok" ] && [ -n "$key" ] || refuse "unexpected remote response"
+    case "$key" in *[!a-z_]*) refuse "unexpected remote response" ;; esac
+    case "$allowed" in *" $key "*) : ;; *)
+      refuse "unexpected remote response (unknown field '$key')" ;;
+    esac
+    case "$keys_seen" in *" $key "*)
+      refuse "unexpected remote response (duplicate field '$key')" ;;
+    esac
+    keys_seen="$keys_seen$key "
+    case "$val" in ''|*[!A-Za-z0-9._/-]*) refuse "unexpected remote response (bad value)" ;; esac
+    [ "${#val}" -le 512 ] || refuse "unexpected remote response (bad value)"
+    RESP_TOKENS+=("$tok")
+  done
+}
+
+resp_get() {
+  local t
+  for t in ${RESP_TOKENS[@]+"${RESP_TOKENS[@]}"}; do
+    case "$t" in "$1"=*)
+      printf '%s\n' "${t#*=}"
+      return 0 ;;
+    esac
+  done
+  return 1
+}
+
+resp_require() {
+  resp_get "$1" || refuse "unexpected remote response (missing field '$1')"
+}
+
+# --- remote script bodies (static single-quoted text, expanded remotely) ---
+
+# The remote bodies below are deliberately single-quoted: their $vars expand
+# on the REMOTE side, seeded only by build_prelude's printf-%q assignments.
+# shellcheck disable=SC2016
+
+# Shared: verify git exists and $proj is the physical top level of a repo.
+REMOTE_COMMON='
+LC_ALL=C
+export LC_ALL
+command -v git >/dev/null 2>&1 || { printf "fm-remote-v1 refuse reason=git-missing\n"; exit 0; }
+[ -d "$proj" ] || { printf "fm-remote-v1 refuse reason=project-missing\n"; exit 0; }
+proj_phys=$(cd "$proj" && pwd -P) || { printf "fm-remote-v1 refuse reason=project-unreadable\n"; exit 0; }
+top=$(git -C "$proj" rev-parse --show-toplevel 2>/dev/null) || { printf "fm-remote-v1 refuse reason=not-a-repo\n"; exit 0; }
+top_phys=$(cd "$top" && pwd -P) || { printf "fm-remote-v1 refuse reason=not-a-repo\n"; exit 0; }
+[ "$top_phys" = "$proj_phys" ] || { printf "fm-remote-v1 refuse reason=project-not-toplevel\n"; exit 0; }
+'
+
+# Shared: resolve $dest physically and prove containment below $root plus
+# that it is a worktree whose top level is $dest itself.
+# shellcheck disable=SC2016
+REMOTE_DEST_CHECK='
+[ -d "$dest" ] || { printf "fm-remote-v1 refuse reason=path-not-dir\n"; exit 0; }
+dest_phys=$(cd "$dest" && pwd -P) || { printf "fm-remote-v1 refuse reason=path-unreadable\n"; exit 0; }
+root_phys=$(cd "$root" && pwd -P) || { printf "fm-remote-v1 refuse reason=task-root-unreadable\n"; exit 0; }
+case "$dest_phys/" in "$root_phys"/*) : ;; *) printf "fm-remote-v1 refuse reason=out-of-root\n"; exit 0 ;; esac
+[ "$dest_phys" != "$proj_phys" ] || { printf "fm-remote-v1 refuse reason=path-is-project\n"; exit 0; }
+wt_top=$(git -C "$dest" rev-parse --show-toplevel 2>/dev/null) || { printf "fm-remote-v1 refuse reason=not-a-worktree\n"; exit 0; }
+wt_top_phys=$(cd "$wt_top" && pwd -P) || { printf "fm-remote-v1 refuse reason=not-a-worktree\n"; exit 0; }
+[ "$wt_top_phys" = "$dest_phys" ] || { printf "fm-remote-v1 refuse reason=toplevel-mismatch\n"; exit 0; }
+'
+
+# Shared: prove $dest_phys is registered in $proj's `git worktree list`.
+# shellcheck disable=SC2016
+REMOTE_REG_CHECK='
+registered=no
+while IFS= read -r wline; do
+  case "$wline" in
+    "worktree "*)
+      wpath=${wline#worktree }
+      if [ -d "$wpath" ]; then
+        wphys=$(cd "$wpath" && pwd -P) || continue
+        [ "$wphys" = "$dest_phys" ] && registered=yes
+      fi
+      ;;
+  esac
+done <<FM_WT_LIST
+$(git -C "$proj" worktree list --porcelain)
+FM_WT_LIST
+[ "$registered" = yes ] || { printf "fm-remote-v1 refuse reason=unregistered\n"; exit 0; }
+'
+
+# Shared: read branch, head, and a clean/dirty BOOLEAN (never filenames).
+# shellcheck disable=SC2016
+REMOTE_STATE_READ='
+cur_branch=$(git -C "$dest" rev-parse --abbrev-ref HEAD 2>/dev/null) || { printf "fm-remote-v1 refuse reason=head-unreadable\n"; exit 0; }
+head_oid=$(git -C "$dest" rev-parse HEAD 2>/dev/null) || { printf "fm-remote-v1 refuse reason=head-unreadable\n"; exit 0; }
+status_out=$(git -C "$dest" status --porcelain 2>/dev/null) || { printf "fm-remote-v1 refuse reason=status-unreadable\n"; exit 0; }
+clean=yes
+[ -z "$status_out" ] || clean=no
+'
+
+# shellcheck disable=SC2016
+REMOTE_PREFLIGHT_BODY='
+set -u
+uid=$(id -u) || exit 9
+'"$REMOTE_COMMON"'
+if [ -e "$root" ] && [ ! -d "$root" ]; then printf "fm-remote-v1 refuse reason=task-root-not-dir\n"; exit 0; fi
+rootstate=absent
+[ -d "$root" ] && rootstate=dir
+printf "fm-remote-v1 preflight uid=%s project=%s taskroot=%s\n" "$uid" "$proj_phys" "$rootstate"
+'
+
+# shellcheck disable=SC2016
+REMOTE_CREATE_BODY='
+set -u
+'"$REMOTE_COMMON"'
+[ ! -e "$dest" ] || { printf "fm-remote-v1 refuse reason=path-exists\n"; exit 0; }
+if git -C "$proj" rev-parse --verify --quiet "refs/heads/$branch" >/dev/null 2>&1; then
+  printf "fm-remote-v1 refuse reason=branch-exists\n"; exit 0
+fi
+base_oid=$(git -C "$proj" rev-parse --verify --quiet "$base^{commit}" 2>/dev/null) || { printf "fm-remote-v1 refuse reason=base-ref-unknown\n"; exit 0; }
+mkdir -p "$destdir" 2>/dev/null || { printf "fm-remote-v1 refuse reason=task-root-unwritable\n"; exit 0; }
+git -C "$proj" worktree add -b "$branch" "$dest" "$base_oid" >/dev/null 2>&1 || { printf "fm-remote-v1 refuse reason=worktree-add-failed\n"; exit 0; }
+'"$REMOTE_DEST_CHECK"'
+'"$REMOTE_REG_CHECK"'
+'"$REMOTE_STATE_READ"'
+[ "$head_oid" = "$base_oid" ] || { printf "fm-remote-v1 refuse reason=head-mismatch\n"; exit 0; }
+[ "$cur_branch" = "$branch" ] || { printf "fm-remote-v1 refuse reason=branch-mismatch\n"; exit 0; }
+printf "fm-remote-v1 worktree-create path=%s branch=%s head=%s base_oid=%s\n" "$dest_phys" "$branch" "$head_oid" "$base_oid"
+'
+
+# shellcheck disable=SC2016
+REMOTE_INSPECT_BODY='
+set -u
+'"$REMOTE_COMMON"'
+if [ ! -e "$dest" ]; then printf "fm-remote-v1 worktree-inspect state=absent\n"; exit 0; fi
+'"$REMOTE_DEST_CHECK"'
+'"$REMOTE_REG_CHECK"'
+'"$REMOTE_STATE_READ"'
+printf "fm-remote-v1 worktree-inspect state=worktree path=%s branch=%s head=%s clean=%s\n" "$dest_phys" "$cur_branch" "$head_oid" "$clean"
+'
+
+# shellcheck disable=SC2016
+REMOTE_REMOVE_BODY='
+set -u
+'"$REMOTE_COMMON"'
+[ -e "$dest" ] || { printf "fm-remote-v1 refuse reason=path-not-dir\n"; exit 0; }
+'"$REMOTE_DEST_CHECK"'
+'"$REMOTE_REG_CHECK"'
+'"$REMOTE_STATE_READ"'
+[ "$cur_branch" = "$branch" ] || { printf "fm-remote-v1 refuse reason=branch-mismatch\n"; exit 0; }
+[ "$clean" = yes ] || { printf "fm-remote-v1 refuse reason=dirty\n"; exit 0; }
+git -C "$proj" worktree remove "$dest" >/dev/null 2>&1 || { printf "fm-remote-v1 refuse reason=remove-failed\n"; exit 0; }
+[ ! -e "$dest" ] || { printf "fm-remote-v1 refuse reason=remove-incomplete\n"; exit 0; }
+printf "fm-remote-v1 worktree-remove path=%s branch=%s\n" "$dest_phys" "$branch"
+'
+
+# --- shared command argument handling ---------------------------------------
+
+TASK_PROJ=
+TASK_DEST=
+TASK_BRANCH=
+
+# task_args <host-id> <remote-project> <task-id>: validate and derive the one
+# permitted worktree path and branch for this task on this host.
+task_args() {
+  local host=$1 proj=$2 id=$3 slug
+  valid_host_id "$host" || usage_error "invalid host id"
+  parse_registry "$host"
+  valid_abs_path "$proj" \
+    || usage_error "remote project must be a clean absolute path"
+  fm_task_id_creation_valid "$id" || usage_error "invalid task id"
+  slug=$(basename "$proj")
+  TASK_PROJ=$proj
+  TASK_DEST="$HOST_TASK_ROOT/worktrees/$slug/$id"
+  TASK_BRANCH="fm/$id"
+}
+
+# --- commands ---------------------------------------------------------------
+
+cmd_resolve() {
+  [ "$#" -eq 1 ] || usage_error "resolve takes exactly: <host-id>"
+  valid_host_id "$1" || usage_error "invalid host id"
+  parse_registry "$1"
+  printf 'host=%s\n' "$HOST_ID"
+  printf 'alias=%s\n' "$HOST_ALIAS"
+  printf 'class=%s\n' "$HOST_CLASS"
+  printf 'login_shell=%s\n' "$HOST_LOGIN_SHELL"
+  printf 'task_root=%s\n' "$HOST_TASK_ROOT"
+  printf 'handoff=%s\n' "$HOST_HANDOFF"
+}
+
+cmd_preflight() {
+  [ "$#" -eq 2 ] || usage_error "preflight takes exactly: <host-id> <remote-project>"
+  local host=$1 proj=$2 script uid project taskroot
+  valid_host_id "$host" || usage_error "invalid host id"
+  parse_registry "$host"
+  valid_abs_path "$proj" \
+    || usage_error "remote project must be a clean absolute path"
+  script="$(build_prelude proj "$proj" root "$HOST_TASK_ROOT")
+$REMOTE_PREFLIGHT_BODY"
+  remote_run "$script"
+  parse_response preflight "uid project taskroot"
+  uid=$(resp_require uid)
+  project=$(resp_require project)
+  taskroot=$(resp_require taskroot)
+  case "$uid" in *[!0-9]*) refuse "unexpected remote response (bad uid)" ;; esac
+  [ "$uid" != 0 ] || refuse "remote user on host '$HOST_ID' is root; a non-root remote account is required"
+  valid_abs_path "$project" || refuse "unexpected remote response (bad project path)"
+  case "$taskroot" in dir|absent) : ;; *) refuse "unexpected remote response (bad taskroot)" ;; esac
+  printf 'host=%s\n' "$HOST_ID"
+  printf 'class=%s\n' "$HOST_CLASS"
+  printf 'uid=%s\n' "$uid"
+  printf 'project=%s\n' "$project"
+  printf 'taskroot=%s\n' "$taskroot"
+}
+
+cmd_worktree_create() {
+  [ "$#" -eq 4 ] || usage_error "worktree-create takes exactly: <host-id> <remote-project> <task-id> <base-ref>"
+  local base=$4 script path branch head base_oid
+  task_args "$1" "$2" "$3"
+  valid_base_ref "$base" || usage_error "invalid base ref"
+  script="$(build_prelude proj "$TASK_PROJ" root "$HOST_TASK_ROOT" \
+    destdir "$(dirname "$TASK_DEST")" dest "$TASK_DEST" \
+    branch "$TASK_BRANCH" base "$base")
+$REMOTE_CREATE_BODY"
+  remote_run "$script"
+  parse_response worktree-create "path branch head base_oid"
+  path=$(resp_require path)
+  branch=$(resp_require branch)
+  head=$(resp_require head)
+  base_oid=$(resp_require base_oid)
+  valid_abs_path "$path" || refuse "unexpected remote response (bad path)"
+  [ "$branch" = "$TASK_BRANCH" ] || refuse "unexpected remote response (branch mismatch)"
+  valid_oid "$head" || refuse "unexpected remote response (bad head oid)"
+  valid_oid "$base_oid" || refuse "unexpected remote response (bad base oid)"
+  printf 'path=%s\n' "$path"
+  printf 'branch=%s\n' "$branch"
+  printf 'head=%s\n' "$head"
+  printf 'base_oid=%s\n' "$base_oid"
+}
+
+cmd_worktree_inspect() {
+  [ "$#" -eq 3 ] || usage_error "worktree-inspect takes exactly: <host-id> <remote-project> <task-id>"
+  local script state path branch head clean
+  task_args "$1" "$2" "$3"
+  script="$(build_prelude proj "$TASK_PROJ" root "$HOST_TASK_ROOT" dest "$TASK_DEST")
+$REMOTE_INSPECT_BODY"
+  remote_run "$script"
+  parse_response worktree-inspect "state path branch head clean"
+  state=$(resp_require state)
+  if [ "$state" = absent ]; then
+    printf 'state=absent\n'
+    return 0
+  fi
+  [ "$state" = worktree ] || refuse "unexpected remote response (bad state)"
+  path=$(resp_require path)
+  branch=$(resp_require branch)
+  head=$(resp_require head)
+  clean=$(resp_require clean)
+  valid_abs_path "$path" || refuse "unexpected remote response (bad path)"
+  [ "$branch" = "$TASK_BRANCH" ] \
+    || refuse "remote worktree is on branch '$branch', not the task branch '$TASK_BRANCH'"
+  valid_oid "$head" || refuse "unexpected remote response (bad head oid)"
+  case "$clean" in yes|no) : ;; *) refuse "unexpected remote response (bad clean flag)" ;; esac
+  printf 'state=worktree\n'
+  printf 'path=%s\n' "$path"
+  printf 'branch=%s\n' "$branch"
+  printf 'head=%s\n' "$head"
+  printf 'clean=%s\n' "$clean"
+}
+
+cmd_worktree_remove() {
+  [ "$#" -eq 3 ] || usage_error "worktree-remove takes exactly: <host-id> <remote-project> <task-id>"
+  local script path branch
+  task_args "$1" "$2" "$3"
+  script="$(build_prelude proj "$TASK_PROJ" root "$HOST_TASK_ROOT" \
+    dest "$TASK_DEST" branch "$TASK_BRANCH")
+$REMOTE_REMOVE_BODY"
+  remote_run "$script"
+  parse_response worktree-remove "path branch"
+  path=$(resp_require path)
+  branch=$(resp_require branch)
+  valid_abs_path "$path" || refuse "unexpected remote response (bad path)"
+  [ "$branch" = "$TASK_BRANCH" ] || refuse "unexpected remote response (branch mismatch)"
+  printf 'path=%s\n' "$path"
+  printf 'branch=%s\n' "$branch"
+}
+
+# --- dispatch ---------------------------------------------------------------
+
+[ "$#" -ge 1 ] || usage_error "missing command"
+COMMAND=$1
+shift
+case "$COMMAND" in
+  --help|-h|help) usage ;;
+  resolve) cmd_resolve "$@" ;;
+  preflight) cmd_preflight "$@" ;;
+  worktree-create) cmd_worktree_create "$@" ;;
+  worktree-inspect) cmd_worktree_inspect "$@" ;;
+  worktree-remove) cmd_worktree_remove "$@" ;;
+  *) usage_error "unknown command: $COMMAND" ;;
+esac

--- a/bin/fm-remote-ssh.sh
+++ b/bin/fm-remote-ssh.sh
@@ -105,6 +105,10 @@ duplicate line, an unexpected verb, or an unknown field is a local refusal.
 
 Environment:
   FM_REMOTE_SSH_CONNECT_TIMEOUT  ssh ConnectTimeout seconds (default 10).
+  FM_REMOTE_SSH_DEADLINE         overall wall-clock deadline in seconds for
+                                 each remote call (default 120); a remote
+                                 command still running at the deadline is
+                                 killed and the call refuses.
   FM_CONFIG_OVERRIDE             alternate config directory (testing).
 
 Exit codes: 0 success; 1 registry, transport, protocol, or remote refusal;
@@ -266,15 +270,37 @@ parse_registry() {
 
 REMOTE_OUT=
 
+# run_with_deadline <seconds> <command...>: enforce an overall wall-clock
+# bound on one remote call, via timeout/gtimeout when available and a perl
+# alarm watchdog otherwise; every path exits 124 when the deadline expires,
+# matching timeout(1).
+run_with_deadline() {
+  local secs=$1
+  shift
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$secs" "$@"
+  elif command -v gtimeout >/dev/null 2>&1; then
+    gtimeout "$secs" "$@"
+  else
+    # shellcheck disable=SC2016  # single quotes are deliberate: Perl expands its own variables.
+    perl -e 'my $t = shift; my $pid = fork; die "fork failed" unless defined $pid; if (!$pid) { setpgrp(0, 0); exec @ARGV or exit 127 } my $stop = sub { $SIG{HUP} = $SIG{INT} = $SIG{TERM} = "IGNORE"; kill "TERM", -$pid; select undef, undef, undef, 0.2; kill "KILL", -$pid; waitpid $pid, 0; exit 124 }; local $SIG{ALRM} = $stop; local $SIG{HUP} = $stop; local $SIG{INT} = $stop; local $SIG{TERM} = $stop; alarm $t; waitpid $pid, 0; exit(($? & 127) ? 128 + ($? & 127) : $? >> 8)' "$secs" "$@"
+  fi
+}
+
 # remote_run <script>: run <script> on HOST_ALIAS through bash -lc/-c per
 # HOST_LOGIN_SHELL, with BatchMode (never an interactive prompt), a bounded
-# connect timeout, keepalive bounds, and a fixed stdout byte cap. The script
-# text is embedded via printf %q so it crosses ssh as one argument.
+# connect timeout, keepalive bounds, an overall wall-clock deadline, and a
+# fixed stdout byte cap. The script text is embedded via printf %q so it
+# crosses ssh as one argument.
 remote_run() {
-  local script=$1 flags rc
+  local script=$1 flags rc deadline
+  deadline=${FM_REMOTE_SSH_DEADLINE:-120}
+  case "$deadline" in ''|0*|*[!0-9]*)
+    refuse "FM_REMOTE_SSH_DEADLINE must be a positive integer (seconds)" ;;
+  esac
   if [ "$HOST_LOGIN_SHELL" = yes ]; then flags='-lc'; else flags='-c'; fi
   REMOTE_OUT=$(
-    ssh -o BatchMode=yes \
+    run_with_deadline "$deadline" ssh -o BatchMode=yes \
       -o ConnectTimeout="${FM_REMOTE_SSH_CONNECT_TIMEOUT:-10}" \
       -o ServerAliveInterval=15 -o ServerAliveCountMax=4 \
       -- "$HOST_ALIAS" "bash $flags $(printf '%q' "$script")" \
@@ -282,6 +308,8 @@ remote_run() {
     exit "${PIPESTATUS[0]}"
   )
   rc=$?
+  [ "$rc" -ne 124 ] \
+    || refuse "remote host '$HOST_ID' hit the ${deadline}s wall-clock deadline (FM_REMOTE_SSH_DEADLINE)"
   [ "$rc" -eq 0 ] \
     || refuse "remote host '$HOST_ID' unreachable or remote command failed (ssh exit $rc)"
 }
@@ -381,14 +409,14 @@ top_phys=$(cd "$top" && pwd -P) || { printf "fm-remote-v1 refuse reason=not-a-re
 [ "$top_phys" = "$proj_phys" ] || { printf "fm-remote-v1 refuse reason=project-not-toplevel\n"; exit 0; }
 '
 
-# Shared: resolve $dest physically and prove containment below $root plus
-# that it is a worktree whose top level is $dest itself.
+# Shared: resolve $dest physically and prove containment strictly below
+# $root plus that it is a worktree whose top level is $dest itself.
 # shellcheck disable=SC2016
 REMOTE_DEST_CHECK='
 [ -d "$dest" ] || { printf "fm-remote-v1 refuse reason=path-not-dir\n"; exit 0; }
 dest_phys=$(cd "$dest" && pwd -P) || { printf "fm-remote-v1 refuse reason=path-unreadable\n"; exit 0; }
 root_phys=$(cd "$root" && pwd -P) || { printf "fm-remote-v1 refuse reason=task-root-unreadable\n"; exit 0; }
-case "$dest_phys/" in "$root_phys"/*) : ;; *) printf "fm-remote-v1 refuse reason=out-of-root\n"; exit 0 ;; esac
+case "$dest_phys/" in "$root_phys"/?*) : ;; *) printf "fm-remote-v1 refuse reason=out-of-root\n"; exit 0 ;; esac
 [ "$dest_phys" != "$proj_phys" ] || { printf "fm-remote-v1 refuse reason=path-is-project\n"; exit 0; }
 wt_top=$(git -C "$dest" rev-parse --show-toplevel 2>/dev/null) || { printf "fm-remote-v1 refuse reason=not-a-worktree\n"; exit 0; }
 wt_top_phys=$(cd "$wt_top" && pwd -P) || { printf "fm-remote-v1 refuse reason=not-a-worktree\n"; exit 0; }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -83,6 +83,15 @@ The caller-facing label remains `fm-<id>`, but the actual cmux workspace title i
 Test cleanup must use the guarded path described in [`docs/cmux-backend.md`](cmux-backend.md)'s "Test safety" section, never enumerate-and-close every workspace.
 The `config/backend` file is not inherited by secondmate homes.
 
+## Remote host registry (config/remote-hosts)
+
+The local, gitignored `config/remote-hosts` file registers the SSH hosts approved for phase-4 remote-run task checkouts.
+`bin/fm-remote-ssh.sh` is the single owner of the registry's exact line schema, field validation, remote-run shell mechanics, and safety rules; its header and `--help` are the contract.
+Each entry names the host's ssh_config alias, its `client|non-client` classification, whether remote commands require a login shell, the only remote directory tree task worktrees may be created under, and the git remotes approved for handoff pushes.
+An absent file means no host is registered, and every remote-run helper call refuses.
+No spawn, watcher, or teardown path routes to this helper yet; it is the foundations layer of the phase-4 remote-run series.
+The file is not inherited into secondmate homes.
+
 ## Away-mode supervisor backend (FM_SUPERVISOR_BACKEND / FM_SUPERVISOR_TARGET)
 
 The `/afk` sub-supervisor injects escalation digests into firstmate's own pane independently of where new task endpoints are spawned.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -40,6 +40,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `backends/zellij.sh`     | Experimental zellij session-provider adapter                                         |
 | `backends/orca.sh`       | Experimental Orca backend adapter owning both worktree and terminal                  |
 | `backends/cmux.sh`       | Experimental cmux session-provider adapter                                           |
+| `fm-remote-ssh.sh`       | Single owner of remote-run SSH mechanics: registered-host resolution, bounded preflight, and guarded remote git-worktree primitives |
 | `fm-config-push.sh`      | Push declared inherited local material to live secondmate homes mid-session          |
 | `fm-project-mode.sh`     | Resolve a project's delivery mode and `+yolo` flag from `data/projects.md`           |
 | `fm-merge-local.sh`      | Fast-forward a `local-only` project's local default branch after approval            |

--- a/tests/fm-remote-ssh.test.sh
+++ b/tests/fm-remote-ssh.test.sh
@@ -5,9 +5,10 @@
 # a fake `ssh` that logs every invocation (one line, unit-separated args) and
 # then either EXECUTES the remote command locally with real git (mode "exec",
 # so the actual remote script logic is exercised against real repositories),
-# fails like an unreachable host (mode "fail"), or replays a canned response
-# (mode "canned", for protocol/refusal parsing). No real ssh connection is
-# ever made: the fake shadows ssh on PATH for every case.
+# fails like an unreachable host (mode "fail"), replays a canned response
+# (mode "canned", for protocol/refusal parsing), or blocks like a hung remote
+# command (mode "hang", for the wall-clock deadline). No real ssh connection
+# is ever made: the fake shadows ssh on PATH for every case.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -51,6 +52,9 @@ case "$mode" in
     [ -n "${FM_FAKE_SSH_CANNED:-}" ] && cat "$FM_FAKE_SSH_CANNED"
     exit "${FM_FAKE_SSH_EXIT:-0}"
     ;;
+  hang)
+    exec sleep 30
+    ;;
 esac
 exit 0
 SH
@@ -87,7 +91,8 @@ write_host() {
 
 # run_rs <dir> <mode> <args...>: run fm-remote-ssh.sh with the fake ssh and
 # this case's config; captures OUT and STATUS. Canned-mode tests preset
-# CANNED (a response file) and optionally CANNED_EXIT before calling.
+# CANNED (a response file) and optionally CANNED_EXIT before calling; the
+# deadline test presets DEADLINE (seconds, empty means the script default).
 OUT=
 STATUS=0
 run_rs() {
@@ -100,6 +105,7 @@ run_rs() {
     FM_FAKE_SSH_HOME="$SSH_HOME" \
     FM_FAKE_SSH_CANNED="${CANNED:-}" \
     FM_FAKE_SSH_EXIT="${CANNED_EXIT:-0}" \
+    FM_REMOTE_SSH_DEADLINE="${DEADLINE:-}" \
     "$RS" "$@" 2>&1)
   STATUS=$?
 }
@@ -286,6 +292,18 @@ test_unreachable_host_refuses() {
   [ "$STATUS" -ne 0 ] || fail "an unreachable host must refuse"
   assert_contains "$OUT" "ssh exit 255" "transport failure not reported"
   pass "transport: an unreachable host (ssh exit 255) refuses"
+}
+
+test_deadline_bounds_hung_remote() {
+  local dir
+  dir=$(case_env ssh-hang)
+  write_host "$dir"
+  DEADLINE=1
+  run_rs "$dir" hang preflight vps1 "$dir/remote-proj"
+  DEADLINE=
+  [ "$STATUS" -ne 0 ] || fail "a hung remote command must refuse at the deadline"
+  assert_contains "$OUT" "wall-clock deadline" "deadline expiry not reported"
+  pass "transport: a hung remote command is killed at the wall-clock deadline"
 }
 
 test_garbage_response_refuses() {
@@ -554,6 +572,20 @@ test_remove_out_of_root_refuses() {
   pass "worktree-remove: a path resolving outside the registered task root refuses untouched"
 }
 
+test_remove_dest_equal_to_root_refuses() {
+  local dir dest
+  dir=$(case_env wt-remove-destroot)
+  write_host "$dir"
+  dest="$dir/taskroot/worktrees/remote-proj/task1"
+  mkdir -p "$(dirname "$dest")"
+  ln -s "$dir/taskroot" "$dest"
+  run_rs "$dir" exec worktree-remove vps1 "$dir/remote-proj" task1
+  [ "$STATUS" -ne 0 ] || fail "a task path resolving to the task root itself must refuse"
+  assert_contains "$OUT" "remote refused: out-of-root" "root-equal task path not refused"
+  assert_present "$dir/taskroot" "the task root must be left untouched"
+  pass "worktree-remove: a path resolving to the task root itself refuses untouched"
+}
+
 test_remove_absent_refuses() {
   local dir
   dir=$(case_env wt-remove-absent)
@@ -579,6 +611,7 @@ test_resolve_prints_validated_entry
 test_injection_arguments_refused_before_ssh
 test_ssh_invocation_shape_and_login_shell
 test_unreachable_host_refuses
+test_deadline_bounds_hung_remote
 test_garbage_response_refuses
 test_multiple_protocol_lines_refuse
 test_wrong_verb_refuses
@@ -596,6 +629,7 @@ test_inspect_absent_and_worktree_states
 test_inspect_branch_mismatch_refuses
 test_remove_happy_path_keeps_branch
 test_remove_out_of_root_refuses
+test_remove_dest_equal_to_root_refuses
 test_remove_dirty_refuses
 test_remove_unregistered_refuses
 test_remove_absent_refuses

--- a/tests/fm-remote-ssh.test.sh
+++ b/tests/fm-remote-ssh.test.sh
@@ -1,0 +1,603 @@
+#!/usr/bin/env bash
+# tests/fm-remote-ssh.test.sh - fake-ssh unit tests for bin/fm-remote-ssh.sh,
+# PR 1 of the phase-4 remote-run series (data/phase4-sshpane-design-s1).
+# Mirrors tests/fm-backend-herdr.test.sh's fakebin/command-log convention with
+# a fake `ssh` that logs every invocation (one line, unit-separated args) and
+# then either EXECUTES the remote command locally with real git (mode "exec",
+# so the actual remote script logic is exercised against real repositories),
+# fails like an unreachable host (mode "fail"), or replays a canned response
+# (mode "canned", for protocol/refusal parsing). No real ssh connection is
+# ever made: the fake shadows ssh on PATH for every case.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+RS="$ROOT/bin/fm-remote-ssh.sh"
+TMP_ROOT=$(fm_test_tmproot fm-remote-ssh-tests)
+# Registry paths are validated strictly (no doubled slash, no dot components),
+# and a trailing-slash TMPDIR would embed "//" into fixture paths - normalize
+# the case root to its physical path once (mkdir -p first, matching the other
+# suites' pattern of recreating the root before use).
+mkdir -p "$TMP_ROOT"
+TMP_ROOT=$(cd "$TMP_ROOT" && pwd -P)
+
+# One shared fake-ssh; per-test log files via FM_SSH_LOG. In exec mode the
+# remote command (ssh's final argument, "bash -lc <quoted-script>") runs
+# locally under a scratch HOME so a login shell sources no user profile noise.
+make_ssh_fakebin() {  # <dir> -> echoes fakebin dir
+  local fb="$1/fakebin"
+  mkdir -p "$fb"
+  cat > "$fb/ssh" <<'SH'
+#!/usr/bin/env bash
+set -u
+LOG="${FM_SSH_LOG:?}"
+{
+  printf 'ssh'
+  for a in "$@"; do printf '\x1f%s' "$a"; done
+  printf '\n'
+} >> "$LOG"
+mode="${FM_FAKE_SSH_MODE:-exec}"
+case "$mode" in
+  exec)
+    cmd=
+    for a in "$@"; do cmd=$a; done
+    HOME="${FM_FAKE_SSH_HOME:?}" exec bash -c "$cmd"
+    ;;
+  fail)
+    exit 255
+    ;;
+  canned)
+    [ -n "${FM_FAKE_SSH_CANNED:-}" ] && cat "$FM_FAKE_SSH_CANNED"
+    exit "${FM_FAKE_SSH_EXIT:-0}"
+    ;;
+esac
+exit 0
+SH
+  chmod +x "$fb/ssh"
+  printf '%s\n' "$fb"
+}
+
+FB=$(make_ssh_fakebin "$TMP_ROOT")
+SSH_HOME="$TMP_ROOT/ssh-home"
+mkdir -p "$SSH_HOME"
+
+# case_env <name>: create an isolated case dir with a config dir, a "remote"
+# project repo normalized to branch main, a task root, and an empty ssh log.
+# Echoes the case dir; the registry is written separately per test.
+case_env() {
+  local dir="$TMP_ROOT/$1"
+  mkdir -p "$dir/config" "$dir/taskroot"
+  fm_git_init_commit "$dir/remote-proj"
+  git -C "$dir/remote-proj" branch -M main
+  : > "$dir/ssh.log"
+  printf '%s\n' "$dir"
+}
+
+# write_host <dir> [extra registry lines...]: write the default single-host
+# registry (host vps1, non-client, no login shell) plus any extra lines.
+write_host() {
+  local dir=$1
+  shift
+  {
+    printf 'vps1 alias=fmvps class=non-client login-shell=no task-root=%s handoff=origin\n' "$dir/taskroot"
+    [ "$#" -gt 0 ] && printf '%s\n' "$@"
+  } > "$dir/config/remote-hosts"
+}
+
+# run_rs <dir> <mode> <args...>: run fm-remote-ssh.sh with the fake ssh and
+# this case's config; captures OUT and STATUS. Canned-mode tests preset
+# CANNED (a response file) and optionally CANNED_EXIT before calling.
+OUT=
+STATUS=0
+run_rs() {
+  local dir=$1 mode=$2
+  shift 2
+  OUT=$(PATH="$FB:$PATH" \
+    FM_CONFIG_OVERRIDE="$dir/config" \
+    FM_SSH_LOG="$dir/ssh.log" \
+    FM_FAKE_SSH_MODE="$mode" \
+    FM_FAKE_SSH_HOME="$SSH_HOME" \
+    FM_FAKE_SSH_CANNED="${CANNED:-}" \
+    FM_FAKE_SSH_EXIT="${CANNED_EXIT:-0}" \
+    "$RS" "$@" 2>&1)
+  STATUS=$?
+}
+
+# --- registry validation (all refuse BEFORE any ssh call) --------------------
+
+test_registry_missing_file_refuses() {
+  local dir
+  dir=$(case_env reg-missing)
+  run_rs "$dir" exec resolve vps1
+  [ "$STATUS" -ne 0 ] || fail "resolve should refuse when config/remote-hosts is absent"
+  assert_contains "$OUT" "no remote host registry" "missing registry not reported"
+  [ ! -s "$dir/ssh.log" ] || fail "no ssh call may happen without a registry"
+  pass "registry: an absent config/remote-hosts refuses with no ssh call"
+}
+
+test_registry_unknown_host_refuses() {
+  local dir
+  dir=$(case_env reg-unknown)
+  write_host "$dir"
+  run_rs "$dir" exec resolve nosuch
+  [ "$STATUS" -ne 0 ] || fail "resolve should refuse an unregistered host id"
+  assert_contains "$OUT" "unknown remote host" "unknown host not reported"
+  [ ! -s "$dir/ssh.log" ] || fail "no ssh call may happen for an unknown host"
+  pass "registry: an unregistered host id refuses with no ssh call"
+}
+
+test_registry_missing_field_refuses() {
+  local dir
+  dir=$(case_env reg-missing-field)
+  printf 'vps1 alias=fmvps class=non-client login-shell=no handoff=origin\n' \
+    > "$dir/config/remote-hosts"
+  run_rs "$dir" exec resolve vps1
+  [ "$STATUS" -ne 0 ] || fail "a host line without task-root must refuse"
+  assert_contains "$OUT" "missing required field" "missing field not reported"
+  pass "registry: a line missing a required field refuses the registry"
+}
+
+test_registry_duplicate_host_refuses() {
+  local dir
+  dir=$(case_env reg-dup)
+  write_host "$dir" \
+    "vps1 alias=other class=non-client login-shell=no task-root=/srv/tasks handoff=origin"
+  run_rs "$dir" exec resolve vps1
+  [ "$STATUS" -ne 0 ] || fail "a duplicate host id must refuse"
+  assert_contains "$OUT" "duplicate host id" "duplicate host id not reported"
+  pass "registry: a duplicate host id refuses the registry"
+}
+
+test_registry_bad_class_refuses() {
+  local dir
+  dir=$(case_env reg-bad-class)
+  printf 'vps1 alias=fmvps class=friendly login-shell=no task-root=/srv/tasks handoff=origin\n' \
+    > "$dir/config/remote-hosts"
+  run_rs "$dir" exec resolve vps1
+  [ "$STATUS" -ne 0 ] || fail "class must be client or non-client"
+  assert_contains "$OUT" "class must be client or non-client" "bad class not reported"
+  pass "registry: a class outside client|non-client refuses"
+}
+
+test_registry_relative_task_root_refuses() {
+  local dir
+  dir=$(case_env reg-rel-root)
+  printf 'vps1 alias=fmvps class=non-client login-shell=no task-root=srv/tasks handoff=origin\n' \
+    > "$dir/config/remote-hosts"
+  run_rs "$dir" exec resolve vps1
+  [ "$STATUS" -ne 0 ] || fail "a relative task-root must refuse"
+  assert_contains "$OUT" "task-root must be a clean absolute path" "relative task-root not reported"
+  pass "registry: a relative task-root refuses"
+}
+
+test_registry_dotdot_task_root_refuses() {
+  local dir
+  dir=$(case_env reg-dotdot-root)
+  printf 'vps1 alias=fmvps class=non-client login-shell=no task-root=/srv/../etc handoff=origin\n' \
+    > "$dir/config/remote-hosts"
+  run_rs "$dir" exec resolve vps1
+  [ "$STATUS" -ne 0 ] || fail "a task-root with a .. component must refuse"
+  pass "registry: a task-root containing a dot-dot component refuses"
+}
+
+test_registry_dash_alias_refuses() {
+  local dir
+  dir=$(case_env reg-dash-alias)
+  printf 'vps1 alias=-oProxyCommand=evil class=non-client login-shell=no task-root=/srv/tasks handoff=origin\n' \
+    > "$dir/config/remote-hosts"
+  run_rs "$dir" exec resolve vps1
+  [ "$STATUS" -ne 0 ] || fail "an alias with a leading dash (ssh option injection) must refuse"
+  assert_contains "$OUT" "invalid alias value" "dash alias not reported"
+  pass "registry: an alias with a leading dash (option injection) refuses"
+}
+
+test_registry_unknown_key_refuses() {
+  local dir
+  dir=$(case_env reg-unknown-key)
+  printf 'vps1 alias=fmvps class=non-client login-shell=no task-root=/srv/tasks handoff=origin sudo=yes\n' \
+    > "$dir/config/remote-hosts"
+  run_rs "$dir" exec resolve vps1
+  [ "$STATUS" -ne 0 ] || fail "an unknown registry key must refuse"
+  assert_contains "$OUT" "unknown key" "unknown key not reported"
+  pass "registry: an unknown key on any line refuses"
+}
+
+test_resolve_prints_validated_entry() {
+  local dir
+  dir=$(case_env reg-resolve-ok)
+  write_host "$dir"
+  run_rs "$dir" exec resolve vps1
+  expect_code 0 "$STATUS" "resolve of a valid host should succeed"
+  assert_contains "$OUT" "host=vps1" "resolve did not print the host id"
+  assert_contains "$OUT" "alias=fmvps" "resolve did not print the alias"
+  assert_contains "$OUT" "class=non-client" "resolve did not print the class"
+  assert_contains "$OUT" "login_shell=no" "resolve did not print the login-shell mode"
+  assert_contains "$OUT" "task_root=$dir/taskroot" "resolve did not print the task root"
+  assert_contains "$OUT" "handoff=origin" "resolve did not print the handoff remotes"
+  [ ! -s "$dir/ssh.log" ] || fail "resolve is local-only and must not call ssh"
+  pass "resolve: prints the validated registry entry without any ssh call"
+}
+
+# --- injection attempts (refused locally, no ssh spawn, no side effect) ------
+
+test_injection_arguments_refused_before_ssh() {
+  local dir marker
+  dir=$(case_env inject-args)
+  write_host "$dir"
+  marker="$dir/pwned"
+  local bad_proj bad_id bad_ref
+  # The single-quoted $(...) payloads below are deliberate literals: the test
+  # proves they are refused, never expanded.
+  # shellcheck disable=SC2016
+  for bad_proj in "/tmp/x;touch $marker" '/tmp/$(touch pwned)' '/tmp/a b' '/tmp/../etc' '//tmp/x'; do
+    run_rs "$dir" exec worktree-create vps1 "$bad_proj" task1 main
+    [ "$STATUS" -ne 0 ] || fail "project '$bad_proj' must be refused"
+  done
+  # shellcheck disable=SC2016
+  for bad_id in 'a;b' '../up' 'a b' '.hidden' 'a$(touch pwned)' 'a/b'; do
+    run_rs "$dir" exec worktree-create vps1 "$dir/remote-proj" "$bad_id" main
+    [ "$STATUS" -ne 0 ] || fail "task id '$bad_id' must be refused"
+  done
+  # shellcheck disable=SC2016
+  for bad_ref in '-D' 'a;b' 'a..b' 'refs/heads/x y' '$(reboot)'; do
+    run_rs "$dir" exec worktree-create vps1 "$dir/remote-proj" task1 "$bad_ref"
+    [ "$STATUS" -ne 0 ] || fail "base ref '$bad_ref' must be refused"
+  done
+  [ ! -s "$dir/ssh.log" ] || fail "an injection attempt must be refused BEFORE any ssh call"
+  assert_absent "$marker" "an injection payload executed (marker file created)"
+  pass "injection: hostile project/task-id/base-ref values refuse before any ssh call"
+}
+
+# --- ssh invocation shape ----------------------------------------------------
+
+test_ssh_invocation_shape_and_login_shell() {
+  local dir log
+  dir=$(case_env ssh-shape)
+  write_host "$dir" \
+    "ccag alias=ccagw class=client login-shell=yes task-root=/srv/tasks handoff=origin"
+  CANNED="$dir/resp"
+  printf 'fm-remote-v1 preflight uid=501 project=%s taskroot=dir\n' "$dir/remote-proj" > "$CANNED"
+  run_rs "$dir" canned preflight vps1 "$dir/remote-proj"
+  expect_code 0 "$STATUS" "canned preflight should succeed"
+  log=$(cat "$dir/ssh.log")
+  assert_contains "$log" $'\x1f''-o'$'\x1f''BatchMode=yes' "ssh call missing BatchMode=yes (must never prompt)"
+  assert_contains "$log" "ConnectTimeout=" "ssh call missing a bounded ConnectTimeout"
+  assert_contains "$log" $'\x1f''--'$'\x1f''fmvps' "ssh call missing '--' before the alias (option-injection guard)"
+  assert_contains "$log" $'\x1f''bash -c ' "login-shell=no host must run through bash -c"
+  : > "$dir/ssh.log"
+  printf 'fm-remote-v1 preflight uid=501 project=/srv/proj taskroot=dir\n' > "$CANNED"
+  run_rs "$dir" canned preflight ccag /srv/proj
+  expect_code 0 "$STATUS" "canned preflight on the login-shell host should succeed"
+  log=$(cat "$dir/ssh.log")
+  assert_contains "$log" $'\x1f''--'$'\x1f''ccagw' "second host's alias not used"
+  assert_contains "$log" $'\x1f''bash -lc ' "login-shell=yes host must run through bash -lc"
+  CANNED=
+  pass "transport: BatchMode, bounded timeout, '--' alias guard, and login-shell selection"
+}
+
+# --- transport and protocol refusals ----------------------------------------
+
+test_unreachable_host_refuses() {
+  local dir
+  dir=$(case_env ssh-fail)
+  write_host "$dir"
+  run_rs "$dir" fail preflight vps1 "$dir/remote-proj"
+  [ "$STATUS" -ne 0 ] || fail "an unreachable host must refuse"
+  assert_contains "$OUT" "ssh exit 255" "transport failure not reported"
+  pass "transport: an unreachable host (ssh exit 255) refuses"
+}
+
+test_garbage_response_refuses() {
+  local dir
+  dir=$(case_env resp-garbage)
+  write_host "$dir"
+  CANNED="$dir/resp"
+  printf 'Welcome to the server!\ntotally not a protocol line\n' > "$CANNED"
+  run_rs "$dir" canned preflight vps1 "$dir/remote-proj"
+  [ "$STATUS" -ne 0 ] || fail "a response without a protocol line must refuse"
+  assert_contains "$OUT" "unexpected remote response" "garbage response not refused"
+  CANNED=
+  pass "protocol: output with no fm-remote-v1 line refuses"
+}
+
+test_multiple_protocol_lines_refuse() {
+  local dir
+  dir=$(case_env resp-multi)
+  write_host "$dir"
+  CANNED="$dir/resp"
+  printf 'fm-remote-v1 preflight uid=501 project=/p taskroot=dir\nfm-remote-v1 preflight uid=0 project=/p taskroot=dir\n' > "$CANNED"
+  run_rs "$dir" canned preflight vps1 "$dir/remote-proj"
+  [ "$STATUS" -ne 0 ] || fail "two protocol lines must refuse"
+  assert_contains "$OUT" "multiple protocol lines" "duplicate protocol line not refused"
+  CANNED=
+  pass "protocol: more than one fm-remote-v1 line refuses"
+}
+
+test_wrong_verb_refuses() {
+  local dir
+  dir=$(case_env resp-verb)
+  write_host "$dir"
+  CANNED="$dir/resp"
+  printf 'fm-remote-v1 worktree-create path=/x branch=fm/t head=0 base_oid=0\n' > "$CANNED"
+  run_rs "$dir" canned preflight vps1 "$dir/remote-proj"
+  [ "$STATUS" -ne 0 ] || fail "a mismatched verb must refuse"
+  assert_contains "$OUT" "verb mismatch" "verb mismatch not refused"
+  CANNED=
+  pass "protocol: a response with the wrong verb refuses"
+}
+
+test_unknown_field_refuses() {
+  local dir
+  dir=$(case_env resp-field)
+  write_host "$dir"
+  CANNED="$dir/resp"
+  printf 'fm-remote-v1 preflight uid=501 project=/p taskroot=dir evil=1\n' > "$CANNED"
+  run_rs "$dir" canned preflight vps1 "$dir/remote-proj"
+  [ "$STATUS" -ne 0 ] || fail "an unknown response field must refuse"
+  assert_contains "$OUT" "unknown field" "unknown field not refused"
+  CANNED=
+  pass "protocol: an unallowlisted response field refuses"
+}
+
+test_remote_refuse_reason_is_relayed() {
+  local dir
+  dir=$(case_env resp-refuse)
+  write_host "$dir"
+  CANNED="$dir/resp"
+  printf 'fm-remote-v1 refuse reason=not-a-repo\n' > "$CANNED"
+  run_rs "$dir" canned preflight vps1 "$dir/remote-proj"
+  [ "$STATUS" -ne 0 ] || fail "a remote refuse must exit nonzero"
+  assert_contains "$OUT" "remote refused: not-a-repo" "remote refusal code not relayed"
+  CANNED=
+  pass "protocol: a remote refuse reason is relayed as a local refusal"
+}
+
+test_root_uid_refuses() {
+  local dir
+  dir=$(case_env resp-root)
+  write_host "$dir"
+  CANNED="$dir/resp"
+  printf 'fm-remote-v1 preflight uid=0 project=/p taskroot=dir\n' > "$CANNED"
+  run_rs "$dir" canned preflight vps1 "$dir/remote-proj"
+  [ "$STATUS" -ne 0 ] || fail "a root remote user must refuse"
+  assert_contains "$OUT" "is root" "root remote user not refused"
+  CANNED=
+  pass "preflight: a remote root user refuses (non-root harness constraint)"
+}
+
+# --- preflight against real local git (exec mode) ----------------------------
+
+test_preflight_happy_path() {
+  local dir
+  dir=$(case_env pre-ok)
+  write_host "$dir"
+  run_rs "$dir" exec preflight vps1 "$dir/remote-proj"
+  expect_code 0 "$STATUS" "preflight against a real repo should succeed: $OUT"
+  assert_contains "$OUT" "host=vps1" "preflight did not print the host"
+  assert_contains "$OUT" "class=non-client" "preflight did not print the class"
+  assert_contains "$OUT" "taskroot=dir" "preflight did not report the existing task root"
+  pass "preflight: a valid non-root host with a real repo passes"
+}
+
+test_preflight_not_a_repo_refuses() {
+  local dir
+  dir=$(case_env pre-norepo)
+  write_host "$dir"
+  mkdir -p "$dir/plain"
+  run_rs "$dir" exec preflight vps1 "$dir/plain"
+  [ "$STATUS" -ne 0 ] || fail "a non-repo project must refuse"
+  assert_contains "$OUT" "remote refused: not-a-repo" "non-repo not refused"
+  pass "preflight: a project directory that is not a git repo refuses"
+}
+
+test_preflight_non_toplevel_refuses() {
+  local dir
+  dir=$(case_env pre-subdir)
+  write_host "$dir"
+  mkdir -p "$dir/remote-proj/subdir"
+  run_rs "$dir" exec preflight vps1 "$dir/remote-proj/subdir"
+  [ "$STATUS" -ne 0 ] || fail "a repo subdirectory must refuse"
+  assert_contains "$OUT" "remote refused: project-not-toplevel" "non-toplevel project not refused"
+  pass "preflight: a repo subdirectory given as the project refuses"
+}
+
+# --- worktree create/inspect/remove happy paths (exec mode, real git) --------
+
+test_create_happy_path() {
+  local dir dest expected_head
+  dir=$(case_env wt-create)
+  write_host "$dir"
+  run_rs "$dir" exec worktree-create vps1 "$dir/remote-proj" task1 main
+  expect_code 0 "$STATUS" "worktree-create should succeed: $OUT"
+  expected_head=$(git -C "$dir/remote-proj" rev-parse main)
+  assert_contains "$OUT" "branch=fm/task1" "create did not report the task branch"
+  assert_contains "$OUT" "head=$expected_head" "create did not report the base head oid"
+  dest="$dir/taskroot/worktrees/remote-proj/task1"
+  [ -d "$dest" ] || fail "the worktree was not created at the deterministic layout path"
+  [ "$(git -C "$dest" rev-parse --abbrev-ref HEAD)" = "fm/task1" ] \
+    || fail "the created worktree is not on fm/task1"
+  git -C "$dir/remote-proj" worktree list --porcelain | grep -q "task1" \
+    || fail "the worktree is not registered by the project"
+  pass "worktree-create: creates a registered worktree on fm/<id> at the pinned base"
+}
+
+test_create_existing_path_refuses() {
+  local dir
+  dir=$(case_env wt-create-dup)
+  write_host "$dir"
+  run_rs "$dir" exec worktree-create vps1 "$dir/remote-proj" task1 main
+  expect_code 0 "$STATUS" "first create should succeed"
+  run_rs "$dir" exec worktree-create vps1 "$dir/remote-proj" task1 main
+  [ "$STATUS" -ne 0 ] || fail "a second create over an existing path must refuse"
+  assert_contains "$OUT" "remote refused: path-exists" "existing path not refused"
+  pass "worktree-create: an existing task path refuses instead of being reused"
+}
+
+test_create_existing_branch_refuses() {
+  local dir
+  dir=$(case_env wt-create-branch)
+  write_host "$dir"
+  git -C "$dir/remote-proj" branch fm/task1 main
+  run_rs "$dir" exec worktree-create vps1 "$dir/remote-proj" task1 main
+  [ "$STATUS" -ne 0 ] || fail "a preexisting fm/<id> branch must refuse"
+  assert_contains "$OUT" "remote refused: branch-exists" "existing branch not refused"
+  pass "worktree-create: a preexisting task branch refuses (never reused silently)"
+}
+
+test_create_unknown_base_refuses() {
+  local dir
+  dir=$(case_env wt-create-base)
+  write_host "$dir"
+  run_rs "$dir" exec worktree-create vps1 "$dir/remote-proj" task1 nosuchref
+  [ "$STATUS" -ne 0 ] || fail "an unknown base ref must refuse"
+  assert_contains "$OUT" "remote refused: base-ref-unknown" "unknown base ref not refused"
+  pass "worktree-create: an unknown base ref refuses"
+}
+
+test_inspect_absent_and_worktree_states() {
+  local dir dest
+  dir=$(case_env wt-inspect)
+  write_host "$dir"
+  run_rs "$dir" exec worktree-inspect vps1 "$dir/remote-proj" task1
+  expect_code 0 "$STATUS" "inspect of an absent path should succeed with state=absent: $OUT"
+  assert_contains "$OUT" "state=absent" "absent worktree not reported"
+  run_rs "$dir" exec worktree-create vps1 "$dir/remote-proj" task1 main
+  expect_code 0 "$STATUS" "create should succeed"
+  run_rs "$dir" exec worktree-inspect vps1 "$dir/remote-proj" task1
+  expect_code 0 "$STATUS" "inspect of a clean worktree should succeed: $OUT"
+  assert_contains "$OUT" "state=worktree" "worktree state not reported"
+  assert_contains "$OUT" "branch=fm/task1" "inspect did not report the branch"
+  assert_contains "$OUT" "clean=yes" "a clean worktree must report clean=yes"
+  dest="$dir/taskroot/worktrees/remote-proj/task1"
+  touch "$dest/scratch.txt"
+  run_rs "$dir" exec worktree-inspect vps1 "$dir/remote-proj" task1
+  expect_code 0 "$STATUS" "inspect of a dirty worktree still succeeds (dirty is a fact)"
+  assert_contains "$OUT" "clean=no" "a dirty worktree must report clean=no"
+  assert_not_contains "$OUT" "scratch.txt" "inspect leaked a filename; clean is a boolean only"
+  pass "worktree-inspect: reports absent, clean, and dirty as facts without filenames"
+}
+
+test_inspect_branch_mismatch_refuses() {
+  local dir dest
+  dir=$(case_env wt-inspect-branch)
+  write_host "$dir"
+  dest="$dir/taskroot/worktrees/remote-proj/task1"
+  mkdir -p "$(dirname "$dest")"
+  git -C "$dir/remote-proj" worktree add --quiet -b other-branch "$dest" main
+  run_rs "$dir" exec worktree-inspect vps1 "$dir/remote-proj" task1
+  [ "$STATUS" -ne 0 ] || fail "a worktree on a foreign branch must refuse identity"
+  assert_contains "$OUT" "not the task branch" "branch mismatch not refused"
+  pass "worktree-inspect: a worktree on a non-task branch refuses identity"
+}
+
+test_remove_happy_path_keeps_branch() {
+  local dir dest log
+  dir=$(case_env wt-remove)
+  write_host "$dir"
+  run_rs "$dir" exec worktree-create vps1 "$dir/remote-proj" task1 main
+  expect_code 0 "$STATUS" "create should succeed"
+  dest="$dir/taskroot/worktrees/remote-proj/task1"
+  run_rs "$dir" exec worktree-remove vps1 "$dir/remote-proj" task1
+  expect_code 0 "$STATUS" "remove of a clean registered worktree should succeed: $OUT"
+  assert_absent "$dest" "the worktree directory should be gone after remove"
+  git -C "$dir/remote-proj" rev-parse --verify --quiet refs/heads/fm/task1 >/dev/null \
+    || fail "remove must NOT delete the fm/<id> branch (reachability proof is teardown's job)"
+  log=$(cat "$dir/ssh.log")
+  assert_not_contains "$log" "rm -rf" "the composed remote commands must never contain rm -rf"
+  assert_not_contains "$log" "--force" "the composed remote commands must never contain --force"
+  pass "worktree-remove: removes the clean worktree without --force and keeps the branch"
+}
+
+test_remove_dirty_refuses() {
+  local dir dest
+  dir=$(case_env wt-remove-dirty)
+  write_host "$dir"
+  run_rs "$dir" exec worktree-create vps1 "$dir/remote-proj" task1 main
+  expect_code 0 "$STATUS" "create should succeed"
+  dest="$dir/taskroot/worktrees/remote-proj/task1"
+  touch "$dest/unlanded.txt"
+  run_rs "$dir" exec worktree-remove vps1 "$dir/remote-proj" task1
+  [ "$STATUS" -ne 0 ] || fail "a dirty worktree must refuse removal"
+  assert_contains "$OUT" "remote refused: dirty" "dirty refusal not reported"
+  assert_present "$dest/unlanded.txt" "the dirty worktree must be left untouched"
+  pass "worktree-remove: a dirty worktree refuses and is left untouched"
+}
+
+test_remove_unregistered_refuses() {
+  local dir dest
+  dir=$(case_env wt-remove-unreg)
+  write_host "$dir"
+  dest="$dir/taskroot/worktrees/remote-proj/task1"
+  fm_git_init_commit "$dest"
+  run_rs "$dir" exec worktree-remove vps1 "$dir/remote-proj" task1
+  [ "$STATUS" -ne 0 ] || fail "an unregistered repo at the task path must refuse removal"
+  assert_contains "$OUT" "remote refused: unregistered" "unregistered refusal not reported"
+  assert_present "$dest/README.md" "the unregistered directory must be left untouched"
+  pass "worktree-remove: an unregistered directory at the task path refuses untouched"
+}
+
+test_remove_out_of_root_refuses() {
+  local dir dest outside
+  dir=$(case_env wt-remove-outroot)
+  write_host "$dir"
+  outside="$dir/elsewhere/task1"
+  mkdir -p "$dir/elsewhere"
+  git -C "$dir/remote-proj" worktree add --quiet -b fm/task1 "$outside" main
+  dest="$dir/taskroot/worktrees/remote-proj/task1"
+  mkdir -p "$(dirname "$dest")"
+  ln -s "$outside" "$dest"
+  run_rs "$dir" exec worktree-remove vps1 "$dir/remote-proj" task1
+  [ "$STATUS" -ne 0 ] || fail "a task path resolving outside the task root must refuse"
+  assert_contains "$OUT" "remote refused: out-of-root" "out-of-root refusal not reported"
+  assert_present "$outside/README.md" "the out-of-root target must be left untouched"
+  pass "worktree-remove: a path resolving outside the registered task root refuses untouched"
+}
+
+test_remove_absent_refuses() {
+  local dir
+  dir=$(case_env wt-remove-absent)
+  write_host "$dir"
+  run_rs "$dir" exec worktree-remove vps1 "$dir/remote-proj" task1
+  [ "$STATUS" -ne 0 ] || fail "removing an absent worktree must refuse"
+  assert_contains "$OUT" "remote refused: path-not-dir" "absent path refusal not reported"
+  pass "worktree-remove: an absent task path refuses"
+}
+
+# --- run --------------------------------------------------------------------
+
+test_registry_missing_file_refuses
+test_registry_unknown_host_refuses
+test_registry_missing_field_refuses
+test_registry_duplicate_host_refuses
+test_registry_bad_class_refuses
+test_registry_relative_task_root_refuses
+test_registry_dotdot_task_root_refuses
+test_registry_dash_alias_refuses
+test_registry_unknown_key_refuses
+test_resolve_prints_validated_entry
+test_injection_arguments_refused_before_ssh
+test_ssh_invocation_shape_and_login_shell
+test_unreachable_host_refuses
+test_garbage_response_refuses
+test_multiple_protocol_lines_refuse
+test_wrong_verb_refuses
+test_unknown_field_refuses
+test_remote_refuse_reason_is_relayed
+test_root_uid_refuses
+test_preflight_happy_path
+test_preflight_not_a_repo_refuses
+test_preflight_non_toplevel_refuses
+test_create_happy_path
+test_create_existing_path_refuses
+test_create_existing_branch_refuses
+test_create_unknown_base_refuses
+test_inspect_absent_and_worktree_states
+test_inspect_branch_mismatch_refuses
+test_remove_happy_path_keeps_branch
+test_remove_out_of_root_refuses
+test_remove_dirty_refuses
+test_remove_unregistered_refuses
+test_remove_absent_refuses
+
+echo "all fm-remote-ssh tests passed"


### PR DESCRIPTION
## Intent

Implement PR 1 of the phase-4 remote-run series from the agreed design record (data/phase4-sshpane-design-s1): give firstmate a foundations-only, safety-first remote-run layer - a local gitignored remote-host registry schema and bin/fm-remote-ssh.sh as the single owner of remote-run shell mechanics (structured args only, safe quoting, bounded preflight, git-worktree create/inspect/remove primitives that never rm -rf or force-remove and refuse unknown remote responses), with fake-ssh test coverage; no fm-spawn/fm-watch/fm-teardown routing yet

## What Changed

- Adds `bin/fm-remote-ssh.sh` as the single owner of remote-run shell mechanics, with `resolve`, `preflight`, `worktree-create`, `worktree-inspect`, and `worktree-remove` commands. Every caller-supplied value is validated against a strict allowlist charset before any `ssh` spawns and crosses the wire only via `printf %q`; remote task paths are recomputed from the registry rather than accepted from the caller; each call is bounded by a connect timeout plus an overall wall-clock deadline (`FM_REMOTE_SSH_DEADLINE`, defaulting to 120s, enforced through `timeout`/`gtimeout` or a perl alarm watchdog); removal runs `git worktree remove` without `--force` (never `rm -rf`) only after re-proving registration, strict containment below the task root, branch identity, and cleanliness; and any response that is not exactly one well-formed `fm-remote-v1` line with the expected verb and allowlisted fields is a refusal.
- Introduces the local, gitignored `config/remote-hosts` registry (alias, `client|non-client` class, login-shell flag, permitted task root, approved handoff remotes) — added to `.gitignore`, the `AGENTS.md` home layout, a new "Remote host registry" section in `docs/configuration.md`, and the `docs/scripts.md` script table, with the script header and `--help` as the canonical schema contract.
- Adds `tests/fm-remote-ssh.test.sh`, a fake-`ssh` suite following the existing fakebin/command-log convention that shadows `ssh` on `PATH` for every case so no real connection is attempted. No `fm-spawn`/`fm-watch`/`fm-teardown` path routes to the helper yet; this is the foundations layer only.

## Risk Assessment

✅ Low: The fix commit precisely implements both requested round-1 remediations (strict task-root containment and an env-tunable 120s wall-clock deadline) with fail-closed validation, a verified portable timeout fallback chain, and targeted regression tests, leaving no material issues in the additive, not-yet-routed foundations layer.

## Testing

Completed 1 recorded test check.

- Outcome: ⚠️ 1 error across 1 run (25m48s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-remote-ssh.sh:391` - The remote containment check `case &#34;$dest_phys/&#34; in &#34;$root_phys&#34;/*)` passes when the destination path physically resolves to the task root itself (the trailing `*` matches the empty string — verified empirically), contradicting the header&#39;s stated invariant that a removable path must be &#39;physically below the registered task root&#39;. A symlink planted at the derived task path pointing at the task root would pass containment; the later registered-worktree/branch/cleanliness proofs make real damage very contrived, but the invariant is not strictly enforced. Fix is one line: additionally require `[ &#34;$dest_phys&#34; != &#34;$root_phys&#34; ]` (or use pattern `&#34;$root_phys&#34;/?*`).
- ⚠️ `bin/fm-remote-ssh.sh:278` - remote_run has no overall execution timeout: ConnectTimeout bounds connection setup and ServerAliveInterval=15/CountMax=4 kills dead connections in ~60s, but a live connection whose remote command hangs (e.g. git blocked on a stale index.lock) blocks the helper indefinitely. The intent requires a &#39;bounded preflight&#39;; if that includes wall-clock bounding, a total command deadline (e.g. wrapping ssh in a timeout or a kill-after watchdog) is missing. Whether time-bounding was in the agreed design scope (data/phase4-sshpane-design-s1 is gitignored and not inspectable here) is an author decision.
- ℹ️ `bin/fm-remote-ssh.sh:280` - printf %q renders the multi-line remote script as bash ANSI-C `$&#39;…&#39;` quoting, so the remote account&#39;s sshd-invoked login shell must understand it (bash/zsh/ksh93 do; dash, fish, and csh-family shells mangle the command). Every mangling scenario traced fails closed (command-not-found or garbage output → local refusal), so this is not a safety hole, but the host constraint is undocumented — a one-line note in the --help registry contract (&#39;remote account shell must be bash-compatible&#39;) would save debugging on a dash-login host.

🔧 Fix: enforce remote-call wall-clock deadline and strict task-root containment
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Test** - 1 error</summary>

- 🚨 tests failed with exit code 1
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `docs/configuration.md:351` - The two new tunables FM_REMOTE_SSH_CONNECT_TIMEOUT and FM_REMOTE_SSH_DEADLINE are documented only in bin/fm-remote-ssh.sh&#39;s --help/header, not in docs/configuration.md&#39;s &#34;Environment variables&#34; block. That block is a near-exhaustive index of user-facing FM_* knobs, so a reader may expect them there; I left them out because the new &#34;Remote host registry&#34; section explicitly delegates remote-run mechanics to the script&#39;s header and --help, and copying them would create a second copy to drift. Worth revisiting in PR 2, when a lifecycle path actually routes to the helper and the knobs become operator-facing.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
