### PR TITLE
feat(council): add persistent multi-model council MVP with sandboxed Herdr lane

### DIFF
--- a/.agents/skills/council/SKILL.md
+++ b/.agents/skills/council/SKILL.md
@@ -48,7 +48,7 @@ After Firstmate restarts during collection, use `recover` once and tell the capt
 Never respawn a participant merely because Firstmate restarted.
 
 Close only on an explicit captain command.
-Run `close` exactly once and treat an endpoint-identity refusal as a blocker requiring inspection, never as permission to guess a pane or broaden cleanup.
+Run `close` and, if it fails partway, rerun it: journal-confirmed members are skipped, while an endpoint-identity refusal remains a blocker requiring inspection, never permission to guess a pane or broaden cleanup.
 Closing clears only that council's participant conversations and does not affect another council or create an implementation task.
 
 ## Outcome phrasing

--- a/.agents/skills/council/SKILL.md
+++ b/.agents/skills/council/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: council
+description: >-
+  Create and operate the thin persistent read-only model council when the captain invokes /council or naturally asks to create, question, accept, reject, rerun, retry, or close a council.
+  Keeps exact Claude Fable and Codex GPT-5.6 Sol participant conversations across rounds, requires project-specific provider disclosure consent, and routes implementation to a separate ordinary task only after an explicit accept-and-implement instruction.
+user-invocable: true
+metadata:
+  internal: true
+---
+
+# council
+
+Use this skill for every captain request concerning a persistent model council.
+Run `bin/fm-council.sh --help` before the first mutation in a session because that output owns exact commands, fields, phase transitions, storage, and safety mechanics.
+
+## Captain-facing workflow
+
+Translate natural language into one of six outcomes: create, ask, accept, accept and implement, reject or rerun, and close.
+Use the captain's council name in chat and keep script identifiers out of captain-facing messages.
+
+For create, require one name, one absolute local project path, and at least two exact profiles.
+The MVP supports only `claude/claude-fable-5/xhigh` and `codex/gpt-5.6-sol/xhigh`, and an unsupported profile is a blocker rather than permission to substitute.
+A new council always gets fresh participant conversations.
+It receives the project's active accepted decisions by default, while an explicit clean-slate request maps to `--clean-slate` and omits them.
+After create, load `harness-adapters`, inspect each fresh exact endpoint for its already-verified trust or bypass confirmation, handle only that dialog, and verify both participant interfaces are idle before the first ask.
+
+Provider disclosure is security-sensitive and project-specific.
+If the script names a missing provider consent, ask the captain whether the filtered project view may be sent to that provider for that exact project.
+Run `provider-consent ... --acknowledge-project-disclosure` only after an explicit yes in the trusted conversation, and never infer consent from council creation or from consent for another project or provider.
+Do not run a live council round merely to validate orchestration unless that project-specific consent already exists.
+
+For ask, pass one complete task with all stated constraints.
+One council must finish, reject, or retry its current round before another task begins, while unrelated councils may proceed independently.
+After `ask`, use `wait` for the bounded collection wait, then `collect` available answers.
+Name every unavailable profile honestly.
+If exactly one answer is available, describe it as the only available answer and use `present --kind only`; never call it a winner.
+With several answers, independently compare correctness, project grounding, safety, and feasibility, then freeze either the best answer or a short synthesis with `present --kind best|synthesis`.
+Do not expose one participant's answer to another before collection.
+
+`present` is the captain-visible canonical proposal.
+On a plain acceptance, run `accept` and report the saved decision plus any participant whose delivery is deferred.
+On “accept and implement”, run `accept-and-implement`, then follow its structured result by creating a separate ordinary Firstmate implementation task under the normal lifecycle.
+Council participants never edit or implement the source project.
+
+A rejection records no result.
+Use `reject` to return the council to idle, or `rerun --clarify` to discard the result and immediately send a fresh independent round with the added constraint.
+After Firstmate restarts during collection, use `recover` once and tell the captain the interrupted round needs explicit retry; use `retry` only when they request it or their original instruction already clearly authorizes retrying interrupted work.
+Never respawn a participant merely because Firstmate restarted.
+
+Close only on an explicit captain command.
+Run `close` exactly once and treat an endpoint-identity refusal as a blocker requiring inspection, never as permission to guess a pane or broaden cleanup.
+Closing clears only that council's participant conversations and does not affect another council or create an implementation task.
+
+## Outcome phrasing
+
+After a result is presented, give the conclusion first, then one or two reasons, then unavailable profiles if any, and ask only whether to accept, accept and implement, reject, or rerun with a constraint.
+After acceptance, say that the exact shown decision was saved before participant notification.
+After accept and implement, name the newly created ordinary work separately so recommendation and implementation authority remain distinct.

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ config/secondmate-harness
 config/backlog-backend
 config/backend
 config/x-mode.env
+config/council-provider-consent.json
+config/.council-provider-consent.lock
 config/cmux-socket-password
 config/wedge-alarm
 config/herdr-presentation-spaces

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,7 @@ config/herdr-presentation-spaces  optional presence flag for Herdr's default-off
 config/cmux-socket-password  optional cmux control-socket password; LOCAL, gitignored; read fresh on every cmux CLI call and passed through without ever overriding an operator's own ambient CMUX_SOCKET_PASSWORD when absent (docs/cmux-backend.md "Setup")
 config/wedge-alarm  optional away-mode wedge-alarm active-alert directives; LOCAL, gitignored; absent means auto (macOS Notification Center when available); see docs/wedge-alarm.md
 config/x-mode.env    generated X-mode watcher cadence; LOCAL, gitignored; source before arming watcher when present
+config/council-provider-consent.json  project-specific cloud-provider disclosure approvals for `/council`; LOCAL, gitignored; mechanics owned by bin/fm-council.sh
 data/                personal fleet records; LOCAL, gitignored as a whole
   backlog.md         task queue, dependencies, history
   captain.md         this home's domain-local captain preferences and working style; LOCAL, gitignored, canonical even if harness memory mirrors it, and updated with inspect-then-update
@@ -79,6 +80,8 @@ data/                personal fleet records; LOCAL, gitignored as a whole
   learnings.md       fleet-local operational facts and gotchas; LOCAL, gitignored; dated, evidence-backed, curated, and updated with inspect-then-update - rewrite and prune rather than append forever, the same contract as captain.md; created lazily, absent until this home has a learning to store
   projects.md        thin fleet navigation registry; firstmate-private, parsed by fm-project-mode.sh (section 6)
   secondmates.md      secondmate routing table; firstmate-private, maintained by fm-home-seed.sh (section 6)
+  councils/           durable council identity, rounds, and presented canonical decisions; owned by bin/fm-council.sh
+  council-projects/   accepted project decision bodies shared with new councils by default; owned by bin/fm-council.sh
   <id>/brief.md      per-task crewmate brief, or per-secondmate charter brief when kind=secondmate
   <id>/report.md     scout task deliverable, written by the crewmate; survives teardown
 projects/            cloned repos; gitignored; READ-ONLY for you
@@ -100,6 +103,7 @@ state/               volatile runtime signals; gitignored
   x-context/         generated X-mode durable per-request reply context and one-wake offer markers, keyed by request_id; survives inbox cleanup and expires within seven days (section 14; bin/fm-x-lib.sh)
   x-outbox/          generated X-mode dry-run reply and dismiss previews; inspect it when FMX_DRY_RUN is set (section 14)
   x-poll.error x-poll.claim-error  generated X-mode relay and offer-claim diagnostic dedupe markers
+  councils/          volatile exact participant endpoints, private homes, answer outboxes, and collections; owned by bin/fm-council.sh
   .wake-queue        durable queued wakes: epoch<TAB>seq<TAB>kind<TAB>key<TAB>payload
   .afk               durable away-mode flag; present = sub-supervisor may inject escalations (set by /afk, cleared on user return)
   .watch.lock .wake-queue.lock watcher singleton and queue serialization locks
@@ -214,6 +218,9 @@ When the captain invokes `/stow`, load the `stow` skill for the complete knowled
 The delivery lifecycle is an always-loaded operational contract; referenced scripts own exact commands, flags, and data mechanics.
 
 ### Intake and authority
+
+Load `/council` whenever the captain invokes it or naturally asks to create, question, accept, reject, rerun, retry, or close a persistent council.
+Council participants are hard read-only and never implement, cloud disclosure is project-specific and explicit, and only an explicit close may terminate their exact sessions; the skill and `bin/fm-council.sh --help` own the procedure.
 
 Resolve the project independently for every request.
 An explicit project wins, a clear follow-up inherits its referent, and otherwise match the request against the registry, work under way, and project code or README.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Launching a supported harness inside it instantiates your first mate - and makes
 - **Two task shapes** - ship tasks deliver a change; scout tasks investigate, plan, reproduce, or audit and leave a report.
 - **Explicit project modes** - each project ships via `no-mistakes`, `direct-PR`, or `local-only`, with an optional `+yolo` autonomy flag.
 - **Optional secondmates** - opt in to persistent second mates that run from isolated firstmate homes with their own `FM_HOME`, state, projects, and session lock, supervising project clones or a project-less firstmate-repo domain, kept on the primary firstmate version by guarded local fast-forwards and checked for live agent processes at session start.
