### PR TITLE
fix: surface main inventory gaps in Bearings

### DIFF
--- a/.agents/skills/bearings/SKILL.md
+++ b/.agents/skills/bearings/SKILL.md
@@ -26,6 +26,7 @@ It never tears down a task, merges a PR, dispatches new work, or mutates any tas
    For registered secondmates, use the snapshot's structured-home classification and provenance; a parent event or bounded terminal contradiction is fallback evidence, never authority over readable structured home state.
    Structured captain-held decisions come from `decision-hold-lifecycle` and appear under `decisions_open`; do not scrape reports or visual-review artifacts to supplement them.
    A queued item under `gates` only becomes "next work" when its blocker is gone and its time/date gate has arrived; until then it stays queued with the reason.
+   The `(main-inventory)` gate is an action-free integrity warning rather than queued work: render it under Charted Next with the related `omitted` disclosure, never invent an Underway row from backlog-only state, and never move it into Captain's Call.
 
 2. **Compose the detailed report file around the four-section spine, adding the richer detail the chat leaves out.**
    The gather step is deterministic; your judgment is scoped to the last mile only - ranking the command's facts by what matters right now and writing the scannable prose.
@@ -35,7 +36,7 @@ It never tears down a task, merges a PR, dispatches new work, or mutates any tas
    - **Captain's Call** - every open decision summarized with its options from the structured decision record, plus each PR ready to merge and each needed credential or login, every PR with the full `https://...` URL, never a bare `#number`.
    - **Recently Landed** - the bounded current recent-completions baseline from structured state across the main fleet and every registered secondmate home, rendered in full on every run.
    - **Underway** - each live direct report making progress, with its current state, and the plans / main pickup pointers worth reopening (`data/<id>/report.md` files, `.lavish/*.html` boards).
-   - **Charted Next** - queued or gated next work, with each item's blocker or date reason.
+   - **Charted Next** - queued or gated work, including any main-inventory integrity warning, with each item's blocker, date, or integrity reason.
 
 3. **Write the dated report file so it persists, then surface the mandatory four-section digest in chat.**
    - Write the full report to `data/status-report-<YYYY-MM-DD>.md` using today's date.
@@ -55,7 +56,7 @@ Every `/bearings` chat response renders EXACTLY these four sections, in THIS ord
    Empty-state: "No recent completions are in the current baseline."
 3. **Underway** - live work progressing on its own, one line of current state per direct report.
    Empty-state: "Nothing is underway."
-4. **Charted Next** - queued or gated work waiting on the fleet or a date, never on the captain.
+4. **Charted Next** - queued or gated work waiting on the fleet or a date, plus action-free fleet-integrity warnings, never on the captain.
    Empty-state: "Nothing is queued."
 
 Rules that keep the contract unambiguous:
@@ -63,7 +64,7 @@ Rules that keep the contract unambiguous:
 - Every section ALWAYS renders, even when empty, with its short empty-state sentence; never omit a section.
 - Every report and chat digest is a complete current snapshot, never a delta against a prior report.
 - Recently Landed always renders the bounded current baseline, even when the same completions appeared in an earlier report.
-- The four buckets are mutually exclusive, so every item is forced into exactly one: needs-your-action is Captain's Call, done is Recently Landed, self-progressing is Underway, not-yet-started is Charted Next.
+- The four buckets are mutually exclusive, so every item is forced into exactly one: needs-your-action is Captain's Call, done is Recently Landed, self-progressing is Underway, and not-yet-started work or an action-free fleet-integrity warning is Charted Next.
 - The strict boundary keeps action-free items OUT of Captain's Call: a working or validating task, a queued item blocked on another task or a date, landed work, a completed scout's report pointer, a declared `paused:` external wait, and a bare recorded PR with no merge-ready signal each belong to one of the other three sections, never Captain's Call.
 - A secondmate appears Underway only for `active_child_work`; `externally_held` belongs in Charted Next, and `unknown` belongs there as an unavailable-state gate unless its reason requires the captain's action.
 - The chat follows `AGENTS.md` section 9 and carries one scannable line per item, each PR as the full `https://...` URL; detailed decisions, plans, full gate reasons, and evidence live only in the report file, which the chat links to, so the chat stays materially shorter than that file.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,16 +81,16 @@ jobs:
           snapshot_output=$(/bin/bash tests/fm-fleet-snapshot-view.test.sh)
           printf '%s\n' "$snapshot_output"
           snapshot_count=$(printf '%s\n' "$snapshot_output" | grep -c '^ok - ')
