### PR TITLE
feat(lock): recognize Copilot CLI for session lock and harness detection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,6 +154,7 @@ A silent bootstrap section needs no action; for any printed actionable diagnosti
 
 Load `harness-adapters` before every spawn or recovery and before trust handling, skill invocation, interrupt, exit, resume, or adapter verification.
 The verified harnesses are `claude`, `codex`, `opencode`, `pi`, and `grok`; never dispatch on an unverified adapter.
+GitHub Copilot CLI (`copilot`) is recognized for session-lock and own-harness detection only and is never dispatchable as a crewmate or secondmate harness.
 If configured harness data names an unverified adapter, report it and fall back only to a verified adapter rather than launching it.
 
 `docs/configuration.md` owns dispatch-profile and runtime-backend schemas, `bin/fm-dispatch-select.sh` owns selector mechanics, `bin/fm-harness.sh` owns static resolution, and `bin/fm-spawn.sh` owns launch flags and fail-closed validation.

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # Detect the agent harness this process tree runs on.
-# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|grok|unknown
+# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|grok|copilot|unknown
+#                                        (copilot is lock/detection only, never
+#                                        dispatchable as a crew/secondmate harness)
 #        fm-harness.sh crew             print the effective CREWMATE harness
 #                                        (config/crew-harness; "default" resolves to own)
 #        fm-harness.sh secondmate       print the harness the PRIMARY uses to launch
@@ -45,8 +47,14 @@ detect_own() {
       *opencode*) echo opencode; return ;;
       *grok*) echo grok; return ;;
       pi) echo pi; return ;;
-      node*|python*)
+      copilot) echo copilot; return ;;
+      node*|python*|MainThread)
         # Bare interpreter: match the harness name in its script path.
+        # MainThread is GitHub Copilot CLI's comm (verified 2026-07-21, copilot
+        # 1.0.73: the bundled ELF renames its main thread and its args are
+        # exactly "copilot"). copilot is lock/detection only, not dispatchable;
+        # its glob is anchored so argv like ".../extensions/copilot --locale"
+        # never matches.
         args=$(ps -o args= -p "$pid" 2>/dev/null)
         case "$args" in
           *claude*) echo claude; return ;;
@@ -54,6 +62,7 @@ detect_own() {
           *opencode*) echo opencode; return ;;
           *grok*) echo grok; return ;;
           *" pi "*|*/pi) echo pi; return ;;
+          copilot|"copilot "*) echo copilot; return ;;
         esac ;;
     esac
     pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')

--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -19,10 +19,10 @@ mkdir -p "$STATE"
 # a dispatchable crew/secondmate harness. Verified 2026-07-21 on copilot 1.0.73:
 # its bundled ELF renames the main thread, so `ps -o comm=` reports "MainThread"
 # while `ps -o args=` is exactly "copilot"; recognition therefore rides the args
