### PR TITLE
feat(intake,supervision): operate Munra architecture protocol; add token-light heartbeat

### DIFF
--- a/.agents/skills/munra-architecture-intake/SKILL.md
+++ b/.agents/skills/munra-architecture-intake/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: munra-architecture-intake
+description: >-
+  Agent-only protocol for intaking and briefing a Munra issue against Munra's committed agent-facing architecture model (docs/architecture plus docs/development/CHANGE_PROTOCOL, added by Munra PR #275).
+  Load before selecting a Munra issue to dispatch and before writing a Munra implementation brief.
+  Covers refreshing the clone to current origin/master first, choosing work from the current issue list and current master rather than a stale in-flight brief, and requiring the brief to consult the architecture index and change-impact protocol, apply the source-of-truth boundary, name the affected invariants and feature surfaces, and select the proving test lanes.
+user-invocable: false
+metadata:
+  internal: true
+---
+
+# munra-architecture-intake
+
+Load this before you select a Munra issue to dispatch, and before you write a Munra implementation brief.
+Munra ships its own agent-facing architecture model under `docs/architecture/` and `docs/development/CHANGE_PROTOCOL.md` (Munra PR #275).
+This skill makes firstmate operate Munra work through that model without freezing each issue into a rigid preplanned assignment.
+It owns only the firstmate-side workflow; the model's substance stays in Munra's own documents, which the brief points the crewmate at rather than restating.
+
+## 1. Refresh to current origin/master before intake
+
+Do not select or brief a Munra issue against a stale clone.
+Refresh the Munra clone through the guarded fleet-sync path (`bin/fm-fleet-sync.sh`, the same safe fetch session start uses) so both the open-issue list and the architecture docs you read reflect current `origin/master`.
+The architecture index is only trustworthy at `origin/master`; an out-of-date clone can hide a renamed surface, a new invariant, or a just-merged consumer.
+Read the architecture material from that refreshed state, never from memory of an earlier session.
+
+## 2. Choose work from current reality, not a stale brief
+
+Pick the next issue from the currently open issue list and current `master`, not from an in-flight brief left over from an earlier plan.
+A brief written days ago encodes assumptions about code that may have moved; treat it as history, and re-derive scope from today's issue text and today's master.
+This keeps issue selection flexible: firstmate commits to a concrete issue only when it is actually dispatching, and the impact analysis is built against the tree the crewmate will really edit.
+
+## 3. Require the brief to consult Munra's architecture model
+
+Every Munra implementation brief must direct the crewmate to Munra's own protocol; point at these documents, do not copy their content into the brief:
+
+- Read `docs/architecture/README.md` first (the agent index) and follow its mandatory before-changing-code checklist.
+- Build the change-impact graph per `docs/development/CHANGE_PROTOCOL.md` and meet its Definition of Done; green unit tests on one surface is explicitly not done.
+- Apply the source-of-truth boundary the index defines: `WDD/` is normative design intent, `.planning/codebase/` is durable topology, and `docs/architecture/` is a descriptive implementation map; where the map disagrees with code the code wins, and a code-versus-`WDD/` conflict is logged as a Deviation, not silently resolved.
+- Name the affected invariants (`docs/architecture/INVARIANTS.md`, machine subset `invariants.yaml`) and feature surfaces (`docs/architecture/FEATURE_GRAPH.md` and each consumer in `features.yaml`) the change must touch.
+- Select the proving test lanes from `docs/testing/FEATURE_TEST_STRATEGY.md` and the index's test commands, and define the test evidence before implementing.
+
+For a multi-surface feature, point at `docs/development/prompts/IMPLEMENT_CROSS_CUTTING_FEATURE.md`; for a bug fix or small feature, `docs/development/prompts/IMPLEMENT_CHANGE.md`.
+
+## 4. Keep it a brief, not a frozen plan
+
+State the architecture-consult requirement and the target issue; do not pre-decide the edit list.
+The crewmate derives the impact graph itself from current master, so the brief stays a task description plus this requirement, not a rigid assignment that goes stale the moment master moves.
+
+## Keeping this skill honest
+
+These paths are Munra-owned.
+If Munra renames or moves a document, update the pointer here rather than duplicating the document's content, so the two never drift.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -324,13 +324,14 @@ At the start of every wake-handling turn, drain the durable wake queue before pe
 Session start is the only exception because its one-shot digest already drained while locked or deliberately left the queue untouched in lock-refused read-only mode.
 A status line is a wake event, not current state; use `bin/fm-crew-state.sh` when current state matters, especially before re-escalating an old decision, blocker, or pause.
 A declared `paused:` event means a bounded external wait expected to clear on its own, while `blocked:` means firstmate action is needed.
+When a crewmate is parked solely by a harness 5h/quota limit, record the retryable wait with `bin/fm-quota-wait.sh record` so the token-light heartbeat resumes the same queued work when capacity returns instead of the wait rotting.
 
 Handle actionable wakes as follows:
 
 1. For `signal:`, read the listed event lines first, then reconcile current state only where action depends on it.
 2. For `stale:`, inspect the recorded endpoint and load `stuck-crewmate-recovery` for a stopped, looping, confused, or unresponsive worker; a deep-inspection reason also requires current-state and validation-log inspection.
 3. For `check:`, act on the named poll result, including merges and X-mode events.
-4. For `heartbeat:`, review the whole fleet from the structured fleet view, reconcile suspicious tasks and PR state, update the backlog, and never report an unchanged fleet as progress.
+4. For `heartbeat:`, first run `bin/fm-heartbeat.sh` as the token-light pass and act on any line it prints (a cleared stale watcher lock needing re-arm, or a `resume <id>` step for quota-parked work); then review the whole fleet from the structured fleet view, reconcile suspicious tasks and PR state, update the backlog, and never report an unchanged fleet as progress.
 
 When any wake reports a merged PR for a project cloned in this home, refresh that clone through the guarded fleet-sync path.
 When X-linked work reaches a milestone or terminal state, load `fmx-respond`; before terminal teardown, always post the final completion follow-up so the link clears even if earlier follow-ups were spent.
@@ -433,6 +434,7 @@ Keep additions task-specific rather than repeating lifecycle instructions, and a
 
 Every ship brief must retain the worktree-isolation assertion and stop if launched in the primary checkout.
 If a ship task touches firstmate's shared tracked material, explicitly require `firstmate-coding-guidelines` before editing.
+If a task targets Munra, load `munra-architecture-intake` before selecting the issue or writing the brief, so intake refreshes to current `origin/master` and the brief consults Munra's architecture index and change-impact protocol.
 If a task will drive Herdr lifecycle behavior, scaffold with `--herdr-lab`; if that need appears after an unguarded scaffold, stop and regenerate rather than adding commands by hand.
 The generated Herdr contract must use a named non-`default` isolated lab and its guarded helper for every lifecycle action.
 
@@ -462,6 +464,7 @@ These skills are not captain-invocable; load them only at their precise triggers
 - `fmx-respond` - load on an `x-mention <request_id>` `check:` wake to handle the mention, on an `x-mode-error ...` `check:` wake to report the X-mode configuration blocker, and on any milestone or terminal wake for an X-mode-linked task before posting its completion follow-up; relevant only when X mode is on.
 - `firstmate-codexapp` - load before coordinating a visible Codex Desktop thread, evaluating a Codex App backend request, or reconciling Codex Desktop host-tool smoke evidence for Firstmate work.
 - `firstmate-coding-guidelines` - load before changing firstmate's shared, tracked material, as defined by section 1's list, whether editing directly or briefing a crewmate for a firstmate-repo task.
+- `munra-architecture-intake` - load before selecting a Munra issue to dispatch or writing a Munra implementation brief, so intake refreshes to current `origin/master` and the brief consults Munra's committed architecture model.
 
 ## 14. X mode
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -297,6 +297,9 @@ A teardown refusal for uncommitted or unlanded work is a stop-and-investigate re
 Never force teardown without explicit discard authority.
 After successful teardown, record completion, retain only the configured recent Done history, and re-evaluate queued work whose blockers and time gates have cleared.
 
+When a ship or scout reaches a terminal outcome or a no-decision external wait - CI running, a review pending, or a PR waiting on merge authority - do not idle for a captain message: persist the outcome, give the captain the one-line outcome, and autonomously dispatch the next safe item that `bin/fm-backlog-next.sh` selects (a dependency-free, unheld Queued item), still applying the section 4 profile and backend checks and the coarse-overlap check above before spawning.
+A pending decision, a PR merge, and any destructive or security-sensitive action are never autonomous: stop and escalate those to the captain instead of advancing past them.
+
 A secondmate is persistent and an empty queue is healthy.
 Retire one only on an explicit captain or main-firstmate decision, after loading `secondmate-provisioning`; its home must contain no work under way, and forced discard still requires explicit captain authority.
 

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -1927,7 +1927,7 @@ fm_backend_herdr_wait_transition() {  # <session> <timeout_secs> <state_dir> <pa
   done < <(fm_backend_herdr_event_reader_cmd)
   [ "${#reader[@]}" -gt 0 ] || return 2
 
-  local fifo_dir fifo reader_pid line ws status agent raw record hit rc=1 reader_rc=0
+  local fifo_dir fifo reader_pid line ws status agent raw record hit rc=1 reader_rc=0 rest marker
   fifo_dir=$(mktemp -d "${TMPDIR:-/tmp}/fm-herdr-eventwait.XXXXXX") || return 2
   fifo="$fifo_dir/events"
   if ! mkfifo "$fifo" 2>/dev/null; then
@@ -1976,17 +1976,37 @@ fm_backend_herdr_wait_transition() {  # <session> <timeout_secs> <state_dir> <pa
   # status into the wrong column. `cut` preserves empty fields.
   while [ "$rc" -eq 1 ] && IFS= read -r line <&9; do
     [ -n "$line" ] || continue
-    pane_id=$(printf '%s' "$line" | cut -f1)
-    ws=$(printf '%s' "$line" | cut -f2)
-    status=$(printf '%s' "$line" | cut -f3)
-    agent=$(printf '%s' "$line" | cut -f4)
+    # Zero-fork tab split preserving empty fields. A tab is IFS-whitespace, so
+    # `cut -f` per field (or `IFS=$'\t' read`) would fork per event and collapse
+    # an empty workspace_id; parameter expansion keeps columns aligned with no
+    # subprocess per line.
+    rest=$line
+    pane_id=${rest%%$'\t'*}; rest=${rest#*$'\t'}
+    ws=${rest%%$'\t'*};      rest=${rest#*$'\t'}
+    status=${rest%%$'\t'*};  agent=${rest#*$'\t'}
     [ -n "$pane_id" ] || continue
-    record=$(fm_backend_herdr_normalize_event "$pane_id" "$ws" "$status" "$agent")
-    if hit=$(fm_backend_herdr_apply_transition "$state" "$session" "$record"); then
-      printf '%s' "$hit"
-      rc=0
-      break
-    fi
+    # Triage by the single-owner status->action table BEFORE the fork-heavy
+    # normalize/apply round-trip. Only a `blocked` edge is ever actionable, so a
+    # busy crew's flood of `working`/`idle`/`done` events must not each pay a full
+    # record round-trip (about a dozen subprocesses per event) - that is the
+    # watcher busy-loop that pegs this process near 100% CPU under a chatty pane.
+    case "$(fm_transition_policy "$status")" in
+      actionable)
+        record=$(fm_backend_herdr_normalize_event "$pane_id" "$ws" "$status" "$agent")
+        if hit=$(fm_backend_herdr_apply_transition "$state" "$session" "$record"); then
+          printf '%s' "$hit"
+          rc=0
+          break
+        fi
+        ;;
+      absorb)
+        # `working` clears this pane's escalation dedupe marker so a later
+        # ->blocked re-escalates - the only side effect apply_transition has for a
+        # non-blocked status, done here without the record round-trip.
+        marker=$(fm_backend_herdr_escalation_marker "$state" "$session:$pane_id")
+        rm -f "$marker" 2>/dev/null || true
+        ;;
+    esac
   done
   if [ "$rc" -eq 0 ]; then
     kill "$reader_pid" 2>/dev/null || true

--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -58,11 +58,34 @@ fm_backend_tmux_send_text_submit() {  # <target> <text> <retries> <enter-sleep> 
 # firstmate itself runs inside tmux, else ensure a dedicated detached
 # "firstmate" session exists. Mirrors fm-spawn.sh's container-ensure block;
 # prints the resolved session name.
+# fm_backend_tmux_wsl_start_dir: a real WSL directory to anchor the firstmate
+# session's default cwd on, so a pane whose per-window start dir cannot apply
+# never falls back to the launcher's Windows mount (e.g. /mnt/c/Users/... when
+# firstmate drives WSL tmux from the Windows side) and builds a worktree there -
+# the leakage that makes `treehouse get` land under /mnt/c and fm-spawn refuse.
+# Prefers the firstmate home, then this adapter's own repo (guaranteed WSL since
+# these scripts run from it), then /tmp - skipping any /mnt, UNC, or drive-letter
+# candidate.
+fm_backend_tmux_wsl_start_dir() {
+  local c
+  for c in "${FM_HOME:-}" "$(dirname "$FM_BACKEND_LIB_DIR")" "$FM_BACKEND_LIB_DIR" "${TMPDIR:-/tmp}"; do
+    [ -n "$c" ] && [ -d "$c" ] || continue
+    case "$c" in
+      /mnt/*|//*|[A-Za-z]:/*|[A-Za-z]:\\*) continue ;;
+    esac
+    printf '%s\n' "$c"
+    return 0
+  done
+  printf '/\n'
+}
+
 fm_backend_tmux_container_ensure() {
   if [ -n "${TMUX:-}" ]; then
     tmux display-message -p '#S'
   else
-    tmux has-session -t firstmate 2>/dev/null || tmux new-session -d -s firstmate
+    # Anchor to a real WSL dir so the session never inherits /mnt/c as its default.
+    tmux has-session -t firstmate 2>/dev/null \
+      || tmux new-session -d -s firstmate -c "$(fm_backend_tmux_wsl_start_dir)"
     printf 'firstmate'
   fi
 }
@@ -84,6 +107,15 @@ fm_backend_tmux_container_ensure() {
 # lost, so worktree discovery cannot fall back to the active client's window.
 fm_backend_tmux_create_task() {  # <session> <window-name> <proj-abs> -> prints window id
   local ses=$1 wname=$2 proj_abs=$3 wid
+  # Fail closed on a non-WSL start dir: an empty, /mnt, UNC, or drive-letter path
+  # would make the pane fall back to the session default and `treehouse get` build
+  # the worktree under a Windows mount (the leakage fm-spawn then refuses). Refuse
+  # here with a pointed diagnostic instead of opening a doomed window.
+  case "$proj_abs" in
+    ''|/mnt/*|//*|[A-Za-z]:/*|[A-Za-z]:\\*)
+      echo "error: refusing to open task window '$wname' at a non-WSL start dir '${proj_abs:-<empty>}' (Windows/UNC worktree leakage); resolve the project inside WSL before spawning" >&2
+      return 1 ;;
+  esac
   if tmux list-windows -t "$ses" -F '#{window_name}' | grep -qx "$wname"; then
     echo "error: window $ses:$wname already exists" >&2
     return 1

--- a/bin/fm-backlog-next.sh
+++ b/bin/fm-backlog-next.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# fm-backlog-next.sh - deterministically pick the next SAFE, dependency-free
+# backlog item to auto-dispatch, so queue advance never depends on agent memory.
+#
+# When a ship/scout reaches a terminal outcome or a no-decision external wait
+# (CI running, review pending, awaiting merge authority), firstmate advances the
+# queue autonomously instead of idling for a captain message. This script is the
+# single owner of "which item is next": it scans `data/backlog.md`'s Queued
+# section in order and prints the id of the first item that is:
+#   - unchecked (`- [ ]`, i.e. not already done/in-flight),
+#   - not held - no `(hold:` or `(hold-kind:` marker, so a parked item and any
+#     captain- or decision-gated thread is never auto-dispatched, and
+#   - dependency-free - it has no `blocked-by: <id>` link, or every such blocker
+#     is already in the Done section.
+#
+# It prints exactly one id and exits 0 when a safe item exists, or prints nothing
+# and exits 1 when none does. It never dispatches: the caller still applies the
+# coarse-overlap and delivery-path checks in AGENTS.md sections 7 and 4 before
+# spawning, and decisions, merges, and destructive/security actions still stop
+# and escalate rather than ride this path.
+#
+# Usage:
+#   fm-backlog-next.sh [<backlog-file>]   default: $FM_HOME/data/backlog.md
+#
+# FM_DATA_OVERRIDE overrides the data dir; an explicit file argument wins.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
+
+case "${1:-}" in
+  -h|--help)
+    awk 'NR==1{next} /^#/{sub(/^# ?/,"");print;next} {exit}' "$0" >&2
+    exit 0 ;;
+esac
+
+BACKLOG=${1:-$DATA/backlog.md}
+[ -f "$BACKLOG" ] || { exit 1; }
+
+# item_id <line> -> the task id after the "- [ ] " / "- [x] " checkbox.
+item_id() {
+  local rest=${1#*] }
+  printf '%s' "${rest%% *}"
+}
+
+# Pass 1: collect Done ids (a blocker in Done counts as cleared).
+done_ids=""
+section=""
+while IFS= read -r line || [ -n "$line" ]; do
+  case "$line" in
+    "## Done"*) section="done"; continue ;;
+    "## "*) section="other"; continue ;;
+  esac
+  [ "$section" = "done" ] || continue
+  case "$line" in
+    "- ["*"] "*) done_ids="$done_ids $(item_id "$line")" ;;
+  esac
+done < "$BACKLOG"
+
+is_done() {  # <id>
+  case " $done_ids " in *" $1 "*) return 0 ;; *) return 1 ;; esac
+}
+
+# Pass 2: first safe, dependency-free Queued item wins.
+section=""
+while IFS= read -r line || [ -n "$line" ]; do
+  case "$line" in
+    "## Queued"*) section="queued"; continue ;;
+    "## "*) section="other"; continue ;;
+  esac
+  [ "$section" = "queued" ] || continue
+  # Only unchecked items are dispatchable.
+  case "$line" in
+    "- [ ] "*) : ;;
+    *) continue ;;
+  esac
+  # Held / parked / captain- or decision-gated: never auto-dispatched.
+  case "$line" in
+    *"(hold:"*|*"(hold-kind:"*) continue ;;
+  esac
+  # Dependency check: every blocked-by link must already be Done.
+  if case "$line" in *"blocked-by:"*) true ;; *) false ;; esac; then
+    blocker_rest=${line#*blocked-by: }
+    blocker=${blocker_rest%% *}
+    is_done "$blocker" || continue
+  fi
+  printf '%s\n' "$(item_id "$line")"
+  exit 0
+done < "$BACKLOG"
+
+exit 1

--- a/bin/fm-heartbeat.sh
+++ b/bin/fm-heartbeat.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# fm-heartbeat.sh - the token-light five-minute supervision heartbeat.
+#
+# This is the cheap pass firstmate runs on each heartbeat wake BEFORE (or instead
+# of) any broad fleet review. It reads only durable, actionable signals - the
+# watcher lock and the quota-wait registry - never captures panes, polls forges,
+# or re-reads the whole fleet. It prints one short line per actionable finding and
+# NOTHING when the fleet cannot advance, so an idle heartbeat costs almost no
+# tokens. It is idempotent and lock-free (it holds no fleet lock), so it is safe
+# to run repeatedly and from any session.
+#
+# It does two things:
+#
+#   1. Recover a provably-stale watcher lock. If this home's watcher lock is
+#      unhealthy AND its recorded holder pid is not alive, the lock is cleared so
+#      the next arm can own a fresh cycle, and "re-arm supervision" is surfaced.
+#      It fails closed: a live holder (even a wedged one) is the guard/daemon's
+#      concern and is never force-unlocked here.
+#
+#   2. Resume quota-parked work. For each bin/fm-quota-wait.sh entry whose backoff
+#      window has passed, re-check availability (quota-axi general windows, the
+#      same signal bin/fm-dispatch-select.sh uses). When capacity is back it
+#      surfaces a "resume <id>" next step and leaves the entry due so it keeps
+#      re-surfacing until firstmate relaunches and clears it - it is never
+#      silently abandoned. When still constrained it pushes the entry out with
+#      bounded backoff, so nothing here busy-polls.
+#
+# Provider-detection limitation: quota-axi reports GENERAL windows only for claude
+# (five_hour, seven_day) and codex (five_hour, weekly). For any other vendor, or
+# when quota-axi is missing or returns unparseable JSON, capacity cannot be
+# verified; the heartbeat falls back to the entry's recorded reset time
+# (--wait-until) and, absent that, keeps backing off rather than abandoning or
+# busy-polling.
+#
+# Usage:
+#   fm-heartbeat.sh [--quota-json <file>] [--now <epoch>]
+#
+# FM_GUARD_GRACE               watcher-liveness beacon freshness (default 300).
+# FM_QUOTA_WAIT_MIN_REMAINING  percentRemaining at/above which a vendor counts as
+#                              recovered (default 5).
+# FM_HEARTBEAT_QUOTA_AXI / FM_DISPATCH_QUOTA_AXI  override the quota command.
+# --quota-json / --now         test seams (fixture quota JSON; fixed clock).
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=bin/fm-wake-lib.sh
+. "$SCRIPT_DIR/fm-wake-lib.sh"
+
+WATCH="$SCRIPT_DIR/fm-watch.sh"
+QUOTA_WAIT="$SCRIPT_DIR/fm-quota-wait.sh"
+GRACE=${FM_GUARD_GRACE:-300}
+MIN_REMAINING=${FM_QUOTA_WAIT_MIN_REMAINING:-5}
+QUOTA_AXI=${FM_HEARTBEAT_QUOTA_AXI:-${FM_DISPATCH_QUOTA_AXI:-quota-axi}}
+
+QUOTA_JSON_FILE=
+NOW_OVERRIDE=
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --quota-json) QUOTA_JSON_FILE=${2:-}; shift 2 ;;
+    --now) NOW_OVERRIDE=${2:-}; shift 2 ;;
+    -h|--help)
+      awk 'NR==1{next} /^#/{sub(/^# ?/,"");print;next} {exit}' "$0" >&2
+      exit 0 ;;
+    *) echo "error: unknown argument $1" >&2; exit 2 ;;
+  esac
+done
+
+now_epoch() {
+  if [ -n "$NOW_OVERRIDE" ]; then printf '%s\n' "$NOW_OVERRIDE"; else date +%s; fi
+}
+
+# --- 1. stale watcher-lock recovery -----------------------------------------
+
+recover_stale_watcher_lock() {
+  local lockdir="$STATE/.watch.lock" lock_pid
+  [ -e "$lockdir" ] || return 0
+  # A genuinely live, identity-matched, freshly-beating watcher is healthy: leave it.
+  fm_watcher_healthy "$STATE" "$WATCH" "$GRACE" "$FM_HOME" && return 0
+  lock_pid=$(cat "$lockdir/pid" 2>/dev/null || true)
+  # Fail closed: only clear a lock whose recorded holder is PROVABLY not alive.
+  if [ -n "$lock_pid" ] && fm_pid_alive "$lock_pid"; then
+    return 0
+  fi
+  fm_lock_remove_path "$lockdir" 2>/dev/null || fm_lock_clean_known_files "$lockdir"
+  printf 'watcher: cleared stale lock (holder pid %s not alive); re-arm supervision\n' "${lock_pid:-none}"
+}
+
+# --- 2. quota-wait resume ----------------------------------------------------
+
+# General (non-model) windows that gate whole-vendor availability, mirroring
+# bin/fm-dispatch-select.sh's quota-balanced contract. A jq fragment, so the
+# unexpanded $v is intentional.
+# shellcheck disable=SC2016
+general_ids_jq='
+  def general_ids($v):
+    if $v == "claude" then ["five_hour","seven_day"]
+    elif $v == "codex" then ["five_hour","weekly"]
+    else [] end;'
+
+# Load the quota snapshot once. Empty on any trouble - callers then fall back to
+# the recorded reset time instead of guessing.
+load_quota_json() {
+  if [ -n "$QUOTA_JSON_FILE" ]; then
+    cat "$QUOTA_JSON_FILE" 2>/dev/null || true
+    return 0
+  fi
+  command -v "$QUOTA_AXI" >/dev/null 2>&1 || return 0
+  "$QUOTA_AXI" --json 2>/dev/null || true
+}
+
+# Echo the min percentRemaining across a vendor's general windows (optionally a
+# single named window), or nothing if the snapshot is unusable or has no windows.
+quota_min_remaining() {  # <quota_json> <vendor> <window-or-empty>
+  local quota_json=$1 vendor=$2 window=$3
+  printf '%s\n' "$quota_json" | jq -er --arg v "$vendor" --arg w "$window" "
+    $general_ids_jq
+    (if \$w == \"\" then general_ids(\$v) else [\$w] end) as \$ids
+    | [ (.providers // [])[]? | select(.provider == \$v)
+        | (.windows // [])[]?
+        | . as \$win
+        | select( (\$ids | index(\$win.id)) != null
+                  and ((\$win.kind? // \"\") != \"model\")
+                  and ((\$win.percentRemaining? | type) == \"number\") )
+        | \$win.percentRemaining ]
+    | if length == 0 then error(\"none\") else min end
+  " 2>/dev/null
+}
+
+resume_quota_waits() {
+  local now quota_json due id entry vendor window relaunch wait_until min available
+  now=$(now_epoch)
+  quota_json=$(load_quota_json)
+  due=$("$QUOTA_WAIT" due --now "$now" 2>/dev/null) || return 0
+  [ -n "$due" ] || return 0
+
+  while IFS= read -r id; do
+    [ -n "$id" ] || continue
+    entry=$("$QUOTA_WAIT" get "$id" 2>/dev/null) || continue
+    vendor=$(printf '%s' "$entry" | jq -r '.vendor // ""')
+    window=$(printf '%s' "$entry" | jq -r '.window // ""')
+    relaunch=$(printf '%s' "$entry" | jq -r '.relaunch // "no relaunch instruction recorded"')
+    wait_until=$(printf '%s' "$entry" | jq -r '.wait_until // ""')
+
+    available=0
+    min=
+    if [ -n "$quota_json" ]; then
+      min=$(quota_min_remaining "$quota_json" "$vendor" "$window" || true)
+    fi
+    if [ -n "$min" ]; then
+      # Capacity-verified: a real percentRemaining at/above the floor.
+      if awk -v m="$min" -v t="$MIN_REMAINING" 'BEGIN{exit !(m+0 >= t+0)}'; then
+        available=1
+      fi
+    else
+      # No usable quota signal (unknown vendor, or quota-axi absent/unparseable):
+      # fall back to the recorded reset time.
+      case "$wait_until" in
+        ''|null) : ;;
+        *) [ "$now" -ge "$wait_until" ] 2>/dev/null && available=1 ;;
+      esac
+    fi
+
+    if [ "$available" -eq 1 ]; then
+      if [ -n "$min" ]; then
+        printf 'resume %s: %s capacity available (%s%% remaining); relaunch: %s\n' \
+          "$id" "$vendor" "$min" "$relaunch"
+      else
+        printf 'resume %s: %s wait window elapsed; relaunch: %s\n' \
+          "$id" "$vendor" "$relaunch"
+      fi
+      # Leave the entry due so it keeps re-surfacing until firstmate relaunches
+      # and clears it - never silently dropped.
+    else
+      # Still constrained: push next_check out with bounded backoff (no busy poll).
+      "$QUOTA_WAIT" bump "$id" >/dev/null 2>&1 || true
+    fi
+  done <<EOF
+$due
+EOF
+}
+
+recover_stale_watcher_lock
+resume_quota_waits
+exit 0

--- a/bin/fm-quota-wait.sh
+++ b/bin/fm-quota-wait.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# fm-quota-wait.sh - durable registry of crewmate work parked ONLY on a harness
+# 5h/quota limit, so a lightweight heartbeat can resume it the moment capacity
+# returns instead of the wait rotting invisibly.
+#
+# One entry per task lives at $FM_HOME/state/<id>.quota-wait as compact JSON, the
+# same single-link, colocated convention as <id>.meta/<id>.status. The entry
+# records everything needed to relaunch the SAME queued work without re-deriving
+# it: the vendor whose limit blocked it, the optional general window, and a
+# free-form relaunch instruction (a fm-send steer, a spawn, a promote - whatever
+# resumes it). Backoff is stored, not slept, so nothing here busy-polls: the
+# heartbeat cadence is the only clock, and each due re-check either resumes or
+# pushes next_check out with bounded exponential backoff.
+#
+# This script is pure registry CRUD. Capacity is judged by the consumer
+# (bin/fm-heartbeat.sh) so quota-axi evaluation lives in exactly one place.
+#
+# Provider-detection limitation: firstmate cannot itself prove a pane is blocked
+# SOLELY by a quota limit; the caller classifies that (from the crewmate's
+# `paused:` reason) and records it here. A wrong vendor or a non-quota block
+# recorded here only costs an extra harmless heartbeat re-check; it is never
+# silently dropped.
+#
+# Usage:
+#   fm-quota-wait.sh record <id> --vendor <v> [--window <w>] [--relaunch <str>]
+#                               [--wait-secs <n> | --wait-until <epoch>]
+#   fm-quota-wait.sh list                     one line per entry: <id> <vendor> <window> next=<epoch> attempts=<n>
+#   fm-quota-wait.sh due [--now <epoch>]      ids whose next_check has passed
+#   fm-quota-wait.sh get <id>                 print the entry JSON
+#   fm-quota-wait.sh bump <id>                one more attempt; push next_check out with bounded backoff
+#   fm-quota-wait.sh clear <id>               remove the entry (resumed or abandoned by decision)
+#
+# FM_QUOTA_WAIT_BASE_SECS   first/base backoff step (default 300, one heartbeat).
+# FM_QUOTA_WAIT_MAX_SECS    backoff ceiling (default 3600).
+# FM_QUOTA_WAIT_NOW         override "now" epoch for deterministic tests.
+# FM_STATE_OVERRIDE         state dir (default $FM_HOME/state).
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+
+BASE_SECS=${FM_QUOTA_WAIT_BASE_SECS:-300}
+MAX_SECS=${FM_QUOTA_WAIT_MAX_SECS:-3600}
+
+usage() {
+  awk '
+    NR == 1 { next }
+    /^#/ { sub(/^# ?/, ""); print; next }
+    { exit }
+  ' "$0" >&2
+}
+
+command -v jq >/dev/null 2>&1 || { echo "error: jq is required" >&2; exit 2; }
+
+now_epoch() {
+  if [ -n "${FM_QUOTA_WAIT_NOW:-}" ]; then
+    printf '%s\n' "$FM_QUOTA_WAIT_NOW"
+  else
+    date +%s
+  fi
+}
+
+entry_path() {  # <id>
+  printf '%s/%s.quota-wait\n' "$STATE" "$1"
+}
+
+valid_id() {  # <id>
+  case "$1" in
+    ''|*/*|.|..) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+# next_check = now + min(BASE * 2^attempts, MAX), clamped so a bad env never
+# yields a negative or runaway step.
+backoff_next() {  # <attempts>
+  local attempts=$1 step=$BASE_SECS i
+  [ "$step" -ge 1 ] 2>/dev/null || step=300
+  i=0
+  while [ "$i" -lt "$attempts" ]; do
+    step=$(( step * 2 ))
+    if [ "$step" -ge "$MAX_SECS" ]; then step=$MAX_SECS; break; fi
+    i=$(( i + 1 ))
+  done
+  [ "$step" -le "$MAX_SECS" ] || step=$MAX_SECS
+  printf '%s\n' "$(( $(now_epoch) + step ))"
+}
+
+cmd_record() {
+  local id=${1:-}; shift || true
+  valid_id "$id" || { echo "error: record needs a valid task id" >&2; exit 2; }
+  local vendor="" window="" relaunch="" wait_secs="" wait_until=""
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --vendor) vendor=${2:-}; shift 2 ;;
+      --window) window=${2:-}; shift 2 ;;
+      --relaunch) relaunch=${2:-}; shift 2 ;;
+      --wait-secs) wait_secs=${2:-}; shift 2 ;;
+      --wait-until) wait_until=${2:-}; shift 2 ;;
+      *) echo "error: unknown record option $1" >&2; exit 2 ;;
+    esac
+  done
+  [ -n "$vendor" ] || { echo "error: --vendor is required" >&2; exit 2; }
+
+  local now next
+  now=$(now_epoch)
+  if [ -n "$wait_until" ]; then
+    next=$wait_until
+  elif [ -n "$wait_secs" ]; then
+    next=$(( now + wait_secs ))
+  else
+    next=$now
+  fi
+
+  mkdir -p "$STATE"
+  local tmp
+  tmp=$(mktemp "$STATE/.quota-wait.XXXXXX") || { echo "error: mktemp failed" >&2; exit 1; }
+  jq -nc \
+    --arg id "$id" --arg vendor "$vendor" --arg window "$window" \
+    --arg relaunch "$relaunch" --argjson recorded "$now" \
+    --argjson wait_until "${wait_until:-0}" --argjson next "$next" '
+    {
+      id: $id,
+      vendor: $vendor,
+      window: (if $window == "" then null else $window end),
+      relaunch: (if $relaunch == "" then null else $relaunch end),
+      recorded_at: $recorded,
+      wait_until: (if $wait_until == 0 then null else $wait_until end),
+      attempts: 0,
+      next_check: $next
+    }' > "$tmp" || { rm -f "$tmp"; echo "error: could not compose entry" >&2; exit 1; }
+  mv -f "$tmp" "$(entry_path "$id")"
+  printf 'recorded quota-wait %s vendor=%s next=%s\n' "$id" "$vendor" "$next"
+}
+
+cmd_list() {
+  local f
+  for f in "$STATE"/*.quota-wait; do
+    [ -e "$f" ] || continue
+    jq -r '"\(.id) \(.vendor) \(.window // "-") next=\(.next_check) attempts=\(.attempts)"' "$f" 2>/dev/null || true
+  done
+}
+
+cmd_due() {
+  local now=
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --now) now=${2:-}; shift 2 ;;
+      *) echo "error: unknown due option $1" >&2; exit 2 ;;
+    esac
+  done
+  [ -n "$now" ] || now=$(now_epoch)
+  local f
+  for f in "$STATE"/*.quota-wait; do
+    [ -e "$f" ] || continue
+    jq -r --argjson now "$now" 'select(.next_check <= $now) | .id' "$f" 2>/dev/null || true
+  done
+}
+
+cmd_get() {
+  local id=${1:-}
+  valid_id "$id" || { echo "error: get needs a valid task id" >&2; exit 2; }
+  local f
+  f=$(entry_path "$id")
+  [ -e "$f" ] || { echo "error: no quota-wait entry for $id" >&2; exit 1; }
+  cat "$f"
+}
+
+cmd_bump() {
+  local id=${1:-}
+  valid_id "$id" || { echo "error: bump needs a valid task id" >&2; exit 2; }
+  local f attempts next tmp
+  f=$(entry_path "$id")
+  [ -e "$f" ] || { echo "error: no quota-wait entry for $id" >&2; exit 1; }
+  attempts=$(jq -r '.attempts' "$f" 2>/dev/null || echo 0)
+  case "$attempts" in ''|*[!0-9]*) attempts=0 ;; esac
+  attempts=$(( attempts + 1 ))
+  next=$(backoff_next "$attempts")
+  tmp=$(mktemp "$STATE/.quota-wait.XXXXXX") || { echo "error: mktemp failed" >&2; exit 1; }
+  jq -c --argjson attempts "$attempts" --argjson next "$next" \
+    '.attempts = $attempts | .next_check = $next' "$f" > "$tmp" \
+    || { rm -f "$tmp"; echo "error: could not update entry" >&2; exit 1; }
+  mv -f "$tmp" "$f"
+  printf 'bumped %s attempts=%s next=%s\n' "$id" "$attempts" "$next"
+}
+
+cmd_clear() {
+  local id=${1:-}
+  valid_id "$id" || { echo "error: clear needs a valid task id" >&2; exit 2; }
+  rm -f "$(entry_path "$id")"
+  printf 'cleared quota-wait %s\n' "$id"
+}
+
+case "${1:-}" in
+  record) shift; cmd_record "$@" ;;
+  list) shift; cmd_list "$@" ;;
+  due) shift; cmd_due "$@" ;;
+  get) shift; cmd_get "$@" ;;
+  bump) shift; cmd_bump "$@" ;;
+  clear) shift; cmd_clear "$@" ;;
+  -h|--help) usage; exit 0 ;;
+  *) usage; exit 2 ;;
+esac

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1101,8 +1101,15 @@ if [ "$KIND" != secondmate ]; then
   case "$HARNESS" in
     claude*)
       mkdir -p "$WT/.claude"
+      # `mkdir -p` the state dir before `touch` so the turn-end signal is durable:
+      # the Stop hook fires from the crew's own launch environment, and if that
+      # path's parent is momentarily absent (a fresh/rebuilt home, a not-yet-created
+      # state dir, or a Windows/WSL launch where the dir must be re-materialized) a
+      # bare `touch` dies with "No such file or directory" and the turn-end signal is
+      # silently lost - the watcher then only sees the crew via the late stale-pane
+      # timer instead of an immediate wake.
       cat > "$WT/.claude/settings.local.json" <<EOF
-{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"touch '$TURNEND'"}]}]}}
+{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"mkdir -p '$STATE_REAL' && touch '$TURNEND'"}]}]}}
 EOF
       exclude_path '.claude/settings.local.json'
       ;;

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -2371,6 +2371,37 @@ test_wait_transition_stream_absorb_clears_then_timeout() {
   pass "fm_backend_herdr_wait_transition: streamed working clears the marker, idle/done are deferred (clean timeout)"
 }
 
+test_wait_transition_event_flood_skips_forkheavy_path() {
+  # Regression: a busy crew (e.g. tsc -b) floods the transition stream with
+  # non-actionable `working` events. The drain must triage each by the
+  # single-owner status->action table BEFORE the fork-heavy normalize/apply
+  # round-trip, or the watcher pegs ~100% CPU per event (the observed busy loop).
+  # normalize/apply are stubbed here to COUNT calls: they must fire only for the
+  # one reconcile level-check and the one real `blocked` edge - never per flood
+  # event - while the blocked edge is still returned and the working flood still
+  # clears the escalation marker (absorb side effect preserved).
+  local dir state agent fb reader lines cnt out rc marker acount i
+  dir="$TMP_ROOT/wt-flood"; state="$dir/state"; agent="$dir/agents"; mkdir -p "$state" "$agent"
+  fb=$(make_herdr_eventfake "$dir")
+  set_fake_agent "$agent" "wG:pQ" idle   # reconcile sees idle -> proceeds to stream
+  reader=$(make_fake_reader "$dir"); lines="$dir/lines"; cnt="$dir/calls"; : > "$cnt"
+  marker="$state/.herdr-escalated-sess_wG_pQ"
+  : > "$marker"   # previously escalated; the working flood must clear it
+  { for i in $(seq 800); do printf 'wG:pQ\t\tworking\tclaude\n'; done; printf 'wG:pQ\t\tblocked\tclaude\n'; } > "$lines"
+  out=$(PATH="$fb:$PATH" FM_BACKEND_HERDR_EVENTS_FORCE=1 FM_FAKE_SESSION_NAME=sess FM_FAKE_SOCKET="$dir/x.sock" FM_FAKE_AGENT_DIR="$agent" \
+    FM_BACKEND_HERDR_EVENT_READER="$reader" FM_FAKE_READER_LINES="$lines" FM_FLOOD_CNT="$cnt" \
+    bash -c '. "$0/bin/backends/herdr.sh"
+      fm_backend_herdr_normalize_event() { printf n >> "$FM_FLOOD_CNT"; printf "%s\t\t%s\t%s" "$1" "$3" "$4"; }
+      fm_backend_herdr_apply_transition() { printf a >> "$FM_FLOOD_CNT"; case "$3" in *blocked*) printf "%s" "$3"; return 0 ;; *) return 1 ;; esac; }
+      fm_backend_herdr_wait_transition sess 5 "$1" sess:wG:pQ' "$ROOT" "$state"); rc=$?
+  [ "$rc" = 0 ] || fail "the blocked edge after a working flood must still return 0, got $rc"
+  case "$out" in *blocked*) : ;; *) fail "the blocked edge must still be returned after the flood, got '$out'" ;; esac
+  [ ! -e "$marker" ] || fail "the working flood must still clear the escalation marker (absorb preserved)"
+  acount=$(tr -dc a < "$cnt" | wc -c | tr -d ' ')
+  [ "$acount" -lt 100 ] || fail "fork-heavy apply must NOT run per flood event (busy-loop regression); apply ran $acount times for an 800-event flood"
+  pass "fm_backend_herdr_wait_transition: a working-event flood is triaged cheaply, not one normalize/apply per event"
+}
+
 test_wait_transition_reader_failure_returns_2() {
   local dir state agent temp fb reader lines rc
   dir="$TMP_ROOT/wt-reader-fail"; state="$dir/state"; agent="$dir/agents"; temp="$dir/temp"; mkdir -p "$state" "$agent" "$temp"
@@ -2532,6 +2563,7 @@ test_wait_transition_subscribes_before_reconcile
 test_wait_transition_reconcile_dedupes_when_marked
 test_wait_transition_stream_blocked_returns_record
 test_wait_transition_stream_absorb_clears_then_timeout
+test_wait_transition_event_flood_skips_forkheavy_path
 test_wait_transition_reader_failure_returns_2
 test_wait_transition_bad_ack_returns_2_and_cleans_up
 test_wait_transition_clean_timeout_returns_1

--- a/tests/fm-backend-tmux-smoke.test.sh
+++ b/tests/fm-backend-tmux-smoke.test.sh
@@ -73,6 +73,27 @@ if fm_backend_tmux_create_task "$SESSION" "$WINDOW" "$HOME" 2>/dev/null; then
 fi
 pass "real tmux: fm_backend_tmux_create_task creates a window and refuses a duplicate"
 
+# --- WSL/Windows worktree-leakage guard --------------------------------------
+# A non-WSL start dir (a /mnt mount, a UNC path, a drive-letter path, or empty)
+# must be refused BEFORE a window opens, so a Windows-launched session can never
+# let `treehouse get` build the worktree under /mnt/c (the leakage fm-spawn
+# refuses only after the fact, stranding queued work).
+for bad in "/mnt/c/Users/tiger" "//wsl.localhost/x" "C:/Users/tiger" ""; do
+  if fm_backend_tmux_create_task "$SESSION" "fm-guard-$RANDOM" "$bad" 2>/dev/null; then
+    fail "create_task must refuse a non-WSL start dir: '${bad:-<empty>}'"
+  fi
+done
+if tmux list-windows -t "$SESSION" -F '#{window_name}' | grep -q '^fm-guard-'; then
+  fail "a refused non-WSL start dir must not leave a window behind"
+fi
+# The session anchor must resolve to a real WSL dir, never a /mnt or UNC path.
+anchor=$(fm_backend_tmux_wsl_start_dir)
+[ -d "$anchor" ] || fail "wsl_start_dir must be an existing directory (got '$anchor')"
+case "$anchor" in
+  /mnt/*|//*|[A-Za-z]:/*) fail "wsl_start_dir must not be a Windows mount/UNC path (got '$anchor')" ;;
+esac
+pass "real tmux: create_task refuses a Windows/UNC start dir and the session anchor is a WSL dir"
+
 # --- send text + Enter -------------------------------------------------------
 
 # A newly-created interactive shell can exist before its startup files and line

--- a/tests/fm-backlog-next.test.sh
+++ b/tests/fm-backlog-next.test.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# tests/fm-backlog-next.test.sh - the durable queue-advance selector: pick the
+# first SAFE, dependency-free Queued backlog item, skipping held/parked/captain-
+# gated items and items whose blocked-by dependency has not landed.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+NEXT="$ROOT/bin/fm-backlog-next.sh"
+TMP_ROOT=$(fm_test_tmproot fm-backlog-next-tests)
+
+write_backlog() {  # <file> <<<content
+  mkdir -p "$TMP_ROOT"
+  cat > "$1"
+}
+
+test_picks_first_free_item() {
+  local f; f="$TMP_ROOT/b1.md"
+  write_backlog "$f" <<'EOF'
+## In flight
+- [ ] running-1 - a running ship (kind: ship)
+## Queued
+- [ ] parked-1 - a parked item (kind: ship) (hold: awaiting captain) (hold-kind: captain)
+- [ ] blocked-1 - waits on the running ship (kind: ship) blocked-by: running-1 - after it
+- [ ] free-1 - dependency-free and unheld (kind: ship)
+## Done
+- [x] old-done - finished earlier (kind: ship)
+EOF
+  local out rc
+  out=$("$NEXT" "$f"); rc=$?
+  expect_code 0 "$rc" "a safe item exists so the selector must succeed"
+  [ "$out" = "free-1" ] || fail "expected free-1 (parked skipped, blocked skipped), got '$out'"
+  pass "selector skips a held item and one blocked by in-flight work, picking the first free item"
+}
+
+test_dependency_cleared_by_done_is_dispatchable() {
+  local f; f="$TMP_ROOT/b2.md"
+  write_backlog "$f" <<'EOF'
+## Queued
+- [ ] after-done - runs once its blocker lands (kind: ship) blocked-by: old-done - cleared
+## Done
+- [x] old-done - finished (kind: ship)
+EOF
+  local out
+  out=$("$NEXT" "$f") || fail "an item whose blocker is Done must be dispatchable"
+  [ "$out" = "after-done" ] || fail "expected after-done (blocker is Done), got '$out'"
+  pass "an item whose blocked-by dependency is already Done is dispatchable"
+}
+
+test_no_safe_item_exits_nonzero() {
+  local f; f="$TMP_ROOT/b3.md"
+  write_backlog "$f" <<'EOF'
+## In flight
+- [ ] running-1 - a running ship (kind: ship)
+## Queued
+- [ ] parked-1 - parked (kind: ship) (hold: re-scope) (hold-kind: parked)
+- [ ] blocked-1 - waits on running (kind: ship) blocked-by: running-1 - later
+## Done
+EOF
+  local out rc
+  out=$("$NEXT" "$f"); rc=$?
+  expect_code 1 "$rc" "no safe item means a non-zero exit"
+  [ -z "$out" ] || fail "no safe item must print nothing, got '$out'"
+  pass "when every queued item is held or blocked, the selector advances nothing (exit 1)"
+}
+
+test_captain_gated_item_is_never_autodispatched() {
+  local f; f="$TMP_ROOT/b4.md"
+  write_backlog "$f" <<'EOF'
+## Queued
+- [ ] decide-1 - needs a captain decision (kind: ship) (hold: awaiting captain decision) (hold-kind: captain)
+- [ ] safe-1 - free (kind: ship)
+EOF
+  local out
+  out=$("$NEXT" "$f") || fail "a free item exists after the gated one"
+  [ "$out" = "safe-1" ] || fail "a captain-gated item must never be auto-dispatched, got '$out'"
+  pass "a captain/decision-gated item is skipped so it stays escalated, not auto-dispatched"
+}
+
+test_missing_backlog_exits_nonzero() {
+  local rc
+  "$NEXT" "$TMP_ROOT/does-not-exist.md" >/dev/null 2>&1; rc=$?
+  expect_code 1 "$rc" "a missing backlog file must exit non-zero, not crash"
+  pass "a missing backlog file exits non-zero without error"
+}
+
+test_picks_first_free_item
+test_dependency_cleared_by_done_is_dispatchable
+test_no_safe_item_exits_nonzero
+test_captain_gated_item_is_never_autodispatched
+test_missing_backlog_exits_nonzero

--- a/tests/fm-heartbeat.test.sh
+++ b/tests/fm-heartbeat.test.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# tests/fm-heartbeat.test.sh - the token-light heartbeat: provably-stale
+# watcher-lock recovery (fail-closed on a live holder) and quota-wait resume
+# (capacity-verified, time-based fallback, bounded backoff, never abandoned).
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+HB="$ROOT/bin/fm-heartbeat.sh"
+QW="$ROOT/bin/fm-quota-wait.sh"
+TMP_ROOT=$(fm_test_tmproot fm-heartbeat-tests)
+
+dead_pid() {
+  local p=999999
+  while kill -0 "$p" 2>/dev/null; do p=$((p + 1)); done
+  printf '%s\n' "$p"
+}
+
+new_home() {  # echo a fresh FM_HOME with an empty state dir
+  local d
+  mkdir -p "$TMP_ROOT"
+  d=$(mktemp -d "$TMP_ROOT/home.XXXXXX")
+  mkdir -p "$d/state"
+  printf '%s\n' "$d"
+}
+
+quota_fixture() {  # <file> <percentRemaining>
+  local file=$1 pct=$2
+  cat > "$file" <<EOF
+{"providers":[{"provider":"claude","state":{"status":"fresh"},
+  "windows":[{"id":"five_hour","percentRemaining":$pct},
+             {"id":"seven_day","percentRemaining":$pct}]}]}
+EOF
+}
+
+# --- stale watcher-lock recovery --------------------------------------------
+
+test_stale_lock_cleared() {
+  local home state out dp
+  home=$(new_home); state="$home/state"
+  dp=$(dead_pid)
+  mkdir -p "$state/.watch.lock"
+  printf '%s\n' "$dp" > "$state/.watch.lock/pid"
+  out=$(FM_HOME="$home" FM_STATE_OVERRIDE="$state" "$HB" 2>&1)
+  assert_contains "$out" "cleared stale lock" "stale lock (dead holder) is reported"
+  assert_contains "$out" "re-arm supervision" "recovery surfaces the next step"
+  assert_absent "$state/.watch.lock/pid" "the stale lock file is removed"
+  pass "a provably-stale watcher lock (dead holder) is recovered"
+}
+
+test_live_lock_preserved() {
+  local home state out
+  home=$(new_home); state="$home/state"
+  mkdir -p "$state/.watch.lock"
+  # A live pid that is NOT an identity-matched healthy watcher: unhealthy, but
+  # alive, so it must be left alone (fail closed).
+  printf '%s\n' "$$" > "$state/.watch.lock/pid"
+  out=$(FM_HOME="$home" FM_STATE_OVERRIDE="$state" "$HB" 2>&1)
+  assert_not_contains "$out" "cleared stale lock" "a live holder is never force-unlocked"
+  assert_present "$state/.watch.lock/pid" "the live lock file is preserved"
+  pass "a live (even unhealthy) watcher lock is preserved - fail closed"
+}
+
+# --- quota-wait resume ------------------------------------------------------
+
+test_resume_when_capacity_back() {
+  local home state fixture out attempts
+  home=$(new_home); state="$home/state"
+  fixture="$home/quota.json"
+  quota_fixture "$fixture" 80
+  FM_STATE_OVERRIDE="$state" FM_QUOTA_WAIT_NOW=1000 \
+    "$QW" record parked-1 --vendor claude --relaunch 'fm-send parked-1 resume' >/dev/null
+  out=$(FM_HOME="$home" FM_STATE_OVERRIDE="$state" \
+    "$HB" --quota-json "$fixture" --now 2000 2>&1)
+  assert_contains "$out" "resume parked-1" "capacity return surfaces a resume step"
+  assert_contains "$out" "fm-send parked-1 resume" "the recorded relaunch is surfaced"
+  attempts=$(FM_STATE_OVERRIDE="$state" "$QW" get parked-1 | jq -r '.attempts')
+  [ "$attempts" = "0" ] || fail "an available entry stays due (not backed off), got attempts=$attempts"
+  assert_present "$state/parked-1.quota-wait" "the entry is not dropped until firstmate clears it"
+  pass "resume is surfaced when verified capacity returns, entry kept until cleared"
+}
+
+test_backoff_when_still_constrained() {
+  local home state fixture out attempts due
+  home=$(new_home); state="$home/state"
+  fixture="$home/quota.json"
+  quota_fixture "$fixture" 1
+  FM_STATE_OVERRIDE="$state" FM_QUOTA_WAIT_NOW=1000 \
+    "$QW" record parked-2 --vendor claude >/dev/null
+  out=$(FM_HOME="$home" FM_STATE_OVERRIDE="$state" \
+    "$HB" --quota-json "$fixture" --now 2000 2>&1)
+  assert_not_contains "$out" "resume parked-2" "still-constrained work is not resumed"
+  attempts=$(FM_STATE_OVERRIDE="$state" "$QW" get parked-2 | jq -r '.attempts')
+  [ "$attempts" = "1" ] || fail "a constrained re-check backs off (attempts=1), got $attempts"
+  due=$(FM_STATE_OVERRIDE="$state" "$QW" due --now 2000)
+  assert_not_contains "$due" "parked-2" "backoff pushes next_check past now (no busy poll)"
+  pass "a still-constrained entry backs off and is never busy-polled"
+}
+
+test_time_fallback_without_quota_axi() {
+  local home state out
+  home=$(new_home); state="$home/state"
+  FM_STATE_OVERRIDE="$state" "$QW" record parked-3 --vendor opencode --wait-until 1500 \
+    --relaunch 'relaunch parked-3' >/dev/null
+  # No fixture and a missing quota command: capacity cannot be verified, so the
+  # declared reset time drives resumption.
+  out=$(FM_HOME="$home" FM_STATE_OVERRIDE="$state" \
+    FM_HEARTBEAT_QUOTA_AXI=/nonexistent/quota-axi "$HB" --now 2000 2>&1)
+  assert_contains "$out" "resume parked-3" "elapsed reset time resumes when capacity is unverifiable"
+  assert_contains "$out" "wait window elapsed" "the fallback reason is time-based, not a false capacity claim"
+  pass "unverifiable vendor falls back to the recorded reset time"
+}
+
+test_no_output_when_nothing_actionable() {
+  local home state out
+  home=$(new_home); state="$home/state"
+  out=$(FM_HOME="$home" FM_STATE_OVERRIDE="$state" \
+    FM_HEARTBEAT_QUOTA_AXI=/nonexistent/quota-axi "$HB" --now 2000 2>&1)
+  [ -z "$out" ] || fail "an idle heartbeat must be silent, got: $out"
+  pass "an idle heartbeat prints nothing (token-light)"
+}
+
+test_stale_lock_cleared
+test_live_lock_preserved
+test_resume_when_capacity_back
+test_backoff_when_still_constrained
+test_time_fallback_without_quota_axi
+test_no_output_when_nothing_actionable

--- a/tests/fm-munra-architecture-intake.test.sh
+++ b/tests/fm-munra-architecture-intake.test.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# tests/fm-munra-architecture-intake.test.sh - the Munra architecture-intake skill
+# must exist, stay agent-only, cover every required consult point of Munra PR
+# #275's model, and be loaded by a real AGENTS.md trigger (a skill nothing loads
+# is dead weight).
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SKILL="$ROOT/.agents/skills/munra-architecture-intake/SKILL.md"
+AGENTS="$ROOT/AGENTS.md"
+
+test_skill_exists_agent_only() {
+  assert_present "$SKILL" "the skill file exists"
+  assert_grep "name: munra-architecture-intake" "$SKILL" "skill declares its name"
+  assert_grep "user-invocable: false" "$SKILL" "skill is agent-only, not captain-invocable"
+  pass "skill exists and is agent-only"
+}
+
+test_skill_covers_required_protocol() {
+  # Refresh to current origin/master through the existing safe mechanism.
+  assert_grep "origin/master" "$SKILL" "skill requires refresh against current origin/master"
+  assert_grep "fm-fleet-sync.sh" "$SKILL" "skill reuses the guarded fleet-sync refresh"
+  # Flexible selection from current reality, not a stale brief.
+  assert_grep "stale" "$SKILL" "skill warns against a stale in-flight brief"
+  # Consult the architecture index + change-impact protocol.
+  assert_grep "docs/architecture/README.md" "$SKILL" "skill points at the architecture index"
+  assert_grep "docs/development/CHANGE_PROTOCOL.md" "$SKILL" "skill points at the change protocol"
+  # Source-of-truth boundary.
+  assert_grep "source-of-truth boundary" "$SKILL" "skill applies the source-of-truth boundary"
+  # Affected invariants + feature surfaces.
+  assert_grep "INVARIANTS.md" "$SKILL" "skill names affected invariants"
+  assert_grep "features.yaml" "$SKILL" "skill names affected feature surfaces"
+  # Test lanes.
+  assert_grep "FEATURE_TEST_STRATEGY.md" "$SKILL" "skill selects test lanes"
+  pass "skill covers refresh, flexible selection, and every consult point"
+}
+
+test_agents_triggers_present() {
+  # Section 13 canonical listing.
+  assert_grep "\`munra-architecture-intake\` - load before selecting a Munra issue" "$AGENTS" \
+    "section 13 lists the skill with a load trigger"
+  # Brief-authoring trigger (section 11).
+  assert_grep "load \`munra-architecture-intake\` before selecting the issue or writing the brief" "$AGENTS" \
+    "the brief section triggers the skill"
+  pass "AGENTS.md loads the skill at its intake and brief triggers"
+}
+
+test_skill_exists_agent_only
+test_skill_covers_required_protocol
+test_agents_triggers_present

--- a/tests/fm-quota-wait.test.sh
+++ b/tests/fm-quota-wait.test.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# tests/fm-quota-wait.test.sh - durable quota-wait registry CRUD, due-filtering,
+# and bounded backoff. A parked-on-quota entry must survive as a real on-disk
+# record and never busy-poll: backoff is stored, capped, and never negative.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+QW="$ROOT/bin/fm-quota-wait.sh"
+TMP_ROOT=$(fm_test_tmproot fm-quota-wait-tests)
+
+new_state() {  # echo a fresh empty state dir
+  local d
+  mkdir -p "$TMP_ROOT"
+  d=$(mktemp -d "$TMP_ROOT/state.XXXXXX")
+  printf '%s\n' "$d"
+}
+
+test_record_then_get() {
+  local state entry
+  state=$(new_state)
+  FM_STATE_OVERRIDE="$state" FM_QUOTA_WAIT_NOW=1000 \
+    "$QW" record shipwork-1 --vendor claude --window five_hour \
+    --relaunch 'fm-send shipwork-1 resume' >/dev/null
+  entry=$(FM_STATE_OVERRIDE="$state" "$QW" get shipwork-1)
+  assert_contains "$entry" '"vendor":"claude"' "vendor persisted"
+  assert_contains "$entry" '"window":"five_hour"' "window persisted"
+  assert_contains "$entry" '"relaunch":"fm-send shipwork-1 resume"' "relaunch persisted"
+  assert_contains "$entry" '"attempts":0' "attempts start at zero"
+  assert_present "$state/shipwork-1.quota-wait" "entry is a durable on-disk file"
+  pass "record persists a durable, complete quota-wait entry"
+}
+
+test_due_filters_on_time() {
+  local state due_before due_after
+  state=$(new_state)
+  FM_STATE_OVERRIDE="$state" FM_QUOTA_WAIT_NOW=1000 \
+    "$QW" record late --vendor codex --wait-secs 300 >/dev/null
+  due_before=$(FM_STATE_OVERRIDE="$state" "$QW" due --now 1200)
+  assert_not_contains "$due_before" "late" "entry not due before its wait window"
+  due_after=$(FM_STATE_OVERRIDE="$state" "$QW" due --now 1300)
+  assert_contains "$due_after" "late" "entry due once the wait window passes"
+  pass "due filters entries by next_check against the clock"
+}
+
+test_wait_until_is_honored() {
+  local state due
+  state=$(new_state)
+  FM_STATE_OVERRIDE="$state" "$QW" record reset --vendor claude --wait-until 5000 >/dev/null
+  due=$(FM_STATE_OVERRIDE="$state" "$QW" due --now 4999)
+  assert_not_contains "$due" "reset" "not due one second before the declared reset"
+  due=$(FM_STATE_OVERRIDE="$state" "$QW" due --now 5000)
+  assert_contains "$due" "reset" "due at the declared reset epoch"
+  pass "explicit --wait-until reset time drives due-ness"
+}
+
+test_bump_backs_off_bounded() {
+  local state n1 n2 n3 attempts
+  state=$(new_state)
+  FM_STATE_OVERRIDE="$state" FM_QUOTA_WAIT_NOW=1000 \
+    FM_QUOTA_WAIT_BASE_SECS=300 FM_QUOTA_WAIT_MAX_SECS=3600 \
+    "$QW" record slow --vendor claude >/dev/null
+  FM_STATE_OVERRIDE="$state" FM_QUOTA_WAIT_NOW=1000 \
+    FM_QUOTA_WAIT_BASE_SECS=300 FM_QUOTA_WAIT_MAX_SECS=3600 "$QW" bump slow >/dev/null
+  n1=$(FM_STATE_OVERRIDE="$state" "$QW" get slow | jq -r '.next_check')
+  FM_STATE_OVERRIDE="$state" FM_QUOTA_WAIT_NOW=1000 \
+    FM_QUOTA_WAIT_BASE_SECS=300 FM_QUOTA_WAIT_MAX_SECS=3600 "$QW" bump slow >/dev/null
+  n2=$(FM_STATE_OVERRIDE="$state" "$QW" get slow | jq -r '.next_check')
+  # attempt 1 -> +600, attempt 2 -> +1200 (300 * 2^attempts), both under the cap.
+  [ "$n1" = "1600" ] || fail "first bump should be now+600, got $n1"
+  [ "$n2" = "2200" ] || fail "second bump should be now+1200, got $n2"
+  # Many bumps must clamp at the ceiling, never run away.
+  for _ in 1 2 3 4 5 6 7 8; do
+    FM_STATE_OVERRIDE="$state" FM_QUOTA_WAIT_NOW=1000 \
+      FM_QUOTA_WAIT_BASE_SECS=300 FM_QUOTA_WAIT_MAX_SECS=3600 "$QW" bump slow >/dev/null
+  done
+  n3=$(FM_STATE_OVERRIDE="$state" "$QW" get slow | jq -r '.next_check')
+  [ "$n3" = "4600" ] || fail "deep backoff should clamp at now+3600, got $n3"
+  attempts=$(FM_STATE_OVERRIDE="$state" "$QW" get slow | jq -r '.attempts')
+  [ "$attempts" = "10" ] || fail "attempts should count every bump, got $attempts"
+  pass "bump applies bounded exponential backoff and never exceeds the cap"
+}
+
+test_clear_removes_entry() {
+  local state
+  state=$(new_state)
+  FM_STATE_OVERRIDE="$state" "$QW" record gone --vendor claude >/dev/null
+  FM_STATE_OVERRIDE="$state" "$QW" clear gone >/dev/null
+  assert_absent "$state/gone.quota-wait" "clear removes the durable entry"
+  pass "clear removes a resumed entry"
+}
+
+test_bad_input_rejected() {
+  local state rc
+  state=$(new_state)
+  rc=0
+  FM_STATE_OVERRIDE="$state" "$QW" record nomvendor >/dev/null 2>&1 || rc=$?
+  expect_code 2 "$rc" "record without --vendor is a usage error"
+  rc=0
+  FM_STATE_OVERRIDE="$state" "$QW" record 'bad/id' --vendor claude >/dev/null 2>&1 || rc=$?
+  expect_code 2 "$rc" "a path-bearing id is rejected"
+  pass "invalid record input fails closed"
+}
+
+test_record_then_get
+test_due_filters_on_time
+test_wait_until_is_honored
+test_bump_backs_off_bounded
+test_clear_removes_entry
+test_bad_input_rejected

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -384,6 +384,33 @@ test_active_dispatch_profile_does_not_block_secondmate_launch() {
   pass "active crew-dispatch profile does not block secondmate launches"
 }
 
+test_claude_turnend_hook_is_durable() {
+  # Regression: the crew's Stop hook fires from its own launch environment, and a
+  # bare `touch <state>/<id>.turn-ended` dies with "No such file or directory" if
+  # that parent is momentarily absent (a fresh/rebuilt home or a Windows/WSL
+  # launch that must re-materialize the dir), silently losing the turn-end signal
+  # so the watcher only sees the crew via the late stale timer. The hook must be
+  # self-healing: re-create the state dir and still land the marker.
+  local rec id out status cmd marker dir
+  id=turnend-durable-z1
+  rec=$(make_spawn_case turnend-durable claude "$id")
+  read_case_record "$rec"
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR")
+  status=$?
+  expect_code 0 "$status" "claude spawn should succeed ($out)"
+  cmd=$(jq -r '.hooks.Stop[0].hooks[0].command' "$WT_DIR/.claude/settings.local.json") \
+    || fail "could not read the Stop hook command"
+  case "$cmd" in *"mkdir -p "*"&& touch "*) : ;; *) fail "Stop hook is not self-healing: $cmd" ;; esac
+  # Exact path the hook touches, so a symlinked TMPDIR cannot skew the assertion.
+  marker=${cmd##*touch \'}; marker=${marker%\'*}
+  dir=$(dirname "$marker")
+  rm -rf "$dir"   # simulate the missing-parent condition the crew hit
+  sh -c "$cmd" || fail "self-healing Stop hook exited non-zero with the state dir absent"
+  assert_present "$marker" "durable Stop hook must re-create the state dir and land the turn-ended marker"
+  pass "claude Stop hook re-creates a missing state dir and still signals turn-end"
+}
+
+test_claude_turnend_hook_is_durable
 test_no_profile_keeps_claude_launch_unchanged
 test_active_dispatch_profile_requires_explicit_harness_for_ship
 test_active_dispatch_profile_requires_explicit_harness_for_scout


### PR DESCRIPTION
## What and why

Firstmate must operate Munra work through Munra PR #275's agent-facing architecture model without freezing each issue into a rigid preplanned assignment, plus a set of durable supervision/launch reliability fixes the captain flagged as blockers. All changes are additive and land as separate commits.

## Design choices

**Architecture-protocol intake (skill + minimal triggers).** New agent-only skill `munra-architecture-intake` owns the workflow; only load triggers go into `AGENTS.md` (section 11 briefs, section 13 list). It refreshes the Munra clone to current `origin/master` via the existing `fm-fleet-sync.sh`, requires picking work from the current issue list and master (not a stale brief), and requires each brief to consult Munra's own docs (architecture index, `CHANGE_PROTOCOL.md`, source-of-truth boundary, affected invariants/feature surfaces, test lanes) - pointing, not restating (one-owner rule).

**Token-light heartbeat + durable quota-wait retry.** `bin/fm-heartbeat.sh` reads only the watcher lock and quota-wait registry (never re-reads the fleet), recovers a provably-stale watcher lock (fail closed on a live holder), and resumes quota-parked work when capacity returns. `bin/fm-quota-wait.sh` is a durable per-task registry with bounded backoff; provider-detection limits documented in the headers.

**Watcher busy-loop fix (`bin/backends/herdr.sh`).** A busy crew (`tsc -b`) flooding the herdr transition stream with `working` events made `fm_backend_herdr_wait_transition` run the full normalize+apply round-trip (~a dozen forks/event, plus 4 `cut` forks) per event, pegging `fm-watch.sh` at ~97% CPU and starving the heartbeat. Now each line is split fork-free and triaged by the single-owner `fm_transition_policy` before the expensive path: only `blocked` takes it, `working` clears the marker inline, `idle`/`done` are no-ops.

**Turn-end signal durability (`bin/fm-spawn.sh`).** The claude Stop hook fired a bare `touch <state>/<id>.turn-ended`; when the parent dir was momentarily absent (a rebuilt home or the Windows/WSL launch re-materializing state) it died with "No such file or directory", silently losing the turn-end signal so the captain was pinged late via the stale timer. The hook is now `mkdir -p <state> && touch <marker>`, restoring the immediate turn-end wake that surfaces terminal done/blocked promptly.

**Windows/WSL spawn-path guard (`bin/backends/tmux.sh`).** When firstmate drives WSL tmux from Windows, the server inherits the launcher CWD (`/mnt/c/...`); a task pane whose per-window start dir could not apply fell back there and `treehouse get` built the worktree under `/mnt/c`, which fm-spawn refused - stranding queued work. Now the firstmate session is anchored to a real WSL dir (`fm_backend_tmux_wsl_start_dir`), and `create_task` refuses any empty/`/mnt`/UNC/drive-letter start dir before opening the pane.

**Autonomous durable queue advance (`bin/fm-backlog-next.sh` + AGENTS.md section 7).** On a terminal outcome or a no-decision external wait (CI running, review pending, PR awaiting merge authority), firstmate no longer idles for a captain message: it persists the outcome, gives the one-line result, and autonomously dispatches the next safe item the selector returns - the first Queued item that is unchecked, unheld (parked and captain/decision-gated threads are never picked), and dependency-free (no `blocked-by`, or every blocker already Done). Decisions, PR merges, and destructive/security actions still stop and escalate.

## Validation evidence

ShellCheck 0.11.0 (pinned): every changed script/test is clean; whole-tree per-file scan (`</dev/null`) shows zero new findings.

New/updated tests, all green:
- `fm-quota-wait` (6/6), `fm-heartbeat` (6/6), `fm-munra-architecture-intake` (3/3).
- `fm-backend-herdr` 116/116 incl. `test_wait_transition_event_flood_skips_forkheavy_path` (an 800-event working flood still returns the blocked edge and clears the marker while normalize/apply run only for the reconcile + the one real edge).
- `fm-spawn-dispatch-profile` 17/17 incl. `test_claude_turnend_hook_is_durable` (deletes the state dir, runs the generated Stop hook, asserts it re-creates the dir + marker).
- `fm-backend-tmux-smoke` new guard case: `create_task` refuses each non-WSL start dir without leaving a window, and the session anchor resolves to a WSL dir.
- `fm-backlog-next` (5/5): first free item picked; held/parked/captain-gated skipped; blocked-by-in-flight skipped; blocked-by-Done dispatchable; nothing safe / missing file -> exit 1.
- Existing contract suites still green: `fm-instruction-owners` (9/9), `fm-captain-translation-contract` (7/7), `fm-supervision-events` (7/7), `fm-brief` (14/14), `fm-ensure-agents-md` (9/9).

Environment notes (pre-existing, not from this change): this WSL box's ShellCheck stalls on the single multi-file `fm-lint.sh` invocation (a local stdin quirk; per-file `</dev/null` resolves it, zero timeouts), `fm-session-start.test.sh` fails identically on pristine `origin/main`, and the real-interactive-shell section of the tmux smoke test is timing-sensitive under headless WSL (the new guard case runs before it and passes). CI runs the authoritative `bin/fm-lint.sh` + full suite on Ubuntu.

Do not merge.