+- **Thin read-only councils** - on Linux x86_64 with Herdr, ask the same fixed secret-filtered project view of persistent exact Claude Fable and Codex GPT-5.6 Sol conversations, then accept one canonical decision or route a separate ordinary implementation task.
 - **Event-driven, zero-token supervision** - a bash watcher sleeps on the fleet and wakes the first mate only when something needs you; verified primary harnesses also get a turn-end backstop that blocks or follows up on a blind stop when work is under way and supervision is not live.
 - **Optional X mode** - opt in with one local `.env` token so firstmate can answer your public `@myfirstmate` mentions, act on normal reversible mention requests through the same lifecycle as chat requests, acknowledge spawned work, and post up to three public-safe completion follow-ups within seven days for genuine milestones and the final outcome without changing non-X behavior; dry-run preview records would-be replies and dismissals locally before go-live.
 - **Guarded by construction** - the first mate is read-only over your projects except for the guarded paths authorized by [hard rule 1](AGENTS.md#1-identity-and-prime-directives), with fleet sync's safe branch pruning remaining part of the fleet-sync exception; crewmates make every project change behind the configured merge authority.
@@ -165,6 +166,7 @@ Claude and grok use the slash form shown here; codex uses the same names with `$
 | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
 | `/afk`             | Enter away-mode supervision: the sub-supervisor self-handles routine notifications in bash, escalates captain-relevant events and bounded declared-external-wait rechecks as batched digests, and actively alerts if delivery gets stuck while you step away |
 | `/bearings`        | Generate a standalone current-status report from bounded local fleet and registered-secondmate state, with live PR enrichment only when requested, written to a dated file in `data/` and surfaced concisely in chat; read-mostly, mutates no task state |
+| `/council`         | Operate persistent read-only model councils with project-specific provider consent, exact accepted decisions, explicit rerun and close, and separate implementation authority |
 | `/updatefirstmate` | Self-update the running firstmate and its secondmates to the latest from origin with fast-forward-only pulls, then re-read instructions and nudge secondmates |
 | `/stow`            | Sweep the session for uncaptured durable knowledge, route each finding to its disk home per AGENTS.md, file undone next steps to the backlog, and report what is now safe to reset |
 
@@ -184,6 +186,7 @@ Firstmate's skills live in two separate places with different audiences:
 
 - [docs/architecture.md](docs/architecture.md) - how the crew, supervision, worktrees, secondmates, and project modes work.
 - [docs/configuration.md](docs/configuration.md) - environment variables, `FM_HOME`, runtime backend selection, optional X mode, the files you set, and harness support.
+- [docs/council.md](docs/council.md) - the supported persistent council workflow, isolation boundary, acceptance semantics, and short parallel example.
 - [docs/wedge-alarm.md](docs/wedge-alarm.md) - configure the active alert for an away-mode escalation delivery that gets stuck.
 - [docs/tmux-backend.md](docs/tmux-backend.md) - setup guide for the tmux reference backend: prerequisites, attaching, and watching crew windows.
 - [docs/herdr-backend.md](docs/herdr-backend.md) - setup guide for the experimental herdr backend, plus its verification notes and known gaps.

--- a/bin/fm-council-sandbox.py
+++ b/bin/fm-council-sandbox.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""Launch one council participant under a Linux Landlock policy.
+
+This helper is intentionally not a general sandbox.  Landlock denies filesystem
+reads, writes, and executable launches by default, admits the system executable
+tree, and grants writes only below explicit participant-owned directories.  A
+seccomp filter also denies new Unix-domain sockets so terminal-control sockets
+cannot be reached by path guessing.  Both policies are inherited by every child
+before exec.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ctypes
+import errno
+import os
+from pathlib import Path
+import stat
+import sys
+
+
+SYS_LANDLOCK_CREATE_RULESET = 444
+SYS_LANDLOCK_ADD_RULE = 445
+SYS_LANDLOCK_RESTRICT_SELF = 446
+LANDLOCK_CREATE_RULESET_VERSION = 1
+LANDLOCK_RULE_PATH_BENEATH = 1
+PR_SET_NO_NEW_PRIVS = 38
+PR_SET_SECCOMP = 22
+SECCOMP_MODE_FILTER = 2
+SECCOMP_RET_ALLOW = 0x7FFF0000
+SECCOMP_RET_ERRNO = 0x00050000
+BPF_LD_W_ABS = 0x20
+BPF_JMP_JEQ_K = 0x15
+BPF_RET_K = 0x06
+SYS_SOCKET_X86_64 = 41
+AF_UNIX = 1
+
+EXECUTE = 1 << 0
+WRITE_FILE = 1 << 1
+READ_FILE = 1 << 2
+READ_DIR = 1 << 3
+REMOVE_DIR = 1 << 4
+REMOVE_FILE = 1 << 5
+MAKE_CHAR = 1 << 6
+MAKE_DIR = 1 << 7
+MAKE_REG = 1 << 8
+MAKE_SOCK = 1 << 9
+MAKE_FIFO = 1 << 10
+MAKE_BLOCK = 1 << 11
+MAKE_SYM = 1 << 12
+REFER = 1 << 13
+TRUNCATE = 1 << 14
+
+READ_ACCESS = READ_FILE | READ_DIR
+WRITE_ACCESS = (
+    WRITE_FILE
+    | REMOVE_DIR
+    | REMOVE_FILE
+    | MAKE_CHAR
+    | MAKE_DIR
+    | MAKE_REG
+    | MAKE_SOCK
+    | MAKE_FIFO
+    | MAKE_BLOCK
+    | MAKE_SYM
+    | REFER
+    | TRUNCATE
+)
+HANDLED_ACCESS = EXECUTE | READ_ACCESS | WRITE_ACCESS
+FILE_ACCESS = EXECUTE | READ_FILE | WRITE_FILE | TRUNCATE
+
+
+class RulesetAttr(ctypes.Structure):
+    _fields_ = [("handled_access_fs", ctypes.c_uint64)]
+
+
+class PathBeneathAttr(ctypes.Structure):
+    _fields_ = [
+        ("allowed_access", ctypes.c_uint64),
+        ("parent_fd", ctypes.c_int32),
+        ("reserved", ctypes.c_uint32),
+    ]
+
+
+class SockFilter(ctypes.Structure):
+    _fields_ = [
+        ("code", ctypes.c_ushort),
+        ("jt", ctypes.c_ubyte),
+        ("jf", ctypes.c_ubyte),
+        ("k", ctypes.c_uint32),
+    ]
+
+
+class SockFprog(ctypes.Structure):
+    _fields_ = [("length", ctypes.c_ushort), ("filter", ctypes.POINTER(SockFilter))]
+
+
+LIBC = ctypes.CDLL(None, use_errno=True)
+
+
+def syscall(number: int, *args: object) -> int:
+    result = LIBC.syscall(number, *args)
+    if result < 0:
+        error = ctypes.get_errno()
+        raise OSError(error, os.strerror(error))
+    return int(result)
+
+
+def canonical_existing(path: str) -> Path:
+    resolved = Path(path).expanduser().resolve(strict=True)
+    return resolved
+
+
+def add_path_rule(ruleset_fd: int, path: Path, access: int) -> None:
+    flags = os.O_PATH | os.O_CLOEXEC
+    path_fd = os.open(path, flags)
+    try:
+        mode = os.fstat(path_fd).st_mode
+        allowed = access if stat.S_ISDIR(mode) else access & FILE_ACCESS
+        if stat.S_ISDIR(mode) and allowed & EXECUTE:
+            allowed |= READ_DIR
+        attribute = PathBeneathAttr(allowed, path_fd, 0)
+        syscall(
+            SYS_LANDLOCK_ADD_RULE,
+            ruleset_fd,
+            LANDLOCK_RULE_PATH_BENEATH,
+            ctypes.byref(attribute),
+            0,
+        )
+    finally:
+        os.close(path_fd)
+
+
+def deny_new_unix_sockets() -> None:
+    if os.uname().machine != "x86_64":
+        raise RuntimeError("the council Unix-socket filter is verified only on Linux x86_64")
+    filters = (SockFilter * 6)(
+        SockFilter(BPF_LD_W_ABS, 0, 0, 0),
+        SockFilter(BPF_JMP_JEQ_K, 0, 3, SYS_SOCKET_X86_64),
+        SockFilter(BPF_LD_W_ABS, 0, 0, 16),
+        SockFilter(BPF_JMP_JEQ_K, 0, 1, AF_UNIX),
+        SockFilter(BPF_RET_K, 0, 0, SECCOMP_RET_ERRNO | errno.EACCES),
+        SockFilter(BPF_RET_K, 0, 0, SECCOMP_RET_ALLOW),
+    )
+    program = SockFprog(len(filters), ctypes.cast(filters, ctypes.POINTER(SockFilter)))
+    if LIBC.prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER, ctypes.byref(program), 0, 0) != 0:
+        error = ctypes.get_errno()
+        raise OSError(error, os.strerror(error))
+
+
+def install_policy(readable: list[Path], writable: list[Path], executables: list[Path]) -> int:
+    try:
+        abi = syscall(
+            SYS_LANDLOCK_CREATE_RULESET,
+            0,
+            0,
+            LANDLOCK_CREATE_RULESET_VERSION,
+        )
+    except OSError as error:
+        if error.errno in (errno.ENOSYS, errno.EOPNOTSUPP):
+            raise RuntimeError("Linux Landlock is unavailable; refusing an unconfined council participant") from error
+        raise
+    if abi < 4:
+        raise RuntimeError(f"Linux Landlock ABI {abi} is below the verified council minimum 4")
+
+    attribute = RulesetAttr(HANDLED_ACCESS)
+    ruleset_fd = syscall(
+        SYS_LANDLOCK_CREATE_RULESET,
+        ctypes.byref(attribute),
+        ctypes.sizeof(attribute),
+        0,
+    )
+    try:
+        for path in readable:
+            add_path_rule(ruleset_fd, path, READ_ACCESS)
+        for path in writable:
+            add_path_rule(ruleset_fd, path, READ_ACCESS | WRITE_ACCESS)
+        for path in executables:
+            add_path_rule(ruleset_fd, path, READ_FILE | EXECUTE)
+
+        if LIBC.prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) != 0:
+            error = ctypes.get_errno()
+            raise OSError(error, os.strerror(error))
+        syscall(SYS_LANDLOCK_RESTRICT_SELF, ruleset_fd, 0)
+        deny_new_unix_sockets()
+    finally:
+        os.close(ruleset_fd)
+    return abi
+
+
+def safe_environment(home: Path) -> dict[str, str]:
+    keep = {
+        "ANTHROPIC_API_KEY",
+        "CLAUDE_CODE_OAUTH_TOKEN",
+        "OPENAI_API_KEY",
+        "SSL_CERT_DIR",
+        "SSL_CERT_FILE",
+        "TERM",
+        "COLORTERM",
+        "LANG",
+        "LC_ALL",
+        "TZ",
+    }
+    environment = {key: value for key, value in os.environ.items() if key in keep}
+    environment.update(
+        {
+            "HOME": str(home),
+            "XDG_CONFIG_HOME": str(home / ".config"),
+            "XDG_CACHE_HOME": str(home / ".cache"),
+            "XDG_DATA_HOME": str(home / ".local" / "share"),
+            "TMPDIR": str(home / "tmp"),
+            "CODEX_HOME": str(home / ".codex"),
+            "CLAUDE_CONFIG_DIR": str(home / ".claude"),
+            "PATH": "/usr/local/bin:/usr/bin:/bin",
+            "FM_COUNCIL_SANDBOX": "landlock-v1",
+        }
+    )
+    return environment
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run a command in the verified Linux council read-only filesystem lane."
+    )
+    parser.add_argument("--home", required=True, help="participant-owned HOME and writable root")
+    parser.add_argument("--readable", action="append", default=[], help="additional readable path")
+    parser.add_argument("--writable", action="append", default=[], help="additional writable path")
+    parser.add_argument("--allow-exec", action="append", default=[], help="exact executable path")
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    arguments = parser.parse_args()
+    if arguments.command and arguments.command[0] == "--":
+        arguments.command = arguments.command[1:]
+    if not arguments.command:
+        parser.error("a command is required after --")
+    return arguments
+
+
+def main() -> int:
+    arguments = parse_args()
+    if sys.platform != "linux":
+        print("fm-council-sandbox: only verified on Linux; refusing this platform", file=sys.stderr)
+        return 1
+
+    home = canonical_existing(arguments.home)
+    if not home.is_dir():
+        print("fm-council-sandbox: --home must be a directory", file=sys.stderr)
+        return 2
+    for child in (".config", ".cache", ".local/share", "tmp", ".codex", ".claude"):
+        path = home / child
+        path.mkdir(parents=True, exist_ok=True, mode=0o700)
+
+    system_readables = [
+        path
+        for candidate in (
+            "/usr",
+            "/bin",
+            "/lib",
+            "/lib64",
+            "/proc/self",
+            "/sys",
+            "/dev/null",
+            "/dev/zero",
+            "/dev/random",
+            "/dev/urandom",
+            "/dev/tty",
+            "/etc/ssl",
+            "/etc/pki",
+            "/etc/ca-certificates",
+            "/etc/resolv.conf",
+            "/etc/hosts",
+            "/etc/nsswitch.conf",
+            "/etc/passwd",
+            "/etc/group",
+            "/etc/localtime",
+            "/etc/ld.so.cache",
+        )
+        if (path := Path(candidate).resolve()).exists()
+    ]
+    readable = system_readables + [canonical_existing(path) for path in arguments.readable]
+    device_writables = [path for candidate in ("/dev/null", "/dev/tty") if (path := Path(candidate).resolve()).exists()]
+    writable = [home, *device_writables] + [canonical_existing(path) for path in arguments.writable]
+    command_path = canonical_existing(arguments.command[0])
+    usr = Path("/usr").resolve()
+    try:
+        command_path.relative_to(usr)
+    except ValueError as error:
+        raise RuntimeError(f"council command must resolve below the verified system executable tree {usr}: {command_path}") from error
+    # Landlock rights cannot be regained below a parent rule that omitted them.
+    # /usr is already the system read rule, so executable permission is added at
+    # that same boundary.  Home-local Herdr and multiplexer clients remain
+    # unreadable and unexecutable because /home is never admitted.
+    executables = [usr]
+    for requested in arguments.allow_exec:
+        executable = canonical_existing(requested)
+        try:
+            executable.relative_to(usr)
+        except ValueError as error:
+            raise RuntimeError(f"allowed executable is outside {usr}: {executable}") from error
+
+    try:
+        install_policy(readable, writable, executables)
+    except (OSError, RuntimeError, ValueError) as error:
+        print(f"fm-council-sandbox: {error}", file=sys.stderr)
+        return 1
+
+    environment = safe_environment(home)
+    os.chdir(home)
+    os.execve(command_path, [arguments.command[0], *arguments.command[1:]], environment)
+    return 127
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bin/fm-council-sandbox.py
+++ b/bin/fm-council-sandbox.py
@@ -2,11 +2,11 @@
 """Launch one council participant under a Linux Landlock policy.
 
 This helper is intentionally not a general sandbox.  Landlock denies filesystem
-reads, writes, and executable launches by default, admits the system executable
-tree, and grants writes only below explicit participant-owned directories.  A
-seccomp filter also denies new Unix-domain sockets so terminal-control sockets
-cannot be reached by path guessing.  Both policies are inherited by every child
-before exec.
+reads, writes, and executable launches by default, admits read-only system
+paths, grants execute only on the exact allowlisted binaries, and grants writes
+only below explicit participant-owned directories.  A seccomp filter also
+denies new Unix-domain sockets so terminal-control sockets cannot be reached by
+path guessing.  Both policies are inherited by every child before exec.
 """
 
 from __future__ import annotations
@@ -32,9 +32,12 @@ SECCOMP_RET_ALLOW = 0x7FFF0000
 SECCOMP_RET_ERRNO = 0x00050000
 BPF_LD_W_ABS = 0x20
 BPF_JMP_JEQ_K = 0x15
+BPF_JMP_JGE_K = 0x35
 BPF_RET_K = 0x06
 SYS_SOCKET_X86_64 = 41
 AF_UNIX = 1
+AUDIT_ARCH_X86_64 = 0xC000003E
+X32_SYSCALL_BIT = 0x40000000
 
 EXECUTE = 1 << 0
 WRITE_FILE = 1 << 1
@@ -135,8 +138,11 @@ def add_path_rule(ruleset_fd: int, path: Path, access: int) -> None:
 def deny_new_unix_sockets() -> None:
     if os.uname().machine != "x86_64":
         raise RuntimeError("the council Unix-socket filter is verified only on Linux x86_64")
-    filters = (SockFilter * 6)(
+    filters = (SockFilter * 9)(
+        SockFilter(BPF_LD_W_ABS, 0, 0, 4),
+        SockFilter(BPF_JMP_JEQ_K, 0, 5, AUDIT_ARCH_X86_64),
         SockFilter(BPF_LD_W_ABS, 0, 0, 0),
+        SockFilter(BPF_JMP_JGE_K, 3, 0, X32_SYSCALL_BIT),
         SockFilter(BPF_JMP_JEQ_K, 0, 3, SYS_SOCKET_X86_64),
         SockFilter(BPF_LD_W_ABS, 0, 0, 16),
         SockFilter(BPF_JMP_JEQ_K, 0, 1, AF_UNIX),
@@ -189,11 +195,14 @@ def install_policy(readable: list[Path], writable: list[Path], executables: list
     return abi
 
 
-def safe_environment(home: Path) -> dict[str, str]:
+PROVIDER_KEYS = {
+    "claude": ("ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN"),
+    "codex": ("OPENAI_API_KEY",),
+}
+
+
+def safe_environment(home: Path, harness: str | None) -> dict[str, str]:
     keep = {
-        "ANTHROPIC_API_KEY",
-        "CLAUDE_CODE_OAUTH_TOKEN",
-        "OPENAI_API_KEY",
         "SSL_CERT_DIR",
         "SSL_CERT_FILE",
         "TERM",
@@ -202,6 +211,7 @@ def safe_environment(home: Path) -> dict[str, str]:
         "LC_ALL",
         "TZ",
     }
+    keep.update(PROVIDER_KEYS.get(harness or "", ()))
     environment = {key: value for key, value in os.environ.items() if key in keep}
     environment.update(
         {
@@ -227,6 +237,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--readable", action="append", default=[], help="additional readable path")
     parser.add_argument("--writable", action="append", default=[], help="additional writable path")
     parser.add_argument("--allow-exec", action="append", default=[], help="exact executable path")
+    parser.add_argument("--harness", choices=("claude", "codex"), help="harness whose own provider credentials pass through")
     parser.add_argument("command", nargs=argparse.REMAINDER)
     arguments = parser.parse_args()
     if arguments.command and arguments.command[0] == "--":
@@ -286,17 +297,18 @@ def main() -> int:
         command_path.relative_to(usr)
     except ValueError as error:
         raise RuntimeError(f"council command must resolve below the verified system executable tree {usr}: {command_path}") from error
-    # Landlock rights cannot be regained below a parent rule that omitted them.
-    # /usr is already the system read rule, so executable permission is added at
-    # that same boundary.  Home-local Herdr and multiplexer clients remain
-    # unreadable and unexecutable because /home is never admitted.
-    executables = [usr]
+    executables = [command_path]
+    loader = Path("/lib64/ld-linux-x86-64.so.2")
+    if loader.exists():
+        executables.append(loader.resolve())
     for requested in arguments.allow_exec:
         executable = canonical_existing(requested)
         try:
             executable.relative_to(usr)
         except ValueError as error:
             raise RuntimeError(f"allowed executable is outside {usr}: {executable}") from error
+        if executable not in executables:
+            executables.append(executable)
 
     try:
         install_policy(readable, writable, executables)
@@ -304,7 +316,7 @@ def main() -> int:
         print(f"fm-council-sandbox: {error}", file=sys.stderr)
         return 1
 
-    environment = safe_environment(home)
+    environment = safe_environment(home, arguments.harness)
     os.chdir(home)
     os.execve(command_path, [arguments.command[0], *arguments.command[1:]], environment)
     return 127

--- a/bin/fm-council-sandbox.py
+++ b/bin/fm-council-sandbox.py
@@ -5,8 +5,9 @@ This helper is intentionally not a general sandbox.  Landlock denies filesystem
 reads, writes, and executable launches by default, admits read-only system
 paths, grants execute only on the exact allowlisted binaries, and grants writes
 only below explicit participant-owned directories.  A seccomp filter also
-denies new Unix-domain sockets so terminal-control sockets cannot be reached by
-path guessing.  Both policies are inherited by every child before exec.
+denies new Unix-domain sockets (socket and socketpair) and io_uring setup so
+terminal-control sockets cannot be reached by path guessing or by ring-submitted
+socket operations.  Both policies are inherited by every child before exec.
 """
 
 from __future__ import annotations
@@ -35,6 +36,8 @@ BPF_JMP_JEQ_K = 0x15
 BPF_JMP_JGE_K = 0x35
 BPF_RET_K = 0x06
 SYS_SOCKET_X86_64 = 41
+SYS_SOCKETPAIR_X86_64 = 53
+SYS_IO_URING_SETUP_X86_64 = 425
 AF_UNIX = 1
 AUDIT_ARCH_X86_64 = 0xC000003E
 X32_SYSCALL_BIT = 0x40000000
@@ -138,12 +141,14 @@ def add_path_rule(ruleset_fd: int, path: Path, access: int) -> None:
 def deny_new_unix_sockets() -> None:
     if os.uname().machine != "x86_64":
         raise RuntimeError("the council Unix-socket filter is verified only on Linux x86_64")
-    filters = (SockFilter * 9)(
+    filters = (SockFilter * 11)(
         SockFilter(BPF_LD_W_ABS, 0, 0, 4),
-        SockFilter(BPF_JMP_JEQ_K, 0, 5, AUDIT_ARCH_X86_64),
+        SockFilter(BPF_JMP_JEQ_K, 0, 7, AUDIT_ARCH_X86_64),
         SockFilter(BPF_LD_W_ABS, 0, 0, 0),
-        SockFilter(BPF_JMP_JGE_K, 3, 0, X32_SYSCALL_BIT),
-        SockFilter(BPF_JMP_JEQ_K, 0, 3, SYS_SOCKET_X86_64),
+        SockFilter(BPF_JMP_JGE_K, 5, 0, X32_SYSCALL_BIT),
+        SockFilter(BPF_JMP_JEQ_K, 4, 0, SYS_IO_URING_SETUP_X86_64),
+        SockFilter(BPF_JMP_JEQ_K, 1, 0, SYS_SOCKET_X86_64),
+        SockFilter(BPF_JMP_JEQ_K, 0, 3, SYS_SOCKETPAIR_X86_64),
         SockFilter(BPF_LD_W_ABS, 0, 0, 16),
         SockFilter(BPF_JMP_JEQ_K, 0, 1, AF_UNIX),
         SockFilter(BPF_RET_K, 0, 0, SECCOMP_RET_ERRNO | errno.EACCES),

--- a/bin/fm-council.py
+++ b/bin/fm-council.py
@@ -408,7 +408,7 @@ def copy_auth(profile_value: dict[str, str], lane_home: Path) -> None:
 
 
 def executable_paths(harness: str) -> list[str]:
-    names = ["bash", "sh", "cat", "rg", "grep", "find", "sed", "awk", "head", "tail", "wc", "sort", "uniq", "cut", "tr", "ls", "stat", "mktemp", "mv"]
+    names = ["bash", "sh", "cat", "rg", "grep", "find", "sed", "awk", "head", "tail", "wc", "sort", "uniq", "cut", "tr", "ls", "stat", "mktemp", "mv", "env", "node"]
     result: list[str] = []
     for name in [harness, *names]:
         resolved = shutil.which(name)
@@ -417,10 +417,6 @@ def executable_paths(harness: str) -> list[str]:
             if real not in result:
                 result.append(real)
     if harness == "codex":
-        for name in ("env", "node"):
-            resolved = shutil.which(name)
-            if resolved:
-                result.append(str(Path(resolved).resolve()))
         codex_root = Path("/usr/lib/node_modules/@openai/codex")
         if codex_root.exists():
             for path in codex_root.glob("node_modules/@openai/codex-linux-*/vendor/*/bin/codex"):
@@ -460,6 +456,8 @@ def sandbox_command(profile_value: dict[str, str], lane_home: Path, snapshots: P
         str(lane_home),
         "--readable",
         str(snapshots),
+        "--harness",
+        profile_value["harness"],
     ]
     for executable in executable_paths(profile_value["harness"]):
         command.extend(("--allow-exec", executable))
@@ -841,36 +839,44 @@ def start_round(directory: Path, council: dict[str, Any], task: str) -> dict[str
     round_id = next_round_id(council)
     round_directory = directory / "rounds" / round_id
     round_directory.mkdir(parents=True, mode=0o700)
-    snapshot, view_hash, excluded = build_snapshot(directory, project, round_id)
-    common = (
-        f"# Council round {round_id}\n\n"
-        f"Project view: `{snapshot}`\n\n"
-        f"View hash: `{view_hash}`\n\n"
-        f"## Task\n\n{task}\n\n"
-        f"## Accepted project decisions\n\n{accepted_context(council)}\n\n"
-        "Analyze independently. Do not inspect other participants, terminal-control state, or any source path outside the fixed project view. "
-        "Do not edit or implement the source project. Give a concise, project-grounded answer.\n"
-    )
-    common_path = round_directory / "common.md"
-    atomic_text(common_path, common)
-    common_hash = hashlib.sha256(common.encode()).hexdigest()
-    roster: dict[str, Any] = {}
-    round_value = {
-        "schema": "fm-council-round.v1",
-        "id": round_id,
-        "status": "dispatching",
-        "task": task,
-        "view": str(snapshot),
-        "view_hash": view_hash,
-        "common_hash": common_hash,
-        "excluded": excluded,
-        "roster": roster,
-        "created_at": now(),
-    }
-    save_round(directory, round_value)
-    council["phase"] = "collecting"
-    council["active_round"] = round_id
-    save_council(directory, council)
+    try:
+        snapshot, view_hash, excluded = build_snapshot(directory, project, round_id)
+        common = (
+            f"# Council round {round_id}\n\n"
+            f"Project view: `{snapshot}`\n\n"
+            f"View hash: `{view_hash}`\n\n"
+            f"## Task\n\n{task}\n\n"
+            f"## Accepted project decisions\n\n{accepted_context(council)}\n\n"
+            "Analyze independently. Do not inspect other participants, terminal-control state, or any source path outside the fixed project view. "
+            "Do not edit or implement the source project. Give a concise, project-grounded answer.\n"
+        )
+        common_path = round_directory / "common.md"
+        atomic_text(common_path, common)
+        common_hash = hashlib.sha256(common.encode()).hexdigest()
+        roster: dict[str, Any] = {}
+        round_value = {
+            "schema": "fm-council-round.v1",
+            "id": round_id,
+            "status": "dispatching",
+            "task": task,
+            "view": str(snapshot),
+            "view_hash": view_hash,
+            "common_hash": common_hash,
+            "excluded": excluded,
+            "roster": roster,
+            "created_at": now(),
+        }
+        save_round(directory, round_value)
+        council["phase"] = "collecting"
+        council["active_round"] = round_id
+        save_council(directory, council)
+    except Exception:
+        council["round_counter"] = int(council["round_counter"]) - 1
+        council["phase"] = "idle"
+        council["active_round"] = None
+        shutil.rmtree(round_directory, ignore_errors=True)
+        remove_snapshot(directory, round_id)
+        raise
     append_event(directory / "events.jsonl", {"event": "round_started", "round": round_id, "common_hash": common_hash})
 
     for member in council["members"]:
@@ -1062,6 +1068,17 @@ def command_present(arguments: argparse.Namespace) -> None:
     print(content.decode(), end="" if content.endswith(b"\n") else "\n")
 
 
+def remove_snapshot(directory: Path, round_id: str) -> None:
+    snapshot = directory / "snapshots" / round_id
+    if snapshot.exists():
+        for path in sorted(snapshot.rglob("*"), reverse=True):
+            with contextlib.suppress(OSError):
+                os.chmod(path, 0o700 if path.is_dir() else 0o600)
+        with contextlib.suppress(OSError):
+            os.chmod(snapshot, 0o700)
+        shutil.rmtree(snapshot, ignore_errors=True)
+
+
 def cleanup_round_payloads(directory: Path, council: dict[str, Any], round_value: dict[str, Any], keep_presentation: bool) -> None:
     for roster_value in round_value.get("roster", {}).values():
         answer = roster_value.get("answer")
@@ -1073,14 +1090,7 @@ def cleanup_round_payloads(directory: Path, council: dict[str, Any], round_value
     if not keep_presentation:
         with contextlib.suppress(FileNotFoundError):
             (round_record_path(directory, round_value["id"]).parent / "presented.md").unlink()
-    snapshot = directory / "snapshots" / round_value["id"]
-    if snapshot.exists():
-        for path in sorted(snapshot.rglob("*"), reverse=True):
-            with contextlib.suppress(OSError):
-                os.chmod(path, 0o700 if path.is_dir() else 0o600)
-        with contextlib.suppress(OSError):
-            os.chmod(snapshot, 0o700)
-        shutil.rmtree(snapshot, ignore_errors=True)
+    remove_snapshot(directory, round_value["id"])
 
 
 def accept_round(directory: Path, council: dict[str, Any]) -> tuple[str, Path, list[str]]:
@@ -1094,34 +1104,56 @@ def accept_round(directory: Path, council: dict[str, Any]) -> tuple[str, Path, l
     project = Path(council["project"])
     decisions = project_decision_dir(project)
     decisions.mkdir(parents=True, exist_ok=True, mode=0o700)
+    digest = hashlib.sha256(content).hexdigest()
     with lock(decisions / ".lock"):
         index = decision_index(project)
-        sequence = len(index["decisions"]) + 1
-        decision_id = f"D{sequence:04d}"
-        destination = decision_path(project, decision_id)
-        if destination.exists():
-            raise CouncilError(f"decision destination already exists: {destination}")
-        atomic_bytes(destination, content)
-        index["decisions"].append(
-            {
-                "id": decision_id,
-                "active": True,
-                "council_id": council["id"],
-                "round_id": round_value["id"],
-                "sha256": hashlib.sha256(content).hexdigest(),
-                "accepted_at": now(),
-            }
+        existing = next(
+            (
+                item
+                for item in index["decisions"]
+                if item.get("council_id") == council["id"] and item.get("round_id") == round_value["id"]
+            ),
+            None,
         )
-        atomic_json(decisions / "index.json", index)
-    append_event(directory / "events.jsonl", {"event": "decision_saved", "decision": decision_id, "round": round_value["id"], "sha256": hashlib.sha256(content).hexdigest()})
+        if existing is not None:
+            if existing.get("sha256") != digest:
+                raise CouncilError(f"round {round_value['id']} already saved a different decision: {existing.get('id')}")
+            decision_id = str(existing["id"])
+            destination = decision_path(project, decision_id)
+            if not destination.is_file():
+                raise CouncilError(f"accepted decision body is missing: {destination}")
+        else:
+            sequence = len(index["decisions"]) + 1
+            decision_id = f"D{sequence:04d}"
+            destination = decision_path(project, decision_id)
+            if destination.exists():
+                raise CouncilError(f"decision destination already exists: {destination}")
+            atomic_bytes(destination, content)
+            index["decisions"].append(
+                {
+                    "id": decision_id,
+                    "active": True,
+                    "council_id": council["id"],
+                    "round_id": round_value["id"],
+                    "sha256": digest,
+                    "accepted_at": now(),
+                }
+            )
+            atomic_json(decisions / "index.json", index)
+            append_event(directory / "events.jsonl", {"event": "decision_saved", "decision": decision_id, "round": round_value["id"], "sha256": digest})
     if decision_id not in council["decision_ids"]:
         council["decision_ids"].append(decision_id)
     deferred: list[str] = []
     body = content.decode()
     for member in council["members"]:
-        runtime_file, runtime = load_runtime(council, member)
-        if send_member(council, member, "decision", body):
+        delivered: list[str] = []
+        try:
+            runtime_file, runtime = load_runtime(council, member)
             delivered = list(runtime.get("delivered_decisions", []))
+            sent = decision_id in delivered or send_member(council, member, "decision", body)
+        except CouncilError:
+            sent = False
+        if sent:
             if decision_id not in delivered:
                 delivered.append(decision_id)
             runtime["delivered_decisions"] = delivered
@@ -1261,12 +1293,31 @@ def close_member(council: dict[str, Any], member: dict[str, Any], runtime: dict[
             raise CouncilError(f"failed to close exact participant endpoint for {member['id']}")
 
 
+def load_close_journal(directory: Path, council: dict[str, Any]) -> tuple[Path, dict[str, Any]]:
+    path = directory / "close-journal.json"
+    if not path.exists():
+        return path, {"schema": "fm-council-close.v1", "council_id": council["id"], "closed": {}}
+    journal = load_json(path)
+    if (
+        journal.get("schema") != "fm-council-close.v1"
+        or journal.get("council_id") != council["id"]
+        or not isinstance(journal.get("closed"), dict)
+    ):
+        raise CouncilError(f"invalid council close journal: {path}")
+    return path, journal
+
+
 def command_close(arguments: argparse.Namespace) -> None:
     directory, council = find_council(arguments.name, include_closed=False)
     with lock(PATHS.runtime_dir(council["id"]) / ".lock"):
-        runtimes = [(member, close_preflight(council, member)) for member in council["members"]]
+        journal_path, journal = load_close_journal(directory, council)
+        pending = [member for member in council["members"] if member["id"] not in journal["closed"]]
+        runtimes = [(member, close_preflight(council, member)) for member in pending]
         for member, runtime in runtimes:
             close_member(council, member, runtime)
+            journal["closed"][member["id"]] = now()
+            atomic_json(journal_path, journal)
+            append_event(directory / "events.jsonl", {"event": "member_closed", "member": member["id"]})
         runtime_root = PATHS.runtime_dir(council["id"])
         shutil.rmtree(runtime_root / "members", ignore_errors=True)
         shutil.rmtree(runtime_root / "rounds", ignore_errors=True)

--- a/bin/fm-council.py
+++ b/bin/fm-council.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import argparse
 import contextlib
 import datetime as dt
+import errno
 import fcntl
 import hashlib
 import json
@@ -851,32 +852,40 @@ def expected_answer_path(runtime: dict[str, Any], round_id: str) -> Path:
     return Path(str(runtime["home"])) / "outbox" / f"{round_id}.md"
 
 
-def read_member_answer(council: dict[str, Any], member: dict[str, Any], round_id: str, answer_value: Any) -> str | None:
+def inspect_member_answer(council: dict[str, Any], member: dict[str, Any], round_id: str, answer_value: Any) -> tuple[str | None, str | None]:
     try:
         _, runtime = load_runtime(council, member)
     except CouncilError:
-        return None
-    if not answer_value or Path(str(answer_value)) != expected_answer_path(runtime, round_id):
-        return None
+        return None, None
+    if not answer_value:
+        return None, None
+    if Path(str(answer_value)) != expected_answer_path(runtime, round_id):
+        return None, "answer-path-mismatch"
     directory_fd = open_outbox_dir(Path(str(runtime["home"])))
     if directory_fd is None:
-        return None
+        return None, "outbox-not-private"
     try:
         answer_fd = os.open(f"{round_id}.md", os.O_RDONLY | os.O_NOFOLLOW | os.O_NOCTTY | os.O_CLOEXEC, dir_fd=directory_fd)
-    except OSError:
-        return None
+    except FileNotFoundError:
+        return None, None
+    except OSError as error:
+        return None, "symlink" if error.errno == errno.ELOOP else "unreadable"
     finally:
         os.close(directory_fd)
     try:
         info = os.fstat(answer_fd)
-        if (
-            not stat.S_ISREG(info.st_mode)
-            or info.st_nlink != 1
-            or info.st_uid != os.getuid()
-            or info.st_mode & (stat.S_IWGRP | stat.S_IWOTH | stat.S_ISUID | stat.S_ISGID)
-            or not 0 < info.st_size <= MAX_ANSWER_BYTES
-        ):
-            return None
+        if not stat.S_ISREG(info.st_mode):
+            return None, "not-regular"
+        if info.st_nlink != 1:
+            return None, "hard-linked"
+        if info.st_uid != os.getuid():
+            return None, "foreign-owner"
+        if info.st_mode & (stat.S_IWGRP | stat.S_IWOTH | stat.S_ISUID | stat.S_ISGID):
+            return None, "unsafe-mode"
+        if info.st_size > MAX_ANSWER_BYTES:
+            return None, "oversized"
+        if info.st_size == 0:
+            return None, "empty"
         chunks: list[bytes] = []
         total = 0
         while True:
@@ -886,13 +895,16 @@ def read_member_answer(council: dict[str, Any], member: dict[str, Any], round_id
             chunks.append(chunk)
             total += len(chunk)
             if total > MAX_ANSWER_BYTES:
-                return None
+                return None, "oversized"
     finally:
         os.close(answer_fd)
     try:
-        return b"".join(chunks).decode("utf-8")
+        text = b"".join(chunks).decode("utf-8")
     except UnicodeDecodeError:
-        return None
+        return None, "not-utf8"
+    if not text.strip():
+        return None, "empty"
+    return text, None
 
 
 def remove_member_answer(council: dict[str, Any], member: dict[str, Any], round_id: str, answer_value: Any) -> None:
@@ -1094,8 +1106,6 @@ def command_submit(arguments: argparse.Namespace) -> None:
         _, runtime = load_runtime(council, member_record)
         if destination != expected_answer_path(runtime, arguments.round_id):
             raise CouncilError("submission destination escaped the member's recorded outbox")
-        if destination.exists() or destination.is_symlink():
-            raise CouncilError("participant already submitted an answer for this round")
         source = Path(arguments.file)
         content = source.read_bytes()
         if not content.strip():
@@ -1103,8 +1113,28 @@ def command_submit(arguments: argparse.Namespace) -> None:
         directory_fd = open_outbox_dir(Path(str(runtime["home"])))
         if directory_fd is None:
             raise CouncilError("participant outbox is not a private directory")
-        os.close(directory_fd)
-        atomic_bytes(destination, content)
+        try:
+            name = f"{arguments.round_id}.md"
+            temporary = f".{name}.{secrets.token_hex(8)}"
+            temporary_fd = os.open(
+                temporary,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW | os.O_CLOEXEC,
+                mode=0o600,
+                dir_fd=directory_fd,
+            )
+            try:
+                with os.fdopen(temporary_fd, "wb") as stream:
+                    stream.write(content)
+                    stream.flush()
+                    os.fsync(stream.fileno())
+                os.link(temporary, name, src_dir_fd=directory_fd, dst_dir_fd=directory_fd)
+            except FileExistsError as error:
+                raise CouncilError("participant already submitted an answer for this round") from error
+            finally:
+                with contextlib.suppress(OSError):
+                    os.unlink(temporary, dir_fd=directory_fd)
+        finally:
+            os.close(directory_fd)
     print(f"submitted: {arguments.member} {arguments.round_id}")
 
 
@@ -1115,11 +1145,15 @@ def readiness(directory: Path, council: dict[str, Any]) -> dict[str, Any]:
     answered: list[str] = []
     pending: list[str] = []
     unavailable: list[str] = []
+    refusals: dict[str, str] = {}
     for member in council["members"]:
         roster_value = round_value.get("roster", {}).get(member["id"], {})
-        answer_text = read_member_answer(council, member, round_value["id"], roster_value.get("answer"))
-        if answer_text is not None and answer_text.strip():
+        answer_text, refusal = inspect_member_answer(council, member, round_value["id"], roster_value.get("answer"))
+        if answer_text is not None:
             answered.append(member["id"])
+        elif refusal:
+            unavailable.append(member["id"])
+            refusals[member["id"]] = refusal
         elif roster_value.get("dispatch") != "sent":
             unavailable.append(member["id"])
         else:
@@ -1135,6 +1169,7 @@ def readiness(directory: Path, council: dict[str, Any]) -> dict[str, Any]:
         "answered": answered,
         "pending": pending,
         "unavailable": unavailable,
+        "refusals": refusals,
     }
 
 
@@ -1166,13 +1201,25 @@ def command_collect(arguments: argparse.Namespace) -> None:
         round_value = load_round(directory, council["active_round"])
         answers: list[dict[str, str]] = []
         unavailable: list[str] = []
+        refusal_recorded = False
         for member in council["members"]:
             roster_value = round_value["roster"].get(member["id"], {})
-            answer_text = (read_member_answer(council, member, round_value["id"], roster_value.get("answer")) or "").strip()
-            if answer_text:
-                answers.append({"member": member["id"], "profile": f"{member['harness']}/{member['model']}/{member['effort']}", "answer": answer_text})
+            answer_text, refusal = inspect_member_answer(council, member, round_value["id"], roster_value.get("answer"))
+            if answer_text is not None:
+                answers.append({"member": member["id"], "profile": f"{member['harness']}/{member['model']}/{member['effort']}", "answer": answer_text.strip()})
+                if roster_value.pop("refusal", None) is not None:
+                    refusal_recorded = True
             else:
                 unavailable.append(member["id"])
+                if refusal and roster_value.get("refusal") != refusal:
+                    roster_value["refusal"] = refusal
+                    refusal_recorded = True
+                    append_event(
+                        directory / "events.jsonl",
+                        {"event": "answer_refused", "round": round_value["id"], "member": member["id"], "reason": refusal},
+                    )
+        if refusal_recorded:
+            save_round(directory, round_value)
         if not answers:
             raise CouncilError("no participant answer is available; retry or wait rather than inventing a council result")
         collection = {

--- a/bin/fm-council.py
+++ b/bin/fm-council.py
@@ -45,9 +45,12 @@ SECRET_NAMES = {
     "service-account.json",
 }
 SECRET_SUFFIXES = (".pem", ".key", ".p12", ".pfx", ".jks", ".keystore")
+SECRET_STEMS = {"secret", "secrets", "token", "tokens"}
+SECRET_STEM_SUFFIXES = ("", ".yaml", ".yml", ".json", ".txt", ".toml", ".ini")
 SKIP_DIRS = {".git", ".hg", ".svn", "node_modules", "__pycache__", ".cache", ".venv", "venv"}
 SECRET_DIRS = {".ssh", ".gnupg", ".aws", ".azure", ".kube", ".docker"}
 MAX_FILE_BYTES = 20 * 1024 * 1024
+MAX_ANSWER_BYTES = 1024 * 1024
 
 
 class CouncilError(RuntimeError):
@@ -312,6 +315,10 @@ def excluded_reason(relative: Path, entry: os.DirEntry[str]) -> str | None:
         return "secret-default"
     if name in SECRET_NAMES or name.endswith(SECRET_SUFFIXES) or "credential" in name or "private-key" in name:
         return "credential-default"
+    if not entry.is_dir(follow_symlinks=False) and any(
+        name == stem + suffix for stem in SECRET_STEMS for suffix in SECRET_STEM_SUFFIXES
+    ):
+        return "secret-default"
     return None
 
 
@@ -361,6 +368,17 @@ def inventory(source: Path) -> tuple[list[dict[str, Any]], list[dict[str, str]]]
     return entries, excluded
 
 
+def remove_readonly_tree(root: Path) -> None:
+    if not root.exists():
+        return
+    for path in sorted(root.rglob("*"), reverse=True):
+        with contextlib.suppress(OSError):
+            os.chmod(path, 0o700 if path.is_dir() else 0o600)
+    with contextlib.suppress(OSError):
+        os.chmod(root, 0o700)
+    shutil.rmtree(root, ignore_errors=True)
+
+
 def build_snapshot(council_dir: Path, source: Path, round_id: str) -> tuple[Path, str, list[dict[str, str]]]:
     snapshots = council_dir / "snapshots"
     snapshots.mkdir(parents=True, exist_ok=True, mode=0o700)
@@ -370,19 +388,24 @@ def build_snapshot(council_dir: Path, source: Path, round_id: str) -> tuple[Path
         tree = staging / "project"
         tree.mkdir(mode=0o700)
         try:
-            for entry in before:
-                target = tree / entry["path"]
-                if entry["type"] == "dir":
-                    target.mkdir(parents=True, exist_ok=True, mode=0o700)
-                    os.chmod(target, entry["mode"])
-                else:
-                    target.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
-                    shutil.copyfile(source / entry["path"], target, follow_symlinks=False)
-                    os.chmod(target, entry["mode"])
+            try:
+                for entry in before:
+                    target = tree / entry["path"]
+                    if entry["type"] == "dir":
+                        target.mkdir(parents=True, exist_ok=True, mode=0o700)
+                    else:
+                        target.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+                        shutil.copyfile(source / entry["path"], target, follow_symlinks=False)
+                        os.chmod(target, entry["mode"])
+                for entry in before:
+                    if entry["type"] == "dir":
+                        os.chmod(tree / entry["path"], entry["mode"])
+            except OSError as error:
+                raise CouncilError(f"cannot copy the project into its fixed read-only view: {error}") from error
             after, excluded_after = inventory(source)
             copied, copied_excluded = inventory(tree)
             if before != after or excluded_before != excluded_after or before != copied or copied_excluded:
-                shutil.rmtree(staging)
+                remove_readonly_tree(staging)
                 if attempt == 0:
                     continue
                 raise CouncilError("project changed while the fixed read-only view was being built; retry after it stabilizes")
@@ -405,7 +428,7 @@ def build_snapshot(council_dir: Path, source: Path, round_id: str) -> tuple[Path
             os.replace(staging, final)
             return final / "project", view_hash, excluded_before
         except Exception:
-            shutil.rmtree(staging, ignore_errors=True)
+            remove_readonly_tree(staging)
             raise
     raise CouncilError("could not build a stable project view")
 
@@ -562,7 +585,8 @@ def launch_test_members(council: dict[str, Any], directory: Path) -> None:
 def launch_herdr_members(council: dict[str, Any], directory: Path, arguments: argparse.Namespace) -> None:
     if sys.platform != "linux" or os.uname().machine != "x86_64":
         raise CouncilError("the MVP participant lane is verified only on Linux x86_64")
-    if shutil.which("herdr") is None or shutil.which("python3") is None:
+    has_herdr = shutil.which("herdr") is not None or os.environ.get("FM_COUNCIL_HERDR_LAB_HELPER")
+    if not has_herdr or shutil.which("python3") is None:
         raise CouncilError("Herdr and python3 are required for council participants")
     runtime_root = PATHS.runtime_dir(council["id"])
     session = herdr_session(arguments)
@@ -759,7 +783,14 @@ def write_payload(runtime: dict[str, Any], kind: str, payload: str) -> Path:
     return path
 
 
-def send_member(council: dict[str, Any], member: dict[str, Any], kind: str, payload: str, common_path: Path | None = None) -> bool:
+def send_member(
+    council: dict[str, Any],
+    member: dict[str, Any],
+    kind: str,
+    payload: str,
+    answer_path: Path | None = None,
+    common_path: Path | None = None,
+) -> bool:
     state, runtime = probe_member(council, member)
     if state != "available":
         return False
@@ -780,12 +811,105 @@ def send_member(council: dict[str, Any], member: dict[str, Any], kind: str, payl
             return True
         except CouncilError:
             return False
-    result = herdr_run(runtime["session"], ["agent", "send", runtime["pane_id"], payload], check=False)
+    digest = hashlib.sha256(payload.encode()).hexdigest()
+    lines = [
+        f"Council {kind} message. Your complete instructions are in your own private inbox payload file.",
+        f"Payload file: {payload_path}",
+        f"Payload sha256: {digest}",
+    ]
+    if answer_path is not None:
+        lines.append(f"Write your complete answer atomically to this participant-private path before finishing your turn: {answer_path}")
+        lines.append("Use a temporary file in the same directory and rename it into place. Do not only leave the answer on screen.")
+    lines.append("Read the payload file, verify its exact sha256, then follow it fully.")
+    instruction = "\n".join(lines) + "\n"
+    result = herdr_run(runtime["session"], ["agent", "send", runtime["pane_id"], instruction], check=False)
     return result.returncode == 0
 
 
 def update_runtime(path: Path, runtime: dict[str, Any]) -> None:
     atomic_json(path, runtime)
+
+
+def open_outbox_dir(home: Path) -> int | None:
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC
+    try:
+        descriptor = os.open(str(home.parent), flags)
+    except OSError:
+        return None
+    for component in ("home", "outbox"):
+        try:
+            child = os.open(component, flags, dir_fd=descriptor)
+        except OSError:
+            os.close(descriptor)
+            return None
+        os.close(descriptor)
+        descriptor = child
+    return descriptor
+
+
+def expected_answer_path(runtime: dict[str, Any], round_id: str) -> Path:
+    return Path(str(runtime["home"])) / "outbox" / f"{round_id}.md"
+
+
+def read_member_answer(council: dict[str, Any], member: dict[str, Any], round_id: str, answer_value: Any) -> str | None:
+    try:
+        _, runtime = load_runtime(council, member)
+    except CouncilError:
+        return None
+    if not answer_value or Path(str(answer_value)) != expected_answer_path(runtime, round_id):
+        return None
+    directory_fd = open_outbox_dir(Path(str(runtime["home"])))
+    if directory_fd is None:
+        return None
+    try:
+        answer_fd = os.open(f"{round_id}.md", os.O_RDONLY | os.O_NOFOLLOW | os.O_NOCTTY | os.O_CLOEXEC, dir_fd=directory_fd)
+    except OSError:
+        return None
+    finally:
+        os.close(directory_fd)
+    try:
+        info = os.fstat(answer_fd)
+        if (
+            not stat.S_ISREG(info.st_mode)
+            or info.st_nlink != 1
+            or info.st_uid != os.getuid()
+            or info.st_mode & (stat.S_IWGRP | stat.S_IWOTH | stat.S_ISUID | stat.S_ISGID)
+            or not 0 < info.st_size <= MAX_ANSWER_BYTES
+        ):
+            return None
+        chunks: list[bytes] = []
+        total = 0
+        while True:
+            chunk = os.read(answer_fd, 1 << 16)
+            if not chunk:
+                break
+            chunks.append(chunk)
+            total += len(chunk)
+            if total > MAX_ANSWER_BYTES:
+                return None
+    finally:
+        os.close(answer_fd)
+    try:
+        return b"".join(chunks).decode("utf-8")
+    except UnicodeDecodeError:
+        return None
+
+
+def remove_member_answer(council: dict[str, Any], member: dict[str, Any], round_id: str, answer_value: Any) -> None:
+    try:
+        _, runtime = load_runtime(council, member)
+    except CouncilError:
+        return
+    if not answer_value or Path(str(answer_value)) != expected_answer_path(runtime, round_id):
+        return
+    directory_fd = open_outbox_dir(Path(str(runtime["home"])))
+    if directory_fd is None:
+        return
+    try:
+        with contextlib.suppress(OSError):
+            os.unlink(f"{round_id}.md", dir_fd=directory_fd)
+    finally:
+        os.close(directory_fd)
 
 
 def catch_up_member(directory: Path, council: dict[str, Any], member: dict[str, Any]) -> bool:
@@ -924,13 +1048,7 @@ def start_round(directory: Path, council: dict[str, Any], task: str) -> dict[str
             }
             envelope_path = Path(runtime["home"]) / "inbox" / f"{round_id}.json"
             atomic_json(envelope_path, envelope)
-            message = (
-                common
-                + "\nWrite your complete answer atomically to this participant-private path before finishing your turn:\n"
-                + f"`{answer_path}`\n"
-                + "Use a temporary file in the same directory and rename it into place. Do not only leave the answer on screen.\n"
-            )
-            if send_member(council, member, "round", message, common_path):
+            if send_member(council, member, "round", common, answer_path=answer_path, common_path=common_path):
                 roster[member["id"]] = {"dispatch": "sent", "answer": str(answer_path), "nonce": nonce}
                 runtime["active_round"] = round_id
                 update_runtime(runtime_file, runtime)
@@ -969,15 +1087,23 @@ def command_submit(arguments: argparse.Namespace) -> None:
         round_value = load_round(directory, arguments.round_id)
         roster = round_value.get("roster", {})
         member_value = roster.get(arguments.member)
-        if not member_value or member_value.get("dispatch") != "sent" or member_value.get("nonce") != arguments.nonce:
+        member_record = next((item for item in council["members"] if item["id"] == arguments.member), None)
+        if not member_value or not member_record or member_value.get("dispatch") != "sent" or member_value.get("nonce") != arguments.nonce:
             raise CouncilError("submission identity or nonce does not match the frozen round roster")
         destination = Path(member_value["answer"])
-        if destination.exists():
+        _, runtime = load_runtime(council, member_record)
+        if destination != expected_answer_path(runtime, arguments.round_id):
+            raise CouncilError("submission destination escaped the member's recorded outbox")
+        if destination.exists() or destination.is_symlink():
             raise CouncilError("participant already submitted an answer for this round")
         source = Path(arguments.file)
         content = source.read_bytes()
         if not content.strip():
             raise CouncilError("participant answer is empty")
+        directory_fd = open_outbox_dir(Path(str(runtime["home"])))
+        if directory_fd is None:
+            raise CouncilError("participant outbox is not a private directory")
+        os.close(directory_fd)
         atomic_bytes(destination, content)
     print(f"submitted: {arguments.member} {arguments.round_id}")
 
@@ -991,13 +1117,16 @@ def readiness(directory: Path, council: dict[str, Any]) -> dict[str, Any]:
     unavailable: list[str] = []
     for member in council["members"]:
         roster_value = round_value.get("roster", {}).get(member["id"], {})
-        answer = roster_value.get("answer")
-        if answer and Path(answer).is_file() and Path(answer).stat().st_size > 0:
+        answer_text = read_member_answer(council, member, round_value["id"], roster_value.get("answer"))
+        if answer_text is not None and answer_text.strip():
             answered.append(member["id"])
         elif roster_value.get("dispatch") != "sent":
             unavailable.append(member["id"])
         else:
-            state, _ = probe_member(council, member)
+            try:
+                state, _ = probe_member(council, member)
+            except CouncilError:
+                state = "unavailable"
             (pending if state == "available" else unavailable).append(member["id"])
     return {
         "council": council["id"],
@@ -1039,10 +1168,7 @@ def command_collect(arguments: argparse.Namespace) -> None:
         unavailable: list[str] = []
         for member in council["members"]:
             roster_value = round_value["roster"].get(member["id"], {})
-            answer_text = ""
-            answer_path_value = roster_value.get("answer")
-            if answer_path_value and Path(answer_path_value).is_file():
-                answer_text = Path(answer_path_value).read_text(encoding="utf-8").strip()
+            answer_text = (read_member_answer(council, member, round_value["id"], roster_value.get("answer")) or "").strip()
             if answer_text:
                 answers.append({"member": member["id"], "profile": f"{member['harness']}/{member['model']}/{member['effort']}", "answer": answer_text})
             else:
@@ -1103,22 +1229,16 @@ def command_present(arguments: argparse.Namespace) -> None:
 
 
 def remove_snapshot(directory: Path, round_id: str) -> None:
-    snapshot = directory / "snapshots" / round_id
-    if snapshot.exists():
-        for path in sorted(snapshot.rglob("*"), reverse=True):
-            with contextlib.suppress(OSError):
-                os.chmod(path, 0o700 if path.is_dir() else 0o600)
-        with contextlib.suppress(OSError):
-            os.chmod(snapshot, 0o700)
-        shutil.rmtree(snapshot, ignore_errors=True)
+    remove_readonly_tree(directory / "snapshots" / round_id)
 
 
 def cleanup_round_payloads(directory: Path, council: dict[str, Any], round_value: dict[str, Any], keep_presentation: bool) -> None:
-    for roster_value in round_value.get("roster", {}).values():
+    members = {member["id"]: member for member in council["members"]}
+    for member_id, roster_value in round_value.get("roster", {}).items():
+        member = members.get(member_id)
         answer = roster_value.get("answer")
-        if answer:
-            with contextlib.suppress(FileNotFoundError):
-                Path(answer).unlink()
+        if member and answer:
+            remove_member_answer(council, member, round_value["id"], answer)
     runtime_round = PATHS.runtime_dir(council["id"]) / "rounds" / round_value["id"]
     shutil.rmtree(runtime_round, ignore_errors=True)
     if not keep_presentation:

--- a/bin/fm-council.py
+++ b/bin/fm-council.py
@@ -1,0 +1,1383 @@
+#!/usr/bin/env python3
+"""Implementation core for bin/fm-council.sh.
+
+The shell entrypoint and its --help output are the public contract.
+This module owns only the private mechanics behind that contract.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import datetime as dt
+import fcntl
+import hashlib
+import json
+import os
+from pathlib import Path
+import secrets
+import shutil
+import shlex
+import stat
+import subprocess
+import sys
+import tempfile
+import time
+from typing import Any, Iterator
+
+
+SCHEMA = "fm-council.v1"
+SUPPORTED: dict[tuple[str, str, str], str] = {
+    ("claude", "claude-fable-5", "xhigh"): "anthropic",
+    ("codex", "gpt-5.6-sol", "xhigh"): "openai",
+}
+SECRET_NAMES = {
+    ".netrc",
+    ".npmrc",
+    ".pypirc",
+    "auth.json",
+    "credentials",
+    "credentials.json",
+    "id_dsa",
+    "id_ed25519",
+    "id_ecdsa",
+    "id_rsa",
+    "service-account.json",
+}
+SECRET_SUFFIXES = (".pem", ".key", ".p12", ".pfx", ".jks", ".keystore")
+SKIP_DIRS = {".git", ".hg", ".svn", "node_modules", "__pycache__", ".cache", ".venv", "venv"}
+SECRET_DIRS = {".ssh", ".gnupg", ".aws", ".azure", ".kube", ".docker"}
+MAX_FILE_BYTES = 20 * 1024 * 1024
+
+
+class CouncilError(RuntimeError):
+    pass
+
+
+def now() -> str:
+    return dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def atomic_bytes(path: Path, content: bytes, mode: int = 0o600) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temporary = Path(temporary_name)
+    try:
+        os.fchmod(descriptor, mode)
+        with os.fdopen(descriptor, "wb") as stream:
+            stream.write(content)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+    finally:
+        with contextlib.suppress(FileNotFoundError):
+            temporary.unlink()
+
+
+def atomic_text(path: Path, content: str, mode: int = 0o600) -> None:
+    atomic_bytes(path, content.encode(), mode)
+
+
+def atomic_json(path: Path, value: Any) -> None:
+    atomic_text(path, json.dumps(value, indent=2, sort_keys=True, ensure_ascii=False) + "\n")
+
+
+def load_json(path: Path) -> Any:
+    try:
+        with path.open(encoding="utf-8") as stream:
+            return json.load(stream)
+    except FileNotFoundError as error:
+        raise CouncilError(f"missing council record: {path}") from error
+    except json.JSONDecodeError as error:
+        raise CouncilError(f"invalid council JSON: {path}: {error}") from error
+
+
+def append_event(path: Path, event: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    event = {"at": now(), **event}
+    descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+    try:
+        os.write(descriptor, (json.dumps(event, sort_keys=True, ensure_ascii=False) + "\n").encode())
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def slug(value: str) -> str:
+    cleaned = "".join(character.lower() if character.isalnum() else "-" for character in value)
+    cleaned = "-".join(part for part in cleaned.split("-") if part)[:40].strip("-")
+    if not cleaned:
+        cleaned = "council"
+    suffix = hashlib.sha256(value.casefold().encode()).hexdigest()[:8]
+    return f"{cleaned}-{suffix}"
+
+
+def validate_name(value: str) -> str:
+    value = value.strip()
+    if not value or "\n" in value or "\r" in value or "\0" in value:
+        raise CouncilError("council name must be one non-empty line")
+    return value
+
+
+def canonical_project(path: str) -> Path:
+    candidate = Path(path).expanduser()
+    if candidate.is_symlink():
+        raise CouncilError("project root may not be a symlink")
+    try:
+        resolved = candidate.resolve(strict=True)
+    except FileNotFoundError as error:
+        raise CouncilError(f"project path does not exist: {candidate}") from error
+    if not resolved.is_dir():
+        raise CouncilError(f"project path is not a directory: {resolved}")
+    for system_root in (Path("/usr"), Path("/etc"), Path("/proc"), Path("/sys"), Path("/dev")):
+        with contextlib.suppress(ValueError):
+            resolved.relative_to(system_root)
+            raise CouncilError(f"project path is inside the sandbox's admitted system surface: {resolved}")
+    return resolved
+
+
+def profile(text: str) -> dict[str, str]:
+    parts = text.split("/")
+    if len(parts) != 3 or any(not part for part in parts):
+        raise CouncilError(f"participant must be harness/model/effort, got: {text}")
+    key = tuple(parts)
+    provider = SUPPORTED.get(key)
+    if provider is None:
+        supported = ", ".join("/".join(item) for item in SUPPORTED)
+        raise CouncilError(f"unsupported exact participant profile '{text}'; supported: {supported}")
+    harness, model, effort = parts
+    return {
+        "id": f"{harness}-{hashlib.sha256(text.encode()).hexdigest()[:10]}",
+        "harness": harness,
+        "model": model,
+        "effort": effort,
+        "provider": provider,
+    }
+
+
+class Paths:
+    def __init__(self) -> None:
+        root = Path(__file__).resolve().parent.parent
+        home = Path(os.environ.get("FM_HOME", root)).resolve()
+        self.root = root
+        self.home = home
+        self.data = Path(os.environ.get("FM_DATA_OVERRIDE", home / "data")).resolve()
+        self.state = Path(os.environ.get("FM_STATE_OVERRIDE", home / "state")).resolve()
+        self.config = Path(os.environ.get("FM_CONFIG_OVERRIDE", home / "config")).resolve()
+        self.councils = self.data / "councils"
+        self.runtime = self.state / "councils"
+        self.projects = self.data / "council-projects"
+        self.consent = self.config / "council-provider-consent.json"
+        for path in (self.councils, self.runtime, self.projects, self.config):
+            path.mkdir(parents=True, exist_ok=True, mode=0o700)
+
+    def council_dir(self, council_id: str) -> Path:
+        return self.councils / council_id
+
+    def runtime_dir(self, council_id: str) -> Path:
+        return self.runtime / council_id
+
+
+PATHS = Paths()
+
+
+@contextlib.contextmanager
+def lock(path: Path, blocking: bool = True) -> Iterator[None]:
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    descriptor = os.open(path, os.O_RDWR | os.O_CREAT, 0o600)
+    try:
+        flags = fcntl.LOCK_EX | (0 if blocking else fcntl.LOCK_NB)
+        try:
+            fcntl.flock(descriptor, flags)
+        except BlockingIOError as error:
+            raise CouncilError("another command is already changing this council") from error
+        yield
+    finally:
+        fcntl.flock(descriptor, fcntl.LOCK_UN)
+        os.close(descriptor)
+
+
+def find_council(name: str, include_closed: bool = True) -> tuple[Path, dict[str, Any]]:
+    wanted = name.casefold()
+    matches: list[tuple[Path, dict[str, Any]]] = []
+    for record_path in PATHS.councils.glob("*/council.json"):
+        record = load_json(record_path)
+        if record.get("schema") != SCHEMA:
+            raise CouncilError(f"unsupported council schema in {record_path}")
+        if record.get("id") == name or str(record.get("name", "")).casefold() == wanted:
+            if include_closed or record.get("status") == "open":
+                matches.append((record_path.parent, record))
+    if not matches:
+        raise CouncilError(f"council not found: {name}")
+    if len(matches) != 1:
+        raise CouncilError(f"ambiguous council identity: {name}")
+    return matches[0]
+
+
+def save_council(directory: Path, council: dict[str, Any]) -> None:
+    council["updated_at"] = now()
+    atomic_json(directory / "council.json", council)
+
+
+def project_key(project: Path) -> str:
+    return hashlib.sha256(str(project).encode()).hexdigest()
+
+
+def project_decision_dir(project: Path) -> Path:
+    return PATHS.projects / project_key(project) / "decisions"
+
+
+def decision_index(project: Path) -> dict[str, Any]:
+    path = project_decision_dir(project) / "index.json"
+    if not path.exists():
+        return {"schema": "fm-council-project-decisions.v1", "project": str(project), "decisions": []}
+    value = load_json(path)
+    if value.get("schema") != "fm-council-project-decisions.v1" or value.get("project") != str(project):
+        raise CouncilError(f"invalid project decision index: {path}")
+    return value
+
+
+def active_project_decision_ids(project: Path) -> list[str]:
+    return [str(item["id"]) for item in decision_index(project).get("decisions", []) if item.get("active", True)]
+
+
+def decision_path(project: Path, decision_id: str) -> Path:
+    return project_decision_dir(project) / f"{decision_id}.md"
+
+
+def load_consent() -> dict[str, Any]:
+    if not PATHS.consent.exists():
+        return {"schema": "fm-council-provider-consent.v1", "consents": []}
+    value = load_json(PATHS.consent)
+    if value.get("schema") != "fm-council-provider-consent.v1":
+        raise CouncilError(f"unsupported provider consent schema: {PATHS.consent}")
+    return value
+
+
+def has_consent(provider: str, project: Path) -> bool:
+    return any(
+        item.get("provider") == provider and item.get("project") == str(project) and item.get("active") is True
+        for item in load_consent().get("consents", [])
+    )
+
+
+def command_consent(arguments: argparse.Namespace) -> None:
+    project = canonical_project(arguments.project)
+    if not arguments.acknowledge_project_disclosure:
+        raise CouncilError("provider consent requires --acknowledge-project-disclosure after the captain explicitly approves this provider and project")
+    providers = {value for value in SUPPORTED.values()}
+    if arguments.provider not in providers:
+        raise CouncilError(f"unsupported provider: {arguments.provider}")
+    with lock(PATHS.config / ".council-provider-consent.lock"):
+        consent = load_consent()
+        records = consent["consents"]
+        for item in records:
+            if item.get("provider") == arguments.provider and item.get("project") == str(project):
+                item.update({"active": True, "granted_at": now()})
+                break
+        else:
+            records.append({"provider": arguments.provider, "project": str(project), "active": True, "granted_at": now()})
+        atomic_json(PATHS.consent, consent)
+    print(f"consent saved: {arguments.provider} may receive filtered council views of {project}")
+
+
+def excluded_reason(relative: Path, entry: os.DirEntry[str]) -> str | None:
+    name = entry.name.lower()
+    if entry.is_symlink():
+        return "symlink"
+    if entry.is_dir(follow_symlinks=False) and name in SKIP_DIRS:
+        return "metadata-or-build-directory"
+    if entry.is_dir(follow_symlinks=False) and name in SECRET_DIRS:
+        return "credential-directory-default"
+    if name == ".env.example":
+        return None
+    if name == ".env" or name.startswith(".env."):
+        return "secret-default"
+    if name in SECRET_NAMES or name.endswith(SECRET_SUFFIXES) or "credential" in name or "private-key" in name:
+        return "credential-default"
+    return None
+
+
+def inventory(source: Path) -> tuple[list[dict[str, Any]], list[dict[str, str]]]:
+    entries: list[dict[str, Any]] = []
+    excluded: list[dict[str, str]] = []
+
+    def walk(directory: Path, relative: Path) -> None:
+        try:
+            children = sorted(os.scandir(directory), key=lambda item: item.name)
+        except OSError as error:
+            raise CouncilError(f"cannot read project directory {directory}: {error}") from error
+        for child in children:
+            child_relative = relative / child.name
+            reason = excluded_reason(child_relative, child)
+            if reason:
+                excluded.append({"path": child_relative.as_posix(), "reason": reason})
+                continue
+            try:
+                child_stat = child.stat(follow_symlinks=False)
+            except OSError as error:
+                raise CouncilError(f"cannot stat project entry {child_relative}: {error}") from error
+            if stat.S_ISDIR(child_stat.st_mode):
+                entries.append({"path": child_relative.as_posix(), "type": "dir", "mode": stat.S_IMODE(child_stat.st_mode)})
+                walk(Path(child.path), child_relative)
+            elif stat.S_ISREG(child_stat.st_mode):
+                if child_stat.st_size > MAX_FILE_BYTES:
+                    excluded.append({"path": child_relative.as_posix(), "reason": "file-too-large"})
+                    continue
+                try:
+                    content = Path(child.path).read_bytes()
+                except OSError as error:
+                    raise CouncilError(f"cannot read project file {child_relative}: {error}") from error
+                entries.append(
+                    {
+                        "path": child_relative.as_posix(),
+                        "type": "file",
+                        "mode": stat.S_IMODE(child_stat.st_mode),
+                        "size": len(content),
+                        "sha256": hashlib.sha256(content).hexdigest(),
+                    }
+                )
+            else:
+                excluded.append({"path": child_relative.as_posix(), "reason": "unsafe-file-type"})
+
+    walk(source, Path())
+    return entries, excluded
+
+
+def build_snapshot(council_dir: Path, source: Path, round_id: str) -> tuple[Path, str, list[dict[str, str]]]:
+    snapshots = council_dir / "snapshots"
+    snapshots.mkdir(parents=True, exist_ok=True, mode=0o700)
+    for attempt in range(2):
+        before, excluded_before = inventory(source)
+        staging = Path(tempfile.mkdtemp(prefix=f".{round_id}.", dir=snapshots))
+        tree = staging / "project"
+        tree.mkdir(mode=0o700)
+        try:
+            for entry in before:
+                target = tree / entry["path"]
+                if entry["type"] == "dir":
+                    target.mkdir(parents=True, exist_ok=True, mode=0o700)
+                    os.chmod(target, entry["mode"])
+                else:
+                    target.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+                    shutil.copyfile(source / entry["path"], target, follow_symlinks=False)
+                    os.chmod(target, entry["mode"])
+            after, excluded_after = inventory(source)
+            copied, copied_excluded = inventory(tree)
+            if before != after or excluded_before != excluded_after or before != copied or copied_excluded:
+                shutil.rmtree(staging)
+                if attempt == 0:
+                    continue
+                raise CouncilError("project changed while the fixed read-only view was being built; retry after it stabilizes")
+            manifest_bytes = json.dumps(before, sort_keys=True, separators=(",", ":")).encode()
+            view_hash = hashlib.sha256(manifest_bytes).hexdigest()
+            manifest = {
+                "schema": "fm-council-view.v1",
+                "source": str(source),
+                "round_id": round_id,
+                "view_hash": view_hash,
+                "entries": before,
+                "excluded": excluded_before,
+                "created_at": now(),
+            }
+            atomic_json(staging / "manifest.json", manifest)
+            for path in sorted(tree.rglob("*"), reverse=True):
+                os.chmod(path, 0o555 if path.is_dir() else 0o444)
+            os.chmod(tree, 0o555)
+            final = snapshots / round_id
+            os.replace(staging, final)
+            return final / "project", view_hash, excluded_before
+        except Exception:
+            shutil.rmtree(staging, ignore_errors=True)
+            raise
+    raise CouncilError("could not build a stable project view")
+
+
+def copy_auth(profile_value: dict[str, str], lane_home: Path) -> None:
+    real_home = Path.home()
+    if profile_value["harness"] == "claude":
+        source = real_home / ".claude" / ".credentials.json"
+        destination = lane_home / ".claude" / ".credentials.json"
+    else:
+        source = real_home / ".codex" / "auth.json"
+        destination = lane_home / ".codex" / "auth.json"
+    destination.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    if source.is_file():
+        shutil.copyfile(source, destination)
+        os.chmod(destination, 0o600)
+
+
+def executable_paths(harness: str) -> list[str]:
+    names = ["bash", "sh", "cat", "rg", "grep", "find", "sed", "awk", "head", "tail", "wc", "sort", "uniq", "cut", "tr", "ls", "stat", "mktemp", "mv"]
+    result: list[str] = []
+    for name in [harness, *names]:
+        resolved = shutil.which(name)
+        if resolved:
+            real = str(Path(resolved).resolve())
+            if real not in result:
+                result.append(real)
+    if harness == "codex":
+        for name in ("env", "node"):
+            resolved = shutil.which(name)
+            if resolved:
+                result.append(str(Path(resolved).resolve()))
+        codex_root = Path("/usr/lib/node_modules/@openai/codex")
+        if codex_root.exists():
+            for path in codex_root.glob("node_modules/@openai/codex-linux-*/vendor/*/bin/codex"):
+                result.append(str(path.resolve()))
+            for path in codex_root.glob("node_modules/@openai/codex-linux-*/vendor/*/bin/codex-code-mode-host"):
+                result.append(str(path.resolve()))
+    return sorted(set(result))
+
+
+def launch_argv(profile_value: dict[str, str]) -> list[str]:
+    if profile_value["harness"] == "claude":
+        return [
+            shutil.which("claude") or "claude",
+            "--model",
+            profile_value["model"],
+            "--effort",
+            profile_value["effort"],
+            "--dangerously-skip-permissions",
+        ]
+    return [
+        shutil.which("codex") or "codex",
+        "--model",
+        profile_value["model"],
+        "-c",
+        f'model_reasoning_effort="{profile_value["effort"]}"',
+        "--dangerously-bypass-approvals-and-sandbox",
+        "--cd",
+        ".",
+    ]
+
+
+def sandbox_command(profile_value: dict[str, str], lane_home: Path, snapshots: Path) -> list[str]:
+    command = [
+        shutil.which("python3") or "/usr/bin/python3",
+        str(PATHS.root / "bin" / "fm-council-sandbox.py"),
+        "--home",
+        str(lane_home),
+        "--readable",
+        str(snapshots),
+    ]
+    for executable in executable_paths(profile_value["harness"]):
+        command.extend(("--allow-exec", executable))
+    command.append("--")
+    command.extend(launch_argv(profile_value))
+    return command
+
+
+def test_transport() -> str | None:
+    return os.environ.get("FM_COUNCIL_TEST_TRANSPORT")
+
+
+def run_transport(arguments: list[str], expect_json: bool = False) -> Any:
+    transport = test_transport()
+    if not transport:
+        raise CouncilError("internal: no test transport configured")
+    result = subprocess.run([transport, *arguments], text=True, capture_output=True, check=False)
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+        raise CouncilError(f"participant transport failed: {detail}")
+    if expect_json:
+        try:
+            return json.loads(result.stdout)
+        except json.JSONDecodeError as error:
+            raise CouncilError("participant transport returned invalid JSON") from error
+    return result.stdout
+
+
+def herdr_session(arguments: argparse.Namespace | None = None) -> str:
+    explicit = getattr(arguments, "herdr_session", None) if arguments else None
+    return explicit or os.environ.get("FM_COUNCIL_HERDR_SESSION") or os.environ.get("HERDR_SESSION") or "default"
+
+
+def herdr_run(session: str, arguments: list[str], check: bool = True) -> subprocess.CompletedProcess[str]:
+    helper = os.environ.get("FM_COUNCIL_HERDR_LAB_HELPER")
+    if helper:
+        command = [helper, "run", session, *arguments]
+        environment = os.environ.copy()
+    else:
+        command = ["herdr", *arguments, "--session", session]
+        environment = {**os.environ, "HERDR_SESSION": session}
+    result = subprocess.run(command, text=True, capture_output=True, check=False, env=environment)
+    if check and result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+        raise CouncilError(f"Herdr command failed: {detail}")
+    return result
+
+
+def parse_result_json(result: subprocess.CompletedProcess[str], label: str) -> dict[str, Any]:
+    try:
+        value = json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        raise CouncilError(f"could not parse Herdr {label} response") from error
+    if not isinstance(value, dict):
+        raise CouncilError(f"invalid Herdr {label} response")
+    return value
+
+
+def launch_test_members(council: dict[str, Any], directory: Path) -> None:
+    runtime_root = PATHS.runtime_dir(council["id"])
+    for member in council["members"]:
+        lane_home = runtime_root / "members" / member["id"] / "home"
+        lane_home.mkdir(parents=True, exist_ok=False, mode=0o700)
+        owner = secrets.token_hex(16)
+        seed = {
+            "schema": "fm-council-member-runtime.v1",
+            "council_id": council["id"],
+            "member_id": member["id"],
+            "owner_token": owner,
+            "machine_label": f"fm-council-{council['id']}-{member['id']}",
+            "home": str(lane_home),
+            "delivered_decisions": [],
+        }
+        runtime_path = lane_home.parent / "runtime.json"
+        atomic_json(runtime_path, seed)
+        returned = run_transport(["launch", council["id"], member["id"], owner, str(runtime_path)], expect_json=True)
+        for field in ("session", "workspace_id", "tab_id", "pane_id", "endpoint"):
+            if not isinstance(returned.get(field), str) or not returned[field]:
+                raise CouncilError(f"test transport launch omitted exact endpoint field {field}")
+        seed.update({field: returned[field] for field in ("session", "workspace_id", "tab_id", "pane_id", "endpoint")})
+        atomic_json(runtime_path, seed)
+        member["runtime"] = str(runtime_path.relative_to(PATHS.home) if runtime_path.is_relative_to(PATHS.home) else runtime_path)
+
+
+def launch_herdr_members(council: dict[str, Any], directory: Path, arguments: argparse.Namespace) -> None:
+    if sys.platform != "linux" or os.uname().machine != "x86_64":
+        raise CouncilError("the MVP participant lane is verified only on Linux x86_64")
+    if shutil.which("herdr") is None or shutil.which("python3") is None:
+        raise CouncilError("Herdr and python3 are required for council participants")
+    runtime_root = PATHS.runtime_dir(council["id"])
+    session = herdr_session(arguments)
+    member_endpoints: list[tuple[dict[str, str], str, str, str, str]] = []
+    created_panes: list[str] = []
+    try:
+        first_member = council["members"][0]
+        first_home = runtime_root / "members" / first_member["id"] / "home"
+        first_home.mkdir(parents=True, exist_ok=False, mode=0o700)
+        token = secrets.token_hex(10)
+        workspace_label = f"fm-council-{council['id']}-{token}"
+        response = parse_result_json(
+            herdr_run(session, ["workspace", "create", "--cwd", str(first_home), "--label", workspace_label, "--no-focus"]),
+            "workspace create",
+        )
+        workspace_id = str(response.get("result", {}).get("workspace", {}).get("workspace_id", ""))
+        first_tab = str(response.get("result", {}).get("tab", {}).get("tab_id", ""))
+        first_pane = str(response.get("result", {}).get("root_pane", {}).get("pane_id", ""))
+        if not workspace_id or not first_tab or not first_pane:
+            raise CouncilError("Herdr workspace create omitted exact endpoint IDs")
+        first_label = f"fm-council-member-{council['id']}-{first_member['id']}-{token}"
+        herdr_run(session, ["tab", "rename", first_tab, first_label])
+        created_panes.append(first_pane)
+        member_endpoints.append((first_member, first_tab, first_pane, first_label, str(first_home)))
+
+        for member in council["members"][1:]:
+            lane_home = runtime_root / "members" / member["id"] / "home"
+            lane_home.mkdir(parents=True, exist_ok=False, mode=0o700)
+            label = f"fm-council-member-{council['id']}-{member['id']}-{token}"
+            response = parse_result_json(
+                herdr_run(
+                    session,
+                    ["tab", "create", "--workspace", workspace_id, "--cwd", str(lane_home), "--label", label, "--no-focus"],
+                ),
+                "tab create",
+            )
+            tab_id = str(response.get("result", {}).get("tab", {}).get("tab_id", ""))
+            pane_id = str(response.get("result", {}).get("root_pane", {}).get("pane_id", ""))
+            if not tab_id or not pane_id:
+                raise CouncilError("Herdr tab create omitted exact endpoint IDs")
+            created_panes.append(pane_id)
+            member_endpoints.append((member, tab_id, pane_id, label, str(lane_home)))
+
+        for member, tab_id, pane_id, label, home_text in member_endpoints:
+            lane_home = Path(home_text)
+            for child in ("outbox", "inbox", "tmp", ".config", ".cache", ".local/share"):
+                (lane_home / child).mkdir(parents=True, exist_ok=True, mode=0o700)
+            copy_auth(member, lane_home)
+            command = sandbox_command(member, lane_home, directory / "snapshots")
+            herdr_run(session, ["pane", "run", pane_id, shlex.join(command)])
+            runtime = {
+                "schema": "fm-council-member-runtime.v1",
+                "council_id": council["id"],
+                "member_id": member["id"],
+                "owner_token": token,
+                "machine_label": label,
+                "session": session,
+                "workspace_id": workspace_id,
+                "tab_id": tab_id,
+                "pane_id": pane_id,
+                "endpoint": f"{session}:{pane_id}",
+                "home": str(lane_home),
+                "delivered_decisions": [],
+                "sandbox": "linux-landlock-v1",
+                "launch_profile": {key: member[key] for key in ("harness", "model", "effort")},
+            }
+            runtime_path = lane_home.parent / "runtime.json"
+            atomic_json(runtime_path, runtime)
+            member["runtime"] = str(runtime_path.relative_to(PATHS.home) if runtime_path.is_relative_to(PATHS.home) else runtime_path)
+        council["herdr_session"] = session
+        council["herdr_workspace_id"] = workspace_id
+        council["owner_token"] = token
+    except Exception:
+        for pane in reversed(created_panes):
+            herdr_run(session, ["pane", "close", pane], check=False)
+        shutil.rmtree(runtime_root, ignore_errors=True)
+        raise
+
+
+def runtime_path(member: dict[str, Any]) -> Path:
+    value = Path(str(member["runtime"]))
+    return value if value.is_absolute() else PATHS.home / value
+
+
+def load_runtime(council: dict[str, Any], member: dict[str, Any]) -> tuple[Path, dict[str, Any]]:
+    path = runtime_path(member).resolve()
+    expected_path = (PATHS.runtime_dir(council["id"]) / "members" / member["id"] / "runtime.json").resolve()
+    if path != expected_path:
+        raise CouncilError(f"participant runtime path escaped its exact council/member identity: {path}")
+    value = load_json(path)
+    expected_home = (expected_path.parent / "home").resolve()
+    if (
+        value.get("schema") != "fm-council-member-runtime.v1"
+        or value.get("council_id") != council["id"]
+        or value.get("member_id") != member["id"]
+        or Path(str(value.get("home", ""))).resolve() != expected_home
+        or any(not isinstance(value.get(field), str) or not value[field] for field in ("session", "workspace_id", "tab_id", "pane_id", "endpoint", "owner_token"))
+    ):
+        raise CouncilError(f"invalid participant runtime identity: {path}")
+    return path, value
+
+
+def command_create(arguments: argparse.Namespace) -> None:
+    name = validate_name(arguments.name)
+    project = canonical_project(arguments.project)
+    participants = [profile(value) for value in arguments.participant]
+    if len(participants) < 2:
+        raise CouncilError("a council requires at least two exact participant profiles")
+    ids = [item["id"] for item in participants]
+    if len(set(ids)) != len(ids):
+        raise CouncilError("duplicate participant profiles are not allowed")
+    council_id = slug(name)
+    with lock(PATHS.councils / ".registry.lock"):
+        for record_path in PATHS.councils.glob("*/council.json"):
+            record = load_json(record_path)
+            if str(record.get("name", "")).casefold() == name.casefold():
+                raise CouncilError(f"council name already exists: {name}")
+        directory = PATHS.council_dir(council_id)
+        if directory.exists():
+            raise CouncilError(f"council identity already exists: {council_id}")
+        directory.mkdir(parents=True, mode=0o700)
+        (directory / "snapshots").mkdir(mode=0o700)
+        council = {
+            "schema": SCHEMA,
+            "id": council_id,
+            "name": name,
+            "status": "open",
+            "phase": "idle",
+            "project": str(project),
+            "project_key": project_key(project),
+            "members": participants,
+            "decision_ids": [] if arguments.clean_slate else active_project_decision_ids(project),
+            "clean_slate": bool(arguments.clean_slate),
+            "active_round": None,
+            "round_counter": 0,
+            "created_at": now(),
+            "updated_at": now(),
+        }
+        save_council(directory, council)
+        try:
+            if test_transport():
+                launch_test_members(council, directory)
+            else:
+                launch_herdr_members(council, directory, arguments)
+            save_council(directory, council)
+            append_event(directory / "events.jsonl", {"event": "council_created", "members": ids})
+        except Exception:
+            shutil.rmtree(directory, ignore_errors=True)
+            shutil.rmtree(PATHS.runtime_dir(council_id), ignore_errors=True)
+            raise
+    print(json.dumps({"council": name, "id": council_id, "project": str(project), "members": ids, "clean_slate": bool(arguments.clean_slate)}, ensure_ascii=False))
+
+
+def probe_member(council: dict[str, Any], member: dict[str, Any]) -> tuple[str, dict[str, Any]]:
+    _, runtime = load_runtime(council, member)
+    if test_transport():
+        try:
+            value = run_transport(
+                ["probe", council["id"], member["id"], runtime["owner_token"], str(runtime_path(member))],
+                expect_json=True,
+            )
+        except CouncilError:
+            return "unavailable", runtime
+        exact = all(value.get(field) == runtime.get(field) for field in ("session", "workspace_id", "tab_id", "pane_id", "owner_token"))
+        return ("available" if exact and value.get("alive") is True else "unavailable"), runtime
+    pane_result = herdr_run(runtime["session"], ["pane", "get", runtime["pane_id"]], check=False)
+    tab_result = herdr_run(runtime["session"], ["tab", "get", runtime["tab_id"]], check=False)
+    if pane_result.returncode != 0 or tab_result.returncode != 0:
+        return "unavailable", runtime
+    try:
+        pane = json.loads(pane_result.stdout).get("result", {}).get("pane", {})
+        tab = json.loads(tab_result.stdout).get("result", {}).get("tab", {})
+    except json.JSONDecodeError:
+        return "unavailable", runtime
+    exact = (
+        pane.get("pane_id") == runtime["pane_id"]
+        and pane.get("tab_id") == runtime["tab_id"]
+        and pane.get("workspace_id") == runtime["workspace_id"]
+        and tab.get("tab_id") == runtime["tab_id"]
+        and tab.get("workspace_id") == runtime["workspace_id"]
+        and tab.get("label") == runtime["machine_label"]
+    )
+    return ("available" if exact else "unavailable"), runtime
+
+
+def write_payload(runtime: dict[str, Any], kind: str, payload: str) -> Path:
+    inbox = Path(runtime["home"]) / "inbox"
+    inbox.mkdir(parents=True, exist_ok=True, mode=0o700)
+    path = inbox / f"{now().replace(':', '')}-{kind}-{secrets.token_hex(4)}.md"
+    atomic_text(path, payload)
+    return path
+
+
+def send_member(council: dict[str, Any], member: dict[str, Any], kind: str, payload: str, common_path: Path | None = None) -> bool:
+    state, runtime = probe_member(council, member)
+    if state != "available":
+        return False
+    payload_path = write_payload(runtime, kind, payload)
+    if test_transport():
+        try:
+            run_transport(
+                [
+                    "send",
+                    council["id"],
+                    member["id"],
+                    kind,
+                    str(payload_path),
+                    str(common_path or "-"),
+                    str(runtime_path(member)),
+                ]
+            )
+            return True
+        except CouncilError:
+            return False
+    result = herdr_run(runtime["session"], ["agent", "send", runtime["pane_id"], payload], check=False)
+    return result.returncode == 0
+
+
+def update_runtime(path: Path, runtime: dict[str, Any]) -> None:
+    atomic_json(path, runtime)
+
+
+def catch_up_member(directory: Path, council: dict[str, Any], member: dict[str, Any]) -> bool:
+    path, runtime = load_runtime(council, member)
+    delivered = list(runtime.get("delivered_decisions", []))
+    project = Path(council["project"])
+    for decision_id in council.get("decision_ids", []):
+        if decision_id in delivered:
+            continue
+        body_path = decision_path(project, decision_id)
+        if not body_path.is_file():
+            raise CouncilError(f"accepted decision body is missing: {body_path}")
+        body = body_path.read_text(encoding="utf-8")
+        if not send_member(council, member, "decision", body):
+            append_event(directory / "events.jsonl", {"event": "decision_delivery_deferred", "member": member["id"], "decision": decision_id})
+            return False
+        delivered.append(decision_id)
+        runtime["delivered_decisions"] = delivered
+        update_runtime(path, runtime)
+        append_event(directory / "events.jsonl", {"event": "decision_delivered", "member": member["id"], "decision": decision_id})
+    return True
+
+
+def round_record_path(directory: Path, round_id: str) -> Path:
+    return directory / "rounds" / round_id / "round.json"
+
+
+def load_round(directory: Path, round_id: str) -> dict[str, Any]:
+    return load_json(round_record_path(directory, round_id))
+
+
+def save_round(directory: Path, round_value: dict[str, Any]) -> None:
+    atomic_json(round_record_path(directory, round_value["id"]), round_value)
+
+
+def next_round_id(council: dict[str, Any]) -> str:
+    council["round_counter"] = int(council.get("round_counter", 0)) + 1
+    return f"R{council['round_counter']:04d}"
+
+
+def accepted_context(council: dict[str, Any]) -> str:
+    project = Path(council["project"])
+    sections: list[str] = []
+    for decision_id in council.get("decision_ids", []):
+        path = decision_path(project, decision_id)
+        if path.is_file():
+            sections.append(f"### {decision_id}\n\n{path.read_text(encoding='utf-8')}")
+    return "\n\n".join(sections) if sections else "(none)"
+
+
+def require_idle(council: dict[str, Any]) -> None:
+    if council.get("status") != "open":
+        raise CouncilError("council is closed")
+    if council.get("phase") != "idle" or council.get("active_round"):
+        raise CouncilError(f"council already has an active round in phase {council.get('phase')}")
+
+
+def start_round(directory: Path, council: dict[str, Any], task: str) -> dict[str, Any]:
+    require_idle(council)
+    task = task.strip()
+    if not task:
+        raise CouncilError("round task must not be empty")
+    project = Path(council["project"])
+    missing = sorted({member["provider"] for member in council["members"] if not has_consent(member["provider"], project)})
+    if missing:
+        raise CouncilError(
+            "provider consent missing for this project: "
+            + ", ".join(missing)
+            + "; use provider-consent only after explicit captain approval"
+        )
+    round_id = next_round_id(council)
+    round_directory = directory / "rounds" / round_id
+    round_directory.mkdir(parents=True, mode=0o700)
+    snapshot, view_hash, excluded = build_snapshot(directory, project, round_id)
+    common = (
+        f"# Council round {round_id}\n\n"
+        f"Project view: `{snapshot}`\n\n"
+        f"View hash: `{view_hash}`\n\n"
+        f"## Task\n\n{task}\n\n"
+        f"## Accepted project decisions\n\n{accepted_context(council)}\n\n"
+        "Analyze independently. Do not inspect other participants, terminal-control state, or any source path outside the fixed project view. "
+        "Do not edit or implement the source project. Give a concise, project-grounded answer.\n"
+    )
+    common_path = round_directory / "common.md"
+    atomic_text(common_path, common)
+    common_hash = hashlib.sha256(common.encode()).hexdigest()
+    roster: dict[str, Any] = {}
+    round_value = {
+        "schema": "fm-council-round.v1",
+        "id": round_id,
+        "status": "dispatching",
+        "task": task,
+        "view": str(snapshot),
+        "view_hash": view_hash,
+        "common_hash": common_hash,
+        "excluded": excluded,
+        "roster": roster,
+        "created_at": now(),
+    }
+    save_round(directory, round_value)
+    council["phase"] = "collecting"
+    council["active_round"] = round_id
+    save_council(directory, council)
+    append_event(directory / "events.jsonl", {"event": "round_started", "round": round_id, "common_hash": common_hash})
+
+    for member in council["members"]:
+        if not catch_up_member(directory, council, member):
+            roster[member["id"]] = {"dispatch": "unavailable", "answer": None}
+            continue
+        runtime_file, runtime = load_runtime(council, member)
+        outbox = Path(runtime["home"]) / "outbox"
+        outbox.mkdir(parents=True, exist_ok=True, mode=0o700)
+        answer_path = outbox / f"{round_id}.md"
+        nonce = secrets.token_hex(16)
+        envelope = {
+            "schema": "fm-council-envelope.v1",
+            "council_id": council["id"],
+            "round_id": round_id,
+            "member_id": member["id"],
+            "common_hash": common_hash,
+            "view_hash": view_hash,
+            "answer_path": str(answer_path),
+            "nonce": nonce,
+        }
+        envelope_path = Path(runtime["home"]) / "inbox" / f"{round_id}.json"
+        atomic_json(envelope_path, envelope)
+        message = (
+            common
+            + "\nWrite your complete answer atomically to this participant-private path before finishing your turn:\n"
+            + f"`{answer_path}`\n"
+            + "Use a temporary file in the same directory and rename it into place. Do not only leave the answer on screen.\n"
+        )
+        if send_member(council, member, "round", message, common_path):
+            roster[member["id"]] = {"dispatch": "sent", "answer": str(answer_path), "nonce": nonce}
+            runtime["active_round"] = round_id
+            update_runtime(runtime_file, runtime)
+        else:
+            roster[member["id"]] = {"dispatch": "unavailable", "answer": None}
+    round_value["status"] = "collecting"
+    save_round(directory, round_value)
+    append_event(
+        directory / "events.jsonl",
+        {
+            "event": "round_dispatched",
+            "round": round_id,
+            "available": [member for member, value in roster.items() if value["dispatch"] == "sent"],
+            "unavailable": [member for member, value in roster.items() if value["dispatch"] != "sent"],
+        },
+    )
+    return round_value
+
+
+def command_ask(arguments: argparse.Namespace) -> None:
+    directory, council = find_council(arguments.name, include_closed=False)
+    with lock(PATHS.runtime_dir(council["id"]) / ".lock", blocking=False):
+        round_value = start_round(directory, council, arguments.task)
+    print(json.dumps({"council": council["name"], "round": round_value["id"], "common_hash": round_value["common_hash"], "view_hash": round_value["view_hash"], "roster": round_value["roster"]}, ensure_ascii=False))
+
+
+def command_submit(arguments: argparse.Namespace) -> None:
+    directory, council = find_council(arguments.name, include_closed=False)
+    with lock(PATHS.runtime_dir(council["id"]) / ".lock"):
+        if council.get("active_round") != arguments.round_id or council.get("phase") != "collecting":
+            raise CouncilError("submission does not match the active collecting round")
+        round_value = load_round(directory, arguments.round_id)
+        roster = round_value.get("roster", {})
+        member_value = roster.get(arguments.member)
+        if not member_value or member_value.get("dispatch") != "sent" or member_value.get("nonce") != arguments.nonce:
+            raise CouncilError("submission identity or nonce does not match the frozen round roster")
+        destination = Path(member_value["answer"])
+        if destination.exists():
+            raise CouncilError("participant already submitted an answer for this round")
+        source = Path(arguments.file)
+        content = source.read_bytes()
+        if not content.strip():
+            raise CouncilError("participant answer is empty")
+        atomic_bytes(destination, content)
+    print(f"submitted: {arguments.member} {arguments.round_id}")
+
+
+def readiness(directory: Path, council: dict[str, Any]) -> dict[str, Any]:
+    if council.get("phase") != "collecting" or not council.get("active_round"):
+        raise CouncilError("council has no collecting round")
+    round_value = load_round(directory, council["active_round"])
+    answered: list[str] = []
+    pending: list[str] = []
+    unavailable: list[str] = []
+    for member in council["members"]:
+        roster_value = round_value.get("roster", {}).get(member["id"], {})
+        answer = roster_value.get("answer")
+        if answer and Path(answer).is_file() and Path(answer).stat().st_size > 0:
+            answered.append(member["id"])
+        elif roster_value.get("dispatch") != "sent":
+            unavailable.append(member["id"])
+        else:
+            state, _ = probe_member(council, member)
+            (pending if state == "available" else unavailable).append(member["id"])
+    return {
+        "council": council["id"],
+        "round": round_value["id"],
+        "ready": not pending,
+        "answered": answered,
+        "pending": pending,
+        "unavailable": unavailable,
+    }
+
+
+def command_ready(arguments: argparse.Namespace) -> None:
+    directory, council = find_council(arguments.name, include_closed=False)
+    print(json.dumps(readiness(directory, council), ensure_ascii=False))
+
+
+def command_wait(arguments: argparse.Namespace) -> None:
+    deadline = time.monotonic() + arguments.timeout
+    while True:
+        directory, council = find_council(arguments.name, include_closed=False)
+        value = readiness(directory, council)
+        if value["ready"] or time.monotonic() >= deadline:
+            value["timed_out"] = not value["ready"]
+            print(json.dumps(value, ensure_ascii=False))
+            if value["timed_out"]:
+                raise SystemExit(3)
+            return
+        time.sleep(arguments.poll)
+
+
+def command_collect(arguments: argparse.Namespace) -> None:
+    directory, council = find_council(arguments.name, include_closed=False)
+    with lock(PATHS.runtime_dir(council["id"]) / ".lock"):
+        if council.get("phase") != "collecting" or not council.get("active_round"):
+            raise CouncilError("council has no collecting round")
+        round_value = load_round(directory, council["active_round"])
+        answers: list[dict[str, str]] = []
+        unavailable: list[str] = []
+        for member in council["members"]:
+            roster_value = round_value["roster"].get(member["id"], {})
+            answer_text = ""
+            answer_path_value = roster_value.get("answer")
+            if answer_path_value and Path(answer_path_value).is_file():
+                answer_text = Path(answer_path_value).read_text(encoding="utf-8").strip()
+            if answer_text:
+                answers.append({"member": member["id"], "profile": f"{member['harness']}/{member['model']}/{member['effort']}", "answer": answer_text})
+            else:
+                unavailable.append(member["id"])
+        if not answers:
+            raise CouncilError("no participant answer is available; retry or wait rather than inventing a council result")
+        collection = {
+            "schema": "fm-council-collection.v1",
+            "council": council["id"],
+            "round": round_value["id"],
+            "common_hash": round_value["common_hash"],
+            "answers": answers,
+            "unavailable": unavailable,
+            "comparison": "only-available" if len(answers) == 1 else "compare-or-synthesize",
+        }
+        collection_path = PATHS.runtime_dir(council["id"]) / "rounds" / round_value["id"] / "collection.json"
+        atomic_json(collection_path, collection)
+        round_value["status"] = "awaiting_presentation"
+        round_value["available_members"] = [answer["member"] for answer in answers]
+        round_value["unavailable_members"] = unavailable
+        save_round(directory, round_value)
+        council["phase"] = "awaiting_presentation"
+        save_council(directory, council)
+        append_event(directory / "events.jsonl", {"event": "answers_collected", "round": round_value["id"], "available": round_value["available_members"], "unavailable": unavailable})
+    print(json.dumps({"collection": str(collection_path), **collection}, ensure_ascii=False, indent=2))
+
+
+def command_present(arguments: argparse.Namespace) -> None:
+    directory, council = find_council(arguments.name, include_closed=False)
+    with lock(PATHS.runtime_dir(council["id"]) / ".lock"):
+        if council.get("phase") != "awaiting_presentation" or not council.get("active_round"):
+            raise CouncilError("collect available answers before presenting a canonical decision")
+        round_value = load_round(directory, council["active_round"])
+        available = round_value.get("available_members", [])
+        if len(available) == 1 and arguments.kind != "only":
+            raise CouncilError("one available answer must be presented as the only available answer, never as a comparative winner or synthesis")
+        if len(available) > 1 and arguments.kind == "only":
+            raise CouncilError("--kind only is valid only when exactly one answer is available")
+        source = Path(arguments.file)
+        content = source.read_bytes()
+        if not content.strip():
+            raise CouncilError("presented canonical decision is empty")
+        presented = round_record_path(directory, round_value["id"]).parent / "presented.md"
+        atomic_bytes(presented, content)
+        round_value["status"] = "awaiting_acceptance"
+        round_value["presentation_kind"] = arguments.kind
+        round_value["presented_sha256"] = hashlib.sha256(content).hexdigest()
+        save_round(directory, round_value)
+        council["phase"] = "awaiting_acceptance"
+        save_council(directory, council)
+        append_event(directory / "events.jsonl", {"event": "canonical_presented", "round": round_value["id"], "sha256": round_value["presented_sha256"], "kind": arguments.kind})
+    print(content.decode(), end="" if content.endswith(b"\n") else "\n")
+
+
+def cleanup_round_payloads(directory: Path, council: dict[str, Any], round_value: dict[str, Any], keep_presentation: bool) -> None:
+    for roster_value in round_value.get("roster", {}).values():
+        answer = roster_value.get("answer")
+        if answer:
+            with contextlib.suppress(FileNotFoundError):
+                Path(answer).unlink()
+    runtime_round = PATHS.runtime_dir(council["id"]) / "rounds" / round_value["id"]
+    shutil.rmtree(runtime_round, ignore_errors=True)
+    if not keep_presentation:
+        with contextlib.suppress(FileNotFoundError):
+            (round_record_path(directory, round_value["id"]).parent / "presented.md").unlink()
+    snapshot = directory / "snapshots" / round_value["id"]
+    if snapshot.exists():
+        for path in sorted(snapshot.rglob("*"), reverse=True):
+            with contextlib.suppress(OSError):
+                os.chmod(path, 0o700 if path.is_dir() else 0o600)
+        with contextlib.suppress(OSError):
+            os.chmod(snapshot, 0o700)
+        shutil.rmtree(snapshot, ignore_errors=True)
+
+
+def accept_round(directory: Path, council: dict[str, Any]) -> tuple[str, Path, list[str]]:
+    if council.get("phase") != "awaiting_acceptance" or not council.get("active_round"):
+        raise CouncilError("council has no presented canonical decision to accept")
+    round_value = load_round(directory, council["active_round"])
+    presented = round_record_path(directory, round_value["id"]).parent / "presented.md"
+    content = presented.read_bytes()
+    if hashlib.sha256(content).hexdigest() != round_value.get("presented_sha256"):
+        raise CouncilError("presented canonical decision changed after presentation")
+    project = Path(council["project"])
+    decisions = project_decision_dir(project)
+    decisions.mkdir(parents=True, exist_ok=True, mode=0o700)
+    with lock(decisions / ".lock"):
+        index = decision_index(project)
+        sequence = len(index["decisions"]) + 1
+        decision_id = f"D{sequence:04d}"
+        destination = decision_path(project, decision_id)
+        if destination.exists():
+            raise CouncilError(f"decision destination already exists: {destination}")
+        atomic_bytes(destination, content)
+        index["decisions"].append(
+            {
+                "id": decision_id,
+                "active": True,
+                "council_id": council["id"],
+                "round_id": round_value["id"],
+                "sha256": hashlib.sha256(content).hexdigest(),
+                "accepted_at": now(),
+            }
+        )
+        atomic_json(decisions / "index.json", index)
+    append_event(directory / "events.jsonl", {"event": "decision_saved", "decision": decision_id, "round": round_value["id"], "sha256": hashlib.sha256(content).hexdigest()})
+    if decision_id not in council["decision_ids"]:
+        council["decision_ids"].append(decision_id)
+    deferred: list[str] = []
+    body = content.decode()
+    for member in council["members"]:
+        runtime_file, runtime = load_runtime(council, member)
+        if send_member(council, member, "decision", body):
+            delivered = list(runtime.get("delivered_decisions", []))
+            if decision_id not in delivered:
+                delivered.append(decision_id)
+            runtime["delivered_decisions"] = delivered
+            runtime["active_round"] = None
+            update_runtime(runtime_file, runtime)
+            append_event(directory / "events.jsonl", {"event": "decision_delivered", "decision": decision_id, "member": member["id"]})
+        else:
+            deferred.append(member["id"])
+            append_event(directory / "events.jsonl", {"event": "decision_delivery_deferred", "decision": decision_id, "member": member["id"]})
+    round_value["status"] = "accepted"
+    round_value["decision_id"] = decision_id
+    save_round(directory, round_value)
+    cleanup_round_payloads(directory, council, round_value, keep_presentation=True)
+    council["phase"] = "idle"
+    council["active_round"] = None
+    save_council(directory, council)
+    return decision_id, destination, deferred
+
+
+def command_accept(arguments: argparse.Namespace) -> None:
+    directory, council = find_council(arguments.name, include_closed=False)
+    with lock(PATHS.runtime_dir(council["id"]) / ".lock"):
+        decision_id, destination, deferred = accept_round(directory, council)
+    result: dict[str, Any] = {"accepted": decision_id, "canonical": str(destination), "deferred_members": deferred}
+    if arguments.implement:
+        result["implementation"] = {
+            "action": "create_separate_ordinary_implementation_task",
+            "project_path": council["project"],
+            "decision_id": decision_id,
+            "decision_path": str(destination),
+            "instruction": "Create a separate ordinary Firstmate implementation task from this accepted decision. Do not reuse council participants as implementers.",
+        }
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+
+
+def reject_active(directory: Path, council: dict[str, Any], reason: str) -> str:
+    if council.get("phase") not in {"collecting", "awaiting_presentation", "awaiting_acceptance", "interrupted"} or not council.get("active_round"):
+        raise CouncilError("council has no active round to reject")
+    round_value = load_round(directory, council["active_round"])
+    round_value["status"] = "rejected"
+    round_value.pop("presented_sha256", None)
+    round_value.pop("presentation_kind", None)
+    round_value.pop("available_members", None)
+    round_value.pop("unavailable_members", None)
+    round_value["rejection_reason"] = reason
+    cleanup_round_payloads(directory, council, round_value, keep_presentation=False)
+    save_round(directory, round_value)
+    round_id = round_value["id"]
+    council["phase"] = "idle"
+    council["active_round"] = None
+    save_council(directory, council)
+    append_event(directory / "events.jsonl", {"event": "round_rejected", "round": round_id, "reason": reason})
+    return round_id
+
+
+def command_reject(arguments: argparse.Namespace) -> None:
+    directory, council = find_council(arguments.name, include_closed=False)
+    with lock(PATHS.runtime_dir(council["id"]) / ".lock"):
+        round_id = reject_active(directory, council, arguments.reason)
+    print(f"rejected: {round_id}; no rejected result was retained")
+
+
+def command_rerun(arguments: argparse.Namespace) -> None:
+    directory, council = find_council(arguments.name, include_closed=False)
+    with lock(PATHS.runtime_dir(council["id"]) / ".lock"):
+        if not council.get("active_round"):
+            raise CouncilError("council has no active round to rerun")
+        old = load_round(directory, council["active_round"])
+        task = old["task"]
+        if arguments.clarify:
+            task = f"{task}\n\nClarified constraint: {arguments.clarify.strip()}"
+        rejected = reject_active(directory, council, "rerun with clarified constraints")
+        round_value = start_round(directory, council, task)
+    print(json.dumps({"rejected": rejected, "rerun": round_value["id"], "task": task}, ensure_ascii=False))
+
+
+def command_recover(arguments: argparse.Namespace) -> None:
+    directory, council = find_council(arguments.name, include_closed=False)
+    with lock(PATHS.runtime_dir(council["id"]) / ".lock"):
+        if council.get("phase") != "collecting" or not council.get("active_round"):
+            raise CouncilError("only an interrupted collecting round can be marked for explicit retry")
+        round_value = load_round(directory, council["active_round"])
+        round_value["status"] = "interrupted"
+        save_round(directory, round_value)
+        council["phase"] = "interrupted"
+        save_council(directory, council)
+        append_event(directory / "events.jsonl", {"event": "round_interrupted", "round": round_value["id"]})
+    print(f"interrupted: {round_value['id']}; use retry explicitly")
+
+
+def command_retry(arguments: argparse.Namespace) -> None:
+    directory, council = find_council(arguments.name, include_closed=False)
+    with lock(PATHS.runtime_dir(council["id"]) / ".lock"):
+        if council.get("phase") != "interrupted" or not council.get("active_round"):
+            raise CouncilError("council has no interrupted round to retry")
+        old = load_round(directory, council["active_round"])
+        task = old["task"]
+        if arguments.clarify:
+            task = f"{task}\n\nClarified constraint: {arguments.clarify.strip()}"
+        rejected = reject_active(directory, council, "interrupted round retried explicitly")
+        round_value = start_round(directory, council, task)
+    print(json.dumps({"interrupted": rejected, "retry": round_value["id"], "task": task}, ensure_ascii=False))
+
+
+def close_preflight(council: dict[str, Any], member: dict[str, Any]) -> dict[str, Any]:
+    _, runtime = load_runtime(council, member)
+    if runtime.get("council_id") != council["id"] or runtime.get("member_id") != member["id"]:
+        raise CouncilError(f"participant identity mismatch for {member['id']}")
+    if test_transport():
+        value = run_transport(["probe", council["id"], member["id"], runtime["owner_token"], str(runtime_path(member))], expect_json=True)
+        for field in ("session", "workspace_id", "tab_id", "pane_id", "owner_token"):
+            if value.get(field) != runtime.get(field):
+                raise CouncilError(f"participant endpoint identity mismatch for {member['id']}: {field}")
+        return runtime
+    pane_result = herdr_run(runtime["session"], ["pane", "get", runtime["pane_id"]], check=False)
+    tab_result = herdr_run(runtime["session"], ["tab", "get", runtime["tab_id"]], check=False)
+    if pane_result.returncode != 0 or tab_result.returncode != 0:
+        raise CouncilError(f"cannot verify exact council-owned participant endpoint for {member['id']}")
+    try:
+        pane = json.loads(pane_result.stdout).get("result", {}).get("pane", {})
+        tab = json.loads(tab_result.stdout).get("result", {}).get("tab", {})
+    except json.JSONDecodeError as error:
+        raise CouncilError(f"cannot parse endpoint identity for {member['id']}") from error
+    if pane.get("pane_id") != runtime["pane_id"] or pane.get("tab_id") != runtime["tab_id"] or pane.get("workspace_id") != runtime["workspace_id"]:
+        raise CouncilError(f"exact pane identity changed for {member['id']}")
+    if tab.get("tab_id") != runtime["tab_id"] or tab.get("workspace_id") != runtime["workspace_id"] or tab.get("label") != runtime["machine_label"]:
+        raise CouncilError(f"exact tab ownership changed for {member['id']}")
+    return runtime
+
+
+def close_member(council: dict[str, Any], member: dict[str, Any], runtime: dict[str, Any]) -> None:
+    if test_transport():
+        run_transport(["close", council["id"], member["id"], runtime["owner_token"], str(runtime_path(member))])
+    else:
+        result = herdr_run(runtime["session"], ["pane", "close", runtime["pane_id"]], check=False)
+        if result.returncode != 0:
+            raise CouncilError(f"failed to close exact participant endpoint for {member['id']}")
+
+
+def command_close(arguments: argparse.Namespace) -> None:
+    directory, council = find_council(arguments.name, include_closed=False)
+    with lock(PATHS.runtime_dir(council["id"]) / ".lock"):
+        runtimes = [(member, close_preflight(council, member)) for member in council["members"]]
+        for member, runtime in runtimes:
+            close_member(council, member, runtime)
+        runtime_root = PATHS.runtime_dir(council["id"])
+        shutil.rmtree(runtime_root / "members", ignore_errors=True)
+        shutil.rmtree(runtime_root / "rounds", ignore_errors=True)
+        council["status"] = "closed"
+        council["phase"] = "closed"
+        council["active_round"] = None
+        council["closed_at"] = now()
+        for member in council["members"]:
+            member.pop("runtime", None)
+        save_council(directory, council)
+        append_event(directory / "events.jsonl", {"event": "council_closed"})
+    print(f"closed: {council['name']}; participant conversations were cleared")
+
+
+def command_status(arguments: argparse.Namespace) -> None:
+    if arguments.name:
+        _, council = find_council(arguments.name)
+        output = [council]
+    else:
+        output = [load_json(path) for path in sorted(PATHS.councils.glob("*/council.json"))]
+    print(json.dumps(output, ensure_ascii=False, indent=2))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("command")
+    parser.add_argument("rest", nargs=argparse.REMAINDER)
+    return parser
+
+
+def command_parser(command: str) -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog=f"fm-council.sh {command}")
+    if command == "create":
+        parser.add_argument("name")
+        parser.add_argument("--project", required=True)
+        parser.add_argument("--participant", action="append", required=True)
+        parser.add_argument("--clean-slate", action="store_true")
+        parser.add_argument("--herdr-session")
+    elif command == "provider-consent":
+        parser.add_argument("provider")
+        parser.add_argument("--project", required=True)
+        parser.add_argument("--acknowledge-project-disclosure", action="store_true")
+    elif command == "ask":
+        parser.add_argument("name")
+        parser.add_argument("task")
+    elif command == "submit":
+        parser.add_argument("name")
+        parser.add_argument("member")
+        parser.add_argument("--round", dest="round_id", required=True)
+        parser.add_argument("--nonce", required=True)
+        parser.add_argument("--file", required=True)
+    elif command in {"ready", "collect"}:
+        parser.add_argument("name")
+    elif command == "wait":
+        parser.add_argument("name")
+        parser.add_argument("--timeout", type=int, default=900)
+        parser.add_argument("--poll", type=float, default=2.0)
+    elif command == "present":
+        parser.add_argument("name")
+        parser.add_argument("--file", required=True)
+        parser.add_argument("--kind", choices=("best", "synthesis", "only"), required=True)
+    elif command in {"accept", "accept-and-implement"}:
+        parser.add_argument("name")
+        parser.set_defaults(implement=command == "accept-and-implement")
+    elif command == "reject":
+        parser.add_argument("name")
+        parser.add_argument("--reason", default="explicitly rejected")
+    elif command in {"rerun", "retry"}:
+        parser.add_argument("name")
+        parser.add_argument("--clarify")
+    elif command in {"recover", "close"}:
+        parser.add_argument("name")
+    elif command == "status":
+        parser.add_argument("name", nargs="?")
+    else:
+        raise CouncilError(f"unknown command: {command}; run fm-council.sh --help")
+    return parser
+
+
+def main() -> int:
+    top = build_parser()
+    arguments = top.parse_args()
+    parsed = command_parser(arguments.command).parse_args(arguments.rest)
+    commands = {
+        "create": command_create,
+        "provider-consent": command_consent,
+        "ask": command_ask,
+        "submit": command_submit,
+        "ready": command_ready,
+        "wait": command_wait,
+        "collect": command_collect,
+        "present": command_present,
+        "accept": command_accept,
+        "accept-and-implement": command_accept,
+        "reject": command_reject,
+        "rerun": command_rerun,
+        "recover": command_recover,
+        "retry": command_retry,
+        "close": command_close,
+        "status": command_status,
+    }
+    commands[arguments.command](parsed)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except CouncilError as error:
+        print(f"fm-council: {error}", file=sys.stderr)
+        raise SystemExit(1)
+    except KeyboardInterrupt:
+        print("fm-council: interrupted", file=sys.stderr)
+        raise SystemExit(130)

--- a/bin/fm-council.py
+++ b/bin/fm-council.py
@@ -197,13 +197,23 @@ def lock(path: Path, blocking: bool = True) -> Iterator[None]:
         os.close(descriptor)
 
 
+def read_council_record(record_path: Path) -> dict[str, Any]:
+    record = load_json(record_path)
+    if not isinstance(record, dict) or record.get("schema") != SCHEMA:
+        raise CouncilError(f"unsupported council schema in {record_path}")
+    return record
+
+
 def find_council(name: str, include_closed: bool = True) -> tuple[Path, dict[str, Any]]:
     wanted = name.casefold()
     matches: list[tuple[Path, dict[str, Any]]] = []
     for record_path in PATHS.councils.glob("*/council.json"):
-        record = load_json(record_path)
-        if record.get("schema") != SCHEMA:
-            raise CouncilError(f"unsupported council schema in {record_path}")
+        try:
+            record = read_council_record(record_path)
+        except CouncilError:
+            if record_path.parent.name == name:
+                raise
+            continue
         if record.get("id") == name or str(record.get("name", "")).casefold() == wanted:
             if include_closed or record.get("status") == "open":
                 matches.append((record_path.parent, record))
@@ -217,6 +227,13 @@ def find_council(name: str, include_closed: bool = True) -> tuple[Path, dict[str
 def save_council(directory: Path, council: dict[str, Any]) -> None:
     council["updated_at"] = now()
     atomic_json(directory / "council.json", council)
+
+
+def reload_open_council(directory: Path) -> dict[str, Any]:
+    council = read_council_record(directory / "council.json")
+    if council.get("status") != "open":
+        raise CouncilError("council is closed")
+    return council
 
 
 def project_key(project: Path) -> str:
@@ -660,7 +677,10 @@ def command_create(arguments: argparse.Namespace) -> None:
     council_id = slug(name)
     with lock(PATHS.councils / ".registry.lock"):
         for record_path in PATHS.councils.glob("*/council.json"):
-            record = load_json(record_path)
+            try:
+                record = read_council_record(record_path)
+            except CouncilError:
+                continue
             if str(record.get("name", "")).casefold() == name.casefold():
                 raise CouncilError(f"council name already exists: {name}")
         directory = PATHS.council_dir(council_id)
@@ -838,6 +858,9 @@ def start_round(directory: Path, council: dict[str, Any], task: str) -> dict[str
         )
     round_id = next_round_id(council)
     round_directory = directory / "rounds" / round_id
+    if round_directory.exists():
+        shutil.rmtree(round_directory)
+    remove_snapshot(directory, round_id)
     round_directory.mkdir(parents=True, mode=0o700)
     try:
         snapshot, view_hash, excluded = build_snapshot(directory, project, round_id)
@@ -880,37 +903,40 @@ def start_round(directory: Path, council: dict[str, Any], task: str) -> dict[str
     append_event(directory / "events.jsonl", {"event": "round_started", "round": round_id, "common_hash": common_hash})
 
     for member in council["members"]:
-        if not catch_up_member(directory, council, member):
-            roster[member["id"]] = {"dispatch": "unavailable", "answer": None}
-            continue
-        runtime_file, runtime = load_runtime(council, member)
-        outbox = Path(runtime["home"]) / "outbox"
-        outbox.mkdir(parents=True, exist_ok=True, mode=0o700)
-        answer_path = outbox / f"{round_id}.md"
-        nonce = secrets.token_hex(16)
-        envelope = {
-            "schema": "fm-council-envelope.v1",
-            "council_id": council["id"],
-            "round_id": round_id,
-            "member_id": member["id"],
-            "common_hash": common_hash,
-            "view_hash": view_hash,
-            "answer_path": str(answer_path),
-            "nonce": nonce,
-        }
-        envelope_path = Path(runtime["home"]) / "inbox" / f"{round_id}.json"
-        atomic_json(envelope_path, envelope)
-        message = (
-            common
-            + "\nWrite your complete answer atomically to this participant-private path before finishing your turn:\n"
-            + f"`{answer_path}`\n"
-            + "Use a temporary file in the same directory and rename it into place. Do not only leave the answer on screen.\n"
-        )
-        if send_member(council, member, "round", message, common_path):
-            roster[member["id"]] = {"dispatch": "sent", "answer": str(answer_path), "nonce": nonce}
-            runtime["active_round"] = round_id
-            update_runtime(runtime_file, runtime)
-        else:
+        try:
+            if not catch_up_member(directory, council, member):
+                roster[member["id"]] = {"dispatch": "unavailable", "answer": None}
+                continue
+            runtime_file, runtime = load_runtime(council, member)
+            outbox = Path(runtime["home"]) / "outbox"
+            outbox.mkdir(parents=True, exist_ok=True, mode=0o700)
+            answer_path = outbox / f"{round_id}.md"
+            nonce = secrets.token_hex(16)
+            envelope = {
+                "schema": "fm-council-envelope.v1",
+                "council_id": council["id"],
+                "round_id": round_id,
+                "member_id": member["id"],
+                "common_hash": common_hash,
+                "view_hash": view_hash,
+                "answer_path": str(answer_path),
+                "nonce": nonce,
+            }
+            envelope_path = Path(runtime["home"]) / "inbox" / f"{round_id}.json"
+            atomic_json(envelope_path, envelope)
+            message = (
+                common
+                + "\nWrite your complete answer atomically to this participant-private path before finishing your turn:\n"
+                + f"`{answer_path}`\n"
+                + "Use a temporary file in the same directory and rename it into place. Do not only leave the answer on screen.\n"
+            )
+            if send_member(council, member, "round", message, common_path):
+                roster[member["id"]] = {"dispatch": "sent", "answer": str(answer_path), "nonce": nonce}
+                runtime["active_round"] = round_id
+                update_runtime(runtime_file, runtime)
+            else:
+                roster[member["id"]] = {"dispatch": "unavailable", "answer": None}
+        except CouncilError:
             roster[member["id"]] = {"dispatch": "unavailable", "answer": None}
     round_value["status"] = "collecting"
     save_round(directory, round_value)
@@ -929,6 +955,7 @@ def start_round(directory: Path, council: dict[str, Any], task: str) -> dict[str
 def command_ask(arguments: argparse.Namespace) -> None:
     directory, council = find_council(arguments.name, include_closed=False)
     with lock(PATHS.runtime_dir(council["id"]) / ".lock", blocking=False):
+        council = reload_open_council(directory)
         round_value = start_round(directory, council, arguments.task)
     print(json.dumps({"council": council["name"], "round": round_value["id"], "common_hash": round_value["common_hash"], "view_hash": round_value["view_hash"], "roster": round_value["roster"]}, ensure_ascii=False))
 
@@ -936,6 +963,7 @@ def command_ask(arguments: argparse.Namespace) -> None:
 def command_submit(arguments: argparse.Namespace) -> None:
     directory, council = find_council(arguments.name, include_closed=False)
     with lock(PATHS.runtime_dir(council["id"]) / ".lock"):
+        council = reload_open_council(directory)
         if council.get("active_round") != arguments.round_id or council.get("phase") != "collecting":
             raise CouncilError("submission does not match the active collecting round")
         round_value = load_round(directory, arguments.round_id)
@@ -1003,6 +1031,7 @@ def command_wait(arguments: argparse.Namespace) -> None:
 def command_collect(arguments: argparse.Namespace) -> None:
     directory, council = find_council(arguments.name, include_closed=False)
     with lock(PATHS.runtime_dir(council["id"]) / ".lock"):
+        council = reload_open_council(directory)
         if council.get("phase") != "collecting" or not council.get("active_round"):
             raise CouncilError("council has no collecting round")
         round_value = load_round(directory, council["active_round"])
@@ -1044,6 +1073,7 @@ def command_collect(arguments: argparse.Namespace) -> None:
 def command_present(arguments: argparse.Namespace) -> None:
     directory, council = find_council(arguments.name, include_closed=False)
     with lock(PATHS.runtime_dir(council["id"]) / ".lock"):
+        council = reload_open_council(directory)
         if council.get("phase") != "awaiting_presentation" or not council.get("active_round"):
             raise CouncilError("collect available answers before presenting a canonical decision")
         round_value = load_round(directory, council["active_round"])
@@ -1056,6 +1086,10 @@ def command_present(arguments: argparse.Namespace) -> None:
         content = source.read_bytes()
         if not content.strip():
             raise CouncilError("presented canonical decision is empty")
+        try:
+            text = content.decode("utf-8")
+        except UnicodeDecodeError as error:
+            raise CouncilError("presented canonical decision must be valid UTF-8") from error
         presented = round_record_path(directory, round_value["id"]).parent / "presented.md"
         atomic_bytes(presented, content)
         round_value["status"] = "awaiting_acceptance"
@@ -1065,7 +1099,7 @@ def command_present(arguments: argparse.Namespace) -> None:
         council["phase"] = "awaiting_acceptance"
         save_council(directory, council)
         append_event(directory / "events.jsonl", {"event": "canonical_presented", "round": round_value["id"], "sha256": round_value["presented_sha256"], "kind": arguments.kind})
-    print(content.decode(), end="" if content.endswith(b"\n") else "\n")
+    print(text, end="" if text.endswith("\n") else "\n")
 
 
 def remove_snapshot(directory: Path, round_id: str) -> None:
@@ -1176,6 +1210,7 @@ def accept_round(directory: Path, council: dict[str, Any]) -> tuple[str, Path, l
 def command_accept(arguments: argparse.Namespace) -> None:
     directory, council = find_council(arguments.name, include_closed=False)
     with lock(PATHS.runtime_dir(council["id"]) / ".lock"):
+        council = reload_open_council(directory)
         decision_id, destination, deferred = accept_round(directory, council)
     result: dict[str, Any] = {"accepted": decision_id, "canonical": str(destination), "deferred_members": deferred}
     if arguments.implement:
@@ -1212,6 +1247,7 @@ def reject_active(directory: Path, council: dict[str, Any], reason: str) -> str:
 def command_reject(arguments: argparse.Namespace) -> None:
     directory, council = find_council(arguments.name, include_closed=False)
     with lock(PATHS.runtime_dir(council["id"]) / ".lock"):
+        council = reload_open_council(directory)
         round_id = reject_active(directory, council, arguments.reason)
     print(f"rejected: {round_id}; no rejected result was retained")
 
@@ -1219,6 +1255,7 @@ def command_reject(arguments: argparse.Namespace) -> None:
 def command_rerun(arguments: argparse.Namespace) -> None:
     directory, council = find_council(arguments.name, include_closed=False)
     with lock(PATHS.runtime_dir(council["id"]) / ".lock"):
+        council = reload_open_council(directory)
         if not council.get("active_round"):
             raise CouncilError("council has no active round to rerun")
         old = load_round(directory, council["active_round"])
@@ -1233,6 +1270,7 @@ def command_rerun(arguments: argparse.Namespace) -> None:
 def command_recover(arguments: argparse.Namespace) -> None:
     directory, council = find_council(arguments.name, include_closed=False)
     with lock(PATHS.runtime_dir(council["id"]) / ".lock"):
+        council = reload_open_council(directory)
         if council.get("phase") != "collecting" or not council.get("active_round"):
             raise CouncilError("only an interrupted collecting round can be marked for explicit retry")
         round_value = load_round(directory, council["active_round"])
@@ -1247,6 +1285,7 @@ def command_recover(arguments: argparse.Namespace) -> None:
 def command_retry(arguments: argparse.Namespace) -> None:
     directory, council = find_council(arguments.name, include_closed=False)
     with lock(PATHS.runtime_dir(council["id"]) / ".lock"):
+        council = reload_open_council(directory)
         if council.get("phase") != "interrupted" or not council.get("active_round"):
             raise CouncilError("council has no interrupted round to retry")
         old = load_round(directory, council["active_round"])
@@ -1310,6 +1349,7 @@ def load_close_journal(directory: Path, council: dict[str, Any]) -> tuple[Path, 
 def command_close(arguments: argparse.Namespace) -> None:
     directory, council = find_council(arguments.name, include_closed=False)
     with lock(PATHS.runtime_dir(council["id"]) / ".lock"):
+        council = reload_open_council(directory)
         journal_path, journal = load_close_journal(directory, council)
         pending = [member for member in council["members"] if member["id"] not in journal["closed"]]
         runtimes = [(member, close_preflight(council, member)) for member in pending]
@@ -1337,7 +1377,12 @@ def command_status(arguments: argparse.Namespace) -> None:
         _, council = find_council(arguments.name)
         output = [council]
     else:
-        output = [load_json(path) for path in sorted(PATHS.councils.glob("*/council.json"))]
+        output = []
+        for path in sorted(PATHS.councils.glob("*/council.json")):
+            try:
+                output.append(read_council_record(path))
+            except CouncilError as error:
+                output.append({"id": path.parent.name, "status": "unreadable", "error": str(error)})
     print(json.dumps(output, ensure_ascii=False, indent=2))
 
 

--- a/bin/fm-council.sh
+++ b/bin/fm-council.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# fm-council.sh - authoritative CLI for the thin persistent council MVP.
+#
+# Usage:
+#   fm-council.sh create <name> --project <absolute-path> \
+#     --participant claude/claude-fable-5/xhigh \
+#     --participant codex/gpt-5.6-sol/xhigh [--clean-slate] [--herdr-session <name>]
+#   fm-council.sh provider-consent anthropic|openai --project <absolute-path> \
+#     --acknowledge-project-disclosure
+#   fm-council.sh ask <name> <task>
+#   fm-council.sh ready <name>
+#   fm-council.sh wait <name> [--timeout <seconds>] [--poll <seconds>]
+#   fm-council.sh collect <name>
+#   fm-council.sh present <name> --file <canonical-decision> --kind best|synthesis|only
+#   fm-council.sh accept <name>
+#   fm-council.sh accept-and-implement <name>
+#   fm-council.sh reject <name> [--reason <text>]
+#   fm-council.sh rerun <name> [--clarify <constraint>]
+#   fm-council.sh recover <name>
+#   fm-council.sh retry <name> [--clarify <constraint>]
+#   fm-council.sh close <name>
+#   fm-council.sh status [<name>]
+#
+# `submit` is the private answer-ingest command used by deterministic transports:
+#   fm-council.sh submit <name> <member-id> --round <id> --nonce <nonce> --file <answer>
+#
+# Exact contract:
+# - Council names are durable and globally unique inside one FM_HOME.
+# - The only supported lane is Linux x86_64 with Herdr and the two exact participant profiles shown above.
+# - `create` launches fresh persistent participant conversations in one Herdr workspace.
+# - Linux Landlock denies project writes and hides the source project; seccomp denies
+#   terminal-control Unix sockets while provider TCP remains available. Participants
+#   see only immutable filtered round views and their own writable home.
+# - A round starts only after project-specific consent exists for every cloud provider.
+# - One council has one active round; separate council locks permit independent councils.
+# - `collect` records available answers and names unavailable members. Firstmate chooses
+#   the best answer or writes a short synthesis, then freezes that exact text with
+#   `present`. `--kind only` is mandatory when only one answer is available.
+# - `accept` atomically saves exactly `presented.md` before sending that canonical text.
+#   Missed decisions are delivered before that participant receives its next round.
+# - `accept-and-implement` accepts identically, then prints a structured instruction for
+#   a separate ordinary implementation task. Council participants never implement.
+# - `reject`, `rerun`, and `retry` delete raw answers and any rejected presentation.
+# - `recover` marks an interrupted collecting round for explicit `retry`; it never
+#   duplicates or silently resumes participant endpoints.
+# - `close` is the only participant termination command. It verifies every exact
+#   response-derived endpoint before closing only those panes and deleting lane homes.
+#
+# State ownership:
+# - data/councils/<id>/council.json owns council identity and phase.
+# - data/councils/<id>/rounds/<round>/ owns durable round metadata and the currently
+#   presented canonical text; raw collections and answer outboxes stay under state/.
+# - data/council-projects/<path-hash>/decisions/ owns exact accepted decision bodies.
+# - state/councils/<id>/members/<member>/runtime.json owns exact endpoint identity.
+# - config/council-provider-consent.json owns project-specific provider disclosure.
+set -eu
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+usage() {
+  sed -n '2,/^set -eu$/p' "${BASH_SOURCE[0]}" | sed '$d; s/^# \{0,1\}//'
+}
+
+case "${1:-}" in
+  -h|--help|help|'')
+    usage
+    ;;
+  *)
+    exec python3 "$ROOT/bin/fm-council.py" "$@"
+    ;;
+esac

--- a/bin/fm-council.sh
+++ b/bin/fm-council.sh
@@ -45,6 +45,8 @@
 #   duplicates or silently resumes participant endpoints.
 # - `close` is the only participant termination command. It verifies every exact
 #   response-derived endpoint before closing only those panes and deleting lane homes.
+#   A partially failed close is retryable: only members recorded in the durable
+#   close journal are skipped, and an absent or ambiguous pane is never assumed owned.
 #
 # State ownership:
 # - data/councils/<id>/council.json owns council identity and phase.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,8 +10,8 @@ The shared orchestrator behavior lives in [`AGENTS.md`](../AGENTS.md) - edit it 
 
 This section is the single owner of the top-level operational-home layout; producer script headers and their help own exact child-file fields and mutation contracts.
 The tracked code root contains the shared instruction, skill, documentation, workflow, and `bin/` surfaces, while each effective `FM_HOME` contains private operational directories.
-`data/` holds durable private fleet records such as the project and secondmate registries, captain preferences, optional shared captain preferences, learnings, backlog, briefs, and scout reports.
-`state/` holds volatile runtime records such as task metadata, append-only status events, endpoint signals, watcher and wake-queue coordination, away-mode state, generated X-mode artifacts, and private secondmate config-reread generations with their retry and quarantine state.
+`data/` holds durable private fleet records such as the project and secondmate registries, councils and accepted project decisions, captain preferences, optional shared captain preferences, learnings, backlog, briefs, and scout reports.
+`state/` holds volatile runtime records such as task metadata, council participant endpoints and private answer outboxes, append-only status events, endpoint signals, watcher and wake-queue coordination, away-mode state, generated X-mode artifacts, and private secondmate config-reread generations with their retry and quarantine state.
 `config/` holds local gitignored operating choices, and `projects/` holds the local project clones that Firstmate reads but changes only through the guarded exceptions in `AGENTS.md`.
 
 `bin/fm-spawn.sh` owns the base task-metadata fields it emits, while the runtime-backend section below owns backend-specific fields and selector interpretation.
@@ -22,6 +22,14 @@ Wake, watcher, away-mode, and X-specific state mechanics remain with their named
 `docs/sessionstart-nudge.md` owns the native session-open adapter mechanics that nudge the digest command.
 `AGENTS.md` retains the run-once and read-once operator rules, lock-refusal safety, installation consent, and direct-report recovery boundaries because those facts apply at every session start.
 Ordinary dead-direct-report recovery is owned by `stuck-crewmate-recovery`, while persistent-secondmate recovery is owned by `secondmate-provisioning`.
+
+## Persistent councils (data/councils / state/councils / config/council-provider-consent.json)
+
+Persistent council identity and round metadata live under local `data/councils/`, while exact accepted decision bodies are grouped by canonical project-path hash under local `data/council-projects/`.
+Exact participant endpoint identities, isolated participant homes, raw answer outboxes, and collected raw answers live under volatile `state/councils/`.
+Project-specific Anthropic and OpenAI disclosure approvals live in local `config/council-provider-consent.json`, which is gitignored and created only through the captain-approved command path.
+The `council` skill owns captain-facing semantics, [`docs/council.md`](council.md) is the human reference, and `bin/fm-council.sh --help` owns exact schemas, commands, and mutation mechanics.
+No council file is a backlog item or ordinary task record.
 
 ## Backlog backend (.tasks.toml / config/backlog-backend)
 

--- a/docs/council.md
+++ b/docs/council.md
@@ -20,14 +20,16 @@ Persistent filesystem writes are limited to the participant's own private home a
 Execution is granted only on the exact controller-supplied binary allowlist, never on the whole system tree.
 A seccomp filter denies new Unix-domain sockets (from `socket` and `socketpair` alike) and io_uring setup while retaining provider TCP access, so a participant cannot reach Herdr or another terminal-control service by guessing its socket path or through ring-submitted socket operations; it verifies the x86_64 audit architecture and denies alternate syscall ABIs outright.
 Home-local control clients and socket metadata are also outside the admitted filesystem and absent from the sanitized environment, which passes through only the participant's own provider credentials.
+Round and decision content is written into each participant's own inbox as a payload file whose bytes are identical across members, and the terminal receives only a short pointer naming that exact file, its hash, and the private answer path, never the full body as a command argument.
 
-The filter excludes version-control metadata, common dependency and cache directories, symlinks, special files, oversized files, `.env` variants, private keys, and common credential files.
+The filter excludes version-control metadata, common dependency and cache directories, symlinks, special files, oversized files, `.env` variants, private keys, common credential files, and exact secret- and token-named data files such as `secrets.yaml` or `token.txt` (ordinary source modules like `secrets.py` stay visible).
 `.env.example` remains visible.
 The manifest names every exclusion so an answer cannot imply that the participant reviewed omitted material.
 This is a local filesystem boundary, not permission to disclose code to a remote model provider.
 Project-specific durable consent is required separately for Anthropic and OpenAI before the first round can be sent.
 
 Available answers remain in participant-private outboxes until collection.
+An answer is ingested only as a private regular single-link file at the exact recorded outbox path; a symlinked, hard-linked, group-writable, oversized, or otherwise unsafe answer file is honestly treated as unavailable rather than followed.
 Firstmate then presents either one best answer or a short synthesis without adding a separate judge model or numeric scorecard.
 One available answer is labeled only as the available answer.
 Raw answers and rejected presentations are removed when a round is accepted, rejected, or rerun; accepted canonical decision bodies remain durable.

--- a/docs/council.md
+++ b/docs/council.md
@@ -1,0 +1,57 @@
+# Persistent councils
+
+`/council` is a thin read-only workflow for asking the same project question of persistent Claude and Codex conversations, then accepting one canonical decision.
+It is not a task type, a second mate, a judge service, or an implementation lane.
+The [`council` skill](../.agents/skills/council/SKILL.md) owns the captain-facing procedure, while `bin/fm-council.sh --help` owns exact commands and state mechanics.
+
+## Supported MVP
+
+The first supported lane is Linux x86_64 with Herdr and two exact participant profiles: Claude Code `claude-fable-5` at `xhigh`, and Codex `gpt-5.6-sol` at `xhigh`.
+The data format admits more participants later, but the command refuses every profile that has not passed the same isolation and lifecycle verification.
+It never substitutes a model, harness, or effort.
+
+Each council has a durable name, one absolute local project path, fresh participant conversations, exact Herdr endpoint identity, and a list of applicable accepted decisions.
+Only one round can be active in one council, but separate council locks allow unrelated councils to run in parallel.
+An interrupted collecting round is marked for explicit retry instead of being silently resumed or duplicated.
+
+Before fan-out, Firstmate builds one stable filtered project view and makes its files read-only.
+The Linux participant process installs a Landlock policy before the model starts, so the source project and other participant homes are unreadable and unwritable while the fixed view is readable but unwritable.
+Persistent filesystem writes are limited to the participant's own private home and answer outbox, with only its terminal and `/dev/null` admitted as device sinks.
+A seccomp filter denies new Unix-domain sockets while retaining provider TCP access, so a participant cannot reach Herdr or another terminal-control service by guessing its socket path.
+Home-local control clients and socket metadata are also outside the admitted filesystem and absent from the sanitized environment.
+
+The filter excludes version-control metadata, common dependency and cache directories, symlinks, special files, oversized files, `.env` variants, private keys, and common credential files.
+`.env.example` remains visible.
+The manifest names every exclusion so an answer cannot imply that the participant reviewed omitted material.
+This is a local filesystem boundary, not permission to disclose code to a remote model provider.
+Project-specific durable consent is required separately for Anthropic and OpenAI before the first round can be sent.
+
+Available answers remain in participant-private outboxes until collection.
+Firstmate then presents either one best answer or a short synthesis without adding a separate judge model or numeric scorecard.
+One available answer is labeled only as the available answer.
+Raw answers and rejected presentations are removed when a round is accepted, rejected, or rerun; accepted canonical decision bodies remain durable.
+
+Acceptance copies exactly the presented bytes into the project's decision journal before any participant notification.
+A failed notification remains pending and is delivered before that participant receives its next task.
+“Accept and implement” performs the same acceptance and returns a structured request for an ordinary Firstmate implementation task, which is always separate from the council.
+
+Close is explicit and exact.
+It verifies each response-derived session, workspace, tab, pane, owner token, and machine label before closing only those participant panes, then removes their conversation homes.
+It never searches by a friendly title and never closes a Herdr workspace directly.
+
+## Short example
+
+Create `Atlas API` for `/work/atlas` with the two supported profiles, approve Anthropic and OpenAI disclosure for that project when prompted, and ask: “Choose a cache strategy without changing the public API.”
+Firstmate collects both independent answers, presents a short synthesis, and “accept” saves that exact synthesis as `D0001` before sending it to both persistent conversations.
+Ask a second round: “Plan the schema migration.”
+The same participant conversations answer with `D0001` in their shared accepted context.
+
+While the Atlas round is active, create a separate `Docs` council for `/work/docs` and ask it to choose an information architecture.
+The Docs round runs independently because serialization is per council, not global.
+Closing `Atlas API` clears only its two conversations and leaves `Docs` running.
+A later `Atlas API 2` starts fresh conversations with active Atlas decisions by default, while “start clean” maps to `--clean-slate` and omits them.
+
+## Deferred on purpose
+
+The MVP has no scorecard, separate judge model, budget dashboard, transcript analytics, card UI, display-title migration, cross-backend matrix, mid-answer recovery, or broad retention controls.
+Those features must not be inferred from the durable schema or added by bypassing the supported-profile refusal.

--- a/docs/council.md
+++ b/docs/council.md
@@ -18,7 +18,7 @@ Before fan-out, Firstmate builds one stable filtered project view and makes its 
 The Linux participant process installs a Landlock policy before the model starts, so the source project and other participant homes are unreadable and unwritable while the fixed view is readable but unwritable.
 Persistent filesystem writes are limited to the participant's own private home and answer outbox, with only its terminal and `/dev/null` admitted as device sinks.
 Execution is granted only on the exact controller-supplied binary allowlist, never on the whole system tree.
-A seccomp filter denies new Unix-domain sockets while retaining provider TCP access, so a participant cannot reach Herdr or another terminal-control service by guessing its socket path; it verifies the x86_64 audit architecture and denies alternate syscall ABIs outright.
+A seccomp filter denies new Unix-domain sockets (from `socket` and `socketpair` alike) and io_uring setup while retaining provider TCP access, so a participant cannot reach Herdr or another terminal-control service by guessing its socket path or through ring-submitted socket operations; it verifies the x86_64 audit architecture and denies alternate syscall ABIs outright.
 Home-local control clients and socket metadata are also outside the admitted filesystem and absent from the sanitized environment, which passes through only the participant's own provider credentials.
 
 The filter excludes version-control metadata, common dependency and cache directories, symlinks, special files, oversized files, `.env` variants, private keys, and common credential files.

--- a/docs/council.md
+++ b/docs/council.md
@@ -29,7 +29,7 @@ This is a local filesystem boundary, not permission to disclose code to a remote
 Project-specific durable consent is required separately for Anthropic and OpenAI before the first round can be sent.
 
 Available answers remain in participant-private outboxes until collection.
-An answer is ingested only as a private regular single-link file at the exact recorded outbox path; a symlinked, hard-linked, group-writable, oversized, or otherwise unsafe answer file is honestly treated as unavailable rather than followed.
+An answer is ingested only as a private regular single-link file at the exact recorded outbox path; a symlinked, hard-linked, group-writable, oversized, or otherwise unsafe answer file is honestly treated as unavailable rather than followed, with one bounded refusal reason surfaced by `ready` and recorded durably in the round evidence at collection.
 Firstmate then presents either one best answer or a short synthesis without adding a separate judge model or numeric scorecard.
 One available answer is labeled only as the available answer.
 Raw answers and rejected presentations are removed when a round is accepted, rejected, or rerun; accepted canonical decision bodies remain durable.

--- a/docs/council.md
+++ b/docs/council.md
@@ -17,8 +17,9 @@ An interrupted collecting round is marked for explicit retry instead of being si
 Before fan-out, Firstmate builds one stable filtered project view and makes its files read-only.
 The Linux participant process installs a Landlock policy before the model starts, so the source project and other participant homes are unreadable and unwritable while the fixed view is readable but unwritable.
 Persistent filesystem writes are limited to the participant's own private home and answer outbox, with only its terminal and `/dev/null` admitted as device sinks.
-A seccomp filter denies new Unix-domain sockets while retaining provider TCP access, so a participant cannot reach Herdr or another terminal-control service by guessing its socket path.
-Home-local control clients and socket metadata are also outside the admitted filesystem and absent from the sanitized environment.
+Execution is granted only on the exact controller-supplied binary allowlist, never on the whole system tree.
+A seccomp filter denies new Unix-domain sockets while retaining provider TCP access, so a participant cannot reach Herdr or another terminal-control service by guessing its socket path; it verifies the x86_64 audit architecture and denies alternate syscall ABIs outright.
+Home-local control clients and socket metadata are also outside the admitted filesystem and absent from the sanitized environment, which passes through only the participant's own provider credentials.
 
 The filter excludes version-control metadata, common dependency and cache directories, symlinks, special files, oversized files, `.env` variants, private keys, and common credential files.
 `.env.example` remains visible.
@@ -37,6 +38,7 @@ A failed notification remains pending and is delivered before that participant r
 
 Close is explicit and exact.
 It verifies each response-derived session, workspace, tab, pane, owner token, and machine label before closing only those participant panes, then removes their conversation homes.
+A close that fails partway can simply be rerun: members recorded in the durable close journal are skipped, while an absent or ambiguous pane is never inferred to be council-owned.
 It never searches by a friendly title and never closes a Herdr workspace directly.
 
 ## Short example

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -1012,6 +1012,30 @@ On entry the launcher drops the prior session's artifacts when the daemon is not
 This never drops a genuinely-pending escalation: the durable record is `state/.wake-queue` plus each crew's `state/<id>.status`, and any still-true condition is re-escalated by the daemon's heartbeat catch-all scan.
 Covered by the unit cases in `tests/fm-afk-launch.test.sh` (clear-on-fresh-entry vs refresh, and the stop ordering asserting the daemon saw `state/.afk` present at SIGTERM).
 
+## Council read-only lane verification
+
+Verified on 2026-07-21 against Herdr 0.7.4 on Linux 6.8.0-136-generic with Landlock ABI 4 and source commit `59ece454935d9b280864f001c9173fce13e9ed43`.
+The test used only a shell stub and made no model-provider call.
+It provisioned a generated named non-`default` session, created one exact workspace/tab/pane, launched `bin/fm-council-sandbox.py` through that pane, and attempted to read and write the source, write the admitted fixed view, read a sibling answer, and create a Unix-domain socket.
+The fixed view remained readable, all four forbidden boundaries returned permission errors, provider-style TCP remained outside the socket filter, participant-owned output remained writable, the exact response-derived pane closed successfully, and guarded teardown confirmed the default-session fleet tripwire was byte-identical.
+
+Exact command:
+
+```sh
+HERDR_LAB_HELPER='/home/dev/firstmate/bin/fm-herdr-lab.sh' \
+  FM_COUNCIL_HERDR_E2E=1 \
+  bash tests/fm-council-herdr-e2e.test.sh
+```
+
+Exact output:
+
+```text
+ok - real Herdr lab: exact council lane lifecycle enforces read-only source/view, answer isolation, and terminal-socket denial without a provider call
+```
+
+Every Herdr operation in the test goes through `fm-herdr-lab.sh run`, while provisioning and teardown use only that helper's named-session lifecycle commands.
+The test never calls `workspace close`, any server-global operation, or any Herdr command scoped only by ambient `HERDR_SESSION`.
+
 ## Known gaps and follow-up notes
 
 - **RESOLVED: worktree-discovery isolation guard's symlinked-project-prefix false refusal.** Originally discovered while building the runtime-backend-auto-detection real smoke test (`tests/fm-backend-autodetect-smoke.test.sh`), which needed a scratch project.

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -1014,17 +1014,15 @@ Covered by the unit cases in `tests/fm-afk-launch.test.sh` (clear-on-fresh-entry
 
 ## Council read-only lane verification
 
-Verified on 2026-07-21 against Herdr 0.7.4 on Linux 6.8.0-136-generic with Landlock ABI 4 and source commit `59ece454935d9b280864f001c9173fce13e9ed43`.
+Verified on 2026-07-22 against Herdr 0.7.4 on Linux 6.8.0-136-generic with Landlock ABI 4 and source commit `d0f9062c6a1c2aad189b24dc3ce461e30e2cbf68`.
 The test used only a shell stub and made no model-provider call.
-It provisioned a generated named non-`default` session, created one exact workspace/tab/pane, launched `bin/fm-council-sandbox.py` through that pane, and attempted to read and write the source, write the admitted fixed view, read a sibling answer, and create a Unix-domain socket.
-The fixed view remained readable, all four forbidden boundaries returned permission errors, provider-style TCP remained outside the socket filter, participant-owned output remained writable, the exact response-derived pane closed successfully, and guarded teardown confirmed the default-session fleet tripwire was byte-identical.
+It provisioned a generated named non-`default` session, created one exact workspace/tab/pane, launched `bin/fm-council-sandbox.py` through that pane, and attempted to read and write the source, write the admitted fixed view, read a sibling answer, create a Unix-domain socket with `socket` and with `socketpair`, and set up an io_uring ring.
+The fixed view remained readable, every forbidden boundary returned a permission error, provider-style TCP remained outside the socket filter, participant-owned output remained writable, the exact response-derived pane closed successfully, and guarded teardown confirmed the default-session fleet tripwire was byte-identical.
 
-Exact command:
+Exact command (the helper defaults to this checkout's `bin/fm-herdr-lab.sh`; set `HERDR_LAB_HELPER` to point elsewhere):
 
 ```sh
-HERDR_LAB_HELPER='/home/dev/firstmate/bin/fm-herdr-lab.sh' \
-  FM_COUNCIL_HERDR_E2E=1 \
-  bash tests/fm-council-herdr-e2e.test.sh
+FM_COUNCIL_HERDR_E2E=1 bash tests/fm-council-herdr-e2e.test.sh
 ```
 
 Exact output:

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -1016,6 +1016,7 @@ Covered by the unit cases in `tests/fm-afk-launch.test.sh` (clear-on-fresh-entry
 
 Verified on 2026-07-22 against Herdr 0.7.4 on Linux 6.8.0-136-generic with Landlock ABI 4 and source commit `d0f9062c6a1c2aad189b24dc3ce461e30e2cbf68`.
 The test used only a shell stub and made no model-provider call.
+The proof executes only `bin/fm-council-sandbox.py` through the lab helper, never `bin/fm-council.py`; the shipped council change hardened only `bin/fm-council.py` after this run, leaving `bin/fm-council-sandbox.py`, `bin/fm-herdr-lab.sh`, and `tests/fm-council-herdr-e2e.test.sh` byte-identical to the verified state.
 It provisioned a generated named non-`default` session, created one exact workspace/tab/pane, launched `bin/fm-council-sandbox.py` through that pane, and attempted to read and write the source, write the admitted fixed view, read a sibling answer, create a Unix-domain socket with `socket` and with `socketpair`, and set up an io_uring ring.
 The fixed view remained readable, every forbidden boundary returned a permission error, provider-style TCP remained outside the socket filter, participant-owned output remained writable, the exact response-derived pane closed successfully, and guarded teardown confirmed the default-session fleet tripwire was byte-identical.
 

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -19,6 +19,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-decision-hold.sh`    | Create, verify, complete, and resolve durable captain-held decisions                 |
 | `fm-brief.sh`            | Scaffold ship, scout, secondmate-charter, and Herdr-lab briefs                       |
 | `fm-herdr-lab.sh`        | Provision and guardedly operate an isolated, never-default Herdr lab session         |
+| `fm-council.sh`          | Create and operate persistent read-only model councils with exact accepted decisions |
 | `fm-ensure-agents-md.sh` | Ensure a project's real `AGENTS.md`, its `CLAUDE.md` symlink, and the canonical self-governance section |
 | `fm-guard.sh`            | Warn on primary-checkout tangles, pending queued wakes, and stale watcher liveness   |
 | `fm-primary-scope-lib.sh` | Shared marker-or-plain-checkout primary-home predicate for tracked hooks             |

--- a/tests/fm-council-herdr-e2e.test.sh
+++ b/tests/fm-council-herdr-e2e.test.sh
@@ -61,6 +61,8 @@ printf -v command '%q ' \
       if echo mutate > "$3/code"; then echo source-write-bad >> "$2/source-status"; else echo source-write-denied >> "$2/source-status"; fi
       if cat "$4/answer" > "$2/other-answer"; then echo answer-read-bad > "$2/answer-status"; else echo answer-read-denied > "$2/answer-status"; fi
       if /usr/bin/python3 -c "import socket; socket.socket(socket.AF_UNIX)"; then echo unix-socket-bad > "$2/socket-status"; else echo unix-socket-denied > "$2/socket-status"; fi
+      if /usr/bin/python3 -c "import socket; socket.socketpair()"; then echo socketpair-bad > "$2/socketpair-status"; else echo socketpair-denied > "$2/socketpair-status"; fi
+      if /usr/bin/python3 -c "import ctypes, sys; libc = ctypes.CDLL(None, use_errno=True); rc = libc.syscall(425, 4, 0); sys.exit(0 if rc < 0 and ctypes.get_errno() == 13 else 1)"; then echo io-uring-denied > "$2/iouring-status"; else echo io-uring-bad > "$2/iouring-status"; fi
       if /usr/bin/python3 -c "import socket; socket.socket(socket.AF_INET).close()"; then echo tcp-socket-allowed > "$2/tcp-status"; else echo tcp-socket-bad > "$2/tcp-status"; fi
       printf ready > "$2/ready"
     } 2> "$2/denials"