-# path. The copilot alternative is anchored to a standalone word so unrelated
-# argv such as ".../extensions/copilot --locale" or
-# "@vscode/copilot-typescript-server-plugin" never matches.
-HARNESS_RE='claude|codex|opencode|grok|^pi$|(^| )copilot( |$)'
+# path. The copilot alternative is anchored to the start of argv (matching
+# fm-harness.sh detection) so unrelated argv such as ".../extensions/copilot
+# --locale" or "node runner.js copilot" never matches.
+HARNESS_RE='claude|codex|opencode|grok|^pi$|^copilot( |$)'
 
 harness_pid() {
   local pid=$$ comm args

--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -15,7 +15,14 @@ LOCK="$STATE/.lock"
 mkdir -p "$STATE"
 
 # Known harness command names; extend when a new adapter is verified.
-HARNESS_RE='claude|codex|opencode|grok|^pi$'
+# copilot (GitHub Copilot CLI) is recognized for lock/detection only - it is NOT
+# a dispatchable crew/secondmate harness. Verified 2026-07-21 on copilot 1.0.73:
+# its bundled ELF renames the main thread, so `ps -o comm=` reports "MainThread"
+# while `ps -o args=` is exactly "copilot"; recognition therefore rides the args
+# path. The copilot alternative is anchored to a standalone word so unrelated
+# argv such as ".../extensions/copilot --locale" or
+# "@vscode/copilot-typescript-server-plugin" never matches.
+HARNESS_RE='claude|codex|opencode|grok|^pi$|(^| )copilot( |$)'
 
 harness_pid() {
   local pid=$$ comm args
@@ -26,8 +33,9 @@ harness_pid() {
       echo "$pid"; return 0
     fi
     # Bare interpreter (e.g. node): match the harness name in its script path.
+    # MainThread is copilot's comm (see HARNESS_RE note); its args carry the name.
     case "$comm" in
-      *node*|*python*) printf '%s' "$args" | grep -qE "$HARNESS_RE" && { echo "$pid"; return 0; } ;;
+      *node*|*python*|MainThread) printf '%s' "$args" | grep -qE "$HARNESS_RE" && { echo "$pid"; return 0; } ;;
     esac
     pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
     [ -n "$pid" ] && [ "$pid" -gt 1 ] || return 1

--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -47,7 +47,17 @@ holder_alive() {  # true if $1 is a live process that looks like a harness
   local pid=$1 comm
   kill -0 "$pid" 2>/dev/null || return 1
   comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
-  printf '%s' "$(basename "$comm") $(ps -o args= -p "$pid" 2>/dev/null)" | grep -qE "$HARNESS_RE"
+  if printf '%s' "$(basename "$comm")" | grep -qE "$HARNESS_RE"; then
+    return 0
+  fi
+  # Only trust args when comm is a bare interpreter or copilot's MainThread,
+  # mirroring harness_pid; otherwise a recycled pid whose argv merely mentions
+  # a harness name (e.g. "gh copilot suggest") would look like a live holder.
+  case "$comm" in
+    *node*|*python*|MainThread)
+      printf '%s' "$(ps -o args= -p "$pid" 2>/dev/null)" | grep -qE "$HARNESS_RE" ;;
+    *) return 1 ;;
+  esac
 }
 
 if [ "${1:-}" = "status" ]; then

--- a/bin/fm-supervision-instructions.sh
+++ b/bin/fm-supervision-instructions.sh
@@ -82,6 +82,10 @@ fi
 
 case "$HARNESS" in
   claude|codex|opencode|pi|grok) SNIPPET="$DOC_DIR/$HARNESS.md" ;;
+  # copilot is detected distinctly (lock/detection only, not dispatchable) but
+  # has no verified watcher wake adapter, so it keeps its name in the heading
+  # while operating on the generic manual-supervision fallback snippet.
+  copilot) SNIPPET="$DOC_DIR/unknown.md" ;;
   *) HARNESS=unknown; SNIPPET="$DOC_DIR/unknown.md" ;;
 esac
 [ -f "$SNIPPET" ] || SNIPPET="$DOC_DIR/unknown.md"
@@ -203,6 +207,9 @@ else
   printf '%s\n' '- X mode: inactive; use the default watcher cadence.'
 fi
 ordinary_wake_line
+if [ "$HARNESS" = copilot ]; then
+  printf '%s\n' '- Harness note: copilot is recognized for session identity only; it has no verified watcher wake adapter and is never dispatchable for crew or secondmate work, so supervise manually per the fallback below.'
+fi
 printf '\n'
 render_snippet
 printf '\n'

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -165,6 +165,7 @@ The full cmux home label also includes a short hash of the resolved `FM_ROOT` pa
 ## Harness support
 
 claude, codex, opencode, pi, and grok are all empirically verified; new harnesses get verified through a supervised trial task before joining the set.
