### PR TITLE
fix: deduplicate authoritative terminal watcher alerts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,7 +103,7 @@ state/               volatile runtime signals; gitignored
   .wake-queue        durable queued wakes: epoch<TAB>seq<TAB>kind<TAB>key<TAB>payload
   .afk               durable away-mode flag; present = sub-supervisor may inject escalations (set by /afk, cleared on user return)
   .watch.lock .wake-queue.lock watcher singleton and queue serialization locks
-  .hash-* .count-* .stale-* .stale-since-* .paused-* .wedge-escalations-* .seen-* .hb-surfaced-* .last-* .heartbeat-streak   watcher internals; never touch
+  .hash-* .count-* .stale-* .stale-since-* .paused-* .terminal-* .wedge-escalations-* .seen-* .hb-surfaced-* .last-* .heartbeat-streak   watcher internals; never touch
   .watch-triage.log  watcher's absorbed-wake debug log (size-capped); never relied on, safe to delete
   .last-watcher-beat watcher liveness beacon, touched every poll (including while absorbing benign wakes); guard scripts read it
   .subsuper-* .supervise-daemon.*   sub-supervisor internals; never touch

--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -348,6 +348,28 @@ crew_absorb_class() {  # <id>
   printf 'none'
 }
 
+crew_terminal_transition_class() {  # <id>
+  local id=$1 line state src
+  [ -n "$id" ] || { printf 'unknown'; return; }
+  line=$("$FM_CREW_STATE_BIN" "$id" 2>/dev/null) || true
+  case "$line" in state:*) ;; *) printf 'unknown'; return ;; esac
+  state=${line#state: }; state=${state%% *}
+  src=${line#*source: }; src=${src%% *}
+  if [ "$src" = run-step ]; then
+    case "$state" in
+      done|failed) printf 'terminal' ;;
+      *) printf 'nonterminal' ;;
+    esac
+    return
+  fi
+  if { [ "$src" = pane ] && [ "$state" = working ]; } || \
+     { [ "$src" = status-log ] && [ "$state" = paused ]; }; then
+    printf 'nonterminal'
+    return
+  fi
+  printf 'unknown'
+}
+
 # 0 if crew <id> shows POSITIVE evidence it is still working (crew_absorb_class
 # reports `working`). This is the "provably working" predicate at the heart of
 # absorb-only-when-provably-working: a no-verb turn-end or stale wake is absorbed

--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Shared wake classifier: the common source of truth for captain-relevant status
-# tests, declared-external-wait vocabulary, and the working/paused absorb
-# classification that makes no-verb signal and stale-pane wakes safe to absorb.
+# tests, declared-external-wait vocabulary, and the working/paused/terminal
+# classification that makes no-verb signal and stale-pane triage deterministic.
 # Sourced by BOTH the always-on watcher
 # (bin/fm-watch.sh) and the away-mode daemon (bin/fm-supervise-daemon.sh) so the
 # overlapping triage policy lives in one place instead of two copies that can
@@ -13,13 +13,12 @@
 # daemon keeps its escalation-digest seen-markers; the watcher keeps its .seen-*
 # signatures).
 #
-# The one exception is the absorb classification (crew_absorb_class and its
+# The one exception is the current-state classification (crew_absorb_class and its
 # working/paused wrappers). It is NOT a pure status-file read: it reuses
 # bin/fm-crew-state.sh, which may make a bounded no-mistakes call, to decide
 # whether a crew that just stopped its turn or went stale is working, deliberately
-# paused, or neither. Callers run it ONLY on no-verb signal handling and first
-# sighting of a stale hash, never on every wake, so the per-wake triage stays
-# cheap.
+# paused, terminal, or neither. Callers limit it to no-verb signals and stale-state
+# reconciliation so ordinary wake triage stays cheap.
 
 # Directory of this library, used to locate the sibling fm-crew-state.sh reader.
 # Resolved at source time from BASH_SOURCE so it works whether sourced by a
@@ -323,8 +322,9 @@ signal_reason_is_actionable() {  # <file> ...
 #             (e.g. waiting on CI);
 #   paused  - the crew's authoritative current state is a declared external-wait
 #             pause (paused:), which is EXPECTED to idle;
-#   none    - neither, so the wake must surface (a stopped/finished/parked/failed/
-#             torn-down/unknown crew, or an unreadable verdict).
+#   terminal - an authoritative no-mistakes run-step is done or failed;
+#   none    - neither, so the wake must surface (a stopped/parked/torn-down/unknown
+#             crew, or an unreadable verdict).
 # One fm-crew-state.sh read serves BOTH absorb reasons at once. Reading the state
 # authoritatively (not the status log) is what keeps run-step precedence: a crew
 # that appended paused: but then STARTED a run reports working, never paused.
@@ -338,8 +338,11 @@ crew_absorb_class() {  # <id>
   case "$line" in state:*) ;; *) printf 'none'; return ;; esac
   state=${line#state: }; state=${state%% *}
   if [ "$state" = paused ]; then printf 'paused'; return; fi
+  src=${line#*source: }; src=${src%% *}
+  if [ "$src" = run-step ]; then
+    case "$state" in done|failed) printf 'terminal'; return ;; esac
+  fi
   if [ "$state" = working ]; then
-    src=${line#*source: }; src=${src%% *}
     case "$src" in run-step|pane) printf 'working'; return ;; esac
   fi
   printf 'none'
@@ -351,7 +354,7 @@ crew_absorb_class() {  # <id>
 # ONLY when this returns 0, and SURFACED otherwise (the crew may be done, waiting
 # on a decision, or wedged). For stale panes it is checked before trusting the
 # status log so a pre-validation captain-relevant line does not override an active
-# run. See crew_absorb_class for the exact working/paused/none decision.
+# run. See crew_absorb_class for the exact working/paused/terminal/none decision.
 crew_is_provably_working() {  # <id>
   [ "$(crew_absorb_class "$1")" = working ]
 }

--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -329,7 +329,8 @@ signal_reason_is_actionable() {  # <file> ...
 # authoritatively (not the status log) is what keeps run-step precedence: a crew
 # that appended paused: but then STARTED a run reports working, never paused.
 # NOT a pure read: fm-crew-state.sh may make a bounded no-mistakes call, so callers
-# run it only on no-verb signal and first-sighting stale paths, never every wake.
+# run it only when a no-verb signal or stale transition needs authoritative
+# reconciliation, never for ordinary wake scanning.
 # FM_CREW_STATE_BIN lets tests stub the verdict.
 crew_absorb_class() {  # <id>
   local id=$1 line state src

--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -362,11 +362,6 @@ crew_terminal_transition_class() {  # <id>
     esac
     return
   fi
-  if { [ "$src" = pane ] && [ "$state" = working ]; } || \
-     { [ "$src" = status-log ] && [ "$state" = paused ]; }; then
-    printf 'nonterminal'
-    return
-  fi
   printf 'unknown'
 }
 

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1185,7 +1185,7 @@ fi
 
 META_WINDOW=$T
 [ "$BACKEND" = orca ] && META_WINDOW=$W
-{
+if {
   echo "window=$META_WINDOW"
   echo "worktree=$WT"
   echo "project=$PROJ_ABS"
@@ -1223,7 +1223,11 @@ META_WINDOW=$T
     echo "home=$PROJ_ABS"
     echo "projects=$SECONDMATE_PROJECTS"
   fi
-} > "$STATE/$ID.meta"
+} > "$STATE/$ID.meta"; then
+  :
+else
+  exit 1
+fi
 [ "$BACKEND" = orca ] && ORCA_ABORT_CLEANUP=0
 
 sq_brief=$(shell_quote "$BRIEF")

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -1009,7 +1009,7 @@ EOF
                          printf '%s' "$h" > "$sf"
                          wedge_timer_check "$w" "$ssf" "non-terminal stale (provably working after a declared pause)" "$ewf"
                          triage_log "absorbed non-terminal stale (provably working): $w" ;;
-                terminal) if [ -e "$pf" ]; then
+                terminal) if [ -e "$pf" ] || [ -e "$ssf" ]; then
                             surface_terminal_stale "$w" "$h"
                           else
                             clear_pause_state "$w"

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -324,18 +324,38 @@ terminal_transition_is_surfaced() {  # <window>
   [ -e "$STATE/.terminal-transition-$key" ]
 }
 
-refresh_terminal_transition() {  # <window> <task> <force>
-  local win=$1 task=$2 force=$3 key recheck_file class
+clear_terminal_transition() {  # <window>
+  local win=$1 key
+  key=$(printf '%s' "$win" | tr ':/.' '___')
+  rm -f "$STATE/.terminal-transition-$key" "$STATE/.terminal-rechecked-$key" \
+    "$STATE/.terminal-unknown-$key" "$STATE/.stale-$key" "$STATE/.stale-class-$key" \
+    "$STATE/.stale-since-$key" "$STATE/.wedge-escalations-$key"
+}
+
+refresh_terminal_transition() {  # <window> <task> <force> <busy>
+  local win=$1 task=$2 force=$3 busy=$4 key recheck_file unknown_file class
   key=$(printf '%s' "$win" | tr ':/.' '___')
   [ -e "$STATE/.terminal-transition-$key" ] || return 0
+  if [ "$busy" = 1 ]; then
+    clear_terminal_transition "$win"
+    return
+  fi
   recheck_file="$STATE/.terminal-rechecked-$key"
+  unknown_file="$STATE/.terminal-unknown-$key"
   [ "$force" = 1 ] || [ "$(age_of "$recheck_file")" -ge "$TERMINAL_RECHECK_SECS" ] || return 0
   class=$(crew_terminal_transition_class "$task")
   date +%s > "$recheck_file"
-  if [ "$class" = nonterminal ]; then
-    rm -f "$STATE/.terminal-transition-$key" "$STATE/.stale-$key" "$STATE/.stale-class-$key" \
-      "$STATE/.stale-since-$key" "$STATE/.wedge-escalations-$key" "$recheck_file"
-  fi
+  case "$class" in
+    terminal) rm -f "$unknown_file" ;;
+    nonterminal) clear_terminal_transition "$win" ;;
+    unknown)
+      if [ -e "$unknown_file" ] && [ "$(age_of "$unknown_file")" -ge "$TERMINAL_RECHECK_SECS" ]; then
+        clear_terminal_transition "$win"
+      else
+        [ -e "$unknown_file" ] || date +%s > "$unknown_file"
+      fi
+      ;;
+  esac
 }
 
 # Absorb a stale pane under a declared external-wait pause (paused:) or a
@@ -957,10 +977,14 @@ EOF
     ewf="$STATE/.wedge-escalations-$key"
     pf="$STATE/.paused-$key"   # flag: this key's stale is using the bounded pause cadence
     prev=$(cat "$hf" 2>/dev/null || true)
-    if ! afk_present && [ "$kind" != secondmate ]; then
+    terminal_busy_checked=0
+    terminal_busy=0
+    if ! afk_present && [ "$kind" != secondmate ] && terminal_transition_is_surfaced "$w"; then
+      terminal_busy_checked=1
+      window_is_busy "$w" "$tail40" && terminal_busy=1
       terminal_refresh_force=0
-      [ "$h" = "$prev" ] || terminal_refresh_force=1
-      refresh_terminal_transition "$w" "$task" "$terminal_refresh_force"
+      if [ "$h" != "$prev" ] || [ "$terminal_busy" = 1 ]; then terminal_refresh_force=1; fi
+      refresh_terminal_transition "$w" "$task" "$terminal_refresh_force" "$terminal_busy"
     fi
     if [ "$h" = "$prev" ]; then
       n=$(( $(cat "$cf" 2>/dev/null || echo 0) + 1 ))
