### PR TITLE
fix(pi): reset watcher across logical sessions

### DIFF
--- a/.pi/extensions/fm-primary-pi-watch.ts
+++ b/.pi/extensions/fm-primary-pi-watch.ts
@@ -19,6 +19,13 @@ type CloseClassification = {
   message: string;
 };
 
+type SessionReplacementReason = "reload" | "new" | "resume" | "fork";
+
+type ActiveRestoration = {
+  generation: number;
+  token: number;
+};
+
 const extensionFile = fileURLToPath(import.meta.url);
 const extensionDir = dirname(extensionFile);
 const root = resolve(extensionDir, "../..");
@@ -40,7 +47,10 @@ let retryTimer: ReturnType<typeof setTimeout> | null = null;
 let retryFailures = 0;
 let stopping = false;
 let seq = 0;
-let restoring = false;
+let sessionGeneration = 0;
+let pendingSessionStart: SessionReplacementReason | null = null;
+let restorationSequence = 0;
+let activeRestoration: ActiveRestoration | null = null;
 const armReadiness = new WeakMap<ChildProcess, Promise<boolean>>();
 const armClose = new WeakMap<ChildProcess, Promise<void>>();
 
@@ -48,6 +58,11 @@ function positiveInteger(name: string, fallback: number): number {
   const value = Number(process.env[name]);
   if (!Number.isFinite(value) || value <= 0) return fallback;
   return Math.floor(value);
+}
+
+function sessionReplacementReason(reason: unknown): SessionReplacementReason | null {
+  if (reason === "reload" || reason === "new" || reason === "resume" || reason === "fork") return reason;
+  return null;
 }
 
 function parentPid(pid: string): string {
@@ -125,28 +140,47 @@ function classifyClose(stdout: string, stderr: string, code: number | null, sign
 }
 
 export default function (pi: ExtensionAPI) {
+  function sessionIsActive(generation: number): boolean {
+    return !stopping && generation === sessionGeneration;
+  }
+
   function stopArm(): void {
+    if (!stopping) sessionGeneration += 1;
     stopping = true;
+    activeRestoration = null;
     if (retryTimer) clearTimeout(retryTimer);
     retryTimer = null;
     if (child) child.kill("SIGTERM");
     child = null;
   }
 
+  let processExitCleanupRegistered = false;
   const cleanupOnProcessExit = () => {
+    pendingSessionStart = null;
     stopArm();
   };
-  process.once("exit", cleanupOnProcessExit);
+  const installProcessExitCleanup = (): void => {
+    if (processExitCleanupRegistered) return;
+    process.once("exit", cleanupOnProcessExit);
+    processExitCleanupRegistered = true;
+  };
+  const removeProcessExitCleanup = (): void => {
+    if (!processExitCleanupRegistered) return;
+    process.off("exit", cleanupOnProcessExit);
+    processExitCleanupRegistered = false;
+  };
+  installProcessExitCleanup();
 
-  async function sendWake(message: string): Promise<void> {
+  async function sendWake(message: string, generation: number): Promise<void> {
+    if (!sessionIsActive(generation)) return;
     await pi.sendUserMessage(
       `FIRSTMATE WATCHER WAKE: ${message}\n\nRun bin/fm-wake-drain.sh first and handle the queued wake. Watcher continuity is extension-owned.`,
       { deliverAs: "followUp" },
     );
   }
 
-  function surfaceFailure(message: string): void {
-    void sendWake(message).catch(() => {
+  function surfaceFailure(message: string, generation: number): void {
+    void sendWake(message, generation).catch(() => {
       // Pi owns delivery errors; continuity restoration never waits on prompting.
     });
   }
@@ -190,10 +224,10 @@ export default function (pi: ExtensionAPI) {
     });
   }
 
-  async function restoreAfterActionableClose(predecessorArmPid: string): Promise<string> {
+  async function restoreAfterActionableClose(predecessorArmPid: string, generation: number): Promise<string> {
     let failure = "";
     for (let attempt = 0; attempt <= retryLimit; attempt += 1) {
-      if (stopping) return "";
+      if (!sessionIsActive(generation)) return "";
       const replacement = startArm(predecessorArmPid);
       const successorChild = child;
       if (replacement.ok && successorChild && await waitForReadiness(successorChild)) return "";
@@ -214,23 +248,24 @@ export default function (pi: ExtensionAPI) {
     return `${failure}\nwatcher: FAILED - Pi extension could not restore watcher continuity after ${retryLimit} retries`;
   }
 
-  function scheduleRetry(message: string, predecessorArmPid: string): void {
-    if (stopping || child || retryTimer) return;
+  function scheduleRetry(message: string, predecessorArmPid: string, generation: number): void {
+    if (!sessionIsActive(generation) || child || retryTimer) return;
     const ownership = lockOwnership();
     if (ownership !== "owned") {
-      surfaceFailure(`watcher: FAILED - Pi extension cannot restore continuity because this session no longer owns the lock\n${message}`);
+      surfaceFailure(`watcher: FAILED - Pi extension cannot restore continuity because this session no longer owns the lock\n${message}`, generation);
       return;
     }
     retryFailures += 1;
     if (retryFailures > retryLimit) {
-      surfaceFailure(`watcher: FAILED - Pi extension could not restore watcher continuity after ${retryLimit} retries\n${message}`);
+      surfaceFailure(`watcher: FAILED - Pi extension could not restore watcher continuity after ${retryLimit} retries\n${message}`, generation);
       return;
     }
     const timer = setTimeout(() => {
       if (retryTimer === timer) retryTimer = null;
+      if (!sessionIsActive(generation)) return;
       const result = startArm(predecessorArmPid);
       if (!result.ok) {
-        surfaceFailure(`watcher: FAILED - Pi extension could not launch a continuity retry\n${result.message}`);
+        surfaceFailure(`watcher: FAILED - Pi extension could not launch a continuity retry\n${result.message}`, generation);
       }
     }, retryDelay(retryFailures));
     timer.unref();
@@ -251,6 +286,7 @@ export default function (pi: ExtensionAPI) {
     if (child) return { ok: true, message: "watcher: healthy - Pi extension already has an arm child" };
     if (retryTimer) return { ok: true, message: "watcher: continuity retry already scheduled by the Pi extension" };
     const id = ++seq;
+    const generation = sessionGeneration;
     const env = {
       ...process.env,
       FM_HOME: fmHome,
@@ -306,24 +342,28 @@ export default function (pi: ExtensionAPI) {
       resolveClosed();
       settleReadiness(false);
       releaseChild();
-      if (stopping) return;
+      if (!sessionIsActive(generation)) return;
       const classification = classifyClose(stdout, stderr, code, signal);
       const predecessor = String(armChild.pid ?? "");
       if (classification.kind === "actionable") {
         retryFailures = 0;
-        restoring = true;
+        const restoration: ActiveRestoration = { generation, token: ++restorationSequence };
+        activeRestoration = restoration;
         void (async () => {
-          const failure = await restoreAfterActionableClose(predecessor);
-          restoring = false;
-          if (stopping) return;
-          const message = failure ? `${classification.message}\n\n${failure}` : classification.message;
-          await sendWake(message);
+          try {
+            const failure = await restoreAfterActionableClose(predecessor, generation);
+            if (!sessionIsActive(generation)) return;
+            const message = failure ? `${classification.message}\n\n${failure}` : classification.message;
+            await sendWake(message, generation);
+          } finally {
+            if (activeRestoration?.token === restoration.token) activeRestoration = null;
+          }
         })().catch(() => {
         });
         return;
       }
-      if (restoring) return;
-      scheduleRetry(classification.message, predecessor);
+      if (activeRestoration?.generation === generation) return;
+      scheduleRetry(classification.message, predecessor, generation);
     });
     armChild.on("error", (error: Error) => {
       if (settled) return;
@@ -331,19 +371,28 @@ export default function (pi: ExtensionAPI) {
       resolveClosed();
       settleReadiness(false);
       releaseChild();
-      if (stopping) return;
-      if (restoring) return;
-      scheduleRetry(`watcher: FAILED - Pi extension arm child ${id} failed: ${error.message}`, String(armChild.pid ?? ""));
+      if (!sessionIsActive(generation)) return;
+      if (activeRestoration?.generation === generation) return;
+      scheduleRetry(`watcher: FAILED - Pi extension arm child ${id} failed: ${error.message}`, String(armChild.pid ?? ""), generation);
     });
     return { ok: true, message: `watcher: started Pi extension arm child ${id}` };
   }
 
-  pi.on?.("session_start", () => {
+  pi.on?.("session_start", (event) => {
+    const reason = sessionReplacementReason(event.reason);
+    if (reason && pendingSessionStart === reason) {
+      pendingSessionStart = null;
+      stopping = false;
+      retryFailures = 0;
+      activeRestoration = null;
+      installProcessExitCleanup();
+    }
     markLoaded();
   });
-  pi.on?.("session_shutdown", () => {
+  pi.on?.("session_shutdown", (event) => {
+    pendingSessionStart = sessionReplacementReason(event.reason);
     stopArm();
-    process.off("exit", cleanupOnProcessExit);
+    removeProcessExitCleanup();
   });
 
   pi.registerCommand?.("fm-watch-arm-pi", {

--- a/.pi/extensions/fm-primary-pi-watch.ts
+++ b/.pi/extensions/fm-primary-pi-watch.ts
@@ -378,9 +378,8 @@ export default function (pi: ExtensionAPI) {
     return { ok: true, message: `watcher: started Pi extension arm child ${id}` };
   }
 
-  pi.on?.("session_start", (event) => {
-    const reason = sessionReplacementReason(event.reason);
-    if (reason && pendingSessionStart === reason) {
+  pi.on?.("session_start", () => {
+    if (pendingSessionStart !== null) {
       pendingSessionStart = null;
       stopping = false;
       retryFailures = 0;

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1223,7 +1223,13 @@ META_WINDOW=$T
     echo "home=$PROJ_ABS"
     echo "projects=$SECONDMATE_PROJECTS"
   fi
-} > "$STATE/$ID.meta"
+} > "$STATE/$ID.meta" || {
+  # A redirection failure on this group command does not trip set -e (bash
+  # quirk), so fail closed explicitly. Exiting here keeps ORCA_ABORT_CLEANUP
+  # armed so the EXIT trap releases the orphaned terminal and worktree.
+  echo "fm-spawn: failed to write task metadata to $STATE/$ID.meta" >&2
+  exit 1
+}
 [ "$BACKEND" = orca ] && ORCA_ABORT_CLEANUP=0
 
 sq_brief=$(shell_quote "$BRIEF")

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -515,6 +515,19 @@ treehouse_return_is_index_lock_error() {
   printf '%s\n' "$text" | grep -Eq "Unable to create ['\"].*index\\.lock['\"]: File exists"
 }
 
+# A treehouse return that failed inside its own `git checkout` step, but which a
+# second return clears, is the same class of transient as the index.lock case:
+# treehouse terminates the visible worktree processes, then immediately checks
+# out the pool base, but the backend can respawn a shell (with a git-aware
+# prompt) into the just-vacated worktree in that window, racing the checkout.
+# Re-terminating on retry catches the respawn. (verified: fm-teardown herdr e2e
+# smokes, where the first return's checkout races the pane's respawned shell.)
+treehouse_return_is_retryable_transient() {
+  local text=$1
+  treehouse_return_is_index_lock_error "$text" && return 0
+  printf '%s\n' "$text" | grep -Eq "failed to return worktree: git checkout"
+}
+
 # Absolute path to the git index lock for a worktree/repo dir, or empty when it
 # cannot be resolved (dir missing or not a git worktree at all).
 worktree_git_lock_path() {
@@ -581,7 +594,7 @@ teardown_treehouse_return() {
   fi
   [ -n "$out" ] && printf '%s\n' "$out" >&2
 
-  if ! treehouse_return_is_index_lock_error "$out"; then
+  if ! treehouse_return_is_retryable_transient "$out"; then
     return 1
   fi
 
@@ -597,18 +610,18 @@ teardown_treehouse_return() {
 
   while [ "$attempt" -lt "$max_retries" ]; do
     attempt=$(( attempt + 1 ))
-    echo "teardown: $label return failed with transient git lock ($lock_desc); waiting ${TREEHOUSE_RETURN_LOCK_RETRY_WAIT_SECS}s and retrying ($attempt/${max_retries})" >&2
+    echo "teardown: $label return failed with a transient condition ($lock_desc / process race); waiting ${TREEHOUSE_RETURN_LOCK_RETRY_WAIT_SECS}s and retrying ($attempt/${max_retries})" >&2
     sleep "$TREEHOUSE_RETURN_LOCK_RETRY_WAIT_SECS"
 
     if out=$( ( cd "$cd_dir" && treehouse return --force "$dir" ) 2>&1 ); then
       [ -n "$out" ] && printf '%s\n' "$out"
-      echo "teardown: $label return succeeded on retry; lock cleared on its own" >&2
+      echo "teardown: $label return succeeded on retry; transient condition cleared" >&2
       return 0
     fi
     [ -n "$out" ] && printf '%s\n' "$out" >&2
 
-    if ! treehouse_return_is_index_lock_error "$out"; then
-      echo "teardown: $label return failed with a non-lock error after retry; aborting" >&2
+    if ! treehouse_return_is_retryable_transient "$out"; then
+      echo "teardown: $label return failed with a non-transient error after retry; aborting" >&2
       return 1
     fi
   done

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -410,7 +410,7 @@ FM_WATCH_TRIAGE_LOG_MAX_BYTES=262144   # size cap for the watcher's absorbed-wak
 FM_FLEET_SYNC_BOOTSTRAP_TIMEOUT=     # optional seconds allowed for bootstrap's best-effort clone refresh; unset/blank defaults to max(20, 5 + 3 * origin-backed-project-count)
 FM_FLEET_PRUNE=1        # set to 0 to skip pruning local branches whose upstream is gone
 FM_STALE_WORKTREE_LOCK_AGE_SECS=30       # min mtime age before fm-teardown.sh treats a leftover worktree git index.lock as provably stale
-FM_TREEHOUSE_RETURN_LOCK_RETRIES=3        # retries after a treehouse return fails on the transient git index.lock signature
+FM_TREEHOUSE_RETURN_LOCK_RETRIES=3        # retries after a treehouse return fails on a transient signature (git index.lock, or a git-checkout worktree respawn race)
 FM_TREEHOUSE_RETURN_LOCK_RETRY_WAIT_SECS=1 # seconds fm-teardown.sh waits before each retry after that signature
 FM_STALE_WORKTREE_LOCK_RETRY_WAIT_SECS=   # legacy alias for FM_TREEHOUSE_RETURN_LOCK_RETRY_WAIT_SECS when the new variable is unset
 FM_FLEET_SYNC_PACKED_REFS_LOCK_RETRIES=3        # fetch retries after fm-fleet-sync.sh hits the orphaned .git/packed-refs.lock signature
@@ -445,7 +445,7 @@ FM_LOG_MAX_BYTES=1048576           # daemon log size that triggers trimming
 FM_LOG_KEEP_LINES=2000             # daemon log lines kept when trimming
 ```
 
-`fm-teardown.sh` retries only Git's `Unable to create '...index.lock': File exists` return failure up to `FM_TREEHOUSE_RETURN_LOCK_RETRIES` times.
+`fm-teardown.sh` retries only transient `treehouse return` failures - Git's `Unable to create '...index.lock': File exists`, or a `failed to return worktree: git checkout` race where the backend respawned a shell into the just-vacated worktree during the checkout - up to `FM_TREEHOUSE_RETURN_LOCK_RETRIES` times, since re-terminating on retry clears the respawn.
 `FM_TREEHOUSE_RETURN_LOCK_RETRIES` accepts a nonnegative integer, and an unset, blank, or invalid value uses the default of 3.
 `FM_TREEHOUSE_RETURN_LOCK_RETRY_WAIT_SECS` accepts nonnegative whole or fractional seconds between attempts.
 When it is unset or blank, `FM_STALE_WORKTREE_LOCK_RETRY_WAIT_SECS` remains a compatible fallback, and a blank fallback uses the 1-second default.

--- a/docs/supervision-protocols/pi.md
+++ b/docs/supervision-protocols/pi.md
@@ -8,11 +8,13 @@ When this session owns supervision and away mode is not active:
    Never run `bin/fm-watch-arm.sh` through Pi's bash tool because that foreground arm can wedge the agent and bypasses extension-owned cleanup.
 4. If the extension says no live session holds the lock, run `bin/fm-session-start.sh` to reclaim the session lock, then call `fm_watch_arm_pi` again.
 5. The extension starts `bin/fm-watch-arm.sh --restart`, keeps the child attached to the live Pi process, and owns every later successor launch.
-6. After an actionable child close, the extension rechecks session-lock ownership and verifies one successor before it delivers the follow-up wake; its bounded fallback is defined in `docs/watcher-continuity.md`.
-7. Ordinary wake: do not call `fm_watch_arm_pi` again because continuity is extension-owned rather than model-memory-owned.
-8. An unexpected child close enters bounded exponential retry, and an exhausted retry or lost session lock is surfaced as a watcher failure instead of disappearing.
-9. Failure or missing cycle only: if the extension reports a watcher failure, drain queued wakes, inspect the failure text, call `fm_watch_arm_pi`, and restart Pi with both extensions loaded if needed.
-10. Never use shell `&` for watcher supervision.
+6. On `/new`, `/resume`, `/fork`, or `/reload`, `session_shutdown` invalidates the old logical session, cancels its retry state, and signals its child to stop before the matching `session_start` restores clean arm state and one process-exit cleanup listener.
+   A real `quit` or process exit never creates that pending replacement, so a late callback cannot restart supervision during shutdown.
+7. After an actionable child close, the extension rechecks session-lock ownership and verifies one successor before it delivers the follow-up wake; its bounded fallback is defined in `docs/watcher-continuity.md`.
+8. Ordinary wake: do not call `fm_watch_arm_pi` again because continuity is extension-owned rather than model-memory-owned.
+9. An unexpected child close enters bounded exponential retry, and an exhausted retry or lost session lock is surfaced as a watcher failure instead of disappearing.
+10. Failure or missing cycle only: if the extension reports a watcher failure, drain queued wakes, inspect the failure text, call `fm_watch_arm_pi`, and restart Pi with both extensions loaded if needed.
+11. Never use shell `&` for watcher supervision.
    The arm mechanism above is extension-owned, not a model tool call, but a manual recovery probe that backgrounds, pipes, or bundles the arm is denied automatically by the PreToolUse seatbelt (`bin/fm-arm-pretool-check.sh`, wired into the turn-end guard extension at `__FM_PI_TURNEND_EXT__`).
 
 The turn-end guard extension lives at `__FM_PI_TURNEND_EXT__`.
@@ -35,3 +37,13 @@ The isolated live test copied no credential material and created no account.
 The model called `fm_watch_arm_pi` exactly once, an actionable status closed that cycle, the extension ledger-linked a verified successor before the handling turn ended, the turn-end guard never fired, and `/quit` cleaned up both child processes.
 Command: `FM_PI_LIVE_E2E=1 tests/fm-pi-primary-live-e2e.test.sh`.
 Observed output: `ok - Pi 0.80.10 live E2E used shared Codex auth, auto-started one successor before turn end, and cleaned up`.
+
+Logical-session replacement verification on 2026-07-20 used Pi 0.80.10, an isolated `PI_CODING_AGENT_DIR`, an isolated `FM_HOME`, and a unique tmux socket.
+The launch shape was `env PI_CODING_AGENT_DIR="$LAB/pi-agent" FM_HOME="$LAB/fmhome" FM_ROOT_OVERRIDE="$LAB/project" pi --offline --approve --no-session --no-context-files --no-extensions --no-skills --no-prompt-templates -e .pi/extensions/fm-primary-turnend-guard.ts -e .pi/extensions/fm-primary-pi-watch.ts`.
+The interactive sequence was `/fm-watch-arm-pi`, `/new`, `/fm-watch-arm-pi`, `/new`, `/fm-watch-arm-pi`, and `/quit`.
+Before the fix, the second arm rendered `Warning: watcher: not armed - Pi session is shutting down` even though Pi had rendered `New session started`.
+After the fix, each old arm and watcher exited with ledger reason `arm-interrupted`, each new watcher published a new identity-matched lock PID and fresh readiness beacon, and the final `/quit` left no arm or watcher child alive.
+Command: `FM_PI_SESSION_LIVE_E2E=1 tests/fm-pi-primary-live-e2e.test.sh`.
+Observed output: `ok - Pi 0.80.10 isolated live E2E re-armed after two /new commands and cleaned up on exit`.
+Command: `tests/fm-pi-watch-extension.test.sh`.
+Relevant observed output: `ok - Pi session replacement resets supervision while real shutdown stays terminal`.

--- a/tests/fm-pi-primary-live-e2e.test.sh
+++ b/tests/fm-pi-primary-live-e2e.test.sh
@@ -1,12 +1,18 @@
 #!/usr/bin/env bash
-# Opt-in credentialed Pi continuity regression on a private tmux socket and
-# isolated project/home state. It uses the existing shared Pi auth store without
-# copying credentials and pins the captain-approved openai-codex model.
+# Opt-in Pi regressions on a private tmux socket and isolated project/home state.
+# FM_PI_SESSION_LIVE_E2E needs no credentials and isolates Pi's config while it
+# exercises logical session replacement. FM_PI_LIVE_E2E additionally uses the
+# existing shared Pi auth store for the model-driven continuity path.
 set -u
 
+SESSION_ONLY=0
 if [ "${FM_PI_LIVE_E2E:-0}" != 1 ]; then
-  echo "skip: set FM_PI_LIVE_E2E=1 to run the isolated interactive Pi regression"
-  exit 0
+  if [ "${FM_PI_SESSION_LIVE_E2E:-0}" = 1 ]; then
+    SESSION_ONLY=1
+  else
+    echo "skip: set FM_PI_SESSION_LIVE_E2E=1 or FM_PI_LIVE_E2E=1 to run an isolated interactive Pi regression"
+    exit 0
+  fi
 fi
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -20,12 +26,14 @@ command -v pi >/dev/null 2>&1 || fail "pi not found"
 command -v tmux >/dev/null 2>&1 || fail "tmux not found"
 
 TMUX=$(command -v tmux)
+PI_BIN=$(command -v pi)
 SOCKET="fm-pi-live-e2e-$$"
 SESSION=pi-live-e2e
 LAB="$ROOT/.pi-live-e2e.$$"
 PROJECT="$LAB/project"
 HOME_DIR="$LAB/fmhome"
-PI_VERSION=$(pi --version)
+PI_AGENT_DIR="$LAB/pi-agent"
+PI_VERSION=$("$PI_BIN" --version)
 
 capture() {
   "$TMUX" -L "$SOCKET" capture-pane -p -t "$SESSION" -S -600 2>/dev/null || true
@@ -68,10 +76,10 @@ lab_pid_is_safe() {
 
 cleanup() {
   local pid_file watcher_pid arm_pid
-  pid_file=$(find "$HOME_DIR/state" -maxdepth 3 -type f -name pid 2>/dev/null | head -1 || true)
+  pid_file="$HOME_DIR/state/.watch.lock/pid"
   watcher_pid=
   arm_pid=
-  if [ -n "$pid_file" ]; then
+  if [ -f "$pid_file" ]; then
     watcher_pid=$(sed -n '1p' "$pid_file" 2>/dev/null || true)
     arm_pid=$(ps -p "$watcher_pid" -o ppid= 2>/dev/null | tr -d ' ' || true)
   fi
@@ -103,6 +111,25 @@ wait_pid_dead() {
   return 1
 }
 
+wait_for_ready_watcher() {
+  local previous_pid=${1:-} i=0 candidate
+  while [ "$i" -lt 100 ]; do
+    candidate=$(FM_HOME="$HOME_DIR" FM_ROOT_OVERRIDE="$PROJECT" FM_GUARD_GRACE=300 bash -c '
+      . "$FM_ROOT_OVERRIDE/bin/fm-wake-lib.sh"
+      if fm_watcher_healthy "$FM_HOME/state" "$FM_ROOT_OVERRIDE/bin/fm-watch.sh" "$FM_GUARD_GRACE" "$FM_HOME"; then
+        printf "%s\n" "$FM_WATCHER_HEALTHY_PID"
+      fi
+    ')
+    if [ -n "$candidate" ] && [ "$candidate" != "$previous_pid" ]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+    sleep 0.1
+    i=$((i + 1))
+  done
+  return 1
+}
+
 mkdir -p "$LAB"
 git clone -q "$ROOT" "$PROJECT"
 cp "$ROOT/.pi/extensions/fm-primary-pi-watch.ts" "$PROJECT/.pi/extensions/fm-primary-pi-watch.ts"
@@ -111,8 +138,14 @@ cp "$ROOT/bin/fm-watch-arm.sh" "$PROJECT/bin/fm-watch-arm.sh"
 cp "$ROOT/bin/fm-supervision-instructions.sh" "$PROJECT/bin/fm-supervision-instructions.sh"
 mkdir -p "$HOME_DIR/state" "$HOME_DIR/config"
 
-"$TMUX" -L "$SOCKET" new-session -d -s "$SESSION" -c "$PROJECT" \
-  "env FM_HOME='$HOME_DIR' FM_ROOT_OVERRIDE='$PROJECT' FM_POLL=1 FM_SIGNAL_GRACE=0 FM_HEARTBEAT=600 bash -lc 'printf \"%s\\n\" \"\$\$\" > \"\$FM_HOME/state/.lock\"; pi --approve --no-session --no-context-files --no-extensions -e .pi/extensions/fm-primary-turnend-guard.ts -e .pi/extensions/fm-primary-pi-watch.ts --model openai-codex/gpt-5.6-sol --thinking low; rc=\$?; printf \"PI_EXIT=%s\\n\" \"\$rc\"; sleep 300'"
+if [ "$SESSION_ONLY" -eq 1 ]; then
+  mkdir -p "$PI_AGENT_DIR"
+  "$TMUX" -L "$SOCKET" new-session -d -s "$SESSION" -c "$PROJECT" \
+    "env PI_CODING_AGENT_DIR='$PI_AGENT_DIR' FM_HOME='$HOME_DIR' FM_ROOT_OVERRIDE='$PROJECT' FM_POLL=1 FM_SIGNAL_GRACE=0 FM_HEARTBEAT=600 bash -c 'printf \"%s\\n\" \"\$\$\" > \"\$FM_HOME/state/.lock\"; \"$PI_BIN\" --offline --approve --no-session --no-context-files --no-extensions --no-skills --no-prompt-templates -e .pi/extensions/fm-primary-turnend-guard.ts -e .pi/extensions/fm-primary-pi-watch.ts; rc=\$?; printf \"PI_EXIT=%s\\n\" \"\$rc\"; sleep 10'"
+else
+  "$TMUX" -L "$SOCKET" new-session -d -s "$SESSION" -c "$PROJECT" \
+    "env FM_HOME='$HOME_DIR' FM_ROOT_OVERRIDE='$PROJECT' FM_POLL=1 FM_SIGNAL_GRACE=0 FM_HEARTBEAT=600 bash -c 'printf \"%s\\n\" \"\$\$\" > \"\$FM_HOME/state/.lock\"; \"$PI_BIN\" --approve --no-session --no-context-files --no-extensions -e .pi/extensions/fm-primary-turnend-guard.ts -e .pi/extensions/fm-primary-pi-watch.ts --model openai-codex/gpt-5.6-sol --thinking low; rc=\$?; printf \"PI_EXIT=%s\\n\" \"\$rc\"; sleep 300'"
+fi
 
 i=0
 while [ "$i" -lt 120 ]; do
@@ -122,6 +155,49 @@ while [ "$i" -lt 120 ]; do
 done
 [ -f "$HOME_DIR/state/.pi-turnend-extension-loaded" ] || fail "Pi turn-end extension did not load"
 [ -f "$HOME_DIR/state/.pi-watch-extension-loaded" ] || fail "Pi watcher extension did not load"
+if [ "$SESSION_ONLY" -eq 1 ]; then
+  wait_for_text "No models available" 120 || fail "isolated Pi did not reach its ready composer"
+  sleep 1
+
+  : > "$HOME_DIR/state/pi-session-e2e.meta"
+  "$TMUX" -L "$SOCKET" send-keys -t "$SESSION" -l '/fm-watch-arm-pi'
+  "$TMUX" -L "$SOCKET" send-keys -t "$SESSION" Enter
+  wait_for_text "watcher: started Pi extension arm child 1" 60 || fail "initial logical session did not arm supervision"
+  watcher_pid=$(wait_for_ready_watcher) || fail "initial logical session did not establish a healthy watcher"
+  arm_pid=$(ps -p "$watcher_pid" -o ppid= | tr -d ' ')
+  [ -n "$arm_pid" ] || fail "initial logical session watcher parent was not live"
+
+  for expected_arm in 2 3; do
+    previous_watcher_pid=$watcher_pid
+    previous_arm_pid=$arm_pid
+    "$TMUX" -L "$SOCKET" send-keys -t "$SESSION" -l '/new'
+    "$TMUX" -L "$SOCKET" send-keys -t "$SESSION" Enter
+    wait_for_text "New session started" 60 || fail "Pi did not start replacement logical session $expected_arm"
+    wait_pid_dead "$previous_watcher_pid" || fail "watcher child survived logical session replacement $expected_arm"
+    wait_pid_dead "$previous_arm_pid" || fail "arm child survived logical session replacement $expected_arm"
+    interrupted_count=$(grep -c $'reason=arm-interrupted\t' "$HOME_DIR/state/.watch-cycle-exits.log" 2>/dev/null || true)
+    [ "$interrupted_count" -ge "$((expected_arm - 1))" ] \
+      || fail "logical session replacement $expected_arm did not record an interrupted arm close"
+
+    "$TMUX" -L "$SOCKET" send-keys -t "$SESSION" -l '/fm-watch-arm-pi'
+    "$TMUX" -L "$SOCKET" send-keys -t "$SESSION" Enter
+    wait_for_text "watcher: started Pi extension arm child $expected_arm" 60 \
+      || fail "Pi logical session $expected_arm did not arm supervision"
+    watcher_pid=$(wait_for_ready_watcher "$previous_watcher_pid") \
+      || fail "Pi logical session $expected_arm did not establish a new healthy watcher"
+    arm_pid=$(ps -p "$watcher_pid" -o ppid= | tr -d ' ')
+    [ -n "$arm_pid" ] || fail "Pi logical session $expected_arm watcher parent was not live"
+  done
+
+  "$TMUX" -L "$SOCKET" send-keys -t "$SESSION" -l '/quit'
+  "$TMUX" -L "$SOCKET" send-keys -t "$SESSION" Enter
+  wait_for_text "PI_EXIT=0" 60 || fail "Pi did not exit cleanly after logical session replacements"
+  wait_pid_dead "$watcher_pid" || fail "watcher child survived clean Pi exit"
+  wait_pid_dead "$arm_pid" || fail "arm child survived clean Pi exit"
+  printf 'ok - Pi %s isolated live E2E re-armed after two /new commands and cleaned up on exit\n' "$PI_VERSION"
+  exit 0
+fi
+
 wait_for_text "(openai-codex)" 120 || fail "Pi did not reach its ready composer"
 sleep 1
 
@@ -150,9 +226,7 @@ fi
 arm_tool_count=$(printf '%s\n' "$pane" | grep -Fc 'started Pi extension arm child' || true)
 [ "$arm_tool_count" -eq 1 ] || fail "Pi model re-armed from memory instead of the extension (tool-result count $arm_tool_count)"
 
-pid_file=$(find "$HOME_DIR/state" -maxdepth 3 -type f -name pid | head -1)
-[ -n "$pid_file" ] || fail "re-armed watcher pid was not recorded"
-watcher_pid=$(sed -n '1p' "$pid_file")
+watcher_pid=$(wait_for_ready_watcher) || fail "re-armed watcher was not healthy"
 arm_pid=$(ps -p "$watcher_pid" -o ppid= | tr -d ' ')
 [ -n "$arm_pid" ] || fail "re-armed watcher parent was not live"
 

--- a/tests/fm-pi-watch-extension.test.sh
+++ b/tests/fm-pi-watch-extension.test.sh
@@ -835,8 +835,13 @@ if (process.listenerCount("exit") !== before + 1) {
 await handlers.get("session_start")?.({ type: "session_start", reason: "startup" }, {});
 await arm(1);
 
+const replacementReasons = [
+  { shutdown: "reload", start: "resume" },
+  { shutdown: "fork", start: "reload" },
+];
 for (let expectedCount = 2; expectedCount <= 3; expectedCount += 1) {
-  await handlers.get("session_shutdown")?.({ type: "session_shutdown", reason: "new" }, {});
+  const reasons = replacementReasons[expectedCount - 2];
+  await handlers.get("session_shutdown")?.({ type: "session_shutdown", reason: reasons.shutdown }, {});
   if (process.listenerCount("exit") !== before) {
     throw new Error("replaced logical session left its process-exit fallback installed");
   }
@@ -844,7 +849,7 @@ for (let expectedCount = 2; expectedCount <= 3; expectedCount += 1) {
   if (process.listenerCount("exit") !== before + 1) {
     throw new Error("replacement extension runtime did not reinstall one process-exit fallback");
   }
-  await handlers.get("session_start")?.({ type: "session_start", reason: "new" }, {});
+  await handlers.get("session_start")?.({ type: "session_start", reason: reasons.start }, {});
   if (process.listenerCount("exit") !== before + 1) {
     throw new Error("replacement logical session duplicated or removed its process-exit fallback");
   }

--- a/tests/fm-pi-watch-extension.test.sh
+++ b/tests/fm-pi-watch-extension.test.sh
@@ -762,6 +762,133 @@ EOF
   pass "Pi watcher arm distinguishes all session lock ownership states"
 }
 
+test_pi_session_replacement_restarts_runtime_without_process_restart() {
+  local repo home plugin log out status
+  repo="$TMP_ROOT/pi-session-replacement-root"
+  home="$TMP_ROOT/pi-session-replacement-home"
+  log="$TMP_ROOT/pi-session-replacement.log"
+  mkdir -p "$repo/bin" "$home/state" "$home/config"
+  install_pi_watch_extension_fixture "$repo"
+  plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
+  cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
+#!/usr/bin/env bash
+printf 'arm=%s\n' "$$" >> "${FM_ARM_LOG:?}"
+printf 'watcher: started pid=%s (beacon fresh)\n' "$$"
+trap 'exit 0' TERM INT
+while :; do sleep 0.02; done
+SH
+  chmod +x "$repo/bin/fm-watch-arm.sh"
+  out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" FM_ARM_LOG="$log" FM_WATCH_REARM_RETRY_BASE_MS=250 FM_WATCH_REARM_RETRY_MAX_MS=250 node --input-type=module 2>&1 <<'EOF'
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const handlers = new Map();
+let armCommand = null;
+let notification = "";
+const pi = {
+  on(event, handler) {
+    handlers.set(event, handler);
+  },
+  registerCommand(name, options) {
+    if (name === "fm-watch-arm-pi") armCommand = options.handler;
+  },
+  registerTool() {},
+  sendUserMessage: async () => {},
+};
+const armRows = () => existsSync(process.env.FM_ARM_LOG)
+  ? readFileSync(process.env.FM_ARM_LOG, "utf8").trim().split("\n").filter(Boolean)
+  : [];
+async function waitForArmCount(expected) {
+  for (let i = 0; i < 250; i += 1) {
+    if (armRows().length >= expected) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`expected ${expected} arm children, got ${armRows().length}`);
+}
+async function arm(expectedCount) {
+  notification = "";
+  await armCommand("", {
+    ui: {
+      notify(message) {
+        notification = message;
+      },
+    },
+  });
+  if (!notification.includes("started Pi extension arm child")) {
+    throw new Error(`logical session ${expectedCount} did not arm: ${notification}`);
+  }
+  await waitForArmCount(expectedCount);
+  await new Promise((resolve) => setTimeout(resolve, 80));
+  if (armRows().length !== expectedCount) {
+    throw new Error(`stale logical session launched an extra arm: ${armRows().join(" | ")}`);
+  }
+}
+
+writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
+const before = process.listenerCount("exit");
+const mod = await import(pathToFileURL(process.env.PLUGIN).href);
+mod.default(pi);
+if (!armCommand) throw new Error("Pi watch command was not registered");
+if (process.listenerCount("exit") !== before + 1) {
+  throw new Error("initial logical session did not install one process-exit fallback");
+}
+await handlers.get("session_start")?.({ type: "session_start", reason: "startup" }, {});
+await arm(1);
+
+for (let expectedCount = 2; expectedCount <= 3; expectedCount += 1) {
+  await handlers.get("session_shutdown")?.({ type: "session_shutdown", reason: "new" }, {});
+  if (process.listenerCount("exit") !== before) {
+    throw new Error("replaced logical session left its process-exit fallback installed");
+  }
+  mod.default(pi);
+  if (process.listenerCount("exit") !== before + 1) {
+    throw new Error("replacement extension runtime did not reinstall one process-exit fallback");
+  }
+  await handlers.get("session_start")?.({ type: "session_start", reason: "new" }, {});
+  if (process.listenerCount("exit") !== before + 1) {
+    throw new Error("replacement logical session duplicated or removed its process-exit fallback");
+  }
+  await arm(expectedCount);
+  if (expectedCount === 2) {
+    const armPid = Number(armRows().at(-1)?.match(/^arm=([0-9]+)$/)?.[1] ?? 0);
+    if (!armPid) throw new Error(`could not read arm pid before retry-timer test: ${armRows().join(" | ")}`);
+    process.kill(armPid, "SIGTERM");
+    await new Promise((resolve) => setTimeout(resolve, 60));
+  }
+}
+await new Promise((resolve) => setTimeout(resolve, 300));
+if (armRows().length !== 3) {
+  throw new Error(`replaced logical session retry timer launched a stale arm: ${armRows().join(" | ")}`);
+}
+
+await handlers.get("session_shutdown")?.({ type: "session_shutdown", reason: "quit" }, {});
+if (process.listenerCount("exit") !== before) {
+  throw new Error("real shutdown left its process-exit fallback installed");
+}
+await handlers.get("session_start")?.({ type: "session_start", reason: "new" }, {});
+notification = "";
+await armCommand("", {
+  ui: {
+    notify(message) {
+      notification = message;
+    },
+  },
+});
+if (!notification.includes("Pi session is shutting down")) {
+  throw new Error(`real shutdown was resurrected by a later session_start: ${notification}`);
+}
+await new Promise((resolve) => setTimeout(resolve, 100));
+if (armRows().length !== 3) {
+  throw new Error(`real shutdown launched another arm: ${armRows().join(" | ")}`);
+}
+EOF
+)
+  status=$?
+  expect_code 0 "$status" "Pi session replacement must restart supervision state without resurrecting after real shutdown"
+  [ -z "$out" ] || fail "Pi session-replacement test printed output: $out"
+  pass "Pi session replacement resets supervision while real shutdown stays terminal"
+}
+
 test_pi_process_exit_cleanup_listener_lifecycle() {
   local repo home plugin out status
   repo="$TMP_ROOT/pi-exit-listener-root"
@@ -1836,6 +1963,7 @@ test_pi_empty_close_retries_instead_of_disappearing
 test_pi_established_empty_close_honors_retry_limit
 test_pi_actionable_close_rechecks_session_lock
 test_pi_arm_distinguishes_session_lock_ownership
+test_pi_session_replacement_restarts_runtime_without_process_restart
 test_pi_process_exit_cleanup_listener_lifecycle
 test_pi_process_exit_cleanup_stops_arm_child
 test_opencode_primary_watch_plugin_static_wiring


### PR DESCRIPTION
## Intent

Fix Firstmate's primary Pi supervision extension so Pi's `/new` command cleanly ends the prior logical session and supervision can be armed normally in the replacement session without restarting the Pi process. Reproduce the original `Pi session is shutting down` refusal with an isolated Pi configuration and `FM_HOME`, then make the `session_shutdown`/`session_start` lifecycle robust and idempotent across repeated `/new`, `/resume`, `/fork`, and `/reload` transitions. Stop old children, cancel retries, invalidate stale timers and callbacks, reinstall exactly one process-exit cleanup listener, and never resurrect supervision during a real quit or process shutdown. Treat any non-null pending replacement as sufficient proof of a logical-session replacement while preserving generation-safe stale-callback invalidation and terminal shutdown behavior. Add deterministic regression coverage, extend the existing isolated live Pi E2E with identity-matched watcher-lock and fresh-beacon readiness checks, validate strict Pi types and related tests, and record dated verification evidence without unrelated refactors.

## What Changed

eb4f28f no-mistakes(document): broaden teardown retry-class docs for git-checkout race
061f4d6 no-mistakes(test): fix orca meta-write fail-closed and treehouse return race retry
7d418e1 no-mistakes(review): gate watcher reset on pending replacement, not reason equality
c3a50fc fix(pi): reset watcher across logical sessions

## Risk Assessment

✅ Low: The change is a well-bounded, carefully-scoped concurrency fix that threads a session-generation guard through every async watcher callback, is type-safe against the pi SDK event contract, and is backed by documented live e2e verification, with no correctness or safety defects found.

## Testing

The configured baseline suite already ran green. On top of that I ran the isolated Pi live e2e (`FM_PI_SESSION_LIVE_E2E=1`), which exercises the actual feature as an end user hits it: a real Pi 0.81.0 process is driven through tmux to arm the watcher, replace its logical session twice with /new, re-arm after each, and quit — the test verifies the prior watcher/arm children are actually killed on each replacement, a fresh healthy watcher re-establishes (the exact behavior that previously failed with "watcher: not armed - Pi session is shutting down"), and nothing survives the real exit. It passed. I also ran the watch-extension unit suite (with its new session-replacement test) and the teardown suite, both green. This is a CLI/runtime supervision change with no rendered UI surface, so the reviewer-visible evidence is the live e2e transcript rather than a screenshot. Not separately covered by a dedicated test: the new "failed to return worktree: git checkout" transient predicate in fm-teardown.sh (its retry loop is exercised via the existing index.lock cases) and the orca meta-write fail-closed guard in fm-spawn.sh — both are small hardening branches, not the headline intent, so I did not add tests for them. Worktree left clean; no transient dirs remained.

<details>
<summary>Evidence: Pi session-replacement isolated live e2e result</summary>

`ok - Pi 0.81.0 isolated live E2E re-armed after two /new commands and cleaned up on exit`

```text
ok - Pi 0.81.0 isolated live E2E re-armed after two /new commands and cleaned up on exit
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- <code>`FM_PI_SESSION_LIVE_E2E=1 bash tests/fm-pi-primary-live-e2e.test.sh` — isolated, credential-free live regression: real Pi 0.81.0 in tmux ran /fm-watch-arm-pi, /new, /fm-watch-arm-pi, /new, /fm-watch-arm-pi, /quit; asserted each old watcher+arm PID dies on replacement, a new identity-matched healthy watcher re-arms, and no child survives clean exit</code>
- <code>`bash tests/fm-pi-watch-extension.test.sh` — includes new `test_pi_session_replacement_restarts_runtime_without_process_restart` covering generation/process-exit-listener lifecycle and no stale-arm resurrection</code>
- <code>`bash tests/fm-teardown.test.sh` — treehouse-return transient retry loop (index.lock path) and teardown safety</code>
- <code>`bash tests/fm-pi-primary-types.test.sh` via baseline suite</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