-          [ "$snapshot_count" -eq 13 ] || {
-            echo "::error::expected 13 snapshot/fleet-view tests, got $snapshot_count"
+          [ "$snapshot_count" -eq 14 ] || {
+            echo "::error::expected 14 snapshot/fleet-view tests, got $snapshot_count"
             exit 1
           }
 
           bearings_output=$(/bin/bash tests/fm-bearings-snapshot.test.sh)
           printf '%s\n' "$bearings_output"
           bearings_count=$(printf '%s\n' "$bearings_output" | grep -c '^ok - ')
-          [ "$bearings_count" -eq 36 ] || {
-            echo "::error::expected 36 Bearings tests, got $bearings_count"
+          [ "$bearings_count" -eq 39 ] || {
+            echo "::error::expected 39 Bearings tests, got $bearings_count"
             exit 1
           }
 

--- a/bin/fm-bearings-snapshot.sh
+++ b/bin/fm-bearings-snapshot.sh
@@ -22,6 +22,12 @@
 # This wrapper consumes canonical status decisions plus structured captain-held
 # backlog items. It never infers decisions from report or visual-review prose.
 #
+# Main-home inventory validity comes from the canonical snapshot's main_inventory
+# object (orphan structured in-flight without meta, unstructured current rows).
+# Bearings never invents Underway rows from backlog-only ids; it discloses those
+# gaps in omitted[] and, when invalid, a Charted Next gate line so the four-section
+# chat cannot claim an empty fleet while main current state is broken.
+#
 # The landed section merges this home's Done with the canonical snapshot's
 # secondmate_landed roll-up (fm-fleet-snapshot.sh), so merges a secondmate managed -
 # recorded in ITS OWN backlog, never the main one - are visible. It stays bounded by
@@ -379,13 +385,20 @@ MODEL=$(printf '%s' "$SNAP" | jq \
          | select(.source == "backlog" and .verb == "captain-hold")
          | {id:($m.id + "/" + .id),key,verb,
             summary:(((.summary // .id) + ": " + (.reason // "captain decision pending")) | trunc(90)),owner:$m.id} ]) as $decisions_all
-  | ([ .backlog.records[]
-       | select(.state == "queued" and .structured)
-       | select((.kind == "captain" and .hold_kind == "captain" and .hold_reason != null) | not)
-       | select(($all_queued == 1)
-                or (((.body_excerpt // "") | test("SUPERSEDED|NOT REQUIRED|NOT-REQUIRED|DEFERRED"; "i")) | not))
-       | {id, title:(.title | trunc(60)), blocked_by:(.blocked_by // "-"),
-          reason:((.blocked_reason // "-") | trunc(40)),owner:"(main)"} ]
+  | ((if (.main_inventory.valid == false) then
+        [{id:"(main-inventory)",
+          title:((.main_inventory.reason // "main inventory invalid") | trunc(60)),
+          blocked_by:"-",
+          reason:"main inventory",
+          owner:"(main)"}]
+      else [] end)
+     + [ .backlog.records[]
+         | select(.state == "queued" and .structured)
+         | select((.kind == "captain" and .hold_kind == "captain" and .hold_reason != null) | not)
+         | select(($all_queued == 1)
+                  or (((.body_excerpt // "") | test("SUPERSEDED|NOT REQUIRED|NOT-REQUIRED|DEFERRED"; "i")) | not))
+         | {id, title:(.title | trunc(60)), blocked_by:(.blocked_by // "-"),
+            reason:((.blocked_reason // "-") | trunc(40)),owner:"(main)"} ]
      + [ (.secondmate_current.records // [])[] as $m
          | select($m.provenance.selected == "structured-home")
          | $m.queued[]?
@@ -431,6 +444,10 @@ MODEL=$(printf '%s' "$SNAP" | jq \
         (if $all_landed == 0 and $home_cap_dropped > 0 then {surface:("landed per-home capped at \($landed_per_home_n) for \($home_cap_dropped) home(s)"), reveal:"--all-landed"} else empty end),
         (if (($snap.secondmate_landed.unreadable // []) | length) > 0 then {surface:("secondmate home(s) with unreadable backlog: \(($snap.secondmate_landed.unreadable // []) | length)"), reveal:"inspect the listed secondmate home backlogs"} else empty end),
         (if $all_landed == 0 and (($snap.secondmate_landed.truncated // []) | length) > 0 then {surface:("secondmate home Done capped at the snapshot layer for \(($snap.secondmate_landed.truncated // []) | length) home(s)"), reveal:"--all-landed"} else empty end),
+        ((($snap.main_inventory.orphan_in_flight // []) | length) as $n
+         | if $n > 0 then {surface:("main in-flight backlog item(s) have no child metadata: \($n)"), reveal:"inspect main data/backlog.md In flight vs state/*.meta"} else empty end),
+        ((($snap.main_inventory.unstructured_current_count // 0)) as $n
+         | if $n > 0 then {surface:("main unstructured current backlog row(s): \($n)"), reveal:"inspect main data/backlog.md In flight and Queued free-form rows"} else empty end),
         (if $all_in_flight == 0 and ($in_flight_all | length) > $in_flight_n then {surface:("in_flight showing \($in_flight_n) of \($in_flight_all | length)"), reveal:"--all-in-flight"} else empty end),
         (if $all_secondmates == 0 and ($secondmates_all | length) > $secondmates_n then {surface:("secondmates showing \($secondmates_n) of \($secondmates_all | length)"), reveal:"--all-secondmates"} else empty end),
         (if (($snap.secondmate_current.truncated // 0) > 0) then {surface:("registered secondmates omitted by snapshot bound: \($snap.secondmate_current.truncated)"), reveal:"raise FM_SNAPSHOT_SECONDMATES"} else empty end),

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -30,6 +30,12 @@
 #     endpoint.agent_alive is populated for secondmates only, where it is useful
 #     return-channel supervision data; other tasks use "not_checked".
 #   scout_reports[]: present data/<id>/report.md pointers.
+#   main_inventory: {valid,reason,orphan_in_flight[],unstructured_current_count} -
+#     main-home current-inventory checks shared with secondmate_home_summary_json
+#     (orphan structured in-flight ids with no state/<id>.meta, and unstructured
+#     current backlog rows). Does not invent live tasks; meta remains truth for
+#     workers. Bearings maps failures into omitted[] disclosure (and a Charted
+#     Next gate line) rather than silent empty Underway.
 #   secondmate_current: {records[],total,shown,truncated} - bounded current summaries
 #     for registered secondmates, selected from validated structured state inside
 #     each home with explicit provenance, freshness, endpoint evidence, and unknown
@@ -518,6 +524,33 @@ task_json_lines() {
           end)
       }'
   done | jq -s 'sort_by(.id)'
+}
+
+# Main-home current-inventory validity: same orphan / unstructured-current checks
+# used by secondmate_home_summary_json, without inventing live task rows.
+# Meta inventory remains the sole source of live workers; this object only
+# discloses backlog↔task inconsistency for renderers (Bearings omitted/gates).
+main_inventory_json() {  # <backlog-json> <tasks-json>
+  jq -n \
+    --argjson backlog "$1" \
+    --argjson tasks "$2" '
+    ([ $backlog.records[]?
+       | select((.state == "in_flight" or .state == "queued") and (.structured | not)) ]) as $unstructured_current
+    | ([ $backlog.records[]? | select(.state == "in_flight" and .structured) ]) as $owned_in_flight
+    | ([ $owned_in_flight[]
+         | select(.id as $id | [$tasks[].id] | index($id) | not)
+         | .id ]) as $orphan_in_flight
+    | (($unstructured_current | length) == 0
+       and ($orphan_in_flight | length) == 0) as $valid
+    | (if ($unstructured_current | length) > 0 then "unstructured current backlog row"
+       elif ($orphan_in_flight | length) > 0 then "in-flight backlog item has no child metadata"
+       else null end) as $reason
+    | {
+        valid:$valid,
+        reason:$reason,
+        orphan_in_flight:$orphan_in_flight,
+        unstructured_current_count:($unstructured_current | length)
+      }'
 }
 
 # Project one home's canonical structured inventory into the bounded shape a
@@ -1179,6 +1212,8 @@ if [ "$OUTPUT_MODE" = secondmate-home-summary ]; then
 fi
 
 SCOUT_REPORTS_JSON=$(scout_report_lines)
+MAIN_INVENTORY_JSON=$(main_inventory_json "$BACKLOG_JSON" "$TASKS_JSON") \
+  || { echo "fm-fleet-snapshot: main inventory summary failed" >&2; exit 1; }
 SECONDMATE_CURRENT_JSON=$(secondmate_current_json "$TASKS_JSON") \
   || { echo "fm-fleet-snapshot: registered secondmate aggregation failed" >&2; exit 1; }
 SECONDMATE_LANDED_JSON=$(secondmate_landed_from_current_json "$SECONDMATE_CURRENT_JSON") \
@@ -1194,6 +1229,7 @@ jq -n \
   --arg projects "$PROJECTS" \
   --argjson backlog "$BACKLOG_JSON" \
   --argjson tasks "$TASKS_JSON" \
+  --argjson main_inventory "$MAIN_INVENTORY_JSON" \
   --argjson scout_reports "$SCOUT_REPORTS_JSON" \
   --argjson secondmate_current "$SECONDMATE_CURRENT_JSON" \
   --argjson secondmate_landed "$SECONDMATE_LANDED_JSON" \
@@ -1207,6 +1243,7 @@ jq -n \
      roots:{fm_root:$fm_root,state:$state,data:$data,config:$config,projects:$projects},
      backlog:$backlog,
      tasks:($tasks | map(. + {backlog:backlog_by_id(.id)})),
+     main_inventory:$main_inventory,
      scout_reports:($scout_reports | map(. + {kind:report_kind(.id)})),
      secondmate_current:$secondmate_current,
      secondmate_landed:$secondmate_landed,

--- a/tests/fm-bearings-snapshot.test.sh
+++ b/tests/fm-bearings-snapshot.test.sh
@@ -1368,6 +1368,138 @@ test_captains_call_anti_leak() {
   pass "action-free items (working/done/queued/landed) do not leak into Captain's Call"
 }
 
+# R1: main-home orphan in-flight and unstructured current rows must not vanish
+# silently. Meta remains the sole live-work inventory; disclosure is via
+# main_inventory + omitted[] + a Charted Next gate line, never fake Underway.
+test_main_orphan_in_flight_is_disclosed_not_invented() {
+  local home fakebin json canonical
+  home=$(make_home main-orphan)
+  : > "$home/data/secondmates.md"
+  cat > "$home/data/backlog.md" <<'EOF'
+## In flight
+- [ ] only-orphan - Structured in flight without meta (repo: firstmate) (kind: ship) (since 2026-07-11)
+
+## Queued
+
+## Done
+EOF
+  fakebin=$(make_fakebin "$home")
+  canonical=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SNAPSHOT_NOW=2026-07-11T18:00:00Z \
+    "$ROOT/bin/fm-fleet-snapshot.sh" --json)
+  printf '%s' "$canonical" | jq -e '
+    .main_inventory.valid == false
+      and .main_inventory.reason == "in-flight backlog item has no child metadata"
+      and (.main_inventory.orphan_in_flight == ["only-orphan"])
+      and .main_inventory.unstructured_current_count == 0
+      and (.tasks | length) == 0
+  ' >/dev/null || fail "canonical main inventory missed orphan: $canonical"
+  json=$(run "$home" "$fakebin" --json)
+  printf '%s' "$json" | jq -e '
+    (.in_flight | length) == 0
+      and ([.in_flight[].id] | index("only-orphan") | not)
+      and ([.decisions_open[].id] | index("only-orphan") | not)
+      and (.gates | any(.id == "(main-inventory)"
+        and (.title | contains("in-flight backlog item has no child metadata"))))
+      and (.omitted | any(.surface == "main in-flight backlog item(s) have no child metadata: 1"))
+  ' >/dev/null || fail "orphan in-flight was invented or not disclosed: $json"
+  pass "main orphan in-flight stays out of Underway and is disclosed in omitted/gates"
+}
+
+test_main_unstructured_current_is_disclosed_with_structured_sibling() {
+  local home fakebin json canonical
+  home=$(make_home main-unstructured)
+  : > "$home/data/secondmates.md"
+  mkdir -p "$home/projects/structured-ship"
+  cat > "$home/data/backlog.md" <<'EOF'
+## In flight
+this current row is not structured
+- [ ] structured-ship - Visible structured sibling (repo: firstmate) (kind: ship) (since 2026-07-11)
+
+## Queued
+another free-form note without checkbox
+- [ ] structured-queued - Structured queued (repo: firstmate) (kind: ship)
+
+## Done
+EOF
+  fm_write_meta "$home/state/structured-ship.meta" \
+    "window=firstmate:fm-structured-ship" \
+    "worktree=$home/projects/structured-ship" \
+    "project=firstmate" \
+    "harness=codex" \
+    "kind=ship" \
+    "mode=no-mistakes"
+  printf 'working: structured sibling still projects\n' > "$home/state/structured-ship.status"
+  fakebin=$(make_fakebin "$home")
+  canonical=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SNAPSHOT_NOW=2026-07-11T18:00:00Z \
+    "$ROOT/bin/fm-fleet-snapshot.sh" --json)
+  printf '%s' "$canonical" | jq -e '
+    .main_inventory.valid == false
+      and .main_inventory.reason == "unstructured current backlog row"
+      and .main_inventory.unstructured_current_count == 2
+      and (.main_inventory.orphan_in_flight | length) == 0
+  ' >/dev/null || fail "canonical main inventory missed unstructured current: $canonical"
+  json=$(run "$home" "$fakebin" --json)
+  printf '%s' "$json" | jq -e '
+    ([.in_flight[].id] == ["structured-ship"])
+      and ([.gates[].id] | index("structured-queued") != null)
+      and (.gates | any(.id == "(main-inventory)"
+        and (.title | contains("unstructured current backlog row"))))
+      and (.omitted | any(.surface == "main unstructured current backlog row(s): 2"))
+      and ([.decisions_open[].id] | index("(main-inventory)") | not)
+  ' >/dev/null || fail "unstructured current not disclosed or structured sibling lost: $json"
+  pass "main unstructured current is disclosed while structured siblings still project"
+}
+
+test_main_orphan_counterfactual_meta_clears_inventory_warning() {
+  local home fakebin json_before json_after
+  home=$(make_home main-orphan-counterfactual)
+  : > "$home/data/secondmates.md"
+  mkdir -p "$home/projects/orphan-ship"
+  cat > "$home/data/backlog.md" <<'EOF'
+## In flight
+- [ ] orphan-ship - Gains meta in counterfactual (repo: firstmate) (kind: ship) (since 2026-07-11)
+- [ ] visible-ship - Already live (repo: firstmate) (kind: ship) (since 2026-07-11)
+
+## Queued
+- [ ] queued-ship - Ordinary queue (repo: firstmate) (kind: ship)
+
+## Done
+EOF
+  fm_write_meta "$home/state/visible-ship.meta" \
+    "window=firstmate:fm-visible-ship" \
+    "worktree=$home/projects/orphan-ship" \
+    "project=firstmate" \
+    "harness=codex" \
+    "kind=ship" \
+    "mode=no-mistakes"
+  printf 'working: visible sibling\n' > "$home/state/visible-ship.status"
+  fakebin=$(make_fakebin "$home")
+  json_before=$(run "$home" "$fakebin" --json)
+  printf '%s' "$json_before" | jq -e '
+    ([.in_flight[].id] == ["visible-ship"])
+      and ([.in_flight[].id] | index("orphan-ship") | not)
+      and (.omitted | any(.surface == "main in-flight backlog item(s) have no child metadata: 1"))
+      and (.gates | any(.id == "(main-inventory)"))
+      and ([.gates[].id] | index("queued-ship") != null)
+  ' >/dev/null || fail "pre-meta orphan fixture failed: $json_before"
+  fm_write_meta "$home/state/orphan-ship.meta" \
+    "window=firstmate:fm-orphan-ship" \
+    "worktree=$home/projects/orphan-ship" \
+    "project=firstmate" \
+    "harness=codex" \
+    "kind=ship" \
+    "mode=no-mistakes"
+  printf 'working: orphan now has meta\n' > "$home/state/orphan-ship.status"
+  json_after=$(run "$home" "$fakebin" --json)
+  printf '%s' "$json_after" | jq -e '
+    ([.in_flight[].id] | sort) == ["orphan-ship", "visible-ship"]
+      and ([.omitted[].surface] | any(test("main in-flight backlog item")) | not)
+      and ([.gates[].id] | index("(main-inventory)") | not)
+      and ([.decisions_open[].id] | index("orphan-ship") | not)
+  ' >/dev/null || fail "adding meta did not clear inventory warning or project orphan: $json_after"
+  pass "counterfactual meta clears main inventory warning and projects the live task"
+}
+
 # The /bearings skill is the one owner of the four-section chat-response contract.
 # Assert it states exactly the four fixed sections in order, each with its explicit
 # empty-state sentence, documents the At Anchor exclusion, and mandates a chat that is
@@ -1421,6 +1553,9 @@ test_all_landed_keeps_complete_global_order
 test_landed_bounded_and_disclosed
 test_live_blocker_is_not_charted_queue_work
 test_captains_call_anti_leak
+test_main_orphan_in_flight_is_disclosed_not_invented
+test_main_unstructured_current_is_disclosed_with_structured_sibling
+test_main_orphan_counterfactual_meta_clears_inventory_warning
 test_chat_contract_four_sections
 test_completed_scout_report_not_pending
 test_open_decision_surfaces_end_to_end

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -120,7 +120,15 @@ test_empty_fleet_json() {
   local home out view
   home=$(make_home empty)
   out=$(FM_HOME="$home" "$SNAPSHOT" --json)
-  printf '%s' "$out" | jq -e '.schema == "fm-fleet-snapshot.v1" and .backlog.present == false and (.tasks|length == 0)' >/dev/null \
+  printf '%s' "$out" | jq -e '
+    .schema == "fm-fleet-snapshot.v1"
+      and .backlog.present == false
+      and (.tasks|length == 0)
+      and .main_inventory.valid == true
+      and .main_inventory.reason == null
+      and (.main_inventory.orphan_in_flight | length) == 0
+      and .main_inventory.unstructured_current_count == 0
+  ' >/dev/null \
     || fail "empty snapshot schema or absence markers wrong: $out"
   view=$(FM_HOME="$home" "$VIEW")
   assert_contains "$view" "No live task metadata found." "empty fleet view should say no live metadata"
@@ -171,6 +179,71 @@ test_fixture_snapshot_json() {
     | .state == "done" and .pr_url == "https://github.com/kunchenguid/firstmate/pull/7"
   ' >/dev/null || fail "done backlog PR row missing"
   pass "fixture snapshot covers task rows, backlog rows, pointers, and stable ordering"
+}
+
+# R1 owner contract: main_inventory discloses orphan in-flight and unstructured
+# current rows without inventing task rows.
+test_main_inventory_orphan_and_unstructured_disclosure() {
+  local home fakebin out
+  home=$(make_home main-inventory)
+  mkdir -p "$home/projects/visible"
+  cat > "$home/data/backlog.md" <<'EOF'
+## In flight
+free-form current note
+- [ ] orphan-ship - Structured without meta (repo: alpha) (kind: ship) (since 2026-07-11)
+- [ ] visible-ship - Structured with meta (repo: alpha) (kind: ship) (since 2026-07-11)
+
+## Queued
+another free-form queued note
+- [ ] queued-ship - Structured queued (repo: alpha) (kind: ship)
+
+## Done
+EOF
+  fm_write_meta "$home/state/visible-ship.meta" \
+    "window=firstmate:fm-visible-ship" \
+    "worktree=$home/projects/visible" \
+    "project=alpha" \
+    "harness=codex" \
+    "kind=ship" \
+    "mode=ship"
+  printf 'working: visible\n' > "$home/state/visible-ship.status"
+  fakebin=$(make_fakebin "$home")
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$SNAPSHOT" --json)
+  printf '%s' "$out" | jq -e '
+    .main_inventory.valid == false
+      and .main_inventory.reason == "unstructured current backlog row"
+      and .main_inventory.unstructured_current_count == 2
+      and (.main_inventory.orphan_in_flight == ["orphan-ship"])
+      and ([.tasks[].id] == ["visible-ship"])
+  ' >/dev/null || fail "main_inventory did not disclose orphan/unstructured: $out"
+  # Counterfactual: add meta for the orphan and strip free-form current lines.
+  cat > "$home/data/backlog.md" <<'EOF'
+## In flight
+- [ ] orphan-ship - Structured without meta (repo: alpha) (kind: ship) (since 2026-07-11)
+- [ ] visible-ship - Structured with meta (repo: alpha) (kind: ship) (since 2026-07-11)
+
+## Queued
+- [ ] queued-ship - Structured queued (repo: alpha) (kind: ship)
+
+## Done
+EOF
+  fm_write_meta "$home/state/orphan-ship.meta" \
+    "window=firstmate:fm-orphan-ship" \
+    "worktree=$home/projects/visible" \
+    "project=alpha" \
+    "harness=codex" \
+    "kind=ship" \
+    "mode=ship"
+  printf 'working: orphan now live\n' > "$home/state/orphan-ship.status"
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$SNAPSHOT" --json)
+  printf '%s' "$out" | jq -e '
+    .main_inventory.valid == true
+      and .main_inventory.reason == null
+      and .main_inventory.unstructured_current_count == 0
+      and (.main_inventory.orphan_in_flight | length) == 0
+      and (([.tasks[].id] | sort) == ["orphan-ship", "visible-ship"])
+  ' >/dev/null || fail "main_inventory stayed invalid after meta + structured cleanup: $out"
+  pass "main_inventory discloses orphan/unstructured and clears when inventory is consistent"
 }
 
 test_event_hints_follow_reconciled_current_state() {
@@ -588,6 +661,7 @@ test_parked_scout_decision_stays_pending() {
 
 test_empty_fleet_json
 test_fixture_snapshot_json
+test_main_inventory_orphan_and_unstructured_disclosure
 test_event_hints_follow_reconciled_current_state
 test_open_decision_survives_later_unrelated_event
 test_secondmate_open_decision_survives_live_endpoint


### PR DESCRIPTION
## Intent

Ship R1 only from the authorized promotion of scout fm-bearings-projection-gaps: close the main-home silent inventory gap where structured in-flight backlog rows without child metadata and unstructured current backlog rows vanished from Bearings with no disclosure. Owner is the main fleet snapshot (main_inventory with valid/reason/orphan_in_flight/unstructured_current_count using the same current-inventory checks as secondmate home summary), mapped by Bearings into omitted[] surfaces and a Charted Next main-inventory gate line so the four-section chat cannot claim empty fleet when main current state is broken. Explicit non-goals: do not invent Underway rows from backlog-only ids (meta remains truth for live workers); do not put orphans into decisions_open; leave R2 captain-hold triple-predicate and optional R3/R4 unchanged; do not touch concurrent test-runner paths (fm-test-run.sh, CI topology, family manifest, Behavior runner wiring). Focused regression fixtures only for orphan-only, unstructured+structured sibling, and counterfactual meta clear.

## What Changed

- Add a `main_inventory` projection that detects orphaned in-flight backlog items and unstructured current backlog rows.
- Surface invalid main inventory through Bearings omissions and a Charted Next integrity gate without inventing Underway work or captain decisions.
- Add regression coverage for orphan-only, mixed structured/unstructured, and metadata-restoration scenarios.

## Risk Assessment

✅ Low: The change is narrowly scoped and satisfies the R1 requirements by exposing main-home inventory gaps without inventing live work or leaking them into captain decisions.

## Testing

The focused snapshot and Bearings regressions passed, and manual CLI evidence demonstrated the complete counterfactual: before metadata, Underway and Captain's Call remain empty while Charted Next and omitted disclosures expose the inventory gap; after metadata and structured cleanup, the worker appears Underway and those warnings disappear. No screenshot was produced because this is a CLI/JSON projection change with no rendered UI.

<details>
<summary>Evidence: Bearings before metadata</summary>

```text
schema: fm-bearings.v1
home: 01KY3Z1A3WJR96JMRG6SGS1CRC/fm-home
generated: "2026-07-21T19:00:00Z"
prs: "not_requested (run: /bearings include PRs)"
in_flight: []
secondmates: []
decisions_open: []
landed: []
gates[2]{id,title,blocked_by,reason,owner}:
  (main-inventory),unstructured current backlog row,"-",main inventory,(main)
  queued-ship,Structured queued work,"-","-",(main)
reports: []
recorded_prs: []
omitted[9]{surface,reveal}:
  backlog item bodies,"--fields bodies"
  task paths,"--fields paths"
  watch/steer actions,"--fields actions"
  healthy endpoint detail,"--fields endpoints"
  full scout-report inventory,"--all-reports"
  superseded queued items,"--all-queued"
  "main in-flight backlog item(s) have no child metadata: 1",inspect main data/backlog.md In flight vs state/*.meta
  "main unstructured current backlog row(s): 2",inspect main data/backlog.md In flight and Queued free-form rows
  live PR discovery + checks,"--include-prs"
```
</details>
<details>
<summary>Evidence: Bearings after metadata</summary>

```text
schema: fm-bearings.v1
home: 01KY3Z1A3WJR96JMRG6SGS1CRC/fm-home
generated: "2026-07-21T19:05:00Z"
prs: "not_requested (run: /bearings include PRs)"
in_flight[1]{id,kind,state,doing}:
  orphan-ship,ship,working,metadata now makes this a real live worker
secondmates: []
decisions_open: []
landed: []
gates[1]{id,title,blocked_by,reason,owner}:
  queued-ship,Structured queued work,"-","-",(main)
reports: []
recorded_prs: []
omitted[7]{surface,reveal}:
  backlog item bodies,"--fields bodies"
  task paths,"--fields paths"
  watch/steer actions,"--fields actions"
  healthy endpoint detail,"--fields endpoints"
  full scout-report inventory,"--all-reports"
  superseded queued items,"--all-queued"
  live PR discovery + checks,"--include-prs"
```
</details>
<details>
<summary>Evidence: Before-metadata projection</summary>

```text
{
  "schema": "fm-bearings.v1",
  "home": "01KY3Z1A3WJR96JMRG6SGS1CRC/fm-home",
  "generated": "2026-07-21T19:00:00Z",
  "prs": "not_requested (run: /bearings include PRs)",
  "in_flight": [],
  "secondmates": [],
  "decisions_open": [],
  "landed": [],
  "gates": [
    {
      "id": "(main-inventory)",
      "title": "unstructured current backlog row",
      "blocked_by": "-",
      "reason": "main inventory",
      "owner": "(main)"
    },
    {
      "id": "queued-ship",
      "title": "Structured queued work",
      "blocked_by": "-",
      "reason": "-",
      "owner": "(main)"
    }
  ],
  "reports": [],
  "recorded_prs": [],
  "omitted": [
    {
      "surface": "backlog item bodies",
      "reveal": "--fields bodies"
    },
    {
      "surface": "task paths",
      "reveal": "--fields paths"
    },
    {
      "surface": "watch/steer actions",
      "reveal": "--fields actions"
    },
    {
      "surface": "healthy endpoint detail",
      "reveal": "--fields endpoints"
    },
    {
      "surface": "full scout-report inventory",
      "reveal": "--all-reports"
    },
    {
      "surface": "superseded queued items",
      "reveal": "--all-queued"
    },
    {
      "surface": "main in-flight backlog item(s) have no child metadata: 1",
      "reveal": "inspect main data/backlog.md In flight vs state/*.meta"
    },
    {
      "surface": "main unstructured current backlog row(s): 2",
      "reveal": "inspect main data/backlog.md In flight and Queued free-form rows"
    },
    {
      "surface": "live PR discovery + checks",
      "reveal": "--include-prs"
    }
  ]
}
```
</details>
<details>
<summary>Evidence: After-metadata projection</summary>

```text
{
  "schema": "fm-bearings.v1",
  "home": "01KY3Z1A3WJR96JMRG6SGS1CRC/fm-home",
  "generated": "2026-07-21T19:05:00Z",
  "prs": "not_requested (run: /bearings include PRs)",
  "in_flight": [
    {
      "id": "orphan-ship",
      "kind": "ship",
      "state": "working",
      "doing": "metadata now makes this a real live worker"
    }
  ],
  "secondmates": [],
  "decisions_open": [],
  "landed": [],
  "gates": [
    {
      "id": "queued-ship",
      "title": "Structured queued work",
      "blocked_by": "-",
      "reason": "-",
      "owner": "(main)"
    }
  ],
  "reports": [],
  "recorded_prs": [],
  "omitted": [
    {
      "surface": "backlog item bodies",
      "reveal": "--fields bodies"
    },
    {
      "surface": "task paths",
      "reveal": "--fields paths"
    },
    {
      "surface": "watch/steer actions",
      "reveal": "--fields actions"
    },
    {
      "surface": "healthy endpoint detail",
      "reveal": "--fields endpoints"
    },
    {
      "surface": "full scout-report inventory",
      "reveal": "--all-reports"
    },
    {
      "surface": "superseded queued items",
      "reveal": "--all-queued"
    },
    {
      "surface": "live PR discovery + checks",
      "reveal": "--include-prs"
    }
  ]
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff --name-only b843c66b2d61b7a4dd257a07234ddd1a6227adad..9754fb75871e9a10b34d0ac40c3bbd5f4e94a47a` to verify the change excludes concurrent test-runner paths</code>
- `tests/fm-fleet-snapshot-view.test.sh`
- `tests/fm-bearings-snapshot.test.sh`
- <code>Manual `bin/fm-bearings-snapshot.sh --json` and default TOON runs against an orphan plus unstructured-sibling fixture, before and after adding `state/orphan-ship.meta`</code>
- <code>Focused `jq -e` assertions over both captured JSON projections</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