@@ -79,6 +81,8 @@ assert_grep source-read-denied "$LANE/source-status" "real Herdr lane read the s
 assert_grep source-write-denied "$LANE/source-status" "real Herdr lane wrote the source project"
 [ "$(cat "$LANE/answer-status")" = answer-read-denied ] || fail "real Herdr lane read a competing answer"
 [ "$(cat "$LANE/socket-status")" = unix-socket-denied ] || fail "real Herdr lane could open a terminal-control socket channel"
+[ "$(cat "$LANE/socketpair-status")" = socketpair-denied ] || fail "real Herdr lane could open a Unix socketpair channel"
+[ "$(cat "$LANE/iouring-status")" = io-uring-denied ] || fail "real Herdr lane could set up an io_uring socket bypass"
 [ "$(cat "$LANE/tcp-status")" = tcp-socket-allowed ] || fail "real Herdr lane blocked provider-style TCP sockets"
 [ "$(cat "$SOURCE/code")" = source-private ] || fail "real Herdr lane changed source bytes"
 

--- a/tests/fm-council-herdr-e2e.test.sh
+++ b/tests/fm-council-herdr-e2e.test.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Opt-in real Herdr lab proof for the council lane's hard read-only boundary.
+# It launches only a stub process and never calls a model provider.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+if [ "${FM_COUNCIL_HERDR_E2E:-0}" != 1 ]; then
+  echo "skip: set FM_COUNCIL_HERDR_E2E=1 for the guarded council Herdr lab proof"
+  exit 0
+fi
+command -v herdr >/dev/null 2>&1 || { echo "skip: herdr not found"; exit 0; }
+command -v jq >/dev/null 2>&1 || { echo "skip: jq not found"; exit 0; }
+[ "$(uname -s)-$(uname -m)" = Linux-x86_64 ] || { echo "skip: the council lane is Linux x86_64-only"; exit 0; }
+
+HERDR_LAB_HELPER=${HERDR_LAB_HELPER:-$ROOT/bin/fm-herdr-lab.sh}
+HERDR_LAB_SESSION=$("$HERDR_LAB_HELPER" name firstmate-council-mvp-pi-gpt56sol-u9)
+TMP_ROOT=$(fm_test_tmproot fm-council-herdr)
+SOURCE="$TMP_ROOT/source"
+VIEW="$TMP_ROOT/view"
+LANE="$TMP_ROOT/lane"
+OTHER="$TMP_ROOT/other"
+mkdir -p "$SOURCE" "$VIEW" "$LANE" "$OTHER"
+printf 'source-private\n' > "$SOURCE/code"
+printf 'fixed-view\n' > "$VIEW/code"
+printf 'competing-answer\n' > "$OTHER/answer"
+
+cleanup() {
+  "$HERDR_LAB_HELPER" teardown "$HERDR_LAB_SESSION"
+  fm_test_cleanup
+}
+trap cleanup EXIT
+"$HERDR_LAB_HELPER" provision "$HERDR_LAB_SESSION"
+
+created=$("$HERDR_LAB_HELPER" run "$HERDR_LAB_SESSION" \
+  workspace create --cwd "$LANE" --label fm-council-readonly-stub --no-focus)
+workspace=$(jq -r '.result.workspace.workspace_id // empty' <<<"$created")
+tab=$(jq -r '.result.tab.tab_id // empty' <<<"$created")
+pane=$(jq -r '.result.root_pane.pane_id // empty' <<<"$created")
+[ -n "$workspace" ] && [ -n "$tab" ] && [ -n "$pane" ] \
+  || fail "real Herdr workspace create omitted exact endpoint IDs"
+member_label="fm-council-member-readonly-stub"
+"$HERDR_LAB_HELPER" run "$HERDR_LAB_SESSION" tab rename "$tab" "$member_label" >/dev/null
+tab_info=$("$HERDR_LAB_HELPER" run "$HERDR_LAB_SESSION" tab get "$tab")
+[ "$(jq -r '.result.tab.label' <<<"$tab_info")" = "$member_label" ] || fail "real Herdr tab lost its exact ownership label"
+
+# shellcheck disable=SC2016  # positional parameters expand inside the sandboxed shell
+printf -v command '%q ' \
+  "$ROOT/bin/fm-council-sandbox.py" \
+  --home "$LANE" \
+  --readable "$VIEW" \
+  --allow-exec /bin/sh \
+  --allow-exec /bin/cat \
+  --allow-exec /usr/bin/python3 \
+  -- /bin/sh -c '
+    {
+      cat "$1/code" > "$2/read-view"
+      if echo mutate > "$1/code"; then echo view-write-bad > "$2/view-write"; else echo view-write-denied > "$2/view-write"; fi
+      if cat "$3/code" > "$2/source-read"; then echo source-read-bad > "$2/source-status"; else echo source-read-denied > "$2/source-status"; fi
+      if echo mutate > "$3/code"; then echo source-write-bad >> "$2/source-status"; else echo source-write-denied >> "$2/source-status"; fi
+      if cat "$4/answer" > "$2/other-answer"; then echo answer-read-bad > "$2/answer-status"; else echo answer-read-denied > "$2/answer-status"; fi
+      if /usr/bin/python3 -c "import socket; socket.socket(socket.AF_UNIX)"; then echo unix-socket-bad > "$2/socket-status"; else echo unix-socket-denied > "$2/socket-status"; fi
+      if /usr/bin/python3 -c "import socket; socket.socket(socket.AF_INET).close()"; then echo tcp-socket-allowed > "$2/tcp-status"; else echo tcp-socket-bad > "$2/tcp-status"; fi
+      printf ready > "$2/ready"
+    } 2> "$2/denials"
+  ' sh "$VIEW" "$LANE" "$SOURCE" "$OTHER"
+"$HERDR_LAB_HELPER" run "$HERDR_LAB_SESSION" pane run "$pane" "$command" >/dev/null
+
+attempt=0
+while [ ! -f "$LANE/ready" ] && [ "$attempt" -lt 100 ]; do
+  sleep 0.1
+  attempt=$((attempt + 1))
+done
+assert_present "$LANE/ready" "real Herdr stub did not finish the sandbox probe"
+[ "$(cat "$LANE/read-view")" = fixed-view ] || fail "real Herdr lane could not read its fixed view"
+[ "$(cat "$LANE/view-write")" = view-write-denied ] || fail "real Herdr lane wrote its fixed view"
+assert_grep source-read-denied "$LANE/source-status" "real Herdr lane read the source project"
+assert_grep source-write-denied "$LANE/source-status" "real Herdr lane wrote the source project"
+[ "$(cat "$LANE/answer-status")" = answer-read-denied ] || fail "real Herdr lane read a competing answer"
+[ "$(cat "$LANE/socket-status")" = unix-socket-denied ] || fail "real Herdr lane could open a terminal-control socket channel"
+[ "$(cat "$LANE/tcp-status")" = tcp-socket-allowed ] || fail "real Herdr lane blocked provider-style TCP sockets"
+[ "$(cat "$SOURCE/code")" = source-private ] || fail "real Herdr lane changed source bytes"
+
+current=$("$HERDR_LAB_HELPER" run "$HERDR_LAB_SESSION" pane get "$pane")
+[ "$(jq -r '.result.pane.workspace_id' <<<"$current")" = "$workspace" ] || fail "real Herdr pane moved to another workspace"
+[ "$(jq -r '.result.pane.tab_id' <<<"$current")" = "$tab" ] || fail "real Herdr pane moved to another tab"
+"$HERDR_LAB_HELPER" run "$HERDR_LAB_SESSION" pane close "$pane" >/dev/null
+if "$HERDR_LAB_HELPER" run "$HERDR_LAB_SESSION" pane get "$pane" >/dev/null 2>&1; then
+  fail "exact council stub pane remained after exact close"
+fi
+
+pass "real Herdr lab: exact council lane lifecycle enforces read-only source/view, answer isolation, and terminal-socket denial without a provider call"

