### PR TITLE
feat(harness): verify Copilot CLI as a dispatchable crew/secondmate harness

### DIFF
--- a/.agents/skills/firstmate-orca/SKILL.md
+++ b/.agents/skills/firstmate-orca/SKILL.md
@@ -13,7 +13,7 @@ It does not replace `AGENTS.md`, `docs/orca-backend.md`, or `harness-adapters`.
 
 Orca is a runtime backend, not an agent harness.
 The runtime backend owns the task endpoint and, for Orca, the task worktree.
-The harness is the agent process launched inside that endpoint, such as `claude`, `codex`, `opencode`, `pi`, or `grok`.
+The harness is the agent process launched inside that endpoint, such as `claude`, `codex`, `opencode`, `pi`, `grok`, or `copilot`.
 Load `harness-adapters` for harness-specific launch, interrupt, resume, trust-dialog, and skill-invocation facts.
 
 Implementation details, metadata fields, teardown guarantees, limitations, and smoke evidence live in `docs/orca-backend.md`.

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harness-adapters
-description: Agent-only reference for firstmate harness operations. Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter. Contains verified facts for claude, codex, opencode, pi, and grok.
+description: Agent-only reference for firstmate harness operations. Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter. Contains verified facts for claude, codex, opencode, pi, grok, and copilot (crew/secondmate dispatch only).
 user-invocable: false
 metadata:
   internal: true
@@ -108,6 +108,7 @@ The supported launch-profile flags below are verified locally; each row records 
 | grok | `--model <model>` | `--reasoning-effort <low\|medium\|high>` | Verified on grok 0.2.99 (2026-07-13). `--effort` is an alias, but firstmate's profile axis is reasoning effort. As of 0.2.99 the ceiling is `high`; both `xhigh` and `max` are rejected with `use one of: high, medium, low`, so firstmate omits them. |
 | pi | `--model <model>` | `--thinking <low\|medium\|high\|xhigh\|max>` | Verified 2026-07-13 on Pi 0.80.6. `pi --help` advertises `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`; `pi --print --model openai-codex/gpt-5.6-sol --thinking max 'Reply with exactly OK.'` completed successfully. |
 | opencode | `--model <provider/model>` | none for firstmate's interactive launch | Verified on opencode 1.17.6. `opencode run` has `--variant`, but firstmate launches the interactive `opencode --prompt` path, which has no verified effort flag. |
+| copilot | `--model <model>` | `--effort <low\|medium\|high\|xhigh\|max>` | Verified 2026-07-21 on copilot 1.0.73. `--effort` (alias `--reasoning-effort`) advertises `none\|minimal\|low\|medium\|high\|xhigh\|max`, a superset of firstmate's vocabulary, and `--effort low` launched and ran a turn unattended live. The model catalog includes `claude-*`, `gpt-5.6-*`, `gemini-*`, `kimi-*`, and `auto`; `--model claude-haiku-4.5` verified live (the footer showed the selected model). |
 
 When a requested effort value is outside the harness-specific accepted set, `fm-spawn` records the requested `effort=` in meta but emits no effort flag for that harness.
 This preserves launch success instead of passing a known-bad value.
@@ -121,6 +122,7 @@ Natural language is acceptable if uncertain.
 - codex: `$<skill>`, for example `$no-mistakes`; `/<skill>` is claude-only and codex rejects it as "Unrecognized command".
 - opencode: no separate verified skill invocation beyond normal slash-command behavior; use natural language if the exact skill command is uncertain.
 - pi: no separate verified skill invocation beyond normal command behavior; use natural language if the exact skill command is uncertain.
