### PR TITLE
fix(fm-pr-check): rebase ready-to-merge wake onto GitLab-support hardening

### DIFF
--- a/bin/fm-pr-poll.sh
+++ b/bin/fm-pr-poll.sh
@@ -1,11 +1,19 @@
 #!/usr/bin/env bash
 # Static watcher program for a validated PR/MR poll sidecar.
-# It emits exactly one merged line for a merged PR or MR and stays silent
-# otherwise, including on every error, so a failed lookup can never be read as
-# a merge. The provider-tagged identity is data in the sidecar and is never
-# interpolated into this source: these bytes are identical for every task.
-# Each provider is read through its own standard CLI, gh for GitHub and glab
-# for GitLab, so an upstream checkout needs no extra tooling to follow either.
+# It prints one line iff firstmate should wake, on distinct outcomes:
+#   - merged: PR/MR state is MERGED, confirming landing for teardown.
+#   - ready-to-merge (GitHub PRs only): PR is OPEN with mergeStateStatus=CLEAN
+#     (all required and non-required checks pass and the PR is mergeable).
+#     For the direct-PR + yolo path this is the signal that firstmate should
+#     perform the merge itself under standing routine authority.
+# It stays silent otherwise, including on every error, so a failed lookup can
+# never be read as a merge: interim/not-ready states (pending checks,
+# blocked reviews or failed required checks, needs-rebase, merge conflicts,
+# etc.) and any other non-matching outcome. The provider-tagged identity is
+# data in the sidecar and is never interpolated into this source: these
+# bytes are identical for every task. Each provider is read through its own
+# standard CLI, gh for GitHub and glab for GitLab, so an upstream checkout
+# needs no extra tooling to follow either.
 set -u
 LC_ALL=C
 export LC_ALL
@@ -62,8 +70,12 @@ case "$provider" in
       .|..|*[!A-Za-z0-9._-]*) exit 0 ;;
     esac
     [ "$url" = "https://github.com/$owner/$repo/pull/$number" ] || exit 0
-    state=$(gh pr view "$url" --json state -q .state 2>/dev/null) || exit 0
-    [ "$state" = MERGED ] && printf '%s\n' merged
+    state=$(gh pr view "$url" --json state,mergeStateStatus \
+      -q '.state + " " + .mergeStateStatus' 2>/dev/null) || exit 0
+    case "$state" in
+      "MERGED "*) printf '%s\n' merged ;;
+      "OPEN CLEAN") printf '%s\n' ready-to-merge ;;
+    esac
     ;;
   gitlab)
     [ "${#host}" -ge 1 ] && [ "${#host}" -le 253 ] || exit 0

--- a/tests/fm-pr-check-security.test.sh
+++ b/tests/fm-pr-check-security.test.sh
@@ -66,10 +66,10 @@ SH
 printf '%s\n' "$*" >> "$FM_TEST_GH_LOG"
 case " $* " in
   *" headRefOid "*) printf '%s\n' "${FM_TEST_GH_HEAD:-0123456789abcdef0123456789abcdef01234567}" ;;
-  *" state "*)
+  *state,mergeStateStatus*)
     [ "${FM_TEST_GH_FAIL:-0}" = 0 ] || exit 1
     [ "${FM_TEST_GH_SLEEP:-0}" = 0 ] || sleep "$FM_TEST_GH_SLEEP"
-    printf '%s\n' "${FM_TEST_GH_STATE:-OPEN}"
+    printf '%s %s\n' "${FM_TEST_GH_STATE:-OPEN}" "${FM_TEST_GH_MERGE:-}"
     ;;
 esac
 SH