@@ -969,7 +993,11 @@ EOF
       # else the last 6 non-blank lines only (the TUI footer area, where every
       # verified harness renders its busy indicator) so busy-looking strings
       # in displayed content cannot suppress stale detection.
-      if [ "$n" -ge 2 ] && ! window_is_busy "$w" "$tail40"; then
+      if [ "$n" -ge 2 ]; then
+        if [ "$terminal_busy_checked" = 0 ]; then
+          window_is_busy "$w" "$tail40" && terminal_busy=1
+        fi
+        if [ "$terminal_busy" = 0 ]; then
         # The pane is idle/stale at hash $h. Triage decides whether this wakes
         # firstmate. Detection itself is unchanged from above.
         if [ "$kind" = secondmate ]; then
@@ -1107,6 +1135,7 @@ EOF
             fi
           fi
         fi
+      fi
       else
         # Pane busy or not yet stably stale: reset pending escalation bookkeeping.
         rm -f "$ssf" "$ewf"

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -317,6 +317,22 @@ stale_class_is() {  # <window> <hash> <class>
   [ "$(cat "$STATE/.stale-class-$key" 2>/dev/null || true)" = "$class:$h" ]
 }
 
+terminal_transition_is_surfaced() {  # <window>
+  local win=$1 key
+  key=$(printf '%s' "$win" | tr ':/.' '___')
+  [ -e "$STATE/.terminal-transition-$key" ]
+}
+
+refresh_terminal_transition() {  # <window> <task>
+  local win=$1 task=$2 key
+  key=$(printf '%s' "$win" | tr ':/.' '___')
+  [ -e "$STATE/.terminal-transition-$key" ] || return 0
+  if [ "$(crew_terminal_transition_class "$task")" = nonterminal ]; then
+    rm -f "$STATE/.terminal-transition-$key" "$STATE/.stale-$key" "$STATE/.stale-class-$key" \
+      "$STATE/.stale-since-$key" "$STATE/.wedge-escalations-$key"
+  fi
+}
+
 # Absorb a stale pane under a declared external-wait pause (paused:) or a
 # dead-agent captain-held transfer, and re-surface it once every
 # PAUSE_RESURFACE_SECS for a recheck so it cannot rot invisibly. Called on any
@@ -417,14 +433,18 @@ pause_state_class() {  # <window> <task>
 }
 
 surface_terminal_stale() {  # <window> <hash>
-  local win=$1 h=$2 key
+  local win=$1 h=$2 key surfaced=0
   key=$(printf '%s' "$win" | tr ':/.' '___')
-  fm_wake_append stale "$win" "stale: $win" || exit 1
+  if ! terminal_transition_is_surfaced "$win"; then
+    fm_wake_append stale "$win" "stale: $win" || exit 1
+    : > "$STATE/.terminal-transition-$key"
+    surfaced=1
+  fi
   printf '%s' "$h" > "$STATE/.stale-$key"
   set_stale_class "$win" "$h" terminal
   rm -f "$STATE/.stale-since-$key" "$STATE/.wedge-escalations-$key"
   clear_pause_state "$win"
-  wake "stale: $win"
+  [ "$surfaced" -eq 0 ] || wake "stale: $win"
 }
 
 surface_nonterminal_stale() {  # <window> <hash>
@@ -911,6 +931,9 @@ EOF
       continue
     fi
     tail40=$(fm_backend_capture "$(window_backend "$w")" "$w" 40 "$(window_label "$w")" 2>/dev/null) || continue
+    if ! afk_present && [ "$kind" != secondmate ]; then
+      refresh_terminal_transition "$w" "$task"
+    fi
     h=$(printf '%s' "$tail40" | hash_pane)
     key=$(printf '%s' "$w" | tr ':/.' '___')
     hf="$STATE/.hash-$key"
@@ -958,20 +981,35 @@ EOF
           # line. On a NEW hash, give an active run/busy pane (the same
           # authoritative source fm-crew-state.sh itself already prioritizes
           # over the log) a chance to override before trusting the log.
-          if [ "$(cat "$sf" 2>/dev/null || true)" != "$h" ]; then
-            if crew_is_provably_working "$(window_to_task "$w" "$STATE")"; then
-              printf '%s' "$h" > "$sf"
-              set_stale_class "$w" "$h" working
-              date +%s > "$ssf"
-              triage_log "absorbed stale (provably working, overriding a stale captain-relevant status): $w"
-            else
+          if [ "$(cat "$sf" 2>/dev/null || true)" != "$h" ] || stale_class_is "$w" "$h" working; then
+            case "$(crew_absorb_class "$task")" in
+              working)
+                if stale_class_is "$w" "$h" working; then
+                  wedge_timer_check "$w" "$ssf" "stale (overridden terminal status)" "$ewf"
+                else
+                  printf '%s' "$h" > "$sf"
+                  set_stale_class "$w" "$h" working
+                  date +%s > "$ssf"
+                  triage_log "absorbed stale (provably working, overriding a stale captain-relevant status): $w"
+                fi
+                ;;
+              terminal)
+                surface_terminal_stale "$w" "$h"
+                ;;
+              paused)
+                handle_paused_stale "$w" "$task" "$h"
+                ;;
+              *)
               fm_wake_append stale "$w" "stale: $w" || exit 1
               printf '%s' "$h" > "$sf"
-              set_stale_class "$w" "$h" terminal
+              set_stale_class "$w" "$h" nonterminal
               rm -f "$ssf"
-              mark_surfaced "$STATE/$(window_to_task "$w" "$STATE").status"
+              mark_surfaced "$STATE/$task.status"
               wake "stale: $w"
-            fi
+                ;;
+            esac
+          elif stale_class_is "$w" "$h" terminal && terminal_transition_is_surfaced "$w"; then
+            rm -f "$ssf" "$ewf"
           elif [ -e "$ssf" ]; then
             # This exact hash was already overridden as provably-working (a
             # wedge timer is running for it) - keep treating it that way
@@ -1036,6 +1074,13 @@ EOF
                             rm -f "$ssf" "$ewf"
                           fi ;;
                 *)       handle_paused_stale "$w" "$task" "$h" ;;
+              esac
+            elif stale_class_is "$w" "$h" working; then
+              case "$(crew_absorb_class "$task")" in
+                terminal) surface_terminal_stale "$w" "$h" ;;
+                paused) handle_paused_stale "$w" "$task" "$h" ;;
+                working) wedge_timer_check "$w" "$ssf" "non-terminal stale" "$ewf" ;;
+                *) surface_nonterminal_stale "$w" "$h" ;;
               esac
             else
               wedge_timer_check "$w" "$ssf" "non-terminal stale" "$ewf"

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -305,6 +305,18 @@ wedge_timer_check() {  # <window> <since-file> <triage-label> <escalation-count-
   esac
 }
 
+set_stale_class() {  # <window> <hash> <class>
+  local win=$1 h=$2 class=$3 key
+  key=$(printf '%s' "$win" | tr ':/.' '___')
+  printf '%s:%s\n' "$class" "$h" > "$STATE/.stale-class-$key"
+}
+
+stale_class_is() {  # <window> <hash> <class>
+  local win=$1 h=$2 class=$3 key
+  key=$(printf '%s' "$win" | tr ':/.' '___')
+  [ "$(cat "$STATE/.stale-class-$key" 2>/dev/null || true)" = "$class:$h" ]
+}
+
 # Absorb a stale pane under a declared external-wait pause (paused:) or a
 # dead-agent captain-held transfer, and re-surface it once every
 # PAUSE_RESURFACE_SECS for a recheck so it cannot rot invisibly. Called on any
@@ -319,6 +331,7 @@ handle_paused_stale() {  # <window> <task> <hash>
   local win=$1 task=$2 h=$3 key statusf mtime age rf rf_age reason
   key=$(printf '%s' "$win" | tr ':/.' '___')
   printf '%s' "$h" > "$STATE/.stale-$key"
+  set_stale_class "$win" "$h" paused
   : > "$STATE/.paused-$key"
   rm -f "$STATE/.stale-since-$key" "$STATE/.wedge-escalations-$key"
   statusf="$STATE/$task.status"
@@ -350,7 +363,7 @@ clear_pause_tracking() {  # <window>
   key=${key//\//_}
   key=${key//./_}
   clear_pause_state "$win"
-  rm -f "$STATE/.stale-$key" "$STATE/.stale-since-$key" "$STATE/.wedge-escalations-$key"
+  rm -f "$STATE/.stale-$key" "$STATE/.stale-class-$key" "$STATE/.stale-since-$key" "$STATE/.wedge-escalations-$key"
 }
 
 # Reconcile a declared pause or captain-held status with authoritative crew state.
@@ -408,6 +421,7 @@ surface_terminal_stale() {  # <window> <hash>
   key=$(printf '%s' "$win" | tr ':/.' '___')
   fm_wake_append stale "$win" "stale: $win" || exit 1
   printf '%s' "$h" > "$STATE/.stale-$key"
+  set_stale_class "$win" "$h" terminal
   rm -f "$STATE/.stale-since-$key" "$STATE/.wedge-escalations-$key"
   clear_pause_state "$win"
   wake "stale: $win"
@@ -418,6 +432,7 @@ surface_nonterminal_stale() {  # <window> <hash>
   key=$(printf '%s' "$win" | tr ':/.' '___')
   fm_wake_append stale "$win" "stale: $win" || exit 1
   printf '%s' "$h" > "$STATE/.stale-$key"
+  set_stale_class "$win" "$h" nonterminal
   rm -f "$STATE/.stale-since-$key"
   task=$(window_to_task "$win" "$STATE")
   last=$(last_status_line "$STATE/$task.status")
@@ -901,6 +916,7 @@ EOF
     hf="$STATE/.hash-$key"
     cf="$STATE/.count-$key"
     sf="$STATE/.stale-$key"
+    scf="$STATE/.stale-class-$key"
     ssf="$STATE/.stale-since-$key"
     ewf="$STATE/.wedge-escalations-$key"
     pf="$STATE/.paused-$key"   # flag: this key's stale is using the bounded pause cadence
@@ -945,11 +961,13 @@ EOF
           if [ "$(cat "$sf" 2>/dev/null || true)" != "$h" ]; then
             if crew_is_provably_working "$(window_to_task "$w" "$STATE")"; then
               printf '%s' "$h" > "$sf"
+              set_stale_class "$w" "$h" working
               date +%s > "$ssf"
               triage_log "absorbed stale (provably working, overriding a stale captain-relevant status): $w"
             else
               fm_wake_append stale "$w" "stale: $w" || exit 1
               printf '%s' "$h" > "$sf"
+              set_stale_class "$w" "$h" terminal
               rm -f "$ssf"
               mark_surfaced "$STATE/$(window_to_task "$w" "$STATE").status"
               wake "stale: $w"
@@ -987,6 +1005,7 @@ EOF
               working)
                 clear_pause_tracking "$w"
                 printf '%s' "$h" > "$sf"
+                set_stale_class "$w" "$h" working
                 date +%s > "$ssf"
                 triage_log "absorbed non-terminal stale (provably working): $w"
                 ;;
@@ -1007,9 +1026,10 @@ EOF
                 paused)  handle_paused_stale "$w" "$task" "$h" ;;
                 working) clear_pause_state "$w"
                          printf '%s' "$h" > "$sf"
+                         set_stale_class "$w" "$h" working
                          wedge_timer_check "$w" "$ssf" "non-terminal stale (provably working after a declared pause)" "$ewf"
                          triage_log "absorbed non-terminal stale (provably working): $w" ;;
-                terminal) if [ -e "$pf" ] || [ -e "$ssf" ]; then
+                terminal) if ! stale_class_is "$w" "$h" terminal; then
                             surface_terminal_stale "$w" "$h"
                           else
                             clear_pause_state "$w"