+GitHub Copilot CLI (`copilot`) is additionally recognized for the session lock and own-harness detection only, so a copilot-driven home can hold its own lock; it has no verified watcher wake adapter (supervision falls back to the manual snippet) and is never dispatchable as a crewmate or secondmate harness.
 The verified adapter knowledge - busy signatures, interrupt and exit commands, skill-invocation syntax, and per-harness quirks - lives in [`.agents/skills/harness-adapters/SKILL.md`](../.agents/skills/harness-adapters/SKILL.md).
 Launch mechanics, including the verified command templates, live in [`bin/fm-spawn.sh`](../bin/fm-spawn.sh).
 Primary-session turn-end guard integrations for verified harnesses are tracked as repo-level hook files and documented in [`docs/turnend-guard.md`](turnend-guard.md).

--- a/tests/fm-copilot-harness.test.sh
+++ b/tests/fm-copilot-harness.test.sh
@@ -98,6 +98,21 @@ SH
   printf '%s\n' "$$" > "$home/state/.lock"
   out=$(FM_HOME="$home" PATH="$fakebin:$PATH" "$LOCK" status)
   assert_contains "$out" "lock: stale" "holder with only plugin-path copilot argv should read as stale"
+
+  # MainThread comm with copilot as a mid-argv word (not at argv start) must
+  # not match either - lock recognition aligns with fm-harness.sh detection.
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *"ppid="*) exit 1 ;;
+  *"comm="*) printf '%s\n' 'MainThread'; exit 0 ;;
+  *"args="*) printf '%s\n' 'node runner.js copilot'; exit 0 ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/ps"
+  out=$(FM_HOME="$home" PATH="$fakebin:$PATH" "$LOCK" status)
+  assert_contains "$out" "lock: stale" "MainThread holder with mid-argv copilot should read as stale"
   pass "anchored copilot match ignores vscode plugin paths in unrelated argv"
 }
 

