### PR TITLE
fix: keep local no-mistakes tests intent-targeted

### DIFF
--- a/.no-mistakes.yaml
+++ b/.no-mistakes.yaml
@@ -9,23 +9,22 @@
 # HEAD-continuity guard; see docs/architecture.md "No-mistakes gate authority boundary."
 disable_project_settings: true
 
-# Pin lint and the portable behavior suite to the same deterministic commands
-# the Linux CI jobs run, instead of leaving them to no-mistakes' default handling.
-# CI separately owns platform-specific compatibility lanes, including the stock
-# macOS Bash snapshot checks. Without a configured
-# commands.lint, the gate's lint step never ran the deterministic
+# Pin lint to the same deterministic command CI runs, instead of leaving it to
+# no-mistakes' default handling. Without a configured commands.lint, the gate's
+# lint step never ran the deterministic
 # `shellcheck bin/*.sh bin/backends/*.sh tests/*.sh` that CI runs, so info-level
 # ShellCheck findings (e.g. SC2015) were not surfaced locally before CI rejected
 # them. commands.lint delegates to bin/fm-lint.sh, the single owner of the lint
 # definition that .github/workflows/ci.yml also invokes, so local can never
 # diverge from CI again (parity asserted by tests/fm-lint.test.sh).
-# The test command mirrors the Linux behavior job in .github/workflows/ci.yml:
-# iterate every tests/*.test.sh, run each, and fail the step if any one exits
-# non-zero (an agent-driven test step has crashed the daemon). The e2e tests need
-# tmux on PATH, which the firstmate environment provides.
+#
+# Do not set commands.test to a complete tests/*.test.sh walk. Local no-mistakes
+# Test is intent-targeted validation of whether the change meets its brief;
+# .github/workflows/ci.yml owns broad regression (behavior suite, platform,
+# security, Herdr, tmux, and lifecycle coverage). A full-suite override here
+# would duplicate CI and defeat the targeted Test contract.
 commands:
   lint: 'bin/fm-lint.sh'
-  test: 'command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"'
 
 # Keep test evidence out of this repo; it stays in a temp dir instead.
 test:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,8 @@ A crewmate picking up such a brief should load the skill even if the brief preda
 When supervising live crewmates, keep firstmate's own long validation or build commands in the background so watcher wakes can still be handled.
 Crewmate validation follows the installed no-mistakes version's SKILL.md and live `axi` help instead of duplicating gate mechanics in firstmate docs.
 Firstmate's wrapper still matters: `ask-user` findings route to the captain through firstmate, and crewmates avoid `--yes` because it silently resolves captain-owned decisions without escalation.
-Local `.no-mistakes/` state and test evidence stay out of this repo; `.no-mistakes.yaml` keeps evidence in a temp directory and pins the gate's lint and portable behavior commands to the Linux CI jobs, while `.github/workflows/ci.yml` owns additional platform-specific compatibility lanes.
+Local `.no-mistakes/` state and test evidence stay out of this repo; `.no-mistakes.yaml` keeps evidence in a temp directory and pins the gate's lint command to `bin/fm-lint.sh`, matching the Linux CI lint job.
+Local no-mistakes Test is intent-targeted and must not re-run every `tests/*.test.sh`; `.github/workflows/ci.yml` owns the broad behavior suite plus platform-specific compatibility lanes.
 That is firstmate-specific; do not commit `.no-mistakes/evidence/` here even when another no-mistakes-managed target project keeps committed PR evidence.
 
 Check and test the toolbelt before pushing:
@@ -70,7 +71,7 @@ Check and test the toolbelt before pushing:
 ```sh
 for script in bin/*.sh bin/backends/*.sh; do bash -n "$script"; done   # syntax-check the toolbelt
 bin/fm-lint.sh   # lint the toolbelt and behavior tests; the single owner CI and the no-mistakes gate both run
-for test_script in tests/*.test.sh; do bash "$test_script"; done   # behavior tests, matching CI and no-mistakes commands.test
+for test_script in tests/*.test.sh; do bash "$test_script"; done   # full behavior suite (CI Behavior job; optional local full run)
 [ "$(readlink CLAUDE.md)" = "AGENTS.md" ]
 [ "$(readlink .claude/skills)" = "../.agents/skills" ]
 tmp=$(mktemp -d) && printf 'done: smoke\n' > "$tmp/smoke.status" && FM_STATE_OVERRIDE="$tmp" FM_SIGNAL_GRACE=1 FM_POLL=1 FM_HEARTBEAT=999999 bin/fm-watch-arm.sh  # watcher re-arm smoke test (prints arm status, then an actionable signal)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -106,10 +106,10 @@ See [`wedge-alarm.md`](wedge-alarm.md) for the channel reference and macOS verif
 
 ## Gate defaults (.no-mistakes.yaml)
 
-The tracked `.no-mistakes.yaml` keeps test evidence outside the repo and defines `commands.test` so no-mistakes runs firstmate's bash behavior suite directly.
+The tracked `.no-mistakes.yaml` keeps test evidence outside the repo and pins `commands.lint` to `bin/fm-lint.sh` so local lint matches CI.
 That evidence policy is specific to the firstmate repo: target projects may legitimately commit `.no-mistakes/evidence/` from their own no-mistakes pipeline, but firstmate keeps `.no-mistakes/` local and CI rejects tracked entries under that path.
-That command requires `tmux` on `PATH`, prints `tmux -V`, runs every `tests/*.test.sh` with `bash`, and fails if any script exits non-zero.
-It intentionally mirrors the behavior-test baseline in [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) instead of delegating the test step to an agent.
+It does not set `commands.test` to a complete `tests/*.test.sh` walk.
+Local no-mistakes Test stays intent-targeted; broad regression (including the portable behavior suite) lives in [`.github/workflows/ci.yml`](../.github/workflows/ci.yml).
 
 ## Captain Preferences (data/captain.md / data/captain-shared.md)
 

--- a/tests/fm-nm-test-contract.test.sh
+++ b/tests/fm-nm-test-contract.test.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Contract: local no-mistakes Test is intent-targeted; CI owns broad regression.
+#
+# Firstmate must not configure commands.test as a complete tests/*.test.sh walk
+# (that duplicated CI and burned local pipeline time). Lint stays pinned to
+# bin/fm-lint.sh. Remote CI Behavior must keep iterating every tests/*.test.sh.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+NM="$ROOT/.no-mistakes.yaml"
+CI="$ROOT/.github/workflows/ci.yml"
+
+test_nm_yaml_tracked() {
+  assert_present "$NM" "tracked .no-mistakes.yaml is missing"
+  git -C "$ROOT" ls-files --error-unmatch .no-mistakes.yaml >/dev/null 2>&1 \
+    || fail ".no-mistakes.yaml is not tracked by git"
+  pass ".no-mistakes.yaml is present and tracked"
+}
+
+test_nm_keeps_lint_pin() {
+  grep -Fqx "  lint: 'bin/fm-lint.sh'" "$NM" \
+    || fail "commands.lint must remain exactly bin/fm-lint.sh"
+  pass "commands.lint stays pinned to bin/fm-lint.sh"
+}
+
+# True when the YAML maps a non-empty commands.test (string or mapping value).
+# Empty / null / absent is the intended targeted-Test posture.
+nm_commands_test_value() {
+  if command -v python3 >/dev/null 2>&1 && python3 -c 'import yaml' >/dev/null 2>&1; then
+    python3 -c '
+import yaml, sys
+doc = yaml.safe_load(open(sys.argv[1])) or {}
+cmds = doc.get("commands") or {}
+val = cmds.get("test") if isinstance(cmds, dict) else None
+if val is None or val is False:
+    print("")
+elif isinstance(val, str):
+    print(val)
+else:
+    print(repr(val))
+' "$NM"
+    return
+  fi
+  if command -v ruby >/dev/null 2>&1; then
+    ruby -ryaml -e '
+doc = YAML.safe_load(File.read(ARGV[0])) || {}
+cmds = doc["commands"] || {}
+val = cmds.is_a?(Hash) ? cmds["test"] : nil
+if val.nil? || val == false
+  puts ""
+elsif val.is_a?(String)
+  puts val
+else
+  puts val.inspect
+end
+' "$NM"
+    return
+  fi
+  # Structural fallback: any commands.test line under the commands block.
+  awk '
+    /^commands:[[:space:]]*$/ { in_cmds=1; next }
+    in_cmds && /^[^[:space:]#]/ { in_cmds=0 }
+    in_cmds && /^[[:space:]]+test:[[:space:]]*/ {
+      sub(/^[[:space:]]+test:[[:space:]]*/, "")
+      gsub(/^['\''"]|['\''"]$/, "")
+      print
+      exit
+    }
+  ' "$NM"
+}
+
+test_nm_has_no_complete_local_test_command() {
+  local val
+  val=$(nm_commands_test_value) || fail "failed to read commands.test from .no-mistakes.yaml"
+  if [ -n "$val" ]; then
+    case "$val" in
+      *'tests/*.test.sh'*|*'tests/'*'.test.sh'*)
+        fail "commands.test must not walk the complete tests/*.test.sh suite; got: $val"
+        ;;
+      *)
+        # Any non-empty override still steers Test away from intent-targeted default.
+        fail "commands.test must be absent or empty so Test stays intent-targeted; got: $val"
+        ;;
+    esac
+  fi
+  # Also refuse a commented-out full-suite remnant that could be re-enabled by habit.
+  if grep -E '^[[:space:]]*#?[[:space:]]*test:[[:space:]].*tests/\*\.test\.sh' "$NM" >/dev/null 2>&1; then
+    fail ".no-mistakes.yaml still documents a full-suite commands.test line (active or comment)"
+  fi
+  pass "no-mistakes does not configure a complete local Test command"
+}
+
+test_ci_still_runs_broad_behavior_suite() {
+  assert_present "$CI" "ci.yml is missing"
+  # Behavior job still iterates every portable behavior script.
+  grep -Fq 'for test_script in tests/*.test.sh' "$CI" \
+    || fail "CI Behavior job must still loop over tests/*.test.sh"
+  grep -Fq '"$test_script"' "$CI" \
+    || fail "CI Behavior job must still execute each tests/*.test.sh script"
+  # Preserve other CI lanes this task must not shrink.
+  grep -Eq 'name:[[:space:]]*Lint shell scripts' "$CI" \
+    || fail "CI must retain the lint job"
+  grep -Eq 'name:[[:space:]]*Stock macOS Bash snapshot compatibility' "$CI" \
+    || fail "CI must retain the macOS stock Bash compatibility job"
+  grep -Eq 'name:[[:space:]]*Repo invariants' "$CI" \
+    || fail "CI must retain the repo invariants job"
+  pass "CI still owns the broad behavior suite and companion jobs"
+}
+
+test_nm_yaml_tracked
+test_nm_keeps_lint_pin
+test_nm_has_no_complete_local_test_command
+test_ci_still_runs_broad_behavior_suite