+- copilot: `/<skill>`, for example `/no-mistakes` (same form as claude). Verified live on 1.0.73: copilot discovers `no-mistakes` from `~/.agents/skills/` (its "Personal" source; project skills load from `.github/skills/`, `.agents/skills/`, or `.claude/skills/`), typing `/no-mistakes` opens a slash-autocomplete popup listing the skill with its description, and one Enter submits it - the model then invokes its `skill(no-mistakes)` tool. Unlike grok/codex, the popup did NOT swallow the first Enter for exact-typed command text on the tmux backend (fm-send's 1.2s `/`-settle was in effect; its retried Enter remains the safety net).
 - grok: `/<skill>`, for example `/no-mistakes` (same form as claude). Verified end to end: grok discovers the user-level `no-mistakes` skill, `/no-mistakes` invokes it, and grok drives a real `no-mistakes axi run`. Like codex's `$`/`/` popups, typing `/<skill>` opens grok's slash-autocomplete, so a too-fast Enter selects the popup entry instead of sending, and for an argument-taking command (like `/no-mistakes`'s optional task-first argument) that first Enter only expands the popup selection into an argument-hint placeholder rather than submitting - a genuine second Enter is required (see the grok section below for the 2026-07-03 incident and fix). `fm_tmux_submit_core`'s retried Enter (used by `fm-send` on the tmux backend) already handles this correctly by reading the cursor row; the herdr backend needed a dedicated fix (`fm_backend_herdr_composer_state`, docs/herdr-backend.md) because its prior delta-based verification false-positived on that same popup-close content change.
 
 ## claude (VERIFIED)
@@ -305,3 +307,38 @@ The adapter therefore runs the shared predicate and, when it returns 2, forces o
 It does not pass `--permission-mode`, so the passive hook cannot escalate the primary session's tool permissions.
 Project-local Grok hooks require folder trust, verified with launch-time `--trust`; if the primary firstmate checkout is not trusted for Grok hooks, this primary guard fails open and `fm-guard.sh` remains the next-command alarm.
 Grok's primary watcher protocol is Claude-shaped background-notify around `bin/fm-watch-arm.sh`; the passive Stop hook is only a backstop for blind turn ends.
+
+## copilot (VERIFIED 2026-07-21, GitHub Copilot CLI 1.0.73 - crew/secondmate dispatch only, NOT a verified primary)
+
+GitHub Copilot CLI (`copilot`), an interactive TUI harness.
+Launch with the prompt as the `-i` flag's VALUE: `copilot --allow-all --no-ask-user -i "$(cat <brief>)"` - `-i/--interactive` starts the supervised interactive session and auto-executes the prompt, while `-p/--prompt` exits after one turn and is unsuitable for a steerable crewmate.
+For copilot's supported model and effort flags, see the [launch-profile-axes table](#launch-profile-axes).
+Every fact below was verified live in throwaway sessions on the tmux backend (private `tmux -L` server, scratch git repos, 2026-07-21).
+
+| Fact | Value |
+|---|---|
+| Busy-pane signature | `<spinner> Working · <bytes> esc interrupt` (e.g. `◎ Working · 916 B esc interrupt`), shown iff a turn is running; matched by the existing `esc (to )?interrupt` busy-regex alternative, so no copilot-specific regex entry exists. Idle footer is `/ commands · ? help · tab next tab`. |
+| Exit command | `/exit` typed into the composer (give the slash popup a settle before Enter; `fm-send`'s 1.2s `/`-settle suffices). On exit copilot prints session stats plus `Resume  copilot --resume=<session-id>`. |
+| Interrupt | `Ctrl+C` mid-turn (prints `Operation aborted by user` / `Operation cancelled by user`). The busy footer advertises `esc interrupt`, but Esc pressed twice did NOT cancel a running sync shell tool in live testing - use Ctrl+C. On an IDLE composer Ctrl+C instead arms exit (footer shows `ctrl+c again to exit`), so never send it to an idle pane. |
+| Skill invocation | `/<skill>` (e.g. `/no-mistakes`), same form as claude - see the no-mistakes skill invocation list above for the popup and discovery details. |
+| Autonomy | `--allow-all` (equivalent to `--allow-all-tools --allow-all-paths --allow-all-urls`; `--yolo` is its documented alias, also verified live) plus `--no-ask-user` so the `ask_user` tool never stalls the crew. Verified: a shell-touching turn ran fully unattended with no permission prompt after folder trust. |
+| Composer | A bare `❯` glyph row between two horizontal rules, no box border. The glyph is truecolor `38;2;134;134;134` (luminance 134, at/above the ghost-strip threshold) and real typed text renders in the default foreground, so the shared classifier reads idle as `empty` and typed-unsubmitted as `pending` with no `FM_COMPOSER_IDLE_RE` override (verified through `fm_tmux_composer_state` live). |
+| Submit | One Enter submits plain text AND an exact-typed `/<skill>` command on tmux (composer clears immediately; no popup Enter-swallow reproduced there). The herdr adapter's structural bare-prompt scan (`^[❯›]`) matches copilot's composer row, so its settle-plus-retried-Enter submit path applies; live end-to-end herdr steer verification is still pending (see the herdr note below). |
+| Env / detection | `ps -o comm=` reports `MainThread` (the bundled ELF renames its main thread) while `ps -o args=` is exactly `copilot ...`; tmux's `#{pane_current_command}` is cmdline-derived and reports `copilot`. Detection and the session lock ride the anchored args path (`bin/fm-harness.sh`, `bin/fm-lock.sh`). |
+| Resume | `copilot --resume=<session-id>` (printed on exit), `--continue` (most recent), `-r/--resume[=id|name]`, or `--session-id <id>`. |
+
+Folder trust dialog: "Confirm folder trust" appears on EVERY launch in a not-yet-remembered folder, including every fresh task worktree, with `❯ 1. Yes` preselected (option 2 remembers the folder; firstmate does not use it so no durable trust is accumulated for disposable worktrees).
+Accept with Enter from an active firstmate session using `FM_HOME=<this-firstmate-home> bin/fm-send.sh <window> --key Enter`, the same post-spawn peek-within-20-seconds handling as claude.
+The `-i` prompt auto-executes immediately after the dialog is accepted (verified: the brief turn started and its shell command ran with no further keystroke).
+
+Turn-end hook: copilot loads repo-level hooks from `<git-root>/.github/hooks/*.json` with no gate beyond the same folder-trust dialog, and fires `agentStop` at every COMPLETED turn boundary (payload includes `stopReason: "end_turn"` and a `stop_hook_active` field; verified with a probe hook - two completed turns fired exactly two `agentStop` events).
+`fm-spawn` therefore writes `<worktree>/.github/hooks/fm-turn-end.json` (an `agentStop` hook touching `state/<id>.turn-ended`), git-excluded via info/exclude and removed by `fm-teardown` before a pooled worktree is returned, exactly the claude `.claude/settings.local.json` shape.
+A user-CANCELLED turn fires no `agentStop` (verified: a Ctrl+C-aborted turn left the count unchanged), which the watcher's pane-staleness backstop covers.
+`sessionStart` (with `initialPrompt`), `preToolUse`/`postToolUse` (with `toolName`/`toolArgs`), and `sessionEnd` (on `/exit`) also fired in the same probe; `userPromptSubmit` and other guessed event names never fired.
+Secondmate spawns skip the hook file (idle panes are healthy, no stale-pane detection for them).
+
+Herdr backend note: the original dispatch-parity observation (a brief typed into copilot's composer via herdr needed a separate Enter) is the shape `fm_backend_herdr_send_text_submit` already handles - it types, settles, then retries Enter until herdr's native agent state or the composer read confirms the submit.
+Copilot's composer rows classify correctly through the shared herdr path (regression-fixtured in `tests/fm-backend-herdr.test.sh` with real captured ANSI rows), but a live herdr end-to-end steer to a copilot crew has not been run yet; treat the first herdr-backed copilot dispatch as a supervised verification of that last step.
+
+NOT verified as a primary harness: copilot has no verified watcher wake protocol, turn-end guard, PreToolUse seatbelt, or session-start nudge wiring (the hook probe above confirms the events exist - `agentStop`, `preToolUse`, `sessionStart` with `additionalContext` support - but the primary adapters are unbuilt and unvalidated).
+Do not run a firstmate primary on copilot; a copilot-driven home currently gets only the session lock, own-harness detection, and the manual supervision snippet.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,6 +154,7 @@ A silent bootstrap section needs no action; for any printed actionable diagnosti
 
 Load `harness-adapters` before every spawn or recovery and before trust handling, skill invocation, interrupt, exit, resume, or adapter verification.
 The verified harnesses are `claude`, `codex`, `opencode`, `pi`, and `grok`; never dispatch on an unverified adapter.
+GitHub Copilot CLI (`copilot`) is recognized for session-lock and own-harness detection only and is never dispatchable as a crewmate or secondmate harness.
 If configured harness data names an unverified adapter, report it and fall back only to a verified adapter rather than launching it.
 
 `docs/configuration.md` owns dispatch-profile and runtime-backend schemas, `bin/fm-dispatch-select.sh` owns selector mechanics, `bin/fm-harness.sh` owns static resolution, and `bin/fm-spawn.sh` owns launch flags and fail-closed validation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,7 +154,7 @@ A silent bootstrap section needs no action; for any printed actionable diagnosti
 
 Load `harness-adapters` before every spawn or recovery and before trust handling, skill invocation, interrupt, exit, resume, or adapter verification.
 The verified harnesses are `claude`, `codex`, `opencode`, `pi`, and `grok`; never dispatch on an unverified adapter.
-GitHub Copilot CLI (`copilot`) is recognized for session-lock and own-harness detection only and is never dispatchable as a crewmate or secondmate harness.
+GitHub Copilot CLI (`copilot`) is additionally verified for crewmate and secondmate dispatch and remains recognized for session-lock and own-harness detection, but is not a verified primary harness.
 If configured harness data names an unverified adapter, report it and fall back only to a verified adapter rather than launching it.
 
 `docs/configuration.md` owns dispatch-profile and runtime-backend schemas, `bin/fm-dispatch-select.sh` owns selector mechanics, `bin/fm-harness.sh` owns static resolution, and `bin/fm-spawn.sh` owns launch flags and fail-closed validation.

--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -144,7 +144,11 @@ fm_backend_tmux_current_command() {  # <target>
 # "Agent liveness probe" for the empirical basis. Prints one of:
 #   alive   - the foreground command is one of the verified harness binaries
 #             (claude, codex, opencode, grok - each confirmed to run as its
-#             own process name, never wrapped by a generic interpreter).
+#             own process name, never wrapped by a generic interpreter - plus
+#             copilot: its ELF renames its main thread so `ps -o comm=` reports
+#             "MainThread", but tmux's #{pane_current_command} is derived from
+#             the process CMDLINE, which is exactly "copilot" - verified live
+#             on copilot 1.0.73 with tmux 3.x, 2026-07-21).
 #   dead    - the foreground command is a bare shell: nothing is running in
 #             the pane, so a prior agent process has exited.
 #   unknown - anything else, INCLUDING a bare "node"/"python" interpreter
@@ -160,7 +164,7 @@ fm_backend_tmux_agent_alive() {  # <target>
   comm=${comm#-}
   case "$comm" in
     '') printf 'unknown' ;;
-    *claude*|*codex*|*opencode*|*grok*) printf 'alive' ;;
+    *claude*|*codex*|*opencode*|*grok*|*copilot*) printf 'alive' ;;
     zsh|bash|sh|dash|ash|ksh|mksh|tcsh|csh|fish) printf 'dead' ;;
     *) printf 'unknown' ;;
   esac

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -711,7 +711,7 @@ crew_dispatch_validate() {
     return 0
   fi
   err=$(jq -r '
-    def verified($h): ["claude","codex","opencode","pi","grok"] | index($h);
+    def verified($h): ["claude","codex","opencode","pi","grok","copilot"] | index($h);
     def effort_ok($h; $e):
       if $e == null then true
       elif ($e | type) != "string" then false
@@ -719,6 +719,7 @@ crew_dispatch_validate() {
       elif $h == "codex" then (["low","medium","high","xhigh"] | index($e))
       elif $h == "grok" then (["low","medium","high"] | index($e))
       elif $h == "pi" then (["low","medium","high","xhigh","max"] | index($e))
+      elif $h == "copilot" then (["low","medium","high","xhigh","max"] | index($e))
       elif $h == "opencode" then false
       else true
       end;

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -455,7 +455,7 @@ secondmate_liveness_sweep() {
     [ -n "$target" ] || target="$window"
     verdict=$(fm_backend_agent_alive "$backend" "$target" 2>/dev/null) || verdict="unknown"
     case "$harness" in
-      claude|codex|opencode|pi|grok) ;;
+      claude|codex|opencode|pi|grok|copilot) ;;
       *) [ "$verdict" = dead ] && verdict=unknown ;;
     esac
     case "$verdict" in

--- a/bin/fm-composer-lib.sh
+++ b/bin/fm-composer-lib.sh
@@ -19,8 +19,11 @@
 # container - a bordered composer box, where the harness draws its own prompt
 # glyph (e.g. claude's older `| > ... |`). On a bare, unstructured row it is a
 # dead-shell prompt and is NEVER "empty"; it classifies as `unknown` (not a safe
-# injection target). The AGENT prompt glyphs `❯` (claude) and `›` (codex) are a
-# genuine empty agent composer either way, bordered or bare.
+# injection target). The AGENT prompt glyphs `❯` (claude, and copilot's own
+# composer glyph - verified copilot 1.0.73, 2026-07-21: a bare `❯` styled
+# truecolor 38;2;134;134;134 between two horizontal rules, no box border, real
+# typed text in the default foreground) and `›` (codex) are a genuine empty
+# agent composer either way, bordered or bare.
 #
 # GHOST/PLACEHOLDER TEXT is the other half of this owner (task
 # afk-herdr-false-pending): a harness fills an otherwise-empty composer with

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 # Detect the agent harness this process tree runs on.
 # Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|grok|copilot|unknown
-#                                        (copilot is lock/detection only, never
-#                                        dispatchable as a crew/secondmate harness)
 #        fm-harness.sh crew             print the effective CREWMATE harness
 #                                        (config/crew-harness; "default" resolves to own)
 #        fm-harness.sh secondmate       print the harness the PRIMARY uses to launch
@@ -52,9 +50,8 @@ detect_own() {
         # Bare interpreter: match the harness name in its script path.
         # MainThread is GitHub Copilot CLI's comm (verified 2026-07-21, copilot
         # 1.0.73: the bundled ELF renames its main thread and its args are
-        # exactly "copilot"). copilot is lock/detection only, not dispatchable;
-        # its glob is anchored so argv like ".../extensions/copilot --locale"
-        # never matches.
+        # exactly "copilot"). copilot's glob is anchored so argv like
+        # ".../extensions/copilot --locale" never matches.
         args=$(ps -o args= -p "$pid" 2>/dev/null)
         case "$args" in
           *claude*) echo claude; return ;;

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -55,15 +55,17 @@ detect_own() {
         # ".../extensions/copilot --locale" never matches.
         args=$(ps -o args= -p "$pid" 2>/dev/null)
         case "$args" in
+          copilot|"copilot "*) echo copilot; return ;;
+        esac
+        case "${args%% *}" in
+          */copilot) echo copilot; return ;;
+        esac
+        case "$args" in
           *claude*) echo claude; return ;;
           *codex*) echo codex; return ;;
           *opencode*) echo opencode; return ;;
           *grok*) echo grok; return ;;
           *" pi "*|*/pi) echo pi; return ;;
-          copilot|"copilot "*) echo copilot; return ;;
-        esac
-        case "${args%% *}" in
-          */copilot) echo copilot; return ;;
         esac ;;
     esac
     pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # Detect the agent harness this process tree runs on.
-# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|grok|unknown
+# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|grok|copilot|unknown
+#                                        (copilot is lock/detection only, never
+#                                        dispatchable as a crew/secondmate harness)
 #        fm-harness.sh crew             print the effective CREWMATE harness
 #                                        (config/crew-harness; "default" resolves to own)
 #        fm-harness.sh secondmate       print the harness the PRIMARY uses to launch
@@ -45,8 +47,14 @@ detect_own() {
       *opencode*) echo opencode; return ;;
       *grok*) echo grok; return ;;
       pi) echo pi; return ;;
-      node*|python*)
+      copilot) echo copilot; return ;;
+      node*|python*|MainThread)
         # Bare interpreter: match the harness name in its script path.
+        # MainThread is GitHub Copilot CLI's comm (verified 2026-07-21, copilot
+        # 1.0.73: the bundled ELF renames its main thread and its args are
+        # exactly "copilot"). copilot is lock/detection only, not dispatchable;
+        # its glob is anchored so argv like ".../extensions/copilot --locale"
+        # never matches.
         args=$(ps -o args= -p "$pid" 2>/dev/null)
         case "$args" in
           *claude*) echo claude; return ;;
@@ -54,6 +62,7 @@ detect_own() {
           *opencode*) echo opencode; return ;;
           *grok*) echo grok; return ;;
           *" pi "*|*/pi) echo pi; return ;;
+          copilot|"copilot "*) echo copilot; return ;;
         esac ;;
     esac
     pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -50,7 +50,8 @@ detect_own() {
         # Bare interpreter: match the harness name in its script path.
         # MainThread is GitHub Copilot CLI's comm (verified 2026-07-21, copilot
         # 1.0.73: the bundled ELF renames its main thread and its args are
-        # exactly "copilot"). copilot's glob is anchored so argv like
+        # exactly "copilot"). copilot's glob is anchored to a standalone word
+        # or a path-prefixed argv[0] so argv like
         # ".../extensions/copilot --locale" never matches.
         args=$(ps -o args= -p "$pid" 2>/dev/null)
         case "$args" in
@@ -60,6 +61,9 @@ detect_own() {
           *grok*) echo grok; return ;;
           *" pi "*|*/pi) echo pi; return ;;
           copilot|"copilot "*) echo copilot; return ;;
+        esac
+        case "${args%% *}" in
+          */copilot) echo copilot; return ;;
         esac ;;
     esac
     pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')

--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -20,10 +20,11 @@ mkdir -p "$STATE"
 # (still not a verified primary). Verified 2026-07-21 on copilot 1.0.73:
 # its bundled ELF renames the main thread, so `ps -o comm=` reports "MainThread"
 # while `ps -o args=` is exactly "copilot"; recognition therefore rides the args
