### PR TITLE
fix(bin): recover Codex session locks without process inspection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,7 +125,8 @@ Read the complete digest once and trust it as this turn's startup and recovery i
 Do not separately re-read the context, backlog, metadata, or bulk status inputs it just printed unless a source was reported absent or corrupt, older history is specifically needed, or a targeted workflow must inspect before writing.
 An `ABSENT` captain, shared-captain, secondmate, or learnings file means the firstmate repo's built-in defaults, no shared captain preferences, no registered secondmates, or no captured learnings; rebuild an absent or stale project registry from the clones before dispatch.
 
-If the session lock is refused, tell the captain another active session is managing the fleet and remain read-only.
+If the session lock is refused, remain read-only and tell the captain that another session is managing the fleet or that an unknown Codex session holds the lock.
+For a `codex-thread:` holder, run `bin/fm-lock.sh clear` only after the captain confirms that the recorded Codex session is no longer live.
 A lock-refused session must not spawn, steer, merge, drain the wake queue, repair supervision, repair a checkout, or perform any other fleet mutation.
 
 1. **Lock** - acquires the per-home session lock first, before anything mutates shared state.

--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -7,6 +7,7 @@
 # back to Codex's stable per-thread session id.
 # Usage: fm-lock.sh           acquire; exit 1 if another live session holds it
 #        fm-lock.sh status    print holder and liveness; always exits 0
+#        fm-lock.sh clear     remove the current lock
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -57,6 +58,12 @@ holder_alive() {  # true if $1 is a live process that looks like a harness
   printf '%s' "$(basename "$comm") $args" | grep -qE "$HARNESS_RE"
 }
 
+if [ "${1:-}" = "clear" ]; then
+  rm -f "$LOCK"
+  echo "lock cleared"
+  exit 0
+fi
+
 if [ "${1:-}" = "status" ]; then
   if [ ! -f "$LOCK" ]; then echo "lock: free"; exit 0; fi
   old=$(cat "$LOCK")
@@ -79,7 +86,10 @@ me=$(harness_pid) || { echo "error: cannot locate harness process in ancestry" >
 if [ -f "$LOCK" ]; then
   old=$(cat "$LOCK")
   if [ "$old" != "$me" ] && holder_alive "$old"; then
-    echo "error: another live firstmate session holds the lock (pid $old); operate read-only until resolved" >&2
+    case "$old" in
+      codex-thread:*) echo "error: another live firstmate session holds the lock (Codex session $old); if the previous Codex session is known dead, run bin/fm-lock.sh clear; otherwise operate read-only until resolved" >&2 ;;
+      *) echo "error: another live firstmate session holds the lock (pid $old); operate read-only until resolved" >&2 ;;
+    esac
     exit 1
   fi
 fi

--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -2,7 +2,9 @@
 # Acquire or inspect the per-home firstmate session lock.
 # Writes the harness (agent) process PID found by walking the shell's ancestry,
 # which lives as long as the firstmate session - unlike the transient subshell
-# PID of any one tool call, which is dead moments after it is written.
+# PID of any one tool call, which is dead moments after it is written. In
+# sandboxed Codex tool calls where process inspection is unavailable, it falls
+# back to Codex's stable per-thread session id.
 # Usage: fm-lock.sh           acquire; exit 1 if another live session holds it
 #        fm-lock.sh status    print holder and liveness; always exits 0
 set -u