@@ -1032,7 +1052,7 @@ EOF
     else
       printf '%s' "$h" > "$hf"
       echo 0 > "$cf"
-      rm -f "$ssf" "$ewf"
+      rm -f "$scf" "$ssf" "$ewf"
       task=$(window_to_task "$w" "$STATE")
       if ! afk_present && status_is_paused_or_captain_held "$(last_status_line "$STATE/$task.status")" && ! window_is_busy "$w" "$tail40"; then
         case "$(pause_state_class "$w" "$task")" in

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -993,11 +993,10 @@ EOF
       # else the last 6 non-blank lines only (the TUI footer area, where every
       # verified harness renders its busy indicator) so busy-looking strings
       # in displayed content cannot suppress stale detection.
-      if [ "$n" -ge 2 ]; then
-        if [ "$terminal_busy_checked" = 0 ]; then
-          window_is_busy "$w" "$tail40" && terminal_busy=1
-        fi
-        if [ "$terminal_busy" = 0 ]; then
+      if [ "$n" -ge 2 ] && [ "$terminal_busy_checked" = 0 ]; then
+        window_is_busy "$w" "$tail40" && terminal_busy=1
+      fi
+      if [ "$n" -ge 2 ] && [ "$terminal_busy" = 0 ]; then
         # The pane is idle/stale at hash $h. Triage decides whether this wakes
         # firstmate. Detection itself is unchanged from above.
         if [ "$kind" = secondmate ]; then
@@ -1135,7 +1134,6 @@ EOF
             fi
           fi
         fi
-      fi
       else
         # Pane busy or not yet stably stale: reset pending escalation bookkeeping.
         rm -f "$ssf" "$ewf"

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -355,7 +355,8 @@ clear_pause_tracking() {  # <window>
 
 # Reconcile a declared pause or captain-held status with authoritative crew state.
 # Only a confidently dead ordinary crew may recover paused classification after
-# fm-crew-state has fallen back to stopped or unknown.
+# fm-crew-state has fallen back to stopped or unknown. An authoritative terminal
+# run remains terminal regardless of the older sparse status event.
 pause_state_class() {  # <window> <task>
   local win=$1 task=$2 key last recheck_file class agent_alive
   key=${win//:/_}
@@ -381,9 +382,9 @@ pause_state_class() {  # <window> <task>
     return
   fi
   class=$(crew_absorb_class "$task")
-  if [ "$class" = working ]; then
+  if [ "$class" = working ] || [ "$class" = terminal ]; then
     rm -f "$recheck_file"
-    printf 'working'
+    printf '%s' "$class"
     return
   fi
   if [ "$(window_kind "$win")" != secondmate ]; then
@@ -400,6 +401,16 @@ pause_state_class() {  # <window> <task>
     *) rm -f "$recheck_file" ;;
   esac
   printf '%s' "$class"
+}
+
+surface_terminal_stale() {  # <window> <hash>
+  local win=$1 h=$2 key
+  key=$(printf '%s' "$win" | tr ':/.' '___')
+  fm_wake_append stale "$win" "stale: $win" || exit 1
+  printf '%s' "$h" > "$STATE/.stale-$key"
+  rm -f "$STATE/.stale-since-$key" "$STATE/.wedge-escalations-$key"
+  clear_pause_state "$win"
+  wake "stale: $win"
 }
 
 surface_nonterminal_stale() {  # <window> <hash>
@@ -963,6 +974,8 @@ EOF
           #   - paused: the crew declared an external wait, or a declared pause or
           #     captain hold is paired with a confidently dead agent, so absorb on
           #     the long PAUSE_RESURFACE_SECS cadence instead of wedge-escalating;
+#           - terminal: the authoritative no-mistakes run is done or failed, so
+#             surface once even when paused: remains the latest sparse event;
           #   - none: no running pipeline, idle pane, no busy signature, no declared
           #     pause - the crew has STOPPED. Surface immediately so firstmate peeks
           #     (it may be done via an interactive menu that wrote no done: status,
@@ -980,6 +993,9 @@ EOF
               paused)
                 handle_paused_stale "$w" "$task" "$h"
                 ;;
+              terminal)
+                surface_terminal_stale "$w" "$h"
+                ;;
               *)
                 surface_nonterminal_stale "$w" "$h"
                 ;;
@@ -993,6 +1009,8 @@ EOF
                          printf '%s' "$h" > "$sf"
                          wedge_timer_check "$w" "$ssf" "non-terminal stale (provably working after a declared pause)" "$ewf"
                          triage_log "absorbed non-terminal stale (provably working): $w" ;;
+                terminal) clear_pause_state "$w"
+                          rm -f "$ssf" "$ewf" ;;
                 *)       handle_paused_stale "$w" "$task" "$h" ;;
               esac
             else

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -9,6 +9,9 @@
 # working signal is never silently swallowed. A declared external-wait pause is
 # the separate idle absorb case and re-surfaces only on its long bounded cadence,
 # although its initial no-verb status signal still surfaces in normal mode.
+# An authoritative completed or failed no-mistakes run-step outranks an older
+# sparse status event, surfaces exactly once per terminal transition, and retains
+# durable transition identity until authoritative work resumes.
 # While state/.afk exists, the daemon owns triage and this watcher queues and exits
 # on every wake. Printed reason lines:
 #   signal: <file>...      status/turn-end signals, surfaced when a listed status
@@ -1069,16 +1072,16 @@ EOF
           # unmodified terminal-status behavior).
         else
           # Non-terminal stale: a crew gone quiet without a captain-relevant status.
-          # Decided once per distinct stale hash (the costly state reads run only
-          # on first sight, never every poll) via pause_state_class, which returns:
+          # pause_state_class performs authoritative reconciliation when the stale
+          # class changes or its bounded recheck becomes due, and returns:
           #   - working: an actively-running pipeline legitimately sits on a static
           #     pane (e.g. waiting on CI), so absorb and start the wedge timer so a
           #     genuinely frozen run still escalates past STALE_ESCALATE_SECS;
           #   - paused: the crew declared an external wait, or a declared pause or
           #     captain hold is paired with a confidently dead agent, so absorb on
           #     the long PAUSE_RESURFACE_SECS cadence instead of wedge-escalating;
-#           - terminal: the authoritative no-mistakes run is done or failed, so
-#             surface once even when paused: remains the latest sparse event;
+          #   - terminal: the authoritative no-mistakes run is done or failed, so
+          #     surface once even when paused: remains the latest sparse event;
           #   - none: no running pipeline, idle pane, no busy signature, no declared
           #     pause - the crew has STOPPED. Surface immediately so firstmate peeks
           #     (it may be done via an interactive menu that wrote no done: status,

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -135,6 +135,7 @@ BUSY_REGEX=${FM_BUSY_REGEX:-'esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel'}
 # daemon owns triage, so this watcher reverts to one-shot (enqueue + exit on every
 # wake) and never double-triages - and never runs the costly provably-working read.
 STALE_ESCALATE_SECS=${FM_STALE_ESCALATE_SECS:-240}  # idle secs before a provably-working stale escalates as a possible wedge
+TERMINAL_RECHECK_SECS=$STALE_ESCALATE_SECS
 # A crew that declared a pause is idling on a known external wait, so its stale
 # pane is absorbed rather than wedge-escalated.
 # A captain-held or paused crew whose agent has confidently exited uses the same
@@ -323,13 +324,17 @@ terminal_transition_is_surfaced() {  # <window>
   [ -e "$STATE/.terminal-transition-$key" ]
 }
 