-# path. The copilot alternative is anchored to a standalone word so unrelated
-# argv such as ".../extensions/copilot --locale" or
+# path. The copilot alternatives are anchored to a standalone word or a
+# path-prefixed argv[0] (e.g. "/home/x/.local/bin/copilot --allow-all") so
+# unrelated argv such as ".../extensions/copilot --locale" or
 # "@vscode/copilot-typescript-server-plugin" never matches.
-HARNESS_RE='claude|codex|opencode|grok|^pi$|(^| )copilot( |$)'
+HARNESS_RE='claude|codex|opencode|grok|^pi$|(^| )copilot( |$)|^[^ ]*/copilot( |$)'
 
 harness_pid() {
   local pid=$$ comm args

--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -15,7 +15,14 @@ LOCK="$STATE/.lock"
 mkdir -p "$STATE"
 
 # Known harness command names; extend when a new adapter is verified.
-HARNESS_RE='claude|codex|opencode|grok|^pi$'
+# copilot (GitHub Copilot CLI) is recognized for lock/detection only - it is NOT
+# a dispatchable crew/secondmate harness. Verified 2026-07-21 on copilot 1.0.73:
+# its bundled ELF renames the main thread, so `ps -o comm=` reports "MainThread"
+# while `ps -o args=` is exactly "copilot"; recognition therefore rides the args
+# path. The copilot alternative is anchored to a standalone word so unrelated
+# argv such as ".../extensions/copilot --locale" or
+# "@vscode/copilot-typescript-server-plugin" never matches.
+HARNESS_RE='claude|codex|opencode|grok|^pi$|(^| )copilot( |$)'
 
 harness_pid() {
   local pid=$$ comm args
@@ -26,8 +33,9 @@ harness_pid() {
       echo "$pid"; return 0
     fi
     # Bare interpreter (e.g. node): match the harness name in its script path.
+    # MainThread is copilot's comm (see HARNESS_RE note); its args carry the name.
     case "$comm" in
-      *node*|*python*) printf '%s' "$args" | grep -qE "$HARNESS_RE" && { echo "$pid"; return 0; } ;;
+      *node*|*python*|MainThread) printf '%s' "$args" | grep -qE "$HARNESS_RE" && { echo "$pid"; return 0; } ;;
     esac
     pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
     [ -n "$pid" ] && [ "$pid" -gt 1 ] || return 1

--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -47,7 +47,17 @@ holder_alive() {  # true if $1 is a live process that looks like a harness
   local pid=$1 comm
   kill -0 "$pid" 2>/dev/null || return 1
   comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
-  printf '%s' "$(basename "$comm") $(ps -o args= -p "$pid" 2>/dev/null)" | grep -qE "$HARNESS_RE"
+  if printf '%s' "$(basename "$comm")" | grep -qE "$HARNESS_RE"; then
+    return 0
+  fi
+  # Only trust args when comm is a bare interpreter or copilot's MainThread,
+  # mirroring harness_pid; otherwise a recycled pid whose argv merely mentions
+  # a harness name (e.g. "gh copilot suggest") would look like a live holder.
+  case "$comm" in
+    *node*|*python*|MainThread)
+      printf '%s' "$(ps -o args= -p "$pid" 2>/dev/null)" | grep -qE "$HARNESS_RE" ;;
+    *) return 1 ;;
+  esac
 }
 
 if [ "${1:-}" = "status" ]; then

--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -15,8 +15,9 @@ LOCK="$STATE/.lock"
 mkdir -p "$STATE"
 
 # Known harness command names; extend when a new adapter is verified.
-# copilot (GitHub Copilot CLI) is recognized for lock/detection only - it is NOT
-# a dispatchable crew/secondmate harness. Verified 2026-07-21 on copilot 1.0.73:
+# copilot (GitHub Copilot CLI) is recognized for the session lock and
+# own-harness detection, and is a verified dispatchable crew/secondmate harness
+# (still not a verified primary). Verified 2026-07-21 on copilot 1.0.73:
 # its bundled ELF renames the main thread, so `ps -o comm=` reports "MainThread"
 # while `ps -o args=` is exactly "copilot"; recognition therefore rides the args
 # path. The copilot alternative is anchored to a standalone word so unrelated

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -56,7 +56,7 @@
 #   profile consultation. A --secondmate spawn is exempt and resolves the SECONDMATE
 #   harness (config/secondmate-harness -> config/crew-harness -> own), so the
 #   secondmate-vs-crewmate split is DURABLE across every respawn (recovery,
-#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|grok)
+#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|grok|copilot)
 #   overrides it for this spawn (either kind). A non-flag string containing
 #   whitespace is treated as a RAW launch command - the escape hatch for verifying
 #   new adapters.
@@ -382,7 +382,7 @@ FIRSTMATE_HOME=
 
 if [ "$KIND" = secondmate ]; then
   case "${POS[1]:-}" in
-    ''|claude|codex|opencode|pi|grok)
+    ''|claude|codex|opencode|pi|grok|copilot)
       ARG3=${POS[1]:-}
       ;;
     *' '*)
@@ -443,6 +443,18 @@ launch_template() {
     # launch command - it is a Stop-event hook installed below (global hook +
     # per-task pointer), so the template is identical for ship/scout/secondmate.
     grok) printf '%s' 'grok --always-approve __MODELFLAG____EFFORTFLAG__"$(cat __BRIEF__)"' ;;
+    # copilot (GitHub Copilot CLI): -i/--interactive takes the prompt as its VALUE
+    # (verified 1.0.73: it starts the supervised interactive session and
+    # auto-executes the prompt; -p/--prompt would exit after one turn, unsuitable
+    # for a steerable crewmate). --allow-all enables every permission
+    # (tools+paths+URLs; --yolo is its documented alias), and --no-ask-user
+    # disables the ask_user tool so the crew never stalls on a question - both
+    # verified to run a shell-touching turn fully unattended after the folder
+    # trust dialog is accepted (see harness-adapters for the dialog handling).
+    # copilot's turn-end signal does not ride the launch command - it is a
+    # repo-level agentStop hook installed below, so the template is identical
+    # for ship/scout/secondmate.
+    copilot) printf '%s' 'copilot --allow-all --no-ask-user __MODELFLAG____EFFORTFLAG__-i "$(cat __BRIEF__)"' ;;
     *) return 1 ;;
   esac
 }
@@ -530,7 +542,7 @@ model_flag_for_harness() {
   local harness=$1 model=$2
   [ -n "$model" ] && [ "$model" != default ] || return 0
   case "$harness" in
-    claude|codex|opencode|pi|grok)
+    claude|codex|opencode|pi|grok|copilot)
       printf -- '--model %s ' "$(shell_quote "$model")"
       ;;
   esac
@@ -567,6 +579,15 @@ effort_flag_for_harness() {
       # its --thinking flag.
       case "$effort" in
         low|medium|high|xhigh|max) printf -- '--thinking %s ' "$(shell_quote "$effort")" ;;
+      esac
+      ;;
+    copilot)
+      # copilot 1.0.73's --effort (alias --reasoning-effort) advertises
+      # none|minimal|low|medium|high|xhigh|max - a superset of firstmate's
+      # shared effort vocabulary, so every firstmate value passes through
+      # (verified live: --effort low launched and ran a turn unattended).
+      case "$effort" in
+        low|medium|high|xhigh|max) printf -- '--effort %s ' "$(shell_quote "$effort")" ;;
       esac
       ;;
     # opencode's interactive `opencode --prompt` launch has a verified --model
@@ -1140,6 +1161,20 @@ EOF
       ;;
     codex*)
       # codex: turn-end rides the launch command via -c notify=[...] and __TURNEND__.
+      ;;
+    copilot*)
+      # copilot loads repo-level hooks from <git-root>/.github/hooks/*.json with
+      # no trust gate beyond the standard folder-trust dialog the launch already
+      # passes through, and fires agentStop at every COMPLETED turn boundary
+      # (verified 1.0.73: two turns fired two agentStop events with
+      # stopReason=end_turn; a user-cancelled turn fires none, which the
+      # watcher's staleness backstop covers). The "bash" command runs on Unix;
+      # "powershell" would be the Windows key, not needed for this fleet.
+      mkdir -p "$WT/.github/hooks"
+      cat > "$WT/.github/hooks/fm-turn-end.json" <<EOF
+{"version":1,"hooks":{"agentStop":[{"type":"command","bash":"touch '$TURNEND'","timeoutSec":10}]}}
+EOF
+      exclude_path '.github/hooks/fm-turn-end.json'
       ;;
     grok*)
       # grok fires a Stop hook at every turn boundary (verified, grok 0.2.73), the

--- a/bin/fm-supervision-instructions.sh
+++ b/bin/fm-supervision-instructions.sh
@@ -82,9 +82,10 @@ fi
 
 case "$HARNESS" in
   claude|codex|opencode|pi|grok) SNIPPET="$DOC_DIR/$HARNESS.md" ;;
-  # copilot is detected distinctly (lock/detection only, not dispatchable) but
-  # has no verified watcher wake adapter, so it keeps its name in the heading
-  # while operating on the generic manual-supervision fallback snippet.
+  # copilot is detected distinctly (and is a verified crew/secondmate dispatch
+  # harness) but has no verified PRIMARY watcher wake adapter, so it keeps its
+  # name in the heading while operating on the generic manual-supervision
+  # fallback snippet.
   copilot) SNIPPET="$DOC_DIR/unknown.md" ;;
   *) HARNESS=unknown; SNIPPET="$DOC_DIR/unknown.md" ;;
 esac
@@ -208,7 +209,7 @@ else
 fi
 ordinary_wake_line
 if [ "$HARNESS" = copilot ]; then
-  printf '%s\n' '- Harness note: copilot is recognized for session identity only; it has no verified watcher wake adapter and is never dispatchable for crew or secondmate work, so supervise manually per the fallback below.'
+  printf '%s\n' '- Harness note: copilot is a verified crew/secondmate dispatch harness, but this PRIMARY session has no verified watcher wake adapter on copilot, so supervise manually per the fallback below.'
 fi
 printf '\n'
 render_snippet

--- a/bin/fm-supervision-instructions.sh
+++ b/bin/fm-supervision-instructions.sh
@@ -82,6 +82,10 @@ fi
 
 case "$HARNESS" in
   claude|codex|opencode|pi|grok) SNIPPET="$DOC_DIR/$HARNESS.md" ;;
+  # copilot is detected distinctly (lock/detection only, not dispatchable) but
+  # has no verified watcher wake adapter, so it keeps its name in the heading
+  # while operating on the generic manual-supervision fallback snippet.
+  copilot) SNIPPET="$DOC_DIR/unknown.md" ;;
   *) HARNESS=unknown; SNIPPET="$DOC_DIR/unknown.md" ;;
 esac
 [ -f "$SNIPPET" ] || SNIPPET="$DOC_DIR/unknown.md"
@@ -203,6 +207,9 @@ else
   printf '%s\n' '- X mode: inactive; use the default watcher cadence.'
 fi
 ordinary_wake_line