--- a/tests/fm-council.test.sh
+++ b/tests/fm-council.test.sh
@@ -92,6 +92,9 @@ new_home() {
   printf 'TOP_SECRET\n' > "$project/.env"
   printf 'PRIVATE\n' > "$project/id_rsa"
   printf 'example=yes\n' > "$project/.env.example"
+  printf 'db_password: hunter2\n' > "$project/secrets.yaml"
+  printf 'tok\n' > "$project/token.txt"
+  printf 'import secrets\n' > "$project/secrets.py"
   printf '%s\t%s\n' "$home" "$project"
 }
 
@@ -169,8 +172,13 @@ round_log=$(grep -F $'send\t' "$STUB/events" | grep -F $'\tround\t' | grep -F "$
 manifest="$HOME1/data/councils/$ID1/snapshots/$ROUND1/manifest.json"
 assert_grep '"path": ".env"' "$manifest" "snapshot manifest did not list .env exclusion"
 assert_grep '"path": "id_rsa"' "$manifest" "snapshot manifest did not list private-key exclusion"
+assert_grep '"path": "secrets.yaml"' "$manifest" "snapshot manifest did not list the secrets.yaml exclusion"
+assert_grep '"path": "token.txt"' "$manifest" "snapshot manifest did not list the token.txt exclusion"
 assert_present "$HOME1/data/councils/$ID1/snapshots/$ROUND1/project/.env.example" ".env.example should remain visible"
+assert_present "$HOME1/data/councils/$ID1/snapshots/$ROUND1/project/secrets.py" "ordinary source module secrets.py must remain visible"
 assert_absent "$HOME1/data/councils/$ID1/snapshots/$ROUND1/project/.env" ".env leaked into the project view"
+assert_absent "$HOME1/data/councils/$ID1/snapshots/$ROUND1/project/secrets.yaml" "secrets.yaml leaked into the project view"
+assert_absent "$HOME1/data/councils/$ID1/snapshots/$ROUND1/project/token.txt" "token.txt leaked into the project view"
 for answer_path in $(jq -r '.roster[].answer' <<<"$ASK1"); do
   assert_absent "$answer_path" "fan-out exposed an answer before that participant submitted it"
 done
@@ -490,3 +498,212 @@ expect_code 1 "$status" "a direct request for the corrupt identity must report t
 [ "$(council "$HOME7" status | jq -r '.[] | select(.id == "corrupt-1234") | .status')" = unreadable ] || fail "the status listing did not surface the corrupt record"
 rm -rf "$HOME7/data/councils/corrupt-1234"
 pass "council isolation: corrupt records are skipped for other councils and reported when requested directly"
+
+# Symlinked or hard-linked answer files are never ingested; they degrade to
+# honest unavailability instead of exfiltrating controller-readable bytes.
+IFS=$'\t' read -r HOME8 PROJECT8 < <(new_home ingest)
+CREATE8=$(create_pair "$HOME8" "$PROJECT8" Ingest)
+consent_pair "$HOME8" "$PROJECT8"
+ASK8=$(council "$HOME8" ask Ingest "Pick a database.")
+CLAUDE8=$(jq -r '.members[] | select(startswith("claude-"))' <<<"$CREATE8")
+CODEX8=$(jq -r '.members[] | select(startswith("codex-"))' <<<"$CREATE8")
+claude_answer8=$(jq -r --arg member "$CLAUDE8" '.roster[$member].answer' <<<"$ASK8")
+codex_answer8=$(jq -r --arg member "$CODEX8" '.roster[$member].answer' <<<"$ASK8")
+printf 'INGEST-LOOT\n' > "$HOME8/loot"
+ln -s "$HOME8/loot" "$claude_answer8"
+ln "$HOME8/loot" "$codex_answer8"
+READY8=$(council "$HOME8" ready Ingest) || fail "unsafe answer files crashed readiness"
+[ "$(jq '.answered | length' <<<"$READY8")" = 0 ] || fail "a symlinked or hard-linked answer was counted as answered"
+status=0
+council "$HOME8" collect Ingest >/dev/null 2>&1 || status=$?
+expect_code 1 "$status" "symlinked and hard-linked answers must not be ingested"
+rm "$codex_answer8"
+printf 'honest ingest answer\n' > "$codex_answer8"
+chmod 600 "$codex_answer8"
+COLLECT8=$(council "$HOME8" collect Ingest)
+[ "$(jq -r .comparison <<<"$COLLECT8")" = only-available ] || fail "the honest regular answer was not collected"
+[ "$(jq -r '.unavailable[0]' <<<"$COLLECT8")" = "$CLAUDE8" ] || fail "the symlinked answer was not degraded to unavailable"
+assert_not_contains "$COLLECT8" INGEST-LOOT "a symlinked answer exfiltrated controller-readable bytes"
+pass "council answer ingest: only exact private regular single-link outbox files are read"
+
+# A corrupt member runtime during ready/wait degrades that member to honest
+# unavailability instead of crashing every readiness poll.
+IFS=$'\t' read -r HOME9 PROJECT9 < <(new_home readyprobe)
+CREATE9=$(create_pair "$HOME9" "$PROJECT9" ReadyProbe)
+ID9=$(json_id "$CREATE9")
+consent_pair "$HOME9" "$PROJECT9"
+council "$HOME9" ask ReadyProbe "Pick a formatter." >/dev/null
+CODEX9=$(jq -r '.members[] | select(startswith("codex-"))' <<<"$CREATE9")
+codex_runtime9="$HOME9/state/councils/$ID9/members/$CODEX9/runtime.json"
+cp "$codex_runtime9" "$codex_runtime9.saved"
+printf 'not-json\n' > "$codex_runtime9"
+READY9=$(council "$HOME9" ready ReadyProbe) || fail "a corrupt member runtime crashed readiness"
+[ "$(jq -r --arg member "$CODEX9" '.unavailable | index($member) != null' <<<"$READY9")" = true ] || fail "a corrupt member runtime was not honestly unavailable in ready"
+mv "$codex_runtime9.saved" "$codex_runtime9"
+pass "council readiness: a corrupt runtime degrades to unavailable instead of failing ready and wait"
+
+# A project directory without owner write permission still snapshots because
+# subtree modes are applied only after the subtree is populated.
+IFS=$'\t' read -r HOME10 PROJECT10 < <(new_home readonlydir)
+CREATE10=$(create_pair "$HOME10" "$PROJECT10" ReadonlyDir)
+ID10=$(json_id "$CREATE10")
+consent_pair "$HOME10" "$PROJECT10"
+mkdir -p "$PROJECT10/vendored"
+printf 'pinned\n' > "$PROJECT10/vendored/lib"
+chmod 555 "$PROJECT10/vendored"
+ASK10=$(council "$HOME10" ask ReadonlyDir "Task with a read-only vendored tree") || fail "a read-only project directory failed the round snapshot"
+ROUND10=$(jq -r .round <<<"$ASK10")
+assert_present "$HOME10/data/councils/$ID10/snapshots/$ROUND10/project/vendored/lib" "read-only directory content is missing from the fixed view"
+chmod 755 "$PROJECT10/vendored"
+pass "council snapshot: read-only project directories are populated before their modes apply"
+
+# The real Herdr lane sends only bounded pointer instructions over argv: a
+# leading-dash canonical decision far beyond MAX_ARG_STRLEN is delivered
+# through each member's own hashed inbox payload file without a provider call.
+if [ "$(uname -s)-$(uname -m)" = Linux-x86_64 ]; then
+  FAKE_HERDR="$TMP_ROOT/fake-herdr"
+  FAKE_HERDR_STATE="$TMP_ROOT/fake-herdr-state"
+  mkdir -p "$FAKE_HERDR_STATE"
+  cat > "$FAKE_HERDR" <<'SH'
+#!/usr/bin/env bash
+set -eu
+[ "$1" = run ] || { echo "unsupported helper mode: $1" >&2; exit 40; }
+shift 2
+state=$FAKE_HERDR_DIR
+for argument in "$@"; do
+  [ "${#argument}" -le 131071 ] || { echo "E2BIG: argument exceeds MAX_ARG_STRLEN" >&2; exit 41; }
+done
+next_id() {
+  local n
+  n=$(cat "$state/counter" 2>/dev/null || printf 0)
+  n=$((n + 1))
+  printf '%s' "$n" > "$state/counter"
+  printf '%s' "$n"
+}
+case "$1 $2" in
+  "workspace create")
+    shift 2
+    label=
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --cwd) shift ;;
+        --label) label=$2; shift ;;
+        --no-focus) ;;
+        *) echo "unknown workspace create flag: $1" >&2; exit 42 ;;
+      esac
+      shift
+    done
+    n=$(next_id)
+    printf 'ws-%s\n' "$n" > "$state/tab-$n.workspace"
+    printf '%s\n' "$label" > "$state/tab-$n.label"
+    printf 'tab-%s ws-%s\n' "$n" "$n" > "$state/pane-$n"
+    jq -nc --arg w "ws-$n" --arg t "tab-$n" --arg p "pane-$n" \
+      '{result:{workspace:{workspace_id:$w},tab:{tab_id:$t},root_pane:{pane_id:$p}}}'
+    ;;
+  "tab create")
+    shift 2
+    workspace= label=
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --workspace) workspace=$2; shift ;;
+        --cwd) shift ;;
+        --label) label=$2; shift ;;
+        --no-focus) ;;
+        *) echo "unknown tab create flag: $1" >&2; exit 43 ;;
+      esac
+      shift
+    done
+    n=$(next_id)
+    printf '%s\n' "$workspace" > "$state/tab-$n.workspace"
+    printf '%s\n' "$label" > "$state/tab-$n.label"
+    printf 'tab-%s %s\n' "$n" "$workspace" > "$state/pane-$n"
+    jq -nc --arg w "$workspace" --arg t "tab-$n" --arg p "pane-$n" \
+      '{result:{tab:{tab_id:$t,workspace_id:$w},root_pane:{pane_id:$p}}}'
+    ;;
+  "tab rename")
+    [ -f "$state/$3.label" ] || exit 44
+    printf '%s\n' "$4" > "$state/$3.label"
+    ;;
+  "tab get")
+    [ -f "$state/$3.label" ] || exit 45
+    jq -nc --arg t "$3" --arg w "$(cat "$state/$3.workspace")" --arg l "$(cat "$state/$3.label")" \
+      '{result:{tab:{tab_id:$t,workspace_id:$w,label:$l}}}'
+    ;;
+  "pane get")
+    [ -f "$state/$3" ] || exit 46
+    read -r tab workspace < "$state/$3"
+    jq -nc --arg p "$3" --arg t "$tab" --arg w "$workspace" \
+      '{result:{pane:{pane_id:$p,tab_id:$t,workspace_id:$w}}}'
+    ;;
+  "pane run")
+    [ -f "$state/$3" ] || exit 47
+    ;;
+  "agent send")
+    [ -f "$state/$3" ] || exit 48
+    case "$4" in
+      -*) echo "unknown flag: the message was parsed as an option" >&2; exit 49 ;;
+    esac
+    [ "${#4}" -le 4096 ] || { echo "agent send message is not a bounded pointer" >&2; exit 50; }
+    n=$(next_id)
+    printf '%s' "$4" > "$state/agent-send-$n-$3"
+    ;;
+  "pane close")
+    rm -f "$state/$3"
+    ;;
+  *)
+    echo "unsupported fake herdr command: $1 $2" >&2
+    exit 51
+    ;;
+esac
+SH
+  chmod +x "$FAKE_HERDR"
+  LAB_CAPTAIN_HOME="$TMP_ROOT/lab-captain-home"
+  mkdir -p "$LAB_CAPTAIN_HOME"
+  IFS=$'\t' read -r HOMEL PROJECTL < <(new_home herdrlab)
+  lab_council() {
+    local home=$1
+    shift
+    HOME="$LAB_CAPTAIN_HOME" FM_HOME="$home" FM_COUNCIL_HERDR_LAB_HELPER="$FAKE_HERDR" \
+      FAKE_HERDR_DIR="$FAKE_HERDR_STATE" FM_COUNCIL_HERDR_SESSION=lab \
+      "$ROOT/bin/fm-council.sh" "$@"
+  }
+  lab_council "$HOMEL" create Lab --project "$PROJECTL" \
+    --participant claude/claude-fable-5/xhigh \
+    --participant codex/gpt-5.6-sol/xhigh >/dev/null
+  lab_council "$HOMEL" provider-consent anthropic --project "$PROJECTL" --acknowledge-project-disclosure >/dev/null
+  lab_council "$HOMEL" provider-consent openai --project "$PROJECTL" --acknowledge-project-disclosure >/dev/null
+  ASKL=$(lab_council "$HOMEL" ask Lab "Choose a strategy.")
+  [ "$(jq -r '.roster[].dispatch' <<<"$ASKL" | sort -u)" = sent ] || fail "bounded pointer dispatch did not reach both real-lane members"
+  round_sends=$(grep -l "Council round message" "$FAKE_HERDR_STATE"/agent-send-*)
+  [ "$(printf '%s\n' "$round_sends" | wc -l | tr -d ' ')" = 2 ] || fail "the real-lane round did not send exactly two pointer instructions"
+  round_payload_hashes=""
+  while IFS= read -r send_file; do
+    [ "$(wc -c < "$send_file")" -le 4096 ] || fail "a round instruction exceeded the bounded pointer size"
+    assert_grep 'Write your complete answer atomically' "$send_file" "the round pointer omitted the private answer path"
+    payload_file=$(sed -n 's/^Payload file: //p' "$send_file")
+    payload_hash=$(sed -n 's/^Payload sha256: //p' "$send_file")
+    [ -f "$payload_file" ] || fail "a round pointer referenced a missing inbox payload file"
+    [ "$(sha256sum "$payload_file" | awk '{print $1}')" = "$payload_hash" ] || fail "a round pointer hash did not match its inbox payload bytes"
+    round_payload_hashes="$round_payload_hashes$payload_hash"$'\n'
+  done <<<"$round_sends"
+  [ "$(printf '%s' "$round_payload_hashes" | sort -u | wc -l | tr -d ' ')" = 1 ] || fail "round payload bytes differed across members"
+  while IFS=$'\t' read -r member answer; do
+    [ -n "$member" ] || continue
+    printf 'lab answer from %s\n' "$member" > "$answer"
+    chmod 600 "$answer"
+  done < <(jq -r '.roster | to_entries[] | [.key, .value.answer] | @tsv' <<<"$ASKL")
+  COLLECTL=$(lab_council "$HOMEL" collect Lab)
+  [ "$(jq '.answers | length' <<<"$COLLECTL")" = 2 ] || fail "real-lane answers were not collected from private outboxes"
+  { printf -- '--dash-led canonical decision\n'; head -c 200000 /dev/zero | tr '\0' x; printf '\n'; } > "$TMP_ROOT/lab-canonical.md"
+  lab_council "$HOMEL" present Lab --file "$TMP_ROOT/lab-canonical.md" --kind synthesis >/dev/null
+  ACCEPTL=$(lab_council "$HOMEL" accept Lab)
+  [ "$(jq '.deferred_members | length' <<<"$ACCEPTL")" = 0 ] || fail "a leading-dash decision beyond MAX_ARG_STRLEN was not delivered through bounded pointers"
+  decision_sends=$(grep -l "Council decision message" "$FAKE_HERDR_STATE"/agent-send-*)
+  [ "$(printf '%s\n' "$decision_sends" | wc -l | tr -d ' ')" = 2 ] || fail "the accepted decision was not pointer-delivered to both members"
+  while IFS= read -r send_file; do
+    payload_file=$(sed -n 's/^Payload file: //p' "$send_file")
+    cmp -s "$TMP_ROOT/lab-canonical.md" "$payload_file" || fail "a decision payload file did not match the presented canonical bytes"
+  done <<<"$decision_sends"
+  lab_council "$HOMEL" close Lab >/dev/null
+  pass "council herdr argv: oversized and leading-dash payloads travel as exact hashed inbox files behind bounded pointer instructions"
+fi

