### PR TITLE
feat: require pinned real-Herdr CI coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,17 +55,139 @@ jobs:
           tasks-axi --version
       # Single owner of serial suite selection, timing markers, and aggregate
       # failure. Do not re-spell a for-loop over tests/*.test.sh here.
+      # Real Herdr coverage lives in the dedicated required herdr job below;
+      # exclude that family here so portable green is never claimed as Herdr.
       - name: Run portable behavior suite
         run: |
           set -eu
           mkdir -p "$RUNNER_TEMP/fm-test"
-          bin/fm-test-run.sh --all --json "$RUNNER_TEMP/fm-test/fm-test-timing.json"
+          bin/fm-test-run.sh --all \
+            --exclude-family real-herdr-gated \
+            --json "$RUNNER_TEMP/fm-test/fm-test-timing.json"
       - name: Upload behavior timing artifact
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: fm-test-timing
           path: ${{ runner.temp }}/fm-test/fm-test-timing.json
+          if-no-files-found: warn
+
+  # Required real-Herdr lane: pinned install, serial real-herdr-gated family,
+  # hard-fail on "skip: herdr not found". Starts on Linux x86_64; if a genuine
+  # platform invariant fails (focus, cleanup, default-session tripwire), keep
+  # the failure evidence and move the job to macOS rather than skip assertions.
+  tests-herdr:
+    name: Behavior tests (Herdr)
+    runs-on: ubuntu-latest
+    # Real Herdr is slower than the portable suite; this is a hang tripwire,
+    # not the expected healthy end of the lane (estimate 15-40 min first cut).
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Require tools for real Herdr
+        run: |
+          set -eu
+          command -v jq >/dev/null || { echo "::error::jq is required"; exit 1; }
+          command -v python3 >/dev/null || { echo "::error::python3 is required"; exit 1; }
+          command -v curl >/dev/null || { echo "::error::curl is required"; exit 1; }
+          command -v tar >/dev/null || { echo "::error::tar is required"; exit 1; }
+          jq --version
+          python3 --version
+      - name: Install pinned Herdr
+        run: |
+          set -eu
+          bin/fm-install-herdr.sh "$RUNNER_TEMP/bin"
+          echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+      - name: Install pinned Treehouse
+        run: |
+          set -eu
+          # Several real-herdr-gated E2E scripts require treehouse for spawn
+          # worktree acquisition (presentation, workspace-per-home, autodetect).
+          bin/fm-install-treehouse.sh "$RUNNER_TEMP/bin"
+          echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+      - name: Assert Herdr pin and protocol floor
+        run: |
+          set -eu
+          command -v herdr >/dev/null || { echo "::error::herdr not on PATH after install"; exit 1; }
+          command -v treehouse >/dev/null || { echo "::error::treehouse not on PATH after install"; exit 1; }
+          herdr --version
+          treehouse --version
+          status=$(herdr status --json)
+          printf '%s\n' "$status"
+          version=$(printf '%s' "$status" | jq -r '.client.version // empty')
+          protocol=$(printf '%s' "$status" | jq -r '.client.protocol // empty')
+          [ "$version" = "0.7.4" ] || {
+            echo "::error::expected exact Herdr pin 0.7.4, got ${version:-<empty>}"
+            exit 1
+          }
+          case "$protocol" in
+            ''|*[!0-9]*) echo "::error::could not read client protocol"; exit 1 ;;
+          esac
+          [ "$protocol" -ge 16 ] || {
+            echo "::error::herdr protocol $protocol is below the required floor 16"
+            exit 1
+          }
+      - name: Start default Herdr session for fleet-state tripwire
+        run: |
+          set -eu
+          # Lab provision requires exactly one running default session so the
+          # default-session tripwire can arm. Start it headless; never use it
+          # for lab work (tests still refuse default and use fm-lab-* only).
+          mkdir -p "$RUNNER_TEMP/fm-herdr"
+          nohup herdr server >"$RUNNER_TEMP/fm-herdr/default-server.log" 2>&1 &
+          echo $! >"$RUNNER_TEMP/fm-herdr/default-server.pid"
+          attempt=0
+          while [ "$attempt" -lt 150 ]; do
+            running=$(herdr status --json 2>/dev/null | jq -r '.server.running // false' || echo false)
+            if [ "$running" = true ]; then
+              herdr session list --json | jq -e '
+                [.sessions[]? | select(.default == true and .name == "default" and .running == true)]
+                | length == 1
+              ' >/dev/null
+              echo "default Herdr session is running"
+              exit 0
+            fi
+            sleep 0.2
+            attempt=$((attempt + 1))
+          done
+          echo "::error::default Herdr server did not become ready"
+          cat "$RUNNER_TEMP/fm-herdr/default-server.log" || true
+          exit 1
+      - name: Snapshot pre-suite Herdr sessions
+        run: |
+          set -eu
+          mkdir -p "$RUNNER_TEMP/fm-herdr"
+          bin/fm-herdr-ci-cleanup.sh snapshot "$RUNNER_TEMP/fm-herdr/sessions-before.json"
+      - name: Run real-Herdr family (serial, required)
+        run: |
+          set -eu
+          mkdir -p "$RUNNER_TEMP/fm-test"
+          # Serial only. Fail if any script reports herdr not found. Live
+          # harness credential tests stay outside this family (opt-in env only).
+          bin/fm-test-run.sh --family real-herdr-gated \
+            --fail-on-gate-skip 'herdr not found' \
+            --json "$RUNNER_TEMP/fm-test/fm-test-timing-herdr.json"
+      - name: Cleanup job-owned Herdr lab sessions
+        if: always()
+        run: |
+          set -eu
+          bin/fm-herdr-ci-cleanup.sh teardown "$RUNNER_TEMP/fm-herdr/sessions-before.json" || {
+            echo "::warning::lab session cleanup reported a problem; see logs"
+            # Surface diagnostics without weakening the suite result above.
+            herdr session list --json || true
+            exit 1
+          }
+      - name: Upload Herdr timing and diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fm-test-timing-herdr
+          path: |
+            ${{ runner.temp }}/fm-test/fm-test-timing-herdr.json
+            ${{ runner.temp }}/fm-herdr/sessions-before.json
+            ${{ runner.temp }}/fm-herdr/default-server.log
           if-no-files-found: warn
 
   macos-stock-bash:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,10 +73,14 @@ for script in bin/*.sh bin/backends/*.sh; do bash -n "$script"; done   # syntax-
 bin/fm-lint.sh   # lint the toolbelt and behavior tests; the single owner CI and the no-mistakes gate both run
 bin/fm-test-run.sh tests/<subject>.test.sh   # one script (primary local focus path, timed)
 bin/fm-test-run.sh --family pure-contract-unit   # one declared family (serial, timed)
+bin/fm-test-run.sh --family real-herdr-gated --fail-on-gate-skip 'herdr not found'   # local mirror of the required Herdr CI lane
 bin/fm-test-run.sh --changed   # conservative changed-file-informed set (never silent full suite)
-bin/fm-test-run.sh --all   # intentional complete portable suite (CI Behavior; optional local full run)
+bin/fm-test-run.sh --all   # intentional complete suite (optional local full run)
+bin/fm-test-run.sh --all --exclude-family real-herdr-gated   # portable CI Behavior shape
 bin/fm-test-isolation-proof.sh --list   # proven parallel candidate set (Phase 2; not production sharding)
 bin/fm-test-isolation-proof.sh --jobs 4 --json /tmp/fm-isolation-proof.json   # concurrent isolation proof only
+bin/fm-install-herdr.sh /tmp/fm-bin   # pin+checksum install of suite-verified Herdr for CI/local lane setup
+bin/fm-install-treehouse.sh /tmp/fm-bin   # pin+checksum Treehouse when real-herdr-gated E2E needs it
 [ "$(readlink CLAUDE.md)" = "AGENTS.md" ]
 [ "$(readlink .claude/skills)" = "../.agents/skills" ]
 tmp=$(mktemp -d) && printf 'done: smoke\n' > "$tmp/smoke.status" && FM_STATE_OVERRIDE="$tmp" FM_SIGNAL_GRACE=1 FM_POLL=1 FM_HEARTBEAT=999999 bin/fm-watch-arm.sh  # watcher re-arm smoke test (prints arm status, then an actionable signal)
@@ -86,9 +90,12 @@ tmp=$(mktemp -d) && printf 'done: smoke\n' > "$tmp/smoke.status" && FM_STATE_OVE
 Its header and `--help` own the flags, family labels, and changed-file map; this section only documents the entry points.
 `bin/fm-test-isolation-proof.sh` is the single owner of the Phase 2 concurrent isolation proof for a bounded, audited portable candidate set.
 It does not enable production CI sharding or general local `--jobs` on the serial runner; see `docs/fm-test-isolation-proof.md` for the archived candidate set, concurrency, and results.
-Local no-mistakes Test stays intent-targeted and must not wire `commands.test` to `--all` or a `tests/*.test.sh` walk; CI Behavior calls `bin/fm-test-run.sh --all` for broad regression.
+Local no-mistakes Test stays intent-targeted and must not wire `commands.test` to `--all` or a `tests/*.test.sh` walk.
+CI portable Behavior calls `bin/fm-test-run.sh --all --exclude-family real-herdr-gated` for broad non-Herdr regression.
+The required Herdr Behavior job installs pinned Herdr and Treehouse via `bin/fm-install-herdr.sh` and `bin/fm-install-treehouse.sh`, then runs `bin/fm-test-run.sh --family real-herdr-gated --fail-on-gate-skip 'herdr not found'` serially with job-scoped lab cleanup.
 Discover tests by listing `tests/*.test.sh`: each is a self-contained bash script named `<subject>.test.sh`, and its header comment describes what it covers, so pass one to `bin/fm-test-run.sh` to focus on a subject with canonical timing output.
-Tests that need a real optional backend or an explicit opt-in (real herdr/zellij/cmux smoke tests, the live Pi regression) skip themselves and print the tool or environment gate needed to enable them, so `--all` remains safe on machines without those tools.
+Tests that need a real optional backend or an explicit opt-in (real herdr/zellij/cmux smoke tests, the live Pi regression) skip themselves and print the tool or environment gate needed to enable them, so the portable suite remains safe on machines without those tools.
+Live harness credential tests stay opt-in and outside the default Herdr CI lane.
 
 ## Questions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,14 +73,10 @@ for script in bin/*.sh bin/backends/*.sh; do bash -n "$script"; done   # syntax-
 bin/fm-lint.sh   # lint the toolbelt and behavior tests; the single owner CI and the no-mistakes gate both run
 bin/fm-test-run.sh tests/<subject>.test.sh   # one script (primary local focus path, timed)
 bin/fm-test-run.sh --family pure-contract-unit   # one declared family (serial, timed)
-bin/fm-test-run.sh --family real-herdr-gated --fail-on-gate-skip 'herdr not found'   # local mirror of the required Herdr CI lane
 bin/fm-test-run.sh --changed   # conservative changed-file-informed set (never silent full suite)
 bin/fm-test-run.sh --all   # intentional complete suite (optional local full run)
-bin/fm-test-run.sh --all --exclude-family real-herdr-gated   # portable CI Behavior shape
 bin/fm-test-isolation-proof.sh --list   # proven parallel candidate set (Phase 2; not production sharding)
 bin/fm-test-isolation-proof.sh --jobs 4 --json /tmp/fm-isolation-proof.json   # concurrent isolation proof only
-bin/fm-install-herdr.sh /tmp/fm-bin   # pin+checksum install of suite-verified Herdr for CI/local lane setup
-bin/fm-install-treehouse.sh /tmp/fm-bin   # pin+checksum Treehouse when real-herdr-gated E2E needs it
 [ "$(readlink CLAUDE.md)" = "AGENTS.md" ]
 [ "$(readlink .claude/skills)" = "../.agents/skills" ]
 tmp=$(mktemp -d) && printf 'done: smoke\n' > "$tmp/smoke.status" && FM_STATE_OVERRIDE="$tmp" FM_SIGNAL_GRACE=1 FM_POLL=1 FM_HEARTBEAT=999999 bin/fm-watch-arm.sh  # watcher re-arm smoke test (prints arm status, then an actionable signal)
@@ -91,11 +87,11 @@ Its header and `--help` own the flags, family labels, and changed-file map; this
 `bin/fm-test-isolation-proof.sh` is the single owner of the Phase 2 concurrent isolation proof for a bounded, audited portable candidate set.
 It does not enable production CI sharding or general local `--jobs` on the serial runner; see `docs/fm-test-isolation-proof.md` for the archived candidate set, concurrency, and results.
 Local no-mistakes Test stays intent-targeted and must not wire `commands.test` to `--all` or a `tests/*.test.sh` walk.
-CI portable Behavior calls `bin/fm-test-run.sh --all --exclude-family real-herdr-gated` for broad non-Herdr regression.
-The required Herdr Behavior job installs pinned Herdr and Treehouse via `bin/fm-install-herdr.sh` and `bin/fm-install-treehouse.sh`, then runs `bin/fm-test-run.sh --family real-herdr-gated --fail-on-gate-skip 'herdr not found'` serially with job-scoped lab cleanup.
+CI owns the broad portable and required real-Herdr lane composition in [`.github/workflows/ci.yml`](.github/workflows/ci.yml).
+Use `bin/fm-test-run.sh --help` for the exact family exclusion and required gate-skip flags when reproducing either lane locally.
 Discover tests by listing `tests/*.test.sh`: each is a self-contained bash script named `<subject>.test.sh`, and its header comment describes what it covers, so pass one to `bin/fm-test-run.sh` to focus on a subject with canonical timing output.
 Tests that need a real optional backend or an explicit opt-in (real herdr/zellij/cmux smoke tests, the live Pi regression) skip themselves and print the tool or environment gate needed to enable them, so the portable suite remains safe on machines without those tools.
-Live harness credential tests stay opt-in and outside the default Herdr CI lane.
+The [Herdr backend guide](docs/herdr-backend.md) owns the lane's safety and isolation rationale, including why live harness credential tests remain opt-in.
 
 ## Questions
 

--- a/bin/fm-herdr-ci-cleanup.sh
+++ b/bin/fm-herdr-ci-cleanup.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# fm-herdr-ci-cleanup.sh - bounded cleanup of CI-owned Herdr lab sessions.
+#
+# Snapshot the session list before the real-Herdr suite, then at job end only
+# stop/delete sessions that:
+#   1. match the guarded fm-lab-* name pattern,
+#   2. were not present in the pre-suite snapshot (job-proven ownership),
+#   3. report default:false on a fresh session list.
+#
+# Never touches the default session. Never adopts or force-deletes non-lab
+# names. Missing herdr is a no-op (exit 0) so portable jobs can call this
+# harmlessly; destructive failures for known lab leftovers exit non-zero.
+#
+# Usage:
+#   fm-herdr-ci-cleanup.sh snapshot <path>
+#   fm-herdr-ci-cleanup.sh teardown <snapshot-path>
+set -eu
+
+die() {
+  printf 'fm-herdr-ci-cleanup.sh: %s\n' "$*" >&2
+  exit 1
+}
+
+log() {
+  printf 'fm-herdr-ci-cleanup.sh: %s\n' "$*" >&2
+}
+
+cmd=${1:-}
+path=${2:-}
+[ -n "$cmd" ] && [ -n "$path" ] || die "usage: fm-herdr-ci-cleanup.sh snapshot|teardown <path>"
+
+if ! command -v herdr >/dev/null 2>&1; then
+  log "herdr not on PATH; nothing to $cmd"
+  exit 0
+fi
+command -v jq >/dev/null 2>&1 || die "jq is required"
+
+list_sessions_json() {
+  herdr session list --json 2>/dev/null \
+    || die "could not list Herdr sessions"
+}
+
+is_lab_name() {
+  local name=$1
+  [[ "$name" =~ ^fm-lab-[a-zA-Z0-9][a-zA-Z0-9_-]*$ ]]
+}
+
+case "$cmd" in
+  snapshot)
+    list_sessions_json | jq -c '[.sessions[]? | .name] | unique | sort' >"$path" \
+      || die "failed to write session snapshot to $path"
+    log "wrote session snapshot to $path ($(jq -r 'length' "$path") names)"
+    ;;
+  teardown)
+    [ -f "$path" ] || die "snapshot file not found: $path"
+    before=$(cat "$path")
+    after_json=$(list_sessions_json)
+    # Candidates: lab-named, default:false, not in the pre-suite snapshot.
+    candidates=$(printf '%s' "$after_json" | jq -r --argjson before "$before" '
+      .sessions[]?
+      | select(.default == false)
+      | select(.name | test("^fm-lab-[a-zA-Z0-9][a-zA-Z0-9_-]*$"))
+      | select((.name as $n | $before | index($n) | not))
+      | .name
+    ')
+    failed=0
+    if [ -z "$candidates" ]; then
+      log "no job-owned fm-lab-* sessions to clean"
+      exit 0
+    fi
+    while IFS= read -r name; do
+      [ -n "$name" ] || continue
+      is_lab_name "$name" || {
+        log "refusing non-lab name from candidate set: $name"
+        failed=1
+        continue
+      }
+      # Fresh refuse-default check immediately before each destructive call.
+      flag=$(herdr session list --json 2>/dev/null \
+        | jq -r --arg n "$name" '.sessions[]? | select(.name == $n) | .default' 2>/dev/null || true)
+      if [ "$flag" != "false" ]; then
+        log "refusing cleanup of '$name' (default=${flag:-<not found>})"
+        failed=1
+        continue
+      fi
+      log "stopping job-owned lab session $name"
+      herdr session stop "$name" --json >/dev/null 2>&1 || true
+      sleep 0.3
+      flag=$(herdr session list --json 2>/dev/null \
+        | jq -r --arg n "$name" '.sessions[]? | select(.name == $n) | .default' 2>/dev/null || true)
+      if [ "$flag" != "false" ]; then
+        log "refusing delete of '$name' after stop (default=${flag:-<not found>})"
+        failed=1
+        continue
+      fi
+      if herdr session delete "$name" --json >/dev/null 2>&1; then
+        log "deleted job-owned lab session $name"
+      else
+        # Already gone is success; still present is failure.
+        still=$(herdr session list --json 2>/dev/null \
+          | jq -r --arg n "$name" '.sessions[]? | select(.name == $n) | .name' 2>/dev/null || true)
+        if [ -n "$still" ]; then
+          log "failed to delete lab session $name"
+          failed=1
+        else
+          log "lab session $name already absent after stop"
+        fi
+      fi
+    done <<<"$candidates"
+    [ "$failed" -eq 0 ] || die "one or more job-owned lab sessions could not be cleaned"
+    ;;
+  *)
+    die "unknown command: $cmd (use snapshot or teardown)"
+    ;;
+esac

--- a/bin/fm-install-herdr.sh
+++ b/bin/fm-install-herdr.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# fm-install-herdr.sh - install CI's pinned, verified Herdr build.
+#
+# Single owner of the exact Herdr version, official release asset URL, and
+# SHA-256 pin used by the required real-Herdr CI lane. Never installs a
+# floating package-manager latest.
+#
+# Usage:
+#   fm-install-herdr.sh <destination-directory>
+#
+# Pins Herdr v0.7.4 (protocol 16), the suite-verified protocol-16 release.
+# Selects the official GitHub Releases asset for the host OS/arch, downloads
+# with a bounded max size, verifies SHA-256 before install, then refuses to
+# finish unless the binary reports the exact pin version and a client protocol
+# at or above the required floor (16 for the real-Herdr family).
+set -eu
+
+# Exact pin - change only with a re-verified real-Herdr matrix.
+FM_HERDR_CI_VERSION=0.7.4
+FM_HERDR_CI_TAG="v${FM_HERDR_CI_VERSION}"
+FM_HERDR_CI_MIN_PROTOCOL=16
+# Bounded download ceiling (bytes). The largest official 0.7.4 asset is under 20 MiB.
+FM_HERDR_CI_MAX_BYTES=25000000
+FM_HERDR_CI_REPO=ogulcancelik/herdr
+
+die() {
+  printf 'fm-install-herdr.sh: %s\n' "$*" >&2
+  exit 1
+}
+
+DESTINATION=${1:?usage: fm-install-herdr.sh <destination-directory>}
+
+os=$(uname -s)
+arch=$(uname -m)
+case "${os}-${arch}" in
+  Linux-x86_64)
+    ASSET=herdr-linux-x86_64
+    SHA256=bc0fc02d4ba500f9cac2353a43e67fe036785ecca6eb55378e050fac3c103059
+    ;;
+  Linux-aarch64|Linux-arm64)
+    ASSET=herdr-linux-aarch64
+    SHA256=544e0002de42806d1ab64ccdef3a7e7414f24717b0b6b022bc9e57d2eefd26a2
+    ;;
+  Darwin-arm64)
+    ASSET=herdr-macos-aarch64
+    SHA256=24992e1625dbdcb18354a59e299e4b263c312400b31396cdc07cd46ed57f24a7
+    ;;
+  Darwin-x86_64)
+    ASSET=herdr-macos-x86_64
+    SHA256=ddf430133352e1712413d5d865b34a485546f4658893fc89986257d65a7585a8
+    ;;
+  *)
+    die "unsupported platform ${os}-${arch}; official Herdr assets are linux/macos x86_64 and aarch64"
+    ;;
+esac
+
+URL="https://github.com/${FM_HERDR_CI_REPO}/releases/download/${FM_HERDR_CI_TAG}/${ASSET}"
+TMP=$(mktemp -d "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/fm-herdr.XXXXXX")
+trap 'rm -rf "$TMP"' EXIT
+
+printf 'fm-install-herdr.sh: downloading %s from %s\n' "$ASSET" "$URL" >&2
+# --fail: HTTP errors; --location: follow redirects; --max-filesize: bound.
+curl -fsSL --max-filesize "$FM_HERDR_CI_MAX_BYTES" "$URL" -o "$TMP/$ASSET" \
+  || die "download failed for $URL (bounded at $FM_HERDR_CI_MAX_BYTES bytes)"
+
+if command -v sha256sum >/dev/null 2>&1; then
+  ACTUAL_SHA256=$(sha256sum "$TMP/$ASSET" | awk '{print $1}')
+elif command -v shasum >/dev/null 2>&1; then
+  ACTUAL_SHA256=$(shasum -a 256 "$TMP/$ASSET" | awk '{print $1}')
+else
+  die "need sha256sum or shasum to verify the Herdr asset"
+fi
+
+[ "$ACTUAL_SHA256" = "$SHA256" ] || die "checksum mismatch for $ASSET (expected $SHA256, got $ACTUAL_SHA256)"
+
+mkdir -p "$DESTINATION"
+install -m 0755 "$TMP/$ASSET" "$DESTINATION/herdr"
+
+# Post-install version and protocol gates (no floating latest).
+installed_version=$("$DESTINATION/herdr" --version 2>/dev/null | awk '{print $2; exit}')
+[ "$installed_version" = "$FM_HERDR_CI_VERSION" ] \
+  || die "installed herdr version is '${installed_version:-<empty>}', expected exact pin $FM_HERDR_CI_VERSION"
+
+status=$("$DESTINATION/herdr" status --json 2>/dev/null) \
+  || die "could not run 'herdr status --json' after install"
+protocol=$(printf '%s' "$status" | jq -r '.client.protocol // empty' 2>/dev/null) \
+  || die "jq is required to parse herdr status after install"
+case "$protocol" in
+  ''|*[!0-9]*) die "could not read herdr client protocol from status --json" ;;
+esac
+[ "$protocol" -ge "$FM_HERDR_CI_MIN_PROTOCOL" ] \
+  || die "herdr protocol $protocol is below the required floor $FM_HERDR_CI_MIN_PROTOCOL"
+
+printf 'fm-install-herdr.sh: installed herdr %s (protocol %s) to %s\n' \
+  "$installed_version" "$protocol" "$DESTINATION/herdr" >&2
+"$DESTINATION/herdr" --version

--- a/bin/fm-install-treehouse.sh
+++ b/bin/fm-install-treehouse.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# fm-install-treehouse.sh - install CI's pinned, verified Treehouse build.
+#
+# Used only by the required real-Herdr CI lane for E2E scripts that genuinely
+# need treehouse (spawn worktree acquisition). Same pin/checksum discipline as
+# fm-install-herdr.sh: official release URL, exact asset, SHA-256, bounded
+# download, post-install version check. Never a floating package-manager latest.
+#
+# Usage:
+#   fm-install-treehouse.sh <destination-directory>
+#
+# Pins Treehouse v2.0.1, the version exercised by the local real-Herdr suite.
+set -eu
+
+FM_TREEHOUSE_CI_VERSION=2.0.1
+FM_TREEHOUSE_CI_TAG="v${FM_TREEHOUSE_CI_VERSION}"
+# Bounded download ceiling (bytes). Official 2.0.1 archives are under 8 MiB.
+FM_TREEHOUSE_CI_MAX_BYTES=15000000
+FM_TREEHOUSE_CI_REPO=kunchenguid/treehouse
+
+die() {
+  printf 'fm-install-treehouse.sh: %s\n' "$*" >&2
+  exit 1
+}
+
+DESTINATION=${1:?usage: fm-install-treehouse.sh <destination-directory>}
+
+os=$(uname -s)
+arch=$(uname -m)
+case "${os}-${arch}" in
+  Linux-x86_64)
+    ARCHIVE=treehouse-v${FM_TREEHOUSE_CI_VERSION}-linux-amd64.tar.gz
+    SHA256=1d5a32751ab921670103fd201ddb2b91b47338cb13976f45642b827cf8976af2
+    ;;
+  Linux-aarch64|Linux-arm64)
+    ARCHIVE=treehouse-v${FM_TREEHOUSE_CI_VERSION}-linux-arm64.tar.gz
+    SHA256=eaccc9c5b98125df8bd77425598eeecee66cb0371db4eb1cf75f0d813c18fab9
+    ;;
+  Darwin-arm64)
+    ARCHIVE=treehouse-v${FM_TREEHOUSE_CI_VERSION}-darwin-arm64.tar.gz
+    SHA256=7ee5078f3d1f33c01196548797fce65408e459d53530b77d4ba56e074fa1c1a2
+    ;;
+  Darwin-x86_64)
+    ARCHIVE=treehouse-v${FM_TREEHOUSE_CI_VERSION}-darwin-amd64.tar.gz
+    SHA256=1cf44580a5837f995e1d3bb74f4fbd3112b642acd20406087d9735a8106112fd
+    ;;
+  *)
+    die "unsupported platform ${os}-${arch}; official Treehouse assets are linux/darwin amd64 and arm64"
+    ;;
+esac
+
+URL="https://github.com/${FM_TREEHOUSE_CI_REPO}/releases/download/${FM_TREEHOUSE_CI_TAG}/${ARCHIVE}"
+TMP=$(mktemp -d "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/fm-treehouse.XXXXXX")
+trap 'rm -rf "$TMP"' EXIT
+
+printf 'fm-install-treehouse.sh: downloading %s from %s\n' "$ARCHIVE" "$URL" >&2
+curl -fsSL --max-filesize "$FM_TREEHOUSE_CI_MAX_BYTES" "$URL" -o "$TMP/$ARCHIVE" \
+  || die "download failed for $URL (bounded at $FM_TREEHOUSE_CI_MAX_BYTES bytes)"
+
+if command -v sha256sum >/dev/null 2>&1; then
+  ACTUAL_SHA256=$(sha256sum "$TMP/$ARCHIVE" | awk '{print $1}')
+elif command -v shasum >/dev/null 2>&1; then
+  ACTUAL_SHA256=$(shasum -a 256 "$TMP/$ARCHIVE" | awk '{print $1}')
+else
+  die "need sha256sum or shasum to verify the Treehouse archive"
+fi
+
+[ "$ACTUAL_SHA256" = "$SHA256" ] || die "checksum mismatch for $ARCHIVE (expected $SHA256, got $ACTUAL_SHA256)"
+
+tar -xzf "$TMP/$ARCHIVE" -C "$TMP"
+# Archive layout: a single `treehouse` binary at the archive root (verified for v2.0.1).
+if [ -f "$TMP/treehouse" ]; then
+  BIN="$TMP/treehouse"
+elif [ -f "$TMP/treehouse-v${FM_TREEHOUSE_CI_VERSION}/treehouse" ]; then
+  BIN="$TMP/treehouse-v${FM_TREEHOUSE_CI_VERSION}/treehouse"
+else
+  BIN=$(find "$TMP" -type f -name treehouse | head -n 1)
+  [ -n "$BIN" ] || die "archive $ARCHIVE did not contain a treehouse binary"
+fi
+
+mkdir -p "$DESTINATION"
+install -m 0755 "$BIN" "$DESTINATION/treehouse"
+
+installed_version=$("$DESTINATION/treehouse" --version 2>/dev/null | tr -d '[:space:]')
+# treehouse prints "v2.0.1" (leading v) on --version.
+case "$installed_version" in
+  "v${FM_TREEHOUSE_CI_VERSION}"|"${FM_TREEHOUSE_CI_VERSION}") ;;
+  *)
+    die "installed treehouse version is '${installed_version:-<empty>}', expected exact pin v${FM_TREEHOUSE_CI_VERSION}"
+    ;;
+esac
+
+printf 'fm-install-treehouse.sh: installed treehouse %s to %s\n' \
+  "$installed_version" "$DESTINATION/treehouse" >&2
+"$DESTINATION/treehouse" --version

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -20,6 +20,15 @@
 #   --json <path>   write a deterministic timing artifact after the run
 #   --list          print selected script paths (one per line) and exit 0
 #   --base <ref>    with --changed, compare against this ref (default: origin/main)
+#   --exclude-family <name>
+#                   drop scripts whose primary family matches <name> after selection
+#                   (repeatable; used by the portable CI job to leave real Herdr
+#                   coverage to the dedicated required lane)
+#   --fail-on-gate-skip <token>
+#                   after each script, fail the run if any output line contains
+#                   "skip: <token>" (e.g. --fail-on-gate-skip 'herdr not found').
+#                   The required Herdr CI lane uses this so a missing pin cannot
+#                   silently pass as a gate skip.
 #   -h, --help      print this header
 #
 # Per-script machine-parseable markers (stdout):
@@ -50,6 +59,8 @@ FAMILY=
 BASE_REF=origin/main
 JSON_PATH=
 SCRIPTS=()
+EXCLUDE_FAMILIES=()
+FAIL_ON_GATE_SKIP=
 
 usage() {
   awk '
@@ -90,7 +101,8 @@ family_for_basename() {
     fm-continuity-pretool-check.test.sh|fm-crew-state.test.sh|fm-decision-hold-lifecycle.test.sh|\
     fm-dispatch-select.test.sh|fm-ensure-agents-md.test.sh|fm-grok-harness.test.sh|\
     fm-herdr-lab.test.sh|fm-instruction-owners.test.sh|fm-lint.test.sh|\
-    fm-nm-test-contract.test.sh|fm-no-mistakes-ownership.test.sh|fm-pi-primary-types.test.sh|\
+    fm-install-herdr.test.sh|fm-nm-test-contract.test.sh|fm-no-mistakes-ownership.test.sh|\
+    fm-pi-primary-types.test.sh|\
     fm-send-popup-settle.test.sh|fm-send-settle.test.sh|fm-stow-contract.test.sh|\
     fm-supervision-instructions.test.sh|fm-tmux-submit-busy.test.sh|fm-transition-lib.test.sh|\
     fm-test-run.test.sh|fm-test-isolation-proof.test.sh)
@@ -277,7 +289,7 @@ families_for_changed_path() {
       # resolution in the caller; emit a marker family of __script__
       printf '%s\n' "__script__:$(basename "$path")"
       ;;
-    bin/fm-test-run.sh)
+    bin/fm-test-run.sh|bin/fm-test-isolation-proof.sh)
       printf '%s\n' pure-contract-unit
       ;;
     bin/backends/herdr*|bin/fm-herdr-lab.sh|tests/herdr-test-safety.sh)
@@ -336,6 +348,12 @@ families_for_changed_path() {
     bin/fm-bearings-snapshot.sh|bin/fm-fleet-snapshot.sh|bin/fm-fleet-view.sh)
       printf '%s\n' snapshot-bearings
       ;;
+    bin/fm-install-herdr.sh|bin/fm-install-treehouse.sh|bin/fm-herdr-ci-cleanup.sh)
+      printf '%s\n' pure-contract-unit
+      # Pin or cleanup changes also select the real-Herdr family so the required
+      # lane's contract coverage re-runs.
+      printf '%s\n' real-herdr-gated
+      ;;
     bin/fm-lint.sh|bin/fm-install-shellcheck.sh|\
     bin/fm-brief.sh|bin/fm-ensure-agents-md.sh|bin/fm-crew-state.sh|\
     bin/fm-decision-hold.sh|bin/fm-supervision*|bin/fm-transition-lib.sh|\
@@ -346,6 +364,7 @@ families_for_changed_path() {
       ;;
     .github/workflows/ci.yml|.no-mistakes.yaml)
       printf '%s\n' pure-contract-unit
+      printf '%s\n' real-herdr-gated
       ;;
     .github/*|.tasks.toml|AGENTS.md|CLAUDE.md|CONTRIBUTING.md|\
     docs/configuration.md|docs/supervision-protocols/*)
@@ -440,6 +459,31 @@ detect_gate_skip() {
     skip:*) return 0 ;;
     *) return 1 ;;
   esac
+}
+
+# True when any output line contains "skip: <token>" (token may contain spaces).
+detect_gate_skip_token() {
+  local file=$1 token=$2
+  [ -n "$token" ] || return 1
+  grep -F -q "skip: $token" "$file" 2>/dev/null
+}
+
+apply_exclude_families() {
+  local s fam keep ex
+  local -a kept=()
+  [ "${#EXCLUDE_FAMILIES[@]}" -gt 0 ] || return 0
+  for s in "${SCRIPTS[@]+"${SCRIPTS[@]}"}"; do
+    fam=$(family_for_basename "$(basename "$s")")
+    keep=1
+    for ex in "${EXCLUDE_FAMILIES[@]}"; do
+      if [ "$fam" = "$ex" ]; then
+        keep=0
+        break
+      fi
+    done
+    [ "$keep" -eq 1 ] && kept+=("$s")
+  done
+  SCRIPTS=("${kept[@]+"${kept[@]}"}")
 }
 
 write_json_artifact() {
@@ -565,6 +609,24 @@ while [ "$#" -gt 0 ]; do
       LIST_FAMILIES=1
       shift
       ;;
+    --exclude-family)
+      [ "$#" -gt 1 ] || die "--exclude-family requires a name"
+      EXCLUDE_FAMILIES+=("$2")
+      shift 2
+      ;;
+    --exclude-family=*)
+      EXCLUDE_FAMILIES+=("${1#--exclude-family=}")
+      shift
+      ;;
+    --fail-on-gate-skip)
+      [ "$#" -gt 1 ] || die "--fail-on-gate-skip requires a token (e.g. 'herdr not found')"
+      FAIL_ON_GATE_SKIP=$2
+      shift 2
+      ;;
+    --fail-on-gate-skip=*)
+      FAIL_ON_GATE_SKIP=${1#--fail-on-gate-skip=}
+      shift
+      ;;
     -h|--help)
       usage
       exit 0
@@ -622,6 +684,14 @@ case "${MODE:-}" in
     die "select with --all, --family <name>, --changed, or one or more script paths (see --help)"
     ;;
 esac
+
+apply_exclude_families
+if [ "${#EXCLUDE_FAMILIES[@]}" -gt 0 ]; then
+  SELECTION_DESC="${SELECTION_DESC};exclude-family=$(IFS=,; printf '%s' "${EXCLUDE_FAMILIES[*]}")"
+fi
+if [ -n "$FAIL_ON_GATE_SKIP" ]; then
+  SELECTION_DESC="${SELECTION_DESC};fail-on-gate-skip=$FAIL_ON_GATE_SKIP"
+fi
 
 if [ "$LIST_ONLY" -eq 1 ]; then
   for s in "${SCRIPTS[@]+"${SCRIPTS[@]}"}"; do
@@ -721,6 +791,14 @@ for script in "${SCRIPTS[@]}"; do
   duration=$((end_ms - begin_ms))
   if [ "$duration" -lt 0 ]; then
     duration=0
+  fi
+
+  # Required-lane hard fail: a configured skip token anywhere in the output is
+  # a failure even when the script itself exited 0 (classic "skip: herdr not
+  # found" gate). Retries are not used as a green strategy.
+  if [ -n "$FAIL_ON_GATE_SKIP" ] && detect_gate_skip_token "$out" "$FAIL_ON_GATE_SKIP"; then
+    log "required gate skip token seen in $script: skip: $FAIL_ON_GATE_SKIP"
+    rc=1
   fi
 
   gate_skip=false

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -40,9 +40,9 @@
 #   FM_TEST_SUMMARY_FAMILY family=<name> count=<n> duration_ms=<n> failed=<n>
 #   FM_TEST_SLOWEST rank=<k> script=<path> duration_ms=<n>
 #
-# Exit status is the aggregate of script exits: non-zero if any selected script
-# exits non-zero. Gate skips (first meaningful line matching ^skip:) still exit
-# 0 from the script and are counted as skipped_gate, not failures.
+# Exit status is non-zero if any selected script exits non-zero or a configured
+# --fail-on-gate-skip token appears. Other gate skips (first meaningful line
+# matching ^skip:) remain successful and are counted as skipped_gate.
 #
 # Family labels and the changed-file map live in this script only (one owner).
 # --changed is conservative: it over-selects related families rather than

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -109,9 +109,8 @@ See [`wedge-alarm.md`](wedge-alarm.md) for the channel reference and macOS verif
 The tracked `.no-mistakes.yaml` keeps test evidence outside the repo and pins `commands.lint` to `bin/fm-lint.sh` so local lint matches CI.
 That evidence policy is specific to the firstmate repo: target projects may legitimately commit `.no-mistakes/evidence/` from their own no-mistakes pipeline, but firstmate keeps `.no-mistakes/` local and CI rejects tracked entries under that path.
 It does not set `commands.test` to a complete `tests/*.test.sh` walk.
-Local no-mistakes Test stays intent-targeted; broad portable regression lives in [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) via `bin/fm-test-run.sh --all --exclude-family real-herdr-gated`.
-Required real-Herdr coverage is a separate CI job that installs pinned Herdr and Treehouse (`bin/fm-install-herdr.sh`, `bin/fm-install-treehouse.sh`) and runs `bin/fm-test-run.sh --family real-herdr-gated --fail-on-gate-skip 'herdr not found'`.
-See [CONTRIBUTING.md](../CONTRIBUTING.md) for one-script, family, changed-file, and intentional complete-suite entry points, and [herdr-backend.md](herdr-backend.md) for the Herdr CI pin and isolation contract.
+Local no-mistakes Test stays intent-targeted; [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) owns the broad portable and required real-Herdr lane composition.
+See [CONTRIBUTING.md](../CONTRIBUTING.md) for local test entry points, `bin/fm-test-run.sh --help` for exact selection mechanics, and [herdr-backend.md](herdr-backend.md) for the real-Herdr lane's verification and isolation rationale.
 The Phase 2 concurrent isolation proof for the portable parallel candidate set is owned by `bin/fm-test-isolation-proof.sh` and archived in [fm-test-isolation-proof.md](fm-test-isolation-proof.md); it does not enable production CI sharding.
 
 ## Captain Preferences (data/captain.md / data/captain-shared.md)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -109,8 +109,9 @@ See [`wedge-alarm.md`](wedge-alarm.md) for the channel reference and macOS verif
 The tracked `.no-mistakes.yaml` keeps test evidence outside the repo and pins `commands.lint` to `bin/fm-lint.sh` so local lint matches CI.
 That evidence policy is specific to the firstmate repo: target projects may legitimately commit `.no-mistakes/evidence/` from their own no-mistakes pipeline, but firstmate keeps `.no-mistakes/` local and CI rejects tracked entries under that path.
 It does not set `commands.test` to a complete `tests/*.test.sh` walk.
-Local no-mistakes Test stays intent-targeted; broad regression (including the portable behavior suite) lives in [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) via `bin/fm-test-run.sh --all`.
-See [CONTRIBUTING.md](../CONTRIBUTING.md) for one-script, family, changed-file, and intentional complete-suite entry points.
+Local no-mistakes Test stays intent-targeted; broad portable regression lives in [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) via `bin/fm-test-run.sh --all --exclude-family real-herdr-gated`.
+Required real-Herdr coverage is a separate CI job that installs pinned Herdr and Treehouse (`bin/fm-install-herdr.sh`, `bin/fm-install-treehouse.sh`) and runs `bin/fm-test-run.sh --family real-herdr-gated --fail-on-gate-skip 'herdr not found'`.
+See [CONTRIBUTING.md](../CONTRIBUTING.md) for one-script, family, changed-file, and intentional complete-suite entry points, and [herdr-backend.md](herdr-backend.md) for the Herdr CI pin and isolation contract.
 The Phase 2 concurrent isolation proof for the portable parallel candidate set is owned by `bin/fm-test-isolation-proof.sh` and archived in [fm-test-isolation-proof.md](fm-test-isolation-proof.md); it does not enable production CI sharding.
 
 ## Captain Preferences (data/captain.md / data/captain-shared.md)

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -22,6 +22,16 @@ Prerequisites:
 - `jq`, required to parse herdr's JSON output: `brew install jq` (or your platform's package manager).
 - The universal firstmate prerequisites - a verified crew harness plus the required toolchain, owned by [`docs/configuration.md`](configuration.md) ("Harness support", "Toolchain"); treehouse still provides the worktree, herdr only provides the session.
 
+### CI pin and required real-Herdr lane
+
+The required GitHub Actions Herdr Behavior job does not use a floating package-manager latest.
+It installs exactly Herdr **v0.7.4** (protocol 16), the suite-verified protocol-16 release, through `bin/fm-install-herdr.sh`: official GitHub Releases URL for `ogulcancelik/herdr`, exact per-arch asset, pinned SHA-256, bounded download, and post-install version plus protocol checks.
+Scripts that need treehouse for real spawn worktrees install Treehouse **v2.0.1** the same way through `bin/fm-install-treehouse.sh`.
+The lane runs only the `real-herdr-gated` family serially via `bin/fm-test-run.sh --family real-herdr-gated --fail-on-gate-skip 'herdr not found'`, so a missing pin cannot pass as a silent skip.
+Live harness credential tests stay outside that family and outside default CI.
+Lab sessions remain `fm-lab-*` only with refuse-default and default-session tripwires intact; `bin/fm-herdr-ci-cleanup.sh` may remove only sessions proven to belong to that CI job (snapshot delta of non-default `fm-lab-*` names).
+The first required lane targets Linux x86_64; if a genuine unsupported platform invariant appears (focus, cleanup, or default-session tripwire), keep the failure evidence and move the job to macOS rather than skip or weaken the assertion.
+
 Select herdr by putting `herdr` in a local `config/backend` file - the durable way to pick it - or by exporting `FM_BACKEND=herdr` when you launch your harness for a one-off session; telling the first mate in chat to use herdr also works.
 It can also be auto-detected: when firstmate itself is running natively inside herdr (`HERDR_ENV=1`) and no explicit backend is set, firstmate auto-selects herdr and prints a one-time opt-out notice; running inside tmux nested in herdr always resolves to tmux instead.
 A herdr spawn refuses loudly before creating a session container or acquiring a ship/scout worktree if `herdr` or `jq` is missing or the installed herdr's protocol is older than verified.

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -24,12 +24,11 @@ Prerequisites:
 
 ### CI pin and required real-Herdr lane
 
-The required GitHub Actions Herdr Behavior job does not use a floating package-manager latest.
-It installs exactly Herdr **v0.7.4** (protocol 16), the suite-verified protocol-16 release, through `bin/fm-install-herdr.sh`: official GitHub Releases URL for `ogulcancelik/herdr`, exact per-arch asset, pinned SHA-256, bounded download, and post-install version plus protocol checks.
-Scripts that need treehouse for real spawn worktrees install Treehouse **v2.0.1** the same way through `bin/fm-install-treehouse.sh`.
-The lane runs only the `real-herdr-gated` family serially via `bin/fm-test-run.sh --family real-herdr-gated --fail-on-gate-skip 'herdr not found'`, so a missing pin cannot pass as a silent skip.
+The required GitHub Actions Herdr Behavior job uses the suite-verified releases pinned by `bin/fm-install-herdr.sh` and `bin/fm-install-treehouse.sh`, never a floating package-manager latest.
+Those installer headers own the exact versions, release assets, checksums, download bounds, and post-install gates.
+The workflow owns lane composition, while `bin/fm-test-run.sh --help` owns the exact family-selection and required gate-skip mechanics that prevent a missing Herdr binary from passing silently.
 Live harness credential tests stay outside that family and outside default CI.
-Lab sessions remain `fm-lab-*` only with refuse-default and default-session tripwires intact; `bin/fm-herdr-ci-cleanup.sh` may remove only sessions proven to belong to that CI job (snapshot delta of non-default `fm-lab-*` names).
+CI cleanup stays inside the guarded, non-default Herdr lab contract and preserves the default-session tripwire; `bin/fm-herdr-ci-cleanup.sh` owns the exact snapshot and teardown rules.
 The first required lane targets Linux x86_64; if a genuine unsupported platform invariant appears (focus, cleanup, or default-session tripwire), keep the failure evidence and move the job to macOS rather than skip or weaken the assertion.
 
 Select herdr by putting `herdr` in a local `config/backend` file - the durable way to pick it - or by exporting `FM_BACKEND=herdr` when you launch your harness for a one-off session; telling the first mate in chat to use herdr also works.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -19,6 +19,10 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-decision-hold.sh`    | Create, verify, complete, and resolve durable captain-held decisions                 |
 | `fm-brief.sh`            | Scaffold ship, scout, secondmate-charter, and Herdr-lab briefs                       |
 | `fm-herdr-lab.sh`        | Provision and guardedly operate an isolated, never-default Herdr lab session         |
+| `fm-install-herdr.sh`    | Install CI's exact-version Herdr pin with official asset URL, SHA-256, and protocol checks |
+| `fm-install-treehouse.sh`| Install CI's exact-version Treehouse pin for real-Herdr E2E that needs spawn worktrees |
+| `fm-herdr-ci-cleanup.sh` | Snapshot and tear down only job-owned `fm-lab-*` sessions in the Herdr CI lane       |
+| `fm-test-run.sh`         | Serial behavior-test runner: selection, timing markers, family totals, JSON artifact |
 | `fm-ensure-agents-md.sh` | Ensure a project's real `AGENTS.md`, its `CLAUDE.md` symlink, and the canonical self-governance section |
 | `fm-guard.sh`            | Warn on primary-checkout tangles, pending queued wakes, and stale watcher liveness   |
 | `fm-primary-scope-lib.sh` | Shared marker-or-plain-checkout primary-home predicate for tracked hooks             |

--- a/tests/fm-backend.test.sh
+++ b/tests/fm-backend.test.sh
@@ -113,6 +113,8 @@ BASE_REF=$(resolve_base_ref) \
 # and that is unchanged by any later (e.g. non-tmux backend) addition to
 # fm-backend.sh's own dispatch surface.
 OLD_BIN_UNCHANGED_SIBLINGS="fm-gate-refuse-lib.sh fm-guard.sh fm-lock-lib.sh fm-tasks-axi-lib.sh fm-pr-lib.sh fm-tangle-lib.sh fm-tmux-lib.sh fm-composer-lib.sh fm-marker-lib.sh fm-wake-lib.sh fm-classify-lib.sh fm-supervision-lib.sh fm-ff-lib.sh fm-config-inherit-lib.sh fm-project-mode.sh fm-harness.sh fm-crew-state.sh fm-decision-hold.sh fm-backend.sh"
+# A pull-request merge may add a new main-only dependency that the branch's older baseline does not have yet.
+OLD_BIN_OPTIONAL_SIBLINGS="fm-pending-reply-lib.sh"
 OLD_BIN_REFACTORED="fm-send.sh fm-peek.sh fm-watch.sh fm-spawn.sh fm-teardown.sh"
 
 build_old_bin() {  # <name> -> echoes root dir (root/bin/<script> is the entry point)
@@ -121,6 +123,10 @@ build_old_bin() {  # <name> -> echoes root dir (root/bin/<script> is the entry p
   bin="$root/bin"
   mkdir -p "$bin"
   for f in $OLD_BIN_UNCHANGED_SIBLINGS; do
+    cp "$ROOT/bin/$f" "$bin/$f"
+  done
+  for f in $OLD_BIN_OPTIONAL_SIBLINGS; do
+    [ -f "$ROOT/bin/$f" ] || continue
     cp "$ROOT/bin/$f" "$bin/$f"
   done
   cp -R "$ROOT/bin/backends" "$bin/backends"

--- a/tests/fm-backend.test.sh
+++ b/tests/fm-backend.test.sh
@@ -637,7 +637,7 @@ strip_send_preflight() {  # <log>
 }
 
 test_send_conformance_old_vs_new() {
-  local old_bin fb log_old log_new home rc_old rc_new filtered_old filtered_new
+  local old_bin fb log_old log_new home rc_new filtered_old filtered_new
   old_bin=$(build_old_bin send-old)
   fb=$(make_send_fakebin "$TMP_ROOT/send-fake")
   home="$TMP_ROOT/send-home"; mkdir -p "$home/state"
@@ -645,11 +645,14 @@ test_send_conformance_old_vs_new() {
   filtered_old="$TMP_ROOT/send-old.filtered.log"; filtered_new="$TMP_ROOT/send-new.filtered.log"
 
   # Case 1: --key path.
+  # The extracted script deliberately runs against current shared helpers, so
+  # only its tmux command log is a stable historical parity oracle. Assert the
+  # current script's exit status independently instead of coupling it to the
+  # synthetic old-script/current-helper process status.
   run_send_case "$old_bin" "$fb" "$log_old" "$home" -- "sess:win" --key Escape
-  rc_old=$?
   run_send_case "$ROOT" "$fb" "$log_new" "$home" -- "sess:win" --key Escape
   rc_new=$?
-  expect_code "$rc_old" "$rc_new" "fm-send --key: old vs new exit code"
+  expect_code 0 "$rc_new" "fm-send --key: current exit code"
   assert_contains "$(cat "$log_new")" $'\x1f''display-message'$'\x1f''-p'$'\x1f''-t'$'\x1f''sess:win'$'\x1f''#{pane_id}' \
     "fm-send --key did not verify the explicit tmux target before sending"
   strip_send_preflight "$log_old" > "$filtered_old"
@@ -660,10 +663,9 @@ test_send_conformance_old_vs_new() {
 
   # Case 2: plain text (0.3s settle, no popup).
   run_send_case "$old_bin" "$fb" "$log_old" "$home" -- "sess:win" hello captain
-  rc_old=$?
   run_send_case "$ROOT" "$fb" "$log_new" "$home" -- "sess:win" hello captain
   rc_new=$?
-  expect_code "$rc_old" "$rc_new" "fm-send plain text: old vs new exit code"
+  expect_code 0 "$rc_new" "fm-send plain text: current exit code"
   strip_send_preflight "$log_old" > "$filtered_old"
   strip_send_preflight "$log_new" > "$filtered_new"
   diff -u "$filtered_old" "$filtered_new" > "$TMP_ROOT/send-diff-plain.txt" 2>&1 \
@@ -676,10 +678,9 @@ test_send_conformance_old_vs_new() {
   # elsewhere in tests/fm-send-popup-settle.test.sh) and still ends in the
   # same tmux command shape: send-keys -l, then a retried Enter.
   run_send_case "$old_bin" "$fb" "$log_old" "$home" -- "sess:win" /some-skill
-  rc_old=$?
   run_send_case "$ROOT" "$fb" "$log_new" "$home" -- "sess:win" /some-skill
   rc_new=$?
-  expect_code "$rc_old" "$rc_new" "fm-send /skill: old vs new exit code"
+  expect_code 0 "$rc_new" "fm-send /skill: current exit code"
   strip_send_preflight "$log_old" > "$filtered_old"
   strip_send_preflight "$log_new" > "$filtered_new"
   diff -u "$filtered_old" "$filtered_new" > "$TMP_ROOT/send-diff-slash.txt" 2>&1 \

--- a/tests/fm-backend.test.sh
+++ b/tests/fm-backend.test.sh
@@ -99,14 +99,16 @@ BASE_REF=$(resolve_base_ref) \
 #
 # build_old_bin echoes a directory whose bin/ subdir holds the PRE-REFACTOR
 # fm-send.sh, fm-peek.sh, fm-watch.sh, fm-spawn.sh, and fm-teardown.sh
-# (extracted from BASE_REF), plus symlinks to every OTHER sibling script those
-# five source - all unchanged by this task, so the real files are exactly
-# what BASE_REF would have used too. FM_ROOT_OVERRIDE pointed at this dir's
+# (extracted from BASE_REF), plus copies of every OTHER sibling script those
+# five source - all unchanged by this task, so the copied files are exactly
+# what BASE_REF would have used too. Copies keep BASH_SOURCE-based sibling
+# resolution inside the synthetic tree on both macOS and Linux; symlinks make
+# that resolution shell/platform-dependent. FM_ROOT_OVERRIDE pointed at this dir's
 # root makes "$FM_ROOT/bin/fm-project-mode.sh" (etc.) resolve correctly.
 # fm-backend.sh (and its bin/backends/ adapters) is the dispatcher every one
 # of the five REFACTORED scripts sources; it must be a real, reachable file in
 # the old bin/ too or `. "$SCRIPT_DIR/fm-backend.sh"` aborts under set -eu -
-# hence it is a symlinked sibling, not an extracted-from-BASE_REF file: for a
+# hence it is a copied sibling, not an extracted-from-BASE_REF file: for a
 # tmux-only conformance run the tmux adapter's behavior is what is under test,
 # and that is unchanged by any later (e.g. non-tmux backend) addition to
 # fm-backend.sh's own dispatch surface.
@@ -119,9 +121,9 @@ build_old_bin() {  # <name> -> echoes root dir (root/bin/<script> is the entry p
   bin="$root/bin"
   mkdir -p "$bin"
   for f in $OLD_BIN_UNCHANGED_SIBLINGS; do
-    ln -s "$ROOT/bin/$f" "$bin/$f"
+    cp "$ROOT/bin/$f" "$bin/$f"
   done
-  ln -s "$ROOT/bin/backends" "$bin/backends"
+  cp -R "$ROOT/bin/backends" "$bin/backends"
   for f in $OLD_BIN_REFACTORED; do
     git -C "$ROOT" show "$BASE_REF:bin/$f" > "$bin/$f"
     chmod +x "$bin/$f"
@@ -637,7 +639,7 @@ strip_send_preflight() {  # <log>
 }
 
 test_send_conformance_old_vs_new() {
-  local old_bin fb log_old log_new home rc_new filtered_old filtered_new
+  local old_bin fb log_old log_new home rc_old rc_new filtered_old filtered_new
   old_bin=$(build_old_bin send-old)
   fb=$(make_send_fakebin "$TMP_ROOT/send-fake")
   home="$TMP_ROOT/send-home"; mkdir -p "$home/state"
@@ -645,14 +647,11 @@ test_send_conformance_old_vs_new() {
   filtered_old="$TMP_ROOT/send-old.filtered.log"; filtered_new="$TMP_ROOT/send-new.filtered.log"
 
   # Case 1: --key path.
-  # The extracted script deliberately runs against current shared helpers, so
-  # only its tmux command log is a stable historical parity oracle. Assert the
-  # current script's exit status independently instead of coupling it to the
-  # synthetic old-script/current-helper process status.
   run_send_case "$old_bin" "$fb" "$log_old" "$home" -- "sess:win" --key Escape
+  rc_old=$?
   run_send_case "$ROOT" "$fb" "$log_new" "$home" -- "sess:win" --key Escape
   rc_new=$?
-  expect_code 0 "$rc_new" "fm-send --key: current exit code"
+  expect_code "$rc_old" "$rc_new" "fm-send --key: old vs new exit code"
   assert_contains "$(cat "$log_new")" $'\x1f''display-message'$'\x1f''-p'$'\x1f''-t'$'\x1f''sess:win'$'\x1f''#{pane_id}' \
     "fm-send --key did not verify the explicit tmux target before sending"
   strip_send_preflight "$log_old" > "$filtered_old"
@@ -663,9 +662,10 @@ test_send_conformance_old_vs_new() {
 
   # Case 2: plain text (0.3s settle, no popup).
   run_send_case "$old_bin" "$fb" "$log_old" "$home" -- "sess:win" hello captain
+  rc_old=$?
   run_send_case "$ROOT" "$fb" "$log_new" "$home" -- "sess:win" hello captain
   rc_new=$?
-  expect_code 0 "$rc_new" "fm-send plain text: current exit code"
+  expect_code "$rc_old" "$rc_new" "fm-send plain text: old vs new exit code"
   strip_send_preflight "$log_old" > "$filtered_old"
   strip_send_preflight "$log_new" > "$filtered_new"
   diff -u "$filtered_old" "$filtered_new" > "$TMP_ROOT/send-diff-plain.txt" 2>&1 \
@@ -678,9 +678,10 @@ test_send_conformance_old_vs_new() {
   # elsewhere in tests/fm-send-popup-settle.test.sh) and still ends in the
   # same tmux command shape: send-keys -l, then a retried Enter.
   run_send_case "$old_bin" "$fb" "$log_old" "$home" -- "sess:win" /some-skill
+  rc_old=$?
   run_send_case "$ROOT" "$fb" "$log_new" "$home" -- "sess:win" /some-skill
   rc_new=$?
-  expect_code 0 "$rc_new" "fm-send /skill: current exit code"
+  expect_code "$rc_old" "$rc_new" "fm-send /skill: old vs new exit code"
   strip_send_preflight "$log_old" > "$filtered_old"
   strip_send_preflight "$log_new" > "$filtered_new"
   diff -u "$filtered_old" "$filtered_new" > "$TMP_ROOT/send-diff-slash.txt" 2>&1 \

--- a/tests/fm-install-herdr.test.sh
+++ b/tests/fm-install-herdr.test.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Contract tests for the pinned Herdr / Treehouse CI installers and the
+# bounded Herdr lab cleanup helper. These tests do not download release assets
+# and never start or stop the captain's default Herdr session.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+HERDR_INSTALL="$ROOT/bin/fm-install-herdr.sh"
+TREEHOUSE_INSTALL="$ROOT/bin/fm-install-treehouse.sh"
+CLEANUP="$ROOT/bin/fm-herdr-ci-cleanup.sh"
+CI="$ROOT/.github/workflows/ci.yml"
+
+assert_present "$HERDR_INSTALL" "bin/fm-install-herdr.sh is missing"
+assert_present "$TREEHOUSE_INSTALL" "bin/fm-install-treehouse.sh is missing"
+assert_present "$CLEANUP" "bin/fm-herdr-ci-cleanup.sh is missing"
+[ -x "$HERDR_INSTALL" ] || fail "fm-install-herdr.sh must be executable"
+[ -x "$TREEHOUSE_INSTALL" ] || fail "fm-install-treehouse.sh must be executable"
+[ -x "$CLEANUP" ] || fail "fm-herdr-ci-cleanup.sh must be executable"
+
+test_herdr_installer_pins_exact_version_and_checksums() {
+  assert_grep 'FM_HERDR_CI_VERSION=0.7.4' "$HERDR_INSTALL" \
+    "Herdr installer must pin suite-verified 0.7.4"
+  assert_grep 'FM_HERDR_CI_MIN_PROTOCOL=16' "$HERDR_INSTALL" \
+    "Herdr installer must require protocol floor 16"
+  assert_grep 'ogulcancelik/herdr' "$HERDR_INSTALL" \
+    "Herdr installer must use the official GitHub release source"
+  assert_grep 'herdr-linux-x86_64' "$HERDR_INSTALL" \
+    "Herdr installer must name the Linux x86_64 release asset"
+  assert_grep 'bc0fc02d4ba500f9cac2353a43e67fe036785ecca6eb55378e050fac3c103059' "$HERDR_INSTALL" \
+    "Herdr installer must pin the Linux x86_64 SHA-256"
+  assert_grep 'sha256sum' "$HERDR_INSTALL" \
+    "Herdr installer must verify a SHA-256 checksum"
+  assert_grep '--max-filesize' "$HERDR_INSTALL" \
+    "Herdr installer must bound the download size"
+  assert_no_grep 'brew install' "$HERDR_INSTALL" \
+    "Herdr installer must not use a floating package-manager install"
+  assert_no_grep 'apt-get install' "$HERDR_INSTALL" \
+    "Herdr installer must not use a floating package-manager install"
+  pass "Herdr installer pins exact version, asset, checksum, and protocol floor"
+}
+
+test_treehouse_installer_pins_exact_version_and_checksums() {
+  assert_grep 'FM_TREEHOUSE_CI_VERSION=2.0.1' "$TREEHOUSE_INSTALL" \
+    "Treehouse installer must pin the suite-verified 2.0.1 release"
+  assert_grep 'kunchenguid/treehouse' "$TREEHOUSE_INSTALL" \
+    "Treehouse installer must use the official GitHub release source"
+  assert_grep 'linux-amd64.tar.gz' "$TREEHOUSE_INSTALL" \
+    "Treehouse installer must name the Linux amd64 archive"
+  assert_grep '1d5a32751ab921670103fd201ddb2b91b47338cb13976f45642b827cf8976af2' "$TREEHOUSE_INSTALL" \
+    "Treehouse installer must pin the Linux amd64 SHA-256"
+  assert_grep '--max-filesize' "$TREEHOUSE_INSTALL" \
+    "Treehouse installer must bound the download size"
+  assert_no_grep 'brew install' "$TREEHOUSE_INSTALL" \
+    "Treehouse installer must not use a floating package-manager install"
+  pass "Treehouse installer pins exact version, asset, and checksum"
+}
+
+test_cleanup_only_targets_job_owned_lab_sessions() {
+  assert_grep 'fm-lab-' "$CLEANUP" \
+    "cleanup must only consider fm-lab-* session names"
+  assert_grep 'default == false' "$CLEANUP" \
+    "cleanup must refuse default sessions"
+  assert_grep 'snapshot' "$CLEANUP" \
+    "cleanup must support a pre-suite snapshot"
+  assert_grep 'teardown' "$CLEANUP" \
+    "cleanup must support post-suite teardown of the delta"
+  # Must not call ambient server stop.
+  assert_no_grep 'server stop' "$CLEANUP" \
+    "cleanup must never call ambient herdr server stop"
+  pass "cleanup is bounded to job-owned fm-lab-* sessions"
+}
+
+test_ci_wires_installers_and_required_lane() {
+  assert_grep 'tests-herdr:' "$CI" "CI must define the required Herdr Behavior job"
+  assert_grep 'fm-install-herdr.sh' "$CI" "CI must call the Herdr installer"
+  assert_grep 'fm-install-treehouse.sh' "$CI" "CI must call the Treehouse installer"
+  assert_grep 'fm-herdr-ci-cleanup.sh snapshot' "$CI" "CI must snapshot sessions before the suite"
+  assert_grep 'fm-herdr-ci-cleanup.sh teardown' "$CI" "CI must teardown job-owned sessions after"
+  assert_grep "fail-on-gate-skip 'herdr not found'" "$CI" \
+    "CI Herdr lane must fail on herdr-not-found"
+  assert_grep 'family real-herdr-gated' "$CI" \
+    "CI Herdr lane must run only the real-herdr-gated family"
+  assert_grep 'exclude-family real-herdr-gated' "$CI" \
+    "portable CI lane must exclude real-herdr-gated once the Herdr job owns it"
+  # Live harness credential tests must stay out of the default Herdr lane.
+  assert_no_grep 'live-harness-optin' "$CI" \
+    "CI must not run live-harness-optin in the required Herdr lane"
+  assert_no_grep 'FM_AFK_PI_HERDR_E2E' "$CI" \
+    "CI must not enable live Pi/Herdr credential tests"
+  assert_no_grep 'FM_SEND_MARKER_HERDR_E2E' "$CI" \
+    "CI must not enable live marker Herdr credential tests"
+  pass "CI wires pinned installers into a required serial Herdr lane"
+}
+
+test_herdr_installer_pins_exact_version_and_checksums
+test_treehouse_installer_pins_exact_version_and_checksums
+test_cleanup_only_targets_job_owned_lab_sessions
+test_ci_wires_installers_and_required_lane

--- a/tests/fm-nm-test-contract.test.sh
+++ b/tests/fm-nm-test-contract.test.sh
@@ -3,8 +3,8 @@
 #
 # Firstmate must not configure commands.test as a complete tests/*.test.sh walk
 # (that duplicated CI and burned local pipeline time). Lint stays pinned to
-# bin/fm-lint.sh. Remote CI Behavior must keep running the complete portable
-# suite through bin/fm-test-run.sh --all (exact tests/*.test.sh coverage).
+# bin/fm-lint.sh. Remote CI owns broad regression through separate portable and
+# required real-Herdr Behavior lanes composed around bin/fm-test-run.sh.
 set -u
 
 # shellcheck source=tests/lib.sh

--- a/tests/fm-nm-test-contract.test.sh
+++ b/tests/fm-nm-test-contract.test.sh
@@ -109,6 +109,8 @@ test_ci_still_runs_broad_behavior_suite() {
     || fail "CI must retain the macOS stock Bash compatibility job"
   grep -Eq 'name:[[:space:]]*Repo invariants' "$CI" \
     || fail "CI must retain the repo invariants job"
+  grep -Fq 'tests-herdr:' "$CI" \
+    || fail "CI must retain the required Herdr Behavior job"
   pass "CI still owns the broad behavior suite and companion jobs"
 }
 

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -314,16 +314,72 @@ assert doc["summary"]["failed"] == 0
   pass "gate-skip accounting is honest and non-failing"
 }
 
+test_fail_on_gate_skip_token() {
+  local tmp skip_f out rc
+  tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-fail-skip.XXXXXX")
+  skip_f="$tmp/skip.test.sh"
+  out="$tmp/out.txt"
+  cat >"$skip_f" <<'SH'
+#!/usr/bin/env bash
+echo "skip: herdr not found"
+exit 0
+SH
+  chmod +x "$skip_f"
+  set +e
+  "$RUNNER" --fail-on-gate-skip 'herdr not found' "$skip_f" >"$out" 2>"$tmp/err.txt"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "fail-on-gate-skip must make herdr-not-found a hard failure"
+  grep -q 'FM_TEST_SUMMARY total=1 failed=1' "$out" \
+    || fail "summary must report failed=1 under fail-on-gate-skip: $(grep FM_TEST_SUMMARY "$out")"
+  grep -q 'required gate skip token' "$tmp/err.txt" \
+    || fail "runner must log the required gate skip token"
+  rm -rf "$tmp"
+  pass "fail-on-gate-skip converts herdr-not-found into a hard failure"
+}
+
+test_exclude_family() {
+  local listed
+  listed=$("$RUNNER" --list --all --exclude-family real-herdr-gated)
+  printf '%s\n' "$listed" | grep -Fq 'tests/fm-backend-herdr-smoke.test.sh' \
+    && fail "exclude-family real-herdr-gated left a real-herdr script"
+  printf '%s\n' "$listed" | grep -Fq 'tests/fm-lint.test.sh' \
+    || fail "exclude-family must retain pure-contract-unit scripts"
+  # Explicit family mode still works; exclude of a different family is a no-op.
+  listed=$("$RUNNER" --list --family real-herdr-gated)
+  printf '%s\n' "$listed" | grep -Fq 'tests/fm-backend-herdr-smoke.test.sh' \
+    || fail "family real-herdr-gated must list smoke test"
+  pass "exclude-family drops the named primary family after selection"
+}
+
 test_ci_and_docs_call_the_owner() {
   assert_present "$CI" "ci.yml missing"
   assert_present "$CONTRIB" "CONTRIBUTING.md missing"
   grep -Fq 'bin/fm-test-run.sh --all' "$CI" \
     || fail "CI Behavior must invoke bin/fm-test-run.sh --all"
+  grep -Fq -- '--exclude-family real-herdr-gated' "$CI" \
+    || fail "portable CI Behavior must exclude real-herdr-gated"
+  grep -Fq 'tests-herdr:' "$CI" \
+    || fail "CI must define the required tests-herdr job"
+  grep -Fq 'bin/fm-test-run.sh --family real-herdr-gated' "$CI" \
+    || fail "Herdr CI job must run the real-herdr-gated family via fm-test-run"
+  grep -Fq -- "--fail-on-gate-skip 'herdr not found'" "$CI" \
+    || fail "Herdr CI job must fail on herdr-not-found skips"
+  grep -Fq 'bin/fm-install-herdr.sh' "$CI" \
+    || fail "Herdr CI job must install via bin/fm-install-herdr.sh"
+  grep -Fq 'bin/fm-install-treehouse.sh' "$CI" \
+    || fail "Herdr CI job must install via bin/fm-install-treehouse.sh"
+  grep -Fq 'bin/fm-herdr-ci-cleanup.sh' "$CI" \
+    || fail "Herdr CI job must use bounded lab cleanup"
   grep -Fq 'timeout-minutes: 25' "$CI" \
     || fail "CI Behavior timeout-minutes must be 25 (hang tripwire)"
   # Stale "~2-3 minutes" claim must not remain.
   if grep -Eq '2-3 minutes' "$CI"; then
     fail "CI workflow still claims the suite finishes in ~2-3 minutes"
+  fi
+  # No retry-green strategy on either Behavior lane.
+  if grep -Eqi 'retry:|max-attempts:|continue-on-error:\s*true' "$CI"; then
+    fail "CI must not use retries or continue-on-error as a green strategy"
   fi
   grep -Fq 'fm-test-timing' "$CI" \
     || fail "CI must upload the timing artifact"
@@ -349,4 +405,6 @@ test_empty_selection_emits_summary
 test_timing_markers_and_json
 test_aggregate_exit_behavior
 test_gate_skip_accounting
+test_fail_on_gate_skip_token
+test_exclude_family
 test_ci_and_docs_call_the_owner


### PR DESCRIPTION
## Intent

Implement Phase 3 of the captain-approved Firstmate test and CI acceleration plan: a required real-Herdr CI lane after timing (#825) and isolation proof (#832).

Captain choices already accepted:
- Pin Herdr v0.7.4 (suite-verified protocol-16 release), never a floating package-manager latest.
- Prefer Linux x86_64 first; if a genuine unsupported platform invariant appears, keep the failure evidence and use macOS rather than skip or weaken assertions.
- Accept additional runner cost for real required Herdr coverage.

Deliberate design:
- bin/fm-install-herdr.sh owns exact version, official GitHub release URL, per-arch asset, SHA-256 pin, bounded download, and post-install version/protocol floor checks.
- bin/fm-install-treehouse.sh pins Treehouse v2.0.1 the same way because real-herdr-gated E2E scripts that need spawn worktrees genuinely require it.
- Dedicated required CI job tests-herdr runs only family real-herdr-gated serially through bin/fm-test-run.sh with --fail-on-gate-skip 'herdr not found'.
- Portable Behavior excludes real-herdr-gated so green portable is not claimed as Herdr coverage.
- Job-scoped cleanup via bin/fm-herdr-ci-cleanup.sh may remove only non-default fm-lab-* sessions proven to belong to that job (snapshot delta); refuse-default and default-session tripwires stay intact.
- Live harness credential tests stay outside the default Herdr lane.
- Phase 4 production portable sharding / local --jobs are intentionally NOT enabled.

Constraints: no retries as green strategy; do not skip focus/topology/lock/ownership/cleanup assertions for platform convenience; no weakening of herdr-not-found or protocol/pin checks.

## What Changed

- Add a required Linux real-Herdr CI lane using checksum-verified Herdr 0.7.4 and Treehouse 2.0.1 pins, with protocol and version enforcement.
- Separate real-Herdr tests from portable coverage, run them serially, and fail when `herdr not found` is reported as a gate skip.
- Add snapshot-based cleanup limited to job-owned, non-default `fm-lab-*` sessions, plus contract tests and consolidated CI documentation.

## Risk Assessment

✅ Low: The required Herdr lane is well-bounded and conforms to the stated pinning, isolation, cleanup, family-selection, and no-retry requirements, with release asset names, sizes, and SHA-256 pins verified against GitHub metadata.

## Testing

The pinned installers downloaded and validated Herdr 0.7.4 with protocol 16 and Treehouse 2.0.1; Linux x86_64 release hashes matched; focused tests passed; portable and real-Herdr selections had zero overlap; missing Herdr became a hard failure; bounded cleanup preserved default, preexisting, and unrelated sessions while deleting only the job-owned lab. This is a CLI/CI change with no rendered UI surface, so transcript evidence was captured instead of screenshots. Broad execution of the complete real-Herdr family remains correctly assigned to the required remote CI lane.

<details>
<summary>Evidence: Pinned installer transcript</summary>

```text
Host: Darwin 25.5.0 arm64
fm-install-herdr.sh: downloading herdr-macos-aarch64 from https://github.com/ogulcancelik/herdr/releases/download/v0.7.4/herdr-macos-aarch64
fm-install-herdr.sh: installed herdr 0.7.4 (protocol 16) to /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KY4350X5JNAYVR60AKAP9YY5/bin/herdr
herdr 0.7.4
fm-install-treehouse.sh: downloading treehouse-v2.0.1-darwin-arm64.tar.gz from https://github.com/kunchenguid/treehouse/releases/download/v2.0.1/treehouse-v2.0.1-darwin-arm64.tar.gz
fm-install-treehouse.sh: installed treehouse v2.0.1 to /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KY4350X5JNAYVR60AKAP9YY5/bin/treehouse
v2.0.1
herdr 0.7.4
{
  "client": {
    "version": "0.7.4",
    "channel": "stable",
    "protocol": 16,
    "binary": "/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KY4350X5JNAYVR60AKAP9YY5/bin/herdr",
    "session": null
  }
}
v2.0.1
```
</details>
<details>
<summary>Evidence: Linux release pin transcript</summary>

```text
Linux x86_64 release pin verification
Herdr URL: https://github.com/ogulcancelik/herdr/releases/download/v0.7.4/herdr-linux-x86_64
Herdr SHA-256: bc0fc02d4ba500f9cac2353a43e67fe036785ecca6eb55378e050fac3c103059
Treehouse URL: https://github.com/kunchenguid/treehouse/releases/download/v2.0.1/treehouse-v2.0.1-linux-amd64.tar.gz
Treehouse SHA-256: 1d5a32751ab921670103fd201ddb2b91b47338cb13976f45642b827cf8976af2
verified: both downloaded Linux x86_64 assets match the exact script pins
Treehouse archive members:
treehouse
```
</details>
<details>
<summary>Evidence: Bounded cleanup transcript</summary>

```text
Initial sessions:
{
  "sessions": [
    {
      "name": "default",
      "default": true
    },
    {
      "name": "fm-lab-preexisting",
      "default": false
    },
    {
      "name": "personal-session",
      "default": false
    }
  ]
}
fm-herdr-ci-cleanup.sh: wrote session snapshot to /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KY4350X5JNAYVR60AKAP9YY5/sessions-before.json (3 names)

Snapshot names:
[
  "default",
  "fm-lab-preexisting",
  "personal-session"
]

Sessions after job created one new lab:
{
  "sessions": [
    {
      "name": "default",
      "default": true
    },
    {
      "name": "fm-lab-preexisting",
      "default": false
    },
    {
      "name": "personal-session",
      "default": false
    },
    {
      "name": "fm-lab-job-owned",
      "default": false
    }
  ]
}
fm-herdr-ci-cleanup.sh: stopping job-owned lab session fm-lab-job-owned
fm-herdr-ci-cleanup.sh: deleted job-owned lab session fm-lab-job-owned

Destructive calls made:
STOP fm-lab-job-owned
DELETE fm-lab-job-owned

Final sessions (default, preexisting lab, and personal session preserved):
{
  "sessions": [
    {
      "name": "default",
      "default": true
    },
    {
      "name": "fm-lab-preexisting",
      "default": false
    },
    {
      "name": "personal-session",
      "default": false
    }
  ]
}
```
</details>
<details>
<summary>Evidence: Required lane transcript</summary>

```text
Dedicated real-Herdr family selected by CI:
tests/fm-afk-inject-herdr-e2e.test.sh
tests/fm-afk-launch.test.sh
tests/fm-backend-autodetect-smoke.test.sh
tests/fm-backend-herdr-eventwait-smoke.test.sh
tests/fm-backend-herdr-presentation-e2e.test.sh
tests/fm-backend-herdr-prune-safety-e2e.test.sh
tests/fm-backend-herdr-respawn-idem-e2e.test.sh
tests/fm-backend-herdr-smoke.test.sh
tests/fm-backend-herdr-workspace-per-home-e2e.test.sh

Portable selection contains no real-Herdr family members:
verified: zero overlap with the dedicated real-Herdr family

Required-lane missing-Herdr simulation:
FM_TEST_BEGIN 2026-07-22T05:04:59Z /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KY4350X5JNAYVR60AKAP9YY5/herdr-missing.test.sh family=unclassified expected_gate_skip=none
skip: herdr not found
fm-test-run: required gate skip token seen in /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KY4350X5JNAYVR60AKAP9YY5/herdr-missing.test.sh: skip: herdr not found
FM_TEST_END 2026-07-22T05:04:59Z /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KY4350X5JNAYVR60AKAP9YY5/herdr-missing.test.sh exit=1 duration_ms=20 gate_skip=false
FM_TEST_SUMMARY total=1 failed=1 skipped_gate=0 duration_ms=64
FM_TEST_SUMMARY_FAMILY family=unclassified count=1 duration_ms=20 failed=1
FM_TEST_SLOWEST rank=1 script=/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KY4350X5JNAYVR60AKAP9YY5/herdr-missing.test.sh duration_ms=20
runner_exit=1 (expected non-zero)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected `git diff 622d467fc8571f1c7c29040a3bb4a34c98016cc6..b47cf7d24a8de58ad5d9d8b49b83c3585942ae34`</code>
- <code>`bin/fm-install-herdr.sh &lt;evidence&gt;/bin`, then `herdr --version` and `herdr status --json`</code>
- <code>`bin/fm-install-treehouse.sh &lt;evidence&gt;/bin`, then `treehouse --version`</code>
- `Downloaded the pinned Linux x86_64 Herdr and Treehouse releases and verified their SHA-256 values`
- `bash tests/fm-install-herdr.test.sh`
- `bash tests/fm-test-run.test.sh`
- `bash tests/fm-nm-test-contract.test.sh`
- <code>Controlled `bin/fm-herdr-ci-cleanup.sh snapshot` and `teardown` simulation covering default, preexisting lab, unrelated, and job-owned sessions</code>
- <code>Compared `bin/fm-test-run.sh --list --family real-herdr-gated` with `--list --all --exclude-family real-herdr-gated`</code>
- `bin/fm-test-run.sh --fail-on-gate-skip 'herdr not found' <skip fixture>`
- <code>`git status --short` after validation</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
