### PR TITLE
feat: add canonical timed test runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,10 @@ jobs:
   tests:
     name: Behavior tests
     runs-on: ubuntu-latest
-    # The suite should finish in ~2-3 minutes; this generous cap fails loudly on a
-    # hung watcher or tmux test instead of riding GitHub's 360-minute default.
-    timeout-minutes: 15
+    # Measured portable suite wall-clock is ~13-15+ minutes without Herdr.
+    # This cap is a hang tripwire for a stuck watcher or tmux test, not the
+    # expected end of a healthy suite (and not a substitute for green results).
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v6
         with:
@@ -52,11 +53,20 @@ jobs:
           set -eu
           npm install -g tasks-axi
           tasks-axi --version
-      - run: |
+      # Single owner of serial suite selection, timing markers, and aggregate
+      # failure. Do not re-spell a for-loop over tests/*.test.sh here.
+      - name: Run portable behavior suite
+        run: |
           set -eu
-          for test_script in tests/*.test.sh; do
-            "$test_script"
-          done
+          mkdir -p "$RUNNER_TEMP/fm-test"
+          bin/fm-test-run.sh --all --json "$RUNNER_TEMP/fm-test/fm-test-timing.json"
+      - name: Upload behavior timing artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fm-test-timing
+          path: ${{ runner.temp }}/fm-test/fm-test-timing.json
+          if-no-files-found: warn
 
   macos-stock-bash:
     name: Stock macOS Bash snapshot compatibility

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,14 +71,20 @@ Check and test the toolbelt before pushing:
 ```sh
 for script in bin/*.sh bin/backends/*.sh; do bash -n "$script"; done   # syntax-check the toolbelt
 bin/fm-lint.sh   # lint the toolbelt and behavior tests; the single owner CI and the no-mistakes gate both run
-for test_script in tests/*.test.sh; do bash "$test_script"; done   # full behavior suite (CI Behavior job; optional local full run)
+bash tests/<subject>.test.sh   # one script (primary local focus path)
+bin/fm-test-run.sh --family pure-contract-unit   # one declared family (serial, timed)
+bin/fm-test-run.sh --changed   # conservative changed-file-informed set (never silent full suite)
+bin/fm-test-run.sh --all   # intentional complete portable suite (CI Behavior; optional local full run)
 [ "$(readlink CLAUDE.md)" = "AGENTS.md" ]
 [ "$(readlink .claude/skills)" = "../.agents/skills" ]
 tmp=$(mktemp -d) && printf 'done: smoke\n' > "$tmp/smoke.status" && FM_STATE_OVERRIDE="$tmp" FM_SIGNAL_GRACE=1 FM_POLL=1 FM_HEARTBEAT=999999 bin/fm-watch-arm.sh  # watcher re-arm smoke test (prints arm status, then an actionable signal)
 ```
 
+`bin/fm-test-run.sh` is the single owner of serial behavior-suite selection, per-script timing markers, family totals, and the optional JSON timing artifact.
+Its header and `--help` own the flags, family labels, and changed-file map; this section only documents the entry points.
+Local no-mistakes Test stays intent-targeted and must not wire `commands.test` to `--all` or a `tests/*.test.sh` walk; CI Behavior calls `bin/fm-test-run.sh --all` for broad regression.
 Discover tests by listing `tests/*.test.sh`: each is a self-contained bash script named `<subject>.test.sh`, and its header comment describes what it covers, so run one directly to focus on a subject.
-Tests that need a real optional backend or an explicit opt-in (real herdr/zellij/cmux smoke tests, the live Pi regression) skip themselves and print the tool or environment gate needed to enable them, so the run-all loop above is always safe.
+Tests that need a real optional backend or an explicit opt-in (real herdr/zellij/cmux smoke tests, the live Pi regression) skip themselves and print the tool or environment gate needed to enable them, so `--all` remains safe on machines without those tools.
 
 ## Questions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,7 @@ Check and test the toolbelt before pushing:
 ```sh
 for script in bin/*.sh bin/backends/*.sh; do bash -n "$script"; done   # syntax-check the toolbelt
 bin/fm-lint.sh   # lint the toolbelt and behavior tests; the single owner CI and the no-mistakes gate both run
-bash tests/<subject>.test.sh   # one script (primary local focus path)
+bin/fm-test-run.sh tests/<subject>.test.sh   # one script (primary local focus path, timed)
 bin/fm-test-run.sh --family pure-contract-unit   # one declared family (serial, timed)
 bin/fm-test-run.sh --changed   # conservative changed-file-informed set (never silent full suite)
 bin/fm-test-run.sh --all   # intentional complete portable suite (CI Behavior; optional local full run)
@@ -83,7 +83,7 @@ tmp=$(mktemp -d) && printf 'done: smoke\n' > "$tmp/smoke.status" && FM_STATE_OVE
 `bin/fm-test-run.sh` is the single owner of serial behavior-suite selection, per-script timing markers, family totals, and the optional JSON timing artifact.
 Its header and `--help` own the flags, family labels, and changed-file map; this section only documents the entry points.
 Local no-mistakes Test stays intent-targeted and must not wire `commands.test` to `--all` or a `tests/*.test.sh` walk; CI Behavior calls `bin/fm-test-run.sh --all` for broad regression.
-Discover tests by listing `tests/*.test.sh`: each is a self-contained bash script named `<subject>.test.sh`, and its header comment describes what it covers, so run one directly to focus on a subject.
+Discover tests by listing `tests/*.test.sh`: each is a self-contained bash script named `<subject>.test.sh`, and its header comment describes what it covers, so pass one to `bin/fm-test-run.sh` to focus on a subject with canonical timing output.
 Tests that need a real optional backend or an explicit opt-in (real herdr/zellij/cmux smoke tests, the live Pi regression) skip themselves and print the tool or environment gate needed to enable them, so `--all` remains safe on machines without those tools.
 
 ## Questions

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -247,6 +247,19 @@ select_family() {
   [ "$found" -eq 1 ] || die "no tests mapped to family '$want'"
 }
 
+families_for_test_reference() {
+  local needle=$1 s
+  local found=0
+  while IFS= read -r s; do
+    [ -n "$s" ] || continue
+    if grep -Fq "$needle" "$s"; then
+      family_for_basename "$(basename "$s")"
+      found=1
+    fi
+  done < <(all_repo_tests)
+  [ "$found" -eq 1 ]
+}
+
 # Conservative path → family map. Over-selects rather than under-selects.
 # Never expands to the complete suite.
 families_for_changed_path() {
@@ -254,6 +267,10 @@ families_for_changed_path() {
   case "$path" in
     tests/fm-test-run.test.sh)
       printf '%s\n' pure-contract-unit
+      ;;
+    tests/fm-backend-herdr-eventwait.test.py)
+      printf '%s\n' real-herdr-gated
+      printf '%s\n' backend-dispatch
       ;;
     tests/*.test.sh)
       # A single test file change selects only that script via basename family
@@ -292,6 +309,12 @@ families_for_changed_path() {
       printf '%s\n' afk
       printf '%s\n' real-herdr-gated
       ;;
+    bin/fm-supervisor-target-lib.sh)
+      printf '%s\n' watcher-wake-lock
+      printf '%s\n' real-herdr-gated
+      printf '%s\n' live-harness-optin
+      printf '%s\n' afk
+      ;;
     bin/fm-secondmate*|bin/fm-home-seed.sh|bin/fm-backlog-handoff.sh|\
     bin/fm-config-inherit-lib.sh|bin/fm-config-push.sh|bin/fm-shared*)
       printf '%s\n' secondmate
@@ -325,12 +348,15 @@ families_for_changed_path() {
       printf '%s\n' pure-contract-unit
       ;;
     tests/lib.sh|tests/*-helpers.sh)
-      # Shared test helpers can affect many families; pick a broad but still
-      # non-complete set of high-churn families rather than --all.
-      printf '%s\n' pure-contract-unit
-      printf '%s\n' watcher-wake-lock
-      printf '%s\n' session-bootstrap
-      printf '%s\n' backend-dispatch
+      families_for_test_reference "$(basename "$path")" \
+        || printf '%s\n' "__unmapped__:$path"
+      ;;
+    bin/*)
+      families_for_test_reference "$(basename "$path")" \
+        || printf '%s\n' "__unmapped__:$path"
+      ;;
+    tests/*)
+      printf '%s\n' "__unmapped__:$path"
       ;;
     *)
       # No mapping: select nothing for this path (conservative non-expansion).
@@ -355,6 +381,9 @@ select_changed() {
         __script__:*)
           script_name=${entry#__script__:}
           wanted_scripts+=("$script_name")
+          ;;
+        __unmapped__:*)
+          die "no changed-test mapping for source path: ${entry#__unmapped__:}"
           ;;
         *)
           wanted_families+=("$entry")
@@ -596,12 +625,14 @@ fi
 
 if [ "${#SCRIPTS[@]}" -eq 0 ]; then
   log "nothing to run"
+  printf 'FM_TEST_SUMMARY total=0 failed=0 skipped_gate=0 duration_ms=0\n'
   if [ -n "$JSON_PATH" ]; then
     empty_rec=$(mktemp)
     empty_fam=$(mktemp)
     : >"$empty_rec"
     : >"$empty_fam"
     started=$(now_iso)
+    mkdir -p "$(dirname "$JSON_PATH")"
     write_json_artifact "$JSON_PATH" "$started" "$started" "empty" 0 0 0 0 "$SELECTION_DESC" "$empty_rec" "$empty_fam"
     rm -f "$empty_rec" "$empty_fam"
   fi

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -1,0 +1,753 @@
+#!/usr/bin/env bash
+# fm-test-run.sh - single owner of Firstmate's serial behavior-test runner.
+#
+# Replaces duplicated `for test_script in tests/*.test.sh` loops in CONTRIBUTING
+# and the CI Behavior job. This phase is intentionally serial: no sharding and
+# no local --jobs parallelism.
+#
+# Selection modes (exactly one of: --all, --family, --changed, or script paths):
+#   fm-test-run.sh --all
+#   fm-test-run.sh --family <name>
+#   fm-test-run.sh --changed [--base <git-ref>]
+#   fm-test-run.sh tests/<name>.test.sh [more scripts...]
+#
+# Inspection (no execution):
+#   fm-test-run.sh --list --all
+#   fm-test-run.sh --list --family <name>
+#   fm-test-run.sh --list-families
+#
+# Options:
+#   --json <path>   write a deterministic timing artifact after the run
+#   --list          print selected script paths (one per line) and exit 0
+#   --base <ref>    with --changed, compare against this ref (default: origin/main)
+#   -h, --help      print this header
+#
+# Per-script machine-parseable markers (stdout):
+#   FM_TEST_BEGIN <iso8601> <script> family=<family> expected_gate_skip=<class>
+#   FM_TEST_END <iso8601> <script> exit=<code> duration_ms=<n> gate_skip=<true|false>
+#
+# After all scripts (stdout):
+#   FM_TEST_SUMMARY total=<n> failed=<n> skipped_gate=<n> duration_ms=<n>
+#   FM_TEST_SUMMARY_FAMILY family=<name> count=<n> duration_ms=<n> failed=<n>
+#   FM_TEST_SLOWEST rank=<k> script=<path> duration_ms=<n>
+#
+# Exit status is the aggregate of script exits: non-zero if any selected script
+# exits non-zero. Gate skips (first meaningful line matching ^skip:) still exit
+# 0 from the script and are counted as skipped_gate, not failures.
+#
+# Family labels and the changed-file map live in this script only (one owner).
+# --changed is conservative: it over-selects related families rather than
+# under-selecting, and never expands to the complete suite unless --all.
+set -eu
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT" || exit 1
+
+MODE=
+LIST_ONLY=0
+LIST_FAMILIES=0
+FAMILY=
+BASE_REF=origin/main
+JSON_PATH=
+SCRIPTS=()
+
+usage() {
+  awk '
+    NR == 1 { next }
+    /^#/ { sub(/^# ?/, ""); print; next }
+    { exit }
+  ' "$0" >&2
+}
+
+die() {
+  printf 'fm-test-run: %s\n' "$*" >&2
+  exit 2
+}
+
+log() {
+  printf 'fm-test-run: %s\n' "$*" >&2
+}
+
+now_iso() {
+  date -u +%Y-%m-%dT%H:%M:%SZ
+}
+
+now_ms() {
+  if command -v python3 >/dev/null 2>&1; then
+    python3 -c 'import time; print(int(time.time() * 1000))'
+  else
+    # Second precision only when python3 is unavailable.
+    echo $(($(date +%s) * 1000))
+  fi
+}
+
+# Primary family for one tests/*.test.sh basename. Unmapped scripts are
+# unclassified so new tests are still runnable and visible in summaries.
+family_for_basename() {
+  case "$1" in
+    fm-arm-pretool-check.test.sh|fm-brief.test.sh|fm-captain-translation-contract.test.sh|\
+    fm-cd-pretool-check.test.sh|fm-composer-ghost.test.sh|fm-composer-lib.test.sh|\
+    fm-continuity-pretool-check.test.sh|fm-crew-state.test.sh|fm-decision-hold-lifecycle.test.sh|\
+    fm-dispatch-select.test.sh|fm-ensure-agents-md.test.sh|fm-grok-harness.test.sh|\
+    fm-herdr-lab.test.sh|fm-instruction-owners.test.sh|fm-lint.test.sh|\
+    fm-nm-test-contract.test.sh|fm-no-mistakes-ownership.test.sh|fm-pi-primary-types.test.sh|\
+    fm-send-popup-settle.test.sh|fm-send-settle.test.sh|fm-stow-contract.test.sh|\
+    fm-supervision-instructions.test.sh|fm-tmux-submit-busy.test.sh|fm-transition-lib.test.sh|\
+    fm-test-run.test.sh)
+      printf '%s\n' pure-contract-unit
+      ;;
+    fm-daemon.test.sh|fm-guard-stale-banner.test.sh|fm-pi-watch-extension.test.sh|\
+    fm-supervision-events.test.sh|fm-turnend-guard.test.sh|fm-wake-daemon-lifecycle-e2e.test.sh|\
+    fm-wake-queue.test.sh|fm-watch-checkpoint.test.sh|fm-watch-triage.test.sh|\
+    fm-watcher-lock.test.sh)
+      printf '%s\n' watcher-wake-lock
+      ;;
+    fm-afk-inject-herdr-e2e.test.sh|fm-afk-launch.test.sh|fm-backend-autodetect-smoke.test.sh|\
+    fm-backend-herdr-eventwait-smoke.test.sh|fm-backend-herdr-presentation-e2e.test.sh|\
+    fm-backend-herdr-prune-safety-e2e.test.sh|fm-backend-herdr-respawn-idem-e2e.test.sh|\
+    fm-backend-herdr-smoke.test.sh|fm-backend-herdr-workspace-per-home-e2e.test.sh)
+      printf '%s\n' real-herdr-gated
+      ;;
+    fm-backlog-handoff.test.sh|fm-secondmate-harness.test.sh|fm-secondmate-lifecycle-e2e.test.sh|\
+    fm-secondmate-liveness.test.sh|fm-secondmate-safety.test.sh|fm-secondmate-sync.test.sh|\
+    fm-send-secondmate-marker.test.sh|fm-shared-captain-inheritance.test.sh)
+      printf '%s\n' secondmate
+      ;;
+    fm-bootstrap.test.sh|fm-fleet-sync.test.sh|fm-gate-refuse.test.sh|fm-gotmp.test.sh|\
+    fm-session-start.test.sh|fm-sessionstart-nudge.test.sh|fm-tangle-guard.test.sh|\
+    fm-update.test.sh)
+      printf '%s\n' session-bootstrap
+      ;;
+    fm-afk-pi-herdr-return-e2e.test.sh|fm-claude-continuity-live-e2e.test.sh|\
+    fm-codex-continuity-live-e2e.test.sh|fm-grok-continuity-live-e2e.test.sh|\
+    fm-opencode-primary-live-e2e.test.sh|fm-pi-primary-live-e2e.test.sh|\
+    fm-send-secondmate-marker-herdr-e2e.test.sh)
+      printf '%s\n' live-harness-optin
+      ;;
+    fm-backend-herdr.test.sh|fm-backend-tmux-smoke.test.sh|fm-backend.test.sh|\
+    fm-send-strict.test.sh|fm-spawn-batch.test.sh|fm-spawn-dispatch-profile.test.sh|\
+    fm-spawn-worktree-settle.test.sh)
+      printf '%s\n' backend-dispatch
+      ;;
+    fm-pr-check-security.test.sh|fm-pr-merge.test.sh|fm-review-diff.test.sh|\
+    fm-teardown.test.sh|fm-x-mode.test.sh)
+      printf '%s\n' pr-forge
+      ;;
+    fm-afk-inject-e2e.test.sh|fm-afk-return.test.sh)
+      printf '%s\n' afk
+      ;;
+    fm-bearings-snapshot.test.sh|fm-fleet-snapshot-view.test.sh)
+      printf '%s\n' snapshot-bearings
+      ;;
+    fm-backend-cmux.test.sh|fm-backend-cmux-smoke.test.sh)
+      printf '%s\n' cmux
+      ;;
+    fm-backend-zellij.test.sh|fm-backend-zellij-smoke.test.sh)
+      printf '%s\n' zellij
+      ;;
+    fm-backend-orca.test.sh)
+      printf '%s\n' orca
+      ;;
+    *)
+      printf '%s\n' unclassified
+      ;;
+  esac
+}
+
+expected_gate_skip_for_family() {
+  case "$1" in
+    real-herdr-gated) printf '%s\n' herdr ;;
+    live-harness-optin) printf '%s\n' optin-env ;;
+    cmux|zellij|orca) printf '%s\n' optional-binary ;;
+    snapshot-bearings) printf '%s\n' optional-binary ;;
+    *) printf '%s\n' none ;;
+  esac
+}
+
+list_known_families() {
+  cat <<'EOF'
+pure-contract-unit
+watcher-wake-lock
+real-herdr-gated
+secondmate
+session-bootstrap
+live-harness-optin
+backend-dispatch
+pr-forge
+afk
+snapshot-bearings
+cmux
+zellij
+orca
+unclassified
+EOF
+}
+
+all_repo_tests() {
+  # Deterministic lexical order (same as bash glob expansion under LC_ALL=C).
+  local f
+  # shellcheck disable=SC2035
+  for f in tests/*.test.sh; do
+    [ -f "$f" ] || continue
+    printf '%s\n' "$f"
+  done | LC_ALL=C sort
+}
+
+normalize_script_path() {
+  local p=$1
+  case "$p" in
+    /*) printf '%s\n' "$p" ;;
+    tests/*|./tests/*)
+      p=${p#./}
+      printf '%s\n' "$p"
+      ;;
+    *.test.sh)
+      if [ -f "tests/$p" ]; then
+        printf 'tests/%s\n' "$p"
+      else
+        printf '%s\n' "$p"
+      fi
+      ;;
+    *)
+      printf '%s\n' "$p"
+      ;;
+  esac
+}
+
+# Append unique relative-or-absolute script paths to SCRIPTS.
+add_script() {
+  local p existing
+  p=$(normalize_script_path "$1")
+  for existing in "${SCRIPTS[@]+"${SCRIPTS[@]}"}"; do
+    [ "$existing" = "$p" ] && return 0
+  done
+  SCRIPTS+=("$p")
+}
+
+select_all() {
+  local s
+  while IFS= read -r s; do
+    [ -n "$s" ] || continue
+    add_script "$s"
+  done < <(all_repo_tests)
+}
+
+select_family() {
+  local want=$1 s base fam found=0
+  [ -n "$want" ] || die "--family requires a name"
+  while IFS= read -r s; do
+    [ -n "$s" ] || continue
+    base=$(basename "$s")
+    fam=$(family_for_basename "$base")
+    if [ "$fam" = "$want" ]; then
+      add_script "$s"
+      found=1
+    fi
+  done < <(all_repo_tests)
+  [ "$found" -eq 1 ] || die "no tests mapped to family '$want'"
+}
+
+# Conservative path → family map. Over-selects rather than under-selects.
+# Never expands to the complete suite.
+families_for_changed_path() {
+  local path=$1
+  case "$path" in
+    tests/fm-test-run.test.sh)
+      printf '%s\n' pure-contract-unit
+      ;;
+    tests/*.test.sh)
+      # A single test file change selects only that script via basename family
+      # resolution in the caller; emit a marker family of __script__
+      printf '%s\n' "__script__:$(basename "$path")"
+      ;;
+    bin/fm-test-run.sh)
+      printf '%s\n' pure-contract-unit
+      ;;
+    bin/backends/herdr*|bin/fm-herdr-lab.sh|tests/herdr-test-safety.sh)
+      printf '%s\n' real-herdr-gated
+      printf '%s\n' backend-dispatch
+      printf '%s\n' pure-contract-unit
+      ;;
+    bin/backends/zellij*|tests/zellij-test-safety.sh)
+      printf '%s\n' zellij
+      printf '%s\n' backend-dispatch
+      ;;
+    bin/backends/cmux*|tests/cmux-test-safety.sh)
+      printf '%s\n' cmux
+      printf '%s\n' backend-dispatch
+      ;;
+    bin/backends/orca*|bin/backends/tmux.sh)
+      printf '%s\n' backend-dispatch
+      printf '%s\n' orca
+      ;;
+    bin/fm-backend.sh|bin/fm-backend-hometag-lib.sh)
+      printf '%s\n' backend-dispatch
+      printf '%s\n' real-herdr-gated
+      ;;
+    bin/fm-watch*|bin/fm-wake*|\
+    bin/fm-classify-lib.sh|bin/fm-daemon*|bin/fm-turnend-guard*|bin/fm-guard.sh)
+      printf '%s\n' watcher-wake-lock
+      ;;
+    bin/fm-afk*)
+      printf '%s\n' afk
+      printf '%s\n' real-herdr-gated
+      ;;
+    bin/fm-secondmate*|bin/fm-home-seed.sh|bin/fm-backlog-handoff.sh|\
+    bin/fm-config-inherit-lib.sh|bin/fm-config-push.sh|bin/fm-shared*)
+      printf '%s\n' secondmate
+      ;;
+    bin/fm-session-start.sh|bin/fm-bootstrap.sh|bin/fm-fleet-sync.sh|\
+    bin/fm-sessionstart-nudge.sh|bin/fm-tangle*|bin/fm-update.sh|\
+    bin/fm-gate-refuse*|bin/fm-lock*)
+      printf '%s\n' session-bootstrap
+      ;;
+    bin/fm-pr-*|bin/fm-merge-local.sh|bin/fm-teardown.sh|bin/fm-review-diff.sh|\
+    bin/fm-x-*|bin/fm-check*)
+      printf '%s\n' pr-forge
+      ;;
+    bin/fm-spawn.sh|bin/fm-send.sh|bin/fm-dispatch-select.sh|bin/fm-harness.sh|\
+    bin/fm-peek.sh|bin/fm-composer*)
+      printf '%s\n' backend-dispatch
+      printf '%s\n' pure-contract-unit
+      ;;
+    bin/fm-bearings-snapshot.sh|bin/fm-fleet-snapshot.sh|bin/fm-fleet-view.sh)
+      printf '%s\n' snapshot-bearings
+      ;;
+    bin/fm-lint.sh|bin/fm-install-shellcheck.sh|\
+    bin/fm-brief.sh|bin/fm-ensure-agents-md.sh|bin/fm-crew-state.sh|\
+    bin/fm-decision-hold.sh|bin/fm-supervision*|bin/fm-transition-lib.sh|\
+    bin/fm-tmux-lib.sh|bin/fm-marker-lib.sh|bin/fm-tasks-axi-lib.sh|\
+    bin/fm-primary-scope-lib.sh|bin/fm-project-mode.sh|bin/fm-promote.sh|\
+    bin/fm-ff-lib.sh|bin/fm-gotmp*|bin/*pretool*)
+      printf '%s\n' pure-contract-unit
+      ;;
+    .github/workflows/ci.yml|.no-mistakes.yaml)
+      printf '%s\n' pure-contract-unit
+      ;;
+    tests/lib.sh|tests/*-helpers.sh)
+      # Shared test helpers can affect many families; pick a broad but still
+      # non-complete set of high-churn families rather than --all.
+      printf '%s\n' pure-contract-unit
+      printf '%s\n' watcher-wake-lock
+      printf '%s\n' session-bootstrap
+      printf '%s\n' backend-dispatch
+      ;;
+    *)
+      # No mapping: select nothing for this path (conservative non-expansion).
+      ;;
+  esac
+}
+
+select_changed() {
+  local base=$1 path entry fam script_name s
+  local -a wanted_families=()
+  local -a wanted_scripts=()
+
+  if ! git -C "$ROOT" rev-parse --verify "$base" >/dev/null 2>&1; then
+    die "changed-file base ref not found: $base (pass --base <ref>)"
+  fi
+
+  while IFS= read -r path; do
+    [ -n "$path" ] || continue
+    while IFS= read -r entry; do
+      [ -n "$entry" ] || continue
+      case "$entry" in
+        __script__:*)
+          script_name=${entry#__script__:}
+          wanted_scripts+=("$script_name")
+          ;;
+        *)
+          wanted_families+=("$entry")
+          ;;
+      esac
+    done < <(families_for_changed_path "$path")
+  done < <(git -C "$ROOT" diff --name-only "${base}...HEAD" 2>/dev/null; \
+           git -C "$ROOT" diff --name-only HEAD 2>/dev/null; \
+           git -C "$ROOT" ls-files --others --exclude-standard 2>/dev/null)
+
+  # Dedup families
+  local f seen_f
+  local -a unique_families=()
+  for f in "${wanted_families[@]+"${wanted_families[@]}"}"; do
+    seen_f=0
+    for u in "${unique_families[@]+"${unique_families[@]}"}"; do
+      [ "$u" = "$f" ] && { seen_f=1; break; }
+    done
+    [ "$seen_f" -eq 0 ] && unique_families+=("$f")
+  done
+
+  for f in "${unique_families[@]+"${unique_families[@]}"}"; do
+    while IFS= read -r s; do
+      [ -n "$s" ] || continue
+      if [ "$(family_for_basename "$(basename "$s")")" = "$f" ]; then
+        add_script "$s"
+      fi
+    done < <(all_repo_tests)
+  done
+
+  for script_name in "${wanted_scripts[@]+"${wanted_scripts[@]}"}"; do
+    if [ -f "tests/$script_name" ]; then
+      add_script "tests/$script_name"
+    fi
+  done
+
+  if [ "${#SCRIPTS[@]}" -eq 0 ]; then
+    log "no tests selected for changes vs $base (map is conservative; use --all for the complete suite)"
+  fi
+}
+
+detect_gate_skip() {
+  # True when the first non-empty output line is a skip: gate message.
+  local file=$1 first
+  first=$(awk 'NF { print; exit }' "$file" 2>/dev/null || true)
+  case "$first" in
+    skip:*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+write_json_artifact() {
+  local out=$1
+  local started=$2
+  local finished=$3
+  local run_id=$4
+  local total=$5
+  local failed=$6
+  local skipped=$7
+  local duration=$8
+  local selection=$9
+  local records_file=${10}
+  local families_file=${11}
+
+  if ! command -v python3 >/dev/null 2>&1; then
+    die "--json requires python3 to emit a valid timing artifact"
+  fi
+
+  python3 - "$out" "$started" "$finished" "$run_id" "$total" "$failed" "$skipped" "$duration" "$selection" "$records_file" "$families_file" <<'PY'
+import json, sys
+
+out, started, finished, run_id, total, failed, skipped, duration, selection, records_file, families_file = sys.argv[1:]
+
+scripts = []
+with open(records_file, encoding="utf-8") as fh:
+    for line in fh:
+        line = line.rstrip("\n")
+        if not line:
+            continue
+        path, family, expected, exit_s, dur_s, gate = line.split("\t")
+        scripts.append({
+            "path": path,
+            "family": family,
+            "expected_gate_skip": expected,
+            "duration_ms": int(dur_s),
+            "exit": int(exit_s),
+            "gate_skip": gate == "true",
+        })
+
+families = []
+with open(families_file, encoding="utf-8") as fh:
+    for line in fh:
+        line = line.rstrip("\n")
+        if not line:
+            continue
+        name, count_s, dur_s, failed_s = line.split("\t")
+        families.append({
+            "name": name,
+            "count": int(count_s),
+            "duration_ms": int(dur_s),
+            "failed": int(failed_s),
+        })
+
+doc = {
+    "run_id": run_id,
+    "started_at": started,
+    "finished_at": finished,
+    "selection": selection,
+    "summary": {
+        "total": int(total),
+        "failed": int(failed),
+        "skipped_gate": int(skipped),
+        "duration_ms": int(duration),
+    },
+    "scripts": scripts,
+    "families": families,
+}
+with open(out, "w", encoding="utf-8") as fh:
+    json.dump(doc, fh, indent=2, sort_keys=True)
+    fh.write("\n")
+PY
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --all)
+      [ -z "$MODE" ] || die "only one selection mode is allowed"
+      MODE=all
+      shift
+      ;;
+    --family)
+      [ -z "$MODE" ] || die "only one selection mode is allowed"
+      [ "$#" -gt 1 ] || die "--family requires a name"
+      MODE=family
+      FAMILY=$2
+      shift 2
+      ;;
+    --family=*)
+      [ -z "$MODE" ] || die "only one selection mode is allowed"
+      MODE=family
+      FAMILY=${1#--family=}
+      shift
+      ;;
+    --changed)
+      [ -z "$MODE" ] || die "only one selection mode is allowed"
+      MODE=changed
+      shift
+      ;;
+    --base)
+      [ "$#" -gt 1 ] || die "--base requires a git ref"
+      BASE_REF=$2
+      shift 2
+      ;;
+    --base=*)
+      BASE_REF=${1#--base=}
+      shift
+      ;;
+    --json)
+      [ "$#" -gt 1 ] || die "--json requires a path"
+      JSON_PATH=$2
+      shift 2
+      ;;
+    --json=*)
+      JSON_PATH=${1#--json=}
+      shift
+      ;;
+    --list)
+      LIST_ONLY=1
+      shift
+      ;;
+    --list-families)
+      LIST_FAMILIES=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      while [ "$#" -gt 0 ]; do
+        SCRIPTS+=("$1")
+        shift
+      done
+      ;;
+    -*)
+      die "unknown option: $1"
+      ;;
+    *)
+      if [ -z "$MODE" ] || [ "$MODE" = scripts ]; then
+        MODE=scripts
+        SCRIPTS+=("$1")
+      else
+        die "script paths cannot be combined with --$MODE"
+      fi
+      shift
+      ;;
+  esac
+done
+
+if [ "$LIST_FAMILIES" -eq 1 ]; then
+  list_known_families
+  exit 0
+fi
+
+case "${MODE:-}" in
+  all)
+    select_all
+    SELECTION_DESC="all"
+    ;;
+  family)
+    select_family "$FAMILY"
+    SELECTION_DESC="family=$FAMILY"
+    ;;
+  changed)
+    select_changed "$BASE_REF"
+    SELECTION_DESC="changed:base=$BASE_REF"
+    ;;
+  scripts)
+    # Normalize and re-add through add_script for consistent paths.
+    raw=("${SCRIPTS[@]}")
+    SCRIPTS=()
+    for s in "${raw[@]}"; do
+      add_script "$s"
+    done
+    SELECTION_DESC="scripts"
+    ;;
+  *)
+    die "select with --all, --family <name>, --changed, or one or more script paths (see --help)"
+    ;;
+esac
+
+if [ "$LIST_ONLY" -eq 1 ]; then
+  for s in "${SCRIPTS[@]+"${SCRIPTS[@]}"}"; do
+    printf '%s\n' "$s"
+  done
+  exit 0
+fi
+
+if [ "${#SCRIPTS[@]}" -eq 0 ]; then
+  log "nothing to run"
+  if [ -n "$JSON_PATH" ]; then
+    empty_rec=$(mktemp)
+    empty_fam=$(mktemp)
+    : >"$empty_rec"
+    : >"$empty_fam"
+    started=$(now_iso)
+    write_json_artifact "$JSON_PATH" "$started" "$started" "empty" 0 0 0 0 "$SELECTION_DESC" "$empty_rec" "$empty_fam"
+    rm -f "$empty_rec" "$empty_fam"
+  fi
+  exit 0
+fi
+
+# Verify selected scripts exist before starting.
+for s in "${SCRIPTS[@]}"; do
+  [ -f "$s" ] || die "test script not found: $s"
+  [ -x "$s" ] || [ -r "$s" ] || die "test script not readable: $s"
+done
+
+RUN_TMP=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run.XXXXXX")
+RECORDS="$RUN_TMP/records.tsv"
+FAMILIES_TSV="$RUN_TMP/families.tsv"
+: >"$RECORDS"
+trap 'rm -rf "$RUN_TMP"' EXIT
+
+RUN_STARTED_ISO=$(now_iso)
+RUN_STARTED_MS=$(now_ms)
+RUN_ID="fm-test-run-${RUN_STARTED_MS}-$$"
+TOTAL=0
+FAILED=0
+SKIPPED_GATE=0
+AGG_RC=0
+
+# Family accumulators as TSV lines updated in-memory via temp files.
+# family -> count, duration_ms, failed
+family_bump() {
+  local fam=$1 dur=$2 failed_delta=$3
+  local line name count duration failed_count rest
+  local found=0
+  local tmp="$RUN_TMP/families.new"
+  : >"$tmp"
+  if [ -s "$FAMILIES_TSV" ]; then
+    while IFS= read -r line; do
+      name=${line%%$'\t'*}
+      rest=${line#*$'\t'}
+      count=${rest%%$'\t'*}
+      rest=${rest#*$'\t'}
+      duration=${rest%%$'\t'*}
+      failed_count=${rest#*$'\t'}
+      if [ "$name" = "$fam" ]; then
+        count=$((count + 1))
+        duration=$((duration + dur))
+        failed_count=$((failed_count + failed_delta))
+        found=1
+      fi
+      printf '%s\t%s\t%s\t%s\n' "$name" "$count" "$duration" "$failed_count" >>"$tmp"
+    done <"$FAMILIES_TSV"
+  fi
+  if [ "$found" -eq 0 ]; then
+    printf '%s\t%s\t%s\t%s\n' "$fam" 1 "$dur" "$failed_delta" >>"$tmp"
+  fi
+  mv "$tmp" "$FAMILIES_TSV"
+}
+
+for script in "${SCRIPTS[@]}"; do
+  base=$(basename "$script")
+  family=$(family_for_basename "$base")
+  expected=$(expected_gate_skip_for_family "$family")
+  out="$RUN_TMP/out.$TOTAL"
+  begin_iso=$(now_iso)
+  begin_ms=$(now_ms)
+
+  printf 'FM_TEST_BEGIN %s %s family=%s expected_gate_skip=%s\n' \
+    "$begin_iso" "$script" "$family" "$expected"
+
+  set +e
+  # Stream live output while retaining a copy for gate-skip detection.
+  # PIPESTATUS[0] is the test script; tee's exit is ignored for aggregate.
+  bash "$script" 2>&1 | tee "$out"
+  rc=${PIPESTATUS[0]}
+  set -e
+  : "${rc:=1}"
+
+  end_ms=$(now_ms)
+  end_iso=$(now_iso)
+  duration=$((end_ms - begin_ms))
+  if [ "$duration" -lt 0 ]; then
+    duration=0
+  fi
+
+  gate_skip=false
+  if [ "$rc" -eq 0 ] && detect_gate_skip "$out"; then
+    gate_skip=true
+    SKIPPED_GATE=$((SKIPPED_GATE + 1))
+  fi
+
+  printf 'FM_TEST_END %s %s exit=%s duration_ms=%s gate_skip=%s\n' \
+    "$end_iso" "$script" "$rc" "$duration" "$gate_skip"
+
+  fail_delta=0
+  if [ "$rc" -ne 0 ]; then
+    FAILED=$((FAILED + 1))
+    fail_delta=1
+    AGG_RC=1
+  fi
+
+  printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
+    "$script" "$family" "$expected" "$rc" "$duration" "$gate_skip" >>"$RECORDS"
+  family_bump "$family" "$duration" "$fail_delta"
+  TOTAL=$((TOTAL + 1))
+done
+
+RUN_FINISHED_ISO=$(now_iso)
+RUN_FINISHED_MS=$(now_ms)
+RUN_DURATION=$((RUN_FINISHED_MS - RUN_STARTED_MS))
+if [ "$RUN_DURATION" -lt 0 ]; then
+  RUN_DURATION=0
+fi
+
+printf 'FM_TEST_SUMMARY total=%s failed=%s skipped_gate=%s duration_ms=%s\n' \
+  "$TOTAL" "$FAILED" "$SKIPPED_GATE" "$RUN_DURATION"
+
+if [ -s "$FAMILIES_TSV" ]; then
+  # Stable family summary order by name.
+  sort -t$'\t' -k1,1 "$FAMILIES_TSV" | while IFS=$'\t' read -r name count duration failed_count; do
+    printf 'FM_TEST_SUMMARY_FAMILY family=%s count=%s duration_ms=%s failed=%s\n' \
+      "$name" "$count" "$duration" "$failed_count"
+  done
+fi
+
+# Slowest scripts (top 15) from records.
+if [ -s "$RECORDS" ]; then
+  rank=1
+  sort -t$'\t' -k5,5nr "$RECORDS" | head -n 15 | while IFS=$'\t' read -r path _family _expected _rc duration _gate; do
+    printf 'FM_TEST_SLOWEST rank=%s script=%s duration_ms=%s\n' \
+      "$rank" "$path" "$duration"
+    rank=$((rank + 1))
+  done
+fi
+
+if [ -n "$JSON_PATH" ]; then
+  mkdir -p "$(dirname "$JSON_PATH")"
+  # Families file may be unsorted; write_json reads as-is (deterministic sort in python).
+  if [ -s "$FAMILIES_TSV" ]; then
+    sort -t$'\t' -k1,1 "$FAMILIES_TSV" -o "$FAMILIES_TSV"
+  else
+    : >"$FAMILIES_TSV"
+  fi
+  write_json_artifact "$JSON_PATH" \
+    "$RUN_STARTED_ISO" "$RUN_FINISHED_ISO" "$RUN_ID" \
+    "$TOTAL" "$FAILED" "$SKIPPED_GATE" "$RUN_DURATION" \
+    "$SELECTION_DESC" "$RECORDS" "$FAMILIES_TSV"
+  log "wrote timing artifact: $JSON_PATH"
+fi
+
+exit "$AGG_RC"

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -347,6 +347,10 @@ families_for_changed_path() {
     .github/workflows/ci.yml|.no-mistakes.yaml)
       printf '%s\n' pure-contract-unit
       ;;
+    .github/*|.tasks.toml|AGENTS.md|CLAUDE.md|CONTRIBUTING.md|\
+    docs/configuration.md|docs/supervision-protocols/*)
+      printf '%s\n' pure-contract-unit
+      ;;
     tests/lib.sh|tests/*-helpers.sh)
       families_for_test_reference "$(basename "$path")" \
         || printf '%s\n' "__unmapped__:$path"
@@ -358,8 +362,11 @@ families_for_changed_path() {
     tests/*)
       printf '%s\n' "__unmapped__:$path"
       ;;
+    README.md|LICENSE|assets/*|docs/*|.gitignore)
+      ;;
     *)
-      # No mapping: select nothing for this path (conservative non-expansion).
+      families_for_test_reference "$path" \
+        || printf '%s\n' "__unmapped__:$path"
       ;;
   esac
 }

--- a/docs/arm-pretool-check.md
+++ b/docs/arm-pretool-check.md
@@ -250,5 +250,5 @@ bash -n bin/fm-arm-pretool-check.sh
 shellcheck bin/fm-arm-pretool-check.sh tests/fm-arm-pretool-check.test.sh
 node --check bin/fm-arm-command-policy.mjs
 tests/fm-arm-pretool-check.test.sh
-for test_script in tests/*.test.sh; do bash "$test_script"; done
+bin/fm-test-run.sh --all
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -109,7 +109,8 @@ See [`wedge-alarm.md`](wedge-alarm.md) for the channel reference and macOS verif
 The tracked `.no-mistakes.yaml` keeps test evidence outside the repo and pins `commands.lint` to `bin/fm-lint.sh` so local lint matches CI.
 That evidence policy is specific to the firstmate repo: target projects may legitimately commit `.no-mistakes/evidence/` from their own no-mistakes pipeline, but firstmate keeps `.no-mistakes/` local and CI rejects tracked entries under that path.
 It does not set `commands.test` to a complete `tests/*.test.sh` walk.
-Local no-mistakes Test stays intent-targeted; broad regression (including the portable behavior suite) lives in [`.github/workflows/ci.yml`](../.github/workflows/ci.yml).
+Local no-mistakes Test stays intent-targeted; broad regression (including the portable behavior suite) lives in [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) via `bin/fm-test-run.sh --all`.
+See [CONTRIBUTING.md](../CONTRIBUTING.md) for one-script, family, changed-file, and intentional complete-suite entry points.
 
 ## Captain Preferences (data/captain.md / data/captain-shared.md)
 

--- a/tests/fm-nm-test-contract.test.sh
+++ b/tests/fm-nm-test-contract.test.sh
@@ -3,7 +3,8 @@
 #
 # Firstmate must not configure commands.test as a complete tests/*.test.sh walk
 # (that duplicated CI and burned local pipeline time). Lint stays pinned to
-# bin/fm-lint.sh. Remote CI Behavior must keep iterating every tests/*.test.sh.
+# bin/fm-lint.sh. Remote CI Behavior must keep running the complete portable
+# suite through bin/fm-test-run.sh --all (exact tests/*.test.sh coverage).
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -94,11 +95,13 @@ test_nm_has_no_complete_local_test_command() {
 
 test_ci_still_runs_broad_behavior_suite() {
   assert_present "$CI" "ci.yml is missing"
-  # Behavior job still iterates every portable behavior script.
-  grep -Fq 'for test_script in tests/*.test.sh' "$CI" \
-    || fail "CI Behavior job must still loop over tests/*.test.sh"
-  grep -Fq "\"\$test_script\"" "$CI" \
-    || fail "CI Behavior job must still execute each tests/*.test.sh script"
+  # Behavior job still runs every portable behavior script via the one owner.
+  grep -Fq 'bin/fm-test-run.sh --all' "$CI" \
+    || fail "CI Behavior job must invoke bin/fm-test-run.sh --all"
+  # Guard against regression to an uninstrumented inline loop that drops timing.
+  if grep -Eq 'for test_script in tests/\*\.test\.sh' "$CI"; then
+    fail "CI Behavior must not re-spell an inline tests/*.test.sh loop; use fm-test-run.sh"
+  fi
   # Preserve other CI lanes this task must not shrink.
   grep -Eq 'name:[[:space:]]*Lint shell scripts' "$CI" \
     || fail "CI must retain the lint job"

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -96,6 +96,8 @@ init_changed_fixture_repo() {
   chmod +x "$repo/bin/fm-test-run.sh"
   for script in \
     fm-brief.test.sh \
+    fm-captain-translation-contract.test.sh \
+    fm-cd-pretool-check.test.sh \
     fm-daemon.test.sh \
     fm-backend-herdr-smoke.test.sh \
     fm-secondmate-safety.test.sh \
@@ -103,6 +105,7 @@ init_changed_fixture_repo() {
     fm-afk-pi-herdr-return-e2e.test.sh \
     fm-backend.test.sh \
     fm-pr-merge.test.sh \
+    fm-pi-watch-extension.test.sh \
     fm-afk-return.test.sh \
     fm-bearings-snapshot.test.sh \
     fm-backend-cmux.test.sh \
@@ -115,6 +118,16 @@ init_changed_fixture_repo() {
   : >"$repo/tests/fm-backend-herdr-eventwait.test.py"
   : >"$repo/bin/fm-supervisor-target-lib.sh"
   : >"$repo/bin/unmapped-source.sh"
+  printf '# .agents/skills/example/SKILL.md\n' >>"$repo/tests/fm-captain-translation-contract.test.sh"
+  printf '# .claude/settings.json\n# .pi/extensions/fm-primary-turnend-guard.ts\n' \
+    >>"$repo/tests/fm-cd-pretool-check.test.sh"
+  printf '# .pi/extensions/fm-primary-pi-watch.ts\n' >>"$repo/tests/fm-pi-watch-extension.test.sh"
+  mkdir -p "$repo/.agents/skills/example" "$repo/.claude" "$repo/.pi/extensions" "$repo/src"
+  : >"$repo/.agents/skills/example/SKILL.md"
+  : >"$repo/.claude/settings.json"
+  : >"$repo/.pi/extensions/fm-primary-pi-watch.ts"
+  : >"$repo/.pi/extensions/fm-primary-turnend-guard.ts"
+  : >"$repo/src/unmapped.ts"
   git -C "$repo" init -q
   git -C "$repo" add .
   git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm baseline
@@ -148,13 +161,24 @@ test_changed_dependency_selection_and_unmapped_failure() {
   git -C "$repo" add bin/fm-supervisor-target-lib.sh
   git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm supervisor-change
 
-  printf '\n' >>"$repo/bin/unmapped-source.sh"
+  printf '\n' >>"$repo/.agents/skills/example/SKILL.md"
+  printf '\n' >>"$repo/.claude/settings.json"
+  printf '\n' >>"$repo/.pi/extensions/fm-primary-pi-watch.ts"
+  printf '\n' >>"$repo/.pi/extensions/fm-primary-turnend-guard.ts"
+  listed=$(cd "$repo" && bin/fm-test-run.sh --list --changed --base HEAD)
+  assert_contains "$listed" "tests/fm-captain-translation-contract.test.sh" "skill source selects contract coverage"
+  assert_contains "$listed" "tests/fm-cd-pretool-check.test.sh" "Claude and Pi source selects hook coverage"
+  assert_contains "$listed" "tests/fm-pi-watch-extension.test.sh" "Pi source selects watcher coverage"
+  git -C "$repo" add .agents .claude .pi
+  git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm non-bin-source-change
+
+  printf '\n' >>"$repo/src/unmapped.ts"
   set +e
   (cd "$repo" && bin/fm-test-run.sh --list --changed --base HEAD) >"$tmp/out" 2>"$tmp/err"
   rc=$?
   set -e
   [ "$rc" -eq 2 ] || fail "unmapped changed source must fail with exit 2, got $rc"
-  grep -Fq 'no changed-test mapping for source path: bin/unmapped-source.sh' "$tmp/err" \
+  grep -Fq 'no changed-test mapping for source path: src/unmapped.ts' "$tmp/err" \
     || fail "unmapped changed source failure is not actionable: $(cat "$tmp/err")"
   rm -rf "$tmp"
   pass "changed selection covers dependents and fails closed for unmapped source"

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -89,6 +89,99 @@ test_changed_file_selection_is_conservative() {
   pass "changed-file selection stays conservative (never silent full suite)"
 }
 
+init_changed_fixture_repo() {
+  local repo=$1 script
+  mkdir -p "$repo/bin" "$repo/tests"
+  cp "$RUNNER" "$repo/bin/fm-test-run.sh"
+  chmod +x "$repo/bin/fm-test-run.sh"
+  for script in \
+    fm-brief.test.sh \
+    fm-daemon.test.sh \
+    fm-backend-herdr-smoke.test.sh \
+    fm-secondmate-safety.test.sh \
+    fm-session-start.test.sh \
+    fm-afk-pi-herdr-return-e2e.test.sh \
+    fm-backend.test.sh \
+    fm-pr-merge.test.sh \
+    fm-afk-return.test.sh \
+    fm-bearings-snapshot.test.sh \
+    fm-backend-cmux.test.sh \
+    fm-backend-zellij.test.sh \
+    fm-backend-orca.test.sh; do
+    printf '#!/usr/bin/env bash\n# tests/lib.sh\n' >"$repo/tests/$script"
+    chmod +x "$repo/tests/$script"
+  done
+  : >"$repo/tests/lib.sh"
+  : >"$repo/tests/fm-backend-herdr-eventwait.test.py"
+  : >"$repo/bin/fm-supervisor-target-lib.sh"
+  : >"$repo/bin/unmapped-source.sh"
+  git -C "$repo" init -q
+  git -C "$repo" add .
+  git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm baseline
+}
+
+test_changed_dependency_selection_and_unmapped_failure() {
+  local tmp repo listed rc
+  tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-changed.XXXXXX")
+  repo="$tmp/repo"
+  init_changed_fixture_repo "$repo"
+
+  printf '\n' >>"$repo/tests/lib.sh"
+  listed=$(cd "$repo" && bin/fm-test-run.sh --list --changed --base HEAD)
+  assert_contains "$listed" "tests/fm-pr-merge.test.sh" "shared helper selects pr-forge dependents"
+  assert_contains "$listed" "tests/fm-secondmate-safety.test.sh" "shared helper selects secondmate dependents"
+  assert_contains "$listed" "tests/fm-bearings-snapshot.test.sh" "shared helper selects snapshot dependents"
+  git -C "$repo" add tests/lib.sh
+  git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm helper-change
+
+  printf '\n' >>"$repo/tests/fm-backend-herdr-eventwait.test.py"
+  listed=$(cd "$repo" && bin/fm-test-run.sh --list --changed --base HEAD)
+  assert_contains "$listed" "tests/fm-backend-herdr-smoke.test.sh" "eventwait test selects Herdr coverage"
+  assert_contains "$listed" "tests/fm-backend.test.sh" "eventwait test selects backend coverage"
+  git -C "$repo" add tests/fm-backend-herdr-eventwait.test.py
+  git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm eventwait-change
+
+  printf '\n' >>"$repo/bin/fm-supervisor-target-lib.sh"
+  listed=$(cd "$repo" && bin/fm-test-run.sh --list --changed --base HEAD)
+  assert_contains "$listed" "tests/fm-daemon.test.sh" "supervisor target selects daemon coverage"
+  assert_contains "$listed" "tests/fm-afk-return.test.sh" "supervisor target selects afk coverage"
+  git -C "$repo" add bin/fm-supervisor-target-lib.sh
+  git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm supervisor-change
+
+  printf '\n' >>"$repo/bin/unmapped-source.sh"
+  set +e
+  (cd "$repo" && bin/fm-test-run.sh --list --changed --base HEAD) >"$tmp/out" 2>"$tmp/err"
+  rc=$?
+  set -e
+  [ "$rc" -eq 2 ] || fail "unmapped changed source must fail with exit 2, got $rc"
+  grep -Fq 'no changed-test mapping for source path: bin/unmapped-source.sh' "$tmp/err" \
+    || fail "unmapped changed source failure is not actionable: $(cat "$tmp/err")"
+  rm -rf "$tmp"
+  pass "changed selection covers dependents and fails closed for unmapped source"
+}
+
+test_empty_selection_emits_summary() {
+  local tmp repo out json
+  tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-empty.XXXXXX")
+  repo="$tmp/repo"
+  init_changed_fixture_repo "$repo"
+  printf 'documentation only\n' >"$repo/README.md"
+  out=$(cd "$repo" && bin/fm-test-run.sh --changed --base HEAD --json "$tmp/artifacts/timing.json" 2>"$tmp/err") \
+    || fail "empty valid changed selection must pass"
+  [ "$out" = "FM_TEST_SUMMARY total=0 failed=0 skipped_gate=0 duration_ms=0" ] \
+    || fail "empty selection summary is missing or non-deterministic: $out"
+  json="$tmp/artifacts/timing.json"
+  python3 -c '
+import json, sys
+doc = json.load(open(sys.argv[1]))
+assert doc["summary"] == {"duration_ms": 0, "failed": 0, "skipped_gate": 0, "total": 0}
+assert doc["scripts"] == []
+assert doc["families"] == []
+' "$json" || { rm -rf "$tmp"; fail "empty selection JSON summary is wrong"; }
+  rm -rf "$tmp"
+  pass "empty changed selection emits deterministic text and JSON summaries"
+}
+
 test_timing_markers_and_json() {
   local tmp fixture out json begin_n end_n summary
   tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-timing.XXXXXX")
@@ -227,6 +320,8 @@ test_list_all_exact_suite_coverage
 test_family_selection
 test_single_script_selection
 test_changed_file_selection_is_conservative
+test_changed_dependency_selection_and_unmapped_failure
+test_empty_selection_emits_summary
 test_timing_markers_and_json
 test_aggregate_exit_behavior
 test_gate_skip_accounting

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+# Contract tests for bin/fm-test-run.sh - the single owner of serial behavior
+# suite selection, timing markers, JSON artifacts, and aggregate exit status.
+#
+# These tests intentionally exercise the runner with fixtures and --list, not
+# the complete Firstmate suite.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+RUNNER="$ROOT/bin/fm-test-run.sh"
+CI="$ROOT/.github/workflows/ci.yml"
+CONTRIB="$ROOT/CONTRIBUTING.md"
+
+assert_present "$RUNNER" "bin/fm-test-run.sh is missing"
+[ -x "$RUNNER" ] || fail "bin/fm-test-run.sh must be executable"
+
+test_list_all_exact_suite_coverage() {
+  local listed expected missing extra f
+  listed=$("$RUNNER" --list --all | LC_ALL=C sort)
+  expected=$(
+    for f in "$ROOT"/tests/*.test.sh; do
+      [ -f "$f" ] || continue
+      printf 'tests/%s\n' "$(basename "$f")"
+    done | LC_ALL=C sort
+  )
+  [ -n "$listed" ] || fail "--list --all printed nothing"
+  missing=$(comm -23 <(printf '%s\n' "$expected") <(printf '%s\n' "$listed") || true)
+  extra=$(comm -13 <(printf '%s\n' "$expected") <(printf '%s\n' "$listed") || true)
+  [ -z "$missing" ] || fail "--list --all missing scripts: $missing"
+  [ -z "$extra" ] || fail "--list --all unexpected scripts: $extra"
+  # No duplicates.
+  [ "$(printf '%s\n' "$listed" | uniq | wc -l | tr -d ' ')" = \
+    "$(printf '%s\n' "$listed" | wc -l | tr -d ' ')" ] \
+    || fail "--list --all must not duplicate scripts"
+  pass "exact suite coverage: --all lists every tests/*.test.sh once"
+}
+
+test_family_selection() {
+  local listed line
+  listed=$("$RUNNER" --list --family pure-contract-unit)
+  [ -n "$listed" ] || fail "--family pure-contract-unit selected nothing"
+  printf '%s\n' "$listed" | grep -Fq 'tests/fm-test-run.test.sh' \
+    || fail "pure-contract-unit must include fm-test-run.test.sh"
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    case "$line" in
+      tests/*.test.sh) ;;
+      *) fail "family selection produced non-test path: $line" ;;
+    esac
+  done <<<"$listed"
+  # Family mode must not equal the complete suite for a narrow family.
+  local all_count fam_count
+  all_count=$("$RUNNER" --list --all | wc -l | tr -d ' ')
+  fam_count=$(printf '%s\n' "$listed" | wc -l | tr -d ' ')
+  [ "$fam_count" -lt "$all_count" ] \
+    || fail "pure-contract-unit must be a proper subset of --all"
+  pass "family selection returns a proper subset of the suite"
+}
+
+test_single_script_selection() {
+  local listed
+  listed=$("$RUNNER" --list tests/fm-lint.test.sh)
+  [ "$listed" = "tests/fm-lint.test.sh" ] \
+    || fail "single-script list expected tests/fm-lint.test.sh, got: $listed"
+  pass "single-script selection lists exactly that path"
+}
+
+test_changed_file_selection_is_conservative() {
+  local listed all_count fam_count listed_count
+  # A path-mapped pure unit should not expand to --all.
+  listed=$("$RUNNER" --list --family pure-contract-unit)
+  all_count=$("$RUNNER" --list --all | wc -l | tr -d ' ')
+  fam_count=$(printf '%s\n' "$listed" | wc -l | tr -d ' ')
+  [ "$fam_count" -lt "$all_count" ] || fail "changed-informed pure family still full suite"
+  # Directly exercise --changed: empty or partial selection is ok; must not
+  # exceed the suite and must never silently become --all by accident.
+  listed=$("$RUNNER" --list --changed --base HEAD 2>/dev/null || true)
+  if [ -n "$listed" ]; then
+    listed_count=$(printf '%s\n' "$listed" | wc -l | tr -d ' ')
+    [ "$listed_count" -le "$all_count" ] || fail "changed selection larger than suite"
+  fi
+  # A single test path selects only that script (same contract as a
+  # tests/*.test.sh change entry in the map).
+  listed=$("$RUNNER" --list tests/fm-brief.test.sh)
+  [ "$listed" = "tests/fm-brief.test.sh" ] \
+    || fail "test-file-only change contract should select one script"
+  pass "changed-file selection stays conservative (never silent full suite)"
+}
+
+test_timing_markers_and_json() {
+  local tmp fixture out json begin_n end_n summary
+  tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-timing.XXXXXX")
+  fixture="$tmp/ok.test.sh"
+  out="$tmp/out.txt"
+  json="$tmp/timing.json"
+  cat >"$fixture" <<'SH'
+#!/usr/bin/env bash
+echo "ok - fixture"
+exit 0
+SH
+  chmod +x "$fixture"
+  "$RUNNER" --json "$json" "$fixture" >"$out" 2>"$tmp/err.txt" \
+    || { rm -rf "$tmp"; fail "runner should pass on a green fixture"; }
+  begin_n=$(grep -c '^FM_TEST_BEGIN ' "$out" || true)
+  end_n=$(grep -c '^FM_TEST_END ' "$out" || true)
+  [ "$begin_n" -eq 1 ] || fail "expected one FM_TEST_BEGIN, got $begin_n"
+  [ "$end_n" -eq 1 ] || fail "expected one FM_TEST_END, got $end_n"
+  grep -Eq '^FM_TEST_BEGIN .+ family=unclassified expected_gate_skip=none$' "$out" \
+    || fail "BEGIN line missing family/expected_gate_skip: $(grep '^FM_TEST_BEGIN' "$out")"
+  grep -Eq '^FM_TEST_END .+ exit=0 duration_ms=[0-9]+ gate_skip=false$' "$out" \
+    || fail "END line missing exit/duration/gate_skip: $(grep '^FM_TEST_END' "$out")"
+  summary=$(grep '^FM_TEST_SUMMARY ' "$out" || true)
+  assert_contains "$summary" "total=1" "summary total"
+  assert_contains "$summary" "failed=0" "summary failed"
+  assert_contains "$summary" "skipped_gate=0" "summary skipped_gate"
+  grep -q '^FM_TEST_SLOWEST rank=1 ' "$out" \
+    || fail "expected FM_TEST_SLOWEST rank=1"
+  [ -f "$json" ] || fail "JSON timing artifact was not written"
+  python3 -c 'import json,sys; json.load(open(sys.argv[1]))' "$json" \
+    || fail "JSON timing artifact is not valid JSON"
+  python3 -c '
+import json, sys
+doc = json.load(open(sys.argv[1]))
+assert "scripts" in doc and len(doc["scripts"]) == 1, doc
+assert doc["scripts"][0]["exit"] == 0
+assert doc["scripts"][0]["gate_skip"] is False
+assert doc["summary"]["total"] == 1
+assert doc["summary"]["failed"] == 0
+assert "duration_ms" in doc["scripts"][0]
+assert "family" in doc["scripts"][0]
+' "$json" || { rm -rf "$tmp"; fail "JSON timing artifact missing required fields"; }
+  rm -rf "$tmp"
+  pass "timing markers and JSON artifact are valid"
+}
+
+test_aggregate_exit_behavior() {
+  local tmp pass_f fail_f rc
+  tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-agg.XXXXXX")
+  pass_f="$tmp/pass.test.sh"
+  fail_f="$tmp/fail.test.sh"
+  cat >"$pass_f" <<'SH'
+#!/usr/bin/env bash
+echo "ok - pass"
+exit 0
+SH
+  cat >"$fail_f" <<'SH'
+#!/usr/bin/env bash
+echo "not ok - fail"
+exit 1
+SH
+  chmod +x "$pass_f" "$fail_f"
+  set +e
+  "$RUNNER" "$pass_f" "$fail_f" >"$tmp/out.txt" 2>"$tmp/err.txt"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "aggregate exit must be non-zero when any script fails"
+  grep -q 'FM_TEST_SUMMARY total=2 failed=1' "$tmp/out.txt" \
+    || fail "summary should report total=2 failed=1: $(grep FM_TEST_SUMMARY "$tmp/out.txt")"
+  # All-green stays 0.
+  set +e
+  "$RUNNER" "$pass_f" >"$tmp/out2.txt" 2>"$tmp/err2.txt"
+  rc=$?
+  set -e
+  [ "$rc" -eq 0 ] || { rm -rf "$tmp"; fail "aggregate exit must be 0 when every script passes"; }
+  rm -rf "$tmp"
+  pass "aggregate exit reflects any script failure"
+}
+
+test_gate_skip_accounting() {
+  local tmp skip_f out json
+  tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-skip.XXXXXX")
+  skip_f="$tmp/skip.test.sh"
+  out="$tmp/out.txt"
+  json="$tmp/timing.json"
+  cat >"$skip_f" <<'SH'
+#!/usr/bin/env bash
+echo "skip: herdr not found"
+exit 0
+SH
+  chmod +x "$skip_f"
+  "$RUNNER" --json "$json" "$skip_f" >"$out" 2>"$tmp/err.txt" \
+    || fail "gate-skip fixture must exit 0 from the runner"
+  grep -Eq '^FM_TEST_END .+ exit=0 duration_ms=[0-9]+ gate_skip=true$' "$out" \
+    || fail "END must mark gate_skip=true: $(grep '^FM_TEST_END' "$out")"
+  grep -q 'FM_TEST_SUMMARY total=1 failed=0 skipped_gate=1' "$out" \
+    || fail "summary must count skipped_gate=1: $(grep FM_TEST_SUMMARY "$out")"
+  python3 -c '
+import json, sys
+doc = json.load(open(sys.argv[1]))
+assert doc["scripts"][0]["gate_skip"] is True
+assert doc["summary"]["skipped_gate"] == 1
+assert doc["summary"]["failed"] == 0
+' "$json" || { rm -rf "$tmp"; fail "JSON gate_skip accounting is wrong"; }
+  rm -rf "$tmp"
+  pass "gate-skip accounting is honest and non-failing"
+}
+
+test_ci_and_docs_call_the_owner() {
+  assert_present "$CI" "ci.yml missing"
+  assert_present "$CONTRIB" "CONTRIBUTING.md missing"
+  grep -Fq 'bin/fm-test-run.sh --all' "$CI" \
+    || fail "CI Behavior must invoke bin/fm-test-run.sh --all"
+  grep -Fq 'timeout-minutes: 25' "$CI" \
+    || fail "CI Behavior timeout-minutes must be 25 (hang tripwire)"
+  # Stale "~2-3 minutes" claim must not remain.
+  if grep -Eq '2-3 minutes' "$CI"; then
+    fail "CI workflow still claims the suite finishes in ~2-3 minutes"
+  fi
+  grep -Fq 'fm-test-timing' "$CI" \
+    || fail "CI must upload the timing artifact"
+  grep -Fq 'bin/fm-test-run.sh --all' "$CONTRIB" \
+    || fail "CONTRIBUTING must document bin/fm-test-run.sh --all"
+  grep -Fq 'bin/fm-test-run.sh --family' "$CONTRIB" \
+    || fail "CONTRIBUTING must document family selection"
+  grep -Fq 'bin/fm-test-run.sh --changed' "$CONTRIB" \
+    || fail "CONTRIBUTING must document changed-file selection"
+  # Do not restore a complete-suite commands.test.
+  if grep -E '^[[:space:]]*test:[[:space:]].*tests/\*\.test\.sh' "$ROOT/.no-mistakes.yaml" >/dev/null 2>&1; then
+    fail ".no-mistakes.yaml must not set a full-suite commands.test"
+  fi
+  pass "CI and CONTRIBUTING call the one-owner runner; no full-suite local Test"
+}
+
+test_list_all_exact_suite_coverage
+test_family_selection
+test_single_script_selection
+test_changed_file_selection_is_conservative
+test_timing_markers_and_json
+test_aggregate_exit_behavior
+test_gate_skip_accounting
+test_ci_and_docs_call_the_owner


### PR DESCRIPTION
## Intent

Implement Phase 1 of the captain-approved Firstmate test and CI acceleration plan: add one canonical timed test runner (bin/fm-test-run.sh) that replaces duplicated serial tests/*.test.sh loops, supports selecting one script / one family / conservative changed-file set / explicit --all complete suite, stays serial (no sharding, no --jobs), emits machine-parseable begin/end timing plus family/overall/slowest summaries and a deterministic JSON timing artifact, wire Linux Behavior CI through that runner while preserving exact full portable suite coverage and aggregate-fail-if-any-fails semantics, correct the stale ~2-3 minutes CI comment and set interim Behavior timeout-minutes to 25 as a hang tripwire (not expected healthy end), preserve macOS Bash job / lint / invariants / existing assertions, add focused runner contract tests, and update CONTRIBUTING plus authoritative testing docs with the entry points. Explicitly do not restore a complete-suite commands.test (local no-mistakes Test stays intent-targeted after #823), do not run the full suite in local Test, do not add retries/broader skips/weaker timeouts, and do not implement Herdr CI lane or local parallelism.

## What Changed

- Add a canonical serial test runner with script, family, changed-file, and full-suite selection, plus timing summaries and deterministic JSON artifacts.
- Route Linux Behavior CI through the runner, upload timing data, preserve aggregate failure behavior, and set a 25-minute hang timeout.
- Add focused runner contract coverage and document the canonical local and CI test entry points.

## Risk Assessment

✅ Low: The fixups now fail closed for unmapped source changes, preserve intentional documentation-only empty selections, and the cumulative implementation satisfies the stated runner, CI, coverage, summary, and local-Test constraints.

## Testing

Focused Bash and stock macOS Bash contracts passed, including selection modes, conservative changed-file mapping, exact list-only full-suite coverage, CI ownership and timeout assertions, serial timing markers, deterministic JSON structure, gate-skip accounting, and aggregate failure after every selected script ran. Manual CLI evidence captured the actual runner experience; no screenshot was applicable because this is a CLI and CI-only change, and the prohibited local full suite was not run.

<details>
<summary>Evidence: Single-script runner transcript</summary>

```text
FM_TEST_BEGIN 2026-07-22T03:36:51Z tests/fm-nm-test-contract.test.sh family=pure-contract-unit expected_gate_skip=none
ok - .no-mistakes.yaml is present and tracked
ok - commands.lint stays pinned to bin/fm-lint.sh
ok - no-mistakes does not configure a complete local Test command
ok - CI still owns the broad behavior suite and companion jobs
FM_TEST_END 2026-07-22T03:36:51Z tests/fm-nm-test-contract.test.sh exit=0 duration_ms=180 gate_skip=false
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=244
FM_TEST_SUMMARY_FAMILY family=pure-contract-unit count=1 duration_ms=180 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-nm-test-contract.test.sh duration_ms=180
```
</details>
<details>
<summary>Evidence: Single-script timing artifact</summary>

```text
{
  "families": [
    {
      "count": 1,
      "duration_ms": 180,
      "failed": 0,
      "name": "pure-contract-unit"
    }
  ],
  "finished_at": "2026-07-22T03:36:51Z",
  "run_id": "fm-test-run-1784691411321-91913",
  "scripts": [
    {
      "duration_ms": 180,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "pure-contract-unit",
      "gate_skip": false,
      "path": "tests/fm-nm-test-contract.test.sh"
    }
  ],
  "selection": "scripts",
  "started_at": "2026-07-22T03:36:51Z",
  "summary": {
    "duration_ms": 244,
    "failed": 0,
    "skipped_gate": 0,
    "total": 1
  }
}
```
</details>
<details>
<summary>Evidence: Aggregate-failure runner transcript</summary>

```text
FM_TEST_BEGIN 2026-07-22T03:36:51Z /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KY3XM5EYK9Z4J9ENNS4N9X2V/pass.test.sh family=unclassified expected_gate_skip=none
ok - first fixture completed
FM_TEST_END 2026-07-22T03:36:51Z /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KY3XM5EYK9Z4J9ENNS4N9X2V/pass.test.sh exit=0 duration_ms=29 gate_skip=false
FM_TEST_BEGIN 2026-07-22T03:36:51Z /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KY3XM5EYK9Z4J9ENNS4N9X2V/fail.test.sh family=unclassified expected_gate_skip=none
not ok - second fixture failed as intended
FM_TEST_END 2026-07-22T03:36:51Z /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KY3XM5EYK9Z4J9ENNS4N9X2V/fail.test.sh exit=7 duration_ms=31 gate_skip=false
FM_TEST_SUMMARY total=2 failed=1 skipped_gate=0 duration_ms=160
FM_TEST_SUMMARY_FAMILY family=unclassified count=2 duration_ms=60 failed=1
FM_TEST_SLOWEST rank=1 script=/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KY3XM5EYK9Z4J9ENNS4N9X2V/fail.test.sh duration_ms=31
FM_TEST_SLOWEST rank=2 script=/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KY3XM5EYK9Z4J9ENNS4N9X2V/pass.test.sh duration_ms=29
runner_exit=1
```
</details>
<details>
<summary>Evidence: Aggregate-failure timing artifact</summary>

```text
{
  "families": [
    {
      "count": 2,
      "duration_ms": 60,
      "failed": 1,
      "name": "unclassified"
    }
  ],
  "finished_at": "2026-07-22T03:36:51Z",
  "run_id": "fm-test-run-1784691411647-91966",
  "scripts": [
    {
      "duration_ms": 29,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "unclassified",
      "gate_skip": false,
      "path": "/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KY3XM5EYK9Z4J9ENNS4N9X2V/pass.test.sh"
    },
    {
      "duration_ms": 31,
      "exit": 7,
      "expected_gate_skip": "none",
      "family": "unclassified",
      "gate_skip": false,
      "path": "/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KY3XM5EYK9Z4J9ENNS4N9X2V/fail.test.sh"
    }
  ],
  "selection": "scripts",
  "started_at": "2026-07-22T03:36:51Z",
  "summary": {
    "duration_ms": 160,
    "failed": 1,
    "skipped_gate": 0,
    "total": 2
  }
}
```
</details>
<details>
<summary>Evidence: Single, family, changed, and complete-suite list selections</summary>

```text
[single script selection]
tests/fm-nm-test-contract.test.sh
[family selection: pure-contract-unit]
tests/fm-arm-pretool-check.test.sh
tests/fm-brief.test.sh
tests/fm-captain-translation-contract.test.sh
tests/fm-cd-pretool-check.test.sh
tests/fm-composer-ghost.test.sh
tests/fm-composer-lib.test.sh
tests/fm-continuity-pretool-check.test.sh
tests/fm-crew-state.test.sh
tests/fm-decision-hold-lifecycle.test.sh
tests/fm-dispatch-select.test.sh
tests/fm-ensure-agents-md.test.sh
tests/fm-grok-harness.test.sh
tests/fm-herdr-lab.test.sh
tests/fm-instruction-owners.test.sh
tests/fm-lint.test.sh
tests/fm-nm-test-contract.test.sh
tests/fm-no-mistakes-ownership.test.sh
tests/fm-pi-primary-types.test.sh
tests/fm-send-popup-settle.test.sh
tests/fm-send-settle.test.sh
tests/fm-stow-contract.test.sh
tests/fm-supervision-instructions.test.sh
tests/fm-test-run.test.sh
tests/fm-tmux-submit-busy.test.sh
tests/fm-transition-lib.test.sh
[changed selection from supplied base]
tests/fm-arm-pretool-check.test.sh
tests/fm-brief.test.sh
tests/fm-captain-translation-contract.test.sh
tests/fm-cd-pretool-check.test.sh
tests/fm-composer-ghost.test.sh
tests/fm-composer-lib.test.sh
tests/fm-continuity-pretool-check.test.sh
tests/fm-crew-state.test.sh
tests/fm-decision-hold-lifecycle.test.sh
tests/fm-dispatch-select.test.sh
tests/fm-ensure-agents-md.test.sh
tests/fm-grok-harness.test.sh
tests/fm-herdr-lab.test.sh
tests/fm-instruction-owners.test.sh
tests/fm-lint.test.sh
tests/fm-nm-test-contract.test.sh
tests/fm-no-mistakes-ownership.test.sh
tests/fm-pi-primary-types.test.sh
tests/fm-send-popup-settle.test.sh
tests/fm-send-settle.test.sh
tests/fm-stow-contract.test.sh
tests/fm-supervision-instructions.test.sh
tests/fm-test-run.test.sh
tests/fm-tmux-submit-busy.test.sh
tests/fm-transition-lib.test.sh
[complete suite selection: list-only, not executed]
runner_all_count=88 repository_test_count=88 exact_match=true
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (2) ✅</summary>

- 🚨 `bin/fm-test-run.sh:327` - Required intent says `--changed` must provide a &#34;conservative changed-file set&#34;, but this map under-selects known dependencies. For example, `tests/lib.sh` is mapped to only four families even though pr-forge, secondmate, snapshot, and other tests source it; `tests/fm-backend-herdr-eventwait.test.py` and `bin/fm-supervisor-target-lib.sh` fall through to no selection despite feeding existing tests. Expand the map to cover actual dependents or fail explicitly for unmapped test/source files.
- 🚨 `bin/fm-test-run.sh:597` - Required intent says the runner &#34;emits ... family/overall/slowest summaries&#34;, but an empty valid selection such as a documentation-only `--changed` run exits here without an `FM_TEST_SUMMARY`. Emit the deterministic zero-count overall summary before returning so machine consumers always receive the advertised run-level marker.

🔧 Fix: Captain: fix changed selection and empty summaries
1 error still open:
- 🚨 `bin/fm-test-run.sh:361` - Required intent says `--changed` must provide a &#34;conservative changed-file set&#34;, but the new fail-closed handling only covers `bin/*` and `tests/*`; all other paths still silently select nothing. This misses tracked, directly tested source such as `.pi/extensions/fm-primary-pi-watch.ts`, `.pi/extensions/fm-primary-turnend-guard.ts`, `.claude/settings.json`, and `.agents/skills/**`. Map these source surfaces to their dependent families or classify unmapped non-documentation paths as errors.

🔧 Fix: Captain: fail closed on unmapped changed sources
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected the committed diff from `b843c66b2d61b7a4dd257a07234ddd1a6227adad` to `4b4945926eec0dc76b414e8ddcdd64264e443f6c` against the supplied intent.</code>
- `bash tests/fm-test-run.test.sh`
- `bash tests/fm-nm-test-contract.test.sh`
- <code>`/bin/bash tests/fm-test-run.test.sh` using macOS stock Bash 3.2.57</code>
- <code>`/bin/bash tests/fm-nm-test-contract.test.sh` using macOS stock Bash 3.2.57</code>
- `bin/fm-test-run.sh --json <evidence>/single-script-timing.json tests/fm-nm-test-contract.test.sh`
- <code>`bin/fm-test-run.sh --json &lt;evidence&gt;/aggregate-failure-timing.json &lt;passing-fixture&gt; &lt;failing-fixture&gt;` and verified aggregate exit 1 after both scripts ran</code>
- `bin/fm-test-run.sh --list tests/fm-nm-test-contract.test.sh`
- `bin/fm-test-run.sh --list --family pure-contract-unit`
- `bin/fm-test-run.sh --list --changed --base b843c66b2d61b7a4dd257a07234ddd1a6227adad`
- <code>Compared `bin/fm-test-run.sh --list --all` with repository `tests/*.test.sh`: 88 versus 88, exact match; list-only, no full-suite execution.</code>
- `Verified the worktree remained clean after testing.`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