--- a/tests/fm-copilot-harness.test.sh
+++ b/tests/fm-copilot-harness.test.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+# Behavior tests for GitHub Copilot CLI recognition: session-lock acquisition and
+# holder detection, own-harness detection, anchored non-matches against unrelated
+# copilot-flavored argv, and the dispatch refusal that keeps copilot lock/detection
+# only (never a crew/secondmate harness).
+# Empirical shape (copilot 1.0.73, 2026-07-21): `ps -o comm=` reports "MainThread"
+# (the bundled ELF renames its main thread) and `ps -o args=` is exactly "copilot".
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+LOCK="$ROOT/bin/fm-lock.sh"
+HARNESS="$ROOT/bin/fm-harness.sh"
+SPAWN="$ROOT/bin/fm-spawn.sh"
+TMP_ROOT=$(fm_test_tmproot fm-copilot-harness)
+
+# Fake ps reproducing the observed copilot process shape for every queried pid.
+make_copilot_ps() {
+  local fakebin=$1
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *"ppid="*) exit 1 ;;
+  *"comm="*) printf '%s\n' 'MainThread'; exit 0 ;;
+  *"args="*) printf '%s\n' 'copilot'; exit 0 ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/ps"
+}
+
+test_fm_lock_acquires_under_copilot_ancestor() {
+  local home fakebin out status
+  home="$TMP_ROOT/acquire-home"
+  fakebin=$(fm_fakebin "$TMP_ROOT/acquire-fake")
+  mkdir -p "$home/state"
+  make_copilot_ps "$fakebin"
+  out=$(FM_HOME="$home" PATH="$fakebin:$PATH" "$LOCK")
+  status=$?
+  expect_code 0 "$status" "copilot-ancestored lock acquisition should succeed"
+  assert_contains "$out" "lock acquired: harness pid" "fm-lock did not acquire under a copilot ancestor"
+  assert_present "$home/state/.lock" "lock file was not written"
+  pass "fm-lock acquires under a copilot ancestor (comm MainThread, args copilot)"
+}
+
+test_fm_lock_overwrites_stale_dead_copilot_holder() {
+  local home fakebin dead out status
+  home="$TMP_ROOT/stale-home"
+  fakebin=$(fm_fakebin "$TMP_ROOT/stale-fake")
+  mkdir -p "$home/state"
+  make_copilot_ps "$fakebin"
+  dead=$(bash -c 'echo $$')
+  while kill -0 "$dead" 2>/dev/null; do sleep 0.1; done
+  printf '%s\n' "$dead" > "$home/state/.lock"
+  out=$(FM_HOME="$home" PATH="$fakebin:$PATH" "$LOCK")
+  status=$?
+  expect_code 0 "$status" "stale dead-holder lock should be overwritten"
+  assert_contains "$out" "lock acquired: harness pid" "fm-lock did not overwrite the stale holder"
+  [ "$(cat "$home/state/.lock")" != "$dead" ] || fail "stale holder pid survived in the lock file"
+  pass "fm-lock overwrites a stale dead-holder lock under a copilot ancestor"
+}
+
+test_fm_lock_recognizes_copilot_holder() {
+  local home fakebin out
+  home="$TMP_ROOT/holder-home"
+  fakebin=$(fm_fakebin "$TMP_ROOT/holder-fake")
+  mkdir -p "$home/state"
+  printf '%s\n' "$$" > "$home/state/.lock"
+  make_copilot_ps "$fakebin"
+  out=$(FM_HOME="$home" PATH="$fakebin:$PATH" "$LOCK" status)
+  assert_contains "$out" "lock: held by live harness pid" "fm-lock did not recognize copilot as a live holder"
+  pass "fm-lock recognizes a copilot holder as live"
+}
+
+test_fm_lock_ignores_unrelated_copilot_argv() {
+  local home fakebin out status
+  home="$TMP_ROOT/plugin-home"
+  fakebin=$(fm_fakebin "$TMP_ROOT/plugin-fake")
+  mkdir -p "$home/state"
+  # A node process whose argv only mentions copilot inside plugin paths (the
+  # VS Code tsserver shape observed alongside the real copilot CLI) must not
+  # be mistaken for a harness.
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *"ppid="*) exit 1 ;;
+  *"comm="*) printf '%s\n' 'node'; exit 0 ;;
+  *"args="*) printf '%s\n' 'node tsserver.js --globalPlugins @vscode/copilot-typescript-server-plugin --pluginProbeLocations /x/extensions/copilot --locale en'; exit 0 ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/ps"
+  out=$(FM_HOME="$home" PATH="$fakebin:$PATH" "$LOCK" 2>&1)
+  status=$?
+  expect_code 1 "$status" "plugin-path argv must not be recognized as a harness"
+  assert_contains "$out" "cannot locate harness process" "fm-lock accepted vscode copilot plugin argv as a harness"
+  printf '%s\n' "$$" > "$home/state/.lock"
+  out=$(FM_HOME="$home" PATH="$fakebin:$PATH" "$LOCK" status)
+  assert_contains "$out" "lock: stale" "holder with only plugin-path copilot argv should read as stale"
+  pass "anchored copilot match ignores vscode plugin paths in unrelated argv"
+}
+
+test_fm_lock_acquires_under_renamed_copilot_wrapper() {
+  local home wrapper out status
+  home="$TMP_ROOT/wrapper-home"
+  mkdir -p "$home/state" "$TMP_ROOT/wrapper-bin"
+  # Real ps, real ancestry: a wrapper process whose comm is "copilot" (a script
+  # named copilot) stands in for the CLI on platforms where comm is the binary name.
+  wrapper="$TMP_ROOT/wrapper-bin/copilot"
+  # Direct shebang: an env shebang would exec bash and reset comm to "bash",
+  # while a direct interpreter keeps comm as the script name "copilot".
+  cat > "$wrapper" <<'SH'
+#!/bin/bash
+"$@"
+SH
+  chmod +x "$wrapper"
+  out=$(FM_HOME="$home" "$wrapper" "$LOCK")
+  status=$?
+  expect_code 0 "$status" "lock acquisition under a copilot-named ancestor should succeed"
+  assert_contains "$out" "lock acquired: harness pid" "fm-lock did not find the copilot-named ancestor with real ps"
+  pass "fm-lock acquires under a real copilot-named ancestor process"
+}
+
+test_fm_harness_reports_copilot() {
+  local fakebin out
+  fakebin=$(fm_fakebin "$TMP_ROOT/detect-fake")
+  make_copilot_ps "$fakebin"
+  out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT PATH="$fakebin:$PATH" "$HARNESS")
+  [ "$out" = copilot ] || fail "fm-harness printed '$out' instead of copilot for the MainThread/args shape"
+
+  # comm reported directly as the binary name (non-thread-renaming platforms).
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *"ppid="*) exit 1 ;;
+  *"comm="*) printf '%s\n' '/home/x/.local/bin/copilot'; exit 0 ;;
+  *"args="*) printf '%s\n' 'copilot'; exit 0 ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/ps"
+  out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT PATH="$fakebin:$PATH" "$HARNESS")
+  [ "$out" = copilot ] || fail "fm-harness printed '$out' instead of copilot for a copilot comm"
+  pass "fm-harness reports copilot distinctly for both observed process shapes"
+}
+
+test_fm_harness_existing_detection_unchanged() {
+  local fakebin out
+  fakebin=$(fm_fakebin "$TMP_ROOT/regress-fake")
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *"ppid="*) exit 1 ;;
+  *"comm="*) printf '%s\n' 'pi'; exit 0 ;;
+  *"args="*) printf '%s\n' 'pi'; exit 0 ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/ps"
+  out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT PATH="$fakebin:$PATH" "$HARNESS")
+  [ "$out" = pi ] || fail "fm-harness printed '$out' instead of pi (anchoring regression)"
+  pass "existing pi detection is unchanged by the copilot entry"
+}
+
+test_spawn_refuses_copilot_dispatch() {
+  local case_dir home proj wt fakebin id out status
+  case_dir="$TMP_ROOT/spawn-refuse"
+  home="$case_dir/home"
+  proj="$case_dir/project"
+  wt="$case_dir/wt"
+  fakebin=$(fm_fakebin "$case_dir/fake")
+  id="copilot-refuse-x1"
+  mkdir -p "$home/data/$id" "$home/projects" "$home/state" "$home/config"
+  printf 'brief\n' > "$home/data/$id/brief.md"
+  fm_git_worktree "$proj" "$wt" "fm/$id"
+  touch "$home/state/.last-watcher-beat"
+  fm_fake_exit0 "$fakebin" tmux treehouse gh-axi gh
+
+  # Explicit harness argument.
+  out=$(FM_ROOT_OVERRIDE='' FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
+    FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" PATH="$fakebin:$PATH" \
+    "$SPAWN" "$id" "$proj" copilot 2>&1)
+  status=$?
+  expect_code 1 "$status" "explicit copilot harness must be refused"
+  assert_contains "$out" "unknown harness 'copilot'" "spawn did not refuse the explicit copilot harness"
+
+  # Configured crew harness resolving to copilot.
+  printf 'copilot\n' > "$home/config/crew-harness"
+  out=$(FM_ROOT_OVERRIDE='' FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
+    FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" PATH="$fakebin:$PATH" \
+    "$SPAWN" "$id" "$proj" 2>&1)
+  status=$?
+  expect_code 1 "$status" "crew-harness copilot must be refused"
+  assert_contains "$out" "no launch template for harness 'copilot'" "spawn did not refuse the configured copilot crew harness"
+  pass "crew/secondmate dispatch of copilot is still refused fail-closed"
+}
+
+test_fm_lock_acquires_under_copilot_ancestor
+test_fm_lock_overwrites_stale_dead_copilot_holder
+test_fm_lock_recognizes_copilot_holder
+test_fm_lock_ignores_unrelated_copilot_argv
+test_fm_lock_acquires_under_renamed_copilot_wrapper
+test_fm_harness_reports_copilot
+test_fm_harness_existing_detection_unchanged
+test_spawn_refuses_copilot_dispatch

--- a/tests/fm-copilot-harness.test.sh
+++ b/tests/fm-copilot-harness.test.sh
@@ -101,6 +101,43 @@ SH
   pass "anchored copilot match ignores vscode plugin paths in unrelated argv"
 }
 
+test_fm_lock_holder_argv_only_matters_for_interpreters() {
+  local home fakebin out
+  home="$TMP_ROOT/recycled-home"
+  fakebin=$(fm_fakebin "$TMP_ROOT/recycled-fake")
+  mkdir -p "$home/state"
+  printf '%s\n' "$$" > "$home/state/.lock"
+  # Recycled pid: comm gh, argv merely containing the word copilot must not
+  # read as a live harness holder.
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *"ppid="*) exit 1 ;;
+  *"comm="*) printf '%s\n' 'gh'; exit 0 ;;
+  *"args="*) printf '%s\n' 'gh copilot suggest fix my code'; exit 0 ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/ps"
+  out=$(FM_HOME="$home" PATH="$fakebin:$PATH" "$LOCK" status)
+  assert_contains "$out" "lock: stale" "gh-comm holder with copilot argv should read as stale"
+
+  # comm-only path still recognizes a real harness comm.
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *"ppid="*) exit 1 ;;
+  *"comm="*) printf '%s\n' 'claude'; exit 0 ;;
+  *"args="*) printf '%s\n' 'claude'; exit 0 ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/ps"
+  out=$(FM_HOME="$home" PATH="$fakebin:$PATH" "$LOCK" status)
+  assert_contains "$out" "lock: held by live harness pid" "claude comm holder should still read as live"
+  pass "holder argv is only trusted for interpreter/MainThread comms"
+}
+
 test_fm_lock_acquires_under_renamed_copilot_wrapper() {
   local home wrapper out status
   home="$TMP_ROOT/wrapper-home"
@@ -204,6 +241,7 @@ test_fm_lock_acquires_under_copilot_ancestor
 test_fm_lock_overwrites_stale_dead_copilot_holder
 test_fm_lock_recognizes_copilot_holder
 test_fm_lock_ignores_unrelated_copilot_argv
+test_fm_lock_holder_argv_only_matters_for_interpreters
 test_fm_lock_acquires_under_renamed_copilot_wrapper
 test_fm_harness_reports_copilot
 test_fm_harness_existing_detection_unchanged

--- a/tests/fm-supervision-instructions.test.sh
+++ b/tests/fm-supervision-instructions.test.sh
@@ -27,6 +27,18 @@ test_unknown_fallback() {
   pass "renderer falls back to unknown.md for unverified harness names"
 }
 
+test_copilot_detected_but_manual() {
+  local out
+  out=$("$RENDER" --harness copilot)
+  assert_contains "$out" "SUPERVISION OPERATING INSTRUCTIONS - primary harness: copilot" "copilot heading missing or renamed to unknown"
+  assert_contains "$out" "Mode: Unknown harness fallback." "copilot did not get the manual-supervision fallback snippet"
+  assert_contains "$out" "never dispatchable for crew or secondmate work" "copilot harness note missing"
+  assert_not_contains "$out" "Mode: Claude background-notify supervision." "copilot must not claim a wired watcher protocol"
+  out=$("$RENDER" --harness copilot --repair-line)
+  assert_contains "$out" "according to the session-start block for this harness" "copilot repair line should be the generic one"
+  pass "copilot keeps its name but degrades to manual supervision with no wired protocol"
+}
+
 test_conditional_stanzas() {
   local home config out
   home="$TMP_ROOT/conditional-home"
@@ -135,6 +147,7 @@ test_pi_snippet_uses_effective_extension_path() {
 
 test_selected_harness_block_only
 test_unknown_fallback
+test_copilot_detected_but_manual
 test_conditional_stanzas
 test_repair_lines
 test_ordinary_wake_lines_are_distinct_from_repair


### PR DESCRIPTION
## Intent

The developer wanted to research, via a subagent, how to implement an equivalent of Claude Code's automatic session handoff behavior for the GitHub Copilot CLI within their firstmate multi-agent supervision project. Their goal was to understand what Copilot CLI and its SDK offer (hooks, compaction events, session creation/resume, context usage monitoring) and how a fresh-session handoff before context compaction could be built, since no native mechanism exists. They wanted verified, cited findings covering triggers, state transfer, crash recovery, session locking/ownership, and watcher continuity, with an eye toward adding Copilot as a new harness adapter in firstmate. When the research dragged on, they pushed the agent to stop expanding and finalize its conclusions from evidence already gathered.

## What Changed

- Taught `fm-lock.sh` and `fm-harness.sh` to recognize GitHub Copilot CLI: since copilot 1.0.73's bundled ELF renames its main thread (`comm` reports `MainThread` while `args` is exactly `copilot`), recognition rides the args path with a start-of-argv anchored `copilot` pattern so unrelated argv like `.../extensions/copilot --locale` or `node runner.js copilot` never matches. A copilot-driven home can now hold its own session lock and report `copilot` as its own harness.
- Hardened `holder_alive()` to only trust argv when `comm` is a bare interpreter or copilot's `MainThread`, mirroring `harness_pid()`, so a recycled pid whose argv merely mentions a harness name no longer looks like a live lock holder.
- Routed `copilot` through the generic manual-supervision fallback snippet in `fm-supervision-instructions.sh` (it keeps its name in the heading but has no verified watcher wake adapter) and documented in `AGENTS.md` and `docs/configuration.md` that copilot is lock/detection-only and never dispatchable as a crewmate or secondmate harness. Adds coverage in `tests/fm-copilot-harness.test.sh` and `tests/fm-supervision-instructions.test.sh`.

## Risk Assessment

✅ Low: The follow-up commit is a minimal, correctly implemented regex anchoring fix with matching comment update and a targeted regression test, fully resolving the prior round's finding without side effects.

## Testing

Completed 1 recorded test check.

- Outcome: ⚠️ 1 error across 1 run (24m2s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- ℹ️ `bin/fm-lock.sh:25` - Copilot argv matching is asymmetric between scripts: fm-lock.sh HARNESS_RE (&#39;(^| )copilot( |$)&#39;) accepts &#39;copilot&#39; as a standalone word anywhere in an interpreter/MainThread argv, while fm-harness.sh only matches argv that begins with &#39;copilot&#39; (patterns &#39;copilot&#39; | &#39;copilot *&#39;). A process like &#39;node runner.js copilot&#39; would hold the session lock per fm-lock.sh yet be reported &#39;unknown&#39; by fm-harness.sh. Tightening the lock regex to prefix-anchored &#39;^copilot( |$)&#39; would align them and shrink the false-positive window.
- ℹ️ `bin/fm-lock.sh:57` - &#39;MainThread&#39; as comm is not unique to Copilot CLI (any process that renames its main thread reports it), and the pre-existing unanchored alternatives (claude|codex|opencode|grok) then match anywhere in that process&#39;s argv in both harness_pid and holder_alive. This modestly widens the args-trust surface beyond node*/python*, though it is the same risk class the existing interpreter paths already accept. No action strictly required; noting the tradeoff.

🔧 Fix: prefix-anchor copilot lock regex to match harness detection
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Test** - 1 error</summary>

- 🚨 tests failed with exit code 1
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