+if [ "$HARNESS" = copilot ]; then
+  printf '%s\n' '- Harness note: copilot is recognized for session identity only; it has no verified watcher wake adapter and is never dispatchable for crew or secondmate work, so supervise manually per the fallback below.'
+fi
 printf '\n'
 render_snippet
 printf '\n'

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -661,7 +661,7 @@ validate_worktree_teardown_safety() {
     echo "Restore the git index state, or get the captain's explicit OK to discard, then --force." >&2
     return 1
   fi
-  dirty=$(printf '%s\n' "$dirty_raw" | grep -vE '^\?\? (\.claude/|\.fm-grok-turnend$)' | head -1 || true)
+  dirty=$(printf '%s\n' "$dirty_raw" | grep -vE '^\?\? (\.claude/|\.fm-grok-turnend$|\.github/hooks/fm-turn-end\.json$)' | head -1 || true)
 
   if ! unpushed_raw=$(git -C "$WT" log --oneline HEAD --not --remotes -- 2>/dev/null); then
     if worktree_safety_blocked_by_lock "commits not on a remote"; then
@@ -991,12 +991,12 @@ cleanup_firstmate_home_children() {
     elif [ "$child_backend" = orca ]; then
       if [ -n "$child_wt" ] && [ -d "$child_wt" ]; then
         validate_child_worktree_for_removal "$child_wt" "$child_proj" >/dev/null || return 1
-        rm -f "$child_wt/.claude/settings.local.json" "$child_wt/.opencode/plugins/fm-turn-end.js" "$child_wt/.fm-grok-turnend"
+        rm -f "$child_wt/.claude/settings.local.json" "$child_wt/.opencode/plugins/fm-turn-end.js" "$child_wt/.fm-grok-turnend" "$child_wt/.github/hooks/fm-turn-end.json"
       fi
       fm_backend_remove_worktree "$child_backend" "$child_orca_worktree_id" || return 1
     elif [ -n "$child_wt" ] && [ -d "$child_wt" ]; then
       validate_child_worktree_for_removal "$child_wt" "$child_proj" >/dev/null || return 1
-      rm -f "$child_wt/.claude/settings.local.json" "$child_wt/.opencode/plugins/fm-turn-end.js" "$child_wt/.fm-grok-turnend"
+      rm -f "$child_wt/.claude/settings.local.json" "$child_wt/.opencode/plugins/fm-turn-end.js" "$child_wt/.fm-grok-turnend" "$child_wt/.github/hooks/fm-turn-end.json"
       if [ -n "$child_proj" ] && [ -d "$child_proj" ] && command -v treehouse >/dev/null 2>&1; then
         if teardown_treehouse_return "$child_wt" "$child_proj" "child worktree"; then
           :
@@ -1103,7 +1103,7 @@ if [ "$BACKEND" = orca ] && [ "$KIND" != secondmate ]; then
         git -C "$WT" branch -D "$branch" >/dev/null 2>&1 || true
       fi
     fi
-    rm -f "$WT/.claude/settings.local.json" "$WT/.opencode/plugins/fm-turn-end.js" "$WT/.fm-grok-turnend"
+    rm -f "$WT/.claude/settings.local.json" "$WT/.opencode/plugins/fm-turn-end.js" "$WT/.fm-grok-turnend" "$WT/.github/hooks/fm-turn-end.json"
   fi
   [ -z "$T_ORCA" ] || fm_backend_kill "$BACKEND" "$T" "$(meta_value "$META" zellij_tab_id)" "fm-$ID" 2>/dev/null || true
   fm_backend_remove_worktree "$BACKEND" "$ORCA_WORKTREE_ID"
@@ -1115,7 +1115,7 @@ elif [ -d "$WT" ] && [ "$KIND" != secondmate ]; then
     fi
   fi
   # Remove our hook file so a reused pool worktree cannot fire signals for a dead task.
-  rm -f "$WT/.claude/settings.local.json" "$WT/.opencode/plugins/fm-turn-end.js" "$WT/.fm-grok-turnend"
+  rm -f "$WT/.claude/settings.local.json" "$WT/.opencode/plugins/fm-turn-end.js" "$WT/.fm-grok-turnend" "$WT/.github/hooks/fm-turn-end.json"
   # Kills remaining processes in the worktree (including the agent), resets, returns
   # to pool. treehouse resolves the pool from the working directory, so run it from
   # the project. teardown_treehouse_return tolerates transient and stale git locks

--- a/bin/fm-tmux-lib.sh
+++ b/bin/fm-tmux-lib.sh
@@ -62,7 +62,11 @@
 
 # Busy footers per harness (mirror fm-watch.sh). claude/codex: "esc to
 # interrupt"; opencode: "esc interrupt"; pi: "Working..."; grok: "Ctrl+c:cancel"
-# (grok's mid-turn cancel hint, shown iff a turn is running - verified grok 0.2.73).
+# (grok's mid-turn cancel hint, shown iff a turn is running - verified grok 0.2.73);
+# copilot: "<spinner> Working · <bytes> esc interrupt" (shown iff a turn is
+# running; idle footer is "/ commands · ? help · tab next tab" - verified
+# copilot 1.0.73, 2026-07-21), already matched by the "esc (to )?interrupt"
+# alternative, so the regex needs no copilot-specific entry.
 FM_TMUX_BUSY_REGEX_DEFAULT='esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel'
 
 # fm_tmux_strip_ghost: thin adapter over the shared, fleet-wide ghost extractor

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -114,7 +114,10 @@ SIGNAL_GRACE=${FM_SIGNAL_GRACE:-30}   # seconds to linger after a signal so trai
 # claude/codex: "esc to interrupt"; opencode: "esc interrupt"; pi: "Working...";
 # grok: "Ctrl+c:cancel" (the mid-turn cancel hint in grok's keybind bar, shown iff a
 # turn is running; absent when idle - verified grok 0.2.73, ASCII to avoid the
-# locale fragility of matching grok's braille spinner glyph directly).
+# locale fragility of matching grok's braille spinner glyph directly);
+# copilot: "<spinner> Working · <bytes> esc interrupt" iff a turn is running
+# (verified copilot 1.0.73, 2026-07-21), covered by the existing
+# "esc (to )?interrupt" alternative with no copilot-specific entry.
 BUSY_REGEX=${FM_BUSY_REGEX:-'esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel'}
 # Always-on wake triage: most wakes during a long crew validation are benign (a
 # working: note or turn-end while a pipeline runs, a no-change heartbeat). Rather

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -138,7 +138,7 @@ The session-start bootstrap step surfaces either the active rule block or a conc
 When the file exists, `fm-spawn.sh` refuses crewmate and scout launches without an explicit harness, so `config/crew-harness` is only automatic when no dispatch profile file is active.
 Secondmate launches are exempt because they resolve the secondmate harness and any optional secondmate model or effort tokens instead.
 Unsupported effort values are still recorded in task meta when passed to `fm-spawn.sh`, but the launch template omits any effort flag that the selected harness does not accept.
-That keeps spawn launch compatible across claude, codex, grok, pi, and opencode while preserving the requested profile for later audit.
+That keeps spawn launch compatible across claude, codex, grok, pi, opencode, and copilot while preserving the requested profile for later audit.
 
 ## Optional secondmates
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -165,7 +165,7 @@ The full cmux home label also includes a short hash of the resolved `FM_ROOT` pa
 ## Harness support
 
 claude, codex, opencode, pi, and grok are all empirically verified; new harnesses get verified through a supervised trial task before joining the set.
-GitHub Copilot CLI (`copilot`) is additionally recognized for the session lock and own-harness detection only, so a copilot-driven home can hold its own lock; it has no verified watcher wake adapter (supervision falls back to the manual snippet) and is never dispatchable as a crewmate or secondmate harness.
+GitHub Copilot CLI (`copilot`) is additionally recognized for the session lock and own-harness detection, so a copilot-driven home can hold its own lock, and is a verified crewmate/secondmate dispatch harness whose empirical facts live in the `harness-adapters` skill; it has no verified watcher wake adapter as a primary (supervision falls back to the manual snippet).
 The verified adapter knowledge - busy signatures, interrupt and exit commands, skill-invocation syntax, and per-harness quirks - lives in [`.agents/skills/harness-adapters/SKILL.md`](../.agents/skills/harness-adapters/SKILL.md).
 Launch mechanics, including the verified command templates, live in [`bin/fm-spawn.sh`](../bin/fm-spawn.sh).
 Primary-session turn-end guard integrations for verified harnesses are tracked as repo-level hook files and documented in [`docs/turnend-guard.md`](turnend-guard.md).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -165,6 +165,7 @@ The full cmux home label also includes a short hash of the resolved `FM_ROOT` pa
 ## Harness support
 
 claude, codex, opencode, pi, and grok are all empirically verified; new harnesses get verified through a supervised trial task before joining the set.
+GitHub Copilot CLI (`copilot`) is additionally recognized for the session lock and own-harness detection only, so a copilot-driven home can hold its own lock; it has no verified watcher wake adapter (supervision falls back to the manual snippet) and is never dispatchable as a crewmate or secondmate harness.
 The verified adapter knowledge - busy signatures, interrupt and exit commands, skill-invocation syntax, and per-harness quirks - lives in [`.agents/skills/harness-adapters/SKILL.md`](../.agents/skills/harness-adapters/SKILL.md).
 Launch mechanics, including the verified command templates, live in [`bin/fm-spawn.sh`](../bin/fm-spawn.sh).
 Primary-session turn-end guard integrations for verified harnesses are tracked as repo-level hook files and documented in [`docs/turnend-guard.md`](turnend-guard.md).

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -532,7 +532,7 @@ The tmux backend was NOT affected by this incident: `fm_tmux_composer_state` rea
 **Fix:** `fm_backend_herdr_composer_state` replaced the delta-based check with a structural read of the composer's OWN row, mirroring what the cursor-row read gives tmux.
 Herdr's CLI exposes no cursor-row primitive, so the composer row is located by shape instead of position.
 For bordered composers, the row is the only line in a generous tail capture whose trimmed content both starts and ends with the same border glyph (`│`, `┃`, or a plain `|`) - the box's own top/bottom rows use rounded corners and never match, popup item rows and separator rows carry no border glyph at all, and the footer help line uses `│` only as an interior separator (never as the first/last character), so none of those can be mistaken for the composer.
-For unbordered live composers, added after the 2026-07-07 incident below, the row is a bottom-most trimmed line starting with a verified agent prompt glyph (`❯` for claude or `›` for codex); decorative bordered boxes above it lose to that bottom-most match.
+For unbordered live composers, added after the 2026-07-07 incident below, the row is a bottom-most trimmed line starting with a verified agent prompt glyph (`❯` for claude and copilot, or `›` for codex); decorative bordered boxes above it lose to that bottom-most match.
 For Pi, added after the 2026-07-14 incident above, the candidate is the content between the bottom-most complete separator pair, admitted only when native Herdr identity reports exactly `pi` with status `idle`, `done`, or `blocked` and the bounded structure is unambiguous.
 A popup-close-with-placeholder-fill still reads as real content on that row, so composer fallback correctly classifies it as pending; on the normal idle-baseline path, the same first Enter also fails to start a turn, so native agent-state confirmation likewise retries instead of stopping early.
 Known ghost/placeholder composer text (`Type a message...`, verified grok 0.2.82's empty-composer hint) is recognized and still reads as empty.
@@ -876,7 +876,7 @@ Each adapter still owns its own capture and structural row-finding (genuinely di
 
 **The safety rule.** A bare shell prompt glyph is a genuine empty agent composer ONLY inside a bordered composer container (where the harness draws its own prompt glyph, e.g. claude's older `| > ... |`).
 On a bare, unstructured row it is a dead-shell prompt and reads `unknown` (not a safe injection target), never `empty`.
-The agent prompt glyphs `❯` (claude) and `›` (codex) read `empty` either way.
+The agent prompt glyphs `❯` (claude, and copilot's composer glyph - see `bin/fm-composer-lib.sh` for the verified styling) and `›` (codex) read `empty` either way.
 `inject_msg` was hardened to match: its composer-guard now reads `fm_backend_composer_state` directly and defers on anything that is not affirmatively `empty` (`pending` real text, or `unknown` for a dead shell or an unreadable pane), instead of only deferring on `pending`.
 
 **Regression coverage.** `tests/fm-composer-lib.test.sh` pins the shared owner directly (bare shell glyph -> `unknown`, the same glyph bordered -> `empty`, agent glyphs -> `empty` bordered or bare, idle placeholder, real text -> `pending`).

--- a/docs/orca-backend.md
+++ b/docs/orca-backend.md
@@ -1,7 +1,7 @@
 # Orca Backend
 
 Orca is an experimental runtime backend for firstmate.
-It is distinct from the crewmate harness: the harness is the agent process firstmate launches (`claude`, `codex`, `opencode`, `pi`, or `grok`), while Orca owns the task worktree and terminal endpoint underneath that process.
+It is distinct from the crewmate harness: the harness is the agent process firstmate launches (`claude`, `codex`, `opencode`, `pi`, `grok`, or `copilot`), while Orca owns the task worktree and terminal endpoint underneath that process.
 Firstmate agents operating this backend should load the agent-only [`firstmate-orca`](../.agents/skills/firstmate-orca/SKILL.md) checklist before switching to Orca, spawning or supervising Orca-backed work, smoke-testing, debugging task state, or reconciling Orca metadata.
 
 ## Setup

--- a/docs/tmux-backend.md
+++ b/docs/tmux-backend.md
@@ -73,6 +73,7 @@ A secondmate agent that exits leaves its pane alive as a bare idle shell, which 
 
 `fm_backend_tmux_agent_alive` (`bin/backends/tmux.sh`) answers a deeper question: is a real harness-agent *process* running in the pane right now, not just whether the pane exists?
 It reads tmux's own `#{pane_current_command}`, which reports the pane's live foreground process name - already resolved by tmux from the pty's controlling process group, not something this adapter derives itself.
+That value is cmdline-derived, not the kernel `comm`: verified 2026-07-21 with copilot 1.0.73 live in a tmux pane, `ps -o comm= -p <pid>` reported `MainThread` (the bundled ELF renames its main thread) and `ps -o args= -p <pid>` began `copilot --allow-all ...`, while `tmux display-message -p '#{pane_current_command}'` reported exactly `copilot` - which is why the alive case can match copilot by name with no args-reading special case.
 
 Agent liveness and composer safety are separate checks.
 During away-mode escalation delivery, `fm_tmux_composer_state` sends a bare shell glyph on an unbordered row to the shared composer classifier as `unknown`, and the daemon injects only into an affirmatively `empty` composer; see [Composer-emptiness safety](herdr-backend.md#composer-emptiness-safety-2026-07-10-fleet-wide-across-all-four-backends).

--- a/docs/tmux-backend.md
+++ b/docs/tmux-backend.md
@@ -112,7 +112,7 @@ Verified the same session: a persisting parent process running a child command (
 
 The classifier (`fm_backend_tmux_agent_alive`) maps the observed name to `alive`, `dead`, or `unknown`:
 
-- `alive` - the name contains `claude`, `codex`, `opencode`, or `grok`. All four were confirmed to run as their own literal process name (`ps -ef`, 2026-07-07): `claude` and `codex` and `opencode` are each a native compiled binary (`file` reports Mach-O), so their `comm` is their own binary name with no interpreter wrapper to hide behind.
+- `alive` - the name contains `claude`, `codex`, `opencode`, `grok`, or `copilot`. The first four were confirmed to run as their own literal process name (`ps -ef`, 2026-07-07): `claude` and `codex` and `opencode` are each a native compiled binary (`file` reports Mach-O), so their `comm` is their own binary name with no interpreter wrapper to hide behind. `copilot` matches because `#{pane_current_command}` is cmdline-derived (see the verification above), even though its kernel `comm` is `MainThread`.
 - `dead` - the name is a bare shell (`zsh`, `bash`, `sh`, `dash`, `ash`, `ksh`, `mksh`, `tcsh`, `csh`, `fish`).
 - `unknown` - anything else, including an unreadable pane.
 

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -1788,6 +1788,39 @@ test_composer_state_grok_bright_truecolor_real_text_is_pending() {
   pass "fm_backend_herdr_composer_state: grok's real bright typed input still reads pending"
 }
 
+# copilot's idle composer (verified live, copilot 1.0.73, 2026-07-21, real tmux
+# capture-pane -e bytes): a bare `❯ ` styled truecolor 38;2;134;134;134
+# (luminance 134, at/above the ghost threshold so the glyph survives the strip)
+# sitting BETWEEN two full-width horizontal rules - the same separated shape as
+# Pi, so this also proves the Pi separator-pair override does not suppress the
+# generic bare-glyph verdict when the glyph row sits INSIDE the pair.
+test_composer_state_copilot_bare_glyph_between_rules_is_empty() {
+  local dir log resp fb out rule
+  dir="$TMP_ROOT/composer-copilot-idle"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  rule=$(printf '\xe2\x94\x80%.0s' 1 2 3 4 5 6 7 8 9 10 11 12)
+  printf ' \xe2\x9d\xaf Reply with exactly: SECOND TURN OK\n %s\n\x1b[38;2;134;134;134m\xe2\x9d\xaf \x1b[39m\n %s\n / commands \xc2\xb7 ? help \xc2\xb7 tab next tab\n' "$rule" "$rule" > "$resp/1.out"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_composer_state default:w1:p2' "$ROOT" )
+  [ "$out" = empty ] || fail "copilot's idle bare-glyph composer between horizontal rules must read empty, got '$out'"
+  pass "fm_backend_herdr_composer_state: copilot's idle bare ❯ between rules reads empty"
+}
+
+# Same shape with REAL typed-but-unsubmitted text (default foreground after the
+# gray glyph run, as captured live) must read pending - the state fm-send's
+# retried Enter relies on when a copilot submit needs a second Enter on herdr.
+test_composer_state_copilot_typed_text_is_pending() {
+  local dir log resp fb out rule
+  dir="$TMP_ROOT/composer-copilot-typed"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  rule=$(printf '\xe2\x94\x80%.0s' 1 2 3 4 5 6 7 8 9 10 11 12)
+  printf ' %s\n\x1b[38;2;134;134;134m\xe2\x9d\xaf \x1b[39mRun the shell command: sleep 60\n %s\n' "$rule" "$rule" > "$resp/1.out"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_composer_state default:w1:p2' "$ROOT" )
+  [ "$out" = pending ] || fail "real typed text in copilot's composer must read pending, got '$out'"
+  pass "fm_backend_herdr_composer_state: copilot's typed-unsubmitted text reads pending"
+}
+
 test_composer_state_codex_bare_prompt_glyph_is_empty() {
   local dir log resp fb out
   dir="$TMP_ROOT/composer-codex-bare"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
@@ -2830,6 +2863,8 @@ test_composer_state_claude_dim_prompt_suggestion_ghost_is_empty
 test_composer_state_claude_dim_ghost_row_with_real_text_is_pending
 test_composer_state_grok_dark_truecolor_placeholder_is_empty
 test_composer_state_grok_bright_truecolor_real_text_is_pending
+test_composer_state_copilot_bare_glyph_between_rules_is_empty
+test_composer_state_copilot_typed_text_is_pending
 test_composer_state_codex_bare_prompt_glyph_is_empty
 test_composer_state_codex_faint_suggestion_is_empty
 test_composer_state_codex_non_faint_same_text_is_pending

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -775,6 +775,7 @@ unsupported codex max effort is flagged^{"rules":[{"when":"big feature","use":{"
 unsupported grok max effort is flagged^{"rules":[{"when":"deep current work","use":{"harness":"grok","model":"grok-4","effort":"max"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: grok:max
 unsupported grok xhigh effort is flagged^{"rules":[{"when":"deep current work","use":{"harness":"grok","model":"grok-4","effort":"xhigh"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: grok:xhigh
 pi max effort is accepted^{"rules":[{"when":"deep coding","use":{"harness":"pi","model":"openai-codex/gpt-5.6-sol","effort":"max"}}]}^empty^
+copilot max effort is accepted^{"rules":[{"when":"github work","use":{"harness":"copilot","effort":"max"}}]}^empty^
 unsupported opencode effort is flagged^{"rules":[{"when":"opencode work","use":{"harness":"opencode","model":"anthropic/claude-sonnet-4-5","effort":"high"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: opencode:high
 array use with quota-balanced is accepted^{"rules":[{"when":"big feature","use":[{"harness":"claude","model":"claude-sonnet-5","effort":"high"},{"harness":"codex","model":"gpt-5.5","effort":"high"}],"select":"quota-balanced"}]}^empty^
 array use without select is accepted^{"rules":[{"when":"big feature","use":[{"harness":"claude"},{"harness":"codex"}]}]}^empty^

--- a/tests/fm-copilot-harness.test.sh
+++ b/tests/fm-copilot-harness.test.sh
@@ -78,6 +78,33 @@ test_fm_lock_recognizes_copilot_holder() {
   pass "fm-lock recognizes a copilot holder as live"
 }
 
+test_fm_lock_acquires_under_path_prefixed_copilot() {
+  local home fakebin out status
+  home="$TMP_ROOT/pathargv-home"
+  fakebin=$(fm_fakebin "$TMP_ROOT/pathargv-fake")
+  mkdir -p "$home/state"
+  # A copilot primary launched via an absolute path keeps comm MainThread but
+  # carries the full path in argv[0]; it must still read as a harness.
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *"ppid="*) exit 1 ;;
+  *"comm="*) printf '%s\n' 'MainThread'; exit 0 ;;
+  *"args="*) printf '%s\n' '/home/x/.local/bin/copilot --allow-all'; exit 0 ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/ps"
+  out=$(FM_HOME="$home" PATH="$fakebin:$PATH" "$LOCK")
+  status=$?
+  expect_code 0 "$status" "path-prefixed copilot argv should acquire the lock"
+  assert_contains "$out" "lock acquired: harness pid" "fm-lock did not accept a path-prefixed copilot argv[0]"
+  printf '%s\n' "$$" > "$home/state/.lock"
+  out=$(FM_HOME="$home" PATH="$fakebin:$PATH" "$LOCK" status)
+  assert_contains "$out" "lock: held by live harness pid" "path-prefixed copilot holder should read as live"
+  pass "fm-lock recognizes a path-prefixed copilot argv[0]"
+}
+
 test_fm_lock_ignores_unrelated_copilot_argv() {
   local home fakebin out status
   home="$TMP_ROOT/plugin-home"
@@ -184,7 +211,21 @@ SH
   chmod +x "$fakebin/ps"
   out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT PATH="$fakebin:$PATH" "$HARNESS")
   [ "$out" = copilot ] || fail "fm-harness printed '$out' instead of copilot for a copilot comm"
-  pass "fm-harness reports copilot distinctly for both observed process shapes"
+
+  # MainThread comm with a path-prefixed argv[0] (absolute-path launch).
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *"ppid="*) exit 1 ;;
+  *"comm="*) printf '%s\n' 'MainThread'; exit 0 ;;
+  *"args="*) printf '%s\n' '/home/x/.local/bin/copilot --allow-all'; exit 0 ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/ps"
+  out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT PATH="$fakebin:$PATH" "$HARNESS")
+  [ "$out" = copilot ] || fail "fm-harness printed '$out' instead of copilot for a path-prefixed argv[0]"
+  pass "fm-harness reports copilot distinctly for all observed process shapes"
 }
 
 test_fm_harness_existing_detection_unchanged() {
@@ -366,6 +407,7 @@ EOF
 test_fm_lock_acquires_under_copilot_ancestor
 test_fm_lock_overwrites_stale_dead_copilot_holder
 test_fm_lock_recognizes_copilot_holder
+test_fm_lock_acquires_under_path_prefixed_copilot
 test_fm_lock_ignores_unrelated_copilot_argv
 test_fm_lock_holder_argv_only_matters_for_interpreters
 test_fm_lock_acquires_under_renamed_copilot_wrapper

--- a/tests/fm-copilot-harness.test.sh
+++ b/tests/fm-copilot-harness.test.sh
@@ -1,10 +1,15 @@
 #!/usr/bin/env bash
-# Behavior tests for GitHub Copilot CLI recognition: session-lock acquisition and
-# holder detection, own-harness detection, anchored non-matches against unrelated
-# copilot-flavored argv, and the dispatch refusal that keeps copilot lock/detection
-# only (never a crew/secondmate harness).
+# Behavior tests for GitHub Copilot CLI recognition and crew/secondmate dispatch:
+# session-lock acquisition and holder detection, own-harness detection, anchored
+# non-matches against unrelated copilot-flavored argv, the verified launch template
+# with model/effort flags, the repo-level agentStop turn-end hook install, and its
+# teardown cleanup.
 # Empirical shape (copilot 1.0.73, 2026-07-21): `ps -o comm=` reports "MainThread"
 # (the bundled ELF renames its main thread) and `ps -o args=` is exactly "copilot".
+# Dispatch facts (same session, harness-adapters "copilot" section): -i takes the
+# prompt as its value and auto-executes, --allow-all + --no-ask-user run a turn
+# fully unattended, --effort accepts firstmate's full low..max vocabulary, and
+# repo-level .github/hooks/*.json fire agentStop at every completed turn end.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -200,41 +205,162 @@ SH
   pass "existing pi detection is unchanged by the copilot entry"
 }
 
-test_spawn_refuses_copilot_dispatch() {
-  local case_dir home proj wt fakebin id out status
-  case_dir="$TMP_ROOT/spawn-refuse"
+# A tmux stub that behaves like the grok test's spawn stub but also captures the
+# literal `send-keys -l <cmd>` launch command into FM_FAKE_LAUNCH_LOG, mirroring
+# tests/fm-secondmate-harness.test.sh's make_launch_capturing_tmux.
+make_copilot_spawn_fakebin() {
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+esac
+case "${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+  list-windows) exit 0 ;;
+  has-session|new-session|new-window|kill-window) exit 0 ;;
+  send-keys)
+    if [ -n "${FM_FAKE_LAUNCH_LOG:-}" ]; then
+      prev=
+      for a in "$@"; do
+        if [ "$prev" = "-l" ]; then
+          printf '%s\n' "$a" >> "$FM_FAKE_LAUNCH_LOG"
+        fi
+        prev=$a
+      done
+    fi
+    exit 0
+    ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" treehouse gh-axi gh
+  printf '%s\n' "$fakebin"
+}
+
+make_copilot_spawn_case() {
+  local name=$1 case_dir home proj wt fakebin id
+  case_dir="$TMP_ROOT/$name"
   home="$case_dir/home"
   proj="$case_dir/project"
   wt="$case_dir/wt"
-  fakebin=$(fm_fakebin "$case_dir/fake")
-  id="copilot-refuse-x1"
+  fakebin=$(make_copilot_spawn_fakebin "$case_dir/fake")
+  id="copilot-$name-x1"
   mkdir -p "$home/data/$id" "$home/projects" "$home/state" "$home/config"
   printf 'brief\n' > "$home/data/$id/brief.md"
   fm_git_worktree "$proj" "$wt" "fm/$id"
   touch "$home/state/.last-watcher-beat"
-  fm_fake_exit0 "$fakebin" tmux treehouse gh-axi gh
+  printf '%s\n' "$case_dir|$home|$proj|$wt|$fakebin|$id"
+}
 
-  # Explicit harness argument.
-  out=$(FM_ROOT_OVERRIDE='' FM_HOME="$home" \
+run_copilot_spawn() {
+  local home=$1 proj=$2 wt=$3 fakebin=$4 id=$5 launchlog=$6
+  shift 6
+  FM_ROOT_OVERRIDE='' FM_HOME="$home" \
     FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
     FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
-    FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" PATH="$fakebin:$PATH" \
-    "$SPAWN" "$id" "$proj" copilot 2>&1)
-  status=$?
-  expect_code 1 "$status" "explicit copilot harness must be refused"
-  assert_contains "$out" "unknown harness 'copilot'" "spawn did not refuse the explicit copilot harness"
+    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" FM_FAKE_LAUNCH_LOG="$launchlog" \
+    TMUX="fake,1,0" PATH="$fakebin:$PATH" \
+    "$SPAWN" "$id" "$proj" copilot "$@" 2>&1
+}
 
-  # Configured crew harness resolving to copilot.
-  printf 'copilot\n' > "$home/config/crew-harness"
-  out=$(FM_ROOT_OVERRIDE='' FM_HOME="$home" \
-    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
-    FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
-    FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" PATH="$fakebin:$PATH" \
-    "$SPAWN" "$id" "$proj" 2>&1)
+test_spawn_dispatches_copilot_with_flags_and_turnend_hook() {
+  local rec case_dir home proj wt fakebin id launchlog out status launch hook excl meta
+  rec=$(make_copilot_spawn_case dispatch)
+  IFS='|' read -r case_dir home proj wt fakebin id <<EOF
+$rec
+EOF
+  launchlog="$case_dir/launch.log"
+  : > "$launchlog"
+  out=$(run_copilot_spawn "$home" "$proj" "$wt" "$fakebin" "$id" "$launchlog" \
+    --model claude-haiku-4.5 --effort low)
   status=$?
-  expect_code 1 "$status" "crew-harness copilot must be refused"
-  assert_contains "$out" "no launch template for harness 'copilot'" "spawn did not refuse the configured copilot crew harness"
-  pass "crew/secondmate dispatch of copilot is still refused fail-closed"
+  expect_code 0 "$status" "copilot spawn should succeed"
+  assert_contains "$out" "spawned $id harness=copilot" "copilot spawn did not report success"
+
+  launch=$(cat "$launchlog")
+  assert_contains "$launch" "copilot --allow-all --no-ask-user " \
+    "launch command lost the verified unattended-autonomy flags"
+  assert_contains "$launch" "--model 'claude-haiku-4.5'" "launch command lost the model flag"
+  assert_contains "$launch" "--effort 'low'" "launch command lost the effort flag"
+# shellcheck disable=SC2016  # single quotes are deliberate: the literal $(cat ...) must appear in the launch command
+  assert_contains "$launch" '-i "$(cat ' \
+    "launch command must pass the brief as -i's value (auto-executing interactive mode)"
+
+  hook="$wt/.github/hooks/fm-turn-end.json"
+  assert_present "$hook" "repo-level agentStop turn-end hook was not installed"
+  assert_grep 'agentStop' "$hook" "turn-end hook is not registered on the agentStop event"
+  assert_grep "$id.turn-ended" "$hook" "turn-end hook does not touch the task's turn-ended file"
+  excl=$(git -C "$wt" rev-parse --git-path info/exclude)
+  assert_grep '.github/hooks/fm-turn-end.json' "$excl" \
+    "turn-end hook file was not git-excluded (would dirty teardown's landed-work check)"
+
+  meta="$home/state/$id.meta"
+  assert_grep 'harness=copilot' "$meta" "meta did not record harness=copilot"
+  pass "copilot dispatch wires the verified launch template, flags, and agentStop hook"
+}
+
+test_spawn_copilot_omits_default_model_effort() {
+  local rec case_dir home proj wt fakebin id launchlog out status launch
+  rec=$(make_copilot_spawn_case defaults)
+  IFS='|' read -r case_dir home proj wt fakebin id <<EOF
+$rec
+EOF
+  launchlog="$case_dir/launch.log"
+  : > "$launchlog"
+  out=$(run_copilot_spawn "$home" "$proj" "$wt" "$fakebin" "$id" "$launchlog")
+  status=$?
+  expect_code 0 "$status" "flagless copilot spawn should succeed"
+  launch=$(cat "$launchlog")
+  case "$launch" in
+    *--model*|*--effort*) fail "default model/effort must emit no flag, got: $launch" ;;
+  esac
+  pass "copilot dispatch omits model/effort flags when unset"
+}
+
+# The live-captured busy and idle footers (copilot 1.0.73, 2026-07-21). The busy
+# footer must match the shared default busy regex (via its "esc (to )?interrupt"
+# alternative - no copilot-specific entry exists) and the idle footer must not,
+# so a working copilot crew reads busy and an idle one reads stale-eligible.
+test_copilot_busy_footer_matches_default_busy_regex() {
+  local regex
+  regex=$(bash -c '. "$0/bin/fm-tmux-lib.sh"; printf "%s" "$FM_TMUX_BUSY_REGEX_DEFAULT"' "$ROOT")
+  printf '%s' ' ◎ Working · 916 B esc interrupt' | grep -qiE "$regex" \
+    || fail "copilot's live busy footer did not match the default busy regex"
+  printf '%s' ' ● Working esc interrupt' | grep -qiE "$regex" \
+    || fail "copilot's byte-count-free busy footer did not match the default busy regex"
+  printf '%s' ' / commands · ? help · tab next tab' | grep -qiE "$regex" \
+    && fail "copilot's idle footer must not match the busy regex"
+  grep -qF "BUSY_REGEX=\${FM_BUSY_REGEX:-'esc (to )?interrupt|Working\\.\\.\\.|Ctrl\\+c:cancel'}" "$ROOT/bin/fm-watch.sh" \
+    || fail "fm-watch.sh BUSY_REGEX default drifted from the value these footers were verified against"
+  pass "copilot busy/idle footers classify correctly under the shared busy regex"
+}
+
+test_copilot_teardown_removes_turnend_hook() {
+  local rec case_dir home proj wt fakebin id launchlog out status
+  rec=$(make_copilot_spawn_case teardown)
+  IFS='|' read -r case_dir home proj wt fakebin id <<EOF
+$rec
+EOF
+  launchlog="$case_dir/launch.log"
+  : > "$launchlog"
+  out=$(run_copilot_spawn "$home" "$proj" "$wt" "$fakebin" "$id" "$launchlog")
+  status=$?
+  expect_code 0 "$status" "copilot spawn should succeed before teardown"
+  assert_present "$wt/.github/hooks/fm-turn-end.json" "hook missing before teardown"
+
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    PATH="$fakebin:$PATH" \
+    "$ROOT/bin/fm-teardown.sh" "$id" --force >/dev/null 2>&1 \
+    || fail "copilot teardown failed"
+
+  assert_absent "$wt/.github/hooks/fm-turn-end.json" \
+    "agentStop hook survived teardown (a reused pool worktree would fire signals for a dead task)"
+  assert_absent "$home/state/$id.turn-ended" "turn-ended state file survived teardown"
+  pass "copilot teardown removes the repo-level agentStop hook"
 }
 
 test_fm_lock_acquires_under_copilot_ancestor
@@ -245,4 +371,7 @@ test_fm_lock_holder_argv_only_matters_for_interpreters
 test_fm_lock_acquires_under_renamed_copilot_wrapper
 test_fm_harness_reports_copilot
 test_fm_harness_existing_detection_unchanged
-test_spawn_refuses_copilot_dispatch
+test_spawn_dispatches_copilot_with_flags_and_turnend_hook
+test_spawn_copilot_omits_default_model_effort
+test_copilot_busy_footer_matches_default_busy_regex
+test_copilot_teardown_removes_turnend_hook

--- a/tests/fm-copilot-harness.test.sh
+++ b/tests/fm-copilot-harness.test.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+# Behavior tests for GitHub Copilot CLI recognition: session-lock acquisition and
+# holder detection, own-harness detection, anchored non-matches against unrelated
+# copilot-flavored argv, and the dispatch refusal that keeps copilot lock/detection
+# only (never a crew/secondmate harness).
+# Empirical shape (copilot 1.0.73, 2026-07-21): `ps -o comm=` reports "MainThread"
+# (the bundled ELF renames its main thread) and `ps -o args=` is exactly "copilot".
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+LOCK="$ROOT/bin/fm-lock.sh"
+HARNESS="$ROOT/bin/fm-harness.sh"
+SPAWN="$ROOT/bin/fm-spawn.sh"
+TMP_ROOT=$(fm_test_tmproot fm-copilot-harness)
+
+# Fake ps reproducing the observed copilot process shape for every queried pid.
+make_copilot_ps() {
+  local fakebin=$1
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *"ppid="*) exit 1 ;;
+  *"comm="*) printf '%s\n' 'MainThread'; exit 0 ;;
+  *"args="*) printf '%s\n' 'copilot'; exit 0 ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/ps"
+}
+
+test_fm_lock_acquires_under_copilot_ancestor() {
+  local home fakebin out status
+  home="$TMP_ROOT/acquire-home"
+  fakebin=$(fm_fakebin "$TMP_ROOT/acquire-fake")
+  mkdir -p "$home/state"
+  make_copilot_ps "$fakebin"
+  out=$(FM_HOME="$home" PATH="$fakebin:$PATH" "$LOCK")
+  status=$?
+  expect_code 0 "$status" "copilot-ancestored lock acquisition should succeed"
+  assert_contains "$out" "lock acquired: harness pid" "fm-lock did not acquire under a copilot ancestor"
+  assert_present "$home/state/.lock" "lock file was not written"
+  pass "fm-lock acquires under a copilot ancestor (comm MainThread, args copilot)"
+}
+
+test_fm_lock_overwrites_stale_dead_copilot_holder() {
+  local home fakebin dead out status
+  home="$TMP_ROOT/stale-home"
+  fakebin=$(fm_fakebin "$TMP_ROOT/stale-fake")
+  mkdir -p "$home/state"
+  make_copilot_ps "$fakebin"
+  dead=$(bash -c 'echo $$')
+  while kill -0 "$dead" 2>/dev/null; do sleep 0.1; done
+  printf '%s\n' "$dead" > "$home/state/.lock"
+  out=$(FM_HOME="$home" PATH="$fakebin:$PATH" "$LOCK")
+  status=$?
+  expect_code 0 "$status" "stale dead-holder lock should be overwritten"
+  assert_contains "$out" "lock acquired: harness pid" "fm-lock did not overwrite the stale holder"
+  [ "$(cat "$home/state/.lock")" != "$dead" ] || fail "stale holder pid survived in the lock file"
+  pass "fm-lock overwrites a stale dead-holder lock under a copilot ancestor"
+}
+
+test_fm_lock_recognizes_copilot_holder() {
+  local home fakebin out
+  home="$TMP_ROOT/holder-home"
+  fakebin=$(fm_fakebin "$TMP_ROOT/holder-fake")
+  mkdir -p "$home/state"
+  printf '%s\n' "$$" > "$home/state/.lock"
+  make_copilot_ps "$fakebin"
+  out=$(FM_HOME="$home" PATH="$fakebin:$PATH" "$LOCK" status)
+  assert_contains "$out" "lock: held by live harness pid" "fm-lock did not recognize copilot as a live holder"
+  pass "fm-lock recognizes a copilot holder as live"
+}
+
+test_fm_lock_ignores_unrelated_copilot_argv() {
+  local home fakebin out status
+  home="$TMP_ROOT/plugin-home"
+  fakebin=$(fm_fakebin "$TMP_ROOT/plugin-fake")
+  mkdir -p "$home/state"
+  # A node process whose argv only mentions copilot inside plugin paths (the
+  # VS Code tsserver shape observed alongside the real copilot CLI) must not
+  # be mistaken for a harness.
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *"ppid="*) exit 1 ;;
+  *"comm="*) printf '%s\n' 'node'; exit 0 ;;
+  *"args="*) printf '%s\n' 'node tsserver.js --globalPlugins @vscode/copilot-typescript-server-plugin --pluginProbeLocations /x/extensions/copilot --locale en'; exit 0 ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/ps"
+  out=$(FM_HOME="$home" PATH="$fakebin:$PATH" "$LOCK" 2>&1)
+  status=$?
+  expect_code 1 "$status" "plugin-path argv must not be recognized as a harness"
+  assert_contains "$out" "cannot locate harness process" "fm-lock accepted vscode copilot plugin argv as a harness"
+  printf '%s\n' "$$" > "$home/state/.lock"
+  out=$(FM_HOME="$home" PATH="$fakebin:$PATH" "$LOCK" status)
+  assert_contains "$out" "lock: stale" "holder with only plugin-path copilot argv should read as stale"
+  pass "anchored copilot match ignores vscode plugin paths in unrelated argv"
+}
+
+test_fm_lock_acquires_under_renamed_copilot_wrapper() {
+  local home wrapper out status
+  home="$TMP_ROOT/wrapper-home"
+  mkdir -p "$home/state" "$TMP_ROOT/wrapper-bin"
+  # Real ps, real ancestry: a wrapper process whose comm is "copilot" (a script
+  # named copilot) stands in for the CLI on platforms where comm is the binary name.
+  wrapper="$TMP_ROOT/wrapper-bin/copilot"
+  # Direct shebang: an env shebang would exec bash and reset comm to "bash",
+  # while a direct interpreter keeps comm as the script name "copilot".
+  cat > "$wrapper" <<'SH'
+#!/bin/bash
+"$@"
+SH
+  chmod +x "$wrapper"
+  out=$(FM_HOME="$home" "$wrapper" "$LOCK")
+  status=$?
+  expect_code 0 "$status" "lock acquisition under a copilot-named ancestor should succeed"
+  assert_contains "$out" "lock acquired: harness pid" "fm-lock did not find the copilot-named ancestor with real ps"
+  pass "fm-lock acquires under a real copilot-named ancestor process"
+}
+
+test_fm_harness_reports_copilot() {
+  local fakebin out
+  fakebin=$(fm_fakebin "$TMP_ROOT/detect-fake")
+  make_copilot_ps "$fakebin"
+  out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT PATH="$fakebin:$PATH" "$HARNESS")
+  [ "$out" = copilot ] || fail "fm-harness printed '$out' instead of copilot for the MainThread/args shape"
+
+  # comm reported directly as the binary name (non-thread-renaming platforms).
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *"ppid="*) exit 1 ;;
+  *"comm="*) printf '%s\n' '/home/x/.local/bin/copilot'; exit 0 ;;
+  *"args="*) printf '%s\n' 'copilot'; exit 0 ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/ps"
+  out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT PATH="$fakebin:$PATH" "$HARNESS")
+  [ "$out" = copilot ] || fail "fm-harness printed '$out' instead of copilot for a copilot comm"
+  pass "fm-harness reports copilot distinctly for both observed process shapes"
+}
+
+test_fm_harness_existing_detection_unchanged() {
+  local fakebin out
+  fakebin=$(fm_fakebin "$TMP_ROOT/regress-fake")
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *"ppid="*) exit 1 ;;
+  *"comm="*) printf '%s\n' 'pi'; exit 0 ;;
+  *"args="*) printf '%s\n' 'pi'; exit 0 ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/ps"
+  out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT PATH="$fakebin:$PATH" "$HARNESS")
+  [ "$out" = pi ] || fail "fm-harness printed '$out' instead of pi (anchoring regression)"
+  pass "existing pi detection is unchanged by the copilot entry"
+}
+
+test_spawn_refuses_copilot_dispatch() {
+  local case_dir home proj wt fakebin id out status
+  case_dir="$TMP_ROOT/spawn-refuse"
+  home="$case_dir/home"
+  proj="$case_dir/project"
+  wt="$case_dir/wt"
+  fakebin=$(fm_fakebin "$case_dir/fake")
+  id="copilot-refuse-x1"
+  mkdir -p "$home/data/$id" "$home/projects" "$home/state" "$home/config"
+  printf 'brief\n' > "$home/data/$id/brief.md"
+  fm_git_worktree "$proj" "$wt" "fm/$id"
+  touch "$home/state/.last-watcher-beat"
+  fm_fake_exit0 "$fakebin" tmux treehouse gh-axi gh
+
+  # Explicit harness argument.
+  out=$(FM_ROOT_OVERRIDE='' FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
+    FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" PATH="$fakebin:$PATH" \
+    "$SPAWN" "$id" "$proj" copilot 2>&1)
+  status=$?
+  expect_code 1 "$status" "explicit copilot harness must be refused"
+  assert_contains "$out" "unknown harness 'copilot'" "spawn did not refuse the explicit copilot harness"
+
+  # Configured crew harness resolving to copilot.
+  printf 'copilot\n' > "$home/config/crew-harness"
+  out=$(FM_ROOT_OVERRIDE='' FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
+    FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" PATH="$fakebin:$PATH" \
+    "$SPAWN" "$id" "$proj" 2>&1)
+  status=$?
+  expect_code 1 "$status" "crew-harness copilot must be refused"
+  assert_contains "$out" "no launch template for harness 'copilot'" "spawn did not refuse the configured copilot crew harness"
+  pass "crew/secondmate dispatch of copilot is still refused fail-closed"
+}
+
+test_fm_lock_acquires_under_copilot_ancestor
+test_fm_lock_overwrites_stale_dead_copilot_holder
+test_fm_lock_recognizes_copilot_holder
+test_fm_lock_ignores_unrelated_copilot_argv
+test_fm_lock_acquires_under_renamed_copilot_wrapper
+test_fm_harness_reports_copilot
+test_fm_harness_existing_detection_unchanged
+test_spawn_refuses_copilot_dispatch

--- a/tests/fm-copilot-harness.test.sh
+++ b/tests/fm-copilot-harness.test.sh
@@ -101,6 +101,43 @@ SH
   pass "anchored copilot match ignores vscode plugin paths in unrelated argv"
 }
 
+test_fm_lock_holder_argv_only_matters_for_interpreters() {
+  local home fakebin out
+  home="$TMP_ROOT/recycled-home"
+  fakebin=$(fm_fakebin "$TMP_ROOT/recycled-fake")
+  mkdir -p "$home/state"
+  printf '%s\n' "$$" > "$home/state/.lock"
+  # Recycled pid: comm gh, argv merely containing the word copilot must not
+  # read as a live harness holder.
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *"ppid="*) exit 1 ;;
+  *"comm="*) printf '%s\n' 'gh'; exit 0 ;;
+  *"args="*) printf '%s\n' 'gh copilot suggest fix my code'; exit 0 ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/ps"
+  out=$(FM_HOME="$home" PATH="$fakebin:$PATH" "$LOCK" status)
+  assert_contains "$out" "lock: stale" "gh-comm holder with copilot argv should read as stale"
+
+  # comm-only path still recognizes a real harness comm.
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *"ppid="*) exit 1 ;;
+  *"comm="*) printf '%s\n' 'claude'; exit 0 ;;
+  *"args="*) printf '%s\n' 'claude'; exit 0 ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/ps"
+  out=$(FM_HOME="$home" PATH="$fakebin:$PATH" "$LOCK" status)
+  assert_contains "$out" "lock: held by live harness pid" "claude comm holder should still read as live"
+  pass "holder argv is only trusted for interpreter/MainThread comms"
+}
+
 test_fm_lock_acquires_under_renamed_copilot_wrapper() {
   local home wrapper out status
   home="$TMP_ROOT/wrapper-home"
@@ -204,6 +241,7 @@ test_fm_lock_acquires_under_copilot_ancestor
 test_fm_lock_overwrites_stale_dead_copilot_holder
 test_fm_lock_recognizes_copilot_holder
 test_fm_lock_ignores_unrelated_copilot_argv
+test_fm_lock_holder_argv_only_matters_for_interpreters
 test_fm_lock_acquires_under_renamed_copilot_wrapper
 test_fm_harness_reports_copilot
 test_fm_harness_existing_detection_unchanged

--- a/tests/fm-copilot-harness.test.sh
+++ b/tests/fm-copilot-harness.test.sh
@@ -228,6 +228,24 @@ SH
   pass "fm-harness reports copilot distinctly for all observed process shapes"
 }
 