--- a/tests/fm-council.test.sh
+++ b/tests/fm-council.test.sh
@@ -65,6 +65,11 @@ case "$op" in
     ;;
   close)
     council=$1 member=$2 owner=$3 runtime=$4
+    failclose="$state/fail-close-once-$council--$member"
+    if [ -f "$failclose" ]; then
+      rm -f "$failclose"
+      exit 37
+    fi
     marker="$state/endpoints/$council--$member.json"
     [ -f "$marker" ] || exit 34
     [ "$(jq -r .owner_token "$marker")" = "$owner" ] || exit 35
@@ -198,9 +203,11 @@ if [ "$(uname -s)-$(uname -m)" = Linux-x86_64 ]; then
         if cat "$4/answer" > "$2/other-answer"; then echo answer-read-bad > "$2/answer-status"; else echo answer-read-denied > "$2/answer-status"; fi
         if /usr/bin/python3 -c "import socket; socket.socket(socket.AF_UNIX)"; then echo unix-socket-bad > "$2/socket-status"; else echo unix-socket-denied > "$2/socket-status"; fi
         if /usr/bin/python3 -c "import socket; socket.socket(socket.AF_INET).close()"; then echo tcp-socket-allowed > "$2/tcp-status"; else echo tcp-socket-bad > "$2/tcp-status"; fi