--- a/tests/fm-nm-test-contract.test.sh
+++ b/tests/fm-nm-test-contract.test.sh
@@ -97,7 +97,7 @@ test_ci_still_runs_broad_behavior_suite() {
   # Behavior job still iterates every portable behavior script.
   grep -Fq 'for test_script in tests/*.test.sh' "$CI" \
     || fail "CI Behavior job must still loop over tests/*.test.sh"
-  grep -Fq '"$test_script"' "$CI" \
+  grep -Fq "\"\$test_script\"" "$CI" \
     || fail "CI Behavior job must still execute each tests/*.test.sh script"
   # Preserve other CI lanes this task must not shrink.
   grep -Eq 'name:[[:space:]]*Lint shell scripts' "$CI" \


### PR DESCRIPTION
## Intent

Adopt the targeted no-mistakes Test product contract on Firstmate: remove only the .no-mistakes.yaml commands.test override that looped over every tests/*.test.sh so local no-mistakes Test is intent-targeted rather than a full-suite walk; keep commands.lint as bin/fm-lint.sh; rewrite stale comments and CONTRIBUTING/docs/configuration so they state that remote CI owns broad regression; add focused contract tests proving no complete local Test command while .github/workflows/ci.yml still runs the full behavior suite. Do not shrink CI coverage (security, platform, Herdr, tmux, lifecycle). Parallel phase after signed no-mistakes v1.40.3 is installed. Do not revive historical override rationale in always-loaded AGENTS.md.

## What Changed

- Remove the full-suite `commands.test` override so local no-mistakes Test uses intent-targeted validation while keeping lint pinned to `bin/fm-lint.sh`.
- Update contributor and configuration docs to make remote CI the owner of broad regression coverage.
- Add contract tests that reject local full-suite Test overrides and verify CI continues running the behavior suite and companion jobs.

## Risk Assessment

✅ Low: The change is narrowly scoped, preserves CI coverage and the lint override, removes the full-suite local Test override, and adds contract coverage matching the stated intent.

## Testing

The supplied full-suite baseline was green; the focused contract test and manual config, CI, documentation, and version checks all passed, with direct CLI evidence recorded and no transient worktree artifacts left behind.

<details>
<summary>Evidence: Targeted Test contract evidence</summary>

<code>Shows no local `commands.test`, retained lint pin, unchanged CI full-suite loop, updated documentation language, and installed no-mistakes v1.40.3.</code>

```text
$ bash tests/fm-nm-test-contract.test.sh
ok - .no-mistakes.yaml is present and tracked
ok - commands.lint stays pinned to bin/fm-lint.sh
ok - no-mistakes does not configure a complete local Test command
ok - CI still owns the broad behavior suite and companion jobs

$ active commands block in .no-mistakes.yaml
commands:
  lint: 'bin/fm-lint.sh'

# Keep test evidence out of this repo; it stays in a temp dir instead.
$ CI behavior-suite execution loop
          for test_script in tests/*.test.sh; do
            "$test_script"

$ CI workflow changed between base and target?
no - CI workflow is byte-identical across the change

$ documentation acceptance checks
CONTRIBUTING.md:66:Local no-mistakes Test is intent-targeted and must not re-run every `tests/*.test.sh`; `.github/workflows/ci.yml` owns the broad behavior suite plus platform-specific compatibility lanes.
CONTRIBUTING.md:74:for test_script in tests/*.test.sh; do bash "$test_script"; done   # full behavior suite (CI Behavior job; optional local full run)
docs/configuration.md:112:Local no-mistakes Test stays intent-targeted; broad regression (including the portable behavior suite) lives in [`.github/workflows/ci.yml`](../.github/workflows/ci.yml).
.no-mistakes.yaml:22:# Test is intent-targeted validation of whether the change meets its brief;
.no-mistakes.yaml:23:# .github/workflows/ci.yml owns broad regression (behavior suite, platform,
no stale full-suite local-Test rationale remains in the edited docs

$ no-mistakes --version
no-mistakes version v1.40.3 (d873960) 2026-07-22T01:41:55Z
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `command -v tmux >/dev/null || { echo "tmux is required for e2e tests" >&2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo "== $t =="; bash "$t" || rc=1; done; exit "$rc"`
- <code>Supplied successful baseline: `command -v tmux &gt;/dev/null || { echo &#34;tmux is required for e2e tests&#34; &gt;&amp;2; exit 1; }; tmux -V; rc=0; for t in tests/*.test.sh; do echo &#34;== $t ==&#34;; bash &#34;$t&#34; || rc=1; done; exit &#34;$rc&#34;`</code>
- `bash tests/fm-nm-test-contract.test.sh`
- <code>Compared `.github/workflows/ci.yml` between base `c58cb0fbe8f6adc165b89f53124978414f2c7c6f` and target `fd749fa8845176c6005ebd5607fc4422f2294f20`</code>
- <code>Inspected the active `.no-mistakes.yaml` commands block and CI `tests/*.test.sh` loop</code>
- <code>Checked updated contract wording and absence of stale full-suite rationale in `.no-mistakes.yaml`, `CONTRIBUTING.md`, and `docs/configuration.md`</code>
- <code>`no-mistakes --version` confirmed v1.40.3</code>
- <code>`git status --short` confirmed testing left the worktree clean</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: Make CI contract assertion ShellCheck-clean
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