@@ -20,7 +22,7 @@ HARNESS_RE='claude|codex|opencode|grok|^pi$'
 harness_pid() {
   local pid=$$ comm args
   for _ in 1 2 3 4 5 6 7 8; do
-    comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
+    comm=$(ps -o comm= -p "$pid" 2>/dev/null) || break
     args=$(ps -o args= -p "$pid" 2>/dev/null)
     if printf '%s' "$(basename "$comm")" | grep -qE "$HARNESS_RE"; then
       echo "$pid"; return 0
@@ -32,11 +34,24 @@ harness_pid() {
     pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
     [ -n "$pid" ] && [ "$pid" -gt 1 ] || return 1
   done
+  # Codex exposes this stable session identifier to every tool call. Prefer
+  # process ancestry whenever it is readable, but do not make Firstmate's
+  # session lock depend on ps permission in a sandboxed Codex session.
+  if [ -n "${CODEX_THREAD_ID:-}" ]; then
+    printf 'codex-thread:%s\n' "$CODEX_THREAD_ID"
+    return 0
+  fi
   return 1
 }
 
 holder_alive() {  # true if $1 is a live process that looks like a harness
   local pid=$1 comm
+  case "$pid" in
+    codex-thread:*)
+      [ "${CODEX_THREAD_ID:-}" = "${pid#codex-thread:}" ]
+      return
+      ;;
+  esac
   kill -0 "$pid" 2>/dev/null || return 1
   comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
   printf '%s' "$(basename "$comm") $(ps -o args= -p "$pid" 2>/dev/null)" | grep -qE "$HARNESS_RE"
@@ -45,7 +60,17 @@ holder_alive() {  # true if $1 is a live process that looks like a harness
 if [ "${1:-}" = "status" ]; then
   if [ ! -f "$LOCK" ]; then echo "lock: free"; exit 0; fi
   old=$(cat "$LOCK")
-  if holder_alive "$old"; then echo "lock: held by live harness pid $old"; else echo "lock: stale (pid $old dead or not a harness)"; fi
+  if holder_alive "$old"; then
+    case "$old" in
+      codex-thread:*) echo "lock: held by current Codex session" ;;
+      *) echo "lock: held by live harness pid $old" ;;
+    esac
+  else
+    case "$old" in
+      codex-thread:*) echo "lock: stale (Codex session is no longer current)" ;;
+      *) echo "lock: stale (pid $old dead or not a harness)" ;;
+    esac
+  fi
   exit 0
 fi
 
@@ -58,4 +83,7 @@ if [ -f "$LOCK" ]; then
   fi
 fi
 echo "$me" > "$LOCK"
-echo "lock acquired: harness pid $me"
+case "$me" in
+  codex-thread:*) echo "lock acquired: Codex session" ;;
+  *) echo "lock acquired: harness pid $me" ;;
+esac

--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -7,7 +7,8 @@
 # back to Codex's stable per-thread session id.
 # Usage: fm-lock.sh           acquire; exit 1 if another live session holds it
 #        fm-lock.sh status    print holder and liveness; always exits 0
-#        fm-lock.sh clear     remove the current lock
+#        fm-lock.sh clear     remove the current lock; for a codex-thread owner,
+#                             only after the captain confirms that session is dead
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -52,8 +52,9 @@ holder_alive() {  # true if $1 is a live process that looks like a harness
       ;;
   esac
   kill -0 "$pid" 2>/dev/null || return 1
-  comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
-  printf '%s' "$(basename "$comm") $(ps -o args= -p "$pid" 2>/dev/null)" | grep -qE "$HARNESS_RE"
+  comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 0
+  args=$(ps -o args= -p "$pid" 2>/dev/null) || return 0
+  printf '%s' "$(basename "$comm") $args" | grep -qE "$HARNESS_RE"
 }
 
 if [ "${1:-}" = "status" ]; then

--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -32,7 +32,7 @@ harness_pid() {
       *node*|*python*) printf '%s' "$args" | grep -qE "$HARNESS_RE" && { echo "$pid"; return 0; } ;;
     esac
     pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
-    [ -n "$pid" ] && [ "$pid" -gt 1 ] || return 1
+    [ -n "$pid" ] && [ "$pid" -gt 1 ] || break
   done
   # Codex exposes this stable session identifier to every tool call. Prefer
   # process ancestry whenever it is readable, but do not make Firstmate's

--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -48,8 +48,7 @@ holder_alive() {  # true if $1 is a live process that looks like a harness
   local pid=$1 comm
   case "$pid" in
     codex-thread:*)
-      [ "${CODEX_THREAD_ID:-}" = "${pid#codex-thread:}" ]
-      return
+      return 0
       ;;
   esac
   kill -0 "$pid" 2>/dev/null || return 1
@@ -62,7 +61,8 @@ if [ "${1:-}" = "status" ]; then
   old=$(cat "$LOCK")
   if holder_alive "$old"; then
     case "$old" in
-      codex-thread:*) echo "lock: held by current Codex session" ;;
+      "codex-thread:${CODEX_THREAD_ID:-}") echo "lock: held by current Codex session" ;;
+      codex-thread:*) echo "lock: held by another or unknown Codex session" ;;
       *) echo "lock: held by live harness pid $old" ;;
     esac
   else