+        if /bin/ls / > /dev/null; then echo exec-bad > "$2/exec-status"; else echo exec-denied > "$2/exec-status"; fi
       } 2> "$2/denials"
     ' sh "$sandbox/view" "$sandbox/home" "$sandbox/source" "$sandbox/other"
   [ "$(cat "$sandbox/home/read-view")" = fixed-view ] || fail "sandbox could not read the fixed project view"
+  [ "$(cat "$sandbox/home/exec-status")" = exec-denied ] || fail "sandbox executed a binary outside the exact allowlist"
   [ "$(cat "$sandbox/home/view-write")" = view-write-denied ] || fail "sandbox wrote the fixed project view"
   assert_grep source-read-denied "$sandbox/home/source-status" "sandbox read the source project outside the fixed view"
   assert_grep source-write-denied "$sandbox/home/source-status" "sandbox wrote the source project"
@@ -208,7 +215,22 @@ if [ "$(uname -s)-$(uname -m)" = Linux-x86_64 ]; then
   [ "$(cat "$sandbox/home/socket-status")" = unix-socket-denied ] || fail "sandbox allowed a terminal-control socket channel"
   [ "$(cat "$sandbox/home/tcp-status")" = tcp-socket-allowed ] || fail "sandbox blocked provider-style TCP sockets"
   [ "$(cat "$sandbox/source/code")" = source-private ] || fail "sandbox changed the source bytes"