+test_fm_harness_copilot_brief_argv_mentions_other_harness() {
+  local fakebin out
+  fakebin=$(fm_fakebin "$TMP_ROOT/brief-fake")
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *"ppid="*) exit 1 ;;
+  *"comm="*) printf '%s\n' 'MainThread'; exit 0 ;;
+  *"args="*) printf '%s\n' 'copilot --allow-all --no-ask-user -i Update CLAUDE.md per the brief'; exit 0 ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/ps"
+  out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT PATH="$fakebin:$PATH" "$HARNESS")
+  [ "$out" = copilot ] || fail "fm-harness printed '$out' instead of copilot when the -i brief argv mentions claude"
+  pass "copilot detection wins over unanchored harness names in the brief argv"
+}
+
 test_fm_harness_existing_detection_unchanged() {
   local fakebin out
   fakebin=$(fm_fakebin "$TMP_ROOT/regress-fake")
@@ -412,6 +430,7 @@ test_fm_lock_ignores_unrelated_copilot_argv
 test_fm_lock_holder_argv_only_matters_for_interpreters
 test_fm_lock_acquires_under_renamed_copilot_wrapper
 test_fm_harness_reports_copilot
+test_fm_harness_copilot_brief_argv_mentions_other_harness
 test_fm_harness_existing_detection_unchanged
 test_spawn_dispatches_copilot_with_flags_and_turnend_hook
 test_spawn_copilot_omits_default_model_effort

--- a/tests/fm-secondmate-liveness.test.sh
+++ b/tests/fm-secondmate-liveness.test.sh
@@ -85,6 +85,13 @@ test_tmux_agent_alive_classifies() {
   [ "$(PATH="$fb:$BASE_PATH" bash -c '. "$0/bin/fm-backend.sh"; fm_backend_source tmux; fm_backend_tmux_agent_alive sess:win' "$ROOT")" = alive ] \
     || fail "a live grok foreground process should classify as alive"
 
+  # copilot's ELF renames its main thread (ps comm "MainThread"), but tmux's
+  # #{pane_current_command} is cmdline-derived and reports "copilot" (verified
+  # live, copilot 1.0.73, 2026-07-21).
+  fb=$(make_probe_tmux "$TMP_ROOT/tmux-copilot" copilot)
+  [ "$(PATH="$fb:$BASE_PATH" bash -c '. "$0/bin/fm-backend.sh"; fm_backend_source tmux; fm_backend_tmux_agent_alive sess:win' "$ROOT")" = alive ] \
+    || fail "a live copilot foreground process should classify as alive"
+
   fb=$(make_probe_tmux "$TMP_ROOT/tmux-zsh" zsh)
   [ "$(PATH="$fb:$BASE_PATH" bash -c '. "$0/bin/fm-backend.sh"; fm_backend_source tmux; fm_backend_tmux_agent_alive sess:win' "$ROOT")" = dead ] \
     || fail "a bare zsh foreground process should classify as dead"

--- a/tests/fm-supervision-instructions.test.sh
+++ b/tests/fm-supervision-instructions.test.sh
@@ -32,7 +32,8 @@ test_copilot_detected_but_manual() {
   out=$("$RENDER" --harness copilot)
   assert_contains "$out" "SUPERVISION OPERATING INSTRUCTIONS - primary harness: copilot" "copilot heading missing or renamed to unknown"
   assert_contains "$out" "Mode: Unknown harness fallback." "copilot did not get the manual-supervision fallback snippet"
-  assert_contains "$out" "never dispatchable for crew or secondmate work" "copilot harness note missing"
+  assert_contains "$out" "no verified watcher wake adapter on copilot" "copilot harness note missing"
+  assert_contains "$out" "verified crew/secondmate dispatch harness" "copilot harness note lost the dispatchability fact"
   assert_not_contains "$out" "Mode: Claude background-notify supervision." "copilot must not claim a wired watcher protocol"
   out=$("$RENDER" --harness copilot --repair-line)
   assert_contains "$out" "according to the session-start block for this harness" "copilot repair line should be the generic one"

--- a/tests/fm-supervision-instructions.test.sh
+++ b/tests/fm-supervision-instructions.test.sh
@@ -27,6 +27,18 @@ test_unknown_fallback() {
   pass "renderer falls back to unknown.md for unverified harness names"
 }
 
+test_copilot_detected_but_manual() {
+  local out
+  out=$("$RENDER" --harness copilot)
+  assert_contains "$out" "SUPERVISION OPERATING INSTRUCTIONS - primary harness: copilot" "copilot heading missing or renamed to unknown"
+  assert_contains "$out" "Mode: Unknown harness fallback." "copilot did not get the manual-supervision fallback snippet"
+  assert_contains "$out" "never dispatchable for crew or secondmate work" "copilot harness note missing"
+  assert_not_contains "$out" "Mode: Claude background-notify supervision." "copilot must not claim a wired watcher protocol"
+  out=$("$RENDER" --harness copilot --repair-line)
+  assert_contains "$out" "according to the session-start block for this harness" "copilot repair line should be the generic one"
+  pass "copilot keeps its name but degrades to manual supervision with no wired protocol"
+}
+
 test_conditional_stanzas() {
   local home config out
   home="$TMP_ROOT/conditional-home"
@@ -135,6 +147,7 @@ test_pi_snippet_uses_effective_extension_path() {
 
 test_selected_harness_block_only
 test_unknown_fallback
+test_copilot_detected_but_manual
 test_conditional_stanzas
 test_repair_lines
 test_ordinary_wake_lines_are_distinct_from_repair


### PR DESCRIPTION
Phase 1 of Copilot CLI parity: crew/secondmate DISPATCH, per the copilot-parity investigation report. Every wired fact is backed by live empirical verification on copilot 1.0.73 (2026-07-21), recorded in the new `## copilot (VERIFIED ...)` section of the harness-adapters skill.

**Includes PR #816's commits rebased onto main** (lock/detection is a prerequisite; on plain main copilot is unrecognized). If this merges first, #816 can be closed as superseded.

## What this adds
- `fm-spawn`: copilot launch template (`copilot --allow-all --no-ask-user -i "$(cat brief)"` - `-i` takes the prompt as its value and auto-executes), `--model`/`--effort` passthrough (copilot accepts firstmate's full low..max effort vocabulary), secondmate positional harness support.
- Crew turn-end signal: copilot fires `agentStop` at every completed turn from repo-level `.github/hooks/*.json` with no extra trust gate (verified with a live hook probe), so fm-spawn installs a git-excluded `.github/hooks/fm-turn-end.json` per task worktree - the claude `settings.local.json` shape. `fm-teardown` removes it before pool return.
- `backends/tmux` agent liveness: copilot matches by name - tmux's `#{pane_current_command}` is cmdline-derived (`copilot`) even though ps comm is `MainThread` (evidence in `docs/tmux-backend.md`).
- Busy/composer: no regex or classifier changes needed - copilot's busy footer matches the existing `esc (to )?interrupt` alternative and its bare `❯` composer classifies correctly through the shared owner (verified live on tmux; herdr regression-fixtured with real captured ANSI rows).
- `fm-bootstrap`: copilot joins the confident-dead liveness list and the crew-dispatch profile validation (verified-harness list + effort branch).
- harness-adapters skill: full `## copilot (VERIFIED ...)` facts section (trust dialog, Ctrl+C interrupt - Esc does not cancel a running sync shell tool, `/exit`/resume, `/<skill>` invocation); AGENTS.md and docs drop the never-dispatchable language. Copilot remains NOT a verified primary (Phase 2).
- Tests: dispatch/teardown/busy-regex/liveness/herdr-composer coverage; suite green; `bin/fm-lint.sh` clean on pinned ShellCheck 0.11.0.

Validated by the no-mistakes pipeline (review, full test suite, docs, lint all green; pipeline fixes: stale fm-lock comment, doc harness enumerations, path-prefixed copilot argv anchors per captain decision, bootstrap dispatch validation per captain decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)