--- a/bin/fm-sessionstart-nudge.sh
+++ b/bin/fm-sessionstart-nudge.sh
@@ -23,6 +23,10 @@ lock_is_in_ancestry() {
   [ -f "$STATE/.lock" ] || return 1
   IFS= read -r lock_pid < "$STATE/.lock" 2>/dev/null || return 1
   case "$lock_pid" in
+    "codex-thread:${CODEX_THREAD_ID:-}")
+      [ -n "${CODEX_THREAD_ID:-}" ] && return 0
+      return 1
+      ;;
     ''|*[!0-9]*|1) return 1 ;;
   esac
   kill -0 "$lock_pid" 2>/dev/null || return 1

--- a/docs/sessionstart-nudge.md
+++ b/docs/sessionstart-nudge.md
@@ -12,7 +12,7 @@ It shares `bin/fm-primary-scope-lib.sh` with `bin/fm-turnend-guard.sh`, so the t
 The Shared Predicate section of `docs/turnend-guard.md` remains authoritative for marker validation, plain-checkout detection, and the required firstmate-shaped paths.
 
 Before printing, the wrapper reads `state/.lock` and walks at most eight parents from its own pid, matching `bin/fm-lock.sh` and Pi's `lockOwnership()` ancestry depth.
-If the lock names a live pid in that ancestry, session-start already ran in this harness session and the wrapper stays silent.
+If the lock names a live pid in that ancestry, or a `codex-thread:` value matching the current nonempty `CODEX_THREAD_ID`, session-start already ran in this harness session and the wrapper stays silent.
 Every path exits 0, including malformed state and adapter errors, because Claude SessionStart exit 2 blocks session initialization.
 
 ## Harness transports
@@ -105,7 +105,7 @@ The underlying Claude SessionStart stdout injection and Pi `session_start` event
 
 ## Regression coverage
 
-`tests/fm-sessionstart-nudge.test.sh` proves wrapper silence for both gate signals, an unmarked linked worktree, a missing state directory, and an already-owned lock.
+`tests/fm-sessionstart-nudge.test.sh` proves wrapper silence for both gate signals, an unmarked linked worktree, a missing state directory, an already-owned PID lock, and an already-owned Codex thread lock.
 It proves exact one-line output for a plain primary and a marked linked secondmate primary.
 It also verifies tracked wrapper registration for Claude, Codex, OpenCode, Pi, and Grok.
 `tests/fm-turnend-guard.test.sh` continues to cover the same shared primary scope through the turn-end path.

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -202,6 +202,23 @@ EOF
   pass "foreign Codex thread locks remain held when process inspection is denied"
 }
 