-  pass "council sandbox: Landlock enforces read-only fixed views and hides source and competing answers"
+  pass "council sandbox: Landlock enforces read-only fixed views, the exact exec allowlist, and answer isolation"
+
+  env_probe='import json, os, sys; json.dump({key: os.environ.get(key) for key in ("ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN", "OPENAI_API_KEY") if key in os.environ}, open(sys.argv[1], "w"))'
+  ANTHROPIC_API_KEY=anthropic-secret CLAUDE_CODE_OAUTH_TOKEN=claude-oauth OPENAI_API_KEY=openai-secret \
+    "$ROOT/bin/fm-council-sandbox.py" --home "$sandbox/home" --harness claude \
+    -- /usr/bin/python3 -c "$env_probe" "$sandbox/home/env-claude.json"
+  ANTHROPIC_API_KEY=anthropic-secret CLAUDE_CODE_OAUTH_TOKEN=claude-oauth OPENAI_API_KEY=openai-secret \
+    "$ROOT/bin/fm-council-sandbox.py" --home "$sandbox/home" --harness codex \
+    -- /usr/bin/python3 -c "$env_probe" "$sandbox/home/env-codex.json"
+  [ "$(jq -r '.ANTHROPIC_API_KEY // "-"' "$sandbox/home/env-claude.json")" = anthropic-secret ] || fail "claude lane lost its own provider key"
+  [ "$(jq -r '.CLAUDE_CODE_OAUTH_TOKEN // "-"' "$sandbox/home/env-claude.json")" = claude-oauth ] || fail "claude lane lost its own oauth token"
+  [ "$(jq -r '.OPENAI_API_KEY // "-"' "$sandbox/home/env-claude.json")" = - ] || fail "claude lane leaked the OpenAI key"
+  [ "$(jq -r '.OPENAI_API_KEY // "-"' "$sandbox/home/env-codex.json")" = openai-secret ] || fail "codex lane lost its own provider key"
+  [ "$(jq -r '.ANTHROPIC_API_KEY // "-"' "$sandbox/home/env-codex.json")" = - ] || fail "codex lane leaked the Anthropic key"
+  [ "$(jq -r '.CLAUDE_CODE_OAUTH_TOKEN // "-"' "$sandbox/home/env-codex.json")" = - ] || fail "codex lane leaked the Claude oauth token"
+  pass "council sandbox: each lane receives only its own harness provider credentials"
 fi
 
 # Different councils use independent locks and can dispatch concurrently.
@@ -339,3 +361,64 @@ expect_code 1 "$status" "close must refuse a changed endpoint identity"
 mv "$clean_runtime.saved" "$clean_runtime"
 council "$HOME1" close AtlasClean >/dev/null
 pass "council close: only exact owned sessions terminate, ambiguity refuses, and conversation context is cleared"
+
+# Failed round setup rolls back its unpublished round directory and keeps the
+# durable counter retryable.
+if [ "$(id -u)" != 0 ]; then
+  IFS=$'\t' read -r HOME4 PROJECT4 < <(new_home rollback)
+  CREATE4=$(create_pair "$HOME4" "$PROJECT4" Rollback)
+  ID4=$(json_id "$CREATE4")
+  consent_pair "$HOME4" "$PROJECT4"
+  mkdir -p "$PROJECT4/blocked"
+  printf 'x\n' > "$PROJECT4/blocked/file"
+  chmod 000 "$PROJECT4/blocked"
+  status=0
+  council "$HOME4" ask Rollback "Task while the project is unreadable" >/dev/null 2>&1 || status=$?
+  chmod 700 "$PROJECT4/blocked"
+  expect_code 1 "$status" "unreadable project must fail the round setup"
+  [ ! -d "$HOME4/data/councils/$ID4/rounds/R0001" ] || fail "failed round setup left a stale round directory"
+  [ ! -d "$HOME4/data/councils/$ID4/snapshots/R0001" ] || fail "failed round setup left a stale snapshot"
+  [ "$(jq -r .round_counter "$HOME4/data/councils/$ID4/council.json")" = 0 ] || fail "failed round setup burned the durable round counter"
+  ASK4=$(council "$HOME4" ask Rollback "Task after the project stabilizes")
+  [ "$(jq -r .round <<<"$ASK4")" = R0001 ] || fail "retry after a failed setup did not reuse the rolled-back round identity"
+  pass "council round rollback: failed snapshot setup is retryable without a stale round directory"
+fi
+
+# A corrupt participant runtime defers decision delivery instead of aborting an
+# acceptance whose canonical decision is already saved, without duplicating it.
+IFS=$'\t' read -r HOME5 PROJECT5 < <(new_home deferral)
+CREATE5=$(create_pair "$HOME5" "$PROJECT5" Deferral)
+ID5=$(json_id "$CREATE5")
+consent_pair "$HOME5" "$PROJECT5"
+ASK5=$(council "$HOME5" ask Deferral "Pick a queue.")
+submit_all "$HOME5" Deferral "$ASK5" deferral
+council "$HOME5" collect Deferral >/dev/null
+printf 'Queue decision.\n' > "$TMP_ROOT/deferral-canonical.md"
+council "$HOME5" present Deferral --file "$TMP_ROOT/deferral-canonical.md" --kind synthesis >/dev/null
+CODEX5=$(jq -r '.members[] | select(startswith("codex-"))' <<<"$CREATE5")
+codex_runtime="$HOME5/state/councils/$ID5/members/$CODEX5/runtime.json"
+cp "$codex_runtime" "$codex_runtime.saved"
+printf 'not-json\n' > "$codex_runtime"
+ACCEPT5=$(council "$HOME5" accept Deferral)
+[ "$(jq -r '.deferred_members[0]' <<<"$ACCEPT5")" = "$CODEX5" ] || fail "a corrupt runtime aborted acceptance instead of deferring delivery"
+[ "$(jq -r .phase "$HOME5/data/councils/$ID5/council.json")" = idle ] || fail "acceptance with a corrupt runtime did not complete"
+index5=$(find "$HOME5/data/council-projects" -name index.json)
+[ "$(jq '.decisions | length' "$index5")" = 1 ] || fail "acceptance duplicated the saved decision entry"
+mv "$codex_runtime.saved" "$codex_runtime"
+council "$HOME5" ask Deferral "Follow-up task." >/dev/null
+codex_events5=$(grep -F $'send\t' "$STUB/events" | grep -F "$ID5" | grep -F "$CODEX5" | tail -2 | awk -F '\t' '{print $4}' | paste -sd, -)
+[ "$codex_events5" = decision,round ] || fail "deferred member did not catch up before its next round"
+pass "council acceptance deferral: canonical save survives a corrupt runtime and is never duplicated"
+
+# A close that fails partway is retryable; retries skip only journal-confirmed
+# closures and close each remaining exact endpoint once.
+: > "$STUB/fail-close-once-$ID5--$CODEX5"
+status=0
+council "$HOME5" close Deferral >/dev/null 2>&1 || status=$?
+expect_code 1 "$status" "a partial close failure must be reported"
+[ "$(jq -r .status "$HOME5/data/councils/$ID5/council.json")" = open ] || fail "a partially closed council must remain open"
+[ "$(jq '.closed | length' "$HOME5/data/councils/$ID5/close-journal.json")" = 1 ] || fail "close journal did not record exactly the confirmed closure"
+council "$HOME5" close Deferral >/dev/null
+[ "$(grep -c "^close.$ID5" "$STUB/events")" = 2 ] || fail "close retry did not close each participant exactly once"
+[ "$(jq -r .status "$HOME5/data/councils/$ID5/council.json")" = closed ] || fail "close retry did not complete the council closure"
+pass "council close retry: journal-confirmed closures are skipped and remaining endpoints close exactly once"

--- a/tests/fm-council.test.sh
+++ b/tests/fm-council.test.sh
@@ -1,0 +1,341 @@
+#!/usr/bin/env bash
+# Deterministic behavior coverage for the thin persistent council MVP.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-council)
+TRANSPORT="$TMP_ROOT/transport"
+STUB="$TMP_ROOT/stub"
+mkdir -p "$STUB"
+
+cat > "$TRANSPORT" <<'SH'
+#!/usr/bin/env bash
+set -eu
+op=$1
+shift
+state=$FM_COUNCIL_STUB_DIR
+mkdir -p "$state/endpoints" "$state/payloads"
+case "$op" in
+  launch)
+    council=$1 member=$2 owner=$3 runtime=$4
+    marker="$state/endpoints/$council--$member.json"
+    [ ! -e "$marker" ] || { echo "duplicate launch" >&2; exit 31; }
+    jq -nc --arg c "$council" --arg m "$member" --arg o "$owner" \
+      '{session:"stub",workspace_id:("ws-"+$c),tab_id:("tab-"+$m),pane_id:("pane-"+$m),endpoint:("stub:pane-"+$m),owner_token:$o,alive:true}' > "$marker"
+    printf 'launch\t%s\t%s\t%s\n' "$council" "$member" "$owner" >> "$state/events"
+    jq -c '{session,workspace_id,tab_id,pane_id,endpoint}' "$marker"
+    ;;
+  probe)
+    council=$1 member=$2 owner=$3 runtime=$4
+    marker="$state/endpoints/$council--$member.json"
+    if [ -f "$state/unavailable-$council--$member" ]; then
+      jq -nc --arg c "$council" --arg m "$member" --arg o "$owner" \
+        '{session:"stub",workspace_id:("ws-"+$c),tab_id:("tab-"+$m),pane_id:("pane-"+$m),owner_token:$o,alive:false}'
+      exit 0
+    fi
+    [ -f "$marker" ] || exit 32
+    cat "$marker"
+    ;;
+  send)
+    council=$1 member=$2 kind=$3 payload=$4 common=$5 runtime=$6
+    fail="$state/fail-once-$council--$member--$kind"
+    if [ -f "$fail" ]; then
+      rm -f "$fail"
+      exit 33
+    fi
+    if [ "$kind" = round ] && [ -f "$state/parallel-mode" ]; then
+      : > "$state/active-$council"
+      sleep 0.25
+      active_count=$(find "$state" -maxdepth 1 -name 'active-*' -type f | wc -l | tr -d ' ')
+      [ "$active_count" -lt 2 ] || : > "$state/parallel-proved"
+      rm -f "$state/active-$council"
+    fi
+    sequence=$(($(wc -l < "$state/events" 2>/dev/null || printf 0) + 1))
+    copy="$state/payloads/$sequence-$council-$member-$kind.md"
+    cp "$payload" "$copy"
+    payload_hash=$(sha256sum "$payload" | awk '{print $1}')
+    if [ "$common" = - ]; then
+      common_hash=-
+    else
+      common_hash=$(sha256sum "$common" | awk '{print $1}')
+    fi
+    printf 'send\t%s\t%s\t%s\t%s\t%s\t%s\n' "$council" "$member" "$kind" "$payload_hash" "$common_hash" "$copy" >> "$state/events"
+    ;;
+  close)
+    council=$1 member=$2 owner=$3 runtime=$4
+    marker="$state/endpoints/$council--$member.json"
+    [ -f "$marker" ] || exit 34
+    [ "$(jq -r .owner_token "$marker")" = "$owner" ] || exit 35
+    rm -f "$marker"
+    printf 'close\t%s\t%s\t%s\n' "$council" "$member" "$owner" >> "$state/events"
+    ;;
+  *)
+    exit 36
+    ;;
+esac
+SH
+chmod +x "$TRANSPORT"
+
+new_home() {
+  local label=$1 home project
+  home="$TMP_ROOT/$label/home"
+  project="$TMP_ROOT/$label/project"
+  mkdir -p "$home/data" "$home/state" "$home/config" "$project"
+  printf 'visible\n' > "$project/README.md"
+  printf 'TOP_SECRET\n' > "$project/.env"
+  printf 'PRIVATE\n' > "$project/id_rsa"
+  printf 'example=yes\n' > "$project/.env.example"
+  printf '%s\t%s\n' "$home" "$project"
+}
+
+council() {
+  local home=$1
+  shift
+  FM_HOME="$home" FM_COUNCIL_TEST_TRANSPORT="$TRANSPORT" FM_COUNCIL_STUB_DIR="$STUB" \
+    "$ROOT/bin/fm-council.sh" "$@"
+}
+
+create_pair() {
+  local home=$1 project=$2 name=$3
+  shift 3
+  council "$home" create "$name" --project "$project" \
+    --participant claude/claude-fable-5/xhigh \
+    --participant codex/gpt-5.6-sol/xhigh "$@"
+}
+
+consent_pair() {
+  local home=$1 project=$2
+  council "$home" provider-consent anthropic --project "$project" --acknowledge-project-disclosure >/dev/null
+  council "$home" provider-consent openai --project "$project" --acknowledge-project-disclosure >/dev/null
+}
+
+json_id() {
+  jq -r .id <<<"$1"
+}
+
+submit_all() {
+  local home=$1 name=$2 ask_json=$3 prefix=$4 round member nonce answer
+  round=$(jq -r .round <<<"$ask_json")
+  while IFS=$'\t' read -r member nonce; do
+    [ -n "$member" ] || continue
+    answer="$TMP_ROOT/$prefix-$member.md"
+    printf '%s answer from %s\n' "$prefix" "$member" > "$answer"
+    council "$home" submit "$name" "$member" --round "$round" --nonce "$nonce" --file "$answer" >/dev/null
+  done < <(jq -r '.roster | to_entries[] | select(.value.dispatch == "sent") | [.key,.value.nonce] | @tsv' <<<"$ask_json")
+}
+
+# Create, exact profile validation, and duplicate-name refusal.
+IFS=$'\t' read -r HOME1 PROJECT1 < <(new_home core)
+CREATE1=$(create_pair "$HOME1" "$PROJECT1" Atlas)
+ID1=$(json_id "$CREATE1")
+[ "$(jq '.members | length' <<<"$CREATE1")" = 2 ] || fail "create did not retain two exact profiles"
+status=0
+create_pair "$HOME1" "$PROJECT1" atlas >/dev/null 2>&1 || status=$?
+expect_code 1 "$status" "duplicate names must be refused case-insensitively"
+status=0
+council "$HOME1" create Other --project "$PROJECT1" \
+  --participant claude/claude-opus-4/xhigh \
+  --participant codex/gpt-5.6-sol/xhigh >/dev/null 2>&1 || status=$?
+expect_code 1 "$status" "unsupported exact model must be refused instead of substituted"
+pass "council create: named identity, two exact profiles, duplicate refusal, and no model substitution"
+
+# Provider consent must exist before any project view is built or sent.
+status=0
+council "$HOME1" ask Atlas "Choose a cache." >/dev/null 2>&1 || status=$?
+expect_code 1 "$status" "round without provider consent must be refused"
+[ ! -d "$HOME1/data/councils/$ID1/snapshots/R0001" ] || fail "consent refusal created a project view"
+status=0
+council "$HOME1" provider-consent anthropic --project "$PROJECT1" >/dev/null 2>&1 || status=$?
+expect_code 1 "$status" "provider consent without explicit disclosure acknowledgement must be refused"
+consent_pair "$HOME1" "$PROJECT1"
+pass "council consent: project-specific durable provider approval is required before fan-out"
+
+# Same-input fan-out, secret exclusions, answer isolation, and one active round.
+ASK1=$(council "$HOME1" ask Atlas "Choose a cache.")
+ROUND1=$(jq -r .round <<<"$ASK1")
+COMMON1="$HOME1/data/councils/$ID1/rounds/$ROUND1/common.md"
+[ "$(jq -r '.roster[].dispatch' <<<"$ASK1" | sort -u)" = sent ] || fail "same-input round did not dispatch to both profiles"
+common_hash=$(sha256sum "$COMMON1" | awk '{print $1}')
+[ "$(jq -r .common_hash <<<"$ASK1")" = "$common_hash" ] || fail "round common hash does not match the frozen common bytes"
+round_log=$(grep -F $'send\t' "$STUB/events" | grep -F $'\tround\t' | grep -F "$ID1")
+[ "$(printf '%s\n' "$round_log" | awk -F '\t' '{print $6}' | sort -u | wc -l | tr -d ' ')" = 1 ] || fail "participants received different common inputs"
+manifest="$HOME1/data/councils/$ID1/snapshots/$ROUND1/manifest.json"
+assert_grep '"path": ".env"' "$manifest" "snapshot manifest did not list .env exclusion"
+assert_grep '"path": "id_rsa"' "$manifest" "snapshot manifest did not list private-key exclusion"
+assert_present "$HOME1/data/councils/$ID1/snapshots/$ROUND1/project/.env.example" ".env.example should remain visible"
+assert_absent "$HOME1/data/councils/$ID1/snapshots/$ROUND1/project/.env" ".env leaked into the project view"
+for answer_path in $(jq -r '.roster[].answer' <<<"$ASK1"); do
+  assert_absent "$answer_path" "fan-out exposed an answer before that participant submitted it"
+done
+status=0
+council "$HOME1" ask Atlas "Second overlapping task" >/dev/null 2>&1 || status=$?
+expect_code 1 "$status" "a second active round in one council must be refused"
+pass "council round: one frozen secret-filtered input is isolated and serialized per council"
+
+# Linux Landlock enforces the fixed-view and answer-isolation boundaries below
+# the participant process rather than relying on council instructions.
+if [ "$(uname -s)-$(uname -m)" = Linux-x86_64 ]; then
+  sandbox="$TMP_ROOT/sandbox"
+  mkdir -p "$sandbox/home" "$sandbox/source" "$sandbox/view" "$sandbox/other"
+  printf 'source-private\n' > "$sandbox/source/code"
+  printf 'fixed-view\n' > "$sandbox/view/code"
+  printf 'competing-answer\n' > "$sandbox/other/answer"
+  # shellcheck disable=SC2016  # positional parameters expand inside the sandboxed shell
+  "$ROOT/bin/fm-council-sandbox.py" \
+    --home "$sandbox/home" \
+    --readable "$sandbox/view" \
+    --allow-exec /bin/sh \
+    --allow-exec /bin/cat \
+    --allow-exec /usr/bin/python3 \
+    -- /bin/sh -c '
+      {
+        cat "$1/code" > "$2/read-view"
+        if echo mutate > "$1/code"; then echo view-write-bad > "$2/view-write"; else echo view-write-denied > "$2/view-write"; fi
+        if cat "$3/code" > "$2/source-read"; then echo source-read-bad > "$2/source-status"; else echo source-read-denied > "$2/source-status"; fi
+        if echo mutate > "$3/code"; then echo source-write-bad >> "$2/source-status"; else echo source-write-denied >> "$2/source-status"; fi
+        if cat "$4/answer" > "$2/other-answer"; then echo answer-read-bad > "$2/answer-status"; else echo answer-read-denied > "$2/answer-status"; fi
+        if /usr/bin/python3 -c "import socket; socket.socket(socket.AF_UNIX)"; then echo unix-socket-bad > "$2/socket-status"; else echo unix-socket-denied > "$2/socket-status"; fi
+        if /usr/bin/python3 -c "import socket; socket.socket(socket.AF_INET).close()"; then echo tcp-socket-allowed > "$2/tcp-status"; else echo tcp-socket-bad > "$2/tcp-status"; fi
+      } 2> "$2/denials"
+    ' sh "$sandbox/view" "$sandbox/home" "$sandbox/source" "$sandbox/other"
+  [ "$(cat "$sandbox/home/read-view")" = fixed-view ] || fail "sandbox could not read the fixed project view"
+  [ "$(cat "$sandbox/home/view-write")" = view-write-denied ] || fail "sandbox wrote the fixed project view"
+  assert_grep source-read-denied "$sandbox/home/source-status" "sandbox read the source project outside the fixed view"
+  assert_grep source-write-denied "$sandbox/home/source-status" "sandbox wrote the source project"
+  [ "$(cat "$sandbox/home/answer-status")" = answer-read-denied ] || fail "sandbox exposed a competing participant answer"
+  [ "$(cat "$sandbox/home/socket-status")" = unix-socket-denied ] || fail "sandbox allowed a terminal-control socket channel"
+  [ "$(cat "$sandbox/home/tcp-status")" = tcp-socket-allowed ] || fail "sandbox blocked provider-style TCP sockets"
+  [ "$(cat "$sandbox/source/code")" = source-private ] || fail "sandbox changed the source bytes"
+  pass "council sandbox: Landlock enforces read-only fixed views and hides source and competing answers"
+fi
+
+# Different councils use independent locks and can dispatch concurrently.
+IFS=$'\t' read -r HOME2 PROJECT2 < <(new_home parallel)
+create_pair "$HOME2" "$PROJECT2" Alpha >/dev/null
+create_pair "$HOME2" "$PROJECT2" Beta >/dev/null
+consent_pair "$HOME2" "$PROJECT2"
+: > "$STUB/parallel-mode"
+council "$HOME2" ask Alpha "Alpha task" > "$TMP_ROOT/alpha.ask" &
+pid_a=$!
+council "$HOME2" ask Beta "Beta task" > "$TMP_ROOT/beta.ask" &
+pid_b=$!
+wait "$pid_a" || fail "first independent council ask failed"
+wait "$pid_b" || fail "second independent council ask failed"
+assert_present "$STUB/parallel-proved" "different councils did not overlap their independent fan-out"
+rm -f "$STUB/parallel-mode" "$STUB"/active-*
+pass "council concurrency: independent councils dispatch in parallel while each remains serialized"
+
+# Partial failure produces an honest sole-answer collection, never a winner.
+IFS=$'\t' read -r HOME3 PROJECT3 < <(new_home partial)
+CREATE3=$(create_pair "$HOME3" "$PROJECT3" Partial)
+ID3=$(json_id "$CREATE3")
+consent_pair "$HOME3" "$PROJECT3"
+CODEX3=$(jq -r '.members[] | select(startswith("codex-"))' <<<"$CREATE3")
+: > "$STUB/unavailable-$ID3--$CODEX3"
+ASK3=$(council "$HOME3" ask Partial "Choose one safe option.")
+[ "$(jq -r --arg member "$CODEX3" '.roster[$member].dispatch' <<<"$ASK3")" = unavailable ] || fail "partial failure was not named unavailable"
+submit_all "$HOME3" Partial "$ASK3" partial
+COLLECT3=$(council "$HOME3" collect Partial)
+[ "$(jq -r .comparison <<<"$COLLECT3")" = only-available ] || fail "one answer was treated as a comparative result"
+[ "$(jq -r '.unavailable[0]' <<<"$COLLECT3")" = "$CODEX3" ] || fail "collection did not name the unavailable participant"
+printf 'Only available answer: use the safe option.\n' > "$TMP_ROOT/only.md"
+status=0
+council "$HOME3" present Partial --file "$TMP_ROOT/only.md" --kind best >/dev/null 2>&1 || status=$?
+expect_code 1 "$status" "one answer must not be presented as a winner"
+council "$HOME3" present Partial --file "$TMP_ROOT/only.md" --kind only >/dev/null
+PARTIAL_ROUND=$(jq -r .round <<<"$ASK3")
+council "$HOME3" reject Partial --reason "captain rejected the sole answer" >/dev/null
+[ "$(jq -r .phase "$HOME3/data/councils/$ID3/council.json")" = idle ] || fail "plain reject did not return the council to idle"
+assert_absent "$HOME3/data/councils/$ID3/rounds/$PARTIAL_ROUND/presented.md" "plain reject retained the rejected canonical result"
+pass "council collection: partial failure is honest, one answer is never a winner, and plain rejection retains no result"
+
+# Acceptance saves exact bytes before broadcast, defers one member, catches it up,
+# preserves participant sessions, and emits a separate implementation instruction.
+submit_all "$HOME1" Atlas "$ASK1" first
+COLLECT1=$(council "$HOME1" collect Atlas)
+[ "$(jq -r '.answers | length' <<<"$COLLECT1")" = 2 ] || fail "two answers were not collected"
+printf 'Canonical synthesis byte-for-byte.\nSecond line.\n' > "$TMP_ROOT/canonical.md"
+council "$HOME1" present Atlas --file "$TMP_ROOT/canonical.md" --kind synthesis >/dev/null
+CODEX1=$(jq -r '.members[] | select(startswith("codex-"))' <<<"$CREATE1")
+: > "$STUB/fail-once-$ID1--$CODEX1--decision"
+ACCEPT1=$(council "$HOME1" accept-and-implement Atlas)
+DECISION1=$(jq -r .canonical <<<"$ACCEPT1")
+cmp -s "$TMP_ROOT/canonical.md" "$DECISION1" || fail "accepted decision bytes differ from the presented canonical bytes"
+[ "$(jq -r .implementation.action <<<"$ACCEPT1")" = create_separate_ordinary_implementation_task ] || fail "accept-and-implement did not return an ordinary-task instruction"
+[ "$(jq -r '.deferred_members[0]' <<<"$ACCEPT1")" = "$CODEX1" ] || fail "temporary decision delivery failure was not deferred honestly"
+saved_line=$(grep -n '"event": "decision_saved"' "$HOME1/data/councils/$ID1/events.jsonl" | tail -1 | cut -d: -f1)
+delivered_line=$(grep -n '"event": "decision_delivered"' "$HOME1/data/councils/$ID1/events.jsonl" | tail -1 | cut -d: -f1)
+[ "$saved_line" -lt "$delivered_line" ] || fail "decision broadcast preceded durable canonical save"
+decision_payload=$(grep -F $'send\t' "$STUB/events" | grep -F "$ID1" | grep -F $'\tdecision\t' | tail -1 | awk -F '\t' '{print $7}')
+cmp -s "$TMP_ROOT/canonical.md" "$decision_payload" || fail "broadcast payload was not exactly the presented canonical decision"
+launches_before=$(grep -c "^launch.$ID1" "$STUB/events")
+ASK1B=$(council "$HOME1" ask Atlas "Plan the schema migration.")
+launches_after=$(grep -c "^launch.$ID1" "$STUB/events")
+[ "$launches_before" = "$launches_after" ] || fail "next round duplicated persistent participant sessions"
+codex_events=$(grep -F $'send\t' "$STUB/events" | grep -F "$ID1" | grep -F "$CODEX1" | tail -2 | awk -F '\t' '{print $4}' | paste -sd, -)
+[ "$codex_events" = decision,round ] || fail "unavailable participant did not catch up before its next round"
+pass "council acceptance: exact save precedes exact broadcast, catch-up, and separate implementation routing"
+
+# Reject/rerun removes rejected output and sends clarified constraints.
+submit_all "$HOME1" Atlas "$ASK1B" second
+ROUND1B=$(jq -r .round <<<"$ASK1B")
+RERUN=$(council "$HOME1" rerun Atlas --clarify "Do not use Redis")
+ROUND1C=$(jq -r .rerun <<<"$RERUN")
+[ "$ROUND1B" != "$ROUND1C" ] || fail "rerun reused the rejected round identity"
+old_round_dir="$HOME1/data/councils/$ID1/rounds/$ROUND1B"
+assert_absent "$old_round_dir/presented.md" "rerun retained a rejected presentation"
+for answer_path in $(jq -r '.roster[].answer // empty' "$old_round_dir/round.json"); do
+  assert_absent "$answer_path" "rerun retained a rejected raw answer"
+done
+assert_grep 'Clarified constraint: Do not use Redis' "$HOME1/data/councils/$ID1/rounds/$ROUND1C/common.md" "rerun did not fan out clarified constraints"
+pass "council rerun: rejected results are removed and clarified constraints get a fresh round"
+
+# Restart/recovery is duplicate-safe and interrupted work requires explicit retry.
+launches_before=$(grep -c "^launch.$ID1" "$STUB/events")
+council "$HOME1" status Atlas >/dev/null
+launches_after=$(grep -c "^launch.$ID1" "$STUB/events")
+[ "$launches_before" = "$launches_after" ] || fail "clean restart/status inspection duplicated participants"
+council "$HOME1" recover Atlas >/dev/null
+status=0
+council "$HOME1" ask Atlas "Must refuse while interrupted" >/dev/null 2>&1 || status=$?
+expect_code 1 "$status" "interrupted round accepted a new ask without retry"
+RETRY=$(council "$HOME1" retry Atlas --clarify "Retry after restart")
+[ "$(jq -r .retry <<<"$RETRY")" != "$ROUND1C" ] || fail "explicit retry reused interrupted identity"
+launches_after=$(grep -c "^launch.$ID1" "$STUB/events")
+[ "$launches_before" = "$launches_after" ] || fail "explicit retry duplicated participant endpoints"
+pass "council restart: endpoint identity is reused and interrupted rounds require explicit retry"
+
+# New councils inherit active project decisions by default, while clean-slate omits
+# them and always starts fresh conversation homes.
+DEFAULT_NEW=$(create_pair "$HOME1" "$PROJECT1" Atlas2)
+CLEAN_NEW=$(create_pair "$HOME1" "$PROJECT1" AtlasClean --clean-slate)
+DEFAULT_ID=$(json_id "$DEFAULT_NEW")
+CLEAN_ID=$(json_id "$CLEAN_NEW")
+[ "$(jq -r '.decision_ids[0]' "$HOME1/data/councils/$DEFAULT_ID/council.json")" = D0001 ] || fail "new council did not inherit active project decisions"
+[ "$(jq '.decision_ids | length' "$HOME1/data/councils/$CLEAN_ID/council.json")" = 0 ] || fail "clean-slate council inherited old decisions"
+default_homes=$(jq -r '.members[].runtime' "$HOME1/data/councils/$DEFAULT_ID/council.json" | sort)
+clean_homes=$(jq -r '.members[].runtime' "$HOME1/data/councils/$CLEAN_ID/council.json" | sort)
+[ "$default_homes" != "$clean_homes" ] || fail "new councils reused old participant conversations"
+pass "council restart policy: fresh conversations inherit active decisions unless clean-slate is explicit"
+
+# Explicit close verifies and closes exact owned endpoints only, preserving an
+# unrelated endpoint marker and deleting conversation homes.
+printf 'unrelated\n' > "$STUB/endpoints/unrelated"
+council "$HOME1" close Atlas2 >/dev/null
+assert_present "$STUB/endpoints/unrelated" "council close touched an unrelated endpoint"
+[ "$(grep -c "^close.$DEFAULT_ID" "$STUB/events")" = 2 ] || fail "close did not terminate exactly its two participants"
+assert_absent "$HOME1/state/councils/$DEFAULT_ID/members" "close did not clear participant conversation homes"
+[ "$(jq -r .status "$HOME1/data/councils/$DEFAULT_ID/council.json")" = closed ] || fail "close did not preserve durable closed identity"
+clean_runtime_rel=$(jq -r '.members[0].runtime' "$HOME1/data/councils/$CLEAN_ID/council.json")
+clean_runtime="$HOME1/$clean_runtime_rel"
+cp "$clean_runtime" "$clean_runtime.saved"
+jq '.pane_id = "forged-pane"' "$clean_runtime.saved" > "$clean_runtime"
+status=0
+council "$HOME1" close AtlasClean >/dev/null 2>&1 || status=$?
+expect_code 1 "$status" "close must refuse a changed endpoint identity"
+[ "$(find "$STUB/endpoints" -maxdepth 1 -name "$CLEAN_ID--*" -type f | wc -l | tr -d ' ')" = 2 ] || fail "ambiguous close touched a council participant"
+mv "$clean_runtime.saved" "$clean_runtime"
+council "$HOME1" close AtlasClean >/dev/null
+pass "council close: only exact owned sessions terminate, ambiguity refuses, and conversation context is cleared"

