### PR TITLE
修复 watcher healthy-peer 测试夹具竞态

### DIFF
--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -14,6 +14,11 @@ DRAIN="$ROOT/bin/fm-wake-drain.sh"
 LIB="$ROOT/bin/fm-wake-lib.sh"
 
 TMP_ROOT=$(fm_test_tmproot fm-watcher-lock-tests)
+# Caller state must not select guard/X-mode paths or skip their fixture branches.
+FM_HOME="$TMP_ROOT/home"
+mkdir -p "$FM_HOME/state" "$FM_HOME/config" || fail "could not create fixture-owned FM_HOME"
+export FM_HOME
+unset PI_CODING_AGENT
 
 mark_pr_check_migration_complete() {
   local state=$1
@@ -127,7 +132,7 @@ test_guard_warnings() {
   printf 'project=x\n' > "$state/task.meta"
   printf 'project=y\n' > "$state/task2.meta"
   append_wake "$state" heartbeat heartbeat heartbeat || fail "guard heartbeat append failed"
-  CLAUDECODE=1 PI_CODING_AGENT='' GROK_AGENT='' FM_ROOT_OVERRIDE="$dir" FM_STATE_OVERRIDE="$state" FM_GUARD_GRACE=1 "$ROOT/bin/fm-guard.sh" 2> "$err" >/dev/null || fail "guard failed"
+  CLAUDECODE=1 PI_CODING_AGENT='' GROK_AGENT='' FM_HOME="$dir" FM_ROOT_OVERRIDE="$dir" FM_STATE_OVERRIDE="$state" FM_GUARD_GRACE=1 "$ROOT/bin/fm-guard.sh" 2> "$err" >/dev/null || fail "guard failed"
   first=$(grep -v '^[[:space:]]*$' "$err" | head -1)
   case "$first" in
     '●'*) ;;
@@ -153,7 +158,7 @@ test_guard_warnings() {
   mkdir -p "$dir/config"
   printf 'project=x\n' > "$state/task.meta"
   : > "$dir/config/x-mode.env"
-  CLAUDECODE=1 PI_CODING_AGENT='' GROK_AGENT='' FM_ROOT_OVERRIDE="$dir" FM_STATE_OVERRIDE="$state" FM_GUARD_GRACE=1 "$ROOT/bin/fm-guard.sh" 2> "$err" >/dev/null || fail "guard failed"
+  CLAUDECODE=1 PI_CODING_AGENT='' GROK_AGENT='' FM_HOME="$dir" FM_ROOT_OVERRIDE="$dir" FM_STATE_OVERRIDE="$state" FM_GUARD_GRACE=1 "$ROOT/bin/fm-guard.sh" 2> "$err" >/dev/null || fail "guard failed"
   grep -F "source '$dir/config/x-mode.env' first" "$err" >/dev/null || fail "guard repair line did not source the X-mode cadence config"
 
   # (2) fresh watcher, empty queue -> silence.
@@ -164,7 +169,7 @@ test_guard_warnings() {
   touch "$state/.last-watcher-beat"
   # Non-git FM_ROOT keeps the worktree-tangle check inert so "fresh watcher ->
   # total silence" stays a pure assertion about watcher state.
-  FM_ROOT_OVERRIDE="$dir" FM_STATE_OVERRIDE="$state" FM_GUARD_GRACE=300 "$ROOT/bin/fm-guard.sh" 2> "$err" >/dev/null || fail "guard failed"
+  FM_HOME="$dir" FM_ROOT_OVERRIDE="$dir" FM_STATE_OVERRIDE="$state" FM_GUARD_GRACE=300 "$ROOT/bin/fm-guard.sh" 2> "$err" >/dev/null || fail "guard failed"
   [ ! -s "$err" ] || fail "guard warned with a fresh watcher and no queued wakes: $(cat "$err")"
   pass "guard banner leads when down with pending wakes (repair-after-drain) and stays silent when fresh"
 }
@@ -438,14 +443,34 @@ test_watch_restart_rejects_reused_pid() {
 }
 
 test_watch_restart_attaches_to_healthy_peer() {
-  local dir state fakebin out peer identity armpid status i
+  local dir state fakebin out ready term peer identity armpid status i
   dir=$(make_case restart-healthy-peer)
   state="$dir/state"
   fakebin="$dir/fakebin"
   out="$dir/restart.out"
+  ready="$dir/peer.ready"
+  term="$dir/peer.term"
   mark_pr_check_migration_complete "$state"
-  node -e 'process.on("SIGTERM", () => {}); setTimeout(() => {}, 300000)' &
+  # PID identity alone does not prove that the synthetic peer can resist TERM.
+  FM_TEST_PEER_READY="$ready" FM_TEST_PEER_TERM="$term" node -e '
+const fs = require("node:fs");
+process.on("SIGTERM", () => {
+  fs.writeFileSync(process.env.FM_TEST_PEER_TERM, "handled\n");
+});
+fs.writeFileSync(process.env.FM_TEST_PEER_READY, "ready\n");
+setTimeout(() => {}, 300000);
+' &
   peer=$!
+  i=0
+  while [ "$i" -lt 80 ] && [ ! -s "$ready" ]; do
+    sleep 0.1
+    i=$((i + 1))
+  done
+  if [ ! -s "$ready" ]; then
+    kill -KILL "$peer" 2>/dev/null || true
+    wait "$peer" 2>/dev/null || true
+    fail "synthetic peer did not publish handler readiness"
+  fi
   identity=$(FM_STATE_OVERRIDE="$state" bash -c '. "$1"; fm_pid_identity "$2"' _ "$LIB" "$peer") || fail "could not identify peer pid"
   mkdir "$state/.watch.lock"
   printf '%s\n' "$peer" > "$state/.watch.lock/pid"
@@ -457,11 +482,13 @@ test_watch_restart_attaches_to_healthy_peer() {
   armpid=$!
   i=0
   while [ "$i" -lt 80 ]; do
-    grep -qF "watcher: attached pid=$peer" "$out" 2>/dev/null && break
+    grep -qF "watcher: attached pid=$peer" "$out" 2>/dev/null && [ -s "$term" ] && break
     sleep 0.1
     i=$((i + 1))
   done
+  [ -s "$term" ] || fail "restart did not deliver SIGTERM to the ready synthetic peer"
   grep -qF "watcher: attached pid=$peer" "$out" || fail "restart did not attach to the verified healthy peer: $(cat "$out")"
+  ! grep -qF 'watcher: started pid=' "$out" || fail "restart started a replacement behind the ready synthetic peer"
   is_live_non_zombie "$armpid" || fail "restart arm exited instead of following the healthy peer"
   is_live_non_zombie "$peer" || fail "restart killed a TERM-resistant peer unexpectedly"
   kill -KILL "$peer" 2>/dev/null || true


### PR DESCRIPTION
## 问题

`test_watch_restart_attaches_to_healthy_peer` 启动 synthetic Node peer 后立即发布 PID 与 watcher identity。
Node 进程存在不代表 SIGTERM handler 已安装完成；`--restart` 若在这个窗口发送 SIGTERM，peer 会退出，生产代码随后正确启动 replacement watcher，但测试会误判为 attach 失败。
环境中继承的 `PI_CODING_AGENT` 与 `FM_HOME` 还会让 guard/X-mode 夹具走到其他路径，掩盖目标竞态。

## 修复

- watcher-lock 套件统一使用夹具自有的 `FM_HOME`，并清除会改变测试路径的 `PI_CODING_AGENT`。
- guard 与 X-mode 场景显式绑定各自 case home，避免读取调用方配置。
- synthetic peer 在安装 SIGTERM handler 后写入 readiness sentinel；夹具观察到 sentinel 后才发布 healthy lock identity。
- SIGTERM handler 另写 TERM sentinel；测试同时要求 TERM 已处理、peer 仍存活、arm 输出 `attached`，且不存在 `watcher: started` replacement。

## 确定性证明

readiness sentinel 明确建立 handler 安装完成到 healthy identity 发布之间的先后关系。
12 轮真实 `fm-watch-arm.sh --restart` 因果验证均观察到 `readiness -> identity publish -> TERM handled -> attached`，peer 在 TERM 后保持存活，replacement 启动次数为 0。

## 验证

- GitHub checks：5 passed、0 failed、1 skipped。
- `Lint shell scripts`、`PR must be raised via no-mistakes`、`Behavior tests`、`Stock macOS Bash snapshot compatibility` 与 `Repo invariants` 均通过；skipped 项为同名 required-check 的非执行记录。
- 目标 healthy-peer case 重复运行 8/8 通过。
- 完整 `tests/fm-watcher-lock.test.sh` 在故意污染的 ambient `FM_HOME` 与 `PI_CODING_AGENT` 下 27/27 通过。
- 9 个相关 watcher/wake/guard/daemon shell 套件共 235 项断言通过。
- `bin/fm-lint.sh` 使用固定 ShellCheck 0.11.0 通过。

## 风险与限制

风险低：仅修改 `tests/fm-watcher-lock.test.sh`，未修改 production watcher、spawn/worktree ownership、Herdr topology 或 presentation 行为。
本次验证覆盖 macOS 上的真实进程时序；Linux 专属 PID identity 用例在非 Linux 主机上按既有逻辑跳过，且不在本次变更范围内。

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)