@@ -713,6 +713,8 @@ test_static_poll_contract() {
   done
   out=$(FM_TEST_GH_STATE=MERGED run_poll "$dir")
   [ "$out" = merged ] || fail "static poll did not emit exactly one merged line"
+  out=$(FM_TEST_GH_STATE=OPEN FM_TEST_GH_MERGE=CLEAN run_poll "$dir")
+  [ "$out" = ready-to-merge ] || fail "static poll did not emit ready-to-merge for OPEN CLEAN"
   out=$(FM_TEST_GH_FAIL=1 run_poll "$dir")
   [ -z "$out" ] || fail "static poll emitted after gh failure"
 
@@ -748,7 +750,7 @@ test_static_poll_contract() {
   set -e
   [ "$rc" -eq 0 ] || fail "watcher did not surface merged poll"
   [ "$(grep -c '^check: .*: merged$' "$dir/watch.out")" -eq 1 ] || fail "watcher did not convert merged output into exactly one wake"
-  pass "static poll is silent except for one merged line and remains watcher-bounded"
+  pass "static poll wakes on merged and ready-to-merge, is silent otherwise, and remains watcher-bounded"
 }
 
 test_atomic_interruption_leaves_no_partial_artifact() {

--- a/tests/fm-pr-check.test.sh
+++ b/tests/fm-pr-check.test.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# Tests for the merge-poll wake matrix that bin/fm-pr-check.sh arms.
+#
+# fm-pr-check.sh no longer interpolates task data into a generated check.sh;
+# it arms a byte-for-byte copy of bin/fm-pr-poll.sh backed by a private sidecar
+# (url/owner/repo/number). The wake decision therefore lives entirely in
+# bin/fm-pr-poll.sh, so this file exercises that poll program directly against a
+# sidecar. The security/artifact aspects of arming (validation, atomic publish,
+# non-interpolation, migration, watcher-bounded wakes) are owned by
+# tests/fm-pr-check-security.test.sh.
+#
+# The watcher's check contract: the poll prints one line iff firstmate should
+# wake; silence keeps sleeping. It wakes on the two outcomes that require a
+# supervisor act:
+#   - ready-to-merge (OPEN + mergeStateStatus=CLEAN): the direct-PR + yolo
+#     signal for firstmate to perform the merge itself.
+#   - merged (state=MERGED): post-merge confirmation for teardown.
+# Silence must cover every interim and not-ready state (pending UNSTABLE,
+# blocked BLOCKED, behind BEHIND, dirty DIRTY, empty mergeStateStatus, gh
+# failure) so the watcher does not spam wakes while CI is in flight or the PR
+# cannot be merged.
+#
+# Matrix:
+#   (a) ready-to-merge: OPEN + CLEAN -> "ready-to-merge"
+#   (b) merged: MERGED + CLEAN -> "merged"
+#   (c) merged: MERGED + empty status -> "merged" (any post-merge status)
+#   (d) interim UNSTABLE: OPEN + UNSTABLE -> silence
+#   (e) blocked: OPEN + BLOCKED -> silence
+#   (f) behind: OPEN + BEHIND -> silence
+#   (g) dirty: OPEN + DIRTY -> silence
+#   (h) empty mergeStateStatus: OPEN + (blank) -> silence
+#   (i) gh failure -> silence
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+POLL="$ROOT/bin/fm-pr-poll.sh"
+TMP_ROOT=$(fm_test_tmproot fm-pr-check-tests)
+PR_URL="https://github.com/example/repo/pull/7"
+
+# Build a sandbox that mirrors what fm-pr-check.sh arms: a byte-for-byte copy of
+# bin/fm-pr-poll.sh as the check program, its private sidecar with the validated
+# provider/url/host/path/number, and a fakebin gh that answers
+# `gh pr view URL --json state,mergeStateStatus -q '.state + " " + .mergeStateStatus'`
+# with the named pair, exactly as the real gh -q filter would print it.
+# Args: case_name pr_state merge_state_status [fail]. Echoes the case dir.
+make_case() {
+  local name=$1 pr_state=$2 merge_state=$3 fail=${4:-0} case_dir fakebin
+  case_dir="$TMP_ROOT/$name"
+  fakebin="$case_dir/fakebin"
+  mkdir -p "$case_dir/state" "$fakebin"
+  cp "$POLL" "$case_dir/state/task-x1.check.sh"
+  printf '%s\n%s\n%s\n%s\n%s\n' github "$PR_URL" github.com example/repo 7 > "$case_dir/state/task-x1.pr-poll"
+  chmod 0700 "$case_dir/state/task-x1.check.sh"
+  chmod 0600 "$case_dir/state/task-x1.pr-poll"
+  cat > "$fakebin/gh" <<SH
+#!/usr/bin/env bash
+case "\${1:-} \${2:-}" in
+  "pr view")
+    [ "$fail" = 0 ] || exit 1
+    printf '%s %s\n' "$pr_state" "$merge_state"
+    exit 0
+    ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/gh"
+  printf '%s\n' "$case_dir"
+}
+
+# Execute the armed poll under the case's fakebin gh and echo its output.
+run_poll() {
+  local case_dir=$1
+  PATH="$case_dir/fakebin:$PATH" bash "$case_dir/state/task-x1.check.sh"
+}
+
+test_ready_to_merge_open_clean() {
+  local case_dir out
+  case_dir=$(make_case ready-clean OPEN CLEAN)
+  out=$(run_poll "$case_dir")
+  [ "$out" = "ready-to-merge" ] \
+    || fail "ready-clean: expected 'ready-to-merge', got '$out'"
+  pass "OPEN + CLEAN triggers ready-to-merge wake"
+}
+
+test_merged_clean() {
+  local case_dir out
+  case_dir=$(make_case merged-clean MERGED CLEAN)
+  out=$(run_poll "$case_dir")
+  [ "$out" = "merged" ] \
+    || fail "merged-clean: expected 'merged', got '$out'"
+  pass "MERGED + CLEAN triggers merged confirmation wake"
+}
+
+test_merged_any_status() {
+  local case_dir out
+  case_dir=$(make_case merged-empty MERGED "")
+  out=$(run_poll "$case_dir")
+  [ "$out" = "merged" ] \
+    || fail "merged-empty: expected 'merged' for any post-merge status, got '$out'"
+  pass "MERGED with empty status still triggers merged wake"
+}
+
+test_interim_unstable_silent() {
+  local case_dir out
+  case_dir=$(make_case unstable OPEN UNSTABLE)
+  out=$(run_poll "$case_dir")
+  [ -z "$out" ] \
+    || fail "unstable: expected silence, got '$out'"
+  pass "OPEN + UNSTABLE (pending checks) stays silent"
+}
+
+test_blocked_silent() {
+  local case_dir out
+  case_dir=$(make_case blocked OPEN BLOCKED)
+  out=$(run_poll "$case_dir")
+  [ -z "$out" ] \
+    || fail "blocked: expected silence, got '$out'"
+  pass "OPEN + BLOCKED stays silent"
+}
+
+test_behind_silent() {
+  local case_dir out
+  case_dir=$(make_case behind OPEN BEHIND)
+  out=$(run_poll "$case_dir")
+  [ -z "$out" ] \
+    || fail "behind: expected silence, got '$out'"
+  pass "OPEN + BEHIND stays silent"
+}
+
+test_dirty_silent() {
+  local case_dir out
+  case_dir=$(make_case dirty OPEN DIRTY)
+  out=$(run_poll "$case_dir")
+  [ -z "$out" ] \
+    || fail "dirty: expected silence, got '$out'"
+  pass "OPEN + DIRTY stays silent"
+}
+
+test_empty_merge_state_silent() {
+  local case_dir out
+  case_dir=$(make_case empty-merge OPEN "")
+  out=$(run_poll "$case_dir")
+  [ -z "$out" ] \
+    || fail "empty-merge: expected silence, got '$out'"
+  pass "OPEN with empty mergeStateStatus stays silent"
+}
+
+test_gh_failure_silent() {
+  local case_dir out
+  case_dir=$(make_case gh-fail OPEN CLEAN 1)
+  out=$(run_poll "$case_dir")
+  [ -z "$out" ] \
+    || fail "gh-fail: expected silence on gh failure, got '$out'"
+  pass "gh failure stays silent (no wake on an unreadable PR)"
+}
+
+test_ready_to_merge_open_clean
+test_merged_clean
+test_merged_any_status
+test_interim_unstable_silent
+test_blocked_silent
+test_behind_silent
+test_dirty_silent
+test_empty_merge_state_silent
+test_gh_failure_silent


### PR DESCRIPTION
## Intent

Re-express a local, previously-unpushed fix on top of upstream's GitLab
merge-request support (#797), which restructured `bin/fm-pr-poll.sh`'s
sidecar/argument format from `(url, owner, repo, number)` to a
provider-tagged `(provider, url, host, path, number)`.

The original fix adds a `ready-to-merge` wake (GitHub PRs, `OPEN` +
`mergeStateStatus=CLEAN`) alongside the existing `merged` wake, so the
watcher can autonomously detect a direct-PR + yolo task's PR is checks-green
and mergeable without firstmate needing to poll `gh pr view` manually. This
only applies to the `github` provider case; the `gitlab` case is untouched
from upstream, since GitLab merge-request support didn't exist when the
original fix was written and extending the ready-to-merge concept to GitLab
wasn't part of either change's original scope.

## What changed in the rebase

- `bin/fm-pr-poll.sh`: folded the `ready-to-merge` state check into the
  `github)` case of upstream's provider dispatch, preserving all of
  upstream's host/path validation and the `gitlab)` case exactly as-is.
- `tests/fm-pr-check.test.sh` (new in the original fix): updated
  `make_case`'s sidecar writer from the old 4-field format to the new
  5-field provider-tagged format so the test matrix actually exercises the
  current script instead of silently testing against a stale calling
  convention.
- `tests/fm-pr-check-security.test.sh`: auto-merged cleanly, no changes
  needed beyond upstream's own content.

## Verification

Both test files pass in full against the rebased script:
- `tests/fm-pr-check.test.sh`: 9/9 (ready-to-merge, merged, and every
  silent/interim case).
- `tests/fm-pr-check-security.test.sh`: 25/25 (arming, validation, atomic
  publish, migration, and watcher-bounded wake behavior).