--- a/tests/fm-council.test.sh
+++ b/tests/fm-council.test.sh
@@ -514,6 +514,9 @@ ln -s "$HOME8/loot" "$claude_answer8"
 ln "$HOME8/loot" "$codex_answer8"
 READY8=$(council "$HOME8" ready Ingest) || fail "unsafe answer files crashed readiness"
 [ "$(jq '.answered | length' <<<"$READY8")" = 0 ] || fail "a symlinked or hard-linked answer was counted as answered"
+[ "$(jq -r --arg member "$CLAUDE8" '.refusals[$member]' <<<"$READY8")" = symlink ] || fail "the symlinked answer refusal reason was not surfaced in ready"
+[ "$(jq -r --arg member "$CODEX8" '.refusals[$member]' <<<"$READY8")" = hard-linked ] || fail "the hard-linked answer refusal reason was not surfaced in ready"
+[ "$(jq '.pending | length' <<<"$READY8")" = 0 ] || fail "refused answers left members pending forever"
 status=0
 council "$HOME8" collect Ingest >/dev/null 2>&1 || status=$?
 expect_code 1 "$status" "symlinked and hard-linked answers must not be ingested"
@@ -524,7 +527,12 @@ COLLECT8=$(council "$HOME8" collect Ingest)
 [ "$(jq -r .comparison <<<"$COLLECT8")" = only-available ] || fail "the honest regular answer was not collected"
 [ "$(jq -r '.unavailable[0]' <<<"$COLLECT8")" = "$CLAUDE8" ] || fail "the symlinked answer was not degraded to unavailable"
 assert_not_contains "$COLLECT8" INGEST-LOOT "a symlinked answer exfiltrated controller-readable bytes"
-pass "council answer ingest: only exact private regular single-link outbox files are read"
+ID8=$(json_id "$CREATE8")
+ROUND8=$(jq -r .round <<<"$ASK8")
+[ "$(jq -r --arg member "$CLAUDE8" '.roster[$member].refusal' "$HOME8/data/councils/$ID8/rounds/$ROUND8/round.json")" = symlink ] || fail "the refusal reason was not recorded in the round evidence"
+[ "$(jq -r --arg member "$CODEX8" '.roster[$member].refusal // "-"' "$HOME8/data/councils/$ID8/rounds/$ROUND8/round.json")" = - ] || fail "a stale refusal survived the member's honest answer"
+[ "$(grep -cF "\"member\": \"$CLAUDE8\", \"reason\": \"symlink\"" "$HOME8/data/councils/$ID8/events.jsonl")" = 1 ] || fail "the answer refusal event was missing or duplicated across collects"
+pass "council answer ingest: only exact private regular single-link outbox files are read, with bounded refusal reasons recorded once"
 
 # A corrupt member runtime during ready/wait degrades that member to honest
 # unavailability instead of crashing every readiness poll.
@@ -532,7 +540,7 @@ IFS=$'\t' read -r HOME9 PROJECT9 < <(new_home readyprobe)
 CREATE9=$(create_pair "$HOME9" "$PROJECT9" ReadyProbe)
 ID9=$(json_id "$CREATE9")
 consent_pair "$HOME9" "$PROJECT9"
-council "$HOME9" ask ReadyProbe "Pick a formatter." >/dev/null
+ASK9=$(council "$HOME9" ask ReadyProbe "Pick a formatter.")
 CODEX9=$(jq -r '.members[] | select(startswith("codex-"))' <<<"$CREATE9")
 codex_runtime9="$HOME9/state/councils/$ID9/members/$CODEX9/runtime.json"
 cp "$codex_runtime9" "$codex_runtime9.saved"
@@ -541,6 +549,34 @@ READY9=$(council "$HOME9" ready ReadyProbe) || fail "a corrupt member runtime cr
 [ "$(jq -r --arg member "$CODEX9" '.unavailable | index($member) != null' <<<"$READY9")" = true ] || fail "a corrupt member runtime was not honestly unavailable in ready"
 mv "$codex_runtime9.saved" "$codex_runtime9"
 pass "council readiness: a corrupt runtime degrades to unavailable instead of failing ready and wait"
+
+# Submission publishes the answer through the pinned verified outbox descriptor,
+# so an outbox replaced by a symlink cannot redirect the controller's write.
+CLAUDE9=$(jq -r '.members[] | select(startswith("claude-"))' <<<"$CREATE9")
+ROUND9=$(jq -r .round <<<"$ASK9")
+claude_nonce9=$(jq -r --arg member "$CLAUDE9" '.roster[$member].nonce' <<<"$ASK9")
+claude_answer9=$(jq -r --arg member "$CLAUDE9" '.roster[$member].answer' <<<"$ASK9")
+outbox9=$(dirname "$claude_answer9")
+redirect9="$TMP_ROOT/redirect9"
+mkdir -p "$redirect9"
+printf 'submitted through the pinned descriptor\n' > "$TMP_ROOT/answer9.md"
+rmdir "$outbox9"
+ln -s "$redirect9" "$outbox9"
+status=0
+council "$HOME9" submit ReadyProbe "$CLAUDE9" --round "$ROUND9" --nonce "$claude_nonce9" --file "$TMP_ROOT/answer9.md" >/dev/null 2>&1 || status=$?
+expect_code 1 "$status" "submit through a symlink-replaced outbox must refuse"
+assert_absent "$redirect9/$ROUND9.md" "submit redirected an answer write outside the private outbox"
+rm "$outbox9"
+mkdir -m 700 "$outbox9"
+council "$HOME9" submit ReadyProbe "$CLAUDE9" --round "$ROUND9" --nonce "$claude_nonce9" --file "$TMP_ROOT/answer9.md" >/dev/null
+[ "$(stat -c %a "$claude_answer9")" = 600 ] || fail "the submitted answer is not private 0600"
+[ "$(stat -c %h "$claude_answer9")" = 1 ] || fail "the submitted answer is not a single-link regular file"
+status=0
+council "$HOME9" submit ReadyProbe "$CLAUDE9" --round "$ROUND9" --nonce "$claude_nonce9" --file "$TMP_ROOT/answer9.md" >/dev/null 2>&1 || status=$?
+expect_code 1 "$status" "a duplicate submission must be refused create-exclusively"
+READY9B=$(council "$HOME9" ready ReadyProbe)
+[ "$(jq -r --arg member "$CLAUDE9" '.answered | index($member) != null' <<<"$READY9B")" = true ] || fail "the pinned-descriptor submission was not ingested"
+pass "council submit: answer publication stays pinned to the verified private outbox descriptor"
 
 # A project directory without owner write permission still snapshots because
 # subtree modes are applied only after the subtree is populated.

--- a/tests/fm-council.test.sh
+++ b/tests/fm-council.test.sh
@@ -202,6 +202,8 @@ if [ "$(uname -s)-$(uname -m)" = Linux-x86_64 ]; then
         if echo mutate > "$3/code"; then echo source-write-bad >> "$2/source-status"; else echo source-write-denied >> "$2/source-status"; fi
         if cat "$4/answer" > "$2/other-answer"; then echo answer-read-bad > "$2/answer-status"; else echo answer-read-denied > "$2/answer-status"; fi
         if /usr/bin/python3 -c "import socket; socket.socket(socket.AF_UNIX)"; then echo unix-socket-bad > "$2/socket-status"; else echo unix-socket-denied > "$2/socket-status"; fi
+        if /usr/bin/python3 -c "import socket; socket.socketpair()"; then echo socketpair-bad > "$2/socketpair-status"; else echo socketpair-denied > "$2/socketpair-status"; fi
+        if /usr/bin/python3 -c "import ctypes, sys; libc = ctypes.CDLL(None, use_errno=True); rc = libc.syscall(425, 4, 0); sys.exit(0 if rc < 0 and ctypes.get_errno() == 13 else 1)"; then echo io-uring-denied > "$2/iouring-status"; else echo io-uring-bad > "$2/iouring-status"; fi
         if /usr/bin/python3 -c "import socket; socket.socket(socket.AF_INET).close()"; then echo tcp-socket-allowed > "$2/tcp-status"; else echo tcp-socket-bad > "$2/tcp-status"; fi
         if /bin/ls / > /dev/null; then echo exec-bad > "$2/exec-status"; else echo exec-denied > "$2/exec-status"; fi
       } 2> "$2/denials"
@@ -213,6 +215,8 @@ if [ "$(uname -s)-$(uname -m)" = Linux-x86_64 ]; then
   assert_grep source-write-denied "$sandbox/home/source-status" "sandbox wrote the source project"
   [ "$(cat "$sandbox/home/answer-status")" = answer-read-denied ] || fail "sandbox exposed a competing participant answer"
   [ "$(cat "$sandbox/home/socket-status")" = unix-socket-denied ] || fail "sandbox allowed a terminal-control socket channel"
+  [ "$(cat "$sandbox/home/socketpair-status")" = socketpair-denied ] || fail "sandbox allowed a Unix socketpair channel"
+  [ "$(cat "$sandbox/home/iouring-status")" = io-uring-denied ] || fail "sandbox allowed an io_uring socket bypass"
   [ "$(cat "$sandbox/home/tcp-status")" = tcp-socket-allowed ] || fail "sandbox blocked provider-style TCP sockets"
   [ "$(cat "$sandbox/source/code")" = source-private ] || fail "sandbox changed the source bytes"
   pass "council sandbox: Landlock enforces read-only fixed views, the exact exec allowlist, and answer isolation"
@@ -422,3 +426,67 @@ council "$HOME5" close Deferral >/dev/null
 [ "$(grep -c "^close.$ID5" "$STUB/events")" = 2 ] || fail "close retry did not close each participant exactly once"
 [ "$(jq -r .status "$HOME5/data/councils/$ID5/council.json")" = closed ] || fail "close retry did not complete the council closure"
 pass "council close retry: journal-confirmed closures are skipped and remaining endpoints close exactly once"
+
+# Stale unpublished round/snapshot leftovers from a crashed ask are recovered
+# deterministically instead of blocking every later ask.
+IFS=$'\t' read -r HOME6 PROJECT6 < <(new_home stale)
+CREATE6=$(create_pair "$HOME6" "$PROJECT6" Stale)
+ID6=$(json_id "$CREATE6")
+consent_pair "$HOME6" "$PROJECT6"
+mkdir -p "$HOME6/data/councils/$ID6/rounds/R0001"
+printf 'leftover\n' > "$HOME6/data/councils/$ID6/rounds/R0001/common.md"
+mkdir -p "$HOME6/data/councils/$ID6/snapshots/R0001/project"
+printf 'leftover\n' > "$HOME6/data/councils/$ID6/snapshots/R0001/project/file"
+chmod 555 "$HOME6/data/councils/$ID6/snapshots/R0001/project"
+ASK6=$(council "$HOME6" ask Stale "Task after a crashed ask") || fail "stale unpublished leftovers blocked the next ask"
+[ "$(jq -r .round <<<"$ASK6")" = R0001 ] || fail "stale leftovers changed the deterministic round identity"
+if grep -q leftover "$HOME6/data/councils/$ID6/rounds/R0001/common.md"; then
+  fail "stale round leftovers were adopted as a valid round"
+fi
+assert_absent "$HOME6/data/councils/$ID6/snapshots/R0001/project/file" "stale snapshot leftovers were adopted as a valid view"
+pass "council stale recovery: unpublished crash leftovers are cleared, never adopted"
+
+# A corrupt participant runtime during dispatch becomes an honest unavailable
+# roster entry in a complete frozen roster instead of aborting the fan-out.
+IFS=$'\t' read -r HOME7 PROJECT7 < <(new_home dispatch)
+CREATE7=$(create_pair "$HOME7" "$PROJECT7" Dispatch)
+ID7=$(json_id "$CREATE7")
+consent_pair "$HOME7" "$PROJECT7"
+CODEX7=$(jq -r '.members[] | select(startswith("codex-"))' <<<"$CREATE7")
+codex_runtime7="$HOME7/state/councils/$ID7/members/$CODEX7/runtime.json"
+cp "$codex_runtime7" "$codex_runtime7.saved"
+printf 'not-json\n' > "$codex_runtime7"
+ASK7=$(council "$HOME7" ask Dispatch "Pick a linter.") || fail "a corrupt runtime aborted the round fan-out"
+ROUND7=$(jq -r .round <<<"$ASK7")
+[ "$(jq -r --arg member "$CODEX7" '.roster[$member].dispatch' <<<"$ASK7")" = unavailable ] || fail "corrupt runtime was not an honest unavailable roster entry"
+[ "$(jq '.roster | length' <<<"$ASK7")" = 2 ] || fail "dispatch failure left an incomplete frozen roster"
+[ "$(jq -r .status "$HOME7/data/councils/$ID7/rounds/$ROUND7/round.json")" = collecting ] || fail "round did not finish dispatch after a member failure"
+grep -q '"event": "round_dispatched"' "$HOME7/data/councils/$ID7/events.jsonl" || fail "dispatch failure suppressed the round_dispatched event"
+mv "$codex_runtime7.saved" "$codex_runtime7"
+pass "council dispatch: a per-member runtime failure defers honestly and still freezes a complete roster"
+
+# A non-UTF-8 presentation is refused before any state mutates.
+submit_all "$HOME7" Dispatch "$ASK7" dispatch
+council "$HOME7" collect Dispatch >/dev/null
+printf '\xff\xfe broken bytes' > "$TMP_ROOT/bad-utf8.md"
+status=0
+council "$HOME7" present Dispatch --file "$TMP_ROOT/bad-utf8.md" --kind only >/dev/null 2>&1 || status=$?
+expect_code 1 "$status" "non-UTF-8 presentation must be refused"
+[ "$(jq -r .phase "$HOME7/data/councils/$ID7/council.json")" = awaiting_presentation ] || fail "invalid presentation mutated the council phase"
+assert_absent "$HOME7/data/councils/$ID7/rounds/$ROUND7/presented.md" "invalid presentation bytes were saved"
+printf 'Valid decision.\n' > "$TMP_ROOT/good-utf8.md"
+council "$HOME7" present Dispatch --file "$TMP_ROOT/good-utf8.md" --kind only >/dev/null
+pass "council present: non-UTF-8 canonical bytes are refused before any state mutation"
+
+# One corrupt council record neither bricks other councils nor hides itself
+# from a direct request.
+mkdir -p "$HOME7/data/councils/corrupt-1234"
+printf 'not-json\n' > "$HOME7/data/councils/corrupt-1234/council.json"
+council "$HOME7" status Dispatch >/dev/null || fail "a corrupt unrelated record broke healthy council status"
+council "$HOME7" reject Dispatch --reason cleanup >/dev/null || fail "a corrupt unrelated record broke healthy council mutation"
+status=0
+council "$HOME7" status corrupt-1234 >/dev/null 2>&1 || status=$?
+expect_code 1 "$status" "a direct request for the corrupt identity must report the corruption"
+[ "$(council "$HOME7" status | jq -r '.[] | select(.id == "corrupt-1234") | .status')" = unreadable ] || fail "the status listing did not surface the corrupt record"
+rm -rf "$HOME7/data/councils/corrupt-1234"
+pass "council isolation: corrupt records are skipped for other councils and reported when requested directly"


### PR DESCRIPTION
## Intent

Implement the captain-approved narrow persistent council MVP for Firstmate without restoring the rejected large architecture. Provide one natural-language /council workflow backed by one authoritative CLI that creates named project-bound councils with the exact Claude Code claude-fable-5 xhigh and Codex gpt-5.6-sol xhigh profiles, preserves each participant conversation across serialized rounds, permits independent councils in parallel, fans out one fixed secret-filtered read-only view with isolated answers, handles partial availability honestly, and atomically saves the exact presented canonical decision before broadcast and catch-up. Keep accept-and-implement separate from council analysis, support reject/rerun, exact explicit close, fresh conversations with inherited accepted decisions or clean slate, restart-safe endpoint identity, interrupted-round retry, and project-specific provider consent. Enforce the first supported Linux x86_64 Herdr lane with Landlock plus terminal-socket denial, validate lifecycle with provider-free stubs in a guarded non-default Herdr lab, include deterministic contract tests and concise user documentation, and deliberately omit scorecards, judge models, budget/UI/transcript systems, global display migration, broad backend support, and complex recovery.

## What Changed

- Added a persistent council MVP: a `/council` skill and an authoritative `bin/fm-council.py` CLI (plus `bin/fm-council.sh` wrapper) that create named, project-bound councils with fixed Claude Code `claude-fable-5` xhigh and Codex `gpt-5.6-sol` xhigh participant profiles, preserve each participant's conversation across serialized rounds, allow independent councils to run in parallel, fan out one fixed secret-filtered read-only project snapshot with isolated per-participant answers, report partial availability honestly, and atomically save the canonical accepted decision before broadcast and catch-up — with reject/rerun, explicit close, fresh conversations (inheriting accepted decisions or clean slate), restart-safe endpoint identity, and interrupted-round retry.
- Added `bin/fm-council-sandbox.py` enforcing the Linux x86_64 Herdr lane (Landlock confinement plus terminal-socket and io_uring seccomp denial); follow-up review commits hardened the controller with symlink-safe answer ingest (lstat/O_NOFOLLOW/dir_fd, size caps), outbox-fd-pinned submit writes, recorded answer-refusal reasons, per-member readiness degradation instead of hard failure, snapshot directory-mode ordering, and the fixed secret-stem filter.
- Added deterministic contract tests (`tests/fm-council.test.sh`), a guarded provider-free Herdr e2e lab test (`tests/fm-council-herdr-e2e.test.sh`), and concise user docs (`docs/council.md`, Herdr lane verification record in `docs/herdr-backend.md`, configuration/scripts updates).

## Risk Assessment

✅ Low: All findings accepted across prior rounds are now verifiably fixed with dedicated regression tests (fd-pinned create-exclusive submit publication and durable, deduplicated answer-refusal evidence), the branch satisfies every source-verifiable intent criterion, and this round's diff introduces no new material issues.

## Testing

Completed 1 recorded test check.

- Outcome: ⚠️ 1 error across 1 run (20m30s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 6 issues found → auto-fixed (2) ✅</summary>

- 🚨 `bin/fm-council.py:1045` - Participant answer ingestion follows symlinks out of the untrusted sandbox: `command_collect` reads the roster answer path with `Path(...).is_file()`/`read_text()` (and `readiness` stats it at line 995) from the participant-writable outbox. The Landlock policy grants participants MAKE_SYM in their home, so a malicious/prompt-injected participant can plant `outbox/&lt;round&gt;.md -&gt; &lt;project&gt;/.env` (the very file the secret filter excluded), `~/.ssh/id_rsa`, another participant&#39;s outbox, or any controller-readable file; the unsandboxed controller then reads that target as the participant&#39;s answer, surfaces it to the captain, and after acceptance broadcasts it to both model providers. This defeats the hard isolation boundary and secret-filtered-view guarantee under the change&#39;s own threat model. Fix: open answer files with O_NOFOLLOW, verify S_ISREG via lstat, and cap read size (read_text is currently unbounded).
- ⚠️ `bin/fm-council.py:377` - `build_snapshot` applies each directory&#39;s original mode immediately after mkdir (`os.chmod(target, entry[&#34;mode&#34;])`) before copying its children. Any project directory lacking owner write permission (e.g. a 0o555 vendored or generated tree) makes the subsequent child `shutil.copyfile` raise an uncaught PermissionError — surfacing as a raw traceback instead of a CouncilError — and the round can never start until the project&#39;s permissions change. Directory modes should be applied after the subtree is populated (e.g. in the final read-only chmod pass, which already rewrites all modes anyway).
- ⚠️ `bin/fm-council.py:1000` - `readiness()` calls `probe_member` without catching CouncilError, so one corrupt or tampered member `runtime.json` mid-round makes `ready` and `wait` fail entirely (and `wait` crash on every poll) instead of degrading that member to &#34;unavailable&#34;. This is inconsistent with the dispatch path (line 939) and the acceptance path (line 1188), which both deliberately convert the same per-member CouncilError into an honest unavailable/deferred entry. Wrap the probe in try/except CouncilError and classify the member unavailable.
- ⚠️ `bin/fm-council.py:783` - Real-lane delivery passes the entire round/decision payload as one argv element to `herdr agent send`. Every round&#39;s common.md embeds all accepted decision bodies, so accumulated decisions can push a payload past Linux&#39;s ~128 KiB MAX_ARG_STRLEN, failing with E2BIG and mislabeling a live participant &#34;unavailable&#34;; a captain-authored decision body starting with `-` may also be parsed as a herdr flag since no `--` separator is used. The payload file is already written into the participant&#39;s inbox (write_payload), so file-referenced delivery is possible, but that changes the participant interaction contract, so the remediation choice belongs to the author.
- ℹ️ `bin/fm-council.py:313` - The fixed secret filter excludes names containing &#34;credential&#34; and &#34;private-key&#34;, .env variants, key suffixes, and known credential filenames, but passes through common secret-bearing names containing &#34;secret&#34; or &#34;token&#34; (e.g. secrets.yaml, secrets.json, token.txt), which then reach cloud providers in the round view. Since the filter is intentionally fixed and documented, extending it is a deliberate product decision.
- ℹ️ `tests/fm-council.test.sh:252` - The independent-council parallelism proof depends on two 0.25 s stub sleeps physically overlapping (`parallel-proved` is only created when two `active-*` markers coexist), so the assertion can flake on a heavily loaded or slow runner where the second `ask` starts after the first stub sleep ends. A longer overlap window or a rendezvous (each sender waits briefly for the peer marker) would make it deterministic.

🔧 Fix: Harden answer ingest, snapshot modes, readiness, argv delivery, secret filter
3 issues (1 warning, 2 infos) still open:
- ⚠️ `bin/fm-council.py:1107` - Write-side TOCTOU in `command_submit`: the outbox is verified to be a private real directory via `open_outbox_dir`, but the returned fd is immediately closed and the answer is then written through the untrusted path with `atomic_bytes(destination, content)`. A participant that replaces `outbox` with a symlink between the check (line 1106) and the write can redirect the controller&#39;s `&lt;round&gt;.md` creation into any controller-writable directory (e.g. the source project or council data dirs). The read side already solves this pattern with dir_fd + O_NOFOLLOW; mirror it here by keeping the verified directory fd open and creating the file with os.open(f&#34;{round_id}.md&#34;, O_WRONLY|O_CREAT|O_EXCL|O_NOFOLLOW, dir_fd=...) instead of a path-based atomic_bytes. Window is narrow and submit is only exercised by deterministic transports, so follow-up is acceptable.
- ℹ️ `bin/fm-council.py:876` - An answer file that exists but fails the safety gate in `read_member_answer` (non-regular, hard-linked, wrong uid, group/other-writable, oversized, empty, or non-UTF-8) is silently treated as never-answered: the member shows as &#34;pending&#34; until wait times out, with no events.jsonl record of the refusal or its reason. Notably, a live participant that writes its answer via a plain shell redirect under a umask-002 system (Ubuntu user-private-group default) produces a 0664 file that is silently discarded even though the participant genuinely answered; only the instructed mkstemp+rename path yields a passing 0600 file. Emitting an `answer_refused_unsafe` event (with the failed check) would make the refusal observable and support the honesty contract; whether to log, mention the required mode in the pointer instruction, or relax the group-write check is a product decision.
- ℹ️ `bin/fm-council.py:318` - The new secret-stem filter deliberately applies to files only (`not entry.is_dir(...)`), so a directory named `secrets/` or `tokens/` is still included in the round view and its contents leak unless individually matched by other rules. This matches the requested narrow scope (avoid broad exclusions of ordinary source identifiers like a `secrets.py` module), so no action is required; recording the tradeoff.

🔧 Fix: Pin submit writes to outbox fd, record answer refusal reasons
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Test** - 1 error</summary>

- 🚨 tests failed with exit code 1
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `docs/herdr-backend.md:1017` - The Herdr lane verification record in docs/herdr-backend.md cites source commit d0f9062c6a1c2aad189b24dc3ce461e30e2cbf68, a gate-internal commit that will dangle in the published linear history. I added a sentence documenting that the files the proof executes (bin/fm-council-sandbox.py, bin/fm-herdr-lab.sh, tests/fm-council-herdr-e2e.test.sh) are byte-identical between that commit and the shipped change, but the hash itself remains unresolvable for future readers; refreshing it honestly would require rerunning the guarded FM_COUNCIL_HERDR_E2E lab proof at the final commit, which is outside this documentation-only task.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