+test_live_pid_lock_is_not_overwritten_when_process_inspection_is_denied() {
+  local rec root home fakebin out status=0
+  rec=$(new_world live-pid-lock)
+  IFS='|' read -r root home fakebin <<EOF
+$rec
+EOF
+  make_fake_ps_denied "$fakebin"
+  printf '%s\n' "$$" > "$home/state/.lock"
+
+  out=$(CODEX_THREAD_ID=thread-under-test FM_HOME="$home" FM_ROOT_OVERRIDE="$root" PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-lock.sh" 2>&1) || status=$?
+  expect_code 1 "$status" "live PID lock acquisition with denied process inspection"
+  assert_contains "$out" "another live firstmate session holds the lock" "Codex thread was allowed to replace a live PID lock"
+  [ "$(cat "$home/state/.lock")" = "$$" ] || fail "Codex thread overwrote the existing PID lock"
+
+  pass "live PID locks remain held when process inspection is denied"
+}
+
 make_fake_ps_pi_holder() {
   local fakebin=$1 holder_pid=$2
   cat > "$fakebin/ps" <<SH
@@ -952,6 +969,7 @@ EOF
 test_context_digest_absent_empty_present
 test_codex_thread_lock_survives_denied_process_inspection
 test_foreign_codex_thread_lock_is_not_overwritten
+test_live_pid_lock_is_not_overwritten_when_process_inspection_is_denied
 test_lock_refusal_read_only_path
 test_output_ordering_diagnostics_lead
 test_herdr_backend_diagnostics_follow_real_session_start

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -156,6 +156,35 @@ SH
   printf '%s\n' "$harness" > "$fakebin/.harness-name"
 }
 
+make_fake_ps_denied() {
+  local fakebin=$1
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' 'ps: operation not permitted' >&2
+exit 1
+SH
+  chmod +x "$fakebin/ps"
+}
+
+test_codex_thread_lock_survives_denied_process_inspection() {
+  local rec root home fakebin out
+  rec=$(new_world codex-thread-lock)
+  IFS='|' read -r root home fakebin <<EOF
+$rec
+EOF
+  make_fake_ps_denied "$fakebin"
+
+  out=$(CODEX_THREAD_ID=thread-under-test FM_HOME="$home" FM_ROOT_OVERRIDE="$root" PATH="$fakebin:$BASE_PATH" "$SESSION_START")
+  assert_contains "$out" "lock acquired: Codex session" "Codex session did not acquire a lock when ps was denied"
+  assert_not_contains "$out" "READ-ONLY SESSION" "Codex session was incorrectly downgraded to read-only when ps was denied"
+  assert_contains "$(cat "$home/state/.lock")" "codex-thread:thread-under-test" "Codex lock did not store its stable session owner"
+
+  out=$(CODEX_THREAD_ID=thread-under-test FM_HOME="$home" FM_ROOT_OVERRIDE="$root" PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-lock.sh" status)
+  assert_contains "$out" "lock: held by current Codex session" "Codex session lock was not recognized without ps"
+
+  pass "Codex thread session lock works when process inspection is denied"
+}
+
 make_fake_ps_pi_holder() {
   local fakebin=$1 holder_pid=$2
   cat > "$fakebin/ps" <<SH
@@ -904,6 +933,7 @@ EOF
 }
 
 test_context_digest_absent_empty_present
+test_codex_thread_lock_survives_denied_process_inspection
 test_lock_refusal_read_only_path
 test_output_ordering_diagnostics_lead
 test_herdr_backend_diagnostics_follow_real_session_start

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -166,6 +166,20 @@ SH
   chmod +x "$fakebin/ps"
 }
 
+make_fake_ps_parent_denied() {
+  local fakebin=$1
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *"comm="*) printf '%s\n' '/bin/zsh'; exit 0 ;;
+  *"args="*) printf '%s\n' 'zsh'; exit 0 ;;
+  *"ppid="*) printf '%s\n' 'ps: operation not permitted' >&2; exit 1 ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/ps"
+}
+
 test_codex_thread_lock_survives_denied_process_inspection() {
   local rec root home fakebin out
   rec=$(new_world codex-thread-lock)
@@ -183,6 +197,22 @@ EOF
   assert_contains "$out" "lock: held by current Codex session" "Codex session lock was not recognized without ps"
 
   pass "Codex thread session lock works when process inspection is denied"
+}
+
+test_codex_thread_lock_survives_denied_parent_lookup() {
+  local rec root home fakebin out
+  rec=$(new_world codex-thread-parent-denied)
+  IFS='|' read -r root home fakebin <<EOF
+$rec
+EOF
+  make_fake_ps_parent_denied "$fakebin"
+
+  out=$(CODEX_THREAD_ID=thread-under-test FM_HOME="$home" FM_ROOT_OVERRIDE="$root" PATH="$fakebin:$BASE_PATH" "$SESSION_START")
+  assert_contains "$out" "lock acquired: Codex session" "Codex session did not acquire a lock when parent lookup was denied"
+  assert_not_contains "$out" "READ-ONLY SESSION" "Codex session was incorrectly downgraded to read-only when parent lookup was denied"
+  assert_contains "$(cat "$home/state/.lock")" "codex-thread:thread-under-test" "Codex lock did not store its stable session owner"
+
+  pass "Codex thread session lock works when parent lookup is denied"
 }
 
 test_foreign_codex_thread_lock_is_not_overwritten() {
@@ -968,6 +998,7 @@ EOF
 
 test_context_digest_absent_empty_present
 test_codex_thread_lock_survives_denied_process_inspection
+test_codex_thread_lock_survives_denied_parent_lookup
 test_foreign_codex_thread_lock_is_not_overwritten
 test_live_pid_lock_is_not_overwritten_when_process_inspection_is_denied
 test_lock_refusal_read_only_path

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -185,6 +185,23 @@ EOF
   pass "Codex thread session lock works when process inspection is denied"
 }
 