-refresh_terminal_transition() {  # <window> <task>
-  local win=$1 task=$2 key
+refresh_terminal_transition() {  # <window> <task> <force>
+  local win=$1 task=$2 force=$3 key recheck_file class
   key=$(printf '%s' "$win" | tr ':/.' '___')
   [ -e "$STATE/.terminal-transition-$key" ] || return 0
-  if [ "$(crew_terminal_transition_class "$task")" = nonterminal ]; then
+  recheck_file="$STATE/.terminal-rechecked-$key"
+  [ "$force" = 1 ] || [ "$(age_of "$recheck_file")" -ge "$TERMINAL_RECHECK_SECS" ] || return 0
+  class=$(crew_terminal_transition_class "$task")
+  date +%s > "$recheck_file"
+  if [ "$class" = nonterminal ]; then
     rm -f "$STATE/.terminal-transition-$key" "$STATE/.stale-$key" "$STATE/.stale-class-$key" \
-      "$STATE/.stale-since-$key" "$STATE/.wedge-escalations-$key"
+      "$STATE/.stale-since-$key" "$STATE/.wedge-escalations-$key" "$recheck_file"
   fi
 }
 
@@ -393,12 +398,22 @@ pause_state_class() {  # <window> <task>
   key=${key//./_}
   last=$(last_status_line "$STATE/$task.status")
   recheck_file="$STATE/.paused-rechecked-$key"
+  if terminal_transition_is_surfaced "$win"; then
+    printf 'terminal'
+    return
+  fi
   if ! status_is_paused_or_captain_held "$last"; then
     rm -f "$recheck_file"
     crew_absorb_class "$task"
     return
   fi
   if [ -e "$STATE/.paused-$key" ] && [ "$(age_of "$recheck_file")" -lt "$STALE_ESCALATE_SECS" ]; then
+    class=$(crew_absorb_class "$task")
+    if [ "$class" = working ] || [ "$class" = terminal ]; then
+      rm -f "$recheck_file"
+      printf '%s' "$class"
+      return
+    fi
     if [ "$(window_kind "$win")" != secondmate ]; then
       agent_alive=$(fm_backend_agent_alive "$(window_backend "$win")" "$win" 2>/dev/null) || agent_alive=unknown
       if [ "$agent_alive" != dead ]; then
@@ -438,6 +453,7 @@ surface_terminal_stale() {  # <window> <hash>
   if ! terminal_transition_is_surfaced "$win"; then
     fm_wake_append stale "$win" "stale: $win" || exit 1
     : > "$STATE/.terminal-transition-$key"
+    date +%s > "$STATE/.terminal-rechecked-$key"
     surfaced=1
   fi
   printf '%s' "$h" > "$STATE/.stale-$key"
@@ -931,9 +947,6 @@ EOF
       continue
     fi
     tail40=$(fm_backend_capture "$(window_backend "$w")" "$w" 40 "$(window_label "$w")" 2>/dev/null) || continue
-    if ! afk_present && [ "$kind" != secondmate ]; then
-      refresh_terminal_transition "$w" "$task"
-    fi
     h=$(printf '%s' "$tail40" | hash_pane)
     key=$(printf '%s' "$w" | tr ':/.' '___')
     hf="$STATE/.hash-$key"
@@ -944,6 +957,11 @@ EOF
     ewf="$STATE/.wedge-escalations-$key"
     pf="$STATE/.paused-$key"   # flag: this key's stale is using the bounded pause cadence
     prev=$(cat "$hf" 2>/dev/null || true)
+    if ! afk_present && [ "$kind" != secondmate ]; then
+      terminal_refresh_force=0
+      [ "$h" = "$prev" ] || terminal_refresh_force=1
+      refresh_terminal_transition "$w" "$task" "$terminal_refresh_force"
+    fi
     if [ "$h" = "$prev" ]; then
       n=$(( $(cat "$cf" 2>/dev/null || echo 0) + 1 ))
       echo "$n" > "$cf"
@@ -966,6 +984,8 @@ EOF
             printf '%s' "$h" > "$sf"
             wake "stale: $w"
           fi
+        elif terminal_transition_is_surfaced "$w"; then
+          surface_terminal_stale "$w" "$h"
         elif stale_is_terminal "$w" "$STATE"; then
           # The log's last line is captain-relevant - but that alone is not
           # proof the crew is actually done: a crew's own status log gets no

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -1009,8 +1009,12 @@ EOF
                          printf '%s' "$h" > "$sf"
                          wedge_timer_check "$w" "$ssf" "non-terminal stale (provably working after a declared pause)" "$ewf"
                          triage_log "absorbed non-terminal stale (provably working): $w" ;;
-                terminal) clear_pause_state "$w"
-                          rm -f "$ssf" "$ewf" ;;
+                terminal) if [ -e "$pf" ]; then
+                            surface_terminal_stale "$w" "$h"
+                          else
+                            clear_pause_state "$w"
+                            rm -f "$ssf" "$ewf"
+                          fi ;;
                 *)       handle_paused_stale "$w" "$task" "$h" ;;
               esac
             else

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -66,7 +66,9 @@ The guard covers the main primary and genuinely marked secondmate homes, exempts
 A presence-gated sub-supervisor (`bin/fm-supervise-daemon.sh`) extends this for walk-away supervision: the `/afk` skill starts it through the tracked foreground helper `bin/fm-afk-start.sh`, after which the watcher reverts to daemon-managed one-shot mode and the daemon self-handles routine wakes in bash.
 The watcher and daemon share `bin/fm-classify-lib.sh` for captain-relevant status verbs, declared-external-wait vocabulary, and status-scan primitives.
 Terminal verbs remain captain-relevant, while a nonterminal progress verb cannot become terminal merely because its prose contains a legacy free-text token such as `merged`; bare legacy free-text lines remain compatible.
-The always-on watcher also uses that library's absorb classification on no-verb signals and first-sighting stale panes before status-log terminality is trusted, while the daemon maintains distinct wedge and declared-pause recheck cadences.
+The always-on watcher also uses that library's current-state classification to reconcile no-verb signals and stale transitions before trusting status-log terminality.
+An authoritative completed or failed no-mistakes run-step outranks older sparse status events, surfaces once per terminal transition, and retains durable transition identity until authoritative work resumes, while genuine declared external waits keep their bounded pause cadence.
+The daemon maintains its distinct wedge and declared-pause recheck cadences.
 In away mode, seen-status dedupe does not clear possible-wedge aging for nonterminal progress, so housekeeping still re-escalates an unchanged idle pane at the configured bound.
 The daemon escalates captain-relevant events, plus a bounded recheck for a declared pause that remains idle, as one batched, single-line digest prefixed with a terminal-safe U+2063 sentinel marker so firstmate can tell daemon injections apart from real messages.
 Its supervisor injection path supports tmux and herdr panes, with `FM_SUPERVISOR_BACKEND` and `FM_SUPERVISOR_TARGET` resolved independently from the task-spawn backend.

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -711,7 +711,17 @@ assert_tracked_stale_surfaces_terminal_transition_once() {  # <prior> <label> <c
       touch -t 200001010000 "$state/.paused-rechecked-$key"
       ;;
     working)
-      date +%s > "$state/.stale-since-$key"
+      PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
+        FM_FAKE_TMUX_CURRENT_COMMAND=codex FM_FAKE_CREW_STATE='state: working · source: run-step · validating' \
+        FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_STALE_ESCALATE_SECS=999 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+        FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+      pid=$!
+      wait_numeric_file "$state/.stale-since-$key" 30 || { reap "$pid"; fail "tracked working state did not start wedge cadence"; }
+      [ "$(cat "$state/.stale-class-$key" 2>/dev/null || true)" = "working:$pane_hash" ] \
+        || { reap "$pid"; fail "tracked working state did not retain per-hash classification"; }
+      reap "$pid"
+      rm -f "$state/.stale-since-$key"
+      printf '1\n' > "$state/.wedge-escalations-$key"
       ;;
   esac
 
@@ -724,6 +734,9 @@ assert_tracked_stale_surfaces_terminal_transition_once() {  # <prior> <label> <c
   grep -Fx "stale: $window" "$out" >/dev/null || fail "tracked $prior state suppressed its $label transition"
   [ ! -e "$state/.paused-$key" ] || fail "$label transition retained declared-pause cadence"
   [ ! -e "$state/.stale-since-$key" ] || fail "$label transition retained prior-working wedge cadence"
+  [ ! -e "$state/.wedge-escalations-$key" ] || fail "$label transition retained prior-working escalation cadence"
+  [ "$(cat "$state/.stale-class-$key" 2>/dev/null || true)" = "terminal:$pane_hash" ] \
+    || fail "$label transition did not retain terminal deduplication provenance"
 
   : > "$out"
   PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
@@ -746,10 +759,10 @@ test_tracked_paused_stale_surfaces_terminal_transition_once() {
   pass "tracked paused stale state surfaces authoritative done and failed transitions exactly once"
 }
 
-test_prior_working_stale_surfaces_terminal_transition_once() {
+test_consumed_working_stale_surfaces_terminal_transition_once() {
   assert_tracked_stale_surfaces_terminal_transition_once working 'done' 'state: done · source: run-step · checks green'
   assert_tracked_stale_surfaces_terminal_transition_once working failed 'state: failed · source: run-step · validation failed'
-  pass "prior working stale state surfaces authoritative done and failed transitions exactly once"
+  pass "consumed working stale cadence preserves authoritative done and failed transitions exactly once"
 }
 
 # A captain-held crew can leave a stable backend endpoint after its agent exits.
@@ -1400,7 +1413,7 @@ test_nonterminal_stale_not_working_surfaced
 test_nonterminal_stale_paused_absorbed_then_resurfaced
 test_completed_run_overrides_paused_status_without_repeated_stale
 test_tracked_paused_stale_surfaces_terminal_transition_once
-test_prior_working_stale_surfaces_terminal_transition_once
+test_consumed_working_stale_surfaces_terminal_transition_once
 test_exited_declared_pause_is_bounded_but_live_gate_surfaces
 test_secondmate_paused_resurfaces_in_normal_mode
 test_secondmate_nonpaused_stale_remains_suppressed

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -692,10 +692,10 @@ test_completed_run_overrides_paused_status_without_repeated_stale() {
   pass "a completed run overrides trailing paused status, surfaces once as terminal, and does not enter pause cadence"
 }
 
-assert_tracked_paused_stale_surfaces_terminal_transition_once() {  # <label> <crew-state>
-  local label=$1 crew_state=$2 dir state fakebin out capture_file window key pane_hash sig pid wakes
-  dir=$(make_case "tracked-pause-to-$label"); state="$dir/state"; fakebin="$dir/fakebin"
-  out="$dir/watch.out"; capture_file="$dir/pane.txt"; window="test:fm-pause-to-$label"
+assert_tracked_stale_surfaces_terminal_transition_once() {  # <prior> <label> <crew-state>
+  local prior=$1 label=$2 crew_state=$3 dir state fakebin out capture_file window key pane_hash sig pid wakes
+  dir=$(make_case "tracked-$prior-to-$label"); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"; capture_file="$dir/pane.txt"; window="test:fm-$prior-to-$label"
   printf 'idle after no-mistakes terminal transition\n' > "$capture_file"
   printf 'window=%s\nkind=ship\nharness=codex\nbackend=tmux\n' "$window" > "$state/$label.meta"
   printf 'paused: waiting for an external dependency\n' > "$state/$label.status"
@@ -705,17 +705,25 @@ assert_tracked_paused_stale_surfaces_terminal_transition_once() {  # <label> <cr
   printf '%s' "$pane_hash" > "$state/.hash-$key"
   printf '%s' "$pane_hash" > "$state/.stale-$key"
   printf '1\n' > "$state/.count-$key"
-  : > "$state/.paused-$key"
-  touch -t 200001010000 "$state/.paused-rechecked-$key"
+  case "$prior" in
+    paused)
+      : > "$state/.paused-$key"
+      touch -t 200001010000 "$state/.paused-rechecked-$key"
+      ;;
+    working)
+      date +%s > "$state/.stale-since-$key"
+      ;;
+  esac
 
   PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
     FM_FAKE_TMUX_CURRENT_COMMAND=codex FM_FAKE_CREW_STATE="$crew_state" \
     FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_PAUSE_RESURFACE_SECS=999 FM_POLL=1 FM_SIGNAL_GRACE=1 \
     FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
   pid=$!
-  wait_for_exit "$pid" 40 || fail "tracked pause did not surface its $label transition"
-  grep -Fx "stale: $window" "$out" >/dev/null || fail "tracked pause suppressed its $label transition"
+  wait_for_exit "$pid" 40 || fail "tracked $prior state did not surface its $label transition"
+  grep -Fx "stale: $window" "$out" >/dev/null || fail "tracked $prior state suppressed its $label transition"
   [ ! -e "$state/.paused-$key" ] || fail "$label transition retained declared-pause cadence"
+  [ ! -e "$state/.stale-since-$key" ] || fail "$label transition retained prior-working wedge cadence"
 
   : > "$out"
   PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
@@ -733,9 +741,15 @@ assert_tracked_paused_stale_surfaces_terminal_transition_once() {  # <label> <cr
 }
 
 test_tracked_paused_stale_surfaces_terminal_transition_once() {
-  assert_tracked_paused_stale_surfaces_terminal_transition_once 'done' 'state: done · source: run-step · checks green'
-  assert_tracked_paused_stale_surfaces_terminal_transition_once failed 'state: failed · source: run-step · validation failed'
+  assert_tracked_stale_surfaces_terminal_transition_once paused 'done' 'state: done · source: run-step · checks green'
+  assert_tracked_stale_surfaces_terminal_transition_once paused failed 'state: failed · source: run-step · validation failed'
   pass "tracked paused stale state surfaces authoritative done and failed transitions exactly once"
+}
+
+test_prior_working_stale_surfaces_terminal_transition_once() {
+  assert_tracked_stale_surfaces_terminal_transition_once working 'done' 'state: done · source: run-step · checks green'
+  assert_tracked_stale_surfaces_terminal_transition_once working failed 'state: failed · source: run-step · validation failed'
+  pass "prior working stale state surfaces authoritative done and failed transitions exactly once"
 }
 
 # A captain-held crew can leave a stable backend endpoint after its agent exits.
@@ -1386,6 +1400,7 @@ test_nonterminal_stale_not_working_surfaced
 test_nonterminal_stale_paused_absorbed_then_resurfaced
 test_completed_run_overrides_paused_status_without_repeated_stale
 test_tracked_paused_stale_surfaces_terminal_transition_once
+test_prior_working_stale_surfaces_terminal_transition_once
 test_exited_declared_pause_is_bounded_but_live_gate_surfaces
 test_secondmate_paused_resurfaces_in_normal_mode
 test_secondmate_nonpaused_stale_remains_suppressed

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -277,6 +277,8 @@ test_crew_absorb_class_classifier() {
   [ "$(crew_terminal_transition_class a)" = terminal ] || fail "completed run-step lost terminal identity"
   FM_FAKE_CREW_STATE='state: unknown · source: none · run temporarily unreadable'
   [ "$(crew_terminal_transition_class a)" = unknown ] || fail "unreadable state cleared terminal identity"
+  FM_FAKE_CREW_STATE='state: paused · source: status-log · older sparse pause'
+  [ "$(crew_terminal_transition_class a)" = unknown ] || fail "sparse pause cleared terminal identity"
   FM_FAKE_CREW_STATE='state: working · source: status-log · working: compiling'
   [ "$(crew_absorb_class a)" = none ] || fail "stale working: status-log classed absorbable"
   FM_FAKE_CREW_STATE='state: unknown · source: none · worktree gone'
@@ -770,6 +772,30 @@ test_consumed_working_stale_surfaces_terminal_transition_once() {
   pass "consumed working stale cadence preserves authoritative done and failed transitions exactly once"
 }
 
+test_fresh_pause_cache_revalidates_terminal_run() {
+  local dir state fakebin out capture_file window key pane_hash sig pid
+  dir=$(make_case fresh-pause-cache-terminal); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"; capture_file="$dir/pane.txt"; window="test:fm-fresh-pause-terminal"
+  printf 'idle after completed validation\n' > "$capture_file"
+  printf 'window=%s\nkind=ship\nharness=codex\nbackend=tmux\n' "$window" > "$state/fresh.meta"
+  printf 'paused: waiting for an external dependency\n' > "$state/fresh.status"
+  sig=$(seen_sig "$state/fresh.status"); printf '%s' "$sig" > "$state/.seen-fresh_status"
+  key=$(printf '%s' "$window" | tr ':/.' '___'); pane_hash=$(hash_text "idle after completed validation")
+  printf '%s' "$pane_hash" > "$state/.hash-$key"; printf '%s' "$pane_hash" > "$state/.stale-$key"
+  printf 'paused:%s\n' "$pane_hash" > "$state/.stale-class-$key"; printf '1\n' > "$state/.count-$key"
+  : > "$state/.paused-$key"; date +%s > "$state/.paused-rechecked-$key"
+
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
+    FM_FAKE_TMUX_CURRENT_COMMAND=zsh FM_FAKE_CREW_STATE='state: done · source: run-step · checks green' \
+    FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_PAUSE_RESURFACE_SECS=0 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!; wait_for_exit "$pid" 40 || fail "fresh pause cache hid an authoritative terminal run"
+  grep -Fx "stale: $window" "$out" >/dev/null || fail "terminal run behind fresh pause cache did not surface plainly"
+  grep -F "awaiting external" "$out" >/dev/null && fail "terminal run entered pause recheck handling"
+  [ ! -e "$state/.paused-$key" ] || fail "terminal run retained cached pause state"
+  pass "fresh pause cache revalidates and surfaces an authoritative terminal run"
+}
+
 assert_nonpaused_working_surfaces_terminal_transition_once() {  # <label> <crew-state> <captain-relevant-status>
   local label=$1 crew_state=$2 captain_status=$3 dir state fakebin out capture_file window key pane_hash sig pid
   dir=$(make_case "nonpaused-working-to-$label-$captain_status"); state="$dir/state"; fakebin="$dir/fakebin"
@@ -808,7 +834,7 @@ test_nonpaused_working_surfaces_terminal_transitions_once() {
 }
 
 test_terminal_transition_survives_pane_redraw_until_new_run() {
-  local dir state fakebin out capture_file window key first_hash second_hash sig pid wakes i
+  local dir state fakebin out capture_file window key first_hash second_hash sig pid wakes i rechecked
   dir=$(make_case terminal-pane-redraw); state="$dir/state"; fakebin="$dir/fakebin"
   out="$dir/watch.out"; capture_file="$dir/pane.txt"; window="test:fm-terminal-redraw"
   printf 'window=%s\nkind=ship\nharness=codex\nbackend=tmux\n' "$window" > "$state/redraw.meta"
@@ -832,10 +858,33 @@ test_terminal_transition_survives_pane_redraw_until_new_run() {
   [ "$wakes" -eq 1 ] || fail "terminal pane redraw emitted $wakes alerts"
   [ "$(cat "$state/.stale-class-$key" 2>/dev/null || true)" = "terminal:$second_hash" ] || fail "redraw was not deduplicated as the same terminal transition"
 
+  touch -t 200001010000 "$state/.terminal-rechecked-$key"
+  : > "$out"
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" FM_FAKE_TMUX_CURRENT_COMMAND=codex \
+    FM_FAKE_CREW_STATE='state: paused · source: status-log · older sparse pause' FM_STATE_OVERRIDE="$state" \
+    FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_STALE_ESCALATE_SECS=1 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!; wait_live "$pid" 30 || { reap "$pid"; fail "transient run lookup miss repeated the terminal alert"; }; reap "$pid"
+  [ -e "$state/.terminal-transition-$key" ] || fail "transient run lookup miss cleared terminal identity"
+  [ ! -e "$state/.paused-$key" ] || fail "transient run lookup miss routed terminal identity into pause cadence"
+  wakes=$(awk -F '\t' -v w="$window" '$3 == "stale" && $4 == w { n++ } END { print n + 0 }' "$state/.wake-queue")
+  [ "$wakes" -eq 1 ] || fail "transient run lookup miss emitted $wakes terminal alerts"
+
+  rechecked=$(cat "$state/.terminal-rechecked-$key")
   : > "$out"
   PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" FM_FAKE_TMUX_CURRENT_COMMAND=codex \
     FM_FAKE_CREW_STATE='state: working · source: run-step · new validation' FM_STATE_OVERRIDE="$state" \
     FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_STALE_ESCALATE_SECS=999 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!; wait_live "$pid" 30 || { reap "$pid"; fail "bounded terminal recheck unexpectedly surfaced"; }; reap "$pid"
+  [ -e "$state/.terminal-transition-$key" ] || fail "terminal identity rechecked before its bounded cadence"
+  [ "$(cat "$state/.terminal-rechecked-$key")" = "$rechecked" ] || fail "terminal identity was queried on every watcher poll"
+
+  touch -t 200001010000 "$state/.terminal-rechecked-$key"
+  : > "$out"
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" FM_FAKE_TMUX_CURRENT_COMMAND=codex \
+    FM_FAKE_CREW_STATE='state: working · source: run-step · new validation' FM_STATE_OVERRIDE="$state" \
+    FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_STALE_ESCALATE_SECS=1 FM_POLL=1 FM_SIGNAL_GRACE=1 \
     FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
   pid=$!
   i=0
@@ -1502,6 +1551,7 @@ test_nonterminal_stale_paused_absorbed_then_resurfaced
 test_completed_run_overrides_paused_status_without_repeated_stale
 test_tracked_paused_stale_surfaces_terminal_transition_once
 test_consumed_working_stale_surfaces_terminal_transition_once
+test_fresh_pause_cache_revalidates_terminal_run
 test_nonpaused_working_surfaces_terminal_transitions_once
 test_terminal_transition_survives_pane_redraw_until_new_run
 test_exited_declared_pause_is_bounded_but_live_gate_surfaces

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -248,9 +248,10 @@ test_status_is_paused_classifier() {
   pass "status_is_paused: only the leading paused verb matches, and paused is not captain-relevant"
 }
 
-# crew_absorb_class: the single fm-crew-state.sh read that returns BOTH absorb
-# reasons - working (active run/busy pane), paused (declared external wait), or none
-# (surface it) - so the watcher's stale path gets both for one bounded call.
+# crew_absorb_class: the single fm-crew-state.sh read that returns working (active
+# run/busy pane), paused (declared external wait), terminal (an authoritative
+# finished run), or none (surface it), so the watcher's stale path gets every
+# current-state class from one bounded call.
 # crew_is_paused delegates to it exactly as crew_is_provably_working does.
 test_crew_absorb_class_classifier() {
   local dir fakebin
@@ -265,6 +266,12 @@ test_crew_absorb_class_classifier() {
   [ "$(crew_absorb_class a)" = paused ] || fail "declared pause not classed paused"
   crew_is_paused a || fail "crew_is_paused did not recognize a paused verdict"
   ! crew_is_provably_working a || fail "a paused crew was treated as provably working"
+  FM_FAKE_CREW_STATE='state: done · source: run-step · checks green'
+  [ "$(crew_absorb_class a)" = terminal ] || fail "completed run-step not classed terminal"
+  FM_FAKE_CREW_STATE='state: failed · source: run-step · run failed'
+  [ "$(crew_absorb_class a)" = terminal ] || fail "failed run-step not classed terminal"
+  FM_FAKE_CREW_STATE='state: parked · source: run-step · parked at review'
+  [ "$(crew_absorb_class a)" = none ] || fail "parked run-step classed terminal"
   FM_FAKE_CREW_STATE='state: working · source: status-log · working: compiling'
   [ "$(crew_absorb_class a)" = none ] || fail "stale working: status-log classed absorbable"
   FM_FAKE_CREW_STATE='state: unknown · source: none · worktree gone'
@@ -272,7 +279,7 @@ test_crew_absorb_class_classifier() {
   ! crew_is_paused a || fail "unknown crew classed paused"
   [ "$(crew_absorb_class "")" = none ] || fail "empty id not classed none"
   unset FM_FAKE_CREW_STATE
-  pass "crew_absorb_class: working/paused/none from one read; crew_is_paused and crew_is_provably_working agree"
+  pass "crew_absorb_class: working/paused/terminal/none from one read; helper predicates agree"
 }
 
 # signal_crew_provably_working: a no-verb "signal:" wake is benign ONLY when EVERY
@@ -642,6 +649,47 @@ test_nonterminal_stale_paused_absorbed_then_resurfaced() {
   FM_STATE_OVERRIDE="$state" "$DRAIN" > "$drain_out" 2>/dev/null || fail "drain after the paused re-surface failed"
   grep "$(printf '\tstale\t')" "$drain_out" | grep -F "$window" >/dev/null || fail "paused re-surface was not queued"
   pass "a declared pause is absorbed on first sight, then re-surfaced as a recheck past the threshold, never wedge-escalated"
+}
+
+# A no-mistakes completion is authoritative even when sparse status reporting
+# leaves an older paused: event last in the log. Surface that terminal state once,
+# but do not enter pause cadence or repeat a stopped-work alert on every poll.
+test_completed_run_overrides_paused_status_without_repeated_stale() {
+  local dir state fakebin out capture_file window key pane_hash sig pid wakes
+  dir=$(make_case completed-run-paused-status); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"; capture_file="$dir/pane.txt"; window="test:fm-complete"
+  printf 'idle after no-mistakes completed\n' > "$capture_file"
+  printf 'window=%s\nkind=ship\nharness=codex\nbackend=tmux\n' "$window" > "$state/complete.meta"
+  printf 'paused: waiting for an external dependency before validation resumed\n' > "$state/complete.status"
+  sig=$(seen_sig "$state/complete.status"); printf '%s' "$sig" > "$state/.seen-complete_status"
+  key=$(printf '%s' "$window" | tr ':/.' '___')
+  pane_hash=$(hash_text "idle after no-mistakes completed")
+  printf '%s' "$pane_hash" > "$state/.hash-$key"
+  printf '1\n' > "$state/.count-$key"
+
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
+    FM_FAKE_TMUX_CURRENT_COMMAND=codex FM_FAKE_CREW_STATE='state: done · source: run-step · checks green' \
+    FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_PAUSE_RESURFACE_SECS=999 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  wait_for_exit "$pid" 40 || fail "watcher did not surface the completed run behind a paused status"
+  grep -Fx "stale: $window" "$out" >/dev/null || fail "completed run did not surface through terminal stale handling"
+  [ ! -e "$state/.paused-$key" ] || fail "completed run was misclassified into declared-pause cadence"
+
+  : > "$out"
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
+    FM_FAKE_TMUX_CURRENT_COMMAND=codex FM_FAKE_CREW_STATE='state: done · source: run-step · checks green' \
+    FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_PAUSE_RESURFACE_SECS=999 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  if ! wait_live "$pid" 30; then
+    reap "$pid"
+    fail "unchanged completed run repeated its stale alert: $(cat "$out")"
+  fi
+  reap "$pid"
+  wakes=$(awk -F '\t' -v w="$window" '$3 == "stale" && $4 == w { n++ } END { print n + 0 }' "$state/.wake-queue")
+  [ "$wakes" -eq 1 ] || fail "completed run emitted $wakes stale alerts across unchanged polls"
+  pass "a completed run overrides trailing paused status, surfaces once as terminal, and does not enter pause cadence"
 }
 
 # A captain-held crew can leave a stable backend endpoint after its agent exits.
@@ -1290,6 +1338,7 @@ test_wedge_escalation_marks_demand_deep_inspection_after_threshold
 test_wedge_escalation_resets_when_pane_becomes_active
 test_nonterminal_stale_not_working_surfaced
 test_nonterminal_stale_paused_absorbed_then_resurfaced
+test_completed_run_overrides_paused_status_without_repeated_stale
 test_exited_declared_pause_is_bounded_but_live_gate_surfaces
 test_secondmate_paused_resurfaces_in_normal_mode
 test_secondmate_nonpaused_stale_remains_suppressed

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -692,6 +692,52 @@ test_completed_run_overrides_paused_status_without_repeated_stale() {
   pass "a completed run overrides trailing paused status, surfaces once as terminal, and does not enter pause cadence"
 }
 
+assert_tracked_paused_stale_surfaces_terminal_transition_once() {  # <label> <crew-state>
+  local label=$1 crew_state=$2 dir state fakebin out capture_file window key pane_hash sig pid wakes
+  dir=$(make_case "tracked-pause-to-$label"); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"; capture_file="$dir/pane.txt"; window="test:fm-pause-to-$label"
+  printf 'idle after no-mistakes terminal transition\n' > "$capture_file"
+  printf 'window=%s\nkind=ship\nharness=codex\nbackend=tmux\n' "$window" > "$state/$label.meta"
+  printf 'paused: waiting for an external dependency\n' > "$state/$label.status"
+  sig=$(seen_sig "$state/$label.status"); printf '%s' "$sig" > "$state/.seen-${label}_status"
+  key=$(printf '%s' "$window" | tr ':/.' '___')
+  pane_hash=$(hash_text "idle after no-mistakes terminal transition")
+  printf '%s' "$pane_hash" > "$state/.hash-$key"
+  printf '%s' "$pane_hash" > "$state/.stale-$key"
+  printf '1\n' > "$state/.count-$key"
+  : > "$state/.paused-$key"
+  touch -t 200001010000 "$state/.paused-rechecked-$key"
+
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
+    FM_FAKE_TMUX_CURRENT_COMMAND=codex FM_FAKE_CREW_STATE="$crew_state" \
+    FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_PAUSE_RESURFACE_SECS=999 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  wait_for_exit "$pid" 40 || fail "tracked pause did not surface its $label transition"
+  grep -Fx "stale: $window" "$out" >/dev/null || fail "tracked pause suppressed its $label transition"
+  [ ! -e "$state/.paused-$key" ] || fail "$label transition retained declared-pause cadence"
+
+  : > "$out"
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
+    FM_FAKE_TMUX_CURRENT_COMMAND=codex FM_FAKE_CREW_STATE="$crew_state" \
+    FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_PAUSE_RESURFACE_SECS=999 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  if ! wait_live "$pid" 30; then
+    reap "$pid"
+    fail "unchanged $label transition repeated its stale alert: $(cat "$out")"
+  fi
+  reap "$pid"
+  wakes=$(awk -F '\t' -v w="$window" '$3 == "stale" && $4 == w { n++ } END { print n + 0 }' "$state/.wake-queue")
+  [ "$wakes" -eq 1 ] || fail "$label transition emitted $wakes stale alerts"
+}
+
+test_tracked_paused_stale_surfaces_terminal_transition_once() {
+  assert_tracked_paused_stale_surfaces_terminal_transition_once 'done' 'state: done · source: run-step · checks green'
+  assert_tracked_paused_stale_surfaces_terminal_transition_once failed 'state: failed · source: run-step · validation failed'
+  pass "tracked paused stale state surfaces authoritative done and failed transitions exactly once"
+}
+
 # A captain-held crew can leave a stable backend endpoint after its agent exits.
 # fm-crew-state then authoritatively reports stopped rather than paused, but the
 # confirmed-dead agent plus the declared wait or captain-held transfer must retain
@@ -1339,6 +1385,7 @@ test_wedge_escalation_resets_when_pane_becomes_active
 test_nonterminal_stale_not_working_surfaced
 test_nonterminal_stale_paused_absorbed_then_resurfaced
 test_completed_run_overrides_paused_status_without_repeated_stale
+test_tracked_paused_stale_surfaces_terminal_transition_once
 test_exited_declared_pause_is_bounded_but_live_gate_surfaces
 test_secondmate_paused_resurfaces_in_normal_mode
 test_secondmate_nonpaused_stale_remains_suppressed

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -833,6 +833,87 @@ test_nonpaused_working_surfaces_terminal_transitions_once() {
   pass "non-paused working provenance reclassifies done and failed with sparse working or captain-relevant status"
 }
 
+assert_same_hash_busy_run_surfaces_terminal_once() {  # <label> <crew-state>
+  local label=$1 crew_state=$2 dir state fakebin out capture_file window key pane_hash sig pid wakes i
+  dir=$(make_case "same-hash-busy-$label"); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"; capture_file="$dir/pane.txt"; window="test:fm-same-hash-$label"
+  printf 'unchanged native pane\n' > "$capture_file"
+  printf 'window=%s\nkind=ship\nharness=codex\nbackend=tmux\n' "$window" > "$state/$label.meta"
+  printf 'working: validation under way\n' > "$state/$label.status"
+  sig=$(seen_sig "$state/$label.status"); printf '%s' "$sig" > "$state/.seen-${label}_status"
+  key=$(printf '%s' "$window" | tr ':/.' '___'); pane_hash=$(hash_text "unchanged native pane")
+  printf '%s' "$pane_hash" > "$state/.hash-$key"; printf '1\n' > "$state/.count-$key"
+  : > "$state/.terminal-transition-$key"; date +%s > "$state/.terminal-rechecked-$key"
+  printf '%s' "$pane_hash" > "$state/.stale-$key"; printf 'terminal:%s\n' "$pane_hash" > "$state/.stale-class-$key"
+
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" FM_FAKE_TMUX_CURRENT_COMMAND=codex \
+    FM_FAKE_CREW_STATE='state: unknown · source: none · run lookup pending' FM_BUSY_REGEX='unchanged native pane' \
+    FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_STALE_ESCALATE_SECS=999 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!; i=0
+  while [ "$i" -lt 30 ] && [ -e "$state/.terminal-transition-$key" ]; do sleep 0.1; i=$((i + 1)); done
+  [ ! -e "$state/.terminal-transition-$key" ] || { reap "$pid"; fail "same-hash busy state did not clear terminal identity"; }
+  reap "$pid"
+
+  : > "$out"
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" FM_FAKE_TMUX_CURRENT_COMMAND=codex \
+    FM_FAKE_CREW_STATE="$crew_state" FM_BUSY_REGEX='never-match-this-pane' \
+    FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!; wait_for_exit "$pid" 40 || fail "same-hash busy run did not surface $label"
+  wakes=$(awk -F '\t' -v w="$window" '$3 == "stale" && $4 == w { n++ } END { print n + 0 }' "$state/.wake-queue")
+  [ "$wakes" -eq 1 ] || fail "same-hash busy run emitted $wakes $label alerts"
+
+  : > "$out"
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" FM_FAKE_TMUX_CURRENT_COMMAND=codex \
+    FM_FAKE_CREW_STATE="$crew_state" FM_BUSY_REGEX='never-match-this-pane' \
+    FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!; wait_live "$pid" 5 || { reap "$pid"; fail "same-hash busy run repeated its $label alert"; }; reap "$pid"
+  wakes=$(awk -F '\t' -v w="$window" '$3 == "stale" && $4 == w { n++ } END { print n + 0 }' "$state/.wake-queue")
+  [ "$wakes" -eq 1 ] || fail "same-hash busy run repeated $label across watcher re-arms"
+}
+
+test_same_hash_busy_runs_surface_terminal_transitions_once() {
+  assert_same_hash_busy_run_surfaces_terminal_once done 'state: done · source: run-step · checks green'
+  assert_same_hash_busy_run_surfaces_terminal_once failed 'state: failed · source: run-step · validation failed'
+  pass "same-hash busy runs surface done and failed transitions exactly once"
+}
+
+test_terminal_unknown_provenance_is_transient_then_surfaces() {
+  local dir state fakebin out capture_file window key pane_hash sig pid
+  dir=$(make_case terminal-persistent-unknown); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"; capture_file="$dir/pane.txt"; window="test:fm-terminal-unknown"
+  printf 'unchanged idle pane\n' > "$capture_file"
+  printf 'window=%s\nkind=ship\nharness=codex\nbackend=tmux\n' "$window" > "$state/unknown.meta"
+  printf 'working: prior validation\n' > "$state/unknown.status"
+  sig=$(seen_sig "$state/unknown.status"); printf '%s' "$sig" > "$state/.seen-unknown_status"
+  key=$(printf '%s' "$window" | tr ':/.' '___'); pane_hash=$(hash_text "unchanged idle pane")
+  printf '%s' "$pane_hash" > "$state/.hash-$key"; printf '1\n' > "$state/.count-$key"
+  : > "$state/.terminal-transition-$key"; touch -t 200001010000 "$state/.terminal-rechecked-$key"
+  printf '%s' "$pane_hash" > "$state/.stale-$key"; printf 'terminal:%s\n' "$pane_hash" > "$state/.stale-class-$key"
+
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" FM_FAKE_TMUX_CURRENT_COMMAND=codex \
+    FM_FAKE_CREW_STATE='state: unknown · source: none · transient lookup miss' FM_BUSY_REGEX='never-match-this-pane' \
+    FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_STALE_ESCALATE_SECS=1 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!; wait_live "$pid" 5 || { reap "$pid"; fail "first unknown observation discarded terminal identity"; }; reap "$pid"
+  [ -e "$state/.terminal-transition-$key" ] || fail "transient unknown cleared terminal identity"
+  [ -e "$state/.terminal-unknown-$key" ] || fail "transient unknown provenance was not retained"
+  [ ! -s "$state/.wake-queue" ] || fail "transient unknown surfaced before its bounded confirmation"
+
+  touch -t 200001010000 "$state/.terminal-rechecked-$key" "$state/.terminal-unknown-$key"
+  : > "$out"
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" FM_FAKE_TMUX_CURRENT_COMMAND=codex \
+    FM_FAKE_CREW_STATE='state: unknown · source: none · persistent stopped pane' FM_BUSY_REGEX='never-match-this-pane' \
+    FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_STALE_ESCALATE_SECS=1 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!; wait_for_exit "$pid" 40 || fail "persistent unknown remained hidden behind terminal identity"
+  grep -Fx "stale: $window" "$out" >/dev/null || fail "persistent unknown did not return to ordinary stale surfacing"
+  [ ! -e "$state/.terminal-transition-$key" ] || fail "persistent unknown retained terminal identity"
+  pass "transient unknown preserves terminal identity while persistent unknown surfaces"
+}
+
 test_terminal_transition_survives_pane_redraw_until_new_run() {
   local dir state fakebin out capture_file window key first_hash second_hash sig pid wakes i rechecked
   dir=$(make_case terminal-pane-redraw); state="$dir/state"; fakebin="$dir/fakebin"
@@ -864,7 +945,7 @@ test_terminal_transition_survives_pane_redraw_until_new_run() {
     FM_FAKE_CREW_STATE='state: paused · source: status-log · older sparse pause' FM_STATE_OVERRIDE="$state" \
     FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_STALE_ESCALATE_SECS=1 FM_POLL=1 FM_SIGNAL_GRACE=1 \
     FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
-  pid=$!; wait_live "$pid" 30 || { reap "$pid"; fail "transient run lookup miss repeated the terminal alert"; }; reap "$pid"
+  pid=$!; wait_live "$pid" 5 || { reap "$pid"; fail "transient run lookup miss repeated the terminal alert"; }; reap "$pid"
   [ -e "$state/.terminal-transition-$key" ] || fail "transient run lookup miss cleared terminal identity"
   [ ! -e "$state/.paused-$key" ] || fail "transient run lookup miss routed terminal identity into pause cadence"
   wakes=$(awk -F '\t' -v w="$window" '$3 == "stale" && $4 == w { n++ } END { print n + 0 }' "$state/.wake-queue")
@@ -1553,6 +1634,8 @@ test_tracked_paused_stale_surfaces_terminal_transition_once
 test_consumed_working_stale_surfaces_terminal_transition_once
 test_fresh_pause_cache_revalidates_terminal_run
 test_nonpaused_working_surfaces_terminal_transitions_once
+test_same_hash_busy_runs_surface_terminal_transitions_once
+test_terminal_unknown_provenance_is_transient_then_surfaces
 test_terminal_transition_survives_pane_redraw_until_new_run
 test_exited_declared_pause_is_bounded_but_live_gate_surfaces
 test_secondmate_paused_resurfaces_in_normal_mode

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -826,9 +826,9 @@ assert_nonpaused_working_surfaces_terminal_transition_once() {  # <label> <crew-
 }
 
 test_nonpaused_working_surfaces_terminal_transitions_once() {
-  assert_nonpaused_working_surfaces_terminal_transition_once done 'state: done · source: run-step · checks green' no
+  assert_nonpaused_working_surfaces_terminal_transition_once 'done' 'state: done · source: run-step · checks green' no
   assert_nonpaused_working_surfaces_terminal_transition_once failed 'state: failed · source: run-step · validation failed' no
-  assert_nonpaused_working_surfaces_terminal_transition_once done 'state: done · source: run-step · checks green' yes
+  assert_nonpaused_working_surfaces_terminal_transition_once 'done' 'state: done · source: run-step · checks green' yes
   assert_nonpaused_working_surfaces_terminal_transition_once failed 'state: failed · source: run-step · validation failed' yes
   pass "non-paused working provenance reclassifies done and failed with sparse working or captain-relevant status"
 }
@@ -875,7 +875,7 @@ assert_same_hash_busy_run_surfaces_terminal_once() {  # <label> <crew-state>
 }
 
 test_same_hash_busy_runs_surface_terminal_transitions_once() {
-  assert_same_hash_busy_run_surfaces_terminal_once done 'state: done · source: run-step · checks green'
+  assert_same_hash_busy_run_surfaces_terminal_once 'done' 'state: done · source: run-step · checks green'
   assert_same_hash_busy_run_surfaces_terminal_once failed 'state: failed · source: run-step · validation failed'
   pass "same-hash busy runs surface done and failed transitions exactly once"
 }

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -272,6 +272,11 @@ test_crew_absorb_class_classifier() {
   [ "$(crew_absorb_class a)" = terminal ] || fail "failed run-step not classed terminal"
   FM_FAKE_CREW_STATE='state: parked · source: run-step · parked at review'
   [ "$(crew_absorb_class a)" = none ] || fail "parked run-step classed terminal"
+  [ "$(crew_terminal_transition_class a)" = nonterminal ] || fail "parked run-step did not end terminal identity"
+  FM_FAKE_CREW_STATE='state: done · source: run-step · checks green'
+  [ "$(crew_terminal_transition_class a)" = terminal ] || fail "completed run-step lost terminal identity"
+  FM_FAKE_CREW_STATE='state: unknown · source: none · run temporarily unreadable'
+  [ "$(crew_terminal_transition_class a)" = unknown ] || fail "unreadable state cleared terminal identity"
   FM_FAKE_CREW_STATE='state: working · source: status-log · working: compiling'
   [ "$(crew_absorb_class a)" = none ] || fail "stale working: status-log classed absorbable"
   FM_FAKE_CREW_STATE='state: unknown · source: none · worktree gone'
@@ -763,6 +768,89 @@ test_consumed_working_stale_surfaces_terminal_transition_once() {
   assert_tracked_stale_surfaces_terminal_transition_once working 'done' 'state: done · source: run-step · checks green'
   assert_tracked_stale_surfaces_terminal_transition_once working failed 'state: failed · source: run-step · validation failed'
   pass "consumed working stale cadence preserves authoritative done and failed transitions exactly once"
+}
+
+assert_nonpaused_working_surfaces_terminal_transition_once() {  # <label> <crew-state> <captain-relevant-status>
+  local label=$1 crew_state=$2 captain_status=$3 dir state fakebin out capture_file window key pane_hash sig pid
+  dir=$(make_case "nonpaused-working-to-$label-$captain_status"); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"; capture_file="$dir/pane.txt"; window="test:fm-nonpaused-$label-$captain_status"
+  printf 'idle after authoritative transition\n' > "$capture_file"
+  printf 'window=%s\nkind=ship\nharness=codex\nbackend=tmux\n' "$window" > "$state/$label.meta"
+  if [ "$captain_status" = yes ]; then
+    printf 'done: implementation ready before validation\n' > "$state/$label.status"
+  else
+    printf 'working: validation under way\n' > "$state/$label.status"
+  fi
+  sig=$(seen_sig "$state/$label.status"); printf '%s' "$sig" > "$state/.seen-${label}_status"
+  key=$(printf '%s' "$window" | tr ':/.' '___')
+  pane_hash=$(hash_text "idle after authoritative transition")
+  printf '%s' "$pane_hash" > "$state/.hash-$key"
+  printf '%s' "$pane_hash" > "$state/.stale-$key"
+  printf 'working:%s\n' "$pane_hash" > "$state/.stale-class-$key"
+  printf '1\n' > "$state/.count-$key"
+
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
+    FM_FAKE_TMUX_CURRENT_COMMAND=codex FM_FAKE_CREW_STATE="$crew_state" \
+    FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  wait_for_exit "$pid" 40 || fail "non-paused working provenance did not surface $label with captain status $captain_status"
+  grep -Fx "stale: $window" "$out" >/dev/null || fail "non-paused working provenance suppressed $label"
+  [ -e "$state/.terminal-transition-$key" ] || fail "$label did not retain transition identity"
+}
+
+test_nonpaused_working_surfaces_terminal_transitions_once() {
+  assert_nonpaused_working_surfaces_terminal_transition_once done 'state: done · source: run-step · checks green' no
+  assert_nonpaused_working_surfaces_terminal_transition_once failed 'state: failed · source: run-step · validation failed' no
+  assert_nonpaused_working_surfaces_terminal_transition_once done 'state: done · source: run-step · checks green' yes
+  assert_nonpaused_working_surfaces_terminal_transition_once failed 'state: failed · source: run-step · validation failed' yes
+  pass "non-paused working provenance reclassifies done and failed with sparse working or captain-relevant status"
+}
+
+test_terminal_transition_survives_pane_redraw_until_new_run() {
+  local dir state fakebin out capture_file window key first_hash second_hash sig pid wakes i
+  dir=$(make_case terminal-pane-redraw); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"; capture_file="$dir/pane.txt"; window="test:fm-terminal-redraw"
+  printf 'window=%s\nkind=ship\nharness=codex\nbackend=tmux\n' "$window" > "$state/redraw.meta"
+  printf 'working: validation under way\n' > "$state/redraw.status"
+  sig=$(seen_sig "$state/redraw.status"); printf '%s' "$sig" > "$state/.seen-redraw_status"
+  key=$(printf '%s' "$window" | tr ':/.' '___')
+  printf 'first terminal pane\n' > "$capture_file"; first_hash=$(hash_text "first terminal pane")
+  printf '%s' "$first_hash" > "$state/.hash-$key"; printf '1\n' > "$state/.count-$key"
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" FM_FAKE_TMUX_CURRENT_COMMAND=codex \
+    FM_FAKE_CREW_STATE='state: done · source: run-step · checks green' FM_STATE_OVERRIDE="$state" \
+    FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!; wait_for_exit "$pid" 40 || fail "initial terminal transition did not surface"
+
+  printf 'redrawn terminal pane\n' > "$capture_file"; second_hash=$(hash_text "redrawn terminal pane")
+  : > "$out"
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" FM_FAKE_TMUX_CURRENT_COMMAND=codex \
+    FM_FAKE_CREW_STATE='state: done · source: run-step · checks green' FM_STATE_OVERRIDE="$state" \
+    FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!; wait_live "$pid" 30 || { reap "$pid"; fail "terminal pane redraw repeated its alert"; }; reap "$pid"
+  wakes=$(awk -F '\t' -v w="$window" '$3 == "stale" && $4 == w { n++ } END { print n + 0 }' "$state/.wake-queue")
+  [ "$wakes" -eq 1 ] || fail "terminal pane redraw emitted $wakes alerts"
+  [ "$(cat "$state/.stale-class-$key" 2>/dev/null || true)" = "terminal:$second_hash" ] || fail "redraw was not deduplicated as the same terminal transition"
+
+  : > "$out"
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" FM_FAKE_TMUX_CURRENT_COMMAND=codex \
+    FM_FAKE_CREW_STATE='state: working · source: run-step · new validation' FM_STATE_OVERRIDE="$state" \
+    FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_STALE_ESCALATE_SECS=999 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  i=0
+  while [ "$i" -lt 30 ] && [ -e "$state/.terminal-transition-$key" ]; do sleep 0.1; i=$((i + 1)); done
+  [ ! -e "$state/.terminal-transition-$key" ] || { reap "$pid"; fail "new authoritative run did not clear prior terminal identity"; }
+  reap "$pid"
+
+  : > "$out"
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" FM_FAKE_TMUX_CURRENT_COMMAND=codex \
+    FM_FAKE_CREW_STATE='state: failed · source: run-step · new validation failed' FM_STATE_OVERRIDE="$state" \
+    FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!; wait_for_exit "$pid" 40 || fail "new terminal transition after resumed work did not surface"
+  wakes=$(awk -F '\t' -v w="$window" '$3 == "stale" && $4 == w { n++ } END { print n + 0 }' "$state/.wake-queue")
+  [ "$wakes" -eq 2 ] || fail "new terminal transition emitted $wakes total alerts instead of two"
+  pass "terminal identity survives pane redraw, clears on authoritative work, and allows a new terminal transition"
 }
 
 # A captain-held crew can leave a stable backend endpoint after its agent exits.
@@ -1414,6 +1502,8 @@ test_nonterminal_stale_paused_absorbed_then_resurfaced
 test_completed_run_overrides_paused_status_without_repeated_stale
 test_tracked_paused_stale_surfaces_terminal_transition_once
 test_consumed_working_stale_surfaces_terminal_transition_once
+test_nonpaused_working_surfaces_terminal_transitions_once
+test_terminal_transition_survives_pane_redraw_until_new_run
 test_exited_declared_pause_is_bounded_but_live_gate_surfaces
 test_secondmate_paused_resurfaces_in_normal_mode
 test_secondmate_nonpaused_stale_remains_suppressed

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -880,6 +880,39 @@ test_same_hash_busy_runs_surface_terminal_transitions_once() {
   pass "same-hash busy runs surface done and failed transitions exactly once"
 }
 
+test_same_hash_busy_resets_prior_wedge_cadence() {
+  local dir state fakebin out capture_file window key pane_hash sig pid
+  dir=$(make_case same-hash-busy-wedge-reset); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"; capture_file="$dir/pane.txt"; window="test:fm-busy-wedge-reset"
+  printf 'unchanged busy pane\n' > "$capture_file"
+  printf 'window=%s\nkind=ship\nharness=codex\nbackend=tmux\n' "$window" > "$state/busy-reset.meta"
+  printf 'working: validation under way\n' > "$state/busy-reset.status"
+  sig=$(seen_sig "$state/busy-reset.status"); printf '%s' "$sig" > "$state/.seen-busy-reset_status"
+  key=$(printf '%s' "$window" | tr ':/.' '___'); pane_hash=$(hash_text "unchanged busy pane")
+  printf '%s' "$pane_hash" > "$state/.hash-$key"; printf '2\n' > "$state/.count-$key"
+  printf '%s' "$pane_hash" > "$state/.stale-$key"; printf 'working:%s\n' "$pane_hash" > "$state/.stale-class-$key"
+  printf '%s\n' $(( $(date +%s) - 500 )) > "$state/.stale-since-$key"; printf '2\n' > "$state/.wedge-escalations-$key"
+
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" FM_FAKE_TMUX_CURRENT_COMMAND=codex \
+    FM_FAKE_CREW_STATE='state: working · source: run-step · validation running' FM_BUSY_REGEX='unchanged busy pane' \
+    FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_STALE_ESCALATE_SECS=1 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!; wait_live "$pid" 5 || { reap "$pid"; fail "same-hash busy period surfaced an aged wedge"; }; reap "$pid"
+  [ ! -e "$state/.stale-since-$key" ] || fail "same-hash busy period retained the prior wedge timer"
+  [ ! -e "$state/.wedge-escalations-$key" ] || fail "same-hash busy period retained wedge escalation state"
+  [ ! -s "$state/.wake-queue" ] || fail "same-hash busy cleanup emitted a stale alert"
+
+  : > "$out"
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" FM_FAKE_TMUX_CURRENT_COMMAND=codex \
+    FM_FAKE_CREW_STATE='state: working · source: run-step · validation running' FM_BUSY_REGEX='never-match-this-pane' \
+    FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_STALE_ESCALATE_SECS=1 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!; wait_live "$pid" 5 || { reap "$pid"; fail "post-busy idle pane immediately reused the prior wedge timer"; }; reap "$pid"
+  [ -s "$state/.stale-since-$key" ] || fail "post-busy idle pane did not start a fresh wedge timer"
+  [ ! -s "$state/.wake-queue" ] || fail "post-busy idle pane immediately emitted a stale alert"
+  pass "same-hash busy time resets prior wedge cadence before idle resumes"
+}
+
 test_terminal_unknown_provenance_is_transient_then_surfaces() {
   local dir state fakebin out capture_file window key pane_hash sig pid
   dir=$(make_case terminal-persistent-unknown); state="$dir/state"; fakebin="$dir/fakebin"
@@ -1635,6 +1668,7 @@ test_consumed_working_stale_surfaces_terminal_transition_once
 test_fresh_pause_cache_revalidates_terminal_run
 test_nonpaused_working_surfaces_terminal_transitions_once
 test_same_hash_busy_runs_surface_terminal_transitions_once
+test_same_hash_busy_resets_prior_wedge_cadence
 test_terminal_unknown_provenance_is_transient_then_surfaces
 test_terminal_transition_survives_pane_redraw_until_new_run
 test_exited_declared_pause_is_bounded_but_live_gate_surfaces


### PR DESCRIPTION
## Intent

Fix repeated monitoring alerts when an authoritative completed no-mistakes run is paired with an older sparse paused: status event. Preserve run-step precedence by treating completed or failed authoritative run-step states as terminal, surface each first observed terminal transition exactly once even after prior pause, working, busy, or wedge-cadence cleanup, and do not route terminal states into pause cadence or repeated stopped-work alerts. Genuine declared external waits must retain their bounded pause/recheck behavior, while parked, unknown, stopped, and other nonterminal work must still surface. Keep the change at the watcher classification boundary, preserve durable per-hash transition provenance where transient cadence state is insufficient, add focused done/failed regression coverage for the exact combination and transition counterexamples, and validate with the full repository test and pinned lint commands.

## What Changed

- Prioritize authoritative done/failed run-step states over stale pause events and surface each terminal transition exactly once across pause, working, busy, redraw, and wedge-cadence state changes.
- Preserve bounded external-wait rechecks while allowing persistent unknown, parked, stopped, and other nonterminal states to return to normal stale-work surfacing.
- Add focused watcher regressions, document durable terminal provenance, and fail Orca spawning cleanly when metadata publication fails.

## Risk Assessment

✅ Low: Captain, the final repair restores busy-state cleanup while preserving terminal deduplication, bounded unknown handling, pause precedence, and focused transition coverage; no material source defect remains.

## Testing

The supplied baseline and unchanged full-suite rerun passed with tmux 3.7b; focused watcher tests, five Bash 3.2 Orca repetitions, and direct operator-state evidence also passed. Pinned lint was not run because this testing step explicitly prohibited linters.

<details>
<summary>Evidence: Watcher end-to-end transition transcript</summary>

`Authoritative done and failed states each produced exactly one operator wake, retained terminal provenance, and created no pause-cadence marker despite an older paused event.`

```text
ok - a completed run overrides trailing paused status, surfaces once as terminal, and does not enter pause cadence
== completed-run-paused-status ==
sparse status event: paused: waiting for an external dependency before validation resumed
operator wake queue:
kind=stale key=test:fm-complete payload=stale: test:fm-complete
terminal provenance: present
pause cadence marker: absent
wake count: 1

== tracked-paused-to-failed ==
sparse status event: paused: waiting for an external dependency
operator wake queue:
kind=stale key=test:fm-paused-to-failed payload=stale: test:fm-paused-to-failed
terminal provenance: present
pause cadence marker: absent
wake count: 1
```
</details>
<details>
<summary>Evidence: Orca metadata-failure cleanup transcript</summary>

`Under GNU Bash 3.2.57, forced metadata publication failure published no regular metadata and issued terminal-close and forced worktree-removal operations.`

```text
ok - fm-spawn.sh --backend orca: releases terminal and worktree on later aborts
host shell: GNU bash, version 3.2.57(1)-release (arm64-apple-darwin25)
metadata target: directory (forced publication failure)
regular metadata published: no
cleanup operations issued:
terminal close handle=term-meta-fail
worktree rm target=id:wt-meta-fail force=--force
```
</details>
- Outcome: 🔧 1 issue found → auto-fixed ✅ across 2 runs (1h43m48s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (4) ✅</summary>

- 🚨 `bin/fm-watch.sh:964` - Captain, this contradicts the required criterion “surface each first observed terminal transition exactly once even after prior pause, working, busy, or wedge-cadence cleanup.” The new `working:&lt;hash&gt;` provenance is recorded here, but same-hash non-paused and stale-captain-status paths never re-read it; a working→done/failed transition is therefore misreported through wedge cadence or suppressed after cadence cleanup. Reclassify persisted working hashes and add non-paused counterexamples.
- 🚨 `bin/fm-watch.sh:1055` - This deletion contradicts “surface each first observed terminal transition exactly once” and “do not route terminal states into … repeated stopped-work alerts.” After a terminal state is surfaced for one pane hash, any subsequent pane redraw deletes its terminal provenance; once the new hash becomes stale, the unchanged completed run surfaces again. Preserve terminal-transition identity across pane-hash churn, or confirm that repeated alerts after redraws are intended.

🔧 Fix: Captain, preserve terminal alerts across watcher state transitions
3 issues (2 errors, 1 warning) still open:
- 🚨 `bin/fm-classify-lib.sh:365` - Captain, this contradicts the required rule to clear terminal identity only when authoritative state leaves terminal. If the no-mistakes lookup transiently misses, the same older `paused:` event becomes `paused · source: status-log`; this branch calls it nonterminal, deletes the durable marker, and lets the unchanged terminal run alert again when lookup recovers. A sparse status-log pause must not by itself invalidate an authoritative terminal identity.
- 🚨 `bin/fm-watch.sh:414` - The terminal handling added here remains unreachable while `.paused-rechecked-*` is fresh: the earlier cache path returns `paused` without reading current run state, especially for a dead endpoint. A run completing during that interval remains in pause cadence for up to the stale-recheck threshold and can emit an awaiting-external alert, contradicting “do not route terminal states into pause cadence.” Revalidate authoritative run state before reusing cached pause classification.
- ⚠️ `bin/fm-watch.sh:935` - Every watcher loop now invokes `fm-crew-state.sh` for every task retaining a terminal marker. That reader can perform a bounded 10-second no-mistakes query, so several completed tasks can serially delay signal processing and the watcher beacon on every poll. Recheck terminal identity only on a bounded cadence or a meaningful state-change indicator.

🔧 Fix: Captain, bound terminal rechecks and preserve run precedence
2 errors still open:
- 🚨 `bin/fm-watch.sh:962` - Captain, this contradicts “surface each first observed terminal transition exactly once even after prior … busy.” Only pane-hash changes force terminal-identity refresh; native backend busy state can transition terminal→working→terminal while the captured pane hash remains unchanged. If that run finishes within the 240-second cadence, the old marker survives and line 987 suppresses the new terminal transition. Treat observed busy state as a meaningful forced refresh and cover a same-hash fast run.
- 🚨 `bin/fm-classify-lib.sh:365` - This contradicts “parked, unknown, stopped, and other nonterminal work must still surface.” After a terminal alert, a persistently unattributed idle/stopped task returns `unknown` here forever; refresh never clears or supersedes the terminal marker, and line 987 consequently bypasses ordinary stale classification indefinitely. Preserve transient-miss deduplication while allowing persistent unknown/stopped evidence to surface, for example through bounded unknown provenance without discarding the prior terminal identity prematurely.

🔧 Fix: Captain, preserve busy transitions and bound unknown provenance
1 error still open:
- 🚨 `bin/fm-watch.sh:1000` - Captain, the busy-path refactor leaves cleanup under the `n &lt; 2` branch only. Once `n &gt;= 2` and `terminal_busy=1`, the inner classification is skipped but `.stale-since-*`, wedge escalation, and pause tracking are not reset. Time spent actively busy therefore continues aging a prior wedge timer and can trigger an immediate false stale alert when the pane becomes idle. Restore the former cleanup behavior for both “busy” and “not yet stable” cases.

🔧 Fix: Captain, reset wedge cadence during busy periods
✅ Re-checked - no issues remain.

</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed ✅</summary>

- 🚨 tests failed with exit code 1
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`

🔧 Fix: Captain, fail metadata publication cleanly on Bash 3.2
✅ Re-checked - no issues remain.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- `Confirmed the supplied baseline full-suite command had already passed.`
- <code>Ran `bash tests/fm-backend-orca.test.sh` five consecutive times under GNU Bash 3.2.57.</code>
- <code>Ran `bash tests/fm-watch-triage.test.sh`.</code>
- <code>Invoked `bin/fm-watch.sh` through repository fixtures for authoritative done and failed states paired with older sparse paused events; inspected `.wake-queue`, terminal provenance, and pause markers.</code>
- <code>Invoked `bin/fm-spawn.sh --backend orca` with forced metadata-publication failure; inspected metadata state and Orca cleanup operations.</code>
- <code>Reran unchanged full command: `command -v tmux &gt;/dev/null || { echo &#34;tmux is required for e2e tests&#34; &gt;&amp;2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo &#34;== $t ==&#34;; bash &#34;$t&#34; || rc=1; done; exit &#34;$rc&#34;`.</code>
- <code>Verified `git status --short --untracked-files=all` is clean.</code>

</details>

<details>
<summary>⚠️ **Document** - 1 error</summary>

- 🚨 `tests/fm-watch-triage.test.sh:829` - Pinned lint fails on three unquoted `done` arguments. Fixing them requires executable test edits, forbidden by this documentation-only task.

</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: Captain, quote literal done arguments for ShellCheck
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