+test_foreign_codex_thread_lock_is_not_overwritten() {
+  local rec root home fakebin out status=0
+  rec=$(new_world foreign-codex-thread-lock)
+  IFS='|' read -r root home fakebin <<EOF
+$rec
+EOF
+  make_fake_ps_denied "$fakebin"
+
+  CODEX_THREAD_ID=owner-thread FM_HOME="$home" FM_ROOT_OVERRIDE="$root" PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-lock.sh" >/dev/null
+  out=$(CODEX_THREAD_ID=other-thread FM_HOME="$home" FM_ROOT_OVERRIDE="$root" PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-lock.sh" 2>&1) || status=$?
+  expect_code 1 "$status" "foreign Codex thread lock acquisition"
+  assert_contains "$out" "another live firstmate session holds the lock" "foreign Codex thread was allowed to replace the lock"
+  [ "$(cat "$home/state/.lock")" = "codex-thread:owner-thread" ] || fail "foreign Codex thread overwrote the existing lock"
+
+  pass "foreign Codex thread locks remain held when process inspection is denied"
+}
+
 make_fake_ps_pi_holder() {
   local fakebin=$1 holder_pid=$2
   cat > "$fakebin/ps" <<SH
@@ -934,6 +951,7 @@ EOF
 
 test_context_digest_absent_empty_present
 test_codex_thread_lock_survives_denied_process_inspection
+test_foreign_codex_thread_lock_is_not_overwritten
 test_lock_refusal_read_only_path
 test_output_ordering_diagnostics_lead
 test_herdr_backend_diagnostics_follow_real_session_start

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -227,9 +227,17 @@ EOF
   out=$(CODEX_THREAD_ID=other-thread FM_HOME="$home" FM_ROOT_OVERRIDE="$root" PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-lock.sh" 2>&1) || status=$?
   expect_code 1 "$status" "foreign Codex thread lock acquisition"
   assert_contains "$out" "another live firstmate session holds the lock" "foreign Codex thread was allowed to replace the lock"
+  assert_contains "$out" "bin/fm-lock.sh clear" "foreign Codex thread lock did not explain manual recovery"
   [ "$(cat "$home/state/.lock")" = "codex-thread:owner-thread" ] || fail "foreign Codex thread overwrote the existing lock"
 
-  pass "foreign Codex thread locks remain held when process inspection is denied"
+  out=$(FM_HOME="$home" FM_ROOT_OVERRIDE="$root" "$ROOT/bin/fm-lock.sh" clear)
+  assert_contains "$out" "lock cleared" "manual lock clear did not report success"
+  [ ! -e "$home/state/.lock" ] || fail "manual lock clear did not remove the lock"
+
+  CODEX_THREAD_ID=other-thread FM_HOME="$home" FM_ROOT_OVERRIDE="$root" PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-lock.sh" >/dev/null
+  [ "$(cat "$home/state/.lock")" = "codex-thread:other-thread" ] || fail "Codex session could not acquire after manual lock clear"
+
+  pass "foreign Codex thread locks support explicit manual recovery"
 }
 
 test_live_pid_lock_is_not_overwritten_when_process_inspection_is_denied() {

--- a/tests/fm-sessionstart-nudge.test.sh
+++ b/tests/fm-sessionstart-nudge.test.sh
@@ -103,6 +103,15 @@ test_owned_lock_is_silent() {
   pass "fm-sessionstart-nudge: a lock holder in process ancestry is already run"
 }
 
+test_owned_codex_thread_lock_is_silent() {
+  local root="$TMP_ROOT/already-ran-codex"
+  make_primary "$root"
+  printf '%s\n' 'codex-thread:thread-under-test' > "$root/state/.lock"
+  expect_silent_zero "owned Codex thread lock nudge" env CODEX_THREAD_ID=thread-under-test \
+    FM_GATE_REFUSE_BYPASS=0 FM_ROOT_OVERRIDE="$root" FM_HOME="$root" "$NUDGE"
+  pass "fm-sessionstart-nudge: a matching Codex thread lock is already run"
+}
+
 test_opencode_plugin_delivers_exact_nudge_once() {
   local root="$TMP_ROOT/opencode-primary" out status=0
   make_primary "$root"
@@ -186,5 +195,6 @@ test_unmarked_linked_worktree_is_silent
 test_linked_secondmate_primary_nudges
 test_missing_state_is_silent
 test_owned_lock_is_silent
+test_owned_codex_thread_lock_is_silent
 test_opencode_plugin_delivers_exact_nudge_once
 test_tracked_harness_registration


### PR DESCRIPTION
## Intent

The transcript contains only harness setup, permission-approval boilerplate, skill/tool listings, and an interrupted turn, with no substantive developer request preserved; the only concrete developer-driven actions were approving command prefixes for running "wezterm cli send-text" (including one that sends a "/config" nudge to a wezterm pane). There is not enough content to determine a specific developer goal, requirements, or constraints from this transcript.

## What Changed

- Fall back to `CODEX_THREAD_ID` ownership when process inspection or parent lookup is unavailable, while preserving live PID locks and refusing foreign Codex-thread locks.
- Add explicit lock clearing and status messaging for unrecoverable Codex-thread owners, with corresponding session-start guidance.
- Recognize a matching Codex-thread lock in the session-start nudge and add coverage for denied inspection, ownership conflicts, recovery, and nudge suppression.

## Risk Assessment

✅ Low: The explicit operator-clear recovery is narrowly scoped and preserves the selected fail-closed behavior for automatic lock acquisition.

## Testing

Completed 1 recorded test check.

- Outcome: ⚠️ 1 error across 1 run (22m27s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (4) ✅</summary>

- 🚨 `bin/fm-lock.sh:51` - A different active Codex thread has a different `CODEX_THREAD_ID`, so this returns false for its `codex-thread:` lock. The acquire path then overwrites that live lock and both sessions run mutable startup work. Treat foreign thread owners as held/unknown (fail closed) unless their liveness can be independently proven.
- ⚠️ `bin/fm-lock.sh:41` - The new non-numeric lock format is rejected by `fm-sessionstart-nudge.sh`&#39;s numeric-only ownership check, so a later SessionStart in the same Codex thread re-emits the instruction to run the supposedly once-per-session mutable digest. Add matching `codex-thread:$CODEX_THREAD_ID` recognition in the nudge path.

🔧 Fix: Harden Codex thread lock ownership checks
1 error still open:
- 🚨 `bin/fm-lock.sh:40` - When `ps` is denied, the new fallback can acquire with a `codex-thread:` owner, but an existing live numeric lock is classified stale: `kill -0` may succeed and the following `ps -o comm` failure makes `holder_alive` return false. The acquire path then overwrites a conventional live harness lock. Fail closed for a live PID whenever harness inspection is unavailable, and cover this cross-owner case.

🔧 Fix: Fail closed on unavailable PID inspection
1 error still open:
- 🚨 `bin/fm-lock.sh:25` - The new fallback is reached only when `ps -o comm` fails. If a sandbox permits `comm` but denies the parent lookup, this branch returns before reaching `CODEX_THREAD_ID`, so session start still fails instead of acquiring its thread lock. Treat an unavailable parent lookup as a loop break and fall back after the loop.

🔧 Fix: Reach Codex fallback after parent lookup denial
1 warning still open:
- ⚠️ `bin/fm-lock.sh:50` - Every `codex-thread:` owner is now permanently treated as alive, but there is no session-end cleanup or verifiable stale-owner recovery. After a sandboxed Codex thread ends, all future threads have different IDs and are refused indefinitely; the Codex “stale” status branch is unreachable. Please choose and implement a recovery lifecycle (for example, explicit operator clear or a verified expiry protocol).

🔧 Fix: Add explicit Codex lock recovery
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Test** - 1 error</summary>

- 🚨 tests failed with exit code 1
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`

</details>

<details>
<summary>⚠️ **Document** - 1 warning</summary>

- ⚠️ `bin/fm-lock.sh:51` - `holder_alive` treats every `codex-thread:` lock as live, so the Codex stale-status branch is unreachable; resolving this requires a behavior change outside the documentation-only scope.

🔧 Fix: Document Codex lock-clear confirmation
1 warning still open:
- ⚠️ `bin/fm-lock.sh:79` - The `codex-thread` stale-status branch remains unreachable because `holder_alive` always returns success for those owners; aligning it with the explicit-clear lifecycle requires the requested executable and test change outside this documentation-only scope.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
